### PR TITLE
Some basic housekeeping fixes:

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ include_directories(3rdparty)
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     message(STATUS "Enabling AddressSanitizer")
     add_definitions(-fsanitize=address -fno-omit-frame-pointer
-                    -fno-optimize-sibling-calls -fstack-protector-all)
+                    -fno-optimize-sibling-calls -fstack-protector-all -DCHIMERA_SANITIZE=1)
     add_link_options(-fsanitize=address)
 endif()
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@ RUN sed -i 's|archive.ubuntu.com|azure.archive.ubuntu.com|g' /etc/apt/sources.li
 
 RUN apt-get -y update && \
     apt-get -y --no-install-recommends upgrade && \
-    apt-get -y --no-install-recommends install clang cmake ninja-build git flex bison uuid-dev uthash-dev \
-    librdmacm-dev libjansson-dev libclang-rt-18-dev llvm libxxhash-dev liburcu-dev liburing-dev libunwind-dev librocksdb-dev && \
+    apt-get -y --no-install-recommends install clang cmake ninja-build git flex bison uuid-dev uthash-dev libkrb5-3 libkrb5-dev libgssapi-krb5-2  gss-ntlmssp-dev \
+    librdmacm-dev libjansson-dev libclang-rt-18-dev llvm libxxhash-dev liburcu-dev liburing-dev libunwind-dev librocksdb-dev libssl-dev openssl && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -29,7 +29,7 @@ FROM ubuntu:24.04
 ARG BUILD_TYPE=Release
 RUN apt-get -y update && \
     apt-get -y --no-install-recommends upgrade && \
-    apt-get -y --no-install-recommends install libuuid1 librdmacm1 libjansson4 liburcu8t64 ibverbs-providers liburing2 libunwind8 librocksdb8.9 && \
+    apt-get -y --no-install-recommends install libuuid1 librdmacm1 libjansson4 liburcu8t64 ibverbs-providers liburing2 libunwind8 librocksdb8.9 gss-ntlmssp libkrb5-3 libkrb5-dev libgssapi-krb5-2 gss-ntlmssp-dev openssl && \
     if [ "${BUILD_TYPE}" = "Debug" ]; then \
     apt-get -y --no-install-recommends install llvm gdb ; \
     fi && \

--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -43,7 +43,13 @@ main(
 
     chimera_log_init();
 
+#if CHIMERA_SANITIZE != 1
+    /* If we are not using address sanitizer, add a crash handler to
+     * print stack on signals.   Otherwise, let address sanitizer
+     * handle it.
+     */
     chimera_enable_crash_handler();
+ #endif /* ifndef CHIMERA_SANITIZE */
 
     evpl_set_log_fn(chimera_vlog);
 
@@ -133,7 +139,7 @@ main(
 
     server = chimera_server_init(server_config, chimera_metrics_get(metrics));
 
-    shares = json_object_get(config, "shares");
+    shares = json_object_get(config, "mounts");
 
     if (shares) {
         json_object_foreach(shares, share_name, share)
@@ -141,10 +147,9 @@ main(
             share_module = json_string_value(json_object_get(share, "module"));
             share_path   = json_string_value(json_object_get(share, "path"));
 
-            chimera_server_info("Initializing share %s (%s://%s)...", share_name
-                                ,
-                                share_module, share_path);
-            chimera_server_mount(server, share_module, share_name, share_path);
+            chimera_server_info("Mounting %s://%s to /%s..."
+                                , share_module, share_path, share_name);
+            chimera_server_mount(server, share_name, share_module, share_path);
         }
     }
 

--- a/src/metrics/metrics.c
+++ b/src/metrics/metrics.c
@@ -134,6 +134,8 @@ chimera_metrics_thread_shutdown(
 {
     struct chimera_metrics *metrics = private_data;
 
+    prometheus_metrics_destroy(metrics->metrics);
+
     evpl_http_server_destroy(metrics->agent, metrics->server);
     evpl_listener_destroy(metrics->listener);
     evpl_http_destroy(metrics->agent);


### PR DESCRIPTION
* If using address sanitizer, don't install our own crash signal handler & stack dumper.  Just let ASAN do it.    It does a better job.
* Handle mounts vs shares properly in the daemon.
* Don't leak prometheus metrics.
* Update libevpl with some RPCRDMA fixes