### PR TITLE
Add Contributing doc and Contributors list, make copyright notices generic

### DIFF
--- a/.cursorignore
+++ b/.cursorignore
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Ben Jarvis
+# SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 #
 # SPDX-License-Identifier: Unlicense
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Ben Jarvis
+# SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 #
 # SPDX-License-Identifier: Unlicense
 

--- a/.devcontainer/devcontainer.json.license
+++ b/.devcontainer/devcontainer.json.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2025 Ben Jarvis
+SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 
 SPDX-License-Identifier: Unlicense

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Ben Jarvis
+# SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 #
 # SPDX-License-Identifier: Unlicense
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Ben Jarvis
+# SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 #
 # SPDX-License-Identifier: Unlicense
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Ben Jarvis
+# SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 #
 # SPDX-License-Identifier: Unlicense
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Ben Jarvis
+# SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 #
 # SPDX-License-Identifier: Unlicense
 

--- a/.github/workflows/reuse-compliance.yml
+++ b/.github/workflows/reuse-compliance.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Ben Jarvis
+# SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 # SPDX-License-Identifier: Unlicense
 
 name: REUSE Compliance Check

--- a/.github/workflows/syntax-check.yml
+++ b/.github/workflows/syntax-check.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Ben Jarvis
+# SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 #
 # SPDX-License-Identifier: Unlicense
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Ben Jarvis
+# SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 #
 # SPDX-License-Identifier: Unlicense
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 
-# SPDX-FileCopyrightText: 2025 Ben Jarvis
+# SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 # SPDX-License-Identifier: Unlicense
  
 [submodule "ext/xdrzcc"]

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -5,5 +5,5 @@ Source: https://github.com/chimera-nas/chimera
 
 # Documentation files (Jekyll markdown)
 Files: README.md docs/*.md docs/**/*.md
-Copyright: 2025 Ben Jarvis
+Copyright: 2025 Chimera-NAS Project Contributors
 License: Unlicense

--- a/.vscode/settings.json.license
+++ b/.vscode/settings.json.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2025 Ben Jarvis
+SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 
 SPDX-License-Identifier: Unlicense

--- a/.vscode/tasks.json.license
+++ b/.vscode/tasks.json.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2025 Ben Jarvis
+SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 
 SPDX-License-Identifier: Unlicense

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2025 Ben Jarvis
+SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 
 SPDX-License-Identifier: Unlicense
 -->

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 - 2025 Ben Jarvis
+# SPDX-FileCopyrightText: 2024 - 2025 Chimera-NAS Project Contributors
 #
 # SPDX-License-Identifier: LGPL-2.1-only
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+<!--
+SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+
+SPDX-License-Identifier: Unlicense
+-->
+
+This project is licensed under the LGPL license for the most part.  There are a few ancillary bits and pieces with other
+licenses, such as the plugin for FIO is GPL licensed for compatibility with fio.  There are also a few files in the tree
+that were sourced externally and are under other, more permissive licenses.
+
+Contributors may add their names to CONTRIBUTORS.md in their first pull request, if desired.   Whether or not this is done,
+authors retain copyright ownership of their contributions and agree to the distribution of those contributions under the
+indicated license(s).

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,11 @@
+<!--
+SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+
+SPDX-License-Identifier: Unlicense
+-->
+
+The following individuals and organizations have contributed to this project:
+
+Ben Jarvis
+Alain Renaud
+Quantum Corporation

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Ben Jarvis
+# SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 #
 # SPDX-License-Identifier: Unlicense
 

--- a/Dockerfile.ubuntu22.04
+++ b/Dockerfile.ubuntu22.04
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Ben Jarvis
+# SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 #
 # SPDX-License-Identifier: Unlicense
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 - 2025 Ben Jarvis
+# SPDX-FileCopyrightText: 2024 - 2025 Chimera-NAS Project Contributors
 #
 # SPDX-License-Identifier: Unlicense
 

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# SPDX-FileCopyrightText: 2025 Ben Jarvis
+# SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 #
 # SPDX-License-Identifier: Unlicense
 

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Ben Jarvis
+# SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 #
 # SPDX-License-Identifier: Unlicense
 

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Ben Jarvis
+# SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 #
 # SPDX-License-Identifier: Unlicense
 

--- a/docs/Gemfile.lock.license
+++ b/docs/Gemfile.lock.license
@@ -1,2 +1,2 @@
-SPDX-FileCopyrightText: 2025 Ben Jarvis
+SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 SPDX-License-Identifier: Unlicense

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2025 Ben Jarvis
+SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 SPDX-License-Identifier: Unlicense
 -->
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Ben Jarvis
+# SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 #
 # SPDX-License-Identifier: Unlicense
 

--- a/etc/uncrustify.cfg
+++ b/etc/uncrustify.cfg
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 - 2025 Ben Jarvis
+# SPDX-FileCopyrightText: 2024 - 2025 Chimera-NAS Project Contributors
 #
 # SPDX-License-Identifier: Unlicense
 #

--- a/ext/CMakeLists.txt
+++ b/ext/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Ben Jarvis
+# SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 #
 # SPDX-License-Identifier: LGPL-2.1-only
 

--- a/scripts/netns_test_wrapper.sh
+++ b/scripts/netns_test_wrapper.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# SPDX-FileCopyrightText: 2025 Ben Jarvis
+# SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 #
 # SPDX-License-Identifier: Unlicense
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Ben Jarvis
+# SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 #
 # SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Ben Jarvis
+# SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 #
 # SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/client/client.c
+++ b/src/client/client.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/client/client_close.c
+++ b/src/client/client_close.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/client/client_internal.h
+++ b/src/client/client_internal.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/client/client_mkdir.c
+++ b/src/client/client_mkdir.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/client/client_open.c
+++ b/src/client/client_open.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/client/client_read.c
+++ b/src/client/client_read.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/client/client_write.c
+++ b/src/client/client_write.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/client/tests/CMakeLists.txt
+++ b/src/client/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Ben Jarvis
+# SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 #
 # SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/client/tests/basic.c
+++ b/src/client/tests/basic.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Ben Jarvis
+# SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 #
 # SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/common/evpl_iovec_cursor.h
+++ b/src/common/evpl_iovec_cursor.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/common/format.h
+++ b/src/common/format.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/common/logging.c
+++ b/src/common/logging.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/common/logging.h
+++ b/src/common/logging.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/common/macros.h
+++ b/src/common/macros.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/common/misc.h
+++ b/src/common/misc.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/common/rbtree.h
+++ b/src/common/rbtree.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/common/snprintf.c
+++ b/src/common/snprintf.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: Unlicense
 

--- a/src/common/tests/CMakeLists.txt
+++ b/src/common/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Ben Jarvis
+# SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 #
 # SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/common/tests/rbtree_test.c
+++ b/src/common/tests/rbtree_test.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/common/varint.h
+++ b/src/common/varint.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/cufile/CMakeLists.txt
+++ b/src/cufile/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Ben Jarvis
+# SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 #
 # SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/cufile/chimera_cufile.c
+++ b/src/cufile/chimera_cufile.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/cufile/chimera_cufile.h
+++ b/src/cufile/chimera_cufile.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/cufile/tests/CMakeLists.txt
+++ b/src/cufile/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Ben Jarvis
+# SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 #
 # SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/cufile/tests/basic.cu
+++ b/src/cufile/tests/basic.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Ben Jarvis
+ * SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
  * SPDX-License-Identifier: Unlicense
  */
 

--- a/src/daemon/CMakeLists.txt
+++ b/src/daemon/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Ben Jarvis
+# SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 #
 # SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/daemon/chimera.json.license
+++ b/src/daemon/chimera.json.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2025 Ben Jarvis
+SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 
 SPDX-License-Identifier: Unlicense

--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/daemon/daemon.h.in
+++ b/src/daemon/daemon.h.in
@@ -1,6 +1,6 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
 
-#define CONFIG_PATH  "@CMAKE_INSTALL_PREFIX@/etc/chimera.json"
+#define CONFIG_PATH "@CMAKE_INSTALL_PREFIX@/etc/chimera.json"

--- a/src/fio/CMakeLists.txt
+++ b/src/fio/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Ben Jarvis
+# SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 #
 # SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/fio/fio.c
+++ b/src/fio/fio.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/fio/tests/CMakeLists.txt
+++ b/src/fio/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Ben Jarvis
+# SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 #
 # SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/fio/tests/demofs_basic.fio
+++ b/src/fio/tests/demofs_basic.fio
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Ben Jarvis
+# SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 #
 # SPDX-License-Identifier: Unlicense
 

--- a/src/fio/tests/demofs_basic.json.license
+++ b/src/fio/tests/demofs_basic.json.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2025 Ben Jarvis
+SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 
 SPDX-License-Identifier: Unlicense

--- a/src/fio/tests/demofs_config.json.license
+++ b/src/fio/tests/demofs_config.json.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2025 Ben Jarvis
+SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 
 SPDX-License-Identifier: Unlicense

--- a/src/fio/tests/memfs_basic.fio
+++ b/src/fio/tests/memfs_basic.fio
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Ben Jarvis
+# SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 #
 # SPDX-License-Identifier: Unlicense
 

--- a/src/fio/tests/memfs_basic.json.license
+++ b/src/fio/tests/memfs_basic.json.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2025 Ben Jarvis
+SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 
 SPDX-License-Identifier: Unlicense

--- a/src/fio/tests/suppressions.txt
+++ b/src/fio/tests/suppressions.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Ben Jarvis
+# SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 # SPDX-License-Identifier: Unlicense
 # fio intentionally leaks memory that is allocated during options parsing
 leak:parse_options

--- a/src/metrics/CMakeLists.txt
+++ b/src/metrics/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Ben Jarvis
+# SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 #
 # SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/metrics/metrics.c
+++ b/src/metrics/metrics.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/metrics/metrics.h
+++ b/src/metrics/metrics.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/posix/CMakeLists.txt
+++ b/src/posix/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Ben Jarvis
+# SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 #
 # SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/posix/posix.c
+++ b/src/posix/posix.c
@@ -1,3 +1,3 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only

--- a/src/posix/posix.h
+++ b/src/posix/posix.h
@@ -1,3 +1,3 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only

--- a/src/posix/tests/CMakeLists.txt
+++ b/src/posix/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Ben Jarvis
+# SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 #
 # SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/posix/tests/basic.c
+++ b/src/posix/tests/basic.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Ben Jarvis
+# SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 #
 # SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/CMakeLists.txt
+++ b/src/server/nfs/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Ben Jarvis
+# SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 #
 # SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs.c
+++ b/src/server/nfs/nfs.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs.h
+++ b/src/server/nfs/nfs.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs3_attr.h
+++ b/src/server/nfs/nfs3_attr.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs3_dump.c
+++ b/src/server/nfs/nfs3_dump.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs3_dump.h
+++ b/src/server/nfs/nfs3_dump.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs3_proc_access.c
+++ b/src/server/nfs/nfs3_proc_access.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs3_proc_commit.c
+++ b/src/server/nfs/nfs3_proc_commit.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs3_proc_create.c
+++ b/src/server/nfs/nfs3_proc_create.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs3_proc_fsinfo.c
+++ b/src/server/nfs/nfs3_proc_fsinfo.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs3_proc_fsstat.c
+++ b/src/server/nfs/nfs3_proc_fsstat.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs3_proc_getattr.c
+++ b/src/server/nfs/nfs3_proc_getattr.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs3_proc_link.c
+++ b/src/server/nfs/nfs3_proc_link.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs3_proc_lookup.c
+++ b/src/server/nfs/nfs3_proc_lookup.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs3_proc_mkdir.c
+++ b/src/server/nfs/nfs3_proc_mkdir.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs3_proc_mknod.c
+++ b/src/server/nfs/nfs3_proc_mknod.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs3_proc_null.c
+++ b/src/server/nfs/nfs3_proc_null.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs3_proc_pathconf.c
+++ b/src/server/nfs/nfs3_proc_pathconf.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs3_proc_read.c
+++ b/src/server/nfs/nfs3_proc_read.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs3_proc_readdir.c
+++ b/src/server/nfs/nfs3_proc_readdir.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs3_proc_readdirplus.c
+++ b/src/server/nfs/nfs3_proc_readdirplus.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs3_proc_readlink.c
+++ b/src/server/nfs/nfs3_proc_readlink.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs3_proc_remove.c
+++ b/src/server/nfs/nfs3_proc_remove.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs3_proc_rename.c
+++ b/src/server/nfs/nfs3_proc_rename.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs3_proc_rmdir.c
+++ b/src/server/nfs/nfs3_proc_rmdir.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs3_proc_setattr.c
+++ b/src/server/nfs/nfs3_proc_setattr.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs3_proc_symlink.c
+++ b/src/server/nfs/nfs3_proc_symlink.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs3_proc_write.c
+++ b/src/server/nfs/nfs3_proc_write.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs3_procs.h
+++ b/src/server/nfs/nfs3_procs.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs3_status.h
+++ b/src/server/nfs/nfs3_status.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs4_attr.h
+++ b/src/server/nfs/nfs4_attr.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs4_dump.c
+++ b/src/server/nfs/nfs4_dump.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs4_dump.h
+++ b/src/server/nfs/nfs4_dump.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs4_proc_access.c
+++ b/src/server/nfs/nfs4_proc_access.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs4_proc_close.c
+++ b/src/server/nfs/nfs4_proc_close.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs4_proc_commit.c
+++ b/src/server/nfs/nfs4_proc_commit.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs4_proc_compound.c
+++ b/src/server/nfs/nfs4_proc_compound.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs4_proc_create.c
+++ b/src/server/nfs/nfs4_proc_create.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs4_proc_create_session.c
+++ b/src/server/nfs/nfs4_proc_create_session.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs4_proc_destroy_clientid.c
+++ b/src/server/nfs/nfs4_proc_destroy_clientid.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs4_proc_destroy_session.c
+++ b/src/server/nfs/nfs4_proc_destroy_session.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs4_proc_exchange_id.c
+++ b/src/server/nfs/nfs4_proc_exchange_id.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs4_proc_getattr.c
+++ b/src/server/nfs/nfs4_proc_getattr.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs4_proc_getfh.c
+++ b/src/server/nfs/nfs4_proc_getfh.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs4_proc_link.c
+++ b/src/server/nfs/nfs4_proc_link.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs4_proc_lookup.c
+++ b/src/server/nfs/nfs4_proc_lookup.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs4_proc_null.c
+++ b/src/server/nfs/nfs4_proc_null.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs4_proc_open.c
+++ b/src/server/nfs/nfs4_proc_open.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs4_proc_putfh.c
+++ b/src/server/nfs/nfs4_proc_putfh.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs4_proc_putrootfh.c
+++ b/src/server/nfs/nfs4_proc_putrootfh.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs4_proc_read.c
+++ b/src/server/nfs/nfs4_proc_read.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs4_proc_readdir.c
+++ b/src/server/nfs/nfs4_proc_readdir.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs4_proc_readlink.c
+++ b/src/server/nfs/nfs4_proc_readlink.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs4_proc_reclaim_complete.c
+++ b/src/server/nfs/nfs4_proc_reclaim_complete.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs4_proc_remove.c
+++ b/src/server/nfs/nfs4_proc_remove.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs4_proc_rename.c
+++ b/src/server/nfs/nfs4_proc_rename.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs4_proc_savefh.c
+++ b/src/server/nfs/nfs4_proc_savefh.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs4_proc_secinfo_no_name.c
+++ b/src/server/nfs/nfs4_proc_secinfo_no_name.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs4_proc_sequence.c
+++ b/src/server/nfs/nfs4_proc_sequence.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs4_proc_setattr.c
+++ b/src/server/nfs/nfs4_proc_setattr.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs4_proc_setclientid.c
+++ b/src/server/nfs/nfs4_proc_setclientid.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs4_proc_setclientid_confirm.c
+++ b/src/server/nfs/nfs4_proc_setclientid_confirm.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs4_proc_write.c
+++ b/src/server/nfs/nfs4_proc_write.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs4_procs.h
+++ b/src/server/nfs/nfs4_procs.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs4_session.c
+++ b/src/server/nfs/nfs4_session.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs4_session.h
+++ b/src/server/nfs/nfs4_session.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs4_status.h
+++ b/src/server/nfs/nfs4_status.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs_common.h
+++ b/src/server/nfs/nfs_common.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs_internal.h
+++ b/src/server/nfs/nfs_internal.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs_mount.c
+++ b/src/server/nfs/nfs_mount.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs_mount.h
+++ b/src/server/nfs/nfs_mount.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs_portmap.c
+++ b/src/server/nfs/nfs_portmap.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs_portmap.h
+++ b/src/server/nfs/nfs_portmap.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/tests/CMakeLists.txt
+++ b/src/server/nfs/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Ben Jarvis
+# SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 #
 # SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/tests/libnfs_bigdir.c
+++ b/src/server/nfs/tests/libnfs_bigdir.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/tests/libnfs_create.c
+++ b/src/server/nfs/tests/libnfs_create.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/tests/libnfs_link.c
+++ b/src/server/nfs/tests/libnfs_link.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/tests/libnfs_mkdir.c
+++ b/src/server/nfs/tests/libnfs_mkdir.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/tests/libnfs_mount.c
+++ b/src/server/nfs/tests/libnfs_mount.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/tests/libnfs_read.c
+++ b/src/server/nfs/tests/libnfs_read.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/tests/libnfs_readdir.c
+++ b/src/server/nfs/tests/libnfs_readdir.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/tests/libnfs_readdir_shares.c
+++ b/src/server/nfs/tests/libnfs_readdir_shares.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/tests/libnfs_remove.c
+++ b/src/server/nfs/tests/libnfs_remove.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/tests/libnfs_rename.c
+++ b/src/server/nfs/tests/libnfs_rename.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/tests/libnfs_rmdir.c
+++ b/src/server/nfs/tests/libnfs_rmdir.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/tests/libnfs_setattr.c
+++ b/src/server/nfs/tests/libnfs_setattr.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/tests/libnfs_statvfs.c
+++ b/src/server/nfs/tests/libnfs_statvfs.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/tests/libnfs_symlink.c
+++ b/src/server/nfs/tests/libnfs_symlink.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/tests/libnfs_test_common.h
+++ b/src/server/nfs/tests/libnfs_test_common.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/tests/libnfs_tree.c
+++ b/src/server/nfs/tests/libnfs_tree.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/tests/libnfs_write.c
+++ b/src/server/nfs/tests/libnfs_write.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/protocol.h
+++ b/src/server/protocol.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/s3/CMakeLists.txt
+++ b/src/server/s3/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Ben Jarvis
+# SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 #
 # SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/s3/s3.c
+++ b/src/server/s3/s3.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/s3/s3.h
+++ b/src/server/s3/s3.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/s3/s3_bucket_map.h
+++ b/src/server/s3/s3_bucket_map.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/s3/s3_delete.c
+++ b/src/server/s3/s3_delete.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/s3/s3_dump.c
+++ b/src/server/s3/s3_dump.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/s3/s3_dump.h
+++ b/src/server/s3/s3_dump.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/s3/s3_etag.h
+++ b/src/server/s3/s3_etag.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/s3/s3_get.c
+++ b/src/server/s3/s3_get.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/s3/s3_internal.h
+++ b/src/server/s3/s3_internal.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/s3/s3_list.c
+++ b/src/server/s3/s3_list.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/s3/s3_procs.h
+++ b/src/server/s3/s3_procs.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/s3/s3_put.c
+++ b/src/server/s3/s3_put.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/s3/s3_status.c
+++ b/src/server/s3/s3_status.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/s3/s3_status.h
+++ b/src/server/s3/s3_status.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/s3/tests/CMakeLists.txt
+++ b/src/server/s3/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Ben Jarvis
+# SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 #
 # SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/s3/tests/libs3_common.h
+++ b/src/server/s3/tests/libs3_common.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/s3/tests/libs3_delete.c
+++ b/src/server/s3/tests/libs3_delete.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/s3/tests/libs3_get.c
+++ b/src/server/s3/tests/libs3_get.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/s3/tests/libs3_head.c
+++ b/src/server/s3/tests/libs3_head.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/s3/tests/libs3_list.c
+++ b/src/server/s3/tests/libs3_list.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/s3/tests/libs3_put.c
+++ b/src/server/s3/tests/libs3_put.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/s3/tests/libs3_test_common.h
+++ b/src/server/s3/tests/libs3_test_common.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/server_internal.h
+++ b/src/server/server_internal.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/smb/CMakeLists.txt
+++ b/src/server/smb/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Ben Jarvis
+# SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 #
 # SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/smb/smb.h
+++ b/src/server/smb/smb.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/smb/smb1.h
+++ b/src/server/smb/smb1.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/smb/smb2.h
+++ b/src/server/smb/smb2.h
@@ -3,7 +3,7 @@
 #include <stdint.h>
 
 // Copyright (C) 2016 by Ronnie Sahlberg <ronniesahlberg@gmail.com>
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/smb/smb_attr.h
+++ b/src/server/smb/smb_attr.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/smb/smb_dcerpc.h
+++ b/src/server/smb/smb_dcerpc.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/smb/smb_dump.c
+++ b/src/server/smb/smb_dump.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/smb/smb_dump.h
+++ b/src/server/smb/smb_dump.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/smb/smb_lsarpc.c
+++ b/src/server/smb/smb_lsarpc.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/smb/smb_lsarpc.h
+++ b/src/server/smb/smb_lsarpc.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/smb/smb_proc_close.c
+++ b/src/server/smb/smb_proc_close.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/smb/smb_proc_echo.c
+++ b/src/server/smb/smb_proc_echo.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/smb/smb_proc_flush.c
+++ b/src/server/smb/smb_proc_flush.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/smb/smb_proc_ioctl.c
+++ b/src/server/smb/smb_proc_ioctl.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/smb/smb_proc_logoff.c
+++ b/src/server/smb/smb_proc_logoff.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/smb/smb_proc_negotiate.c
+++ b/src/server/smb/smb_proc_negotiate.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/smb/smb_proc_query_directory.c
+++ b/src/server/smb/smb_proc_query_directory.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/smb/smb_proc_query_info.c
+++ b/src/server/smb/smb_proc_query_info.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/smb/smb_proc_read.c
+++ b/src/server/smb/smb_proc_read.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/smb/smb_proc_session_setup.c
+++ b/src/server/smb/smb_proc_session_setup.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/smb/smb_proc_set_info.c
+++ b/src/server/smb/smb_proc_set_info.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/smb/smb_proc_tree_connect.c
+++ b/src/server/smb/smb_proc_tree_connect.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/smb/smb_proc_tree_disconnect.c
+++ b/src/server/smb/smb_proc_tree_disconnect.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/smb/smb_proc_write.c
+++ b/src/server/smb/smb_proc_write.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/smb/smb_procs.h
+++ b/src/server/smb/smb_procs.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/smb/smb_session.h
+++ b/src/server/smb/smb_session.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/smb/smb_signing.c
+++ b/src/server/smb/smb_signing.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/smb/smb_signing.h
+++ b/src/server/smb/smb_signing.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/smb/smb_string.h
+++ b/src/server/smb/smb_string.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Ben Jarvis
+# SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 #
 # SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/smb/tests/libsmb2_basic.c
+++ b/src/server/smb/tests/libsmb2_basic.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/smb/tests/libsmb2_bigdir.c
+++ b/src/server/smb/tests/libsmb2_bigdir.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/smb/tests/libsmb2_echo.c
+++ b/src/server/smb/tests/libsmb2_echo.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/smb/tests/libsmb2_test_common.h
+++ b/src/server/smb/tests/libsmb2_test_common.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/smb/tests/suppressions.txt
+++ b/src/server/smb/tests/suppressions.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Ben Jarvis
+# SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 # SPDX-License-Identifier: Unlicense
 # Suppress OpenSSL provider leaks from gssntlmssp
 leak:OSSL_PROVIDER_try_load

--- a/src/vfs/CMakeLists.txt
+++ b/src/vfs/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Ben Jarvis
+# SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 #
 # SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/vfs/cairn/CMakeLists.txt
+++ b/src/vfs/cairn/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Ben Jarvis
+# SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 #
 # SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/vfs/cairn/cairn.c
+++ b/src/vfs/cairn/cairn.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/vfs/cairn/cairn.h
+++ b/src/vfs/cairn/cairn.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/vfs/cairn/evpl_iovec_cursor.h
+++ b/src/vfs/cairn/evpl_iovec_cursor.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/vfs/demofs/CMakeLists.txt
+++ b/src/vfs/demofs/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Ben Jarvis
+# SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 #
 # SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/vfs/demofs/demofs.c
+++ b/src/vfs/demofs/demofs.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/vfs/demofs/demofs.h
+++ b/src/vfs/demofs/demofs.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/vfs/demofs/slab_allocator.h
+++ b/src/vfs/demofs/slab_allocator.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/vfs/io_uring/CMakeLists.txt
+++ b/src/vfs/io_uring/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Ben Jarvis
+# SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 #
 # SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/vfs/io_uring/io_uring.c
+++ b/src/vfs/io_uring/io_uring.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/vfs/io_uring/io_uring.h
+++ b/src/vfs/io_uring/io_uring.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/vfs/linux/CMakeLists.txt
+++ b/src/vfs/linux/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Ben Jarvis
+# SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 #
 # SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/vfs/linux/linux.c
+++ b/src/vfs/linux/linux.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/vfs/linux/linux.h
+++ b/src/vfs/linux/linux.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/vfs/linux/linux_common.h
+++ b/src/vfs/linux/linux_common.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/vfs/memfs/CMakeLists.txt
+++ b/src/vfs/memfs/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Ben Jarvis
+# SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 #
 # SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/vfs/memfs/memfs.h
+++ b/src/vfs/memfs/memfs.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/vfs/root/CMakeLists.txt
+++ b/src/vfs/root/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Ben Jarvis
+# SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 #
 # SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/vfs/root/vfs_root.c
+++ b/src/vfs/root/vfs_root.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/vfs/root/vfs_root.h
+++ b/src/vfs/root/vfs_root.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/vfs/vfs.c
+++ b/src/vfs/vfs.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/vfs/vfs.h
+++ b/src/vfs/vfs.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/vfs/vfs_attr_cache.h
+++ b/src/vfs/vfs_attr_cache.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/vfs/vfs_dump.c
+++ b/src/vfs/vfs_dump.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/vfs/vfs_dump.h
+++ b/src/vfs/vfs_dump.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/vfs/vfs_error.h
+++ b/src/vfs/vfs_error.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/vfs/vfs_internal.h
+++ b/src/vfs/vfs_internal.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/vfs/vfs_name_cache.h
+++ b/src/vfs/vfs_name_cache.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/vfs/vfs_open_cache.h
+++ b/src/vfs/vfs_open_cache.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/vfs/vfs_proc_close.c
+++ b/src/vfs/vfs_proc_close.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/vfs/vfs_proc_commit.c
+++ b/src/vfs/vfs_proc_commit.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/vfs/vfs_proc_create_path.c
+++ b/src/vfs/vfs_proc_create_path.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/vfs/vfs_proc_create_unlinked.c
+++ b/src/vfs/vfs_proc_create_unlinked.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/vfs/vfs_proc_find.c
+++ b/src/vfs/vfs_proc_find.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/vfs/vfs_proc_getattr.c
+++ b/src/vfs/vfs_proc_getattr.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/vfs/vfs_proc_getrootfh.c
+++ b/src/vfs/vfs_proc_getrootfh.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/vfs/vfs_proc_link.c
+++ b/src/vfs/vfs_proc_link.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/vfs/vfs_proc_lookup.c
+++ b/src/vfs/vfs_proc_lookup.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/vfs/vfs_proc_lookup_path.c
+++ b/src/vfs/vfs_proc_lookup_path.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/vfs/vfs_proc_mkdir.c
+++ b/src/vfs/vfs_proc_mkdir.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/vfs/vfs_proc_open.c
+++ b/src/vfs/vfs_proc_open.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/vfs/vfs_proc_open_at.c
+++ b/src/vfs/vfs_proc_open_at.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/vfs/vfs_proc_read.c
+++ b/src/vfs/vfs_proc_read.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/vfs/vfs_proc_readdir.c
+++ b/src/vfs/vfs_proc_readdir.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/vfs/vfs_proc_readlink.c
+++ b/src/vfs/vfs_proc_readlink.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/vfs/vfs_proc_remove.c
+++ b/src/vfs/vfs_proc_remove.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/vfs/vfs_proc_rename.c
+++ b/src/vfs/vfs_proc_rename.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/vfs/vfs_proc_setattr.c
+++ b/src/vfs/vfs_proc_setattr.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/vfs/vfs_proc_symlink.c
+++ b/src/vfs/vfs_proc_symlink.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/vfs/vfs_proc_write.c
+++ b/src/vfs/vfs_proc_write.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/vfs/vfs_procs.h
+++ b/src/vfs/vfs_procs.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/vfs/vfs_release.h
+++ b/src/vfs/vfs_release.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Ben Jarvis
+// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/suppressions.txt
+++ b/suppressions.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Ben Jarvis
+# SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
 # SPDX-License-Identifier: Unlicense
 # Suppress OpenSSL provider leaks from gssntlmssp
 leak:OSSL_PROVIDER_try_load


### PR DESCRIPTION
Replace all copyright notices with a generic project contributors notice, and add contributing documentation and contributors list at the top level.