### PR TITLE
Fix SMB2 create problem on Linux/io_uring backends

### DIFF
--- a/src/server/nfs/nfs4_proc_open.c
+++ b/src/server/nfs/nfs4_proc_open.c
@@ -149,7 +149,10 @@ chimera_nfs4_open_parent_complete(
             case EXCLUSIVE4_1:
                 break;
         } /* switch */
+    }
 
+    if (args->share_access == OPEN4_SHARE_ACCESS_READ) {
+        flags |= CHIMERA_VFS_OPEN_READ_ONLY;
     }
 
     switch (args->claim.claim) {

--- a/src/server/smb/smb_dump.c
+++ b/src/server/smb/smb_dump.c
@@ -1169,10 +1169,12 @@ _smb_dump_request(
             sprintf(argstr, " path %.*s", request->tree_connect.path_length, request->tree_connect.path);
             break;
         case SMB2_CREATE:
-            sprintf(argstr, " parent_path %.*s name %.*s create_disposition %s",
+            sprintf(argstr, " parent_path %.*s name %.*s create_disposition %s create_options %x desired_access %x",
                     request->create.parent_path_len, request->create.parent_path,
                     request->create.name_len, request->create.name,
-                    smb_create_disposition_name(request->create.create_disposition));
+                    smb_create_disposition_name(request->create.create_disposition),
+                    request->create.create_options,
+                    request->create.desired_access);
             break;
         case SMB2_CLOSE:
             if (request->close.file_id.pid != UINT64_MAX) {

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -15,6 +15,19 @@
 #include "smb_attr.h"
 #include "smb_lsarpc.h"
 
+#define SMB2_WRITE_MASK (SMB2_FILE_WRITE_DATA | \
+                         SMB2_FILE_APPEND_DATA | \
+                         SMB2_FILE_WRITE_EA | \
+                         SMB2_FILE_WRITE_ATTRIBUTES | \
+                         SMB2_FILE_DELETE_CHILD | \
+                         SMB2_FILE_ADD_FILE | \
+                         SMB2_FILE_ADD_SUBDIRECTORY | \
+                         SMB2_DELETE | \
+                         SMB2_WRITE_DACL | \
+                         SMB2_WRITE_OWNER | \
+                         SMB2_GENERIC_WRITE | \
+                         SMB2_GENERIC_ALL)
+
 const uint8_t root_fh = CHIMERA_VFS_FH_MAGIC_ROOT;
 
 static inline void
@@ -361,6 +374,14 @@ chimera_smb_create_open_parent_callback(
     } else {
         if (request->create.create_options & SMB2_FILE_DIRECTORY_FILE) {
             flags |= CHIMERA_VFS_OPEN_DIRECTORY;
+        }
+
+        if (request->create.desired_access == SMB2_FILE_READ_ATTRIBUTES) {
+            flags |= CHIMERA_VFS_OPEN_PATH;
+        }
+
+        if (!(request->create.desired_access & SMB2_WRITE_MASK)) {
+            flags |= CHIMERA_VFS_OPEN_READ_ONLY;
         }
 
         switch (request->create.create_disposition) {

--- a/src/vfs/io_uring/io_uring.c
+++ b/src/vfs/io_uring/io_uring.c
@@ -781,7 +781,10 @@ chimera_io_uring_open(
     }
 
     if (request->open.flags & CHIMERA_VFS_OPEN_DIRECTORY) {
-        flags |= O_DIRECTORY | O_RDONLY;
+        flags |= O_DIRECTORY;
+    }
+    if (request->open.flags & (CHIMERA_VFS_OPEN_READ_ONLY | CHIMERA_VFS_OPEN_PATH | CHIMERA_VFS_OPEN_DIRECTORY)) {
+        flags |= O_RDONLY;
     } else {
         flags |= O_RDWR;
     }

--- a/src/vfs/linux/linux.c
+++ b/src/vfs/linux/linux.c
@@ -454,7 +454,7 @@ chimera_linux_open_at(
 
     flags = 0;
 
-    if (request->open_at.flags & (CHIMERA_VFS_OPEN_PATH | CHIMERA_VFS_OPEN_DIRECTORY)) {
+    if (request->open_at.flags & (CHIMERA_VFS_OPEN_PATH | CHIMERA_VFS_OPEN_DIRECTORY | CHIMERA_VFS_OPEN_READ_ONLY)) {
         flags |= O_RDONLY;
     } else {
         flags |= O_RDWR;

--- a/src/vfs/vfs.h
+++ b/src/vfs/vfs.h
@@ -131,6 +131,8 @@ struct chimera_vfs_attrs {
 #define CHIMERA_VFS_OPEN_PATH          (1U << 1)
 #define CHIMERA_VFS_OPEN_INFERRED      (1U << 2)
 #define CHIMERA_VFS_OPEN_DIRECTORY     (1U << 3)
+#define CHIMERA_VFS_OPEN_READ_ONLY     (1U << 4)
+
 
 #define CHIMERA_VFS_OPEN_ID_SYNTHETIC  0
 #define CHIMERA_VFS_OPEN_ID_PATH       1


### PR DESCRIPTION
Add CHIMERA_VFS_OPEN_READ_ONLY flag, map NFS4 and SMB access attributes to it.   In SMB2 create, if client indicates it wants only to read attributes, specify CHIMERA_VFS_OPEN_PATH.  Add some more dump details to SMB2 create.

This is particularly important for linux/io_uring backends as the kernel cares and opening directories for read/write is not allowed.  For the other native backends, the VFS caller is presumed to be privileged, so this level of security is not necessary, consequently they ignore these flags.

This is not the whole story for properly handling all the SMB2 create options yet...