### PR TITLE
fchmodat AT_SYMLINK_NOFOLLOW fail on older kernel

### DIFF
--- a/src/vfs/linux/linux.c
+++ b/src/vfs/linux/linux.c
@@ -16,7 +16,15 @@
 #include <fcntl.h>
 #include <errno.h>
 #include <uthash.h>
+#include <linux/version.h>
 #include "vfs/vfs_error.h"
+
+// fchmodat support for AT_SYMLINK_NOFOLLOW was added in Linux 6.6
+#if defined(LINUX_VERSION_CODE) && defined(KERNEL_VERSION)
+    #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
+        #define HAVE_FCHMODAT_AT_SYMLINK_NOFOLLOW 1
+    #endif /* if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0) */
+#endif /* if defined(LINUX_VERSION_CODE) && defined(KERNEL_VERSION) */
 
 #include "evpl/evpl.h"
 
@@ -81,9 +89,13 @@ chimera_linux_set_attrs(
 
     if (attr->va_req_mask & CHIMERA_VFS_ATTR_MODE) {
 
-        rc = fchmodat(fd, "", attr->va_mode, AT_SYMLINK_NOFOLLOW | AT_EMPTY_PATH
-                      );
-
+#ifdef HAVE_FCHMODAT_AT_SYMLINK_NOFOLLOW
+        // Use fchmodat with AT_SYMLINK_NOFOLLOW on kernels >= 6.6
+        rc = fchmodat(fd, "", attr->va_mode, AT_SYMLINK_NOFOLLOW | AT_EMPTY_PATH);
+#else  /* ifdef HAVE_FCHMODAT_AT_SYMLINK_NOFOLLOW */
+        // Fall back to fchmod on older kernels (AT_SYMLINK_NOFOLLOW not supported)
+        rc = fchmod(fd, attr->va_mode);
+#endif /* ifdef HAVE_FCHMODAT_AT_SYMLINK_NOFOLLOW */
         if (rc) {
             chimera_linux_error("linux_setattr: fchmod(%o) failed: %s",
                                 attr->va_mode,


### PR DESCRIPTION
The call to fchmodat() fail on kernel < 6.6 because it does not support the AT_SYMLINK_NOFOLLOW flag.

To resolve this fallback to fchmod when the flag is not supported