### PR TITLE
Use synthetic FSSTAT block and file counts for the memfs/demofs/cairn backends

### DIFF
--- a/src/vfs/cairn/cairn.c
+++ b/src/vfs/cairn/cairn.c
@@ -825,13 +825,13 @@ cairn_map_attrs(
 
     if (attr->va_req_mask & CHIMERA_VFS_ATTR_MASK_STATFS) {
         attr->va_set_mask      |= CHIMERA_VFS_ATTR_MASK_STATFS;
-        attr->va_fs_space_avail = 0;
-        attr->va_fs_space_free  = 0;
-        attr->va_fs_space_total = 0;
+        attr->va_fs_space_avail = CHIMERA_VFS_SYNTHETIC_FS_BYTES;
+        attr->va_fs_space_free  = CHIMERA_VFS_SYNTHETIC_FS_BYTES;
+        attr->va_fs_space_total = CHIMERA_VFS_SYNTHETIC_FS_BYTES;
         attr->va_fs_space_used  = 0;
-        attr->va_fs_files_total = 0;
-        attr->va_fs_files_free  = 0;
-        attr->va_fs_files_avail = 0;
+        attr->va_fs_files_total = CHIMERA_VFS_SYNTHETIC_FS_INODES;
+        attr->va_fs_files_free  = CHIMERA_VFS_SYNTHETIC_FS_INODES;
+        attr->va_fs_files_avail = CHIMERA_VFS_SYNTHETIC_FS_INODES;
         attr->va_fsid           = shared->fsid;
     }
 } /* cairn_map_attrs */

--- a/src/vfs/demofs/demofs.c
+++ b/src/vfs/demofs/demofs.c
@@ -854,13 +854,13 @@ demofs_map_attrs(
 
     if (attr->va_req_mask & CHIMERA_VFS_ATTR_MASK_STATFS) {
         attr->va_set_mask      |= CHIMERA_VFS_ATTR_MASK_STATFS;
-        attr->va_fs_space_total = 0;
+        attr->va_fs_space_total = CHIMERA_VFS_SYNTHETIC_FS_BYTES;
         attr->va_fs_space_used  = 0;
-        attr->va_fs_space_avail = 0;
-        attr->va_fs_space_free  = 0;
-        attr->va_fs_files_total = 0;
-        attr->va_fs_files_avail = 0;
-        attr->va_fs_files_free  = 0;
+        attr->va_fs_space_avail = CHIMERA_VFS_SYNTHETIC_FS_BYTES;
+        attr->va_fs_space_free  = CHIMERA_VFS_SYNTHETIC_FS_BYTES;
+        attr->va_fs_files_total = CHIMERA_VFS_SYNTHETIC_FS_INODES;
+        attr->va_fs_files_avail = CHIMERA_VFS_SYNTHETIC_FS_INODES;
+        attr->va_fs_files_free  = CHIMERA_VFS_SYNTHETIC_FS_INODES;
 
         pthread_mutex_lock(&shared->lock);
 

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -645,13 +645,13 @@ memfs_map_attrs(
 
     if (attr->va_req_mask & CHIMERA_VFS_ATTR_MASK_STATFS) {
         attr->va_set_mask      |= CHIMERA_VFS_ATTR_MASK_STATFS;
-        attr->va_fs_space_avail = 0;
-        attr->va_fs_space_free  = 0;
-        attr->va_fs_space_total = 0;
+        attr->va_fs_space_avail = CHIMERA_VFS_SYNTHETIC_FS_BYTES;
+        attr->va_fs_space_free  = CHIMERA_VFS_SYNTHETIC_FS_BYTES;
+        attr->va_fs_space_total = CHIMERA_VFS_SYNTHETIC_FS_BYTES;
         attr->va_fs_space_used  = 0;
-        attr->va_fs_files_total = 0;
-        attr->va_fs_files_free  = 0;
-        attr->va_fs_files_avail = 0;
+        attr->va_fs_files_total = CHIMERA_VFS_SYNTHETIC_FS_INODES;
+        attr->va_fs_files_free  = CHIMERA_VFS_SYNTHETIC_FS_INODES;
+        attr->va_fs_files_avail = CHIMERA_VFS_SYNTHETIC_FS_INODES;
         attr->va_fsid           = shared->fsid;
     }
 

--- a/src/vfs/vfs.h
+++ b/src/vfs/vfs.h
@@ -72,6 +72,10 @@ struct prometheus_metrics;
 
 #define CHIMERA_VFS_TIME_NOW             ((1l << 30) - 3l)
 
+/* FSSTAT values used with builtin backends until statvfs tracking is implemented */
+#define CHIMERA_VFS_SYNTHETIC_FS_BYTES   ((uint64_t) 100 * 1024 * 1024 * 1024)
+#define CHIMERA_VFS_SYNTHETIC_FS_INODES  (1024 * 1024)
+
 /* Flags for chimera_vfs_lookup_path */
 #define CHIMERA_VFS_LOOKUP_FOLLOW        (1U << 0) /* Follow symlinks in final component */
 


### PR DESCRIPTION
For the memfs/demofs/cairn backends, until space tracking is implemented, populate FSSTAT with synthetic block and file counts instead of zeros. This keeps "df" happy.