### PR TITLE
WIP: Add NFS4 VFS client module

### DIFF
--- a/src/posix/tests/CMakeLists.txt
+++ b/src/posix/tests/CMakeLists.txt
@@ -150,6 +150,54 @@ generate_posix_nfs3_backend_tests(linux "")
 generate_posix_nfs3_backend_tests(io_uring CHIMERA_VFS_IO_URING)
 
 # ============================================================================
+# NFS4 Backend Tests
+# These tests run the POSIX tests through the Chimera NFS4 client,
+# connecting to a Chimera NFS server in the same process.
+# They require a network namespace for loopback networking.
+# ============================================================================
+
+# Macro to add a test that runs via NFS4 client (requires network namespace)
+macro(add_posix_nfs4_test testname prog nfs_backend)
+    add_test(NAME chimera/posix/${testname}_nfs4_${nfs_backend}
+        COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_${prog} -b nfs4_${nfs_backend}
+    )
+    get_target_property(test_file posix_${prog} TEST_FILE)
+    set_tests_properties(chimera/posix/${testname}_nfs4_${nfs_backend} PROPERTIES
+        ENVIRONMENT "TEST_FILE=${test_file}"
+        TIMEOUT 60
+    )
+endmacro()
+
+# Helper macro to generate NFS4 tests for a specific server-side backend
+macro(_generate_posix_nfs4_tests_for_backend nfs_backend)
+    foreach(prog ${POSIX_TEST_PROGRAMS})
+        string(REGEX REPLACE "^test_" "" test_name ${prog})
+        add_posix_nfs4_test(${test_name} ${prog} ${nfs_backend})
+    endforeach()
+endmacro()
+
+# Macro to generate all NFS4 tests for a backend with optional condition
+macro(generate_posix_nfs4_backend_tests backend condition_var)
+    if(condition_var)
+        if(${condition_var})
+            _generate_posix_nfs4_tests_for_backend(${backend})
+        endif()
+    else()
+        _generate_posix_nfs4_tests_for_backend(${backend})
+    endif()
+endmacro()
+
+# Generate NFS4 tests for each backend
+generate_posix_nfs4_backend_tests(memfs "")
+generate_posix_nfs4_backend_tests(demofs_io_uring "")
+if(HAVE_LIBAIO)
+    generate_posix_nfs4_backend_tests(demofs_aio "")
+endif()
+generate_posix_nfs4_backend_tests(cairn CAIRN_ENABLED)
+generate_posix_nfs4_backend_tests(linux "")
+generate_posix_nfs4_backend_tests(io_uring IO_URING_ENABLED)
+
+# ============================================================================
 # NFS3 over TCP-RDMA Backend Tests
 # These tests run the POSIX tests through the Chimera NFS client using TCP-RDMA,
 # connecting to a Chimera NFS server in the same process.
@@ -260,6 +308,21 @@ endif()
 add_fsx_test(nfs3rdma_linux)
 if(CHIMERA_VFS_IO_URING)
     add_fsx_test(nfs3rdma_io_uring)
+endif()
+
+# NFS4 FSX tests
+# These tests run FSX through the NFS4 protocol to an in-process server
+add_fsx_test(nfs4_memfs)
+add_fsx_test(nfs4_demofs_io_uring)
+if(HAVE_LIBAIO)
+    add_fsx_test(nfs4_demofs_aio)
+endif()
+if(CAIRN_ENABLED)
+    add_fsx_test(nfs4_cairn)
+endif()
+add_fsx_test(nfs4_linux)
+if(IO_URING_ENABLED)
+    add_fsx_test(nfs4_io_uring)
 endif()
 
 # Cthon common library (shared helpers for all cthon tests)
@@ -480,6 +543,53 @@ generate_cthon_nfs3rdma_backend_tests(linux "")
 generate_cthon_nfs3rdma_backend_tests(io_uring CHIMERA_VFS_IO_URING)
 
 # ============================================================================
+# NFS4 Cthon Tests
+# These tests run the cthon tests through the Chimera NFS4 client,
+# connecting to a Chimera NFS server in the same process.
+# They require a network namespace for loopback networking.
+# ============================================================================
+
+# Macro to add a cthon test that runs via NFS4 client (requires network namespace)
+macro(add_cthon_nfs4_test testname prog nfs_backend)
+    add_test(NAME chimera/posix/cthon/${testname}_nfs4_${nfs_backend}
+        COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_${prog} -b nfs4_${nfs_backend}
+    )
+    get_target_property(test_file posix_${prog} TEST_FILE)
+    set_tests_properties(chimera/posix/cthon/${testname}_nfs4_${nfs_backend} PROPERTIES
+        ENVIRONMENT "TEST_FILE=${test_file}"
+        TIMEOUT 300
+    )
+endmacro()
+
+# Helper macro to generate NFS4 cthon tests for a specific server-side backend
+macro(_generate_cthon_nfs4_tests_for_backend nfs_backend)
+    foreach(prog ${CTHON_TEST_PROGRAMS})
+        add_cthon_nfs4_test(${prog} ${prog} ${nfs_backend})
+    endforeach()
+endmacro()
+
+# Macro to generate all NFS4 cthon tests for a backend with optional condition
+macro(generate_cthon_nfs4_backend_tests backend condition_var)
+    if(condition_var)
+        if(${condition_var})
+            _generate_cthon_nfs4_tests_for_backend(${backend})
+        endif()
+    else()
+        _generate_cthon_nfs4_tests_for_backend(${backend})
+    endif()
+endmacro()
+
+# Generate NFS4 cthon tests for each backend
+generate_cthon_nfs4_backend_tests(memfs "")
+generate_cthon_nfs4_backend_tests(demofs_io_uring "")
+if(HAVE_LIBAIO)
+    generate_cthon_nfs4_backend_tests(demofs_aio "")
+endif()
+generate_cthon_nfs4_backend_tests(cairn CAIRN_ENABLED)
+generate_cthon_nfs4_backend_tests(linux "")
+generate_cthon_nfs4_backend_tests(io_uring IO_URING_ENABLED)
+
+# ============================================================================
 # Stress Tests ported from xfstests
 # These are longer-running tests that exercise filesystem operations heavily
 # ============================================================================
@@ -676,6 +786,67 @@ endif()
 generate_stress_nfs3rdma_tests(cairn CAIRN_ENABLED)
 generate_stress_nfs3rdma_tests(linux "")
 generate_stress_nfs3rdma_tests(io_uring CHIMERA_VFS_IO_URING)
+
+# ============================================================================
+# NFS4 Stress Tests
+# These tests run the stress tests through the Chimera NFS4 client,
+# connecting to a Chimera NFS server in the same process.
+# They require a network namespace for loopback networking.
+# ============================================================================
+
+# Helper macro to generate NFS4 stress tests for a backend
+macro(_generate_stress_nfs4_tests_for_backend nfs_backend)
+    # dirstress: directory operations stress test (reduced params for testing)
+    add_test(NAME chimera/posix/dirstress_nfs4_${nfs_backend}
+        COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_dirstress -b nfs4_${nfs_backend} -p 1 -f 50
+    )
+    set_tests_properties(chimera/posix/dirstress_nfs4_${nfs_backend} PROPERTIES TIMEOUT 120)
+
+    # rewinddir: tests rewinddir() POSIX semantics
+    add_test(NAME chimera/posix/rewinddir_nfs4_${nfs_backend}
+        COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_rewinddir -b nfs4_${nfs_backend}
+    )
+    set_tests_properties(chimera/posix/rewinddir_nfs4_${nfs_backend} PROPERTIES TIMEOUT 120)
+
+    # fstest: data integrity verification test
+    add_test(NAME chimera/posix/fstest_nfs4_${nfs_backend}
+        COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_fstest -b nfs4_${nfs_backend} -n 1 -f 2 -l 5 -s 65536
+    )
+    set_tests_properties(chimera/posix/fstest_nfs4_${nfs_backend} PROPERTIES TIMEOUT 120)
+
+    # nametest: namespace stress test
+    add_test(NAME chimera/posix/nametest_nfs4_${nfs_backend}
+        COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_nametest -b nfs4_${nfs_backend} -n 50 -i 1000
+    )
+    set_tests_properties(chimera/posix/nametest_nfs4_${nfs_backend} PROPERTIES TIMEOUT 120)
+
+    # fsstress: comprehensive filesystem stress test
+    add_test(NAME chimera/posix/fsstress_nfs4_${nfs_backend}
+        COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_fsstress -b nfs4_${nfs_backend} -n 500 -p 1
+    )
+    set_tests_properties(chimera/posix/fsstress_nfs4_${nfs_backend} PROPERTIES TIMEOUT 180)
+endmacro()
+
+# Macro to generate NFS4 stress tests with optional condition
+macro(generate_stress_nfs4_tests backend condition_var)
+    if(condition_var)
+        if(${condition_var})
+            _generate_stress_nfs4_tests_for_backend(${backend})
+        endif()
+    else()
+        _generate_stress_nfs4_tests_for_backend(${backend})
+    endif()
+endmacro()
+
+# Generate NFS4 stress tests for each backend
+generate_stress_nfs4_tests(memfs "")
+generate_stress_nfs4_tests(demofs_io_uring "")
+if(HAVE_LIBAIO)
+    generate_stress_nfs4_tests(demofs_aio "")
+endif()
+generate_stress_nfs4_tests(cairn CAIRN_ENABLED)
+generate_stress_nfs4_tests(linux "")
+generate_stress_nfs4_tests(io_uring CHIMERA_VFS_IO_URING)
 
 # ============================================================================
 # Non-root user tests

--- a/src/posix/tests/CMakeLists.txt
+++ b/src/posix/tests/CMakeLists.txt
@@ -178,24 +178,22 @@ endmacro()
 
 # Macro to generate all NFS4 tests for a backend with optional condition
 macro(generate_posix_nfs4_backend_tests backend condition_var)
-    if(condition_var)
-        if(${condition_var})
-            _generate_posix_nfs4_tests_for_backend(${backend})
-        endif()
-    else()
+    if("${condition_var}" STREQUAL "")
+        _generate_posix_nfs4_tests_for_backend(${backend})
+    elseif(${condition_var})
         _generate_posix_nfs4_tests_for_backend(${backend})
     endif()
 endmacro()
 
 # Generate NFS4 tests for each backend
 generate_posix_nfs4_backend_tests(memfs "")
-generate_posix_nfs4_backend_tests(demofs_io_uring "")
+generate_posix_nfs4_backend_tests(demofs_io_uring IO_URING_ENABLED)
 if(HAVE_LIBAIO)
     generate_posix_nfs4_backend_tests(demofs_aio "")
 endif()
 generate_posix_nfs4_backend_tests(cairn CAIRN_ENABLED)
 generate_posix_nfs4_backend_tests(linux "")
-generate_posix_nfs4_backend_tests(io_uring IO_URING_ENABLED)
+generate_posix_nfs4_backend_tests(io_uring CHIMERA_VFS_IO_URING)
 
 # ============================================================================
 # NFS3 over TCP-RDMA Backend Tests
@@ -313,7 +311,9 @@ endif()
 # NFS4 FSX tests
 # These tests run FSX through the NFS4 protocol to an in-process server
 add_fsx_test(nfs4_memfs)
-add_fsx_test(nfs4_demofs_io_uring)
+if(IO_URING_ENABLED)
+    add_fsx_test(nfs4_demofs_io_uring)
+endif()
 if(HAVE_LIBAIO)
     add_fsx_test(nfs4_demofs_aio)
 endif()
@@ -321,7 +321,7 @@ if(CAIRN_ENABLED)
     add_fsx_test(nfs4_cairn)
 endif()
 add_fsx_test(nfs4_linux)
-if(IO_URING_ENABLED)
+if(CHIMERA_VFS_IO_URING)
     add_fsx_test(nfs4_io_uring)
 endif()
 
@@ -570,24 +570,22 @@ endmacro()
 
 # Macro to generate all NFS4 cthon tests for a backend with optional condition
 macro(generate_cthon_nfs4_backend_tests backend condition_var)
-    if(condition_var)
-        if(${condition_var})
-            _generate_cthon_nfs4_tests_for_backend(${backend})
-        endif()
-    else()
+    if("${condition_var}" STREQUAL "")
+        _generate_cthon_nfs4_tests_for_backend(${backend})
+    elseif(${condition_var})
         _generate_cthon_nfs4_tests_for_backend(${backend})
     endif()
 endmacro()
 
 # Generate NFS4 cthon tests for each backend
 generate_cthon_nfs4_backend_tests(memfs "")
-generate_cthon_nfs4_backend_tests(demofs_io_uring "")
+generate_cthon_nfs4_backend_tests(demofs_io_uring IO_URING_ENABLED)
 if(HAVE_LIBAIO)
     generate_cthon_nfs4_backend_tests(demofs_aio "")
 endif()
 generate_cthon_nfs4_backend_tests(cairn CAIRN_ENABLED)
 generate_cthon_nfs4_backend_tests(linux "")
-generate_cthon_nfs4_backend_tests(io_uring IO_URING_ENABLED)
+generate_cthon_nfs4_backend_tests(io_uring CHIMERA_VFS_IO_URING)
 
 # ============================================================================
 # Stress Tests ported from xfstests
@@ -829,18 +827,16 @@ endmacro()
 
 # Macro to generate NFS4 stress tests with optional condition
 macro(generate_stress_nfs4_tests backend condition_var)
-    if(condition_var)
-        if(${condition_var})
-            _generate_stress_nfs4_tests_for_backend(${backend})
-        endif()
-    else()
+    if("${condition_var}" STREQUAL "")
+        _generate_stress_nfs4_tests_for_backend(${backend})
+    elseif(${condition_var})
         _generate_stress_nfs4_tests_for_backend(${backend})
     endif()
 endmacro()
 
 # Generate NFS4 stress tests for each backend
 generate_stress_nfs4_tests(memfs "")
-generate_stress_nfs4_tests(demofs_io_uring "")
+generate_stress_nfs4_tests(demofs_io_uring IO_URING_ENABLED)
 if(HAVE_LIBAIO)
     generate_stress_nfs4_tests(demofs_aio "")
 endif()

--- a/src/posix/tests/run_fsx.sh
+++ b/src/posix/tests/run_fsx.sh
@@ -25,6 +25,7 @@ usage() {
     echo "Direct backends:    memfs, demofs_io_uring, demofs_aio, cairn, linux, io_uring"
     echo "NFS3 backends:      nfs3_memfs, nfs3_demofs_io_uring, nfs3_demofs_aio, nfs3_cairn, nfs3_linux, nfs3_io_uring"
     echo "NFS3 RDMA backends: nfs3rdma_memfs, nfs3rdma_demofs_io_uring, nfs3rdma_demofs_aio, nfs3rdma_cairn, nfs3rdma_linux, nfs3rdma_io_uring"
+    echo "NFS4 backends:      nfs4_memfs, nfs4_demofs_io_uring, nfs4_demofs_aio, nfs4_cairn, nfs4_linux, nfs4_io_uring"
     echo ""
     echo "Options:"
     echo "  -b <backend>   VFS backend to use (required)"
@@ -60,6 +61,7 @@ case "$BACKEND" in
     memfs|demofs_io_uring|demofs_aio|cairn|linux|io_uring) ;;
     nfs3_memfs|nfs3_demofs_io_uring|nfs3_demofs_aio|nfs3_cairn|nfs3_linux|nfs3_io_uring) IS_NFS=1 ;;
     nfs3rdma_memfs|nfs3rdma_demofs_io_uring|nfs3rdma_demofs_aio|nfs3rdma_cairn|nfs3rdma_linux|nfs3rdma_io_uring) IS_NFS=1 ;;
+    nfs4_memfs|nfs4_demofs_io_uring|nfs4_demofs_aio|nfs4_cairn|nfs4_linux|nfs4_io_uring) IS_NFS=1 ;;
     *) echo "Error: Unknown backend '$BACKEND'"; usage ;;
 esac
 

--- a/src/server/nfs/CMakeLists.txt
+++ b/src/server/nfs/CMakeLists.txt
@@ -15,7 +15,7 @@ add_library(chimera_nfs SHARED nfs.c nfs4_session.c nfs_mount.c nfs_portmap.c nf
 
 
             nfs4_proc_getfh.c nfs4_proc_access.c nfs4_proc_putrootfh.c nfs4_proc_putfh.c
-            nfs4_proc_getattr.c nfs4_proc_lookup.c nfs4_proc_compound.c nfs4_proc_null.c
+            nfs4_proc_getattr.c nfs4_proc_lookup.c nfs4_proc_lookupp.c nfs4_proc_compound.c nfs4_proc_null.c
             nfs4_proc_readdir.c nfs4_proc_close.c nfs4_proc_create.c  nfs4_proc_open.c
             nfs4_proc_setclientid.c nfs4_proc_setclientid_confirm.c nfs4_proc_remove.c
             nfs4_proc_read.c nfs4_proc_write.c nfs4_proc_commit.c nfs4_proc_readlink.c

--- a/src/server/nfs/nfs4_proc_compound.c
+++ b/src/server/nfs/nfs4_proc_compound.c
@@ -72,6 +72,9 @@ chimera_nfs4_compound_process(
             case OP_LOOKUP:
                 chimera_nfs4_lookup(thread, req, argop, resop);
                 break;
+            case OP_LOOKUPP:
+                chimera_nfs4_lookupp(thread, req, argop, resop);
+                break;
             case OP_PUTFH:
                 chimera_nfs4_putfh(thread, req, argop, resop);
                 break;

--- a/src/server/nfs/nfs4_proc_lookupp.c
+++ b/src/server/nfs/nfs4_proc_lookupp.c
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "nfs4_procs.h"
+#include "nfs4_status.h"
+#include "vfs/vfs_procs.h"
+#include "vfs/vfs_release.h"
+
+static void
+chimera_nfs4_lookupp_complete(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *attr,
+    struct chimera_vfs_attrs *dir_attr,
+    void                     *private_data)
+{
+    struct nfs_request *req    = private_data;
+    nfsstat4            status = chimera_nfs4_errno_to_nfsstat4(error_code);
+    struct LOOKUPP4res *res    = &req->res_compound.resarray[req->index].oplookupp;
+
+    if (error_code == CHIMERA_VFS_OK) {
+        if (!(attr->va_set_mask & CHIMERA_VFS_ATTR_FH)) {
+            status = NFS4ERR_SERVERFAULT;
+        } else {
+            memcpy(req->fh, attr->va_fh, attr->va_fh_len);
+            req->fhlen = attr->va_fh_len;
+        }
+    }
+
+    res->status = status;
+    chimera_vfs_release(req->thread->vfs_thread, req->handle);
+    chimera_nfs4_compound_complete(req, status);
+} /* chimera_nfs4_lookupp_complete */
+
+static void
+chimera_nfs4_lookupp_open_callback(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *handle,
+    void                           *private_data)
+{
+    struct nfs_request *req    = private_data;
+    nfsstat4            status = chimera_nfs4_errno_to_nfsstat4(error_code);
+    struct LOOKUPP4res *res    = &req->res_compound.resarray[req->index].oplookupp;
+
+    if (error_code == CHIMERA_VFS_OK) {
+        req->handle = handle;
+
+        /*
+         * Resolve parent via lookup_at(handle, "..").  Backends that
+         * understand directory structure (memfs, cairn, demofs) handle
+         * ".." natively; pass-through backends (linux, io_uring) get
+         * parent attrs from fstatat(parent_fd, "..").
+         */
+        chimera_vfs_lookup_at(req->thread->vfs_thread, &req->cred,
+                              handle,
+                              "..",
+                              2,
+                              CHIMERA_VFS_ATTR_FH,
+                              0,
+                              chimera_nfs4_lookupp_complete,
+                              req);
+    } else {
+        res->status = status;
+        chimera_nfs4_compound_complete(req, status);
+    }
+} /* chimera_nfs4_lookupp_open_callback */
+
+void
+chimera_nfs4_lookupp(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_request               *req,
+    struct nfs_argop4                *argop,
+    struct nfs_resop4                *resop)
+{
+    struct LOOKUPP4res *res = &resop->oplookupp;
+
+    if (req->fhlen == 0) {
+        res->status = NFS4ERR_NOFILEHANDLE;
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    /*
+     * LOOKUPP at the namespace root returns the root again (RFC 7530
+     * 14.2.16).  No need to descend into VFS for the synthetic NFS4 root.
+     */
+    if (fh_is_nfs4_root(req->fh, req->fhlen)) {
+        res->status = NFS4_OK;
+        chimera_nfs4_compound_complete(req, NFS4_OK);
+        return;
+    }
+
+    chimera_vfs_open_fh(thread->vfs_thread, &req->cred,
+                        req->fh,
+                        req->fhlen,
+                        CHIMERA_VFS_OPEN_INFERRED | CHIMERA_VFS_OPEN_PATH | CHIMERA_VFS_OPEN_DIRECTORY,
+                        chimera_nfs4_lookupp_open_callback,
+                        req);
+} /* chimera_nfs4_lookupp */

--- a/src/server/nfs/nfs4_proc_read.c
+++ b/src/server/nfs/nfs4_proc_read.c
@@ -7,6 +7,14 @@
 #include "vfs/vfs_procs.h"
 #include "vfs/vfs_release.h"
 
+static inline int
+chimera_nfs4_stateid_is_anonymous(const struct stateid4 *sid)
+{
+    static const uint8_t zero[12] = { 0 };
+
+    return sid->seqid == 0 && memcmp(sid->other, zero, sizeof(zero)) == 0;
+} /* chimera_nfs4_stateid_is_anonymous */
+
 static void
 chimera_nfs4_read_complete(
     enum chimera_vfs_error    error_code,
@@ -32,14 +40,53 @@ chimera_nfs4_read_complete(
         evpl_iovecs_release(req->thread->evpl, iov, niov);
     }
 
-    deferred = nfs4_session_release_state(req->session, req->nfs4_state);
-    if (deferred) {
-        chimera_vfs_release(req->thread->vfs_thread, deferred);
+    if (req->nfs4_state) {
+        deferred = nfs4_session_release_state(req->session, req->nfs4_state);
+        if (deferred) {
+            chimera_vfs_release(req->thread->vfs_thread, deferred);
+        }
+    } else if (req->handle) {
+        /* Anonymous stateid: release the on-the-fly handle we opened. */
+        chimera_vfs_release(req->thread->vfs_thread, req->handle);
+        req->handle = NULL;
     }
 
     chimera_nfs4_compound_complete(req, NFS4_OK);
 
 } /* chimera_nfs4_read_complete */
+
+static void
+chimera_nfs4_read_open_callback(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *handle,
+    void                           *private_data)
+{
+    struct nfs_request *req  = private_data;
+    struct READ4args   *args = &req->args_compound->argarray[req->index].opread;
+    struct READ4res    *res  = &req->res_compound.resarray[req->index].opread;
+    struct evpl_iovec  *iov;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        res->status = chimera_nfs4_errno_to_nfsstat4(error_code);
+        chimera_nfs4_compound_complete(req, NFS4_OK);
+        return;
+    }
+
+    req->handle = handle;
+
+    iov = xdr_dbuf_alloc_space(sizeof(*iov) * 256, req->encoding->dbuf);
+    chimera_nfs_abort_if(iov == NULL, "Failed to allocate space");
+
+    chimera_vfs_read(req->thread->vfs_thread, &req->cred,
+                     handle,
+                     args->offset,
+                     args->count,
+                     iov,
+                     256,
+                     0,
+                     chimera_nfs4_read_complete,
+                     req);
+} /* chimera_nfs4_read_open_callback */
 
 void
 chimera_nfs4_read(
@@ -48,15 +95,41 @@ chimera_nfs4_read(
     struct nfs_argop4                *argop,
     struct nfs_resop4                *resop)
 {
-    struct READ4args               *args    = &argop->opread;
-    struct READ4res                *res     = &resop->opread;
-    struct nfs4_session            *session = nfs4_resolve_session(
+    struct READ4args               *args = &argop->opread;
+    struct READ4res                *res  = &resop->opread;
+    struct chimera_vfs_open_handle *state_handle;
+    struct nfs4_state              *state;
+    struct nfs4_session            *session;
+    struct evpl_iovec              *iov;
+
+    req->nfs4_state = NULL;
+    req->handle     = NULL;
+
+    /*
+     * RFC 7530 9.1.4.3 / RFC 8881 8.2.3 require READ to honor the
+     * anonymous stateid (all zeros).  Open the current FH on the fly
+     * instead of consulting per-session state.
+     */
+    if (chimera_nfs4_stateid_is_anonymous(&args->stateid)) {
+        if (req->fhlen == 0) {
+            res->status = NFS4ERR_NOFILEHANDLE;
+            chimera_nfs4_compound_complete(req, NFS4_OK);
+            return;
+        }
+
+        chimera_vfs_open_fh(thread->vfs_thread, &req->cred,
+                            req->fh,
+                            req->fhlen,
+                            CHIMERA_VFS_OPEN_INFERRED | CHIMERA_VFS_OPEN_READ_ONLY,
+                            chimera_nfs4_read_open_callback,
+                            req);
+        return;
+    }
+
+    session = nfs4_resolve_session(
         req->session, req->conn,
         &thread->shared->nfs4_shared_clients,
         &args->stateid);
-    struct nfs4_state              *state;
-    struct chimera_vfs_open_handle *state_handle;
-    struct evpl_iovec              *iov;
 
     if (!session) {
         res->status = NFS4ERR_BAD_STATEID;

--- a/src/server/nfs/nfs4_proc_readdir.c
+++ b/src/server/nfs/nfs4_proc_readdir.c
@@ -144,7 +144,7 @@ chimera_nfs4_readdir_open_callback(
                         0,
                         args->cookie,
                         cookieverf,
-                        CHIMERA_VFS_READDIR_EMIT_DOT,
+                        0,
                         chimera_nfs4_readdir_callback,
                         chimera_nfs4_readdir_complete,
                         req);

--- a/src/server/nfs/nfs4_proc_readdir.c
+++ b/src/server/nfs/nfs4_proc_readdir.c
@@ -144,7 +144,7 @@ chimera_nfs4_readdir_open_callback(
                         0,
                         args->cookie,
                         cookieverf,
-                        0,
+                        CHIMERA_VFS_READDIR_EMIT_DOT,
                         chimera_nfs4_readdir_callback,
                         chimera_nfs4_readdir_complete,
                         req);

--- a/src/server/nfs/nfs4_proc_sequence.c
+++ b/src/server/nfs/nfs4_proc_sequence.c
@@ -45,4 +45,4 @@ chimera_nfs4_sequence(
     res->sr_resok4.sr_status_flags          = 0;
 
     chimera_nfs4_compound_complete(req, NFS4_OK);
-} /* chimera_nfs4_reclaim_complete */
+} /* chimera_nfs4_sequence */

--- a/src/server/nfs/nfs4_proc_write.c
+++ b/src/server/nfs/nfs4_proc_write.c
@@ -66,6 +66,7 @@ chimera_nfs4_write(
 
     if (!session) {
         res->status = NFS4ERR_BAD_STATEID;
+        evpl_iovecs_release(thread->evpl, args->data.iov, args->data.niov);
         chimera_nfs4_compound_complete(req, NFS4_OK);
         return;
     }
@@ -75,6 +76,7 @@ chimera_nfs4_write(
     if (nfs4_session_acquire_state(session, &args->stateid,
                                    &state, &state_handle) != NFS4_OK) {
         res->status = NFS4ERR_BAD_STATEID;
+        evpl_iovecs_release(thread->evpl, args->data.iov, args->data.niov);
         chimera_nfs4_compound_complete(req, NFS4_OK);
         return;
     }

--- a/src/server/nfs/nfs4_proc_write.c
+++ b/src/server/nfs/nfs4_proc_write.c
@@ -8,6 +8,14 @@
 #include "vfs/vfs_release.h"
 #include "evpl/evpl.h"
 
+static inline int
+chimera_nfs4_write_stateid_is_anonymous(const struct stateid4 *sid)
+{
+    static const uint8_t zero[12] = { 0 };
+
+    return sid->seqid == 0 && memcmp(sid->other, zero, sizeof(zero)) == 0;
+} /* chimera_nfs4_write_stateid_is_anonymous */
+
 static void
 chimera_nfs4_write_complete(
     enum chimera_vfs_error    error_code,
@@ -40,13 +48,52 @@ chimera_nfs4_write_complete(
         res->status = chimera_nfs4_errno_to_nfsstat4(error_code);
     }
 
-    deferred = nfs4_session_release_state(req->session, req->nfs4_state);
-    if (deferred) {
-        chimera_vfs_release(req->thread->vfs_thread, deferred);
+    if (req->nfs4_state) {
+        deferred = nfs4_session_release_state(req->session, req->nfs4_state);
+        if (deferred) {
+            chimera_vfs_release(req->thread->vfs_thread, deferred);
+        }
+    } else if (req->handle) {
+        /* Anonymous stateid: release the on-the-fly handle we opened. */
+        chimera_vfs_release(req->thread->vfs_thread, req->handle);
+        req->handle = NULL;
     }
 
     chimera_nfs4_compound_complete(req, NFS4_OK);
 } /* chimera_nfs4_write_complete */
+
+static void
+chimera_nfs4_write_open_callback(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *handle,
+    void                           *private_data)
+{
+    struct nfs_request *req  = private_data;
+    struct WRITE4args  *args = &req->args_compound->argarray[req->index].opwrite;
+    struct WRITE4res   *res  = &req->res_compound.resarray[req->index].opwrite;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        res->status = chimera_nfs4_errno_to_nfsstat4(error_code);
+        evpl_iovecs_release(req->thread->evpl, args->data.iov, args->data.niov);
+        chimera_nfs4_compound_complete(req, NFS4_OK);
+        return;
+    }
+
+    req->handle      = handle;
+    req->args_write4 = args;
+
+    chimera_vfs_write(req->thread->vfs_thread, &req->cred,
+                      handle,
+                      args->offset,
+                      args->data.length,
+                      (args->stable != UNSTABLE4),
+                      0,
+                      0,
+                      args->data.iov,
+                      args->data.niov,
+                      chimera_nfs4_write_complete,
+                      req);
+} /* chimera_nfs4_write_open_callback */
 
 void
 chimera_nfs4_write(
@@ -55,14 +102,50 @@ chimera_nfs4_write(
     struct nfs_argop4                *argop,
     struct nfs_resop4                *resop)
 {
-    struct WRITE4args              *args    = &argop->opwrite;
-    struct WRITE4res               *res     = &resop->opwrite;
-    struct nfs4_session            *session = nfs4_resolve_session(
+    struct WRITE4args              *args = &argop->opwrite;
+    struct WRITE4res               *res  = &resop->opwrite;
+    struct nfs4_session            *session;
+    struct nfs4_state              *state;
+    struct chimera_vfs_open_handle *state_handle;
+
+    req->nfs4_state = NULL;
+    req->handle     = NULL;
+
+    /*
+     * Transfer ownership of write iovecs from the RPC2 message to prevent
+     * msg_free from double-releasing (args->data.iov points to msg->read_chunk.iov
+     * via XDR zerocopy).  The iovecs will be released in the write completion
+     * callback on this server thread, not in the VFS backend (which may run on
+     * a different delegation thread).
+     */
+    evpl_rpc2_encoding_take_read_chunk(req->encoding, NULL, NULL);
+
+    /*
+     * RFC 7530 9.1.4.3 / RFC 8881 8.2.3 require WRITE to honor the
+     * anonymous stateid (all zeros).  Open the current FH on the fly
+     * instead of consulting per-session state.
+     */
+    if (chimera_nfs4_write_stateid_is_anonymous(&args->stateid)) {
+        if (req->fhlen == 0) {
+            res->status = NFS4ERR_NOFILEHANDLE;
+            evpl_iovecs_release(thread->evpl, args->data.iov, args->data.niov);
+            chimera_nfs4_compound_complete(req, NFS4_OK);
+            return;
+        }
+
+        chimera_vfs_open_fh(thread->vfs_thread, &req->cred,
+                            req->fh,
+                            req->fhlen,
+                            CHIMERA_VFS_OPEN_INFERRED,
+                            chimera_nfs4_write_open_callback,
+                            req);
+        return;
+    }
+
+    session = nfs4_resolve_session(
         req->session, req->conn,
         &thread->shared->nfs4_shared_clients,
         &args->stateid);
-    struct nfs4_state              *state;
-    struct chimera_vfs_open_handle *state_handle;
 
     if (!session) {
         res->status = NFS4ERR_BAD_STATEID;
@@ -84,14 +167,6 @@ chimera_nfs4_write(
     req->nfs4_state  = state;
     req->args_write4 = args;
 
-    /* Transfer ownership of write iovecs from the RPC2 message to prevent
-     * msg_free from double-releasing (args->data.iov points to msg->read_chunk.iov
-     * via XDR zerocopy). The iovecs will be released in the write completion
-     * callback on this server thread, not in the VFS backend (which may run on
-     * a different delegation thread).
-     */
-    evpl_rpc2_encoding_take_read_chunk(req->encoding, NULL, NULL);
-
     chimera_vfs_write(thread->vfs_thread, &req->cred,
                       state_handle,
                       args->offset,
@@ -104,4 +179,3 @@ chimera_nfs4_write(
                       chimera_nfs4_write_complete,
                       req);
 } /* chimera_nfs4_write */
-

--- a/src/server/nfs/nfs4_procs.h
+++ b/src/server/nfs/nfs4_procs.h
@@ -152,6 +152,13 @@ chimera_nfs4_lookup(
     struct nfs_resop4                *resop);
 
 void
+chimera_nfs4_lookupp(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_request               *req,
+    struct nfs_argop4                *argop,
+    struct nfs_resop4                *resop);
+
+void
 chimera_nfs4_read(
     struct chimera_server_nfs_thread *thread,
     struct nfs_request               *req,

--- a/src/server/nfs/nfs4_status.h
+++ b/src/server/nfs/nfs4_status.h
@@ -61,8 +61,10 @@ chimera_nfs4_errno_to_nfsstat4(enum chimera_vfs_error err)
             return NFS4ERR_SERVERFAULT;
         case CHIMERA_VFS_ESYMLINK:
             return NFS4ERR_SYMLINK;
+        case CHIMERA_VFS_ELOOP:
+            return NFS4ERR_SERVERFAULT;
         default:
             chimera_nfs_error("Unknown VFS error code: %d", err);
-            abort();
+            return NFS4ERR_SERVERFAULT;
     } /* switch */
 } /* chimera_nfs4_errno_to_nfsstat4 */

--- a/src/vfs/nfs/CMakeLists.txt
+++ b/src/vfs/nfs/CMakeLists.txt
@@ -45,6 +45,7 @@ add_library(chimera_vfs_nfs SHARED
     nfs4_rename_at.c
     nfs4_setattr.c
     nfs4_symlink_at.c
+    nfs4_umount.c
     nfs4_write.c
 )
 

--- a/src/vfs/nfs/nfs.c
+++ b/src/vfs/nfs/nfs.c
@@ -107,6 +107,11 @@ chimera_nfs_destroy(void *private_data)
 
     for (i = 0; i < shared->max_servers; i++) {
         if (shared->servers[i]) {
+            /* Free NFS4 session if present */
+            if (shared->servers[i]->nfs4_session) {
+                free(shared->servers[i]->nfs4_session->slot_seqids);
+                free(shared->servers[i]->nfs4_session);
+            }
             free(shared->servers[i]);
         }
     }

--- a/src/vfs/nfs/nfs3_open_state.h
+++ b/src/vfs/nfs/nfs3_open_state.h
@@ -22,9 +22,9 @@
  */
 
 struct chimera_nfs3_open_state {
+    uint8_t                 server_index; /* NFS server index for dispatch routing */
     atomic_int              dirty; /* Count of uncommitted unstable writes */
     int                     silly_renamed; /* File has been silly renamed */
-    uint8_t                 server_index; /* NFS server index for dispatch routing */
     uint8_t                 dir_fh_len; /* Directory fh for silly remove on close */
     uint8_t                 dir_fh[CHIMERA_VFS_FH_SIZE];
 

--- a/src/vfs/nfs/nfs4.c
+++ b/src/vfs/nfs/nfs4.c
@@ -16,6 +16,9 @@ chimera_nfs4_dispatch(
         case CHIMERA_VFS_OP_MOUNT:
             chimera_nfs4_mount(thread, shared, request, private_data);
             break;
+        case CHIMERA_VFS_OP_UMOUNT:
+            chimera_nfs4_umount(thread, shared, request, private_data);
+            break;
         case CHIMERA_VFS_OP_LOOKUP_AT:
             chimera_nfs4_lookup_at(thread, shared, request, private_data);
             break;

--- a/src/vfs/nfs/nfs4_close.c
+++ b/src/vfs/nfs/nfs4_close.c
@@ -1,8 +1,9 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
 #include "nfs_internal.h"
+#include "nfs4_open_state.h"
 
 void
 chimera_nfs4_close(
@@ -11,7 +12,23 @@ chimera_nfs4_close(
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
-    request->status = CHIMERA_VFS_ENOTSUP;
+    struct chimera_nfs4_open_state *open_state;
+
+    open_state = (struct chimera_nfs4_open_state *) request->close.vfs_private;
+
+    /* Handle case where no open state was tracked (e.g., inferred opens) */
+    if (!open_state) {
+        request->status = CHIMERA_VFS_OK;
+        request->complete(request);
+        return;
+    }
+
+    /* TODO: Send NFS4 CLOSE compound to release the stateid on server.
+     * For now, just free the local state. */
+
+    /* Free the open state */
+    chimera_nfs4_open_state_free(open_state);
+
+    request->status = CHIMERA_VFS_OK;
     request->complete(request);
 } /* chimera_nfs4_close */
-

--- a/src/vfs/nfs/nfs4_getattr.c
+++ b/src/vfs/nfs/nfs4_getattr.c
@@ -1,8 +1,66 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
 #include "nfs_internal.h"
+
+static void
+chimera_nfs4_getattr_callback(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    struct COMPOUND4res         *res,
+    int                          status,
+    void                        *private_data)
+{
+    struct chimera_vfs_request *request = private_data;
+    struct nfs_resop4          *getattr_res;
+
+    if (unlikely(status)) {
+        request->status = CHIMERA_VFS_EFAULT;
+        request->complete(request);
+        return;
+    }
+
+    if (res->status != NFS4_OK) {
+        request->status = chimera_nfs4_status_to_errno(res->status);
+        request->complete(request);
+        return;
+    }
+
+    /* Check SEQUENCE result */
+    if (res->num_resarray < 1 || res->resarray[0].opsequence.sr_status != NFS4_OK) {
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+
+    /* Check PUTFH result */
+    if (res->num_resarray < 2 || res->resarray[1].opputfh.status != NFS4_OK) {
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+
+    /* Check GETATTR result */
+    if (res->num_resarray < 3) {
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+    getattr_res = &res->resarray[2];
+    if (getattr_res->opgetattr.status != NFS4_OK) {
+        request->status = chimera_nfs4_status_to_errno(getattr_res->opgetattr.status);
+        request->complete(request);
+        return;
+    }
+
+    /* Unmarshall attributes */
+    chimera_nfs4_unmarshall_fattr(&getattr_res->opgetattr.resok4.obj_attributes,
+                                  &request->getattr.r_attr);
+
+    request->status = CHIMERA_VFS_OK;
+    request->complete(request);
+} /* chimera_nfs4_getattr_callback */
 
 void
 chimera_nfs4_getattr(
@@ -11,7 +69,75 @@ chimera_nfs4_getattr(
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
-    request->status = CHIMERA_VFS_ENOTSUP;
-    request->complete(request);
+    struct chimera_nfs_client_server_thread *server_thread = chimera_nfs_thread_get_server_thread(thread, request->fh,
+                                                                                                  request->fh_len);
+    struct chimera_nfs_client_server        *server;
+    struct chimera_nfs4_client_session      *session;
+    struct COMPOUND4args                     args;
+    struct nfs_argop4                        argarray[3];
+    uint32_t                                 attr_request[2];
+    struct evpl_rpc2_cred                    rpc2_cred;
+    uint8_t                                 *fh;
+    int                                      fhlen;
+
+    if (!server_thread) {
+        request->status = CHIMERA_VFS_ESTALE;
+        request->complete(request);
+        return;
+    }
+
+    server  = server_thread->server;
+    session = server->nfs4_session;
+
+    if (!session) {
+        request->status = CHIMERA_VFS_ESTALE;
+        request->complete(request);
+        return;
+    }
+
+    chimera_nfs4_map_fh(request->fh, request->fh_len, &fh, &fhlen);
+
+    /* Build compound: SEQUENCE + PUTFH + GETATTR */
+    memset(&args, 0, sizeof(args));
+    args.tag.len      = 0;
+    args.minorversion = 1;
+    args.argarray     = argarray;
+    args.num_argarray = 3;
+
+    /* Op 0: SEQUENCE */
+    argarray[0].argop = OP_SEQUENCE;
+    memcpy(argarray[0].opsequence.sa_sessionid, session->sessionid, NFS4_SESSIONID_SIZE);
+    argarray[0].opsequence.sa_sequenceid     = chimera_nfs4_get_sequenceid(session, server_thread->slot_id);
+    argarray[0].opsequence.sa_slotid         = server_thread->slot_id;
+    argarray[0].opsequence.sa_highest_slotid = session->max_slots - 1;
+    argarray[0].opsequence.sa_cachethis      = 0;
+
+    /* Op 1: PUTFH - set current file handle */
+    argarray[1].argop               = OP_PUTFH;
+    argarray[1].opputfh.object.data = fh;
+    argarray[1].opputfh.object.len  = fhlen;
+
+    /* Op 2: GETATTR - get attributes */
+    argarray[2].argop = OP_GETATTR;
+    attr_request[0]   = (1 << FATTR4_TYPE) | (1 << FATTR4_SIZE) | (1 << FATTR4_FILEID);
+    attr_request[1]   = (1 << (FATTR4_MODE - 32)) | (1 << (FATTR4_NUMLINKS - 32)) |
+        (1 << (FATTR4_OWNER - 32)) | (1 << (FATTR4_OWNER_GROUP - 32)) |
+        (1 << (FATTR4_TIME_ACCESS - 32)) | (1 << (FATTR4_TIME_MODIFY - 32));
+    argarray[2].opgetattr.attr_request     = attr_request;
+    argarray[2].opgetattr.num_attr_request = 2;
+
+    chimera_nfs_init_rpc2_cred(&rpc2_cred, request->cred,
+                               request->thread->vfs->machine_name,
+                               request->thread->vfs->machine_name_len);
+
+    shared->nfs_v4.send_call_NFSPROC4_COMPOUND(
+        &shared->nfs_v4.rpc2,
+        thread->evpl,
+        server_thread->nfs_conn,
+        &rpc2_cred,
+        &args,
+        0, 0, 0,
+        chimera_nfs4_getattr_callback,
+        request);
 } /* chimera_nfs4_getattr */
 

--- a/src/vfs/nfs/nfs4_link_at.c
+++ b/src/vfs/nfs/nfs4_link_at.c
@@ -4,6 +4,79 @@
 
 #include "nfs_internal.h"
 
+struct chimera_nfs4_link_ctx {
+    struct chimera_nfs_thread        *thread;
+    struct chimera_nfs_client_server *server;
+};
+
+static void
+chimera_nfs4_link_callback(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    struct COMPOUND4res         *res,
+    int                          status,
+    void                        *private_data)
+{
+    struct chimera_vfs_request *request = private_data;
+    struct nfs_resop4          *link_res;
+
+    if (unlikely(status)) {
+        request->status = CHIMERA_VFS_EFAULT;
+        request->complete(request);
+        return;
+    }
+
+    if (res->status != NFS4_OK) {
+        request->status = chimera_nfs4_status_to_errno(res->status);
+        request->complete(request);
+        return;
+    }
+
+    /* Check SEQUENCE result (index 0) */
+    if (res->num_resarray < 1 || res->resarray[0].opsequence.sr_status != NFS4_OK) {
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+
+    /* Check PUTFH result (index 1) - source file */
+    if (res->num_resarray < 2 || res->resarray[1].opputfh.status != NFS4_OK) {
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+
+    /* Check SAVEFH result (index 2) */
+    if (res->num_resarray < 3 || res->resarray[2].opsavefh.status != NFS4_OK) {
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+
+    /* Check PUTFH result (index 3) - target directory */
+    if (res->num_resarray < 4 || res->resarray[3].opputfh.status != NFS4_OK) {
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+
+    /* Check LINK result (index 4) */
+    if (res->num_resarray < 5) {
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+    link_res = &res->resarray[4];
+    if (link_res->oplink.status != NFS4_OK) {
+        request->status = chimera_nfs4_status_to_errno(link_res->oplink.status);
+        request->complete(request);
+        return;
+    }
+
+    request->status = CHIMERA_VFS_OK;
+    request->complete(request);
+} /* chimera_nfs4_link_callback */
+
 void
 chimera_nfs4_link_at(
     struct chimera_nfs_thread  *thread,
@@ -11,7 +84,89 @@ chimera_nfs4_link_at(
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
-    request->status = CHIMERA_VFS_ENOTSUP;
-    request->complete(request);
-} /* chimera_nfs4_link_at */
+    struct chimera_nfs_client_server_thread *server_thread = chimera_nfs_thread_get_server_thread(thread, request->fh,
+                                                                                                  request->fh_len);
+    struct chimera_nfs_client_server        *server;
+    struct chimera_nfs4_client_session      *session;
+    struct chimera_nfs4_link_ctx            *ctx;
+    struct COMPOUND4args                     args;
+    struct nfs_argop4                        argarray[5];
+    struct evpl_rpc2_cred                    rpc2_cred;
+    uint8_t                                 *src_fh;
+    int                                      src_fhlen;
+    uint8_t                                 *dir_fh;
+    int                                      dir_fhlen;
 
+    ctx = request->plugin_data;
+
+    if (!server_thread) {
+        request->status = CHIMERA_VFS_ESTALE;
+        request->complete(request);
+        return;
+    }
+
+    server  = server_thread->server;
+    session = server->nfs4_session;
+
+    if (!session) {
+        request->status = CHIMERA_VFS_ESTALE;
+        request->complete(request);
+        return;
+    }
+
+    ctx->thread = thread;
+    ctx->server = server;
+
+    /* Map source file FH (request->fh) */
+    chimera_nfs4_map_fh(request->fh, request->fh_len, &src_fh, &src_fhlen);
+
+    /* Map target directory FH */
+    chimera_nfs4_map_fh(request->link_at.dir_fh, request->link_at.dir_fhlen, &dir_fh, &dir_fhlen);
+
+    /* Build compound: SEQUENCE + PUTFH(file) + SAVEFH + PUTFH(dir) + LINK */
+    memset(&args, 0, sizeof(args));
+    args.tag.len      = 0;
+    args.minorversion = 1;
+    args.argarray     = argarray;
+    args.num_argarray = 5;
+
+    /* Op 0: SEQUENCE */
+    argarray[0].argop = OP_SEQUENCE;
+    memcpy(argarray[0].opsequence.sa_sessionid, session->sessionid, NFS4_SESSIONID_SIZE);
+    argarray[0].opsequence.sa_sequenceid     = chimera_nfs4_get_sequenceid(session, server_thread->slot_id);
+    argarray[0].opsequence.sa_slotid         = server_thread->slot_id;
+    argarray[0].opsequence.sa_highest_slotid = session->max_slots - 1;
+    argarray[0].opsequence.sa_cachethis      = 0;
+
+    /* Op 1: PUTFH - set current FH to source file (the file to link) */
+    argarray[1].argop               = OP_PUTFH;
+    argarray[1].opputfh.object.data = src_fh;
+    argarray[1].opputfh.object.len  = src_fhlen;
+
+    /* Op 2: SAVEFH - save source file FH */
+    argarray[2].argop = OP_SAVEFH;
+
+    /* Op 3: PUTFH - set current FH to target directory */
+    argarray[3].argop               = OP_PUTFH;
+    argarray[3].opputfh.object.data = dir_fh;
+    argarray[3].opputfh.object.len  = dir_fhlen;
+
+    /* Op 4: LINK - create link from saved FH (file) in current FH (directory) */
+    argarray[4].argop               = OP_LINK;
+    argarray[4].oplink.newname.data = (uint8_t *) request->link_at.name;
+    argarray[4].oplink.newname.len  = request->link_at.namelen;
+
+    chimera_nfs_init_rpc2_cred(&rpc2_cred, request->cred,
+                               request->thread->vfs->machine_name,
+                               request->thread->vfs->machine_name_len);
+
+    shared->nfs_v4.send_call_NFSPROC4_COMPOUND(
+        &shared->nfs_v4.rpc2,
+        thread->evpl,
+        server_thread->nfs_conn,
+        &rpc2_cred,
+        &args,
+        0, 0, 0,
+        chimera_nfs4_link_callback,
+        request);
+} /* chimera_nfs4_link_at */

--- a/src/vfs/nfs/nfs4_lookup_at.c
+++ b/src/vfs/nfs/nfs4_lookup_at.c
@@ -3,6 +3,89 @@
 // SPDX-License-Identifier: LGPL-2.1-only
 
 #include "nfs_internal.h"
+#include "vfs/vfs_error.h"
+
+struct chimera_nfs4_lookup_ctx {
+    struct chimera_nfs_client_server *server;
+};
+
+static void
+chimera_nfs4_lookup_callback(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    struct COMPOUND4res         *res,
+    int                          status,
+    void                        *private_data)
+{
+    struct chimera_vfs_request     *request = private_data;
+    struct chimera_nfs4_lookup_ctx *ctx     = request->plugin_data;
+    struct nfs_resop4              *getfh_res;
+    struct nfs_resop4              *getattr_res;
+    xdr_opaque                     *remote_fh;
+
+    if (unlikely(status)) {
+        request->status = CHIMERA_VFS_EFAULT;
+        request->complete(request);
+        return;
+    }
+
+    if (res->status != NFS4_OK) {
+        request->status = chimera_nfs4_status_to_errno(res->status);
+        request->complete(request);
+        return;
+    }
+
+    /* Check SEQUENCE result */
+    if (res->num_resarray < 1 || res->resarray[0].opsequence.sr_status != NFS4_OK) {
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+
+    /* Check PUTFH result */
+    if (res->num_resarray < 2 || res->resarray[1].opputfh.status != NFS4_OK) {
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+
+    /* Check LOOKUP result */
+    if (res->num_resarray < 3 || res->resarray[2].oplookup.status != NFS4_OK) {
+        request->status = chimera_nfs4_status_to_errno(res->resarray[2].oplookup.status);
+        request->complete(request);
+        return;
+    }
+
+    /* Get GETFH result */
+    if (res->num_resarray < 4) {
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+    getfh_res = &res->resarray[3];
+    if (getfh_res->opgetfh.status != NFS4_OK) {
+        request->status = chimera_nfs4_status_to_errno(getfh_res->opgetfh.status);
+        request->complete(request);
+        return;
+    }
+
+    remote_fh = &getfh_res->opgetfh.resok4.object;
+
+    /* Build local file handle from server index + remote FH */
+    chimera_nfs4_unmarshall_fh(remote_fh, ctx->server->index, request->fh, &request->lookup_at.r_attr);
+
+    /* Get GETATTR result */
+    if (res->num_resarray >= 5) {
+        getattr_res = &res->resarray[4];
+        if (getattr_res->opgetattr.status == NFS4_OK) {
+            chimera_nfs4_unmarshall_fattr(&getattr_res->opgetattr.resok4.obj_attributes,
+                                          &request->lookup_at.r_attr);
+        }
+    }
+
+    request->status = CHIMERA_VFS_OK;
+    request->complete(request);
+} /* chimera_nfs4_lookup_callback */
 
 void
 chimera_nfs4_lookup_at(
@@ -11,7 +94,85 @@ chimera_nfs4_lookup_at(
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
-    request->status = CHIMERA_VFS_ENOTSUP;
-    request->complete(request);
-} /* chimera_nfs4_lookup_at */
+    struct chimera_nfs_client_server_thread *server_thread = chimera_nfs_thread_get_server_thread(thread, request->fh,
+                                                                                                  request->fh_len);
+    struct chimera_nfs_client_server        *server;
+    struct chimera_nfs4_client_session      *session;
+    struct COMPOUND4args                     args;
+    struct nfs_argop4                        argarray[5];
+    uint32_t                                 attr_request[2];
+    struct evpl_rpc2_cred                    rpc2_cred;
+    uint8_t                                 *fh;
+    int                                      fhlen;
+    struct chimera_nfs4_lookup_ctx          *ctx;
 
+    if (!server_thread) {
+        request->status = CHIMERA_VFS_ESTALE;
+        request->complete(request);
+        return;
+    }
+
+    server  = server_thread->server;
+    session = server->nfs4_session;
+
+    if (!session) {
+        request->status = CHIMERA_VFS_ESTALE;
+        request->complete(request);
+        return;
+    }
+
+    ctx         = request->plugin_data;
+    ctx->server = server;
+
+    chimera_nfs4_map_fh(request->fh, request->fh_len, &fh, &fhlen);
+
+    /* Build compound: SEQUENCE + PUTFH + LOOKUP + GETFH + GETATTR */
+    memset(&args, 0, sizeof(args));
+    args.tag.len      = 0;
+    args.minorversion = 1;
+    args.argarray     = argarray;
+    args.num_argarray = 5;
+
+    /* Op 0: SEQUENCE */
+    argarray[0].argop = OP_SEQUENCE;
+    memcpy(argarray[0].opsequence.sa_sessionid, session->sessionid, NFS4_SESSIONID_SIZE);
+    argarray[0].opsequence.sa_sequenceid     = chimera_nfs4_get_sequenceid(session, server_thread->slot_id);
+    argarray[0].opsequence.sa_slotid         = server_thread->slot_id;
+    argarray[0].opsequence.sa_highest_slotid = session->max_slots - 1;
+    argarray[0].opsequence.sa_cachethis      = 0;
+
+    /* Op 1: PUTFH - set current file handle to parent directory */
+    argarray[1].argop               = OP_PUTFH;
+    argarray[1].opputfh.object.data = fh;
+    argarray[1].opputfh.object.len  = fhlen;
+
+    /* Op 2: LOOKUP - lookup the component name */
+    argarray[2].argop                 = OP_LOOKUP;
+    argarray[2].oplookup.objname.data = (void *) request->lookup_at.component;
+    argarray[2].oplookup.objname.len  = request->lookup_at.component_len;
+
+    /* Op 3: GETFH - get file handle for looked up object */
+    argarray[3].argop = OP_GETFH;
+
+    /* Op 4: GETATTR - get attributes for looked up object */
+    argarray[4].argop = OP_GETATTR;
+    attr_request[0]   = (1 << FATTR4_TYPE) | (1 << FATTR4_SIZE) | (1 << FATTR4_FILEID);
+    attr_request[1]   = (1 << (FATTR4_MODE - 32)) | (1 << (FATTR4_NUMLINKS - 32)) |
+        (1 << (FATTR4_TIME_ACCESS - 32)) | (1 << (FATTR4_TIME_MODIFY - 32));
+    argarray[4].opgetattr.attr_request     = attr_request;
+    argarray[4].opgetattr.num_attr_request = 2;
+
+    chimera_nfs_init_rpc2_cred(&rpc2_cred, request->cred,
+                               request->thread->vfs->machine_name,
+                               request->thread->vfs->machine_name_len);
+
+    shared->nfs_v4.send_call_NFSPROC4_COMPOUND(
+        &shared->nfs_v4.rpc2,
+        thread->evpl,
+        server_thread->nfs_conn,
+        &rpc2_cred,
+        &args,
+        0, 0, 0,
+        chimera_nfs4_lookup_callback,
+        request);
+} /* chimera_nfs4_lookup_at */

--- a/src/vfs/nfs/nfs4_lookup_at.c
+++ b/src/vfs/nfs/nfs4_lookup_at.c
@@ -5,8 +5,15 @@
 #include "nfs_internal.h"
 #include "vfs/vfs_error.h"
 
+enum chimera_nfs4_lookup_op_type {
+    LOOKUP_OP_NORMAL,
+    LOOKUP_OP_DOT,
+    LOOKUP_OP_DOTDOT,
+};
+
 struct chimera_nfs4_lookup_ctx {
     struct chimera_nfs_client_server *server;
+    enum chimera_nfs4_lookup_op_type op_type;
 };
 
 static void
@@ -22,6 +29,9 @@ chimera_nfs4_lookup_callback(
     struct nfs_resop4              *getfh_res;
     struct nfs_resop4              *getattr_res;
     xdr_opaque                     *remote_fh;
+    int                             getfh_idx;
+    int                             getattr_idx;
+    nfsstat4                        traverse_status;
 
     if (unlikely(status)) {
         request->status = CHIMERA_VFS_EFAULT;
@@ -49,20 +59,41 @@ chimera_nfs4_lookup_callback(
         return;
     }
 
-    /* Check LOOKUP result */
-    if (res->num_resarray < 3 || res->resarray[2].oplookup.status != NFS4_OK) {
-        request->status = chimera_nfs4_status_to_errno(res->resarray[2].oplookup.status);
-        request->complete(request);
-        return;
+    /*
+     * For ".", the compound is SEQUENCE + PUTFH + GETFH + GETATTR (no
+     * traversal op).  For ".." and normal names, there is a LOOKUPP or
+     * LOOKUP at index 2 whose status must be checked.
+     */
+    if (ctx->op_type == LOOKUP_OP_DOT) {
+        getfh_idx   = 2;
+        getattr_idx = 3;
+    } else {
+        if (res->num_resarray < 3) {
+            request->status = CHIMERA_VFS_EIO;
+            request->complete(request);
+            return;
+        }
+        if (ctx->op_type == LOOKUP_OP_DOTDOT) {
+            traverse_status = res->resarray[2].oplookupp.status;
+        } else {
+            traverse_status = res->resarray[2].oplookup.status;
+        }
+        if (traverse_status != NFS4_OK) {
+            request->status = chimera_nfs4_status_to_errno(traverse_status);
+            request->complete(request);
+            return;
+        }
+        getfh_idx   = 3;
+        getattr_idx = 4;
     }
 
     /* Get GETFH result */
-    if (res->num_resarray < 4) {
+    if (res->num_resarray <= (uint32_t) getfh_idx) {
         request->status = CHIMERA_VFS_EIO;
         request->complete(request);
         return;
     }
-    getfh_res = &res->resarray[3];
+    getfh_res = &res->resarray[getfh_idx];
     if (getfh_res->opgetfh.status != NFS4_OK) {
         request->status = chimera_nfs4_status_to_errno(getfh_res->opgetfh.status);
         request->complete(request);
@@ -75,8 +106,8 @@ chimera_nfs4_lookup_callback(
     chimera_nfs4_unmarshall_fh(remote_fh, ctx->server->index, request->fh, &request->lookup_at.r_attr);
 
     /* Get GETATTR result */
-    if (res->num_resarray >= 5) {
-        getattr_res = &res->resarray[4];
+    if (res->num_resarray > (uint32_t) getattr_idx) {
+        getattr_res = &res->resarray[getattr_idx];
         if (getattr_res->opgetattr.status == NFS4_OK) {
             chimera_nfs4_unmarshall_fattr(&getattr_res->opgetattr.resok4.obj_attributes,
                                           &request->lookup_at.r_attr);
@@ -105,6 +136,8 @@ chimera_nfs4_lookup_at(
     uint8_t                                 *fh;
     int                                      fhlen;
     struct chimera_nfs4_lookup_ctx          *ctx;
+    enum chimera_nfs4_lookup_op_type         op_type;
+    int                                      getattr_idx;
 
     if (!server_thread) {
         request->status = CHIMERA_VFS_ESTALE;
@@ -121,17 +154,33 @@ chimera_nfs4_lookup_at(
         return;
     }
 
-    ctx         = request->plugin_data;
-    ctx->server = server;
+    /*
+     * NFSv4 OP_LOOKUP rejects "." and ".." with NFS4ERR_BADNAME (RFC 7530
+     * 14.2.15).  For ".", drop the traversal op entirely (current FH is
+     * unchanged after PUTFH).  For "..", use OP_LOOKUPP which moves the
+     * current FH to the parent directory.
+     */
+    if (request->lookup_at.component_len == 1 &&
+        request->lookup_at.component[0] == '.') {
+        op_type = LOOKUP_OP_DOT;
+    } else if (request->lookup_at.component_len == 2 &&
+               request->lookup_at.component[0] == '.' &&
+               request->lookup_at.component[1] == '.') {
+        op_type = LOOKUP_OP_DOTDOT;
+    } else {
+        op_type = LOOKUP_OP_NORMAL;
+    }
+
+    ctx          = request->plugin_data;
+    ctx->server  = server;
+    ctx->op_type = op_type;
 
     chimera_nfs4_map_fh(request->fh, request->fh_len, &fh, &fhlen);
 
-    /* Build compound: SEQUENCE + PUTFH + LOOKUP + GETFH + GETATTR */
     memset(&args, 0, sizeof(args));
     args.tag.len      = 0;
     args.minorversion = 1;
     args.argarray     = argarray;
-    args.num_argarray = 5;
 
     /* Op 0: SEQUENCE */
     argarray[0].argop = OP_SEQUENCE;
@@ -146,21 +195,35 @@ chimera_nfs4_lookup_at(
     argarray[1].opputfh.object.data = fh;
     argarray[1].opputfh.object.len  = fhlen;
 
-    /* Op 2: LOOKUP - lookup the component name */
-    argarray[2].argop                 = OP_LOOKUP;
-    argarray[2].oplookup.objname.data = (void *) request->lookup_at.component;
-    argarray[2].oplookup.objname.len  = request->lookup_at.component_len;
+    if (op_type == LOOKUP_OP_DOT) {
+        /* No traversal op: GETFH at 2, GETATTR at 3 */
+        argarray[2].argop = OP_GETFH;
+        getattr_idx       = 3;
+        args.num_argarray = 4;
+    } else {
+        if (op_type == LOOKUP_OP_DOTDOT) {
+            /* Op 2: LOOKUPP - move current FH to parent directory */
+            argarray[2].argop = OP_LOOKUPP;
+        } else {
+            /* Op 2: LOOKUP - lookup the component name */
+            argarray[2].argop                 = OP_LOOKUP;
+            argarray[2].oplookup.objname.data = (void *) request->lookup_at.component;
+            argarray[2].oplookup.objname.len  = request->lookup_at.component_len;
+        }
 
-    /* Op 3: GETFH - get file handle for looked up object */
-    argarray[3].argop = OP_GETFH;
+        /* Op 3: GETFH - get file handle for resolved object */
+        argarray[3].argop = OP_GETFH;
+        getattr_idx       = 4;
+        args.num_argarray = 5;
+    }
 
-    /* Op 4: GETATTR - get attributes for looked up object */
-    argarray[4].argop = OP_GETATTR;
-    attr_request[0]   = (1 << FATTR4_TYPE) | (1 << FATTR4_SIZE) | (1 << FATTR4_FILEID);
-    attr_request[1]   = (1 << (FATTR4_MODE - 32)) | (1 << (FATTR4_NUMLINKS - 32)) |
+    /* GETATTR for the resolved object */
+    argarray[getattr_idx].argop = OP_GETATTR;
+    attr_request[0]             = (1 << FATTR4_TYPE) | (1 << FATTR4_SIZE) | (1 << FATTR4_FILEID);
+    attr_request[1]             = (1 << (FATTR4_MODE - 32)) | (1 << (FATTR4_NUMLINKS - 32)) |
         (1 << (FATTR4_TIME_ACCESS - 32)) | (1 << (FATTR4_TIME_MODIFY - 32));
-    argarray[4].opgetattr.attr_request     = attr_request;
-    argarray[4].opgetattr.num_attr_request = 2;
+    argarray[getattr_idx].opgetattr.attr_request     = attr_request;
+    argarray[getattr_idx].opgetattr.num_attr_request = 2;
 
     chimera_nfs_init_rpc2_cred(&rpc2_cred, request->cred,
                                request->thread->vfs->machine_name,

--- a/src/vfs/nfs/nfs4_mkdir_at.c
+++ b/src/vfs/nfs/nfs4_mkdir_at.c
@@ -4,6 +4,96 @@
 
 #include "nfs_internal.h"
 
+struct chimera_nfs4_mkdir_ctx {
+    struct chimera_nfs_thread        *thread;
+    struct chimera_nfs_client_server *server;
+};
+
+static void
+chimera_nfs4_mkdir_callback(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    struct COMPOUND4res         *res,
+    int                          status,
+    void                        *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct chimera_nfs4_mkdir_ctx *ctx     = request->plugin_data;
+    struct nfs_resop4             *create_res;
+    struct nfs_resop4             *getfh_res;
+    struct nfs_resop4             *getattr_res;
+    xdr_opaque                    *remote_fh;
+
+    if (unlikely(status)) {
+        request->status = CHIMERA_VFS_EFAULT;
+        request->complete(request);
+        return;
+    }
+
+    if (res->status != NFS4_OK) {
+        request->status = chimera_nfs4_status_to_errno(res->status);
+        request->complete(request);
+        return;
+    }
+
+    /* Check SEQUENCE result */
+    if (res->num_resarray < 1 || res->resarray[0].opsequence.sr_status != NFS4_OK) {
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+
+    /* Check PUTFH result */
+    if (res->num_resarray < 2 || res->resarray[1].opputfh.status != NFS4_OK) {
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+
+    /* Check CREATE result */
+    if (res->num_resarray < 3) {
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+    create_res = &res->resarray[2];
+    if (create_res->opcreate.status != NFS4_OK) {
+        request->status = chimera_nfs4_status_to_errno(create_res->opcreate.status);
+        request->complete(request);
+        return;
+    }
+
+    /* Check GETFH result */
+    if (res->num_resarray < 4) {
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+    getfh_res = &res->resarray[3];
+    if (getfh_res->opgetfh.status != NFS4_OK) {
+        request->status = chimera_nfs4_status_to_errno(getfh_res->opgetfh.status);
+        request->complete(request);
+        return;
+    }
+
+    remote_fh = &getfh_res->opgetfh.resok4.object;
+
+    /* Build local file handle from server index + remote FH */
+    chimera_nfs4_unmarshall_fh(remote_fh, ctx->server->index, request->fh, &request->mkdir_at.r_attr);
+
+    /* Get GETATTR result */
+    if (res->num_resarray >= 5) {
+        getattr_res = &res->resarray[4];
+        if (getattr_res->opgetattr.status == NFS4_OK) {
+            chimera_nfs4_unmarshall_fattr(&getattr_res->opgetattr.resok4.obj_attributes,
+                                          &request->mkdir_at.r_attr);
+        }
+    }
+
+    request->status = CHIMERA_VFS_OK;
+    request->complete(request);
+} /* chimera_nfs4_mkdir_callback */
+
 void
 chimera_nfs4_mkdir_at(
     struct chimera_nfs_thread  *thread,
@@ -11,7 +101,92 @@ chimera_nfs4_mkdir_at(
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
-    request->status = CHIMERA_VFS_ENOTSUP;
-    request->complete(request);
-} /* chimera_nfs4_mkdir_at */
+    struct chimera_nfs_client_server_thread *server_thread = chimera_nfs_thread_get_server_thread(thread, request->fh,
+                                                                                                  request->fh_len);
+    struct chimera_nfs_client_server        *server;
+    struct chimera_nfs4_client_session      *session;
+    struct chimera_nfs4_mkdir_ctx           *ctx;
+    struct COMPOUND4args                     args;
+    struct nfs_argop4                        argarray[5];
+    uint32_t                                 attr_request[2];
+    struct evpl_rpc2_cred                    rpc2_cred;
+    uint8_t                                 *fh;
+    int                                      fhlen;
 
+    ctx = request->plugin_data;
+
+    if (!server_thread) {
+        request->status = CHIMERA_VFS_ESTALE;
+        request->complete(request);
+        return;
+    }
+
+    server  = server_thread->server;
+    session = server->nfs4_session;
+
+    if (!session) {
+        request->status = CHIMERA_VFS_ESTALE;
+        request->complete(request);
+        return;
+    }
+
+    ctx->thread = thread;
+    ctx->server = server;
+
+    chimera_nfs4_map_fh(request->fh, request->fh_len, &fh, &fhlen);
+
+    /* Build compound: SEQUENCE + PUTFH + CREATE + GETFH + GETATTR */
+    memset(&args, 0, sizeof(args));
+    args.tag.len      = 0;
+    args.minorversion = 1;
+    args.argarray     = argarray;
+    args.num_argarray = 5;
+
+    /* Op 0: SEQUENCE */
+    argarray[0].argop = OP_SEQUENCE;
+    memcpy(argarray[0].opsequence.sa_sessionid, session->sessionid, NFS4_SESSIONID_SIZE);
+    argarray[0].opsequence.sa_sequenceid     = chimera_nfs4_get_sequenceid(session, server_thread->slot_id);
+    argarray[0].opsequence.sa_slotid         = server_thread->slot_id;
+    argarray[0].opsequence.sa_highest_slotid = session->max_slots - 1;
+    argarray[0].opsequence.sa_cachethis      = 0;
+
+    /* Op 1: PUTFH - set current file handle to parent directory */
+    argarray[1].argop               = OP_PUTFH;
+    argarray[1].opputfh.object.data = fh;
+    argarray[1].opputfh.object.len  = fhlen;
+
+    /* Op 2: CREATE - create the directory */
+    argarray[2].argop                               = OP_CREATE;
+    argarray[2].opcreate.objtype.type               = NF4DIR;
+    argarray[2].opcreate.objname.data               = (uint8_t *) request->mkdir_at.name;
+    argarray[2].opcreate.objname.len                = request->mkdir_at.name_len;
+    argarray[2].opcreate.createattrs.num_attrmask   = 0;
+    argarray[2].opcreate.createattrs.attrmask       = NULL;
+    argarray[2].opcreate.createattrs.attr_vals.len  = 0;
+    argarray[2].opcreate.createattrs.attr_vals.data = NULL;
+
+    /* Op 3: GETFH - get file handle for created directory */
+    argarray[3].argop = OP_GETFH;
+
+    /* Op 4: GETATTR - get attributes for created directory */
+    argarray[4].argop = OP_GETATTR;
+    attr_request[0]   = (1 << FATTR4_TYPE) | (1 << FATTR4_SIZE) | (1 << FATTR4_FILEID);
+    attr_request[1]   = (1 << (FATTR4_MODE - 32)) | (1 << (FATTR4_NUMLINKS - 32)) |
+        (1 << (FATTR4_TIME_ACCESS - 32)) | (1 << (FATTR4_TIME_MODIFY - 32));
+    argarray[4].opgetattr.attr_request     = attr_request;
+    argarray[4].opgetattr.num_attr_request = 2;
+
+    chimera_nfs_init_rpc2_cred(&rpc2_cred, request->cred,
+                               request->thread->vfs->machine_name,
+                               request->thread->vfs->machine_name_len);
+
+    shared->nfs_v4.send_call_NFSPROC4_COMPOUND(
+        &shared->nfs_v4.rpc2,
+        thread->evpl,
+        server_thread->nfs_conn,
+        &rpc2_cred,
+        &args,
+        0, 0, 0,
+        chimera_nfs4_mkdir_callback,
+        request);
+} /* chimera_nfs4_mkdir_at */

--- a/src/vfs/nfs/nfs4_mount.c
+++ b/src/vfs/nfs/nfs4_mount.c
@@ -1,8 +1,583 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <utlist.h>
+#include <pthread.h>
+#include <time.h>
+
 #include "nfs_internal.h"
+#include "evpl/evpl_rpc2.h"
+#include "vfs/vfs_internal.h"
+#include "vfs/vfs_fh.h"
+
+#define CHIMERA_NFS4_DEFAULT_PORT 2049
+#define CHIMERA_NFS4_RDMA_PORT    20049
+
+struct chimera_nfs4_mount_ctx {
+    struct chimera_nfs_client_server_thread *server_thread;
+    struct chimera_nfs_client_mount         *mount;
+};
+
+/* Forward declarations */
+static void chimera_nfs4_mount_exchange_id(
+    struct chimera_nfs_client_server_thread *server_thread,
+    struct chimera_vfs_request              *request);
+
+static void chimera_nfs4_mount_create_session(
+    struct chimera_nfs_client_server_thread *server_thread,
+    struct chimera_vfs_request              *request);
+
+static void chimera_nfs4_mount_get_root_fh(
+    struct chimera_nfs_client_server_thread *server_thread,
+    struct chimera_vfs_request              *request);
+
+/* Get the RDMA protocol from mount options */
+static enum evpl_protocol_id
+chimera_nfs4_mount_get_rdma_protocol(const struct chimera_vfs_mount_options *options)
+{
+    int i;
+
+    for (i = 0; i < options->num_options; i++) {
+        if (strcmp(options->options[i].key, "rdma") == 0) {
+            if (options->options[i].value &&
+                strcmp(options->options[i].value, "tcp") == 0) {
+                return EVPL_DATAGRAM_TCP_RDMA;
+            }
+            return EVPL_DATAGRAM_RDMACM_RC;
+        }
+    }
+
+    return 0;
+} /* chimera_nfs4_mount_get_rdma_protocol */
+
+/* Get the port from mount options */
+static int
+chimera_nfs4_mount_get_port(
+    const struct chimera_vfs_mount_options *options,
+    int                                     default_port)
+{
+    int i;
+
+    for (i = 0; i < options->num_options; i++) {
+        if (strcmp(options->options[i].key, "port") == 0) {
+            if (options->options[i].value) {
+                return atoi(options->options[i].value);
+            }
+        }
+    }
+
+    return default_port;
+} /* chimera_nfs4_mount_get_port */
+
+/*
+ * Callback for SEQUENCE + PUTROOTFH + GETFH + GETATTR compound
+ * This is the final step of mount - we have the root file handle
+ */
+static void
+chimera_nfs4_mount_get_root_fh_callback(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    struct COMPOUND4res         *res,
+    int                          status,
+    void                        *private_data)
+{
+    struct chimera_vfs_request      *request = private_data;
+    struct chimera_nfs4_mount_ctx   *ctx     = request->plugin_data;
+    struct chimera_nfs_client_mount *mount   = ctx->mount;
+    struct chimera_nfs_shared       *shared  = mount->server->shared;
+    struct nfs_resop4               *getfh_res;
+    xdr_opaque                      *remote_fh;
+    uint8_t                          fh_fragment[CHIMERA_VFS_FH_SIZE];
+    uint8_t                          fsid_buf[CHIMERA_VFS_FSID_SIZE];
+    uint8_t                          hash_input[256 + NFS4_FHSIZE];
+    int                              hash_input_len;
+    int                              fh_fragment_len;
+    int                              hostname_len;
+    XXH128_hash_t                    fsid_hash;
+
+    if (status != 0) {
+        chimera_nfsclient_error("NFS4 mount get_root_fh RPC failed: %d", status);
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+
+    if (res->status != NFS4_OK) {
+        chimera_nfsclient_error("NFS4 mount get_root_fh compound failed: %d", res->status);
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+
+    /* Check individual operation results */
+    /* res->resarray[0] = SEQUENCE */
+    /* res->resarray[1] = PUTROOTFH */
+    /* res->resarray[2] = LOOKUP */
+    /* res->resarray[3] = GETFH */
+    /* res->resarray[4] = GETATTR */
+
+    if (res->num_resarray < 5) {
+        chimera_nfsclient_error("NFS4 mount get_root_fh: incomplete response");
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+
+    if (res->resarray[0].opsequence.sr_status != NFS4_OK) {
+        chimera_nfsclient_error("NFS4 SEQUENCE failed: %d", res->resarray[0].opsequence.sr_status);
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+
+    if (res->resarray[1].opputrootfh.status != NFS4_OK) {
+        chimera_nfsclient_error("NFS4 PUTROOTFH failed: %d", res->resarray[1].opputrootfh.status);
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+
+    if (res->resarray[2].oplookup.status != NFS4_OK) {
+        chimera_nfsclient_error("NFS4 LOOKUP failed: %d", res->resarray[2].oplookup.status);
+        request->status = chimera_nfs4_status_to_errno(res->resarray[2].oplookup.status);
+        request->complete(request);
+        return;
+    }
+
+    getfh_res = &res->resarray[3];
+    if (getfh_res->opgetfh.status != NFS4_OK) {
+        chimera_nfsclient_error("NFS4 GETFH failed: %d", getfh_res->opgetfh.status);
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+
+    remote_fh = &getfh_res->opgetfh.resok4.object;
+
+    /*
+     * Build the local file handle:
+     * - fh_fragment = [server_index (1 byte)][remote_root_fh]
+     * - FSID = XXH3_128bits(server_hostname || remote_root_fh)
+     */
+    fh_fragment[0] = mount->server->index;
+    memcpy(fh_fragment + 1, remote_fh->data, remote_fh->len);
+    fh_fragment_len = 1 + remote_fh->len;
+
+    /* Compute FSID by hashing server hostname + remote root FH */
+    hostname_len = strlen(mount->server->hostname);
+    memcpy(hash_input, mount->server->hostname, hostname_len);
+    memcpy(hash_input + hostname_len, remote_fh->data, remote_fh->len);
+    hash_input_len = hostname_len + remote_fh->len;
+
+    fsid_hash = XXH3_128bits(hash_input, hash_input_len);
+    memcpy(fsid_buf, &fsid_hash, CHIMERA_VFS_FSID_SIZE);
+
+    request->mount.r_attr.va_set_mask = CHIMERA_VFS_ATTR_FH;
+    request->mount.r_attr.va_fh_len   = chimera_vfs_encode_fh_mount(
+        fsid_buf, fh_fragment, fh_fragment_len, request->mount.r_attr.va_fh);
+
+    request->mount.r_mount_private = mount;
+
+    mount->status = CHIMERA_NFS_CLIENT_MOUNT_STATE_MOUNTED;
+    pthread_mutex_unlock(&shared->lock);
+
+    chimera_nfsclient_info("NFS4 mount complete: %s", mount->path);
+
+    request->status = CHIMERA_VFS_OK;
+    request->complete(request);
+} /* chimera_nfs4_mount_get_root_fh_callback */
+
+/*
+ * Send SEQUENCE + PUTROOTFH + GETFH + GETATTR compound to get root FH
+ */
+static void
+chimera_nfs4_mount_get_root_fh(
+    struct chimera_nfs_client_server_thread *server_thread,
+    struct chimera_vfs_request              *request)
+{
+    struct chimera_nfs_shared          *shared  = server_thread->shared;
+    struct chimera_nfs_client_server   *server  = server_thread->server;
+    struct chimera_nfs4_client_session *session = server->nfs4_session;
+    struct chimera_nfs4_mount_ctx      *ctx     = request->plugin_data;
+    struct chimera_nfs_client_mount    *mount   = ctx->mount;
+    struct COMPOUND4args                args;
+    struct nfs_argop4                   argarray[5];
+    uint32_t                            attr_request[2];
+    const char                         *path;
+    int                                 pathlen;
+
+    /* Skip leading '/' in mount path to get the share name */
+    path = mount->path;
+    if (path[0] == '/') {
+        path++;
+    }
+    pathlen = strlen(path);
+
+    memset(&args, 0, sizeof(args));
+    args.tag.len      = 0;
+    args.minorversion = 1;
+    args.argarray     = argarray;
+    args.num_argarray = 5;
+
+    /* Op 0: SEQUENCE */
+    argarray[0].argop = OP_SEQUENCE;
+    memcpy(argarray[0].opsequence.sa_sessionid, session->sessionid, NFS4_SESSIONID_SIZE);
+    argarray[0].opsequence.sa_sequenceid     = chimera_nfs4_get_sequenceid(session, 0);
+    argarray[0].opsequence.sa_slotid         = 0;  /* Use slot 0 for mount operation */
+    argarray[0].opsequence.sa_highest_slotid = session->max_slots - 1;
+    argarray[0].opsequence.sa_cachethis      = 0;
+
+    /* Op 1: PUTROOTFH */
+    argarray[1].argop = OP_PUTROOTFH;
+
+    /* Op 2: LOOKUP - lookup the export/share name */
+    argarray[2].argop                 = OP_LOOKUP;
+    argarray[2].oplookup.objname.data = (uint8_t *) path;
+    argarray[2].oplookup.objname.len  = pathlen;
+
+    /* Op 3: GETFH */
+    argarray[3].argop = OP_GETFH;
+
+    /* Op 4: GETATTR - request basic attributes */
+    argarray[4].argop                      = OP_GETATTR;
+    attr_request[0]                        = (1 << FATTR4_TYPE) | (1 << FATTR4_SIZE) | (1 << FATTR4_FILEID);
+    attr_request[1]                        = (1 << (FATTR4_MODE - 32)) | (1 << (FATTR4_NUMLINKS - 32));
+    argarray[4].opgetattr.attr_request     = attr_request;
+    argarray[4].opgetattr.num_attr_request = 2;
+
+    shared->nfs_v4.send_call_NFSPROC4_COMPOUND(
+        &shared->nfs_v4.rpc2,
+        server_thread->thread->evpl,
+        server_thread->nfs_conn,
+        NULL,
+        &args,
+        0, 0, 0,
+        chimera_nfs4_mount_get_root_fh_callback,
+        request);
+} /* chimera_nfs4_mount_get_root_fh */
+
+/*
+ * Callback for CREATE_SESSION compound
+ */
+static void
+chimera_nfs4_mount_create_session_callback(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    struct COMPOUND4res         *res,
+    int                          status,
+    void                        *private_data)
+{
+    struct chimera_vfs_request              *request       = private_data;
+    struct chimera_nfs4_mount_ctx           *ctx           = request->plugin_data;
+    struct chimera_nfs_client_server_thread *server_thread = ctx->server_thread;
+    struct chimera_nfs_client_server        *server        = server_thread->server;
+    struct chimera_nfs4_client_session      *session;
+    struct CREATE_SESSION4resok             *cs_res;
+    uint32_t                                 i;
+
+    if (status != 0) {
+        chimera_nfsclient_error("NFS4 CREATE_SESSION RPC failed: %d", status);
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+
+    if (res->status != NFS4_OK) {
+        chimera_nfsclient_error("NFS4 CREATE_SESSION compound failed: %d", res->status);
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+
+    if (res->num_resarray < 1 ||
+        res->resarray[0].opcreate_session.csr_status != NFS4_OK) {
+        chimera_nfsclient_error("NFS4 CREATE_SESSION op failed: %d",
+                                res->resarray[0].opcreate_session.csr_status);
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+
+    cs_res = &res->resarray[0].opcreate_session.csr_resok4;
+
+    /* Store session information */
+    session = server->nfs4_session;
+    memcpy(session->sessionid, cs_res->csr_sessionid, NFS4_SESSIONID_SIZE);
+
+    /* Use the server's fore channel max requests as the number of slots */
+    session->max_slots    = cs_res->csr_fore_chan_attrs.ca_maxrequests;
+    session->next_slot_id = 1;  /* Start at 1, slot 0 is used by mount thread */
+
+    /* Allocate per-slot sequence IDs */
+    session->slot_seqids = calloc(session->max_slots, sizeof(uint32_t));
+    for (i = 0; i < session->max_slots; i++) {
+        session->slot_seqids[i] = 1; /* Start at 1 per RFC 5661 */
+    }
+
+    chimera_nfsclient_info("NFS4 CREATE_SESSION successful, clientid=%lu, max_slots=%u",
+                           (unsigned long) session->clientid, session->max_slots);
+
+    /* Now get the root file handle */
+    chimera_nfs4_mount_get_root_fh(server_thread, request);
+} /* chimera_nfs4_mount_create_session_callback */
+
+/*
+ * Send CREATE_SESSION compound
+ */
+static void
+chimera_nfs4_mount_create_session(
+    struct chimera_nfs_client_server_thread *server_thread,
+    struct chimera_vfs_request              *request)
+{
+    struct chimera_nfs_shared          *shared  = server_thread->shared;
+    struct chimera_nfs_client_server   *server  = server_thread->server;
+    struct chimera_nfs4_client_session *session = server->nfs4_session;
+    struct COMPOUND4args                args;
+    struct nfs_argop4                   argarray[1];
+    struct CREATE_SESSION4args         *cs_args;
+
+    memset(&args, 0, sizeof(args));
+    args.tag.len      = 0;
+    args.minorversion = 1;
+    args.argarray     = argarray;
+    args.num_argarray = 1;
+
+    /* CREATE_SESSION */
+    argarray[0].argop = OP_CREATE_SESSION;
+    cs_args           = &argarray[0].opcreate_session;
+
+    cs_args->csa_clientid = session->clientid;
+    cs_args->csa_sequence = 1;
+    cs_args->csa_flags    = 0;
+
+    /* Fore channel attributes */
+    cs_args->csa_fore_chan_attrs.ca_headerpadsize          = 0;
+    cs_args->csa_fore_chan_attrs.ca_maxrequestsize         = 1024 * 1024;
+    cs_args->csa_fore_chan_attrs.ca_maxresponsesize        = 1024 * 1024;
+    cs_args->csa_fore_chan_attrs.ca_maxresponsesize_cached = 0;
+    cs_args->csa_fore_chan_attrs.ca_maxoperations          = 64;
+    cs_args->csa_fore_chan_attrs.ca_maxrequests            = 64;
+    cs_args->csa_fore_chan_attrs.ca_rdma_ird               = NULL;
+    cs_args->csa_fore_chan_attrs.num_ca_rdma_ird           = 0;
+
+    /* Back channel attributes (minimal, we don't use callbacks) */
+    cs_args->csa_back_chan_attrs.ca_headerpadsize          = 0;
+    cs_args->csa_back_chan_attrs.ca_maxrequestsize         = 4096;
+    cs_args->csa_back_chan_attrs.ca_maxresponsesize        = 4096;
+    cs_args->csa_back_chan_attrs.ca_maxresponsesize_cached = 0;
+    cs_args->csa_back_chan_attrs.ca_maxoperations          = 2;
+    cs_args->csa_back_chan_attrs.ca_maxrequests            = 1;
+    cs_args->csa_back_chan_attrs.ca_rdma_ird               = NULL;
+    cs_args->csa_back_chan_attrs.num_ca_rdma_ird           = 0;
+
+    cs_args->csa_cb_program    = 0;
+    cs_args->csa_sec_parms     = NULL;
+    cs_args->num_csa_sec_parms = 0;
+
+    shared->nfs_v4.send_call_NFSPROC4_COMPOUND(
+        &shared->nfs_v4.rpc2,
+        server_thread->thread->evpl,
+        server_thread->nfs_conn,
+        NULL,
+        &args,
+        0, 0, 0,
+        chimera_nfs4_mount_create_session_callback,
+        request);
+} /* chimera_nfs4_mount_create_session */
+
+/*
+ * Callback for EXCHANGE_ID compound
+ */
+static void
+chimera_nfs4_mount_exchange_id_callback(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    struct COMPOUND4res         *res,
+    int                          status,
+    void                        *private_data)
+{
+    struct chimera_vfs_request              *request       = private_data;
+    struct chimera_nfs4_mount_ctx           *ctx           = request->plugin_data;
+    struct chimera_nfs_client_server_thread *server_thread = ctx->server_thread;
+    struct chimera_nfs_client_server        *server        = server_thread->server;
+    struct chimera_nfs4_client_session      *session;
+    struct EXCHANGE_ID4resok                *eid_res;
+
+    if (status != 0) {
+        chimera_nfsclient_error("NFS4 EXCHANGE_ID RPC failed: %d", status);
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+
+    if (res->status != NFS4_OK) {
+        chimera_nfsclient_error("NFS4 EXCHANGE_ID compound failed: %d", res->status);
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+
+    if (res->num_resarray < 1 ||
+        res->resarray[0].opexchange_id.eir_status != NFS4_OK) {
+        chimera_nfsclient_error("NFS4 EXCHANGE_ID op failed: %d",
+                                res->resarray[0].opexchange_id.eir_status);
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+
+    eid_res = &res->resarray[0].opexchange_id.eir_resok4;
+
+    /* Allocate and initialize session */
+    session              = calloc(1, sizeof(*session));
+    session->clientid    = eid_res->eir_clientid;
+    server->nfs4_session = session;
+
+    chimera_nfsclient_info("NFS4 EXCHANGE_ID successful, clientid=%lu",
+                           (unsigned long) session->clientid);
+
+    /* Next step: CREATE_SESSION */
+    chimera_nfs4_mount_create_session(server_thread, request);
+} /* chimera_nfs4_mount_exchange_id_callback */
+
+/*
+ * Send EXCHANGE_ID compound to register with the server
+ */
+static void
+chimera_nfs4_mount_exchange_id(
+    struct chimera_nfs_client_server_thread *server_thread,
+    struct chimera_vfs_request              *request)
+{
+    struct chimera_nfs_shared        *shared = server_thread->shared;
+    struct chimera_nfs_client_server *server = server_thread->server;
+    struct COMPOUND4args              args;
+    struct nfs_argop4                 argarray[1];
+    struct EXCHANGE_ID4args          *eid_args;
+    struct timespec                   now;
+
+    memset(&args, 0, sizeof(args));
+    args.tag.len      = 0;
+    args.minorversion = 1;
+    args.argarray     = argarray;
+    args.num_argarray = 1;
+
+    /* EXCHANGE_ID */
+    argarray[0].argop = OP_EXCHANGE_ID;
+    eid_args          = &argarray[0].opexchange_id;
+
+    /* Generate client owner ID based on hostname and time */
+    clock_gettime(CLOCK_REALTIME, &now);
+    memcpy(server->nfs4_verifier, &now.tv_sec, sizeof(now.tv_sec));
+
+    /* Client owner: use verifier and a unique owner ID string */
+    memcpy(eid_args->eia_clientowner.co_verifier, server->nfs4_verifier, NFS4_VERIFIER_SIZE);
+
+    /* Owner ID: hostname + pid for uniqueness - stored in server struct for lifetime */
+    server->nfs4_owner_id_len = snprintf(server->nfs4_owner_id, sizeof(server->nfs4_owner_id),
+                                         "chimera-%s-%d", server->hostname, getpid());
+    eid_args->eia_clientowner.co_ownerid.data = (uint8_t *) server->nfs4_owner_id;
+    eid_args->eia_clientowner.co_ownerid.len  = server->nfs4_owner_id_len;
+
+    eid_args->eia_flags                 = EXCHGID4_FLAG_USE_NON_PNFS;
+    eid_args->eia_state_protect.spa_how = SP4_NONE;
+    eid_args->eia_client_impl_id        = NULL;
+    eid_args->num_eia_client_impl_id    = 0;
+
+    shared->nfs_v4.send_call_NFSPROC4_COMPOUND(
+        &shared->nfs_v4.rpc2,
+        server_thread->thread->evpl,
+        server_thread->nfs_conn,
+        NULL,
+        &args,
+        0, 0, 0,
+        chimera_nfs4_mount_exchange_id_callback,
+        request);
+} /* chimera_nfs4_mount_exchange_id */
+
+/*
+ * Process mount after server connection is established
+ */
+static void
+chimera_nfs4_mount_process_mount(
+    struct chimera_nfs_client_server_thread *server_thread,
+    struct chimera_vfs_request              *request)
+{
+    struct chimera_nfs_client_server *server = server_thread->server;
+    struct chimera_nfs_shared        *shared = server_thread->shared;
+    struct chimera_nfs_client_mount  *mount;
+    struct chimera_nfs4_mount_ctx    *ctx;
+    int                               i;
+    const char                       *path = NULL;
+
+    /* Parse path from "hostname:path" format */
+    for (i = 0; i < request->mount.pathlen; i++) {
+        if (request->mount.path[i] == ':') {
+            path = request->mount.path + i + 1;
+            break;
+        }
+    }
+
+    if (!path) {
+        chimera_nfsclient_error("NFS4 mount failed: invalid path %s", request->mount.path);
+        request->status = CHIMERA_VFS_EINVAL;
+        request->complete(request);
+        return;
+    }
+
+    mount = calloc(1, sizeof(*mount));
+
+    mount->server        = server;
+    mount->nfsvers       = 4;
+    mount->status        = CHIMERA_NFS_CLIENT_MOUNT_STATE_MOUNTING;
+    mount->mount_request = request;
+
+    memcpy(mount->path, path, strlen(path) + 1);
+
+    pthread_mutex_lock(&shared->lock);
+    DL_APPEND(shared->mounts, mount);
+
+    /* Store mount context in request */
+    ctx                = request->plugin_data;
+    ctx->server_thread = server_thread;
+    ctx->mount         = mount;
+
+    /* Start the NFS4 session establishment */
+    chimera_nfs4_mount_exchange_id(server_thread, request);
+} /* chimera_nfs4_mount_process_mount */
+
+/*
+ * Callback after NFS4 NULL call (connection test)
+ */
+static void
+chimera_nfs4_mount_null_callback(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    int                          status,
+    void                        *private_data)
+{
+    struct chimera_vfs_request              *request       = private_data;
+    struct chimera_nfs4_mount_ctx           *ctx           = request->plugin_data;
+    struct chimera_nfs_client_server_thread *server_thread = ctx->server_thread;
+    struct chimera_nfs_client_server        *server        = server_thread->server;
+    struct chimera_nfs_shared               *shared        = server_thread->shared;
+
+    if (status != 0) {
+        chimera_nfsclient_error("NFS4 NULL call failed: %d", status);
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+
+    pthread_mutex_lock(&shared->lock);
+    server->state = CHIMERA_NFS_CLIENT_SERVER_STATE_DISCOVERED;
+    pthread_mutex_unlock(&shared->lock);
+
+    chimera_nfs4_mount_process_mount(server_thread, request);
+} /* chimera_nfs4_mount_null_callback */
 
 void
 chimera_nfs4_mount(
@@ -11,7 +586,154 @@ chimera_nfs4_mount(
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
-    request->status = CHIMERA_VFS_ENOTSUP;
-    request->complete(request);
-} /* chimera_nfs4_mount */
+    const char                              *path     = request->mount.path;
+    const char                              *hostname = NULL;
+    struct chimera_nfs_client_server       **new_servers, *server = NULL;
+    struct chimera_nfs_client_server_thread *server_thread;
+    struct chimera_nfs4_mount_ctx           *ctx;
+    int                                      hostnamelen = 0;
+    int                                      i, idx = -1;
+    int                                      need_discover = 0;
+    int                                      port;
 
+    /* Parse hostname from "hostname:path" */
+    for (i = 0; i < request->mount.pathlen; i++) {
+        if (path[i] == ':') {
+            hostname    = path;
+            hostnamelen = i;
+            break;
+        }
+    }
+
+    if (hostnamelen == 0) {
+        chimera_nfsclient_error("NFS4 mount: invalid path format (expected hostname:path)");
+        request->status = CHIMERA_VFS_EINVAL;
+        request->complete(request);
+        return;
+    }
+
+    pthread_mutex_lock(&shared->lock);
+
+    /* Check if we already have a server connection for this host */
+    for (i = 0; i < shared->max_servers; i++) {
+        if (shared->servers[i] &&
+            strncmp(shared->servers[i]->hostname, hostname, hostnamelen) == 0 &&
+            shared->servers[i]->hostname[hostnamelen] == '\0' &&
+            shared->servers[i]->nfsvers == 4) {
+            server = shared->servers[i];
+            break;
+        }
+    }
+
+    if (server) {
+        server->refcnt++;
+
+        if (server->state == CHIMERA_NFS_CLIENT_SERVER_STATE_DISCOVERING) {
+            /* Someone else is discovering this server, wait for them */
+            DL_APPEND(server->pending_mounts, request);
+            pthread_mutex_unlock(&shared->lock);
+            return;
+        }
+    } else {
+        /* Find a free slot for the new server */
+        for (i = 0; i < shared->max_servers; i++) {
+            if (shared->servers[i] == NULL) {
+                idx = i;
+                break;
+            }
+        }
+
+        if (idx < 0 || idx >= shared->max_servers) {
+            /* Expand server array */
+            shared->max_servers *= 2;
+            new_servers          = calloc(shared->max_servers, sizeof(*new_servers));
+            memcpy(new_servers, shared->servers, (shared->max_servers / 2) * sizeof(*new_servers));
+            free(shared->servers);
+            shared->servers = new_servers;
+            idx             = i;
+        }
+
+        server          = calloc(1, sizeof(*server));
+        server->state   = CHIMERA_NFS_CLIENT_SERVER_STATE_DISCOVERING;
+        server->refcnt  = 1;
+        server->nfsvers = 4;
+        server->shared  = shared;
+
+        /* Parse RDMA options */
+        server->rdma_protocol = chimera_nfs4_mount_get_rdma_protocol(&request->mount.options);
+        server->use_rdma      = server->rdma_protocol != 0;
+
+        /* Get port (default 2049 for TCP, 20049 for RDMA) */
+        port = chimera_nfs4_mount_get_port(&request->mount.options,
+                                           server->use_rdma ? CHIMERA_NFS4_RDMA_PORT : CHIMERA_NFS4_DEFAULT_PORT);
+        server->nfs_port = port;
+
+        strncpy(server->hostname, hostname, hostnamelen);
+        server->hostname[hostnamelen] = '\0';
+
+        shared->servers[idx] = server;
+        server->index        = idx;
+
+        need_discover = 1;
+
+        DL_APPEND(server->pending_mounts, request);
+    }
+
+    pthread_mutex_unlock(&shared->lock);
+
+    /* Create server thread context */
+    server_thread         = calloc(1, sizeof(*server_thread));
+    server_thread->thread = thread;
+    server_thread->shared = shared;
+    server_thread->server = server;
+
+    /* Store context in request plugin_data */
+    ctx                = request->plugin_data;
+    ctx->server_thread = server_thread;
+
+    if (thread->max_server_threads != shared->max_servers) {
+        thread->max_server_threads = shared->max_servers;
+        thread->server_threads     = realloc(thread->server_threads,
+                                             thread->max_server_threads * sizeof(*thread->server_threads));
+    }
+
+    thread->server_threads[server->index] = server_thread;
+
+    if (need_discover) {
+        enum evpl_protocol_id proto;
+
+        /* Create NFS endpoint and connect */
+        server->nfs_endpoint = evpl_endpoint_create(server->hostname, server->nfs_port);
+
+        proto = server->use_rdma ? server->rdma_protocol : EVPL_STREAM_SOCKET_TCP;
+
+        server_thread->nfs_conn = evpl_rpc2_client_connect(
+            thread->rpc2_thread,
+            proto,
+            server->nfs_endpoint,
+            NULL, 0, NULL);
+
+        if (!server_thread->nfs_conn) {
+            chimera_nfsclient_error("NFS4 mount: failed to connect to %s:%d",
+                                    server->hostname, server->nfs_port);
+            request->status = CHIMERA_VFS_EIO;
+            request->complete(request);
+            return;
+        }
+
+        chimera_nfsclient_info("NFS4 connecting to %s:%d", server->hostname, server->nfs_port);
+
+        /* Send NULL call to verify connection */
+        shared->nfs_v4.send_call_NFSPROC4_NULL(
+            &shared->nfs_v4.rpc2,
+            thread->evpl,
+            server_thread->nfs_conn,
+            NULL,
+            0, 0, 0,
+            chimera_nfs4_mount_null_callback,
+            request);
+    } else {
+        /* Server already discovered, proceed with mount */
+        chimera_nfs4_mount_process_mount(server_thread, request);
+    }
+} /* chimera_nfs4_mount */

--- a/src/vfs/nfs/nfs4_open_at.c
+++ b/src/vfs/nfs/nfs4_open_at.c
@@ -105,7 +105,8 @@ chimera_nfs4_open_at_callback(
         }
 
         /* Store the stateid from OPEN response */
-        state->stateid = open_res->opopen.resok4.stateid;
+        state->server_index = ctx->server->index;
+        state->stateid      = open_res->opopen.resok4.stateid;
 
         request->open_at.r_vfs_private = (uint64_t) state;
     } else {

--- a/src/vfs/nfs/nfs4_open_at.c
+++ b/src/vfs/nfs/nfs4_open_at.c
@@ -1,8 +1,120 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
 #include "nfs_internal.h"
+#include "nfs4_open_state.h"
+#include "vfs/vfs_error.h"
+
+struct chimera_nfs4_open_at_ctx {
+    struct chimera_nfs_thread        *thread;
+    struct chimera_nfs_client_server *server;
+};
+
+static void
+chimera_nfs4_open_at_callback(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    struct COMPOUND4res         *res,
+    int                          status,
+    void                        *private_data)
+{
+    struct chimera_vfs_request      *request = private_data;
+    struct chimera_nfs4_open_at_ctx *ctx     = request->plugin_data;
+    struct nfs_resop4               *open_res;
+    struct nfs_resop4               *getfh_res;
+    struct nfs_resop4               *getattr_res;
+    xdr_opaque                      *remote_fh;
+    struct chimera_nfs4_open_state  *state;
+
+    if (unlikely(status)) {
+        request->status = CHIMERA_VFS_EFAULT;
+        request->complete(request);
+        return;
+    }
+
+    if (res->status != NFS4_OK) {
+        request->status = chimera_nfs4_status_to_errno(res->status);
+        request->complete(request);
+        return;
+    }
+
+    /* Check SEQUENCE result */
+    if (res->num_resarray < 1 || res->resarray[0].opsequence.sr_status != NFS4_OK) {
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+
+    /* Check PUTFH result */
+    if (res->num_resarray < 2 || res->resarray[1].opputfh.status != NFS4_OK) {
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+
+    /* Check OPEN result */
+    if (res->num_resarray < 3) {
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+    open_res = &res->resarray[2];
+    if (open_res->opopen.status != NFS4_OK) {
+        request->status = chimera_nfs4_status_to_errno(open_res->opopen.status);
+        request->complete(request);
+        return;
+    }
+
+    /* Check GETFH result */
+    if (res->num_resarray < 4) {
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+    getfh_res = &res->resarray[3];
+    if (getfh_res->opgetfh.status != NFS4_OK) {
+        request->status = chimera_nfs4_status_to_errno(getfh_res->opgetfh.status);
+        request->complete(request);
+        return;
+    }
+
+    remote_fh = &getfh_res->opgetfh.resok4.object;
+
+    /* Build local file handle from server index + remote FH */
+    chimera_nfs4_unmarshall_fh(remote_fh, ctx->server->index, request->fh, &request->open_at.r_attr);
+
+    /* Get GETATTR result */
+    if (res->num_resarray >= 5) {
+        getattr_res = &res->resarray[4];
+        if (getattr_res->opgetattr.status == NFS4_OK) {
+            chimera_nfs4_unmarshall_fattr(&getattr_res->opgetattr.resok4.obj_attributes,
+                                          &request->open_at.r_attr);
+        }
+    }
+
+    /* Allocate and store open state with stateid
+     * Skip for inferred opens (use synthetic handles which don't call close). */
+    if (!(request->open_at.flags & CHIMERA_VFS_OPEN_INFERRED)) {
+        state = chimera_nfs4_open_state_alloc();
+
+        if (!state) {
+            request->status = CHIMERA_VFS_EFAULT;
+            request->complete(request);
+            return;
+        }
+
+        /* Store the stateid from OPEN response */
+        state->stateid = open_res->opopen.resok4.stateid;
+
+        request->open_at.r_vfs_private = (uint64_t) state;
+    } else {
+        request->open_at.r_vfs_private = 0;
+    }
+
+    request->status = CHIMERA_VFS_OK;
+    request->complete(request);
+} /* chimera_nfs4_open_at_callback */
 
 void
 chimera_nfs4_open_at(
@@ -11,7 +123,126 @@ chimera_nfs4_open_at(
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
-    request->status = CHIMERA_VFS_ENOTSUP;
-    request->complete(request);
-} /* chimera_nfs4_open_at */
+    struct chimera_nfs_client_server_thread *server_thread = chimera_nfs_thread_get_server_thread(thread, request->fh,
+                                                                                                  request->fh_len);
+    struct chimera_nfs_client_server        *server;
+    struct chimera_nfs4_client_session      *session;
+    struct COMPOUND4args                     args;
+    struct nfs_argop4                        argarray[5];
+    uint32_t                                 attr_request[2];
+    struct evpl_rpc2_cred                    rpc2_cred;
+    uint8_t                                 *fh;
+    int                                      fhlen;
+    struct chimera_nfs4_open_at_ctx         *ctx;
+    struct OPEN4args                        *open_args;
 
+    ctx = request->plugin_data;
+
+    if (!server_thread) {
+        request->status = CHIMERA_VFS_ESTALE;
+        request->complete(request);
+        return;
+    }
+
+    server  = server_thread->server;
+    session = server->nfs4_session;
+
+    if (!session) {
+        request->status = CHIMERA_VFS_ESTALE;
+        request->complete(request);
+        return;
+    }
+
+    ctx->thread = thread;
+    ctx->server = server;
+
+    chimera_nfs4_map_fh(request->fh, request->fh_len, &fh, &fhlen);
+
+    /* Build compound: SEQUENCE + PUTFH + OPEN + GETFH + GETATTR */
+    memset(&args, 0, sizeof(args));
+    args.tag.len      = 0;
+    args.minorversion = 1;
+    args.argarray     = argarray;
+    args.num_argarray = 5;
+
+    /* Op 0: SEQUENCE */
+    argarray[0].argop = OP_SEQUENCE;
+    memcpy(argarray[0].opsequence.sa_sessionid, session->sessionid, NFS4_SESSIONID_SIZE);
+    argarray[0].opsequence.sa_sequenceid     = chimera_nfs4_get_sequenceid(session, server_thread->slot_id);
+    argarray[0].opsequence.sa_slotid         = server_thread->slot_id;
+    argarray[0].opsequence.sa_highest_slotid = session->max_slots - 1;
+    argarray[0].opsequence.sa_cachethis      = 0;
+
+    /* Op 1: PUTFH - set current file handle to parent directory */
+    argarray[1].argop               = OP_PUTFH;
+    argarray[1].opputfh.object.data = fh;
+    argarray[1].opputfh.object.len  = fhlen;
+
+    /* Op 2: OPEN - open/create the file */
+    argarray[2].argop = OP_OPEN;
+    open_args         = &argarray[2].opopen;
+
+    open_args->seqid = 0; /* Sequence ID for open state - 0 for new opens */
+
+    /* Set share access based on flags */
+    if (request->open_at.flags & CHIMERA_VFS_OPEN_READ_ONLY) {
+        open_args->share_access = OPEN4_SHARE_ACCESS_READ;
+    } else {
+        open_args->share_access = OPEN4_SHARE_ACCESS_READ | OPEN4_SHARE_ACCESS_WRITE;
+    }
+    open_args->share_deny = OPEN4_SHARE_DENY_NONE;
+
+    /* Owner identification */
+    open_args->owner.clientid   = session->clientid;
+    open_args->owner.owner.data = (uint8_t *) server->nfs4_owner_id;
+    open_args->owner.owner.len  = server->nfs4_owner_id_len;
+
+    /* Open mode - create or nocreate */
+    if (request->open_at.flags & CHIMERA_VFS_OPEN_CREATE) {
+        open_args->openhow.opentype = OPEN4_CREATE;
+
+        if (request->open_at.flags & CHIMERA_VFS_OPEN_EXCLUSIVE) {
+            open_args->openhow.how.mode = GUARDED4;
+        } else {
+            open_args->openhow.how.mode = UNCHECKED4;
+        }
+
+        /* Set create attributes */
+        open_args->openhow.how.createattrs.num_attrmask   = 0;
+        open_args->openhow.how.createattrs.attrmask       = NULL;
+        open_args->openhow.how.createattrs.attr_vals.len  = 0;
+        open_args->openhow.how.createattrs.attr_vals.data = NULL;
+    } else {
+        open_args->openhow.opentype = OPEN4_NOCREATE;
+    }
+
+    /* Claim - how to identify the file */
+    open_args->claim.claim     = CLAIM_NULL;
+    open_args->claim.file.data = (void *) request->open_at.name;
+    open_args->claim.file.len  = request->open_at.namelen;
+
+    /* Op 3: GETFH - get file handle for opened file */
+    argarray[3].argop = OP_GETFH;
+
+    /* Op 4: GETATTR - get attributes for opened file */
+    argarray[4].argop = OP_GETATTR;
+    attr_request[0]   = (1 << FATTR4_TYPE) | (1 << FATTR4_SIZE) | (1 << FATTR4_FILEID);
+    attr_request[1]   = (1 << (FATTR4_MODE - 32)) | (1 << (FATTR4_NUMLINKS - 32)) |
+        (1 << (FATTR4_TIME_ACCESS - 32)) | (1 << (FATTR4_TIME_MODIFY - 32));
+    argarray[4].opgetattr.attr_request     = attr_request;
+    argarray[4].opgetattr.num_attr_request = 2;
+
+    chimera_nfs_init_rpc2_cred(&rpc2_cred, request->cred,
+                               request->thread->vfs->machine_name,
+                               request->thread->vfs->machine_name_len);
+
+    shared->nfs_v4.send_call_NFSPROC4_COMPOUND(
+        &shared->nfs_v4.rpc2,
+        thread->evpl,
+        server_thread->nfs_conn,
+        &rpc2_cred,
+        &args,
+        0, 0, 0,
+        chimera_nfs4_open_at_callback,
+        request);
+} /* chimera_nfs4_open_at */

--- a/src/vfs/nfs/nfs4_open_fh.c
+++ b/src/vfs/nfs/nfs4_open_fh.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-only
 
 #include "nfs_internal.h"
+#include "nfs4_open_state.h"
 
 void
 chimera_nfs4_open_fh(
@@ -11,7 +12,40 @@ chimera_nfs4_open_fh(
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
-    request->status = CHIMERA_VFS_ENOTSUP;
+    struct chimera_nfs4_open_state *state = NULL;
+
+    /*
+     * For inferred opens (internal opens used for path traversal, like
+     * opening a parent directory before open_at), we don't need to do an
+     * actual NFS4 OPEN operation.  Just allocate minimal state and return OK.
+     *
+     * Similarly, directories don't need NFS4 OPEN - they're accessed via
+     * READDIR, LOOKUP etc.
+     */
+    if ((request->open.flags & CHIMERA_VFS_OPEN_INFERRED) ||
+        (request->open.flags & CHIMERA_VFS_OPEN_DIRECTORY)) {
+        request->open.r_vfs_private = 0;
+        request->status             = CHIMERA_VFS_OK;
+        request->complete(request);
+        return;
+    }
+
+    /*
+     * For regular file opens (not creates - those go through open_at),
+     * we need to allocate state for tracking dirty writes.  A true NFS4 OPEN
+     * by file handle would require CLAIM_FH which is only supported in
+     * NFSv4.1+.  For now, we allocate state and return OK, relying on the
+     * fact that reads/writes will use an anonymous stateid.
+     */
+    state = chimera_nfs4_open_state_alloc();
+
+    if (!state) {
+        request->status = CHIMERA_VFS_EFAULT;
+        request->complete(request);
+        return;
+    }
+
+    request->open.r_vfs_private = (uint64_t) state;
+    request->status             = CHIMERA_VFS_OK;
     request->complete(request);
 } /* chimera_nfs4_open_fh */
-

--- a/src/vfs/nfs/nfs4_open_fh.c
+++ b/src/vfs/nfs/nfs4_open_fh.c
@@ -22,10 +22,10 @@ chimera_nfs4_open_fh(
      * Similarly, directories don't need NFS4 OPEN - they're accessed via
      * READDIR, LOOKUP etc.
      */
-    if ((request->open.flags & CHIMERA_VFS_OPEN_INFERRED) ||
-        (request->open.flags & CHIMERA_VFS_OPEN_DIRECTORY)) {
-        request->open.r_vfs_private = 0;
-        request->status             = CHIMERA_VFS_OK;
+    if ((request->open_fh.flags & CHIMERA_VFS_OPEN_INFERRED) ||
+        (request->open_fh.flags & CHIMERA_VFS_OPEN_DIRECTORY)) {
+        request->open_fh.r_vfs_private = 0;
+        request->status                = CHIMERA_VFS_OK;
         request->complete(request);
         return;
     }
@@ -45,7 +45,8 @@ chimera_nfs4_open_fh(
         return;
     }
 
-    request->open.r_vfs_private = (uint64_t) state;
-    request->status             = CHIMERA_VFS_OK;
+    state->server_index            = request->fh[CHIMERA_VFS_MOUNT_ID_SIZE];
+    request->open_fh.r_vfs_private = (uint64_t) state;
+    request->status                = CHIMERA_VFS_OK;
     request->complete(request);
 } /* chimera_nfs4_open_fh */

--- a/src/vfs/nfs/nfs4_open_state.h
+++ b/src/vfs/nfs/nfs4_open_state.h
@@ -23,6 +23,7 @@
  */
 
 struct chimera_nfs4_open_state {
+    uint8_t                 server_index;  /* NFS server index for dispatch routing */
     struct stateid4         stateid;       /* NFS4 stateid for this open */
     uint32_t                seqid;         /* Sequence ID for state operations */
     uint32_t                access;        /* Share access mode */

--- a/src/vfs/nfs/nfs4_open_state.h
+++ b/src/vfs/nfs/nfs4_open_state.h
@@ -1,0 +1,93 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#pragma once
+
+#include <stdint.h>
+#include <stdatomic.h>
+#include <stdlib.h>
+#include <string.h>
+#include "vfs/vfs.h"
+#include "nfs4_xdr.h"
+
+/*
+ * NFS4 Open State
+ *
+ * This structure tracks per-file state for NFS4 opens:
+ * 1. Stateid - the NFS4.1 stateid returned by OPEN, needed for READ/WRITE/CLOSE
+ * 2. Dirty tracking - to issue COMMIT on close if unstable writes were performed
+ * 3. Silly rename - when removing an open file, rename to .nfs<hex(fh)> instead
+ *
+ * The state is allocated on open, stored in vfs_private, and freed on close.
+ */
+
+struct chimera_nfs4_open_state {
+    struct stateid4         stateid;       /* NFS4 stateid for this open */
+    uint32_t                seqid;         /* Sequence ID for state operations */
+    uint32_t                access;        /* Share access mode */
+    atomic_int              dirty;         /* Count of uncommitted unstable writes */
+    int                     silly_renamed; /* File has been silly renamed */
+    uint8_t                 dir_fh_len;    /* Directory fh for silly remove on close */
+    uint8_t                 dir_fh[CHIMERA_VFS_FH_SIZE];
+
+    /*
+     * Credentials for silly remove on close.
+     */
+    struct chimera_vfs_cred silly_remove_cred;
+};
+
+/*
+ * Allocate and initialize a new open state.
+ */
+static inline struct chimera_nfs4_open_state *
+chimera_nfs4_open_state_alloc(void)
+{
+    struct chimera_nfs4_open_state *state;
+
+    state = calloc(1, sizeof(*state));
+    if (state) {
+        atomic_init(&state->dirty, 0);
+        state->seqid = 1;
+    }
+
+    return state;
+} /* chimera_nfs4_open_state_alloc */
+
+/*
+ * Free an open state.
+ */
+static inline void
+chimera_nfs4_open_state_free(struct chimera_nfs4_open_state *state)
+{
+    free(state);
+} /* chimera_nfs4_open_state_free */
+
+/*
+ * Mark a file as having dirty (unstable) data.
+ */
+static inline void
+chimera_nfs4_open_state_mark_dirty(struct chimera_nfs4_open_state *state)
+{
+    atomic_fetch_add(&state->dirty, 1);
+} /* chimera_nfs4_open_state_mark_dirty */
+
+/*
+ * Clear dirty count after a successful COMMIT.
+ */
+static inline int
+chimera_nfs4_open_state_clear_dirty(
+    struct chimera_nfs4_open_state *state,
+    int                             committed_count)
+{
+    return atomic_fetch_sub(&state->dirty, committed_count) - committed_count;
+} /* chimera_nfs4_open_state_clear_dirty */
+
+/*
+ * Get the current dirty count.
+ */
+static inline int
+chimera_nfs4_open_state_get_dirty(struct chimera_nfs4_open_state *state)
+{
+    return atomic_load(&state->dirty);
+} /* chimera_nfs4_open_state_get_dirty */

--- a/src/vfs/nfs/nfs4_read.c
+++ b/src/vfs/nfs/nfs4_read.c
@@ -1,8 +1,74 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
 #include "nfs_internal.h"
+#include "nfs4_open_state.h"
+
+struct chimera_nfs4_read_ctx {
+    struct chimera_nfs_thread        *thread;
+    struct chimera_nfs_client_server *server;
+};
+
+static void
+chimera_nfs4_read_callback(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    struct COMPOUND4res         *res,
+    int                          status,
+    void                        *private_data)
+{
+    struct chimera_vfs_request *request = private_data;
+    struct nfs_resop4          *read_res;
+
+    if (unlikely(status)) {
+        request->status = CHIMERA_VFS_EFAULT;
+        request->complete(request);
+        return;
+    }
+
+    if (res->status != NFS4_OK) {
+        request->status = chimera_nfs4_status_to_errno(res->status);
+        request->complete(request);
+        return;
+    }
+
+    /* Check SEQUENCE result */
+    if (res->num_resarray < 1 || res->resarray[0].opsequence.sr_status != NFS4_OK) {
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+
+    /* Check PUTFH result */
+    if (res->num_resarray < 2 || res->resarray[1].opputfh.status != NFS4_OK) {
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+
+    /* Check READ result */
+    if (res->num_resarray < 3) {
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+    read_res = &res->resarray[2];
+    if (read_res->opread.status != NFS4_OK) {
+        request->status = chimera_nfs4_status_to_errno(read_res->opread.status);
+        request->complete(request);
+        return;
+    }
+
+    /* Extract read results */
+    request->read.r_eof    = read_res->opread.resok4.eof;
+    request->read.r_length = read_res->opread.resok4.data.length;
+    request->read.r_niov   = read_res->opread.resok4.data.niov;
+    request->read.iov      = read_res->opread.resok4.data.iov;
+
+    request->status = CHIMERA_VFS_OK;
+    request->complete(request);
+} /* chimera_nfs4_read_callback */
 
 void
 chimera_nfs4_read(
@@ -11,7 +77,87 @@ chimera_nfs4_read(
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
-    request->status = CHIMERA_VFS_ENOTSUP;
-    request->complete(request);
-} /* chimera_nfs4_read */
+    struct chimera_nfs_client_server_thread *server_thread = chimera_nfs_thread_get_server_thread(thread, request->fh,
+                                                                                                  request->fh_len);
+    struct chimera_nfs_client_server        *server;
+    struct chimera_nfs4_client_session      *session;
+    struct chimera_nfs4_read_ctx            *ctx;
+    struct chimera_nfs4_open_state          *open_state;
+    struct COMPOUND4args                     args;
+    struct nfs_argop4                        argarray[3];
+    struct evpl_rpc2_cred                    rpc2_cred;
+    uint8_t                                 *fh;
+    int                                      fhlen;
 
+    if (!server_thread) {
+        request->status = CHIMERA_VFS_ESTALE;
+        request->complete(request);
+        return;
+    }
+
+    server  = server_thread->server;
+    session = server->nfs4_session;
+
+    if (!session) {
+        request->status = CHIMERA_VFS_ESTALE;
+        request->complete(request);
+        return;
+    }
+
+    ctx         = request->plugin_data;
+    ctx->thread = thread;
+    ctx->server = server;
+
+    open_state = (struct chimera_nfs4_open_state *) request->read.handle->vfs_private;
+
+    chimera_nfs4_map_fh(request->fh, request->fh_len, &fh, &fhlen);
+
+    /* Build compound: SEQUENCE + PUTFH + READ */
+    memset(&args, 0, sizeof(args));
+    args.tag.len      = 0;
+    args.minorversion = 1;
+    args.argarray     = argarray;
+    args.num_argarray = 3;
+
+    /* Op 0: SEQUENCE */
+    argarray[0].argop = OP_SEQUENCE;
+    memcpy(argarray[0].opsequence.sa_sessionid, session->sessionid, NFS4_SESSIONID_SIZE);
+    argarray[0].opsequence.sa_sequenceid     = chimera_nfs4_get_sequenceid(session, server_thread->slot_id);
+    argarray[0].opsequence.sa_slotid         = server_thread->slot_id;
+    argarray[0].opsequence.sa_highest_slotid = session->max_slots - 1;
+    argarray[0].opsequence.sa_cachethis      = 0;
+
+    /* Op 1: PUTFH */
+    argarray[1].argop               = OP_PUTFH;
+    argarray[1].opputfh.object.data = fh;
+    argarray[1].opputfh.object.len  = fhlen;
+
+    /* Op 2: READ */
+    argarray[2].argop = OP_READ;
+
+    /* Use the stateid from the open state, or anonymous stateid if not available */
+    if (open_state) {
+        argarray[2].opread.stateid = open_state->stateid;
+    } else {
+        /* Anonymous stateid */
+        memset(&argarray[2].opread.stateid, 0, sizeof(argarray[2].opread.stateid));
+        argarray[2].opread.stateid.seqid = 0;
+    }
+
+    argarray[2].opread.offset = request->read.offset;
+    argarray[2].opread.count  = request->read.length;
+
+    chimera_nfs_init_rpc2_cred(&rpc2_cred, request->cred,
+                               request->thread->vfs->machine_name,
+                               request->thread->vfs->machine_name_len);
+
+    shared->nfs_v4.send_call_NFSPROC4_COMPOUND(
+        &shared->nfs_v4.rpc2,
+        thread->evpl,
+        server_thread->nfs_conn,
+        &rpc2_cred,
+        &args,
+        0, request->read.length, 0,
+        chimera_nfs4_read_callback,
+        request);
+} /* chimera_nfs4_read */

--- a/src/vfs/nfs/nfs4_readdir.c
+++ b/src/vfs/nfs/nfs4_readdir.c
@@ -1,8 +1,251 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
 #include "nfs_internal.h"
+
+struct chimera_nfs4_readdir_ctx {
+    struct chimera_nfs_thread        *thread;
+    struct chimera_nfs_client_server *server;
+    uint32_t                          attr_request[2];
+};
+
+/*
+ * Parse readdir entry attributes from fattr4
+ * This is a specialized version for readdir that handles FATTR4_FILEHANDLE
+ */
+static void
+chimera_nfs4_readdir_parse_attrs(
+    const struct fattr4      *fattr,
+    struct chimera_vfs_attrs *attr,
+    uint64_t                 *fileid,
+    uint8_t                  *fh_data,
+    int                      *fh_len)
+{
+    void    *data    = fattr->attr_vals.data;
+    void    *dataend = data + fattr->attr_vals.len;
+    uint32_t type;
+    uint32_t len;
+
+    *fileid           = 0;
+    *fh_len           = 0;
+    attr->va_set_mask = 0;
+
+    if (fattr->num_attrmask < 1) {
+        return;
+    }
+
+    /* Parse attributes in bitmap order */
+
+    /* FATTR4_TYPE = 1 */
+    if (fattr->attrmask[0] & (1 << FATTR4_TYPE)) {
+        if (data + sizeof(uint32_t) > dataend) {
+            return;
+        }
+        type               = chimera_nfs_ntoh32(*(uint32_t *) data);
+        data              += sizeof(uint32_t);
+        attr->va_set_mask |= CHIMERA_VFS_ATTR_MODE;
+        switch (type) {
+            case NF4REG:
+                attr->va_mode = S_IFREG;
+                break;
+            case NF4DIR:
+                attr->va_mode = S_IFDIR;
+                break;
+            case NF4BLK:
+                attr->va_mode = S_IFBLK;
+                break;
+            case NF4CHR:
+                attr->va_mode = S_IFCHR;
+                break;
+            case NF4LNK:
+                attr->va_mode = S_IFLNK;
+                break;
+            case NF4SOCK:
+                attr->va_mode = S_IFSOCK;
+                break;
+            case NF4FIFO:
+                attr->va_mode = S_IFIFO;
+                break;
+            default:
+                attr->va_mode = S_IFREG;
+                break;
+        } /* switch */
+    }
+
+    /* FATTR4_SIZE = 4 */
+    if (fattr->attrmask[0] & (1 << FATTR4_SIZE)) {
+        if (data + sizeof(uint64_t) > dataend) {
+            return;
+        }
+        attr->va_size      = chimera_nfs_ntoh64(*(uint64_t *) data);
+        data              += sizeof(uint64_t);
+        attr->va_set_mask |= CHIMERA_VFS_ATTR_SIZE;
+    }
+
+    /* FATTR4_FILEHANDLE = 19 - opaque<NFS4_FHSIZE> */
+    if (fattr->attrmask[0] & (1 << FATTR4_FILEHANDLE)) {
+        if (data + sizeof(uint32_t) > dataend) {
+            return;
+        }
+        len   = chimera_nfs_ntoh32(*(uint32_t *) data);
+        data += sizeof(uint32_t);
+
+        if (data + len > dataend || len > NFS4_FHSIZE) {
+            return;
+        }
+
+        memcpy(fh_data, data, len);
+        *fh_len = len;
+        data   += len;
+
+        /* XDR padding to 4-byte boundary */
+        if (len % 4) {
+            data += 4 - (len % 4);
+        }
+    }
+
+    /* FATTR4_FILEID = 20 */
+    if (fattr->attrmask[0] & (1 << FATTR4_FILEID)) {
+        if (data + sizeof(uint64_t) > dataend) {
+            return;
+        }
+        *fileid            = chimera_nfs_ntoh64(*(uint64_t *) data);
+        attr->va_ino       = *fileid;
+        data              += sizeof(uint64_t);
+        attr->va_set_mask |= CHIMERA_VFS_ATTR_INUM;
+    }
+
+    if (fattr->num_attrmask < 2) {
+        return;
+    }
+
+    /* FATTR4_MODE = 33 */
+    if (fattr->attrmask[1] & (1 << (FATTR4_MODE - 32))) {
+        if (data + sizeof(uint32_t) > dataend) {
+            return;
+        }
+        attr->va_mode     |= chimera_nfs_ntoh32(*(uint32_t *) data) & ~S_IFMT;
+        data              += sizeof(uint32_t);
+        attr->va_set_mask |= CHIMERA_VFS_ATTR_MODE;
+    }
+
+    /* FATTR4_NUMLINKS = 35 */
+    if (fattr->attrmask[1] & (1 << (FATTR4_NUMLINKS - 32))) {
+        if (data + sizeof(uint32_t) > dataend) {
+            return;
+        }
+        attr->va_nlink     = chimera_nfs_ntoh32(*(uint32_t *) data);
+        attr->va_set_mask |= CHIMERA_VFS_ATTR_NLINK;
+    }
+} /* chimera_nfs4_readdir_parse_attrs */
+
+static void
+chimera_nfs4_readdir_callback(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    struct COMPOUND4res         *res,
+    int                          status,
+    void                        *private_data)
+{
+    struct chimera_vfs_request      *request = private_data;
+    struct chimera_nfs4_readdir_ctx *ctx;
+    struct nfs_resop4               *readdir_res;
+    struct entry4                   *entry;
+    struct chimera_vfs_attrs         attrs;
+    uint64_t                         fileid;
+    uint8_t                          remote_fh[NFS4_FHSIZE];
+    int                              remote_fh_len;
+    uint8_t                          fh_fragment[NFS4_FHSIZE + 1];
+    int                              fh_fragment_len;
+    int                              rc, eof = 0;
+
+    if (unlikely(status)) {
+        request->status = CHIMERA_VFS_EFAULT;
+        request->complete(request);
+        return;
+    }
+
+    if (res->status != NFS4_OK) {
+        request->status = chimera_nfs4_status_to_errno(res->status);
+        request->complete(request);
+        return;
+    }
+
+    /* Check SEQUENCE result (index 0) */
+    if (res->num_resarray < 1 || res->resarray[0].opsequence.sr_status != NFS4_OK) {
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+
+    /* Check PUTFH result (index 1) */
+    if (res->num_resarray < 2 || res->resarray[1].opputfh.status != NFS4_OK) {
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+
+    /* Check READDIR result (index 2) */
+    if (res->num_resarray < 3) {
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+    readdir_res = &res->resarray[2];
+    if (readdir_res->opreaddir.status != NFS4_OK) {
+        request->status = chimera_nfs4_status_to_errno(readdir_res->opreaddir.status);
+        request->complete(request);
+        return;
+    }
+
+    ctx = request->plugin_data;
+
+    /* Copy cookie verifier */
+    memcpy(&request->readdir.r_verifier, readdir_res->opreaddir.resok4.cookieverf,
+           sizeof(request->readdir.r_verifier));
+
+    entry = readdir_res->opreaddir.resok4.reply.entries;
+    eof   = readdir_res->opreaddir.resok4.reply.eof;
+
+    while (entry) {
+        memset(&attrs, 0, sizeof(attrs));
+
+        /* Parse attributes including file handle */
+        chimera_nfs4_readdir_parse_attrs(&entry->attrs, &attrs, &fileid, remote_fh, &remote_fh_len);
+
+        /* Build full file handle: [server_index][remote_fh] */
+        if (remote_fh_len > 0) {
+            fh_fragment[0] = ctx->server->index;
+            memcpy(fh_fragment + 1, remote_fh, remote_fh_len);
+            fh_fragment_len = 1 + remote_fh_len;
+
+            attrs.va_set_mask |= CHIMERA_VFS_ATTR_FH;
+            attrs.va_fh_len    = chimera_vfs_encode_fh_parent(request->fh, fh_fragment, fh_fragment_len, attrs.va_fh);
+        }
+
+        rc = request->readdir.callback(fileid,
+                                       entry->cookie,
+                                       (const char *) entry->name.data,
+                                       entry->name.len,
+                                       &attrs,
+                                       request->proto_private_data);
+
+        request->readdir.r_cookie = entry->cookie;
+
+        if (rc) {
+            eof = 0;
+            break;
+        }
+
+        entry = entry->nextentry;
+    }
+
+    request->readdir.r_eof = eof;
+
+    request->status = CHIMERA_VFS_OK;
+    request->complete(request);
+} /* chimera_nfs4_readdir_callback */
 
 void
 chimera_nfs4_readdir(
@@ -11,7 +254,86 @@ chimera_nfs4_readdir(
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
-    request->status = CHIMERA_VFS_ENOTSUP;
-    request->complete(request);
-} /* chimera_nfs4_readdir */
+    struct chimera_nfs_client_server_thread *server_thread = chimera_nfs_thread_get_server_thread(thread, request->fh,
+                                                                                                  request->fh_len);
+    struct chimera_nfs_client_server        *server;
+    struct chimera_nfs4_client_session      *session;
+    struct chimera_nfs4_readdir_ctx         *ctx;
+    struct COMPOUND4args                     args;
+    struct nfs_argop4                        argarray[3];
+    struct evpl_rpc2_cred                    rpc2_cred;
+    uint8_t                                 *fh;
+    int                                      fhlen;
 
+    if (!server_thread) {
+        request->status = CHIMERA_VFS_ESTALE;
+        request->complete(request);
+        return;
+    }
+
+    server  = server_thread->server;
+    session = server->nfs4_session;
+
+    if (!session) {
+        request->status = CHIMERA_VFS_ESTALE;
+        request->complete(request);
+        return;
+    }
+
+    ctx         = request->plugin_data;
+    ctx->thread = thread;
+    ctx->server = server;
+
+    chimera_nfs4_map_fh(request->fh, request->fh_len, &fh, &fhlen);
+
+    /* Build compound: SEQUENCE + PUTFH + READDIR */
+    memset(&args, 0, sizeof(args));
+    args.tag.len      = 0;
+    args.minorversion = 1;
+    args.argarray     = argarray;
+    args.num_argarray = 3;
+
+    /* Op 0: SEQUENCE */
+    argarray[0].argop = OP_SEQUENCE;
+    memcpy(argarray[0].opsequence.sa_sessionid, session->sessionid, NFS4_SESSIONID_SIZE);
+    argarray[0].opsequence.sa_sequenceid     = chimera_nfs4_get_sequenceid(session, server_thread->slot_id);
+    argarray[0].opsequence.sa_slotid         = server_thread->slot_id;
+    argarray[0].opsequence.sa_highest_slotid = session->max_slots - 1;
+    argarray[0].opsequence.sa_cachethis      = 0;
+
+    /* Op 1: PUTFH - set current file handle to directory */
+    argarray[1].argop               = OP_PUTFH;
+    argarray[1].opputfh.object.data = fh;
+    argarray[1].opputfh.object.len  = fhlen;
+
+    /* Op 2: READDIR */
+    argarray[2].argop              = OP_READDIR;
+    argarray[2].opreaddir.cookie   = request->readdir.cookie;
+    argarray[2].opreaddir.dircount = 8192;
+    argarray[2].opreaddir.maxcount = 8192;
+
+    /* Copy cookie verifier */
+    memcpy(argarray[2].opreaddir.cookieverf, &request->readdir.verifier, sizeof(argarray[2].opreaddir.cookieverf));
+
+    /* Request attributes: TYPE, SIZE, FILEHANDLE, FILEID, MODE, NUMLINKS */
+    ctx->attr_request[0] = (1 << FATTR4_TYPE) | (1 << FATTR4_SIZE) |
+        (1 << FATTR4_FILEHANDLE) | (1 << FATTR4_FILEID);
+    ctx->attr_request[1] = (1 << (FATTR4_MODE - 32)) | (1 << (FATTR4_NUMLINKS - 32));
+
+    argarray[2].opreaddir.attr_request     = ctx->attr_request;
+    argarray[2].opreaddir.num_attr_request = 2;
+
+    chimera_nfs_init_rpc2_cred(&rpc2_cred, request->cred,
+                               request->thread->vfs->machine_name,
+                               request->thread->vfs->machine_name_len);
+
+    shared->nfs_v4.send_call_NFSPROC4_COMPOUND(
+        &shared->nfs_v4.rpc2,
+        thread->evpl,
+        server_thread->nfs_conn,
+        &rpc2_cred,
+        &args,
+        0, 0, 0,
+        chimera_nfs4_readdir_callback,
+        request);
+} /* chimera_nfs4_readdir */

--- a/src/vfs/nfs/nfs4_readdir.c
+++ b/src/vfs/nfs/nfs4_readdir.c
@@ -284,6 +284,46 @@ chimera_nfs4_readdir(
     ctx->thread = thread;
     ctx->server = server;
 
+    /*
+     * Synthesize "." and ".." entries before issuing the server READDIR.
+     * NFSv4 servers do not include them in READDIR responses (RFC 7530
+     * 14.2.30 reserves cookies 0/1/2), so emit them here when the caller
+     * asked for them.  Reserved cookies 1 and 2 are safe to use for the
+     * synthesized entries; real entries from the server start at >= 3.
+     */
+    if (request->readdir.flags & CHIMERA_VFS_READDIR_EMIT_DOT) {
+        struct chimera_vfs_attrs dot_attrs;
+        int                      rc;
+
+        memset(&dot_attrs, 0, sizeof(dot_attrs));
+
+        if (request->readdir.cookie < 1) {
+            rc = request->readdir.callback(0, 1, ".", 1, &dot_attrs,
+                                           request->proto_private_data);
+            request->readdir.r_cookie = 1;
+            if (rc) {
+                request->readdir.r_eof = 0;
+                request->status        = CHIMERA_VFS_OK;
+                request->complete(request);
+                return;
+            }
+            request->readdir.cookie = 1;
+        }
+
+        if (request->readdir.cookie < 2) {
+            rc = request->readdir.callback(0, 2, "..", 2, &dot_attrs,
+                                           request->proto_private_data);
+            request->readdir.r_cookie = 2;
+            if (rc) {
+                request->readdir.r_eof = 0;
+                request->status        = CHIMERA_VFS_OK;
+                request->complete(request);
+                return;
+            }
+            request->readdir.cookie = 2;
+        }
+    }
+
     chimera_nfs4_map_fh(request->fh, request->fh_len, &fh, &fhlen);
 
     /* Build compound: SEQUENCE + PUTFH + READDIR */

--- a/src/vfs/nfs/nfs4_readlink.c
+++ b/src/vfs/nfs/nfs4_readlink.c
@@ -1,8 +1,72 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
 #include "nfs_internal.h"
+
+
+static void
+chimera_nfs4_readlink_callback(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    struct COMPOUND4res         *res,
+    int                          status,
+    void                        *private_data)
+{
+    struct chimera_vfs_request *request = private_data;
+    struct nfs_resop4          *readlink_res;
+
+    if (unlikely(status)) {
+        request->status = CHIMERA_VFS_EFAULT;
+        request->complete(request);
+        return;
+    }
+
+    if (res->status != NFS4_OK) {
+        request->status = chimera_nfs4_status_to_errno(res->status);
+        request->complete(request);
+        return;
+    }
+
+    /* Check SEQUENCE result */
+    if (res->num_resarray < 1 || res->resarray[0].opsequence.sr_status != NFS4_OK) {
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+
+    /* Check PUTFH result */
+    if (res->num_resarray < 2 || res->resarray[1].opputfh.status != NFS4_OK) {
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+
+    /* Check READLINK result */
+    if (res->num_resarray < 3) {
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+    readlink_res = &res->resarray[2];
+    if (readlink_res->opreadlink.status != NFS4_OK) {
+        request->status = chimera_nfs4_status_to_errno(readlink_res->opreadlink.status);
+        request->complete(request);
+        return;
+    }
+
+    /* Copy link target to request */
+    request->readlink.r_target_length = readlink_res->opreadlink.resok4.link.len;
+    if (request->readlink.r_target_length > request->readlink.target_maxlength) {
+        request->readlink.r_target_length = request->readlink.target_maxlength;
+    }
+    memcpy(request->readlink.r_target,
+           readlink_res->opreadlink.resok4.link.data,
+           request->readlink.r_target_length);
+
+    request->status = CHIMERA_VFS_OK;
+    request->complete(request);
+} /* chimera_nfs4_readlink_callback */
 
 void
 chimera_nfs4_readlink(
@@ -11,7 +75,69 @@ chimera_nfs4_readlink(
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
-    request->status = CHIMERA_VFS_ENOTSUP;
-    request->complete(request);
-} /* chimera_nfs4_readlink */
+    struct chimera_nfs_client_server_thread *server_thread = chimera_nfs_thread_get_server_thread(thread, request->fh,
+                                                                                                  request->fh_len);
+    struct chimera_nfs_client_server        *server;
+    struct chimera_nfs4_client_session      *session;
+    struct COMPOUND4args                     args;
+    struct nfs_argop4                        argarray[3];
+    struct evpl_rpc2_cred                    rpc2_cred;
+    uint8_t                                 *fh;
+    int                                      fhlen;
+
+    if (!server_thread) {
+        request->status = CHIMERA_VFS_ESTALE;
+        request->complete(request);
+        return;
+    }
+
+    server  = server_thread->server;
+    session = server->nfs4_session;
+
+    if (!session) {
+        request->status = CHIMERA_VFS_ESTALE;
+        request->complete(request);
+        return;
+    }
+
+    /* Map FH */
+    chimera_nfs4_map_fh(request->fh, request->fh_len, &fh, &fhlen);
+
+    /* Build compound: SEQUENCE + PUTFH + READLINK */
+    memset(&args, 0, sizeof(args));
+    args.tag.len      = 0;
+    args.minorversion = 1;
+    args.argarray     = argarray;
+    args.num_argarray = 3;
+
+    /* Op 0: SEQUENCE */
+    argarray[0].argop = OP_SEQUENCE;
+    memcpy(argarray[0].opsequence.sa_sessionid, session->sessionid, NFS4_SESSIONID_SIZE);
+    argarray[0].opsequence.sa_sequenceid     = chimera_nfs4_get_sequenceid(session, server_thread->slot_id);
+    argarray[0].opsequence.sa_slotid         = server_thread->slot_id;
+    argarray[0].opsequence.sa_highest_slotid = session->max_slots - 1;
+    argarray[0].opsequence.sa_cachethis      = 0;
+
+    /* Op 1: PUTFH - set current FH to the symlink */
+    argarray[1].argop               = OP_PUTFH;
+    argarray[1].opputfh.object.data = fh;
+    argarray[1].opputfh.object.len  = fhlen;
+
+    /* Op 2: READLINK - read the symbolic link target */
+    argarray[2].argop = OP_READLINK;
+
+    chimera_nfs_init_rpc2_cred(&rpc2_cred, request->cred,
+                               request->thread->vfs->machine_name,
+                               request->thread->vfs->machine_name_len);
+
+    shared->nfs_v4.send_call_NFSPROC4_COMPOUND(
+        &shared->nfs_v4.rpc2,
+        thread->evpl,
+        server_thread->nfs_conn,
+        &rpc2_cred,
+        &args,
+        0, 0, 0,
+        chimera_nfs4_readlink_callback,
+        request);
+} /* chimera_nfs4_readlink */ /* chimera_nfs4_readlink */
 

--- a/src/vfs/nfs/nfs4_remove_at.c
+++ b/src/vfs/nfs/nfs4_remove_at.c
@@ -4,6 +4,65 @@
 
 #include "nfs_internal.h"
 
+struct chimera_nfs4_remove_ctx {
+    struct chimera_nfs_thread        *thread;
+    struct chimera_nfs_client_server *server;
+};
+
+static void
+chimera_nfs4_remove_callback(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    struct COMPOUND4res         *res,
+    int                          status,
+    void                        *private_data)
+{
+    struct chimera_vfs_request *request = private_data;
+    struct nfs_resop4          *remove_res;
+
+    if (unlikely(status)) {
+        request->status = CHIMERA_VFS_EFAULT;
+        request->complete(request);
+        return;
+    }
+
+    if (res->status != NFS4_OK) {
+        request->status = chimera_nfs4_status_to_errno(res->status);
+        request->complete(request);
+        return;
+    }
+
+    /* Check SEQUENCE result */
+    if (res->num_resarray < 1 || res->resarray[0].opsequence.sr_status != NFS4_OK) {
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+
+    /* Check PUTFH result */
+    if (res->num_resarray < 2 || res->resarray[1].opputfh.status != NFS4_OK) {
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+
+    /* Check REMOVE result */
+    if (res->num_resarray < 3) {
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+    remove_res = &res->resarray[2];
+    if (remove_res->opremove.status != NFS4_OK) {
+        request->status = chimera_nfs4_status_to_errno(remove_res->opremove.status);
+        request->complete(request);
+        return;
+    }
+
+    request->status = CHIMERA_VFS_OK;
+    request->complete(request);
+} /* chimera_nfs4_remove_callback */
+
 void
 chimera_nfs4_remove_at(
     struct chimera_nfs_thread  *thread,
@@ -11,7 +70,75 @@ chimera_nfs4_remove_at(
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
-    request->status = CHIMERA_VFS_ENOTSUP;
-    request->complete(request);
-} /* chimera_nfs4_remove_at */
+    struct chimera_nfs_client_server_thread *server_thread = chimera_nfs_thread_get_server_thread(thread, request->fh,
+                                                                                                  request->fh_len);
+    struct chimera_nfs_client_server        *server;
+    struct chimera_nfs4_client_session      *session;
+    struct chimera_nfs4_remove_ctx          *ctx;
+    struct COMPOUND4args                     args;
+    struct nfs_argop4                        argarray[3];
+    struct evpl_rpc2_cred                    rpc2_cred;
+    uint8_t                                 *fh;
+    int                                      fhlen;
 
+    ctx = request->plugin_data;
+
+    if (!server_thread) {
+        request->status = CHIMERA_VFS_ESTALE;
+        request->complete(request);
+        return;
+    }
+
+    server  = server_thread->server;
+    session = server->nfs4_session;
+
+    if (!session) {
+        request->status = CHIMERA_VFS_ESTALE;
+        request->complete(request);
+        return;
+    }
+
+    ctx->thread = thread;
+    ctx->server = server;
+
+    chimera_nfs4_map_fh(request->fh, request->fh_len, &fh, &fhlen);
+
+    /* Build compound: SEQUENCE + PUTFH + REMOVE */
+    memset(&args, 0, sizeof(args));
+    args.tag.len      = 0;
+    args.minorversion = 1;
+    args.argarray     = argarray;
+    args.num_argarray = 3;
+
+    /* Op 0: SEQUENCE */
+    argarray[0].argop = OP_SEQUENCE;
+    memcpy(argarray[0].opsequence.sa_sessionid, session->sessionid, NFS4_SESSIONID_SIZE);
+    argarray[0].opsequence.sa_sequenceid     = chimera_nfs4_get_sequenceid(session, server_thread->slot_id);
+    argarray[0].opsequence.sa_slotid         = server_thread->slot_id;
+    argarray[0].opsequence.sa_highest_slotid = session->max_slots - 1;
+    argarray[0].opsequence.sa_cachethis      = 0;
+
+    /* Op 1: PUTFH - set current file handle to parent directory */
+    argarray[1].argop               = OP_PUTFH;
+    argarray[1].opputfh.object.data = fh;
+    argarray[1].opputfh.object.len  = fhlen;
+
+    /* Op 2: REMOVE - remove the file or directory */
+    argarray[2].argop                = OP_REMOVE;
+    argarray[2].opremove.target.data = (uint8_t *) request->remove_at.name;
+    argarray[2].opremove.target.len  = request->remove_at.namelen;
+
+    chimera_nfs_init_rpc2_cred(&rpc2_cred, request->cred,
+                               request->thread->vfs->machine_name,
+                               request->thread->vfs->machine_name_len);
+
+    shared->nfs_v4.send_call_NFSPROC4_COMPOUND(
+        &shared->nfs_v4.rpc2,
+        thread->evpl,
+        server_thread->nfs_conn,
+        &rpc2_cred,
+        &args,
+        0, 0, 0,
+        chimera_nfs4_remove_callback,
+        request);
+} /* chimera_nfs4_remove_at */

--- a/src/vfs/nfs/nfs4_rename_at.c
+++ b/src/vfs/nfs/nfs4_rename_at.c
@@ -4,6 +4,79 @@
 
 #include "nfs_internal.h"
 
+struct chimera_nfs4_rename_ctx {
+    struct chimera_nfs_thread        *thread;
+    struct chimera_nfs_client_server *server;
+};
+
+static void
+chimera_nfs4_rename_callback(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    struct COMPOUND4res         *res,
+    int                          status,
+    void                        *private_data)
+{
+    struct chimera_vfs_request *request = private_data;
+    struct nfs_resop4          *rename_res;
+
+    if (unlikely(status)) {
+        request->status = CHIMERA_VFS_EFAULT;
+        request->complete(request);
+        return;
+    }
+
+    if (res->status != NFS4_OK) {
+        request->status = chimera_nfs4_status_to_errno(res->status);
+        request->complete(request);
+        return;
+    }
+
+    /* Check SEQUENCE result (index 0) */
+    if (res->num_resarray < 1 || res->resarray[0].opsequence.sr_status != NFS4_OK) {
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+
+    /* Check PUTFH result (index 1) - source directory */
+    if (res->num_resarray < 2 || res->resarray[1].opputfh.status != NFS4_OK) {
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+
+    /* Check SAVEFH result (index 2) */
+    if (res->num_resarray < 3 || res->resarray[2].opsavefh.status != NFS4_OK) {
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+
+    /* Check PUTFH result (index 3) - target directory */
+    if (res->num_resarray < 4 || res->resarray[3].opputfh.status != NFS4_OK) {
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+
+    /* Check RENAME result (index 4) */
+    if (res->num_resarray < 5) {
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+    rename_res = &res->resarray[4];
+    if (rename_res->oprename.status != NFS4_OK) {
+        request->status = chimera_nfs4_status_to_errno(rename_res->oprename.status);
+        request->complete(request);
+        return;
+    }
+
+    request->status = CHIMERA_VFS_OK;
+    request->complete(request);
+} /* chimera_nfs4_rename_callback */
+
 void
 chimera_nfs4_rename_at(
     struct chimera_nfs_thread  *thread,
@@ -11,7 +84,91 @@ chimera_nfs4_rename_at(
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
-    request->status = CHIMERA_VFS_ENOTSUP;
-    request->complete(request);
-} /* chimera_nfs4_rename_at */
+    struct chimera_nfs_client_server_thread *server_thread = chimera_nfs_thread_get_server_thread(thread, request->fh,
+                                                                                                  request->fh_len);
+    struct chimera_nfs_client_server        *server;
+    struct chimera_nfs4_client_session      *session;
+    struct chimera_nfs4_rename_ctx          *ctx;
+    struct COMPOUND4args                     args;
+    struct nfs_argop4                        argarray[5];
+    struct evpl_rpc2_cred                    rpc2_cred;
+    uint8_t                                 *src_fh;
+    int                                      src_fhlen;
+    uint8_t                                 *dst_fh;
+    int                                      dst_fhlen;
 
+    ctx = request->plugin_data;
+
+    if (!server_thread) {
+        request->status = CHIMERA_VFS_ESTALE;
+        request->complete(request);
+        return;
+    }
+
+    server  = server_thread->server;
+    session = server->nfs4_session;
+
+    if (!session) {
+        request->status = CHIMERA_VFS_ESTALE;
+        request->complete(request);
+        return;
+    }
+
+    ctx->thread = thread;
+    ctx->server = server;
+
+    /* Map source directory FH (request->fh) */
+    chimera_nfs4_map_fh(request->fh, request->fh_len, &src_fh, &src_fhlen);
+
+    /* Map target directory FH */
+    chimera_nfs4_map_fh(request->rename_at.new_fh, request->rename_at.new_fhlen, &dst_fh, &dst_fhlen);
+
+    /* Build compound: SEQUENCE + PUTFH(src) + SAVEFH + PUTFH(dst) + RENAME */
+    memset(&args, 0, sizeof(args));
+    args.tag.len      = 0;
+    args.minorversion = 1;
+    args.argarray     = argarray;
+    args.num_argarray = 5;
+
+    /* Op 0: SEQUENCE */
+    argarray[0].argop = OP_SEQUENCE;
+    memcpy(argarray[0].opsequence.sa_sessionid, session->sessionid, NFS4_SESSIONID_SIZE);
+    argarray[0].opsequence.sa_sequenceid     = chimera_nfs4_get_sequenceid(session, server_thread->slot_id);
+    argarray[0].opsequence.sa_slotid         = server_thread->slot_id;
+    argarray[0].opsequence.sa_highest_slotid = session->max_slots - 1;
+    argarray[0].opsequence.sa_cachethis      = 0;
+
+    /* Op 1: PUTFH - set current FH to source directory */
+    argarray[1].argop               = OP_PUTFH;
+    argarray[1].opputfh.object.data = src_fh;
+    argarray[1].opputfh.object.len  = src_fhlen;
+
+    /* Op 2: SAVEFH - save source directory FH */
+    argarray[2].argop = OP_SAVEFH;
+
+    /* Op 3: PUTFH - set current FH to target directory */
+    argarray[3].argop               = OP_PUTFH;
+    argarray[3].opputfh.object.data = dst_fh;
+    argarray[3].opputfh.object.len  = dst_fhlen;
+
+    /* Op 4: RENAME - rename from saved FH (source dir) to current FH (target dir) */
+    argarray[4].argop                 = OP_RENAME;
+    argarray[4].oprename.oldname.data = (uint8_t *) request->rename_at.name;
+    argarray[4].oprename.oldname.len  = request->rename_at.namelen;
+    argarray[4].oprename.newname.data = (uint8_t *) request->rename_at.new_name;
+    argarray[4].oprename.newname.len  = request->rename_at.new_namelen;
+
+    chimera_nfs_init_rpc2_cred(&rpc2_cred, request->cred,
+                               request->thread->vfs->machine_name,
+                               request->thread->vfs->machine_name_len);
+
+    shared->nfs_v4.send_call_NFSPROC4_COMPOUND(
+        &shared->nfs_v4.rpc2,
+        thread->evpl,
+        server_thread->nfs_conn,
+        &rpc2_cred,
+        &args,
+        0, 0, 0,
+        chimera_nfs4_rename_callback,
+        request);
+} /* chimera_nfs4_rename_at */

--- a/src/vfs/nfs/nfs4_setattr.c
+++ b/src/vfs/nfs/nfs4_setattr.c
@@ -1,8 +1,69 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
 #include "nfs_internal.h"
+
+struct chimera_nfs4_setattr_ctx {
+    struct chimera_nfs_thread        *thread;
+    struct chimera_nfs_client_server *server;
+    uint32_t                          attr_mask[2];
+    uint8_t                           attr_vals[128];
+};
+
+static void
+chimera_nfs4_setattr_callback(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    struct COMPOUND4res         *res,
+    int                          status,
+    void                        *private_data)
+{
+    struct chimera_vfs_request *request = private_data;
+    struct nfs_resop4          *setattr_res;
+
+    if (unlikely(status)) {
+        request->status = CHIMERA_VFS_EFAULT;
+        request->complete(request);
+        return;
+    }
+
+    if (res->status != NFS4_OK) {
+        request->status = chimera_nfs4_status_to_errno(res->status);
+        request->complete(request);
+        return;
+    }
+
+    /* Check SEQUENCE result */
+    if (res->num_resarray < 1 || res->resarray[0].opsequence.sr_status != NFS4_OK) {
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+
+    /* Check PUTFH result */
+    if (res->num_resarray < 2 || res->resarray[1].opputfh.status != NFS4_OK) {
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+
+    /* Check SETATTR result */
+    if (res->num_resarray < 3) {
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+    setattr_res = &res->resarray[2];
+    if (setattr_res->opsetattr.status != NFS4_OK) {
+        request->status = chimera_nfs4_status_to_errno(setattr_res->opsetattr.status);
+        request->complete(request);
+        return;
+    }
+
+    request->status = CHIMERA_VFS_OK;
+    request->complete(request);
+} /* chimera_nfs4_setattr_callback */
 
 void
 chimera_nfs4_setattr(
@@ -11,7 +72,162 @@ chimera_nfs4_setattr(
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
-    request->status = CHIMERA_VFS_ENOTSUP;
-    request->complete(request);
-} /* chimera_nfs4_setattr */
+    struct chimera_nfs_client_server_thread *server_thread = chimera_nfs_thread_get_server_thread(thread, request->fh,
+                                                                                                  request->fh_len);
+    struct chimera_nfs_client_server        *server;
+    struct chimera_nfs4_client_session      *session;
+    struct chimera_nfs4_setattr_ctx         *ctx;
+    struct chimera_vfs_attrs                *set_attr;
+    struct COMPOUND4args                     args;
+    struct nfs_argop4                        argarray[3];
+    struct evpl_rpc2_cred                    rpc2_cred;
+    uint8_t                                 *fh;
+    int                                      fhlen;
+    uint8_t                                 *attr_ptr;
+    int                                      attr_len;
+    char                                     owner_str[32];
+    char                                     group_str[32];
+    int                                      owner_len;
+    int                                      group_len;
 
+    ctx = request->plugin_data;
+
+    if (!server_thread) {
+        request->status = CHIMERA_VFS_ESTALE;
+        request->complete(request);
+        return;
+    }
+
+    server  = server_thread->server;
+    session = server->nfs4_session;
+
+    if (!session) {
+        request->status = CHIMERA_VFS_ESTALE;
+        request->complete(request);
+        return;
+    }
+
+    ctx->thread = thread;
+    ctx->server = server;
+
+    chimera_nfs4_map_fh(request->fh, request->fh_len, &fh, &fhlen);
+
+    /* Build fattr4 from set_attr */
+    set_attr = request->setattr.set_attr;
+
+    memset(ctx->attr_mask, 0, sizeof(ctx->attr_mask));
+    attr_ptr = ctx->attr_vals;
+    attr_len = 0;
+
+    /* Attributes must be encoded in ascending order by attribute number:
+     * SIZE (4), MODE (33), OWNER (36), OWNER_GROUP (37)
+     */
+
+    /* Encode SIZE if requested - FATTR4_SIZE = 4 */
+    if (set_attr->va_set_mask & CHIMERA_VFS_ATTR_SIZE) {
+        ctx->attr_mask[0]     |= (1 << FATTR4_SIZE);
+        *(uint64_t *) attr_ptr = chimera_nfs_hton64(set_attr->va_size);
+        attr_ptr              += sizeof(uint64_t);
+        attr_len              += sizeof(uint64_t);
+    }
+
+    /* Encode MODE if requested - FATTR4_MODE = 33 */
+    if (set_attr->va_set_mask & CHIMERA_VFS_ATTR_MODE) {
+        ctx->attr_mask[1]     |= (1 << (FATTR4_MODE - 32));
+        *(uint32_t *) attr_ptr = chimera_nfs_hton32(set_attr->va_mode & 07777);
+        attr_ptr              += sizeof(uint32_t);
+        attr_len              += sizeof(uint32_t);
+    }
+
+    /* Encode OWNER (uid) if requested - FATTR4_OWNER = 36 */
+    if (set_attr->va_set_mask & CHIMERA_VFS_ATTR_UID) {
+        ctx->attr_mask[1] |= (1 << (FATTR4_OWNER - 32));
+        /* Convert numeric uid to string */
+        owner_len              = snprintf(owner_str, sizeof(owner_str), "%lu", (unsigned long) set_attr->va_uid);
+        *(uint32_t *) attr_ptr = chimera_nfs_hton32(owner_len);
+        attr_ptr              += sizeof(uint32_t);
+        attr_len              += sizeof(uint32_t);
+        memcpy(attr_ptr, owner_str, owner_len);
+        attr_ptr += owner_len;
+        attr_len += owner_len;
+        /* Pad to 4-byte boundary */
+        while (attr_len % 4) {
+            *attr_ptr++ = 0;
+            attr_len++;
+        }
+    }
+
+    /* Encode OWNER_GROUP (gid) if requested - FATTR4_OWNER_GROUP = 37 */
+    if (set_attr->va_set_mask & CHIMERA_VFS_ATTR_GID) {
+        ctx->attr_mask[1] |= (1 << (FATTR4_OWNER_GROUP - 32));
+        /* Convert numeric gid to string */
+        group_len              = snprintf(group_str, sizeof(group_str), "%lu", (unsigned long) set_attr->va_gid);
+        *(uint32_t *) attr_ptr = chimera_nfs_hton32(group_len);
+        attr_ptr              += sizeof(uint32_t);
+        attr_len              += sizeof(uint32_t);
+        memcpy(attr_ptr, group_str, group_len);
+        attr_ptr += group_len;
+        attr_len += group_len;
+        /* Pad to 4-byte boundary */
+        while (attr_len % 4) {
+            *attr_ptr++ = 0;
+            attr_len++;
+        }
+    }
+
+    /* Build compound: SEQUENCE + PUTFH + SETATTR */
+    memset(&args, 0, sizeof(args));
+    args.tag.len      = 0;
+    args.minorversion = 1;
+    args.argarray     = argarray;
+    args.num_argarray = 3;
+
+    /* Op 0: SEQUENCE */
+    argarray[0].argop = OP_SEQUENCE;
+    memcpy(argarray[0].opsequence.sa_sessionid, session->sessionid, NFS4_SESSIONID_SIZE);
+    argarray[0].opsequence.sa_sequenceid     = chimera_nfs4_get_sequenceid(session, server_thread->slot_id);
+    argarray[0].opsequence.sa_slotid         = server_thread->slot_id;
+    argarray[0].opsequence.sa_highest_slotid = session->max_slots - 1;
+    argarray[0].opsequence.sa_cachethis      = 0;
+
+    /* Op 1: PUTFH - set current file handle */
+    argarray[1].argop               = OP_PUTFH;
+    argarray[1].opputfh.object.data = fh;
+    argarray[1].opputfh.object.len  = fhlen;
+
+    /* Op 2: SETATTR */
+    argarray[2].argop = OP_SETATTR;
+
+    /* Anonymous stateid (all zeros) for setattr on unopened files */
+    memset(&argarray[2].opsetattr.stateid, 0, sizeof(argarray[2].opsetattr.stateid));
+
+    /* Set attribute mask - use 2 words if we have any bit in word 1, else 1 word */
+    if (ctx->attr_mask[1]) {
+        argarray[2].opsetattr.obj_attributes.num_attrmask = 2;
+    } else if (ctx->attr_mask[0]) {
+        argarray[2].opsetattr.obj_attributes.num_attrmask = 1;
+    } else {
+        /* No attributes to set - just return OK */
+        request->status = CHIMERA_VFS_OK;
+        request->complete(request);
+        return;
+    }
+
+    argarray[2].opsetattr.obj_attributes.attrmask       = ctx->attr_mask;
+    argarray[2].opsetattr.obj_attributes.attr_vals.data = ctx->attr_vals;
+    argarray[2].opsetattr.obj_attributes.attr_vals.len  = attr_len;
+
+    chimera_nfs_init_rpc2_cred(&rpc2_cred, request->cred,
+                               request->thread->vfs->machine_name,
+                               request->thread->vfs->machine_name_len);
+
+    shared->nfs_v4.send_call_NFSPROC4_COMPOUND(
+        &shared->nfs_v4.rpc2,
+        thread->evpl,
+        server_thread->nfs_conn,
+        &rpc2_cred,
+        &args,
+        0, 0, 0,
+        chimera_nfs4_setattr_callback,
+        request);
+} /* chimera_nfs4_setattr */ /* chimera_nfs4_setattr */

--- a/src/vfs/nfs/nfs4_symlink_at.c
+++ b/src/vfs/nfs/nfs4_symlink_at.c
@@ -4,6 +4,97 @@
 
 #include "nfs_internal.h"
 
+
+struct chimera_nfs4_symlink_ctx {
+    struct chimera_nfs_thread        *thread;
+    struct chimera_nfs_client_server *server;
+};
+
+static void
+chimera_nfs4_symlink_callback(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    struct COMPOUND4res         *res,
+    int                          status,
+    void                        *private_data)
+{
+    struct chimera_vfs_request      *request = private_data;
+    struct chimera_nfs4_symlink_ctx *ctx     = request->plugin_data;
+    struct nfs_resop4               *create_res;
+    struct nfs_resop4               *getfh_res;
+    struct nfs_resop4               *getattr_res;
+    xdr_opaque                      *remote_fh;
+
+    if (unlikely(status)) {
+        request->status = CHIMERA_VFS_EFAULT;
+        request->complete(request);
+        return;
+    }
+
+    if (res->status != NFS4_OK) {
+        request->status = chimera_nfs4_status_to_errno(res->status);
+        request->complete(request);
+        return;
+    }
+
+    /* Check SEQUENCE result */
+    if (res->num_resarray < 1 || res->resarray[0].opsequence.sr_status != NFS4_OK) {
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+
+    /* Check PUTFH result */
+    if (res->num_resarray < 2 || res->resarray[1].opputfh.status != NFS4_OK) {
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+
+    /* Check CREATE result */
+    if (res->num_resarray < 3) {
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+    create_res = &res->resarray[2];
+    if (create_res->opcreate.status != NFS4_OK) {
+        request->status = chimera_nfs4_status_to_errno(create_res->opcreate.status);
+        request->complete(request);
+        return;
+    }
+
+    /* Check GETFH result */
+    if (res->num_resarray < 4) {
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+    getfh_res = &res->resarray[3];
+    if (getfh_res->opgetfh.status != NFS4_OK) {
+        request->status = chimera_nfs4_status_to_errno(getfh_res->opgetfh.status);
+        request->complete(request);
+        return;
+    }
+
+    remote_fh = &getfh_res->opgetfh.resok4.object;
+
+    /* Build local file handle from server index + remote FH */
+    chimera_nfs4_unmarshall_fh(remote_fh, ctx->server->index, request->fh, &request->symlink_at.r_attr);
+
+    /* Get GETATTR result */
+    if (res->num_resarray >= 5) {
+        getattr_res = &res->resarray[4];
+        if (getattr_res->opgetattr.status == NFS4_OK) {
+            chimera_nfs4_unmarshall_fattr(&getattr_res->opgetattr.resok4.obj_attributes,
+                                          &request->symlink_at.r_attr);
+        }
+    }
+
+    request->status = CHIMERA_VFS_OK;
+    request->complete(request);
+} /* chimera_nfs4_symlink_callback */
+
 void
 chimera_nfs4_symlink_at(
     struct chimera_nfs_thread  *thread,
@@ -11,7 +102,95 @@ chimera_nfs4_symlink_at(
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
-    request->status = CHIMERA_VFS_ENOTSUP;
-    request->complete(request);
-} /* chimera_nfs4_symlink_at */
+    struct chimera_nfs_client_server_thread *server_thread = chimera_nfs_thread_get_server_thread(thread, request->fh,
+                                                                                                  request->fh_len);
+    struct chimera_nfs_client_server        *server;
+    struct chimera_nfs4_client_session      *session;
+    struct chimera_nfs4_symlink_ctx         *ctx;
+    struct COMPOUND4args                     args;
+    struct nfs_argop4                        argarray[5];
+    uint32_t                                 attr_request[2];
+    struct evpl_rpc2_cred                    rpc2_cred;
+    uint8_t                                 *dir_fh;
+    int                                      dir_fhlen;
 
+    ctx = request->plugin_data;
+
+    if (!server_thread) {
+        request->status = CHIMERA_VFS_ESTALE;
+        request->complete(request);
+        return;
+    }
+
+    server  = server_thread->server;
+    session = server->nfs4_session;
+
+    if (!session) {
+        request->status = CHIMERA_VFS_ESTALE;
+        request->complete(request);
+        return;
+    }
+
+    ctx->thread = thread;
+    ctx->server = server;
+
+    /* Map directory FH */
+    chimera_nfs4_map_fh(request->fh, request->fh_len, &dir_fh, &dir_fhlen);
+
+    /* Build compound: SEQUENCE + PUTFH(dir) + CREATE(NF4LNK) + GETFH + GETATTR */
+    memset(&args, 0, sizeof(args));
+    args.tag.len      = 0;
+    args.minorversion = 1;
+    args.argarray     = argarray;
+    args.num_argarray = 5;
+
+    /* Op 0: SEQUENCE */
+    argarray[0].argop = OP_SEQUENCE;
+    memcpy(argarray[0].opsequence.sa_sessionid, session->sessionid, NFS4_SESSIONID_SIZE);
+    argarray[0].opsequence.sa_sequenceid     = chimera_nfs4_get_sequenceid(session, server_thread->slot_id);
+    argarray[0].opsequence.sa_slotid         = server_thread->slot_id;
+    argarray[0].opsequence.sa_highest_slotid = session->max_slots - 1;
+    argarray[0].opsequence.sa_cachethis      = 0;
+
+    /* Op 1: PUTFH - set current FH to directory */
+    argarray[1].argop               = OP_PUTFH;
+    argarray[1].opputfh.object.data = dir_fh;
+    argarray[1].opputfh.object.len  = dir_fhlen;
+
+    /* Op 2: CREATE - create symbolic link */
+    argarray[2].argop                               = OP_CREATE;
+    argarray[2].opcreate.objtype.type               = NF4LNK;
+    argarray[2].opcreate.objtype.linkdata.data      = (uint8_t *) request->symlink_at.target;
+    argarray[2].opcreate.objtype.linkdata.len       = request->symlink_at.targetlen;
+    argarray[2].opcreate.objname.data               = (uint8_t *) request->symlink_at.name;
+    argarray[2].opcreate.objname.len                = request->symlink_at.namelen;
+    argarray[2].opcreate.createattrs.num_attrmask   = 0;
+    argarray[2].opcreate.createattrs.attrmask       = NULL;
+    argarray[2].opcreate.createattrs.attr_vals.data = NULL;
+    argarray[2].opcreate.createattrs.attr_vals.len  = 0;
+
+    /* Op 3: GETFH - get file handle of created symlink */
+    argarray[3].argop = OP_GETFH;
+
+    /* Op 4: GETATTR - get attributes of created symlink */
+    argarray[4].argop = OP_GETATTR;
+    attr_request[0]   = (1 << FATTR4_TYPE) | (1 << FATTR4_SIZE) | (1 << FATTR4_FILEID);
+    attr_request[1]   = (1 << (FATTR4_MODE - 32)) | (1 << (FATTR4_NUMLINKS - 32)) |
+        (1 << (FATTR4_TIME_ACCESS - 32)) | (1 << (FATTR4_TIME_MODIFY - 32));
+    argarray[4].opgetattr.attr_request     = attr_request;
+    argarray[4].opgetattr.num_attr_request = 2;
+
+    chimera_nfs_init_rpc2_cred(&rpc2_cred, request->cred,
+                               request->thread->vfs->machine_name,
+                               request->thread->vfs->machine_name_len);
+
+    shared->nfs_v4.send_call_NFSPROC4_COMPOUND(
+        &shared->nfs_v4.rpc2,
+        thread->evpl,
+        server_thread->nfs_conn,
+        &rpc2_cred,
+        &args,
+        0, 0, 0,
+        chimera_nfs4_symlink_callback,
+        request);
+} /* chimera_nfs4_symlink_at */

--- a/src/vfs/nfs/nfs4_umount.c
+++ b/src/vfs/nfs/nfs4_umount.c
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "nfs_internal.h"
+
+void
+chimera_nfs4_umount(
+    struct chimera_nfs_thread  *thread,
+    struct chimera_nfs_shared  *shared,
+    struct chimera_vfs_request *request,
+    void                       *private_data)
+{
+    struct chimera_nfs_client_mount  *mount  = request->umount.mount_private;
+    struct chimera_nfs_client_server *server = mount->server;
+
+    pthread_mutex_lock(&shared->lock);
+
+    DL_DELETE(shared->mounts, mount);
+
+    free(mount);
+
+    server->refcnt--;
+
+    /* Free session when last mount is removed */
+    if (server->refcnt == 0 && server->nfs4_session) {
+        free(server->nfs4_session->slot_seqids);
+        free(server->nfs4_session);
+        server->nfs4_session = NULL;
+    }
+
+    pthread_mutex_unlock(&shared->lock);
+
+    request->status = CHIMERA_VFS_OK;
+    request->complete(request);
+
+} /* chimera_nfs4_umount */

--- a/src/vfs/nfs/nfs4_write.c
+++ b/src/vfs/nfs/nfs4_write.c
@@ -1,8 +1,78 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
 #include "nfs_internal.h"
+#include "nfs4_open_state.h"
+#include "vfs/vfs_error.h"
+
+struct chimera_nfs4_write_ctx {
+    struct chimera_nfs_thread        *thread;
+    struct chimera_nfs_client_server *server;
+    struct chimera_nfs4_open_state   *open_state;
+};
+
+static void
+chimera_nfs4_write_callback(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    struct COMPOUND4res         *res,
+    int                          status,
+    void                        *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct chimera_nfs4_write_ctx *ctx     = request->plugin_data;
+    struct nfs_resop4             *write_res;
+
+    if (unlikely(status)) {
+        request->status = CHIMERA_VFS_EFAULT;
+        request->complete(request);
+        return;
+    }
+
+    if (res->status != NFS4_OK) {
+        request->status = chimera_nfs4_status_to_errno(res->status);
+        request->complete(request);
+        return;
+    }
+
+    /* Check SEQUENCE result */
+    if (res->num_resarray < 1 || res->resarray[0].opsequence.sr_status != NFS4_OK) {
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+
+    /* Check PUTFH result */
+    if (res->num_resarray < 2 || res->resarray[1].opputfh.status != NFS4_OK) {
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+
+    /* Check WRITE result */
+    if (res->num_resarray < 3) {
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+    write_res = &res->resarray[2];
+    if (write_res->opwrite.status != NFS4_OK) {
+        request->status = chimera_nfs4_status_to_errno(write_res->opwrite.status);
+        request->complete(request);
+        return;
+    }
+
+    /* Mark file as dirty if the write was not fully committed to stable storage */
+    if (write_res->opwrite.resok4.committed != FILE_SYNC4 && ctx->open_state) {
+        chimera_nfs4_open_state_mark_dirty(ctx->open_state);
+    }
+
+    request->write.r_sync   = write_res->opwrite.resok4.committed;
+    request->write.r_length = write_res->opwrite.resok4.count;
+    request->status         = CHIMERA_VFS_OK;
+    request->complete(request);
+} /* chimera_nfs4_write_callback */
 
 void
 chimera_nfs4_write(
@@ -11,7 +81,90 @@ chimera_nfs4_write(
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
-    request->status = CHIMERA_VFS_ENOTSUP;
-    request->complete(request);
-} /* chimera_nfs4_write */
+    struct chimera_nfs_client_server_thread *server_thread = chimera_nfs_thread_get_server_thread(thread, request->fh,
+                                                                                                  request->fh_len);
+    struct chimera_nfs_client_server        *server;
+    struct chimera_nfs4_client_session      *session;
+    struct chimera_nfs4_write_ctx           *ctx;
+    struct chimera_nfs4_open_state          *open_state;
+    struct COMPOUND4args                     args;
+    struct nfs_argop4                        argarray[3];
+    struct evpl_rpc2_cred                    rpc2_cred;
+    uint8_t                                 *fh;
+    int                                      fhlen;
 
+    if (!server_thread) {
+        request->status = CHIMERA_VFS_ESTALE;
+        request->complete(request);
+        return;
+    }
+
+    server  = server_thread->server;
+    session = server->nfs4_session;
+
+    if (!session) {
+        request->status = CHIMERA_VFS_ESTALE;
+        request->complete(request);
+        return;
+    }
+
+    ctx             = request->plugin_data;
+    ctx->thread     = thread;
+    ctx->server     = server;
+    open_state      = (struct chimera_nfs4_open_state *) request->write.handle->vfs_private;
+    ctx->open_state = open_state;
+
+    chimera_nfs4_map_fh(request->fh, request->fh_len, &fh, &fhlen);
+
+    /* Build compound: SEQUENCE + PUTFH + WRITE */
+    memset(&args, 0, sizeof(args));
+    args.tag.len      = 0;
+    args.minorversion = 1;
+    args.argarray     = argarray;
+    args.num_argarray = 3;
+
+    /* Op 0: SEQUENCE */
+    argarray[0].argop = OP_SEQUENCE;
+    memcpy(argarray[0].opsequence.sa_sessionid, session->sessionid, NFS4_SESSIONID_SIZE);
+    argarray[0].opsequence.sa_sequenceid     = chimera_nfs4_get_sequenceid(session, server_thread->slot_id);
+    argarray[0].opsequence.sa_slotid         = server_thread->slot_id;
+    argarray[0].opsequence.sa_highest_slotid = session->max_slots - 1;
+    argarray[0].opsequence.sa_cachethis      = 0;
+
+    /* Op 1: PUTFH */
+    argarray[1].argop               = OP_PUTFH;
+    argarray[1].opputfh.object.data = fh;
+    argarray[1].opputfh.object.len  = fhlen;
+
+    /* Op 2: WRITE */
+    argarray[2].argop = OP_WRITE;
+
+    /* Use the stateid from the open state, or anonymous stateid if not available */
+    if (open_state) {
+        argarray[2].opwrite.stateid = open_state->stateid;
+    } else {
+        /* Anonymous stateid */
+        memset(&argarray[2].opwrite.stateid, 0, sizeof(argarray[2].opwrite.stateid));
+        argarray[2].opwrite.stateid.seqid = 0;
+    }
+
+    argarray[2].opwrite.offset      = request->write.offset;
+    argarray[2].opwrite.stable      = request->write.sync ? FILE_SYNC4 : UNSTABLE4;
+    argarray[2].opwrite.data.iov    = request->write.iov;
+    argarray[2].opwrite.data.niov   = request->write.niov;
+    argarray[2].opwrite.data.length = request->write.length;
+
+    chimera_nfs_init_rpc2_cred(&rpc2_cred, request->cred,
+                               request->thread->vfs->machine_name,
+                               request->thread->vfs->machine_name_len);
+
+    shared->nfs_v4.send_call_NFSPROC4_COMPOUND(
+        &shared->nfs_v4.rpc2,
+        thread->evpl,
+        server_thread->nfs_conn,
+        &rpc2_cred,
+        &args,
+        1, 0, 0,
+        chimera_nfs4_write_callback,
+        request);
+} /* chimera_nfs4_write */

--- a/src/vfs/nfs/nfs_internal.h
+++ b/src/vfs/nfs/nfs_internal.h
@@ -7,6 +7,8 @@
 #include <stdint.h>
 #include <string.h>
 #include <pthread.h>
+#include <sys/stat.h>
+#include <endian.h>
 #include <utlist.h>
 #include "vfs/vfs.h"
 #include "evpl/evpl.h"
@@ -19,6 +21,27 @@
 #include "vfs/vfs_fh.h"
 #include "evpl/evpl_rpc2.h"
 #include "nlm4_xdr.h"
+
+/* Byte order conversion macros */
+static inline uint32_t
+chimera_nfs_hton32(uint32_t value)
+{
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+    return __builtin_bswap32(value);
+#else // if __BYTE_ORDER == __LITTLE_ENDIAN
+    return value;
+#endif // if __BYTE_ORDER == __LITTLE_ENDIAN
+} /* chimera_nfs_hton32 */
+
+static inline uint64_t
+chimera_nfs_hton64(uint64_t value)
+{
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+    return __builtin_bswap64(value);
+#else // if __BYTE_ORDER == __LITTLE_ENDIAN
+    return value;
+#endif // if __BYTE_ORDER == __LITTLE_ENDIAN
+} /* chimera_nfs_hton64 */
 
 #define chimera_nfsclient_debug(...) chimera_debug("nfsclient", \
                                                    __FILE__, \
@@ -57,6 +80,18 @@ enum chimera_nfs_client_mount_state {
     CHIMERA_NFS_CLIENT_MOUNT_STATE_MOUNTED,
 };
 
+/*
+ * NFS4 client session state
+ * Holds the session information established via EXCHANGE_ID + CREATE_SESSION
+ */
+struct chimera_nfs4_client_session {
+    uint8_t   sessionid[NFS4_SESSIONID_SIZE];
+    uint64_t  clientid;
+    uint32_t  max_slots;           /* Maximum slots from server (ca_maxrequests) */
+    uint32_t  next_slot_id;        /* Next slot ID to assign to a thread */
+    uint32_t *slot_seqids;         /* Per-slot sequence IDs (array of max_slots) */
+};
+
 struct chimera_nfs_client_mount;
 
 struct chimera_nfs_client_server_thread {
@@ -68,30 +103,37 @@ struct chimera_nfs_client_server_thread {
     struct evpl_rpc2_conn            *mount_conn;
     struct evpl_rpc2_conn            *nfs_conn;
     struct evpl_rpc2_conn            *nlm_conn;
+
+    uint32_t                          slot_id;     /* This thread's assigned NFS4.1 slot */
 };
 
 struct chimera_nfs_client_server {
-    struct chimera_nfs_shared  *shared;
-    int                         state;
-    int                         refcnt;
-    int                         nfsvers;
-    int                         index;
-    int                         use_rdma;
-    enum evpl_protocol_id       rdma_protocol;
+    struct chimera_nfs_shared          *shared;
+    int                                 state;
+    int                                 refcnt;
+    int                                 nfsvers;
+    int                                 index;
+    int                                 use_rdma;
+    enum evpl_protocol_id               rdma_protocol;
 
-    struct evpl_endpoint       *portmap_endpoint;
-    struct evpl_endpoint       *mount_endpoint;
-    struct evpl_endpoint       *nfs_endpoint;
-    struct evpl_endpoint       *nlm_endpoint;
+    struct evpl_endpoint               *portmap_endpoint;
+    struct evpl_endpoint               *mount_endpoint;
+    struct evpl_endpoint               *nfs_endpoint;
+    struct evpl_endpoint               *nlm_endpoint;
 
-    uint16_t                    mount_port;
-    uint16_t                    nfs_port;
-    uint16_t                    nlm_port;
+    uint16_t                            mount_port;
+    uint16_t                            nfs_port;
+    uint16_t                            nlm_port;
 
-    struct chimera_vfs_request *pending_mounts;
+    struct chimera_vfs_request         *pending_mounts;
 
-    char                        hostname[256];
+    char                                hostname[256];
 
+    /* NFS4-specific fields (only used when nfsvers == 4) */
+    struct chimera_nfs4_client_session *nfs4_session;
+    uint8_t                             nfs4_verifier[NFS4_VERIFIER_SIZE];
+    char                                nfs4_owner_id[128];
+    int                                 nfs4_owner_id_len;
 };
 
 struct chimera_nfs_client_mount {
@@ -166,6 +208,7 @@ chimera_nfs_thread_get_server_thread(
     int                        fhlen)
 {
     struct chimera_nfs_client_server_thread *server_thread = NULL;
+    struct chimera_nfs4_client_session      *session;
     int                                      index;
 
     if (unlikely(fhlen < CHIMERA_VFS_MOUNT_ID_SIZE + 1)) {
@@ -190,6 +233,14 @@ chimera_nfs_thread_get_server_thread(
         thread->server_threads[index]->thread = thread;
         thread->server_threads[index]->shared = thread->shared;
         thread->server_threads[index]->server = thread->shared->servers[index];
+
+        /* Assign a slot ID for NFS4.1 sessions */
+        session = thread->shared->servers[index]->nfs4_session;
+        if (session && session->max_slots > 0) {
+            /* Round-robin slot assignment. If more threads than slots, they share. */
+            thread->server_threads[index]->slot_id = session->next_slot_id % session->max_slots;
+            session->next_slot_id++;
+        }
     }
 
     server_thread = thread->server_threads[index];
@@ -212,7 +263,7 @@ chimera_nfs_thread_get_server_thread(
     }
 
     return server_thread;
-} // chimera_nfs_thread_get_server_thread
+} // chimera_nfs_thread_get_server_thread // chimera_nfs_thread_get_server_thread
 
 static inline void
 chimera_nfs3_map_fh(
@@ -225,6 +276,294 @@ chimera_nfs3_map_fh(
     *mapped_fh    = (uint8_t *) fh + CHIMERA_VFS_MOUNT_ID_SIZE + 1;
     *mapped_fhlen = fhlen - CHIMERA_VFS_MOUNT_ID_SIZE - 1;
 } // chimera_nfs3_map_fh
+
+/*
+ * Map local file handle to remote NFS4 file handle
+ * Same format as NFS3: [mount_id (16 bytes)][server_index (1 byte)][remote_fh]
+ */
+static inline void
+chimera_nfs4_map_fh(
+    const uint8_t *fh,
+    int            fhlen,
+    uint8_t      **mapped_fh,
+    int           *mapped_fhlen)
+{
+    /* Skip mount_id (16 bytes) + server_index (1 byte) to get remote NFS fh */
+    *mapped_fh    = (uint8_t *) fh + CHIMERA_VFS_MOUNT_ID_SIZE + 1;
+    *mapped_fhlen = fhlen - CHIMERA_VFS_MOUNT_ID_SIZE - 1;
+} // chimera_nfs4_map_fh
+
+/*
+ * Get the next sequence ID for an NFS4 session and increment it
+ */
+static inline uint32_t
+chimera_nfs4_get_sequenceid(
+    struct chimera_nfs4_client_session *session,
+    uint32_t                            slot_id)
+{
+    return session->slot_seqids[slot_id]++;
+} // chimera_nfs4_get_sequenceid // chimera_nfs4_get_sequenceid
+
+/*
+ * Byte-order conversion helpers
+ */
+static inline uint32_t
+chimera_nfs_ntoh32(uint32_t value)
+{
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+    return __builtin_bswap32(value);
+#else // if __BYTE_ORDER == __LITTLE_ENDIAN
+    return value;
+#endif // if __BYTE_ORDER == __LITTLE_ENDIAN
+} // chimera_nfs_ntoh32
+
+static inline uint64_t
+chimera_nfs_ntoh64(uint64_t value)
+{
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+    return __builtin_bswap64(value);
+#else // if __BYTE_ORDER == __LITTLE_ENDIAN
+    return value;
+#endif // if __BYTE_ORDER == __LITTLE_ENDIAN
+} // chimera_nfs_ntoh64
+
+/*
+ * Convert NFS4 status to VFS error code
+ */
+static inline enum chimera_vfs_error
+chimera_nfs4_status_to_errno(nfsstat4 status)
+{
+    switch (status) {
+        case NFS4_OK:
+            return CHIMERA_VFS_OK;
+        case NFS4ERR_PERM:
+            return CHIMERA_VFS_EPERM;
+        case NFS4ERR_NOENT:
+            return CHIMERA_VFS_ENOENT;
+        case NFS4ERR_IO:
+            return CHIMERA_VFS_EIO;
+        case NFS4ERR_NXIO:
+            return CHIMERA_VFS_ENXIO;
+        case NFS4ERR_ACCESS:
+            return CHIMERA_VFS_EACCES;
+        case NFS4ERR_EXIST:
+            return CHIMERA_VFS_EEXIST;
+        case NFS4ERR_XDEV:
+            return CHIMERA_VFS_EXDEV;
+        case NFS4ERR_NOTDIR:
+            return CHIMERA_VFS_ENOTDIR;
+        case NFS4ERR_ISDIR:
+            return CHIMERA_VFS_EISDIR;
+        case NFS4ERR_INVAL:
+            return CHIMERA_VFS_EINVAL;
+        case NFS4ERR_FBIG:
+            return CHIMERA_VFS_EFBIG;
+        case NFS4ERR_NOSPC:
+            return CHIMERA_VFS_ENOSPC;
+        case NFS4ERR_ROFS:
+            return CHIMERA_VFS_EROFS;
+        case NFS4ERR_MLINK:
+            return CHIMERA_VFS_EMLINK;
+        case NFS4ERR_NAMETOOLONG:
+            return CHIMERA_VFS_ENAMETOOLONG;
+        case NFS4ERR_NOTEMPTY:
+            return CHIMERA_VFS_ENOTEMPTY;
+        case NFS4ERR_DQUOT:
+            return CHIMERA_VFS_EDQUOT;
+        case NFS4ERR_STALE:
+        case NFS4ERR_FHEXPIRED:
+        case NFS4ERR_STALE_CLIENTID:
+        case NFS4ERR_STALE_STATEID:
+            return CHIMERA_VFS_ESTALE;
+        case NFS4ERR_BAD_COOKIE:
+            return CHIMERA_VFS_EBADCOOKIE;
+        case NFS4ERR_BADHANDLE:
+            return CHIMERA_VFS_EBADF;
+        case NFS4ERR_NOTSUPP:
+            return CHIMERA_VFS_ENOTSUP;
+        case NFS4ERR_TOOSMALL:
+            return CHIMERA_VFS_EOVERFLOW;
+        case NFS4ERR_SERVERFAULT:
+            return CHIMERA_VFS_EFAULT;
+        default:
+            return CHIMERA_VFS_EINVAL;
+    } // switch
+} // chimera_nfs4_status_to_errno
+
+/*
+ * Unmarshall a file handle from NFS4 GETFH response
+ * Builds local FH: [parent_mount_id][server_index][remote_fh]
+ */
+static inline void
+chimera_nfs4_unmarshall_fh(
+    const xdr_opaque         *fh,
+    int                       server_index,
+    const void               *parent_fh,
+    struct chimera_vfs_attrs *attr)
+{
+    uint8_t fragment[CHIMERA_VFS_FH_SIZE];
+    int     fragment_len;
+
+    /* Build fh_fragment: [server_index][remote_fh_data] */
+    fragment[0] = server_index;
+    memcpy(fragment + 1, fh->data, fh->len);
+    fragment_len = 1 + fh->len;
+
+    attr->va_set_mask |= CHIMERA_VFS_ATTR_FH;
+    attr->va_fh_len    = chimera_vfs_encode_fh_parent(parent_fh, fragment, fragment_len, attr->va_fh);
+} // chimera_nfs4_unmarshall_fh
+
+/*
+ * Unmarshall attributes from NFS4 GETATTR response
+ * This is a simplified version - it only handles basic attributes encoded
+ * in the fattr4 structure.
+ */
+static inline void
+chimera_nfs4_unmarshall_fattr(
+    const struct fattr4      *fattr,
+    struct chimera_vfs_attrs *attr)
+{
+    void    *data    = fattr->attr_vals.data;
+    void    *dataend = data + fattr->attr_vals.len;
+    uint32_t type;
+
+    if (fattr->num_attrmask < 1) {
+        return;
+    }
+
+    /* Parse attributes based on bitmap - they appear in order */
+    if (fattr->attrmask[0] & (1 << FATTR4_TYPE)) {
+        if (data + sizeof(uint32_t) > dataend) {
+            return;
+        }
+        type               = chimera_nfs_ntoh32(*(uint32_t *) data);
+        data              += sizeof(uint32_t);
+        attr->va_set_mask |= CHIMERA_VFS_ATTR_MODE;
+        switch (type) {
+            case NF4REG:
+                attr->va_mode = S_IFREG;
+                break;
+            case NF4DIR:
+                attr->va_mode = S_IFDIR;
+                break;
+            case NF4BLK:
+                attr->va_mode = S_IFBLK;
+                break;
+            case NF4CHR:
+                attr->va_mode = S_IFCHR;
+                break;
+            case NF4LNK:
+                attr->va_mode = S_IFLNK;
+                break;
+            case NF4SOCK:
+                attr->va_mode = S_IFSOCK;
+                break;
+            case NF4FIFO:
+                attr->va_mode = S_IFIFO;
+                break;
+            default:
+                attr->va_mode = S_IFREG;
+                break;
+        } // switch
+    }
+
+    if (fattr->attrmask[0] & (1 << FATTR4_SIZE)) {
+        if (data + sizeof(uint64_t) > dataend) {
+            return;
+        }
+        attr->va_size      = chimera_nfs_ntoh64(*(uint64_t *) data);
+        data              += sizeof(uint64_t);
+        attr->va_set_mask |= CHIMERA_VFS_ATTR_SIZE;
+    }
+
+    if (fattr->attrmask[0] & (1 << FATTR4_FILEID)) {
+        if (data + sizeof(uint64_t) > dataend) {
+            return;
+        }
+        attr->va_ino       = chimera_nfs_ntoh64(*(uint64_t *) data);
+        data              += sizeof(uint64_t);
+        attr->va_set_mask |= CHIMERA_VFS_ATTR_INUM;
+    }
+
+    if (fattr->num_attrmask < 2) {
+        return;
+    }
+
+    if (fattr->attrmask[1] & (1 << (FATTR4_MODE - 32))) {
+        if (data + sizeof(uint32_t) > dataend) {
+            return;
+        }
+        attr->va_mode     |= chimera_nfs_ntoh32(*(uint32_t *) data) & ~S_IFMT;
+        data              += sizeof(uint32_t);
+        attr->va_set_mask |= CHIMERA_VFS_ATTR_MODE;
+    }
+
+    if (fattr->attrmask[1] & (1 << (FATTR4_NUMLINKS - 32))) {
+        if (data + sizeof(uint32_t) > dataend) {
+            return;
+        }
+        attr->va_nlink     = chimera_nfs_ntoh32(*(uint32_t *) data);
+        data              += sizeof(uint32_t);
+        attr->va_set_mask |= CHIMERA_VFS_ATTR_NLINK;
+    }
+
+    if (fattr->attrmask[1] & (1 << (FATTR4_OWNER - 32))) {
+        uint32_t owner_len;
+        uint32_t owner_padded_len;
+        if (data + sizeof(uint32_t) > dataend) {
+            return;
+        }
+        owner_len        = chimera_nfs_ntoh32(*(uint32_t *) data);
+        data            += sizeof(uint32_t);
+        owner_padded_len = (owner_len + 3) & ~3;
+        if (data + owner_padded_len > dataend) {
+            return;
+        }
+        /* Convert string to numeric uid */
+        attr->va_uid       = strtoul(data, NULL, 10);
+        data              += owner_padded_len;
+        attr->va_set_mask |= CHIMERA_VFS_ATTR_UID;
+    }
+
+    if (fattr->attrmask[1] & (1 << (FATTR4_OWNER_GROUP - 32))) {
+        uint32_t group_len;
+        uint32_t group_padded_len;
+        if (data + sizeof(uint32_t) > dataend) {
+            return;
+        }
+        group_len        = chimera_nfs_ntoh32(*(uint32_t *) data);
+        data            += sizeof(uint32_t);
+        group_padded_len = (group_len + 3) & ~3;
+        if (data + group_padded_len > dataend) {
+            return;
+        }
+        /* Convert string to numeric gid */
+        attr->va_gid       = strtoul(data, NULL, 10);
+        data              += group_padded_len;
+        attr->va_set_mask |= CHIMERA_VFS_ATTR_GID;
+    }
+
+    if (fattr->attrmask[1] & (1 << (FATTR4_TIME_ACCESS - 32))) {
+        if (data + sizeof(uint64_t) + sizeof(uint32_t) > dataend) {
+            return;
+        }
+        attr->va_atime.tv_sec  = chimera_nfs_ntoh64(*(uint64_t *) data);
+        data                  += sizeof(uint64_t);
+        attr->va_atime.tv_nsec = chimera_nfs_ntoh32(*(uint32_t *) data);
+        data                  += sizeof(uint32_t);
+        attr->va_set_mask     |= CHIMERA_VFS_ATTR_ATIME;
+    }
+
+    if (fattr->attrmask[1] & (1 << (FATTR4_TIME_MODIFY - 32))) {
+        if (data + sizeof(uint64_t) + sizeof(uint32_t) > dataend) {
+            return;
+        }
+        attr->va_mtime.tv_sec  = chimera_nfs_ntoh64(*(uint64_t *) data);
+        data                  += sizeof(uint64_t);
+        attr->va_mtime.tv_nsec = chimera_nfs_ntoh32(*(uint32_t *) data);
+        attr->va_set_mask     |= CHIMERA_VFS_ATTR_MTIME;
+    }
+} // chimera_nfs4_unmarshall_fattr
 
 /*
  * Initialize an RPC2 credential for AUTH_SYS from a VFS credential.
@@ -430,6 +769,11 @@ void chimera_nfs4_open_at(
     struct chimera_vfs_request *,
     void *);
 void chimera_nfs4_close(
+    struct chimera_nfs_thread *,
+    struct chimera_nfs_shared *,
+    struct chimera_vfs_request *,
+    void *);
+void chimera_nfs4_umount(
     struct chimera_nfs_thread *,
     struct chimera_nfs_shared *,
     struct chimera_vfs_request *,

--- a/src/vfs/vfs_proc_read.c
+++ b/src/vfs/vfs_proc_read.c
@@ -63,6 +63,9 @@ chimera_vfs_read(
     request->read.length             = count;
     request->read.iov                = iov;
     request->read.niov               = niov;
+    request->read.r_length           = 0;
+    request->read.r_niov             = 0;
+    request->read.r_eof              = 0;
     request->read.r_attr.va_req_mask = attr_mask | CHIMERA_VFS_ATTR_MASK_CACHEABLE;
     request->read.r_attr.va_set_mask = 0;
     request->proto_callback          = callback;


### PR DESCRIPTION
## Summary
- Adds NFS4.1 client as a VFS backend module (`src/vfs/nfs/nfs4_*`)
- Implements core NFSv4.1 operations: mount, open, close, read, write, getattr, setattr, lookup, mkdir, remove, rename, link, symlink, readlink, readdir, open_at, umount
- Client-side open state tracking for stateid management
- NFS4 backend test configurations for POSIX, FSX, cthon, and stress tests

This is just a first pass, lots and lots of missing stuff