### PR TITLE
Add configurable watchdog timeout and protocol-level watchdog support

### DIFF
--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -297,6 +297,12 @@ main(
         chimera_server_config_set_delegation_threads(server_config, int_value);
     }
 
+    json_value = json_object_get(server_params, "watchdog_timeout");
+    if (json_is_integer(json_value)) {
+        int_value = json_integer_value(json_value);
+        chimera_server_config_set_watchdog_timeout(server_config, int_value);
+    }
+
     json_value = json_object_get(server_params, "external_portmap");
     if (json_is_true(json_value)) {
         chimera_server_info("Enabling external portmap/rpcbind support");

--- a/src/server/nfs/nfs.c
+++ b/src/server/nfs/nfs.c
@@ -366,6 +366,16 @@ nfs_server_thread_destroy(void *data)
     free(thread);
 } /* nfs_server_thread_destroy */
 
+static void
+nfs_server_watchdog(
+    void    *data,
+    uint64_t timeout_ns)
+{
+    struct chimera_server_nfs_thread *thread = data;
+
+    evpl_rpc2_thread_watchdog(thread->rpc2_thread, timeout_ns);
+} /* nfs_server_watchdog */
+
 SYMBOL_EXPORT void
 chimera_nfs_add_export(
     void       *nfs_shared,
@@ -468,4 +478,5 @@ SYMBOL_EXPORT struct chimera_server_protocol nfs_protocol = {
     .stop           = nfs_server_stop,
     .thread_init    = nfs_server_thread_init,
     .thread_destroy = nfs_server_thread_destroy,
+    .watchdog       = nfs_server_watchdog,
 };

--- a/src/server/protocol.h
+++ b/src/server/protocol.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -32,4 +32,8 @@ struct chimera_server_protocol {
         void                      *data);
     void  (*thread_destroy)(
         void *data);
+
+    void  (*watchdog)(
+        void    *thread_private,
+        uint64_t timeout_ns);
 };

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -204,6 +204,15 @@ uint32_t
 chimera_server_config_get_anongid(
     const struct chimera_server_config *config);
 
+void
+chimera_server_config_set_watchdog_timeout(
+    struct chimera_server_config *config,
+    int                           watchdog_timeout_secs);
+
+int
+chimera_server_config_get_watchdog_timeout(
+    const struct chimera_server_config *config);
+
 static void
 chimera_server_thread_wake(
     struct evpl       *evpl,

--- a/src/vfs/vfs.c
+++ b/src/vfs/vfs.c
@@ -541,7 +541,9 @@ chimera_vfs_process_completion(
 } /* chimera_vfs_process_completion */
 
 SYMBOL_EXPORT void
-chimera_vfs_watchdog(struct chimera_vfs_thread *thread)
+chimera_vfs_watchdog(
+    struct chimera_vfs_thread *thread,
+    uint64_t                   timeout_ns)
 {
     struct chimera_vfs_request *request;
     struct timespec             now;
@@ -557,12 +559,14 @@ chimera_vfs_watchdog(struct chimera_vfs_thread *thread)
 
     elapsed = chimera_get_elapsed_ns(&now, &request->start_time);
 
-    if (elapsed > 10000000000UL) {
-        chimera_vfs_debug("oldest request has been active for %lu ns", elapsed);
-        chimera_vfs_dump_request(request);
+    if (elapsed > timeout_ns) {
+        chimera_vfs_error("VFS request stuck for %.1fs: opcode=%d num_active=%d",
+                          (double) elapsed / 1e9,
+                          request->opcode,
+                          thread->num_active_requests);
     }
 
-} /* chimera_vfs_watchdog_callback */
+} /* chimera_vfs_watchdog */
 
 SYMBOL_EXPORT struct chimera_vfs_thread *
 chimera_vfs_thread_init(

--- a/src/vfs/vfs.h
+++ b/src/vfs/vfs.h
@@ -989,4 +989,5 @@ chimera_vfs_iterate_builtin_users(
     void                       *data);
 void
 chimera_vfs_watchdog(
-    struct chimera_vfs_thread *thread);
+    struct chimera_vfs_thread *thread,
+    uint64_t                   timeout_ns);


### PR DESCRIPTION
## Summary
- Make watchdog timeout configurable via server.watchdog_timeout JSON config (default: 10 seconds)
- Upgrade VFS watchdog logging from debug to error level for immediate visibility into stuck operations
- Add optional watchdog callback to protocol interface, with NFS implementation that checks RPC-level timeouts