### PR TITLE
Add PyNFS test suite integration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -84,6 +84,13 @@ RUN apt-get -y update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
+RUN apt-get -y update && \
+    apt-get -y --no-install-recommends install python3-ply python3-gssapi python3-pip && \
+    pip3 install --break-system-packages xdrlib3 && \
+    git clone --depth 1 https://github.com/chimera-nas/pynfs.git /opt/pynfs && \
+    cd /opt/pynfs && python3 ./setup.py build && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
 RUN if [ "$ENABLE_UV" = "1" ] ; then \
     curl -LsSf https://astral.sh/uv/install.sh | sh ; \
     fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,6 +165,15 @@ else()
     message(STATUS "KVM testing disabled")
 endif()
 
+# PyNFS testing detection
+find_package(Python3 COMPONENTS Interpreter QUIET)
+if(Python3_FOUND AND EXISTS "/opt/pynfs/nfs4.0/testserver.py")
+    message(STATUS "PyNFS testing enabled")
+    add_subdirectory(pynfs)
+else()
+    message(STATUS "PyNFS testing disabled")
+endif()
+
 add_subdirectory(ext)
 
 include_directories(ext/libevpl/include)

--- a/pynfs/CMakeLists.txt
+++ b/pynfs/CMakeLists.txt
@@ -40,7 +40,6 @@ foreach(minor ${PYNFS_MINOR_VERSIONS})
             set_tests_properties(chimera/pynfs/${flag}_${backend}_nfs4.${minor}
                 PROPERTIES
                     LABELS pynfs
-                    TIMEOUT 300
                     ENVIRONMENT "PYTHONUNBUFFERED=1")
         endforeach()
     endforeach()
@@ -56,7 +55,6 @@ if(CAIRN_ENABLED)
             set_tests_properties(chimera/pynfs/${flag}_cairn_nfs4.${minor}
                 PROPERTIES
                     LABELS pynfs
-                    TIMEOUT 300
                     ENVIRONMENT "PYTHONUNBUFFERED=1")
         endforeach()
     endforeach()

--- a/pynfs/CMakeLists.txt
+++ b/pynfs/CMakeLists.txt
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+#
+# SPDX-License-Identifier: Unlicense
+
+set(CHIMERA_BINARY ${CMAKE_BINARY_DIR}/src/daemon/chimera)
+set(PYNFS_WRAPPER ${CMAKE_SOURCE_DIR}/scripts/pynfs_test_wrapper.sh)
+set(PYNFS_DIR /opt/pynfs)
+
+set(PYNFS_BACKENDS memfs linux io_uring demofs_io_uring)
+
+if(HAVE_LIBAIO)
+    list(APPEND PYNFS_BACKENDS demofs_aio)
+endif()
+
+# NFSv4.0 test flags
+set(PYNFS_FLAGS_0
+    access acl close commit compound create getattr getfh link lock lockt locku
+    lookup lookupp nverify open openconfirm opendowngrade putfh putpubfh putrootfh
+    read readdir readlink releaselockowner remove rename renew replay restorefh
+    savefh secinfo setattr setclientid setclientidconfirm verify write)
+
+# NFSv4.1 test flags
+set(PYNFS_FLAGS_1
+    compound courteous create_session currentstateid deleg destroy_clientid
+    destroy_session exchange_id getfh lookup lookupp open putfh reclaim_complete
+    rename sequence verify xattr)
+
+# NFSv4.2 test flags (4.1 flags plus copy and sparse)
+set(PYNFS_FLAGS_2 ${PYNFS_FLAGS_1} copy sparse)
+
+set(PYNFS_MINOR_VERSIONS 0 1 2)
+
+foreach(minor ${PYNFS_MINOR_VERSIONS})
+    foreach(flag ${PYNFS_FLAGS_${minor}})
+        foreach(backend ${PYNFS_BACKENDS})
+            add_test(NAME chimera/pynfs/${flag}_${backend}_nfs4.${minor}
+                COMMAND bash ${PYNFS_WRAPPER}
+                        ${CHIMERA_BINARY} ${backend} ${minor} ${PYNFS_DIR}
+                        ${flag})
+            set_tests_properties(chimera/pynfs/${flag}_${backend}_nfs4.${minor}
+                PROPERTIES
+                    LABELS pynfs
+                    TIMEOUT 300
+                    ENVIRONMENT "PYTHONUNBUFFERED=1")
+        endforeach()
+    endforeach()
+endforeach()
+
+if(CAIRN_ENABLED)
+    foreach(minor ${PYNFS_MINOR_VERSIONS})
+        foreach(flag ${PYNFS_FLAGS_${minor}})
+            add_test(NAME chimera/pynfs/${flag}_cairn_nfs4.${minor}
+                COMMAND bash ${PYNFS_WRAPPER}
+                        ${CHIMERA_BINARY} cairn ${minor} ${PYNFS_DIR}
+                        ${flag})
+            set_tests_properties(chimera/pynfs/${flag}_cairn_nfs4.${minor}
+                PROPERTIES
+                    LABELS pynfs
+                    TIMEOUT 300
+                    ENVIRONMENT "PYTHONUNBUFFERED=1")
+        endforeach()
+    endforeach()
+endif()

--- a/scripts/pynfs_test_wrapper.sh
+++ b/scripts/pynfs_test_wrapper.sh
@@ -1,0 +1,209 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+#
+# SPDX-License-Identifier: Unlicense
+
+# Usage: pynfs_test_wrapper.sh <chimera_binary> <backend> <nfs_minor_version> <pynfs_dir> <flag_args...>
+#
+# Orchestrates a chimera NFS server + pynfs test suite in a network namespace.
+# 1. Generates chimera config for the given backend
+# 2. Creates a network namespace with loopback
+# 3. Starts chimera daemon in the netns (127.0.0.1:2049)
+# 4. Runs pynfs testserver.py with the given flags
+# 5. Checks JSON results for failures
+# 6. Captures exit code and cleans up
+
+set -u
+
+# Save and clear LD_PRELOAD immediately to avoid ASAN interference with
+# system binaries (ip, sysctl, etc.) which exit non-zero under ASAN.
+# LD_PRELOAD is restored only for the chimera daemon.
+SAVED_LD_PRELOAD="${LD_PRELOAD:-}"
+unset LD_PRELOAD
+
+CHIMERA_BINARY=$1; shift
+BACKEND=$1; shift
+NFS_MINOR_VERSION=$1; shift
+PYNFS_DIR=$1; shift
+FLAG_ARGS="$*"
+
+NETNS_NAME="pynfs_$$_$(date +%s%N)"
+BUILD_DIR=$(dirname "$(dirname "$CHIMERA_BINARY")")
+SESSION_DIR=$(mktemp -d "${BUILD_DIR}/pynfs_session_XXXXXX")
+CONFIG_FILE="${SESSION_DIR}/chimera.json"
+RESULTS_FILE="${SESSION_DIR}/results.json"
+CHIMERA_PID=""
+CHIMERA_LOG="${SESSION_DIR}/chimera_stderr.log"
+
+cleanup() {
+    if [ -n "$CHIMERA_PID" ]; then
+        kill "$CHIMERA_PID" 2>/dev/null || true
+        for i in $(seq 1 30); do
+            kill -0 "$CHIMERA_PID" 2>/dev/null || break
+            sleep 0.1
+        done
+        if kill -0 "$CHIMERA_PID" 2>/dev/null; then
+            echo "=== Chimera shutdown hung, force killing ==="
+            kill -9 "$CHIMERA_PID" 2>/dev/null || true
+        fi
+        wait "$CHIMERA_PID" 2>/dev/null || true
+    fi
+    if [ -f "$CHIMERA_LOG" ]; then
+        echo "=== Chimera stderr (last 100 lines) ==="
+        tail -100 "$CHIMERA_LOG"
+    fi
+    ip netns delete "${NETNS_NAME}" 2>/dev/null || true
+    rm -rf "$SESSION_DIR"
+}
+trap cleanup EXIT
+
+# Generate chimera config based on backend
+generate_config() {
+    local mount_path="/"
+    local vfs_section=""
+
+    case "$BACKEND" in
+        linux|io_uring)
+            mount_path="$SESSION_DIR/data"
+            mkdir -p "$SESSION_DIR/data"
+            ;;
+        memfs)
+            mount_path="/"
+            ;;
+        demofs_io_uring|demofs_aio)
+            local device_type="io_uring"
+            if [ "$BACKEND" = "demofs_aio" ]; then
+                device_type="libaio"
+            fi
+            local devices_json=""
+            for i in $(seq 0 9); do
+                local device_path="${SESSION_DIR}/device-${i}.img"
+                truncate -s 256G "$device_path"
+                if [ $i -gt 0 ]; then
+                    devices_json="${devices_json},"
+                fi
+                devices_json="${devices_json}{\"type\":\"$device_type\",\"size\":1,\"path\":\"$device_path\"}"
+            done
+            mount_path="/"
+            BACKEND="demofs"
+            vfs_section="\"vfs\": {
+                \"demofs\": {
+                    \"config\": {\"devices\":[$devices_json]}
+                }
+            },"
+            ;;
+        cairn)
+            mount_path="/"
+            vfs_section="\"vfs\": {
+                \"cairn\": {
+                    \"config\": {\"initialize\":true,\"path\":\"$SESSION_DIR\"}
+                }
+            },"
+            ;;
+    esac
+
+    cat > "$CONFIG_FILE" << EOF
+{
+    "server": {
+        "threads": 4,
+        "delegation_threads": 4,
+        $vfs_section
+        "external_portmap": false
+    },
+    "mounts": {
+        "share": {
+            "module": "$BACKEND",
+            "path": "$mount_path"
+        }
+    },
+    "exports": {
+        "/share": {
+            "path": "/share"
+        }
+    }
+}
+EOF
+}
+
+generate_config
+
+# Create network namespace
+ip netns add "${NETNS_NAME}"
+ip netns exec "${NETNS_NAME}" ip link set lo up
+
+ulimit -l unlimited
+sysctl -q -w fs.aio-max-nr=2097152 2>/dev/null || true
+
+# Start chimera daemon in the netns (restore LD_PRELOAD for chimera only)
+if [ -n "${SAVED_LD_PRELOAD}" ]; then
+    ip netns exec "${NETNS_NAME}" env LD_PRELOAD="${SAVED_LD_PRELOAD}" "$CHIMERA_BINARY" -c "$CONFIG_FILE" 2>"$CHIMERA_LOG" &
+else
+    ip netns exec "${NETNS_NAME}" "$CHIMERA_BINARY" -c "$CONFIG_FILE" 2>"$CHIMERA_LOG" &
+fi
+CHIMERA_PID=$!
+
+# Wait for NFS port to be ready
+for i in $(seq 1 30); do
+    if ip netns exec "${NETNS_NAME}" bash -c "echo > /dev/tcp/127.0.0.1/2049" 2>/dev/null; then
+        break
+    fi
+    if ! kill -0 "$CHIMERA_PID" 2>/dev/null; then
+        echo "chimera daemon exited prematurely"
+        exit 1
+    fi
+    sleep 0.1
+done
+
+# Run pynfs tests based on NFS minor version
+# Flags are passed as positional arguments to testserver.py
+# --jsonout writes structured results for failure detection
+# PYTHONPATH includes pynfs root for shared modules (rpc, xdr)
+export PYTHONPATH="${PYNFS_DIR}:${PYTHONPATH:-}"
+
+if [ "$NFS_MINOR_VERSION" = "0" ]; then
+    TESTSERVER="${PYNFS_DIR}/nfs4.0/testserver.py"
+    # shellcheck disable=SC2086
+    ip netns exec "${NETNS_NAME}" python3 "${TESTSERVER}" 127.0.0.1:/share \
+        --maketree --force -v --json="${RESULTS_FILE}" $FLAG_ARGS
+elif [ "$NFS_MINOR_VERSION" = "1" ]; then
+    TESTSERVER="${PYNFS_DIR}/nfs4.1/testserver.py"
+    # shellcheck disable=SC2086
+    ip netns exec "${NETNS_NAME}" python3 "${TESTSERVER}" 127.0.0.1:/share \
+        --minorversion=1 --maketree --force -v --json="${RESULTS_FILE}" $FLAG_ARGS
+elif [ "$NFS_MINOR_VERSION" = "2" ]; then
+    TESTSERVER="${PYNFS_DIR}/nfs4.1/testserver.py"
+    # shellcheck disable=SC2086
+    ip netns exec "${NETNS_NAME}" python3 "${TESTSERVER}" 127.0.0.1:/share \
+        --minorversion=2 --maketree --force -v --json="${RESULTS_FILE}" $FLAG_ARGS
+else
+    echo "Unsupported NFS minor version: $NFS_MINOR_VERSION"
+    exit 1
+fi
+PYNFS_EXIT=$?
+
+# Check if chimera is still alive after tests
+if ! kill -0 "$CHIMERA_PID" 2>/dev/null; then
+    wait "$CHIMERA_PID" 2>/dev/null
+    CHIMERA_EXIT=$?
+    echo "=== Chimera daemon DIED during test (exit code: $CHIMERA_EXIT) ==="
+    CHIMERA_PID=""
+fi
+
+# If pynfs itself failed (crash, connection error, etc.), propagate that
+if [ "$PYNFS_EXIT" -ne 0 ]; then
+    exit "$PYNFS_EXIT"
+fi
+
+# Check JSON results for test failures
+if [ -f "$RESULTS_FILE" ]; then
+    FAILURES=$(jq '.failures' "$RESULTS_FILE" 2>/dev/null)
+    if [ "$FAILURES" != "0" ] && [ -n "$FAILURES" ]; then
+        echo "=== PyNFS reported $FAILURES test failure(s) ==="
+        exit 1
+    fi
+else
+    echo "=== PyNFS results file not found ==="
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

- Integrates the [PyNFS](https://github.com/chimera-nas/pynfs) test suite for NFS4 protocol correctness testing (679 NFSv4.0 tests, 264 NFSv4.1/4.2 tests)
- PyNFS acts as a userspace NFS client connecting directly over TCP, so tests use lightweight network namespace isolation (no kernel mount or KVM required)
- Registers 450 ctest entries across test flags, VFS backends (memfs, linux, io_uring, demofs, cairn), and NFS minor versions (4.0, 4.1, 4.2)
- Wrapper uses pynfs `--json` output to detect subtest failures and propagate them as ctest failures

## Files

| File | Description |
|------|-------------|
| `.devcontainer/Dockerfile` | Install pynfs and Python dependencies |
| `scripts/pynfs_test_wrapper.sh` | Orchestrate chimera + pynfs in a network namespace |
| `pynfs/CMakeLists.txt` | Register ctest entries for all flag/backend/version combinations |
| `CMakeLists.txt` | Add `add_subdirectory(pynfs)` conditional on Python3 + pynfs availability |

## Usage

```bash
# Run all pynfs tests
ctest -L pynfs --output-on-failure

# Run a specific test
ctest -R chimera/pynfs/access_memfs_nfs4.0 --output-on-failure -V

# Run all tests for a specific NFS version
ctest -R 'chimera/pynfs/.*nfs4\.1' --output-on-failure
```