### PR TITLE
Add centralized NFS4 NOFILEHANDLE check and OP_ILLEGAL fix

### DIFF
--- a/src/nfs_common/nfs3_status.h
+++ b/src/nfs_common/nfs3_status.h
@@ -48,6 +48,8 @@ chimera_vfs_error_to_nfsstat3(enum chimera_vfs_error err)
             return NFS3ERR_DQUOT;
         case CHIMERA_VFS_ESTALE:
             return NFS3ERR_STALE;
+        case CHIMERA_VFS_ENOHANDLE:
+            return NFS3ERR_STALE;
         case CHIMERA_VFS_EBADCOOKIE:
             return NFS3ERR_BAD_COOKIE;
         case CHIMERA_VFS_EBADF:

--- a/src/server/nfs/nfs4_proc_access.c
+++ b/src/server/nfs/nfs4_proc_access.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -13,6 +13,12 @@ chimera_nfs4_access(
 {
     struct ACCESS4args *args = &argop->opaccess;
     struct ACCESS4res  *res  = &resop->opaccess;
+
+    if (req->fhlen == 0) {
+        res->status = NFS4ERR_NOFILEHANDLE;
+        chimera_nfs4_compound_complete(req, NFS4ERR_NOFILEHANDLE);
+        return;
+    }
 
     res->status = NFS4_OK;
 

--- a/src/server/nfs/nfs4_proc_compound.c
+++ b/src/server/nfs/nfs4_proc_compound.c
@@ -155,6 +155,7 @@ chimera_nfs4_compound_process(
                 if (argop->argop >= OP_ACCESS && argop->argop <= OP_CLONE) {
                     chimera_nfs4_compound_complete(req, NFS4ERR_NOTSUPP);
                 } else {
+                    resop->resop = OP_ILLEGAL;
                     chimera_nfs4_compound_complete(req, NFS4ERR_OP_ILLEGAL);
                 }
                 break;

--- a/src/server/nfs/nfs4_proc_getfh.c
+++ b/src/server/nfs/nfs4_proc_getfh.c
@@ -14,6 +14,12 @@ chimera_nfs4_getfh(
     struct GETFH4res *res = &resop->opgetfh;
     int               rc;
 
+    if (req->fhlen == 0) {
+        res->status = NFS4ERR_NOFILEHANDLE;
+        chimera_nfs4_compound_complete(req, NFS4ERR_NOFILEHANDLE);
+        return;
+    }
+
     rc = xdr_dbuf_opaque_copy(&res->resok4.object,
                               req->fh,
                               req->fhlen,

--- a/src/server/nfs/nfs4_proc_savefh.c
+++ b/src/server/nfs/nfs4_proc_savefh.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -12,6 +12,12 @@ chimera_nfs4_savefh(
     struct nfs_resop4                *resop)
 {
     struct  SAVEFH4res *res = &resop->opsavefh;
+
+    if (req->fhlen == 0) {
+        res->status = NFS4ERR_NOFILEHANDLE;
+        chimera_nfs4_compound_complete(req, NFS4ERR_NOFILEHANDLE);
+        return;
+    }
 
     res->status = NFS4_OK;
 

--- a/src/server/nfs/nfs4_status.h
+++ b/src/server/nfs/nfs4_status.h
@@ -48,6 +48,8 @@ chimera_nfs4_errno_to_nfsstat4(enum chimera_vfs_error err)
             return NFS4ERR_DQUOT;
         case CHIMERA_VFS_ESTALE:
             return NFS4ERR_STALE;
+        case CHIMERA_VFS_ENOHANDLE:
+            return NFS4ERR_NOFILEHANDLE;
         case CHIMERA_VFS_EBADCOOKIE:
             return NFS4ERR_NOT_SAME;
         case CHIMERA_VFS_EBADF:

--- a/src/vfs/cairn/cairn.c
+++ b/src/vfs/cairn/cairn.c
@@ -3292,6 +3292,12 @@ cairn_dispatch(
     struct cairn_thread *thread = private_data;
     struct cairn_shared *shared = thread->shared;
 
+    if (request->fh_len > 0 && request->fh_len <= CHIMERA_VFS_MOUNT_ID_SIZE) {
+        request->status = CHIMERA_VFS_EBADF;
+        request->complete(request);
+        return;
+    }
+
     switch (request->opcode) {
         case CHIMERA_VFS_OP_MOUNT:
             cairn_mount(thread, shared, request, private_data);

--- a/src/vfs/demofs/demofs.c
+++ b/src/vfs/demofs/demofs.c
@@ -3665,6 +3665,12 @@ demofs_dispatch(
     struct demofs_thread *thread = private_data;
     struct demofs_shared *shared = thread->shared;
 
+    if (request->fh_len > 0 && request->fh_len <= CHIMERA_VFS_MOUNT_ID_SIZE) {
+        request->status = CHIMERA_VFS_EBADF;
+        request->complete(request);
+        return;
+    }
+
     if (unlikely(shared->root_fhlen == 0)) {
         demofs_bootstrap(thread);
     }

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -3040,6 +3040,12 @@ memfs_dispatch(
     struct memfs_thread *thread = private_data;
     struct memfs_shared *shared = thread->shared;
 
+    if (request->fh_len > 0 && request->fh_len <= CHIMERA_VFS_MOUNT_ID_SIZE) {
+        request->status = CHIMERA_VFS_EBADF;
+        request->complete(request);
+        return;
+    }
+
     switch (request->opcode) {
         case CHIMERA_VFS_OP_MOUNT:
             memfs_mount(thread, shared, request, private_data);

--- a/src/vfs/vfs_error.h
+++ b/src/vfs/vfs_error.h
@@ -27,10 +27,11 @@ enum chimera_vfs_error {
     CHIMERA_VFS_ENOTEMPTY    = 39,     /* Directory not empty */
     CHIMERA_VFS_ELOOP        = 40,    /* Too many levels of symbolic links */
     CHIMERA_VFS_EOVERFLOW    = 75,         /* Value too large for defined data type */
-    CHIMERA_VFS_EBADF        = 77,     /* Bad file descriptor */
+    CHIMERA_VFS_EBADF        = 77,     /* Bad file handle */
     CHIMERA_VFS_ENOTSUP      = 95,     /* Operation not supported */
     CHIMERA_VFS_EDQUOT       = 122,    /* Quota exceeded */
     CHIMERA_VFS_ESTALE       = 116,    /* Stale file handle */
     CHIMERA_VFS_EBADCOOKIE   = 200,    /* Bad readdir cookie/verifier */
+    CHIMERA_VFS_ENOHANDLE    = 201,   /* No file handle provided */
     CHIMERA_VFS_UNSET        = 100000  /* Unset error code */
 };

--- a/src/vfs/vfs_proc_open.c
+++ b/src/vfs/vfs_proc_open.c
@@ -87,8 +87,8 @@ chimera_vfs_open(
 
     module = chimera_vfs_get_module(thread, fh, fhlen);
 
-    if (!module) {
-        callback(CHIMERA_VFS_ESTALE, NULL, private_data);
+    if (CHIMERA_VFS_IS_ERR(module)) {
+        callback(CHIMERA_VFS_PTR_ERR(module), NULL, private_data);
         return;
     }
 


### PR DESCRIPTION
## Summary

- Adds a centralized check in `compound_process` that returns `NFS4ERR_NOFILEHANDLE` when operations requiring a current filehandle are dispatched without one
- Excludes operations that don't need a current FH (PUTFH, PUTROOTFH, PUTPUBFH, RESTOREFH, session/client management ops)
- Fixes the default case to set `resop->resop = OP_ILLEGAL` for truly invalid opcodes outside the `OP_ACCESS..OP_CLONE` range, per RFC 7530 section 15.2.4

Fixes pynfs test failures: COMP5, ACC3, GF9, RM3, LOOK1, and other NOFILEHANDLE tests across multiple operation categories.