### PR TITLE
Add KVM-based Windows SMB integration tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,6 +140,7 @@ else()
 endif()
 
 set(KVM_TESTING_AVAILABLE FALSE)
+set(KVM_WINDOWS_TESTING_AVAILABLE FALSE)
 
 if(DOCKER_EXECUTABLE AND QEMU_EXECUTABLE)
     execute_process(
@@ -174,8 +175,30 @@ else()
     endif()
 endif()
 
-if(KVM_TESTING_AVAILABLE)
-    message(STATUS "KVM testing enabled")
+# Windows KVM tests require QEMU + KVM + WINDOWS_SERVER_ISO + OVMF
+if(WINDOWS_SERVER_ISO AND QEMU_EXECUTABLE AND KVM_AVAILABLE)
+    # Detect OVMF firmware for UEFI boot
+    find_file(OVMF_CODE_PATH
+        NAMES OVMF_CODE_4M.fd OVMF_CODE.fd
+        PATHS /usr/share/OVMF /usr/share/edk2/ovmf /usr/share/qemu
+        NO_DEFAULT_PATH
+    )
+    if(OVMF_CODE_PATH)
+        set(KVM_WINDOWS_TESTING_AVAILABLE TRUE)
+        message(STATUS "KVM Windows testing: OVMF found at ${OVMF_CODE_PATH}")
+    else()
+        message(STATUS "KVM Windows testing: OVMF firmware not found")
+    endif()
+endif()
+
+# Enter kvm subdir if any KVM testing is available
+if(KVM_TESTING_AVAILABLE OR KVM_WINDOWS_TESTING_AVAILABLE)
+    if(KVM_TESTING_AVAILABLE)
+        message(STATUS "KVM testing enabled (Linux)")
+    endif()
+    if(KVM_WINDOWS_TESTING_AVAILABLE)
+        message(STATUS "KVM testing enabled (Windows)")
+    endif()
     add_subdirectory(kvm)
 else()
     message(STATUS "KVM testing disabled")

--- a/kvm/CMakeLists.txt
+++ b/kvm/CMakeLists.txt
@@ -19,34 +19,62 @@ set(KVM_IMAGES
     "ubuntu2204_hwe|22.04|jammy|linux-image-generic-hwe-22.04"
 )
 
-foreach(image_spec ${KVM_IMAGES})
-    string(REPLACE "|" ";" image_parts "${image_spec}")
-    list(GET image_parts 0 IMAGE_NAME)
-    list(GET image_parts 1 UBUNTU_VERSION)
-    list(GET image_parts 2 UBUNTU_VERSION_CODENAME)
-    list(GET image_parts 3 KERNEL_PACKAGE)
+# Linux VM images (requires Docker)
+if(KVM_TESTING_AVAILABLE)
+    foreach(image_spec ${KVM_IMAGES})
+        string(REPLACE "|" ";" image_parts "${image_spec}")
+        list(GET image_parts 0 IMAGE_NAME)
+        list(GET image_parts 1 UBUNTU_VERSION)
+        list(GET image_parts 2 UBUNTU_VERSION_CODENAME)
+        list(GET image_parts 3 KERNEL_PACKAGE)
 
-    set(IMAGE_DIR ${BUILD_ROOT}/kvm/${IMAGE_NAME})
+        set(IMAGE_DIR ${BUILD_ROOT}/kvm/${IMAGE_NAME})
+
+        add_custom_command(
+            OUTPUT ${IMAGE_DIR}/vmlinuz ${IMAGE_DIR}/initrd ${IMAGE_DIR}/rootfs.qcow2
+            COMMAND ${CMAKE_COMMAND} -E env
+                    KVM_CACHE_REGISTRY=${KVM_IMAGE_CACHE_REGISTRY}
+                    bash ${CMAKE_CURRENT_SOURCE_DIR}/build_vm_image.sh
+                    ${IMAGE_DIR}
+                    ${CMAKE_CURRENT_SOURCE_DIR}/Dockerfile.kvm
+                    ${CMAKE_SOURCE_DIR}
+                    UBUNTU_VERSION=${UBUNTU_VERSION}
+                    UBUNTU_VERSION_CODENAME=${UBUNTU_VERSION_CODENAME}
+                    KERNEL_PACKAGE=${KERNEL_PACKAGE}
+            DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/Dockerfile.kvm
+                    ${CMAKE_CURRENT_SOURCE_DIR}/init.sh
+            COMMENT "Building KVM test image (${IMAGE_NAME})"
+        )
+
+        add_custom_target(kvm_${IMAGE_NAME}_image ALL
+            DEPENDS ${IMAGE_DIR}/vmlinuz ${IMAGE_DIR}/initrd ${IMAGE_DIR}/rootfs.qcow2
+        )
+    endforeach()
+endif()
+
+# Windows Server 2025 VM image (requires WINDOWS_SERVER_ISO, not part of ALL)
+if(KVM_WINDOWS_TESTING_AVAILABLE)
+    set(KVM_WINDOWS_IMAGE_DIR ${BUILD_ROOT}/kvm/windows2025)
 
     add_custom_command(
-        OUTPUT ${IMAGE_DIR}/vmlinuz ${IMAGE_DIR}/initrd ${IMAGE_DIR}/rootfs.qcow2
-        COMMAND ${CMAKE_COMMAND} -E env
-                KVM_CACHE_REGISTRY=${KVM_IMAGE_CACHE_REGISTRY}
-                bash ${CMAKE_CURRENT_SOURCE_DIR}/build_vm_image.sh
-                ${IMAGE_DIR}
-                ${CMAKE_CURRENT_SOURCE_DIR}/Dockerfile.kvm
+        OUTPUT ${KVM_WINDOWS_IMAGE_DIR}/windows.qcow2
+               ${KVM_WINDOWS_IMAGE_DIR}/OVMF_VARS.fd
+               ${KVM_WINDOWS_IMAGE_DIR}/ssh_key
+        COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/build_windows_image.sh
+                ${KVM_WINDOWS_IMAGE_DIR}
+                ${WINDOWS_SERVER_ISO}
                 ${CMAKE_SOURCE_DIR}
-                UBUNTU_VERSION=${UBUNTU_VERSION}
-                UBUNTU_VERSION_CODENAME=${UBUNTU_VERSION_CODENAME}
-                KERNEL_PACKAGE=${KERNEL_PACKAGE}
-        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/Dockerfile.kvm
-                ${CMAKE_CURRENT_SOURCE_DIR}/init.sh
-        COMMENT "Building KVM test image (${IMAGE_NAME})"
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/build_windows_image.sh
+                ${CMAKE_CURRENT_SOURCE_DIR}/autounattend.xml
+                ${CMAKE_CURRENT_SOURCE_DIR}/provision_windows.sh
+        COMMENT "Building Windows Server 2025 KVM test image"
     )
 
-    add_custom_target(kvm_${IMAGE_NAME}_image ALL
-        DEPENDS ${IMAGE_DIR}/vmlinuz ${IMAGE_DIR}/initrd ${IMAGE_DIR}/rootfs.qcow2
+    add_custom_target(kvm_windows2025_image
+        DEPENDS ${KVM_WINDOWS_IMAGE_DIR}/windows.qcow2
+                ${KVM_WINDOWS_IMAGE_DIR}/OVMF_VARS.fd
+                ${KVM_WINDOWS_IMAGE_DIR}/ssh_key
     )
-endforeach()
+endif()
 
 add_subdirectory(tests)

--- a/kvm/autounattend.xml
+++ b/kvm/autounattend.xml
@@ -1,0 +1,214 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+
+SPDX-License-Identifier: Unlicense
+-->
+<unattend xmlns="urn:schemas-microsoft-com:unattend">
+
+    <!-- windowsPE: Partition disk, load virtio drivers, select image -->
+    <settings pass="windowsPE">
+        <component name="Microsoft-Windows-International-Core-WinPE"
+                   processorArchitecture="amd64"
+                   publicKeyToken="31bf3856ad364e35"
+                   language="neutral"
+                   versionScope="nonSxS"
+                   xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+            <SetupUILanguage>
+                <UILanguage>en-US</UILanguage>
+            </SetupUILanguage>
+            <InputLocale>en-US</InputLocale>
+            <SystemLocale>en-US</SystemLocale>
+            <UILanguage>en-US</UILanguage>
+            <UserLocale>en-US</UserLocale>
+        </component>
+
+        <component name="Microsoft-Windows-PnpCustomizationsWinPE"
+                   processorArchitecture="amd64"
+                   publicKeyToken="31bf3856ad364e35"
+                   language="neutral"
+                   versionScope="nonSxS"
+                   xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+            <DriverPaths>
+                <!-- Search multiple drive letters for virtio-win drivers
+                     since UEFI drive letter assignment varies -->
+                <PathAndCredentials wcm:action="add" wcm:keyValue="1">
+                    <Path>D:\viostor\2k25\amd64</Path>
+                </PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="2">
+                    <Path>D:\NetKVM\2k25\amd64</Path>
+                </PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="3">
+                    <Path>E:\viostor\2k25\amd64</Path>
+                </PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="4">
+                    <Path>E:\NetKVM\2k25\amd64</Path>
+                </PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="5">
+                    <Path>F:\viostor\2k25\amd64</Path>
+                </PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="6">
+                    <Path>F:\NetKVM\2k25\amd64</Path>
+                </PathAndCredentials>
+            </DriverPaths>
+        </component>
+
+        <component name="Microsoft-Windows-Setup"
+                   processorArchitecture="amd64"
+                   publicKeyToken="31bf3856ad364e35"
+                   language="neutral"
+                   versionScope="nonSxS"
+                   xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+            <DiskConfiguration>
+                <Disk wcm:action="add">
+                    <DiskID>0</DiskID>
+                    <WillWipeDisk>true</WillWipeDisk>
+                    <CreatePartitions>
+                        <!-- EFI System Partition -->
+                        <CreatePartition wcm:action="add">
+                            <Order>1</Order>
+                            <Size>256</Size>
+                            <Type>EFI</Type>
+                        </CreatePartition>
+                        <!-- MSR partition -->
+                        <CreatePartition wcm:action="add">
+                            <Order>2</Order>
+                            <Size>16</Size>
+                            <Type>MSR</Type>
+                        </CreatePartition>
+                        <!-- Windows partition -->
+                        <CreatePartition wcm:action="add">
+                            <Order>3</Order>
+                            <Extend>true</Extend>
+                            <Type>Primary</Type>
+                        </CreatePartition>
+                    </CreatePartitions>
+                    <ModifyPartitions>
+                        <ModifyPartition wcm:action="add">
+                            <Order>1</Order>
+                            <PartitionID>1</PartitionID>
+                            <Format>FAT32</Format>
+                            <Label>EFI</Label>
+                        </ModifyPartition>
+                        <ModifyPartition wcm:action="add">
+                            <Order>2</Order>
+                            <PartitionID>3</PartitionID>
+                            <Format>NTFS</Format>
+                            <Label>Windows</Label>
+                        </ModifyPartition>
+                    </ModifyPartitions>
+                </Disk>
+            </DiskConfiguration>
+
+            <ImageInstall>
+                <OSImage>
+                    <InstallTo>
+                        <DiskID>0</DiskID>
+                        <PartitionID>3</PartitionID>
+                    </InstallTo>
+                    <InstallFrom>
+                        <MetaData wcm:action="add">
+                            <Key>/IMAGE/NAME</Key>
+                            <Value>Windows Server 2025 SERVERSTANDARDCORE</Value>
+                        </MetaData>
+                    </InstallFrom>
+                </OSImage>
+            </ImageInstall>
+
+            <UserData>
+                <ProductKey>
+                    <!-- Windows Server 2025 Standard KMS client setup key -->
+                    <Key>MFY9F-XBN2F-TYFMP-CCV49-RMYVH</Key>
+                    <WillShowUI>OnError</WillShowUI>
+                </ProductKey>
+                <AcceptEula>true</AcceptEula>
+            </UserData>
+        </component>
+    </settings>
+
+    <!-- specialize: Computer name, enable OpenSSH, disable firewall -->
+    <settings pass="specialize">
+        <component name="Microsoft-Windows-Shell-Setup"
+                   processorArchitecture="amd64"
+                   publicKeyToken="31bf3856ad364e35"
+                   language="neutral"
+                   versionScope="nonSxS">
+            <ComputerName>CHIMERA-TEST</ComputerName>
+            <TimeZone>UTC</TimeZone>
+        </component>
+
+        <component name="Microsoft-Windows-Deployment"
+                   processorArchitecture="amd64"
+                   publicKeyToken="31bf3856ad364e35"
+                   language="neutral"
+                   versionScope="nonSxS"
+                   xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+            <RunSynchronous>
+                <!-- Install OpenSSH Server -->
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>1</Order>
+                    <Path>powershell -NoProfile -Command "Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0"</Path>
+                </RunSynchronousCommand>
+                <!-- Start and enable OpenSSH Server -->
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>2</Order>
+                    <Path>powershell -NoProfile -Command "Set-Service -Name sshd -StartupType Automatic; Start-Service sshd"</Path>
+                </RunSynchronousCommand>
+                <!-- Set PowerShell as default SSH shell -->
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>3</Order>
+                    <Path>powershell -NoProfile -Command "New-ItemProperty -Path 'HKLM:\SOFTWARE\OpenSSH' -Name DefaultShell -Value 'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe' -PropertyType String -Force"</Path>
+                </RunSynchronousCommand>
+                <!-- Disable Windows Firewall for all profiles -->
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>4</Order>
+                    <Path>powershell -NoProfile -Command "Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled False"</Path>
+                </RunSynchronousCommand>
+            </RunSynchronous>
+        </component>
+    </settings>
+
+    <!-- oobeSystem: Skip OOBE, set admin password, shutdown -->
+    <settings pass="oobeSystem">
+        <component name="Microsoft-Windows-Shell-Setup"
+                   processorArchitecture="amd64"
+                   publicKeyToken="31bf3856ad364e35"
+                   language="neutral"
+                   versionScope="nonSxS"
+                   xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+            <OOBE>
+                <HideEULAPage>true</HideEULAPage>
+                <HideLocalAccountScreen>true</HideLocalAccountScreen>
+                <HideOEMRegistrationScreen>true</HideOEMRegistrationScreen>
+                <HideOnlineAccountScreens>true</HideOnlineAccountScreens>
+                <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
+                <ProtectYourPC>3</ProtectYourPC>
+                <SkipMachineOOBE>true</SkipMachineOOBE>
+                <SkipUserOOBE>true</SkipUserOOBE>
+            </OOBE>
+
+            <UserAccounts>
+                <AdministratorPassword>
+                    <Value>P@ssw0rd!</Value>
+                    <PlainText>true</PlainText>
+                </AdministratorPassword>
+            </UserAccounts>
+
+            <!-- No AutoLogon or FirstLogonCommands needed.
+                 The build script detects installation completion via SSH
+                 (OpenSSH Server is installed in the specialize pass) and then
+                 proceeds with provisioning directly. -->
+        </component>
+
+        <component name="Microsoft-Windows-International-Core"
+                   processorArchitecture="amd64"
+                   publicKeyToken="31bf3856ad364e35"
+                   language="neutral"
+                   versionScope="nonSxS">
+            <InputLocale>en-US</InputLocale>
+            <SystemLocale>en-US</SystemLocale>
+            <UILanguage>en-US</UILanguage>
+            <UserLocale>en-US</UserLocale>
+        </component>
+    </settings>
+</unattend>

--- a/kvm/build_windows_image.sh
+++ b/kvm/build_windows_image.sh
@@ -1,0 +1,231 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+#
+# SPDX-License-Identifier: Unlicense
+
+# Usage: build_windows_image.sh <output_dir> <windows_iso_path> <source_dir>
+#
+# Builds a provisioned Windows Server 2025 QEMU image for KVM testing.
+#
+# Steps:
+# 1. Download virtio-win drivers ISO
+# 2. Build a modified Windows ISO (Autounattend.xml + ei.cfg + noprompt boot)
+# 3. Run fully unattended Windows installation via QEMU/UEFI
+# 4. Provision the VM over SSH (MSYS2, build tools, test suites)
+# 5. Output: windows.qcow2, OVMF_VARS.fd, ssh_key
+#
+# Dependencies: qemu-system-x86_64, OVMF firmware, xorriso,
+#               sshpass, ssh-keygen, curl, internet access
+
+set -euo pipefail
+
+OUTDIR=$1
+WINDOWS_ISO=$2
+SOURCE_DIR=$3
+
+OVMF_CODE="${OVMF_CODE_PATH:-/usr/share/OVMF/OVMF_CODE_4M.fd}"
+DISK_IMAGE="${OUTDIR}/windows.qcow2"
+OVMF_VARS="${OUTDIR}/OVMF_VARS.fd"
+SSH_KEY="${OUTDIR}/ssh_key"
+VIRTIO_ISO="${OUTDIR}/virtio-win.iso"
+MODIFIED_ISO="${OUTDIR}/windows_unattended.iso"
+SSH_PORT=2222
+ADMIN_PASSWORD="P@ssw0rd!"
+QEMU_PID=""
+
+SESSION_DIR=$(mktemp -d /tmp/kvm_windows_build_XXXXXX)
+
+cleanup() {
+    if [ -n "$QEMU_PID" ]; then
+        kill "$QEMU_PID" 2>/dev/null || true
+        wait "$QEMU_PID" 2>/dev/null || true
+    fi
+    rm -rf "$SESSION_DIR"
+}
+trap cleanup EXIT
+
+mkdir -p "$OUTDIR"
+
+echo "=== Building Windows Server 2025 KVM test image ==="
+echo "Output directory: $OUTDIR"
+echo "Windows ISO: $WINDOWS_ISO"
+
+# Verify Windows ISO exists
+if [ ! -f "$WINDOWS_ISO" ]; then
+    echo "ERROR: Windows ISO not found: $WINDOWS_ISO"
+    exit 1
+fi
+
+# Verify OVMF firmware exists
+if [ ! -f "$OVMF_CODE" ]; then
+    echo "ERROR: OVMF firmware not found: $OVMF_CODE"
+    echo "Install with: apt-get install ovmf"
+    exit 1
+fi
+
+# Verify xorriso is available
+if ! command -v xorriso &>/dev/null; then
+    echo "ERROR: xorriso not found. Install with: apt-get install xorriso"
+    exit 1
+fi
+
+# Generate SSH keypair for provisioning and test access
+if [ ! -f "$SSH_KEY" ]; then
+    echo "--- Generating SSH keypair ---"
+    ssh-keygen -t ed25519 -f "$SSH_KEY" -N "" -C "chimera-kvm-test"
+fi
+
+# Download virtio-win drivers ISO if not cached
+if [ ! -f "$VIRTIO_ISO" ]; then
+    echo "--- Downloading virtio-win drivers ---"
+    curl -L -o "$VIRTIO_ISO" \
+        "https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/stable-virtio/virtio-win.iso"
+fi
+
+# Create a fresh copy of OVMF_VARS for this image (UEFI variable store)
+echo "--- Preparing OVMF variable store ---"
+OVMF_VARS_TEMPLATE="${OVMF_CODE_PATH:-/usr/share/OVMF/OVMF_CODE_4M.fd}"
+OVMF_VARS_TEMPLATE="${OVMF_VARS_TEMPLATE/OVMF_CODE/OVMF_VARS}"
+if [ ! -f "$OVMF_VARS_TEMPLATE" ]; then
+    for candidate in \
+        /usr/share/OVMF/OVMF_VARS_4M.fd \
+        /usr/share/OVMF/OVMF_VARS.fd \
+        /usr/share/edk2/ovmf/OVMF_VARS.fd \
+        /usr/share/qemu/OVMF_VARS.fd; do
+        if [ -f "$candidate" ]; then
+            OVMF_VARS_TEMPLATE="$candidate"
+            break
+        fi
+    done
+fi
+cp "$OVMF_VARS_TEMPLATE" "$OVMF_VARS"
+
+# Build a modified Windows ISO with Autounattend.xml embedded
+# This approach:
+# - Embeds the answer file directly on the install media (most reliable detection)
+# - Uses efisys_noprompt.bin to skip "Press any key to boot from CD or DVD"
+# - Adds ei.cfg to bypass the "Choose a licensing method" dialog
+if [ ! -f "$MODIFIED_ISO" ]; then
+    echo "--- Building modified Windows ISO ---"
+    ISO_MOUNT="${SESSION_DIR}/iso_mount"
+    ADDONS_DIR="${SESSION_DIR}/addons"
+    mkdir -p "$ISO_MOUNT" "$ADDONS_DIR"
+
+    mount -o loop,ro "$WINDOWS_ISO" "$ISO_MOUNT"
+
+    cp "${SOURCE_DIR}/kvm/autounattend.xml" "${ADDONS_DIR}/Autounattend.xml"
+
+    # ei.cfg bypasses the "Choose a licensing method" dialog on evaluation ISOs
+    mkdir -p "${ADDONS_DIR}/sources"
+    cat > "${ADDONS_DIR}/sources/ei.cfg" << 'EICFG'
+[Channel]
+Retail
+EICFG
+
+    # Rebuild ISO: efisys_noprompt.bin for silent UEFI boot
+    xorriso -as mkisofs \
+        -iso-level 4 \
+        -disable-deep-relocation \
+        -untranslated-filenames \
+        -b boot/etfsboot.com \
+        -no-emul-boot \
+        -boot-load-size 8 \
+        -eltorito-alt-boot \
+        -eltorito-platform efi \
+        -b efi/microsoft/boot/efisys_noprompt.bin \
+        -no-emul-boot \
+        -o "$MODIFIED_ISO" \
+        "$ISO_MOUNT" "$ADDONS_DIR"
+
+    umount "$ISO_MOUNT"
+    echo "Modified ISO created: $(du -h "$MODIFIED_ISO" | cut -f1)"
+fi
+
+# Create the disk image
+echo "--- Creating disk image ---"
+qemu-img create -f qcow2 "$DISK_IMAGE" 40G
+
+# VNC port for monitoring (connect with VNC viewer to localhost:VNC_PORT)
+VNC_PORT="${KVM_VNC_PORT:-5900}"
+VNC_DISPLAY=$((VNC_PORT - 5900))
+
+# Single QEMU session: install + provision
+# Windows installs unattended (multiple reboots), OpenSSH starts after OOBE,
+# then we SSH in to provision and shut down.
+echo "=== Starting Windows installation and provisioning ==="
+echo "This will take 15-30 minutes..."
+echo "Monitor via VNC at localhost:${VNC_PORT}"
+
+qemu-system-x86_64 \
+    -enable-kvm -smp 4 -m 4G -cpu host \
+    -machine q35 \
+    -global ICH9-LPC.disable_s3=1 \
+    -drive if=pflash,format=raw,readonly=on,file="$OVMF_CODE" \
+    -drive if=pflash,format=raw,file="$OVMF_VARS" \
+    -drive file="$DISK_IMAGE",if=virtio,format=qcow2 \
+    -drive file="$MODIFIED_ISO",media=cdrom,readonly=on \
+    -drive file="$VIRTIO_ISO",media=cdrom,readonly=on \
+    -netdev user,id=net0,hostfwd=tcp::${SSH_PORT}-:22 \
+    -device virtio-net-pci,netdev=net0 \
+    -vnc :${VNC_DISPLAY} &
+QEMU_PID=$!
+
+# Wait for SSH to become available (installation complete + OpenSSH running)
+echo "--- Waiting for SSH (port ${SSH_PORT}) ---"
+echo "Windows will reboot multiple times during installation..."
+SSH_READY=0
+for i in $(seq 1 600); do
+    if sshpass -p "$ADMIN_PASSWORD" ssh \
+        -o StrictHostKeyChecking=no \
+        -o UserKnownHostsFile=/dev/null \
+        -o LogLevel=ERROR \
+        -o ConnectTimeout=5 \
+        -p "$SSH_PORT" \
+        "Administrator@127.0.0.1" "echo SSH ready" 2>/dev/null; then
+        echo "SSH available after ~${i} seconds"
+        SSH_READY=1
+        break
+    fi
+    if ! kill -0 "$QEMU_PID" 2>/dev/null; then
+        echo "ERROR: QEMU exited unexpectedly"
+        QEMU_PID=""
+        exit 1
+    fi
+    sleep 1
+done
+
+if [ "$SSH_READY" -ne 1 ]; then
+    echo "ERROR: SSH did not become available within 10 minutes"
+    exit 1
+fi
+
+echo "=== Windows installation complete, starting provisioning ==="
+
+# Run provisioning script
+bash "${SOURCE_DIR}/kvm/provision_windows.sh" "$SSH_PORT" "$SSH_KEY" "$ADMIN_PASSWORD"
+
+# Shut down the VM cleanly
+echo "--- Shutting down VM ---"
+sshpass -p "$ADMIN_PASSWORD" ssh \
+    -o StrictHostKeyChecking=no \
+    -o UserKnownHostsFile=/dev/null \
+    -o LogLevel=ERROR \
+    -p "$SSH_PORT" \
+    "Administrator@127.0.0.1" \
+    'Stop-Computer -Force' || true
+
+# Wait for QEMU to exit
+for i in $(seq 1 60); do
+    if ! kill -0 "$QEMU_PID" 2>/dev/null; then
+        break
+    fi
+    sleep 1
+done
+kill "$QEMU_PID" 2>/dev/null || true
+wait "$QEMU_PID" 2>/dev/null || true
+QEMU_PID=""
+
+echo "=== Windows image built successfully ==="
+echo "  Disk image: ${DISK_IMAGE}"
+echo "  OVMF vars:  ${OVMF_VARS}"
+echo "  SSH key:     ${SSH_KEY}"

--- a/kvm/kvm_smb_windows_test_wrapper.sh
+++ b/kvm/kvm_smb_windows_test_wrapper.sh
@@ -1,0 +1,269 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+#
+# SPDX-License-Identifier: Unlicense
+
+# Usage: kvm_smb_windows_test_wrapper.sh <windows.qcow2> <OVMF_VARS.fd> <OVMF_CODE.fd>
+#                                         <ssh_key> <chimera_binary> <backend> <test_cmd>
+#
+# Orchestrates a chimera SMB server + Windows QEMU VM to run tests over SMB.
+# 1. Generates chimera config for the given backend
+# 2. Creates a network namespace with TAP device
+# 3. Starts chimera daemon in the netns (SMB on 10.0.0.1:445)
+# 4. Boots Windows QEMU VM (UEFI) with TAP + user-mode networking (SSH)
+# 5. Maps SMB share via 'net use', runs PowerShell test command via SSH
+# 6. Captures exit code and cleans up
+
+set -u
+
+DISK_IMAGE=$1; shift
+OVMF_VARS_TEMPLATE=$1; shift
+OVMF_CODE=$1; shift
+SSH_KEY=$1; shift
+CHIMERA_BINARY=$1; shift
+BACKEND=$1; shift
+TEST_CMD_ARG="$*"
+
+NETNS_NAME="kvm_smbw_$$_$(date +%s%N)"
+TAP_NAME="tap_$$"
+BUILD_DIR=$(dirname "$(dirname "$CHIMERA_BINARY")")
+SESSION_DIR=$(mktemp -d "${BUILD_DIR}/kvm_smbw_session_XXXXXX")
+CONFIG_FILE="${SESSION_DIR}/chimera.json"
+OVMF_VARS="${SESSION_DIR}/OVMF_VARS.fd"
+CHIMERA_PID=""
+QEMU_PID=""
+TCPDUMP_PID=""
+PCAP_FILE="${KVM_PCAP_FILE:-}"
+
+# SSH settings — SSH is forwarded via QEMU user-mode networking on a second NIC
+SSH_PORT=10022
+SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR -o ConnectTimeout=10"
+
+cleanup() {
+    if [ -n "$QEMU_PID" ]; then
+        kill "$QEMU_PID" 2>/dev/null || true
+        wait "$QEMU_PID" 2>/dev/null || true
+    fi
+    if [ -n "$TCPDUMP_PID" ]; then
+        kill "$TCPDUMP_PID" 2>/dev/null || true
+        wait "$TCPDUMP_PID" 2>/dev/null || true
+    fi
+    if [ -n "$CHIMERA_PID" ]; then
+        kill "$CHIMERA_PID" 2>/dev/null || true
+        wait "$CHIMERA_PID" 2>/dev/null || true
+    fi
+    ip netns delete "${NETNS_NAME}" 2>/dev/null || true
+    rm -rf "$SESSION_DIR"
+}
+trap cleanup EXIT
+
+# Generate chimera config based on backend (same logic as Linux SMB wrapper)
+generate_config() {
+    local mount_path="/"
+    local vfs_section=""
+
+    case "$BACKEND" in
+        linux|io_uring)
+            mount_path="$SESSION_DIR/data"
+            mkdir -p "$SESSION_DIR/data"
+            ;;
+        memfs)
+            mount_path="/"
+            ;;
+        demofs_io_uring|demofs_aio)
+            local device_type="io_uring"
+            if [ "$BACKEND" = "demofs_aio" ]; then
+                device_type="libaio"
+            fi
+            local devices_json=""
+            for i in $(seq 0 9); do
+                local device_path="${SESSION_DIR}/device-${i}.img"
+                truncate -s 256G "$device_path"
+                if [ $i -gt 0 ]; then
+                    devices_json="${devices_json},"
+                fi
+                devices_json="${devices_json}{\"type\":\"$device_type\",\"size\":1,\"path\":\"$device_path\"}"
+            done
+            mount_path="/"
+            BACKEND="demofs"
+            vfs_section="\"vfs\": {
+                \"demofs\": {
+                    \"config\": {\"devices\":[$devices_json]}
+                }
+            },"
+            ;;
+        cairn)
+            mount_path="/"
+            vfs_section="\"vfs\": {
+                \"cairn\": {
+                    \"config\": {\"initialize\":true,\"path\":\"$SESSION_DIR\"}
+                }
+            },"
+            ;;
+    esac
+
+    cat > "$CONFIG_FILE" << EOF
+{
+    "server": {
+        "threads": 4,
+        "delegation_threads": 4,
+        $vfs_section
+        "external_portmap": false
+    },
+    "mounts": {
+        "share": {
+            "module": "$BACKEND",
+            "path": "$mount_path"
+        }
+    },
+    "shares": {
+        "share": {
+            "path": "/share"
+        }
+    },
+    "users": [
+        {
+            "username": "root",
+            "smbpasswd": "secret",
+            "uid": 0,
+            "gid": 0
+        }
+    ]
+}
+EOF
+}
+
+generate_config
+
+# Create a session-local copy of OVMF_VARS (each VM run needs its own writable copy)
+cp "$OVMF_VARS_TEMPLATE" "$OVMF_VARS"
+
+# Create network namespace
+ip netns add "${NETNS_NAME}"
+ip netns exec "${NETNS_NAME}" ip link set lo up
+
+# Create TAP device inside the netns (for chimera <-> Windows SMB traffic)
+ip netns exec "${NETNS_NAME}" ip tuntap add dev "${TAP_NAME}" mode tap
+ip netns exec "${NETNS_NAME}" ip addr add 10.0.0.1/24 dev "${TAP_NAME}"
+ip netns exec "${NETNS_NAME}" ip link set "${TAP_NAME}" up
+
+# Optionally start tcpdump to capture traffic (set KVM_PCAP_FILE to enable)
+if [ -n "$PCAP_FILE" ]; then
+    ip netns exec "${NETNS_NAME}" tcpdump -i "${TAP_NAME}" -w "$PCAP_FILE" -s 0 &
+    TCPDUMP_PID=$!
+    sleep 0.5
+fi
+
+# Start chimera daemon in the netns
+CHIMERA_LOG="${SESSION_DIR}/chimera_stderr.log"
+ip netns exec "${NETNS_NAME}" env \
+    ASAN_OPTIONS="detect_leaks=0:handle_abort=2:print_cmdline=1" \
+    "$CHIMERA_BINARY" ${CHIMERA_DEBUG:+-d} -c "$CONFIG_FILE" \
+    2>"$CHIMERA_LOG" &
+CHIMERA_PID=$!
+
+# Wait for SMB port to be ready
+for i in $(seq 1 30); do
+    if ip netns exec "${NETNS_NAME}" bash -c "echo > /dev/tcp/10.0.0.1/445" 2>/dev/null; then
+        break
+    fi
+    if ! kill -0 "$CHIMERA_PID" 2>/dev/null; then
+        echo "chimera daemon exited prematurely"
+        exit 1
+    fi
+    sleep 0.1
+done
+
+# Boot Windows QEMU VM inside the netns
+# Two NICs:
+#   - virtio-net on TAP (10.0.0.x) for SMB traffic to chimera
+#   - e1000 on user-mode networking with SSH port forward for control
+ip netns exec "${NETNS_NAME}" qemu-system-x86_64 \
+    -enable-kvm -smp 4 -m 4G -cpu host \
+    -machine q35 \
+    -drive if=pflash,format=raw,readonly=on,file="$OVMF_CODE" \
+    -drive if=pflash,format=raw,file="$OVMF_VARS" \
+    -drive file="$DISK_IMAGE",if=virtio,format=qcow2,snapshot=on \
+    -netdev tap,id=net0,ifname="${TAP_NAME}",script=no,downscript=no \
+    -device virtio-net-pci,netdev=net0 \
+    -netdev user,id=net1,hostfwd=tcp:127.0.0.1:${SSH_PORT}-:22 \
+    -device e1000,netdev=net1 \
+    -display none \
+    -serial null \
+    -no-reboot &
+QEMU_PID=$!
+
+# Wait for SSH to become available (Windows boot takes longer)
+echo "Waiting for Windows VM SSH..."
+SSH_READY=0
+for i in $(seq 1 120); do
+    if ip netns exec "${NETNS_NAME}" ssh $SSH_OPTS \
+        -i "$SSH_KEY" -p "$SSH_PORT" \
+        "Administrator@127.0.0.1" "echo ready" 2>/dev/null; then
+        SSH_READY=1
+        echo "SSH available after ~${i} seconds"
+        break
+    fi
+    if ! kill -0 "$QEMU_PID" 2>/dev/null; then
+        echo "QEMU exited during boot"
+        QEMU_PID=""
+        exit 1
+    fi
+    sleep 1
+done
+
+if [ "$SSH_READY" -ne 1 ]; then
+    echo "Timed out waiting for SSH"
+    exit 1
+fi
+
+# Helper: run raw command via SSH inside the network namespace
+vm_ssh() {
+    ip netns exec "${NETNS_NAME}" ssh $SSH_OPTS \
+        -i "$SSH_KEY" -p "$SSH_PORT" \
+        "Administrator@127.0.0.1" "$@"
+}
+
+# Helper: run PowerShell command via SSH using -EncodedCommand (quoting-safe)
+vm_ps() {
+    local encoded
+    encoded=$(printf '%s' "$1" | iconv -f utf-8 -t utf-16le | base64 -w0)
+    vm_ssh "powershell -NoProfile -EncodedCommand $encoded"
+}
+
+# Configure the Windows VM's TAP NIC with a static IP
+echo "Configuring Windows network..."
+vm_ps '
+$tapAdapter = Get-NetAdapter | Where-Object { $_.InterfaceDescription -like "*VirtIO*" } | Select-Object -First 1
+New-NetIPAddress -InterfaceIndex $tapAdapter.ifIndex -IPAddress 10.0.0.2 -PrefixLength 24 -DefaultGateway 10.0.0.1 -ErrorAction SilentlyContinue
+Set-DnsClientServerAddress -InterfaceIndex $tapAdapter.ifIndex -ServerAddresses @() -ErrorAction SilentlyContinue
+'
+
+# Map the SMB share and run the test in a single session
+# (Windows drive mappings are per-logon session, so net use + test must share one)
+echo "Mapping SMB share and running test..."
+echo "Test command: $TEST_CMD_ARG"
+vm_ps "net use Z: \\\\10.0.0.1\\share /user:root secret
+if (\$LASTEXITCODE -ne 0) { Write-Error 'net use failed'; exit 1 }
+$TEST_CMD_ARG"
+EXIT_CODE=$?
+
+echo "Test exit code: $EXIT_CODE"
+
+# Show chimera debug output if present
+if [ -f "$CHIMERA_LOG" ]; then
+    echo "=== Chimera stderr (last 100 lines) ==="
+    tail -100 "$CHIMERA_LOG"
+fi
+
+# Shut down the VM
+vm_ps 'Stop-Computer -Force' || true
+for i in $(seq 1 15); do
+    if ! kill -0 "$QEMU_PID" 2>/dev/null; then
+        QEMU_PID=""
+        break
+    fi
+    sleep 1
+done
+
+exit $EXIT_CODE

--- a/kvm/provision_windows.sh
+++ b/kvm/provision_windows.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+#
+# SPDX-License-Identifier: Unlicense
+
+# Usage: provision_windows.sh <ssh_port> <ssh_key> <password>
+#
+# Provisions a running Windows Server VM over SSH:
+# 1. Disables Windows Firewall (belt and suspenders)
+# 2. Injects SSH public key for passwordless auth
+#
+# The VM's default SSH shell is PowerShell (configured in autounattend.xml).
+# Commands are sent via -EncodedCommand (base64 UTF-16LE) to avoid quoting
+# issues between bash, SSH, and Windows OpenSSH's PowerShell wrapping.
+
+set -euo pipefail
+
+SSH_PORT=$1
+SSH_KEY=$2
+PASSWORD=$3
+
+SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR"
+
+# Run a PowerShell command on the Windows VM via SSH.
+# Uses -EncodedCommand to avoid quoting issues with Windows OpenSSH.
+run_ps() {
+    local encoded
+    encoded=$(printf '%s' "$1" | iconv -f utf-8 -t utf-16le | base64 -w0)
+    sshpass -p "$PASSWORD" ssh $SSH_OPTS -p "$SSH_PORT" "Administrator@127.0.0.1" \
+        "powershell -NoProfile -EncodedCommand $encoded"
+}
+
+echo "=== Provisioning Windows VM ==="
+
+# Disable Windows Firewall (redundant with autounattend, but belt and suspenders)
+echo "--- Disabling Windows Firewall ---"
+run_ps 'Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled False'
+
+# Inject SSH public key for passwordless authentication during tests
+echo "--- Injecting SSH public key ---"
+SSH_PUBKEY=$(cat "${SSH_KEY}.pub")
+run_ps "New-Item -Path C:\ProgramData\ssh -ItemType Directory -Force | Out-Null"
+run_ps "Set-Content -Path C:\ProgramData\ssh\administrators_authorized_keys -Value '${SSH_PUBKEY}'"
+run_ps "icacls C:\ProgramData\ssh\administrators_authorized_keys /inheritance:r /grant Administrators:F /grant SYSTEM:F"
+
+# Verify passwordless SSH works
+echo "--- Verifying passwordless SSH ---"
+ssh $SSH_OPTS -i "$SSH_KEY" -p "$SSH_PORT" "Administrator@127.0.0.1" "echo SSH key auth working"
+
+echo "=== Provisioning complete ==="

--- a/kvm/tests/CMakeLists.txt
+++ b/kvm/tests/CMakeLists.txt
@@ -45,6 +45,12 @@ set(XFSTESTS_CMD_nametest  "mkdir -p /mnt/test && cd /mnt/test && /opt/xfstests/
 set(XFSTESTS_CMD_fstest    "mkdir -p /mnt/test && /opt/xfstests/src/fstest -p /mnt/test -n 1 -f 2 -l 5 -s 65536")
 set(XFSTESTS_CMD_rewinddir "mkdir -p /mnt/test && /opt/xfstests/src/rewinddir-test /mnt/test")
 
+# =============================================================================
+# Linux KVM tests (NFS + SMB via Linux CIFS client)
+# =============================================================================
+
+if(KVM_TESTING_AVAILABLE)
+
 foreach(image_spec ${KVM_IMAGES})
     string(REPLACE "|" ";" image_parts "${image_spec}")
     list(GET image_parts 0 IMAGE_NAME)
@@ -159,3 +165,71 @@ foreach(image_spec ${KVM_IMAGES})
     endif()
 
 endforeach()
+
+endif() # KVM_TESTING_AVAILABLE
+
+# =============================================================================
+# Windows KVM tests (SMB via Windows native client)
+# =============================================================================
+
+if(KVM_WINDOWS_TESTING_AVAILABLE)
+
+set(SMB_WINDOWS_WRAPPER ${CMAKE_SOURCE_DIR}/kvm/kvm_smb_windows_test_wrapper.sh)
+
+# Native PowerShell tests over mapped SMB share (Z:\)
+set(WINDOWS_TESTS auth_ntlm file_io dir_ops)
+
+# auth_ntlm: share mapping in wrapper verifies NTLM authentication works
+set(WINDOWS_CMD_auth_ntlm "Get-PSDrive Z")
+
+# file_io: create file, write, read back, verify content, delete
+set(WINDOWS_CMD_file_io [=[
+$f = 'Z:\test_file_io.txt'
+$data = 'hello chimera'
+Set-Content -Path $f -Value $data
+$read = Get-Content -Path $f
+Remove-Item -Path $f
+if ($read -ne $data) { Write-Error "mismatch: expected '$data' got '$read'"; exit 1 }
+]=])
+
+# dir_ops: create directory, add files, enumerate, verify count, cleanup
+set(WINDOWS_CMD_dir_ops [=[
+$d = 'Z:\test_dir_ops'
+New-Item -Path $d -ItemType Directory -Force | Out-Null
+1..5 | ForEach-Object { Set-Content -Path "$d\file_$_.txt" -Value "content $_" }
+$count = (Get-ChildItem -Path $d -File).Count
+Remove-Item -Path $d -Recurse -Force
+if ($count -ne 5) { Write-Error "expected 5 files, got $count"; exit 1 }
+]=])
+
+foreach(test ${WINDOWS_TESTS})
+    foreach(backend ${KVM_BACKENDS})
+        add_test(NAME chimera/kvm/smb-windows/${test}_${backend}
+            COMMAND bash ${SMB_WINDOWS_WRAPPER}
+                    ${KVM_WINDOWS_IMAGE_DIR}/windows.qcow2
+                    ${KVM_WINDOWS_IMAGE_DIR}/OVMF_VARS.fd
+                    ${OVMF_CODE_PATH}
+                    ${KVM_WINDOWS_IMAGE_DIR}/ssh_key
+                    ${CHIMERA_BINARY} ${backend}
+                    "${WINDOWS_CMD_${test}}")
+        set_tests_properties(chimera/kvm/smb-windows/${test}_${backend}
+            PROPERTIES LABELS "kvm;kvm-windows")
+    endforeach()
+endforeach()
+
+if(CAIRN_ENABLED)
+    foreach(test ${WINDOWS_TESTS})
+        add_test(NAME chimera/kvm/smb-windows/${test}_cairn
+            COMMAND bash ${SMB_WINDOWS_WRAPPER}
+                    ${KVM_WINDOWS_IMAGE_DIR}/windows.qcow2
+                    ${KVM_WINDOWS_IMAGE_DIR}/OVMF_VARS.fd
+                    ${OVMF_CODE_PATH}
+                    ${KVM_WINDOWS_IMAGE_DIR}/ssh_key
+                    ${CHIMERA_BINARY} cairn
+                    "${WINDOWS_CMD_${test}}")
+        set_tests_properties(chimera/kvm/smb-windows/${test}_cairn
+            PROPERTIES LABELS "kvm;kvm-windows")
+    endforeach()
+endif()
+
+endif() # KVM_WINDOWS_TESTING_AVAILABLE


### PR DESCRIPTION
## Summary

- Adds infrastructure to build a Windows Server 2025 QEMU image and run native PowerShell tests over mapped SMB shares against chimera's SMB server
- Exercises the real Windows SMB client stack (NTLM auth, file I/O, directory operations) rather than POSIX compatibility layers
- Three test cases per backend: `auth_ntlm`, `file_io`, `dir_ops`

## Known issues

- `file_io` test crashes chimera on memfs backend (ASAN abort in `chimera_smb_query_directory_readdir_complete`)
- `file_io` test fails on linux backend (`Remove-Item` reports file not found after successful write/read)
- These are pre-existing server bugs that the new tests correctly surface