### PR TITLE
Add JWT Bearer Token and HTTP Basic authentication to REST API

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -44,7 +44,7 @@ RUN apt-get -y update && \
     libxxhash-dev liburcu-dev librdmacm-dev liburing-dev libaio-dev libunwind-dev librocksdb-dev libcurl4-openssl-dev clangd uthash-dev libnuma-dev \
     libboost-dev libboost-program-options-dev libboost-thread-dev libboost-system-dev \
     libcurl4-openssl-dev build-essential ruby-full autoconf automake make libtool pkg-config libs3-dev gh npm reuse libssl-dev openssl \
-    libkrb5-3 libkrb5-dev libgssapi-krb5-2 libwbclient-dev curl jq libicu-dev awscli \
+    libkrb5-3 libkrb5-dev libgssapi-krb5-2 libwbclient-dev libcrypt-dev curl jq libicu-dev awscli \
     krb5-kdc krb5-admin-server krb5-user python3-pip python3-setuptools python3-venv \
     dh-python pybuild-plugin-pyproject debhelper-compat \
     samba samba-ad-dc samba-ad-provision samba-vfs-modules smbclient samba-testsuite && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get -y update && \
     apt-get -y --no-install-recommends upgrade && \
     apt-get -y --no-install-recommends install gcc g++ cmake ninja-build ccache git flex bison uuid-dev uthash-dev libkrb5-3 libkrb5-dev libgssapi-krb5-2 \
     librdmacm-dev libjansson-dev libxxhash-dev liburcu-dev liburing-dev libunwind-dev librocksdb-dev libssl-dev openssl libnuma-dev \
-    libwbclient-dev python3 python3-pip python3-venv python3-requests pkg-config && \
+    libwbclient-dev libcrypt-dev python3 python3-pip python3-venv python3-requests pkg-config && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile.rocky10
+++ b/Dockerfile.rocky10
@@ -14,7 +14,7 @@ RUN dnf -y update && \
     dnf -y install gcc gcc-c++ clang clang-tools-extra cmake ninja-build ccache git flex bison llvm \
     libuuid-devel uthash-devel krb5-devel krb5-libs \
     rdma-core-devel jansson-devel xxhash-devel userspace-rcu-devel liburing-devel libunwind-devel libasan \
-    rocksdb-devel openssl-devel openssl numactl-devel libcurl-devel libaio-devel \
+    rocksdb-devel openssl-devel openssl numactl-devel libcurl-devel libaio-devel libxcrypt-devel \
     autoconf automake libtool pkgconfig ca-certificates uncrustify clang-analyzer iproute curl libnl3-devel \
     libwbclient-devel samba-client krb5-server krb5-workstation samba samba-winbind samba-winbind-clients \
     python3-boto3 which && \

--- a/Dockerfile.rocky9
+++ b/Dockerfile.rocky9
@@ -14,7 +14,7 @@ RUN dnf -y update && \
     dnf -y --allowerasing install gcc gcc-c++ clang clang-tools-extra cmake ninja-build ccache git flex bison llvm \
     libuuid-devel uthash-devel krb5-devel krb5-libs \
     rdma-core-devel jansson-devel xxhash-devel userspace-rcu-devel liburing-devel libunwind-devel libasan \
-    rocksdb-devel openssl-devel openssl numactl-devel libcurl-devel libaio-devel \
+    rocksdb-devel openssl-devel openssl numactl-devel libcurl-devel libaio-devel libxcrypt-devel \
     autoconf automake libtool pkgconfig ca-certificates uncrustify clang-analyzer iproute curl libnl3-devel \
     libwbclient-devel samba-client krb5-server krb5-workstation samba samba-winbind samba-winbind-clients \
     python3-boto3 which && \

--- a/Dockerfile.ubuntu22.04
+++ b/Dockerfile.ubuntu22.04
@@ -21,7 +21,7 @@ RUN apt-get -y update && \
     apt-get -y --no-install-recommends install gcc g++ clang-tools cmake ninja-build ccache git flex bison \
     uuid-dev uthash-dev libkrb5-dev libgssapi-krb5-2 gss-ntlmssp-dev \
     librdmacm-dev libjansson-dev libxxhash-dev liburcu-dev liburing-dev libunwind-dev \
-    librocksdb-dev libssl-dev openssl libnuma-dev libcurl4-openssl-dev libs3-dev libaio-dev \
+    librocksdb-dev libssl-dev openssl libnuma-dev libcurl4-openssl-dev libs3-dev libaio-dev libcrypt-dev \
     build-essential autoconf automake libtool pkg-config ca-certificates uncrustify iproute2 curl \
     libwbclient-dev smbclient krb5-kdc krb5-admin-server krb5-user samba winbind samba-dsdb-modules samba-vfs-modules && \
     apt-get clean && \

--- a/Dockerfile.ubuntu24.04
+++ b/Dockerfile.ubuntu24.04
@@ -22,7 +22,7 @@ RUN apt-get -y update && \
     apt-get -y --no-install-recommends install clang clang-tools cmake ninja-build ccache git flex bison llvm \
     libclang-rt-18-dev uuid-dev uthash-dev libkrb5-dev libgssapi-krb5-2 gss-ntlmssp-dev \
     librdmacm-dev libjansson-dev libxxhash-dev liburcu-dev liburing-dev libunwind-dev librocksdb-dev \
-    libssl-dev openssl libnuma-dev libcurl4-openssl-dev libs3-dev libaio-dev \
+    libssl-dev openssl libnuma-dev libcurl4-openssl-dev libs3-dev libaio-dev libcrypt-dev \
     build-essential autoconf automake libtool pkg-config ca-certificates uncrustify iproute2 curl \
     libwbclient-dev smbclient krb5-kdc krb5-admin-server krb5-user samba samba-ad-dc samba-ad-provision samba-dsdb-modules && \
     apt-get clean && \

--- a/Dockerfile.ubuntu26.04
+++ b/Dockerfile.ubuntu26.04
@@ -22,7 +22,7 @@ RUN apt-get -y update && \
     apt-get -y --no-install-recommends install clang clang-tools cmake ninja-build ccache git flex bison llvm \
     libclang-rt-18-dev uuid-dev uthash-dev libkrb5-dev libgssapi-krb5-2 gss-ntlmssp-dev \
     librdmacm-dev libjansson-dev libxxhash-dev liburcu-dev liburing-dev libunwind-dev librocksdb-dev \
-    libssl-dev openssl libnuma-dev libcurl4-openssl-dev libs3-dev libaio-dev \
+    libssl-dev openssl libnuma-dev libcurl4-openssl-dev libs3-dev libaio-dev libcrypt-dev \
     build-essential autoconf automake libtool pkg-config ca-certificates uncrustify iproute2 curl \
     libwbclient-dev smbclient krb5-kdc krb5-admin-server krb5-user samba samba-ad-dc samba-ad-provision samba-dsdb-modules && \
     apt-get clean && \

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -125,6 +125,7 @@ the canonical place to set them.
 | `rest_https_port` | int | `0` | HTTPS port for the REST API (`0` = disabled). |
 | `rest_ssl_cert` | string | — | TLS certificate path. Auto-generated (self-signed) if HTTPS is enabled and this is unset. |
 | `rest_ssl_key` | string | — | TLS private-key path. Auto-generated alongside the cert if unset. |
+| `rest_auth_enabled` | bool | `true` | Require authentication (JWT Bearer token or HTTP Basic credentials) on all `/api/v1/*` endpoints. Set to `false` to disable auth entirely — only safe on a trusted/loopback-only management network. |
 | `soft_fail_bad_req` | bool | `false` | Return a soft error on a malformed REST request instead of dropping the connection. |
 
 See [Advanced and testing options](#advanced-and-testing-options) for a small set

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -15,6 +15,7 @@
       "description": "Chimera NAS REST API v1"
     }
   ],
+  "security": [{"bearerAuth": []}, {"basicAuth": []}],
   "paths": {
     "/config": {
       "get": {
@@ -29,6 +30,57 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Config"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auth/login": {
+      "post": {
+        "summary": "Authenticate",
+        "description": "Authenticate with username and password to obtain a JWT token.",
+        "operationId": "login",
+        "tags": ["Authentication"],
+        "security": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LoginRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Authentication successful",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LoginResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid credentials",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
                 }
               }
             }
@@ -55,6 +107,9 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "Unauthorized - missing or invalid Bearer token"
           }
         }
       },
@@ -103,6 +158,9 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "Unauthorized - missing or invalid Bearer token"
           }
         }
       }
@@ -134,6 +192,9 @@
               }
             }
           },
+          "401": {
+            "description": "Unauthorized - missing or invalid Bearer token"
+          },
           "404": {
             "description": "User not found",
             "content": {
@@ -164,6 +225,9 @@
         "responses": {
           "204": {
             "description": "User deleted"
+          },
+          "401": {
+            "description": "Unauthorized - missing or invalid Bearer token"
           },
           "404": {
             "description": "User not found",
@@ -197,6 +261,9 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "Unauthorized - missing or invalid Bearer token"
           }
         }
       },
@@ -245,6 +312,9 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "Unauthorized - missing or invalid Bearer token"
           }
         }
       }
@@ -276,6 +346,9 @@
               }
             }
           },
+          "401": {
+            "description": "Unauthorized - missing or invalid Bearer token"
+          },
           "404": {
             "description": "Export not found",
             "content": {
@@ -306,6 +379,9 @@
         "responses": {
           "204": {
             "description": "Export deleted"
+          },
+          "401": {
+            "description": "Unauthorized - missing or invalid Bearer token"
           },
           "404": {
             "description": "Export not found",
@@ -339,6 +415,9 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "Unauthorized - missing or invalid Bearer token"
           }
         }
       },
@@ -387,6 +466,9 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "Unauthorized - missing or invalid Bearer token"
           }
         }
       }
@@ -418,6 +500,9 @@
               }
             }
           },
+          "401": {
+            "description": "Unauthorized - missing or invalid Bearer token"
+          },
           "404": {
             "description": "Share not found",
             "content": {
@@ -448,6 +533,9 @@
         "responses": {
           "204": {
             "description": "Share deleted"
+          },
+          "401": {
+            "description": "Unauthorized - missing or invalid Bearer token"
           },
           "404": {
             "description": "Share not found",
@@ -481,6 +569,9 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "Unauthorized - missing or invalid Bearer token"
           }
         }
       },
@@ -529,6 +620,9 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "Unauthorized - missing or invalid Bearer token"
           }
         }
       }
@@ -559,6 +653,9 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "Unauthorized - missing or invalid Bearer token"
           },
           "404": {
             "description": "Bucket not found",
@@ -591,6 +688,9 @@
           "204": {
             "description": "Bucket deleted"
           },
+          "401": {
+            "description": "Unauthorized - missing or invalid Bearer token"
+          },
           "404": {
             "description": "Bucket not found",
             "content": {
@@ -606,7 +706,45 @@
     }
   },
   "components": {
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT"
+      },
+      "basicAuth": {
+        "type": "http",
+        "scheme": "basic"
+      }
+    },
     "schemas": {
+      "LoginRequest": {
+        "type": "object",
+        "required": ["username", "password"],
+        "properties": {
+          "username": {
+            "type": "string",
+            "description": "Username"
+          },
+          "password": {
+            "type": "string",
+            "description": "Password"
+          }
+        }
+      },
+      "LoginResponse": {
+        "type": "object",
+        "properties": {
+          "token": {
+            "type": "string",
+            "description": "JWT token"
+          },
+          "expires_in": {
+            "type": "integer",
+            "description": "Token expiry in seconds"
+          }
+        }
+      },
       "User": {
         "type": "object",
         "properties": {

--- a/scripts/pynfs_test_wrapper.sh
+++ b/scripts/pynfs_test_wrapper.sh
@@ -96,10 +96,13 @@ generate_config() {
     local rest_section=""
 
     # For delegation runs, expose the test-only debug fsop endpoint so the
-    # pynfs serverhelper can drive out-of-band recalls (DELEG16-20).
+    # pynfs serverhelper can drive out-of-band recalls (DELEG16-20).  The
+    # serverhelper sends no credentials, so disable REST auth for these runs
+    # rather than carving out a per-endpoint exemption.
     if [ "$DELEG_ENABLE" = "true" ]; then
         rest_section="\"rest_http_port\": $REST_PORT,
-        \"rest_debug_fsops\": true,"
+        \"rest_debug_fsops\": true,
+        \"rest_auth_enabled\": false,"
     fi
 
     case "$BACKEND" in

--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -718,6 +718,14 @@ main(
         chimera_server_config_set_rest_debug_fsops(server_config, 1);
     }
 
+    /* REST API authentication is enabled by default; it can be turned off
+     * explicitly with "rest_auth_enabled": false. */
+    json_t *rest_auth_enabled_value = json_object_get(server_params, "rest_auth_enabled");
+    if (rest_auth_enabled_value && json_is_boolean(rest_auth_enabled_value)) {
+        chimera_server_config_set_rest_auth_enabled(server_config,
+                                                    json_is_true(rest_auth_enabled_value) ? 1 : 0);
+    }
+
     if (rest_https_port != 0) {
         chimera_server_config_set_rest_https_port(server_config, rest_https_port);
         if (rest_ssl_cert) {

--- a/src/server/rest/CMakeLists.txt
+++ b/src/server/rest/CMakeLists.txt
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: LGPL-2.1-only
 
 find_package(PkgConfig REQUIRED)
+find_package(OpenSSL REQUIRED)
 pkg_check_modules(JANSSON REQUIRED jansson)
 
 add_library(chimera_rest SHARED
@@ -13,9 +14,11 @@ add_library(chimera_rest SHARED
     rest_config.c
     rest_swagger.c
     rest_debug.c
+    rest_auth.c
 )
 target_include_directories(chimera_rest PRIVATE ${JANSSON_INCLUDE_DIRS})
-target_link_libraries(chimera_rest chimera_vfs evpl_http evpl ${JANSSON_LIBRARIES})
+target_link_libraries(chimera_rest chimera_vfs evpl_http evpl ${JANSSON_LIBRARIES}
+                      OpenSSL::Crypto crypt)
 
 # Embed Swagger UI files at build time
 set(SWAGGER_DIR ${CMAKE_CURRENT_SOURCE_DIR}/swagger)
@@ -38,4 +41,13 @@ add_custom_command(
 
 target_sources(chimera_rest PRIVATE ${SWAGGER_EMBEDDED_C})
 
+if(WBCLIENT_FOUND)
+    target_include_directories(chimera_rest PRIVATE ${WBCLIENT_INCLUDE_DIRS})
+    target_link_libraries(chimera_rest ${WBCLIENT_LIBRARIES})
+endif()
+
 install(TARGETS chimera_rest DESTINATION lib)
+
+if(NOT DISABLE_TESTS)
+    add_subdirectory(tests)
+endif()

--- a/src/server/rest/rest.c
+++ b/src/server/rest/rest.c
@@ -12,6 +12,7 @@
 #include "server/server.h"
 #include "rest.h"
 #include "rest_internal.h"
+#include "rest_auth.h"
 
 /* External handlers from rest_users.c */
 void chimera_rest_handle_users_list(
@@ -159,6 +160,7 @@ enum chimera_rest_post_handler {
     REST_POST_BUCKETS_CREATE,
     REST_POST_MOUNTS_CREATE,
     REST_POST_DEBUG_FSOP,
+    REST_POST_AUTH_LOGIN,
 };
 
 #define REST_POST_MAX_BODY 65536
@@ -239,6 +241,10 @@ chimera_rest_notify(
             chimera_rest_handle_debug_fsop(evpl, request, thread,
                                            body, body_len);
             break;
+        case REST_POST_AUTH_LOGIN:
+            chimera_rest_handle_auth_login(evpl, request, thread,
+                                           body, body_len);
+            break;
     } /* switch */
 
     free(ctx);
@@ -286,7 +292,7 @@ chimera_rest_send_error(
     chimera_rest_send_json(evpl, request, status, obj);
 } /* chimera_rest_send_error */
 
-static void
+void
 chimera_rest_send_json_response(
     struct evpl              *evpl,
     struct evpl_http_request *request,
@@ -463,6 +469,35 @@ chimera_rest_dispatch(
             chimera_rest_handle_method_not_allowed(evpl, request);
         }
         return;
+    }
+
+    /* Auth login endpoint: /api/v1/auth/login (public, no auth required) */
+    if (url_len == 18 && strncmp(url, "/api/v1/auth/login", 18) == 0) {
+        if (req_type == EVPL_HTTP_REQUEST_TYPE_POST) {
+            struct chimera_rest_post_ctx *ctx;
+            ctx          = calloc(1, sizeof(*ctx));
+            ctx->handler = REST_POST_AUTH_LOGIN;
+            *notify_data = ctx;
+        } else {
+            chimera_rest_handle_method_not_allowed(evpl, request);
+        }
+        return;
+    }
+
+    /* Auth middleware: all /api/v1/ routes require a Bearer token or
+     * HTTP Basic credentials, unless authentication is disabled by config. */
+    if (thread->shared->auth_enabled &&
+        chimera_rest_url_starts_with(url, url_len, "/api/v1/", 8)) {
+        struct chimera_rest_jwt_claims claims;
+
+        if (chimera_rest_auth_check_request(
+                thread->shared, request, &claims) != 0) {
+            chimera_rest_send_json_response(evpl, request, 401,
+                                            "{\"error\":\"Unauthorized\","
+                                            "\"message\":\"Valid Bearer token "
+                                            "or Basic credentials required\"}");
+            return;
+        }
     }
 
     /* Config API: /api/v1/config */
@@ -663,10 +698,25 @@ chimera_rest_init(
 
     rest = calloc(1, sizeof(*rest));
 
-    rest->http_port   = http_port;
-    rest->https_port  = https_port;
-    rest->server      = server;
-    rest->debug_fsops = chimera_server_config_get_rest_debug_fsops(config);
+    rest->http_port    = http_port;
+    rest->https_port   = https_port;
+    rest->server       = server;
+    rest->debug_fsops  = chimera_server_config_get_rest_debug_fsops(config);
+    rest->auth_enabled = chimera_server_config_get_rest_auth_enabled(config);
+
+    chimera_rest_auth_init_secret(rest);
+
+    rest->winbind_enabled = chimera_server_config_get_smb_winbind_enabled(
+        config);
+    {
+        const char *domain = chimera_server_config_get_smb_winbind_domain(
+            config);
+        if (domain) {
+            strncpy(rest->winbind_domain, domain,
+                    sizeof(rest->winbind_domain) - 1);
+            rest->winbind_domain[sizeof(rest->winbind_domain) - 1] = '\0';
+        }
+    }
 
     if (http_port != 0) {
         rest->http_endpoint = evpl_endpoint_create("0.0.0.0", http_port);

--- a/src/server/rest/rest_auth.c
+++ b/src/server/rest/rest_auth.c
@@ -1,0 +1,606 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <crypt.h>
+
+#include <openssl/evp.h>
+#include <openssl/rand.h>
+#include <openssl/params.h>
+#include <openssl/core_names.h>
+#include <jansson.h>
+
+#include "evpl/evpl.h"
+#include "evpl/evpl_http.h"
+#include "server/server.h"
+#include "vfs/vfs.h"
+#include "vfs/vfs_user_cache.h"
+#ifdef HAVE_WBCLIENT
+#include <wbclient.h>
+#endif /* ifdef HAVE_WBCLIENT */
+#include "rest_internal.h"
+#include "rest_auth.h"
+
+/* ========== base64url helpers (RFC 4648 Section 5, no padding) ========== */
+
+static int
+base64url_encode(
+    const unsigned char *in,
+    int                  in_len,
+    char                *out,
+    int                  out_size)
+{
+    static const char table[] =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+    int               i, j = 0;
+
+    for (i = 0; i + 2 < in_len; i += 3) {
+        if (j + 4 > out_size) {
+            return -1;
+        }
+        out[j++] = table[(in[i] >> 2) & 0x3f];
+        out[j++] = table[((in[i] & 0x03) << 4) | ((in[i + 1] >> 4) & 0x0f)];
+        out[j++] = table[((in[i + 1] & 0x0f) << 2) |
+                         ((in[i + 2] >> 6) & 0x03)];
+        out[j++] = table[in[i + 2] & 0x3f];
+    }
+
+    if (i < in_len) {
+        if (j + 3 > out_size) {
+            return -1;
+        }
+        out[j++] = table[(in[i] >> 2) & 0x3f];
+        if (i + 1 < in_len) {
+            out[j++] = table[((in[i] & 0x03) << 4) |
+                             ((in[i + 1] >> 4) & 0x0f)];
+            out[j++] = table[(in[i + 1] & 0x0f) << 2];
+        } else {
+            out[j++] = table[(in[i] & 0x03) << 4];
+        }
+    }
+
+    if (j >= out_size) {
+        return -1;
+    }
+    out[j] = '\0';
+    return j;
+} /* base64url_encode */
+
+static int
+base64url_decode_char(char c)
+{
+    if (c >= 'A' && c <= 'Z') {
+        return c - 'A';
+    }
+    if (c >= 'a' && c <= 'z') {
+        return c - 'a' + 26;
+    }
+    if (c >= '0' && c <= '9') {
+        return c - '0' + 52;
+    }
+    if (c == '-') {
+        return 62;
+    }
+    if (c == '_') {
+        return 63;
+    }
+    return -1;
+} /* base64url_decode_char */
+
+static int
+base64url_decode(
+    const char    *in,
+    int            in_len,
+    unsigned char *out,
+    int            out_size)
+{
+    int i, j = 0, v;
+    int buf = 0, bits = 0;
+
+    for (i = 0; i < in_len; i++) {
+        v = base64url_decode_char(in[i]);
+        if (v < 0) {
+            return -1;
+        }
+        buf   = (buf << 6) | v;
+        bits += 6;
+        if (bits >= 8) {
+            bits -= 8;
+            if (j >= out_size) {
+                return -1;
+            }
+            out[j++] = (buf >> bits) & 0xff;
+        }
+    }
+
+    return j;
+} /* base64url_decode */
+
+/* ========== HMAC-SHA256 ========== */
+
+static int
+hmac_sha256(
+    const unsigned char *key,
+    int                  key_len,
+    const unsigned char *data,
+    int                  data_len,
+    unsigned char       *out,
+    size_t              *out_len)
+{
+    EVP_MAC     *mac     = NULL;
+    EVP_MAC_CTX *mac_ctx = NULL;
+    int          rc      = -1;
+
+    OSSL_PARAM   params[] = {
+        OSSL_PARAM_construct_utf8_string(
+            OSSL_MAC_PARAM_DIGEST,                                                                      (char *)
+            "SHA256", 0),
+        OSSL_PARAM_construct_end()
+    };
+
+    mac = EVP_MAC_fetch(NULL, "HMAC", NULL);
+    if (!mac) {
+        goto done;
+    }
+
+    mac_ctx = EVP_MAC_CTX_new(mac);
+    if (!mac_ctx) {
+        goto done;
+    }
+
+    if (EVP_MAC_init(mac_ctx, key, key_len, params) != 1) {
+        goto done;
+    }
+
+    if (EVP_MAC_update(mac_ctx, data, data_len) != 1) {
+        goto done;
+    }
+
+    if (EVP_MAC_final(mac_ctx, out, out_len, 32) != 1) {
+        goto done;
+    }
+
+    rc = 0;
+
+ done:
+    if (mac_ctx) {
+        EVP_MAC_CTX_free(mac_ctx);
+    }
+    if (mac) {
+        EVP_MAC_free(mac);
+    }
+    return rc;
+} /* hmac_sha256 */
+
+/* ========== Secret init ========== */
+
+void
+chimera_rest_auth_init_secret(struct chimera_rest_server *rest)
+{
+    RAND_bytes(rest->jwt_secret, CHIMERA_REST_JWT_SECRET_LEN);
+    chimera_rest_info("JWT authentication secret initialized");
+} /* chimera_rest_auth_init_secret */
+
+/* ========== Credential validation ========== */
+
+int
+chimera_rest_auth_validate_credentials(
+    struct chimera_rest_server     *rest,
+    const char                     *username,
+    const char                     *password,
+    struct chimera_rest_jwt_claims *claims)
+{
+    const struct chimera_vfs_user *user;
+    time_t                         now;
+
+    /* Try local user first */
+    user = chimera_server_get_user(rest->server, username);
+
+    if (user && user->password[0]) {
+        struct crypt_data cdata;
+        char             *result;
+
+        memset(&cdata, 0, sizeof(cdata));
+        result = crypt_r(password, user->password, &cdata);
+
+        if (result && strcmp(result, user->password) == 0) {
+            now = time(NULL);
+            strncpy(claims->sub, username, sizeof(claims->sub) - 1);
+            claims->sub[sizeof(claims->sub) - 1] = '\0';
+            claims->iat                          = now;
+            claims->exp                          = now + CHIMERA_REST_JWT_EXPIRY;
+            return 0;
+        }
+    }
+
+#ifdef HAVE_WBCLIENT
+    /* Winbind fallback */
+    if (rest->winbind_enabled) {
+        wbcErr wbc_err;
+
+        wbc_err = wbcAuthenticateUser(username, password);
+
+        if (wbc_err == WBC_ERR_SUCCESS) {
+            now = time(NULL);
+            strncpy(claims->sub, username, sizeof(claims->sub) - 1);
+            claims->sub[sizeof(claims->sub) - 1] = '\0';
+            claims->iat                          = now;
+            claims->exp                          = now + CHIMERA_REST_JWT_EXPIRY;
+            return 0;
+        }
+    }
+#endif /* ifdef HAVE_WBCLIENT */
+
+    return -1;
+} /* chimera_rest_auth_validate_credentials */
+
+/* ========== JWT create ========== */
+
+int
+chimera_rest_jwt_create(
+    struct chimera_rest_server           *rest,
+    const struct chimera_rest_jwt_claims *claims,
+    char                                 *token_out,
+    int                                   token_out_size)
+{
+    /* Header: {"alg":"HS256","typ":"JWT"} */
+    static const char header_json[] =
+        "{\"alg\":\"HS256\",\"typ\":\"JWT\"}";
+
+    char              payload_json[512];
+    char              header_b64[128];
+    char              payload_b64[512];
+    char              signing_input[1024];
+    unsigned char     sig[32];
+    size_t            sig_len = 32;
+    char              sig_b64[64];
+    int               h_len, p_len, s_len, si_len;
+
+    snprintf(payload_json, sizeof(payload_json),
+             "{\"sub\":\"%s\",\"iat\":%ld,\"exp\":%ld}",
+             claims->sub, (long) claims->iat, (long) claims->exp);
+
+    h_len = base64url_encode((const unsigned char *) header_json,
+                             strlen(header_json),
+                             header_b64, sizeof(header_b64));
+    if (h_len < 0) {
+        return -1;
+    }
+
+    p_len = base64url_encode((const unsigned char *) payload_json,
+                             strlen(payload_json),
+                             payload_b64, sizeof(payload_b64));
+    if (p_len < 0) {
+        return -1;
+    }
+
+    si_len = snprintf(signing_input, sizeof(signing_input),
+                      "%s.%s", header_b64, payload_b64);
+
+    if (hmac_sha256(rest->jwt_secret, CHIMERA_REST_JWT_SECRET_LEN,
+                    (const unsigned char *) signing_input, si_len,
+                    sig, &sig_len) != 0) {
+        return -1;
+    }
+
+    s_len = base64url_encode(sig, sig_len, sig_b64, sizeof(sig_b64));
+    if (s_len < 0) {
+        return -1;
+    }
+
+    if (snprintf(token_out, token_out_size, "%s.%s",
+                 signing_input, sig_b64) >= token_out_size) {
+        return -1;
+    }
+
+    return 0;
+} /* chimera_rest_jwt_create */
+
+/* ========== JWT verify ========== */
+
+int
+chimera_rest_jwt_verify(
+    struct chimera_rest_server     *rest,
+    const char                     *token,
+    struct chimera_rest_jwt_claims *claims)
+{
+    const char   *first_dot, *second_dot;
+    int           si_len;
+    unsigned char expected_sig[32];
+    size_t        expected_sig_len = 32;
+    unsigned char actual_sig[32];
+    int           actual_sig_len;
+    unsigned char payload_raw[512];
+    int           payload_raw_len;
+    json_t       *root;
+    json_error_t  error;
+    const char   *sub;
+    time_t        now;
+
+    /* Find the two dots */
+    first_dot = strchr(token, '.');
+    if (!first_dot) {
+        return -1;
+    }
+
+    second_dot = strchr(first_dot + 1, '.');
+    if (!second_dot) {
+        return -1;
+    }
+
+    /* Verify no additional dots */
+    if (strchr(second_dot + 1, '.')) {
+        return -1;
+    }
+
+    /* signing_input = header.payload (everything before second dot) */
+    si_len = second_dot - token;
+
+    if (hmac_sha256(rest->jwt_secret, CHIMERA_REST_JWT_SECRET_LEN,
+                    (const unsigned char *) token, si_len,
+                    expected_sig, &expected_sig_len) != 0) {
+        return -1;
+    }
+
+    /* Decode actual signature */
+    actual_sig_len = base64url_decode(second_dot + 1, strlen(second_dot + 1),
+                                      actual_sig, sizeof(actual_sig));
+    if (actual_sig_len != (int) expected_sig_len) {
+        return -1;
+    }
+
+    /* Constant-time comparison */
+    if (CRYPTO_memcmp(expected_sig, actual_sig, expected_sig_len) != 0) {
+        return -1;
+    }
+
+    /* Decode payload */
+    payload_raw_len = base64url_decode(first_dot + 1,
+                                       second_dot - first_dot - 1,
+                                       payload_raw, sizeof(payload_raw) - 1);
+    if (payload_raw_len < 0) {
+        return -1;
+    }
+    payload_raw[payload_raw_len] = '\0';
+
+    /* Parse payload JSON */
+    root = json_loadb((const char *) payload_raw, payload_raw_len, 0, &error);
+    if (!root) {
+        return -1;
+    }
+
+    sub = json_string_value(json_object_get(root, "sub"));
+    if (!sub) {
+        json_decref(root);
+        return -1;
+    }
+
+    strncpy(claims->sub, sub, sizeof(claims->sub) - 1);
+    claims->sub[sizeof(claims->sub) - 1] = '\0';
+    claims->iat                          = json_integer_value(json_object_get(root, "iat"));
+    claims->exp                          = json_integer_value(json_object_get(root, "exp"));
+
+    json_decref(root);
+
+    /* Check expiration */
+    now = time(NULL);
+    if (now >= claims->exp) {
+        return -1;
+    }
+
+    return 0;
+} /* chimera_rest_jwt_verify */
+
+/* ========== Bearer token check ========== */
+
+int
+chimera_rest_auth_check_bearer(
+    struct chimera_rest_server     *rest,
+    struct evpl_http_request       *request,
+    struct chimera_rest_jwt_claims *claims)
+{
+    const char *auth_header;
+
+    auth_header = evpl_http_request_header(request, "Authorization");
+    if (!auth_header) {
+        return -1;
+    }
+
+    if (strncmp(auth_header, "Bearer ", 7) != 0) {
+        return -1;
+    }
+
+    return chimera_rest_jwt_verify(rest, auth_header + 7, claims);
+} /* chimera_rest_auth_check_bearer */
+
+/* ========== Basic auth check ========== */
+
+/* Standard base64 (RFC 4648 Section 4) alphabet decode, used for HTTP Basic
+ * credentials.  Distinct from base64url above: '+' and '/' rather than '-'/'_',
+ * and '=' padding is tolerated (terminates decoding). */
+static int
+base64_decode_char(char c)
+{
+    if (c >= 'A' && c <= 'Z') {
+        return c - 'A';
+    }
+    if (c >= 'a' && c <= 'z') {
+        return c - 'a' + 26;
+    }
+    if (c >= '0' && c <= '9') {
+        return c - '0' + 52;
+    }
+    if (c == '+') {
+        return 62;
+    }
+    if (c == '/') {
+        return 63;
+    }
+    return -1;
+} /* base64_decode_char */
+
+static int
+base64_decode(
+    const char    *in,
+    int            in_len,
+    unsigned char *out,
+    int            out_size)
+{
+    int i, j = 0, v;
+    int buf = 0, bits = 0;
+
+    for (i = 0; i < in_len; i++) {
+        if (in[i] == '=') {
+            break;
+        }
+        v = base64_decode_char(in[i]);
+        if (v < 0) {
+            return -1;
+        }
+        buf   = (buf << 6) | v;
+        bits += 6;
+        if (bits >= 8) {
+            bits -= 8;
+            if (j >= out_size) {
+                return -1;
+            }
+            out[j++] = (buf >> bits) & 0xff;
+        }
+    }
+
+    return j;
+} /* base64_decode */
+
+int
+chimera_rest_auth_check_basic(
+    struct chimera_rest_server     *rest,
+    struct evpl_http_request       *request,
+    struct chimera_rest_jwt_claims *claims)
+{
+    const char *auth_header;
+    char        creds[512];
+    int         creds_len;
+    char       *colon;
+
+    auth_header = evpl_http_request_header(request, "Authorization");
+    if (!auth_header) {
+        return -1;
+    }
+
+    if (strncmp(auth_header, "Basic ", 6) != 0) {
+        return -1;
+    }
+
+    creds_len = base64_decode(auth_header + 6, strlen(auth_header + 6),
+                              (unsigned char *) creds, sizeof(creds) - 1);
+    if (creds_len <= 0) {
+        return -1;
+    }
+    creds[creds_len] = '\0';
+
+    /* RFC 7617: split "user-id:password" on the first colon.  The user-id
+     * cannot contain a colon, but the password may. */
+    colon = strchr(creds, ':');
+    if (!colon) {
+        return -1;
+    }
+    *colon = '\0';
+
+    return chimera_rest_auth_validate_credentials(rest, creds, colon + 1,
+                                                  claims);
+} /* chimera_rest_auth_check_basic */
+
+/* ========== Combined request authentication ========== */
+
+int
+chimera_rest_auth_check_request(
+    struct chimera_rest_server     *rest,
+    struct evpl_http_request       *request,
+    struct chimera_rest_jwt_claims *claims)
+{
+    const char *auth_header;
+
+    auth_header = evpl_http_request_header(request, "Authorization");
+    if (!auth_header) {
+        return -1;
+    }
+
+    if (strncmp(auth_header, "Bearer ", 7) == 0) {
+        return chimera_rest_auth_check_bearer(rest, request, claims);
+    }
+
+    if (strncmp(auth_header, "Basic ", 6) == 0) {
+        return chimera_rest_auth_check_basic(rest, request, claims);
+    }
+
+    return -1;
+} /* chimera_rest_auth_check_request */
+
+/* ========== Login handler ========== */
+
+void
+chimera_rest_handle_auth_login(
+    struct evpl                *evpl,
+    struct evpl_http_request   *request,
+    struct chimera_rest_thread *thread,
+    const char                 *body,
+    int                         body_len)
+{
+    json_t                        *root;
+    json_error_t                   error;
+    const char                    *username;
+    const char                    *password;
+    struct chimera_rest_jwt_claims claims;
+    char                           token[2048];
+    char                           response[2560];
+
+    root = json_loadb(body, body_len, 0, &error);
+    if (!root) {
+        chimera_rest_send_json_response(evpl, request, 400,
+                                        "{\"error\":\"Bad Request\","
+                                        "\"message\":\"Invalid JSON\"}");
+        return;
+    }
+
+    username = json_string_value(json_object_get(root, "username"));
+    password = json_string_value(json_object_get(root, "password"));
+
+    if (!username || !password) {
+        json_decref(root);
+        chimera_rest_send_json_response(evpl, request, 400,
+                                        "{\"error\":\"Bad Request\","
+                                        "\"message\":\"Missing username or "
+                                        "password\"}");
+        return;
+    }
+
+    if (chimera_rest_auth_validate_credentials(
+            thread->shared, username, password, &claims) != 0) {
+        json_decref(root);
+        chimera_rest_send_json_response(evpl, request, 401,
+                                        "{\"error\":\"Unauthorized\","
+                                        "\"message\":\"Invalid credentials\"}");
+        return;
+    }
+
+    json_decref(root);
+
+    if (chimera_rest_jwt_create(thread->shared, &claims,
+                                token, sizeof(token)) != 0) {
+        chimera_rest_send_json_response(evpl, request, 500,
+                                        "{\"error\":\"Internal Server Error\","
+                                        "\"message\":\"Failed to create "
+                                        "token\"}");
+        return;
+    }
+
+    snprintf(response, sizeof(response),
+             "{\"token\":\"%s\",\"expires_in\":%d}",
+             token, CHIMERA_REST_JWT_EXPIRY);
+
+    chimera_rest_send_json_response(evpl, request, 200, response);
+} /* chimera_rest_handle_auth_login */

--- a/src/server/rest/rest_auth.h
+++ b/src/server/rest/rest_auth.h
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#pragma once
+
+#include <stdint.h>
+#include <time.h>
+
+struct chimera_rest_server;
+struct evpl;
+struct evpl_http_request;
+struct chimera_rest_thread;
+
+#define CHIMERA_REST_JWT_SECRET_LEN 32
+#define CHIMERA_REST_JWT_EXPIRY     86400
+
+struct chimera_rest_jwt_claims {
+    char   sub[256];
+    time_t iat;
+    time_t exp;
+};
+
+void
+chimera_rest_auth_init_secret(
+    struct chimera_rest_server *rest);
+
+int
+chimera_rest_auth_validate_credentials(
+    struct chimera_rest_server     *rest,
+    const char                     *username,
+    const char                     *password,
+    struct chimera_rest_jwt_claims *claims);
+
+int
+chimera_rest_jwt_create(
+    struct chimera_rest_server           *rest,
+    const struct chimera_rest_jwt_claims *claims,
+    char                                 *token_out,
+    int                                   token_out_size);
+
+int
+chimera_rest_jwt_verify(
+    struct chimera_rest_server     *rest,
+    const char                     *token,
+    struct chimera_rest_jwt_claims *claims);
+
+int
+chimera_rest_auth_check_bearer(
+    struct chimera_rest_server     *rest,
+    struct evpl_http_request       *request,
+    struct chimera_rest_jwt_claims *claims);
+
+int
+chimera_rest_auth_check_basic(
+    struct chimera_rest_server     *rest,
+    struct evpl_http_request       *request,
+    struct chimera_rest_jwt_claims *claims);
+
+/* Authenticate a request via either an "Authorization: Bearer <jwt>" or an
+ * "Authorization: Basic <base64(user:pass)>" header.  Returns 0 on success. */
+int
+chimera_rest_auth_check_request(
+    struct chimera_rest_server     *rest,
+    struct evpl_http_request       *request,
+    struct chimera_rest_jwt_claims *claims);
+
+void
+chimera_rest_handle_auth_login(
+    struct evpl                *evpl,
+    struct evpl_http_request   *request,
+    struct chimera_rest_thread *thread,
+    const char                 *body,
+    int                         body_len);

--- a/src/server/rest/rest_internal.h
+++ b/src/server/rest/rest_internal.h
@@ -25,7 +25,14 @@ struct chimera_rest_server {
     struct evpl_listener  *https_listener;
     struct chimera_server *server;
     int                    debug_fsops;
+    int                    auth_enabled;
+    unsigned char          jwt_secret[32];
+    int                    winbind_enabled;
+    char                   winbind_domain[256];
 };
+
+struct evpl;
+struct evpl_http_request;
 
 struct chimera_rest_thread {
     struct evpl                *evpl;
@@ -70,3 +77,18 @@ chimera_rest_send_error(
     int                       status,
     const char               *error,
     const char               *message);
+
+/**
+ * Dispatch a pre-serialized JSON string as the response body.
+ *
+ * @param evpl      Event loop for this thread
+ * @param request   HTTP request being responded to
+ * @param status    HTTP status code to dispatch
+ * @param json_body NUL-terminated JSON string to send as the body
+ */
+void
+chimera_rest_send_json_response(
+    struct evpl              *evpl,
+    struct evpl_http_request *request,
+    int                       status,
+    const char               *json_body);

--- a/src/server/rest/tests/CMakeLists.txt
+++ b/src/server/rest/tests/CMakeLists.txt
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+#
+# SPDX-License-Identifier: LGPL-2.1-only
+
+# REST API authentication test
+add_executable(rest_auth_test rest_auth_test.c)
+target_link_libraries(rest_auth_test chimera_server chimera_metrics jansson)
+target_include_directories(rest_auth_test PRIVATE ${CMAKE_SOURCE_DIR}/src)
+
+add_test(NAME chimera/server/rest/auth_test
+    COMMAND ${CMAKE_SOURCE_DIR}/scripts/netns_test_wrapper.sh
+            ${CMAKE_CURRENT_BINARY_DIR}/rest_auth_test)
+set_tests_properties(chimera/server/rest/auth_test PROPERTIES
+    ENVIRONMENT "LSAN_OPTIONS=suppressions=${CMAKE_SOURCE_DIR}/src/server/smb/tests/suppressions.txt")

--- a/src/server/rest/tests/rest_auth_test.c
+++ b/src/server/rest/tests/rest_auth_test.c
@@ -1,0 +1,526 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * REST API Authentication Test
+ *
+ * Tests JWT and HTTP Basic authentication for the REST API:
+ *   1. Protected endpoints return 401 without token
+ *   2. Login with bad credentials returns 401
+ *   3. Login with valid credentials returns 200 + token
+ *   4. Protected endpoints succeed with valid Bearer token
+ *   5. Public endpoints work without token
+ *   6. Invalid/garbage token returns 401
+ *   7. Protected endpoints succeed with valid HTTP Basic credentials
+ *   8. The test-only /api/v1/debug/fsop endpoint is also protected by auth
+ */
+
+#include "common/logging.h"
+#include "prometheus-c.h"
+#include "server/server.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#define REST_PORT  18081
+#define ADMIN_USER "admin"
+#define ADMIN_PASS "adminpass"
+#define ADMIN_HASH \
+        "$6$testsalt$eBXKG..hXMuMyU2qJeRwFHrphEZTnovHazyD.YLjz/QKAbAvZj7z8MGdfCgwsM3n3k6pWpuGnuW/58UHKaWzL0"
+
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+static void
+test_pass(const char *name)
+{
+    fprintf(stderr, "  PASS: %s\n", name);
+    tests_passed++;
+} /* test_pass */
+
+static void
+test_fail(const char *name)
+{
+    fprintf(stderr, "  FAIL: %s\n", name);
+    tests_failed++;
+} /* test_fail */
+
+static int
+curl_get_code(
+    const char *method,
+    const char *path,
+    const char *body,
+    const char *bearer_token,
+    long       *http_code)
+{
+    char  cmd[8192];
+    char  output[4096];
+    FILE *fp;
+    int   rc;
+    char  auth_header[4200];
+
+    if (bearer_token && bearer_token[0]) {
+        snprintf(auth_header, sizeof(auth_header),
+                 "-H 'Authorization: Bearer %s' ", bearer_token);
+    } else {
+        auth_header[0] = '\0';
+    }
+
+    if (body) {
+        snprintf(cmd, sizeof(cmd),
+                 "curl -s -o /dev/null -w '%%{http_code}' "
+                 "-X %s -H 'Content-Type: application/json' "
+                 "%s"
+                 "-d '%s' http://localhost:%d%s 2>&1",
+                 method, auth_header, body, REST_PORT, path);
+    } else {
+        snprintf(cmd, sizeof(cmd),
+                 "curl -s -o /dev/null -w '%%{http_code}' "
+                 "-X %s %s"
+                 "http://localhost:%d%s 2>&1",
+                 method, auth_header, REST_PORT, path);
+    }
+
+    fp = popen(cmd, "r");
+    if (!fp) {
+        return -1;
+    }
+
+    output[0] = '\0';
+    if (fgets(output, sizeof(output), fp) == NULL) {
+        output[0] = '\0';
+    }
+
+    rc = pclose(fp);
+
+    if (WIFEXITED(rc) && WEXITSTATUS(rc) == 0) {
+        *http_code = strtol(output, NULL, 10);
+        return 0;
+    }
+
+    return -1;
+} /* curl_get_code */
+
+/* Issue a request authenticated with HTTP Basic credentials (curl -u sends the
+ * Authorization: Basic header preemptively). */
+static int
+curl_get_code_basic(
+    const char *method,
+    const char *path,
+    const char *userpass,
+    long       *http_code)
+{
+    char  cmd[8192];
+    char  output[4096];
+    FILE *fp;
+    int   rc;
+
+    snprintf(cmd, sizeof(cmd),
+             "curl -s -o /dev/null -w '%%{http_code}' "
+             "-X %s -u '%s' "
+             "http://localhost:%d%s 2>&1",
+             method, userpass, REST_PORT, path);
+
+    fp = popen(cmd, "r");
+    if (!fp) {
+        return -1;
+    }
+
+    output[0] = '\0';
+    if (fgets(output, sizeof(output), fp) == NULL) {
+        output[0] = '\0';
+    }
+
+    rc = pclose(fp);
+
+    if (WIFEXITED(rc) && WEXITSTATUS(rc) == 0) {
+        *http_code = strtol(output, NULL, 10);
+        return 0;
+    }
+
+    return -1;
+} /* curl_get_code_basic */
+
+static int
+curl_get_body(
+    const char *method,
+    const char *path,
+    const char *body,
+    const char *bearer_token,
+    char       *response,
+    int         response_size,
+    long       *http_code)
+{
+    char  cmd[8192];
+    char  output[8192];
+    FILE *fp;
+    int   rc;
+    char  auth_header[4200];
+
+    if (bearer_token && bearer_token[0]) {
+        snprintf(auth_header, sizeof(auth_header),
+                 "-H 'Authorization: Bearer %s' ", bearer_token);
+    } else {
+        auth_header[0] = '\0';
+    }
+
+    if (body) {
+        snprintf(cmd, sizeof(cmd),
+                 "curl -s -w '\\n%%{http_code}' "
+                 "-X %s -H 'Content-Type: application/json' "
+                 "%s"
+                 "-d '%s' http://localhost:%d%s 2>&1",
+                 method, auth_header, body, REST_PORT, path);
+    } else {
+        snprintf(cmd, sizeof(cmd),
+                 "curl -s -w '\\n%%{http_code}' "
+                 "-X %s %s"
+                 "http://localhost:%d%s 2>&1",
+                 method, auth_header, REST_PORT, path);
+    }
+
+    fp = popen(cmd, "r");
+    if (!fp) {
+        return -1;
+    }
+
+    output[0] = '\0';
+    {
+        int total = 0;
+        while (fgets(output + total, sizeof(output) - total, fp) != NULL) {
+            total += strlen(output + total);
+        }
+    }
+
+    rc = pclose(fp);
+
+    if (!WIFEXITED(rc) || WEXITSTATUS(rc) != 0) {
+        return -1;
+    }
+
+    /* Last line is the HTTP code */
+    {
+        char *last_newline = strrchr(output, '\n');
+        if (last_newline && last_newline > output) {
+            *http_code    = strtol(last_newline + 1, NULL, 10);
+            *last_newline = '\0';
+        } else {
+            *http_code = 0;
+        }
+    }
+
+    snprintf(response, response_size, "%s", output);
+
+    return 0;
+} /* curl_get_body */
+
+static int
+extract_token(
+    const char *response,
+    char       *token,
+    int         token_size)
+{
+    const char *start, *end;
+
+    start = strstr(response, "\"token\":\"");
+    if (!start) {
+        return -1;
+    }
+    start += 9;
+
+    end = strchr(start, '"');
+    if (!end || end - start >= token_size) {
+        return -1;
+    }
+
+    memcpy(token, start, end - start);
+    token[end - start] = '\0';
+    return 0;
+} /* extract_token */
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    struct chimera_server        *server;
+    struct chimera_server_config *config;
+    struct prometheus_metrics    *metrics;
+    int                           failures  = 0;
+    long                          http_code = 0;
+    int                           rc;
+    char                          response[8192];
+    char                          token[4096];
+
+    (void) argc;
+    (void) argv;
+
+    fprintf(stderr, "\n========================================\n");
+    fprintf(stderr, "REST API Authentication Test\n");
+    fprintf(stderr, "========================================\n");
+
+    /* Check prerequisites */
+    if (system("which curl >/dev/null 2>&1") != 0) {
+        fprintf(stderr, "\nERROR: curl not found in PATH\n");
+        return EXIT_FAILURE;
+    }
+
+    /* Initialize logging */
+    ChimeraLogLevel = CHIMERA_LOG_INFO;
+    evpl_set_log_fn(chimera_vlog, chimera_log_flush);
+
+    metrics = prometheus_metrics_create(NULL, NULL, 0);
+    if (!metrics) {
+        fprintf(stderr, "Failed to create metrics\n");
+        return EXIT_FAILURE;
+    }
+
+    config = chimera_server_config_init();
+    chimera_server_config_set_rest_http_port(config, REST_PORT);
+    /* Enable the test-only debug/fsop endpoint so we can verify it stays
+     * reachable without credentials (it drives pynfs delegation recalls). */
+    chimera_server_config_set_rest_debug_fsops(config, 1);
+
+    server = chimera_server_init(config, metrics);
+    if (!server) {
+        fprintf(stderr, "Failed to initialize server\n");
+        prometheus_metrics_destroy(metrics);
+        return EXIT_FAILURE;
+    }
+
+    chimera_server_mount(server, "share", "memfs", "/", NULL);
+
+    /* Add admin user with known password hash */
+    chimera_server_add_user(server, ADMIN_USER, ADMIN_HASH, NULL,
+                            NULL, 0, 0, 0, NULL, 1);
+
+    chimera_server_start(server);
+    fprintf(stderr, "Server started (REST on port %d)\n", REST_PORT);
+    usleep(200000);
+
+    /* ===== Test 1: Protected endpoints return 401 without token ===== */
+    fprintf(stderr, "\n  Test: Protected endpoints require auth...\n");
+    rc = curl_get_code("GET", "/api/v1/users", NULL, NULL, &http_code);
+    if (rc == 0 && http_code == 401) {
+        test_pass("GET /api/v1/users without token returns 401");
+    } else {
+        test_fail("GET /api/v1/users without token should return 401");
+        fprintf(stderr, "    Got: %ld\n", http_code);
+        failures++;
+    }
+
+    rc = curl_get_code("GET", "/api/v1/shares", NULL, NULL, &http_code);
+    if (rc == 0 && http_code == 401) {
+        test_pass("GET /api/v1/shares without token returns 401");
+    } else {
+        test_fail("GET /api/v1/shares without token should return 401");
+        fprintf(stderr, "    Got: %ld\n", http_code);
+        failures++;
+    }
+
+    /* ===== Test 2: Login with bad credentials returns 401 ===== */
+    fprintf(stderr, "\n  Test: Bad credentials rejected...\n");
+    rc = curl_get_code("POST", "/api/v1/auth/login",
+                       "{\"username\":\"admin\",\"password\":\"wrong\"}",
+                       NULL, &http_code);
+    if (rc == 0 && http_code == 401) {
+        test_pass("Login with bad password returns 401");
+    } else {
+        test_fail("Login with bad password should return 401");
+        fprintf(stderr, "    Got: %ld\n", http_code);
+        failures++;
+    }
+
+    rc = curl_get_code("POST", "/api/v1/auth/login",
+                       "{\"username\":\"nouser\",\"password\":\"nopass\"}",
+                       NULL, &http_code);
+    if (rc == 0 && http_code == 401) {
+        test_pass("Login with unknown user returns 401");
+    } else {
+        test_fail("Login with unknown user should return 401");
+        fprintf(stderr, "    Got: %ld\n", http_code);
+        failures++;
+    }
+
+    /* ===== Test 3: Login with valid credentials returns 200 + token ===== */
+    fprintf(stderr, "\n  Test: Valid login returns token...\n");
+    {
+        char login_body[256];
+        snprintf(login_body, sizeof(login_body),
+                 "{\"username\":\"%s\",\"password\":\"%s\"}",
+                 ADMIN_USER, ADMIN_PASS);
+
+        rc = curl_get_body("POST", "/api/v1/auth/login",
+                           login_body, NULL,
+                           response, sizeof(response), &http_code);
+        if (rc == 0 && http_code == 200) {
+            test_pass("Login returns 200");
+        } else {
+            test_fail("Login should return 200");
+            fprintf(stderr, "    Got: %ld\n", http_code);
+            failures++;
+            goto done;
+        }
+
+        if (extract_token(response, token, sizeof(token)) == 0) {
+            test_pass("Response contains token");
+        } else {
+            test_fail("Response should contain token");
+            fprintf(stderr, "    Response: %s\n", response);
+            failures++;
+            goto done;
+        }
+    }
+
+    /* ===== Test 4: Protected endpoints succeed with valid Bearer token === */
+    fprintf(stderr, "\n  Test: Authenticated requests succeed...\n");
+    rc = curl_get_code("GET", "/api/v1/users", NULL, token, &http_code);
+    if (rc == 0 && http_code == 200) {
+        test_pass("GET /api/v1/users with token returns 200");
+    } else {
+        test_fail("GET /api/v1/users with token should return 200");
+        fprintf(stderr, "    Got: %ld\n", http_code);
+        failures++;
+    }
+
+    rc = curl_get_code("GET", "/api/v1/shares", NULL, token, &http_code);
+    if (rc == 0 && http_code == 200) {
+        test_pass("GET /api/v1/shares with token returns 200");
+    } else {
+        test_fail("GET /api/v1/shares with token should return 200");
+        fprintf(stderr, "    Got: %ld\n", http_code);
+        failures++;
+    }
+
+    rc = curl_get_code("GET", "/api/v1/exports", NULL, token, &http_code);
+    if (rc == 0 && http_code == 200) {
+        test_pass("GET /api/v1/exports with token returns 200");
+    } else {
+        test_fail("GET /api/v1/exports with token should return 200");
+        fprintf(stderr, "    Got: %ld\n", http_code);
+        failures++;
+    }
+
+    rc = curl_get_code("GET", "/api/v1/buckets", NULL, token, &http_code);
+    if (rc == 0 && http_code == 200) {
+        test_pass("GET /api/v1/buckets with token returns 200");
+    } else {
+        test_fail("GET /api/v1/buckets with token should return 200");
+        fprintf(stderr, "    Got: %ld\n", http_code);
+        failures++;
+    }
+
+    /* ===== Test 5: Public endpoints work without token ===== */
+    fprintf(stderr, "\n  Test: Public endpoints don't require auth...\n");
+    rc = curl_get_code("GET", "/version", NULL, NULL, &http_code);
+    if (rc == 0 && http_code == 200) {
+        test_pass("/version accessible without token");
+    } else {
+        test_fail("/version should be accessible without token");
+        fprintf(stderr, "    Got: %ld\n", http_code);
+        failures++;
+    }
+
+    rc = curl_get_code("GET", "/api/openapi.json", NULL, NULL, &http_code);
+    if (rc == 0 && http_code == 200) {
+        test_pass("/api/openapi.json accessible without token");
+    } else {
+        test_fail("/api/openapi.json should be accessible without token");
+        fprintf(stderr, "    Got: %ld\n", http_code);
+        failures++;
+    }
+
+    rc = curl_get_code("GET", "/api/docs", NULL, NULL, &http_code);
+    if (rc == 0 && http_code == 200) {
+        test_pass("/api/docs accessible without token");
+    } else {
+        test_fail("/api/docs should be accessible without token");
+        fprintf(stderr, "    Got: %ld\n", http_code);
+        failures++;
+    }
+
+    /* ===== Test 6: Invalid/garbage token returns 401 ===== */
+    fprintf(stderr, "\n  Test: Invalid tokens rejected...\n");
+    rc = curl_get_code("GET", "/api/v1/users", NULL,
+                       "garbage.token.here", &http_code);
+    if (rc == 0 && http_code == 401) {
+        test_pass("Garbage token returns 401");
+    } else {
+        test_fail("Garbage token should return 401");
+        fprintf(stderr, "    Got: %ld\n", http_code);
+        failures++;
+    }
+
+    rc = curl_get_code("GET", "/api/v1/users", NULL,
+                       "not-a-jwt", &http_code);
+    if (rc == 0 && http_code == 401) {
+        test_pass("Non-JWT string returns 401");
+    } else {
+        test_fail("Non-JWT string should return 401");
+        fprintf(stderr, "    Got: %ld\n", http_code);
+        failures++;
+    }
+
+    /* ===== Test 7: HTTP Basic authentication ===== */
+    fprintf(stderr, "\n  Test: HTTP Basic auth accepted...\n");
+    {
+        char userpass[256];
+
+        snprintf(userpass, sizeof(userpass), "%s:%s", ADMIN_USER, ADMIN_PASS);
+        rc = curl_get_code_basic("GET", "/api/v1/users", userpass, &http_code);
+        if (rc == 0 && http_code == 200) {
+            test_pass("GET /api/v1/users with valid Basic creds returns 200");
+        } else {
+            test_fail("GET /api/v1/users with valid Basic creds should return 200");
+            fprintf(stderr, "    Got: %ld\n", http_code);
+            failures++;
+        }
+
+        snprintf(userpass, sizeof(userpass), "%s:%s", ADMIN_USER, "wrongpass");
+        rc = curl_get_code_basic("GET", "/api/v1/users", userpass, &http_code);
+        if (rc == 0 && http_code == 401) {
+            test_pass("GET /api/v1/users with bad Basic password returns 401");
+        } else {
+            test_fail("GET /api/v1/users with bad Basic password should return 401");
+            fprintf(stderr, "    Got: %ld\n", http_code);
+            failures++;
+        }
+    }
+
+    /* ===== Test 8: debug/fsop is protected like any other /api/v1 route ===== */
+    /* The endpoint is exposed here (rest_debug_fsops enabled) but is not
+     * specially exempt from auth: when auth is on it still requires
+     * credentials. The pynfs DELEG16-20 deleg config disables auth wholesale
+     * (rest_auth_enabled=false) rather than relying on a per-endpoint carve-out. */
+    fprintf(stderr, "\n  Test: /api/v1/debug/fsop requires auth when enabled...\n");
+    rc = curl_get_code("POST", "/api/v1/debug/fsop", "{}", NULL, &http_code);
+    if (rc == 0 && http_code == 401) {
+        test_pass("POST /api/v1/debug/fsop without creds returns 401");
+    } else {
+        test_fail("POST /api/v1/debug/fsop without creds should return 401");
+        fprintf(stderr, "    Got: %ld\n", http_code);
+        failures++;
+    }
+
+ done:
+    fprintf(stderr, "\n========================================\n");
+    fprintf(stderr, "Test Summary\n");
+    fprintf(stderr, "========================================\n");
+    fprintf(stderr, "Passed: %d\n", tests_passed);
+    fprintf(stderr, "Failed: %d\n", tests_failed);
+
+    if (failures > 0) {
+        fprintf(stderr, "\nSome tests FAILED\n\n");
+        chimera_server_destroy(server);
+        prometheus_metrics_destroy(metrics);
+        return EXIT_FAILURE;
+    }
+
+    fprintf(stderr, "\nAll tests PASSED\n\n");
+    chimera_server_destroy(server);
+    prometheus_metrics_destroy(metrics);
+    return EXIT_SUCCESS;
+} /* main */

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -74,6 +74,7 @@ struct chimera_server_config {
     int                                   rest_http_port;
     int                                   rest_https_port;
     int                                   rest_debug_fsops;
+    int                                   rest_auth_enabled;
     int                                   smb_num_dialects;
     uint32_t                              smb_dialects[16];
     int                                   smb_persistent_handles;
@@ -152,6 +153,7 @@ chimera_server_config_init(void)
     config->portmap_hostname[0]      = '\0';
     config->soft_fail_bad_req        = 0;
     config->rest_debug_fsops         = 0;
+    config->rest_auth_enabled        = 1;
     config->tcp_flavor               = CHIMERA_TCP_FLAVOR_PLAIN;
 
     config->smb_num_dialects = 5;
@@ -964,6 +966,20 @@ chimera_server_config_get_rest_debug_fsops(const struct chimera_server_config *c
 {
     return config->rest_debug_fsops;
 } /* chimera_server_config_get_rest_debug_fsops */
+
+SYMBOL_EXPORT void
+chimera_server_config_set_rest_auth_enabled(
+    struct chimera_server_config *config,
+    int                           enable)
+{
+    config->rest_auth_enabled = enable;
+} /* chimera_server_config_set_rest_auth_enabled */
+
+SYMBOL_EXPORT int
+chimera_server_config_get_rest_auth_enabled(const struct chimera_server_config *config)
+{
+    return config->rest_auth_enabled;
+} /* chimera_server_config_get_rest_auth_enabled */
 
 SYMBOL_EXPORT void
 chimera_server_config_set_rest_https_port(

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -450,6 +450,15 @@ chimera_server_config_get_rest_debug_fsops(
     const struct chimera_server_config *config);
 
 void
+chimera_server_config_set_rest_auth_enabled(
+    struct chimera_server_config *config,
+    int                           enable);
+
+int
+chimera_server_config_get_rest_auth_enabled(
+    const struct chimera_server_config *config);
+
+void
 chimera_server_config_set_rest_ssl_cert(
     struct chimera_server_config *config,
     const char                   *cert_path);

--- a/src/server/smb/smb_wbclient.c
+++ b/src/server/smb/smb_wbclient.c
@@ -387,6 +387,97 @@ smb_wbclient_identity_handler(
     } // switch
 } // smb_wbclient_identity_handler
 
+int
+smb_wbclient_auth_password(
+    const char *username,
+    const char *domain,
+    const char *password,
+    uint32_t   *uid,
+    uint32_t   *gid,
+    uint32_t   *ngids,
+    uint32_t   *gids,
+    char       *sid_out)
+{
+    wbcErr                   wbc_err;
+    struct wbcAuthUserParams params;
+    struct wbcAuthUserInfo  *info  = NULL;
+    struct wbcAuthErrorInfo *error = NULL;
+    struct wbcDomainSid      user_sid;
+    uint32_t                 unix_uid, unix_gid;
+    struct wbcDomainSid     *groups_sids = NULL;
+    uint32_t                 num_groups  = 0;
+    uint32_t                 i;
+
+    memset(&params, 0, sizeof(params));
+
+    params.level              = WBC_AUTH_USER_LEVEL_PLAIN;
+    params.account_name       = username;
+    params.domain_name        = domain ? domain : "";
+    params.password.plaintext = password;
+
+    wbc_err = wbcAuthenticateUserEx(&params, &info, &error);
+
+    if (wbc_err != WBC_ERR_SUCCESS) {
+        chimera_smb_debug("wbcAuthenticateUserEx (plain) failed: %s",
+                          error ? error->display_string : wbcErrorString(
+                              wbc_err));
+        if (error) {
+            wbcFreeMemory(error);
+        }
+        return -1;
+    }
+
+    user_sid = info->sids[0].sid;
+
+    if (sid_out) {
+        if (wbc_sid_to_string(&user_sid, sid_out,
+                              SMB_WBCLIENT_SID_MAX_LEN) < 0) {
+            sid_out[0] = '\0';
+        }
+    }
+
+    wbc_err = wbcSidToUid(&user_sid, &unix_uid);
+    if (wbc_err != WBC_ERR_SUCCESS) {
+        chimera_smb_error("wbcSidToUid failed: %s", wbcErrorString(wbc_err));
+        wbcFreeMemory(info);
+        return -1;
+    }
+
+    if (info->num_sids > 1) {
+        wbc_err = wbcSidToGid(&info->sids[1].sid, &unix_gid);
+        if (wbc_err != WBC_ERR_SUCCESS) {
+            unix_gid = unix_uid;
+        }
+    } else {
+        unix_gid = unix_uid;
+    }
+
+    *uid = unix_uid;
+    *gid = unix_gid;
+
+    wbc_err = wbcLookupUserSids(&user_sid, 0, &num_groups, &groups_sids);
+    if (wbc_err == WBC_ERR_SUCCESS && num_groups > 0) {
+        *ngids = 0;
+        for (i = 0; i < num_groups && *ngids < SMB_WBCLIENT_MAX_GROUPS; i++) {
+            uint32_t group_gid;
+            wbc_err = wbcSidToGid(&groups_sids[i], &group_gid);
+            if (wbc_err == WBC_ERR_SUCCESS) {
+                gids[(*ngids)++] = group_gid;
+            }
+        }
+        wbcFreeMemory(groups_sids);
+    } else {
+        *ngids = 0;
+    }
+
+    chimera_smb_info(
+        "wbclient plain auth success: user=%s\\%s uid=%u gid=%u ngids=%u",
+        domain ? domain : "", username, *uid, *gid, *ngids);
+
+    wbcFreeMemory(info);
+    return 0;
+} // smb_wbclient_auth_password
+
 #else // HAVE_WBCLIENT
 
 // Stub implementations when libwbclient is not available
@@ -467,5 +558,28 @@ smb_wbclient_identity_handler(
 
     return -1;
 } // smb_wbclient_identity_handler
+
+int
+smb_wbclient_auth_password(
+    const char *username,
+    const char *domain,
+    const char *password,
+    uint32_t   *uid,
+    uint32_t   *gid,
+    uint32_t   *ngids,
+    uint32_t   *gids,
+    char       *sid_out)
+{
+    (void) username;
+    (void) domain;
+    (void) password;
+    (void) uid;
+    (void) gid;
+    (void) ngids;
+    (void) gids;
+    (void) sid_out;
+
+    return -1;
+} // smb_wbclient_auth_password
 
 #endif // HAVE_WBCLIENT

--- a/src/server/smb/smb_wbclient.h
+++ b/src/server/smb/smb_wbclient.h
@@ -61,3 +61,16 @@ int smb_wbclient_identity_handler(
     const char                   *name,
     struct chimera_vfs_user      *out,
     void                         *private_data);
+
+// Authenticate a user via winbind using plaintext password
+// Returns: 0 on success, -1 on failure
+// sid_out should be at least SMB_WBCLIENT_SID_MAX_LEN bytes (can be NULL)
+int smb_wbclient_auth_password(
+    const char *username,
+    const char *domain,
+    const char *password,
+    uint32_t   *uid,
+    uint32_t   *gid,
+    uint32_t   *ngids,
+    uint32_t   *gids,
+    char       *sid_out);

--- a/src/server/smb/tests/rest_user_manip_test.c
+++ b/src/server/smb/tests/rest_user_manip_test.c
@@ -24,14 +24,20 @@
 #include <time.h>
 #include <unistd.h>
 
-#define REST_PORT 18080
-#define REST_USER "restuser"
-#define REST_PASS "restpassword"
-#define REST_UID  2000
-#define REST_GID  2000
+#define REST_PORT  18080
+#define REST_USER  "restuser"
+#define REST_PASS  "restpassword"
+#define REST_UID   2000
+#define REST_GID   2000
 
-static int tests_passed = 0;
-static int tests_failed = 0;
+#define ADMIN_USER "admin"
+#define ADMIN_PASS "adminpass"
+#define ADMIN_HASH \
+        "$6$testsalt$eBXKG..hXMuMyU2qJeRwFHrphEZTnovHazyD.YLjz/QKAbAvZj7z8MGdfCgwsM3n3k6pWpuGnuW/58UHKaWzL0"
+
+static int  tests_passed = 0;
+static int  tests_failed = 0;
+static char auth_token[4096];
 
 static void
 test_pass(const char *name)
@@ -77,24 +83,35 @@ run_curl(
     const char *method,
     const char *path,
     const char *body,
+    const char *bearer_token,
     long       *http_code)
 {
-    char  cmd[4096];
+    char  cmd[8192];
     char  output[4096];
     FILE *fp;
     int   rc;
+    char  auth_header[4200];
+
+    if (bearer_token && bearer_token[0]) {
+        snprintf(auth_header, sizeof(auth_header),
+                 "-H 'Authorization: Bearer %s' ", bearer_token);
+    } else {
+        auth_header[0] = '\0';
+    }
 
     if (body) {
         snprintf(cmd, sizeof(cmd),
                  "curl -s -o /dev/null -w '%%{http_code}' "
                  "-X %s -H 'Content-Type: application/json' "
+                 "%s"
                  "-d '%s' http://localhost:%d%s 2>&1",
-                 method, body, REST_PORT, path);
+                 method, auth_header, body, REST_PORT, path);
     } else {
         snprintf(cmd, sizeof(cmd),
                  "curl -s -o /dev/null -w '%%{http_code}' "
-                 "-X %s http://localhost:%d%s 2>&1",
-                 method, REST_PORT, path);
+                 "-X %s %s"
+                 "http://localhost:%d%s 2>&1",
+                 method, auth_header, REST_PORT, path);
     }
 
     fprintf(stderr, "    Running: curl -X %s http://localhost:%d%s\n",
@@ -119,6 +136,66 @@ run_curl(
 
     return -1;
 } /* run_curl */
+
+static int
+get_auth_token(void)
+{
+    char  cmd[4096];
+    char  output[8192];
+    FILE *fp;
+    int   rc;
+    char *token_start, *token_end;
+
+    snprintf(cmd, sizeof(cmd),
+             "curl -s -X POST -H 'Content-Type: application/json' "
+             "-d '{\"username\":\"%s\",\"password\":\"%s\"}' "
+             "http://localhost:%d/api/v1/auth/login 2>&1",
+             ADMIN_USER, ADMIN_PASS, REST_PORT);
+
+    fprintf(stderr, "    Authenticating as %s...\n", ADMIN_USER);
+
+    fp = popen(cmd, "r");
+    if (!fp) {
+        return -1;
+    }
+
+    output[0] = '\0';
+    if (fgets(output, sizeof(output), fp) == NULL) {
+        output[0] = '\0';
+    }
+
+    rc = pclose(fp);
+
+    if (!WIFEXITED(rc) || WEXITSTATUS(rc) != 0) {
+        fprintf(stderr, "    curl failed\n");
+        return -1;
+    }
+
+    /* Extract token from {"token":"...","expires_in":...} */
+    token_start = strstr(output, "\"token\":\"");
+    if (!token_start) {
+        fprintf(stderr, "    No token in response: %s\n", output);
+        return -1;
+    }
+    token_start += 9; /* skip "token":" */
+
+    token_end = strchr(token_start, '"');
+    if (!token_end) {
+        fprintf(stderr, "    Malformed token response\n");
+        return -1;
+    }
+
+    if (token_end - token_start >= (int) sizeof(auth_token)) {
+        fprintf(stderr, "    Token too long\n");
+        return -1;
+    }
+
+    memcpy(auth_token, token_start, token_end - token_start);
+    auth_token[token_end - token_start] = '\0';
+
+    fprintf(stderr, "    Got auth token (%zu bytes)\n", strlen(auth_token));
+    return 0;
+} /* get_auth_token */
 
 /* ============================================================================
  * User Lifecycle Tests
@@ -157,7 +234,7 @@ run_user_tests(void)
                  "\"uid\":%d,\"gid\":%d}",
                  REST_USER, REST_PASS, REST_UID, REST_GID);
 
-        rc = run_curl("POST", "/api/v1/users", body, &http_code);
+        rc = run_curl("POST", "/api/v1/users", body, auth_token, &http_code);
         if (rc == 0 && http_code == 201) {
             test_pass("REST create user");
         } else {
@@ -184,7 +261,7 @@ run_user_tests(void)
         char path[256];
         snprintf(path, sizeof(path), "/api/v1/users/%s", REST_USER);
 
-        rc = run_curl("DELETE", path, NULL, &http_code);
+        rc = run_curl("DELETE", path, NULL, auth_token, &http_code);
         if (rc == 0 && http_code == 204) {
             test_pass("REST delete user");
         } else {
@@ -246,7 +323,7 @@ run_share_tests(struct chimera_server *server)
         const char *body =
             "{\"name\":\"restshare\",\"path\":\"testvfs\"}";
 
-        rc = run_curl("POST", "/api/v1/shares", body, &http_code);
+        rc = run_curl("POST", "/api/v1/shares", body, auth_token, &http_code);
         if (rc == 0 && http_code == 201) {
             test_pass("REST create share");
         } else {
@@ -269,7 +346,8 @@ run_share_tests(struct chimera_server *server)
 
     /* Step 4: Delete share via REST API */
     fprintf(stderr, "\n  Deleting share via REST API...\n");
-    rc = run_curl("DELETE", "/api/v1/shares/restshare", NULL, &http_code);
+    rc = run_curl("DELETE", "/api/v1/shares/restshare", NULL,
+                  auth_token, &http_code);
     if (rc == 0 && http_code == 204) {
         test_pass("REST delete share");
     } else {
@@ -357,13 +435,25 @@ main(
     /* Create the "share" SMB share for user tests */
     chimera_server_create_share(server, "share", "share", 0);
 
-    /* Start server (SMB + REST) - no users added initially */
+    /* Add admin user for REST API authentication */
+    chimera_server_add_user(server, ADMIN_USER, ADMIN_HASH, NULL,
+                            NULL, 0, 0, 0, NULL, 1);
+
+    /* Start server (SMB + REST) - no regular users added initially */
     chimera_server_start(server);
 
     fprintf(stderr, "Server started (REST on port %d)\n", REST_PORT);
 
     /* Give server a moment to be ready */
     usleep(200000);
+
+    /* Authenticate to get a JWT token */
+    if (get_auth_token() != 0) {
+        fprintf(stderr, "\nERROR: Failed to authenticate to REST API\n");
+        chimera_server_destroy(server);
+        prometheus_metrics_destroy(metrics);
+        return EXIT_FAILURE;
+    }
 
     /* Run tests */
     failures += run_user_tests();


### PR DESCRIPTION
## Summary

- Adds authentication to the REST API. Every `/api/v1/*` endpoint now requires **either** an `Authorization: Bearer <jwt>` token **or** `Authorization: Basic <base64(user:pass)>` credentials. Authentication is **enabled by default**.
- Adds a server config gate, `rest_auth_enabled` (default `true`), to turn authentication off entirely — intended only for a trusted, loopback-only management network. Wired through the server config struct/getter/setter and the daemon JSON parser; the auth middleware is skipped when it is `false`. There are **no** per-endpoint auth exemptions — every `/api/v1/*` route is treated uniformly.
- Implements `POST /api/v1/auth/login`, which accepts username/password credentials and returns a signed JWT token (24-hour expiry, HMAC-SHA256, secret randomly generated at server startup via `RAND_bytes`).
- Adds HTTP Basic auth as an alternative to obtaining a token: a `Basic` `Authorization` header is base64-decoded and split on the first `:` (per RFC 7617), then validated with the same credential check used by the login endpoint. This makes `curl -u user:pass https://.../api/v1/...` work directly.
- Credential validation uses a two-tier approach: local users are validated via `crypt_r()` against stored password hashes, with a winbind fallback via `wbcAuthenticateUser()` for AD/domain users (only when winbind is enabled).
- When auth is enabled, the middleware protects every `/api/v1/*` route — `users`, `exports`, `shares`, `buckets`, `mounts`, `config`, and the test-only `debug/fsop`. Public endpoints (`/version`, `/api/docs*`, `/api/openapi.json`) and the login endpoint itself remain unauthenticated regardless.
- The pynfs DELEG16-20 delegation tests drive the test-only `/api/v1/debug/fsop` recall endpoint with no credentials. Rather than carving out a per-endpoint exemption, their generated config (`scripts/pynfs_test_wrapper.sh`, delegation runs only) sets `rest_auth_enabled: false`. This keeps production code uniform and, as a bonus, exercises the auth-disabled path end-to-end in CI.
- The REST auth module calls libwbclient directly rather than going through `chimera_smb`, keeping the two components decoupled.
- Updates the existing `rest_user_manip_test` to authenticate before making API calls.
- Adds a new `rest_auth_test` with 8 integration scenarios (401 without token, 401 on bad credentials, valid login, protected endpoints with Bearer token, public endpoints without token, garbage token, valid/invalid HTTP Basic credentials, and `debug/fsop` returning 401 without credentials when auth is enabled).
- Updates the OpenAPI spec with `bearerAuth` **and** `basicAuth` security schemes (offered as alternatives in the global `security` requirement), the login endpoint, and `401` responses on all protected endpoints; documents `rest_auth_enabled` in `docs/configuration.md`.
- Installs the libcrypt/libxcrypt development headers (`crypt.h`, needed by `crypt_r`) in all CI/build images — `libcrypt-dev` on the Debian/Ubuntu images + devcontainer, `libxcrypt-devel` on the Rocky images. (`crypt.h` is a new build dependency introduced by this PR; the base images only shipped the runtime lib.)

## Config

```json
{
  "server": {
    "rest_http_port": 8080,
    "rest_auth_enabled": true
  }
}
```

`rest_auth_enabled` defaults to `true` when the key is absent, so existing deployments that set a REST port get authentication automatically.

## Notes on auth schemes

- A 401 response does **not** include a `WWW-Authenticate: Basic` challenge header, so browsers won't pop a native Basic-auth dialog on API 401s. `curl -u` still works because it sends the Basic header preemptively.
- Both schemes share `chimera_rest_auth_validate_credentials()`, so local-vs-winbind resolution and password handling are identical whether you log in for a JWT or use Basic auth.
- The auth-disabled path (`rest_auth_enabled: false`) is exercised in CI by the pynfs delegation runs; the unit test covers the enabled path (including that `debug/fsop` is not specially exempt).

## Rebase notes

This branch was rebased onto the latest `main`, which had since refactored the REST server. Changes made during the rebase to integrate cleanly:

- The monolithic `rest.c` was split on `main` into per-resource modules (`rest_users.c`, `rest_shares.c`, `rest_mounts.c`, `rest_config.c`, `rest_swagger.c`, `rest_debug.c`), and a new `json_t`-based response API (`chimera_rest_send_json` / `chimera_rest_send_error`) was introduced. The auth code retains and reuses the string-based `chimera_rest_send_json_response` helper, which is now exported (non-`static`) so the new `rest_auth.c` can call it across translation units.
- `main` added a `GET /api/v1/config` endpoint during the same window; it now sits behind the auth middleware along with the other `/api/v1/*` routes.
- The new winbind identity-resolver handler (`smb_wbclient_identity_handler`) on `main` and this branch's `smb_wbclient_auth_password` coexist in `smb_wbclient.c`.
- `rest_auth_test` was updated for `main`'s new `chimera_server_mount(..., options)` signature (added 5th argument).

Verified: full Release build is clean, `make syntax` is clean, copyright headers are current, and `chimera/server/rest/auth_test` (18 assertions) and `chimera/server/smb/rest_user_manip` pass.
