### PR TITLE
Implement "soft_fail_bad_req"

### DIFF
--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -342,6 +342,11 @@ main(
         }
     }
 
+    json_value = json_object_get(server_params, "soft_fail_bad_req");
+    if (json_is_true(json_value)) {
+        chimera_server_config_set_soft_fail_bad_req(server_config, 1);
+    }
+
     // Parse SMB auth configuration
     json_t *smb_auth = json_object_get(server_params, "smb_auth");
     if (smb_auth && json_is_object(smb_auth)) {

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -37,6 +37,7 @@ struct chimera_server_config {
     int                                   nfs_rdma_port;
     int                                   nfs_tcp_rdma_port;
     int                                   external_portmap;
+    int                                   soft_fail_bad_req;
     rlim_t                                max_open_files;
     int                                   core_threads;
     int                                   delegation_threads;
@@ -95,6 +96,7 @@ chimera_server_config_init(void)
     config->delegation_threads = 8;
     config->nfs_rdma           = 0;
     config->external_portmap   = 0;
+    config->soft_fail_bad_req  = 0;
 
     config->smb_num_dialects = 2;
     config->smb_dialects[0]  = SMB2_DIALECT_2_1;
@@ -427,6 +429,20 @@ chimera_server_config_get_anongid(const struct chimera_server_config *config)
 {
     return config->anongid;
 } /* chimera_server_config_get_anongid */
+
+SYMBOL_EXPORT void
+chimera_server_config_set_soft_fail_bad_req(
+    struct chimera_server_config *config,
+    int                           enable)
+{
+    config->soft_fail_bad_req = enable;
+} /* chimera_server_config_set_soft_fail_bad_req */
+
+SYMBOL_EXPORT uint32_t
+chimera_server_config_get_soft_fail_bad_req(const struct chimera_server_config *config)
+{
+    return config->soft_fail_bad_req;
+} /* chimera_server_config_get_soft_fail_bad_req */
 
 static void
 chimera_server_thread_wake(

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -78,6 +78,15 @@ chimera_server_config_set_external_portmap(
     struct chimera_server_config *config,
     int                           enable);
 
+uint32_t
+chimera_server_config_get_soft_fail_bad_req(
+    const struct chimera_server_config *config);
+
+void
+chimera_server_config_set_soft_fail_bad_req(
+    struct chimera_server_config *config,
+    int                           enable);
+
 void
 chimera_server_config_set_nfs_rdma(
     struct chimera_server_config *config,

--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -133,6 +133,8 @@ chimera_smb_server_init(
                          shared->config.auth.kerberos_keytab[0] ? shared->config.auth.kerberos_keytab : "(default)");
     }
 
+    shared->config.soft_fail_bad_req = chimera_server_config_get_soft_fail_bad_req(config);
+
     shared->vfs     = vfs;
     shared->metrics = metrics;
 
@@ -851,7 +853,11 @@ chimera_smb_server_handle_smb2(
             } else {
                 chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
             }
-            evpl_finish(evpl, conn->bind);
+
+            if (thread->shared->config.soft_fail_bad_req == 0) {
+                evpl_finish(evpl, conn->bind);
+            }
+
             return;
         }
 

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -88,6 +88,7 @@ struct chimera_smb_config {
     int                            rdma_port;
     int                            num_dialects;
     int                            num_nic_info;
+    int                            soft_fail_bad_req;
     uint32_t                       capabilities;
     uint32_t                       dialects[16];
     struct chimera_smb_nic_info    nic_info[16];


### PR DESCRIPTION
Added a new server option called "soft_fail_bad_req"
When set to /true/, the SMB service will not disconnect if an invalid request is sent.
This is needed to allow the InvalidCreateRequestStructureSize test in the
Windows Protocol Test Suites to pass. The default is /false/ to retain current behavior.