### PR TITLE
Add NFSv4 LOCK, LOCKT, and LOCKU operation support

### DIFF
--- a/src/server/nfs/CMakeLists.txt
+++ b/src/server/nfs/CMakeLists.txt
@@ -23,7 +23,8 @@ add_library(chimera_nfs SHARED nfs.c nfs4_session.c nfs_mount.c nfs_portmap.c nf
             nfs4_proc_exchange_id.c nfs4_proc_create_session.c nfs4_proc_destroy_session.c
             nfs4_proc_destroy_clientid.c nfs4_proc_sequence.c nfs4_proc_reclaim_complete.c
             nfs4_proc_secinfo_no_name.c nfs4_proc_test_stateid.c nfs4_root.c
-            nfs4_proc_allocate.c nfs4_proc_deallocate.c nfs4_proc_seek.c)
+            nfs4_proc_allocate.c nfs4_proc_deallocate.c nfs4_proc_seek.c
+            nfs4_proc_lock.c nfs4_proc_lockt.c nfs4_proc_locku.c)
 
 target_compile_definitions(chimera_nfs PRIVATE XXH_INLINE_ALL)
 target_link_libraries(chimera_nfs chimera_nfs_common chimera_common evpl evpl_rpc2 pthread uuid urcu urcu-common)

--- a/src/server/nfs/nfs4_proc_close.c
+++ b/src/server/nfs/nfs4_proc_close.c
@@ -34,14 +34,29 @@ chimera_nfs4_close(
         evpl_rpc2_conn_set_private_data(req->conn, session);
     }
 
+    if (*(uint32_t *) args->open_stateid.other >= NFS4_SESSION_MAX_STATE) {
+        res->status = NFS4ERR_BAD_STATEID;
+        chimera_nfs4_compound_complete(req, NFS4_OK);
+        return;
+    }
+
     state = nfs4_session_get_state(session, &args->open_stateid);
+
+    if (state->nfs4_state_type != NFS4_STATE_TYPE_OPEN) {
+        res->status = NFS4ERR_BAD_STATEID;
+        chimera_nfs4_compound_complete(req, NFS4_OK);
+        return;
+    }
+
+    nfs4_session_free_lock_states(session, *(uint32_t *) state->nfs4_state_id.other);
+
+    res->open_stateid = state->nfs4_state_id;
 
     rc = nfs4_session_free_slot(session, state, &handle);
 
     if (rc < 0) {
         res->status = NFS4ERR_BAD_STATEID;
     } else {
-        res->open_stateid = state->nfs4_state_id;
         if (handle) {
             chimera_vfs_release(thread->vfs_thread, handle);
         }

--- a/src/server/nfs/nfs4_proc_compound.c
+++ b/src/server/nfs/nfs4_proc_compound.c
@@ -150,6 +150,15 @@ chimera_nfs4_compound_process(
             case OP_SEEK:
                 chimera_nfs4_seek(thread, req, argop, resop);
                 break;
+            case OP_LOCK:
+                chimera_nfs4_lock(thread, req, argop, resop);
+                break;
+            case OP_LOCKT:
+                chimera_nfs4_lockt(thread, req, argop, resop);
+                break;
+            case OP_LOCKU:
+                chimera_nfs4_locku(thread, req, argop, resop);
+                break;
             default:
                 chimera_nfs_error("Unsupported operation: %d", argop->argop);
                 if (argop->argop >= OP_ACCESS && argop->argop <= OP_CLONE) {

--- a/src/server/nfs/nfs4_proc_lock.c
+++ b/src/server/nfs/nfs4_proc_lock.c
@@ -1,0 +1,210 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "nfs4_procs.h"
+#include "nfs4_status.h"
+#include "nfs4_session.h"
+#include "vfs/vfs_procs.h"
+#include "vfs/vfs_release.h"
+
+static void
+chimera_nfs4_lock_complete(
+    enum chimera_vfs_error error_code,
+    uint32_t               conflict_type,
+    uint64_t               conflict_offset,
+    uint64_t               conflict_length,
+    pid_t                  conflict_pid,
+    void                  *private_data)
+{
+    struct nfs_request             *req        = private_data;
+    struct LOCK4args               *args       = &req->args_compound->argarray[req->index].oplock;
+    struct LOCK4res                *res        = &req->res_compound.resarray[req->index].oplock;
+    struct nfs4_session            *session    = req->session;
+    struct nfs4_state              *lock_state = req->nfs4_state;
+    struct chimera_vfs_open_handle *unused;
+
+    if (error_code == CHIMERA_VFS_OK) {
+        /* RFC 7530 Section 9.1.3: seqid starts at 1 for a new lock stateid;
+         * only increment when modifying an existing lock state. */
+        if (!args->locker.new_lock_owner) {
+            lock_state->nfs4_state_id.seqid++;
+            nfs4_session_release_state(session, lock_state);
+        }
+        res->status              = NFS4_OK;
+        res->resok4.lock_stateid = lock_state->nfs4_state_id;
+        chimera_nfs4_compound_complete(req, NFS4_OK);
+        return;
+    }
+
+    /* Lock conflict - free the slot if we just allocated it */
+    if (error_code == CHIMERA_VFS_EACCES || error_code == CHIMERA_VFS_EAGAIN) {
+        if (args->locker.new_lock_owner) {
+            lock_state->nfs4_state_handle = NULL;
+            nfs4_session_free_slot(session, lock_state, &unused);
+        } else {
+            nfs4_session_release_state(session, lock_state);
+        }
+        res->status          = NFS4ERR_DENIED;
+        res->denied.offset   = conflict_offset;
+        res->denied.length   = conflict_length;
+        res->denied.locktype = (conflict_type == CHIMERA_VFS_LOCK_READ) ?
+            READ_LT : WRITE_LT;
+        /* The VFS layer does not expose the conflicting lock's NFS owner;
+         * return a zeroed owner rather than the requester's clientid. */
+        res->denied.owner.clientid   = 0;
+        res->denied.owner.owner.len  = 0;
+        res->denied.owner.owner.data = NULL;
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    /* Other error - clean up allocated or acquired state */
+    if (args->locker.new_lock_owner) {
+        lock_state->nfs4_state_handle = NULL;
+        nfs4_session_free_slot(session, lock_state, &unused);
+    } else {
+        nfs4_session_release_state(session, lock_state);
+    }
+
+    res->status = chimera_nfs4_errno_to_nfsstat4(error_code);
+    chimera_nfs4_compound_complete(req, res->status);
+} /* chimera_nfs4_lock_complete */
+
+void
+chimera_nfs4_lock(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_request               *req,
+    struct nfs_argop4                *argop,
+    struct nfs_resop4                *resop)
+{
+    struct LOCK4args               *args = &argop->oplock;
+    struct LOCK4res                *res  = &resop->oplock;
+    struct nfs4_session            *session;
+    struct nfs4_state              *open_state;
+    struct nfs4_state              *lock_state;
+    struct chimera_vfs_open_handle *handle;
+    struct chimera_vfs_open_handle *unused;
+    uint32_t                        lock_type;
+
+    /* RFC 7530 Section 16.10.3: current filehandle must be set */
+    if (req->fhlen == 0) {
+        res->status = NFS4ERR_NOFILEHANDLE;
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    if (args->locktype == READ_LT || args->locktype == READW_LT) {
+        lock_type = CHIMERA_VFS_LOCK_READ;
+    } else {
+        lock_type = CHIMERA_VFS_LOCK_WRITE;
+    }
+
+    if (args->locker.new_lock_owner) {
+        /* First lock for this open - validate open stateid, allocate lock state */
+        session = nfs4_resolve_session(
+            req->session,
+            &args->locker.open_owner.open_stateid,
+            &thread->shared->nfs4_shared_clients);
+
+        if (!session) {
+            res->status = NFS4ERR_BAD_STATEID;
+            chimera_nfs4_compound_complete(req, res->status);
+            return;
+        }
+
+        if (!req->session) {
+            req->session = session;
+            evpl_rpc2_conn_set_private_data(req->conn, session);
+        }
+
+        if (nfs4_session_acquire_state(session,
+                                       &args->locker.open_owner.open_stateid,
+                                       &open_state,
+                                       &handle) != NFS4_OK) {
+            res->status = NFS4ERR_BAD_STATEID;
+            chimera_nfs4_compound_complete(req, res->status);
+            return;
+        }
+
+        if (open_state->nfs4_state_type != NFS4_STATE_TYPE_OPEN) {
+            nfs4_session_release_state(session, open_state);
+            res->status = NFS4ERR_BAD_STATEID;
+            chimera_nfs4_compound_complete(req, res->status);
+            return;
+        }
+
+        /* Allocate a lock state that borrows the open handle */
+        lock_state                         = nfs4_session_alloc_slot(session);
+        lock_state->nfs4_state_type        = NFS4_STATE_TYPE_LOCK;
+        lock_state->nfs4_state_handle      = handle;
+        lock_state->nfs4_state_parent_slot = *(uint32_t *) open_state->nfs4_state_id.other;
+
+        req->nfs4_state = lock_state;
+
+        /* Release the open state acquire ref - handle stays alive while open is active */
+        nfs4_session_release_state(session, open_state);
+
+    } else {
+        /* Subsequent lock - use existing lock stateid */
+        session = nfs4_resolve_session(
+            req->session,
+            &args->locker.lock_owner.lock_stateid,
+            &thread->shared->nfs4_shared_clients);
+
+        if (!session) {
+            res->status = NFS4ERR_BAD_STATEID;
+            chimera_nfs4_compound_complete(req, res->status);
+            return;
+        }
+
+        if (!req->session) {
+            req->session = session;
+            evpl_rpc2_conn_set_private_data(req->conn, session);
+        }
+
+        if (nfs4_session_acquire_state(session,
+                                       &args->locker.lock_owner.lock_stateid,
+                                       &lock_state,
+                                       &handle) != NFS4_OK) {
+            res->status = NFS4ERR_BAD_STATEID;
+            chimera_nfs4_compound_complete(req, res->status);
+            return;
+        }
+
+        if (lock_state->nfs4_state_type != NFS4_STATE_TYPE_LOCK) {
+            nfs4_session_release_state(session, lock_state);
+            res->status = NFS4ERR_BAD_STATEID;
+            chimera_nfs4_compound_complete(req, res->status);
+            return;
+        }
+
+        req->nfs4_state = lock_state;
+    }
+
+    /* RFC 7530 Section 16.10.4: length must not be zero; if not the all-ones
+     * "to-EOF" sentinel, offset+length must not exceed UINT64_MAX. */
+    if (args->length == 0 ||
+        (args->length != UINT64_MAX && args->offset > UINT64_MAX - args->length)) {
+        if (args->locker.new_lock_owner) {
+            lock_state->nfs4_state_handle = NULL;
+            nfs4_session_free_slot(session, lock_state, &unused);
+        } else {
+            nfs4_session_release_state(session, lock_state);
+        }
+        res->status = NFS4ERR_INVAL;
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    /* NFS uses UINT64_MAX to mean "to end of file"; POSIX fcntl uses 0. */
+    chimera_vfs_lock(thread->vfs_thread, &req->cred,
+                     handle,
+                     SEEK_SET,
+                     args->offset,
+                     args->length == UINT64_MAX ? 0 : args->length,
+                     lock_type,
+                     0,
+                     chimera_nfs4_lock_complete,
+                     req);
+} /* chimera_nfs4_lock */

--- a/src/server/nfs/nfs4_proc_lockt.c
+++ b/src/server/nfs/nfs4_proc_lockt.c
@@ -1,0 +1,123 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "nfs4_procs.h"
+#include "nfs4_status.h"
+#include "vfs/vfs_procs.h"
+#include "vfs/vfs_release.h"
+
+static void
+chimera_nfs4_lockt_complete(
+    enum chimera_vfs_error error_code,
+    uint32_t               conflict_type,
+    uint64_t               conflict_offset,
+    uint64_t               conflict_length,
+    pid_t                  conflict_pid,
+    void                  *private_data)
+{
+    struct nfs_request             *req    = private_data;
+    struct LOCKT4res               *res    = &req->res_compound.resarray[req->index].oplockt;
+    struct chimera_vfs_open_handle *handle = req->handle;
+
+    chimera_vfs_release(req->thread->vfs_thread, handle);
+    req->handle = NULL;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        res->status = chimera_nfs4_errno_to_nfsstat4(error_code);
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    /* F_GETLK always returns OK; conflict is signalled via conflict_type.
+     * LOCKT NFS4ERR_DENIED is a successful query result - compound stays NFS4_OK. */
+    if (conflict_type == CHIMERA_VFS_LOCK_UNLOCK) {
+        res->status = NFS4_OK;
+    } else {
+        res->status          = NFS4ERR_DENIED;
+        res->denied.offset   = conflict_offset;
+        res->denied.length   = conflict_length;
+        res->denied.locktype = (conflict_type == CHIMERA_VFS_LOCK_READ)
+            ? READ_LT : WRITE_LT;
+        /* The VFS layer does not expose the conflicting lock's NFS owner;
+         * return a zeroed owner rather than the requester's clientid. */
+        res->denied.owner.clientid   = 0;
+        res->denied.owner.owner.len  = 0;
+        res->denied.owner.owner.data = NULL;
+    }
+
+    chimera_nfs4_compound_complete(req, NFS4_OK);
+} /* chimera_nfs4_lockt_complete */
+
+static void
+chimera_nfs4_lockt_open_complete(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *handle,
+    void                           *private_data)
+{
+    struct nfs_request *req  = private_data;
+    struct LOCKT4args  *args = &req->args_compound->argarray[req->index].oplockt;
+    struct LOCKT4res   *res  = &req->res_compound.resarray[req->index].oplockt;
+    uint32_t            lock_type;
+    uint64_t            vfs_length;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        res->status = chimera_nfs4_errno_to_nfsstat4(error_code);
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    /* RFC 7530 Section 16.11.4: same length rules as LOCK */
+    if (args->length == 0 ||
+        (args->length != UINT64_MAX && args->offset > UINT64_MAX - args->length)) {
+        chimera_vfs_release(req->thread->vfs_thread, handle);
+        res->status = NFS4ERR_INVAL;
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    req->handle = handle;
+
+    if (args->locktype == READ_LT || args->locktype == READW_LT) {
+        lock_type = CHIMERA_VFS_LOCK_READ;
+    } else {
+        lock_type = CHIMERA_VFS_LOCK_WRITE;
+    }
+
+    /* NFS uses UINT64_MAX to mean "to end of file"; POSIX fcntl uses 0. */
+    vfs_length = args->length == UINT64_MAX ? 0 : args->length;
+
+    chimera_vfs_lock(req->thread->vfs_thread, &req->cred,
+                     handle,
+                     SEEK_SET,
+                     args->offset,
+                     vfs_length,
+                     lock_type,
+                     CHIMERA_VFS_LOCK_TEST,
+                     chimera_nfs4_lockt_complete,
+                     req);
+} /* chimera_nfs4_lockt_open_complete */
+
+void
+chimera_nfs4_lockt(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_request               *req,
+    struct nfs_argop4                *argop,
+    struct nfs_resop4                *resop)
+{
+    struct LOCKT4res *res = &resop->oplockt;
+
+    if (req->fhlen == 0) {
+        res->status = NFS4ERR_NOFILEHANDLE;
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    /* LOCKT operates on CURRENT_FH - open it temporarily to get a handle */
+    chimera_vfs_open_fh(thread->vfs_thread, &req->cred,
+                        req->fh,
+                        req->fhlen,
+                        CHIMERA_VFS_OPEN_INFERRED,
+                        chimera_nfs4_lockt_open_complete,
+                        req);
+} /* chimera_nfs4_lockt */

--- a/src/server/nfs/nfs4_proc_locku.c
+++ b/src/server/nfs/nfs4_proc_locku.c
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "nfs4_procs.h"
+#include "nfs4_status.h"
+#include "nfs4_session.h"
+#include "vfs/vfs_procs.h"
+#include "vfs/vfs_release.h"
+
+static void
+chimera_nfs4_locku_complete(
+    enum chimera_vfs_error error_code,
+    uint32_t               conflict_type,
+    uint64_t               conflict_offset,
+    uint64_t               conflict_length,
+    pid_t                  conflict_pid,
+    void                  *private_data)
+{
+    struct nfs_request *req        = private_data;
+    struct LOCKU4res   *res        = &req->res_compound.resarray[req->index].oplocku;
+    struct nfs4_state  *lock_state = req->nfs4_state;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        nfs4_session_release_state(req->session, lock_state);
+        res->status = chimera_nfs4_errno_to_nfsstat4(error_code);
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    lock_state->nfs4_state_id.seqid++;
+    res->status       = NFS4_OK;
+    res->lock_stateid = lock_state->nfs4_state_id;
+    nfs4_session_release_state(req->session, lock_state);
+
+    chimera_nfs4_compound_complete(req, NFS4_OK);
+} /* chimera_nfs4_locku_complete */
+
+void
+chimera_nfs4_locku(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_request               *req,
+    struct nfs_argop4                *argop,
+    struct nfs_resop4                *resop)
+{
+    struct LOCKU4args              *args = &argop->oplocku;
+    struct LOCKU4res               *res  = &resop->oplocku;
+    struct nfs4_session            *session;
+    struct nfs4_state              *lock_state;
+    struct chimera_vfs_open_handle *handle;
+    uint64_t                        vfs_length;
+
+    /* RFC 7530 Section 16.12.3: current filehandle must be set */
+    if (req->fhlen == 0) {
+        res->status = NFS4ERR_NOFILEHANDLE;
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    session = nfs4_resolve_session(
+        req->session,
+        &args->lock_stateid,
+        &thread->shared->nfs4_shared_clients);
+
+    if (!session) {
+        res->status = NFS4ERR_BAD_STATEID;
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    if (!req->session) {
+        req->session = session;
+        evpl_rpc2_conn_set_private_data(req->conn, session);
+    }
+
+    if (nfs4_session_acquire_state(session,
+                                   &args->lock_stateid,
+                                   &lock_state,
+                                   &handle) != NFS4_OK) {
+        res->status = NFS4ERR_BAD_STATEID;
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    if (lock_state->nfs4_state_type != NFS4_STATE_TYPE_LOCK) {
+        nfs4_session_release_state(session, lock_state);
+        res->status = NFS4ERR_BAD_STATEID;
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    req->nfs4_state = lock_state;
+
+    /* RFC 7530 Section 16.12.4: same length rules as LOCK */
+    if (args->length == 0 ||
+        (args->length != UINT64_MAX && args->offset > UINT64_MAX - args->length)) {
+        nfs4_session_release_state(session, lock_state);
+        res->status = NFS4ERR_INVAL;
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    /* NFS uses UINT64_MAX to mean "to end of file"; POSIX fcntl uses 0. */
+    vfs_length = args->length == UINT64_MAX ? 0 : args->length;
+
+    chimera_vfs_lock(thread->vfs_thread, &req->cred,
+                     handle,
+                     SEEK_SET,
+                     args->offset,
+                     vfs_length,
+                     CHIMERA_VFS_LOCK_UNLOCK,
+                     0,
+                     chimera_nfs4_locku_complete,
+                     req);
+} /* chimera_nfs4_locku */

--- a/src/server/nfs/nfs4_proc_open.c
+++ b/src/server/nfs/nfs4_proc_open.c
@@ -58,12 +58,13 @@ chimera_nfs4_open_exclusive_verify(
     state                    = nfs4_session_alloc_slot(session);
     state->nfs4_state_handle = handle;
 
-    res->status                            = NFS4_OK;
-    res->resok4.stateid                    = state->nfs4_state_id;
-    res->resok4.cinfo.atomic               = 0;
-    res->resok4.cinfo.before               = 0;
-    res->resok4.cinfo.after                = 0;
-    res->resok4.rflags                     = 0;
+    res->status              = NFS4_OK;
+    res->resok4.stateid      = state->nfs4_state_id;
+    res->resok4.cinfo.atomic = 0;
+    res->resok4.cinfo.before = 0;
+    res->resok4.cinfo.after  = 0;
+    res->resok4.rflags       = (handle->vfs_module->capabilities & CHIMERA_VFS_CAP_FS_LOCK) ?
+        OPEN4_RESULT_LOCKTYPE_POSIX : 0;
     res->resok4.num_attrset                = 0;
     res->resok4.delegation.delegation_type = OPEN_DELEGATE_NONE;
 
@@ -121,12 +122,13 @@ chimera_nfs4_open_at_complete(
     state                    = nfs4_session_alloc_slot(session);
     state->nfs4_state_handle = handle;
 
-    res->status                            = NFS4_OK;
-    res->resok4.stateid                    = state->nfs4_state_id;
-    res->resok4.cinfo.atomic               = 0;
-    res->resok4.cinfo.before               = 0;
-    res->resok4.cinfo.after                = 0;
-    res->resok4.rflags                     = 0;
+    res->status              = NFS4_OK;
+    res->resok4.stateid      = state->nfs4_state_id;
+    res->resok4.cinfo.atomic = 0;
+    res->resok4.cinfo.before = 0;
+    res->resok4.cinfo.after  = 0;
+    res->resok4.rflags       = (handle->vfs_module->capabilities & CHIMERA_VFS_CAP_FS_LOCK) ?
+        OPEN4_RESULT_LOCKTYPE_POSIX : 0;
     res->resok4.num_attrset                = 0;
     res->resok4.delegation.delegation_type = OPEN_DELEGATE_NONE;
 
@@ -182,12 +184,13 @@ chimera_nfs4_open_complete(
     state                    = nfs4_session_alloc_slot(session);
     state->nfs4_state_handle = handle;
 
-    res->status                            = NFS4_OK;
-    res->resok4.stateid                    = state->nfs4_state_id;
-    res->resok4.cinfo.atomic               = 0;
-    res->resok4.cinfo.before               = 0;
-    res->resok4.cinfo.after                = 0;
-    res->resok4.rflags                     = 0;
+    res->status              = NFS4_OK;
+    res->resok4.stateid      = state->nfs4_state_id;
+    res->resok4.cinfo.atomic = 0;
+    res->resok4.cinfo.before = 0;
+    res->resok4.cinfo.after  = 0;
+    res->resok4.rflags       = (handle->vfs_module->capabilities & CHIMERA_VFS_CAP_FS_LOCK) ?
+        OPEN4_RESULT_LOCKTYPE_POSIX : 0;
     res->resok4.num_attrset                = 0;
     res->resok4.delegation.delegation_type = OPEN_DELEGATE_NONE;
 

--- a/src/server/nfs/nfs4_procs.h
+++ b/src/server/nfs/nfs4_procs.h
@@ -306,6 +306,27 @@ chimera_nfs4_seek(
     struct nfs_resop4                *resop);
 
 void
+chimera_nfs4_lock(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_request               *req,
+    struct nfs_argop4                *argop,
+    struct nfs_resop4                *resop);
+
+void
+chimera_nfs4_lockt(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_request               *req,
+    struct nfs_argop4                *argop,
+    struct nfs_resop4                *resop);
+
+void
+chimera_nfs4_locku(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_request               *req,
+    struct nfs_argop4                *argop,
+    struct nfs_resop4                *resop);
+
+void
 chimera_nfs4_compound_process(
     struct nfs_request *req,
     nfsstat4            status);

--- a/src/server/nfs/nfs4_session.h
+++ b/src/server/nfs/nfs4_session.h
@@ -13,12 +13,16 @@
 
 #define NFS4_SESSION_MAX_STATE 1024
 
+#define NFS4_STATE_TYPE_OPEN   0
+#define NFS4_STATE_TYPE_LOCK   1
+
 struct nfs4_state {
     struct stateid4                 nfs4_state_id;
     uint16_t                        nfs4_state_type;
     uint16_t                        nfs4_state_active;
     uint32_t                        nfs4_state_refcnt;
     struct chimera_vfs_open_handle *nfs4_state_handle;
+    uint32_t                        nfs4_state_parent_slot; /* open slot index for LOCK states */
 };
 
 struct nfs4_client {
@@ -127,9 +131,11 @@ nfs4_session_alloc_slot(struct nfs4_session *session)
     *(uint32_t *) state->nfs4_state_id.other       = slot;
     *(uint64_t *) (state->nfs4_state_id.other + 4) = session->nfs4_session_clientid;
 
-    state->nfs4_state_active = 1;
-    state->nfs4_state_refcnt = 0;
-    state->nfs4_state_handle = NULL;
+    state->nfs4_state_type        = NFS4_STATE_TYPE_OPEN;
+    state->nfs4_state_active      = 1;
+    state->nfs4_state_refcnt      = 0;
+    state->nfs4_state_handle      = NULL;
+    state->nfs4_state_parent_slot = NFS4_SESSION_MAX_STATE;
 
     pthread_mutex_unlock(&session->nfs4_session_lock);
 
@@ -156,7 +162,9 @@ nfs4_session_free_slot(
     state->nfs4_state_active = 0;
 
     if (state->nfs4_state_refcnt == 0) {
-        *out_handle                                   = state->nfs4_state_handle;
+        if (state->nfs4_state_type != NFS4_STATE_TYPE_LOCK) {
+            *out_handle = state->nfs4_state_handle;
+        }
         state->nfs4_state_handle                      = NULL;
         session->free_slot[session->num_free_slots++] = slot;
         pthread_mutex_unlock(&session->nfs4_session_lock);
@@ -167,6 +175,26 @@ nfs4_session_free_slot(
     pthread_mutex_unlock(&session->nfs4_session_lock);
     return 1;
 } /* nfs4_session_free_slot */
+
+static inline void
+nfs4_session_free_lock_states(
+    struct nfs4_session *session,
+    uint32_t             open_slot)
+{
+    struct chimera_vfs_open_handle *unused;
+    uint32_t                        i;
+
+    for (i = 0; i < NFS4_SESSION_MAX_STATE; i++) {
+        struct nfs4_state *s = &session->nfs4_session_state[i];
+
+        if (s->nfs4_state_type        == NFS4_STATE_TYPE_LOCK &&
+            s->nfs4_state_active      == 1 &&
+            s->nfs4_state_parent_slot == open_slot) {
+            s->nfs4_state_handle = NULL;
+            nfs4_session_free_slot(session, s, &unused);
+        }
+    }
+} /* nfs4_session_free_lock_states */
 
 static inline struct nfs4_state *
 nfs4_session_get_state(
@@ -229,8 +257,10 @@ nfs4_session_release_state(
     state->nfs4_state_refcnt--;
 
     if (state->nfs4_state_refcnt == 0 && !state->nfs4_state_active) {
-        /* CLOSE already ran; we are the last user — do deferred cleanup */
-        handle                   = state->nfs4_state_handle;
+        /* CLOSE already ran; we are the last user - do deferred cleanup */
+        if (state->nfs4_state_type != NFS4_STATE_TYPE_LOCK) {
+            handle = state->nfs4_state_handle;
+        }
         state->nfs4_state_handle = NULL;
         uint32_t slot = *(uint32_t *) state->nfs4_state_id.other;
         session->free_slot[session->num_free_slots++] = slot;


### PR DESCRIPTION
Implement the three NFS4 byte-range locking operations (LOCK, LOCKT, LOCKU) backed by the VFS lock interface (chimera_vfs_lock).

Lock stateids are distinct from open stateids. A new NFS4_STATE_TYPE_LOCK type is introduced alongside NFS4_STATE_TYPE_OPEN. Lock states record their parent open slot so that CLOSE can sweep and free all associated lock states.

OPEN now sets OPEN4_RESULT_LOCKTYPE_POSIX in rflags when the VFS module advertises CHIMERA_VFS_CAP_FS_LOCK, signalling to the client that POSIX locking semantics apply.