### PR TITLE
Improve NFSv4 error codes and centralize name/attr validation

### DIFF
--- a/src/server/nfs/nfs4_attr.h
+++ b/src/server/nfs/nfs4_attr.h
@@ -731,6 +731,99 @@ chimera_nfs4_unmarshall_attrs(
     return (attrs <= attrsend) ? 0 : -1;
 } /* chimera_nfs4_unmarshall_attrs */
 
+static inline nfsstat4
+chimera_nfs4_validate_createattrs(
+    uint32_t        num_attrmask,
+    const uint32_t *attrmask)
+{
+    static const uint32_t supported_word0 =
+        (1 << FATTR4_SUPPORTED_ATTRS) |
+        (1 << FATTR4_TYPE) |
+        (1 << FATTR4_FH_EXPIRE_TYPE) |
+        (1 << FATTR4_CHANGE) |
+        (1 << FATTR4_SIZE) |
+        (1 << FATTR4_LINK_SUPPORT) |
+        (1 << FATTR4_SYMLINK_SUPPORT) |
+        (1 << FATTR4_NAMED_ATTR) |
+        (1 << FATTR4_FSID) |
+        (1 << FATTR4_UNIQUE_HANDLES) |
+        (1 << FATTR4_LEASE_TIME) |
+        (1 << FATTR4_RDATTR_ERROR) |
+        /* no FATTR4_ACL = 12 */
+        (1 << FATTR4_ACLSUPPORT) |
+        (1 << FATTR4_ARCHIVE) |
+        (1 << FATTR4_CANSETTIME) |
+        (1 << FATTR4_CASE_INSENSITIVE) |
+        (1 << FATTR4_CASE_PRESERVING) |
+        (1 << FATTR4_CHOWN_RESTRICTED) |
+        (1 << FATTR4_FILEHANDLE) |
+        (1 << FATTR4_FILEID) |
+        (1 << FATTR4_FILES_AVAIL) |
+        (1 << FATTR4_FILES_FREE) |
+        (1 << FATTR4_FILES_TOTAL) |
+        /* no fs_locations=24, hidden=25, homogeneous=26, maxfilesize=27, maxlink=28 */
+        (1 << FATTR4_MAXNAME) |
+        (1 << FATTR4_MAXREAD) |
+        (1U << FATTR4_MAXWRITE);
+
+    static const uint32_t supported_word1 =
+        (1 << (FATTR4_MODE - 32)) |
+        (1 << (FATTR4_NUMLINKS - 32)) |
+        (1 << (FATTR4_OWNER - 32)) |
+        (1 << (FATTR4_OWNER_GROUP - 32)) |
+        (1 << (FATTR4_SPACE_AVAIL - 32)) |
+        (1 << (FATTR4_SPACE_FREE - 32)) |
+        (1 << (FATTR4_SPACE_TOTAL - 32)) |
+        (1 << (FATTR4_SPACE_USED - 32)) |
+        (1 << (FATTR4_TIME_ACCESS - 32)) |
+        (1 << (FATTR4_TIME_ACCESS_SET - 32)) |
+        (1 << (FATTR4_TIME_METADATA - 32)) |
+        (1 << (FATTR4_TIME_MODIFY - 32)) |
+        (1 << (FATTR4_TIME_MODIFY_SET - 32));
+
+    static const uint32_t writable_word0 =
+        (1 << FATTR4_SIZE);
+
+    static const uint32_t writable_word1 =
+        (1 << (FATTR4_MODE - 32)) |
+        (1 << (FATTR4_OWNER - 32)) |
+        (1 << (FATTR4_OWNER_GROUP - 32)) |
+        (1 << (FATTR4_TIME_ACCESS_SET - 32)) |
+        (1 << (FATTR4_TIME_MODIFY_SET - 32));
+
+    uint32_t              w;
+
+    if (num_attrmask >= 1) {
+        w = attrmask[0];
+
+        if (w & ~supported_word0) {
+            return NFS4ERR_ATTRNOTSUPP;
+        }
+
+        if (w & supported_word0 & ~writable_word0) {
+            return NFS4ERR_INVAL;
+        }
+    }
+
+    if (num_attrmask >= 2) {
+        w = attrmask[1];
+
+        if (w & ~supported_word1) {
+            return NFS4ERR_ATTRNOTSUPP;
+        }
+
+        if (w & supported_word1 & ~writable_word1) {
+            return NFS4ERR_INVAL;
+        }
+    }
+
+    if (num_attrmask >= 3 && attrmask[2] != 0) {
+        return NFS4ERR_ATTRNOTSUPP;
+    }
+
+    return NFS4_OK;
+} /* chimera_nfs4_validate_createattrs */
+
 static void
 chimera_nfs4_set_changeinfo(
     struct change_info4      *cinfo,

--- a/src/server/nfs/nfs4_proc_create.c
+++ b/src/server/nfs/nfs4_proc_create.c
@@ -182,6 +182,13 @@ chimera_nfs4_create_open_callback(
                 chimera_vfs_release(thread->vfs_thread, handle);
                 return;
             case NF4LNK:
+                if (args->objtype.linkdata.len == 0) {
+                    struct CREATE4res *res = &req->res_compound.resarray[req->index].opcreate;
+                    res->status = NFS4ERR_INVAL;
+                    chimera_nfs4_compound_complete(req, NFS4ERR_INVAL);
+                    chimera_vfs_release(thread->vfs_thread, handle);
+                    return;
+                }
                 req->handle = handle;
 
                 chimera_vfs_symlink_at(
@@ -228,9 +235,18 @@ chimera_nfs4_create(
         return;
     }
 
-    if (args->objname.len == 0) {
-        res->status = NFS4ERR_INVAL;
-        chimera_nfs4_compound_complete(req, NFS4ERR_INVAL);
+    res->status = chimera_nfs4_validate_name(&args->objname);
+
+    if (res->status != NFS4_OK) {
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    res->status = chimera_nfs4_validate_createattrs(args->createattrs.num_attrmask,
+                                                    args->createattrs.attrmask);
+
+    if (res->status != NFS4_OK) {
+        chimera_nfs4_compound_complete(req, res->status);
         return;
     }
 

--- a/src/server/nfs/nfs4_proc_link.c
+++ b/src/server/nfs/nfs4_proc_link.c
@@ -95,17 +95,10 @@ chimera_nfs4_link(
         return;
     }
 
-    if (args->newname.len == 0) {
-        res->status = NFS4ERR_INVAL;
-        chimera_nfs4_compound_complete(req, NFS4ERR_INVAL);
-        return;
-    }
+    res->status = chimera_nfs4_validate_name(&args->newname);
 
-    if ((args->newname.len == 1 && ((const char *) args->newname.data)[0] == '.') ||
-        (args->newname.len == 2 && ((const char *) args->newname.data)[0] == '.' &&
-         ((const char *) args->newname.data)[1] == '.')) {
-        res->status = NFS4ERR_BADNAME;
-        chimera_nfs4_compound_complete(req, NFS4ERR_BADNAME);
+    if (res->status != NFS4_OK) {
+        chimera_nfs4_compound_complete(req, res->status);
         return;
     }
 

--- a/src/server/nfs/nfs4_proc_lookup.c
+++ b/src/server/nfs/nfs4_proc_lookup.c
@@ -77,17 +77,10 @@ chimera_nfs4_lookup(
         return;
     }
 
-    if (args->objname.len == 0) {
-        res->status = NFS4ERR_INVAL;
-        chimera_nfs4_compound_complete(req, NFS4ERR_INVAL);
-        return;
-    }
+    res->status = chimera_nfs4_validate_name(&args->objname);
 
-    if ((args->objname.len == 1 && ((const char *) args->objname.data)[0] == '.') ||
-        (args->objname.len == 2 && ((const char *) args->objname.data)[0] == '.' &&
-         ((const char *) args->objname.data)[1] == '.')) {
-        res->status = NFS4ERR_BADNAME;
-        chimera_nfs4_compound_complete(req, NFS4ERR_BADNAME);
+    if (res->status != NFS4_OK) {
+        chimera_nfs4_compound_complete(req, res->status);
         return;
     }
 

--- a/src/server/nfs/nfs4_proc_open.c
+++ b/src/server/nfs/nfs4_proc_open.c
@@ -213,6 +213,7 @@ chimera_nfs4_open_parent_complete(
     struct nfs_request       *req   = private_data;
     struct OPEN4args         *args  = &req->args_compound->argarray[req->index].opopen;
     unsigned int              flags = 0;
+    nfsstat4                  status;
     struct chimera_vfs_attrs *attr;
 
     req->handle = parent_handle;
@@ -239,6 +240,16 @@ chimera_nfs4_open_parent_complete(
                 flags |= CHIMERA_VFS_OPEN_EXCLUSIVE;
             /* fallthrough */
             case UNCHECKED4:
+                status = chimera_nfs4_validate_createattrs(
+                    args->openhow.how.createattrs.num_attrmask,
+                    args->openhow.how.createattrs.attrmask);
+                if (status != NFS4_OK) {
+                    struct OPEN4res *res = &req->res_compound.resarray[req->index].opopen;
+                    chimera_vfs_release(req->thread->vfs_thread, parent_handle);
+                    res->status = status;
+                    chimera_nfs4_compound_complete(req, status);
+                    return;
+                }
                 chimera_nfs4_unmarshall_attrs(attr,
                                               args->openhow.how.createattrs.num_attrmask,
                                               args->openhow.how.createattrs.attrmask,
@@ -247,6 +258,16 @@ chimera_nfs4_open_parent_complete(
                 break;
             case EXCLUSIVE4_1:
                 flags |= CHIMERA_VFS_OPEN_EXCLUSIVE;
+                status = chimera_nfs4_validate_createattrs(
+                    args->openhow.how.ch_createboth.cva_attrs.num_attrmask,
+                    args->openhow.how.ch_createboth.cva_attrs.attrmask);
+                if (status != NFS4_OK) {
+                    struct OPEN4res *res = &req->res_compound.resarray[req->index].opopen;
+                    chimera_vfs_release(req->thread->vfs_thread, parent_handle);
+                    res->status = status;
+                    chimera_nfs4_compound_complete(req, status);
+                    return;
+                }
                 chimera_nfs4_unmarshall_attrs(attr,
                                               args->openhow.how.ch_createboth.cva_attrs.num_attrmask,
                                               args->openhow.how.ch_createboth.cva_attrs.attrmask,
@@ -280,6 +301,16 @@ chimera_nfs4_open_parent_complete(
 
     switch (args->claim.claim) {
         case CLAIM_NULL:
+            status = chimera_nfs4_validate_name(&args->claim.file);
+
+            if (status != NFS4_OK) {
+                struct OPEN4res *res = &req->res_compound.resarray[req->index].opopen;
+                chimera_vfs_release(req->thread->vfs_thread, parent_handle);
+                res->status = status;
+                chimera_nfs4_compound_complete(req, status);
+                return;
+            }
+
             chimera_vfs_open_at(req->thread->vfs_thread, &req->cred,
                                 parent_handle,
                                 args->claim.file.data,

--- a/src/server/nfs/nfs4_proc_remove.c
+++ b/src/server/nfs/nfs4_proc_remove.c
@@ -77,17 +77,10 @@ chimera_nfs4_remove(
         return;
     }
 
-    if (args->target.len == 0) {
-        res->status = NFS4ERR_INVAL;
-        chimera_nfs4_compound_complete(req, NFS4ERR_INVAL);
-        return;
-    }
+    res->status = chimera_nfs4_validate_name(&args->target);
 
-    if ((args->target.len == 1 && ((const char *) args->target.data)[0] == '.') ||
-        (args->target.len == 2 && ((const char *) args->target.data)[0] == '.' &&
-         ((const char *) args->target.data)[1] == '.')) {
-        res->status = NFS4ERR_BADNAME;
-        chimera_nfs4_compound_complete(req, NFS4ERR_BADNAME);
+    if (res->status != NFS4_OK) {
+        chimera_nfs4_compound_complete(req, res->status);
         return;
     }
 

--- a/src/server/nfs/nfs4_proc_rename.c
+++ b/src/server/nfs/nfs4_proc_rename.c
@@ -83,21 +83,6 @@ chimera_nfs4_rename_open_callback(
 } /* chimera_nfs4_rename_open_callback */
 
 
-static nfsstat4
-chimera_nfs4_check_name(const xdr_opaque *name)
-{
-    if (name->len == 0) {
-        return NFS4ERR_INVAL;
-    }
-
-    if ((name->len == 1 && ((const char *) name->data)[0] == '.') ||
-        (name->len == 2 && ((const char *) name->data)[0] == '.' &&
-         ((const char *) name->data)[1] == '.')) {
-        return NFS4ERR_BADNAME;
-    }
-
-    return NFS4_OK;
-} /* chimera_nfs4_check_name */
 
 void
 chimera_nfs4_rename(
@@ -116,10 +101,10 @@ chimera_nfs4_rename(
         return;
     }
 
-    status = chimera_nfs4_check_name(&args->oldname);
+    status = chimera_nfs4_validate_name(&args->oldname);
 
     if (status == NFS4_OK) {
-        status = chimera_nfs4_check_name(&args->newname);
+        status = chimera_nfs4_validate_name(&args->newname);
     }
 
     if (status != NFS4_OK) {

--- a/src/server/nfs/nfs4_procs.h
+++ b/src/server/nfs/nfs4_procs.h
@@ -331,6 +331,99 @@ chimera_nfs4_compound_process(
     struct nfs_request *req,
     nfsstat4            status);
 
+static inline nfsstat4
+chimera_nfs4_validate_name(const xdr_opaque *name)
+{
+    const char *p;
+    uint32_t    i;
+
+    if (name->len == 0) {
+        return NFS4ERR_INVAL;
+    }
+
+    if (name->len > 255) {
+        return NFS4ERR_NAMETOOLONG;
+    }
+
+    if ((name->len == 1 && ((const char *) name->data)[0] == '.') ||
+        (name->len == 2 && ((const char *) name->data)[0] == '.' &&
+         ((const char *) name->data)[1] == '.')) {
+        return NFS4ERR_BADNAME;
+    }
+
+    p = (const char *) name->data;
+
+    for (i = 0; i < name->len; ) {
+        unsigned char c     = (unsigned char) p[i];
+        uint32_t      extra = 0;
+
+        if (c == '/' || c == '\0') {
+            return NFS4ERR_BADCHAR;
+        }
+
+        if (c < 0x80) {
+            i++;
+            continue;
+        } else if (c < 0xC2) {
+            /* 0x80-0xBF: stray continuation byte; 0xC0-0xC1: overlong encoding */
+            return NFS4ERR_INVAL;
+        } else if (c < 0xE0) {
+            extra = 1;
+        } else if (c < 0xF0) {
+            unsigned char c2;
+            /* 3-byte sequence: need at least one more byte to range-check */
+            if (i + 1 >= name->len || ((unsigned char) p[i + 1] & 0xC0) != 0x80) {
+                return NFS4ERR_INVAL;
+            }
+            c2    = (unsigned char) p[i + 1];
+            extra = 2;
+            /* 0xE0 0x80-0x9F: overlong (encodes U+0000-U+07FF in 3 bytes) */
+            if (c == 0xE0 && c2 < 0xA0) {
+                return NFS4ERR_INVAL;
+            }
+            /* 0xED 0xA0-0xBF: surrogate (U+D800-U+DFFF) */
+            if (c == 0xED && c2 >= 0xA0) {
+                return NFS4ERR_INVAL;
+            }
+            /* 0xEF 0xBF 0xBE/0xBF: U+FFFE and U+FFFF are non-characters */
+            if (c == 0xEF && c2 == 0xBF && i + 2 < name->len) {
+                unsigned char c3 = (unsigned char) p[i + 2];
+                if (c3 == 0xBE || c3 == 0xBF) {
+                    return NFS4ERR_INVAL;
+                }
+            }
+        } else if (c <= 0xF4) {
+            unsigned char c2;
+            /* 4-byte sequence: need at least one more byte to range-check */
+            if (i + 1 >= name->len || ((unsigned char) p[i + 1] & 0xC0) != 0x80) {
+                return NFS4ERR_INVAL;
+            }
+            c2    = (unsigned char) p[i + 1];
+            extra = 3;
+            /* 0xF0 0x80-0x8F: overlong (encodes U+0000-U+FFFF in 4 bytes) */
+            if (c == 0xF0 && c2 < 0x90) {
+                return NFS4ERR_INVAL;
+            }
+            /* 0xF4 0x90-0xBF: above U+10FFFF */
+            if (c == 0xF4 && c2 > 0x8F) {
+                return NFS4ERR_INVAL;
+            }
+        } else {
+            return NFS4ERR_INVAL;
+        }
+
+        i++;
+        while (extra--) {
+            if (i >= name->len || ((unsigned char) p[i] & 0xC0) != 0x80) {
+                return NFS4ERR_INVAL;
+            }
+            i++;
+        }
+    }
+
+    return NFS4_OK;
+} /* chimera_nfs4_validate_name */
+
 static inline void
 chimera_nfs4_compound_complete(
     struct nfs_request *req,

--- a/src/server/nfs/nfs4_status.h
+++ b/src/server/nfs/nfs4_status.h
@@ -59,6 +59,8 @@ chimera_nfs4_errno_to_nfsstat4(enum chimera_vfs_error err)
             return NFS4ERR_TOOSMALL;
         case CHIMERA_VFS_EFAULT:
             return NFS4ERR_SERVERFAULT;
+        case CHIMERA_VFS_ESYMLINK:
+            return NFS4ERR_SYMLINK;
         default:
             chimera_nfs_error("Unknown VFS error code: %d", err);
             abort();

--- a/src/vfs/cairn/cairn.c
+++ b/src/vfs/cairn/cairn.c
@@ -1162,8 +1162,9 @@ cairn_lookup_at(
     inode = ih.inode;
 
     if (unlikely(!S_ISDIR(inode->mode))) {
+        enum chimera_vfs_error err = S_ISLNK(inode->mode) ? CHIMERA_VFS_ESYMLINK : CHIMERA_VFS_ENOTDIR;
         cairn_inode_handle_release(&ih);
-        request->status = CHIMERA_VFS_ENOENT;
+        request->status = err;
         request->complete(request);
         return;
     }
@@ -1483,7 +1484,7 @@ cairn_remove_at(
 
     if (!S_ISDIR(parent_inode->mode)) {
         cairn_inode_handle_release(&parent_ih);
-        request->status = CHIMERA_VFS_ENOENT;
+        request->status = CHIMERA_VFS_ENOTDIR;
         request->complete(request);
         return;
     }
@@ -2618,15 +2619,16 @@ cairn_symlink_at(
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
-    rocksdb_transaction_t    *txn;
-    struct cairn_inode_handle parent_ih;
-    struct cairn_inode       *parent_inode, new_inode;
-    struct cairn_dirent_key   dirent_key;
-    struct cairn_dirent_value dirent_value;
-    struct cairn_symlink_key  target_key;
-    char                     *err = NULL;
-    int                       rc;
-    struct timespec           now;
+    rocksdb_transaction_t     *txn;
+    struct cairn_inode_handle  parent_ih;
+    struct cairn_dirent_handle dh;
+    struct cairn_inode        *parent_inode, new_inode;
+    struct cairn_dirent_key    dirent_key;
+    struct cairn_dirent_value  dirent_value;
+    struct cairn_symlink_key   target_key;
+    char                      *err = NULL;
+    int                        rc;
+    struct timespec            now;
 
     clock_gettime(CLOCK_REALTIME, &now);
     txn = cairn_get_transaction(thread);
@@ -2653,6 +2655,16 @@ cairn_symlink_at(
     dirent_key.keytype = CAIRN_KEY_DIRENT;
     dirent_key.inum    = parent_inode->inum;
     dirent_key.hash    = request->symlink_at.name_hash;
+
+    rc = cairn_dirent_get(thread, txn, &dirent_key, &dh);
+
+    if (rc == 0) {
+        cairn_inode_handle_release(&parent_ih);
+        cairn_dirent_handle_release(&dh);
+        request->status = CHIMERA_VFS_EEXIST;
+        request->complete(request);
+        return;
+    }
 
     cairn_alloc_inum(thread, &new_inode);
     new_inode.size       = request->symlink_at.targetlen;
@@ -3044,7 +3056,7 @@ cairn_link_at(
     if (S_ISDIR(target_inode->mode)) {
         cairn_inode_handle_release(&parent_ih);
         cairn_inode_handle_release(&target_ih);
-        request->status = CHIMERA_VFS_EPERM;
+        request->status = CHIMERA_VFS_EISDIR;
         request->complete(request);
         return;
     }

--- a/src/vfs/demofs/demofs.c
+++ b/src/vfs/demofs/demofs.c
@@ -1259,8 +1259,9 @@ demofs_lookup_at(
     }
 
     if (unlikely(!S_ISDIR(inode->mode))) {
+        enum chimera_vfs_error err = S_ISLNK(inode->mode) ? CHIMERA_VFS_ESYMLINK : CHIMERA_VFS_ENOTDIR;
         pthread_mutex_unlock(&inode->lock);
-        request->status = CHIMERA_VFS_ENOTDIR;
+        request->status = err;
         request->complete(request);
         return;
     }
@@ -1553,7 +1554,7 @@ demofs_remove_at(
 
     if (!S_ISDIR(parent_inode->mode)) {
         pthread_mutex_unlock(&parent_inode->lock);
-        request->status = CHIMERA_VFS_ENOENT;
+        request->status = CHIMERA_VFS_ENOTDIR;
         request->complete(request);
         return;
     }
@@ -3439,7 +3440,7 @@ demofs_link_at(
     if (unlikely(S_ISDIR(inode->mode))) {
         pthread_mutex_unlock(&parent_inode->lock);
         pthread_mutex_unlock(&inode->lock);
-        request->status = CHIMERA_VFS_EPERM;
+        request->status = CHIMERA_VFS_EISDIR;
         request->complete(request);
         return;
     }

--- a/src/vfs/io_uring/io_uring.c
+++ b/src/vfs/io_uring/io_uring.c
@@ -906,7 +906,26 @@ chimera_io_uring_open_fh(
                               flags);
 
     if (fd < 0) {
-        request->status = chimera_linux_errno_to_status(errno);
+        if (errno == ENOTDIR && (request->open_fh.flags & CHIMERA_VFS_OPEN_DIRECTORY)) {
+            int         probe_fd = linux_open_by_handle(&thread->mount_table,
+                                                        request->fh,
+                                                        request->fh_len,
+                                                        O_PATH | O_NOFOLLOW);
+            struct stat st;
+
+            if (probe_fd >= 0) {
+                if (fstat(probe_fd, &st) == 0 && S_ISLNK(st.st_mode)) {
+                    request->status = CHIMERA_VFS_ESYMLINK;
+                } else {
+                    request->status = CHIMERA_VFS_ENOTDIR;
+                }
+                close(probe_fd);
+            } else {
+                request->status = CHIMERA_VFS_ENOTDIR;
+            }
+        } else {
+            request->status = chimera_linux_errno_to_status(errno);
+        }
         request->complete(request);
         return;
     }
@@ -1561,7 +1580,17 @@ chimera_io_uring_link_at(
     rc = linkat(fd, "", dir_fd, fullname, AT_EMPTY_PATH);
 
     if (rc < 0) {
-        request->status = chimera_linux_errno_to_status(errno);
+        if (errno == EPERM) {
+            struct stat st;
+
+            if (fstat(fd, &st) == 0 && S_ISDIR(st.st_mode)) {
+                request->status = CHIMERA_VFS_EISDIR;
+            } else {
+                request->status = CHIMERA_VFS_EPERM;
+            }
+        } else {
+            request->status = chimera_linux_errno_to_status(errno);
+        }
     } else {
         request->status = CHIMERA_VFS_OK;
     }

--- a/src/vfs/linux/linux.c
+++ b/src/vfs/linux/linux.c
@@ -559,6 +559,8 @@ chimera_linux_open_fh(
     struct chimera_linux_thread *thread = private_data;
     int                          flags;
     int                          fd;
+    int                          probe_fd;
+    struct stat                  st;
 
     flags = chimera_linux_set_open_flags(request->open_fh.flags);
 
@@ -568,7 +570,25 @@ chimera_linux_open_fh(
                               flags);
 
     if (fd < 0) {
-        request->status = chimera_linux_errno_to_status(errno);
+        if (errno == ENOTDIR && (request->open_fh.flags & CHIMERA_VFS_OPEN_DIRECTORY)) {
+            probe_fd = linux_open_by_handle(&thread->mount_table,
+                                            request->fh,
+                                            request->fh_len,
+                                            O_PATH | O_NOFOLLOW);
+
+            if (probe_fd >= 0) {
+                if (fstat(probe_fd, &st) == 0 && S_ISLNK(st.st_mode)) {
+                    request->status = CHIMERA_VFS_ESYMLINK;
+                } else {
+                    request->status = CHIMERA_VFS_ENOTDIR;
+                }
+                close(probe_fd);
+            } else {
+                request->status = CHIMERA_VFS_ENOTDIR;
+            }
+        } else {
+            request->status = chimera_linux_errno_to_status(errno);
+        }
         request->complete(request);
         return;
     }
@@ -1257,7 +1277,17 @@ chimera_linux_link_at(
     rc = linkat(fd, "", dir_fd, fullname, AT_EMPTY_PATH);
 
     if (rc < 0) {
-        request->status = chimera_linux_errno_to_status(errno);
+        if (errno == EPERM) {
+            struct stat st;
+
+            if (fstat(fd, &st) == 0 && S_ISDIR(st.st_mode)) {
+                request->status = CHIMERA_VFS_EISDIR;
+            } else {
+                request->status = CHIMERA_VFS_EPERM;
+            }
+        } else {
+            request->status = chimera_linux_errno_to_status(errno);
+        }
     } else {
         request->status = CHIMERA_VFS_OK;
     }

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -1130,8 +1130,9 @@ memfs_lookup_at(
     }
 
     if (unlikely(!S_ISDIR(inode->mode))) {
+        enum chimera_vfs_error err = S_ISLNK(inode->mode) ? CHIMERA_VFS_ESYMLINK : CHIMERA_VFS_ENOTDIR;
         pthread_mutex_unlock(&inode->lock);
-        request->status = CHIMERA_VFS_ENOTDIR;
+        request->status = err;
         request->complete(request);
         return;
     }
@@ -1442,7 +1443,7 @@ memfs_remove_at(
 
     if (!S_ISDIR(parent_inode->mode)) {
         pthread_mutex_unlock(&parent_inode->lock);
-        request->status = CHIMERA_VFS_ENOENT;
+        request->status = CHIMERA_VFS_ENOTDIR;
         request->complete(request);
         return;
     }
@@ -2794,7 +2795,7 @@ memfs_link_at(
     if (unlikely(S_ISDIR(inode->mode))) {
         pthread_mutex_unlock(&parent_inode->lock);
         pthread_mutex_unlock(&inode->lock);
-        request->status = CHIMERA_VFS_EPERM;
+        request->status = CHIMERA_VFS_EISDIR;
         request->complete(request);
         return;
     }

--- a/src/vfs/vfs_error.h
+++ b/src/vfs/vfs_error.h
@@ -32,6 +32,7 @@ enum chimera_vfs_error {
     CHIMERA_VFS_ENOTSUP      = 95,     /* Operation not supported */
     CHIMERA_VFS_EDQUOT       = 122,    /* Quota exceeded */
     CHIMERA_VFS_ESTALE       = 116,    /* Stale file handle */
+    CHIMERA_VFS_ESYMLINK     = 120,    /* Is a symbolic link */
     CHIMERA_VFS_EBADCOOKIE   = 200,    /* Bad readdir cookie/verifier */
     CHIMERA_VFS_UNSET        = 100000  /* Unset error code */
 };


### PR DESCRIPTION
Add CHIMERA_VFS_ESYMLINK to distinguish symlink traversal from ENOTDIR. VFS backends (cairn, demofs, memfs, linux, io_uring) return ESYMLINK from lookup_at when a path component is a symlink, and from open_fh when O_DIRECTORY open fails on a symlink. Link operations return EISDIR instead of EPERM when the target is a directory. remove_at returns ENOTDIR instead of ENOENT when the parent is not a directory.

Replace per-operation inline name checks with chimera_nfs4_validate_name(), adding NAMETOOLONG (>255 bytes), NUL and slash rejection via NFS4ERR_BADCHAR, and full UTF-8 structural validation including overlong sequences, surrogates, and code points above U+10FFFF.

Add chimera_nfs4_validate_createattrs() and call it from CREATE and OPEN (UNCHECKED4, GUARDED4, EXCLUSIVE4_1) before unmarshalling attrs, returning NFS4ERR_ATTRNOTSUPP for unknown attributes and NFS4ERR_INVAL for read-only ones.

Signed-off-by: Alain Renaud <alain.renaud@quantum.com>