### PR TITLE
Correct delete-on-close handling

### DIFF
--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -208,10 +208,12 @@ struct chimera_smb_request {
         } create;
 
         struct  {
-            uint16_t                      flags;
-            struct chimera_smb_file_id    file_id;
-            struct chimera_smb_open_file *open_file;
-            struct chimera_smb_attrs      r_attrs;
+            uint16_t                        flags;
+            struct chimera_smb_file_id      file_id;
+            struct chimera_smb_open_file   *open_file;
+            struct chimera_vfs_open_handle *parent_handle;
+            struct chimera_vfs_doc_info     doc_info;
+            struct chimera_smb_attrs        r_attrs;
         } close;
 
         struct {

--- a/src/server/smb/smb_proc_close.c
+++ b/src/server/smb/smb_proc_close.c
@@ -7,6 +7,138 @@
 #include "smb_sharemode.h"
 #include "common/misc.h"
 #include "vfs/vfs.h"
+#include "vfs/vfs_procs.h"
+#include "vfs/vfs_release.h"
+
+static void chimera_smb_close_release(
+    struct chimera_smb_request *request);
+
+static void
+chimera_smb_close_doc_remove_callback(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *pre_attr,
+    struct chimera_vfs_attrs *post_attr,
+    void                     *private_data)
+{
+    struct chimera_smb_request *request    = private_data;
+    struct chimera_vfs_thread  *vfs_thread = request->compound->thread->vfs_thread;
+
+    if (error_code) {
+        chimera_smb_debug("delete-on-close: remove_at failed for '%.*s' (error %d)",
+                          request->close.doc_info.name_len,
+                          request->close.doc_info.name,
+                          error_code);
+    }
+
+    chimera_vfs_release(vfs_thread, request->close.parent_handle);
+
+    /* Close the backend VFS module handle that was detached from the cache */
+    chimera_vfs_close(vfs_thread,
+                      request->close.doc_info.close_module,
+                      request->close.doc_info.close_private,
+                      request->close.doc_info.close_hash,
+                      NULL,
+                      NULL);
+
+    chimera_smb_open_file_release(request, request->close.open_file);
+
+    chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
+} /* chimera_smb_close_doc_remove_callback */
+
+static void
+chimera_smb_close_doc_open_parent_callback(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *oh,
+    void                           *private_data)
+{
+    struct chimera_smb_request *request    = private_data;
+    struct chimera_vfs_thread  *vfs_thread = request->compound->thread->vfs_thread;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        /* Cannot open parent directory — skip deletion, but still close backend */
+        chimera_smb_debug("delete-on-close: failed to open parent dir for '%.*s' (error %d)",
+                          request->close.doc_info.name_len,
+                          request->close.doc_info.name,
+                          error_code);
+
+        chimera_vfs_close(vfs_thread,
+                          request->close.doc_info.close_module,
+                          request->close.doc_info.close_private,
+                          request->close.doc_info.close_hash,
+                          NULL,
+                          NULL);
+
+        chimera_smb_open_file_release(request, request->close.open_file);
+        chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
+        return;
+    }
+
+    request->close.parent_handle = oh;
+
+    chimera_vfs_remove_at(
+        vfs_thread,
+        &request->close.doc_info.cred,
+        oh,
+        request->close.doc_info.name,
+        request->close.doc_info.name_len,
+        NULL,
+        0,
+        0,
+        0,
+        chimera_smb_close_doc_remove_callback,
+        request);
+} /* chimera_smb_close_doc_open_parent_callback */
+
+/*
+ * Release the VFS handle and check for delete-on-close.
+ *
+ * If this was the last reference and DOC was set on the VFS handle,
+ * perform the unlink synchronously before completing the close request.
+ * Otherwise just release and complete.
+ */
+static void
+chimera_smb_close_release(struct chimera_smb_request *request)
+{
+    struct chimera_smb_open_file *open_file  = request->close.open_file;
+    struct chimera_vfs_thread    *vfs_thread = request->compound->thread->vfs_thread;
+    int                           need_doc;
+
+    if (!open_file->handle) {
+        chimera_smb_open_file_release(request, open_file);
+        chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
+        return;
+    }
+
+    need_doc = chimera_vfs_release_doc(vfs_thread,
+                                       open_file->handle,
+                                       &request->close.doc_info);
+
+    /* Detach VFS handle — it has been released (or consumed by DOC) */
+    open_file->handle = NULL;
+
+    if (need_doc && request->close.doc_info.parent_fh_len > 0) {
+        chimera_vfs_open_fh(
+            vfs_thread,
+            &request->close.doc_info.cred,
+            request->close.doc_info.parent_fh,
+            request->close.doc_info.parent_fh_len,
+            CHIMERA_VFS_OPEN_INFERRED | CHIMERA_VFS_OPEN_PATH,
+            chimera_smb_close_doc_open_parent_callback,
+            request);
+    } else {
+        if (need_doc) {
+            /* DOC set but no parent fh — close backend handle directly */
+            chimera_vfs_close(vfs_thread,
+                              request->close.doc_info.close_module,
+                              request->close.doc_info.close_private,
+                              request->close.doc_info.close_hash,
+                              NULL,
+                              NULL);
+        }
+        chimera_smb_open_file_release(request, open_file);
+        chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
+    }
+} /* chimera_smb_close_release */
 
 static void
 chimera_smb_close_getattr_callback(
@@ -16,17 +148,14 @@ chimera_smb_close_getattr_callback(
 {
     struct chimera_smb_request *request = private_data;
 
-    chimera_smb_open_file_release(request, request->close.open_file);
-
-    chimera_smb_marshal_attrs(
-        attr,
-        &request->close.r_attrs);
-
     if (unlikely(error_code)) {
-        chimera_smb_complete_request(request, SMB2_STATUS_INTERNAL_ERROR);
+        memset(&request->close.r_attrs, 0, sizeof(request->close.r_attrs));
     } else {
-        chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
+        chimera_smb_marshal_attrs(attr, &request->close.r_attrs);
     }
+
+    /* Always go through close_release so DOC fires even if getattr failed */
+    chimera_smb_close_release(request);
 } /* chimera_smb_close_getattr_callback */
 
 
@@ -34,7 +163,6 @@ void
 chimera_smb_close(struct chimera_smb_request *request)
 {
     struct chimera_server_smb_thread *thread = request->compound->thread;
-
 
     request->close.open_file = chimera_smb_open_file_close(request, &request->close.file_id);
 
@@ -60,11 +188,8 @@ chimera_smb_close(struct chimera_smb_request *request)
                             request);
 
     } else {
-        chimera_smb_open_file_release(request, request->close.open_file);
-
         memset(&request->close.r_attrs, 0, sizeof(request->close.r_attrs));
-
-        chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
+        chimera_smb_close_release(request);
     }
 
 } /* chimera_smb_close */

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -29,45 +29,6 @@
                          SMB2_GENERIC_WRITE | \
                          SMB2_GENERIC_ALL)
 
-static inline void
-chimera_smb_create_unlink_callback(
-    enum chimera_vfs_error    error_code,
-    struct chimera_vfs_attrs *pre_attr,
-    struct chimera_vfs_attrs *post_attr,
-    void                     *private_data)
-{
-    struct chimera_smb_request *request    = private_data;
-    struct chimera_vfs_thread  *vfs_thread = request->compound->thread->vfs_thread;
-
-    /* XXX We will ignore any error because there's nothing sane to do */
-
-    chimera_vfs_release(vfs_thread, request->create.parent_handle);
-    chimera_smb_open_file_release(request, request->create.r_open_file);
-
-    chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
-} /* chimera_smb_create_unlink_callback */
-
-
-static inline void
-chimera_smb_create_unlink(struct chimera_smb_request *request)
-{
-    struct chimera_vfs_thread    *vfs_thread = request->compound->thread->vfs_thread;
-    struct chimera_smb_open_file *open_file  = request->create.r_open_file;
-
-    chimera_vfs_remove_at(
-        vfs_thread,
-        &request->session_handle->session->cred,
-        request->create.parent_handle,
-        open_file->name,
-        open_file->name_len,
-        NULL,
-        0,
-        0,
-        0,
-        chimera_smb_create_unlink_callback,
-        request);
-} /* chimera_smb_create_unlink */
-
 static inline struct chimera_smb_open_file *
 chimera_smb_create_gen_open_file(
     struct chimera_smb_request     *request,
@@ -128,6 +89,15 @@ chimera_smb_create_gen_open_file(
             chimera_smb_open_file_free(thread, open_file);
             return NULL;
         }
+    }
+
+    /* Propagate delete-on-close to the VFS handle so the file is
+    * removed when the last reference (opencnt) drops to zero. */
+    if (delete_on_close && oh) {
+        chimera_vfs_set_delete_on_close(thread->vfs_thread, oh,
+                                        parent_fh, parent_fh_len,
+                                        name, name_len,
+                                        &request->session_handle->session->cred);
     }
 
     open_file_bucket = open_file->file_id.vid & CHIMERA_SMB_OPEN_FILE_BUCKET_MASK;
@@ -218,15 +188,11 @@ chimera_smb_create_mkdir_open_callback(
 
     request->create.r_open_file = open_file;
 
-    if (request->create.create_options & SMB2_FILE_DELETE_ON_CLOSE) {
-        chimera_smb_create_unlink(request);
-    } else {
-        chimera_vfs_release(vfs_thread, request->create.parent_handle);
-        chimera_smb_open_file_release(request, open_file);
-        chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
-    }
+    chimera_vfs_release(vfs_thread, request->create.parent_handle);
+    chimera_smb_open_file_release(request, open_file);
+    chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
 
-} /* chimera_smb_create_open_parent_callback */
+} /* chimera_smb_create_mkdir_open_callback */
 
 static inline void
 chimera_smb_create_mkdir_callback(
@@ -310,13 +276,9 @@ chimera_smb_create_open_at_callback(
         attr,
         &request->create.r_attrs);
 
-    if (request->create.create_options & SMB2_FILE_DELETE_ON_CLOSE) {
-        chimera_smb_create_unlink(request);
-    } else {
-        chimera_vfs_release(vfs_thread, request->create.parent_handle);
-        chimera_smb_open_file_release(request, open_file);
-        chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
-    }
+    chimera_vfs_release(vfs_thread, request->create.parent_handle);
+    chimera_smb_open_file_release(request, open_file);
+    chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
 } /* chimera_smb_create_open_at_callback */
 
 static inline void

--- a/src/server/smb/smb_proc_set_info.c
+++ b/src/server/smb/smb_proc_set_info.c
@@ -6,6 +6,7 @@
 #include "smb_procs.h"
 #include "common/misc.h"
 #include "vfs/vfs.h"
+#include "vfs/vfs_release.h"
 
 static void
 chimera_smb_set_info_callback(
@@ -21,54 +22,6 @@ chimera_smb_set_info_callback(
 
     chimera_smb_complete_request(request, error_code ? SMB2_STATUS_INTERNAL_ERROR : SMB2_STATUS_SUCCESS);
 } /* chimera_smb_set_info_callback */
-
-static void
-chimera_smb_set_info_remove_callback(
-    enum chimera_vfs_error    error_code,
-    struct chimera_vfs_attrs *pre_attr,
-    struct chimera_vfs_attrs *post_attr,
-    void                     *private_data)
-{
-    struct chimera_smb_request *request = private_data;
-
-    chimera_vfs_release(request->compound->thread->vfs_thread, request->set_info.parent_handle);
-
-    chimera_smb_open_file_release(request, request->set_info.open_file);
-
-    chimera_smb_complete_request(request, error_code ? SMB2_STATUS_INTERNAL_ERROR : SMB2_STATUS_SUCCESS);
-} /* chimera_smb_set_info_remove_callback */ /* chimera_smb_set_info_remove_callback */
-
-static void
-chimera_smb_set_info_open_unlink_callback(
-    enum chimera_vfs_error          error_code,
-    struct chimera_vfs_open_handle *oh,
-    void                           *private_data)
-{
-    struct chimera_smb_request   *request   = private_data;
-    struct chimera_smb_open_file *open_file = request->set_info.open_file;
-
-    request->set_info.parent_handle = oh;
-
-    if (error_code != CHIMERA_VFS_OK) {
-        chimera_smb_open_file_release(request, request->set_info.open_file);
-        chimera_smb_complete_request(request, SMB2_STATUS_INTERNAL_ERROR);
-        return;
-    }
-
-    chimera_vfs_remove_at(
-        request->compound->thread->vfs_thread,
-        &request->session_handle->session->cred,
-        oh,
-        open_file->name,
-        open_file->name_len,
-        NULL,
-        0,
-        0,
-        0,
-        chimera_smb_set_info_remove_callback,
-        request);
-
-} /* chimera_smb_set_info_open_unlink_callback */
 
 static void
 chimera_smb_set_info_link_callback(
@@ -228,19 +181,27 @@ chimera_smb_set_info(struct chimera_smb_request *request)
                     break;
                 case SMB2_FILE_DISPOSITION_INFO:
                 case SMB2_FILE_DISPOSITION_INFO_EX:
-                    if (request->set_info.open_file->flags & CHIMERA_SMB_OPEN_FILE_FLAG_DELETE_ON_CLOSE) {
-                        chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
-                    } else {
-                        chimera_vfs_open_fh(
+                    if (request->set_info.attrs.smb_disposition) {
+                        request->set_info.open_file->flags |=
+                            CHIMERA_SMB_OPEN_FILE_FLAG_DELETE_ON_CLOSE;
+                        /* Propagate to VFS handle for final-close deletion */
+                        chimera_vfs_set_delete_on_close(
                             request->compound->thread->vfs_thread,
-                            &request->session_handle->session->cred,
+                            request->set_info.open_file->handle,
                             request->set_info.open_file->parent_fh,
                             request->set_info.open_file->parent_fh_len,
-                            CHIMERA_VFS_OPEN_INFERRED | CHIMERA_VFS_OPEN_PATH,
-                            chimera_smb_set_info_open_unlink_callback,
-                            request);
-
+                            request->set_info.open_file->name,
+                            request->set_info.open_file->name_len,
+                            &request->session_handle->session->cred);
+                    } else {
+                        request->set_info.open_file->flags &=
+                            ~CHIMERA_SMB_OPEN_FILE_FLAG_DELETE_ON_CLOSE;
+                        chimera_vfs_clear_delete_on_close(
+                            request->compound->thread->vfs_thread,
+                            request->set_info.open_file->handle);
                     }
+                    chimera_smb_open_file_release(request, request->set_info.open_file);
+                    chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
                     break;
                 case SMB2_FILE_RENAME_INFO:
                     chimera_smb_set_info_rename_process(request);

--- a/src/server/smb/smb_proc_set_info_rename.c
+++ b/src/server/smb/smb_proc_set_info_rename.c
@@ -6,6 +6,7 @@
 #include "smb_procs.h"
 #include "common/misc.h"
 #include "vfs/vfs.h"
+#include "vfs/vfs_release.h"
 
 /* Forward declaration */
 static void chimera_smb_set_info_rename_check_dest_callback(
@@ -50,6 +51,19 @@ chimera_smb_set_info_rename_callback(
         memcpy(open_file->name, rename_info->new_name, rename_info->new_name_len);
         open_file->name[rename_info->new_name_len] = '\0';
         open_file->name_len                        = rename_info->new_name_len;
+
+        /* Update VFS handle DOC path so close deletes the new name */
+        if ((open_file->flags & CHIMERA_SMB_OPEN_FILE_FLAG_DELETE_ON_CLOSE) &&
+            open_file->handle) {
+            chimera_vfs_set_delete_on_close(
+                request->compound->thread->vfs_thread,
+                open_file->handle,
+                open_file->parent_fh,
+                open_file->parent_fh_len,
+                open_file->name,
+                open_file->name_len,
+                &request->session_handle->session->cred);
+        }
 
         /* Re-acquire sharemode entry under the new name */
         if (open_file->type == CHIMERA_SMB_OPEN_FILE_TYPE_FILE &&

--- a/src/vfs/vfs.h
+++ b/src/vfs/vfs.h
@@ -139,6 +139,15 @@ struct chimera_vfs_open_handle {
     struct chimera_vfs_open_handle *next;
     uint8_t                         fh[CHIMERA_VFS_FH_SIZE + 16];
 
+    /* Delete-on-close state: when doc_delete_on_close is set and opencnt
+     * drops to zero, the file at (doc_parent_fh, doc_name) is removed
+     * before the handle is recycled. */
+    uint8_t                         doc_delete_on_close;
+    uint16_t                        doc_parent_fh_len;
+    uint16_t                        doc_name_len;
+    struct chimera_vfs_cred         doc_cred;
+    uint8_t                         doc_parent_fh[CHIMERA_VFS_FH_SIZE];
+    char                            doc_name[CHIMERA_VFS_NAME_MAX];
 };
 
 

--- a/src/vfs/vfs_open_cache.h
+++ b/src/vfs/vfs_open_cache.h
@@ -430,6 +430,7 @@ chimera_vfs_open_cache_acquire(
 
         if (handle->opencnt == 0) {
             DL_DELETE(shard->pending_close, handle);
+            handle->doc_delete_on_close = 0;
         }
 
         handle->opencnt++;
@@ -446,17 +447,18 @@ chimera_vfs_open_cache_acquire(
 
         prometheus_counter_increment(shard->insert);
 
-        handle                   = chimera_vfs_open_cache_alloc(shard);
-        handle->vfs_module       = module;
-        handle->fh_hash          = fh_hash;
-        handle->fh_len           = fhlen;
-        handle->opencnt          = 1;
-        handle->access_mode      = access_mode;
-        handle->flags            = exclusive ? CHIMERA_VFS_OPEN_HANDLE_EXCLUSIVE : 0;
-        handle->callback         = callback;
-        handle->request          = request;
-        handle->vfs_private      = vfs_private_data;
-        handle->blocked_requests = NULL;
+        handle                      = chimera_vfs_open_cache_alloc(shard);
+        handle->vfs_module          = module;
+        handle->fh_hash             = fh_hash;
+        handle->fh_len              = fhlen;
+        handle->opencnt             = 1;
+        handle->access_mode         = access_mode;
+        handle->flags               = exclusive ? CHIMERA_VFS_OPEN_HANDLE_EXCLUSIVE : 0;
+        handle->callback            = callback;
+        handle->request             = request;
+        handle->vfs_private         = vfs_private_data;
+        handle->blocked_requests    = NULL;
+        handle->doc_delete_on_close = 0;
 
         if (handle->vfs_private == UINT64_MAX) {
             handle->flags |= CHIMERA_VFS_OPEN_HANDLE_PENDING;
@@ -535,17 +537,18 @@ chimera_vfs_open_cache_insert(
     prometheus_counter_increment(shard->insert);
 
     /* Allocate and populate the new handle */
-    handle                   = chimera_vfs_open_cache_alloc(shard);
-    handle->vfs_module       = module;
-    handle->fh_hash          = fh_hash;
-    handle->fh_len           = fhlen;
-    handle->opencnt          = 1;
-    handle->access_mode      = access_mode;
-    handle->flags            = 0;
-    handle->callback         = callback;
-    handle->request          = request;
-    handle->vfs_private      = vfs_private_data;
-    handle->blocked_requests = NULL;
+    handle                      = chimera_vfs_open_cache_alloc(shard);
+    handle->vfs_module          = module;
+    handle->fh_hash             = fh_hash;
+    handle->fh_len              = fhlen;
+    handle->opencnt             = 1;
+    handle->access_mode         = access_mode;
+    handle->flags               = 0;
+    handle->callback            = callback;
+    handle->request             = request;
+    handle->vfs_private         = vfs_private_data;
+    handle->blocked_requests    = NULL;
+    handle->doc_delete_on_close = 0;
 
     memcpy(handle->fh, fh, fhlen);
 
@@ -799,3 +802,163 @@ chimera_vfs_open_cache_exists(
 
     return found;
 } /* chimera_vfs_open_cache_exists */
+
+/* --- Delete-on-close helpers --- */
+
+/*
+ * Mark a cached handle for delete-on-close.
+ */
+static inline void
+chimera_vfs_open_cache_set_doc(
+    struct vfs_open_cache          *cache,
+    struct chimera_vfs_open_handle *handle,
+    const uint8_t                  *parent_fh,
+    uint16_t                        parent_fh_len,
+    const char                     *name,
+    uint16_t                        name_len,
+    const struct chimera_vfs_cred  *cred)
+{
+    struct vfs_open_cache_shard *shard;
+
+    chimera_vfs_abort_if(parent_fh_len > CHIMERA_VFS_FH_SIZE,
+                         "set_doc: parent_fh_len exceeds FH_SIZE");
+    chimera_vfs_abort_if(name_len > CHIMERA_VFS_NAME_MAX,
+                         "set_doc: name_len exceeds NAME_MAX");
+
+    shard = &cache->shards[handle->fh_hash & cache->shard_mask];
+
+    pthread_mutex_lock(&shard->lock);
+
+    handle->doc_delete_on_close = 1;
+    handle->doc_parent_fh_len   = parent_fh_len;
+    handle->doc_name_len        = name_len;
+    handle->doc_cred            = *cred;
+
+    if (parent_fh_len > 0) {
+        memcpy(handle->doc_parent_fh, parent_fh, parent_fh_len);
+    }
+
+    if (name_len > 0) {
+        memcpy(handle->doc_name, name, name_len);
+    }
+
+    pthread_mutex_unlock(&shard->lock);
+} /* chimera_vfs_open_cache_set_doc */
+
+/*
+ * Clear the delete-on-close flag.
+ */
+static inline void
+chimera_vfs_open_cache_clear_doc(
+    struct vfs_open_cache          *cache,
+    struct chimera_vfs_open_handle *handle)
+{
+    struct vfs_open_cache_shard *shard;
+
+    shard = &cache->shards[handle->fh_hash & cache->shard_mask];
+
+    pthread_mutex_lock(&shard->lock);
+
+    handle->doc_delete_on_close = 0;
+    handle->doc_parent_fh_len   = 0;
+    handle->doc_name_len        = 0;
+
+    pthread_mutex_unlock(&shard->lock);
+} /* chimera_vfs_open_cache_clear_doc */
+
+/*
+ * Atomically release a handle reference and check for delete-on-close.
+ *
+ * If this is the last reference (opencnt drops to 0) and DOC is set,
+ * the handle is removed from the cache and the DOC parameters are
+ * copied into the caller-provided output buffers.  Returns 1.
+ *
+ * Otherwise performs a normal release and returns 0.
+ */
+struct chimera_vfs_doc_info {
+    uint8_t                    parent_fh[CHIMERA_VFS_FH_SIZE];
+    char                       name[CHIMERA_VFS_NAME_MAX];
+    struct chimera_vfs_cred    cred;
+    uint16_t                   parent_fh_len;
+    uint16_t                   name_len;
+    /* Backend close state — caller must close after unlink */
+    struct chimera_vfs_module *close_module;
+    uint64_t                   close_private;
+    uint64_t                   close_hash;
+};
+
+static inline int
+chimera_vfs_open_cache_release_doc(
+    struct chimera_vfs_thread      *thread,
+    struct vfs_open_cache          *cache,
+    struct chimera_vfs_open_handle *handle,
+    struct chimera_vfs_doc_info    *doc_out)
+{
+    struct vfs_open_cache_shard *shard;
+    struct chimera_vfs_request  *requests;
+    int                          do_doc = 0;
+
+    shard = &cache->shards[handle->fh_hash & cache->shard_mask];
+
+    chimera_vfs_abort_if(handle->cache_id != shard->cache_id,
+                         "handle released by wrong cache");
+
+    pthread_mutex_lock(&shard->lock);
+
+    handle->flags &= ~CHIMERA_VFS_OPEN_HANDLE_EXCLUSIVE;
+
+    requests                 = handle->blocked_requests;
+    handle->blocked_requests = NULL;
+
+    handle->opencnt--;
+
+    if (handle->opencnt == 0 && handle->doc_delete_on_close) {
+        /* Last reference with DOC — extract deletion info and remove
+         * from cache.  The caller is responsible for the actual unlink
+         * and for closing the underlying VFS module handle. */
+        doc_out->parent_fh_len = handle->doc_parent_fh_len;
+        doc_out->name_len      = handle->doc_name_len;
+        doc_out->cred          = handle->doc_cred;
+        doc_out->close_module  = handle->vfs_module;
+        doc_out->close_private = handle->vfs_private;
+        doc_out->close_hash    = handle->fh_hash;
+        memcpy(doc_out->parent_fh, handle->doc_parent_fh,
+               handle->doc_parent_fh_len);
+        memcpy(doc_out->name, handle->doc_name, handle->doc_name_len);
+
+        if (handle->flags & CHIMERA_VFS_OPEN_HANDLE_DETACHED) {
+            chimera_vfs_open_cache_free(shard, handle);
+        } else {
+            chimera_vfs_open_cache_shard_remove(shard, handle);
+            shard->open_handles--;
+            chimera_vfs_open_cache_free(shard, handle);
+        }
+
+        do_doc = 1;
+
+        pthread_mutex_unlock(&shard->lock);
+        chimera_vfs_open_cache_release_blocked(thread, requests, 0);
+        return do_doc;
+    }
+
+    if (handle->opencnt == 0) {
+        if (handle->flags & CHIMERA_VFS_OPEN_HANDLE_DETACHED) {
+            struct chimera_vfs_module *close_module  = handle->vfs_module;
+            uint64_t                   close_private = handle->vfs_private;
+            uint64_t                   close_hash    = handle->fh_hash;
+            chimera_vfs_open_cache_free(shard, handle);
+            pthread_mutex_unlock(&shard->lock);
+            chimera_vfs_open_cache_release_blocked(thread, requests, 0);
+            chimera_vfs_close(thread, close_module, close_private,
+                              close_hash, NULL, NULL);
+            return 0;
+        }
+        clock_gettime(CLOCK_MONOTONIC, &handle->timestamp);
+        DL_APPEND(shard->pending_close, handle);
+    }
+
+    pthread_mutex_unlock(&shard->lock);
+    chimera_vfs_open_cache_release_blocked(thread, requests, 0);
+
+    return 0;
+} /* chimera_vfs_open_cache_release_doc */

--- a/src/vfs/vfs_release.h
+++ b/src/vfs/vfs_release.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/vfs/vfs_release.h
+++ b/src/vfs/vfs_release.h
@@ -59,6 +59,83 @@ chimera_vfs_dup_handle(
     }
 } /* chimera_vfs_dup_handle */
 
+static inline struct vfs_open_cache *
+chimera_vfs_get_cache_for_handle(
+    struct chimera_vfs_thread      *thread,
+    struct chimera_vfs_open_handle *handle)
+{
+    if (handle->cache_id == CHIMERA_VFS_OPEN_ID_PATH) {
+        return thread->vfs->vfs_open_path_cache;
+    } else if (handle->cache_id == CHIMERA_VFS_OPEN_ID_FILE) {
+        return thread->vfs->vfs_open_file_cache;
+    }
+
+    return NULL;
+} /* chimera_vfs_get_cache_for_handle */
+
+/* Mark a VFS handle for delete-on-close. */
+static inline void
+chimera_vfs_set_delete_on_close(
+    struct chimera_vfs_thread      *thread,
+    struct chimera_vfs_open_handle *handle,
+    const uint8_t                  *parent_fh,
+    uint16_t                        parent_fh_len,
+    const char                     *name,
+    uint16_t                        name_len,
+    const struct chimera_vfs_cred  *cred)
+{
+    struct vfs_open_cache *cache = chimera_vfs_get_cache_for_handle(thread,
+                                                                    handle);
+
+    if (cache) {
+        chimera_vfs_open_cache_set_doc(cache, handle,
+                                       parent_fh, parent_fh_len,
+                                       name, name_len, cred);
+    }
+} /* chimera_vfs_set_delete_on_close */
+
+/* Clear the delete-on-close flag on a VFS handle. */
+static inline void
+chimera_vfs_clear_delete_on_close(
+    struct chimera_vfs_thread      *thread,
+    struct chimera_vfs_open_handle *handle)
+{
+    struct vfs_open_cache *cache = chimera_vfs_get_cache_for_handle(thread,
+                                                                    handle);
+
+    if (cache) {
+        chimera_vfs_open_cache_clear_doc(cache, handle);
+    }
+} /* chimera_vfs_clear_delete_on_close */
+
+/*
+ * Release a VFS handle and atomically check for delete-on-close.
+ * Returns 1 if this was the last reference and DOC was set (caller
+ * must perform the unlink using info in doc_out).  Returns 0 otherwise.
+ */
+static inline int
+chimera_vfs_release_doc(
+    struct chimera_vfs_thread      *thread,
+    struct chimera_vfs_open_handle *handle,
+    struct chimera_vfs_doc_info    *doc_out)
+{
+    if (handle->cache_id == CHIMERA_VFS_OPEN_ID_PATH) {
+        return chimera_vfs_open_cache_release_doc(
+            thread, thread->vfs->vfs_open_path_cache, handle, doc_out);
+    } else if (handle->cache_id == CHIMERA_VFS_OPEN_ID_FILE) {
+        return chimera_vfs_open_cache_release_doc(
+            thread, thread->vfs->vfs_open_file_cache, handle, doc_out);
+    }
+
+    /* Synthetic or unknown handle — no DOC possible, do normal release */
+    if (handle->cache_id == CHIMERA_VFS_OPEN_ID_SYNTHETIC) {
+        chimera_vfs_synth_handle_free(thread, handle);
+    } else {
+        chimera_vfs_abort("invalid cache id for release_doc");
+    }
+    return 0;
+} /* chimera_vfs_release_doc */
+
 static inline void
 chimera_vfs_release_failed(
     struct chimera_vfs_thread      *thread,


### PR DESCRIPTION
Implemented synchronous delete-on-close with proper last-close semantics:

- Moved delete-on-close (DOC) handling out of the CREATE and SET_INFO paths and into the CLOSE path, executing the unlink synchronously before sending the close response. The DOC flag is stored on the VFS open_handle so it is shared across all SMB handles referencing the same underlying file, and the actual deletion only fires when the last reference (opencnt) drops to zero.

- Previously, DOC was handled in two different ways, both problematic: the original code deleted immediately during CREATE/SET_INFO (ignoring other open handles), and a subsequent VFS-level approach deleted asynchronously after the close response was already sent, causing a race where the client's next operation could see stale directory state.

The new approach works as follows:

- When a file is opened with FILE_DELETE_ON_CLOSE or disposition is set via SET_INFO, the DOC flag and deletion path (parent file handle, filename, credentials) are propagated to the VFS open_handle.  On CLOSE, chimera_vfs_release_doc() atomically checks whether opencnt has reached zero and DOC is set. If so, it extracts the deletion parameters and backend close state, removes the handle from the cache, and returns control to the SMB close handler.  The SMB close handler then opens the parent directory, calls remove_at to unlink the file, closes the backend VFS module handle, and only then completes the close request.  If the file is renamed while DOC is set, the stored deletion path is updated to reflect the new location. Stale DOC flags are cleared whenever a VFS open cache handle is recycled from the free list or reactivated from pending_close. DOC unlink failures and parent-open failures are logged but do not fail the close, matching Windows best-effort semantics.