### PR TITLE
Linux vfs: use chmod via /proc symlink for O_PATH fds

### DIFF
--- a/src/posix/tests/CMakeLists.txt
+++ b/src/posix/tests/CMakeLists.txt
@@ -675,3 +675,56 @@ endif()
 generate_stress_nfs3rdma_tests(cairn CAIRN_ENABLED)
 generate_stress_nfs3rdma_tests(linux "")
 generate_stress_nfs3rdma_tests(io_uring CHIMERA_VFS_IO_URING)
+
+# ============================================================================
+# Non-root user tests
+# Run all POSIX tests as 'myuser' against the linux, nfs3_linux, and
+# nfs3rdma_linux backends to catch permission errors that only surface for
+# non-root callers (e.g. chmod on mode-0000 files).
+# ============================================================================
+
+macro(add_posix_test_myuser testname prog backend)
+    add_test(NAME chimera/posix/${testname}_myuser COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_${prog} -b ${backend} -U myuser)
+    get_target_property(test_file posix_${prog} TEST_FILE)
+    set_tests_properties(chimera/posix/${testname}_myuser PROPERTIES
+        ENVIRONMENT "TEST_FILE=${test_file}"
+        SKIP_RETURN_CODE 77)
+endmacro()
+
+macro(add_posix_nfs3_test_myuser testname prog nfs_backend)
+    add_test(NAME chimera/posix/${testname}_nfs3_${nfs_backend}_myuser
+        COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_${prog} -b nfs3_${nfs_backend} -U myuser
+    )
+    get_target_property(test_file posix_${prog} TEST_FILE)
+    set_tests_properties(chimera/posix/${testname}_nfs3_${nfs_backend}_myuser PROPERTIES
+        ENVIRONMENT "TEST_FILE=${test_file}"
+        TIMEOUT 60
+        SKIP_RETURN_CODE 77
+    )
+endmacro()
+
+macro(add_posix_nfs3rdma_test_myuser testname prog nfs_backend)
+    add_test(NAME chimera/posix/${testname}_nfs3rdma_${nfs_backend}_myuser
+        COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_${prog} -b nfs3rdma_${nfs_backend} -U myuser
+    )
+    get_target_property(test_file posix_${prog} TEST_FILE)
+    set_tests_properties(chimera/posix/${testname}_nfs3rdma_${nfs_backend}_myuser PROPERTIES
+        ENVIRONMENT "TEST_FILE=${test_file}"
+        TIMEOUT 60
+        SKIP_RETURN_CODE 77
+    )
+endmacro()
+
+foreach(prog ${POSIX_TEST_PROGRAMS})
+    string(REGEX REPLACE "^test_" "" test_name ${prog})
+    add_posix_test_myuser(${test_name}_linux    ${prog} linux)
+    add_posix_nfs3_test_myuser(${test_name}     ${prog} linux)
+    add_posix_nfs3rdma_test_myuser(${test_name} ${prog} linux)
+endforeach()
+
+foreach(prog test_fcntl test_lockf)
+    string(REGEX REPLACE "^test_" "" test_name ${prog})
+    add_posix_test_myuser(${test_name}_linux    ${prog} linux)
+    add_posix_nfs3_test_myuser(${test_name}     ${prog} linux)
+    add_posix_nfs3rdma_test_myuser(${test_name} ${prog} linux)
+endforeach()

--- a/src/posix/tests/cthon_lock_tlock.c
+++ b/src/posix/tests/cthon_lock_tlock.c
@@ -512,13 +512,12 @@ main(
     int    argc,
     char **argv)
 {
-    struct posix_test_env   env;
-    struct chimera_vfs_cred root_cred;
-    struct timespec         tv;
-    json_t                 *posix_json_root;
-    char                    posix_json_path[300];
-    int                     rc;
-    int                     opt;
+    struct posix_test_env env;
+    struct timespec       tv;
+    json_t               *posix_json_root;
+    char                  posix_json_path[300];
+    int                   rc;
+    int                   opt;
 
     cthon_Myname = "cthon_lock_tlock";
 
@@ -560,9 +559,15 @@ main(
         int saved_opterr = opterr;
         opterr = 0;
         optind = 1;
-        while ((opt = getopt(argc, argv, "+b:")) != -1) {
+        while ((opt = getopt(argc, argv, "+b:U:")) != -1) {
             if (opt == 'b') {
                 env.backend = optarg;
+            } else if (opt == 'U') {
+                if (!chimera_test_parse_user(optarg, &env.cred)) {
+                    fprintf(stderr, "Unknown user spec '%s'. "
+                            "Use: root, johndoe, myuser, or uid:gid\n", optarg);
+                    exit(EXIT_FAILURE);
+                }
             }
         }
         opterr = saved_opterr;
@@ -585,6 +590,12 @@ main(
     (void) mkdir("/build/test", 0755);
     (void) mkdir(env.session_dir, 0755);
 
+    rc = chown(env.session_dir, env.cred.uid, env.cred.gid);
+    if (rc < 0) {
+        fprintf(stderr, "Failed to set session_dir uid/gid: %s\n", strerror(errno));
+        exit(EXIT_FAILURE);
+    }
+
     /* Write posix.json config (no VFS-specific section needed for linux backend). */
     posix_json_root = json_object();
     json_object_set_new(posix_json_root, "config", json_object());
@@ -593,7 +604,10 @@ main(
     json_dump_file(posix_json_root, posix_json_path, 0);
     json_decref(posix_json_root);
 
-    chimera_vfs_cred_init_unix(&root_cred, 0, 0, 0, NULL);
+    chimera_vfs_cred_init_unix(&env.cred,
+                               CHIMERA_TEST_USER_ROOT_UID,
+                               CHIMERA_TEST_USER_ROOT_GID,
+                               0, NULL);
 
     fprintf(stdout, "%s: record locking test\n", cthon_Myname);
 
@@ -618,7 +632,7 @@ main(
      * Each process (parent and child) starts its own chimera client
      * independently after the fork.
      */
-    env.posix = chimera_posix_init_json(posix_json_path, &root_cred, env.metrics);
+    env.posix = chimera_posix_init_json(posix_json_path, &env.cred, env.metrics);
     if (!env.posix) {
         fprintf(stderr, "%s: Failed to initialize POSIX client\n",
                 (who == PARENT) ? "Parent" : "Child");

--- a/src/posix/tests/posix_test_common.h
+++ b/src/posix/tests/posix_test_common.h
@@ -27,6 +27,7 @@ struct posix_test_env {
     const char                  *nfs_backend;  // Actual backend behind NFS (e.g., "memfs")
     int                          nfs_version;  // 3 or 4, 0 if not NFS
     int                          use_nfs_rdma; // 1 if using NFS over RDMA (TCP-RDMA)
+    struct chimera_vfs_cred      cred;         // Credential used to initialize the POSIX client
 };
 
 // Helper to parse env->backend for NFS backends (e.g., "nfs3_memfs" -> version=3, backend="memfs")
@@ -208,6 +209,11 @@ posix_test_init(
     env->metrics = prometheus_metrics_create(NULL, NULL, 0);
     env->server  = NULL;
 
+    chimera_vfs_cred_init_unix(&env->cred,
+                               CHIMERA_TEST_USER_ROOT_UID,
+                               CHIMERA_TEST_USER_ROOT_GID,
+                               0, NULL);
+
     clock_gettime(CLOCK_MONOTONIC, &tv);
 
     env->session_dir[0] = '\0';
@@ -217,10 +223,17 @@ posix_test_init(
      * Use "+" prefix to stop at first non-option (POSIX behavior),
      * preventing argv permutation that would break subsequent getopt calls. */
     opterr = 0;
-    while ((opt = getopt(argc, argv, "+b:")) != -1) {
+    while ((opt = getopt(argc, argv, "+b:U:")) != -1) {
         switch (opt) {
             case 'b':
                 backend = optarg;
+                break;
+            case 'U':
+                if (!chimera_test_parse_user(optarg, &env->cred)) {
+                    fprintf(stderr, "Unknown user spec '%s'. "
+                            "Use: root, johndoe, myuser, or uid:gid\n", optarg);
+                    exit(EXIT_FAILURE);
+                }
                 break;
         } /* switch */
     }
@@ -250,8 +263,16 @@ posix_test_init(
 
     fprintf(stderr, "Creating session directory %s\n", env->session_dir);
 
+    int rc;
+
     (void) mkdir("/build/test", 0755);
     (void) mkdir(env->session_dir, 0755);
+
+    rc = chown(env->session_dir, env->cred.uid, env->cred.gid);
+    if (rc < 0) {
+        fprintf(stderr, "Failed to set session_dir uid/gid: %s\n", strerror(errno));
+        exit(EXIT_FAILURE);
+    }
 
     if (is_nfs) {
         posix_test_start_nfs_server(env);
@@ -297,9 +318,7 @@ posix_test_init(
         json_dump_file(posix_json_root, posix_json_path, 0);
         json_decref(posix_json_root);
 
-        struct chimera_vfs_cred root_cred;
-        chimera_vfs_cred_init_unix(&root_cred, 0, 0, 0, NULL);
-        env->posix = chimera_posix_init_json(posix_json_path, &root_cred, env->metrics);
+        env->posix = chimera_posix_init_json(posix_json_path, &env->cred, env->metrics);
     }
 
     if (!env->posix) {

--- a/src/posix/tests/test_chmod.c
+++ b/src/posix/tests/test_chmod.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -34,6 +34,29 @@ main(
     }
 
     chimera_posix_close(fd);
+
+    // Change mode to 0000
+    rc = chimera_posix_chmod("/test/chmod_test", 0000);
+
+    if (rc != 0) {
+        fprintf(stderr, "chmod to 0000 failed: %s\n", strerror(errno));
+        posix_test_fail(&env);
+    }
+
+    // Verify the mode changed to 0000
+    rc = chimera_posix_stat("/test/chmod_test", &st);
+
+    if (rc != 0) {
+        fprintf(stderr, "stat failed: %s\n", strerror(errno));
+        posix_test_fail(&env);
+    }
+
+    if ((st.st_mode & 0777) != 0000) {
+        fprintf(stderr, "chmod: expected mode 0000, got %03o\n", st.st_mode & 0777);
+        posix_test_fail(&env);
+    }
+
+    fprintf(stderr, "chmod 0000 test passed\n");
 
     // Change mode to 0755
     rc = chimera_posix_chmod("/test/chmod_test", 0755);

--- a/src/posix/tests/test_chown.c
+++ b/src/posix/tests/test_chown.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -15,6 +15,12 @@ main(
     struct stat           st;
 
     posix_test_init(&env, argv, argc);
+
+    if (env.cred.uid != 0) {
+        fprintf(stderr, "Skipping chown test: requires root credential\n");
+        posix_test_cleanup(&env, 1);
+        return 77;
+    }
 
     rc = posix_test_mount(&env);
 

--- a/src/posix/tests/test_fchmod.c
+++ b/src/posix/tests/test_fchmod.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -33,16 +33,42 @@ main(
         posix_test_fail(&env);
     }
 
-    // Change mode to 0755 using fchmod
-    rc = chimera_posix_fchmod(fd, 0755);
+    // Change mode to 0000 using fchmod
+    rc = chimera_posix_fchmod(fd, 0000);
 
     if (rc != 0) {
-        fprintf(stderr, "fchmod failed: %s\n", strerror(errno));
+        fprintf(stderr, "fchmod to 0000 failed: %s\n", strerror(errno));
         chimera_posix_close(fd);
         posix_test_fail(&env);
     }
 
-    // Verify the mode changed using fstat
+    // Verify the mode changed to 0000 using fstat
+    rc = chimera_posix_fstat(fd, &st);
+
+    if (rc != 0) {
+        fprintf(stderr, "fstat failed: %s\n", strerror(errno));
+        chimera_posix_close(fd);
+        posix_test_fail(&env);
+    }
+
+    if ((st.st_mode & 0777) != 0000) {
+        fprintf(stderr, "fchmod: expected mode 0000, got %03o\n", st.st_mode & 0777);
+        chimera_posix_close(fd);
+        posix_test_fail(&env);
+    }
+
+    fprintf(stderr, "fchmod 0000 test passed\n");
+
+    // Change mode to 0755 using fchmod
+    rc = chimera_posix_fchmod(fd, 0755);
+
+    if (rc != 0) {
+        fprintf(stderr, "fchmod to 0755 failed: %s\n", strerror(errno));
+        chimera_posix_close(fd);
+        posix_test_fail(&env);
+    }
+
+    // Verify the mode changed to 0755 using fstat
     rc = chimera_posix_fstat(fd, &st);
 
     if (rc != 0) {

--- a/src/posix/tests/test_fchown.c
+++ b/src/posix/tests/test_fchown.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -15,6 +15,12 @@ main(
     struct stat           st;
 
     posix_test_init(&env, argv, argc);
+
+    if (env.cred.uid != 0) {
+        fprintf(stderr, "Skipping fchown test: requires root credential\n");
+        posix_test_cleanup(&env, 1);
+        return 77;
+    }
 
     rc = posix_test_mount(&env);
 

--- a/src/posix/tests/test_fchownat.c
+++ b/src/posix/tests/test_fchownat.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -19,6 +19,12 @@ main(
     struct stat           st;
 
     posix_test_init(&env, argv, argc);
+
+    if (env.cred.uid != 0) {
+        fprintf(stderr, "Skipping fchownat test: requires root credential\n");
+        posix_test_cleanup(&env, 1);
+        return 77;
+    }
 
     rc = posix_test_mount(&env);
 

--- a/src/posix/tests/test_fcntl.c
+++ b/src/posix/tests/test_fcntl.c
@@ -178,18 +178,17 @@ main(
     int    argc,
     char **argv)
 {
-    struct posix_test_env   env;
-    struct chimera_vfs_cred root_cred;
-    char                    posix_json_path[300];
-    int                     fd;
-    struct flock            fl;
-    pid_t                   child;
-    int                     status;
-    int                     rc;
-    int                     opt;
-    struct timespec         tv;
-    json_t                 *posix_json_root;
-    int                     is_nfs;
+    struct posix_test_env env;
+    char                  posix_json_path[300];
+    int                   fd;
+    struct flock          fl;
+    pid_t                 child;
+    int                   status;
+    int                   rc;
+    int                   opt;
+    struct timespec       tv;
+    json_t               *posix_json_root;
+    int                   is_nfs;
 
     /*
      * Pre-fork setup: create session directory and write posix.json.
@@ -210,9 +209,15 @@ main(
 
         opterr = 0;
         optind = 1;
-        while ((opt = getopt(argc, argv, "+b:")) != -1) {
+        while ((opt = getopt(argc, argv, "+b:U:")) != -1) {
             if (opt == 'b') {
                 env.backend = optarg;
+            } else if (opt == 'U') {
+                if (!chimera_test_parse_user(optarg, &env.cred)) {
+                    fprintf(stderr, "Unknown user spec '%s'. "
+                            "Use: root, johndoe, myuser, or uid:gid\n", optarg);
+                    exit(EXIT_FAILURE);
+                }
             }
         }
         opterr = saved_opterr;
@@ -236,6 +241,12 @@ main(
     (void) mkdir("/build/test", 0755);
     (void) mkdir(env.session_dir, 0755);
 
+    rc = chown(env.session_dir, env.cred.uid, env.cred.gid);
+    if (rc < 0) {
+        fprintf(stderr, "Failed to set session_dir uid/gid: %s\n", strerror(errno));
+        exit(EXIT_FAILURE);
+    }
+
     posix_json_root = json_object();
     json_object_set_new(posix_json_root, "config", json_object());
     chimera_test_write_users_json(posix_json_root);
@@ -244,7 +255,10 @@ main(
     json_dump_file(posix_json_root, posix_json_path, 0);
     json_decref(posix_json_root);
 
-    chimera_vfs_cred_init_unix(&root_cred, 0, 0, 0, NULL);
+    chimera_vfs_cred_init_unix(&env.cred,
+                               CHIMERA_TEST_USER_ROOT_UID,
+                               CHIMERA_TEST_USER_ROOT_GID,
+                               0, NULL);
 
     if (pipe(p2c) != 0) {
         perror("tlock: parent pipe");
@@ -258,7 +272,7 @@ main(
     child = fork();
 
     if (child == 0) {
-        exit(child_main(&env, posix_json_path, &root_cred));
+        exit(child_main(&env, posix_json_path, &env.cred));
     }
 
     /* ---- parent ---- */
@@ -270,7 +284,7 @@ main(
         posix_test_start_nfs_server(&env);
     }
 
-    env.posix = chimera_posix_init_json(posix_json_path, &root_cred, env.metrics);
+    env.posix = chimera_posix_init_json(posix_json_path, &env.cred, env.metrics);
     if (!env.posix) {
         fprintf(stderr, "parent: chimera init failed\n");
         posix_test_fail(&env);

--- a/src/posix/tests/test_lockf.c
+++ b/src/posix/tests/test_lockf.c
@@ -164,17 +164,16 @@ main(
     int    argc,
     char **argv)
 {
-    struct posix_test_env   env;
-    struct chimera_vfs_cred root_cred;
-    char                    posix_json_path[300];
-    int                     fd;
-    pid_t                   child;
-    int                     status;
-    int                     rc;
-    int                     opt;
-    struct timespec         tv;
-    json_t                 *posix_json_root;
-    int                     is_nfs;
+    struct posix_test_env env;
+    char                  posix_json_path[300];
+    int                   fd;
+    pid_t                 child;
+    int                   status;
+    int                   rc;
+    int                   opt;
+    struct timespec       tv;
+    json_t               *posix_json_root;
+    int                   is_nfs;
 
     /*
      * Pre-fork setup: create session directory and write posix.json.
@@ -195,9 +194,15 @@ main(
 
         opterr = 0;
         optind = 1;
-        while ((opt = getopt(argc, argv, "+b:")) != -1) {
+        while ((opt = getopt(argc, argv, "+b:U:")) != -1) {
             if (opt == 'b') {
                 env.backend = optarg;
+            } else if (opt == 'U') {
+                if (!chimera_test_parse_user(optarg, &env.cred)) {
+                    fprintf(stderr, "Unknown user spec '%s'. "
+                            "Use: root, johndoe, myuser, or uid:gid\n", optarg);
+                    exit(EXIT_FAILURE);
+                }
             }
         }
         opterr = saved_opterr;
@@ -221,6 +226,12 @@ main(
     (void) mkdir("/build/test", 0755);
     (void) mkdir(env.session_dir, 0755);
 
+    rc = chown(env.session_dir, env.cred.uid, env.cred.gid);
+    if (rc < 0) {
+        fprintf(stderr, "Failed to set session_dir uid/gid: %s\n", strerror(errno));
+        exit(EXIT_FAILURE);
+    }
+
     posix_json_root = json_object();
     json_object_set_new(posix_json_root, "config", json_object());
     chimera_test_write_users_json(posix_json_root);
@@ -229,7 +240,10 @@ main(
     json_dump_file(posix_json_root, posix_json_path, 0);
     json_decref(posix_json_root);
 
-    chimera_vfs_cred_init_unix(&root_cred, 0, 0, 0, NULL);
+    chimera_vfs_cred_init_unix(&env.cred,
+                               CHIMERA_TEST_USER_ROOT_UID,
+                               CHIMERA_TEST_USER_ROOT_GID,
+                               0, NULL);
 
     if (pipe(p2c) != 0) {
         perror("tlock: parent pipe");
@@ -243,7 +257,7 @@ main(
     child = fork();
 
     if (child == 0) {
-        exit(child_main(&env, posix_json_path, &root_cred));
+        exit(child_main(&env, posix_json_path, &env.cred));
     }
 
     /* ---- parent ---- */
@@ -254,7 +268,7 @@ main(
         posix_test_start_nfs_server(&env);
     }
 
-    env.posix = chimera_posix_init_json(posix_json_path, &root_cred, env.metrics);
+    env.posix = chimera_posix_init_json(posix_json_path, &env.cred, env.metrics);
     if (!env.posix) {
         fprintf(stderr, "parent: chimera init failed\n");
         posix_test_fail(&env);

--- a/src/vfs/linux/linux.c
+++ b/src/vfs/linux/linux.c
@@ -148,17 +148,11 @@ chimera_linux_set_attrs(
         if (strlen(path) != 0) {
             rc = fchmodat(dirfd, path, attr->va_mode, 0);
         } else {
-            // dirfd might be O_PATH, reopen without O_PATH via /proc/self/fd
+            // dirfd may be O_PATH; chmod via /proc symlink avoids needing
+            // read/write permission on the file (chmod only requires ownership)
             char procpath[64];
             snprintf(procpath, sizeof(procpath), "/proc/self/fd/%d", dirfd);
-            int  reopen_fd = open(procpath, O_RDONLY);
-            if (reopen_fd < 0) {
-                chimera_linux_error("linux_setattr: reopen via /proc for fchmod failed: %s",
-                                    strerror(errno));
-                return -errno;
-            }
-            rc = fchmod(reopen_fd, attr->va_mode);
-            close(reopen_fd);
+            rc = chmod(procpath, attr->va_mode);
         }
 #endif /* ifdef HAVE_FCHMODAT_AT_SYMLINK_NOFOLLOW */
         if (rc) {


### PR DESCRIPTION
**Linux vfs: use chmod via /proc symlink for O_PATH fds**

When setting permissions on a file referenced by an O_PATH fd with an
empty path, the previous code reopened the fd via /proc/self/fd/<N>
using O_RDONLY before calling fchmod().  This fails when the file has
no read permission (e.g. mode 0000) because the O_RDONLY open is
rejected before ownership is even checked.

Replace the reopen+fchmod sequence with a direct chmod() on the
/proc/self/fd/<N> symlink.  chmod() enforces only ownership, not
read/write access, so it succeeds regardless of the file's current
permission bits.
    
    ---
**posix tests: add non-root user testing and 0000-mode chmod cases**

The VFS fix for chmod on mode-0000 files only surfaces when the caller
is not root (root bypasses permission checks).  Add a -U <user> option
to the test framework so every POSIX test can be re-run as a non-root
user, and wire it up in CMakeLists.txt for the linux, nfs3_linux, and
nfs3rdma_linux backends.

Framework changes (posix_test_common.h):
- Add cred field to posix_test_env; default is root (uid=0/gid=0)
- Accept -U <user> flag (root, myuser, johndoe, uid:gid) and call
  chimera_vfs_cred_init_unix() accordingly
- chown the per-test session directory to the selected uid/gid so the
  non-root client can write into it
- Pass env->cred to chimera_posix_init_json() instead of a hard-coded
  root credential

CMakeLists.txt:
- Add add_posix_test_myuser / add_posix_nfs3_test_myuser /
  add_posix_nfs3rdma_test_myuser macros that re-run every test with
  -U myuser against the linux, nfs3_linux, and nfs3rdma_linux backends
- Set SKIP_RETURN_CODE 77 on all myuser variants so tests that require
  root can gracefully opt out
- Include test_fcntl and test_lockf in the myuser variants

Test changes:
- test_chmod.c / test_fchmod.c: add a 0000-mode step before the 0755
  step; test_fchmod.c closes and reopens the fd between the two steps
- test_chown.c / test_fchown.c / test_fchownat.c: return 77 (skip)
  when running without root credentials, since chown requires root
- test_fcntl.c / test_lockf.c / cthon_lock_tlock.c: replace hard-coded
  root_cred with env.cred; add -U parsing and session-dir chown to
  match posix_test_common.h behaviour