### PR TITLE
upgrade build images and devcontainer to Ubuntu 26.04

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,11 @@
 {
         "name": "chimera",
         "build": {
-                "dockerfile": "Dockerfile"
+                "dockerfile": "Dockerfile",
+                "args": {
+                        "DOCKER_MIRROR": "${localEnv:DOCKER_MIRROR}",
+                        "APT_MIRROR": "${localEnv:APT_MIRROR}"
+                }
         },
         "initializeCommand": "mkdir -p \"${localEnv:HOME}${localEnv:USERPROFILE}/.claude\"",
         "containerEnv": {

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -10,6 +10,7 @@ on:
 
 env:
   DEV_IMAGE_TAG_PREFIX: repository.mdh.quantum.com:5004/cache/chimera-dev
+  U26_IMAGE_TAG_PREFIX: repository.mdh.quantum.com:5004/cache/chimera-ubuntu26
   U24_IMAGE_TAG_PREFIX: repository.mdh.quantum.com:5004/cache/chimera-ubuntu24
   U22_IMAGE_TAG_PREFIX: repository.mdh.quantum.com:5004/cache/chimera-ubuntu22
   R9_IMAGE_TAG_PREFIX: repository.mdh.quantum.com:5004/cache/chimera-rocky9
@@ -58,6 +59,50 @@ jobs:
           tags: ${{ env.DEV_IMAGE_TAG_PREFIX }}:${{ github.sha }}-${{ matrix.arch }}
           cache-from: type=registry,ref=repository.mdh.quantum.com:5004/cache/chimera-dev:${{ matrix.arch }}
           cache-to: type=registry,ref=repository.mdh.quantum.com:5004/cache/chimera-dev:${{ matrix.arch }},mode=max
+          build-args: |
+            APT_MIRROR=${{ env.APT_MIRROR }}
+            DOCKER_MIRROR=${{ env.DOCKER_MIRROR }}
+
+  build-ubuntu26:
+    name: Build ubuntu26 ${{ matrix.platform }}
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: arc-amd64
+            arch: amd64
+          - platform: linux/arm64
+            runner: arc-arm64
+            arch: arm64
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker-container
+          buildkitd-config-inline: |
+            [registry."docker.io"]
+              mirrors = ["repository.mdh.quantum.com:5001"]
+
+      - name: Build and push the ubuntu26 CI image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.ubuntu26.04
+          platforms: ${{ matrix.platform }}
+          push: true
+          tags: ${{ env.U26_IMAGE_TAG_PREFIX }}:${{ github.sha }}-${{ matrix.arch }}
+          cache-from: type=registry,ref=repository.mdh.quantum.com:5004/cache/chimera-ubuntu26:${{ matrix.arch }}
+          cache-to: type=registry,ref=repository.mdh.quantum.com:5004/cache/chimera-ubuntu26:${{ matrix.arch }},mode=max
           build-args: |
             APT_MIRROR=${{ env.APT_MIRROR }}
             DOCKER_MIRROR=${{ env.DOCKER_MIRROR }}
@@ -238,7 +283,7 @@ jobs:
 
   test:
     name: Test ${{ matrix.image_name }} ${{ matrix.platform }} ${{ matrix.build_type }}
-    needs: [build-devcontainer, build-ubuntu24, build-ubuntu22, build-rocky9, build-rocky10]
+    needs: [build-devcontainer, build-ubuntu26, build-ubuntu24, build-ubuntu22, build-rocky9, build-rocky10]
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -274,6 +319,35 @@ jobs:
             build_type: Debug
             image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-dev
             image_name: devcontainer
+            cmake_extra: ""
+          # ubuntu 26
+          - platform: linux/amd64
+            runner: arc-amd64
+            arch: amd64
+            build_type: Release
+            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu26
+            image_name: ubuntu26
+            cmake_extra: ""
+          - platform: linux/amd64
+            runner: arc-amd64
+            arch: amd64
+            build_type: Debug
+            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu26
+            image_name: ubuntu26
+            cmake_extra: ""
+          - platform: linux/arm64
+            runner: arc-arm64
+            arch: arm64
+            build_type: Release
+            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu26
+            image_name: ubuntu26
+            cmake_extra: ""
+          - platform: linux/arm64
+            runner: arc-arm64
+            arch: arm64
+            build_type: Debug
+            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu26
+            image_name: ubuntu26
             cmake_extra: ""
           # ubuntu 24
           - platform: linux/amd64
@@ -417,7 +491,7 @@ jobs:
 
   static-analysis:
     name: Static Analysis ${{ matrix.image_name }} ${{ matrix.platform }} ${{ matrix.build_type }}
-    needs: [build-devcontainer, build-ubuntu24, build-ubuntu22, build-rocky9, build-rocky10]
+    needs: [build-devcontainer, build-ubuntu26, build-ubuntu24, build-ubuntu22, build-rocky9, build-rocky10]
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -453,6 +527,35 @@ jobs:
             build_type: Debug
             image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-dev
             image_name: devcontainer
+            cmake_extra: ""
+          # ubuntu 26
+          - platform: linux/amd64
+            runner: arc-amd64
+            arch: amd64
+            build_type: Release
+            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu26
+            image_name: ubuntu26
+            cmake_extra: ""
+          - platform: linux/amd64
+            runner: arc-amd64
+            arch: amd64
+            build_type: Debug
+            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu26
+            image_name: ubuntu26
+            cmake_extra: ""
+          - platform: linux/arm64
+            runner: arc-arm64
+            arch: arm64
+            build_type: Release
+            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu26
+            image_name: ubuntu26
+            cmake_extra: ""
+          - platform: linux/arm64
+            runner: arc-arm64
+            arch: arm64
+            build_type: Debug
+            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu26
+            image_name: ubuntu26
             cmake_extra: ""
           # ubuntu 24
           - platform: linux/amd64

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,15 @@
 # SPDX-License-Identifier: Unlicense
 
 ARG DOCKER_MIRROR
-FROM ${DOCKER_MIRROR}ubuntu:24.04 AS build
+FROM ${DOCKER_MIRROR}ubuntu:26.04 AS build
 ARG BUILD_TYPE=Release
 ARG APT_MIRROR
+ARG ENABLE_XLIO=0
 
 RUN if [ -n "$APT_MIRROR" ]; then \
-    echo "deb $APT_MIRROR noble main universe" > /etc/apt/sources.list.d/local-mirror.list && \
-    echo "deb $APT_MIRROR noble-updates main universe" >> /etc/apt/sources.list.d/local-mirror.list && \
-    echo "deb $APT_MIRROR noble-security main universe" >> /etc/apt/sources.list.d/local-mirror.list && \
+    echo "deb $APT_MIRROR resolute main universe" > /etc/apt/sources.list.d/local-mirror.list && \
+    echo "deb $APT_MIRROR resolute-updates main universe" >> /etc/apt/sources.list.d/local-mirror.list && \
+    echo "deb $APT_MIRROR resolute-security main universe" >> /etc/apt/sources.list.d/local-mirror.list && \
     rm -f /etc/apt/sources.list.d/ubuntu.sources; \
     fi
 
@@ -25,7 +26,7 @@ RUN apt-get -y update && \
 # Note: We use our own NTLM implementation instead of gss-ntlmssp
 
 RUN if [ "$ENABLE_XLIO" = "1" ] ; then \
-git clone https://github.com/Mellanox/libdpcp.git /libdpcp && \
+git clone --depth 1 --branch gcc_15.2.0_build_fix https://github.com/arenaud16/libdpcp.git /libdpcp && \
 cd /libdpcp && \
 ./autogen.sh && \
 ./configure && \
@@ -49,12 +50,12 @@ RUN cmake -G Ninja -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DDISABLE_TESTS=ON /chimera 
     ninja && \
     ninja install
 
-FROM ${DOCKER_MIRROR}ubuntu:24.04
+FROM ${DOCKER_MIRROR}ubuntu:26.04
 ARG BUILD_TYPE=Release
 RUN apt-get -y update && \
     apt-get -y --no-install-recommends upgrade && \
     apt-get -y --no-install-recommends install libuuid1 librdmacm1 libjansson4 liburcu8t64 ibverbs-providers \
-    libasan8 liburing2 libunwind8 librocksdb8.9 libkrb5-3 libgssapi-krb5-2 openssl libnuma1 libwbclient0 \
+    libasan8 liburing2 libunwind8 librocksdb9.11 libkrb5-3 libgssapi-krb5-2 openssl libnuma1 libwbclient0 \
     python3 python3-requests && \
     if [ "${BUILD_TYPE}" = "Debug" ]; then \
     apt-get -y --no-install-recommends install llvm gdb ; \

--- a/Dockerfile.ubuntu26.04
+++ b/Dockerfile.ubuntu26.04
@@ -2,15 +2,11 @@
 #
 # SPDX-License-Identifier: Unlicense
 
-ARG DOCKER_MIRROR
+ARG DOCKER_MIRROR=""
 FROM ${DOCKER_MIRROR}ubuntu:26.04
-ARG APT_MIRROR
 ARG ENABLE_XLIO=1
-ARG ENABLE_DOCA=0
 ARG ENABLE_FIO=1
-ARG ENABLE_CLAUDE=1
-ARG ENABLE_CODEX=1
-ARG ENABLE_UV=1
+ARG APT_MIRROR=""
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -23,24 +19,14 @@ RUN if [ -n "$APT_MIRROR" ]; then \
 
 RUN apt-get -y update && \
     apt-get -y --no-install-recommends upgrade && \
-    apt-get -y --no-install-recommends install unminimize apt-utils && \
-    yes | unminimize && \
-    apt-get -y --no-install-recommends install clang clang-tools cmake ninja-build git flex bison lldb gdb less vim psmisc uncrustify \
-    net-tools tshark tcpdump uuid-dev iproute2 man-db manpages-dev ca-certificates ssh libjansson-dev libclang-rt-18-dev llvm wget \
-    libxxhash-dev liburcu-dev librdmacm-dev liburing-dev libaio-dev libunwind-dev librocksdb-dev libcurl4-openssl-dev clangd uthash-dev libnuma-dev \
-    libcurl4-openssl-dev build-essential ruby-full autoconf automake make libtool pkg-config libs3-dev gh npm reuse libssl-dev openssl \
-    libkrb5-3 libkrb5-dev libgssapi-krb5-2 libwbclient-dev curl jq \
-    krb5-kdc krb5-admin-server krb5-user python3-pip python3-setuptools \
-    samba samba-ad-dc samba-ad-provision samba-vfs-modules smbclient && \
-    gem install jekyll bundler
-
-RUN if [ "$ENABLE_CLAUDE" = "1" ] ; then \
-    npm install -g @anthropic-ai/claude-code ; \
-    fi
-
-RUN if [ "$ENABLE_CODEX" = "1" ] ; then \
-    npm install -g @openai/codex ; \
-    fi
+    apt-get -y --no-install-recommends install clang clang-tools cmake ninja-build git flex bison llvm \
+    libclang-rt-18-dev uuid-dev uthash-dev libkrb5-dev libgssapi-krb5-2 gss-ntlmssp-dev \
+    librdmacm-dev libjansson-dev libxxhash-dev liburcu-dev liburing-dev libunwind-dev librocksdb-dev \
+    libssl-dev openssl libnuma-dev libcurl4-openssl-dev libs3-dev libaio-dev \
+    build-essential autoconf automake libtool pkg-config ca-certificates uncrustify iproute2 curl \
+    libwbclient-dev smbclient krb5-kdc krb5-admin-server krb5-user samba samba-ad-dc samba-ad-provision samba-dsdb-modules && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN if [ "$ENABLE_FIO" = "1" ] ; then \
     git clone --depth 1 --branch fio-3.40 https://github.com/axboe/fio.git /fio && \
@@ -48,13 +34,6 @@ RUN if [ "$ENABLE_FIO" = "1" ] ; then \
     ./configure --disable-libnfs && \
     make -j8 && \
     make install ; \
-    fi
-
-RUN if [ "$ENABLE_DOCA" = "1" ] ; then \
-    wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/cuda-keyring_1.1-1_all.deb && \
-    dpkg -i cuda-keyring_1.1-1_all.deb && \
-    apt-get update && \
-    apt-get -y install cuda-toolkit-12-8 ; \
     fi
 
 RUN if [ "$ENABLE_XLIO" = "1" ] ; then \
@@ -73,7 +52,7 @@ RUN if [ "$ENABLE_XLIO" = "1" ] ; then \
     fi
 
 RUN apt-get -y update && \
-    apt-get -y --no-install-recommends install qemu-system-x86  qemu-utils && \
+    apt-get -y --no-install-recommends install qemu-system-x86 qemu-utils && \
     install -m 0755 -d /etc/apt/keyrings && \
     curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc && \
     chmod a+r /etc/apt/keyrings/docker.asc && \
@@ -83,7 +62,3 @@ RUN apt-get -y update && \
     apt-get -y --no-install-recommends install docker-ce docker-ce-cli containerd.io && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-
-RUN if [ "$ENABLE_UV" = "1" ] ; then \
-    curl -LsSf https://astral.sh/uv/install.sh | sh ; \
-    fi

--- a/kvm/CMakeLists.txt
+++ b/kvm/CMakeLists.txt
@@ -7,8 +7,6 @@
 get_filename_component(BUILD_ROOT ${CMAKE_BINARY_DIR} DIRECTORY)
 
 set(KVM_IMAGES
-    "ubuntu2604|26.04|resolute|linux-image-generic"
-    "ubuntu2604_hwe|26.04|resolute|linux-image-generic-hwe-26.04"
     "ubuntu2404|24.04|noble|linux-image-generic"
     "ubuntu2404_hwe|24.04|noble|linux-image-generic-hwe-24.04"
     "ubuntu2204|22.04|jammy|linux-image-generic"

--- a/kvm/CMakeLists.txt
+++ b/kvm/CMakeLists.txt
@@ -7,6 +7,8 @@
 get_filename_component(BUILD_ROOT ${CMAKE_BINARY_DIR} DIRECTORY)
 
 set(KVM_IMAGES
+    "ubuntu2604|26.04|resolute|linux-image-generic"
+    "ubuntu2604_hwe|26.04|resolute|linux-image-generic-hwe-26.04"
     "ubuntu2404|24.04|noble|linux-image-generic"
     "ubuntu2404_hwe|24.04|noble|linux-image-generic-hwe-24.04"
     "ubuntu2204|22.04|jammy|linux-image-generic"

--- a/scripts/kerberos_test_wrapper.sh
+++ b/scripts/kerberos_test_wrapper.sh
@@ -262,6 +262,7 @@ run_test() {
         KRB5CCNAME="${CCACHE}" \
         KRB_REALM="${REALM}" \
         KRB_USER="testuser1" \
+        KRB_PASSWORD="Password1!" \
         KRB_SMB_HOST="${SMB_HOST}" \
         KRB_KDC="${KDC_IP}:${KDC_PORT}" \
         "$@"

--- a/src/server/s3/s3.c
+++ b/src/server/s3/s3.c
@@ -38,8 +38,8 @@ chimera_s3_parse_range(
     int64_t    *offset,
     int64_t    *length)
 {
-    char *dash;
-    char *end;
+    const char *dash;
+    char       *end;
 
     if (strncmp(range_str, "bytes=", 6) != 0) {
         return -1;

--- a/src/server/smb/tests/smbclient_auth_test.c
+++ b/src/server/smb/tests/smbclient_auth_test.c
@@ -370,17 +370,29 @@ verify_kerberos_environment(void)
     fprintf(stderr, "  KRB5_CONFIG: %s\n", krb5_config);
     fprintf(stderr, "  KRB5CCNAME:  %s\n", ccache);
 
-    /* smbclient picks up the credential cache via the KRB5CCNAME
-     * environment variable (works with both MIT and Heimdal backends).
-     * We need -U user@REALM so smbclient matches the ccache principal
-     * instead of defaulting to the Unix username (root). */
-    if (krb_user && krb_realm) {
-        snprintf(kerberos_auth_args, sizeof(kerberos_auth_args),
-                 "--use-kerberos=required -U %s@%s -N",
-                 krb_user, krb_realm);
-    } else {
-        snprintf(kerberos_auth_args, sizeof(kerberos_auth_args),
-                 "--use-kerberos=required -N");
+    /* Samba 4.23+ ships a private Heimdal that cannot read credential
+    * caches created by the system MIT kinit.  When a password is
+    * available (KRB_PASSWORD), pass it directly so smbclient's
+    * bundled Heimdal acquires its own ticket from the KDC.
+    * Fall back to ccache-only for environments without a password. */
+    {
+        const char *krb_pass = getenv("KRB_PASSWORD");
+
+        if (krb_user && krb_realm && krb_pass) {
+            snprintf(kerberos_auth_args, sizeof(kerberos_auth_args),
+                     "--use-kerberos=required -U %s@%s%%%s",
+                     krb_user, krb_realm, krb_pass);
+        } else if (krb_user && krb_realm) {
+            snprintf(kerberos_auth_args, sizeof(kerberos_auth_args),
+                     "--use-kerberos=required"
+                     " --use-krb5-ccache=%s -U %s@%s -N",
+                     ccache, krb_user, krb_realm);
+        } else {
+            snprintf(kerberos_auth_args, sizeof(kerberos_auth_args),
+                     "--use-kerberos=required"
+                     " --use-krb5-ccache=%s -N",
+                     ccache);
+        }
     }
 
     return 0;


### PR DESCRIPTION
Migrate all Dockerfiles from Ubuntu 24.04 (noble) to 26.04 (resolute).  Key changes driven by the new base image:

- Switch libdpcp to a fork with a GCC 15.2.0 build fix
- Update package names (qemu-kvm -> qemu-system-x86, librocksdb8.9 -> librocksdb9.11) and add python3-setuptools
- Fix const-correctness warning in s3 range parser (GCC 15)
- Work around Samba 4.23+ bundled Heimdal rejecting MIT ccaches by passing KRB_PASSWORD directly when available
- Add new Dockerfile.ubuntu26.04 standalone builder
- Forward DOCKER_MIRROR / APT_MIRROR build args in devcontainer