### PR TITLE
kvm: add Ubuntu 26.04 images and fix cthon04 build flags

### DIFF
--- a/kvm/CMakeLists.txt
+++ b/kvm/CMakeLists.txt
@@ -7,6 +7,8 @@
 get_filename_component(BUILD_ROOT ${CMAKE_BINARY_DIR} DIRECTORY)
 
 set(KVM_IMAGES
+    "ubuntu2604|26.04|resolute|linux-image-generic"
+    "ubuntu2604_hwe|26.04|resolute|linux-image-generic-hwe-26.04"
     "ubuntu2404|24.04|noble|linux-image-generic"
     "ubuntu2404_hwe|24.04|noble|linux-image-generic-hwe-24.04"
     "ubuntu2204|22.04|jammy|linux-image-generic"

--- a/kvm/Dockerfile.kvm
+++ b/kvm/Dockerfile.kvm
@@ -35,11 +35,12 @@ RUN apt-get -y update && \
 
 RUN git clone https://github.com/chimera-nas/cthon04.git /opt/cthon04 && \
     cd /opt/cthon04 && \
-    make domount getopt && \
-    make -C basic && \
-    make -C general && \
-    make -C special && \
-    make -C lock && \
+    CTHON_CFLAGS="CFLAGS=-DLINUX -DHAVE_SOCKLEN_T -DGLIBC=22 -DMMAP -DSTDARG -std=gnu89" && \
+    make domount getopt "$CTHON_CFLAGS" && \
+    make -C basic "$CTHON_CFLAGS" && \
+    make -C general "$CTHON_CFLAGS" && \
+    make -C special "$CTHON_CFLAGS" && \
+    make -C lock "$CTHON_CFLAGS" && \
     chmod a+x runtests
 
 RUN git clone https://github.com/chimera-nas/xfstests.git /opt/xfstests && \


### PR DESCRIPTION
Add ubuntu2604 and ubuntu2604_hwe targets to the KVM image list, and pass CFLAGS with -std=gnu89 (plus the existing LINUX/HAVE_SOCKLEN_T/ GLIBC/MMAP/STDARG defines) to cthon04's make invocations so it builds against newer toolchains.