### PR TITLE
Address assert tripping in chimera_smb_open_file_resolve()

### DIFF
--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -863,9 +863,6 @@ chimera_smb_open_file_resolve(
 
     pthread_mutex_unlock(&tree->open_files_lock[open_file_bucket]);
 
-    chimera_smb_abort_if(!open_file, "open request for file id %lx.%lx did not match an open file",
-                         file_id->pid, file_id->vid);
-
     return open_file;
 } /* chimera_smb_open_file_resolve */
 

--- a/src/server/smb/smb_proc_flush.c
+++ b/src/server/smb/smb_proc_flush.c
@@ -29,6 +29,11 @@ chimera_smb_flush(struct chimera_smb_request *request)
 
     request->flush.open_file = chimera_smb_open_file_resolve(request, &request->flush.file_id);
 
+    if (unlikely(!request->flush.open_file)) {
+        chimera_smb_complete_request(request, SMB2_STATUS_FILE_CLOSED);
+        return;
+    }
+
     chimera_vfs_commit(
         thread->vfs_thread,
         &request->session_handle->session->cred,

--- a/src/server/smb/smb_proc_ioctl.c
+++ b/src/server/smb/smb_proc_ioctl.c
@@ -36,6 +36,12 @@ chimera_smb_ioctl(struct chimera_smb_request *request)
 
             open_file = chimera_smb_open_file_resolve(request, &request->ioctl.file_id);
 
+            if (unlikely(!open_file)) {
+                evpl_iovecs_release(thread->evpl, request->ioctl.input_iov, request->ioctl.input_niov);
+                chimera_smb_complete_request(request, SMB2_STATUS_FILE_CLOSED);
+                return;
+            }
+
             evpl_iovec_alloc(
                 thread->evpl,
                 65535,

--- a/src/server/smb/smb_proc_query_directory.c
+++ b/src/server/smb/smb_proc_query_directory.c
@@ -271,7 +271,7 @@ chimera_smb_query_directory(struct chimera_smb_request *request)
     request->query_directory.open_file = chimera_smb_open_file_resolve(request, &request->query_directory.file_id);
 
     if (unlikely(!request->query_directory.open_file)) {
-        chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
+        chimera_smb_complete_request(request, SMB2_STATUS_FILE_CLOSED);
         return;
     }
 

--- a/src/server/smb/smb_proc_query_info.c
+++ b/src/server/smb/smb_proc_query_info.c
@@ -80,7 +80,7 @@ chimera_smb_query_info(struct chimera_smb_request *request)
     request->query_info.r_attrs.smb_attr_mask = 0;
 
     if (unlikely(!request->query_info.open_file)) {
-        chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
+        chimera_smb_complete_request(request, SMB2_STATUS_FILE_CLOSED);
         return;
     }
 

--- a/src/server/smb/smb_proc_read.c
+++ b/src/server/smb/smb_proc_read.c
@@ -76,6 +76,11 @@ chimera_smb_read(struct chimera_smb_request *request)
 
     request->read.open_file = chimera_smb_open_file_resolve(request, &request->read.file_id);
 
+    if (unlikely(!request->read.open_file)) {
+        chimera_smb_complete_request(request, SMB2_STATUS_FILE_CLOSED);
+        return;
+    }
+
     chimera_vfs_read(
         thread->vfs_thread,
         &request->session_handle->session->cred,

--- a/src/server/smb/smb_proc_reparse.c
+++ b/src/server/smb/smb_proc_reparse.c
@@ -232,7 +232,7 @@ chimera_smb_ioctl_set_reparse(struct chimera_smb_request *request)
     open_file = chimera_smb_open_file_resolve(request, &request->ioctl.file_id);
 
     if (!open_file) {
-        chimera_smb_complete_request(request, SMB2_STATUS_INVALID_HANDLE);
+        chimera_smb_complete_request(request, SMB2_STATUS_FILE_CLOSED);
         return;
     }
 
@@ -463,7 +463,7 @@ chimera_smb_ioctl_get_reparse(struct chimera_smb_request *request)
     open_file = chimera_smb_open_file_resolve(request, &request->ioctl.file_id);
 
     if (!open_file) {
-        chimera_smb_complete_request(request, SMB2_STATUS_INVALID_HANDLE);
+        chimera_smb_complete_request(request, SMB2_STATUS_FILE_CLOSED);
         return;
     }
 

--- a/src/server/smb/smb_proc_set_info.c
+++ b/src/server/smb/smb_proc_set_info.c
@@ -162,6 +162,11 @@ chimera_smb_set_info(struct chimera_smb_request *request)
     request->set_info.open_file     = chimera_smb_open_file_resolve(request, &request->set_info.file_id);
     request->set_info.parent_handle = NULL;
 
+    if (unlikely(!request->set_info.open_file)) {
+        chimera_smb_complete_request(request, SMB2_STATUS_FILE_CLOSED);
+        return;
+    }
+
     switch (request->set_info.info_type) {
         case SMB2_INFO_FILE:
             switch (request->set_info.info_class) {
@@ -180,6 +185,11 @@ chimera_smb_set_info(struct chimera_smb_request *request)
                         request);
                     break;
                 case SMB2_FILE_ENDOFFILE_INFO:
+                case SMB2_FILE_ALLOCATION_INFO:
+                    /* AllocationInfo strictly only truncates when alloc <
+                     * EOF (MS-FSCC §2.4.4).  We collapse it to setattr(size)
+                     * because Windows always follows up with set-EOF in the
+                     * save flow, and a stand-alone shrink still truncates. */
                     chimera_smb_unmarshal_end_of_file_info(&request->set_info.attrs, &request->set_info.vfs_attrs);
 
                     chimera_vfs_setattr(
@@ -292,6 +302,7 @@ chimera_smb_parse_set_info(
                     chimera_smb_parse_disposition_info_ex(request_cursor, &request->set_info.attrs);
                     break;
                 case SMB2_FILE_ENDOFFILE_INFO:
+                case SMB2_FILE_ALLOCATION_INFO:
                     chimera_smb_parse_end_of_file_info(
                         request_cursor,
                         &request->set_info.attrs);

--- a/src/server/smb/smb_proc_write.c
+++ b/src/server/smb/smb_proc_write.c
@@ -102,6 +102,11 @@ chimera_smb_write(struct chimera_smb_request *request)
 
     request->write.open_file = chimera_smb_open_file_resolve(request, &request->write.file_id);
 
+    if (unlikely(!request->write.open_file)) {
+        chimera_smb_complete_request(request, SMB2_STATUS_FILE_CLOSED);
+        return;
+    }
+
     if (request->write.channel == SMB2_CHANNEL_RDMA_V1) {
         /* We need to read in the data we're supposed to be writing first */
 


### PR DESCRIPTION
Root cause
chimera_smb_open_file_resolve treats a miss as fatal. That makes any stale file id a remote DoS — a misbehaving or reconnecting client can crash the daemon. The fallback in change_notify itself (smb_proc_change_notify.c:56-59) returning SMB2_STATUS_FILE_CLOSED is unreachable today because the abort fires first.

Other callers (write, read, query_info, query_directory, flush, ioctl, set_info, reparse) don't even have a NULL check — they all rely on the abort and would crash the same way.

Two-part change:

Make chimera_smb_open_file_resolve non-fatal on miss — drop the chimera_smb_abort_if(!open_file, …) so it returns NULL instead. Log at debug or info level if useful. Make every caller handle NULL — return SMB2_STATUS_FILE_CLOSED (change_notify already does; the others need it added). This is the spec-correct response per MS-SMB2 §3.3.5.2. The tree == NULL and pid/vid == UINT64_MAX checks at the top of the function are different cases (programming errors in our compound state, not bad client input) and can stay as aborts.

Side issue also addressed:
The trigger was the unhandled SET_INFO info class 19. That's FileEndOfFileInformation (or FileAllocationInformation depending on the level vs. class encoding). Windows uses it during normal file operations; not implementing it forces clients to reconnect.