### PR TITLE
Lay the wire-format plumbing for SMB 3.1.1 and CA features.

### DIFF
--- a/src/server/smb/smb2.h
+++ b/src/server/smb/smb2.h
@@ -609,6 +609,33 @@ typedef uint8_t smb2_guid[SMB2_GUID_SIZE];
 #define SMB2_GLOBAL_CAP_DIRECTORY_LEASING           0x00000020 // Supports directory leasing (SMB 3.0+)
 #define SMB2_GLOBAL_CAP_ENCRYPTION                  0x00000040 // Supports encryption (SMB 3.0+)
 
+/* SMB2 3.1.1 negotiate context types (MS-SMB2 §2.2.3.1) */
+#define SMB2_PREAUTH_INTEGRITY_CAPABILITIES         0x0001
+#define SMB2_ENCRYPTION_CAPABILITIES                0x0002
+#define SMB2_COMPRESSION_CAPABILITIES               0x0003
+#define SMB2_NETNAME_NEGOTIATE_CONTEXT_ID           0x0005
+#define SMB2_TRANSPORT_CAPABILITIES                 0x0006
+#define SMB2_RDMA_TRANSFORM_CAPABILITIES            0x0007
+#define SMB2_SIGNING_CAPABILITIES                   0x0008
+
+/* SMB2_PREAUTH_INTEGRITY_CAPABILITIES HashAlgorithm IDs */
+#define SMB2_PREAUTH_HASH_SHA_512                   0x0001
+
+/* SMB2_ENCRYPTION_CAPABILITIES Cipher IDs */
+#define SMB2_ENCRYPTION_AES_128_CCM                 0x0001
+#define SMB2_ENCRYPTION_AES_128_GCM                 0x0002
+#define SMB2_ENCRYPTION_AES_256_CCM                 0x0003
+#define SMB2_ENCRYPTION_AES_256_GCM                 0x0004
+
+/* SMB2_SIGNING_CAPABILITIES Algorithm IDs */
+#define SMB2_SIGNING_HMAC_SHA256                    0x0000
+#define SMB2_SIGNING_AES_CMAC                       0x0001
+#define SMB2_SIGNING_AES_GMAC                       0x0002
+
+/* SMB2_COMPRESSION_CAPABILITIES Flags */
+#define SMB2_COMPRESSION_FLAG_NONE                  0x00000000
+#define SMB2_COMPRESSION_FLAG_CHAINED               0x00000001
+
 #define SMB2_NEGOTIATE_MAX_DIALECTS                 10
 
 #define SMB2_FLAGS_SERVER_TO_REDIR                  0x00000001

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -15,6 +15,7 @@
 #include <gssapi/gssapi_krb5.h>
 #include "evpl/evpl.h"
 #include "common/logging.h"
+#include "common/macros.h"
 #include "common/misc.h"
 #include "smb2.h"
 #include "smb1.h"
@@ -63,6 +64,27 @@
                          __LINE__, \
                          __VA_ARGS__)
 
+/* Little-endian decoders for SMB2 wire fields. Used by the negotiate-context
+ * and CREATE-context parsers; defined here so all SMB protocol code shares one
+ * implementation. The SMB2 wire format is little-endian throughout. */
+static inline uint16_t
+smb_wire_le16(const uint8_t *p)
+{
+    return (uint16_t) p[0] | ((uint16_t) p[1] << 8);
+} /* smb_wire_le16 */
+
+static inline uint32_t
+smb_wire_le32(const uint8_t *p)
+{
+    return (uint32_t) p[0] | ((uint32_t) p[1] << 8) |
+           ((uint32_t) p[2] << 16) | ((uint32_t) p[3] << 24);
+} /* smb_wire_le32 */
+
+static inline uint64_t
+smb_wire_le64(const uint8_t *p)
+{
+    return (uint64_t) smb_wire_le32(p) | ((uint64_t) smb_wire_le32(p + 4) << 32);
+} /* smb_wire_le64 */
 
 struct chimera_smb_nic_info {
     struct sockaddr_storage addr;
@@ -164,10 +186,45 @@ struct chimera_smb_request {
             uint64_t r_system_time;
             uint64_t r_server_start_time;
             uint16_t dialects[SMB2_MAX_DIALECTS];
+            /* Typed parse outputs for 3.1.1 negotiate contexts. The ctx_present_mask
+             * is the canonical "client sent this context" record; the typed structs
+             * carry the parsed fields. Phase 0 stores everything; Phase 2/4/5
+             * consumes the chosen algorithms via conn->negotiated.*. */
+            uint32_t ctx_present_mask;
             struct {
-                uint16_t type;
-                uint16_t length;
-            } negotiate_context[SMB2_MAX_NEGOTIATE_CONTEXTS];
+                uint16_t hash_alg_count;
+                uint16_t salt_length;
+                uint16_t hash_algs[8];
+                uint8_t  salt[32];
+            } preauth_in;
+            struct {
+                uint16_t cipher_count;
+                uint16_t ciphers[8];
+            } encryption_in;
+            struct {
+                uint16_t alg_count;
+                uint32_t flags;
+                uint16_t algs[8];
+            } compression_in;
+            struct {
+                uint16_t alg_count;
+                uint16_t algs[4];
+            } signing_in;
+            struct {
+                uint16_t transform_count;
+                uint16_t transforms[4];
+            } rdma_transform_in;
+            struct {
+                uint32_t flags;
+            } transport_in;
+            struct {
+                /* Wire length in bytes (not in UTF-16 code units). May be less
+                 * than the on-wire NetnameNegotiateContextId if it exceeded
+                 * sizeof(utf16le) — the parser truncates silently. Informational
+                 * only in Phase 0; consumed by Phase 4 for virtual hosting. */
+                uint16_t length_bytes;
+                uint8_t  utf16le[256];
+            } netname_in;
         } negotiate;
 
         struct {
@@ -205,8 +262,37 @@ struct chimera_smb_request {
             struct chimera_smb_open_file   *r_open_file;
             struct chimera_smb_attrs        r_attrs;
             struct chimera_vfs_attrs        set_attr;
-            char                            parent_path[SMB_FILENAME_MAX];
-            char                           *name;
+            /* CREATE contexts the client sent (CHIMERA_SMB_CREATE_CTX_* bits).
+             * Phase-0 stubs set the bit and capture a minimum set of fields needed
+             * by the response emit; Phase 1/3 will populate the rest. */
+            uint32_t                        ctx_present_mask;
+            struct {
+                uint64_t persistent;
+                uint64_t volatile_id;
+            } dhnc;
+            struct {
+                uint32_t timeout_ms;
+                uint32_t flags;
+                uint8_t  create_guid[16];
+            } dh2q;
+            struct {
+                uint64_t persistent;
+                uint64_t volatile_id;
+                uint8_t  create_guid[16];
+                uint32_t flags;
+            } dh2c;
+            struct {
+                uint8_t  key[16];
+                uint32_t state;
+                uint32_t flags;
+                uint8_t  parent_key[16];
+                uint16_t epoch;
+                int      is_v2;
+            } rqls;
+            uint64_t alsi_alloc_size;
+            uint64_t twrp_timestamp;
+            char     parent_path[SMB_FILENAME_MAX];
+            char    *name;
         } create;
 
         struct  {
@@ -387,6 +473,17 @@ struct chimera_smb_session_handle {
 #define CHIMERA_SMB_CONN_FLAG_SIGNING_REQUIRED      0x01
 #define CHIMERA_SMB_CONN_FLAG_SMB_DIRECT_NEGOTIATED 0x02
 
+/* Bits identifying which negotiate contexts the client sent (and that we
+ * accepted on the wire). Phase 0 records this so unit tests can assert
+ * dispatch behavior; Phase 2/4/5 will consume conn->negotiated.* values. */
+#define CHIMERA_SMB_NEGOTIATE_CTX_PREAUTH           (1u << 0)
+#define CHIMERA_SMB_NEGOTIATE_CTX_ENCRYPTION        (1u << 1)
+#define CHIMERA_SMB_NEGOTIATE_CTX_COMPRESSION       (1u << 2)
+#define CHIMERA_SMB_NEGOTIATE_CTX_NETNAME           (1u << 3)
+#define CHIMERA_SMB_NEGOTIATE_CTX_TRANSPORT         (1u << 4)
+#define CHIMERA_SMB_NEGOTIATE_CTX_RDMA_TRANSFORM    (1u << 5)
+#define CHIMERA_SMB_NEGOTIATE_CTX_SIGNING           (1u << 6)
+
 struct chimera_smb_notify_request;
 
 struct chimera_smb_conn {
@@ -408,6 +505,21 @@ struct chimera_smb_conn {
     int                                rdma_max_send;
     int                                rdma_niov;
     int                                rdma_length;
+    /* Algorithms selected at NEGOTIATE time from the client's offer; consumed
+     * by Phase 2 (preauth/encryption/signing), Phase 4 (RDMA transform), and
+     * Phase 5 (RDMA path). Zero means "not selected / not supported". */
+    struct {
+        uint32_t ctx_present_mask;          /* CHIMERA_SMB_NEGOTIATE_CTX_* */
+        uint16_t preauth_hash_alg;          /* 0 or SMB2_PREAUTH_HASH_SHA_512 */
+        uint16_t cipher_id;                 /* 0 or SMB2_ENCRYPTION_* */
+        uint16_t signing_alg;               /* SMB2_SIGNING_* */
+        uint16_t compression_flags;         /* SMB2_COMPRESSION_FLAG_* */
+        uint8_t  preauth_salt[32];          /* server-generated; Phase 2 will hash */
+        uint8_t  compression_alg_count;
+        uint8_t  rdma_transform_count;
+        uint16_t compression_algs[8];
+        uint16_t rdma_transforms[4];
+    } negotiated;
     struct chimera_smb_session_handle *last_session_handle;
     struct chimera_smb_tree           *last_tree;
     struct chimera_smb_session_handle *session_handles;
@@ -468,6 +580,39 @@ chimera_smb_tree_free(
     struct chimera_server_smb_shared *shared,
     struct chimera_smb_tree          *tree);
 
+/*
+ * Open-file lifetime model (current; Phase 3 will change this):
+ *
+ *   - Allocation: thread-local LIFO free list per chimera_server_smb_thread;
+ *     a freshly-popped open_file is NOT zeroed. Every caller (today only
+ *     chimera_smb_create_gen_open_file) is responsible for explicitly setting
+ *     every field that matters for its lifetime — see the explicit init block
+ *     in smb_proc_create.c.
+ *
+ *   - Ownership: an open is owned by exactly one chimera_smb_tree at a time,
+ *     hashed into the tree's open_files[] buckets by file_id (pid+vid). The
+ *     tree's lifetime is bounded by the connection that established it; when
+ *     the connection drops, the tree is torn down and every open it owns is
+ *     freed back to its allocating thread's free list.
+ *
+ *   - Cross-references: the share-mode table and the change-notify state
+ *     hold raw pointers into open_file objects. These are *only* safe while
+ *     the owning tree is alive — there is currently no global open-instance
+ *     registry, no disconnect-survival, and no cross-thread migration.
+ *
+ *   - Reconnect/durable: NOT supported. The ctx_present_mask / lease_* /
+ *     durable_* fields added in Phase 0 are inert state slots; the durable
+ *     handle lifecycle (which lets opens outlive their connection) lands in
+ *     Phase 3 and will almost certainly need to lift these fields out of
+ *     this struct into separate lease/durable objects with their own
+ *     lifetimes.
+ *
+ *   - Phase-3 reviewer's checklist: before merging persistent-handle work,
+ *     confirm (a) file_id no longer collides across tree teardowns, (b) lease
+ *     and durable objects own their own backing store, and (c) the share-mode
+ *     table either takes a strong reference or learns about open-instance
+ *     migration.
+ */
 static inline struct chimera_smb_open_file *
 chimera_smb_open_file_alloc(struct chimera_server_smb_thread *thread)
 {

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -107,6 +107,18 @@ chimera_smb_create_gen_open_file(
     open_file->pipe_transceive = transceive;
     open_file->refcnt          = 2;
 
+    /* Phase-0 plumbing state: zeroed; Phases 1/3 will populate from CREATE contexts. */
+    open_file->ctx_present_mask   = 0;
+    open_file->oplock_level       = 0;
+    open_file->lease_state        = 0;
+    open_file->lease_epoch        = 0;
+    open_file->lease_flags        = 0;
+    open_file->durable_flags      = 0;
+    open_file->durable_timeout_ms = 0;
+    memset(open_file->lease_key,        0, sizeof(open_file->lease_key));
+    memset(open_file->parent_lease_key, 0, sizeof(open_file->parent_lease_key));
+    memset(open_file->create_guid,      0, sizeof(open_file->create_guid));
+
     open_file->name_len = name_len;
     memcpy(open_file->name, name, open_file->name_len);
 
@@ -722,11 +734,201 @@ chimera_smb_create(struct chimera_smb_request *request)
     }
 } /* chimera_smb_create */
 
+/* CREATE-context response emit helpers.
+ *
+ * Each response context on the wire has this 16-byte header (mirroring 2.2.13.2):
+ *   Next(4) NameOffset(2) NameLength(2) Reserved(2) DataOffset(2) DataLength(4)
+ * followed by the 4-byte name at offset 16, 4 bytes of zero padding (to 8-byte
+ * align the data), then the data at offset 24. Chain advance = 24 + data_len
+ * rounded up to 8 bytes. Last context has Next = 0. */
+
+static const uint32_t SMB2_CREATE_CTX_FIXED_OVERHEAD = 24;
+
+static inline uint32_t
+smb_create_ctx_chain_advance(uint32_t data_len)
+{
+    uint32_t total = SMB2_CREATE_CTX_FIXED_OVERHEAD + data_len;
+
+    return (total + 7u) & ~7u;
+} /* smb_create_ctx_chain_advance */
+
+static uint32_t
+emit_create_response_context(
+    uint8_t       *buf,
+    uint32_t       buf_size,
+    uint32_t       pos,
+    const char    *tag,
+    const uint8_t *data,
+    uint32_t       data_len)
+{
+    uint32_t advance = smb_create_ctx_chain_advance(data_len);
+
+    if (pos + advance > buf_size) {
+        return 0;
+    }
+
+    /* Header. Next is filled in later (or zeroed for the last entry); write
+     * the advance value for now so chained reads work as we go, and the caller
+     * zeroes the field on the final context. */
+    buf[pos + 0]  = advance & 0xff;
+    buf[pos + 1]  = (advance >> 8) & 0xff;
+    buf[pos + 2]  = (advance >> 16) & 0xff;
+    buf[pos + 3]  = (advance >> 24) & 0xff;
+    buf[pos + 4]  = 16; buf[pos + 5]  = 0;                  /* NameOffset = 16 */
+    buf[pos + 6]  = 4;  buf[pos + 7]  = 0;                  /* NameLength = 4 */
+    buf[pos + 8]  = 0;  buf[pos + 9]  = 0;                  /* Reserved */
+    buf[pos + 10] = 24; buf[pos + 11] = 0;                  /* DataOffset = 24 */
+    buf[pos + 12] = data_len & 0xff;
+    buf[pos + 13] = (data_len >> 8) & 0xff;
+    buf[pos + 14] = (data_len >> 16) & 0xff;
+    buf[pos + 15] = (data_len >> 24) & 0xff;
+    buf[pos + 16] = (uint8_t) tag[0];
+    buf[pos + 17] = (uint8_t) tag[1];
+    buf[pos + 18] = (uint8_t) tag[2];
+    buf[pos + 19] = (uint8_t) tag[3];
+    buf[pos + 20] = 0; buf[pos + 21] = 0; buf[pos + 22] = 0; buf[pos + 23] = 0;
+    if (data_len > 0) {
+        memcpy(buf + pos + 24, data, data_len);
+    }
+    /* Zero any trailing pad bytes so we never leak stack contents. */
+    if (advance > SMB2_CREATE_CTX_FIXED_OVERHEAD + data_len) {
+        memset(buf + pos + SMB2_CREATE_CTX_FIXED_OVERHEAD + data_len,
+               0,
+               advance - SMB2_CREATE_CTX_FIXED_OVERHEAD - data_len);
+    }
+    return advance;
+} /* emit_create_response_context */
+
+/* Build the MxAc response body. 8 bytes: QueryStatus(4) | MaximalAccess(4).
+ *
+ * Spec semantics: MaximalAccess is the user's effective rights against the
+ * file's DACL — what the user *could* obtain, not what they happened to ask
+ * for. Computing that properly needs ACL evaluation we don't yet have, so
+ * Phase 0 only emits MxAc when the client opened with MAXIMUM_ALLOWED — that
+ * is the case where the granted desired_access (post-expansion in the create
+ * path) approximates the effective rights closely enough to be useful. For
+ * specific-access opens we omit the reply: the client already knows what it
+ * asked for, and returning that same mask back as "maximal" would be
+ * misleading. Phase 1's DACL evaluation will lift the gate. */
+static int
+build_mxac_response(
+    struct chimera_smb_request *request,
+    uint8_t                    *out,
+    uint32_t                    out_size)
+{
+    uint32_t max_access;
+
+    if (out_size < 8) {
+        return -1;
+    }
+
+    if ((request->create.desired_access & SMB2_MAXIMUM_ALLOWED) == 0) {
+        return -1;  /* not a MAXIMUM_ALLOWED open — omit the reply */
+    }
+
+    max_access = request->create.r_open_file ?
+        request->create.r_open_file->desired_access :
+        request->create.desired_access;
+
+    out[0] = 0; out[1] = 0; out[2] = 0; out[3] = 0;  /* QueryStatus = STATUS_SUCCESS */
+    out[4] = max_access & 0xff;
+    out[5] = (max_access >> 8) & 0xff;
+    out[6] = (max_access >> 16) & 0xff;
+    out[7] = (max_access >> 24) & 0xff;
+    return 8;
+} /* build_mxac_response */
+
+struct chimera_smb_create_response_emitter {
+    uint32_t    need_mask_bit;
+    const char *tag;  /* points at a 4-char literal; no NUL on the wire */
+    int         (*build)(
+        struct chimera_smb_request *r,
+        uint8_t                    *out,
+        uint32_t                    out_size);
+};
+
+/* *INDENT-OFF* */ /* uncrustify oscillates on aligned struct-init tables */
+static const struct chimera_smb_create_response_emitter smb_create_response_emitters[] = {
+    { CHIMERA_SMB_CREATE_CTX_MXAC, "MxAc", build_mxac_response },
+    /* Phase 1: + RqLs (lease grant)
+     * Phase 3: + DH2Q (durable handle grant), DHnQ
+     * Phase 8: + QFid (32-byte on-disk id) */
+    { 0,                           NULL,   NULL                },
+};
+/* *INDENT-ON* */
+
+/* Returns total bytes written into ctx_buf. Zero if no contexts to emit.
+ * Exposed for unit tests in tests/phase0_contexts_test.c. */
+SYMBOL_EXPORT uint32_t
+chimera_smb_build_create_response_contexts(
+    struct chimera_smb_request *request,
+    uint8_t                    *ctx_buf,
+    uint32_t                    ctx_buf_size)
+{
+    uint32_t                                          pos      = 0;
+    uint32_t                                          last_pos = 0;
+    int                                               emitted  = 0;
+    const struct chimera_smb_create_response_emitter *e;
+
+    if (!request->create.r_open_file) {
+        return 0;
+    }
+
+    for (e = smb_create_response_emitters; e->need_mask_bit != 0; e++) {
+        uint8_t  data_buf[64];
+        int      data_len;
+        uint32_t advance;
+
+        if ((request->create.ctx_present_mask & e->need_mask_bit) == 0) {
+            continue;
+        }
+        data_len = e->build(request, data_buf, sizeof(data_buf));
+        if (data_len < 0) {
+            continue;
+        }
+        advance = emit_create_response_context(ctx_buf, ctx_buf_size, pos,
+                                               e->tag, data_buf, (uint32_t) data_len);
+        /* Silently dropping a context the client asked for would create
+         * subtle interop failures (missing lease grant, missing durable
+         * grant, etc.) that are very hard to debug from a pcap. The caller
+         * controls ctx_buf_size; if the budget is wrong, it should grow,
+         * not silently truncate. Phase 2/3 will add more emitters and this
+         * fires the moment the buffer is undersized for the new mix. */
+        chimera_smb_abort_if(advance == 0,
+                             "CREATE response context %c%c%c%c overflowed ctx_buf "
+                             "(pos=%u data_len=%d size=%u)",
+                             e->tag[0], e->tag[1], e->tag[2], e->tag[3],
+                             pos, data_len, ctx_buf_size);
+        last_pos = pos;
+        pos     += advance;
+        emitted++;
+    }
+
+    if (emitted > 0) {
+        /* Patch the last context's Next field to zero. */
+        ctx_buf[last_pos + 0] = 0;
+        ctx_buf[last_pos + 1] = 0;
+        ctx_buf[last_pos + 2] = 0;
+        ctx_buf[last_pos + 3] = 0;
+    }
+
+    return pos;
+} /* chimera_smb_build_create_response_contexts */
+
 void
 chimera_smb_create_reply(
     struct evpl_iovec_cursor   *reply_cursor,
     struct chimera_smb_request *request)
 {
+    uint8_t  ctx_buf[256];
+    uint32_t ctx_len;
+    uint32_t ctx_off;
+
+    ctx_len = chimera_smb_build_create_response_contexts(request, ctx_buf, sizeof(ctx_buf));
+    /* Absolute offset from the start of the SMB2 header. CREATE reply fixed body
+     * is 88 bytes; contexts start in the Buffer field immediately after. The
+     * sum (header + 88) is naturally 8-byte aligned for the standard header. */
+    ctx_off = (ctx_len > 0) ? (uint32_t) (sizeof(struct smb2_header) + 88) : 0;
 
     evpl_iovec_cursor_append_uint16(reply_cursor, SMB2_CREATE_REPLY_SIZE);
 
@@ -754,16 +956,249 @@ chimera_smb_create_reply(
     evpl_iovec_cursor_append_uint64(reply_cursor, request->create.r_open_file ?
                                     request->create.r_open_file->file_id.vid : 0);
 
-    /* Create Context Offset */
-    evpl_iovec_cursor_append_uint32(reply_cursor, 0);
+    /* Create Context Offset / Length */
+    evpl_iovec_cursor_append_uint32(reply_cursor, ctx_off);
+    evpl_iovec_cursor_append_uint32(reply_cursor, ctx_len);
 
-    /* Create Context Length */
-    evpl_iovec_cursor_append_uint32(reply_cursor, 0);
+    if (ctx_len > 0) {
+        evpl_iovec_cursor_append_blob(reply_cursor, ctx_buf, ctx_len);
+    } else {
+        /* Preserve the 4-byte zero pad that the original implementation emitted
+         * here so the Buffer field is non-empty (StructureSize encodes +1). */
+        evpl_iovec_cursor_append_uint32(reply_cursor, 0);
+    }
 
-    /* Ea Error Offset */
-    evpl_iovec_cursor_append_uint32(reply_cursor, 0);
+    /* Phase-0 housekeeping: propagate which CREATE contexts the client supplied
+     * onto the open file so later phases (lease/durable break, reconnect) can
+     * tell which contracts the client expects. */
+    if (request->create.r_open_file) {
+        request->create.r_open_file->ctx_present_mask = request->create.ctx_present_mask;
+    }
 
 } /* chimera_smb_create_reply */
+
+/* CREATE-context request handlers. Each fills typed fields in request->create.
+ * NULL handler = presence-only (the bit in ctx_present_mask is all that matters
+ * for Phase 0; Phase 1/3 will add real semantics for the open-after-CREATE step). */
+
+static void
+parse_ctx_secd(
+    const uint8_t              *data,
+    uint32_t                    data_len,
+    struct chimera_smb_request *request)
+{
+    chimera_smb_parse_sd_to_attrs(data, data_len, &request->create.set_attr);
+} /* parse_ctx_secd */
+
+static void
+parse_ctx_dhnc(
+    const uint8_t              *data,
+    uint32_t                    data_len,
+    struct chimera_smb_request *request)
+{
+    /* DHnC body: 16-byte SMB2_FILEID (persistent | volatile) + 16 reserved bytes. */
+    if (data_len < 16) {
+        return;
+    }
+    request->create.dhnc.persistent  = smb_wire_le64(data);
+    request->create.dhnc.volatile_id = smb_wire_le64(data + 8);
+} /* parse_ctx_dhnc */
+
+static void
+parse_ctx_dh2q(
+    const uint8_t              *data,
+    uint32_t                    data_len,
+    struct chimera_smb_request *request)
+{
+    /* DH2Q body: Timeout(4) | Flags(4) | Reserved(8) | CreateGuid(16) = 32 bytes. */
+    if (data_len < 32) {
+        return;
+    }
+    request->create.dh2q.timeout_ms = smb_wire_le32(data);
+    request->create.dh2q.flags      = smb_wire_le32(data + 4);
+    memcpy(request->create.dh2q.create_guid, data + 16, 16);
+} /* parse_ctx_dh2q */
+
+static void
+parse_ctx_dh2c(
+    const uint8_t              *data,
+    uint32_t                    data_len,
+    struct chimera_smb_request *request)
+{
+    /* DH2C body: FileId(16) | CreateGuid(16) | Flags(4) = 36 bytes. */
+    if (data_len < 36) {
+        return;
+    }
+    request->create.dh2c.persistent  = smb_wire_le64(data);
+    request->create.dh2c.volatile_id = smb_wire_le64(data + 8);
+    memcpy(request->create.dh2c.create_guid, data + 16, 16);
+    request->create.dh2c.flags = smb_wire_le32(data + 32);
+} /* parse_ctx_dh2c */
+
+static void
+parse_ctx_rqls(
+    const uint8_t              *data,
+    uint32_t                    data_len,
+    struct chimera_smb_request *request)
+{
+    /* RqLs v1 body (32 bytes): LeaseKey(16) | LeaseState(4) | LeaseFlags(4) | LeaseDuration(8 reserved).
+     * RqLs v2 body (52 bytes): adds ParentLeaseKey(16) | Epoch(2) | Reserved(2).
+     * Differentiate by data_len. Other sizes: malformed; skip without setting fields. */
+    if (data_len != 32 && data_len != 52) {
+        return;
+    }
+    memcpy(request->create.rqls.key, data, 16);
+    request->create.rqls.state = smb_wire_le32(data + 16);
+    request->create.rqls.flags = smb_wire_le32(data + 20);
+    if (data_len == 52) {
+        request->create.rqls.is_v2 = 1;
+        memcpy(request->create.rqls.parent_key, data + 32, 16);
+        request->create.rqls.epoch = smb_wire_le16(data + 48);
+    } else {
+        request->create.rqls.is_v2 = 0;
+    }
+} /* parse_ctx_rqls */
+
+static void
+parse_ctx_alsi(
+    const uint8_t              *data,
+    uint32_t                    data_len,
+    struct chimera_smb_request *request)
+{
+    if (data_len < 8) {
+        return;
+    }
+    request->create.alsi_alloc_size = smb_wire_le64(data);
+} /* parse_ctx_alsi */
+
+static void
+parse_ctx_twrp(
+    const uint8_t              *data,
+    uint32_t                    data_len,
+    struct chimera_smb_request *request)
+{
+    if (data_len < 8) {
+        return;
+    }
+    request->create.twrp_timestamp = smb_wire_le64(data);
+} /* parse_ctx_twrp */
+
+typedef void (*chimera_smb_create_ctx_handler_t)(
+    const uint8_t              *data,
+    uint32_t                    data_len,
+    struct chimera_smb_request *request);
+
+struct chimera_smb_create_ctx_parser {
+    const char                      *tag;  /* points at a 4-char literal */
+    uint32_t                         mask_bit;
+    chimera_smb_create_ctx_handler_t handler;
+};
+
+/* Dispatch table for 4-byte tagged CREATE contexts. 16-byte GUID-named contexts
+ * (AppInstanceId, AppInstanceVersion, SVHDX_*) are silently skipped in Phase 0. */
+/* *INDENT-OFF* */ /* uncrustify oscillates on aligned struct-init tables */
+static const struct chimera_smb_create_ctx_parser smb_create_ctx_parsers[] = {
+    { "SecD", CHIMERA_SMB_CREATE_CTX_SECD, parse_ctx_secd },
+    { "ExtA", CHIMERA_SMB_CREATE_CTX_EXTA, NULL           },
+    { "DHnQ", CHIMERA_SMB_CREATE_CTX_DHNQ, NULL           },
+    { "DHnC", CHIMERA_SMB_CREATE_CTX_DHNC, parse_ctx_dhnc },
+    { "DH2Q", CHIMERA_SMB_CREATE_CTX_DH2Q, parse_ctx_dh2q },
+    { "DH2C", CHIMERA_SMB_CREATE_CTX_DH2C, parse_ctx_dh2c },
+    { "AlSi", CHIMERA_SMB_CREATE_CTX_ALSI, parse_ctx_alsi },
+    { "MxAc", CHIMERA_SMB_CREATE_CTX_MXAC, NULL           },
+    { "TWrp", CHIMERA_SMB_CREATE_CTX_TWRP, parse_ctx_twrp },
+    { "QFid", CHIMERA_SMB_CREATE_CTX_QFID, NULL           },
+    { "RqLs", CHIMERA_SMB_CREATE_CTX_RQLS, parse_ctx_rqls },
+    { NULL,   0,                           NULL           },
+};
+/* *INDENT-ON* */
+
+/* Exposed for unit tests in tests/phase0_contexts_test.c. */
+SYMBOL_EXPORT int
+chimera_smb_parse_create_contexts(
+    const uint8_t              *buf,
+    uint32_t                    buf_len,
+    struct chimera_smb_request *request)
+{
+    uint32_t pos = 0;
+
+    while (pos < buf_len) {
+        uint32_t       next, data_len;
+        uint16_t       name_off, name_len, data_off;
+        const uint8_t *name;
+        const uint8_t *data = NULL;
+
+        if (buf_len - pos < 16) {
+            chimera_smb_error("CREATE-context chain truncated before header (pos=%u, remaining=%u)",
+                              pos, buf_len - pos);
+            request->status = SMB2_STATUS_INVALID_PARAMETER;
+            return -1;
+        }
+
+        next     = smb_wire_le32(buf + pos);
+        name_off = smb_wire_le16(buf + pos + 4);
+        name_len = smb_wire_le16(buf + pos + 6);
+        /* buf[pos+8..pos+10] is the 2-byte Reserved */
+        data_off = smb_wire_le16(buf + pos + 10);
+        data_len = smb_wire_le32(buf + pos + 12);
+
+        if ((uint32_t) name_off + name_len > buf_len - pos) {
+            chimera_smb_error("CREATE-context name out of bounds (pos=%u, name_off=%u, name_len=%u)",
+                              pos, name_off, name_len);
+            request->status = SMB2_STATUS_INVALID_PARAMETER;
+            return -1;
+        }
+
+        if (data_len > 0) {
+            if (data_off == 0 || (uint32_t) data_off + data_len > buf_len - pos) {
+                chimera_smb_error("CREATE-context data out of bounds (pos=%u, data_off=%u, data_len=%u)",
+                                  pos, data_off, data_len);
+                request->status = SMB2_STATUS_INVALID_PARAMETER;
+                return -1;
+            }
+            data = buf + pos + data_off;
+        }
+
+        name = buf + pos + name_off;
+
+        /* Dispatch on 4-byte tags only. 16-byte GUID-named contexts
+         * (AppInstanceId, AppInstanceVersion, SVHDX_*) fall through. */
+        if (name_len == 4) {
+            const struct chimera_smb_create_ctx_parser *p;
+            for (p = smb_create_ctx_parsers; p->tag != NULL; p++) {
+                if (memcmp(name, p->tag, 4) == 0) {
+
+                    /* Tag-aware special case: RqLs v2 (52-byte body) sets a
+                     * distinct mask bit so the response emit can tell which
+                     * lease variant the client requested. */
+                    if (p->mask_bit == CHIMERA_SMB_CREATE_CTX_RQLS && data_len == 52) {
+                        request->create.ctx_present_mask |= CHIMERA_SMB_CREATE_CTX_RQLS_V2;
+                    } else {
+                        request->create.ctx_present_mask |= p->mask_bit;
+                    }
+                    if (p->handler) {
+                        p->handler(data, data_len, request);
+                    }
+                    break;
+                }
+            }
+        }
+
+        if (next == 0) {
+            break;
+        }
+
+        if (next < 16 || (next & 0x7) != 0 || pos + next > buf_len) {
+            chimera_smb_error("CREATE-context Next field invalid (pos=%u, next=%u, buf_len=%u)",
+                              pos, next, buf_len);
+            request->status = SMB2_STATUS_INVALID_PARAMETER;
+            return -1;
+        }
+        pos += next;
+    }
+
+    return 0;
+} /* chimera_smb_parse_create_contexts */
 
 /*
  * Parse SMB2 CREATE request
@@ -869,8 +1304,8 @@ chimera_smb_parse_create(
     /* Initialize create-time attributes (may be populated by SD create context) */
     request->create.set_attr.va_req_mask = 0;
     request->create.set_attr.va_set_mask = 0;
+    request->create.ctx_present_mask     = 0;
 
-    /* Parse create contexts for security descriptor (modefromsid) */
     if (blob_offset > 0 && blob_length > 0 && blob_length <= 1024) {
         uint8_t  ctx_buf[1024];
         uint32_t skip = blob_offset - evpl_iovec_cursor_consumed(request_cursor);
@@ -878,41 +1313,11 @@ chimera_smb_parse_create(
         evpl_iovec_cursor_skip(request_cursor, skip);
 
         if (evpl_iovec_cursor_get_blob(request_cursor, ctx_buf, blob_length) == 0) {
-            uint32_t pos = 0;
-
-            while (pos + 16 <= blob_length) {
-                uint32_t next = ctx_buf[pos]    | (ctx_buf[pos + 1] << 8) |
-                    (ctx_buf[pos + 2] << 16) | (ctx_buf[pos + 3] << 24);
-                uint16_t name_off = ctx_buf[pos + 4] | (ctx_buf[pos + 5] << 8);
-                uint16_t name_len = ctx_buf[pos + 6] | (ctx_buf[pos + 7] << 8);
-                uint16_t data_off = ctx_buf[pos + 10] | (ctx_buf[pos + 11] << 8);
-                uint32_t data_len = ctx_buf[pos + 12] | (ctx_buf[pos + 13] << 8) |
-                    (ctx_buf[pos + 14] << 16) | (ctx_buf[pos + 15] << 24);
-
-                /* Look for SMB2_CREATE_SD_BUFFER ("SecD") */
-                if (name_len == 4 &&
-                    pos + name_off + 4 <= blob_length &&
-                    ctx_buf[pos + name_off]     == 'S' &&
-                    ctx_buf[pos + name_off + 1] == 'e' &&
-                    ctx_buf[pos + name_off + 2] == 'c' &&
-                    ctx_buf[pos + name_off + 3] == 'D' &&
-                    data_off > 0 &&
-                    pos + data_off + data_len <= blob_length) {
-
-                    chimera_smb_parse_sd_to_attrs(
-                        ctx_buf + pos + data_off,
-                        data_len,
-                        &request->create.set_attr);
-                    break;
-                }
-
-                if (next == 0) {
-                    break;
-                }
-                pos += next;
+            if (chimera_smb_parse_create_contexts(ctx_buf, blob_length, request) < 0) {
+                return -1;
             }
         }
     }
 
     return 0;
-} /* chimera_smb_parse_create */ /* chimera_smb_parse_create */
+} /* chimera_smb_parse_create */

--- a/src/server/smb/smb_proc_negotiate.c
+++ b/src/server/smb/smb_proc_negotiate.c
@@ -5,6 +5,11 @@
 #include "smb_internal.h"
 #include "smb_procs.h"
 
+/* Forward declarations for helpers defined later in this file. */
+static void chimera_smb_select_negotiated_algorithms(
+    struct chimera_smb_conn    *conn,
+    struct chimera_smb_request *request);
+
 /*
  * Pre-built SPNEGO negTokenInit advertising available authentication mechanisms.
  * This is the security blob sent in the SMB2 NEGOTIATE response.
@@ -115,23 +120,163 @@ chimera_smb_negotiate(struct chimera_smb_request *request)
 
     conn->dialect = dialect;
 
+    /* Pick algorithms from the client's negotiate contexts. Phase 0 records
+     * presence; Phases 2/4/5 will actually flip on preauth/encryption/RDMA. */
+    chimera_smb_select_negotiated_algorithms(conn, request);
+
     chimera_smb_complete_request(
         request,
         SMB2_STATUS_SUCCESS);
 } /* smb_procs_negotiate */
+
+/* Wire emit for one negotiate-response context.
+ *   ContextType(2) DataLength(2) Reserved(4) Data(...)
+ * followed by 0..7 padding bytes so the next context starts on an 8-byte
+ * boundary. Returns the total bytes consumed (header + data + pad), or 0
+ * if the output buffer is too small. */
+static uint32_t
+emit_negotiate_response_context(
+    uint8_t       *buf,
+    uint32_t       buf_size,
+    uint32_t       pos,
+    uint16_t       type,
+    const uint8_t *data,
+    uint16_t       data_len)
+{
+    uint32_t total   = 8u + (uint32_t) data_len;
+    uint32_t advance = (total + 7u) & ~7u;
+
+    if (pos + advance > buf_size) {
+        return 0;
+    }
+
+    buf[pos + 0] = type & 0xff;
+    buf[pos + 1] = (type >> 8) & 0xff;
+    buf[pos + 2] = data_len & 0xff;
+    buf[pos + 3] = (data_len >> 8) & 0xff;
+    buf[pos + 4] = 0; buf[pos + 5] = 0; buf[pos + 6] = 0; buf[pos + 7] = 0;  /* Reserved */
+    if (data_len > 0) {
+        memcpy(buf + pos + 8, data, data_len);
+    }
+    if (advance > total) {
+        memset(buf + pos + total, 0, advance - total);
+    }
+    return advance;
+} /* emit_negotiate_response_context */
+
+struct chimera_smb_negotiate_response_emitter {
+    uint32_t need_mask_bit;
+    uint16_t type;
+    int      (*build)(
+        struct chimera_smb_conn    *conn,
+        struct chimera_smb_request *request,
+        uint8_t                    *out,
+        uint32_t                    out_size);
+};
+
+/* Phase 0 ships an empty table on purpose. We have the plumbing to emit
+ * negotiate response contexts, but nothing positive to advertise yet:
+ *   - PreauthIntegrity, Encryption, Signing → Phase 2
+ *   - Compression                            → Phase 8
+ *   - RdmaTransform                          → Phase 5
+ *   - Transport/Netname are not server-reply contexts in any phase.
+ * Phase 2 will register builders here.
+ *
+ * !! Do NOT add SMB 3.1.1 to server.c's default dialect list until Phase 2
+ * lands preauth integrity. With this table empty, a successful 3.1.1
+ * negotiation produces a reply that is structurally legal (NegotiateContext-
+ * Count=0, Offset=0) but spec-noncompliant: 3.1.1 mandates that the server
+ * emit a PreauthIntegrityCapabilities reply. Lenient clients (current
+ * Win11, macOS, libsmb2) tolerate the missing context and then derive
+ * session-keys using SMB 3.0-style KDF — which diverges from the client's
+ * preauth-bound derivation. The first signed message after SESSION_SETUP
+ * fails MAC verification on both ends and the connection dies. The dialect
+ * ceiling stays at 3.0 in server.c:103-105 specifically to keep this latent
+ * mismatch unreachable. */
+static const struct chimera_smb_negotiate_response_emitter smb_negotiate_response_emitters[] = {
+    { 0, 0, NULL }
+};
+
+/* Build the negotiate context list into ctx_buf. Returns total bytes written
+ * and writes the number of emitted contexts to *out_count. Contexts are only
+ * valid when DialectRevision == 0x0311. */
+static uint32_t
+chimera_smb_build_negotiate_response_contexts(
+    struct chimera_smb_request *request,
+    struct chimera_smb_conn    *conn,
+    uint8_t                    *ctx_buf,
+    uint32_t                    ctx_buf_size,
+    uint16_t                   *out_count)
+{
+    uint32_t                                             pos   = 0;
+    uint16_t                                             count = 0;
+    const struct chimera_smb_negotiate_response_emitter *e;
+
+    if (request->negotiate.r_dialect != SMB2_DIALECT_3_1_1) {
+        *out_count = 0;
+        return 0;
+    }
+
+    for (e = smb_negotiate_response_emitters; e->build != NULL; e++) {
+        uint8_t  data_buf[256];
+        int      data_len;
+        uint32_t advance;
+
+        if (e->need_mask_bit &&
+            (conn->negotiated.ctx_present_mask & e->need_mask_bit) == 0) {
+            continue;
+        }
+        data_len = e->build(conn, request, data_buf, sizeof(data_buf));
+        if (data_len < 0) {
+            continue;
+        }
+        advance = emit_negotiate_response_context(ctx_buf, ctx_buf_size, pos,
+                                                  e->type, data_buf, (uint16_t) data_len);
+        if (advance == 0) {
+            break;
+        }
+        pos += advance;
+        count++;
+    }
+
+    *out_count = count;
+    return pos;
+} /* chimera_smb_build_negotiate_response_contexts */
 
 void
 chimera_smb_negotiate_reply(
     struct evpl_iovec_cursor   *reply_cursor,
     struct chimera_smb_request *request)
 {
-    uint16_t security_buffer_offset = sizeof(struct smb2_header) + 64;
-    uint16_t security_buffer_length = sizeof(spnego_negotiate_token);
+    struct chimera_smb_conn *conn                   = request->compound->conn;
+    uint16_t                 security_buffer_offset = sizeof(struct smb2_header) + 64;
+    uint16_t                 security_buffer_length = sizeof(spnego_negotiate_token);
+    uint8_t                  ctx_buf[1024];
+    uint32_t                 ctx_len;
+    uint16_t                 ctx_count;
+    uint32_t                 ctx_offset     = 0;
+    uint32_t                 after_security = (uint32_t) security_buffer_offset + security_buffer_length;
+    uint32_t                 pad_before_ctx = 0;
+
+    /* Reply path runs after chimera_smb_negotiate, which dereferences conn
+     * unconditionally — if we got here without it, we have a different bug
+     * to find, but make the failure loud. */
+    chimera_smb_abort_if(conn == NULL, "chimera_smb_negotiate_reply: NULL conn");
+
+    ctx_len = chimera_smb_build_negotiate_response_contexts(
+        request, conn, ctx_buf, sizeof(ctx_buf), &ctx_count);
+
+    if (ctx_count > 0) {
+        /* First context must be 8-byte aligned from start of SMB2 header. */
+        ctx_offset     = (after_security + 7u) & ~7u;
+        pad_before_ctx = ctx_offset - after_security;
+    }
 
     evpl_iovec_cursor_append_uint16(reply_cursor, SMB2_NEGOTIATE_REPLY_SIZE);
     evpl_iovec_cursor_append_uint16(reply_cursor, request->negotiate.r_security_mode);
     evpl_iovec_cursor_append_uint16(reply_cursor, request->negotiate.r_dialect);
-    evpl_iovec_cursor_append_uint16(reply_cursor, 0); /* NegotiateContextCount / Reserved */
+    /* NegotiateContextCount / Reserved (only meaningful for 0x0311) */
+    evpl_iovec_cursor_append_uint16(reply_cursor, ctx_count);
     evpl_iovec_cursor_append_blob(reply_cursor, request->negotiate.r_server_guid, SMB2_GUID_SIZE);
     evpl_iovec_cursor_append_uint32(reply_cursor, request->negotiate.r_capabilities);
     evpl_iovec_cursor_append_uint32(reply_cursor, request->negotiate.r_max_transact_size);
@@ -141,13 +286,352 @@ chimera_smb_negotiate_reply(
     evpl_iovec_cursor_append_uint64(reply_cursor, request->negotiate.r_server_start_time);
     evpl_iovec_cursor_append_uint16(reply_cursor, security_buffer_offset);
     evpl_iovec_cursor_append_uint16(reply_cursor, security_buffer_length);
-    /* NegotiateContextOffset / Reserved2 */
-    evpl_iovec_cursor_append_uint32(reply_cursor, 0);
+    /* NegotiateContextOffset / Reserved2 — absolute from start of SMB2 header */
+    evpl_iovec_cursor_append_uint32(reply_cursor, ctx_offset);
+
     /* SPNEGO security buffer */
     evpl_iovec_cursor_append_blob(reply_cursor, (void *) spnego_negotiate_token,
                                   security_buffer_length);
 
+    if (pad_before_ctx > 0) {
+        static const uint8_t pad_zero[8] = { 0 };
+        evpl_iovec_cursor_append_blob(reply_cursor, (void *) pad_zero, pad_before_ctx);
+    }
+
+    if (ctx_len > 0) {
+        evpl_iovec_cursor_append_blob(reply_cursor, ctx_buf, ctx_len);
+    }
+
 } /* chimera_smb_negotiate_reply */
+
+/* Per-type negotiate-context parsers. Each returns 0 on success, -1 on a
+ * malformed body. Phase 0 records the parsed fields onto request->negotiate.*_in
+ * for later inspection (selection logic, unit tests, future phase consumers). */
+
+static int
+parse_neg_ctx_preauth(
+    struct chimera_smb_request *request,
+    const uint8_t              *data,
+    uint16_t                    data_len)
+{
+    uint16_t hash_count, salt_len, i;
+
+    if (data_len < 4) {
+        return -1;
+    }
+    hash_count = smb_wire_le16(data);
+    salt_len   = smb_wire_le16(data + 2);
+
+    if (hash_count == 0 ||
+        hash_count > sizeof(request->negotiate.preauth_in.hash_algs) / sizeof(uint16_t)) {
+        return -1;
+    }
+    if ((uint32_t) 4 + (uint32_t) hash_count * 2u + (uint32_t) salt_len > data_len) {
+        return -1;
+    }
+    if (salt_len > sizeof(request->negotiate.preauth_in.salt)) {
+        return -1;
+    }
+
+    request->negotiate.preauth_in.hash_alg_count = hash_count;
+    request->negotiate.preauth_in.salt_length    = salt_len;
+    for (i = 0; i < hash_count; i++) {
+        request->negotiate.preauth_in.hash_algs[i] = smb_wire_le16(data + 4 + i * 2);
+    }
+    if (salt_len > 0) {
+        memcpy(request->negotiate.preauth_in.salt,
+               data + 4 + hash_count * 2,
+               salt_len);
+    }
+    return 0;
+} /* parse_neg_ctx_preauth */
+
+static int
+parse_neg_ctx_encryption(
+    struct chimera_smb_request *request,
+    const uint8_t              *data,
+    uint16_t                    data_len)
+{
+    uint16_t count, i;
+
+    if (data_len < 2) {
+        return -1;
+    }
+    count = smb_wire_le16(data);
+    if (count == 0 ||
+        count > sizeof(request->negotiate.encryption_in.ciphers) / sizeof(uint16_t)) {
+        return -1;
+    }
+    if ((uint32_t) 2 + (uint32_t) count * 2u > data_len) {
+        return -1;
+    }
+
+    request->negotiate.encryption_in.cipher_count = count;
+    for (i = 0; i < count; i++) {
+        request->negotiate.encryption_in.ciphers[i] = smb_wire_le16(data + 2 + i * 2);
+    }
+    return 0;
+} /* parse_neg_ctx_encryption */
+
+static int
+parse_neg_ctx_compression(
+    struct chimera_smb_request *request,
+    const uint8_t              *data,
+    uint16_t                    data_len)
+{
+    uint16_t count, i;
+
+    if (data_len < 8) {
+        return -1;
+    }
+    count = smb_wire_le16(data);
+    /* data + 2: 2-byte padding (ignored) */
+    request->negotiate.compression_in.flags = smb_wire_le32(data + 4);
+
+    if (count > sizeof(request->negotiate.compression_in.algs) / sizeof(uint16_t)) {
+        return -1;
+    }
+    if ((uint32_t) 8 + (uint32_t) count * 2u > data_len) {
+        return -1;
+    }
+
+    request->negotiate.compression_in.alg_count = count;
+    for (i = 0; i < count; i++) {
+        request->negotiate.compression_in.algs[i] = smb_wire_le16(data + 8 + i * 2);
+    }
+    return 0;
+} /* parse_neg_ctx_compression */
+
+static int
+parse_neg_ctx_signing(
+    struct chimera_smb_request *request,
+    const uint8_t              *data,
+    uint16_t                    data_len)
+{
+    uint16_t count, i;
+
+    if (data_len < 2) {
+        return -1;
+    }
+    count = smb_wire_le16(data);
+    if (count == 0 ||
+        count > sizeof(request->negotiate.signing_in.algs) / sizeof(uint16_t)) {
+        return -1;
+    }
+    if ((uint32_t) 2 + (uint32_t) count * 2u > data_len) {
+        return -1;
+    }
+
+    request->negotiate.signing_in.alg_count = count;
+    for (i = 0; i < count; i++) {
+        request->negotiate.signing_in.algs[i] = smb_wire_le16(data + 2 + i * 2);
+    }
+    return 0;
+} /* parse_neg_ctx_signing */
+
+static int
+parse_neg_ctx_netname(
+    struct chimera_smb_request *request,
+    const uint8_t              *data,
+    uint16_t                    data_len)
+{
+    uint16_t copy_len = data_len;
+
+    if (copy_len > sizeof(request->negotiate.netname_in.utf16le)) {
+        copy_len = sizeof(request->negotiate.netname_in.utf16le);
+    }
+    request->negotiate.netname_in.length_bytes = copy_len;
+    if (copy_len > 0) {
+        memcpy(request->negotiate.netname_in.utf16le, data, copy_len);
+    }
+    return 0;
+} /* parse_neg_ctx_netname */
+
+static int
+parse_neg_ctx_transport(
+    struct chimera_smb_request *request,
+    const uint8_t              *data,
+    uint16_t                    data_len)
+{
+    if (data_len < 4) {
+        return -1;
+    }
+    request->negotiate.transport_in.flags = smb_wire_le32(data);
+    return 0;
+} /* parse_neg_ctx_transport */
+
+static int
+parse_neg_ctx_rdma_transform(
+    struct chimera_smb_request *request,
+    const uint8_t              *data,
+    uint16_t                    data_len)
+{
+    uint16_t count, i;
+
+    if (data_len < 8) {
+        return -1;
+    }
+    count = smb_wire_le16(data);
+    /* data + 2: 2-byte Reserved1; data + 4: 4-byte Reserved2 */
+    if (count > sizeof(request->negotiate.rdma_transform_in.transforms) / sizeof(uint16_t)) {
+        return -1;
+    }
+    if ((uint32_t) 8 + (uint32_t) count * 2u > data_len) {
+        return -1;
+    }
+
+    request->negotiate.rdma_transform_in.transform_count = count;
+    for (i = 0; i < count; i++) {
+        request->negotiate.rdma_transform_in.transforms[i] = smb_wire_le16(data + 8 + i * 2);
+    }
+    return 0;
+} /* parse_neg_ctx_rdma_transform */
+
+/* Map a negotiate-context type to its CHIMERA_SMB_NEGOTIATE_CTX_* bit.
+ * Returns 0 for unknown types. */
+static uint32_t
+negotiate_ctx_mask_bit(uint16_t type)
+{
+    switch (type) {
+        case SMB2_PREAUTH_INTEGRITY_CAPABILITIES:
+            return CHIMERA_SMB_NEGOTIATE_CTX_PREAUTH;
+        case SMB2_ENCRYPTION_CAPABILITIES:
+            return CHIMERA_SMB_NEGOTIATE_CTX_ENCRYPTION;
+        case SMB2_COMPRESSION_CAPABILITIES:
+            return CHIMERA_SMB_NEGOTIATE_CTX_COMPRESSION;
+        case SMB2_NETNAME_NEGOTIATE_CONTEXT_ID:
+            return CHIMERA_SMB_NEGOTIATE_CTX_NETNAME;
+        case SMB2_TRANSPORT_CAPABILITIES:
+            return CHIMERA_SMB_NEGOTIATE_CTX_TRANSPORT;
+        case SMB2_RDMA_TRANSFORM_CAPABILITIES:
+            return CHIMERA_SMB_NEGOTIATE_CTX_RDMA_TRANSFORM;
+        case SMB2_SIGNING_CAPABILITIES:
+            return CHIMERA_SMB_NEGOTIATE_CTX_SIGNING;
+        default:
+            return 0;
+    } /* switch */
+} /* negotiate_ctx_mask_bit */
+
+/*
+ * Negotiate-context dispatch policy (Phase 0; Phase 2 will tighten):
+ *
+ *   - Unknown context types: silently ignored (MS-SMB2 §2.2.3.1 reserved
+ *     value 0x0100 and any future unknown ID). This is mandated by spec.
+ *
+ *   - Known type with a malformed body: parser returns -1 internally, we
+ *     log at debug level and return 0 to the caller without setting the
+ *     mask bit. The connection is not aborted — selection downstream will
+ *     simply not pick that algorithm class. This is slightly more lenient
+ *     than the spec strictly requires but matches Samba behavior.
+ *
+ *   - Duplicate of a known type: rejected with STATUS_INVALID_PARAMETER
+ *     (return -1). MS-SMB2 §3.3.5.4 makes duplicates an error for several
+ *     context types; we apply the rule uniformly.
+ *
+ *   - Ordering: contexts may arrive in any order. Selection happens after
+ *     all contexts are parsed, so wire order does not influence outcomes.
+ *
+ *   - Dialect-dependent validity: NOT validated here. A client could send
+ *     EncryptionCapabilities while negotiating 2.0.2; we parse and store it
+ *     anyway. The selection step (and Phase 2) is responsible for refusing
+ *     to act on dialect-illegal contexts. The default dialect ceiling of
+ *     3.0 ensures this is moot today.
+ *
+ *   - Preauth-integrity is mandatory for 3.1.1 per spec. Phase 0 does not
+ *     enforce this because Phase 0 does not advertise 3.1.1 by default;
+ *     Phase 2 will fail the negotiate when 3.1.1 is selected without a
+ *     valid preauth context.
+ *
+ * Exposed for unit tests in tests/phase0_contexts_test.c.
+ * Returns 0 on success or "silently ignored"; -1 if the caller MUST reject
+ * the whole NEGOTIATE.
+ */
+SYMBOL_EXPORT int
+chimera_smb_parse_one_negotiate_context(
+    struct chimera_smb_request *request,
+    uint16_t                    type,
+    const uint8_t              *data,
+    uint16_t                    data_len)
+{
+    uint32_t bit = negotiate_ctx_mask_bit(type);
+    int      rc  = 0;
+
+    if (bit == 0) {
+        /* Unknown context type — per spec, silently ignore on receipt. */
+        return 0;
+    }
+
+    if (request->negotiate.ctx_present_mask & bit) {
+        chimera_smb_error("Duplicate negotiate context type=0x%04x", type);
+        request->status = SMB2_STATUS_INVALID_PARAMETER;
+        return -1;
+    }
+
+    switch (type) {
+        case SMB2_PREAUTH_INTEGRITY_CAPABILITIES:
+            rc = parse_neg_ctx_preauth(request, data, data_len);
+            break;
+        case SMB2_ENCRYPTION_CAPABILITIES:
+            rc = parse_neg_ctx_encryption(request, data, data_len);
+            break;
+        case SMB2_COMPRESSION_CAPABILITIES:
+            rc = parse_neg_ctx_compression(request, data, data_len);
+            break;
+        case SMB2_NETNAME_NEGOTIATE_CONTEXT_ID:
+            rc = parse_neg_ctx_netname(request, data, data_len);
+            break;
+        case SMB2_TRANSPORT_CAPABILITIES:
+            rc = parse_neg_ctx_transport(request, data, data_len);
+            break;
+        case SMB2_RDMA_TRANSFORM_CAPABILITIES:
+            rc = parse_neg_ctx_rdma_transform(request, data, data_len);
+            break;
+        case SMB2_SIGNING_CAPABILITIES:
+            rc = parse_neg_ctx_signing(request, data, data_len);
+            break;
+        default:
+            /* Unreachable: negotiate_ctx_mask_bit returned non-zero. */
+            break;
+    } /* switch */
+
+    if (rc != 0) {
+        chimera_smb_debug("Failed to parse negotiate context type=0x%04x len=%u (ignored)",
+                          type, data_len);
+        /* Body was malformed but the type is known; per spec, do not abort the
+         * connection — the absent bit in ctx_present_mask will steer selection
+         * away from this algorithm class. */
+        return 0;
+    }
+
+    request->negotiate.ctx_present_mask |= bit;
+    return 0;
+} /* chimera_smb_parse_one_negotiate_context */
+
+/* Choose algorithms from the client's offer, following client preference order
+ * (index 0 = most preferred — matches Samba and Windows Server behavior). For
+ * Phase 0 the only honest selection is "nothing" — encryption, GMAC signing,
+ * and preauth-bound key derivation are all Phase 2 work. We record presence so
+ * the future code paths have everything they need to flip the bits later. */
+static void
+chimera_smb_select_negotiated_algorithms(
+    struct chimera_smb_conn    *conn,
+    struct chimera_smb_request *request)
+{
+    conn->negotiated.ctx_present_mask = request->negotiate.ctx_present_mask;
+
+    /* Phase 0 selects nothing new. Phase 2 will replace these zeros with the
+     * highest-preference algorithm the client offered that we implement.
+     * Leave the salt zeroed for now — Phase 2 generates a real one. */
+    conn->negotiated.preauth_hash_alg      = 0;
+    conn->negotiated.cipher_id             = 0;
+    conn->negotiated.signing_alg           = 0;
+    conn->negotiated.compression_flags     = 0;
+    conn->negotiated.compression_alg_count = 0;
+    conn->negotiated.rdma_transform_count  = 0;
+    memset(conn->negotiated.preauth_salt,    0, sizeof(conn->negotiated.preauth_salt));
+    memset(conn->negotiated.compression_algs, 0, sizeof(conn->negotiated.compression_algs));
+    memset(conn->negotiated.rdma_transforms,  0, sizeof(conn->negotiated.rdma_transforms));
+} /* chimera_smb_select_negotiated_algorithms */
 
 int
 chimera_smb_parse_negotiate(
@@ -188,17 +672,53 @@ chimera_smb_parse_negotiate(
         evpl_iovec_cursor_get_uint16(request_cursor, &request->negotiate.dialects[i]);
     }
 
+    request->negotiate.ctx_present_mask = 0;
+
     if (request->negotiate.negotiate_context_count) {
+        /* Reject a context list that starts before the bytes we've already
+         * consumed — without this, the uint32 subtraction below wraps and
+         * evpl_iovec_cursor_skip burns through the rest of the cursor. */
+        if (request->negotiate.negotiate_context_offset <
+            (uint32_t) evpl_iovec_cursor_consumed(request_cursor)) {
+            chimera_smb_error("Negotiate context offset %u precedes consumed bytes %d",
+                              request->negotiate.negotiate_context_offset,
+                              evpl_iovec_cursor_consumed(request_cursor));
+            request->status = SMB2_STATUS_INVALID_PARAMETER;
+            return -1;
+        }
+
         evpl_iovec_cursor_skip(request_cursor,
                                request->negotiate.negotiate_context_offset -
                                evpl_iovec_cursor_consumed(request_cursor));
 
         for (i = 0; i < request->negotiate.negotiate_context_count; i++) {
+            uint16_t type, length;
+            uint8_t  data[512];
+
             evpl_iovec_cursor_align64(request_cursor);
-            evpl_iovec_cursor_get_uint16(request_cursor, &request->negotiate.negotiate_context[i].type);
-            evpl_iovec_cursor_get_uint16(request_cursor, &request->negotiate.negotiate_context[i].length);
-            evpl_iovec_cursor_skip(request_cursor, 4);
-            evpl_iovec_cursor_skip(request_cursor, request->negotiate.negotiate_context[i].length);
+            evpl_iovec_cursor_get_uint16(request_cursor, &type);
+            evpl_iovec_cursor_get_uint16(request_cursor, &length);
+            evpl_iovec_cursor_skip(request_cursor, 4);  /* Reserved */
+
+            if (length > sizeof(data)) {
+                chimera_smb_error("Negotiate context length %u exceeds parser cap %zu",
+                                  length, sizeof(data));
+                request->status = SMB2_STATUS_INVALID_PARAMETER;
+                return -1;
+            }
+
+            if (length > 0) {
+                if (evpl_iovec_cursor_get_blob(request_cursor, data, length) != 0) {
+                    chimera_smb_error("Negotiate context body truncated (type=0x%04x len=%u)",
+                                      type, length);
+                    request->status = SMB2_STATUS_INVALID_PARAMETER;
+                    return -1;
+                }
+            }
+
+            if (chimera_smb_parse_one_negotiate_context(request, type, data, length) < 0) {
+                return -1;
+            }
         }
     }
 

--- a/src/server/smb/smb_procs.h
+++ b/src/server/smb/smb_procs.h
@@ -17,6 +17,25 @@ void chimera_smb_negotiate_reply(
     struct evpl_iovec_cursor   *reply_cursor,
     struct chimera_smb_request *request);
 
+/* Phase 0 test hooks. Exposed so tests/phase0_contexts_test.c can drive the
+ * negotiate-context and CREATE-context dispatch paths directly without
+ * standing up a full SMB compound + connection. Not used outside tests. */
+int chimera_smb_parse_one_negotiate_context(
+    struct chimera_smb_request *request,
+    uint16_t                    type,
+    const uint8_t              *data,
+    uint16_t                    data_len);
+
+int chimera_smb_parse_create_contexts(
+    const uint8_t              *buf,
+    uint32_t                    buf_len,
+    struct chimera_smb_request *request);
+
+uint32_t chimera_smb_build_create_response_contexts(
+    struct chimera_smb_request *request,
+    uint8_t                    *ctx_buf,
+    uint32_t                    ctx_buf_size);
+
 int chimera_smb_parse_session_setup(
     struct evpl_iovec_cursor   *request_cursor,
     struct chimera_smb_request *request);

--- a/src/server/smb/smb_session.h
+++ b/src/server/smb/smb_session.h
@@ -23,6 +23,31 @@ struct chimera_smb_file_id {
 #define CHIMERA_SMB_OPEN_FILE_FLAG_DELETE_ON_CLOSE 0x00000002
 #define CHIMERA_SMB_OPEN_FILE_CLOSED               0x00000004
 
+/* Bits identifying which CREATE contexts a client supplied on the open. Mirrored
+ * from request->create.ctx_present_mask into the open file so later phases
+ * (lease break, durable reconnect) can tell which contracts the client expects. */
+#define CHIMERA_SMB_CREATE_CTX_SECD                (1u << 0)
+#define CHIMERA_SMB_CREATE_CTX_EXTA                (1u << 1)
+#define CHIMERA_SMB_CREATE_CTX_DHNQ                (1u << 2)
+#define CHIMERA_SMB_CREATE_CTX_DHNC                (1u << 3)
+#define CHIMERA_SMB_CREATE_CTX_DH2Q                (1u << 4)
+#define CHIMERA_SMB_CREATE_CTX_DH2C                (1u << 5)
+#define CHIMERA_SMB_CREATE_CTX_RQLS                (1u << 6)
+#define CHIMERA_SMB_CREATE_CTX_RQLS_V2             (1u << 7)
+#define CHIMERA_SMB_CREATE_CTX_MXAC                (1u << 8)
+#define CHIMERA_SMB_CREATE_CTX_TWRP                (1u << 9)
+#define CHIMERA_SMB_CREATE_CTX_QFID                (1u << 10)
+#define CHIMERA_SMB_CREATE_CTX_ALSI                (1u << 11)
+/* App-instance contexts (SMB2_CREATE_APP_INSTANCE_ID / *_VERSION) use 16-byte
+ * GUID names and so are not reachable from the 4-byte tag dispatch. Phase 3
+ * (durable / app-instance handle replacement) will add a GUID-name match path
+ * and re-introduce a CHIMERA_SMB_CREATE_CTX_APP bit at that point. */
+
+/* Bits for chimera_smb_open_file.durable_flags */
+#define CHIMERA_SMB_DURABLE_V1                     (1u << 0)
+#define CHIMERA_SMB_DURABLE_V2                     (1u << 1)
+#define CHIMERA_SMB_DURABLE_PERSISTENT             (1u << 2)
+
 enum chimera_smb_open_file_type {
     CHIMERA_SMB_OPEN_FILE_TYPE_FILE,
     CHIMERA_SMB_OPEN_FILE_TYPE_PIPE,
@@ -56,6 +81,17 @@ struct chimera_smb_open_file {
     uint64_t                         position;
     uint32_t                         parent_fh_len;
     uint32_t                         refcnt;
+    /* Phase-0 plumbing: fields populated by later phases. Zeroed on alloc. */
+    uint32_t                         ctx_present_mask;
+    uint8_t                          oplock_level;
+    uint8_t                          lease_state;
+    uint16_t                         lease_epoch;
+    uint32_t                         lease_flags;
+    uint32_t                         durable_flags;
+    uint64_t                         durable_timeout_ms;
+    uint8_t                          lease_key[16];
+    uint8_t                          parent_lease_key[16];
+    uint8_t                          create_guid[16];
     struct chimera_smb_open_file    *next;
     struct chimera_smb_notify_state *notify_state;
     uint8_t                          parent_fh[CHIMERA_VFS_FH_SIZE];

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -41,6 +41,14 @@ target_include_directories(smb_sharemode_test PRIVATE ${CMAKE_SOURCE_DIR}/src)
 add_test(NAME chimera/server/smb/sharemode_test
     COMMAND ${CMAKE_CURRENT_BINARY_DIR}/smb_sharemode_test)
 
+# Phase 0: negotiate-context and CREATE-context dispatch
+add_executable(phase0_contexts_test phase0_contexts_test.c)
+target_link_libraries(phase0_contexts_test chimera_server chimera_smb)
+target_include_directories(phase0_contexts_test PRIVATE ${CMAKE_SOURCE_DIR}/src)
+
+add_test(NAME chimera/server/smb/phase0_contexts_test
+    COMMAND ${CMAKE_CURRENT_BINARY_DIR}/phase0_contexts_test)
+
 # REST API user/share manipulation test
 add_executable(rest_user_manip_test rest_user_manip_test.c)
 target_link_libraries(rest_user_manip_test chimera_server chimera_metrics jansson)

--- a/src/server/smb/tests/phase0_contexts_test.c
+++ b/src/server/smb/tests/phase0_contexts_test.c
@@ -1,0 +1,884 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * Phase 0 Foundation: unit tests for NEGOTIATE/CREATE context dispatch.
+ *
+ * These tests drive the parse/emit helpers directly with synthetic wire bytes
+ * — no SMB connection, no daemon, no I/O. The wire-byte builders mirror the
+ * layouts in MS-SMB2 §2.2.3.1 and §2.2.13.2 so a regression in either parser
+ * is caught immediately.
+ *
+ * Coverage:
+ *   - NEGOTIATE contexts: parse one each of preauth, encryption, signing,
+ *     compression, netname, transport, rdma_transform.
+ *   - CREATE contexts: parse a Win11-style chain (MxAc + QFid + DH2Q),
+ *     RqLs v1 vs v2 distinction.
+ *   - Malformed CREATE chains: next < 16, next not 8-aligned, data overrun.
+ *   - MxAc response emit: ctx_present_mask bit set, build response, decode
+ *     wire bytes, assert structure and access mask.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#undef NDEBUG
+#include <assert.h>
+
+#include "server/smb/smb_internal.h"
+#include "server/smb/smb_procs.h"
+
+#define TEST_PASS(name) do { fprintf(stderr, "  PASS: %s\n", name); passed++; } while (0)
+#define TEST_FAIL(name) do { fprintf(stderr, "  FAIL: %s\n", name); failed++; } while (0)
+
+static int passed = 0;
+static int failed = 0;
+
+/* Write LE16/32/64 into a buffer at the given offset. */
+static void
+put_le16(
+    uint8_t *buf,
+    uint32_t off,
+    uint16_t v)
+{
+    buf[off]     = v & 0xff;
+    buf[off + 1] = (v >> 8) & 0xff;
+} /* put_le16 */
+
+static void
+put_le32(
+    uint8_t *buf,
+    uint32_t off,
+    uint32_t v)
+{
+    buf[off]     = v & 0xff;
+    buf[off + 1] = (v >> 8) & 0xff;
+    buf[off + 2] = (v >> 16) & 0xff;
+    buf[off + 3] = (v >> 24) & 0xff;
+} /* put_le32 */
+
+static void
+put_le64(
+    uint8_t *buf,
+    uint32_t off,
+    uint64_t v)
+{
+    put_le32(buf, off, (uint32_t) v);
+    put_le32(buf, off + 4, (uint32_t) (v >> 32));
+} /* put_le64 */
+
+/* ------------------------------------------------------------------ *
+*  NEGOTIATE context tests                                           *
+* ------------------------------------------------------------------ */
+
+static void
+test_negotiate_preauth(void)
+{
+    struct chimera_smb_request req;
+    uint8_t                    data[40];
+    int                        i;
+
+    memset(&req, 0, sizeof(req));
+
+    put_le16(data, 0, 1);                              /* HashAlgorithmCount */
+    put_le16(data, 2, 32);                             /* SaltLength */
+    put_le16(data, 4, SMB2_PREAUTH_HASH_SHA_512);      /* HashAlgorithms[0] */
+    for (i = 0; i < 32; i++) {
+        data[6 + i] = (uint8_t) (0xa0 + i);
+    }
+
+    chimera_smb_parse_one_negotiate_context(
+        &req, SMB2_PREAUTH_INTEGRITY_CAPABILITIES, data, 6 + 32);
+
+    if ((req.negotiate.ctx_present_mask & CHIMERA_SMB_NEGOTIATE_CTX_PREAUTH) &&
+        req.negotiate.preauth_in.hash_alg_count == 1 &&
+        req.negotiate.preauth_in.hash_algs[0] == SMB2_PREAUTH_HASH_SHA_512 &&
+        req.negotiate.preauth_in.salt_length == 32 &&
+        req.negotiate.preauth_in.salt[0]  == 0xa0 &&
+        req.negotiate.preauth_in.salt[31] == (uint8_t) 0xbf) {
+        TEST_PASS("preauth: SHA-512 + 32-byte salt");
+    } else {
+        TEST_FAIL("preauth: SHA-512 + 32-byte salt");
+    }
+} /* test_negotiate_preauth */
+
+static void
+test_negotiate_encryption(void)
+{
+    struct chimera_smb_request req;
+    uint8_t                    data[16];
+
+    memset(&req, 0, sizeof(req));
+    /* Win11 24H2 order: GCM-128, CCM-128, GCM-256, CCM-256 */
+    put_le16(data, 0, 4);                              /* CipherCount */
+    put_le16(data, 2, SMB2_ENCRYPTION_AES_128_GCM);
+    put_le16(data, 4, SMB2_ENCRYPTION_AES_128_CCM);
+    put_le16(data, 6, SMB2_ENCRYPTION_AES_256_GCM);
+    put_le16(data, 8, SMB2_ENCRYPTION_AES_256_CCM);
+
+    chimera_smb_parse_one_negotiate_context(
+        &req, SMB2_ENCRYPTION_CAPABILITIES, data, 10);
+
+    if ((req.negotiate.ctx_present_mask & CHIMERA_SMB_NEGOTIATE_CTX_ENCRYPTION) &&
+        req.negotiate.encryption_in.cipher_count == 4 &&
+        req.negotiate.encryption_in.ciphers[0] == SMB2_ENCRYPTION_AES_128_GCM &&
+        req.negotiate.encryption_in.ciphers[3] == SMB2_ENCRYPTION_AES_256_CCM) {
+        TEST_PASS("encryption: Win11 cipher order parsed");
+    } else {
+        TEST_FAIL("encryption: Win11 cipher order parsed");
+    }
+} /* test_negotiate_encryption */
+
+static void
+test_negotiate_signing(void)
+{
+    struct chimera_smb_request req;
+    uint8_t                    data[8];
+
+    memset(&req, 0, sizeof(req));
+    put_le16(data, 0, 3);                              /* SigningAlgorithmCount */
+    put_le16(data, 2, SMB2_SIGNING_AES_GMAC);
+    put_le16(data, 4, SMB2_SIGNING_AES_CMAC);
+    put_le16(data, 6, SMB2_SIGNING_HMAC_SHA256);
+
+    chimera_smb_parse_one_negotiate_context(
+        &req, SMB2_SIGNING_CAPABILITIES, data, 8);
+
+    if ((req.negotiate.ctx_present_mask & CHIMERA_SMB_NEGOTIATE_CTX_SIGNING) &&
+        req.negotiate.signing_in.alg_count == 3 &&
+        req.negotiate.signing_in.algs[0] == SMB2_SIGNING_AES_GMAC) {
+        TEST_PASS("signing: GMAC > CMAC > HMAC-SHA256");
+    } else {
+        TEST_FAIL("signing: GMAC > CMAC > HMAC-SHA256");
+    }
+} /* test_negotiate_signing */
+
+static void
+test_negotiate_compression(void)
+{
+    struct chimera_smb_request req;
+    uint8_t                    data[18];
+
+    memset(&req, 0, sizeof(req));
+    put_le16(data, 0, 5);                              /* CompressionAlgorithmCount */
+    put_le16(data, 2, 0);                              /* Padding */
+    put_le32(data, 4, SMB2_COMPRESSION_FLAG_CHAINED);
+    put_le16(data, 8,  0x0004);                        /* Pattern_V1 */
+    put_le16(data, 10, 0x0002);                        /* LZ77 */
+    put_le16(data, 12, 0x0003);                        /* LZ77+Huffman */
+    put_le16(data, 14, 0x0001);                        /* LZNT1 */
+    put_le16(data, 16, 0x0005);                        /* LZ4 */
+
+    chimera_smb_parse_one_negotiate_context(
+        &req, SMB2_COMPRESSION_CAPABILITIES, data, 18);
+
+    if ((req.negotiate.ctx_present_mask & CHIMERA_SMB_NEGOTIATE_CTX_COMPRESSION) &&
+        req.negotiate.compression_in.alg_count == 5 &&
+        req.negotiate.compression_in.flags == SMB2_COMPRESSION_FLAG_CHAINED &&
+        req.negotiate.compression_in.algs[4] == 0x0005) {
+        TEST_PASS("compression: chained, 5 algs incl. LZ4");
+    } else {
+        TEST_FAIL("compression: chained, 5 algs incl. LZ4");
+    }
+} /* test_negotiate_compression */
+
+static void
+test_negotiate_netname(void)
+{
+    struct chimera_smb_request req;
+    uint8_t                    data[64];
+    /* "jrh-ubuntu-debug" in UTF-16LE = 32 bytes */
+    static const char         *src = "jrh-ubuntu-debug";
+    size_t                     n   = strlen(src);
+    size_t                     i;
+
+    memset(&req, 0, sizeof(req));
+    memset(data, 0, sizeof(data));
+    for (i = 0; i < n; i++) {
+        data[i * 2]     = (uint8_t) src[i];
+        data[i * 2 + 1] = 0;
+    }
+
+    chimera_smb_parse_one_negotiate_context(
+        &req, SMB2_NETNAME_NEGOTIATE_CONTEXT_ID, data, (uint16_t) (n * 2));
+
+    if ((req.negotiate.ctx_present_mask & CHIMERA_SMB_NEGOTIATE_CTX_NETNAME) &&
+        req.negotiate.netname_in.length_bytes == n * 2 &&
+        req.negotiate.netname_in.utf16le[0] == 'j' &&
+        req.negotiate.netname_in.utf16le[1] == 0) {
+        TEST_PASS("netname: UTF-16LE hostname stored");
+    } else {
+        TEST_FAIL("netname: UTF-16LE hostname stored");
+    }
+} /* test_negotiate_netname */
+
+static void
+test_negotiate_rdma_transform(void)
+{
+    struct chimera_smb_request req;
+    uint8_t                    data[12];
+
+    memset(&req, 0, sizeof(req));
+    put_le16(data, 0, 2);                              /* TransformCount */
+    put_le16(data, 2, 0);                              /* Reserved1 */
+    put_le32(data, 4, 0);                              /* Reserved2 */
+    put_le16(data, 8,  0x0001);                        /* Encryption */
+    put_le16(data, 10, 0x0002);                        /* Signing */
+
+    chimera_smb_parse_one_negotiate_context(
+        &req, SMB2_RDMA_TRANSFORM_CAPABILITIES, data, 12);
+
+    if ((req.negotiate.ctx_present_mask & CHIMERA_SMB_NEGOTIATE_CTX_RDMA_TRANSFORM) &&
+        req.negotiate.rdma_transform_in.transform_count == 2 &&
+        req.negotiate.rdma_transform_in.transforms[0] == 0x0001 &&
+        req.negotiate.rdma_transform_in.transforms[1] == 0x0002) {
+        TEST_PASS("rdma_transform: 2 transforms parsed");
+    } else {
+        TEST_FAIL("rdma_transform: 2 transforms parsed");
+    }
+} /* test_negotiate_rdma_transform */
+
+static void
+test_negotiate_transport(void)
+{
+    struct chimera_smb_request req;
+    uint8_t                    data[4];
+
+    memset(&req, 0, sizeof(req));
+    put_le32(data, 0, 0x00000001);
+
+    chimera_smb_parse_one_negotiate_context(
+        &req, SMB2_TRANSPORT_CAPABILITIES, data, 4);
+
+    if ((req.negotiate.ctx_present_mask & CHIMERA_SMB_NEGOTIATE_CTX_TRANSPORT) &&
+        req.negotiate.transport_in.flags == 0x00000001) {
+        TEST_PASS("transport: flags parsed");
+    } else {
+        TEST_FAIL("transport: flags parsed");
+    }
+} /* test_negotiate_transport */
+
+static void
+test_negotiate_unknown_type_ignored(void)
+{
+    struct chimera_smb_request req;
+    uint8_t                    data[4] = { 0 };
+
+    memset(&req, 0, sizeof(req));
+    /* SMB2_CONTEXTTYPE_RESERVED = 0x0100, must be silently ignored on receipt */
+    chimera_smb_parse_one_negotiate_context(&req, 0x0100, data, 4);
+
+    if (req.negotiate.ctx_present_mask == 0) {
+        TEST_PASS("unknown type: silently ignored (no mask bit set)");
+    } else {
+        TEST_FAIL("unknown type: silently ignored (no mask bit set)");
+    }
+} /* test_negotiate_unknown_type_ignored */
+
+/* ------------------------------------------------------------------ *
+*  CREATE context tests                                              *
+* ------------------------------------------------------------------ */
+
+/* Build one CREATE context entry in the buffer at `pos`, return advance. */
+static uint32_t
+emit_create_ctx_entry(
+    uint8_t       *buf,
+    uint32_t       pos,
+    const char    *tag,
+    const uint8_t *data,
+    uint32_t       data_len,
+    int            is_last)
+{
+    /* Layout: header(16) + name(4) + 4 pad + data + pad to 8 */
+    uint32_t total   = 24 + data_len;
+    uint32_t advance = (total + 7u) & ~7u;
+    uint32_t next    = is_last ? 0 : advance;
+
+    put_le32(buf, pos + 0, next);
+    put_le16(buf, pos + 4, 16);   /* NameOffset */
+    put_le16(buf, pos + 6, 4);    /* NameLength */
+    put_le16(buf, pos + 8, 0);    /* Reserved */
+    put_le16(buf, pos + 10, 24);  /* DataOffset */
+    put_le32(buf, pos + 12, data_len);
+    memcpy(buf + pos + 16, tag, 4);
+    buf[pos + 20] = buf[pos + 21] = buf[pos + 22] = buf[pos + 23] = 0;
+    if (data_len) {
+        memcpy(buf + pos + 24, data, data_len);
+    }
+    if (advance > total) {
+        memset(buf + pos + total, 0, advance - total);
+    }
+    return advance;
+} /* emit_create_ctx_entry */
+
+static void
+test_create_win11_chain(void)
+{
+    /* Win11 24H2 sends DH2Q + MxAc + QFid on file create. */
+    struct chimera_smb_request req;
+    uint8_t                    buf[512];
+    uint8_t                    dh2q_body[32];
+    uint32_t                   pos = 0;
+    int                        i;
+
+    memset(&req, 0, sizeof(req));
+    memset(buf, 0, sizeof(buf));
+
+    /* DH2Q body: Timeout(4) | Flags(4) | Reserved(8) | CreateGuid(16) */
+    put_le32(dh2q_body, 0, 30000);                     /* 30s timeout */
+    put_le32(dh2q_body, 4, 0);                         /* flags */
+    for (i = 0; i < 16; i++) {
+        dh2q_body[16 + i] = (uint8_t) (0x10 + i);
+    }
+
+    pos += emit_create_ctx_entry(buf, pos, "DH2Q", dh2q_body, 32, 0);
+    pos += emit_create_ctx_entry(buf, pos, "MxAc", NULL, 0, 0);
+    pos += emit_create_ctx_entry(buf, pos, "QFid", NULL, 0, 1);
+
+    if (chimera_smb_parse_create_contexts(buf, pos, &req) != 0) {
+        TEST_FAIL("Win11 chain: parser returned error");
+        return;
+    }
+
+    if ((req.create.ctx_present_mask & CHIMERA_SMB_CREATE_CTX_DH2Q) &&
+        (req.create.ctx_present_mask & CHIMERA_SMB_CREATE_CTX_MXAC) &&
+        (req.create.ctx_present_mask & CHIMERA_SMB_CREATE_CTX_QFID) &&
+        req.create.dh2q.timeout_ms == 30000 &&
+        req.create.dh2q.create_guid[0] == 0x10 &&
+        req.create.dh2q.create_guid[15] == 0x1f) {
+        TEST_PASS("Win11 chain: DH2Q + MxAc + QFid parsed");
+    } else {
+        TEST_FAIL("Win11 chain: DH2Q + MxAc + QFid parsed");
+    }
+} /* test_create_win11_chain */
+
+static void
+test_create_rqls_v1_vs_v2(void)
+{
+    struct chimera_smb_request req;
+    uint8_t                    buf[128];
+    uint8_t                    rqls_v1[32], rqls_v2[52];
+    uint32_t                   pos = 0;
+    int                        i;
+
+    memset(&req, 0, sizeof(req));
+    memset(buf, 0, sizeof(buf));
+    memset(rqls_v1, 0, sizeof(rqls_v1));
+    memset(rqls_v2, 0, sizeof(rqls_v2));
+
+    /* v1: 16-byte key + state(4) + flags(4) + duration(8 reserved) */
+    for (i = 0; i < 16; i++) {
+        rqls_v1[i] = (uint8_t) (0x80 + i);
+    }
+    put_le32(rqls_v1, 16, 0x07);  /* RWH */
+    put_le32(rqls_v1, 20, 0);
+    pos += emit_create_ctx_entry(buf, pos, "RqLs", rqls_v1, 32, 1);
+
+    if (chimera_smb_parse_create_contexts(buf, pos, &req) != 0) {
+        TEST_FAIL("RqLs v1 parse");
+        return;
+    }
+    if ((req.create.ctx_present_mask & CHIMERA_SMB_CREATE_CTX_RQLS) &&
+        !(req.create.ctx_present_mask & CHIMERA_SMB_CREATE_CTX_RQLS_V2) &&
+        req.create.rqls.is_v2 == 0 &&
+        req.create.rqls.key[0]  == 0x80 &&
+        req.create.rqls.key[15] == 0x8f &&
+        req.create.rqls.state == 0x07) {
+        TEST_PASS("RqLs v1 (32-byte body) parsed");
+    } else {
+        TEST_FAIL("RqLs v1 (32-byte body) parsed");
+    }
+
+    /* Second request: v2 — sets BOTH RQLS and RQLS_V2 bits */
+    memset(&req, 0, sizeof(req));
+    memset(buf, 0, sizeof(buf));
+    for (i = 0; i < 16; i++) {
+        rqls_v2[i] = (uint8_t) (0xc0 + i);
+    }
+    put_le32(rqls_v2, 16, 0x07);
+    put_le32(rqls_v2, 20, 0x02);  /* parent_key valid */
+    for (i = 0; i < 16; i++) {
+        rqls_v2[32 + i] = (uint8_t) (0xd0 + i);
+    }
+    put_le16(rqls_v2, 48, 7);     /* Epoch */
+    pos = emit_create_ctx_entry(buf, 0, "RqLs", rqls_v2, 52, 1);
+
+    if (chimera_smb_parse_create_contexts(buf, pos, &req) != 0) {
+        TEST_FAIL("RqLs v2 parse");
+        return;
+    }
+    if ((req.create.ctx_present_mask & CHIMERA_SMB_CREATE_CTX_RQLS_V2) &&
+        req.create.rqls.is_v2 == 1 &&
+        req.create.rqls.parent_key[0] == 0xd0 &&
+        req.create.rqls.epoch == 7) {
+        TEST_PASS("RqLs v2 (52-byte body) parsed");
+    } else {
+        TEST_FAIL("RqLs v2 (52-byte body) parsed");
+    }
+} /* test_create_rqls_v1_vs_v2 */
+
+static void
+test_create_malformed_short_next(void)
+{
+    struct chimera_smb_request req;
+    uint8_t                    buf[64] = { 0 };
+
+    memset(&req, 0, sizeof(req));
+    /* Header alone is 16 bytes; setting Next=8 is invalid (< 16) */
+    put_le32(buf, 0, 8);   /* Next = 8 — too small */
+    put_le16(buf, 4, 16);
+    put_le16(buf, 6, 4);
+    put_le16(buf, 10, 0);
+    put_le32(buf, 12, 0);
+    memcpy(buf + 16, "MxAc", 4);
+
+    if (chimera_smb_parse_create_contexts(buf, 64, &req) < 0 &&
+        req.status == SMB2_STATUS_INVALID_PARAMETER) {
+        TEST_PASS("malformed CREATE: Next < 16 rejected");
+    } else {
+        TEST_FAIL("malformed CREATE: Next < 16 rejected");
+    }
+} /* test_create_malformed_short_next */
+
+static void
+test_create_malformed_unaligned_next(void)
+{
+    struct chimera_smb_request req;
+    uint8_t                    buf[64] = { 0 };
+
+    memset(&req, 0, sizeof(req));
+    put_le32(buf, 0, 20);  /* Next = 20 — not 8-aligned */
+    put_le16(buf, 4, 16);
+    put_le16(buf, 6, 4);
+    put_le16(buf, 10, 0);
+    put_le32(buf, 12, 0);
+    memcpy(buf + 16, "MxAc", 4);
+
+    if (chimera_smb_parse_create_contexts(buf, 64, &req) < 0 &&
+        req.status == SMB2_STATUS_INVALID_PARAMETER) {
+        TEST_PASS("malformed CREATE: Next not 8-aligned rejected");
+    } else {
+        TEST_FAIL("malformed CREATE: Next not 8-aligned rejected");
+    }
+} /* test_create_malformed_unaligned_next */
+
+static void
+test_create_malformed_data_overrun(void)
+{
+    struct chimera_smb_request req;
+    uint8_t                    buf[32] = { 0 };
+
+    memset(&req, 0, sizeof(req));
+    put_le32(buf, 0, 0);    /* Last */
+    put_le16(buf, 4, 16);
+    put_le16(buf, 6, 4);
+    put_le16(buf, 10, 24);
+    put_le32(buf, 12, 200); /* DataLength 200 in a 32-byte buffer */
+    memcpy(buf + 16, "DH2Q", 4);
+
+    if (chimera_smb_parse_create_contexts(buf, 32, &req) < 0 &&
+        req.status == SMB2_STATUS_INVALID_PARAMETER) {
+        TEST_PASS("malformed CREATE: data overrun rejected");
+    } else {
+        TEST_FAIL("malformed CREATE: data overrun rejected");
+    }
+} /* test_create_malformed_data_overrun */
+
+static void
+test_create_response_mxac_on_maximum_allowed(void)
+{
+    struct chimera_smb_request   req;
+    struct chimera_smb_open_file open_file;
+    uint8_t                      ctx_buf[256];
+    uint32_t                     ctx_len;
+
+    memset(&req,       0, sizeof(req));
+    memset(&open_file, 0, sizeof(open_file));
+
+    req.create.ctx_present_mask = CHIMERA_SMB_CREATE_CTX_MXAC;
+    /* Client opened with MAXIMUM_ALLOWED — this is the only case where Phase 0
+     * emits the MxAc reply (per spec, MaximalAccess is the user's effective
+     * rights; for specific-access opens we don't have DACL evaluation yet). */
+    req.create.desired_access = SMB2_MAXIMUM_ALLOWED;
+    open_file.desired_access  = 0x001f01ff;            /* FILE_ALL_ACCESS */
+    req.create.r_open_file    = &open_file;
+
+    ctx_len = chimera_smb_build_create_response_contexts(&req, ctx_buf, sizeof(ctx_buf));
+
+    /* Expected wire: 24 + 8 = 32 bytes, single context.
+     * Header @ 0..15: Next=0, NameOffset=16, NameLength=4, Reserved=0, DataOffset=24, DataLength=8.
+     * Name "MxAc" @ 16..19.
+     * Data @ 24..31: QueryStatus=0, MaximalAccess=0x001f01ff. */
+    if (ctx_len == 32 &&
+        ctx_buf[0]  == 0 && ctx_buf[1]  == 0 && ctx_buf[2] == 0 && ctx_buf[3] == 0 &&
+        ctx_buf[4]  == 16 && ctx_buf[6]  == 4 &&
+        ctx_buf[10] == 24 && ctx_buf[12] == 8 &&
+        ctx_buf[16] == 'M' && ctx_buf[17] == 'x' && ctx_buf[18] == 'A' && ctx_buf[19] == 'c' &&
+        ctx_buf[24] == 0 && ctx_buf[25] == 0 && ctx_buf[26] == 0 && ctx_buf[27] == 0 &&
+        ctx_buf[28] == 0xff && ctx_buf[29] == 0x01 && ctx_buf[30] == 0x1f && ctx_buf[31] == 0x00) {
+        TEST_PASS("MxAc response on MAXIMUM_ALLOWED: 32-byte chain entry");
+    } else {
+        TEST_FAIL("MxAc response on MAXIMUM_ALLOWED: 32-byte chain entry");
+        fprintf(stderr, "    got ctx_len=%u, bytes:", ctx_len);
+        for (uint32_t i = 0; i < ctx_len && i < 40; i++) {
+            fprintf(stderr, " %02x", ctx_buf[i]);
+        }
+        fprintf(stderr, "\n");
+    }
+} /* test_create_response_mxac_on_maximum_allowed */
+
+static void
+test_create_response_mxac_suppressed_on_specific_access(void)
+{
+    struct chimera_smb_request   req;
+    struct chimera_smb_open_file open_file;
+    uint8_t                      ctx_buf[256];
+    uint32_t                     ctx_len;
+
+    memset(&req,       0, sizeof(req));
+    memset(&open_file, 0, sizeof(open_file));
+
+    /* Client sent MxAc but opened with specific bits — we suppress the reply
+     * because we don't have effective-rights evaluation yet. */
+    req.create.ctx_present_mask = CHIMERA_SMB_CREATE_CTX_MXAC;
+    req.create.desired_access   = 0x00000080;          /* FILE_READ_ATTRIBUTES */
+    open_file.desired_access    = 0x00000080;
+    req.create.r_open_file      = &open_file;
+
+    ctx_len = chimera_smb_build_create_response_contexts(&req, ctx_buf, sizeof(ctx_buf));
+
+    if (ctx_len == 0) {
+        TEST_PASS("MxAc suppressed for specific-access open (no DACL eval yet)");
+    } else {
+        TEST_FAIL("MxAc suppressed for specific-access open (no DACL eval yet)");
+    }
+} /* test_create_response_mxac_suppressed_on_specific_access */
+
+static void
+test_create_response_empty_when_no_mxac_bit(void)
+{
+    struct chimera_smb_request   req;
+    struct chimera_smb_open_file open_file;
+    uint8_t                      ctx_buf[256];
+    uint32_t                     ctx_len;
+
+    memset(&req,       0, sizeof(req));
+    memset(&open_file, 0, sizeof(open_file));
+
+    /* Client did not send MxAc — we must emit nothing for it. */
+    req.create.ctx_present_mask = CHIMERA_SMB_CREATE_CTX_QFID;
+    req.create.desired_access   = SMB2_MAXIMUM_ALLOWED;
+    req.create.r_open_file      = &open_file;
+
+    ctx_len = chimera_smb_build_create_response_contexts(&req, ctx_buf, sizeof(ctx_buf));
+
+    if (ctx_len == 0) {
+        TEST_PASS("CREATE response: empty when client didn't ask for MxAc");
+    } else {
+        TEST_FAIL("CREATE response: empty when client didn't ask for MxAc");
+    }
+} /* test_create_response_empty_when_no_mxac_bit */
+
+/* ------------------------------------------------------------------ *
+*  Per-tag CREATE-context parser tests (DHnC, DH2C, AlSi, TWrp, SecD) *
+* ------------------------------------------------------------------ */
+
+static void
+test_create_ctx_dhnc(void)
+{
+    struct chimera_smb_request req;
+    uint8_t                    buf[64];
+    uint8_t                    body[32];
+    uint32_t                   pos;
+    int                        i;
+
+    memset(&req, 0, sizeof(req));
+    memset(buf, 0, sizeof(buf));
+    memset(body, 0, sizeof(body));
+
+    /* DHnC body: FileId(16) + 16 reserved bytes */
+    put_le64(body, 0,  0x0123456789abcdefULL);  /* persistent */
+    put_le64(body, 8,  0xfedcba9876543210ULL);  /* volatile */
+    for (i = 16; i < 32; i++) {
+        body[i] = 0;
+    }
+
+    pos = emit_create_ctx_entry(buf, 0, "DHnC", body, 32, 1);
+
+    if (chimera_smb_parse_create_contexts(buf, pos, &req) != 0) {
+        TEST_FAIL("DHnC parse");
+        return;
+    }
+    if ((req.create.ctx_present_mask & CHIMERA_SMB_CREATE_CTX_DHNC) &&
+        req.create.dhnc.persistent == 0x0123456789abcdefULL &&
+        req.create.dhnc.volatile_id == 0xfedcba9876543210ULL) {
+        TEST_PASS("DHnC: FileId parsed");
+    } else {
+        TEST_FAIL("DHnC: FileId parsed");
+    }
+} /* test_create_ctx_dhnc */
+
+static void
+test_create_ctx_dh2c(void)
+{
+    struct chimera_smb_request req;
+    uint8_t                    buf[64];
+    uint8_t                    body[36];
+    uint32_t                   pos;
+    int                        i;
+
+    memset(&req, 0, sizeof(req));
+    memset(buf, 0, sizeof(buf));
+    memset(body, 0, sizeof(body));
+
+    /* DH2C body: FileId(16) + CreateGuid(16) + Flags(4) */
+    put_le64(body, 0, 0x1111111111111111ULL);
+    put_le64(body, 8, 0x2222222222222222ULL);
+    for (i = 0; i < 16; i++) {
+        body[16 + i] = (uint8_t) (0x40 + i);
+    }
+    put_le32(body, 32, 0x00000002);            /* SMB2_DHANDLE_FLAG_PERSISTENT */
+
+    pos = emit_create_ctx_entry(buf, 0, "DH2C", body, 36, 1);
+
+    if (chimera_smb_parse_create_contexts(buf, pos, &req) != 0) {
+        TEST_FAIL("DH2C parse");
+        return;
+    }
+    if ((req.create.ctx_present_mask & CHIMERA_SMB_CREATE_CTX_DH2C) &&
+        req.create.dh2c.persistent == 0x1111111111111111ULL &&
+        req.create.dh2c.volatile_id == 0x2222222222222222ULL &&
+        req.create.dh2c.create_guid[0] == 0x40 &&
+        req.create.dh2c.create_guid[15] == 0x4f &&
+        req.create.dh2c.flags == 0x00000002) {
+        TEST_PASS("DH2C: FileId + CreateGuid + Flags parsed");
+    } else {
+        TEST_FAIL("DH2C: FileId + CreateGuid + Flags parsed");
+    }
+} /* test_create_ctx_dh2c */
+
+static void
+test_create_ctx_alsi(void)
+{
+    struct chimera_smb_request req;
+    uint8_t                    buf[64];
+    uint8_t                    body[8];
+    uint32_t                   pos;
+
+    memset(&req, 0, sizeof(req));
+    memset(buf, 0, sizeof(buf));
+
+    put_le64(body, 0, 0x12345678ULL);          /* allocation size */
+    pos = emit_create_ctx_entry(buf, 0, "AlSi", body, 8, 1);
+
+    if (chimera_smb_parse_create_contexts(buf, pos, &req) != 0) {
+        TEST_FAIL("AlSi parse");
+        return;
+    }
+    if ((req.create.ctx_present_mask & CHIMERA_SMB_CREATE_CTX_ALSI) &&
+        req.create.alsi_alloc_size == 0x12345678ULL) {
+        TEST_PASS("AlSi: 64-bit allocation size parsed");
+    } else {
+        TEST_FAIL("AlSi: 64-bit allocation size parsed");
+    }
+} /* test_create_ctx_alsi */
+
+static void
+test_create_ctx_twrp(void)
+{
+    struct chimera_smb_request req;
+    uint8_t                    buf[64];
+    uint8_t                    body[8];
+    uint32_t                   pos;
+
+    memset(&req, 0, sizeof(req));
+    memset(buf, 0, sizeof(buf));
+
+    /* TWrp timestamp is FILETIME (100ns ticks since 1601). Use an arbitrary value. */
+    put_le64(body, 0, 132514560000000000ULL);  /* 2020-09-22 UTC */
+    pos = emit_create_ctx_entry(buf, 0, "TWrp", body, 8, 1);
+
+    if (chimera_smb_parse_create_contexts(buf, pos, &req) != 0) {
+        TEST_FAIL("TWrp parse");
+        return;
+    }
+    if ((req.create.ctx_present_mask & CHIMERA_SMB_CREATE_CTX_TWRP) &&
+        req.create.twrp_timestamp == 132514560000000000ULL) {
+        TEST_PASS("TWrp: timewarp timestamp parsed");
+    } else {
+        TEST_FAIL("TWrp: timewarp timestamp parsed");
+    }
+} /* test_create_ctx_twrp */
+
+/* Minimal valid SecD body: 20-byte SD header with owner-SID offset, followed by
+ * a single S-1-5-88-1-<uid> SID. Exercises the new dispatch table's path to
+ * chimera_smb_parse_sd_to_attrs (the one production behavior already in place
+ * before Phase 0). */
+static void
+test_create_ctx_secd(void)
+{
+    struct chimera_smb_request req;
+    uint8_t                    buf[128];
+    uint8_t                    sd[40];
+    uint32_t                   pos;
+
+    memset(&req, 0, sizeof(req));
+    memset(buf, 0, sizeof(buf));
+    memset(sd, 0, sizeof(sd));
+
+    /* SD header (20 bytes): owner_offset @ bytes 4-7, group @ 8-11, DACL @ 16-19.
+     * Place a single owner SID immediately after the header at offset 20. */
+    put_le32(sd, 4, 20);          /* owner_offset = 20 */
+
+    /* Owner SID at offset 20: S-1-5-88-1-5000 */
+    sd[20] = 1;                   /* revision */
+    sd[21] = 3;                   /* sub_authority_count */
+    sd[27] = 5;                   /* authority = NT */
+    sd[28] = 88;                  /* sub-authority[0] = 88 */
+    put_le32(sd, 32, 1);          /* kind = 1 (UID) */
+    put_le32(sd, 36, 5000);       /* value = 5000 */
+
+    pos = emit_create_ctx_entry(buf, 0, "SecD", sd, 40, 1);
+
+    if (chimera_smb_parse_create_contexts(buf, pos, &req) != 0) {
+        TEST_FAIL("SecD parse");
+        return;
+    }
+    if ((req.create.ctx_present_mask & CHIMERA_SMB_CREATE_CTX_SECD) &&
+        (req.create.set_attr.va_set_mask & CHIMERA_VFS_ATTR_UID) &&
+        req.create.set_attr.va_uid == 5000) {
+        TEST_PASS("SecD: dispatch routes to SD parser, UID 5000 extracted");
+    } else {
+        TEST_FAIL("SecD: dispatch routes to SD parser, UID 5000 extracted");
+        fprintf(stderr, "    mask=0x%x va_set_mask=0x%llx va_uid=%llu\n",
+                req.create.ctx_present_mask,
+                (unsigned long long) req.create.set_attr.va_set_mask,
+                (unsigned long long) req.create.set_attr.va_uid);
+    }
+} /* test_create_ctx_secd */
+
+/* ------------------------------------------------------------------ *
+*  Hardening: malformed inputs that should be tolerated, not crashes  *
+* ------------------------------------------------------------------ */
+
+static void
+test_create_ctx_name_off_zero_silently_skipped(void)
+{
+    /* A context with NameOffset = 0 makes the "name" overlap the header. The
+     * 4-byte dispatch reads the first 4 bytes of the header as the tag, which
+     * won't match anything in our table. The parser must accept this and
+     * advance to the next entry (or end) without crashing. */
+    struct chimera_smb_request req;
+    uint8_t                    buf[64] = { 0 };
+
+    memset(&req, 0, sizeof(req));
+    put_le32(buf, 0, 0);     /* Next = 0 (last) */
+    put_le16(buf, 4, 0);     /* NameOffset = 0 — points at the header */
+    put_le16(buf, 6, 4);     /* NameLength = 4 */
+    put_le16(buf, 10, 0);    /* DataOffset */
+    put_le32(buf, 12, 0);    /* DataLength = 0 */
+
+    if (chimera_smb_parse_create_contexts(buf, 64, &req) == 0 &&
+        req.create.ctx_present_mask == 0) {
+        TEST_PASS("CREATE: name_off=0 entry silently skipped (no crash)");
+    } else {
+        TEST_FAIL("CREATE: name_off=0 entry silently skipped (no crash)");
+    }
+} /* test_create_ctx_name_off_zero_silently_skipped */
+
+static void
+test_negotiate_context_oversized_rejected(void)
+{
+    /* Negotiate-context length cap is 512 bytes per the parser. A length
+     * field declaring >512 should be rejected before we even try to copy.
+     * We test the per-context parser directly with a synthetic too-long body. */
+    struct chimera_smb_request req;
+    uint8_t                    big_data[600] = { 0 };
+
+    memset(&req, 0, sizeof(req));
+    /* parse_one_negotiate_context's per-type parsers don't cap on data_len —
+     * the cap is enforced in chimera_smb_parse_negotiate's loop. Here we just
+     * confirm that a known type with malformed-but-bounded body returns 0
+     * (silently ignored — bit not set) and doesn't crash. */
+    if (chimera_smb_parse_one_negotiate_context(&req, SMB2_PREAUTH_INTEGRITY_CAPABILITIES,
+                                                big_data, 2) == 0 &&
+        (req.negotiate.ctx_present_mask & CHIMERA_SMB_NEGOTIATE_CTX_PREAUTH) == 0) {
+        TEST_PASS("preauth: too-short body (< 4) is ignored, no bit set");
+    } else {
+        TEST_FAIL("preauth: too-short body (< 4) is ignored, no bit set");
+    }
+} /* test_negotiate_context_oversized_rejected */
+
+static void
+test_negotiate_duplicate_context_rejected(void)
+{
+    /* A duplicate context type must cause the dispatcher to return -1 and
+     * set request->status = STATUS_INVALID_PARAMETER. */
+    struct chimera_smb_request req;
+    uint8_t                    data[8];
+
+    memset(&req, 0, sizeof(req));
+    put_le16(data, 0, 1);  /* CipherCount = 1 */
+    put_le16(data, 2, SMB2_ENCRYPTION_AES_128_GCM);
+
+    if (chimera_smb_parse_one_negotiate_context(
+            &req, SMB2_ENCRYPTION_CAPABILITIES, data, 4) != 0) {
+        TEST_FAIL("duplicate negotiate context: first parse should succeed");
+        return;
+    }
+    if (chimera_smb_parse_one_negotiate_context(
+            &req, SMB2_ENCRYPTION_CAPABILITIES, data, 4) >= 0) {
+        TEST_FAIL("duplicate negotiate context: second parse should fail");
+        return;
+    }
+    if (req.status == SMB2_STATUS_INVALID_PARAMETER) {
+        TEST_PASS("duplicate negotiate context type rejected with STATUS_INVALID_PARAMETER");
+    } else {
+        TEST_FAIL("duplicate negotiate context type rejected with STATUS_INVALID_PARAMETER");
+    }
+} /* test_negotiate_duplicate_context_rejected */
+
+int
+main(
+    int   argc,
+    char *argv[])
+{
+    (void) argc;
+    (void) argv;
+
+    chimera_log_init();
+
+    fprintf(stderr, "=== Phase 0: NEGOTIATE context parse ===\n");
+    test_negotiate_preauth();
+    test_negotiate_encryption();
+    test_negotiate_signing();
+    test_negotiate_compression();
+    test_negotiate_netname();
+    test_negotiate_rdma_transform();
+    test_negotiate_transport();
+    test_negotiate_unknown_type_ignored();
+    test_negotiate_context_oversized_rejected();
+    test_negotiate_duplicate_context_rejected();
+
+    fprintf(stderr, "=== Phase 0: CREATE context parse ===\n");
+    test_create_win11_chain();
+    test_create_rqls_v1_vs_v2();
+    test_create_ctx_dhnc();
+    test_create_ctx_dh2c();
+    test_create_ctx_alsi();
+    test_create_ctx_twrp();
+    test_create_ctx_secd();
+    test_create_malformed_short_next();
+    test_create_malformed_unaligned_next();
+    test_create_malformed_data_overrun();
+    test_create_ctx_name_off_zero_silently_skipped();
+
+    fprintf(stderr, "=== Phase 0: CREATE context emit ===\n");
+    test_create_response_mxac_on_maximum_allowed();
+    test_create_response_mxac_suppressed_on_specific_access();
+    test_create_response_empty_when_no_mxac_bit();
+
+    fprintf(stderr, "\nTotal: %d passed, %d failed\n", passed, failed);
+    return failed == 0 ? 0 : 1;
+} /* main */


### PR DESCRIPTION
Background: the default dialect list at server.c:103-105 caps at SMB 3.0, so today's hard-coded NegotiateContextCount=0 reply is spec-correct only by accident. CREATE-context parsing short-circuited on SecD and silently dropped every other context.

Workstream A — NEGOTIATE contexts (smb_proc_negotiate.c)
  - Replaced opaque negotiate_context[] with typed parse outputs and a ctx_present_mask, plus per-type parsers for all seven types in MS-SMB2 §2.2.3.1 (Preauth, Encryption, Compression, Netname, Transport, RdmaTransform, Signing) with full bounds validation.
  - chimera_smb_select_negotiated_algorithms picks from the client's offer in preference order; Phase 0 selects nothing, Phase 2/4/5 will populate conn->negotiated.*.
  - 8-byte-aligned reply-emit infrastructure with patched offset/count. Emitter table is intentionally empty in Phase 0 with a DO-NOT-flip- the-dialect-ceiling warning naming the preauth/KDF mismatch that would otherwise break the first signed message.
  - Duplicate-type rejection per MS-SMB2 §3.3.5.4. Guarded a pre-existing uint32 underflow in the offset-skip arithmetic and asserted non-NULL conn at the reply path.

Workstream B — CREATE contexts (smb_proc_create.c)
  - Refactored the SecD-only context loop into a static dispatch table covering all 11 4-byte tags (SecD/ExtA/DHnQ/DHnC/DH2Q/DH2C/AlSi/MxAc/ TWrp/QFid/RqLs). SecD behavior preserved bit-for-bit. RqLs v1 vs v2 differentiated by data_len.
  - Iterator rejects malformed chains with INVALID_PARAMETER (Next < 16, not 8-aligned, name/data out of bounds, mid-header truncation).
  - Response-emit infrastructure mirrors the request side, with a hard abort on per-context buffer overflow — silent truncation would surface as cryptic interop failures once Phase 2/3 adds emitters.
  - MxAc response is the one semantic Phase-0 deliverable: 8-byte body, STATUS_SUCCESS, gated on MAXIMUM_ALLOWED. We don't emit for specific- access opens because returning the granted mask as "maximal" is misleading without DACL evaluation (Phase 1 will lift the gate).

Workstream C — per-open state (smb_session.h, smb_internal.h)
  - Widened chimera_smb_open_file with oplock/lease/durable/ctx_mask fields, all zero-init, all unused in Phase 0.
  - Documented the open-file ownership/lifetime model on chimera_smb_open_file_alloc: thread-local free list, tree-owned, connection-bounded, no reconnect survival. Includes a Phase-3 reviewer's checklist for when persistent handles land.