### PR TITLE
refcount nfs4_session to fix UAF on TCP disconnect

### DIFF
--- a/src/server/nfs/nfs.c
+++ b/src/server/nfs/nfs.c
@@ -304,13 +304,12 @@ nfs_server_destroy(void *data)
     chimera_vfs_thread_destroy(vfs_thread);
     evpl_destroy(evpl);
 
-    /* Close out all the nfs4 session state */
-    nfs4_client_table_free(&shared->nfs4_shared_clients);
-
-    if (shared->op_histogram) {
-        prometheus_histogram_destroy(shared->metrics, shared->op_histogram);
-    }
-
+    /* evpl_destroy(evpl) above already drained the conns and fired
+     * NOTIFY_DISCONNECTED for each one, which dropped every conn's
+     * nfs4_session ref via nfs4_session_unbind_conn.  Free the rpc2
+     * servers and then drop the hash table's refs -- with no conn refs
+     * outstanding, refcount reaches zero and the sessions are freed in
+     * nfs4_client_table_free. */
     evpl_rpc2_server_destroy(shared->mount_server);
     evpl_rpc2_server_destroy(shared->nfs_server);
     evpl_rpc2_server_destroy(shared->nlm_server);
@@ -320,6 +319,13 @@ nfs_server_destroy(void *data)
         free(shared->portmap_v2.rpc2.metrics);
         free(shared->portmap_v3.rpc2.metrics);
         free(shared->portmap_v4.rpc2.metrics);
+    }
+
+    /* Close out all the nfs4 session state */
+    nfs4_client_table_free(&shared->nfs4_shared_clients);
+
+    if (shared->op_histogram) {
+        prometheus_histogram_destroy(shared->metrics, shared->op_histogram);
     }
     free(shared->mount_v3.rpc2.metrics);
     free(shared->nfs_v3.rpc2.metrics);
@@ -349,6 +355,8 @@ chimera_nfs_server_notify(
 {
     struct chimera_server_nfs_thread *thread = private_data;
     struct chimera_server_nfs_shared *shared = thread->shared;
+    void                             *priv;
+    uint32_t                          magic;
     struct nlm_client                *nlm_cli;
     struct chimera_vfs_cred           anon_cred;
     char                              local_addr[80], remote_addr[80];
@@ -364,10 +372,20 @@ chimera_nfs_server_notify(
             evpl_rpc2_conn_get_remote_address(conn, remote_addr, sizeof(remote_addr));
             chimera_nfs_debug("Client disconnected from %s to %s", remote_addr, local_addr);
 
-            nlm_cli = evpl_rpc2_conn_get_private_data(conn);
-            if (nlm_cli && nlm_cli->magic == NLM_CLIENT_MAGIC) {
+            priv = evpl_rpc2_conn_get_private_data(conn);
+            if (!priv) {
+                break;
+            }
+
+            /* The private_data slot is multiplexed between nlm_client and
+             * nfs4_session.  Both layouts begin with a uint32_t magic at
+             * offset 0; read it with memcpy to avoid strict-aliasing UB. */
+            memcpy(&magic, priv, sizeof(magic));
+
+            if (magic == NLM_CLIENT_MAGIC) {
                 bool release_locks = false;
 
+                nlm_cli = priv;
                 chimera_vfs_cred_init_anonymous(&anon_cred,
                                                 CHIMERA_VFS_ANON_UID,
                                                 CHIMERA_VFS_ANON_GID);
@@ -387,6 +405,8 @@ chimera_nfs_server_notify(
                     nlm_state_remove_client_file(&shared->nlm_state,
                                                  nlm_cli->hostname);
                 }
+            } else if (magic == NFS4_SESSION_MAGIC) {
+                nfs4_session_unbind_conn(conn);
             }
             break;
     } /* switch */

--- a/src/server/nfs/nfs4_proc_close.c
+++ b/src/server/nfs/nfs4_proc_close.c
@@ -17,8 +17,9 @@ chimera_nfs4_close(
     struct CLOSE4args              *args    = &argop->opclose;
     struct CLOSE4res               *res     = &resop->opclose;
     struct nfs4_session            *session = nfs4_resolve_session(
-        req->session, &args->open_stateid,
-        &thread->shared->nfs4_shared_clients);
+        req->session, req->conn,
+        &thread->shared->nfs4_shared_clients,
+        &args->open_stateid);
     struct nfs4_state              *state;
     struct chimera_vfs_open_handle *handle;
     int                             rc;
@@ -29,10 +30,7 @@ chimera_nfs4_close(
         return;
     }
 
-    if (!req->session) {
-        req->session = session;
-        evpl_rpc2_conn_set_private_data(req->conn, session);
-    }
+    req->session = session;
 
     if (*(uint32_t *) args->open_stateid.other >= NFS4_SESSION_MAX_STATE) {
         res->status = NFS4ERR_BAD_STATEID;

--- a/src/server/nfs/nfs4_proc_compound.c
+++ b/src/server/nfs/nfs4_proc_compound.c
@@ -198,7 +198,18 @@ chimera_nfs4_compound(
 
     nfs4_dump_compound(req, args);
 
-    req->session              = evpl_rpc2_conn_get_private_data(conn);
+    /* The conn caches its bound nfs4_session in private_data.  The conn
+     * holds a refcount on it (set up by nfs4_session_bind_conn) so the
+     * memory is valid for the duration of this request.  However the
+     * session may already have been destroyed by a prior DESTROY_SESSION
+     * compound -- in that case treat the cache as empty so that the
+     * lookup-by-id paths produce the appropriate BADSESSION/BAD_STATEID
+     * errors. */
+    {
+        struct nfs4_session *cached = evpl_rpc2_conn_get_private_data(conn);
+
+        req->session = nfs4_session_is_live(cached) ? cached : NULL;
+    }
     req->args_compound        = args;
     req->res_compound.status  = NFS4_OK;
     req->res_compound.tag.len = 0;

--- a/src/server/nfs/nfs4_proc_create_session.c
+++ b/src/server/nfs/nfs4_proc_create_session.c
@@ -1,9 +1,9 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
 #include "nfs4_procs.h"
-#include "evpl/evpl_rpc2.h"
+#include "nfs4_session.h"
 
 void
 chimera_nfs4_create_session(
@@ -36,7 +36,7 @@ chimera_nfs4_create_session(
         return;
     }
 
-    evpl_rpc2_conn_set_private_data(conn, session);
+    nfs4_session_bind_conn(conn, session);
     req->session = session;
 
     res->csr_status = NFS4_OK;
@@ -46,6 +46,10 @@ chimera_nfs4_create_session(
 
     res->csr_resok4.csr_fore_chan_attrs = session->nfs4_session_fore_attrs;
     res->csr_resok4.csr_back_chan_attrs = session->nfs4_session_back_attrs;
+
+    /* Drop the +1 ref returned by nfs4_create_session; the conn now holds
+     * its own ref via bind_conn, and the hash holds the other ref. */
+    nfs4_session_put(session);
 
     chimera_nfs4_compound_complete(req, NFS4_OK);
 } /* chimera_nfs4_setclientid */

--- a/src/server/nfs/nfs4_proc_lock.c
+++ b/src/server/nfs/nfs4_proc_lock.c
@@ -103,9 +103,9 @@ chimera_nfs4_lock(
     if (args->locker.new_lock_owner) {
         /* First lock for this open - validate open stateid, allocate lock state */
         session = nfs4_resolve_session(
-            req->session,
-            &args->locker.open_owner.open_stateid,
-            &thread->shared->nfs4_shared_clients);
+            req->session, req->conn,
+            &thread->shared->nfs4_shared_clients,
+            &args->locker.open_owner.open_stateid);
 
         if (!session) {
             res->status = NFS4ERR_BAD_STATEID;
@@ -113,10 +113,7 @@ chimera_nfs4_lock(
             return;
         }
 
-        if (!req->session) {
-            req->session = session;
-            evpl_rpc2_conn_set_private_data(req->conn, session);
-        }
+        req->session = session;
 
         if (nfs4_session_acquire_state(session,
                                        &args->locker.open_owner.open_stateid,
@@ -148,9 +145,9 @@ chimera_nfs4_lock(
     } else {
         /* Subsequent lock - use existing lock stateid */
         session = nfs4_resolve_session(
-            req->session,
-            &args->locker.lock_owner.lock_stateid,
-            &thread->shared->nfs4_shared_clients);
+            req->session, req->conn,
+            &thread->shared->nfs4_shared_clients,
+            &args->locker.lock_owner.lock_stateid);
 
         if (!session) {
             res->status = NFS4ERR_BAD_STATEID;
@@ -158,10 +155,7 @@ chimera_nfs4_lock(
             return;
         }
 
-        if (!req->session) {
-            req->session = session;
-            evpl_rpc2_conn_set_private_data(req->conn, session);
-        }
+        req->session = session;
 
         if (nfs4_session_acquire_state(session,
                                        &args->locker.lock_owner.lock_stateid,

--- a/src/server/nfs/nfs4_proc_locku.c
+++ b/src/server/nfs/nfs4_proc_locku.c
@@ -58,9 +58,9 @@ chimera_nfs4_locku(
     }
 
     session = nfs4_resolve_session(
-        req->session,
-        &args->lock_stateid,
-        &thread->shared->nfs4_shared_clients);
+        req->session, req->conn,
+        &thread->shared->nfs4_shared_clients,
+        &args->lock_stateid);
 
     if (!session) {
         res->status = NFS4ERR_BAD_STATEID;
@@ -68,10 +68,7 @@ chimera_nfs4_locku(
         return;
     }
 
-    if (!req->session) {
-        req->session = session;
-        evpl_rpc2_conn_set_private_data(req->conn, session);
-    }
+    req->session = session;
 
     if (nfs4_session_acquire_state(session,
                                    &args->lock_stateid,

--- a/src/server/nfs/nfs4_proc_open.c
+++ b/src/server/nfs/nfs4_proc_open.c
@@ -355,12 +355,15 @@ chimera_nfs4_open(
     }
 
     if (!req->session) {
-        req->session = nfs4_session_find_by_clientid(
+        struct nfs4_session *found = nfs4_session_find_by_clientid(
             &thread->shared->nfs4_shared_clients,
             args->owner.clientid);
 
-        if (req->session) {
-            evpl_rpc2_conn_set_private_data(req->conn, req->session);
+        if (found) {
+            nfs4_session_bind_conn(req->conn, found);
+            req->session = found;
+            /* Drop the +1 ref returned by find_by_clientid; conn owns it. */
+            nfs4_session_put(found);
         }
     }
 

--- a/src/server/nfs/nfs4_proc_read.c
+++ b/src/server/nfs/nfs4_proc_read.c
@@ -51,8 +51,9 @@ chimera_nfs4_read(
     struct READ4args               *args    = &argop->opread;
     struct READ4res                *res     = &resop->opread;
     struct nfs4_session            *session = nfs4_resolve_session(
-        req->session, &args->stateid,
-        &thread->shared->nfs4_shared_clients);
+        req->session, req->conn,
+        &thread->shared->nfs4_shared_clients,
+        &args->stateid);
     struct nfs4_state              *state;
     struct chimera_vfs_open_handle *state_handle;
     struct evpl_iovec              *iov;
@@ -63,10 +64,7 @@ chimera_nfs4_read(
         return;
     }
 
-    if (!req->session) {
-        req->session = session;
-        evpl_rpc2_conn_set_private_data(req->conn, session);
-    }
+    req->session = session;
 
     if (nfs4_session_acquire_state(session, &args->stateid,
                                    &state, &state_handle) != NFS4_OK) {

--- a/src/server/nfs/nfs4_proc_sequence.c
+++ b/src/server/nfs/nfs4_proc_sequence.c
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-only
 
 #include "nfs4_procs.h"
-#include "evpl/evpl_rpc2.h"
+#include "nfs4_session.h"
 
 void
 chimera_nfs4_sequence(
@@ -24,6 +24,12 @@ chimera_nfs4_sequence(
         chimera_nfs4_compound_complete(req, NFS4ERR_BADSESSION);
         return;
     }
+
+    /* Bind this session to the conn (idempotent if already bound) and drop
+     * the +1 ref returned by nfs4_session_lookup -- the conn's ref keeps
+     * the session alive for the rest of this compound. */
+    nfs4_session_bind_conn(req->conn, session);
+    nfs4_session_put(session);
 
     /* Store session in request for use by subsequent operations */
     req->session = session;

--- a/src/server/nfs/nfs4_proc_setclientid.c
+++ b/src/server/nfs/nfs4_proc_setclientid.c
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-only
 
 #include "nfs4_procs.h"
-#include "evpl/evpl_rpc2.h"
+#include "nfs4_session.h"
 
 void
 chimera_nfs4_setclientid(
@@ -38,7 +38,7 @@ chimera_nfs4_setclientid(
             NULL);
     }
 
-    evpl_rpc2_conn_set_private_data(conn, session);
+    nfs4_session_bind_conn(conn, session);
     req->session = session;
 
     resop->opsetclientid.status = NFS4_OK;
@@ -46,6 +46,10 @@ chimera_nfs4_setclientid(
     memcpy(&resop->opsetclientid.resok4.setclientid_confirm,
            session->nfs4_session_id,
            sizeof(session->nfs4_session_id));
+
+    /* Drop the +1 ref returned by find_by_clientid / create_session; the
+     * conn now holds its own ref via bind_conn. */
+    nfs4_session_put(session);
 
     chimera_nfs4_compound_complete(req, NFS4_OK);
 } /* chimera_nfs4_setclientid */

--- a/src/server/nfs/nfs4_proc_write.c
+++ b/src/server/nfs/nfs4_proc_write.c
@@ -58,8 +58,9 @@ chimera_nfs4_write(
     struct WRITE4args              *args    = &argop->opwrite;
     struct WRITE4res               *res     = &resop->opwrite;
     struct nfs4_session            *session = nfs4_resolve_session(
-        req->session, &args->stateid,
-        &thread->shared->nfs4_shared_clients);
+        req->session, req->conn,
+        &thread->shared->nfs4_shared_clients,
+        &args->stateid);
     struct nfs4_state              *state;
     struct chimera_vfs_open_handle *state_handle;
 
@@ -69,10 +70,7 @@ chimera_nfs4_write(
         return;
     }
 
-    if (!req->session) {
-        req->session = session;
-        evpl_rpc2_conn_set_private_data(req->conn, session);
-    }
+    req->session = session;
 
     if (nfs4_session_acquire_state(session, &args->stateid,
                                    &state, &state_handle) != NFS4_OK) {

--- a/src/server/nfs/nfs4_session.c
+++ b/src/server/nfs/nfs4_session.c
@@ -8,6 +8,8 @@
 #include <uuid/uuid.h>
 #include "nfs4_session.h"
 #include "nfs_internal.h"
+#include "nfs_nlm_state.h"
+#include "evpl/evpl_rpc2.h"
 #include "vfs/vfs_release.h"
 
 void
@@ -43,8 +45,12 @@ nfs4_client_table_free(struct nfs4_client_table *table)
     HASH_ITER(nfs4_session_hh, table->nfs4_ct_sessions, sess, sesstmp)
     {
         HASH_DELETE(nfs4_session_hh, table->nfs4_ct_sessions, sess);
-        pthread_mutex_destroy(&sess->nfs4_session_lock);
-        free(sess);
+        atomic_store_explicit(&sess->destroyed, true, memory_order_release);
+        /* Drop the table's ref.  By this point in shutdown evpl_destroy()
+         * has already drained all conns and fired NOTIFY_DISCONNECTED for
+         * each, so no conns hold refs and refcount is exactly 1 -- the
+         * session is freed here. */
+        nfs4_session_put(sess);
     }
 
 #endif /* ifndef __clang_analyzer__ */
@@ -165,6 +171,13 @@ nfs4_create_session(
     if (client) {
         session = calloc(1, sizeof(*session));
 
+        session->magic = NFS4_SESSION_MAGIC;
+        /* refcount: 1 for the hash table, 1 for the caller (so the session
+         * cannot be destroyed by another thread before the caller binds it
+         * to a conn). */
+        atomic_init(&session->refcount, 2);
+        atomic_init(&session->destroyed, false);
+
         uuid_generate(session->nfs4_session_id);
 
         pthread_mutex_init(&session->nfs4_session_lock, NULL);
@@ -227,6 +240,13 @@ nfs4_session_lookup(
     HASH_FIND(nfs4_session_hh, table->nfs4_ct_sessions,
               sessionid, NFS4_SESSIONID_SIZE, session);
 
+    if (session) {
+        /* take a +1 ref for the caller while holding the table lock so a
+         * concurrent nfs4_destroy_session cannot race the free. */
+        atomic_fetch_add_explicit(&session->refcount, 1,
+                                  memory_order_acq_rel);
+    }
+
     pthread_mutex_unlock(&table->nfs4_ct_lock);
 
     return session;
@@ -248,6 +268,12 @@ nfs4_session_find_by_clientid(
             session = cur;
             break;
         }
+    }
+
+    if (session) {
+        /* take a +1 ref for the caller while holding the table lock. */
+        atomic_fetch_add_explicit(&session->refcount, 1,
+                                  memory_order_acq_rel);
     }
 
     pthread_mutex_unlock(&table->nfs4_ct_lock);
@@ -274,13 +300,17 @@ nfs4_destroy_session(
 
     if (session) {
         HASH_DELETE(nfs4_session_hh, table->nfs4_ct_sessions, session);
+        atomic_store_explicit(&session->destroyed, true,
+                              memory_order_release);
     }
 
     pthread_mutex_unlock(&table->nfs4_ct_lock);
 
     if (session) {
-        pthread_mutex_destroy(&session->nfs4_session_lock);
-        free(session);
+        /* Drop the hash table's ref.  The session is freed only when the
+         * last conn that still caches it in private_data also drops its
+         * ref (in the disconnect notify). */
+        nfs4_session_put(session);
     }
 
 } /* nfs4_destroy_session */
@@ -311,3 +341,85 @@ nfs4_client_table_release_handles(
     pthread_mutex_unlock(&table->nfs4_ct_lock);
 #endif /* ifndef __clang_analyzer__ */
 } /* nfs4_client_table_release_handles */
+
+void
+nfs4_session_get(struct nfs4_session *session)
+{
+    atomic_fetch_add_explicit(&session->refcount, 1, memory_order_acq_rel);
+} /* nfs4_session_get */
+
+void
+nfs4_session_put(struct nfs4_session *session)
+{
+    uint32_t prev;
+
+    prev = atomic_fetch_sub_explicit(&session->refcount, 1,
+                                     memory_order_acq_rel);
+
+    chimera_nfs_abort_if(prev == 0,
+                         "nfs4_session_put: refcount underflow on session %p",
+                         session);
+
+    if (prev == 1) {
+        /* Last ref -- safe to tear down. */
+        pthread_mutex_destroy(&session->nfs4_session_lock);
+        session->magic = 0;
+        free(session);
+    }
+} /* nfs4_session_put */
+
+void
+nfs4_session_bind_conn(
+    struct evpl_rpc2_conn *conn,
+    struct nfs4_session   *session)
+{
+    void    *existing;
+    uint32_t magic = 0;
+
+    existing = evpl_rpc2_conn_get_private_data(conn);
+
+    if (existing) {
+        memcpy(&magic, existing, sizeof(magic));
+    }
+
+    if (magic == NFS4_SESSION_MAGIC) {
+        if (existing == session) {
+            /* Already bound to this session. */
+            return;
+        }
+        /* Bound to a different session -- unbind the old one. */
+        nfs4_session_put((struct nfs4_session *) existing);
+    } else if (magic == NLM_CLIENT_MAGIC) {
+        /* NLM and NFS4 should never share a conn (different ports). */
+        chimera_nfs_abort(
+            "nfs4_session_bind_conn: conn %p already holds an NLM client",
+            conn);
+    }
+
+    nfs4_session_get(session);
+    evpl_rpc2_conn_set_private_data(conn, session);
+} /* nfs4_session_bind_conn */
+
+void
+nfs4_session_unbind_conn(struct evpl_rpc2_conn *conn)
+{
+    void                *existing;
+    uint32_t             magic = 0;
+    struct nfs4_session *session;
+
+    existing = evpl_rpc2_conn_get_private_data(conn);
+
+    if (!existing) {
+        return;
+    }
+
+    memcpy(&magic, existing, sizeof(magic));
+
+    if (magic != NFS4_SESSION_MAGIC) {
+        return;
+    }
+
+    session = (struct nfs4_session *) existing;
+    evpl_rpc2_conn_set_private_data(conn, NULL);
+    nfs4_session_put(session);
+} /* nfs4_session_unbind_conn */

--- a/src/server/nfs/nfs4_session.h
+++ b/src/server/nfs/nfs4_session.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <stdatomic.h>
+#include <stdbool.h>
 #include <uthash.h>
 
 #include "nfs3_xdr.h"
@@ -11,10 +13,18 @@
 #include "nfs_internal.h"
 #include "vfs/vfs.h"
 
+struct evpl_rpc2_conn;
+
 #define NFS4_SESSION_MAX_STATE 1024
 
 #define NFS4_STATE_TYPE_OPEN   0
 #define NFS4_STATE_TYPE_LOCK   1
+
+/* Magic stored in nfs4_session.magic so that a connection's private_data
+ * (which may hold either an nlm_client* or an nfs4_session*) can be safely
+ * type-checked in the disconnect handler.  Must match the layout of
+ * nlm_client (uint32_t magic at offset 0). */
+#define NFS4_SESSION_MAGIC     0x4E465353U /* "NFSS" */
 
 struct nfs4_state {
     struct stateid4                 nfs4_state_id;
@@ -39,6 +49,10 @@ struct nfs4_client {
 };
 
 struct nfs4_session {
+    /* magic MUST be the first member -- see NFS4_SESSION_MAGIC comment. */
+    uint32_t              magic;
+    _Atomic uint32_t      refcount;
+    _Atomic bool          destroyed;
     uint8_t               nfs4_session_id[NFS4_SESSIONID_SIZE];
     uint64_t              nfs4_session_clientid;
     pthread_mutex_t       nfs4_session_lock;
@@ -112,6 +126,42 @@ struct nfs4_session *
 nfs4_session_find_by_clientid(
     struct nfs4_client_table *table,
     uint64_t                  client_id);
+
+/*
+ * Reference counting for nfs4_session.
+ *
+ * A session is referenced by:
+ *   - the client table (1 ref, dropped by nfs4_destroy_session or
+ *     nfs4_client_table_free)
+ *   - every evpl_rpc2_conn whose private_data points to it (1 ref each,
+ *     installed by nfs4_session_bind_conn, dropped by
+ *     nfs4_session_unbind_conn from the disconnect notify)
+ *
+ * nfs4_session_lookup() and nfs4_session_find_by_clientid() both return
+ * a session with +1 ref.  Callers must release that ref with
+ * nfs4_session_put() (either directly, or by binding it to a conn and then
+ * putting the lookup ref).
+ *
+ * nfs4_session_bind_conn() takes its own +1 ref; it does NOT consume the
+ * caller's ref.
+ */
+void nfs4_session_get(
+    struct nfs4_session *session);
+void nfs4_session_put(
+    struct nfs4_session *session);
+void nfs4_session_bind_conn(
+    struct evpl_rpc2_conn *conn,
+    struct nfs4_session   *session);
+void nfs4_session_unbind_conn(
+    struct evpl_rpc2_conn *conn);
+
+static inline bool
+nfs4_session_is_live(struct nfs4_session *session)
+{
+    return session &&
+           session->magic == NFS4_SESSION_MAGIC &&
+           !atomic_load_explicit(&session->destroyed, memory_order_acquire);
+} // nfs4_session_is_live
 
 static inline struct nfs4_state *
 nfs4_session_alloc_slot(struct nfs4_session *session)
@@ -303,19 +353,40 @@ nfs4_session_validate_stateid(
     return status;
 } /* nfs4_session_validate_stateid */
 
+/*
+ * Resolve the session for the current request.
+ *
+ * If `session` is non-NULL it is already borrowed via the conn's bind
+ * (compound entry transitively holds a ref through evpl_rpc2_conn private_data)
+ * and is returned as-is.
+ *
+ * Otherwise look up the session by the clientid embedded in `stateid`.  If
+ * found, bind it to `conn` (taking a ref on the conn's behalf) and drop the
+ * lookup's ref; the returned pointer is then borrowed via that conn ref.
+ *
+ * Returns NULL if no session exists for this client.
+ */
 static inline struct nfs4_session *
 nfs4_resolve_session(
     struct nfs4_session      *session,
-    const struct stateid4    *stateid,
-    struct nfs4_client_table *table)
+    struct evpl_rpc2_conn    *conn,
+    struct nfs4_client_table *table,
+    const struct stateid4    *stateid)
 {
-    uint64_t client_id;
+    uint64_t             client_id;
+    struct nfs4_session *found;
 
     if (session) {
         return session;
     }
 
     client_id = *(uint64_t *) (stateid->other + 4);
+    found     = nfs4_session_find_by_clientid(table, client_id);
 
-    return nfs4_session_find_by_clientid(table, client_id);
+    if (found) {
+        nfs4_session_bind_conn(conn, found);
+        nfs4_session_put(found);
+    }
+
+    return found;
 } /* nfs4_resolve_session */


### PR DESCRIPTION
The evpl_rpc2_conn private_data slot is multiplexed between an nlm_client pointer and an nfs4_session pointer.  The disconnect notify in chimera_nfs_server_notify reads a magic word at offset 0 to discriminate the two, but nfs4_session had neither a magic field nor a refcount and was freed synchronously by nfs4_destroy_session while connections still cached the pointer.  After DESTROY_SESSION the next TCP disconnect dereferenced freed memory.

Mirror the nlm_client lifetime pattern on nfs4_session:

- Add NFS4_SESSION_MAGIC as the first member of nfs4_session so the disconnect notify can safely discriminate types via memcpy of the first four bytes.
- Add _Atomic refcount and destroyed flag.  nfs4_session_lookup and nfs4_session_find_by_clientid take +1 ref under the table lock. nfs4_session_bind_conn installs the cached pointer and takes its own ref; nfs4_session_unbind_conn drops it from the disconnect notify.  nfs4_destroy_session marks the session destroyed, removes it from the hash, and drops the table ref; actual free happens when the last conn ref goes away.
- nfs4_resolve_session now takes the conn and binds the resolved session itself, replacing the duplicated lazy-bind blocks in close/open/read/write/lock/locku.
- chimera_nfs4_compound validates the cached session via nfs4_session_is_live so a destroyed-but-still-referenced session is treated as absent, forcing BADSESSION / BAD_STATEID through the normal protocol paths.
- Reorder nfs_server_destroy so the rpc2 servers are torn down (which drains conns and runs the disconnect notify) before nfs4_client_table_free drops the hash table's refs.