### PR TITLE
Add optional async delegation thread pool for VFS dispatch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,7 +128,9 @@ Chimera uses JSON configuration files. Example:
         }
     },
     "core_threads": 4,
-    "delegation_threads": 16,
+    "sync_delegation_threads": 16,
+    "async_delegation": false,
+    "async_delegation_threads": 8,
     "enable_rdma": false
 }
 ```

--- a/README.md
+++ b/README.md
@@ -140,7 +140,9 @@ Chimera uses JSON configuration files to define shares and runtime parameters:
 {
     "server": {
         "threads": 16,
-        "delegation_threads": 64,
+        "sync_delegation_threads": 64,
+        "async_delegation": false,
+        "async_delegation_threads": 8,
         "rdma": true,
         "smb_multichannel": [
             {

--- a/README.md
+++ b/README.md
@@ -107,7 +107,9 @@ A minimal example that exports a single in-memory filesystem over NFS at
 {
     "server": {
         "threads": 32,
-        "delegation_threads": 32,
+        "sync_delegation_threads": 32,
+        "async_delegation": false,
+        "async_delegation_threads": 8,
         "preallocate_slabs": 8,
         "preallocate_threads": 4,
         "max_open_files": 262144,

--- a/chimera-docker.json
+++ b/chimera-docker.json
@@ -1,7 +1,9 @@
 {
     "server": {
         "threads": 4,
-        "delegation_threads": 8,
+        "sync_delegation_threads": 8,
+        "async_delegation": false,
+        "async_delegation_threads": 8,
         "rest_http_port": 8080
     },
     "mounts": {

--- a/docs/design/smb_change_notify.md
+++ b/docs/design/smb_change_notify.md
@@ -35,7 +35,7 @@ The work spans three layers:
    watches   (RPL resolve)              │
         │         │                     │
         │         ▼                     │
-        │    delegation_threads[0]      │
+        │ sync_delegation_threads[0]    │
         │    chimera_vfs_getparent      │
         │         │                     │
         └────┬────┘                     │
@@ -85,7 +85,7 @@ The work spans three layers:
   - Walks `walk_fh → parent → grandparent → ...` toward the mount root.
   - At each step, all dereferences of the mount entry (subtree iteration AND the at-root check using `root_fh_len`/`root_fh`) happen inside the `mount_entries_lock` critical section, so the entry can be safely GC'd by `watch_destroy` when its last subtree watch is removed.
   - Skips subtree iteration at `depth==1` because that's the event's parent dir, already covered by the exact-watch dispatch.
-  - Tries RPL cache first (`chimera_vfs_rpl_cache_lookup`); on hit, prepends the component synchronously and continues. On miss, calls async `chimera_vfs_getparent` via `delegation_threads[0]` and returns; the callback resumes the walk.
+  - Tries RPL cache first (`chimera_vfs_rpl_cache_lookup`); on hit, prepends the component synchronously and continues. On miss, calls async `chimera_vfs_getparent` via `sync_delegation_threads[0]` and returns; the callback resumes the walk.
   - Builds the relative path right-to-left in `pev->path_buf[CHIMERA_VFS_PATH_MAX]`.
   - At the mount root or on error/overflow/depth-cap, frees the pev and signals overflow to subtree watches on the mount where appropriate.
 
@@ -204,7 +204,7 @@ Documented in code; load-bearing for safety.
 ## Known limitations (documented in code)
 
 - Spurious `FILE_ADDED` for `OPEN_IF`/`OVERWRITE_IF`/`SUPERSEDE` + pre-existing file — needs `create_action` plumbed through `chimera_vfs_open_at`.
-- Subtree resolver funnels through `delegation_threads[0]` — perf bottleneck under heavy subtree-watch + mutation load.
+- Subtree resolver funnels through `sync_delegation_threads[0]` — perf bottleneck under heavy subtree-watch + mutation load.
 - `chimera_vfs_notify_destroy` blocks indefinitely if a delegation thread wedges (with progress logs); contract documented as "callers must quiesce frontends first."
 - SMB 3.1.1 signing falls through to AES-CMAC-AES-128 instead of the preauth-integrity-derived key derivation (chimera doesn't yet implement 3.1.1 fully).
 - Subtree `CHANGE_NOTIFY` on linux backend currently uses the coarse `!has_rpl` overflow path because the linux module doesn't advertise `CHIMERA_VFS_CAP_RPL`.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -93,7 +93,9 @@ with RDMA enabled:
 {
     "server": {
         "threads": 32,
-        "delegation_threads": 32,
+        "sync_delegation_threads": 32,
+        "async_delegation": false,
+        "async_delegation_threads": 8,
         "preallocate_slabs": 8,
         "preallocate_threads": 4,
         "max_open_files": 262144,

--- a/src/admin/tests/conftest.py
+++ b/src/admin/tests/conftest.py
@@ -75,7 +75,7 @@ def chimera_server():
     config = {
         "server": {
             "threads": 2,
-            "delegation_threads": 4,
+            "sync_delegation_threads": 4,
             "rest_http_port": rest_port,
         },
         "mounts": {
@@ -164,7 +164,7 @@ def chimera_server_https():
     config = {
         "server": {
             "threads": 2,
-            "delegation_threads": 4,
+            "sync_delegation_threads": 4,
             "rest_http_port": http_port,
             "rest_https_port": https_port,
             # No rest_ssl_cert/rest_ssl_key - will auto-generate

--- a/src/client/client.c
+++ b/src/client/client.c
@@ -25,10 +25,12 @@ chimera_client_config_init(void)
 
     config = calloc(1, sizeof(struct chimera_client_config));
 
-    config->core_threads       = 16;
-    config->delegation_threads = 64;
-    config->cache_ttl          = 60;
-    config->max_fds            = 1024;
+    config->core_threads             = 16;
+    config->sync_delegation_threads  = 64;
+    config->async_delegation         = 0;
+    config->async_delegation_threads = 8;
+    config->cache_ttl                = 60;
+    config->max_fds                  = 1024;
 
     strncpy(config->modules[0].module_name, "root", sizeof(config->modules[0].module_name));
     config->modules[0].config_data[0] = '\0';
@@ -139,7 +141,8 @@ chimera_client_init(
 
     chimera_client_info("Initializing VFS...");
 
-    client->vfs = chimera_vfs_init(config->delegation_threads,
+    client->vfs = chimera_vfs_init(config->sync_delegation_threads,
+                                   config->async_delegation ? config->async_delegation_threads : 0,
                                    config->modules,
                                    config->num_modules,
                                    config->kv_module,
@@ -204,9 +207,19 @@ chimera_client_init_json(
             config->core_threads = json_integer_value(val);
         }
 
-        val = json_object_get(config_section, "delegation_threads");
+        val = json_object_get(config_section, "sync_delegation_threads");
         if (val && json_is_integer(val)) {
-            config->delegation_threads = json_integer_value(val);
+            config->sync_delegation_threads = json_integer_value(val);
+        }
+
+        val = json_object_get(config_section, "async_delegation");
+        if (val && json_is_boolean(val)) {
+            config->async_delegation = json_is_true(val);
+        }
+
+        val = json_object_get(config_section, "async_delegation_threads");
+        if (val && json_is_integer(val)) {
+            config->async_delegation_threads = json_integer_value(val);
         }
 
         val = json_object_get(config_section, "cache_ttl");

--- a/src/client/client_internal.h
+++ b/src/client/client_internal.h
@@ -358,7 +358,9 @@ struct chimera_client_request {
 
 struct chimera_client_config {
     int                           core_threads;
-    int                           delegation_threads;
+    int                           sync_delegation_threads;
+    int                           async_delegation;
+    int                           async_delegation_threads;
     int                           cache_ttl;
     int                           max_fds;
     char                          kv_module[64];

--- a/src/daemon/chimera.json
+++ b/src/daemon/chimera.json
@@ -1,7 +1,9 @@
 {
     "server": {
 	"threads": 16,
-	"delegation_threads": 1
+	"sync_delegation_threads": 1,
+	"async_delegation": false,
+	"async_delegation_threads": 8
     },
     "mounts": {
 	"memfs_dir": {

--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -322,10 +322,21 @@ main(
         chimera_server_config_set_max_open_files(server_config, int_value);
     }
 
-    json_value = json_object_get(server_params, "delegation_threads");
+    json_value = json_object_get(server_params, "sync_delegation_threads");
     if (json_is_integer(json_value)) {
         int_value = json_integer_value(json_value);
-        chimera_server_config_set_delegation_threads(server_config, int_value);
+        chimera_server_config_set_sync_delegation_threads(server_config, int_value);
+    }
+
+    json_value = json_object_get(server_params, "async_delegation");
+    if (json_is_boolean(json_value)) {
+        chimera_server_config_set_async_delegation(server_config, json_is_true(json_value));
+    }
+
+    json_value = json_object_get(server_params, "async_delegation_threads");
+    if (json_is_integer(json_value)) {
+        int_value = json_integer_value(json_value);
+        chimera_server_config_set_async_delegation_threads(server_config, int_value);
     }
 
     json_value = json_object_get(server_params, "external_portmap");

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -41,7 +41,9 @@ struct chimera_server_config {
     int                                   soft_fail_bad_req;
     rlim_t                                max_open_files;
     int                                   core_threads;
-    int                                   delegation_threads;
+    int                                   sync_delegation_threads;
+    int                                   async_delegation;
+    int                                   async_delegation_threads;
     int                                   cache_ttl;
     int                                   num_modules;
     int                                   metrics_port;
@@ -94,13 +96,15 @@ chimera_server_config_init(void)
 
     config = calloc(1, sizeof(struct chimera_server_config));
 
-    config->core_threads       = 8;
-    config->max_open_files     = 65535;
-    config->delegation_threads = 8;
-    config->nfs_rdma           = 0;
-    config->external_portmap   = 0;
-    config->soft_fail_bad_req  = 0;
-    config->tcp_flavor         = CHIMERA_TCP_FLAVOR_PLAIN;
+    config->core_threads             = 8;
+    config->max_open_files           = 65535;
+    config->sync_delegation_threads  = 8;
+    config->async_delegation         = 0;
+    config->async_delegation_threads = 8;
+    config->nfs_rdma                 = 0;
+    config->external_portmap         = 0;
+    config->soft_fail_bad_req        = 0;
+    config->tcp_flavor               = CHIMERA_TCP_FLAVOR_PLAIN;
 
     config->smb_num_dialects = 2;
     config->smb_dialects[0]  = SMB2_DIALECT_2_1;
@@ -164,12 +168,28 @@ chimera_server_config_set_core_threads(
 } /* chimera_server_config_set_core_threads */
 
 SYMBOL_EXPORT void
-chimera_server_config_set_delegation_threads(
+chimera_server_config_set_sync_delegation_threads(
     struct chimera_server_config *config,
     int                           threads)
 {
-    config->delegation_threads = threads;
-} /* chimera_server_config_set_delegation_threads */
+    config->sync_delegation_threads = threads;
+} /* chimera_server_config_set_sync_delegation_threads */
+
+SYMBOL_EXPORT void
+chimera_server_config_set_async_delegation(
+    struct chimera_server_config *config,
+    int                           enable)
+{
+    config->async_delegation = enable;
+} /* chimera_server_config_set_async_delegation */
+
+SYMBOL_EXPORT void
+chimera_server_config_set_async_delegation_threads(
+    struct chimera_server_config *config,
+    int                           threads)
+{
+    config->async_delegation_threads = threads;
+} /* chimera_server_config_set_async_delegation_threads */
 
 SYMBOL_EXPORT void
 chimera_server_config_set_max_open_files(
@@ -712,7 +732,8 @@ chimera_server_init(
     pthread_cond_init(&server->all_threads_online, NULL);
 
     chimera_server_info("Initializing VFS...");
-    server->vfs = chimera_vfs_init(config->delegation_threads,
+    server->vfs = chimera_vfs_init(config->sync_delegation_threads,
+                                   config->async_delegation ? config->async_delegation_threads : 0,
                                    config->modules,
                                    config->num_modules,
                                    config->kv_module,

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -61,7 +61,17 @@ chimera_server_config_set_core_threads(
     int                           threads);
 
 void
-chimera_server_config_set_delegation_threads(
+chimera_server_config_set_sync_delegation_threads(
+    struct chimera_server_config *config,
+    int                           threads);
+
+void
+chimera_server_config_set_async_delegation(
+    struct chimera_server_config *config,
+    int                           enable);
+
+void
+chimera_server_config_set_async_delegation_threads(
     struct chimera_server_config *config,
     int                           threads);
 

--- a/src/vfs/tests/CMakeLists.txt
+++ b/src/vfs/tests/CMakeLists.txt
@@ -10,6 +10,10 @@ add_executable(vfs_kv_test vfs_kv_test.c)
 target_link_libraries(vfs_kv_test chimera_vfs chimera_vfs_memfs evpl)
 add_test(chimera/vfs/kv_test vfs_kv_test)
 
+add_executable(vfs_async_delegation_test vfs_async_delegation_test.c)
+target_link_libraries(vfs_async_delegation_test chimera_vfs chimera_vfs_memfs evpl)
+add_test(chimera/vfs/async_delegation_test vfs_async_delegation_test)
+
 add_executable(vfs_notify_test vfs_notify_test.c)
 target_link_libraries(vfs_notify_test chimera_vfs urcu)
 add_test(chimera/vfs/notify_test vfs_notify_test)

--- a/src/vfs/tests/vfs_async_delegation_test.c
+++ b/src/vfs/tests/vfs_async_delegation_test.c
@@ -1,0 +1,312 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * Exercises the async delegation thread pool with a non-BLOCKING backend
+ * (memfs). Verifies:
+ *   - Operations complete end-to-end when routed through the async pool.
+ *   - Module dispatch runs on a delegation thread, not the caller thread.
+ *   - Same hash key consistently lands on the same delegation thread.
+ *   - Distinct hash keys exercise multiple delegation threads.
+ *   - With the pool disabled (count = 0), dispatch falls back to inline
+ *     execution on the caller thread.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#undef NDEBUG
+#include <assert.h>
+#include <unistd.h>
+#include <pthread.h>
+
+#include "evpl/evpl.h"
+#include "vfs/vfs.h"
+#include "vfs/vfs_procs.h"
+#include "common/logging.h"
+#include "prometheus-c.h"
+
+#define TEST_PASS(name) fprintf(stderr, "  PASS: %s\n", name)
+
+#define NUM_ASYNC_THREADS 4
+#define NUM_DISTINCT_KEYS 32
+
+struct test_ctx {
+    int                        done;
+    enum chimera_vfs_error status;
+    int                        search_hits;
+    pthread_t                  dispatch_tid;
+    struct chimera_vfs        *vfs;
+    struct chimera_vfs_thread *vfs_thread;
+    struct evpl               *evpl;
+};
+
+static void
+put_key_callback(
+    enum chimera_vfs_error error_code,
+    void                  *private_data)
+{
+    struct test_ctx *ctx = private_data;
+
+    ctx->status = error_code;
+    ctx->done   = 1;
+} /* put_key_callback */
+
+static void
+delete_key_callback(
+    enum chimera_vfs_error error_code,
+    void                  *private_data)
+{
+    struct test_ctx *ctx = private_data;
+
+    ctx->status = error_code;
+    ctx->done   = 1;
+} /* delete_key_callback */
+
+/*
+ * The per-entry callback runs inside the module's dispatch routine, which
+ * executes on the thread that picked the request up. With async delegation
+ * enabled, that's an async delegation thread; without, it's the caller.
+ */
+static int
+search_keys_callback(
+    const void *key,
+    uint32_t    key_len,
+    const void *value,
+    uint32_t    value_len,
+    void       *private_data)
+{
+    struct test_ctx *ctx = private_data;
+
+    ctx->dispatch_tid = pthread_self();
+    ctx->search_hits++;
+    return 0;
+} /* search_keys_callback */
+
+static void
+search_keys_complete(
+    enum chimera_vfs_error error_code,
+    void                  *private_data)
+{
+    struct test_ctx *ctx = private_data;
+
+    ctx->status = error_code;
+    ctx->done   = 1;
+} /* search_keys_complete */
+
+static void
+wait_for_completion(struct test_ctx *ctx)
+{
+    while (!ctx->done) {
+        evpl_continue(ctx->evpl);
+    }
+    ctx->done = 0;
+} /* wait_for_completion */
+
+static void
+put_key(
+    struct test_ctx *ctx,
+    const char      *key,
+    const char      *value)
+{
+    ctx->search_hits = 0;
+    chimera_vfs_put_key(
+        ctx->vfs_thread,
+        key,
+        strlen(key),
+        value,
+        strlen(value),
+        put_key_callback,
+        ctx);
+
+    wait_for_completion(ctx);
+    assert(ctx->status == CHIMERA_VFS_OK);
+} /* put_key */
+
+/*
+ * Runs a search over a range that matches a single inserted key and returns
+ * the pthread_t that ran the per-entry callback.
+ */
+static pthread_t
+search_for_single_key(
+    struct test_ctx *ctx,
+    const char      *key)
+{
+    char end_key[64];
+
+    snprintf(end_key, sizeof(end_key), "%s\xff", key);
+
+    ctx->search_hits  = 0;
+    ctx->dispatch_tid = 0;
+
+    chimera_vfs_search_keys(
+        ctx->vfs_thread,
+        key,
+        strlen(key),
+        end_key,
+        strlen(end_key),
+        search_keys_callback,
+        search_keys_complete,
+        ctx);
+
+    wait_for_completion(ctx);
+    assert(ctx->status == CHIMERA_VFS_OK);
+    assert(ctx->search_hits == 1);
+    assert(ctx->dispatch_tid != 0);
+
+    return ctx->dispatch_tid;
+} /* search_for_single_key */
+
+static void
+test_async_delegation_enabled(struct test_ctx *ctx)
+{
+    pthread_t main_tid = pthread_self();
+    pthread_t tids[NUM_DISTINCT_KEYS];
+    char      keys[NUM_DISTINCT_KEYS][32];
+    char      values[NUM_DISTINCT_KEYS][32];
+    int       i, j;
+    int       distinct_threads = 0;
+    int       saw_main_thread  = 0;
+
+    /* Insert NUM_DISTINCT_KEYS keys with prefixes that should hash differently. */
+    for (i = 0; i < NUM_DISTINCT_KEYS; i++) {
+        snprintf(keys[i], sizeof(keys[i]), "async_test_%02d", i);
+        snprintf(values[i], sizeof(values[i]), "v_%02d", i);
+        put_key(ctx, keys[i], values[i]);
+    }
+
+    /* Run one search per key and capture the dispatch thread. */
+    for (i = 0; i < NUM_DISTINCT_KEYS; i++) {
+        tids[i] = search_for_single_key(ctx, keys[i]);
+        if (pthread_equal(tids[i], main_tid)) {
+            saw_main_thread = 1;
+        }
+    }
+
+    /* No dispatch should have happened on the caller thread. */
+    assert(saw_main_thread == 0);
+
+    /* Affinity: re-running search for the same key should land on the same thread. */
+    for (i = 0; i < NUM_DISTINCT_KEYS; i++) {
+        pthread_t again = search_for_single_key(ctx, keys[i]);
+        assert(pthread_equal(again, tids[i]));
+    }
+
+    /* Distribution: with NUM_ASYNC_THREADS=4 threads and NUM_DISTINCT_KEYS=32
+     * keys hashed independently, we expect well more than one thread used. */
+    for (i = 0; i < NUM_DISTINCT_KEYS; i++) {
+        int seen = 0;
+        for (j = 0; j < i; j++) {
+            if (pthread_equal(tids[i], tids[j])) {
+                seen = 1;
+                break;
+            }
+        }
+        if (!seen) {
+            distinct_threads++;
+        }
+    }
+    assert(distinct_threads >= 2);
+
+    /* Cleanup */
+    for (i = 0; i < NUM_DISTINCT_KEYS; i++) {
+        chimera_vfs_delete_key(
+            ctx->vfs_thread,
+            keys[i],
+            strlen(keys[i]),
+            delete_key_callback,
+            ctx);
+        wait_for_completion(ctx);
+        assert(ctx->status == CHIMERA_VFS_OK);
+    }
+
+    fprintf(stderr, "    %d distinct dispatch threads used across %d keys\n",
+            distinct_threads, NUM_DISTINCT_KEYS);
+    TEST_PASS("async delegation routes dispatch off the caller thread with FH-hash affinity");
+} /* test_async_delegation_enabled */
+
+static void
+test_async_delegation_disabled(struct test_ctx *ctx)
+{
+    pthread_t main_tid = pthread_self();
+    pthread_t tid;
+
+    put_key(ctx, "inline_key_a", "v_a");
+
+    tid = search_for_single_key(ctx, "inline_key_a");
+
+    /* With the async pool disabled and a non-BLOCKING backend, dispatch must
+     * happen inline on the caller thread. */
+    assert(pthread_equal(tid, main_tid));
+
+    chimera_vfs_delete_key(
+        ctx->vfs_thread,
+        "inline_key_a",
+        strlen("inline_key_a"),
+        delete_key_callback,
+        ctx);
+    wait_for_completion(ctx);
+    assert(ctx->status == CHIMERA_VFS_OK);
+
+    TEST_PASS("async delegation disabled routes dispatch inline on the caller thread");
+} /* test_async_delegation_disabled */
+
+static void
+run_phase(
+    int         num_async_threads,
+    const char *label,
+    void (     *test_fn )(struct test_ctx *))
+{
+    struct test_ctx               ctx = { 0 };
+    struct chimera_vfs_module_cfg module_cfgs[1];
+    struct prometheus_metrics    *metrics;
+
+    metrics = prometheus_metrics_create(NULL, NULL, 0);
+    assert(metrics != NULL);
+
+    memset(module_cfgs, 0, sizeof(module_cfgs));
+    strncpy(module_cfgs[0].module_name, "memfs", sizeof(module_cfgs[0].module_name) - 1);
+
+    ctx.evpl = evpl_create(NULL);
+    assert(ctx.evpl != NULL);
+
+    ctx.vfs = chimera_vfs_init(
+        4,                  /* num_sync_delegation_threads */
+        num_async_threads,  /* num_async_delegation_threads */
+        module_cfgs,
+        1,
+        "",
+        60,
+        metrics);
+    assert(ctx.vfs != NULL);
+
+    ctx.vfs_thread = chimera_vfs_thread_init(ctx.evpl, ctx.vfs);
+    assert(ctx.vfs_thread != NULL);
+
+    fprintf(stderr, "Phase: %s (num_async_delegation_threads=%d)\n",
+            label, num_async_threads);
+
+    test_fn(&ctx);
+
+    chimera_vfs_thread_destroy(ctx.vfs_thread);
+    chimera_vfs_destroy(ctx.vfs);
+    evpl_destroy(ctx.evpl);
+    prometheus_metrics_destroy(metrics);
+} /* run_phase */
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    chimera_log_init();
+
+    run_phase(NUM_ASYNC_THREADS, "async delegation enabled",
+              test_async_delegation_enabled);
+    run_phase(0, "async delegation disabled",
+              test_async_delegation_disabled);
+
+    fprintf(stderr, "All async delegation tests passed!\n");
+    return 0;
+} /* main */

--- a/src/vfs/tests/vfs_kv_test.c
+++ b/src/vfs/tests/vfs_kv_test.c
@@ -374,7 +374,8 @@ main(
 
     /* Initialize VFS with memfs as KV module (default) */
     ctx.vfs = chimera_vfs_init(
-        4,              /* num_delegation_threads */
+        4,              /* num_sync_delegation_threads */
+        0,              /* num_async_delegation_threads */
         module_cfgs,
         1,              /* num_modules */
         "",             /* kv_module_name - empty means use default (memfs) */

--- a/src/vfs/vfs.c
+++ b/src/vfs/vfs.c
@@ -41,16 +41,11 @@
 
 
 static void
-chimera_vfs_delegation_thread_wake(
-    struct evpl          *evpl,
-    struct evpl_doorbell *doorbell)
+chimera_vfs_delegation_drain(struct chimera_vfs_delegation_thread *delegation_thread)
 {
-    struct chimera_vfs_delegation_thread *delegation_thread = container_of(doorbell, struct
-                                                                           chimera_vfs_delegation_thread,
-                                                                           doorbell);
-    struct chimera_vfs_thread            *thread = delegation_thread->vfs_thread;
-    struct chimera_vfs_request           *requests, *request;
-    struct chimera_vfs_module            *module;
+    struct chimera_vfs_thread  *thread = delegation_thread->vfs_thread;
+    struct chimera_vfs_request *requests, *request;
+    struct chimera_vfs_module  *module;
 
     pthread_mutex_lock(&delegation_thread->lock);
     requests                    = delegation_thread->requests;
@@ -64,7 +59,29 @@ chimera_vfs_delegation_thread_wake(
         module = request->module;
         module->dispatch(request, thread->module_private[module->fh_magic]);
     }
+} /* chimera_vfs_delegation_drain */
+
+static void
+chimera_vfs_delegation_thread_wake(
+    struct evpl          *evpl,
+    struct evpl_doorbell *doorbell)
+{
+    struct chimera_vfs_delegation_thread *delegation_thread = container_of(doorbell, struct
+                                                                           chimera_vfs_delegation_thread,
+                                                                           doorbell);
+
+    chimera_vfs_delegation_drain(delegation_thread);
 } /* chimera_vfs_delegation_thread_wake */
+
+static void
+chimera_vfs_delegation_thread_poll(
+    struct evpl *evpl,
+    void        *private_data)
+{
+    struct chimera_vfs_delegation_thread *delegation_thread = private_data;
+
+    chimera_vfs_delegation_drain(delegation_thread);
+} /* chimera_vfs_delegation_thread_poll */
 
 static void *
 chimera_vfs_delegation_thread_init(
@@ -79,6 +96,14 @@ chimera_vfs_delegation_thread_init(
     evpl_add_doorbell(evpl, &delegation_thread->doorbell,
                       chimera_vfs_delegation_thread_wake);
 
+    if (delegation_thread->mode == CHIMERA_VFS_DELEGATION_ASYNC) {
+        delegation_thread->poll = evpl_add_poll(evpl,
+                                                NULL,
+                                                NULL,
+                                                chimera_vfs_delegation_thread_poll,
+                                                delegation_thread);
+    }
+
     return private_data;
 } /* chimera_vfs_delegation_thread_init */
 
@@ -88,6 +113,11 @@ chimera_vfs_delegation_thread_shutdown(
     void        *private_data)
 {
     struct chimera_vfs_delegation_thread *delegation_thread = private_data;
+
+    if (delegation_thread->poll) {
+        evpl_remove_poll(evpl, delegation_thread->poll);
+        delegation_thread->poll = NULL;
+    }
 
     evpl_remove_doorbell(evpl, &delegation_thread->doorbell);
 
@@ -303,9 +333,39 @@ chimera_vfs_synthesize_machine_name(struct chimera_vfs *vfs)
     chimera_vfs_info("Machine name: %.*s", vfs->machine_name_len, vfs->machine_name);
 } /* chimera_vfs_synthesize_machine_name */
 
+static struct chimera_vfs_delegation_thread *
+chimera_vfs_spawn_delegation_pool(
+    struct chimera_vfs              *vfs,
+    int                              count,
+    enum chimera_vfs_delegation_mode mode)
+{
+    struct chimera_vfs_delegation_thread *pool;
+
+    if (count <= 0) {
+        return NULL;
+    }
+
+    pool = calloc(count, sizeof(struct chimera_vfs_delegation_thread));
+
+    for (int i = 0; i < count; i++) {
+        pool[i].vfs  = vfs;
+        pool[i].mode = mode;
+        pthread_mutex_init(&pool[i].lock, NULL);
+
+        pool[i].evpl_thread = evpl_thread_create(
+            NULL,
+            chimera_vfs_delegation_thread_init,
+            chimera_vfs_delegation_thread_shutdown,
+            &pool[i]);
+    }
+
+    return pool;
+} /* chimera_vfs_spawn_delegation_pool */
+
 SYMBOL_EXPORT struct chimera_vfs *
 chimera_vfs_init(
-    int                                  num_delegation_threads,
+    int                                  num_sync_delegation_threads,
+    int                                  num_async_delegation_threads,
     const struct chimera_vfs_module_cfg *module_cfgs,
     int                                  num_modules,
     const char                          *kv_module_name,
@@ -417,19 +477,13 @@ chimera_vfs_init(
 
     chimera_vfs_info("Using '%s' as KV backend", effective_kv_module);
 
-    vfs->num_delegation_threads = num_delegation_threads;
-    vfs->delegation_threads     = calloc(num_delegation_threads, sizeof(struct chimera_vfs_delegation_thread));
+    vfs->num_sync_delegation_threads = num_sync_delegation_threads;
+    vfs->sync_delegation_threads     = chimera_vfs_spawn_delegation_pool(
+        vfs, num_sync_delegation_threads, CHIMERA_VFS_DELEGATION_SYNC);
 
-    for (int i = 0; i < vfs->num_delegation_threads; i++) {
-        vfs->delegation_threads[i].vfs = vfs;
-        pthread_mutex_init(&vfs->delegation_threads[i].lock, NULL);
-
-        vfs->delegation_threads[i].evpl_thread = evpl_thread_create(
-            NULL,
-            chimera_vfs_delegation_thread_init,
-            chimera_vfs_delegation_thread_shutdown,
-            &vfs->delegation_threads[i]);
-    }
+    vfs->num_async_delegation_threads = num_async_delegation_threads;
+    vfs->async_delegation_threads     = chimera_vfs_spawn_delegation_pool(
+        vfs, num_async_delegation_threads, CHIMERA_VFS_DELEGATION_ASYNC);
 
     pthread_mutex_init(&vfs->close_thread.lock, NULL);
     pthread_cond_init(&vfs->close_thread.cond, NULL);
@@ -465,10 +519,15 @@ chimera_vfs_destroy(struct chimera_vfs *vfs)
      * in-flight delegated close operations finish and their completion
      * doorbell rings execute before the close thread's vfs_thread
      * (and its doorbell) is freed. */
-    for (i = 0; i < vfs->num_delegation_threads; i++) {
-        evpl_thread_destroy(vfs->delegation_threads[i].evpl_thread);
+    for (i = 0; i < vfs->num_sync_delegation_threads; i++) {
+        evpl_thread_destroy(vfs->sync_delegation_threads[i].evpl_thread);
     }
-    free(vfs->delegation_threads);
+    free(vfs->sync_delegation_threads);
+
+    for (i = 0; i < vfs->num_async_delegation_threads; i++) {
+        evpl_thread_destroy(vfs->async_delegation_threads[i].evpl_thread);
+    }
+    free(vfs->async_delegation_threads);
 
     evpl_thread_destroy(vfs->close_thread.evpl_thread);
 

--- a/src/vfs/vfs.h
+++ b/src/vfs/vfs.h
@@ -1009,6 +1009,11 @@ struct chimera_vfs_mount {
     uint8_t                        root_fh[CHIMERA_VFS_FH_SIZE + 16];
 };
 
+enum chimera_vfs_delegation_mode {
+    CHIMERA_VFS_DELEGATION_SYNC,
+    CHIMERA_VFS_DELEGATION_ASYNC,
+};
+
 struct chimera_vfs_delegation_thread {
     struct evpl                *evpl;
     struct chimera_vfs         *vfs;
@@ -1017,6 +1022,8 @@ struct chimera_vfs_delegation_thread {
     struct chimera_vfs_request *requests;
     pthread_mutex_t             lock;
     struct evpl_doorbell        doorbell;
+    enum chimera_vfs_delegation_mode mode;
+    struct evpl_poll           *poll;
 };
 
 struct chimera_vfs_close_thread {
@@ -1048,8 +1055,10 @@ struct chimera_vfs {
     struct chimera_vfs_user_cache        *vfs_user_cache;
     struct chimera_vfs_notify            *vfs_notify;
     struct chimera_vfs_mount_table       *mount_table;
-    int                                   num_delegation_threads;
-    struct chimera_vfs_delegation_thread *delegation_threads;
+    int                                   num_sync_delegation_threads;
+    struct chimera_vfs_delegation_thread *sync_delegation_threads;
+    int                                   num_async_delegation_threads;
+    struct chimera_vfs_delegation_thread *async_delegation_threads;
     struct chimera_vfs_close_thread       close_thread;
     struct chimera_vfs_metrics            metrics;
     int                                   machine_name_len;
@@ -1083,7 +1092,8 @@ struct chimera_vfs_module_cfg {
 
 struct chimera_vfs *
 chimera_vfs_init(
-    int                                  num_delegation_threads,
+    int                                  num_sync_delegation_threads,
+    int                                  num_async_delegation_threads,
     const struct chimera_vfs_module_cfg *module_cfgs,
     int                                  num_modules,
     const char                          *kv_module_name,

--- a/src/vfs/vfs_internal.h
+++ b/src/vfs/vfs_internal.h
@@ -350,6 +350,21 @@ chimera_vfs_complete_delegate(struct chimera_vfs_request *request)
 } /* chimera_vfs_complete_delegate */
 
 static inline void
+chimera_vfs_post_to_delegation(
+    struct chimera_vfs_request           *request,
+    struct chimera_vfs_delegation_thread *delegation_thread)
+{
+    request->complete_delegate = request->complete;
+    request->complete          = chimera_vfs_complete_delegate;
+
+    pthread_mutex_lock(&delegation_thread->lock);
+    DL_APPEND(delegation_thread->requests, request);
+    pthread_mutex_unlock(&delegation_thread->lock);
+
+    evpl_ring_doorbell(&delegation_thread->doorbell);
+} /* chimera_vfs_post_to_delegation */
+
+static inline void
 chimera_vfs_dispatch(struct chimera_vfs_request *request)
 {
     struct chimera_vfs_thread            *thread = request->thread;
@@ -367,19 +382,13 @@ chimera_vfs_dispatch(struct chimera_vfs_request *request)
     }
 
     if (module->capabilities & CHIMERA_VFS_CAP_BLOCKING) {
-        thread_id = request->fh_hash % vfs->num_delegation_threads;
-
-        request->complete_delegate = request->complete;
-        request->complete          = chimera_vfs_complete_delegate;
-
-        delegation_thread = &vfs->delegation_threads[thread_id];
-
-        pthread_mutex_lock(&delegation_thread->lock);
-        DL_APPEND(delegation_thread->requests, request);
-        pthread_mutex_unlock(&delegation_thread->lock);
-
-        evpl_ring_doorbell(&delegation_thread->doorbell);
-
+        thread_id         = request->fh_hash % vfs->num_sync_delegation_threads;
+        delegation_thread = &vfs->sync_delegation_threads[thread_id];
+        chimera_vfs_post_to_delegation(request, delegation_thread);
+    } else if (vfs->num_async_delegation_threads > 0) {
+        thread_id         = request->fh_hash % vfs->num_async_delegation_threads;
+        delegation_thread = &vfs->async_delegation_threads[thread_id];
+        chimera_vfs_post_to_delegation(request, delegation_thread);
     } else {
         module->dispatch(request, thread->module_private[module->fh_magic]);
     }

--- a/src/vfs/vfs_notify.c
+++ b/src/vfs/vfs_notify.c
@@ -486,7 +486,7 @@ chimera_vfs_notify_resolve(struct chimera_vfs_notify_pending_event *pev)
 
         /* Cache miss — issue async getparent.
          * The callback will continue the resolve loop. */
-        chimera_vfs_getparent(notify->vfs->delegation_threads[0].vfs_thread,
+        chimera_vfs_getparent(notify->vfs->sync_delegation_threads[0].vfs_thread,
                               NULL, /* cred — internal operation */
                               pev->walk_fh,
                               pev->walk_fh_len,


### PR DESCRIPTION
## Summary

Introduces a third VFS thread pool that offloads dispatch of non-BLOCKING backends off the core (network) threads, with brief CPU spinning after each request to keep threads on-CPU under bursty load.

- New `async_delegation` boolean config (default `false`) and `async_delegation_threads` count (default `8`).
- When enabled, dispatch of non-BLOCKING backends (memfs / demofs / io_uring / nfs) is steered into the async pool by file-handle hash, the same way the existing pool steers BLOCKING backends.
- Async-mode threads register an `evpl_add_poll` callback so each doorbell wake puts the thread in libevpl's poll mode, spinning for `spin_ns` (~1ms default) before sleeping.
- Renames the existing `delegation_threads` config / `num_delegation_threads` struct field / `chimera_server_config_set_delegation_threads` setter to `sync_delegation_threads` for symmetry. **Breaking config rename** — old `delegation_threads` keys must be updated.
- Bumps the `ext/libevpl` submodule to pick up [chimera-nas/libevpl#39](https://github.com/chimera-nas/libevpl/pull/39), which exposes the public `evpl_add_poll` / `evpl_remove_poll` API this change depends on.

## Routing

`chimera_vfs_dispatch` now branches:

```
if (module is BLOCKING)              -> sync delegation pool
else if (async_delegation enabled)   -> async delegation pool
else                                  -> inline on caller thread
```

Both pools share `struct chimera_vfs_delegation_thread` with a `mode` field set at init; the only behavioral difference is the `evpl_add_poll` registration on async threads.

## Tests

Adds `src/vfs/tests/vfs_async_delegation_test.c`:

- Spawns a VFS with `num_async_delegation_threads=4` and memfs.
- Inserts 32 distinct keys; runs a single-key search per key and captures `pthread_self()` from the per-entry callback (which runs inside the module dispatch).
- Asserts:
  - No dispatch ran on the caller thread.
  - Same key hashes back to the same dispatch thread (affinity).
  - At least 2 dispatch threads are exercised across the 32 keys (in practice all 4 are used).
- Re-runs the same flow with `num_async_delegation_threads=0` and verifies dispatch falls back to the caller thread.

`make check` clean: build + test (debug + release), `scan-build`, uncrustify, reuse-lint.