### PR TITLE
call-claude: drop serena, enable clangd-lsp plugin

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,6 +3,9 @@
     "commit": "",
     "pr": ""
   },
+  "enabledPlugins": {
+    "clangd-lsp@claude-plugins-official": true
+  },
   "permissions": {
     "allow": [
       "Bash(ctest:*)",
@@ -15,8 +18,7 @@
       "Bash(reuse:*)",
       "Read(/build/**)",
       "Write(/build/**)",
-      "Edit(/build/**)",
-      "mcp__serena__*"
+      "Edit(/build/**)"
     ]
   }
 }

--- a/call-claude
+++ b/call-claude
@@ -220,18 +220,6 @@ setup_worktree_pr() {
     echo "$worktree_path"
 }
 
-setup_serena() {
-    local worktree_path="$1"
-
-    echo "Configuring Serena MCP server for $worktree_path..." >&2
-    (cd "$worktree_path" && claude mcp add \
-        --scope local \
-        serena \
-        -- \
-        uvx --from git+https://github.com/oraios/serena \
-        serena start-mcp-server --project "$worktree_path") >&2
-}
-
 setup_claude_permissions() {
     local worktree_path="$1"
     local claude_dir="$worktree_path/.claude"
@@ -289,9 +277,8 @@ case "$MODE" in
         ;;
 esac
 
-# Configure Claude Code permissions and Serena MCP server for the worktree
+# Configure Claude Code permissions for the worktree
 setup_claude_permissions "$WORKTREE_PATH"
-setup_serena "$WORKTREE_PATH"
 
 # Launch Claude Code in the worktree
 # Note: Claude will show a one-time trust dialog for new worktrees

--- a/call-claude
+++ b/call-claude
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+# SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 #
 # SPDX-License-Identifier: Unlicense
 


### PR DESCRIPTION
## Summary
- Remove the `setup_serena` helper and its invocation from `call-claude` so new worktrees no longer register the serena MCP server.
- In `.claude/settings.json`, enable the official `clangd-lsp@claude-plugins-official` plugin and drop the now-unused `mcp__serena__*` permission entry.