### PR TITLE
Add tcp_flavor configuration to select TCP transport backend

### DIFF
--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -4,6 +4,8 @@
 
 #include <stdio.h>
 #include <signal.h>
+#include <string.h>
+#include <strings.h>
 #include <sys/stat.h>
 #include <unistd.h>
 #include <jansson.h>
@@ -245,6 +247,32 @@ main(
     evpl_global_config_set_huge_pages(evpl_global_config, 1);
     evpl_global_config_set_libaio_max_pending(evpl_global_config, 1024);
 
+    /* Only enable XLIO in libevpl when we actually plan to use it.
+     * libevpl defaults xlio_enabled=1 and starts XLIO's polling
+     * machinery in every worker thread regardless of whether any
+     * socket binds to EVPL_STREAM_XLIO_TCP — that's pure overhead
+     * for plain-TCP and RDMA deployments.
+     */
+    {
+        enum chimera_tcp_flavor flavor = CHIMERA_TCP_FLAVOR_PLAIN;
+        json_t                 *flavor_value;
+
+        if (server_params) {
+            flavor_value = json_object_get(server_params, "tcp_flavor");
+            if (flavor_value && json_is_string(flavor_value)) {
+                const char *s = json_string_value(flavor_value);
+                if (strcasecmp(s, "xlio") == 0) {
+                    flavor = CHIMERA_TCP_FLAVOR_XLIO;
+                } else if (strcasecmp(s, "io_uring") == 0) {
+                    flavor = CHIMERA_TCP_FLAVOR_IO_URING;
+                }
+            }
+        }
+
+        evpl_global_config_set_xlio_enabled(evpl_global_config,
+                                            flavor == CHIMERA_TCP_FLAVOR_XLIO);
+    }
+
     /* Configure TLS if HTTPS is enabled */
     if (rest_https_port != 0) {
         if (rest_ssl_cert && rest_ssl_key) {
@@ -359,6 +387,20 @@ main(
     json_value = json_object_get(server_params, "soft_fail_bad_req");
     if (json_is_true(json_value)) {
         chimera_server_config_set_soft_fail_bad_req(server_config, 1);
+    }
+
+    json_value = json_object_get(server_params, "tcp_flavor");
+    if (json_is_string(json_value)) {
+        str_value = json_string_value(json_value);
+        if (strcasecmp(str_value, "plain") == 0) {
+            chimera_server_config_set_tcp_flavor(server_config, CHIMERA_TCP_FLAVOR_PLAIN);
+        } else if (strcasecmp(str_value, "io_uring") == 0) {
+            chimera_server_config_set_tcp_flavor(server_config, CHIMERA_TCP_FLAVOR_IO_URING);
+        } else if (strcasecmp(str_value, "xlio") == 0) {
+            chimera_server_config_set_tcp_flavor(server_config, CHIMERA_TCP_FLAVOR_XLIO);
+        } else {
+            chimera_server_error("Unknown tcp_flavor '%s', defaulting to plain", str_value);
+        }
     }
 
     // Parse SMB auth configuration

--- a/src/server/nfs/nfs.c
+++ b/src/server/nfs/nfs.c
@@ -245,7 +245,9 @@ nfs_server_start(void *arg)
     struct chimera_server_nfs_shared *shared = arg;
     enum evpl_protocol_id             rdma_protocol;
 
-    evpl_rpc2_server_start(shared->nfs_server, EVPL_STREAM_SOCKET_TCP, shared->nfs_endpoint);
+    evpl_rpc2_server_start(shared->nfs_server,
+                           chimera_server_config_get_tcp_stream_protocol(shared->config),
+                           shared->nfs_endpoint);
 
     if (shared->nfs_rdma_endpoint) {
         /* Use TCP-RDMA emulation when nfs_tcp_rdma_port > 0, otherwise use native RDMA */

--- a/src/server/s3/s3.c
+++ b/src/server/s3/s3.c
@@ -9,6 +9,7 @@
 #include "evpl/evpl.h"
 #include "evpl/evpl_http.h"
 #include "server/protocol.h"
+#include "server/server.h"
 #include "common/macros.h"
 #include "common/misc.h"
 #include "s3_internal.h"
@@ -571,6 +572,8 @@ s3_server_init(
 
     shared->config = calloc(1, sizeof(*shared->config));
 
+    shared->tcp_protocol = chimera_server_config_get_tcp_stream_protocol(config);
+
     shared->config->port    = 5000;
     shared->config->io_size = 128 * 1024;
 
@@ -619,7 +622,7 @@ s3_server_start(void *data)
 {
     struct chimera_server_s3_shared *shared = data;
 
-    evpl_listen(shared->listener, EVPL_STREAM_SOCKET_TCP, shared->endpoint);
+    evpl_listen(shared->listener, shared->tcp_protocol, shared->endpoint);
 } /* s3_server_start */
 
 static void *

--- a/src/server/s3/s3_internal.h
+++ b/src/server/s3/s3_internal.h
@@ -115,6 +115,7 @@ struct chimera_server_s3_shared {
     struct chimera_s3_cred_cache *cred_cache;
     struct evpl_endpoint         *endpoint;
     struct evpl_listener         *listener;
+    enum evpl_protocol_id         tcp_protocol;
     struct chimera_vfs_cred       cred;
     uint32_t                      root_fh_len;
     uint8_t                       root_fh[CHIMERA_VFS_FH_SIZE];

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -52,6 +52,7 @@ struct chimera_server_config {
     int                                   smb_num_nic_info;
     uint32_t                              anonuid;
     uint32_t                              anongid;
+    enum chimera_tcp_flavor               tcp_flavor;
     char                                  nfs_rdma_hostname[256];
     char                                  kv_module[64];
     char                                  state_dir[256];
@@ -99,6 +100,7 @@ chimera_server_config_init(void)
     config->nfs_rdma           = 0;
     config->external_portmap   = 0;
     config->soft_fail_bad_req  = 0;
+    config->tcp_flavor         = CHIMERA_TCP_FLAVOR_PLAIN;
 
     config->smb_num_dialects = 2;
     config->smb_dialects[0]  = SMB2_DIALECT_2_1;
@@ -476,6 +478,34 @@ chimera_server_config_get_soft_fail_bad_req(const struct chimera_server_config *
 {
     return config->soft_fail_bad_req;
 } /* chimera_server_config_get_soft_fail_bad_req */
+
+SYMBOL_EXPORT void
+chimera_server_config_set_tcp_flavor(
+    struct chimera_server_config *config,
+    enum chimera_tcp_flavor       flavor)
+{
+    config->tcp_flavor = flavor;
+} /* chimera_server_config_set_tcp_flavor */
+
+SYMBOL_EXPORT enum chimera_tcp_flavor
+chimera_server_config_get_tcp_flavor(const struct chimera_server_config *config)
+{
+    return config->tcp_flavor;
+} /* chimera_server_config_get_tcp_flavor */
+
+SYMBOL_EXPORT enum evpl_protocol_id
+chimera_server_config_get_tcp_stream_protocol(const struct chimera_server_config *config)
+{
+    switch (config->tcp_flavor) {
+        case CHIMERA_TCP_FLAVOR_IO_URING:
+            return EVPL_STREAM_IO_URING_TCP;
+        case CHIMERA_TCP_FLAVOR_XLIO:
+            return EVPL_STREAM_XLIO_TCP;
+        case CHIMERA_TCP_FLAVOR_PLAIN:
+        default:
+            return EVPL_STREAM_SOCKET_TCP;
+    } /* switch */
+} /* chimera_server_config_get_tcp_stream_protocol */
 
 static void
 chimera_server_thread_wake(

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -31,10 +31,29 @@ struct chimera_server_config_smb_nic {
     uint8_t  rdma;
 };
 
+enum chimera_tcp_flavor {
+    CHIMERA_TCP_FLAVOR_PLAIN    = 0,
+    CHIMERA_TCP_FLAVOR_IO_URING = 1,
+    CHIMERA_TCP_FLAVOR_XLIO     = 2,
+};
+
 
 struct chimera_server_config *
 chimera_server_config_init(
     void);
+
+void
+chimera_server_config_set_tcp_flavor(
+    struct chimera_server_config *config,
+    enum chimera_tcp_flavor       flavor);
+
+enum chimera_tcp_flavor
+chimera_server_config_get_tcp_flavor(
+    const struct chimera_server_config *config);
+
+enum evpl_protocol_id
+chimera_server_config_get_tcp_stream_protocol(
+    const struct chimera_server_config *config);
 
 void
 chimera_server_config_set_core_threads(

--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -67,6 +67,8 @@ chimera_smb_server_init(
         return NULL;
     }
 
+    shared->tcp_protocol = chimera_server_config_get_tcp_stream_protocol(config);
+
     shared->config.port      = 445;
     shared->config.rdma_port = 445;
 
@@ -231,7 +233,7 @@ chimera_smb_server_start(void *data)
 {
     struct chimera_server_smb_shared *shared = data;
 
-    evpl_listen(shared->listener, EVPL_STREAM_SOCKET_TCP, shared->endpoint);
+    evpl_listen(shared->listener, shared->tcp_protocol, shared->endpoint);
 
     if (shared->endpoint_rdma) {
         evpl_listen(shared->listener, EVPL_DATAGRAM_RDMACM_RC, shared->endpoint_rdma);

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -536,6 +536,7 @@ struct chimera_smb_conn {
 struct chimera_server_smb_shared {
     struct chimera_smb_config   config;
     int                         rdma;
+    enum evpl_protocol_id       tcp_protocol;
     uint8_t                     guid[SMB2_GUID_SIZE];
     gss_name_t                  svc;
     gss_cred_id_t               srv_cred;


### PR DESCRIPTION
## Summary

Adds a \`tcp_flavor\` option to chimera's server config that selects which libevpl stream protocol is used for the NFS, SMB, and S3 listeners:

| Value | libevpl protocol | Notes |
|---|---|---|
| \`plain\` (default) | \`EVPL_STREAM_SOCKET_TCP\` | Kernel TCP. Unchanged behavior. |
| \`io_uring\` | \`EVPL_STREAM_IO_URING_TCP\` | io_uring-accelerated TCP |
| \`xlio\` | \`EVPL_STREAM_XLIO_TCP\` | NVIDIA XLIO kernel-bypass TCP |

Set via JSON:

\`\`\`json
{
    \"server\": {
        \"tcp_flavor\": \"plain\"
    }
}
\`\`\`

## Scope

- Only the **NFS data server**, **SMB listener**, and **S3 listener** observe \`tcp_flavor\`.
- **Mount, NLM, portmap, REST, and metrics** listeners stay on plain TCP regardless — those are control paths where accelerated transport adds complexity without measurable benefit.

## Side effect: XLIO disabled when not used

In \`daemon.c\` we now call \`evpl_global_config_set_xlio_enabled(false)\` whenever the flavor isn't \`xlio\`. libevpl defaults \`xlio_enabled=1\` and starts XLIO's polling machinery in every worker thread regardless of whether any socket actually binds to \`EVPL_STREAM_XLIO_TCP\` — leaving it enabled costs noticeable CPU (~25% of total worker CPU in profile traces) for plain-TCP and RDMA-only deployments.

## Files

- \`src/server/server.h\` — new \`enum chimera_tcp_flavor\` + setter/getter/protocol-resolver declarations
- \`src/server/server.c\` — config field, default, implementation
- \`src/daemon/daemon.c\` — JSON parsing + early-init XLIO-enabled conditional
- \`src/server/nfs/nfs.c\` — main NFS RPC server uses the resolved protocol
- \`src/server/smb/smb.c\` / \`smb_internal.h\` — SMB listener uses the resolved protocol
- \`src/server/s3/s3.c\` / \`s3_internal.h\` — S3 listener uses the resolved protocol

## Test

All 1839 tests pass (\`make test_release\`).