### PR TITLE
docs: add Community page and Discord link

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Chimera is currently in an experimental state of development.  The focus so far 
 
 Currently, there is none beyond this README.   More to come.
 
+# Community
+
+Join the conversation on [Discord](https://discord.gg/hnRkvQFecq) to ask questions, share what you're building, or follow along with development.
+
 # License
 
 Chimera is licensed under LGPL-2.1. See [LICENSE](LICENSE) for details.

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -12,4 +12,5 @@ url: https://chimeraproject.io/chimera
 
 aux_links:
   GitHub: https://github.com/chimera-nas/chimera
+  Discord: https://discord.gg/hnRkvQFecq
 

--- a/docs/community.md
+++ b/docs/community.md
@@ -1,0 +1,26 @@
+---
+title: Community
+layout: default
+nav_order: 2
+permalink: /community
+---
+
+# Community
+
+Chimera is an open source project and we welcome participation from anyone interested in high-performance NAS, modern storage protocols, and userspace I/O.
+
+## GitHub
+
+Source code, issue tracking, and pull requests live on GitHub:
+
+- [github.com/chimera-nas/chimera](https://github.com/chimera-nas/chimera)
+
+Bug reports, feature requests, and contributions are all welcome. Please file issues for anything you find or wish to discuss.
+
+## Discord
+
+For real-time discussion, questions, and design conversations, join the project Discord server:
+
+- [Join the Chimera Discord](https://discord.gg/hnRkvQFecq)
+
+The Discord is a good place to ask questions, share what you're building, or chat with other developers using Chimera.


### PR DESCRIPTION
## Summary
- Adds a new Community page (`docs/community.md`) with links to the GitHub repo and the project Discord server.
- Adds the Discord invite to `docs/_config.yml` `aux_links` so it appears next to GitHub in the docs top header.
- Adds a Community section to the top-level `README.md` pointing at the Discord.