### PR TITLE
Expose libevpl allocator preallocation knobs in server JSON config

### DIFF
--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -273,6 +273,21 @@ main(
                                             flavor == CHIMERA_TCP_FLAVOR_XLIO);
     }
 
+    if (server_params) {
+        json_t *prealloc_slabs_value   = json_object_get(server_params, "preallocate_slabs");
+        json_t *prealloc_threads_value = json_object_get(server_params, "preallocate_threads");
+
+        if (prealloc_slabs_value && json_is_integer(prealloc_slabs_value)) {
+            evpl_global_config_set_preallocate_slabs(evpl_global_config,
+                                                     json_integer_value(prealloc_slabs_value));
+        }
+
+        if (prealloc_threads_value && json_is_integer(prealloc_threads_value)) {
+            evpl_global_config_set_preallocate_threads(evpl_global_config,
+                                                       json_integer_value(prealloc_threads_value));
+        }
+    }
+
     /* Configure TLS if HTTPS is enabled */
     if (rest_https_port != 0) {
         if (rest_ssl_cert && rest_ssl_key) {


### PR DESCRIPTION
## Summary

Reads two new optional integer fields from \`server\` in the JSON config and forwards them to libevpl's allocator at \`evpl_init\` time:

\`\`\`json
{
    \"server\": {
        \"preallocate_slabs\":   16,
        \"preallocate_threads\":  4
    }
}
\`\`\`

| Key | Meaning |
|---|---|
| \`preallocate_slabs\` | Target number of free slabs to keep ready in the allocator pool. |
| \`preallocate_threads\` | Size of the producer-thread pool that builds slabs ahead of demand. |

Both default to **0** (no preallocation; current behavior unchanged).

If \`preallocate_slabs\` is set but \`preallocate_threads\` is left at 0, libevpl defaults it to 1.

## Bumps libevpl

Picks up the underlying allocator changes from libevpl PRs:

- chimera-nas/libevpl#42 — preallocator threads, slab prefault, per-thread shared cache, allocator metrics
- chimera-nas/libevpl#44 — only prefault slabs when built by a preallocator thread

## When to set it

For workloads where the allocator grows its slab pool on demand during traffic (e.g. cold-cache benchmarks), setting \`preallocate_slabs\` keeps slab \`mmap\` + \`ibv_reg_mr\` + hugepage faults off the IO hot path. For low-volume / test deployments, leaving these unset is correct.

## Test

\`make test_release\` passes (one transient port-collision in \`smbclient_winbind\` resolved on retry).