### PR TITLE
Gate copyright-year check on pull_request events

### DIFF
--- a/.github/workflows/reuse-compliance.yml
+++ b/.github/workflows/reuse-compliance.yml
@@ -33,5 +33,6 @@ jobs:
         reuse lint
 
     - name: Check copyright years
+      if: github.event_name == 'pull_request'
       run: |
         bash etc/copyright-year.sh --check --base origin/${{ github.base_ref }}

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+# SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
 #
 # SPDX-License-Identifier: Unlicense
 


### PR DESCRIPTION
github.base_ref is only populated for pull_request and pull_request_target events. On push runs (e.g. push to main) it expands to an empty string, so the Check copyright years step invoked the script with --base origin/, which is not a valid ref and caused the workflow to fail.

Add an if: github.event_name == 'pull_request' guard so the step runs only when a base ref is available; the reuse lint step still runs on every push as before.