### PR TITLE
Plumb mount options string from server JSON config through to the VFS

### DIFF
--- a/src/client/tests/client_test_common.h
+++ b/src/client/tests/client_test_common.h
@@ -175,20 +175,20 @@ client_test_init(
         env->server = chimera_server_init(server_config, env->server_metrics);
 
         if (strcmp(backend, "linux") == 0) {
-            chimera_server_mount(env->server, "share", "linux", env->session_dir);
+            chimera_server_mount(env->server, "share", "linux", env->session_dir, NULL);
 
         } else if (strcmp(backend, "io_uring") == 0) {
-            chimera_server_mount(env->server, "share", "io_uring", env->session_dir);
+            chimera_server_mount(env->server, "share", "io_uring", env->session_dir, NULL);
 
         } else if (strcmp(backend, "memfs") == 0) {
-            chimera_server_mount(env->server, "share", "memfs", "/");
+            chimera_server_mount(env->server, "share", "memfs", "/", NULL);
 
         } else if (strcmp(backend, "demofs_io_uring") == 0 ||
                    strcmp(backend, "demofs_aio") == 0) {
-            chimera_server_mount(env->server, "share", "demofs", "/");
+            chimera_server_mount(env->server, "share", "demofs", "/", NULL);
 
         } else if (strcmp(backend, "cairn") == 0) {
-            chimera_server_mount(env->server, "share", "cairn", "/");
+            chimera_server_mount(env->server, "share", "cairn", "/", NULL);
         } else {
             fprintf(stderr, "Unknown backend: %s\n", backend);
             exit(EXIT_FAILURE);

--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -507,12 +507,17 @@ main(
     if (mounts) {
         json_object_foreach(mounts, name, mount)
         {
-            module = json_string_value(json_object_get(mount, "module"));
-            path   = json_string_value(json_object_get(mount, "path"));
+            const char *mount_options;
 
-            chimera_server_info("Mounting %s://%s to /%s...",
-                                module, path, name);
-            chimera_server_mount(server, name, module, path);
+            module        = json_string_value(json_object_get(mount, "module"));
+            path          = json_string_value(json_object_get(mount, "path"));
+            mount_options = json_string_value(json_object_get(mount, "options"));
+
+            chimera_server_info("Mounting %s://%s to /%s%s%s...",
+                                module, path, name,
+                                mount_options ? " options=" : "",
+                                mount_options ? mount_options : "");
+            chimera_server_mount(server, name, module, path, mount_options);
         }
     }
 

--- a/src/posix/tests/fsx.c
+++ b/src/posix/tests/fsx.c
@@ -4001,19 +4001,19 @@ main(
                 char fsx_dir[512];
                 snprintf(fsx_dir, sizeof(fsx_dir), "%s/fsx", chimera_session_dir);
                 (void) mkdir(fsx_dir, 0755);
-                chimera_server_mount(chimera_server, "share", "linux", chimera_session_dir);
+                chimera_server_mount(chimera_server, "share", "linux", chimera_session_dir, NULL);
             } else if (strcmp(chimera_nfs_backend, "io_uring") == 0) {
                 char fsx_dir[512];
                 snprintf(fsx_dir, sizeof(fsx_dir), "%s/fsx", chimera_session_dir);
                 (void) mkdir(fsx_dir, 0755);
-                chimera_server_mount(chimera_server, "share", "io_uring", chimera_session_dir);
+                chimera_server_mount(chimera_server, "share", "io_uring", chimera_session_dir, NULL);
             } else if (strcmp(chimera_nfs_backend, "memfs") == 0) {
-                chimera_server_mount(chimera_server, "share", "memfs", "/");
+                chimera_server_mount(chimera_server, "share", "memfs", "/", NULL);
             } else if (strcmp(chimera_nfs_backend, "demofs_io_uring") == 0 ||
                        strcmp(chimera_nfs_backend, "demofs_aio") == 0) {
-                chimera_server_mount(chimera_server, "share", "demofs", "/");
+                chimera_server_mount(chimera_server, "share", "demofs", "/", NULL);
             } else if (strcmp(chimera_nfs_backend, "cairn") == 0) {
-                chimera_server_mount(chimera_server, "share", "cairn", "/");
+                chimera_server_mount(chimera_server, "share", "cairn", "/", NULL);
             } else {
                 fprintf(stderr, "Unknown NFS backend: %s\n", chimera_nfs_backend);
                 exit(100);

--- a/src/posix/tests/posix_test_common.h
+++ b/src/posix/tests/posix_test_common.h
@@ -173,15 +173,15 @@ posix_test_start_nfs_server(struct posix_test_env *env)
     env->server = chimera_server_init(server_config, env->metrics);
 
     if (strcmp(nfs_backend_name, "linux") == 0) {
-        chimera_server_mount(env->server, "share", "linux", env->session_dir);
+        chimera_server_mount(env->server, "share", "linux", env->session_dir, NULL);
     } else if (strcmp(nfs_backend_name, "io_uring") == 0) {
-        chimera_server_mount(env->server, "share", "io_uring", env->session_dir);
+        chimera_server_mount(env->server, "share", "io_uring", env->session_dir, NULL);
     } else if (strcmp(nfs_backend_name, "memfs") == 0) {
-        chimera_server_mount(env->server, "share", "memfs", "/");
+        chimera_server_mount(env->server, "share", "memfs", "/", NULL);
     } else if (posix_test_is_demofs(nfs_backend_name)) {
-        chimera_server_mount(env->server, "share", "demofs", "/");
+        chimera_server_mount(env->server, "share", "demofs", "/", NULL);
     } else if (strcmp(nfs_backend_name, "cairn") == 0) {
-        chimera_server_mount(env->server, "share", "cairn", "/");
+        chimera_server_mount(env->server, "share", "cairn", "/", NULL);
     } else {
         fprintf(stderr, "Unknown NFS backend: %s\n", nfs_backend_name);
         exit(EXIT_FAILURE);

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -544,7 +544,8 @@ chimera_server_mount(
     struct chimera_server *server,
     const char            *mount_path,
     const char            *module_name,
-    const char            *module_path)
+    const char            *module_path,
+    const char            *options)
 {
     struct evpl               *evpl;
     struct chimera_vfs_thread *thread;
@@ -554,7 +555,7 @@ chimera_server_mount(
 
     thread = chimera_vfs_thread_init(evpl, server->vfs);
 
-    chimera_vfs_mount(thread, NULL, mount_path, module_name, module_path, NULL, chimera_server_mount_callback, &ctx);
+    chimera_vfs_mount(thread, NULL, mount_path, module_name, module_path, options, chimera_server_mount_callback, &ctx);
 
     while (!ctx.done) {
         evpl_continue(evpl);

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -241,7 +241,8 @@ chimera_server_mount(
     struct chimera_server *server,
     const char            *mount_path,
     const char            *module_name,
-    const char            *module_path);
+    const char            *module_path,
+    const char            *options);
 
 int
 chimera_server_create_bucket(

--- a/src/server/smb/tests/rest_user_manip_test.c
+++ b/src/server/smb/tests/rest_user_manip_test.c
@@ -351,8 +351,8 @@ main(
     /* Mount VFS backends:
      * - "share" for user tests (pre-existing share)
      * - "testvfs" for share tests (shares created dynamically via REST) */
-    chimera_server_mount(server, "share", "memfs", "/");
-    chimera_server_mount(server, "testvfs", "memfs", "/");
+    chimera_server_mount(server, "share", "memfs", "/", NULL);
+    chimera_server_mount(server, "testvfs", "memfs", "/", NULL);
 
     /* Create the "share" SMB share for user tests */
     chimera_server_create_share(server, "share", "share");

--- a/src/server/smb/tests/smbclient_auth_test.c
+++ b/src/server/smb/tests/smbclient_auth_test.c
@@ -802,9 +802,9 @@ main(
 
     /* Mount filesystem */
     if (strcmp(backend, "memfs") == 0) {
-        chimera_server_mount(env.server, "share", "memfs", "/");
+        chimera_server_mount(env.server, "share", "memfs", "/", NULL);
     } else if (strcmp(backend, "linux") == 0) {
-        chimera_server_mount(env.server, "share", "linux", env.session_dir);
+        chimera_server_mount(env.server, "share", "linux", env.session_dir, NULL);
     } else {
         fprintf(stderr, "Unknown backend: %s\n", backend);
         test_cleanup(&env, 0);


### PR DESCRIPTION
## Summary

\`chimera_vfs_mount()\` has long accepted an \`options\` string that gets parsed into a \`chimera_vfs_mount_options\` struct and handed to the backend module — but \`chimera_server_mount()\` ignored the parameter and always passed NULL, so there was no way to actually configure a mount from the JSON config.

This change wires the plumbing:

- \`chimera_server_mount()\` gains an \`options\` parameter and forwards it to \`chimera_vfs_mount()\`.
- The daemon reads an optional \`options\` string from each entry in the \`mounts\` JSON object and passes it through.
- All existing callers (the various test harnesses) are updated to pass \`NULL\`, preserving current behavior.

## Example

\`\`\`json
{
    \"mounts\": {
        \"data\": {
            \"module\": \"memfs\",
            \"path\": \"/\",
            \"options\": \"size=64,preallocate\"
        }
    }
}
\`\`\`

The string format and semantics are defined by the receiving backend. No backend currently consumes any options (memfs continues to ignore unknown keys); this PR only adds the plumbing so future backend-specific options have a way through.

## Test

All 1839 \`make test_release\` tests pass.