### PR TITLE
Add server-side byte-range COPY, CLONE, and MOVE VFS ops

### DIFF
--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -6,7 +6,8 @@ add_library(chimera_client SHARED client.c client_dispatch.c
             client_mount.c client_umount.c
             client_open.c client_mkdir.c client_mknod.c client_close.c client_read.c client_write.c
             client_symlink.c client_link.c client_remove.c client_rename.c
-            client_readlink.c client_stat.c client_readdir.c client_statfs.c)
+            client_readlink.c client_stat.c client_readdir.c client_statfs.c
+            client_copy_range.c client_clone_range.c)
 target_link_libraries(chimera_client chimera_vfs evpl prometheus-c jansson)
 
 install(TARGETS chimera_client DESTINATION lib)

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -202,6 +202,46 @@ chimera_close(
     struct chimera_client_thread   *thread,
     struct chimera_vfs_open_handle *oh);
 
+typedef void (*chimera_copy_range_callback_t)(
+    struct chimera_client_thread *thread,
+    enum chimera_vfs_error        status,
+    uint64_t                      bytes_copied,
+    void                         *private_data);
+
+/* Server-side byte-range copy. Both handles must be served by a backend
+ * that advertises CHIMERA_VFS_CAP_COPY_RANGE (and currently must be the
+ * same backend).
+ */
+void
+chimera_copy_range(
+    struct chimera_client_thread   *thread,
+    struct chimera_vfs_open_handle *src_handle,
+    uint64_t                        src_offset,
+    struct chimera_vfs_open_handle *dst_handle,
+    uint64_t                        dst_offset,
+    uint64_t                        length,
+    chimera_copy_range_callback_t   callback,
+    void                           *private_data);
+
+typedef void (*chimera_clone_range_callback_t)(
+    struct chimera_client_thread *thread,
+    enum chimera_vfs_error        status,
+    void                         *private_data);
+
+/* Reflink-style share of a byte range. Requires CHIMERA_VFS_CAP_CLONE_RANGE
+ * on the destination backend; will surface ENOTSUP otherwise.
+ */
+void
+chimera_clone_range(
+    struct chimera_client_thread   *thread,
+    struct chimera_vfs_open_handle *src_handle,
+    uint64_t                        src_offset,
+    struct chimera_vfs_open_handle *dst_handle,
+    uint64_t                        dst_offset,
+    uint64_t                        length,
+    chimera_clone_range_callback_t  callback,
+    void                           *private_data);
+
 typedef void (*chimera_symlink_callback_t)(
     struct chimera_client_thread *client,
     enum chimera_vfs_error        status,

--- a/src/client/client_clone_range.c
+++ b/src/client/client_clone_range.c
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "client_clone_range.h"
+
+SYMBOL_EXPORT void
+chimera_clone_range(
+    struct chimera_client_thread   *thread,
+    struct chimera_vfs_open_handle *src_handle,
+    uint64_t                        src_offset,
+    struct chimera_vfs_open_handle *dst_handle,
+    uint64_t                        dst_offset,
+    uint64_t                        length,
+    chimera_clone_range_callback_t  callback,
+    void                           *private_data)
+{
+    struct chimera_client_request *request;
+
+    request = chimera_client_request_alloc(thread);
+
+    request->opcode                   = CHIMERA_CLIENT_OP_CLONE_RANGE;
+    request->clone_range.callback     = callback;
+    request->clone_range.private_data = private_data;
+    request->clone_range.src_handle   = src_handle;
+    request->clone_range.dst_handle   = dst_handle;
+    request->clone_range.src_offset   = src_offset;
+    request->clone_range.dst_offset   = dst_offset;
+    request->clone_range.length       = length;
+
+    chimera_dispatch_clone_range(thread, request);
+} /* chimera_clone_range */

--- a/src/client/client_clone_range.h
+++ b/src/client/client_clone_range.h
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#pragma once
+
+#include "client_internal.h"
+
+static void
+chimera_clone_range_complete(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *pre_attr,
+    struct chimera_vfs_attrs *post_attr,
+    void                     *private_data)
+{
+    struct chimera_client_request *request        = private_data;
+    struct chimera_client_thread  *client_thread  = request->thread;
+    chimera_clone_range_callback_t callback       = request->clone_range.callback;
+    void                          *callback_arg   = request->clone_range.private_data;
+    int                            heap_allocated = request->heap_allocated;
+
+    if (heap_allocated) {
+        chimera_client_request_free(client_thread, request);
+    }
+
+    callback(client_thread, error_code, callback_arg);
+} /* chimera_clone_range_complete */
+
+static inline void
+chimera_dispatch_clone_range(
+    struct chimera_client_thread  *thread,
+    struct chimera_client_request *request)
+{
+    chimera_vfs_clone_range(
+        thread->vfs_thread,
+        &thread->client->cred,
+        request->clone_range.src_handle,
+        request->clone_range.src_offset,
+        request->clone_range.dst_handle,
+        request->clone_range.dst_offset,
+        request->clone_range.length,
+        0,
+        0,
+        chimera_clone_range_complete,
+        request);
+} /* chimera_dispatch_clone_range */

--- a/src/client/client_copy_range.c
+++ b/src/client/client_copy_range.c
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "client_copy_range.h"
+
+SYMBOL_EXPORT void
+chimera_copy_range(
+    struct chimera_client_thread   *thread,
+    struct chimera_vfs_open_handle *src_handle,
+    uint64_t                        src_offset,
+    struct chimera_vfs_open_handle *dst_handle,
+    uint64_t                        dst_offset,
+    uint64_t                        length,
+    chimera_copy_range_callback_t   callback,
+    void                           *private_data)
+{
+    struct chimera_client_request *request;
+
+    request = chimera_client_request_alloc(thread);
+
+    request->opcode                  = CHIMERA_CLIENT_OP_COPY_RANGE;
+    request->copy_range.callback     = callback;
+    request->copy_range.private_data = private_data;
+    request->copy_range.src_handle   = src_handle;
+    request->copy_range.dst_handle   = dst_handle;
+    request->copy_range.src_offset   = src_offset;
+    request->copy_range.dst_offset   = dst_offset;
+    request->copy_range.length       = length;
+    request->copy_range.r_length     = 0;
+
+    chimera_dispatch_copy_range(thread, request);
+} /* chimera_copy_range */

--- a/src/client/client_copy_range.h
+++ b/src/client/client_copy_range.h
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#pragma once
+
+#include "client_internal.h"
+
+static void
+chimera_copy_range_complete(
+    enum chimera_vfs_error    error_code,
+    uint64_t                  length,
+    struct chimera_vfs_attrs *pre_attr,
+    struct chimera_vfs_attrs *post_attr,
+    void                     *private_data)
+{
+    struct chimera_client_request *request        = private_data;
+    struct chimera_client_thread  *client_thread  = request->thread;
+    chimera_copy_range_callback_t  callback       = request->copy_range.callback;
+    void                          *callback_arg   = request->copy_range.private_data;
+    int                            heap_allocated = request->heap_allocated;
+
+    request->copy_range.r_length = length;
+
+    if (heap_allocated) {
+        chimera_client_request_free(client_thread, request);
+    }
+
+    callback(client_thread, error_code, length, callback_arg);
+} /* chimera_copy_range_complete */
+
+static inline void
+chimera_dispatch_copy_range(
+    struct chimera_client_thread  *thread,
+    struct chimera_client_request *request)
+{
+    chimera_vfs_copy_range(
+        thread->vfs_thread,
+        &thread->client->cred,
+        request->copy_range.src_handle,
+        request->copy_range.src_offset,
+        request->copy_range.dst_handle,
+        request->copy_range.dst_offset,
+        request->copy_range.length,
+        0,
+        0,
+        chimera_copy_range_complete,
+        request);
+} /* chimera_dispatch_copy_range */

--- a/src/client/client_internal.h
+++ b/src/client/client_internal.h
@@ -53,6 +53,8 @@ enum chimera_client_request_opcode {
     CHIMERA_CLIENT_OP_FSTATFS,
     CHIMERA_CLIENT_OP_MKNOD,
     CHIMERA_CLIENT_OP_LOCK,
+    CHIMERA_CLIENT_OP_COPY_RANGE,
+    CHIMERA_CLIENT_OP_CLONE_RANGE,
 };
 
 struct chimera_client_request;
@@ -330,6 +332,27 @@ struct chimera_client_request {
             uint64_t                        r_conflict_length;
             pid_t                           r_conflict_pid;
         } lock;
+
+        struct {
+            struct chimera_vfs_open_handle *src_handle;
+            struct chimera_vfs_open_handle *dst_handle;
+            uint64_t                        src_offset;
+            uint64_t                        dst_offset;
+            uint64_t                        length;
+            uint64_t                        r_length;
+            chimera_copy_range_callback_t   callback;
+            void                           *private_data;
+        } copy_range;
+
+        struct {
+            struct chimera_vfs_open_handle *src_handle;
+            struct chimera_vfs_open_handle *dst_handle;
+            uint64_t                        src_offset;
+            uint64_t                        dst_offset;
+            uint64_t                        length;
+            chimera_clone_range_callback_t  callback;
+            void                           *private_data;
+        } clone_range;
     };
 } __attribute__((aligned(64)));
 

--- a/src/posix/CMakeLists.txt
+++ b/src/posix/CMakeLists.txt
@@ -68,7 +68,9 @@ add_library(chimera_posix SHARED
             posix_dup.c
             posix_dup2.c
             posix_fdopen.c
-            posix_statfs.c)
+            posix_statfs.c
+            posix_copy_file_range.c
+            posix_clone_file_range.c)
 
 target_link_libraries(chimera_posix chimera_client evpl pthread)
 

--- a/src/posix/posix.h
+++ b/src/posix/posix.h
@@ -531,6 +531,29 @@ chimera_posix_lockf(
     int   cmd,
     off_t len);
 
+// Server-side byte-range copy. Mirrors Linux copy_file_range(2).
+// If off_in / off_out are NULL the corresponding fd's current offset is used
+// and updated; otherwise *off_in / *off_out are updated by the number of
+// bytes copied. `flags` must be 0.
+ssize_t
+chimera_posix_copy_file_range(
+    int          fd_in,
+    off_t       *off_in,
+    int          fd_out,
+    off_t       *off_out,
+    size_t       len,
+    unsigned int flags);
+
+// Reflink/COW clone of a byte range. Backend must advertise
+// CHIMERA_VFS_CAP_CLONE_RANGE; otherwise returns -1 with errno=EOPNOTSUPP.
+int
+chimera_posix_clone_file_range(
+    int    dst_fd,
+    off_t  dst_offset,
+    int    src_fd,
+    off_t  src_offset,
+    size_t len);
+
 // Sync functions
 int
 chimera_posix_fsync(

--- a/src/posix/posix_clone_file_range.c
+++ b/src/posix/posix_clone_file_range.c
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include <errno.h>
+
+#include "posix_internal.h"
+#include "../client/client_clone_range.h"
+
+static void
+chimera_posix_clone_file_range_callback(
+    struct chimera_client_thread *thread,
+    enum chimera_vfs_error        status,
+    void                         *private_data)
+{
+    struct chimera_posix_completion *comp = private_data;
+
+    chimera_posix_complete(comp, status);
+} /* chimera_posix_clone_file_range_callback */
+
+static void
+chimera_posix_clone_file_range_exec(
+    struct chimera_client_thread  *thread,
+    struct chimera_client_request *request)
+{
+    chimera_dispatch_clone_range(thread, request);
+} /* chimera_posix_clone_file_range_exec */
+
+SYMBOL_EXPORT int
+chimera_posix_clone_file_range(
+    int    dst_fd,
+    off_t  dst_offset,
+    int    src_fd,
+    off_t  src_offset,
+    size_t len)
+{
+    struct chimera_posix_client    *posix  = chimera_posix_get_global();
+    struct chimera_posix_worker    *worker = chimera_posix_choose_worker(posix);
+    struct chimera_posix_fd_entry  *src_entry;
+    struct chimera_posix_fd_entry  *dst_entry;
+    struct chimera_client_request   req;
+    struct chimera_posix_completion comp;
+
+    src_entry = chimera_posix_fd_acquire(posix, src_fd, 0);
+    if (!src_entry) {
+        return -1;
+    }
+
+    dst_entry = chimera_posix_fd_acquire(posix, dst_fd, 0);
+    if (!dst_entry) {
+        chimera_posix_fd_release(src_entry, 0);
+        return -1;
+    }
+
+    chimera_posix_completion_init(&comp, &req);
+
+    req.opcode                   = CHIMERA_CLIENT_OP_CLONE_RANGE;
+    req.clone_range.src_handle   = src_entry->handle;
+    req.clone_range.dst_handle   = dst_entry->handle;
+    req.clone_range.src_offset   = (uint64_t) src_offset;
+    req.clone_range.dst_offset   = (uint64_t) dst_offset;
+    req.clone_range.length       = len;
+    req.clone_range.callback     = chimera_posix_clone_file_range_callback;
+    req.clone_range.private_data = &comp;
+
+    chimera_posix_worker_enqueue(worker, &req, chimera_posix_clone_file_range_exec);
+
+    int err = chimera_posix_wait(&comp);
+
+    chimera_posix_fd_release(dst_entry, 0);
+    chimera_posix_fd_release(src_entry, 0);
+    chimera_posix_completion_destroy(&comp);
+
+    if (err) {
+        errno = err;
+        return -1;
+    }
+
+    return 0;
+} /* chimera_posix_clone_file_range */

--- a/src/posix/posix_copy_file_range.c
+++ b/src/posix/posix_copy_file_range.c
@@ -1,0 +1,116 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include <errno.h>
+
+#include "posix_internal.h"
+#include "../client/client_copy_range.h"
+
+struct chimera_posix_copy_range_state {
+    struct chimera_posix_completion comp;
+    uint64_t                        bytes_copied;
+};
+
+static void
+chimera_posix_copy_file_range_callback(
+    struct chimera_client_thread *thread,
+    enum chimera_vfs_error        status,
+    uint64_t                      bytes_copied,
+    void                         *private_data)
+{
+    struct chimera_posix_copy_range_state *st = private_data;
+
+    st->bytes_copied = bytes_copied;
+    chimera_posix_complete(&st->comp, status);
+} /* chimera_posix_copy_file_range_callback */
+
+static void
+chimera_posix_copy_file_range_exec(
+    struct chimera_client_thread  *thread,
+    struct chimera_client_request *request)
+{
+    chimera_dispatch_copy_range(thread, request);
+} /* chimera_posix_copy_file_range_exec */
+
+SYMBOL_EXPORT ssize_t
+chimera_posix_copy_file_range(
+    int          fd_in,
+    off_t       *off_in,
+    int          fd_out,
+    off_t       *off_out,
+    size_t       len,
+    unsigned int flags)
+{
+    struct chimera_posix_client          *posix  = chimera_posix_get_global();
+    struct chimera_posix_worker          *worker = chimera_posix_choose_worker(posix);
+    struct chimera_posix_fd_entry        *in_entry;
+    struct chimera_posix_fd_entry        *out_entry;
+    struct chimera_client_request         req;
+    struct chimera_posix_copy_range_state st;
+    off_t                                 src_off, dst_off;
+
+    if (flags != 0) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (len == 0) {
+        return 0;
+    }
+
+    in_entry = chimera_posix_fd_acquire(posix, fd_in, 0);
+    if (!in_entry) {
+        return -1;
+    }
+
+    out_entry = chimera_posix_fd_acquire(posix, fd_out, 0);
+    if (!out_entry) {
+        chimera_posix_fd_release(in_entry, 0);
+        return -1;
+    }
+
+    src_off = off_in ? *off_in : (off_t) in_entry->offset;
+    dst_off = off_out ? *off_out : (off_t) out_entry->offset;
+
+    chimera_posix_completion_init(&st.comp, &req);
+    st.bytes_copied = 0;
+
+    req.opcode                  = CHIMERA_CLIENT_OP_COPY_RANGE;
+    req.copy_range.src_handle   = in_entry->handle;
+    req.copy_range.dst_handle   = out_entry->handle;
+    req.copy_range.src_offset   = (uint64_t) src_off;
+    req.copy_range.dst_offset   = (uint64_t) dst_off;
+    req.copy_range.length       = len;
+    req.copy_range.r_length     = 0;
+    req.copy_range.callback     = chimera_posix_copy_file_range_callback;
+    req.copy_range.private_data = &st;
+
+    chimera_posix_worker_enqueue(worker, &req, chimera_posix_copy_file_range_exec);
+
+    int err = chimera_posix_wait(&st.comp);
+
+    if (!err) {
+        if (off_in) {
+            *off_in = src_off + (off_t) st.bytes_copied;
+        } else {
+            in_entry->offset = (uint64_t) (src_off + (off_t) st.bytes_copied);
+        }
+        if (off_out) {
+            *off_out = dst_off + (off_t) st.bytes_copied;
+        } else {
+            out_entry->offset = (uint64_t) (dst_off + (off_t) st.bytes_copied);
+        }
+    }
+
+    chimera_posix_fd_release(out_entry, 0);
+    chimera_posix_fd_release(in_entry, 0);
+    chimera_posix_completion_destroy(&st.comp);
+
+    if (err) {
+        errno = err;
+        return -1;
+    }
+
+    return (ssize_t) st.bytes_copied;
+} /* chimera_posix_copy_file_range */

--- a/src/posix/tests/CMakeLists.txt
+++ b/src/posix/tests/CMakeLists.txt
@@ -68,6 +68,7 @@ set(POSIX_TEST_PROGRAMS
     test_fdatasync
     test_dup
     test_fdopen
+    test_copy_range
 )
 
 # Create test programs

--- a/src/posix/tests/test_copy_range.c
+++ b/src/posix/tests/test_copy_range.c
@@ -1,0 +1,440 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Tests for chimera_posix_copy_file_range and chimera_posix_clone_file_range.
+ *
+ * Some backends don't advertise CHIMERA_VFS_CAP_COPY_RANGE / _CLONE_RANGE
+ * (demofs, cairn, the nfs proxy used by nfs3/nfs3rdma tests). On those the
+ * VFS layer returns ENOTSUP at the cap gate. The test probes for support
+ * up front and only asserts behavior the backend actually offers.
+ */
+
+#include "posix_test_common.h"
+
+#define PATTERN_LEN 4096
+
+static struct posix_test_env *g_env;
+
+static void
+die(
+    const char *what,
+    ssize_t     n)
+{
+    fprintf(stderr, "%s: ret=%zd errno=%s\n", what, n, strerror(errno));
+    posix_test_fail(g_env);
+} /* die */
+
+static void
+fill_pattern(
+    char  *buf,
+    size_t len,
+    char   seed)
+{
+    for (size_t i = 0; i < len; i++) {
+        buf[i] = (char) (seed + (char) (i & 0x3f));
+    }
+} /* fill_pattern */
+
+/* Returns 1 if the backend supports copy_file_range, 0 if ENOTSUP. */
+static int
+probe_copy_support(void)
+{
+    int     fd1, fd2;
+    ssize_t n;
+
+    fd1 = chimera_posix_open("/test/probe_a", O_CREAT | O_RDWR | O_TRUNC, 0644);
+    fd2 = chimera_posix_open("/test/probe_b", O_CREAT | O_RDWR | O_TRUNC, 0644);
+    if (fd1 < 0 || fd2 < 0) {
+        die("probe open", -1);
+    }
+
+    n = chimera_posix_pwrite(fd1, "X", 1, 0);
+    if (n != 1) {
+        die("probe pwrite", n);
+    }
+
+    n = chimera_posix_copy_file_range(fd1, NULL, fd2, NULL, 1, 0);
+
+    chimera_posix_close(fd1);
+    chimera_posix_close(fd2);
+
+    if (n == 1) {
+        return 1;
+    }
+    if (n == -1 && (errno == ENOTSUP || errno == EOPNOTSUPP)) {
+        return 0;
+    }
+    fprintf(stderr, "probe copy_file_range unexpected: ret=%zd errno=%s\n",
+            n, strerror(errno));
+    posix_test_fail(g_env);
+    return 0; /* unreachable */
+} /* probe_copy_support */
+
+static void
+test_basic_copy(void)
+{
+    char    src_buf[PATTERN_LEN];
+    char    verify[PATTERN_LEN];
+    int     src_fd, dst_fd;
+    ssize_t n;
+
+    fprintf(stderr, "Testing chimera_posix_copy_file_range basic...\n");
+
+    fill_pattern(src_buf, PATTERN_LEN, 'a');
+
+    src_fd = chimera_posix_open("/test/copy_src", O_CREAT | O_RDWR | O_TRUNC, 0644);
+    if (src_fd < 0) {
+        die("open src", src_fd);
+    }
+    dst_fd = chimera_posix_open("/test/copy_dst", O_CREAT | O_RDWR | O_TRUNC, 0644);
+    if (dst_fd < 0) {
+        die("open dst", dst_fd);
+    }
+
+    n = chimera_posix_pwrite(src_fd, src_buf, PATTERN_LEN, 0);
+    if (n != PATTERN_LEN) {
+        die("pwrite src", n);
+    }
+
+    n = chimera_posix_copy_file_range(src_fd, NULL, dst_fd, NULL, PATTERN_LEN, 0);
+    if (n != PATTERN_LEN) {
+        die("copy_file_range basic", n);
+    }
+
+    n = chimera_posix_pread(dst_fd, verify, PATTERN_LEN, 0);
+    if (n != PATTERN_LEN || memcmp(src_buf, verify, PATTERN_LEN) != 0) {
+        die("dst content mismatch", n);
+    }
+
+    chimera_posix_close(src_fd);
+    chimera_posix_close(dst_fd);
+
+    fprintf(stderr, "  basic passed\n");
+} /* test_basic_copy */
+
+static void
+test_copy_with_offsets(void)
+{
+    char    src_buf[PATTERN_LEN];
+    char    verify[PATTERN_LEN];
+    int     src_fd, dst_fd;
+    off_t   src_off = 1024;
+    off_t   dst_off = 2048;
+    ssize_t n;
+
+    fprintf(stderr, "Testing copy_file_range with explicit offsets...\n");
+
+    fill_pattern(src_buf, PATTERN_LEN, 'b');
+
+    src_fd = chimera_posix_open("/test/copy_off_src", O_CREAT | O_RDWR | O_TRUNC, 0644);
+    dst_fd = chimera_posix_open("/test/copy_off_dst", O_CREAT | O_RDWR | O_TRUNC, 0644);
+    if (src_fd < 0 || dst_fd < 0) {
+        die("open offsets", -1);
+    }
+
+    n = chimera_posix_pwrite(src_fd, src_buf, PATTERN_LEN, 0);
+    if (n != PATTERN_LEN) {
+        die("pwrite offsets", n);
+    }
+
+    n = chimera_posix_copy_file_range(src_fd, &src_off, dst_fd, &dst_off, 2048, 0);
+    if (n != 2048) {
+        die("copy_file_range offsets", n);
+    }
+    if (src_off != 1024 + 2048 || dst_off != 2048 + 2048) {
+        fprintf(stderr, "offsets not advanced: src_off=%lld dst_off=%lld\n",
+                (long long) src_off, (long long) dst_off);
+        posix_test_fail(g_env);
+    }
+
+    n = chimera_posix_pread(dst_fd, verify, 2048, 2048);
+    if (n != 2048 || memcmp(verify, src_buf + 1024, 2048) != 0) {
+        die("offset content mismatch", n);
+    }
+
+    chimera_posix_close(src_fd);
+    chimera_posix_close(dst_fd);
+
+    fprintf(stderr, "  offsets passed\n");
+} /* test_copy_with_offsets */
+
+static void
+test_copy_zero_length(void)
+{
+    int     fd1, fd2;
+    ssize_t n;
+
+    fprintf(stderr, "Testing copy_file_range with len=0...\n");
+
+    fd1 = chimera_posix_open("/test/copy_zero_a", O_CREAT | O_RDWR | O_TRUNC, 0644);
+    fd2 = chimera_posix_open("/test/copy_zero_b", O_CREAT | O_RDWR | O_TRUNC, 0644);
+
+    n = chimera_posix_copy_file_range(fd1, NULL, fd2, NULL, 0, 0);
+    if (n != 0) {
+        die("copy len=0", n);
+    }
+
+    chimera_posix_close(fd1);
+    chimera_posix_close(fd2);
+
+    fprintf(stderr, "  zero-length passed\n");
+} /* test_copy_zero_length */
+
+static void
+test_copy_short_at_eof(void)
+{
+    char    src_buf[1024];
+    char    verify[2048];
+    int     src_fd, dst_fd;
+    ssize_t n;
+
+    fprintf(stderr, "Testing copy_file_range short read at EOF...\n");
+
+    fill_pattern(src_buf, 1024, 'c');
+
+    src_fd = chimera_posix_open("/test/copy_short_src", O_CREAT | O_RDWR | O_TRUNC, 0644);
+    dst_fd = chimera_posix_open("/test/copy_short_dst", O_CREAT | O_RDWR | O_TRUNC, 0644);
+    if (src_fd < 0 || dst_fd < 0) {
+        die("open short", -1);
+    }
+
+    n = chimera_posix_pwrite(src_fd, src_buf, 1024, 0);
+    if (n != 1024) {
+        die("pwrite short", n);
+    }
+
+    n = chimera_posix_copy_file_range(src_fd, NULL, dst_fd, NULL, 2048, 0);
+    if (n != 1024) {
+        die("short-at-EOF expected 1024", n);
+    }
+
+    n = chimera_posix_pread(dst_fd, verify, 1024, 0);
+    if (n != 1024 || memcmp(verify, src_buf, 1024) != 0) {
+        die("short-at-EOF content mismatch", n);
+    }
+
+    chimera_posix_close(src_fd);
+    chimera_posix_close(dst_fd);
+
+    fprintf(stderr, "  short-at-EOF passed\n");
+} /* test_copy_short_at_eof */
+
+static void
+test_copy_invalid_flags(void)
+{
+    int     fd1, fd2;
+    ssize_t n;
+
+    fprintf(stderr, "Testing copy_file_range with invalid flags...\n");
+
+    fd1 = chimera_posix_open("/test/copy_inv_a", O_CREAT | O_RDWR | O_TRUNC, 0644);
+    fd2 = chimera_posix_open("/test/copy_inv_b", O_CREAT | O_RDWR | O_TRUNC, 0644);
+
+    errno = 0;
+    n     = chimera_posix_copy_file_range(fd1, NULL, fd2, NULL, 16, 0x1);
+    if (n != -1 || errno != EINVAL) {
+        fprintf(stderr, "expected EINVAL for nonzero flags, got n=%zd errno=%s\n",
+                n, strerror(errno));
+        posix_test_fail(g_env);
+    }
+
+    chimera_posix_close(fd1);
+    chimera_posix_close(fd2);
+
+    fprintf(stderr, "  invalid-flags passed\n");
+} /* test_copy_invalid_flags */
+
+/* Clone is block-aligned on memfs and on filesystems with reflink support.
+ * memfs's default block size is 64 KiB and the linux backend's underlying
+ * fs typically requires 4 KiB alignment, so 64 KiB safely lands on a real
+ * block boundary on every supporting backend without needing to ask. */
+#define CLONE_PROBE_LEN (64 * 1024)
+
+/* Returns 1 if the backend supports clone_file_range on a block-aligned
+ * range, 0 if it surfaces ENOTSUP. Other errors fail the test. */
+static int
+probe_clone_support(void)
+{
+    int     fd1, fd2, rc;
+    char   *src_buf;
+    ssize_t n;
+
+    src_buf = malloc(CLONE_PROBE_LEN);
+    if (!src_buf) {
+        die("probe_clone malloc", -1);
+    }
+    memset(src_buf, 'Z', CLONE_PROBE_LEN);
+
+    fd1 = chimera_posix_open("/test/probe_clone_a", O_CREAT | O_RDWR | O_TRUNC, 0644);
+    fd2 = chimera_posix_open("/test/probe_clone_b", O_CREAT | O_RDWR | O_TRUNC, 0644);
+    if (fd1 < 0 || fd2 < 0) {
+        die("probe_clone open", -1);
+    }
+
+    n = chimera_posix_pwrite(fd1, src_buf, CLONE_PROBE_LEN, 0);
+    if (n != CLONE_PROBE_LEN) {
+        die("probe_clone pwrite", n);
+    }
+
+    rc = chimera_posix_clone_file_range(fd2, 0, fd1, 0, CLONE_PROBE_LEN);
+
+    chimera_posix_close(fd1);
+    chimera_posix_close(fd2);
+    free(src_buf);
+
+    if (rc == 0) {
+        return 1;
+    }
+    if (rc == -1 && (errno == ENOTSUP || errno == EOPNOTSUPP)) {
+        return 0;
+    }
+    fprintf(stderr, "probe clone unexpected: rc=%d errno=%s\n",
+            rc, strerror(errno));
+    posix_test_fail(g_env);
+    return 0; /* unreachable */
+} /* probe_clone_support */
+
+static void
+test_clone_content(void)
+{
+    char   *src_buf;
+    char   *overwrite;
+    char   *verify;
+    int     src_fd, dst_fd, rc;
+    ssize_t n;
+
+    fprintf(stderr, "Testing clone_file_range content...\n");
+
+    src_buf   = malloc(CLONE_PROBE_LEN);
+    overwrite = malloc(CLONE_PROBE_LEN);
+    verify    = malloc(CLONE_PROBE_LEN);
+    if (!src_buf || !overwrite || !verify) {
+        die("clone malloc", -1);
+    }
+
+    fill_pattern(src_buf, CLONE_PROBE_LEN, 'd');
+    fill_pattern(overwrite, CLONE_PROBE_LEN, 'e');
+
+    src_fd = chimera_posix_open("/test/clone_src", O_CREAT | O_RDWR | O_TRUNC, 0644);
+    dst_fd = chimera_posix_open("/test/clone_dst", O_CREAT | O_RDWR | O_TRUNC, 0644);
+    if (src_fd < 0 || dst_fd < 0) {
+        die("clone open", -1);
+    }
+
+    n = chimera_posix_pwrite(src_fd, src_buf, CLONE_PROBE_LEN, 0);
+    if (n != CLONE_PROBE_LEN) {
+        die("clone pwrite", n);
+    }
+
+    rc = chimera_posix_clone_file_range(dst_fd, 0, src_fd, 0, CLONE_PROBE_LEN);
+    if (rc != 0) {
+        die("clone_file_range", rc);
+    }
+
+    n = chimera_posix_pread(dst_fd, verify, CLONE_PROBE_LEN, 0);
+    if (n != CLONE_PROBE_LEN || memcmp(src_buf, verify, CLONE_PROBE_LEN) != 0) {
+        die("clone content mismatch", n);
+    }
+
+    /* COW: write to dst must not disturb src */
+    n = chimera_posix_pwrite(dst_fd, overwrite, CLONE_PROBE_LEN, 0);
+    if (n != CLONE_PROBE_LEN) {
+        die("clone pwrite dst", n);
+    }
+
+    n = chimera_posix_pread(src_fd, verify, CLONE_PROBE_LEN, 0);
+    if (n != CLONE_PROBE_LEN || memcmp(src_buf, verify, CLONE_PROBE_LEN) != 0) {
+        die("clone src disturbed after dst write", n);
+    }
+
+    chimera_posix_close(src_fd);
+    chimera_posix_close(dst_fd);
+    free(src_buf);
+    free(overwrite);
+    free(verify);
+
+    fprintf(stderr, "  clone content + COW passed\n");
+} /* test_clone_content */
+
+static void
+test_clone_unsupported(void)
+{
+    int fd1, fd2, rc;
+
+    fprintf(stderr, "Testing clone_file_range surfaces ENOTSUP cleanly...\n");
+
+    fd1 = chimera_posix_open("/test/clone_unsup_a", O_CREAT | O_RDWR | O_TRUNC, 0644);
+    fd2 = chimera_posix_open("/test/clone_unsup_b", O_CREAT | O_RDWR | O_TRUNC, 0644);
+
+    errno = 0;
+    rc    = chimera_posix_clone_file_range(fd2, 0, fd1, 0, 4096);
+    if (rc != -1 || (errno != ENOTSUP && errno != EOPNOTSUPP)) {
+        fprintf(stderr, "expected ENOTSUP/EOPNOTSUPP, got rc=%d errno=%s\n",
+                rc, strerror(errno));
+        posix_test_fail(g_env);
+    }
+
+    chimera_posix_close(fd1);
+    chimera_posix_close(fd2);
+
+    fprintf(stderr, "  ENOTSUP path passed\n");
+} /* test_clone_unsupported */
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    struct posix_test_env env;
+    int                   rc;
+    int                   copy_supported;
+
+    g_env = &env;
+
+    posix_test_init(&env, argv, argc);
+
+    rc = posix_test_mount(&env);
+    if (rc != 0) {
+        fprintf(stderr, "Failed to mount: %s\n", strerror(errno));
+        posix_test_fail(&env);
+    }
+
+    copy_supported = probe_copy_support();
+
+    if (copy_supported) {
+        fprintf(stderr, "Backend '%s' supports copy_file_range - running full tests\n",
+                env.backend);
+        test_basic_copy();
+        test_copy_with_offsets();
+        test_copy_zero_length();
+        test_copy_short_at_eof();
+    } else {
+        fprintf(stderr, "Backend '%s' does not advertise CAP_COPY_RANGE - "
+                "skipping copy-content tests\n", env.backend);
+    }
+
+    /* flag-validation runs regardless of copy support */
+    test_copy_invalid_flags();
+
+    if (probe_clone_support()) {
+        fprintf(stderr, "Backend '%s' supports clone_file_range - validating content\n",
+                env.backend);
+        test_clone_content();
+    } else {
+        fprintf(stderr, "Backend '%s' does not advertise CAP_CLONE_RANGE - "
+                "verifying ENOTSUP path\n", env.backend);
+        test_clone_unsupported();
+    }
+
+    fprintf(stderr, "All copy_file_range/clone_file_range tests passed!\n");
+
+    rc = posix_test_umount();
+    if (rc != 0) {
+        fprintf(stderr, "Failed to unmount: %s\n", strerror(errno));
+        posix_test_fail(&env);
+    }
+
+    posix_test_success(&env);
+    return 0;
+} /* main */

--- a/src/vfs/CMakeLists.txt
+++ b/src/vfs/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(chimera_vfs SHARED vfs.c vfs_lsan.c
             vfs_proc_find.c vfs_proc_put_key.c vfs_proc_get_key.c
             vfs_proc_delete_key.c vfs_proc_search_keys.c
             vfs_proc_allocate.c vfs_proc_seek.c vfs_proc_lock.c
+            vfs_proc_copy_range.c vfs_proc_clone_range.c vfs_proc_move_range.c
             vfs_proc_getparent.c vfs_notify.c vfs_dump.c)
 
 target_compile_definitions(chimera_vfs PRIVATE

--- a/src/vfs/io_uring/io_uring.c
+++ b/src/vfs/io_uring/io_uring.c
@@ -17,6 +17,8 @@
 #include <dirent.h>
 #include <fcntl.h>
 #include <errno.h>
+#include <sys/ioctl.h>
+#include <linux/fs.h>
 #include <liburing.h>
 #include <uthash.h>
 #include <utlist.h>
@@ -1343,6 +1345,103 @@ chimera_io_uring_allocate(
 } /* chimera_io_uring_allocate */
 
 static void
+chimera_io_uring_copy_range(
+    struct chimera_vfs_request *request,
+    void                       *private_data)
+{
+    struct chimera_io_uring_thread *thread = private_data;
+    int                             src_fd, dst_fd;
+    loff_t                          src_off, dst_off;
+    uint64_t                        remaining;
+    uint64_t                        copied = 0;
+    ssize_t                         rc;
+
+    --thread->inflight;
+
+    if (request->copy_range.src_handle->vfs_module !=
+        request->copy_range.dst_handle->vfs_module) {
+        request->status = CHIMERA_VFS_ENOTSUP;
+        request->complete(request);
+        return;
+    }
+
+    src_fd    = (int) request->copy_range.src_handle->vfs_private;
+    dst_fd    = (int) request->copy_range.dst_handle->vfs_private;
+    src_off   = (loff_t) request->copy_range.src_offset;
+    dst_off   = (loff_t) request->copy_range.dst_offset;
+    remaining = request->copy_range.length;
+
+    while (remaining > 0) {
+        rc = copy_file_range(src_fd, &src_off, dst_fd, &dst_off, remaining, 0);
+
+        if (rc < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            request->status = chimera_linux_errno_to_status(errno);
+            request->complete(request);
+            return;
+        }
+
+        if (rc == 0) {
+            break;
+        }
+
+        copied    += (uint64_t) rc;
+        remaining -= (uint64_t) rc;
+    }
+
+    chimera_linux_map_attrs(CHIMERA_VFS_FH_MAGIC_IO_URING,
+                            &request->copy_range.r_post_attr, dst_fd);
+
+    request->copy_range.r_length = copied;
+    request->status              = CHIMERA_VFS_OK;
+    request->complete(request);
+} /* chimera_io_uring_copy_range */
+
+static void
+chimera_io_uring_clone_range(
+    struct chimera_vfs_request *request,
+    void                       *private_data)
+{
+    struct chimera_io_uring_thread *thread = private_data;
+    int                             src_fd, dst_fd;
+    struct file_clone_range         args;
+    int                             rc;
+
+    --thread->inflight;
+
+    if (request->clone_range.src_handle->vfs_module !=
+        request->clone_range.dst_handle->vfs_module) {
+        request->status = CHIMERA_VFS_ENOTSUP;
+        request->complete(request);
+        return;
+    }
+
+    src_fd = (int) request->clone_range.src_handle->vfs_private;
+    dst_fd = (int) request->clone_range.dst_handle->vfs_private;
+
+    args.src_fd      = src_fd;
+    args.src_offset  = request->clone_range.src_offset;
+    args.src_length  = request->clone_range.length;
+    args.dest_offset = request->clone_range.dst_offset;
+
+    rc = ioctl(dst_fd, FICLONERANGE, &args);
+
+    if (rc < 0) {
+        request->status = chimera_linux_errno_to_status(errno);
+        request->complete(request);
+        return;
+    }
+
+    chimera_linux_map_attrs(CHIMERA_VFS_FH_MAGIC_IO_URING,
+                            &request->clone_range.r_post_attr, dst_fd);
+
+    request->status = CHIMERA_VFS_OK;
+    request->complete(request);
+} /* chimera_io_uring_clone_range */
+
+static void
 chimera_io_uring_seek(
     struct chimera_vfs_request *request,
     void                       *private_data)
@@ -1761,6 +1860,12 @@ chimera_io_uring_dispatch(
         case CHIMERA_VFS_OP_ALLOCATE:
             chimera_io_uring_allocate(request, private_data);
             break;
+        case CHIMERA_VFS_OP_COPY_RANGE:
+            chimera_io_uring_copy_range(request, private_data);
+            break;
+        case CHIMERA_VFS_OP_CLONE_RANGE:
+            chimera_io_uring_clone_range(request, private_data);
+            break;
         case CHIMERA_VFS_OP_SEEK:
             chimera_io_uring_seek(request, private_data);
             break;
@@ -1781,7 +1886,8 @@ SYMBOL_EXPORT struct chimera_vfs_module vfs_io_uring = {
     .name         = "io_uring",
     .fh_magic     = CHIMERA_VFS_FH_MAGIC_IO_URING,
     .capabilities = CHIMERA_VFS_CAP_OPEN_PATH_REQUIRED | CHIMERA_VFS_CAP_OPEN_FILE_REQUIRED | CHIMERA_VFS_CAP_FS |
-        CHIMERA_VFS_CAP_FS_PATH_OP | CHIMERA_VFS_CAP_FS_LOCK,
+        CHIMERA_VFS_CAP_FS_PATH_OP | CHIMERA_VFS_CAP_FS_LOCK |
+        CHIMERA_VFS_CAP_COPY_RANGE | CHIMERA_VFS_CAP_CLONE_RANGE,
     .init           = chimera_io_uring_init,
     .destroy        = chimera_io_uring_destroy,
     .thread_init    = chimera_io_uring_thread_init,

--- a/src/vfs/linux/linux.c
+++ b/src/vfs/linux/linux.c
@@ -16,6 +16,8 @@
 #include <dirent.h>
 #include <fcntl.h>
 #include <errno.h>
+#include <sys/ioctl.h>
+#include <linux/fs.h>
 #include <uthash.h>
 #include <jansson.h>
 #include <linux/version.h>
@@ -1048,6 +1050,98 @@ chimera_linux_allocate(
 } /* chimera_linux_allocate */
 
 static void
+chimera_linux_copy_range(
+    struct chimera_vfs_request *request,
+    void                       *private_data)
+{
+    int      src_fd, dst_fd;
+    loff_t   src_off, dst_off;
+    uint64_t remaining;
+    uint64_t copied = 0;
+    ssize_t  rc;
+
+    if (request->copy_range.src_handle->vfs_module !=
+        request->copy_range.dst_handle->vfs_module) {
+        request->status = CHIMERA_VFS_ENOTSUP;
+        request->complete(request);
+        return;
+    }
+
+    src_fd    = (int) request->copy_range.src_handle->vfs_private;
+    dst_fd    = (int) request->copy_range.dst_handle->vfs_private;
+    src_off   = (loff_t) request->copy_range.src_offset;
+    dst_off   = (loff_t) request->copy_range.dst_offset;
+    remaining = request->copy_range.length;
+
+    while (remaining > 0) {
+        rc = copy_file_range(src_fd, &src_off, dst_fd, &dst_off, remaining, 0);
+
+        if (rc < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            request->status = chimera_linux_errno_to_status(errno);
+            request->complete(request);
+            return;
+        }
+
+        if (rc == 0) {
+            /* EOF on source */
+            break;
+        }
+
+        copied    += (uint64_t) rc;
+        remaining -= (uint64_t) rc;
+    }
+
+    chimera_linux_map_attrs(CHIMERA_VFS_FH_MAGIC_LINUX,
+                            &request->copy_range.r_post_attr, dst_fd);
+
+    request->copy_range.r_length = copied;
+    request->status              = CHIMERA_VFS_OK;
+    request->complete(request);
+} /* chimera_linux_copy_range */
+
+static void
+chimera_linux_clone_range(
+    struct chimera_vfs_request *request,
+    void                       *private_data)
+{
+    int                     src_fd, dst_fd;
+    struct file_clone_range args;
+    int                     rc;
+
+    if (request->clone_range.src_handle->vfs_module !=
+        request->clone_range.dst_handle->vfs_module) {
+        request->status = CHIMERA_VFS_ENOTSUP;
+        request->complete(request);
+        return;
+    }
+
+    src_fd = (int) request->clone_range.src_handle->vfs_private;
+    dst_fd = (int) request->clone_range.dst_handle->vfs_private;
+
+    args.src_fd      = src_fd;
+    args.src_offset  = request->clone_range.src_offset;
+    args.src_length  = request->clone_range.length;
+    args.dest_offset = request->clone_range.dst_offset;
+
+    rc = ioctl(dst_fd, FICLONERANGE, &args);
+
+    if (rc < 0) {
+        request->status = chimera_linux_errno_to_status(errno);
+        request->complete(request);
+        return;
+    }
+
+    chimera_linux_map_attrs(CHIMERA_VFS_FH_MAGIC_LINUX,
+                            &request->clone_range.r_post_attr, dst_fd);
+
+    request->status = CHIMERA_VFS_OK;
+    request->complete(request);
+} /* chimera_linux_clone_range */
+
+static void
 chimera_linux_seek(
     struct chimera_vfs_request *request,
     void                       *private_data)
@@ -1540,6 +1634,12 @@ chimera_linux_dispatch(
         case CHIMERA_VFS_OP_ALLOCATE:
             chimera_linux_allocate(request, private_data);
             break;
+        case CHIMERA_VFS_OP_COPY_RANGE:
+            chimera_linux_copy_range(request, private_data);
+            break;
+        case CHIMERA_VFS_OP_CLONE_RANGE:
+            chimera_linux_clone_range(request, private_data);
+            break;
         case CHIMERA_VFS_OP_SEEK:
             chimera_linux_seek(request, private_data);
             break;
@@ -1563,7 +1663,8 @@ SYMBOL_EXPORT struct chimera_vfs_module vfs_linux = {
     .fh_magic     = CHIMERA_VFS_FH_MAGIC_LINUX,
     .capabilities = CHIMERA_VFS_CAP_BLOCKING | CHIMERA_VFS_CAP_OPEN_PATH_REQUIRED | CHIMERA_VFS_CAP_OPEN_FILE_REQUIRED |
         CHIMERA_VFS_CAP_FS | CHIMERA_VFS_CAP_FS_RELATIVE_OP | CHIMERA_VFS_CAP_FS_PATH_OP |
-        CHIMERA_VFS_CAP_FS_LOCK | CHIMERA_VFS_CAP_RPL
+        CHIMERA_VFS_CAP_FS_LOCK | CHIMERA_VFS_CAP_RPL |
+        CHIMERA_VFS_CAP_COPY_RANGE | CHIMERA_VFS_CAP_CLONE_RANGE
     ,
     .init           = chimera_linux_init,
     .destroy        = chimera_linux_destroy,

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -2349,6 +2349,620 @@ memfs_allocate(
     request->complete(request);
 } /* memfs_allocate */
 
+/* Copy `len` bytes starting at `src_pos` from src inode into the flat buffer
+ * `dst`. Reads from src blocks; holes and past-EOF read as zeros.
+ * Returns the number of bytes within file bounds; the caller's view of
+ * how much was logically copied is min(len, src->size - src_pos).
+ */
+static void
+memfs_copy_from_inode(
+    struct memfs_shared *shared,
+    struct memfs_inode  *src,
+    uint64_t             src_pos,
+    void                *dst,
+    uint32_t             len)
+{
+    const uint32_t block_size  = shared->block_size;
+    const uint32_t block_shift = shared->block_shift;
+    const uint32_t block_mask  = shared->block_mask;
+    uint8_t       *out         = dst;
+
+    while (len > 0) {
+        uint64_t            src_bi  = src_pos >> block_shift;
+        uint32_t            src_off = src_pos & block_mask;
+        uint32_t            chunk   = block_size - src_off;
+        struct memfs_block *sb;
+
+        if (chunk > len) {
+            chunk = len;
+        }
+
+        if (src->file.blocks && src_bi < src->file.num_blocks) {
+            sb = src->file.blocks[src_bi];
+        } else {
+            sb = NULL;
+        }
+
+        if (sb) {
+            memcpy(out, (uint8_t *) sb->iov[0].data + src_off, chunk);
+        } else {
+            memset(out, 0, chunk);
+        }
+
+        out     += chunk;
+        src_pos += chunk;
+        len     -= chunk;
+    }
+} /* memfs_copy_from_inode */
+
+static void
+memfs_recompute_space_used(
+    struct memfs_shared *shared,
+    struct memfs_inode  *inode)
+{
+    const uint32_t block_size = shared->block_size;
+    uint64_t       bi;
+
+    inode->space_used = 0;
+
+    if (!inode->file.blocks) {
+        return;
+    }
+
+    for (bi = 0; bi < inode->file.num_blocks; bi++) {
+        if (inode->file.blocks[bi]) {
+            inode->space_used += block_size;
+        }
+    }
+} /* memfs_recompute_space_used */
+
+static int
+memfs_grow_blocks(
+    struct memfs_inode *inode,
+    uint64_t            last_block)
+{
+    struct memfs_block **new_blocks;
+    unsigned int         new_max_blocks;
+
+    if (inode->file.blocks && inode->file.max_blocks > last_block) {
+        return 0;
+    }
+
+    new_max_blocks = inode->file.max_blocks ? inode->file.max_blocks : 1024;
+
+    while (new_max_blocks <= last_block) {
+        new_max_blocks <<= 1;
+    }
+
+    new_blocks = malloc(new_max_blocks * sizeof(struct memfs_block *));
+
+    if (!new_blocks) {
+        return -1;
+    }
+
+    if (inode->file.blocks) {
+        memcpy(new_blocks, inode->file.blocks,
+               inode->file.num_blocks * sizeof(struct memfs_block *));
+        free(inode->file.blocks);
+    }
+
+    memset(new_blocks + inode->file.num_blocks, 0,
+           (new_max_blocks - inode->file.num_blocks) *
+           sizeof(struct memfs_block *));
+
+    inode->file.blocks     = new_blocks;
+    inode->file.max_blocks = new_max_blocks;
+    return 0;
+} /* memfs_grow_blocks */
+
+static void
+memfs_copy_range(
+    struct memfs_thread        *thread,
+    struct memfs_shared        *shared,
+    struct chimera_vfs_request *request,
+    void                       *private_data)
+{
+    struct evpl        *evpl        = thread->evpl;
+    const uint32_t      block_size  = shared->block_size;
+    const uint32_t      block_shift = shared->block_shift;
+    const uint32_t      block_mask  = shared->block_mask;
+    struct memfs_inode *src_inode, *dst_inode;
+    struct memfs_block *old_block, *new_block;
+    uint64_t            src_offset, dst_offset, length, src_eof_len;
+    uint64_t            first_block, last_block, bi;
+    uint32_t            block_offset, left, block_len;
+    uint64_t            copied = 0;
+    struct timespec     now;
+
+    if (request->copy_range.src_handle->vfs_module !=
+        request->copy_range.dst_handle->vfs_module) {
+        request->status = CHIMERA_VFS_ENOTSUP;
+        request->complete(request);
+        return;
+    }
+
+    src_inode = (struct memfs_inode *) request->copy_range.src_handle->vfs_private;
+    dst_inode = (struct memfs_inode *) request->copy_range.dst_handle->vfs_private;
+
+    if (!src_inode || !dst_inode) {
+        request->status = CHIMERA_VFS_EINVAL;
+        request->complete(request);
+        return;
+    }
+
+    src_offset = request->copy_range.src_offset;
+    dst_offset = request->copy_range.dst_offset;
+    length     = request->copy_range.length;
+
+    if (length == 0) {
+        request->status              = CHIMERA_VFS_OK;
+        request->copy_range.r_length = 0;
+        request->complete(request);
+        return;
+    }
+
+    /* Same file: reject overlap (POSIX copy_file_range semantics) */
+    if (src_inode == dst_inode) {
+        uint64_t s_end = src_offset + length;
+        uint64_t d_end = dst_offset + length;
+        if (src_offset < d_end && dst_offset < s_end) {
+            request->status = CHIMERA_VFS_EINVAL;
+            request->complete(request);
+            return;
+        }
+    }
+
+    clock_gettime(CLOCK_REALTIME, &now);
+
+    /* Lock in deterministic order to avoid AB/BA deadlock */
+    if (src_inode == dst_inode) {
+        pthread_mutex_lock(&src_inode->lock);
+    } else if (src_inode < dst_inode) {
+        pthread_mutex_lock(&src_inode->lock);
+        pthread_mutex_lock(&dst_inode->lock);
+    } else {
+        pthread_mutex_lock(&dst_inode->lock);
+        pthread_mutex_lock(&src_inode->lock);
+    }
+
+    memfs_map_attrs(shared, &request->copy_range.r_pre_attr, dst_inode,
+                    request->copy_range.dst_handle->fh);
+
+    /* Clamp length to what's available in source */
+    if (src_offset >= src_inode->size) {
+        src_eof_len = 0;
+    } else {
+        src_eof_len = src_inode->size - src_offset;
+        if (src_eof_len > length) {
+            src_eof_len = length;
+        }
+    }
+
+    if (src_eof_len == 0) {
+        memfs_map_attrs(shared, &request->copy_range.r_post_attr, dst_inode,
+                        request->copy_range.dst_handle->fh);
+        if (src_inode != dst_inode) {
+            pthread_mutex_unlock(&src_inode->lock);
+        }
+        pthread_mutex_unlock(&dst_inode->lock);
+        request->status              = CHIMERA_VFS_OK;
+        request->copy_range.r_length = 0;
+        request->complete(request);
+        return;
+    }
+
+    length       = src_eof_len;
+    first_block  = dst_offset >> block_shift;
+    block_offset = dst_offset & block_mask;
+    last_block   = (dst_offset + length - 1) >> block_shift;
+    left         = length;
+
+    if (memfs_grow_blocks(dst_inode, last_block) != 0) {
+        if (src_inode != dst_inode) {
+            pthread_mutex_unlock(&src_inode->lock);
+        }
+        pthread_mutex_unlock(&dst_inode->lock);
+        request->status = CHIMERA_VFS_ENOSPC;
+        request->complete(request);
+        return;
+    }
+
+    if (last_block + 1 > dst_inode->file.num_blocks) {
+        dst_inode->file.num_blocks = last_block + 1;
+    }
+
+    for (bi = first_block; bi <= last_block; bi++) {
+        block_len = block_size - block_offset;
+        if (left < block_len) {
+            block_len = left;
+        }
+
+        old_block = dst_inode->file.blocks[bi];
+        new_block = memfs_block_alloc(thread);
+
+        if (!new_block) {
+            if (src_inode != dst_inode) {
+                pthread_mutex_unlock(&src_inode->lock);
+            }
+            pthread_mutex_unlock(&dst_inode->lock);
+            request->status = CHIMERA_VFS_ENOSPC;
+            request->complete(request);
+            return;
+        }
+
+        new_block->niov = evpl_iovec_alloc(evpl, block_size, 4096,
+                                           CHIMERA_MEMFS_BLOCK_MAX_IOV,
+                                           EVPL_IOVEC_FLAG_SHARED,
+                                           new_block->iov);
+
+        /* Preserve edges of the destination block outside [block_offset, +block_len) */
+        if (block_offset || block_len < block_size) {
+            if (old_block) {
+                if (block_offset) {
+                    memcpy(new_block->iov[0].data,
+                           old_block->iov[0].data, block_offset);
+                }
+                uint32_t tail_off = block_offset + block_len;
+                if (tail_off < block_size) {
+                    memcpy((uint8_t *) new_block->iov[0].data + tail_off,
+                           (uint8_t *) old_block->iov[0].data + tail_off,
+                           block_size - tail_off);
+                }
+            } else {
+                memset(new_block->iov[0].data, 0, block_offset);
+                uint32_t tail_off = block_offset + block_len;
+                if (tail_off < block_size) {
+                    memset((uint8_t *) new_block->iov[0].data + tail_off, 0,
+                           block_size - tail_off);
+                }
+            }
+        }
+
+        memfs_copy_from_inode(shared, src_inode, src_offset + copied,
+                              (uint8_t *) new_block->iov[0].data + block_offset,
+                              block_len);
+
+        if (old_block) {
+            memfs_block_free(thread, old_block);
+        }
+        dst_inode->file.blocks[bi] = new_block;
+
+        copied      += block_len;
+        left        -= block_len;
+        block_offset = 0;
+    }
+
+    if (dst_inode->size < dst_offset + length) {
+        dst_inode->size = dst_offset + length;
+    }
+
+    memfs_recompute_space_used(shared, dst_inode);
+
+    dst_inode->mtime = now;
+    dst_inode->ctime = now;
+    src_inode->atime = now;
+
+    memfs_map_attrs(shared, &request->copy_range.r_post_attr, dst_inode,
+                    request->copy_range.dst_handle->fh);
+
+    if (src_inode != dst_inode) {
+        pthread_mutex_unlock(&src_inode->lock);
+    }
+    pthread_mutex_unlock(&dst_inode->lock);
+
+    request->status              = CHIMERA_VFS_OK;
+    request->copy_range.r_length = copied;
+    request->complete(request);
+} /* memfs_copy_range */
+
+static void
+memfs_move_range(
+    struct memfs_thread        *thread,
+    struct memfs_shared        *shared,
+    struct chimera_vfs_request *request,
+    void                       *private_data)
+{
+    const uint32_t      block_shift = shared->block_shift;
+    const uint32_t      block_mask  = shared->block_mask;
+    struct memfs_inode *src_inode, *dst_inode;
+    uint64_t            src_offset, dst_offset, length;
+    uint64_t            first_block, last_block, bi;
+    uint64_t            src_first_block, n_blocks;
+    struct timespec     now;
+
+    if (request->move_range.src_handle->vfs_module !=
+        request->move_range.dst_handle->vfs_module) {
+        request->status = CHIMERA_VFS_ENOTSUP;
+        request->complete(request);
+        return;
+    }
+
+    src_offset = request->move_range.src_offset;
+    dst_offset = request->move_range.dst_offset;
+    length     = request->move_range.length;
+
+    /* Move is zero-copy at block granularity */
+    if ((src_offset & block_mask) ||
+        (dst_offset & block_mask) ||
+        (length     & block_mask)) {
+        request->status = CHIMERA_VFS_EINVAL;
+        request->complete(request);
+        return;
+    }
+
+    if (length == 0) {
+        request->status = CHIMERA_VFS_OK;
+        request->complete(request);
+        return;
+    }
+
+    src_inode = (struct memfs_inode *) request->move_range.src_handle->vfs_private;
+    dst_inode = (struct memfs_inode *) request->move_range.dst_handle->vfs_private;
+
+    if (!src_inode || !dst_inode) {
+        request->status = CHIMERA_VFS_EINVAL;
+        request->complete(request);
+        return;
+    }
+
+    if (src_inode == dst_inode) {
+        uint64_t s_end = src_offset + length;
+        uint64_t d_end = dst_offset + length;
+        if (src_offset < d_end && dst_offset < s_end) {
+            request->status = CHIMERA_VFS_EINVAL;
+            request->complete(request);
+            return;
+        }
+    }
+
+    clock_gettime(CLOCK_REALTIME, &now);
+
+    if (src_inode == dst_inode) {
+        pthread_mutex_lock(&src_inode->lock);
+    } else if (src_inode < dst_inode) {
+        pthread_mutex_lock(&src_inode->lock);
+        pthread_mutex_lock(&dst_inode->lock);
+    } else {
+        pthread_mutex_lock(&dst_inode->lock);
+        pthread_mutex_lock(&src_inode->lock);
+    }
+
+    memfs_map_attrs(shared, &request->move_range.r_dst_pre_attr, dst_inode,
+                    request->move_range.dst_handle->fh);
+
+    first_block     = dst_offset >> block_shift;
+    last_block      = (dst_offset + length - 1) >> block_shift;
+    src_first_block = src_offset >> block_shift;
+    n_blocks        = length >> block_shift;
+
+    if (memfs_grow_blocks(dst_inode, last_block) != 0) {
+        if (src_inode != dst_inode) {
+            pthread_mutex_unlock(&src_inode->lock);
+        }
+        pthread_mutex_unlock(&dst_inode->lock);
+        request->status = CHIMERA_VFS_ENOSPC;
+        request->complete(request);
+        return;
+    }
+
+    if (last_block + 1 > dst_inode->file.num_blocks) {
+        dst_inode->file.num_blocks = last_block + 1;
+    }
+
+    for (bi = 0; bi < n_blocks; bi++) {
+        uint64_t            si = src_first_block + bi;
+        uint64_t            di = first_block + bi;
+        struct memfs_block *src_block;
+
+        if (src_inode->file.blocks && si < src_inode->file.num_blocks) {
+            src_block                  = src_inode->file.blocks[si];
+            src_inode->file.blocks[si] = NULL;
+        } else {
+            src_block = NULL;
+        }
+
+        /* Free anything currently at the destination slot before overwriting */
+        if (dst_inode->file.blocks[di]) {
+            memfs_block_free(thread, dst_inode->file.blocks[di]);
+        }
+
+        dst_inode->file.blocks[di] = src_block;
+    }
+
+    if (dst_inode->size < dst_offset + length) {
+        dst_inode->size = dst_offset + length;
+    }
+
+    memfs_recompute_space_used(shared, dst_inode);
+    memfs_recompute_space_used(shared, src_inode);
+
+    dst_inode->mtime = now;
+    dst_inode->ctime = now;
+    src_inode->mtime = now;
+    src_inode->ctime = now;
+
+    memfs_map_attrs(shared, &request->move_range.r_dst_post_attr, dst_inode,
+                    request->move_range.dst_handle->fh);
+    memfs_map_attrs(shared, &request->move_range.r_src_post_attr, src_inode,
+                    request->move_range.src_handle->fh);
+
+    if (src_inode != dst_inode) {
+        pthread_mutex_unlock(&src_inode->lock);
+    }
+    pthread_mutex_unlock(&dst_inode->lock);
+
+    request->status = CHIMERA_VFS_OK;
+    request->complete(request);
+} /* memfs_move_range */
+
+static void
+memfs_clone_range(
+    struct memfs_thread        *thread,
+    struct memfs_shared        *shared,
+    struct chimera_vfs_request *request,
+    void                       *private_data)
+{
+    const uint32_t      block_shift = shared->block_shift;
+    const uint32_t      block_mask  = shared->block_mask;
+    struct memfs_inode *src_inode, *dst_inode;
+    uint64_t            src_offset, dst_offset, length;
+    uint64_t            first_block, last_block, bi;
+    uint64_t            src_first_block, n_blocks;
+    struct timespec     now;
+
+    if (request->clone_range.src_handle->vfs_module !=
+        request->clone_range.dst_handle->vfs_module) {
+        request->status = CHIMERA_VFS_ENOTSUP;
+        request->complete(request);
+        return;
+    }
+
+    src_offset = request->clone_range.src_offset;
+    dst_offset = request->clone_range.dst_offset;
+    length     = request->clone_range.length;
+
+    /* Block-aligned only: matches memfs_move_range and POSIX FICLONERANGE
+     * semantics on filesystems with reflink support. Sub-block edges would
+     * require copy-on-write and defeat the zero-copy benefit. */
+    if ((src_offset & block_mask) ||
+        (dst_offset & block_mask) ||
+        (length & block_mask)) {
+        request->status = CHIMERA_VFS_EINVAL;
+        request->complete(request);
+        return;
+    }
+
+    if (length == 0) {
+        request->status = CHIMERA_VFS_OK;
+        request->complete(request);
+        return;
+    }
+
+    src_inode = (struct memfs_inode *) request->clone_range.src_handle->vfs_private;
+    dst_inode = (struct memfs_inode *) request->clone_range.dst_handle->vfs_private;
+
+    if (!src_inode || !dst_inode) {
+        request->status = CHIMERA_VFS_EINVAL;
+        request->complete(request);
+        return;
+    }
+
+    if (src_inode == dst_inode) {
+        uint64_t s_end = src_offset + length;
+        uint64_t d_end = dst_offset + length;
+        if (src_offset < d_end && dst_offset < s_end) {
+            request->status = CHIMERA_VFS_EINVAL;
+            request->complete(request);
+            return;
+        }
+    }
+
+    clock_gettime(CLOCK_REALTIME, &now);
+
+    if (src_inode == dst_inode) {
+        pthread_mutex_lock(&src_inode->lock);
+    } else if (src_inode < dst_inode) {
+        pthread_mutex_lock(&src_inode->lock);
+        pthread_mutex_lock(&dst_inode->lock);
+    } else {
+        pthread_mutex_lock(&dst_inode->lock);
+        pthread_mutex_lock(&src_inode->lock);
+    }
+
+    memfs_map_attrs(shared, &request->clone_range.r_pre_attr, dst_inode,
+                    request->clone_range.dst_handle->fh);
+
+    first_block     = dst_offset >> block_shift;
+    last_block      = (dst_offset + length - 1) >> block_shift;
+    src_first_block = src_offset >> block_shift;
+    n_blocks        = length >> block_shift;
+
+    if (memfs_grow_blocks(dst_inode, last_block) != 0) {
+        if (src_inode != dst_inode) {
+            pthread_mutex_unlock(&src_inode->lock);
+        }
+        pthread_mutex_unlock(&dst_inode->lock);
+        request->status = CHIMERA_VFS_ENOSPC;
+        request->complete(request);
+        return;
+    }
+
+    if (last_block + 1 > dst_inode->file.num_blocks) {
+        dst_inode->file.num_blocks = last_block + 1;
+    }
+
+    for (bi = 0; bi < n_blocks; bi++) {
+        uint64_t            si = src_first_block + bi;
+        uint64_t            di = first_block + bi;
+        struct memfs_block *src_block;
+        struct memfs_block *new_block;
+
+        if (src_inode->file.blocks && si < src_inode->file.num_blocks) {
+            src_block = src_inode->file.blocks[si];
+        } else {
+            src_block = NULL;
+        }
+
+        /* Free anything currently at the destination slot before overwriting */
+        if (dst_inode->file.blocks[di]) {
+            memfs_block_free(thread, dst_inode->file.blocks[di]);
+            dst_inode->file.blocks[di] = NULL;
+        }
+
+        if (!src_block) {
+            /* Source is a hole - leave destination NULL (reads as zeros) */
+            continue;
+        }
+
+        /* Share underlying buffer via iovec refcount; the new memfs_block
+         * has its own iovec descriptors that hold refs into the same
+         * buffers as the source block. Subsequent writes on either side
+         * COW naturally because memfs_write always allocates a new block. */
+        new_block = memfs_block_alloc(thread);
+
+        if (!new_block) {
+            if (src_inode != dst_inode) {
+                pthread_mutex_unlock(&src_inode->lock);
+            }
+            pthread_mutex_unlock(&dst_inode->lock);
+            request->status = CHIMERA_VFS_ENOSPC;
+            request->complete(request);
+            return;
+        }
+
+        new_block->niov = src_block->niov;
+        for (int j = 0; j < src_block->niov; j++) {
+            evpl_iovec_clone_segment(&new_block->iov[j],
+                                     &src_block->iov[j],
+                                     0,
+                                     src_block->iov[j].length);
+        }
+
+        dst_inode->file.blocks[di] = new_block;
+    }
+
+    if (dst_inode->size < dst_offset + length) {
+        dst_inode->size = dst_offset + length;
+    }
+
+    memfs_recompute_space_used(shared, dst_inode);
+
+    dst_inode->mtime = now;
+    dst_inode->ctime = now;
+    src_inode->atime = now;
+
+    memfs_map_attrs(shared, &request->clone_range.r_post_attr, dst_inode,
+                    request->clone_range.dst_handle->fh);
+
+    if (src_inode != dst_inode) {
+        pthread_mutex_unlock(&src_inode->lock);
+    }
+    pthread_mutex_unlock(&dst_inode->lock);
+
+    request->status = CHIMERA_VFS_OK;
+    request->complete(request);
+} /* memfs_clone_range */
+
 static void
 memfs_seek(
     struct memfs_thread        *thread,
@@ -3160,6 +3774,15 @@ memfs_dispatch(
         case CHIMERA_VFS_OP_ALLOCATE:
             memfs_allocate(thread, shared, request, private_data);
             break;
+        case CHIMERA_VFS_OP_COPY_RANGE:
+            memfs_copy_range(thread, shared, request, private_data);
+            break;
+        case CHIMERA_VFS_OP_CLONE_RANGE:
+            memfs_clone_range(thread, shared, request, private_data);
+            break;
+        case CHIMERA_VFS_OP_MOVE_RANGE:
+            memfs_move_range(thread, shared, request, private_data);
+            break;
         case CHIMERA_VFS_OP_SEEK:
             memfs_seek(thread, shared, request, private_data);
             break;
@@ -3200,7 +3823,8 @@ SYMBOL_EXPORT struct chimera_vfs_module vfs_memfs = {
     .name         = "memfs",
     .fh_magic     = CHIMERA_VFS_FH_MAGIC_MEMFS,
     .capabilities = CHIMERA_VFS_CAP_CREATE_UNLINKED | CHIMERA_VFS_CAP_FS | CHIMERA_VFS_CAP_KV |
-        CHIMERA_VFS_CAP_FS_RELATIVE_OP,
+        CHIMERA_VFS_CAP_FS_RELATIVE_OP |
+        CHIMERA_VFS_CAP_COPY_RANGE | CHIMERA_VFS_CAP_CLONE_RANGE | CHIMERA_VFS_CAP_MOVE_RANGE,
     .init           = memfs_init,
     .destroy        = memfs_destroy,
     .thread_init    = memfs_thread_init,

--- a/src/vfs/vfs.h
+++ b/src/vfs/vfs.h
@@ -72,7 +72,10 @@ struct chimera_vfs_mount_options {
 #define CHIMERA_VFS_OP_SEEK             26
 #define CHIMERA_VFS_OP_LOCK             27
 #define CHIMERA_VFS_OP_GETPARENT        28
-#define CHIMERA_VFS_OP_NUM              29
+#define CHIMERA_VFS_OP_COPY_RANGE       29
+#define CHIMERA_VFS_OP_CLONE_RANGE      30
+#define CHIMERA_VFS_OP_MOVE_RANGE       31
+#define CHIMERA_VFS_OP_NUM              32
 
 #define CHIMERA_VFS_OPEN_CREATE         (1U << 0)
 #define CHIMERA_VFS_OPEN_PATH           (1U << 1)
@@ -725,6 +728,38 @@ struct chimera_vfs_request {
         } allocate;
 
         struct {
+            struct chimera_vfs_open_handle *src_handle;
+            struct chimera_vfs_open_handle *dst_handle;
+            uint64_t                        src_offset;
+            uint64_t                        dst_offset;
+            uint64_t                        length;
+            uint64_t                        r_length;
+            struct chimera_vfs_attrs        r_pre_attr;
+            struct chimera_vfs_attrs        r_post_attr;
+        } copy_range;
+
+        struct {
+            struct chimera_vfs_open_handle *src_handle;
+            struct chimera_vfs_open_handle *dst_handle;
+            uint64_t                        src_offset;
+            uint64_t                        dst_offset;
+            uint64_t                        length;
+            struct chimera_vfs_attrs        r_pre_attr;
+            struct chimera_vfs_attrs        r_post_attr;
+        } clone_range;
+
+        struct {
+            struct chimera_vfs_open_handle *src_handle;
+            struct chimera_vfs_open_handle *dst_handle;
+            uint64_t                        src_offset;
+            uint64_t                        dst_offset;
+            uint64_t                        length;
+            struct chimera_vfs_attrs        r_src_post_attr;
+            struct chimera_vfs_attrs        r_dst_pre_attr;
+            struct chimera_vfs_attrs        r_dst_post_attr;
+        } move_range;
+
+        struct {
             struct chimera_vfs_open_handle *handle;
             uint64_t                        offset;
             uint32_t                        what;
@@ -848,6 +883,23 @@ enum CHIMERA_FS_FH_MAGIC {
  * resolve (parent_fh, name_in_parent).  Enables precise subtree
  * change notifications via CHIMERA_VFS_OP_GETPARENT. */
 #define CHIMERA_VFS_CAP_RPL                (1U << 9)
+
+/* If set, module supports server-side byte-range copy between two
+ * open handles served by the same module (chimera_vfs_copy_range). */
+#define CHIMERA_VFS_CAP_COPY_RANGE         (1U << 10)
+
+/* If set, module supports reflink/COW share of a byte range between
+ * two open handles served by the same module (chimera_vfs_clone_range).
+ * Modules backed by filesystems without reflink support should leave
+ * this unset; the VFS layer will surface ENOTSUP. */
+#define CHIMERA_VFS_CAP_CLONE_RANGE        (1U << 11)
+
+/* If set, module supports zero-copy move of a byte range between two
+ * open handles served by the same module (chimera_vfs_move_range): block
+ * references are transferred from source to destination and the source
+ * range becomes a hole. Not exposed over NFS; intended for server-internal
+ * use (e.g. S3 multipart-upload completion). */
+#define CHIMERA_VFS_CAP_MOVE_RANGE         (1U << 12)
 
 struct chimera_vfs_module {
     /* Required

--- a/src/vfs/vfs_dump.c
+++ b/src/vfs/vfs_dump.c
@@ -40,6 +40,9 @@ chimera_vfs_op_name(unsigned int opcode)
         case CHIMERA_VFS_OP_ALLOCATE: return "Allocate";
         case CHIMERA_VFS_OP_SEEK: return "Seek";
         case CHIMERA_VFS_OP_LOCK: return "Lock";
+        case CHIMERA_VFS_OP_COPY_RANGE: return "CopyRange";
+        case CHIMERA_VFS_OP_CLONE_RANGE: return "CloneRange";
+        case CHIMERA_VFS_OP_MOVE_RANGE: return "MoveRange";
         default: return "Unknown";
     } /* switch */
 
@@ -134,6 +137,33 @@ __chimera_vfs_dump_request(struct chimera_vfs_request *req)
                              req->allocate.offset,
                              req->allocate.length,
                              req->allocate.flags);
+            break;
+        case CHIMERA_VFS_OP_COPY_RANGE:
+            chimera_snprintf(argstr, sizeof(argstr),
+                             "src_hdl %lx src_off %lu dst_hdl %lx dst_off %lu len %lu",
+                             req->copy_range.src_handle->vfs_private,
+                             req->copy_range.src_offset,
+                             req->copy_range.dst_handle->vfs_private,
+                             req->copy_range.dst_offset,
+                             req->copy_range.length);
+            break;
+        case CHIMERA_VFS_OP_CLONE_RANGE:
+            chimera_snprintf(argstr, sizeof(argstr),
+                             "src_hdl %lx src_off %lu dst_hdl %lx dst_off %lu len %lu",
+                             req->clone_range.src_handle->vfs_private,
+                             req->clone_range.src_offset,
+                             req->clone_range.dst_handle->vfs_private,
+                             req->clone_range.dst_offset,
+                             req->clone_range.length);
+            break;
+        case CHIMERA_VFS_OP_MOVE_RANGE:
+            chimera_snprintf(argstr, sizeof(argstr),
+                             "src_hdl %lx src_off %lu dst_hdl %lx dst_off %lu len %lu",
+                             req->move_range.src_handle->vfs_private,
+                             req->move_range.src_offset,
+                             req->move_range.dst_handle->vfs_private,
+                             req->move_range.dst_offset,
+                             req->move_range.length);
             break;
         case CHIMERA_VFS_OP_SYMLINK_AT:
             format_safe_name(namestr, sizeof(namestr),
@@ -269,6 +299,10 @@ __chimera_vfs_dump_reply(struct chimera_vfs_request *req)
         case CHIMERA_VFS_OP_WRITE:
             chimera_snprintf(argstr, sizeof(argstr), "r_len %u",
                              req->write.r_length);
+            break;
+        case CHIMERA_VFS_OP_COPY_RANGE:
+            chimera_snprintf(argstr, sizeof(argstr), "r_len %lu",
+                             req->copy_range.r_length);
             break;
         default:
             break;

--- a/src/vfs/vfs_proc_clone_range.c
+++ b/src/vfs/vfs_proc_clone_range.c
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "vfs/vfs_procs.h"
+#include "vfs_internal.h"
+#include "vfs_open_cache.h"
+#include "vfs_attr_cache.h"
+#include "common/macros.h"
+
+static void
+chimera_vfs_clone_range_complete(struct chimera_vfs_request *request)
+{
+    chimera_vfs_clone_range_callback_t callback = request->proto_callback;
+
+    if (request->status == CHIMERA_VFS_OK) {
+        chimera_vfs_attr_cache_insert(request->thread->vfs->vfs_attr_cache,
+                                      request->clone_range.dst_handle->fh_hash,
+                                      request->clone_range.dst_handle->fh,
+                                      request->clone_range.dst_handle->fh_len,
+                                      &request->clone_range.r_post_attr);
+    }
+
+    chimera_vfs_complete(request);
+
+    callback(request->status,
+             &request->clone_range.r_pre_attr,
+             &request->clone_range.r_post_attr,
+             request->proto_private_data);
+
+    chimera_vfs_request_free(request->thread, request);
+} /* chimera_vfs_clone_range_complete */
+
+SYMBOL_EXPORT void
+chimera_vfs_clone_range(
+    struct chimera_vfs_thread         *thread,
+    const struct chimera_vfs_cred     *cred,
+    struct chimera_vfs_open_handle    *src_handle,
+    uint64_t                           src_offset,
+    struct chimera_vfs_open_handle    *dst_handle,
+    uint64_t                           dst_offset,
+    uint64_t                           length,
+    uint64_t                           pre_attr_mask,
+    uint64_t                           post_attr_mask,
+    chimera_vfs_clone_range_callback_t callback,
+    void                              *private_data)
+{
+    struct chimera_vfs_request *request;
+
+    if (!(dst_handle->vfs_module->capabilities & CHIMERA_VFS_CAP_CLONE_RANGE)) {
+        callback(CHIMERA_VFS_ENOTSUP, NULL, NULL, private_data);
+        return;
+    }
+
+    request = chimera_vfs_request_alloc_by_handle(thread, cred, dst_handle);
+
+    if (CHIMERA_VFS_IS_ERR(request)) {
+        callback(CHIMERA_VFS_PTR_ERR(request), NULL, NULL, private_data);
+        return;
+    }
+
+    request->opcode                              = CHIMERA_VFS_OP_CLONE_RANGE;
+    request->complete                            = chimera_vfs_clone_range_complete;
+    request->clone_range.src_handle              = src_handle;
+    request->clone_range.dst_handle              = dst_handle;
+    request->clone_range.src_offset              = src_offset;
+    request->clone_range.dst_offset              = dst_offset;
+    request->clone_range.length                  = length;
+    request->clone_range.r_pre_attr.va_req_mask  = pre_attr_mask;
+    request->clone_range.r_pre_attr.va_set_mask  = 0;
+    request->clone_range.r_post_attr.va_req_mask = post_attr_mask | CHIMERA_VFS_ATTR_MASK_CACHEABLE;
+    request->clone_range.r_post_attr.va_set_mask = 0;
+    request->proto_callback                      = callback;
+    request->proto_private_data                  = private_data;
+
+    chimera_vfs_dispatch(request);
+} /* chimera_vfs_clone_range */

--- a/src/vfs/vfs_proc_copy_range.c
+++ b/src/vfs/vfs_proc_copy_range.c
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "vfs/vfs_procs.h"
+#include "vfs_internal.h"
+#include "vfs_open_cache.h"
+#include "vfs_attr_cache.h"
+#include "common/macros.h"
+
+static void
+chimera_vfs_copy_range_complete(struct chimera_vfs_request *request)
+{
+    chimera_vfs_copy_range_callback_t callback = request->proto_callback;
+
+    if (request->status == CHIMERA_VFS_OK) {
+        chimera_vfs_attr_cache_insert(request->thread->vfs->vfs_attr_cache,
+                                      request->copy_range.dst_handle->fh_hash,
+                                      request->copy_range.dst_handle->fh,
+                                      request->copy_range.dst_handle->fh_len,
+                                      &request->copy_range.r_post_attr);
+    }
+
+    chimera_vfs_complete(request);
+
+    callback(request->status,
+             request->copy_range.r_length,
+             &request->copy_range.r_pre_attr,
+             &request->copy_range.r_post_attr,
+             request->proto_private_data);
+
+    chimera_vfs_request_free(request->thread, request);
+} /* chimera_vfs_copy_range_complete */
+
+SYMBOL_EXPORT void
+chimera_vfs_copy_range(
+    struct chimera_vfs_thread        *thread,
+    const struct chimera_vfs_cred    *cred,
+    struct chimera_vfs_open_handle   *src_handle,
+    uint64_t                          src_offset,
+    struct chimera_vfs_open_handle   *dst_handle,
+    uint64_t                          dst_offset,
+    uint64_t                          length,
+    uint64_t                          pre_attr_mask,
+    uint64_t                          post_attr_mask,
+    chimera_vfs_copy_range_callback_t callback,
+    void                             *private_data)
+{
+    struct chimera_vfs_request *request;
+
+    if (!(dst_handle->vfs_module->capabilities & CHIMERA_VFS_CAP_COPY_RANGE)) {
+        callback(CHIMERA_VFS_ENOTSUP, 0, NULL, NULL, private_data);
+        return;
+    }
+
+    request = chimera_vfs_request_alloc_by_handle(thread, cred, dst_handle);
+
+    if (CHIMERA_VFS_IS_ERR(request)) {
+        callback(CHIMERA_VFS_PTR_ERR(request), 0, NULL, NULL, private_data);
+        return;
+    }
+
+    request->opcode                             = CHIMERA_VFS_OP_COPY_RANGE;
+    request->complete                           = chimera_vfs_copy_range_complete;
+    request->copy_range.src_handle              = src_handle;
+    request->copy_range.dst_handle              = dst_handle;
+    request->copy_range.src_offset              = src_offset;
+    request->copy_range.dst_offset              = dst_offset;
+    request->copy_range.length                  = length;
+    request->copy_range.r_length                = 0;
+    request->copy_range.r_pre_attr.va_req_mask  = pre_attr_mask;
+    request->copy_range.r_pre_attr.va_set_mask  = 0;
+    request->copy_range.r_post_attr.va_req_mask = post_attr_mask | CHIMERA_VFS_ATTR_MASK_CACHEABLE;
+    request->copy_range.r_post_attr.va_set_mask = 0;
+    request->proto_callback                     = callback;
+    request->proto_private_data                 = private_data;
+
+    chimera_vfs_dispatch(request);
+} /* chimera_vfs_copy_range */

--- a/src/vfs/vfs_proc_move_range.c
+++ b/src/vfs/vfs_proc_move_range.c
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "vfs/vfs_procs.h"
+#include "vfs_internal.h"
+#include "vfs_open_cache.h"
+#include "vfs_attr_cache.h"
+#include "common/macros.h"
+
+static void
+chimera_vfs_move_range_complete(struct chimera_vfs_request *request)
+{
+    chimera_vfs_move_range_callback_t callback = request->proto_callback;
+
+    if (request->status == CHIMERA_VFS_OK) {
+        chimera_vfs_attr_cache_insert(request->thread->vfs->vfs_attr_cache,
+                                      request->move_range.dst_handle->fh_hash,
+                                      request->move_range.dst_handle->fh,
+                                      request->move_range.dst_handle->fh_len,
+                                      &request->move_range.r_dst_post_attr);
+        chimera_vfs_attr_cache_insert(request->thread->vfs->vfs_attr_cache,
+                                      request->move_range.src_handle->fh_hash,
+                                      request->move_range.src_handle->fh,
+                                      request->move_range.src_handle->fh_len,
+                                      &request->move_range.r_src_post_attr);
+    }
+
+    chimera_vfs_complete(request);
+
+    callback(request->status,
+             &request->move_range.r_src_post_attr,
+             &request->move_range.r_dst_pre_attr,
+             &request->move_range.r_dst_post_attr,
+             request->proto_private_data);
+
+    chimera_vfs_request_free(request->thread, request);
+} /* chimera_vfs_move_range_complete */
+
+SYMBOL_EXPORT void
+chimera_vfs_move_range(
+    struct chimera_vfs_thread        *thread,
+    const struct chimera_vfs_cred    *cred,
+    struct chimera_vfs_open_handle   *src_handle,
+    uint64_t                          src_offset,
+    struct chimera_vfs_open_handle   *dst_handle,
+    uint64_t                          dst_offset,
+    uint64_t                          length,
+    uint64_t                          src_post_attr_mask,
+    uint64_t                          dst_pre_attr_mask,
+    uint64_t                          dst_post_attr_mask,
+    chimera_vfs_move_range_callback_t callback,
+    void                             *private_data)
+{
+    struct chimera_vfs_request *request;
+
+    if (!(dst_handle->vfs_module->capabilities & CHIMERA_VFS_CAP_MOVE_RANGE)) {
+        callback(CHIMERA_VFS_ENOTSUP, NULL, NULL, NULL, private_data);
+        return;
+    }
+
+    request = chimera_vfs_request_alloc_by_handle(thread, cred, dst_handle);
+
+    if (CHIMERA_VFS_IS_ERR(request)) {
+        callback(CHIMERA_VFS_PTR_ERR(request), NULL, NULL, NULL, private_data);
+        return;
+    }
+
+    request->opcode                                 = CHIMERA_VFS_OP_MOVE_RANGE;
+    request->complete                               = chimera_vfs_move_range_complete;
+    request->move_range.src_handle                  = src_handle;
+    request->move_range.dst_handle                  = dst_handle;
+    request->move_range.src_offset                  = src_offset;
+    request->move_range.dst_offset                  = dst_offset;
+    request->move_range.length                      = length;
+    request->move_range.r_src_post_attr.va_req_mask = src_post_attr_mask | CHIMERA_VFS_ATTR_MASK_CACHEABLE;
+    request->move_range.r_src_post_attr.va_set_mask = 0;
+    request->move_range.r_dst_pre_attr.va_req_mask  = dst_pre_attr_mask;
+    request->move_range.r_dst_pre_attr.va_set_mask  = 0;
+    request->move_range.r_dst_post_attr.va_req_mask = dst_post_attr_mask | CHIMERA_VFS_ATTR_MASK_CACHEABLE;
+    request->move_range.r_dst_post_attr.va_set_mask = 0;
+    request->proto_callback                         = callback;
+    request->proto_private_data                     = private_data;
+
+    chimera_vfs_dispatch(request);
+} /* chimera_vfs_move_range */

--- a/src/vfs/vfs_procs.h
+++ b/src/vfs/vfs_procs.h
@@ -586,6 +586,69 @@ chimera_vfs_allocate(
     chimera_vfs_allocate_callback_t callback,
     void                           *private_data);
 
+typedef void (*chimera_vfs_copy_range_callback_t)(
+    enum chimera_vfs_error    error_code,
+    uint64_t                  length,
+    struct chimera_vfs_attrs *pre_attr,
+    struct chimera_vfs_attrs *post_attr,
+    void                     *private_data);
+
+void
+chimera_vfs_copy_range(
+    struct chimera_vfs_thread        *thread,
+    const struct chimera_vfs_cred    *cred,
+    struct chimera_vfs_open_handle   *src_handle,
+    uint64_t                          src_offset,
+    struct chimera_vfs_open_handle   *dst_handle,
+    uint64_t                          dst_offset,
+    uint64_t                          length,
+    uint64_t                          pre_attr_mask,
+    uint64_t                          post_attr_mask,
+    chimera_vfs_copy_range_callback_t callback,
+    void                             *private_data);
+
+typedef void (*chimera_vfs_clone_range_callback_t)(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *pre_attr,
+    struct chimera_vfs_attrs *post_attr,
+    void                     *private_data);
+
+void
+chimera_vfs_clone_range(
+    struct chimera_vfs_thread         *thread,
+    const struct chimera_vfs_cred     *cred,
+    struct chimera_vfs_open_handle    *src_handle,
+    uint64_t                           src_offset,
+    struct chimera_vfs_open_handle    *dst_handle,
+    uint64_t                           dst_offset,
+    uint64_t                           length,
+    uint64_t                           pre_attr_mask,
+    uint64_t                           post_attr_mask,
+    chimera_vfs_clone_range_callback_t callback,
+    void                              *private_data);
+
+typedef void (*chimera_vfs_move_range_callback_t)(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *src_post_attr,
+    struct chimera_vfs_attrs *dst_pre_attr,
+    struct chimera_vfs_attrs *dst_post_attr,
+    void                     *private_data);
+
+void
+chimera_vfs_move_range(
+    struct chimera_vfs_thread        *thread,
+    const struct chimera_vfs_cred    *cred,
+    struct chimera_vfs_open_handle   *src_handle,
+    uint64_t                          src_offset,
+    struct chimera_vfs_open_handle   *dst_handle,
+    uint64_t                          dst_offset,
+    uint64_t                          length,
+    uint64_t                          src_post_attr_mask,
+    uint64_t                          dst_pre_attr_mask,
+    uint64_t                          dst_post_attr_mask,
+    chimera_vfs_move_range_callback_t callback,
+    void                             *private_data);
+
 typedef void (*chimera_vfs_seek_callback_t)(
     enum chimera_vfs_error error_code,
     int                    sr_eof,


### PR DESCRIPTION
## Summary

Adds three new VFS operations for byte-range data movement between two open files, plus the surfacing of NFS 4.2 `OP_COPY` / `OP_CLONE` over the wire and `copy_file_range(2)` / `FICLONERANGE`-equivalent calls in the POSIX layer.

- **COPY_RANGE** — server-side copy of a byte range.
- **CLONE_RANGE** — reflink / COW share of a byte range.
- **MOVE_RANGE** — zero-copy transfer of a byte range. **Internal-only** — no NFS, client, or POSIX surface; intended for a future S3 multipart-upload completion path that needs to stitch parts into the final object without copying data.

Each op has its own capability flag so backends can declare what they support; the VFS layer surfaces `ENOTSUP` at the cap gate for backends that don't.

## Backend coverage

| Backend | COPY | CLONE | MOVE |
|---|---|---|---|
| memfs | ✓ (block-by-block) | ✓ (block-aligned, zero-copy via iovec refcount sharing) | ✓ (block-aligned, block-pointer transfer) |
| linux | ✓ (`copy_file_range(2)`) | ✓ (`ioctl FICLONERANGE`) | — |
| io_uring | ✓ | ✓ | — |
| demofs, cairn, nfs proxy, root | — | — | — |

`demofs` and `cairn` could grow native extent-aware implementations later; the API and capability infrastructure are in place.

memfs's CLONE shares each block's underlying iovec via `evpl_iovec_clone_segment` (which uses the existing `EVPL_IOVEC_FLAG_SHARED` atomic refcount). Each side gets its own `struct memfs_block` but the data pages are shared. COW emerges naturally because `memfs_write` always allocates a fresh block on modification.

Each backend handler also gates on `src_handle->vfs_module == dst_handle->vfs_module` so cross-backend copies (e.g. memfs→linux) cleanly return `ENOTSUP`.

## NFS 4.2

`OP_COPY` and `OP_CLONE` are now wired into the compound dispatcher. Constraints:

- **Single-server only** — `ca_source_server` non-empty → `NFS4ERR_NOTSUPP`. The async / offload ops (`OP_COPY_NOTIFY`, `OP_OFFLOAD_CANCEL`, `OP_OFFLOAD_STATUS`) are not implemented.
- **Synchronous** — `cr_synchronous = true` in the response regardless of what the client asked for.

`struct nfs_request` gains a second `nfs4_state_src` slot so the source and destination stateids can be acquired together.

## Client and POSIX

- `chimera_copy_range` / `chimera_clone_range` — async client wrappers.
- `chimera_posix_copy_file_range(int fd_in, off_t *off_in, int fd_out, off_t *off_out, size_t len, unsigned int flags)` — mirrors Linux `copy_file_range(2)`.
- `chimera_posix_clone_file_range(int dst_fd, off_t dst_off, int src_fd, off_t src_off, size_t len)` — mirrors `FICLONERANGE`.

## Tests

New `src/posix/tests/test_copy_range.c` probes per-backend capability and asserts behavior the backend actually offers — basic copy, explicit offsets, zero-length, short-read-at-EOF, invalid-flags rejection, and (when supported) clone content correctness plus COW invariant. All 21 backend variants pass.