### PR TITLE
Limit KVM testing to chimera-dev container

### DIFF
--- a/Dockerfile.rocky9
+++ b/Dockerfile.rocky9
@@ -43,7 +43,3 @@ RUN if [ "$ENABLE_XLIO" = "1" ] ; then \
     make install ; \
     fi
 
-RUN dnf -y install qemu-kvm qemu-img && \
-    dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo && \
-    dnf -y install docker-ce docker-ce-cli containerd.io && \
-    dnf clean all

--- a/Dockerfile.ubuntu22.04
+++ b/Dockerfile.ubuntu22.04
@@ -50,14 +50,3 @@ RUN if [ "$ENABLE_XLIO" = "1" ] ; then \
     make install ; \
     fi
 
-RUN apt-get -y update && \
-    apt-get -y --no-install-recommends install qemu-kvm qemu-utils && \
-    install -m 0755 -d /etc/apt/keyrings && \
-    curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc && \
-    chmod a+r /etc/apt/keyrings/docker.asc && \
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu jammy stable" \
-        > /etc/apt/sources.list.d/docker.list && \
-    apt-get -y update && \
-    apt-get -y --no-install-recommends install docker-ce docker-ce-cli containerd.io && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.ubuntu24.04
+++ b/Dockerfile.ubuntu24.04
@@ -51,14 +51,3 @@ RUN if [ "$ENABLE_XLIO" = "1" ] ; then \
     make install ; \
     fi
 
-RUN apt-get -y update && \
-    apt-get -y --no-install-recommends install qemu-kvm qemu-utils && \
-    install -m 0755 -d /etc/apt/keyrings && \
-    curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc && \
-    chmod a+r /etc/apt/keyrings/docker.asc && \
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu noble stable" \
-        > /etc/apt/sources.list.d/docker.list && \
-    apt-get -y update && \
-    apt-get -y --no-install-recommends install docker-ce docker-ce-cli containerd.io && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.ubuntu26.04
+++ b/Dockerfile.ubuntu26.04
@@ -51,14 +51,3 @@ RUN if [ "$ENABLE_XLIO" = "1" ] ; then \
     make install ; \
     fi
 
-RUN apt-get -y update && \
-    apt-get -y --no-install-recommends install qemu-system-x86 qemu-utils && \
-    install -m 0755 -d /etc/apt/keyrings && \
-    curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc && \
-    chmod a+r /etc/apt/keyrings/docker.asc && \
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu resolute stable" \
-        > /etc/apt/sources.list.d/docker.list && \
-    apt-get -y update && \
-    apt-get -y --no-install-recommends install docker-ce docker-ce-cli containerd.io && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
We really don't need to do KVM testing on all
the os since we do test all the different KVM
OS each time.

Removing kvm and docker install on all other
docker images