### PR TITLE
s3: canonicalize all x-amz-* headers in V2 signing

### DIFF
--- a/src/server/s3/s3_auth.c
+++ b/src/server/s3/s3_auth.c
@@ -113,6 +113,59 @@ base64_encode(
 } /* base64_encode */
 
 /*
+ * Collected x-amz-* header for V2 canonical headers section.
+ * Name is stored lowercased; value points into the request's header storage.
+ */
+struct amz_header_entry {
+    char        name[64];
+    const char *value;
+};
+
+#define V2_MAX_AMZ_HEADERS 64
+
+struct amz_header_collector {
+    struct amz_header_entry entries[V2_MAX_AMZ_HEADERS];
+    int                     count;
+};
+
+static void
+collect_amz_header(
+    const char *name,
+    const char *value,
+    void       *private_data)
+{
+    struct amz_header_collector *c = private_data;
+    struct amz_header_entry     *e;
+    int                          i;
+
+    if (strncasecmp(name, "x-amz-", 6) != 0) {
+        return;
+    }
+    if (c->count >= V2_MAX_AMZ_HEADERS) {
+        return;
+    }
+
+    e = &c->entries[c->count++];
+
+    for (i = 0; name[i] && i < (int) sizeof(e->name) - 1; i++) {
+        e->name[i] = tolower((unsigned char) name[i]);
+    }
+    e->name[i] = '\0';
+    e->value   = value;
+} /* collect_amz_header */
+
+static int
+amz_header_compare(
+    const void *a,
+    const void *b)
+{
+    const struct amz_header_entry *ha = a;
+    const struct amz_header_entry *hb = b;
+
+    return strcmp(ha->name, hb->name);
+} /* amz_header_compare */
+
+/*
  * Parse AWS Signature V2 Authorization header
  * Format: AWS AWSAccessKeyId:Signature
  */
@@ -229,10 +282,30 @@ build_string_to_sign_v2(
                            date ? date : "");
     }
 
-    /* Canonicalized AMZ Headers - include x-amz-date if present */
-    if (amz_date) {
-        offset += snprintf(string_to_sign + offset, max_len - offset,
-                           "x-amz-date:%s\n", amz_date);
+    /*
+     * CanonicalizedAmzHeaders: every x-amz-* request header, lowercased,
+     * sorted lexicographically by name, emitted as "name:value\n".
+     *
+     * Recent boto3 (>= 1.36) adds x-amz-checksum-* and
+     * x-amz-sdk-checksum-algorithm headers on PUT/POST by default and
+     * includes them in the signing string, so we must canonicalize all
+     * x-amz-* headers rather than only the ones we recognize.
+     */
+    {
+        struct amz_header_collector amz = { .count = 0 };
+
+        evpl_http_request_header_iterate(request, collect_amz_header, &amz);
+
+        if (amz.count > 1) {
+            qsort(amz.entries, amz.count, sizeof(amz.entries[0]),
+                  amz_header_compare);
+        }
+
+        for (int i = 0; i < amz.count; i++) {
+            offset += snprintf(string_to_sign + offset, max_len - offset,
+                               "%s:%s\n",
+                               amz.entries[i].name, amz.entries[i].value);
+        }
     }
 
     /* Canonicalized Resource */


### PR DESCRIPTION
## Summary

Fixes a regression where every S3 AWS Signature V2 mutating request fails with `SignatureDoesNotMatch` against modern boto3 (>= 1.36).

`build_string_to_sign_v2()` only emitted `x-amz-date` in the `CanonicalizedAmzHeaders` section, but the V2 spec requires every `x-amz-*` request header (lowercased, sorted by name, one per line). Recent boto3 sets `x-amz-checksum-crc32` and `x-amz-sdk-checksum-algorithm` on PUT/POST by default and includes them in its own signing string, so its signature didn't match ours.

## Changes

- Enumerate request headers via the new `evpl_http_request_header_iterate()` (added in chimera-nas/libevpl#46, submodule bumped here).
- Collect every `x-amz-*` header, lowercase the names, sort lexicographically, emit `name:value\n`.
- `evpl_http_request_header_iterate()` plus a `count_header` test path were added to libevpl in the linked PR.

## Test coverage

All 30 boto3 S3 tests now pass — including the previously-failing 5:

```
89 - chimera/server/s3/boto3_v2_memfs_put     Passed
90 - chimera/server/s3/boto3_v2_memfs_get     Passed
91 - chimera/server/s3/boto3_v2_memfs_head    Passed
92 - chimera/server/s3/boto3_v2_memfs_delete  Passed
93 - chimera/server/s3/boto3_v2_memfs_list    Passed
```

Full `ctest` Debug suite green (no new failures vs. main).