### PR TITLE
NFSv4: unified state model + 4.0 establishment, 4.1 replay, lease/grace plumbing

### DIFF
--- a/src/server/nfs/CMakeLists.txt
+++ b/src/server/nfs/CMakeLists.txt
@@ -5,7 +5,7 @@
 include_directories(${NFS_COMMON_INCLUDE_DIR})
 
 # Create libraries for NFSv3 and NFSv4
-add_library(chimera_nfs SHARED nfs.c nfs4_session.c nfs_mount.c nfs_portmap.c nfs3_dump.c nfs4_dump.c
+add_library(chimera_nfs SHARED nfs.c nfs4_session.c nfs4_state.c nfs4_lease.c nfs4_recovery.c nfs_mount.c nfs_portmap.c nfs3_dump.c nfs4_dump.c
             nfs_external_portmap.c nfs_nlm.c nfs_nlm_state.c
             nfs3_proc_null.c nfs3_proc_getattr.c nfs3_proc_setattr.c nfs3_proc_lookup.c 
             nfs3_proc_access.c nfs3_proc_readlink.c nfs3_proc_read.c nfs3_proc_write.c
@@ -26,7 +26,9 @@ add_library(chimera_nfs SHARED nfs.c nfs4_session.c nfs_mount.c nfs_portmap.c nf
             nfs4_proc_allocate.c nfs4_proc_deallocate.c nfs4_proc_seek.c
             nfs4_proc_lock.c nfs4_proc_lockt.c nfs4_proc_locku.c
             nfs4_proc_verify.c
-            nfs4_proc_putpubfh.c nfs4_proc_renew.c nfs4_proc_release_lockowner.c)
+            nfs4_proc_putpubfh.c
+            nfs4_proc_renew.c nfs4_proc_open_confirm.c
+            nfs4_proc_open_downgrade.c nfs4_proc_release_lockowner.c)
 
 target_compile_definitions(chimera_nfs PRIVATE XXH_INLINE_ALL)
 target_link_libraries(chimera_nfs chimera_nfs_common chimera_common evpl evpl_rpc2 pthread uuid urcu urcu-common)

--- a/src/server/nfs/nfs.c
+++ b/src/server/nfs/nfs.c
@@ -17,6 +17,7 @@
 #include "nfs_common.h"
 #include "nfs_internal.h"
 #include "nfs4_session.h"
+#include "nfs4_lease.h"
 #include "nfs_nlm.h"
 #include "prometheus-c.h"
 #include "nfs_external_portmap.h"
@@ -112,6 +113,41 @@ nfs_server_init(
     shared->op_histogram = prometheus_metrics_create_histogram_exponential(metrics, "chimera_nfs_op_latency",
                                                                            "The latency of NFS operations", 24);
 
+    /* NFS4.1 SEQUENCE replay cache metrics.  One counter with an "op"
+     * label distinguishes outcomes; a gauge tracks total bytes held in
+     * the cache across all sessions. */
+    {
+        struct nfs4_replay_metrics *rm = &shared->replay_metrics;
+
+        rm->counter = prometheus_metrics_create_counter(
+            metrics, "chimera_nfs4_replay_cache",
+            "NFS4.1 SEQUENCE replay cache outcomes");
+        rm->hit_series = prometheus_counter_create_series(
+            rm->counter,
+            (const char *[]) { "op" }, (const char *[]) { "hit" }, 1);
+        rm->seq_misordered_series = prometheus_counter_create_series(
+            rm->counter,
+            (const char *[]) { "op" }, (const char *[]) { "seq_misordered" }, 1);
+        rm->bad_slot_series = prometheus_counter_create_series(
+            rm->counter,
+            (const char *[]) { "op" }, (const char *[]) { "bad_slot" }, 1);
+        rm->retry_uncached_series = prometheus_counter_create_series(
+            rm->counter,
+            (const char *[]) { "op" }, (const char *[]) { "retry_uncached" }, 1);
+
+        rm->hit            = prometheus_counter_series_create_instance(rm->hit_series);
+        rm->seq_misordered = prometheus_counter_series_create_instance(rm->seq_misordered_series);
+        rm->bad_slot       = prometheus_counter_series_create_instance(rm->bad_slot_series);
+        rm->retry_uncached = prometheus_counter_series_create_instance(rm->retry_uncached_series);
+
+        rm->bytes_gauge = prometheus_metrics_create_gauge(
+            metrics, "chimera_nfs4_replay_cache_bytes",
+            "Bytes currently held in the NFS4.1 SEQUENCE replay cache");
+        rm->bytes_series = prometheus_gauge_create_series(
+            rm->bytes_gauge, NULL, NULL, 0);
+        rm->bytes_in_use = prometheus_gauge_series_create_instance(rm->bytes_series);
+    }
+
     if (!external_portmap) {
         /* PORTMAP V2 */
         PORTMAP_V2_init(&shared->portmap_v2);
@@ -198,6 +234,22 @@ nfs_server_init(
     shared->nlm_v4.recv_call_NLMPROC4_FREE_ALL    = chimera_nfs_nlm4_free_all;
 
     nfs4_client_table_init(&shared->nfs4_shared_clients);
+    nfs_state_table_init(&shared->nfs4_state_table);
+
+    /* Phase 3: lease defaults.  Per RFC 7530 §10.2.3, the lease_time
+     * attribute reported via FATTR4_LEASE_TIME governs how often 4.0 clients
+     * send RENEW. */
+    shared->nfs_lease_time_s = NFS4_LEASE_TIME_DEFAULT_S;
+    shared->nfs_grace_time_s = NFS4_GRACE_TIME_DEFAULT_S;
+
+    /* Phase 5: server-reboot recovery / grace window.  Persistence is
+     * stubbed in this phase -- nfs_recovery_load loads zero records, so
+     * nfs_recovery_begin_grace short-circuits to in_grace=false. */
+    nfs_recovery_load(&shared->nfs4_recovery,
+                      chimera_server_config_get_state_dir(config),
+                      NULL);
+    nfs_recovery_begin_grace(&shared->nfs4_recovery,
+                             shared->nfs_grace_time_s);
 
     nlm_state_init(&shared->nlm_state,
                    chimera_server_config_get_state_dir(config));
@@ -311,8 +363,12 @@ nfs_server_destroy(void *data)
     evpl       = evpl_create(NULL);
     vfs_thread = chimera_vfs_thread_init(evpl, shared->vfs);
 
-    /* Release all open handles from NFS4 sessions */
-    nfs4_client_table_release_handles(&shared->nfs4_shared_clients, vfs_thread);
+    /* Tear down every client's unified state hierarchy.  This walks
+     * owners → states → locks, releasing the dup'd VFS handles and freeing
+     * the structs and slot table entries. */
+    nfs4_client_table_destroy_unified(&shared->nfs4_shared_clients,
+                                      &shared->nfs4_state_table,
+                                      vfs_thread);
 
     /* Drain all in-flight VFS operations before destroying the thread.
      * This ensures delegation threads complete before we free the thread. */
@@ -342,8 +398,57 @@ nfs_server_destroy(void *data)
     /* Close out all the nfs4 session state */
     nfs4_client_table_free(&shared->nfs4_shared_clients);
 
+    /* All unified state slots have been freed via destroy_unified above;
+     * this just frees the shard arrays and per-shard locks. */
+    nfs_state_table_free(&shared->nfs4_state_table, NULL);
+
+    nfs_recovery_free(&shared->nfs4_recovery);
+
     if (shared->op_histogram) {
         prometheus_histogram_destroy(shared->metrics, shared->op_histogram);
+    }
+
+    {
+        struct nfs4_replay_metrics *rm = &shared->replay_metrics;
+
+        if (rm->bytes_in_use) {
+            prometheus_gauge_series_destroy_instance(rm->bytes_series, rm->bytes_in_use);
+        }
+        if (rm->bytes_series) {
+            prometheus_gauge_destroy_series(rm->bytes_gauge, rm->bytes_series);
+        }
+        if (rm->bytes_gauge) {
+            prometheus_gauge_destroy(shared->metrics, rm->bytes_gauge);
+        }
+
+        if (rm->hit) {
+            prometheus_counter_series_destroy_instance(rm->hit_series, rm->hit);
+        }
+        if (rm->seq_misordered) {
+            prometheus_counter_series_destroy_instance(rm->seq_misordered_series, rm->seq_misordered);
+        }
+        if (rm->bad_slot) {
+            prometheus_counter_series_destroy_instance(rm->bad_slot_series, rm->bad_slot);
+        }
+        if (rm->retry_uncached) {
+            prometheus_counter_series_destroy_instance(rm->retry_uncached_series, rm->retry_uncached);
+        }
+
+        if (rm->hit_series) {
+            prometheus_counter_destroy_series(rm->counter, rm->hit_series);
+        }
+        if (rm->seq_misordered_series) {
+            prometheus_counter_destroy_series(rm->counter, rm->seq_misordered_series);
+        }
+        if (rm->bad_slot_series) {
+            prometheus_counter_destroy_series(rm->counter, rm->bad_slot_series);
+        }
+        if (rm->retry_uncached_series) {
+            prometheus_counter_destroy_series(rm->counter, rm->retry_uncached_series);
+        }
+        if (rm->counter) {
+            prometheus_counter_destroy(shared->metrics, rm->counter);
+        }
     }
     free(shared->mount_v3.rpc2.metrics);
     free(shared->nfs_v3.rpc2.metrics);
@@ -455,6 +560,12 @@ nfs_server_thread_init(
         evpl_rpc2_server_attach(thread->rpc2_thread, shared->portmap_server, thread);
     }
 
+    /* Phase 3: per-thread lease sweeper.  Each thread arms its own timer;
+     * sweepers serialize on the existing client-table mutex, so redundant
+     * passes converge harmlessly. */
+    thread->lease_sweeper = calloc(1, sizeof(*thread->lease_sweeper));
+    nfs_lease_sweeper_init(thread->lease_sweeper, thread);
+
     return thread;
 } /* nfs_server_thread_init */
 
@@ -463,6 +574,12 @@ nfs_server_thread_destroy(void *data)
 {
     struct chimera_server_nfs_thread *thread = data;
     struct nfs_request               *req;
+
+    if (thread->lease_sweeper) {
+        nfs_lease_sweeper_destroy(thread->lease_sweeper);
+        free(thread->lease_sweeper);
+        thread->lease_sweeper = NULL;
+    }
 
     evpl_rpc2_server_detach(thread->rpc2_thread, thread->shared->mount_server);
     evpl_rpc2_server_detach(thread->rpc2_thread, thread->shared->nfs_server);

--- a/src/server/nfs/nfs4_attr.h
+++ b/src/server/nfs/nfs4_attr.h
@@ -10,6 +10,7 @@
 #include <sys/stat.h>
 
 #include "vfs/vfs.h"
+#include "nfs4_lease.h"
 
 static inline uint64_t
 chimera_nfs4_attr2mask(
@@ -358,7 +359,7 @@ chimera_nfs4_marshall_attrs(
             rsp_mask[0]  |= (1 << FATTR4_LEASE_TIME);
             *num_rsp_mask = 1;
 
-            chimera_nfs4_attr_append_uint32(&attrs, 600);
+            chimera_nfs4_attr_append_uint32(&attrs, NFS4_LEASE_TIME_DEFAULT_S);
         }
 
         if (req_mask[0] & (1 << FATTR4_ACLSUPPORT)) {

--- a/src/server/nfs/nfs4_lease.c
+++ b/src/server/nfs/nfs4_lease.c
@@ -1,0 +1,93 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include <pthread.h>
+#include <stdatomic.h>
+
+#include "nfs4_lease.h"
+#include "nfs4_recovery.h"
+#include "nfs4_session.h"
+#include "nfs4_state.h"
+#include "nfs_common.h"
+#include "nfs_internal.h"
+#include "common/misc.h"
+#include "evpl/evpl.h"
+
+#define NFS_LEASE_SWEEP_INTERVAL_US 1000000   /* 1 Hz */
+
+void
+nfs_lease_sweep_once(struct chimera_server_nfs_shared *shared)
+{
+#ifndef __clang_analyzer__
+    struct nfs4_client_table *table = &shared->nfs4_shared_clients;
+    struct nfs4_client       *cur, *tmp;
+    uint64_t                  now_ns = nfs_lease_now_ns();
+    uint64_t                  lease_ns;
+
+    lease_ns = (uint64_t) shared->nfs_lease_time_s * 1000000000ULL;
+
+    pthread_mutex_lock(&table->nfs4_ct_lock);
+
+    HASH_ITER(nfs4_client_hh_by_id, table->nfs4_ct_clients_by_id, cur, tmp)
+    {
+        struct nfs_client *uc = cur->unified;
+        uint64_t           last;
+
+        if (!uc) {
+            continue;
+        }
+
+        last = atomic_load_explicit((_Atomic uint64_t *) &uc->last_touch_ns,
+                                    memory_order_relaxed);
+
+        if (last == 0) {
+            /* Newly created client that hasn't been touched yet: give it
+             * one sweep grace by stamping now. */
+            atomic_store_explicit((_Atomic uint64_t *) &uc->last_touch_ns,
+                                  now_ns, memory_order_relaxed);
+            continue;
+        }
+
+        if (now_ns - last > lease_ns) {
+            uc->expired = 1;
+        }
+    }
+
+    pthread_mutex_unlock(&table->nfs4_ct_lock);
+#endif /* ifndef __clang_analyzer__ */
+
+    /* Phase 5: piggyback grace-window expiry on the lease tick. */
+    nfs_recovery_sweep_once(&shared->nfs4_recovery);
+} /* nfs_lease_sweep_once */
+
+static void
+nfs_lease_sweeper_fire(
+    struct evpl       *evpl,
+    struct evpl_timer *timer)
+{
+    struct nfs_lease_sweeper *sweeper =
+        container_of(timer, struct nfs_lease_sweeper, timer);
+
+    nfs_lease_sweep_once(sweeper->thread->shared);
+} /* nfs_lease_sweeper_fire */
+
+void
+nfs_lease_sweeper_init(
+    struct nfs_lease_sweeper         *sweeper,
+    struct chimera_server_nfs_thread *thread)
+{
+    sweeper->thread = thread;
+    evpl_add_timer(thread->evpl, &sweeper->timer,
+                   nfs_lease_sweeper_fire,
+                   NFS_LEASE_SWEEP_INTERVAL_US);
+} /* nfs_lease_sweeper_init */
+
+void
+nfs_lease_sweeper_destroy(struct nfs_lease_sweeper *sweeper)
+{
+    if (sweeper->thread) {
+        evpl_remove_timer(sweeper->thread->evpl, &sweeper->timer);
+        sweeper->thread = NULL;
+    }
+} /* nfs_lease_sweeper_destroy */

--- a/src/server/nfs/nfs4_lease.h
+++ b/src/server/nfs/nfs4_lease.h
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#pragma once
+
+#include <stdint.h>
+#include <time.h>
+
+#include "evpl/evpl.h"
+
+/*
+ * NFSv4 lease management.
+ *
+ * A client's lease records the time of the last state-touching op.  A
+ * per-thread sweeper fires at 1Hz to walk the client table and mark any
+ * client whose lease has expired (last_touch + lease_time < now) with the
+ * `expired` flag.  RENEW (4.0) and any state op then return NFS4ERR_EXPIRED
+ * for those clients.
+ *
+ * Phase 3 does not actively destroy expired clients' state -- destruction
+ * happens at DESTROY_CLIENTID or shutdown.  This avoids racing with in-flight
+ * state acquires.  Phase 5+ may add active reclamation.
+ */
+
+#define NFS4_LEASE_TIME_DEFAULT_S 90
+#define NFS4_GRACE_TIME_DEFAULT_S 180
+
+struct chimera_server_nfs_shared;
+struct chimera_server_nfs_thread;
+
+struct nfs_lease_sweeper {
+    struct evpl_timer                 timer;
+    struct chimera_server_nfs_thread *thread;
+};
+
+/* Monotonic time in nanoseconds, used for lease bookkeeping. */
+static inline uint64_t
+nfs_lease_now_ns(void)
+{
+    struct timespec ts;
+
+    clock_gettime(CLOCK_MONOTONIC_COARSE, &ts);
+    return (uint64_t) ts.tv_sec * 1000000000ULL + (uint64_t) ts.tv_nsec;
+} /* nfs_lease_now_ns */
+
+/*
+ * Arm a periodic lease sweeper on `thread`'s evpl loop.  Each thread arms
+ * its own; sweepers iterate the shared client table under the existing
+ * client-table mutex, so redundant sweeps converge harmlessly.
+ */
+void
+nfs_lease_sweeper_init(
+    struct nfs_lease_sweeper         *sweeper,
+    struct chimera_server_nfs_thread *thread);
+
+void
+nfs_lease_sweeper_destroy(
+    struct nfs_lease_sweeper *sweeper);
+
+/*
+ * Walk the shared client table once and flip the `expired` flag on every
+ * client whose lease has lapsed.  Exposed for the sweeper callback and for
+ * tests.
+ */
+void
+nfs_lease_sweep_once(
+    struct chimera_server_nfs_shared *shared);

--- a/src/server/nfs/nfs4_op_matrix.h
+++ b/src/server/nfs/nfs4_op_matrix.h
@@ -1,0 +1,237 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "nfs4_xdr.h"
+
+#define NFS4_OP_MIN                 3 /* OP_ACCESS */
+#define NFS4_OP_MAX                 71 /* OP_CLONE */
+
+/* Per-minor-version support bits. */
+#define NFS4_OP_V40                 0x1
+#define NFS4_OP_V41                 0x2
+#define NFS4_OP_V42                 0x4
+
+/* Behavioral flags applied during dispatch. */
+#define NFS4_OP_FLAG_MUST_BE_FIRST  0x01 /* SEQUENCE in 4.1+: must be at op_index 0 */
+#define NFS4_OP_FLAG_NO_REQ_SESSION 0x02 /* allowed in 4.1+ even without a preceding SEQUENCE */
+
+struct nfs4_op_info {
+    uint8_t minors;
+    uint8_t flags;
+};
+
+static const struct nfs4_op_info nfs4_op_support[NFS4_OP_MAX + 1] = {
+    /* Common 4.0/4.1/4.2 ops */
+    [OP_ACCESS] =               { NFS4_OP_V40 | NFS4_OP_V41 | NFS4_OP_V42, 0
+    },
+    [OP_CLOSE] =                { NFS4_OP_V40 | NFS4_OP_V41 | NFS4_OP_V42, 0
+    },
+    [OP_COMMIT] =               { NFS4_OP_V40 | NFS4_OP_V41 | NFS4_OP_V42, 0
+    },
+    [OP_CREATE] =               { NFS4_OP_V40 | NFS4_OP_V41 | NFS4_OP_V42, 0
+    },
+    [OP_DELEGPURGE] =           { NFS4_OP_V40 | NFS4_OP_V41 | NFS4_OP_V42, 0
+    },
+    [OP_DELEGRETURN] =          { NFS4_OP_V40 | NFS4_OP_V41 | NFS4_OP_V42, 0
+    },
+    [OP_GETATTR] =              { NFS4_OP_V40 | NFS4_OP_V41 | NFS4_OP_V42, 0
+    },
+    [OP_GETFH] =                { NFS4_OP_V40 | NFS4_OP_V41 | NFS4_OP_V42, 0
+    },
+    [OP_LINK] =                 { NFS4_OP_V40 | NFS4_OP_V41 | NFS4_OP_V42, 0
+    },
+    [OP_LOCK] =                 { NFS4_OP_V40 | NFS4_OP_V41 | NFS4_OP_V42, 0
+    },
+    [OP_LOCKT] =                { NFS4_OP_V40 | NFS4_OP_V41 | NFS4_OP_V42, 0
+    },
+    [OP_LOCKU] =                { NFS4_OP_V40 | NFS4_OP_V41 | NFS4_OP_V42, 0
+    },
+    [OP_LOOKUP] =               { NFS4_OP_V40 | NFS4_OP_V41 | NFS4_OP_V42, 0
+    },
+    [OP_LOOKUPP] =              { NFS4_OP_V40 | NFS4_OP_V41 | NFS4_OP_V42, 0
+    },
+    [OP_NVERIFY] =              { NFS4_OP_V40 | NFS4_OP_V41 | NFS4_OP_V42, 0
+    },
+    [OP_OPEN] =                 { NFS4_OP_V40 | NFS4_OP_V41 | NFS4_OP_V42, 0
+    },
+    [OP_OPENATTR] =             { NFS4_OP_V40 | NFS4_OP_V41 | NFS4_OP_V42, 0
+    },
+    [OP_OPEN_DOWNGRADE] =       { NFS4_OP_V40 | NFS4_OP_V41 | NFS4_OP_V42, 0
+    },
+    [OP_PUTFH] =                { NFS4_OP_V40 | NFS4_OP_V41 | NFS4_OP_V42, 0
+    },
+    [OP_PUTPUBFH] =             { NFS4_OP_V40 | NFS4_OP_V41 | NFS4_OP_V42, 0
+    },
+    [OP_PUTROOTFH] =            { NFS4_OP_V40 | NFS4_OP_V41 | NFS4_OP_V42, 0
+    },
+    [OP_READ] =                 { NFS4_OP_V40 | NFS4_OP_V41 | NFS4_OP_V42, 0
+    },
+    [OP_READDIR] =              { NFS4_OP_V40 | NFS4_OP_V41 | NFS4_OP_V42, 0
+    },
+    [OP_READLINK] =             { NFS4_OP_V40 | NFS4_OP_V41 | NFS4_OP_V42, 0
+    },
+    [OP_REMOVE] =               { NFS4_OP_V40 | NFS4_OP_V41 | NFS4_OP_V42, 0
+    },
+    [OP_RENAME] =               { NFS4_OP_V40 | NFS4_OP_V41 | NFS4_OP_V42, 0
+    },
+    [OP_RESTOREFH] =            { NFS4_OP_V40 | NFS4_OP_V41 | NFS4_OP_V42, 0
+    },
+    [OP_SAVEFH] =               { NFS4_OP_V40 | NFS4_OP_V41 | NFS4_OP_V42, 0
+    },
+    [OP_SECINFO] =              { NFS4_OP_V40 | NFS4_OP_V41 | NFS4_OP_V42, 0
+    },
+    [OP_SETATTR] =              { NFS4_OP_V40 | NFS4_OP_V41 | NFS4_OP_V42, 0
+    },
+    [OP_VERIFY] =               { NFS4_OP_V40 | NFS4_OP_V41 | NFS4_OP_V42, 0
+    },
+    [OP_WRITE] =                { NFS4_OP_V40 | NFS4_OP_V41 | NFS4_OP_V42, 0
+    },
+
+    /* 4.0-only ops (RFC 7530); MNI in 4.1+ per RFC 5661 / 8881. */
+    [OP_OPEN_CONFIRM] =         { NFS4_OP_V40,                             0
+    },
+    [OP_RENEW] =                { NFS4_OP_V40,                             0
+    },
+    [OP_SETCLIENTID] =          { NFS4_OP_V40,                             0
+    },
+    [OP_SETCLIENTID_CONFIRM] =  { NFS4_OP_V40,                             0
+    },
+    [OP_RELEASE_LOCKOWNER] =    { NFS4_OP_V40,                             0
+    },
+
+    /* 4.1+ ops. */
+    [OP_BACKCHANNEL_CTL] =      { NFS4_OP_V41 | NFS4_OP_V42,               0
+    },
+    [OP_BIND_CONN_TO_SESSION] = { NFS4_OP_V41 | NFS4_OP_V42,               NFS4_OP_FLAG_NO_REQ_SESSION
+    },
+    [OP_EXCHANGE_ID] =          { NFS4_OP_V41 | NFS4_OP_V42,               NFS4_OP_FLAG_NO_REQ_SESSION
+    },
+    [OP_CREATE_SESSION] =       { NFS4_OP_V41 | NFS4_OP_V42,               NFS4_OP_FLAG_NO_REQ_SESSION
+    },
+    [OP_DESTROY_SESSION] =      { NFS4_OP_V41 | NFS4_OP_V42,               NFS4_OP_FLAG_NO_REQ_SESSION
+    },
+    [OP_FREE_STATEID] =         { NFS4_OP_V41 | NFS4_OP_V42,               0
+    },
+    [OP_GET_DIR_DELEGATION] =   { NFS4_OP_V41 | NFS4_OP_V42,               0
+    },
+    [OP_GETDEVICEINFO] =        { NFS4_OP_V41 | NFS4_OP_V42,               0
+    },
+    [OP_GETDEVICELIST] =        { NFS4_OP_V41 | NFS4_OP_V42,               0
+    },
+    [OP_LAYOUTCOMMIT] =         { NFS4_OP_V41 | NFS4_OP_V42,               0
+    },
+    [OP_LAYOUTGET] =            { NFS4_OP_V41 | NFS4_OP_V42,               0
+    },
+    [OP_LAYOUTRETURN] =         { NFS4_OP_V41 | NFS4_OP_V42,               0
+    },
+    [OP_SECINFO_NO_NAME] =      { NFS4_OP_V41 | NFS4_OP_V42,               0
+    },
+    [OP_SEQUENCE] =             { NFS4_OP_V41 | NFS4_OP_V42,
+                                  NFS4_OP_FLAG_MUST_BE_FIRST | NFS4_OP_FLAG_NO_REQ_SESSION },
+    [OP_SET_SSV] =              { NFS4_OP_V41 | NFS4_OP_V42,               0
+    },
+    [OP_TEST_STATEID] =         { NFS4_OP_V41 | NFS4_OP_V42,               0
+    },
+    [OP_WANT_DELEGATION] =      { NFS4_OP_V41 | NFS4_OP_V42,               0
+    },
+    [OP_DESTROY_CLIENTID] =     { NFS4_OP_V41 | NFS4_OP_V42,               NFS4_OP_FLAG_NO_REQ_SESSION
+    },
+    [OP_RECLAIM_COMPLETE] =     { NFS4_OP_V41 | NFS4_OP_V42,               0
+    },
+
+    /* 4.2-only ops. */
+    [OP_ALLOCATE] =             { NFS4_OP_V42,                             0
+    },
+    [OP_COPY] =                 { NFS4_OP_V42,                             0
+    },
+    [OP_COPY_NOTIFY] =          { NFS4_OP_V42,                             0
+    },
+    [OP_DEALLOCATE] =           { NFS4_OP_V42,                             0
+    },
+    [OP_IO_ADVISE] =            { NFS4_OP_V42,                             0
+    },
+    [OP_LAYOUTERROR] =          { NFS4_OP_V42,                             0
+    },
+    [OP_LAYOUTSTATS] =          { NFS4_OP_V42,                             0
+    },
+    [OP_OFFLOAD_CANCEL] =       { NFS4_OP_V42,                             0
+    },
+    [OP_OFFLOAD_STATUS] =       { NFS4_OP_V42,                             0
+    },
+    [OP_READ_PLUS] =            { NFS4_OP_V42,                             0
+    },
+    [OP_SEEK] =                 { NFS4_OP_V42,                             0
+    },
+    [OP_WRITE_SAME] =           { NFS4_OP_V42,                             0
+    },
+    [OP_CLONE] =                { NFS4_OP_V42,                             0
+    },
+};
+
+/**
+ * Check whether `op` is permitted at this point in the compound, given the
+ * negotiated `minor` and the current `op_index` / `seen_sequence` state.
+ *
+ * Returns one of:
+ *   NFS4_OK                       — op may proceed
+ *   NFS4ERR_OP_ILLEGAL            — op is not part of this minor's protocol
+ *   NFS4ERR_NOTSUPP               — op is in range but not in the matrix
+ *   NFS4ERR_MINOR_VERS_MISMATCH   — minor itself is unrecognized (>2)
+ *   NFS4ERR_SEQUENCE_POS          — SEQUENCE used outside position 0
+ *   NFS4ERR_OP_NOT_IN_SESSION     — 4.1+ op issued before SEQUENCE
+ */
+static inline nfsstat4
+nfs4_op_check_minor(
+    uint32_t op,
+    uint8_t  minor,
+    uint32_t op_index,
+    bool     seen_sequence)
+{
+    const struct nfs4_op_info *info;
+    uint8_t                    minor_bit;
+
+    if (minor > 2) {
+        return NFS4ERR_MINOR_VERS_MISMATCH;
+    }
+
+    if (op == OP_ILLEGAL) {
+        return NFS4ERR_OP_ILLEGAL;
+    }
+
+    if (op < NFS4_OP_MIN || op > NFS4_OP_MAX) {
+        return NFS4ERR_OP_ILLEGAL;
+    }
+
+    info = &nfs4_op_support[op];
+
+    if (info->minors == 0) {
+        return NFS4ERR_NOTSUPP;
+    }
+
+    minor_bit = (minor == 0) ? NFS4_OP_V40 :
+        (minor == 1) ? NFS4_OP_V41 : NFS4_OP_V42;
+
+    if (!(info->minors & minor_bit)) {
+        return NFS4ERR_OP_ILLEGAL;
+    }
+
+    if (minor >= 1) {
+        if (info->flags & NFS4_OP_FLAG_MUST_BE_FIRST) {
+            if (op_index != 0) {
+                return NFS4ERR_SEQUENCE_POS;
+            }
+        } else if (!(info->flags & NFS4_OP_FLAG_NO_REQ_SESSION)) {
+            if (!seen_sequence) {
+                return NFS4ERR_OP_NOT_IN_SESSION;
+            }
+        }
+    }
+
+    return NFS4_OK;
+} /* nfs4_op_check_minor */

--- a/src/server/nfs/nfs4_proc_allocate.c
+++ b/src/server/nfs/nfs4_proc_allocate.c
@@ -4,6 +4,7 @@
 
 #include "nfs4_procs.h"
 #include "nfs4_status.h"
+#include "nfs4_state.h"
 #include "vfs/vfs_procs.h"
 #include "vfs/vfs_release.h"
 
@@ -14,9 +15,8 @@ chimera_nfs4_allocate_complete(
     struct chimera_vfs_attrs *post_attr,
     void                     *private_data)
 {
-    struct nfs_request             *req = private_data;
-    struct ALLOCATE4res            *res = &req->res_compound.resarray[req->index].opallocate;
-    struct chimera_vfs_open_handle *deferred;
+    struct nfs_request  *req = private_data;
+    struct ALLOCATE4res *res = &req->res_compound.resarray[req->index].opallocate;
 
     if (error_code == CHIMERA_VFS_OK) {
         res->ar_status = NFS4_OK;
@@ -24,10 +24,10 @@ chimera_nfs4_allocate_complete(
         res->ar_status = chimera_nfs4_errno_to_nfsstat4(error_code);
     }
 
-    deferred = nfs4_session_release_state(req->session, req->nfs4_state);
-    if (deferred) {
-        chimera_vfs_release(req->thread->vfs_thread, deferred);
-    }
+    nfs_state_table_release(&req->thread->shared->nfs4_state_table,
+                            req->nfs_state_ref, req->nfs_state_type,
+                            req->thread->vfs_thread);
+    req->nfs_state_ref = NULL;
 
     chimera_nfs4_compound_complete(req, NFS4_OK);
 } /* chimera_nfs4_allocate_complete */
@@ -39,26 +39,30 @@ chimera_nfs4_allocate(
     struct nfs_argop4                *argop,
     struct nfs_resop4                *resop)
 {
-    struct ALLOCATE4args           *args    = &argop->opallocate;
-    struct ALLOCATE4res            *res     = &resop->opallocate;
-    struct nfs4_session            *session = req->session;
-    struct nfs4_state              *state;
+    struct ALLOCATE4args           *args  = &argop->opallocate;
+    struct ALLOCATE4res            *res   = &resop->opallocate;
+    struct nfs_state_table         *table = &thread->shared->nfs4_state_table;
+    void                           *state_void;
+    uint8_t                         state_type;
     struct chimera_vfs_open_handle *state_handle;
+    nfsstat4                        status;
 
-    if (!session) {
-        res->ar_status = NFS4ERR_BAD_STATEID;
+    status = nfs_state_table_acquire(table, &args->aa_stateid, 0,
+                                     &state_void, &state_type);
+    if (status != NFS4_OK) {
+        res->ar_status = status;
         chimera_nfs4_compound_complete(req, NFS4_OK);
         return;
     }
 
-    if (nfs4_session_acquire_state(session, &args->aa_stateid,
-                                   &state, &state_handle) != NFS4_OK) {
-        res->ar_status = NFS4ERR_BAD_STATEID;
-        chimera_nfs4_compound_complete(req, NFS4_OK);
-        return;
+    if (state_type == NFS4_SLOT_TYPE_OPEN) {
+        state_handle = ((struct nfs_open_state *) state_void)->handle;
+    } else {
+        state_handle = ((struct nfs_lock_state *) state_void)->handle;
     }
 
-    req->nfs4_state = state;
+    req->nfs_state_ref  = state_void;
+    req->nfs_state_type = state_type;
 
     chimera_vfs_allocate(thread->vfs_thread, &req->cred,
                          state_handle,

--- a/src/server/nfs/nfs4_proc_close.c
+++ b/src/server/nfs/nfs4_proc_close.c
@@ -5,6 +5,7 @@
 #include "nfs4_procs.h"
 #include "nfs4_status.h"
 #include "nfs4_session.h"
+#include "nfs4_state.h"
 #include "vfs/vfs_procs.h"
 #include "vfs/vfs_release.h"
 void
@@ -14,52 +15,93 @@ chimera_nfs4_close(
     struct nfs_argop4                *argop,
     struct nfs_resop4                *resop)
 {
-    struct CLOSE4args              *args    = &argop->opclose;
-    struct CLOSE4res               *res     = &resop->opclose;
-    struct nfs4_session            *session = nfs4_resolve_session(
-        req->session, req->conn,
-        &thread->shared->nfs4_shared_clients,
-        &args->open_stateid);
-    struct nfs4_state              *state;
-    struct chimera_vfs_open_handle *handle;
-    int                             rc;
+    struct CLOSE4args      *args   = &argop->opclose;
+    struct CLOSE4res       *res    = &resop->opclose;
+    struct nfs_state_table *table  = &thread->shared->nfs4_state_table;
+    bool                    is_v40 = (req->minorversion == 0);
+    void                   *state_void;
+    uint8_t                 state_type;
+    nfsstat4                status;
+    uint32_t                client_short_id;
 
-    if (!session) {
-        res->status = NFS4ERR_BAD_STATEID;
+    status = nfs_state_table_acquire(table,
+                                     &args->open_stateid,
+                                     NFS4_SLOT_TYPE_OPEN,
+                                     &state_void,
+                                     &state_type);
+
+    if (status != NFS4_OK) {
+        res->status = status;
         chimera_nfs4_compound_complete(req, res->status);
         return;
     }
 
-    req->session = session;
+    struct nfs_open_state *open_state = state_void;
+    struct nfs_open_owner *owner      = open_state->owner;
 
-    if (*(uint32_t *) args->open_stateid.other >= NFS4_SESSION_MAX_STATE) {
-        res->status = NFS4ERR_BAD_STATEID;
-        chimera_nfs4_compound_complete(req, res->status);
-        return;
-    }
+    if (is_v40 && owner) {
+        pthread_mutex_lock(&owner->lock);
 
-    state = nfs4_session_get_state(session, &args->open_stateid);
+        int seqid_class = nfs4_owner_seqid_classify(owner->seqid,
+                                                    &owner->replay,
+                                                    args->seqid);
 
-    if (state->nfs4_state_type != NFS4_STATE_TYPE_OPEN) {
-        res->status = NFS4ERR_BAD_STATEID;
-        chimera_nfs4_compound_complete(req, res->status);
-        return;
-    }
-
-    nfs4_session_free_lock_states(session, *(uint32_t *) state->nfs4_state_id.other);
-
-    res->open_stateid = state->nfs4_state_id;
-
-    rc = nfs4_session_free_slot(session, state, &handle);
-
-    if (rc < 0) {
-        res->status = NFS4ERR_BAD_STATEID;
-    } else {
-        if (handle) {
-            chimera_vfs_release(thread->vfs_thread, handle);
+        if (seqid_class == NFS4_SEQID_REPLAY) {
+            /* RFC 7530 §9.1.7: return cached reply.  Replay does NOT
+             * destroy the state -- the original CLOSE already did that
+             * (or, if it didn't, our re-execution would have side
+             * effects we must avoid). */
+            res->status       = owner->replay.status;
+            res->open_stateid = owner->replay.stateid;
+            pthread_mutex_unlock(&owner->lock);
+            nfs_state_table_release(table, open_state, NFS4_SLOT_TYPE_OPEN,
+                                    thread->vfs_thread);
+            chimera_nfs4_compound_complete(req, res->status);
+            return;
         }
-        res->status = NFS4_OK;
+
+        if (seqid_class != NFS4_SEQID_NEW) {
+            pthread_mutex_unlock(&owner->lock);
+            nfs_state_table_release(table, open_state, NFS4_SLOT_TYPE_OPEN,
+                                    thread->vfs_thread);
+            res->status = NFS4ERR_BAD_SEQID;
+            chimera_nfs4_compound_complete(req, res->status);
+            return;
+        }
+
+        pthread_mutex_unlock(&owner->lock);
     }
 
-    chimera_nfs4_compound_complete(req, res->status);
+    /* Bump stateid.seqid per RFC 7530 §16.2.4, then encode the returned
+     * stateid before destroying.  Destroy cascades through any lock_states
+     * rooted on this open. */
+    open_state->seqid += 1;
+    client_short_id    = owner ? (uint32_t) owner->client->client_id : 0;
+
+    nfs4_stateid_encode(&res->open_stateid, open_state->seqid,
+                        NFS4_STATEID_TYPE_OPEN,
+                        open_state->shard, open_state->slot_idx,
+                        open_state->generation, client_short_id);
+
+    /* Record reply BEFORE destroying the state -- after destroy, the owner
+     * may also be torn down by client teardown.  In practice the owner
+     * persists until DESTROY_CLIENTID / expiry, so recording here keeps
+     * the cached stateid available for any retransmit. */
+    if (is_v40 && owner) {
+        pthread_mutex_lock(&owner->lock);
+        owner->seqid = args->seqid;
+        nfs4_replay_record(&owner->replay, args->seqid, OP_CLOSE,
+                           NFS4_OK, &res->open_stateid);
+        pthread_mutex_unlock(&owner->lock);
+    }
+
+    /* Drop the acquire ref, then destroy.  If concurrent READ/WRITE still
+     * hold an acquire-ref, destroy marks the state and cleanup runs on the
+     * last release; otherwise destroy releases the handle here. */
+    nfs_state_table_release(table, open_state, NFS4_SLOT_TYPE_OPEN,
+                            thread->vfs_thread);
+    nfs_open_state_destroy(open_state, table, thread->vfs_thread);
+
+    res->status = NFS4_OK;
+    chimera_nfs4_compound_complete(req, NFS4_OK);
 } /* chimera_nfs4_close */

--- a/src/server/nfs/nfs4_proc_compound.c
+++ b/src/server/nfs/nfs4_proc_compound.c
@@ -3,8 +3,12 @@
 // SPDX-License-Identifier: LGPL-2.1-only
 
 #include "nfs4_procs.h"
+#include "nfs4_session.h"
+#include "evpl/evpl.h"
 #include "evpl/evpl_rpc2.h"
+#include "evpl/evpl_bind.h"
 #include "nfs4_dump.h"
+#include "nfs4_op_matrix.h"
 void
 chimera_nfs4_compound_process(
     struct nfs_request *req,
@@ -15,6 +19,34 @@ chimera_nfs4_compound_process(
     struct nfs_argop4                *argop;
     struct nfs_resop4                *resop;
     int                               rc;
+
+    /* SEQUENCE replay short-circuit: the SEQUENCE op detected a
+     * retransmit on a CACHED slot.  Send the cached reply bytes
+     * verbatim and free the request -- skip compound execution
+     * entirely.  The cached buf is alive because the slot stays
+     * CACHED until the next seqid+1 advances it. */
+    if (req->replay_action == NFS4_REPLAY_ACTION_FROM_CACHE &&
+        req->replay_slot && req->replay_slot->cached_buf) {
+        /* XDR clones a +1 ref on every WRITE4args.data; the retransmit
+         * we are about to discard had its args unmarshalled but will
+         * never dispatch, so release any cloned iovecs here. */
+        for (uint32_t i = 0; i < req->args_compound->num_argarray; i++) {
+            struct nfs_argop4 *ap = &req->args_compound->argarray[i];
+            if (ap->argop == OP_WRITE && ap->opwrite.data.niov) {
+                evpl_iovecs_release(thread->evpl,
+                                    ap->opwrite.data.iov,
+                                    ap->opwrite.data.niov);
+                ap->opwrite.data.niov = 0;
+            }
+        }
+        evpl_send(thread->evpl,
+                  req->conn->bind,
+                  req->replay_slot->cached_buf,
+                  req->replay_slot->cached_len);
+        req->replay_slot = NULL;
+        nfs_request_free(thread, req);
+        return;
+    }
 
  again:
 
@@ -34,6 +66,14 @@ chimera_nfs4_compound_process(
             req->encoding);
         chimera_nfs_abort_if(rc, "Failed to send RPC2 reply");
 
+        /* Advance the SEQUENCE replay slot to CACHED/COMPLETED.  Must
+         * run *after* send_reply because the reply-capture callback
+         * (armed in nfs4_replay_slot_acquire when sa_cachethis was set)
+         * fires from inside send_reply and writes the captured bytes
+         * onto slot->cached_buf, which finalize then promotes to
+         * CACHED state. */
+        nfs4_replay_slot_finalize(req);
+
         nfs_request_free(thread, req);
         return;
     }
@@ -50,143 +90,159 @@ chimera_nfs4_compound_process(
     if (req->encoding->dbuf->size - req->encoding->dbuf->used < 8192) {
         chimera_nfs4_compound_complete(req, NFS4ERR_RESOURCE);
     } else {
-        switch (argop->argop) {
-            case OP_ACCESS:
-                chimera_nfs4_access(thread, req, argop, resop);
-                break;
-            case OP_GETFH:
-                chimera_nfs4_getfh(thread, req, argop, resop);
-                break;
-            case OP_PUTROOTFH:
-                chimera_nfs4_putrootfh(thread, req, argop, resop);
-                break;
-            case OP_GETATTR:
-                chimera_nfs4_getattr(thread, req, argop, resop);
-                break;
-            case OP_SETATTR:
-                chimera_nfs4_setattr(thread, req, argop, resop);
-                break;
-            case OP_CREATE:
-                chimera_nfs4_create(thread, req, argop, resop);
-                break;
-            case OP_LOOKUP:
-                chimera_nfs4_lookup(thread, req, argop, resop);
-                break;
-            case OP_LOOKUPP:
-                chimera_nfs4_lookupp(thread, req, argop, resop);
-                break;
-            case OP_PUTFH:
-                chimera_nfs4_putfh(thread, req, argop, resop);
-                break;
-            case OP_SAVEFH:
-                chimera_nfs4_savefh(thread, req, argop, resop);
-                break;
-            case OP_RESTOREFH:
-                chimera_nfs4_restorefh(thread, req, argop, resop);
-                break;
-            case OP_LINK:
-                chimera_nfs4_link(thread, req, argop, resop);
-                break;
-            case OP_RENAME:
-                chimera_nfs4_rename(thread, req, argop, resop);
-                break;
-            case OP_OPEN:
-                chimera_nfs4_open(thread, req, argop, resop);
-                break;
-            case OP_READDIR:
-                chimera_nfs4_readdir(thread, req, argop, resop);
-                break;
-            case OP_READ:
-                chimera_nfs4_read(thread, req, argop, resop);
-                break;
-            case OP_WRITE:
-                chimera_nfs4_write(thread, req, argop, resop);
-                break;
-            case OP_COMMIT:
-                chimera_nfs4_commit(thread, req, argop, resop);
-                break;
-            case OP_CLOSE:
-                chimera_nfs4_close(thread, req, argop, resop);
-                break;
-            case OP_REMOVE:
-                chimera_nfs4_remove(thread, req, argop, resop);
-                break;
-            case OP_READLINK:
-                chimera_nfs4_readlink(thread, req, argop, resop);
-                break;
-            case OP_SETCLIENTID:
-                chimera_nfs4_setclientid(thread, req, argop, resop);
-                break;
-            case OP_SETCLIENTID_CONFIRM:
-                chimera_nfs4_setclientid_confirm(thread, req, argop, resop);
-                break;
-            case OP_EXCHANGE_ID:
-                chimera_nfs4_exchange_id(thread, req, argop, resop);
-                break;
-            case OP_CREATE_SESSION:
-                chimera_nfs4_create_session(thread, req, argop, resop);
-                break;
-            case OP_DESTROY_SESSION:
-                chimera_nfs4_destroy_session(thread, req, argop, resop);
-                break;
-            case OP_DESTROY_CLIENTID:
-                chimera_nfs4_destroy_clientid(thread, req, argop, resop);
-                break;
-            case OP_SEQUENCE:
-                chimera_nfs4_sequence(thread, req, argop, resop);
-                break;
-            case OP_RECLAIM_COMPLETE:
-                chimera_nfs4_reclaim_complete(thread, req, argop, resop);
-                break;
-            case OP_SECINFO_NO_NAME:
-                chimera_nfs4_secinfo_no_name(thread, req, argop, resop);
-                break;
-            case OP_TEST_STATEID:
-                chimera_nfs4_test_stateid(thread, req, argop, resop);
-                break;
-            case OP_ALLOCATE:
-                chimera_nfs4_allocate(thread, req, argop, resop);
-                break;
-            case OP_DEALLOCATE:
-                chimera_nfs4_deallocate(thread, req, argop, resop);
-                break;
-            case OP_SEEK:
-                chimera_nfs4_seek(thread, req, argop, resop);
-                break;
-            case OP_LOCK:
-                chimera_nfs4_lock(thread, req, argop, resop);
-                break;
-            case OP_LOCKT:
-                chimera_nfs4_lockt(thread, req, argop, resop);
-                break;
-            case OP_LOCKU:
-                chimera_nfs4_locku(thread, req, argop, resop);
-                break;
-            case OP_VERIFY:
-                chimera_nfs4_verify(thread, req, argop, resop);
-                break;
-            case OP_NVERIFY:
-                chimera_nfs4_nverify(thread, req, argop, resop);
-                break;
-            case OP_PUTPUBFH:
-                chimera_nfs4_putpubfh(thread, req, argop, resop);
-                break;
-            case OP_RENEW:
-                chimera_nfs4_renew(thread, req, argop, resop);
-                break;
-            case OP_RELEASE_LOCKOWNER:
-                chimera_nfs4_release_lockowner(thread, req, argop, resop);
-                break;
-            default:
-                chimera_nfs_error("Unsupported operation: %d", argop->argop);
-                if (argop->argop >= OP_ACCESS && argop->argop <= OP_CLONE) {
-                    chimera_nfs4_compound_complete(req, NFS4ERR_NOTSUPP);
-                } else {
-                    chimera_nfs4_compound_complete(req, NFS4ERR_OP_ILLEGAL);
-                }
-                break;
-        } /* switch */
+        nfsstat4 gate = nfs4_op_check_minor(argop->argop,
+                                            req->minorversion,
+                                            (uint32_t) req->index,
+                                            req->seen_sequence);
 
+        if (gate != NFS4_OK) {
+            chimera_nfs4_compound_complete(req, gate);
+        } else {
+            switch (argop->argop) {
+                case OP_ACCESS:
+                    chimera_nfs4_access(thread, req, argop, resop);
+                    break;
+                case OP_GETFH:
+                    chimera_nfs4_getfh(thread, req, argop, resop);
+                    break;
+                case OP_PUTROOTFH:
+                    chimera_nfs4_putrootfh(thread, req, argop, resop);
+                    break;
+                case OP_PUTPUBFH:
+                    chimera_nfs4_putpubfh(thread, req, argop, resop);
+                    break;
+                case OP_GETATTR:
+                    chimera_nfs4_getattr(thread, req, argop, resop);
+                    break;
+                case OP_SETATTR:
+                    chimera_nfs4_setattr(thread, req, argop, resop);
+                    break;
+                case OP_CREATE:
+                    chimera_nfs4_create(thread, req, argop, resop);
+                    break;
+                case OP_LOOKUP:
+                    chimera_nfs4_lookup(thread, req, argop, resop);
+                    break;
+                case OP_LOOKUPP:
+                    chimera_nfs4_lookupp(thread, req, argop, resop);
+                    break;
+                case OP_PUTFH:
+                    chimera_nfs4_putfh(thread, req, argop, resop);
+                    break;
+                case OP_SAVEFH:
+                    chimera_nfs4_savefh(thread, req, argop, resop);
+                    break;
+                case OP_RESTOREFH:
+                    chimera_nfs4_restorefh(thread, req, argop, resop);
+                    break;
+                case OP_LINK:
+                    chimera_nfs4_link(thread, req, argop, resop);
+                    break;
+                case OP_RENAME:
+                    chimera_nfs4_rename(thread, req, argop, resop);
+                    break;
+                case OP_OPEN:
+                    chimera_nfs4_open(thread, req, argop, resop);
+                    break;
+                case OP_READDIR:
+                    chimera_nfs4_readdir(thread, req, argop, resop);
+                    break;
+                case OP_READ:
+                    chimera_nfs4_read(thread, req, argop, resop);
+                    break;
+                case OP_WRITE:
+                    chimera_nfs4_write(thread, req, argop, resop);
+                    break;
+                case OP_COMMIT:
+                    chimera_nfs4_commit(thread, req, argop, resop);
+                    break;
+                case OP_CLOSE:
+                    chimera_nfs4_close(thread, req, argop, resop);
+                    break;
+                case OP_REMOVE:
+                    chimera_nfs4_remove(thread, req, argop, resop);
+                    break;
+                case OP_READLINK:
+                    chimera_nfs4_readlink(thread, req, argop, resop);
+                    break;
+                case OP_SETCLIENTID:
+                    chimera_nfs4_setclientid(thread, req, argop, resop);
+                    break;
+                case OP_SETCLIENTID_CONFIRM:
+                    chimera_nfs4_setclientid_confirm(thread, req, argop, resop);
+                    break;
+                case OP_RENEW:
+                    chimera_nfs4_renew(thread, req, argop, resop);
+                    break;
+                case OP_OPEN_CONFIRM:
+                    chimera_nfs4_open_confirm(thread, req, argop, resop);
+                    break;
+                case OP_OPEN_DOWNGRADE:
+                    chimera_nfs4_open_downgrade(thread, req, argop, resop);
+                    break;
+                case OP_RELEASE_LOCKOWNER:
+                    chimera_nfs4_release_lockowner(thread, req, argop, resop);
+                    break;
+                case OP_EXCHANGE_ID:
+                    chimera_nfs4_exchange_id(thread, req, argop, resop);
+                    break;
+                case OP_CREATE_SESSION:
+                    chimera_nfs4_create_session(thread, req, argop, resop);
+                    break;
+                case OP_DESTROY_SESSION:
+                    chimera_nfs4_destroy_session(thread, req, argop, resop);
+                    break;
+                case OP_DESTROY_CLIENTID:
+                    chimera_nfs4_destroy_clientid(thread, req, argop, resop);
+                    break;
+                case OP_SEQUENCE:
+                    req->seen_sequence = true;
+                    chimera_nfs4_sequence(thread, req, argop, resop);
+                    break;
+                case OP_RECLAIM_COMPLETE:
+                    chimera_nfs4_reclaim_complete(thread, req, argop, resop);
+                    break;
+                case OP_SECINFO_NO_NAME:
+                    chimera_nfs4_secinfo_no_name(thread, req, argop, resop);
+                    break;
+                case OP_TEST_STATEID:
+                    chimera_nfs4_test_stateid(thread, req, argop, resop);
+                    break;
+                case OP_ALLOCATE:
+                    chimera_nfs4_allocate(thread, req, argop, resop);
+                    break;
+                case OP_DEALLOCATE:
+                    chimera_nfs4_deallocate(thread, req, argop, resop);
+                    break;
+                case OP_SEEK:
+                    chimera_nfs4_seek(thread, req, argop, resop);
+                    break;
+                case OP_LOCK:
+                    chimera_nfs4_lock(thread, req, argop, resop);
+                    break;
+                case OP_LOCKT:
+                    chimera_nfs4_lockt(thread, req, argop, resop);
+                    break;
+                case OP_LOCKU:
+                    chimera_nfs4_locku(thread, req, argop, resop);
+                    break;
+                case OP_VERIFY:
+                    chimera_nfs4_verify(thread, req, argop, resop);
+                    break;
+                case OP_NVERIFY:
+                    chimera_nfs4_nverify(thread, req, argop, resop);
+                    break;
+                default:
+                    chimera_nfs_error("Unsupported operation: %d", argop->argop);
+                    if (argop->argop >= OP_ACCESS && argop->argop <= OP_CLONE) {
+                        chimera_nfs4_compound_complete(req, NFS4ERR_NOTSUPP);
+                    } else {
+                        chimera_nfs4_compound_complete(req, NFS4ERR_OP_ILLEGAL);
+                    }
+                    break;
+            } /* switch */
+
+        }
     }
     thread->active = 0;
 
@@ -233,9 +289,14 @@ chimera_nfs4_compound(
     /* RFC 7530 §16.2.4: the server MUST echo the request tag back to the
      * client unchanged. xdr_opaque .data is owned by the request msg buffer
      * which lives until the response is sent. */
-    req->res_compound.tag = args->tag;
-    req->fhlen            = 0;
-    req->saved_fhlen      = 0;
+    req->res_compound.tag    = args->tag;
+    req->fhlen               = 0;
+    req->saved_fhlen         = 0;
+    req->minorversion        = (uint8_t) args->minorversion;
+    req->seen_sequence       = false;
+    req->open_4_0_owner      = NULL;
+    req->lock_4_0_open_owner = NULL;
+    req->lock_4_0_lock_owner = NULL;
 
     /* Chimera implements NFS v4.0, v4.1 and v4.2 (minorversions 0–2).
      * Reject unknown minor versions with NFS4ERR_MINOR_VERS_MISMATCH per

--- a/src/server/nfs/nfs4_proc_create_session.c
+++ b/src/server/nfs/nfs4_proc_create_session.c
@@ -17,17 +17,40 @@ chimera_nfs4_create_session(
     struct CREATE_SESSION4args       *args   = &argop->opcreate_session;
     struct CREATE_SESSION4res        *res    = &resop->opcreate_session;
     struct nfs4_session              *session;
+    struct channel_attrs4             clamped_fore;
     uint32_t                          flags = 0;
+    uint32_t                          replay_max_slots;
+    uint32_t                          replay_maxresp_cached;
 
     if (args->csa_flags & CREATE_SESSION4_FLAG_CONN_BACK_CHAN) {
         flags |= CREATE_SESSION4_FLAG_CONN_BACK_CHAN;
     }
 
+    /* RFC 5661 18.36.4: the server may negotiate ca_maxrequests and
+     * ca_maxresponsesize_cached downward and return the effective values
+     * to the client. */
+    clamped_fore = args->csa_fore_chan_attrs;
+
+    replay_max_slots = clamped_fore.ca_maxrequests;
+    if (replay_max_slots == 0 ||
+        replay_max_slots > NFS4_MAX_REPLY_CACHE_SLOTS) {
+        replay_max_slots = NFS4_MAX_REPLY_CACHE_SLOTS;
+    }
+    clamped_fore.ca_maxrequests = replay_max_slots;
+
+    replay_maxresp_cached = clamped_fore.ca_maxresponsesize_cached;
+    if (replay_maxresp_cached > NFS4_MAX_CACHED_RESPONSE_SIZE) {
+        replay_maxresp_cached = NFS4_MAX_CACHED_RESPONSE_SIZE;
+    }
+    clamped_fore.ca_maxresponsesize_cached = replay_maxresp_cached;
+
     session = nfs4_create_session(
         &shared->nfs4_shared_clients,
         args->csa_clientid,
         0,
-        &args->csa_fore_chan_attrs,
+        replay_max_slots,
+        replay_maxresp_cached,
+        &clamped_fore,
         &args->csa_back_chan_attrs);
 
     if (!session) {

--- a/src/server/nfs/nfs4_proc_deallocate.c
+++ b/src/server/nfs/nfs4_proc_deallocate.c
@@ -4,6 +4,7 @@
 
 #include "nfs4_procs.h"
 #include "nfs4_status.h"
+#include "nfs4_state.h"
 #include "vfs/vfs_procs.h"
 #include "vfs/vfs_release.h"
 
@@ -14,9 +15,8 @@ chimera_nfs4_deallocate_complete(
     struct chimera_vfs_attrs *post_attr,
     void                     *private_data)
 {
-    struct nfs_request             *req = private_data;
-    struct DEALLOCATE4res          *res = &req->res_compound.resarray[req->index].opdeallocate;
-    struct chimera_vfs_open_handle *deferred;
+    struct nfs_request    *req = private_data;
+    struct DEALLOCATE4res *res = &req->res_compound.resarray[req->index].opdeallocate;
 
     if (error_code == CHIMERA_VFS_OK) {
         res->dr_status = NFS4_OK;
@@ -24,10 +24,10 @@ chimera_nfs4_deallocate_complete(
         res->dr_status = chimera_nfs4_errno_to_nfsstat4(error_code);
     }
 
-    deferred = nfs4_session_release_state(req->session, req->nfs4_state);
-    if (deferred) {
-        chimera_vfs_release(req->thread->vfs_thread, deferred);
-    }
+    nfs_state_table_release(&req->thread->shared->nfs4_state_table,
+                            req->nfs_state_ref, req->nfs_state_type,
+                            req->thread->vfs_thread);
+    req->nfs_state_ref = NULL;
 
     chimera_nfs4_compound_complete(req, NFS4_OK);
 } /* chimera_nfs4_deallocate_complete */
@@ -39,26 +39,30 @@ chimera_nfs4_deallocate(
     struct nfs_argop4                *argop,
     struct nfs_resop4                *resop)
 {
-    struct DEALLOCATE4args         *args    = &argop->opdeallocate;
-    struct DEALLOCATE4res          *res     = &resop->opdeallocate;
-    struct nfs4_session            *session = req->session;
-    struct nfs4_state              *state;
+    struct DEALLOCATE4args         *args  = &argop->opdeallocate;
+    struct DEALLOCATE4res          *res   = &resop->opdeallocate;
+    struct nfs_state_table         *table = &thread->shared->nfs4_state_table;
+    void                           *state_void;
+    uint8_t                         state_type;
     struct chimera_vfs_open_handle *state_handle;
+    nfsstat4                        status;
 
-    if (!session) {
-        res->dr_status = NFS4ERR_BAD_STATEID;
+    status = nfs_state_table_acquire(table, &args->da_stateid, 0,
+                                     &state_void, &state_type);
+    if (status != NFS4_OK) {
+        res->dr_status = status;
         chimera_nfs4_compound_complete(req, NFS4_OK);
         return;
     }
 
-    if (nfs4_session_acquire_state(session, &args->da_stateid,
-                                   &state, &state_handle) != NFS4_OK) {
-        res->dr_status = NFS4ERR_BAD_STATEID;
-        chimera_nfs4_compound_complete(req, NFS4_OK);
-        return;
+    if (state_type == NFS4_SLOT_TYPE_OPEN) {
+        state_handle = ((struct nfs_open_state *) state_void)->handle;
+    } else {
+        state_handle = ((struct nfs_lock_state *) state_void)->handle;
     }
 
-    req->nfs4_state = state;
+    req->nfs_state_ref  = state_void;
+    req->nfs_state_type = state_type;
 
     chimera_vfs_allocate(thread->vfs_thread, &req->cred,
                          state_handle,

--- a/src/server/nfs/nfs4_proc_destroy_clientid.c
+++ b/src/server/nfs/nfs4_proc_destroy_clientid.c
@@ -1,8 +1,9 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
 #include "nfs4_procs.h"
+#include "nfs4_session.h"
 #include "evpl/evpl_rpc2.h"
 
 void
@@ -16,13 +17,16 @@ chimera_nfs4_destroy_clientid(
     struct DESTROY_CLIENTID4args     *args   = &argop->opdestroy_clientid;
     struct DESTROY_CLIENTID4res      *res    = &resop->opdestroy_clientid;
 
-
-    nfs4_client_unregister(
-        &shared->nfs4_shared_clients,
-        args->dca_clientid);
-
+    /* Pass state_table + vfs_thread so nfs4_client_unregister can tear
+     * down the unified state hierarchy (owners, states, dup'd VFS
+     * handles) along with the nfs4_client record.  Previously this leaked
+     * the unified hierarchy on every DESTROY_CLIENTID. */
+    nfs4_client_unregister(&shared->nfs4_shared_clients,
+                           &shared->nfs4_state_table,
+                           thread->vfs_thread,
+                           args->dca_clientid);
 
     res->dcr_status = NFS4_OK;
 
     chimera_nfs4_compound_complete(req, NFS4_OK);
-} /* chimera_nfs4_setclientid */
+} /* chimera_nfs4_destroy_clientid */

--- a/src/server/nfs/nfs4_proc_exchange_id.c
+++ b/src/server/nfs/nfs4_proc_exchange_id.c
@@ -1,8 +1,11 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
 #include "nfs4_procs.h"
+#include "nfs4_recovery.h"
+#include "nfs4_session.h"
+#include "nfs4_state.h"
 #include "evpl/evpl_rpc2.h"
 
 void
@@ -30,6 +33,25 @@ chimera_nfs4_exchange_id(
         *(uint64_t *) args->eia_clientowner.co_verifier,
         40,
         NULL, NULL);
+
+    /* Phase 5: 4.1+ EXCHANGE_ID is the moment of identity establishment;
+     * stub-persist the unified client so a future stable-storage backend
+     * can pick it up after a restart. */
+    {
+        struct nfs4_client *c  = NULL;
+        struct nfs_client  *uc = NULL;
+        pthread_mutex_lock(&thread->shared->nfs4_shared_clients.nfs4_ct_lock);
+        HASH_FIND(nfs4_client_hh_by_id,
+                  thread->shared->nfs4_shared_clients.nfs4_ct_clients_by_id,
+                  &client_id, sizeof(client_id), c);
+        if (c) {
+            uc = c->unified;
+        }
+        pthread_mutex_unlock(&thread->shared->nfs4_shared_clients.nfs4_ct_lock);
+        if (uc) {
+            nfs_recovery_persist(&thread->shared->nfs4_recovery, uc);
+        }
+    }
 
     res->eir_status                           = NFS4_OK;
     res->eir_resok4.eir_clientid              = client_id;

--- a/src/server/nfs/nfs4_proc_lock.c
+++ b/src/server/nfs/nfs4_proc_lock.c
@@ -5,8 +5,86 @@
 #include "nfs4_procs.h"
 #include "nfs4_status.h"
 #include "nfs4_session.h"
+#include "nfs4_state.h"
 #include "vfs/vfs_procs.h"
 #include "vfs/vfs_release.h"
+
+/*
+ * RFC 7530 §9.1.7 LOCK completion wrapper.  Advances the owner seqid(s)
+ * and caches the reply for every outcome that nfs4_seqid_should_advance()
+ * accepts.  Routing rules per the LOCK4args.locker.new_lock_owner flag:
+ *
+ *   new_lock_owner=true:
+ *     - advance open_owner.seqid to args->locker.open_owner.open_seqid;
+ *     - advance lock_owner.seqid to args->locker.open_owner.lock_seqid
+ *       (this is the initialization step for a brand-new lock_owner);
+ *     - cache the reply on the open_owner keyed by open_seqid (that is
+ *       the seqid the client retransmits).
+ *
+ *   new_lock_owner=false:
+ *     - advance lock_owner.seqid to args->locker.lock_owner.lock_seqid;
+ *     - cache the reply on the lock_owner keyed by lock_seqid.
+ *
+ * Called instead of chimera_nfs4_compound_complete on every LOCK
+ * response path (entry-time short-circuits, length validation, VFS
+ * completion).  Safe to call when the lock_4_0_* fields are NULL --
+ * that means classification didn't run (4.1+ or pre-classification
+ * NOFILEHANDLE etc.), and the wrapper falls through.
+ */
+static void
+chimera_nfs4_lock_finish(
+    struct nfs_request *req,
+    nfsstat4            status)
+{
+    if (req->minorversion == 0 &&
+        nfs4_seqid_should_advance(status)) {
+
+        struct LOCK4args      *args =
+            &req->args_compound->argarray[req->index].oplock;
+        struct LOCK4res       *res =
+            &req->res_compound.resarray[req->index].oplock;
+        const struct stateid4 *cache_stateid =
+            (status == NFS4_OK) ? &res->resok4.lock_stateid : NULL;
+
+        if (args->locker.new_lock_owner) {
+            struct nfs_open_owner *oo         = req->lock_4_0_open_owner;
+            struct nfs_lock_owner *lo         = req->lock_4_0_lock_owner;
+            uint32_t               open_seqid =
+                args->locker.open_owner.open_seqid;
+            uint32_t               lock_seqid =
+                args->locker.open_owner.lock_seqid;
+
+            if (oo) {
+                pthread_mutex_lock(&oo->lock);
+                oo->seqid = open_seqid;
+                nfs4_replay_record(&oo->replay, open_seqid, OP_LOCK,
+                                   status, cache_stateid);
+                pthread_mutex_unlock(&oo->lock);
+            }
+            if (lo) {
+                pthread_mutex_lock(&lo->lock);
+                lo->seqid = lock_seqid;
+                /* No replay cache on a brand-new lock_owner; the open_owner
+                 * cache above is the authoritative replay surface. */
+                pthread_mutex_unlock(&lo->lock);
+            }
+        } else {
+            struct nfs_lock_owner *lo         = req->lock_4_0_lock_owner;
+            uint32_t               lock_seqid =
+                args->locker.lock_owner.lock_seqid;
+
+            if (lo) {
+                pthread_mutex_lock(&lo->lock);
+                lo->seqid = lock_seqid;
+                nfs4_replay_record(&lo->replay, lock_seqid, OP_LOCK,
+                                   status, cache_stateid);
+                pthread_mutex_unlock(&lo->lock);
+            }
+        }
+    }
+
+    chimera_nfs4_compound_complete(req, status);
+} /* chimera_nfs4_lock_finish */
 
 static void
 chimera_nfs4_lock_complete(
@@ -17,58 +95,66 @@ chimera_nfs4_lock_complete(
     pid_t                  conflict_pid,
     void                  *private_data)
 {
-    struct nfs_request             *req        = private_data;
-    struct LOCK4args               *args       = &req->args_compound->argarray[req->index].oplock;
-    struct LOCK4res                *res        = &req->res_compound.resarray[req->index].oplock;
-    struct nfs4_session            *session    = req->session;
-    struct nfs4_state              *lock_state = req->nfs4_state;
-    struct chimera_vfs_open_handle *unused;
+    struct nfs_request     *req        = private_data;
+    struct LOCK4args       *args       = &req->args_compound->argarray[req->index].oplock;
+    struct LOCK4res        *res        = &req->res_compound.resarray[req->index].oplock;
+    struct nfs_state_table *table      = &req->thread->shared->nfs4_state_table;
+    struct nfs_lock_state  *lock_state = req->nfs_state_ref;
+    uint32_t                client_short_id;
 
     if (error_code == CHIMERA_VFS_OK) {
-        /* RFC 7530 Section 9.1.3: seqid starts at 1 for a new lock stateid;
+        /* RFC 7530 §9.1.3: stateid.seqid starts at 1 for a new lock_stateid;
          * only increment when modifying an existing lock state. */
         if (!args->locker.new_lock_owner) {
-            lock_state->nfs4_state_id.seqid++;
-            nfs4_session_release_state(session, lock_state);
+            lock_state->seqid += 1;
         }
-        res->status              = NFS4_OK;
-        res->resok4.lock_stateid = lock_state->nfs4_state_id;
-        chimera_nfs4_compound_complete(req, NFS4_OK);
+
+        client_short_id = (uint32_t) lock_state->lock_owner->client->client_id;
+        nfs4_stateid_encode(&res->resok4.lock_stateid, lock_state->seqid,
+                            NFS4_STATEID_TYPE_LOCK,
+                            lock_state->shard, lock_state->slot_idx,
+                            lock_state->generation, client_short_id);
+
+        res->status = NFS4_OK;
+
+        /* Drop the acquire ref taken at lock entry.  The seqid advance
+         * + replay cache record runs inside chimera_nfs4_lock_complete
+         * (the wrapper, called via the macro below). */
+        nfs_state_table_release(table, lock_state, NFS4_SLOT_TYPE_LOCK,
+                                req->thread->vfs_thread);
+        req->nfs_state_ref = NULL;
+        chimera_nfs4_lock_finish(req, NFS4_OK);
         return;
     }
 
-    /* Lock conflict - free the slot if we just allocated it */
+    /* Failure: tear down the freshly-allocated lock_state if this was a
+     * new lock_owner request; otherwise just drop the acquire ref. */
+    if (args->locker.new_lock_owner) {
+        /* Drop the acquire ref taken at create time, then destroy.  Destroy
+         * will release the dup'd handle as the last ref drops. */
+        nfs_state_table_release(table, lock_state, NFS4_SLOT_TYPE_LOCK,
+                                req->thread->vfs_thread);
+        nfs_lock_state_destroy(lock_state, table, req->thread->vfs_thread);
+    } else {
+        nfs_state_table_release(table, lock_state, NFS4_SLOT_TYPE_LOCK,
+                                req->thread->vfs_thread);
+    }
+    req->nfs_state_ref = NULL;
+
     if (error_code == CHIMERA_VFS_EACCES || error_code == CHIMERA_VFS_EAGAIN) {
-        if (args->locker.new_lock_owner) {
-            lock_state->nfs4_state_handle = NULL;
-            nfs4_session_free_slot(session, lock_state, &unused);
-        } else {
-            nfs4_session_release_state(session, lock_state);
-        }
         res->status          = NFS4ERR_DENIED;
         res->denied.offset   = conflict_offset;
         res->denied.length   = conflict_length;
         res->denied.locktype = (conflict_type == CHIMERA_VFS_LOCK_READ) ?
             READ_LT : WRITE_LT;
-        /* The VFS layer does not expose the conflicting lock's NFS owner;
-         * return a zeroed owner rather than the requester's clientid. */
+        /* VFS does not expose the conflicting lock's NFS owner; zero it. */
         res->denied.owner.clientid   = 0;
         res->denied.owner.owner.len  = 0;
         res->denied.owner.owner.data = NULL;
-        chimera_nfs4_compound_complete(req, res->status);
-        return;
-    }
-
-    /* Other error - clean up allocated or acquired state */
-    if (args->locker.new_lock_owner) {
-        lock_state->nfs4_state_handle = NULL;
-        nfs4_session_free_slot(session, lock_state, &unused);
     } else {
-        nfs4_session_release_state(session, lock_state);
+        res->status = chimera_nfs4_errno_to_nfsstat4(error_code);
     }
-
-    res->status = chimera_nfs4_errno_to_nfsstat4(error_code);
-    chimera_nfs4_compound_complete(req, res->status);
+    chimera_nfs4_lock_finish(req, res->status);
 } /* chimera_nfs4_lock_complete */
 
 void
@@ -78,19 +164,21 @@ chimera_nfs4_lock(
     struct nfs_argop4                *argop,
     struct nfs_resop4                *resop)
 {
-    struct LOCK4args               *args = &argop->oplock;
-    struct LOCK4res                *res  = &resop->oplock;
-    struct nfs4_session            *session;
-    struct nfs4_state              *open_state;
-    struct nfs4_state              *lock_state;
+    struct LOCK4args               *args  = &argop->oplock;
+    struct LOCK4res                *res   = &resop->oplock;
+    struct nfs_state_table         *table = &thread->shared->nfs4_state_table;
+    struct nfs_open_state          *open_state;
+    struct nfs_lock_state          *lock_state;
     struct chimera_vfs_open_handle *handle;
-    struct chimera_vfs_open_handle *unused;
+    void                           *state_void;
+    uint8_t                         state_type;
     uint32_t                        lock_type;
+    nfsstat4                        status;
 
-    /* RFC 7530 Section 16.10.3: current filehandle must be set */
+    /* RFC 7530 §16.10.3: current filehandle must be set */
     if (req->fhlen == 0) {
         res->status = NFS4ERR_NOFILEHANDLE;
-        chimera_nfs4_compound_complete(req, res->status);
+        chimera_nfs4_lock_finish(req, res->status);
         return;
     }
 
@@ -101,93 +189,166 @@ chimera_nfs4_lock(
     }
 
     if (args->locker.new_lock_owner) {
-        /* First lock for this open - validate open stateid, allocate lock state */
-        session = nfs4_resolve_session(
-            req->session, req->conn,
-            &thread->shared->nfs4_shared_clients,
-            &args->locker.open_owner.open_stateid);
+        struct state_owner4   *lo_args = &args->locker.open_owner.lock_owner;
+        struct nfs_client     *client;
+        struct nfs_lock_owner *lock_owner;
+        bool                   created;
 
-        if (!session) {
-            res->status = NFS4ERR_BAD_STATEID;
-            chimera_nfs4_compound_complete(req, res->status);
+        /* Validate the supplied open stateid. */
+        status = nfs_state_table_acquire(table,
+                                         &args->locker.open_owner.open_stateid,
+                                         NFS4_SLOT_TYPE_OPEN,
+                                         &state_void, &state_type);
+        if (status != NFS4_OK) {
+            res->status = status;
+            chimera_nfs4_lock_finish(req, res->status);
             return;
         }
+        open_state = state_void;
+        client     = open_state->owner->client;
 
-        req->session = session;
+        /* RFC 7530 §9.1.4: lock_owner is scoped to the client.  Find or
+         * create one and link the new lock_state to both the lock_owner and
+         * the open_state. */
+        lock_owner = nfs_lock_owner_find_or_create(client,
+                                                   lo_args->owner.data,
+                                                   lo_args->owner.len,
+                                                   &created);
 
-        if (nfs4_session_acquire_state(session,
-                                       &args->locker.open_owner.open_stateid,
-                                       &open_state,
-                                       &handle) != NFS4_OK) {
-            res->status = NFS4ERR_BAD_STATEID;
-            chimera_nfs4_compound_complete(req, res->status);
-            return;
+        /* RFC 7530 §9.1.7 entry-time seqid classification on the open_owner
+         * (whose open_seqid the client advanced to perform this LOCK).
+         * The lock_owner may be brand new; its seqid is initialized on
+         * success in chimera_nfs4_lock_finish.  Done BEFORE the lock_state
+         * is created so a replay short-circuits without leaving stray state. */
+        if (req->minorversion == 0) {
+            struct nfs_open_owner *oo = open_state->owner;
+            pthread_mutex_lock(&oo->lock);
+            int                    cls = nfs4_owner_seqid_classify(
+                oo->seqid, &oo->replay,
+                args->locker.open_owner.open_seqid);
+
+            if (cls == NFS4_SEQID_REPLAY) {
+                res->status              = oo->replay.status;
+                res->resok4.lock_stateid = oo->replay.stateid;
+                pthread_mutex_unlock(&oo->lock);
+                nfs_state_table_release(table, open_state,
+                                        NFS4_SLOT_TYPE_OPEN,
+                                        thread->vfs_thread);
+                chimera_nfs4_compound_complete(req, NFS4_OK);
+                return;
+            }
+            if (cls != NFS4_SEQID_NEW) {
+                pthread_mutex_unlock(&oo->lock);
+                nfs_state_table_release(table, open_state,
+                                        NFS4_SLOT_TYPE_OPEN,
+                                        thread->vfs_thread);
+                res->status = NFS4ERR_BAD_SEQID;
+                chimera_nfs4_compound_complete(req, res->status);
+                return;
+            }
+            pthread_mutex_unlock(&oo->lock);
+            req->lock_4_0_open_owner = oo;
+            req->lock_4_0_lock_owner = lock_owner;
         }
 
-        if (open_state->nfs4_state_type != NFS4_STATE_TYPE_OPEN) {
-            nfs4_session_release_state(session, open_state);
-            res->status = NFS4ERR_BAD_STATEID;
-            chimera_nfs4_compound_complete(req, res->status);
-            return;
-        }
+        /* Take a distinct +1 dup on the VFS handle: lock_state's lifetime
+         * is independent of the open_state's. */
+        handle = open_state->handle;
+        chimera_vfs_dup_handle(thread->vfs_thread, handle);
 
-        /* Allocate a lock state that borrows the open handle */
-        lock_state                         = nfs4_session_alloc_slot(session);
-        lock_state->nfs4_state_type        = NFS4_STATE_TYPE_LOCK;
-        lock_state->nfs4_state_handle      = handle;
-        lock_state->nfs4_state_parent_slot = *(uint32_t *) open_state->nfs4_state_id.other;
+        lock_state = nfs_lock_state_create(lock_owner, open_state, handle,
+                                           (uint32_t) client->client_id,
+                                           table, &res->resok4.lock_stateid);
 
-        req->nfs4_state = lock_state;
+        /* Release the open_state acquire ref.  The lock_state holds its
+         * own dup of the handle; the open_state's lifetime remains its
+         * own concern. */
+        nfs_state_table_release(table, open_state, NFS4_SLOT_TYPE_OPEN,
+                                thread->vfs_thread);
 
-        /* Release the open state acquire ref - handle stays alive while open is active */
-        nfs4_session_release_state(session, open_state);
+        /* For the async VFS call, hold an acquire ref on the lock_state.
+         * Acquire it via the slot table so the refcount machinery is
+         * consistent (avoid manual increments). */
+        struct stateid4 lock_stateid_for_acquire;
+        nfs4_stateid_encode(&lock_stateid_for_acquire, lock_state->seqid,
+                            NFS4_STATEID_TYPE_LOCK,
+                            lock_state->shard, lock_state->slot_idx,
+                            lock_state->generation,
+                            (uint32_t) client->client_id);
+        status = nfs_state_table_acquire(table, &lock_stateid_for_acquire,
+                                         NFS4_SLOT_TYPE_LOCK,
+                                         &state_void, &state_type);
+        chimera_nfs_abort_if(status != NFS4_OK,
+                             "freshly-created lock_state not findable");
+
+        req->nfs_state_ref  = lock_state;
+        req->nfs_state_type = NFS4_SLOT_TYPE_LOCK;
 
     } else {
-        /* Subsequent lock - use existing lock stateid */
-        session = nfs4_resolve_session(
-            req->session, req->conn,
-            &thread->shared->nfs4_shared_clients,
-            &args->locker.lock_owner.lock_stateid);
-
-        if (!session) {
-            res->status = NFS4ERR_BAD_STATEID;
-            chimera_nfs4_compound_complete(req, res->status);
+        /* Subsequent lock under an existing lock stateid. */
+        status = nfs_state_table_acquire(table,
+                                         &args->locker.lock_owner.lock_stateid,
+                                         NFS4_SLOT_TYPE_LOCK,
+                                         &state_void, &state_type);
+        if (status != NFS4_OK) {
+            res->status = status;
+            chimera_nfs4_lock_finish(req, res->status);
             return;
         }
+        lock_state          = state_void;
+        handle              = lock_state->handle;
+        req->nfs_state_ref  = lock_state;
+        req->nfs_state_type = NFS4_SLOT_TYPE_LOCK;
 
-        req->session = session;
+        /* RFC 7530 §9.1.7 entry-time seqid classification on the lock_owner. */
+        if (req->minorversion == 0) {
+            struct nfs_lock_owner *lo = lock_state->lock_owner;
+            pthread_mutex_lock(&lo->lock);
+            int                    cls = nfs4_owner_seqid_classify(
+                lo->seqid, &lo->replay,
+                args->locker.lock_owner.lock_seqid);
 
-        if (nfs4_session_acquire_state(session,
-                                       &args->locker.lock_owner.lock_stateid,
-                                       &lock_state,
-                                       &handle) != NFS4_OK) {
-            res->status = NFS4ERR_BAD_STATEID;
-            chimera_nfs4_compound_complete(req, res->status);
-            return;
+            if (cls == NFS4_SEQID_REPLAY) {
+                res->status              = lo->replay.status;
+                res->resok4.lock_stateid = lo->replay.stateid;
+                pthread_mutex_unlock(&lo->lock);
+                nfs_state_table_release(table, lock_state,
+                                        NFS4_SLOT_TYPE_LOCK,
+                                        thread->vfs_thread);
+                req->nfs_state_ref = NULL;
+                chimera_nfs4_compound_complete(req, NFS4_OK);
+                return;
+            }
+            if (cls != NFS4_SEQID_NEW) {
+                pthread_mutex_unlock(&lo->lock);
+                nfs_state_table_release(table, lock_state,
+                                        NFS4_SLOT_TYPE_LOCK,
+                                        thread->vfs_thread);
+                req->nfs_state_ref = NULL;
+                res->status        = NFS4ERR_BAD_SEQID;
+                chimera_nfs4_compound_complete(req, res->status);
+                return;
+            }
+            pthread_mutex_unlock(&lo->lock);
+            req->lock_4_0_lock_owner = lo;
         }
-
-        if (lock_state->nfs4_state_type != NFS4_STATE_TYPE_LOCK) {
-            nfs4_session_release_state(session, lock_state);
-            res->status = NFS4ERR_BAD_STATEID;
-            chimera_nfs4_compound_complete(req, res->status);
-            return;
-        }
-
-        req->nfs4_state = lock_state;
     }
 
-    /* RFC 7530 Section 16.10.4: length must not be zero; if not the all-ones
+    /* RFC 7530 §16.10.4: length must not be zero; if not the all-ones
      * "to-EOF" sentinel, offset+length must not exceed UINT64_MAX. */
     if (args->length == 0 ||
         (args->length != UINT64_MAX && args->offset > UINT64_MAX - args->length)) {
         if (args->locker.new_lock_owner) {
-            lock_state->nfs4_state_handle = NULL;
-            nfs4_session_free_slot(session, lock_state, &unused);
+            nfs_state_table_release(table, lock_state, NFS4_SLOT_TYPE_LOCK,
+                                    thread->vfs_thread);
+            nfs_lock_state_destroy(lock_state, table, thread->vfs_thread);
         } else {
-            nfs4_session_release_state(session, lock_state);
+            nfs_state_table_release(table, lock_state, NFS4_SLOT_TYPE_LOCK,
+                                    thread->vfs_thread);
         }
-        res->status = NFS4ERR_INVAL;
-        chimera_nfs4_compound_complete(req, res->status);
+        req->nfs_state_ref = NULL;
+        res->status        = NFS4ERR_INVAL;
+        chimera_nfs4_lock_finish(req, res->status);
         return;
     }
 

--- a/src/server/nfs/nfs4_proc_locku.c
+++ b/src/server/nfs/nfs4_proc_locku.c
@@ -5,6 +5,7 @@
 #include "nfs4_procs.h"
 #include "nfs4_status.h"
 #include "nfs4_session.h"
+#include "nfs4_state.h"
 #include "vfs/vfs_procs.h"
 #include "vfs/vfs_release.h"
 
@@ -17,21 +18,44 @@ chimera_nfs4_locku_complete(
     pid_t                  conflict_pid,
     void                  *private_data)
 {
-    struct nfs_request *req        = private_data;
-    struct LOCKU4res   *res        = &req->res_compound.resarray[req->index].oplocku;
-    struct nfs4_state  *lock_state = req->nfs4_state;
+    struct nfs_request     *req        = private_data;
+    struct LOCKU4args      *args       = &req->args_compound->argarray[req->index].oplocku;
+    struct LOCKU4res       *res        = &req->res_compound.resarray[req->index].oplocku;
+    struct nfs_state_table *table      = &req->thread->shared->nfs4_state_table;
+    struct nfs_lock_state  *lock_state = req->nfs_state_ref;
+    struct nfs_lock_owner  *lock_owner = lock_state->lock_owner;
+    bool                    is_v40     = (req->minorversion == 0);
+    uint32_t                client_short_id;
 
     if (error_code != CHIMERA_VFS_OK) {
-        nfs4_session_release_state(req->session, lock_state);
-        res->status = chimera_nfs4_errno_to_nfsstat4(error_code);
+        nfs_state_table_release(table, lock_state, NFS4_SLOT_TYPE_LOCK,
+                                req->thread->vfs_thread);
+        req->nfs_state_ref = NULL;
+        res->status        = chimera_nfs4_errno_to_nfsstat4(error_code);
         chimera_nfs4_compound_complete(req, res->status);
         return;
     }
 
-    lock_state->nfs4_state_id.seqid++;
-    res->status       = NFS4_OK;
-    res->lock_stateid = lock_state->nfs4_state_id;
-    nfs4_session_release_state(req->session, lock_state);
+    lock_state->seqid += 1;
+    client_short_id    = (uint32_t) lock_owner->client->client_id;
+    nfs4_stateid_encode(&res->lock_stateid, lock_state->seqid,
+                        NFS4_STATEID_TYPE_LOCK,
+                        lock_state->shard, lock_state->slot_idx,
+                        lock_state->generation, client_short_id);
+    res->status = NFS4_OK;
+
+    /* RFC 7530 §9.1.7: record cached reply for the lock_owner. */
+    if (is_v40 && lock_owner) {
+        pthread_mutex_lock(&lock_owner->lock);
+        lock_owner->seqid = args->seqid;
+        nfs4_replay_record(&lock_owner->replay, args->seqid, OP_LOCKU,
+                           NFS4_OK, &res->lock_stateid);
+        pthread_mutex_unlock(&lock_owner->lock);
+    }
+
+    nfs_state_table_release(table, lock_state, NFS4_SLOT_TYPE_LOCK,
+                            req->thread->vfs_thread);
+    req->nfs_state_ref = NULL;
 
     chimera_nfs4_compound_complete(req, NFS4_OK);
 } /* chimera_nfs4_locku_complete */
@@ -43,56 +67,74 @@ chimera_nfs4_locku(
     struct nfs_argop4                *argop,
     struct nfs_resop4                *resop)
 {
-    struct LOCKU4args              *args = &argop->oplocku;
-    struct LOCKU4res               *res  = &resop->oplocku;
-    struct nfs4_session            *session;
-    struct nfs4_state              *lock_state;
+    struct LOCKU4args              *args   = &argop->oplocku;
+    struct LOCKU4res               *res    = &resop->oplocku;
+    struct nfs_state_table         *table  = &thread->shared->nfs4_state_table;
+    bool                            is_v40 = (req->minorversion == 0);
+    void                           *state_void;
+    uint8_t                         state_type;
+    struct nfs_lock_state          *lock_state;
+    struct nfs_lock_owner          *lock_owner;
     struct chimera_vfs_open_handle *handle;
     uint64_t                        vfs_length;
+    nfsstat4                        status;
 
-    /* RFC 7530 Section 16.12.3: current filehandle must be set */
+    /* RFC 7530 §16.12.3: current filehandle must be set */
     if (req->fhlen == 0) {
         res->status = NFS4ERR_NOFILEHANDLE;
         chimera_nfs4_compound_complete(req, res->status);
         return;
     }
 
-    session = nfs4_resolve_session(
-        req->session, req->conn,
-        &thread->shared->nfs4_shared_clients,
-        &args->lock_stateid);
-
-    if (!session) {
-        res->status = NFS4ERR_BAD_STATEID;
+    status = nfs_state_table_acquire(table, &args->lock_stateid,
+                                     NFS4_SLOT_TYPE_LOCK,
+                                     &state_void, &state_type);
+    if (status != NFS4_OK) {
+        res->status = status;
         chimera_nfs4_compound_complete(req, res->status);
         return;
     }
 
-    req->session = session;
+    lock_state          = state_void;
+    lock_owner          = lock_state->lock_owner;
+    handle              = lock_state->handle;
+    req->nfs_state_ref  = lock_state;
+    req->nfs_state_type = NFS4_SLOT_TYPE_LOCK;
 
-    if (nfs4_session_acquire_state(session,
-                                   &args->lock_stateid,
-                                   &lock_state,
-                                   &handle) != NFS4_OK) {
-        res->status = NFS4ERR_BAD_STATEID;
-        chimera_nfs4_compound_complete(req, res->status);
-        return;
+    if (is_v40 && lock_owner) {
+        pthread_mutex_lock(&lock_owner->lock);
+        int seqid_class = nfs4_owner_seqid_classify(lock_owner->seqid,
+                                                    &lock_owner->replay,
+                                                    args->seqid);
+        if (seqid_class == NFS4_SEQID_REPLAY) {
+            res->status       = lock_owner->replay.status;
+            res->lock_stateid = lock_owner->replay.stateid;
+            pthread_mutex_unlock(&lock_owner->lock);
+            nfs_state_table_release(table, lock_state, NFS4_SLOT_TYPE_LOCK,
+                                    thread->vfs_thread);
+            req->nfs_state_ref = NULL;
+            chimera_nfs4_compound_complete(req, NFS4_OK);
+            return;
+        }
+        if (seqid_class != NFS4_SEQID_NEW) {
+            pthread_mutex_unlock(&lock_owner->lock);
+            nfs_state_table_release(table, lock_state, NFS4_SLOT_TYPE_LOCK,
+                                    thread->vfs_thread);
+            req->nfs_state_ref = NULL;
+            res->status        = NFS4ERR_BAD_SEQID;
+            chimera_nfs4_compound_complete(req, NFS4_OK);
+            return;
+        }
+        pthread_mutex_unlock(&lock_owner->lock);
     }
 
-    if (lock_state->nfs4_state_type != NFS4_STATE_TYPE_LOCK) {
-        nfs4_session_release_state(session, lock_state);
-        res->status = NFS4ERR_BAD_STATEID;
-        chimera_nfs4_compound_complete(req, res->status);
-        return;
-    }
-
-    req->nfs4_state = lock_state;
-
-    /* RFC 7530 Section 16.12.4: same length rules as LOCK */
+    /* RFC 7530 §16.12.4: same length rules as LOCK */
     if (args->length == 0 ||
         (args->length != UINT64_MAX && args->offset > UINT64_MAX - args->length)) {
-        nfs4_session_release_state(session, lock_state);
-        res->status = NFS4ERR_INVAL;
+        nfs_state_table_release(table, lock_state, NFS4_SLOT_TYPE_LOCK,
+                                thread->vfs_thread);
+        req->nfs_state_ref = NULL;
+        res->status        = NFS4ERR_INVAL;
         chimera_nfs4_compound_complete(req, res->status);
         return;
     }

--- a/src/server/nfs/nfs4_proc_open.c
+++ b/src/server/nfs/nfs4_proc_open.c
@@ -5,8 +5,124 @@
 #include "nfs4_procs.h"
 #include "nfs4_status.h"
 #include "nfs4_attr.h"
+#include "nfs4_state.h"
 #include "vfs/vfs_procs.h"
 #include "vfs/vfs_release.h"
+
+/*
+ * Install a freshly-opened VFS handle into the unified state model, returning
+ * the stateid to send back to the client.  Handles same-owner re-OPEN
+ * coalescing per RFC 7530 §9.1.2: if an open_state already exists for
+ * (open_owner, fh), share bits are merged and stateid.seqid is bumped; the
+ * caller's incoming handle ref is released and the existing handle is reused.
+ *
+ * On entry, `handle` must be a +1 reference returned by chimera_vfs_open_at
+ * or chimera_vfs_open_fh.  On create, ownership transfers to the new
+ * open_state; on coalesce, the function calls chimera_vfs_release on it.
+ */
+static nfsstat4
+chimera_nfs4_open_install_state(
+    struct nfs_request             *req,
+    struct chimera_vfs_open_handle *handle,
+    struct stateid4                *out_stateid,
+    uint32_t                       *out_rflags)
+{
+    struct OPEN4args      *args   = &req->args_compound->argarray[req->index].opopen;
+    struct nfs_client     *client = req->session ? req->session->client_unified : NULL;
+    struct nfs_open_owner *owner;
+    struct nfs_open_state *existing;
+    bool                   created = false;
+
+    *out_rflags = 0;
+
+    if (!client) {
+        chimera_vfs_release(req->thread->vfs_thread, handle);
+        return NFS4ERR_STALE_CLIENTID;
+    }
+
+    owner = nfs_open_owner_find_or_create(client,
+                                          args->owner.owner.data,
+                                          args->owner.owner.len,
+                                          &created);
+
+    /* RFC 7530 §9.10: check share-mode conflict against opens by *other*
+     * owners on this client.  Same-owner OPEN coalesces via the
+     * find_state path below and is exempt. */
+    {
+        nfsstat4 conflict = nfs_client_check_share_conflict(
+            client, owner,
+            handle->fh, handle->fh_len,
+            args->share_access, args->share_deny);
+        if (conflict != NFS4_OK) {
+            chimera_vfs_release(req->thread->vfs_thread, handle);
+            return conflict;
+        }
+    }
+
+    existing = nfs_open_owner_find_state(owner, handle->fh, handle->fh_len);
+
+    if (existing) {
+        nfs_open_state_coalesce(existing,
+                                args->share_access, args->share_deny,
+                                (uint32_t) client->client_id,
+                                out_stateid);
+        chimera_vfs_release(req->thread->vfs_thread, handle);
+    } else {
+        nfs_open_state_create(owner,
+                              handle->fh, handle->fh_len,
+                              args->share_access, args->share_deny,
+                              handle,
+                              (uint32_t) client->client_id,
+                              &req->thread->shared->nfs4_state_table,
+                              out_stateid);
+    }
+
+    /* RFC 7530 §16.18.5: signal OPEN4_RESULT_CONFIRM for an unconfirmed
+     * open_owner on a 4.0 client.  The client must then send OPEN_CONFIRM
+     * before issuing any further state-modifying op against this owner. */
+    if (req->minorversion == 0 && !owner->confirmed) {
+        *out_rflags |= OPEN4_RESULT_CONFIRM;
+    }
+
+    return NFS4_OK;
+} /* chimera_nfs4_open_install_state */
+
+/*
+ * RFC 7530 §9.1.7 OPEN completion: advance open_owner.seqid and cache the
+ * reply for every outcome that nfs4_seqid_should_advance() reports as
+ * advancing (NFS4_OK plus most logical errors -- everything except the
+ * "infrastructure" set documented on that helper).  No-op on 4.1+ and on
+ * the 4.0 path when req->open_4_0_owner is NULL (entry never classified
+ * NEW, e.g. NOFILEHANDLE before the owner was even looked up).
+ *
+ * Then hands off to the regular compound dispatcher.  Every chimera_nfs4
+ * OPEN response path in this file calls this wrapper instead of
+ * chimera_nfs4_compound_complete directly.
+ */
+static void
+chimera_nfs4_open_complete(
+    struct nfs_request *req,
+    nfsstat4            status)
+{
+    if (req->minorversion == 0 &&
+        req->open_4_0_owner &&
+        nfs4_seqid_should_advance(status)) {
+
+        struct nfs_open_owner *owner = req->open_4_0_owner;
+        struct OPEN4args      *args  =
+            &req->args_compound->argarray[req->index].opopen;
+        struct OPEN4res       *res =
+            &req->res_compound.resarray[req->index].opopen;
+
+        pthread_mutex_lock(&owner->lock);
+        owner->seqid = args->seqid;
+        nfs4_replay_record(&owner->replay, args->seqid, OP_OPEN, status,
+                           status == NFS4_OK ? &res->resok4.stateid : NULL);
+        pthread_mutex_unlock(&owner->lock);
+    }
+
+    chimera_nfs4_compound_complete(req, status);
+} /* chimera_nfs4_open_complete */
 
 static void
 chimera_nfs4_open_exclusive_verify(
@@ -19,18 +135,18 @@ chimera_nfs4_open_exclusive_verify(
     void                           *private_data)
 {
     struct nfs_request             *req           = private_data;
-    struct nfs4_session            *session       = req->session;
     struct OPEN4args               *args          = &req->args_compound->argarray[req->index].opopen;
     struct OPEN4res                *res           = &req->res_compound.resarray[req->index].opopen;
     struct chimera_vfs_open_handle *parent_handle = req->handle;
-    struct nfs4_state              *state;
     const uint8_t                  *verf;
     uint32_t                        verf_atime, verf_mtime;
+    uint32_t                        lock_caps;
+    nfsstat4                        status;
 
     if (error_code != CHIMERA_VFS_OK) {
         res->status = chimera_nfs4_errno_to_nfsstat4(error_code);
         chimera_vfs_release(req->thread->vfs_thread, parent_handle);
-        chimera_nfs4_compound_complete(req, res->status);
+        chimera_nfs4_open_complete(req, res->status);
         return;
     }
 
@@ -50,29 +166,41 @@ chimera_nfs4_open_exclusive_verify(
         chimera_vfs_release(req->thread->vfs_thread, handle);
         chimera_vfs_release(req->thread->vfs_thread, parent_handle);
         res->status = NFS4ERR_EXIST;
-        chimera_nfs4_compound_complete(req, NFS4ERR_EXIST);
+        chimera_nfs4_open_complete(req, NFS4ERR_EXIST);
         return;
     }
 
-    /* Verifier matches - this is a retry, treat as success */
-    state                    = nfs4_session_alloc_slot(session);
-    state->nfs4_state_handle = handle;
+    /* Verifier matches - this is a retry, treat as success.  Capture FH and
+     * lock capabilities before install_state may release the handle. */
+    {
+        uint32_t install_rflags = 0;
+        lock_caps = handle->vfs_module->capabilities;
+        memcpy(req->fh, handle->fh, handle->fh_len);
+        req->fhlen = handle->fh_len;
 
-    res->status              = NFS4_OK;
-    res->resok4.stateid      = state->nfs4_state_id;
-    res->resok4.cinfo.atomic = 0;
-    res->resok4.cinfo.before = 0;
-    res->resok4.cinfo.after  = 0;
-    res->resok4.rflags       = (handle->vfs_module->capabilities & CHIMERA_VFS_CAP_FS_LOCK) ?
-        OPEN4_RESULT_LOCKTYPE_POSIX : 0;
+        status = chimera_nfs4_open_install_state(req, handle,
+                                                 &res->resok4.stateid,
+                                                 &install_rflags);
+        if (status != NFS4_OK) {
+            res->status = status;
+            chimera_vfs_release(req->thread->vfs_thread, parent_handle);
+            chimera_nfs4_open_complete(req, status);
+            return;
+        }
+
+        res->status              = NFS4_OK;
+        res->resok4.cinfo.atomic = 0;
+        res->resok4.cinfo.before = 0;
+        res->resok4.cinfo.after  = 0;
+        res->resok4.rflags       = install_rflags |
+            ((lock_caps & CHIMERA_VFS_CAP_FS_LOCK) ?
+             OPEN4_RESULT_LOCKTYPE_POSIX : 0);
+    }
     res->resok4.num_attrset                = 0;
     res->resok4.delegation.delegation_type = OPEN_DELEGATE_NONE;
 
-    memcpy(req->fh, handle->fh, handle->fh_len);
-    req->fhlen = handle->fh_len;
-
     chimera_vfs_release(req->thread->vfs_thread, parent_handle);
-    chimera_nfs4_compound_complete(req, NFS4_OK);
+    chimera_nfs4_open_complete(req, NFS4_OK);
 } /* chimera_nfs4_open_exclusive_verify */
 
 static void
@@ -86,11 +214,9 @@ chimera_nfs4_open_at_complete(
     void                           *private_data)
 {
     struct nfs_request             *req           = private_data;
-    struct nfs4_session            *session       = req->session;
     struct OPEN4args               *args          = &req->args_compound->argarray[req->index].opopen;
     struct OPEN4res                *res           = &req->res_compound.resarray[req->index].opopen;
     struct chimera_vfs_open_handle *parent_handle = req->handle;
-    struct nfs4_state              *state;
     int                             rc;
 
     if (error_code != CHIMERA_VFS_OK) {
@@ -115,20 +241,37 @@ chimera_nfs4_open_at_complete(
         }
         res->status = chimera_nfs4_errno_to_nfsstat4(error_code);
         chimera_vfs_release(req->thread->vfs_thread, parent_handle);
-        chimera_nfs4_compound_complete(req, res->status);
+        chimera_nfs4_open_complete(req, res->status);
         return;
     }
 
-    state                    = nfs4_session_alloc_slot(session);
-    state->nfs4_state_handle = handle;
+    {
+        uint32_t lock_caps      = handle->vfs_module->capabilities;
+        uint32_t install_rflags = 0;
+        nfsstat4 status;
 
-    res->status              = NFS4_OK;
-    res->resok4.stateid      = state->nfs4_state_id;
-    res->resok4.cinfo.atomic = 0;
-    res->resok4.cinfo.before = 0;
-    res->resok4.cinfo.after  = 0;
-    res->resok4.rflags       = (handle->vfs_module->capabilities & CHIMERA_VFS_CAP_FS_LOCK) ?
-        OPEN4_RESULT_LOCKTYPE_POSIX : 0;
+        /* Capture FH before install_state may release the handle (coalesce). */
+        memcpy(req->fh, handle->fh, handle->fh_len);
+        req->fhlen = handle->fh_len;
+
+        status = chimera_nfs4_open_install_state(req, handle,
+                                                 &res->resok4.stateid,
+                                                 &install_rflags);
+        if (status != NFS4_OK) {
+            res->status = status;
+            chimera_vfs_release(req->thread->vfs_thread, parent_handle);
+            chimera_nfs4_open_complete(req, status);
+            return;
+        }
+
+        res->status              = NFS4_OK;
+        res->resok4.cinfo.atomic = 0;
+        res->resok4.cinfo.before = 0;
+        res->resok4.cinfo.after  = 0;
+        res->resok4.rflags       = install_rflags |
+            ((lock_caps & CHIMERA_VFS_CAP_FS_LOCK) ?
+             OPEN4_RESULT_LOCKTYPE_POSIX : 0);
+    }
     res->resok4.num_attrset                = 0;
     res->resok4.delegation.delegation_type = OPEN_DELEGATE_NONE;
 
@@ -152,57 +295,64 @@ chimera_nfs4_open_at_complete(
         res->resok4.num_attrset = 0;
     }
 
-    memcpy(req->fh, handle->fh, handle->fh_len);
-    req->fhlen = handle->fh_len;
-
     chimera_nfs4_set_changeinfo(&res->resok4.cinfo, dir_pre_attr, dir_post_attr);
 
     chimera_vfs_release(req->thread->vfs_thread, parent_handle);
 
-    chimera_nfs4_compound_complete(req, NFS4_OK);
+    chimera_nfs4_open_complete(req, NFS4_OK);
 } /* chimera_nfs4_open_at_complete */
 
 static void
-chimera_nfs4_open_complete(
+chimera_nfs4_open_claim_fh_complete(
     enum chimera_vfs_error          error_code,
     struct chimera_vfs_open_handle *handle,
     void                           *private_data)
 {
     struct nfs_request             *req           = private_data;
-    struct nfs4_session            *session       = req->session;
     struct OPEN4res                *res           = &req->res_compound.resarray[req->index].opopen;
     struct chimera_vfs_open_handle *parent_handle = req->handle;
-    struct nfs4_state              *state;
+    uint32_t                        lock_caps;
+    nfsstat4                        status;
 
     if (error_code != CHIMERA_VFS_OK) {
         res->status = chimera_nfs4_errno_to_nfsstat4(error_code);
         chimera_vfs_release(req->thread->vfs_thread, parent_handle);
-        chimera_nfs4_compound_complete(req, res->status);
+        chimera_nfs4_open_complete(req, res->status);
         return;
     }
 
-    state                    = nfs4_session_alloc_slot(session);
-    state->nfs4_state_handle = handle;
+    /* CLAIM_FH/CLAIM_PREVIOUS: req->fh already carries the FH that was put
+     * on the wire; no need to overwrite from handle->fh.  Capture lock caps
+     * before install_state may release the handle. */
+    {
+        uint32_t install_rflags = 0;
+        lock_caps = handle->vfs_module->capabilities;
 
-    res->status              = NFS4_OK;
-    res->resok4.stateid      = state->nfs4_state_id;
-    res->resok4.cinfo.atomic = 0;
-    res->resok4.cinfo.before = 0;
-    res->resok4.cinfo.after  = 0;
-    res->resok4.rflags       = (handle->vfs_module->capabilities & CHIMERA_VFS_CAP_FS_LOCK) ?
-        OPEN4_RESULT_LOCKTYPE_POSIX : 0;
+        status = chimera_nfs4_open_install_state(req, handle,
+                                                 &res->resok4.stateid,
+                                                 &install_rflags);
+        if (status != NFS4_OK) {
+            res->status = status;
+            chimera_vfs_release(req->thread->vfs_thread, parent_handle);
+            chimera_nfs4_open_complete(req, status);
+            return;
+        }
+
+        res->status              = NFS4_OK;
+        res->resok4.cinfo.atomic = 0;
+        res->resok4.cinfo.before = 0;
+        res->resok4.cinfo.after  = 0;
+        res->resok4.rflags       = install_rflags |
+            ((lock_caps & CHIMERA_VFS_CAP_FS_LOCK) ?
+             OPEN4_RESULT_LOCKTYPE_POSIX : 0);
+    }
     res->resok4.num_attrset                = 0;
     res->resok4.delegation.delegation_type = OPEN_DELEGATE_NONE;
 
-    /* XXX Not sure what to do here since there is no directory */
-    res->resok4.cinfo.atomic = 0;
-    res->resok4.cinfo.before = 0;
-    res->resok4.cinfo.after  = 0;
-
     chimera_vfs_release(req->thread->vfs_thread, parent_handle);
 
-    chimera_nfs4_compound_complete(req, NFS4_OK);
-} /* chimera_nfs4_open_complete */
+    chimera_nfs4_open_complete(req, NFS4_OK);
+} /* chimera_nfs4_open_claim_fh_complete */
 
 static void
 chimera_nfs4_open_parent_complete(
@@ -221,7 +371,7 @@ chimera_nfs4_open_parent_complete(
     if (error_code != CHIMERA_VFS_OK) {
         struct OPEN4res *res = &req->res_compound.resarray[req->index].opopen;
         res->status = chimera_nfs4_errno_to_nfsstat4(error_code);
-        chimera_nfs4_compound_complete(req, res->status);
+        chimera_nfs4_open_complete(req, res->status);
         return;
     }
 
@@ -247,7 +397,7 @@ chimera_nfs4_open_parent_complete(
                     struct OPEN4res *res = &req->res_compound.resarray[req->index].opopen;
                     chimera_vfs_release(req->thread->vfs_thread, parent_handle);
                     res->status = status;
-                    chimera_nfs4_compound_complete(req, status);
+                    chimera_nfs4_open_complete(req, status);
                     return;
                 }
                 chimera_nfs4_unmarshall_attrs(attr,
@@ -265,7 +415,7 @@ chimera_nfs4_open_parent_complete(
                     struct OPEN4res *res = &req->res_compound.resarray[req->index].opopen;
                     chimera_vfs_release(req->thread->vfs_thread, parent_handle);
                     res->status = status;
-                    chimera_nfs4_compound_complete(req, status);
+                    chimera_nfs4_open_complete(req, status);
                     return;
                 }
                 chimera_nfs4_unmarshall_attrs(attr,
@@ -307,7 +457,7 @@ chimera_nfs4_open_parent_complete(
                 struct OPEN4res *res = &req->res_compound.resarray[req->index].opopen;
                 chimera_vfs_release(req->thread->vfs_thread, parent_handle);
                 res->status = status;
-                chimera_nfs4_compound_complete(req, status);
+                chimera_nfs4_open_complete(req, status);
                 return;
             }
 
@@ -329,7 +479,7 @@ chimera_nfs4_open_parent_complete(
                                 req->fh,
                                 req->fhlen,
                                 flags,
-                                chimera_nfs4_open_complete,
+                                chimera_nfs4_open_claim_fh_complete,
                                 req);
             break;
         default:
@@ -350,7 +500,7 @@ chimera_nfs4_open(
 
     if (req->fhlen == 0) {
         res->status = NFS4ERR_NOFILEHANDLE;
-        chimera_nfs4_compound_complete(req, res->status);
+        chimera_nfs4_open_complete(req, res->status);
         return;
     }
 
@@ -364,6 +514,79 @@ chimera_nfs4_open(
             req->session = found;
             /* Drop the +1 ref returned by find_by_clientid; conn owns it. */
             nfs4_session_put(found);
+        }
+    }
+
+    /* RFC 7530 §9.1.7 entry-time seqid classification for the 4.0 path.
+     * Done BEFORE any VFS work so a replay short-circuits without
+     * re-executing the open.  On NEW, the resolved owner is stashed on
+     * req for chimera_nfs4_open_complete to advance + cache the reply. */
+    if (req->minorversion == 0) {
+        struct nfs_client *client =
+            req->session ? req->session->client_unified : NULL;
+
+        if (!client) {
+            /* NFS4ERR_STALE_CLIENTID is in the no-advance set; we don't
+             * touch any owner state. */
+            res->status = NFS4ERR_STALE_CLIENTID;
+            chimera_nfs4_compound_complete(req, res->status);
+            return;
+        }
+
+        bool                   created;
+        struct nfs_open_owner *owner = nfs_open_owner_find_or_create(
+            client, args->owner.owner.data, args->owner.owner.len,
+            &created);
+
+        pthread_mutex_lock(&owner->lock);
+        int                    cls = nfs4_owner_seqid_classify(owner->seqid, &owner->replay,
+                                                               args->seqid);
+
+        if (cls == NFS4_SEQID_REPLAY) {
+            /* Return the cached reply.  Simplified replay (status +
+             * stateid only); cinfo/attrset/rflags/delegation are
+             * reconstructed as zero/none.  Linux clients tolerate this
+             * since they re-fetch attrs via GETATTR after OPEN. */
+            res->status                            = owner->replay.status;
+            res->resok4.stateid                    = owner->replay.stateid;
+            res->resok4.cinfo.atomic               = 0;
+            res->resok4.cinfo.before               = 0;
+            res->resok4.cinfo.after                = 0;
+            res->resok4.rflags                     = 0;
+            res->resok4.num_attrset                = 0;
+            res->resok4.delegation.delegation_type = OPEN_DELEGATE_NONE;
+            pthread_mutex_unlock(&owner->lock);
+            chimera_nfs4_compound_complete(req, NFS4_OK);
+            return;
+        }
+
+        if (cls != NFS4_SEQID_NEW) {
+            /* NFS4ERR_BAD_SEQID is in the no-advance set; do not touch
+             * owner state. */
+            pthread_mutex_unlock(&owner->lock);
+            res->status = NFS4ERR_BAD_SEQID;
+            chimera_nfs4_compound_complete(req, res->status);
+            return;
+        }
+
+        pthread_mutex_unlock(&owner->lock);
+        req->open_4_0_owner = owner;
+    }
+
+    /* Phase 5: gate non-reclaim OPENs during the grace window.  Stubbed
+     * persistence makes this a no-op in practice today (to_reclaim is empty
+     * at boot so begin_grace short-circuits in_grace=false). */
+    {
+        bool     is_reclaim = (args->claim.claim == CLAIM_PREVIOUS);
+        nfsstat4 g_status   = nfs_recovery_open_check(
+            &thread->shared->nfs4_recovery,
+            req->session ? req->session->client_unified : NULL,
+            is_reclaim);
+
+        if (g_status != NFS4_OK) {
+            res->status = g_status;
+            chimera_nfs4_open_complete(req, g_status);
+            return;
         }
     }
 

--- a/src/server/nfs/nfs4_proc_open_confirm.c
+++ b/src/server/nfs/nfs4_proc_open_confirm.c
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * RFC 7530 §16.18: OPEN_CONFIRM
+ *
+ * Confirms a new open_owner.  Server sets OPEN4_RESULT_CONFIRM in the OPEN
+ * response for an as-yet-unconfirmed owner; the client must follow with
+ * OPEN_CONFIRM(seqid+1, open_stateid) before issuing any further state-
+ * modifying op against that owner.  A successful OPEN_CONFIRM:
+ *   - Verifies the open_owner is unconfirmed.
+ *   - Validates the supplied stateid against the open_state.
+ *   - Checks the seqid is owner.seqid + 1.
+ *   - Flips owner.confirmed = true.
+ *   - Bumps stateid.seqid and returns the new stateid.
+ *
+ * 4.1+ does not use this op; Phase 0's op_matrix already rejects it for
+ * 4.1+ minorversions.
+ */
+
+#include "nfs4_procs.h"
+#include "nfs4_state.h"
+#include "vfs/vfs_release.h"
+
+void
+chimera_nfs4_open_confirm(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_request               *req,
+    struct nfs_argop4                *argop,
+    struct nfs_resop4                *resop)
+{
+    struct OPEN_CONFIRM4args *args  = &argop->opopen_confirm;
+    struct OPEN_CONFIRM4res  *res   = &resop->opopen_confirm;
+    struct nfs_state_table   *table = &thread->shared->nfs4_state_table;
+    void                     *state_void;
+    uint8_t                   state_type;
+    struct nfs_open_state    *open_state;
+    struct nfs_open_owner    *owner;
+    nfsstat4                  status;
+    int                       seqid_class;
+
+    if (req->fhlen == 0) {
+        res->status = NFS4ERR_NOFILEHANDLE;
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    status = nfs_state_table_acquire(table, &args->open_stateid,
+                                     NFS4_SLOT_TYPE_OPEN,
+                                     &state_void, &state_type);
+    if (status != NFS4_OK) {
+        res->status = status;
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    open_state = state_void;
+    owner      = open_state->owner;
+
+    pthread_mutex_lock(&owner->lock);
+
+    seqid_class = nfs4_owner_seqid_classify(owner->seqid, &owner->replay,
+                                            args->seqid);
+
+    if (seqid_class == NFS4_SEQID_REPLAY) {
+        /* RFC 7530 §9.1.7: return cached reply.  For OPEN_CONFIRM the
+         * resok carries the confirmed stateid. */
+        res->status              = owner->replay.status;
+        res->resok4.open_stateid = owner->replay.stateid;
+        pthread_mutex_unlock(&owner->lock);
+        nfs_state_table_release(table, open_state, NFS4_SLOT_TYPE_OPEN,
+                                thread->vfs_thread);
+        chimera_nfs4_compound_complete(req, NFS4_OK);
+        return;
+    }
+
+    if (seqid_class != NFS4_SEQID_NEW) {
+        pthread_mutex_unlock(&owner->lock);
+        nfs_state_table_release(table, open_state, NFS4_SLOT_TYPE_OPEN,
+                                thread->vfs_thread);
+        res->status = NFS4ERR_BAD_SEQID;
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    /* New op: confirm the owner and advance state.seqid. */
+    owner->confirmed   = true;
+    owner->seqid       = args->seqid;
+    open_state->seqid += 1;
+
+    nfs4_stateid_encode(&res->resok4.open_stateid,
+                        open_state->seqid,
+                        NFS4_STATEID_TYPE_OPEN,
+                        open_state->shard, open_state->slot_idx,
+                        open_state->generation,
+                        (uint32_t) owner->client->client_id);
+
+    nfs4_replay_record(&owner->replay, args->seqid, OP_OPEN_CONFIRM,
+                       NFS4_OK, &res->resok4.open_stateid);
+
+    pthread_mutex_unlock(&owner->lock);
+
+    nfs_state_table_release(table, open_state, NFS4_SLOT_TYPE_OPEN,
+                            thread->vfs_thread);
+
+    res->status = NFS4_OK;
+    chimera_nfs4_compound_complete(req, NFS4_OK);
+} /* chimera_nfs4_open_confirm */

--- a/src/server/nfs/nfs4_proc_open_downgrade.c
+++ b/src/server/nfs/nfs4_proc_open_downgrade.c
@@ -1,0 +1,116 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * RFC 7530 §16.19: OPEN_DOWNGRADE
+ *
+ * Reduces the share_access / share_deny bits on an existing open_state
+ * without closing it.  Args: open_stateid, seqid, share_access, share_deny.
+ * The new bits must be a subset of the current bits (downgrade only).
+ *
+ * 4.1+ also has OPEN_DOWNGRADE (no seqid check), Phase 0 already routes it
+ * for both minors.  This proc gates the seqid check on req->minorversion.
+ */
+
+#include "nfs4_procs.h"
+#include "nfs4_state.h"
+#include "vfs/vfs_release.h"
+
+void
+chimera_nfs4_open_downgrade(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_request               *req,
+    struct nfs_argop4                *argop,
+    struct nfs_resop4                *resop)
+{
+    struct OPEN_DOWNGRADE4args *args  = &argop->opopen_downgrade;
+    struct OPEN_DOWNGRADE4res  *res   = &resop->opopen_downgrade;
+    struct nfs_state_table     *table = &thread->shared->nfs4_state_table;
+    void                       *state_void;
+    uint8_t                     state_type;
+    struct nfs_open_state      *open_state;
+    struct nfs_open_owner      *owner;
+    nfsstat4                    status;
+    bool                        is_v40 = (req->minorversion == 0);
+
+    if (req->fhlen == 0) {
+        res->status = NFS4ERR_NOFILEHANDLE;
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    status = nfs_state_table_acquire(table, &args->open_stateid,
+                                     NFS4_SLOT_TYPE_OPEN,
+                                     &state_void, &state_type);
+    if (status != NFS4_OK) {
+        res->status = status;
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    open_state = state_void;
+    owner      = open_state->owner;
+
+    pthread_mutex_lock(&owner->lock);
+
+    if (is_v40) {
+        int seqid_class = nfs4_owner_seqid_classify(owner->seqid,
+                                                    &owner->replay,
+                                                    args->seqid);
+        if (seqid_class == NFS4_SEQID_REPLAY) {
+            res->status              = owner->replay.status;
+            res->resok4.open_stateid = owner->replay.stateid;
+            pthread_mutex_unlock(&owner->lock);
+            nfs_state_table_release(table, open_state, NFS4_SLOT_TYPE_OPEN,
+                                    thread->vfs_thread);
+            chimera_nfs4_compound_complete(req, NFS4_OK);
+            return;
+        }
+        if (seqid_class != NFS4_SEQID_NEW) {
+            pthread_mutex_unlock(&owner->lock);
+            nfs_state_table_release(table, open_state, NFS4_SLOT_TYPE_OPEN,
+                                    thread->vfs_thread);
+            res->status = NFS4ERR_BAD_SEQID;
+            chimera_nfs4_compound_complete(req, res->status);
+            return;
+        }
+    }
+
+    /* RFC 7530 §16.19.4: new bits must be a non-empty subset of current. */
+    if (args->share_access == 0 ||
+        (args->share_access & ~open_state->share_access) ||
+        (args->share_deny   & ~open_state->share_deny)) {
+        pthread_mutex_unlock(&owner->lock);
+        nfs_state_table_release(table, open_state, NFS4_SLOT_TYPE_OPEN,
+                                thread->vfs_thread);
+        res->status = NFS4ERR_INVAL;
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    open_state->share_access = args->share_access;
+    open_state->share_deny   = args->share_deny;
+    open_state->seqid       += 1;
+
+    nfs4_stateid_encode(&res->resok4.open_stateid,
+                        open_state->seqid,
+                        NFS4_STATEID_TYPE_OPEN,
+                        open_state->shard, open_state->slot_idx,
+                        open_state->generation,
+                        (uint32_t) owner->client->client_id);
+
+    if (is_v40) {
+        owner->seqid = args->seqid;
+        nfs4_replay_record(&owner->replay, args->seqid, OP_OPEN_DOWNGRADE,
+                           NFS4_OK, &res->resok4.open_stateid);
+    }
+
+    pthread_mutex_unlock(&owner->lock);
+
+    nfs_state_table_release(table, open_state, NFS4_SLOT_TYPE_OPEN,
+                            thread->vfs_thread);
+
+    res->status = NFS4_OK;
+    chimera_nfs4_compound_complete(req, NFS4_OK);
+} /* chimera_nfs4_open_downgrade */

--- a/src/server/nfs/nfs4_proc_read.c
+++ b/src/server/nfs/nfs4_proc_read.c
@@ -4,6 +4,7 @@
 
 #include "nfs4_procs.h"
 #include "nfs4_status.h"
+#include "nfs4_state.h"
 #include "vfs/vfs_procs.h"
 #include "vfs/vfs_release.h"
 
@@ -25,9 +26,8 @@ chimera_nfs4_read_complete(
     struct chimera_vfs_attrs *attr,
     void                     *private_data)
 {
-    struct nfs_request             *req = private_data;
-    struct READ4res                *res = &req->res_compound.resarray[req->index].opread;
-    struct chimera_vfs_open_handle *deferred;
+    struct nfs_request *req = private_data;
+    struct READ4res    *res = &req->res_compound.resarray[req->index].opread;
 
     if (error_code == CHIMERA_VFS_OK) {
         res->status             = NFS4_OK;
@@ -40,11 +40,11 @@ chimera_nfs4_read_complete(
         evpl_iovecs_release(req->thread->evpl, iov, niov);
     }
 
-    if (req->nfs4_state) {
-        deferred = nfs4_session_release_state(req->session, req->nfs4_state);
-        if (deferred) {
-            chimera_vfs_release(req->thread->vfs_thread, deferred);
-        }
+    if (req->nfs_state_ref) {
+        nfs_state_table_release(&req->thread->shared->nfs4_state_table,
+                                req->nfs_state_ref, req->nfs_state_type,
+                                req->thread->vfs_thread);
+        req->nfs_state_ref = NULL;
     } else if (req->handle) {
         /* Anonymous stateid: release the on-the-fly handle we opened. */
         chimera_vfs_release(req->thread->vfs_thread, req->handle);
@@ -95,20 +95,22 @@ chimera_nfs4_read(
     struct nfs_argop4                *argop,
     struct nfs_resop4                *resop)
 {
-    struct READ4args               *args = &argop->opread;
-    struct READ4res                *res  = &resop->opread;
+    struct READ4args               *args  = &argop->opread;
+    struct READ4res                *res   = &resop->opread;
+    struct nfs_state_table         *table = &thread->shared->nfs4_state_table;
+    void                           *state_void;
+    uint8_t                         state_type;
     struct chimera_vfs_open_handle *state_handle;
-    struct nfs4_state              *state;
-    struct nfs4_session            *session;
     struct evpl_iovec              *iov;
+    nfsstat4                        status;
 
-    req->nfs4_state = NULL;
-    req->handle     = NULL;
+    req->nfs_state_ref = NULL;
+    req->handle        = NULL;
 
     /*
      * RFC 7530 9.1.4.3 / RFC 8881 8.2.3 require READ to honor the
      * anonymous stateid (all zeros).  Open the current FH on the fly
-     * instead of consulting per-session state.
+     * instead of consulting the state table.
      */
     if (chimera_nfs4_stateid_is_anonymous(&args->stateid)) {
         if (req->fhlen == 0) {
@@ -126,27 +128,22 @@ chimera_nfs4_read(
         return;
     }
 
-    session = nfs4_resolve_session(
-        req->session, req->conn,
-        &thread->shared->nfs4_shared_clients,
-        &args->stateid);
-
-    if (!session) {
-        res->status = NFS4ERR_BAD_STATEID;
+    status = nfs_state_table_acquire(table, &args->stateid, 0,
+                                     &state_void, &state_type);
+    if (status != NFS4_OK) {
+        res->status = status;
         chimera_nfs4_compound_complete(req, res->status);
         return;
     }
 
-    req->session = session;
-
-    if (nfs4_session_acquire_state(session, &args->stateid,
-                                   &state, &state_handle) != NFS4_OK) {
-        res->status = NFS4ERR_BAD_STATEID;
-        chimera_nfs4_compound_complete(req, res->status);
-        return;
+    if (state_type == NFS4_SLOT_TYPE_OPEN) {
+        state_handle = ((struct nfs_open_state *) state_void)->handle;
+    } else {
+        state_handle = ((struct nfs_lock_state *) state_void)->handle;
     }
 
-    req->nfs4_state = state;
+    req->nfs_state_ref  = state_void;
+    req->nfs_state_type = state_type;
 
     iov = xdr_dbuf_alloc_space(sizeof(*iov) * 256, req->encoding->dbuf);
     chimera_nfs_abort_if(iov == NULL, "Failed to allocate space");

--- a/src/server/nfs/nfs4_proc_reclaim_complete.c
+++ b/src/server/nfs/nfs4_proc_reclaim_complete.c
@@ -1,8 +1,9 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
 #include "nfs4_procs.h"
+#include "nfs4_recovery.h"
 #include "evpl/evpl_rpc2.h"
 
 void
@@ -13,6 +14,15 @@ chimera_nfs4_reclaim_complete(
     struct nfs_resop4                *resop)
 {
     struct RECLAIM_COMPLETE4res *res = &resop->opreclaim_complete;
+
+    /* RFC 8881 §18.51 / RFC 7530 §10.2.5: client signals end of reclaim
+     * activity.  Drop the per-client recovery marker.  When persistence
+     * lands and the to_reclaim hash is populated at boot, the
+     * pending_reclaim counter hitting zero will also end the grace window
+     * early via nfs_recovery_sweep_once. */
+    nfs_recovery_reclaim_complete(
+        &thread->shared->nfs4_recovery,
+        req->session ? req->session->client_unified : NULL);
 
     res->rcr_status = NFS4_OK;
 

--- a/src/server/nfs/nfs4_proc_seek.c
+++ b/src/server/nfs/nfs4_proc_seek.c
@@ -4,6 +4,7 @@
 
 #include "nfs4_procs.h"
 #include "nfs4_status.h"
+#include "nfs4_state.h"
 #include "vfs/vfs_procs.h"
 #include "vfs/vfs_release.h"
 
@@ -14,9 +15,8 @@ chimera_nfs4_seek_complete(
     uint64_t               sr_offset,
     void                  *private_data)
 {
-    struct nfs_request             *req = private_data;
-    struct SEEK4res                *res = &req->res_compound.resarray[req->index].opseek;
-    struct chimera_vfs_open_handle *deferred;
+    struct nfs_request *req = private_data;
+    struct SEEK4res    *res = &req->res_compound.resarray[req->index].opseek;
 
     if (error_code == CHIMERA_VFS_OK) {
         res->sa_status        = NFS4_OK;
@@ -26,10 +26,10 @@ chimera_nfs4_seek_complete(
         res->sa_status = chimera_nfs4_errno_to_nfsstat4(error_code);
     }
 
-    deferred = nfs4_session_release_state(req->session, req->nfs4_state);
-    if (deferred) {
-        chimera_vfs_release(req->thread->vfs_thread, deferred);
-    }
+    nfs_state_table_release(&req->thread->shared->nfs4_state_table,
+                            req->nfs_state_ref, req->nfs_state_type,
+                            req->thread->vfs_thread);
+    req->nfs_state_ref = NULL;
 
     chimera_nfs4_compound_complete(req, NFS4_OK);
 } /* chimera_nfs4_seek_complete */
@@ -41,26 +41,30 @@ chimera_nfs4_seek(
     struct nfs_argop4                *argop,
     struct nfs_resop4                *resop)
 {
-    struct SEEK4args               *args    = &argop->opseek;
-    struct SEEK4res                *res     = &resop->opseek;
-    struct nfs4_session            *session = req->session;
-    struct nfs4_state              *state;
+    struct SEEK4args               *args  = &argop->opseek;
+    struct SEEK4res                *res   = &resop->opseek;
+    struct nfs_state_table         *table = &thread->shared->nfs4_state_table;
+    void                           *state_void;
+    uint8_t                         state_type;
     struct chimera_vfs_open_handle *state_handle;
+    nfsstat4                        status;
 
-    if (!session) {
-        res->sa_status = NFS4ERR_BAD_STATEID;
+    status = nfs_state_table_acquire(table, &args->sa_stateid, 0,
+                                     &state_void, &state_type);
+    if (status != NFS4_OK) {
+        res->sa_status = status;
         chimera_nfs4_compound_complete(req, NFS4_OK);
         return;
     }
 
-    if (nfs4_session_acquire_state(session, &args->sa_stateid,
-                                   &state, &state_handle) != NFS4_OK) {
-        res->sa_status = NFS4ERR_BAD_STATEID;
-        chimera_nfs4_compound_complete(req, NFS4_OK);
-        return;
+    if (state_type == NFS4_SLOT_TYPE_OPEN) {
+        state_handle = ((struct nfs_open_state *) state_void)->handle;
+    } else {
+        state_handle = ((struct nfs_lock_state *) state_void)->handle;
     }
 
-    req->nfs4_state = state;
+    req->nfs_state_ref  = state_void;
+    req->nfs_state_type = state_type;
 
     chimera_vfs_seek(thread->vfs_thread, &req->cred,
                      state_handle,

--- a/src/server/nfs/nfs4_proc_sequence.c
+++ b/src/server/nfs/nfs4_proc_sequence.c
@@ -4,6 +4,7 @@
 
 #include "nfs4_procs.h"
 #include "nfs4_session.h"
+#include "nfs4_state.h"
 
 void
 chimera_nfs4_sequence(
@@ -14,8 +15,11 @@ chimera_nfs4_sequence(
 {
     struct SEQUENCE4args *args = &argop->opsequence;
     struct SEQUENCE4res  *res  = &resop->opsequence;
+    struct nfs4_session  *session;
+    bool                  is_replay = false;
+    nfsstat4              status;
 
-    struct nfs4_session  *session = nfs4_session_lookup(
+    session = nfs4_session_lookup(
         &thread->shared->nfs4_shared_clients,
         args->sa_sessionid);
 
@@ -25,23 +29,50 @@ chimera_nfs4_sequence(
         return;
     }
 
-    /* Bind this session to the conn (idempotent if already bound) and drop
-     * the +1 ref returned by nfs4_session_lookup -- the conn's ref keeps
-     * the session alive for the rest of this compound. */
+    /* Bind this session to the conn (idempotent if already bound) and
+     * drop the +1 ref returned by nfs4_session_lookup -- the conn's ref
+     * keeps the session alive for the rest of this compound. */
     nfs4_session_bind_conn(req->conn, session);
     nfs4_session_put(session);
 
-    /* Store session in request for use by subsequent operations */
     req->session = session;
 
-    res->sr_status = NFS4_OK;
+    /* SEQUENCE is the 4.1+ lease tick (RFC 8881 §8.4); touch the owning
+     * client's lease before consulting the slot table. */
+    nfs_client_touch(session->client_unified);
 
+    status = nfs4_replay_slot_acquire(session,
+                                      args->sa_slotid,
+                                      args->sa_sequenceid,
+                                      args->sa_cachethis,
+                                      req,
+                                      &is_replay);
+
+    if (status != NFS4_OK) {
+        res->sr_status = status;
+        chimera_nfs4_compound_complete(req, status);
+        return;
+    }
+
+    if (is_replay) {
+        /* Phase 2 will short-circuit the compound dispatcher and send
+         * the cached reply bytes verbatim.  Phase 1 has no cache so
+         * this branch is unreachable today; nfs4_replay_slot_acquire
+         * returns NFS4ERR_RETRY_UNCACHED_REP instead. */
+        chimera_nfs4_compound_complete(req, NFS4_OK);
+        return;
+    }
+
+    res->sr_status = NFS4_OK;
     memcpy(res->sr_resok4.sr_sessionid, session->nfs4_session_id,
            NFS4_SESSIONID_SIZE);
-    res->sr_resok4.sr_sequenceid            = args->sa_sequenceid;
-    res->sr_resok4.sr_slotid                = args->sa_slotid;
-    res->sr_resok4.sr_highest_slotid        = session->nfs4_session_fore_attrs.ca_maxrequests;
-    res->sr_resok4.sr_target_highest_slotid = session->nfs4_session_fore_attrs.ca_maxrequests;
+    res->sr_resok4.sr_sequenceid = args->sa_sequenceid;
+    res->sr_resok4.sr_slotid     = args->sa_slotid;
+    /* RFC 5661 18.46.3: sr_highest_slotid is the *maximum slot id*, not
+     * the count.  Linux nfsd returns max_slots - 1. */
+    res->sr_resok4.sr_highest_slotid =
+        session->replay_max_slots ? session->replay_max_slots - 1 : 0;
+    res->sr_resok4.sr_target_highest_slotid = res->sr_resok4.sr_highest_slotid;
     res->sr_resok4.sr_status_flags          = 0;
 
     chimera_nfs4_compound_complete(req, NFS4_OK);

--- a/src/server/nfs/nfs4_proc_setattr.c
+++ b/src/server/nfs/nfs4_proc_setattr.c
@@ -5,6 +5,8 @@
 #include "nfs4_procs.h"
 #include "nfs4_status.h"
 #include "nfs4_attr.h"
+#include "nfs4_state.h"
+#include "nfs4_stateid.h"
 #include "vfs/vfs_procs.h"
 #include "vfs/vfs_release.h"
 
@@ -119,6 +121,41 @@ chimera_nfs4_setattr(
     if (res->status != NFS4_OK) {
         chimera_nfs4_compound_complete(req, res->status);
         return;
+    }
+
+    /* RFC 7530 §16.32.3: when SETATTR carries FATTR4_SIZE the supplied
+     * stateid must identify an open with write access.  Special stateids
+     * (all-zero / all-ones) are exempt -- treated as anonymous, like the
+     * pre-Phase-2 behavior. */
+    if (args->obj_attributes.num_attrmask >= 1 &&
+        (args->obj_attributes.attrmask[0] & (1 << FATTR4_SIZE)) &&
+        !nfs4_stateid_is_special(&args->stateid)) {
+        struct nfs_state_table *table = &thread->shared->nfs4_state_table;
+        void                   *state_void;
+        uint8_t                 state_type;
+        nfsstat4                status;
+
+        status = nfs_state_table_acquire(table, &args->stateid,
+                                         NFS4_SLOT_TYPE_OPEN,
+                                         &state_void, &state_type);
+        if (status != NFS4_OK) {
+            res->status = status;
+            chimera_nfs4_compound_complete(req, res->status);
+            return;
+        }
+
+        struct nfs_open_state *open_state = state_void;
+        bool                   has_write  = (open_state->share_access &
+                                             OPEN4_SHARE_ACCESS_WRITE) != 0;
+
+        nfs_state_table_release(table, open_state, NFS4_SLOT_TYPE_OPEN,
+                                thread->vfs_thread);
+
+        if (!has_write) {
+            res->status = NFS4ERR_OPENMODE;
+            chimera_nfs4_compound_complete(req, res->status);
+            return;
+        }
     }
 
     chimera_vfs_open_fh(thread->vfs_thread,

--- a/src/server/nfs/nfs4_proc_setclientid.c
+++ b/src/server/nfs/nfs4_proc_setclientid.c
@@ -30,10 +30,14 @@ chimera_nfs4_setclientid(
         resop->opsetclientid.resok4.clientid);
 
     if (!session) {
+        /* Implicit (NFS4.0) session -- no SEQUENCE op, so no replay slot
+         * table.  Pass zeros for the slot caps. */
         session = nfs4_create_session(
             &shared->nfs4_shared_clients,
             resop->opsetclientid.resok4.clientid,
             1,
+            0,
+            0,
             NULL,
             NULL);
     }

--- a/src/server/nfs/nfs4_proc_setclientid_confirm.c
+++ b/src/server/nfs/nfs4_proc_setclientid_confirm.c
@@ -1,8 +1,27 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
+/*
+ * RFC 7530 §16.34: SETCLIENTID_CONFIRM
+ *
+ * The client follows SETCLIENTID with SETCLIENTID_CONFIRM to confirm its
+ * binding.  Server must:
+ *   1. Verify the clientid matches a registered record.
+ *   2. Verify the confirmation verifier matches what SETCLIENTID returned.
+ *   3. Mark the unified client record `confirmed = true`.
+ *
+ * Phase 4 honors steps 1-3.  The setclientid_confirm verifier returned by
+ * SETCLIENTID is the implicit session_id (first 8 bytes), which is what we
+ * compare against here.
+ */
+
+#include <string.h>
+
 #include "nfs4_procs.h"
+#include "nfs4_recovery.h"
+#include "nfs4_session.h"
+#include "nfs4_state.h"
 
 void
 chimera_nfs4_setclientid_confirm(
@@ -11,17 +30,63 @@ chimera_nfs4_setclientid_confirm(
     struct nfs_argop4                *argop,
     struct nfs_resop4                *resop)
 {
-    //SETCLIENTID_CONFIRM4args *args = &argop->opsetclientid_confirm;
+    struct SETCLIENTID_CONFIRM4args *args  = &argop->opsetclientid_confirm;
+    struct nfs4_client_table        *table =
+        &thread->shared->nfs4_shared_clients;
+    struct nfs4_client              *c  = NULL;
+    struct nfs_client               *uc = NULL;
+    uint8_t                          expected[NFS4_SESSIONID_SIZE];
+    bool                             have_expected = false;
+    nfsstat4                         status;
 
-    /*
-     * In a real implementation, we would:
-     * 1. Verify the clientid matches one from a previous SETCLIENTID
-     * 2. Verify the confirmation verifier matches
-     * 3. Create/update the confirmed client record
-     * 4. Remove any unconfirmed records for this client
-     */
+    /* table is only read inside the __clang_analyzer__-excluded block
+     * below; consume it here so scan-build doesn't flag the init as
+     * a dead store. */
+    (void) table;
 
-    resop->opsetclientid_confirm.status = NFS4_OK;
+#ifndef __clang_analyzer__
+    pthread_mutex_lock(&table->nfs4_ct_lock);
 
+    HASH_FIND(nfs4_client_hh_by_id, table->nfs4_ct_clients_by_id,
+              &args->clientid, sizeof(args->clientid), c);
+
+    if (c) {
+        uc = c->unified;
+
+        /* The SETCLIENTID response copied the implicit session_id into the
+         * setclientid_confirm verifier; recover it by walking the sessions
+         * table for this clientid. */
+        struct nfs4_session *s, *stmp;
+        HASH_ITER(nfs4_session_hh, table->nfs4_ct_sessions, s, stmp)
+        {
+            if (s->nfs4_session_clientid == args->clientid) {
+                memcpy(expected, s->nfs4_session_id, NFS4_SESSIONID_SIZE);
+                have_expected = true;
+                break;
+            }
+        }
+    }
+
+    pthread_mutex_unlock(&table->nfs4_ct_lock);
+#endif /* ifndef __clang_analyzer__ */
+
+    if (!c) {
+        status = NFS4ERR_STALE_CLIENTID;
+    } else if (!have_expected ||
+               memcmp(args->setclientid_confirm, expected,
+                      sizeof(args->setclientid_confirm)) != 0) {
+        status = NFS4ERR_CLID_INUSE;
+    } else {
+        if (uc) {
+            uc->confirmed = 1;
+            /* Phase 5: stub-persist the confirmed client.  Future backends
+             * will write a record to stable storage so a restart can
+             * reclaim it within the grace window. */
+            nfs_recovery_persist(&thread->shared->nfs4_recovery, uc);
+        }
+        status = NFS4_OK;
+    }
+
+    resop->opsetclientid_confirm.status = status;
     chimera_nfs4_compound_complete(req, NFS4_OK);
 } /* chimera_nfs4_setclientid_confirm */

--- a/src/server/nfs/nfs4_proc_test_stateid.c
+++ b/src/server/nfs/nfs4_proc_test_stateid.c
@@ -4,6 +4,7 @@
 
 #include "nfs4_procs.h"
 #include "nfs4_session.h"
+#include "nfs4_state.h"
 
 void
 chimera_nfs4_test_stateid(
@@ -12,10 +13,10 @@ chimera_nfs4_test_stateid(
     struct nfs_argop4                *argop,
     struct nfs_resop4                *resop)
 {
-    struct TEST_STATEID4args  *args    = &argop->optest_stateid;
-    struct TEST_STATEID4res   *res     = &resop->optest_stateid;
-    struct TEST_STATEID4resok *resok   = &res->tsr_resok4;
-    struct nfs4_session       *session = req->session;
+    struct TEST_STATEID4args  *args  = &argop->optest_stateid;
+    struct TEST_STATEID4res   *res   = &resop->optest_stateid;
+    struct TEST_STATEID4resok *resok = &res->tsr_resok4;
+    struct nfs_state_table    *table = &thread->shared->nfs4_state_table;
     uint32_t                   i;
 
     resok->num_tsr_status_codes = args->num_ts_stateids;
@@ -24,12 +25,8 @@ chimera_nfs4_test_stateid(
         req->encoding->dbuf);
 
     for (i = 0; i < args->num_ts_stateids; i++) {
-        if (session) {
-            resok->tsr_status_codes[i] = nfs4_session_validate_stateid(
-                session, &args->ts_stateids[i]);
-        } else {
-            resok->tsr_status_codes[i] = NFS4ERR_BAD_STATEID;
-        }
+        resok->tsr_status_codes[i] = nfs_state_table_validate(
+            table, &args->ts_stateids[i]);
     }
 
     res->tsr_status = NFS4_OK;

--- a/src/server/nfs/nfs4_proc_write.c
+++ b/src/server/nfs/nfs4_proc_write.c
@@ -4,6 +4,7 @@
 
 #include "nfs4_procs.h"
 #include "nfs4_status.h"
+#include "nfs4_state.h"
 #include "vfs/vfs_procs.h"
 #include "vfs/vfs_release.h"
 #include "evpl/evpl.h"
@@ -25,10 +26,9 @@ chimera_nfs4_write_complete(
     struct chimera_vfs_attrs *post_attr,
     void                     *private_data)
 {
-    struct nfs_request             *req  = private_data;
-    struct WRITE4args              *args = req->args_write4;
-    struct WRITE4res               *res  = &req->res_compound.resarray[req->index].opwrite;
-    struct chimera_vfs_open_handle *deferred;
+    struct nfs_request *req  = private_data;
+    struct WRITE4args  *args = req->args_write4;
+    struct WRITE4res   *res  = &req->res_compound.resarray[req->index].opwrite;
 
     /* Release write iovecs here on the server thread, not in VFS backend.
      * The iovecs were allocated on this thread and must be released here
@@ -48,11 +48,11 @@ chimera_nfs4_write_complete(
         res->status = chimera_nfs4_errno_to_nfsstat4(error_code);
     }
 
-    if (req->nfs4_state) {
-        deferred = nfs4_session_release_state(req->session, req->nfs4_state);
-        if (deferred) {
-            chimera_vfs_release(req->thread->vfs_thread, deferred);
-        }
+    if (req->nfs_state_ref) {
+        nfs_state_table_release(&req->thread->shared->nfs4_state_table,
+                                req->nfs_state_ref, req->nfs_state_type,
+                                req->thread->vfs_thread);
+        req->nfs_state_ref = NULL;
     } else if (req->handle) {
         /* Anonymous stateid: release the on-the-fly handle we opened. */
         chimera_vfs_release(req->thread->vfs_thread, req->handle);
@@ -102,14 +102,16 @@ chimera_nfs4_write(
     struct nfs_argop4                *argop,
     struct nfs_resop4                *resop)
 {
-    struct WRITE4args              *args = &argop->opwrite;
-    struct WRITE4res               *res  = &resop->opwrite;
-    struct nfs4_session            *session;
-    struct nfs4_state              *state;
+    struct WRITE4args              *args  = &argop->opwrite;
+    struct WRITE4res               *res   = &resop->opwrite;
+    struct nfs_state_table         *table = &thread->shared->nfs4_state_table;
+    void                           *state_void;
+    uint8_t                         state_type;
     struct chimera_vfs_open_handle *state_handle;
+    nfsstat4                        status;
 
-    req->nfs4_state = NULL;
-    req->handle     = NULL;
+    req->nfs_state_ref = NULL;
+    req->handle        = NULL;
 
     /*
      * Transfer ownership of write iovecs from the RPC2 message to prevent
@@ -123,7 +125,7 @@ chimera_nfs4_write(
     /*
      * RFC 7530 9.1.4.3 / RFC 8881 8.2.3 require WRITE to honor the
      * anonymous stateid (all zeros).  Open the current FH on the fly
-     * instead of consulting per-session state.
+     * instead of consulting the state table.
      */
     if (chimera_nfs4_write_stateid_is_anonymous(&args->stateid)) {
         if (req->fhlen == 0) {
@@ -142,30 +144,24 @@ chimera_nfs4_write(
         return;
     }
 
-    session = nfs4_resolve_session(
-        req->session, req->conn,
-        &thread->shared->nfs4_shared_clients,
-        &args->stateid);
-
-    if (!session) {
-        res->status = NFS4ERR_BAD_STATEID;
+    status = nfs_state_table_acquire(table, &args->stateid, 0,
+                                     &state_void, &state_type);
+    if (status != NFS4_OK) {
+        res->status = status;
         evpl_iovecs_release(thread->evpl, args->data.iov, args->data.niov);
         chimera_nfs4_compound_complete(req, res->status);
         return;
     }
 
-    req->session = session;
-
-    if (nfs4_session_acquire_state(session, &args->stateid,
-                                   &state, &state_handle) != NFS4_OK) {
-        res->status = NFS4ERR_BAD_STATEID;
-        evpl_iovecs_release(thread->evpl, args->data.iov, args->data.niov);
-        chimera_nfs4_compound_complete(req, res->status);
-        return;
+    if (state_type == NFS4_SLOT_TYPE_OPEN) {
+        state_handle = ((struct nfs_open_state *) state_void)->handle;
+    } else {
+        state_handle = ((struct nfs_lock_state *) state_void)->handle;
     }
 
-    req->nfs4_state  = state;
-    req->args_write4 = args;
+    req->nfs_state_ref  = state_void;
+    req->nfs_state_type = state_type;
+    req->args_write4    = args;
 
     chimera_vfs_write(thread->vfs_thread, &req->cred,
                       state_handle,

--- a/src/server/nfs/nfs4_procs.h
+++ b/src/server/nfs/nfs4_procs.h
@@ -264,6 +264,34 @@ chimera_nfs4_setclientid(
     struct nfs_resop4                *resop);
 
 void
+chimera_nfs4_renew(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_request               *req,
+    struct nfs_argop4                *argop,
+    struct nfs_resop4                *resop);
+
+void
+chimera_nfs4_open_confirm(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_request               *req,
+    struct nfs_argop4                *argop,
+    struct nfs_resop4                *resop);
+
+void
+chimera_nfs4_open_downgrade(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_request               *req,
+    struct nfs_argop4                *argop,
+    struct nfs_resop4                *resop);
+
+void
+chimera_nfs4_release_lockowner(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_request               *req,
+    struct nfs_argop4                *argop,
+    struct nfs_resop4                *resop);
+
+void
 chimera_nfs4_setclientid_confirm(
     struct chimera_server_nfs_thread *thread,
     struct nfs_request               *req,
@@ -478,6 +506,23 @@ chimera_nfs4_compound_complete(
 
         /* Set the status for the failed operation */
         req->res_compound.resarray[req->index].opillegal.status = status;
+
+        /* XDR unmarshall of any WRITE4args in the compound clones the data
+         * iovecs (via xdr_iovec_copy_private / evpl_iovec_clone), taking a
+         * +1 refcount that is normally dropped by chimera_nfs4_write_complete.
+         * When a prior op fails and the compound is truncated, those
+         * WRITE ops never dispatch and their clones would leak.  Release
+         * the unmarshalled iovecs of every WRITE past the failed op. */
+        for (uint32_t i = req->index + 1; i < req->args_compound->num_argarray;
+             i++) {
+            struct nfs_argop4 *ap = &req->args_compound->argarray[i];
+            if (ap->argop == OP_WRITE && ap->opwrite.data.niov) {
+                evpl_iovecs_release(thread->evpl,
+                                    ap->opwrite.data.iov,
+                                    ap->opwrite.data.niov);
+                ap->opwrite.data.niov = 0;
+            }
+        }
 
         /* Per RFC 7530 section 15.2, the response must only include
          * operations up to and including the one that failed. Truncate

--- a/src/server/nfs/nfs4_recovery.c
+++ b/src/server/nfs/nfs4_recovery.c
@@ -1,0 +1,170 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include <stdatomic.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include "nfs4_recovery.h"
+#include "nfs4_lease.h"
+#include "nfs4_state.h"
+
+/*
+ * Generate a fresh, monotonic boot_id.  Phase 5 derives it from
+ * CLOCK_REALTIME; future persistent storage will load the prior epoch
+ * from disk and pick a strictly greater value.
+ */
+static uint64_t
+nfs_recovery_fresh_boot_id(void)
+{
+    struct timespec ts;
+
+    clock_gettime(CLOCK_REALTIME, &ts);
+    return (uint64_t) ts.tv_sec * 1000000000ULL + (uint64_t) ts.tv_nsec;
+} /* nfs_recovery_fresh_boot_id */
+
+int
+nfs_recovery_load(
+    struct nfs_recovery *rec,
+    const char          *state_dir,
+    uint64_t            *out_prev_boot_id)
+{
+    (void) state_dir;
+    (void) out_prev_boot_id;
+
+    pthread_mutex_init(&rec->lock, NULL);
+    rec->to_reclaim      = NULL;
+    rec->pending_reclaim = 0;
+    rec->current_boot_id = nfs_recovery_fresh_boot_id();
+    rec->grace_end_ns    = 0;
+    rec->in_grace        = false;
+    return 0;
+} /* nfs_recovery_load */
+
+void
+nfs_recovery_free(struct nfs_recovery *rec)
+{
+#ifndef __clang_analyzer__
+    struct nfs_recovery_record *r, *tmp;
+
+    pthread_mutex_lock(&rec->lock);
+    HASH_ITER(hh, rec->to_reclaim, r, tmp)
+    {
+        HASH_DEL(rec->to_reclaim, r);
+        free(r);
+    }
+    rec->pending_reclaim = 0;
+    pthread_mutex_unlock(&rec->lock);
+    pthread_mutex_destroy(&rec->lock);
+#endif /* ifndef __clang_analyzer__ */
+} /* nfs_recovery_free */
+
+void
+nfs_recovery_begin_grace(
+    struct nfs_recovery *rec,
+    uint32_t             grace_time_s)
+{
+    pthread_mutex_lock(&rec->lock);
+    if (rec->to_reclaim == NULL) {
+        /* No clients to reclaim -- skip the grace window entirely so
+         * normal traffic is accepted immediately. */
+        rec->in_grace     = false;
+        rec->grace_end_ns = 0;
+    } else {
+        rec->in_grace     = true;
+        rec->grace_end_ns = nfs_lease_now_ns() +
+            (uint64_t) grace_time_s * 1000000000ULL;
+    }
+    pthread_mutex_unlock(&rec->lock);
+} /* nfs_recovery_begin_grace */
+
+void
+nfs_recovery_end_grace(struct nfs_recovery *rec)
+{
+    pthread_mutex_lock(&rec->lock);
+    rec->in_grace     = false;
+    rec->grace_end_ns = 0;
+    pthread_mutex_unlock(&rec->lock);
+} /* nfs_recovery_end_grace */
+
+void
+nfs_recovery_persist(
+    struct nfs_recovery     *rec,
+    const struct nfs_client *client)
+{
+    /* Stub: future backends (file-per-client under state_dir or RocksDB)
+     * will serialize {owner_string, verifier, boot_id, principal} here. */
+    (void) rec;
+    (void) client;
+} /* nfs_recovery_persist */
+
+void
+nfs_recovery_forget(
+    struct nfs_recovery     *rec,
+    const struct nfs_client *client)
+{
+    /* Stub: future backends remove the persistent record. */
+    (void) rec;
+    (void) client;
+} /* nfs_recovery_forget */
+
+nfsstat4
+nfs_recovery_open_check(
+    struct nfs_recovery     *rec,
+    const struct nfs_client *client,
+    bool                     is_reclaim)
+{
+    bool in_grace;
+
+    (void) client;  /* Phase 5 doesn't gate per-client; future use. */
+
+    pthread_mutex_lock(&rec->lock);
+    in_grace = rec->in_grace;
+    pthread_mutex_unlock(&rec->lock);
+
+    if (in_grace && !is_reclaim) {
+        return NFS4ERR_GRACE;
+    }
+    if (!in_grace && is_reclaim) {
+        return NFS4ERR_NO_GRACE;
+    }
+    return NFS4_OK;
+} /* nfs_recovery_open_check */
+
+void
+nfs_recovery_reclaim_complete(
+    struct nfs_recovery     *rec,
+    const struct nfs_client *client)
+{
+    /* Stub-friendly: find this client's record (if any) and mark reclaimed.
+     * In the no-record case we simply leave the recovery state alone. */
+    (void) client;
+    pthread_mutex_lock(&rec->lock);
+    /* When persistence lands, look up record by owner_string here, flip
+     * reclaimed=true, decrement pending_reclaim, and if 0 set in_grace=false. */
+    pthread_mutex_unlock(&rec->lock);
+} /* nfs_recovery_reclaim_complete */
+
+void
+nfs_recovery_sweep_once(struct nfs_recovery *rec)
+{
+    uint64_t now;
+    bool     end_now = false;
+
+    pthread_mutex_lock(&rec->lock);
+    if (!rec->in_grace) {
+        pthread_mutex_unlock(&rec->lock);
+        return;
+    }
+    now = nfs_lease_now_ns();
+    if (now >= rec->grace_end_ns || rec->pending_reclaim == 0) {
+        end_now = true;
+    }
+    if (end_now) {
+        rec->in_grace     = false;
+        rec->grace_end_ns = 0;
+    }
+    pthread_mutex_unlock(&rec->lock);
+} /* nfs_recovery_sweep_once */

--- a/src/server/nfs/nfs4_recovery.h
+++ b/src/server/nfs/nfs4_recovery.h
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#pragma once
+
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <uthash.h>
+
+#include "nfs4_xdr.h"
+
+/*
+ * Server-reboot recovery + grace period.
+ *
+ * On startup the server loads any persistently-stored "confirmed client"
+ * records (in this phase: zero, the persistence layer is stubbed) and
+ * enters a grace window of `grace_time_s` during which:
+ *   - OPENs with CLAIM_PREVIOUS from clients in the to_reclaim set are
+ *     allowed (the reclaim path).
+ *   - All other OPENs return NFS4ERR_GRACE.
+ *
+ * Grace ends when:
+ *   - Every loaded client has issued RECLAIM_COMPLETE, OR
+ *   - `grace_end_ns` is reached, whichever comes first.
+ *
+ * Since the persistence layer is a no-op stub today, to_reclaim is empty
+ * at boot and nfs_recovery_begin_grace short-circuits to in_grace = false.
+ * The wiring is in place for a future file-per-client or RocksDB backend
+ * to plug in behind the same API without touching callers.
+ */
+
+struct nfs_recovery_record {
+    char           owner_string[NFS4_OPAQUE_LIMIT];
+    uint16_t       owner_len;
+    uint64_t       client_id_hint; /* not authoritative; just a sticky ID */
+    uint64_t       verifier;
+    uint64_t       boot_id;
+    bool           reclaimed;
+    UT_hash_handle hh;
+};
+
+struct nfs_recovery {
+    pthread_mutex_t             lock;
+    struct nfs_recovery_record *to_reclaim;       /* uthash by owner_string */
+    uint32_t                    pending_reclaim;  /* count of !reclaimed records */
+    uint64_t                    current_boot_id;
+    uint64_t                    grace_end_ns;
+    bool                        in_grace;
+};
+
+struct nfs_client;
+
+/*
+ * Initialize the recovery state.  Sets current_boot_id to a fresh value;
+ * future implementations will derive it from persistent storage so that a
+ * server restart bumps the boot_id and triggers reclaim eligibility.
+ */
+int
+nfs_recovery_load(
+    struct nfs_recovery *rec,
+    const char          *state_dir,
+    uint64_t            *out_prev_boot_id);
+
+void
+nfs_recovery_free(
+    struct nfs_recovery *rec);
+
+/*
+ * Begin the grace window.  If to_reclaim is empty (the persistence stub
+ * loads nothing), short-circuits to in_grace = false so callers see no
+ * behavioral change.  Otherwise stamps grace_end_ns.
+ */
+void
+nfs_recovery_begin_grace(
+    struct nfs_recovery *rec,
+    uint32_t             grace_time_s);
+
+/*
+ * End the grace window early.  Idempotent.
+ */
+void
+nfs_recovery_end_grace(
+    struct nfs_recovery *rec);
+
+/*
+ * Persist (stub) a newly-confirmed client.  Future backends will write the
+ * record to stable storage so a restart can reclaim it.
+ */
+void
+nfs_recovery_persist(
+    struct nfs_recovery     *rec,
+    const struct nfs_client *client);
+
+/*
+ * Forget (stub) a record when its client issues DESTROY_CLIENTID.
+ */
+void
+nfs_recovery_forget(
+    struct nfs_recovery     *rec,
+    const struct nfs_client *client);
+
+/*
+ * Gate for OPEN during recovery:
+ *   in_grace && !is_reclaim  -> NFS4ERR_GRACE
+ *   !in_grace && is_reclaim  -> NFS4ERR_NO_GRACE
+ *   otherwise                -> NFS4_OK
+ */
+nfsstat4
+nfs_recovery_open_check(
+    struct nfs_recovery     *rec,
+    const struct nfs_client *client,
+    bool                     is_reclaim);
+
+/*
+ * Mark `client` as having completed reclaim.  When the pending_reclaim
+ * count drops to zero the grace window ends early.
+ */
+void
+nfs_recovery_reclaim_complete(
+    struct nfs_recovery     *rec,
+    const struct nfs_client *client);
+
+/*
+ * Called from the lease sweeper at 1Hz.  Ends the grace window when
+ * grace_end_ns has been reached or the to_reclaim set is fully reclaimed.
+ */
+void
+nfs_recovery_sweep_once(
+    struct nfs_recovery *rec);

--- a/src/server/nfs/nfs4_session.c
+++ b/src/server/nfs/nfs4_session.c
@@ -6,17 +6,79 @@
 #include <stdio.h>
 #include <string.h>
 #include <uuid/uuid.h>
+#include "prometheus-c.h"
 #include "nfs4_session.h"
+#include "nfs4_state.h"
 #include "nfs_internal.h"
 #include "nfs_nlm_state.h"
+#include "nfs_common.h"
 #include "evpl/evpl_rpc2.h"
 #include "vfs/vfs_release.h"
+
+/* Bump a replay-cache counter on the shared struct.  Safe when the
+ * thread/shared are not set up (e.g. in the unit test). */
+static inline void
+nfs4_replay_metric_inc(
+    struct nfs_request *req,
+    struct prometheus_counter_instance *(*field)(struct nfs4_replay_metrics *))
+{
+    struct nfs4_replay_metrics         *rm;
+    struct prometheus_counter_instance *inst;
+
+    if (!req || !req->thread || !req->thread->shared) {
+        return;
+    }
+    rm   = &req->thread->shared->replay_metrics;
+    inst = field(rm);
+    if (inst) {
+        prometheus_counter_increment(inst);
+    }
+} /* nfs4_replay_metric_inc */
+
+/* Adjust the replay-cache bytes gauge.  Safe when not set up. */
+static inline void
+nfs4_replay_bytes_delta(
+    struct nfs_request *req,
+    int64_t             delta)
+{
+    struct prometheus_gauge_instance *g;
+
+    if (!req || !req->thread || !req->thread->shared) {
+        return;
+    }
+    g = req->thread->shared->replay_metrics.bytes_in_use;
+    if (g) {
+        prometheus_gauge_add(g, delta);
+    }
+} /* nfs4_replay_bytes_delta */
+
+static struct prometheus_counter_instance *
+replay_field_hit(struct nfs4_replay_metrics *rm)
+{
+    return rm->hit;
+} /* replay_field_hit */
+static struct prometheus_counter_instance *
+replay_field_seq_misordered(struct nfs4_replay_metrics *rm)
+{
+    return rm->seq_misordered;
+} /* replay_field_seq_misordered */
+static struct prometheus_counter_instance *
+replay_field_bad_slot(struct nfs4_replay_metrics *rm)
+{
+    return rm->bad_slot;
+} /* replay_field_bad_slot */
+static struct prometheus_counter_instance *
+replay_field_retry_uncached(struct nfs4_replay_metrics *rm)
+{
+    return rm->retry_uncached;
+} /* replay_field_retry_uncached */
 
 void
 nfs4_client_table_init(struct nfs4_client_table *table)
 {
     table->nfs4_ct_clients_by_owner = NULL;
     table->nfs4_ct_clients_by_id    = NULL;
+    table->nfs4_ct_sessions         = NULL;
     table->nfs4_ct_next_client_id   = 1;
 
     pthread_mutex_init(&table->nfs4_ct_lock, NULL);
@@ -90,6 +152,13 @@ nfs4_client_register(
         client->nfs4_client_verifier  = verifier;
         client->nfs4_client_refcnt    = 1;
 
+        /* Bring up the unified state hierarchy in lockstep with the
+         * registration record.  minor is encoded as proto/40 today
+         * (4.0 only path uses different proto values); pass 0 here and
+         * let Phase 4 thread the real minor through. */
+        client->unified = nfs_client_alloc(client->nfs4_client_id,
+                                           owner, owner_len, verifier, 0);
+
         if (nii_domain) {
             snprintf(client->nfs4_client_domain,
                      sizeof(client->nfs4_client_domain), "%s", nii_domain);
@@ -128,10 +197,13 @@ nfs4_client_register(
 
 void
 nfs4_client_unregister(
-    struct nfs4_client_table *table,
-    uint64_t                  client_id)
+    struct nfs4_client_table  *table,
+    struct nfs_state_table    *state_table,
+    struct chimera_vfs_thread *vfs_thread,
+    uint64_t                   client_id)
 {
     struct nfs4_client *client;
+    struct nfs_client  *unified = NULL;
 
     pthread_mutex_lock(&table->nfs4_ct_lock);
 
@@ -143,11 +215,21 @@ nfs4_client_unregister(
         HASH_DELETE(nfs4_client_hh_by_owner, table->nfs4_ct_clients_by_owner,
                     client);
         HASH_DELETE(nfs4_client_hh_by_id, table->nfs4_ct_clients_by_id, client);
+        unified         = client->unified;
+        client->unified = NULL;
         free(client);
     }
 
     pthread_mutex_unlock(&table->nfs4_ct_lock);
 
+    /* Tear down the unified state hierarchy outside the table lock so
+     * nfs_client_destroy can take per-client / per-owner locks without
+     * inversion against the table lock.  RFC 8881 §18.50.4 requires that
+     * the client have no remaining state at DESTROY_CLIENTID time -- if
+     * any survived, this releases their slots + dup'd VFS handles. */
+    if (unified) {
+        nfs_client_destroy(unified, state_table, vfs_thread);
+    }
 } /* nfs4_client_unregister */
 
 struct nfs4_session *
@@ -155,13 +237,14 @@ nfs4_create_session(
     struct nfs4_client_table    *table,
     uint64_t                     client_id,
     uint32_t                     implicit,
+    uint32_t                     replay_max_slots,
+    uint32_t                     replay_maxresp_cached,
     const struct channel_attrs4 *fore_attrs,
     const struct channel_attrs4 *back_attrs)
 {
     struct nfs4_client  *client  = NULL;
     struct nfs4_session *session = NULL;
     char                 session_id_str[80];
-    uint32_t             i;
 
     pthread_mutex_lock(&table->nfs4_ct_lock);
 
@@ -171,7 +254,8 @@ nfs4_create_session(
     if (client) {
         session = calloc(1, sizeof(*session));
 
-        session->magic = NFS4_SESSION_MAGIC;
+        session->magic          = NFS4_SESSION_MAGIC;
+        session->client_unified = client->unified;
         /* refcount: 1 for the hash table, 1 for the caller (so the session
          * cannot be destroyed by another thread before the caller binds it
          * to a conn). */
@@ -180,16 +264,23 @@ nfs4_create_session(
 
         uuid_generate(session->nfs4_session_id);
 
-        pthread_mutex_init(&session->nfs4_session_lock, NULL);
-
         session->nfs4_session_implicit = implicit;
         session->nfs4_session_clientid = client_id;
 
-        for (i = 0; i < NFS4_SESSION_MAX_STATE; i++) {
-            session->free_slot[i] = NFS4_SESSION_MAX_STATE - (i + 1);
-        }
+        pthread_mutex_init(&session->nfs4_session_lock, NULL);
 
-        session->num_free_slots = NFS4_SESSION_MAX_STATE;
+        /* NFS4.1 SEQUENCE replay cache slot table.  Implicit (NFS4.0)
+         * sessions get zero slots -- v4.0 uses per-owner replay caches in
+         * nfs_open_owner / nfs_lock_owner instead. */
+        session->replay_max_slots      = implicit ? 0 : replay_max_slots;
+        session->replay_maxresp_cached = replay_maxresp_cached;
+        session->replay_bytes_in_use   = 0;
+        session->replay_slots          = NULL;
+
+        if (session->replay_max_slots) {
+            session->replay_slots = calloc(session->replay_max_slots,
+                                           sizeof(*session->replay_slots));
+        }
 
         if (fore_attrs) {
             session->nfs4_session_fore_attrs = *fore_attrs;
@@ -316,31 +407,27 @@ nfs4_destroy_session(
 } /* nfs4_destroy_session */
 
 void
-nfs4_client_table_release_handles(
+nfs4_client_table_destroy_unified(
     struct nfs4_client_table  *table,
+    struct nfs_state_table    *state_table,
     struct chimera_vfs_thread *vfs_thread)
 {
 #ifndef __clang_analyzer__
-    struct nfs4_session *sess, *sesstmp;
-    uint32_t             i;
+    struct nfs4_client *cur, *tmp;
 
     pthread_mutex_lock(&table->nfs4_ct_lock);
 
-    HASH_ITER(nfs4_session_hh, table->nfs4_ct_sessions, sess, sesstmp)
+    HASH_ITER(nfs4_client_hh_by_id, table->nfs4_ct_clients_by_id, cur, tmp)
     {
-        for (i = 0; i < NFS4_SESSION_MAX_STATE; i++) {
-            struct nfs4_state *state = &sess->nfs4_session_state[i];
-            if (state->nfs4_state_handle) {
-                chimera_vfs_release(vfs_thread, state->nfs4_state_handle);
-                state->nfs4_state_handle = NULL;
-                state->nfs4_state_active = 0;
-            }
+        if (cur->unified) {
+            nfs_client_destroy(cur->unified, state_table, vfs_thread);
+            cur->unified = NULL;
         }
     }
 
     pthread_mutex_unlock(&table->nfs4_ct_lock);
 #endif /* ifndef __clang_analyzer__ */
-} /* nfs4_client_table_release_handles */
+} /* nfs4_client_table_destroy_unified */
 
 void
 nfs4_session_get(struct nfs4_session *session)
@@ -362,6 +449,14 @@ nfs4_session_put(struct nfs4_session *session)
 
     if (prev == 1) {
         /* Last ref -- safe to tear down. */
+        if (session->replay_slots) {
+            uint32_t i;
+            for (i = 0; i < session->replay_max_slots; i++) {
+                free(session->replay_slots[i].cached_buf);
+            }
+            free(session->replay_slots);
+            session->replay_slots = NULL;
+        }
         pthread_mutex_destroy(&session->nfs4_session_lock);
         session->magic = 0;
         free(session);
@@ -423,3 +518,244 @@ nfs4_session_unbind_conn(struct evpl_rpc2_conn *conn)
     evpl_rpc2_conn_set_private_data(conn, NULL);
     nfs4_session_put(session);
 } /* nfs4_session_unbind_conn */
+
+/*
+ * Reply-capture callback invoked from inside evpl_rpc2_send_reply, just
+ * before the encoded reply iovecs are queued onto the wire (and the
+ * request -- including the encoding's dbuf -- is freed).  We have one
+ * chance to copy the bytes out for later replay.
+ *
+ * private_data is the struct nfs_request whose SEQUENCE handler armed
+ * the capture (only when sa_cachethis was set and the slot is in
+ * IN_PROGRESS for this request).
+ *
+ * If the reply exceeds the per-slot or per-session byte cap, the
+ * capture is silently demoted: cached_buf stays NULL and finalize will
+ * transition the slot to COMPLETED instead of CACHED.  A future retry
+ * will then return NFS4ERR_RETRY_UNCACHED_REP, which RFC 5661 2.10.6.1
+ * explicitly permits (the server may override sa_cachethis).
+ */
+static void
+nfs4_replay_capture_reply(
+    const struct evpl_iovec *iov,
+    int                      niov,
+    int                      total_length,
+    void                    *private_data)
+{
+    struct nfs_request      *req     = private_data;
+    struct nfs4_session     *session = req->session;
+    struct nfs4_replay_slot *slot    = req->replay_slot;
+    uint8_t                 *buf;
+    size_t                   offset = 0;
+    int                      i;
+
+    if (!slot || !session || total_length <= 0) {
+        return;
+    }
+
+    if ((uint32_t) total_length > session->replay_maxresp_cached) {
+        return;
+    }
+
+    pthread_mutex_lock(&session->nfs4_session_lock);
+
+    if (session->replay_bytes_in_use + (size_t) total_length >
+        NFS4_MAX_REPLY_CACHE_BYTES) {
+        pthread_mutex_unlock(&session->nfs4_session_lock);
+        return;
+    }
+
+    buf = malloc(total_length);
+    if (!buf) {
+        pthread_mutex_unlock(&session->nfs4_session_lock);
+        return;
+    }
+
+    /* Concatenate iovecs into a single contiguous buffer.  Loses
+     * zerocopy on replay; acceptable since cachethis=true is rare for
+     * iovec-heavy ops (READ/READLINK) and replay is rare in general. */
+    for (i = 0; i < niov; i++) {
+        memcpy(buf + offset, iov[i].data, iov[i].length);
+        offset += iov[i].length;
+    }
+
+    slot->cached_buf              = buf;
+    slot->cached_len              = total_length;
+    session->replay_bytes_in_use += total_length;
+
+    pthread_mutex_unlock(&session->nfs4_session_lock);
+
+    /* Update gauge after dropping the session lock. */
+    nfs4_replay_bytes_delta(req, total_length);
+} /* nfs4_replay_capture_reply */
+
+/*
+ * Install the capture callback on the encoding so it fires from inside
+ * the next send_reply call.  Caller already holds the session lock and
+ * has set req->replay_slot. */
+static inline void
+nfs4_replay_arm_capture(struct nfs_request *req)
+{
+    if (req->encoding) {
+        req->encoding->reply_capture_cb      = nfs4_replay_capture_reply;
+        req->encoding->reply_capture_private = req;
+    }
+} /* nfs4_replay_arm_capture */
+
+nfsstat4
+nfs4_replay_slot_acquire(
+    struct nfs4_session *session,
+    uint32_t             slotid,
+    uint32_t             seqid,
+    bool                 cachethis,
+    struct nfs_request  *req,
+    bool                *out_is_replay)
+{
+    struct nfs4_replay_slot *slot;
+    nfsstat4                 status      = NFS4_OK;
+    uint32_t                 freed_bytes = 0;
+
+    *out_is_replay = false;
+
+    if (slotid >= session->replay_max_slots) {
+        nfs4_replay_metric_inc(req, replay_field_bad_slot);
+        return NFS4ERR_BADSLOT;
+    }
+
+    slot = &session->replay_slots[slotid];
+
+    pthread_mutex_lock(&session->nfs4_session_lock);
+
+    switch (slot->state) {
+        case NFS4_SLOT_UNUSED:
+            /* First-ever use.  RFC 5661 sets csr_sequence = 1 at
+             * CREATE_SESSION; the client's first SEQUENCE on a slot must
+             * therefore use seqid = 1. */
+            if (seqid != 1) {
+                status = NFS4ERR_SEQ_MISORDERED;
+                break;
+            }
+            slot->state          = NFS4_SLOT_IN_PROGRESS;
+            slot->inflight_seqid = seqid;
+            slot->cachethis      = cachethis ? 1 : 0;
+            req->replay_slot     = slot;
+            req->replay_slot_id  = slotid;
+            req->replay_action   = NFS4_REPLAY_ACTION_NEW;
+            if (cachethis) {
+                nfs4_replay_arm_capture(req);
+            }
+            break;
+
+        case NFS4_SLOT_CACHED:
+        case NFS4_SLOT_COMPLETED:
+            if (seqid == (uint32_t) (slot->seqid + 1)) {
+                /* Normal advance.  Drop any prior cached reply -- the
+                 * client has acknowledged it by moving on. */
+                if (slot->state == NFS4_SLOT_CACHED &&
+                    slot->cached_buf) {
+                    freed_bytes                   = slot->cached_len;
+                    session->replay_bytes_in_use -= slot->cached_len;
+                    free(slot->cached_buf);
+                    slot->cached_buf = NULL;
+                    slot->cached_len = 0;
+                }
+                slot->state          = NFS4_SLOT_IN_PROGRESS;
+                slot->inflight_seqid = seqid;
+                slot->cachethis      = cachethis ? 1 : 0;
+                req->replay_slot     = slot;
+                req->replay_slot_id  = slotid;
+                req->replay_action   = NFS4_REPLAY_ACTION_NEW;
+                if (cachethis) {
+                    nfs4_replay_arm_capture(req);
+                }
+            } else if (seqid == slot->seqid) {
+                /* Retransmit. */
+                if (slot->state == NFS4_SLOT_CACHED && slot->cached_buf) {
+                    req->replay_slot    = slot;
+                    req->replay_slot_id = slotid;
+                    req->replay_action  = NFS4_REPLAY_ACTION_FROM_CACHE;
+                    *out_is_replay      = true;
+                } else {
+                    /* Original ran with cachethis=false (or was demoted
+                     * for size).  We cannot replay the bytes. */
+                    status = NFS4ERR_RETRY_UNCACHED_REP;
+                }
+            } else {
+                status = NFS4ERR_SEQ_MISORDERED;
+            }
+            break;
+
+        case NFS4_SLOT_IN_PROGRESS:
+            /* Original compound is still running.  Whether seqid matches
+             * (true retry) or not (client jumped ahead), we cannot
+             * produce a reply yet.  Both paths return errors. */
+            if (seqid == slot->inflight_seqid) {
+                status = NFS4ERR_RETRY_UNCACHED_REP;
+            } else {
+                status = NFS4ERR_SEQ_MISORDERED;
+            }
+            break;
+
+        default:
+            status = NFS4ERR_SERVERFAULT;
+            break;
+    } /* switch */
+
+    pthread_mutex_unlock(&session->nfs4_session_lock);
+
+    /* Update metrics outside the session lock to avoid serializing the
+     * shared prometheus counters on per-session traffic. */
+    if (freed_bytes) {
+        nfs4_replay_bytes_delta(req, -(int64_t) freed_bytes);
+    }
+    if (*out_is_replay) {
+        nfs4_replay_metric_inc(req, replay_field_hit);
+    } else if (status == NFS4ERR_SEQ_MISORDERED) {
+        nfs4_replay_metric_inc(req, replay_field_seq_misordered);
+    } else if (status == NFS4ERR_RETRY_UNCACHED_REP) {
+        nfs4_replay_metric_inc(req, replay_field_retry_uncached);
+    }
+    return status;
+} /* nfs4_replay_slot_acquire */
+
+void
+nfs4_replay_slot_finalize(struct nfs_request *req)
+{
+    struct nfs4_session     *session = req->session;
+    struct nfs4_replay_slot *slot    = req->replay_slot;
+
+    if (!slot || !session) {
+        return;
+    }
+
+    /* NB: at this point req->encoding has already been freed inside
+     * send_reply_NFSPROC4_COMPOUND -- do not dereference it. */
+
+    /* If the session has been destroyed under us, the slot table may
+     * still be valid (it lives until the last conn ref is dropped) but
+     * caching the reply is pointless. */
+    if (atomic_load_explicit(&session->destroyed, memory_order_acquire)) {
+        req->replay_slot = NULL;
+        return;
+    }
+
+    pthread_mutex_lock(&session->nfs4_session_lock);
+
+    /* If the capture callback successfully copied bytes into the slot,
+     * transition to CACHED so a retransmit can replay.  Otherwise (no
+     * cachethis, or demoted for size) transition to COMPLETED -- a
+     * retransmit will get NFS4ERR_RETRY_UNCACHED_REP. */
+    if (slot->state == NFS4_SLOT_IN_PROGRESS) {
+        slot->seqid          = slot->inflight_seqid;
+        slot->inflight_seqid = 0;
+        if (slot->cached_buf) {
+            slot->state = NFS4_SLOT_CACHED;
+        } else {
+            slot->state = NFS4_SLOT_COMPLETED;
+        }
+    }
+
+    pthread_mutex_unlock(&session->nfs4_session_lock);
+
+    req->replay_slot = NULL;
+} /* nfs4_replay_slot_finalize */

--- a/src/server/nfs/nfs4_session.h
+++ b/src/server/nfs/nfs4_session.h
@@ -8,32 +8,50 @@
 #include <stdbool.h>
 #include <uthash.h>
 
-#include "nfs3_xdr.h"
 #include "nfs4_xdr.h"
 #include "nfs_internal.h"
-#include "vfs/vfs.h"
 
 struct evpl_rpc2_conn;
+struct chimera_vfs_thread;
+struct nfs_client;
+struct nfs_state_table;
+struct nfs_request;
 
-#define NFS4_SESSION_MAX_STATE 1024
+/* RPC slot table caps (NFS4.1 SEQUENCE replay cache).  These are *server*
+ * ceilings on what a client can negotiate at CREATE_SESSION; the negotiated
+ * value is min(client_request, server_cap). */
+#define NFS4_MAX_REPLY_CACHE_SLOTS    64u
+#define NFS4_MAX_CACHED_RESPONSE_SIZE (64u * 1024u)
+#define NFS4_MAX_REPLY_CACHE_BYTES    (4u * 1024u * 1024u)
 
-#define NFS4_STATE_TYPE_OPEN   0
-#define NFS4_STATE_TYPE_LOCK   1
+enum nfs4_slot_state {
+    NFS4_SLOT_UNUSED      = 0,
+    NFS4_SLOT_IN_PROGRESS = 1,
+    NFS4_SLOT_CACHED      = 2, /* completed; cachethis=true; bytes held */
+    NFS4_SLOT_COMPLETED   = 3, /* completed; cachethis=false; no bytes */
+};
+
+/* Set on req->replay_action by the SEQUENCE handler so the compound
+ * dispatcher knows whether to execute the compound normally or to
+ * short-circuit and replay a cached reply. */
+#define NFS4_REPLAY_ACTION_NONE       0
+#define NFS4_REPLAY_ACTION_NEW        1
+#define NFS4_REPLAY_ACTION_FROM_CACHE 2
+
+struct nfs4_replay_slot {
+    uint32_t seqid;                    /* last completed seqid (in CACHED/COMPLETED) */
+    uint32_t inflight_seqid; /* seqid being processed when IN_PROGRESS */
+    uint8_t  state;                    /* enum nfs4_slot_state */
+    uint8_t  cachethis;      /* sa_cachethis from current inflight */
+    uint32_t cached_len;     /* bytes in cached_buf (CACHED only) */
+    void    *cached_buf;     /* RPC reply (header+body); malloc'd */
+};
 
 /* Magic stored in nfs4_session.magic so that a connection's private_data
  * (which may hold either an nlm_client* or an nfs4_session*) can be safely
  * type-checked in the disconnect handler.  Must match the layout of
  * nlm_client (uint32_t magic at offset 0). */
-#define NFS4_SESSION_MAGIC     0x4E465353U /* "NFSS" */
-
-struct nfs4_state {
-    struct stateid4                 nfs4_state_id;
-    uint16_t                        nfs4_state_type;
-    uint16_t                        nfs4_state_active;
-    uint32_t                        nfs4_state_refcnt;
-    struct chimera_vfs_open_handle *nfs4_state_handle;
-    uint32_t                        nfs4_state_parent_slot; /* open slot index for LOCK states */
-};
+#define NFS4_SESSION_MAGIC 0x4E465353U /* "NFSS" */
 
 struct nfs4_client {
     uint64_t              nfs4_client_id;
@@ -46,26 +64,43 @@ struct nfs4_client {
     uint8_t               nfs4_client_owner[NFS4_OPAQUE_LIMIT];
     char                  nfs4_client_domain[NFS4_OPAQUE_LIMIT];
     char                  nfs4_client_name[NFS4_OPAQUE_LIMIT];
+    /* Unified state hierarchy.  Created when this nfs4_client is first
+     * registered; freed when the nfs4_client is unregistered or the table
+     * is torn down.  See nfs4_state.h. */
+    struct nfs_client    *unified;
 };
 
 struct nfs4_session {
     /* magic MUST be the first member -- see NFS4_SESSION_MAGIC comment. */
-    uint32_t              magic;
-    _Atomic uint32_t      refcount;
-    _Atomic bool          destroyed;
-    uint8_t               nfs4_session_id[NFS4_SESSIONID_SIZE];
-    uint64_t              nfs4_session_clientid;
-    pthread_mutex_t       nfs4_session_lock;
-    uint32_t              num_free_slots;
-    struct nfs4_state     nfs4_session_state[NFS4_SESSION_MAX_STATE];
-    uint16_t              free_slot[NFS4_SESSION_MAX_STATE];
-    uint32_t              nfs4_session_implicit;
-    struct nfs4_client   *nfs4_session_client;
-    struct channel_attrs4 nfs4_session_fore_attrs;
-    struct channel_attrs4 nfs4_session_back_attrs;
-    uint32_t              nfs4_session_fore_attrs_rdma_ird;
-    uint32_t              nfs4_session_back_attrs_rdma_ird;
-    struct UT_hash_handle nfs4_session_hh;
+    uint32_t                 magic;
+    /* Cached pointer to the owning client's unified state hierarchy.  Set
+     * at session creation; cleared at table teardown (when the unified
+     * client is destroyed).  Borrowed reference: lifetime matches the
+     * nfs4_client this session belongs to. */
+    struct nfs_client       *client_unified;
+    _Atomic uint32_t         refcount;
+    _Atomic bool             destroyed;
+    uint8_t                  nfs4_session_id[NFS4_SESSIONID_SIZE];
+    uint64_t                 nfs4_session_clientid;
+    /* Guards mutable session-level state: the 4.1 replay slot table and
+     * its byte accounting.  Stateid lookups don't need this -- they go
+     * through the per-shard rwlocks in nfs_state_table. */
+    pthread_mutex_t          nfs4_session_lock;
+    uint32_t                 nfs4_session_implicit;
+    struct nfs4_client      *nfs4_session_client;
+    struct channel_attrs4    nfs4_session_fore_attrs;
+    struct channel_attrs4    nfs4_session_back_attrs;
+    uint32_t                 nfs4_session_fore_attrs_rdma_ird;
+    uint32_t                 nfs4_session_back_attrs_rdma_ird;
+    /* NFS4.1 SEQUENCE replay cache (per-session slot table).  Distinct
+     * mechanism from the 4.0 per-owner replay in nfs_open_owner.replay /
+     * nfs_lock_owner.replay -- the two coexist by minor version.  Implicit
+     * sessions (4.0 SETCLIENTID path) leave replay_max_slots = 0. */
+    uint32_t                 replay_max_slots;
+    uint32_t                 replay_maxresp_cached;
+    size_t                   replay_bytes_in_use;
+    struct nfs4_replay_slot *replay_slots;
+    struct UT_hash_handle    nfs4_session_hh;
 };
 
 struct nfs4_client_table {
@@ -84,9 +119,14 @@ void
 nfs4_client_table_free(
     struct nfs4_client_table *table);
 
+/* Walk all clients in the table and tear down each one's `unified` state
+ * hierarchy via nfs_client_destroy.  Must be called while the VFS thread is
+ * still live (handles get released through it).  After this returns, every
+ * client->unified pointer is NULL and the state slot table is empty. */
 void
-nfs4_client_table_release_handles(
+nfs4_client_table_destroy_unified(
     struct nfs4_client_table  *table,
+    struct nfs_state_table    *state_table,
     struct chimera_vfs_thread *vfs_thread);
 
 uint64_t
@@ -99,18 +139,52 @@ nfs4_client_register(
     const char               *nii_domain,
     const char               *nii_name);
 
+/* Unregister a client and tear down its unified state hierarchy.
+ *
+ * `state_table` and `vfs_thread` may be NULL only when the caller has
+ * already invoked nfs4_client_table_destroy_unified (e.g. at shutdown);
+ * otherwise both must be valid so that any state slots / dup'd VFS
+ * handles still rooted under client->unified are released. */
 void
 nfs4_client_unregister(
-    struct nfs4_client_table *table,
-    uint64_t                  client_id);
+    struct nfs4_client_table  *table,
+    struct nfs_state_table    *state_table,
+    struct chimera_vfs_thread *vfs_thread,
+    uint64_t                   client_id);
 
 struct nfs4_session *
 nfs4_create_session(
     struct nfs4_client_table    *table,
     uint64_t                     client_id,
     uint32_t                     implicit,
+    uint32_t                     replay_max_slots,
+    uint32_t                     replay_maxresp_cached,
     const struct channel_attrs4 *fore_attrs,
     const struct channel_attrs4 *back_attrs);
+
+/* SEQUENCE replay slot state machine.  See plan in
+ * /root/.claude/plans/lets-plan-out-the-steady-steele.md for the full
+ * state diagram.  Returns NFS4_OK on success (NEW request or REPLAY hit),
+ * otherwise an NFS4ERR_* code (BADSLOT / SEQ_MISORDERED / RETRY_UNCACHED_REP).
+ * On NFS4_OK with *out_is_replay=true the caller must short-circuit the
+ * compound and replay slot->cached_buf.
+ *
+ * On NFS4_OK the slot pointer and slot id are stashed on req for the
+ * compound dispatcher to consume at finalize time.  cachethis is recorded
+ * for the in-flight request and consulted only at finalize. */
+nfsstat4 nfs4_replay_slot_acquire(
+    struct nfs4_session *session,
+    uint32_t             slotid,
+    uint32_t             seqid,
+    bool                 cachethis,
+    struct nfs_request  *req,
+    bool                *out_is_replay);
+
+/* Called by the compound dispatcher just before sending the reply.  In
+ * Phase 1 this advances IN_PROGRESS -> COMPLETED.  Phase 2 will optionally
+ * capture the encoded reply bytes and transition to CACHED. */
+void nfs4_replay_slot_finalize(
+    struct nfs_request *req);
 
 struct nfs4_session *
 nfs4_session_lookup(
@@ -162,231 +236,3 @@ nfs4_session_is_live(struct nfs4_session *session)
            session->magic == NFS4_SESSION_MAGIC &&
            !atomic_load_explicit(&session->destroyed, memory_order_acquire);
 } // nfs4_session_is_live
-
-static inline struct nfs4_state *
-nfs4_session_alloc_slot(struct nfs4_session *session)
-{
-    uint32_t           slot;
-    struct nfs4_state *state;
-
-    pthread_mutex_lock(&session->nfs4_session_lock);
-
-    chimera_nfs_abort_if(session->num_free_slots == 0, "no free session slots");
-
-    slot  = session->free_slot[--session->num_free_slots];
-    state = &session->nfs4_session_state[slot];
-
-    state->nfs4_state_id.seqid = 1;
-
-    *(uint32_t *) state->nfs4_state_id.other       = slot;
-    *(uint64_t *) (state->nfs4_state_id.other + 4) = session->nfs4_session_clientid;
-
-    state->nfs4_state_type        = NFS4_STATE_TYPE_OPEN;
-    state->nfs4_state_active      = 1;
-    state->nfs4_state_refcnt      = 0;
-    state->nfs4_state_handle      = NULL;
-    state->nfs4_state_parent_slot = NFS4_SESSION_MAX_STATE;
-
-    pthread_mutex_unlock(&session->nfs4_session_lock);
-
-    return state;
-} /* nfs4_session_alloc_slot */
-
-static inline int
-nfs4_session_free_slot(
-    struct nfs4_session             *session,
-    struct nfs4_state               *state,
-    struct chimera_vfs_open_handle **out_handle)
-{
-    uint32_t slot = *(uint32_t *) state->nfs4_state_id.other;
-
-    *out_handle = NULL;
-
-    pthread_mutex_lock(&session->nfs4_session_lock);
-
-    if (!state->nfs4_state_active) {
-        pthread_mutex_unlock(&session->nfs4_session_lock);
-        return -1;
-    }
-
-    state->nfs4_state_active = 0;
-
-    if (state->nfs4_state_refcnt == 0) {
-        if (state->nfs4_state_type != NFS4_STATE_TYPE_LOCK) {
-            *out_handle = state->nfs4_state_handle;
-        }
-        state->nfs4_state_handle                      = NULL;
-        session->free_slot[session->num_free_slots++] = slot;
-        pthread_mutex_unlock(&session->nfs4_session_lock);
-        return 0;
-    }
-
-    /* refcnt > 0: deferred cleanup by last release_state */
-    pthread_mutex_unlock(&session->nfs4_session_lock);
-    return 1;
-} /* nfs4_session_free_slot */
-
-static inline void
-nfs4_session_free_lock_states(
-    struct nfs4_session *session,
-    uint32_t             open_slot)
-{
-    struct chimera_vfs_open_handle *unused;
-    uint32_t                        i;
-
-    for (i = 0; i < NFS4_SESSION_MAX_STATE; i++) {
-        struct nfs4_state *s = &session->nfs4_session_state[i];
-
-        if (s->nfs4_state_type        == NFS4_STATE_TYPE_LOCK &&
-            s->nfs4_state_active      == 1 &&
-            s->nfs4_state_parent_slot == open_slot) {
-            s->nfs4_state_handle = NULL;
-            nfs4_session_free_slot(session, s, &unused);
-        }
-    }
-} /* nfs4_session_free_lock_states */
-
-static inline struct nfs4_state *
-nfs4_session_get_state(
-    struct nfs4_session   *session,
-    const struct stateid4 *stateid)
-{
-    uint32_t slot = *(uint32_t *) stateid->other;
-
-    return &session->nfs4_session_state[slot];
-} /* nfs4_session_get_state */
-
-static inline nfsstat4
-nfs4_session_acquire_state(
-    struct nfs4_session             *session,
-    const struct stateid4           *stateid,
-    struct nfs4_state              **out_state,
-    struct chimera_vfs_open_handle **out_handle)
-{
-    uint32_t           slot     = *(uint32_t *) stateid->other;
-    uint64_t           clientid = *(uint64_t *) (stateid->other + 4);
-    struct nfs4_state *state;
-
-    *out_state  = NULL;
-    *out_handle = NULL;
-
-    if (slot >= NFS4_SESSION_MAX_STATE) {
-        return NFS4ERR_BAD_STATEID;
-    }
-
-    if (clientid != session->nfs4_session_clientid) {
-        return NFS4ERR_BAD_STATEID;
-    }
-
-    state = &session->nfs4_session_state[slot];
-
-    pthread_mutex_lock(&session->nfs4_session_lock);
-
-    if (!state->nfs4_state_active || !state->nfs4_state_handle) {
-        pthread_mutex_unlock(&session->nfs4_session_lock);
-        return NFS4ERR_BAD_STATEID;
-    }
-
-    state->nfs4_state_refcnt++;
-    *out_state  = state;
-    *out_handle = state->nfs4_state_handle;
-
-    pthread_mutex_unlock(&session->nfs4_session_lock);
-    return NFS4_OK;
-} /* nfs4_session_acquire_state */
-
-static inline struct chimera_vfs_open_handle *
-nfs4_session_release_state(
-    struct nfs4_session *session,
-    struct nfs4_state   *state)
-{
-    struct chimera_vfs_open_handle *handle = NULL;
-
-    pthread_mutex_lock(&session->nfs4_session_lock);
-
-    state->nfs4_state_refcnt--;
-
-    if (state->nfs4_state_refcnt == 0 && !state->nfs4_state_active) {
-        /* CLOSE already ran; we are the last user - do deferred cleanup */
-        if (state->nfs4_state_type != NFS4_STATE_TYPE_LOCK) {
-            handle = state->nfs4_state_handle;
-        }
-        state->nfs4_state_handle = NULL;
-        uint32_t slot = *(uint32_t *) state->nfs4_state_id.other;
-        session->free_slot[session->num_free_slots++] = slot;
-    }
-
-    pthread_mutex_unlock(&session->nfs4_session_lock);
-    return handle;
-} /* nfs4_session_release_state */
-
-static inline nfsstat4
-nfs4_session_validate_stateid(
-    struct nfs4_session   *session,
-    const struct stateid4 *stateid)
-{
-    uint32_t           slot     = *(uint32_t *) stateid->other;
-    uint64_t           clientid = *(uint64_t *) (stateid->other + 4);
-    struct nfs4_state *state;
-    nfsstat4           status;
-
-    if (slot >= NFS4_SESSION_MAX_STATE) {
-        return NFS4ERR_BAD_STATEID;
-    }
-
-    if (clientid != session->nfs4_session_clientid) {
-        return NFS4ERR_BAD_STATEID;
-    }
-
-    state = &session->nfs4_session_state[slot];
-
-    pthread_mutex_lock(&session->nfs4_session_lock);
-
-    if (!state->nfs4_state_active) {
-        status = NFS4ERR_BAD_STATEID;
-    } else {
-        status = NFS4_OK;
-    }
-
-    pthread_mutex_unlock(&session->nfs4_session_lock);
-
-    return status;
-} /* nfs4_session_validate_stateid */
-
-/*
- * Resolve the session for the current request.
- *
- * If `session` is non-NULL it is already borrowed via the conn's bind
- * (compound entry transitively holds a ref through evpl_rpc2_conn private_data)
- * and is returned as-is.
- *
- * Otherwise look up the session by the clientid embedded in `stateid`.  If
- * found, bind it to `conn` (taking a ref on the conn's behalf) and drop the
- * lookup's ref; the returned pointer is then borrowed via that conn ref.
- *
- * Returns NULL if no session exists for this client.
- */
-static inline struct nfs4_session *
-nfs4_resolve_session(
-    struct nfs4_session      *session,
-    struct evpl_rpc2_conn    *conn,
-    struct nfs4_client_table *table,
-    const struct stateid4    *stateid)
-{
-    uint64_t             client_id;
-    struct nfs4_session *found;
-
-    if (session) {
-        return session;
-    }
-
-    client_id = *(uint64_t *) (stateid->other + 4);
-    found     = nfs4_session_find_by_clientid(table, client_id);
-
-    if (found) {
-        nfs4_session_bind_conn(conn, found);
-        nfs4_session_put(found);
-    }
-
-    return found;
-} /* nfs4_resolve_session */

--- a/src/server/nfs/nfs4_state.c
+++ b/src/server/nfs/nfs4_state.c
@@ -1,0 +1,860 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "nfs4_state.h"
+#include "nfs_internal.h"
+#include "vfs/vfs_release.h"
+
+#define NFS4_SHARD_INITIAL_CAPACITY 64
+
+static void
+shard_init(struct nfs_state_shard *shard)
+{
+    pthread_rwlock_init(&shard->lock, NULL);
+    shard->slots          = NULL;
+    shard->slots_capacity = 0;
+    shard->slots_used     = 0;
+    shard->free_idx       = NULL;
+    shard->free_count     = 0;
+    shard->free_capacity  = 0;
+} /* shard_init */
+
+static void
+shard_free(
+    struct nfs_state_shard    *shard,
+    struct chimera_vfs_thread *vfs_thread)
+{
+    /* Release any handles still held by live slots.  We do not free the
+     * owning open_state / lock_state structs themselves here — that is the
+     * caller's responsibility via the client / owner teardown path. */
+    if (shard->slots && vfs_thread) {
+        for (uint32_t i = 0; i < shard->slots_used; i++) {
+            struct nfs_state_slot *slot = &shard->slots[i];
+            if (slot->type == NFS4_SLOT_TYPE_OPEN) {
+                struct nfs_open_state *os = slot->state;
+                if (os && os->handle) {
+                    chimera_vfs_release(vfs_thread, os->handle);
+                    os->handle = NULL;
+                }
+            } else if (slot->type == NFS4_SLOT_TYPE_LOCK) {
+                struct nfs_lock_state *ls = slot->state;
+                if (ls && ls->handle) {
+                    chimera_vfs_release(vfs_thread, ls->handle);
+                    ls->handle = NULL;
+                }
+            }
+        }
+    }
+
+    free(shard->slots);
+    free(shard->free_idx);
+    pthread_rwlock_destroy(&shard->lock);
+} /* shard_free */
+
+static int
+shard_grow_locked(struct nfs_state_shard *shard)
+{
+    uint32_t               new_cap;
+    struct nfs_state_slot *new_slots;
+
+    new_cap = shard->slots_capacity ? shard->slots_capacity * 2
+              : NFS4_SHARD_INITIAL_CAPACITY;
+
+    /* slot_idx is 24-bit in the wire encoding. */
+    if (new_cap > (1u << 24)) {
+        return -1;
+    }
+
+    new_slots = realloc(shard->slots, new_cap * sizeof(*new_slots));
+    if (!new_slots) {
+        return -1;
+    }
+
+    memset(&new_slots[shard->slots_capacity], 0,
+           (new_cap - shard->slots_capacity) * sizeof(*new_slots));
+
+    shard->slots          = new_slots;
+    shard->slots_capacity = new_cap;
+    return 0;
+} /* shard_grow_locked */
+
+static int
+shard_push_free_locked(
+    struct nfs_state_shard *shard,
+    uint32_t                slot_idx)
+{
+    if (shard->free_count == shard->free_capacity) {
+        uint32_t  new_cap = shard->free_capacity ? shard->free_capacity * 2 : 16;
+        uint32_t *new_arr = realloc(shard->free_idx, new_cap * sizeof(*new_arr));
+        if (!new_arr) {
+            return -1;
+        }
+        shard->free_idx      = new_arr;
+        shard->free_capacity = new_cap;
+    }
+    shard->free_idx[shard->free_count++] = slot_idx;
+    return 0;
+} /* shard_push_free_locked */
+
+void
+nfs_state_table_init(struct nfs_state_table *table)
+{
+    for (int i = 0; i < NFS_STATE_NUM_SHARDS; i++) {
+        shard_init(&table->shards[i]);
+    }
+} /* nfs_state_table_init */
+
+void
+nfs_state_table_free(
+    struct nfs_state_table    *table,
+    struct chimera_vfs_thread *vfs_thread)
+{
+    for (int i = 0; i < NFS_STATE_NUM_SHARDS; i++) {
+        shard_free(&table->shards[i], vfs_thread);
+    }
+} /* nfs_state_table_free */
+
+/* Choose a shard index for new allocations.  Simple round-robin via an
+ * atomic counter; the shard is private once chosen. */
+static _Atomic uint32_t g_alloc_rr = 0;
+
+int
+nfs_state_table_alloc(
+    struct nfs_state_table *table,
+    uint8_t                 type,
+    uint8_t                *out_shard,
+    uint32_t               *out_slot_idx,
+    uint32_t               *out_generation)
+{
+    uint32_t                rr;
+    uint8_t                 shard_idx;
+    struct nfs_state_shard *shard;
+    uint32_t                slot_idx;
+    struct nfs_state_slot  *slot;
+
+    rr        = atomic_fetch_add_explicit(&g_alloc_rr, 1, memory_order_relaxed);
+    shard_idx = (uint8_t) (rr % NFS_STATE_NUM_SHARDS);
+    shard     = &table->shards[shard_idx];
+
+    pthread_rwlock_wrlock(&shard->lock);
+
+    if (shard->free_count) {
+        slot_idx = shard->free_idx[--shard->free_count];
+    } else {
+        if (shard->slots_used == shard->slots_capacity) {
+            if (shard_grow_locked(shard) != 0) {
+                pthread_rwlock_unlock(&shard->lock);
+                return -1;
+            }
+        }
+        slot_idx = shard->slots_used++;
+    }
+
+    slot              = &shard->slots[slot_idx];
+    slot->generation += 1;          /* every (re)use advances generation */
+    slot->type        = type;
+    slot->state       = NULL;       /* installed separately */
+
+    *out_shard      = shard_idx;
+    *out_slot_idx   = slot_idx;
+    *out_generation = slot->generation;
+
+    pthread_rwlock_unlock(&shard->lock);
+    return 0;
+} /* nfs_state_table_alloc */
+
+void
+nfs_state_table_install(
+    struct nfs_state_table *table,
+    uint8_t                 shard_idx,
+    uint32_t                slot_idx,
+    uint8_t                 type,
+    void                   *state)
+{
+    struct nfs_state_shard *shard = &table->shards[shard_idx];
+    struct nfs_state_slot  *slot;
+
+    pthread_rwlock_wrlock(&shard->lock);
+
+    chimera_nfs_abort_if(slot_idx >= shard->slots_used,
+                         "install on unallocated slot %u/%u",
+                         slot_idx, shard->slots_used);
+
+    slot        = &shard->slots[slot_idx];
+    slot->type  = type;
+    slot->state = state;
+
+    pthread_rwlock_unlock(&shard->lock);
+} /* nfs_state_table_install */
+
+void
+nfs_state_table_free_slot(
+    struct nfs_state_table *table,
+    uint8_t                 shard_idx,
+    uint32_t                slot_idx)
+{
+    struct nfs_state_shard *shard = &table->shards[shard_idx];
+    struct nfs_state_slot  *slot;
+
+    pthread_rwlock_wrlock(&shard->lock);
+
+    chimera_nfs_abort_if(slot_idx >= shard->slots_used,
+                         "free of unallocated slot %u/%u",
+                         slot_idx, shard->slots_used);
+
+    slot              = &shard->slots[slot_idx];
+    slot->type        = NFS4_SLOT_TYPE_FREE;
+    slot->state       = NULL;
+    slot->generation += 1;          /* invalidate any extant stateid */
+
+    (void) shard_push_free_locked(shard, slot_idx);
+
+    pthread_rwlock_unlock(&shard->lock);
+} /* nfs_state_table_free_slot */
+
+/*
+ * Internal lookup: under shard rdlock, validate slot identity and (when
+ * `bump_refcount` is true) increment the state's refcount before unlocking.
+ * Doing the refcount bump under the shard rdlock prevents the destroy path
+ * (which takes the shard wrlock first) from racing the cleanup.
+ */
+static nfsstat4
+state_table_lookup_locked(
+    struct nfs_state_table *table,
+    const struct stateid4  *sid,
+    uint8_t                 want_type,
+    bool                    bump_refcount,
+    void                  **out_state,
+    uint8_t                *out_type)
+{
+    struct nfs4_stateid_view view;
+    struct nfs_state_shard  *shard;
+    struct nfs_state_slot   *slot;
+    nfsstat4                 status = NFS4ERR_BAD_STATEID;
+
+    *out_state = NULL;
+    if (out_type) {
+        *out_type = NFS4_SLOT_TYPE_FREE;
+    }
+
+    nfs4_stateid_decode(&view, sid);
+
+    if (view.version != NFS4_STATEID_VERSION) {
+        return NFS4ERR_BAD_STATEID;
+    }
+    if (view.shard >= NFS_STATE_NUM_SHARDS) {
+        return NFS4ERR_BAD_STATEID;
+    }
+
+    shard = &table->shards[view.shard];
+
+    pthread_rwlock_rdlock(&shard->lock);
+
+    if (view.slot_idx >= shard->slots_used) {
+        pthread_rwlock_unlock(&shard->lock);
+        return NFS4ERR_BAD_STATEID;
+    }
+
+    slot = &shard->slots[view.slot_idx];
+
+    if (slot->type == NFS4_SLOT_TYPE_FREE) {
+        status = NFS4ERR_BAD_STATEID;
+    } else if (slot->generation != view.generation) {
+        status = NFS4ERR_STALE_STATEID;
+    } else if (want_type != 0 && slot->type != want_type) {
+        status = NFS4ERR_BAD_STATEID;
+    } else {
+        *out_state = slot->state;
+        if (out_type) {
+            *out_type = slot->type;
+        }
+        if (bump_refcount) {
+            if (slot->type == NFS4_SLOT_TYPE_OPEN) {
+                atomic_fetch_add_explicit(
+                    &((struct nfs_open_state *) slot->state)->refcount, 1,
+                    memory_order_acq_rel);
+            } else if (slot->type == NFS4_SLOT_TYPE_LOCK) {
+                atomic_fetch_add_explicit(
+                    &((struct nfs_lock_state *) slot->state)->refcount, 1,
+                    memory_order_acq_rel);
+            }
+        }
+        status = NFS4_OK;
+    }
+
+    pthread_rwlock_unlock(&shard->lock);
+    return status;
+} /* state_table_lookup_locked */
+
+nfsstat4
+nfs_state_table_acquire(
+    struct nfs_state_table *table,
+    const struct stateid4  *sid,
+    uint8_t                 want_type,
+    void                  **out_state,
+    uint8_t                *out_type)
+{
+    nfsstat4 status = state_table_lookup_locked(table, sid, want_type, true,
+                                                out_state, out_type);
+
+    if (status == NFS4_OK) {
+        /* Phase 3: any successful state acquire renews the owning client's
+         * lease.  Both state types reach their client through their owner. */
+        if (*out_type == NFS4_SLOT_TYPE_OPEN) {
+            struct nfs_open_state *os = *out_state;
+            if (os->owner) {
+                nfs_client_touch(os->owner->client);
+            }
+        } else if (*out_type == NFS4_SLOT_TYPE_LOCK) {
+            struct nfs_lock_state *ls = *out_state;
+            if (ls->lock_owner) {
+                nfs_client_touch(ls->lock_owner->client);
+            }
+        }
+    }
+
+    return status;
+} /* nfs_state_table_acquire */
+
+/* Forward decls for cleanup paths used by release. */
+static void
+open_state_cleanup(
+    struct nfs_open_state     *state,
+    struct nfs_state_table    *table,
+    struct chimera_vfs_thread *vfs_thread);
+static void
+lock_state_cleanup(
+    struct nfs_lock_state     *state,
+    struct nfs_state_table    *table,
+    struct chimera_vfs_thread *vfs_thread);
+
+void
+nfs_state_table_release(
+    struct nfs_state_table    *table,
+    void                      *state,
+    uint8_t                    type,
+    struct chimera_vfs_thread *vfs_thread)
+{
+    uint32_t prev;
+
+    if (type == NFS4_SLOT_TYPE_OPEN) {
+        struct nfs_open_state *s = state;
+        prev = atomic_fetch_sub_explicit(&s->refcount, 1,
+                                         memory_order_acq_rel);
+        chimera_nfs_abort_if(prev == 0,
+                             "open_state refcount underflow on %p", s);
+        if (prev == 1 && atomic_load_explicit(&s->destroyed,
+                                              memory_order_acquire)) {
+            open_state_cleanup(s, table, vfs_thread);
+        }
+    } else if (type == NFS4_SLOT_TYPE_LOCK) {
+        struct nfs_lock_state *s = state;
+        prev = atomic_fetch_sub_explicit(&s->refcount, 1,
+                                         memory_order_acq_rel);
+        chimera_nfs_abort_if(prev == 0,
+                             "lock_state refcount underflow on %p", s);
+        if (prev == 1 && atomic_load_explicit(&s->destroyed,
+                                              memory_order_acquire)) {
+            lock_state_cleanup(s, table, vfs_thread);
+        }
+    }
+} /* nfs_state_table_release */
+
+nfsstat4
+nfs_state_table_validate(
+    struct nfs_state_table *table,
+    const struct stateid4  *sid)
+{
+    void   *unused_state;
+    uint8_t unused_type;
+
+    return state_table_lookup_locked(table, sid, 0, false,
+                                     &unused_state, &unused_type);
+} /* nfs_state_table_validate */
+
+/* ---------------------------------------------------------------------- *
+*  Lifecycle: client / open_owner / open_state / lock_owner / lock_state
+* ---------------------------------------------------------------------- */
+
+struct nfs_client *
+nfs_client_alloc(
+    uint64_t    client_id,
+    const void *owner_string,
+    uint16_t    owner_len,
+    uint64_t    verifier,
+    uint8_t     minor)
+{
+    struct nfs_client *c = calloc(1, sizeof(*c));
+
+    chimera_nfs_abort_if(c == NULL, "nfs_client_alloc OOM");
+
+    c->client_id = client_id;
+    c->verifier  = verifier;
+    c->minor     = minor;
+    if (owner_len > NFS4_OPAQUE_LIMIT) {
+        owner_len = NFS4_OPAQUE_LIMIT;
+    }
+    memcpy(c->owner_string, owner_string, owner_len);
+    c->owner_len = owner_len;
+    atomic_init(&c->refcount, 1);
+    pthread_mutex_init(&c->lock, NULL);
+    return c;
+} /* nfs_client_alloc */
+
+/* Destroy a single open_state (unhash + unlink locks + free slot + release
+ * lifetime ref).  Caller holds owner->lock or is in single-threaded teardown.
+ *
+ * Idempotent: gated by an atomic CAS on `destroyed`.  A losing CAS returns
+ * without touching state, so concurrent destroyers (e.g. two CLOSEs on the
+ * same stateid, or DESTROY_CLIENTID racing CLOSE) are safe. */
+static void
+open_state_destroy_locked(
+    struct nfs_open_owner     *owner,
+    struct nfs_open_state     *state,
+    struct nfs_state_table    *table,
+    struct chimera_vfs_thread *vfs_thread)
+{
+    uint8_t prev_destroyed;
+
+    prev_destroyed = atomic_exchange_explicit(&state->destroyed, 1,
+                                              memory_order_acq_rel);
+    if (prev_destroyed != 0) {
+        return;
+    }
+
+    /* Unhash from the owner so no new acquire can find it through the
+     * owner walk. */
+    HASH_DEL(owner->states_by_fh, state);
+
+    /* Tear down every lock_state still rooted on this open_state.  Each
+     * lock holds a distinct dup'd handle; its own cleanup will release it. */
+    while (state->locks) {
+        struct nfs_lock_state *ls = state->locks;
+        uint8_t                ls_prev_destroyed;
+
+        LL_DELETE2(state->locks, ls, next_in_open);
+        if (ls->lock_owner) {
+            LL_DELETE2(ls->lock_owner->states, ls, next_in_owner);
+        }
+        ls_prev_destroyed = atomic_exchange_explicit(&ls->destroyed, 1,
+                                                     memory_order_acq_rel);
+        if (ls_prev_destroyed == 0) {
+            nfs_state_table_free_slot(table, ls->shard, ls->slot_idx);
+            uint32_t lprev = atomic_fetch_sub_explicit(&ls->refcount, 1,
+                                                       memory_order_acq_rel);
+            if (lprev == 1) {
+                lock_state_cleanup(ls, table, vfs_thread);
+            }
+        }
+    }
+
+    nfs_state_table_free_slot(table, state->shard, state->slot_idx);
+
+    uint32_t prev = atomic_fetch_sub_explicit(&state->refcount, 1,
+                                              memory_order_acq_rel);
+    if (prev == 1) {
+        open_state_cleanup(state, table, vfs_thread);
+    }
+} /* open_state_destroy_locked */
+
+void
+nfs_client_destroy(
+    struct nfs_client         *client,
+    struct nfs_state_table    *table,
+    struct chimera_vfs_thread *vfs_thread)
+{
+    if (!client) {
+        return;
+    }
+
+    pthread_mutex_lock(&client->lock);
+
+    /* HASH_ITER + HASH_DELETE + free is the standard uthash teardown
+     * pattern, but scan-build can't reason through the macro expansion
+     * and flags a (false-positive) UAF on the bucket pointer.  Match
+     * the rest of the codebase by hiding the walks from the analyzer. */
+#ifndef __clang_analyzer__
+    struct nfs_open_owner *oo, *oo_tmp;
+    struct nfs_lock_owner *lo, *lo_tmp;
+
+    HASH_ITER(hh, client->open_owners_by_str, oo, oo_tmp)
+    {
+        pthread_mutex_lock(&oo->lock);
+        struct nfs_open_state *os, *os_tmp;
+        HASH_ITER(hh, oo->states_by_fh, os, os_tmp)
+        {
+            open_state_destroy_locked(oo, os, table, vfs_thread);
+        }
+        pthread_mutex_unlock(&oo->lock);
+
+        HASH_DELETE(hh, client->open_owners_by_str, oo);
+        pthread_mutex_destroy(&oo->lock);
+        free(oo);
+    }
+
+    HASH_ITER(hh, client->lock_owners_by_str, lo, lo_tmp)
+    {
+        /* All states should have been torn down via the open_states above,
+         * since each lock_state is on both lists. */
+        chimera_nfs_abort_if(lo->states != NULL,
+                             "lock_owner %p has leftover lock_states", lo);
+        HASH_DELETE(hh, client->lock_owners_by_str, lo);
+        pthread_mutex_destroy(&lo->lock);
+        free(lo);
+    }
+#endif /* ifndef __clang_analyzer__ */
+
+    pthread_mutex_unlock(&client->lock);
+    pthread_mutex_destroy(&client->lock);
+    free(client);
+} /* nfs_client_destroy */
+
+struct nfs_open_owner *
+nfs_open_owner_find_or_create(
+    struct nfs_client *client,
+    const void        *owner_bytes,
+    uint16_t           owner_len,
+    bool              *out_created)
+{
+    struct nfs_open_owner *owner;
+
+    if (owner_len > NFS4_OPAQUE_LIMIT) {
+        owner_len = NFS4_OPAQUE_LIMIT;
+    }
+
+    pthread_mutex_lock(&client->lock);
+
+    HASH_FIND(hh, client->open_owners_by_str, owner_bytes, owner_len, owner);
+
+    if (owner) {
+        if (out_created) {
+            *out_created = false;
+        }
+        pthread_mutex_unlock(&client->lock);
+        return owner;
+    }
+
+    owner = calloc(1, sizeof(*owner));
+    chimera_nfs_abort_if(owner == NULL, "open_owner alloc OOM");
+    owner->client = client;
+    memcpy(owner->owner, owner_bytes, owner_len);
+    owner->owner_len = owner_len;
+    owner->seqid     = 0;
+    owner->confirmed = false;
+    pthread_mutex_init(&owner->lock, NULL);
+
+    HASH_ADD_KEYPTR(hh, client->open_owners_by_str,
+                    owner->owner, owner->owner_len, owner);
+
+    if (out_created) {
+        *out_created = true;
+    }
+    pthread_mutex_unlock(&client->lock);
+    return owner;
+} /* nfs_open_owner_find_or_create */
+
+struct nfs_open_state *
+nfs_open_owner_find_state(
+    struct nfs_open_owner *owner,
+    const uint8_t         *fh,
+    uint16_t               fh_len)
+{
+    struct nfs_open_state *state = NULL;
+
+    if (fh_len > NFS4_FHSIZE) {
+        return NULL;
+    }
+
+    pthread_mutex_lock(&owner->lock);
+    HASH_FIND(hh, owner->states_by_fh, fh, fh_len, state);
+    pthread_mutex_unlock(&owner->lock);
+    return state;
+} /* nfs_open_owner_find_state */
+
+struct nfs_open_state *
+nfs_open_state_create(
+    struct nfs_open_owner          *owner,
+    const uint8_t                  *fh,
+    uint16_t                        fh_len,
+    uint32_t                        share_access,
+    uint32_t                        share_deny,
+    struct chimera_vfs_open_handle *handle_dup,
+    uint32_t                        client_short_id,
+    struct nfs_state_table         *table,
+    struct stateid4                *out_stateid)
+{
+    struct nfs_open_state *state;
+    uint8_t                shard;
+    uint32_t               slot_idx, gen;
+    int                    rc;
+
+    chimera_nfs_abort_if(fh_len > NFS4_FHSIZE,
+                         "open_state_create fh_len %u", fh_len);
+
+    state = calloc(1, sizeof(*state));
+    chimera_nfs_abort_if(state == NULL, "open_state alloc OOM");
+
+    rc = nfs_state_table_alloc(table, NFS4_SLOT_TYPE_OPEN, &shard, &slot_idx, &gen);
+    chimera_nfs_abort_if(rc != 0, "state table exhausted");
+
+    state->owner = owner;
+    memcpy(state->fh, fh, fh_len);
+    state->fh_len       = fh_len;
+    state->share_access = share_access;
+    state->share_deny   = share_deny;
+    state->seqid        = 1;
+    state->shard        = shard;
+    state->slot_idx     = slot_idx;
+    state->generation   = gen;
+    state->handle       = handle_dup;
+    state->locks        = NULL;
+    atomic_init(&state->refcount, 1);
+    atomic_init(&state->destroyed, 0);
+
+    nfs_state_table_install(table, shard, slot_idx, NFS4_SLOT_TYPE_OPEN, state);
+
+    pthread_mutex_lock(&owner->lock);
+    HASH_ADD_KEYPTR(hh, owner->states_by_fh, state->fh, state->fh_len, state);
+    pthread_mutex_unlock(&owner->lock);
+
+    nfs4_stateid_encode(out_stateid, state->seqid,
+                        NFS4_STATEID_TYPE_OPEN, shard, slot_idx, gen,
+                        client_short_id);
+    return state;
+} /* nfs_open_state_create */
+
+nfsstat4
+nfs_client_check_share_conflict(
+    struct nfs_client     *client,
+    struct nfs_open_owner *requesting_owner,
+    const uint8_t         *fh,
+    uint16_t               fh_len,
+    uint32_t               requested_access,
+    uint32_t               requested_deny)
+{
+    struct nfs_open_owner *oo, *oo_tmp;
+    nfsstat4               status = NFS4_OK;
+
+    if (fh_len > NFS4_FHSIZE) {
+        return NFS4ERR_BAD_STATEID;
+    }
+
+    pthread_mutex_lock(&client->lock);
+
+    HASH_ITER(hh, client->open_owners_by_str, oo, oo_tmp)
+    {
+        struct nfs_open_state *peer = NULL;
+
+        if (oo == requesting_owner) {
+            /* Same-owner OPEN merges via coalesce; no conflict possible. */
+            continue;
+        }
+
+        pthread_mutex_lock(&oo->lock);
+        HASH_FIND(hh, oo->states_by_fh, fh, fh_len, peer);
+        if (peer) {
+            /* RFC 7530 §9.10: SHARE_DENIED if my deny clashes with their
+             * access OR their deny clashes with my access. */
+            if ((peer->share_access & requested_deny) ||
+                (requested_access & peer->share_deny)) {
+                status = NFS4ERR_SHARE_DENIED;
+            }
+        }
+        pthread_mutex_unlock(&oo->lock);
+
+        if (status != NFS4_OK) {
+            break;
+        }
+    }
+
+    pthread_mutex_unlock(&client->lock);
+    return status;
+} /* nfs_client_check_share_conflict */
+
+void
+nfs_open_state_coalesce(
+    struct nfs_open_state *state,
+    uint32_t               share_access,
+    uint32_t               share_deny,
+    uint32_t               client_short_id,
+    struct stateid4       *out_stateid)
+{
+    state->share_access |= share_access;
+    state->share_deny   |= share_deny;
+    state->seqid        += 1;
+
+    nfs4_stateid_encode(out_stateid, state->seqid,
+                        NFS4_STATEID_TYPE_OPEN,
+                        state->shard, state->slot_idx, state->generation,
+                        client_short_id);
+} /* nfs_open_state_coalesce */
+
+static void
+open_state_cleanup(
+    struct nfs_open_state     *state,
+    struct nfs_state_table    *table,
+    struct chimera_vfs_thread *vfs_thread)
+{
+    (void) table;
+    if (state->handle && vfs_thread) {
+        chimera_vfs_release(vfs_thread, state->handle);
+        state->handle = NULL;
+    }
+    free(state);
+} /* open_state_cleanup */
+
+void
+nfs_open_state_destroy(
+    struct nfs_open_state     *state,
+    struct nfs_state_table    *table,
+    struct chimera_vfs_thread *vfs_thread)
+{
+    struct nfs_open_owner *owner = state->owner;
+
+    pthread_mutex_lock(&owner->lock);
+    open_state_destroy_locked(owner, state, table, vfs_thread);
+    pthread_mutex_unlock(&owner->lock);
+} /* nfs_open_state_destroy */
+
+struct nfs_lock_owner *
+nfs_lock_owner_find_or_create(
+    struct nfs_client *client,
+    const void        *owner_bytes,
+    uint16_t           owner_len,
+    bool              *out_created)
+{
+    struct nfs_lock_owner *owner;
+
+    if (owner_len > NFS4_OPAQUE_LIMIT) {
+        owner_len = NFS4_OPAQUE_LIMIT;
+    }
+
+    pthread_mutex_lock(&client->lock);
+
+    HASH_FIND(hh, client->lock_owners_by_str, owner_bytes, owner_len, owner);
+
+    if (owner) {
+        if (out_created) {
+            *out_created = false;
+        }
+        pthread_mutex_unlock(&client->lock);
+        return owner;
+    }
+
+    owner = calloc(1, sizeof(*owner));
+    chimera_nfs_abort_if(owner == NULL, "lock_owner alloc OOM");
+    owner->client = client;
+    memcpy(owner->owner, owner_bytes, owner_len);
+    owner->owner_len = owner_len;
+    owner->seqid     = 0;
+    pthread_mutex_init(&owner->lock, NULL);
+
+    HASH_ADD_KEYPTR(hh, client->lock_owners_by_str,
+                    owner->owner, owner->owner_len, owner);
+
+    if (out_created) {
+        *out_created = true;
+    }
+    pthread_mutex_unlock(&client->lock);
+    return owner;
+} /* nfs_lock_owner_find_or_create */
+
+struct nfs_lock_state *
+nfs_lock_state_create(
+    struct nfs_lock_owner          *lock_owner,
+    struct nfs_open_state          *open_state,
+    struct chimera_vfs_open_handle *handle_dup,
+    uint32_t                        client_short_id,
+    struct nfs_state_table         *table,
+    struct stateid4                *out_stateid)
+{
+    struct nfs_lock_state *state;
+    uint8_t                shard;
+    uint32_t               slot_idx, gen;
+    int                    rc;
+
+    state = calloc(1, sizeof(*state));
+    chimera_nfs_abort_if(state == NULL, "lock_state alloc OOM");
+
+    rc = nfs_state_table_alloc(table, NFS4_SLOT_TYPE_LOCK, &shard, &slot_idx, &gen);
+    chimera_nfs_abort_if(rc != 0, "state table exhausted");
+
+    state->lock_owner = lock_owner;
+    state->open_state = open_state;
+    state->seqid      = 1;
+    state->shard      = shard;
+    state->slot_idx   = slot_idx;
+    state->generation = gen;
+    state->handle     = handle_dup;
+    atomic_init(&state->refcount, 1);
+    atomic_init(&state->destroyed, 0);
+
+    nfs_state_table_install(table, shard, slot_idx, NFS4_SLOT_TYPE_LOCK, state);
+
+    /* Link onto both the lock_owner's list and the open_state's list. */
+    pthread_mutex_lock(&lock_owner->lock);
+    LL_PREPEND2(lock_owner->states, state, next_in_owner);
+    pthread_mutex_unlock(&lock_owner->lock);
+
+    pthread_mutex_lock(&open_state->owner->lock);
+    LL_PREPEND2(open_state->locks, state, next_in_open);
+    pthread_mutex_unlock(&open_state->owner->lock);
+
+    nfs4_stateid_encode(out_stateid, state->seqid,
+                        NFS4_STATEID_TYPE_LOCK, shard, slot_idx, gen,
+                        client_short_id);
+    return state;
+} /* nfs_lock_state_create */
+
+static void
+lock_state_cleanup(
+    struct nfs_lock_state     *state,
+    struct nfs_state_table    *table,
+    struct chimera_vfs_thread *vfs_thread)
+{
+    (void) table;
+    if (state->handle && vfs_thread) {
+        chimera_vfs_release(vfs_thread, state->handle);
+        state->handle = NULL;
+    }
+    free(state);
+} /* lock_state_cleanup */
+
+void
+nfs_lock_state_destroy(
+    struct nfs_lock_state     *state,
+    struct nfs_state_table    *table,
+    struct chimera_vfs_thread *vfs_thread)
+{
+    struct nfs_lock_owner *lock_owner = state->lock_owner;
+    struct nfs_open_state *open_state = state->open_state;
+    uint8_t                prev_destroyed;
+
+    prev_destroyed = atomic_exchange_explicit(&state->destroyed, 1,
+                                              memory_order_acq_rel);
+    if (prev_destroyed != 0) {
+        return;
+    }
+
+    pthread_mutex_lock(&lock_owner->lock);
+    LL_DELETE2(lock_owner->states, state, next_in_owner);
+    pthread_mutex_unlock(&lock_owner->lock);
+
+    if (open_state) {
+        pthread_mutex_lock(&open_state->owner->lock);
+        LL_DELETE2(open_state->locks, state, next_in_open);
+        pthread_mutex_unlock(&open_state->owner->lock);
+    }
+
+    nfs_state_table_free_slot(table, state->shard, state->slot_idx);
+
+    uint32_t prev = atomic_fetch_sub_explicit(&state->refcount, 1,
+                                              memory_order_acq_rel);
+    if (prev == 1) {
+        lock_state_cleanup(state, table, vfs_thread);
+    }
+} /* nfs_lock_state_destroy */

--- a/src/server/nfs/nfs4_state.h
+++ b/src/server/nfs/nfs4_state.h
@@ -1,0 +1,463 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#pragma once
+
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <uthash.h>
+#include <utlist.h>
+
+#include "nfs4_xdr.h"
+#include "nfs4_stateid.h"
+#include "nfs4_lease.h"
+#include "vfs/vfs.h"
+#include "common/macros.h"
+
+/*
+ * Unified NFSv4 state model.
+ *
+ * Shape is independent of minor version.  4.0 uses the seqid/replay fields
+ * on the owners; 4.1+ leaves them at zero (its DRC lives on nfs4_session).
+ * stateid.other is decoded through nfs_state_table (see nfs4_stateid.h),
+ * not through any session.
+ *
+ * Hierarchy:
+ *   nfs_client
+ *     ├── nfs_open_owner            (per {client, owner_string})
+ *     │     └── nfs_open_state      (per {open_owner, fh})
+ *     │                  ↑
+ *     │   nfs_lock_state ┘          (anchored to its open_state)
+ *     │           ↑
+ *     └── nfs_lock_owner            (per {client, lock_owner_string};
+ *                                    holds locks that may span multiple
+ *                                    open_owners — RFC 7530 §9.1.4)
+ *
+ * State objects allocate a slot in the global nfs_state_table; the slot
+ * index and generation are embedded in stateid.other.  Slot reuse advances
+ * the generation, so stale stateids return NFS4ERR_STALE_STATEID.
+ */
+
+struct nfs_client;
+struct nfs_open_owner;
+struct nfs_open_state;
+struct nfs_lock_owner;
+struct nfs_lock_state;
+struct nfs_state_table;
+struct chimera_vfs_thread;
+
+/*
+ * Per-owner replay cache.  RFC 7530 §9.1.7: when an owner-sequenced op is
+ * retransmitted with the same seqid, the server must return the original
+ * reply.  Phase 4 caches the structured fields most clients depend on
+ * (status + stateid).  A fully byte-perfect replay (cinfo, attrset, ...)
+ * is deferred; in practice Linux clients re-fetch those via GETATTR.
+ */
+struct nfs4_replay_cache {
+    uint32_t        seqid;     /* seqid this entry replies to */
+    uint32_t        op;        /* nfs_opnum4 of the cached op  */
+    nfsstat4        status;
+    struct stateid4 stateid;   /* for OPEN/CLOSE/LOCK/LOCKU/etc. responses */
+    uint8_t         valid;
+};
+
+/*
+ * RFC 7530 §9.1.7 seqid classification result.
+ *   NFS4_SEQID_NEW       : seqid == owner.seqid + 1 (or owner.seqid == 0
+ *                          and seqid == 1); caller should execute and
+ *                          record the reply on completion.
+ *   NFS4_SEQID_REPLAY    : seqid == owner.seqid; caller should return the
+ *                          cached reply directly.
+ *   NFS4_SEQID_BAD       : anything else; return NFS4ERR_BAD_SEQID.
+ */
+#define NFS4_SEQID_NEW    0
+#define NFS4_SEQID_REPLAY 1
+#define NFS4_SEQID_BAD    2
+
+static inline int
+nfs4_owner_seqid_classify(
+    uint32_t                        owner_seqid,
+    const struct nfs4_replay_cache *replay,
+    uint32_t                        incoming)
+{
+    /* RFC 7530 §9.1.7: the first state-modifying op against a freshly
+     * created open_owner/lock_owner uses whatever seqid the client picks --
+     * the Linux client picks 0.  Detect "fresh" by an empty replay cache:
+     * the completion wrapper seeds owner.seqid and replay together on the
+     * first advancing outcome, so a populated replay implies the owner has
+     * already been observed by the server. */
+    if (replay && !replay->valid) {
+        return NFS4_SEQID_NEW;
+    }
+    if (incoming == owner_seqid + 1) {
+        return NFS4_SEQID_NEW;
+    }
+    if (replay && replay->valid && replay->seqid == incoming) {
+        return NFS4_SEQID_REPLAY;
+    }
+    return NFS4_SEQID_BAD;
+} /* nfs4_owner_seqid_classify */
+
+static inline void
+nfs4_replay_record(
+    struct nfs4_replay_cache *replay,
+    uint32_t                  seqid,
+    uint32_t                  op,
+    nfsstat4                  status,
+    const struct stateid4    *stateid)
+{
+    replay->seqid  = seqid;
+    replay->op     = op;
+    replay->status = status;
+    if (stateid) {
+        replay->stateid = *stateid;
+    } else {
+        memset(&replay->stateid, 0, sizeof(replay->stateid));
+    }
+    replay->valid = 1;
+} /* nfs4_replay_record */
+
+/*
+ * RFC 7530 §9.1.7: the owner-seqid is advanced and the replay cache is
+ * updated for almost every outcome of an owner-sequenced op.  The only
+ * exceptions are these "infrastructure" errors -- the request hasn't
+ * really been "consumed" by the owner state machine, so the seqid is
+ * left untouched and the client retries with the same seqid.
+ */
+static inline bool
+nfs4_seqid_should_advance(nfsstat4 status)
+{
+    switch (status) {
+        case NFS4ERR_STALE_CLIENTID:
+        case NFS4ERR_STALE_STATEID:
+        case NFS4ERR_BAD_STATEID:
+        case NFS4ERR_BAD_SEQID:
+        case NFS4ERR_BADXDR:
+        case NFS4ERR_RESOURCE:
+        case NFS4ERR_NOFILEHANDLE:
+        case NFS4ERR_MOVED:
+            return false;
+        default:
+            return true;
+    } // switch
+} /* nfs4_seqid_should_advance */
+
+struct nfs_client {
+    uint64_t               client_id;
+    uint64_t               verifier;
+    uint64_t               boot_id;
+    uint8_t                owner_string[NFS4_OPAQUE_LIMIT];
+    uint16_t               owner_len;
+    uint8_t                confirmed     : 1;
+    uint8_t                expired       : 1;
+    uint8_t                recovering    : 1;
+    uint8_t                soft_revoked  : 1;
+    uint8_t                minor;  /* 0/1/2 */
+    uint64_t               last_touch_ns;
+
+    /* Owners are hashed by their byte string. */
+    struct nfs_open_owner *open_owners_by_str;
+    struct nfs_lock_owner *lock_owners_by_str;
+
+    UT_hash_handle         hh_by_owner;
+    UT_hash_handle         hh_by_id;
+
+    _Atomic uint32_t       refcount;
+    pthread_mutex_t        lock;
+};
+
+struct nfs_open_owner {
+    struct nfs_client       *client;       /* borrowed; client outlives owners */
+    uint8_t                  owner[NFS4_OPAQUE_LIMIT];
+    uint16_t                 owner_len;
+    uint32_t                 seqid;        /* 4.0 RFC 7530 §9.1.7; 4.1+ unused */
+    bool                     confirmed;    /* 4.0 OPEN_CONFIRM gate */
+    struct nfs4_replay_cache replay;       /* 4.0 only */
+    struct nfs_open_state   *states_by_fh; /* uthash keyed on {fh, fh_len} */
+    UT_hash_handle           hh;
+    pthread_mutex_t          lock;
+};
+
+struct nfs_open_state {
+    struct nfs_open_owner          *owner;
+    uint8_t                         fh[NFS4_FHSIZE];
+    uint16_t                        fh_len;
+    uint32_t                        share_access;       /* OPEN4_SHARE_ACCESS_* */
+    uint32_t                        share_deny;         /* OPEN4_SHARE_DENY_*   */
+    uint32_t                        seqid;              /* stateid.seqid */
+
+    /* Slot identity (decoded from stateid.other). */
+    uint8_t                         shard;
+    uint32_t                        slot_idx;
+    uint32_t                        generation;
+
+    struct chimera_vfs_open_handle *handle;             /* +1 via chimera_vfs_dup_handle */
+
+    struct nfs_lock_state          *locks;              /* utlist via next_in_open */
+    UT_hash_handle                  hh;                 /* by fh in owner->states_by_fh */
+
+    /* Lifetime: starts at 1 for the state's slot; each acquire bumps it.
+     * destroy() flips `destroyed` and drops the +1.  When refcount reaches
+     * zero AND destroyed is set, the handle is released and the struct
+     * freed by the last release. */
+    _Atomic uint32_t                refcount;
+    _Atomic uint8_t                 destroyed;
+};
+
+struct nfs_lock_owner {
+    struct nfs_client       *client;       /* borrowed */
+    uint8_t                  owner[NFS4_OPAQUE_LIMIT];
+    uint16_t                 owner_len;
+    uint32_t                 seqid;        /* 4.0 */
+    struct nfs4_replay_cache replay;       /* 4.0 only */
+    struct nfs_lock_state   *states;       /* utlist via next_in_owner */
+    UT_hash_handle           hh;
+    pthread_mutex_t          lock;
+};
+
+struct nfs_lock_state {
+    struct nfs_lock_owner          *lock_owner;
+    struct nfs_open_state          *open_state;
+    uint32_t                        seqid;
+
+    uint8_t                         shard;
+    uint32_t                        slot_idx;
+    uint32_t                        generation;
+
+    struct chimera_vfs_open_handle *handle;             /* +1 distinct dup */
+
+    /* utlist LL chains.  *_in_open is rooted on open_state->locks (CLOSE
+     * cascade); *_in_owner is rooted on lock_owner->states (RELEASE_LOCKOWNER
+     * cascade, wired up in Phase 4). */
+    struct nfs_lock_state          *next_in_open;
+    struct nfs_lock_state          *next_in_owner;
+
+    _Atomic uint32_t                refcount;
+    _Atomic uint8_t                 destroyed;
+};
+
+/*
+ * Slot table.
+ *
+ * Each shard owns a dense slot array indexed by 24-bit slot_idx.  The slot
+ * carries the state pointer, a type discriminator, and a generation counter
+ * incremented on every (re)use to detect stale stateids (ABA).
+ */
+
+#define NFS4_SLOT_TYPE_FREE 0
+#define NFS4_SLOT_TYPE_OPEN 1
+#define NFS4_SLOT_TYPE_LOCK 2
+
+struct nfs_state_slot {
+    void    *state;
+    uint32_t generation;
+    uint8_t  type;
+};
+
+struct nfs_state_shard {
+    pthread_rwlock_t       lock;
+    struct nfs_state_slot *slots;
+    uint32_t               slots_capacity;
+    uint32_t               slots_used;       /* high-water of allocated entries */
+    uint32_t              *free_idx;
+    uint32_t               free_count;
+    uint32_t               free_capacity;
+};
+
+struct nfs_state_table {
+    struct nfs_state_shard shards[NFS_STATE_NUM_SHARDS];
+};
+
+/*
+ * Public API.
+ */
+
+SYMBOL_EXPORT void nfs_state_table_init(
+    struct nfs_state_table *table);
+SYMBOL_EXPORT void nfs_state_table_free(
+    struct nfs_state_table    *table,
+    struct chimera_vfs_thread *vfs_thread);
+
+/* Allocate a slot, returning shard / slot_idx / generation.  Caller fills in
+ * the state pointer via nfs_state_table_install. */
+SYMBOL_EXPORT int nfs_state_table_alloc(
+    struct nfs_state_table *table,
+    uint8_t                 type,
+    uint8_t                *out_shard,
+    uint32_t               *out_slot_idx,
+    uint32_t               *out_generation);
+
+/* Install a state pointer into a pre-allocated slot. */
+SYMBOL_EXPORT void nfs_state_table_install(
+    struct nfs_state_table *table,
+    uint8_t                 shard,
+    uint32_t                slot_idx,
+    uint8_t                 type,
+    void                   *state);
+
+/* Release a slot back to the pool (advances generation, clears type). */
+SYMBOL_EXPORT void nfs_state_table_free_slot(
+    struct nfs_state_table *table,
+    uint8_t                 shard,
+    uint32_t                slot_idx);
+
+/* Hot-path lookup + ref.  Returns NFS4_OK with the state pointer and type
+ * filled in, having bumped refcount.  Caller must invoke
+ * nfs_state_table_release() when done.  On error returns NFS4ERR_BAD_STATEID
+ * or NFS4ERR_STALE_STATEID and leaves the outputs untouched. */
+SYMBOL_EXPORT nfsstat4 nfs_state_table_acquire(
+    struct nfs_state_table *table,
+    const struct stateid4  *sid,
+    uint8_t                 want_type,                     /* 0 = ANY */
+    void                  **out_state,
+    uint8_t                *out_type);
+
+/* Drop the ref taken by acquire.  If this was the last ref and the state has
+ * been marked destroyed, performs cleanup (releases the VFS handle, frees
+ * the struct). */
+SYMBOL_EXPORT void nfs_state_table_release(
+    struct nfs_state_table    *table,
+    void                      *state,
+    uint8_t                    type,
+    struct chimera_vfs_thread *vfs_thread);
+
+/* Validate without acquiring (used by TEST_STATEID). */
+SYMBOL_EXPORT nfsstat4 nfs_state_table_validate(
+    struct nfs_state_table *table,
+    const struct stateid4  *sid);
+
+/*
+ * Lifecycle API for client / owner / state objects.  Phase 2 callers use
+ * these in place of the old session-slot allocator.
+ */
+
+SYMBOL_EXPORT struct nfs_client *
+nfs_client_alloc(
+    uint64_t    client_id,
+    const void *owner_string,
+    uint16_t    owner_len,
+    uint64_t    verifier,
+    uint8_t     minor);
+
+/* Tear down everything underneath a client (owners → states → locks),
+ * releasing every dup'd VFS handle via vfs_thread, and freeing the struct.
+ * Idempotent; safe to call on a fully-empty client. */
+SYMBOL_EXPORT void
+nfs_client_destroy(
+    struct nfs_client         *client,
+    struct nfs_state_table    *table,
+    struct chimera_vfs_thread *vfs_thread);
+
+/* Find an existing open_owner under `client` by byte-string, or create one.
+ * Sets *out_created = true if a new one was allocated. */
+SYMBOL_EXPORT struct nfs_open_owner *
+nfs_open_owner_find_or_create(
+    struct nfs_client *client,
+    const void        *owner_bytes,
+    uint16_t           owner_len,
+    bool              *out_created);
+
+/* Find an existing open_state on `owner` whose FH matches.  Returns NULL if
+ * none.  Does NOT acquire a ref. */
+SYMBOL_EXPORT struct nfs_open_state *
+nfs_open_owner_find_state(
+    struct nfs_open_owner *owner,
+    const uint8_t         *fh,
+    uint16_t               fh_len);
+
+/* Create a new open_state under `owner`.  `handle_dup` must already be a
+ * dup'd reference (caller invoked chimera_vfs_dup_handle).  Allocates a slot
+ * in `table` and writes the encoded stateid to `out_stateid`.
+ *
+ * The returned state has refcount = 1 (its lifetime ref). */
+SYMBOL_EXPORT struct nfs_open_state *
+nfs_open_state_create(
+    struct nfs_open_owner          *owner,
+    const uint8_t                  *fh,
+    uint16_t                        fh_len,
+    uint32_t                        share_access,
+    uint32_t                        share_deny,
+    struct chimera_vfs_open_handle *handle_dup,
+    uint32_t                        client_short_id,
+    struct nfs_state_table         *table,
+    struct stateid4                *out_stateid);
+
+/* RFC 7530 §9.10 share-mode conflict check.  Walks every open_owner
+ * on `client` other than `requesting_owner` looking for a state on
+ * `fh`.  Returns NFS4ERR_SHARE_DENIED if any peer state has access bits
+ * the new OPEN is trying to deny (or vice versa), else NFS4_OK.
+ *
+ * NOTE: there is a brief TOCTOU window between this check returning OK
+ * and the subsequent nfs_open_state_create()/_coalesce() call -- a
+ * concurrent OPEN from a different owner against the same fh could
+ * slip in.  In practice this requires two distinct clients/owners
+ * racing on the same file within microseconds.  The common-case
+ * Windows-via-NFS / Samba-on-NFS workload is correctly served. */
+SYMBOL_EXPORT nfsstat4
+nfs_client_check_share_conflict(
+    struct nfs_client     *client,
+    struct nfs_open_owner *requesting_owner,
+    const uint8_t         *fh,
+    uint16_t               fh_len,
+    uint32_t               requested_access,
+    uint32_t               requested_deny);
+
+/* Re-open: merge share bits onto an existing state, bump its seqid, and
+ * write the (now-updated) stateid to `out_stateid`. */
+SYMBOL_EXPORT void
+nfs_open_state_coalesce(
+    struct nfs_open_state *state,
+    uint32_t               share_access,
+    uint32_t               share_deny,
+    uint32_t               client_short_id,
+    struct stateid4       *out_stateid);
+
+/* Mark a state for destruction and drop the lifetime ref.  Any walks
+ * already holding an acquire-ref will complete their work; the actual
+ * cleanup (VFS release, struct free) happens on the last release. */
+SYMBOL_EXPORT void
+nfs_open_state_destroy(
+    struct nfs_open_state     *state,
+    struct nfs_state_table    *table,
+    struct chimera_vfs_thread *vfs_thread);
+
+/* Lock-owner / lock-state equivalents. */
+SYMBOL_EXPORT struct nfs_lock_owner *
+nfs_lock_owner_find_or_create(
+    struct nfs_client *client,
+    const void        *owner_bytes,
+    uint16_t           owner_len,
+    bool              *out_created);
+
+SYMBOL_EXPORT struct nfs_lock_state *
+nfs_lock_state_create(
+    struct nfs_lock_owner          *lock_owner,
+    struct nfs_open_state          *open_state,
+    struct chimera_vfs_open_handle *handle_dup,
+    uint32_t                        client_short_id,
+    struct nfs_state_table         *table,
+    struct stateid4                *out_stateid);
+
+SYMBOL_EXPORT void
+nfs_lock_state_destroy(
+    struct nfs_lock_state     *state,
+    struct nfs_state_table    *table,
+    struct chimera_vfs_thread *vfs_thread);
+
+/* Touch a client's lease.  Cheap relaxed store; called from any op that
+ * counts as renewal evidence (state acquire, SEQUENCE, RENEW).  Phase 3. */
+static inline void
+nfs_client_touch(struct nfs_client *client)
+{
+    if (!client) {
+        return;
+    }
+    atomic_store_explicit((_Atomic uint64_t *) &client->last_touch_ns,
+                          nfs_lease_now_ns(), memory_order_relaxed);
+} /* nfs_client_touch */
+
+

--- a/src/server/nfs/nfs4_stateid.h
+++ b/src/server/nfs/nfs4_stateid.h
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#pragma once
+
+#include <stdint.h>
+#include <string.h>
+
+#include "nfs4_xdr.h"
+
+/*
+ * Server-private encoding of stateid.other (12 bytes):
+ *
+ *   byte 0   : version (high 6 bits) | type (low 2 bits)
+ *   byte 1   : shard index (0..NFS_STATE_NUM_SHARDS-1)
+ *   bytes 2-4: slot_idx (24-bit, big-endian)
+ *   bytes 5-7: generation (24-bit, big-endian)
+ *   bytes 8-11: client_short_id (low 32 bits of nfs_client.client_id, big-endian)
+ *
+ * Special stateids defined by RFC 7530 §9.1.4 (all-zero, all-ones, etc.) are
+ * detected by inspecting the entire {seqid, other} blob before any decode.
+ */
+
+#define NFS4_STATEID_VERSION       0x1
+#define NFS4_STATEID_TYPE_OPEN     0x0
+#define NFS4_STATEID_TYPE_LOCK     0x1
+#define NFS4_STATEID_TYPE_MASK     0x3
+
+#define NFS4_STATEID_VERSION_SHIFT 2
+
+#define NFS_STATE_NUM_SHARDS       64
+
+struct nfs4_stateid_view {
+    uint8_t  version;
+    uint8_t  type;
+    uint8_t  shard;
+    uint32_t slot_idx;       /* 24-bit */
+    uint32_t generation;     /* 24-bit */
+    uint32_t client_short_id;
+};
+
+static inline void
+nfs4_stateid_encode(
+    struct stateid4 *out,
+    uint32_t         seqid,
+    uint8_t          type,
+    uint8_t          shard,
+    uint32_t         slot_idx,
+    uint32_t         generation,
+    uint32_t         client_short_id)
+{
+    uint8_t *p = (uint8_t *) out->other;
+
+    out->seqid = seqid;
+
+    p[0] = (NFS4_STATEID_VERSION << NFS4_STATEID_VERSION_SHIFT) |
+        (type & NFS4_STATEID_TYPE_MASK);
+    p[1]  = shard;
+    p[2]  = (uint8_t) (slot_idx >> 16);
+    p[3]  = (uint8_t) (slot_idx >> 8);
+    p[4]  = (uint8_t) (slot_idx);
+    p[5]  = (uint8_t) (generation >> 16);
+    p[6]  = (uint8_t) (generation >> 8);
+    p[7]  = (uint8_t) (generation);
+    p[8]  = (uint8_t) (client_short_id >> 24);
+    p[9]  = (uint8_t) (client_short_id >> 16);
+    p[10] = (uint8_t) (client_short_id >> 8);
+    p[11] = (uint8_t) (client_short_id);
+} /* nfs4_stateid_encode */
+
+static inline void
+nfs4_stateid_decode(
+    struct nfs4_stateid_view *out,
+    const struct stateid4    *sid)
+{
+    const uint8_t *p = (const uint8_t *) sid->other;
+
+    out->version         = p[0] >> NFS4_STATEID_VERSION_SHIFT;
+    out->type            = p[0] & NFS4_STATEID_TYPE_MASK;
+    out->shard           = p[1];
+    out->slot_idx        = ((uint32_t) p[2] << 16) | ((uint32_t) p[3] << 8) | p[4];
+    out->generation      = ((uint32_t) p[5] << 16) | ((uint32_t) p[6] << 8) | p[7];
+    out->client_short_id = ((uint32_t) p[8] << 24) | ((uint32_t) p[9] << 16) |
+        ((uint32_t) p[10] << 8) | p[11];
+} /* nfs4_stateid_decode */
+
+static inline int
+nfs4_stateid_is_special(const struct stateid4 *sid)
+{
+    /* All-zero stateid (anonymous) and all-ones (read bypass) are special
+     * per RFC 7530 §9.1.4.3.  Detected by looking at both seqid and other. */
+    static const uint8_t zero[NFS4_OTHER_SIZE] = { 0 };
+    static const uint8_t ones[NFS4_OTHER_SIZE] = {
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff
+    };
+
+    if (sid->seqid == 0 && memcmp(sid->other, zero, NFS4_OTHER_SIZE) == 0) {
+        return 1;
+    }
+    if (sid->seqid == 0xffffffff &&
+        memcmp(sid->other, ones, NFS4_OTHER_SIZE) == 0) {
+        return 1;
+    }
+    return 0;
+} /* nfs4_stateid_is_special */

--- a/src/server/nfs/nfs_common.h
+++ b/src/server/nfs/nfs_common.h
@@ -14,6 +14,8 @@
 #include "nfs4_xdr.h"
 #include "nlm4_xdr.h"
 #include "nfs4_session.h"
+#include "nfs4_state.h"
+#include "nfs4_recovery.h"
 #include "nfs_nlm_state.h"
 
 struct chimera_server_nfs_thread;
@@ -40,7 +42,6 @@ struct nfs_nfs4_readdir_cursor {
 struct nfs_request {
     struct chimera_server_nfs_thread *thread;
     struct nfs4_session              *session;
-    struct nfs4_state                *nfs4_state;
     struct chimera_vfs_cred           cred;
     uint8_t                           fh[NFS4_FHSIZE];
     int                               fhlen;
@@ -48,9 +49,37 @@ struct nfs_request {
     int                               saved_fhlen;
     struct chimera_vfs_open_handle   *handle;
     int                               index;
+    uint8_t                           minorversion;     /* COMPOUND4args.minorversion */
+    bool                              seen_sequence;    /* set once OP_SEQUENCE has run in this compound */
+    /* In-flight state ref for ops that acquire from the unified state table.
+     * Released by the completion handler.  Phase 2.  Type is one of
+     * NFS4_SLOT_TYPE_OPEN / NFS4_SLOT_TYPE_LOCK. */
+    void                             *nfs_state_ref;
+    uint8_t                           nfs_state_type;
+    /* Per-owner seqid bookkeeping for the 4.0 OPEN flow.  Populated at
+     * entry to chimera_nfs4_open after the seqid is classified NEW; nil on
+     * 4.1+ and on replay/bad-seqid short-circuits.  All OPEN response
+     * paths route through chimera_nfs4_open_complete, which advances the
+     * owner seqid + caches the reply iff this is non-NULL and the status
+     * is in nfs4_seqid_should_advance(). */
+    struct nfs_open_owner            *open_4_0_owner;
+    /* Per-owner seqid bookkeeping for the 4.0 LOCK flow.  For
+     * new_lock_owner=true both open_owner (open_seqid) and lock_owner
+     * (lock_seqid) advance; for new_lock_owner=false only the lock_owner
+     * advances.  Set in chimera_nfs4_lock after classification; consumed
+     * by chimera_nfs4_lock_finish. */
+    struct nfs_open_owner            *lock_4_0_open_owner;
+    struct nfs_lock_owner            *lock_4_0_lock_owner;
     struct evpl_rpc2_conn            *conn;
     struct evpl_rpc2_encoding        *encoding;
     struct nlm_lock_entry            *nlm_pending_entry; /* in-flight NLM lock/test */
+    /* NFS4.1 SEQUENCE replay slot tracking.  Set by chimera_nfs4_sequence
+     * when a SEQUENCE op is processed; consumed by the compound dispatcher
+     * at completion time (nfs4_replay_slot_finalize) and on replay
+     * short-circuit. */
+    struct nfs4_replay_slot          *replay_slot;
+    uint32_t                          replay_slot_id;
+    uint8_t                           replay_action;
     struct nfs_request               *next;
     union {
         struct mountargs3       *args_mount;
@@ -96,6 +125,24 @@ struct chimera_nfs_export {
     struct chimera_nfs_export *next;
 };
 
+/* Prometheus instances for the NFS4.1 SEQUENCE replay cache.  All
+ * counters are best-effort (not atomic); contention is low because
+ * SEQUENCE handling is per-session under that session's lock. */
+struct nfs4_replay_metrics {
+    struct prometheus_counter          *counter;
+    struct prometheus_counter_series   *hit_series;
+    struct prometheus_counter_series   *seq_misordered_series;
+    struct prometheus_counter_series   *bad_slot_series;
+    struct prometheus_counter_series   *retry_uncached_series;
+    struct prometheus_counter_instance *hit;
+    struct prometheus_counter_instance *seq_misordered;
+    struct prometheus_counter_instance *bad_slot;
+    struct prometheus_counter_instance *retry_uncached;
+    struct prometheus_gauge            *bytes_gauge;
+    struct prometheus_gauge_series     *bytes_series;
+    struct prometheus_gauge_instance   *bytes_in_use;
+};
+
 struct chimera_server_nfs_shared {
 
     const struct chimera_server_config *config;
@@ -130,11 +177,22 @@ struct chimera_server_nfs_shared {
 
     uint64_t                            nfs_verifier;
 
+    /* Lease management (Phase 3).  Set from defaults at init; future
+     * config knobs would override these in nfs_server_init. */
+    uint32_t                            nfs_lease_time_s;
+    uint32_t                            nfs_grace_time_s;
+
     struct nfs4_client_table            nfs4_shared_clients;
+    struct nfs_state_table              nfs4_state_table;
+    struct nfs_recovery                 nfs4_recovery;
 
     struct prometheus_histogram        *op_histogram;
     struct prometheus_metrics          *metrics;
+    struct nfs4_replay_metrics          replay_metrics;
 };
+
+/* Forward decl for the per-thread lease sweeper (defined in nfs4_lease.h). */
+struct nfs_lease_sweeper;
 
 struct chimera_server_nfs_thread {
     struct evpl_rpc2_thread          *rpc2_thread;
@@ -142,6 +200,7 @@ struct chimera_server_nfs_thread {
     struct chimera_vfs_thread        *vfs_thread;
     struct chimera_vfs               *vfs;
     struct evpl                      *evpl;
+    struct nfs_lease_sweeper         *lease_sweeper;
     struct evpl_rpc2_thread          *nfs_server_thread;
     struct evpl_rpc2_thread          *mount_server_thread;
     struct evpl_rpc2_thread          *portmap_server_thread;
@@ -170,6 +229,10 @@ nfs_request_alloc(
 
     req->conn     = conn;
     req->encoding = encoding;
+
+    req->replay_slot    = NULL;
+    req->replay_slot_id = 0;
+    req->replay_action  = NFS4_REPLAY_ACTION_NONE;
 
     thread->active_requests++;
 

--- a/src/server/nfs/tests/CMakeLists.txt
+++ b/src/server/nfs/tests/CMakeLists.txt
@@ -1,3 +1,33 @@
 # SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 #
 # SPDX-License-Identifier: LGPL-2.1-only
+
+# Unit test for the unified NFSv4 state model (Phases 1-4).
+add_executable(test_state_table test_state_table.c)
+target_link_libraries(test_state_table chimera_nfs chimera_server chimera_vfs chimera_nfs_common chimera_common evpl evpl_rpc2 pthread uuid urcu urcu-common)
+target_include_directories(test_state_table PRIVATE
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}/src/server/nfs
+    ${NFS_COMMON_INCLUDE_DIR})
+
+add_test(NAME chimera/server/nfs/state_table
+    COMMAND ${CMAKE_CURRENT_BINARY_DIR}/test_state_table)
+
+# Unit test for the NFS4.1 SEQUENCE replay slot state machine.  Drives
+# nfs4_replay_slot_acquire / _finalize directly.  We compile the
+# session source file straight into the test executable (rather than
+# linking libchimera_nfs.so) because the replay-slot functions are not
+# SYMBOL_EXPORT'd -- they are only called from inside the chimera_nfs
+# library at runtime.
+add_executable(test_replay_slot
+    test_replay_slot.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/../nfs4_session.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/../nfs4_state.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/../nfs4_lease.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/../nfs4_recovery.c)
+target_include_directories(test_replay_slot PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/..
+    ${CMAKE_SOURCE_DIR}/src
+    ${NFS_COMMON_INCLUDE_DIR})
+target_link_libraries(test_replay_slot chimera_vfs chimera_common evpl evpl_rpc2 pthread uuid urcu urcu-common)
+add_test(NAME chimera/server/nfs/replay_slot COMMAND test_replay_slot)

--- a/src/server/nfs/tests/test_replay_slot.c
+++ b/src/server/nfs/tests/test_replay_slot.c
@@ -1,0 +1,433 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * Unit tests for the NFS4.1 SEQUENCE replay slot state machine.
+ * Drives nfs4_replay_slot_acquire / nfs4_replay_slot_finalize directly
+ * against a real session built via the production factory functions.
+ */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "common/logging.h"
+#include "nfs_common.h"
+#include "nfs4_session.h"
+
+/* Active in both debug (NDEBUG unset) and release (NDEBUG set) -- CHECK(3)
+ * compiles to a no-op under NDEBUG, which causes -Wunused-but-set-variable
+ * for inputs only consumed by asserts.  CHECK() always evaluates and dies
+ * on failure. */
+#define CHECK(cond) do { \
+            if (!(cond)) { \
+                fprintf(stderr, "%s:%d: CHECK failed: %s\n", \
+                        __FILE__, __LINE__, #cond); \
+                abort(); \
+            } \
+} while (0)
+
+/* Minimum number of slots we'll request from the server cap.  Several
+ * tests use slot 0 + slot 1 + an out-of-range slot, so we need at
+ * least 2 valid slots. */
+#define TEST_SLOTS   4
+#define TEST_MAXRESP 4096
+
+/*
+ * Build a session attached to a fresh client table.  Caller frees with
+ * destroy_session_table().  No NFS conn / encoding is created here --
+ * acquire/finalize are exercised directly with a stub nfs_request that
+ * carries NULL encoding (the capture arm is a no-op when encoding is
+ * NULL).
+ */
+static struct nfs4_session *
+make_session(
+    struct nfs4_client_table *table,
+    uint32_t                  replay_max_slots,
+    uint32_t                  replay_maxresp_cached)
+{
+    static const uint8_t owner[] = "owner-x";
+    uint64_t             clientid;
+    struct nfs4_session *session;
+
+    nfs4_client_table_init(table);
+
+    clientid = nfs4_client_register(table, owner, (int) sizeof(owner) - 1,
+                                    0xdeadbeefULL, 40, NULL, NULL);
+    CHECK(clientid != 0);
+
+    session = nfs4_create_session(table, clientid, 0,
+                                  replay_max_slots, replay_maxresp_cached,
+                                  NULL, NULL);
+    CHECK(session != NULL);
+
+    return session;
+} /* make_session */
+
+static void
+destroy_session_table(
+    struct nfs4_client_table *table,
+    struct nfs4_session      *session)
+{
+    /* Drop the +1 ref returned by nfs4_create_session.  The table still
+     * holds its ref, which nfs4_client_table_free releases. */
+    nfs4_session_put(session);
+
+    /* nfs4_client_register also allocated a unified state hierarchy on the
+     * client; tear that down before freeing the table.  No state objects
+     * were created in this test, so NULL state_table / vfs_thread are safe
+     * arguments. */
+    nfs4_client_table_destroy_unified(table, NULL, NULL);
+    nfs4_client_table_free(table);
+} /* destroy_session_table */
+
+static void
+reset_request(struct nfs_request *req)
+{
+    memset(req, 0, sizeof(*req));
+} /* reset_request */
+
+/* Case 1: first SEQUENCE on an UNUSED slot with seqid=1 succeeds. */
+static void
+test_unused_slot_first_seq_ok(void)
+{
+    struct nfs4_client_table table;
+    struct nfs4_session     *session = make_session(&table, TEST_SLOTS, TEST_MAXRESP);
+    struct nfs_request       req;
+    bool                     is_replay = true;
+    nfsstat4                 status;
+
+    reset_request(&req);
+    req.session = session;
+
+    status = nfs4_replay_slot_acquire(session, 0, 1, false, &req, &is_replay);
+
+    CHECK(status == NFS4_OK);
+    CHECK(!is_replay);
+    CHECK(req.replay_slot == &session->replay_slots[0]);
+    CHECK(req.replay_slot_id == 0);
+    CHECK(req.replay_action == NFS4_REPLAY_ACTION_NEW);
+    CHECK(session->replay_slots[0].state == NFS4_SLOT_IN_PROGRESS);
+    CHECK(session->replay_slots[0].inflight_seqid == 1);
+
+    /* Finalize transitions to COMPLETED (no cachethis, no cached_buf). */
+    nfs4_replay_slot_finalize(&req);
+    CHECK(session->replay_slots[0].state == NFS4_SLOT_COMPLETED);
+    CHECK(session->replay_slots[0].seqid == 1);
+    CHECK(session->replay_slots[0].cached_buf == NULL);
+
+    destroy_session_table(&table, session);
+} /* test_unused_slot_first_seq_ok */
+
+/* Case 2: first SEQUENCE on an UNUSED slot with seqid != 1 -> MISORDERED. */
+static void
+test_unused_slot_wrong_seq_misordered(void)
+{
+    struct nfs4_client_table table;
+    struct nfs4_session     *session = make_session(&table, TEST_SLOTS, TEST_MAXRESP);
+    struct nfs_request       req;
+    bool                     is_replay = true;
+    nfsstat4                 status;
+
+    reset_request(&req);
+    req.session = session;
+
+    status = nfs4_replay_slot_acquire(session, 0, 2, false, &req, &is_replay);
+
+    CHECK(status == NFS4ERR_SEQ_MISORDERED);
+    CHECK(!is_replay);
+    CHECK(session->replay_slots[0].state == NFS4_SLOT_UNUSED);
+
+    destroy_session_table(&table, session);
+} /* test_unused_slot_wrong_seq_misordered */
+
+/* Case 3: out-of-range slot -> BADSLOT. */
+static void
+test_out_of_range_slot(void)
+{
+    struct nfs4_client_table table;
+    struct nfs4_session     *session = make_session(&table, TEST_SLOTS, TEST_MAXRESP);
+    struct nfs_request       req;
+    bool                     is_replay = true;
+    nfsstat4                 status;
+
+    reset_request(&req);
+    req.session = session;
+
+    status = nfs4_replay_slot_acquire(session, TEST_SLOTS, 1, false, &req,
+                                      &is_replay);
+    CHECK(status == NFS4ERR_BADSLOT);
+    CHECK(!is_replay);
+
+    destroy_session_table(&table, session);
+} /* test_out_of_range_slot */
+
+/* Case 4: in-progress retry (same seqid) -> RETRY_UNCACHED_REP. */
+static void
+test_in_progress_retry(void)
+{
+    struct nfs4_client_table table;
+    struct nfs4_session     *session = make_session(&table, TEST_SLOTS, TEST_MAXRESP);
+    struct nfs_request       req1, req2;
+    bool                     is_replay;
+    nfsstat4                 status;
+
+    reset_request(&req1);
+    reset_request(&req2);
+    req1.session = session;
+    req2.session = session;
+
+    status = nfs4_replay_slot_acquire(session, 0, 1, true, &req1, &is_replay);
+    CHECK(status == NFS4_OK);
+    CHECK(session->replay_slots[0].state == NFS4_SLOT_IN_PROGRESS);
+
+    /* Without calling finalize, a second SEQUENCE on the same slot with
+     * the same seqid arrives -- libevpl has no DRC, so this hits us. */
+    status = nfs4_replay_slot_acquire(session, 0, 1, true, &req2, &is_replay);
+    CHECK(status == NFS4ERR_RETRY_UNCACHED_REP);
+    CHECK(!is_replay);
+
+    /* And a jump-ahead seqid -> MISORDERED. */
+    status = nfs4_replay_slot_acquire(session, 0, 5, true, &req2, &is_replay);
+    CHECK(status == NFS4ERR_SEQ_MISORDERED);
+
+    /* Clean up the first request. */
+    nfs4_replay_slot_finalize(&req1);
+    destroy_session_table(&table, session);
+} /* test_in_progress_retry */
+
+/* Case 5: COMPLETED retry (cachethis was false) -> RETRY_UNCACHED_REP. */
+static void
+test_completed_retry_uncached(void)
+{
+    struct nfs4_client_table table;
+    struct nfs4_session     *session = make_session(&table, TEST_SLOTS, TEST_MAXRESP);
+    struct nfs_request       req;
+    bool                     is_replay;
+    nfsstat4                 status;
+
+    reset_request(&req);
+    req.session = session;
+
+    /* Run a request with cachethis=false. */
+    status = nfs4_replay_slot_acquire(session, 0, 1, false, &req, &is_replay);
+    CHECK(status == NFS4_OK);
+    nfs4_replay_slot_finalize(&req);
+    CHECK(session->replay_slots[0].state == NFS4_SLOT_COMPLETED);
+
+    /* Retry (same seqid) -> no cached bytes -> RETRY_UNCACHED_REP. */
+    reset_request(&req);
+    req.session = session;
+    status      = nfs4_replay_slot_acquire(session, 0, 1, false, &req, &is_replay);
+    CHECK(status == NFS4ERR_RETRY_UNCACHED_REP);
+    CHECK(!is_replay);
+
+    destroy_session_table(&table, session);
+} /* test_completed_retry_uncached */
+
+/* Case 6: CACHED retry -> REPLAY hit.  Simulate capture by manually
+ * installing a cached_buf on the slot post-finalize. */
+static void
+test_cached_retry_replay(void)
+{
+    struct nfs4_client_table table;
+    struct nfs4_session     *session = make_session(&table, TEST_SLOTS, TEST_MAXRESP);
+    struct nfs_request       req;
+    bool                     is_replay;
+    nfsstat4                 status;
+    char                    *fake_reply;
+
+    reset_request(&req);
+    req.session = session;
+
+    /* Run with cachethis=true.  Encoding is NULL so arm_capture is a
+     * no-op; we simulate the capture callback effect manually. */
+    status = nfs4_replay_slot_acquire(session, 0, 1, true, &req, &is_replay);
+    CHECK(status == NFS4_OK);
+
+    /* Pretend the capture callback fired and stored bytes on the slot. */
+    fake_reply = malloc(64);
+    memset(fake_reply, 'x', 64);
+    session->replay_slots[0].cached_buf = fake_reply;
+    session->replay_slots[0].cached_len = 64;
+    session->replay_bytes_in_use       += 64;
+
+    nfs4_replay_slot_finalize(&req);
+    CHECK(session->replay_slots[0].state == NFS4_SLOT_CACHED);
+    CHECK(session->replay_slots[0].cached_buf == fake_reply);
+
+    /* Retry same seqid -> REPLAY. */
+    reset_request(&req);
+    req.session = session;
+    status      = nfs4_replay_slot_acquire(session, 0, 1, true, &req, &is_replay);
+    CHECK(status == NFS4_OK);
+    CHECK(is_replay);
+    CHECK(req.replay_action == NFS4_REPLAY_ACTION_FROM_CACHE);
+    CHECK(req.replay_slot == &session->replay_slots[0]);
+
+    destroy_session_table(&table, session);
+    /* fake_reply was freed by session_put -> slot teardown. */
+} /* test_cached_retry_replay */
+
+/* Case 7: advancing seqid frees the prior cached reply. */
+static void
+test_advance_frees_cache(void)
+{
+    struct nfs4_client_table table;
+    struct nfs4_session     *session = make_session(&table, TEST_SLOTS, TEST_MAXRESP);
+    struct nfs_request       req;
+    bool                     is_replay;
+    nfsstat4                 status;
+    char                    *fake_reply;
+
+    reset_request(&req);
+    req.session = session;
+
+    /* Get into CACHED with simulated bytes. */
+    status = nfs4_replay_slot_acquire(session, 0, 1, true, &req, &is_replay);
+    CHECK(status == NFS4_OK);
+    fake_reply                          = malloc(128);
+    session->replay_slots[0].cached_buf = fake_reply;
+    session->replay_slots[0].cached_len = 128;
+    session->replay_bytes_in_use       += 128;
+    nfs4_replay_slot_finalize(&req);
+    CHECK(session->replay_slots[0].state == NFS4_SLOT_CACHED);
+    CHECK(session->replay_bytes_in_use == 128);
+
+    /* Advance: seqid + 1.  Old buf must be freed and bytes accounted. */
+    reset_request(&req);
+    req.session = session;
+    status      = nfs4_replay_slot_acquire(session, 0, 2, false, &req, &is_replay);
+    CHECK(status == NFS4_OK);
+    CHECK(!is_replay);
+    CHECK(req.replay_action == NFS4_REPLAY_ACTION_NEW);
+    CHECK(session->replay_slots[0].state == NFS4_SLOT_IN_PROGRESS);
+    CHECK(session->replay_slots[0].cached_buf == NULL);
+    CHECK(session->replay_bytes_in_use == 0);
+
+    nfs4_replay_slot_finalize(&req);
+    CHECK(session->replay_slots[0].state == NFS4_SLOT_COMPLETED);
+
+    destroy_session_table(&table, session);
+} /* test_advance_frees_cache */
+
+/* Case 8: misordered seqid on a completed slot. */
+static void
+test_misordered_after_completed(void)
+{
+    struct nfs4_client_table table;
+    struct nfs4_session     *session = make_session(&table, TEST_SLOTS, TEST_MAXRESP);
+    struct nfs_request       req;
+    bool                     is_replay;
+    nfsstat4                 status;
+
+    reset_request(&req);
+    req.session = session;
+
+    status = nfs4_replay_slot_acquire(session, 0, 1, false, &req, &is_replay);
+    CHECK(status == NFS4_OK);
+    nfs4_replay_slot_finalize(&req);
+
+    /* seqid = last+2 -> MISORDERED. */
+    reset_request(&req);
+    req.session = session;
+    status      = nfs4_replay_slot_acquire(session, 0, 3, false, &req, &is_replay);
+    CHECK(status == NFS4ERR_SEQ_MISORDERED);
+
+    destroy_session_table(&table, session);
+} /* test_misordered_after_completed */
+
+/* Case 9: independent slots advance independently. */
+static void
+test_slots_independent(void)
+{
+    struct nfs4_client_table table;
+    struct nfs4_session     *session = make_session(&table, TEST_SLOTS, TEST_MAXRESP);
+    struct nfs_request       req;
+    bool                     is_replay;
+    nfsstat4                 status;
+
+    reset_request(&req);
+    req.session = session;
+
+    status = nfs4_replay_slot_acquire(session, 0, 1, false, &req, &is_replay);
+    CHECK(status == NFS4_OK);
+    nfs4_replay_slot_finalize(&req);
+
+    /* Slot 1 is still UNUSED.  Its first seqid must be 1, not slot 0's
+     * last+1 value. */
+    reset_request(&req);
+    req.session = session;
+    status      = nfs4_replay_slot_acquire(session, 1, 2, false, &req, &is_replay);
+    CHECK(status == NFS4ERR_SEQ_MISORDERED);
+
+    reset_request(&req);
+    req.session = session;
+    status      = nfs4_replay_slot_acquire(session, 1, 1, false, &req, &is_replay);
+    CHECK(status == NFS4_OK);
+    nfs4_replay_slot_finalize(&req);
+    CHECK(session->replay_slots[1].state == NFS4_SLOT_COMPLETED);
+    CHECK(session->replay_slots[0].state == NFS4_SLOT_COMPLETED);
+
+    destroy_session_table(&table, session);
+} /* test_slots_independent */
+
+/* Case 10: implicit (NFS4.0) sessions have no slot table -> every
+ * SEQUENCE attempt is BADSLOT. */
+static void
+test_implicit_session_no_slots(void)
+{
+    static const uint8_t     owner[] = "v40-client";
+    struct nfs4_client_table table;
+    uint64_t                 clientid;
+    struct nfs4_session     *session;
+    struct nfs_request       req;
+    bool                     is_replay;
+    nfsstat4                 status;
+
+    nfs4_client_table_init(&table);
+    clientid = nfs4_client_register(&table, owner, (int) sizeof(owner) - 1,
+                                    0xfeedfaceULL, 40, NULL, NULL);
+
+    /* implicit=1 -> replay_slots stays NULL, replay_max_slots = 0. */
+    session = nfs4_create_session(&table, clientid, 1, 0, 0, NULL, NULL);
+    CHECK(session != NULL);
+    CHECK(session->replay_slots == NULL);
+    CHECK(session->replay_max_slots == 0);
+
+    reset_request(&req);
+    req.session = session;
+    status      = nfs4_replay_slot_acquire(session, 0, 1, false, &req, &is_replay);
+    CHECK(status == NFS4ERR_BADSLOT);
+
+    destroy_session_table(&table, session);
+} /* test_implicit_session_no_slots */
+
+int
+main(
+    int   argc,
+    char *argv[])
+{
+    (void) argc;
+    (void) argv;
+
+    /* chimera_nfs_info() and friends call into the logging library,
+     * which requires init or it crashes inside its formatter. */
+    chimera_log_init();
+
+    test_unused_slot_first_seq_ok();
+    test_unused_slot_wrong_seq_misordered();
+    test_out_of_range_slot();
+    test_in_progress_retry();
+    test_completed_retry_uncached();
+    test_cached_retry_replay();
+    test_advance_frees_cache();
+    test_misordered_after_completed();
+    test_slots_independent();
+    test_implicit_session_no_slots();
+
+    printf("nfs4_replay_slot: all tests passed\n");
+    return 0;
+} /* main */

--- a/src/server/nfs/tests/test_state_table.c
+++ b/src/server/nfs/tests/test_state_table.c
@@ -1,0 +1,324 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * Unit test for the unified NFSv4 state model:
+ *   - slot allocate / install / lookup / free
+ *   - stateid encode/decode roundtrip
+ *   - generation advance invalidates stale stateids
+ *   - client / open_owner / open_state lifecycle
+ *
+ * Exercises the public API in nfs4_state.h without any VFS, RPC, or
+ * compound dispatch in the picture.  Handles are passed as NULL since
+ * destroy skips release when both handle and vfs_thread are NULL.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "nfs4_state.h"
+#include "nfs4_stateid.h"
+
+/* assert(3) compiles to a no-op under NDEBUG (Release builds), which
+ * triggers -Werror=unused-but-set-variable for inputs only consumed by
+ * asserts.  CHECK() always evaluates and dies on failure. */
+#define CHECK(cond)                                                    \
+        do {                                                               \
+            if (!(cond)) {                                                 \
+                fprintf(stderr, "%s:%d: CHECK failed: %s\n",               \
+                        __FILE__, __LINE__, #cond);                        \
+                abort();                                                   \
+            }                                                              \
+        } while (0)
+
+static void
+test_stateid_codec(void)
+{
+    struct stateid4          sid;
+    struct nfs4_stateid_view view;
+
+    nfs4_stateid_encode(&sid,
+                        /*seqid*/ 1,
+                        /*type*/ NFS4_STATEID_TYPE_OPEN,
+                        /*shard*/ 7,
+                        /*slot_idx*/ 0xABCDEF,
+                        /*generation*/ 0x123456,
+                        /*client_short*/ 0xDEADBEEF);
+
+    nfs4_stateid_decode(&view, &sid);
+
+    CHECK(sid.seqid == 1);
+    CHECK(view.version == NFS4_STATEID_VERSION);
+    CHECK(view.type == NFS4_STATEID_TYPE_OPEN);
+    CHECK(view.shard == 7);
+    CHECK(view.slot_idx == 0xABCDEF);
+    CHECK(view.generation == 0x123456);
+    CHECK(view.client_short_id == 0xDEADBEEF);
+
+    /* Special-stateid detection */
+    struct stateid4 zero = { 0 };
+    CHECK(nfs4_stateid_is_special(&zero));
+
+    struct stateid4 ones;
+    ones.seqid = 0xffffffff;
+    memset(ones.other, 0xff, sizeof(ones.other));
+    CHECK(nfs4_stateid_is_special(&ones));
+
+    CHECK(!nfs4_stateid_is_special(&sid));
+    printf("ok: stateid_codec\n");
+} /* test_stateid_codec */
+
+static void
+test_slot_lifecycle(void)
+{
+    struct nfs_state_table table;
+    uint8_t                first_shard;
+    uint32_t               first_slot, first_gen;
+    int                    rc;
+
+    nfs_state_table_init(&table);
+
+    /* Allocate a slot.  Generation must start at 1 (every (re)use bumps). */
+    rc = nfs_state_table_alloc(&table, NFS4_SLOT_TYPE_OPEN,
+                               &first_shard, &first_slot, &first_gen);
+    CHECK(rc == 0);
+    CHECK(first_gen == 1);
+
+    /* Validate an encoded stateid resolves: build one and confirm
+     * nfs_state_table_validate accepts it (we haven't installed a state
+     * pointer yet, so acquire would fault; validate just checks the slot). */
+    struct stateid4 sid;
+    nfs4_stateid_encode(&sid, 1, NFS4_STATEID_TYPE_OPEN,
+                        first_shard, first_slot, first_gen, 0);
+    nfsstat4        v = nfs_state_table_validate(&table, &sid);
+    CHECK(v == NFS4_OK);
+
+    /* Free the slot.  free advances the generation again so the prior
+     * stateid is now stale. */
+    nfs_state_table_free_slot(&table, first_shard, first_slot);
+
+    /* The previously-encoded stateid now references a freed slot.  Validate
+    * must reject -- either as BAD_STATEID (slot is TYPE_FREE) or
+    * STALE_STATEID (generation advanced).  Either way it MUST NOT be OK. */
+    v = nfs_state_table_validate(&table, &sid);
+    CHECK(v != NFS4_OK);
+
+    /* A stateid with a wrong generation also rejects as stale. */
+    struct stateid4 stale;
+    nfs4_stateid_encode(&stale, 1, NFS4_STATEID_TYPE_OPEN,
+                        first_shard, first_slot, /*gen*/ 999, 0);
+    v = nfs_state_table_validate(&table, &stale);
+    CHECK(v != NFS4_OK);
+
+    nfs_state_table_free(&table, NULL);
+    printf("ok: slot_lifecycle\n");
+} /* test_slot_lifecycle */
+
+static void
+test_owner_state_lifecycle(void)
+{
+    struct nfs_state_table table;
+    struct nfs_client     *client;
+    struct nfs_open_owner *owner;
+    struct nfs_open_state *state;
+    struct stateid4        sid;
+    nfsstat4               status;
+    void                  *acquired;
+    uint8_t                acquired_type;
+    bool                   created;
+    uint8_t                fh[4]          = { 0xCA, 0xFE, 0xBA, 0xBE };
+    uint8_t                owner_bytes[8] = "owner-A";
+
+    nfs_state_table_init(&table);
+    client = nfs_client_alloc(42, "client-A", 8, 0xABCD, /*minor*/ 0);
+
+    owner = nfs_open_owner_find_or_create(client, owner_bytes,
+                                          sizeof(owner_bytes), &created);
+    CHECK(created);
+    CHECK(!owner->confirmed);
+    CHECK(owner->seqid == 0);
+
+    /* find_or_create is idempotent. */
+    bool                   created_again;
+    struct nfs_open_owner *owner_again = nfs_open_owner_find_or_create(
+        client, owner_bytes, sizeof(owner_bytes), &created_again);
+    CHECK(!created_again);
+    CHECK(owner_again == owner);
+
+    /* Create an open_state with NULL handle (no VFS). */
+    state = nfs_open_state_create(owner, fh, sizeof(fh),
+                                  OPEN4_SHARE_ACCESS_READ,
+                                  OPEN4_SHARE_DENY_NONE,
+                                  /*handle_dup*/ NULL,
+                                  /*client_short*/ 42,
+                                  &table,
+                                  &sid);
+    CHECK(state != NULL);
+    CHECK(state->seqid == 1);
+    CHECK(sid.seqid == 1);
+
+    /* Lookup by stateid: should bump refcount and return the state. */
+    status = nfs_state_table_acquire(&table, &sid, NFS4_SLOT_TYPE_OPEN,
+                                     &acquired, &acquired_type);
+    CHECK(status == NFS4_OK);
+    CHECK(acquired == state);
+    CHECK(acquired_type == NFS4_SLOT_TYPE_OPEN);
+
+    nfs_state_table_release(&table, acquired, NFS4_SLOT_TYPE_OPEN, NULL);
+
+    /* Coalesce: same owner + same fh; share bits widen, seqid bumps. */
+    struct stateid4 sid2;
+    nfs_open_state_coalesce(state,
+                            OPEN4_SHARE_ACCESS_WRITE,
+                            OPEN4_SHARE_DENY_NONE,
+                            42, &sid2);
+    CHECK((state->share_access &
+           (OPEN4_SHARE_ACCESS_READ | OPEN4_SHARE_ACCESS_WRITE)) ==
+          (OPEN4_SHARE_ACCESS_READ | OPEN4_SHARE_ACCESS_WRITE));
+    CHECK(state->seqid == 2);
+    CHECK(sid2.seqid == 2);
+    /* Stateid 'other' identifies the same slot; only seqid changes. */
+    CHECK(memcmp(sid.other, sid2.other, sizeof(sid.other)) == 0);
+
+    /* Destroy + re-acquire should fail. */
+    nfs_open_state_destroy(state, &table, NULL);
+    status = nfs_state_table_acquire(&table, &sid2, NFS4_SLOT_TYPE_OPEN,
+                                     &acquired, &acquired_type);
+    CHECK(status != NFS4_OK);
+
+    nfs_client_destroy(client, &table, NULL);
+    nfs_state_table_free(&table, NULL);
+    printf("ok: owner_state_lifecycle\n");
+} /* test_owner_state_lifecycle */
+
+static void
+test_replay_helpers(void)
+{
+    struct nfs4_replay_cache replay = { 0 };
+    int                      cls;
+    uint32_t                 owner_seqid = 0;
+
+    /* First op: incoming = owner_seqid + 1 = 1, treat as NEW. */
+    cls = nfs4_owner_seqid_classify(owner_seqid, &replay, 1);
+    CHECK(cls == NFS4_SEQID_NEW);
+
+    /* RFC 7530 §9.1.7: the very first op against a fresh owner may carry
+     * any seqid the client chose -- the Linux kernel client picks 0.
+     * Replay cache is still empty here, so this must classify NEW. */
+    cls = nfs4_owner_seqid_classify(owner_seqid, &replay, 0);
+    CHECK(cls == NFS4_SEQID_NEW);
+    cls = nfs4_owner_seqid_classify(owner_seqid, &replay, 0xDEADBEEF);
+    CHECK(cls == NFS4_SEQID_NEW);
+
+    /* Pretend we executed and recorded the reply. */
+    struct stateid4 sid;
+    nfs4_stateid_encode(&sid, 1, NFS4_STATEID_TYPE_OPEN,
+                        0, 0, 1, 0xDEADBEEF);
+    nfs4_replay_record(&replay, 1, OP_OPEN, NFS4_OK, &sid);
+    owner_seqid = 1;
+
+    /* Retransmit of seqid=1 is REPLAY. */
+    cls = nfs4_owner_seqid_classify(owner_seqid, &replay, 1);
+    CHECK(cls == NFS4_SEQID_REPLAY);
+
+    /* Next valid seqid is 2 (NEW). */
+    cls = nfs4_owner_seqid_classify(owner_seqid, &replay, 2);
+    CHECK(cls == NFS4_SEQID_NEW);
+
+    /* Out-of-window seqids -> BAD. */
+    cls = nfs4_owner_seqid_classify(owner_seqid, &replay, 5);
+    CHECK(cls == NFS4_SEQID_BAD);
+
+    cls = nfs4_owner_seqid_classify(owner_seqid, &replay, 0);
+    CHECK(cls == NFS4_SEQID_BAD);
+
+    printf("ok: replay_helpers\n");
+} /* test_replay_helpers */
+
+/* RFC 7530 §9.10: cross-owner SHARE_DENY conflicts. */
+static void
+test_share_mode_conflict(void)
+{
+    struct nfs_state_table table;
+    struct nfs_client     *client;
+    struct nfs_open_owner *owner_a, *owner_b;
+    struct nfs_open_state *state_a;
+    struct stateid4        sid_a;
+    bool                   created;
+    uint8_t                fh[4] = { 0xDE, 0xAD, 0xBE, 0xEF };
+    nfsstat4               status;
+
+    nfs_state_table_init(&table);
+    client = nfs_client_alloc(99, "share-cli", 9, 0xFFFF, 1);
+
+    owner_a = nfs_open_owner_find_or_create(client, "owner-A", 7, &created);
+    owner_b = nfs_open_owner_find_or_create(client, "owner-B", 7, &created);
+    CHECK(owner_a != owner_b);
+
+    /* Owner A opens with SHARE_DENY_WRITE. */
+    state_a = nfs_open_state_create(owner_a, fh, sizeof(fh),
+                                    OPEN4_SHARE_ACCESS_READ,
+                                    OPEN4_SHARE_DENY_WRITE,
+                                    NULL, 99, &table, &sid_a);
+    CHECK(state_a != NULL);
+
+    /* Owner B asking for WRITE should be denied. */
+    status = nfs_client_check_share_conflict(client, owner_b,
+                                             fh, sizeof(fh),
+                                             OPEN4_SHARE_ACCESS_WRITE,
+                                             OPEN4_SHARE_DENY_NONE);
+    CHECK(status == NFS4ERR_SHARE_DENIED);
+
+    /* Owner B asking only for READ should be fine (no access overlap with
+     * owner A's deny-write). */
+    status = nfs_client_check_share_conflict(client, owner_b,
+                                             fh, sizeof(fh),
+                                             OPEN4_SHARE_ACCESS_READ,
+                                             OPEN4_SHARE_DENY_NONE);
+    CHECK(status == NFS4_OK);
+
+    /* Owner B denying READ would clash with A's existing READ access. */
+    status = nfs_client_check_share_conflict(client, owner_b,
+                                             fh, sizeof(fh),
+                                             OPEN4_SHARE_ACCESS_READ,
+                                             OPEN4_SHARE_DENY_READ);
+    CHECK(status == NFS4ERR_SHARE_DENIED);
+
+    /* Same-owner check skips the requesting owner -- coalesce path. */
+    status = nfs_client_check_share_conflict(client, owner_a,
+                                             fh, sizeof(fh),
+                                             OPEN4_SHARE_ACCESS_WRITE,
+                                             OPEN4_SHARE_DENY_NONE);
+    CHECK(status == NFS4_OK);
+
+    /* Different FH on same client -- no conflict regardless of bits. */
+    uint8_t fh2[4] = { 0x11, 0x22, 0x33, 0x44 };
+    status = nfs_client_check_share_conflict(client, owner_b,
+                                             fh2, sizeof(fh2),
+                                             OPEN4_SHARE_ACCESS_WRITE,
+                                             OPEN4_SHARE_DENY_BOTH);
+    CHECK(status == NFS4_OK);
+
+    nfs_open_state_destroy(state_a, &table, NULL);
+    nfs_client_destroy(client, &table, NULL);
+    nfs_state_table_free(&table, NULL);
+    printf("ok: share_mode_conflict\n");
+} /* test_share_mode_conflict */
+
+int
+main(
+    int   argc,
+    char *argv[])
+{
+    (void) argc;
+    (void) argv;
+    test_stateid_codec();
+    test_slot_lifecycle();
+    test_owner_state_lifecycle();
+    test_replay_helpers();
+    test_share_mode_conflict();
+    printf("PASS: all state table tests\n");
+    return 0;
+} /* main */


### PR DESCRIPTION
## Summary

Refactors the NFSv4 server state model to a minor-version-independent hierarchy and implements the NFSv4.0 establishment / lease / grace / missing-op machinery on top of it, plus the NFS4.1+ SEQUENCE replay cache.

Two replay mechanisms now coexist by minor version:
- **4.1+**: per-session slot table with state machine + wire-byte capture (RFC 5661 §2.10.6).
- **4.0**: per-owner classify + reply cache on `nfs_open_owner` / `nfs_lock_owner`, with `nfs4_seqid_should_advance()` implementing the RFC 7530 §9.1.7 no-advance set.

## What's included

**State model.** Unified hierarchy `nfs_client → open_owner → open_state` plus `lock_owner → lock_state` (lock_owner anchored under client per RFC 7530 §9.1.4). 64-shard slot table with per-shard rwlock; 12-byte server-private `stateid.other` layout with 24-bit generation for stale-stateid detection; atomic refcount + idempotent destroy via CAS.

**4.0 establishment & ops** (RFC 7530):
- OPEN_CONFIRM (§16.18), OPEN_DOWNGRADE (§16.19), RENEW (§16.30), RELEASE_LOCKOWNER (§16.37)
- SETCLIENTID_CONFIRM real verifier validation (§16.34)
- SETATTR(size) stateid + share-access enforcement (§16.32.3)
- Cross-owner SHARE_DENY conflict enforcement (§9.10)
- Same-owner re-OPEN share-mode coalescing (§9.1.2)
- Per-owner seqid classify + reply cache fully wired across OPEN, CLOSE, LOCK (both `new_lock_owner` branches), LOCKU, OPEN_CONFIRM, OPEN_DOWNGRADE — entry-time classification, reply cached for every outcome except the §9.1.7 infrastructure-error set.

**4.1+ session replay** (RFC 5661 §2.10.6): per-session slot table with `UNUSED → IN_PROGRESS → CACHED/COMPLETED` state machine, wire-byte capture via libevpl's pre-dispatch `reply_capture_cb`, per-session ceilings (64 slots × 64 KiB × 4 MiB) negotiated at CREATE_SESSION, prometheus counters.

**Lease + grace**: 1Hz per-thread sweeper, `FATTR4_LEASE_TIME` reports the real value. Recovery API (`nfs_recovery_*`) wired into OPEN / EXCHANGE_ID / SETCLIENTID_CONFIRM / RECLAIM_COMPLETE / shutdown; persistence is a stub today, but a file-per-client backend can land later behind the same API without touching callers.

**Compound dispatcher**: per-minor op support matrix, SEQUENCE-must-be-first / `OP_NOT_IN_SESSION` ordering enforcement for 4.1+.

**DESTROY_CLIENTID** now tears down `client->unified` instead of leaking it.

**Cleanup**: ~250 lines of legacy session-slot machinery removed from `nfs4_session.{h,c}` — `struct nfs4_state`, `nfs4_session_state[]`, `free_slot[]`, eight inline state helpers, etc.

**Tests**: `test_state_table` (stateid codec, slot generation guard, owner lifecycle + coalesce, replay classifier, cross-owner share-mode matrix) and `test_replay_slot` (10 state-machine paths through the 4.1 slot table).

**Submodule**: `ext/libevpl` bumped via upstream/main (carries the reply-capture hook and the http_basic `stdlib.h` fix).

## Still deferred (independent of this PR)

- Persistence backend for the recovery layer (API plumbed; `nfs_recovery_persist` is a stub).
- Back-channel CB sends (delegations remain `OPEN_DELEGATE_NONE`).
- `LOOKUPP` / `VERIFY` / `NVERIFY` / `SECINFO`, NFSv4 ACLs, RPCSEC_GSS, NFSv4 idmapping — from the original audit, all independent.

## Verification

`ctest -E boto3_v2_memfs` → **1887/1887** NFS+POSIX+VFS tests pass on Debug. The five `boto3_v2_memfs_*` failures pre-exist on `main` and are unrelated to NFS.
