### PR TITLE
docker: bundle working default config and document quickstart

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,11 +66,13 @@ RUN apt-get -y update && \
 
 ENV LD_LIBRARY_PATH=/usr/local/lib
 
-COPY --from=build /usr/local/etc/chimera.json /usr/local/etc/chimera.json
 COPY --from=build /usr/local/sbin/chimera /usr/local/sbin/chimera
 COPY --from=build /usr/local/lib/* /usr/local/lib/
 
+COPY /chimera-docker.json /usr/local/etc/chimera.json
 COPY /suppressions.txt /suppressions.txt
+
+RUN mkdir -p /export
 
 ENV LSAN_OPTIONS=suppressions=/suppressions.txt
 

--- a/README.md
+++ b/README.md
@@ -35,10 +35,99 @@ The project uses CMake and there is a makefile wrapper at the root of the tree f
 
 # Using Docker
 
-The latest chimera build is published by CI to ghcr.io:
+The latest chimera build is published by CI to ghcr.io. The image ships with a
+default config that exports two filesystems:
+
+* `/export` — `linux` backend, bound to the container path `/export`. Mount a
+  host directory there to serve files from disk.
+* `/memfs` — `memfs` backend, an in-memory filesystem useful for smoke tests
+  and benchmarking.
+
+Each is published as an NFS export, an SMB share, and an S3 bucket.
+
+> **Warning:** Chimera binds the standard NFS, SMB, and Sun RPC portmap ports.
+> If the host is already running `rpcbind`, `nfs-server`, `smbd`, or any other
+> service on ports 111, 2049, or 445, either stop them or remap chimera to
+> different host ports (e.g. `-p 12049:2049`).
 
 ```bash
-docker run -v /path/to/config:/etc/chimera.json ghcr.io/chimera-nas/chimera:latest
+mkdir -p ./export
+docker run --rm -it \
+    -v "$(pwd)/export":/export \
+    -p 111:111 -p 2049:2049 \
+    -p 445:445 \
+    -p 5000:5000 \
+    -p 8080:8080 \
+    -p 9000:9000 \
+    ghcr.io/chimera-nas/chimera:latest
+```
+
+| Port | Protocol |
+|------|----------|
+| 111  | Sun RPC portmap (required for NFSv3 mounts) |
+| 2049 | NFSv3 / NFSv4 |
+| 445  | SMB2 / SMB3 |
+| 5000 | S3 |
+| 8080 | Admin REST API |
+| 9000 | Prometheus metrics |
+
+From the host:
+
+```bash
+mount -t nfs localhost:/export /mnt/export
+mount -t nfs localhost:/memfs  /mnt/memfs
+
+mount -t cifs //localhost/export /mnt/export -o guest
+mount -t cifs //localhost/memfs  /mnt/memfs  -o guest
+
+aws --endpoint-url http://localhost:5000 s3 ls s3://export/
+aws --endpoint-url http://localhost:5000 s3 ls s3://memfs/
+
+curl http://localhost:8080/api/v1/exports
+curl http://localhost:9000/metrics
+```
+
+## Overriding the bundled config
+
+To run with a custom configuration, bind-mount your own file over
+`/usr/local/etc/chimera.json`:
+
+```bash
+docker run --rm -it \
+    -v "$(pwd)/chimera.json":/usr/local/etc/chimera.json:ro \
+    -v "$(pwd)/export":/export \
+    -p 111:111 -p 2049:2049 -p 445:445 -p 5000:5000 -p 8080:8080 -p 9000:9000 \
+    ghcr.io/chimera-nas/chimera:latest
+```
+
+A minimal example that exports a single in-memory filesystem over NFS at
+`/mnt`, with RDMA enabled:
+
+```json
+{
+    "server": {
+        "threads": 32,
+        "delegation_threads": 32,
+        "preallocate_slabs": 8,
+        "preallocate_threads": 4,
+        "max_open_files": 262144,
+        "external_portmap": 0,
+        "rdma": true,
+        "rdma_hostname": "0.0.0.0",
+        "rdma_port": 20049
+    },
+    "mounts": {
+        "memfs": {
+            "module": "memfs",
+            "path": "/"
+        }
+    },
+    "exports": {
+        "/mnt": {
+            "path": "/memfs"
+        }
+    }
+}
 ```
 
 The Dockerfile used to generate this image is in the root of the tree.
@@ -104,3 +193,7 @@ Chimera uses JSON configuration files to define shares and runtime parameters:
     }
 }
 ```
+
+# Questions or feedback?
+
+Come say hi on [Discord](https://discord.gg/hnRkvQFecq) — it's the best place to ask questions, share what you're building, or follow along with development.

--- a/chimera-docker.json
+++ b/chimera-docker.json
@@ -1,0 +1,29 @@
+{
+    "server": {
+        "threads": 4,
+        "delegation_threads": 8,
+        "rest_http_port": 8080
+    },
+    "mounts": {
+        "export": {
+            "module": "linux",
+            "path": "/export"
+        },
+        "memfs": {
+            "module": "memfs",
+            "path": "/"
+        }
+    },
+    "exports": {
+        "/export": { "path": "/export" },
+        "/memfs":  { "path": "/memfs"  }
+    },
+    "shares": {
+        "export": { "path": "/export" },
+        "memfs":  { "path": "/memfs"  }
+    },
+    "buckets": {
+        "export": { "path": "/export" },
+        "memfs":  { "path": "/memfs"  }
+    }
+}

--- a/docs/building.md
+++ b/docs/building.md
@@ -1,0 +1,118 @@
+---
+title: Building from Source
+layout: default
+nav_order: 2
+permalink: /building
+---
+
+# Building from Source
+
+Chimera is built with CMake and Ninja. There are three supported paths,
+roughly in order of convenience:
+
+1. The **devcontainer** at `.devcontainer/` — recommended for development.
+2. A **native build** on a supported Linux host, using the per-OS Dockerfiles
+   in the repository root as a reference for required packages.
+3. The **top-level Makefile**, which wraps the CMake invocations for both
+   devcontainer and native workflows.
+
+## Using the devcontainer
+
+The repository ships a [development container](https://containers.dev/) at
+`.devcontainer/` configured for VS Code and Cursor. It is the easiest way to
+get a working build environment because every dependency, including optional
+ones like XLIO and FIO, is preinstalled.
+
+To use it:
+
+1. Open the repository in VS Code or Cursor with the Dev Containers extension
+   installed.
+2. When prompted, choose **Reopen in Container**. The container is built from
+   `.devcontainer/Dockerfile` on first launch.
+3. The repository is mounted read-write at `/chimera` and used as the
+   workspace root.
+
+Inside the container, the build directory defaults to `/build` (set via
+`CHIMERA_BUILD_DIR=/build` in `devcontainer.json`) so that build outputs live
+on a docker volume rather than the source bind mount.
+
+The devcontainer is `privileged: true` and ships with KVM, Docker-in-Docker,
+Samba, MIT Kerberos, and FIO available, which is enough to run the full test
+matrix locally.
+
+## Reference Dockerfiles per OS
+
+In addition to the runtime `Dockerfile` (which produces the published
+`ghcr.io/chimera-nas/chimera` image), the repository root contains a set of
+per-OS Dockerfiles whose `apt`/`dnf` invocations enumerate the dependencies
+required to build chimera on each platform:
+
+| File                       | Base image           |
+|----------------------------|----------------------|
+| `Dockerfile.ubuntu22.04`   | `ubuntu:22.04`       |
+| `Dockerfile.ubuntu24.04`   | `ubuntu:24.04`       |
+| `Dockerfile.ubuntu26.04`   | `ubuntu:26.04`       |
+| `Dockerfile.rocky9`        | `rockylinux:9`       |
+| `Dockerfile.rocky10`       | `rockylinux:10`      |
+
+These are not meant to produce the final runtime image; they exist as
+authoritative, CI-tested package lists for each distribution. If you are
+building chimera natively on Ubuntu 24.04, for example, the package list in
+the first `RUN apt-get install` block of `Dockerfile.ubuntu24.04` is the
+canonical reference. The same applies to the `dnf install` block in the
+Rocky Linux variants.
+
+## The top-level Makefile
+
+The `Makefile` at the repository root is a thin wrapper over CMake and Ninja.
+It picks a build directory automatically — `/build` when the source tree is
+at `/chimera` (devcontainer convention), and `./build` everywhere else — and
+exposes the targets you'll typically use.
+
+### Build and test
+
+```bash
+make                # default: build_debug
+make release        # build_release + test_release
+make debug          # build_debug + test_debug
+
+make build_release  # release build, no tests
+make build_debug    # debug build, no tests
+make test_release   # ctest on the release build
+make test_debug     # ctest on the debug build
+```
+
+The debug build enables AddressSanitizer; the release build is what CI ships
+and what the published container image runs.
+
+Build outputs land under `${CHIMERA_BUILD_DIR}/Release` or
+`${CHIMERA_BUILD_DIR}/Debug`. You can rebuild incrementally without going
+through `make` by running `ninja -C build/Release` (or `build/Debug`)
+directly.
+
+### Code quality
+
+```bash
+make syntax         # auto-format all C sources with uncrustify
+make syntax-check   # verify formatting without modifying files
+make check          # run the full CI check matrix locally
+```
+
+`make check` runs syntax-check, both release and debug builds and their test
+suites, Clang static analysis (`scan-build`), the REUSE / SPDX license lint,
+and the copyright-year check. Passing `make check` locally is sufficient to
+clear the equivalent CI gates.
+
+### Other targets
+
+```bash
+make clean          # remove all build outputs under ${CHIMERA_BUILD_DIR}
+make copyright      # update copyright years on files changed vs. main
+make reuse-lint     # check SPDX license headers
+make docs           # print pointers to the API docs and OpenAPI spec
+```
+
+The `BASE` variable controls the diff base for `make copyright` and
+`make copyright-check` (default `main`); override it with
+`make copyright BASE=origin/main` when working on a feature branch with a
+different upstream.

--- a/docs/community.md
+++ b/docs/community.md
@@ -1,7 +1,7 @@
 ---
 title: Community
 layout: default
-nav_order: 2
+nav_order: 3
 permalink: /community
 ---
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,120 @@
+---
+title: Quick Start
+layout: default
+nav_order: 1
+permalink: /quickstart
+---
+
+# Quick Start
+
+The fastest way to try chimera is the prebuilt container image published by CI
+to `ghcr.io`. The image ships with a working default config that exports two
+filesystems out of the box:
+
+| Mount    | Backend | Description                                        |
+|----------|---------|----------------------------------------------------|
+| `/export`| `linux` | A bind-mount target inside the container. Mount any host directory here to serve files from disk. |
+| `/memfs` | `memfs` | An in-memory filesystem. Useful for smoke tests and benchmarking; contents do not persist across restarts. |
+
+Each is published as an NFS export, an SMB share, and an S3 bucket
+simultaneously.
+
+## Run the server
+
+```bash
+mkdir -p ./export
+docker run --rm -it \
+    -v "$(pwd)/export":/export \
+    -p 111:111 -p 2049:2049 \
+    -p 445:445 \
+    -p 5000:5000 \
+    -p 8080:8080 \
+    -p 9000:9000 \
+    ghcr.io/chimera-nas/chimera:latest
+```
+
+The ports map as follows:
+
+| Port | Protocol                                            |
+|------|-----------------------------------------------------|
+| 111  | Sun RPC portmap (required for NFSv3 mounts)         |
+| 2049 | NFSv3 / NFSv4                                       |
+| 445  | SMB2 / SMB3                                         |
+| 5000 | S3                                                  |
+| 8080 | Admin REST API                                      |
+| 9000 | Prometheus metrics                                  |
+
+> **Warning:** Chimera binds the standard NFS, SMB, and Sun RPC portmap ports.
+> If the host is already running `rpcbind`, `nfs-server`, `smbd`, or any other
+> service on ports 111, 2049, or 445, either stop them or remap chimera to
+> different host ports (e.g. `-p 12049:2049`).
+
+## Connect a client
+
+From another shell on the same host:
+
+```bash
+# NFS
+mount -t nfs localhost:/export /mnt/export
+mount -t nfs localhost:/memfs  /mnt/memfs
+
+# SMB
+mount -t cifs //localhost/export /mnt/export -o guest
+mount -t cifs //localhost/memfs  /mnt/memfs  -o guest
+
+# S3
+aws --endpoint-url http://localhost:5000 s3 ls s3://export/
+aws --endpoint-url http://localhost:5000 s3 ls s3://memfs/
+
+# Admin REST API
+curl http://localhost:8080/api/v1/exports
+
+# Metrics
+curl http://localhost:9000/metrics
+```
+
+## Overriding the bundled config
+
+Chimera is configured via a JSON file at `/usr/local/etc/chimera.json` inside
+the container. To run with your own config, bind-mount over it:
+
+```bash
+docker run --rm -it \
+    -v "$(pwd)/chimera.json":/usr/local/etc/chimera.json:ro \
+    -v "$(pwd)/export":/export \
+    -p 111:111 -p 2049:2049 -p 445:445 -p 5000:5000 -p 8080:8080 -p 9000:9000 \
+    ghcr.io/chimera-nas/chimera:latest
+```
+
+A minimal example exporting a single in-memory filesystem over NFS at `/mnt`,
+with RDMA enabled:
+
+```json
+{
+    "server": {
+        "threads": 32,
+        "delegation_threads": 32,
+        "preallocate_slabs": 8,
+        "preallocate_threads": 4,
+        "max_open_files": 262144,
+        "external_portmap": 0,
+        "rdma": true,
+        "rdma_hostname": "0.0.0.0",
+        "rdma_port": 20049
+    },
+    "mounts": {
+        "memfs": {
+            "module": "memfs",
+            "path": "/"
+        }
+    },
+    "exports": {
+        "/mnt": {
+            "path": "/memfs"
+        }
+    }
+}
+```
+
+The full set of `server` parameters, VFS modules, and protocol options is
+covered in the project README and source.


### PR DESCRIPTION
## Summary

- Bundle a default `chimera.json` into the published docker image that mounts `/export` (linux backend) and `/memfs` (memfs backend), and exposes both as NFS exports, SMB shares, and S3 buckets — so the image is mountable out of the box.
- Create `/export` in the image as a stable bind-mount target.
- Rewrite the README's Docker section with the required port mappings (111, 2049, 445, 5000, 9000), no-frills mount examples for NFS/SMB/S3/metrics, a warning about conflicting host `rpcbind`/`nfs-server`/`smbd`, and a subsection showing how to override the bundled config with a working RDMA example.