### PR TITLE
cthon_lock_tlock: shut down chimera client in child before exit

### DIFF
--- a/src/posix/tests/cthon_lock_tlock.c
+++ b/src/posix/tests/cthon_lock_tlock.c
@@ -663,6 +663,8 @@ main(
 
     if (who == CHILD) {
         childwait();
+        posix_test_umount();
+        chimera_posix_shutdown();
     } else {
         signal(SIGCHLD, SIG_DFL);
         childfree(0);


### PR DESCRIPTION
## Summary

- Fixes the intermittent `chimera/posix/cthon/cthon_lock_tlock_linux` timeout seen in CI.
- The fork()ed child of `cthon_lock_tlock` returned from `main()` without ever calling `posix_test_umount()` / `chimera_posix_shutdown()`, so its chimera worker threads were still alive when the atexit-registered `evpl_cleanup()` ran. That race produced the "leaked references" messages from `evpl_allocator_destroy` and an ASAN SEGV at offset `0x28` (`evpl_shared->config`); the parent then hung in its own shutdown.
- The fix mirrors the cleanup pattern already used by the sibling fork-based tests `test_lockf.c` and `test_fcntl.c`: after the child's final `childwait()`, `posix_test_umount()` and `chimera_posix_shutdown()` before returning.