### PR TITLE
cairn: raise RocksDB transaction lock timeout to 30s

### DIFF
--- a/src/vfs/cairn/cairn.c
+++ b/src/vfs/cairn/cairn.c
@@ -623,6 +623,13 @@ cairn_init(const char *cfgdata)
     shared->read_options  = rocksdb_readoptions_create();
     shared->txn_options   = rocksdb_transaction_options_create();
 
+    /* RocksDB's default per-key lock timeout is 1s. Under contended workloads
+     * (e.g. many threads touching the same parent directory inode) a holder
+     * can easily slip past 1s during compactions or slow fsyncs, causing
+     * waiters to fail with "Timeout waiting to lock key" — which cairn treats
+     * as fatal. Raise the ceiling so contention stalls briefly instead. */
+    rocksdb_transactiondb_options_set_transaction_lock_timeout(shared->txndb_options, 30000);
+
     shared->db_txn = rocksdb_transactiondb_open(shared->options, shared->txndb_options, db_path, &err);
 
     chimera_cairn_abort_if(err, "Failed to open database: %s\n", err);


### PR DESCRIPTION
## Summary
- RocksDB's default per-key transaction lock timeout is 1s. Cairn keeps a long-lived per-thread transaction (committed via deferral on the next event-loop tick) and treats every RocksDB error as fatal, so any single batch that holds a write lock for more than 1s aborts the daemon — every other delegation thread waiting on the same key crashes with `Timeout waiting to lock key`.
- This surfaces as an intermittent failure on stress tests that hammer one directory's inode from multiple threads (xfstests `nametest_cairn` over SMB, in the failure I was triaging), where a slow fsync or compaction stall is enough to slip the holder past 1s. 4 threads crash simultaneously at `src/vfs/cairn/cairn.c:299`, all within ~0.4 ms.
- This PR sets `transaction_lock_timeout` to 30 s so contention causes a brief stall instead of a crash. The deeper fix (commit more aggressively, or move hot paths to optimistic transactions) can come later.