### PR TITLE
kvm: share Dockerfile.kvm buildx cache across CI jobs

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -80,7 +80,7 @@ RUN apt-get -y update && \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu resolute stable" \
         > /etc/apt/sources.list.d/docker.list && \
     apt-get -y update && \
-    apt-get -y --no-install-recommends install docker-ce docker-ce-cli containerd.io && \
+    apt-get -y --no-install-recommends install docker-ce docker-ce-cli containerd.io docker-buildx-plugin && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -21,6 +21,7 @@ env:
   U22_IMAGE_TAG_PREFIX: repository.mdh.quantum.com:5004/cache/chimera-ubuntu22
   R9_IMAGE_TAG_PREFIX: repository.mdh.quantum.com:5004/cache/chimera-rocky9
   R10_IMAGE_TAG_PREFIX: repository.mdh.quantum.com:5004/cache/chimera-rocky10
+  KVM_IMAGE_CACHE_REGISTRY: repository.mdh.quantum.com:5004/cache
   APT_MIRROR: http://repository.mdh.quantum.com/repository/pkgs/ubuntu
   DOCKER_MIRROR: repository.mdh.quantum.com/
 
@@ -405,7 +406,7 @@ jobs:
             bash -euxc '\
               dockerd --storage-driver=vfs --registry-mirror=https://repository.mdh.quantum.com:5001 &>/dev/null &
               sleep 2 && \
-              cmake -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ${{ matrix.cmake_extra }} /workspace && \
+              cmake -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DKVM_IMAGE_CACHE_REGISTRY=${{ env.KVM_IMAGE_CACHE_REGISTRY }} ${{ matrix.cmake_extra }} /workspace && \
               ninja && \
               /workspace/scripts/cap_ctest_output.sh \
               ctest --output-on-failure --test-output-size-failed 65536 --timeout 300 -j 32'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,6 +16,7 @@ env:
   U22_IMAGE_TAG_PREFIX: repository.mdh.quantum.com:5004/cache/chimera-ubuntu22
   R9_IMAGE_TAG_PREFIX: repository.mdh.quantum.com:5004/cache/chimera-rocky9
   R10_IMAGE_TAG_PREFIX: repository.mdh.quantum.com:5004/cache/chimera-rocky10
+  KVM_IMAGE_CACHE_REGISTRY: repository.mdh.quantum.com:5004/cache
   APT_MIRROR: http://repository.mdh.quantum.com/repository/pkgs/ubuntu
   DOCKER_MIRROR: repository.mdh.quantum.com/
 
@@ -485,7 +486,7 @@ jobs:
             bash -euxc '\
               dockerd --storage-driver=vfs --registry-mirror=https://repository.mdh.quantum.com:5001 &>/dev/null &
               sleep 2 && \
-              cmake -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ${{ matrix.cmake_extra }} /workspace && \
+              cmake -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DKVM_IMAGE_CACHE_REGISTRY=${{ env.KVM_IMAGE_CACHE_REGISTRY }} ${{ matrix.cmake_extra }} /workspace && \
               ninja && \
               /workspace/scripts/cap_ctest_output.sh \
               ctest --output-on-failure --test-output-size-failed 65536 --timeout 300 -j 32'

--- a/kvm/CMakeLists.txt
+++ b/kvm/CMakeLists.txt
@@ -6,6 +6,12 @@
 # above the per-configuration build dirs (e.g. build/kvm/ alongside build/Release/).
 get_filename_component(BUILD_ROOT ${CMAKE_BINARY_DIR} DIRECTORY)
 
+# Optional registry root used as cache-from/cache-to for the inner
+# Dockerfile.kvm docker buildx build. When empty, build_vm_image.sh falls
+# back to a plain `docker build` (local cache only).
+set(KVM_IMAGE_CACHE_REGISTRY "" CACHE STRING
+    "Registry root (e.g. host:port/path) for sharing the inner KVM image buildx cache. Empty disables it.")
+
 set(KVM_IMAGES
     "ubuntu2404|24.04|noble|linux-image-generic"
     "ubuntu2404_hwe|24.04|noble|linux-image-generic-hwe-24.04"
@@ -24,7 +30,9 @@ foreach(image_spec ${KVM_IMAGES})
 
     add_custom_command(
         OUTPUT ${IMAGE_DIR}/vmlinuz ${IMAGE_DIR}/initrd ${IMAGE_DIR}/rootfs.qcow2
-        COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/build_vm_image.sh
+        COMMAND ${CMAKE_COMMAND} -E env
+                KVM_CACHE_REGISTRY=${KVM_IMAGE_CACHE_REGISTRY}
+                bash ${CMAKE_CURRENT_SOURCE_DIR}/build_vm_image.sh
                 ${IMAGE_DIR}
                 ${CMAKE_CURRENT_SOURCE_DIR}/Dockerfile.kvm
                 ${CMAKE_SOURCE_DIR}

--- a/kvm/build_vm_image.sh
+++ b/kvm/build_vm_image.sh
@@ -21,15 +21,48 @@ done
 
 echo "Building VM image: ${IMAGE_TAG}"
 
-set -x
-docker build \
-    ${DOCKER_MIRROR:+--build-arg DOCKER_MIRROR=$DOCKER_MIRROR} \
-    ${APT_MIRROR:+--build-arg APT_MIRROR=$APT_MIRROR} \
-    ${BUILD_ARGS} \
-    -t "$IMAGE_TAG" \
-    -f "$DOCKERFILE" \
-    "$SOURCE_DIR"
-set +x
+# If KVM_CACHE_REGISTRY is set, use docker buildx with a registry-backed
+# cache so the (expensive) inner Dockerfile.kvm build can share layers across
+# CI jobs. Without it, fall back to a plain local-cache `docker build`.
+if [ -n "${KVM_CACHE_REGISTRY:-}" ]; then
+    case "$(uname -m)" in
+        x86_64)  CACHE_ARCH=amd64 ;;
+        aarch64) CACHE_ARCH=arm64 ;;
+        *)       CACHE_ARCH=$(uname -m) ;;
+    esac
+    CACHE_REF="${KVM_CACHE_REGISTRY}/${IMAGE_TAG}:${CACHE_ARCH}"
+
+    # cache-to=type=registry,mode=max requires the docker-container driver;
+    # the default "docker" driver only supports inline cache. Create the
+    # builder lazily and reuse it across the 4 KVM image targets.
+    if ! docker buildx inspect chimera-kvm-builder >/dev/null 2>&1; then
+        docker buildx create --name chimera-kvm-builder --driver docker-container >/dev/null
+    fi
+
+    set -x
+    docker buildx build \
+        --builder chimera-kvm-builder \
+        ${DOCKER_MIRROR:+--build-arg DOCKER_MIRROR=$DOCKER_MIRROR} \
+        ${APT_MIRROR:+--build-arg APT_MIRROR=$APT_MIRROR} \
+        ${BUILD_ARGS} \
+        --cache-from "type=registry,ref=${CACHE_REF}" \
+        --cache-to "type=registry,ref=${CACHE_REF},mode=max,image-manifest=true,ignore-error=true" \
+        --load \
+        -t "$IMAGE_TAG" \
+        -f "$DOCKERFILE" \
+        "$SOURCE_DIR"
+    set +x
+else
+    set -x
+    docker build \
+        ${DOCKER_MIRROR:+--build-arg DOCKER_MIRROR=$DOCKER_MIRROR} \
+        ${APT_MIRROR:+--build-arg APT_MIRROR=$APT_MIRROR} \
+        ${BUILD_ARGS} \
+        -t "$IMAGE_TAG" \
+        -f "$DOCKERFILE" \
+        "$SOURCE_DIR"
+    set +x
+fi
 
 CONTAINER_ID=$(docker create "$IMAGE_TAG")
 

--- a/kvm/build_vm_image.sh
+++ b/kvm/build_vm_image.sh
@@ -34,10 +34,15 @@ if [ -n "${KVM_CACHE_REGISTRY:-}" ]; then
 
     # cache-to=type=registry,mode=max requires the docker-container driver;
     # the default "docker" driver only supports inline cache. Create the
-    # builder lazily and reuse it across the 4 KVM image targets.
-    if ! docker buildx inspect chimera-kvm-builder >/dev/null 2>&1; then
-        docker buildx create --name chimera-kvm-builder --driver docker-container >/dev/null
-    fi
+    # builder lazily and reuse it across the 4 KVM image targets. Ninja
+    # runs those targets in parallel, so serialize the create with flock to
+    # avoid concurrent `buildx create` calls colliding on the same name.
+    (
+        flock -x 9
+        if ! docker buildx inspect chimera-kvm-builder >/dev/null 2>&1; then
+            docker buildx create --name chimera-kvm-builder --driver docker-container >/dev/null
+        fi
+    ) 9>/tmp/chimera-kvm-builder.lock
 
     set -x
     docker buildx build \


### PR DESCRIPTION
## Summary

- Inner `docker build` in `kvm/build_vm_image.sh` rebuilt all four KVM rootfs images from scratch on every devcontainer Test job (no cache-from/cache-to, legacy builder). This was ~5 minutes of wall-clock per job that the outer image-layer cache could not help with — most of which was `apt-get install` of a full Ubuntu kernel + `update-initramfs`.
- New optional CMake variable `KVM_IMAGE_CACHE_REGISTRY`: when set, `build_vm_image.sh` lazily creates a reusable `docker-container` buildx builder and runs `docker buildx build --cache-from type=registry,ref=… --cache-to type=registry,ref=…,mode=max,image-manifest=true,ignore-error=true --load`. Cache refs land at `<registry>/<image-tag>:<arch>` (arch derived from `uname -m`), mirroring the outer image-cache naming. When the variable is unset, the original `docker build` path is preserved.
- `docker-buildx-plugin` added to the devcontainer image so `docker buildx` is available inside the test container.
- Both `build-test.yml` and `nightly.yml` set `KVM_IMAGE_CACHE_REGISTRY: repository.mdh.quantum.com:5004/cache` (same root as the outer image cache) and pass `-DKVM_IMAGE_CACHE_REGISTRY=${{ env.KVM_IMAGE_CACHE_REGISTRY }}` into the inner cmake. The `-D` is harmless on non-devcontainer Test jobs because `kvm/` is only `add_subdirectory`'d when docker + qemu + `/dev/kvm` are all present.

Notes:
- First run after merge: the devcontainer image will rebuild once to pick up `docker-buildx-plugin` (~30s one-off), then the cache warms.
- First inner KVM build is a cold miss that populates the cache; subsequent jobs hit it.
- `cache-to` uses `ignore-error=true` so a registry-write failure (e.g. auth) degrades to a non-cached build instead of failing the job.