### PR TITLE
smb: implement SET_INFO FilePositionInformation (class 14)

### DIFF
--- a/src/server/smb/smb_attr.h
+++ b/src/server/smb/smb_attr.h
@@ -27,6 +27,7 @@
 #define SMB_ATTR_ACCESS_FLAGS       (1ULL << 11)
 #define SMB_ATTR_REPARSE_TAG        (1ULL << 12)
 #define SMB_ATTR_DISPOSITION        (1ULL << 13)
+#define SMB_ATTR_POSITION           (1ULL << 14)
 
 /* Masks for each information class */
 #define SMB_ATTR_MASK_BASIC         ( \
@@ -76,6 +77,9 @@ struct chimera_smb_attrs {
     uint32_t smb_compression_unit_size; /* Compression unit size */
 
     uint8_t  smb_disposition; /* Disposition */
+
+    /* FilePositionInformation fields */
+    uint64_t smb_position;     /* Current byte offset */
 
     /* Bitmap of populated attributes */
     uint64_t smb_attr_mask;
@@ -392,6 +396,15 @@ chimera_smb_parse_disposition_info_ex(
     attrs->smb_disposition = (flags & 0x01) ? 1 : 0;
     attrs->smb_attr_mask  |= SMB_ATTR_DISPOSITION;
 } /* chimera_smb_parse_disposition_info_ex */
+
+static inline void
+chimera_smb_parse_position_info(
+    struct evpl_iovec_cursor *cursor,
+    struct chimera_smb_attrs *attrs)
+{
+    evpl_iovec_cursor_get_uint64(cursor, &attrs->smb_position);
+    attrs->smb_attr_mask |= SMB_ATTR_POSITION;
+} /* chimera_smb_parse_position_info */
 
 static inline void
 chimera_smb_parse_end_of_file_info(

--- a/src/server/smb/smb_proc_set_info.c
+++ b/src/server/smb/smb_proc_set_info.c
@@ -236,6 +236,11 @@ chimera_smb_set_info(struct chimera_smb_request *request)
                     chimera_smb_open_file_release(request, request->set_info.open_file);
                     chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
                     break;
+                case SMB2_FILE_POSITION_INFO:
+                    request->set_info.open_file->position = request->set_info.attrs.smb_position;
+                    chimera_smb_open_file_release(request, request->set_info.open_file);
+                    chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
+                    break;
                 default:
                     chimera_smb_error("SET_INFO info_class %u not implemented", request->set_info.info_class);
                     chimera_smb_open_file_release(request, request->set_info.open_file);
@@ -313,6 +318,9 @@ chimera_smb_parse_set_info(
                     break;
                 case SMB2_FILE_FULL_EA_INFO:
                     /* EAs not supported, accept and ignore */
+                    break;
+                case SMB2_FILE_POSITION_INFO:
+                    chimera_smb_parse_position_info(request_cursor, &request->set_info.attrs);
                     break;
 
                 default:


### PR DESCRIPTION
## Summary

Add parse and process handlers for `SMB2_FILE_POSITION_INFO` (info class 0x0E / 14), which carries a single 8-byte `current_byte_offset` the client uses to update the per-handle file position.

Previously requests of this class were rejected with `NT_STATUS_NOT_IMPLEMENTED`, blocking `smb2.replay.replay-commands` and other smbtorture tests that exercise the standard set/get position round-trip.