### PR TITLE
memfs: fix readlink SEGV, rename deadlock, and SETATTR(SIZE) type check

### DIFF
--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -913,6 +913,23 @@ memfs_setattr(
         return;
     }
 
+    /* SETATTR(SIZE) is only meaningful for regular files. RFC 7530 §5.7:
+     * directories must report ISDIR; symlinks should report SYMLINK or
+     * INVAL; other non-regular file types report INVAL. */
+    if ((attr->va_set_mask & CHIMERA_VFS_ATTR_SIZE) &&
+        !S_ISREG(inode->mode)) {
+        enum chimera_vfs_error err;
+        if (S_ISDIR(inode->mode)) {
+            err = CHIMERA_VFS_EISDIR;
+        } else {
+            err = CHIMERA_VFS_EINVAL;
+        }
+        pthread_mutex_unlock(&inode->lock);
+        request->status = err;
+        request->complete(request);
+        return;
+    }
+
     memfs_map_attrs(shared, &request->setattr.r_pre_attr, inode, request->fh);
 
     /* Handle truncation: free blocks past new EOF and zero partial block */
@@ -3171,6 +3188,13 @@ memfs_readlink(
         return;
     }
 
+    if (!S_ISLNK(inode->mode)) {
+        pthread_mutex_unlock(&inode->lock);
+        request->status = CHIMERA_VFS_EINVAL;
+        request->complete(request);
+        return;
+    }
+
     request->readlink.r_target_length = inode->symlink.target->length;
 
     memcpy(request->readlink.r_target,
@@ -3259,7 +3283,14 @@ memfs_rename_at(
                                                   request->fh_len);
         }
 
+        /* Cross-directory rename: both parent inodes are locked at this
+         * point (or NULL on lookup miss). Every early-return below must
+         * release whichever locks are still held, or the next request
+         * touching the unreleased inode will deadlock. */
         if (!old_parent_inode) {
+            if (new_parent_inode) {
+                pthread_mutex_unlock(&new_parent_inode->lock);
+            }
             request->status = CHIMERA_VFS_ENOENT;
             request->complete(request);
             return;
@@ -3267,12 +3298,16 @@ memfs_rename_at(
 
         if (!S_ISDIR(old_parent_inode->mode)) {
             pthread_mutex_unlock(&old_parent_inode->lock);
+            if (new_parent_inode) {
+                pthread_mutex_unlock(&new_parent_inode->lock);
+            }
             request->status = CHIMERA_VFS_ENOTDIR;
             request->complete(request);
             return;
         }
 
         if (!new_parent_inode) {
+            pthread_mutex_unlock(&old_parent_inode->lock);
             request->status = CHIMERA_VFS_ENOENT;
             request->complete(request);
             return;
@@ -3280,6 +3315,7 @@ memfs_rename_at(
 
         if (!S_ISDIR(new_parent_inode->mode)) {
             pthread_mutex_unlock(&new_parent_inode->lock);
+            pthread_mutex_unlock(&old_parent_inode->lock);
             request->status = CHIMERA_VFS_ENOTDIR;
             request->complete(request);
             return;


### PR DESCRIPTION
## Summary

Three independent correctness bugs in `memfs` surface as catastrophic failures (process crash or daemon hang) under the pynfs test suite.

**`memfs_readlink` SEGV on non-symlink inodes.** The function unconditionally dereferences `inode->symlink.target` without checking inode type. For any non-symlink, the tagged union holds the `dir` or `file` variant and those bytes are reinterpreted as a stale pointer, producing a SIGSEGV inside the worker thread on the first non-NULL deref. Pynfs's `readlink.testSocket` reliably triggers this. Adds an `S_ISLNK(inode->mode)` check; non-symlinks now return `EINVAL`, which maps to `NFS4ERR_INVAL` as the spec requires.

**`memfs_rename_at` lock leak / daemon deadlock.** `memfs_inode_get_inum` returns inodes already locked. In the cross-directory branch (`cmp != 0`) both parent locks are acquired, but the four early-return error paths (lookup miss and `!S_ISDIR` for each side) only release one of the two. A rename whose source FH is a non-directory leaks the other lock and every subsequent request touching that inode deadlocks; the daemon also fails to respond to SIGTERM cleanly. Releases both locks (when held) on every early-error path.

**`memfs_setattr` accepts SETATTR(SIZE) on non-regular files.** RFC 7530 §5.7 requires `NFS4ERR_ISDIR` for directories and `NFS4ERR_INVAL` for other non-regular file types; chimera was silently setting `inode->size` on them. Returns `EISDIR`/`EINVAL` before the truncate logic runs.

## Background

Found while running the pynfs test suite on the `pynfs` integration branch. Without these fixes:

- `readlink.testSocket` SEGVs the daemon (hits the wrapper's wall-clock timeout because pynfs hangs on the dead socket).
- `rename.testSfhLink`/`testSfhChar`/`testSfhSocket`/etc. deadlock the daemon (SIGTERM also blocks).
- `setattr.testSizeDir`/`testSizeSocket`/etc. silently succeed where they should fail.

After the fix, the `readlink` and `rename` pynfs ctest entries go from hung-then-timeout to fully green (8/8 and 37/37 respectively), and `setattr.testSize*` for all 6 non-regular file types pass.