### PR TITLE
smb: set SE_DACL_AUTO_INHERITED on synthetic security descriptors

### DIFF
--- a/src/server/smb/smb_proc_security.c
+++ b/src/server/smb/smb_proc_security.c
@@ -25,6 +25,7 @@
 /* Security descriptor control flags */
 #define SE_SELF_RELATIVE           0x8000
 #define SE_DACL_PRESENT            0x0004
+#define SE_DACL_AUTO_INHERITED     0x0400
 
 /* Size of a SID with 3 sub-authorities: S-1-5-88-X-Y */
 #define SID_UNIX_SIZE              20 /* 1+1+6+3*4 */
@@ -279,7 +280,7 @@ chimera_smb_query_security_reply(
     memset(sd, 0, sizeof(sd));
 
     if (has_dacl) {
-        control |= SE_DACL_PRESENT;
+        control |= SE_DACL_PRESENT | SE_DACL_AUTO_INHERITED;
     }
 
     /* Build security descriptor: header, then DACL, owner, group */


### PR DESCRIPTION
## Summary

Windows clients and the Samba `acls` smbtorture suite expect every DACL produced by the server to carry the `SE_DACL_AUTO_INHERITED` (0x0400) control bit, indicating that the ACL inheritance has been processed. Chimera's synthetic SD only set `SE_DACL_PRESENT`, which made `smb2.acls_non_canonical.flags` fail immediately.

Add `SE_DACL_AUTO_INHERITED` to the control word whenever a DACL is included in the response. Unblocks the `smb2.acls_non_canonical` smbtorture suite (currently the entire suite fails at this first assertion).