### PR TITLE
smb: reject CREATE requests with stream-name syntax

### DIFF
--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -693,6 +693,15 @@ chimera_smb_create(struct chimera_smb_request *request)
     enum chimera_smb_pipe_magic   pipe_magic;
     chimera_smb_pipe_transceive_t transceive;
 
+    /* Reject stream-name syntax (file:stream[:$DATA]) — streams unsupported.
+     * Done here rather than in parse so the OBJECT_NAME_INVALID response is
+     * returned to the client instead of triggering a parse-error disconnect. */
+    if (request->create.name_len > 0 &&
+        memchr(request->create.name, ':', request->create.name_len)) {
+        chimera_smb_complete_request(request, SMB2_STATUS_OBJECT_NAME_INVALID);
+        return;
+    }
+
     if (request->tree->type == CHIMERA_SMB_TREE_TYPE_PIPE) {
 
         if (strcasecmp(request->create.name, "lsarpc") == 0) {


### PR DESCRIPTION
## Summary

SMB2 alternate data streams use a colon in the path component (`file:stream` or `file:stream:\$DATA`). Chimera doesn't implement streams, so any such name should be rejected with `NT_STATUS_OBJECT_NAME_INVALID` rather than silently passed through to the VFS layer (which currently returns `OBJECT_NAME_NOT_FOUND`).

The check lives in `chimera_smb_create` rather than the parser so the `OBJECT_NAME_INVALID` response is delivered to the client instead of triggering the parse-error connection-drop path.

Unblocks `smb2.create_no_streams.no_stream` in smbtorture.