### PR TITLE
memfs: return ENOTDIR when CHIMERA_VFS_OPEN_DIRECTORY targets a non-dir

### DIFF
--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -1837,6 +1837,14 @@ memfs_open_at(
         }
     }
 
+    if ((flags & CHIMERA_VFS_OPEN_DIRECTORY) && !S_ISDIR(inode->mode)) {
+        pthread_mutex_unlock(&inode->lock);
+        pthread_mutex_unlock(&parent_inode->lock);
+        request->status = CHIMERA_VFS_ENOTDIR;
+        request->complete(request);
+        return;
+    }
+
     if (flags & CHIMERA_VFS_OPEN_INFERRED) {
         /* If this is an inferred open (ie an NFS3 create)
          * then we aren't returning a handle so we don't need


### PR DESCRIPTION
## Summary

When a caller (SMB2 CREATE with `FILE_DIRECTORY_FILE`, NFSv4 OPEN with claim variants, etc.) requests an open with the `CHIMERA_VFS_OPEN_DIRECTORY` flag and the resolved entry is a regular file, `memfs_open_at` silently succeeded.

Reject this with `CHIMERA_VFS_ENOTDIR` so the protocol layer can map it to `NT_STATUS_NOT_A_DIRECTORY` / `NFS4ERR_NOTDIR`. Brings the `smb2.mkdir` collision-with-file test past its first assert in smbtorture.