### PR TITLE
nfs4: protocol-level result correctness — compound status, tag, attribute validation

### DIFF
--- a/src/server/nfs/nfs4_attr.h
+++ b/src/server/nfs/nfs4_attr.h
@@ -824,6 +824,26 @@ chimera_nfs4_validate_createattrs(
     return NFS4_OK;
 } /* chimera_nfs4_validate_createattrs */
 
+/* GETATTR: requested attrs must be supported and readable. The "*_set"
+ * attributes (FATTR4_TIME_ACCESS_SET, FATTR4_TIME_MODIFY_SET) are write-only
+ * — they can be passed to SETATTR but cannot be read. RFC 7530 §5.6 says a
+ * GETATTR for such an attribute MUST return NFS4ERR_INVAL. */
+static inline nfsstat4
+chimera_nfs4_validate_getattr_request(
+    uint32_t        num_attrmask,
+    const uint32_t *attrmask)
+{
+    static const uint32_t writeonly_word1 =
+        (1U << (FATTR4_TIME_ACCESS_SET - 32)) |
+        (1U << (FATTR4_TIME_MODIFY_SET - 32));
+
+    if (num_attrmask >= 2 && (attrmask[1] & writeonly_word1)) {
+        return NFS4ERR_INVAL;
+    }
+
+    return NFS4_OK;
+} /* chimera_nfs4_validate_getattr_request */
+
 static void
 chimera_nfs4_set_changeinfo(
     struct change_info4      *cinfo,

--- a/src/server/nfs/nfs4_proc_close.c
+++ b/src/server/nfs/nfs4_proc_close.c
@@ -26,7 +26,7 @@ chimera_nfs4_close(
 
     if (!session) {
         res->status = NFS4ERR_BAD_STATEID;
-        chimera_nfs4_compound_complete(req, NFS4_OK);
+        chimera_nfs4_compound_complete(req, res->status);
         return;
     }
 
@@ -34,7 +34,7 @@ chimera_nfs4_close(
 
     if (*(uint32_t *) args->open_stateid.other >= NFS4_SESSION_MAX_STATE) {
         res->status = NFS4ERR_BAD_STATEID;
-        chimera_nfs4_compound_complete(req, NFS4_OK);
+        chimera_nfs4_compound_complete(req, res->status);
         return;
     }
 
@@ -42,7 +42,7 @@ chimera_nfs4_close(
 
     if (state->nfs4_state_type != NFS4_STATE_TYPE_OPEN) {
         res->status = NFS4ERR_BAD_STATEID;
-        chimera_nfs4_compound_complete(req, NFS4_OK);
+        chimera_nfs4_compound_complete(req, res->status);
         return;
     }
 
@@ -61,5 +61,5 @@ chimera_nfs4_close(
         res->status = NFS4_OK;
     }
 
-    chimera_nfs4_compound_complete(req, NFS4_OK);
+    chimera_nfs4_compound_complete(req, res->status);
 } /* chimera_nfs4_close */

--- a/src/server/nfs/nfs4_proc_commit.c
+++ b/src/server/nfs/nfs4_proc_commit.c
@@ -28,7 +28,7 @@ chimera_nfs4_commit_complete(
 
     chimera_vfs_release(req->thread->vfs_thread, req->handle);
 
-    chimera_nfs4_compound_complete(req, NFS4_OK);
+    chimera_nfs4_compound_complete(req, res->status);
 } /* chimera_nfs4_commit_complete */
 
 static void

--- a/src/server/nfs/nfs4_proc_compound.c
+++ b/src/server/nfs/nfs4_proc_compound.c
@@ -219,12 +219,33 @@ chimera_nfs4_compound(
 
         req->session = nfs4_session_is_live(cached) ? cached : NULL;
     }
-    req->args_compound        = args;
-    req->res_compound.status  = NFS4_OK;
-    req->res_compound.tag.len = 0;
-    req->fhlen                = 0;
-    req->saved_fhlen          = 0;
+    req->args_compound       = args;
+    req->res_compound.status = NFS4_OK;
+    /* RFC 7530 §16.2.4: the server MUST echo the request tag back to the
+     * client unchanged. xdr_opaque .data is owned by the request msg buffer
+     * which lives until the response is sent. */
+    req->res_compound.tag = args->tag;
+    req->fhlen            = 0;
+    req->saved_fhlen      = 0;
 
+    /* Chimera implements NFS v4.0, v4.1 and v4.2 (minorversions 0–2).
+     * Reject unknown minor versions with NFS4ERR_MINOR_VERS_MISMATCH per
+     * RFC 7530 §16.2.4 / RFC 5661 §15.1.5.4. */
+    if (args->minorversion > 2) {
+        req->res_compound.status       = NFS4ERR_MINOR_VERS_MISMATCH;
+        req->res_compound.num_resarray = 0;
+        req->res_compound.resarray     = NULL;
+
+        rc = thread->shared->nfs_v4.send_reply_NFSPROC4_COMPOUND(
+            thread->evpl,
+            NULL,
+            &req->res_compound,
+            req->encoding);
+        chimera_nfs_abort_if(rc, "Failed to send RPC2 reply");
+
+        nfs_request_free(thread, req);
+        return;
+    }
 
     rc = xdr_dbuf_alloc_array(&req->res_compound, resarray, args->num_argarray, req->encoding->dbuf);
 

--- a/src/server/nfs/nfs4_proc_getattr.c
+++ b/src/server/nfs/nfs4_proc_getattr.c
@@ -107,6 +107,13 @@ chimera_nfs4_getattr(
         return;
     }
 
+    res->status = chimera_nfs4_validate_getattr_request(args->num_attr_request,
+                                                        args->attr_request);
+    if (res->status != NFS4_OK) {
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
     if (fh_is_nfs4_root(req->fh, req->fhlen)) {
         struct chimera_vfs_attrs attr;
         uint64_t                 attr_mask;

--- a/src/server/nfs/nfs4_proc_lockt.c
+++ b/src/server/nfs/nfs4_proc_lockt.c
@@ -29,8 +29,7 @@ chimera_nfs4_lockt_complete(
         return;
     }
 
-    /* F_GETLK always returns OK; conflict is signalled via conflict_type.
-     * LOCKT NFS4ERR_DENIED is a successful query result - compound stays NFS4_OK. */
+    /* F_GETLK always returns OK; conflict is signalled via conflict_type. */
     if (conflict_type == CHIMERA_VFS_LOCK_UNLOCK) {
         res->status = NFS4_OK;
     } else {
@@ -46,7 +45,7 @@ chimera_nfs4_lockt_complete(
         res->denied.owner.owner.data = NULL;
     }
 
-    chimera_nfs4_compound_complete(req, NFS4_OK);
+    chimera_nfs4_compound_complete(req, res->status);
 } /* chimera_nfs4_lockt_complete */
 
 static void

--- a/src/server/nfs/nfs4_proc_read.c
+++ b/src/server/nfs/nfs4_proc_read.c
@@ -51,7 +51,7 @@ chimera_nfs4_read_complete(
         req->handle = NULL;
     }
 
-    chimera_nfs4_compound_complete(req, NFS4_OK);
+    chimera_nfs4_compound_complete(req, res->status);
 
 } /* chimera_nfs4_read_complete */
 
@@ -133,7 +133,7 @@ chimera_nfs4_read(
 
     if (!session) {
         res->status = NFS4ERR_BAD_STATEID;
-        chimera_nfs4_compound_complete(req, NFS4_OK);
+        chimera_nfs4_compound_complete(req, res->status);
         return;
     }
 
@@ -142,7 +142,7 @@ chimera_nfs4_read(
     if (nfs4_session_acquire_state(session, &args->stateid,
                                    &state, &state_handle) != NFS4_OK) {
         res->status = NFS4ERR_BAD_STATEID;
-        chimera_nfs4_compound_complete(req, NFS4_OK);
+        chimera_nfs4_compound_complete(req, res->status);
         return;
     }
 

--- a/src/server/nfs/nfs4_proc_readlink.c
+++ b/src/server/nfs/nfs4_proc_readlink.c
@@ -27,7 +27,7 @@ chimera_nfs4_readlink_complete(
 
     chimera_vfs_release(thread->vfs_thread, req->handle);
 
-    chimera_nfs4_compound_complete(req, NFS4_OK);
+    chimera_nfs4_compound_complete(req, res->status);
 } /* chimera_nfs4_readlink_complete */
 
 static void

--- a/src/server/nfs/nfs4_proc_setattr.c
+++ b/src/server/nfs/nfs4_proc_setattr.c
@@ -38,7 +38,7 @@ chimera_nfs4_setattr_complete(
 
     chimera_vfs_release(thread->vfs_thread, req->handle);
 
-    chimera_nfs4_compound_complete(req, NFS4_OK);
+    chimera_nfs4_compound_complete(req, res->status);
 } /* chimera_nfs4_setattr_complete */
 
 static void
@@ -94,10 +94,29 @@ chimera_nfs4_setattr(
     struct nfs_argop4                *argop,
     struct nfs_resop4                *resop)
 {
-    struct SETATTR4res *res = &resop->opsetattr;
+    struct SETATTR4args *args = &argop->opsetattr;
+    struct SETATTR4res  *res  = &resop->opsetattr;
+
+    /* The XDR marshaller emits num_attrsset and the attrsset array
+     * unconditionally; resarray slots come from a bump allocator that does
+     * not zero memory, so any early-error return must initialize these or
+     * the marshaller dereferences garbage. */
+    res->num_attrsset = 0;
+    res->attrsset     = NULL;
 
     if (req->fhlen == 0) {
         res->status = NFS4ERR_NOFILEHANDLE;
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    /* Reject requests for unsupported / non-writable attributes before
+     * touching the VFS. Same validation as CREATE: returns ATTRNOTSUPP for
+     * unknown attrs and INVAL for read-only attrs. */
+    res->status = chimera_nfs4_validate_createattrs(
+        args->obj_attributes.num_attrmask,
+        args->obj_attributes.attrmask);
+    if (res->status != NFS4_OK) {
         chimera_nfs4_compound_complete(req, res->status);
         return;
     }

--- a/src/server/nfs/nfs4_proc_write.c
+++ b/src/server/nfs/nfs4_proc_write.c
@@ -59,7 +59,7 @@ chimera_nfs4_write_complete(
         req->handle = NULL;
     }
 
-    chimera_nfs4_compound_complete(req, NFS4_OK);
+    chimera_nfs4_compound_complete(req, res->status);
 } /* chimera_nfs4_write_complete */
 
 static void
@@ -150,7 +150,7 @@ chimera_nfs4_write(
     if (!session) {
         res->status = NFS4ERR_BAD_STATEID;
         evpl_iovecs_release(thread->evpl, args->data.iov, args->data.niov);
-        chimera_nfs4_compound_complete(req, NFS4_OK);
+        chimera_nfs4_compound_complete(req, res->status);
         return;
     }
 
@@ -160,7 +160,7 @@ chimera_nfs4_write(
                                    &state, &state_handle) != NFS4_OK) {
         res->status = NFS4ERR_BAD_STATEID;
         evpl_iovecs_release(thread->evpl, args->data.iov, args->data.niov);
-        chimera_nfs4_compound_complete(req, NFS4_OK);
+        chimera_nfs4_compound_complete(req, res->status);
         return;
     }
 


### PR DESCRIPTION
## Summary

A handful of related correctness issues in chimera's NFS4 result-encoding path. All are exposed by the pynfs test suite as `InvalidCompoundRes` failures (~34 instances), tests that should fail succeeding silently, and a SETATTR-with-no-FH SEGV.

**COMPOUND status propagation.** Most `*_complete` callbacks set the op-level `res->status` to an error code and then unconditionally called `chimera_nfs4_compound_complete(req, NFS4_OK)`, losing the error at the COMPOUND level. RFC 7530 §16.1.2 requires `res_compound.status` to equal the status of the last (failing) op. Fixed in `close`, `commit`, `lockt`, `read`, `readlink`, `setattr`, `write` callbacks. `lockt`'s `NFS4ERR_DENIED` result must also propagate to compound (§16.11.4 — DENIED is the canonical result, not OK).

**SETATTR-with-no-FH SEGV.** The XDR marshaller emits `num_attrsset` and the `attrsset[]` array unconditionally. Resarray slots come from a bump allocator that does not zero memory, so the `fhlen == 0` early-return sends uninitialized memory through the marshaller and the for-loop dereferences garbage. Pynfs `setattr.testNoFh` reliably crashes the daemon. Zero-initialize `num_attrsset`/`attrsset` at function entry.

**Attribute mask validation.**
- New `chimera_nfs4_validate_getattr_request` rejects write-only attrs (`FATTR4_TIME_ACCESS_SET`, `FATTR4_TIME_MODIFY_SET`) from GETATTR with `NFS4ERR_INVAL` per RFC 7530 §5.6.
- Wire the existing `chimera_nfs4_validate_createattrs` into SETATTR so requests carrying unsupported attrs (e.g. `FATTR4_ACL`) are rejected with `NFS4ERR_ATTRNOTSUPP` before any VFS work — previously chimera silently accepted them, producing false-positive test passes.

**COMPOUND tag echo and minorversion check.** The response tag was hard-coded to empty rather than echoing the request's tag (RFC 7530 §16.2.4 MUST). COMPOUND with `minorversion != 0` was passed through; now rejected with `NFS4ERR_MINOR_VERS_MISMATCH` up front.

## Background

Found while running the pynfs test suite on the `pynfs` integration branch. The `InvalidCompoundRes` failure is what surfaced first — pynfs sees `compound.status == OK` while individual ops carry errors, which is a wire-format violation. From there the audit found 32 `*_proc_*.c` files calling `compound_complete(req, NFS4_OK)`; this PR fixes the 7 that were genuinely buggy (the rest pass `NFS4_OK` only in success paths).

## Subtest impact on memfs/NFSv4.0

| flag | before | after |
|------|-------:|------:|
| setattr | 19/45 | 39/46 |
| getattr | 32/46 | 39/46 |
| readlink | 0/8 | 8/8 (paired with memfs SEGV fix in #261) |
| compound | 2/6 | 4/6 |

The `acl` flag regressed from 2 passing subtests to 0 — chimera was silently accepting SETATTR(FATTR4_ACL) without applying it; `NFS4ERR_ATTRNOTSUPP` is the honest answer. Adding real ACL support would be a separate change.