### PR TITLE
nfs4: add stub handlers for PUTPUBFH, RENEW, RELEASE_LOCKOWNER

### DIFF
--- a/src/server/nfs/CMakeLists.txt
+++ b/src/server/nfs/CMakeLists.txt
@@ -25,7 +25,8 @@ add_library(chimera_nfs SHARED nfs.c nfs4_session.c nfs_mount.c nfs_portmap.c nf
             nfs4_proc_secinfo_no_name.c nfs4_proc_test_stateid.c nfs4_root.c
             nfs4_proc_allocate.c nfs4_proc_deallocate.c nfs4_proc_seek.c
             nfs4_proc_lock.c nfs4_proc_lockt.c nfs4_proc_locku.c
-            nfs4_proc_verify.c)
+            nfs4_proc_verify.c
+            nfs4_proc_putpubfh.c nfs4_proc_renew.c nfs4_proc_release_lockowner.c)
 
 target_compile_definitions(chimera_nfs PRIVATE XXH_INLINE_ALL)
 target_link_libraries(chimera_nfs chimera_nfs_common chimera_common evpl evpl_rpc2 pthread uuid urcu urcu-common)

--- a/src/server/nfs/nfs4_proc_compound.c
+++ b/src/server/nfs/nfs4_proc_compound.c
@@ -165,6 +165,15 @@ chimera_nfs4_compound_process(
             case OP_NVERIFY:
                 chimera_nfs4_nverify(thread, req, argop, resop);
                 break;
+            case OP_PUTPUBFH:
+                chimera_nfs4_putpubfh(thread, req, argop, resop);
+                break;
+            case OP_RENEW:
+                chimera_nfs4_renew(thread, req, argop, resop);
+                break;
+            case OP_RELEASE_LOCKOWNER:
+                chimera_nfs4_release_lockowner(thread, req, argop, resop);
+                break;
             default:
                 chimera_nfs_error("Unsupported operation: %d", argop->argop);
                 if (argop->argop >= OP_ACCESS && argop->argop <= OP_CLONE) {

--- a/src/server/nfs/nfs4_proc_putpubfh.c
+++ b/src/server/nfs/nfs4_proc_putpubfh.c
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "nfs4_procs.h"
+#include "vfs/vfs.h"
+
+/* RFC 7530 §16.21: PUTPUBFH sets the current FH to the server's "public"
+ * filehandle. Chimera does not distinguish a separate public namespace from
+ * the root namespace, so PUTPUBFH is a synonym for PUTROOTFH. */
+void
+chimera_nfs4_putpubfh(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_request               *req,
+    struct nfs_argop4                *argop,
+    struct nfs_resop4                *resop)
+{
+    struct PUTPUBFH4res *res = &resop->opputpubfh;
+    uint32_t             fhlen;
+
+    nfs4_root_get_fh(req->fh, &fhlen);
+    req->fhlen = fhlen;
+
+    res->status = NFS4_OK;
+
+    chimera_nfs4_compound_complete(req, NFS4_OK);
+} /* chimera_nfs4_putpubfh */

--- a/src/server/nfs/nfs4_proc_release_lockowner.c
+++ b/src/server/nfs/nfs4_proc_release_lockowner.c
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "nfs4_procs.h"
+
+/* RFC 7530 §16.41: RELEASE_LOCKOWNER notifies the server that the client is
+ * done with a lock-owner and any associated state may be released. Chimera
+ * does not retain per-lock-owner state beyond the lifetime of held locks
+ * themselves, so there is nothing to free here. */
+void
+chimera_nfs4_release_lockowner(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_request               *req,
+    struct nfs_argop4                *argop,
+    struct nfs_resop4                *resop)
+{
+    struct RELEASE_LOCKOWNER4res *res = &resop->oprelease_lockowner;
+
+    res->status = NFS4_OK;
+
+    chimera_nfs4_compound_complete(req, NFS4_OK);
+} /* chimera_nfs4_release_lockowner */

--- a/src/server/nfs/nfs4_proc_renew.c
+++ b/src/server/nfs/nfs4_proc_renew.c
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "nfs4_procs.h"
+
+/* RFC 7530 §16.30: RENEW refreshes the lease for the given client. Chimera
+ * does not currently enforce lease expiry, so this is a no-op that always
+ * succeeds. Tests that require true lease-expiry semantics (e.g. pynfs
+ * testExpired) will not behave correctly until real lease tracking lands. */
+void
+chimera_nfs4_renew(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_request               *req,
+    struct nfs_argop4                *argop,
+    struct nfs_resop4                *resop)
+{
+    struct RENEW4res *res = &resop->oprenew;
+
+    res->status = NFS4_OK;
+
+    chimera_nfs4_compound_complete(req, NFS4_OK);
+} /* chimera_nfs4_renew */

--- a/src/server/nfs/nfs4_procs.h
+++ b/src/server/nfs/nfs4_procs.h
@@ -110,6 +110,27 @@ chimera_nfs4_nverify(
     struct nfs_resop4                *resop);
 
 void
+chimera_nfs4_putpubfh(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_request               *req,
+    struct nfs_argop4                *argop,
+    struct nfs_resop4                *resop);
+
+void
+chimera_nfs4_renew(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_request               *req,
+    struct nfs_argop4                *argop,
+    struct nfs_resop4                *resop);
+
+void
+chimera_nfs4_release_lockowner(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_request               *req,
+    struct nfs_argop4                *argop,
+    struct nfs_resop4                *resop);
+
+void
 chimera_nfs4_putfh(
     struct chimera_server_nfs_thread *thread,
     struct nfs_request               *req,


### PR DESCRIPTION
## Summary

These three NFS4 operations were missing from the `chimera_nfs4_compound_process` dispatch switch in `nfs4_proc_compound.c`, so chimera was returning `NFS4ERR_NOTSUPP` for all of them. The pynfs test groups for the corresponding flags fail uniformly with \"got NFS4ERR_NOTSUPP\".

**PUTPUBFH** (RFC 7530 §16.21) sets the current FH to the server's public filehandle. Chimera does not maintain a separate public namespace, so PUTPUBFH is a direct synonym for PUTROOTFH and is implemented the same way.

**RENEW** (RFC 7530 §16.30) refreshes the lease for a clientid. Chimera does not currently enforce lease expiry at all, so the stub returns `NFS4_OK` unconditionally. Tests that exercise actual lease-expiry semantics — pynfs `testExpired`, which sleeps 1200s waiting for the lease to die — still won't behave correctly until real lease tracking lands, but that is the same pre-existing limitation chimera has today; this PR doesn't change those semantics, just makes the RENEW call itself stop returning NOTSUPP.

**RELEASE_LOCKOWNER** (RFC 7530 §16.41) notifies the server that a lock-owner's state may be freed. Chimera does not retain per-lock-owner state beyond the lifetime of held locks, so there is nothing to release; return `NFS4_OK`.

## Background

Found while running the pynfs test suite on the `pynfs` integration branch. Each missing op has its own ctest entry (e.g. `chimera/pynfs/putpubfh_memfs_nfs4.0`) that was failing 100% with NOTSUPP.

## Subtest impact on memfs/NFSv4.0

| flag | before | after |
|------|-------:|------:|
| putpubfh | 0/2 | 2/2 |

`renew` and `releaselockowner` ctest entries remain failing — they depend on lock-flow fixes that aren't part of this change. Future work.