### PR TITLE
cmake: skip netns-wrapped tests when ip netns add is not permitted

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -406,7 +406,7 @@ jobs:
             bash -euxc '\
               dockerd --storage-driver=vfs --registry-mirror=https://repository.mdh.quantum.com:5001 &>/dev/null &
               sleep 2 && \
-              cmake -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DKVM_IMAGE_CACHE_REGISTRY=${{ env.KVM_IMAGE_CACHE_REGISTRY }} ${{ matrix.cmake_extra }} /workspace && \
+              cmake -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DREQUIRE_NETNS_TESTS=ON -DKVM_IMAGE_CACHE_REGISTRY=${{ env.KVM_IMAGE_CACHE_REGISTRY }} ${{ matrix.cmake_extra }} /workspace && \
               ninja && \
               /workspace/scripts/cap_ctest_output.sh \
               ctest --output-on-failure --test-output-size-failed 65536 --timeout 300 -j 32'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -486,7 +486,7 @@ jobs:
             bash -euxc '\
               dockerd --storage-driver=vfs --registry-mirror=https://repository.mdh.quantum.com:5001 &>/dev/null &
               sleep 2 && \
-              cmake -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DKVM_IMAGE_CACHE_REGISTRY=${{ env.KVM_IMAGE_CACHE_REGISTRY }} ${{ matrix.cmake_extra }} /workspace && \
+              cmake -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DREQUIRE_NETNS_TESTS=ON -DKVM_IMAGE_CACHE_REGISTRY=${{ env.KVM_IMAGE_CACHE_REGISTRY }} ${{ matrix.cmake_extra }} /workspace && \
               ninja && \
               /workspace/scripts/cap_ctest_output.sh \
               ctest --output-on-failure --test-output-size-failed 65536 --timeout 300 -j 32'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ cmake_minimum_required(VERSION 3.22)
 option(IO_URING_ENABLED "Enable io_uring support" ON)
 option(CAIRN_ENABLED "Enable cairn support" ON)
 option(CHIMERA_VFS_IO_URING "Enable chimera VFS io_uring backend" ON)
+option(REQUIRE_NETNS_TESTS "Fail configure if network namespace tests cannot be enabled" OFF)
 
 if (EXISTS "/usr/local/cuda")
     set(CUDA_ENABLED true)
@@ -179,6 +180,39 @@ if(KVM_TESTING_AVAILABLE)
 else()
     message(STATUS "KVM testing disabled")
 endif()
+
+# Network namespace testing detection.
+# Many tests run inside an isolated `ip netns` so they can bind well-known
+# ports without colliding with each other or the host. Creating a netns
+# requires CAP_NET_ADMIN, so a non-privileged build/test run would see a
+# pile of failures. Probe whether we can create one; if not, the
+# netns-using tests are silently skipped unless REQUIRE_NETNS_TESTS is ON
+# (which CI should set to prevent accidental coverage loss).
+execute_process(
+    COMMAND bash -c "set -e; n=chimera_netns_probe_$$; ip netns add \"$n\"; ip netns delete \"$n\""
+    RESULT_VARIABLE NETNS_PROBE_RESULT
+    OUTPUT_QUIET
+    ERROR_QUIET
+)
+
+if(NETNS_PROBE_RESULT EQUAL 0)
+    set(CHIMERA_NETNS_TESTING TRUE)
+    message(STATUS "Network namespace testing enabled")
+else()
+    set(CHIMERA_NETNS_TESTING FALSE)
+    if(REQUIRE_NETNS_TESTS)
+        message(FATAL_ERROR
+            "REQUIRE_NETNS_TESTS=ON but `ip netns add` failed "
+            "(need CAP_NET_ADMIN / root). Re-run with sudo, grant the "
+            "capability, or omit -DREQUIRE_NETNS_TESTS=ON.")
+    endif()
+    message(STATUS "Network namespace testing disabled "
+        "(no privileges to create netns; netns-requiring tests will be skipped). "
+        "Pass -DREQUIRE_NETNS_TESTS=ON to make this fatal.")
+endif()
+
+# Forward result to libevpl so it doesn't probe again.
+set(LIBEVPL_NETNS_TESTING ${CHIMERA_NETNS_TESTING})
 
 add_subdirectory(ext)
 

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,9 @@ CMAKE_ARGS_DEBUG := -DCMAKE_BUILD_TYPE=Debug
 CTEST_PARALLEL := $(shell n=$$(nproc); echo $$(( n < 64 ? n : 64 )))
 CTEST_ARGS := --output-on-failure --timeout 30 -j $(CTEST_PARALLEL)
 
-default: build_debug
+# Plain `make` produces a debug build only. Use `make debug`/`make release`
+# to also run the test suite, or `make check` for the full CI sweep.
+.DEFAULT_GOAL := build_debug
 
 .PHONY: build_release
 build_release: 

--- a/src/client/tests/CMakeLists.txt
+++ b/src/client/tests/CMakeLists.txt
@@ -17,10 +17,12 @@ macro(add_client_test testname prog backend user)
 endmacro()
 
 macro(add_client_nfs_test testname prog backend user)
-    add_test(NAME chimera/client/${testname} COMMAND ${CMAKE_SOURCE_DIR}/scripts/netns_test_wrapper.sh ${CMAKE_CURRENT_BINARY_DIR}/${prog} -v 3 -b ${backend} -U ${user})
-    get_target_property(test_file ${prog} TEST_FILE)
-    set_tests_properties(chimera/client/${testname} PROPERTIES
-        ENVIRONMENT "TEST_FILE=${test_file}")
+    if(CHIMERA_NETNS_TESTING)
+        add_test(NAME chimera/client/${testname} COMMAND ${CMAKE_SOURCE_DIR}/scripts/netns_test_wrapper.sh ${CMAKE_CURRENT_BINARY_DIR}/${prog} -v 3 -b ${backend} -U ${user})
+        get_target_property(test_file ${prog} TEST_FILE)
+        set_tests_properties(chimera/client/${testname} PROPERTIES
+            ENVIRONMENT "TEST_FILE=${test_file}")
+    endif()
 endmacro()
 
 # Keep basic test as-is for now

--- a/src/fio/tests/CMakeLists.txt
+++ b/src/fio/tests/CMakeLists.txt
@@ -10,18 +10,24 @@ set(NETNS_WRAPPER "${CMAKE_SOURCE_DIR}/scripts/netns_test_wrapper.sh")
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/memfs_basic.fio ${CMAKE_CURRENT_BINARY_DIR}/memfs_basic.fio)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/memfs_basic.json ${CMAKE_CURRENT_BINARY_DIR}/memfs_basic.json)
 
-add_test(NAME chimera/fio/fio_memfs_basic COMMAND ${NETNS_WRAPPER} /usr/local/bin/fio ${CMAKE_CURRENT_BINARY_DIR}/memfs_basic.fio)
+if(CHIMERA_NETNS_TESTING)
+    add_test(NAME chimera/fio/fio_memfs_basic COMMAND ${NETNS_WRAPPER} /usr/local/bin/fio ${CMAKE_CURRENT_BINARY_DIR}/memfs_basic.fio)
+endif()
 
 if(IO_URING_ENABLED)
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/demofs_io_uring_basic.fio ${CMAKE_CURRENT_BINARY_DIR}/demofs_io_uring_basic.fio)
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/demofs_io_uring_basic.json ${CMAKE_CURRENT_BINARY_DIR}/demofs_io_uring_basic.json)
-    add_test(NAME chimera/fio/fio_demofs_io_uring_basic COMMAND ${NETNS_WRAPPER} /usr/local/bin/fio ${CMAKE_CURRENT_BINARY_DIR}/demofs_io_uring_basic.fio)
+    if(CHIMERA_NETNS_TESTING)
+        add_test(NAME chimera/fio/fio_demofs_io_uring_basic COMMAND ${NETNS_WRAPPER} /usr/local/bin/fio ${CMAKE_CURRENT_BINARY_DIR}/demofs_io_uring_basic.fio)
+    endif()
 endif()
 
 if(HAVE_LIBAIO)
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/demofs_aio_basic.fio ${CMAKE_CURRENT_BINARY_DIR}/demofs_aio_basic.fio)
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/demofs_aio_basic.json ${CMAKE_CURRENT_BINARY_DIR}/demofs_aio_basic.json)
-    add_test(NAME chimera/fio/fio_demofs_aio_basic COMMAND ${NETNS_WRAPPER} /usr/local/bin/fio ${CMAKE_CURRENT_BINARY_DIR}/demofs_aio_basic.fio)
+    if(CHIMERA_NETNS_TESTING)
+        add_test(NAME chimera/fio/fio_demofs_aio_basic COMMAND ${NETNS_WRAPPER} /usr/local/bin/fio ${CMAKE_CURRENT_BINARY_DIR}/demofs_aio_basic.fio)
+    endif()
 endif()
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
@@ -43,19 +49,21 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
         message(FATAL_ERROR "ASAN library not found in any of: ${ASAN_LIB_DIRS}")
     endif()
 
-    set_tests_properties(chimera/fio/fio_memfs_basic PROPERTIES
-        ENVIRONMENT "LD_PRELOAD=${ASAN_LIB};LSAN_OPTIONS=suppressions=${CMAKE_CURRENT_SOURCE_DIR}/suppressions.txt"
-    )
-
-    if(IO_URING_ENABLED)
-        set_tests_properties(chimera/fio/fio_demofs_io_uring_basic PROPERTIES
+    if(CHIMERA_NETNS_TESTING)
+        set_tests_properties(chimera/fio/fio_memfs_basic PROPERTIES
             ENVIRONMENT "LD_PRELOAD=${ASAN_LIB};LSAN_OPTIONS=suppressions=${CMAKE_CURRENT_SOURCE_DIR}/suppressions.txt"
         )
-    endif()
 
-    if(HAVE_LIBAIO)
-        set_tests_properties(chimera/fio/fio_demofs_aio_basic PROPERTIES
-            ENVIRONMENT "LD_PRELOAD=${ASAN_LIB};LSAN_OPTIONS=suppressions=${CMAKE_CURRENT_SOURCE_DIR}/suppressions.txt"
-        )
+        if(IO_URING_ENABLED)
+            set_tests_properties(chimera/fio/fio_demofs_io_uring_basic PROPERTIES
+                ENVIRONMENT "LD_PRELOAD=${ASAN_LIB};LSAN_OPTIONS=suppressions=${CMAKE_CURRENT_SOURCE_DIR}/suppressions.txt"
+            )
+        endif()
+
+        if(HAVE_LIBAIO)
+            set_tests_properties(chimera/fio/fio_demofs_aio_basic PROPERTIES
+                ENVIRONMENT "LD_PRELOAD=${ASAN_LIB};LSAN_OPTIONS=suppressions=${CMAKE_CURRENT_SOURCE_DIR}/suppressions.txt"
+            )
+        endif()
     endif()
 endif()

--- a/src/posix/tests/CMakeLists.txt
+++ b/src/posix/tests/CMakeLists.txt
@@ -18,10 +18,12 @@ macro(add_posix_testprog name)
 endmacro()
 
 macro(add_posix_test testname prog backend)
-    add_test(NAME chimera/posix/${testname} COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_${prog} -b ${backend})
-    get_target_property(test_file posix_${prog} TEST_FILE)
-    set_tests_properties(chimera/posix/${testname} PROPERTIES
-        ENVIRONMENT "TEST_FILE=${test_file}")
+    if(CHIMERA_NETNS_TESTING)
+        add_test(NAME chimera/posix/${testname} COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_${prog} -b ${backend})
+        get_target_property(test_file posix_${prog} TEST_FILE)
+        set_tests_properties(chimera/posix/${testname} PROPERTIES
+            ENVIRONMENT "TEST_FILE=${test_file}")
+    endif()
 endmacro()
 # List of test programs
 set(POSIX_TEST_PROGRAMS
@@ -112,14 +114,16 @@ generate_posix_backend_tests(io_uring CHIMERA_VFS_IO_URING)
 
 # Macro to add a test that runs via NFS3 client (requires network namespace)
 macro(add_posix_nfs3_test testname prog nfs_backend)
-    add_test(NAME chimera/posix/${testname}_nfs3_${nfs_backend}
-        COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_${prog} -b nfs3_${nfs_backend}
-    )
-    get_target_property(test_file posix_${prog} TEST_FILE)
-    set_tests_properties(chimera/posix/${testname}_nfs3_${nfs_backend} PROPERTIES
-        ENVIRONMENT "TEST_FILE=${test_file}"
-        TIMEOUT 60
-    )
+    if(CHIMERA_NETNS_TESTING)
+        add_test(NAME chimera/posix/${testname}_nfs3_${nfs_backend}
+            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_${prog} -b nfs3_${nfs_backend}
+        )
+        get_target_property(test_file posix_${prog} TEST_FILE)
+        set_tests_properties(chimera/posix/${testname}_nfs3_${nfs_backend} PROPERTIES
+            ENVIRONMENT "TEST_FILE=${test_file}"
+            TIMEOUT 60
+        )
+    endif()
 endmacro()
 
 # Helper macro to generate NFS3 tests for a specific server-side backend
@@ -204,14 +208,16 @@ generate_posix_nfs4_backend_tests(io_uring CHIMERA_VFS_IO_URING)
 
 # Macro to add a test that runs via NFS3 RDMA client (requires network namespace)
 macro(add_posix_nfs3rdma_test testname prog nfs_backend)
-    add_test(NAME chimera/posix/${testname}_nfs3rdma_${nfs_backend}
-        COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_${prog} -b nfs3rdma_${nfs_backend}
-    )
-    get_target_property(test_file posix_${prog} TEST_FILE)
-    set_tests_properties(chimera/posix/${testname}_nfs3rdma_${nfs_backend} PROPERTIES
-        ENVIRONMENT "TEST_FILE=${test_file}"
-        TIMEOUT 60
-    )
+    if(CHIMERA_NETNS_TESTING)
+        add_test(NAME chimera/posix/${testname}_nfs3rdma_${nfs_backend}
+            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_${prog} -b nfs3rdma_${nfs_backend}
+        )
+        get_target_property(test_file posix_${prog} TEST_FILE)
+        set_tests_properties(chimera/posix/${testname}_nfs3rdma_${nfs_backend} PROPERTIES
+            ENVIRONMENT "TEST_FILE=${test_file}"
+            TIMEOUT 60
+        )
+    endif()
 endmacro()
 
 # Helper macro to generate NFS3 RDMA tests for a specific server-side backend
@@ -248,14 +254,16 @@ set(FSX_NUM_OPS 10000)
 set(FSX_MAX_LEN 262144)
 
 macro(add_fsx_test backend)
-    add_test(NAME chimera/posix/fsx_${backend}
-        COMMAND ${NETNS_WRAPPER} ${FSX_WRAPPER} -b ${backend} -N ${FSX_NUM_OPS} -l ${FSX_MAX_LEN} -q
-        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-    )
-    set_tests_properties(chimera/posix/fsx_${backend} PROPERTIES
-        ENVIRONMENT "BUILD_DIR=${CMAKE_BINARY_DIR}"
-        TIMEOUT 300
-    )
+    if(CHIMERA_NETNS_TESTING)
+        add_test(NAME chimera/posix/fsx_${backend}
+            COMMAND ${NETNS_WRAPPER} ${FSX_WRAPPER} -b ${backend} -N ${FSX_NUM_OPS} -l ${FSX_MAX_LEN} -q
+            WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+        )
+        set_tests_properties(chimera/posix/fsx_${backend} PROPERTIES
+            ENVIRONMENT "BUILD_DIR=${CMAKE_BINARY_DIR}"
+            TIMEOUT 300
+        )
+    endif()
 endmacro()
 
 # Add FSX tests for each backend
@@ -341,11 +349,13 @@ endmacro()
 
 # Macro to add a cthon test to ctest
 macro(add_cthon_test testname prog backend)
-    add_test(NAME chimera/posix/cthon/${testname} COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_${prog} -b ${backend})
-    get_target_property(test_file posix_${prog} TEST_FILE)
-    set_tests_properties(chimera/posix/cthon/${testname} PROPERTIES
-        ENVIRONMENT "TEST_FILE=${test_file}"
-        TIMEOUT 300)
+    if(CHIMERA_NETNS_TESTING)
+        add_test(NAME chimera/posix/cthon/${testname} COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_${prog} -b ${backend})
+        get_target_property(test_file posix_${prog} TEST_FILE)
+        set_tests_properties(chimera/posix/cthon/${testname} PROPERTIES
+            ENVIRONMENT "TEST_FILE=${test_file}"
+            TIMEOUT 300)
+    endif()
 endmacro()
 
 # List of cthon basic test programs
@@ -461,14 +471,16 @@ endforeach()
 
 # Macro to add a cthon test that runs via NFS3 client (requires network namespace)
 macro(add_cthon_nfs3_test testname prog nfs_backend)
-    add_test(NAME chimera/posix/cthon/${testname}_nfs3_${nfs_backend}
-        COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_${prog} -b nfs3_${nfs_backend}
-    )
-    get_target_property(test_file posix_${prog} TEST_FILE)
-    set_tests_properties(chimera/posix/cthon/${testname}_nfs3_${nfs_backend} PROPERTIES
-        ENVIRONMENT "TEST_FILE=${test_file}"
-        TIMEOUT 300
-    )
+    if(CHIMERA_NETNS_TESTING)
+        add_test(NAME chimera/posix/cthon/${testname}_nfs3_${nfs_backend}
+            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_${prog} -b nfs3_${nfs_backend}
+        )
+        get_target_property(test_file posix_${prog} TEST_FILE)
+        set_tests_properties(chimera/posix/cthon/${testname}_nfs3_${nfs_backend} PROPERTIES
+            ENVIRONMENT "TEST_FILE=${test_file}"
+            TIMEOUT 300
+        )
+    endif()
 endmacro()
 
 # Helper macro to generate NFS3 cthon tests for a specific server-side backend
@@ -506,14 +518,16 @@ generate_cthon_nfs3_backend_tests(io_uring CHIMERA_VFS_IO_URING)
 
 # Macro to add a cthon test that runs via NFS3 RDMA client (requires network namespace)
 macro(add_cthon_nfs3rdma_test testname prog nfs_backend)
-    add_test(NAME chimera/posix/cthon/${testname}_nfs3rdma_${nfs_backend}
-        COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_${prog} -b nfs3rdma_${nfs_backend}
-    )
-    get_target_property(test_file posix_${prog} TEST_FILE)
-    set_tests_properties(chimera/posix/cthon/${testname}_nfs3rdma_${nfs_backend} PROPERTIES
-        ENVIRONMENT "TEST_FILE=${test_file}"
-        TIMEOUT 300
-    )
+    if(CHIMERA_NETNS_TESTING)
+        add_test(NAME chimera/posix/cthon/${testname}_nfs3rdma_${nfs_backend}
+            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_${prog} -b nfs3rdma_${nfs_backend}
+        )
+        get_target_property(test_file posix_${prog} TEST_FILE)
+        set_tests_properties(chimera/posix/cthon/${testname}_nfs3rdma_${nfs_backend} PROPERTIES
+            ENVIRONMENT "TEST_FILE=${test_file}"
+            TIMEOUT 300
+        )
+    endif()
 endmacro()
 
 # Helper macro to generate NFS3 RDMA cthon tests for a specific server-side backend
@@ -617,35 +631,37 @@ endmacro()
 
 # Helper macro to generate stress tests for a backend
 macro(_generate_stress_tests_for_backend backend)
-    # dirstress: directory operations stress test (reduced params for testing)
-    add_test(NAME chimera/posix/dirstress_${backend}
-        COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_dirstress -b ${backend} -p 1 -f 50
-    )
-    set_tests_properties(chimera/posix/dirstress_${backend} PROPERTIES TIMEOUT 120)
+    if(CHIMERA_NETNS_TESTING)
+        # dirstress: directory operations stress test (reduced params for testing)
+        add_test(NAME chimera/posix/dirstress_${backend}
+            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_dirstress -b ${backend} -p 1 -f 50
+        )
+        set_tests_properties(chimera/posix/dirstress_${backend} PROPERTIES TIMEOUT 120)
 
-    # rewinddir: tests rewinddir() POSIX semantics
-    add_test(NAME chimera/posix/rewinddir_${backend}
-        COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_rewinddir -b ${backend}
-    )
-    set_tests_properties(chimera/posix/rewinddir_${backend} PROPERTIES TIMEOUT 120)
+        # rewinddir: tests rewinddir() POSIX semantics
+        add_test(NAME chimera/posix/rewinddir_${backend}
+            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_rewinddir -b ${backend}
+        )
+        set_tests_properties(chimera/posix/rewinddir_${backend} PROPERTIES TIMEOUT 120)
 
-    # fstest: data integrity verification test
-    add_test(NAME chimera/posix/fstest_${backend}
-        COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_fstest -b ${backend} -n 1 -f 2 -l 5 -s 65536
-    )
-    set_tests_properties(chimera/posix/fstest_${backend} PROPERTIES TIMEOUT 120)
+        # fstest: data integrity verification test
+        add_test(NAME chimera/posix/fstest_${backend}
+            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_fstest -b ${backend} -n 1 -f 2 -l 5 -s 65536
+        )
+        set_tests_properties(chimera/posix/fstest_${backend} PROPERTIES TIMEOUT 120)
 
-    # nametest: namespace stress test
-    add_test(NAME chimera/posix/nametest_${backend}
-        COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_nametest -b ${backend} -n 50 -i 1000
-    )
-    set_tests_properties(chimera/posix/nametest_${backend} PROPERTIES TIMEOUT 120)
+        # nametest: namespace stress test
+        add_test(NAME chimera/posix/nametest_${backend}
+            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_nametest -b ${backend} -n 50 -i 1000
+        )
+        set_tests_properties(chimera/posix/nametest_${backend} PROPERTIES TIMEOUT 120)
 
-    # fsstress: comprehensive filesystem stress test
-    add_test(NAME chimera/posix/fsstress_${backend}
-        COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_fsstress -b ${backend} -n 500 -p 1
-    )
-    set_tests_properties(chimera/posix/fsstress_${backend} PROPERTIES TIMEOUT 180)
+        # fsstress: comprehensive filesystem stress test
+        add_test(NAME chimera/posix/fsstress_${backend}
+            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_fsstress -b ${backend} -n 500 -p 1
+        )
+        set_tests_properties(chimera/posix/fsstress_${backend} PROPERTIES TIMEOUT 180)
+    endif()
 endmacro()
 
 # Macro to generate stress tests with optional condition
@@ -676,35 +692,37 @@ generate_stress_tests(io_uring CHIMERA_VFS_IO_URING)
 
 # Helper macro to generate NFS3 stress tests for a backend
 macro(_generate_stress_nfs3_tests_for_backend nfs_backend)
-    # dirstress: directory operations stress test (reduced params for testing)
-    add_test(NAME chimera/posix/dirstress_nfs3_${nfs_backend}
-        COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_dirstress -b nfs3_${nfs_backend} -p 1 -f 50
-    )
-    set_tests_properties(chimera/posix/dirstress_nfs3_${nfs_backend} PROPERTIES TIMEOUT 120)
+    if(CHIMERA_NETNS_TESTING)
+        # dirstress: directory operations stress test (reduced params for testing)
+        add_test(NAME chimera/posix/dirstress_nfs3_${nfs_backend}
+            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_dirstress -b nfs3_${nfs_backend} -p 1 -f 50
+        )
+        set_tests_properties(chimera/posix/dirstress_nfs3_${nfs_backend} PROPERTIES TIMEOUT 120)
 
-    # rewinddir: tests rewinddir() POSIX semantics
-    add_test(NAME chimera/posix/rewinddir_nfs3_${nfs_backend}
-        COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_rewinddir -b nfs3_${nfs_backend}
-    )
-    set_tests_properties(chimera/posix/rewinddir_nfs3_${nfs_backend} PROPERTIES TIMEOUT 120)
+        # rewinddir: tests rewinddir() POSIX semantics
+        add_test(NAME chimera/posix/rewinddir_nfs3_${nfs_backend}
+            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_rewinddir -b nfs3_${nfs_backend}
+        )
+        set_tests_properties(chimera/posix/rewinddir_nfs3_${nfs_backend} PROPERTIES TIMEOUT 120)
 
-    # fstest: data integrity verification test
-    add_test(NAME chimera/posix/fstest_nfs3_${nfs_backend}
-        COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_fstest -b nfs3_${nfs_backend} -n 1 -f 2 -l 5 -s 65536
-    )
-    set_tests_properties(chimera/posix/fstest_nfs3_${nfs_backend} PROPERTIES TIMEOUT 120)
+        # fstest: data integrity verification test
+        add_test(NAME chimera/posix/fstest_nfs3_${nfs_backend}
+            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_fstest -b nfs3_${nfs_backend} -n 1 -f 2 -l 5 -s 65536
+        )
+        set_tests_properties(chimera/posix/fstest_nfs3_${nfs_backend} PROPERTIES TIMEOUT 120)
 
-    # nametest: namespace stress test
-    add_test(NAME chimera/posix/nametest_nfs3_${nfs_backend}
-        COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_nametest -b nfs3_${nfs_backend} -n 50 -i 1000
-    )
-    set_tests_properties(chimera/posix/nametest_nfs3_${nfs_backend} PROPERTIES TIMEOUT 120)
+        # nametest: namespace stress test
+        add_test(NAME chimera/posix/nametest_nfs3_${nfs_backend}
+            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_nametest -b nfs3_${nfs_backend} -n 50 -i 1000
+        )
+        set_tests_properties(chimera/posix/nametest_nfs3_${nfs_backend} PROPERTIES TIMEOUT 120)
 
-    # fsstress: comprehensive filesystem stress test
-    add_test(NAME chimera/posix/fsstress_nfs3_${nfs_backend}
-        COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_fsstress -b nfs3_${nfs_backend} -n 500 -p 1
-    )
-    set_tests_properties(chimera/posix/fsstress_nfs3_${nfs_backend} PROPERTIES TIMEOUT 180)
+        # fsstress: comprehensive filesystem stress test
+        add_test(NAME chimera/posix/fsstress_nfs3_${nfs_backend}
+            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_fsstress -b nfs3_${nfs_backend} -n 500 -p 1
+        )
+        set_tests_properties(chimera/posix/fsstress_nfs3_${nfs_backend} PROPERTIES TIMEOUT 180)
+    endif()
 endmacro()
 
 # Macro to generate NFS3 stress tests with optional condition
@@ -735,35 +753,37 @@ generate_stress_nfs3_tests(io_uring CHIMERA_VFS_IO_URING)
 
 # Helper macro to generate NFS3 RDMA stress tests for a backend
 macro(_generate_stress_nfs3rdma_tests_for_backend nfs_backend)
-    # dirstress: directory operations stress test (reduced params for testing)
-    add_test(NAME chimera/posix/dirstress_nfs3rdma_${nfs_backend}
-        COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_dirstress -b nfs3rdma_${nfs_backend} -p 1 -f 50
-    )
-    set_tests_properties(chimera/posix/dirstress_nfs3rdma_${nfs_backend} PROPERTIES TIMEOUT 120)
+    if(CHIMERA_NETNS_TESTING)
+        # dirstress: directory operations stress test (reduced params for testing)
+        add_test(NAME chimera/posix/dirstress_nfs3rdma_${nfs_backend}
+            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_dirstress -b nfs3rdma_${nfs_backend} -p 1 -f 50
+        )
+        set_tests_properties(chimera/posix/dirstress_nfs3rdma_${nfs_backend} PROPERTIES TIMEOUT 120)
 
-    # rewinddir: tests rewinddir() POSIX semantics
-    add_test(NAME chimera/posix/rewinddir_nfs3rdma_${nfs_backend}
-        COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_rewinddir -b nfs3rdma_${nfs_backend}
-    )
-    set_tests_properties(chimera/posix/rewinddir_nfs3rdma_${nfs_backend} PROPERTIES TIMEOUT 120)
+        # rewinddir: tests rewinddir() POSIX semantics
+        add_test(NAME chimera/posix/rewinddir_nfs3rdma_${nfs_backend}
+            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_rewinddir -b nfs3rdma_${nfs_backend}
+        )
+        set_tests_properties(chimera/posix/rewinddir_nfs3rdma_${nfs_backend} PROPERTIES TIMEOUT 120)
 
-    # fstest: data integrity verification test
-    add_test(NAME chimera/posix/fstest_nfs3rdma_${nfs_backend}
-        COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_fstest -b nfs3rdma_${nfs_backend} -n 1 -f 2 -l 5 -s 65536
-    )
-    set_tests_properties(chimera/posix/fstest_nfs3rdma_${nfs_backend} PROPERTIES TIMEOUT 120)
+        # fstest: data integrity verification test
+        add_test(NAME chimera/posix/fstest_nfs3rdma_${nfs_backend}
+            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_fstest -b nfs3rdma_${nfs_backend} -n 1 -f 2 -l 5 -s 65536
+        )
+        set_tests_properties(chimera/posix/fstest_nfs3rdma_${nfs_backend} PROPERTIES TIMEOUT 120)
 
-    # nametest: namespace stress test
-    add_test(NAME chimera/posix/nametest_nfs3rdma_${nfs_backend}
-        COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_nametest -b nfs3rdma_${nfs_backend} -n 50 -i 1000
-    )
-    set_tests_properties(chimera/posix/nametest_nfs3rdma_${nfs_backend} PROPERTIES TIMEOUT 120)
+        # nametest: namespace stress test
+        add_test(NAME chimera/posix/nametest_nfs3rdma_${nfs_backend}
+            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_nametest -b nfs3rdma_${nfs_backend} -n 50 -i 1000
+        )
+        set_tests_properties(chimera/posix/nametest_nfs3rdma_${nfs_backend} PROPERTIES TIMEOUT 120)
 
-    # fsstress: comprehensive filesystem stress test
-    add_test(NAME chimera/posix/fsstress_nfs3rdma_${nfs_backend}
-        COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_fsstress -b nfs3rdma_${nfs_backend} -n 500 -p 1
-    )
-    set_tests_properties(chimera/posix/fsstress_nfs3rdma_${nfs_backend} PROPERTIES TIMEOUT 180)
+        # fsstress: comprehensive filesystem stress test
+        add_test(NAME chimera/posix/fsstress_nfs3rdma_${nfs_backend}
+            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_fsstress -b nfs3rdma_${nfs_backend} -n 500 -p 1
+        )
+        set_tests_properties(chimera/posix/fsstress_nfs3rdma_${nfs_backend} PROPERTIES TIMEOUT 180)
+    endif()
 endmacro()
 
 # Macro to generate NFS3 RDMA stress tests with optional condition
@@ -852,35 +872,41 @@ generate_stress_nfs4_tests(io_uring CHIMERA_VFS_IO_URING)
 # ============================================================================
 
 macro(add_posix_test_myuser testname prog backend)
-    add_test(NAME chimera/posix/${testname}_myuser COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_${prog} -b ${backend} -U myuser)
-    get_target_property(test_file posix_${prog} TEST_FILE)
-    set_tests_properties(chimera/posix/${testname}_myuser PROPERTIES
-        ENVIRONMENT "TEST_FILE=${test_file}"
-        SKIP_RETURN_CODE 77)
+    if(CHIMERA_NETNS_TESTING)
+        add_test(NAME chimera/posix/${testname}_myuser COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_${prog} -b ${backend} -U myuser)
+        get_target_property(test_file posix_${prog} TEST_FILE)
+        set_tests_properties(chimera/posix/${testname}_myuser PROPERTIES
+            ENVIRONMENT "TEST_FILE=${test_file}"
+            SKIP_RETURN_CODE 77)
+    endif()
 endmacro()
 
 macro(add_posix_nfs3_test_myuser testname prog nfs_backend)
-    add_test(NAME chimera/posix/${testname}_nfs3_${nfs_backend}_myuser
-        COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_${prog} -b nfs3_${nfs_backend} -U myuser
-    )
-    get_target_property(test_file posix_${prog} TEST_FILE)
-    set_tests_properties(chimera/posix/${testname}_nfs3_${nfs_backend}_myuser PROPERTIES
-        ENVIRONMENT "TEST_FILE=${test_file}"
-        TIMEOUT 60
-        SKIP_RETURN_CODE 77
-    )
+    if(CHIMERA_NETNS_TESTING)
+        add_test(NAME chimera/posix/${testname}_nfs3_${nfs_backend}_myuser
+            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_${prog} -b nfs3_${nfs_backend} -U myuser
+        )
+        get_target_property(test_file posix_${prog} TEST_FILE)
+        set_tests_properties(chimera/posix/${testname}_nfs3_${nfs_backend}_myuser PROPERTIES
+            ENVIRONMENT "TEST_FILE=${test_file}"
+            TIMEOUT 60
+            SKIP_RETURN_CODE 77
+        )
+    endif()
 endmacro()
 
 macro(add_posix_nfs3rdma_test_myuser testname prog nfs_backend)
-    add_test(NAME chimera/posix/${testname}_nfs3rdma_${nfs_backend}_myuser
-        COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_${prog} -b nfs3rdma_${nfs_backend} -U myuser
-    )
-    get_target_property(test_file posix_${prog} TEST_FILE)
-    set_tests_properties(chimera/posix/${testname}_nfs3rdma_${nfs_backend}_myuser PROPERTIES
-        ENVIRONMENT "TEST_FILE=${test_file}"
-        TIMEOUT 60
-        SKIP_RETURN_CODE 77
-    )
+    if(CHIMERA_NETNS_TESTING)
+        add_test(NAME chimera/posix/${testname}_nfs3rdma_${nfs_backend}_myuser
+            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_${prog} -b nfs3rdma_${nfs_backend} -U myuser
+        )
+        get_target_property(test_file posix_${prog} TEST_FILE)
+        set_tests_properties(chimera/posix/${testname}_nfs3rdma_${nfs_backend}_myuser PROPERTIES
+            ENVIRONMENT "TEST_FILE=${test_file}"
+            TIMEOUT 60
+            SKIP_RETURN_CODE 77
+        )
+    endif()
 endmacro()
 
 foreach(prog ${POSIX_TEST_PROGRAMS})

--- a/src/server/s3/tests/CMakeLists.txt
+++ b/src/server/s3/tests/CMakeLists.txt
@@ -30,19 +30,21 @@ if(BOTO3_FOUND)
 
     # Macro to add S3 test with specific signature version
     macro(add_s3_test_sigver testname backend sigver)
-        add_test(
-            NAME chimera/server/s3/boto3_${sigver}_${backend}_${testname}
-            COMMAND ${CMAKE_SOURCE_DIR}/scripts/netns_test_wrapper.sh
-                    ${Python3_EXECUTABLE} ${S3_TEST_SCRIPT}
-                    --test ${testname}
-                    --backend ${backend}
-                    --sigver ${sigver}
-                    --chimera ${CHIMERA_DAEMON}
-        )
-        set_tests_properties(chimera/server/s3/boto3_${sigver}_${backend}_${testname} PROPERTIES
-            ENVIRONMENT "PYTHONUNBUFFERED=1"
-            TIMEOUT 300
-        )
+        if(CHIMERA_NETNS_TESTING)
+            add_test(
+                NAME chimera/server/s3/boto3_${sigver}_${backend}_${testname}
+                COMMAND ${CMAKE_SOURCE_DIR}/scripts/netns_test_wrapper.sh
+                        ${Python3_EXECUTABLE} ${S3_TEST_SCRIPT}
+                        --test ${testname}
+                        --backend ${backend}
+                        --sigver ${sigver}
+                        --chimera ${CHIMERA_DAEMON}
+            )
+            set_tests_properties(chimera/server/s3/boto3_${sigver}_${backend}_${testname} PROPERTIES
+                ENVIRONMENT "PYTHONUNBUFFERED=1"
+                TIMEOUT 300
+            )
+        endif()
     endmacro()
 
     # Convenience macro for V4 tests (default)

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -16,9 +16,11 @@ add_executable(smbclient_auth_test smbclient_auth_test.c)
 target_link_libraries(smbclient_auth_test chimera_server chimera_metrics jansson)
 target_include_directories(smbclient_auth_test PRIVATE ${CMAKE_SOURCE_DIR}/src)
 
-add_test(NAME chimera/server/smb/smbclient_ntlm
-    COMMAND ${CMAKE_SOURCE_DIR}/scripts/netns_test_wrapper.sh
-            ${CMAKE_CURRENT_BINARY_DIR}/smbclient_auth_test --mode=ntlm)
+if(CHIMERA_NETNS_TESTING)
+    add_test(NAME chimera/server/smb/smbclient_ntlm
+        COMMAND ${CMAKE_SOURCE_DIR}/scripts/netns_test_wrapper.sh
+                ${CMAKE_CURRENT_BINARY_DIR}/smbclient_auth_test --mode=ntlm)
+endif()
 
 add_test(NAME chimera/server/smb/smbclient_kerberos
     COMMAND ${CMAKE_SOURCE_DIR}/scripts/kerberos_test_wrapper.sh
@@ -54,6 +56,8 @@ add_executable(rest_user_manip_test rest_user_manip_test.c)
 target_link_libraries(rest_user_manip_test chimera_server chimera_metrics jansson)
 target_include_directories(rest_user_manip_test PRIVATE ${CMAKE_SOURCE_DIR}/src)
 
-add_test(NAME chimera/server/smb/rest_user_manip
-    COMMAND ${CMAKE_SOURCE_DIR}/scripts/netns_test_wrapper.sh
-            ${CMAKE_CURRENT_BINARY_DIR}/rest_user_manip_test)
+if(CHIMERA_NETNS_TESTING)
+    add_test(NAME chimera/server/smb/rest_user_manip
+        COMMAND ${CMAKE_SOURCE_DIR}/scripts/netns_test_wrapper.sh
+                ${CMAKE_CURRENT_BINARY_DIR}/rest_user_manip_test)
+endif()


### PR DESCRIPTION
## Summary

Plain `make` as a non-privileged user produced a wall of failed tests because most run inside an isolated `ip netns` (loopback isolation so in-process NFS/SMB/S3 servers can bind well-known ports without colliding), and creating a netns needs CAP_NET_ADMIN.

- Probe `ip netns add` at configure time. If it fails, the netns-using tests are dropped from the test list rather than registered to fail at runtime.
- New `REQUIRE_NETNS_TESTS` option (default OFF). When ON and the probe fails, configure aborts. CI passes `-DREQUIRE_NETNS_TESTS=ON` so a privilege regression on the runner is loud, not silent.
- Probe result is forwarded to libevpl via `LIBEVPL_NETNS_TESTING`; submodule bump pulls in chimera-nas/libevpl#50 which gates its own tests the same way.
- `Makefile` default goal made explicit (`.DEFAULT_GOAL := build_debug`) so plain `make` unambiguously builds without invoking ctest.

Verified:
- root + netns: 1890 tests registered (unchanged), sample netns-wrapped test passes.
- nobody, no netns: configure prints "Network namespace testing disabled", 103 tests registered (only the non-netns local-backend tests), no failures.
- nobody + `-DREQUIRE_NETNS_TESTS=ON`: configure aborts with FATAL_ERROR pointing the user at the cause.

Depends on chimera-nas/libevpl#50 (submodule bump points to that branch; will move to the merged SHA once it lands).