### PR TITLE
nfs: add portmap_hostname to advertise external IP in rpcbind responses

### DIFF
--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -360,6 +360,13 @@ main(
         chimera_server_config_set_external_portmap(server_config, 1);
     }
 
+    json_value = json_object_get(server_params, "portmap_hostname");
+    if (json_is_string(json_value)) {
+        str_value = json_string_value(json_value);
+        chimera_server_info("Setting portmap hostname to %s", str_value);
+        chimera_server_config_set_portmap_hostname(server_config, str_value);
+    }
+
     json_value = json_object_get(server_params, "kv_module");
     if (json_is_string(json_value)) {
         str_value = json_string_value(json_value);

--- a/src/server/nfs/nfs.c
+++ b/src/server/nfs/nfs.c
@@ -5,7 +5,6 @@
 #include <pthread.h>
 #include <utlist.h>
 
-
 #include "nfs.h"
 #include "server/protocol.h"
 #include "server/server.h"
@@ -61,6 +60,7 @@ nfs_server_init(
     int                               nfs_tcp_rdma_port;
     int                               nfs_lockmgr_port;
     int                               external_portmap;
+    const char                       *portmap_hostname;
 
     nfs_rdma          = chimera_server_config_get_nfs_rdma(config);
     nfs_rdma_hostname = chimera_server_config_get_nfs_rdma_hostname(config);
@@ -68,6 +68,7 @@ nfs_server_init(
     nfs_tcp_rdma_port = chimera_server_config_get_nfs_tcp_rdma_port(config);
     nfs_lockmgr_port  = chimera_server_config_get_nfs_lockmgr_port(config);
     external_portmap  = chimera_server_config_get_external_portmap(config);
+    portmap_hostname  = chimera_server_config_get_portmap_hostname(config);
     chimera_nfs_debug("NFS RDMA: %s", nfs_rdma ? "enabled" : "disabled");
     chimera_nfs_debug("NFS TCP-RDMA: %s (port %d)", nfs_tcp_rdma_port > 0 ? "enabled" : "disabled", nfs_tcp_rdma_port);
     chimera_nfs_debug("NFS Lock Manager port: %d", nfs_lockmgr_port);
@@ -78,6 +79,21 @@ nfs_server_init(
     shared = calloc(1, sizeof(*shared));
 
     shared->config = config;
+
+    shared->portmap_hostname[0] = '\0';
+    if (portmap_hostname) {
+        if (external_portmap) {
+            chimera_nfs_info("portmap_hostname '%s' is ignored because "
+                             "external_portmap is enabled",
+                             portmap_hostname);
+        } else {
+            chimera_server_resolve_ipv4(portmap_hostname,
+                                        shared->portmap_hostname,
+                                        sizeof(shared->portmap_hostname));
+            chimera_nfs_debug("Portmap hostname '%s' resolved to %s",
+                              portmap_hostname, shared->portmap_hostname);
+        }
+    }
 
     shared->vfs = vfs;
 

--- a/src/server/nfs/nfs_common.h
+++ b/src/server/nfs/nfs_common.h
@@ -101,6 +101,8 @@ struct chimera_server_nfs_shared {
     const struct chimera_server_config *config;
     struct chimera_vfs                 *vfs;
 
+    char                                portmap_hostname[16];
+
     struct PORTMAP_V2                   portmap_v2;
     struct PORTMAP_V3                   portmap_v3;
     struct PORTMAP_V4                   portmap_v4;

--- a/src/server/nfs/nfs_portmap.c
+++ b/src/server/nfs/nfs_portmap.c
@@ -52,6 +52,7 @@ static int                    num_portmap_services = 6;
 static int
 portmap_make_uaddr(
     struct evpl_rpc2_conn *conn,
+    const char            *override_addr,
     unsigned int           port,
     char                  *uaddr,
     size_t                 uaddr_size)
@@ -59,12 +60,16 @@ portmap_make_uaddr(
     char  local_addr[128];
     char *colon;
 
-    evpl_rpc2_conn_get_local_address(conn, local_addr, sizeof(local_addr));
+    if (override_addr && override_addr[0] != '\0') {
+        snprintf(local_addr, sizeof(local_addr), "%s", override_addr);
+    } else {
+        evpl_rpc2_conn_get_local_address(conn, local_addr, sizeof(local_addr));
 
-    /* Find and terminate at the colon to get just the IP */
-    colon = strchr(local_addr, ':');
-    if (colon) {
-        *colon = '\0';
+        /* Find and terminate at the colon to get just the IP */
+        colon = strchr(local_addr, ':');
+        if (colon) {
+            *colon = '\0';
+        }
     }
 
     return snprintf(uaddr, uaddr_size, "%s.%u.%u",
@@ -127,6 +132,7 @@ portmap_build_pmaplist(struct xdr_dbuf *dbuf)
 static struct rp__list *
 portmap_build_rpcblist(
     struct evpl_rpc2_conn *conn,
+    const char            *override_addr,
     struct xdr_dbuf       *dbuf)
 {
     struct rp__list *head = NULL;
@@ -150,6 +156,7 @@ portmap_build_rpcblist(
         entry->rpcb_map.r_netid.str = "tcp";
         entry->rpcb_map.r_netid.len = 3;
         entry->rpcb_map.r_addr.len  = portmap_make_uaddr(conn,
+                                                         override_addr,
                                                          portmap_services[i].port,
                                                          uaddr, 64);
         entry->rpcb_map.r_addr.str  = uaddr;
@@ -249,6 +256,7 @@ static void
 portmap_getaddr_common(
     struct evpl *evpl,
     struct evpl_rpc2_conn *conn,
+    const char *override_addr,
     struct rpcb *args,
     struct evpl_rpc2_encoding *encoding,
     int ( *send_reply )(struct evpl *, const struct evpl_rpc2_verf *, xdr_string *, struct evpl_rpc2_encoding *))
@@ -266,7 +274,7 @@ portmap_getaddr_common(
         addr.str = "";
         addr.len = 0;
     } else {
-        addr.len = portmap_make_uaddr(conn, port, uaddr, sizeof(uaddr));
+        addr.len = portmap_make_uaddr(conn, override_addr, port, uaddr, sizeof(uaddr));
         addr.str = uaddr;
     }
 
@@ -286,7 +294,7 @@ chimera_portmap_getaddr_v3(
     struct chimera_server_nfs_thread *thread = private_data;
     struct chimera_server_nfs_shared *shared = thread->shared;
 
-    portmap_getaddr_common(evpl, conn, args, encoding,
+    portmap_getaddr_common(evpl, conn, shared->portmap_hostname, args, encoding,
                            shared->portmap_v3.send_reply_rpcbproc_getaddr);
 } /* chimera_portmap_getaddr_v3 */
 
@@ -298,13 +306,14 @@ static void
 portmap_dump_common(
     struct evpl *evpl,
     struct evpl_rpc2_conn *conn,
+    const char *override_addr,
     struct evpl_rpc2_encoding *encoding,
     int ( *send_reply )(struct evpl *, const struct evpl_rpc2_verf *, struct rp__list *, struct evpl_rpc2_encoding *))
 {
     struct rp__list *list;
     int              rc;
 
-    list = portmap_build_rpcblist(conn, encoding->dbuf);
+    list = portmap_build_rpcblist(conn, override_addr, encoding->dbuf);
 
     rc = send_reply(evpl, NULL, list, encoding);
     chimera_nfs_abort_if(rc, "Failed to send RPC2 reply");
@@ -321,7 +330,7 @@ chimera_portmap_dump_v3(
     struct chimera_server_nfs_thread *thread = private_data;
     struct chimera_server_nfs_shared *shared = thread->shared;
 
-    portmap_dump_common(evpl, conn, encoding,
+    portmap_dump_common(evpl, conn, shared->portmap_hostname, encoding,
                         shared->portmap_v3.send_reply_rpcbproc_dump);
 } /* chimera_portmap_dump_v3 */
 
@@ -336,7 +345,7 @@ chimera_portmap_dump_v4(
     struct chimera_server_nfs_thread *thread = private_data;
     struct chimera_server_nfs_shared *shared = thread->shared;
 
-    portmap_dump_common(evpl, conn, encoding,
+    portmap_dump_common(evpl, conn, shared->portmap_hostname, encoding,
                         shared->portmap_v4.send_reply_RPCBPROC_DUMP);
 } /* chimera_portmap_dump_v4 */
 
@@ -352,6 +361,6 @@ chimera_portmap_getaddr_v4(
     struct chimera_server_nfs_thread *thread = private_data;
     struct chimera_server_nfs_shared *shared = thread->shared;
 
-    portmap_getaddr_common(evpl, conn, args, encoding,
+    portmap_getaddr_common(evpl, conn, shared->portmap_hostname, args, encoding,
                            shared->portmap_v4.send_reply_RPCBPROC_GETADDR);
 } /* chimera_portmap_getaddr_v4 */

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -4,9 +4,13 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
 #include <pthread.h>
 #include <sys/resource.h>
+#include <sys/socket.h>
+#include <netdb.h>
+#include <arpa/inet.h>
 #include <errno.h>
 
 #include "evpl/evpl.h"
@@ -38,6 +42,7 @@ struct chimera_server_config {
     int                                   nfs_tcp_rdma_port;
     int                                   nfs_lockmgr_port;
     int                                   external_portmap;
+    char                                  portmap_hostname[256];
     int                                   soft_fail_bad_req;
     rlim_t                                max_open_files;
     int                                   core_threads;
@@ -103,6 +108,7 @@ chimera_server_config_init(void)
     config->async_delegation_threads = 8;
     config->nfs_rdma                 = 0;
     config->external_portmap         = 0;
+    config->portmap_hostname[0] = '\0';
     config->soft_fail_bad_req        = 0;
     config->tcp_flavor               = CHIMERA_TCP_FLAVOR_PLAIN;
 
@@ -206,6 +212,15 @@ chimera_server_config_set_external_portmap(
 {
     config->external_portmap = enable;
 } /* chimera_server_config_set_external_portmap */
+
+SYMBOL_EXPORT void
+chimera_server_config_set_portmap_hostname(
+    struct chimera_server_config *config,
+    const char                   *hostname)
+{
+    strncpy(config->portmap_hostname, hostname, sizeof(config->portmap_hostname) - 1);
+    config->portmap_hostname[sizeof(config->portmap_hostname) - 1] = '\0';
+} /* chimera_server_config_set_portmap_hostname */
 
 SYMBOL_EXPORT void
 chimera_server_config_set_nfs_rdma(
@@ -330,6 +345,43 @@ chimera_server_config_get_external_portmap(const struct chimera_server_config *c
 {
     return config->external_portmap;
 } /* chimera_server_config_get_external_portmap */
+
+SYMBOL_EXPORT const char *
+chimera_server_config_get_portmap_hostname(const struct chimera_server_config *config)
+{
+    if (config->portmap_hostname[0] == '\0') {
+        return NULL;
+    }
+    return config->portmap_hostname;
+} /* chimera_server_config_get_portmap_hostname */
+
+SYMBOL_EXPORT void
+chimera_server_resolve_ipv4(
+    const char *hostname,
+    char       *out_buf,
+    size_t      out_size)
+{
+    struct addrinfo  hints = { .ai_family = AF_INET, .ai_socktype = SOCK_STREAM };
+    struct addrinfo *res;
+    int              gai_rc;
+
+    gai_rc = getaddrinfo(hostname, NULL, &hints, &res);
+    chimera_server_fatal_if(gai_rc != 0,
+                            "Failed to resolve hostname '%s': %s",
+                            hostname, gai_strerror(gai_rc));
+
+    inet_ntop(AF_INET,
+              &((struct sockaddr_in *) res->ai_addr)->sin_addr,
+              out_buf,
+              out_size);
+
+    if (res->ai_next != NULL) {
+        chimera_server_info("Hostname '%s' resolved to multiple addresses; using %s",
+                            hostname, out_buf);
+    }
+
+    freeaddrinfo(res);
+} /* chimera_server_resolve_ipv4 */
 
 SYMBOL_EXPORT void
 chimera_server_config_add_module(

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -108,7 +108,7 @@ chimera_server_config_init(void)
     config->async_delegation_threads = 8;
     config->nfs_rdma                 = 0;
     config->external_portmap         = 0;
-    config->portmap_hostname[0] = '\0';
+    config->portmap_hostname[0]      = '\0';
     config->soft_fail_bad_req        = 0;
     config->tcp_flavor               = CHIMERA_TCP_FLAVOR_PLAIN;
 

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -107,6 +107,27 @@ chimera_server_config_set_external_portmap(
     struct chimera_server_config *config,
     int                           enable);
 
+void
+chimera_server_config_set_portmap_hostname(
+    struct chimera_server_config *config,
+    const char                   *hostname);
+
+const char *
+chimera_server_config_get_portmap_hostname(
+    const struct chimera_server_config *config);
+
+/*
+ * Resolve a hostname or IPv4 dotted-quad string to an IPv4 dotted-quad string.
+ * Writes the result (NUL-terminated) into out_buf. out_size must be at least
+ * INET_ADDRSTRLEN (16). Aborts startup with a clear error on resolution
+ * failure.
+ */
+void
+chimera_server_resolve_ipv4(
+    const char *hostname,
+    char       *out_buf,
+    size_t      out_size);
+
 uint32_t
 chimera_server_config_get_soft_fail_bad_req(
     const struct chimera_server_config *config);


### PR DESCRIPTION
When chimera runs inside a Docker container that publishes port 111 to a host IP, the portmap V3/V4 GETADDR and DUMP responses encode the container's local IP (from evpl_rpc2_conn_get_local_address) into the universal address (uaddr) string. That IP is unreachable from outside the container, so external clients receive a bad address and cannot connect to the advertised NFS / Mount / NLM services.

Add a new optional server-section JSON parameter portmap_hostname (string; hostname or IPv4 dotted-quad). When set, nfs_portmap.c uses that address as the local IP in the uaddr string instead of the connection's actual local address. Hostnames are resolved once at startup via a new chimera_server_resolve_ipv4() helper in server.c (getaddrinfo + inet_ntop, AF_INET); resolution failure aborts startup with a clear error. When unset, behavior is unchanged.

The resolution helper lives in server.c so that nfs.c does not need to include <netdb.h> / <arpa/inet.h> / <sys/socket.h>, whose IPPROTO_TCP / IPPROTO_UDP definitions collide with the RPC protocol-number constants defined by portmap_xdr.h (included via nfs_common.h).

When external_portmap is enabled, portmap_hostname is ignored (with an info log) -- the internal portmap server is not registered in that mode, so resolution is skipped to avoid a spurious DNS-related startup failure for a setting that would have no effect.

The internal portmap server still binds 0.0.0.0:111, so only the advertised uaddr changes -- the bind address is unaffected, which is what the Docker port-publish scenario needs.