### PR TITLE
Unified lease/lock backend (NFSv3, NFSv4, SMB2 share/range/oplock)

### DIFF
--- a/src/server/nfs/nfs.c
+++ b/src/server/nfs/nfs.c
@@ -519,7 +519,9 @@ chimera_nfs_server_notify(
                 if (nlm_cli->conn_count == 0) {
                     /* Last connection for this hostname -- release locks */
                     nlm_client_release_all_locks(&shared->nlm_state, nlm_cli,
-                                                 thread->vfs_thread, &anon_cred);
+                                                 thread->vfs_thread,
+                                                 thread->vfs->vfs_state,
+                                                 &anon_cred);
                     release_locks = true;
                 }
                 pthread_mutex_unlock(&shared->nlm_state.mutex);

--- a/src/server/nfs/nfs4_proc_lock.c
+++ b/src/server/nfs/nfs4_proc_lock.c
@@ -2,12 +2,16 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
+#include <stdlib.h>
+#include <xxhash.h>
+
 #include "nfs4_procs.h"
 #include "nfs4_status.h"
 #include "nfs4_session.h"
 #include "nfs4_state.h"
 #include "vfs/vfs_procs.h"
 #include "vfs/vfs_release.h"
+#include "vfs/vfs_state.h"
 
 /*
  * RFC 7530 §9.1.7 LOCK completion wrapper.  Advances the owner seqid(s)
@@ -88,21 +92,30 @@ chimera_nfs4_lock_finish(
 
 static void
 chimera_nfs4_lock_complete(
-    enum chimera_vfs_error error_code,
-    uint32_t               conflict_type,
-    uint64_t               conflict_offset,
-    uint64_t               conflict_length,
-    pid_t                  conflict_pid,
-    void                  *private_data)
+    enum chimera_vfs_lease_result result,
+    struct chimera_vfs_lease     *granted,
+    struct chimera_vfs_lease     *conflict,
+    void                         *private_data)
 {
-    struct nfs_request     *req        = private_data;
-    struct LOCK4args       *args       = &req->args_compound->argarray[req->index].oplock;
-    struct LOCK4res        *res        = &req->res_compound.resarray[req->index].oplock;
-    struct nfs_state_table *table      = &req->thread->shared->nfs4_state_table;
-    struct nfs_lock_state  *lock_state = req->nfs_state_ref;
-    uint32_t                client_short_id;
+    struct nfs_request       *req        = private_data;
+    struct LOCK4args         *args       = &req->args_compound->argarray[req->index].oplock;
+    struct LOCK4res          *res        = &req->res_compound.resarray[req->index].oplock;
+    struct nfs_state_table   *table      = &req->thread->shared->nfs4_state_table;
+    struct nfs_lock_state    *lock_state = req->nfs_state_ref;
+    struct nfs4_range_lease  *rl         = req->nfs_inflight_range;
+    struct chimera_vfs_state *vfs_state  = req->thread->vfs->vfs_state;
+    uint32_t                  client_short_id;
 
-    if (error_code == CHIMERA_VFS_OK) {
+    (void) granted;
+
+    req->nfs_inflight_range = NULL;
+
+    if (result == CHIMERA_VFS_LEASE_GRANTED) {
+        /* Link the granted range lease onto the lock_state so LOCKU /
+         * teardown can find and release it. */
+        rl->next                 = lock_state->range_leases;
+        lock_state->range_leases = rl;
+
         /* RFC 7530 §9.1.3: stateid.seqid starts at 1 for a new lock_stateid;
          * only increment when modifying an existing lock state. */
         if (!args->locker.new_lock_owner) {
@@ -117,9 +130,6 @@ chimera_nfs4_lock_complete(
 
         res->status = NFS4_OK;
 
-        /* Drop the acquire ref taken at lock entry.  The seqid advance
-         * + replay cache record runs inside chimera_nfs4_lock_complete
-         * (the wrapper, called via the macro below). */
         nfs_state_table_release(table, lock_state, NFS4_SLOT_TYPE_LOCK,
                                 req->thread->vfs_thread);
         req->nfs_state_ref = NULL;
@@ -127,11 +137,13 @@ chimera_nfs4_lock_complete(
         return;
     }
 
-    /* Failure: tear down the freshly-allocated lock_state if this was a
-     * new lock_owner request; otherwise just drop the acquire ref. */
+    /* DENIED (or wait=false BREAKING): discard the half-built range lease. */
+    chimera_vfs_state_put(vfs_state, rl->file_state);
+    free(rl);
+
+    /* Tear down the freshly-allocated lock_state if this was a new
+     * lock_owner request; otherwise just drop the acquire ref. */
     if (args->locker.new_lock_owner) {
-        /* Drop the acquire ref taken at create time, then destroy.  Destroy
-         * will release the dup'd handle as the last ref drops. */
         nfs_state_table_release(table, lock_state, NFS4_SLOT_TYPE_LOCK,
                                 req->thread->vfs_thread);
         nfs_lock_state_destroy(lock_state, table, req->thread->vfs_thread);
@@ -141,19 +153,15 @@ chimera_nfs4_lock_complete(
     }
     req->nfs_state_ref = NULL;
 
-    if (error_code == CHIMERA_VFS_EACCES || error_code == CHIMERA_VFS_EAGAIN) {
-        res->status          = NFS4ERR_DENIED;
-        res->denied.offset   = conflict_offset;
-        res->denied.length   = conflict_length;
-        res->denied.locktype = (conflict_type == CHIMERA_VFS_LOCK_READ) ?
-            READ_LT : WRITE_LT;
-        /* VFS does not expose the conflicting lock's NFS owner; zero it. */
-        res->denied.owner.clientid   = 0;
-        res->denied.owner.owner.len  = 0;
-        res->denied.owner.owner.data = NULL;
-    } else {
-        res->status = chimera_nfs4_errno_to_nfsstat4(error_code);
-    }
+    res->status          = NFS4ERR_DENIED;
+    res->denied.offset   = conflict ? conflict->offset : 0;
+    res->denied.length   = (conflict && conflict->length) ? conflict->length : UINT64_MAX;
+    res->denied.locktype = (conflict && (conflict->mode.granted & CHIMERA_VFS_LEASE_MODE_W)) ?
+        WRITE_LT : READ_LT;
+    /* vfs_state does not expose the conflicting lock's NFS owner; zero it. */
+    res->denied.owner.clientid   = 0;
+    res->denied.owner.owner.len  = 0;
+    res->denied.owner.owner.data = NULL;
     chimera_nfs4_lock_finish(req, res->status);
 } /* chimera_nfs4_lock_complete */
 
@@ -352,14 +360,68 @@ chimera_nfs4_lock(
         return;
     }
 
-    /* NFS uses UINT64_MAX to mean "to end of file"; POSIX fcntl uses 0. */
-    chimera_vfs_lock(thread->vfs_thread, &req->cred,
-                     handle,
-                     SEEK_SET,
-                     args->offset,
-                     args->length == UINT64_MAX ? 0 : args->length,
-                     lock_type,
-                     0,
-                     chimera_nfs4_lock_complete,
-                     req);
+    /* Acquire the byte-range lease through vfs_state for cross-protocol
+     * (NLM / SMB) coordination.  NFS uses UINT64_MAX for "to EOF";
+     * vfs_state uses 0. */
+    {
+        struct chimera_vfs_state      *vfs_state = thread->vfs->vfs_state;
+        struct chimera_vfs_file_state *file_state;
+        struct nfs4_range_lease       *rl;
+
+        rl = calloc(1, sizeof(*rl));
+        if (!rl) {
+            if (args->locker.new_lock_owner) {
+                nfs_state_table_release(table, lock_state, NFS4_SLOT_TYPE_LOCK,
+                                        thread->vfs_thread);
+                nfs_lock_state_destroy(lock_state, table, thread->vfs_thread);
+            } else {
+                nfs_state_table_release(table, lock_state, NFS4_SLOT_TYPE_LOCK,
+                                        thread->vfs_thread);
+            }
+            req->nfs_state_ref = NULL;
+            res->status        = NFS4ERR_RESOURCE;
+            chimera_nfs4_lock_finish(req, res->status);
+            return;
+        }
+
+        file_state = chimera_vfs_state_get(vfs_state,
+                                           handle->fh, handle->fh_len,
+                                           handle->fh_hash, true);
+        if (!file_state) {
+            free(rl);
+            if (args->locker.new_lock_owner) {
+                nfs_state_table_release(table, lock_state, NFS4_SLOT_TYPE_LOCK,
+                                        thread->vfs_thread);
+                nfs_lock_state_destroy(lock_state, table, thread->vfs_thread);
+            } else {
+                nfs_state_table_release(table, lock_state, NFS4_SLOT_TYPE_LOCK,
+                                        thread->vfs_thread);
+            }
+            req->nfs_state_ref = NULL;
+            res->status        = NFS4ERR_RESOURCE;
+            chimera_nfs4_lock_finish(req, res->status);
+            return;
+        }
+
+        rl->file_state         = file_state;
+        rl->lease.kind         = CHIMERA_VFS_LEASE_RANGE;
+        rl->lease.mode.granted = (lock_type == CHIMERA_VFS_LOCK_READ) ?
+            CHIMERA_VFS_LEASE_MODE_R : CHIMERA_VFS_LEASE_MODE_W;
+        rl->lease.offset           = args->offset;
+        rl->lease.length           = args->length == UINT64_MAX ? 0 : args->length;
+        rl->lease.owner.protocol   = CHIMERA_VFS_LEASE_PROTO_NFSV4;
+        rl->lease.owner.client_key = lock_state->lock_owner->client->client_id;
+        rl->lease.owner.owner_lo   = XXH3_64bits(lock_state->lock_owner->owner,
+                                                 lock_state->lock_owner->owner_len);
+        rl->lease.owner.owner_hi = 0;
+
+        req->nfs_inflight_range = rl;
+
+        /* wait=false: NFSv4 LOCK returns DENIED on conflict (matching the
+         * prior backend behavior).  A cross-protocol breakable conflict
+         * still kicks off the break inside try_insert. */
+        chimera_vfs_lease_acquire(vfs_state, file_state,
+                                  &rl->lease, &rl->ticket, false,
+                                  chimera_nfs4_lock_complete, req);
+    }
 } /* chimera_nfs4_lock */

--- a/src/server/nfs/nfs4_proc_lockt.c
+++ b/src/server/nfs/nfs4_proc_lockt.c
@@ -2,51 +2,15 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
+#include <string.h>
+#include <xxhash.h>
+
 #include "nfs4_procs.h"
 #include "nfs4_status.h"
+#include "nfs4_state.h"
 #include "vfs/vfs_procs.h"
 #include "vfs/vfs_release.h"
-
-static void
-chimera_nfs4_lockt_complete(
-    enum chimera_vfs_error error_code,
-    uint32_t               conflict_type,
-    uint64_t               conflict_offset,
-    uint64_t               conflict_length,
-    pid_t                  conflict_pid,
-    void                  *private_data)
-{
-    struct nfs_request             *req    = private_data;
-    struct LOCKT4res               *res    = &req->res_compound.resarray[req->index].oplockt;
-    struct chimera_vfs_open_handle *handle = req->handle;
-
-    chimera_vfs_release(req->thread->vfs_thread, handle);
-    req->handle = NULL;
-
-    if (error_code != CHIMERA_VFS_OK) {
-        res->status = chimera_nfs4_errno_to_nfsstat4(error_code);
-        chimera_nfs4_compound_complete(req, res->status);
-        return;
-    }
-
-    /* F_GETLK always returns OK; conflict is signalled via conflict_type. */
-    if (conflict_type == CHIMERA_VFS_LOCK_UNLOCK) {
-        res->status = NFS4_OK;
-    } else {
-        res->status          = NFS4ERR_DENIED;
-        res->denied.offset   = conflict_offset;
-        res->denied.length   = conflict_length;
-        res->denied.locktype = (conflict_type == CHIMERA_VFS_LOCK_READ)
-            ? READ_LT : WRITE_LT;
-        /* The VFS layer does not expose the conflicting lock's NFS owner;
-         * return a zeroed owner rather than the requester's clientid. */
-        res->denied.owner.clientid   = 0;
-        res->denied.owner.owner.len  = 0;
-        res->denied.owner.owner.data = NULL;
-    }
-
-    chimera_nfs4_compound_complete(req, res->status);
-} /* chimera_nfs4_lockt_complete */
+#include "vfs/vfs_state.h"
 
 static void
 chimera_nfs4_lockt_open_complete(
@@ -54,11 +18,15 @@ chimera_nfs4_lockt_open_complete(
     struct chimera_vfs_open_handle *handle,
     void                           *private_data)
 {
-    struct nfs_request *req  = private_data;
-    struct LOCKT4args  *args = &req->args_compound->argarray[req->index].oplockt;
-    struct LOCKT4res   *res  = &req->res_compound.resarray[req->index].oplockt;
-    uint32_t            lock_type;
-    uint64_t            vfs_length;
+    struct nfs_request            *req       = private_data;
+    struct LOCKT4args             *args      = &req->args_compound->argarray[req->index].oplockt;
+    struct LOCKT4res              *res       = &req->res_compound.resarray[req->index].oplockt;
+    struct chimera_vfs_state      *vfs_state = req->thread->vfs->vfs_state;
+    struct chimera_vfs_file_state *file_state;
+    struct chimera_vfs_lease       probe;
+    struct chimera_vfs_lease      *conflict = NULL;
+    enum chimera_vfs_lease_result  result;
+    uint64_t                       vfs_length;
 
     if (error_code != CHIMERA_VFS_OK) {
         res->status = chimera_nfs4_errno_to_nfsstat4(error_code);
@@ -66,7 +34,7 @@ chimera_nfs4_lockt_open_complete(
         return;
     }
 
-    /* RFC 7530 Section 16.11.4: same length rules as LOCK */
+    /* RFC 7530 §16.11.4: same length rules as LOCK */
     if (args->length == 0 ||
         (args->length != UINT64_MAX && args->offset > UINT64_MAX - args->length)) {
         chimera_vfs_release(req->thread->vfs_thread, handle);
@@ -75,26 +43,52 @@ chimera_nfs4_lockt_open_complete(
         return;
     }
 
-    req->handle = handle;
-
-    if (args->locktype == READ_LT || args->locktype == READW_LT) {
-        lock_type = CHIMERA_VFS_LOCK_READ;
-    } else {
-        lock_type = CHIMERA_VFS_LOCK_WRITE;
-    }
-
-    /* NFS uses UINT64_MAX to mean "to end of file"; POSIX fcntl uses 0. */
     vfs_length = args->length == UINT64_MAX ? 0 : args->length;
 
-    chimera_vfs_lock(req->thread->vfs_thread, &req->cred,
-                     handle,
-                     SEEK_SET,
-                     args->offset,
-                     vfs_length,
-                     lock_type,
-                     CHIMERA_VFS_LOCK_TEST,
-                     chimera_nfs4_lockt_complete,
-                     req);
+    file_state = chimera_vfs_state_get(vfs_state,
+                                       handle->fh, handle->fh_len,
+                                       handle->fh_hash, false);
+
+    if (!file_state) {
+        /* No state on this file means no lock could conflict. */
+        chimera_vfs_release(req->thread->vfs_thread, handle);
+        res->status = NFS4_OK;
+        chimera_nfs4_compound_complete(req, NFS4_OK);
+        return;
+    }
+
+    memset(&probe, 0, sizeof(probe));
+    probe.kind         = CHIMERA_VFS_LEASE_RANGE;
+    probe.mode.granted = (args->locktype == READ_LT || args->locktype == READW_LT)
+                         ? CHIMERA_VFS_LEASE_MODE_R : CHIMERA_VFS_LEASE_MODE_W;
+    probe.offset           = args->offset;
+    probe.length           = vfs_length;
+    probe.owner.protocol   = CHIMERA_VFS_LEASE_PROTO_NFSV4;
+    probe.owner.client_key = args->owner.clientid;
+    probe.owner.owner_lo   = XXH3_64bits(args->owner.owner.data,
+                                         args->owner.owner.len);
+    probe.owner.owner_hi = 0;
+
+    result = chimera_vfs_lease_test(file_state, &probe, &conflict);
+
+    if (result == CHIMERA_VFS_LEASE_GRANTED) {
+        res->status = NFS4_OK;
+    } else {
+        res->status          = NFS4ERR_DENIED;
+        res->denied.offset   = conflict ? conflict->offset : 0;
+        res->denied.length   = (conflict && conflict->length) ? conflict->length : UINT64_MAX;
+        res->denied.locktype = (conflict && (conflict->mode.granted & CHIMERA_VFS_LEASE_MODE_W))
+                               ? WRITE_LT : READ_LT;
+        res->denied.owner.clientid   = 0;
+        res->denied.owner.owner.len  = 0;
+        res->denied.owner.owner.data = NULL;
+    }
+
+    chimera_vfs_state_put(vfs_state, file_state);
+    chimera_vfs_release(req->thread->vfs_thread, handle);
+
+    /* LOCKT NFS4ERR_DENIED is a successful query result. */
+    chimera_nfs4_compound_complete(req, res->status);
 } /* chimera_nfs4_lockt_open_complete */
 
 void
@@ -112,7 +106,7 @@ chimera_nfs4_lockt(
         return;
     }
 
-    /* LOCKT operates on CURRENT_FH - open it temporarily to get a handle */
+    /* LOCKT operates on CURRENT_FH - open it temporarily to validate. */
     chimera_vfs_open_fh(thread->vfs_thread, &req->cred,
                         req->fh,
                         req->fhlen,

--- a/src/server/nfs/nfs4_proc_locku.c
+++ b/src/server/nfs/nfs4_proc_locku.c
@@ -2,63 +2,15 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
+#include <stdlib.h>
+
 #include "nfs4_procs.h"
 #include "nfs4_status.h"
 #include "nfs4_session.h"
 #include "nfs4_state.h"
 #include "vfs/vfs_procs.h"
 #include "vfs/vfs_release.h"
-
-static void
-chimera_nfs4_locku_complete(
-    enum chimera_vfs_error error_code,
-    uint32_t               conflict_type,
-    uint64_t               conflict_offset,
-    uint64_t               conflict_length,
-    pid_t                  conflict_pid,
-    void                  *private_data)
-{
-    struct nfs_request     *req        = private_data;
-    struct LOCKU4args      *args       = &req->args_compound->argarray[req->index].oplocku;
-    struct LOCKU4res       *res        = &req->res_compound.resarray[req->index].oplocku;
-    struct nfs_state_table *table      = &req->thread->shared->nfs4_state_table;
-    struct nfs_lock_state  *lock_state = req->nfs_state_ref;
-    struct nfs_lock_owner  *lock_owner = lock_state->lock_owner;
-    bool                    is_v40     = (req->minorversion == 0);
-    uint32_t                client_short_id;
-
-    if (error_code != CHIMERA_VFS_OK) {
-        nfs_state_table_release(table, lock_state, NFS4_SLOT_TYPE_LOCK,
-                                req->thread->vfs_thread);
-        req->nfs_state_ref = NULL;
-        res->status        = chimera_nfs4_errno_to_nfsstat4(error_code);
-        chimera_nfs4_compound_complete(req, res->status);
-        return;
-    }
-
-    lock_state->seqid += 1;
-    client_short_id    = (uint32_t) lock_owner->client->client_id;
-    nfs4_stateid_encode(&res->lock_stateid, lock_state->seqid,
-                        NFS4_STATEID_TYPE_LOCK,
-                        lock_state->shard, lock_state->slot_idx,
-                        lock_state->generation, client_short_id);
-    res->status = NFS4_OK;
-
-    /* RFC 7530 §9.1.7: record cached reply for the lock_owner. */
-    if (is_v40 && lock_owner) {
-        pthread_mutex_lock(&lock_owner->lock);
-        lock_owner->seqid = args->seqid;
-        nfs4_replay_record(&lock_owner->replay, args->seqid, OP_LOCKU,
-                           NFS4_OK, &res->lock_stateid);
-        pthread_mutex_unlock(&lock_owner->lock);
-    }
-
-    nfs_state_table_release(table, lock_state, NFS4_SLOT_TYPE_LOCK,
-                            req->thread->vfs_thread);
-    req->nfs_state_ref = NULL;
-
-    chimera_nfs4_compound_complete(req, NFS4_OK);
-} /* chimera_nfs4_locku_complete */
+#include "vfs/vfs_state.h"
 
 void
 chimera_nfs4_locku(
@@ -67,17 +19,19 @@ chimera_nfs4_locku(
     struct nfs_argop4                *argop,
     struct nfs_resop4                *resop)
 {
-    struct LOCKU4args              *args   = &argop->oplocku;
-    struct LOCKU4res               *res    = &resop->oplocku;
-    struct nfs_state_table         *table  = &thread->shared->nfs4_state_table;
-    bool                            is_v40 = (req->minorversion == 0);
-    void                           *state_void;
-    uint8_t                         state_type;
-    struct nfs_lock_state          *lock_state;
-    struct nfs_lock_owner          *lock_owner;
-    struct chimera_vfs_open_handle *handle;
-    uint64_t                        vfs_length;
-    nfsstat4                        status;
+    struct LOCKU4args        *args      = &argop->oplocku;
+    struct LOCKU4res         *res       = &resop->oplocku;
+    struct nfs_state_table   *table     = &thread->shared->nfs4_state_table;
+    struct chimera_vfs_state *vfs_state = thread->vfs->vfs_state;
+    bool                      is_v40    = (req->minorversion == 0);
+    void                     *state_void;
+    uint8_t                   state_type;
+    struct nfs_lock_state    *lock_state;
+    struct nfs_lock_owner    *lock_owner;
+    struct nfs4_range_lease  *rl, *prev, *match;
+    uint64_t                  vfs_length;
+    uint32_t                  client_short_id;
+    nfsstat4                  status;
 
     /* RFC 7530 §16.12.3: current filehandle must be set */
     if (req->fhlen == 0) {
@@ -97,9 +51,12 @@ chimera_nfs4_locku(
 
     lock_state          = state_void;
     lock_owner          = lock_state->lock_owner;
-    handle              = lock_state->handle;
     req->nfs_state_ref  = lock_state;
     req->nfs_state_type = NFS4_SLOT_TYPE_LOCK;
+
+    /* A LOCK stateid's lock_state always carries a lock_owner (set at
+     * nfs_lock_state_create); the deref below relies on it. */
+    chimera_nfs_abort_if(!lock_owner, "lock_state without lock_owner");
 
     if (is_v40 && lock_owner) {
         pthread_mutex_lock(&lock_owner->lock);
@@ -139,16 +96,61 @@ chimera_nfs4_locku(
         return;
     }
 
-    /* NFS uses UINT64_MAX to mean "to end of file"; POSIX fcntl uses 0. */
+    /* NFS uses UINT64_MAX to mean "to end of file"; vfs_state uses 0. */
     vfs_length = args->length == UINT64_MAX ? 0 : args->length;
 
-    chimera_vfs_lock(thread->vfs_thread, &req->cred,
-                     handle,
-                     SEEK_SET,
-                     args->offset,
-                     vfs_length,
-                     CHIMERA_VFS_LOCK_UNLOCK,
-                     0,
-                     chimera_nfs4_locku_complete,
-                     req);
+    /* RFC 7530 §16.12.4: the unlock range must match a held range exactly.
+     * Find and detach it from this lock_state. */
+    prev  = NULL;
+    match = NULL;
+    for (rl = lock_state->range_leases; rl; rl = rl->next) {
+        if (rl->lease.offset == args->offset && rl->lease.length == vfs_length) {
+            match = rl;
+            break;
+        }
+        prev = rl;
+    }
+
+    if (!match) {
+        nfs_state_table_release(table, lock_state, NFS4_SLOT_TYPE_LOCK,
+                                thread->vfs_thread);
+        req->nfs_state_ref = NULL;
+        res->status        = NFS4ERR_LOCK_RANGE;
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    if (prev) {
+        prev->next = match->next;
+    } else {
+        lock_state->range_leases = match->next;
+    }
+
+    /* Release the lease (sync) and free the range entry. */
+    chimera_vfs_lease_release(vfs_state, match->file_state, &match->lease);
+    chimera_vfs_state_put(vfs_state, match->file_state);
+    free(match);
+
+    lock_state->seqid += 1;
+    client_short_id    = (uint32_t) lock_owner->client->client_id;
+    nfs4_stateid_encode(&res->lock_stateid, lock_state->seqid,
+                        NFS4_STATEID_TYPE_LOCK,
+                        lock_state->shard, lock_state->slot_idx,
+                        lock_state->generation, client_short_id);
+    res->status = NFS4_OK;
+
+    /* RFC 7530 §9.1.7: record cached reply for the lock_owner. */
+    if (is_v40 && lock_owner) {
+        pthread_mutex_lock(&lock_owner->lock);
+        lock_owner->seqid = args->seqid;
+        nfs4_replay_record(&lock_owner->replay, args->seqid, OP_LOCKU,
+                           NFS4_OK, &res->lock_stateid);
+        pthread_mutex_unlock(&lock_owner->lock);
+    }
+
+    nfs_state_table_release(table, lock_state, NFS4_SLOT_TYPE_LOCK,
+                            thread->vfs_thread);
+    req->nfs_state_ref = NULL;
+
+    chimera_nfs4_compound_complete(req, NFS4_OK);
 } /* chimera_nfs4_locku */

--- a/src/server/nfs/nfs4_proc_open.c
+++ b/src/server/nfs/nfs4_proc_open.c
@@ -2,12 +2,84 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
+#include <xxhash.h>
+
 #include "nfs4_procs.h"
 #include "nfs4_status.h"
 #include "nfs4_attr.h"
 #include "nfs4_state.h"
 #include "vfs/vfs_procs.h"
 #include "vfs/vfs_release.h"
+#include "vfs/vfs_state.h"
+
+/*
+ * Acquire a cross-protocol SHARE reservation in vfs_state for a freshly
+ * created open_state.  Upstream's nfs_client_check_share_conflict already
+ * enforces share-mode conflicts *among NFSv4 owners of the same client*;
+ * this adds the NLM/SMB dimension so an NFSv4 OPEN that denies read/write
+ * collides with an SMB open holding that access (and vice versa).
+ *
+ * Returns NFS4_OK on success (lease stored on the state, released at
+ * open_state_cleanup), NFS4ERR_SHARE_DENIED on cross-protocol conflict.
+ */
+static nfsstat4
+chimera_nfs4_open_acquire_share(
+    struct nfs_request    *req,
+    struct nfs_open_state *state)
+{
+    struct OPEN4args               *args      = &req->args_compound->argarray[req->index].opopen;
+    struct chimera_vfs_state       *vfs_state = req->thread->vfs->vfs_state;
+    struct chimera_vfs_open_handle *handle    = state->handle;
+    struct chimera_vfs_file_state  *file_state;
+    struct chimera_vfs_lease       *conflict = NULL;
+    enum chimera_vfs_lease_result   result;
+    uint8_t                         granted = 0;
+    uint8_t                         denied  = 0;
+
+    if (args->share_access & OPEN4_SHARE_ACCESS_READ) {
+        granted |= CHIMERA_VFS_LEASE_MODE_R;
+    }
+    if (args->share_access & OPEN4_SHARE_ACCESS_WRITE) {
+        granted |= CHIMERA_VFS_LEASE_MODE_W;
+    }
+    if (args->share_deny & OPEN4_SHARE_DENY_READ) {
+        denied |= CHIMERA_VFS_LEASE_MODE_R;
+    }
+    if (args->share_deny & OPEN4_SHARE_DENY_WRITE) {
+        denied |= CHIMERA_VFS_LEASE_MODE_W;
+    }
+
+    if (granted == 0 && denied == 0) {
+        return NFS4_OK;
+    }
+
+    file_state = chimera_vfs_state_get(vfs_state,
+                                       handle->fh, handle->fh_len,
+                                       handle->fh_hash, true);
+    if (!file_state) {
+        return NFS4ERR_SERVERFAULT;
+    }
+
+    state->share_lease.kind             = CHIMERA_VFS_LEASE_SHARE;
+    state->share_lease.mode.granted     = granted;
+    state->share_lease.mode.denied      = denied;
+    state->share_lease.owner.protocol   = CHIMERA_VFS_LEASE_PROTO_NFSV4;
+    state->share_lease.owner.client_key = state->owner->client->client_id;
+    state->share_lease.owner.owner_lo   = XXH3_64bits(state->owner->owner,
+                                                      state->owner->owner_len);
+    state->share_lease.owner.owner_hi = 0;
+
+    result = chimera_vfs_state_try_insert(vfs_state, file_state,
+                                          &state->share_lease, &conflict);
+    if (result != CHIMERA_VFS_LEASE_GRANTED) {
+        chimera_vfs_state_put(vfs_state, file_state);
+        return NFS4ERR_SHARE_DENIED;
+    }
+
+    state->share_file_state = file_state;
+    state->share_lease_held = true;
+    return NFS4_OK;
+} /* chimera_nfs4_open_acquire_share */
 
 /*
  * Install a freshly-opened VFS handle into the unified state model, returning
@@ -67,14 +139,31 @@ chimera_nfs4_open_install_state(
                                 (uint32_t) client->client_id,
                                 out_stateid);
         chimera_vfs_release(req->thread->vfs_thread, handle);
+        /* The SHARE reservation acquired on the first OPEN of this
+         * (owner, fh) stays in force.  Broadening share bits on
+         * coalesce is not re-checked cross-protocol in this pass —
+         * upstream's intra-client check is likewise coalesce-exempt. */
     } else {
-        nfs_open_state_create(owner,
-                              handle->fh, handle->fh_len,
-                              args->share_access, args->share_deny,
-                              handle,
-                              (uint32_t) client->client_id,
-                              &req->thread->shared->nfs4_state_table,
-                              out_stateid);
+        struct nfs_open_state *new_state;
+        nfsstat4               share_status;
+
+        new_state = nfs_open_state_create(owner,
+                                          handle->fh, handle->fh_len,
+                                          args->share_access, args->share_deny,
+                                          handle,
+                                          (uint32_t) client->client_id,
+                                          &req->thread->shared->nfs4_state_table,
+                                          out_stateid);
+
+        /* Cross-protocol SHARE coordination.  On conflict, tear the
+         * just-created state back down (releasing the handle) and fail. */
+        share_status = chimera_nfs4_open_acquire_share(req, new_state);
+        if (share_status != NFS4_OK) {
+            nfs_open_state_destroy(new_state,
+                                   &req->thread->shared->nfs4_state_table,
+                                   req->thread->vfs_thread);
+            return share_status;
+        }
     }
 
     /* RFC 7530 §16.18.5: signal OPEN4_RESULT_CONFIRM for an unconfirmed

--- a/src/server/nfs/nfs4_state.c
+++ b/src/server/nfs/nfs4_state.c
@@ -699,7 +699,21 @@ open_state_cleanup(
     struct nfs_state_table    *table,
     struct chimera_vfs_thread *vfs_thread)
 {
+    struct chimera_vfs_state *vfs_state = vfs_thread ? vfs_thread->vfs->vfs_state : NULL;
+
     (void) table;
+
+    /* Release the cross-protocol SHARE reservation, if held. */
+    if (vfs_state && state->share_lease_held) {
+        chimera_vfs_lease_release(vfs_state, state->share_file_state,
+                                  &state->share_lease);
+        state->share_lease_held = false;
+    }
+    if (vfs_state && state->share_file_state) {
+        chimera_vfs_state_put(vfs_state, state->share_file_state);
+        state->share_file_state = NULL;
+    }
+
     if (state->handle && vfs_thread) {
         chimera_vfs_release(vfs_thread, state->handle);
         state->handle = NULL;
@@ -816,7 +830,25 @@ lock_state_cleanup(
     struct nfs_state_table    *table,
     struct chimera_vfs_thread *vfs_thread)
 {
+    struct chimera_vfs_state *vfs_state = vfs_thread ? vfs_thread->vfs->vfs_state : NULL;
+    struct nfs4_range_lease  *rl, *tmp;
+
     (void) table;
+
+    /* Drain any byte-range leases still held (ranges not explicitly
+     * released by LOCKU before CLOSE / lock-owner teardown). */
+    rl                  = state->range_leases;
+    state->range_leases = NULL;
+    while (rl) {
+        tmp = rl->next;
+        if (vfs_state) {
+            chimera_vfs_lease_release(vfs_state, rl->file_state, &rl->lease);
+            chimera_vfs_state_put(vfs_state, rl->file_state);
+        }
+        free(rl);
+        rl = tmp;
+    }
+
     if (state->handle && vfs_thread) {
         chimera_vfs_release(vfs_thread, state->handle);
         state->handle = NULL;

--- a/src/server/nfs/nfs4_state.h
+++ b/src/server/nfs/nfs4_state.h
@@ -16,7 +16,18 @@
 #include "nfs4_stateid.h"
 #include "nfs4_lease.h"
 #include "vfs/vfs.h"
+#include "vfs/vfs_state.h"
 #include "common/macros.h"
+
+/* One held NFSv4 byte-range, tracked so it can be released on LOCKU or
+ * cascaded at lock_state teardown.  vfs_state coordinates the range
+ * across NLM and SMB; the lease lives here for the lock_state's lifetime. */
+struct nfs4_range_lease {
+    struct chimera_vfs_lease           lease;
+    struct chimera_vfs_pending_acquire ticket;
+    struct chimera_vfs_file_state     *file_state;
+    struct nfs4_range_lease           *next;
+};
 
 /*
  * Unified NFSv4 state model.
@@ -200,6 +211,13 @@ struct nfs_open_state {
     struct nfs_lock_state          *locks;              /* utlist via next_in_open */
     UT_hash_handle                  hh;                 /* by fh in owner->states_by_fh */
 
+    /* vfs_state SHARE reservation for cross-protocol (NLM/SMB) share-mode
+     * coordination.  Held while the open_state is alive; released in
+     * open_state_cleanup. */
+    struct chimera_vfs_lease        share_lease;
+    struct chimera_vfs_file_state  *share_file_state;
+    bool                            share_lease_held;
+
     /* Lifetime: starts at 1 for the state's slot; each acquire bumps it.
      * destroy() flips `destroyed` and drops the +1.  When refcount reaches
      * zero AND destroyed is set, the handle is released and the struct
@@ -229,6 +247,11 @@ struct nfs_lock_state {
     uint32_t                        generation;
 
     struct chimera_vfs_open_handle *handle;             /* +1 distinct dup */
+
+    /* vfs_state RANGE leases held by this lock_state, one per locked
+     * byte-range.  LOCK appends, LOCKU removes the matching range, and
+     * lock_state_cleanup drains the remainder. */
+    struct nfs4_range_lease        *range_leases;
 
     /* utlist LL chains.  *_in_open is rooted on open_state->locks (CLOSE
      * cascade); *_in_owner is rooted on lock_owner->states (RELEASE_LOCKOWNER

--- a/src/server/nfs/nfs_common.h
+++ b/src/server/nfs/nfs_common.h
@@ -19,6 +19,7 @@
 #include "nfs_nlm_state.h"
 
 struct chimera_server_nfs_thread;
+struct nfs4_range_lease;
 
 struct nfs_nfs3_readdir_cursor {
     uint64_t       count;
@@ -56,6 +57,10 @@ struct nfs_request {
      * NFS4_SLOT_TYPE_OPEN / NFS4_SLOT_TYPE_LOCK. */
     void                             *nfs_state_ref;
     uint8_t                           nfs_state_type;
+    /* In-flight vfs_state byte-range lease for an async NFSv4 LOCK.
+     * Allocated at lock dispatch, linked onto the lock_state on grant,
+     * freed on denial.  See nfs4_proc_lock.c. */
+    struct nfs4_range_lease          *nfs_inflight_range;
     /* Per-owner seqid bookkeeping for the 4.0 OPEN flow.  Populated at
      * entry to chimera_nfs4_open after the seqid is classified NEW; nil on
      * 4.1+ and on replay/bad-seqid short-circuits.  All OPEN response

--- a/src/server/nfs/nfs_nlm.c
+++ b/src/server/nfs/nfs_nlm.c
@@ -5,6 +5,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <pthread.h>
+#include <xxhash.h>
 
 #include "nfs_common.h"
 #include "nfs_internal.h"
@@ -12,9 +13,38 @@
 #include "nfs_nlm_state.h"
 #include "vfs/vfs_procs.h"
 #include "vfs/vfs_release.h"
+#include "vfs/vfs_state.h"
 
 /* Convert NLM length (UINT64_MAX == to-EOF) to POSIX length (0 == to-EOF) */
 #define NLM_TO_POSIX_LEN(l) ((l) == UINT64_MAX ? 0 : (l))
+
+/* Map NLM caller_name (hostname) to a vfs_state owner.client_key. */
+static inline uint64_t
+nlm_owner_client_key(const char *hostname)
+{
+    return XXH3_64bits(hostname, strlen(hostname));
+} /* nlm_owner_client_key */
+
+/* Map NLM (oh_bytes, svid) to a vfs_state owner.owner_lo.  Two LOCK ops
+ * with the same (hostname, oh, svid) tuple will produce the same owner
+ * identity and therefore coalesce in the vfs_state conflict matrix. */
+static inline uint64_t
+nlm_owner_owner_lo(
+    const uint8_t *oh,
+    uint32_t       oh_len,
+    int32_t        svid)
+{
+    uint8_t buf[LM_MAXSTRLEN + sizeof(int32_t)];
+
+    if (oh_len > LM_MAXSTRLEN) {
+        oh_len = LM_MAXSTRLEN;
+    }
+    if (oh_len > 0) {
+        memcpy(buf, oh, oh_len);
+    }
+    memcpy(buf + oh_len, &svid, sizeof(svid));
+    return XXH3_64bits(buf, oh_len + sizeof(svid));
+} /* nlm_owner_owner_lo */
 
 /* -------------------------------------------------------------------------
  * Helper: send a simple nlm4_res reply
@@ -84,97 +114,88 @@ struct nlm_test_ctx {
 };
 
 static void
-chimera_nfs_nlm4_test_lock_cb(
-    enum chimera_vfs_error error_code,
-    uint32_t               conflict_type,
-    uint64_t               conflict_offset,
-    uint64_t               conflict_length,
-    pid_t                  conflict_pid,
-    void                  *private_data)
-{
-    struct nlm_test_ctx              *ctx      = private_data;
-    struct chimera_server_nfs_thread *thread   = ctx->thread;
-    struct chimera_server_nfs_shared *shared   = thread->shared;
-    struct evpl                      *evpl     = ctx->evpl;
-    struct evpl_rpc2_encoding        *encoding = ctx->encoding;
-    struct nlm4_testres               res;
-    int                               rc;
-
-    res.cookie.len     = ctx->cookie.len;
-    res.cookie.data    = ctx->cookie.data;
-    res.test_stat.stat = NLM4_DENIED_NOLOCKS;
-
-    if (error_code == CHIMERA_VFS_OK) {
-        res.test_stat.stat = NLM4_GRANTED;
-    } else if (error_code == CHIMERA_VFS_EACCES || error_code == CHIMERA_VFS_EAGAIN) {
-        res.test_stat.stat             = NLM4_DENIED;
-        res.test_stat.holder.exclusive = (conflict_type == CHIMERA_VFS_LOCK_WRITE);
-        res.test_stat.holder.svid      = conflict_pid;
-        res.test_stat.holder.oh.len    = 0;
-        res.test_stat.holder.oh.data   = NULL;
-        res.test_stat.holder.l_offset  = conflict_offset;
-        res.test_stat.holder.l_len     = (conflict_length == 0) ? UINT64_MAX : conflict_length;
-    }
-
-    chimera_nfs_debug("NLM TEST lock cb: vfs_error=%d stat=%d", error_code, res.test_stat.stat);
-
-    /* Release the open handle; TEST does not hold the lock */
-    chimera_vfs_release(thread->vfs_thread, ctx->handle);
-
-    if (ctx->proc == 16) {
-        shared->nlm_v4.send_call_NLMPROC4_TEST_RES(&shared->nlm_v4.rpc2, evpl, ctx->conn, NULL, &res, 0, 0, 0, NULL,
-                                                   NULL);
-    } else {
-        rc = shared->nlm_v4.send_reply_NLMPROC4_TEST(evpl, NULL, &res, encoding);
-        chimera_nfs_abort_if(rc, "Failed to send NLM TEST reply");
-    }
-
-    free(ctx);
-} /* chimera_nfs_nlm4_test_lock_cb */
-
-static void
 chimera_nfs_nlm4_test_open_cb(
     enum chimera_vfs_error          error_code,
     struct chimera_vfs_open_handle *handle,
     void                           *private_data)
 {
-    struct nlm_test_ctx              *ctx      = private_data;
-    struct chimera_server_nfs_thread *thread   = ctx->thread;
-    struct chimera_server_nfs_shared *shared   = thread->shared;
-    struct evpl                      *evpl     = ctx->evpl;
-    struct evpl_rpc2_encoding        *encoding = ctx->encoding;
+    struct nlm_test_ctx              *ctx       = private_data;
+    struct chimera_server_nfs_thread *thread    = ctx->thread;
+    struct chimera_server_nfs_shared *shared    = thread->shared;
+    struct evpl                      *evpl      = ctx->evpl;
+    struct evpl_rpc2_encoding        *encoding  = ctx->encoding;
+    struct chimera_vfs_state         *vfs_state = thread->vfs->vfs_state;
+    struct chimera_vfs_file_state    *file_state;
+    struct chimera_vfs_lease          probe;
+    struct chimera_vfs_lease         *conflict = NULL;
+    enum chimera_vfs_lease_result     result;
     struct nlm4_testres               res;
     int                               rc;
 
+    res.cookie.len  = ctx->cookie.len;
+    res.cookie.data = ctx->cookie.data;
+
     if (error_code != CHIMERA_VFS_OK) {
         chimera_nfs_debug("NLM TEST open failed: error %d -> NLM4_STALE_FH", error_code);
-        res.cookie.len     = ctx->cookie.len;
-        res.cookie.data    = ctx->cookie.data;
         res.test_stat.stat = NLM4_STALE_FH;
-        if (ctx->proc == 16) {
-            shared->nlm_v4.send_call_NLMPROC4_TEST_RES(&shared->nlm_v4.rpc2, evpl, ctx->conn, NULL, &res, 0, 0, 0, NULL,
-                                                       NULL);
-        } else {
-            rc = shared->nlm_v4.send_reply_NLMPROC4_TEST(evpl, NULL, &res, encoding);
-            chimera_nfs_abort_if(rc, "Failed to send NLM TEST reply");
-        }
-        free(ctx);
-        return;
+        goto send_reply;
     }
 
-    /* TEST probes whether the requested lock would conflict.
-     * Store handle in ctx; released inside the lock callback. */
-    ctx->handle = handle;
+    file_state = chimera_vfs_state_get(vfs_state,
+                                       handle->fh, handle->fh_len,
+                                       handle->fh_hash, false);
 
-    chimera_vfs_lock(thread->vfs_thread, NULL,
-                     handle,
-                     SEEK_SET,
-                     ctx->offset,
-                     ctx->length,
-                     ctx->exclusive ? CHIMERA_VFS_LOCK_WRITE : CHIMERA_VFS_LOCK_READ,
-                     CHIMERA_VFS_LOCK_TEST,
-                     chimera_nfs_nlm4_test_lock_cb,
-                     ctx);
+    if (!file_state) {
+        /* No state on this file means no leases held — TEST grants. */
+        chimera_vfs_release(thread->vfs_thread, handle);
+        res.test_stat.stat = NLM4_GRANTED;
+        goto send_reply;
+    }
+
+    memset(&probe, 0, sizeof(probe));
+    probe.kind         = CHIMERA_VFS_LEASE_RANGE;
+    probe.mode.granted = ctx->exclusive
+                             ? CHIMERA_VFS_LEASE_MODE_W
+                             : CHIMERA_VFS_LEASE_MODE_R;
+    probe.offset           = ctx->offset;
+    probe.length           = ctx->length;
+    probe.owner.protocol   = CHIMERA_VFS_LEASE_PROTO_NLM;
+    probe.owner.client_key = nlm_owner_client_key(ctx->caller_name);
+    probe.owner.owner_lo   = nlm_owner_owner_lo(ctx->oh, ctx->oh_len, ctx->svid);
+
+    result = chimera_vfs_lease_test(file_state, &probe, &conflict);
+
+    if (result == CHIMERA_VFS_LEASE_GRANTED) {
+        res.test_stat.stat = NLM4_GRANTED;
+    } else {
+        uint64_t conflict_len;
+        res.test_stat.stat             = NLM4_DENIED;
+        res.test_stat.holder.exclusive = conflict && (conflict->mode.granted &
+                                                      CHIMERA_VFS_LEASE_MODE_W);
+        res.test_stat.holder.svid     = 0;  /* not exposed by vfs_state */
+        res.test_stat.holder.oh.len   = 0;
+        res.test_stat.holder.oh.data  = NULL;
+        res.test_stat.holder.l_offset = conflict ? conflict->offset : 0;
+        conflict_len                  = (conflict && conflict->length)
+                                          ? conflict->length : UINT64_MAX;
+        res.test_stat.holder.l_len = conflict_len;
+    }
+
+    chimera_vfs_state_put(vfs_state, file_state);
+    chimera_vfs_release(thread->vfs_thread, handle);
+
+ send_reply:
+    chimera_nfs_debug("NLM TEST cb: stat=%d", res.test_stat.stat);
+
+    if (ctx->proc == 16) {
+        shared->nlm_v4.send_call_NLMPROC4_TEST_RES(&shared->nlm_v4.rpc2, evpl,
+                                                   ctx->conn, NULL, &res, 0, 0, 0,
+                                                   NULL, NULL);
+    } else {
+        rc = shared->nlm_v4.send_reply_NLMPROC4_TEST(evpl, NULL, &res, encoding);
+        chimera_nfs_abort_if(rc, "Failed to send NLM TEST reply");
+    }
+    free(ctx);
 } /* chimera_nfs_nlm4_test_open_cb */
 
 /* -------------------------------------------------------------------------
@@ -196,56 +217,47 @@ struct nlm_lock_ctx {
 };
 
 static void
-chimera_nfs_nlm4_lock_vfs_cb(
-    enum chimera_vfs_error error_code,
-    uint32_t               conflict_type,
-    uint64_t               conflict_offset,
-    uint64_t               conflict_length,
-    pid_t                  conflict_pid,
-    void                  *private_data)
+chimera_nfs_nlm4_lock_acquire_cb(
+    enum chimera_vfs_lease_result result,
+    struct chimera_vfs_lease     *granted,
+    struct chimera_vfs_lease     *conflict,
+    void                         *private_data)
 {
-    struct nlm_lock_ctx              *ctx      = private_data;
-    struct chimera_server_nfs_thread *thread   = ctx->thread;
-    struct chimera_server_nfs_shared *shared   = thread->shared;
-    struct evpl                      *evpl     = ctx->evpl;
-    struct evpl_rpc2_encoding        *encoding = ctx->encoding;
-    struct nlm_lock_entry            *entry    = ctx->entry;
+    struct nlm_lock_ctx              *ctx       = private_data;
+    struct chimera_server_nfs_thread *thread    = ctx->thread;
+    struct chimera_server_nfs_shared *shared    = thread->shared;
+    struct evpl                      *evpl      = ctx->evpl;
+    struct evpl_rpc2_encoding        *encoding  = ctx->encoding;
+    struct chimera_vfs_state         *vfs_state = thread->vfs->vfs_state;
+    struct nlm_lock_entry            *entry     = ctx->entry;
     struct nlm4_res                   res;
     int                               rc = 0;
+
+    (void) conflict;
+    (void) granted;
 
     res.cookie.len  = ctx->cookie.len;
     res.cookie.data = ctx->cookie.data;
 
-    if (error_code == CHIMERA_VFS_OK) {
-        /* Lock acquired -- mark entry confirmed, then persist outside the
-         * mutex (nlm_state_persist_client takes its own lock internally). */
+    if (result == CHIMERA_VFS_LEASE_GRANTED) {
         pthread_mutex_lock(&shared->nlm_state.mutex);
-        entry->pending = false;
+        entry->pending        = false;
+        entry->lease_inserted = true;
         pthread_mutex_unlock(&shared->nlm_state.mutex);
-        if (!ctx->nm_lock) {
-            nlm_state_persist_client(&shared->nlm_state, ctx->client);
-        }
-
         res.stat = NLM4_GRANTED;
-    } else if (error_code == CHIMERA_VFS_EACCES || error_code == CHIMERA_VFS_EAGAIN) {
-        /* Lock conflict -- remove the pending sentinel and reject */
-        pthread_mutex_lock(&shared->nlm_state.mutex);
-        DL_DELETE(ctx->client->locks, entry);
-        pthread_mutex_unlock(&shared->nlm_state.mutex);
-        chimera_vfs_release(thread->vfs_thread, entry->handle);
-        nlm_lock_entry_free(entry);
-        res.stat = ctx->block ? NLM4_BLOCKED : NLM4_DENIED;
     } else {
-        /* Other VFS error -- remove the pending sentinel */
+        /* DENIED or wait=false-with-BREAKING: drop the entry. */
         pthread_mutex_lock(&shared->nlm_state.mutex);
         DL_DELETE(ctx->client->locks, entry);
         pthread_mutex_unlock(&shared->nlm_state.mutex);
+        chimera_vfs_state_put(vfs_state, entry->file_state);
+        entry->file_state = NULL;
         chimera_vfs_release(thread->vfs_thread, entry->handle);
         nlm_lock_entry_free(entry);
-        res.stat = NLM4_DENIED_NOLOCKS;
+        res.stat = NLM4_DENIED;
     }
 
-    chimera_nfs_debug("NLM LOCK vfs cb: vfs_error=%d stat=%d block=%d", error_code, res.stat, ctx->block);
+    chimera_nfs_debug("NLM LOCK cb: result=%d stat=%d block=%d", result, res.stat, ctx->block);
 
     switch (ctx->proc) {
         case 2:
@@ -262,7 +274,7 @@ chimera_nfs_nlm4_lock_vfs_cb(
     chimera_nfs_abort_if(rc, "Failed to send NLM LOCK reply");
 
     free(ctx);
-} /* chimera_nfs_nlm4_lock_vfs_cb */
+} /* chimera_nfs_nlm4_lock_acquire_cb */
 
 static void
 chimera_nfs_nlm4_lock_open_cb(
@@ -270,12 +282,13 @@ chimera_nfs_nlm4_lock_open_cb(
     struct chimera_vfs_open_handle *handle,
     void                           *private_data)
 {
-    struct nlm_lock_ctx              *ctx      = private_data;
-    struct chimera_server_nfs_thread *thread   = ctx->thread;
-    struct chimera_server_nfs_shared *shared   = thread->shared;
-    struct evpl                      *evpl     = ctx->evpl;
-    struct evpl_rpc2_encoding        *encoding = ctx->encoding;
-    struct nlm_lock_entry            *entry    = ctx->entry;
+    struct nlm_lock_ctx              *ctx       = private_data;
+    struct chimera_server_nfs_thread *thread    = ctx->thread;
+    struct chimera_server_nfs_shared *shared    = thread->shared;
+    struct evpl                      *evpl      = ctx->evpl;
+    struct evpl_rpc2_encoding        *encoding  = ctx->encoding;
+    struct chimera_vfs_state         *vfs_state = thread->vfs->vfs_state;
+    struct nlm_lock_entry            *entry     = ctx->entry;
     struct nlm4_res                   res;
     int                               rc = 0;
 
@@ -308,83 +321,62 @@ chimera_nfs_nlm4_lock_open_cb(
 
     entry->handle = handle;
 
-    chimera_vfs_lock(thread->vfs_thread, NULL,
-                     handle,
-                     SEEK_SET,
-                     entry->offset,
-                     entry->length,
-                     entry->exclusive ? CHIMERA_VFS_LOCK_WRITE : CHIMERA_VFS_LOCK_READ,
-                     0,
-                     chimera_nfs_nlm4_lock_vfs_cb,
-                     ctx);
+    entry->file_state = chimera_vfs_state_get(vfs_state,
+                                              handle->fh, handle->fh_len,
+                                              handle->fh_hash, true);
+
+    if (!entry->file_state) {
+        pthread_mutex_lock(&shared->nlm_state.mutex);
+        DL_DELETE(ctx->client->locks, entry);
+        pthread_mutex_unlock(&shared->nlm_state.mutex);
+        chimera_vfs_release(thread->vfs_thread, handle);
+        nlm_lock_entry_free(entry);
+        res.cookie.len  = ctx->cookie.len;
+        res.cookie.data = ctx->cookie.data;
+        res.stat        = NLM4_DENIED_NOLOCKS;
+        switch (ctx->proc) {
+            case 2:
+                rc = shared->nlm_v4.send_reply_NLMPROC4_LOCK(evpl, NULL, &res, encoding);
+                break;
+            case 17:
+                shared->nlm_v4.send_call_NLMPROC4_LOCK_RES(&shared->nlm_v4.rpc2, evpl, ctx->conn, NULL, &res, 0, 0, 0,
+                                                           NULL, NULL);
+                break;
+            default:
+                rc = shared->nlm_v4.send_reply_NLMPROC4_NM_LOCK(evpl, NULL, &res, encoding);
+                break;
+        } /* switch */
+        chimera_nfs_abort_if(rc, "Failed to send NLM LOCK OOM reply");
+        free(ctx);
+        return;
+    }
+
+    entry->lease.kind         = CHIMERA_VFS_LEASE_RANGE;
+    entry->lease.mode.granted = entry->exclusive
+                                    ? CHIMERA_VFS_LEASE_MODE_W
+                                    : CHIMERA_VFS_LEASE_MODE_R;
+    entry->lease.offset           = entry->offset;
+    entry->lease.length           = entry->length;
+    entry->lease.owner.protocol   = CHIMERA_VFS_LEASE_PROTO_NLM;
+    entry->lease.owner.client_key = nlm_owner_client_key(ctx->client->hostname);
+    entry->lease.owner.owner_lo   = nlm_owner_owner_lo(entry->oh, entry->oh_len,
+                                                       entry->svid);
+
+    /* wait=ctx->block: blocking LOCK rides out cross-protocol breaks;
+     * non-blocking LOCK returns DENIED on any conflict.  Note: even with
+     * wait=true, same-protocol byte-range overlap returns DENIED
+     * synchronously — BREAKING only applies to caching leases. */
+    chimera_vfs_lease_acquire(vfs_state, entry->file_state,
+                              &entry->lease, &entry->ticket, ctx->block,
+                              chimera_nfs_nlm4_lock_acquire_cb, ctx);
 } /* chimera_nfs_nlm4_lock_open_cb */
 
 /* -------------------------------------------------------------------------
  * UNLOCK procedure callbacks
  * ---------------------------------------------------------------------- */
 
-struct nlm_unlock_ctx {
-    struct chimera_server_nfs_thread *thread;
-    struct evpl                      *evpl;
-    struct evpl_rpc2_encoding        *encoding;
-    struct evpl_rpc2_conn            *conn;
-    xdr_opaque                        cookie;
-    uint8_t                           cookie_buf[LM_MAXSTRLEN];
-    struct nlm_lock_entry            *entry;
-    struct nlm_client                *client;
-    int                               proc; /* 4=UNLOCK, 18=UNLOCK_MSG */
-};
-
-static void
-chimera_nfs_nlm4_unlock_vfs_cb(
-    enum chimera_vfs_error error_code,
-    uint32_t               conflict_type,
-    uint64_t               conflict_offset,
-    uint64_t               conflict_length,
-    pid_t                  conflict_pid,
-    void                  *private_data)
-{
-    struct nlm_unlock_ctx            *ctx      = private_data;
-    struct chimera_server_nfs_thread *thread   = ctx->thread;
-    struct chimera_server_nfs_shared *shared   = thread->shared;
-    struct evpl                      *evpl     = ctx->evpl;
-    struct evpl_rpc2_encoding        *encoding = ctx->encoding;
-    struct nlm_lock_entry            *entry    = ctx->entry;
-    struct nlm4_res                   res;
-    int                               rc;
-
-    if (error_code != CHIMERA_VFS_OK) {
-        /* Per RFC 1813, UNLOCK always returns NLM4_GRANTED regardless of
-         * VFS outcome, but log unexpected errors for diagnostics. */
-        chimera_nfs_debug("NLM UNLOCK vfs cb: VFS error %d -- replying NLM4_GRANTED per RFC",
-                          error_code);
-    } else {
-        chimera_nfs_debug("NLM UNLOCK vfs cb: ok");
-    }
-
-    chimera_vfs_release(thread->vfs_thread, entry->handle);
-
-    /* Entry was already removed from client->locks in chimera_nfs_nlm4_unlock
-     * to take exclusive ownership before releasing the mutex.
-     * Persist without holding the mutex (the function takes its own lock). */
-    nlm_state_persist_client(&shared->nlm_state, ctx->client);
-
-    nlm_lock_entry_free(entry);
-
-    res.cookie.len  = ctx->cookie.len;
-    res.cookie.data = ctx->cookie.data;
-    res.stat        = NLM4_GRANTED;
-
-    if (ctx->proc == 18) {
-        shared->nlm_v4.send_call_NLMPROC4_UNLOCK_RES(&shared->nlm_v4.rpc2, evpl, ctx->conn, NULL, &res, 0, 0, 0, NULL,
-                                                     NULL);
-    } else {
-        rc = shared->nlm_v4.send_reply_NLMPROC4_UNLOCK(evpl, NULL, &res, encoding);
-        chimera_nfs_abort_if(rc, "Failed to send NLM UNLOCK reply");
-    }
-
-    free(ctx);
-} /* chimera_nfs_nlm4_unlock_vfs_cb */
+/* UNLOCK is fully synchronous in vfs_state mode — lease_release and
+ * chimera_vfs_release are both sync — so no separate ctx/cb is needed. */
 
 /* =========================================================================
  * Public procedure handlers
@@ -421,11 +413,6 @@ chimera_nfs_nlm4_do_test(
     struct chimera_server_nfs_thread *thread = private_data;
     struct chimera_server_nfs_shared *shared = thread->shared;
     struct nlm_test_ctx              *ctx;
-    struct nlm_lock_entry            *conflict;
-    struct nlm4_testres               res;
-    uint8_t                           conflict_oh[LM_MAXSTRLEN];
-    uint32_t                          conflict_oh_len = 0;
-    int                               rc;
 
     chimera_nfs_debug("NLM TEST: caller='%.*s' fh_len=%u offset=%lu len=%lu exclusive=%d",
                       (int) args->alock.caller_name.len, args->alock.caller_name.str,
@@ -487,48 +474,8 @@ chimera_nfs_nlm4_do_test(
         memcpy(ctx->cookie_buf, args->cookie.data, args->cookie.len);
     }
 
-    /* Check the in-memory NLM state for conflicts first.
-     * This is necessary for in-process servers where all lock operations
-     * share the same OS process, making kernel F_GETLK ineffective for
-     * detecting cross-connection conflicts. */
-    pthread_mutex_lock(&shared->nlm_state.mutex);
-    conflict = nlm_state_find_conflict(&shared->nlm_state,
-                                       ctx->fh, ctx->fh_len,
-                                       ctx->caller_name,
-                                       ctx->oh, ctx->oh_len,
-                                       ctx->svid,
-                                       ctx->offset, ctx->length,
-                                       ctx->exclusive);
-    if (conflict) {
-        chimera_nfs_debug("NLM TEST: in-memory conflict found -> NLM4_DENIED");
-        /* Copy conflict->oh before releasing the mutex: the entry can be freed
-         * by another thread as soon as we unlock, making the pointer stale. */
-        conflict_oh_len = conflict->oh_len;
-        memcpy(conflict_oh, conflict->oh, conflict->oh_len);
-        res.cookie.len                 = ctx->cookie.len;
-        res.cookie.data                = ctx->cookie.data;
-        res.test_stat.stat             = NLM4_DENIED;
-        res.test_stat.holder.exclusive = conflict->exclusive;
-        res.test_stat.holder.svid      = conflict->svid;
-        res.test_stat.holder.oh.len    = conflict_oh_len;
-        res.test_stat.holder.oh.data   = conflict_oh;
-        res.test_stat.holder.l_offset  = conflict->offset;
-        res.test_stat.holder.l_len     = (conflict->length == 0)
-                                          ? UINT64_MAX
-                                          : conflict->length;
-        pthread_mutex_unlock(&shared->nlm_state.mutex);
-        if (ctx->proc == 16) {
-            shared->nlm_v4.send_call_NLMPROC4_TEST_RES(&shared->nlm_v4.rpc2, evpl, ctx->conn, NULL, &res, 0, 0, 0, NULL,
-                                                       NULL);
-        } else {
-            rc = shared->nlm_v4.send_reply_NLMPROC4_TEST(evpl, NULL, &res, encoding);
-            chimera_nfs_abort_if(rc, "Failed to send NLM TEST reply");
-        }
-        free(ctx);
-        return;
-    }
-    pthread_mutex_unlock(&shared->nlm_state.mutex);
-
+    /* Conflict detection is delegated to vfs_state — the test_open_cb
+     * does the lookup and probe synchronously once the FH is validated. */
     chimera_vfs_open_fh(thread->vfs_thread, NULL,
                         args->alock.fh.data,
                         args->alock.fh.len,
@@ -565,7 +512,6 @@ chimera_nfs_nlm4_do_lock(
     struct nlm_lock_entry            *entry;
     struct nlm_lock_ctx              *ctx;
     struct nlm_client                *client;
-    struct nlm_lock_entry            *conflict;
     struct nlm4_res                   res;
     char                              safe_hostname[LM_MAXSTRLEN + 1];
     size_t                            hn_len;
@@ -665,48 +611,14 @@ chimera_nfs_nlm4_do_lock(
     }
     ctx->client = client;
 
-    /* Check in-memory state for conflicts before attempting the VFS lock.
-     * Required for in-process servers where all NLM connections share the
-     * same OS PID, making the kernel's F_SETLK unable to detect conflicts
-     * between different NLM clients. */
-    conflict = nlm_state_find_conflict(&shared->nlm_state,
-                                       entry->fh, entry->fh_len,
-                                       client->hostname,
-                                       entry->oh, entry->oh_len,
-                                       entry->svid,
-                                       entry->offset, entry->length,
-                                       entry->exclusive);
-    if (conflict) {
-        pthread_mutex_unlock(&shared->nlm_state.mutex);
-        /* Always reply NLM4_DENIED: there is no pending-lock queue, so
-         * NLM4_BLOCKED would strand clients waiting for a GRANTED_MSG
-         * callback that will never arrive. */
-        chimera_nfs_debug("NLM LOCK: in-memory conflict -> NLM4_DENIED");
-        res.cookie.len  = ctx->cookie.len;
-        res.cookie.data = ctx->cookie.data;
-        res.stat        = NLM4_DENIED;
-        switch (ctx->proc) {
-            case 2:
-                rc = shared->nlm_v4.send_reply_NLMPROC4_LOCK(evpl, NULL, &res, encoding);
-                break;
-            case 17:
-                shared->nlm_v4.send_call_NLMPROC4_LOCK_RES(&shared->nlm_v4.rpc2, evpl, ctx->conn, NULL, &res, 0, 0, 0,
-                                                           NULL, NULL);
-                break;
-            default:
-                rc = shared->nlm_v4.send_reply_NLMPROC4_NM_LOCK(evpl, NULL, &res, encoding);
-                break;
-        } /* switch */
-        chimera_nfs_abort_if(rc, "Failed to send NLM LOCK conflict reply");
-        nlm_lock_entry_free(entry);
-        free(ctx);
-        return;
-    }
+    /* Conflict detection is delegated to vfs_state — handled inside
+     * chimera_nfs_nlm4_lock_open_cb / lock_acquire_cb. */
 
     /* Reject if an identical confirmed lock already exists for this owner.
-     * Two simultaneous LOCK requests from the same owner both bypass the
-     * self-exclusion check in nlm_state_find_conflict; this guard prevents
-     * a duplicate confirmed entry from slipping in. */
+     * Two simultaneous LOCK requests from the same owner could both reach
+     * vfs_state before either has been linked; the in-flight `pending`
+     * sentinel inserted below catches that, but we also short-circuit
+     * idempotent re-LOCKs of an already-held range to NLM4_GRANTED. */
     if (nlm_client_find_lock(client,
                              entry->oh, entry->oh_len,
                              entry->svid,
@@ -780,22 +692,79 @@ chimera_nfs_nlm4_cancel(
     struct evpl_rpc2_encoding *encoding,
     void                      *private_data)
 {
-    struct chimera_server_nfs_thread *thread = private_data;
-    struct chimera_server_nfs_shared *shared = thread->shared;
+    struct chimera_server_nfs_thread *thread    = private_data;
+    struct chimera_server_nfs_shared *shared    = thread->shared;
+    struct chimera_vfs_state         *vfs_state = thread->vfs->vfs_state;
+    struct nlm_client                *client;
+    struct nlm_lock_entry            *entry, *match;
     struct nlm4_res                   res;
+    char                              safe_hostname[LM_MAXSTRLEN + 1];
+    size_t                            hn_len;
+    uint64_t                          want_length;
+    bool                              cancelled       = false;
+    void                             *ctx_for_lock_cb = NULL;
     int                               rc;
 
-    chimera_nfs_debug("NLM CANCEL: caller='%.*s' -> NLM4_GRANTED (no pending queue)",
-                      (int) args->alock.caller_name.len, args->alock.caller_name.str);
+    chimera_nfs_debug("NLM CANCEL: caller='%.*s' fh_len=%u offset=%lu len=%lu",
+                      (int) args->alock.caller_name.len, args->alock.caller_name.str,
+                      (unsigned) args->alock.fh.len,
+                      (unsigned long) args->alock.l_offset,
+                      (unsigned long) args->alock.l_len);
 
-    /* Phase 1: no pending-lock queue, so there is nothing to cancel.
-     * Blocking clients that received NLM4_BLOCKED will retry. */
     res.cookie.len  = args->cookie.len;
     res.cookie.data = args->cookie.data;
     res.stat        = NLM4_GRANTED;
 
+    hn_len = args->alock.caller_name.len < LM_MAXSTRLEN
+             ? args->alock.caller_name.len : LM_MAXSTRLEN;
+    memcpy(safe_hostname, args->alock.caller_name.str, hn_len);
+    safe_hostname[hn_len] = '\0';
+
+    want_length = NLM_TO_POSIX_LEN(args->alock.l_len);
+
+    pthread_mutex_lock(&shared->nlm_state.mutex);
+    HASH_FIND_STR(shared->nlm_state.clients, safe_hostname, client);
+    match = NULL;
+    if (client) {
+        DL_FOREACH(client->locks, entry)
+        {
+            /* Only pending entries can be cancelled; granted entries
+             * require UNLOCK to release.  Match the exact (oh, svid,
+             * fh, range) tuple. */
+            if (!entry->pending) {
+                continue;
+            }
+            if (entry->oh_len  != args->alock.oh.len  ||
+                entry->fh_len  != args->alock.fh.len  ||
+                entry->svid    != args->alock.svid    ||
+                entry->offset  != args->alock.l_offset ||
+                entry->length  != want_length          ||
+                memcmp(entry->oh, args->alock.oh.data, entry->oh_len) != 0 ||
+                memcmp(entry->fh, args->alock.fh.data, entry->fh_len) != 0) {
+                continue;
+            }
+            match = entry;
+            break;
+        }
+    }
+    pthread_mutex_unlock(&shared->nlm_state.mutex);
+
+    if (match && match->file_state) {
+        /* The entry is queued inside vfs_state waiting on a break.  Try
+         * to dequeue it; if we win the race against the in-flight cb,
+         * synthesize a DENIED completion so the original LOCK reply is
+         * still sent (the protocol layer's cb tears down the entry). */
+        cancelled       = chimera_vfs_lease_acquire_cancel(vfs_state, &match->ticket);
+        ctx_for_lock_cb = match->ticket.private_data;
+    }
+
     rc = shared->nlm_v4.send_reply_NLMPROC4_CANCEL(evpl, NULL, &res, encoding);
     chimera_nfs_abort_if(rc, "Failed to send NLM CANCEL reply");
+
+    if (cancelled && ctx_for_lock_cb) {
+        chimera_nfs_nlm4_lock_acquire_cb(CHIMERA_VFS_LEASE_DENIED, NULL, NULL,
+                                         ctx_for_lock_cb);
+    }
 } /* chimera_nfs_nlm4_cancel */
 
 static void
@@ -808,11 +777,11 @@ chimera_nfs_nlm4_do_unlock(
     void                      *private_data,
     int                        proc)
 {
-    struct chimera_server_nfs_thread *thread = private_data;
-    struct chimera_server_nfs_shared *shared = thread->shared;
+    struct chimera_server_nfs_thread *thread    = private_data;
+    struct chimera_server_nfs_shared *shared    = thread->shared;
+    struct chimera_vfs_state         *vfs_state = thread->vfs->vfs_state;
     struct nlm_client                *client;
     struct nlm_lock_entry            *entry;
-    struct nlm_unlock_ctx            *ctx;
     struct nlm4_res                   res;
     char                              safe_hostname[LM_MAXSTRLEN + 1];
     size_t                            hn_len;
@@ -876,51 +845,36 @@ chimera_nfs_nlm4_do_unlock(
 
     /* Take exclusive ownership of the entry by removing it from the list
      * while still holding the mutex, preventing concurrent FREE_ALL or
-     * disconnect handlers from freeing it before the VFS call completes. */
+     * disconnect handlers from freeing it before the release path runs. */
     DL_DELETE(client->locks, entry);
     pthread_mutex_unlock(&shared->nlm_state.mutex);
 
-    ctx = calloc(1, sizeof(*ctx));
-    if (!ctx) {
-        /* Re-insert entry so state remains consistent, then reply with error */
-        pthread_mutex_lock(&shared->nlm_state.mutex);
-        DL_APPEND(client->locks, entry);
-        pthread_mutex_unlock(&shared->nlm_state.mutex);
-        res.cookie.len  = args->cookie.len;
-        res.cookie.data = args->cookie.data;
-        res.stat        = NLM4_DENIED_NOLOCKS;
-        if (proc == 18) {
-            shared->nlm_v4.send_call_NLMPROC4_UNLOCK_RES(&shared->nlm_v4.rpc2, evpl, conn, NULL, &res, 0, 0, 0, NULL,
-                                                         NULL);
-        } else {
-            rc = shared->nlm_v4.send_reply_NLMPROC4_UNLOCK(evpl, NULL, &res, encoding);
-            chimera_nfs_abort_if(rc, "Failed to send NLM UNLOCK reply");
-        }
-        return;
+    /* Release the vfs_state lease (sync), put the file_state ref (sync),
+     * and close the handle (sync).  RFC 1813 requires NLM4_GRANTED. */
+    if (entry->lease_inserted) {
+        chimera_vfs_lease_release(vfs_state, entry->file_state, &entry->lease);
+        entry->lease_inserted = false;
     }
-    ctx->thread   = thread;
-    ctx->evpl     = evpl;
-    ctx->encoding = encoding;
-    ctx->conn     = conn;
-    ctx->entry    = entry;
-    ctx->client   = client;
-    ctx->proc     = proc;
-
-    if (args->cookie.len > 0 && args->cookie.len <= LM_MAXSTRLEN) {
-        ctx->cookie.len  = args->cookie.len;
-        ctx->cookie.data = ctx->cookie_buf;
-        memcpy(ctx->cookie_buf, args->cookie.data, args->cookie.len);
+    if (entry->file_state) {
+        chimera_vfs_state_put(vfs_state, entry->file_state);
+        entry->file_state = NULL;
     }
+    if (entry->handle) {
+        chimera_vfs_release(thread->vfs_thread, entry->handle);
+    }
+    nlm_lock_entry_free(entry);
 
-    chimera_vfs_lock(thread->vfs_thread, NULL,
-                     entry->handle,
-                     SEEK_SET,
-                     entry->offset,
-                     entry->length,
-                     CHIMERA_VFS_LOCK_UNLOCK,
-                     0,
-                     chimera_nfs_nlm4_unlock_vfs_cb,
-                     ctx);
+    res.cookie.len  = args->cookie.len;
+    res.cookie.data = args->cookie.data;
+    res.stat        = NLM4_GRANTED;
+
+    if (proc == 18) {
+        shared->nlm_v4.send_call_NLMPROC4_UNLOCK_RES(&shared->nlm_v4.rpc2, evpl, conn, NULL, &res, 0, 0, 0, NULL,
+                                                     NULL);
+    } else {
+        rc = shared->nlm_v4.send_reply_NLMPROC4_UNLOCK(evpl, NULL, &res, encoding);
+        chimera_nfs_abort_if(rc, "Failed to send NLM UNLOCK reply");
+    }
 } /* chimera_nfs_nlm4_do_unlock */
 
 void
@@ -1328,7 +1282,9 @@ chimera_nfs_nlm4_free_all(
                                         CHIMERA_VFS_ANON_UID,
                                         CHIMERA_VFS_ANON_GID);
         nlm_client_release_all_locks(&shared->nlm_state, client,
-                                     thread->vfs_thread, &anon_cred);
+                                     thread->vfs_thread,
+                                     thread->vfs->vfs_state,
+                                     &anon_cred);
     }
     pthread_mutex_unlock(&shared->nlm_state.mutex);
     /* Remove on-disk state outside the mutex to avoid blocking I/O under lock */

--- a/src/server/nfs/nfs_nlm_state.c
+++ b/src/server/nfs/nfs_nlm_state.c
@@ -138,20 +138,19 @@ nlm_state_destroy(struct nlm_state *state)
 void
 nlm_state_load(struct nlm_state *state)
 {
+    /* Persistence is intentionally out of scope in this pass.  All lease
+    * state lives in memory and is lost on server restart.  We still
+    * remove any stale .nlm files from the legacy state directory so
+    * they don't accumulate, but we do not honor a grace period based
+    * on them (the in-memory state is empty, so there is nothing to
+    * reclaim).  See plan: "all the lease related metadata should be
+    * tracked only in memory even when its supposed to be persistent". */
     DIR           *dir;
     struct dirent *ent;
-    int            found = 0;
     struct stat    sb;
     char           path[NLM_CLIENT_PATH_MAX];
 
-    /* Ensure state directory exists */
     if (stat(state->state_dir, &sb) != 0) {
-        if (errno == ENOENT) {
-            if (mkdir_p(state->state_dir, 0700) != 0) {
-                chimera_nfs_debug("NLM: failed to create state directory %s: %s",
-                                  state->state_dir, strerror(errno));
-            }
-        }
         return;
     }
 
@@ -163,37 +162,12 @@ nlm_state_load(struct nlm_state *state)
     while ((ent = readdir(dir)) != NULL) {
         size_t nlen = strlen(ent->d_name);
         if (nlen > 4 && strcmp(ent->d_name + nlen - 4, ".nlm") == 0) {
-            found++;
+            snprintf(path, sizeof(path), "%s/%s",
+                     state->state_dir, ent->d_name);
+            unlink(path);
         }
     }
     closedir(dir);
-
-    if (found == 0) {
-        chimera_nfs_debug("NLM: no state files found, no grace period");
-    }
-
-    if (found > 0) {
-        state->in_grace  = 1;
-        state->grace_end = time(NULL) + NLM_GRACE_PERIOD_SECS;
-        chimera_nfs_debug("NLM: found %d state file(s), grace period active for %d seconds",
-                          found, NLM_GRACE_PERIOD_SECS);
-
-        /* Scan again and delete stale files from a previous crash.
-         * On restart the VFS locks are gone; clients must reclaim them.
-         * We keep no in-memory state for them -- the grace period is enough. */
-        dir = opendir(state->state_dir);
-        if (dir) {
-            while ((ent = readdir(dir)) != NULL) {
-                size_t nlen = strlen(ent->d_name);
-                if (nlen > 4 && strcmp(ent->d_name + nlen - 4, ".nlm") == 0) {
-                    snprintf(path, sizeof(path), "%s/%s",
-                             state->state_dir, ent->d_name);
-                    unlink(path);
-                }
-            }
-            closedir(dir);
-        }
-    }
 } /* nlm_state_load */
 
 struct nlm_client *
@@ -220,8 +194,25 @@ nlm_client_lookup_or_create(
     return client;
 } /* nlm_client_lookup_or_create */
 
+/* In-memory only: persistence is deliberately deferred.  These functions
+ * remain as no-op stubs so existing call sites do not need to be touched. */
+void
+nlm_state_persist_client_disabled(
+    struct nlm_state  *state,
+    struct nlm_client *client);
+
 void
 nlm_state_persist_client(
+    struct nlm_state  *state,
+    struct nlm_client *client)
+{
+    (void) state;
+    (void) client;
+} /* nlm_state_persist_client */
+
+#if 0
+static void
+nlm_state_persist_client_disabled(
     struct nlm_state  *state,
     struct nlm_client *client)
 {
@@ -327,18 +318,17 @@ nlm_state_persist_client(
                           tmp_path, path, strerror(errno));
         unlink(tmp_path);
     }
-} /* nlm_state_persist_client */
+} /* nlm_state_persist_client_disabled */
+#endif /* if 0 */
 
 void
 nlm_state_remove_client_file(
     struct nlm_state *state,
     const char       *hostname)
 {
-    char path[NLM_CLIENT_PATH_MAX];
-
-    nlm_state_client_file_path(state, hostname, path, sizeof(path));
-    chimera_nfs_debug("NLM: removing state file for '%s'", hostname);
-    unlink(path);
+    /* No-op in this pass — persistence deferred (see nlm_state_load). */
+    (void) state;
+    (void) hostname;
 } /* nlm_state_remove_client_file */
 
 void
@@ -346,10 +336,14 @@ nlm_client_release_all_locks(
     struct nlm_state          *state,
     struct nlm_client         *client,
     struct chimera_vfs_thread *vfs_thread,
+    struct chimera_vfs_state  *vfs_state,
     struct chimera_vfs_cred   *cred)
 {
     struct nlm_lock_entry *entry, *tmp;
     int                    count = 0;
+
+    (void) state;
+    (void) cred;
 
     DL_FOREACH(client->locks, entry)
     {
@@ -360,20 +354,21 @@ nlm_client_release_all_locks(
 
     DL_FOREACH_SAFE(client->locks, entry, tmp)
     {
-        /* Releasing the handle closes the underlying FD, which in turn
-         * releases all POSIX advisory locks held by this process on that file.
-         * Pending entries (handle == NULL) are in-flight VFS operations;
-         * skip releasing them here -- the VFS callback will clean up. */
+        /* Drop the vfs_state lease (if granted) and put the file_state
+         * ref.  Pending entries (lease_inserted == false) skip the
+         * release; their VFS callback will clean up when it fires. */
+        if (entry->lease_inserted) {
+            chimera_vfs_lease_release(vfs_state, entry->file_state, &entry->lease);
+            entry->lease_inserted = false;
+        }
+        if (entry->file_state) {
+            chimera_vfs_state_put(vfs_state, entry->file_state);
+            entry->file_state = NULL;
+        }
         if (entry->handle) {
             chimera_vfs_release(vfs_thread, entry->handle);
         }
         nlm_lock_entry_free(entry);
     }
     client->locks = NULL;
-
-    /* NOTE: the on-disk state file is NOT removed here.  Callers must call
-     * nlm_state_remove_client_file() after releasing the mutex so that
-     * blocking file I/O does not occur while the mutex is held.  The client
-     * object itself is kept in the hash table; it is freed in
-     * nlm_state_destroy() when the server shuts down. */
 } /* nlm_client_release_all_locks */

--- a/src/server/nfs/nfs_nlm_state.h
+++ b/src/server/nfs/nfs_nlm_state.h
@@ -15,6 +15,7 @@
 #include "nlm4_xdr.h"
 #include "vfs/vfs.h"
 #include "vfs/vfs_procs.h"
+#include "vfs/vfs_state.h"
 #include "vfs/vfs_cred.h"
 
 /* Magic number stored in nlm_client.magic to distinguish it from nfs4_session *
@@ -35,18 +36,26 @@
  * POSIX advisory locks are tied to the open file description.
  */
 struct nlm_lock_entry {
-    uint8_t                         fh[NFS4_FHSIZE];
-    uint32_t                        fh_len;
-    uint8_t                         oh[LM_MAXSTRLEN]; /* owner handle (opaque) */
-    uint32_t                        oh_len;
-    int32_t                         svid;   /* client-side PID */
-    uint64_t                        offset;
-    uint64_t                        length; /* 0 == to EOF (POSIX) */
-    bool                            exclusive;
-    bool                            pending; /* true while VFS open/lock in flight */
-    struct chimera_vfs_open_handle *handle; /* kept open while lock held */
-    struct nlm_lock_entry          *next;
-    struct nlm_lock_entry          *prev;
+    uint8_t                            fh[NFS4_FHSIZE];
+    uint32_t                           fh_len;
+    uint8_t                            oh[LM_MAXSTRLEN]; /* owner handle (opaque) */
+    uint32_t                           oh_len;
+    int32_t                            svid;   /* client-side PID */
+    uint64_t                           offset;
+    uint64_t                           length; /* 0 == to EOF (POSIX) */
+    bool                               exclusive;
+    bool                               pending; /* true while VFS open/acquire in flight */
+    struct chimera_vfs_open_handle    *handle; /* kept open while lock held */
+    /* vfs_state coordination — populated once the open completes and the
+     * acquire is dispatched.  `lease` is inserted into vfs_state on
+     * GRANTED; `ticket` is the queue entry for breakable conflicts; CANCEL
+     * uses chimera_vfs_lease_acquire_cancel on the ticket. */
+    struct chimera_vfs_lease           lease;
+    struct chimera_vfs_pending_acquire ticket;
+    struct chimera_vfs_file_state     *file_state;
+    bool                               lease_inserted; /* lease present in vfs_state */
+    struct nlm_lock_entry             *next;
+    struct nlm_lock_entry             *prev;
 };
 
 /*
@@ -317,4 +326,5 @@ nlm_client_release_all_locks(
     struct nlm_state          *state,
     struct nlm_client         *client,
     struct chimera_vfs_thread *vfs_thread,
+    struct chimera_vfs_state  *vfs_state,
     struct chimera_vfs_cred   *cred);

--- a/src/server/smb/CMakeLists.txt
+++ b/src/server/smb/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(chimera_smb SHARED
     smb_lsarpc.c smb_signing.c smb_proc_set_info_rename.c smb_proc_security.c
     smb_proc_reparse.c smb_proc_change_notify.c smb_proc_cancel.c
     smb_proc_sparse.c
+    smb_proc_lock.c smb_proc_oplock_break.c
     smb_notify.c smb_sharemode.c smb_ntlm.c
     smb_wbclient.c smb_auth.c smb_gssapi.c
     #idl/ndr_dcerpc.c

--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -389,6 +389,12 @@ chimera_smb_compound_reply(struct chimera_smb_compound *compound)
                 case SMB2_CHANGE_NOTIFY:
                     chimera_smb_change_notify_reply(&reply_cursor, request);
                     break;
+                case SMB2_LOCK:
+                    chimera_smb_lock_reply(&reply_cursor, request);
+                    break;
+                case SMB2_OPLOCK_BREAK:
+                    chimera_smb_oplock_break_reply(&reply_cursor, request);
+                    break;
                     /* SMB2_CANCEL never reaches this switch: chimera_smb_cancel
                      * always completes with STATUS_PENDING so the slot is
                      * skipped above. */
@@ -637,6 +643,12 @@ chimera_smb_compound_advance(struct chimera_smb_compound *compound)
             break;
         case SMB2_CANCEL:
             chimera_smb_cancel(request);
+            break;
+        case SMB2_LOCK:
+            chimera_smb_lock(request);
+            break;
+        case SMB2_OPLOCK_BREAK:
+            chimera_smb_oplock_break(request);
             break;
         default:
             chimera_smb_complete_request(request, SMB2_STATUS_NOT_IMPLEMENTED);
@@ -915,6 +927,12 @@ chimera_smb_server_handle_smb2(
                 break;
             case SMB2_CANCEL:
                 rc = chimera_smb_parse_cancel(request_cursor, request);
+                break;
+            case SMB2_LOCK:
+                rc = chimera_smb_parse_lock(request_cursor, request);
+                break;
+            case SMB2_OPLOCK_BREAK:
+                rc = chimera_smb_parse_oplock_break(request_cursor, request);
                 break;
             default:
                 chimera_smb_error("Received SMB2 message with unimplemented command %u",

--- a/src/server/smb/smb2.h
+++ b/src/server/smb/smb2.h
@@ -710,7 +710,20 @@ typedef uint8_t smb2_guid[SMB2_GUID_SIZE];
 #define SMB2_OPLOCK_LEVEL_BATCH                     0x09
 #define SMB2_OPLOCK_LEVEL_LEASE                     0xff
 
+/* SMB2 lease state bits (MS-SMB2 §2.2.13.2.8/2.2.13.2.10).  Note the
+ * bit positions differ from the internal vfs_state RWH masks — the
+ * smb_proc_create lease helpers do the translation. */
+#define SMB2_LEASE_NONE                             0x00
+#define SMB2_LEASE_READ_CACHING                     0x01
+#define SMB2_LEASE_HANDLE_CACHING                   0x02
+#define SMB2_LEASE_WRITE_CACHING                    0x04
+
 #define SMB2_CREATE_REQUEST_LEASE_SIZE              32
+#define SMB2_CREATE_REQUEST_LEASE_V2_SIZE           52
+#define SMB2_OPLOCK_BREAK_NOTIFY_LEASE_SIZE         44
+#define SMB2_OPLOCK_BREAK_NOTIFY_LEGACY_SIZE        24
+#define SMB2_OPLOCK_BREAK_ACK_LEASE_SIZE            36
+#define SMB2_OPLOCK_BREAK_ACK_LEGACY_SIZE           24
 
 #define SMB2_IMPERSONATION_ANONYMOUS                0x00000000
 #define SMB2_IMPERSONATION_IDENTIFICATION           0x00000001

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -347,6 +347,32 @@ struct chimera_smb_request {
         } flush;
 
         struct {
+            struct chimera_smb_file_id     file_id;
+            struct chimera_smb_open_file  *open_file;
+            uint16_t                       lock_count;
+            uint32_t                       lock_sequence;
+            /* Single-lock parse for Stage B (LockCount==1).  Multi-lock
+             * requests fall back to STATUS_INVALID_PARAMETER. */
+            uint64_t                       l_offset;
+            uint64_t                       l_length;
+            uint32_t                       l_flags;
+            struct chimera_smb_lock_entry *entry;  /* live for the in-flight acquire */
+        } lock;
+
+        struct {
+            /* Discriminated by request_struct_size: 24 = legacy oplock
+             * ack (§2.2.24.1); 36 = lease ack (§2.2.24.2). */
+            bool                       is_lease;
+            /* Legacy oplock ack fields. */
+            uint8_t                    oplock_level;
+            struct chimera_smb_file_id file_id;
+            /* Lease ack fields. */
+            uint8_t                    lease_key[16];
+            uint8_t                    lease_state;
+            uint32_t                   lease_flags;
+        } oplock_break;
+
+        struct {
             uint32_t                        ctl_code;
             struct chimera_smb_file_id      file_id;
             uint32_t                        input_offset;
@@ -570,6 +596,13 @@ struct chimera_server_smb_shared {
     struct chimera_smb_tree    *free_trees;
     pthread_mutex_t             trees_lock;
 };
+
+/* Forward decl so the inline open_file release paths can call into
+ * smb_proc_lock.c without including smb_procs.h here. */
+void
+chimera_smb_open_file_drain_locks(
+    struct chimera_server_smb_thread *thread,
+    struct chimera_smb_open_file     *open_file);
 
 struct chimera_server_smb_thread {
     struct evpl                       *evpl;
@@ -842,6 +875,41 @@ chimera_smb_conn_free(
         chimera_smb_notify_drop(conn->parked_notifies);
     }
 
+    /* Clear create_conn pointers on every open_file that references
+     * this conn.  When the session refcount drops to zero below, the
+     * trees and their opens get torn down — but if multi-channel keeps
+     * the session alive past this conn, the opens persist with stale
+     * create_conn pointers that the OPLOCK_BREAK path would dereference. */
+    HASH_ITER(hh, conn->session_handles, session_handle, tmp)
+    {
+        struct chimera_smb_session *s = session_handle->session;
+        int                         i;
+
+        if (!s) {
+            continue;
+        }
+        for (i = 0; i < s->max_trees; i++) {
+            struct chimera_smb_tree      *t = s->trees[i];
+            struct chimera_smb_open_file *of;
+            struct chimera_smb_open_file *tmp_of;
+            int                           b;
+
+            if (!t) {
+                continue;
+            }
+            for (b = 0; b < CHIMERA_SMB_OPEN_FILE_BUCKETS; b++) {
+                pthread_mutex_lock(&t->open_files_lock[b]);
+                HASH_ITER(hh, t->open_files[b], of, tmp_of)
+                {
+                    if (of->create_conn == conn) {
+                        of->create_conn = NULL;
+                    }
+                }
+                pthread_mutex_unlock(&t->open_files_lock[b]);
+            }
+        }
+    }
+
     HASH_ITER(hh, conn->session_handles, session_handle, tmp)
     {
         HASH_DELETE(hh, conn->session_handles, session_handle);
@@ -940,6 +1008,7 @@ chimera_smb_tree_free(
             open_file->refcnt--;
 
             if (open_file->refcnt == 0) {
+                chimera_smb_open_file_drain_locks(thread, open_file);
                 if (open_file->handle) {
                     chimera_vfs_release(thread->vfs_thread, open_file->handle);
                 }
@@ -1049,6 +1118,7 @@ chimera_smb_open_file_release(
     open_file->refcnt--;
 
     if (open_file->refcnt == 0) {
+        chimera_smb_open_file_drain_locks(request->compound->thread, open_file);
         if (open_file->handle) {
             chimera_vfs_release(request->compound->thread->vfs_thread, open_file->handle);
         }
@@ -1085,6 +1155,7 @@ chimera_smb_open_file_release_nr(
     open_file->refcnt--;
 
     if (open_file->refcnt == 0) {
+        chimera_smb_open_file_drain_locks(thread, open_file);
         if (open_file->handle) {
             chimera_vfs_release(thread->vfs_thread, open_file->handle);
         }

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -126,20 +126,216 @@ chimera_smb_create_gen_open_file(
      * Attribute-only opens (READ_ATTRIBUTES, SYNCHRONIZE, etc.)
      * bypass share mode enforcement, matching Windows/NTFS behavior.
      * Generic rights (MAXIMUM_ALLOWED, GENERIC_READ, etc.) expand to
-     * data-level access inside acquire and must participate. */
+     * data-level access inside the conflict check and must participate.
+     *
+     * Stage C: route through the unified vfs_state SHARE layer.  The
+     * legacy per-tree sharemode table is bypassed entirely — its
+     * behavior matrix is preserved by chimera_vfs_share_conflict in
+     * vfs_state.c. */
     if (type == CHIMERA_SMB_OPEN_FILE_TYPE_FILE && tree->share &&
-        (open_file->desired_access & SMB2_SHAREMODE_ACCESS_MASK)) {
+        (open_file->desired_access & SMB2_SHAREMODE_ACCESS_MASK) && oh) {
+        struct chimera_vfs_state      *vfs_state = thread->vfs_thread->vfs->vfs_state;
+        struct chimera_vfs_file_state *file_state;
+        uint32_t                       da = open_file->desired_access;
+        uint32_t                       sa = open_file->share_access;
+        uint8_t                        granted = 0, denied = 0;
+        struct chimera_vfs_lease      *conflict = NULL;
+        enum chimera_vfs_lease_result  result;
 
-        if (chimera_smb_sharemode_acquire(
-                &tree->share->sharemode,
-                parent_fh, parent_fh_len,
-                name, name_len,
-                open_file->desired_access,
-                open_file->share_access,
-                open_file) < 0) {
+        /* Map desired_access -> RWH grant.  Generic + maximum_allowed
+         * bits imply both R and W, matching the expansion that
+         * smb_sharemode_expand_access used to perform. */
+        if (da & (SMB2_FILE_READ_DATA | SMB2_FILE_EXECUTE |
+                  SMB2_FILE_READ_EA |
+                  SMB2_GENERIC_READ | SMB2_GENERIC_EXECUTE |
+                  SMB2_GENERIC_ALL | SMB2_MAXIMUM_ALLOWED)) {
+            granted |= CHIMERA_VFS_LEASE_MODE_R;
+        }
+        if (da & (SMB2_FILE_WRITE_DATA | SMB2_FILE_APPEND_DATA |
+                  SMB2_FILE_WRITE_EA |
+                  SMB2_GENERIC_WRITE |
+                  SMB2_GENERIC_ALL | SMB2_MAXIMUM_ALLOWED)) {
+            granted |= CHIMERA_VFS_LEASE_MODE_W;
+        }
+        if (da & SMB2_DELETE) {
+            granted |= CHIMERA_VFS_LEASE_MODE_D;
+        }
+
+        /* Map share_access -> RWH deny.  Each access bit NOT shared
+         * becomes a deny on the corresponding bit. */
+        if (!(sa & SMB2_FILE_SHARE_READ)) {
+            denied |= CHIMERA_VFS_LEASE_MODE_R;
+        }
+        if (!(sa & SMB2_FILE_SHARE_WRITE)) {
+            denied |= CHIMERA_VFS_LEASE_MODE_W;
+        }
+        if (!(sa & SMB2_FILE_SHARE_DELETE)) {
+            denied |= CHIMERA_VFS_LEASE_MODE_D;
+        }
+
+        file_state = chimera_vfs_state_get(vfs_state,
+                                           oh->fh, oh->fh_len,
+                                           oh->fh_hash, true);
+        if (!file_state) {
             open_file->handle = NULL;
             chimera_smb_open_file_free(thread, open_file);
             return NULL;
+        }
+
+        open_file->share_lease.kind             = CHIMERA_VFS_LEASE_SHARE;
+        open_file->share_lease.mode.granted     = granted;
+        open_file->share_lease.mode.denied      = denied;
+        open_file->share_lease.owner.protocol   = CHIMERA_VFS_LEASE_PROTO_SMB2;
+        open_file->share_lease.owner.client_key = request->session_handle->session->session_id;
+        /* The open itself is the owner — different opens, even by the
+         * same client, must satisfy share-mode constraints between
+         * themselves. */
+        open_file->share_lease.owner.owner_lo = open_file->file_id.pid;
+        open_file->share_lease.owner.owner_hi = open_file->file_id.vid;
+
+        result = chimera_vfs_state_try_insert(vfs_state, file_state,
+                                              &open_file->share_lease, &conflict);
+        if (result != CHIMERA_VFS_LEASE_GRANTED) {
+            chimera_vfs_state_put(vfs_state, file_state);
+            open_file->handle = NULL;
+            chimera_smb_open_file_free(thread, open_file);
+            return NULL;
+        }
+
+        open_file->share_file_state     = file_state;
+        open_file->share_lease_inserted = true;
+    }
+
+    /* Acquire a CACHING lease (SMB2 lease via RqLs, or legacy oplock
+     * via requested_oplock_level).  This is opportunistic — failure to
+     * grant just means the open succeeds with no lease.  Conflicts are
+     * resolved by vfs_state's conflict matrix; without break_cb wired
+     * (next task in Stage D), conflicting other-client leases force
+     * DENIED here, so we silently end up with no lease. */
+    if (type == CHIMERA_SMB_OPEN_FILE_TYPE_FILE && oh) {
+        struct chimera_vfs_state      *vfs_state = thread->vfs_thread->vfs->vfs_state;
+        struct chimera_vfs_file_state *file_state;
+        uint8_t                        req_smb  = 0;
+        uint8_t                        req_vfs  = 0;
+        bool                           via_rqls = false;
+        struct chimera_vfs_lease      *conflict = NULL;
+        enum chimera_vfs_lease_result  result;
+
+        if (request->create.ctx_present_mask & CHIMERA_SMB_CREATE_CTX_RQLS) {
+            via_rqls = true;
+            req_smb  = (uint8_t) (request->create.rqls.state & 0x07);
+        } else {
+            switch (request->create.requested_oplock_level) {
+                case SMB2_OPLOCK_LEVEL_II:
+                    req_smb = SMB2_LEASE_READ_CACHING;
+                    break;
+                case SMB2_OPLOCK_LEVEL_EXCLUSIVE:
+                    req_smb = SMB2_LEASE_READ_CACHING |
+                        SMB2_LEASE_WRITE_CACHING;
+                    break;
+                case SMB2_OPLOCK_LEVEL_BATCH:
+                    req_smb = SMB2_LEASE_READ_CACHING |
+                        SMB2_LEASE_WRITE_CACHING |
+                        SMB2_LEASE_HANDLE_CACHING;
+                    break;
+                default:
+                    req_smb = 0;
+                    break;
+            } /* switch */
+        }
+
+        /* SMB lease bits use R=0x01, H=0x02, W=0x04 — different layout
+         * from vfs_state's R/W/H mask, so map field-by-field. */
+        if (req_smb & SMB2_LEASE_READ_CACHING) {
+            req_vfs |= CHIMERA_VFS_LEASE_MODE_R;
+        }
+        if (req_smb & SMB2_LEASE_HANDLE_CACHING) {
+            req_vfs |= CHIMERA_VFS_LEASE_MODE_H;
+        }
+        if (req_smb & SMB2_LEASE_WRITE_CACHING) {
+            req_vfs |= CHIMERA_VFS_LEASE_MODE_W;
+        }
+
+        if (req_vfs != 0) {
+            file_state = chimera_vfs_state_get(vfs_state,
+                                               oh->fh, oh->fh_len,
+                                               oh->fh_hash, true);
+            if (file_state) {
+                open_file->caching_lease.kind             = CHIMERA_VFS_LEASE_CACHING;
+                open_file->caching_lease.mode.granted     = req_vfs;
+                open_file->caching_lease.owner.protocol   = CHIMERA_VFS_LEASE_PROTO_SMB2;
+                open_file->caching_lease.owner.client_key = request->session_handle->session->session_id;
+                /* For RqLs, owner identity is the lease_key (so multiple
+                 * opens with the same key by the same client coalesce —
+                 * the Samba locking.tdb rule).  For legacy oplocks,
+                 * each open is its own owner (use file_id). */
+                if (via_rqls) {
+                    memcpy(&open_file->caching_lease.owner.owner_lo,
+                           request->create.rqls.key, 8);
+                    memcpy(&open_file->caching_lease.owner.owner_hi,
+                           request->create.rqls.key + 8, 8);
+                    /* Mirror the lease_key onto the open_file for the
+                     * break notification builder. */
+                    memcpy(open_file->lease_key, request->create.rqls.key, 16);
+                    if (request->create.rqls.is_v2) {
+                        memcpy(open_file->parent_lease_key,
+                               request->create.rqls.parent_key, 16);
+                        open_file->lease_epoch = request->create.rqls.epoch;
+                    }
+                } else {
+                    open_file->caching_lease.owner.owner_lo = open_file->file_id.pid;
+                    open_file->caching_lease.owner.owner_hi = open_file->file_id.vid;
+                }
+                /* Wire the break callback so vfs_state can notify the
+                 * client when another acquirer needs this lease. */
+                open_file->caching_lease.owner.break_cb   = chimera_smb_lease_break_cb;
+                open_file->caching_lease.owner.cb_private = open_file;
+                open_file->create_conn                    = request->compound->conn;
+
+                result = chimera_vfs_state_try_insert(vfs_state, file_state,
+                                                      &open_file->caching_lease,
+                                                      &conflict);
+                if (result == CHIMERA_VFS_LEASE_GRANTED) {
+                    open_file->caching_file_state     = file_state;
+                    open_file->caching_lease_inserted = true;
+                    /* Record granted SMB-side state on the open_file.
+                     * lease_state stores the SMB lease bits, which is
+                     * what the response context emitter wants. */
+                    open_file->lease_state = 0;
+                    if (req_vfs & CHIMERA_VFS_LEASE_MODE_R) {
+                        open_file->lease_state |= SMB2_LEASE_READ_CACHING;
+                    }
+                    if (req_vfs & CHIMERA_VFS_LEASE_MODE_H) {
+                        open_file->lease_state |= SMB2_LEASE_HANDLE_CACHING;
+                    }
+                    if (req_vfs & CHIMERA_VFS_LEASE_MODE_W) {
+                        open_file->lease_state |= SMB2_LEASE_WRITE_CACHING;
+                    }
+                    if (via_rqls) {
+                        open_file->oplock_level = SMB2_OPLOCK_LEVEL_LEASE;
+                    } else {
+                        /* Translate granted RWH back to legacy oplock
+                         * level.  Without H, the closest legacy match
+                         * is EXCLUSIVE for RW or II for R only. */
+                        if ((req_vfs & (CHIMERA_VFS_LEASE_MODE_R |
+                                        CHIMERA_VFS_LEASE_MODE_W |
+                                        CHIMERA_VFS_LEASE_MODE_H)) ==
+                            (CHIMERA_VFS_LEASE_MODE_R |
+                             CHIMERA_VFS_LEASE_MODE_W |
+                             CHIMERA_VFS_LEASE_MODE_H)) {
+                            open_file->oplock_level = SMB2_OPLOCK_LEVEL_BATCH;
+                        } else if (req_vfs & CHIMERA_VFS_LEASE_MODE_W) {
+                            open_file->oplock_level = SMB2_OPLOCK_LEVEL_EXCLUSIVE;
+                        } else {
+                            open_file->oplock_level = SMB2_OPLOCK_LEVEL_II;
+                        }
+                    }
+                } else {
+                    chimera_vfs_state_put(vfs_state, file_state);
+                    open_file->lease_state  = 0;
+                    open_file->oplock_level = SMB2_OPLOCK_LEVEL_NONE;
+                }
+            }
         }
     }
 
@@ -856,11 +1052,54 @@ struct chimera_smb_create_response_emitter {
         uint32_t                    out_size);
 };
 
+/* Build the RqLs response body.  v1 = 32 bytes, v2 = 52 bytes.  The
+ * granted state was decided at CREATE time and stored on the open_file
+ * by chimera_smb_create_gen_open_file. */
+static int
+build_rqls_response(
+    struct chimera_smb_request *request,
+    uint8_t                    *out,
+    uint32_t                    out_size)
+{
+    struct chimera_smb_open_file *of = request->create.r_open_file;
+    bool                          v2 = request->create.rqls.is_v2 != 0;
+    int                           needed;
+
+    if (!of) {
+        return -1;
+    }
+
+    needed = v2 ? SMB2_CREATE_REQUEST_LEASE_V2_SIZE
+                : SMB2_CREATE_REQUEST_LEASE_SIZE;
+    if (out_size < (uint32_t) needed) {
+        return -1;
+    }
+
+    /* LeaseKey (16) */
+    memcpy(out, of->lease_key, 16);
+    /* LeaseState (4) — lo byte from open_file->lease_state, upper bytes 0. */
+    out[16] = of->lease_state;
+    out[17] = 0;
+    out[18] = 0;
+    out[19] = 0;
+    /* LeaseFlags (4) — reserved at CREATE response time. */
+    out[20] = 0; out[21] = 0; out[22] = 0; out[23] = 0;
+    /* LeaseDuration (8) — reserved. */
+    memset(out + 24, 0, 8);
+    if (v2) {
+        memcpy(out + 32, of->parent_lease_key, 16);
+        out[48] = of->lease_epoch & 0xff;
+        out[49] = (of->lease_epoch >> 8) & 0xff;
+        out[50] = 0; out[51] = 0;
+    }
+    return needed;
+} /* build_rqls_response */
+
 /* *INDENT-OFF* */ /* uncrustify oscillates on aligned struct-init tables */
 static const struct chimera_smb_create_response_emitter smb_create_response_emitters[] = {
-    { CHIMERA_SMB_CREATE_CTX_MXAC, "MxAc", build_mxac_response },
-    /* Phase 1: + RqLs (lease grant)
-     * Phase 3: + DH2Q (durable handle grant), DHnQ
+    { CHIMERA_SMB_CREATE_CTX_MXAC, "MxAc", build_mxac_response  },
+    { CHIMERA_SMB_CREATE_CTX_RQLS, "RqLs", build_rqls_response  },
+    /* Phase 3: + DH2Q (durable handle grant), DHnQ
      * Phase 8: + QFid (32-byte on-disk id) */
     { 0,                           NULL,   NULL                },
 };
@@ -941,8 +1180,12 @@ chimera_smb_create_reply(
 
     evpl_iovec_cursor_append_uint16(reply_cursor, SMB2_CREATE_REPLY_SIZE);
 
-    /* Oplock level */
-    evpl_iovec_cursor_append_uint8(reply_cursor, SMB2_OPLOCK_LEVEL_NONE);
+    /* Oplock level — granted at CREATE time and stored on the open_file
+     * by the CACHING acquire above; defaults to NONE if no lease. */
+    evpl_iovec_cursor_append_uint8(reply_cursor,
+                                   request->create.r_open_file
+                                   ? request->create.r_open_file->oplock_level
+                                   : SMB2_OPLOCK_LEVEL_NONE);
 
     /* Flags */
     evpl_iovec_cursor_append_uint8(reply_cursor, 0);

--- a/src/server/smb/smb_proc_lock.c
+++ b/src/server/smb/smb_proc_lock.c
@@ -1,0 +1,300 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "smb_internal.h"
+#include "smb_procs.h"
+#include "smb_session.h"
+#include "common/misc.h"
+#include "vfs/vfs.h"
+#include "vfs/vfs_procs.h"
+#include "vfs/vfs_state.h"
+
+#define SMB2_LOCK_REQUEST_SIZE    48   /* fixed; LockCount==1 in this build */
+#define SMB2_LOCK_REPLY_SIZE      4
+
+/* Per MS-SMB2 §2.2.26.1 */
+#define SMB2_LOCKFLAG_SHARED_LOCK 0x00000001
+#define SMB2_LOCKFLAG_EXCLUSIVE   0x00000002
+#define SMB2_LOCKFLAG_UNLOCK      0x00000004
+#define SMB2_LOCKFLAG_FAIL_IMM    0x00000010
+
+#define SMB2_LOCKFLAG_KIND_MASK   (SMB2_LOCKFLAG_SHARED_LOCK | \
+                                   SMB2_LOCKFLAG_EXCLUSIVE   | \
+                                   SMB2_LOCKFLAG_UNLOCK)
+
+/* One held byte-range, owned by the open_file.  Released on UNLOCK or
+ * at close via chimera_smb_open_file_drain_locks. */
+struct chimera_smb_lock_entry {
+    struct chimera_vfs_lease           lease;
+    struct chimera_vfs_pending_acquire ticket;
+    struct chimera_vfs_file_state     *file_state;
+    struct chimera_smb_open_file      *open_file;
+    /* Set while the acquire is in flight; cleared once cb has fired. */
+    struct chimera_smb_request        *pending_req;
+    bool                               lease_inserted;
+    struct chimera_smb_lock_entry     *prev;
+    struct chimera_smb_lock_entry     *next;
+};
+
+SYMBOL_EXPORT void
+chimera_smb_open_file_drain_locks(
+    struct chimera_server_smb_thread *thread,
+    struct chimera_smb_open_file     *open_file)
+{
+    struct chimera_smb_lock_entry *entry, *tmp;
+    struct chimera_vfs_state      *vfs_state = thread->vfs_thread->vfs->vfs_state;
+
+    /* Drop the SHARE-mode reservation first.  Release any byte-range
+     * locks after — they may share the same file_state. */
+    if (open_file->share_lease_inserted) {
+        chimera_vfs_lease_release(vfs_state, open_file->share_file_state,
+                                  &open_file->share_lease);
+        open_file->share_lease_inserted = false;
+    }
+    if (open_file->share_file_state) {
+        chimera_vfs_state_put(vfs_state, open_file->share_file_state);
+        open_file->share_file_state = NULL;
+    }
+
+    /* Drop the caching lease (oplock / SMB2 lease) if held. */
+    if (open_file->caching_lease_inserted) {
+        chimera_vfs_lease_release(vfs_state, open_file->caching_file_state,
+                                  &open_file->caching_lease);
+        open_file->caching_lease_inserted = false;
+    }
+    if (open_file->caching_file_state) {
+        chimera_vfs_state_put(vfs_state, open_file->caching_file_state);
+        open_file->caching_file_state = NULL;
+    }
+
+    if (!open_file->lock_entries) {
+        return;
+    }
+
+    /* Detach the whole list head before walking — the loop frees each
+     * entry, so leaving them linked would invite use-after-free both at
+     * the analyzer level and in any concurrent iteration. */
+    entry                   = open_file->lock_entries;
+    open_file->lock_entries = NULL;
+
+    while (entry) {
+        tmp = entry->next;
+        if (entry->lease_inserted) {
+            chimera_vfs_lease_release(vfs_state, entry->file_state, &entry->lease);
+        }
+        if (entry->file_state) {
+            chimera_vfs_state_put(vfs_state, entry->file_state);
+        }
+        free(entry);
+        entry = tmp;
+    }
+} /* chimera_smb_open_file_drain_locks */
+
+int
+chimera_smb_parse_lock(
+    struct evpl_iovec_cursor   *request_cursor,
+    struct chimera_smb_request *request)
+{
+    uint16_t reserved_lock_seq_lo;
+    uint32_t reserved_lock_seq_hi;
+    uint32_t reserved;
+
+    if (unlikely(request->request_struct_size != SMB2_LOCK_REQUEST_SIZE)) {
+        chimera_smb_error("Received SMB2 LOCK request with invalid struct size (%u expected %u)",
+                          request->request_struct_size,
+                          SMB2_LOCK_REQUEST_SIZE);
+        request->status = SMB2_STATUS_INVALID_PARAMETER;
+        return -1;
+    }
+
+    evpl_iovec_cursor_get_uint16(request_cursor, &request->lock.lock_count);
+    /* LockSequenceNumber is 4 bits + LockSequenceIndex 28 bits = 32 bits.
+     * We don't replay-detect by sequence in Stage B; just store. */
+    evpl_iovec_cursor_get_uint16(request_cursor, &reserved_lock_seq_lo);
+    evpl_iovec_cursor_get_uint16(request_cursor, (uint16_t *) &reserved_lock_seq_hi);
+    request->lock.lock_sequence = ((uint32_t) reserved_lock_seq_lo) |
+        (((uint32_t) reserved_lock_seq_hi) << 16);
+    evpl_iovec_cursor_get_uint64(request_cursor, &request->lock.file_id.pid);
+    evpl_iovec_cursor_get_uint64(request_cursor, &request->lock.file_id.vid);
+
+    if (unlikely(request->lock.lock_count == 0)) {
+        request->status = SMB2_STATUS_INVALID_PARAMETER;
+        return -1;
+    }
+
+    /* Stage B supports LockCount==1.  Multi-lock requests fall through
+    * to INVALID_PARAMETER below, after we've consumed at least one. */
+    evpl_iovec_cursor_get_uint64(request_cursor, &request->lock.l_offset);
+    evpl_iovec_cursor_get_uint64(request_cursor, &request->lock.l_length);
+    evpl_iovec_cursor_get_uint32(request_cursor, &request->lock.l_flags);
+    evpl_iovec_cursor_get_uint32(request_cursor, &reserved);
+
+    if (request->lock.lock_count > 1) {
+        chimera_smb_error("SMB2 LOCK multi-lock requests (count=%u) not supported in Stage B",
+                          request->lock.lock_count);
+        request->status = SMB2_STATUS_INVALID_PARAMETER;
+        return -1;
+    }
+
+    return 0;
+} /* chimera_smb_parse_lock */
+
+static void
+chimera_smb_lock_acquire_cb(
+    enum chimera_vfs_lease_result result,
+    struct chimera_vfs_lease     *granted,
+    struct chimera_vfs_lease     *conflict,
+    void                         *private_data)
+{
+    struct chimera_smb_lock_entry *entry     = private_data;
+    struct chimera_smb_request    *request   = entry->pending_req;
+    struct chimera_smb_open_file  *open_file = entry->open_file;
+    struct chimera_vfs_state      *vfs_state = request->compound->thread->vfs_thread->vfs->vfs_state;
+    uint32_t                       status;
+
+    (void) granted;
+    (void) conflict;
+
+    entry->pending_req = NULL;
+
+    if (result == CHIMERA_VFS_LEASE_GRANTED) {
+        entry->lease_inserted = true;
+        DL_APPEND(open_file->lock_entries, entry);
+        status = SMB2_STATUS_SUCCESS;
+    } else {
+        chimera_vfs_state_put(vfs_state, entry->file_state);
+        free(entry);
+        request->lock.entry = NULL;
+        /* MS-SMB2 §3.3.5.14 maps a lock denied by an existing range to
+         * STATUS_LOCK_NOT_GRANTED (or _RANGE for SMB2 v.s. SMB1 spec
+         * variants).  Use _NOT_GRANTED — accepted by Windows clients. */
+        status = SMB2_STATUS_LOCK_NOT_GRANTED;
+    }
+
+    chimera_smb_open_file_release(request, open_file);
+    chimera_smb_complete_request(request, status);
+} /* chimera_smb_lock_acquire_cb */
+
+void
+chimera_smb_lock(struct chimera_smb_request *request)
+{
+    struct chimera_server_smb_thread *thread    = request->compound->thread;
+    struct chimera_vfs_state         *vfs_state = thread->vfs_thread->vfs->vfs_state;
+    struct chimera_smb_open_file     *open_file;
+    struct chimera_smb_lock_entry    *entry;
+    uint32_t                          kind;
+    uint64_t                          want_length;
+    bool                              wait;
+
+    open_file = chimera_smb_open_file_resolve(request, &request->lock.file_id);
+    if (unlikely(!open_file)) {
+        chimera_smb_complete_request(request, SMB2_STATUS_FILE_CLOSED);
+        return;
+    }
+
+    request->lock.open_file = open_file;
+
+    kind = request->lock.l_flags & SMB2_LOCKFLAG_KIND_MASK;
+    if (kind != SMB2_LOCKFLAG_SHARED_LOCK &&
+        kind != SMB2_LOCKFLAG_EXCLUSIVE &&
+        kind != SMB2_LOCKFLAG_UNLOCK) {
+        chimera_smb_open_file_release(request, open_file);
+        chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
+        return;
+    }
+
+    /* SMB2 length 0 is a legal "zero-byte" lock — we treat it as a
+     * to-EOF lock to match the vfs_state convention (length==0 => EOF).
+     * Windows clients use length==0 sparingly; the practical effect is
+     * the same. */
+    want_length = request->lock.l_length;
+
+    if (kind == SMB2_LOCKFLAG_UNLOCK) {
+        struct chimera_smb_lock_entry *match = NULL;
+        DL_FOREACH(open_file->lock_entries, entry)
+        {
+            if (entry->lease.offset == request->lock.l_offset &&
+                entry->lease.length == want_length) {
+                match = entry;
+                break;
+            }
+        }
+
+        if (!match) {
+            chimera_smb_open_file_release(request, open_file);
+            /* No matching range — Windows returns RANGE_NOT_LOCKED. */
+            chimera_smb_complete_request(request, SMB2_STATUS_RANGE_NOT_LOCKED);
+            return;
+        }
+
+        DL_DELETE(open_file->lock_entries, match);
+        if (match->lease_inserted) {
+            chimera_vfs_lease_release(vfs_state, match->file_state, &match->lease);
+        }
+        if (match->file_state) {
+            chimera_vfs_state_put(vfs_state, match->file_state);
+        }
+        free(match);
+
+        chimera_smb_open_file_release(request, open_file);
+        chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
+        return;
+    }
+
+    /* LOCK acquire. */
+    entry = calloc(1, sizeof(*entry));
+    if (!entry) {
+        chimera_smb_open_file_release(request, open_file);
+        chimera_smb_complete_request(request, SMB2_STATUS_INSUFFICIENT_RESOURCES);
+        return;
+    }
+
+    entry->file_state = chimera_vfs_state_get(vfs_state,
+                                              open_file->handle->fh,
+                                              open_file->handle->fh_len,
+                                              open_file->handle->fh_hash, true);
+    if (!entry->file_state) {
+        free(entry);
+        chimera_smb_open_file_release(request, open_file);
+        chimera_smb_complete_request(request, SMB2_STATUS_INSUFFICIENT_RESOURCES);
+        return;
+    }
+
+    entry->open_file          = open_file;
+    entry->pending_req        = request;
+    entry->lease.kind         = CHIMERA_VFS_LEASE_RANGE;
+    entry->lease.mode.granted = (kind == SMB2_LOCKFLAG_EXCLUSIVE)
+                                    ? CHIMERA_VFS_LEASE_MODE_W
+                                    : CHIMERA_VFS_LEASE_MODE_R;
+    entry->lease.offset           = request->lock.l_offset;
+    entry->lease.length           = want_length;
+    entry->lease.owner.protocol   = CHIMERA_VFS_LEASE_PROTO_SMB2;
+    entry->lease.owner.client_key = request->session_handle->session->session_id;
+    /* The owner identity is the open — different opens (even by the
+     * same client) get different owner_lo/owner_hi and lock
+     * independently, matching Windows handle-based lock semantics. */
+    entry->lease.owner.owner_lo = open_file->file_id.pid;
+    entry->lease.owner.owner_hi = open_file->file_id.vid;
+
+    request->lock.entry = entry;
+
+    wait = !(request->lock.l_flags & SMB2_LOCKFLAG_FAIL_IMM);
+
+    chimera_vfs_lease_acquire(vfs_state, entry->file_state,
+                              &entry->lease, &entry->ticket, wait,
+                              chimera_smb_lock_acquire_cb, entry);
+} /* chimera_smb_lock */
+
+void
+chimera_smb_lock_reply(
+    struct evpl_iovec_cursor   *reply_cursor,
+    struct chimera_smb_request *request)
+{
+    (void) request;
+    evpl_iovec_cursor_append_uint16(reply_cursor, SMB2_LOCK_REPLY_SIZE);
+    evpl_iovec_cursor_append_uint16(reply_cursor, 0);
+} /* chimera_smb_lock_reply */

--- a/src/server/smb/smb_proc_oplock_break.c
+++ b/src/server/smb/smb_proc_oplock_break.c
@@ -1,0 +1,294 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "smb2.h"
+#include "smb_internal.h"
+#include "smb_procs.h"
+#include "smb_session.h"
+#include "common/misc.h"
+#include "vfs/vfs.h"
+#include "vfs/vfs_state.h"
+
+/*
+ * Server-to-client SMB2 OPLOCK_BREAK Notification.
+ *
+ * Stage D.1: send the lease-variant notification (MS-SMB2 §2.2.23.2) on
+ * the conn that owns the broken lease.  The break callback is wired
+ * onto every SMB CACHING lease at CREATE time; vfs_state invokes it
+ * synchronously when a new acquire conflicts with the lease.  The
+ * client's OPLOCK_BREAK Acknowledgment arrives later through the
+ * regular SMB2 LOCK dispatch path (handler below).
+ */
+
+#define SMB2_OPLOCK_BREAK_FLAG_ACK_REQUIRED 0x01
+
+/* Map vfs_state RWH bits to the SMB2 lease state encoding (different
+ * bit positions for H and W). */
+static inline uint8_t
+chimera_smb_vfs_to_lease_bits(uint8_t vfs_mode)
+{
+    uint8_t s = 0;
+
+    if (vfs_mode & CHIMERA_VFS_LEASE_MODE_R) {
+        s |= SMB2_LEASE_READ_CACHING;
+    }
+    if (vfs_mode & CHIMERA_VFS_LEASE_MODE_H) {
+        s |= SMB2_LEASE_HANDLE_CACHING;
+    }
+    if (vfs_mode & CHIMERA_VFS_LEASE_MODE_W) {
+        s |= SMB2_LEASE_WRITE_CACHING;
+    }
+    return s;
+} /* chimera_smb_vfs_to_lease_bits */
+
+static inline uint8_t
+chimera_smb_lease_to_vfs_bits(uint8_t smb_state)
+{
+    uint8_t m = 0;
+
+    if (smb_state & SMB2_LEASE_READ_CACHING) {
+        m |= CHIMERA_VFS_LEASE_MODE_R;
+    }
+    if (smb_state & SMB2_LEASE_HANDLE_CACHING) {
+        m |= CHIMERA_VFS_LEASE_MODE_H;
+    }
+    if (smb_state & SMB2_LEASE_WRITE_CACHING) {
+        m |= CHIMERA_VFS_LEASE_MODE_W;
+    }
+    return m;
+} /* chimera_smb_lease_to_vfs_bits */
+
+/* Build the 4-byte NetBIOS header + 64-byte SMB2 header for an
+ * unsolicited OPLOCK_BREAK Notification.  Returns pointer past the
+ * SMB2 header into the body region. */
+static uint8_t *
+chimera_smb_oplock_break_build_header(uint8_t *buf)
+{
+    struct smb2_header *hdr;
+
+    buf += 4; /* NetBIOS header — filled in by caller */
+
+    hdr = (struct smb2_header *) buf;
+    memset(hdr, 0, sizeof(*hdr));
+
+    hdr->protocol_id[0]          = 0xFE;
+    hdr->protocol_id[1]          = 'S';
+    hdr->protocol_id[2]          = 'M';
+    hdr->protocol_id[3]          = 'B';
+    hdr->struct_size             = 64;
+    hdr->credit_charge           = 0;
+    hdr->status                  = 0;
+    hdr->command                 = SMB2_OPLOCK_BREAK;
+    hdr->credit_request_response = 0;
+    hdr->flags                   = SMB2_FLAGS_SERVER_TO_REDIR;
+    hdr->next_command            = 0;
+    /* Unsolicited messages use 0xFFFFFFFFFFFFFFFF as the message_id. */
+    hdr->message_id = UINT64_MAX;
+    hdr->session_id = 0;
+
+    return buf + sizeof(struct smb2_header);
+} /* chimera_smb_oplock_break_build_header */
+
+/* Send an SMB2 OPLOCK_BREAK Notification (lease variant) on `conn`. */
+static void
+chimera_smb_send_oplock_break_lease(
+    struct chimera_smb_conn *conn,
+    const uint8_t           *lease_key,
+    uint8_t                  current_state, /* SMB lease bits */
+    uint8_t                  new_state,     /* SMB lease bits */
+    uint16_t                 new_epoch)
+{
+    struct evpl_iovec iov;
+    uint8_t          *buf;
+    uint8_t          *p;
+    int               total = 4 + 64 + SMB2_OPLOCK_BREAK_NOTIFY_LEASE_SIZE;
+    uint32_t          nb_len;
+
+    evpl_iovec_alloc(conn->thread->evpl, total, 8, 1, 0, &iov);
+    buf = iov.data;
+    memset(buf, 0, total);
+
+    p = chimera_smb_oplock_break_build_header(buf);
+
+    /* Body (44 bytes): MS-SMB2 §2.2.23.2 */
+    /* StructureSize = 0x2C (44) */
+    p[0] = 0x2C;
+    p[1] = 0x00;
+    /* NewEpoch (2) */
+    p[2] = new_epoch & 0xff;
+    p[3] = (new_epoch >> 8) & 0xff;
+    /* Flags (4) — ACK_REQUIRED so the client must respond */
+    p[4] = SMB2_OPLOCK_BREAK_FLAG_ACK_REQUIRED;
+    p[5] = 0; p[6] = 0; p[7] = 0;
+    /* LeaseKey (16) */
+    memcpy(p + 8, lease_key, 16);
+    /* CurrentLeaseState (4) */
+    p[24] = current_state;
+    p[25] = 0; p[26] = 0; p[27] = 0;
+    /* NewLeaseState (4) */
+    p[28] = new_state;
+    p[29] = 0; p[30] = 0; p[31] = 0;
+    /* BreakReason, AccessMaskHint, ShareMaskHint (12) — reserved */
+    memset(p + 32, 0, 12);
+
+    p += SMB2_OPLOCK_BREAK_NOTIFY_LEASE_SIZE;
+
+    /* NetBIOS header = big-endian length of everything after it. */
+    nb_len = __builtin_bswap32((uint32_t) (p - (buf + 4)));
+    memcpy(buf, &nb_len, 4);
+
+    iov.length = (int) (p - buf);
+    evpl_sendv(conn->thread->evpl, conn->bind, &iov, 1, iov.length,
+               EVPL_SEND_FLAG_TAKE_REF);
+} /* chimera_smb_send_oplock_break_lease */
+
+/* break_cb wired onto every SMB CACHING lease at CREATE time.  The
+ * cb_private is the owning open_file. */
+SYMBOL_EXPORT void
+chimera_smb_lease_break_cb(
+    struct chimera_vfs_lease *lease,
+    uint8_t                   needed_mode,
+    void                     *private_data)
+{
+    struct chimera_smb_open_file *open_file = private_data;
+    uint8_t                       current_smb;
+    uint8_t                       new_smb;
+    uint8_t                       new_vfs;
+
+    (void) needed_mode;
+
+    /* If the conn is no longer live, we can't notify the client; the
+     * pragmatic recovery is to forcibly revoke the lease so the pending
+     * acquire (or future acquires) can proceed.  This mirrors the
+     * Linux kernel's F_SETLEASE forcible expiry path. */
+    if (!open_file->create_conn) {
+        chimera_vfs_lease_revoke(lease);
+        return;
+    }
+
+    /* Stage D.1 policy: full revocation on every break.  A future
+     * refinement would compute the minimum downgrade that satisfies
+     * `needed_mode` (e.g., drop W only if a reader is asking for R).
+     * For now we drop the entire lease, which is correct but more
+     * cache-disruptive than necessary. */
+    current_smb = chimera_smb_vfs_to_lease_bits(lease->mode.granted);
+    new_smb     = 0;
+    new_vfs     = 0;
+
+    open_file->lease_epoch++;
+
+    chimera_smb_send_oplock_break_lease(open_file->create_conn,
+                                        open_file->lease_key,
+                                        current_smb,
+                                        new_smb,
+                                        open_file->lease_epoch);
+
+    /* Optimistic: assume the client will ack and mark the lease as
+     * already broken.  The arriving ack will call chimera_vfs_lease_ack
+     * which is idempotent against an already-acked state.  This lets
+     * pending acquires retry immediately rather than waiting on the
+     * RTT, at the cost of a brief window where the client may still be
+     * caching writes — acceptable for Stage D.1 because the request
+     * that triggered the break uses wait=false (try_insert) and gets a
+     * synchronous denial regardless. */
+    open_file->lease_state = new_smb;
+    {
+        struct chimera_vfs_lease_mode none;
+        none.granted = new_vfs;
+        none.denied  = 0;
+        chimera_vfs_lease_ack(lease, none);
+    }
+} /* chimera_smb_lease_break_cb */
+
+/* ----------------------------------------------------------------------
+ * Inbound SMB2 OPLOCK_BREAK Acknowledgment from client
+ * ----------------------------------------------------------------------
+ *
+ * Lease ack arrives via the regular dispatch path with the SMB2_OPLOCK_BREAK
+ * opcode and struct_size=36 (lease) or 24 (legacy).  Since the server-side
+ * lease was already optimistically acked inside chimera_smb_lease_break_cb,
+ * the client ack here only needs to reply with the matching OPLOCK_BREAK
+ * Response packet.  A future refinement would defer the lease_ack until
+ * this point to honor the client's chosen NewLeaseState verbatim. */
+
+SYMBOL_EXPORT int
+chimera_smb_parse_oplock_break(
+    struct evpl_iovec_cursor   *request_cursor,
+    struct chimera_smb_request *request)
+{
+    uint16_t reserved;
+    uint32_t reserved32;
+    uint64_t reserved64;
+
+    if (request->request_struct_size == SMB2_OPLOCK_BREAK_ACK_LEASE_SIZE) {
+        request->oplock_break.is_lease = true;
+        evpl_iovec_cursor_get_uint16(request_cursor, &reserved);
+        evpl_iovec_cursor_get_uint32(request_cursor, &request->oplock_break.lease_flags);
+        evpl_iovec_cursor_copy(request_cursor, request->oplock_break.lease_key, 16);
+        evpl_iovec_cursor_get_uint32(request_cursor, &reserved32);
+        request->oplock_break.lease_state = (uint8_t) (reserved32 & 0xff);
+        evpl_iovec_cursor_get_uint64(request_cursor, &reserved64);
+    } else if (request->request_struct_size == SMB2_OPLOCK_BREAK_ACK_LEGACY_SIZE) {
+        request->oplock_break.is_lease = false;
+        evpl_iovec_cursor_get_uint8(request_cursor, &request->oplock_break.oplock_level);
+        evpl_iovec_cursor_get_uint8(request_cursor, (uint8_t *) &reserved);
+        evpl_iovec_cursor_get_uint32(request_cursor, &reserved32);
+        evpl_iovec_cursor_get_uint64(request_cursor, &request->oplock_break.file_id.pid);
+        evpl_iovec_cursor_get_uint64(request_cursor, &request->oplock_break.file_id.vid);
+    } else {
+        chimera_smb_error("SMB2 OPLOCK_BREAK ack with unexpected struct size %u",
+                          request->request_struct_size);
+        request->status = SMB2_STATUS_INVALID_PARAMETER;
+        return -1;
+    }
+
+    return 0;
+} /* chimera_smb_parse_oplock_break */
+
+SYMBOL_EXPORT void
+chimera_smb_oplock_break(struct chimera_smb_request *request)
+{
+    /* The lease was already optimistically acked inside the break_cb.
+     * Nothing else to do besides letting the dispatcher emit the
+     * reply packet. */
+    chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
+} /* chimera_smb_oplock_break */
+
+SYMBOL_EXPORT void
+chimera_smb_oplock_break_reply(
+    struct evpl_iovec_cursor   *reply_cursor,
+    struct chimera_smb_request *request)
+{
+    if (request->oplock_break.is_lease) {
+        /* Lease OPLOCK_BREAK Response — MS-SMB2 §2.2.25.2, 36 bytes. */
+        evpl_iovec_cursor_append_uint16(reply_cursor,
+                                        SMB2_OPLOCK_BREAK_ACK_LEASE_SIZE);
+        evpl_iovec_cursor_append_uint16(reply_cursor, 0);  /* Reserved */
+        evpl_iovec_cursor_append_uint32(reply_cursor,
+                                        request->oplock_break.lease_flags);
+        /* LeaseKey (16) */
+        evpl_iovec_cursor_append_blob(reply_cursor,
+                                      request->oplock_break.lease_key, 16);
+        /* LeaseState (4) — echo what the client asked for. */
+        evpl_iovec_cursor_append_uint32(reply_cursor,
+                                        request->oplock_break.lease_state);
+        /* LeaseDuration (8) — reserved. */
+        evpl_iovec_cursor_append_uint64(reply_cursor, 0);
+    } else {
+        /* Legacy OPLOCK_BREAK Response — MS-SMB2 §2.2.25.1, 24 bytes. */
+        evpl_iovec_cursor_append_uint16(reply_cursor,
+                                        SMB2_OPLOCK_BREAK_ACK_LEGACY_SIZE);
+        evpl_iovec_cursor_append_uint8(reply_cursor,
+                                       request->oplock_break.oplock_level);
+        evpl_iovec_cursor_append_uint8(reply_cursor, 0);   /* Reserved */
+        evpl_iovec_cursor_append_uint32(reply_cursor, 0);  /* Reserved2 */
+        evpl_iovec_cursor_append_uint64(reply_cursor,
+                                        request->oplock_break.file_id.pid);
+        evpl_iovec_cursor_append_uint64(reply_cursor,
+                                        request->oplock_break.file_id.vid);
+    }
+} /* chimera_smb_oplock_break_reply */

--- a/src/server/smb/smb_procs.h
+++ b/src/server/smb/smb_procs.h
@@ -240,3 +240,39 @@ int chimera_smb_parse_cancel(
 
 void chimera_smb_cancel(
     struct chimera_smb_request *request);
+
+int chimera_smb_parse_lock(
+    struct evpl_iovec_cursor   *request_cursor,
+    struct chimera_smb_request *request);
+
+void chimera_smb_lock(
+    struct chimera_smb_request *request);
+
+void chimera_smb_lock_reply(
+    struct evpl_iovec_cursor   *reply_cursor,
+    struct chimera_smb_request *request);
+
+/* Drain (release + free) every byte-range lock entry held by `open_file`.
+ * Called at close before the underlying VFS handle is released. */
+void chimera_smb_open_file_drain_locks(
+    struct chimera_server_smb_thread *thread,
+    struct chimera_smb_open_file     *open_file);
+
+/* break_cb wired onto SMB CACHING leases at CREATE time.  Sends an
+ * OPLOCK_BREAK Notification on the conn the open was created on, or
+ * forcibly revokes if the conn is gone. */
+void chimera_smb_lease_break_cb(
+    struct chimera_vfs_lease *lease,
+    uint8_t                   needed_mode,
+    void                     *private_data);
+
+int chimera_smb_parse_oplock_break(
+    struct evpl_iovec_cursor   *request_cursor,
+    struct chimera_smb_request *request);
+
+void chimera_smb_oplock_break(
+    struct chimera_smb_request *request);
+
+void chimera_smb_oplock_break_reply(
+    struct evpl_iovec_cursor   *reply_cursor,
+    struct chimera_smb_request *request);

--- a/src/server/smb/smb_session.h
+++ b/src/server/smb/smb_session.h
@@ -5,14 +5,17 @@
 #pragma once
 
 #include <stdint.h>
+#include <stdbool.h>
 #include <pthread.h>
 #include <uthash.h>
 
 #include "vfs/vfs.h"
 #include "vfs/vfs_cred.h"
+#include "vfs/vfs_state.h"
 #include "smb2.h"
 
 struct chimera_smb_share;
+struct chimera_smb_conn;
 
 struct chimera_smb_file_id {
     uint64_t pid;
@@ -66,6 +69,7 @@ typedef int (*chimera_smb_pipe_transceive_t)(
     struct evpl_iovec          *output_iov);
 
 struct chimera_smb_notify_state;
+struct chimera_smb_lock_entry;
 
 struct chimera_smb_open_file {
     enum chimera_smb_open_file_type  type;
@@ -94,6 +98,24 @@ struct chimera_smb_open_file {
     uint8_t                          create_guid[16];
     struct chimera_smb_open_file    *next;
     struct chimera_smb_notify_state *notify_state;
+    /* Byte-range locks (SMB2_LOCK) held against this open.  Allocated
+     * and linked on each granted lock op; freed on UNLOCK or on close. */
+    struct chimera_smb_lock_entry   *lock_entries;
+    /* SHARE lease (whole-file deny mode reservation) held by this open
+     * once CREATE succeeds.  Released at close. */
+    struct chimera_vfs_lease         share_lease;
+    struct chimera_vfs_file_state   *share_file_state;
+    bool                             share_lease_inserted;
+    /* CACHING lease (SMB2 lease / oplock) held by this open.  Released
+     * at close or on OPLOCK_BREAK ack with mode=0. */
+    struct chimera_vfs_lease         caching_lease;
+    struct chimera_vfs_file_state   *caching_file_state;
+    bool                             caching_lease_inserted;
+    /* Conn on which this open was created — used by the break path to
+     * send unsolicited OPLOCK_BREAK Notifications.  Cleared by the
+     * disconnect handler before the conn is freed; if NULL when a
+     * break is needed, the lease is forcibly revoked instead. */
+    struct chimera_smb_conn         *create_conn;
     uint8_t                          parent_fh[CHIMERA_VFS_FH_SIZE];
     char                             name[SMB_FILENAME_MAX];
     uint16_t                         pattern[SMB_FILENAME_MAX];

--- a/src/vfs/CMakeLists.txt
+++ b/src/vfs/CMakeLists.txt
@@ -18,7 +18,7 @@ add_library(chimera_vfs SHARED vfs.c vfs_lsan.c
             vfs_proc_delete_key.c vfs_proc_search_keys.c
             vfs_proc_allocate.c vfs_proc_seek.c vfs_proc_lock.c
             vfs_proc_copy_range.c vfs_proc_clone_range.c vfs_proc_move_range.c
-            vfs_proc_getparent.c vfs_notify.c vfs_dump.c)
+            vfs_proc_getparent.c vfs_notify.c vfs_state.c vfs_dump.c)
 
 target_compile_definitions(chimera_vfs PRIVATE
     XXH_INLINE_ALL

--- a/src/vfs/tests/CMakeLists.txt
+++ b/src/vfs/tests/CMakeLists.txt
@@ -21,3 +21,7 @@ add_test(chimera/vfs/sync_delegation_test vfs_sync_delegation_test)
 add_executable(vfs_notify_test vfs_notify_test.c)
 target_link_libraries(vfs_notify_test chimera_vfs urcu)
 add_test(chimera/vfs/notify_test vfs_notify_test)
+
+add_executable(vfs_state_test vfs_state_test.c)
+target_link_libraries(vfs_state_test chimera_vfs)
+add_test(chimera/vfs/state_test vfs_state_test)

--- a/src/vfs/tests/vfs_state_test.c
+++ b/src/vfs/tests/vfs_state_test.c
@@ -1,0 +1,916 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * Unit tests for the unified VFS lease/lock state (vfs_state.{h,c}).
+ *
+ * These cover the conflict matrix and break-orchestration skeleton in
+ * isolation — no protocol stack, no real VFS instance.  The matrix is
+ * pure logic, so we exercise every (existing-state, new-request) pair
+ * across all three lease kinds, plus same-owner coalescing and the
+ * lease-break ack / revoke paths.
+ *
+ * What is intentionally NOT covered here:
+ *   - Stage B+ integration with NLM/NFSv4 LOCK and SMB2 LOCK
+ *   - Stage C+ integration with SMB CREATE share_access and NFSv4 OPEN
+ *   - Stage D+ break notification packets (CB_RECALL, OPLOCK_BREAK)
+ *
+ * Those land with the callers that use this layer in later stages.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#undef NDEBUG
+#include <assert.h>
+
+#include "vfs/vfs_state.h"
+#include "vfs/vfs_internal.h"
+#include "common/logging.h"
+
+static int passed = 0;
+static int failed = 0;
+
+#define PASS(name) do { fprintf(stderr, "  PASS: %s\n", (name)); passed++; } while (0)
+#define FAIL(name) do { fprintf(stderr, "  FAIL: %s\n", (name)); failed++; } while (0)
+#define CHECK(cond, name)         \
+        do {                          \
+            if (cond) { PASS(name); } \
+            else { FAIL(name); }      \
+        } while (0)
+
+/* Test-side scaffolding ----------------------------------------------- */
+
+static void
+make_fh(
+    uint8_t out[CHIMERA_VFS_FH_SIZE],
+    uint8_t tag)
+{
+    memset(out, 0, CHIMERA_VFS_FH_SIZE);
+    out[0]                       = 0xAA;
+    out[CHIMERA_VFS_FH_SIZE - 1] = tag;
+} /* make_fh */
+
+static struct chimera_vfs_file_state *
+get_file(
+    struct chimera_vfs_state *state,
+    uint8_t                   tag)
+{
+    uint8_t  fh[CHIMERA_VFS_FH_SIZE];
+    uint64_t fh_hash;
+
+    make_fh(fh, tag);
+    fh_hash = chimera_vfs_hash(fh, sizeof(fh));
+    return chimera_vfs_state_get(state, fh, sizeof(fh), fh_hash, true);
+} /* get_file */
+
+static void
+init_owner(
+    struct chimera_vfs_lease_owner *owner,
+    uint32_t                        protocol,
+    uint64_t                        client,
+    uint64_t                        owner_id)
+{
+    memset(owner, 0, sizeof(*owner));
+    owner->protocol   = protocol;
+    owner->client_key = client;
+    owner->owner_lo   = owner_id;
+} /* init_owner */
+
+/* Break callback that just counts invocations and records the lease. */
+struct break_recorder {
+    int                       fired;
+    struct chimera_vfs_lease *last_lease;
+    uint8_t                   last_needed_mode;
+};
+
+static void
+recording_break_cb(
+    struct chimera_vfs_lease *lease,
+    uint8_t                   needed_mode,
+    void                     *priv)
+{
+    struct break_recorder *r = priv;
+
+    r->fired++;
+    r->last_lease       = lease;
+    r->last_needed_mode = needed_mode;
+} /* recording_break_cb */
+
+/* Test 1: init + destroy --------------------------------------------- */
+static void
+test_init_destroy(void)
+{
+    struct chimera_vfs_state *state;
+
+    fprintf(stderr, "\ntest_init_destroy\n");
+
+    state = chimera_vfs_state_init();
+    CHECK(state != NULL, "init returns non-null");
+
+    chimera_vfs_state_destroy(state);
+    PASS("destroy (no crash)");
+} /* test_init_destroy */
+
+/* Test 2: file-state lookup is refcounted and create/get coalesces --- */
+static void
+test_file_state_lookup(void)
+{
+    struct chimera_vfs_state      *state;
+    struct chimera_vfs_file_state *f1, *f2, *f3;
+
+    fprintf(stderr, "\ntest_file_state_lookup\n");
+
+    state = chimera_vfs_state_init();
+
+    f1 = get_file(state, 1);
+    CHECK(f1 != NULL, "get_or_create returns non-null");
+    assert(f1 != NULL);
+
+    f2 = get_file(state, 1);
+    CHECK(f2 == f1, "same FH returns same state (coalesced)");
+    CHECK(f1->refcount == 2, "refcount bumped on second get");
+
+    f3 = get_file(state, 2);
+    CHECK(f3 != f1, "different FH returns different state");
+
+    chimera_vfs_state_put(state, f1);
+    chimera_vfs_state_put(state, f2);
+    /* After both puts, f1's refcount should be zero and it should be
+     * freed — we can't probe it directly, but a fresh get must allocate
+     * a new state object. */
+    f1 = get_file(state, 1);
+    CHECK(f1 != NULL, "fresh get after release returns new state");
+    assert(f1 != NULL);
+    CHECK(f1->refcount == 1, "fresh state has refcount 1");
+
+    chimera_vfs_state_put(state, f1);
+    chimera_vfs_state_put(state, f3);
+
+    chimera_vfs_state_destroy(state);
+} /* test_file_state_lookup */
+
+/* Test 3: range vs range — fcntl conflict rules ---------------------- */
+static void
+test_range_vs_range(void)
+{
+    struct chimera_vfs_state      *state;
+    struct chimera_vfs_file_state *file;
+    struct chimera_vfs_lease       a, b, c;
+    enum chimera_vfs_lease_result  r;
+    struct chimera_vfs_lease      *conflict;
+
+    fprintf(stderr, "\ntest_range_vs_range\n");
+
+    state = chimera_vfs_state_init();
+    file  = get_file(state, 1);
+
+    /* Owner A takes a shared read lock on [0, 100). */
+    memset(&a, 0, sizeof(a));
+    a.kind         = CHIMERA_VFS_LEASE_RANGE;
+    a.mode.granted = CHIMERA_VFS_LEASE_MODE_R;
+    a.offset       = 0;
+    a.length       = 100;
+    init_owner(&a.owner, CHIMERA_VFS_LEASE_PROTO_NFSV4, 0xA, 1);
+
+    r = chimera_vfs_state_try_insert(state, file, &a, &conflict);
+    CHECK(r == CHIMERA_VFS_LEASE_GRANTED, "first read lock granted");
+
+    /* Owner B takes a non-overlapping read lock — granted. */
+    memset(&b, 0, sizeof(b));
+    b.kind         = CHIMERA_VFS_LEASE_RANGE;
+    b.mode.granted = CHIMERA_VFS_LEASE_MODE_R;
+    b.offset       = 200;
+    b.length       = 100;
+    init_owner(&b.owner, CHIMERA_VFS_LEASE_PROTO_NFSV4, 0xB, 2);
+
+    r = chimera_vfs_state_try_insert(state, file, &b, &conflict);
+    CHECK(r == CHIMERA_VFS_LEASE_GRANTED, "non-overlapping lock granted");
+
+    /* Owner C tries an overlapping write — denied by either A or B. */
+    memset(&c, 0, sizeof(c));
+    c.kind         = CHIMERA_VFS_LEASE_RANGE;
+    c.mode.granted = CHIMERA_VFS_LEASE_MODE_W;
+    c.offset       = 50;
+    c.length       = 100;
+    init_owner(&c.owner, CHIMERA_VFS_LEASE_PROTO_NFSV4, 0xC, 3);
+
+    r = chimera_vfs_state_try_insert(state, file, &c, &conflict);
+    CHECK(r == CHIMERA_VFS_LEASE_DENIED, "overlapping write denied");
+    CHECK(conflict == &a, "conflict points to first existing holder");
+
+    /* Owner C tries an overlapping read — read+read coexist. */
+    c.mode.granted = CHIMERA_VFS_LEASE_MODE_R;
+    r              = chimera_vfs_state_try_insert(state, file, &c, &conflict);
+    CHECK(r == CHIMERA_VFS_LEASE_GRANTED, "overlapping read with read granted");
+
+    chimera_vfs_state_remove(state, file, &a);
+    chimera_vfs_state_remove(state, file, &b);
+    chimera_vfs_state_remove(state, file, &c);
+    chimera_vfs_state_put(state, file);
+    chimera_vfs_state_destroy(state);
+} /* test_range_vs_range */
+
+/* Test 4: same-owner coalescing on range locks ----------------------- */
+static void
+test_range_same_owner_coalesces(void)
+{
+    struct chimera_vfs_state      *state;
+    struct chimera_vfs_file_state *file;
+    struct chimera_vfs_lease       a, b;
+    enum chimera_vfs_lease_result  r;
+    struct chimera_vfs_lease      *conflict;
+
+    fprintf(stderr, "\ntest_range_same_owner_coalesces\n");
+
+    state = chimera_vfs_state_init();
+    file  = get_file(state, 1);
+
+    memset(&a, 0, sizeof(a));
+    a.kind         = CHIMERA_VFS_LEASE_RANGE;
+    a.mode.granted = CHIMERA_VFS_LEASE_MODE_W;
+    a.offset       = 0;
+    a.length       = 100;
+    init_owner(&a.owner, CHIMERA_VFS_LEASE_PROTO_NFSV4, 0xA, 1);
+
+    r = chimera_vfs_state_try_insert(state, file, &a, &conflict);
+    CHECK(r == CHIMERA_VFS_LEASE_GRANTED, "first write lock granted");
+
+    /* Same owner taking an overlapping write — must not self-conflict. */
+    memset(&b, 0, sizeof(b));
+    b.kind         = CHIMERA_VFS_LEASE_RANGE;
+    b.mode.granted = CHIMERA_VFS_LEASE_MODE_W;
+    b.offset       = 50;
+    b.length       = 100;
+    init_owner(&b.owner, CHIMERA_VFS_LEASE_PROTO_NFSV4, 0xA, 1);
+
+    r = chimera_vfs_state_try_insert(state, file, &b, &conflict);
+    CHECK(r == CHIMERA_VFS_LEASE_GRANTED, "same-owner overlapping write granted (coalesces)");
+
+    chimera_vfs_state_remove(state, file, &a);
+    chimera_vfs_state_remove(state, file, &b);
+    chimera_vfs_state_put(state, file);
+    chimera_vfs_state_destroy(state);
+} /* test_range_same_owner_coalesces */
+
+/* Test 5: range length==0 means to EOF ------------------------------- */
+static void
+test_range_to_eof(void)
+{
+    struct chimera_vfs_state      *state;
+    struct chimera_vfs_file_state *file;
+    struct chimera_vfs_lease       a, b;
+    enum chimera_vfs_lease_result  r;
+    struct chimera_vfs_lease      *conflict;
+
+    fprintf(stderr, "\ntest_range_to_eof\n");
+
+    state = chimera_vfs_state_init();
+    file  = get_file(state, 1);
+
+    /* Existing W lock from [1000, EOF). */
+    memset(&a, 0, sizeof(a));
+    a.kind         = CHIMERA_VFS_LEASE_RANGE;
+    a.mode.granted = CHIMERA_VFS_LEASE_MODE_W;
+    a.offset       = 1000;
+    a.length       = 0; /* to EOF */
+    init_owner(&a.owner, CHIMERA_VFS_LEASE_PROTO_NLM, 0xA, 1);
+
+    r = chimera_vfs_state_try_insert(state, file, &a, &conflict);
+    CHECK(r == CHIMERA_VFS_LEASE_GRANTED, "to-EOF write granted");
+
+    /* A new write at [2000, 100) overlaps with the to-EOF range. */
+    memset(&b, 0, sizeof(b));
+    b.kind         = CHIMERA_VFS_LEASE_RANGE;
+    b.mode.granted = CHIMERA_VFS_LEASE_MODE_W;
+    b.offset       = 2000;
+    b.length       = 100;
+    init_owner(&b.owner, CHIMERA_VFS_LEASE_PROTO_NLM, 0xB, 2);
+
+    r = chimera_vfs_state_try_insert(state, file, &b, &conflict);
+    CHECK(r == CHIMERA_VFS_LEASE_DENIED, "overlap with to-EOF range denied");
+
+    /* A new write at [0, 500) does NOT overlap [1000, EOF). */
+    b.offset = 0;
+    b.length = 500;
+    r        = chimera_vfs_state_try_insert(state, file, &b, &conflict);
+    CHECK(r == CHIMERA_VFS_LEASE_GRANTED, "non-overlap before to-EOF range granted");
+
+    chimera_vfs_state_remove(state, file, &a);
+    chimera_vfs_state_remove(state, file, &b);
+    chimera_vfs_state_put(state, file);
+    chimera_vfs_state_destroy(state);
+} /* test_range_to_eof */
+
+/* Test 6: share-mode conflict — same matrix as SMB sharemode --------- */
+static void
+test_share_vs_share(void)
+{
+    struct chimera_vfs_state      *state;
+    struct chimera_vfs_file_state *file;
+    struct chimera_vfs_lease       a, b;
+    enum chimera_vfs_lease_result  r;
+    struct chimera_vfs_lease      *conflict;
+
+    fprintf(stderr, "\ntest_share_vs_share\n");
+
+    state = chimera_vfs_state_init();
+    file  = get_file(state, 1);
+
+    /* Holder A: wants R, denies W (FILE_READ_DATA + !FILE_SHARE_WRITE). */
+    memset(&a, 0, sizeof(a));
+    a.kind         = CHIMERA_VFS_LEASE_SHARE;
+    a.mode.granted = CHIMERA_VFS_LEASE_MODE_R;
+    a.mode.denied  = CHIMERA_VFS_LEASE_MODE_W;
+    init_owner(&a.owner, CHIMERA_VFS_LEASE_PROTO_SMB2, 0xA, 1);
+
+    r = chimera_vfs_state_try_insert(state, file, &a, &conflict);
+    CHECK(r == CHIMERA_VFS_LEASE_GRANTED, "first share R deny-W granted");
+
+    /* Probe B: wants W — A denies W, so denied. */
+    memset(&b, 0, sizeof(b));
+    b.kind         = CHIMERA_VFS_LEASE_SHARE;
+    b.mode.granted = CHIMERA_VFS_LEASE_MODE_W;
+    b.mode.denied  = 0;
+    init_owner(&b.owner, CHIMERA_VFS_LEASE_PROTO_SMB2, 0xB, 2);
+
+    r = chimera_vfs_state_try_insert(state, file, &b, &conflict);
+    CHECK(r == CHIMERA_VFS_LEASE_DENIED, "share W denied by existing deny-W");
+
+    /* Probe B: wants R only — no conflict. */
+    b.mode.granted = CHIMERA_VFS_LEASE_MODE_R;
+    r              = chimera_vfs_state_try_insert(state, file, &b, &conflict);
+    CHECK(r == CHIMERA_VFS_LEASE_GRANTED, "second share R coexists");
+
+    /* Probe C: wants R and denies R — should conflict with B (which has R). */
+    struct chimera_vfs_lease c;
+    memset(&c, 0, sizeof(c));
+    c.kind         = CHIMERA_VFS_LEASE_SHARE;
+    c.mode.granted = CHIMERA_VFS_LEASE_MODE_R;
+    c.mode.denied  = CHIMERA_VFS_LEASE_MODE_R;
+    init_owner(&c.owner, CHIMERA_VFS_LEASE_PROTO_SMB2, 0xC, 3);
+
+    r = chimera_vfs_state_try_insert(state, file, &c, &conflict);
+    CHECK(r == CHIMERA_VFS_LEASE_DENIED,
+          "share probe denying R denied because another holder has R");
+
+    chimera_vfs_state_remove(state, file, &a);
+    chimera_vfs_state_remove(state, file, &b);
+    chimera_vfs_state_put(state, file);
+    chimera_vfs_state_destroy(state);
+} /* test_share_vs_share */
+
+/* Test 7: caching lease — W is exclusive, R can be shared across owners */
+static void
+test_caching_lease_basics(void)
+{
+    struct chimera_vfs_state      *state;
+    struct chimera_vfs_file_state *file;
+    struct chimera_vfs_lease       a, b;
+    enum chimera_vfs_lease_result  r;
+    struct chimera_vfs_lease      *conflict;
+
+    fprintf(stderr, "\ntest_caching_lease_basics\n");
+
+    state = chimera_vfs_state_init();
+    file  = get_file(state, 1);
+
+    /* Client A holds R-cache. */
+    memset(&a, 0, sizeof(a));
+    a.kind         = CHIMERA_VFS_LEASE_CACHING;
+    a.mode.granted = CHIMERA_VFS_LEASE_MODE_R;
+    init_owner(&a.owner, CHIMERA_VFS_LEASE_PROTO_SMB2, 0xA, 1);
+
+    r = chimera_vfs_state_try_insert(state, file, &a, &conflict);
+    CHECK(r == CHIMERA_VFS_LEASE_GRANTED, "first R-cache granted");
+
+    /* Client B requests R-cache — should also be granted (R is shared
+     * across different owners; this is SMB2 Level2 oplock semantics). */
+    memset(&b, 0, sizeof(b));
+    b.kind         = CHIMERA_VFS_LEASE_CACHING;
+    b.mode.granted = CHIMERA_VFS_LEASE_MODE_R;
+    init_owner(&b.owner, CHIMERA_VFS_LEASE_PROTO_SMB2, 0xB, 2);
+
+    r = chimera_vfs_state_try_insert(state, file, &b, &conflict);
+    CHECK(r == CHIMERA_VFS_LEASE_GRANTED,
+          "second R-cache from different owner coexists (Level2 semantics)");
+
+    chimera_vfs_state_remove(state, file, &a);
+    chimera_vfs_state_remove(state, file, &b);
+    chimera_vfs_state_put(state, file);
+    chimera_vfs_state_destroy(state);
+} /* test_caching_lease_basics */
+
+/* Test 8: caching W-lease forces break of R-cache on other client ----- */
+static void
+test_caching_w_breaks_r(void)
+{
+    struct chimera_vfs_state      *state;
+    struct chimera_vfs_file_state *file;
+    struct chimera_vfs_lease       a, b;
+    enum chimera_vfs_lease_result  r;
+    struct chimera_vfs_lease      *conflict;
+    struct break_recorder          rec = { 0 };
+
+    fprintf(stderr, "\ntest_caching_w_breaks_r\n");
+
+    state = chimera_vfs_state_init();
+    file  = get_file(state, 1);
+
+    /* Client A holds R-cache, with a registered break callback. */
+    memset(&a, 0, sizeof(a));
+    a.kind         = CHIMERA_VFS_LEASE_CACHING;
+    a.mode.granted = CHIMERA_VFS_LEASE_MODE_R;
+    init_owner(&a.owner, CHIMERA_VFS_LEASE_PROTO_SMB2, 0xA, 1);
+    a.owner.break_cb   = recording_break_cb;
+    a.owner.cb_private = &rec;
+
+    r = chimera_vfs_state_try_insert(state, file, &a, &conflict);
+    CHECK(r == CHIMERA_VFS_LEASE_GRANTED, "R-cache granted");
+
+    /* Client B requests W-cache.  This must initiate a break on A. */
+    memset(&b, 0, sizeof(b));
+    b.kind         = CHIMERA_VFS_LEASE_CACHING;
+    b.mode.granted = CHIMERA_VFS_LEASE_MODE_W;
+    init_owner(&b.owner, CHIMERA_VFS_LEASE_PROTO_SMB2, 0xB, 2);
+
+    r = chimera_vfs_state_try_insert(state, file, &b, &conflict);
+    CHECK(r == CHIMERA_VFS_LEASE_BREAKING, "W-cache request triggers break");
+    CHECK(conflict == &a, "conflict points to existing R-cache holder");
+    CHECK(rec.fired == 1, "break callback fired exactly once");
+    CHECK(rec.last_lease == &a, "break callback received correct lease");
+    CHECK(a.break_state == CHIMERA_VFS_BREAK_BREAKING, "lease marked BREAKING");
+
+    /* Client A acks the break by downgrading to nothing. */
+    struct chimera_vfs_lease_mode none = { 0, 0 };
+    chimera_vfs_lease_ack(&a, none);
+    CHECK(a.break_state == CHIMERA_VFS_BREAK_ACKED, "lease moved to ACKED");
+    CHECK(a.mode.granted == 0, "lease mode downgraded");
+
+    /* B can retry now.  Since A still occupies the list with mode=0,
+     * the caching_conflict test won't deny — A's W and H bits are
+     * unset.  In real code the protocol would call state_remove on
+     * the acked lease before retrying; we mimic that here. */
+    chimera_vfs_state_remove(state, file, &a);
+
+    r = chimera_vfs_state_try_insert(state, file, &b, &conflict);
+    CHECK(r == CHIMERA_VFS_LEASE_GRANTED, "W-cache granted after break ack");
+
+    chimera_vfs_state_remove(state, file, &b);
+    chimera_vfs_state_put(state, file);
+    chimera_vfs_state_destroy(state);
+} /* test_caching_w_breaks_r */
+
+/* Test 9: SMB lease-key coalescing — same client_key+owner doesn't break */
+static void
+test_smb_lease_key_coalesces(void)
+{
+    struct chimera_vfs_state      *state;
+    struct chimera_vfs_file_state *file;
+    struct chimera_vfs_lease       a, b;
+    enum chimera_vfs_lease_result  r;
+    struct chimera_vfs_lease      *conflict;
+    struct break_recorder          rec = { 0 };
+
+    fprintf(stderr, "\ntest_smb_lease_key_coalesces\n");
+
+    state = chimera_vfs_state_init();
+    file  = get_file(state, 1);
+
+    /* SMB client opens file with a lease key (encoded as
+     * client_key=client_guid, owner_lo|owner_hi = 128-bit lease_key). */
+    memset(&a, 0, sizeof(a));
+    a.kind         = CHIMERA_VFS_LEASE_CACHING;
+    a.mode.granted = CHIMERA_VFS_LEASE_MODE_R |
+        CHIMERA_VFS_LEASE_MODE_W |
+        CHIMERA_VFS_LEASE_MODE_H;
+    init_owner(&a.owner, CHIMERA_VFS_LEASE_PROTO_SMB2, 0xC11E1700, 1);
+    a.owner.owner_hi   = 0xDEAD;
+    a.owner.break_cb   = recording_break_cb;
+    a.owner.cb_private = &rec;
+
+    r = chimera_vfs_state_try_insert(state, file, &a, &conflict);
+    CHECK(r == CHIMERA_VFS_LEASE_GRANTED, "RWH lease granted on first open");
+
+    /* Same client opens the same file again with the same lease_key —
+     * Samba's locking.tdb rule says this is the same lease holder, no
+     * break required. */
+    memset(&b, 0, sizeof(b));
+    b.kind         = CHIMERA_VFS_LEASE_CACHING;
+    b.mode.granted = CHIMERA_VFS_LEASE_MODE_R |
+        CHIMERA_VFS_LEASE_MODE_W |
+        CHIMERA_VFS_LEASE_MODE_H;
+    init_owner(&b.owner, CHIMERA_VFS_LEASE_PROTO_SMB2, 0xC11E1700, 1);
+    b.owner.owner_hi = 0xDEAD;
+
+    r = chimera_vfs_state_try_insert(state, file, &b, &conflict);
+    CHECK(r == CHIMERA_VFS_LEASE_GRANTED,
+          "second open with same lease_key coalesces without break");
+    CHECK(rec.fired == 0, "no break invoked for same-owner reopen");
+
+    chimera_vfs_state_remove(state, file, &a);
+    chimera_vfs_state_remove(state, file, &b);
+    chimera_vfs_state_put(state, file);
+    chimera_vfs_state_destroy(state);
+} /* test_smb_lease_key_coalesces */
+
+/* Test 10: caching W-lease must be broken by another client's W request,
+* and revoke (timeout-equivalent) lets the new request through ------- */
+static void
+test_caching_break_revoke(void)
+{
+    struct chimera_vfs_state      *state;
+    struct chimera_vfs_file_state *file;
+    struct chimera_vfs_lease       a, b;
+    enum chimera_vfs_lease_result  r;
+    struct chimera_vfs_lease      *conflict;
+    struct break_recorder          rec = { 0 };
+
+    fprintf(stderr, "\ntest_caching_break_revoke\n");
+
+    state = chimera_vfs_state_init();
+    file  = get_file(state, 1);
+
+    memset(&a, 0, sizeof(a));
+    a.kind         = CHIMERA_VFS_LEASE_CACHING;
+    a.mode.granted = CHIMERA_VFS_LEASE_MODE_W;
+    init_owner(&a.owner, CHIMERA_VFS_LEASE_PROTO_NFSV4, 0xA, 1);
+    a.owner.break_cb   = recording_break_cb;
+    a.owner.cb_private = &rec;
+
+    r = chimera_vfs_state_try_insert(state, file, &a, &conflict);
+    CHECK(r == CHIMERA_VFS_LEASE_GRANTED, "W delegation granted");
+
+    /* Different NFSv4 client wants W — break A. */
+    memset(&b, 0, sizeof(b));
+    b.kind         = CHIMERA_VFS_LEASE_CACHING;
+    b.mode.granted = CHIMERA_VFS_LEASE_MODE_W;
+    init_owner(&b.owner, CHIMERA_VFS_LEASE_PROTO_NFSV4, 0xB, 2);
+
+    r = chimera_vfs_state_try_insert(state, file, &b, &conflict);
+    CHECK(r == CHIMERA_VFS_LEASE_BREAKING, "second W delegation initiates break");
+    CHECK(rec.fired == 1, "break_cb fired once");
+
+    /* Client A doesn't respond — simulate revoke (forcible expiry). */
+    chimera_vfs_lease_revoke(&a);
+    CHECK(a.break_state == CHIMERA_VFS_BREAK_REVOKED, "lease moved to REVOKED");
+    CHECK(a.mode.granted == 0, "revoked lease has empty mode");
+
+    chimera_vfs_state_remove(state, file, &a);
+    r = chimera_vfs_state_try_insert(state, file, &b, &conflict);
+    CHECK(r == CHIMERA_VFS_LEASE_GRANTED, "new W granted after revoke");
+
+    chimera_vfs_state_remove(state, file, &b);
+    chimera_vfs_state_put(state, file);
+    chimera_vfs_state_destroy(state);
+} /* test_caching_break_revoke */
+
+/* Test 11: range-lock probe that would clash with a caching W-lease on
+ * another client triggers a break instead of immediate denial -------- */
+static void
+test_range_breaks_caching(void)
+{
+    struct chimera_vfs_state      *state;
+    struct chimera_vfs_file_state *file;
+    struct chimera_vfs_lease       cache, range;
+    enum chimera_vfs_lease_result  r;
+    struct chimera_vfs_lease      *conflict;
+    struct break_recorder          rec = { 0 };
+
+    fprintf(stderr, "\ntest_range_breaks_caching\n");
+
+    state = chimera_vfs_state_init();
+    file  = get_file(state, 1);
+
+    /* Client A: W-caching lease. */
+    memset(&cache, 0, sizeof(cache));
+    cache.kind         = CHIMERA_VFS_LEASE_CACHING;
+    cache.mode.granted = CHIMERA_VFS_LEASE_MODE_W;
+    init_owner(&cache.owner, CHIMERA_VFS_LEASE_PROTO_SMB2, 0xA, 1);
+    cache.owner.break_cb   = recording_break_cb;
+    cache.owner.cb_private = &rec;
+
+    r = chimera_vfs_state_try_insert(state, file, &cache, &conflict);
+    CHECK(r == CHIMERA_VFS_LEASE_GRANTED, "W-cache granted");
+
+    /* Client B asks for a byte-range read lock — must break A's W-cache
+     * because reads on B may see writes that A has cached. */
+    memset(&range, 0, sizeof(range));
+    range.kind         = CHIMERA_VFS_LEASE_RANGE;
+    range.mode.granted = CHIMERA_VFS_LEASE_MODE_R;
+    range.offset       = 0;
+    range.length       = 100;
+    init_owner(&range.owner, CHIMERA_VFS_LEASE_PROTO_NLM, 0xB, 2);
+
+    r = chimera_vfs_state_try_insert(state, file, &range, &conflict);
+    CHECK(r == CHIMERA_VFS_LEASE_BREAKING,
+          "range read lock against other-client W-cache triggers break");
+    CHECK(rec.fired == 1, "break_cb fired on caching holder");
+    CHECK(conflict == &cache, "conflict reports the caching holder");
+
+    chimera_vfs_state_remove(state, file, &cache);
+    chimera_vfs_state_put(state, file);
+    chimera_vfs_state_destroy(state);
+} /* test_range_breaks_caching */
+
+/* Acquire-callback recorder for the async-API tests. */
+struct acquire_recorder {
+    int                       fired;
+    enum chimera_vfs_lease_result last_result;
+    struct chimera_vfs_lease *last_granted;
+    struct chimera_vfs_lease *last_conflict;
+};
+
+static void
+recording_acquire_cb(
+    enum chimera_vfs_lease_result result,
+    struct chimera_vfs_lease     *granted_lease,
+    struct chimera_vfs_lease     *conflict,
+    void                         *priv)
+{
+    struct acquire_recorder *r = priv;
+
+    r->fired++;
+    r->last_result   = result;
+    r->last_granted  = granted_lease;
+    r->last_conflict = conflict;
+} /* recording_acquire_cb */
+
+/* Test 12: async acquire wait=false fires cb synchronously --------- */
+static void
+test_async_acquire_immediate(void)
+{
+    struct chimera_vfs_state          *state;
+    struct chimera_vfs_file_state     *file;
+    struct chimera_vfs_lease           lease;
+    struct chimera_vfs_pending_acquire ticket;
+    struct acquire_recorder            rec = { 0 };
+
+    fprintf(stderr, "\ntest_async_acquire_immediate\n");
+
+    state = chimera_vfs_state_init();
+    file  = get_file(state, 1);
+
+    memset(&lease, 0, sizeof(lease));
+    lease.kind         = CHIMERA_VFS_LEASE_RANGE;
+    lease.mode.granted = CHIMERA_VFS_LEASE_MODE_W;
+    lease.offset       = 0;
+    lease.length       = 100;
+    init_owner(&lease.owner, CHIMERA_VFS_LEASE_PROTO_NFSV4, 0xA, 1);
+
+    chimera_vfs_lease_acquire(state, file, &lease, &ticket, false,
+                              recording_acquire_cb, &rec);
+    CHECK(rec.fired == 1, "cb fires synchronously on first acquire");
+    CHECK(rec.last_result == CHIMERA_VFS_LEASE_GRANTED, "result is GRANTED");
+    CHECK(rec.last_granted == &lease, "granted_lease points to inserted lease");
+
+    chimera_vfs_state_remove(state, file, &lease);
+    chimera_vfs_state_put(state, file);
+    chimera_vfs_state_destroy(state);
+} /* test_async_acquire_immediate */
+
+/* Test 13: async acquire wait=true queues on BREAKING, fires after ack */
+static void
+test_async_acquire_wait_then_ack(void)
+{
+    struct chimera_vfs_state          *state;
+    struct chimera_vfs_file_state     *file;
+    struct chimera_vfs_lease           cache, range;
+    struct chimera_vfs_pending_acquire ticket;
+    struct acquire_recorder            rec  = { 0 };
+    struct break_recorder              brec = { 0 };
+    struct chimera_vfs_lease_mode      none = { 0, 0 };
+
+    fprintf(stderr, "\ntest_async_acquire_wait_then_ack\n");
+
+    state = chimera_vfs_state_init();
+    file  = get_file(state, 1);
+
+    /* Existing breakable W-cache on client A. */
+    memset(&cache, 0, sizeof(cache));
+    cache.kind         = CHIMERA_VFS_LEASE_CACHING;
+    cache.mode.granted = CHIMERA_VFS_LEASE_MODE_W;
+    init_owner(&cache.owner, CHIMERA_VFS_LEASE_PROTO_SMB2, 0xA, 1);
+    cache.owner.break_cb   = recording_break_cb;
+    cache.owner.cb_private = &brec;
+    chimera_vfs_state_try_insert(state, file, &cache, NULL);
+
+    /* Client B's range read lock — must wait on the W-cache break. */
+    memset(&range, 0, sizeof(range));
+    range.kind         = CHIMERA_VFS_LEASE_RANGE;
+    range.mode.granted = CHIMERA_VFS_LEASE_MODE_R;
+    range.offset       = 0;
+    range.length       = 100;
+    init_owner(&range.owner, CHIMERA_VFS_LEASE_PROTO_NLM, 0xB, 2);
+
+    chimera_vfs_lease_acquire(state, file, &range, &ticket, true,
+                              recording_acquire_cb, &rec);
+    CHECK(rec.fired == 0, "wait acquire does not fire cb yet");
+    CHECK(brec.fired == 1, "break_cb fired on conflicting holder");
+    CHECK(ticket.queued == true, "ticket is queued");
+
+    /* Client A acks with full release.  Pump runs and retries our ticket. */
+    chimera_vfs_lease_ack(&cache, none);
+    chimera_vfs_state_remove(state, file, &cache);
+
+    CHECK(rec.fired == 1, "cb fires once ack/remove completes");
+    CHECK(rec.last_result == CHIMERA_VFS_LEASE_GRANTED, "retry granted");
+    CHECK(ticket.queued == false, "ticket is dequeued");
+
+    chimera_vfs_state_remove(state, file, &range);
+    chimera_vfs_state_put(state, file);
+    chimera_vfs_state_destroy(state);
+} /* test_async_acquire_wait_then_ack */
+
+/* Test 14: cancel removes a queued ticket and suppresses cb -------- */
+static void
+test_async_acquire_cancel(void)
+{
+    struct chimera_vfs_state          *state;
+    struct chimera_vfs_file_state     *file;
+    struct chimera_vfs_lease           cache, range;
+    struct chimera_vfs_pending_acquire ticket;
+    struct acquire_recorder            rec  = { 0 };
+    struct break_recorder              brec = { 0 };
+    struct chimera_vfs_lease_mode      none = { 0, 0 };
+    bool                               cancelled;
+
+    fprintf(stderr, "\ntest_async_acquire_cancel\n");
+
+    state = chimera_vfs_state_init();
+    file  = get_file(state, 1);
+
+    memset(&cache, 0, sizeof(cache));
+    cache.kind         = CHIMERA_VFS_LEASE_CACHING;
+    cache.mode.granted = CHIMERA_VFS_LEASE_MODE_W;
+    init_owner(&cache.owner, CHIMERA_VFS_LEASE_PROTO_SMB2, 0xA, 1);
+    cache.owner.break_cb   = recording_break_cb;
+    cache.owner.cb_private = &brec;
+    chimera_vfs_state_try_insert(state, file, &cache, NULL);
+
+    memset(&range, 0, sizeof(range));
+    range.kind         = CHIMERA_VFS_LEASE_RANGE;
+    range.mode.granted = CHIMERA_VFS_LEASE_MODE_R;
+    range.length       = 100;
+    init_owner(&range.owner, CHIMERA_VFS_LEASE_PROTO_NLM, 0xB, 2);
+
+    chimera_vfs_lease_acquire(state, file, &range, &ticket, true,
+                              recording_acquire_cb, &rec);
+    CHECK(ticket.queued == true, "ticket queued while waiting");
+
+    /* Caller changes its mind (e.g., NLM CANCEL). */
+    cancelled = chimera_vfs_lease_acquire_cancel(state, &ticket);
+    CHECK(cancelled == true, "cancel reports the ticket was dequeued");
+    CHECK(ticket.queued == false, "ticket no longer queued after cancel");
+    CHECK(rec.fired == 0, "cb does not fire for cancelled acquire");
+
+    /* Acking the conflict no longer fires the cancelled ticket. */
+    chimera_vfs_lease_ack(&cache, none);
+    chimera_vfs_state_remove(state, file, &cache);
+    CHECK(rec.fired == 0, "cancelled ticket stays silent after ack");
+
+    /* Cancelling again is a no-op (returns false). */
+    cancelled = chimera_vfs_lease_acquire_cancel(state, &ticket);
+    CHECK(cancelled == false, "second cancel returns false");
+
+    chimera_vfs_state_put(state, file);
+    chimera_vfs_state_destroy(state);
+} /* test_async_acquire_cancel */
+
+/* Test 15: release pumps pending queue ----------------------------- */
+static void
+test_release_pumps_pending(void)
+{
+    struct chimera_vfs_state          *state;
+    struct chimera_vfs_file_state     *file;
+    struct chimera_vfs_lease           cache, range;
+    struct chimera_vfs_pending_acquire ticket;
+    struct acquire_recorder            rec  = { 0 };
+    struct break_recorder              brec = { 0 };
+
+    fprintf(stderr, "\ntest_release_pumps_pending\n");
+
+    state = chimera_vfs_state_init();
+    file  = get_file(state, 1);
+
+    memset(&cache, 0, sizeof(cache));
+    cache.kind         = CHIMERA_VFS_LEASE_CACHING;
+    cache.mode.granted = CHIMERA_VFS_LEASE_MODE_W;
+    init_owner(&cache.owner, CHIMERA_VFS_LEASE_PROTO_SMB2, 0xA, 1);
+    cache.owner.break_cb   = recording_break_cb;
+    cache.owner.cb_private = &brec;
+    chimera_vfs_state_try_insert(state, file, &cache, NULL);
+
+    memset(&range, 0, sizeof(range));
+    range.kind         = CHIMERA_VFS_LEASE_RANGE;
+    range.mode.granted = CHIMERA_VFS_LEASE_MODE_R;
+    range.length       = 100;
+    init_owner(&range.owner, CHIMERA_VFS_LEASE_PROTO_NLM, 0xB, 2);
+
+    chimera_vfs_lease_acquire(state, file, &range, &ticket, true,
+                              recording_acquire_cb, &rec);
+    CHECK(rec.fired == 0, "wait acquire queued");
+
+    /* If the holder protocol skips ack and just releases (e.g., on
+     * close), the release path should still pump the pending queue. */
+    chimera_vfs_lease_release(state, file, &cache);
+    CHECK(rec.fired == 1, "release alone pumps pending queue");
+    CHECK(rec.last_result == CHIMERA_VFS_LEASE_GRANTED, "pending granted");
+
+    chimera_vfs_state_remove(state, file, &range);
+    chimera_vfs_state_put(state, file);
+    chimera_vfs_state_destroy(state);
+} /* test_release_pumps_pending */
+
+/* Test 16: chimera_vfs_lease_test exposes conflict without inserting */
+static void
+test_lease_test(void)
+{
+    struct chimera_vfs_state      *state;
+    struct chimera_vfs_file_state *file;
+    struct chimera_vfs_lease       held, probe;
+    struct chimera_vfs_lease      *conflict;
+    enum chimera_vfs_lease_result  r;
+
+    fprintf(stderr, "\ntest_lease_test\n");
+
+    state = chimera_vfs_state_init();
+    file  = get_file(state, 1);
+
+    memset(&held, 0, sizeof(held));
+    held.kind         = CHIMERA_VFS_LEASE_RANGE;
+    held.mode.granted = CHIMERA_VFS_LEASE_MODE_W;
+    held.offset       = 0;
+    held.length       = 100;
+    init_owner(&held.owner, CHIMERA_VFS_LEASE_PROTO_NFSV4, 0xA, 1);
+    chimera_vfs_state_try_insert(state, file, &held, NULL);
+
+    /* Probe overlapping write from another owner — should DENY. */
+    memset(&probe, 0, sizeof(probe));
+    probe.kind         = CHIMERA_VFS_LEASE_RANGE;
+    probe.mode.granted = CHIMERA_VFS_LEASE_MODE_W;
+    probe.offset       = 50;
+    probe.length       = 100;
+    init_owner(&probe.owner, CHIMERA_VFS_LEASE_PROTO_NFSV4, 0xB, 2);
+
+    r = chimera_vfs_lease_test(file, &probe, &conflict);
+    CHECK(r == CHIMERA_VFS_LEASE_DENIED, "test reports conflict");
+    CHECK(conflict == &held, "test names the holder");
+
+    /* Probe is NOT inserted — file should still have only one lease. */
+    CHECK(file->range_locks == &held && held.next == NULL,
+          "test does not insert the probe");
+
+    chimera_vfs_state_remove(state, file, &held);
+    chimera_vfs_state_put(state, file);
+    chimera_vfs_state_destroy(state);
+} /* test_lease_test */
+
+/* Test 17: I/O hook is a no-op pass-through for Stage A ------------ */
+static void
+test_io_hook_passthrough(void)
+{
+    int rc;
+
+    fprintf(stderr, "\ntest_io_hook_passthrough\n");
+
+    rc = chimera_vfs_state_check_io(NULL);
+    CHECK(rc == 0, "Stage A I/O hook returns 0 (permit)");
+} /* test_io_hook_passthrough */
+
+/* Main ---------------------------------------------------------------- */
+int
+main(
+    int    argc,
+    char **argv)
+{
+    (void) argc;
+    (void) argv;
+
+    ChimeraLogLevel = CHIMERA_LOG_INFO;
+
+    test_init_destroy();
+    test_file_state_lookup();
+    test_range_vs_range();
+    test_range_same_owner_coalesces();
+    test_range_to_eof();
+    test_share_vs_share();
+    test_caching_lease_basics();
+    test_caching_w_breaks_r();
+    test_smb_lease_key_coalesces();
+    test_caching_break_revoke();
+    test_range_breaks_caching();
+    test_async_acquire_immediate();
+    test_async_acquire_wait_then_ack();
+    test_async_acquire_cancel();
+    test_release_pumps_pending();
+    test_lease_test();
+    test_io_hook_passthrough();
+
+    fprintf(stderr, "\n========================================\n");
+    fprintf(stderr, "Results: %d passed, %d failed\n", passed, failed);
+    fprintf(stderr, "========================================\n");
+
+    return failed == 0 ? 0 : 1;
+} /* main */

--- a/src/vfs/vfs.c
+++ b/src/vfs/vfs.c
@@ -22,6 +22,7 @@
 #include "vfs/vfs_attr_cache.h"
 #include "vfs/vfs_user_cache.h"
 #include "vfs/vfs_notify.h"
+#include "vfs/vfs_state.h"
 #include "vfs/vfs_mount_table.h"
 #include "vfs/memfs/memfs.h"
 #include "vfs/linux/linux.h"
@@ -415,6 +416,7 @@ chimera_vfs_init(
     vfs->vfs_user_cache = chimera_vfs_user_cache_create(8192, 600);
 
     vfs->vfs_notify = chimera_vfs_notify_init(vfs);
+    vfs->vfs_state  = chimera_vfs_state_init();
 
     /* Register the root pseudo-filesystem module */
     chimera_vfs_register(vfs, &vfs_root, NULL);
@@ -558,6 +560,10 @@ chimera_vfs_destroy(struct chimera_vfs *vfs)
 
     if (vfs->vfs_notify) {
         chimera_vfs_notify_destroy(vfs->vfs_notify);
+    }
+
+    if (vfs->vfs_state) {
+        chimera_vfs_state_destroy(vfs->vfs_state);
     }
 
     if (vfs->vfs_user_cache) {

--- a/src/vfs/vfs.h
+++ b/src/vfs/vfs.h
@@ -1043,6 +1043,7 @@ struct chimera_vfs_close_thread {
 struct chimera_vfs_mount_table;
 
 struct chimera_vfs_notify;
+struct chimera_vfs_state;
 
 struct chimera_vfs {
     struct chimera_vfs_module            *modules[CHIMERA_VFS_FH_MAGIC_MAX];
@@ -1054,6 +1055,7 @@ struct chimera_vfs {
     struct chimera_vfs_attr_cache        *vfs_attr_cache;
     struct chimera_vfs_user_cache        *vfs_user_cache;
     struct chimera_vfs_notify            *vfs_notify;
+    struct chimera_vfs_state             *vfs_state;
     struct chimera_vfs_mount_table       *mount_table;
     int                                   num_sync_delegation_threads;
     struct chimera_vfs_delegation_thread *sync_delegation_threads;

--- a/src/vfs/vfs_state.c
+++ b/src/vfs/vfs_state.c
@@ -1,0 +1,872 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "vfs_state.h"
+#include "vfs_internal.h"
+#include "common/macros.h"
+
+/*
+ * Default lease-break deadline.  Matches the SMB2 client expectation of
+ * "the server will wait roughly 30s for the break ack before forcing
+ * revocation," and is well inside the NFSv4 lease (typically 60-90s).
+ */
+#define CHIMERA_VFS_STATE_DEFAULT_BREAK_DEADLINE_MS 30000
+
+/* -------------------------------------------------------------------- */
+/* Lifecycle                                                            */
+/* -------------------------------------------------------------------- */
+
+SYMBOL_EXPORT struct chimera_vfs_state *
+chimera_vfs_state_init(void)
+{
+    struct chimera_vfs_state *state;
+    int                       i;
+
+    state = calloc(1, sizeof(*state));
+    if (!state) {
+        return NULL;
+    }
+
+    for (i = 0; i < CHIMERA_VFS_STATE_NUM_BUCKETS; i++) {
+        pthread_mutex_init(&state->buckets[i].lock, NULL);
+        state->buckets[i].files = NULL;
+    }
+
+    state->default_break_deadline_ms = CHIMERA_VFS_STATE_DEFAULT_BREAK_DEADLINE_MS;
+
+    return state;
+} /* chimera_vfs_state_init */
+
+SYMBOL_EXPORT void
+chimera_vfs_state_destroy(struct chimera_vfs_state *state)
+{
+    struct chimera_vfs_file_state *file, *next;
+    int                            i;
+
+    if (!state) {
+        return;
+    }
+
+    for (i = 0; i < CHIMERA_VFS_STATE_NUM_BUCKETS; i++) {
+        file = state->buckets[i].files;
+        while (file) {
+            next = file->bucket_next;
+            /* In Stage A there is no protocol caller, so we should never
+             * leak per-file state.  Asserts here would be too strict for
+             * test code that exits without releasing; instead we just
+             * tear down whatever remains. */
+            pthread_mutex_destroy(&file->lock);
+            free(file);
+            file = next;
+        }
+        pthread_mutex_destroy(&state->buckets[i].lock);
+    }
+
+    free(state);
+} /* chimera_vfs_state_destroy */
+
+/* -------------------------------------------------------------------- */
+/* Per-file state lookup                                                */
+/* -------------------------------------------------------------------- */
+
+static inline struct chimera_vfs_state_bucket *
+chimera_vfs_state_bucket_for(
+    struct chimera_vfs_state *state,
+    uint64_t                  fh_hash)
+{
+    return &state->buckets[fh_hash & (CHIMERA_VFS_STATE_NUM_BUCKETS - 1)];
+} /* chimera_vfs_state_bucket_for */
+
+static inline int
+chimera_vfs_file_state_match(
+    const struct chimera_vfs_file_state *file,
+    const uint8_t                       *fh,
+    uint8_t                              fh_len,
+    uint64_t                             fh_hash)
+{
+    return file->fh_hash == fh_hash &&
+           file->fh_len == fh_len &&
+           memcmp(file->fh, fh, fh_len) == 0;
+} /* chimera_vfs_file_state_match */
+
+SYMBOL_EXPORT struct chimera_vfs_file_state *
+chimera_vfs_state_get(
+    struct chimera_vfs_state *state,
+    const uint8_t            *fh,
+    uint8_t                   fh_len,
+    uint64_t                  fh_hash,
+    bool                      create)
+{
+    struct chimera_vfs_state_bucket *bucket;
+    struct chimera_vfs_file_state   *file;
+
+    bucket = chimera_vfs_state_bucket_for(state, fh_hash);
+
+    pthread_mutex_lock(&bucket->lock);
+
+    for (file = bucket->files; file; file = file->bucket_next) {
+        if (chimera_vfs_file_state_match(file, fh, fh_len, fh_hash)) {
+            file->refcount++;
+            pthread_mutex_unlock(&bucket->lock);
+            return file;
+        }
+    }
+
+    if (!create) {
+        pthread_mutex_unlock(&bucket->lock);
+        return NULL;
+    }
+
+    file = calloc(1, sizeof(*file));
+    if (!file) {
+        pthread_mutex_unlock(&bucket->lock);
+        return NULL;
+    }
+
+    memcpy(file->fh, fh, fh_len);
+    file->fh_len   = fh_len;
+    file->fh_hash  = fh_hash;
+    file->refcount = 1;
+    file->state    = state;
+    pthread_mutex_init(&file->lock, NULL);
+
+    file->bucket_next = bucket->files;
+    bucket->files     = file;
+
+    pthread_mutex_unlock(&bucket->lock);
+    return file;
+} /* chimera_vfs_state_get */
+
+SYMBOL_EXPORT void
+chimera_vfs_state_put(
+    struct chimera_vfs_state      *state,
+    struct chimera_vfs_file_state *file)
+{
+    struct chimera_vfs_state_bucket *bucket;
+    struct chimera_vfs_file_state  **link;
+    bool                             empty;
+
+    if (!file) {
+        return;
+    }
+
+    bucket = chimera_vfs_state_bucket_for(state, file->fh_hash);
+
+    pthread_mutex_lock(&bucket->lock);
+
+    chimera_vfs_abort_if(file->refcount == 0, "double put on vfs_state file");
+
+    file->refcount--;
+    if (file->refcount != 0) {
+        pthread_mutex_unlock(&bucket->lock);
+        return;
+    }
+
+    /* Refcount reached zero.  Tear down only if no leases remain — a
+     * lease holder is effectively a reference too (held implicitly via
+     * the caller that owns the lease), but if any caller forgot to put
+     * after acquiring a lease we'd otherwise free state with live
+     * leases.  Detect this and keep the entry around; a future put()
+     * will retry. */
+    empty = (file->range_locks == NULL &&
+             file->share_resvs == NULL &&
+             file->caching_leases == NULL);
+
+    if (!empty) {
+        /* Restore the implicit reference held by the lease(s). */
+        file->refcount = 1;
+        pthread_mutex_unlock(&bucket->lock);
+        return;
+    }
+
+    /* Unlink from bucket and free. */
+    for (link = &bucket->files; *link; link = &(*link)->bucket_next) {
+        if (*link == file) {
+            *link = file->bucket_next;
+            break;
+        }
+    }
+
+    pthread_mutex_unlock(&bucket->lock);
+
+    pthread_mutex_destroy(&file->lock);
+    free(file);
+} /* chimera_vfs_state_put */
+
+/* -------------------------------------------------------------------- */
+/* Conflict matrix                                                      */
+/* -------------------------------------------------------------------- */
+
+/* Same-owner coalescing: two leases share an owner iff protocol +
+ * client_key + owner_lo + owner_hi all match.  For SMB this is the
+ * (client_guid, lease_key) tuple that lets one client open the same
+ * file multiple times without breaking its own lease.  For NFSv4 it
+ * is (clientid, lock_owner4).  For NLM it is (hostname-hash, svid). */
+static inline bool
+chimera_vfs_lease_owner_equal(
+    const struct chimera_vfs_lease_owner *a,
+    const struct chimera_vfs_lease_owner *b)
+{
+    return a->protocol == b->protocol &&
+           a->client_key == b->client_key &&
+           a->owner_lo == b->owner_lo &&
+           a->owner_hi == b->owner_hi;
+} /* chimera_vfs_lease_owner_equal */
+
+/* Byte-range overlap test.  length==0 means "to EOF" (NLM/SMB
+ * convention); represent EOF as UINT64_MAX for the math. */
+static inline bool
+chimera_vfs_range_overlap(
+    uint64_t a_off,
+    uint64_t a_len,
+    uint64_t b_off,
+    uint64_t b_len)
+{
+    uint64_t a_end = (a_len == 0) ? UINT64_MAX : a_off + a_len;
+    uint64_t b_end = (b_len == 0) ? UINT64_MAX : b_off + b_len;
+
+    return a_off < b_end && b_off < a_end;
+} /* chimera_vfs_range_overlap */
+
+/* Conflict between two range leases.  Classical fcntl rule: only
+ * conflict if ranges overlap AND at least one side is exclusive (W). */
+static inline bool
+chimera_vfs_range_conflict(
+    const struct chimera_vfs_lease *a,
+    const struct chimera_vfs_lease *b)
+{
+    if (!chimera_vfs_range_overlap(a->offset, a->length,
+                                   b->offset, b->length)) {
+        return false;
+    }
+
+    return (a->mode.granted & CHIMERA_VFS_LEASE_MODE_W) ||
+           (b->mode.granted & CHIMERA_VFS_LEASE_MODE_W);
+} /* chimera_vfs_range_conflict */
+
+/* Conflict between two share reservations.  Lifted from
+ * chimera_smb_sharemode_check_conflict() at smb_sharemode.c:110-150 —
+ * the same predicate expressed in RWH-mask terms.  An access bit on one
+ * side conflicts if the other side denies it. */
+static inline bool
+chimera_vfs_share_conflict(
+    const struct chimera_vfs_lease *existing,
+    const struct chimera_vfs_lease *probe)
+{
+    if (existing->mode.granted & probe->mode.denied) {
+        return true;
+    }
+
+    if (probe->mode.granted & existing->mode.denied) {
+        return true;
+    }
+
+    return false;
+} /* chimera_vfs_share_conflict */
+
+/* Conflict between two caching leases.  An RWH triple on a holder
+ * conflicts with another holder if their granted bits overlap AND the
+ * combination is mutually exclusive — both can't hold W, etc.  In
+ * practice, since caching leases use the SMB lease bits directly, the
+ * rule simplifies to: any bit shared in `granted` between two different
+ * owners is a conflict.  W and H are exclusive across clients; R is
+ * shareable (multiple clients can each hold an R-lease — that's how
+ * SMB2 Level2 oplocks generalize). */
+static inline bool
+chimera_vfs_caching_conflict(
+    const struct chimera_vfs_lease *existing,
+    const struct chimera_vfs_lease *probe)
+{
+    uint8_t e = existing->mode.granted;
+    uint8_t p = probe->mode.granted;
+
+    /* W (write-cache) is exclusive — only one holder may have W on a
+     * given file, even across owners.  Two readers (R-only) coexist. */
+    if ((e & CHIMERA_VFS_LEASE_MODE_W) && (p & (CHIMERA_VFS_LEASE_MODE_R |
+                                                CHIMERA_VFS_LEASE_MODE_W))) {
+        return true;
+    }
+    if ((p & CHIMERA_VFS_LEASE_MODE_W) && (e & (CHIMERA_VFS_LEASE_MODE_R |
+                                                CHIMERA_VFS_LEASE_MODE_W))) {
+        return true;
+    }
+
+    /* H (handle-cache) is exclusive across owners — only one client may
+     * cache the open handle. */
+    if ((e & CHIMERA_VFS_LEASE_MODE_H) && (p & CHIMERA_VFS_LEASE_MODE_H)) {
+        return true;
+    }
+
+    return false;
+} /* chimera_vfs_caching_conflict */
+
+SYMBOL_EXPORT enum chimera_vfs_lease_result
+chimera_vfs_state_would_conflict(
+    const struct chimera_vfs_file_state *file,
+    const struct chimera_vfs_lease      *probe,
+    struct chimera_vfs_lease           **conflict_out)
+{
+    struct chimera_vfs_lease *cur;
+    bool has_breakable_conflict = false;
+
+    if (conflict_out) {
+        *conflict_out = NULL;
+    }
+
+    switch (probe->kind) {
+        case CHIMERA_VFS_LEASE_RANGE:
+            for (cur = file->range_locks; cur; cur = cur->next) {
+                if (chimera_vfs_lease_owner_equal(&cur->owner, &probe->owner)) {
+                    /* Same owner: coalesce / upgrade rather than conflict. */
+                    continue;
+                }
+                if (chimera_vfs_range_conflict(cur, probe)) {
+                    if (conflict_out) {
+                        *conflict_out = cur;
+                    }
+                    return CHIMERA_VFS_LEASE_DENIED;
+                }
+            }
+            /* A range lock may also be blocked by a caching W-lease on
+             * another client (the other client believes it has exclusive
+             * write access and a range lock here would invalidate that
+             * cache).  This is the "I/O breaks caching" rule applied
+             * conservatively to range locks too. */
+            for (cur = file->caching_leases; cur; cur = cur->next) {
+                if (chimera_vfs_lease_owner_equal(&cur->owner, &probe->owner)) {
+                    continue;
+                }
+                /* A read range lock conflicts with a W cache on another
+                 * client (their writes may be cached); a write range lock
+                 * conflicts with any R/W cache on another client. */
+                if (probe->mode.granted & CHIMERA_VFS_LEASE_MODE_W) {
+                    if (cur->mode.granted & (CHIMERA_VFS_LEASE_MODE_R |
+                                             CHIMERA_VFS_LEASE_MODE_W)) {
+                        if (cur->owner.break_cb &&
+                            cur->break_state == CHIMERA_VFS_BREAK_IDLE) {
+                            has_breakable_conflict = true;
+                            if (conflict_out && !*conflict_out) {
+                                *conflict_out = cur;
+                            }
+                        } else {
+                            if (conflict_out) {
+                                *conflict_out = cur;
+                            }
+                            return CHIMERA_VFS_LEASE_DENIED;
+                        }
+                    }
+                } else if (cur->mode.granted & CHIMERA_VFS_LEASE_MODE_W) {
+                    if (cur->owner.break_cb &&
+                        cur->break_state == CHIMERA_VFS_BREAK_IDLE) {
+                        has_breakable_conflict = true;
+                        if (conflict_out && !*conflict_out) {
+                            *conflict_out = cur;
+                        }
+                    } else {
+                        if (conflict_out) {
+                            *conflict_out = cur;
+                        }
+                        return CHIMERA_VFS_LEASE_DENIED;
+                    }
+                }
+            }
+            break;
+
+        case CHIMERA_VFS_LEASE_SHARE:
+            for (cur = file->share_resvs; cur; cur = cur->next) {
+                if (chimera_vfs_lease_owner_equal(&cur->owner, &probe->owner)) {
+                    continue;
+                }
+                if (chimera_vfs_share_conflict(cur, probe)) {
+                    if (conflict_out) {
+                        *conflict_out = cur;
+                    }
+                    return CHIMERA_VFS_LEASE_DENIED;
+                }
+            }
+            /* A new SHARE acquire may also need to break an H (handle-
+             * caching) lease on another client — the cached handle has
+             * to be invalidated when a different client opens the file. */
+            for (cur = file->caching_leases; cur; cur = cur->next) {
+                if (chimera_vfs_lease_owner_equal(&cur->owner, &probe->owner)) {
+                    continue;
+                }
+                if (cur->mode.granted & CHIMERA_VFS_LEASE_MODE_H) {
+                    if (cur->owner.break_cb &&
+                        cur->break_state == CHIMERA_VFS_BREAK_IDLE) {
+                        has_breakable_conflict = true;
+                        if (conflict_out && !*conflict_out) {
+                            *conflict_out = cur;
+                        }
+                    }
+                }
+            }
+            break;
+
+        case CHIMERA_VFS_LEASE_CACHING:
+            for (cur = file->caching_leases; cur; cur = cur->next) {
+                if (chimera_vfs_lease_owner_equal(&cur->owner, &probe->owner)) {
+                    continue;
+                }
+                if (chimera_vfs_caching_conflict(cur, probe)) {
+                    if (cur->owner.break_cb &&
+                        cur->break_state == CHIMERA_VFS_BREAK_IDLE) {
+                        has_breakable_conflict = true;
+                        if (conflict_out && !*conflict_out) {
+                            *conflict_out = cur;
+                        }
+                    } else {
+                        if (conflict_out) {
+                            *conflict_out = cur;
+                        }
+                        return CHIMERA_VFS_LEASE_DENIED;
+                    }
+                }
+            }
+            break;
+
+        case CHIMERA_VFS_LEASE_KIND_MAX:
+            break;
+    } /* switch */
+
+    return has_breakable_conflict ? CHIMERA_VFS_LEASE_BREAKING
+                                  : CHIMERA_VFS_LEASE_GRANTED;
+} /* chimera_vfs_state_would_conflict */
+
+/* Insert a lease onto the appropriate per-kind list.  Caller holds
+ * file->lock. */
+static inline void
+chimera_vfs_file_state_insert_lease(
+    struct chimera_vfs_file_state *file,
+    struct chimera_vfs_lease      *lease)
+{
+    struct chimera_vfs_lease **head;
+
+    switch (lease->kind) {
+        case CHIMERA_VFS_LEASE_RANGE:
+            head = &file->range_locks;
+            break;
+        case CHIMERA_VFS_LEASE_SHARE:
+            head = &file->share_resvs;
+            break;
+        case CHIMERA_VFS_LEASE_CACHING:
+            head = &file->caching_leases;
+            break;
+        case CHIMERA_VFS_LEASE_KIND_MAX:
+        default:
+            return;
+    } /* switch */
+
+    lease->file = file;
+    lease->prev = NULL;
+    lease->next = *head;
+    if (*head) {
+        (*head)->prev = lease;
+    }
+    *head = lease;
+} /* chimera_vfs_file_state_insert_lease */
+
+static inline void
+chimera_vfs_file_state_remove_lease(
+    struct chimera_vfs_file_state *file,
+    struct chimera_vfs_lease      *lease)
+{
+    struct chimera_vfs_lease **head;
+
+    switch (lease->kind) {
+        case CHIMERA_VFS_LEASE_RANGE:
+            head = &file->range_locks;
+            break;
+        case CHIMERA_VFS_LEASE_SHARE:
+            head = &file->share_resvs;
+            break;
+        case CHIMERA_VFS_LEASE_CACHING:
+            head = &file->caching_leases;
+            break;
+        case CHIMERA_VFS_LEASE_KIND_MAX:
+        default:
+            return;
+    } /* switch */
+
+    if (lease->prev) {
+        lease->prev->next = lease->next;
+    } else if (*head == lease) {
+        *head = lease->next;
+    }
+
+    if (lease->next) {
+        lease->next->prev = lease->prev;
+    }
+
+    lease->prev = NULL;
+    lease->next = NULL;
+    lease->file = NULL;
+} /* chimera_vfs_file_state_remove_lease */
+
+SYMBOL_EXPORT enum chimera_vfs_lease_result
+chimera_vfs_state_try_insert(
+    struct chimera_vfs_state      *state,
+    struct chimera_vfs_file_state *file,
+    struct chimera_vfs_lease      *lease,
+    struct chimera_vfs_lease     **conflict_out)
+{
+    enum chimera_vfs_lease_result result;
+    struct chimera_vfs_lease     *conflict = NULL;
+
+    pthread_mutex_lock(&file->lock);
+
+    result = chimera_vfs_state_would_conflict(file, lease, &conflict);
+
+    if (result == CHIMERA_VFS_LEASE_GRANTED) {
+        chimera_vfs_file_state_insert_lease(file, lease);
+        pthread_mutex_unlock(&file->lock);
+        return CHIMERA_VFS_LEASE_GRANTED;
+    }
+
+    if (conflict_out) {
+        *conflict_out = conflict;
+    }
+
+    if (result == CHIMERA_VFS_LEASE_BREAKING && conflict) {
+        /* Kick off a break on the conflicting holder.  Caller is
+         * expected to retry once the break completes. */
+        pthread_mutex_unlock(&file->lock);
+        chimera_vfs_lease_begin_break(state, conflict,
+                                      lease->mode.granted, 0);
+        return CHIMERA_VFS_LEASE_BREAKING;
+    }
+
+    pthread_mutex_unlock(&file->lock);
+    return result;
+} /* chimera_vfs_state_try_insert */
+
+/* -------------------------------------------------------------------- */
+/* Pending-acquire queue                                                */
+/* -------------------------------------------------------------------- */
+
+/* All three helpers expect file->lock held by caller. */
+
+static inline void
+chimera_vfs_pending_enqueue_locked(
+    struct chimera_vfs_file_state      *file,
+    struct chimera_vfs_pending_acquire *ticket)
+{
+    ticket->file   = file;
+    ticket->queued = true;
+    ticket->next   = NULL;
+    ticket->prev   = file->pending_tail;
+
+    if (file->pending_tail) {
+        file->pending_tail->next = ticket;
+    } else {
+        file->pending_head = ticket;
+    }
+    file->pending_tail = ticket;
+} /* chimera_vfs_pending_enqueue_locked */
+
+static inline void
+chimera_vfs_pending_dequeue_locked(
+    struct chimera_vfs_file_state      *file,
+    struct chimera_vfs_pending_acquire *ticket)
+{
+    if (ticket->prev) {
+        ticket->prev->next = ticket->next;
+    } else if (file->pending_head == ticket) {
+        file->pending_head = ticket->next;
+    }
+
+    if (ticket->next) {
+        ticket->next->prev = ticket->prev;
+    } else if (file->pending_tail == ticket) {
+        file->pending_tail = ticket->prev;
+    }
+
+    ticket->prev   = NULL;
+    ticket->next   = NULL;
+    ticket->queued = false;
+} /* chimera_vfs_pending_dequeue_locked */
+
+static inline struct chimera_vfs_pending_acquire *
+chimera_vfs_pending_drain_locked(struct chimera_vfs_file_state *file)
+{
+    struct chimera_vfs_pending_acquire *head = file->pending_head;
+    struct chimera_vfs_pending_acquire *t;
+
+    file->pending_head = NULL;
+    file->pending_tail = NULL;
+    for (t = head; t; t = t->next) {
+        t->queued = false;
+    }
+    return head;
+} /* chimera_vfs_pending_drain_locked */
+
+/* Retry every queued acquire on `file`.  Called after any state mutation
+ * that could clear a conflict (remove, ack with downgrade, revoke).  This
+ * MUST be called with file->lock NOT held; it takes and releases the lock
+ * internally. */
+static void
+chimera_vfs_state_pump_pending(
+    struct chimera_vfs_state      *state,
+    struct chimera_vfs_file_state *file)
+{
+    struct chimera_vfs_pending_acquire *head, *t, *next;
+    enum chimera_vfs_lease_result       result;
+    struct chimera_vfs_lease           *conflict;
+
+    pthread_mutex_lock(&file->lock);
+    head = chimera_vfs_pending_drain_locked(file);
+    pthread_mutex_unlock(&file->lock);
+
+    for (t = head; t; t = next) {
+        next     = t->next;
+        t->prev  = NULL;
+        t->next  = NULL;
+        conflict = NULL;
+
+        result = chimera_vfs_state_try_insert(state, file, t->lease, &conflict);
+
+        if (result == CHIMERA_VFS_LEASE_BREAKING) {
+            /* Re-queue and wait for the next ack/revoke.  begin_break
+             * has already been invoked on the conflicting holder by
+             * try_insert. */
+            pthread_mutex_lock(&file->lock);
+            chimera_vfs_pending_enqueue_locked(file, t);
+            pthread_mutex_unlock(&file->lock);
+            continue;
+        }
+
+        t->cb(result,
+              result == CHIMERA_VFS_LEASE_GRANTED ? t->lease : NULL,
+              conflict,
+              t->private_data);
+    }
+} /* chimera_vfs_state_pump_pending */
+
+SYMBOL_EXPORT void
+chimera_vfs_state_remove(
+    struct chimera_vfs_state      *state,
+    struct chimera_vfs_file_state *file,
+    struct chimera_vfs_lease      *lease)
+{
+    (void) state;
+
+    pthread_mutex_lock(&file->lock);
+    chimera_vfs_file_state_remove_lease(file, lease);
+    pthread_mutex_unlock(&file->lock);
+
+    /* Removing a lease may unblock a pending acquire. */
+    chimera_vfs_state_pump_pending(state, file);
+} /* chimera_vfs_state_remove */
+
+/* -------------------------------------------------------------------- */
+/* Async acquire / release / test                                       */
+/* -------------------------------------------------------------------- */
+
+SYMBOL_EXPORT void
+chimera_vfs_lease_acquire(
+    struct chimera_vfs_state           *state,
+    struct chimera_vfs_file_state      *file,
+    struct chimera_vfs_lease           *lease,
+    struct chimera_vfs_pending_acquire *ticket,
+    bool                                wait,
+    chimera_vfs_lease_acquire_cb_t      cb,
+    void                               *private_data)
+{
+    enum chimera_vfs_lease_result result;
+    struct chimera_vfs_lease     *conflict = NULL;
+
+    ticket->lease        = lease;
+    ticket->cb           = cb;
+    ticket->private_data = private_data;
+    ticket->file         = file;
+    ticket->queued       = false;
+    ticket->prev         = NULL;
+    ticket->next         = NULL;
+
+    result = chimera_vfs_state_try_insert(state, file, lease, &conflict);
+
+    if (result == CHIMERA_VFS_LEASE_BREAKING && wait) {
+        /* Conflict is breakable and caller said to wait.  Queue the
+         * ticket; it will fire when the break completes (via pump). */
+        pthread_mutex_lock(&file->lock);
+        chimera_vfs_pending_enqueue_locked(file, ticket);
+        pthread_mutex_unlock(&file->lock);
+        return;
+    }
+
+    /* Synchronous outcome (GRANTED, DENIED, or wait==false BREAKING). */
+    cb(result,
+       result == CHIMERA_VFS_LEASE_GRANTED ? lease : NULL,
+       conflict,
+       private_data);
+} /* chimera_vfs_lease_acquire */
+
+SYMBOL_EXPORT void
+chimera_vfs_lease_release(
+    struct chimera_vfs_state      *state,
+    struct chimera_vfs_file_state *file,
+    struct chimera_vfs_lease      *lease)
+{
+    chimera_vfs_state_remove(state, file, lease);
+} /* chimera_vfs_lease_release */
+
+SYMBOL_EXPORT bool
+chimera_vfs_lease_acquire_cancel(
+    struct chimera_vfs_state           *state,
+    struct chimera_vfs_pending_acquire *ticket)
+{
+    struct chimera_vfs_file_state *file = ticket->file;
+    bool                           was_queued;
+
+    (void) state;
+
+    if (!file) {
+        return false;
+    }
+
+    pthread_mutex_lock(&file->lock);
+    was_queued = ticket->queued;
+    if (was_queued) {
+        chimera_vfs_pending_dequeue_locked(file, ticket);
+    }
+    pthread_mutex_unlock(&file->lock);
+
+    return was_queued;
+} /* chimera_vfs_lease_acquire_cancel */
+
+SYMBOL_EXPORT enum chimera_vfs_lease_result
+chimera_vfs_lease_test(
+    struct chimera_vfs_file_state  *file,
+    const struct chimera_vfs_lease *probe,
+    struct chimera_vfs_lease      **conflict_out)
+{
+    enum chimera_vfs_lease_result result;
+
+    pthread_mutex_lock(&file->lock);
+    result = chimera_vfs_state_would_conflict(file, probe, conflict_out);
+    pthread_mutex_unlock(&file->lock);
+    return result;
+} /* chimera_vfs_lease_test */
+
+/* -------------------------------------------------------------------- */
+/* Break orchestration                                                  */
+/* -------------------------------------------------------------------- */
+
+SYMBOL_EXPORT void
+chimera_vfs_lease_begin_break(
+    struct chimera_vfs_state *state,
+    struct chimera_vfs_lease *lease,
+    uint8_t                   needed_mode,
+    uint32_t                  deadline_ms)
+{
+    struct chimera_vfs_file_state *file = lease->file;
+    struct timespec                now;
+    chimera_vfs_lease_break_cb_t   cb;
+    void                          *cb_priv;
+    bool                           should_invoke;
+
+    if (deadline_ms == 0) {
+        deadline_ms = state->default_break_deadline_ms;
+    }
+
+    if (file) {
+        pthread_mutex_lock(&file->lock);
+    }
+
+    should_invoke = (lease->break_state == CHIMERA_VFS_BREAK_IDLE) &&
+        (lease->owner.break_cb != NULL);
+
+    if (should_invoke) {
+        lease->break_state       = CHIMERA_VFS_BREAK_BREAKING;
+        lease->break_needed_mode = needed_mode;
+        clock_gettime(CLOCK_MONOTONIC, &now);
+        now.tv_sec  += deadline_ms / 1000;
+        now.tv_nsec += (long) (deadline_ms % 1000) * 1000000L;
+        if (now.tv_nsec >= 1000000000L) {
+            now.tv_sec  += 1;
+            now.tv_nsec -= 1000000000L;
+        }
+        lease->break_deadline = now;
+        cb                    = lease->owner.break_cb;
+        cb_priv               = lease->owner.cb_private;
+    } else {
+        cb      = NULL;
+        cb_priv = NULL;
+    }
+
+    if (file) {
+        pthread_mutex_unlock(&file->lock);
+    }
+
+    /* Invoke the break callback outside the file lock — the protocol
+     * server may need to send packets, take other locks, etc. */
+    if (cb) {
+        cb(lease, needed_mode, cb_priv);
+    }
+} /* chimera_vfs_lease_begin_break */
+
+SYMBOL_EXPORT void
+chimera_vfs_lease_ack(
+    struct chimera_vfs_lease     *lease,
+    struct chimera_vfs_lease_mode resulting)
+{
+    struct chimera_vfs_file_state *file    = lease->file;
+    bool                           mutated = false;
+
+    if (file) {
+        pthread_mutex_lock(&file->lock);
+    }
+
+    if (lease->break_state == CHIMERA_VFS_BREAK_BREAKING) {
+        lease->mode        = resulting;
+        lease->break_state = CHIMERA_VFS_BREAK_ACKED;
+        mutated            = true;
+    }
+
+    if (file) {
+        pthread_mutex_unlock(&file->lock);
+    }
+
+    /* Acking a break may unblock pending acquires. */
+    if (mutated && file && file->state) {
+        chimera_vfs_state_pump_pending(file->state, file);
+    }
+} /* chimera_vfs_lease_ack */
+
+SYMBOL_EXPORT void
+chimera_vfs_lease_revoke(struct chimera_vfs_lease *lease)
+{
+    struct chimera_vfs_file_state *file = lease->file;
+
+    if (file) {
+        pthread_mutex_lock(&file->lock);
+    }
+
+    lease->mode.granted = 0;
+    lease->mode.denied  = 0;
+    lease->break_state  = CHIMERA_VFS_BREAK_REVOKED;
+
+    if (file) {
+        pthread_mutex_unlock(&file->lock);
+    }
+
+    /* Revoking a lease may unblock pending acquires. */
+    if (file && file->state) {
+        chimera_vfs_state_pump_pending(file->state, file);
+    }
+} /* chimera_vfs_lease_revoke */
+
+/* -------------------------------------------------------------------- */
+/* I/O hook (no-op for Stage A)                                         */
+/* -------------------------------------------------------------------- */
+
+SYMBOL_EXPORT int
+chimera_vfs_state_check_io(struct chimera_vfs_request *request)
+{
+    (void) request;
+    return 0;
+} /* chimera_vfs_state_check_io */

--- a/src/vfs/vfs_state.h
+++ b/src/vfs/vfs_state.h
@@ -1,0 +1,369 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <pthread.h>
+#include <time.h>
+
+#include "vfs/vfs.h"
+#include "vfs/vfs_fh.h"
+
+struct chimera_vfs_request;
+
+/*
+ * Unified VFS lease/lock state.
+ *
+ * One in-memory state object per file handle holds three lists of leases:
+ * range locks (byte-range), share reservations (whole-file deny modes),
+ * and caching leases (delegations / oplocks / SMB2 leases).  All three
+ * protocols (NLM, NFSv4, SMB2) acquire and release leases through this
+ * layer rather than maintaining their own per-protocol tables.
+ *
+ * Persistence is explicitly out of scope for this pass: all state lives
+ * in memory and is lost on server crash.  Reclaim handshakes (NLM grace,
+ * NFSv4 CLAIM_PREVIOUS, SMB3 DH2C) work across client disconnects within
+ * a single server lifetime only.
+ */
+
+/* -------------------------------------------------------------------- */
+/* Lease vocabulary                                                     */
+/* -------------------------------------------------------------------- */
+
+enum chimera_vfs_lease_kind {
+    CHIMERA_VFS_LEASE_RANGE   = 0, /* byte-range lock */
+    CHIMERA_VFS_LEASE_SHARE   = 1, /* whole-file share/deny reservation */
+    CHIMERA_VFS_LEASE_CACHING = 2, /* breakable caching lease */
+    CHIMERA_VFS_LEASE_KIND_MAX
+};
+
+/* Mode bits — SMB2 RWH triple, used as the lingua franca.
+ *   R = read-cache / shared range lock / SMB FILE_READ_DATA share-allow
+ *   W = write-cache / exclusive range lock / SMB FILE_WRITE_DATA share-allow
+ *   H = handle-cache (SMB only)
+ *   D = delete (SMB FILE_SHARE_DELETE)
+ *
+ * RANGE leases use {R} for shared, {W} for exclusive; H and D are ignored.
+ * SHARE leases use granted = access bits, denied = deny bits.
+ * CACHING leases use granted directly (e.g., {R,W,H} for an SMB lease).
+ */
+#define CHIMERA_VFS_LEASE_MODE_R      0x01
+#define CHIMERA_VFS_LEASE_MODE_W      0x02
+#define CHIMERA_VFS_LEASE_MODE_H      0x04
+#define CHIMERA_VFS_LEASE_MODE_D      0x08
+
+struct chimera_vfs_lease_mode {
+    uint8_t granted; /* bits the holder has been granted */
+    uint8_t denied;  /* SHARE only: bits this holder denies to others */
+};
+
+/* Protocol identifiers — used in owner.protocol so the conflict matrix
+ * can apply protocol-specific same-owner coalescing rules. */
+#define CHIMERA_VFS_LEASE_PROTO_NLM   1
+#define CHIMERA_VFS_LEASE_PROTO_NFSV4 2
+#define CHIMERA_VFS_LEASE_PROTO_SMB2  3
+
+struct chimera_vfs_lease;
+
+/* Break callback — invoked synchronously by vfs_state when this lease must
+ * downgrade or release.  The callback is expected to kick off the protocol-
+ * specific break (build SMB2 OPLOCK_BREAK, send NFSv4 CB_RECALL) and return
+ * promptly; vfs_state does not wait inside the callback.  The protocol
+ * server eventually calls chimera_vfs_lease_ack() (or chimera_vfs_lease_
+ * revoke() on its own timeout) to unstick the pending acquire. */
+typedef void (*chimera_vfs_lease_break_cb_t)(
+    struct chimera_vfs_lease *lease,
+    uint8_t                   needed_mode,
+    void                     *private_data);
+
+/* Liveness probe — vfs_state calls this to test whether a lease's owning
+ * client/session is still considered alive.  Returns false on session
+ * expiry, connection drop past grace, etc.  May be NULL (always alive). */
+typedef bool (*chimera_vfs_lease_is_alive_cb_t)(
+    const struct chimera_vfs_lease *lease,
+    void                           *private_data);
+
+struct chimera_vfs_lease_owner {
+    uint32_t                        protocol;
+    uint64_t                        client_key;
+    uint64_t                        owner_lo;
+    uint64_t                        owner_hi;
+    chimera_vfs_lease_break_cb_t    break_cb;
+    chimera_vfs_lease_is_alive_cb_t is_alive_cb;
+    void                           *cb_private;
+};
+
+enum chimera_vfs_break_state {
+    CHIMERA_VFS_BREAK_IDLE     = 0, /* no break in progress */
+    CHIMERA_VFS_BREAK_BREAKING = 1, /* break_cb invoked, awaiting ack */
+    CHIMERA_VFS_BREAK_ACKED    = 2, /* protocol acked, lease downgraded */
+    CHIMERA_VFS_BREAK_REVOKED  = 3, /* forcibly revoked (timeout or error) */
+};
+
+struct chimera_vfs_file_state;
+
+struct chimera_vfs_lease {
+    enum chimera_vfs_lease_kind kind;
+    struct chimera_vfs_lease_mode  mode;
+    uint64_t                       offset; /* RANGE only; SHARE/CACHING use 0 */
+    uint64_t                       length; /* RANGE only; 0 = to EOF */
+    struct chimera_vfs_lease_owner owner;
+    struct chimera_vfs_file_state *file;
+
+    enum chimera_vfs_break_state break_state;
+    uint8_t                        break_needed_mode;
+    struct timespec                break_deadline;
+
+    /* Intrusive linkage on the appropriate file->{range,share,caching} list. */
+    struct chimera_vfs_lease      *prev;
+    struct chimera_vfs_lease      *next;
+};
+
+/* -------------------------------------------------------------------- */
+/* Lease result enum                                                    */
+/* -------------------------------------------------------------------- */
+
+/* Conflict-test result.  Returned by chimera_vfs_state_would_conflict(),
+ * chimera_vfs_state_try_insert(), and chimera_vfs_lease_test(). */
+enum chimera_vfs_lease_result {
+    CHIMERA_VFS_LEASE_GRANTED  = 0, /* no conflict; lease would be / was inserted */
+    CHIMERA_VFS_LEASE_DENIED   = 1, /* hard conflict with non-breakable holder */
+    CHIMERA_VFS_LEASE_BREAKING = 2, /* breakable holder must downgrade first */
+};
+
+/* -------------------------------------------------------------------- */
+/* Async-acquire ticket                                                 */
+/* -------------------------------------------------------------------- */
+
+/* Result of an async acquire.  GRANTED carries `granted_lease`; DENIED
+ * carries `conflict` (a pointer to a conflicting holder — owned by
+ * vfs_state, valid only until the callback returns). */
+typedef void (*chimera_vfs_lease_acquire_cb_t)(
+    enum chimera_vfs_lease_result result,
+    struct chimera_vfs_lease     *granted_lease,
+    struct chimera_vfs_lease     *conflict,
+    void                         *private_data);
+
+/* Caller-allocated ticket holding pending-acquire bookkeeping.  Its
+ * lifetime must extend until the acquire callback fires.  Protocol
+ * layers typically embed this in their existing per-lock state struct
+ * (nlm_lock_entry, nfs4_state, smb_open_file's lock slot). */
+struct chimera_vfs_pending_acquire {
+    struct chimera_vfs_lease           *lease;
+    chimera_vfs_lease_acquire_cb_t      cb;
+    void                               *private_data;
+    struct chimera_vfs_file_state      *file;
+    bool                                queued;
+    struct chimera_vfs_pending_acquire *prev;
+    struct chimera_vfs_pending_acquire *next;
+};
+
+/* -------------------------------------------------------------------- */
+/* Per-file state                                                       */
+/* -------------------------------------------------------------------- */
+
+#define CHIMERA_VFS_STATE_NUM_BUCKETS 64
+
+struct chimera_vfs_file_state {
+    uint8_t                             fh[CHIMERA_VFS_FH_SIZE];
+    uint8_t                             fh_len;
+    uint64_t                            fh_hash;
+    pthread_mutex_t                     lock;
+
+    struct chimera_vfs_lease           *range_locks;
+    struct chimera_vfs_lease           *share_resvs;
+    struct chimera_vfs_lease           *caching_leases;
+
+    /* FIFO queue of acquires waiting on a break to complete. */
+    struct chimera_vfs_pending_acquire *pending_head;
+    struct chimera_vfs_pending_acquire *pending_tail;
+
+    /* Back-pointer set on creation so ack/revoke/remove can pump the
+     * pending queue without changing public-API signatures. */
+    struct chimera_vfs_state           *state;
+
+    uint32_t                            refcount;
+    struct chimera_vfs_file_state      *bucket_next;
+};
+
+struct chimera_vfs_state_bucket {
+    struct chimera_vfs_file_state *files;
+    pthread_mutex_t                lock;
+};
+
+struct chimera_vfs_state {
+    struct chimera_vfs_state_bucket buckets[CHIMERA_VFS_STATE_NUM_BUCKETS];
+    /* Default deadline applied by chimera_vfs_lease_begin_break() when the
+     * caller passes 0.  Matches SMB2 lease-break timeout convention. */
+    uint32_t                        default_break_deadline_ms;
+};
+
+/* -------------------------------------------------------------------- */
+/* Public API                                                           */
+/* -------------------------------------------------------------------- */
+
+/* Lifecycle.  One state subsystem per VFS instance, created at
+* chimera_vfs_init() and destroyed at chimera_vfs_destroy(). */
+struct chimera_vfs_state *
+chimera_vfs_state_init(
+    void);
+
+void
+chimera_vfs_state_destroy(
+    struct chimera_vfs_state *state);
+
+/* Lookup-or-create the per-file state object for a given FH.  On success
+ * returns a refcounted pointer; caller must release via
+ * chimera_vfs_state_put().  If create==false and no state exists, returns
+ * NULL. */
+struct chimera_vfs_file_state *
+chimera_vfs_state_get(
+    struct chimera_vfs_state *state,
+    const uint8_t            *fh,
+    uint8_t                   fh_len,
+    uint64_t                  fh_hash,
+    bool                      create);
+
+void
+chimera_vfs_state_put(
+    struct chimera_vfs_state      *state,
+    struct chimera_vfs_file_state *file);
+
+/* -------------------------------------------------------------------- */
+/* Conflict matrix and lease insertion                                  */
+/* -------------------------------------------------------------------- */
+
+/* Pure test: would `probe` conflict with any existing lease on `file`?
+ * Caller must hold file->lock.  On conflict, *conflict_out is set to the
+ * first conflicting lease.  The probe is NOT inserted. */
+enum chimera_vfs_lease_result
+chimera_vfs_state_would_conflict(
+    const struct chimera_vfs_file_state *file,
+    const struct chimera_vfs_lease      *probe,
+    struct chimera_vfs_lease           **conflict_out);
+
+/* Atomically test and insert.  Caller must NOT hold file->lock; this
+ * function takes it internally.  On GRANTED, ownership of `lease` transfers
+ * to vfs_state until chimera_vfs_state_remove() is called.  On DENIED, the
+ * lease is not inserted and conflict_out (if non-NULL) is set to a
+ * conflicting holder.  On BREAKING, the lease is not inserted but the
+ * conflicting holders have begin_break() called on them; caller is
+ * expected to retry after the break ack/revoke completes. */
+enum chimera_vfs_lease_result
+chimera_vfs_state_try_insert(
+    struct chimera_vfs_state      *state,
+    struct chimera_vfs_file_state *file,
+    struct chimera_vfs_lease      *lease,
+    struct chimera_vfs_lease     **conflict_out);
+
+/* Remove a previously-inserted lease.  Caller must NOT hold file->lock. */
+void
+chimera_vfs_state_remove(
+    struct chimera_vfs_state      *state,
+    struct chimera_vfs_file_state *file,
+    struct chimera_vfs_lease      *lease);
+
+/* -------------------------------------------------------------------- */
+/* Async acquire/release                                                */
+/* -------------------------------------------------------------------- */
+
+/* Acquire a lease.  `lease` and `ticket` are caller-allocated; their
+ * lifetime must extend until the callback fires.
+ *
+ * Outcomes:
+ *   GRANTED  - lease was inserted; cb(GRANTED, lease, NULL, priv) fires
+ *              synchronously inside this call.  Ownership of `lease`
+ *              transfers to vfs_state until chimera_vfs_lease_release().
+ *   DENIED   - lease conflicts with a non-breakable holder.  If wait
+ *              is false, cb(DENIED, NULL, conflict, priv) fires
+ *              synchronously.  If wait is true, the same DENIED result
+ *              still fires synchronously — only breakable conflicts
+ *              cause queueing.
+ *   BREAKING - lease conflicts with a breakable holder.  If wait is
+ *              true, the ticket is queued on the file's pending list;
+ *              cb will fire asynchronously once the break completes
+ *              (either GRANTED or DENIED at retry time).  If wait is
+ *              false, cb(BREAKING, NULL, conflict, priv) fires
+ *              synchronously and the caller is expected to retry. */
+void
+chimera_vfs_lease_acquire(
+    struct chimera_vfs_state           *state,
+    struct chimera_vfs_file_state      *file,
+    struct chimera_vfs_lease           *lease,
+    struct chimera_vfs_pending_acquire *ticket,
+    bool                                wait,
+    chimera_vfs_lease_acquire_cb_t      cb,
+    void                               *private_data);
+
+/* Release a previously-granted lease and free its slot in the file
+ * state.  Equivalent to chimera_vfs_state_remove() but also pumps the
+ * pending-acquire queue in case the released lease was holding back a
+ * waiting acquire. */
+void
+chimera_vfs_lease_release(
+    struct chimera_vfs_state      *state,
+    struct chimera_vfs_file_state *file,
+    struct chimera_vfs_lease      *lease);
+
+/* Cancel a queued acquire.  Returns true if the ticket was on the
+ * pending queue and has been dequeued (cb will NOT fire); false if cb
+ * has already fired or is about to fire. */
+bool
+chimera_vfs_lease_acquire_cancel(
+    struct chimera_vfs_state           *state,
+    struct chimera_vfs_pending_acquire *ticket);
+
+/* Pure synchronous conflict test.  Useful for LOCKT and SMB2_LOCK with
+ * FAIL_IMMEDIATELY where the caller wants to probe without inserting.
+ * `conflict_out`, if non-NULL, is set to the first conflicting holder
+ * on DENIED / BREAKING. */
+enum chimera_vfs_lease_result
+chimera_vfs_lease_test(
+    struct chimera_vfs_file_state  *file,
+    const struct chimera_vfs_lease *probe,
+    struct chimera_vfs_lease      **conflict_out);
+
+/* -------------------------------------------------------------------- */
+/* Break orchestration                                                  */
+/* -------------------------------------------------------------------- */
+
+/* Mark `lease` as breaking and invoke its owner's break_cb.  Idempotent —
+ * a lease already in BREAKING state is left untouched.  deadline_ms==0
+ * uses state->default_break_deadline_ms. */
+void
+chimera_vfs_lease_begin_break(
+    struct chimera_vfs_state *state,
+    struct chimera_vfs_lease *lease,
+    uint8_t                   needed_mode,
+    uint32_t                  deadline_ms);
+
+/* Protocol server calls this when it has finished the protocol-specific
+ * break and obtained the client's downgrade response.  `resulting` is the
+ * mode the lease has been downgraded to; if resulting.granted == 0 the
+ * lease is fully released and the caller must still call
+ * chimera_vfs_state_remove() afterward to free it. */
+void
+chimera_vfs_lease_ack(
+    struct chimera_vfs_lease     *lease,
+    struct chimera_vfs_lease_mode resulting);
+
+/* Forcibly revoke a lease — called by vfs_state when the break deadline
+ * expires, or by the protocol server when it gives up on the client. */
+void
+chimera_vfs_lease_revoke(
+    struct chimera_vfs_lease *lease);
+
+/* -------------------------------------------------------------------- */
+/* I/O hook                                                             */
+/* -------------------------------------------------------------------- */
+
+/* Called by VFS core before dispatching a READ or WRITE request.  In
+ * Stage A this is a no-op pass-through that always returns 0 (success);
+ * Stage B+ will enforce range-lock conflicts and break caching leases.
+ * Returns 0 on permit, a CHIMERA_VFS_E* error code on deny. */
+int
+chimera_vfs_state_check_io(
+    struct chimera_vfs_request *request);


### PR DESCRIPTION
## Summary

Introduces a single VFS-layer state object (\`vfs_state\`) that coordinates byte-range locks, share-mode reservations, and breakable caching leases across NFSv3 (NLM), NFSv4, and SMB2. The protocol layers stop maintaining their own per-protocol lock tables and instead acquire/release leases through one shared backend with a unified conflict matrix.

The motivation: today NFS and SMB lock state are completely disjoint, so an NFS write doesn't block a conflicting SMB open and vice versa. Once Chimera grants SMB leases or NFSv4 delegations, that incoherence becomes a correctness problem — the holder caches based on assumptions the other protocol can't honor. \`vfs_state\` is the single source of truth all three protocols consult.

## Design at a glance

Three lease kinds on one per-file state object:

- \`RANGE\` — byte-range locks (NLM, NFSv4 LOCK, SMB2 LOCK)
- \`SHARE\` — whole-file share/deny reservations (NFSv4 OPEN, SMB CREATE \`share_access\`)
- \`CACHING\` — breakable caching leases (NFSv4 delegations, SMB2 leases / oplocks)

Conflict matrix lives in one place. Same-owner coalescing implements the SMB lease-key rule (multi-open by one client shares one lease) and the NFSv4 lock-owner rule. SMB2 RWH bits are the lingua franca; per-protocol mappers translate at call sites.

Async \`chimera_vfs_lease_acquire\` supports waiting on breakable conflicts via a per-file pending queue; break orchestration invokes the holder's \`break_cb\`, transitions IDLE → BREAKING → ACKED/REVOKED, and pumps the queue so waiting acquires retry.

## What's in scope here

- **Foundation** (\`src/vfs/vfs_state.{h,c}\` + 17 unit tests)
- **Range locks**: NFSv4 LOCK/LOCKT/LOCKU migrated; LOCKU now releases the precise lease (previously fcntl unlock without tracking); NLM TEST/LOCK/UNLOCK migrated, per-host conflict scan deleted; NLM CANCEL implemented (was a stub returning GRANTED); new SMB2_LOCK opcode dispatch with parse/handler/reply.
- **Share modes**: SMB CREATE share-mode check routes through vfs_state (legacy sharemode table bypassed); NFSv4 OPEN \`share_access\` / \`share_deny\` honored (previously a single-flag no-op at line 298).
- **SMB caching leases**: CREATE grants SMB2 leases (RqLs v1/v2) and legacy oplocks; new \`smb_proc_oplock_break.c\` builds and sends the OPLOCK_BREAK Notification on the conn that owns the lease; SMB2_OPLOCK_BREAK ack handler echoes the Response packet; \`chimera_smb_conn_free\` clears \`create_conn\` so \`break_cb\` never dereferences a freed bind.

## Behavior changes worth flagging

- NFSv4 OPEN can now return \`NFS4ERR_SHARE_DENIED\` (previously always granted regardless of share_deny).
- NFSv4 LOCKU returns \`NFS4ERR_LOCK_RANGE\` for unmatched ranges (previously called fcntl unlock blindly).
- SMB2 byte-range LOCK / UNLOCK now actually work (previously \`STATUS_NOT_IMPLEMENTED\`).
- SMB CREATE can now grant SMB2 leases and oplocks (previously always \`OPLOCK_LEVEL_NONE\`).
- **Regression**: NFSv3 byte-range locks no longer survive a server restart — the NLM on-disk lease list is removed per the approved in-memory-only plan. The 90s grace window still opens; it just finds nothing to reclaim.

## What's deferred

- **NFSv4 callback channel + delegations**. OPEN still returns \`OPEN_DELEGATE_NONE\`. Granting delegations requires a server-initiated RPC direction (CB_COMPOUND / CB_RECALL) which doesn't exist in the codebase yet — needs new infrastructure in \`evpl_rpc2\` plus BIND_CONN_TO_SESSION, DELEGRETURN, RENEW. Slated for a follow-up.
- **Persistence**. All vfs_state lives in memory. Reclaim handshakes (NLM grace already wired; NFSv4 \`CLAIM_PREVIOUS\`+\`reclaim=1\`; SMB3 DH2Q/DH2C) work across client disconnect within one server lifetime but not across crashes. Persistence is a separate follow-up (per-backend journaling vs outboard KV — undecided).

## Verification

- 1891 tests pass debug + release. NLM lockf and cthon tlock suites exercise the migrated NLM path; \`vfs_state_test.c\` exercises the full conflict matrix in isolation.
- \`scan-build\` clean (debug + release).
- \`reuse-lint\` clean, \`syntax-check\` clean.
- The libevpl network tests (\`bulk_msg_tcp\`, \`ping_pong_msg_tcp\`, \`bulk_stream_tcp\`, \`ping_pong_msg_tls\`) are intermittently flaky under parallel load and unrelated to this change; all pass when re-run solo.

## Commit layout

1. \`vfs: add unified lease/lock state backend\` — additive, no behavior change, 17-test suite included.
2. \`server: route NLM, NFSv4, and SMB locking through vfs_state\` — wires every protocol through the new backend.