### PR TITLE
cmake: gate remaining privilege-requiring tests on netns availability

### DIFF
--- a/src/client/tests/CMakeLists.txt
+++ b/src/client/tests/CMakeLists.txt
@@ -9,11 +9,17 @@ macro(add_client_testprog name)
         TEST_FILE "${CMAKE_CURRENT_SOURCE_DIR}/${name}.c")
 endmacro()
 
+# These run unwrapped, but their fixture chowns the per-test session dir to
+# the target test uid/gid (CAP_CHOWN) and brings up the io_uring VFS module
+# (unlimited RLIMIT_MEMLOCK) -- the same privileges the netns environment
+# provides. Gate them on it so unprivileged `make` skips rather than fails.
 macro(add_client_test testname prog backend user)
-    add_test(NAME chimera/client/${testname} COMMAND ${CMAKE_CURRENT_BINARY_DIR}/${prog} -b ${backend} -U ${user})
-    get_target_property(test_file ${prog} TEST_FILE)
-    set_tests_properties(chimera/client/${testname} PROPERTIES
-        ENVIRONMENT "TEST_FILE=${test_file}")
+    if(CHIMERA_NETNS_TESTING)
+        add_test(NAME chimera/client/${testname} COMMAND ${CMAKE_CURRENT_BINARY_DIR}/${prog} -b ${backend} -U ${user})
+        get_target_property(test_file ${prog} TEST_FILE)
+        set_tests_properties(chimera/client/${testname} PROPERTIES
+            ENVIRONMENT "TEST_FILE=${test_file}")
+    endif()
 endmacro()
 
 macro(add_client_nfs_test testname prog backend user)
@@ -25,10 +31,15 @@ macro(add_client_nfs_test testname prog backend user)
     endif()
 endmacro()
 
-# Keep basic test as-is for now
 add_executable(client_basic basic.c)
 target_link_libraries(client_basic chimera_client)
-add_test(NAME chimera/client/basic COMMAND client_basic)
+# Runs unwrapped (no loopback networking needed), but initializing the VFS
+# brings up the io_uring module, whose queue allocation needs an unlimited
+# RLIMIT_MEMLOCK. The netns wrapper raises that limit for every other test;
+# gate this one on the same privilege so unprivileged `make` doesn't abort.
+if(CHIMERA_NETNS_TESTING)
+    add_test(NAME chimera/client/basic COMMAND client_basic)
+endif()
 
 # List of test programs
 set(CLIENT_TEST_PROGRAMS

--- a/src/posix/tests/CMakeLists.txt
+++ b/src/posix/tests/CMakeLists.txt
@@ -162,14 +162,16 @@ generate_posix_nfs3_backend_tests(io_uring CHIMERA_VFS_IO_URING)
 
 # Macro to add a test that runs via NFS4 client (requires network namespace)
 macro(add_posix_nfs4_test testname prog nfs_backend)
-    add_test(NAME chimera/posix/${testname}_nfs4_${nfs_backend}
-        COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_${prog} -b nfs4_${nfs_backend}
-    )
-    get_target_property(test_file posix_${prog} TEST_FILE)
-    set_tests_properties(chimera/posix/${testname}_nfs4_${nfs_backend} PROPERTIES
-        ENVIRONMENT "TEST_FILE=${test_file}"
-        TIMEOUT 60
-    )
+    if(CHIMERA_NETNS_TESTING)
+        add_test(NAME chimera/posix/${testname}_nfs4_${nfs_backend}
+            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_${prog} -b nfs4_${nfs_backend}
+        )
+        get_target_property(test_file posix_${prog} TEST_FILE)
+        set_tests_properties(chimera/posix/${testname}_nfs4_${nfs_backend} PROPERTIES
+            ENVIRONMENT "TEST_FILE=${test_file}"
+            TIMEOUT 60
+        )
+    endif()
 endmacro()
 
 # Helper macro to generate NFS4 tests for a specific server-side backend
@@ -565,14 +567,16 @@ generate_cthon_nfs3rdma_backend_tests(io_uring CHIMERA_VFS_IO_URING)
 
 # Macro to add a cthon test that runs via NFS4 client (requires network namespace)
 macro(add_cthon_nfs4_test testname prog nfs_backend)
-    add_test(NAME chimera/posix/cthon/${testname}_nfs4_${nfs_backend}
-        COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_${prog} -b nfs4_${nfs_backend}
-    )
-    get_target_property(test_file posix_${prog} TEST_FILE)
-    set_tests_properties(chimera/posix/cthon/${testname}_nfs4_${nfs_backend} PROPERTIES
-        ENVIRONMENT "TEST_FILE=${test_file}"
-        TIMEOUT 300
-    )
+    if(CHIMERA_NETNS_TESTING)
+        add_test(NAME chimera/posix/cthon/${testname}_nfs4_${nfs_backend}
+            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_${prog} -b nfs4_${nfs_backend}
+        )
+        get_target_property(test_file posix_${prog} TEST_FILE)
+        set_tests_properties(chimera/posix/cthon/${testname}_nfs4_${nfs_backend} PROPERTIES
+            ENVIRONMENT "TEST_FILE=${test_file}"
+            TIMEOUT 300
+        )
+    endif()
 endmacro()
 
 # Helper macro to generate NFS4 cthon tests for a specific server-side backend
@@ -814,35 +818,37 @@ generate_stress_nfs3rdma_tests(io_uring CHIMERA_VFS_IO_URING)
 
 # Helper macro to generate NFS4 stress tests for a backend
 macro(_generate_stress_nfs4_tests_for_backend nfs_backend)
-    # dirstress: directory operations stress test (reduced params for testing)
-    add_test(NAME chimera/posix/dirstress_nfs4_${nfs_backend}
-        COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_dirstress -b nfs4_${nfs_backend} -p 1 -f 50
-    )
-    set_tests_properties(chimera/posix/dirstress_nfs4_${nfs_backend} PROPERTIES TIMEOUT 120)
+    if(CHIMERA_NETNS_TESTING)
+        # dirstress: directory operations stress test (reduced params for testing)
+        add_test(NAME chimera/posix/dirstress_nfs4_${nfs_backend}
+            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_dirstress -b nfs4_${nfs_backend} -p 1 -f 50
+        )
+        set_tests_properties(chimera/posix/dirstress_nfs4_${nfs_backend} PROPERTIES TIMEOUT 120)
 
-    # rewinddir: tests rewinddir() POSIX semantics
-    add_test(NAME chimera/posix/rewinddir_nfs4_${nfs_backend}
-        COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_rewinddir -b nfs4_${nfs_backend}
-    )
-    set_tests_properties(chimera/posix/rewinddir_nfs4_${nfs_backend} PROPERTIES TIMEOUT 120)
+        # rewinddir: tests rewinddir() POSIX semantics
+        add_test(NAME chimera/posix/rewinddir_nfs4_${nfs_backend}
+            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_rewinddir -b nfs4_${nfs_backend}
+        )
+        set_tests_properties(chimera/posix/rewinddir_nfs4_${nfs_backend} PROPERTIES TIMEOUT 120)
 
-    # fstest: data integrity verification test
-    add_test(NAME chimera/posix/fstest_nfs4_${nfs_backend}
-        COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_fstest -b nfs4_${nfs_backend} -n 1 -f 2 -l 5 -s 65536
-    )
-    set_tests_properties(chimera/posix/fstest_nfs4_${nfs_backend} PROPERTIES TIMEOUT 120)
+        # fstest: data integrity verification test
+        add_test(NAME chimera/posix/fstest_nfs4_${nfs_backend}
+            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_fstest -b nfs4_${nfs_backend} -n 1 -f 2 -l 5 -s 65536
+        )
+        set_tests_properties(chimera/posix/fstest_nfs4_${nfs_backend} PROPERTIES TIMEOUT 120)
 
-    # nametest: namespace stress test
-    add_test(NAME chimera/posix/nametest_nfs4_${nfs_backend}
-        COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_nametest -b nfs4_${nfs_backend} -n 50 -i 1000
-    )
-    set_tests_properties(chimera/posix/nametest_nfs4_${nfs_backend} PROPERTIES TIMEOUT 120)
+        # nametest: namespace stress test
+        add_test(NAME chimera/posix/nametest_nfs4_${nfs_backend}
+            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_nametest -b nfs4_${nfs_backend} -n 50 -i 1000
+        )
+        set_tests_properties(chimera/posix/nametest_nfs4_${nfs_backend} PROPERTIES TIMEOUT 120)
 
-    # fsstress: comprehensive filesystem stress test
-    add_test(NAME chimera/posix/fsstress_nfs4_${nfs_backend}
-        COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_fsstress -b nfs4_${nfs_backend} -n 500 -p 1
-    )
-    set_tests_properties(chimera/posix/fsstress_nfs4_${nfs_backend} PROPERTIES TIMEOUT 180)
+        # fsstress: comprehensive filesystem stress test
+        add_test(NAME chimera/posix/fsstress_nfs4_${nfs_backend}
+            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_fsstress -b nfs4_${nfs_backend} -n 500 -p 1
+        )
+        set_tests_properties(chimera/posix/fsstress_nfs4_${nfs_backend} PROPERTIES TIMEOUT 180)
+    endif()
 endmacro()
 
 # Macro to generate NFS4 stress tests with optional condition

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -22,17 +22,21 @@ if(CHIMERA_NETNS_TESTING)
                 ${CMAKE_CURRENT_BINARY_DIR}/smbclient_auth_test --mode=ntlm)
 endif()
 
-add_test(NAME chimera/server/smb/smbclient_kerberos
-    COMMAND ${CMAKE_SOURCE_DIR}/scripts/kerberos_test_wrapper.sh
-            ${CMAKE_CURRENT_BINARY_DIR}/smbclient_auth_test --mode=kerberos)
-set_tests_properties(chimera/server/smb/smbclient_kerberos PROPERTIES
-    SKIP_RETURN_CODE 77)
+# kerberos_test_wrapper.sh and ad_test_wrapper.sh both set up an isolated
+# netns internally, so they need the same privilege as the netns wrapper.
+if(CHIMERA_NETNS_TESTING)
+    add_test(NAME chimera/server/smb/smbclient_kerberos
+        COMMAND ${CMAKE_SOURCE_DIR}/scripts/kerberos_test_wrapper.sh
+                ${CMAKE_CURRENT_BINARY_DIR}/smbclient_auth_test --mode=kerberos)
+    set_tests_properties(chimera/server/smb/smbclient_kerberos PROPERTIES
+        SKIP_RETURN_CODE 77)
 
-find_program(SAMBA_TOOL samba-tool)
-if(SAMBA_TOOL)
-    add_test(NAME chimera/server/smb/smbclient_winbind
-        COMMAND ${CMAKE_SOURCE_DIR}/scripts/ad_test_wrapper.sh
-                ${CMAKE_CURRENT_BINARY_DIR}/smbclient_auth_test --mode=winbind)
+    find_program(SAMBA_TOOL samba-tool)
+    if(SAMBA_TOOL)
+        add_test(NAME chimera/server/smb/smbclient_winbind
+            COMMAND ${CMAKE_SOURCE_DIR}/scripts/ad_test_wrapper.sh
+                    ${CMAKE_CURRENT_BINARY_DIR}/smbclient_auth_test --mode=winbind)
+    endif()
 endif()
 
 # SMB share mode test


### PR DESCRIPTION
## Summary

Follow-up to #269. After that merged, an unprivileged `make` still failed a pile of tests, from three causes the original PR missed:

- **nfs4 posix/cthon/stress macros** (added to main in parallel with #269) weren't gated, so they still failed with `mkdir /run/netns failed`. Now gated like the nfs3 equivalents.
- **`smbclient_kerberos` / `smbclient_winbind`** use `kerberos_test_wrapper.sh` / `ad_test_wrapper.sh`, which set up a netns internally (CAP_NET_ADMIN).
- **`client/basic`** runs unwrapped, but VFS init brings up the io_uring module whose queue allocation needs unlimited `RLIMIT_MEMLOCK` (the netns wrapper raises it for every other test).
- **`add_client_test` direct-backend tests** chown the per-test session dir to the target uid/gid (CAP_CHOWN).

All coincide with the privileged test environment, so they hang off the same `CHIMERA_NETNS_TESTING` gate.

Verified: privileged build registers 2394 tests; unprivileged build runs 29 tests with **zero failures** (previously a wall of failures); unprivileged + `-DREQUIRE_NETNS_TESTS=ON` still aborts configure.