### PR TITLE
nfs4: reject COMMIT and OPEN on non-regular files

### DIFF
--- a/src/server/nfs/nfs4_proc_commit.c
+++ b/src/server/nfs/nfs4_proc_commit.c
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
+#include <sys/stat.h>
+
 #include "nfs4_procs.h"
 #include "nfs4_status.h"
 #include "vfs/vfs_procs.h"
@@ -16,14 +18,19 @@ chimera_nfs4_commit_complete(
     struct nfs_request *req = private_data;
     struct COMMIT4res  *res = &req->res_compound.resarray[req->index].opcommit;
 
-    if (error_code == CHIMERA_VFS_OK) {
+    if (error_code != CHIMERA_VFS_OK) {
+        res->status = chimera_nfs4_errno_to_nfsstat4(error_code);
+    } else if ((pre_attr->va_set_mask & CHIMERA_VFS_ATTR_MODE) &&
+               !S_ISREG(pre_attr->va_mode)) {
+        /* RFC 7530 §16.4: COMMIT only applies to regular files. A directory
+         * yields NFS4ERR_ISDIR; any other non-regular object NFS4ERR_INVAL. */
+        res->status = S_ISDIR(pre_attr->va_mode) ? NFS4ERR_ISDIR : NFS4ERR_INVAL;
+    } else {
         res->status = NFS4_OK;
 
         memcpy(res->resok4.writeverf,
                &req->thread->shared->nfs_verifier,
                sizeof(res->resok4.writeverf));
-    } else {
-        res->status = chimera_nfs4_errno_to_nfsstat4(error_code);
     }
 
     chimera_vfs_release(req->thread->vfs_thread, req->handle);
@@ -53,7 +60,7 @@ chimera_nfs4_commit_open_callback(
                        file_handle,
                        args->offset,
                        args->count,
-                       0, 0,
+                       CHIMERA_VFS_ATTR_MODE, 0,
                        chimera_nfs4_commit_complete,
                        req);
 } /* chimera_nfs4_commit_open_callback */

--- a/src/server/nfs/nfs4_proc_open.c
+++ b/src/server/nfs/nfs4_proc_open.c
@@ -245,6 +245,17 @@ chimera_nfs4_open_at_complete(
         return;
     }
 
+    /* RFC 7530 §16.16.5: OPEN targets a regular file. A directory yields
+     * NFS4ERR_ISDIR; any other non-regular object (symlink, socket, fifo,
+     * block/char device) yields NFS4ERR_SYMLINK. */
+    if ((attr->va_set_mask & CHIMERA_VFS_ATTR_MODE) && !S_ISREG(attr->va_mode)) {
+        res->status = S_ISDIR(attr->va_mode) ? NFS4ERR_ISDIR : NFS4ERR_SYMLINK;
+        chimera_vfs_release(req->thread->vfs_thread, handle);
+        chimera_vfs_release(req->thread->vfs_thread, parent_handle);
+        chimera_nfs4_open_complete(req, res->status);
+        return;
+    }
+
     {
         uint32_t lock_caps      = handle->vfs_module->capabilities;
         uint32_t install_rflags = 0;
@@ -467,7 +478,7 @@ chimera_nfs4_open_parent_complete(
                                 args->claim.file.len,
                                 flags,
                                 attr,
-                                CHIMERA_VFS_ATTR_FH,
+                                CHIMERA_VFS_ATTR_FH | CHIMERA_VFS_ATTR_MODE,
                                 CHIMERA_VFS_ATTR_MTIME,
                                 CHIMERA_VFS_ATTR_MTIME,
                                 chimera_nfs4_open_at_complete,

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -895,6 +895,36 @@ memfs_getattr(
     request->complete(request);
 } /* memfs_getattr */
 
+/* memfs holds all data in memory, so COMMIT is a no-op for durability.
+ * It still returns the requested pre/post attributes so callers (e.g. the
+ * NFSv4 server) can validate the target's file type without an extra
+ * round-trip. */
+static void
+memfs_commit(
+    struct memfs_thread        *thread,
+    struct memfs_shared        *shared,
+    struct chimera_vfs_request *request,
+    void                       *private_data)
+{
+    struct memfs_inode *inode;
+
+    inode = memfs_inode_get_fh(shared, request->fh, request->fh_len);
+
+    if (unlikely(!inode)) {
+        request->status = CHIMERA_VFS_ENOENT;
+        request->complete(request);
+        return;
+    }
+
+    memfs_map_attrs(shared, &request->commit.r_pre_attr, inode, request->fh);
+    memfs_map_attrs(shared, &request->commit.r_post_attr, inode, request->fh);
+
+    pthread_mutex_unlock(&inode->lock);
+
+    request->status = CHIMERA_VFS_OK;
+    request->complete(request);
+} /* memfs_commit */
+
 static void
 memfs_setattr(
     struct memfs_thread        *thread,
@@ -3812,8 +3842,7 @@ memfs_dispatch(
             memfs_write(thread, shared, request, private_data);
             break;
         case CHIMERA_VFS_OP_COMMIT:
-            request->status = CHIMERA_VFS_OK;
-            request->complete(request);
+            memfs_commit(thread, shared, request, private_data);
             break;
         case CHIMERA_VFS_OP_ALLOCATE:
             memfs_allocate(thread, shared, request, private_data);


### PR DESCRIPTION
## Summary

COMMIT and OPEN both silently succeeded when their target was a non-regular file, where RFC 7530 requires a type-specific error. pynfs's `commit` and `open` flag groups exercise every file type and caught this.

**OPEN** (RFC 7530 §16.16.5): after `open_at` resolves the target, reject a directory with `NFS4ERR_ISDIR` and any other non-regular object (symlink, socket, fifo, block/char device) with `NFS4ERR_SYMLINK`. The `open_at` result attr mask now requests `CHIMERA_VFS_ATTR_MODE` so the type is known without an extra round-trip.

**COMMIT** (RFC 7530 §16.4): a directory yields `NFS4ERR_ISDIR`, other non-regular objects `NFS4ERR_INVAL`. The handler now requests the pre-op MODE attribute and validates it in the completion callback. memfs's COMMIT was a bare no-op returning no attributes; it now maps pre/post attrs from the in-memory inode (still a durability no-op) so the NFS-layer type check works without forcing an extra getattr.

## Subtest impact (memfs/NFSv4.0, pynfs)

| flag | before | after |
|------|-------:|------:|
| commit | 8/14 | 14/14 |
| open | 21/35 | 27/35 |

The remaining `open` failures are share-reservation / lock-state cases, owned by the separate lease/lock work — out of scope here.