### PR TITLE
nfs4: return NFS4ERR_BADHANDLE for malformed PUTFH handles

### DIFF
--- a/src/server/nfs/nfs4_proc_putfh.c
+++ b/src/server/nfs/nfs4_proc_putfh.c
@@ -1,8 +1,10 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
 #include "nfs4_procs.h"
+#include "nfs4_status.h"
+#include "vfs/vfs_procs.h"
 
 void
 chimera_nfs4_putfh(
@@ -13,6 +15,24 @@ chimera_nfs4_putfh(
 {
     struct PUTFH4args *args = &argop->opputfh;
     struct  PUTFH4res *res  = &resop->opputfh;
+
+    /* RFC 7530 §16.20.5: a structurally invalid handle (wrong length, unknown
+     * mount) is NFS4ERR_BADHANDLE. Existence of the target is not checked here
+     * — a well-formed but deleted handle surfaces NFS4ERR_STALE on the
+     * operation that dereferences it.
+     *
+     * The synthetic NFSv4 pseudo-root handle is not a VFS mount handle (it is
+     * resolved by the server's fh_is_nfs4_root fast path), so accept it
+     * explicitly; the kernel client PUTFHs it during mount. */
+    if (!fh_is_nfs4_root(args->object.data, args->object.len) &&
+        (args->object.len > NFS4_FHSIZE ||
+         !chimera_vfs_fh_is_plausible(thread->vfs_thread,
+                                      args->object.data,
+                                      args->object.len))) {
+        res->status = NFS4ERR_BADHANDLE;
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
 
     res->status = NFS4_OK;
 

--- a/src/vfs/vfs.c
+++ b/src/vfs/vfs.c
@@ -499,6 +499,15 @@ chimera_vfs_init(
     return vfs;
 } /* chimera_vfs_init */
 
+SYMBOL_EXPORT int
+chimera_vfs_fh_is_plausible(
+    struct chimera_vfs_thread *thread,
+    const void                *fh,
+    int                        fhlen)
+{
+    return chimera_vfs_get_module(thread, fh, fhlen) != NULL;
+} /* chimera_vfs_fh_is_plausible */
+
 SYMBOL_EXPORT void
 chimera_vfs_destroy(struct chimera_vfs *vfs)
 {

--- a/src/vfs/vfs_procs.h
+++ b/src/vfs/vfs_procs.h
@@ -8,6 +8,16 @@
 
 struct evpl_iovec;
 
+/* Synchronous, no-I/O check that a file handle is structurally valid and
+ * resolves to a currently-mounted VFS module. Returns 1 if the handle could
+ * name an object on this server, 0 if it is malformed or names an unknown
+ * mount (the caller should map 0 to NFS4ERR_BADHANDLE / NFS3ERR_BADHANDLE).
+ * It does NOT verify that the target object still exists. */
+int
+chimera_vfs_fh_is_plausible(
+    struct chimera_vfs_thread *thread,
+    const void                *fh,
+    int                        fhlen);
 
 typedef void (*chimera_vfs_mount_callback_t)(
     struct chimera_vfs_thread *thread,


### PR DESCRIPTION
## Summary

PUTFH copied the argument handle into the current FH unconditionally, so a structurally invalid handle was accepted (and only failed later, or not at all). RFC 7530 §16.20.5 requires `NFS4ERR_BADHANDLE` for a handle that is not valid for the server.

Adds `chimera_vfs_fh_is_plausible()` — a synchronous, no-I/O check that a handle is long enough and resolves to a currently-mounted VFS module (wrapping the existing `chimera_vfs_get_module` lookup). PUTFH now rejects an over-long or unresolvable handle with `NFS4ERR_BADHANDLE`.

This deliberately does **not** verify the target object still exists: a well-formed handle to a deleted object continues to surface `NFS4ERR_STALE` on the op that dereferences it, avoiding a VFS round-trip on the very hot PUTFH path. (pynfs `PUTFH3`, which expects STALE at PUTFH time, is `ganesha`-flagged and stays out of scope.)

## Subtest impact (memfs/NFSv4.0, pynfs)

| flag | before | after |
|------|-------:|------:|
| putfh | 7/9 | 8/9 |