### PR TITLE
smb/vfs/memfs: persist DOS file attributes

### DIFF
--- a/src/server/smb/smb_attr.h
+++ b/src/server/smb/smb_attr.h
@@ -29,6 +29,14 @@
 #define SMB_ATTR_DISPOSITION        (1ULL << 13)
 #define SMB_ATTR_POSITION           (1ULL << 14)
 
+/* DOS attribute bits a client may set/clear via SET_INFO FileBasicInformation
+ * and that the VFS persists.  DIRECTORY/REPARSE/etc. are derived from the
+ * inode type, not stored, so they are excluded here. */
+#define SMB_DOS_ATTR_SETTABLE       (SMB2_FILE_ATTRIBUTE_READONLY | \
+                                     SMB2_FILE_ATTRIBUTE_HIDDEN |   \
+                                     SMB2_FILE_ATTRIBUTE_SYSTEM |   \
+                                     SMB2_FILE_ATTRIBUTE_ARCHIVE)
+
 /* Masks for each information class */
 #define SMB_ATTR_MASK_BASIC         ( \
             SMB_ATTR_CRTTIME | SMB_ATTR_ATIME | SMB_ATTR_MTIME | \
@@ -114,6 +122,14 @@ chimera_smb_marshal_basic_attrs(
 
     /* File attributes */
     smb_attr->smb_attributes = 0;
+
+    /* Settable DOS attribute bits persisted by the VFS (READONLY, HIDDEN,
+     * SYSTEM, ARCHIVE).  Only honored when the backend reports it actually
+     * stores them; otherwise we fall back to synthesizing from the mode. */
+    if (attr->va_set_mask & CHIMERA_VFS_ATTR_DOS_ATTRIBUTES) {
+        smb_attr->smb_attributes |= attr->va_dos_attributes & SMB_DOS_ATTR_SETTABLE;
+    }
+
     if ((attr->va_mode & S_IFMT) == S_IFDIR) {
         smb_attr->smb_attributes |= 0x10; /* FILE_ATTRIBUTE_DIRECTORY */
     }
@@ -347,6 +363,14 @@ chimera_smb_unmarshal_basic_info(
 
     attr->va_req_mask |= CHIMERA_VFS_ATTR_ATIME | CHIMERA_VFS_ATTR_MTIME | CHIMERA_VFS_ATTR_CTIME;
     attr->va_set_mask |= CHIMERA_VFS_ATTR_ATIME | CHIMERA_VFS_ATTR_MTIME | CHIMERA_VFS_ATTR_CTIME;
+
+    /* A FileAttributes value of 0 means "no change" (MS-FSCC 2.4.7); any
+     * non-zero value replaces the persisted DOS attribute set. */
+    if (smb_attrs->smb_attributes != 0) {
+        attr->va_dos_attributes = smb_attrs->smb_attributes & SMB_DOS_ATTR_SETTABLE;
+        attr->va_req_mask      |= CHIMERA_VFS_ATTR_DOS_ATTRIBUTES;
+        attr->va_set_mask      |= CHIMERA_VFS_ATTR_DOS_ATTRIBUTES;
+    }
 } // chimera_smb_unmarshal_basic_info
 
 static inline void

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -1315,6 +1315,14 @@ chimera_smb_parse_create(
     request->create.set_attr.va_set_mask = 0;
     request->create.ctx_present_mask     = 0;
 
+    /* Persist any settable DOS attribute bits supplied at create time. */
+    if (request->create.file_attributes & SMB_DOS_ATTR_SETTABLE) {
+        request->create.set_attr.va_dos_attributes =
+            request->create.file_attributes & SMB_DOS_ATTR_SETTABLE;
+        request->create.set_attr.va_req_mask |= CHIMERA_VFS_ATTR_DOS_ATTRIBUTES;
+        request->create.set_attr.va_set_mask |= CHIMERA_VFS_ATTR_DOS_ATTRIBUTES;
+    }
+
     if (blob_offset > 0 && blob_length > 0 && blob_length <= 1024) {
         uint8_t  ctx_buf[1024];
         uint32_t skip = blob_offset - evpl_iovec_cursor_consumed(request_cursor);

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -120,6 +120,7 @@ struct memfs_inode {
     uint32_t            uid;
     uint32_t            gid;
     uint64_t            rdev;
+    uint32_t            dos_attributes;
     struct timespec     atime;
     struct timespec     mtime;
     struct timespec     ctime;
@@ -376,8 +377,9 @@ memfs_inode_alloc(
     pthread_mutex_unlock(&inode_list->lock);
 
     inode->gen++;
-    inode->refcnt = 1;
-    inode->mode   = 0;
+    inode->refcnt         = 1;
+    inode->mode           = 0;
+    inode->dos_attributes = 0;
 
     return inode;
 
@@ -796,6 +798,10 @@ memfs_map_attrs(
         attr->va_ino        = inode->inum;
         attr->va_dev        = (42UL << 32) | 42;
         attr->va_rdev       = inode->rdev;
+
+        /* memfs persists DOS attributes, so report them alongside stat. */
+        attr->va_set_mask      |= CHIMERA_VFS_ATTR_DOS_ATTRIBUTES;
+        attr->va_dos_attributes = inode->dos_attributes;
     }
 
     if (attr->va_req_mask & CHIMERA_VFS_ATTR_FSID) {
@@ -846,6 +852,11 @@ memfs_apply_attrs(
     if (set_mask & CHIMERA_VFS_ATTR_SIZE) {
         attr->va_set_mask |= CHIMERA_VFS_ATTR_SIZE;
         inode->size        = attr->va_size;
+    }
+
+    if (set_mask & CHIMERA_VFS_ATTR_DOS_ATTRIBUTES) {
+        attr->va_set_mask    |= CHIMERA_VFS_ATTR_DOS_ATTRIBUTES;
+        inode->dos_attributes = attr->va_dos_attributes;
     }
 
     if (set_mask & CHIMERA_VFS_ATTR_ATIME) {
@@ -1132,6 +1143,10 @@ memfs_mount(
         attr->va_ino        = inode->inum;
         attr->va_dev        = (42UL << 32) | 42;
         attr->va_rdev       = inode->rdev;
+
+        /* memfs persists DOS attributes, so report them alongside stat. */
+        attr->va_set_mask      |= CHIMERA_VFS_ATTR_DOS_ATTRIBUTES;
+        attr->va_dos_attributes = inode->dos_attributes;
     }
 
     if (attr->va_req_mask & CHIMERA_VFS_ATTR_MASK_STATFS) {

--- a/src/vfs/vfs_attrs.h
+++ b/src/vfs/vfs_attrs.h
@@ -32,6 +32,10 @@
 #define CHIMERA_VFS_ATTR_ATOMIC         (1UL << 19)
 #define CHIMERA_VFS_ATTR_FSID           (1UL << 20)
 
+/* Windows/SMB DOS attribute bits (FILE_ATTRIBUTE_*).  Optional: a backend
+ * sets this bit in va_set_mask only if it actually persists the value. */
+#define CHIMERA_VFS_ATTR_DOS_ATTRIBUTES (1UL << 21)
+
 #define CHIMERA_VFS_ATTR_MASK_STAT      ( \
             CHIMERA_VFS_ATTR_DEV | \
             CHIMERA_VFS_ATTR_INUM | \
@@ -85,6 +89,8 @@ struct chimera_vfs_attrs {
     uint64_t        va_fs_files_free;
     uint64_t        va_fs_files_avail;
     uint64_t        va_fsid;
+
+    uint32_t        va_dos_attributes;
 
     uint32_t        va_fh_len;
     uint64_t        va_fh_hash;


### PR DESCRIPTION
## Summary

SMB clients set and read the DOS attribute bits (`READONLY`, `HIDDEN`, `SYSTEM`, `ARCHIVE`) via `FileBasicInformation` and the CREATE `FileAttributes` field. Previously the server **dropped** the value on the way in (`chimera_smb_unmarshal_basic_info` ignored `smb_attributes`) and **synthesized** it on the way out purely from the inode type, so a set/get round-trip lost `HIDDEN`/`SYSTEM`/`READONLY`.

This adds a generic way to carry these through the VFS and persists them in memfs:

- **vfs**: new optional `CHIMERA_VFS_ATTR_DOS_ATTRIBUTES` attribute + `va_dos_attributes` field. A backend advertises it in `va_set_mask` only when it actually stores the value.
- **memfs**: store `dos_attributes` per inode; report it with stat and apply it from setattr (covers create, mkdir, mknod, setinfo).
- **smb**: marshal the persisted bits into `FileBasicInformation` when the backend provides them (else fall back to the previous mode-derived synthesis), unmarshal the settable bits on `SET_INFO`, and apply any settable bits supplied in the CREATE `FileAttributes` field.

Backends that don't implement the attribute (linux, demofs, cairn) are unaffected — they never set the mask bit, so the SMB layer keeps synthesizing exactly as before.

## Effect on smbtorture (memfs)

Flips `smb2.async_dosmode` green and lets `smb2.dosmode` / `smb2.openattr` progress past their attribute-persistence checks to deeper behaviours that remain TODO (create-time write-deny on READONLY, ARCHIVE-on-modify, overwrite-disposition attribute reset).