### PR TITLE
nfs4: validate SETATTR attribute arguments

### DIFF
--- a/src/server/nfs/nfs4_attr.h
+++ b/src/server/nfs/nfs4_attr.h
@@ -590,7 +590,7 @@ chimera_nfs4_marshall_attrs(
     return 0;
 } /* chimera_nfs4_marshall_attrs */
 
-static int
+static nfsstat4
 chimera_nfs4_unmarshall_attrs(
     struct chimera_vfs_attrs *attr,
     uint32_t                  num_req_mask,
@@ -607,7 +607,7 @@ chimera_nfs4_unmarshall_attrs(
         if (req_mask[0] & (1 << FATTR4_SIZE)) {
 
             if (unlikely(attrs + sizeof(uint64_t) > attrsend)) {
-                return -1;
+                return NFS4ERR_BADXDR;
             }
 
             attr->va_size      = chimera_nfs_ntoh64(*(uint64_t *) attrs);
@@ -620,7 +620,7 @@ chimera_nfs4_unmarshall_attrs(
         if (req_mask[1] & (1 << (FATTR4_MODE - 32))) {
 
             if (unlikely(attrs + sizeof(uint32_t) > attrsend)) {
-                return -1;
+                return NFS4ERR_BADXDR;
             }
 
             attr->va_mode      = chimera_nfs_ntoh32(*(uint32_t *) attrs);
@@ -633,7 +633,7 @@ chimera_nfs4_unmarshall_attrs(
             uint32_t owner_padded_len;
 
             if (unlikely(attrs + sizeof(uint32_t) > attrsend)) {
-                return -1;
+                return NFS4ERR_BADXDR;
             }
 
             owner_len        = chimera_nfs_ntoh32(*(uint32_t *) attrs);
@@ -641,7 +641,12 @@ chimera_nfs4_unmarshall_attrs(
             owner_padded_len = (owner_len + 3) & ~3;
 
             if (unlikely(attrs + owner_padded_len > attrsend)) {
-                return -1;
+                return NFS4ERR_BADXDR;
+            }
+
+            /* RFC 7530 §5.9: owner is a non-empty utf8str_mixed. */
+            if (unlikely(owner_len == 0)) {
+                return NFS4ERR_INVAL;
             }
 
             /* Convert string to numeric uid */
@@ -655,7 +660,7 @@ chimera_nfs4_unmarshall_attrs(
             uint32_t group_padded_len;
 
             if (unlikely(attrs + sizeof(uint32_t) > attrsend)) {
-                return -1;
+                return NFS4ERR_BADXDR;
             }
 
             group_len        = chimera_nfs_ntoh32(*(uint32_t *) attrs);
@@ -663,7 +668,12 @@ chimera_nfs4_unmarshall_attrs(
             group_padded_len = (group_len + 3) & ~3;
 
             if (unlikely(attrs + group_padded_len > attrsend)) {
-                return -1;
+                return NFS4ERR_BADXDR;
+            }
+
+            /* RFC 7530 §5.9: owner_group is a non-empty utf8str_mixed. */
+            if (unlikely(group_len == 0)) {
+                return NFS4ERR_INVAL;
             }
 
             /* Convert string to numeric gid */
@@ -675,7 +685,7 @@ chimera_nfs4_unmarshall_attrs(
         if (req_mask[1] & (1 << (FATTR4_TIME_ACCESS_SET - 32))) {
 
             if (unlikely(attrs + sizeof(uint32_t) > attrsend)) {
-                return -1;
+                return NFS4ERR_BADXDR;
             }
 
             set_it = chimera_nfs_ntoh32(*(uint32_t *) attrs);
@@ -684,13 +694,18 @@ chimera_nfs4_unmarshall_attrs(
             if (set_it) {
 
                 if (unlikely(attrs + sizeof(uint64_t) + sizeof(uint32_t) > attrsend)) {
-                    return -1;
+                    return NFS4ERR_BADXDR;
                 }
 
                 attr->va_atime.tv_sec  = chimera_nfs_ntoh64(*(uint64_t *) attrs);
                 attrs                 += sizeof(uint64_t);
                 attr->va_atime.tv_nsec = chimera_nfs_ntoh32(*(uint32_t *) attrs);
                 attrs                 += sizeof(uint32_t);
+
+                /* RFC 7530 §5.7: nseconds must be < 1,000,000,000. */
+                if (unlikely(attr->va_atime.tv_nsec >= 1000000000)) {
+                    return NFS4ERR_INVAL;
+                }
             } else {
                 attr->va_atime.tv_sec  = 0;
                 attr->va_atime.tv_nsec = CHIMERA_VFS_TIME_NOW;
@@ -702,7 +717,7 @@ chimera_nfs4_unmarshall_attrs(
         if (req_mask[1] & (1 << (FATTR4_TIME_MODIFY_SET - 32))) {
 
             if (unlikely(attrs + sizeof(uint32_t) > attrsend)) {
-                return -1;
+                return NFS4ERR_BADXDR;
             }
 
             set_it = chimera_nfs_ntoh32(*(uint32_t *) attrs);
@@ -711,13 +726,18 @@ chimera_nfs4_unmarshall_attrs(
             if (set_it) {
 
                 if (unlikely(attrs + sizeof(uint64_t) + sizeof(uint32_t) > attrsend)) {
-                    return -1;
+                    return NFS4ERR_BADXDR;
                 }
 
                 attr->va_mtime.tv_sec  = chimera_nfs_ntoh64(*(uint64_t *) attrs);
                 attrs                 += sizeof(uint64_t);
                 attr->va_mtime.tv_nsec = chimera_nfs_ntoh32(*(uint32_t *) attrs);
                 attrs                 += sizeof(uint32_t);
+
+                /* RFC 7530 §5.7: nseconds must be < 1,000,000,000. */
+                if (unlikely(attr->va_mtime.tv_nsec >= 1000000000)) {
+                    return NFS4ERR_INVAL;
+                }
             } else {
                 attr->va_mtime.tv_sec  = 0;
                 attr->va_mtime.tv_nsec = CHIMERA_VFS_TIME_NOW;
@@ -729,7 +749,9 @@ chimera_nfs4_unmarshall_attrs(
 
     }
 
-    return (attrs <= attrsend) ? 0 : -1;
+    /* RFC 7530 §5: the attr_vals opaque must be consumed exactly. Leftover
+     * bytes (or an overrun) are a malformed fattr4 -> NFS4ERR_BADXDR. */
+    return (attrs == attrsend) ? NFS4_OK : NFS4ERR_BADXDR;
 } /* chimera_nfs4_unmarshall_attrs */
 
 static inline nfsstat4

--- a/src/server/nfs/nfs4_proc_setattr.c
+++ b/src/server/nfs/nfs4_proc_setattr.c
@@ -72,8 +72,8 @@ chimera_nfs4_setattr_open_callback(
                                        args->obj_attributes.attr_vals.data,
                                        args->obj_attributes.attr_vals.len);
 
-    if (rc != 0) {
-        res->status = NFS4ERR_BADXDR;
+    if (rc != NFS4_OK) {
+        res->status = rc;
         chimera_vfs_release(req->thread->vfs_thread, handle);
         chimera_nfs4_compound_complete(req, res->status);
         return;


### PR DESCRIPTION
## Summary

`chimera_nfs4_unmarshall_attrs` accepted several malformed or out-of-range fattr4 inputs that RFC 7530 requires the server to reject, and it collapsed every decode failure into one sentinel that the SETATTR caller hard-coded to `NFS4ERR_BADXDR` — so even semantic violations surfaced as BADXDR.

The unmarshaller now returns an `nfsstat4` and enforces:
- empty `owner` / `owner_group` string (utf8str length 0) → `NFS4ERR_INVAL` (§5.9)
- `time_access_set` / `time_modify_set` with `nseconds >= 1,000,000,000` → `NFS4ERR_INVAL` (§5.7)
- `attr_vals` not consumed exactly — trailing or short bytes → `NFS4ERR_BADXDR` (§5)

SETATTR propagates the returned status verbatim instead of always reporting BADXDR. CREATE/OPEN callers already ignore the return (their create-time attrs are pre-validated via `validate_createattrs`) and are unaffected.

## Subtest impact (memfs/NFSv4.0, pynfs)

| flag | before | after |
|------|-------:|------:|
| setattr | 40/45 | 44/45 |

Covers SATT8 (trailing data), SATT10 (invalid nsec), SATT16/SATT17 (empty principals). The remaining setattr failure is the open-stateid case (`SATT3d`), owned by the separate lock/state work.