### PR TITLE
posix/test_fcntl: fix intermittent ESTALE race in cross-process lock test

### DIFF
--- a/src/posix/tests/test_fcntl.c
+++ b/src/posix/tests/test_fcntl.c
@@ -536,9 +536,16 @@ main(
     send_sig(p2c[1]); /* child can now acquire */
 
     chimera_posix_close(fd);
-    chimera_posix_unlink(TEST_FILE);
 
+    /*
+     * Wait for the child to finish its final F_SETLKW test before removing
+     * the file. Unlinking earlier races the child's blocking lock: the NLM
+     * handler re-opens the file by handle, which becomes stale once the link
+     * is gone, intermittently failing the child with ESTALE.
+     */
     waitpid(child, &status, 0);
+
+    chimera_posix_unlink(TEST_FILE);
 
     if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
         if (WIFEXITED(status) && WEXITSTATUS(status) == 2) {


### PR DESCRIPTION
## Summary

Fixes an intermittent failure of `chimera/posix/fcntl_*` (e.g. `fcntl_nfs3_io_uring`) that surfaced as:

```
child: F_SETLKW after parent unlock failed: Stale file handle
parent: child process failed (status=0)
```

## Root cause

This is a test-ordering race in `test_fcntl.c`, not a server bug. The parent's final cross-process sequence was:

```c
send_sig(p2c[1]);              // tell child it may now take the lock
chimera_posix_close(fd);
chimera_posix_unlink(TEST_FILE);   // removes the file immediately
waitpid(child, &status, 0);
```

That signal unblocks the child's last subtest — a blocking `F_SETLKW` on the same file. So the parent's `unlink` and the child's lock run concurrently. When the `unlink` wins, the server's NLM LOCK handler re-opens the file *by filehandle*, which is now stale (the link is gone), and the lock fails with ESTALE:

```
parent: Remove ... fcntl_lock_test          <- unlink raced ahead
child:  NLM LOCK ... block=1
Open ... status 116 (Stale file handle)
        NLM LOCK open failed: error 116 -> NLM4_STALE_FH
```

It's intermittent because the child's blocking lock usually reaches the server before the parent's `Remove` lands. Open-but-unlinked semantics don't help: each NLM op re-looks-up the file by handle, and the NFS server doesn't silly-rename to keep removed-but-open files reachable.

## Fix

Move the `unlink` to after `waitpid`, so the file outlives the child's final lock test. The parent already joins the child immediately afterward, so this is the natural place for cleanup and adds no extra synchronization.