### PR TITLE
nfs4: validate READDIR arguments and fix small-maxcount paging

### DIFF
--- a/src/server/nfs/nfs4_proc_readdir.c
+++ b/src/server/nfs/nfs4_proc_readdir.c
@@ -102,7 +102,20 @@ chimera_nfs4_readdir_complete(
     struct nfs_nfs4_readdir_cursor *cursor = &req->readdir4_cursor;
     uint64_t                        cv;
 
+    /* RFC 7530 §16.24.4: if not even one entry fit in maxcount and we are
+     * not at end-of-directory, the buffer is too small. Returning an empty,
+     * non-eof page would stall a paging client. */
+    if (status == NFS4_OK && !eof && cursor->entries == NULL) {
+        status = NFS4ERR_TOOSMALL;
+    }
+
     res->status = status;
+
+    if (status != NFS4_OK) {
+        chimera_vfs_release(req->thread->vfs_thread, req->handle);
+        chimera_nfs4_compound_complete(req, status);
+        return;
+    }
 
     cv = verifier ? verifier : cookie;
     memcpy(res->resok4.cookieverf, &cv, sizeof(res->resok4.cookieverf));
@@ -157,11 +170,29 @@ chimera_nfs4_readdir(
     struct nfs_argop4                *argop,
     struct nfs_resop4                *resop)
 {
-    struct READDIR4res             *res = &req->res_compound.resarray[req->index].opreaddir;
+    struct READDIR4args            *args = &argop->opreaddir;
+    struct READDIR4res             *res  = &req->res_compound.resarray[req->index].opreaddir;
     struct nfs_nfs4_readdir_cursor *cursor;
 
     if (req->fhlen == 0) {
         res->status = NFS4ERR_NOFILEHANDLE;
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    /* maxcount bounds the entire READDIR4resok. If it cannot even hold the
+     * cookie verifier and the empty-directory reply (8 + 4 + 4 bytes), the
+     * server returns NFS4ERR_TOOSMALL. */
+    if (args->maxcount < 16) {
+        res->status = NFS4ERR_TOOSMALL;
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    /* Write-only attributes (time_*_set) cannot be read back per entry. */
+    res->status = chimera_nfs4_validate_getattr_request(args->num_attr_request,
+                                                        args->attr_request);
+    if (res->status != NFS4_OK) {
         chimera_nfs4_compound_complete(req, res->status);
         return;
     }
@@ -174,7 +205,11 @@ chimera_nfs4_readdir(
 
     cursor = &req->readdir4_cursor;
 
-    cursor->count   = 256;
+    /* Fixed READDIR4resok overhead counted against maxcount: cookieverf (8)
+     * + the dirlist4 "entry present" and "eof" booleans (4 each). Keeping
+     * this tight ensures a small maxcount on a continuation still admits at
+     * least one entry rather than returning an empty, non-eof page. */
+    cursor->count   = 16;
     cursor->entries = NULL;
     cursor->last    = NULL;
 

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -1638,8 +1638,10 @@ memfs_readdir(
     }
 
     if (!S_ISDIR(inode->mode)) {
+        enum chimera_vfs_error err = S_ISLNK(inode->mode) ?
+            CHIMERA_VFS_ESYMLINK : CHIMERA_VFS_ENOTDIR;
         pthread_mutex_unlock(&inode->lock);
-        request->status = CHIMERA_VFS_ENOENT;
+        request->status = err;
         request->complete(request);
         return;
     }


### PR DESCRIPTION
## Summary

READDIR accepted several inputs RFC 7530 §16.24 requires it to reject, and a too-large fixed overhead estimate could return an empty, non-eof page that stalls a paging client.

- **reserved cookie** 1 or 2 → `NFS4ERR_BAD_COOKIE` (only 0 or a server-returned cookie is legal)
- **maxcount** too small to hold the cookie verifier + empty-directory reply → `NFS4ERR_TOOSMALL`
- **write-only attributes** (`time_*_set`) requested per entry → `NFS4ERR_INVAL` (reuses `chimera_nfs4_validate_getattr_request`)
- READDIR **on a non-directory** → `NFS4ERR_NOTDIR` (`NFS4ERR_SYMLINK` for a symlink); `memfs_readdir` previously returned `ENOENT` for any non-directory

The per-call maxcount overhead was a flat 256 bytes, so a continuation READDIR with a modest maxcount could reject even its first entry and return zero entries with `eof=false`. Tightened the overhead to the actual fixed cost (cookieverf + two booleans = 16) and, defensively, return `NFS4ERR_TOOSMALL` if a non-eof page still ends up empty.

## Subtest impact (memfs/NFSv4.0, pynfs)

| flag | before | after |
|------|-------:|------:|
| readdir | 7/18 | 18/18 |