### PR TITLE
nfs4: report supported_attrs per the requested minor version

### DIFF
--- a/src/server/nfs/nfs4_attr.h
+++ b/src/server/nfs/nfs4_attr.h
@@ -202,7 +202,8 @@ chimera_nfs4_marshall_attrs(
     uint32_t                       *rsp_mask,
     uint32_t                        max_rsp_mask,
     void                           *attrs,
-    uint32_t                       *attrvals_len)
+    uint32_t                       *attrvals_len,
+    uint8_t                         minorversion)
 {
     void    *attrbase = attrs;
     uint64_t v64;
@@ -216,7 +217,10 @@ chimera_nfs4_marshall_attrs(
             rsp_mask[0]  |= (1 << FATTR4_SUPPORTED_ATTRS);
             *num_rsp_mask = 1;
 
-            chimera_nfs4_attr_append_uint32(&attrs, 3);
+            /* The supported_attrs value is itself a bitmap4. FATTR4_SUPPATTR_
+             * EXCLCREAT lives in word 2 and is only defined for NFSv4.1+, so a
+             * v4.0 reply advertises just the two 4.0 words. */
+            chimera_nfs4_attr_append_uint32(&attrs, minorversion >= 1 ? 3 : 2);
             chimera_nfs4_attr_append_uint32(&attrs,
                                             (1 << FATTR4_SUPPORTED_ATTRS) |
                                             (1 << FATTR4_TYPE) |
@@ -266,8 +270,10 @@ chimera_nfs4_marshall_attrs(
                                             (1UL << (FATTR4_SPACE_FREE - 32)) |
                                             (1UL << (FATTR4_SPACE_TOTAL - 32)));
 
-            chimera_nfs4_attr_append_uint32(&attrs,
-                                            (1 << (FATTR4_SUPPATTR_EXCLCREAT - 64)));
+            if (minorversion >= 1) {
+                chimera_nfs4_attr_append_uint32(&attrs,
+                                                (1 << (FATTR4_SUPPATTR_EXCLCREAT - 64)));
+            }
         }
 
         if (req_mask[0] & (1 << FATTR4_TYPE) &&

--- a/src/server/nfs/nfs4_proc_getattr.c
+++ b/src/server/nfs/nfs4_proc_getattr.c
@@ -57,7 +57,8 @@ chimera_nfs4_getattr_complete(
                                 res->resok4.obj_attributes.attrmask,
                                 3,
                                 res->resok4.obj_attributes.attr_vals.data,
-                                &res->resok4.obj_attributes.attr_vals.len);
+                                &res->resok4.obj_attributes.attr_vals.len,
+                                req->minorversion);
 
     if (req->handle) {
         chimera_vfs_release(req->thread->vfs_thread, req->handle);

--- a/src/server/nfs/nfs4_proc_readdir.c
+++ b/src/server/nfs/nfs4_proc_readdir.c
@@ -63,7 +63,8 @@ chimera_nfs4_readdir_callback(
                                 entry->attrs.attrmask,
                                 3,
                                 entry->attrs.attr_vals.data,
-                                &entry->attrs.attr_vals.len);
+                                &entry->attrs.attr_vals.len,
+                                req->minorversion);
 
     dbuf_cur = req->encoding->dbuf->used - dbuf_before;
 

--- a/src/server/nfs/nfs4_proc_verify.c
+++ b/src/server/nfs/nfs4_proc_verify.c
@@ -83,7 +83,8 @@ chimera_nfs4_verify_complete(
                                 out_mask,
                                 3,
                                 out_buf,
-                                &out_len);
+                                &out_len,
+                                req->minorversion);
 
     bool match = (num_out_mask == args->num_attrmask) &&
         (memcmp(out_mask, args->attrmask,

--- a/src/server/nfs/nfs4_root.c
+++ b/src/server/nfs/nfs4_root.c
@@ -154,7 +154,8 @@ nfs4_root_readdir_lookup_callback(
                                 entry->attrs.attrmask,
                                 3,
                                 entry->attrs.attr_vals.data,
-                                &entry->attrs.attr_vals.len);
+                                &entry->attrs.attr_vals.len,
+                                0);
 } /* nfs4_root_readdir_lookup_callback */
 
 struct nfs4_root_readdir_itr_ctx {


### PR DESCRIPTION
## Summary

`GETATTR(FATTR4_SUPPORTED_ATTRS)` always advertised a three-word bitmap including `FATTR4_SUPPATTR_EXCLCREAT` (attribute 75, word 2). That attribute is only defined for NFSv4.1+, so a v4.0 client saw a supported set containing an attribute the 4.0 protocol does not define (pynfs GATT6 `testSupported*`).

Thread the COMPOUND minor version into `chimera_nfs4_marshall_attrs` and emit the third word (and `SUPPATTR_EXCLCREAT`) only for `minorversion >= 1`; a 4.0 reply now advertises exactly the two 4.0 words. GETATTR, READDIR and VERIFY pass `req->minorversion`; the synthetic-root readdir passes 0 (its entries are not minor-version sensitive and not exercised here).

## Subtest impact (memfs/NFSv4.0, pynfs)

| flag | before | after |
|------|-------:|------:|
| getattr | 39/46 | 46/46 |