### PR TITLE
nfs4: make the NFSv4.1 session slot count configurable

### DIFF
--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -354,6 +354,12 @@ main(
         chimera_server_config_set_async_delegation_threads(server_config, int_value);
     }
 
+    json_value = json_object_get(server_params, "nfs4_session_slots");
+    if (json_is_integer(json_value)) {
+        int_value = json_integer_value(json_value);
+        chimera_server_config_set_nfs4_session_slots(server_config, int_value);
+    }
+
     json_value = json_object_get(server_params, "external_portmap");
     if (json_is_true(json_value)) {
         chimera_server_info("Enabling external portmap/rpcbind support");

--- a/src/server/nfs/nfs4_proc_create_session.c
+++ b/src/server/nfs/nfs4_proc_create_session.c
@@ -4,6 +4,7 @@
 
 #include "nfs4_procs.h"
 #include "nfs4_session.h"
+#include "server/server.h"
 
 void
 chimera_nfs4_create_session(
@@ -21,6 +22,7 @@ chimera_nfs4_create_session(
     uint32_t                          flags = 0;
     uint32_t                          replay_max_slots;
     uint32_t                          replay_maxresp_cached;
+    uint32_t                          server_max_slots;
 
     if (args->csa_flags & CREATE_SESSION4_FLAG_CONN_BACK_CHAN) {
         flags |= CREATE_SESSION4_FLAG_CONN_BACK_CHAN;
@@ -31,10 +33,17 @@ chimera_nfs4_create_session(
      * to the client. */
     clamped_fore = args->csa_fore_chan_attrs;
 
+    /* Server cap on fore-channel slots is configurable (server.nfs4_session_slots);
+     * fall back to the compiled-in default if it is unset/invalid. */
+    server_max_slots = (uint32_t) chimera_server_config_get_nfs4_session_slots(shared->config);
+    if (server_max_slots == 0) {
+        server_max_slots = NFS4_MAX_REPLY_CACHE_SLOTS;
+    }
+
     replay_max_slots = clamped_fore.ca_maxrequests;
     if (replay_max_slots == 0 ||
-        replay_max_slots > NFS4_MAX_REPLY_CACHE_SLOTS) {
-        replay_max_slots = NFS4_MAX_REPLY_CACHE_SLOTS;
+        replay_max_slots > server_max_slots) {
+        replay_max_slots = server_max_slots;
     }
     clamped_fore.ca_maxrequests = replay_max_slots;
 

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -50,6 +50,7 @@ struct chimera_server_config {
     int                                   async_delegation;
     int                                   async_delegation_threads;
     int                                   cache_ttl;
+    int                                   nfs4_session_slots;
     int                                   num_modules;
     int                                   metrics_port;
     int                                   rest_http_port;
@@ -129,6 +130,11 @@ chimera_server_config_init(void)
     config->anongid = 65534;
 
     config->cache_ttl = 60;
+
+    /* Default NFSv4.1 fore-channel session slots (server cap on the number
+     * of concurrent SEQUENCE requests a client may have outstanding per
+     * session).  Mirrors NFS4_MAX_REPLY_CACHE_SLOTS in the NFS server. */
+    config->nfs4_session_slots = 64;
 
     strncpy(config->nfs_rdma_hostname, "0.0.0.0", sizeof(config->nfs_rdma_hostname));
     config->nfs_rdma_port    = 20049;
@@ -243,6 +249,20 @@ chimera_server_config_get_cache_ttl(const struct chimera_server_config *config)
 {
     return config->cache_ttl;
 } /* chimera_server_config_get_cache_ttl */
+
+SYMBOL_EXPORT void
+chimera_server_config_set_nfs4_session_slots(
+    struct chimera_server_config *config,
+    int                           slots)
+{
+    config->nfs4_session_slots = slots;
+} /* chimera_server_config_set_nfs4_session_slots */
+
+SYMBOL_EXPORT int
+chimera_server_config_get_nfs4_session_slots(const struct chimera_server_config *config)
+{
+    return config->nfs4_session_slots;
+} /* chimera_server_config_get_nfs4_session_slots */
 
 SYMBOL_EXPORT void
 chimera_server_config_set_kv_module(

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -85,6 +85,15 @@ chimera_server_config_get_cache_ttl(
     const struct chimera_server_config *config);
 
 void
+chimera_server_config_set_nfs4_session_slots(
+    struct chimera_server_config *config,
+    int                           slots);
+
+int
+chimera_server_config_get_nfs4_session_slots(
+    const struct chimera_server_config *config);
+
+void
 chimera_server_config_set_kv_module(
     struct chimera_server_config *config,
     const char                   *kv_module);


### PR DESCRIPTION
## Summary

The NFSv4.1 fore-channel **session slot count** is the server's cap on how many `SEQUENCE` requests a client may have outstanding per session. Because all `nconnect` connections share a single session, **it is the hard ceiling on concurrent in-flight RPCs for the entire mount**.

`CREATE_SESSION` hardcoded this cap to `NFS4_MAX_REPLY_CACHE_SLOTS` (64). Benchmarking showed a client pegging all 64 slots (slot ids 0–63 used evenly) and unable to go deeper, while the same workload over NFSv3 — which has no session/slot table — ran far deeper and ~2.4× faster. 64 is a fine conservative default but should be tunable for high-throughput, low-client-count deployments.

This adds a **`nfs4_session_slots`** server config variable (**default 64, unchanged**) and wires it through `CREATE_SESSION` as the server cap. The negotiated value stays `min(client_request, server_cap)`; an unset/zero config falls back to the compiled-in default.

## Changes
- `server.c` / `server.h`: new `nfs4_session_slots` config field (default 64) with get/set accessors.
- `daemon.c`: parse `server.nfs4_session_slots` from the JSON config.
- `nfs4_proc_create_session.c`: clamp the fore-channel `ca_maxrequests` to the configured value instead of the hardcoded constant.

## Notes
- Raising the slot count is cheap for READ/WRITE-heavy workloads: the per-slot reply cache only buffers bytes for non-idempotent (`cachethis`) replies (`NFS4_SLOT_CACHED` vs `NFS4_SLOT_COMPLETED`), so extra slots cost only the slot structs, not cached reply buffers. The existing `ca_maxresponsesize_cached` and total-bytes caps are unchanged.
- The replay slot table is already dynamically allocated (`calloc(replay_max_slots, ...)`), so larger values size the table accordingly.

## Testing
`ctest -R nfs4` — 498/498 pass. Default behavior is unchanged (still 64); setting e.g. `"nfs4_session_slots": 256` raises the per-session concurrency ceiling.