### PR TITLE
nfs4: destroy open_state before dropping acquire-ref in CLOSE

### DIFF
--- a/src/server/nfs/nfs4_proc_close.c
+++ b/src/server/nfs/nfs4_proc_close.c
@@ -95,12 +95,18 @@ chimera_nfs4_close(
         pthread_mutex_unlock(&owner->lock);
     }
 
-    /* Drop the acquire ref, then destroy.  If concurrent READ/WRITE still
-     * hold an acquire-ref, destroy marks the state and cleanup runs on the
-     * last release; otherwise destroy releases the handle here. */
+    /* Destroy while we still hold the acquire-ref, then drop the ref.  The
+     * acquire-ref pins the state across destroy so it cannot be freed under
+     * us; destroy unhashes it (no new acquire can find it) and marks it
+     * destroyed.  Dropping the acquire-ref last performs final cleanup -- or,
+     * if a concurrent READ/WRITE still holds an acquire-ref, cleanup runs when
+     * that last ref is released.  Releasing before destroy would leave the
+     * state findable with destroyed=0, letting a racing destroyer (e.g. a
+     * retransmitted CLOSE on another nconnect connection, or lease teardown)
+     * free it before we dereference open_state below. */
+    nfs_open_state_destroy(open_state, table, thread->vfs_thread);
     nfs_state_table_release(table, open_state, NFS4_SLOT_TYPE_OPEN,
                             thread->vfs_thread);
-    nfs_open_state_destroy(open_state, table, thread->vfs_thread);
 
     res->status = NFS4_OK;
     chimera_nfs4_compound_complete(req, NFS4_OK);


### PR DESCRIPTION
## Summary

Fixes an intermittent SIGSEGV in the NFSv4 server's CLOSE handler that surfaces as a 300s timeout in `chimera/kvm/.../xfstests/fsstress_demofs_aio_nfs4.1` (and can hit any nconnect>1 NFSv4 workload).

The "timeout" is a symptom. The server thread actually crashes while processing a CLOSE:

```
Received signal 11.
ip = ... (pthread_mutex_lock+0x4)
ip = ... nfs_open_state_destroy+0x28
ip = ... chimera_nfs4_close+0x11d
ip = ... chimera_nfs4_compound_process+0x66c
```

The client (a `hard` mount, `timeo=600`) then blocks forever in `nfs4_do_close → rpc_wait_for_completion_task` waiting for the CLOSE reply the dead thread never sends, so ctest kills the run at 300s.

## Root cause

`chimera_nfs4_close()` dropped the acquire-ref via `nfs_state_table_release()` **before** calling `nfs_open_state_destroy()`:

```c
nfs_state_table_release(table, open_state, NFS4_SLOT_TYPE_OPEN, thread->vfs_thread);
nfs_open_state_destroy(open_state, table, thread->vfs_thread);   // dereferences open_state
```

Between those two calls the `open_state` sits at `refcount=1, destroyed=0`, still hashed and findable. Under `nconnect=16` across multiple server core threads, a concurrent destroyer — a retransmitted CLOSE on another connection of the bundle, a lingering READ/WRITE, or lease/owner teardown — can run `open_state_destroy_locked()`, set `destroyed=1`, drop the last ref, and `free()` the state. `nfs_open_state_destroy()` then reads `state->owner` from freed memory and locks garbage → SIGSEGV.

Introduced by the refcount/destroy split in the unified state model (54fe109).

## Fix

Swap the order so the acquire-ref pins the state across destroy:

```c
nfs_open_state_destroy(open_state, table, thread->vfs_thread);   // unhash + mark destroyed; ref still held
nfs_state_table_release(table, open_state, NFS4_SLOT_TYPE_OPEN, thread->vfs_thread); // last ref -> cleanup
```

Destroy unhashes the state (no new acquire can find it) and marks it destroyed while our acquire-ref keeps `refcount > 0`, so nothing frees it underneath us. A racing destroyer is harmless thanks to the `atomic_exchange(&destroyed)` guard in `open_state_destroy_locked()`. Final cleanup runs when the genuine last ref drops.

## Testing

- `make build_debug` clean (AddressSanitizer build).
- `ctest` debug suite: **499/499 passed**, including all `fsstress_nfs4_*` / `*_demofs_aio` variants.