### PR TITLE
memfs: fix infinite loop on zero-length READ and WRITE

### DIFF
--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -2063,6 +2063,20 @@ memfs_read(
         eof    = 1;
     }
 
+    if (length == 0) {
+        /* Nothing to read. Returning early also avoids the
+         * (offset + length - 1) underflow below that would spin the
+         * block loop on a zero-length request. */
+        memfs_map_attrs(shared, &request->read.r_attr, inode, request->fh);
+        pthread_mutex_unlock(&inode->lock);
+        request->status        = CHIMERA_VFS_OK;
+        request->read.r_niov   = 0;
+        request->read.r_length = 0;
+        request->read.r_eof    = eof;
+        request->complete(request);
+        return;
+    }
+
     const uint32_t block_size  = shared->block_size;
     const uint32_t block_shift = shared->block_shift;
     const uint32_t block_mask  = shared->block_mask;
@@ -2169,6 +2183,19 @@ memfs_write(
     }
 
     memfs_map_attrs(shared, &request->write.r_pre_attr, inode, request->fh);
+
+    if (request->write.length == 0) {
+        /* A zero-length write changes nothing. Returning early also avoids
+         * the (offset + length - 1) underflow above, which drives last_block
+         * to a huge value and spins the 32-bit block-growth loop forever. */
+        memfs_map_attrs(shared, &request->write.r_post_attr, inode, request->fh);
+        pthread_mutex_unlock(&inode->lock);
+        request->status         = CHIMERA_VFS_OK;
+        request->write.r_length = 0;
+        request->write.r_sync   = 1;
+        request->complete(request);
+        return;
+    }
 
     if (inode->file.max_blocks <= last_block || !inode->file.blocks) {
         struct memfs_block **new_blocks;


### PR DESCRIPTION
## Summary

A **zero-length WRITE** drove a server thread into an infinite loop, pinning a CPU core (a DoS-class bug — any client can trigger it with a single 0-byte write). pynfs `write.testSizes` hits it on its first iteration (a 0-byte write with the anonymous stateid).

`memfs_write` computes `last_block = (offset + length - 1) >> block_shift`. With `length == 0` the subtraction underflows to `UINT64_MAX`, so `last_block` becomes enormous. The block-array growth loop then shifts a **32-bit** counter (`new_max_blocks <<= 1`) until it exceeds `last_block` — but the 32-bit value wraps to 0 first, so `new_max_blocks <= last_block` stays true forever → spin.

`memfs_read` has the same `(offset + length - 1)` underflow once `length` is zero (reachable for a zero-length read within the file; the existing early-out only covers `offset >= size`).

Both paths now short-circuit at `length == 0`: return success with no data / no block allocation after mapping the requested attributes. A zero-length I/O is a valid no-op (RFC 7530 §16.21/§16.36).

## Verification

`write.testSizes` (8192 increasing-size writes starting at 0) previously spun forever on iteration 0; it now passes. The `write`/`read` pynfs flag groups no longer hang the suite.

## Not addressed here

`write.testMaximumData` (a 1 MiB write+read) stalls for a different reason — a large-transfer issue, not this underflow — and is left for separate investigation.