### PR TITLE
Implement NFS4 SECINFO operation

### DIFF
--- a/src/server/nfs/CMakeLists.txt
+++ b/src/server/nfs/CMakeLists.txt
@@ -22,7 +22,7 @@ add_library(chimera_nfs SHARED nfs.c nfs4_session.c nfs4_state.c nfs4_lease.c nf
             nfs4_proc_setattr.c nfs4_proc_link.c nfs4_proc_rename.c nfs4_proc_savefh.c nfs4_proc_restorefh.c
             nfs4_proc_exchange_id.c nfs4_proc_create_session.c nfs4_proc_destroy_session.c
             nfs4_proc_destroy_clientid.c nfs4_proc_sequence.c nfs4_proc_reclaim_complete.c
-            nfs4_proc_secinfo_no_name.c nfs4_proc_test_stateid.c nfs4_root.c
+            nfs4_proc_secinfo.c nfs4_proc_secinfo_no_name.c nfs4_proc_test_stateid.c nfs4_root.c
             nfs4_proc_allocate.c nfs4_proc_deallocate.c nfs4_proc_seek.c
             nfs4_proc_lock.c nfs4_proc_lockt.c nfs4_proc_locku.c
             nfs4_proc_verify.c

--- a/src/server/nfs/nfs4_proc_compound.c
+++ b/src/server/nfs/nfs4_proc_compound.c
@@ -202,6 +202,9 @@ chimera_nfs4_compound_process(
                 case OP_RECLAIM_COMPLETE:
                     chimera_nfs4_reclaim_complete(thread, req, argop, resop);
                     break;
+                case OP_SECINFO:
+                    chimera_nfs4_secinfo(thread, req, argop, resop);
+                    break;
                 case OP_SECINFO_NO_NAME:
                     chimera_nfs4_secinfo_no_name(thread, req, argop, resop);
                     break;

--- a/src/server/nfs/nfs4_proc_secinfo.c
+++ b/src/server/nfs/nfs4_proc_secinfo.c
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "nfs4_procs.h"
+#include "nfs4_status.h"
+#include "evpl/evpl_rpc2.h"
+#include "vfs/vfs_procs.h"
+#include "vfs/vfs_release.h"
+
+/* RFC 7530 §16.31: SECINFO returns the security mechanisms the server will
+ * accept for the named entry in the current-filehandle directory. Chimera
+ * only offers AUTH_SYS, so a successful lookup yields a single-flavor list.
+ * The name lookup also produces the spec-mandated error returns:
+ * NFS4ERR_NOTDIR (cfh not a directory) and NFS4ERR_NOENT (name absent). */
+
+static void
+chimera_nfs4_secinfo_complete(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *attr,
+    struct chimera_vfs_attrs *dir_attr,
+    void                     *private_data)
+{
+    struct nfs_request *req = private_data;
+    struct SECINFO4res *res = &req->res_compound.resarray[req->index].opsecinfo;
+
+    chimera_vfs_release(req->thread->vfs_thread, req->handle);
+
+    if (error_code != CHIMERA_VFS_OK) {
+        res->status = chimera_nfs4_errno_to_nfsstat4(error_code);
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    res->resok4 = xdr_dbuf_alloc_space(sizeof(struct secinfo4), req->encoding->dbuf);
+    chimera_nfs_abort_if(res->resok4 == NULL, "Failed to allocate space");
+
+    res->num_resok4       = 1;
+    res->resok4[0].flavor = AUTH_SYS;
+
+    res->status = NFS4_OK;
+    chimera_nfs4_compound_complete(req, NFS4_OK);
+} /* chimera_nfs4_secinfo_complete */
+
+static void
+chimera_nfs4_secinfo_open_callback(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *handle,
+    void                           *private_data)
+{
+    struct nfs_request  *req  = private_data;
+    struct SECINFO4args *args = &req->args_compound->argarray[req->index].opsecinfo;
+    struct SECINFO4res  *res  = &req->res_compound.resarray[req->index].opsecinfo;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        res->status = chimera_nfs4_errno_to_nfsstat4(error_code);
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    req->handle = handle;
+
+    chimera_vfs_lookup_at(req->thread->vfs_thread, &req->cred,
+                          handle,
+                          args->name.data,
+                          args->name.len,
+                          0,
+                          0,
+                          chimera_nfs4_secinfo_complete,
+                          req);
+} /* chimera_nfs4_secinfo_open_callback */
+
+void
+chimera_nfs4_secinfo(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_request               *req,
+    struct nfs_argop4                *argop,
+    struct nfs_resop4                *resop)
+{
+    struct SECINFO4args *args = &argop->opsecinfo;
+    struct SECINFO4res  *res  = &resop->opsecinfo;
+
+    if (req->fhlen == 0) {
+        res->status = NFS4ERR_NOFILEHANDLE;
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    /* Reject empty / malformed component names (NFS4ERR_INVAL, etc.) before
+     * touching the VFS. */
+    res->status = chimera_nfs4_validate_name(&args->name);
+    if (res->status != NFS4_OK) {
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    /* Opening the current FH as a directory yields NFS4ERR_NOTDIR when it is
+     * not one; the subsequent lookup yields NFS4ERR_NOENT for a missing name. */
+    chimera_vfs_open_fh(thread->vfs_thread, &req->cred,
+                        req->fh,
+                        req->fhlen,
+                        CHIMERA_VFS_OPEN_INFERRED | CHIMERA_VFS_OPEN_PATH | CHIMERA_VFS_OPEN_DIRECTORY,
+                        chimera_nfs4_secinfo_open_callback,
+                        req);
+} /* chimera_nfs4_secinfo */

--- a/src/server/nfs/nfs4_procs.h
+++ b/src/server/nfs/nfs4_procs.h
@@ -348,6 +348,13 @@ chimera_nfs4_test_stateid(
     struct nfs_resop4                *resop);
 
 void
+chimera_nfs4_secinfo(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_request               *req,
+    struct nfs_argop4                *argop,
+    struct nfs_resop4                *resop);
+
+void
 chimera_nfs4_secinfo_no_name(
     struct chimera_server_nfs_thread *thread,
     struct nfs_request               *req,


### PR DESCRIPTION
## Summary

Implements the NFS4 `SECINFO` operation, which previously returned `NFS4ERR_NOTSUPP`.

Per RFC 7530 §16.31, `SECINFO` looks up a named entry in the current-filehandle directory and returns the list of security flavors the server accepts. Chimera offers `AUTH_SYS`, so a successful lookup yields a single-flavor list.

The lookup also drives the spec-mandated error returns:
- `NFS4ERR_NOFILEHANDLE` — no current filehandle
- `NFS4ERR_INVAL` / `NFS4ERR_BADNAME` — malformed component name
- `NFS4ERR_NOTDIR` — current filehandle is not a directory
- `NFS4ERR_NOENT` — named entry does not exist

## Verification

pynfs `st_secinfo` goes from 0/7 to 6/7. The remaining failure (SEC7 `testRPCSEC_GSS`) requires the server to advertise `RPCSEC_GSS`, which Chimera does not implement; it is gated on the `gss` flag and is out of scope here.