### PR TITLE
nfs4: reject reserved READDIR cookies

### DIFF
--- a/src/server/nfs/nfs4_proc_readdir.c
+++ b/src/server/nfs/nfs4_proc_readdir.c
@@ -203,6 +203,16 @@ chimera_nfs4_readdir(
         return;
     }
 
+    /* RFC 7530 §16.24: cookie values 1 and 2 are reserved and must never be
+     * sent by a client (0 means "start of directory"). The VFS backends emit
+     * only cookie 0 or values >= 3 for regular directories, so a reserved
+     * cookie here is a client error. The pseudo-root, handled above, uses its
+     * own export-index cookie space and is intentionally exempt. */
+    if (args->cookie == 1 || args->cookie == 2) {
+        res->status = NFS4ERR_BAD_COOKIE;
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
 
     cursor = &req->readdir4_cursor;
 

--- a/src/vfs/nfs/nfs4_readdir.c
+++ b/src/vfs/nfs/nfs4_readdir.c
@@ -348,12 +348,23 @@ chimera_nfs4_readdir(
 
     /* Op 2: READDIR */
     argarray[2].argop              = OP_READDIR;
-    argarray[2].opreaddir.cookie   = request->readdir.cookie;
     argarray[2].opreaddir.dircount = 8192;
     argarray[2].opreaddir.maxcount = 8192;
 
-    /* Copy cookie verifier */
-    memcpy(argarray[2].opreaddir.cookieverf, &request->readdir.verifier, sizeof(argarray[2].opreaddir.cookieverf));
+    /* Cookies 1 and 2 are consumed locally by the synthesized "." and ".."
+     * entries above; they are reserved on the wire (RFC 7530 14.2.30) and a
+     * conformant server rejects them with NFS4ERR_BAD_COOKIE. When the caller
+     * is still within that reserved range, ask the server to start from the
+     * beginning (cookie 0); real server entries carry cookies >= 3. A zero
+     * cookie must be paired with a zero verifier. */
+    if (request->readdir.cookie < 3) {
+        argarray[2].opreaddir.cookie = 0;
+        memset(argarray[2].opreaddir.cookieverf, 0, sizeof(argarray[2].opreaddir.cookieverf));
+    } else {
+        argarray[2].opreaddir.cookie = request->readdir.cookie;
+        memcpy(argarray[2].opreaddir.cookieverf, &request->readdir.verifier,
+               sizeof(argarray[2].opreaddir.cookieverf));
+    }
 
     /* Request attributes: TYPE, SIZE, FILEHANDLE, FILEID, MODE, NUMLINKS */
     ctx->attr_request[0] = (1 << FATTR4_TYPE) | (1 << FATTR4_SIZE) |


### PR DESCRIPTION
## Summary

A conformant NFSv4 server must reject the reserved READDIR cookie values `1` and `2` with `NFS4ERR_BAD_COOKIE` (RFC 7530 §16.24; `0` means "start of directory"). The READDIR handler now does this for regular directories. The pseudo-root, which uses its own export-index cookie space, is exempt.

This exposed a coupling in our own NFSv4 client VFS module: it synthesizes `.`/`..` locally with cookies `1`/`2` and then forwarded cookie `2` to the server to mean "start the real entries". A conformant server now rejects that. Since real server entries always carry cookies `>= 3`, the client now sends cookie `0` (with a zero verifier) whenever the caller is still within the reserved range, so the synthesized dot entries are handled entirely client-side.

## Verification

- pynfs `st_readdir` RDDR10 (`testReservedCookies`) now passes; full `st_readdir` is 18/18.
- No regression in the posix `opendir`/`dirstress` NFS4 suites across all backends (memfs, linux, io_uring, cairn, demofs), which exercise multi-page directory listing.