### PR TITLE
nfs4: make SEQUENCE replay-slot handling lock-free

### DIFF
--- a/src/server/nfs/nfs4_session.c
+++ b/src/server/nfs/nfs4_session.c
@@ -267,15 +267,13 @@ nfs4_create_session(
         session->nfs4_session_implicit = implicit;
         session->nfs4_session_clientid = client_id;
 
-        pthread_mutex_init(&session->nfs4_session_lock, NULL);
-
         /* NFS4.1 SEQUENCE replay cache slot table.  Implicit (NFS4.0)
          * sessions get zero slots -- v4.0 uses per-owner replay caches in
          * nfs_open_owner / nfs_lock_owner instead. */
         session->replay_max_slots      = implicit ? 0 : replay_max_slots;
         session->replay_maxresp_cached = replay_maxresp_cached;
-        session->replay_bytes_in_use   = 0;
-        session->replay_slots          = NULL;
+        atomic_init(&session->replay_bytes_in_use, 0);
+        session->replay_slots = NULL;
 
         if (session->replay_max_slots) {
             session->replay_slots = calloc(session->replay_max_slots,
@@ -457,7 +455,6 @@ nfs4_session_put(struct nfs4_session *session)
             free(session->replay_slots);
             session->replay_slots = NULL;
         }
-        pthread_mutex_destroy(&session->nfs4_session_lock);
         session->magic = 0;
         free(session);
     }
@@ -547,6 +544,8 @@ nfs4_replay_capture_reply(
     struct nfs4_replay_slot *slot    = req->replay_slot;
     uint8_t                 *buf;
     size_t                   offset = 0;
+    size_t                   total  = (size_t) total_length;
+    size_t                   cur;
     int                      i;
 
     if (!slot || !session || total_length <= 0) {
@@ -557,17 +556,23 @@ nfs4_replay_capture_reply(
         return;
     }
 
-    pthread_mutex_lock(&session->nfs4_session_lock);
-
-    if (session->replay_bytes_in_use + (size_t) total_length >
-        NFS4_MAX_REPLY_CACHE_BYTES) {
-        pthread_mutex_unlock(&session->nfs4_session_lock);
-        return;
-    }
+    /* Reserve against the per-session byte cap with a CAS loop -- no lock.
+     * The slot is IN_PROGRESS for this (owning) thread, so no other thread
+     * touches slot->cached_buf concurrently; only the session-wide counter is
+     * shared. */
+    cur = atomic_load_explicit(&session->replay_bytes_in_use, memory_order_relaxed);
+    do {
+        if (cur + total > NFS4_MAX_REPLY_CACHE_BYTES) {
+            return;  /* demote: over the per-session cap */
+        }
+    } while (!atomic_compare_exchange_weak_explicit(
+                 &session->replay_bytes_in_use, &cur, cur + total,
+                 memory_order_relaxed, memory_order_relaxed));
 
     buf = malloc(total_length);
     if (!buf) {
-        pthread_mutex_unlock(&session->nfs4_session_lock);
+        atomic_fetch_sub_explicit(&session->replay_bytes_in_use, total,
+                                  memory_order_relaxed);
         return;
     }
 
@@ -579,20 +584,18 @@ nfs4_replay_capture_reply(
         offset += iov[i].length;
     }
 
-    slot->cached_buf              = buf;
-    slot->cached_len              = total_length;
-    session->replay_bytes_in_use += total_length;
+    /* Same thread runs finalize next, which release-publishes these via the
+     * state_word store -- a later reader that observes CACHED sees them. */
+    slot->cached_buf = buf;
+    slot->cached_len = total_length;
 
-    pthread_mutex_unlock(&session->nfs4_session_lock);
-
-    /* Update gauge after dropping the session lock. */
     nfs4_replay_bytes_delta(req, total_length);
 } /* nfs4_replay_capture_reply */
 
 /*
  * Install the capture callback on the encoding so it fires from inside
- * the next send_reply call.  Caller already holds the session lock and
- * has set req->replay_slot. */
+ * the next send_reply call.  Caller has won the slot transition and set
+ * req->replay_slot. */
 static inline void
 nfs4_replay_arm_capture(struct nfs_request *req)
 {
@@ -624,10 +627,17 @@ nfs4_replay_slot_acquire(
 
     slot = &session->replay_slots[slotid];
 
-    pthread_mutex_lock(&session->nfs4_session_lock);
+    /* Lock-free state machine.  Distinct slots never collide; the CAS only
+     * ever actually contends on a same-slot retransmit racing the original
+     * (possibly on another connection).  Losers re-read and observe
+     * IN_PROGRESS -> RETRY_UNCACHED_REP, exactly as the old lock produced. */
+    for ( ;; ) {
+        uint64_t             cur = atomic_load_explicit(&slot->state_word,
+                                                        memory_order_acquire);
+        enum nfs4_slot_state state = (enum nfs4_slot_state) (cur & NFS4_SLOT_STATE_MASK);
+        uint32_t             cseq  = (uint32_t) (cur >> NFS4_SLOT_SEQID_SHIFT);
 
-    switch (slot->state) {
-        case NFS4_SLOT_UNUSED:
+        if (state == NFS4_SLOT_UNUSED) {
             /* First-ever use.  RFC 5661 sets csr_sequence = 1 at
              * CREATE_SESSION; the client's first SEQUENCE on a slot must
              * therefore use seqid = 1. */
@@ -635,42 +645,48 @@ nfs4_replay_slot_acquire(
                 status = NFS4ERR_SEQ_MISORDERED;
                 break;
             }
-            slot->state          = NFS4_SLOT_IN_PROGRESS;
-            slot->inflight_seqid = seqid;
-            slot->cachethis      = cachethis ? 1 : 0;
-            req->replay_slot     = slot;
-            req->replay_slot_id  = slotid;
-            req->replay_action   = NFS4_REPLAY_ACTION_NEW;
+            if (!atomic_compare_exchange_weak_explicit(
+                    &slot->state_word, &cur,
+                    nfs4_slot_word(seqid, NFS4_SLOT_IN_PROGRESS),
+                    memory_order_acq_rel, memory_order_acquire)) {
+                continue;  /* lost the race; re-read and re-evaluate */
+            }
+            req->replay_slot    = slot;
+            req->replay_slot_id = slotid;
+            req->replay_action  = NFS4_REPLAY_ACTION_NEW;
             if (cachethis) {
                 nfs4_replay_arm_capture(req);
             }
             break;
-
-        case NFS4_SLOT_CACHED:
-        case NFS4_SLOT_COMPLETED:
-            if (seqid == (uint32_t) (slot->seqid + 1)) {
-                /* Normal advance.  Drop any prior cached reply -- the
-                 * client has acknowledged it by moving on. */
-                if (slot->state == NFS4_SLOT_CACHED &&
-                    slot->cached_buf) {
-                    freed_bytes                   = slot->cached_len;
-                    session->replay_bytes_in_use -= slot->cached_len;
+        } else if (state == NFS4_SLOT_CACHED || state == NFS4_SLOT_COMPLETED) {
+            if (seqid == (uint32_t) (cseq + 1)) {
+                /* Normal advance. */
+                if (!atomic_compare_exchange_weak_explicit(
+                        &slot->state_word, &cur,
+                        nfs4_slot_word(seqid, NFS4_SLOT_IN_PROGRESS),
+                        memory_order_acq_rel, memory_order_acquire)) {
+                    continue;
+                }
+                /* We won the transition; reclaim any prior cached reply -- the
+                 * client acknowledged it by moving on.  Only the CAS winner
+                 * reaches here, so the free is unraced. */
+                if (state == NFS4_SLOT_CACHED && slot->cached_buf) {
+                    freed_bytes = slot->cached_len;
                     free(slot->cached_buf);
                     slot->cached_buf = NULL;
                     slot->cached_len = 0;
+                    atomic_fetch_sub_explicit(&session->replay_bytes_in_use,
+                                              freed_bytes, memory_order_relaxed);
                 }
-                slot->state          = NFS4_SLOT_IN_PROGRESS;
-                slot->inflight_seqid = seqid;
-                slot->cachethis      = cachethis ? 1 : 0;
-                req->replay_slot     = slot;
-                req->replay_slot_id  = slotid;
-                req->replay_action   = NFS4_REPLAY_ACTION_NEW;
+                req->replay_slot    = slot;
+                req->replay_slot_id = slotid;
+                req->replay_action  = NFS4_REPLAY_ACTION_NEW;
                 if (cachethis) {
                     nfs4_replay_arm_capture(req);
                 }
-            } else if (seqid == slot->seqid) {
+            } else if (seqid == cseq) {
                 /* Retransmit. */
-                if (slot->state == NFS4_SLOT_CACHED && slot->cached_buf) {
+                if (state == NFS4_SLOT_CACHED && slot->cached_buf) {
                     req->replay_slot    = slot;
                     req->replay_slot_id = slotid;
                     req->replay_action  = NFS4_REPLAY_ACTION_FROM_CACHE;
@@ -684,26 +700,20 @@ nfs4_replay_slot_acquire(
                 status = NFS4ERR_SEQ_MISORDERED;
             }
             break;
-
-        case NFS4_SLOT_IN_PROGRESS:
+        } else { /* NFS4_SLOT_IN_PROGRESS */
             /* Original compound is still running.  Whether seqid matches
              * (true retry) or not (client jumped ahead), we cannot
              * produce a reply yet.  Both paths return errors. */
-            if (seqid == slot->inflight_seqid) {
+            if (seqid == cseq) {
                 status = NFS4ERR_RETRY_UNCACHED_REP;
             } else {
                 status = NFS4ERR_SEQ_MISORDERED;
             }
             break;
+        }
+    } /* for */
 
-        default:
-            status = NFS4ERR_SERVERFAULT;
-            break;
-    } /* switch */
-
-    pthread_mutex_unlock(&session->nfs4_session_lock);
-
-    /* Update metrics outside the session lock to avoid serializing the
+    /* Update metrics outside the hot path to avoid serializing the
      * shared prometheus counters on per-session traffic. */
     if (freed_bytes) {
         nfs4_replay_bytes_delta(req, -(int64_t) freed_bytes);
@@ -723,6 +733,7 @@ nfs4_replay_slot_finalize(struct nfs_request *req)
 {
     struct nfs4_session     *session = req->session;
     struct nfs4_replay_slot *slot    = req->replay_slot;
+    uint64_t                 cur;
 
     if (!slot || !session) {
         return;
@@ -739,23 +750,21 @@ nfs4_replay_slot_finalize(struct nfs_request *req)
         return;
     }
 
-    pthread_mutex_lock(&session->nfs4_session_lock);
-
-    /* If the capture callback successfully copied bytes into the slot,
-     * transition to CACHED so a retransmit can replay.  Otherwise (no
-     * cachethis, or demoted for size) transition to COMPLETED -- a
-     * retransmit will get NFS4ERR_RETRY_UNCACHED_REP. */
-    if (slot->state == NFS4_SLOT_IN_PROGRESS) {
-        slot->seqid          = slot->inflight_seqid;
-        slot->inflight_seqid = 0;
-        if (slot->cached_buf) {
-            slot->state = NFS4_SLOT_CACHED;
-        } else {
-            slot->state = NFS4_SLOT_COMPLETED;
-        }
+    /* Runs on the same thread that won the acquire; while IN_PROGRESS no other
+     * thread writes the word (retransmits only read it and error out), so a
+     * plain load + release store is sufficient.  The release pairs with the
+     * acquire load in nfs4_replay_slot_acquire so a reader that observes CACHED
+     * also observes cached_buf/cached_len written by the capture callback.
+     * The seqid is unchanged -- it was set to the in-flight value at acquire. */
+    cur = atomic_load_explicit(&slot->state_word, memory_order_relaxed);
+    if ((cur & NFS4_SLOT_STATE_MASK) == NFS4_SLOT_IN_PROGRESS) {
+        enum nfs4_slot_state new_state = slot->cached_buf ?
+            NFS4_SLOT_CACHED : NFS4_SLOT_COMPLETED;
+        atomic_store_explicit(&slot->state_word,
+                              nfs4_slot_word((uint32_t) (cur >> NFS4_SLOT_SEQID_SHIFT),
+                                             new_state),
+                              memory_order_release);
     }
-
-    pthread_mutex_unlock(&session->nfs4_session_lock);
 
     req->replay_slot = NULL;
 } /* nfs4_replay_slot_finalize */

--- a/src/server/nfs/nfs4_session.h
+++ b/src/server/nfs/nfs4_session.h
@@ -38,14 +38,52 @@ enum nfs4_slot_state {
 #define NFS4_REPLAY_ACTION_NEW        1
 #define NFS4_REPLAY_ACTION_FROM_CACHE 2
 
+/*
+ * Per-slot state lives in a single atomic word so the SEQUENCE hot path needs
+ * no per-session lock: bits [1:0] hold enum nfs4_slot_state, bits [33:2] hold
+ * the 32-bit seqid (the in-flight seqid while IN_PROGRESS, otherwise the last
+ * completed seqid).  calloc() zero-init == (seqid 0, NFS4_SLOT_UNUSED).
+ *
+ * Distinct slots are independent (RFC 5661: a client has at most one
+ * outstanding request per slot id), so concurrent SEQUENCEs touch different
+ * words and never contend.  The only same-slot race is a retransmit arriving on
+ * another connection/thread; it is arbitrated by the CAS in
+ * nfs4_replay_slot_acquire.  cached_buf/cached_len are written by the (rare)
+ * cachethis capture path on the owning thread and published via the release
+ * store in nfs4_replay_slot_finalize.
+ */
 struct nfs4_replay_slot {
-    uint32_t seqid;                    /* last completed seqid (in CACHED/COMPLETED) */
-    uint32_t inflight_seqid; /* seqid being processed when IN_PROGRESS */
-    uint8_t  state;                    /* enum nfs4_slot_state */
-    uint8_t  cachethis;      /* sa_cachethis from current inflight */
-    uint32_t cached_len;     /* bytes in cached_buf (CACHED only) */
-    void    *cached_buf;     /* RPC reply (header+body); malloc'd */
+    _Atomic uint64_t state_word;       /* (seqid << NFS4_SLOT_SEQID_SHIFT) | state */
+    uint32_t         cached_len;       /* bytes in cached_buf (CACHED only) */
+    void            *cached_buf;       /* RPC reply (header+body); malloc'd */
 };
+
+#define NFS4_SLOT_STATE_MASK  0x3u
+#define NFS4_SLOT_SEQID_SHIFT 2
+
+static inline uint64_t
+nfs4_slot_word(
+    uint32_t             seqid,
+    enum nfs4_slot_state state)
+{
+    return ((uint64_t) seqid << NFS4_SLOT_SEQID_SHIFT) | (uint64_t) state;
+} /* nfs4_slot_word */
+
+static inline enum nfs4_slot_state
+nfs4_slot_state(struct nfs4_replay_slot *slot)
+{
+    return (enum nfs4_slot_state) (atomic_load_explicit(&slot->state_word,
+                                                        memory_order_acquire) &
+                                   NFS4_SLOT_STATE_MASK);
+} /* nfs4_slot_state */
+
+static inline uint32_t
+nfs4_slot_seqid(struct nfs4_replay_slot *slot)
+{
+    return (uint32_t) (atomic_load_explicit(&slot->state_word,
+                                            memory_order_acquire) >>
+                       NFS4_SLOT_SEQID_SHIFT);
+} /* nfs4_slot_seqid */
 
 /* Magic stored in nfs4_session.magic so that a connection's private_data
  * (which may hold either an nlm_client* or an nfs4_session*) can be safely
@@ -82,10 +120,6 @@ struct nfs4_session {
     _Atomic bool             destroyed;
     uint8_t                  nfs4_session_id[NFS4_SESSIONID_SIZE];
     uint64_t                 nfs4_session_clientid;
-    /* Guards mutable session-level state: the 4.1 replay slot table and
-     * its byte accounting.  Stateid lookups don't need this -- they go
-     * through the per-shard rwlocks in nfs_state_table. */
-    pthread_mutex_t          nfs4_session_lock;
     uint32_t                 nfs4_session_implicit;
     struct nfs4_client      *nfs4_session_client;
     struct channel_attrs4    nfs4_session_fore_attrs;
@@ -98,7 +132,7 @@ struct nfs4_session {
      * sessions (4.0 SETCLIENTID path) leave replay_max_slots = 0. */
     uint32_t                 replay_max_slots;
     uint32_t                 replay_maxresp_cached;
-    size_t                   replay_bytes_in_use;
+    _Atomic size_t           replay_bytes_in_use;
     struct nfs4_replay_slot *replay_slots;
     struct UT_hash_handle    nfs4_session_hh;
 };

--- a/src/server/nfs/tests/test_replay_slot.c
+++ b/src/server/nfs/tests/test_replay_slot.c
@@ -109,13 +109,13 @@ test_unused_slot_first_seq_ok(void)
     CHECK(req.replay_slot == &session->replay_slots[0]);
     CHECK(req.replay_slot_id == 0);
     CHECK(req.replay_action == NFS4_REPLAY_ACTION_NEW);
-    CHECK(session->replay_slots[0].state == NFS4_SLOT_IN_PROGRESS);
-    CHECK(session->replay_slots[0].inflight_seqid == 1);
+    CHECK(nfs4_slot_state(&session->replay_slots[0]) == NFS4_SLOT_IN_PROGRESS);
+    CHECK(nfs4_slot_seqid(&session->replay_slots[0]) == 1);
 
     /* Finalize transitions to COMPLETED (no cachethis, no cached_buf). */
     nfs4_replay_slot_finalize(&req);
-    CHECK(session->replay_slots[0].state == NFS4_SLOT_COMPLETED);
-    CHECK(session->replay_slots[0].seqid == 1);
+    CHECK(nfs4_slot_state(&session->replay_slots[0]) == NFS4_SLOT_COMPLETED);
+    CHECK(nfs4_slot_seqid(&session->replay_slots[0]) == 1);
     CHECK(session->replay_slots[0].cached_buf == NULL);
 
     destroy_session_table(&table, session);
@@ -138,7 +138,7 @@ test_unused_slot_wrong_seq_misordered(void)
 
     CHECK(status == NFS4ERR_SEQ_MISORDERED);
     CHECK(!is_replay);
-    CHECK(session->replay_slots[0].state == NFS4_SLOT_UNUSED);
+    CHECK(nfs4_slot_state(&session->replay_slots[0]) == NFS4_SLOT_UNUSED);
 
     destroy_session_table(&table, session);
 } /* test_unused_slot_wrong_seq_misordered */
@@ -181,7 +181,7 @@ test_in_progress_retry(void)
 
     status = nfs4_replay_slot_acquire(session, 0, 1, true, &req1, &is_replay);
     CHECK(status == NFS4_OK);
-    CHECK(session->replay_slots[0].state == NFS4_SLOT_IN_PROGRESS);
+    CHECK(nfs4_slot_state(&session->replay_slots[0]) == NFS4_SLOT_IN_PROGRESS);
 
     /* Without calling finalize, a second SEQUENCE on the same slot with
      * the same seqid arrives -- libevpl has no DRC, so this hits us. */
@@ -215,7 +215,7 @@ test_completed_retry_uncached(void)
     status = nfs4_replay_slot_acquire(session, 0, 1, false, &req, &is_replay);
     CHECK(status == NFS4_OK);
     nfs4_replay_slot_finalize(&req);
-    CHECK(session->replay_slots[0].state == NFS4_SLOT_COMPLETED);
+    CHECK(nfs4_slot_state(&session->replay_slots[0]) == NFS4_SLOT_COMPLETED);
 
     /* Retry (same seqid) -> no cached bytes -> RETRY_UNCACHED_REP. */
     reset_request(&req);
@@ -255,7 +255,7 @@ test_cached_retry_replay(void)
     session->replay_bytes_in_use       += 64;
 
     nfs4_replay_slot_finalize(&req);
-    CHECK(session->replay_slots[0].state == NFS4_SLOT_CACHED);
+    CHECK(nfs4_slot_state(&session->replay_slots[0]) == NFS4_SLOT_CACHED);
     CHECK(session->replay_slots[0].cached_buf == fake_reply);
 
     /* Retry same seqid -> REPLAY. */
@@ -293,7 +293,7 @@ test_advance_frees_cache(void)
     session->replay_slots[0].cached_len = 128;
     session->replay_bytes_in_use       += 128;
     nfs4_replay_slot_finalize(&req);
-    CHECK(session->replay_slots[0].state == NFS4_SLOT_CACHED);
+    CHECK(nfs4_slot_state(&session->replay_slots[0]) == NFS4_SLOT_CACHED);
     CHECK(session->replay_bytes_in_use == 128);
 
     /* Advance: seqid + 1.  Old buf must be freed and bytes accounted. */
@@ -303,12 +303,12 @@ test_advance_frees_cache(void)
     CHECK(status == NFS4_OK);
     CHECK(!is_replay);
     CHECK(req.replay_action == NFS4_REPLAY_ACTION_NEW);
-    CHECK(session->replay_slots[0].state == NFS4_SLOT_IN_PROGRESS);
+    CHECK(nfs4_slot_state(&session->replay_slots[0]) == NFS4_SLOT_IN_PROGRESS);
     CHECK(session->replay_slots[0].cached_buf == NULL);
     CHECK(session->replay_bytes_in_use == 0);
 
     nfs4_replay_slot_finalize(&req);
-    CHECK(session->replay_slots[0].state == NFS4_SLOT_COMPLETED);
+    CHECK(nfs4_slot_state(&session->replay_slots[0]) == NFS4_SLOT_COMPLETED);
 
     destroy_session_table(&table, session);
 } /* test_advance_frees_cache */
@@ -368,8 +368,8 @@ test_slots_independent(void)
     status      = nfs4_replay_slot_acquire(session, 1, 1, false, &req, &is_replay);
     CHECK(status == NFS4_OK);
     nfs4_replay_slot_finalize(&req);
-    CHECK(session->replay_slots[1].state == NFS4_SLOT_COMPLETED);
-    CHECK(session->replay_slots[0].state == NFS4_SLOT_COMPLETED);
+    CHECK(nfs4_slot_state(&session->replay_slots[1]) == NFS4_SLOT_COMPLETED);
+    CHECK(nfs4_slot_state(&session->replay_slots[0]) == NFS4_SLOT_COMPLETED);
 
     destroy_session_table(&table, session);
 } /* test_slots_independent */


### PR DESCRIPTION
## Summary

Every NFSv4.1 COMPOUND begins with `SEQUENCE`, and `nfs4_replay_slot_acquire` / `nfs4_replay_slot_finalize` each took the **per-session mutex** `nfs4_session_lock`. Because all `nconnect` connections of a mount share **one** session, every connection-thread serialized on that one lock for *every request*.

This was harmless at 64 slots but became a hard scaling wall once the slot count was raised (PR #289): with more concurrent in-flight requests, the (e.g. 16) connection-threads collided on the single mutex and throughput **collapsed (~200K → ~45K)** instead of scaling. The contention is *false* — by RFC 5661 a client has at most one outstanding request per slot id, so concurrent requests use **distinct** slots.

## Change

- Pack `(seqid, state)` into one `_Atomic uint64_t` per slot (`state_word`: bits[1:0]=state, bits[33:2]=seqid). `calloc` zero-init == `(seqid 0, UNUSED)`.
- `acquire`: lock-free CAS state machine. The CAS arbitrates the only genuine same-slot race — a retransmit arriving on another connection/thread — exactly as the mutex did (losers re-read, see IN_PROGRESS → `RETRY_UNCACHED_REP`).
- `finalize`: a single **release** store (runs on the acquire thread; nothing else writes the word while IN_PROGRESS). Pairs with the acquire load so a reader observing `CACHED` also sees `cached_buf`/`cached_len`.
- `replay_bytes_in_use` → `_Atomic` with a CAS reserve against the per-session byte cap.
- **Remove `nfs4_session_lock` entirely** (its only users were these three functions).
- Add `nfs4_slot_word`/`nfs4_slot_state`/`nfs4_slot_seqid` accessors; update the replay-slot unit test to use them. Drop the write-only `cachethis` slot field and the redundant `seqid`/`inflight_seqid` (folded into the word).

## Safety

The cached-reply buffer (cachethis path — OPEN/CLOSE/LOCK/…, **never** the READ/WRITE data path) is written by the capture callback on the owning thread and published via finalize's release store. The CAS winner is the sole freer of a superseded buffer on seqid advance. The FROM_CACHE replay read preserves the **existing** client-cooperative invariant (a client does not advance a slot whose reply it hasn't received) — identical to the prior lock-based code, which also read the buffer outside the lock. No behavior change.

## Testing

- `ctest -R nfs4|replay_slot` — **499/499** pass (release), incl. the replay-slot state-machine unit test.
- `ctest -R cthon|lock` — **801/801** pass (retransmit/dup-request and byte-range lock coverage).
- Full **ASan debug** build: **508/508** nfs4/replay/lock tests pass.

Builds on #289 conceptually (raising the slot count) but is independent; based on current `main`. The perf payoff — raising `nfs4_session_slots` + client `nfs.max_session_slots` should now *scale* instead of collapsing — needs measurement on the rig.