### PR TITLE
nfs4: implement EXCHANGE_ID client-record matching state machine

### DIFF
--- a/src/server/nfs/nfs4_proc_compound.c
+++ b/src/server/nfs/nfs4_proc_compound.c
@@ -273,6 +273,22 @@ chimera_nfs4_compound(
 
     chimera_nfs_map_cred(&req->cred, cred);
 
+    /* Capture the RPC principal for EXCHANGE_ID record-matching. */
+    if (cred && cred->flavor == EVPL_RPC2_AUTH_SYS) {
+        req->principal_flavor          = cred->flavor;
+        req->principal_uid             = cred->authsys.uid;
+        req->principal_gid             = cred->authsys.gid;
+        req->principal_machinename     = cred->authsys.machinename;
+        req->principal_machinename_len = cred->authsys.machinename_len > 0 ?
+            (uint32_t) cred->authsys.machinename_len : 0;
+    } else {
+        req->principal_flavor          = cred ? cred->flavor : EVPL_RPC2_AUTH_NONE;
+        req->principal_uid             = 0;
+        req->principal_gid             = 0;
+        req->principal_machinename     = NULL;
+        req->principal_machinename_len = 0;
+    }
+
     nfs4_dump_compound(req, args);
 
     /* The conn caches its bound nfs4_session in private_data.  The conn

--- a/src/server/nfs/nfs4_proc_create_session.c
+++ b/src/server/nfs/nfs4_proc_create_session.c
@@ -64,8 +64,25 @@ chimera_nfs4_create_session(
 
     if (!session) {
         res->csr_status = NFS4ERR_STALE_CLIENTID;
-        chimera_nfs4_compound_complete(req, NFS4_OK);
+        chimera_nfs4_compound_complete(req, NFS4ERR_STALE_CLIENTID);
         return;
+    }
+
+    /* RFC 8881 §18.36.3: a successful CREATE_SESSION confirms the client
+     * record.  If this record superseded an earlier one (client reboot, see
+     * nfs4_client_exchange_id), confirmation tears the old record and its
+     * sessions down; release its state hierarchy outside the table lock. */
+    {
+        struct nfs_client *superseded = NULL;
+
+        nfs4_client_confirm(&shared->nfs4_shared_clients,
+                            args->csa_clientid, &superseded);
+
+        if (superseded) {
+            nfs_client_destroy(superseded,
+                               &shared->nfs4_state_table,
+                               thread->vfs_thread);
+        }
     }
 
     nfs4_session_bind_conn(conn, session);

--- a/src/server/nfs/nfs4_proc_exchange_id.c
+++ b/src/server/nfs/nfs4_proc_exchange_id.c
@@ -8,6 +8,14 @@
 #include "nfs4_state.h"
 #include "evpl/evpl_rpc2.h"
 
+/* Flag bits a client is permitted to set in eia_flags (RFC 8881 §18.35.3).
+ * EXCHGID4_FLAG_CONFIRMED_R is result-only; any other bit is undefined. */
+#define NFS4_EID_VALID_INPUT_FLAGS                                       \
+        (EXCHGID4_FLAG_SUPP_MOVED_REFER | EXCHGID4_FLAG_SUPP_MOVED_MIGR |     \
+         EXCHGID4_FLAG_SUPP_FENCE_OPS | EXCHGID4_FLAG_BIND_PRINC_STATEID |    \
+         EXCHGID4_FLAG_USE_NON_PNFS | EXCHGID4_FLAG_USE_PNFS_MDS |            \
+         EXCHGID4_FLAG_USE_PNFS_DS | EXCHGID4_FLAG_UPD_CONFIRMED_REC_A)
+
 void
 chimera_nfs4_exchange_id(
     struct chimera_server_nfs_thread *thread,
@@ -15,24 +23,74 @@ chimera_nfs4_exchange_id(
     struct nfs_argop4                *argop,
     struct nfs_resop4                *resop)
 {
-    struct EXCHANGE_ID4args *args = &argop->opexchange_id;
-    struct EXCHANGE_ID4res  *res  = &resop->opexchange_id;
-    uint32_t                 client_id;
-    uint64_t                 owner_major  = 42;
-    uint64_t                 owner_minor  = 42;
-    uint64_t                 server_scope = 42;
-    struct timespec          now;
-    int                      rc;
+    struct EXCHANGE_ID4args       *args         = &argop->opexchange_id;
+    struct EXCHANGE_ID4res        *res          = &resop->opexchange_id;
+    uint64_t                       owner_major  = 42;
+    uint64_t                       owner_minor  = 42;
+    uint64_t                       server_scope = 42;
+    struct timespec                now;
+    struct nfs4_client_principal   principal;
+    struct nfs4_exchange_id_result eid;
+    bool                           update;
+    int                            rc;
 
     clock_gettime(CLOCK_REALTIME, &now);
 
-    client_id = nfs4_client_register(
+    /* RFC 8881 §18.35.3: when used outside a session (no preceding SEQUENCE),
+     * EXCHANGE_ID must be the sole operation in its COMPOUND.  Inside a
+     * session it may appear as an ordinary operation. */
+    if (!req->seen_sequence && req->args_compound->num_argarray != 1) {
+        res->eir_status = NFS4ERR_NOT_ONLY_OP;
+        chimera_nfs4_compound_complete(req, res->eir_status);
+        return;
+    }
+
+    /* The client impl-id is XDR array<1>; more than one element is malformed. */
+    if (args->num_eia_client_impl_id > 1) {
+        res->eir_status = NFS4ERR_BADXDR;
+        chimera_nfs4_compound_complete(req, res->eir_status);
+        return;
+    }
+
+    /* RFC 8881 §18.35.3: undefined flag bits (and the result-only
+    * EXCHGID4_FLAG_CONFIRMED_R) must not be set by the client. */
+    if (args->eia_flags & ~NFS4_EID_VALID_INPUT_FLAGS) {
+        res->eir_status = NFS4ERR_INVAL;
+        chimera_nfs4_compound_complete(req, res->eir_status);
+        return;
+    }
+
+    update = (args->eia_flags & EXCHGID4_FLAG_UPD_CONFIRMED_REC_A) != 0;
+
+    principal.flavor          = req->principal_flavor;
+    principal.uid             = req->principal_uid;
+    principal.gid             = req->principal_gid;
+    principal.machinename     = req->principal_machinename;
+    principal.machinename_len = req->principal_machinename_len;
+
+    nfs4_client_exchange_id(
         &thread->shared->nfs4_shared_clients,
         args->eia_clientowner.co_ownerid.data,
         args->eia_clientowner.co_ownerid.len,
         *(uint64_t *) args->eia_clientowner.co_verifier,
-        40,
-        NULL, NULL);
+        &principal,
+        update,
+        req->minorversion,
+        &eid);
+
+    /* A superseded record's state hierarchy is torn down outside the table
+     * lock (see nfs4_client_exchange_id). */
+    if (eid.destroy_unified) {
+        nfs_client_destroy(eid.destroy_unified,
+                           &thread->shared->nfs4_state_table,
+                           thread->vfs_thread);
+    }
+
+    if (eid.status != NFS4_OK) {
+        res->eir_status = eid.status;
+        chimera_nfs4_compound_complete(req, res->eir_status);
+        return;
+    }
 
     /* Phase 5: 4.1+ EXCHANGE_ID is the moment of identity establishment;
      * stub-persist the unified client so a future stable-storage backend
@@ -43,7 +101,7 @@ chimera_nfs4_exchange_id(
         pthread_mutex_lock(&thread->shared->nfs4_shared_clients.nfs4_ct_lock);
         HASH_FIND(nfs4_client_hh_by_id,
                   thread->shared->nfs4_shared_clients.nfs4_ct_clients_by_id,
-                  &client_id, sizeof(client_id), c);
+                  &eid.clientid, sizeof(eid.clientid), c);
         if (c) {
             uc = c->unified;
         }
@@ -53,10 +111,11 @@ chimera_nfs4_exchange_id(
         }
     }
 
-    res->eir_status                           = NFS4_OK;
-    res->eir_resok4.eir_clientid              = client_id;
-    res->eir_resok4.eir_sequenceid            = 1;
-    res->eir_resok4.eir_flags                 = EXCHGID4_FLAG_USE_NON_PNFS;
+    res->eir_status                = NFS4_OK;
+    res->eir_resok4.eir_clientid   = eid.clientid;
+    res->eir_resok4.eir_sequenceid = 1;
+    res->eir_resok4.eir_flags      = EXCHGID4_FLAG_USE_NON_PNFS |
+        (eid.confirmed ? EXCHGID4_FLAG_CONFIRMED_R : 0);
     res->eir_resok4.eir_state_protect.spr_how = SP4_NONE;
     res->eir_resok4.num_eir_server_impl_id    = 1;
 

--- a/src/server/nfs/nfs4_session.c
+++ b/src/server/nfs/nfs4_session.c
@@ -195,6 +195,260 @@ nfs4_client_register(
     return id;
 } /* nfs4_client_register */
 
+static int
+nfs4_principal_matches(
+    const struct nfs4_client           *c,
+    const struct nfs4_client_principal *p)
+{
+    if (c->nfs4_client_princ_flavor != p->flavor ||
+        c->nfs4_client_princ_uid != p->uid ||
+        c->nfs4_client_princ_gid != p->gid ||
+        c->nfs4_client_princ_mach_len != p->machinename_len) {
+        return 0;
+    }
+    return p->machinename_len == 0 ||
+           memcmp(c->nfs4_client_princ_mach, p->machinename,
+                  p->machinename_len) == 0;
+} /* nfs4_principal_matches */
+
+/* Caller must hold table->nfs4_ct_lock.  Allocates a fresh (unconfirmed)
+ * client record, brings up its unified state hierarchy, and inserts it into
+ * both hash tables. */
+static struct nfs4_client *
+nfs4_client_new_locked(
+    struct nfs4_client_table           *table,
+    const void                         *owner,
+    int                                 owner_len,
+    uint64_t                            verifier,
+    const struct nfs4_client_principal *p,
+    uint8_t                             minorversion)
+{
+    struct nfs4_client *c = calloc(1, sizeof(*c));
+
+    c->nfs4_client_id            = table->nfs4_ct_next_client_id++;
+    c->nfs4_client_owner_len     = owner_len;
+    c->nfs4_client_verifier      = verifier;
+    c->nfs4_client_refcnt        = 1;
+    c->nfs4_client_confirmed     = 0;
+    c->nfs4_client_supersedes_id = 0;
+    memcpy(c->nfs4_client_owner, owner, owner_len);
+
+    c->nfs4_client_princ_flavor   = p->flavor;
+    c->nfs4_client_princ_uid      = p->uid;
+    c->nfs4_client_princ_gid      = p->gid;
+    c->nfs4_client_princ_mach_len = p->machinename_len > NFS4_OPAQUE_LIMIT ?
+        NFS4_OPAQUE_LIMIT : p->machinename_len;
+    if (c->nfs4_client_princ_mach_len) {
+        memcpy(c->nfs4_client_princ_mach, p->machinename,
+               c->nfs4_client_princ_mach_len);
+    }
+
+    strncpy(c->nfs4_client_domain, "unidentified", NFS4_OPAQUE_LIMIT);
+    strncpy(c->nfs4_client_name, "unidentified", NFS4_OPAQUE_LIMIT);
+
+    c->unified = nfs_client_alloc(c->nfs4_client_id, owner, owner_len,
+                                  verifier, minorversion);
+
+    HASH_ADD(nfs4_client_hh_by_owner, table->nfs4_ct_clients_by_owner,
+             nfs4_client_owner, c->nfs4_client_owner_len, c);
+    HASH_ADD(nfs4_client_hh_by_id, table->nfs4_ct_clients_by_id,
+             nfs4_client_id, sizeof(c->nfs4_client_id), c);
+
+    return c;
+} /* nfs4_client_new_locked */
+
+/* Caller must hold table->nfs4_ct_lock.  Unhashes a record from both tables
+ * and frees the bookkeeping struct, returning its unified state hierarchy for
+ * the caller to tear down once the lock is dropped.  The record must be
+ * present in both hash tables (i.e. not a superseded record, which has
+ * already left the by-owner table). */
+static struct nfs_client *
+nfs4_client_remove_locked(
+    struct nfs4_client_table *table,
+    struct nfs4_client       *c)
+{
+    struct nfs_client *unified = c->unified;
+
+    HASH_DELETE(nfs4_client_hh_by_owner, table->nfs4_ct_clients_by_owner, c);
+    HASH_DELETE(nfs4_client_hh_by_id, table->nfs4_ct_clients_by_id, c);
+    c->unified = NULL;
+    free(c);
+    return unified;
+} /* nfs4_client_remove_locked */
+
+/* Caller must hold table->nfs4_ct_lock. */
+static int
+nfs4_client_has_session_locked(
+    struct nfs4_client_table *table,
+    uint64_t                  client_id)
+{
+    struct nfs4_session *s, *tmp;
+
+    HASH_ITER(nfs4_session_hh, table->nfs4_ct_sessions, s, tmp)
+    {
+        if (s->nfs4_session_clientid == client_id) {
+            return 1;
+        }
+    }
+    return 0;
+} /* nfs4_client_has_session_locked */
+
+void
+nfs4_client_exchange_id(
+    struct nfs4_client_table           *table,
+    const void                         *owner,
+    int                                 owner_len,
+    uint64_t                            verifier,
+    const struct nfs4_client_principal *principal,
+    bool                                update,
+    uint8_t                             minorversion,
+    struct nfs4_exchange_id_result     *out)
+{
+    struct nfs4_client *existing, *nc;
+
+    out->status          = NFS4_OK;
+    out->clientid        = 0;
+    out->confirmed       = 0;
+    out->destroy_unified = NULL;
+
+    pthread_mutex_lock(&table->nfs4_ct_lock);
+
+    HASH_FIND(nfs4_client_hh_by_owner, table->nfs4_ct_clients_by_owner,
+              owner, owner_len, existing);
+
+    if (update) {
+        /* EXCHGID4_FLAG_UPD_CONFIRMED_REC_A: an update targets an existing
+         * *confirmed* record (RFC 8881 §18.35.4 cases 6/8/9). */
+        if (!existing || !existing->nfs4_client_confirmed) {
+            out->status = NFS4ERR_NOENT;
+        } else if (!nfs4_principal_matches(existing, principal)) {
+            out->status = NFS4ERR_PERM;
+        } else if (existing->nfs4_client_verifier != verifier) {
+            out->status = NFS4ERR_NOT_SAME;
+        } else {
+            out->clientid  = existing->nfs4_client_id;
+            out->confirmed = 1;
+        }
+        goto out_unlock;
+    }
+
+    if (!existing) {
+        /* Case 1: brand-new owner. */
+        nc = nfs4_client_new_locked(table, owner, owner_len,
+                                    verifier, principal, minorversion);
+        out->clientid = nc->nfs4_client_id;
+        goto out_unlock;
+    }
+
+    if (!existing->nfs4_client_confirmed) {
+        /* Case 4: an unconfirmed record is always replaced -- the client
+         * never proved ownership of its clientid, so a fresh one is issued. */
+        out->destroy_unified = nfs4_client_remove_locked(table, existing);
+        nc                   = nfs4_client_new_locked(table, owner, owner_len,
+                                                      verifier, principal, minorversion);
+        out->clientid = nc->nfs4_client_id;
+        goto out_unlock;
+    }
+
+    /* Confirmed record below. */
+    if (nfs4_principal_matches(existing, principal)) {
+        if (existing->nfs4_client_verifier == verifier) {
+            /* Case 2: identical owner+verifier+principal -- return the same
+             * clientid, leaving existing state intact. */
+            out->clientid  = existing->nfs4_client_id;
+            out->confirmed = 1;
+            goto out_unlock;
+        }
+
+        /* Case 5: same principal, new boot verifier -- the client rebooted.
+         * Issue a new clientid via a superseding unconfirmed record but keep
+         * the old record (and its sessions) live until the new one is
+         * confirmed at CREATE_SESSION. */
+        HASH_DELETE(nfs4_client_hh_by_owner, table->nfs4_ct_clients_by_owner,
+                    existing);
+        nc = nfs4_client_new_locked(table, owner, owner_len, verifier,
+                                    principal, minorversion);
+        nc->nfs4_client_supersedes_id = existing->nfs4_client_id;
+        out->clientid                 = nc->nfs4_client_id;
+        goto out_unlock;
+    }
+
+    /* Confirmed record owned by a different principal (RFC 8881 §18.35.4
+     * case 3).  If the old client still holds session state this is a
+     * collision (CLID_INUSE); otherwise the stale record is replaced. */
+    if (nfs4_client_has_session_locked(table, existing->nfs4_client_id)) {
+        out->status = NFS4ERR_CLID_INUSE;
+        goto out_unlock;
+    }
+
+    out->destroy_unified = nfs4_client_remove_locked(table, existing);
+    nc                   = nfs4_client_new_locked(table, owner, owner_len,
+                                                  verifier, principal, minorversion);
+    out->clientid = nc->nfs4_client_id;
+
+ out_unlock:
+    pthread_mutex_unlock(&table->nfs4_ct_lock);
+} /* nfs4_client_exchange_id */
+
+bool
+nfs4_client_confirm(
+    struct nfs4_client_table *table,
+    uint64_t                  client_id,
+    struct nfs_client       **destroy_unified)
+{
+    struct nfs4_client *c, *old;
+
+    *destroy_unified = NULL;
+
+    pthread_mutex_lock(&table->nfs4_ct_lock);
+
+    HASH_FIND(nfs4_client_hh_by_id, table->nfs4_ct_clients_by_id,
+              &client_id, sizeof(client_id), c);
+
+    if (!c) {
+        pthread_mutex_unlock(&table->nfs4_ct_lock);
+        return false;
+    }
+
+    c->nfs4_client_confirmed = 1;
+
+    if (c->nfs4_client_supersedes_id) {
+        uint64_t oldid = c->nfs4_client_supersedes_id;
+
+        c->nfs4_client_supersedes_id = 0;
+
+        HASH_FIND(nfs4_client_hh_by_id, table->nfs4_ct_clients_by_id,
+                  &oldid, sizeof(oldid), old);
+
+        if (old) {
+            struct nfs4_session *s, *tmp;
+
+            /* Tear down the superseded client's sessions so a stale-session
+             * reference returns NFS4ERR_BADSESSION. */
+            HASH_ITER(nfs4_session_hh, table->nfs4_ct_sessions, s, tmp)
+            {
+                if (s->nfs4_session_clientid == oldid) {
+                    HASH_DELETE(nfs4_session_hh, table->nfs4_ct_sessions, s);
+                    atomic_store_explicit(&s->destroyed, true,
+                                          memory_order_release);
+                    nfs4_session_put(s);
+                }
+            }
+
+            /* The superseded record already left the by-owner table at reboot
+            * time; drop it from by-id and hand its state out for teardown. */
+            HASH_DELETE(nfs4_client_hh_by_id, table->nfs4_ct_clients_by_id,
+                        old);
+            *destroy_unified = old->unified;
+            old->unified     = NULL;
+            free(old);
+        }
+    }
+
+    pthread_mutex_unlock(&table->nfs4_ct_lock);
+    return true;
+} /* nfs4_client_confirm */
+
 void
 nfs4_client_unregister(
     struct nfs4_client_table  *table,

--- a/src/server/nfs/nfs4_session.h
+++ b/src/server/nfs/nfs4_session.h
@@ -53,6 +53,17 @@ struct nfs4_replay_slot {
  * nlm_client (uint32_t magic at offset 0). */
 #define NFS4_SESSION_MAGIC 0x4E465353U /* "NFSS" */
 
+/* Identity of the RPC principal that established a client record, captured at
+ * EXCHANGE_ID time.  Used for the RFC 8881 §18.35.4 record-matching cases,
+ * which distinguish callers by principal as well as by boot verifier. */
+struct nfs4_client_principal {
+    uint32_t    flavor;
+    uint32_t    uid;
+    uint32_t    gid;
+    const char *machinename;
+    uint32_t    machinename_len;
+};
+
 struct nfs4_client {
     uint64_t              nfs4_client_id;
     uint32_t              nfs4_client_owner_len;
@@ -64,10 +75,39 @@ struct nfs4_client {
     uint8_t               nfs4_client_owner[NFS4_OPAQUE_LIMIT];
     char                  nfs4_client_domain[NFS4_OPAQUE_LIMIT];
     char                  nfs4_client_name[NFS4_OPAQUE_LIMIT];
+    /* RFC 8881 §18.35: a record is "unconfirmed" until the client proves
+     * possession of the clientid via a successful CREATE_SESSION; only then
+     * is it "confirmed". */
+    uint8_t               nfs4_client_confirmed;
+    /* Principal that created the record (see nfs4_client_principal). */
+    uint32_t              nfs4_client_princ_flavor;
+    uint32_t              nfs4_client_princ_uid;
+    uint32_t              nfs4_client_princ_gid;
+    uint32_t              nfs4_client_princ_mach_len;
+    char                  nfs4_client_princ_mach[NFS4_OPAQUE_LIMIT];
+    /* Client-reboot (RFC 8881 §18.35.4 case 5): when a confirmed record is
+     * replaced by a new EXCHANGE_ID from the same principal with a new boot
+     * verifier, the new (unconfirmed) record records the old clientid here.
+     * The old record stays live until this new one is confirmed at
+     * CREATE_SESSION, at which point the old record and its sessions are torn
+     * down.  0 means "supersedes nothing". */
+    uint64_t              nfs4_client_supersedes_id;
     /* Unified state hierarchy.  Created when this nfs4_client is first
      * registered; freed when the nfs4_client is unregistered or the table
      * is torn down.  See nfs4_state.h. */
     struct nfs_client    *unified;
+};
+
+/* Outcome of the EXCHANGE_ID record-matching state machine.  The handler acts
+ * on `status`; on NFS4_OK it returns `clientid`/`confirmed` to the client.
+ * `destroy_unified`, if non-NULL, is a superseded client's state hierarchy the
+ * caller must tear down with nfs_client_destroy AFTER dropping the table lock
+ * (nfs4_client_exchange_id only unhashes/frees the bookkeeping struct). */
+struct nfs4_exchange_id_result {
+    nfsstat4           status;
+    uint64_t           clientid;
+    uint32_t           confirmed;
+    struct nfs_client *destroy_unified;
 };
 
 struct nfs4_session {
@@ -138,6 +178,31 @@ nfs4_client_register(
     uint32_t                  proto,
     const char               *nii_domain,
     const char               *nii_name);
+
+/* RFC 8881 §18.35.4 EXCHANGE_ID client-record matching state machine.  Runs
+ * entirely under the table lock and fills *out (see nfs4_exchange_id_result).
+ * `update` reflects EXCHGID4_FLAG_UPD_CONFIRMED_REC_A. */
+void
+nfs4_client_exchange_id(
+    struct nfs4_client_table           *table,
+    const void                         *owner,
+    int                                 owner_len,
+    uint64_t                            verifier,
+    const struct nfs4_client_principal *principal,
+    bool                                update,
+    uint8_t                             minorversion,
+    struct nfs4_exchange_id_result     *out);
+
+/* Mark a client record confirmed (first successful CREATE_SESSION).  If the
+ * record supersedes an older one (client reboot), the older record and its
+ * sessions are torn down and its state hierarchy is returned via
+ * *destroy_unified for teardown outside the table lock.  Returns false when no
+ * such client exists (caller maps to NFS4ERR_STALE_CLIENTID). */
+bool
+nfs4_client_confirm(
+    struct nfs4_client_table *table,
+    uint64_t                  client_id,
+    struct nfs_client       **destroy_unified);
 
 /* Unregister a client and tear down its unified state hierarchy.
  *

--- a/src/server/nfs/nfs_common.h
+++ b/src/server/nfs/nfs_common.h
@@ -43,6 +43,14 @@ struct nfs_request {
     struct chimera_server_nfs_thread *thread;
     struct nfs4_session              *session;
     struct chimera_vfs_cred           cred;
+    /* RPC principal of the caller, captured at compound entry for EXCHANGE_ID
+     * client-record matching (RFC 8881 §18.35.4).  machinename points into the
+     * request message buffer, valid for the lifetime of the request. */
+    uint32_t                          principal_flavor;
+    uint32_t                          principal_uid;
+    uint32_t                          principal_gid;
+    const char                       *principal_machinename;
+    uint32_t                          principal_machinename_len;
     uint8_t                           fh[NFS4_FHSIZE];
     int                               fhlen;
     uint8_t                           saved_fh[NFS4_FHSIZE];


### PR DESCRIPTION
## Summary

`EXCHANGE_ID` was a stub: it always returned the same clientid for a given client owner, ignoring the boot verifier, calling principal, update flag, and confirmed state. This implements the RFC 8881 §18.35.4 client-record matching state machine.

Non-update cases:
- brand-new owner → unconfirmed record, new clientid
- existing unconfirmed record → always replaced (new clientid)
- confirmed record, same principal + verifier → same clientid
- confirmed record, same principal, new boot verifier (client reboot) → new clientid via a *superseding* record; the old record and its sessions are torn down once the new one is confirmed at `CREATE_SESSION`
- confirmed record, different principal → replaced if it holds no session state, else `NFS4ERR_CLID_INUSE`

Update (`EXCHGID4_FLAG_UPD_CONFIRMED_REC_A`) cases resolve to `NFS4ERR_NOENT` (no confirmed record), `NFS4ERR_PERM` (principal mismatch), `NFS4ERR_NOT_SAME` (verifier mismatch), or success.

Also:
- validate `eia_flags` (`NFS4ERR_INVAL` for undefined / result-only bits)
- reject an over-long client impl-id array (`NFS4ERR_BADXDR`)
- require `EXCHANGE_ID` to be the only op when used outside a session (`NFS4ERR_NOT_ONLY_OP`)
- the client record now tracks a confirmed flag and the establishing principal (full RPC cred tuple, captured at compound entry); a successful `CREATE_SESSION` confirms the record
- fix `CREATE_SESSION` to surface `NFS4ERR_STALE_CLIENTID` at the compound level instead of returning a non-error status

## Verification

pynfs `st_exchange_id` (memfs, 4.1) goes from 4/25 to 24/25; the remaining failure (EID50 `testSSV`) needs RPCSEC_GSS/SSV state protection, which is out of scope. The dependent session suites (`create_session`, `destroy_session`, `destroy_clientid`, `sequence`, `reclaim_complete`) also improve substantially as a side effect. No regression in the posix/cthon NFS4 suites (memfs, linux, cairn, io_uring), which mount over NFSv4.1 and exercise EXCHANGE_ID + CREATE_SESSION.