### PR TITLE
nfs4: CREATE_SESSION sequencing, reply cache and arg validation

### DIFF
--- a/src/server/nfs/nfs4_proc_create_session.c
+++ b/src/server/nfs/nfs4_proc_create_session.c
@@ -6,6 +6,17 @@
 #include "nfs4_session.h"
 #include "server/server.h"
 
+/* Flag bits a client may set in csa_flags (RFC 8881 §18.36.3). */
+#define NFS4_CS_VALID_FLAGS                                  \
+        (CREATE_SESSION4_FLAG_PERSIST |                          \
+         CREATE_SESSION4_FLAG_CONN_BACK_CHAN |                   \
+         CREATE_SESSION4_FLAG_CONN_RDMA)
+
+/* Smallest ca_maxrequestsize / ca_maxresponsesize that could ever carry a
+ * request/reply (a bare SEQUENCE op plus COMPOUND framing).  Below this the
+ * server returns NFS4ERR_TOOSMALL per RFC 8881 §18.36.3. */
+#define NFS4_CS_MIN_CHAN_SIZE 64u
+
 void
 chimera_nfs4_create_session(
     struct chimera_server_nfs_thread *thread,
@@ -18,14 +29,97 @@ chimera_nfs4_create_session(
     struct CREATE_SESSION4args       *args   = &argop->opcreate_session;
     struct CREATE_SESSION4res        *res    = &resop->opcreate_session;
     struct nfs4_session              *session;
+    struct nfs4_client_principal      principal;
+    struct nfs4_cs_classify           cs;
     struct channel_attrs4             clamped_fore;
     uint32_t                          flags = 0;
     uint32_t                          replay_max_slots;
     uint32_t                          replay_maxresp_cached;
     uint32_t                          server_max_slots;
 
+    /* RFC 8881 §18.36.3: outside a session CREATE_SESSION must be the only op. */
+    if (!req->seen_sequence && req->args_compound->num_argarray != 1) {
+        res->csr_status = NFS4ERR_NOT_ONLY_OP;
+        chimera_nfs4_compound_complete(req, res->csr_status);
+        return;
+    }
+
+    /* Undefined csa_flags bits are rejected. */
+    if (args->csa_flags & ~NFS4_CS_VALID_FLAGS) {
+        res->csr_status = NFS4ERR_INVAL;
+        chimera_nfs4_compound_complete(req, res->csr_status);
+        return;
+    }
+
+    /* ca_rdma_ird is XDR array<1>; more than one element is malformed. */
+    if (args->csa_fore_chan_attrs.num_ca_rdma_ird > 1 ||
+        args->csa_back_chan_attrs.num_ca_rdma_ird > 1) {
+        res->csr_status = NFS4ERR_BADXDR;
+        chimera_nfs4_compound_complete(req, res->csr_status);
+        return;
+    }
+
+    /* A maxrequestsize/maxresponsesize too small to ever carry a
+     * request/reply is NFS4ERR_TOOSMALL. */
+    if (args->csa_fore_chan_attrs.ca_maxresponsesize < NFS4_CS_MIN_CHAN_SIZE ||
+        args->csa_back_chan_attrs.ca_maxresponsesize < NFS4_CS_MIN_CHAN_SIZE ||
+        args->csa_fore_chan_attrs.ca_maxrequestsize < NFS4_CS_MIN_CHAN_SIZE ||
+        args->csa_back_chan_attrs.ca_maxrequestsize < NFS4_CS_MIN_CHAN_SIZE) {
+        res->csr_status = NFS4ERR_TOOSMALL;
+        chimera_nfs4_compound_complete(req, res->csr_status);
+        return;
+    }
+
     if (args->csa_flags & CREATE_SESSION4_FLAG_CONN_BACK_CHAN) {
         flags |= CREATE_SESSION4_FLAG_CONN_BACK_CHAN;
+    }
+
+    /* RFC 8881 §18.36.4 sequencing + reply cache. */
+    principal.flavor          = req->principal_flavor;
+    principal.uid             = req->principal_uid;
+    principal.gid             = req->principal_gid;
+    principal.machinename     = req->principal_machinename;
+    principal.machinename_len = req->principal_machinename_len;
+
+    nfs4_client_create_session_classify(&shared->nfs4_shared_clients,
+                                        args->csa_clientid,
+                                        args->csa_sequence,
+                                        &principal,
+                                        &cs);
+
+    if (cs.action == NFS4_CS_ERROR) {
+        res->csr_status = cs.status;
+        chimera_nfs4_compound_complete(req, cs.status);
+        return;
+    }
+
+    if (cs.action == NFS4_CS_REPLAY) {
+        res->csr_status = cs.status;
+        if (cs.status == NFS4_OK) {
+            memcpy(res->csr_resok4.csr_sessionid, cs.sessionid,
+                   sizeof(res->csr_resok4.csr_sessionid));
+            res->csr_resok4.csr_sequence        = cs.sequence;
+            res->csr_resok4.csr_flags           = cs.flags;
+            res->csr_resok4.csr_fore_chan_attrs = cs.fore;
+            res->csr_resok4.csr_back_chan_attrs = cs.back;
+        }
+        chimera_nfs4_compound_complete(req, cs.status);
+        return;
+    }
+
+    /* NFS4_CS_NEW.  RFC 8881 §18.36.3: an as-yet-unconfirmed record may only be
+     * confirmed by the same principal that created it (EXCHANGE_ID); a
+     * different principal is a collision.  Cache the error so a retransmit
+     * replays it. */
+    if (!cs.confirmed && !cs.principal_ok) {
+        res->csr_status = NFS4ERR_CLID_INUSE;
+        nfs4_client_create_session_cache(&shared->nfs4_shared_clients,
+                                         args->csa_clientid,
+                                         args->csa_sequence,
+                                         NFS4ERR_CLID_INUSE,
+                                         NULL, 0, 0, NULL, NULL);
+        chimera_nfs4_compound_complete(req, res->csr_status);
+        return;
     }
 
     /* RFC 5661 18.36.4: the server may negotiate ca_maxrequests and
@@ -90,11 +184,23 @@ chimera_nfs4_create_session(
 
     res->csr_status = NFS4_OK;
     memcpy(res->csr_resok4.csr_sessionid, session->nfs4_session_id, sizeof(res->csr_resok4.csr_sessionid));
-    res->csr_resok4.csr_sequence = 1;
+    /* RFC 8881 §18.36.4: csr_sequence MUST equal the request's csa_sequence. */
+    res->csr_resok4.csr_sequence = args->csa_sequence;
     res->csr_resok4.csr_flags    = flags;
 
     res->csr_resok4.csr_fore_chan_attrs = session->nfs4_session_fore_attrs;
     res->csr_resok4.csr_back_chan_attrs = session->nfs4_session_back_attrs;
+
+    /* Cache the reply for retransmit detection (RFC 8881 §18.36.4). */
+    nfs4_client_create_session_cache(&shared->nfs4_shared_clients,
+                                     args->csa_clientid,
+                                     args->csa_sequence,
+                                     NFS4_OK,
+                                     session->nfs4_session_id,
+                                     args->csa_sequence,
+                                     flags,
+                                     &session->nfs4_session_fore_attrs,
+                                     &session->nfs4_session_back_attrs);
 
     /* Drop the +1 ref returned by nfs4_create_session; the conn now holds
      * its own ref via bind_conn, and the hash holds the other ref. */

--- a/src/server/nfs/nfs4_session.c
+++ b/src/server/nfs/nfs4_session.c
@@ -390,6 +390,96 @@ nfs4_client_exchange_id(
     pthread_mutex_unlock(&table->nfs4_ct_lock);
 } /* nfs4_client_exchange_id */
 
+void
+nfs4_client_create_session_classify(
+    struct nfs4_client_table           *table,
+    uint64_t                            client_id,
+    uint32_t                            csa_sequence,
+    const struct nfs4_client_principal *principal,
+    struct nfs4_cs_classify            *out)
+{
+    struct nfs4_client *c;
+
+    memset(out, 0, sizeof(*out));
+
+    pthread_mutex_lock(&table->nfs4_ct_lock);
+
+    HASH_FIND(nfs4_client_hh_by_id, table->nfs4_ct_clients_by_id,
+              &client_id, sizeof(client_id), c);
+
+    if (!c) {
+        out->action = NFS4_CS_ERROR;
+        out->status = NFS4ERR_STALE_CLIENTID;
+    } else if (csa_sequence == c->nfs4_client_cs_seqid) {
+        /* Retransmit of the last request, or -- before any request -- the
+         * contrived (eir_sequenceid - 1) value (RFC 8881 §18.36.4). */
+        if (c->nfs4_client_cs_have_reply) {
+            out->action   = NFS4_CS_REPLAY;
+            out->status   = c->nfs4_client_cs_reply_status;
+            out->sequence = c->nfs4_client_cs_reply_sequence;
+            out->flags    = c->nfs4_client_cs_reply_flags;
+            out->fore     = c->nfs4_client_cs_reply_fore;
+            out->back     = c->nfs4_client_cs_reply_back;
+            memcpy(out->sessionid, c->nfs4_client_cs_reply_sessionid,
+                   NFS4_SESSIONID_SIZE);
+        } else {
+            out->action = NFS4_CS_ERROR;
+            out->status = NFS4ERR_SEQ_MISORDERED;
+        }
+    } else if (csa_sequence == c->nfs4_client_cs_seqid + 1) {
+        out->action       = NFS4_CS_NEW;
+        out->confirmed    = c->nfs4_client_confirmed;
+        out->principal_ok = nfs4_principal_matches(c, principal);
+    } else {
+        out->action = NFS4_CS_ERROR;
+        out->status = NFS4ERR_SEQ_MISORDERED;
+    }
+
+    pthread_mutex_unlock(&table->nfs4_ct_lock);
+} /* nfs4_client_create_session_classify */
+
+void
+nfs4_client_create_session_cache(
+    struct nfs4_client_table    *table,
+    uint64_t                     client_id,
+    uint32_t                     csa_sequence,
+    nfsstat4                     status,
+    const uint8_t               *sessionid,
+    uint32_t                     sequence,
+    uint32_t                     flags,
+    const struct channel_attrs4 *fore,
+    const struct channel_attrs4 *back)
+{
+    struct nfs4_client *c;
+
+    pthread_mutex_lock(&table->nfs4_ct_lock);
+
+    HASH_FIND(nfs4_client_hh_by_id, table->nfs4_ct_clients_by_id,
+              &client_id, sizeof(client_id), c);
+
+    if (c) {
+        c->nfs4_client_cs_seqid        = csa_sequence;
+        c->nfs4_client_cs_have_reply   = 1;
+        c->nfs4_client_cs_reply_status = status;
+
+        if (status == NFS4_OK) {
+            memcpy(c->nfs4_client_cs_reply_sessionid, sessionid,
+                   NFS4_SESSIONID_SIZE);
+            c->nfs4_client_cs_reply_sequence = sequence;
+            c->nfs4_client_cs_reply_flags    = flags;
+            c->nfs4_client_cs_reply_fore     = *fore;
+            c->nfs4_client_cs_reply_back     = *back;
+            /* Drop the borrowed ca_rdma_ird pointers; see header. */
+            c->nfs4_client_cs_reply_fore.num_ca_rdma_ird = 0;
+            c->nfs4_client_cs_reply_fore.ca_rdma_ird     = NULL;
+            c->nfs4_client_cs_reply_back.num_ca_rdma_ird = 0;
+            c->nfs4_client_cs_reply_back.ca_rdma_ird     = NULL;
+        }
+    }
+
+    pthread_mutex_unlock(&table->nfs4_ct_lock);
+} /* nfs4_client_create_session_cache */
+
 bool
 nfs4_client_confirm(
     struct nfs4_client_table *table,

--- a/src/server/nfs/nfs4_session.h
+++ b/src/server/nfs/nfs4_session.h
@@ -130,6 +130,21 @@ struct nfs4_client {
      * CREATE_SESSION, at which point the old record and its sessions are torn
      * down.  0 means "supersedes nothing". */
     uint64_t              nfs4_client_supersedes_id;
+    /* CREATE_SESSION sequencing + single-entry reply cache (RFC 8881
+     * §18.36.4).  cs_seqid is the last csa_sequence processed, initialised to
+     * eir_sequenceid - 1 (= 0).  When cs_have_reply is set, the cached fields
+     * below reproduce the reply for a retransmit of cs_seqid. */
+    uint32_t              nfs4_client_cs_seqid;
+    uint8_t               nfs4_client_cs_have_reply;
+    nfsstat4              nfs4_client_cs_reply_status;
+    uint8_t               nfs4_client_cs_reply_sessionid[NFS4_SESSIONID_SIZE];
+    uint32_t              nfs4_client_cs_reply_sequence;
+    uint32_t              nfs4_client_cs_reply_flags;
+    /* Negotiated channel attrs.  Stored with ca_rdma_ird cleared (the pointer
+     * would otherwise dangle once the session is freed); the RDMA ird is not
+     * preserved across a CREATE_SESSION retransmit, which no client relies on. */
+    struct channel_attrs4 nfs4_client_cs_reply_fore;
+    struct channel_attrs4 nfs4_client_cs_reply_back;
     /* Unified state hierarchy.  Created when this nfs4_client is first
      * registered; freed when the nfs4_client is unregistered or the table
      * is torn down.  See nfs4_state.h. */
@@ -226,6 +241,53 @@ nfs4_client_exchange_id(
     bool                                update,
     uint8_t                             minorversion,
     struct nfs4_exchange_id_result     *out);
+
+/* CREATE_SESSION sequencing decision (RFC 8881 §18.36.4). */
+enum nfs4_cs_action {
+    NFS4_CS_NEW,    /* fresh request -- caller creates the session */
+    NFS4_CS_REPLAY, /* retransmit -- caller replays the cached reply */
+    NFS4_CS_ERROR,  /* sequencing error -- caller returns `status` (uncached) */
+};
+
+struct nfs4_cs_classify {
+    enum nfs4_cs_action   action;
+    nfsstat4              status;   /* ERROR status, or REPLAY cached status */
+    uint32_t              confirmed; /* record confirmed? (NEW only) */
+    uint32_t              principal_ok; /* current principal matches record? (NEW only) */
+    /* REPLAY cached reply fields. */
+    uint8_t               sessionid[NFS4_SESSIONID_SIZE];
+    uint32_t              sequence;
+    uint32_t              flags;
+    struct channel_attrs4 fore;
+    struct channel_attrs4 back;
+};
+
+/* Classify an incoming CREATE_SESSION against the client's sequence state and
+ * reply cache.  Looks up `client_id`; on NFS4_CS_NEW it also reports whether
+ * the record is confirmed and whether `principal` matches the record's
+ * principal so the caller can apply the RFC 8881 §18.36.4 principal rule. */
+void
+nfs4_client_create_session_classify(
+    struct nfs4_client_table           *table,
+    uint64_t                            client_id,
+    uint32_t                            csa_sequence,
+    const struct nfs4_client_principal *principal,
+    struct nfs4_cs_classify            *out);
+
+/* Record the reply for the just-processed CREATE_SESSION (advances cs_seqid
+ * and populates the reply cache).  `status` is the op result; the resok fields
+ * are ignored when status != NFS4_OK. */
+void
+nfs4_client_create_session_cache(
+    struct nfs4_client_table    *table,
+    uint64_t                     client_id,
+    uint32_t                     csa_sequence,
+    nfsstat4                     status,
+    const uint8_t               *sessionid,
+    uint32_t                     sequence,
+    uint32_t                     flags,
+    const struct channel_attrs4 *fore,
+    const struct channel_attrs4 *back);
 
 /* Mark a client record confirmed (first successful CREATE_SESSION).  If the
  * record supersedes an older one (client reboot), the older record and its


### PR DESCRIPTION
## Summary

Stacked on #297 (EXCHANGE_ID). Implements the RFC 8881 §18.36.4 CREATE_SESSION sequencing state machine and reply cache, plus argument validation.

`CREATE_SESSION` previously ignored `csa_sequence` and never cached its reply, so retransmits created duplicate sessions and out-of-order sequence numbers were silently accepted. Now, on the client record:

- `csa_sequence == last + 1` → new request: process, cache the reply, advance
- `csa_sequence == last` → replay the cached reply (or, before any request, the contrived `NFS4ERR_SEQ_MISORDERED`)
- otherwise → `NFS4ERR_SEQ_MISORDERED`

The reply cache also covers failures: an unconfirmed record may only be confirmed by the principal that created it at EXCHANGE_ID, so a different principal gets `NFS4ERR_CLID_INUSE`, and a retransmit replays that error.

Argument validation added:
- undefined `csa_flags` bits → `NFS4ERR_INVAL`
- over-long `ca_rdma_ird` array → `NFS4ERR_BADXDR`
- `ca_maxrequestsize`/`ca_maxresponsesize` too small to carry a request/reply → `NFS4ERR_TOOSMALL`
- `CREATE_SESSION` combined with other ops outside a session → `NFS4ERR_NOT_ONLY_OP`
- `csr_sequence` now echoes `csa_sequence`

## Verification

pynfs `st_create_session` (memfs, 4.1) goes from 12/31 to 27/31. The remaining failures (CSESS26/27 `testRepTooBig*`) require runtime per-op response-size enforcement (`NFS4ERR_REP_TOO_BIG`), which is a separate concern. No regression in the posix/cthon NFS4 suites (which mount over 4.1).

## Note

The first commit here is #297; this PR will show only its own diff once #297 merges and this branch is rebased.