### PR TITLE
nfs4: enforce DESTROY_SESSION / DESTROY_CLIENTID semantics

### DIFF
--- a/src/server/nfs/nfs4_proc_destroy_clientid.c
+++ b/src/server/nfs/nfs4_proc_destroy_clientid.c
@@ -17,16 +17,27 @@ chimera_nfs4_destroy_clientid(
     struct DESTROY_CLIENTID4args     *args   = &argop->opdestroy_clientid;
     struct DESTROY_CLIENTID4res      *res    = &resop->opdestroy_clientid;
 
-    /* Pass state_table + vfs_thread so nfs4_client_unregister can tear
-     * down the unified state hierarchy (owners, states, dup'd VFS
-     * handles) along with the nfs4_client record.  Previously this leaked
-     * the unified hierarchy on every DESTROY_CLIENTID. */
-    nfs4_client_unregister(&shared->nfs4_shared_clients,
-                           &shared->nfs4_state_table,
-                           thread->vfs_thread,
-                           args->dca_clientid);
+    /* RFC 8881 §18.50.3: when preceded by SEQUENCE, DESTROY_CLIENTID must be
+     * the final operation; otherwise it must be the sole operation. */
+    if (req->seen_sequence) {
+        if (req->index != req->args_compound->num_argarray - 1) {
+            res->dcr_status = NFS4ERR_NOT_ONLY_OP;
+            chimera_nfs4_compound_complete(req, res->dcr_status);
+            return;
+        }
+    } else if (req->args_compound->num_argarray != 1) {
+        res->dcr_status = NFS4ERR_NOT_ONLY_OP;
+        chimera_nfs4_compound_complete(req, res->dcr_status);
+        return;
+    }
 
-    res->dcr_status = NFS4_OK;
+    /* NFS4ERR_STALE_CLIENTID for an unknown clientid, NFS4ERR_CLIENTID_BUSY
+     * if it still owns sessions, else tear the record (and its unified state
+     * hierarchy) down. */
+    res->dcr_status = nfs4_client_destroy_clientid(&shared->nfs4_shared_clients,
+                                                   &shared->nfs4_state_table,
+                                                   thread->vfs_thread,
+                                                   args->dca_clientid);
 
-    chimera_nfs4_compound_complete(req, NFS4_OK);
+    chimera_nfs4_compound_complete(req, res->dcr_status);
 } /* chimera_nfs4_destroy_clientid */

--- a/src/server/nfs/nfs4_proc_destroy_session.c
+++ b/src/server/nfs/nfs4_proc_destroy_session.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs4_proc_destroy_session.c
+++ b/src/server/nfs/nfs4_proc_destroy_session.c
@@ -16,6 +16,19 @@ chimera_nfs4_destroy_session(
     struct DESTROY_SESSION4args      *args   = &argop->opdestroy_session;
     struct DESTROY_SESSION4res       *res    = &resop->opdestroy_session;
 
+    /* RFC 8881 §18.37.3: when preceded by SEQUENCE, DESTROY_SESSION must be
+     * the final operation; otherwise it must be the sole operation. */
+    if (req->seen_sequence) {
+        if (req->index != req->args_compound->num_argarray - 1) {
+            res->dsr_status = NFS4ERR_NOT_ONLY_OP;
+            chimera_nfs4_compound_complete(req, res->dsr_status);
+            return;
+        }
+    } else if (req->args_compound->num_argarray != 1) {
+        res->dsr_status = NFS4ERR_NOT_ONLY_OP;
+        chimera_nfs4_compound_complete(req, res->dsr_status);
+        return;
+    }
 
     nfs4_destroy_session(
         &shared->nfs4_shared_clients,

--- a/src/server/nfs/nfs4_session.c
+++ b/src/server/nfs/nfs4_session.c
@@ -480,6 +480,44 @@ nfs4_client_create_session_cache(
     pthread_mutex_unlock(&table->nfs4_ct_lock);
 } /* nfs4_client_create_session_cache */
 
+nfsstat4
+nfs4_client_destroy_clientid(
+    struct nfs4_client_table  *table,
+    struct nfs_state_table    *state_table,
+    struct chimera_vfs_thread *vfs_thread,
+    uint64_t                   client_id)
+{
+    struct nfs4_client *c;
+    struct nfs_client  *unified;
+
+    pthread_mutex_lock(&table->nfs4_ct_lock);
+
+    HASH_FIND(nfs4_client_hh_by_id, table->nfs4_ct_clients_by_id,
+              &client_id, sizeof(client_id), c);
+
+    if (!c) {
+        pthread_mutex_unlock(&table->nfs4_ct_lock);
+        return NFS4ERR_STALE_CLIENTID;
+    }
+
+    /* RFC 8881 §18.50.3: a client that still owns sessions cannot be
+     * destroyed -- the client must DESTROY_SESSION them first. */
+    if (nfs4_client_has_session_locked(table, client_id)) {
+        pthread_mutex_unlock(&table->nfs4_ct_lock);
+        return NFS4ERR_CLIENTID_BUSY;
+    }
+
+    unified = nfs4_client_remove_locked(table, c);
+
+    pthread_mutex_unlock(&table->nfs4_ct_lock);
+
+    if (unified) {
+        nfs_client_destroy(unified, state_table, vfs_thread);
+    }
+
+    return NFS4_OK;
+} /* nfs4_client_destroy_clientid */
+
 bool
 nfs4_client_confirm(
     struct nfs4_client_table *table,

--- a/src/server/nfs/nfs4_session.h
+++ b/src/server/nfs/nfs4_session.h
@@ -289,6 +289,16 @@ nfs4_client_create_session_cache(
     const struct channel_attrs4 *fore,
     const struct channel_attrs4 *back);
 
+/* DESTROY_CLIENTID (RFC 8881 §18.50): returns NFS4ERR_STALE_CLIENTID if no
+ * such client, NFS4ERR_CLIENTID_BUSY if it still owns sessions, else removes
+ * the record (tearing down its unified state hierarchy) and returns NFS4_OK. */
+nfsstat4
+nfs4_client_destroy_clientid(
+    struct nfs4_client_table  *table,
+    struct nfs_state_table    *state_table,
+    struct chimera_vfs_thread *vfs_thread,
+    uint64_t                   client_id);
+
 /* Mark a client record confirmed (first successful CREATE_SESSION).  If the
  * record supersedes an older one (client reboot), the older record and its
  * sessions are torn down and its state hierarchy is returned via


### PR DESCRIPTION
## Summary

Stacked on #298. Implements the RFC 8881 §18.50 / §18.37 semantics for client and session teardown.

`DESTROY_CLIENTID` previously tore the record down unconditionally and always returned `NFS4_OK`. Now:
- unknown clientid → `NFS4ERR_STALE_CLIENTID`
- clientid that still owns sessions → `NFS4ERR_CLIENTID_BUSY` (the client must `DESTROY_SESSION` them first)
- otherwise the record (and its unified state hierarchy) is removed; a second destroy yields `NFS4ERR_STALE_CLIENTID`

Both `DESTROY_SESSION` and `DESTROY_CLIENTID` now enforce operation placement (RFC 8881 §18.37.3 / §18.50.3): when preceded by `SEQUENCE` the op must be the final operation in the COMPOUND; otherwise it must be the sole operation. Violations return `NFS4ERR_NOT_ONLY_OP`.

## Verification

- pynfs `st_destroy_clientid` (memfs, 4.1): 2/8 → 8/8
- pynfs `st_destroy_session`: 2/7 → 4/7; the remaining failures are the ganesha-flagged connection-binding test (`testDestroy`, needs `NFS4ERR_CONN_NOT_BOUND_TO_SESSION`) and two delegation-callback tests, all out of scope here
- No regression in the posix/cthon NFS4 suites (which exercise DESTROY_SESSION at unmount)

## Note

The earlier commits here are #297/#298; this PR will show only its own diff once those merge and the branch is rebased.