### PR TITLE
nfs4: SEQUENCE maxoperations and RECLAIM_COMPLETE idempotency

### DIFF
--- a/src/server/nfs/nfs4_proc_reclaim_complete.c
+++ b/src/server/nfs/nfs4_proc_reclaim_complete.c
@@ -13,7 +13,19 @@ chimera_nfs4_reclaim_complete(
     struct nfs_argop4                *argop,
     struct nfs_resop4                *resop)
 {
-    struct RECLAIM_COMPLETE4res *res = &resop->opreclaim_complete;
+    struct RECLAIM_COMPLETE4args *args = &argop->opreclaim_complete;
+    struct RECLAIM_COMPLETE4res  *res  = &resop->opreclaim_complete;
+
+    /* RFC 8881 §18.51.4: a second *global* (rca_one_fs == FALSE)
+     * RECLAIM_COMPLETE for the same client is NFS4ERR_COMPLETE_ALREADY.  The
+     * per-filesystem variant (rca_one_fs == TRUE) does not set that flag. */
+    if (!args->rca_one_fs && req->session &&
+        nfs4_client_mark_reclaim_complete(&thread->shared->nfs4_shared_clients,
+                                          req->session->nfs4_session_clientid)) {
+        res->rcr_status = NFS4ERR_COMPLETE_ALREADY;
+        chimera_nfs4_compound_complete(req, res->rcr_status);
+        return;
+    }
 
     /* RFC 8881 §18.51 / RFC 7530 §10.2.5: client signals end of reclaim
      * activity.  Drop the per-client recovery marker.  When persistence

--- a/src/server/nfs/nfs4_proc_sequence.c
+++ b/src/server/nfs/nfs4_proc_sequence.c
@@ -63,6 +63,17 @@ chimera_nfs4_sequence(
         return;
     }
 
+    /* RFC 8881 §2.10.6.4: a COMPOUND with more operations than the session's
+     * negotiated fore-channel ca_maxoperations (SEQUENCE counts as one) is
+     * rejected with NFS4ERR_TOO_MANY_OPS. */
+    if (session->nfs4_session_fore_attrs.ca_maxoperations &&
+        req->args_compound->num_argarray >
+        session->nfs4_session_fore_attrs.ca_maxoperations) {
+        res->sr_status = NFS4ERR_TOO_MANY_OPS;
+        chimera_nfs4_compound_complete(req, NFS4ERR_TOO_MANY_OPS);
+        return;
+    }
+
     res->sr_status = NFS4_OK;
     memcpy(res->sr_resok4.sr_sessionid, session->nfs4_session_id,
            NFS4_SESSIONID_SIZE);

--- a/src/server/nfs/nfs4_session.c
+++ b/src/server/nfs/nfs4_session.c
@@ -480,6 +480,29 @@ nfs4_client_create_session_cache(
     pthread_mutex_unlock(&table->nfs4_ct_lock);
 } /* nfs4_client_create_session_cache */
 
+bool
+nfs4_client_mark_reclaim_complete(
+    struct nfs4_client_table *table,
+    uint64_t                  client_id)
+{
+    struct nfs4_client *c;
+    bool                already = false;
+
+    pthread_mutex_lock(&table->nfs4_ct_lock);
+
+    HASH_FIND(nfs4_client_hh_by_id, table->nfs4_ct_clients_by_id,
+              &client_id, sizeof(client_id), c);
+
+    if (c) {
+        already                         = c->nfs4_client_reclaim_complete;
+        c->nfs4_client_reclaim_complete = 1;
+    }
+
+    pthread_mutex_unlock(&table->nfs4_ct_lock);
+
+    return already;
+} /* nfs4_client_mark_reclaim_complete */
+
 nfsstat4
 nfs4_client_destroy_clientid(
     struct nfs4_client_table  *table,

--- a/src/server/nfs/nfs4_session.h
+++ b/src/server/nfs/nfs4_session.h
@@ -145,6 +145,9 @@ struct nfs4_client {
      * preserved across a CREATE_SESSION retransmit, which no client relies on. */
     struct channel_attrs4 nfs4_client_cs_reply_fore;
     struct channel_attrs4 nfs4_client_cs_reply_back;
+    /* Set once the client has issued RECLAIM_COMPLETE; a second one is
+     * NFS4ERR_COMPLETE_ALREADY (RFC 8881 §18.51.4). */
+    uint8_t               nfs4_client_reclaim_complete;
     /* Unified state hierarchy.  Created when this nfs4_client is first
      * registered; freed when the nfs4_client is unregistered or the table
      * is torn down.  See nfs4_state.h. */
@@ -288,6 +291,14 @@ nfs4_client_create_session_cache(
     uint32_t                     flags,
     const struct channel_attrs4 *fore,
     const struct channel_attrs4 *back);
+
+/* Mark a client's RECLAIM_COMPLETE.  Returns true if the client had already
+ * completed reclaim (caller returns NFS4ERR_COMPLETE_ALREADY), false on the
+ * first call (now recorded). */
+bool
+nfs4_client_mark_reclaim_complete(
+    struct nfs4_client_table *table,
+    uint64_t                  client_id);
 
 /* DESTROY_CLIENTID (RFC 8881 §18.50): returns NFS4ERR_STALE_CLIENTID if no
  * such client, NFS4ERR_CLIENTID_BUSY if it still owns sessions, else removes


### PR DESCRIPTION
## Summary

Stacked on #298 → #299. Two small NFSv4.1 session-correctness fixes.

- **SEQUENCE** accepted COMPOUNDs with arbitrarily many operations. It now rejects a COMPOUND whose operation count exceeds the session's negotiated fore-channel `ca_maxoperations` with `NFS4ERR_TOO_MANY_OPS` (RFC 8881 §2.10.6.4).
- **RECLAIM_COMPLETE** never tracked completion, so a duplicate was silently accepted. A per-client reclaim-complete flag is now tracked, and a second *global* (`rca_one_fs == FALSE`) RECLAIM_COMPLETE returns `NFS4ERR_COMPLETE_ALREADY` (RFC 8881 §18.51.4). The per-filesystem variant (`rca_one_fs == TRUE`) does not set the flag.

## Verification

pynfs (memfs, 4.1): `st_sequence` SEQ7 (`testTooManyOps`) now passes; `st_reclaim_complete` RECC4 (`testDoubleRECC`) now passes (RECC1/RECC2 still pass). No regression in the posix/cthon NFS4 suites.

Remaining out-of-scope failures: `st_sequence` SEQ6 (`testRequestTooBig`, needs runtime request-size enforcement) and SEQ9b (`testReplayCache002`, needs SEQUENCE reply-byte DRC caching); `st_reclaim_complete` RECC3 (`testOpenBeforeRECC`, per-client grace, lease-adjacent).

## Note

Earlier commits here are #297/#298/#299; this PR will show only its own diff once those merge and the branch is rebased.