### PR TITLE
nfs4: validate stateid seqid on LOCK and OPEN_DOWNGRADE

### DIFF
--- a/src/server/nfs/nfs4_proc_lock.c
+++ b/src/server/nfs/nfs4_proc_lock.c
@@ -255,6 +255,21 @@ chimera_nfs4_lock(
                 return;
             }
             pthread_mutex_unlock(&oo->lock);
+
+            /* RFC 7530 §9.1.4.2: the supplied open stateid must not be a
+             * superseded (old) or never-issued seqid. */
+            status = nfs4_stateid_check_seqid(
+                open_state->seqid,
+                args->locker.open_owner.open_stateid.seqid);
+            if (status != NFS4_OK) {
+                nfs_state_table_release(table, open_state,
+                                        NFS4_SLOT_TYPE_OPEN,
+                                        thread->vfs_thread);
+                res->status = status;
+                chimera_nfs4_compound_complete(req, res->status);
+                return;
+            }
+
             req->lock_4_0_open_owner = oo;
             req->lock_4_0_lock_owner = lock_owner;
         }
@@ -338,6 +353,22 @@ chimera_nfs4_lock(
                 return;
             }
             pthread_mutex_unlock(&lo->lock);
+
+            /* RFC 7530 §9.1.4.2: the supplied lock stateid must not be a
+             * superseded (old) or never-issued seqid. */
+            status = nfs4_stateid_check_seqid(
+                lock_state->seqid,
+                args->locker.lock_owner.lock_stateid.seqid);
+            if (status != NFS4_OK) {
+                nfs_state_table_release(table, lock_state,
+                                        NFS4_SLOT_TYPE_LOCK,
+                                        thread->vfs_thread);
+                req->nfs_state_ref = NULL;
+                res->status        = status;
+                chimera_nfs4_compound_complete(req, res->status);
+                return;
+            }
+
             req->lock_4_0_lock_owner = lo;
         }
     }

--- a/src/server/nfs/nfs4_proc_open_downgrade.c
+++ b/src/server/nfs/nfs4_proc_open_downgrade.c
@@ -75,6 +75,19 @@ chimera_nfs4_open_downgrade(
             chimera_nfs4_compound_complete(req, res->status);
             return;
         }
+
+        /* RFC 7530 §9.1.4.2: reject a superseded (old) or never-issued
+         * stateid seqid. */
+        status = nfs4_stateid_check_seqid(open_state->seqid,
+                                          args->open_stateid.seqid);
+        if (status != NFS4_OK) {
+            pthread_mutex_unlock(&owner->lock);
+            nfs_state_table_release(table, open_state, NFS4_SLOT_TYPE_OPEN,
+                                    thread->vfs_thread);
+            res->status = status;
+            chimera_nfs4_compound_complete(req, res->status);
+            return;
+        }
     }
 
     /* RFC 7530 §16.19.4: new bits must be a non-empty subset of current. */

--- a/src/server/nfs/nfs4_stateid.h
+++ b/src/server/nfs/nfs4_stateid.h
@@ -85,6 +85,31 @@ nfs4_stateid_decode(
         ((uint32_t) p[10] << 8) | p[11];
 } /* nfs4_stateid_decode */
 
+/*
+ * RFC 7530 §9.1.4.2 seqid validation for a (non-special) NFSv4.0 stateid: the
+ * presented seqid is compared against the state's current seqid.  A smaller
+ * seqid is a stale reference to a superseded stateid (NFS4ERR_OLD_STATEID); a
+ * larger one was never issued (NFS4ERR_BAD_STATEID).  A zero seqid means "use
+ * the most current" and always matches.  4.1+ does not carry this seqid
+ * coupling, so callers gate this on minorversion 0.
+ */
+static inline nfsstat4
+nfs4_stateid_check_seqid(
+    uint32_t cur_seqid,
+    uint32_t sid_seqid)
+{
+    if (sid_seqid == 0) {
+        return NFS4_OK;
+    }
+    if (sid_seqid < cur_seqid) {
+        return NFS4ERR_OLD_STATEID;
+    }
+    if (sid_seqid > cur_seqid) {
+        return NFS4ERR_BAD_STATEID;
+    }
+    return NFS4_OK;
+} /* nfs4_stateid_check_seqid */
+
 static inline int
 nfs4_stateid_is_special(const struct stateid4 *sid)
 {


### PR DESCRIPTION
## Summary

The stateid lookup validated the encoded generation (`NFS4ERR_STALE_STATEID`) and type but never the **seqid**, so a stale reference to a superseded stateid was silently accepted.

This adds the RFC 7530 §9.1.4.2 seqid check — `NFS4ERR_OLD_STATEID` for a seqid older than the state's current seqid, `NFS4ERR_BAD_STATEID` for one that was never issued (seqid 0 means "use current" and always matches) — and applies it on the NFSv4.0 state-mutating paths:

- **LOCK**, for both the open-stateid presented by a new lock-owner and the lock-stateid of a subsequent lock under an existing lock-owner
- **OPEN_DOWNGRADE**

The check runs only on the new-request path (after the owner-seqid replay short-circuit), so legitimate retransmits still replay their cached reply. It is gated on minor version 0; NFSv4.1+ does not carry this seqid coupling.

## Verification

pynfs (memfs, 4.0): `st_lock` LOCK9a/9b/9c (`testOldLockStateid`, `testOldOpenStateid`, `testOldOpenStateid2`) and `st_opendowngrade` OPDG7 (`testOldStateid`) now pass. No regression in `open`/`opendowngrade`/`lock` (the existing `testBadSeqid`/`testBadStateid` still pass) or in the posix/cthon NFS4 suites (all 83 memfs posix tests pass).