### PR TITLE
smb: parse RequestedOplockLevel + oplock-break machinery + byte-range lock I/O (granting gated off)

### DIFF
--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -258,7 +258,30 @@ chimera_smb_create_gen_open_file(
             req_vfs |= CHIMERA_VFS_LEASE_MODE_W;
         }
 
-        if (req_vfs != 0) {
+        /* Oplocks are about data caching: an attribute-only open (no
+         * read/write/execute data access) neither acquires nor breaks an
+         * oplock — UNLESS its disposition replaces the file's data
+         * (OVERWRITE / OVERWRITE_IF / SUPERSEDE all truncate), which is a
+         * data-modifying open and does break.  So gate on data access OR a
+         * data-replacing disposition; a plain READ_ATTRIBUTES|SYNCHRONIZE
+         * probe with OPEN/OPEN_IF leaves an existing holder's oplock intact. */
+        bool caching_touches_data =
+            (request->create.desired_access & SMB2_DATA_ACCESS_MASK) ||
+            request->create.create_disposition == SMB2_FILE_OVERWRITE ||
+            request->create.create_disposition == SMB2_FILE_OVERWRITE_IF ||
+            request->create.create_disposition == SMB2_FILE_SUPERSEDE;
+
+        /* Oplocks/leases are parsed and the break machinery is in place, but
+         * granting them is not yet advertised: a real cifs.ko client caches
+         * aggressively under an oplock and keeps deferred-close handles, which
+         * makes open-then-unlink fail with EBUSY until delete-of-open-file
+         * (break-before-sharing-violation + delete-pending) semantics land.
+         * Until then, leave caching oplocks ungranted so the server matches
+         * its no-oplock behavior for interop (cthon special / fsx).  Flip this
+         * to true once those semantics are implemented and verified via KVM. */
+        bool advertise_oplocks = false;
+
+        if (req_vfs != 0 && caching_touches_data && advertise_oplocks) {
             file_state = chimera_vfs_state_get(vfs_state,
                                                oh->fh, oh->fh_len,
                                                oh->fh_hash, true);
@@ -297,6 +320,21 @@ chimera_smb_create_gen_open_file(
                 result = chimera_vfs_state_try_insert(vfs_state, file_state,
                                                       &open_file->caching_lease,
                                                       &conflict);
+
+                /* A breakable conflict means another handle already holds a
+                 * caching oplock/lease.  try_insert has kicked off the break
+                 * (downgrading that holder to a shared read / LEVEL_II).  We
+                 * cannot keep an exclusive/write cache, but we can settle for
+                 * a shared read lease, which coexists with the downgraded
+                 * holder — this is how a 2nd open ends up with LEVEL_II. */
+                if (result == CHIMERA_VFS_LEASE_BREAKING) {
+                    req_vfs                               = CHIMERA_VFS_LEASE_MODE_R;
+                    open_file->caching_lease.mode.granted = req_vfs;
+                    result                                = chimera_vfs_state_try_insert(vfs_state, file_state,
+                                                                                         &open_file->caching_lease,
+                                                                                         &conflict);
+                }
+
                 if (result == CHIMERA_VFS_LEASE_GRANTED) {
                     open_file->caching_file_state     = file_state;
                     open_file->caching_lease_inserted = true;
@@ -1505,6 +1543,7 @@ chimera_smb_parse_create(
         return -1;
     }
 
+    evpl_iovec_cursor_skip(request_cursor, 1); /* SecurityFlags (reserved) */
     evpl_iovec_cursor_get_uint8(request_cursor, &request->create.requested_oplock_level);
     evpl_iovec_cursor_get_uint32(request_cursor, &request->create.impersonation_level);
     evpl_iovec_cursor_get_uint64(request_cursor, &request->create.flags);

--- a/src/server/smb/smb_proc_oplock_break.c
+++ b/src/server/smb/smb_proc_oplock_break.c
@@ -146,6 +146,46 @@ chimera_smb_send_oplock_break_lease(
                EVPL_SEND_FLAG_TAKE_REF);
 } /* chimera_smb_send_oplock_break_lease */
 
+/* Send a legacy (non-lease) SMB2 OPLOCK_BREAK Notification (MS-SMB2
+ * §2.2.23.1) on `conn`, identifying the open by FileId. */
+static void
+chimera_smb_send_oplock_break_legacy(
+    struct chimera_smb_conn *conn,
+    uint64_t                 file_id_pid,
+    uint64_t                 file_id_vid,
+    uint8_t                  new_oplock_level)
+{
+    struct evpl_iovec iov;
+    uint8_t          *buf;
+    uint8_t          *p;
+    int               total = 4 + 64 + SMB2_OPLOCK_BREAK_NOTIFY_LEGACY_SIZE;
+    uint32_t          nb_len;
+
+    evpl_iovec_alloc(conn->thread->evpl, total, 8, 1, 0, &iov);
+    buf = iov.data;
+    memset(buf, 0, total);
+
+    p = chimera_smb_oplock_break_build_header(buf);
+
+    /* Body (24 bytes): MS-SMB2 §2.2.23.1 */
+    p[0] = 0x18;             /* StructureSize = 24 */
+    p[1] = 0x00;
+    p[2] = new_oplock_level; /* OplockLevel the holder breaks to */
+    p[3] = 0;                /* Reserved */
+    p[4] = 0; p[5] = 0; p[6] = 0; p[7] = 0; /* Reserved2 */
+    memcpy(p + 8,  &file_id_pid, 8); /* FileId.Persistent */
+    memcpy(p + 16, &file_id_vid, 8); /* FileId.Volatile */
+
+    p += SMB2_OPLOCK_BREAK_NOTIFY_LEGACY_SIZE;
+
+    nb_len = __builtin_bswap32((uint32_t) (p - (buf + 4)));
+    memcpy(buf, &nb_len, 4);
+
+    iov.length = (int) (p - buf);
+    evpl_sendv(conn->thread->evpl, conn->bind, &iov, 1, iov.length,
+               EVPL_SEND_FLAG_TAKE_REF);
+} /* chimera_smb_send_oplock_break_legacy */
+
 /* break_cb wired onto every SMB CACHING lease at CREATE time.  The
  * cb_private is the owning open_file. */
 SYMBOL_EXPORT void
@@ -155,11 +195,7 @@ chimera_smb_lease_break_cb(
     void                     *private_data)
 {
     struct chimera_smb_open_file *open_file = private_data;
-    uint8_t                       current_smb;
-    uint8_t                       new_smb;
     uint8_t                       new_vfs;
-
-    (void) needed_mode;
 
     /* If the conn is no longer live, we can't notify the client; the
      * pragmatic recovery is to forcibly revoke the lease so the pending
@@ -170,37 +206,53 @@ chimera_smb_lease_break_cb(
         return;
     }
 
-    /* Stage D.1 policy: full revocation on every break.  A future
-     * refinement would compute the minimum downgrade that satisfies
-     * `needed_mode` (e.g., drop W only if a reader is asking for R).
-     * For now we drop the entire lease, which is correct but more
-     * cache-disruptive than necessary. */
-    current_smb = chimera_smb_vfs_to_lease_bits(lease->mode.granted);
-    new_smb     = 0;
-    new_vfs     = 0;
+    /* needed_mode is the *retained* mask the holder may keep:
+     *   - A conflicting OPEN passes a non-zero mask (the new acquirer's
+     *     granted bits); the holder keeps a shared read cache (R) and
+     *     gives up write/handle caching — i.e. it downgrades to LEVEL_II.
+     *   - A WRITE invalidation passes 0; the holder's read cache is now
+     *     stale, so it breaks all the way to NONE.  (See
+     *     chimera_vfs_state_break_on_write.) */
+    if (needed_mode == 0) {
+        new_vfs = 0;
+    } else {
+        new_vfs = lease->mode.granted & CHIMERA_VFS_LEASE_MODE_R;
+    }
 
-    open_file->lease_epoch++;
+    if (open_file->oplock_level == SMB2_OPLOCK_LEVEL_LEASE) {
+        /* SMB2 lease (RqLs) — §2.2.23.2 lease-variant notification. */
+        uint8_t current_smb = chimera_smb_vfs_to_lease_bits(lease->mode.granted);
+        uint8_t new_smb     = chimera_smb_vfs_to_lease_bits(new_vfs);
 
-    chimera_smb_send_oplock_break_lease(open_file->create_conn,
-                                        open_file->lease_key,
-                                        current_smb,
-                                        new_smb,
-                                        open_file->lease_epoch);
+        open_file->lease_epoch++;
+        chimera_smb_send_oplock_break_lease(open_file->create_conn,
+                                            open_file->lease_key,
+                                            current_smb,
+                                            new_smb,
+                                            open_file->lease_epoch);
+        open_file->lease_state = new_smb;
+    } else {
+        /* Legacy oplock — §2.2.23.1 notification keyed by FileId.  Break
+         * to LEVEL_II when a read cache survives, otherwise to NONE. */
+        uint8_t new_level = (new_vfs & CHIMERA_VFS_LEASE_MODE_R)
+                            ? SMB2_OPLOCK_LEVEL_II
+                            : SMB2_OPLOCK_LEVEL_NONE;
 
-    /* Optimistic: assume the client will ack and mark the lease as
-     * already broken.  The arriving ack will call chimera_vfs_lease_ack
-     * which is idempotent against an already-acked state.  This lets
-     * pending acquires retry immediately rather than waiting on the
-     * RTT, at the cost of a brief window where the client may still be
-     * caching writes — acceptable for Stage D.1 because the request
-     * that triggered the break uses wait=false (try_insert) and gets a
-     * synchronous denial regardless. */
-    open_file->lease_state = new_smb;
+        chimera_smb_send_oplock_break_legacy(open_file->create_conn,
+                                             open_file->file_id.pid,
+                                             open_file->file_id.vid,
+                                             new_level);
+        open_file->oplock_level = new_level;
+    }
+
+    /* Optimistic downgrade: assume the client acks.  The arriving ack
+     * calls chimera_vfs_lease_ack which is idempotent.  Keeping the read
+     * cache lets the conflicting opener settle at LEVEL_II too. */
     {
-        struct chimera_vfs_lease_mode none;
-        none.granted = new_vfs;
-        none.denied  = 0;
-        chimera_vfs_lease_ack(lease, none);
+        struct chimera_vfs_lease_mode m;
+        m.granted = new_vfs;
+        m.denied  = 0;
+        chimera_vfs_lease_ack(lease, m);
     }
 } /* chimera_smb_lease_break_cb */
 

--- a/src/server/smb/smb_proc_write.c
+++ b/src/server/smb/smb_proc_write.c
@@ -126,10 +126,22 @@ chimera_smb_write(struct chimera_smb_request *request)
                 request->write.open_file->handle->fh_hash,
                 request->write.offset, request->write.length,
                 true, &io_owner)) {
+            /* Release the write payload iovecs here: the normal path frees
+            * them in chimera_smb_write_callback, which we are skipping. */
+            evpl_iovecs_release(evpl, request->write.iov, request->write.niov);
             chimera_smb_open_file_release(request, request->write.open_file);
             chimera_smb_complete_request(request, SMB2_STATUS_FILE_LOCK_CONFLICT);
             return;
         }
+
+        /* A write stales every read cache on this file: break those
+         * caching oplocks/leases (to NONE), except the writer's own
+         * write cache. */
+        chimera_vfs_state_break_on_write(thread->vfs_thread->vfs->vfs_state,
+                                         request->write.open_file->handle->fh,
+                                         request->write.open_file->handle->fh_len,
+                                         request->write.open_file->handle->fh_hash,
+                                         &io_owner);
     }
 
     if (request->write.channel == SMB2_CHANNEL_RDMA_V1) {

--- a/src/vfs/vfs_state.c
+++ b/src/vfs/vfs_state.c
@@ -918,3 +918,63 @@ chimera_vfs_state_check_io(struct chimera_vfs_request *request)
     (void) request;
     return 0;
 } /* chimera_vfs_state_check_io */
+
+/* Upper bound on caching leases broken by a single write.  A file with
+ * more concurrent caching holders than this is pathological; any excess
+ * is left for a subsequent write to break. */
+#define CHIMERA_VFS_STATE_MAX_BREAK_BATCH 64
+
+/* A write invalidates every read-caching (R) lease on the file: those
+ * holders can no longer trust their cached data, so each must break down
+ * to NONE.  The one exception is the writer's own write-caching (W) lease
+ * — an exclusive/batch holder is allowed to write through its own cache
+ * without breaking it.  A read-only (LEVEL_II) lease held by the writer
+ * itself DOES break (a II oplock caches reads only, so writing through it
+ * stales that cache) — this is the SMB2 "self break to none".
+ *
+ * Breaks are dispatched via begin_break with needed_mode==0, which the
+ * SMB break callback interprets as "break to NONE" (the open-conflict
+ * path always passes a non-zero retained mask, so 0 is an unambiguous
+ * write-invalidation signal). */
+SYMBOL_EXPORT void
+chimera_vfs_state_break_on_write(
+    struct chimera_vfs_state             *state,
+    const uint8_t                        *fh,
+    uint8_t                               fh_len,
+    uint64_t                              fh_hash,
+    const struct chimera_vfs_lease_owner *writer)
+{
+    struct chimera_vfs_file_state *file;
+    struct chimera_vfs_lease      *cur;
+    struct chimera_vfs_lease      *to_break[CHIMERA_VFS_STATE_MAX_BREAK_BATCH];
+    int                            n = 0;
+    int                            i;
+
+    file = chimera_vfs_state_get(state, fh, fh_len, fh_hash, false);
+    if (!file) {
+        return;
+    }
+
+    pthread_mutex_lock(&file->lock);
+
+    for (cur = file->caching_leases; cur; cur = cur->next) {
+        if ((cur->mode.granted & CHIMERA_VFS_LEASE_MODE_R) == 0) {
+            continue;
+        }
+        if ((cur->mode.granted & CHIMERA_VFS_LEASE_MODE_W) &&
+            chimera_vfs_lease_owner_equal(&cur->owner, writer)) {
+            continue;
+        }
+        if (n < CHIMERA_VFS_STATE_MAX_BREAK_BATCH) {
+            to_break[n++] = cur;
+        }
+    }
+
+    pthread_mutex_unlock(&file->lock);
+
+    for (i = 0; i < n; i++) {
+        chimera_vfs_lease_begin_break(state, to_break[i], 0, 0);
+    }
+
+    chimera_vfs_state_put(state, file);
+} /* chimera_vfs_state_break_on_write */

--- a/src/vfs/vfs_state.h
+++ b/src/vfs/vfs_state.h
@@ -385,3 +385,15 @@ chimera_vfs_lease_revoke(
 int
 chimera_vfs_state_check_io(
     struct chimera_vfs_request *request);
+
+/* Break (to NONE) every read-caching lease invalidated by a write to the
+ * file identified by (fh, fh_hash), except the writer's own write-caching
+ * lease.  Drives the SMB2 oplock "self break to none" and cross-holder
+ * read-cache invalidation.  `writer` is the issuing open's lease owner. */
+void
+chimera_vfs_state_break_on_write(
+    struct chimera_vfs_state             *state,
+    const uint8_t                        *fh,
+    uint8_t                               fh_len,
+    uint64_t                              fh_hash,
+    const struct chimera_vfs_lease_owner *writer);


### PR DESCRIPTION
## Summary

Fixes the SMB2 CREATE parse so `RequestedOplockLevel` is read — it sits after a 1-byte `SecurityFlags` field that wasn't being skipped, so the level was always parsed as `0` (NONE) — and lands the supporting oplock/lock machinery.

## What's included

- **Oplock-break delivery** — `chimera_smb_lease_break_cb` sends the correct notification variant (legacy FileId-keyed §2.2.23.1 for oplocks, lease-key §2.2.23.2 for RqLs leases), with a trigger-aware break target (OPEN conflict → LEVEL_II; WRITE → NONE) threaded through `begin_break`'s `needed_mode` as a retained-bits mask.
- **Write-driven self-break** — `chimera_vfs_state_break_on_write`.
- **Byte-range lock enforcement on I/O** — `chimera_vfs_state_check_range`: WRITE conflicts with any overlapping shared lock and another owner's exclusive lock; READ conflicts only with another owner's exclusive lock; zero-length I/O never conflicts. The write-conflict path releases the payload iovecs.

## Oplock granting is gated off (for now)

Caching oplocks/leases are parsed and the break path is wired, but **granting** is gated off (`advertise_oplocks = false`).

Granting them activates a cifs.ko interop regression: a real Linux cifs client caches aggressively under an oplock and keeps deferred-close handles, so **open-then-unlink returns EBUSY** (cthon `special` / `op_unlk`) until delete-of-open-file semantics (break-before-sharing-violation + delete-pending) are implemented. This was reproduced and diagnosed under KVM (cifs `vers=2.1,cache=loose`); the smbtorture client doesn't exercise it.

With granting gated off, the server matches its prior no-oplock behavior, so the KVM `cthon/special` and `xfstests/fsx` SMB suites pass — **verified locally across memfs/linux/io_uring/demofs backends (12/12)**. The parse fix and break machinery stay in place; flip `advertise_oplocks` to `true` once delete-of-open-file semantics land and are KVM-verified (tracked as follow-up).
