### PR TITLE
nfs4: validate the lock-owner clientid on LOCK and LOCKT

### DIFF
--- a/src/server/nfs/nfs4_proc_lock.c
+++ b/src/server/nfs/nfs4_proc_lock.c
@@ -215,6 +215,18 @@ chimera_nfs4_lock(
         open_state = state_void;
         client     = open_state->owner->client;
 
+        /* RFC 7530 §9.1.4: the new lock-owner's clientid must be the client
+         * that holds the open being locked.  A mismatched (e.g. stale)
+         * clientid is a bad stateid. */
+        if (req->minorversion == 0 &&
+            lo_args->clientid != client->client_id) {
+            nfs_state_table_release(table, open_state, NFS4_SLOT_TYPE_OPEN,
+                                    thread->vfs_thread);
+            res->status = NFS4ERR_BAD_STATEID;
+            chimera_nfs4_lock_finish(req, res->status);
+            return;
+        }
+
         /* RFC 7530 §9.1.4: lock_owner is scoped to the client.  Find or
          * create one and link the new lock_state to both the lock_owner and
          * the open_state. */

--- a/src/server/nfs/nfs4_proc_lock.c
+++ b/src/server/nfs/nfs4_proc_lock.c
@@ -255,6 +255,21 @@ chimera_nfs4_lock(
                 return;
             }
             pthread_mutex_unlock(&oo->lock);
+
+            /* RFC 7530 §9.1.4.2: the supplied open stateid must not be a
+             * superseded (old) or never-issued seqid. */
+            status = nfs4_stateid_check_seqid(
+                open_state->seqid,
+                args->locker.open_owner.open_stateid.seqid);
+            if (status != NFS4_OK) {
+                nfs_state_table_release(table, open_state,
+                                        NFS4_SLOT_TYPE_OPEN,
+                                        thread->vfs_thread);
+                res->status = status;
+                chimera_nfs4_compound_complete(req, res->status);
+                return;
+            }
+
             req->lock_4_0_open_owner = oo;
             req->lock_4_0_lock_owner = lock_owner;
         }
@@ -338,6 +353,22 @@ chimera_nfs4_lock(
                 return;
             }
             pthread_mutex_unlock(&lo->lock);
+
+            /* RFC 7530 §9.1.4.2: the supplied lock stateid must not be a
+             * superseded (old) or never-issued seqid. */
+            status = nfs4_stateid_check_seqid(
+                lock_state->seqid,
+                args->locker.lock_owner.lock_stateid.seqid);
+            if (status != NFS4_OK) {
+                nfs_state_table_release(table, lock_state,
+                                        NFS4_SLOT_TYPE_LOCK,
+                                        thread->vfs_thread);
+                req->nfs_state_ref = NULL;
+                res->status        = status;
+                chimera_nfs4_compound_complete(req, res->status);
+                return;
+            }
+
             req->lock_4_0_lock_owner = lo;
         }
     }

--- a/src/server/nfs/nfs4_proc_lockt.c
+++ b/src/server/nfs/nfs4_proc_lockt.c
@@ -8,6 +8,7 @@
 #include "nfs4_procs.h"
 #include "nfs4_status.h"
 #include "nfs4_state.h"
+#include "nfs4_session.h"
 #include "vfs/vfs_procs.h"
 #include "vfs/vfs_release.h"
 #include "vfs/vfs_state.h"
@@ -98,12 +99,27 @@ chimera_nfs4_lockt(
     struct nfs_argop4                *argop,
     struct nfs_resop4                *resop)
 {
-    struct LOCKT4res *res = &resop->oplockt;
+    struct LOCKT4args *args = &argop->oplockt;
+    struct LOCKT4res  *res  = &resop->oplockt;
 
     if (req->fhlen == 0) {
         res->status = NFS4ERR_NOFILEHANDLE;
         chimera_nfs4_compound_complete(req, res->status);
         return;
+    }
+
+    /* RFC 7530 §9.1.4: the lock-owner names a clientid; reject one the server
+     * has no record of.  4.1+ identifies the client via the session instead. */
+    if (req->minorversion == 0) {
+        struct nfs4_session *s = nfs4_session_find_by_clientid(
+            &thread->shared->nfs4_shared_clients, args->owner.clientid);
+        if (s) {
+            nfs4_session_put(s);
+        } else {
+            res->status = NFS4ERR_STALE_CLIENTID;
+            chimera_nfs4_compound_complete(req, res->status);
+            return;
+        }
     }
 
     /* LOCKT operates on CURRENT_FH - open it temporarily to validate. */

--- a/src/server/nfs/nfs4_proc_open_downgrade.c
+++ b/src/server/nfs/nfs4_proc_open_downgrade.c
@@ -75,6 +75,19 @@ chimera_nfs4_open_downgrade(
             chimera_nfs4_compound_complete(req, res->status);
             return;
         }
+
+        /* RFC 7530 §9.1.4.2: reject a superseded (old) or never-issued
+         * stateid seqid. */
+        status = nfs4_stateid_check_seqid(open_state->seqid,
+                                          args->open_stateid.seqid);
+        if (status != NFS4_OK) {
+            pthread_mutex_unlock(&owner->lock);
+            nfs_state_table_release(table, open_state, NFS4_SLOT_TYPE_OPEN,
+                                    thread->vfs_thread);
+            res->status = status;
+            chimera_nfs4_compound_complete(req, res->status);
+            return;
+        }
     }
 
     /* RFC 7530 §16.19.4: new bits must be a non-empty subset of current. */

--- a/src/server/nfs/nfs4_stateid.h
+++ b/src/server/nfs/nfs4_stateid.h
@@ -85,6 +85,31 @@ nfs4_stateid_decode(
         ((uint32_t) p[10] << 8) | p[11];
 } /* nfs4_stateid_decode */
 
+/*
+ * RFC 7530 §9.1.4.2 seqid validation for a (non-special) NFSv4.0 stateid: the
+ * presented seqid is compared against the state's current seqid.  A smaller
+ * seqid is a stale reference to a superseded stateid (NFS4ERR_OLD_STATEID); a
+ * larger one was never issued (NFS4ERR_BAD_STATEID).  A zero seqid means "use
+ * the most current" and always matches.  4.1+ does not carry this seqid
+ * coupling, so callers gate this on minorversion 0.
+ */
+static inline nfsstat4
+nfs4_stateid_check_seqid(
+    uint32_t cur_seqid,
+    uint32_t sid_seqid)
+{
+    if (sid_seqid == 0) {
+        return NFS4_OK;
+    }
+    if (sid_seqid < cur_seqid) {
+        return NFS4ERR_OLD_STATEID;
+    }
+    if (sid_seqid > cur_seqid) {
+        return NFS4ERR_BAD_STATEID;
+    }
+    return NFS4_OK;
+} /* nfs4_stateid_check_seqid */
+
 static inline int
 nfs4_stateid_is_special(const struct stateid4 *sid)
 {


### PR DESCRIPTION
## Summary

Stacked on #302. NFSv4.0 `LOCK` (new lock-owner) and `LOCKT` carry a clientid inside the lock-owner, but the server never validated it.

- `LOCK` with a new lock-owner whose clientid does not match the client that holds the open being locked now returns `NFS4ERR_BAD_STATEID`.
- `LOCKT` naming a clientid the server has no record of now returns `NFS4ERR_STALE_CLIENTID`.

Both checks are gated on minor version 0; NFSv4.1+ identifies the client via the session.

## Verification

pynfs (memfs, 4.0): `st_lock` LOCK10 (`testStaleClientid`) and `st_lockt` LKT9 (`testStaleClientid`) now pass. No regression in the posix/cthon NFS4 suites (all 83 memfs posix tests pass).

## Note

The first commit here is #302; this PR will show only its own diff once #302 merges and the branch is rebased.