### PR TITLE
smb: integrate Microsoft WPTS MS-SMB2 server conformance tests

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,6 +11,9 @@ ARG ENABLE_FIO=1
 ARG ENABLE_CLAUDE=1
 ARG ENABLE_CODEX=1
 ARG ENABLE_UV=1
+ARG ENABLE_WPTS=1
+# Pinned Microsoft Windows Protocol Test Suites (WPTS) FileServer release.
+ARG WPTS_VERSION=4.26.3.0
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -29,7 +32,7 @@ RUN apt-get -y update && \
     net-tools tshark tcpdump uuid-dev iproute2 man-db manpages-dev ca-certificates ssh libjansson-dev libclang-rt-18-dev llvm wget \
     libxxhash-dev liburcu-dev librdmacm-dev liburing-dev libaio-dev libunwind-dev librocksdb-dev libcurl4-openssl-dev clangd uthash-dev libnuma-dev \
     libcurl4-openssl-dev build-essential ruby-full autoconf automake make libtool pkg-config libs3-dev gh npm reuse libssl-dev openssl \
-    libkrb5-3 libkrb5-dev libgssapi-krb5-2 libwbclient-dev curl jq \
+    libkrb5-3 libkrb5-dev libgssapi-krb5-2 libwbclient-dev curl jq libicu-dev \
     krb5-kdc krb5-admin-server krb5-user python3-pip python3-setuptools \
     samba samba-ad-dc samba-ad-provision samba-vfs-modules smbclient && \
     gem install jekyll bundler
@@ -86,4 +89,20 @@ RUN apt-get -y update && \
 
 RUN if [ "$ENABLE_UV" = "1" ] ; then \
     curl -LsSf https://astral.sh/uv/install.sh | sh ; \
+    fi
+
+# .NET 8 + Microsoft Windows Protocol Test Suites (WPTS) FileServer suite, used
+# by the MS-SMB2 server conformance ctests (src/server/smb/tests). WPTS speaks
+# SMB2 from its own managed stack, so it runs host-side in a netns against the
+# chimera daemon -- no VM needed. CMake auto-detects /opt/dotnet and /opt/wpts.
+ENV DOTNET_ROOT=/opt/dotnet
+RUN if [ "$ENABLE_WPTS" = "1" ] ; then \
+    curl -sSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh && \
+    bash /tmp/dotnet-install.sh --channel 8.0 --install-dir /opt/dotnet && \
+    ln -sf /opt/dotnet/dotnet /usr/local/bin/dotnet && \
+    rm -f /tmp/dotnet-install.sh && \
+    mkdir -p /opt/wpts && \
+    curl -sSL "https://github.com/microsoft/WindowsProtocolTestSuites/releases/download/${WPTS_VERSION}/FileServer-TestSuite-ServerEP.tar.gz" -o /tmp/wpts.tar.gz && \
+    tar -C /opt/wpts -xzf /tmp/wpts.tar.gz && \
+    rm -f /tmp/wpts.tar.gz ; \
     fi

--- a/scripts/wpts_smb_test_wrapper.sh
+++ b/scripts/wpts_smb_test_wrapper.sh
@@ -1,0 +1,187 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+#
+# SPDX-License-Identifier: Unlicense
+
+# Usage: wpts_smb_test_wrapper.sh <chimera_binary> <backend> <test_filter>
+#
+# Runs Microsoft's Windows Protocol Test Suites (WPTS) File Server / MS-SMB2
+# server test suite against a standalone chimera SMB server. Unlike the KVM
+# tests, WPTS speaks SMB2 from its own managed (.NET) stack, so no VM / kernel
+# CIFS client is needed -- the driver and the daemon both live in an isolated
+# network namespace and talk over TCP/445.
+#
+# 1. Generates a chimera config exposing the share names WPTS expects
+# 2. Creates a network namespace with the SUT IP (10.0.0.1)
+# 3. Starts the chimera daemon in the netns (SMB on 10.0.0.1:445)
+# 4. Stages our pinned .ptfconfig files into the WPTS Bin dir
+# 5. Runs `dotnet vstest` with the requested TestCategory filter
+# 6. Captures the TRX result + vstest exit code and cleans up
+#
+# Required environment:
+#   WPTS_BIN_DIR  Path to the extracted WPTS FileServer "Bin" directory
+#   DOTNET        Path to the dotnet executable
+# Optional:
+#   WPTS_PTFCONFIG_DIR  Dir holding our *.deployment.ptfconfig fixtures
+#                       (defaults to <repo>/src/server/smb/tests/wpts)
+#   WPTS_RESULT_DIR     Where to copy the TRX result (defaults to session dir)
+
+set -u
+
+CHIMERA_BINARY=$1; shift
+BACKEND=$1; shift
+TEST_FILTER="$1"; shift || true
+
+: "${WPTS_BIN_DIR:?WPTS_BIN_DIR must point at the WPTS FileServer Bin dir}"
+: "${DOTNET:?DOTNET must point at the dotnet executable}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WPTS_PTFCONFIG_DIR="${WPTS_PTFCONFIG_DIR:-${SCRIPT_DIR}/../src/server/smb/tests/wpts}"
+
+SUT_IP="10.0.0.1"
+NETNS_NAME="wpts_smb_$$_$(date +%s%N)"
+DUMMY_IF="wpts0"
+BUILD_DIR=$(dirname "$(dirname "$CHIMERA_BINARY")")
+SESSION_DIR=$(mktemp -d "${BUILD_DIR}/wpts_smb_session_XXXXXX")
+CONFIG_FILE="${SESSION_DIR}/chimera.json"
+CHIMERA_LOG="${SESSION_DIR}/chimera_stderr.log"
+RESULT_DIR="${WPTS_RESULT_DIR:-${SESSION_DIR}/results}"
+CHIMERA_PID=""
+
+# WPTS-required share names. Each gets its own VFS mount so the share root
+# exists and is isolated (mirrors how the KVM config mounts at /share).
+SHARES=(SMBBasic SMBEncrypted FileShare ShareForceLevel2)
+
+cleanup() {
+    if [ -n "$CHIMERA_PID" ]; then
+        kill "$CHIMERA_PID" 2>/dev/null || true
+        wait "$CHIMERA_PID" 2>/dev/null || true
+    fi
+    ip netns delete "${NETNS_NAME}" 2>/dev/null || true
+    rm -rf "$SESSION_DIR"
+}
+trap cleanup EXIT
+
+generate_config() {
+    local mounts="" shares="" sep=""
+    for share in "${SHARES[@]}"; do
+        local mpath="/"
+        case "$BACKEND" in
+            linux|io_uring)
+                mpath="${SESSION_DIR}/data/${share}"
+                mkdir -p "$mpath"
+                ;;
+        esac
+        mounts="${mounts}${sep}\"${share}\": {\"module\": \"${BACKEND}\", \"path\": \"${mpath}\"}"
+        shares="${shares}${sep}\"${share}\": {\"path\": \"/${share}\"}"
+        sep=",
+        "
+    done
+
+    cat > "$CONFIG_FILE" << EOF
+{
+    "server": {
+        "threads": 4,
+        "delegation_threads": 4,
+        "external_portmap": false
+    },
+    "mounts": {
+        ${mounts}
+    },
+    "shares": {
+        ${shares}
+    },
+    "users": [
+        {
+            "username": "administrator",
+            "smbpasswd": "Password01!",
+            "uid": 0,
+            "gid": 0
+        }
+    ]
+}
+EOF
+}
+
+generate_config
+
+ulimit -l unlimited 2>/dev/null || true
+
+# Network namespace with the SUT IP on a dummy interface. The driver connects
+# to 10.0.0.1 from inside the same netns (locally routed).
+ip netns add "${NETNS_NAME}"
+ip netns exec "${NETNS_NAME}" ip link set lo up
+ip netns exec "${NETNS_NAME}" ip link add "${DUMMY_IF}" type dummy
+ip netns exec "${NETNS_NAME}" ip addr add "${SUT_IP}/24" dev "${DUMMY_IF}"
+ip netns exec "${NETNS_NAME}" ip link set "${DUMMY_IF}" up
+
+# Start the chimera daemon inside the netns
+ip netns exec "${NETNS_NAME}" env \
+    ASAN_OPTIONS="detect_leaks=0:handle_abort=2:print_cmdline=1" \
+    "$CHIMERA_BINARY" ${CHIMERA_DEBUG:+-d} -c "$CONFIG_FILE" \
+    >"$CHIMERA_LOG" 2>&1 &
+CHIMERA_PID=$!
+
+# Wait for SMB port to be ready
+ready=0
+for i in $(seq 1 50); do
+    if ip netns exec "${NETNS_NAME}" bash -c "echo > /dev/tcp/${SUT_IP}/445" 2>/dev/null; then
+        ready=1
+        break
+    fi
+    if ! kill -0 "$CHIMERA_PID" 2>/dev/null; then
+        echo "chimera daemon exited prematurely"
+        echo "=== Chimera stderr ==="
+        cat "$CHIMERA_LOG"
+        exit 1
+    fi
+    sleep 0.1
+done
+if [ "$ready" != "1" ]; then
+    echo "chimera SMB port ${SUT_IP}:445 never became ready"
+    cat "$CHIMERA_LOG"
+    exit 1
+fi
+
+# Stage our pinned ptfconfig fixtures into the WPTS Bin dir. WPTS auto-loads
+# the *.deployment.ptfconfig files sitting next to the test DLL.
+cp -f "${WPTS_PTFCONFIG_DIR}/CommonTestSuite.deployment.ptfconfig" \
+      "${WPTS_PTFCONFIG_DIR}/MS-SMB2_ServerTestSuite.deployment.ptfconfig" \
+      "${WPTS_BIN_DIR}/"
+
+mkdir -p "$RESULT_DIR"
+
+FILTER_ARGS=()
+if [ -n "${TEST_FILTER}" ]; then
+    FILTER_ARGS=(--TestCaseFilter:"${TEST_FILTER}")
+fi
+
+# Run the suite from inside the netns so it can reach the SUT IP
+ip netns exec "${NETNS_NAME}" env \
+    "$DOTNET" vstest "${WPTS_BIN_DIR}/MS-SMB2_ServerTestSuite.dll" \
+        "${FILTER_ARGS[@]}" \
+        --logger:"trx;LogFileName=SMB2TestResult.trx" \
+        --ResultsDirectory:"${RESULT_DIR}"
+VSTEST_RC=$?
+
+echo "=== vstest exit code: ${VSTEST_RC} ==="
+
+# Persist the daemon log alongside the TRX so a crash/abort is recoverable
+# after the session dir is cleaned up.
+cp -f "$CHIMERA_LOG" "${RESULT_DIR}/chimera_stderr.log" 2>/dev/null || true
+
+# A daemon that died during the run is a finding in its own right: fail the
+# test even if vstest itself reported success.
+if ! kill -0 "$CHIMERA_PID" 2>/dev/null; then
+    wait "$CHIMERA_PID" 2>/dev/null
+    DAEMON_RC=$?
+    echo "=== chimera daemon exited during run (rc=${DAEMON_RC}) ==="
+    tail -80 "$CHIMERA_LOG" 2>/dev/null || true
+    CHIMERA_PID=""
+    [ "$VSTEST_RC" = "0" ] && VSTEST_RC=70
+elif [ "$VSTEST_RC" != "0" ]; then
+    echo "=== Chimera stderr (last 80 lines) ==="
+    tail -80 "$CHIMERA_LOG" 2>/dev/null || true
+fi
+
+exit ${VSTEST_RC}

--- a/scripts/wpts_smb_test_wrapper.sh
+++ b/scripts/wpts_smb_test_wrapper.sh
@@ -156,8 +156,15 @@ if [ -n "${TEST_FILTER}" ]; then
     FILTER_ARGS=(--TestCaseFilter:"${TEST_FILTER}")
 fi
 
-# Run the suite from inside the netns so it can reach the SUT IP
+# Run the suite from inside the netns so it can reach the SUT IP.
+# Suppress the .NET first-run experience (telemetry notice + dev-cert
+# generation): it pollutes output and writes to HOME, which may be unset or
+# read-only under ctest/CI.
 ip netns exec "${NETNS_NAME}" env \
+    DOTNET_CLI_TELEMETRY_OPTOUT=1 \
+    DOTNET_NOLOGO=1 \
+    DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1 \
+    HOME="${SESSION_DIR}" \
     "$DOTNET" vstest "${WPTS_BIN_DIR}/MS-SMB2_ServerTestSuite.dll" \
         "${FILTER_ARGS[@]}" \
         --logger:"trx;LogFileName=SMB2TestResult.trx" \

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -83,22 +83,62 @@ find_file(WPTS_SMB2_DLL MS-SMB2_ServerTestSuite.dll
           HINTS ${WPTS_FILESERVER_DIR} /opt/wpts/Bin
           NO_DEFAULT_PATH)
 
-if(CHIMERA_NETNS_TESTING AND WPTS_DOTNET AND WPTS_SMB2_DLL)
+# The WPTS .NET test host only runs reliably on x86_64. The arm64 CI builds run
+# under emulation, where the managed test host crashes ("Test host process
+# crashed") even though the chimera daemon is healthy. Gate to x86_64 until a
+# native arm64 runner is available.
+set(WPTS_ARCH_SUPPORTED FALSE)
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|amd64|AMD64)$")
+    set(WPTS_ARCH_SUPPORTED TRUE)
+endif()
+
+if(CHIMERA_NETNS_TESTING AND WPTS_DOTNET AND WPTS_SMB2_DLL AND WPTS_ARCH_SUPPORTED)
     get_filename_component(WPTS_BIN_DIR "${WPTS_SMB2_DLL}" DIRECTORY)
     set(CHIMERA_DAEMON $<TARGET_FILE:chimera>)
 
-    # Starter allowlist: BVT cases confirmed passing against the Phase-0 SMB2
-    # server. Grow this as features land and bugs (e.g. the compound
-    # double-completion crash in CHANGE_NOTIFY/QUERY_DIRECTORY) are fixed.
+    # Allowlist: MS-SMB2 cases confirmed green across repeated runs against the
+    # current SMB2 server (memfs backend). Grow this as features land. Tests
+    # that only pass with an unmerged server fix (e.g. the QUERY_DIRECTORY
+    # double-completion fix for QueryDir_Reopen_OnFile) are intentionally
+    # enabled in that fix's PR, not here.
     set(WPTS_SMB2_ALLOWLIST
-        BVT_SMB2Basic_QueryDir_Reopen_OnDir
+        BVT_Compound_RelatedRequests
+        BVT_Compound_UnRelatedRequests
+        BVT_CreateClose_CreateAndCloseDirectory
+        BVT_CreateClose_CreateAndCloseFile
+        BVT_Negotiate_Compatible_Wildcard
+        BVT_Negotiate_SMB21
+        BVT_Negotiate_SMB30
+        BVT_Negotiate_SigningEnabled
+        BVT_SMB2Basic_ChangeNotify_ChangeAttributes
+        BVT_SMB2Basic_ChangeNotify_ChangeCreation
+        BVT_SMB2Basic_ChangeNotify_ChangeDirName
+        BVT_SMB2Basic_ChangeNotify_ChangeFileName
+        BVT_SMB2Basic_ChangeNotify_ChangeLastAccess
+        BVT_SMB2Basic_ChangeNotify_ChangeLastWrite
+        BVT_SMB2Basic_ChangeNotify_NonDirectoryFile
         BVT_SMB2Basic_QueryAndSet_FileInfo
-        BVT_SMB2Basic_Query_FileAllInformation)
+        BVT_SMB2Basic_QueryDir_Reopen_OnDir
+        BVT_SMB2Basic_QueryDir_Reopen_OnEmptyDir_NoFilesReturned
+        BVT_SMB2Basic_Query_FileAllInformation
+        BVT_SessionMgmt_NewSession
+        BVT_SessionMgmt_Reauthentication
+        BVT_SessionMgmt_ReconnectSessionSetup
+        BVT_Signing
+        BVT_TreeMgmt_TreeConnectAndDisconnect
+        BVT_ValidateNegotiateInfo
+        CreateClose_CreateAndCloseDirWithDotDir
+        CreateClose_CreateAndCloseFileWithDotDir
+        Negotiate_SMB311_ContextID_NetName
+        Negotiate_SMB311_InvalidCipher
+        Negotiate_SMB311_IsTransportCapabilitiesSupported
+        Signing_VerifyAesGmacSigning
+        TreeMgmt_SMB311_CLUSTER_RECONNECT)
 
     foreach(tc ${WPTS_SMB2_ALLOWLIST})
         add_test(NAME chimera/server/smb/wpts/memfs/${tc}
             COMMAND ${CMAKE_SOURCE_DIR}/scripts/wpts_smb_test_wrapper.sh
-                    ${CHIMERA_DAEMON} memfs "FullyQualifiedName=Microsoft.Protocols.TestSuites.FileSharing.SMB2.TestSuite.SMB2Basic.${tc}")
+                    ${CHIMERA_DAEMON} memfs "Name=${tc}")
         # The wrapper stages our ptfconfig into the shared WPTS Bin dir, so
         # serialize WPTS tests against each other to avoid a write race.
         set_tests_properties(chimera/server/smb/wpts/memfs/${tc} PROPERTIES
@@ -109,6 +149,9 @@ if(CHIMERA_NETNS_TESTING AND WPTS_DOTNET AND WPTS_SMB2_DLL)
     endforeach()
 
     message(STATUS "WPTS MS-SMB2 tests: enabled (${WPTS_BIN_DIR}, ${WPTS_DOTNET})")
+elseif(CHIMERA_NETNS_TESTING AND WPTS_DOTNET AND WPTS_SMB2_DLL AND NOT WPTS_ARCH_SUPPORTED)
+    message(STATUS "WPTS MS-SMB2 tests: disabled "
+            "(unsupported arch ${CMAKE_SYSTEM_PROCESSOR}; .NET test host needs x86_64)")
 else()
     message(STATUS "WPTS MS-SMB2 tests: disabled "
             "(need CHIMERA_NETNS_TESTING + dotnet + -DWPTS_FILESERVER_DIR=<Bin>)")

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -65,3 +65,51 @@ if(CHIMERA_NETNS_TESTING)
         COMMAND ${CMAKE_SOURCE_DIR}/scripts/netns_test_wrapper.sh
                 ${CMAKE_CURRENT_BINARY_DIR}/rest_user_manip_test)
 endif()
+
+# ---------------------------------------------------------------------------
+# Microsoft Windows Protocol Test Suites (WPTS) -- MS-SMB2 server conformance
+#
+# WPTS speaks SMB2 from its own managed (.NET) stack, so it runs host-side in
+# a network namespace against the chimera daemon -- no KVM/kernel CIFS client
+# needed (unlike the cthon/xfstests KVM suites). The .NET runtime and the
+# extracted FileServer "Bin" directory are external prerequisites, located via
+# cache variables (or auto-detected on PATH / common install dirs).
+#
+#   cmake -DWPTS_FILESERVER_DIR=/opt/wpts/Bin -DWPTS_DOTNET=/opt/dotnet/dotnet ...
+#
+# The chimera daemon binary is required to launch the SUT.
+find_program(WPTS_DOTNET dotnet HINTS /opt/dotnet /usr/lib/dotnet /usr/share/dotnet)
+find_file(WPTS_SMB2_DLL MS-SMB2_ServerTestSuite.dll
+          HINTS ${WPTS_FILESERVER_DIR} /opt/wpts/Bin
+          NO_DEFAULT_PATH)
+
+if(CHIMERA_NETNS_TESTING AND WPTS_DOTNET AND WPTS_SMB2_DLL)
+    get_filename_component(WPTS_BIN_DIR "${WPTS_SMB2_DLL}" DIRECTORY)
+    set(CHIMERA_DAEMON $<TARGET_FILE:chimera>)
+
+    # Starter allowlist: BVT cases confirmed passing against the Phase-0 SMB2
+    # server. Grow this as features land and bugs (e.g. the compound
+    # double-completion crash in CHANGE_NOTIFY/QUERY_DIRECTORY) are fixed.
+    set(WPTS_SMB2_ALLOWLIST
+        BVT_SMB2Basic_QueryDir_Reopen_OnDir
+        BVT_SMB2Basic_QueryAndSet_FileInfo
+        BVT_SMB2Basic_Query_FileAllInformation)
+
+    foreach(tc ${WPTS_SMB2_ALLOWLIST})
+        add_test(NAME chimera/server/smb/wpts/memfs/${tc}
+            COMMAND ${CMAKE_SOURCE_DIR}/scripts/wpts_smb_test_wrapper.sh
+                    ${CHIMERA_DAEMON} memfs "FullyQualifiedName=Microsoft.Protocols.TestSuites.FileSharing.SMB2.TestSuite.SMB2Basic.${tc}")
+        # The wrapper stages our ptfconfig into the shared WPTS Bin dir, so
+        # serialize WPTS tests against each other to avoid a write race.
+        set_tests_properties(chimera/server/smb/wpts/memfs/${tc} PROPERTIES
+            LABELS "smb;wpts"
+            TIMEOUT 180
+            RESOURCE_LOCK wpts_smb_bin
+            ENVIRONMENT "WPTS_BIN_DIR=${WPTS_BIN_DIR};DOTNET=${WPTS_DOTNET}")
+    endforeach()
+
+    message(STATUS "WPTS MS-SMB2 tests: enabled (${WPTS_BIN_DIR}, ${WPTS_DOTNET})")
+else()
+    message(STATUS "WPTS MS-SMB2 tests: disabled "
+            "(need CHIMERA_NETNS_TESTING + dotnet + -DWPTS_FILESERVER_DIR=<Bin>)")
+endif()

--- a/src/server/smb/tests/wpts/CommonTestSuite.deployment.ptfconfig
+++ b/src/server/smb/tests/wpts/CommonTestSuite.deployment.ptfconfig
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+  SPDX-License-Identifier: Unlicense
+
+  Chimera deployment overrides for the WPTS File Server common config.
+  Workgroup topology: the chimera daemon is the SUT at 10.0.0.1, reached
+  over loopback-routed TCP inside an isolated network namespace. No domain
+  controller, NTLM auth only.
+
+  Capability flags reflect what the Phase-0 SMB2 server honestly negotiates
+  today: SMB 3.1.1 dialect + signing, but NO encryption / leasing /
+  multichannel / persistent handles. Widen these as features land.
+-->
+<TestSite xmlns="http://schemas.microsoft.com/windows/ProtocolsTest/2007/07/TestConfig"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://schemas.microsoft.com/windows/ProtocolsTest/2007/07/TestConfig http://schemas.microsoft.com/windows/ProtocolsTest/2007/07/TestConfig.xsd">
+  <Properties>
+    <Group name="Common">
+      <Property name="Timeout" value="20"/>
+      <Property name="LongerTimeout" value="120"/>
+      <Property name="RetryInterval" value="5"/>
+      <Property name="UnderlyingTransport" value="Tcp"/>
+      <Property name="TransportPort" value="445"/>
+
+      <!-- SUT identity (workgroup: DomainName == SutComputerName) -->
+      <Property name="SutComputerName" value="10.0.0.1"/>
+      <Property name="SutIPAddress" value="10.0.0.1"/>
+      <Property name="DomainName" value="10.0.0.1"/>
+      <Property name="DCServerComputerName" value=""/>
+
+      <!-- Credentials: matches the chimera smbpasswd user in the wrapper -->
+      <Property name="AdminUserName" value="administrator"/>
+      <Property name="NonAdminUserName" value=""/>
+      <Property name="GuestUserName" value=""/>
+      <Property name="PasswordForAllUsers" value="Password01!"/>
+
+      <!-- Share names provisioned by the wrapper -->
+      <Property name="BasicFileShare" value="SMBBasic"/>
+      <Property name="EncryptedFileShare" value=""/>
+      <Property name="CompressedFileShare" value=""/>
+      <Property name="CAShareName" value=""/>
+      <Property name="CAShareServerName" value=""/>
+
+      <!-- Driver NIC (single homed; same netns as the SUT) -->
+      <Property name="ClientNic1IPAddress" value="10.0.0.1"/>
+      <Property name="ClientNic2IPAddress" value=""/>
+
+      <Property name="Platform" value="NonWindows"/>
+
+      <!-- Dialect + auth -->
+      <Property name="MaxSmbVersionSupported" value="Smb311"/>
+      <Property name="MaxSmbVersionClientSupported" value="Smb311"/>
+      <Property name="IsSMB1NegotiateEnabled" value="false"/>
+      <Property name="SupportedSecurityPackage" value="Ntlm"/>
+      <Property name="UseServerGssToken" value="false"/>
+
+      <!-- Signing: supported (HMAC-SHA256). SMB 3.1.1 mandates signing, so
+           WPTS requires SendSignedRequest=true when MaxSmbVersionSupported is
+           Smb311. We still skip verifying the server's response signatures. -->
+      <Property name="SendSignedRequest" value="true"/>
+      <Property name="DisableVerifySignature" value="true"/>
+      <Property name="IsRequireMessageSigning" value="false"/>
+      <Property name="SupportedSigningAlgorithms" value="HMAC_SHA256"/>
+
+      <!-- Advanced features NOT yet honestly negotiated -->
+      <Property name="IsLeasingSupported" value="false"/>
+      <Property name="IsDirectoryLeasingSupported" value="false"/>
+      <Property name="IsMultiChannelCapable" value="false"/>
+      <Property name="IsPersistentHandlesSupported" value="false"/>
+      <Property name="IsEncryptionSupported" value="false"/>
+      <Property name="IsGlobalEncryptDataEnabled" value="false"/>
+      <Property name="IsGlobalRejectUnencryptedAccessEnabled" value="false"/>
+      <Property name="IsRDMATransformSupported" value="false"/>
+      <Property name="IsChainedCompressionSupported" value="false"/>
+      <Property name="IsMultiCreditSupported" value="true"/>
+      <Property name="SutSupportedEncryptionAlgorithms" value=""/>
+      <Property name="SupportedCompressionAlgorithms" value=""/>
+
+      <Property name="UnsupportedIoCtlCodes" value="FSCTL_OFFLOAD_READ;FSCTL_OFFLOAD_WRITE;FSCTL_FILE_LEVEL_TRIM"/>
+      <Property name="UnsupportedCreateContexts" value=""/>
+      <Property name="MaxResiliencyTimeout" value="300000"/>
+    </Group>
+  </Properties>
+</TestSite>

--- a/src/server/smb/tests/wpts/MS-SMB2_ServerTestSuite.deployment.ptfconfig
+++ b/src/server/smb/tests/wpts/MS-SMB2_ServerTestSuite.deployment.ptfconfig
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+  SPDX-License-Identifier: Unlicense
+
+  Chimera deployment overrides for the WPTS MS-SMB2 server test suite.
+  Most knobs live in the included CommonTestSuite.deployment.ptfconfig; this
+  file only carries SMB2-suite-specific properties and disables the cluster /
+  snapshot / ReFS-integrity features chimera does not implement.
+-->
+<TestSite xmlns="http://schemas.microsoft.com/windows/ProtocolsTest/2007/07/TestConfig"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://schemas.microsoft.com/windows/ProtocolsTest/2007/07/TestConfig http://schemas.microsoft.com/windows/ProtocolsTest/2007/07/TestConfig.xsd">
+  <Include>
+    <File name="CommonTestSuite.deployment.ptfconfig"/>
+  </Include>
+
+  <Properties>
+    <Group name="SMB2">
+      <Property name="WaitTimeoutInMilliseconds" value="8000"/>
+      <Property name="SutAlternativeIPAddress" value=""/>
+
+      <!-- Optional features chimera does not implement: leave blank to skip -->
+      <Property name="FileShareSupportingIntegrityInfo" value=""/>
+      <Property name="Symboliclink" value=""/>
+      <Property name="SymboliclinkInSubFolder" value=""/>
+      <Property name="NumberOfPreviousVersions" value=""/>
+      <Property name="ClusteredInfrastructureFileServerName" value=""/>
+      <Property name="InfrastructureRootShare" value=""/>
+
+      <Property name="DriverComputerName" value="chimera-driver"/>
+      <Property name="IsKB500139Installed" value="false"/>
+      <Property name="IsServerToClientNotificationsSupported" value="false"/>
+    </Group>
+  </Properties>
+</TestSite>


### PR DESCRIPTION
## Summary

Integrates Microsoft's [Windows Protocol Test Suites](https://github.com/microsoft/WindowsProtocolTestSuites) (WPTS) File Server / **MS-SMB2 server** conformance suite into the ctest harness — the gold-standard on-the-wire SMB2 conformance suite, considerably more rigorous than cthon.

**Key architecture point:** WPTS speaks SMB2 from its own managed (.NET) stack, so it runs **host-side in a network namespace** against the chimera daemon — no KVM / kernel CIFS client needed (unlike the cthon/xfstests KVM suites). This follows the existing `smbclient_auth_test` / boto3 netns pattern.

This PR lands the **harness plus a deliberately small allowlist** of cases that pass today. The plan is to grow the allowlist (and fix the bugs it surfaces) in follow-ups.

## What's here

- `scripts/wpts_smb_test_wrapper.sh` — generates a chimera config exposing the WPTS-named shares (one VFS mount each so the share root exists), starts the daemon in a netns on `10.0.0.1:445`, runs `dotnet vstest` with a `--TestCaseFilter`, persists the TRX + daemon log, and fails the test if the daemon dies mid-run.
- `src/server/smb/tests/wpts/*.deployment.ptfconfig` — pinned config: workgroup, `NonWindows`, NTLM, SMB 3.1.1, signing on, advanced features (encryption / leasing / multichannel / persistent handles) off to match what the server honestly negotiates today.
- CMake glue in `src/server/smb/tests/CMakeLists.txt`, gated on `CHIMERA_NETNS_TESTING` + `dotnet` + the WPTS suite DLL (auto-detected at `/opt/dotnet` and `/opt/wpts/Bin`; overridable via `-DWPTS_FILESERVER_DIR=` / `-DWPTS_DOTNET=`). WPTS tests take a `RESOURCE_LOCK` so they don't race on the shared Bin dir.
- `.devcontainer/Dockerfile` — installs .NET 8 and the pinned WPTS FileServer release (`ENABLE_WPTS`, `WPTS_VERSION=4.26.3.0`), plus `libicu` for the .NET runtime.

## Initial allowlist (BVT, memfs)

```
BVT_SMB2Basic_QueryDir_Reopen_OnDir
BVT_SMB2Basic_QueryAndSet_FileInfo
BVT_SMB2Basic_Query_FileAllInformation
```

`ctest -R smb/wpts` -> 3/3 pass.

## Follow-ups

The broader suite run is the triage backlog: most failures today are unimplemented features (change-notify delivery, `FileNormalizedNameInformation`, compression, durable/persistent handles, leasing). It also surfaced a real crash — a compound double-completion assertion at `src/server/smb/smb.c:562` on the CHANGE_NOTIFY / QUERY_DIRECTORY readdir path — which will be addressed separately.