### PR TITLE
nfs4: reject LOCKT on non-regular files

### DIFF
--- a/src/server/nfs/nfs4_proc_lock.c
+++ b/src/server/nfs/nfs4_proc_lock.c
@@ -215,6 +215,18 @@ chimera_nfs4_lock(
         open_state = state_void;
         client     = open_state->owner->client;
 
+        /* RFC 7530 §9.1.4: the new lock-owner's clientid must be the client
+         * that holds the open being locked.  A mismatched (e.g. stale)
+         * clientid is a bad stateid. */
+        if (req->minorversion == 0 &&
+            lo_args->clientid != client->client_id) {
+            nfs_state_table_release(table, open_state, NFS4_SLOT_TYPE_OPEN,
+                                    thread->vfs_thread);
+            res->status = NFS4ERR_BAD_STATEID;
+            chimera_nfs4_lock_finish(req, res->status);
+            return;
+        }
+
         /* RFC 7530 §9.1.4: lock_owner is scoped to the client.  Find or
          * create one and link the new lock_state to both the lock_owner and
          * the open_state. */

--- a/src/server/nfs/nfs4_proc_lock.c
+++ b/src/server/nfs/nfs4_proc_lock.c
@@ -255,6 +255,21 @@ chimera_nfs4_lock(
                 return;
             }
             pthread_mutex_unlock(&oo->lock);
+
+            /* RFC 7530 §9.1.4.2: the supplied open stateid must not be a
+             * superseded (old) or never-issued seqid. */
+            status = nfs4_stateid_check_seqid(
+                open_state->seqid,
+                args->locker.open_owner.open_stateid.seqid);
+            if (status != NFS4_OK) {
+                nfs_state_table_release(table, open_state,
+                                        NFS4_SLOT_TYPE_OPEN,
+                                        thread->vfs_thread);
+                res->status = status;
+                chimera_nfs4_compound_complete(req, res->status);
+                return;
+            }
+
             req->lock_4_0_open_owner = oo;
             req->lock_4_0_lock_owner = lock_owner;
         }
@@ -338,6 +353,22 @@ chimera_nfs4_lock(
                 return;
             }
             pthread_mutex_unlock(&lo->lock);
+
+            /* RFC 7530 §9.1.4.2: the supplied lock stateid must not be a
+             * superseded (old) or never-issued seqid. */
+            status = nfs4_stateid_check_seqid(
+                lock_state->seqid,
+                args->locker.lock_owner.lock_stateid.seqid);
+            if (status != NFS4_OK) {
+                nfs_state_table_release(table, lock_state,
+                                        NFS4_SLOT_TYPE_LOCK,
+                                        thread->vfs_thread);
+                req->nfs_state_ref = NULL;
+                res->status        = status;
+                chimera_nfs4_compound_complete(req, res->status);
+                return;
+            }
+
             req->lock_4_0_lock_owner = lo;
         }
     }

--- a/src/server/nfs/nfs4_proc_lockt.c
+++ b/src/server/nfs/nfs4_proc_lockt.c
@@ -8,6 +8,7 @@
 #include "nfs4_procs.h"
 #include "nfs4_status.h"
 #include "nfs4_state.h"
+#include "nfs4_session.h"
 #include "vfs/vfs_procs.h"
 #include "vfs/vfs_release.h"
 #include "vfs/vfs_state.h"
@@ -98,12 +99,27 @@ chimera_nfs4_lockt(
     struct nfs_argop4                *argop,
     struct nfs_resop4                *resop)
 {
-    struct LOCKT4res *res = &resop->oplockt;
+    struct LOCKT4args *args = &argop->oplockt;
+    struct LOCKT4res  *res  = &resop->oplockt;
 
     if (req->fhlen == 0) {
         res->status = NFS4ERR_NOFILEHANDLE;
         chimera_nfs4_compound_complete(req, res->status);
         return;
+    }
+
+    /* RFC 7530 §9.1.4: the lock-owner names a clientid; reject one the server
+     * has no record of.  4.1+ identifies the client via the session instead. */
+    if (req->minorversion == 0) {
+        struct nfs4_session *s = nfs4_session_find_by_clientid(
+            &thread->shared->nfs4_shared_clients, args->owner.clientid);
+        if (s) {
+            nfs4_session_put(s);
+        } else {
+            res->status = NFS4ERR_STALE_CLIENTID;
+            chimera_nfs4_compound_complete(req, res->status);
+            return;
+        }
     }
 
     /* LOCKT operates on CURRENT_FH - open it temporarily to validate. */

--- a/src/server/nfs/nfs4_proc_lockt.c
+++ b/src/server/nfs/nfs4_proc_lockt.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-only
 
 #include <string.h>
+#include <sys/stat.h>
 #include <xxhash.h>
 
 #include "nfs4_procs.h"
@@ -14,32 +15,35 @@
 #include "vfs/vfs_state.h"
 
 static void
-chimera_nfs4_lockt_open_complete(
-    enum chimera_vfs_error          error_code,
-    struct chimera_vfs_open_handle *handle,
-    void                           *private_data)
+chimera_nfs4_lockt_probe(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *attr,
+    void                     *private_data)
 {
-    struct nfs_request            *req       = private_data;
-    struct LOCKT4args             *args      = &req->args_compound->argarray[req->index].oplockt;
-    struct LOCKT4res              *res       = &req->res_compound.resarray[req->index].oplockt;
-    struct chimera_vfs_state      *vfs_state = req->thread->vfs->vfs_state;
-    struct chimera_vfs_file_state *file_state;
-    struct chimera_vfs_lease       probe;
-    struct chimera_vfs_lease      *conflict = NULL;
-    enum chimera_vfs_lease_result  result;
-    uint64_t                       vfs_length;
+    struct nfs_request             *req       = private_data;
+    struct LOCKT4args              *args      = &req->args_compound->argarray[req->index].oplockt;
+    struct LOCKT4res               *res       = &req->res_compound.resarray[req->index].oplockt;
+    struct chimera_vfs_open_handle *handle    = req->handle;
+    struct chimera_vfs_state       *vfs_state = req->thread->vfs->vfs_state;
+    struct chimera_vfs_file_state  *file_state;
+    struct chimera_vfs_lease        probe;
+    struct chimera_vfs_lease       *conflict = NULL;
+    enum chimera_vfs_lease_result   result;
+    uint64_t                        vfs_length;
 
     if (error_code != CHIMERA_VFS_OK) {
+        chimera_vfs_release(req->thread->vfs_thread, handle);
         res->status = chimera_nfs4_errno_to_nfsstat4(error_code);
         chimera_nfs4_compound_complete(req, res->status);
         return;
     }
 
-    /* RFC 7530 §16.11.4: same length rules as LOCK */
-    if (args->length == 0 ||
-        (args->length != UINT64_MAX && args->offset > UINT64_MAX - args->length)) {
+    /* RFC 7530 §16.11.4: byte-range locking is defined only for regular
+     * files.  A directory target is NFS4ERR_ISDIR; any other non-regular
+     * type is NFS4ERR_INVAL. */
+    if ((attr->va_set_mask & CHIMERA_VFS_ATTR_MODE) && !S_ISREG(attr->va_mode)) {
         chimera_vfs_release(req->thread->vfs_thread, handle);
-        res->status = NFS4ERR_INVAL;
+        res->status = S_ISDIR(attr->va_mode) ? NFS4ERR_ISDIR : NFS4ERR_INVAL;
         chimera_nfs4_compound_complete(req, res->status);
         return;
     }
@@ -90,6 +94,39 @@ chimera_nfs4_lockt_open_complete(
 
     /* LOCKT NFS4ERR_DENIED is a successful query result. */
     chimera_nfs4_compound_complete(req, res->status);
+} /* chimera_nfs4_lockt_probe */
+
+static void
+chimera_nfs4_lockt_open_complete(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *handle,
+    void                           *private_data)
+{
+    struct nfs_request *req  = private_data;
+    struct LOCKT4args  *args = &req->args_compound->argarray[req->index].oplockt;
+    struct LOCKT4res   *res  = &req->res_compound.resarray[req->index].oplockt;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        res->status = chimera_nfs4_errno_to_nfsstat4(error_code);
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    /* RFC 7530 §16.11.4: same length rules as LOCK */
+    if (args->length == 0 ||
+        (args->length != UINT64_MAX && args->offset > UINT64_MAX - args->length)) {
+        chimera_vfs_release(req->thread->vfs_thread, handle);
+        res->status = NFS4ERR_INVAL;
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    /* Fetch the target's type before probing -- LOCKT is only valid on a
+     * regular file (see chimera_nfs4_lockt_probe). */
+    req->handle = handle;
+    chimera_vfs_getattr(req->thread->vfs_thread, &req->cred, handle,
+                        CHIMERA_VFS_ATTR_MASK_STAT,
+                        chimera_nfs4_lockt_probe, req);
 } /* chimera_nfs4_lockt_open_complete */
 
 void

--- a/src/server/nfs/nfs4_proc_open_downgrade.c
+++ b/src/server/nfs/nfs4_proc_open_downgrade.c
@@ -75,6 +75,19 @@ chimera_nfs4_open_downgrade(
             chimera_nfs4_compound_complete(req, res->status);
             return;
         }
+
+        /* RFC 7530 §9.1.4.2: reject a superseded (old) or never-issued
+         * stateid seqid. */
+        status = nfs4_stateid_check_seqid(open_state->seqid,
+                                          args->open_stateid.seqid);
+        if (status != NFS4_OK) {
+            pthread_mutex_unlock(&owner->lock);
+            nfs_state_table_release(table, open_state, NFS4_SLOT_TYPE_OPEN,
+                                    thread->vfs_thread);
+            res->status = status;
+            chimera_nfs4_compound_complete(req, res->status);
+            return;
+        }
     }
 
     /* RFC 7530 §16.19.4: new bits must be a non-empty subset of current. */

--- a/src/server/nfs/nfs4_stateid.h
+++ b/src/server/nfs/nfs4_stateid.h
@@ -85,6 +85,31 @@ nfs4_stateid_decode(
         ((uint32_t) p[10] << 8) | p[11];
 } /* nfs4_stateid_decode */
 
+/*
+ * RFC 7530 §9.1.4.2 seqid validation for a (non-special) NFSv4.0 stateid: the
+ * presented seqid is compared against the state's current seqid.  A smaller
+ * seqid is a stale reference to a superseded stateid (NFS4ERR_OLD_STATEID); a
+ * larger one was never issued (NFS4ERR_BAD_STATEID).  A zero seqid means "use
+ * the most current" and always matches.  4.1+ does not carry this seqid
+ * coupling, so callers gate this on minorversion 0.
+ */
+static inline nfsstat4
+nfs4_stateid_check_seqid(
+    uint32_t cur_seqid,
+    uint32_t sid_seqid)
+{
+    if (sid_seqid == 0) {
+        return NFS4_OK;
+    }
+    if (sid_seqid < cur_seqid) {
+        return NFS4ERR_OLD_STATEID;
+    }
+    if (sid_seqid > cur_seqid) {
+        return NFS4ERR_BAD_STATEID;
+    }
+    return NFS4_OK;
+} /* nfs4_stateid_check_seqid */
+
 static inline int
 nfs4_stateid_is_special(const struct stateid4 *sid)
 {


### PR DESCRIPTION
## Summary

Stacked on #305. `LOCKT` operated on the current filehandle without checking its type, so a LOCKT against a directory, symlink, or special file was answered as though it were a regular file (returning `NFS4_OK`).

LOCKT now fetches the target's attributes and rejects a non-regular target per RFC 7530 §16.11.4: `NFS4ERR_ISDIR` for a directory, `NFS4ERR_INVAL` for any other non-regular type (symlink, block, char, fifo, socket).

## Verification

pynfs (memfs, 4.0): `st_lockt` is now 16/16 — LKT2a/2b/2c/2d/2f/2s (`testLink`/`testBlock`/`testChar`/`testDir`/`testFifo`/`testSocket`) all pass. No regression in the posix/cthon NFS4 suites (all 83 memfs posix tests pass). No memfs change was needed — the special-file objects already exist; only the type check was missing.

## Note

The earlier commits here are #302/#305; this PR will show only its own diff once those merge and the branch is rebased.