### PR TITLE
smb: fix QUERY_DIRECTORY double-completion crash on readdir error

### DIFF
--- a/src/server/smb/smb_proc_query_directory.c
+++ b/src/server/smb/smb_proc_query_directory.c
@@ -10,6 +10,20 @@
 #include "vfs/vfs_procs.h"
 #include "xxhash.h"
 
+static unsigned int
+chimera_smb_query_directory_status(enum chimera_vfs_error error_code)
+{
+    switch (error_code) {
+        case CHIMERA_VFS_OK:      return SMB2_STATUS_SUCCESS;
+        /* QUERY_DIRECTORY against a non-directory open: per MS-SMB2 3.3.5.18
+         * the server fails the request with STATUS_INVALID_PARAMETER. */
+        case CHIMERA_VFS_ENOTDIR: return SMB2_STATUS_INVALID_PARAMETER;
+        case CHIMERA_VFS_EACCES:
+        case CHIMERA_VFS_EPERM:   return SMB2_STATUS_ACCESS_DENIED;
+        default:                  return SMB2_STATUS_INTERNAL_ERROR;
+    } /* switch */
+} /* chimera_smb_query_directory_status */
+
 void
 chimera_smb_query_directory_readdir_complete(
     enum chimera_vfs_error          error_code,
@@ -29,7 +43,12 @@ chimera_smb_query_directory_readdir_complete(
     chimera_smb_open_file_release(request, request->query_directory.open_file);
 
     if (error_code != CHIMERA_VFS_OK) {
-        chimera_smb_complete_request(request, SMB2_STATUS_INTERNAL_ERROR);
+        /* Must return here: falling through would complete the request a
+         * second time, overrunning the compound's completion counter and
+         * tripping the compound_advance abort (smb.c). */
+        evpl_iovec_release(request->compound->thread->evpl, &request->query_directory.iov);
+        chimera_smb_complete_request(request, chimera_smb_query_directory_status(error_code));
+        return;
     }
 
     if (request->query_directory.output_length) {
@@ -39,7 +58,7 @@ chimera_smb_query_directory_readdir_complete(
         chimera_smb_complete_request(request, SMB2_STATUS_NO_MORE_FILES);
     }
 
-} /* chimera_smb_query_directory_readdir_complete */ /* chimera_smb_query_directory_readdir_complete */
+} /* chimera_smb_query_directory_readdir_complete */
 
 int
 chimera_smb_query_directory_readdir_callback(


### PR DESCRIPTION
## Summary

`chimera_smb_query_directory_readdir_complete()` completed the request on the readdir **error** path but didn't `return`, falling through and completing the *same* request a second time. The extra completion overruns the compound's completion counter and trips the assertion in `chimera_smb_compound_advance()`:

```
compound_advance: complete_requests = 2 num_requests = 1   (src/server/smb/smb.c)
```

This aborts the daemon (`SIGABRT`) whenever a `QUERY_DIRECTORY`'s readdir completes with an error — e.g. a `QUERY_DIRECTORY` issued against a **non-directory** open, or a readdir that fails on an async/block backend.

## Fix

- `return` after completing on the error path (the actual crash fix).
- Release the response iovec on that path (avoids a leak).
- Map the VFS error to a sensible SMB2 status instead of a blanket `INTERNAL_ERROR`: `ENOTDIR -> STATUS_INVALID_PARAMETER` (per [MS-SMB2] 3.3.5.18 for QUERY_DIRECTORY on a non-directory), `EACCES`/`EPERM -> STATUS_ACCESS_DENIED`.

## How it was found / verified

Surfaced by the Microsoft WPTS MS-SMB2 conformance suite (see #306 for the test harness). `BVT_SMB2Basic_QueryDir_Reopen_OnFile` previously crashed the daemon and now **passes**. Across the full MS-SMB2 run (memfs): crashes 1 -> 0, pass 31 -> 34, fail 72 -> 68, no regressions (the change only affects the readdir error path that previously aborted).

Note: this is the same `smb.c` assertion independently hit by the KVM Windows SMB harness on async backends (`demofs_*`, `cairn`) via `QUERY_DIRECTORY` — same root cause, fixed here.