### PR TITLE
nfs4: distinguish stale (rebooted) stateids from bad ones via an epoch

### DIFF
--- a/src/server/nfs/nfs4_proc_close.c
+++ b/src/server/nfs/nfs4_proc_close.c
@@ -22,7 +22,6 @@ chimera_nfs4_close(
     void                   *state_void;
     uint8_t                 state_type;
     nfsstat4                status;
-    uint32_t                client_short_id;
 
     status = nfs_state_table_acquire(table,
                                      &args->open_stateid,
@@ -76,12 +75,11 @@ chimera_nfs4_close(
      * stateid before destroying.  Destroy cascades through any lock_states
      * rooted on this open. */
     open_state->seqid += 1;
-    client_short_id    = owner ? (uint32_t) owner->client->client_id : 0;
 
     nfs4_stateid_encode(&res->open_stateid, open_state->seqid,
                         NFS4_STATEID_TYPE_OPEN,
                         open_state->shard, open_state->slot_idx,
-                        open_state->generation, client_short_id);
+                        open_state->generation, table->epoch);
 
     /* Record reply BEFORE destroying the state -- after destroy, the owner
      * may also be torn down by client teardown.  In practice the owner

--- a/src/server/nfs/nfs4_proc_lock.c
+++ b/src/server/nfs/nfs4_proc_lock.c
@@ -104,7 +104,6 @@ chimera_nfs4_lock_complete(
     struct nfs_lock_state    *lock_state = req->nfs_state_ref;
     struct nfs4_range_lease  *rl         = req->nfs_inflight_range;
     struct chimera_vfs_state *vfs_state  = req->thread->vfs->vfs_state;
-    uint32_t                  client_short_id;
 
     (void) granted;
 
@@ -122,11 +121,10 @@ chimera_nfs4_lock_complete(
             lock_state->seqid += 1;
         }
 
-        client_short_id = (uint32_t) lock_state->lock_owner->client->client_id;
         nfs4_stateid_encode(&res->resok4.lock_stateid, lock_state->seqid,
                             NFS4_STATEID_TYPE_LOCK,
                             lock_state->shard, lock_state->slot_idx,
-                            lock_state->generation, client_short_id);
+                            lock_state->generation, table->epoch);
 
         res->status = NFS4_OK;
 
@@ -292,7 +290,6 @@ chimera_nfs4_lock(
         chimera_vfs_dup_handle(thread->vfs_thread, handle);
 
         lock_state = nfs_lock_state_create(lock_owner, open_state, handle,
-                                           (uint32_t) client->client_id,
                                            table, &res->resok4.lock_stateid);
 
         /* Release the open_state acquire ref.  The lock_state holds its
@@ -309,7 +306,7 @@ chimera_nfs4_lock(
                             NFS4_STATEID_TYPE_LOCK,
                             lock_state->shard, lock_state->slot_idx,
                             lock_state->generation,
-                            (uint32_t) client->client_id);
+                            table->epoch);
         status = nfs_state_table_acquire(table, &lock_stateid_for_acquire,
                                          NFS4_SLOT_TYPE_LOCK,
                                          &state_void, &state_type);

--- a/src/server/nfs/nfs4_proc_locku.c
+++ b/src/server/nfs/nfs4_proc_locku.c
@@ -30,7 +30,6 @@ chimera_nfs4_locku(
     struct nfs_lock_owner    *lock_owner;
     struct nfs4_range_lease  *rl, *prev, *match;
     uint64_t                  vfs_length;
-    uint32_t                  client_short_id;
     nfsstat4                  status;
 
     /* RFC 7530 §16.12.3: current filehandle must be set */
@@ -132,11 +131,10 @@ chimera_nfs4_locku(
     free(match);
 
     lock_state->seqid += 1;
-    client_short_id    = (uint32_t) lock_owner->client->client_id;
     nfs4_stateid_encode(&res->lock_stateid, lock_state->seqid,
                         NFS4_STATEID_TYPE_LOCK,
                         lock_state->shard, lock_state->slot_idx,
-                        lock_state->generation, client_short_id);
+                        lock_state->generation, table->epoch);
     res->status = NFS4_OK;
 
     /* RFC 7530 §9.1.7: record cached reply for the lock_owner. */

--- a/src/server/nfs/nfs4_proc_open.c
+++ b/src/server/nfs/nfs4_proc_open.c
@@ -136,7 +136,7 @@ chimera_nfs4_open_install_state(
     if (existing) {
         nfs_open_state_coalesce(existing,
                                 args->share_access, args->share_deny,
-                                (uint32_t) client->client_id,
+                                &req->thread->shared->nfs4_state_table,
                                 out_stateid);
         chimera_vfs_release(req->thread->vfs_thread, handle);
         /* The SHARE reservation acquired on the first OPEN of this
@@ -151,7 +151,6 @@ chimera_nfs4_open_install_state(
                                           handle->fh, handle->fh_len,
                                           args->share_access, args->share_deny,
                                           handle,
-                                          (uint32_t) client->client_id,
                                           &req->thread->shared->nfs4_state_table,
                                           out_stateid);
 

--- a/src/server/nfs/nfs4_proc_open_confirm.c
+++ b/src/server/nfs/nfs4_proc_open_confirm.c
@@ -94,7 +94,7 @@ chimera_nfs4_open_confirm(
                         NFS4_STATEID_TYPE_OPEN,
                         open_state->shard, open_state->slot_idx,
                         open_state->generation,
-                        (uint32_t) owner->client->client_id);
+                        table->epoch);
 
     nfs4_replay_record(&owner->replay, args->seqid, OP_OPEN_CONFIRM,
                        NFS4_OK, &res->resok4.open_stateid);

--- a/src/server/nfs/nfs4_proc_open_downgrade.c
+++ b/src/server/nfs/nfs4_proc_open_downgrade.c
@@ -111,7 +111,7 @@ chimera_nfs4_open_downgrade(
                         NFS4_STATEID_TYPE_OPEN,
                         open_state->shard, open_state->slot_idx,
                         open_state->generation,
-                        (uint32_t) owner->client->client_id);
+                        table->epoch);
 
     if (is_v40) {
         owner->seqid = args->seqid;

--- a/src/server/nfs/nfs4_state.c
+++ b/src/server/nfs/nfs4_state.c
@@ -4,6 +4,7 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 
 #include "nfs4_state.h"
 #include "nfs_internal.h"
@@ -106,6 +107,13 @@ nfs_state_table_init(struct nfs_state_table *table)
     for (int i = 0; i < NFS_STATE_NUM_SHARDS; i++) {
         shard_init(&table->shards[i]);
     }
+
+    /* Per-instance epoch stamped into every stateid (see nfs4_stateid.h).
+     * Boot time makes it differ across restarts so stateids from a previous
+     * instance are recognised as stale.  Force the high bit set so it can
+     * never collide with the special all-zero/all-ones stateids or the small
+     * "old epoch" values pynfs's makeStaleId() uses. */
+    table->epoch = (uint32_t) time(NULL) | 0x80000000u;
 } /* nfs_state_table_init */
 
 void
@@ -241,8 +249,24 @@ state_table_lookup_locked(
         *out_type = NFS4_SLOT_TYPE_FREE;
     }
 
+    /* The special stateids (all-zero anonymous, all-ones read-bypass) are not
+     * resolvable concrete state -- callers that accept them handle them before
+     * calling here, so reaching the table with one is a bad stateid.  Checked
+     * before the epoch test so an all-zero stateid is not misread as a stale
+     * (wrong-epoch) one. */
+    if (nfs4_stateid_is_special(sid)) {
+        return NFS4ERR_BAD_STATEID;
+    }
+
     nfs4_stateid_decode(&view, sid);
 
+    /* RFC 7530 §9.1.4.2: a stateid whose epoch does not match this server
+     * instance was minted before a restart -- NFS4ERR_STALE_STATEID.  Checked
+     * before the structural fields so a "rebooted" stateid (whose other bytes
+     * are otherwise meaningless) is not misreported as merely bad. */
+    if (view.epoch != table->epoch) {
+        return NFS4ERR_STALE_STATEID;
+    }
     if (view.version != NFS4_STATEID_VERSION) {
         return NFS4ERR_BAD_STATEID;
     }
@@ -583,7 +607,6 @@ nfs_open_state_create(
     uint32_t                        share_access,
     uint32_t                        share_deny,
     struct chimera_vfs_open_handle *handle_dup,
-    uint32_t                        client_short_id,
     struct nfs_state_table         *table,
     struct stateid4                *out_stateid)
 {
@@ -623,7 +646,7 @@ nfs_open_state_create(
 
     nfs4_stateid_encode(out_stateid, state->seqid,
                         NFS4_STATEID_TYPE_OPEN, shard, slot_idx, gen,
-                        client_short_id);
+                        table->epoch);
     return state;
 } /* nfs_open_state_create */
 
@@ -677,11 +700,11 @@ nfs_client_check_share_conflict(
 
 void
 nfs_open_state_coalesce(
-    struct nfs_open_state *state,
-    uint32_t               share_access,
-    uint32_t               share_deny,
-    uint32_t               client_short_id,
-    struct stateid4       *out_stateid)
+    struct nfs_open_state  *state,
+    uint32_t                share_access,
+    uint32_t                share_deny,
+    struct nfs_state_table *table,
+    struct stateid4        *out_stateid)
 {
     state->share_access |= share_access;
     state->share_deny   |= share_deny;
@@ -690,7 +713,7 @@ nfs_open_state_coalesce(
     nfs4_stateid_encode(out_stateid, state->seqid,
                         NFS4_STATEID_TYPE_OPEN,
                         state->shard, state->slot_idx, state->generation,
-                        client_short_id);
+                        table->epoch);
 } /* nfs_open_state_coalesce */
 
 static void
@@ -782,7 +805,6 @@ nfs_lock_state_create(
     struct nfs_lock_owner          *lock_owner,
     struct nfs_open_state          *open_state,
     struct chimera_vfs_open_handle *handle_dup,
-    uint32_t                        client_short_id,
     struct nfs_state_table         *table,
     struct stateid4                *out_stateid)
 {
@@ -820,7 +842,7 @@ nfs_lock_state_create(
 
     nfs4_stateid_encode(out_stateid, state->seqid,
                         NFS4_STATEID_TYPE_LOCK, shard, slot_idx, gen,
-                        client_short_id);
+                        table->epoch);
     return state;
 } /* nfs_lock_state_create */
 

--- a/src/server/nfs/nfs4_state.h
+++ b/src/server/nfs/nfs4_state.h
@@ -293,6 +293,9 @@ struct nfs_state_shard {
 
 struct nfs_state_table {
     struct nfs_state_shard shards[NFS_STATE_NUM_SHARDS];
+    /* Per-server-instance epoch stamped into every stateid; see
+     * nfs4_stateid.h.  Set once at nfs_state_table_init. */
+    uint32_t               epoch;
 };
 
 /*
@@ -405,7 +408,6 @@ nfs_open_state_create(
     uint32_t                        share_access,
     uint32_t                        share_deny,
     struct chimera_vfs_open_handle *handle_dup,
-    uint32_t                        client_short_id,
     struct nfs_state_table         *table,
     struct stateid4                *out_stateid);
 
@@ -433,11 +435,11 @@ nfs_client_check_share_conflict(
  * write the (now-updated) stateid to `out_stateid`. */
 SYMBOL_EXPORT void
 nfs_open_state_coalesce(
-    struct nfs_open_state *state,
-    uint32_t               share_access,
-    uint32_t               share_deny,
-    uint32_t               client_short_id,
-    struct stateid4       *out_stateid);
+    struct nfs_open_state  *state,
+    uint32_t                share_access,
+    uint32_t                share_deny,
+    struct nfs_state_table *table,
+    struct stateid4        *out_stateid);
 
 /* Mark a state for destruction and drop the lifetime ref.  Any walks
  * already holding an acquire-ref will complete their work; the actual
@@ -461,7 +463,6 @@ nfs_lock_state_create(
     struct nfs_lock_owner          *lock_owner,
     struct nfs_open_state          *open_state,
     struct chimera_vfs_open_handle *handle_dup,
-    uint32_t                        client_short_id,
     struct nfs_state_table         *table,
     struct stateid4                *out_stateid);
 

--- a/src/server/nfs/nfs4_stateid.h
+++ b/src/server/nfs/nfs4_stateid.h
@@ -12,11 +12,18 @@
 /*
  * Server-private encoding of stateid.other (12 bytes):
  *
- *   byte 0   : version (high 6 bits) | type (low 2 bits)
- *   byte 1   : shard index (0..NFS_STATE_NUM_SHARDS-1)
- *   bytes 2-4: slot_idx (24-bit, big-endian)
- *   bytes 5-7: generation (24-bit, big-endian)
- *   bytes 8-11: client_short_id (low 32 bits of nfs_client.client_id, big-endian)
+ *   bytes 0-3 : server-instance epoch (big-endian) -- see below
+ *   byte 4    : version (high 6 bits) | type (low 2 bits)
+ *   byte 5    : shard index (0..NFS_STATE_NUM_SHARDS-1)
+ *   bytes 6-8 : slot_idx (24-bit, big-endian)
+ *   bytes 9-11: generation (24-bit, big-endian)
+ *
+ * The epoch is a per-server-instance value (see nfs_state_table.epoch),
+ * placed first on purpose: a stateid minted by a previous server instance
+ * carries a different epoch, so the lookup returns NFS4ERR_STALE_STATEID
+ * (server reboot) instead of NFS4ERR_BAD_STATEID (RFC 7530 §9.1.4.2).  This is
+ * the convention pynfs's makeStaleId() probes -- it rewrites the leading bytes
+ * with an "old" epoch while makeBadID() preserves them and corrupts the rest.
  *
  * Special stateids defined by RFC 7530 §9.1.4 (all-zero, all-ones, etc.) are
  * detected by inspecting the entire {seqid, other} blob before any decode.
@@ -32,12 +39,12 @@
 #define NFS_STATE_NUM_SHARDS       64
 
 struct nfs4_stateid_view {
+    uint32_t epoch;
     uint8_t  version;
     uint8_t  type;
     uint8_t  shard;
     uint32_t slot_idx;       /* 24-bit */
     uint32_t generation;     /* 24-bit */
-    uint32_t client_short_id;
 };
 
 static inline void
@@ -48,25 +55,25 @@ nfs4_stateid_encode(
     uint8_t          shard,
     uint32_t         slot_idx,
     uint32_t         generation,
-    uint32_t         client_short_id)
+    uint32_t         epoch)
 {
     uint8_t *p = (uint8_t *) out->other;
 
     out->seqid = seqid;
 
-    p[0] = (NFS4_STATEID_VERSION << NFS4_STATEID_VERSION_SHIFT) |
+    p[0] = (uint8_t) (epoch >> 24);
+    p[1] = (uint8_t) (epoch >> 16);
+    p[2] = (uint8_t) (epoch >> 8);
+    p[3] = (uint8_t) (epoch);
+    p[4] = (NFS4_STATEID_VERSION << NFS4_STATEID_VERSION_SHIFT) |
         (type & NFS4_STATEID_TYPE_MASK);
-    p[1]  = shard;
-    p[2]  = (uint8_t) (slot_idx >> 16);
-    p[3]  = (uint8_t) (slot_idx >> 8);
-    p[4]  = (uint8_t) (slot_idx);
-    p[5]  = (uint8_t) (generation >> 16);
-    p[6]  = (uint8_t) (generation >> 8);
-    p[7]  = (uint8_t) (generation);
-    p[8]  = (uint8_t) (client_short_id >> 24);
-    p[9]  = (uint8_t) (client_short_id >> 16);
-    p[10] = (uint8_t) (client_short_id >> 8);
-    p[11] = (uint8_t) (client_short_id);
+    p[5]  = shard;
+    p[6]  = (uint8_t) (slot_idx >> 16);
+    p[7]  = (uint8_t) (slot_idx >> 8);
+    p[8]  = (uint8_t) (slot_idx);
+    p[9]  = (uint8_t) (generation >> 16);
+    p[10] = (uint8_t) (generation >> 8);
+    p[11] = (uint8_t) (generation);
 } /* nfs4_stateid_encode */
 
 static inline void
@@ -76,13 +83,13 @@ nfs4_stateid_decode(
 {
     const uint8_t *p = (const uint8_t *) sid->other;
 
-    out->version         = p[0] >> NFS4_STATEID_VERSION_SHIFT;
-    out->type            = p[0] & NFS4_STATEID_TYPE_MASK;
-    out->shard           = p[1];
-    out->slot_idx        = ((uint32_t) p[2] << 16) | ((uint32_t) p[3] << 8) | p[4];
-    out->generation      = ((uint32_t) p[5] << 16) | ((uint32_t) p[6] << 8) | p[7];
-    out->client_short_id = ((uint32_t) p[8] << 24) | ((uint32_t) p[9] << 16) |
-        ((uint32_t) p[10] << 8) | p[11];
+    out->epoch = ((uint32_t) p[0] << 24) | ((uint32_t) p[1] << 16) |
+        ((uint32_t) p[2] << 8) | p[3];
+    out->version    = p[4] >> NFS4_STATEID_VERSION_SHIFT;
+    out->type       = p[4] & NFS4_STATEID_TYPE_MASK;
+    out->shard      = p[5];
+    out->slot_idx   = ((uint32_t) p[6] << 16) | ((uint32_t) p[7] << 8) | p[8];
+    out->generation = ((uint32_t) p[9] << 16) | ((uint32_t) p[10] << 8) | p[11];
 } /* nfs4_stateid_decode */
 
 /*

--- a/src/server/nfs/tests/test_state_table.c
+++ b/src/server/nfs/tests/test_state_table.c
@@ -45,17 +45,17 @@ test_stateid_codec(void)
                         /*shard*/ 7,
                         /*slot_idx*/ 0xABCDEF,
                         /*generation*/ 0x123456,
-                        /*client_short*/ 0xDEADBEEF);
+                        /*epoch*/ 0xDEADBEEF);
 
     nfs4_stateid_decode(&view, &sid);
 
     CHECK(sid.seqid == 1);
+    CHECK(view.epoch == 0xDEADBEEF);
     CHECK(view.version == NFS4_STATEID_VERSION);
     CHECK(view.type == NFS4_STATEID_TYPE_OPEN);
     CHECK(view.shard == 7);
     CHECK(view.slot_idx == 0xABCDEF);
     CHECK(view.generation == 0x123456);
-    CHECK(view.client_short_id == 0xDEADBEEF);
 
     /* Special-stateid detection */
     struct stateid4 zero = { 0 };
@@ -91,7 +91,7 @@ test_slot_lifecycle(void)
      * pointer yet, so acquire would fault; validate just checks the slot). */
     struct stateid4 sid;
     nfs4_stateid_encode(&sid, 1, NFS4_STATEID_TYPE_OPEN,
-                        first_shard, first_slot, first_gen, 0);
+                        first_shard, first_slot, first_gen, table.epoch);
     nfsstat4        v = nfs_state_table_validate(&table, &sid);
     CHECK(v == NFS4_OK);
 
@@ -108,9 +108,20 @@ test_slot_lifecycle(void)
     /* A stateid with a wrong generation also rejects as stale. */
     struct stateid4 stale;
     nfs4_stateid_encode(&stale, 1, NFS4_STATEID_TYPE_OPEN,
-                        first_shard, first_slot, /*gen*/ 999, 0);
+                        first_shard, first_slot, /*gen*/ 999, table.epoch);
     v = nfs_state_table_validate(&table, &stale);
     CHECK(v != NFS4_OK);
+
+    /* A stateid carrying a different server-instance epoch (i.e. minted
+     * before a reboot) must be reported as stale, not merely bad. */
+    rc = nfs_state_table_alloc(&table, NFS4_SLOT_TYPE_OPEN,
+                               &first_shard, &first_slot, &first_gen);
+    CHECK(rc == 0);
+    struct stateid4 wrong_epoch;
+    nfs4_stateid_encode(&wrong_epoch, 1, NFS4_STATEID_TYPE_OPEN,
+                        first_shard, first_slot, first_gen, table.epoch ^ 0x1u);
+    v = nfs_state_table_validate(&table, &wrong_epoch);
+    CHECK(v == NFS4ERR_STALE_STATEID);
 
     nfs_state_table_free(&table, NULL);
     printf("ok: slot_lifecycle\n");
@@ -152,7 +163,6 @@ test_owner_state_lifecycle(void)
                                   OPEN4_SHARE_ACCESS_READ,
                                   OPEN4_SHARE_DENY_NONE,
                                   /*handle_dup*/ NULL,
-                                  /*client_short*/ 42,
                                   &table,
                                   &sid);
     CHECK(state != NULL);
@@ -173,7 +183,7 @@ test_owner_state_lifecycle(void)
     nfs_open_state_coalesce(state,
                             OPEN4_SHARE_ACCESS_WRITE,
                             OPEN4_SHARE_DENY_NONE,
-                            42, &sid2);
+                            &table, &sid2);
     CHECK((state->share_access &
            (OPEN4_SHARE_ACCESS_READ | OPEN4_SHARE_ACCESS_WRITE)) ==
           (OPEN4_SHARE_ACCESS_READ | OPEN4_SHARE_ACCESS_WRITE));
@@ -261,7 +271,7 @@ test_share_mode_conflict(void)
     state_a = nfs_open_state_create(owner_a, fh, sizeof(fh),
                                     OPEN4_SHARE_ACCESS_READ,
                                     OPEN4_SHARE_DENY_WRITE,
-                                    NULL, 99, &table, &sid_a);
+                                    NULL, &table, &sid_a);
     CHECK(state_a != NULL);
 
     /* Owner B asking for WRITE should be denied. */


### PR DESCRIPTION
## Summary

Stacked on #307. The stateid lookup validated the encoded generation and type but had no notion of *server instance*, so a stateid minted before a restart was reported as `NFS4ERR_BAD_STATEID` instead of `NFS4ERR_STALE_STATEID` (RFC 7530 §9.1.4.2).

`stateid.other` is restructured to carry a 32-bit per-instance **epoch** in its leading four bytes (stamped at `nfs_state_table_init` from boot time, high bit forced set so it never collides with the special all-zero/all-ones stateids or pynfs's small "old epoch" probe values). The lookup now:
- rejects a stateid whose epoch ≠ the running instance with `NFS4ERR_STALE_STATEID`, **before** the structural checks;
- treats a special (all-zero / all-ones) stateid as `BAD_STATEID` up front, so it's never mistaken for a wrong-epoch one.

The leading-bytes placement matches the convention pynfs probes: `makeStaleId()` overwrites the leading bytes with an old epoch (→ stale) while `makeBadID()` preserves them and corrupts the rest (→ bad). The epoch displaces the previously-encoded `client_short_id`, which was cosmetic (never consulted during lookup); the per-state encode sites now pass the table epoch.

(No backwards-compat constraint — stateids are server-opaque and not persisted across restarts.)

## Verification

pynfs (memfs, 4.0): `st_openconfirm` OPCF6, `st_opendowngrade` OPDG6, `st_write` WRT11, `st_locku` LKU9 — all `testStaleStateid` variants — now pass; LKU8 `testBadLockStateid` (all-zero special stateid → BAD) still passes (guarded). No regression in `open` (27 pass), `lock` (24 pass), `read`/`write`, or the posix/cthon NFS4 suites (83/83). The `state_table` unit test is updated (new signatures + an epoch-mismatch assertion) and passes.

## Note

Earlier commits here are #302/#305/#307; this PR shows only its own diff once those merge and the branch is rebased.