### PR TITLE
s3: implement batch DeleteObjects (POST /bucket?delete)

### DIFF
--- a/src/server/s3/CMakeLists.txt
+++ b/src/server/s3/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 find_package(OpenSSL REQUIRED)
 
-add_library(chimera_s3 SHARED s3.c s3_get.c s3_put.c s3_dump.c s3_status.c s3_delete.c s3_list.c s3_auth.c s3_multipart.c)
+add_library(chimera_s3 SHARED s3.c s3_get.c s3_put.c s3_dump.c s3_status.c s3_delete.c s3_delete_objects.c s3_list.c s3_auth.c s3_multipart.c)
 target_link_libraries(chimera_s3 chimera_vfs evpl_http evpl OpenSSL::Crypto)
 
 install(TARGETS chimera_s3 DESTINATION lib)

--- a/src/server/s3/s3.c
+++ b/src/server/s3/s3.c
@@ -187,10 +187,13 @@ s3_server_notify(
     struct chimera_server_s3_thread *thread     = private_data;
     int                              is_upload_part;
     int                              is_complete_mpu;
+    int                              is_delete_objects;
 
     is_upload_part  = s3_request->has_upload_id && s3_request->has_part_number;
     is_complete_mpu = (request_type == EVPL_HTTP_REQUEST_TYPE_POST &&
                        s3_request->has_upload_id);
+    is_delete_objects = (request_type == EVPL_HTTP_REQUEST_TYPE_POST &&
+                         s3_request->has_delete);
 
     switch (notify_type) {
         case EVPL_HTTP_NOTIFY_RECEIVE_DATA:
@@ -204,6 +207,9 @@ s3_server_notify(
             } else if (is_complete_mpu) {
                 /* Accumulate the client's part manifest. */
                 chimera_s3_complete_multipart_upload_recv(evpl, s3_request);
+            } else if (is_delete_objects) {
+                /* Accumulate the <Delete> document. */
+                chimera_s3_delete_objects_recv(evpl, s3_request);
             } else if (request_type == EVPL_HTTP_REQUEST_TYPE_POST) {
                 /* CreateMultipartUpload: body is empty in practice. */
                 s3_server_drain_body(evpl, s3_request);
@@ -224,6 +230,10 @@ s3_server_notify(
                 chimera_s3_complete_multipart_upload_recv(evpl, s3_request);
                 /* Body fully in hand: parse + validate + assemble. */
                 chimera_s3_complete_multipart_upload_body_done(evpl, s3_request);
+            } else if (is_delete_objects) {
+                chimera_s3_delete_objects_recv(evpl, s3_request);
+                /* Body fully in hand: parse keys + remove them. */
+                chimera_s3_delete_objects_body_done(evpl, s3_request);
             } else if (request_type == EVPL_HTTP_REQUEST_TYPE_POST) {
                 s3_server_drain_body(evpl, s3_request);
             }
@@ -305,6 +315,8 @@ chimera_s3_dispatch_callback(
                 chimera_s3_create_multipart_upload(evpl, thread, s3_request);
             } else if (s3_request->has_upload_id) {
                 chimera_s3_complete_multipart_upload(evpl, thread, s3_request);
+            } else if (s3_request->has_delete) {
+                chimera_s3_delete_objects(evpl, thread, s3_request);
             } else {
                 s3_request->status    = CHIMERA_S3_STATUS_NOT_IMPLEMENTED;
                 s3_request->vfs_state = CHIMERA_S3_VFS_STATE_COMPLETE;
@@ -354,6 +366,7 @@ s3_server_dispatch(
     s3_request->is_list            = 0;
     s3_request->has_uploads        = 0;
     s3_request->has_upload_id      = 0;
+    s3_request->has_delete         = 0;
     s3_request->has_part_number    = 0;
     s3_request->query_upload_idlen = 0;
     s3_request->query_part_number  = 0;
@@ -497,6 +510,8 @@ s3_server_dispatch(
 
                 if (key_len == 7 && memcmp(key_start, "uploads", 7) == 0) {
                     s3_request->has_uploads = 1;
+                } else if (key_len == 6 && memcmp(key_start, "delete", 6) == 0) {
+                    s3_request->has_delete = 1;
                 } else if (key_len == 8 && memcmp(key_start, "uploadId", 8) == 0) {
                     int copy = value_len;
                     if (copy > CHIMERA_S3_UPLOAD_ID_LEN) {
@@ -548,6 +563,23 @@ s3_server_dispatch(
                     s3_request->multipart.part_number =
                         s3_request->query_part_number;
                 }
+            } else if (s3_request->has_delete) {
+                /* POST /bucket?delete: the keys to remove arrive in the
+                 * request body, so there is no object key in the path.
+                 * Initialize the body/response accumulators here, before any
+                 * RECEIVE_DATA notification can fire. */
+                s3_request->path         = "";
+                s3_request->path_len     = 0;
+                s3_request->del.body_buf = NULL;
+                s3_request->del.body_len = 0;
+                s3_request->del.body_cap = 0;
+                s3_request->del.resp_buf = NULL;
+                s3_request->del.resp_len = 0;
+                s3_request->del.resp_cap = 0;
+                s3_request->del.entries  = NULL;
+                s3_request->del.n_keys   = 0;
+                s3_request->del.cur      = 0;
+                s3_request->del.quiet    = 0;
             } else if (qmark == s3_request->path) {
                 /* Path starts with '?': bucket-level LIST query. */
                 s3_request->is_list         = 1;

--- a/src/server/s3/s3_delete_objects.c
+++ b/src/server/s3/s3_delete_objects.c
@@ -1,0 +1,579 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * DeleteObjects (POST /bucket?delete): the S3 batch-delete operation used by
+ * `aws s3 rm --recursive` and the delete phase of `aws s3 sync`. The request
+ * body is a <Delete> document listing object keys; the response is a
+ * <DeleteResult> reporting each key as <Deleted> or <Error>. Deletes are
+ * idempotent: removing a key that does not exist is reported as success.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+#include <stdarg.h>
+
+#include "evpl/evpl.h"
+#include "evpl/evpl_http.h"
+#include "vfs/vfs.h"
+#include "vfs/vfs_procs.h"
+#include "vfs/vfs_release.h"
+#include "s3_internal.h"
+#include "s3_procs.h"
+
+#define CHIMERA_S3_DEL_BODY_HARD_CAP (4 * 1024 * 1024)
+#define CHIMERA_S3_DEL_BODY_OVERFLOW (-1)
+#define CHIMERA_S3_DEL_MAX_KEYS      1000
+
+/* ----- request body accumulation ----- */
+
+void
+chimera_s3_delete_objects_recv(
+    struct evpl               *evpl,
+    struct chimera_s3_request *request)
+{
+    struct evpl_iovec iov[CHIMERA_S3_IOV_MAX];
+    uint64_t          avail, total;
+    int               niov, i;
+
+    while ((avail = evpl_http_request_get_data_avail(request->http_request)) > 0) {
+        niov  = evpl_http_request_get_datav(evpl, request->http_request, iov, avail);
+        total = 0;
+        for (i = 0; i < niov; i++) {
+            total += iov[i].length;
+        }
+
+        if (request->del.body_len == CHIMERA_S3_DEL_BODY_OVERFLOW) {
+            /* Already over the hard cap; keep draining to release iovs. */
+        } else if (request->del.body_len + total > CHIMERA_S3_DEL_BODY_HARD_CAP) {
+            free(request->del.body_buf);
+            request->del.body_buf = NULL;
+            request->del.body_cap = 0;
+            request->del.body_len = CHIMERA_S3_DEL_BODY_OVERFLOW;
+        } else {
+            if (request->del.body_len + total > request->del.body_cap) {
+                int new_cap = request->del.body_cap ? request->del.body_cap * 2 : 4096;
+                while ((uint64_t) new_cap < request->del.body_len + total) {
+                    new_cap *= 2;
+                }
+                request->del.body_buf = realloc(request->del.body_buf, new_cap);
+                request->del.body_cap = new_cap;
+            }
+            for (i = 0; i < niov; i++) {
+                memcpy(request->del.body_buf + request->del.body_len,
+                       iov[i].data, iov[i].length);
+                request->del.body_len += iov[i].length;
+            }
+        }
+
+        evpl_iovecs_release(evpl, iov, niov);
+    }
+} /* chimera_s3_delete_objects_recv */
+
+/* ----- XML helpers ----- */
+
+/* Locate `tag` between [start, end) and return pointer past its end. */
+static const char *
+chimera_s3_del_xml_find(
+    const char *start,
+    const char *end,
+    const char *tag)
+{
+    size_t tag_len = strlen(tag);
+
+    if ((size_t) (end - start) < tag_len) {
+        return NULL;
+    }
+    for (const char *p = start; p <= end - tag_len; p++) {
+        if (memcmp(p, tag, tag_len) == 0) {
+            return p + tag_len;
+        }
+    }
+    return NULL;
+} /* chimera_s3_del_xml_find */
+
+/* Decode the five predefined XML entities in place. Always shrinks, so the
+ * result fits within the original [s, s+len) range. Returns the new length. */
+static int
+chimera_s3_del_xml_unescape(
+    char *s,
+    int   len)
+{
+    int r = 0, w = 0;
+
+    while (r < len) {
+        if (s[r] == '&') {
+            if (r + 5 <= len && memcmp(s + r, "&amp;", 5) == 0) {
+                s[w++] = '&';
+                r     += 5;
+                continue;
+            }
+            if (r + 4 <= len && memcmp(s + r, "&lt;", 4) == 0) {
+                s[w++] = '<';
+                r     += 4;
+                continue;
+            }
+            if (r + 4 <= len && memcmp(s + r, "&gt;", 4) == 0) {
+                s[w++] = '>';
+                r     += 4;
+                continue;
+            }
+            if (r + 6 <= len && memcmp(s + r, "&quot;", 6) == 0) {
+                s[w++] = '"';
+                r     += 6;
+                continue;
+            }
+            if (r + 6 <= len && memcmp(s + r, "&apos;", 6) == 0) {
+                s[w++] = '\'';
+                r     += 6;
+                continue;
+            }
+        }
+        s[w++] = s[r++];
+    }
+    return w;
+} /* chimera_s3_del_xml_unescape */
+
+/* ----- response buffer (growable) ----- */
+
+static void
+chimera_s3_del_resp_append(
+    struct chimera_s3_request *request,
+    const char                *s,
+    int                        len)
+{
+    if (request->del.resp_len + len > request->del.resp_cap) {
+        int new_cap = request->del.resp_cap ? request->del.resp_cap * 2 : 8192;
+        while (new_cap < request->del.resp_len + len) {
+            new_cap *= 2;
+        }
+        request->del.resp_buf = realloc(request->del.resp_buf, new_cap);
+        request->del.resp_cap = new_cap;
+    }
+    memcpy(request->del.resp_buf + request->del.resp_len, s, len);
+    request->del.resp_len += len;
+} /* chimera_s3_del_resp_append */
+
+static void
+chimera_s3_del_resp_str(
+    struct chimera_s3_request *request,
+    const char                *s)
+{
+    chimera_s3_del_resp_append(request, s, strlen(s));
+} /* chimera_s3_del_resp_str */
+
+/* Append a key, escaping the predefined XML entities. */
+static void
+chimera_s3_del_resp_key(
+    struct chimera_s3_request *request,
+    const char                *s,
+    int                        len)
+{
+    int i;
+
+    for (i = 0; i < len; i++) {
+        switch (s[i]) {
+            case '&':
+                chimera_s3_del_resp_append(request, "&amp;", 5);
+                break;
+            case '<':
+                chimera_s3_del_resp_append(request, "&lt;", 4);
+                break;
+            case '>':
+                chimera_s3_del_resp_append(request, "&gt;", 4);
+                break;
+            case '"':
+                chimera_s3_del_resp_append(request, "&quot;", 6);
+                break;
+            case '\'':
+                chimera_s3_del_resp_append(request, "&apos;", 6);
+                break;
+            default:
+                chimera_s3_del_resp_append(request, &s[i], 1);
+                break;
+        } /* switch */
+    }
+} /* chimera_s3_del_resp_key */
+
+/* ----- body parsing ----- */
+
+/*
+ * Parse the <Delete> document into request->del.entries. Keys are unescaped
+ * in place inside the body buffer (which outlives parsing). Returns
+ * CHIMERA_S3_STATUS_OK or MALFORMED_XML.
+ */
+static enum chimera_s3_status
+chimera_s3_del_parse_body(struct chimera_s3_request *request)
+{
+    char *body         = request->del.body_buf;
+    const char *end    = body + request->del.body_len;
+    const char *cursor = body;
+    struct chimera_s3_delete_entry *entries = NULL;
+    int n   = 0;
+    int cap = 0;
+    const char *quiet_open, *quiet_close;
+
+    /* Optional <Quiet> flag: suppress per-key <Deleted> entries. */
+    quiet_open = chimera_s3_del_xml_find(body, end, "<Quiet>");
+    if (quiet_open) {
+        quiet_close = chimera_s3_del_xml_find(quiet_open, end, "</Quiet>");
+        if (quiet_close) {
+            const char *v = quiet_open;
+            int vlen      = (quiet_close - strlen("</Quiet>")) - v;
+            if (vlen >= 4 && strncasecmp(v, "true", 4) == 0) {
+                request->del.quiet = 1;
+            }
+        }
+    }
+
+    while (cursor < end) {
+        const char *obj_open = chimera_s3_del_xml_find(cursor, end, "<Object>");
+        const char *obj_close, *key_open, *key_close;
+        char *key;
+        int key_len;
+
+        if (!obj_open) {
+            break;
+        }
+        obj_close = chimera_s3_del_xml_find(obj_open, end, "</Object>");
+        if (!obj_close) {
+            free(entries);
+            return CHIMERA_S3_STATUS_MALFORMED_XML;
+        }
+
+        key_open  = chimera_s3_del_xml_find(obj_open, obj_close, "<Key>");
+        key_close = key_open ? chimera_s3_del_xml_find(key_open, obj_close, "</Key>") : NULL;
+        if (!key_open || !key_close) {
+            free(entries);
+            return CHIMERA_S3_STATUS_MALFORMED_XML;
+        }
+
+        key     = (char *) key_open;
+        key_len = (key_close - strlen("</Key>")) - key_open;
+        key_len = chimera_s3_del_xml_unescape(key, key_len);
+
+        if (n >= CHIMERA_S3_DEL_MAX_KEYS) {
+            free(entries);
+            return CHIMERA_S3_STATUS_MALFORMED_XML;
+        }
+        if (n == cap) {
+            cap = cap ? cap * 2 : 16;
+            if (cap > CHIMERA_S3_DEL_MAX_KEYS) {
+                cap = CHIMERA_S3_DEL_MAX_KEYS;
+            }
+            entries = realloc(entries, cap * sizeof(*entries));
+        }
+
+        entries[n].key      = key;
+        entries[n].key_len  = key_len;
+        entries[n].deleted  = 0;
+        entries[n].err_code = NULL;
+        entries[n].err_msg  = NULL;
+        n++;
+
+        cursor = obj_close;
+    }
+
+    request->del.entries = entries;
+    request->del.n_keys  = n;
+    return CHIMERA_S3_STATUS_OK;
+} /* chimera_s3_del_parse_body */
+
+/* ----- sequential deletion driver ----- */
+
+static void chimera_s3_del_drive(
+    struct chimera_s3_request *request);
+
+static void
+chimera_s3_del_finalize(
+    struct evpl               *evpl,
+    struct chimera_s3_request *request)
+{
+    struct evpl_iovec iov;
+    int               i;
+
+    chimera_s3_del_resp_str(request, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+    chimera_s3_del_resp_str(request,
+                            "<DeleteResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\n");
+
+    for (i = 0; i < request->del.n_keys; i++) {
+        struct chimera_s3_delete_entry *e = &request->del.entries[i];
+
+        if (e->deleted) {
+            if (!request->del.quiet) {
+                chimera_s3_del_resp_str(request, " <Deleted><Key>");
+                chimera_s3_del_resp_key(request, e->key, e->key_len);
+                chimera_s3_del_resp_str(request, "</Key></Deleted>\n");
+            }
+        } else {
+            char tail[256];
+
+            chimera_s3_del_resp_str(request, " <Error><Key>");
+            chimera_s3_del_resp_key(request, e->key, e->key_len);
+            chimera_s3_del_resp_append(request, tail,
+                                       snprintf(tail, sizeof(tail),
+                                                "</Key><Code>%s</Code><Message>%s</Message></Error>\n",
+                                                e->err_code, e->err_msg));
+        }
+    }
+
+    chimera_s3_del_resp_str(request, "</DeleteResult>\n");
+
+    /* Copy the assembled document into an evpl iovec for the HTTP response.
+     * Keys in resp_buf are independent copies, so the body buffer and entry
+     * array can now be released. */
+    evpl_iovec_alloc(evpl, request->del.resp_len, 0, 1, 0, &iov);
+    memcpy(evpl_iovec_data(&iov), request->del.resp_buf, request->del.resp_len);
+    evpl_iovec_set_length(&iov, request->del.resp_len);
+    evpl_http_request_add_datav(request->http_request, &iov, 1);
+
+    request->file_length      = request->del.resp_len;
+    request->file_real_length = request->del.resp_len;
+    request->file_offset      = 0;
+    request->is_list          = 1; /* render Content-Type: application/xml */
+    request->status           = CHIMERA_S3_STATUS_OK;
+
+    free(request->del.resp_buf);
+    request->del.resp_buf = NULL;
+    free(request->del.entries);
+    request->del.entries = NULL;
+    free(request->del.body_buf);
+    request->del.body_buf = NULL;
+
+    request->vfs_state = CHIMERA_S3_VFS_STATE_COMPLETE;
+
+    if (request->http_state == CHIMERA_S3_HTTP_STATE_RECVED) {
+        s3_server_respond(evpl, request);
+    }
+} /* chimera_s3_del_finalize */
+
+/*
+ * Record the outcome for the current key. If we are unwinding from an
+ * inline (synchronous) VFS completion, just clear the pending flag and let
+ * chimera_s3_del_drive()'s loop advance; otherwise advance and resume the
+ * loop here. This trampoline keeps a long batch from recursing per key.
+ */
+static void
+chimera_s3_del_record(
+    struct chimera_s3_request *request,
+    int                        deleted,
+    const char                *code,
+    const char                *msg)
+{
+    struct chimera_s3_delete_entry *e = &request->del.entries[request->del.cur];
+
+    e->deleted  = deleted;
+    e->err_code = code;
+    e->err_msg  = msg;
+
+    request->del.pending = 0;
+
+    if (!request->del.synchronous) {
+        request->del.cur++;
+        chimera_s3_del_drive(request);
+    }
+} /* chimera_s3_del_record */
+
+static void
+chimera_s3_del_remove_cb(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *pre_attr,
+    struct chimera_vfs_attrs *post_attr,
+    void                     *private_data)
+{
+    struct chimera_s3_request       *request = private_data;
+    struct chimera_server_s3_thread *thread  = request->thread;
+
+    chimera_vfs_release(thread->vfs, request->dir_handle);
+
+    if (error_code == CHIMERA_VFS_OK || error_code == CHIMERA_VFS_ENOENT) {
+        /* Removed, or already absent: both count as success. */
+        chimera_s3_del_record(request, 1, NULL, NULL);
+    } else if (error_code == CHIMERA_VFS_EACCES) {
+        chimera_s3_del_record(request, 0, "AccessDenied", "Access Denied");
+    } else {
+        chimera_s3_del_record(request, 0, "InternalError",
+                              "We encountered an internal error. Please try again.");
+    }
+} /* chimera_s3_del_remove_cb */
+
+static void
+chimera_s3_del_open_cb(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *oh,
+    void                           *private_data)
+{
+    struct chimera_s3_request       *request = private_data;
+    struct chimera_server_s3_thread *thread  = request->thread;
+
+    if (error_code) {
+        /* Parent directory could not be opened: object is effectively gone. */
+        chimera_s3_del_record(request, 1, NULL, NULL);
+        return;
+    }
+
+    request->dir_handle = oh;
+
+    chimera_vfs_remove_at(thread->vfs, &thread->shared->cred,
+                          oh,
+                          request->del.cur_name,
+                          request->del.cur_name_len,
+                          NULL, 0, 0, 0,
+                          chimera_s3_del_remove_cb,
+                          request);
+} /* chimera_s3_del_open_cb */
+
+static void
+chimera_s3_del_lookup_cb(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *attr,
+    void                     *private_data)
+{
+    struct chimera_s3_request       *request = private_data;
+    struct chimera_server_s3_thread *thread  = request->thread;
+
+    if (error_code) {
+        /* Parent path does not exist: object is effectively gone. */
+        chimera_s3_del_record(request, 1, NULL, NULL);
+        return;
+    }
+
+    chimera_vfs_open_fh(thread->vfs, &thread->shared->cred,
+                        attr->va_fh,
+                        attr->va_fh_len,
+                        CHIMERA_VFS_OPEN_PATH | CHIMERA_VFS_OPEN_INFERRED | CHIMERA_VFS_OPEN_DIRECTORY,
+                        chimera_s3_del_open_cb,
+                        request);
+} /* chimera_s3_del_lookup_cb */
+
+static void
+chimera_s3_del_drive(struct chimera_s3_request *request)
+{
+    struct chimera_server_s3_thread *thread = request->thread;
+    struct evpl                     *evpl   = thread->evpl;
+
+    while (request->del.cur < request->del.n_keys) {
+        struct chimera_s3_delete_entry *e       = &request->del.entries[request->del.cur];
+        const char                     *key     = e->key;
+        int                             key_len = e->key_len;
+        const char                     *dirpath, *name;
+        int                             dirpathlen, name_len, i;
+        const char                     *slash = NULL;
+
+        for (i = key_len - 1; i >= 0; i--) {
+            if (key[i] == '/') {
+                slash = key + i;
+                break;
+            }
+        }
+
+        if (slash) {
+            dirpath    = key;
+            dirpathlen = slash - key;
+            name       = slash + 1;
+            while (name < key + key_len && *name == '/') {
+                name++;
+            }
+            name_len = (key + key_len) - name;
+        } else {
+            dirpath    = "/";
+            dirpathlen = 1;
+            name       = key;
+            name_len   = key_len;
+        }
+
+        /* Empty key, or a key naming only directories: nothing to remove. */
+        if (name_len == 0) {
+            e->deleted = 1;
+            request->del.cur++;
+            continue;
+        }
+
+        request->del.cur_name     = name;
+        request->del.cur_name_len = name_len;
+
+        request->del.synchronous = 1;
+        request->del.pending     = 1;
+
+        chimera_vfs_lookup(thread->vfs, &thread->shared->cred,
+                           request->bucket_fh,
+                           request->bucket_fhlen,
+                           dirpath,
+                           dirpathlen,
+                           CHIMERA_VFS_ATTR_FH,
+                           CHIMERA_VFS_LOOKUP_FOLLOW,
+                           chimera_s3_del_lookup_cb,
+                           request);
+
+        if (request->del.pending) {
+            /* Completion is asynchronous; the callback chain will resume the
+             * loop via chimera_s3_del_record(). */
+            request->del.synchronous = 0;
+            return;
+        }
+
+        /* Completed inline; result already recorded. Advance and continue. */
+        request->del.cur++;
+    }
+
+    chimera_s3_del_finalize(evpl, request);
+} /* chimera_s3_del_drive */
+
+/* ----- entry points ----- */
+
+void
+chimera_s3_delete_objects(
+    struct evpl                     *evpl,
+    struct chimera_server_s3_thread *thread,
+    struct chimera_s3_request       *request)
+{
+    (void) evpl;
+    (void) thread;
+
+    /* Body/response accumulators were initialized during request parsing.
+     * The real work begins once the <Delete> body is fully received. */
+    request->vfs_state = CHIMERA_S3_VFS_STATE_INIT;
+} /* chimera_s3_delete_objects */
+
+void
+chimera_s3_delete_objects_body_done(
+    struct evpl               *evpl,
+    struct chimera_s3_request *request)
+{
+    enum chimera_s3_status err;
+
+    if (request->del.body_len == CHIMERA_S3_DEL_BODY_OVERFLOW) {
+        request->status    = CHIMERA_S3_STATUS_MALFORMED_XML;
+        request->vfs_state = CHIMERA_S3_VFS_STATE_COMPLETE;
+        if (request->http_state == CHIMERA_S3_HTTP_STATE_RECVED) {
+            s3_server_respond(evpl, request);
+        }
+        return;
+    }
+
+    err = chimera_s3_del_parse_body(request);
+
+    /* A well-formed request lists at least one object. */
+    if (err == CHIMERA_S3_STATUS_OK && request->del.n_keys == 0) {
+        err = CHIMERA_S3_STATUS_MALFORMED_XML;
+    }
+
+    if (err != CHIMERA_S3_STATUS_OK) {
+        free(request->del.entries);
+        request->del.entries = NULL;
+        free(request->del.body_buf);
+        request->del.body_buf = NULL;
+        request->status       = err;
+        request->vfs_state    = CHIMERA_S3_VFS_STATE_COMPLETE;
+        if (request->http_state == CHIMERA_S3_HTTP_STATE_RECVED) {
+            s3_server_respond(evpl, request);
+        }
+        return;
+    }
+
+    request->del.cur = 0;
+    chimera_s3_del_drive(request);
+} /* chimera_s3_delete_objects_body_done */

--- a/src/server/s3/s3_internal.h
+++ b/src/server/s3/s3_internal.h
@@ -38,6 +38,16 @@ struct chimera_server_s3_thread;
 struct chimera_s3_multipart_table;
 struct chimera_s3_multipart_upload;
 
+/* One <Object> entry from a DeleteObjects (POST /bucket?delete) request.
+ * key points into the accumulated request body (unescaped in place). */
+struct chimera_s3_delete_entry {
+    char       *key;
+    int         key_len;
+    int         deleted;     /* 1 once the key is resolved as removed/absent */
+    const char *err_code;    /* NULL on success, else S3 error code string   */
+    const char *err_msg;
+};
+
 struct chimera_s3_config {
     int      port;
     uint64_t io_size;
@@ -63,6 +73,7 @@ struct chimera_s3_request {
     int                              is_list;
     int                              has_uploads;
     int                              has_upload_id;
+    int                              has_delete;
     int                              has_part_number;
     int                              query_upload_idlen;
     int                              query_part_number;
@@ -122,6 +133,28 @@ struct chimera_s3_request {
             char                                tmp_name[64];
             char                                path_buf[1024];
         } multipart;
+
+        struct {
+            /* Request body (the <Delete> document) accumulator. */
+            char                           *body_buf;
+            int                             body_len;
+            int                             body_cap;
+            int                             quiet;
+            /* Parsed object keys and the sequential delete cursor. */
+            struct chimera_s3_delete_entry *entries;
+            int                             n_keys;
+            int                             cur;
+            /* Trampoline flags so inline VFS completions don't recurse. */
+            int                             pending;
+            int                             synchronous;
+            /* Working state for the key currently being removed. */
+            const char                     *cur_name;
+            int                             cur_name_len;
+            /* Response (<DeleteResult>) builder. */
+            char                           *resp_buf;
+            int                             resp_len;
+            int                             resp_cap;
+        } del;
     };
 };
 

--- a/src/server/s3/s3_procs.h
+++ b/src/server/s3/s3_procs.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -45,3 +45,19 @@ chimera_s3_list(
     struct evpl                     *evpl,
     struct chimera_server_s3_thread *thread,
     struct chimera_s3_request       *request);
+
+void
+chimera_s3_delete_objects(
+    struct evpl                     *evpl,
+    struct chimera_server_s3_thread *thread,
+    struct chimera_s3_request       *request);
+
+void
+chimera_s3_delete_objects_recv(
+    struct evpl               *evpl,
+    struct chimera_s3_request *request);
+
+void
+chimera_s3_delete_objects_body_done(
+    struct evpl               *evpl,
+    struct chimera_s3_request *request);

--- a/src/server/s3/s3_status.c
+++ b/src/server/s3/s3_status.c
@@ -46,6 +46,8 @@ chimera_s3_status_to_string(enum chimera_s3_status status)
             return "Malformed XML";
         case CHIMERA_S3_STATUS_NO_CONTENT:
             return "No Content";
+        case CHIMERA_S3_STATUS_NOT_IMPLEMENTED:
+            return "Not Implemented";
         default:
             return "Internal Error";
     } /* switch */
@@ -129,6 +131,13 @@ chimera_s3_prepare_error_response(
             bp += sprintf(bp,
                           "  <Message>The XML you provided was not well-formed or did not validate against our published schema.</Message>\n");
             code = 400;
+            break;
+        case CHIMERA_S3_STATUS_NOT_IMPLEMENTED:
+            bp += sprintf(bp, "  <Code>NotImplemented</Code>\n");
+            bp += sprintf(bp,
+                          "  <Message>A header you provided implies functionality that is not implemented.</Message>\n")
+            ;
+            code = 501;
             break;
         default:
             bp  += sprintf(bp, "  <Code>InternalError</Code>\n");

--- a/src/server/s3/tests/CMakeLists.txt
+++ b/src/server/s3/tests/CMakeLists.txt
@@ -59,6 +59,7 @@ if(BOTO3_FOUND)
     add_s3_test(get memfs)
     add_s3_test(head memfs)
     add_s3_test(delete memfs)
+    add_s3_test(delete_objects memfs)
     add_s3_test(list memfs)
     add_s3_test(multipart memfs)
 
@@ -67,6 +68,7 @@ if(BOTO3_FOUND)
     add_s3_test(get linux)
     add_s3_test(head linux)
     add_s3_test(delete linux)
+    add_s3_test(delete_objects linux)
     add_s3_test(list linux)
     add_s3_test(multipart linux)
 
@@ -76,6 +78,7 @@ if(BOTO3_FOUND)
         add_s3_test(get io_uring)
         add_s3_test(head io_uring)
         add_s3_test(delete io_uring)
+        add_s3_test(delete_objects io_uring)
         add_s3_test(list io_uring)
         add_s3_test(multipart io_uring)
 
@@ -84,6 +87,7 @@ if(BOTO3_FOUND)
         add_s3_test(get demofs)
         add_s3_test(head demofs)
         add_s3_test(delete demofs)
+        add_s3_test(delete_objects demofs)
         add_s3_test(list demofs)
         # demofs multipart is omitted: assembly via read+write across two
         # files on demofs produces corrupted output; suspected demofs bug
@@ -96,6 +100,7 @@ if(BOTO3_FOUND)
     add_s3_test(get cairn)
     add_s3_test(head cairn)
     add_s3_test(delete cairn)
+    add_s3_test(delete_objects cairn)
     add_s3_test(list cairn)
     add_s3_test(multipart cairn)
 
@@ -107,9 +112,9 @@ if(BOTO3_FOUND)
     add_s3_test_sigver(head memfs v2)
     add_s3_test_sigver(delete memfs v2)
     add_s3_test_sigver(list memfs v2)
-    # Multipart V2 omitted: V2 signing's canonical resource doesn't include
-    # the multipart subresources (uploads, uploadId, partNumber) that boto3
-    # adds to its signature. Re-enable when build_string_to_sign_v2 in
-    # s3_auth.c learns to append the AWS V2 subresource list.
+    # Multipart and DeleteObjects V2 omitted: V2 signing's canonical resource
+    # doesn't include the subresources (uploads, uploadId, partNumber, delete)
+    # that boto3 adds to its signature. Re-enable when build_string_to_sign_v2
+    # in s3_auth.c learns to append the AWS V2 subresource list.
 
 endif()

--- a/src/server/s3/tests/s3_test.py
+++ b/src/server/s3/tests/s3_test.py
@@ -331,6 +331,71 @@ def test_delete(client, bucket):
     print("DELETE tests passed!")
 
 
+def test_delete_objects(client, bucket):
+    """Test batch DeleteObjects (POST /bucket?delete) used by `aws s3 rm
+    --recursive` and the delete phase of `aws s3 sync`."""
+    print("Testing batch DeleteObjects operations...")
+
+    data = b'y' * 1024
+    keys = [
+        'batch/a/key1',
+        'batch/a/key2',
+        'batch/b/key3',
+        'batch/key4',
+    ]
+    for k in keys:
+        client.put_object(Bucket=bucket, Key=k, Body=data)
+    print(f"  Put {len(keys)} objects")
+
+    # Batch-delete a subset plus a nonexistent key. DeleteObjects is
+    # idempotent, so the missing key is reported as deleted, not an error.
+    to_delete = keys[:3] + ['batch/does-not-exist']
+    response = client.delete_objects(
+        Bucket=bucket,
+        Delete={'Objects': [{'Key': k} for k in to_delete]},
+    )
+
+    deleted = sorted(d['Key'] for d in response.get('Deleted', []))
+    errors = response.get('Errors', [])
+    assert not errors, f"Unexpected errors: {errors}"
+    assert deleted == sorted(to_delete), f"Deleted mismatch: {deleted}"
+    print("  Batch delete reported all keys deleted (incl. nonexistent) - OK")
+
+    # Deleted keys are gone.
+    for k in keys[:3]:
+        try:
+            client.head_object(Bucket=bucket, Key=k)
+            raise AssertionError(f"{k} should have been deleted")
+        except ClientError as e:
+            if e.response['Error']['Code'] != '404':
+                raise
+    print("  Verified deleted keys are gone - OK")
+
+    # The untouched key survives.
+    resp = client.head_object(Bucket=bucket, Key='batch/key4')
+    assert resp['ContentLength'] == 1024
+    print("  Verified untouched key survives - OK")
+
+    # Quiet mode: successful deletes are not echoed back in the result.
+    response = client.delete_objects(
+        Bucket=bucket,
+        Delete={'Objects': [{'Key': 'batch/key4'}], 'Quiet': True},
+    )
+    assert not response.get('Deleted'), "Quiet mode should omit Deleted entries"
+    assert not response.get('Errors'), f"Unexpected errors: {response.get('Errors')}"
+    print("  Quiet mode suppressed Deleted entries - OK")
+
+    try:
+        client.head_object(Bucket=bucket, Key='batch/key4')
+        raise AssertionError("batch/key4 should have been deleted")
+    except ClientError as e:
+        if e.response['Error']['Code'] != '404':
+            raise
+    print("  Verified quiet-mode delete removed the key - OK")
+
+    print("Batch DeleteObjects tests passed!")
+
+
 def test_list(client, bucket):
     """Test LIST operations."""
     print("Testing LIST operations...")
@@ -664,6 +729,7 @@ TESTS = {
     'get': test_get,
     'head': test_head,
     'delete': test_delete,
+    'delete_objects': test_delete_objects,
     'list': test_list,
     'multipart': test_multipart,
 }


### PR DESCRIPTION
## Problem

`aws s3 rm --recursive` and the delete phase of `aws s3 sync` issue a batch **DeleteObjects** request — `POST /bucket?delete` with an XML `<Delete>` document listing keys. Chimera had no handler: the request fell into the POST default branch and was set to `NOT_IMPLEMENTED`, but the error renderer had no `case` for that enum value, so it surfaced as a generic **500 InternalError** rather than 501. Common bulk-delete and sync workflows therefore looked like a server fault.

## Change

Implements the operation rather than just correcting the status code.

- **`s3_delete_objects.c`** (new): accumulate the `<Delete>` body, parse `<Object><Key>` entries (XML-entity unescape, `<Quiet>` support), remove each key via the VFS `lookup → open_fh → remove_at` chain, and emit a `<DeleteResult>` (200 OK). Deletes are **idempotent** — a missing key reports as `<Deleted>`, matching S3 — while `EACCES`/other VFS errors produce `<Error>` entries. An inline-completion trampoline keeps a long batch from recursing once per key.
- **`s3.c`**: parse the `delete` subresource, route `POST?delete` in the dispatch callback, and accumulate the request body in the notify path (mirroring CompleteMultipartUpload).
- **`s3_status.c`**: render `NOT_IMPLEMENTED` as **501 NotImplemented**, so any genuinely unimplemented POST subresource no longer masquerades as a 500.

## Notes

- New `test_delete_objects` (subset delete, idempotent missing key, survivor, quiet mode) is registered as v4 ctest entries for memfs, linux, io_uring, demofs and cairn.
- **V2 signing is intentionally omitted** with a comment: SigV2's canonical resource doesn't include the `?delete` subresource, the same limitation already documented for multipart V2. Re-enable once `build_string_to_sign_v2` learns the AWS V2 subresource list.