### PR TITLE
s3: implement CopyObject (server-side copy)

### DIFF
--- a/src/server/s3/CMakeLists.txt
+++ b/src/server/s3/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 find_package(OpenSSL REQUIRED)
 
-add_library(chimera_s3 SHARED s3.c s3_get.c s3_put.c s3_dump.c s3_status.c s3_delete.c s3_delete_objects.c s3_list.c s3_auth.c s3_multipart.c)
+add_library(chimera_s3 SHARED s3.c s3_get.c s3_put.c s3_copy.c s3_dump.c s3_status.c s3_delete.c s3_delete_objects.c s3_list.c s3_auth.c s3_multipart.c)
 target_link_libraries(chimera_s3 chimera_vfs evpl_http evpl OpenSSL::Crypto)
 
 install(TARGETS chimera_s3 DESTINATION lib)

--- a/src/server/s3/s3.c
+++ b/src/server/s3/s3.c
@@ -304,12 +304,28 @@ chimera_s3_dispatch_callback(
             }
             break;
         case EVPL_HTTP_REQUEST_TYPE_PUT:
+        {
+            const char *copy_source = evpl_http_request_header(
+                s3_request->http_request, "x-amz-copy-source");
+
             if (s3_request->has_upload_id && s3_request->has_part_number) {
-                chimera_s3_upload_part(evpl, thread, s3_request);
+                if (copy_source) {
+                    /* UploadPartCopy (copying a byte range of an existing
+                     * object into an in-progress multipart upload) is not
+                     * implemented yet. Reject explicitly rather than treating
+                     * the (empty) body as the part contents. */
+                    s3_request->status    = CHIMERA_S3_STATUS_NOT_IMPLEMENTED;
+                    s3_request->vfs_state = CHIMERA_S3_VFS_STATE_COMPLETE;
+                } else {
+                    chimera_s3_upload_part(evpl, thread, s3_request);
+                }
+            } else if (copy_source) {
+                chimera_s3_copy(evpl, thread, s3_request);
             } else {
                 chimera_s3_put(evpl, thread, s3_request);
             }
             break;
+        }
         case EVPL_HTTP_REQUEST_TYPE_POST:
             if (s3_request->has_uploads) {
                 chimera_s3_create_multipart_upload(evpl, thread, s3_request);

--- a/src/server/s3/s3_copy.c
+++ b/src/server/s3/s3_copy.c
@@ -1,0 +1,831 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * S3 CopyObject (server-side copy).
+ *
+ * Handles PUT requests carrying an x-amz-copy-source header. The source
+ * object is located and opened, a fresh destination file is created, the
+ * bytes are transferred server-side, and the destination is linked/renamed
+ * into place. The reply is a CopyObjectResult document carrying the ETag and
+ * LastModified of the new object.
+ *
+ * Byte transfer prefers the cheapest primitive the destination module can
+ * offer:
+ *   - clone_range  (reflink / copy-on-write, zero data movement) as a
+ *     whole-file fast path. clone has block-alignment constraints (memfs
+ *     rejects an unaligned length; FICLONERANGE only tolerates the unaligned
+ *     remainder at source EOF), so on any failure we transparently fall back.
+ *   - copy_range   (server-side byte copy, arbitrary length) — same primitive
+ *     the multipart-completion assembler uses.
+ *   - read + write (buffered) — final fallback, and the only option when the
+ *     source and destination live on different VFS modules (range ops are
+ *     intra-module).
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+#include <time.h>
+
+#include "vfs/vfs.h"
+#include "vfs/vfs_procs.h"
+#include "vfs/vfs_release.h"
+#include "s3_internal.h"
+#include "s3_procs.h"
+#include "s3_etag.h"
+#include "s3.h"
+
+enum chimera_s3_copy_mode {
+    CHIMERA_S3_COPY_CLONE,
+    CHIMERA_S3_COPY_COPY,
+    CHIMERA_S3_COPY_RW,
+};
+
+struct chimera_s3_copy_ctx {
+    struct chimera_s3_request      *request;
+    struct chimera_vfs_open_handle *src_handle;
+    enum chimera_s3_copy_mode       mode;
+    uint64_t                        src_size;
+    uint64_t                        offset;
+    int                             tmp_name_len;
+    int                             rw_niov;
+    struct timespec                 src_mtime;
+    int                             src_bucket_namelen;
+    int                             src_key_len;
+    char                            src_bucket_name[256];
+    char                            src_key[1024];
+    char                            tmp_name[64];
+    struct evpl_iovec               rw_iov[CHIMERA_S3_IOV_MAX];
+};
+
+static void chimera_s3_copy_step(
+    struct chimera_s3_copy_ctx *ctx);
+
+/*
+ * URL-decode percent escapes (%XX) from src into dst in place-safe fashion.
+ * '+' is left untouched: S3 copy-source values percent-encode spaces as %20
+ * and do not use form-encoding. Returns the decoded length.
+ */
+static int
+chimera_s3_url_decode(
+    char       *dst,
+    const char *src,
+    int         src_len)
+{
+    int i = 0, o = 0;
+
+    while (i < src_len) {
+        if (src[i] == '%' && i + 2 < src_len &&
+            isxdigit((unsigned char) src[i + 1]) &&
+            isxdigit((unsigned char) src[i + 2])) {
+            char hex[3] = { src[i + 1], src[i + 2], '\0' };
+            dst[o++] = (char) strtol(hex, NULL, 16);
+            i       += 3;
+        } else {
+            dst[o++] = src[i++];
+        }
+    }
+    dst[o] = '\0';
+    return o;
+} /* chimera_s3_url_decode */
+
+/*
+ * Parse an x-amz-copy-source value of the form "[/]bucket/key[?versionId=..]"
+ * into the ctx's source bucket name and key. Returns 0 on success, -1 if the
+ * value is malformed (no key component).
+ */
+static int
+chimera_s3_parse_copy_source(
+    struct chimera_s3_copy_ctx *ctx,
+    const char                 *copy_source)
+{
+    const char *p = copy_source;
+    const char *slash, *qmark;
+    int         bucket_len, key_len;
+
+    while (*p == '/') {
+        p++;
+    }
+
+    slash = strchr(p, '/');
+
+    if (!slash || slash[1] == '\0') {
+        return -1;
+    }
+
+    bucket_len = slash - p;
+
+    if (bucket_len <= 0 || bucket_len >= (int) sizeof(ctx->src_bucket_name)) {
+        return -1;
+    }
+
+    /* Versioning is not supported; drop any ?versionId= suffix. */
+    key_len = strlen(slash + 1);
+    qmark   = memchr(slash + 1, '?', key_len);
+    if (qmark) {
+        key_len = qmark - (slash + 1);
+    }
+
+    if (key_len <= 0 || key_len >= (int) sizeof(ctx->src_key)) {
+        return -1;
+    }
+
+    ctx->src_bucket_namelen = chimera_s3_url_decode(ctx->src_bucket_name,
+                                                    p, bucket_len);
+    ctx->src_key_len = chimera_s3_url_decode(ctx->src_key,
+                                             slash + 1, key_len);
+
+    return 0;
+} /* chimera_s3_parse_copy_source */
+
+/*
+ * Terminal path: release any open handles, free the ctx, and either build the
+ * CopyObjectResult reply (success) or set the error status. The HTTP response
+ * is dispatched here if the request body has already been drained, otherwise
+ * the notify path will dispatch it once it has.
+ */
+static void
+chimera_s3_copy_finish(
+    struct chimera_s3_copy_ctx *ctx,
+    enum chimera_vfs_error      error_code,
+    enum chimera_s3_status      status,
+    struct chimera_vfs_attrs   *dst_attr)
+{
+    struct chimera_s3_request       *request = ctx->request;
+    struct chimera_server_s3_thread *thread  = request->thread;
+    struct evpl                     *evpl    = thread->evpl;
+
+    if (ctx->src_handle) {
+        chimera_vfs_release(thread->vfs, ctx->src_handle);
+    }
+    if (request->file_handle) {
+        chimera_vfs_release(thread->vfs, request->file_handle);
+        request->file_handle = NULL;
+    }
+    if (request->dir_handle) {
+        chimera_vfs_release(thread->vfs, request->dir_handle);
+        request->dir_handle = NULL;
+    }
+
+    if (error_code || status != CHIMERA_S3_STATUS_OK) {
+        request->status = status != CHIMERA_S3_STATUS_OK ?
+            status : CHIMERA_S3_STATUS_INTERNAL_ERROR;
+    } else {
+        char *bp, *body_start;
+        char  etag[80], date[64];
+
+        chimera_s3_attach_etag(request->http_request, dst_attr);
+        chimera_s3_etag_hex(etag, sizeof(etag), dst_attr);
+        chimera_s3_format_date(date, sizeof(date), &dst_attr->va_mtime);
+
+        evpl_iovec_alloc(evpl, 4096, 0, 1, 0, &request->multipart.response);
+
+        bp = body_start = evpl_iovec_data(&request->multipart.response);
+
+        bp += sprintf(bp, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+        bp += sprintf(bp, "<CopyObjectResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\n");
+        bp += sprintf(bp, "  <LastModified>%s</LastModified>\n", date);
+        bp += sprintf(bp, "  <ETag>%s</ETag>\n", etag);
+        bp += sprintf(bp, "</CopyObjectResult>\n");
+
+        evpl_iovec_set_length(&request->multipart.response, bp - body_start);
+        evpl_http_request_add_datav(request->http_request,
+                                    &request->multipart.response, 1);
+
+        request->status           = CHIMERA_S3_STATUS_OK;
+        request->file_length      = bp - body_start;
+        request->file_real_length = request->file_length;
+        request->file_offset      = 0;
+        request->is_list          = 1; /* triggers application/xml Content-Type */
+    }
+
+    request->vfs_state = CHIMERA_S3_VFS_STATE_COMPLETE;
+
+    free(ctx);
+
+    if (request->http_state == CHIMERA_S3_HTTP_STATE_RECVED) {
+        s3_server_respond(evpl, request);
+    }
+} /* chimera_s3_copy_finish */
+
+/* ----- destination attributes (for the reply ETag/LastModified) ----- */
+
+static void
+chimera_s3_copy_getattr_callback(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *attr,
+    void                     *private_data)
+{
+    struct chimera_s3_copy_ctx *ctx = private_data;
+
+    chimera_s3_copy_finish(ctx, error_code, CHIMERA_S3_STATUS_OK, attr);
+} /* chimera_s3_copy_getattr_callback */
+
+static void
+chimera_s3_copy_link_callback(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *r_attr,
+    struct chimera_vfs_attrs *r_dir_pre_attr,
+    struct chimera_vfs_attrs *r_dir_post_attr,
+    void                     *private_data)
+{
+    struct chimera_s3_copy_ctx      *ctx    = private_data;
+    struct chimera_server_s3_thread *thread = ctx->request->thread;
+
+    if (error_code) {
+        chimera_s3_copy_finish(ctx, error_code, CHIMERA_S3_STATUS_OK, NULL);
+        return;
+    }
+
+    chimera_vfs_getattr(thread->vfs, &thread->shared->cred,
+                        ctx->request->file_handle,
+                        CHIMERA_VFS_ATTR_FH | CHIMERA_VFS_ATTR_MASK_STAT,
+                        chimera_s3_copy_getattr_callback,
+                        ctx);
+} /* chimera_s3_copy_link_callback */
+
+static void
+chimera_s3_copy_rename_callback(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *fromdir_pre_attr,
+    struct chimera_vfs_attrs *fromdir_post_attr,
+    struct chimera_vfs_attrs *todir_pre_attr,
+    struct chimera_vfs_attrs *todir_post_attr,
+    void                     *private_data)
+{
+    struct chimera_s3_copy_ctx      *ctx    = private_data;
+    struct chimera_server_s3_thread *thread = ctx->request->thread;
+
+    if (error_code) {
+        chimera_s3_copy_finish(ctx, error_code, CHIMERA_S3_STATUS_OK, NULL);
+        return;
+    }
+
+    chimera_vfs_getattr(thread->vfs, &thread->shared->cred,
+                        ctx->request->file_handle,
+                        CHIMERA_VFS_ATTR_FH | CHIMERA_VFS_ATTR_MASK_STAT,
+                        chimera_s3_copy_getattr_callback,
+                        ctx);
+} /* chimera_s3_copy_rename_callback */
+
+/*
+ * Bytes are in the (still hidden) destination file; publish it under the
+ * destination key. Backends that created the file unlinked link it into the
+ * directory (replacing any existing object); backends that used a temp name
+ * rename over the key.
+ */
+static void
+chimera_s3_copy_finalize(struct chimera_s3_copy_ctx *ctx)
+{
+    struct chimera_s3_request       *request = ctx->request;
+    struct chimera_server_s3_thread *thread  = request->thread;
+
+    if (ctx->tmp_name_len) {
+        chimera_vfs_rename_at(
+            thread->vfs,
+            &thread->shared->cred,
+            request->dir_handle->fh,
+            request->dir_handle->fh_len,
+            ctx->tmp_name,
+            ctx->tmp_name_len,
+            request->dir_handle->fh,
+            request->dir_handle->fh_len,
+            request->name,
+            request->name_len,
+            NULL,
+            0,
+            0,
+            0,
+            chimera_s3_copy_rename_callback,
+            ctx);
+    } else {
+        chimera_vfs_link_at(
+            thread->vfs,
+            &thread->shared->cred,
+            request->file_handle->fh,
+            request->file_handle->fh_len,
+            request->dir_handle->fh,
+            request->dir_handle->fh_len,
+            request->name,
+            request->name_len,
+            1,
+            CHIMERA_VFS_ATTR_FH | CHIMERA_VFS_ATTR_MASK_STAT,
+            0,
+            0,
+            chimera_s3_copy_link_callback,
+            ctx);
+    }
+} /* chimera_s3_copy_finalize */
+
+/* ----- byte transfer ----- */
+
+static void
+chimera_s3_copy_clone_callback(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *pre_attr,
+    struct chimera_vfs_attrs *post_attr,
+    void                     *private_data)
+{
+    struct chimera_s3_copy_ctx      *ctx    = private_data;
+    struct chimera_server_s3_thread *thread = ctx->request->thread;
+    struct chimera_vfs_module       *module;
+
+    if (error_code) {
+        /* clone is best-effort: alignment limits (EINVAL), cross-module
+         * handles (ENOTSUP), or a backend that advertised the capability but
+         * cannot satisfy this particular range. A failed clone makes no
+         * changes to the destination, so restart the whole transfer with a
+         * byte-copy primitive. */
+        module = chimera_vfs_get_module(thread->vfs,
+                                        ctx->request->file_handle->fh,
+                                        ctx->request->file_handle->fh_len);
+
+        ctx->mode = (module->capabilities & CHIMERA_VFS_CAP_COPY_RANGE) ?
+            CHIMERA_S3_COPY_COPY : CHIMERA_S3_COPY_RW;
+        ctx->offset = 0;
+        chimera_s3_copy_step(ctx);
+        return;
+    }
+
+    /* clone transfers the whole remaining range in one shot. */
+    ctx->offset = ctx->src_size;
+    chimera_s3_copy_step(ctx);
+} /* chimera_s3_copy_clone_callback */
+
+static void
+chimera_s3_copy_copy_callback(
+    enum chimera_vfs_error    error_code,
+    uint64_t                  length,
+    struct chimera_vfs_attrs *pre_attr,
+    struct chimera_vfs_attrs *post_attr,
+    void                     *private_data)
+{
+    struct chimera_s3_copy_ctx *ctx = private_data;
+
+    if (error_code) {
+        chimera_s3_copy_finish(ctx, error_code, CHIMERA_S3_STATUS_OK, NULL);
+        return;
+    }
+
+    ctx->offset += length;
+    chimera_s3_copy_step(ctx);
+} /* chimera_s3_copy_copy_callback */
+
+static void
+chimera_s3_copy_write_callback(
+    enum chimera_vfs_error    error_code,
+    uint32_t                  length,
+    uint32_t                  sync,
+    struct chimera_vfs_attrs *pre_attr,
+    struct chimera_vfs_attrs *post_attr,
+    void                     *private_data)
+{
+    struct chimera_s3_copy_ctx      *ctx    = private_data;
+    struct chimera_server_s3_thread *thread = ctx->request->thread;
+    struct evpl                     *evpl   = thread->evpl;
+
+    evpl_iovecs_release(evpl, ctx->rw_iov, ctx->rw_niov);
+    ctx->rw_niov = 0;
+
+    if (error_code) {
+        chimera_s3_copy_finish(ctx, error_code, CHIMERA_S3_STATUS_OK, NULL);
+        return;
+    }
+
+    ctx->offset += length;
+    chimera_s3_copy_step(ctx);
+} /* chimera_s3_copy_write_callback */
+
+static void
+chimera_s3_copy_read_callback(
+    enum chimera_vfs_error    error_code,
+    uint32_t                  count,
+    uint32_t                  eof,
+    struct evpl_iovec        *iov,
+    int                       niov,
+    struct chimera_vfs_attrs *attr,
+    void                     *private_data)
+{
+    struct chimera_s3_copy_ctx      *ctx    = private_data;
+    struct chimera_server_s3_thread *thread = ctx->request->thread;
+
+    if (error_code) {
+        chimera_s3_copy_finish(ctx, error_code, CHIMERA_S3_STATUS_OK, NULL);
+        return;
+    }
+
+    /* The backend filled ctx->rw_iov (the array handed to read); pass it
+     * straight through to write, which will release the descriptors. */
+    ctx->rw_niov = niov;
+
+    chimera_vfs_write(
+        thread->vfs, &thread->shared->cred,
+        ctx->request->file_handle,
+        ctx->offset,
+        count,
+        1,
+        0,
+        0,
+        ctx->rw_iov,
+        ctx->rw_niov,
+        chimera_s3_copy_write_callback,
+        ctx);
+} /* chimera_s3_copy_read_callback */
+
+static void
+chimera_s3_copy_step(struct chimera_s3_copy_ctx *ctx)
+{
+    struct chimera_s3_request       *request = ctx->request;
+    struct chimera_server_s3_thread *thread  = request->thread;
+    uint64_t                         remaining, chunk;
+
+    remaining = ctx->src_size - ctx->offset;
+
+    if (remaining == 0) {
+        chimera_s3_copy_finalize(ctx);
+        return;
+    }
+
+    switch (ctx->mode) {
+        case CHIMERA_S3_COPY_CLONE:
+            /* Whole remaining range in a single reflink. */
+            chimera_vfs_clone_range(
+                thread->vfs, &thread->shared->cred,
+                ctx->src_handle,
+                ctx->offset,
+                request->file_handle,
+                ctx->offset,
+                remaining,
+                0, 0,
+                chimera_s3_copy_clone_callback,
+                ctx);
+            break;
+        case CHIMERA_S3_COPY_COPY:
+            chunk = thread->shared->config->io_size;
+            if (chunk > remaining) {
+                chunk = remaining;
+            }
+            chimera_vfs_copy_range(
+                thread->vfs, &thread->shared->cred,
+                ctx->src_handle,
+                ctx->offset,
+                request->file_handle,
+                ctx->offset,
+                chunk,
+                0, 0,
+                chimera_s3_copy_copy_callback,
+                ctx);
+            break;
+        case CHIMERA_S3_COPY_RW:
+            chunk = thread->shared->config->io_size;
+            if (chunk > remaining) {
+                chunk = remaining;
+            }
+            ctx->rw_niov = CHIMERA_S3_IOV_MAX;
+            chimera_vfs_read(
+                thread->vfs, &thread->shared->cred,
+                ctx->src_handle,
+                ctx->offset,
+                chunk,
+                ctx->rw_iov,
+                ctx->rw_niov,
+                0,
+                chimera_s3_copy_read_callback,
+                ctx);
+            break;
+    } /* switch */
+} /* chimera_s3_copy_step */
+
+/*
+ * Source and destination are both open; choose the transfer primitive.
+ * Range ops are intra-module, so a cross-module copy must use read/write.
+ */
+static void
+chimera_s3_copy_start_transfer(struct chimera_s3_copy_ctx *ctx)
+{
+    struct chimera_s3_request       *request = ctx->request;
+    struct chimera_server_s3_thread *thread  = request->thread;
+    struct chimera_vfs_module       *src_module, *dst_module;
+
+    if (ctx->src_size == 0) {
+        /* Nothing to transfer; just publish the empty object. */
+        ctx->offset = 0;
+        chimera_s3_copy_finalize(ctx);
+        return;
+    }
+
+    src_module = chimera_vfs_get_module(thread->vfs,
+                                        ctx->src_handle->fh,
+                                        ctx->src_handle->fh_len);
+    dst_module = chimera_vfs_get_module(thread->vfs,
+                                        request->file_handle->fh,
+                                        request->file_handle->fh_len);
+
+    if (src_module != dst_module) {
+        ctx->mode = CHIMERA_S3_COPY_RW;
+    } else if (dst_module->capabilities & CHIMERA_VFS_CAP_CLONE_RANGE) {
+        ctx->mode = CHIMERA_S3_COPY_CLONE;
+    } else if (dst_module->capabilities & CHIMERA_VFS_CAP_COPY_RANGE) {
+        ctx->mode = CHIMERA_S3_COPY_COPY;
+    } else {
+        ctx->mode = CHIMERA_S3_COPY_RW;
+    }
+
+    ctx->offset = 0;
+    chimera_s3_copy_step(ctx);
+} /* chimera_s3_copy_start_transfer */
+
+/* ----- destination creation (mirrors the PutObject create path) ----- */
+
+static void
+chimera_s3_copy_create_unlinked_callback(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *oh,
+    struct chimera_vfs_attrs       *set_attr,
+    struct chimera_vfs_attrs       *attr,
+    void                           *private_data)
+{
+    struct chimera_s3_copy_ctx *ctx = private_data;
+
+    if (error_code) {
+        chimera_s3_copy_finish(ctx, error_code, CHIMERA_S3_STATUS_OK, NULL);
+        return;
+    }
+
+    ctx->request->file_handle = oh;
+    chimera_s3_copy_start_transfer(ctx);
+} /* chimera_s3_copy_create_unlinked_callback */
+
+static void
+chimera_s3_copy_create_callback(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *oh,
+    struct chimera_vfs_attrs       *set_attr,
+    struct chimera_vfs_attrs       *attr,
+    struct chimera_vfs_attrs       *dir_pre_attr,
+    struct chimera_vfs_attrs       *dir_post_attr,
+    void                           *private_data)
+{
+    struct chimera_s3_copy_ctx *ctx = private_data;
+
+    if (error_code) {
+        chimera_s3_copy_finish(ctx, error_code, CHIMERA_S3_STATUS_OK, NULL);
+        return;
+    }
+
+    ctx->request->file_handle = oh;
+    chimera_s3_copy_start_transfer(ctx);
+} /* chimera_s3_copy_create_callback */
+
+static void
+chimera_s3_copy_open_dir_callback(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *oh,
+    void                           *private_data)
+{
+    struct chimera_s3_copy_ctx      *ctx     = private_data;
+    struct chimera_s3_request       *request = ctx->request;
+    struct chimera_server_s3_thread *thread  = request->thread;
+    struct chimera_vfs_module       *module;
+
+    if (error_code) {
+        chimera_s3_copy_finish(ctx, error_code, CHIMERA_S3_STATUS_NO_SUCH_KEY,
+                               NULL);
+        return;
+    }
+
+    request->dir_handle = oh;
+
+    request->set_attr.va_req_mask = 0;
+    request->set_attr.va_set_mask = 0;
+
+    module = chimera_vfs_get_module(thread->vfs, oh->fh, oh->fh_len);
+
+    if (module->capabilities & CHIMERA_VFS_CAP_CREATE_UNLINKED) {
+        ctx->tmp_name_len = 0;
+        chimera_vfs_create_unlinked(
+            thread->vfs, &thread->shared->cred,
+            oh->fh,
+            oh->fh_len,
+            &request->set_attr,
+            CHIMERA_VFS_ATTR_FH,
+            chimera_s3_copy_create_unlinked_callback,
+            ctx);
+    } else {
+        ctx->tmp_name_len = snprintf(ctx->tmp_name, sizeof(ctx->tmp_name),
+                                     "._chimera_cp_%lx%lx", (uint64_t) request,
+                                     (uint64_t) request->start_time.tv_nsec);
+        chimera_vfs_open_at(
+            thread->vfs, &thread->shared->cred,
+            oh,
+            ctx->tmp_name,
+            ctx->tmp_name_len,
+            CHIMERA_VFS_OPEN_CREATE,
+            &request->set_attr,
+            CHIMERA_VFS_ATTR_FH,
+            0,
+            0,
+            chimera_s3_copy_create_callback,
+            ctx);
+    }
+} /* chimera_s3_copy_open_dir_callback */
+
+static void
+chimera_s3_copy_create_dir_callback(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *attr,
+    void                     *private_data)
+{
+    struct chimera_s3_copy_ctx      *ctx    = private_data;
+    struct chimera_server_s3_thread *thread = ctx->request->thread;
+
+    if (error_code) {
+        chimera_s3_copy_finish(ctx, error_code, CHIMERA_S3_STATUS_NO_SUCH_KEY,
+                               NULL);
+        return;
+    }
+
+    chimera_vfs_open_fh(thread->vfs, &thread->shared->cred,
+                        attr->va_fh,
+                        attr->va_fh_len,
+                        CHIMERA_VFS_OPEN_PATH | CHIMERA_VFS_OPEN_INFERRED |
+                        CHIMERA_VFS_OPEN_DIRECTORY,
+                        chimera_s3_copy_open_dir_callback,
+                        ctx);
+} /* chimera_s3_copy_create_dir_callback */
+
+/* ----- source open ----- */
+
+static void
+chimera_s3_copy_open_src_callback(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *oh,
+    void                           *private_data)
+{
+    struct chimera_s3_copy_ctx      *ctx     = private_data;
+    struct chimera_s3_request       *request = ctx->request;
+    struct chimera_server_s3_thread *thread  = request->thread;
+    const char                      *slash;
+    const char                      *dirpath;
+    int                              dirpathlen;
+
+    if (error_code) {
+        chimera_s3_copy_finish(ctx, error_code, CHIMERA_S3_STATUS_NO_SUCH_KEY,
+                               NULL);
+        return;
+    }
+
+    ctx->src_handle = oh;
+
+    /* Resolve the destination directory and key from the request path,
+     * exactly as PutObject does, then create the destination there. */
+    slash = rindex(request->path, '/');
+
+    if (slash) {
+        dirpath       = request->path;
+        dirpathlen    = slash - request->path;
+        request->name = slash + 1;
+        while (*request->name == '/') {
+            request->name++;
+        }
+    } else {
+        dirpath       = "/";
+        dirpathlen    = 1;
+        request->name = request->path;
+    }
+
+    request->name_len = strlen(request->name);
+
+    if (request->name_len == 0) {
+        chimera_s3_copy_finish(ctx, 0, CHIMERA_S3_STATUS_BAD_REQUEST, NULL);
+        return;
+    }
+
+    request->set_attr.va_req_mask = 0;
+    request->set_attr.va_set_mask = 0;
+
+    chimera_vfs_create(thread->vfs, &thread->shared->cred,
+                       request->bucket_fh,
+                       request->bucket_fhlen,
+                       dirpath,
+                       dirpathlen,
+                       &request->set_attr,
+                       CHIMERA_VFS_ATTR_FH,
+                       chimera_s3_copy_create_dir_callback,
+                       ctx);
+} /* chimera_s3_copy_open_src_callback */
+
+static void
+chimera_s3_copy_lookup_src_callback(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *attr,
+    void                     *private_data)
+{
+    struct chimera_s3_copy_ctx      *ctx    = private_data;
+    struct chimera_server_s3_thread *thread = ctx->request->thread;
+
+    if (error_code) {
+        chimera_s3_copy_finish(ctx, error_code, CHIMERA_S3_STATUS_NO_SUCH_KEY,
+                               NULL);
+        return;
+    }
+
+    chimera_s3_abort_if(
+        (attr->va_set_mask & (CHIMERA_VFS_ATTR_FH | CHIMERA_VFS_ATTR_SIZE |
+                              CHIMERA_VFS_ATTR_MTIME)) !=
+        (CHIMERA_VFS_ATTR_FH | CHIMERA_VFS_ATTR_SIZE | CHIMERA_VFS_ATTR_MTIME),
+        "copy source lookup: missing attributes");
+
+    ctx->src_size  = attr->va_size;
+    ctx->src_mtime = attr->va_mtime;
+
+    chimera_vfs_open_fh(thread->vfs, &thread->shared->cred,
+                        attr->va_fh,
+                        attr->va_fh_len,
+                        0,
+                        chimera_s3_copy_open_src_callback,
+                        ctx);
+} /* chimera_s3_copy_lookup_src_callback */
+
+static void
+chimera_s3_copy_lookup_src_bucket_callback(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *attr,
+    void                     *private_data)
+{
+    struct chimera_s3_copy_ctx      *ctx    = private_data;
+    struct chimera_server_s3_thread *thread = ctx->request->thread;
+
+    if (error_code) {
+        chimera_s3_copy_finish(ctx, error_code,
+                               CHIMERA_S3_STATUS_NO_SUCH_BUCKET, NULL);
+        return;
+    }
+
+    chimera_vfs_lookup(thread->vfs, &thread->shared->cred,
+                       attr->va_fh,
+                       attr->va_fh_len,
+                       ctx->src_key,
+                       ctx->src_key_len,
+                       CHIMERA_VFS_ATTR_FH | CHIMERA_VFS_ATTR_MASK_STAT,
+                       CHIMERA_VFS_LOOKUP_FOLLOW,
+                       chimera_s3_copy_lookup_src_callback,
+                       ctx);
+} /* chimera_s3_copy_lookup_src_bucket_callback */
+
+void
+chimera_s3_copy(
+    struct evpl                     *evpl,
+    struct chimera_server_s3_thread *thread,
+    struct chimera_s3_request       *request)
+{
+    struct chimera_server_s3_shared *shared = thread->shared;
+    struct chimera_s3_copy_ctx      *ctx;
+    const char                      *copy_source;
+    const struct s3_bucket          *src_bucket;
+    const char                      *src_path;
+
+    copy_source = evpl_http_request_header(request->http_request,
+                                           "x-amz-copy-source");
+
+    ctx          = calloc(1, sizeof(*ctx));
+    ctx->request = request;
+
+    request->dir_handle  = NULL;
+    request->file_handle = NULL;
+
+    if (!copy_source || chimera_s3_parse_copy_source(ctx, copy_source) != 0) {
+        chimera_s3_copy_finish(ctx, 0, CHIMERA_S3_STATUS_BAD_REQUEST, NULL);
+        return;
+    }
+
+    /* chimera_s3_get_bucket() acquires the bucket-map read lock and leaves it
+     * held; chimera_s3_release_bucket() drops it. The path string stays valid
+     * past the unlock for the duration of the request (buckets are not freed
+     * underneath in-flight operations), matching the dispatch path. */
+    src_bucket = chimera_s3_get_bucket(shared, ctx->src_bucket_name);
+
+    if (src_bucket == NULL) {
+        chimera_s3_release_bucket(shared);
+        chimera_s3_copy_finish(ctx, 0, CHIMERA_S3_STATUS_NO_SUCH_BUCKET, NULL);
+        return;
+    }
+
+    src_path = chimera_s3_bucket_get_path(src_bucket);
+
+    chimera_vfs_lookup(thread->vfs,
+                       &thread->shared->cred,
+                       shared->root_fh,
+                       shared->root_fh_len,
+                       src_path,
+                       strlen(src_path),
+                       CHIMERA_VFS_ATTR_FH,
+                       CHIMERA_VFS_LOOKUP_FOLLOW,
+                       chimera_s3_copy_lookup_src_bucket_callback,
+                       ctx);
+
+    chimera_s3_release_bucket(shared);
+} /* chimera_s3_copy */

--- a/src/server/s3/s3_copy.c
+++ b/src/server/s3/s3_copy.c
@@ -343,7 +343,8 @@ chimera_s3_copy_clone_callback(
                                         ctx->request->file_handle->fh,
                                         ctx->request->file_handle->fh_len);
 
-        ctx->mode = (module->capabilities & CHIMERA_VFS_CAP_COPY_RANGE) ?
+        ctx->mode = (module &&
+                     (module->capabilities & CHIMERA_VFS_CAP_COPY_RANGE)) ?
             CHIMERA_S3_COPY_COPY : CHIMERA_S3_COPY_RW;
         ctx->offset = 0;
         chimera_s3_copy_step(ctx);
@@ -524,7 +525,9 @@ chimera_s3_copy_start_transfer(struct chimera_s3_copy_ctx *ctx)
                                         request->file_handle->fh,
                                         request->file_handle->fh_len);
 
-    if (src_module != dst_module) {
+    if (!dst_module || src_module != dst_module) {
+        /* Range ops require both handles on the same (resolvable) module;
+         * otherwise the buffered read+write path is the only option. */
         ctx->mode = CHIMERA_S3_COPY_RW;
     } else if (dst_module->capabilities & CHIMERA_VFS_CAP_CLONE_RANGE) {
         ctx->mode = CHIMERA_S3_COPY_CLONE;

--- a/src/server/s3/s3_procs.h
+++ b/src/server/s3/s3_procs.h
@@ -18,6 +18,13 @@ chimera_s3_put(
     );
 
 void
+chimera_s3_copy(
+    struct evpl                     *evpl,
+    struct chimera_server_s3_thread *thread,
+    struct chimera_s3_request       *request
+    );
+
+void
 chimera_s3_get_send(
     struct evpl               *evpl,
     struct chimera_s3_request *request);

--- a/src/server/s3/s3_status.c
+++ b/src/server/s3/s3_status.c
@@ -132,6 +132,11 @@ chimera_s3_prepare_error_response(
                           "  <Message>The XML you provided was not well-formed or did not validate against our published schema.</Message>\n");
             code = 400;
             break;
+        case CHIMERA_S3_STATUS_BAD_REQUEST:
+            bp  += sprintf(bp, "  <Code>InvalidArgument</Code>\n");
+            bp  += sprintf(bp, "  <Message>Invalid Argument</Message>\n");
+            code = 400;
+            break;
         case CHIMERA_S3_STATUS_NOT_IMPLEMENTED:
             bp += sprintf(bp, "  <Code>NotImplemented</Code>\n");
             bp += sprintf(bp,

--- a/src/server/s3/tests/CMakeLists.txt
+++ b/src/server/s3/tests/CMakeLists.txt
@@ -61,6 +61,7 @@ if(BOTO3_FOUND)
     add_s3_test(delete memfs)
     add_s3_test(delete_objects memfs)
     add_s3_test(list memfs)
+    add_s3_test(copy memfs)
     add_s3_test(multipart memfs)
 
     # linux tests (V4)
@@ -70,6 +71,7 @@ if(BOTO3_FOUND)
     add_s3_test(delete linux)
     add_s3_test(delete_objects linux)
     add_s3_test(list linux)
+    add_s3_test(copy linux)
     add_s3_test(multipart linux)
 
     # io_uring tests (V4)
@@ -80,6 +82,7 @@ if(BOTO3_FOUND)
         add_s3_test(delete io_uring)
         add_s3_test(delete_objects io_uring)
         add_s3_test(list io_uring)
+        add_s3_test(copy io_uring)
         add_s3_test(multipart io_uring)
 
         # demofs tests (V4) - demofs uses io_uring backend
@@ -89,10 +92,10 @@ if(BOTO3_FOUND)
         add_s3_test(delete demofs)
         add_s3_test(delete_objects demofs)
         add_s3_test(list demofs)
-        # demofs multipart is omitted: assembly via read+write across two
-        # files on demofs produces corrupted output; suspected demofs bug
-        # (cairn, which takes the same RW assembly path, works fine).
-        # Re-enable when demofs read/write interleaving is investigated.
+        # demofs multipart and copy are omitted: both fall back to read+write
+        # across two files, which produces corrupted output on demofs;
+        # suspected demofs bug (cairn, which takes the same RW path, works
+        # fine). Re-enable when demofs read/write interleaving is investigated.
     endif()
 
     # cairn tests (V4)
@@ -102,6 +105,7 @@ if(BOTO3_FOUND)
     add_s3_test(delete cairn)
     add_s3_test(delete_objects cairn)
     add_s3_test(list cairn)
+    add_s3_test(copy cairn)
     add_s3_test(multipart cairn)
 
     # ==================== V2 Signature Tests ====================
@@ -112,6 +116,7 @@ if(BOTO3_FOUND)
     add_s3_test_sigver(head memfs v2)
     add_s3_test_sigver(delete memfs v2)
     add_s3_test_sigver(list memfs v2)
+    add_s3_test_sigver(copy memfs v2)
     # Multipart and DeleteObjects V2 omitted: V2 signing's canonical resource
     # doesn't include the subresources (uploads, uploadId, partNumber, delete)
     # that boto3 adds to its signature. Re-enable when build_string_to_sign_v2

--- a/src/server/s3/tests/s3_test.py
+++ b/src/server/s3/tests/s3_test.py
@@ -429,6 +429,83 @@ def test_list(client, bucket):
     print("LIST tests passed!")
 
 
+def test_copy(client, bucket):
+    """Test server-side CopyObject (x-amz-copy-source) operations.
+
+    Exercises the copy handler's transfer paths (clone_range fast path,
+    copy_range, and the read+write fallback are selected per backend) plus
+    source/destination parsing and the error paths.
+    """
+    print("Testing COPY operations...")
+
+    data = b'abcd' * 1024  # 4096 bytes
+    client.put_object(Bucket=bucket, Key='copydir/src1', Body=data)
+
+    # Simple copy to a new key.
+    client.copy_object(Bucket=bucket, Key='copydir/dst1',
+                       CopySource={'Bucket': bucket, 'Key': 'copydir/src1'})
+    assert client.get_object(Bucket=bucket, Key='copydir/dst1')['Body'].read() == data
+    print("  COPY src1 -> dst1 (4KB) - content matches")
+
+    # Source must remain intact (copy, not move).
+    assert client.get_object(Bucket=bucket, Key='copydir/src1')['Body'].read() == data
+    print("  source intact after copy - OK")
+
+    # Empty object.
+    client.put_object(Bucket=bucket, Key='copydir/empty', Body=b'')
+    client.copy_object(Bucket=bucket, Key='copydir/empty_copy',
+                       CopySource={'Bucket': bucket, 'Key': 'copydir/empty'})
+    assert client.get_object(Bucket=bucket, Key='copydir/empty_copy')['Body'].read() == b''
+    print("  COPY empty object - OK")
+
+    # Large, deliberately non-block-aligned object. On reflink-capable
+    # backends this forces the clone fast path to fall back (an unaligned
+    # interior length is rejected) to copy_range / read+write.
+    large = b'z' * (5 * 1024 * 1024 + 123)
+    client.put_object(Bucket=bucket, Key='copydir/large', Body=large)
+    client.copy_object(Bucket=bucket, Key='copydir/large_copy',
+                       CopySource={'Bucket': bucket, 'Key': 'copydir/large'})
+    body = client.get_object(Bucket=bucket, Key='copydir/large_copy')['Body'].read()
+    assert len(body) == len(large), f"size {len(body)} != {len(large)}"
+    assert body == large, "large copy content mismatch"
+    print("  COPY large unaligned (5MB+123) - content matches")
+
+    # Copy over an existing destination object (replace).
+    client.put_object(Bucket=bucket, Key='copydir/dst2', Body=b'stale-contents')
+    client.copy_object(Bucket=bucket, Key='copydir/dst2',
+                       CopySource={'Bucket': bucket, 'Key': 'copydir/src1'})
+    assert client.get_object(Bucket=bucket, Key='copydir/dst2')['Body'].read() == data
+    print("  COPY overwrites existing destination - OK")
+
+    # CopySource passed as a raw "bucket/key" string.
+    client.copy_object(Bucket=bucket, Key='copydir/dst3',
+                       CopySource=f'{bucket}/copydir/src1')
+    assert client.get_object(Bucket=bucket, Key='copydir/dst3')['Body'].read() == data
+    print("  COPY with string CopySource - OK")
+
+    # Missing source key -> NoSuchKey.
+    try:
+        client.copy_object(Bucket=bucket, Key='copydir/nope',
+                           CopySource={'Bucket': bucket, 'Key': 'copydir/does_not_exist'})
+        raise AssertionError("copy of missing source should fail")
+    except ClientError as e:
+        if e.response['Error']['Code'] != 'NoSuchKey':
+            raise
+    print("  COPY missing source -> NoSuchKey (ok)")
+
+    # Missing source bucket -> NoSuchBucket.
+    try:
+        client.copy_object(Bucket=bucket, Key='copydir/nope2',
+                           CopySource={'Bucket': 'no_such_bucket_xyz', 'Key': 'copydir/src1'})
+        raise AssertionError("copy from missing bucket should fail")
+    except ClientError as e:
+        if e.response['Error']['Code'] != 'NoSuchBucket':
+            raise
+    print("  COPY missing source bucket -> NoSuchBucket (ok)")
+
+    print("COPY tests passed!")
+
+
 def _multipart_upload_and_verify(client, bucket, key, part_sizes):
     """Helper: run a full multipart upload and verify the assembled bytes
     match the concatenation of the part bodies. Exercises whichever
@@ -731,6 +808,7 @@ TESTS = {
     'delete': test_delete,
     'delete_objects': test_delete_objects,
     'list': test_list,
+    'copy': test_copy,
     'multipart': test_multipart,
 }
 

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -3544,7 +3544,7 @@ memfs_link_at(
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
-    struct memfs_inode  *parent_inode, *inode;
+    struct memfs_inode  *parent_inode, *inode, *existing_inode;
     struct memfs_dirent *dirent, *existing_dirent;
     struct timespec      now;
     uint64_t             hash;
@@ -3592,11 +3592,64 @@ memfs_link_at(
     rb_tree_query_exact(&parent_inode->dir.dirents, hash, hash, existing_dirent);
 
     if (existing_dirent) {
-        pthread_mutex_unlock(&parent_inode->lock);
-        pthread_mutex_unlock(&inode->lock);
-        request->status = CHIMERA_VFS_EEXIST;
-        request->complete(request);
-        return;
+        /* The name is taken. Without an explicit replace request this is an
+         * error; with one we clobber the existing entry (CIFS rename with
+         * replace-if-exists, S3 PutObject/CopyObject overwrite). */
+        if (!request->link_at.replace) {
+            pthread_mutex_unlock(&parent_inode->lock);
+            pthread_mutex_unlock(&inode->lock);
+            request->status = CHIMERA_VFS_EEXIST;
+            request->complete(request);
+            return;
+        }
+
+        /* If the name already points at the link target itself, the link is
+         * already in place — succeed without disturbing it. Guard this before
+         * locking the existing inode, which would otherwise self-deadlock on
+         * the target's mutex. */
+        if (existing_dirent->inum == inode->inum &&
+            existing_dirent->gen == inode->gen) {
+            inode->ctime        = now;
+            parent_inode->mtime = now;
+            parent_inode->ctime = now;
+            memfs_map_attrs(shared, &request->link_at.r_dir_post_attr,
+                            parent_inode, request->link_at.dir_fh);
+            memfs_map_attrs(shared, &request->link_at.r_attr, inode,
+                            request->fh);
+            pthread_mutex_unlock(&parent_inode->lock);
+            pthread_mutex_unlock(&inode->lock);
+            request->status = CHIMERA_VFS_OK;
+            request->complete(request);
+            return;
+        }
+
+        existing_inode = memfs_inode_get_inum(shared, existing_dirent->inum,
+                                              existing_dirent->gen);
+
+        /* Refuse to clobber a directory with a file link. */
+        if (existing_inode && S_ISDIR(existing_inode->mode)) {
+            pthread_mutex_unlock(&parent_inode->lock);
+            pthread_mutex_unlock(&inode->lock);
+            pthread_mutex_unlock(&existing_inode->lock);
+            request->status = CHIMERA_VFS_EISDIR;
+            request->complete(request);
+            return;
+        }
+
+        /* Detach the existing entry and release its inode link, freeing the
+         * inode if it now has neither links nor open handles (mirrors
+         * memfs_remove_at). */
+        rb_tree_remove(&parent_inode->dir.dirents, &existing_dirent->node);
+
+        if (existing_inode) {
+            existing_inode->nlink--;
+            if (existing_inode->nlink == 0 && --existing_inode->refcnt == 0) {
+                memfs_inode_free(thread, existing_inode);
+            }
+            pthread_mutex_unlock(&existing_inode->lock);
+        }
+
+        memfs_dirent_free(thread, existing_dirent);
     }
 
     dirent = memfs_dirent_alloc(thread,


### PR DESCRIPTION
## Summary

`x-amz-copy-source` was never inspected, so `aws s3 cp s3://a s3://b` (and CLI renames, which are implemented as copy+delete) fell through to the PutObject path and **overwrote the destination with an empty body**. This adds a real server-side CopyObject handler.

## What's here

- **New `s3_copy.c` (`chimera_s3_copy`)**: parses `x-amz-copy-source` (`[/]bucket/key[?versionId=…]`, percent-decoded), opens the source, creates the destination via the same create-unlinked/temp-file path PutObject uses, transfers the bytes, links/renames into place, and replies with a `CopyObjectResult` (ETag + LastModified).
- **Transfer primitive selection**: prefers `clone_range` (reflink / copy-on-write, zero data movement) as a whole-file fast path, falling back to `copy_range` and then buffered read+write. The fallback chain is load-bearing — `clone_range` can't be the sole mechanism because it has block-alignment constraints (memfs rejects an unaligned length; `FICLONERANGE` only tolerates the unaligned remainder at source EOF) and only works within a single VFS module. Cross-module copies use read+write.
- **Dispatch wiring** (`s3.c`): PUT + copy-source (no upload-id) routes to copy. `UploadPartCopy` (PUT with uploadId + partNumber + copy-source) is explicitly rejected `NotImplemented` (501) rather than silently corrupting the upload — left as a follow-up.

## Incidental fix: `memfs_link_at` ignored `replace`

While testing overwrite, I found `memfs_link_at` always returned `EEXIST`, ignoring its `replace` flag. This silently broke overwriting an existing key for **both PutObject and CopyObject on memfs**, and for **SMB rename-with-replace** (`smb_proc_set_info` passes `replace_if_exist`). NFS link callers pass `replace=0` and are unaffected. The fix mirrors `memfs_rename_at`'s replace handling: same-inode no-op guard, `EISDIR` guard, and dirent detach + `nlink`/`refcnt` drop like `memfs_remove_at`. Verified clean under AddressSanitizer.

## Tests

New `test_copy` covers small / empty / large-unaligned / overwrite / string CopySource and the missing-key / missing-bucket error paths. Registered for memfs, linux, cairn, io_uring, and v2-signature memfs. Omitted for demofs (hits the same read+write cross-file corruption that already omits demofs multipart).

Passes locally on memfs / linux / cairn (Release and Debug/ASan); existing S3 suite still green. KVM/SMB `make check` steps were not run in this environment.