### PR TITLE
s3: de-chunk SigV4 streaming (aws-chunked) uploads

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get -y update && \
     net-tools tshark tcpdump uuid-dev iproute2 man-db manpages-dev ca-certificates ssh libjansson-dev libclang-rt-18-dev llvm wget \
     libxxhash-dev liburcu-dev librdmacm-dev liburing-dev libaio-dev libunwind-dev librocksdb-dev libcurl4-openssl-dev clangd uthash-dev libnuma-dev \
     libcurl4-openssl-dev build-essential ruby-full autoconf automake make libtool pkg-config libs3-dev gh npm reuse libssl-dev openssl \
-    libkrb5-3 libkrb5-dev libgssapi-krb5-2 libwbclient-dev curl jq libicu-dev \
+    libkrb5-3 libkrb5-dev libgssapi-krb5-2 libwbclient-dev curl jq libicu-dev awscli \
     krb5-kdc krb5-admin-server krb5-user python3-pip python3-setuptools \
     samba samba-ad-dc samba-ad-provision samba-vfs-modules smbclient && \
     gem install jekyll bundler

--- a/src/server/s3/s3.c
+++ b/src/server/s3/s3.c
@@ -355,6 +355,7 @@ s3_server_dispatch(
     s3_request->has_uploads        = 0;
     s3_request->has_upload_id      = 0;
     s3_request->has_part_number    = 0;
+    s3_request->chunked            = 0;
     s3_request->query_upload_idlen = 0;
     s3_request->query_part_number  = 0;
     s3_request->http_request       = request;
@@ -387,6 +388,19 @@ s3_server_dispatch(
             s3_request->vfs_state = CHIMERA_S3_VFS_STATE_COMPLETE;
             return;
     } /* switch */
+
+    /* SigV4 streaming uploads (aws-chunked) carry the object body wrapped in
+     * chunk framing rather than as raw bytes. The sentinel lives in
+     * x-amz-content-sha256; flag the request so the PUT / UploadPart body
+     * handlers de-chunk before writing to the VFS. */
+    {
+        const char *content_sha256 = evpl_http_request_header(request, "x-amz-content-sha256");
+
+        if (content_sha256 && strncmp(content_sha256, "STREAMING-", 10) == 0) {
+            s3_request->chunked = 1;
+            s3_chunk_decoder_init(&s3_request->chunk);
+        }
+    }
 
     host_header = evpl_http_request_header(request, "Host");
 

--- a/src/server/s3/s3_auth.c
+++ b/src/server/s3/s3_auth.c
@@ -854,7 +854,15 @@ build_canonical_request_v4(
     /* Signed Headers */
     offset += snprintf(canonical_request + offset, max_len - offset, "%s\n", signed_headers);
 
-    /* Hashed Payload */
+    /* Hashed Payload.
+     *
+     * For SigV4 streaming uploads the client sends a sentinel here
+     * (STREAMING-AWS4-HMAC-SHA256-PAYLOAD or STREAMING-UNSIGNED-PAYLOAD-TRAILER)
+     * rather than a payload hash, and that literal value is exactly what the
+     * seed signature is computed over -- so copying it verbatim is correct.
+     * The streaming sentinel additionally signals that the body is wrapped in
+     * aws-chunked framing; the PUT / UploadPart handlers detect it (see
+     * s3_server_dispatch) and de-chunk the body before storing it. */
     const char *content_sha256 = evpl_http_request_header(request, "x-amz-content-sha256");
     if (content_sha256) {
         strncpy(payload_hash, content_sha256, sizeof(payload_hash) - 1);

--- a/src/server/s3/s3_chunk.h
+++ b/src/server/s3/s3_chunk.h
@@ -1,0 +1,174 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#pragma once
+
+#include <stdint.h>
+#include <string.h>
+
+/*
+ * Streaming decoder for the AWS "aws-chunked" content encoding used by
+ * SigV4 streaming uploads (x-amz-content-sha256:
+ * STREAMING-AWS4-HMAC-SHA256-PAYLOAD and STREAMING-UNSIGNED-PAYLOAD-TRAILER).
+ *
+ * The body is a sequence of chunks, each framed as:
+ *
+ *     <hex-size>[;chunk-signature=<hex>]\r\n
+ *     <chunk-data>\r\n
+ *
+ * terminated by a zero-length chunk followed by optional trailer headers and
+ * a final CRLF:
+ *
+ *     0[;chunk-signature=<hex>]\r\n
+ *     [trailer-header\r\n]...
+ *     \r\n
+ *
+ * The decoder is byte-oriented and fully resumable, so a chunk header, data
+ * region or trailer may be split arbitrarily across successive calls (i.e.
+ * across separate network reads / iovecs). We do not verify per-chunk
+ * signatures; the seed signature in the Authorization header is validated by
+ * the normal auth path, and the chunk-signature extension is skipped.
+ */
+
+enum s3_chunk_state {
+    S3_CHUNK_SIZE,       /* accumulating the hex chunk-size */
+    S3_CHUNK_EXT,        /* skipping a ;chunk-ext up to CR */
+    S3_CHUNK_SIZE_CR,    /* saw CR ending the size line, expect LF */
+    S3_CHUNK_DATA,       /* copying chunk-data payload bytes */
+    S3_CHUNK_DATA_CR,    /* expect CR following chunk-data */
+    S3_CHUNK_DATA_LF,    /* expect LF following chunk-data CR */
+    S3_CHUNK_TRAILER,    /* past the zero chunk: drain trailer + final CRLF */
+};
+
+struct s3_chunk_decoder {
+    enum s3_chunk_state state;
+    uint64_t remaining;             /* hex accumulator, then data bytes left */
+    int      done;                  /* saw the terminating zero-length chunk */
+    int      error;                 /* malformed framing encountered */
+};
+
+static inline void
+s3_chunk_decoder_init(struct s3_chunk_decoder *d)
+{
+    d->state     = S3_CHUNK_SIZE;
+    d->remaining = 0;
+    d->done      = 0;
+    d->error     = 0;
+} /* s3_chunk_decoder_init */
+
+static inline int
+s3_chunk_hexval(int c)
+{
+    if (c >= '0' && c <= '9') {
+        return c - '0';
+    }
+    if (c >= 'a' && c <= 'f') {
+        return c - 'a' + 10;
+    }
+    if (c >= 'A' && c <= 'F') {
+        return c - 'A' + 10;
+    }
+    return -1;
+} /* s3_chunk_hexval */
+
+/*
+ * Decode up to in_len bytes of aws-chunked input, appending the decoded
+ * payload bytes to out at offset *out_len (and advancing *out_len). Because
+ * decoding only ever strips framing, the decoded output is never larger than
+ * the input, so callers can size out to at least in_len. Returns 0 on success
+ * or -1 if the framing is malformed (d->error is also set).
+ */
+static inline int
+s3_chunk_decode(
+    struct s3_chunk_decoder *d,
+    const uint8_t           *in,
+    int                      in_len,
+    uint8_t                 *out,
+    int                     *out_len)
+{
+    int i = 0;
+
+    while (i < in_len) {
+        uint8_t c = in[i];
+
+        switch (d->state) {
+            case S3_CHUNK_SIZE:
+            {
+                int v = s3_chunk_hexval(c);
+                if (v >= 0) {
+                    d->remaining = (d->remaining << 4) | (uint64_t) v;
+                    i++;
+                } else if (c == ';') {
+                    d->state = S3_CHUNK_EXT;
+                    i++;
+                } else if (c == '\r') {
+                    d->state = S3_CHUNK_SIZE_CR;
+                    i++;
+                } else {
+                    d->error = 1;
+                    return -1;
+                }
+            }
+            break;
+            case S3_CHUNK_EXT:
+                if (c == '\r') {
+                    d->state = S3_CHUNK_SIZE_CR;
+                }
+                i++;
+                break;
+            case S3_CHUNK_SIZE_CR:
+                if (c != '\n') {
+                    d->error = 1;
+                    return -1;
+                }
+                i++;
+                if (d->remaining == 0) {
+                    /* Zero-length chunk: body data is complete. */
+                    d->state = S3_CHUNK_TRAILER;
+                    d->done  = 1;
+                } else {
+                    d->state = S3_CHUNK_DATA;
+                }
+                break;
+            case S3_CHUNK_DATA:
+            {
+                uint64_t avail = (uint64_t) (in_len - i);
+                uint64_t n     = d->remaining < avail ? d->remaining : avail;
+
+                memcpy(out + *out_len, in + i, n);
+                *out_len     += (int) n;
+                i            += (int) n;
+                d->remaining -= n;
+
+                if (d->remaining == 0) {
+                    d->state = S3_CHUNK_DATA_CR;
+                }
+            }
+            break;
+            case S3_CHUNK_DATA_CR:
+                if (c != '\r') {
+                    d->error = 1;
+                    return -1;
+                }
+                d->state = S3_CHUNK_DATA_LF;
+                i++;
+                break;
+            case S3_CHUNK_DATA_LF:
+                if (c != '\n') {
+                    d->error = 1;
+                    return -1;
+                }
+                d->state     = S3_CHUNK_SIZE;
+                d->remaining = 0;
+                i++;
+                break;
+            case S3_CHUNK_TRAILER:
+                /* Trailer headers and the final CRLF carry no object data. */
+                i++;
+                break;
+        } /* switch */
+    }
+
+    return 0;
+} /* s3_chunk_decode */

--- a/src/server/s3/s3_get.c
+++ b/src/server/s3/s3_get.c
@@ -155,6 +155,7 @@ chimera_s3_get_lookup_callback(
     }
 
     chimera_s3_attach_etag(request->http_request, attr);
+    chimera_s3_attach_last_modified(request->http_request, attr);
 
     request->file_real_length = attr->va_size;
 

--- a/src/server/s3/s3_internal.h
+++ b/src/server/s3/s3_internal.h
@@ -13,6 +13,7 @@
 #include "vfs/vfs.h"
 #include "vfs/vfs_cred.h"
 #include "s3_cred_cache.h"
+#include "s3_chunk.h"
 
 enum chimera_s3_vfs_state {
     CHIMERA_S3_VFS_STATE_INIT,
@@ -64,6 +65,7 @@ struct chimera_s3_request {
     int                              has_uploads;
     int                              has_upload_id;
     int                              has_part_number;
+    int                              chunked;
     int                              query_upload_idlen;
     int                              query_part_number;
     char                             query_upload_id[CHIMERA_S3_UPLOAD_ID_LEN + 1];
@@ -85,6 +87,7 @@ struct chimera_s3_request {
     struct chimera_s3_request       *prev;
     struct chimera_s3_request       *next;
     struct chimera_vfs_attrs         set_attr;
+    struct s3_chunk_decoder          chunk;
     uint8_t                          bucket_fh[CHIMERA_VFS_FH_SIZE];
 
     union {
@@ -191,6 +194,28 @@ chimera_s3_format_date(
     return ret;
 
 } /* chimera_s3_format_date */
+
+/*
+ * Attach an HTTP Last-Modified header from an object's mtime. The AWS CLI
+ * (unlike boto3) requires this header on GET/HEAD responses; without it
+ * `aws s3 cp s3://...` aborts with a KeyError on 'LastModified'.
+ */
+static inline void
+chimera_s3_attach_last_modified(
+    struct evpl_http_request       *request,
+    const struct chimera_vfs_attrs *attr)
+{
+    char      buf[64];
+    struct tm tm;
+
+    if (!(attr->va_set_mask & CHIMERA_VFS_ATTR_MTIME)) {
+        return;
+    }
+
+    gmtime_r(&attr->va_mtime.tv_sec, &tm);
+    strftime(buf, sizeof(buf), "%a, %d %b %Y %H:%M:%S GMT", &tm);
+    evpl_http_request_add_header(request, "Last-Modified", buf);
+} /* chimera_s3_attach_last_modified */
 
 void
 s3_server_respond(

--- a/src/server/s3/s3_multipart.c
+++ b/src/server/s3/s3_multipart.c
@@ -643,8 +643,56 @@ chimera_s3_upload_part_recv(
 
     io = chimera_s3_io_alloc(thread, request);
 
-    io->niov = evpl_http_request_get_datav(evpl, request->http_request,
-                                           io->iov, avail);
+    if (request->chunked) {
+        /* De-chunk the aws-chunked framing into a fresh buffer. Decoding only
+         * strips framing, so the decoded length never exceeds the raw input
+         * and a single output iovec of `avail` bytes always suffices. The raw
+         * input is pulled into a separate scratch array and released once
+         * copied; the decoded output is allocated directly into io->iov[0] so
+         * libevpl's iovec ownership tracking stays intact. */
+        struct evpl_iovec in_iov[CHIMERA_S3_IOV_MAX];
+        int               in_niov;
+        int               out_len = 0;
+        int               i;
+
+        in_niov = evpl_http_request_get_datav(evpl, request->http_request,
+                                              in_iov, avail);
+
+        evpl_iovec_alloc(evpl, avail, 0, 1, 0, &io->iov[0]);
+
+        for (i = 0; i < in_niov; i++) {
+            s3_chunk_decode(&request->chunk,
+                            evpl_iovec_data(&in_iov[i]),
+                            evpl_iovec_length(&in_iov[i]),
+                            evpl_iovec_data(&io->iov[0]),
+                            &out_len);
+        }
+
+        evpl_iovecs_release(evpl, in_iov, in_niov);
+
+        if (request->chunk.error) {
+            evpl_iovec_release(evpl, &io->iov[0]);
+            chimera_s3_io_free(thread, io);
+            request->status    = CHIMERA_S3_STATUS_BAD_REQUEST;
+            request->vfs_state = CHIMERA_S3_VFS_STATE_COMPLETE;
+            return;
+        }
+
+        if (out_len == 0) {
+            /* This read carried only framing (e.g. a chunk header or the
+             * trailer); nothing to write yet. */
+            evpl_iovec_release(evpl, &io->iov[0]);
+            chimera_s3_io_free(thread, io);
+            goto again;
+        }
+
+        evpl_iovec_set_length(&io->iov[0], out_len);
+        io->niov = 1;
+        avail    = out_len;
+    } else {
+        io->niov = evpl_http_request_get_datav(evpl, request->http_request,
+                                               io->iov, avail);
+    }
 
     request->io_pending++;
 
@@ -1266,6 +1314,20 @@ chimera_s3_complete_move_callback(
     struct chimera_s3_complete_ctx *ctx = private_data;
 
     if (error_code) {
+        /* memfs move_range is a zero-copy block-pointer swap and rejects
+         * sub-block-aligned moves with EINVAL. Real S3 part sizes (e.g. the
+         * AWS CLI's trailing part) are rarely block-aligned, so fall back to
+         * read+write for the rest of the assembly. Once the running write
+         * offset is unaligned no further move_range can succeed anyway, so
+         * switching the whole remainder to RW (rather than per-part probing)
+         * avoids repeated failed moves. Nothing was moved on EINVAL, so
+         * part_offset/write_offset are unchanged and the retry is safe. */
+        if (error_code == CHIMERA_VFS_EINVAL &&
+            ctx->assemble_mode == CHIMERA_S3_ASSEMBLE_MOVE) {
+            ctx->assemble_mode = CHIMERA_S3_ASSEMBLE_RW;
+            chimera_s3_complete_assemble_next(ctx);
+            return;
+        }
         chimera_s3_complete_finish_common(error_code, ctx);
         return;
     }

--- a/src/server/s3/s3_put.c
+++ b/src/server/s3/s3_put.c
@@ -167,7 +167,55 @@ chimera_s3_put_recv(
 
     io = chimera_s3_io_alloc(thread, request);
 
-    io->niov = evpl_http_request_get_datav(evpl, request->http_request, io->iov, avail);
+    if (request->chunked) {
+        /* De-chunk the aws-chunked framing into a fresh buffer. Decoding only
+         * strips framing, so the decoded length never exceeds the raw input
+         * and a single output iovec of `avail` bytes always suffices. The raw
+         * input is pulled into a separate scratch array and released once
+         * copied; the decoded output is allocated directly into io->iov[0] so
+         * libevpl's iovec ownership tracking stays intact. */
+        struct evpl_iovec in_iov[CHIMERA_S3_IOV_MAX];
+        int               in_niov;
+        int               out_len = 0;
+        int               i;
+
+        in_niov = evpl_http_request_get_datav(evpl, request->http_request,
+                                              in_iov, avail);
+
+        evpl_iovec_alloc(evpl, avail, 0, 1, 0, &io->iov[0]);
+
+        for (i = 0; i < in_niov; i++) {
+            s3_chunk_decode(&request->chunk,
+                            evpl_iovec_data(&in_iov[i]),
+                            evpl_iovec_length(&in_iov[i]),
+                            evpl_iovec_data(&io->iov[0]),
+                            &out_len);
+        }
+
+        evpl_iovecs_release(evpl, in_iov, in_niov);
+
+        if (request->chunk.error) {
+            evpl_iovec_release(evpl, &io->iov[0]);
+            chimera_s3_io_free(thread, io);
+            request->status    = CHIMERA_S3_STATUS_BAD_REQUEST;
+            request->vfs_state = CHIMERA_S3_VFS_STATE_COMPLETE;
+            return;
+        }
+
+        if (out_len == 0) {
+            /* This read carried only framing (e.g. a chunk header or the
+             * trailer); nothing to write yet. */
+            evpl_iovec_release(evpl, &io->iov[0]);
+            chimera_s3_io_free(thread, io);
+            goto again;
+        }
+
+        evpl_iovec_set_length(&io->iov[0], out_len);
+        io->niov = 1;
+        avail    = out_len;
+    } else {
+        io->niov = evpl_http_request_get_datav(evpl, request->http_request, io->iov, avail);
+    }
 
     request->io_pending++;
 

--- a/src/server/s3/tests/CMakeLists.txt
+++ b/src/server/s3/tests/CMakeLists.txt
@@ -28,6 +28,13 @@ if(BOTO3_FOUND)
     set(S3_TEST_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/s3_test.py)
     set(CHIMERA_DAEMON ${CMAKE_BINARY_DIR}/src/daemon/chimera)
 
+    # The 'awscli' test drives the real AWS CLI; only register it where the
+    # `aws` binary is available.
+    find_program(AWS_CLI aws)
+    if(NOT AWS_CLI)
+        message(STATUS "aws CLI not found - S3 awscli interop tests will be skipped")
+    endif()
+
     # Macro to add S3 test with specific signature version
     macro(add_s3_test_sigver testname backend sigver)
         if(CHIMERA_NETNS_TESTING)
@@ -61,6 +68,10 @@ if(BOTO3_FOUND)
     add_s3_test(delete memfs)
     add_s3_test(list memfs)
     add_s3_test(multipart memfs)
+    add_s3_test(streaming memfs)
+    if(AWS_CLI)
+        add_s3_test(awscli memfs)
+    endif()
 
     # linux tests (V4)
     add_s3_test(put linux)
@@ -69,6 +80,10 @@ if(BOTO3_FOUND)
     add_s3_test(delete linux)
     add_s3_test(list linux)
     add_s3_test(multipart linux)
+    add_s3_test(streaming linux)
+    if(AWS_CLI)
+        add_s3_test(awscli linux)
+    endif()
 
     # io_uring tests (V4)
     if(IO_URING_ENABLED)
@@ -78,6 +93,10 @@ if(BOTO3_FOUND)
         add_s3_test(delete io_uring)
         add_s3_test(list io_uring)
         add_s3_test(multipart io_uring)
+        add_s3_test(streaming io_uring)
+        if(AWS_CLI)
+            add_s3_test(awscli io_uring)
+        endif()
 
         # demofs tests (V4) - demofs uses io_uring backend
         add_s3_test(put demofs)
@@ -98,6 +117,10 @@ if(BOTO3_FOUND)
     add_s3_test(delete cairn)
     add_s3_test(list cairn)
     add_s3_test(multipart cairn)
+    add_s3_test(streaming cairn)
+    if(AWS_CLI)
+        add_s3_test(awscli cairn)
+    endif()
 
     # ==================== V2 Signature Tests ====================
     # V2 tests use memfs backend to verify V2 signing works

--- a/src/server/s3/tests/s3_test.py
+++ b/src/server/s3/tests/s3_test.py
@@ -9,6 +9,10 @@ Starts chimera daemon as a subprocess and runs tests against it.
 """
 
 import argparse
+import datetime
+import hashlib
+import hmac
+import http.client
 import json
 import os
 import shutil
@@ -659,6 +663,313 @@ def test_multipart(client, bucket):
     print("multipart tests passed!")
 
 
+def _sign(key, msg):
+    return hmac.new(key, msg.encode('utf-8'), hashlib.sha256).digest()
+
+
+def _sha256_hex(data):
+    return hashlib.sha256(data).hexdigest()
+
+
+def _canonical_query(query):
+    """Replicate the server's query canonicalization: split on '&', sort, and
+    append '=' to bare keys."""
+    if not query:
+        return ''
+    params = sorted(query.split('&'))
+    return '&'.join(p if '=' in p else p + '=' for p in params)
+
+
+def streaming_put(host, port, access_key, secret_key, region, bucket, key,
+                  data, chunk_size, query=None):
+    """Perform a SigV4 streaming (aws-chunked) PUT by hand.
+
+    Mirrors what the AWS CLI / SDKs send when they default to
+    STREAMING-AWS4-HMAC-SHA256-PAYLOAD: the seed signature is computed over a
+    canonical request whose hashed-payload is the literal streaming sentinel,
+    and the body is wrapped in signed chunk framing. boto3 will not emit this
+    encoding for an in-memory body, so we build it directly to exercise the
+    server's de-chunking path. An optional raw query string (e.g. the
+    partNumber/uploadId of an UploadPart) is included in the URL and signature.
+    Returns (http_status, etag).
+    """
+    service = 's3'
+    host_header = f'{host}:{port}'
+    canonical_uri = f'/{bucket}/{key}'
+    request_target = canonical_uri + (f'?{query}' if query else '')
+
+    now = datetime.datetime.now(datetime.timezone.utc)
+    amz_date = now.strftime('%Y%m%dT%H%M%SZ')
+    date_stamp = now.strftime('%Y%m%d')
+    scope = f'{date_stamp}/{region}/{service}/aws4_request'
+
+    seed_sha = 'STREAMING-AWS4-HMAC-SHA256-PAYLOAD'
+
+    # Split the payload into chunks; build the chunk stream and its signature
+    # chain after we have the seed signature.
+    chunks = [data[i:i + chunk_size] for i in range(0, len(data), chunk_size)]
+    if not chunks:
+        chunks = []  # zero-length object: only the terminating chunk
+
+    # Derive the signing key (identical to the server's derive_signing_key_v4).
+    k_date = _sign(('AWS4' + secret_key).encode('utf-8'), date_stamp)
+    k_region = hmac.new(k_date, region.encode('utf-8'), hashlib.sha256).digest()
+    k_service = hmac.new(k_region, service.encode('utf-8'), hashlib.sha256).digest()
+    signing_key = hmac.new(k_service, b'aws4_request', hashlib.sha256).digest()
+
+    # Compute the encoded content-length so it can be signed. Each data chunk
+    # is "<hexsize>;chunk-signature=<64hex>\r\n<data>\r\n"; the final chunk is
+    # "0;chunk-signature=<64hex>\r\n\r\n".
+    def chunk_overhead(size):
+        return len(f'{size:x}') + len(';chunk-signature=') + 64 + 2 + 2
+
+    content_length = sum(chunk_overhead(len(c)) + len(c) for c in chunks)
+    content_length += chunk_overhead(0)  # terminating zero chunk
+
+    headers = {
+        'content-encoding': 'aws-chunked',
+        'content-length': str(content_length),
+        'host': host_header,
+        'x-amz-content-sha256': seed_sha,
+        'x-amz-date': amz_date,
+        'x-amz-decoded-content-length': str(len(data)),
+    }
+    signed_headers = ';'.join(sorted(headers))
+    canonical_headers = ''.join(f'{n}:{headers[n]}\n' for n in sorted(headers))
+
+    canonical_request = (
+        f'PUT\n{canonical_uri}\n{_canonical_query(query)}\n{canonical_headers}\n'
+        f'{signed_headers}\n{seed_sha}'
+    )
+    string_to_sign = (
+        f'AWS4-HMAC-SHA256\n{amz_date}\n{scope}\n'
+        f'{_sha256_hex(canonical_request.encode("utf-8"))}'
+    )
+    seed_signature = hmac.new(signing_key, string_to_sign.encode('utf-8'),
+                              hashlib.sha256).hexdigest()
+
+    authorization = (
+        f'AWS4-HMAC-SHA256 Credential={access_key}/{scope}, '
+        f'SignedHeaders={signed_headers}, Signature={seed_signature}'
+    )
+
+    # Build the chunk-signed body.
+    empty_hash = _sha256_hex(b'')
+    prev_sig = seed_signature
+    body = b''
+
+    def chunk_signature(chunk_bytes):
+        chunk_sts = (
+            f'AWS4-HMAC-SHA256-PAYLOAD\n{amz_date}\n{scope}\n{prev_sig}\n'
+            f'{empty_hash}\n{_sha256_hex(chunk_bytes)}'
+        )
+        return hmac.new(signing_key, chunk_sts.encode('utf-8'),
+                        hashlib.sha256).hexdigest()
+
+    for c in chunks:
+        sig = chunk_signature(c)
+        prev_sig = sig
+        body += f'{len(c):x};chunk-signature={sig}\r\n'.encode('utf-8')
+        body += c + b'\r\n'
+
+    final_sig = chunk_signature(b'')
+    body += f'0;chunk-signature={final_sig}\r\n\r\n'.encode('utf-8')
+
+    assert len(body) == content_length, \
+        f'content-length mismatch: declared {content_length}, body {len(body)}'
+
+    conn = http.client.HTTPConnection(host, port, timeout=30)
+    send_headers = dict(headers)
+    send_headers['Authorization'] = authorization
+    conn.request('PUT', request_target, body=body, headers=send_headers)
+    resp = conn.getresponse()
+    etag = resp.getheader('ETag')
+    resp.read()
+    conn.close()
+    return resp.status, etag
+
+
+def test_streaming(client, bucket):
+    """Test SigV4 streaming (aws-chunked) uploads.
+
+    This is the AWS CLI / SDK default upload encoding. The server must strip
+    the chunk framing before storing the object; otherwise the chunk size and
+    signature lines are written into the object and the data is silently
+    corrupted. We upload by hand and read back through boto3 to confirm the
+    stored bytes are exactly the payload.
+    """
+    print("Testing SigV4 streaming (aws-chunked) uploads...")
+
+    cases = [
+        ('streamdir/small', b'hello streaming world', 8 * 1024),
+        # Multi-chunk payload that also crosses the server's internal 128 KiB
+        # read boundary, so the decoder must resume across reads.
+        ('streamdir/multi', bytes((i * 7) & 0xff for i in range(300000)), 64 * 1024),
+        ('streamdir/empty', b'', 64 * 1024),
+    ]
+
+    for key, data, chunk_size in cases:
+        status, _ = streaming_put('localhost', 5000, 'myaccessid', 'mysecretkey',
+                                  'us-east-1', bucket, key, data, chunk_size)
+        assert status == 200, f"streaming PUT {key} returned HTTP {status}"
+
+        head = client.head_object(Bucket=bucket, Key=key)
+        assert head['ContentLength'] == len(data), \
+            f"{key}: size mismatch, expected {len(data)}, got {head['ContentLength']}"
+
+        actual = client.get_object(Bucket=bucket, Key=key)['Body'].read()
+        assert actual == data, (
+            f"{key}: content corrupted; {len(actual)} bytes stored, "
+            f"first diff at offset "
+            f"{next((i for i, (a, b) in enumerate(zip(actual, data)) if a != b), -1)}"
+        )
+        print(f"  streaming PUT {key} ({len(data)} bytes, "
+              f"{chunk_size} chunk) -> content matches")
+
+    # Multipart UploadPart also defaults to aws-chunked in the AWS CLI/SDKs for
+    # large files. Initiate via boto3, stream the parts by hand, complete via
+    # boto3, and verify the assembled object.
+    mp_key = 'streamdir/multipart'
+    part_size = 5 * 1024 * 1024  # boto3's per-part minimum for non-final parts
+    init = client.create_multipart_upload(Bucket=bucket, Key=mp_key)
+    upload_id = init['UploadId']
+    parts = []
+    expected = b''
+    for part_number in range(1, 3):
+        body = bytes([part_number]) * part_size
+        expected += body
+        query = f'partNumber={part_number}&uploadId={upload_id}'
+        status, etag = streaming_put('localhost', 5000, 'myaccessid', 'mysecretkey',
+                                     'us-east-1', bucket, mp_key, body,
+                                     64 * 1024, query=query)
+        assert status == 200, \
+            f"streaming UploadPart #{part_number} returned HTTP {status}"
+        assert etag, f"streaming UploadPart #{part_number} returned no ETag"
+        parts.append({'PartNumber': part_number, 'ETag': etag})
+        print(f"  streaming UploadPart #{part_number} ({part_size} bytes) -> {etag}")
+
+    client.complete_multipart_upload(
+        Bucket=bucket, Key=mp_key, UploadId=upload_id,
+        MultipartUpload={'Parts': parts},
+    )
+    actual = client.get_object(Bucket=bucket, Key=mp_key)['Body'].read()
+    assert actual == expected, "streaming multipart: assembled content mismatch"
+    print(f"  streaming multipart upload ({len(expected)} bytes) -> content matches")
+
+    print("streaming tests passed!")
+
+
+def test_awscli(client, bucket):
+    """Real AWS CLI (`aws s3 cp`) interop smoke test.
+
+    Drives the actual AWS CLI against the daemon to catch real-client
+    regressions that boto3 doesn't surface. Note this is NOT the de-chunking
+    test: the modern AWS CLI (v2 / CRT) precomputes payload checksums and does
+    not emit aws-chunked streaming for `cp`, so it cannot exercise the
+    de-chunking path -- that is covered by test_streaming. What this guards:
+
+      * basic object PUT and GET through the CLI,
+      * the Last-Modified response header the CLI requires for downloads
+        (boto3 tolerates its absence; the CLI aborts without it), and
+      * multipart upload + assembly with the CLI's natural, non-block-aligned
+        part sizes (which the boto3 multipart test deliberately avoids).
+
+    The CLI's parallel ranged download of large objects is a separate known
+    gap, so the large multipart object is verified via boto3 rather than a CLI
+    download.
+    """
+    aws = shutil.which('aws')
+    if not aws:
+        raise RuntimeError("aws CLI not found on PATH")
+
+    print("Testing AWS CLI (aws s3 cp) interop...")
+
+    # localhost may resolve to ::1 first; the daemon listens on IPv4 only.
+    endpoint = 'http://127.0.0.1:5000'
+    workdir = tempfile.mkdtemp(prefix='chimera_awscli_')
+    cfg_path = os.path.join(workdir, 'awsconfig')
+
+    env = os.environ.copy()
+    # In debug builds the daemon runs under ASan via LD_PRELOAD (set for the
+    # test process by the netns wrapper); the standalone `aws` binary exits
+    # non-zero under ASan, so strip it for the CLI subprocess.
+    env.pop('LD_PRELOAD', None)
+    env.update({
+        'HOME': workdir,
+        'AWS_CONFIG_FILE': cfg_path,
+        'AWS_ACCESS_KEY_ID': 'myaccessid',
+        'AWS_SECRET_ACCESS_KEY': 'mysecretkey',
+        'AWS_DEFAULT_REGION': 'us-east-1',
+        'AWS_EC2_METADATA_DISABLED': 'true',
+    })
+
+    def write_cfg(extra=''):
+        # Path-style addressing: the CLI defaults to virtual-host style, which
+        # can't work against a bare host:port endpoint.
+        with open(cfg_path, 'w') as f:
+            f.write('[default]\ns3 =\n    addressing_style = path\n' + extra)
+
+    def aws_cp(src, dst, timeout=120):
+        r = subprocess.run(
+            [aws, '--endpoint-url', endpoint,
+             '--cli-connect-timeout', '15', '--cli-read-timeout', '60',
+             's3', 'cp', src, dst],
+            env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            timeout=timeout)
+        if r.returncode != 0:
+            raise RuntimeError(
+                f"aws s3 cp {src} {dst} failed (rc={r.returncode}): "
+                f"{r.stdout.decode(errors='replace')}")
+
+    try:
+        # --- Single-object roundtrip: PUT and GET both via the CLI. Kept under
+        #     the CLI's 8 MiB multipart threshold so the download is a single
+        #     GET (exercises the Last-Modified header). ---
+        write_cfg()
+        small = os.urandom(1024 * 1024 + 7)
+        src = os.path.join(workdir, 'small.bin')
+        dst = os.path.join(workdir, 'small.out')
+        with open(src, 'wb') as f:
+            f.write(small)
+
+        aws_cp(src, f's3://{bucket}/awscli/small.bin')
+        head = client.head_object(Bucket=bucket, Key='awscli/small.bin')
+        assert head['ContentLength'] == len(small), \
+            f"size mismatch: expected {len(small)}, got {head['ContentLength']}"
+
+        aws_cp(f's3://{bucket}/awscli/small.bin', dst)
+        with open(dst, 'rb') as f:
+            assert f.read() == small, "CLI upload+download roundtrip mismatch"
+        print(f"  aws s3 cp upload+download ({len(small)} bytes) -> roundtrip matches")
+
+        # --- Multipart upload with the CLI's natural part sizes. 9,000,000
+        #     bytes at an 8 MiB chunk size splits into 8 MiB + 611,392 B; the
+        #     trailing part is not block-aligned, exercising the assembly
+        #     fallback. Verified via boto3 (the CLI's parallel ranged download
+        #     of large objects is a separate known gap). ---
+        write_cfg('    multipart_threshold = 8MB\n    multipart_chunksize = 8MB\n')
+        big = os.urandom(9_000_000)
+        bsrc = os.path.join(workdir, 'big.bin')
+        with open(bsrc, 'wb') as f:
+            f.write(big)
+
+        aws_cp(bsrc, f's3://{bucket}/awscli/big.bin')
+        head = client.head_object(Bucket=bucket, Key='awscli/big.bin')
+        assert head['ContentLength'] == len(big), \
+            f"multipart size mismatch: expected {len(big)}, got {head['ContentLength']}"
+        got = client.get_object(Bucket=bucket, Key='awscli/big.bin')['Body'].read()
+        assert got == big, (
+            f"multipart upload content mismatch: {len(got)} vs {len(big)} bytes, "
+            f"first diff @ "
+            f"{next((i for i, (a, b) in enumerate(zip(got, big)) if a != b), -1)}")
+        print(f"  aws s3 cp multipart upload ({len(big)} bytes, unaligned parts) "
+              f"-> content matches")
+    finally:
+        shutil.rmtree(workdir, ignore_errors=True)
+
+    print("AWS CLI tests passed!")
+
+
 TESTS = {
     'put': test_put,
     'get': test_get,
@@ -666,6 +977,8 @@ TESTS = {
     'delete': test_delete,
     'list': test_list,
     'multipart': test_multipart,
+    'streaming': test_streaming,
+    'awscli': test_awscli,
 }
 
 


### PR DESCRIPTION
## Problem

Streaming SigV4 uploads silently corrupt object data. The AWS CLI and many SDKs default to `STREAMING-AWS4-HMAC-SHA256-PAYLOAD` (aws-chunked) for uploads. The auth path treats the `x-amz-content-sha256` sentinel correctly for signing, but the PUT/UploadPart body handlers wrote the **raw HTTP bytes straight to the VFS** with no de-chunking — so every per-chunk size/signature framing line got stored inside the object. The upload "succeeds" while the stored data is corrupt.

## Fix

- New resumable aws-chunked decoder (`s3_chunk.h`): byte-oriented, handles framing split arbitrarily across network reads, and supports both the signed (`;chunk-signature=…`) and unsigned-trailer chunk variants.
- `s3.c` flags the request when `x-amz-content-sha256` carries a `STREAMING-*` sentinel; `s3_put.c` and `s3_multipart.c` de-chunk the body before writing to the VFS (decoded output allocated directly into the destination iovec to keep libevpl's iovec ownership tracking intact under `EVPL_IOVEC_TRACE`).
- The seed signature already validates correctly — the sentinel is the literal canonical payload hash — so no auth change beyond a clarifying comment.

## Adjacent gaps found while validating against the real AWS CLI (also fixed)

- **`Last-Modified` header**: GET/HEAD responses omitted it, so `aws s3 cp s3://…` (download) aborts with a `'LastModified'` KeyError. boto3 tolerated the absence; the CLI does not.
- **memfs multipart assembly**: `move_range` is a zero-copy block-pointer swap and rejects sub-block-aligned moves with `EINVAL`. The AWS CLI's natural trailing part size (e.g. 9 MB → 8 MB + 611,392 B) hits this, failing `CompleteMultipartUpload`. The assembly now falls back to read+write for the remainder on `EINVAL`. (The boto3 multipart test sidesteps this with block-aligned part sizes.)

## Tests

- `streaming` (memfs/linux/io_uring/cairn): a hand-crafted SigV4 `STREAMING-AWS4-HMAC-SHA256-PAYLOAD` upload for both PUT and multipart UploadPart, then read back to assert byte-exact content. Built by hand because the modern AWS CLI/boto3 won't emit aws-chunked from in-memory bodies. Regression-proven (corrupts with the fix removed).
- `awscli` (memfs/linux/io_uring/cairn): real `aws s3 cp` interop smoke test — single PUT+GET roundtrip and multipart upload with unaligned parts. Guarded by `find_program(aws)`; `awscli` added to the devcontainer.

## Known limitation (not addressed here)

The modern AWS CLI v2 (CRT + default CRC64NVME checksums) precomputes payload checksums and does **not** emit aws-chunked for `aws s3 cp`, so the de-chunking path is verified by the hand-crafted `streaming` test rather than the CLI. Separately, the CLI's parallel **ranged download** of large objects (≥ 8 MiB) hangs against chimera (single-GET and boto3 GETs are fine); the `awscli` test verifies the large multipart object via boto3 to avoid it. Worth a follow-up.