### PR TITLE
smb: require DELETE access for FILE_DELETE_ON_CLOSE creates

### DIFF
--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -931,6 +931,17 @@ chimera_smb_create(struct chimera_smb_request *request)
 
     } else {
 
+        /* MS-SMB2 3.3.5.9: if FILE_DELETE_ON_CLOSE is set in CreateOptions,
+         * the create must also request DELETE access (DELETE, GENERIC_ALL, or
+         * MAXIMUM_ALLOWED, which resolves to a superset). Otherwise fail with
+         * STATUS_ACCESS_DENIED rather than silently honoring delete-on-close. */
+        if ((request->create.create_options & SMB2_FILE_DELETE_ON_CLOSE) &&
+            !(request->create.desired_access &
+              (SMB2_DELETE | SMB2_GENERIC_ALL | SMB2_MAXIMUM_ALLOWED))) {
+            chimera_smb_complete_request(request, SMB2_STATUS_ACCESS_DENIED);
+            return;
+        }
+
         clock_gettime(CLOCK_MONOTONIC, &now);
 
         if (chimera_timespec_cmp(&now, &request->tree->fh_expiration) > 0) {


### PR DESCRIPTION
## Summary

A `CREATE` that sets `FILE_DELETE_ON_CLOSE` in CreateOptions must also request DELETE access. Per [MS-SMB2] 3.3.5.9, when `DesiredAccess` does not include `DELETE` (nor a superset — `GENERIC_ALL` / `MAXIMUM_ALLOWED`), the server must fail the request with `STATUS_ACCESS_DENIED`.

The server previously honored delete-on-close regardless of the requested access and returned `STATUS_SUCCESS`.

## Fix

Validate the `FILE_DELETE_ON_CLOSE` ↔ DELETE-access relationship at the top of the file path in `chimera_smb_create()`, before the open is dispatched.

## Testing

Found by the WPTS MS-SMB2 case `CreateClose_DeleteFile_DesiredAccessNotIncludeDeleteOrGenericAll`, which now passes. The 32-case WPTS allowlist and the SMB unit tests (sharemode/auth/phase0/ntlm) still pass — no regressions.

First of a series working through the lock/oplock/share-mode "returns SUCCESS where it must reject" cluster surfaced by WPTS.