### PR TITLE
smb: enforce mandatory byte-range locks on read/write

### DIFF
--- a/src/server/smb/smb_proc_read.c
+++ b/src/server/smb/smb_proc_read.c
@@ -5,7 +5,9 @@
 #include "common/evpl_iovec_cursor.h"
 #include "smb_internal.h"
 #include "smb_procs.h"
+#include "smb_session.h"
 #include "vfs/vfs.h"
+#include "vfs/vfs_state.h"
 
 static void
 chimera_smb_read_callback(
@@ -123,6 +125,29 @@ chimera_smb_read(struct chimera_smb_request *request)
         chimera_smb_open_file_release(request, request->read.open_file);
         chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
         return;
+    }
+
+    /* Mandatory byte-range lock enforcement: an exclusive lock held by a
+     * different open denies reads of the locked range. */
+    {
+        struct chimera_vfs_lease_owner io_owner = {
+            .protocol   = CHIMERA_VFS_LEASE_PROTO_SMB2,
+            .client_key = request->session_handle->session->session_id,
+            .owner_lo   = request->read.open_file->file_id.pid,
+            .owner_hi   = request->read.open_file->file_id.vid,
+        };
+
+        if (chimera_vfs_state_range_io_conflict(
+                thread->vfs_thread->vfs->vfs_state,
+                request->read.open_file->handle->fh,
+                request->read.open_file->handle->fh_len,
+                request->read.open_file->handle->fh_hash,
+                request->read.offset, request->read.length,
+                false, &io_owner)) {
+            chimera_smb_open_file_release(request, request->read.open_file);
+            chimera_smb_complete_request(request, SMB2_STATUS_FILE_LOCK_CONFLICT);
+            return;
+        }
     }
 
     chimera_vfs_read(

--- a/src/server/smb/smb_proc_write.c
+++ b/src/server/smb/smb_proc_write.c
@@ -4,8 +4,10 @@
 
 #include "smb_internal.h"
 #include "smb_procs.h"
+#include "smb_session.h"
 #include "vfs/vfs.h"
 #include "vfs/vfs_notify.h"
+#include "vfs/vfs_state.h"
 
 static void
 chimera_smb_write_callback(
@@ -105,6 +107,29 @@ chimera_smb_write(struct chimera_smb_request *request)
     if (unlikely(!request->write.open_file)) {
         chimera_smb_complete_request(request, SMB2_STATUS_FILE_CLOSED);
         return;
+    }
+
+    /* Mandatory byte-range lock enforcement: a shared lock denies writes from
+     * everyone, an exclusive lock denies writes from other opens. */
+    {
+        struct chimera_vfs_lease_owner io_owner = {
+            .protocol   = CHIMERA_VFS_LEASE_PROTO_SMB2,
+            .client_key = request->session_handle->session->session_id,
+            .owner_lo   = request->write.open_file->file_id.pid,
+            .owner_hi   = request->write.open_file->file_id.vid,
+        };
+
+        if (chimera_vfs_state_range_io_conflict(
+                thread->vfs_thread->vfs->vfs_state,
+                request->write.open_file->handle->fh,
+                request->write.open_file->handle->fh_len,
+                request->write.open_file->handle->fh_hash,
+                request->write.offset, request->write.length,
+                true, &io_owner)) {
+            chimera_smb_open_file_release(request, request->write.open_file);
+            chimera_smb_complete_request(request, SMB2_STATUS_FILE_LOCK_CONFLICT);
+            return;
+        }
     }
 
     if (request->write.channel == SMB2_CHANNEL_RDMA_V1) {

--- a/src/vfs/vfs_state.c
+++ b/src/vfs/vfs_state.c
@@ -752,6 +752,54 @@ chimera_vfs_lease_test(
     return result;
 } /* chimera_vfs_lease_test */
 
+SYMBOL_EXPORT bool
+chimera_vfs_state_range_io_conflict(
+    struct chimera_vfs_state             *state,
+    const uint8_t                        *fh,
+    uint8_t                               fh_len,
+    uint64_t                              fh_hash,
+    uint64_t                              offset,
+    uint64_t                              length,
+    bool                                  is_write,
+    const struct chimera_vfs_lease_owner *owner)
+{
+    struct chimera_vfs_file_state *file;
+    struct chimera_vfs_lease      *cur;
+    bool                           conflict = false;
+
+    /* Fast path: with no per-file state there are no byte-range locks. */
+    file = chimera_vfs_state_get(state, fh, fh_len, fh_hash, false);
+    if (!file) {
+        return false;
+    }
+
+    pthread_mutex_lock(&file->lock);
+    for (cur = file->range_locks; cur; cur = cur->next) {
+        if (!chimera_vfs_range_overlap(cur->offset, cur->length, offset, length)) {
+            continue;
+        }
+        if (cur->mode.granted & CHIMERA_VFS_LEASE_MODE_W) {
+            /* Exclusive lock: blocks all I/O from other owners; the lock
+             * owner may still read and write within its own range. */
+            if (!chimera_vfs_lease_owner_equal(&cur->owner, owner)) {
+                conflict = true;
+                break;
+            }
+        } else {
+            /* Shared lock: reads are permitted for everyone, but writes are
+             * denied for everyone — including the lock owner (MS-FSA). */
+            if (is_write) {
+                conflict = true;
+                break;
+            }
+        }
+    }
+    pthread_mutex_unlock(&file->lock);
+
+    chimera_vfs_state_put(state, file);
+    return conflict;
+} /* chimera_vfs_state_range_io_conflict */
+
 /* -------------------------------------------------------------------- */
 /* Break orchestration                                                  */
 /* -------------------------------------------------------------------- */

--- a/src/vfs/vfs_state.h
+++ b/src/vfs/vfs_state.h
@@ -326,6 +326,24 @@ chimera_vfs_lease_test(
     const struct chimera_vfs_lease *probe,
     struct chimera_vfs_lease      **conflict_out);
 
+/* SMB mandatory byte-range lock enforcement for an I/O.  Returns true if an
+ * I/O of the given direction over [offset, offset+length) (length==0 means
+ * to EOF) conflicts with a byte-range lock held on the file:
+ *   - a shared lock denies writes from all owners (including the lock owner);
+ *   - an exclusive lock denies reads and writes from any other owner.
+ * `owner` identifies the open performing the I/O.  Looks up file state by FH;
+ * a file with no state (no locks) never conflicts. */
+bool
+chimera_vfs_state_range_io_conflict(
+    struct chimera_vfs_state             *state,
+    const uint8_t                        *fh,
+    uint8_t                               fh_len,
+    uint64_t                              fh_hash,
+    uint64_t                              offset,
+    uint64_t                              length,
+    bool                                  is_write,
+    const struct chimera_vfs_lease_owner *owner);
+
 /* -------------------------------------------------------------------- */
 /* Break orchestration                                                  */
 /* -------------------------------------------------------------------- */


### PR DESCRIPTION
## Summary

Byte-range locks (`SMB2 LOCK`) were acquired and tracked but **never consulted on I/O**. A write into a region covered by another open's shared lock returned `STATUS_SUCCESS` instead of `STATUS_FILE_LOCK_CONFLICT`.

## Fix

Add `chimera_vfs_state_range_io_conflict()` — an SMB *mandatory-lock* I/O check, distinct from the fcntl-style `range_conflict` used at lock-acquire time. Its rules follow [MS-FSA]:

- a **shared** lock denies writes from **all** owners (including the lock owner);
- an **exclusive** lock denies reads and writes from any **other** owner (the owner may still read/write its own range).

The SMB2 WRITE and READ handlers consult it and return `STATUS_FILE_LOCK_CONFLICT` on conflict. Files with no per-file state (the common, lock-free case) short-circuit on the state lookup, so the hot path only pays a single hash lookup.

## Testing

Found by WPTS MS-SMB2 `BVT_SMB2Basic_LockAndUnLock`, which now passes (stable over repeated runs). The 32-case WPTS allowlist and SMB unit tests (sharemode/auth/phase0/ntlm) still pass — no regressions. Verified self-contained on a clean branch off `main`.

Second in the series working through the lock/oplock/share-mode "returns SUCCESS where it must reject" cluster (after #316).