### PR TITLE
smb: validate FSCTL_VALIDATE_NEGOTIATE_INFO and terminate on mismatch

### DIFF
--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -544,6 +544,11 @@ struct chimera_smb_conn {
     uint16_t                           dialect;
     uint16_t                           smbvers;
     uint32_t                           capabilities;
+    /* Client values captured at NEGOTIATE, validated later by
+     * FSCTL_VALIDATE_NEGOTIATE_INFO (MS-SMB2 3.3.5.15.12). */
+    uint8_t                            client_guid[16];
+    uint8_t                            client_security_mode;
+    uint32_t                           client_capabilities;
     uint32_t                           requests_completed;
     int                                rdma_max_send;
     int                                rdma_niov;

--- a/src/server/smb/smb_proc_ioctl.c
+++ b/src/server/smb/smb_proc_ioctl.c
@@ -8,6 +8,57 @@
 #include "smb2.h"
 #include "common/misc.h"
 
+/* MS-SMB2 3.3.5.15.12: validate an FSCTL_VALIDATE_NEGOTIATE_INFO request
+ * against the connection's negotiated state.  Returns true if it matches and
+ * a response should be sent; false if the connection MUST be terminated. */
+static bool
+chimera_smb_validate_negotiate_info_ok(
+    const struct chimera_smb_conn          *conn,
+    const struct chimera_server_smb_shared *shared,
+    const struct chimera_smb_request       *request)
+{
+    uint16_t gcd = 0;
+    int      i, j;
+
+    /* The response is 24 bytes; an output buffer too small to hold it is a
+     * protocol violation. */
+    if (request->ioctl.max_output_response < 24) {
+        return false;
+    }
+
+    /* VALIDATE_NEGOTIATE_INFO is not used on SMB 3.1.1 (preauth integrity
+     * supersedes it); receiving it there terminates the connection. */
+    if (conn->dialect == SMB2_DIALECT_3_1_1) {
+        return false;
+    }
+
+    if (memcmp(request->ioctl.vni_guid, conn->client_guid, 16) != 0) {
+        return false;
+    }
+    if (request->ioctl.vni_security_mode != conn->client_security_mode) {
+        return false;
+    }
+    if (request->ioctl.vni_capabilities != conn->client_capabilities) {
+        return false;
+    }
+
+    /* The greatest dialect common to the request's list and the server's
+     * supported set must equal the dialect negotiated on this connection. */
+    for (i = 0; i < request->ioctl.vni_dialect_count; i++) {
+        uint16_t cand = request->ioctl.vni_dialects[i];
+        for (j = 0; j < shared->config.num_dialects; j++) {
+            if (shared->config.dialects[j] == cand && cand > gcd) {
+                gcd = cand;
+            }
+        }
+    }
+    if (gcd != conn->dialect) {
+        return false;
+    }
+
+    return true;
+} /* chimera_smb_validate_negotiate_info_ok */
+
 void
 chimera_smb_ioctl(struct chimera_smb_request *request)
 {
@@ -24,6 +75,18 @@ chimera_smb_ioctl(struct chimera_smb_request *request)
             break;
 
         case SMB2_FSCTL_VALIDATE_NEGOTIATE_INFO:
+            if (!chimera_smb_validate_negotiate_info_ok(conn, shared, request)) {
+                /* MS-SMB2 3.3.5.15.12: a mismatch (or a 3.1.1 connection)
+                 * MUST terminate the transport connection with no reply.
+                 * Mirror the signing-failure teardown: drop the compound and
+                 * close the bind. */
+                struct chimera_smb_compound *compound = request->compound;
+
+                chimera_smb_compound_free(thread, compound);
+                evpl_close(thread->evpl, conn->bind);
+                return;
+            }
+
             request->ioctl.r_capabilities = conn->capabilities;
             memcpy(request->ioctl.r_guid, shared->guid, 16);
             request->ioctl.r_security_mode = SMB2_SIGNING_ENABLED;

--- a/src/server/smb/smb_proc_negotiate.c
+++ b/src/server/smb/smb_proc_negotiate.c
@@ -120,6 +120,12 @@ chimera_smb_negotiate(struct chimera_smb_request *request)
 
     conn->dialect = dialect;
 
+    /* Record the client's negotiate parameters so a later
+     * FSCTL_VALIDATE_NEGOTIATE_INFO can be checked against them. */
+    memcpy(conn->client_guid, request->negotiate.client_guid, SMB2_GUID_SIZE);
+    conn->client_security_mode = request->negotiate.security_mode;
+    conn->client_capabilities  = request->negotiate.capabilities;
+
     /* Pick algorithms from the client's negotiate contexts. Phase 0 records
      * presence; Phases 2/4/5 will actually flip on preauth/encryption/RDMA. */
     chimera_smb_select_negotiated_algorithms(conn, request);

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -133,7 +133,13 @@ if(CHIMERA_NETNS_TESTING AND WPTS_DOTNET AND WPTS_SMB2_DLL AND WPTS_ARCH_SUPPORT
         Negotiate_SMB311_InvalidCipher
         Negotiate_SMB311_IsTransportCapabilitiesSupported
         Signing_VerifyAesGmacSigning
-        TreeMgmt_SMB311_CLUSTER_RECONNECT)
+        TreeMgmt_SMB311_CLUSTER_RECONNECT
+        ValidateNegotiateInfo_Negative_InvalidCapabilities
+        ValidateNegotiateInfo_Negative_InvalidDialects_CommonDialectNotExpected
+        ValidateNegotiateInfo_Negative_InvalidDialects_NoCommonDialect
+        ValidateNegotiateInfo_Negative_InvalidGuid
+        ValidateNegotiateInfo_Negative_InvalidMaxOutputResponse
+        ValidateNegotiateInfo_Negative_InvalidSecurityMode)
 
     foreach(tc ${WPTS_SMB2_ALLOWLIST})
         add_test(NAME chimera/server/smb/wpts/memfs/${tc}


### PR DESCRIPTION
## Summary

The server answered every `FSCTL_VALIDATE_NEGOTIATE_INFO` with a success response without checking the request against the connection's negotiated state. Per [MS-SMB2] 3.3.5.15.12, the server **MUST terminate the transport connection** (with no reply) when the request doesn't match — this is the SMB3 downgrade-attack guard.

## Fix

- Capture the client's `Guid`, `SecurityMode`, and `Capabilities` on the connection at NEGOTIATE.
- In the FSCTL handler, terminate the connection when:
  - `MaxOutputResponse` < 24 (the response size),
  - the connection dialect is 3.1.1 (the FSCTL is not used there — preauth integrity supersedes it),
  - `Guid` / `SecurityMode` / `Capabilities` differ from the negotiated values, or
  - the greatest dialect common to the request's list and the server's supported set isn't the negotiated dialect.
- Teardown reuses the existing signing-failure pattern (free compound, `evpl_close` the bind).

## Testing

Found by WPTS MS-SMB2 `ValidateNegotiateInfo_Negative_*`. Six now pass and are **added to the allowlist**: InvalidGuid, InvalidSecurityMode, InvalidCapabilities, InvalidMaxOutputResponse, InvalidDialects_NoCommonDialect, InvalidDialects_CommonDialectNotExpected. The positive `BVT_ValidateNegotiateInfo` is unaffected; full allowlist (now 38) passes.

`Negative_SMB311` is intentionally **not** included: it requires the connection to negotiate 3.1.1, but the server currently caps at SMB 3.0, so its precondition can't be met. That's separate dialect-support work; the 3.1.1 termination check is already in place for when it lands.

Third in the series working through WPTS-surfaced clusters (after #316, #318).