### PR TITLE
nfs4: report NFS4ERR_EXPIRED for stateids of a purged client

### DIFF
--- a/src/server/nfs/nfs4_proc_close.c
+++ b/src/server/nfs/nfs4_proc_close.c
@@ -22,7 +22,6 @@ chimera_nfs4_close(
     void                   *state_void;
     uint8_t                 state_type;
     nfsstat4                status;
-    uint32_t                client_short_id;
 
     status = nfs_state_table_acquire(table,
                                      &args->open_stateid,
@@ -76,12 +75,11 @@ chimera_nfs4_close(
      * stateid before destroying.  Destroy cascades through any lock_states
      * rooted on this open. */
     open_state->seqid += 1;
-    client_short_id    = owner ? (uint32_t) owner->client->client_id : 0;
 
     nfs4_stateid_encode(&res->open_stateid, open_state->seqid,
                         NFS4_STATEID_TYPE_OPEN,
                         open_state->shard, open_state->slot_idx,
-                        open_state->generation, client_short_id);
+                        open_state->generation, table->epoch);
 
     /* Record reply BEFORE destroying the state -- after destroy, the owner
      * may also be torn down by client teardown.  In practice the owner

--- a/src/server/nfs/nfs4_proc_lock.c
+++ b/src/server/nfs/nfs4_proc_lock.c
@@ -104,7 +104,6 @@ chimera_nfs4_lock_complete(
     struct nfs_lock_state    *lock_state = req->nfs_state_ref;
     struct nfs4_range_lease  *rl         = req->nfs_inflight_range;
     struct chimera_vfs_state *vfs_state  = req->thread->vfs->vfs_state;
-    uint32_t                  client_short_id;
 
     (void) granted;
 
@@ -122,11 +121,10 @@ chimera_nfs4_lock_complete(
             lock_state->seqid += 1;
         }
 
-        client_short_id = (uint32_t) lock_state->lock_owner->client->client_id;
         nfs4_stateid_encode(&res->resok4.lock_stateid, lock_state->seqid,
                             NFS4_STATEID_TYPE_LOCK,
                             lock_state->shard, lock_state->slot_idx,
-                            lock_state->generation, client_short_id);
+                            lock_state->generation, table->epoch);
 
         res->status = NFS4_OK;
 
@@ -292,7 +290,6 @@ chimera_nfs4_lock(
         chimera_vfs_dup_handle(thread->vfs_thread, handle);
 
         lock_state = nfs_lock_state_create(lock_owner, open_state, handle,
-                                           (uint32_t) client->client_id,
                                            table, &res->resok4.lock_stateid);
 
         /* Release the open_state acquire ref.  The lock_state holds its
@@ -309,7 +306,7 @@ chimera_nfs4_lock(
                             NFS4_STATEID_TYPE_LOCK,
                             lock_state->shard, lock_state->slot_idx,
                             lock_state->generation,
-                            (uint32_t) client->client_id);
+                            table->epoch);
         status = nfs_state_table_acquire(table, &lock_stateid_for_acquire,
                                          NFS4_SLOT_TYPE_LOCK,
                                          &state_void, &state_type);

--- a/src/server/nfs/nfs4_proc_locku.c
+++ b/src/server/nfs/nfs4_proc_locku.c
@@ -30,7 +30,6 @@ chimera_nfs4_locku(
     struct nfs_lock_owner    *lock_owner;
     struct nfs4_range_lease  *rl, *prev, *match;
     uint64_t                  vfs_length;
-    uint32_t                  client_short_id;
     nfsstat4                  status;
 
     /* RFC 7530 §16.12.3: current filehandle must be set */
@@ -132,11 +131,10 @@ chimera_nfs4_locku(
     free(match);
 
     lock_state->seqid += 1;
-    client_short_id    = (uint32_t) lock_owner->client->client_id;
     nfs4_stateid_encode(&res->lock_stateid, lock_state->seqid,
                         NFS4_STATEID_TYPE_LOCK,
                         lock_state->shard, lock_state->slot_idx,
-                        lock_state->generation, client_short_id);
+                        lock_state->generation, table->epoch);
     res->status = NFS4_OK;
 
     /* RFC 7530 §9.1.7: record cached reply for the lock_owner. */

--- a/src/server/nfs/nfs4_proc_open.c
+++ b/src/server/nfs/nfs4_proc_open.c
@@ -136,7 +136,7 @@ chimera_nfs4_open_install_state(
     if (existing) {
         nfs_open_state_coalesce(existing,
                                 args->share_access, args->share_deny,
-                                (uint32_t) client->client_id,
+                                &req->thread->shared->nfs4_state_table,
                                 out_stateid);
         chimera_vfs_release(req->thread->vfs_thread, handle);
         /* The SHARE reservation acquired on the first OPEN of this
@@ -151,7 +151,6 @@ chimera_nfs4_open_install_state(
                                           handle->fh, handle->fh_len,
                                           args->share_access, args->share_deny,
                                           handle,
-                                          (uint32_t) client->client_id,
                                           &req->thread->shared->nfs4_state_table,
                                           out_stateid);
 

--- a/src/server/nfs/nfs4_proc_open.c
+++ b/src/server/nfs/nfs4_proc_open.c
@@ -603,26 +603,33 @@ chimera_nfs4_open(
         return;
     }
 
-    if (!req->session) {
-        struct nfs4_session *found = nfs4_session_find_by_clientid(
-            &thread->shared->nfs4_shared_clients,
-            args->owner.clientid);
-
-        if (found) {
-            nfs4_session_bind_conn(req->conn, found);
-            req->session = found;
-            /* Drop the +1 ref returned by find_by_clientid; conn owns it. */
-            nfs4_session_put(found);
-        }
-    }
-
     /* RFC 7530 §9.1.7 entry-time seqid classification for the 4.0 path.
      * Done BEFORE any VFS work so a replay short-circuits without
      * re-executing the open.  On NEW, the resolved owner is stashed on
      * req for chimera_nfs4_open_complete to advance + cache the reply. */
     if (req->minorversion == 0) {
-        struct nfs_client *client =
-            req->session ? req->session->client_unified : NULL;
+        struct nfs_client *client = NULL;
+
+        /* Resolve the client strictly by the OPEN owner's clientid.  The
+         * connection may carry a stale or unrelated implicit session (e.g. a
+         * prior confirmed client), so an unconfirmed/unknown clientid must not
+         * be silently accepted just because the conn is bound. */
+        if (req->session && req->session->client_unified &&
+            req->session->client_unified->client_id == args->owner.clientid) {
+            client = req->session->client_unified;
+        } else {
+            struct nfs4_session *found = nfs4_session_find_by_clientid(
+                &thread->shared->nfs4_shared_clients,
+                args->owner.clientid);
+
+            if (found) {
+                client = found->client_unified;
+                nfs4_session_bind_conn(req->conn, found);
+                req->session = found;
+                /* Drop the +1 ref from find_by_clientid; the conn owns it. */
+                nfs4_session_put(found);
+            }
+        }
 
         if (!client) {
             /* NFS4ERR_STALE_CLIENTID is in the no-advance set; we don't

--- a/src/server/nfs/nfs4_proc_open_confirm.c
+++ b/src/server/nfs/nfs4_proc_open_confirm.c
@@ -94,7 +94,7 @@ chimera_nfs4_open_confirm(
                         NFS4_STATEID_TYPE_OPEN,
                         open_state->shard, open_state->slot_idx,
                         open_state->generation,
-                        (uint32_t) owner->client->client_id);
+                        table->epoch);
 
     nfs4_replay_record(&owner->replay, args->seqid, OP_OPEN_CONFIRM,
                        NFS4_OK, &res->resok4.open_stateid);

--- a/src/server/nfs/nfs4_proc_open_downgrade.c
+++ b/src/server/nfs/nfs4_proc_open_downgrade.c
@@ -111,7 +111,7 @@ chimera_nfs4_open_downgrade(
                         NFS4_STATEID_TYPE_OPEN,
                         open_state->shard, open_state->slot_idx,
                         open_state->generation,
-                        (uint32_t) owner->client->client_id);
+                        table->epoch);
 
     if (is_v40) {
         owner->seqid = args->seqid;

--- a/src/server/nfs/nfs4_proc_setclientid.c
+++ b/src/server/nfs/nfs4_proc_setclientid.c
@@ -4,6 +4,7 @@
 
 #include "nfs4_procs.h"
 #include "nfs4_session.h"
+#include "nfs4_state.h"
 
 void
 chimera_nfs4_setclientid(
@@ -13,47 +14,55 @@ chimera_nfs4_setclientid(
     struct nfs_resop4                *resop)
 {
     struct SETCLIENTID4args          *args   = &argop->opsetclientid;
+    struct SETCLIENTID4res           *res    = &resop->opsetclientid;
     struct chimera_server_nfs_shared *shared = thread->shared;
-    struct evpl_rpc2_conn            *conn   = req->conn;
-    struct nfs4_session              *session;
+    struct nfs4_client_principal      principal;
+    struct nfs4_setclientid_result    scid;
 
-    resop->opsetclientid.resok4.clientid = nfs4_client_register(
-        &thread->shared->nfs4_shared_clients,
-        args->client.id.data,
-        args->client.id.len,
-        *(uint64_t *) args->client.verifier,
-        40,
-        NULL, NULL);
+    principal.flavor          = req->principal_flavor;
+    principal.uid             = req->principal_uid;
+    principal.gid             = req->principal_gid;
+    principal.machinename     = req->principal_machinename;
+    principal.machinename_len = req->principal_machinename_len;
 
-    session = nfs4_session_find_by_clientid(
-        &shared->nfs4_shared_clients,
-        resop->opsetclientid.resok4.clientid);
+    /* RFC 7530 §16.33: record (or update) an unconfirmed client record.  The
+     * clientid is not usable until SETCLIENTID_CONFIRM, so no session is
+     * created here -- that happens at confirm time. */
+    nfs4_client_setclientid(&shared->nfs4_shared_clients,
+                            args->client.id.data,
+                            args->client.id.len,
+                            *(uint64_t *) args->client.verifier,
+                            &principal,
+                            req->minorversion,
+                            &scid);
 
-    if (!session) {
-        /* Implicit (NFS4.0) session -- no SEQUENCE op, so no replay slot
-         * table.  Pass zeros for the slot caps. */
-        session = nfs4_create_session(
-            &shared->nfs4_shared_clients,
-            resop->opsetclientid.resok4.clientid,
-            1,
-            0,
-            0,
-            NULL,
-            NULL);
+    /* A replaced unconfirmed record's state hierarchy is torn down outside the
+     * table lock. */
+    if (scid.destroy_unified) {
+        nfs_client_destroy(scid.destroy_unified,
+                           &shared->nfs4_state_table,
+                           thread->vfs_thread);
     }
 
-    nfs4_session_bind_conn(conn, session);
-    req->session = session;
+    if (scid.status != NFS4_OK) {
+        res->status = scid.status;
+        /* The NFS4ERR_CLID_INUSE arm of SETCLIENTID4res carries a client_using
+         * (netaddr4) that the marshaller encodes even on error, so it must be
+         * initialised.  We do not track the conflicting client's address. */
+        if (scid.status == NFS4ERR_CLID_INUSE) {
+            res->client_using.na_r_netid.len = 0;
+            res->client_using.na_r_netid.str = (char *) "";
+            res->client_using.na_r_addr.len  = 0;
+            res->client_using.na_r_addr.str  = (char *) "";
+        }
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
 
-    resop->opsetclientid.status = NFS4_OK;
-
-    memcpy(&resop->opsetclientid.resok4.setclientid_confirm,
-           session->nfs4_session_id,
-           sizeof(session->nfs4_session_id));
-
-    /* Drop the +1 ref returned by find_by_clientid / create_session; the
-     * conn now holds its own ref via bind_conn. */
-    nfs4_session_put(session);
+    res->status          = NFS4_OK;
+    res->resok4.clientid = scid.clientid;
+    memcpy(res->resok4.setclientid_confirm, scid.confirm,
+           sizeof(res->resok4.setclientid_confirm));
 
     chimera_nfs4_compound_complete(req, NFS4_OK);
 } /* chimera_nfs4_setclientid */

--- a/src/server/nfs/nfs4_proc_setclientid_confirm.c
+++ b/src/server/nfs/nfs4_proc_setclientid_confirm.c
@@ -5,15 +5,12 @@
 /*
  * RFC 7530 §16.34: SETCLIENTID_CONFIRM
  *
- * The client follows SETCLIENTID with SETCLIENTID_CONFIRM to confirm its
- * binding.  Server must:
- *   1. Verify the clientid matches a registered record.
- *   2. Verify the confirmation verifier matches what SETCLIENTID returned.
- *   3. Mark the unified client record `confirmed = true`.
- *
- * Phase 4 honors steps 1-3.  The setclientid_confirm verifier returned by
- * SETCLIENTID is the implicit session_id (first 8 bytes), which is what we
- * compare against here.
+ * Confirms the unconfirmed client record named by {clientid, verifier} that a
+ * prior SETCLIENTID created.  On success the clientid becomes usable, so the
+ * implicit NFSv4.0 session (how non-SEQUENCE ops resolve the client) is
+ * created and bound to the connection here -- not at SETCLIENTID, so that an
+ * unconfirmed clientid cannot be used.  A client reboot purges the superseded
+ * record's state inside nfs4_client_setclientid_confirm.
  */
 
 #include <string.h>
@@ -30,63 +27,54 @@ chimera_nfs4_setclientid_confirm(
     struct nfs_argop4                *argop,
     struct nfs_resop4                *resop)
 {
-    struct SETCLIENTID_CONFIRM4args *args  = &argop->opsetclientid_confirm;
-    struct nfs4_client_table        *table =
-        &thread->shared->nfs4_shared_clients;
-    struct nfs4_client              *c  = NULL;
-    struct nfs_client               *uc = NULL;
-    uint8_t                          expected[NFS4_SESSIONID_SIZE];
-    bool                             have_expected = false;
-    nfsstat4                         status;
+    struct SETCLIENTID_CONFIRM4args  *args            = &argop->opsetclientid_confirm;
+    struct chimera_server_nfs_shared *shared          = thread->shared;
+    struct nfs_client                *destroy_unified = NULL;
+    struct nfs4_session              *session;
+    nfsstat4                          status;
 
-    /* table is only read inside the __clang_analyzer__-excluded block
-     * below; consume it here so scan-build doesn't flag the init as
-     * a dead store. */
-    (void) table;
+    status = nfs4_client_setclientid_confirm(&shared->nfs4_shared_clients,
+                                             args->clientid,
+                                             args->setclientid_confirm,
+                                             &destroy_unified);
 
-#ifndef __clang_analyzer__
-    pthread_mutex_lock(&table->nfs4_ct_lock);
-
-    HASH_FIND(nfs4_client_hh_by_id, table->nfs4_ct_clients_by_id,
-              &args->clientid, sizeof(args->clientid), c);
-
-    if (c) {
-        uc = c->unified;
-
-        /* The SETCLIENTID response copied the implicit session_id into the
-         * setclientid_confirm verifier; recover it by walking the sessions
-         * table for this clientid. */
-        struct nfs4_session *s, *stmp;
-        HASH_ITER(nfs4_session_hh, table->nfs4_ct_sessions, s, stmp)
-        {
-            if (s->nfs4_session_clientid == args->clientid) {
-                memcpy(expected, s->nfs4_session_id, NFS4_SESSIONID_SIZE);
-                have_expected = true;
-                break;
-            }
-        }
+    /* A superseded (rebooted) client's state hierarchy is torn down outside
+     * the table lock. */
+    if (destroy_unified) {
+        nfs_client_destroy(destroy_unified,
+                           &shared->nfs4_state_table,
+                           thread->vfs_thread);
     }
 
-    pthread_mutex_unlock(&table->nfs4_ct_lock);
-#endif /* ifndef __clang_analyzer__ */
+    if (status != NFS4_OK) {
+        resop->opsetclientid_confirm.status = status;
+        chimera_nfs4_compound_complete(req, status);
+        return;
+    }
 
-    if (!c) {
-        status = NFS4ERR_STALE_CLIENTID;
-    } else if (!have_expected ||
-               memcmp(args->setclientid_confirm, expected,
-                      sizeof(args->setclientid_confirm)) != 0) {
-        status = NFS4ERR_CLID_INUSE;
-    } else {
+    /* The clientid is now confirmed and usable.  Ensure it has an implicit
+     * (NFS4.0) session and bind it to this connection so subsequent
+     * non-SEQUENCE operations resolve the client. */
+    session = nfs4_session_find_by_clientid(&shared->nfs4_shared_clients,
+                                            args->clientid);
+    if (!session) {
+        session = nfs4_create_session(&shared->nfs4_shared_clients,
+                                      args->clientid, 1, 0, 0, NULL, NULL);
+    }
+
+    if (session) {
+        struct nfs_client *uc = session->client_unified;
+
+        nfs4_session_bind_conn(req->conn, session);
+        req->session = session;
+        nfs4_session_put(session);
+
         if (uc) {
             uc->confirmed = 1;
-            /* Phase 5: stub-persist the confirmed client.  Future backends
-             * will write a record to stable storage so a restart can
-             * reclaim it within the grace window. */
             nfs_recovery_persist(&thread->shared->nfs4_recovery, uc);
         }
-        status = NFS4_OK;
     }
 
-    resop->opsetclientid_confirm.status = status;
+    resop->opsetclientid_confirm.status = NFS4_OK;
     chimera_nfs4_compound_complete(req, NFS4_OK);
 } /* chimera_nfs4_setclientid_confirm */

--- a/src/server/nfs/nfs4_session.c
+++ b/src/server/nfs/nfs4_session.c
@@ -80,6 +80,7 @@ nfs4_client_table_init(struct nfs4_client_table *table)
     table->nfs4_ct_clients_by_id    = NULL;
     table->nfs4_ct_sessions         = NULL;
     table->nfs4_ct_next_client_id   = 1;
+    table->nfs4_ct_next_confirm     = 1;
 
     pthread_mutex_init(&table->nfs4_ct_lock, NULL);
 } /* nfs4_client_table_init */
@@ -221,7 +222,8 @@ nfs4_client_new_locked(
     int                                 owner_len,
     uint64_t                            verifier,
     const struct nfs4_client_principal *p,
-    uint8_t                             minorversion)
+    uint8_t                             minorversion,
+    bool                                add_to_owner)
 {
     struct nfs4_client *c = calloc(1, sizeof(*c));
 
@@ -249,8 +251,13 @@ nfs4_client_new_locked(
     c->unified = nfs_client_alloc(c->nfs4_client_id, owner, owner_len,
                                   verifier, minorversion);
 
-    HASH_ADD(nfs4_client_hh_by_owner, table->nfs4_ct_clients_by_owner,
-             nfs4_client_owner, c->nfs4_client_owner_len, c);
+    /* A by-id-only record (add_to_owner=false) is an unconfirmed SETCLIENTID
+     * reboot record that coexists with a still-confirmed record holding the
+     * by-owner slot; it joins the by-owner table when it is confirmed. */
+    if (add_to_owner) {
+        HASH_ADD(nfs4_client_hh_by_owner, table->nfs4_ct_clients_by_owner,
+                 nfs4_client_owner, c->nfs4_client_owner_len, c);
+    }
     HASH_ADD(nfs4_client_hh_by_id, table->nfs4_ct_clients_by_id,
              nfs4_client_id, sizeof(c->nfs4_client_id), c);
 
@@ -335,7 +342,7 @@ nfs4_client_exchange_id(
     if (!existing) {
         /* Case 1: brand-new owner. */
         nc = nfs4_client_new_locked(table, owner, owner_len,
-                                    verifier, principal, minorversion);
+                                    verifier, principal, minorversion, true);
         out->clientid = nc->nfs4_client_id;
         goto out_unlock;
     }
@@ -345,7 +352,7 @@ nfs4_client_exchange_id(
          * never proved ownership of its clientid, so a fresh one is issued. */
         out->destroy_unified = nfs4_client_remove_locked(table, existing);
         nc                   = nfs4_client_new_locked(table, owner, owner_len,
-                                                      verifier, principal, minorversion);
+                                                      verifier, principal, minorversion, true);
         out->clientid = nc->nfs4_client_id;
         goto out_unlock;
     }
@@ -367,7 +374,7 @@ nfs4_client_exchange_id(
         HASH_DELETE(nfs4_client_hh_by_owner, table->nfs4_ct_clients_by_owner,
                     existing);
         nc = nfs4_client_new_locked(table, owner, owner_len, verifier,
-                                    principal, minorversion);
+                                    principal, minorversion, true);
         nc->nfs4_client_supersedes_id = existing->nfs4_client_id;
         out->clientid                 = nc->nfs4_client_id;
         goto out_unlock;
@@ -383,12 +390,228 @@ nfs4_client_exchange_id(
 
     out->destroy_unified = nfs4_client_remove_locked(table, existing);
     nc                   = nfs4_client_new_locked(table, owner, owner_len,
-                                                  verifier, principal, minorversion);
+                                                  verifier, principal, minorversion, true);
     out->clientid = nc->nfs4_client_id;
 
  out_unlock:
     pthread_mutex_unlock(&table->nfs4_ct_lock);
 } /* nfs4_client_exchange_id */
+
+/* Caller holds the table lock.  Remove a record that lives in the by-id table
+ * only (an in-flight superseding SETCLIENTID record), returning its unified
+ * hierarchy for teardown outside the lock. */
+static struct nfs_client *
+nfs4_client_remove_byid_locked(
+    struct nfs4_client_table *table,
+    struct nfs4_client       *c)
+{
+    struct nfs_client *unified = c->unified;
+
+    HASH_DELETE(nfs4_client_hh_by_id, table->nfs4_ct_clients_by_id, c);
+    c->unified = NULL;
+    free(c);
+    return unified;
+} /* nfs4_client_remove_byid_locked */
+
+/* Caller holds the table lock.  Stamp a fresh, unique setclientid_confirm
+ * verifier onto a record and mark a confirm pending. */
+static void
+nfs4_scid_set_confirm(
+    struct nfs4_client_table *table,
+    struct nfs4_client       *c)
+{
+    uint64_t v = table->nfs4_ct_next_confirm++;
+
+    memcpy(c->nfs4_client_scid_confirm, &v, NFS4_VERIFIER_SIZE);
+    c->nfs4_client_scid_confirm_valid = 1;
+} /* nfs4_scid_set_confirm */
+
+/* Does the client hold any open/lock-owner state?  Used for the SETCLIENTID
+ * CLID_INUSE rule (RFC 7530 §16.33.5). */
+static int
+nfs4_client_has_state(const struct nfs4_client *c)
+{
+    return c->unified &&
+           (c->unified->open_owners_by_str != NULL ||
+            c->unified->lock_owners_by_str != NULL);
+} /* nfs4_client_has_state */
+
+void
+nfs4_client_setclientid(
+    struct nfs4_client_table           *table,
+    const void                         *owner,
+    int                                 owner_len,
+    uint64_t                            verifier,
+    const struct nfs4_client_principal *principal,
+    uint8_t                             minorversion,
+    struct nfs4_setclientid_result     *out)
+{
+    struct nfs4_client *existing, *nc, *pending;
+
+    out->status          = NFS4_OK;
+    out->clientid        = 0;
+    out->destroy_unified = NULL;
+    memset(out->confirm, 0, NFS4_VERIFIER_SIZE);
+
+    pthread_mutex_lock(&table->nfs4_ct_lock);
+
+    HASH_FIND(nfs4_client_hh_by_owner, table->nfs4_ct_clients_by_owner,
+              owner, owner_len, existing);
+
+    if (!existing) {
+        /* No record for this owner: create an unconfirmed one. */
+        nc = nfs4_client_new_locked(table, owner, owner_len, verifier,
+                                    principal, minorversion, true);
+        nfs4_scid_set_confirm(table, nc);
+        out->clientid = nc->nfs4_client_id;
+        memcpy(out->confirm, nc->nfs4_client_scid_confirm, NFS4_VERIFIER_SIZE);
+        goto out_unlock;
+    }
+
+    if (!existing->nfs4_client_confirmed) {
+        /* The by-owner record is itself unconfirmed (no confirmed record for
+         * this owner yet) -- RFC 7530 §16.33.5: any unconfirmed record is
+         * replaced by a fresh one with a new clientid. */
+        out->destroy_unified = nfs4_client_remove_locked(table, existing);
+        nc                   = nfs4_client_new_locked(table, owner, owner_len,
+                                                      verifier, principal,
+                                                      minorversion, true);
+        nfs4_scid_set_confirm(table, nc);
+        out->clientid = nc->nfs4_client_id;
+        memcpy(out->confirm, nc->nfs4_client_scid_confirm, NFS4_VERIFIER_SIZE);
+        goto out_unlock;
+    }
+
+    /* A confirmed record exists for this owner. */
+
+    /* Different principal while the confirmed client still holds state is a
+     * collision (RFC 7530 §16.33.5 -- NFS4ERR_CLID_INUSE). */
+    if (!nfs4_principal_matches(existing, principal) &&
+        nfs4_client_has_state(existing)) {
+        out->status = NFS4ERR_CLID_INUSE;
+        goto out_unlock;
+    }
+
+    /* A new SETCLIENTID supersedes any earlier in-flight unconfirmed record
+     * for this owner (RFC 7530 §16.33.5 cases 4c/4d/4e). */
+    if (existing->nfs4_client_scid_pending_id) {
+        HASH_FIND(nfs4_client_hh_by_id, table->nfs4_ct_clients_by_id,
+                  &existing->nfs4_client_scid_pending_id,
+                  sizeof(existing->nfs4_client_scid_pending_id), pending);
+        existing->nfs4_client_scid_pending_id = 0;
+        if (pending) {
+            out->destroy_unified = nfs4_client_remove_byid_locked(table,
+                                                                  pending);
+        }
+    }
+
+    if (nfs4_principal_matches(existing, principal) &&
+        existing->nfs4_client_verifier == verifier) {
+        /* Same verifier + principal: a callback-info update of the confirmed
+         * record.  Same clientid, a fresh confirm verifier; the confirmed
+         * record stays usable until (if ever) the update is confirmed. */
+        nfs4_scid_set_confirm(table, existing);
+        out->clientid = existing->nfs4_client_id;
+        memcpy(out->confirm, existing->nfs4_client_scid_confirm,
+               NFS4_VERIFIER_SIZE);
+        goto out_unlock;
+    }
+
+    /* Different verifier (client reboot) or different principal with no state:
+     * issue a new clientid via a superseding unconfirmed record kept in the
+     * by-id table only.  The confirmed record remains live and usable until
+     * this one is confirmed. */
+    nc = nfs4_client_new_locked(table, owner, owner_len, verifier,
+                                principal, minorversion, false);
+    nc->nfs4_client_supersedes_id = existing->nfs4_client_id;
+    nfs4_scid_set_confirm(table, nc);
+    existing->nfs4_client_scid_pending_id = nc->nfs4_client_id;
+    out->clientid                         = nc->nfs4_client_id;
+    memcpy(out->confirm, nc->nfs4_client_scid_confirm, NFS4_VERIFIER_SIZE);
+
+ out_unlock:
+    pthread_mutex_unlock(&table->nfs4_ct_lock);
+} /* nfs4_client_setclientid */
+
+nfsstat4
+nfs4_client_setclientid_confirm(
+    struct nfs4_client_table *table,
+    uint64_t                  clientid,
+    const uint8_t            *confirm,
+    struct nfs_client       **destroy_unified)
+{
+    struct nfs4_client *r, *old;
+    nfsstat4            status;
+
+    *destroy_unified = NULL;
+
+    pthread_mutex_lock(&table->nfs4_ct_lock);
+
+    HASH_FIND(nfs4_client_hh_by_id, table->nfs4_ct_clients_by_id,
+              &clientid, sizeof(clientid), r);
+
+    if (!r) {
+        status = NFS4ERR_STALE_CLIENTID;
+        goto out_unlock;
+    }
+
+    if (!r->nfs4_client_scid_confirm_valid ||
+        memcmp(confirm, r->nfs4_client_scid_confirm, NFS4_VERIFIER_SIZE) != 0) {
+        /* The (clientid, verifier) pair does not name a record awaiting
+         * confirmation (RFC 7530 §16.34.5). */
+        status = NFS4ERR_STALE_STATEID;
+        goto out_unlock;
+    }
+
+    if (!r->nfs4_client_confirmed) {
+        /* Promote the unconfirmed record.  If it superseded a confirmed one
+         * (client reboot), tear that record and its sessions down now and move
+         * this record into the by-owner table. */
+        if (r->nfs4_client_supersedes_id) {
+            uint64_t oldid = r->nfs4_client_supersedes_id;
+
+            r->nfs4_client_supersedes_id = 0;
+
+            HASH_FIND(nfs4_client_hh_by_id, table->nfs4_ct_clients_by_id,
+                      &oldid, sizeof(oldid), old);
+            if (old) {
+                struct nfs4_session *s, *stmp;
+
+                HASH_ITER(nfs4_session_hh, table->nfs4_ct_sessions, s, stmp)
+                {
+                    if (s->nfs4_session_clientid == oldid) {
+                        HASH_DELETE(nfs4_session_hh, table->nfs4_ct_sessions, s);
+                        atomic_store_explicit(&s->destroyed, true,
+                                              memory_order_release);
+                        nfs4_session_put(s);
+                    }
+                }
+
+                old->nfs4_client_scid_pending_id = 0;
+                HASH_DELETE(nfs4_client_hh_by_owner,
+                            table->nfs4_ct_clients_by_owner, old);
+                HASH_DELETE(nfs4_client_hh_by_id,
+                            table->nfs4_ct_clients_by_id, old);
+                *destroy_unified = old->unified;
+                old->unified     = NULL;
+                free(old);
+            }
+
+            HASH_ADD(nfs4_client_hh_by_owner, table->nfs4_ct_clients_by_owner,
+                     nfs4_client_owner, r->nfs4_client_owner_len, r);
+        }
+        r->nfs4_client_confirmed = 1;
+    }
+
+    /* The confirm verifier stays valid so a retransmitted SETCLIENTID_CONFIRM
+     * with the same {clientid, verifier} is idempotent (NFS4_OK); a later
+     * SETCLIENTID overwrites it. */
+    status = NFS4_OK;
+
+ out_unlock:
+    pthread_mutex_unlock(&table->nfs4_ct_lock);
+    return status;
+} /* nfs4_client_setclientid_confirm */
 
 void
 nfs4_client_create_session_classify(

--- a/src/server/nfs/nfs4_session.h
+++ b/src/server/nfs/nfs4_session.h
@@ -148,6 +148,15 @@ struct nfs4_client {
     /* Set once the client has issued RECLAIM_COMPLETE; a second one is
      * NFS4ERR_COMPLETE_ALREADY (RFC 8881 §18.51.4). */
     uint8_t               nfs4_client_reclaim_complete;
+    /* NFSv4.0 SETCLIENTID/SETCLIENTID_CONFIRM handshake (RFC 7530 §16.33/16.34).
+     * When a SETCLIENTID leaves a confirm pending on this record, the 8-byte
+     * verifier the client must echo back is stored here and scid_confirm_valid
+     * is set.  For a *confirmed* record, scid_pending_id names a separate
+     * superseding unconfirmed record (a reboot with a new verifier created a
+     * new clientid); 0 = none. */
+    uint8_t               nfs4_client_scid_confirm[NFS4_VERIFIER_SIZE];
+    uint8_t               nfs4_client_scid_confirm_valid;
+    uint64_t              nfs4_client_scid_pending_id;
     /* Unified state hierarchy.  Created when this nfs4_client is first
      * registered; freed when the nfs4_client is unregistered or the table
      * is torn down.  See nfs4_state.h. */
@@ -200,6 +209,9 @@ struct nfs4_client_table {
     struct nfs4_client  *nfs4_ct_clients_by_id;
     struct nfs4_session *nfs4_ct_sessions;
     uint64_t             nfs4_ct_next_client_id;
+    /* Monotonic source for SETCLIENTID setclientid_confirm verifiers; every
+     * value handed out is unique for the life of the table. */
+    uint64_t             nfs4_ct_next_confirm;
     pthread_mutex_t      nfs4_ct_lock;
 };
 
@@ -230,6 +242,45 @@ nfs4_client_register(
     uint32_t                  proto,
     const char               *nii_domain,
     const char               *nii_name);
+
+/* Outcome of the NFSv4.0 SETCLIENTID record-matching state machine
+ * (RFC 7530 §16.33.5).  On NFS4_OK the handler returns `clientid` and the
+ * `confirm` verifier the client must echo in SETCLIENTID_CONFIRM. */
+struct nfs4_setclientid_result {
+    nfsstat4           status;
+    uint64_t           clientid;
+    uint8_t            confirm[NFS4_VERIFIER_SIZE];
+    /* A replaced unconfirmed record's state hierarchy, to be torn down with
+     * nfs_client_destroy after the table lock is dropped (NULL if none). */
+    struct nfs_client *destroy_unified;
+};
+
+/* RFC 7530 §16.33.5 SETCLIENTID record matching.  Records (or updates) an
+ * unconfirmed record for the client owner and fills *out.  May return
+ * NFS4ERR_CLID_INUSE when a confirmed record owned by a different principal
+ * still holds open/lock state. */
+void
+nfs4_client_setclientid(
+    struct nfs4_client_table           *table,
+    const void                         *owner,
+    int                                 owner_len,
+    uint64_t                            verifier,
+    const struct nfs4_client_principal *principal,
+    uint8_t                             minorversion,
+    struct nfs4_setclientid_result     *out);
+
+/* RFC 7530 §16.34 SETCLIENTID_CONFIRM.  Confirms the (unconfirmed) record
+ * named by `clientid`/`confirm`.  On a client reboot this promotes the
+ * superseding record and tears the old one down, returning its unified state
+ * hierarchy via *destroy_unified for teardown outside the table lock.
+ * Returns NFS4ERR_STALE_CLIENTID (no such clientid) or NFS4ERR_CLID_INUSE
+ * (confirm verifier mismatch) on failure. */
+nfsstat4
+nfs4_client_setclientid_confirm(
+    struct nfs4_client_table *table,
+    uint64_t                  clientid,
+    const uint8_t            *confirm,
+    struct nfs_client       **destroy_unified);
 
 /* RFC 8881 §18.35.4 EXCHANGE_ID client-record matching state machine.  Runs
  * entirely under the table lock and fills *out (see nfs4_exchange_id_result).

--- a/src/server/nfs/nfs4_state.c
+++ b/src/server/nfs/nfs4_state.c
@@ -224,6 +224,35 @@ nfs_state_table_free_slot(
     pthread_rwlock_unlock(&shard->lock);
 } /* nfs_state_table_free_slot */
 
+/* Like nfs_state_table_free_slot, but for a slot whose owning client was
+ * purged.  The generation is left unchanged so a stateid the client still
+ * holds continues to resolve to this slot -- now marked EXPIRED so the lookup
+ * returns NFS4ERR_EXPIRED.  The slot is placed on the free list and reverts to
+ * a normal type (bumping the generation) when it is next allocated. */
+void
+nfs_state_table_expire_slot(
+    struct nfs_state_table *table,
+    uint8_t                 shard_idx,
+    uint32_t                slot_idx)
+{
+    struct nfs_state_shard *shard = &table->shards[shard_idx];
+    struct nfs_state_slot  *slot;
+
+    pthread_rwlock_wrlock(&shard->lock);
+
+    chimera_nfs_abort_if(slot_idx >= shard->slots_used,
+                         "expire of unallocated slot %u/%u",
+                         slot_idx, shard->slots_used);
+
+    slot        = &shard->slots[slot_idx];
+    slot->type  = NFS4_SLOT_TYPE_EXPIRED;
+    slot->state = NULL;
+
+    (void) shard_push_free_locked(shard, slot_idx);
+
+    pthread_rwlock_unlock(&shard->lock);
+} /* nfs_state_table_expire_slot */
+
 /*
  * Internal lookup: under shard rdlock, validate slot identity and (when
  * `bump_refcount` is true) increment the state's refcount before unlocking.
@@ -285,7 +314,12 @@ state_table_lookup_locked(
 
     slot = &shard->slots[view.slot_idx];
 
-    if (slot->type == NFS4_SLOT_TYPE_FREE) {
+    if (slot->type == NFS4_SLOT_TYPE_EXPIRED) {
+        /* The owning client was purged.  A stateid still naming this slot's
+         * generation gets NFS4ERR_EXPIRED; an older generation is stale. */
+        status = (slot->generation == view.generation)
+                 ? NFS4ERR_EXPIRED : NFS4ERR_STALE_STATEID;
+    } else if (slot->type == NFS4_SLOT_TYPE_FREE) {
         status = NFS4ERR_BAD_STATEID;
     } else if (slot->generation != view.generation) {
         status = NFS4ERR_STALE_STATEID;
@@ -440,7 +474,8 @@ open_state_destroy_locked(
     struct nfs_open_owner     *owner,
     struct nfs_open_state     *state,
     struct nfs_state_table    *table,
-    struct chimera_vfs_thread *vfs_thread)
+    struct chimera_vfs_thread *vfs_thread,
+    bool                       expire)
 {
     uint8_t prev_destroyed;
 
@@ -467,7 +502,11 @@ open_state_destroy_locked(
         ls_prev_destroyed = atomic_exchange_explicit(&ls->destroyed, 1,
                                                      memory_order_acq_rel);
         if (ls_prev_destroyed == 0) {
-            nfs_state_table_free_slot(table, ls->shard, ls->slot_idx);
+            if (expire) {
+                nfs_state_table_expire_slot(table, ls->shard, ls->slot_idx);
+            } else {
+                nfs_state_table_free_slot(table, ls->shard, ls->slot_idx);
+            }
             uint32_t lprev = atomic_fetch_sub_explicit(&ls->refcount, 1,
                                                        memory_order_acq_rel);
             if (lprev == 1) {
@@ -476,7 +515,11 @@ open_state_destroy_locked(
         }
     }
 
-    nfs_state_table_free_slot(table, state->shard, state->slot_idx);
+    if (expire) {
+        nfs_state_table_expire_slot(table, state->shard, state->slot_idx);
+    } else {
+        nfs_state_table_free_slot(table, state->shard, state->slot_idx);
+    }
 
     uint32_t prev = atomic_fetch_sub_explicit(&state->refcount, 1,
                                               memory_order_acq_rel);
@@ -511,7 +554,9 @@ nfs_client_destroy(
         struct nfs_open_state *os, *os_tmp;
         HASH_ITER(hh, oo->states_by_fh, os, os_tmp)
         {
-            open_state_destroy_locked(oo, os, table, vfs_thread);
+            /* The whole client is going away (lease expiry / reboot /
+             * DESTROY_CLIENTID); mark its stateids EXPIRED, not free. */
+            open_state_destroy_locked(oo, os, table, vfs_thread, true);
         }
         pthread_mutex_unlock(&oo->lock);
 
@@ -753,7 +798,9 @@ nfs_open_state_destroy(
     struct nfs_open_owner *owner = state->owner;
 
     pthread_mutex_lock(&owner->lock);
-    open_state_destroy_locked(owner, state, table, vfs_thread);
+    /* A single open being closed/rolled back -- its stateid becomes invalid
+     * (free), not expired. */
+    open_state_destroy_locked(owner, state, table, vfs_thread, false);
     pthread_mutex_unlock(&owner->lock);
 } /* nfs_open_state_destroy */
 

--- a/src/server/nfs/nfs4_state.c
+++ b/src/server/nfs/nfs4_state.c
@@ -4,6 +4,7 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 
 #include "nfs4_state.h"
 #include "nfs_internal.h"
@@ -106,6 +107,13 @@ nfs_state_table_init(struct nfs_state_table *table)
     for (int i = 0; i < NFS_STATE_NUM_SHARDS; i++) {
         shard_init(&table->shards[i]);
     }
+
+    /* Per-instance epoch stamped into every stateid (see nfs4_stateid.h).
+     * Boot time makes it differ across restarts so stateids from a previous
+     * instance are recognised as stale.  Force the high bit set so it can
+     * never collide with the special all-zero/all-ones stateids or the small
+     * "old epoch" values pynfs's makeStaleId() uses. */
+    table->epoch = (uint32_t) time(NULL) | 0x80000000u;
 } /* nfs_state_table_init */
 
 void
@@ -241,8 +249,24 @@ state_table_lookup_locked(
         *out_type = NFS4_SLOT_TYPE_FREE;
     }
 
+    /* The special stateids (all-zero anonymous, all-ones read-bypass) are not
+     * resolvable concrete state -- callers that accept them handle them before
+     * calling here, so reaching the table with one is a bad stateid.  Checked
+     * before the epoch test so an all-zero stateid is not misread as a stale
+     * (wrong-epoch) one. */
+    if (nfs4_stateid_is_special(sid)) {
+        return NFS4ERR_BAD_STATEID;
+    }
+
     nfs4_stateid_decode(&view, sid);
 
+    /* RFC 7530 §9.1.4.2: a stateid whose epoch does not match this server
+     * instance was minted before a restart -- NFS4ERR_STALE_STATEID.  Checked
+     * before the structural fields so a "rebooted" stateid (whose other bytes
+     * are otherwise meaningless) is not misreported as merely bad. */
+    if (view.epoch != table->epoch) {
+        return NFS4ERR_STALE_STATEID;
+    }
     if (view.version != NFS4_STATEID_VERSION) {
         return NFS4ERR_BAD_STATEID;
     }
@@ -583,7 +607,6 @@ nfs_open_state_create(
     uint32_t                        share_access,
     uint32_t                        share_deny,
     struct chimera_vfs_open_handle *handle_dup,
-    uint32_t                        client_short_id,
     struct nfs_state_table         *table,
     struct stateid4                *out_stateid)
 {
@@ -623,7 +646,7 @@ nfs_open_state_create(
 
     nfs4_stateid_encode(out_stateid, state->seqid,
                         NFS4_STATEID_TYPE_OPEN, shard, slot_idx, gen,
-                        client_short_id);
+                        table->epoch);
     return state;
 } /* nfs_open_state_create */
 
@@ -677,11 +700,11 @@ nfs_client_check_share_conflict(
 
 void
 nfs_open_state_coalesce(
-    struct nfs_open_state *state,
-    uint32_t               share_access,
-    uint32_t               share_deny,
-    uint32_t               client_short_id,
-    struct stateid4       *out_stateid)
+    struct nfs_open_state  *state,
+    uint32_t                share_access,
+    uint32_t                share_deny,
+    struct nfs_state_table *table,
+    struct stateid4        *out_stateid)
 {
     state->share_access |= share_access;
     state->share_deny   |= share_deny;
@@ -690,7 +713,7 @@ nfs_open_state_coalesce(
     nfs4_stateid_encode(out_stateid, state->seqid,
                         NFS4_STATEID_TYPE_OPEN,
                         state->shard, state->slot_idx, state->generation,
-                        client_short_id);
+                        table->epoch);
 } /* nfs_open_state_coalesce */
 
 static void
@@ -782,7 +805,6 @@ nfs_lock_state_create(
     struct nfs_lock_owner          *lock_owner,
     struct nfs_open_state          *open_state,
     struct chimera_vfs_open_handle *handle_dup,
-    uint32_t                        client_short_id,
     struct nfs_state_table         *table,
     struct stateid4                *out_stateid)
 {
@@ -820,7 +842,7 @@ nfs_lock_state_create(
 
     nfs4_stateid_encode(out_stateid, state->seqid,
                         NFS4_STATEID_TYPE_LOCK, shard, slot_idx, gen,
-                        client_short_id);
+                        table->epoch);
     return state;
 } /* nfs_lock_state_create */
 

--- a/src/server/nfs/nfs4_state.h
+++ b/src/server/nfs/nfs4_state.h
@@ -293,6 +293,9 @@ struct nfs_state_shard {
 
 struct nfs_state_table {
     struct nfs_state_shard shards[NFS_STATE_NUM_SHARDS];
+    /* Per-server-instance epoch stamped into every stateid; see
+     * nfs4_stateid.h.  Set once at nfs_state_table_init. */
+    uint32_t               epoch;
 };
 
 /*
@@ -405,7 +408,6 @@ nfs_open_state_create(
     uint32_t                        share_access,
     uint32_t                        share_deny,
     struct chimera_vfs_open_handle *handle_dup,
-    uint32_t                        client_short_id,
     struct nfs_state_table         *table,
     struct stateid4                *out_stateid);
 
@@ -433,11 +435,11 @@ nfs_client_check_share_conflict(
  * write the (now-updated) stateid to `out_stateid`. */
 SYMBOL_EXPORT void
 nfs_open_state_coalesce(
-    struct nfs_open_state *state,
-    uint32_t               share_access,
-    uint32_t               share_deny,
-    uint32_t               client_short_id,
-    struct stateid4       *out_stateid);
+    struct nfs_open_state  *state,
+    uint32_t                share_access,
+    uint32_t                share_deny,
+    struct nfs_state_table *table,
+    struct stateid4        *out_stateid);
 
 /* Mark a state for destruction and drop the lifetime ref.  Any walks
  * already holding an acquire-ref will complete their work; the actual
@@ -461,7 +463,6 @@ nfs_lock_state_create(
     struct nfs_lock_owner          *lock_owner,
     struct nfs_open_state          *open_state,
     struct chimera_vfs_open_handle *handle_dup,
-    uint32_t                        client_short_id,
     struct nfs_state_table         *table,
     struct stateid4                *out_stateid);
 

--- a/src/server/nfs/nfs4_state.h
+++ b/src/server/nfs/nfs4_state.h
@@ -271,9 +271,15 @@ struct nfs_lock_state {
  * incremented on every (re)use to detect stale stateids (ABA).
  */
 
-#define NFS4_SLOT_TYPE_FREE 0
-#define NFS4_SLOT_TYPE_OPEN 1
-#define NFS4_SLOT_TYPE_LOCK 2
+#define NFS4_SLOT_TYPE_FREE    0
+#define NFS4_SLOT_TYPE_OPEN    1
+#define NFS4_SLOT_TYPE_LOCK    2
+/* A slot whose state was torn down because the owning client was purged
+ * (lease expiry / reboot / DESTROY_CLIENTID).  Distinct from FREE so a stateid
+ * minted by the purged client resolves to NFS4ERR_EXPIRED rather than
+ * NFS4ERR_BAD_STATEID (RFC 7530 §8.1.3).  The slot is on the free list and
+ * reverts to a normal type when reallocated. */
+#define NFS4_SLOT_TYPE_EXPIRED 3
 
 struct nfs_state_slot {
     void    *state;
@@ -327,6 +333,13 @@ SYMBOL_EXPORT void nfs_state_table_install(
 
 /* Release a slot back to the pool (advances generation, clears type). */
 SYMBOL_EXPORT void nfs_state_table_free_slot(
+    struct nfs_state_table *table,
+    uint8_t                 shard,
+    uint32_t                slot_idx);
+
+/* Like free_slot but marks the slot EXPIRED (client purged); see
+ * NFS4_SLOT_TYPE_EXPIRED. */
+SYMBOL_EXPORT void nfs_state_table_expire_slot(
     struct nfs_state_table *table,
     uint8_t                 shard,
     uint32_t                slot_idx);

--- a/src/server/nfs/nfs4_stateid.h
+++ b/src/server/nfs/nfs4_stateid.h
@@ -12,11 +12,18 @@
 /*
  * Server-private encoding of stateid.other (12 bytes):
  *
- *   byte 0   : version (high 6 bits) | type (low 2 bits)
- *   byte 1   : shard index (0..NFS_STATE_NUM_SHARDS-1)
- *   bytes 2-4: slot_idx (24-bit, big-endian)
- *   bytes 5-7: generation (24-bit, big-endian)
- *   bytes 8-11: client_short_id (low 32 bits of nfs_client.client_id, big-endian)
+ *   bytes 0-3 : server-instance epoch (big-endian) -- see below
+ *   byte 4    : version (high 6 bits) | type (low 2 bits)
+ *   byte 5    : shard index (0..NFS_STATE_NUM_SHARDS-1)
+ *   bytes 6-8 : slot_idx (24-bit, big-endian)
+ *   bytes 9-11: generation (24-bit, big-endian)
+ *
+ * The epoch is a per-server-instance value (see nfs_state_table.epoch),
+ * placed first on purpose: a stateid minted by a previous server instance
+ * carries a different epoch, so the lookup returns NFS4ERR_STALE_STATEID
+ * (server reboot) instead of NFS4ERR_BAD_STATEID (RFC 7530 §9.1.4.2).  This is
+ * the convention pynfs's makeStaleId() probes -- it rewrites the leading bytes
+ * with an "old" epoch while makeBadID() preserves them and corrupts the rest.
  *
  * Special stateids defined by RFC 7530 §9.1.4 (all-zero, all-ones, etc.) are
  * detected by inspecting the entire {seqid, other} blob before any decode.
@@ -32,12 +39,12 @@
 #define NFS_STATE_NUM_SHARDS       64
 
 struct nfs4_stateid_view {
+    uint32_t epoch;
     uint8_t  version;
     uint8_t  type;
     uint8_t  shard;
     uint32_t slot_idx;       /* 24-bit */
     uint32_t generation;     /* 24-bit */
-    uint32_t client_short_id;
 };
 
 static inline void
@@ -48,25 +55,25 @@ nfs4_stateid_encode(
     uint8_t          shard,
     uint32_t         slot_idx,
     uint32_t         generation,
-    uint32_t         client_short_id)
+    uint32_t         epoch)
 {
     uint8_t *p = (uint8_t *) out->other;
 
     out->seqid = seqid;
 
-    p[0] = (NFS4_STATEID_VERSION << NFS4_STATEID_VERSION_SHIFT) |
+    p[0] = (uint8_t) (epoch >> 24);
+    p[1] = (uint8_t) (epoch >> 16);
+    p[2] = (uint8_t) (epoch >> 8);
+    p[3] = (uint8_t) (epoch);
+    p[4] = (NFS4_STATEID_VERSION << NFS4_STATEID_VERSION_SHIFT) |
         (type & NFS4_STATEID_TYPE_MASK);
-    p[1]  = shard;
-    p[2]  = (uint8_t) (slot_idx >> 16);
-    p[3]  = (uint8_t) (slot_idx >> 8);
-    p[4]  = (uint8_t) (slot_idx);
-    p[5]  = (uint8_t) (generation >> 16);
-    p[6]  = (uint8_t) (generation >> 8);
-    p[7]  = (uint8_t) (generation);
-    p[8]  = (uint8_t) (client_short_id >> 24);
-    p[9]  = (uint8_t) (client_short_id >> 16);
-    p[10] = (uint8_t) (client_short_id >> 8);
-    p[11] = (uint8_t) (client_short_id);
+    p[5]  = shard;
+    p[6]  = (uint8_t) (slot_idx >> 16);
+    p[7]  = (uint8_t) (slot_idx >> 8);
+    p[8]  = (uint8_t) (slot_idx);
+    p[9]  = (uint8_t) (generation >> 16);
+    p[10] = (uint8_t) (generation >> 8);
+    p[11] = (uint8_t) (generation);
 } /* nfs4_stateid_encode */
 
 static inline void
@@ -76,13 +83,13 @@ nfs4_stateid_decode(
 {
     const uint8_t *p = (const uint8_t *) sid->other;
 
-    out->version         = p[0] >> NFS4_STATEID_VERSION_SHIFT;
-    out->type            = p[0] & NFS4_STATEID_TYPE_MASK;
-    out->shard           = p[1];
-    out->slot_idx        = ((uint32_t) p[2] << 16) | ((uint32_t) p[3] << 8) | p[4];
-    out->generation      = ((uint32_t) p[5] << 16) | ((uint32_t) p[6] << 8) | p[7];
-    out->client_short_id = ((uint32_t) p[8] << 24) | ((uint32_t) p[9] << 16) |
-        ((uint32_t) p[10] << 8) | p[11];
+    out->epoch = ((uint32_t) p[0] << 24) | ((uint32_t) p[1] << 16) |
+        ((uint32_t) p[2] << 8) | p[3];
+    out->version    = p[4] >> NFS4_STATEID_VERSION_SHIFT;
+    out->type       = p[4] & NFS4_STATEID_TYPE_MASK;
+    out->shard      = p[5];
+    out->slot_idx   = ((uint32_t) p[6] << 16) | ((uint32_t) p[7] << 8) | p[8];
+    out->generation = ((uint32_t) p[9] << 16) | ((uint32_t) p[10] << 8) | p[11];
 } /* nfs4_stateid_decode */
 
 /*

--- a/src/server/nfs/tests/test_state_table.c
+++ b/src/server/nfs/tests/test_state_table.c
@@ -45,17 +45,17 @@ test_stateid_codec(void)
                         /*shard*/ 7,
                         /*slot_idx*/ 0xABCDEF,
                         /*generation*/ 0x123456,
-                        /*client_short*/ 0xDEADBEEF);
+                        /*epoch*/ 0xDEADBEEF);
 
     nfs4_stateid_decode(&view, &sid);
 
     CHECK(sid.seqid == 1);
+    CHECK(view.epoch == 0xDEADBEEF);
     CHECK(view.version == NFS4_STATEID_VERSION);
     CHECK(view.type == NFS4_STATEID_TYPE_OPEN);
     CHECK(view.shard == 7);
     CHECK(view.slot_idx == 0xABCDEF);
     CHECK(view.generation == 0x123456);
-    CHECK(view.client_short_id == 0xDEADBEEF);
 
     /* Special-stateid detection */
     struct stateid4 zero = { 0 };
@@ -91,7 +91,7 @@ test_slot_lifecycle(void)
      * pointer yet, so acquire would fault; validate just checks the slot). */
     struct stateid4 sid;
     nfs4_stateid_encode(&sid, 1, NFS4_STATEID_TYPE_OPEN,
-                        first_shard, first_slot, first_gen, 0);
+                        first_shard, first_slot, first_gen, table.epoch);
     nfsstat4        v = nfs_state_table_validate(&table, &sid);
     CHECK(v == NFS4_OK);
 
@@ -108,9 +108,20 @@ test_slot_lifecycle(void)
     /* A stateid with a wrong generation also rejects as stale. */
     struct stateid4 stale;
     nfs4_stateid_encode(&stale, 1, NFS4_STATEID_TYPE_OPEN,
-                        first_shard, first_slot, /*gen*/ 999, 0);
+                        first_shard, first_slot, /*gen*/ 999, table.epoch);
     v = nfs_state_table_validate(&table, &stale);
     CHECK(v != NFS4_OK);
+
+    /* A stateid carrying a different server-instance epoch (i.e. minted
+     * before a reboot) must be reported as stale, not merely bad. */
+    rc = nfs_state_table_alloc(&table, NFS4_SLOT_TYPE_OPEN,
+                               &first_shard, &first_slot, &first_gen);
+    CHECK(rc == 0);
+    struct stateid4 wrong_epoch;
+    nfs4_stateid_encode(&wrong_epoch, 1, NFS4_STATEID_TYPE_OPEN,
+                        first_shard, first_slot, first_gen, table.epoch ^ 0x1u);
+    v = nfs_state_table_validate(&table, &wrong_epoch);
+    CHECK(v == NFS4ERR_STALE_STATEID);
 
     nfs_state_table_free(&table, NULL);
     printf("ok: slot_lifecycle\n");
@@ -152,7 +163,6 @@ test_owner_state_lifecycle(void)
                                   OPEN4_SHARE_ACCESS_READ,
                                   OPEN4_SHARE_DENY_NONE,
                                   /*handle_dup*/ NULL,
-                                  /*client_short*/ 42,
                                   &table,
                                   &sid);
     CHECK(state != NULL);
@@ -173,7 +183,7 @@ test_owner_state_lifecycle(void)
     nfs_open_state_coalesce(state,
                             OPEN4_SHARE_ACCESS_WRITE,
                             OPEN4_SHARE_DENY_NONE,
-                            42, &sid2);
+                            &table, &sid2);
     CHECK((state->share_access &
            (OPEN4_SHARE_ACCESS_READ | OPEN4_SHARE_ACCESS_WRITE)) ==
           (OPEN4_SHARE_ACCESS_READ | OPEN4_SHARE_ACCESS_WRITE));
@@ -261,7 +271,7 @@ test_share_mode_conflict(void)
     state_a = nfs_open_state_create(owner_a, fh, sizeof(fh),
                                     OPEN4_SHARE_ACCESS_READ,
                                     OPEN4_SHARE_DENY_WRITE,
-                                    NULL, 99, &table, &sid_a);
+                                    NULL, &table, &sid_a);
     CHECK(state_a != NULL);
 
     /* Owner B asking for WRITE should be denied. */


### PR DESCRIPTION
## Summary

Stacked on #317 (and #310). When a client was purged — lease expiry, reboot (via SETCLIENTID/EXCHANGE_ID), or DESTROY_CLIENTID — its open/lock state slots were freed, so a stateid the client still held resolved to `NFS4ERR_BAD_STATEID`. RFC 7530 §8.1.3 wants `NFS4ERR_EXPIRED` for state lost because the client went away.

Adds an `NFS4_SLOT_TYPE_EXPIRED` slot state:
- client teardown (`nfs_client_destroy`) now marks each slot **EXPIRED** instead of freeing it, and leaves the **generation unchanged** so the client's extant stateids still resolve to the slot;
- the lookup returns `NFS4ERR_EXPIRED` for a matching generation (and `NFS4ERR_STALE_STATEID` for an older one);
- a normal CLOSE / open rollback still **frees** the slot (`NFS4ERR_BAD_STATEID` for a closed stateid);
- expired slots remain on the free list and revert to a normal type (bumping the generation) when reallocated.

## Verification

pynfs (memfs, 4.0): `st_setclientid` CID1 (`testClientReboot`) now passes — **`st_setclientid` is 14/14**. `st_lock` also improves (24→25, the lease-expiry `testTimedoutGrabLock` path). No regression: posix/cthon NFS4 (83/83), `open` 4.0 (27), `locku` (unchanged), `destroy_clientid` 4.1 (8/8), and the `state_table` unit test.

## Note

Earlier commits here are #310/#317; this PR shows only its own diff once they merge and the branch is rebased.