### PR TITLE
memfs: detect non-empty directories by entries, not link count (fixes dirent leak)

### DIFF
--- a/src/common/rbtree.h
+++ b/src/common/rbtree.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/common/rbtree.h
+++ b/src/common/rbtree.h
@@ -139,6 +139,12 @@ rb_tree_init(struct rb_tree *tree)
     tree->root      = &tree->nil;
 } /* rb_tree_init */
 
+static inline int
+rb_tree_empty(const struct rb_tree *tree)
+{
+    return tree->root == &tree->nil;
+} /* rb_tree_empty */
+
 static void
 rb_tree_destroy(
     struct rb_tree *tree,

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -1571,7 +1571,7 @@ memfs_remove_at(
         return;
     }
 
-    if (S_ISDIR(inode->mode) && inode->nlink > 2) {
+    if (S_ISDIR(inode->mode) && !rb_tree_empty(&inode->dir.dirents)) {
         pthread_mutex_unlock(&parent_inode->lock);
         pthread_mutex_unlock(&inode->lock);
         request->status = CHIMERA_VFS_ENOTEMPTY;
@@ -3474,7 +3474,8 @@ memfs_rename_at(
             }
 
             /* Cannot replace non-empty directory */
-            if (S_ISDIR(existing_inode->mode) && existing_inode->nlink > 2) {
+            if (S_ISDIR(existing_inode->mode) &&
+                !rb_tree_empty(&existing_inode->dir.dirents)) {
                 pthread_mutex_unlock(&existing_inode->lock);
                 pthread_mutex_unlock(&child_inode->lock);
                 pthread_mutex_unlock(&old_parent_inode->lock);


### PR DESCRIPTION
## Summary

`memfs_remove_at` and `memfs_rename_at` decided whether a directory was empty using `inode->nlink > 2`. But a directory's link count only counts **subdirectories** (each child dir adds a link via its `..`) — regular files don't bump it. So a directory containing only files has `nlink == 2` and was wrongly treated as empty:

- `rmdir` / rename-over-directory **succeeded** when it should have returned `NT_STATUS_DIRECTORY_NOT_EMPTY` / `ENOTEMPTY`, and
- the contained directory entries were **orphaned** — a `memfs_dirent` leak, since the parent directory was freed without its children being removed.

## Fix

Check actual emptiness via the directory's dirent rb-tree instead of the link count. Adds a small `rb_tree_empty()` helper to `src/common/rbtree.h`. (`.`/`..` are synthesized in readdir and are not stored as dirents, so an empty directory has an empty tree.)

## How it was found

LeakSanitizer (Debug builds) flagged a 320-byte `memfs_dirent` leak on the smbtorture `acls_non_canonical` / `async_dosmode` suites, which create a file in a test directory and then remove the directory. The leak is deterministic given the right op sequence — it showed up on arm64 CI but reproduces identically on x86_64.

## Testing

- The two leaking suites pass clean under ASan/LSan after the fix.
- KVM regression on memfs (ubuntu2404): NFS cthon basic/general/special (v3/v4.x), SMB cthon basic/general, and xfstests `fsx` all pass — the stricter `ENOTEMPTY` behavior is the correct POSIX/SMB semantics and didn't regress them.
