### PR TITLE
smb: negotiate SMB 3.0.2

### DIFF
--- a/src/server/server.c
+++ b/src/server/server.c
@@ -115,9 +115,10 @@ chimera_server_config_init(void)
     config->soft_fail_bad_req        = 0;
     config->tcp_flavor               = CHIMERA_TCP_FLAVOR_PLAIN;
 
-    config->smb_num_dialects = 2;
+    config->smb_num_dialects = 3;
     config->smb_dialects[0]  = SMB2_DIALECT_2_1;
     config->smb_dialects[1]  = SMB2_DIALECT_3_0;
+    config->smb_dialects[2]  = SMB2_DIALECT_3_0_2;
 
     config->smb_num_nic_info = 0;
 

--- a/src/server/smb/smb_signing.c
+++ b/src/server/smb/smb_signing.c
@@ -137,6 +137,9 @@ chimera_smb_derive_signing_key(
                 return -1;
             }
         case SMB2_DIALECT_3_0:
+        case SMB2_DIALECT_3_0_2:
+            /* 3.0 and 3.0.2 share the SP800-108 signing-key derivation
+             * (label "SMB2AESCMAC", context "SmbSign"). */
             return kdf_counter_hmac_sha256_ossl3(session_key, session_key_len,
                                                  label30, sizeof(label30), /* includes '\0' */
                                                  (const uint8_t *) ctx30, sizeof(ctx30), /* includes '\0' */
@@ -337,6 +340,7 @@ chimera_smb_verify_signature(
             }
             break;
         case SMB2_DIALECT_3_0:
+        case SMB2_DIALECT_3_0_2:
             rc = chimera_smb_request_cmac_aes_128_cbc(
                 ctx,
                 &request->smb2_hdr,
@@ -448,6 +452,7 @@ chimera_smb_sign_compound(
                     }
                     break;
                 case SMB2_DIALECT_3_0:
+                case SMB2_DIALECT_3_0_2:
                     rc = chimera_smb_request_cmac_aes_128_cbc(
                         ctx,
                         hdr,

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -109,6 +109,7 @@ if(CHIMERA_NETNS_TESTING AND WPTS_DOTNET AND WPTS_SMB2_DLL AND WPTS_ARCH_SUPPORT
         BVT_Negotiate_Compatible_Wildcard
         BVT_Negotiate_SMB21
         BVT_Negotiate_SMB30
+        BVT_Negotiate_SMB302
         BVT_Negotiate_SigningEnabled
         BVT_SMB2Basic_ChangeNotify_ChangeAttributes
         BVT_SMB2Basic_ChangeNotify_ChangeCreation


### PR DESCRIPTION
## Summary

The server advertised only up to SMB 3.0, so a client offering 3.0.2 (or higher) was negotiated down to 3.0. Add SMB **3.0.2** to the default dialect list and handle it everywhere the signing path switches on the dialect:

- signing-key derivation (same SP800-108 KDF as 3.0),
- reply signing and request-signature verification (AES-128-CMAC, as 3.0).

3.0.2 carries no negotiate contexts (those are 3.1.1-only), so this is purely dialect plumbing. With 3.0.2 advertised, the server now negotiates it as the top dialect for current clients, and signed sessions continue to work.

## Testing

Found by WPTS MS-SMB2 `BVT_Negotiate_SMB302`, now passing and **added to the allowlist** (39). The full allowlist still passes (39/39, incl. the signing tests, which exercise the now-3.0.2 signing path).

Stepping stone toward SMB 3.1.1 (preauth integrity), which is the next batch.