### PR TITLE
nfs4: implement the NFSv4.1 current stateid (RFC 8881 §16.2.3.1.2)

### DIFF
--- a/src/server/nfs/nfs4_proc_close.c
+++ b/src/server/nfs/nfs4_proc_close.c
@@ -23,6 +23,9 @@ chimera_nfs4_close(
     uint8_t                 state_type;
     nfsstat4                status;
 
+    /* NFS4.1 current-stateid substitution (RFC 8881 §16.2.3.1.2). */
+    chimera_nfs4_resolve_current_stateid(req, &args->open_stateid);
+
     status = nfs_state_table_acquire(table,
                                      &args->open_stateid,
                                      NFS4_SLOT_TYPE_OPEN,

--- a/src/server/nfs/nfs4_proc_compound.c
+++ b/src/server/nfs/nfs4_proc_compound.c
@@ -98,6 +98,33 @@ chimera_nfs4_compound_process(
         if (gate != NFS4_OK) {
             chimera_nfs4_compound_complete(req, gate);
         } else {
+            /* NFS4.1 current-stateid lifecycle (RFC 8881 §16.2.3.1.2):
+             * ops that change the current filehandle clear the current
+             * stateid, while SAVEFH/RESTOREFH carry it alongside the
+             * saved filehandle.  Stateid-returning ops set it in their
+             * own handlers. */
+            switch (argop->argop) {
+                case OP_PUTFH:
+                case OP_PUTROOTFH:
+                case OP_PUTPUBFH:
+                case OP_LOOKUP:
+                case OP_LOOKUPP:
+                case OP_CREATE:
+                case OP_OPENATTR:
+                    chimera_nfs4_clear_current_stateid(req);
+                    break;
+                case OP_SAVEFH:
+                    req->saved_current_stateid_valid = req->current_stateid_valid;
+                    req->saved_current_stateid       = req->current_stateid;
+                    break;
+                case OP_RESTOREFH:
+                    req->current_stateid_valid = req->saved_current_stateid_valid;
+                    req->current_stateid       = req->saved_current_stateid;
+                    break;
+                default:
+                    break;
+            } /* switch */
+
             switch (argop->argop) {
                 case OP_ACCESS:
                     chimera_nfs4_access(thread, req, argop, resop);
@@ -308,14 +335,16 @@ chimera_nfs4_compound(
     /* RFC 7530 §16.2.4: the server MUST echo the request tag back to the
      * client unchanged. xdr_opaque .data is owned by the request msg buffer
      * which lives until the response is sent. */
-    req->res_compound.tag    = args->tag;
-    req->fhlen               = 0;
-    req->saved_fhlen         = 0;
-    req->minorversion        = (uint8_t) args->minorversion;
-    req->seen_sequence       = false;
-    req->open_4_0_owner      = NULL;
-    req->lock_4_0_open_owner = NULL;
-    req->lock_4_0_lock_owner = NULL;
+    req->res_compound.tag            = args->tag;
+    req->fhlen                       = 0;
+    req->saved_fhlen                 = 0;
+    req->minorversion                = (uint8_t) args->minorversion;
+    req->seen_sequence               = false;
+    req->current_stateid_valid       = false;
+    req->saved_current_stateid_valid = false;
+    req->open_4_0_owner              = NULL;
+    req->lock_4_0_open_owner         = NULL;
+    req->lock_4_0_lock_owner         = NULL;
 
     /* Chimera implements NFS v4.0, v4.1 and v4.2 (minorversions 0–2).
      * Reject unknown minor versions with NFS4ERR_MINOR_VERS_MISMATCH per

--- a/src/server/nfs/nfs4_proc_lock.c
+++ b/src/server/nfs/nfs4_proc_lock.c
@@ -127,6 +127,7 @@ chimera_nfs4_lock_complete(
                             lock_state->generation, table->epoch);
 
         res->status = NFS4_OK;
+        chimera_nfs4_set_current_stateid(req, &res->resok4.lock_stateid);
 
         nfs_state_table_release(table, lock_state, NFS4_SLOT_TYPE_LOCK,
                                 req->thread->vfs_thread);

--- a/src/server/nfs/nfs4_proc_locku.c
+++ b/src/server/nfs/nfs4_proc_locku.c
@@ -39,6 +39,9 @@ chimera_nfs4_locku(
         return;
     }
 
+    /* NFS4.1 current-stateid substitution (RFC 8881 §16.2.3.1.2). */
+    chimera_nfs4_resolve_current_stateid(req, &args->lock_stateid);
+
     status = nfs_state_table_acquire(table, &args->lock_stateid,
                                      NFS4_SLOT_TYPE_LOCK,
                                      &state_void, &state_type);
@@ -136,6 +139,7 @@ chimera_nfs4_locku(
                         lock_state->shard, lock_state->slot_idx,
                         lock_state->generation, table->epoch);
     res->status = NFS4_OK;
+    chimera_nfs4_set_current_stateid(req, &res->lock_stateid);
 
     /* RFC 7530 §9.1.7: record cached reply for the lock_owner. */
     if (is_v40 && lock_owner) {

--- a/src/server/nfs/nfs4_proc_open.c
+++ b/src/server/nfs/nfs4_proc_open.c
@@ -209,6 +209,13 @@ chimera_nfs4_open_complete(
         pthread_mutex_unlock(&owner->lock);
     }
 
+    /* NFS4.1: a successful OPEN sets the COMPOUND's current stateid. */
+    if (status == NFS4_OK) {
+        struct OPEN4res *res =
+            &req->res_compound.resarray[req->index].opopen;
+        chimera_nfs4_set_current_stateid(req, &res->resok4.stateid);
+    }
+
     chimera_nfs4_compound_complete(req, status);
 } /* chimera_nfs4_open_complete */
 

--- a/src/server/nfs/nfs4_proc_open_downgrade.c
+++ b/src/server/nfs/nfs4_proc_open_downgrade.c
@@ -40,6 +40,9 @@ chimera_nfs4_open_downgrade(
         return;
     }
 
+    /* NFS4.1 current-stateid substitution (RFC 8881 §16.2.3.1.2). */
+    chimera_nfs4_resolve_current_stateid(req, &args->open_stateid);
+
     status = nfs_state_table_acquire(table, &args->open_stateid,
                                      NFS4_SLOT_TYPE_OPEN,
                                      &state_void, &state_type);
@@ -125,5 +128,6 @@ chimera_nfs4_open_downgrade(
                             thread->vfs_thread);
 
     res->status = NFS4_OK;
+    chimera_nfs4_set_current_stateid(req, &res->resok4.open_stateid);
     chimera_nfs4_compound_complete(req, NFS4_OK);
 } /* chimera_nfs4_open_downgrade */

--- a/src/server/nfs/nfs4_proc_setattr.c
+++ b/src/server/nfs/nfs4_proc_setattr.c
@@ -123,6 +123,9 @@ chimera_nfs4_setattr(
         return;
     }
 
+    /* NFS4.1 current-stateid substitution (RFC 8881 §16.2.3.1.2). */
+    chimera_nfs4_resolve_current_stateid(req, &args->stateid);
+
     /* RFC 7530 §16.32.3: when SETATTR carries FATTR4_SIZE the supplied
      * stateid must identify an open with write access.  Special stateids
      * (all-zero / all-ones) are exempt -- treated as anonymous, like the

--- a/src/server/nfs/nfs4_proc_write.c
+++ b/src/server/nfs/nfs4_proc_write.c
@@ -113,6 +113,9 @@ chimera_nfs4_write(
     req->nfs_state_ref = NULL;
     req->handle        = NULL;
 
+    /* NFS4.1 current-stateid substitution (RFC 8881 §16.2.3.1.2). */
+    chimera_nfs4_resolve_current_stateid(req, &args->stateid);
+
     /*
      * Transfer ownership of write iovecs from the RPC2 message to prevent
      * msg_free from double-releasing (args->data.iov points to msg->read_chunk.iov

--- a/src/server/nfs/nfs4_procs.h
+++ b/src/server/nfs/nfs4_procs.h
@@ -411,6 +411,54 @@ chimera_nfs4_compound_process(
 /* Validate that [p, p+len) is well-formed UTF-8 (RFC 3629): rejects stray
  * continuation bytes, overlong encodings, UTF-16 surrogates, the U+FFFE/FFFF
  * non-characters, and anything above U+10FFFF. Returns true if well-formed. */
+/*
+ * NFS4.1 "current stateid" (RFC 8881 §16.2.3.1.2).  The special value
+ * { seqid = 1, other = all zeros } means "use the COMPOUND's current stateid",
+ * which stateid-returning operations (OPEN, LOCK, OPEN_DOWNGRADE, ...) set.
+ */
+static inline bool
+chimera_nfs4_stateid_is_current(const struct stateid4 *sid)
+{
+    static const uint8_t zero[NFS4_OTHER_SIZE] = { 0 };
+
+    return sid->seqid == 1 &&
+           memcmp(sid->other, zero, NFS4_OTHER_SIZE) == 0;
+} /* chimera_nfs4_stateid_is_current */
+
+/* Record the current stateid produced by a stateid-returning op (4.1+). */
+static inline void
+chimera_nfs4_set_current_stateid(
+    struct nfs_request    *req,
+    const struct stateid4 *sid)
+{
+    if (req->minorversion >= 1) {
+        req->current_stateid       = *sid;
+        req->current_stateid_valid = true;
+    }
+} /* chimera_nfs4_set_current_stateid */
+
+/* Clear the COMPOUND's current stateid -- done by ops that change the current
+ * filehandle (RFC 8881 §16.2.3.1.2). */
+static inline void
+chimera_nfs4_clear_current_stateid(struct nfs_request *req)
+{
+    req->current_stateid_valid = false;
+} /* chimera_nfs4_clear_current_stateid */
+
+/* If `sid` is the special current-stateid value, replace it in place with the
+ * COMPOUND's current stateid (4.1+).  No-op otherwise. */
+static inline void
+chimera_nfs4_resolve_current_stateid(
+    struct nfs_request *req,
+    struct stateid4    *sid)
+{
+    if (req->minorversion >= 1 &&
+        req->current_stateid_valid &&
+        chimera_nfs4_stateid_is_current(sid)) {
+        *sid = req->current_stateid;
+    }
+} /* chimera_nfs4_resolve_current_stateid */
+
 static inline bool
 chimera_nfs4_utf8_valid(
     const char *data,

--- a/src/server/nfs/nfs_common.h
+++ b/src/server/nfs/nfs_common.h
@@ -60,6 +60,15 @@ struct nfs_request {
     int                               index;
     uint8_t                           minorversion;     /* COMPOUND4args.minorversion */
     bool                              seen_sequence;    /* set once OP_SEQUENCE has run in this compound */
+    /* NFS4.1 "current stateid" (RFC 8881 §16.2.3.1.2): a per-COMPOUND value
+     * set by stateid-returning ops (OPEN/LOCK/...) and substituted into
+     * later ops that present the special current-stateid value. */
+    bool                              current_stateid_valid;
+    struct stateid4                   current_stateid;
+    /* SAVEFH/RESTOREFH save and restore the current stateid alongside the
+     * current filehandle (RFC 8881 §16.2.3.1.2). */
+    bool                              saved_current_stateid_valid;
+    struct stateid4                   saved_current_stateid;
     /* In-flight state ref for ops that acquire from the unified state table.
      * Released by the completion handler.  Phase 2.  Type is one of
      * NFS4_SLOT_TYPE_OPEN / NFS4_SLOT_TYPE_LOCK. */


### PR DESCRIPTION
## Summary

NFSv4.1 lets an operation refer to a stateid produced earlier in the **same COMPOUND** via the special "current stateid" value `{ seqid = 1, other = all-zeros }` — so OPEN+CLOSE, LOCK+LOCKU, OPEN+WRITE+CLOSE, etc. work in a single COMPOUND. The server didn't track this, so any op presenting the special value failed.

This maintains a per-COMPOUND current stateid on the request:
- **producers** (OPEN, LOCK, LOCKU, OPEN_DOWNGRADE) set it from their result;
- **consumers** (CLOSE, WRITE, LOCKU, SETATTR, OPEN_DOWNGRADE) substitute it when handed the special value;
- ops that **change the current filehandle** (PUTFH/PUTROOTFH/PUTPUBFH/LOOKUP/LOOKUPP/CREATE/OPENATTR) **clear** it, and **SAVEFH/RESTOREFH carry it** alongside the saved filehandle.

All gated on `minorversion >= 1`, so the 4.0 path is untouched.

## Verification

pynfs `st_current_stateid` (memfs, 4.1): **2/10 → 8/10**. The two remaining — CSID7 (`testOpenLayoutGet`) and CSID9 (`testOpenFreestateidClose`) — require the LAYOUTGET (pNFS) and FREE_STATEID operations, which aren't implemented.

No regression: posix/cthon NFS4 memfs (83/83), and the 4.0 stateid suites (`open` 27, `setattr` 44, `locku` 7) and 4.1 `open`/`sequence` are unchanged (their failures are pre-existing delegation/misc cases).