### PR TITLE
nfs4: implement FREE_STATEID and enable the currentstateid pynfs suite

### DIFF
--- a/pynfs/CMakeLists.txt
+++ b/pynfs/CMakeLists.txt
@@ -42,7 +42,7 @@ set(PYNFS_PASS_0
     access commit create getattr getfh link lockt lookup lookupp nverify
     putpubfh putrootfh readdir readlink remove rename restorefh savefh verify)
 set(PYNFS_PASS_1
-    destroy_clientid getfh lookup putfh rename verify xattr)
+    currentstateid destroy_clientid getfh lookup putfh rename verify xattr)
 set(PYNFS_PASS_2
     destroy_clientid getfh lookup rename sparse verify)
 
@@ -50,13 +50,20 @@ set(PYNFS_PASS_2
 # register the same suites but leave them DISABLED until validated.
 set(PYNFS_PASS_BACKENDS memfs)
 
+# Extra pynfs flag tokens for specific suites.  pynfs excludes any test tagged
+# with a "no<flag>" token, so this drops tests a suite pulls in that the server
+# does not support.  currentstateid's CSID7 is tagged pnfs (LAYOUTGET); chimera
+# is not a pNFS server, so exclude it.
+set(PYNFS_EXTRA_currentstateid nopnfs)
+
 # Register one suite, enabling it only when both the backend and the
 # flag/minor pair are on the validated pass-lists; otherwise mark it DISABLED.
 function(pynfs_add_test flag backend minor)
     set(name chimera/pynfs/${flag}_${backend}_nfs4.${minor})
     add_test(NAME ${name}
         COMMAND bash ${PYNFS_WRAPPER}
-                ${CHIMERA_BINARY} ${backend} ${minor} ${PYNFS_DIR} ${flag})
+                ${CHIMERA_BINARY} ${backend} ${minor} ${PYNFS_DIR} ${flag}
+                ${PYNFS_EXTRA_${flag}})
     set_tests_properties(${name} PROPERTIES
         LABELS pynfs
         ENVIRONMENT "PYTHONUNBUFFERED=1")

--- a/src/server/nfs/CMakeLists.txt
+++ b/src/server/nfs/CMakeLists.txt
@@ -22,7 +22,8 @@ add_library(chimera_nfs SHARED nfs.c nfs4_session.c nfs4_state.c nfs4_lease.c nf
             nfs4_proc_setattr.c nfs4_proc_link.c nfs4_proc_rename.c nfs4_proc_savefh.c nfs4_proc_restorefh.c
             nfs4_proc_exchange_id.c nfs4_proc_create_session.c nfs4_proc_destroy_session.c
             nfs4_proc_destroy_clientid.c nfs4_proc_sequence.c nfs4_proc_reclaim_complete.c
-            nfs4_proc_secinfo.c nfs4_proc_secinfo_no_name.c nfs4_proc_test_stateid.c nfs4_root.c
+            nfs4_proc_secinfo.c nfs4_proc_secinfo_no_name.c nfs4_proc_test_stateid.c
+            nfs4_proc_free_stateid.c nfs4_root.c
             nfs4_proc_allocate.c nfs4_proc_deallocate.c nfs4_proc_seek.c
             nfs4_proc_lock.c nfs4_proc_lockt.c nfs4_proc_locku.c
             nfs4_proc_verify.c

--- a/src/server/nfs/nfs4_proc_close.c
+++ b/src/server/nfs/nfs4_proc_close.c
@@ -23,6 +23,9 @@ chimera_nfs4_close(
     uint8_t                 state_type;
     nfsstat4                status;
 
+    /* NFS4.1 current-stateid substitution (RFC 8881 §16.2.3.1.2). */
+    chimera_nfs4_resolve_current_stateid(req, &args->open_stateid);
+
     status = nfs_state_table_acquire(table,
                                      &args->open_stateid,
                                      NFS4_SLOT_TYPE_OPEN,

--- a/src/server/nfs/nfs4_proc_compound.c
+++ b/src/server/nfs/nfs4_proc_compound.c
@@ -98,6 +98,33 @@ chimera_nfs4_compound_process(
         if (gate != NFS4_OK) {
             chimera_nfs4_compound_complete(req, gate);
         } else {
+            /* NFS4.1 current-stateid lifecycle (RFC 8881 §16.2.3.1.2):
+             * ops that change the current filehandle clear the current
+             * stateid, while SAVEFH/RESTOREFH carry it alongside the
+             * saved filehandle.  Stateid-returning ops set it in their
+             * own handlers. */
+            switch (argop->argop) {
+                case OP_PUTFH:
+                case OP_PUTROOTFH:
+                case OP_PUTPUBFH:
+                case OP_LOOKUP:
+                case OP_LOOKUPP:
+                case OP_CREATE:
+                case OP_OPENATTR:
+                    chimera_nfs4_clear_current_stateid(req);
+                    break;
+                case OP_SAVEFH:
+                    req->saved_current_stateid_valid = req->current_stateid_valid;
+                    req->saved_current_stateid       = req->current_stateid;
+                    break;
+                case OP_RESTOREFH:
+                    req->current_stateid_valid = req->saved_current_stateid_valid;
+                    req->current_stateid       = req->saved_current_stateid;
+                    break;
+                default:
+                    break;
+            } /* switch */
+
             switch (argop->argop) {
                 case OP_ACCESS:
                     chimera_nfs4_access(thread, req, argop, resop);
@@ -308,14 +335,16 @@ chimera_nfs4_compound(
     /* RFC 7530 §16.2.4: the server MUST echo the request tag back to the
      * client unchanged. xdr_opaque .data is owned by the request msg buffer
      * which lives until the response is sent. */
-    req->res_compound.tag    = args->tag;
-    req->fhlen               = 0;
-    req->saved_fhlen         = 0;
-    req->minorversion        = (uint8_t) args->minorversion;
-    req->seen_sequence       = false;
-    req->open_4_0_owner      = NULL;
-    req->lock_4_0_open_owner = NULL;
-    req->lock_4_0_lock_owner = NULL;
+    req->res_compound.tag            = args->tag;
+    req->fhlen                       = 0;
+    req->saved_fhlen                 = 0;
+    req->minorversion                = (uint8_t) args->minorversion;
+    req->seen_sequence               = false;
+    req->current_stateid_valid       = false;
+    req->saved_current_stateid_valid = false;
+    req->open_4_0_owner              = NULL;
+    req->lock_4_0_open_owner         = NULL;
+    req->lock_4_0_lock_owner         = NULL;
 
     /* Chimera implements NFS v4.0, v4.1 and v4.2 (minorversions 0–2).
      * Reject unknown minor versions with NFS4ERR_MINOR_VERS_MISMATCH per

--- a/src/server/nfs/nfs4_proc_compound.c
+++ b/src/server/nfs/nfs4_proc_compound.c
@@ -238,6 +238,9 @@ chimera_nfs4_compound_process(
                 case OP_TEST_STATEID:
                     chimera_nfs4_test_stateid(thread, req, argop, resop);
                     break;
+                case OP_FREE_STATEID:
+                    chimera_nfs4_free_stateid(thread, req, argop, resop);
+                    break;
                 case OP_ALLOCATE:
                     chimera_nfs4_allocate(thread, req, argop, resop);
                     break;

--- a/src/server/nfs/nfs4_proc_free_stateid.c
+++ b/src/server/nfs/nfs4_proc_free_stateid.c
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * RFC 8881 §18.38: FREE_STATEID
+ *
+ * Frees a stateid whose state has already been released -- a lock stateid with
+ * no remaining byte-range locks, or a stateid the server has revoked.  If state
+ * is still held (an open, or a lock stateid that still owns locks), the stateid
+ * cannot be freed and the server returns NFS4ERR_LOCKS_HELD.  4.1+ only.
+ */
+
+#include "nfs4_procs.h"
+#include "nfs4_state.h"
+#include "nfs4_stateid.h"
+
+void
+chimera_nfs4_free_stateid(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_request               *req,
+    struct nfs_argop4                *argop,
+    struct nfs_resop4                *resop)
+{
+    struct FREE_STATEID4args *args  = &argop->opfree_stateid;
+    struct FREE_STATEID4res  *res   = &resop->opfree_stateid;
+    struct nfs_state_table   *table = &thread->shared->nfs4_state_table;
+    struct nfs_lock_state    *lock_state;
+    void                     *state_void;
+    uint8_t                   state_type;
+    nfsstat4                  status;
+
+    /* NFS4.1 current-stateid substitution (RFC 8881 §16.2.3.1.2). */
+    chimera_nfs4_resolve_current_stateid(req, &args->fsa_stateid);
+
+    /* The special anonymous/read-bypass stateids name no state to free. */
+    if (nfs4_stateid_is_special(&args->fsa_stateid)) {
+        res->fsr_status = NFS4ERR_BAD_STATEID;
+        chimera_nfs4_compound_complete(req, res->fsr_status);
+        return;
+    }
+
+    status = nfs_state_table_acquire(table, &args->fsa_stateid, 0,
+                                     &state_void, &state_type);
+    if (status != NFS4_OK) {
+        res->fsr_status = status;
+        chimera_nfs4_compound_complete(req, res->fsr_status);
+        return;
+    }
+
+    /* An open is released via CLOSE, never FREE_STATEID. */
+    if (state_type == NFS4_SLOT_TYPE_OPEN) {
+        nfs_state_table_release(table, state_void, NFS4_SLOT_TYPE_OPEN,
+                                thread->vfs_thread);
+        res->fsr_status = NFS4ERR_LOCKS_HELD;
+        chimera_nfs4_compound_complete(req, res->fsr_status);
+        return;
+    }
+
+    lock_state = state_void;
+
+    /* A lock stateid that still owns byte-range locks cannot be freed. */
+    if (lock_state->range_leases != NULL) {
+        nfs_state_table_release(table, lock_state, NFS4_SLOT_TYPE_LOCK,
+                                thread->vfs_thread);
+        res->fsr_status = NFS4ERR_LOCKS_HELD;
+        chimera_nfs4_compound_complete(req, res->fsr_status);
+        return;
+    }
+
+    /* No locks remain: free the lock stateid.  destroy drops the lifetime
+     * ref and marks the slot freed; the release below drops our acquire ref,
+     * which then runs cleanup. */
+    nfs_lock_state_destroy(lock_state, table, thread->vfs_thread);
+    nfs_state_table_release(table, lock_state, NFS4_SLOT_TYPE_LOCK,
+                            thread->vfs_thread);
+
+    res->fsr_status = NFS4_OK;
+    chimera_nfs4_compound_complete(req, NFS4_OK);
+} /* chimera_nfs4_free_stateid */

--- a/src/server/nfs/nfs4_proc_lock.c
+++ b/src/server/nfs/nfs4_proc_lock.c
@@ -127,6 +127,7 @@ chimera_nfs4_lock_complete(
                             lock_state->generation, table->epoch);
 
         res->status = NFS4_OK;
+        chimera_nfs4_set_current_stateid(req, &res->resok4.lock_stateid);
 
         nfs_state_table_release(table, lock_state, NFS4_SLOT_TYPE_LOCK,
                                 req->thread->vfs_thread);

--- a/src/server/nfs/nfs4_proc_locku.c
+++ b/src/server/nfs/nfs4_proc_locku.c
@@ -39,6 +39,9 @@ chimera_nfs4_locku(
         return;
     }
 
+    /* NFS4.1 current-stateid substitution (RFC 8881 §16.2.3.1.2). */
+    chimera_nfs4_resolve_current_stateid(req, &args->lock_stateid);
+
     status = nfs_state_table_acquire(table, &args->lock_stateid,
                                      NFS4_SLOT_TYPE_LOCK,
                                      &state_void, &state_type);
@@ -136,6 +139,7 @@ chimera_nfs4_locku(
                         lock_state->shard, lock_state->slot_idx,
                         lock_state->generation, table->epoch);
     res->status = NFS4_OK;
+    chimera_nfs4_set_current_stateid(req, &res->lock_stateid);
 
     /* RFC 7530 §9.1.7: record cached reply for the lock_owner. */
     if (is_v40 && lock_owner) {

--- a/src/server/nfs/nfs4_proc_open.c
+++ b/src/server/nfs/nfs4_proc_open.c
@@ -209,6 +209,13 @@ chimera_nfs4_open_complete(
         pthread_mutex_unlock(&owner->lock);
     }
 
+    /* NFS4.1: a successful OPEN sets the COMPOUND's current stateid. */
+    if (status == NFS4_OK) {
+        struct OPEN4res *res =
+            &req->res_compound.resarray[req->index].opopen;
+        chimera_nfs4_set_current_stateid(req, &res->resok4.stateid);
+    }
+
     chimera_nfs4_compound_complete(req, status);
 } /* chimera_nfs4_open_complete */
 

--- a/src/server/nfs/nfs4_proc_open_downgrade.c
+++ b/src/server/nfs/nfs4_proc_open_downgrade.c
@@ -40,6 +40,9 @@ chimera_nfs4_open_downgrade(
         return;
     }
 
+    /* NFS4.1 current-stateid substitution (RFC 8881 §16.2.3.1.2). */
+    chimera_nfs4_resolve_current_stateid(req, &args->open_stateid);
+
     status = nfs_state_table_acquire(table, &args->open_stateid,
                                      NFS4_SLOT_TYPE_OPEN,
                                      &state_void, &state_type);
@@ -125,5 +128,6 @@ chimera_nfs4_open_downgrade(
                             thread->vfs_thread);
 
     res->status = NFS4_OK;
+    chimera_nfs4_set_current_stateid(req, &res->resok4.open_stateid);
     chimera_nfs4_compound_complete(req, NFS4_OK);
 } /* chimera_nfs4_open_downgrade */

--- a/src/server/nfs/nfs4_proc_setattr.c
+++ b/src/server/nfs/nfs4_proc_setattr.c
@@ -123,6 +123,9 @@ chimera_nfs4_setattr(
         return;
     }
 
+    /* NFS4.1 current-stateid substitution (RFC 8881 §16.2.3.1.2). */
+    chimera_nfs4_resolve_current_stateid(req, &args->stateid);
+
     /* RFC 7530 §16.32.3: when SETATTR carries FATTR4_SIZE the supplied
      * stateid must identify an open with write access.  Special stateids
      * (all-zero / all-ones) are exempt -- treated as anonymous, like the

--- a/src/server/nfs/nfs4_proc_write.c
+++ b/src/server/nfs/nfs4_proc_write.c
@@ -113,6 +113,9 @@ chimera_nfs4_write(
     req->nfs_state_ref = NULL;
     req->handle        = NULL;
 
+    /* NFS4.1 current-stateid substitution (RFC 8881 §16.2.3.1.2). */
+    chimera_nfs4_resolve_current_stateid(req, &args->stateid);
+
     /*
      * Transfer ownership of write iovecs from the RPC2 message to prevent
      * msg_free from double-releasing (args->data.iov points to msg->read_chunk.iov

--- a/src/server/nfs/nfs4_procs.h
+++ b/src/server/nfs/nfs4_procs.h
@@ -411,6 +411,54 @@ chimera_nfs4_compound_process(
 /* Validate that [p, p+len) is well-formed UTF-8 (RFC 3629): rejects stray
  * continuation bytes, overlong encodings, UTF-16 surrogates, the U+FFFE/FFFF
  * non-characters, and anything above U+10FFFF. Returns true if well-formed. */
+/*
+ * NFS4.1 "current stateid" (RFC 8881 §16.2.3.1.2).  The special value
+ * { seqid = 1, other = all zeros } means "use the COMPOUND's current stateid",
+ * which stateid-returning operations (OPEN, LOCK, OPEN_DOWNGRADE, ...) set.
+ */
+static inline bool
+chimera_nfs4_stateid_is_current(const struct stateid4 *sid)
+{
+    static const uint8_t zero[NFS4_OTHER_SIZE] = { 0 };
+
+    return sid->seqid == 1 &&
+           memcmp(sid->other, zero, NFS4_OTHER_SIZE) == 0;
+} /* chimera_nfs4_stateid_is_current */
+
+/* Record the current stateid produced by a stateid-returning op (4.1+). */
+static inline void
+chimera_nfs4_set_current_stateid(
+    struct nfs_request    *req,
+    const struct stateid4 *sid)
+{
+    if (req->minorversion >= 1) {
+        req->current_stateid       = *sid;
+        req->current_stateid_valid = true;
+    }
+} /* chimera_nfs4_set_current_stateid */
+
+/* Clear the COMPOUND's current stateid -- done by ops that change the current
+ * filehandle (RFC 8881 §16.2.3.1.2). */
+static inline void
+chimera_nfs4_clear_current_stateid(struct nfs_request *req)
+{
+    req->current_stateid_valid = false;
+} /* chimera_nfs4_clear_current_stateid */
+
+/* If `sid` is the special current-stateid value, replace it in place with the
+ * COMPOUND's current stateid (4.1+).  No-op otherwise. */
+static inline void
+chimera_nfs4_resolve_current_stateid(
+    struct nfs_request *req,
+    struct stateid4    *sid)
+{
+    if (req->minorversion >= 1 &&
+        req->current_stateid_valid &&
+        chimera_nfs4_stateid_is_current(sid)) {
+        *sid = req->current_stateid;
+    }
+} /* chimera_nfs4_resolve_current_stateid */
+
 static inline bool
 chimera_nfs4_utf8_valid(
     const char *data,

--- a/src/server/nfs/nfs4_procs.h
+++ b/src/server/nfs/nfs4_procs.h
@@ -348,6 +348,13 @@ chimera_nfs4_test_stateid(
     struct nfs_resop4                *resop);
 
 void
+chimera_nfs4_free_stateid(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_request               *req,
+    struct nfs_argop4                *argop,
+    struct nfs_resop4                *resop);
+
+void
 chimera_nfs4_secinfo(
     struct chimera_server_nfs_thread *thread,
     struct nfs_request               *req,

--- a/src/server/nfs/nfs_common.h
+++ b/src/server/nfs/nfs_common.h
@@ -60,6 +60,15 @@ struct nfs_request {
     int                               index;
     uint8_t                           minorversion;     /* COMPOUND4args.minorversion */
     bool                              seen_sequence;    /* set once OP_SEQUENCE has run in this compound */
+    /* NFS4.1 "current stateid" (RFC 8881 §16.2.3.1.2): a per-COMPOUND value
+     * set by stateid-returning ops (OPEN/LOCK/...) and substituted into
+     * later ops that present the special current-stateid value. */
+    bool                              current_stateid_valid;
+    struct stateid4                   current_stateid;
+    /* SAVEFH/RESTOREFH save and restore the current stateid alongside the
+     * current filehandle (RFC 8881 §16.2.3.1.2). */
+    bool                              saved_current_stateid_valid;
+    struct stateid4                   saved_current_stateid;
     /* In-flight state ref for ops that acquire from the unified state table.
      * Released by the completion handler.  Phase 2.  Type is one of
      * NFS4_SLOT_TYPE_OPEN / NFS4_SLOT_TYPE_LOCK. */


### PR DESCRIPTION
## Summary

Stacked on #323. `FREE_STATEID` (RFC 8881 §18.38) had no handler — it fell through to the COMPOUND dispatch default and returned `NFS4ERR_NOTSUPP`. This implements it:

- resolve the NFS4.1 current stateid (it's a current-stateid consumer);
- if the stateid still **owns state** — an open, or a lock stateid that still holds byte-range locks — return **`NFS4ERR_LOCKS_HELD`**;
- otherwise free a lock stateid whose locks have all been released (return `NFS4_OK`);
- special (anonymous/read-bypass) stateids → `NFS4ERR_BAD_STATEID`.

It also **enables the `currentstateid` suite** in the pynfs pass-list. Its one remaining test, CSID7 (`testOpenLayoutGet`), needs LAYOUTGET/pNFS, so a small per-suite extra-flag hook runs the suite with pynfs's `nopnfs` exclusion (chimera is not a pNFS server). The hook (`PYNFS_EXTRA_<flag>`) is reusable for any future suite that pulls in unsupported-feature tests.

## Verification

- `st_current_stateid` (memfs, 4.1, `nopnfs`): **9/9**, and `currentstateid_memfs_nfs4.1` now runs and passes as an enabled ctest (`100% tests passed`).
- No regression: posix/cthon NFS4 memfs 83/83.

## Note

Earlier commit here is #323; this PR shows only its own diff once #323 merges and the branch is rebased.