### PR TITLE
smb: grant SMB2 read-caching oplocks, backed by server-side copychunk

### DIFF
--- a/src/server/smb/CMakeLists.txt
+++ b/src/server/smb/CMakeLists.txt
@@ -10,7 +10,7 @@ add_library(chimera_smb SHARED
     smb_proc_query_directory.c smb_proc_ioctl.c smb_proc_flush.c smb_proc_echo.c
     smb_lsarpc.c smb_signing.c smb_proc_set_info_rename.c smb_proc_security.c
     smb_proc_reparse.c smb_proc_change_notify.c smb_proc_cancel.c
-    smb_proc_sparse.c
+    smb_proc_sparse.c smb_proc_copychunk.c
     smb_proc_lock.c smb_proc_oplock_break.c
     smb_notify.c smb_sharemode.c smb_ntlm.c
     smb_wbclient.c smb_auth.c smb_gssapi.c

--- a/src/server/smb/smb2.h
+++ b/src/server/smb/smb2.h
@@ -872,6 +872,9 @@ typedef uint8_t smb2_guid[SMB2_GUID_SIZE];
 #define SMB2_FSCTL_SET_SPARSE                       0x000900C4
 #define SMB2_FSCTL_SET_ZERO_DATA                    0x000980C8
 #define SMB2_FSCTL_QUERY_ALLOCATED_RANGES           0x000940CF
+#define SMB2_FSCTL_SRV_REQUEST_RESUME_KEY           0x00140078
+#define SMB2_FSCTL_SRV_COPYCHUNK                    0x001440F2
+#define SMB2_FSCTL_SRV_COPYCHUNK_WRITE              0x001480F2
 
 #define SMB2_IO_REPARSE_TAG_NFS                     0x80000014
 #define SMB2_IO_REPARSE_TAG_SYMLINK                 0xA000000C

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -427,6 +427,20 @@ struct chimera_smb_request {
                 uint64_t offset;
                 uint64_t length;
             }                               sp_qar_ranges[CHIMERA_SMB_QAR_MAX];
+            /* SRV_REQUEST_RESUME_KEY / SRV_COPYCHUNK fields */
+            struct chimera_smb_open_file   *cc_src_open_file;
+            struct chimera_smb_open_file   *cc_dst_open_file;
+            struct chimera_smb_file_id      cc_src_file_id;
+            uint32_t                        cc_chunk_count;
+            uint32_t                        cc_chunk_idx;
+            uint32_t                        cc_chunks_written;
+            uint64_t                        cc_total_written;
+#define CHIMERA_SMB_COPYCHUNK_MAX 16
+            struct {
+                uint64_t src_offset;
+                uint64_t dst_offset;
+                uint32_t length;
+            }                               cc_chunks[CHIMERA_SMB_COPYCHUNK_MAX];
         } ioctl;
         struct {
             uint8_t                       info_type;

--- a/src/server/smb/smb_proc_copychunk.c
+++ b/src/server/smb/smb_proc_copychunk.c
@@ -1,0 +1,181 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "smb_internal.h"
+#include "smb_procs.h"
+#include "smb2.h"
+#include "smb_session.h"
+#include "vfs/vfs.h"
+#include "vfs/vfs_procs.h"
+
+/*
+ * Server-side copy: FSCTL_SRV_REQUEST_RESUME_KEY + FSCTL_SRV_COPYCHUNK.
+ *
+ * The client opens the source file and asks for a 24-byte "resume key"
+ * identifying that open (MS-SMB2 2.2.32.2/2.2.32.3).  It then opens the
+ * destination and issues COPYCHUNK on the destination handle, passing the
+ * source's resume key plus a list of {source offset, target offset,
+ * length} chunks.  We map the resume key back to the source open and copy
+ * each chunk server-side via chimera_vfs_copy_range, so the data never
+ * round-trips through the client (and never through the client's oplock
+ * cache, which is what makes copy_file_range coherent here).
+ *
+ * The resume key simply encodes the source open's FileId (persistent +
+ * volatile); the client treats it opaquely.  COPYCHUNK on the destination
+ * resolves that FileId within the same session to find the source handle.
+ */
+
+/* MS-SMB2 server-side copy limits (2.2.32.1). */
+#define CHIMERA_SMB_CC_MAX_CHUNKS    16
+#define CHIMERA_SMB_CC_MAX_CHUNK_LEN (1024 * 1024)
+#define CHIMERA_SMB_CC_MAX_TOTAL_LEN (16 * 1024 * 1024)
+
+static void chimera_smb_copychunk_next(
+    struct chimera_smb_request *request);
+
+/* Resolve the source open from the resume key, then start copying. */
+void
+chimera_smb_ioctl_request_resume_key(struct chimera_smb_request *request)
+{
+    struct chimera_smb_open_file *open_file;
+
+    open_file = chimera_smb_open_file_resolve(request, &request->ioctl.file_id);
+
+    if (unlikely(!open_file)) {
+        chimera_smb_complete_request(request, SMB2_STATUS_FILE_CLOSED);
+        return;
+    }
+
+    /* The resume key is built from the open's FileId at reply time; nothing
+     * else to do here. */
+    chimera_smb_open_file_release(request, open_file);
+    chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
+} /* chimera_smb_ioctl_request_resume_key */
+
+static void
+chimera_smb_copychunk_done(
+    struct chimera_smb_request *request,
+    uint32_t                    status)
+{
+    if (request->ioctl.cc_src_open_file) {
+        chimera_smb_open_file_release(request, request->ioctl.cc_src_open_file);
+        request->ioctl.cc_src_open_file = NULL;
+    }
+    if (request->ioctl.cc_dst_open_file) {
+        chimera_smb_open_file_release(request, request->ioctl.cc_dst_open_file);
+        request->ioctl.cc_dst_open_file = NULL;
+    }
+    chimera_smb_complete_request(request, status);
+} /* chimera_smb_copychunk_done */
+
+static void
+chimera_smb_copychunk_cb(
+    enum chimera_vfs_error    error_code,
+    uint64_t                  length,
+    struct chimera_vfs_attrs *pre_attr,
+    struct chimera_vfs_attrs *post_attr,
+    void                     *private_data)
+{
+    struct chimera_smb_request *request = private_data;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        /* A backend without server-side copy support must answer
+         * NOT_SUPPORTED so the client falls back to a normal read/write
+         * copy rather than treating it as a hard error. */
+        uint32_t status = (error_code == CHIMERA_VFS_ENOTSUP)
+                          ? SMB2_STATUS_NOT_SUPPORTED
+                          : SMB2_STATUS_INVALID_PARAMETER;
+
+        chimera_smb_copychunk_done(request, status);
+        return;
+    }
+
+    request->ioctl.cc_total_written += length;
+    request->ioctl.cc_chunks_written++;
+    request->ioctl.cc_chunk_idx++;
+
+    chimera_smb_copychunk_next(request);
+} /* chimera_smb_copychunk_cb */
+
+/* Issue the next pending chunk, or finish if all are done. */
+static void
+chimera_smb_copychunk_next(struct chimera_smb_request *request)
+{
+    struct chimera_vfs_thread *vfs_thread = request->compound->thread->vfs_thread;
+    uint32_t                   i          = request->ioctl.cc_chunk_idx;
+
+    if (i >= request->ioctl.cc_chunk_count) {
+        chimera_smb_copychunk_done(request, SMB2_STATUS_SUCCESS);
+        return;
+    }
+
+    chimera_vfs_copy_range(
+        vfs_thread,
+        &request->session_handle->session->cred,
+        request->ioctl.cc_src_open_file->handle,
+        request->ioctl.cc_chunks[i].src_offset,
+        request->ioctl.cc_dst_open_file->handle,
+        request->ioctl.cc_chunks[i].dst_offset,
+        request->ioctl.cc_chunks[i].length,
+        0,
+        0,
+        chimera_smb_copychunk_cb,
+        request);
+} /* chimera_smb_copychunk_next */
+
+void
+chimera_smb_ioctl_copychunk(struct chimera_smb_request *request)
+{
+    struct chimera_smb_open_file *dst_open_file, *src_open_file;
+    uint64_t                      total = 0;
+    uint32_t                      i;
+
+    request->ioctl.cc_src_open_file  = NULL;
+    request->ioctl.cc_dst_open_file  = NULL;
+    request->ioctl.cc_chunk_idx      = 0;
+    request->ioctl.cc_chunks_written = 0;
+    request->ioctl.cc_total_written  = 0;
+
+    if (request->ioctl.cc_chunk_count == 0 ||
+        request->ioctl.cc_chunk_count > CHIMERA_SMB_CC_MAX_CHUNKS) {
+        chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
+        return;
+    }
+
+    for (i = 0; i < request->ioctl.cc_chunk_count; i++) {
+        if (request->ioctl.cc_chunks[i].length == 0 ||
+            request->ioctl.cc_chunks[i].length > CHIMERA_SMB_CC_MAX_CHUNK_LEN) {
+            chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
+            return;
+        }
+        total += request->ioctl.cc_chunks[i].length;
+    }
+
+    if (total > CHIMERA_SMB_CC_MAX_TOTAL_LEN) {
+        chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
+        return;
+    }
+
+    /* The FSCTL is sent on the destination handle. */
+    dst_open_file = chimera_smb_open_file_resolve(request, &request->ioctl.file_id);
+    if (unlikely(!dst_open_file)) {
+        chimera_smb_complete_request(request, SMB2_STATUS_FILE_CLOSED);
+        return;
+    }
+
+    /* The source is identified by the resume key (its FileId). */
+    src_open_file = chimera_smb_open_file_resolve(request, &request->ioctl.cc_src_file_id);
+    if (unlikely(!src_open_file)) {
+        chimera_smb_open_file_release(request, dst_open_file);
+        /* An unknown/expired resume key -> OBJECT_NAME_NOT_FOUND per
+         * MS-SMB2 3.3.5.15.6. */
+        chimera_smb_complete_request(request, SMB2_STATUS_OBJECT_NAME_NOT_FOUND);
+        return;
+    }
+
+    request->ioctl.cc_dst_open_file = dst_open_file;
+    request->ioctl.cc_src_open_file = src_open_file;
+
+    chimera_smb_copychunk_next(request);
+} /* chimera_smb_ioctl_copychunk */

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -247,15 +247,29 @@ chimera_smb_create_gen_open_file(
         }
 
         /* SMB lease bits use R=0x01, H=0x02, W=0x04 — different layout
-         * from vfs_state's R/W/H mask, so map field-by-field. */
+         * from vfs_state's R/W/H mask, so map field-by-field.  We grant only
+         * the read-caching (R) bit — a LEVEL_II oplock — and deliberately
+         * withhold write caching (W) and handle caching (H):
+         *
+         *   - Handle caching (batch oplock) makes the Linux cifs client keep
+         *     "deferred close" handles cached, which collide with unlink of
+         *     an open file (delete-of-open-file needs delete-pending across
+         *     the cached handle, not yet implemented) — cthon op_unlk failed
+         *     with EBUSY.
+         *   - Write caching lets the client buffer writes it has not flushed
+         *     to the server, which corrupts server-side copy: copy_file_range
+         *     (FSCTL_SRV_COPYCHUNK) reads the source on the server before the
+         *     buffered write lands, copying stale/zero data (fsx READ BAD
+         *     DATA).  Write-through keeps the server authoritative.
+         *
+         * Read caching is the important win and is coherent: a write breaks
+         * other holders' R leases (chimera_vfs_state_break_on_write), and the
+         * VFS attr/data caches keep a single client consistent.  A client that
+         * asked for an exclusive/batch oplock or an RWH lease simply receives
+         * the read-only (LEVEL_II) subset.  Re-enable W/H once write-cache
+         * flush-before-copy and delete-pending semantics are implemented. */
         if (req_smb & SMB2_LEASE_READ_CACHING) {
             req_vfs |= CHIMERA_VFS_LEASE_MODE_R;
-        }
-        if (req_smb & SMB2_LEASE_HANDLE_CACHING) {
-            req_vfs |= CHIMERA_VFS_LEASE_MODE_H;
-        }
-        if (req_smb & SMB2_LEASE_WRITE_CACHING) {
-            req_vfs |= CHIMERA_VFS_LEASE_MODE_W;
         }
 
         /* Oplocks are about data caching: an attribute-only open (no
@@ -271,17 +285,17 @@ chimera_smb_create_gen_open_file(
             request->create.create_disposition == SMB2_FILE_OVERWRITE_IF ||
             request->create.create_disposition == SMB2_FILE_SUPERSEDE;
 
-        /* Oplocks/leases are parsed and the break machinery is in place, but
-         * granting them is not yet advertised: a real cifs.ko client caches
-         * aggressively under an oplock and keeps deferred-close handles, which
-         * makes open-then-unlink fail with EBUSY until delete-of-open-file
-         * (break-before-sharing-violation + delete-pending) semantics land.
-         * Until then, leave caching oplocks ungranted so the server matches
-         * its no-oplock behavior for interop (cthon special / fsx).  Flip this
-         * to true once those semantics are implemented and verified via KVM. */
-        bool advertise_oplocks = false;
+        /* Only advertise a read-caching oplock on backends that can serve a
+         * server-side copy (FSCTL_SRV_COPYCHUNK -> chimera_vfs_copy_range).
+         * Under a read cache the client offloads copy_file_range to the
+         * server; if the backend can't do server-side copy the client falls
+         * back to a cache-mediated copy that reads stale data (fsx READ BAD
+         * DATA on demofs/cairn).  Where copy_range is unavailable we leave the
+         * file uncached (write-through), which is correct. */
+        bool backend_copy_safe =
+            (oh->vfs_module->capabilities & CHIMERA_VFS_CAP_COPY_RANGE) != 0;
 
-        if (req_vfs != 0 && caching_touches_data && advertise_oplocks) {
+        if (req_vfs != 0 && caching_touches_data && backend_copy_safe) {
             file_state = chimera_vfs_state_get(vfs_state,
                                                oh->fh, oh->fh_len,
                                                oh->fh_hash, true);
@@ -376,6 +390,30 @@ chimera_smb_create_gen_open_file(
                     open_file->oplock_level = SMB2_OPLOCK_LEVEL_NONE;
                 }
             }
+        } else if ((request->create.desired_access &
+                    (SMB2_FILE_WRITE_DATA | SMB2_FILE_APPEND_DATA |
+                     SMB2_GENERIC_WRITE | SMB2_GENERIC_ALL |
+                     SMB2_DELETE | SMB2_MAXIMUM_ALLOWED)) ||
+                   (request->create.create_options & SMB2_FILE_DELETE_ON_CLOSE) ||
+                   request->create.create_disposition == SMB2_FILE_OVERWRITE ||
+                   request->create.create_disposition == SMB2_FILE_OVERWRITE_IF ||
+                   request->create.create_disposition == SMB2_FILE_SUPERSEDE) {
+            /* This open does not request a caching lease of its own, but it
+             * modifies or deletes the file, so it must break any caching
+             * oplock/lease another open holds — otherwise that holder keeps a
+             * stale cache.  Concretely, the delete-on-close open that cifs.ko
+             * issues to unlink a file held open under a batch oplock would
+             * otherwise leave the oplock unbroken, and the client fails the
+             * unlink with EBUSY (cthon special op_unlk). */
+            struct chimera_vfs_lease_owner io_owner = {
+                .protocol   = CHIMERA_VFS_LEASE_PROTO_SMB2,
+                .client_key = request->session_handle->session->session_id,
+                .owner_lo   = open_file->file_id.pid,
+                .owner_hi   = open_file->file_id.vid,
+            };
+
+            chimera_vfs_state_break_on_write(vfs_state, oh->fh, oh->fh_len,
+                                             oh->fh_hash, &io_owner);
         }
     }
 

--- a/src/server/smb/smb_proc_ioctl.c
+++ b/src/server/smb/smb_proc_ioctl.c
@@ -154,6 +154,15 @@ chimera_smb_ioctl(struct chimera_smb_request *request)
             chimera_smb_ioctl_query_allocated_ranges(request);
             break;
 
+        case SMB2_FSCTL_SRV_REQUEST_RESUME_KEY:
+            chimera_smb_ioctl_request_resume_key(request);
+            break;
+
+        case SMB2_FSCTL_SRV_COPYCHUNK:
+        case SMB2_FSCTL_SRV_COPYCHUNK_WRITE:
+            chimera_smb_ioctl_copychunk(request);
+            break;
+
         default:
             chimera_smb_complete_request(request, SMB2_STATUS_NOT_IMPLEMENTED);
             break;
@@ -189,6 +198,13 @@ chimera_smb_ioctl_reply(
             break;
         case SMB2_FSCTL_QUERY_ALLOCATED_RANGES:
             output_length = request->ioctl.sp_qar_count * 16;
+            break;
+        case SMB2_FSCTL_SRV_REQUEST_RESUME_KEY:
+            output_length = 32; /* ResumeKey(24) + ContextLength(4) + Context(pad 4) */
+            break;
+        case SMB2_FSCTL_SRV_COPYCHUNK:
+        case SMB2_FSCTL_SRV_COPYCHUNK_WRITE:
+            output_length = 12; /* ChunksWritten + ChunkBytesWritten + TotalBytesWritten */
             break;
     } /* switch */
 
@@ -262,6 +278,21 @@ chimera_smb_ioctl_reply(
                 evpl_iovec_cursor_append_uint64(reply_cursor, request->ioctl.sp_qar_ranges[qi].offset);
                 evpl_iovec_cursor_append_uint64(reply_cursor, request->ioctl.sp_qar_ranges[qi].length);
             }
+            break;
+        case SMB2_FSCTL_SRV_REQUEST_RESUME_KEY:
+            /* ResumeKey (24): encode the source open's FileId; the client
+             * treats it opaquely and echoes it back in COPYCHUNK. */
+            evpl_iovec_cursor_append_uint64(reply_cursor, request->ioctl.file_id.pid);
+            evpl_iovec_cursor_append_uint64(reply_cursor, request->ioctl.file_id.vid);
+            evpl_iovec_cursor_append_uint64(reply_cursor, 0);
+            evpl_iovec_cursor_append_uint32(reply_cursor, 0); /* ContextLength */
+            evpl_iovec_cursor_append_uint32(reply_cursor, 0); /* Context (pad) */
+            break;
+        case SMB2_FSCTL_SRV_COPYCHUNK:
+        case SMB2_FSCTL_SRV_COPYCHUNK_WRITE:
+            evpl_iovec_cursor_append_uint32(reply_cursor, request->ioctl.cc_chunks_written);
+            evpl_iovec_cursor_append_uint32(reply_cursor, 0); /* ChunkBytesWritten */
+            evpl_iovec_cursor_append_uint32(reply_cursor, (uint32_t) request->ioctl.cc_total_written);
             break;
         default:
             break;
@@ -540,6 +571,39 @@ chimera_smb_parse_ioctl(
                 evpl_iovec_cursor_get_uint64(request_cursor, &request->ioctl.sp_qar_offset);
                 evpl_iovec_cursor_get_uint64(request_cursor, &request->ioctl.sp_qar_length);
                 break;
+            case SMB2_FSCTL_SRV_COPYCHUNK:
+            case SMB2_FSCTL_SRV_COPYCHUNK_WRITE: {
+                /* SRV_COPYCHUNK_COPY: SourceKey(24) + ChunkCount(4) +
+                 * Reserved(4) + ChunkCount * SRV_COPYCHUNK{ SourceOffset(8),
+                 * TargetOffset(8), Length(4), Reserved(4) }. */
+                uint32_t reserved, cc, i;
+
+                if (request->ioctl.input_count < 32) {
+                    request->status = SMB2_STATUS_INVALID_PARAMETER;
+                    return -1;
+                }
+                /* The 24-byte SourceKey encodes the source open's FileId. */
+                evpl_iovec_cursor_get_uint64(request_cursor, &request->ioctl.cc_src_file_id.pid);
+                evpl_iovec_cursor_get_uint64(request_cursor, &request->ioctl.cc_src_file_id.vid);
+                evpl_iovec_cursor_skip(request_cursor, 8); /* remainder of resume key */
+                evpl_iovec_cursor_get_uint32(request_cursor, &cc);
+                evpl_iovec_cursor_get_uint32(request_cursor, &reserved);
+
+                if (cc > CHIMERA_SMB_COPYCHUNK_MAX ||
+                    request->ioctl.input_count < 32 + (uint64_t) cc * 24) {
+                    request->status = SMB2_STATUS_INVALID_PARAMETER;
+                    return -1;
+                }
+
+                request->ioctl.cc_chunk_count = cc;
+                for (i = 0; i < cc; i++) {
+                    evpl_iovec_cursor_get_uint64(request_cursor, &request->ioctl.cc_chunks[i].src_offset);
+                    evpl_iovec_cursor_get_uint64(request_cursor, &request->ioctl.cc_chunks[i].dst_offset);
+                    evpl_iovec_cursor_get_uint32(request_cursor, &request->ioctl.cc_chunks[i].length);
+                    evpl_iovec_cursor_get_uint32(request_cursor, &reserved);
+                }
+                break;
+            }
             default:
                 /* Other IOCTLs don't need input parsing yet */
                 chimera_smb_info("Received IOCTL request with unhandled ctl_code 0x%08x, skipping input parsing",

--- a/src/server/smb/smb_procs.h
+++ b/src/server/smb/smb_procs.h
@@ -223,6 +223,12 @@ void chimera_smb_ioctl_set_zero_data(
 void chimera_smb_ioctl_query_allocated_ranges(
     struct chimera_smb_request *request);
 
+void chimera_smb_ioctl_request_resume_key(
+    struct chimera_smb_request *request);
+
+void chimera_smb_ioctl_copychunk(
+    struct chimera_smb_request *request);
+
 int chimera_smb_parse_change_notify(
     struct evpl_iovec_cursor   *request_cursor,
     struct chimera_smb_request *request);


### PR DESCRIPTION
## Summary

Turns on SMB2 oplock granting (the parse + break-delivery machinery landed earlier but was gated off behind `advertise_oplocks`) and makes it coherent against a real Linux **cifs** client. Verified end-to-end under KVM.

## What is granted

- **Read caching only (LEVEL_II).** Write caching (W) and handle caching (H / batch oplock) are deliberately withheld:
  - **Handle caching** makes cifs keep *deferred-close* handles that collide with unlinking an open file — delete-of-open-file needs delete-pending across the cached handle (not yet implemented), so cthon `op_unlk` failed with `EBUSY`.
  - **Write caching** lets the client buffer unflushed writes, which the server-side copy (below) would then read as stale/zero data (`fsx READ BAD DATA`). Write-through keeps the server authoritative.
- **Only on backends that can serve a server-side copy** (`CAP_COPY_RANGE`: memfs/linux/io_uring). Under a read cache the client offloads `copy_file_range` to the server; a backend that can't do that would force a cache-mediated client copy that reads stale data. Backends without it stay write-through (correct).

## Supporting changes

- **Break-on-incompatible-open**: an open that modifies/deletes the file but requests no lease of its own now breaks other holders' oplocks (`chimera_vfs_state_break_on_write`), so the delete-on-close open cifs issues to unlink a file breaks a batch holder instead of leaving it stale.
- **Server-side copy** — implement `FSCTL_SRV_REQUEST_RESUME_KEY` and `FSCTL_SRV_COPYCHUNK[_WRITE]` (new `smb_proc_copychunk.c`). The resume key encodes the source open's FileId; COPYCHUNK resolves it and copies each chunk via `chimera_vfs_copy_range`. Backends without `copy_range` answer `NOT_SUPPORTED` so the client falls back cleanly.

## Testing

KVM (cifs `vers=2.1,cache=loose`): **cthon basic/general/special + xfstests fsx pass across memfs/linux/io_uring/demofs/cairn on both the 6.8 (Ubuntu 24.04) and 5.15 (Ubuntu 22.04) clients — 48/48.**

smbtorture `ioctl`: `req_resume_key`, `req_two_resume_keys`, and `copy_chunk_{simple,multi,tiny,overwrite,append,src_is_dest,sparse_dest,write_access,bad_key,bug15644}` pass. Remaining copychunk conformance edges (the limits response, byte-range-lock/access checks, source-exceeds-EOF) are follow-ups.

## Follow-ups (tracked, not blocking)

- Handle caching (batch oplock) + delete-pending across cached handles, to re-enable the H bit.
- Write-cache (exclusive oplock) with flush-before-copy.
- copychunk conformance edges noted above.
