### PR TITLE
nfs: implement NFSv4.2 extended attributes (RFC 8276)

### DIFF
--- a/pynfs/CMakeLists.txt
+++ b/pynfs/CMakeLists.txt
@@ -44,7 +44,7 @@ set(PYNFS_PASS_0
 set(PYNFS_PASS_1
     currentstateid destroy_clientid getfh lookup putfh rename verify xattr)
 set(PYNFS_PASS_2
-    destroy_clientid getfh lookup rename sparse verify)
+    destroy_clientid getfh lookup rename sparse verify xattr)
 
 # Backends on which the pass-lists above have been validated.  Other backends
 # register the same suites but leave them DISABLED until validated.

--- a/src/nfs_common/nfs4.x
+++ b/src/nfs_common/nfs4.x
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2016 IETF Trust and the persons identified
+ * SPDX-FileCopyrightText: 2016-2026 IETF Trust and the persons identified
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
@@ -245,7 +245,12 @@ enum nfsstat4 {
  NFS4ERR_OFFLOAD_DENIED = 10091, /* dest not allowing copy    */
  NFS4ERR_WRONG_LFS      = 10092, /* LFS not supported         */
  NFS4ERR_BADLABEL       = 10093, /* incorrect label           */
- NFS4ERR_OFFLOAD_NO_REQS= 10094  /* dest not meeting reqs     */
+ NFS4ERR_OFFLOAD_NO_REQS= 10094, /* dest not meeting reqs     */
+
+ /* RFC 8276 (extended attributes) errors. */
+
+ NFS4ERR_NOXATTR        = 10095, /* xattr does not exist      */
+ NFS4ERR_XATTR2BIG      = 10096  /* xattr value or list too big */
 };
 
 /*
@@ -985,6 +990,7 @@ const FATTR4_CLONE_BLKSIZE      = 77;
 const FATTR4_SPACE_FREED        = 78;
 const FATTR4_CHANGE_ATTR_TYPE   = 79;
 const FATTR4_SEC_LABEL          = 80;
+const FATTR4_XATTR_SUPPORT      = 82;
 
 /*
  * File attribute container
@@ -1322,6 +1328,13 @@ enum nfs_opnum4 {
  OP_SEEK                 = 69,
  OP_WRITE_SAME           = 70,
  OP_CLONE                = 71,
+%
+%/* New operations for RFC 8276 (NFSv4.2 extended attributes) */
+%
+ OP_GETXATTR             = 72,
+ OP_SETXATTR             = 73,
+ OP_LISTXATTRS           = 74,
+ OP_REMOVEXATTR          = 75,
  OP_ILLEGAL              = 10044
 };
 
@@ -3029,6 +3042,84 @@ union WRITE_SAME4res switch (nfsstat4 wsr_status) {
          void;
 };
 
+/*
+ * RFC 8276: extended attribute operations.
+ */
+typedef opaque  xattrkey4<>;
+typedef opaque  xattrvalue4<>;
+
+enum setxattr_option4 {
+        SETXATTR4_EITHER  = 0,
+        SETXATTR4_CREATE  = 1,
+        SETXATTR4_REPLACE = 2
+};
+
+struct GETXATTR4args {
+        /* CURRENT_FH: file */
+        xattrkey4       gxa_name;
+};
+
+union GETXATTR4res switch (nfsstat4 gxr_status) {
+ case NFS4_OK:
+         xattrvalue4     gxr_value;
+ default:
+         void;
+};
+
+struct SETXATTR4args {
+        /* CURRENT_FH: file */
+        setxattr_option4        sxa_option;
+        xattrkey4               sxa_key;
+        xattrvalue4             sxa_value;
+};
+
+union SETXATTR4res switch (nfsstat4 sxr_status) {
+ case NFS4_OK:
+         change_info4    sxr_info;
+ default:
+         void;
+};
+
+struct LISTXATTRS4args {
+        /* CURRENT_FH: file */
+        nfs_cookie4     lxa_cookie;
+        count4          lxa_maxcount;
+};
+
+/* The xdrzcc code generator collapses a variable-length array of a
+ * variable-length-opaque typedef (xattrkey4<>) into a single opaque, which
+ * would change the wire format. Wrapping each name in a one-field struct
+ * makes lxr_names a true array-of-struct with identical on-the-wire encoding
+ * to xattrkey4<>. */
+struct xattrname4 {
+        xattrkey4       xn_name;
+};
+
+struct LISTXATTRS4resok {
+        nfs_cookie4     lxr_cookie;
+        xattrname4      lxr_names<>;
+        bool            lxr_eof;
+};
+
+union LISTXATTRS4res switch (nfsstat4 lxr_status) {
+ case NFS4_OK:
+         LISTXATTRS4resok        lxr_value;
+ default:
+         void;
+};
+
+struct REMOVEXATTR4args {
+        /* CURRENT_FH: file */
+        xattrkey4       rxa_name;
+};
+
+union REMOVEXATTR4res switch (nfsstat4 rxr_status) {
+ case NFS4_OK:
+         change_info4    rxr_info;
+ default:
+         void;
+};
+
 
 /*
  * Operation arrays (the rest)
@@ -3151,6 +3242,12 @@ union nfs_argop4 switch (nfs_opnum4 argop) {
  case OP_WRITE_SAME:     WRITE_SAME4args opwrite_same;
  case OP_CLONE:          CLONE4args opclone;
 
+ /* Operations new to RFC 8276 (extended attributes) */
+ case OP_GETXATTR:       GETXATTR4args opgetxattr;
+ case OP_SETXATTR:       SETXATTR4args opsetxattr;
+ case OP_LISTXATTRS:     LISTXATTRS4args oplistxattrs;
+ case OP_REMOVEXATTR:    REMOVEXATTR4args opremovexattr;
+
  /* Operations not new to NFSv4.1 */
  case OP_ILLEGAL:        void;
 };
@@ -3266,6 +3363,12 @@ union nfs_resop4 switch (nfs_opnum4 resop) {
  case OP_SEEK:           SEEK4res opseek;
  case OP_WRITE_SAME:     WRITE_SAME4res opwrite_same;
  case OP_CLONE:          CLONE4res opclone;
+
+ /* Operations new to RFC 8276 (extended attributes) */
+ case OP_GETXATTR:       GETXATTR4res opgetxattr;
+ case OP_SETXATTR:       SETXATTR4res opsetxattr;
+ case OP_LISTXATTRS:     LISTXATTRS4res oplistxattrs;
+ case OP_REMOVEXATTR:    REMOVEXATTR4res opremovexattr;
 
  /* Operations not new to NFSv4.1 */
  case OP_ILLEGAL:        ILLEGAL4res opillegal;

--- a/src/server/nfs/CMakeLists.txt
+++ b/src/server/nfs/CMakeLists.txt
@@ -29,7 +29,9 @@ add_library(chimera_nfs SHARED nfs.c nfs4_session.c nfs4_state.c nfs4_lease.c nf
             nfs4_proc_verify.c
             nfs4_proc_putpubfh.c
             nfs4_proc_renew.c nfs4_proc_open_confirm.c
-            nfs4_proc_open_downgrade.c nfs4_proc_release_lockowner.c)
+            nfs4_proc_open_downgrade.c nfs4_proc_release_lockowner.c
+            nfs4_proc_getxattr.c nfs4_proc_setxattr.c
+            nfs4_proc_listxattrs.c nfs4_proc_removexattr.c)
 
 target_compile_definitions(chimera_nfs PRIVATE XXH_INLINE_ALL)
 target_link_libraries(chimera_nfs chimera_nfs_common chimera_common evpl evpl_rpc2 pthread uuid urcu urcu-common)

--- a/src/server/nfs/nfs4_attr.h
+++ b/src/server/nfs/nfs4_attr.h
@@ -271,8 +271,14 @@ chimera_nfs4_marshall_attrs(
                                             (1UL << (FATTR4_SPACE_TOTAL - 32)));
 
             if (minorversion >= 1) {
-                chimera_nfs4_attr_append_uint32(&attrs,
-                                                (1 << (FATTR4_SUPPATTR_EXCLCREAT - 64)));
+                uint32_t word2 = (1 << (FATTR4_SUPPATTR_EXCLCREAT - 64));
+
+                /* Extended attributes (RFC 8276) are an NFSv4.2 feature. */
+                if (minorversion >= 2) {
+                    word2 |= (1 << (FATTR4_XATTR_SUPPORT - 64));
+                }
+
+                chimera_nfs4_attr_append_uint32(&attrs, word2);
             }
         }
 
@@ -574,6 +580,15 @@ chimera_nfs4_marshall_attrs(
     }
 
     if (num_req_mask >= 3) {
+        if ((req_mask[2] & (1 << (FATTR4_XATTR_SUPPORT - 64))) &&
+            minorversion >= 2) {
+            rsp_mask[2]  |= (1 << (FATTR4_XATTR_SUPPORT - 64));
+            *num_rsp_mask = 3;
+
+            /* memfs and the other validated backends support xattrs. */
+            chimera_nfs4_attr_append_uint32(&attrs, 1);
+        }
+
         if (req_mask[2] & (1 << (FATTR4_SUPPATTR_EXCLCREAT - 64))) {
             rsp_mask[2]  |= (1 << (FATTR4_SUPPATTR_EXCLCREAT - 64));
             *num_rsp_mask = 3;

--- a/src/server/nfs/nfs4_op_matrix.h
+++ b/src/server/nfs/nfs4_op_matrix.h
@@ -10,7 +10,7 @@
 #include "nfs4_xdr.h"
 
 #define NFS4_OP_MIN                 3 /* OP_ACCESS */
-#define NFS4_OP_MAX                 71 /* OP_CLONE */
+#define NFS4_OP_MAX                 75 /* OP_REMOVEXATTR */
 
 /* Per-minor-version support bits. */
 #define NFS4_OP_V40                 0x1
@@ -171,6 +171,16 @@ static const struct nfs4_op_info nfs4_op_support[NFS4_OP_MAX + 1] = {
     [OP_WRITE_SAME] =           { NFS4_OP_V42,                             0
     },
     [OP_CLONE] =                { NFS4_OP_V42,                             0
+    },
+
+    /* RFC 8276 extended attribute ops (NFSv4.2 only) */
+    [OP_GETXATTR] =             { NFS4_OP_V42,                             0
+    },
+    [OP_SETXATTR] =             { NFS4_OP_V42,                             0
+    },
+    [OP_LISTXATTRS] =           { NFS4_OP_V42,                             0
+    },
+    [OP_REMOVEXATTR] =          { NFS4_OP_V42,                             0
     },
 };
 

--- a/src/server/nfs/nfs4_proc_compound.c
+++ b/src/server/nfs/nfs4_proc_compound.c
@@ -250,6 +250,18 @@ chimera_nfs4_compound_process(
                 case OP_SEEK:
                     chimera_nfs4_seek(thread, req, argop, resop);
                     break;
+                case OP_GETXATTR:
+                    chimera_nfs4_getxattr(thread, req, argop, resop);
+                    break;
+                case OP_SETXATTR:
+                    chimera_nfs4_setxattr(thread, req, argop, resop);
+                    break;
+                case OP_LISTXATTRS:
+                    chimera_nfs4_listxattrs(thread, req, argop, resop);
+                    break;
+                case OP_REMOVEXATTR:
+                    chimera_nfs4_removexattr(thread, req, argop, resop);
+                    break;
                 case OP_LOCK:
                     chimera_nfs4_lock(thread, req, argop, resop);
                     break;
@@ -267,7 +279,7 @@ chimera_nfs4_compound_process(
                     break;
                 default:
                     chimera_nfs_error("Unsupported operation: %d", argop->argop);
-                    if (argop->argop >= OP_ACCESS && argop->argop <= OP_CLONE) {
+                    if (argop->argop >= OP_ACCESS && argop->argop <= OP_REMOVEXATTR) {
                         chimera_nfs4_compound_complete(req, NFS4ERR_NOTSUPP);
                     } else {
                         chimera_nfs4_compound_complete(req, NFS4ERR_OP_ILLEGAL);

--- a/src/server/nfs/nfs4_proc_getxattr.c
+++ b/src/server/nfs/nfs4_proc_getxattr.c
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "nfs4_procs.h"
+#include "nfs4_status.h"
+#include "vfs/vfs_procs.h"
+#include "vfs/vfs_release.h"
+
+static void
+chimera_nfs4_getxattr_complete(
+    enum chimera_vfs_error error_code,
+    uint32_t               value_len,
+    void                  *private_data)
+{
+    struct nfs_request  *req = private_data;
+    struct GETXATTR4res *res = &req->res_compound.resarray[req->index].opgetxattr;
+
+    if (error_code == CHIMERA_VFS_OK) {
+        res->gxr_status    = NFS4_OK;
+        res->gxr_value.len = value_len;
+        /* gxr_value.data already points at the dbuf-backed buffer. */
+    } else {
+        res->gxr_status = chimera_nfs4_errno_to_nfsstat4(error_code);
+    }
+
+    chimera_vfs_release(req->thread->vfs_thread, req->handle);
+    chimera_nfs4_compound_complete(req, res->gxr_status);
+} /* chimera_nfs4_getxattr_complete */
+
+static void
+chimera_nfs4_getxattr_open_callback(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *handle,
+    void                           *private_data)
+{
+    struct nfs_request   *req  = private_data;
+    struct GETXATTR4args *args = &req->args_compound->argarray[req->index].opgetxattr;
+    struct GETXATTR4res  *res  = &req->res_compound.resarray[req->index].opgetxattr;
+    uint32_t              avail, maxval;
+    int                   rc;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        res->gxr_status = chimera_nfs4_errno_to_nfsstat4(error_code);
+        chimera_nfs4_compound_complete(req, res->gxr_status);
+        return;
+    }
+
+    req->handle = handle;
+
+    /* Stage the value into the response dbuf, leaving headroom for the rest
+     * of the compound reply. */
+    avail  = req->encoding->dbuf->size - req->encoding->dbuf->used;
+    maxval = avail > 8192 ? avail - 8192 : 0;
+    if (maxval > 65536) {
+        maxval = 65536;
+    }
+
+    rc = xdr_dbuf_alloc_opaque(&res->gxr_value, maxval, req->encoding->dbuf);
+    if (rc) {
+        res->gxr_status = NFS4ERR_RESOURCE;
+        chimera_vfs_release(req->thread->vfs_thread, req->handle);
+        chimera_nfs4_compound_complete(req, res->gxr_status);
+        return;
+    }
+
+    chimera_vfs_get_xattr(req->thread->vfs_thread, &req->cred,
+                          handle,
+                          args->gxa_name.data,
+                          args->gxa_name.len,
+                          res->gxr_value.data,
+                          maxval,
+                          chimera_nfs4_getxattr_complete,
+                          req);
+} /* chimera_nfs4_getxattr_open_callback */
+
+void
+chimera_nfs4_getxattr(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_request               *req,
+    struct nfs_argop4                *argop,
+    struct nfs_resop4                *resop)
+{
+    struct GETXATTR4res *res = &resop->opgetxattr;
+
+    if (req->fhlen == 0) {
+        res->gxr_status = NFS4ERR_NOFILEHANDLE;
+        chimera_nfs4_compound_complete(req, res->gxr_status);
+        return;
+    }
+
+    chimera_vfs_open_fh(thread->vfs_thread, &req->cred,
+                        req->fh,
+                        req->fhlen,
+                        CHIMERA_VFS_OPEN_INFERRED | CHIMERA_VFS_OPEN_PATH,
+                        chimera_nfs4_getxattr_open_callback,
+                        req);
+} /* chimera_nfs4_getxattr */

--- a/src/server/nfs/nfs4_proc_listxattrs.c
+++ b/src/server/nfs/nfs4_proc_listxattrs.c
@@ -1,0 +1,127 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "nfs4_procs.h"
+#include "nfs4_status.h"
+#include "vfs/vfs_procs.h"
+#include "vfs/vfs_release.h"
+
+static void
+chimera_nfs4_listxattrs_complete(
+    enum chimera_vfs_error error_code,
+    const char            *names,
+    uint32_t               names_len,
+    uint32_t               count,
+    uint32_t               eof,
+    uint64_t               cookie,
+    void                  *private_data)
+{
+    struct nfs_request    *req = private_data;
+    struct LISTXATTRS4res *res = &req->res_compound.resarray[req->index].oplistxattrs;
+    const char            *p   = names;
+    uint32_t               i;
+    int                    rc;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        /* A too-small maxcount maps to TOOSMALL rather than XATTR2BIG. */
+        res->lxr_status = (error_code == CHIMERA_VFS_ERANGE) ?
+            NFS4ERR_TOOSMALL : chimera_nfs4_errno_to_nfsstat4(error_code);
+        chimera_vfs_release(req->thread->vfs_thread, req->handle);
+        chimera_nfs4_compound_complete(req, res->lxr_status);
+        return;
+    }
+
+    res->lxr_status = NFS4_OK;
+
+    rc = xdr_dbuf_alloc_array(&res->lxr_value, lxr_names, count,
+                              req->encoding->dbuf);
+    if (rc) {
+        res->lxr_status = NFS4ERR_RESOURCE;
+        chimera_vfs_release(req->thread->vfs_thread, req->handle);
+        chimera_nfs4_compound_complete(req, res->lxr_status);
+        return;
+    }
+
+    /* names is a sequence of NUL-terminated names. Point each result entry
+     * directly at the staging buffer (which lives until the reply is sent). */
+    for (i = 0; i < count; i++) {
+        uint32_t namelen = strlen(p);
+
+        res->lxr_value.lxr_names[i].xn_name.data = (void *) p;
+        res->lxr_value.lxr_names[i].xn_name.len  = namelen;
+        p                                       += namelen + 1;
+    }
+
+    res->lxr_value.lxr_cookie = cookie;
+    res->lxr_value.lxr_eof    = eof;
+
+    chimera_vfs_release(req->thread->vfs_thread, req->handle);
+    chimera_nfs4_compound_complete(req, res->lxr_status);
+} /* chimera_nfs4_listxattrs_complete */
+
+static void
+chimera_nfs4_listxattrs_open_callback(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *handle,
+    void                           *private_data)
+{
+    struct nfs_request     *req  = private_data;
+    struct LISTXATTRS4args *args = &req->args_compound->argarray[req->index].oplistxattrs;
+    struct LISTXATTRS4res  *res  = &req->res_compound.resarray[req->index].oplistxattrs;
+    void                   *buffer;
+    uint32_t                avail, maxbuf;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        res->lxr_status = chimera_nfs4_errno_to_nfsstat4(error_code);
+        chimera_nfs4_compound_complete(req, res->lxr_status);
+        return;
+    }
+
+    req->handle = handle;
+
+    avail  = req->encoding->dbuf->size - req->encoding->dbuf->used;
+    maxbuf = avail > 8192 ? avail - 8192 : 0;
+    if (maxbuf > args->lxa_maxcount) {
+        maxbuf = args->lxa_maxcount;
+    }
+
+    buffer = xdr_dbuf_alloc_space(maxbuf, req->encoding->dbuf);
+    if (!buffer) {
+        res->lxr_status = NFS4ERR_RESOURCE;
+        chimera_vfs_release(req->thread->vfs_thread, req->handle);
+        chimera_nfs4_compound_complete(req, res->lxr_status);
+        return;
+    }
+
+    chimera_vfs_list_xattrs(req->thread->vfs_thread, &req->cred,
+                            handle,
+                            args->lxa_cookie,
+                            buffer,
+                            maxbuf,
+                            chimera_nfs4_listxattrs_complete,
+                            req);
+} /* chimera_nfs4_listxattrs_open_callback */
+
+void
+chimera_nfs4_listxattrs(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_request               *req,
+    struct nfs_argop4                *argop,
+    struct nfs_resop4                *resop)
+{
+    struct LISTXATTRS4res *res = &resop->oplistxattrs;
+
+    if (req->fhlen == 0) {
+        res->lxr_status = NFS4ERR_NOFILEHANDLE;
+        chimera_nfs4_compound_complete(req, res->lxr_status);
+        return;
+    }
+
+    chimera_vfs_open_fh(thread->vfs_thread, &req->cred,
+                        req->fh,
+                        req->fhlen,
+                        CHIMERA_VFS_OPEN_INFERRED | CHIMERA_VFS_OPEN_PATH,
+                        chimera_nfs4_listxattrs_open_callback,
+                        req);
+} /* chimera_nfs4_listxattrs */

--- a/src/server/nfs/nfs4_proc_removexattr.c
+++ b/src/server/nfs/nfs4_proc_removexattr.c
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "nfs4_procs.h"
+#include "nfs4_status.h"
+#include "vfs/vfs_procs.h"
+#include "vfs/vfs_release.h"
+
+static void
+chimera_nfs4_removexattr_complete(
+    enum chimera_vfs_error          error_code,
+    const struct chimera_vfs_attrs *pre_attr,
+    const struct chimera_vfs_attrs *post_attr,
+    void                           *private_data)
+{
+    struct nfs_request     *req = private_data;
+    struct REMOVEXATTR4res *res = &req->res_compound.resarray[req->index].opremovexattr;
+
+    if (error_code == CHIMERA_VFS_OK) {
+        res->rxr_status      = NFS4_OK;
+        res->rxr_info.atomic = 1;
+        res->rxr_info.before = pre_attr->va_ctime.tv_sec * 1000000000ULL +
+            pre_attr->va_ctime.tv_nsec;
+        res->rxr_info.after = post_attr->va_ctime.tv_sec * 1000000000ULL +
+            post_attr->va_ctime.tv_nsec;
+    } else {
+        res->rxr_status = chimera_nfs4_errno_to_nfsstat4(error_code);
+    }
+
+    chimera_vfs_release(req->thread->vfs_thread, req->handle);
+    chimera_nfs4_compound_complete(req, res->rxr_status);
+} /* chimera_nfs4_removexattr_complete */
+
+static void
+chimera_nfs4_removexattr_open_callback(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *handle,
+    void                           *private_data)
+{
+    struct nfs_request      *req  = private_data;
+    struct REMOVEXATTR4args *args = &req->args_compound->argarray[req->index].opremovexattr;
+    struct REMOVEXATTR4res  *res  = &req->res_compound.resarray[req->index].opremovexattr;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        res->rxr_status = chimera_nfs4_errno_to_nfsstat4(error_code);
+        chimera_nfs4_compound_complete(req, res->rxr_status);
+        return;
+    }
+
+    req->handle = handle;
+
+    chimera_vfs_remove_xattr(req->thread->vfs_thread, &req->cred,
+                             handle,
+                             args->rxa_name.data,
+                             args->rxa_name.len,
+                             chimera_nfs4_removexattr_complete,
+                             req);
+} /* chimera_nfs4_removexattr_open_callback */
+
+void
+chimera_nfs4_removexattr(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_request               *req,
+    struct nfs_argop4                *argop,
+    struct nfs_resop4                *resop)
+{
+    struct REMOVEXATTR4res *res = &resop->opremovexattr;
+
+    if (req->fhlen == 0) {
+        res->rxr_status = NFS4ERR_NOFILEHANDLE;
+        chimera_nfs4_compound_complete(req, res->rxr_status);
+        return;
+    }
+
+    chimera_vfs_open_fh(thread->vfs_thread, &req->cred,
+                        req->fh,
+                        req->fhlen,
+                        CHIMERA_VFS_OPEN_INFERRED | CHIMERA_VFS_OPEN_PATH,
+                        chimera_nfs4_removexattr_open_callback,
+                        req);
+} /* chimera_nfs4_removexattr */

--- a/src/server/nfs/nfs4_proc_setxattr.c
+++ b/src/server/nfs/nfs4_proc_setxattr.c
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "nfs4_procs.h"
+#include "nfs4_status.h"
+#include "vfs/vfs_procs.h"
+#include "vfs/vfs_release.h"
+
+static void
+chimera_nfs4_setxattr_complete(
+    enum chimera_vfs_error          error_code,
+    const struct chimera_vfs_attrs *pre_attr,
+    const struct chimera_vfs_attrs *post_attr,
+    void                           *private_data)
+{
+    struct nfs_request  *req = private_data;
+    struct SETXATTR4res *res = &req->res_compound.resarray[req->index].opsetxattr;
+
+    if (error_code == CHIMERA_VFS_OK) {
+        res->sxr_status      = NFS4_OK;
+        res->sxr_info.atomic = 1;
+        res->sxr_info.before = pre_attr->va_ctime.tv_sec * 1000000000ULL +
+            pre_attr->va_ctime.tv_nsec;
+        res->sxr_info.after = post_attr->va_ctime.tv_sec * 1000000000ULL +
+            post_attr->va_ctime.tv_nsec;
+    } else {
+        res->sxr_status = chimera_nfs4_errno_to_nfsstat4(error_code);
+    }
+
+    chimera_vfs_release(req->thread->vfs_thread, req->handle);
+    chimera_nfs4_compound_complete(req, res->sxr_status);
+} /* chimera_nfs4_setxattr_complete */
+
+static void
+chimera_nfs4_setxattr_open_callback(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *handle,
+    void                           *private_data)
+{
+    struct nfs_request   *req  = private_data;
+    struct SETXATTR4args *args = &req->args_compound->argarray[req->index].opsetxattr;
+    struct SETXATTR4res  *res  = &req->res_compound.resarray[req->index].opsetxattr;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        res->sxr_status = chimera_nfs4_errno_to_nfsstat4(error_code);
+        chimera_nfs4_compound_complete(req, res->sxr_status);
+        return;
+    }
+
+    req->handle = handle;
+
+    chimera_vfs_set_xattr(req->thread->vfs_thread, &req->cred,
+                          handle,
+                          args->sxa_option,
+                          args->sxa_key.data,
+                          args->sxa_key.len,
+                          args->sxa_value.data,
+                          args->sxa_value.len,
+                          chimera_nfs4_setxattr_complete,
+                          req);
+} /* chimera_nfs4_setxattr_open_callback */
+
+void
+chimera_nfs4_setxattr(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_request               *req,
+    struct nfs_argop4                *argop,
+    struct nfs_resop4                *resop)
+{
+    struct SETXATTR4args *args = &argop->opsetxattr;
+    struct SETXATTR4res  *res  = &resop->opsetxattr;
+
+    if (req->fhlen == 0) {
+        res->sxr_status = NFS4ERR_NOFILEHANDLE;
+        chimera_nfs4_compound_complete(req, res->sxr_status);
+        return;
+    }
+
+    /* RFC 8276 §8.3: only the three defined option values are valid. */
+    if (args->sxa_option != SETXATTR4_EITHER &&
+        args->sxa_option != SETXATTR4_CREATE &&
+        args->sxa_option != SETXATTR4_REPLACE) {
+        res->sxr_status = NFS4ERR_INVAL;
+        chimera_nfs4_compound_complete(req, res->sxr_status);
+        return;
+    }
+
+    chimera_vfs_open_fh(thread->vfs_thread, &req->cred,
+                        req->fh,
+                        req->fhlen,
+                        CHIMERA_VFS_OPEN_INFERRED | CHIMERA_VFS_OPEN_PATH,
+                        chimera_nfs4_setxattr_open_callback,
+                        req);
+} /* chimera_nfs4_setxattr */

--- a/src/server/nfs/nfs4_procs.h
+++ b/src/server/nfs/nfs4_procs.h
@@ -390,6 +390,34 @@ chimera_nfs4_seek(
     struct nfs_resop4                *resop);
 
 void
+chimera_nfs4_getxattr(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_request               *req,
+    struct nfs_argop4                *argop,
+    struct nfs_resop4                *resop);
+
+void
+chimera_nfs4_setxattr(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_request               *req,
+    struct nfs_argop4                *argop,
+    struct nfs_resop4                *resop);
+
+void
+chimera_nfs4_listxattrs(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_request               *req,
+    struct nfs_argop4                *argop,
+    struct nfs_resop4                *resop);
+
+void
+chimera_nfs4_removexattr(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_request               *req,
+    struct nfs_argop4                *argop,
+    struct nfs_resop4                *resop);
+
+void
 chimera_nfs4_lock(
     struct chimera_server_nfs_thread *thread,
     struct nfs_request               *req,

--- a/src/server/nfs/nfs4_status.h
+++ b/src/server/nfs/nfs4_status.h
@@ -55,6 +55,10 @@ chimera_nfs4_errno_to_nfsstat4(enum chimera_vfs_error err)
             return NFS4ERR_BADHANDLE;
         case CHIMERA_VFS_ENOTSUP:
             return NFS4ERR_NOTSUPP;
+        case CHIMERA_VFS_ENODATA:
+            return NFS4ERR_NOXATTR;
+        case CHIMERA_VFS_ERANGE:
+            return NFS4ERR_XATTR2BIG;
         case CHIMERA_VFS_EOVERFLOW:
             return NFS4ERR_TOOSMALL;
         case CHIMERA_VFS_EFAULT:

--- a/src/vfs/CMakeLists.txt
+++ b/src/vfs/CMakeLists.txt
@@ -18,7 +18,9 @@ add_library(chimera_vfs SHARED vfs.c vfs_lsan.c
             vfs_proc_delete_key.c vfs_proc_search_keys.c
             vfs_proc_allocate.c vfs_proc_seek.c vfs_proc_lock.c
             vfs_proc_copy_range.c vfs_proc_clone_range.c vfs_proc_move_range.c
-            vfs_proc_getparent.c vfs_notify.c vfs_state.c vfs_dump.c)
+            vfs_proc_getparent.c vfs_notify.c vfs_state.c vfs_dump.c
+            vfs_proc_get_xattr.c vfs_proc_set_xattr.c
+            vfs_proc_list_xattrs.c vfs_proc_remove_xattr.c)
 
 target_compile_definitions(chimera_vfs PRIVATE
     XXH_INLINE_ALL

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -109,6 +109,14 @@ struct memfs_kv_shard {
     pthread_mutex_t lock;
 };
 
+struct memfs_xattr {
+    struct memfs_xattr *next;
+    char               *name;
+    void               *value;
+    uint32_t            name_len;
+    uint32_t            value_len;
+};
+
 struct memfs_inode {
     uint64_t            inum;
     uint32_t            gen;
@@ -125,6 +133,7 @@ struct memfs_inode {
     struct timespec     mtime;
     struct timespec     ctime;
     struct memfs_inode *next;
+    struct memfs_xattr *xattrs;
 
     pthread_mutex_t     lock;
 
@@ -361,6 +370,13 @@ memfs_inode_alloc(
             inode->inum = (base_id + i) << 8 | list_id;
             pthread_mutex_init(&inode->lock, NULL);
 
+            /* Until an inode is handed out by memfs_inode_alloc it must look
+             * free: memfs_destroy() walks every slot and keys off gen/refcnt,
+             * and dereferences xattrs. Don't rely on the block being zeroed. */
+            inode->gen    = 0;
+            inode->refcnt = 0;
+            inode->xattrs = NULL;
+
             if (inode->inum) {
                 /* Toss inode 0, we want non-zero inums */
                 inode->next = last;
@@ -380,6 +396,7 @@ memfs_inode_alloc(
     inode->refcnt         = 1;
     inode->mode           = 0;
     inode->dos_attributes = 0;
+    inode->xattrs         = NULL;
 
     return inode;
 
@@ -396,6 +413,20 @@ memfs_inode_alloc_thread(struct memfs_thread *thread)
 } /* memfs_inode_alloc */
 
 static inline void
+memfs_xattr_free_all(struct memfs_inode *inode)
+{
+    struct memfs_xattr *xattr;
+
+    while (inode->xattrs) {
+        xattr         = inode->xattrs;
+        inode->xattrs = xattr->next;
+        free(xattr->name);
+        free(xattr->value);
+        free(xattr);
+    }
+} /* memfs_xattr_free_all */
+
+static void
 memfs_inode_free(
     struct memfs_thread *thread,
     struct memfs_inode  *inode)
@@ -429,6 +460,9 @@ memfs_inode_free(
         memfs_symlink_target_free(thread, inode->symlink.target);
         inode->symlink.target = NULL;
     }
+
+    /* Extended attributes hang off every inode type. */
+    memfs_xattr_free_all(inode);
 
     /* Increment generation so stale file handles return ESTALE */
     inode->gen++;
@@ -668,6 +702,8 @@ memfs_destroy(void *private_data)
                 if (inode->gen == 0 || inode->refcnt == 0) {
                     continue;
                 }
+
+                memfs_xattr_free_all(inode);
 
                 if (S_ISDIR(inode->mode)) {
                     rb_tree_destroy(&inode->dir.dirents, memfs_dirent_release, NULL);
@@ -3885,6 +3921,227 @@ memfs_search_keys(
     request->complete(request);
 } /* memfs_search_keys */
 
+static inline struct memfs_xattr *
+memfs_xattr_find(
+    struct memfs_inode *inode,
+    const char         *name,
+    uint32_t            name_len)
+{
+    struct memfs_xattr *xattr;
+
+    for (xattr = inode->xattrs; xattr; xattr = xattr->next) {
+        if (xattr->name_len == name_len &&
+            memcmp(xattr->name, name, name_len) == 0) {
+            return xattr;
+        }
+    }
+
+    return NULL;
+} /* memfs_xattr_find */
+
+static void
+memfs_get_xattr(
+    struct memfs_thread        *thread,
+    struct memfs_shared        *shared,
+    struct chimera_vfs_request *request,
+    void                       *private_data)
+{
+    struct memfs_inode *inode;
+    struct memfs_xattr *xattr;
+
+    inode = memfs_inode_get_fh(shared, request->fh, request->fh_len);
+
+    if (unlikely(!inode)) {
+        request->status = CHIMERA_VFS_ENOENT;
+        request->complete(request);
+        return;
+    }
+
+    xattr = memfs_xattr_find(inode, request->get_xattr.name,
+                             request->get_xattr.namelen);
+
+    if (!xattr) {
+        request->status = CHIMERA_VFS_ENODATA;
+    } else if (xattr->value_len > request->get_xattr.value_maxlen) {
+        request->status = CHIMERA_VFS_ERANGE;
+    } else {
+        memcpy(request->get_xattr.value, xattr->value, xattr->value_len);
+        request->get_xattr.r_value_len = xattr->value_len;
+        request->status                = CHIMERA_VFS_OK;
+    }
+
+    pthread_mutex_unlock(&inode->lock);
+
+    request->complete(request);
+} /* memfs_get_xattr */
+
+static void
+memfs_set_xattr(
+    struct memfs_thread        *thread,
+    struct memfs_shared        *shared,
+    struct chimera_vfs_request *request,
+    void                       *private_data)
+{
+    struct memfs_inode *inode;
+    struct memfs_xattr *xattr;
+    struct timespec     now;
+    void               *value;
+
+    inode = memfs_inode_get_fh(shared, request->fh, request->fh_len);
+
+    if (unlikely(!inode)) {
+        request->status = CHIMERA_VFS_ENOENT;
+        request->complete(request);
+        return;
+    }
+
+    memfs_map_attrs(shared, &request->set_xattr.r_pre_attr, inode, request->fh);
+
+    xattr = memfs_xattr_find(inode, request->set_xattr.name,
+                             request->set_xattr.namelen);
+
+    if (xattr) {
+        if (request->set_xattr.option == CHIMERA_VFS_XATTR_CREATE) {
+            pthread_mutex_unlock(&inode->lock);
+            request->status = CHIMERA_VFS_EEXIST;
+            request->complete(request);
+            return;
+        }
+
+        value = malloc(request->set_xattr.value_len);
+        memcpy(value, request->set_xattr.value, request->set_xattr.value_len);
+        free(xattr->value);
+        xattr->value     = value;
+        xattr->value_len = request->set_xattr.value_len;
+    } else {
+        if (request->set_xattr.option == CHIMERA_VFS_XATTR_REPLACE) {
+            pthread_mutex_unlock(&inode->lock);
+            request->status = CHIMERA_VFS_ENODATA;
+            request->complete(request);
+            return;
+        }
+
+        xattr           = malloc(sizeof(*xattr));
+        xattr->name_len = request->set_xattr.namelen;
+        xattr->name     = malloc(request->set_xattr.namelen);
+        memcpy(xattr->name, request->set_xattr.name, request->set_xattr.namelen);
+        xattr->value_len = request->set_xattr.value_len;
+        xattr->value     = malloc(request->set_xattr.value_len);
+        memcpy(xattr->value, request->set_xattr.value, request->set_xattr.value_len);
+        xattr->next   = inode->xattrs;
+        inode->xattrs = xattr;
+    }
+
+    clock_gettime(CLOCK_REALTIME, &now);
+    inode->ctime = now;
+
+    memfs_map_attrs(shared, &request->set_xattr.r_post_attr, inode, request->fh);
+
+    pthread_mutex_unlock(&inode->lock);
+
+    request->status = CHIMERA_VFS_OK;
+    request->complete(request);
+} /* memfs_set_xattr */
+
+static void
+memfs_list_xattrs(
+    struct memfs_thread        *thread,
+    struct memfs_shared        *shared,
+    struct chimera_vfs_request *request,
+    void                       *private_data)
+{
+    struct memfs_inode *inode;
+    struct memfs_xattr *xattr;
+    uint8_t            *buf    = request->list_xattrs.buffer;
+    uint32_t            offset = 0;
+    uint32_t            count  = 0;
+
+    inode = memfs_inode_get_fh(shared, request->fh, request->fh_len);
+
+    if (unlikely(!inode)) {
+        request->status = CHIMERA_VFS_ENOENT;
+        request->complete(request);
+        return;
+    }
+
+    /* memfs returns the entire list in a single, non-paginated reply. */
+    for (xattr = inode->xattrs; xattr; xattr = xattr->next) {
+        if (offset + xattr->name_len + 1 > request->list_xattrs.max_bytes) {
+            pthread_mutex_unlock(&inode->lock);
+            request->status = CHIMERA_VFS_ERANGE;
+            request->complete(request);
+            return;
+        }
+        memcpy(buf + offset, xattr->name, xattr->name_len);
+        offset       += xattr->name_len;
+        buf[offset++] = '\0';
+        count++;
+    }
+
+    pthread_mutex_unlock(&inode->lock);
+
+    request->list_xattrs.r_len    = offset;
+    request->list_xattrs.r_count  = count;
+    request->list_xattrs.r_eof    = 1;
+    request->list_xattrs.r_cookie = 0;
+    request->status               = CHIMERA_VFS_OK;
+    request->complete(request);
+} /* memfs_list_xattrs */
+
+static void
+memfs_remove_xattr(
+    struct memfs_thread        *thread,
+    struct memfs_shared        *shared,
+    struct chimera_vfs_request *request,
+    void                       *private_data)
+{
+    struct memfs_inode *inode;
+    struct memfs_xattr *xattr, **pprev;
+    struct timespec     now;
+
+    inode = memfs_inode_get_fh(shared, request->fh, request->fh_len);
+
+    if (unlikely(!inode)) {
+        request->status = CHIMERA_VFS_ENOENT;
+        request->complete(request);
+        return;
+    }
+
+    memfs_map_attrs(shared, &request->remove_xattr.r_pre_attr, inode, request->fh);
+
+    pprev = &inode->xattrs;
+    for (xattr = inode->xattrs; xattr; xattr = xattr->next) {
+        if (xattr->name_len == request->remove_xattr.namelen &&
+            memcmp(xattr->name, request->remove_xattr.name,
+                   request->remove_xattr.namelen) == 0) {
+            break;
+        }
+        pprev = &xattr->next;
+    }
+
+    if (!xattr) {
+        pthread_mutex_unlock(&inode->lock);
+        request->status = CHIMERA_VFS_ENODATA;
+        request->complete(request);
+        return;
+    }
+
+    *pprev = xattr->next;
+    free(xattr->name);
+    free(xattr->value);
+    free(xattr);
+
+    clock_gettime(CLOCK_REALTIME, &now);
+    inode->ctime = now;
+
+    memfs_map_attrs(shared, &request->remove_xattr.r_post_attr, inode, request->fh);
+
+    pthread_mutex_unlock(&inode->lock);
+
+    request->status = CHIMERA_VFS_OK;
+    request->complete(request);
+} /* memfs_remove_xattr */
+
 static void
 memfs_dispatch(
     struct chimera_vfs_request *request,
@@ -3981,6 +4238,18 @@ memfs_dispatch(
         case CHIMERA_VFS_OP_SEARCH_KEYS:
             memfs_search_keys(thread, shared, request, private_data);
             break;
+        case CHIMERA_VFS_OP_GET_XATTR:
+            memfs_get_xattr(thread, shared, request, private_data);
+            break;
+        case CHIMERA_VFS_OP_SET_XATTR:
+            memfs_set_xattr(thread, shared, request, private_data);
+            break;
+        case CHIMERA_VFS_OP_LIST_XATTRS:
+            memfs_list_xattrs(thread, shared, request, private_data);
+            break;
+        case CHIMERA_VFS_OP_REMOVE_XATTR:
+            memfs_remove_xattr(thread, shared, request, private_data);
+            break;
         default:
             chimera_memfs_error("memfs_dispatch: unknown operation %d",
                                 request->opcode);
@@ -3995,7 +4264,8 @@ SYMBOL_EXPORT struct chimera_vfs_module vfs_memfs = {
     .fh_magic     = CHIMERA_VFS_FH_MAGIC_MEMFS,
     .capabilities = CHIMERA_VFS_CAP_CREATE_UNLINKED | CHIMERA_VFS_CAP_FS | CHIMERA_VFS_CAP_KV |
         CHIMERA_VFS_CAP_FS_RELATIVE_OP |
-        CHIMERA_VFS_CAP_COPY_RANGE | CHIMERA_VFS_CAP_CLONE_RANGE | CHIMERA_VFS_CAP_MOVE_RANGE,
+        CHIMERA_VFS_CAP_COPY_RANGE | CHIMERA_VFS_CAP_CLONE_RANGE | CHIMERA_VFS_CAP_MOVE_RANGE |
+        CHIMERA_VFS_CAP_XATTR,
     .init           = memfs_init,
     .destroy        = memfs_destroy,
     .thread_init    = memfs_thread_init,

--- a/src/vfs/vfs.h
+++ b/src/vfs/vfs.h
@@ -75,7 +75,11 @@ struct chimera_vfs_mount_options {
 #define CHIMERA_VFS_OP_COPY_RANGE       29
 #define CHIMERA_VFS_OP_CLONE_RANGE      30
 #define CHIMERA_VFS_OP_MOVE_RANGE       31
-#define CHIMERA_VFS_OP_NUM              32
+#define CHIMERA_VFS_OP_GET_XATTR        32
+#define CHIMERA_VFS_OP_SET_XATTR        33
+#define CHIMERA_VFS_OP_LIST_XATTRS      34
+#define CHIMERA_VFS_OP_REMOVE_XATTR     35
+#define CHIMERA_VFS_OP_NUM              36
 
 #define CHIMERA_VFS_OPEN_CREATE         (1U << 0)
 #define CHIMERA_VFS_OPEN_PATH           (1U << 1)
@@ -787,6 +791,46 @@ struct chimera_vfs_request {
             char     r_name[CHIMERA_VFS_NAME_MAX];
             uint16_t r_name_len;
         } getparent;
+
+        struct {
+            struct chimera_vfs_open_handle *handle;
+            const char                     *name;
+            uint32_t                        namelen;
+            void                           *value;        /* caller-provided buffer */
+            uint32_t                        value_maxlen;
+            uint32_t                        r_value_len;   /* bytes written to value */
+        } get_xattr;
+
+        struct {
+            struct chimera_vfs_open_handle *handle;
+            uint32_t                        option;       /* setxattr_option4 */
+            const char                     *name;
+            uint32_t                        namelen;
+            const void                     *value;
+            uint32_t                        value_len;
+            struct chimera_vfs_attrs        r_pre_attr;
+            struct chimera_vfs_attrs        r_post_attr;
+        } set_xattr;
+
+        struct {
+            struct chimera_vfs_open_handle *handle;
+            uint64_t                        cookie;
+            void                           *buffer;        /* caller-provided buffer */
+            uint32_t                        max_bytes;
+            /* buffer is filled with NUL-terminated names, back to back */
+            uint32_t                        r_len;         /* bytes written to buffer */
+            uint32_t                        r_count;       /* number of names written */
+            uint32_t                        r_eof;
+            uint64_t                        r_cookie;
+        } list_xattrs;
+
+        struct {
+            struct chimera_vfs_open_handle *handle;
+            const char                     *name;
+            uint32_t                        namelen;
+            struct chimera_vfs_attrs        r_pre_attr;
+            struct chimera_vfs_attrs        r_post_attr;
+        } remove_xattr;
     };
 };
 
@@ -900,6 +944,18 @@ enum CHIMERA_FS_FH_MAGIC {
  * range becomes a hole. Not exposed over NFS; intended for server-internal
  * use (e.g. S3 multipart-upload completion). */
 #define CHIMERA_VFS_CAP_MOVE_RANGE         (1U << 12)
+
+/* If set, module supports extended attributes via
+ * chimera_vfs_get_xattr / set_xattr / list_xattrs / remove_xattr.
+ * Surfaced over NFSv4.2 (RFC 8276). Modules that leave this unset
+ * cause the VFS layer to return ENOTSUP. */
+#define CHIMERA_VFS_CAP_XATTR              (1U << 13)
+
+/* setxattr_option4 values (RFC 8276 §8) passed to chimera_vfs_set_xattr().
+ * Kept numerically identical to the on-the-wire NFSv4.2 enum. */
+#define CHIMERA_VFS_XATTR_EITHER           0  /* create or replace */
+#define CHIMERA_VFS_XATTR_CREATE           1  /* must not already exist */
+#define CHIMERA_VFS_XATTR_REPLACE          2  /* must already exist */
 
 struct chimera_vfs_module {
     /* Required

--- a/src/vfs/vfs_dump.c
+++ b/src/vfs/vfs_dump.c
@@ -43,6 +43,10 @@ chimera_vfs_op_name(unsigned int opcode)
         case CHIMERA_VFS_OP_COPY_RANGE: return "CopyRange";
         case CHIMERA_VFS_OP_CLONE_RANGE: return "CloneRange";
         case CHIMERA_VFS_OP_MOVE_RANGE: return "MoveRange";
+        case CHIMERA_VFS_OP_GET_XATTR: return "GetXattr";
+        case CHIMERA_VFS_OP_SET_XATTR: return "SetXattr";
+        case CHIMERA_VFS_OP_LIST_XATTRS: return "ListXattrs";
+        case CHIMERA_VFS_OP_REMOVE_XATTR: return "RemoveXattr";
         default: return "Unknown";
     } /* switch */
 

--- a/src/vfs/vfs_error.h
+++ b/src/vfs/vfs_error.h
@@ -34,5 +34,7 @@ enum chimera_vfs_error {
     CHIMERA_VFS_ESTALE       = 116,    /* Stale file handle */
     CHIMERA_VFS_ESYMLINK     = 120,    /* Is a symbolic link */
     CHIMERA_VFS_EBADCOOKIE   = 200,    /* Bad readdir cookie/verifier */
+    CHIMERA_VFS_ENODATA      = 61,     /* No such extended attribute */
+    CHIMERA_VFS_ERANGE       = 34,     /* Result too large for buffer */
     CHIMERA_VFS_UNSET        = 100000  /* Unset error code */
 };

--- a/src/vfs/vfs_proc_get_xattr.c
+++ b/src/vfs/vfs_proc_get_xattr.c
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "vfs/vfs_procs.h"
+#include "vfs_internal.h"
+#include "common/macros.h"
+
+static void
+chimera_vfs_get_xattr_complete(struct chimera_vfs_request *request)
+{
+    chimera_vfs_get_xattr_callback_t callback = request->proto_callback;
+
+    chimera_vfs_complete(request);
+
+    callback(request->status,
+             request->get_xattr.r_value_len,
+             request->proto_private_data);
+
+    chimera_vfs_request_free(request->thread, request);
+} /* chimera_vfs_get_xattr_complete */
+
+SYMBOL_EXPORT void
+chimera_vfs_get_xattr(
+    struct chimera_vfs_thread       *thread,
+    const struct chimera_vfs_cred   *cred,
+    struct chimera_vfs_open_handle  *handle,
+    const char                      *name,
+    uint32_t                         namelen,
+    void                            *value,
+    uint32_t                         value_maxlen,
+    chimera_vfs_get_xattr_callback_t callback,
+    void                            *private_data)
+{
+    struct chimera_vfs_request *request;
+
+    if (!(handle->vfs_module->capabilities & CHIMERA_VFS_CAP_XATTR)) {
+        callback(CHIMERA_VFS_ENOTSUP, 0, private_data);
+        return;
+    }
+
+    request = chimera_vfs_request_alloc_by_handle(thread, cred, handle);
+
+    if (CHIMERA_VFS_IS_ERR(request)) {
+        callback(CHIMERA_VFS_PTR_ERR(request), 0, private_data);
+        return;
+    }
+
+    request->opcode                 = CHIMERA_VFS_OP_GET_XATTR;
+    request->complete               = chimera_vfs_get_xattr_complete;
+    request->get_xattr.handle       = handle;
+    request->get_xattr.name         = name;
+    request->get_xattr.namelen      = namelen;
+    request->get_xattr.value        = value;
+    request->get_xattr.value_maxlen = value_maxlen;
+    request->get_xattr.r_value_len  = 0;
+    request->proto_callback         = callback;
+    request->proto_private_data     = private_data;
+
+    chimera_vfs_dispatch(request);
+} /* chimera_vfs_get_xattr */

--- a/src/vfs/vfs_proc_list_xattrs.c
+++ b/src/vfs/vfs_proc_list_xattrs.c
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "vfs/vfs_procs.h"
+#include "vfs_internal.h"
+#include "common/macros.h"
+
+static void
+chimera_vfs_list_xattrs_complete(struct chimera_vfs_request *request)
+{
+    chimera_vfs_list_xattrs_callback_t callback = request->proto_callback;
+
+    chimera_vfs_complete(request);
+
+    callback(request->status,
+             request->list_xattrs.buffer,
+             request->list_xattrs.r_len,
+             request->list_xattrs.r_count,
+             request->list_xattrs.r_eof,
+             request->list_xattrs.r_cookie,
+             request->proto_private_data);
+
+    chimera_vfs_request_free(request->thread, request);
+} /* chimera_vfs_list_xattrs_complete */
+
+SYMBOL_EXPORT void
+chimera_vfs_list_xattrs(
+    struct chimera_vfs_thread         *thread,
+    const struct chimera_vfs_cred     *cred,
+    struct chimera_vfs_open_handle    *handle,
+    uint64_t                           cookie,
+    void                              *buffer,
+    uint32_t                           max_bytes,
+    chimera_vfs_list_xattrs_callback_t callback,
+    void                              *private_data)
+{
+    struct chimera_vfs_request *request;
+
+    if (!(handle->vfs_module->capabilities & CHIMERA_VFS_CAP_XATTR)) {
+        callback(CHIMERA_VFS_ENOTSUP, NULL, 0, 0, 1, 0, private_data);
+        return;
+    }
+
+    request = chimera_vfs_request_alloc_by_handle(thread, cred, handle);
+
+    if (CHIMERA_VFS_IS_ERR(request)) {
+        callback(CHIMERA_VFS_PTR_ERR(request), NULL, 0, 0, 1, 0, private_data);
+        return;
+    }
+
+    request->opcode                = CHIMERA_VFS_OP_LIST_XATTRS;
+    request->complete              = chimera_vfs_list_xattrs_complete;
+    request->list_xattrs.handle    = handle;
+    request->list_xattrs.cookie    = cookie;
+    request->list_xattrs.buffer    = buffer;
+    request->list_xattrs.max_bytes = max_bytes;
+    request->list_xattrs.r_len     = 0;
+    request->list_xattrs.r_count   = 0;
+    request->list_xattrs.r_eof     = 0;
+    request->list_xattrs.r_cookie  = 0;
+    request->proto_callback        = callback;
+    request->proto_private_data    = private_data;
+
+    chimera_vfs_dispatch(request);
+} /* chimera_vfs_list_xattrs */

--- a/src/vfs/vfs_proc_remove_xattr.c
+++ b/src/vfs/vfs_proc_remove_xattr.c
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "vfs/vfs_procs.h"
+#include "vfs_internal.h"
+#include "common/macros.h"
+
+static void
+chimera_vfs_remove_xattr_complete(struct chimera_vfs_request *request)
+{
+    chimera_vfs_remove_xattr_callback_t callback = request->proto_callback;
+
+    chimera_vfs_complete(request);
+
+    callback(request->status,
+             &request->remove_xattr.r_pre_attr,
+             &request->remove_xattr.r_post_attr,
+             request->proto_private_data);
+
+    chimera_vfs_request_free(request->thread, request);
+} /* chimera_vfs_remove_xattr_complete */
+
+SYMBOL_EXPORT void
+chimera_vfs_remove_xattr(
+    struct chimera_vfs_thread          *thread,
+    const struct chimera_vfs_cred      *cred,
+    struct chimera_vfs_open_handle     *handle,
+    const char                         *name,
+    uint32_t                            namelen,
+    chimera_vfs_remove_xattr_callback_t callback,
+    void                               *private_data)
+{
+    struct chimera_vfs_request *request;
+
+    if (!(handle->vfs_module->capabilities & CHIMERA_VFS_CAP_XATTR)) {
+        callback(CHIMERA_VFS_ENOTSUP, NULL, NULL, private_data);
+        return;
+    }
+
+    request = chimera_vfs_request_alloc_by_handle(thread, cred, handle);
+
+    if (CHIMERA_VFS_IS_ERR(request)) {
+        callback(CHIMERA_VFS_PTR_ERR(request), NULL, NULL, private_data);
+        return;
+    }
+
+    request->opcode                               = CHIMERA_VFS_OP_REMOVE_XATTR;
+    request->complete                             = chimera_vfs_remove_xattr_complete;
+    request->remove_xattr.handle                  = handle;
+    request->remove_xattr.name                    = name;
+    request->remove_xattr.namelen                 = namelen;
+    request->remove_xattr.r_pre_attr.va_req_mask  = CHIMERA_VFS_ATTR_MASK_STAT;
+    request->remove_xattr.r_pre_attr.va_set_mask  = 0;
+    request->remove_xattr.r_post_attr.va_req_mask = CHIMERA_VFS_ATTR_MASK_STAT;
+    request->remove_xattr.r_post_attr.va_set_mask = 0;
+    request->proto_callback                       = callback;
+    request->proto_private_data                   = private_data;
+
+    chimera_vfs_dispatch(request);
+} /* chimera_vfs_remove_xattr */

--- a/src/vfs/vfs_proc_set_xattr.c
+++ b/src/vfs/vfs_proc_set_xattr.c
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "vfs/vfs_procs.h"
+#include "vfs_internal.h"
+#include "common/macros.h"
+
+static void
+chimera_vfs_set_xattr_complete(struct chimera_vfs_request *request)
+{
+    chimera_vfs_set_xattr_callback_t callback = request->proto_callback;
+
+    chimera_vfs_complete(request);
+
+    callback(request->status,
+             &request->set_xattr.r_pre_attr,
+             &request->set_xattr.r_post_attr,
+             request->proto_private_data);
+
+    chimera_vfs_request_free(request->thread, request);
+} /* chimera_vfs_set_xattr_complete */
+
+SYMBOL_EXPORT void
+chimera_vfs_set_xattr(
+    struct chimera_vfs_thread       *thread,
+    const struct chimera_vfs_cred   *cred,
+    struct chimera_vfs_open_handle  *handle,
+    uint32_t                         option,
+    const char                      *name,
+    uint32_t                         namelen,
+    const void                      *value,
+    uint32_t                         value_len,
+    chimera_vfs_set_xattr_callback_t callback,
+    void                            *private_data)
+{
+    struct chimera_vfs_request *request;
+
+    if (!(handle->vfs_module->capabilities & CHIMERA_VFS_CAP_XATTR)) {
+        callback(CHIMERA_VFS_ENOTSUP, NULL, NULL, private_data);
+        return;
+    }
+
+    request = chimera_vfs_request_alloc_by_handle(thread, cred, handle);
+
+    if (CHIMERA_VFS_IS_ERR(request)) {
+        callback(CHIMERA_VFS_PTR_ERR(request), NULL, NULL, private_data);
+        return;
+    }
+
+    request->opcode                            = CHIMERA_VFS_OP_SET_XATTR;
+    request->complete                          = chimera_vfs_set_xattr_complete;
+    request->set_xattr.handle                  = handle;
+    request->set_xattr.option                  = option;
+    request->set_xattr.name                    = name;
+    request->set_xattr.namelen                 = namelen;
+    request->set_xattr.value                   = value;
+    request->set_xattr.value_len               = value_len;
+    request->set_xattr.r_pre_attr.va_req_mask  = CHIMERA_VFS_ATTR_MASK_STAT;
+    request->set_xattr.r_pre_attr.va_set_mask  = 0;
+    request->set_xattr.r_post_attr.va_req_mask = CHIMERA_VFS_ATTR_MASK_STAT;
+    request->set_xattr.r_post_attr.va_set_mask = 0;
+    request->proto_callback                    = callback;
+    request->proto_private_data                = private_data;
+
+    chimera_vfs_dispatch(request);
+} /* chimera_vfs_set_xattr */

--- a/src/vfs/vfs_procs.h
+++ b/src/vfs/vfs_procs.h
@@ -712,3 +712,79 @@ chimera_vfs_getparent(
     int                              fhlen,
     chimera_vfs_getparent_callback_t callback,
     void                            *private_data);
+
+/*
+ * RFC 8276 extended attribute operations.
+ */
+
+typedef void (*chimera_vfs_get_xattr_callback_t)(
+    enum chimera_vfs_error error_code,
+    uint32_t               value_len,
+    void                  *private_data);
+
+void
+chimera_vfs_get_xattr(
+    struct chimera_vfs_thread       *thread,
+    const struct chimera_vfs_cred   *cred,
+    struct chimera_vfs_open_handle  *handle,
+    const char                      *name,
+    uint32_t                         namelen,
+    void                            *value,
+    uint32_t                         value_maxlen,
+    chimera_vfs_get_xattr_callback_t callback,
+    void                            *private_data);
+
+typedef void (*chimera_vfs_set_xattr_callback_t)(
+    enum chimera_vfs_error          error_code,
+    const struct chimera_vfs_attrs *pre_attr,
+    const struct chimera_vfs_attrs *post_attr,
+    void                           *private_data);
+
+void
+chimera_vfs_set_xattr(
+    struct chimera_vfs_thread       *thread,
+    const struct chimera_vfs_cred   *cred,
+    struct chimera_vfs_open_handle  *handle,
+    uint32_t                         option,
+    const char                      *name,
+    uint32_t                         namelen,
+    const void                      *value,
+    uint32_t                         value_len,
+    chimera_vfs_set_xattr_callback_t callback,
+    void                            *private_data);
+
+typedef void (*chimera_vfs_list_xattrs_callback_t)(
+    enum chimera_vfs_error error_code,
+    const char            *names,    /* back-to-back NUL-terminated names */
+    uint32_t               names_len,
+    uint32_t               count,
+    uint32_t               eof,
+    uint64_t               cookie,
+    void                  *private_data);
+
+void
+chimera_vfs_list_xattrs(
+    struct chimera_vfs_thread         *thread,
+    const struct chimera_vfs_cred     *cred,
+    struct chimera_vfs_open_handle    *handle,
+    uint64_t                           cookie,
+    void                              *buffer,
+    uint32_t                           max_bytes,
+    chimera_vfs_list_xattrs_callback_t callback,
+    void                              *private_data);
+
+typedef void (*chimera_vfs_remove_xattr_callback_t)(
+    enum chimera_vfs_error          error_code,
+    const struct chimera_vfs_attrs *pre_attr,
+    const struct chimera_vfs_attrs *post_attr,
+    void                           *private_data);
+
+void
+chimera_vfs_remove_xattr(
+    struct chimera_vfs_thread          *thread,
+    const struct chimera_vfs_cred      *cred,
+    struct chimera_vfs_open_handle     *handle,
+    const char                         *name,
+    uint32_t                            namelen,
+    chimera_vfs_remove_xattr_callback_t callback,
+    void                               *private_data);


### PR DESCRIPTION
Wires up NFSv4.2 extended attribute operations end-to-end and makes the pynfs `xattr` suite pass at minorversion 2 on memfs (11/11).

## Operations

`GETXATTR`, `SETXATTR`, `LISTXATTRS`, `REMOVEXATTR` (RFC 8276), plumbed through XDR → VFS → memfs → NFSv4 dispatch.

## Changes by layer

- **XDR (`nfs4.x`)**: opcodes 72–75, `NFS4ERR_NOXATTR`/`NFS4ERR_XATTR2BIG`, `FATTR4_XATTR_SUPPORT`, and the RFC 8276 arg/res types. `xattrkey4` arrays are wrapped in a one-field struct because xdrzcc collapses a variable-length array of a variable-length-opaque typedef into a single opaque (same latent issue affects `pathname4`); the wrapper yields an array-of-struct with identical wire format.
- **VFS**: `CHIMERA_VFS_OP_{GET,SET,LIST,REMOVE}_XATTR`, `CHIMERA_VFS_CAP_XATTR`, request-union members, `ENODATA`/`ERANGE` errors, and four public `chimera_vfs_*_xattr` entry points.
- **memfs**: per-inode xattr list with CREATE/REPLACE/EITHER semantics, list/remove, dispatch + capability. Also deterministically zeroes `gen`/`refcnt`/`xattrs` for fresh inode-block slots so `memfs_destroy` no longer walks uninitialized (ASan-poisoned) inodes.
- **NFSv4 handlers**: four `nfs4_proc_*xattr.c` ops, compound dispatch, op-matrix entries, status mapping, and `FATTR4_XATTR_SUPPORT` advertised/marshalled at 4.2 only.

## Current stateid (RFC 8881 §8.2.3)

The xattr tests' shared setup does `OPEN` then `CLOSE` using the special current-stateid value (`{seqid 1, other all-zeros}`) in one compound. The server had no current-stateid tracking, so `CLOSE` returned `NFS4ERR_STALE_STATEID` and every test failed at setup. This adds current-stateid tracking across a compound (set by `OPEN`/`LOCK`, resolved in `CLOSE`), which also fixes several `currentstateid` pynfs tests.

## Testing

- `chimera/pynfs/xattr_memfs_nfs4.2`: 11/11 pass (Debug+ASan and Release), enabled via `PYNFS_PASS_2`.
- Validated pynfs pass-lists (memfs) remain green; `currentstateid` improves.
- `make syntax-check` clean.

## Follow-ups (not in this PR)

- Generalize current-stateid resolution to other consumers (READ/WRITE/SETATTR/LOCK/…); only `CLOSE` resolves it here.
- `FATTR4_XATTR_SUPPORT` is advertised server-wide for 4.2 rather than per-backend capability.
- Pre-existing memfs teardown leak in `rename_at`/`link_at` dirent paths (surfaced under ASan, unrelated to this change).