### PR TITLE
nfs4: tighten OPEN_CONFIRM, RELEASE_LOCKOWNER and SETATTR validation

### DIFF
--- a/src/server/nfs/nfs4_proc_open_confirm.c
+++ b/src/server/nfs/nfs4_proc_open_confirm.c
@@ -84,6 +84,18 @@ chimera_nfs4_open_confirm(
         return;
     }
 
+    /* RFC 7530 §16.18: OPEN_CONFIRM is only valid for an unconfirmed owner.
+     * A (non-replayed) confirm of an already-confirmed owner is a stale use of
+     * the stateid. */
+    if (owner->confirmed) {
+        pthread_mutex_unlock(&owner->lock);
+        nfs_state_table_release(table, open_state, NFS4_SLOT_TYPE_OPEN,
+                                thread->vfs_thread);
+        res->status = NFS4ERR_BAD_STATEID;
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
     /* New op: confirm the owner and advance state.seqid. */
     owner->confirmed   = true;
     owner->seqid       = args->seqid;

--- a/src/server/nfs/nfs4_proc_release_lockowner.c
+++ b/src/server/nfs/nfs4_proc_release_lockowner.c
@@ -3,11 +3,14 @@
 // SPDX-License-Identifier: LGPL-2.1-only
 
 #include "nfs4_procs.h"
+#include "nfs4_session.h"
+#include "nfs4_state.h"
 
-/* RFC 7530 §16.41: RELEASE_LOCKOWNER notifies the server that the client is
- * done with a lock-owner and any associated state may be released. Chimera
- * does not retain per-lock-owner state beyond the lifetime of held locks
- * themselves, so there is nothing to free here. */
+/*
+ * RFC 7530 §16.41: RELEASE_LOCKOWNER notifies the server that the client is
+ * done with a lock-owner.  If the lock-owner still holds byte-range locks the
+ * request must be refused with NFS4ERR_LOCKS_HELD; otherwise it succeeds.
+ */
 void
 chimera_nfs4_release_lockowner(
     struct chimera_server_nfs_thread *thread,
@@ -15,9 +18,38 @@ chimera_nfs4_release_lockowner(
     struct nfs_argop4                *argop,
     struct nfs_resop4                *resop)
 {
-    struct RELEASE_LOCKOWNER4res *res = &resop->oprelease_lockowner;
+    struct RELEASE_LOCKOWNER4args *args   = &argop->oprelease_lockowner;
+    struct RELEASE_LOCKOWNER4res  *res    = &resop->oprelease_lockowner;
+    struct nfs_client             *client =
+        req->session ? req->session->client_unified : NULL;
+    struct nfs_lock_owner         *lo;
+    struct nfs_lock_state         *ls;
+    bool                           held = false;
 
-    res->status = NFS4_OK;
+    if (!client || args->lock_owner.clientid != client->client_id) {
+        res->status = NFS4ERR_STALE_CLIENTID;
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
 
-    chimera_nfs4_compound_complete(req, NFS4_OK);
+    pthread_mutex_lock(&client->lock);
+
+    HASH_FIND(hh, client->lock_owners_by_str,
+              args->lock_owner.owner.data, args->lock_owner.owner.len, lo);
+
+    if (lo) {
+        pthread_mutex_lock(&lo->lock);
+        for (ls = lo->states; ls; ls = ls->next_in_owner) {
+            if (ls->range_leases != NULL) {
+                held = true;
+                break;
+            }
+        }
+        pthread_mutex_unlock(&lo->lock);
+    }
+
+    pthread_mutex_unlock(&client->lock);
+
+    res->status = held ? NFS4ERR_LOCKS_HELD : NFS4_OK;
+    chimera_nfs4_compound_complete(req, res->status);
 } /* chimera_nfs4_release_lockowner */

--- a/src/server/nfs/nfs4_proc_setattr.c
+++ b/src/server/nfs/nfs4_proc_setattr.c
@@ -148,8 +148,20 @@ chimera_nfs4_setattr(
         }
 
         struct nfs_open_state *open_state = state_void;
-        bool                   has_write  = (open_state->share_access &
-                                             OPEN4_SHARE_ACCESS_WRITE) != 0;
+
+        /* RFC 7530 §9.1.4.3: the stateid must name an open of the object that
+         * is the current filehandle, not some other open file. */
+        if (open_state->fh_len != req->fhlen ||
+            memcmp(open_state->fh, req->fh, req->fhlen) != 0) {
+            nfs_state_table_release(table, open_state, NFS4_SLOT_TYPE_OPEN,
+                                    thread->vfs_thread);
+            res->status = NFS4ERR_BAD_STATEID;
+            chimera_nfs4_compound_complete(req, res->status);
+            return;
+        }
+
+        bool has_write = (open_state->share_access &
+                          OPEN4_SHARE_ACCESS_WRITE) != 0;
 
         nfs_state_table_release(table, open_state, NFS4_SLOT_TYPE_OPEN,
                                 thread->vfs_thread);


### PR DESCRIPTION
## Summary

Three RFC 7530 conformance gaps surfaced by pynfs, each a missing error check:

- **OPEN_CONFIRM** on an already-confirmed open-owner returned `NFS4_OK`; it must be **`NFS4ERR_BAD_STATEID`** (the op is only valid for an unconfirmed owner). *(OPCF1)*
- **RELEASE_LOCKOWNER** was a no-op stub that always succeeded; it must return **`NFS4ERR_LOCKS_HELD`** when the named lock-owner still holds byte-range locks. *(RLOWN3)*
- **SETATTR** with `FATTR4_SIZE` accepted any valid open stateid; it must verify the stateid names an open of the **current filehandle** and return **`NFS4ERR_BAD_STATEID`** otherwise. *(SATT3d)*

## Verification

pynfs (memfs): `openconfirm` 7/7, `releaselockowner` 3/3, `setattr` clean. No regression in posix/cthon NFS4 memfs (83/83).