### PR TITLE
nfs4: enforce share-deny conflicts on same-owner OPEN

### DIFF
--- a/src/server/nfs/nfs4_proc_open.c
+++ b/src/server/nfs/nfs4_proc_open.c
@@ -134,6 +134,15 @@ chimera_nfs4_open_install_state(
     existing = nfs_open_owner_find_state(owner, handle->fh, handle->fh_len);
 
     if (existing) {
+        /* RFC 7530 §9.9: a same-owner re-open is still a distinct share
+         * request -- it must not ask for access the existing open denies, nor
+         * deny access the existing open holds.  (Plain deny=NONE upgrades, as
+         * normal clients issue, never trip this.) */
+        if ((existing->share_access & args->share_deny) ||
+            (args->share_access & existing->share_deny)) {
+            chimera_vfs_release(req->thread->vfs_thread, handle);
+            return NFS4ERR_SHARE_DENIED;
+        }
         nfs_open_state_coalesce(existing,
                                 args->share_access, args->share_deny,
                                 &req->thread->shared->nfs4_state_table,


### PR DESCRIPTION
## Summary

A second OPEN of a file by the **same open-owner** coalesced into the existing open without re-checking share reservations. So an OPEN whose requested access conflicts with that owner's *own* existing deny (or whose deny conflicts with the existing access) wrongly succeeded with `NFS4_OK`.

RFC 7530 §9.9 treats each OPEN as a distinct share request. This checks the new `access`/`deny` against the existing open's bits before coalescing and returns `NFS4ERR_SHARE_DENIED` on conflict. Plain `deny=NONE` upgrades — all that normal clients issue — never trip this, so the mount path is unaffected.

## Verification

pynfs (memfs, 4.0 `open`): **OPEN21** (testDenyRead1), **OPEN25** (testDenyWrite1), and **OPEN30** (testReplay) now pass — the suite goes 27→30. No regression in posix/cthon NFS4 memfs (83/83), and the 4.1/4.2 `open` results are unchanged (their remaining failures are delegation tests).