### PR TITLE
smb: enforce DOS-attribute rules and truncate on overwriting creates

### DIFF
--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -747,6 +747,130 @@ chimera_smb_create_open_callback(
 } /* chimera_smb_create_open_at_callback */
 
 
+/* True for the dispositions that replace an existing file's contents
+ * (OVERWRITE / OVERWRITE_IF / SUPERSEDE). */
+static inline bool
+chimera_smb_disposition_overwrites(uint32_t disposition)
+{
+    return disposition == SMB2_FILE_OVERWRITE ||
+           disposition == SMB2_FILE_OVERWRITE_IF ||
+           disposition == SMB2_FILE_SUPERSEDE;
+} /* chimera_smb_disposition_overwrites */
+
+/* Issue the open_at against the (already opened) parent handle in
+ * request->create.parent_handle.  Shared by the plain path and the
+ * post-overwrite-check path. */
+static void
+chimera_smb_create_issue_open(struct chimera_smb_request *request)
+{
+    struct chimera_vfs_thread *vfs_thread = request->compound->thread->vfs_thread;
+    unsigned int               flags      = 0;
+
+    if (request->create.create_options & SMB2_FILE_DIRECTORY_FILE) {
+        flags |= CHIMERA_VFS_OPEN_DIRECTORY;
+    }
+
+    /* Metadata-only open: when the caller doesn't request any data-access
+     * bits, satisfy the open with an O_PATH-style handle. */
+    if (!(request->create.desired_access & SMB2_DATA_ACCESS_MASK) &&
+        request->create.create_disposition == SMB2_FILE_OPEN) {
+        flags |= CHIMERA_VFS_OPEN_PATH;
+    }
+
+    if (!(request->create.desired_access & SMB2_WRITE_MASK)) {
+        flags |= CHIMERA_VFS_OPEN_READ_ONLY;
+    }
+
+    if ((request->create.create_options & SMB2_FILE_OPEN_REPARSE_POINT) &&
+        request->create.create_disposition == SMB2_FILE_OPEN) {
+        flags |= CHIMERA_VFS_OPEN_NOFOLLOW;
+    }
+
+    switch (request->create.create_disposition) {
+        case SMB2_FILE_OPEN:
+        case SMB2_FILE_OVERWRITE:
+            /* Open existing only; never create. */
+            break;
+        case SMB2_FILE_SUPERSEDE:
+        case SMB2_FILE_OPEN_IF:
+        case SMB2_FILE_CREATE:
+        case SMB2_FILE_OVERWRITE_IF:
+            flags |= CHIMERA_VFS_OPEN_CREATE;
+            break;
+    } /* switch */
+
+    /* Replacing a file's contents truncates it and stamps it ARCHIVE
+    * (MS-FSCC).  OPEN_TRUNCATE makes the backend apply both to an existing
+    * file (a fresh create already starts empty with these attrs). */
+    if (chimera_smb_disposition_overwrites(request->create.create_disposition)) {
+        flags                                      |= CHIMERA_VFS_OPEN_TRUNCATE;
+        request->create.set_attr.va_dos_attributes |= SMB2_FILE_ATTRIBUTE_ARCHIVE;
+        request->create.set_attr.va_req_mask       |= CHIMERA_VFS_ATTR_DOS_ATTRIBUTES;
+        request->create.set_attr.va_set_mask       |= CHIMERA_VFS_ATTR_DOS_ATTRIBUTES;
+    }
+
+    chimera_vfs_open_at(
+        vfs_thread,
+        &request->session_handle->session->cred,
+        request->create.parent_handle,
+        request->create.name,
+        request->create.name_len,
+        flags,
+        &request->create.set_attr,
+        CHIMERA_VFS_ATTR_FH | CHIMERA_VFS_ATTR_MASK_STAT | CHIMERA_VFS_ATTR_BTIME,
+        0,
+        0,
+        chimera_smb_create_open_at_callback,
+        request);
+} /* chimera_smb_create_issue_open */
+
+/* MS-FSA create with an overwriting disposition: before replacing an
+ * existing file, reject the request when the target is READONLY, or when
+ * it is HIDDEN/SYSTEM and the request does not also carry that bit (which
+ * would otherwise silently clear it).  Run a getattr first so the check
+ * happens before any attribute change. */
+static void
+chimera_smb_create_overwrite_check_callback(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *attr,
+    struct chimera_vfs_attrs *dir_attr,
+    void                     *private_data)
+{
+    struct chimera_smb_request *request = private_data;
+    uint32_t                    existing, requested;
+
+    if (error_code == CHIMERA_VFS_ENOENT) {
+        /* OVERWRITE requires an existing file; OVERWRITE_IF / SUPERSEDE
+         * create it. */
+        if (request->create.create_disposition == SMB2_FILE_OVERWRITE) {
+            chimera_smb_complete_request(request, SMB2_STATUS_OBJECT_NAME_NOT_FOUND);
+            return;
+        }
+        chimera_smb_create_issue_open(request);
+        return;
+    }
+
+    if (error_code != CHIMERA_VFS_OK) {
+        chimera_smb_complete_request(request, chimera_smb_create_error_status(error_code));
+        return;
+    }
+
+    existing = (attr->va_set_mask & CHIMERA_VFS_ATTR_DOS_ATTRIBUTES)
+                ? attr->va_dos_attributes : 0;
+    requested = request->create.file_attributes;
+
+    if ((existing & SMB2_FILE_ATTRIBUTE_READONLY) ||
+        ((existing & SMB2_FILE_ATTRIBUTE_HIDDEN) &&
+         !(requested & SMB2_FILE_ATTRIBUTE_HIDDEN)) ||
+        ((existing & SMB2_FILE_ATTRIBUTE_SYSTEM) &&
+         !(requested & SMB2_FILE_ATTRIBUTE_SYSTEM))) {
+        chimera_smb_complete_request(request, SMB2_STATUS_ACCESS_DENIED);
+        return;
+    }
+
+    chimera_smb_create_issue_open(request);
+} /* chimera_smb_create_overwrite_check_callback */
+
 static inline void
 chimera_smb_create_open_parent_callback(
     enum chimera_vfs_error          error_code,
@@ -756,7 +880,6 @@ chimera_smb_create_open_parent_callback(
     struct chimera_smb_request       *request    = private_data;
     struct chimera_server_smb_thread *thread     = request->compound->thread;
     struct chimera_vfs_thread        *vfs_thread = thread->vfs_thread;
-    unsigned int                      flags      = 0;
 
     if (error_code != CHIMERA_VFS_OK) {
         chimera_smb_error("Open parent error_code %d", error_code);
@@ -783,67 +906,23 @@ chimera_smb_create_open_parent_callback(
             chimera_smb_create_mkdir_callback,
             request);
 
-    } else {
-        if (request->create.create_options & SMB2_FILE_DIRECTORY_FILE) {
-            flags |= CHIMERA_VFS_OPEN_DIRECTORY;
-        }
-
-        /* Metadata-only open: when the caller doesn't request any
-         * data-access bits, satisfy the open with an O_PATH-style
-         * handle.  This lets tools (e.g. cmd.exe `ren`, Explorer) open
-         * a directory with DELETE | READ_ATTRIBUTES | SYNCHRONIZE plus
-         * FILE_NON_DIRECTORY_FILE — Windows servers honor this opening
-         * pattern for metadata operations like rename and delete-on-
-         * close, and refusing it breaks directory rename over SMB. */
-        if (!(request->create.desired_access & SMB2_DATA_ACCESS_MASK) &&
-            request->create.create_disposition == SMB2_FILE_OPEN) {
-            flags |= CHIMERA_VFS_OPEN_PATH;
-        }
-
-        if (!(request->create.desired_access & SMB2_WRITE_MASK)) {
-            flags |= CHIMERA_VFS_OPEN_READ_ONLY;
-        }
-
-        if ((request->create.create_options & SMB2_FILE_OPEN_REPARSE_POINT) &&
-            request->create.create_disposition == SMB2_FILE_OPEN) {
-            flags |= CHIMERA_VFS_OPEN_NOFOLLOW;
-        }
-
-        switch (request->create.create_disposition) {
-            case SMB2_FILE_SUPERSEDE:
-                break;
-            case SMB2_FILE_OPEN:
-                break;
-            case SMB2_FILE_OPEN_IF:
-                flags |= CHIMERA_VFS_OPEN_CREATE;
-                break;
-            case SMB2_FILE_CREATE:
-                flags |= CHIMERA_VFS_OPEN_CREATE;
-                break;
-            case SMB2_FILE_OVERWRITE:
-                flags |= CHIMERA_VFS_OPEN_CREATE;
-                break;
-            case SMB2_FILE_OVERWRITE_IF:
-                flags |= CHIMERA_VFS_OPEN_CREATE;
-                break;
-        } /* switch */
-
-        chimera_vfs_open_at(
+    } else if (chimera_smb_disposition_overwrites(request->create.create_disposition)) {
+        /* Check the existing file's DOS attributes before overwriting. */
+        chimera_vfs_lookup_at(
             vfs_thread,
             &request->session_handle->session->cred,
             oh,
             request->create.name,
             request->create.name_len,
-            flags,
-            &request->create.set_attr,
-            CHIMERA_VFS_ATTR_FH | CHIMERA_VFS_ATTR_MASK_STAT | CHIMERA_VFS_ATTR_BTIME,
+            CHIMERA_VFS_ATTR_DOS_ATTRIBUTES | CHIMERA_VFS_ATTR_MASK_STAT,
             0,
-            0,
-            chimera_smb_create_open_at_callback,
+            chimera_smb_create_overwrite_check_callback,
             request);
+    } else {
+        chimera_smb_create_issue_open(request);
     }
+} /* chimera_smb_create_open_parent_callback */
 
-} /* chimera_smb_create_open_at_callback */
 
 static inline void
 chimera_smb_create_lookup_parent_callback(

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -427,6 +427,31 @@ memfs_xattr_free_all(struct memfs_inode *inode)
     }
 } /* memfs_xattr_free_all */
 
+/* Free all data blocks of a regular file and reset its block tracking.
+ * Leaves inode->size untouched (callers set it). */
+static void
+memfs_inode_truncate_blocks(
+    struct memfs_thread *thread,
+    struct memfs_inode  *inode)
+{
+    struct memfs_block *block;
+    int                 i;
+
+    if (inode->file.blocks) {
+        for (i = 0; i < inode->file.num_blocks; i++) {
+            block = inode->file.blocks[i];
+            if (block) {
+                memfs_block_free(thread, block);
+                inode->file.blocks[i] = NULL;
+            }
+        }
+        free(inode->file.blocks);
+        inode->file.blocks = NULL;
+    }
+    inode->file.num_blocks = 0;
+    inode->file.max_blocks = 0;
+} /* memfs_inode_truncate_blocks */
+
 static void
 memfs_inode_free(
     struct memfs_thread *thread,
@@ -434,29 +459,13 @@ memfs_inode_free(
 {
     struct memfs_shared     *shared = thread->shared;
     struct memfs_inode_list *inode_list;
-    int                      i;
-    struct memfs_block      *block;
     uint32_t                 list_id = thread->thread_id &
         CHIMERA_MEMFS_INODE_LIST_MASK;
 
     inode_list = &shared->inode_list[list_id];
 
     if (S_ISREG(inode->mode)) {
-        if (inode->file.blocks) {
-            for (i = 0; i < inode->file.num_blocks; i++) {
-                block = inode->file.blocks[i];
-                if (block) {
-                    memfs_block_free(thread, block);
-                    inode->file.blocks[i] = NULL;
-                }
-            }
-            free(inode->file.blocks);
-            inode->file.blocks = NULL;
-        }
-        /* Reset block tracking fields to prevent stale state if inode is
-         * reused or accessed via a stale handle */
-        inode->file.num_blocks = 0;
-        inode->file.max_blocks = 0;
+        memfs_inode_truncate_blocks(thread, inode);
     } else if (S_ISLNK(inode->mode)) {
         memfs_symlink_target_free(thread, inode->symlink.target);
         inode->symlink.target = NULL;
@@ -1961,6 +1970,15 @@ memfs_open_at(
             request->status = CHIMERA_VFS_ENOENT;
             request->complete(request);
             return;
+        }
+
+        /* Overwrite/supersede disposition: replace the existing file's
+         * contents (truncate to zero) and apply the new attributes. */
+        if ((flags & CHIMERA_VFS_OPEN_TRUNCATE) && S_ISREG(inode->mode)) {
+            memfs_inode_truncate_blocks(thread, inode);
+            inode->size       = 0;
+            inode->space_used = 0;
+            memfs_apply_attrs(inode, request->open_at.set_attr);
         }
     }
 

--- a/src/vfs/vfs.h
+++ b/src/vfs/vfs.h
@@ -88,6 +88,10 @@ struct chimera_vfs_mount_options {
 #define CHIMERA_VFS_OPEN_READ_ONLY      (1U << 4)
 #define CHIMERA_VFS_OPEN_EXCLUSIVE      (1U << 5)
 #define CHIMERA_VFS_OPEN_NOFOLLOW       (1U << 6)
+/* Replace an existing file's contents on open: truncate to zero and apply
+ * set_attr (used for the SMB OVERWRITE / OVERWRITE_IF / SUPERSEDE
+ * dispositions).  Backends that do not honor it simply open the file. */
+#define CHIMERA_VFS_OPEN_TRUNCATE       (1U << 7)
 
 /* Allocate flags */
 #define CHIMERA_VFS_ALLOCATE_DEALLOCATE 0x01


### PR DESCRIPTION
## Summary

The SMB CREATE path ignored the existing file's DOS attributes on overwriting dispositions and never actually replaced a file's contents. This implements both, per MS-FSA / MS-FSCC.

### Overwrite attribute rules (OVERWRITE / OVERWRITE_IF / SUPERSEDE)
Before replacing an existing file, getattr it and fail `STATUS_ACCESS_DENIED` when:
- it is **READONLY**, or
- it is **HIDDEN/SYSTEM** and the request omits that bit (which would otherwise silently clear it).

On success the file is stamped **ARCHIVE**. The check runs *before* any change, so a denied create leaves the file untouched.

### Truncate on overwrite
Add `CHIMERA_VFS_OPEN_TRUNCATE`, set by the SMB layer for the overwriting dispositions. memfs honors it by freeing the existing file's blocks, zeroing the size, and applying the new attributes; backends that don't honor it simply open the file (unchanged behavior). The block-free is factored out of `memfs_inode_free` into `memfs_inode_truncate_blocks`.

### SUPERSEDE / OVERWRITE disposition fixes
`SUPERSEDE` previously mapped to neither create-if-absent nor a plain open — it now creates the file when absent (was failing `OBJECT_NAME_NOT_FOUND`). `OVERWRITE` now correctly opens-existing-only (no implicit create).

The open-issuing tail of the create path is factored into a shared `chimera_smb_create_issue_open()` used by both the plain path and the new overwrite pre-check.

## Testing

- `smbtorture smb2.openattr` (memfs) now **passes**; the full memfs suite shows no regression to the other passing suites.
- Verified against a real Linux **cifs** client under KVM: **fsx** (5000 ops — truncate/overwrite/data-integrity stress) reported "All operations completed A-OK!", and cthon basic/general/special pass.

## Not included (separate follow-ups)

- `smb2.dosmode` additionally needs the Samba "hide files" / "hide dot files" share-config feature (auto-hiding files by name pattern).
- `smb2.winattr` additionally needs NORMAL-vs-ARCHIVE attribute reporting (a regular file with no DOS bits should report `FILE_ATTRIBUTE_NORMAL`, not synthesized `ARCHIVE`) — touches the shared marshalling and risks the passing `winattr2`, so kept separate.
