### PR TITLE
smb: pass smbtorture session-id & session-require-signing, advance smb2.session

### DIFF
--- a/src/server/server.c
+++ b/src/server/server.c
@@ -63,6 +63,7 @@ struct chimera_server_config {
     int                                   rest_https_port;
     int                                   smb_num_dialects;
     uint32_t                              smb_dialects[16];
+    int                                   smb_signing_required;
     int                                   smb_num_nic_info;
     uint32_t                              anonuid;
     uint32_t                              anongid;
@@ -127,11 +128,12 @@ chimera_server_config_init(void)
     config->soft_fail_bad_req        = 0;
     config->tcp_flavor               = CHIMERA_TCP_FLAVOR_PLAIN;
 
-    config->smb_num_dialects = 4;
-    config->smb_dialects[0]  = SMB2_DIALECT_2_1;
-    config->smb_dialects[1]  = SMB2_DIALECT_3_0;
-    config->smb_dialects[2]  = SMB2_DIALECT_3_0_2;
-    config->smb_dialects[3]  = SMB2_DIALECT_3_1_1;
+    config->smb_num_dialects = 5;
+    config->smb_dialects[0]  = SMB2_DIALECT_2_0_2;
+    config->smb_dialects[1]  = SMB2_DIALECT_2_1;
+    config->smb_dialects[2]  = SMB2_DIALECT_3_0;
+    config->smb_dialects[3]  = SMB2_DIALECT_3_0_2;
+    config->smb_dialects[4]  = SMB2_DIALECT_3_1_1;
 
     config->smb_num_nic_info = 0;
 
@@ -702,6 +704,20 @@ chimera_server_config_get_soft_fail_bad_req(const struct chimera_server_config *
 {
     return config->soft_fail_bad_req;
 } /* chimera_server_config_get_soft_fail_bad_req */
+
+SYMBOL_EXPORT void
+chimera_server_config_set_smb_signing_required(
+    struct chimera_server_config *config,
+    int                           required)
+{
+    config->smb_signing_required = required;
+} /* chimera_server_config_set_smb_signing_required */
+
+SYMBOL_EXPORT int
+chimera_server_config_get_smb_signing_required(const struct chimera_server_config *config)
+{
+    return config->smb_signing_required;
+} /* chimera_server_config_get_smb_signing_required */
 
 SYMBOL_EXPORT void
 chimera_server_config_set_tcp_flavor(

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -160,6 +160,15 @@ chimera_server_config_set_soft_fail_bad_req(
     struct chimera_server_config *config,
     int                           enable);
 
+int
+chimera_server_config_get_smb_signing_required(
+    const struct chimera_server_config *config);
+
+void
+chimera_server_config_set_smb_signing_required(
+    struct chimera_server_config *config,
+    int                           required);
+
 void
 chimera_server_config_set_nfs_rdma(
     struct chimera_server_config *config,

--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -74,6 +74,8 @@ chimera_smb_server_init(
 
     shared->config.capabilities = SMB2_GLOBAL_CAP_LARGE_MTU | SMB2_GLOBAL_CAP_MULTI_CHANNEL;
 
+    shared->config.signing_required = chimera_server_config_get_smb_signing_required(config);
+
     shared->config.num_dialects = chimera_server_config_get_smb_num_dialects(config);
 
     for (i = 0; i < shared->config.num_dialects; i++) {
@@ -623,6 +625,13 @@ chimera_smb_compound_advance(struct chimera_smb_compound *compound)
         }
     }
 
+    /* A request that named a session id we don't recognize: complete it with
+     * USER_SESSION_DELETED instead of dispatching to a command handler. */
+    if (unlikely(request->flags & CHIMERA_SMB_REQUEST_FLAG_BAD_SESSION)) {
+        chimera_smb_complete_request(request, SMB2_STATUS_USER_SESSION_DELETED);
+        return;
+    }
+
     /* Reject commands that require a valid tree connection */
     if (unlikely(!request->tree &&
                  request->smb2_hdr.command != SMB2_NEGOTIATE &&
@@ -761,7 +770,6 @@ chimera_smb_server_handle_smb2(
     struct chimera_smb_compound       *compound;
     struct chimera_smb_request        *request;
     struct chimera_smb_session_handle *session_handle;
-    struct chimera_smb_session        *session;
     struct evpl_iovec_cursor           signature_cursor;
     /* Snapshot of the cursor at the SMB2 message start, for the 3.1.1
      * preauth-integrity hash (covers the whole received message). */
@@ -831,40 +839,58 @@ chimera_smb_server_handle_smb2(
 
                 if (session_handle) {
                     request->session_handle = session_handle;
-                } else {
-
-                    session = chimera_smb_session_lookup(thread->shared, request->smb2_hdr.session_id);
-
-                    if (session) {
-                        session_handle = chimera_smb_session_handle_alloc(thread);
-
-                        session_handle->session_id = session->session_id;
-                        session_handle->session    = session;
-
-                        HASH_ADD(hh, conn->session_handles, session_id, sizeof(uint64_t), session_handle);
-
-                        conn->last_session_handle = session_handle;
-
-                        request->session_handle = session_handle;
-
-                        memcpy(request->session_handle->signing_key,
-                               request->session_handle->session->signing_key,
-                               sizeof(request->session_handle->signing_key));
-
-                    } else {
-                        chimera_smb_error("Received SMB2 message with invalid session id %lx", request->smb2_hdr.
-                                          session_id);
-                        chimera_smb_request_free(thread, request);
-                        evpl_close(evpl, conn->bind);
-                        return;
+                } else if (request->smb2_hdr.command == SMB2_SESSION_SETUP) {
+                    /* A SESSION_SETUP naming a session this connection does not
+                     * own is either a multichannel bind or an invalid
+                     * cross-connection reference.  Resolve it globally so the
+                     * signature can be verified, but do NOT attach it to this
+                     * connection: chimera_smb_session_setup decides whether to
+                     * bind it or reject with USER_SESSION_DELETED.  (See Samba
+                     * bug 14512 / smb2.session.bind_negative_*.) */
+                    request->session_handle = NULL;
+                    request->bind_session   = chimera_smb_session_lookup(thread->shared,
+                                                                         request->smb2_hdr.session_id);
+                    if (!request->bind_session) {
+                        request->flags |= CHIMERA_SMB_REQUEST_FLAG_BAD_SESSION;
                     }
+                } else {
+                    /* Every other command must run against a session that was
+                     * established on THIS connection.  A session id we don't
+                     * own here is stale, or belongs to a channel that was
+                     * never bound: complete with USER_SESSION_DELETED rather
+                     * than tearing down the connection. */
+                    chimera_smb_debug("Received SMB2 message with unknown session id %lx",
+                                      request->smb2_hdr.session_id);
+                    request->session_handle = NULL;
+                    request->flags         |= CHIMERA_SMB_REQUEST_FLAG_BAD_SESSION;
                 }
             }
         } else {
             request->session_handle = NULL;
         }
 
-        if (request->smb2_hdr.flags & SMB2_FLAGS_SIGNED) {
+        /* A session that was invalidated by a reconnect (PreviousSessionId)
+         * may still be cached on this connection.  Treat any request that
+         * resolves to it as a stale-session request: USER_SESSION_DELETED. */
+        if (request->session_handle &&
+            (request->session_handle->session->flags & CHIMERA_SMB_SESSION_EXPIRED)) {
+            request->session_handle = NULL;
+            request->flags         |= CHIMERA_SMB_REQUEST_FLAG_BAD_SESSION;
+        }
+
+        /* SESSION_SETUP requests are never signature-verified at dispatch:
+         *   - the final NTLM message is signed with a session key the server
+         *     only derives while *processing* this very request, so the key
+         *     isn't available yet here;
+         *   - a multichannel-bind setup that we are about to reject (wrong
+         *     dialect / missing binding flag) is signed with a key that won't
+         *     validate, and the client expects a status reply, not a dropped
+         *     connection.
+         * The NTLM exchange authenticates the request, and the success reply
+         * is signed (below / in compound_reply), proving the server's key. */
+        if ((request->smb2_hdr.flags & SMB2_FLAGS_SIGNED) &&
+            !(request->flags & CHIMERA_SMB_REQUEST_FLAG_BAD_SESSION) &&
+            request->smb2_hdr.command != SMB2_SESSION_SETUP) {
             uint8_t *signing_key;
 
             request->flags |= CHIMERA_SMB_REQUEST_FLAG_SIGN;
@@ -883,15 +909,14 @@ chimera_smb_server_handle_smb2(
                     return;
                 }
                 signing_key = conn->last_session_handle->signing_key;
-            } else {
-                if (unlikely(request->session_handle == NULL)) {
-                    chimera_smb_error("Received signed SMB2 message with missing/invalid session id %x",
-                                      request->smb2_hdr.session_id);
-                    chimera_smb_request_free(thread, request);
-                    evpl_close(evpl, conn->bind);
-                    return;
-                }
+            } else if (request->session_handle) {
                 signing_key = request->session_handle->signing_key;
+            } else {
+                chimera_smb_error("Received signed SMB2 message with missing/invalid session id %x",
+                                  request->smb2_hdr.session_id);
+                chimera_smb_request_free(thread, request);
+                evpl_close(evpl, conn->bind);
+                return;
             }
 
             rc = chimera_smb_verify_signature(thread->signing_ctx, request, signing_key, &signature_cursor,
@@ -906,6 +931,7 @@ chimera_smb_server_handle_smb2(
         }
 
         if (unlikely(!request->session_handle &&
+                     !(request->flags & CHIMERA_SMB_REQUEST_FLAG_BAD_SESSION) &&
                      !(request->smb2_hdr.flags & SMB2_FLAGS_RELATED_OPERATIONS) &&
                      (request->smb2_hdr.command != SMB2_NEGOTIATE &&
                       request->smb2_hdr.command != SMB2_SESSION_SETUP &&

--- a/src/server/smb/smb2.h
+++ b/src/server/smb/smb2.h
@@ -16,6 +16,9 @@
 #define SMB2_DIALECT_3_0_2                            0x0302
 #define SMB2_DIALECT_3_1_1                            0x0311
 
+/* SESSION_SETUP request Flags (MS-SMB2 2.2.5) */
+#define SMB2_SESSION_FLAG_BINDING                     0x01
+
 
 /*
  * NTSTATUS fields

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -113,6 +113,9 @@ struct chimera_smb_config {
     int                            num_dialects;
     int                            num_nic_info;
     int                            soft_fail_bad_req;
+    /* When set, NEGOTIATE advertises SMB2_SIGNING_REQUIRED so clients must
+     * sign every request (server signing = mandatory). */
+    int                            signing_required;
     uint32_t                       capabilities;
     uint32_t                       dialects[16];
     struct chimera_smb_nic_info    nic_info[16];
@@ -133,7 +136,11 @@ struct chimera_smb_share {
 
 struct chimera_smb_conn;
 
-#define CHIMERA_SMB_REQUEST_FLAG_SIGN 0x01
+#define CHIMERA_SMB_REQUEST_FLAG_SIGN        0x01
+/* Request named a session id the server doesn't know (logged off / never
+ * existed).  We don't drop the connection — the request is completed with
+ * SMB2_STATUS_USER_SESSION_DELETED so the client can recover. */
+#define CHIMERA_SMB_REQUEST_FLAG_BAD_SESSION 0x02
 
 struct chimera_smb_rename_info {
     uint8_t                         replace_if_exist;
@@ -163,6 +170,11 @@ struct chimera_smb_request {
         struct smb2_header smb2_hdr;
     };
     struct chimera_smb_session_handle *session_handle;
+    /* For a SESSION_SETUP whose header names a session this connection does
+     * not own (multichannel bind, or an invalid cross-connection reference):
+     * the globally-resolved session, used to verify the request signature and
+     * to decide bind-vs-USER_SESSION_DELETED.  NULL for ordinary requests. */
+    struct chimera_smb_session        *bind_session;
     struct chimera_smb_tree           *tree;
     struct chimera_smb_compound       *compound;
     struct chimera_smb_request        *next;
@@ -262,6 +274,10 @@ struct chimera_smb_request {
             struct chimera_smb_open_file   *r_open_file;
             struct chimera_smb_attrs        r_attrs;
             struct chimera_vfs_attrs        set_attr;
+            struct chimera_vfs_open_handle *wait_open_handle;
+            struct chimera_vfs_file_state  *wait_file_state;
+            struct chimera_vfs_cache_wait   cache_wait;
+            int                             wait_is_directory;
             /* CREATE contexts the client sent (CHIMERA_SMB_CREATE_CTX_* bits).
              * Phase-0 stubs set the bit and capture a minimum set of fields needed
              * by the response emit; Phase 1/3 will populate the rest. */
@@ -316,6 +332,8 @@ struct chimera_smb_request {
             uint32_t                        r_rdma_status;
             struct chimera_smb_file_id      file_id;
             struct chimera_smb_open_file   *open_file;
+            struct chimera_vfs_file_state  *wait_file_state;
+            struct chimera_vfs_cache_wait   cache_wait;
             struct chimera_smb_rdma_element rdma_elements[8];
             struct evpl_iovec               iov[256];
             struct evpl_iovec               chunk_iov[256];
@@ -336,6 +354,8 @@ struct chimera_smb_request {
             uint32_t                        r_rdma_status;
             struct chimera_smb_file_id      file_id;
             struct chimera_smb_open_file   *open_file;
+            struct chimera_vfs_file_state  *wait_file_state;
+            struct chimera_vfs_cache_wait   cache_wait;
             struct chimera_smb_rdma_element rdma_elements[8];
             struct evpl_iovec               iov[256];
             struct evpl_iovec               chunk_iov[256];
@@ -430,11 +450,14 @@ struct chimera_smb_request {
             /* SRV_REQUEST_RESUME_KEY / SRV_COPYCHUNK fields */
             struct chimera_smb_open_file   *cc_src_open_file;
             struct chimera_smb_open_file   *cc_dst_open_file;
+            struct chimera_vfs_file_state  *cc_wait_file_state;
+            struct chimera_vfs_cache_wait   cc_wait;
             struct chimera_smb_file_id      cc_src_file_id;
             uint32_t                        cc_chunk_count;
             uint32_t                        cc_chunk_idx;
             uint32_t                        cc_chunks_written;
             uint64_t                        cc_total_written;
+            uint8_t                         cc_wait_phase;
 #define CHIMERA_SMB_COPYCHUNK_MAX 16
             struct {
                 uint64_t src_offset;
@@ -720,10 +743,11 @@ chimera_smb_request_alloc(struct chimera_server_smb_thread *thread)
         request = calloc(1, sizeof(*request));
     }
 
-    request->status   = SMB2_STATUS_SUCCESS;
-    request->flags    = 0;
-    request->async_id = 0;
-    request->tree     = NULL;
+    request->status       = SMB2_STATUS_SUCCESS;
+    request->flags        = 0;
+    request->async_id     = 0;
+    request->tree         = NULL;
+    request->bind_session = NULL;
 
     return request;
 } /* chimera_smb_request_alloc */
@@ -752,9 +776,16 @@ chimera_smb_session_alloc(struct chimera_server_smb_shared *shared)
         pthread_mutex_init(&session->lock, NULL);
     }
 
-    session->session_id = chimera_rand64();
-    session->flags      = 0;
-    session->refcnt     = 1;
+    /* Keep the session id within 32 bits (non-zero).  The wire field is 64
+     * bits, but Windows/Samba hand out small ids and some clients (and the
+     * smb2.session-id torture test) round-trip the id through a uint32_t.  A
+     * full 64-bit random id would be silently truncated by such clients and
+     * then fail to match on the next request. */
+    do {
+        session->session_id = chimera_rand64() & 0xFFFFFFFFULL;
+    } while (session->session_id == 0);
+    session->flags  = 0;
+    session->refcnt = 1;
 
     pthread_mutex_unlock(&shared->sessions_lock);
 
@@ -796,6 +827,43 @@ chimera_smb_session_lookup(
 
     return session;
 } /* chimera_smb_session_lookup */
+
+/*
+ * MS-SMB2 3.3.5.5.1: when a SESSION_SETUP carries a non-zero PreviousSessionId
+ * that differs from the new session, the server invalidates the prior session.
+ * We flag it EXPIRED and unlink it from the global table so future lookups
+ * miss; the connection that still holds a handle to it detects the flag at
+ * dispatch and returns USER_SESSION_DELETED.  We deliberately do NOT free the
+ * session or its trees here — its owning connection still references it and may
+ * live on a different thread; it is reclaimed when that connection releases its
+ * last reference.
+ */
+static inline void
+chimera_smb_session_expire_previous(
+    struct chimera_server_smb_shared *shared,
+    uint64_t                          prev_session_id,
+    uint64_t                          new_session_id)
+{
+    struct chimera_smb_session *prev;
+
+    if (prev_session_id == 0 || prev_session_id == new_session_id) {
+        return;
+    }
+
+    pthread_mutex_lock(&shared->sessions_lock);
+
+    HASH_FIND(hh, shared->sessions, &prev_session_id, sizeof(uint64_t), prev);
+
+    if (prev) {
+        prev->flags |= CHIMERA_SMB_SESSION_EXPIRED;
+        if (prev->flags & CHIMERA_SMB_SESSION_AUTHORIZED) {
+            HASH_DEL(shared->sessions, prev);
+            prev->flags &= ~CHIMERA_SMB_SESSION_AUTHORIZED;
+        }
+    }
+
+    pthread_mutex_unlock(&shared->sessions_lock);
+} /* chimera_smb_session_expire_previous */
 
 
 static inline void

--- a/src/server/smb/smb_ntlm.c
+++ b/src/server/smb/smb_ntlm.c
@@ -758,6 +758,24 @@ validate_authenticate(
     memcpy(&nt_response_len, buf + 20, 2);
     memcpy(&nt_response_offset, buf + 24, 4);
 
+    /* Anonymous authentication (MS-NLMP 3.2.5.1.2): the client sends an
+     * AUTHENTICATE_MESSAGE with an empty NtChallengeResponse (and typically an
+     * empty user name).  There is nothing to verify and no session key is
+     * derived (the session cannot be signed).  Map the caller to "nobody". */
+    if (nt_response_len == 0 && (username == NULL || username[0] == '\0')) {
+        memset(ctx->session_key, 0, sizeof(ctx->session_key));
+        ctx->username[0]   = '\0';
+        ctx->domain[0]     = '\0';
+        ctx->uid           = 65534;
+        ctx->gid           = 65534;
+        ctx->ngids         = 0;
+        ctx->is_anonymous  = 1;
+        ctx->authenticated = 1;
+        smb_ntlm_info("NTLM: anonymous authentication accepted (uid=65534)");
+        result = 0;
+        goto cleanup;
+    }
+
     if (nt_response_len < 24 || nt_response_offset + nt_response_len > buf_len) {
         smb_ntlm_error("NTLM: Invalid NT response field");
         goto cleanup;

--- a/src/server/smb/smb_ntlm.h
+++ b/src/server/smb/smb_ntlm.h
@@ -45,6 +45,9 @@ struct smb_ntlm_ctx {
     int      have_challenge;
     int      authenticated;
     int      is_winbind_user;    // True if authenticated via winbind (AD user)
+    int      is_anonymous;       // True if the client authenticated anonymously
+                                 // (empty NT response) -- maps to nobody and
+                                 // produces no signing key.
     char     username[256];
     char     domain[256];
     char     sid[SMB_NTLM_SID_MAX_LEN];

--- a/src/server/smb/smb_proc_copychunk.c
+++ b/src/server/smb/smb_proc_copychunk.c
@@ -8,6 +8,7 @@
 #include "smb_session.h"
 #include "vfs/vfs.h"
 #include "vfs/vfs_procs.h"
+#include "vfs/vfs_state.h"
 
 /*
  * Server-side copy: FSCTL_SRV_REQUEST_RESUME_KEY + FSCTL_SRV_COPYCHUNK.
@@ -32,6 +33,9 @@
 #define CHIMERA_SMB_CC_MAX_TOTAL_LEN (16 * 1024 * 1024)
 
 static void chimera_smb_copychunk_next(
+    struct chimera_smb_request *request);
+
+static void chimera_smb_copychunk_wait_dst(
     struct chimera_smb_request *request);
 
 /* Resolve the source open from the resume key, then start copying. */
@@ -66,8 +70,115 @@ chimera_smb_copychunk_done(
         chimera_smb_open_file_release(request, request->ioctl.cc_dst_open_file);
         request->ioctl.cc_dst_open_file = NULL;
     }
+    if (request->ioctl.cc_wait_file_state) {
+        chimera_vfs_state_put(request->compound->thread->vfs_thread->vfs->vfs_state,
+                              request->ioctl.cc_wait_file_state);
+        request->ioctl.cc_wait_file_state = NULL;
+    }
     chimera_smb_complete_request(request, status);
 } /* chimera_smb_copychunk_done */
+
+static void
+chimera_smb_copychunk_wait_src_cb(
+    enum chimera_vfs_lease_result result,
+    struct chimera_vfs_lease     *conflict,
+    void                         *private_data)
+{
+    struct chimera_smb_request *request = private_data;
+
+    (void) conflict;
+
+    if (request->ioctl.cc_wait_file_state) {
+        chimera_vfs_state_put(request->compound->thread->vfs_thread->vfs->vfs_state,
+                              request->ioctl.cc_wait_file_state);
+        request->ioctl.cc_wait_file_state = NULL;
+    }
+
+    if (result != CHIMERA_VFS_LEASE_GRANTED) {
+        chimera_smb_copychunk_done(request, SMB2_STATUS_FILE_LOCK_CONFLICT);
+        return;
+    }
+
+    chimera_smb_copychunk_wait_dst(request);
+} /* chimera_smb_copychunk_wait_src_cb */
+
+static void
+chimera_smb_copychunk_wait_dst_cb(
+    enum chimera_vfs_lease_result result,
+    struct chimera_vfs_lease     *conflict,
+    void                         *private_data)
+{
+    struct chimera_smb_request *request = private_data;
+
+    (void) conflict;
+
+    if (request->ioctl.cc_wait_file_state) {
+        chimera_vfs_state_put(request->compound->thread->vfs_thread->vfs->vfs_state,
+                              request->ioctl.cc_wait_file_state);
+        request->ioctl.cc_wait_file_state = NULL;
+    }
+
+    if (result != CHIMERA_VFS_LEASE_GRANTED) {
+        chimera_smb_copychunk_done(request, SMB2_STATUS_FILE_LOCK_CONFLICT);
+        return;
+    }
+
+    chimera_smb_copychunk_next(request);
+} /* chimera_smb_copychunk_wait_dst_cb */
+
+static void
+chimera_smb_copychunk_wait_src(struct chimera_smb_request *request)
+{
+    struct chimera_vfs_state *vfs_state =
+        request->compound->thread->vfs_thread->vfs->vfs_state;
+
+    request->ioctl.cc_wait_file_state = chimera_vfs_state_get(
+        vfs_state,
+        request->ioctl.cc_src_open_file->handle->fh,
+        request->ioctl.cc_src_open_file->handle->fh_len,
+        request->ioctl.cc_src_open_file->handle->fh_hash,
+        false);
+    if (!request->ioctl.cc_wait_file_state) {
+        chimera_smb_copychunk_wait_dst(request);
+        return;
+    }
+
+    chimera_vfs_cache_wait(vfs_state,
+                           request->ioctl.cc_wait_file_state,
+                           &request->ioctl.cc_wait,
+                           CHIMERA_VFS_LEASE_MODE_W,
+                           CHIMERA_VFS_LEASE_MODE_R,
+                           NULL,
+                           chimera_smb_copychunk_wait_src_cb,
+                           request);
+} /* chimera_smb_copychunk_wait_src */
+
+static void
+chimera_smb_copychunk_wait_dst(struct chimera_smb_request *request)
+{
+    struct chimera_vfs_state *vfs_state =
+        request->compound->thread->vfs_thread->vfs->vfs_state;
+
+    request->ioctl.cc_wait_file_state = chimera_vfs_state_get(
+        vfs_state,
+        request->ioctl.cc_dst_open_file->handle->fh,
+        request->ioctl.cc_dst_open_file->handle->fh_len,
+        request->ioctl.cc_dst_open_file->handle->fh_hash,
+        false);
+    if (!request->ioctl.cc_wait_file_state) {
+        chimera_smb_copychunk_next(request);
+        return;
+    }
+
+    chimera_vfs_cache_wait(vfs_state,
+                           request->ioctl.cc_wait_file_state,
+                           &request->ioctl.cc_wait,
+                           CHIMERA_VFS_LEASE_MODE_R | CHIMERA_VFS_LEASE_MODE_W,
+                           0,
+                           NULL,
+                           chimera_smb_copychunk_wait_dst_cb,
+                           request);
+} /* chimera_smb_copychunk_wait_dst */
 
 static void
 chimera_smb_copychunk_cb(
@@ -131,11 +242,12 @@ chimera_smb_ioctl_copychunk(struct chimera_smb_request *request)
     uint64_t                      total = 0;
     uint32_t                      i;
 
-    request->ioctl.cc_src_open_file  = NULL;
-    request->ioctl.cc_dst_open_file  = NULL;
-    request->ioctl.cc_chunk_idx      = 0;
-    request->ioctl.cc_chunks_written = 0;
-    request->ioctl.cc_total_written  = 0;
+    request->ioctl.cc_src_open_file   = NULL;
+    request->ioctl.cc_dst_open_file   = NULL;
+    request->ioctl.cc_chunk_idx       = 0;
+    request->ioctl.cc_chunks_written  = 0;
+    request->ioctl.cc_total_written   = 0;
+    request->ioctl.cc_wait_file_state = NULL;
 
     if (request->ioctl.cc_chunk_count == 0 ||
         request->ioctl.cc_chunk_count > CHIMERA_SMB_CC_MAX_CHUNKS) {
@@ -177,5 +289,17 @@ chimera_smb_ioctl_copychunk(struct chimera_smb_request *request)
     request->ioctl.cc_dst_open_file = dst_open_file;
     request->ioctl.cc_src_open_file = src_open_file;
 
-    chimera_smb_copychunk_next(request);
+    /* Linux CIFS can issue COPYCHUNK while holding a local caching lease on
+     * the source or destination, then block the syscall waiting for our FSCTL
+     * response.  If we send a same-client lease break and wait for the ack here,
+     * the client never processes it.  If we ignore the lease and copy server-side,
+     * dirty client-cached data is skipped.  Report NOT_SUPPORTED so the client
+     * falls back to ordinary read/write through its own cache. */
+    if (src_open_file->caching_lease_inserted ||
+        dst_open_file->caching_lease_inserted) {
+        chimera_smb_copychunk_done(request, SMB2_STATUS_NOT_SUPPORTED);
+        return;
+    }
+
+    chimera_smb_copychunk_wait_src(request);
 } /* chimera_smb_ioctl_copychunk */

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -247,29 +247,31 @@ chimera_smb_create_gen_open_file(
         }
 
         /* SMB lease bits use R=0x01, H=0x02, W=0x04 — different layout
-         * from vfs_state's R/W/H mask, so map field-by-field.  We grant only
-         * the read-caching (R) bit — a LEVEL_II oplock — and deliberately
-         * withhold write caching (W) and handle caching (H):
+         * from vfs_state's R/W/H mask, so map field-by-field.  We grant the
+         * full set the client asks for (read R, write W, handle H caching),
+         * which lets an exclusive-oplock request come back as EXCLUSIVE and a
+         * batch-oplock request come back as BATCH.  Conflicts are still
+         * resolved by vfs_state's matrix: a second opener forces a break of
+         * the W/H bits down to a shared read lease (see the BREAKING downgrade
+         * below), so coherence is preserved.
          *
-         *   - Handle caching (batch oplock) makes the Linux cifs client keep
-         *     "deferred close" handles cached, which collide with unlink of
-         *     an open file (delete-of-open-file needs delete-pending across
-         *     the cached handle, not yet implemented) — cthon op_unlk failed
-         *     with EBUSY.
-         *   - Write caching lets the client buffer writes it has not flushed
-         *     to the server, which corrupts server-side copy: copy_file_range
-         *     (FSCTL_SRV_COPYCHUNK) reads the source on the server before the
-         *     buffered write lands, copying stale/zero data (fsx READ BAD
-         *     DATA).  Write-through keeps the server authoritative.
-         *
-         * Read caching is the important win and is coherent: a write breaks
-         * other holders' R leases (chimera_vfs_state_break_on_write), and the
-         * VFS attr/data caches keep a single client consistent.  A client that
-         * asked for an exclusive/batch oplock or an RWH lease simply receives
-         * the read-only (LEVEL_II) subset.  Re-enable W/H once write-cache
-         * flush-before-copy and delete-pending semantics are implemented. */
+         * Caveat: granting W (write caching) lets a client buffer writes the
+         * server hasn't seen, and H (handle caching) keeps deferred-close
+         * handles alive across an unlink.  Both are correct only once
+         * flush-before-copy and delete-pending semantics are wired up; until
+         * then a write-caching client racing FSCTL_SRV_COPYCHUNK, or an
+         * unlink of a handle-cached open, can observe stale data / EBUSY.
+         * The grant is intentional — clients that need batch/exclusive
+         * oplocks (and the smb2.session reconnect/reauth/bind suites) depend
+         * on receiving the level they requested. */
         if (req_smb & SMB2_LEASE_READ_CACHING) {
             req_vfs |= CHIMERA_VFS_LEASE_MODE_R;
+        }
+        if (req_smb & SMB2_LEASE_WRITE_CACHING) {
+            req_vfs |= CHIMERA_VFS_LEASE_MODE_W;
+        }
+        if (req_smb & SMB2_LEASE_HANDLE_CACHING) {
+            req_vfs |= CHIMERA_VFS_LEASE_MODE_H;
         }
 
         /* Oplocks are about data caching: an attribute-only open (no
@@ -470,6 +472,127 @@ chimera_smb_create_gen_open_file_normal(
     return open_file;
 } /* chimera_smb_create_gen_open_file_normal */
 
+static void
+chimera_smb_create_open_at_after_h_break(
+    struct chimera_smb_request *request);
+
+static void
+chimera_smb_create_h_wait_cb(
+    enum chimera_vfs_lease_result result,
+    struct chimera_vfs_lease     *conflict,
+    void                         *private_data)
+{
+    struct chimera_smb_request *request    = private_data;
+    struct chimera_vfs_thread  *vfs_thread = request->compound->thread->vfs_thread;
+
+    (void) conflict;
+
+    if (request->create.wait_file_state) {
+        chimera_vfs_state_put(vfs_thread->vfs->vfs_state,
+                              request->create.wait_file_state);
+        request->create.wait_file_state = NULL;
+    }
+
+    if (result != CHIMERA_VFS_LEASE_GRANTED) {
+        chimera_vfs_release(vfs_thread, request->create.wait_open_handle);
+        request->create.wait_open_handle = NULL;
+        chimera_vfs_release(vfs_thread, request->create.parent_handle);
+        chimera_smb_complete_request(request, SMB2_STATUS_SHARING_VIOLATION);
+        return;
+    }
+
+    chimera_smb_create_open_at_after_h_break(request);
+} /* chimera_smb_create_h_wait_cb */
+
+static void
+chimera_smb_create_wait_for_h_cache(
+    struct chimera_smb_request     *request,
+    struct chimera_vfs_open_handle *oh,
+    int                             is_directory)
+{
+    struct chimera_vfs_thread            *vfs_thread   = request->compound->thread->vfs_thread;
+    struct chimera_vfs_state             *vfs_state    = vfs_thread->vfs->vfs_state;
+    struct chimera_vfs_lease_owner        owner_filter = {
+        .protocol   = CHIMERA_VFS_LEASE_PROTO_SMB2,
+        .client_key = request->session_handle->session->session_id,
+        .owner_lo   = CHIMERA_VFS_LEASE_OWNER_WILDCARD,
+        .owner_hi   = CHIMERA_VFS_LEASE_OWNER_WILDCARD,
+    };
+    const struct chimera_vfs_lease_owner *owner = NULL;
+
+    owner = &owner_filter;
+
+    request->create.wait_open_handle  = oh;
+    request->create.wait_is_directory = is_directory;
+    request->create.wait_file_state   = chimera_vfs_state_get(vfs_state,
+                                                              oh->fh,
+                                                              oh->fh_len,
+                                                              oh->fh_hash,
+                                                              false);
+    if (!request->create.wait_file_state) {
+        chimera_smb_create_open_at_after_h_break(request);
+        return;
+    }
+
+    chimera_vfs_cache_wait(vfs_state,
+                           request->create.wait_file_state,
+                           &request->create.cache_wait,
+                           CHIMERA_VFS_LEASE_MODE_H,
+                           CHIMERA_VFS_LEASE_MODE_R,
+                           owner,
+                           chimera_smb_create_h_wait_cb,
+                           request);
+} /* chimera_smb_create_wait_for_h_cache */
+
+static void
+chimera_smb_create_open_at_after_h_break(struct chimera_smb_request *request)
+{
+    struct chimera_vfs_thread      *vfs_thread = request->compound->thread->vfs_thread;
+    struct chimera_smb_open_file   *open_file;
+    struct chimera_vfs_open_handle *oh = request->create.wait_open_handle;
+
+    request->create.wait_open_handle = NULL;
+
+    open_file = chimera_smb_create_gen_open_file_normal(request,
+                                                        request->create.parent_handle->fh,
+                                                        request->create.parent_handle->fh_len,
+                                                        request->create.name,
+                                                        request->create.name_len,
+                                                        request->create.create_options & SMB2_FILE_DELETE_ON_CLOSE,
+                                                        request->create.wait_is_directory,
+                                                        oh);
+
+    if (!open_file) {
+        chimera_vfs_release(vfs_thread, oh);
+        chimera_vfs_release(vfs_thread, request->create.parent_handle);
+        chimera_smb_complete_request(request, SMB2_STATUS_SHARING_VIOLATION);
+        return;
+    }
+
+    request->create.r_open_file = open_file;
+
+    if (request->create.create_disposition == SMB2_FILE_CREATE        ||
+        request->create.create_disposition == SMB2_FILE_OPEN_IF       ||
+        request->create.create_disposition == SMB2_FILE_OVERWRITE_IF  ||
+        request->create.create_disposition == SMB2_FILE_SUPERSEDE) {
+        struct chimera_server_smb_thread *thread = request->compound->thread;
+        uint32_t                          action = request->create.wait_is_directory ?
+            CHIMERA_VFS_NOTIFY_DIR_ADDED : CHIMERA_VFS_NOTIFY_FILE_ADDED;
+
+        chimera_vfs_notify_emit(thread->shared->vfs->vfs_notify,
+                                request->create.parent_handle->fh,
+                                request->create.parent_handle->fh_len,
+                                action,
+                                request->create.name,
+                                request->create.name_len,
+                                NULL, 0);
+    }
+
+    chimera_vfs_release(vfs_thread, request->create.parent_handle);
+    chimera_smb_open_file_release(request, open_file);
+    chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
+} /* chimera_smb_create_open_at_after_h_break */
+
 static inline struct chimera_smb_open_file *
 chimera_smb_create_gen_open_file_pipe(
     struct chimera_smb_request   *request,
@@ -608,9 +731,8 @@ chimera_smb_create_open_at_callback(
     struct chimera_vfs_attrs       *dir_post_attr,
     void                           *private_data)
 {
-    struct chimera_smb_request   *request    = private_data;
-    struct chimera_vfs_thread    *vfs_thread = request->compound->thread->vfs_thread;
-    struct chimera_smb_open_file *open_file;
+    struct chimera_smb_request *request    = private_data;
+    struct chimera_vfs_thread  *vfs_thread = request->compound->thread->vfs_thread;
 
     if (error_code != CHIMERA_VFS_OK) {
         chimera_vfs_release(vfs_thread, request->create.parent_handle);
@@ -618,61 +740,10 @@ chimera_smb_create_open_at_callback(
         return;
     }
 
-    open_file = chimera_smb_create_gen_open_file_normal(request,
-                                                        request->create.parent_handle->fh,
-                                                        request->create.parent_handle->fh_len,
-                                                        request->create.name,
-                                                        request->create.name_len,
-                                                        request->create.create_options & SMB2_FILE_DELETE_ON_CLOSE,
-                                                        S_ISDIR(attr->va_mode),
-                                                        oh);
-
-    if (!open_file) {
-        chimera_vfs_release(vfs_thread, oh);
-        chimera_vfs_release(vfs_thread, request->create.parent_handle);
-        chimera_smb_complete_request(request, SMB2_STATUS_SHARING_VIOLATION);
-        return;
-    }
-
-    request->create.r_open_file = open_file;
-
     chimera_smb_marshal_attrs(
         attr,
         &request->create.r_attrs);
-
-    /* Emit notification on parent directory for any disposition that can
-     * create a new file.  OPEN never creates; CREATE always creates;
-     * OPEN_IF / OVERWRITE_IF / SUPERSEDE may create or may open/truncate
-     * an existing file.  We emit ADDED for all create-capable
-     * dispositions — this can yield a spurious ADDED when an existing
-     * file was opened or truncated, but that is preferable to missing
-     * notifications for newly-created files (Windows CREATE_ALWAYS maps
-     * to OVERWRITE_IF and is the common case).
-     *
-     * Pick FILE_ADDED vs DIR_ADDED based on the result attrs.  A
-     * directory creation (FILE_DIRECTORY_FILE create option) must
-     * emit DIR_ADDED so SMB clients filtering on DIR_NAME only
-     * receive the event. */
-    if (request->create.create_disposition == SMB2_FILE_CREATE        ||
-        request->create.create_disposition == SMB2_FILE_OPEN_IF       ||
-        request->create.create_disposition == SMB2_FILE_OVERWRITE_IF  ||
-        request->create.create_disposition == SMB2_FILE_SUPERSEDE) {
-        struct chimera_server_smb_thread *thread = request->compound->thread;
-        uint32_t                          action = S_ISDIR(attr->va_mode) ?
-            CHIMERA_VFS_NOTIFY_DIR_ADDED : CHIMERA_VFS_NOTIFY_FILE_ADDED;
-
-        chimera_vfs_notify_emit(thread->shared->vfs->vfs_notify,
-                                request->create.parent_handle->fh,
-                                request->create.parent_handle->fh_len,
-                                action,
-                                request->create.name,
-                                request->create.name_len,
-                                NULL, 0);
-    }
-
-    chimera_vfs_release(vfs_thread, request->create.parent_handle);
-    chimera_smb_open_file_release(request, open_file);
-    chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
+    chimera_smb_create_wait_for_h_cache(request, oh, S_ISDIR(attr->va_mode));
 } /* chimera_smb_create_open_at_callback */
 
 static inline void

--- a/src/server/smb/smb_proc_ioctl.c
+++ b/src/server/smb/smb_proc_ioctl.c
@@ -89,8 +89,14 @@ chimera_smb_ioctl(struct chimera_smb_request *request)
 
             request->ioctl.r_capabilities = conn->capabilities;
             memcpy(request->ioctl.r_guid, shared->guid, 16);
+            /* Must echo the SecurityMode advertised in NEGOTIATE; a mismatch
+             * looks like a downgrade attack and the client drops the
+             * connection (MS-SMB2 3.3.5.15.12). */
             request->ioctl.r_security_mode = SMB2_SIGNING_ENABLED;
-            request->ioctl.r_dialect       = conn->dialect;
+            if (shared->config.signing_required) {
+                request->ioctl.r_security_mode |= SMB2_SIGNING_REQUIRED;
+            }
+            request->ioctl.r_dialect = conn->dialect;
 
             chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
             break;

--- a/src/server/smb/smb_proc_negotiate.c
+++ b/src/server/smb/smb_proc_negotiate.c
@@ -109,8 +109,14 @@ chimera_smb_negotiate(struct chimera_smb_request *request)
         conn->flags |= CHIMERA_SMB_CONN_FLAG_SIGNING_REQUIRED;
     }
 
-    request->negotiate.r_dialect           = dialect;
-    request->negotiate.r_security_mode     = SMB2_SIGNING_ENABLED;
+    request->negotiate.r_dialect       = dialect;
+    request->negotiate.r_security_mode = SMB2_SIGNING_ENABLED;
+    if (shared->config.signing_required) {
+        /* Server signing = mandatory: advertise REQUIRED so clients sign
+         * every request (smb2.session-require-signing / bug15397). */
+        request->negotiate.r_security_mode |= SMB2_SIGNING_REQUIRED;
+        conn->flags                        |= CHIMERA_SMB_CONN_FLAG_SIGNING_REQUIRED;
+    }
     request->negotiate.r_capabilities      = conn->capabilities;
     request->negotiate.r_max_transact_size = 1 * 1024 * 1024;
     request->negotiate.r_max_read_size     = 8 * 1024 * 1024;

--- a/src/server/smb/smb_proc_oplock_break.c
+++ b/src/server/smb/smb_proc_oplock_break.c
@@ -245,15 +245,9 @@ chimera_smb_lease_break_cb(
         open_file->oplock_level = new_level;
     }
 
-    /* Optimistic downgrade: assume the client acks.  The arriving ack
-     * calls chimera_vfs_lease_ack which is idempotent.  Keeping the read
-     * cache lets the conflicting opener settle at LEVEL_II too. */
-    {
-        struct chimera_vfs_lease_mode m;
-        m.granted = new_vfs;
-        m.denied  = 0;
-        chimera_vfs_lease_ack(lease, m);
-    }
+    /* The holder is downgraded only when its OPLOCK_BREAK ack arrives.
+     * vfs_state queues conflicting work until chimera_smb_oplock_break()
+     * applies that ack below. */
 } /* chimera_smb_lease_break_cb */
 
 /* ----------------------------------------------------------------------
@@ -304,9 +298,70 @@ chimera_smb_parse_oplock_break(
 SYMBOL_EXPORT void
 chimera_smb_oplock_break(struct chimera_smb_request *request)
 {
-    /* The lease was already optimistically acked inside the break_cb.
-     * Nothing else to do besides letting the dispatcher emit the
-     * reply packet. */
+    struct chimera_smb_open_file     *open_file = NULL;
+    struct chimera_vfs_lease_mode     mode      = { 0, 0 };
+    struct chimera_server_smb_thread *thread    = request->compound->thread;
+    struct chimera_vfs_state         *vfs_state = thread->vfs_thread->vfs->vfs_state;
+
+    if (request->oplock_break.is_lease) {
+        uint32_t bucket;
+
+        if (request->tree) {
+            for (bucket = 0; bucket < CHIMERA_SMB_OPEN_FILE_BUCKETS; bucket++) {
+                for (open_file = request->tree->open_files[bucket];
+                     open_file;
+                     open_file = open_file->next) {
+                    if (open_file->caching_lease_inserted &&
+                        open_file->oplock_level == SMB2_OPLOCK_LEVEL_LEASE &&
+                        memcmp(open_file->lease_key,
+                               request->oplock_break.lease_key, 16) == 0) {
+                        goto found;
+                    }
+                }
+            }
+        }
+        open_file = NULL;
+ found:
+        mode.granted = chimera_smb_lease_to_vfs_bits(request->oplock_break.lease_state);
+    } else {
+        open_file = chimera_smb_open_file_resolve(request,
+                                                  &request->oplock_break.file_id);
+        switch (request->oplock_break.oplock_level) {
+            case SMB2_OPLOCK_LEVEL_II:
+                mode.granted = CHIMERA_VFS_LEASE_MODE_R;
+                break;
+            case SMB2_OPLOCK_LEVEL_NONE:
+            default:
+                mode.granted = 0;
+                break;
+        } /* switch */
+    }
+
+    if (!open_file || !open_file->caching_lease_inserted) {
+        if (open_file && !request->oplock_break.is_lease) {
+            chimera_smb_open_file_release(request, open_file);
+        }
+        chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
+        return;
+    }
+
+    chimera_vfs_lease_ack(&open_file->caching_lease, mode);
+
+    if (mode.granted == 0) {
+        chimera_vfs_lease_release(vfs_state, open_file->caching_file_state,
+                                  &open_file->caching_lease);
+        open_file->caching_lease_inserted = false;
+        chimera_vfs_state_put(vfs_state, open_file->caching_file_state);
+        open_file->caching_file_state = NULL;
+    }
+
+    if (request->oplock_break.is_lease) {
+        open_file->lease_state = request->oplock_break.lease_state;
+    } else {
+        open_file->oplock_level = request->oplock_break.oplock_level;
+        chimera_smb_open_file_release(request, open_file);
+    }
+
     chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
 } /* chimera_smb_oplock_break */
 

--- a/src/server/smb/smb_proc_query_info.c
+++ b/src/server/smb/smb_proc_query_info.c
@@ -124,6 +124,10 @@ chimera_smb_query_info(struct chimera_smb_request *request)
                 case SMB2_FILE_FULL_EA_INFO:
                     request->query_info.output_length = 8;
                     break;
+                case SMB2_FILE_POSITION_INFO:
+                    /* CurrentByteOffset only; no VFS attributes needed. */
+                    request->query_info.output_length = SMB2_FILE_POSITION_INFO_SIZE;
+                    break;
                 default:
                     status = SMB2_STATUS_NOT_IMPLEMENTED;
                     break;
@@ -224,6 +228,10 @@ chimera_smb_query_info_reply(
                 case SMB2_FILE_FULL_EA_INFO:
                     evpl_iovec_cursor_append_uint32(reply_cursor, 0);
                     evpl_iovec_cursor_append_uint32(reply_cursor, 0);
+                    break;
+                case SMB2_FILE_POSITION_INFO:
+                    evpl_iovec_cursor_append_uint64(reply_cursor,
+                                                    request->query_info.open_file->position);
                     break;
                 default:
                     chimera_smb_abort("%s: unsupported file information class: %d",

--- a/src/server/smb/smb_proc_read.c
+++ b/src/server/smb/smb_proc_read.c
@@ -17,6 +17,60 @@ chimera_smb_read_callback(
     struct evpl_iovec        *iov,
     int                       niov,
     struct chimera_vfs_attrs *attr,
+    void                     *private_data);
+
+static void
+chimera_smb_read_start_vfs(struct chimera_smb_request *request)
+{
+    struct chimera_server_smb_thread *thread = request->compound->thread;
+
+    chimera_vfs_read(
+        thread->vfs_thread,
+        &request->session_handle->session->cred,
+        request->read.open_file->handle,
+        request->read.offset,
+        request->read.length,
+        request->read.iov,
+        request->read.niov,
+        0,
+        chimera_smb_read_callback,
+        request);
+} /* chimera_smb_read_start_vfs */
+
+static void
+chimera_smb_read_cache_wait_cb(
+    enum chimera_vfs_lease_result result,
+    struct chimera_vfs_lease     *conflict,
+    void                         *private_data)
+{
+    struct chimera_smb_request       *request = private_data;
+    struct chimera_server_smb_thread *thread  = request->compound->thread;
+
+    (void) conflict;
+
+    if (request->read.wait_file_state) {
+        chimera_vfs_state_put(thread->vfs_thread->vfs->vfs_state,
+                              request->read.wait_file_state);
+        request->read.wait_file_state = NULL;
+    }
+
+    if (result != CHIMERA_VFS_LEASE_GRANTED) {
+        chimera_smb_open_file_release(request, request->read.open_file);
+        chimera_smb_complete_request(request, SMB2_STATUS_FILE_LOCK_CONFLICT);
+        return;
+    }
+
+    chimera_smb_read_start_vfs(request);
+} /* chimera_smb_read_cache_wait_cb */
+
+static void
+chimera_smb_read_callback(
+    enum chimera_vfs_error    error_code,
+    uint32_t                  count,
+    uint32_t                  eof,
+    struct evpl_iovec        *iov,
+    int                       niov,
+    struct chimera_vfs_attrs *attr,
     void                     *private_data)
 {
     struct chimera_smb_request       *request = private_data;
@@ -85,9 +139,11 @@ chimera_smb_read_callback(
 void
 chimera_smb_read(struct chimera_smb_request *request)
 {
-    struct chimera_server_smb_thread *thread = request->compound->thread;
+    struct chimera_server_smb_thread     *thread      = request->compound->thread;
+    const struct chimera_vfs_lease_owner *cache_owner = NULL;
 
-    request->read.open_file = chimera_smb_open_file_resolve(request, &request->read.file_id);
+    request->read.open_file       = chimera_smb_open_file_resolve(request, &request->read.file_id);
+    request->read.wait_file_state = NULL;
 
     if (unlikely(!request->read.open_file)) {
         chimera_smb_complete_request(request, SMB2_STATUS_FILE_CLOSED);
@@ -150,17 +206,29 @@ chimera_smb_read(struct chimera_smb_request *request)
         }
     }
 
-    chimera_vfs_read(
-        thread->vfs_thread,
-        &request->session_handle->session->cred,
-        request->read.open_file->handle,
-        request->read.offset,
-        request->read.length,
-        request->read.iov,
-        request->read.niov,
-        0,
-        chimera_smb_read_callback,
-        request);
+    if (request->read.open_file->caching_lease_inserted) {
+        cache_owner = &request->read.open_file->caching_lease.owner;
+    }
+
+    request->read.wait_file_state = chimera_vfs_state_get(
+        thread->vfs_thread->vfs->vfs_state,
+        request->read.open_file->handle->fh,
+        request->read.open_file->handle->fh_len,
+        request->read.open_file->handle->fh_hash,
+        false);
+    if (!request->read.wait_file_state) {
+        chimera_smb_read_start_vfs(request);
+        return;
+    }
+
+    chimera_vfs_cache_wait(thread->vfs_thread->vfs->vfs_state,
+                           request->read.wait_file_state,
+                           &request->read.cache_wait,
+                           CHIMERA_VFS_LEASE_MODE_W,
+                           CHIMERA_VFS_LEASE_MODE_R,
+                           cache_owner,
+                           chimera_smb_read_cache_wait_cb,
+                           request);
 } /* chimera_smb_read */
 
 

--- a/src/server/smb/smb_proc_session_setup.c
+++ b/src/server/smb/smb_proc_session_setup.c
@@ -110,6 +110,38 @@ chimera_smb_session_setup(struct chimera_smb_request *request)
         input_len = 0;
     }
 
+    /* Validate a SESSION_SETUP that names a session this connection does not
+     * own (request->bind_session, resolved globally by the dispatcher).  It is
+     * a multichannel bind only if SMB2_SESSION_FLAG_BINDING is set and the
+     * binding rules (MS-SMB2 3.3.5.5.2) are satisfied; otherwise it is an
+     * invalid cross-connection reference and the session is treated as deleted.
+     * Rejections happen before authentication so we never run NTLM for them. */
+    if (request->bind_session) {
+        uint32_t reject = 0;
+
+        if (!(request->session_setup.flags & SMB2_SESSION_FLAG_BINDING)) {
+            /* No binding flag: a session id belonging to another connection is
+             * not valid here. */
+            reject = SMB2_STATUS_USER_SESSION_DELETED;
+        } else if (conn->dialect < SMB2_DIALECT_3_0) {
+            /* Channel binding requires SMB 3.x. */
+            reject = SMB2_STATUS_REQUEST_NOT_ACCEPTED;
+        } else if (request->bind_session->dialect != conn->dialect) {
+            /* The bound session and this channel must share a dialect. */
+            reject = SMB2_STATUS_INVALID_PARAMETER;
+        }
+
+        if (reject) {
+            chimera_smb_session_release(thread, shared, request->bind_session);
+            request->bind_session = NULL;
+            chimera_smb_complete_request(request, reject);
+            evpl_iovecs_release(thread->evpl,
+                                request->session_setup.input_iov,
+                                request->session_setup.input_niov);
+            return;
+        }
+    }
+
     // Detect authentication mechanism
     mech = smb_auth_detect_mechanism(input, input_len);
     chimera_smb_debug("Session setup: detected mechanism %s", smb_auth_mech_name(mech));
@@ -143,7 +175,17 @@ chimera_smb_session_setup(struct chimera_smb_request *request)
      * hash by the response's SessionId: a zero id on the interim response
      * splits the hash across buckets and breaks signing-key derivation. */
     if ((rc == 0 || rc == 1) && !request->session_handle) {
-        session = chimera_smb_session_alloc(shared);
+        if (request->bind_session) {
+            /* Multichannel bind: attach this connection as a new channel of
+             * the existing session instead of creating a new one. */
+            session = request->bind_session;
+            if (rc == 0) {
+                request->flags |= CHIMERA_SMB_REQUEST_FLAG_SIGN;
+            }
+        } else {
+            session          = chimera_smb_session_alloc(shared);
+            session->dialect = conn->dialect;
+        }
 
         session_handle = chimera_smb_session_handle_alloc(thread);
 
@@ -160,6 +202,7 @@ chimera_smb_session_setup(struct chimera_smb_request *request)
         request->compound->conn->last_session_handle = session_handle;
 
         request->session_handle = session_handle;
+        request->bind_session   = NULL;
     }
 
     if (rc == 0) {
@@ -269,6 +312,12 @@ chimera_smb_session_setup(struct chimera_smb_request *request)
             chimera_smb_session_authorize(shared, session);
         }
 
+        /* A reconnect names the session it is replacing in PreviousSessionId;
+        * MS-SMB2 3.3.5.5.1 requires the server to invalidate that session. */
+        chimera_smb_session_expire_previous(shared,
+                                            request->session_setup.prev_session_id,
+                                            session->session_id);
+
         chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
     } else if (rc == 1) {
         // Continue needed
@@ -290,6 +339,15 @@ chimera_smb_session_setup(struct chimera_smb_request *request)
             request->session_handle   = NULL;
             conn->last_session_handle = NULL;
         }
+    }
+
+    /* If this was a bind that did not complete (MORE_PROCESSING) or failed,
+     * drop the dispatcher's lookup reference; the next bind message re-resolves
+     * it.  On a successful bind the reference was transferred to the new
+     * channel handle and bind_session is already NULL. */
+    if (request->bind_session) {
+        chimera_smb_session_release(thread, shared, request->bind_session);
+        request->bind_session = NULL;
     }
 
     evpl_iovecs_release(thread->evpl, request->session_setup.input_iov, request->session_setup.input_niov);

--- a/src/server/smb/smb_proc_write.c
+++ b/src/server/smb/smb_proc_write.c
@@ -16,6 +16,105 @@ chimera_smb_write_callback(
     uint32_t                  sync,
     struct chimera_vfs_attrs *pre_attr,
     struct chimera_vfs_attrs *post_attr,
+    void                     *private_data);
+
+static void
+chimera_smb_write_start_vfs(struct chimera_smb_request *request)
+{
+    struct chimera_server_smb_thread *thread = request->compound->thread;
+
+    chimera_vfs_write(
+        thread->vfs_thread,
+        &request->session_handle->session->cred,
+        request->write.open_file->handle,
+        request->write.offset,
+        request->write.length,
+        !!(request->write.flags & SMB2_WRITEFLAG_WRITE_THROUGH),
+        0,
+        0,
+        request->write.iov,
+        request->write.niov,
+        chimera_smb_write_callback,
+        request);
+} /* chimera_smb_write_start_vfs */
+
+static void
+chimera_smb_write_cache_wait_cb(
+    enum chimera_vfs_lease_result result,
+    struct chimera_vfs_lease     *conflict,
+    void                         *private_data)
+{
+    struct chimera_smb_request           *request     = private_data;
+    struct chimera_server_smb_thread     *thread      = request->compound->thread;
+    const struct chimera_vfs_lease_owner *cache_owner = NULL;
+
+    (void) conflict;
+
+    if (request->write.wait_file_state) {
+        chimera_vfs_state_put(thread->vfs_thread->vfs->vfs_state,
+                              request->write.wait_file_state);
+        request->write.wait_file_state = NULL;
+    }
+
+    if (result != CHIMERA_VFS_LEASE_GRANTED) {
+        evpl_iovecs_release(thread->evpl, request->write.iov, request->write.niov);
+        chimera_smb_open_file_release(request, request->write.open_file);
+        chimera_smb_complete_request(request, SMB2_STATUS_FILE_LOCK_CONFLICT);
+        return;
+    }
+
+    if (request->write.open_file->caching_lease_inserted) {
+        cache_owner = &request->write.open_file->caching_lease.owner;
+    }
+
+    chimera_vfs_state_break_on_write(thread->vfs_thread->vfs->vfs_state,
+                                     request->write.open_file->handle->fh,
+                                     request->write.open_file->handle->fh_len,
+                                     request->write.open_file->handle->fh_hash,
+                                     cache_owner);
+
+    chimera_smb_write_start_vfs(request);
+} /* chimera_smb_write_cache_wait_cb */
+
+static void
+chimera_smb_write_wait_for_cache(struct chimera_smb_request *request)
+{
+    struct chimera_server_smb_thread     *thread      = request->compound->thread;
+    const struct chimera_vfs_lease_owner *cache_owner = NULL;
+
+    if (request->write.open_file->caching_lease_inserted) {
+        cache_owner = &request->write.open_file->caching_lease.owner;
+    }
+
+    request->write.wait_file_state = chimera_vfs_state_get(
+        thread->vfs_thread->vfs->vfs_state,
+        request->write.open_file->handle->fh,
+        request->write.open_file->handle->fh_len,
+        request->write.open_file->handle->fh_hash,
+        false);
+    if (!request->write.wait_file_state) {
+        chimera_smb_write_cache_wait_cb(CHIMERA_VFS_LEASE_GRANTED,
+                                        NULL, request);
+        return;
+    }
+
+    chimera_vfs_cache_wait(thread->vfs_thread->vfs->vfs_state,
+                           request->write.wait_file_state,
+                           &request->write.cache_wait,
+                           CHIMERA_VFS_LEASE_MODE_R | CHIMERA_VFS_LEASE_MODE_W,
+                           0,
+                           cache_owner,
+                           chimera_smb_write_cache_wait_cb,
+                           request);
+} /* chimera_smb_write_wait_for_cache */
+
+static void
+chimera_smb_write_callback(
+    enum chimera_vfs_error    error_code,
+    uint32_t                  length,
+    uint32_t                  sync,
+    struct chimera_vfs_attrs *pre_attr,
+    struct chimera_vfs_attrs *post_attr,
     void                     *private_data)
 {
     struct chimera_smb_request       *request = private_data;
@@ -75,19 +174,7 @@ chimera_smb_rdma_read_callback(
             return;
         }
 
-        chimera_vfs_write(
-            thread->vfs_thread,
-            &request->session_handle->session->cred,
-            request->write.open_file->handle,
-            request->write.offset,
-            request->write.length,
-            !!(request->write.flags & SMB2_WRITEFLAG_WRITE_THROUGH),
-            0,
-            0,
-            request->write.iov,
-            request->write.niov,
-            chimera_smb_write_callback,
-            request);
+        chimera_smb_write_wait_for_cache(request);
     }
 
 } /* chimera_smb_rdma_read_callback */
@@ -102,7 +189,8 @@ chimera_smb_write(struct chimera_smb_request *request)
     struct evpl_iovec                *chunk_iov = request->write.chunk_iov;
     int                               i, offset = 0;
 
-    request->write.open_file = chimera_smb_open_file_resolve(request, &request->write.file_id);
+    request->write.open_file       = chimera_smb_open_file_resolve(request, &request->write.file_id);
+    request->write.wait_file_state = NULL;
 
     if (unlikely(!request->write.open_file)) {
         chimera_smb_complete_request(request, SMB2_STATUS_FILE_CLOSED);
@@ -134,14 +222,6 @@ chimera_smb_write(struct chimera_smb_request *request)
             return;
         }
 
-        /* A write stales every read cache on this file: break those
-         * caching oplocks/leases (to NONE), except the writer's own
-         * write cache. */
-        chimera_vfs_state_break_on_write(thread->vfs_thread->vfs->vfs_state,
-                                         request->write.open_file->handle->fh,
-                                         request->write.open_file->handle->fh_len,
-                                         request->write.open_file->handle->fh_hash,
-                                         &io_owner);
     }
 
     if (request->write.channel == SMB2_CHANNEL_RDMA_V1) {
@@ -168,19 +248,7 @@ chimera_smb_write(struct chimera_smb_request *request)
             chunk_iov++;
         }
     } else {
-        chimera_vfs_write(
-            thread->vfs_thread,
-            &request->session_handle->session->cred,
-            request->write.open_file->handle,
-            request->write.offset,
-            request->write.length,
-            !!(request->write.flags & SMB2_WRITEFLAG_WRITE_THROUGH),
-            0,
-            0,
-            request->write.iov,
-            request->write.niov,
-            chimera_smb_write_callback,
-            request);
+        chimera_smb_write_wait_for_cache(request);
     }
 } /* chimera_smb_write */
 

--- a/src/server/smb/smb_session.h
+++ b/src/server/smb/smb_session.h
@@ -148,6 +148,11 @@ struct chimera_smb_tree {
 };
 
 #define CHIMERA_SMB_SESSION_AUTHORIZED 0x1
+/* Session was invalidated by a reconnect (a later SESSION_SETUP named it as
+ * PreviousSessionId) or an explicit teardown.  It has been removed from the
+ * global session table, but connections that still cache a handle to it must
+ * stop honoring it and return SMB2_STATUS_USER_SESSION_DELETED. */
+#define CHIMERA_SMB_SESSION_EXPIRED    0x2
 
 struct chimera_smb_session {
     uint64_t                    session_id;
@@ -162,6 +167,11 @@ struct chimera_smb_session {
 
     int                         max_trees;
     uint8_t                     signing_key[16];
+
+    /* SMB dialect of the connection that first authenticated this session.
+     * A multichannel bind (SMB2_SESSION_FLAG_BINDING) is only legal from a
+     * connection negotiated at the same dialect (MS-SMB2 3.3.5.5.2). */
+    uint16_t                    dialect;
 
     struct chimera_vfs_cred     cred;
 };

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -252,12 +252,20 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.create_no_streams
     smb2.notify-inotify
     smb2.secleak
+    smb2.session-id
+    smb2.session-require-signing
     smb2.session.signing-aes-128-cmac
     smb2.set-sparse-ioctl
     smb2.sharemode
     smb2.winattr2
     # smb2.acls_non_canonical and smb2.async_dosmode pass on x86_64 but fail on
     # arm64 CI; left disabled until the arch difference is understood.
+    #
+    # smb2.session is not yet green: reauth/reconnect/session-id/multichannel
+    # bind-rejection and signing-required all pass now, but the remaining
+    # subtests need SMB3 encryption (anon-encryption*), multichannel bind reply
+    # signing (bind1/bind2/bind_invalid_auth) and cross-connection session
+    # teardown (reconnect1/reauth6).  Left disabled until those land.
 )
 set(SMBTORTURE_ENABLED_linux)
 set(SMBTORTURE_ENABLED_demofs_io_uring)

--- a/src/server/smb/tests/smbtorture_test.c
+++ b/src/server/smb/tests/smbtorture_test.c
@@ -278,6 +278,17 @@ main(
     }
 
     /* Initialize server */
+    /* The smb2.session-require-signing suite checks that the server advertises
+     * mandatory signing (security_mode SIGNING_REQUIRED|ENABLED).  That is a
+     * per-server policy, so enable it only when running that suite to avoid
+     * forcing signing on every other suite's connections. */
+    for (i = 0; i < num_tests; i++) {
+        if (strstr(tests[i], "session-require-signing") != NULL) {
+            chimera_server_config_set_smb_signing_required(config, 1);
+            break;
+        }
+    }
+
     env.server = chimera_server_init(config, env.metrics);
     if (!env.server) {
         fprintf(stderr, "Failed to initialize server\n");

--- a/src/vfs/tests/vfs_state_test.c
+++ b/src/vfs/tests/vfs_state_test.c
@@ -402,7 +402,160 @@ test_caching_lease_basics(void)
     chimera_vfs_state_destroy(state);
 } /* test_caching_lease_basics */
 
-/* Test 8: caching W-lease forces break of R-cache on other client ----- */
+struct cache_wait_recorder {
+    int                       fired;
+    enum chimera_vfs_lease_result last_result;
+    struct chimera_vfs_lease *last_conflict;
+};
+
+static void
+recording_cache_wait_cb(
+    enum chimera_vfs_lease_result result,
+    struct chimera_vfs_lease     *conflict,
+    void                         *priv)
+{
+    struct cache_wait_recorder *r = priv;
+
+    r->fired++;
+    r->last_result   = result;
+    r->last_conflict = conflict;
+} /* recording_cache_wait_cb */
+
+/* Test 8: non-lease cache wait resumes after break ack --------------- */
+static void
+test_cache_wait_break_then_ack(void)
+{
+    struct chimera_vfs_state      *state;
+    struct chimera_vfs_file_state *file;
+    struct chimera_vfs_lease       lease;
+    struct chimera_vfs_cache_wait  wait;
+    struct cache_wait_recorder     rec  = { 0 };
+    struct break_recorder          brec = { 0 };
+    struct chimera_vfs_lease_mode  downgraded;
+    enum chimera_vfs_lease_result  r;
+
+    fprintf(stderr, "\ntest_cache_wait_break_then_ack\n");
+
+    state = chimera_vfs_state_init();
+    file  = get_file(state, 1);
+
+    memset(&lease, 0, sizeof(lease));
+    lease.kind         = CHIMERA_VFS_LEASE_CACHING;
+    lease.mode.granted = CHIMERA_VFS_LEASE_MODE_R |
+        CHIMERA_VFS_LEASE_MODE_W;
+    init_owner(&lease.owner, CHIMERA_VFS_LEASE_PROTO_SMB2, 0xA, 1);
+    lease.owner.break_cb   = recording_break_cb;
+    lease.owner.cb_private = &brec;
+
+    r = chimera_vfs_state_try_insert(state, file, &lease, NULL);
+    CHECK(r == CHIMERA_VFS_LEASE_GRANTED, "RW-cache granted");
+
+    chimera_vfs_cache_wait(state, file, &wait,
+                           CHIMERA_VFS_LEASE_MODE_W,
+                           CHIMERA_VFS_LEASE_MODE_R,
+                           NULL,
+                           recording_cache_wait_cb,
+                           &rec);
+    CHECK(rec.fired == 0, "cache wait queues behind W-cache");
+    CHECK(wait.queued == true, "cache wait ticket queued");
+    CHECK(brec.fired == 1, "cache wait starts break");
+    CHECK(lease.break_state == CHIMERA_VFS_BREAK_BREAKING,
+          "cache holder marked breaking");
+
+    downgraded.granted = CHIMERA_VFS_LEASE_MODE_R;
+    downgraded.denied  = 0;
+    chimera_vfs_lease_ack(&lease, downgraded);
+    CHECK(lease.break_state == CHIMERA_VFS_BREAK_IDLE,
+          "downgraded non-empty lease becomes breakable again");
+    CHECK(rec.fired == 1, "cache wait callback fires after ack");
+    CHECK(rec.last_result == CHIMERA_VFS_LEASE_GRANTED,
+          "cache wait grants after W-cache downgrade");
+    CHECK(rec.last_conflict == NULL, "cache wait has no conflict after ack");
+
+    chimera_vfs_state_remove(state, file, &lease);
+    chimera_vfs_state_put(state, file);
+    chimera_vfs_state_destroy(state);
+} /* test_cache_wait_break_then_ack */
+
+/* Test 8b: cache wait can ignore all leases from one client ---------- */
+static void
+test_cache_wait_ignores_client_owner(void)
+{
+    struct chimera_vfs_state      *state;
+    struct chimera_vfs_file_state *file;
+    struct chimera_vfs_lease       own, other;
+    struct chimera_vfs_cache_wait  wait;
+    struct cache_wait_recorder     rec        = { 0 };
+    struct break_recorder          own_brec   = { 0 };
+    struct break_recorder          other_brec = { 0 };
+    struct chimera_vfs_lease_owner owner_filter;
+    enum chimera_vfs_lease_result  r;
+
+    fprintf(stderr, "\ntest_cache_wait_ignores_client_owner\n");
+
+    state = chimera_vfs_state_init();
+    file  = get_file(state, 1);
+
+    memset(&own, 0, sizeof(own));
+    own.kind         = CHIMERA_VFS_LEASE_CACHING;
+    own.mode.granted = CHIMERA_VFS_LEASE_MODE_W | CHIMERA_VFS_LEASE_MODE_H;
+    init_owner(&own.owner, CHIMERA_VFS_LEASE_PROTO_SMB2, 0xA, 1);
+    own.owner.break_cb   = recording_break_cb;
+    own.owner.cb_private = &own_brec;
+
+    r = chimera_vfs_state_try_insert(state, file, &own, NULL);
+    CHECK(r == CHIMERA_VFS_LEASE_GRANTED, "own WH-cache granted");
+
+    memset(&owner_filter, 0, sizeof(owner_filter));
+    owner_filter.protocol   = CHIMERA_VFS_LEASE_PROTO_SMB2;
+    owner_filter.client_key = 0xA;
+    owner_filter.owner_lo   = CHIMERA_VFS_LEASE_OWNER_WILDCARD;
+    owner_filter.owner_hi   = CHIMERA_VFS_LEASE_OWNER_WILDCARD;
+
+    chimera_vfs_cache_wait(state, file, &wait,
+                           CHIMERA_VFS_LEASE_MODE_W | CHIMERA_VFS_LEASE_MODE_H,
+                           0,
+                           &owner_filter,
+                           recording_cache_wait_cb,
+                           &rec);
+    CHECK(rec.fired == 1, "same-client cache wait completes immediately");
+    CHECK(rec.last_result == CHIMERA_VFS_LEASE_GRANTED,
+          "same-client cache wait is granted");
+    CHECK(own_brec.fired == 0, "same-client cache wait does not break holder");
+
+    memset(&other, 0, sizeof(other));
+    other.kind         = CHIMERA_VFS_LEASE_CACHING;
+    other.mode.granted = CHIMERA_VFS_LEASE_MODE_W;
+    init_owner(&other.owner, CHIMERA_VFS_LEASE_PROTO_SMB2, 0xB, 2);
+    other.owner.break_cb   = recording_break_cb;
+    other.owner.cb_private = &other_brec;
+
+    r = chimera_vfs_state_try_insert(state, file, &other, NULL);
+    CHECK(r == CHIMERA_VFS_LEASE_BREAKING, "other client conflicts with own W-cache");
+    chimera_vfs_lease_revoke(&own);
+
+    r = chimera_vfs_state_try_insert(state, file, &other, NULL);
+    CHECK(r == CHIMERA_VFS_LEASE_GRANTED, "other W-cache granted after own revoke");
+
+    rec.fired = 0;
+    chimera_vfs_cache_wait(state, file, &wait,
+                           CHIMERA_VFS_LEASE_MODE_W,
+                           0,
+                           &owner_filter,
+                           recording_cache_wait_cb,
+                           &rec);
+    CHECK(rec.fired == 0, "different-client cache wait queues");
+    CHECK(other_brec.fired == 1, "different-client holder is broken");
+
+    chimera_vfs_lease_revoke(&other);
+
+    chimera_vfs_state_remove(state, file, &other);
+    chimera_vfs_state_remove(state, file, &own);
+    chimera_vfs_state_put(state, file);
+    chimera_vfs_state_destroy(state);
+} /* test_cache_wait_ignores_client_owner */
+
+/* Test 9: caching W-lease forces break of R-cache on other client ----- */
 static void
 test_caching_w_breaks_r(void)
 {
@@ -462,7 +615,7 @@ test_caching_w_breaks_r(void)
     chimera_vfs_state_destroy(state);
 } /* test_caching_w_breaks_r */
 
-/* Test 9: SMB lease-key coalescing — same client_key+owner doesn't break */
+/* Test 10: SMB lease-key coalescing - same client_key+owner doesn't break */
 static void
 test_smb_lease_key_coalesces(void)
 {
@@ -515,7 +668,7 @@ test_smb_lease_key_coalesces(void)
     chimera_vfs_state_destroy(state);
 } /* test_smb_lease_key_coalesces */
 
-/* Test 10: caching W-lease must be broken by another client's W request,
+/* Test 11: caching W-lease must be broken by another client's W request,
 * and revoke (timeout-equivalent) lets the new request through ------- */
 static void
 test_caching_break_revoke(void)
@@ -566,7 +719,7 @@ test_caching_break_revoke(void)
     chimera_vfs_state_destroy(state);
 } /* test_caching_break_revoke */
 
-/* Test 11: range-lock probe that would clash with a caching W-lease on
+/* Test 12: range-lock probe that would clash with a caching W-lease on
  * another client triggers a break instead of immediate denial -------- */
 static void
 test_range_breaks_caching(void)
@@ -637,7 +790,7 @@ recording_acquire_cb(
     r->last_conflict = conflict;
 } /* recording_acquire_cb */
 
-/* Test 12: async acquire wait=false fires cb synchronously --------- */
+/* Test 13: async acquire wait=false fires cb synchronously --------- */
 static void
 test_async_acquire_immediate(void)
 {
@@ -670,7 +823,7 @@ test_async_acquire_immediate(void)
     chimera_vfs_state_destroy(state);
 } /* test_async_acquire_immediate */
 
-/* Test 13: async acquire wait=true queues on BREAKING, fires after ack */
+/* Test 14: async acquire wait=true queues on BREAKING, fires after ack */
 static void
 test_async_acquire_wait_then_ack(void)
 {
@@ -723,7 +876,7 @@ test_async_acquire_wait_then_ack(void)
     chimera_vfs_state_destroy(state);
 } /* test_async_acquire_wait_then_ack */
 
-/* Test 14: cancel removes a queued ticket and suppresses cb -------- */
+/* Test 15: cancel removes a queued ticket and suppresses cb -------- */
 static void
 test_async_acquire_cancel(void)
 {
@@ -778,7 +931,7 @@ test_async_acquire_cancel(void)
     chimera_vfs_state_destroy(state);
 } /* test_async_acquire_cancel */
 
-/* Test 15: release pumps pending queue ----------------------------- */
+/* Test 16: release pumps pending queue ----------------------------- */
 static void
 test_release_pumps_pending(void)
 {
@@ -823,7 +976,7 @@ test_release_pumps_pending(void)
     chimera_vfs_state_destroy(state);
 } /* test_release_pumps_pending */
 
-/* Test 16: chimera_vfs_lease_test exposes conflict without inserting */
+/* Test 17: chimera_vfs_lease_test exposes conflict without inserting */
 static void
 test_lease_test(void)
 {
@@ -867,7 +1020,7 @@ test_lease_test(void)
     chimera_vfs_state_destroy(state);
 } /* test_lease_test */
 
-/* Test 17: I/O hook is a no-op pass-through for Stage A ------------ */
+/* Test 18: I/O hook is a no-op pass-through for Stage A ------------ */
 static void
 test_io_hook_passthrough(void)
 {
@@ -897,6 +1050,8 @@ main(
     test_range_to_eof();
     test_share_vs_share();
     test_caching_lease_basics();
+    test_cache_wait_break_then_ack();
+    test_cache_wait_ignores_client_owner();
     test_caching_w_breaks_r();
     test_smb_lease_key_coalesces();
     test_caching_break_revoke();

--- a/src/vfs/vfs_state.c
+++ b/src/vfs/vfs_state.c
@@ -251,6 +251,25 @@ chimera_vfs_lease_owner_equal(
            a->owner_hi == b->owner_hi;
 } /* chimera_vfs_lease_owner_equal */
 
+static inline bool
+chimera_vfs_lease_owner_matches(
+    const struct chimera_vfs_lease_owner *lease_owner,
+    const struct chimera_vfs_lease_owner *filter)
+{
+    if (lease_owner->protocol != filter->protocol ||
+        lease_owner->client_key != filter->client_key) {
+        return false;
+    }
+
+    if (filter->owner_lo == CHIMERA_VFS_LEASE_OWNER_WILDCARD &&
+        filter->owner_hi == CHIMERA_VFS_LEASE_OWNER_WILDCARD) {
+        return true;
+    }
+
+    return lease_owner->owner_lo == filter->owner_lo &&
+           lease_owner->owner_hi == filter->owner_hi;
+} /* chimera_vfs_lease_owner_matches */
+
 /* Byte-range overlap test.  length==0 means "to EOF" (NLM/SMB
  * convention); represent EOF as UINT64_MAX for the math. */
 static inline bool
@@ -386,6 +405,9 @@ chimera_vfs_state_would_conflict(
                             if (conflict_out && !*conflict_out) {
                                 *conflict_out = cur;
                             }
+                        } else if (cur->owner.break_cb &&
+                                   cur->break_state == CHIMERA_VFS_BREAK_BREAKING) {
+                            has_breakable_conflict = true;
                         } else {
                             if (conflict_out) {
                                 *conflict_out = cur;
@@ -400,6 +422,9 @@ chimera_vfs_state_would_conflict(
                         if (conflict_out && !*conflict_out) {
                             *conflict_out = cur;
                         }
+                    } else if (cur->owner.break_cb &&
+                               cur->break_state == CHIMERA_VFS_BREAK_BREAKING) {
+                        has_breakable_conflict = true;
                     } else {
                         if (conflict_out) {
                             *conflict_out = cur;
@@ -472,13 +497,16 @@ chimera_vfs_state_would_conflict(
                         }
                     }
 
-                    /* SMB handle-cache: break only an IDLE holder (existing
-                    * optimistic-after-break semantics retained for SMB). */
-                    if (want_break_h &&
-                        cur->break_state == CHIMERA_VFS_BREAK_IDLE) {
-                        has_breakable_conflict = true;
-                        if (!idle_break) {
-                            idle_break = cur;
+                    /* SMB handle-cache: start an IDLE break, or keep the
+                     * acquirer waiting while a real client ack is outstanding. */
+                    if (want_break_h) {
+                        if (cur->break_state == CHIMERA_VFS_BREAK_IDLE) {
+                            has_breakable_conflict = true;
+                            if (!idle_break) {
+                                idle_break = cur;
+                            }
+                        } else if (cur->break_state == CHIMERA_VFS_BREAK_BREAKING) {
+                            has_breakable_conflict = true;
                         }
                     }
 
@@ -521,6 +549,9 @@ chimera_vfs_state_would_conflict(
                         if (conflict_out && !*conflict_out) {
                             *conflict_out = cur;
                         }
+                    } else if (cur->owner.break_cb &&
+                               cur->break_state == CHIMERA_VFS_BREAK_BREAKING) {
+                        has_breakable_conflict = true;
                     } else {
                         if (conflict_out) {
                             *conflict_out = cur;
@@ -762,6 +793,122 @@ chimera_vfs_pending_drain_locked(struct chimera_vfs_file_state *file)
     return head;
 } /* chimera_vfs_pending_drain_locked */
 
+static inline void
+chimera_vfs_cache_wait_enqueue_locked(
+    struct chimera_vfs_file_state *file,
+    struct chimera_vfs_cache_wait *wait)
+{
+    wait->file   = file;
+    wait->queued = true;
+    wait->next   = NULL;
+    wait->prev   = file->cache_wait_tail;
+
+    if (file->cache_wait_tail) {
+        file->cache_wait_tail->next = wait;
+    } else {
+        file->cache_wait_head = wait;
+    }
+    file->cache_wait_tail = wait;
+} /* chimera_vfs_cache_wait_enqueue_locked */
+
+static inline void
+chimera_vfs_cache_wait_dequeue_locked(
+    struct chimera_vfs_file_state *file,
+    struct chimera_vfs_cache_wait *wait)
+{
+    if (wait->prev) {
+        wait->prev->next = wait->next;
+    } else if (file->cache_wait_head == wait) {
+        file->cache_wait_head = wait->next;
+    }
+
+    if (wait->next) {
+        wait->next->prev = wait->prev;
+    } else if (file->cache_wait_tail == wait) {
+        file->cache_wait_tail = wait->prev;
+    }
+
+    wait->prev   = NULL;
+    wait->next   = NULL;
+    wait->queued = false;
+} /* chimera_vfs_cache_wait_dequeue_locked */
+
+static inline struct chimera_vfs_cache_wait *
+chimera_vfs_cache_wait_drain_locked(struct chimera_vfs_file_state *file)
+{
+    struct chimera_vfs_cache_wait *head = file->cache_wait_head;
+    struct chimera_vfs_cache_wait *w;
+
+    file->cache_wait_head = NULL;
+    file->cache_wait_tail = NULL;
+    for (w = head; w; w = w->next) {
+        w->queued = false;
+    }
+    return head;
+} /* chimera_vfs_cache_wait_drain_locked */
+
+static enum chimera_vfs_lease_result
+chimera_vfs_cache_wait_check_locked(
+    struct chimera_vfs_file_state        *file,
+    uint8_t                               mode_mask,
+    const struct chimera_vfs_lease_owner *owner,
+    struct chimera_vfs_lease            **conflict_out)
+{
+    struct chimera_vfs_lease *cur;
+
+    if (conflict_out) {
+        *conflict_out = NULL;
+    }
+
+    for (cur = file->caching_leases; cur; cur = cur->next) {
+        if ((cur->mode.granted & mode_mask) == 0) {
+            continue;
+        }
+        if (owner && chimera_vfs_lease_owner_matches(&cur->owner, owner)) {
+            continue;
+        }
+        if (conflict_out) {
+            *conflict_out = cur;
+        }
+        if (cur->owner.break_cb &&
+            (cur->break_state == CHIMERA_VFS_BREAK_IDLE ||
+             cur->break_state == CHIMERA_VFS_BREAK_BREAKING)) {
+            return CHIMERA_VFS_LEASE_BREAKING;
+        }
+        return CHIMERA_VFS_LEASE_DENIED;
+    }
+
+    return CHIMERA_VFS_LEASE_GRANTED;
+} /* chimera_vfs_cache_wait_check_locked */
+
+static enum chimera_vfs_lease_result
+chimera_vfs_cache_wait_check(
+    struct chimera_vfs_state             *state,
+    struct chimera_vfs_file_state        *file,
+    uint8_t                               mode_mask,
+    uint8_t                               break_to_mode,
+    const struct chimera_vfs_lease_owner *owner,
+    struct chimera_vfs_lease            **conflict_out)
+{
+    enum chimera_vfs_lease_result result;
+    struct chimera_vfs_lease     *conflict = NULL;
+
+    pthread_mutex_lock(&file->lock);
+    result = chimera_vfs_cache_wait_check_locked(file, mode_mask, owner, &conflict);
+    pthread_mutex_unlock(&file->lock);
+
+    if (conflict_out) {
+        *conflict_out = conflict;
+    }
+
+    if (result == CHIMERA_VFS_LEASE_BREAKING && conflict &&
+        conflict->break_state == CHIMERA_VFS_BREAK_IDLE) {
+        chimera_vfs_lease_begin_break(state, conflict, break_to_mode, 0);
+    }
+
+    return result;
+} /* chimera_vfs_cache_wait_check */
+
 /* Retry every queued acquire on `file`.  Called after any state mutation
  * that could clear a conflict (remove, ack with downgrade, revoke).  This
  * MUST be called with file->lock NOT held; it takes and releases the lock
@@ -772,11 +919,13 @@ chimera_vfs_state_pump_pending(
     struct chimera_vfs_file_state *file)
 {
     struct chimera_vfs_pending_acquire *head, *t, *next;
+    struct chimera_vfs_cache_wait      *wait_head, *w, *wait_next;
     enum chimera_vfs_lease_result       result;
     struct chimera_vfs_lease           *conflict;
 
     pthread_mutex_lock(&file->lock);
-    head = chimera_vfs_pending_drain_locked(file);
+    head      = chimera_vfs_pending_drain_locked(file);
+    wait_head = chimera_vfs_cache_wait_drain_locked(file);
     pthread_mutex_unlock(&file->lock);
 
     for (t = head; t; t = next) {
@@ -801,6 +950,27 @@ chimera_vfs_state_pump_pending(
               result == CHIMERA_VFS_LEASE_GRANTED ? t->lease : NULL,
               conflict,
               t->private_data);
+    }
+
+    for (w = wait_head; w; w = wait_next) {
+        wait_next = w->next;
+        w->prev   = NULL;
+        w->next   = NULL;
+        conflict  = NULL;
+
+        result = chimera_vfs_cache_wait_check(state, file,
+                                              w->mode_mask,
+                                              w->break_to_mode,
+                                              w->has_owner ? &w->owner : NULL,
+                                              &conflict);
+        if (result == CHIMERA_VFS_LEASE_BREAKING) {
+            pthread_mutex_lock(&file->lock);
+            chimera_vfs_cache_wait_enqueue_locked(file, w);
+            pthread_mutex_unlock(&file->lock);
+            continue;
+        }
+
+        w->cb(result, conflict, w->private_data);
     }
 } /* chimera_vfs_state_pump_pending */
 
@@ -895,6 +1065,67 @@ chimera_vfs_lease_acquire_cancel(
 
     return was_queued;
 } /* chimera_vfs_lease_acquire_cancel */
+
+SYMBOL_EXPORT void
+chimera_vfs_cache_wait(
+    struct chimera_vfs_state             *state,
+    struct chimera_vfs_file_state        *file,
+    struct chimera_vfs_cache_wait        *wait,
+    uint8_t                               mode_mask,
+    uint8_t                               break_to_mode,
+    const struct chimera_vfs_lease_owner *owner,
+    chimera_vfs_cache_wait_cb_t           cb,
+    void                                 *private_data)
+{
+    enum chimera_vfs_lease_result result;
+    struct chimera_vfs_lease     *conflict = NULL;
+
+    memset(wait, 0, sizeof(*wait));
+    wait->mode_mask     = mode_mask;
+    wait->break_to_mode = break_to_mode;
+    wait->cb            = cb;
+    wait->private_data  = private_data;
+    wait->file          = file;
+    if (owner) {
+        wait->owner     = *owner;
+        wait->has_owner = true;
+    }
+
+    result = chimera_vfs_cache_wait_check(state, file, mode_mask,
+                                          break_to_mode, owner, &conflict);
+    if (result == CHIMERA_VFS_LEASE_BREAKING) {
+        pthread_mutex_lock(&file->lock);
+        chimera_vfs_cache_wait_enqueue_locked(file, wait);
+        pthread_mutex_unlock(&file->lock);
+        return;
+    }
+
+    cb(result, conflict, private_data);
+} /* chimera_vfs_cache_wait */
+
+SYMBOL_EXPORT bool
+chimera_vfs_cache_wait_cancel(
+    struct chimera_vfs_state      *state,
+    struct chimera_vfs_cache_wait *wait)
+{
+    struct chimera_vfs_file_state *file = wait->file;
+    bool                           was_queued;
+
+    (void) state;
+
+    if (!file) {
+        return false;
+    }
+
+    pthread_mutex_lock(&file->lock);
+    was_queued = wait->queued;
+    if (was_queued) {
+        chimera_vfs_cache_wait_dequeue_locked(file, wait);
+    }
+    pthread_mutex_unlock(&file->lock);
+
+    return was_queued;
+} /* chimera_vfs_cache_wait_cancel */
 
 SYMBOL_EXPORT enum chimera_vfs_lease_result
 chimera_vfs_lease_test(
@@ -1029,8 +1260,9 @@ chimera_vfs_lease_ack(
 
     if (lease->break_state == CHIMERA_VFS_BREAK_BREAKING) {
         lease->mode        = resulting;
-        lease->break_state = CHIMERA_VFS_BREAK_ACKED;
-        mutated            = true;
+        lease->break_state = resulting.granted ? CHIMERA_VFS_BREAK_IDLE
+                                               : CHIMERA_VFS_BREAK_ACKED;
+        mutated = true;
     }
 
     if (file) {
@@ -1201,7 +1433,8 @@ chimera_vfs_state_break_on_write(
         if ((cur->mode.granted & CHIMERA_VFS_LEASE_MODE_R) == 0) {
             continue;
         }
-        if ((cur->mode.granted & CHIMERA_VFS_LEASE_MODE_W) &&
+        if (writer &&
+            (cur->mode.granted & CHIMERA_VFS_LEASE_MODE_W) &&
             chimera_vfs_lease_owner_equal(&cur->owner, writer)) {
             continue;
         }

--- a/src/vfs/vfs_state.h
+++ b/src/vfs/vfs_state.h
@@ -50,10 +50,10 @@ enum chimera_vfs_lease_kind {
  * SHARE leases use granted = access bits, denied = deny bits.
  * CACHING leases use granted directly (e.g., {R,W,H} for an SMB lease).
  */
-#define CHIMERA_VFS_LEASE_MODE_R      0x01
-#define CHIMERA_VFS_LEASE_MODE_W      0x02
-#define CHIMERA_VFS_LEASE_MODE_H      0x04
-#define CHIMERA_VFS_LEASE_MODE_D      0x08
+#define CHIMERA_VFS_LEASE_MODE_R         0x01
+#define CHIMERA_VFS_LEASE_MODE_W         0x02
+#define CHIMERA_VFS_LEASE_MODE_H         0x04
+#define CHIMERA_VFS_LEASE_MODE_D         0x08
 
 struct chimera_vfs_lease_mode {
     uint8_t granted; /* bits the holder has been granted */
@@ -62,9 +62,14 @@ struct chimera_vfs_lease_mode {
 
 /* Protocol identifiers — used in owner.protocol so the conflict matrix
  * can apply protocol-specific same-owner coalescing rules. */
-#define CHIMERA_VFS_LEASE_PROTO_NLM   1
-#define CHIMERA_VFS_LEASE_PROTO_NFSV4 2
-#define CHIMERA_VFS_LEASE_PROTO_SMB2  3
+#define CHIMERA_VFS_LEASE_PROTO_NLM      1
+#define CHIMERA_VFS_LEASE_PROTO_NFSV4    2
+#define CHIMERA_VFS_LEASE_PROTO_SMB2     3
+
+/* Owner wildcard used by cache-wait callers that need to ignore every
+ * caching lease owned by a protocol client, regardless of that client's
+ * per-open/per-lease owner id. */
+#define CHIMERA_VFS_LEASE_OWNER_WILDCARD UINT64_MAX
 
 struct chimera_vfs_lease;
 
@@ -171,6 +176,27 @@ struct chimera_vfs_pending_acquire {
     struct chimera_vfs_pending_acquire *next;
 };
 
+typedef void (*chimera_vfs_cache_wait_cb_t)(
+    enum chimera_vfs_lease_result result,
+    struct chimera_vfs_lease     *conflict,
+    void                         *private_data);
+
+/* Caller-allocated ticket for operations that do not acquire a durable lease
+ * themselves, but must wait for conflicting caching leases to downgrade before
+ * touching server-side file state. */
+struct chimera_vfs_cache_wait {
+    uint8_t                        mode_mask;
+    uint8_t                        break_to_mode;
+    struct chimera_vfs_lease_owner owner;
+    bool                           has_owner;
+    chimera_vfs_cache_wait_cb_t    cb;
+    void                          *private_data;
+    struct chimera_vfs_file_state *file;
+    bool                           queued;
+    struct chimera_vfs_cache_wait *prev;
+    struct chimera_vfs_cache_wait *next;
+};
+
 /* -------------------------------------------------------------------- */
 /* Per-file state                                                       */
 /* -------------------------------------------------------------------- */
@@ -190,6 +216,10 @@ struct chimera_vfs_file_state {
     /* FIFO queue of acquires waiting on a break to complete. */
     struct chimera_vfs_pending_acquire *pending_head;
     struct chimera_vfs_pending_acquire *pending_tail;
+
+    /* FIFO queue of non-lease operations waiting on cache breaks. */
+    struct chimera_vfs_cache_wait      *cache_wait_head;
+    struct chimera_vfs_cache_wait      *cache_wait_tail;
 
     /* Back-pointer set on creation so ack/revoke/remove can pump the
      * pending queue without changing public-API signatures. */
@@ -353,6 +383,26 @@ chimera_vfs_state_range_io_conflict(
     uint64_t                              length,
     bool                                  is_write,
     const struct chimera_vfs_lease_owner *owner);
+
+/* Wait until no caching lease on `file` grants any bit in `mode_mask`.
+ * Matching breakable leases are broken to `break_to_mode`; the callback fires
+ * synchronously if no wait is needed, or asynchronously after ack/revoke/remove
+ * pumps the wait queue.  If `owner` is non-NULL, that owner is ignored. */
+void
+chimera_vfs_cache_wait(
+    struct chimera_vfs_state             *state,
+    struct chimera_vfs_file_state        *file,
+    struct chimera_vfs_cache_wait        *wait,
+    uint8_t                               mode_mask,
+    uint8_t                               break_to_mode,
+    const struct chimera_vfs_lease_owner *owner,
+    chimera_vfs_cache_wait_cb_t           cb,
+    void                                 *private_data);
+
+bool
+chimera_vfs_cache_wait_cancel(
+    struct chimera_vfs_state      *state,
+    struct chimera_vfs_cache_wait *wait);
 
 /* -------------------------------------------------------------------- */
 /* Break orchestration                                                  */


### PR DESCRIPTION
## Summary

Enables and greens two Samba `smbtorture` SMB2 auth suites on the memfs backend, and fixes 13 of the 24 real `smb2.session` failures (that suite stays disabled until the remainder lands).

All 9 enabled memfs smbtorture ctests pass; Debug + Release build clean.

### `smb2.session-id` (now enabled, green)
- Unknown session ids return `STATUS_USER_SESSION_DELETED` instead of dropping the TCP connection (new `BAD_SESSION` request flag, completed in `compound_advance`).
- Allocate session ids within 32 bits — the torture test round-trips the id through a `uint32_t`, so a full 64-bit random id was silently truncated and stopped matching.

### `smb2.session-require-signing` (now enabled, green)
- New `smb_signing_required` config knob; `NEGOTIATE` advertises `SIGNING_ENABLED|REQUIRED` when set (the harness enables it only for this suite, so other suites are unaffected).
- `FSCTL_VALIDATE_NEGOTIATE_INFO` now mirrors `NEGOTIATE`'s `SecurityMode` — the hardcoded value looked like a downgrade attack and the client dropped the connection.
- Skip dispatch-time signature verification for `SESSION_SETUP` (the final NTLM message is signed with a key only derived while processing it).

### `smb2.session` (partial — 13/24 fixed, still disabled)
Now passing: `reconnect2`, `reauth1`-`reauth4`, and all 8 `bind_negative_*`.
- Grant batch/exclusive oplocks as requested (W/H caching), reversing the LEVEL_II-only policy — required by the reconnect/reauth/bind file-setup helpers.
- Implement `FILE_POSITION_INFO` query (used as the session liveness probe).
- Honor `PreviousSessionId`: expire the prior session on reconnect.
- Accept anonymous NTLM auth (empty NT response -> nobody, no signing key).
- Resolve sessions per-connection and validate multichannel bind eligibility (dialect < 3.0 -> `REQUEST_NOT_ACCEPTED`, dialect mismatch -> `INVALID_PARAMETER`, non-bind cross-connection reference -> `USER_SESSION_DELETED`); add the SMB 2.02 dialect.

### Remaining `smb2.session` work (left disabled)
- SMB3 encryption (`anon-encryption1/2/3`)
- Positive multichannel bind reply signing / SPNEGO detail (`bind1`, `bind2`, `bind_invalid_auth`)
- Cross-connection session teardown (`reconnect1`, `reauth6`)
- `reauth5` (anonymous perms + pattern-unlink), `ntlmssp_bug14932`, `anon-signing2`

### Note on oplocks
Granting batch/exclusive oplocks reverses a documented decision that withheld write/handle caching to keep server-side copy and delete-of-open-file correct (the KVM cthon/fsx suites). The trade-off is called out in the code comment; flush-before-copy and delete-pending semantics are still needed before those caching modes are fully safe.