### PR TITLE
smb: negotiate SMB 3.1.1 with preauth integrity and signing

### DIFF
--- a/src/server/server.c
+++ b/src/server/server.c
@@ -115,10 +115,11 @@ chimera_server_config_init(void)
     config->soft_fail_bad_req        = 0;
     config->tcp_flavor               = CHIMERA_TCP_FLAVOR_PLAIN;
 
-    config->smb_num_dialects = 3;
+    config->smb_num_dialects = 4;
     config->smb_dialects[0]  = SMB2_DIALECT_2_1;
     config->smb_dialects[1]  = SMB2_DIALECT_3_0;
     config->smb_dialects[2]  = SMB2_DIALECT_3_0_2;
+    config->smb_dialects[3]  = SMB2_DIALECT_3_1_1;
 
     config->smb_num_nic_info = 0;
 

--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -256,8 +256,9 @@ chimera_smb_compound_reply(struct chimera_smb_compound *compound)
     struct smb2_header               *reply_hdr;
     struct smb_direct_hdr            *direct_hdr = NULL;
     struct chimera_smb_request       *request;
-    uint32_t                         *prev_command = NULL;
-    uint16_t                          prev_hdr     = 0;
+    uint32_t                         *prev_command     = NULL;
+    uint16_t                          prev_hdr         = 0;
+    uint32_t                          preauth_fold_len = 0;
     struct evpl_iovec                 chunk_iov[3];
     int                               i, rc, chunk_niov;
     int                               reply_hdr_len, reply_payload_length, left, chunk;
@@ -292,6 +293,18 @@ chimera_smb_compound_reply(struct chimera_smb_compound *compound)
 
         if ((conn->flags & CHIMERA_SMB_CONN_FLAG_SIGNING_REQUIRED) &&
             request->session_handle) {
+            request->flags |= CHIMERA_SMB_REQUEST_FLAG_SIGN;
+        }
+
+        /* The final SESSION_SETUP response that establishes an authenticated
+         * session MUST be signed once a signing key exists, even when signing
+         * is only enabled (not required). SMB 3.x clients verify this response
+         * to confirm the server holds the session key; for SMB 3.1.1 it also
+         * binds the preauth-integrity hash. */
+        if (request->smb2_hdr.command == SMB2_SESSION_SETUP &&
+            request->status == SMB2_STATUS_SUCCESS &&
+            request->session_handle &&
+            (request->session_handle->session->flags & CHIMERA_SMB_SESSION_AUTHORIZED)) {
             request->flags |= CHIMERA_SMB_REQUEST_FLAG_SIGN;
         }
 
@@ -401,7 +414,19 @@ chimera_smb_compound_reply(struct chimera_smb_compound *compound)
             } /* switch */
         }
 
-        evpl_iovec_cursor_zero(&reply_cursor, (8 - (evpl_iovec_cursor_consumed(&reply_cursor) & 7)) & 7);
+        /* Length of this response with no trailing alignment padding, captured
+         * before padding for the SMB 3.1.1 preauth-integrity fold below. */
+        preauth_fold_len = evpl_iovec_cursor_consumed(&reply_cursor);
+
+        /* Pad each response to an 8-byte boundary so the next compounded
+         * response's header is aligned. NEGOTIATE and SESSION_SETUP are never
+         * compounded and feed the SMB 3.1.1 preauth-integrity hash, which the
+         * client computes over the message *as received* (no trailing pad):
+         * emit them in canonical form so our hash matches the client's. */
+        if (request->smb2_hdr.command != SMB2_NEGOTIATE &&
+            request->smb2_hdr.command != SMB2_SESSION_SETUP) {
+            evpl_iovec_cursor_zero(&reply_cursor, (8 - (evpl_iovec_cursor_consumed(&reply_cursor) & 7)) & 7);
+        }
 
     }
 
@@ -431,7 +456,25 @@ chimera_smb_compound_reply(struct chimera_smb_compound *compound)
         return;
     }
 
+    /* SMB 3.1.1 preauth integrity: fold the NEGOTIATE / SESSION_SETUP response
+    * into the running hash. The hash covers the canonical (unpadded) message,
+    * so use preauth_fold_len rather than the padded payload length — Windows
+    * and WPTS hash the message without trailing alignment padding. These
+    * responses are not compounded and carry no injected payload, so the whole
+    * SMB2 message is contiguous in reply_iov[0] after the transport header. */
+    if (compound->num_requests > 0 &&
+        (compound->requests[0]->smb2_hdr.command == SMB2_NEGOTIATE ||
+         compound->requests[0]->smb2_hdr.command == SMB2_SESSION_SETUP)) {
+        chimera_smb_preauth_extend(conn->preauth_hash,
+                                   (uint8_t *) evpl_iovec_data(&reply_iov[0]) + reply_hdr_len,
+                                   preauth_fold_len);
+    }
+
     if (conn->protocol == EVPL_DATAGRAM_RDMACM_RC) {
+
+        /* direct_hdr was set above under this same protocol check; assert the
+         * invariant so it is not a bare conditional dereference. */
+        chimera_smb_abort_if(direct_hdr == NULL, "RDMA reply without SMB-Direct header");
 
         left = reply_payload_length;
 
@@ -720,6 +763,9 @@ chimera_smb_server_handle_smb2(
     struct chimera_smb_session_handle *session_handle;
     struct chimera_smb_session        *session;
     struct evpl_iovec_cursor           signature_cursor;
+    /* Snapshot of the cursor at the SMB2 message start, for the 3.1.1
+     * preauth-integrity hash (covers the whole received message). */
+    struct evpl_iovec_cursor           preauth_cursor = *request_cursor;
     int                                more_requests, rc, left = length, payload_length;
 
     compound = chimera_smb_compound_alloc(thread);
@@ -974,6 +1020,21 @@ chimera_smb_server_handle_smb2(
     }
 
     smb_dump_compound_request(compound);
+
+    /* SMB 3.1.1 preauth integrity: fold the raw NEGOTIATE / SESSION_SETUP
+     * request into the running hash before dispatch, so the SESSION_SETUP
+     * handler derives the signing key over a hash that includes this request.
+     * Maintained unconditionally for these commands; only consumed at 3.1.1. */
+    if (compound->num_requests > 0 &&
+        (compound->requests[0]->smb2_hdr.command == SMB2_NEGOTIATE ||
+         compound->requests[0]->smb2_hdr.command == SMB2_SESSION_SETUP)) {
+        uint8_t *msg = malloc(length);
+        if (msg) {
+            evpl_iovec_cursor_copy(&preauth_cursor, msg, length);
+            chimera_smb_preauth_extend(conn->preauth_hash, msg, length);
+            free(msg);
+        }
+    }
 
     chimera_smb_compound_advance(compound);
 
@@ -1321,6 +1382,8 @@ chimera_smb_server_accept(
     conn->ntlm_output_len   = 0;
     smb_ntlm_ctx_init(&conn->ntlm_ctx);
     memset(&conn->gssapi_ctx, 0, sizeof(conn->gssapi_ctx));
+    /* SMB 3.1.1 preauth-integrity hash starts at zero for each connection. */
+    memset(conn->preauth_hash, 0, sizeof(conn->preauth_hash));
     conn->rdma_niov   = 0;
     conn->rdma_length = 0;
 

--- a/src/server/smb/smb2.h
+++ b/src/server/smb/smb2.h
@@ -621,6 +621,9 @@ typedef uint8_t smb2_guid[SMB2_GUID_SIZE];
 /* SMB2_PREAUTH_INTEGRITY_CAPABILITIES HashAlgorithm IDs */
 #define SMB2_PREAUTH_HASH_SHA_512                   0x0001
 
+/* SHA-512 produces a 64-byte preauth-integrity hash value. */
+#define SMB2_PREAUTH_HASH_SIZE                      64
+
 /* SMB2_ENCRYPTION_CAPABILITIES Cipher IDs */
 #define SMB2_ENCRYPTION_AES_128_CCM                 0x0001
 #define SMB2_ENCRYPTION_AES_128_GCM                 0x0002

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -563,6 +563,10 @@ struct chimera_smb_conn {
     uint8_t                            client_guid[16];
     uint8_t                            client_security_mode;
     uint32_t                           client_capabilities;
+    /* SMB 3.1.1 preauth-integrity running hash (SHA-512), extended over the
+     * NEGOTIATE and SESSION_SETUP request/response chain. Reset per connection
+     * at accept. Only consumed when the negotiated dialect is 3.1.1. */
+    uint8_t                            preauth_hash[SMB2_PREAUTH_HASH_SIZE];
     uint32_t                           requests_completed;
     int                                rdma_max_send;
     int                                rdma_niov;

--- a/src/server/smb/smb_ntlm.c
+++ b/src/server/smb/smb_ntlm.c
@@ -593,7 +593,10 @@ validate_local_user(
     const char                    *username,
     const char                    *domain,
     const uint8_t                 *nt_response,
-    size_t                         nt_response_len)
+    size_t                         nt_response_len,
+    uint32_t                       negotiate_flags,
+    const uint8_t                 *enc_session_key,
+    size_t                         enc_session_key_len)
 {
     const uint8_t *client_blob;
     size_t         client_blob_len;
@@ -644,11 +647,36 @@ validate_local_user(
         return -1;
     }
 
-    // Compute session key = HMAC-MD5(ntlmv2_hash, NTProofStr)
+    // Compute the key-exchange key = HMAC-MD5(ntlmv2_hash, NTProofStr).
+    // For NTLMv2 this is also the session base key.
     if (!HMAC(EVP_md5(), ntlmv2_hash, 16, nt_response, 16,
               ctx->session_key, &hmac_len)) {
         smb_ntlm_error("NTLM: Failed to compute session key");
         return -1;
+    }
+
+    /* If the client negotiated key exchange, the actual session key is a
+     * random value the client generated and sent RC4-wrapped with the
+     * key-exchange key (MS-NLMP 3.4.5.1). Recover it; otherwise the
+     * key-exchange key is used directly as the session key. */
+    if ((negotiate_flags & NTLMSSP_NEGOTIATE_KEY_EXCH) &&
+        enc_session_key_len == 16) {
+        uint8_t         exported_key[16];
+        int             outl = 0;
+        EVP_CIPHER_CTX *rc4  = EVP_CIPHER_CTX_new();
+
+        if (!rc4 ||
+            EVP_DecryptInit_ex(rc4, EVP_rc4(), NULL, ctx->session_key, NULL) != 1 ||
+            EVP_DecryptUpdate(rc4, exported_key, &outl, enc_session_key, 16) != 1 ||
+            outl != 16) {
+            if (rc4) {
+                EVP_CIPHER_CTX_free(rc4);
+            }
+            smb_ntlm_error("NTLM: Failed to unwrap exported session key");
+            return -1;
+        }
+        EVP_CIPHER_CTX_free(rc4);
+        memcpy(ctx->session_key, exported_key, 16);
     }
 
     // Store user info
@@ -736,12 +764,36 @@ validate_authenticate(
     }
     nt_response = buf + nt_response_offset;
 
+    // EncryptedRandomSessionKey field (offset 52) and NegotiateFlags (offset 60).
+    // Both live in the fixed AUTHENTICATE header (>= 64 bytes when present); a
+    // short LMv2-only message may omit them, so guard the read.
+    uint32_t       negotiate_flags     = 0;
+    const uint8_t *enc_session_key     = NULL;
+    size_t         enc_session_key_len = 0;
+
+    if (buf_len >= 64) {
+        uint16_t eskey_len;
+        uint32_t eskey_offset;
+
+        memcpy(&eskey_len, buf + 52, 2);
+        memcpy(&eskey_offset, buf + 56, 4);
+        memcpy(&negotiate_flags, buf + 60, 4);
+
+        if (eskey_len > 0 &&
+            (size_t) eskey_offset + eskey_len <= buf_len) {
+            enc_session_key     = buf + eskey_offset;
+            enc_session_key_len = eskey_len;
+        }
+    }
+
     // First, try to look up user in local VFS cache
     user = chimera_vfs_lookup_user_by_name(vfs, username);
     if (user && user->smbpasswd[0]) {
         // Found a local user with SMB password - validate locally
         result = validate_local_user(ctx, user, username, domain,
-                                     nt_response, nt_response_len);
+                                     nt_response, nt_response_len,
+                                     negotiate_flags, enc_session_key,
+                                     enc_session_key_len);
         goto cleanup;
     }
 

--- a/src/server/smb/smb_proc_negotiate.c
+++ b/src/server/smb/smb_proc_negotiate.c
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
+#include <openssl/rand.h>
+
 #include "smb_internal.h"
 #include "smb_procs.h"
 
@@ -120,6 +122,28 @@ chimera_smb_negotiate(struct chimera_smb_request *request)
 
     conn->dialect = dialect;
 
+    /* SMB 3.1.1 mandates a PreauthIntegrityCapabilities context offering a
+     * hash algorithm we support (SHA-512). Per MS-SMB2 3.3.5.4, a 3.1.1
+     * NEGOTIATE without it (or offering no supported hash) fails with
+     * STATUS_INVALID_PARAMETER. */
+    if (dialect == SMB2_DIALECT_3_1_1) {
+        int have_sha512 = 0;
+
+        if (request->negotiate.ctx_present_mask & CHIMERA_SMB_NEGOTIATE_CTX_PREAUTH) {
+            for (i = 0; i < request->negotiate.preauth_in.hash_alg_count; i++) {
+                if (request->negotiate.preauth_in.hash_algs[i] == SMB2_PREAUTH_HASH_SHA_512) {
+                    have_sha512 = 1;
+                    break;
+                }
+            }
+        }
+
+        if (!have_sha512) {
+            chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
+            return;
+        }
+    }
+
     /* Record the client's negotiate parameters so a later
      * FSCTL_VALIDATE_NEGOTIATE_INFO can be checked against them. */
     memcpy(conn->client_guid, request->negotiate.client_guid, SMB2_GUID_SIZE);
@@ -180,27 +204,46 @@ struct chimera_smb_negotiate_response_emitter {
         uint32_t                    out_size);
 };
 
-/* Phase 0 ships an empty table on purpose. We have the plumbing to emit
- * negotiate response contexts, but nothing positive to advertise yet:
- *   - PreauthIntegrity, Encryption, Signing → Phase 2
- *   - Compression                            → Phase 8
- *   - RdmaTransform                          → Phase 5
- *   - Transport/Netname are not server-reply contexts in any phase.
- * Phase 2 will register builders here.
+/* Build the SMB2_PREAUTH_INTEGRITY_CAPABILITIES response context:
+ *   HashAlgorithmCount(2)=1, SaltLength(2)=32, HashAlgorithms[1](2)=SHA-512,
+ *   Salt(32). */
+static int
+build_preauth_integrity_response(
+    struct chimera_smb_conn    *conn,
+    struct chimera_smb_request *request,
+    uint8_t                    *out,
+    uint32_t                    out_size)
+{
+    const uint16_t salt_len = sizeof(conn->negotiated.preauth_salt);
+
+    (void) request;
+
+    if (out_size < (uint32_t) (6 + salt_len)) {
+        return -1;
+    }
+
+    out[0] = 1;    out[1] = 0;                            /* HashAlgorithmCount */
+    out[2] = salt_len & 0xff; out[3] = (salt_len >> 8) & 0xff; /* SaltLength */
+    out[4] = SMB2_PREAUTH_HASH_SHA_512 & 0xff;
+    out[5] = (SMB2_PREAUTH_HASH_SHA_512 >> 8) & 0xff;     /* HashAlgorithms[0] */
+    memcpy(out + 6, conn->negotiated.preauth_salt, salt_len);
+
+    return 6 + salt_len;
+} /* build_preauth_integrity_response */
+
+/* The negotiate-response context emitters. Only consulted when the negotiated
+ * dialect is 3.1.1; each entry emits only if the client sent the matching
+ * request context (need_mask_bit).
  *
- * !! Do NOT add SMB 3.1.1 to server.c's default dialect list until Phase 2
- * lands preauth integrity. With this table empty, a successful 3.1.1
- * negotiation produces a reply that is structurally legal (NegotiateContext-
- * Count=0, Offset=0) but spec-noncompliant: 3.1.1 mandates that the server
- * emit a PreauthIntegrityCapabilities reply. Lenient clients (current
- * Win11, macOS, libsmb2) tolerate the missing context and then derive
- * session-keys using SMB 3.0-style KDF — which diverges from the client's
- * preauth-bound derivation. The first signed message after SESSION_SETUP
- * fails MAC verification on both ends and the connection dies. The dialect
- * ceiling stays at 3.0 in server.c:103-105 specifically to keep this latent
- * mismatch unreachable. */
+ * PreauthIntegrity is implemented: the server selects SHA-512, returns a salt,
+ * maintains Connection.PreauthIntegrityHashValue across NEGOTIATE/SESSION_SETUP
+ * (smb.c), and derives the 3.1.1 signing key bound to that hash. Encryption,
+ * Signing (GMAC), Compression and RdmaTransform contexts are not yet emitted
+ * (encryption/compression deferred). */
 static const struct chimera_smb_negotiate_response_emitter smb_negotiate_response_emitters[] = {
-    { 0, 0, NULL }
+    { CHIMERA_SMB_NEGOTIATE_CTX_PREAUTH, SMB2_PREAUTH_INTEGRITY_CAPABILITIES,
+      build_preauth_integrity_response },
+    { 0,                                 0,                                  NULL }
 };
 
 /* Build the negotiate context list into ctx_buf. Returns total bytes written
@@ -214,8 +257,9 @@ chimera_smb_build_negotiate_response_contexts(
     uint32_t                    ctx_buf_size,
     uint16_t                   *out_count)
 {
-    uint32_t                                             pos   = 0;
-    uint16_t                                             count = 0;
+    uint32_t                                             pos      = 0;
+    uint32_t                                             last_end = 0;
+    uint16_t                                             count    = 0;
     const struct chimera_smb_negotiate_response_emitter *e;
 
     if (request->negotiate.r_dialect != SMB2_DIALECT_3_1_1) {
@@ -241,12 +285,19 @@ chimera_smb_build_negotiate_response_contexts(
         if (advance == 0) {
             break;
         }
-        pos += advance;
+        /* The 8-byte alignment padding belongs *between* contexts, so the next
+         * context starts aligned. The message itself MUST end at the last
+         * context's data (no trailing pad) — Windows/Samba emit it that way,
+         * and strict clients (e.g. WPTS) re-serialize to that canonical form
+         * when computing the SMB 3.1.1 preauth-integrity hash. Track the end
+         * of the current context's data and return that as the list length. */
+        last_end = pos + 8u + (uint32_t) data_len;
+        pos     += advance;
         count++;
     }
 
     *out_count = count;
-    return pos;
+    return last_end;
 } /* chimera_smb_build_negotiate_response_contexts */
 
 void
@@ -625,9 +676,6 @@ chimera_smb_select_negotiated_algorithms(
 {
     conn->negotiated.ctx_present_mask = request->negotiate.ctx_present_mask;
 
-    /* Phase 0 selects nothing new. Phase 2 will replace these zeros with the
-     * highest-preference algorithm the client offered that we implement.
-     * Leave the salt zeroed for now — Phase 2 generates a real one. */
     conn->negotiated.preauth_hash_alg      = 0;
     conn->negotiated.cipher_id             = 0;
     conn->negotiated.signing_alg           = 0;
@@ -637,6 +685,20 @@ chimera_smb_select_negotiated_algorithms(
     memset(conn->negotiated.preauth_salt,    0, sizeof(conn->negotiated.preauth_salt));
     memset(conn->negotiated.compression_algs, 0, sizeof(conn->negotiated.compression_algs));
     memset(conn->negotiated.rdma_transforms,  0, sizeof(conn->negotiated.rdma_transforms));
+
+    /* SMB 3.1.1: select SHA-512 preauth integrity and generate a server salt.
+     * The salt value need not match anything the client derives independently —
+     * both sides fold the negotiate *response* (which carries this salt) into
+     * the preauth hash, so any value works as long as it is the one we send.
+     * Encryption/compression/RDMA-transform selection remains deferred. */
+    if (conn->dialect == SMB2_DIALECT_3_1_1 &&
+        (request->negotiate.ctx_present_mask & CHIMERA_SMB_NEGOTIATE_CTX_PREAUTH)) {
+        conn->negotiated.preauth_hash_alg = SMB2_PREAUTH_HASH_SHA_512;
+        if (RAND_bytes(conn->negotiated.preauth_salt,
+                       sizeof(conn->negotiated.preauth_salt)) != 1) {
+            memset(conn->negotiated.preauth_salt, 0, sizeof(conn->negotiated.preauth_salt));
+        }
+    }
 } /* chimera_smb_select_negotiated_algorithms */
 
 int

--- a/src/server/smb/smb_proc_session_setup.c
+++ b/src/server/smb/smb_proc_session_setup.c
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
-#include <stdio.h>
-
 #include "smb_internal.h"
 #include "smb_procs.h"
 #include "smb_signing.h"
@@ -137,28 +135,35 @@ chimera_smb_session_setup(struct chimera_smb_request *request)
             break;
     } /* switch */
 
+    /* Allocate the session (and its SessionId) on the first leg, whether the
+     * exchange completes now or needs another round trip. The server MUST
+     * return this SessionId in the interim STATUS_MORE_PROCESSING_REQUIRED
+     * response so the client echoes it on subsequent legs (MS-SMB2 3.3.5.5).
+     * Crucially for SMB 3.1.1, the client keys its session preauth-integrity
+     * hash by the response's SessionId: a zero id on the interim response
+     * splits the hash across buckets and breaks signing-key derivation. */
+    if ((rc == 0 || rc == 1) && !request->session_handle) {
+        session = chimera_smb_session_alloc(shared);
+
+        session_handle = chimera_smb_session_handle_alloc(thread);
+
+        session_handle->session_id = session->session_id;
+        session_handle->session    = session;
+
+        chimera_smb_debug("chimera_smb_session_setup adding session_handle %p\n",
+                          session_handle);
+
+        HASH_ADD(hh, conn->session_handles, session_id, sizeof(uint64_t), session_handle);
+
+        session_handle->ctx = GSS_C_NO_CONTEXT;
+
+        request->compound->conn->last_session_handle = session_handle;
+
+        request->session_handle = session_handle;
+    }
+
     if (rc == 0) {
         // Authentication complete
-        if (!request->session_handle) {
-            session = chimera_smb_session_alloc(shared);
-
-            session_handle = chimera_smb_session_handle_alloc(thread);
-
-            session_handle->session_id = session->session_id;
-            session_handle->session    = session;
-
-            chimera_smb_debug("chimera_smb_session_setup adding session_handle %p\n",
-                              session_handle);
-
-            HASH_ADD(hh, conn->session_handles, session_id, sizeof(uint64_t), session_handle);
-
-            session_handle->ctx = GSS_C_NO_CONTEXT;
-
-            request->compound->conn->last_session_handle = session_handle;
-
-            request->session_handle = session_handle;
-        }
-
         session_handle = request->session_handle;
         session        = session_handle->session;
 
@@ -175,7 +180,9 @@ chimera_smb_session_setup(struct chimera_smb_request *request)
                 chimera_smb_derive_signing_key(conn->dialect,
                                                session_handle->signing_key,
                                                session_key,
-                                               SMB_NTLM_SESSION_KEY_SIZE);
+                                               SMB_NTLM_SESSION_KEY_SIZE,
+                                               conn->dialect == SMB2_DIALECT_3_1_1 ?
+                                               conn->preauth_hash : NULL);
             }
 
             uid        = smb_ntlm_get_uid(&conn->ntlm_ctx);
@@ -206,7 +213,9 @@ chimera_smb_session_setup(struct chimera_smb_request *request)
                 chimera_smb_derive_signing_key(conn->dialect,
                                                session_handle->signing_key,
                                                session_key,
-                                               SMB_GSSAPI_SESSION_KEY_SIZE);
+                                               SMB_GSSAPI_SESSION_KEY_SIZE,
+                                               conn->dialect == SMB2_DIALECT_3_1_1 ?
+                                               conn->preauth_hash : NULL);
             }
 
             // Map Kerberos principal to Unix credentials via winbind
@@ -271,6 +280,11 @@ chimera_smb_session_setup(struct chimera_smb_request *request)
 
         if (request->session_handle &&
             (!(request->session_handle->session->flags & CHIMERA_SMB_SESSION_AUTHORIZED))) {
+            /* The handle was registered in conn->session_handles when the
+             * session was allocated (possibly on an earlier interim leg), so
+             * remove it there before freeing — otherwise connection teardown
+             * iterates it again and double-releases the session. */
+            HASH_DEL(conn->session_handles, request->session_handle);
             chimera_smb_session_release(thread, shared, request->session_handle->session);
             chimera_smb_session_handle_free(thread, request->session_handle);
             request->session_handle   = NULL;

--- a/src/server/smb/smb_signing.c
+++ b/src/server/smb/smb_signing.c
@@ -116,15 +116,39 @@ kdf_counter_hmac_sha256_ossl3(
     return ok;
 } /* kdf_counter_hmac_sha256_ossl3 */
 
+/* Extend an SMB 3.1.1 preauth-integrity hash: hash = SHA512(hash || msg).
+ * `hash` is the running 64-byte value, updated in place. */
+void
+chimera_smb_preauth_extend(
+    uint8_t    *hash,
+    const void *msg,
+    uint32_t    msg_len)
+{
+    EVP_MD_CTX  *md      = EVP_MD_CTX_new();
+    unsigned int out_len = 0;
+
+    chimera_smb_abort_if(!md, "EVP_MD_CTX_new failed");
+
+    if (EVP_DigestInit_ex(md, EVP_sha512(), NULL) != 1 ||
+        EVP_DigestUpdate(md, hash, SMB2_PREAUTH_HASH_SIZE) != 1 ||
+        EVP_DigestUpdate(md, msg, msg_len) != 1 ||
+        EVP_DigestFinal_ex(md, hash, &out_len) != 1) {
+        chimera_smb_abort("SHA-512 preauth hash update failed");
+    }
+    EVP_MD_CTX_free(md);
+} /* chimera_smb_preauth_extend */
+
 int
 chimera_smb_derive_signing_key(
-    int    dialect,
-    void  *output,
-    void  *session_key,
-    size_t session_key_len)
+    int            dialect,
+    void          *output,
+    void          *session_key,
+    size_t         session_key_len,
+    const uint8_t *preauth_hash)
 {
-    static const char label30[] = "SMB2AESCMAC";  /* include NUL per spec */
-    static const char ctx30[]   = "SmbSign";      /* include NUL per spec */
+    static const char label30[]  = "SMB2AESCMAC";   /* include NUL per spec */
+    static const char ctx30[]    = "SmbSign";       /* include NUL per spec */
+    static const char label311[] = "SMBSigningKey"; /* include NUL per spec */
 
     switch (dialect) {
         case SMB2_DIALECT_2_0_2:
@@ -143,6 +167,21 @@ chimera_smb_derive_signing_key(
             return kdf_counter_hmac_sha256_ossl3(session_key, session_key_len,
                                                  label30, sizeof(label30), /* includes '\0' */
                                                  (const uint8_t *) ctx30, sizeof(ctx30), /* includes '\0' */
+                                                 output, 16);
+        case SMB2_DIALECT_3_1_1:
+            /* 3.1.1 binds the signing key to the preauth-integrity hash:
+             * label "SMBSigningKey", context = PreauthIntegrityHashValue. */
+            if (!preauth_hash) {
+                chimera_smb_error("SMB 3.1.1 signing key derivation without preauth hash");
+                return -1;
+            }
+            /* Per the WPTS/Windows reference, the label includes its NUL
+             * terminator ("SMBSigningKey\0"); the KDF helper then inserts the
+             * SP800-108 0x00 separator before the PreauthIntegrityHashValue
+             * context. Pass the full sizeof (label + NUL). */
+            return kdf_counter_hmac_sha256_ossl3(session_key, session_key_len,
+                                                 label311, sizeof(label311),
+                                                 preauth_hash, SMB2_PREAUTH_HASH_SIZE,
                                                  output, 16);
         default:
             return -1;
@@ -341,6 +380,7 @@ chimera_smb_verify_signature(
             break;
         case SMB2_DIALECT_3_0:
         case SMB2_DIALECT_3_0_2:
+        case SMB2_DIALECT_3_1_1:
             rc = chimera_smb_request_cmac_aes_128_cbc(
                 ctx,
                 &request->smb2_hdr,
@@ -453,6 +493,7 @@ chimera_smb_sign_compound(
                     break;
                 case SMB2_DIALECT_3_0:
                 case SMB2_DIALECT_3_0_2:
+                case SMB2_DIALECT_3_1_1:
                     rc = chimera_smb_request_cmac_aes_128_cbc(
                         ctx,
                         hdr,

--- a/src/server/smb/smb_signing.h
+++ b/src/server/smb/smb_signing.h
@@ -20,10 +20,18 @@ chimera_smb_signing_ctx_destroy(
 
 int
 chimera_smb_derive_signing_key(
-    int    dialect,
-    void  *output,
-    void  *session_key,
-    size_t session_key_len);
+    int            dialect,
+    void          *output,
+    void          *session_key,
+    size_t         session_key_len,
+    const uint8_t *preauth_hash);
+
+/* Extend an SMB 3.1.1 preauth-integrity hash in place: hash = SHA512(hash||msg). */
+void
+chimera_smb_preauth_extend(
+    uint8_t    *hash,
+    const void *msg,
+    uint32_t    msg_len);
 
 
 int


### PR DESCRIPTION
Enables SMB 3.1.1 as the top advertised dialect and makes signed 3.1.1 sessions verify end to end. Implementing the rest of the 3.1.1 feature set (encryption, compression, RDMA transform, etc.) is out of scope — this is the minimum needed for the protocol version to negotiate and sign correctly.

Validated against the MS-SMB2 WPTS conformance suite — all 39 `wpts/memfs` cases pass, including `BVT_Signing`, `Signing_VerifyAesGmacSigning`, and `Negotiate_SMB311_ContextID_NetName` / `_InvalidCipher` / `_IsTransportCapabilitiesSupported` — and against `smbclient`. No regressions in the existing SMB netns suite (auth, sharemode, smbclient NTLM).

### What's here

- **Negotiate:** require a `PreauthIntegrityCapabilities` context offering SHA-512 (else `STATUS_INVALID_PARAMETER`), and advertise SHA-512 plus a server salt in the response.
- **Preauth-integrity hashing over the canonical message.** The hash must cover the message *without* trailing alignment padding, the way Windows/WPTS compute it. NEGOTIATE/SESSION_SETUP responses are emitted in canonical form (no trailing 8-byte alignment pad, and no trailing negotiate-context pad), and the running hash folds the unpadded length. Other responses keep their alignment padding.
- **Stable SessionId across auth legs.** Allocate the session and its SessionId on the first SESSION_SETUP leg and return it in the interim `STATUS_MORE_PROCESSING_REQUIRED` response. The client keys its session preauth hash by the response's SessionId, so a zero id on the interim leg split the hash into the wrong bucket and broke signing-key derivation. A failed leg now removes the handle from `conn->session_handles` before freeing it, so connection teardown can't double-release the session.
- **Sign the final SESSION_SETUP success response** whenever a signing key exists (not only when signing is *required*); SMB 3.x clients verify it to confirm the server holds the session key.
- **NTLMSSP_NEGOTIATE_KEY_EXCH:** recover the client's RC4-wrapped `ExportedSessionKey` rather than signing with the key-exchange key. (Not exercised by the current test clients, which don't negotiate key exchange, but fixes a latent interop gap.)