### PR TITLE
nfs: handle write special cases on memfs

### DIFF
--- a/src/server/nfs/nfs4_proc_write.c
+++ b/src/server/nfs/nfs4_proc_write.c
@@ -11,12 +11,10 @@
 #include "evpl/evpl.h"
 
 static inline int
-chimera_nfs4_write_stateid_is_anonymous(const struct stateid4 *sid)
+chimera_nfs4_write_stateid_is_special(const struct stateid4 *sid)
 {
-    static const uint8_t zero[12] = { 0 };
-
-    return sid->seqid == 0 && memcmp(sid->other, zero, sizeof(zero)) == 0;
-} /* chimera_nfs4_write_stateid_is_anonymous */
+    return nfs4_stateid_is_special(sid);
+} /* chimera_nfs4_write_stateid_is_special */
 
 static void
 chimera_nfs4_write_complete(
@@ -127,15 +125,15 @@ chimera_nfs4_write(
     evpl_rpc2_encoding_take_read_chunk(req->encoding, NULL, NULL);
 
     /*
-     * RFC 7530 9.1.4.3 / RFC 8881 8.2.3 require WRITE to honor the
-     * anonymous stateid (all zeros).  Open the current FH on the fly
-     * instead of consulting the state table.
+     * RFC 7530 9.1.4.3 / RFC 8881 8.2.3 require WRITE to honor special
+     * stateids.  Open the current FH on the fly instead of consulting the
+     * state table.
      *
      * A pNFS data server does not hold open state for the files it stores --
      * the metadata server authorizes the client's I/O via the layout -- so it
      * likewise serves WRITE by file handle without a state-table lookup.
      */
-    if (chimera_nfs4_write_stateid_is_anonymous(&args->stateid) ||
+    if (chimera_nfs4_write_stateid_is_special(&args->stateid) ||
         chimera_server_config_get_nfs_data_server(thread->shared->config)) {
         if (req->fhlen == 0) {
             res->status = NFS4ERR_NOFILEHANDLE;

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -997,6 +997,34 @@ memfs_apply_attrs(
 
 } /* memfs_apply_attrs */
 
+static int
+memfs_cred_can_write(
+    const struct memfs_inode      *inode,
+    const struct chimera_vfs_cred *cred)
+{
+    if (cred->uid == 0) {
+        return 1;
+    }
+
+    if ((uint64_t) cred->uid == inode->uid) {
+        return !!(inode->mode & S_IWUSR);
+    }
+
+    int in_group = ((uint64_t) cred->gid == inode->gid);
+
+    for (uint32_t i = 0; !in_group && i < cred->ngids; i++) {
+        if ((uint64_t) cred->gids[i] == inode->gid) {
+            in_group = 1;
+        }
+    }
+
+    if (in_group) {
+        return !!(inode->mode & S_IWGRP);
+    }
+
+    return !!(inode->mode & S_IWOTH);
+} /* memfs_cred_can_write */
+
 static void
 memfs_getattr(
     struct memfs_thread        *thread,
@@ -2321,6 +2349,21 @@ memfs_write(
             request->complete(request);
             return;
         }
+    }
+
+    if (!S_ISREG(inode->mode)) {
+        request->status = S_ISDIR(inode->mode) ?
+            CHIMERA_VFS_EISDIR : CHIMERA_VFS_EINVAL;
+        pthread_mutex_unlock(&inode->lock);
+        request->complete(request);
+        return;
+    }
+
+    if (!memfs_cred_can_write(inode, request->cred)) {
+        request->status = CHIMERA_VFS_EACCES;
+        pthread_mutex_unlock(&inode->lock);
+        request->complete(request);
+        return;
     }
 
     memfs_map_attrs(shared, &request->write.r_pre_attr, inode, request->fh);


### PR DESCRIPTION
Handles the PyNFS WRITE special cases that were narrow memfs/NFS gaps: all-ones special stateid is accepted like the other special bypass stateid, memfs rejects writes to non-regular files, and memfs WRITE checks current credentials before honoring an open stateid.

Validation:
- cmake --build build --target chimera
- ctest --test-dir build -R 'chimera/pynfs/write_memfs_nfs4\.0$' --output-on-failure

Result: WRT2, WRT6s, and WRT19 now pass. The full suite still times out at WRT15 under the 60s PyNFS wrapper timeout.

Note: the focused ctest run used the local memfs-suite enablement change for validation only; that registration change is not part of this PR.