### PR TITLE
nfs: validate OPEN_DOWNGRADE share history

### DIFF
--- a/src/server/nfs/nfs4_proc_open_downgrade.c
+++ b/src/server/nfs/nfs4_proc_open_downgrade.c
@@ -17,6 +17,14 @@
 #include "nfs4_state.h"
 #include "vfs/vfs_release.h"
 
+static uint32_t
+chimera_nfs4_open_share_history(uint32_t share)
+{
+    share &= (OPEN4_SHARE_ACCESS_READ | OPEN4_SHARE_ACCESS_WRITE);
+    return share == (OPEN4_SHARE_ACCESS_READ | OPEN4_SHARE_ACCESS_WRITE) ?
+           0x04 : share;
+} /* chimera_nfs4_open_share_history */
+
 void
 chimera_nfs4_open_downgrade(
     struct chimera_server_nfs_thread *thread,
@@ -93,10 +101,17 @@ chimera_nfs4_open_downgrade(
         }
     }
 
-    /* RFC 7530 §16.19.4: new bits must be a non-empty subset of current. */
+    /* RFC 7530 §16.19.4: new bits must be a non-empty subset of current and
+     * match the union of some subset of OPENs currently in effect.  The
+     * history bit maps BOTH to a separate bit so OPEN(BOTH) cannot be
+     * downgraded to READ unless READ was opened separately. */
     if (args->share_access == 0 ||
         (args->share_access & ~open_state->share_access) ||
-        (args->share_deny   & ~open_state->share_deny)) {
+        (args->share_deny   & ~open_state->share_deny) ||
+        (chimera_nfs4_open_share_history(args->share_access) &
+         ~open_state->share_access_hist) ||
+        (chimera_nfs4_open_share_history(args->share_deny) &
+         ~open_state->share_deny_hist)) {
         pthread_mutex_unlock(&owner->lock);
         nfs_state_table_release(table, open_state, NFS4_SLOT_TYPE_OPEN,
                                 thread->vfs_thread);
@@ -105,9 +120,11 @@ chimera_nfs4_open_downgrade(
         return;
     }
 
-    open_state->share_access = args->share_access;
-    open_state->share_deny   = args->share_deny;
-    open_state->seqid       += 1;
+    open_state->share_access      = args->share_access;
+    open_state->share_deny        = args->share_deny;
+    open_state->share_access_hist = chimera_nfs4_open_share_history(args->share_access);
+    open_state->share_deny_hist   = chimera_nfs4_open_share_history(args->share_deny);
+    open_state->seqid            += 1;
 
     nfs4_stateid_encode(&res->resok4.open_stateid,
                         open_state->seqid,

--- a/src/server/nfs/nfs4_state.c
+++ b/src/server/nfs/nfs4_state.c
@@ -695,6 +695,14 @@ nfs_open_owner_find_state(
     return state;
 } /* nfs_open_owner_find_state */
 
+static uint32_t
+nfs_open_share_history(uint32_t share)
+{
+    share &= (OPEN4_SHARE_ACCESS_READ | OPEN4_SHARE_ACCESS_WRITE);
+    return share == (OPEN4_SHARE_ACCESS_READ | OPEN4_SHARE_ACCESS_WRITE) ?
+           0x04 : share;
+} /* nfs_open_share_history */
+
 struct nfs_open_state *
 nfs_open_state_create(
     struct nfs_open_owner          *owner,
@@ -722,15 +730,17 @@ nfs_open_state_create(
 
     state->owner = owner;
     memcpy(state->fh, fh, fh_len);
-    state->fh_len       = fh_len;
-    state->share_access = share_access;
-    state->share_deny   = share_deny;
-    state->seqid        = 1;
-    state->shard        = shard;
-    state->slot_idx     = slot_idx;
-    state->generation   = gen;
-    state->handle       = handle_dup;
-    state->locks        = NULL;
+    state->fh_len            = fh_len;
+    state->share_access      = share_access;
+    state->share_deny        = share_deny;
+    state->share_access_hist = nfs_open_share_history(share_access);
+    state->share_deny_hist   = nfs_open_share_history(share_deny);
+    state->seqid             = 1;
+    state->shard             = shard;
+    state->slot_idx          = slot_idx;
+    state->generation        = gen;
+    state->handle            = handle_dup;
+    state->locks             = NULL;
     atomic_init(&state->refcount, 1);
     atomic_init(&state->destroyed, 0);
 
@@ -802,9 +812,11 @@ nfs_open_state_coalesce(
     struct nfs_state_table *table,
     struct stateid4        *out_stateid)
 {
-    state->share_access |= share_access;
-    state->share_deny   |= share_deny;
-    state->seqid        += 1;
+    state->share_access      |= share_access;
+    state->share_deny        |= share_deny;
+    state->share_access_hist |= nfs_open_share_history(share_access);
+    state->share_deny_hist   |= nfs_open_share_history(share_deny);
+    state->seqid             += 1;
 
     nfs4_stateid_encode(out_stateid, state->seqid,
                         NFS4_STATEID_TYPE_OPEN,

--- a/src/server/nfs/nfs4_state.h
+++ b/src/server/nfs/nfs4_state.h
@@ -253,6 +253,8 @@ struct nfs_open_state {
     uint16_t                        fh_len;
     uint32_t                        share_access;       /* OPEN4_SHARE_ACCESS_* */
     uint32_t                        share_deny;         /* OPEN4_SHARE_DENY_*   */
+    uint32_t                        share_access_hist;  /* 3-bit OPEN_DOWNGRADE history */
+    uint32_t                        share_deny_hist;    /* 3-bit OPEN_DOWNGRADE history */
     uint32_t                        seqid;              /* stateid.seqid */
 
     /* Slot identity (decoded from stateid.other). */
@@ -643,5 +645,4 @@ nfs_client_touch(struct nfs_client *client)
     atomic_store_explicit((_Atomic uint64_t *) &client->last_touch_ns,
                           nfs_lease_now_ns(), memory_order_relaxed);
 } /* nfs_client_touch */
-
 


### PR DESCRIPTION
Tracks the OPEN share-mode history needed by OPEN_DOWNGRADE so a coalesced OPEN(BOTH) cannot be downgraded to READ unless READ was also opened separately.

Validation:
- cmake --build build --target chimera
- ctest --test-dir build -R 'chimera/pynfs/opendowngrade_memfs_nfs4\.0$' --output-on-failure

Note: the focused ctest run used the local memfs-suite enablement change for validation only; that registration change is not part of this PR.