### PR TITLE
nfs: encode illegal compound op responses

### DIFF
--- a/src/server/nfs/nfs4_proc_compound.c
+++ b/src/server/nfs/nfs4_proc_compound.c
@@ -96,6 +96,9 @@ chimera_nfs4_compound_process(
                                             req->seen_sequence);
 
         if (gate != NFS4_OK) {
+            if (gate == NFS4ERR_OP_ILLEGAL) {
+                resop->resop = OP_ILLEGAL;
+            }
             chimera_nfs4_compound_complete(req, gate);
         } else {
             /* NFS4.1 current-stateid lifecycle (RFC 8881 §16.2.3.1.2):
@@ -291,6 +294,7 @@ chimera_nfs4_compound_process(
                     if (argop->argop >= OP_ACCESS && argop->argop <= OP_REMOVEXATTR) {
                         chimera_nfs4_compound_complete(req, NFS4ERR_NOTSUPP);
                     } else {
+                        resop->resop = OP_ILLEGAL;
                         chimera_nfs4_compound_complete(req, NFS4ERR_OP_ILLEGAL);
                     }
                     break;


### PR DESCRIPTION
Fixes the PyNFS compound undefined-op response by encoding OP_ILLEGAL as the response discriminant when returning NFS4ERR_OP_ILLEGAL, including the minor-version gate path.

Validation:
- cmake --build build --target chimera
- ctest --test-dir build -R 'chimera/pynfs/compound_memfs_nfs4\.(0|1|2)$' --output-on-failure

Note: the focused ctest run used the local memfs-suite enablement change for validation only; that registration change is not part of this PR.