### PR TITLE
memfs: fix NFS open-at edge cases

### DIFF
--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -1910,7 +1910,7 @@ memfs_open_at(
 
     if (!S_ISDIR(parent_inode->mode)) {
         pthread_mutex_unlock(&parent_inode->lock);
-        request->status = CHIMERA_VFS_ENOENT;
+        request->status = CHIMERA_VFS_ENOTDIR;
         request->complete(request);
         return;
     }
@@ -1979,6 +1979,13 @@ memfs_open_at(
             inode->size       = 0;
             inode->space_used = 0;
             memfs_apply_attrs(inode, request->open_at.set_attr);
+        } else if ((flags & CHIMERA_VFS_OPEN_CREATE) &&
+                   S_ISREG(inode->mode) &&
+                   (request->open_at.set_attr->va_set_mask & CHIMERA_VFS_ATTR_SIZE) &&
+                   request->open_at.set_attr->va_size == 0) {
+            memfs_inode_truncate_blocks(thread, inode);
+            inode->size       = 0;
+            inode->space_used = 0;
         }
     }
 


### PR DESCRIPTION
Fixes two memfs OPEN edge cases covered by PyNFS: opening below a non-directory parent now returns ENOTDIR, and UNCHECKED create of an existing regular file applies the NFSv4 size-zero truncation rule without applying unrelated attrs.

Validation:
- cmake --build build --target chimera
- ctest --test-dir build -R 'chimera/pynfs/open_memfs_nfs4\.0$' --output-on-failure

Result: OPEN2 and OPEN12 now pass. The suite still has unrelated share-deny/status-ordering failures: OPEN20, OPEN23, OPEN27.

Note: the focused ctest run used the local memfs-suite enablement change for validation only; that registration change is not part of this PR.