### PR TITLE
nfs4: serialize client session slot state

### DIFF
--- a/src/vfs/nfs/nfs.c
+++ b/src/vfs/nfs/nfs.c
@@ -110,6 +110,7 @@ chimera_nfs_destroy(void *private_data)
             /* Free NFS4 session if present */
             if (shared->servers[i]->nfs4_session) {
                 free(shared->servers[i]->nfs4_session->slot_seqids);
+                pthread_mutex_destroy(&shared->servers[i]->nfs4_session->lock);
                 free(shared->servers[i]->nfs4_session);
             }
             free(shared->servers[i]);

--- a/src/vfs/nfs/nfs4_mount.c
+++ b/src/vfs/nfs/nfs4_mount.c
@@ -433,7 +433,8 @@ chimera_nfs4_mount_exchange_id_callback(
     eid_res = &res->resarray[0].opexchange_id.eir_resok4;
 
     /* Allocate and initialize session */
-    session              = calloc(1, sizeof(*session));
+    session = calloc(1, sizeof(*session));
+    pthread_mutex_init(&session->lock, NULL);
     session->clientid    = eid_res->eir_clientid;
     server->nfs4_session = session;
 

--- a/src/vfs/nfs/nfs4_umount.c
+++ b/src/vfs/nfs/nfs4_umount.c
@@ -25,6 +25,7 @@ chimera_nfs4_umount(
     /* Free session when last mount is removed */
     if (server->refcnt == 0 && server->nfs4_session) {
         free(server->nfs4_session->slot_seqids);
+        pthread_mutex_destroy(&server->nfs4_session->lock);
         free(server->nfs4_session);
         server->nfs4_session = NULL;
     }

--- a/src/vfs/nfs/nfs_internal.h
+++ b/src/vfs/nfs/nfs_internal.h
@@ -85,11 +85,12 @@ enum chimera_nfs_client_mount_state {
  * Holds the session information established via EXCHANGE_ID + CREATE_SESSION
  */
 struct chimera_nfs4_client_session {
-    uint8_t   sessionid[NFS4_SESSIONID_SIZE];
-    uint64_t  clientid;
-    uint32_t  max_slots;           /* Maximum slots from server (ca_maxrequests) */
-    uint32_t  next_slot_id;        /* Next slot ID to assign to a thread */
-    uint32_t *slot_seqids;         /* Per-slot sequence IDs (array of max_slots) */
+    pthread_mutex_t lock;
+    uint8_t         sessionid[NFS4_SESSIONID_SIZE];
+    uint64_t        clientid;
+    uint32_t        max_slots;     /* Maximum slots from server (ca_maxrequests) */
+    uint32_t        next_slot_id;  /* Next slot ID to assign to a thread */
+    uint32_t       *slot_seqids;   /* Per-slot sequence IDs (array of max_slots) */
 };
 
 struct chimera_nfs_client_mount;
@@ -238,8 +239,10 @@ chimera_nfs_thread_get_server_thread(
         session = thread->shared->servers[index]->nfs4_session;
         if (session && session->max_slots > 0) {
             /* Round-robin slot assignment. If more threads than slots, they share. */
+            pthread_mutex_lock(&session->lock);
             thread->server_threads[index]->slot_id = session->next_slot_id % session->max_slots;
             session->next_slot_id++;
+            pthread_mutex_unlock(&session->lock);
         }
     }
 
@@ -301,7 +304,13 @@ chimera_nfs4_get_sequenceid(
     struct chimera_nfs4_client_session *session,
     uint32_t                            slot_id)
 {
-    return session->slot_seqids[slot_id]++;
+    uint32_t seqid;
+
+    pthread_mutex_lock(&session->lock);
+    seqid = session->slot_seqids[slot_id]++;
+    pthread_mutex_unlock(&session->lock);
+
+    return seqid;
 } // chimera_nfs4_get_sequenceid // chimera_nfs4_get_sequenceid
 
 /*


### PR DESCRIPTION
## Summary
- protect NFSv4.1 client session slot assignment with the session mutex
- protect per-slot SEQUENCE id allocation with the same mutex
- initialize and destroy the session mutex with the NFS4 client session

## Why
The POSIX-over-NFS4 client uses many VFS delegation threads against one shared NFSv4.1 session. Slot assignment and slot sequence counters were shared mutable state but were updated without synchronization. That can duplicate slots or lose sequence-id increments under concurrent first use, which is consistent with timing-sensitive NFS4-only namespace flakes while NFS3 and direct demofs remain clean.

## Testing
- env LSAN_OPTIONS=detect_leaks=0 ninja -C build/Debug src/vfs/nfs/libchimera_vfs_nfs.so src/posix/tests/posix_test_rewinddir src/posix/tests/posix_cthon_basic_1 src/posix/tests/posix_test_nametest
- env LSAN_OPTIONS=detect_leaks=0 ctest --test-dir build/Debug -R 'chimera/posix/rewinddir_nfs4_demofs_aio$|chimera/posix/cthon/cthon_basic_1_nfs4_demofs_io_uring$|chimera/posix/nametest_nfs4_demofs_io_uring$' --output-on-failure --repeat until-fail:8

Note: I could not reproduce the reported failures locally before the fix; the same focused ctest repeat passed 8/8 per target before and after. The patched race is still real in the NFS4 client sequencing path.