### PR TITLE
nfs: validate stale handles in PUTFH

### DIFF
--- a/src/server/nfs/nfs4_proc_putfh.c
+++ b/src/server/nfs/nfs4_proc_putfh.c
@@ -4,8 +4,41 @@
 
 #include "nfs4_procs.h"
 #include "nfs4_status.h"
+#include "nfs4_state.h"
 #include "vfs/vfs_procs.h"
 #include "vfs/vfs_release.h"
+
+static bool
+chimera_nfs4_putfh_has_open_state(
+    struct nfs_request *req,
+    const uint8_t      *fh,
+    uint16_t            fh_len)
+{
+    struct nfs_client     *client = req->session ? req->session->client_unified : NULL;
+    struct nfs_open_owner *owner, *owner_tmp;
+    struct nfs_open_state *state;
+    bool                   found = false;
+
+    if (!client) {
+        return false;
+    }
+
+    pthread_mutex_lock(&client->lock);
+    HASH_ITER(hh, client->open_owners_by_str, owner, owner_tmp)
+    {
+        pthread_mutex_lock(&owner->lock);
+        HASH_FIND(hh, owner->states_by_fh, fh, fh_len, state);
+        pthread_mutex_unlock(&owner->lock);
+
+        if (state) {
+            found = true;
+            break;
+        }
+    }
+    pthread_mutex_unlock(&client->lock);
+
+    return found;
+} /* chimera_nfs4_putfh_has_open_state */
 
 static void
 chimera_nfs4_putfh_getattr_complete(
@@ -32,7 +65,8 @@ chimera_nfs4_putfh_getattr_complete(
     chimera_vfs_release(req->thread->vfs_thread, handle);
 
     if ((attr->va_set_mask & CHIMERA_VFS_ATTR_NLINK) &&
-        attr->va_nlink == 0) {
+        attr->va_nlink == 0 &&
+        !chimera_nfs4_putfh_has_open_state(req, args->object.data, args->object.len)) {
         res->status = NFS4ERR_STALE;
         chimera_nfs4_compound_complete(req, res->status);
         return;

--- a/src/server/nfs/nfs4_proc_putfh.c
+++ b/src/server/nfs/nfs4_proc_putfh.c
@@ -5,6 +5,70 @@
 #include "nfs4_procs.h"
 #include "nfs4_status.h"
 #include "vfs/vfs_procs.h"
+#include "vfs/vfs_release.h"
+
+static void
+chimera_nfs4_putfh_getattr_complete(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *attr,
+    void                     *private_data)
+{
+    struct nfs_request             *req    = private_data;
+    struct PUTFH4args              *args   = &req->args_compound->argarray[req->index].opputfh;
+    struct PUTFH4res               *res    = &req->res_compound.resarray[req->index].opputfh;
+    struct chimera_vfs_open_handle *handle = req->handle;
+
+    req->handle = NULL;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        res->status = (error_code == CHIMERA_VFS_ENOENT ||
+                       error_code == CHIMERA_VFS_ESTALE) ?
+            NFS4ERR_STALE : chimera_nfs4_errno_to_nfsstat4(error_code);
+        chimera_vfs_release(req->thread->vfs_thread, handle);
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    chimera_vfs_release(req->thread->vfs_thread, handle);
+
+    if ((attr->va_set_mask & CHIMERA_VFS_ATTR_NLINK) &&
+        attr->va_nlink == 0) {
+        res->status = NFS4ERR_STALE;
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    memcpy(req->fh, args->object.data, args->object.len);
+    req->fhlen = args->object.len;
+
+    res->status = NFS4_OK;
+    chimera_nfs4_compound_complete(req, NFS4_OK);
+} /* chimera_nfs4_putfh_getattr_complete */
+
+static void
+chimera_nfs4_putfh_validate_complete(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *handle,
+    void                           *private_data)
+{
+    struct nfs_request *req = private_data;
+    struct PUTFH4res   *res = &req->res_compound.resarray[req->index].opputfh;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        res->status = (error_code == CHIMERA_VFS_ENOENT ||
+                       error_code == CHIMERA_VFS_ESTALE) ?
+            NFS4ERR_STALE : chimera_nfs4_errno_to_nfsstat4(error_code);
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    req->handle = handle;
+    chimera_vfs_getattr(req->thread->vfs_thread, &req->cred,
+                        handle,
+                        CHIMERA_VFS_ATTR_NLINK,
+                        chimera_nfs4_putfh_getattr_complete,
+                        req);
+} /* chimera_nfs4_putfh_validate_complete */
 
 void
 chimera_nfs4_putfh(
@@ -35,6 +99,16 @@ chimera_nfs4_putfh(
     }
 
     res->status = NFS4_OK;
+
+    if (!fh_is_nfs4_root(args->object.data, args->object.len)) {
+        chimera_vfs_open_fh(thread->vfs_thread, &req->cred,
+                            args->object.data,
+                            args->object.len,
+                            CHIMERA_VFS_OPEN_INFERRED | CHIMERA_VFS_OPEN_PATH,
+                            chimera_nfs4_putfh_validate_complete,
+                            req);
+        return;
+    }
 
     memcpy(req->fh, args->object.data, args->object.len);
     req->fhlen = args->object.len;


### PR DESCRIPTION
Validates well-formed filehandles during PUTFH and maps deleted/stale objects to NFS4ERR_STALE. This keeps BADHANDLE for structurally invalid handles while satisfying the PyNFS stale-handle case.

Validation:
- cmake --build build --target chimera
- ctest --test-dir build -R 'chimera/pynfs/putfh_memfs_nfs4\.0$' --output-on-failure

Note: the focused ctest run used the local memfs-suite enablement change for validation only; that registration change is not part of this PR.