### PR TITLE
nfs: enforce session channel size limits

### DIFF
--- a/src/server/nfs/nfs4_proc_compound.c
+++ b/src/server/nfs/nfs4_proc_compound.c
@@ -59,6 +59,17 @@ chimera_nfs4_compound_process(
 
         //dump_COMPOUND4res("res", &req->res_compound);
 
+        if (req->session &&
+            req->res_compound.status == NFS4_OK &&
+            req->res_compound.num_resarray > 0 &&
+            req->session->nfs4_session_fore_attrs.ca_maxresponsesize &&
+            marshall_length_COMPOUND4res(&req->res_compound) >
+            (int) req->session->nfs4_session_fore_attrs.ca_maxresponsesize) {
+            req->index = req->res_compound.num_resarray - 1;
+            chimera_nfs4_compound_complete(req, NFS4ERR_REP_TOO_BIG);
+            return;
+        }
+
         rc = shared->nfs_v4.send_reply_NFSPROC4_COMPOUND(
             thread->evpl,
             NULL,

--- a/src/server/nfs/nfs4_proc_sequence.c
+++ b/src/server/nfs/nfs4_proc_sequence.c
@@ -63,6 +63,14 @@ chimera_nfs4_sequence(
         return;
     }
 
+    if (session->nfs4_session_fore_attrs.ca_maxrequestsize &&
+        marshall_length_COMPOUND4args(req->args_compound) >
+        (int) session->nfs4_session_fore_attrs.ca_maxrequestsize) {
+        res->sr_status = NFS4ERR_REQ_TOO_BIG;
+        chimera_nfs4_compound_complete(req, NFS4ERR_REQ_TOO_BIG);
+        return;
+    }
+
     /* RFC 8881 §2.10.6.4: a COMPOUND with more operations than the session's
      * negotiated fore-channel ca_maxoperations (SEQUENCE counts as one) is
      * rejected with NFS4ERR_TOO_MANY_OPS. */
@@ -94,6 +102,15 @@ chimera_nfs4_sequence(
         atomic_load_explicit(&session->client_unified->revoked_deleg_count,
                              memory_order_acquire) > 0) {
         res->sr_resok4.sr_status_flags |= SEQ4_STATUS_RECALLABLE_STATE_REVOKED;
+    }
+
+    if (args->sa_cachethis &&
+        session->nfs4_session_fore_attrs.ca_maxresponsesize_cached &&
+        marshall_length_nfs_resop4(resop) >
+        (int) session->nfs4_session_fore_attrs.ca_maxresponsesize_cached) {
+        res->sr_status = NFS4ERR_REP_TOO_BIG_TO_CACHE;
+        chimera_nfs4_compound_complete(req, NFS4ERR_REP_TOO_BIG_TO_CACHE);
+        return;
     }
 
     chimera_nfs4_compound_complete(req, NFS4_OK);


### PR DESCRIPTION
Enforces negotiated NFSv4.1+ session channel size limits: oversized decoded COMPOUND requests fail at SEQUENCE with NFS4ERR_REQ_TOO_BIG, cache-this SEQUENCE replies larger than ca_maxresponsesize_cached fail with NFS4ERR_REP_TOO_BIG_TO_CACHE, and final COMPOUND replies larger than ca_maxresponsesize fail with NFS4ERR_REP_TOO_BIG.

Validation:
- cmake --build build --target chimera
- ctest --test-dir build -R 'chimera/pynfs/(sequence_memfs_nfs4\.[12]|create_session_memfs_nfs4\.[12])$' --output-on-failure

Result: targeted CSESS26, CSESS27, and SEQ6 now pass for v4.1/v4.2. The create_session suites still have unrelated delegation failures (DELEG5-7), and sequence still has the existing SEQ9b replay-cache failure.

Note: the focused ctest run used the local memfs-suite enablement change for validation only; that registration change is not part of this PR.