### PR TITLE
diskfs: persistent, crash-consistent on-disk demofs (b+tree, intent log, caches, zero-copy/COW, space reclaim)

### DIFF
--- a/src/vfs/demofs/CMakeLists.txt
+++ b/src/vfs/demofs/CMakeLists.txt
@@ -1,9 +1,10 @@
-# SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+# SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 #
 # SPDX-License-Identifier: LGPL-2.1-only
 
 add_library(chimera_vfs_demofs SHARED
     demofs.c
+    space_map.c
 )
 
 target_link_libraries(chimera_vfs_demofs jansson)

--- a/src/vfs/demofs/demofs.c
+++ b/src/vfs/demofs/demofs.c
@@ -1336,8 +1336,6 @@ demofs_block_claim(
     struct demofs_block_shard *shard  = &cache->shards[sidx];
     struct demofs_block       *blk;
 
-    (void) is_new;
-
     pthread_mutex_lock(&shard->lock);
 
     blk = demofs_block_lookup_locked(shard, bucket, device_id, device_offset);
@@ -1348,6 +1346,28 @@ demofs_block_claim(
         blk->buffer        = calloc(1, DEMOFS_BLOCK_SIZE);
         blk->state         = DEMOFS_BLOCK_CLEAN;
         blk->pin_count     = 0;
+
+        /* On a remounted FS a synchronous structural modify can reference a
+         * block the async descent never faulted in -- notably a leaf merge
+         * relinking the right partner's next_leaf, which is not one of the
+         * ci-1/ci/ci+1 siblings the rebalance pre-faults.  Read its real
+         * contents from disk rather than publishing a zeroed block (which
+         * would corrupt the tree once written back).  Rare; a buffered read
+         * served from the page cache.  is_new blocks are freshly allocated,
+         * so they are correctly left zeroed. */
+        if (thread->shared->mounted && !is_new) {
+            int fd = open(thread->shared->device_paths[device_id], O_RDONLY);
+
+            if (fd >= 0) {
+                ssize_t n = pread(fd, blk->buffer, DEMOFS_BLOCK_SIZE,
+                                  (off_t) device_offset);
+                close(fd);
+                chimera_demofs_abort_if(n != (ssize_t) DEMOFS_BLOCK_SIZE,
+                                        "block_claim disk read failed off=%lu n=%zd",
+                                        device_offset, n);
+            }
+        }
+
         /* Publish into the bucket chain (RCU readers will use hash_next). */
         blk->hash_next = shard->buckets[bucket];
         rcu_assign_pointer(shard->buckets[bucket], blk);

--- a/src/vfs/demofs/demofs.c
+++ b/src/vfs/demofs/demofs.c
@@ -544,6 +544,18 @@ typedef void (*demofs_txn_commit_cb_t)(
     int                status,
     void              *private_data);
 
+/* A space range freed by a txn.  The FREE delta is journaled immediately (it
+ * rides the redo), but the in-memory free is withheld until the txn is durable
+ * (applied in demofs_redo_write_cb) or discarded on abort -- so a freed range
+ * (and any still-cached metadata block backing it) can't be reused until the
+ * free is committed. */
+struct demofs_txn_free {
+    uint32_t                device_id;
+    uint64_t                device_offset;
+    uint64_t                length;
+    struct demofs_txn_free *next;
+};
+
 struct demofs_txn {
     enum demofs_txn_type     type;
     struct demofs_thread    *thread;
@@ -551,6 +563,7 @@ struct demofs_txn {
     struct demofs_txn_slot   inodes[DEMOFS_TXN_MAX_INODES];
     int                      num_inodes;
     struct demofs_txn_block *blocks;       /* dirty blocks pinned by this txn */
+    struct demofs_txn_free  *pending_frees; /* ranges freed, applied on commit */
 };
 
 /*
@@ -1757,6 +1770,71 @@ demofs_sm_claim_block(
         struct demofs_sm_jnl name ## _ctx = { (thr), (t) };  \
         struct sm_journal    name         = { demofs_sm_claim_block, &name ## _ctx }
 
+/*
+ * Free a device range as part of a transaction.  The FREE delta is journaled
+ * now (it rides this txn's redo), but the in-memory free is deferred onto the
+ * txn's pending list and applied only once the record is durable
+ * (demofs_txn_apply_frees) or discarded on abort (demofs_txn_discard_frees).
+ * This is required for metadata blocks (b+tree nodes), which unlike file data
+ * are resident + pinned in the block cache: applying the free immediately
+ * could hand the range to a concurrent allocation that then claims the stale,
+ * still-pinned block.  Deferring to commit (block is LOGGED, unpinned by then)
+ * makes a re-claim COW cleanly.
+ */
+static void
+demofs_txn_free_space(
+    struct demofs_thread *thread,
+    struct demofs_txn    *txn,
+    uint32_t              device_id,
+    uint64_t              device_offset,
+    uint64_t              length)
+{
+    struct demofs_txn_free *f;
+
+    DEMOFS_SM_JNL(jnl, thread, txn);
+
+    space_map_free_journal(thread->shared->space_map, &jnl,
+                           device_id, device_offset, length);
+
+    f                  = malloc(sizeof(*f));
+    f->device_id       = device_id;
+    f->device_offset   = device_offset;
+    f->length          = length;
+    f->next            = txn->pending_frees;
+    txn->pending_frees = f;
+} /* demofs_txn_free_space */
+
+/* Commit a txn's pending frees -- the ranges become reusable.  Runs on the
+ * intent-log thread once the redo record is durable, after the txn's blocks
+ * have been unpinned (so a freed metadata block is LOGGED, not DIRTY-pinned). */
+static void
+demofs_txn_apply_frees(struct demofs_txn *txn)
+{
+    struct space_map       *sm = txn->thread->shared->space_map;
+    struct demofs_txn_free *f, *n;
+
+    for (f = txn->pending_frees; f; f = n) {
+        n = f->next;
+        space_map_free_apply(sm, f->device_id, f->device_offset, f->length);
+        free(f);
+    }
+    txn->pending_frees = NULL;
+} /* demofs_txn_apply_frees */
+
+/* Discard a txn's pending frees without applying (abort): the journaled FREE
+ * deltas never become durable, so the ranges stay allocated. */
+static void
+demofs_txn_discard_frees(struct demofs_txn *txn)
+{
+    struct demofs_txn_free *f, *n;
+
+    for (f = txn->pending_frees; f; f = n) {
+        n = f->next;
+        free(f);
+    }
+    txn->pending_frees = NULL;
+} /* demofs_txn_discard_frees */
+
 /* ------------------------------------------------------------------ */
 /* Async block fetch with per-op suspend/resume                        */
 /* ------------------------------------------------------------------ */
@@ -2806,6 +2884,16 @@ demofs_bt_rebalance_leaf(
         }
         demofs_bt_hdr(pbuf, pbase)->nitems = pn - 1;
         merged                             = 1;
+
+        /* R is merged away: return its node block to the allocator (pending
+         * free, applied when this txn commits). */
+        {
+            uint32_t fdev;
+            uint64_t foff = sm_inum_to_device_offset(thread->shared->space_map,
+                                                     r_bptr, &fdev);
+
+            demofs_txn_free_space(thread, txn, fdev, foff, DEMOFS_BLOCK_SIZE);
+        }
     } else {
         /* Redistribute evenly across L and R. */
         uint32_t half = o / 2, acc = 0, off = 0;
@@ -2904,6 +2992,10 @@ demofs_bt_rebalance_interior(
         sizeof(struct demofs_bt_islot);
 
     if ((uint32_t) total <= maxi) {
+        uint64_t r_child = psl[ridx].child;   /* captured before the slot shift */
+        uint32_t fdev;
+        uint64_t foff = sm_inum_to_device_offset(thread->shared->space_map, r_child, &fdev);
+
         for (i = 0; i < total; i++) {
             demofs_bt_islots(lbuf, 0)[i] = all[i];
         }
@@ -2914,6 +3006,9 @@ demofs_bt_rebalance_interior(
         }
         demofs_bt_hdr(pbuf, pbase)->nitems = pn - 1;
         merged                             = 1;
+
+        /* R is merged away: pending-free its node block. */
+        demofs_txn_free_space(thread, txn, fdev, foff, DEMOFS_BLOCK_SIZE);
     } else {
         int split = total / 2;
 
@@ -3017,7 +3112,14 @@ demofs_bt_collapse_root(
             }
             demofs_bt_hdr(root, base)->nitems = n;
         }
-        /* cbuf is now orphaned; physical reclaim deferred. */
+        /* The child was pulled into the embedded root: pending-free its block. */
+        {
+            uint32_t fdev;
+            uint64_t foff = sm_inum_to_device_offset(thread->shared->space_map,
+                                                     cbptr, &fdev);
+
+            demofs_txn_free_space(thread, txn, fdev, foff, DEMOFS_BLOCK_SIZE);
+        }
     }
 } /* demofs_bt_collapse_root */
 
@@ -4464,8 +4566,10 @@ demofs_thread_free_space(
     uint64_t              device_offset,
     uint64_t              length)
 {
-    DEMOFS_SM_JNL(jnl, thread, txn);
-    space_map_free(thread->shared->space_map, &jnl, device_id, device_offset, length);
+    /* Pending free: journal now, apply on commit (hardens the data path's
+     * abort behavior too -- an aborted txn no longer leaves the range freed
+     * in memory while its redo is discarded). */
+    demofs_txn_free_space(thread, txn, device_id, device_offset, length);
 } /* demofs_thread_free_space */
 
 /* ------------------------------------------------------------------ */
@@ -4485,11 +4589,12 @@ demofs_txn_begin(
         txn = malloc(sizeof(*txn));
     }
 
-    txn->type       = type;
-    txn->thread     = thread;
-    txn->next       = NULL;
-    txn->num_inodes = 0;
-    txn->blocks     = NULL;
+    txn->type          = type;
+    txn->thread        = thread;
+    txn->next          = NULL;
+    txn->num_inodes    = 0;
+    txn->blocks        = NULL;
+    txn->pending_frees = NULL;
     return txn;
 } /* demofs_txn_begin */
 
@@ -4505,9 +4610,12 @@ demofs_txn_release(struct demofs_txn *txn)
 static inline void
 demofs_txn_abort(struct demofs_txn *txn)
 {
-    /* Nothing to undo today; future intent records and deferred frees
-     * get discarded here.  Drop any blocks the aborted txn pinned (their
-     * contents are discarded) and release the inode locks. */
+    /* Discard pending frees (their journaled FREE deltas never commit, so the
+     * ranges stay allocated).  Drop any blocks the aborted txn pinned (their
+     * contents are discarded) and release the inode locks.  NOTE: the in-memory
+     * allocator alloc deltas applied during the txn are still not rolled back
+     * here -- a pre-existing transaction-atomicity gap, separate from frees. */
+    demofs_txn_discard_frees(txn);
     demofs_txn_unpin_blocks(txn, DEMOFS_BLOCK_CLEAN);
     demofs_txn_unlock_all(txn);
     demofs_txn_release(txn);
@@ -4814,6 +4922,10 @@ demofs_redo_write_cb(
     il->redo_inflight--;
 
     demofs_txn_unpin_blocks(ctx->entry.txn, DEMOFS_BLOCK_LOGGED);
+    /* Record now durable: the freed metadata blocks are LOGGED + unpinned, so
+     * returning their ranges to the allocator can no longer collide with a
+     * still-pinned block (a re-claim COWs cleanly). */
+    demofs_txn_apply_frees(ctx->entry.txn);
     demofs_txn_unlock_all(ctx->entry.txn);
 
     ctx->entry.status = status;

--- a/src/vfs/demofs/demofs.c
+++ b/src/vfs/demofs/demofs.c
@@ -486,6 +486,16 @@ _Static_assert(DEMOFS_DIRENT_REC_MAX <= 320,
                "demofs_request_private.rec_scratch must hold a full dirent record");
 
 /*
+ * A symlink stores its target as the single record of the new inode's b+tree,
+ * which lives in the embedded root (it can never be split out -- there's only
+ * one record), so the target must fit one node: root capacity minus the node
+ * header and one leaf slot.  Longer targets are rejected with ENAMETOOLONG
+ * rather than aborting the daemon.
+ */
+#define DEMOFS_SYMLINK_TARGET_MAX \
+        (DEMOFS_BT_ROOT_CAP - sizeof(struct demofs_bt_node_hdr) - sizeof(struct demofs_bt_lslot))
+
+/*
  * Intent-log redo record, written into the reserved intent-log region.
  * A record is a header followed by num_blocks (block-header, 4 KiB content)
  * pairs, padded to a 4 KiB multiple.  Full-block redo: the record carries
@@ -787,8 +797,12 @@ struct demofs_bt_op {
     enum demofs_bt_phase      phase;
     struct demofs_bt_key      key;
 
-    /* insert payload (copied into op-owned storage so it survives suspension) */
+    /* insert payload (copied into op-owned storage so it survives suspension).
+     * Most records (dirents, extents) fit recbuf; an oversized one (a long
+     * symlink target) is staged in a heap buffer instead.  `rec` points at
+     * whichever holds the payload and is freed in demofs_bt_complete. */
     uint8_t                   recbuf[DEMOFS_DIRENT_REC_MAX];
+    uint8_t                  *rec;
     uint32_t                  reclen;
 
     /* lookup output (caller-owned, must outlive the op) */
@@ -3804,6 +3818,13 @@ demofs_bt_complete(
     }
     op->npins = 0;
 
+    /* Free an oversized record's heap staging buffer (small records sit in
+     * recbuf and need no free). */
+    if (op->rec && op->rec != op->recbuf) {
+        free(op->rec);
+    }
+    op->rec = NULL;
+
     op->result = result;
     if (op->suspended) {
         op->cb(op, result, op->private_data);
@@ -3921,7 +3942,7 @@ demofs_bt_run(struct demofs_bt_op *op)
             /* At the leaf. */
             if (op->opcode == DEMOFS_BT_OP_INSERT) {
                 demofs_bt_insert_locked(thread, op->txn, inode, &op->key,
-                                        op->recbuf, op->reclen);
+                                        op->rec, op->reclen);
                 demofs_bt_complete(op, 0);
                 return;
             } else if (op->opcode == DEMOFS_BT_OP_REMOVE) {
@@ -4047,7 +4068,10 @@ demofs_bt_insert_async(
     demofs_bt_cb_t              cb,
     void                       *private_data)
 {
-    chimera_demofs_abort_if(reclen > sizeof(op->recbuf), "b+tree record too large");
+    /* No record can exceed a single node; callers (e.g. the symlink path)
+     * reject oversized payloads before reaching here, so this is a true
+     * invariant. */
+    chimera_demofs_abort_if(reclen > DEMOFS_BT_NODE_CAP, "b+tree record too large");
 
     memset(op, 0, sizeof(*op));
     op->thread       = thread;
@@ -4060,7 +4084,10 @@ demofs_bt_insert_async(
     op->use_root     = 1;
     op->cb           = cb;
     op->private_data = private_data;
-    memcpy(op->recbuf, rec, reclen);
+    /* Stage the payload in op-owned storage so it survives suspension; recbuf
+     * for the common (small) case, a heap buffer for an oversized one. */
+    op->rec = (reclen > sizeof(op->recbuf)) ? malloc(reclen) : op->recbuf;
+    memcpy(op->rec, rec, reclen);
 
     demofs_bt_run(op);
     return op->done;
@@ -10356,7 +10383,16 @@ demofs_symlink_at(
     (void) private_data;
 
     p->thread = thread;
-    p->txn    = demofs_txn_begin(thread, DEMOFS_TXN_WRITE);
+
+    /* The target is the new inode's single b+tree record and must fit one
+     * node; reject anything longer rather than aborting deeper in the insert. */
+    if (request->symlink_at.targetlen > DEMOFS_SYMLINK_TARGET_MAX) {
+        request->status = CHIMERA_VFS_ENAMETOOLONG;
+        request->complete(request);
+        return;
+    }
+
+    p->txn = demofs_txn_begin(thread, DEMOFS_TXN_WRITE);
 
     demofs_inode_get_fh_async(thread, p->txn,
                               request->fh, request->fh_len,

--- a/src/vfs/demofs/demofs.c
+++ b/src/vfs/demofs/demofs.c
@@ -141,6 +141,11 @@ struct demofs_request_private {
     uint32_t                 rmw_prefix_valid; // Valid bytes in prefix (extent may be truncated)
     uint32_t                 rmw_suffix_adjust; // Adjustment for suffix when block starts before extent
     uint32_t                 rmw_suffix_valid; // Valid bytes in suffix (extent may be truncated)
+    /* Carried across the async prefix/suffix lookups + trim walk. */
+    int                      need_prefix_read;
+    int                      need_suffix_read;
+    uint64_t                 prefix_device_id, prefix_device_offset;
+    uint64_t                 suffix_device_id, suffix_device_offset;
 };
 
 struct demofs_device {
@@ -6912,25 +6917,478 @@ demofs_write_phase2(
 
 } /* demofs_write_phase2 */
 
-// Find the extent covering a specific file offset; fills *buf and returns
-// it, or NULL if no extent covers the offset.
-static struct demofs_extent *
-demofs_find_extent_at(
-    struct demofs_thread *thread,
-    struct demofs_inode  *inode,
-    uint64_t              file_offset,
-    struct demofs_extent *buf)
-{
-    if (demofs_ext_floor(thread, inode, file_offset, buf)) {
-        uint64_t extent_end = buf->file_offset + buf->length;
+/*
+ * Write (read-modify-write) as an async chain:
+ *   prefix lookup -> suffix lookup -> trim overlapping extents ->
+ *   insert the new aligned extent -> [RMW reads] -> phase2 data write.
+ * State is carried in demofs_private (rmw_*, need_*_read, *_device_*),
+ * inode_stash[0] = inode, ext_iter = current extent during the trim walk.
+ */
+static void demofs_write_trim_process(
+    struct chimera_vfs_request *request);
+static void demofs_write_trim_done(
+    struct chimera_vfs_request *request);
 
-        if (file_offset >= buf->file_offset && file_offset < extent_end) {
-            return buf;
+/* Tail: inode metadata, unlock, RMW reads, phase2. */
+static void
+demofs_write_inserted_cb(
+    struct demofs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request        = private_data;
+    struct demofs_request_private *demofs_private = request->plugin_data;
+    struct demofs_thread          *thread         = demofs_private->thread;
+    struct demofs_shared          *shared         = thread->shared;
+    struct evpl                   *evpl           = thread->evpl;
+    struct demofs_inode           *inode          = demofs_private->inode_stash[0];
+    uint64_t                       write_end      = request->write.offset + request->write.length;
+    struct timespec                now;
+
+    (void) result;
+    demofs_bt_op_free(thread, op);
+
+    if (inode->size < write_end) {
+        inode->size       = write_end;
+        inode->space_used = (inode->size + 4095) & ~4095;
+    }
+
+    clock_gettime(CLOCK_REALTIME, &now);
+    inode->mtime_sec  = now.tv_sec;
+    inode->mtime_nsec = now.tv_nsec;
+    inode->ctime_sec  = now.tv_sec;
+    inode->ctime_nsec = now.tv_nsec;
+
+    demofs_map_attrs(thread, &request->write.r_post_attr, inode);
+
+    request->write.r_length = request->write.length;
+    request->write.r_sync   = 1;
+
+    /* In-memory mutations done; release the inode lock before block I/O. */
+    demofs_txn_unlock_inode(demofs_private->txn, inode);
+
+    if (demofs_private->need_prefix_read || demofs_private->need_suffix_read) {
+        demofs_private->rmw_phase = 1;
+
+        if (demofs_private->need_prefix_read) {
+            int niov = evpl_iovec_alloc(evpl, 4096, 4096, 1, 0,
+                                        &demofs_private->rmw_prefix_iov);
+            if (niov > 0) {
+                demofs_private->pending++;
+                thread->pending_io++;
+                demofs_private->rmw_prefix_pending = 1;
+                evpl_block_read(evpl, thread->queue[demofs_private->prefix_device_id],
+                                &demofs_private->rmw_prefix_iov, 1,
+                                demofs_private->prefix_device_offset,
+                                demofs_write_rmw_read_callback, request);
+            }
+        }
+        if (demofs_private->need_suffix_read) {
+            int niov = evpl_iovec_alloc(evpl, 4096, 4096, 1, 0,
+                                        &demofs_private->rmw_suffix_iov);
+            if (niov > 0) {
+                demofs_private->pending++;
+                thread->pending_io++;
+                demofs_private->rmw_suffix_pending = 1;
+                evpl_block_read(evpl, thread->queue[demofs_private->suffix_device_id],
+                                &demofs_private->rmw_suffix_iov, 1,
+                                demofs_private->suffix_device_offset,
+                                demofs_write_rmw_read_callback, request);
+            }
+        }
+
+        if (demofs_private->pending == 0) {
+            demofs_private->rmw_phase = 2;
+            demofs_write_phase2(thread, shared, request);
+        }
+    } else {
+        demofs_private->rmw_phase = 2;
+        demofs_write_phase2(thread, shared, request);
+    }
+} /* demofs_write_inserted_cb */
+
+static void
+demofs_write_trim_done(struct chimera_vfs_request *request)
+{
+    struct demofs_request_private *p      = request->plugin_data;
+    struct demofs_thread          *thread = p->thread;
+    struct demofs_bt_op           *op     = demofs_bt_op_alloc(thread);
+
+    if (demofs_ext_insert_async(op, thread, p->txn, p->inode_stash[0],
+                                p->rmw_aligned_start, p->rmw_aligned_length,
+                                p->rmw_device_id, p->rmw_device_offset,
+                                demofs_write_inserted_cb, request)) {
+        demofs_write_inserted_cb(op, op->result, request);
+    }
+} /* demofs_write_trim_done */
+
+static void
+demofs_write_trim_walk_cb(
+    struct demofs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+
+    p->loop_have = demofs_ext_from_op(op, result, &p->ext_iter);
+    demofs_bt_op_free(p->thread, op);
+    demofs_write_trim_process(request);
+} /* demofs_write_trim_walk_cb */
+
+static void
+demofs_write_trim_advance(struct chimera_vfs_request *request)
+{
+    struct demofs_request_private *p      = request->plugin_data;
+    struct demofs_thread          *thread = p->thread;
+    struct demofs_bt_op           *op     = demofs_bt_op_alloc(thread);
+
+    if (demofs_ext_next_async(op, thread, p->inode_stash[0], p->ext_iter.file_offset,
+                              p->rec_scratch, sizeof(p->rec_scratch),
+                              demofs_write_trim_walk_cb, request)) {
+        demofs_write_trim_walk_cb(op, op->result, request);
+    }
+} /* demofs_write_trim_advance */
+
+static void
+demofs_write_trim_advance_cb(
+    struct demofs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request *request = private_data;
+
+    (void) result;
+    demofs_bt_op_free(((struct demofs_request_private *) request->plugin_data)->thread, op);
+    demofs_write_trim_advance(request);
+} /* demofs_write_trim_advance_cb */
+
+/* spans: insert tail -> remove -> insert head -> done. */
+static void
+demofs_write_trim_spans_before_cb(
+    struct demofs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request *request = private_data;
+
+    (void) result;
+    demofs_bt_op_free(((struct demofs_request_private *) request->plugin_data)->thread, op);
+    demofs_write_trim_done(request);
+} /* demofs_write_trim_spans_before_cb */
+
+static void
+demofs_write_trim_spans_removed_cb(
+    struct demofs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+    struct demofs_thread          *thread  = p->thread;
+    uint64_t                       astart  = p->rmw_aligned_start;
+
+    (void) result;
+    demofs_bt_op_free(thread, op);
+
+    op = demofs_bt_op_alloc(thread);
+    if (demofs_ext_insert_async(op, thread, p->txn, p->inode_stash[0],
+                                p->ext_iter.file_offset, astart - p->ext_iter.file_offset,
+                                p->ext_iter.device_id, p->ext_iter.device_offset,
+                                demofs_write_trim_spans_before_cb, request)) {
+        demofs_write_trim_spans_before_cb(op, op->result, request);
+    }
+} /* demofs_write_trim_spans_removed_cb */
+
+static void
+demofs_write_trim_spans_after_cb(
+    struct demofs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+    struct demofs_thread          *thread  = p->thread;
+
+    (void) result;
+    demofs_bt_op_free(thread, op);
+
+    op = demofs_bt_op_alloc(thread);
+    if (demofs_ext_remove_async(op, thread, p->txn, p->inode_stash[0],
+                                p->ext_iter.file_offset,
+                                demofs_write_trim_spans_removed_cb, request)) {
+        demofs_write_trim_spans_removed_cb(op, op->result, request);
+    }
+} /* demofs_write_trim_spans_after_cb */
+
+/* overlap-left: remove -> reinsert head -> advance. */
+static void
+demofs_write_trim_oleft_removed_cb(
+    struct demofs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+    struct demofs_thread          *thread  = p->thread;
+    uint64_t                       astart  = p->rmw_aligned_start;
+
+    (void) result;
+    demofs_bt_op_free(thread, op);
+
+    op = demofs_bt_op_alloc(thread);
+    if (demofs_ext_insert_async(op, thread, p->txn, p->inode_stash[0],
+                                p->ext_iter.file_offset, astart - p->ext_iter.file_offset,
+                                p->ext_iter.device_id, p->ext_iter.device_offset,
+                                demofs_write_trim_advance_cb, request)) {
+        demofs_write_trim_advance_cb(op, op->result, request);
+    }
+} /* demofs_write_trim_oleft_removed_cb */
+
+/* overlap-right: remove -> reinsert tail at aligned_end -> done. */
+static void
+demofs_write_trim_oright_removed_cb(
+    struct demofs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+    struct demofs_thread          *thread  = p->thread;
+    uint64_t                       es      = p->ext_iter.file_offset;
+    uint64_t                       ee      = es + p->ext_iter.length;
+    uint64_t                       aend    = p->rmw_aligned_start + p->rmw_aligned_length;
+
+    (void) result;
+    demofs_bt_op_free(thread, op);
+
+    op = demofs_bt_op_alloc(thread);
+    if (demofs_ext_insert_async(op, thread, p->txn, p->inode_stash[0], aend, ee - aend,
+                                p->ext_iter.device_id,
+                                p->ext_iter.device_offset + (aend - es),
+                                demofs_write_trim_spans_before_cb, request)) {
+        demofs_write_trim_spans_before_cb(op, op->result, request);
+    }
+} /* demofs_write_trim_oright_removed_cb */
+
+static void
+demofs_write_trim_process(struct chimera_vfs_request *request)
+{
+    struct demofs_request_private *p      = request->plugin_data;
+    struct demofs_thread          *thread = p->thread;
+    uint64_t                       astart = p->rmw_aligned_start;
+    uint64_t                       aend   = p->rmw_aligned_start + p->rmw_aligned_length;
+    uint64_t                       es, ee;
+    struct demofs_bt_op           *op;
+
+    if (!p->loop_have) {
+        demofs_write_trim_done(request);
+        return;
+    }
+
+    es = p->ext_iter.file_offset;
+    ee = es + p->ext_iter.length;
+
+    if (es >= aend) {
+        demofs_write_trim_done(request);
+        return;
+    }
+
+    if (es >= astart && ee <= aend) {
+        /* Completely inside the aligned region: remove, then advance. */
+        op = demofs_bt_op_alloc(thread);
+        if (demofs_ext_remove_async(op, thread, p->txn, p->inode_stash[0], es,
+                                    demofs_write_trim_advance_cb, request)) {
+            demofs_write_trim_advance_cb(op, op->result, request);
+        }
+    } else if (es < astart && ee > aend) {
+        /* Spans the region: insert tail at aligned_end first. */
+        op = demofs_bt_op_alloc(thread);
+        if (demofs_ext_insert_async(op, thread, p->txn, p->inode_stash[0], aend,
+                                    ee - aend, p->ext_iter.device_id,
+                                    p->ext_iter.device_offset + (aend - es),
+                                    demofs_write_trim_spans_after_cb, request)) {
+            demofs_write_trim_spans_after_cb(op, op->result, request);
+        }
+    } else if (es < astart && ee > astart) {
+        /* Overlaps the left edge: remove, reinsert the head. */
+        op = demofs_bt_op_alloc(thread);
+        if (demofs_ext_remove_async(op, thread, p->txn, p->inode_stash[0], es,
+                                    demofs_write_trim_oleft_removed_cb, request)) {
+            demofs_write_trim_oleft_removed_cb(op, op->result, request);
+        }
+    } else if (es < aend && ee > aend) {
+        /* Starts within, extends past: remove, reinsert tail at aligned_end. */
+        op = demofs_bt_op_alloc(thread);
+        if (demofs_ext_remove_async(op, thread, p->txn, p->inode_stash[0], es,
+                                    demofs_write_trim_oright_removed_cb, request)) {
+            demofs_write_trim_oright_removed_cb(op, op->result, request);
+        }
+    } else {
+        /* No overlap (extent before aligned_start): skip. */
+        demofs_write_trim_advance(request);
+    }
+} /* demofs_write_trim_process */
+
+static void
+demofs_write_trim_first_cb(
+    struct demofs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+    struct demofs_thread          *thread  = p->thread;
+    int                            have    = demofs_ext_from_op(op, result, &p->ext_iter);
+
+    demofs_bt_op_free(thread, op);
+
+    if (!have) {
+        op = demofs_bt_op_alloc(thread);
+        if (demofs_ext_ceil_async(op, thread, p->inode_stash[0], 0, p->rec_scratch,
+                                  sizeof(p->rec_scratch), demofs_write_trim_walk_cb,
+                                  request)) {
+            demofs_write_trim_walk_cb(op, op->result, request);
+        }
+        return;
+    }
+
+    p->loop_have = 1;
+    demofs_write_trim_process(request);
+} /* demofs_write_trim_first_cb */
+
+static void
+demofs_write_trim_start(struct chimera_vfs_request *request)
+{
+    struct demofs_request_private *p      = request->plugin_data;
+    struct demofs_thread          *thread = p->thread;
+    struct demofs_bt_op           *op     = demofs_bt_op_alloc(thread);
+
+    if (demofs_ext_floor_async(op, thread, p->inode_stash[0], p->rmw_aligned_start,
+                               p->rec_scratch, sizeof(p->rec_scratch),
+                               demofs_write_trim_first_cb, request)) {
+        demofs_write_trim_first_cb(op, op->result, request);
+    }
+} /* demofs_write_trim_start */
+
+static void
+demofs_write_suffix_cb(
+    struct demofs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request   = private_data;
+    struct demofs_request_private *p         = request->plugin_data;
+    int                            have      = demofs_ext_from_op(op, result, &p->ext_iter);
+    uint64_t                       write_end = request->write.offset + request->write.length;
+    uint64_t                       aend      = p->rmw_aligned_start + p->rmw_aligned_length;
+
+    demofs_bt_op_free(p->thread, op);
+
+    if (have && p->ext_iter.file_offset <= write_end &&
+        write_end < p->ext_iter.file_offset + p->ext_iter.length) {
+        uint64_t suffix_block = write_end & ~4095ULL;
+        uint64_t ee           = p->ext_iter.file_offset + p->ext_iter.length;
+
+        if (ee >= aend) {
+            p->rmw_suffix_valid = p->rmw_suffix_len;
+        } else if (ee > write_end) {
+            p->rmw_suffix_valid = ee - write_end;
+        } else {
+            p->rmw_suffix_valid = 0;
+        }
+
+        if (suffix_block >= p->ext_iter.file_offset) {
+            p->need_suffix_read     = 1;
+            p->suffix_device_id     = p->ext_iter.device_id;
+            p->suffix_device_offset = p->ext_iter.device_offset +
+                (suffix_block - p->ext_iter.file_offset);
+        } else {
+            p->need_suffix_read     = 1;
+            p->suffix_device_id     = p->ext_iter.device_id;
+            p->suffix_device_offset = p->ext_iter.device_offset;
+            p->rmw_suffix_adjust    = p->ext_iter.file_offset - suffix_block;
         }
     }
 
-    return NULL;
-} /* demofs_find_extent_at */
+    demofs_write_trim_start(request);
+} /* demofs_write_suffix_cb */
+
+static void
+demofs_write_suffix_lookup(struct chimera_vfs_request *request)
+{
+    struct demofs_request_private *p         = request->plugin_data;
+    struct demofs_thread          *thread    = p->thread;
+    uint64_t                       write_end = request->write.offset + request->write.length;
+    struct demofs_bt_op           *op;
+
+    if (p->rmw_suffix_len == 0) {
+        demofs_write_trim_start(request);
+        return;
+    }
+
+    op = demofs_bt_op_alloc(thread);
+    if (demofs_ext_floor_async(op, thread, p->inode_stash[0], write_end, p->rec_scratch,
+                               sizeof(p->rec_scratch), demofs_write_suffix_cb, request)) {
+        demofs_write_suffix_cb(op, op->result, request);
+    }
+} /* demofs_write_suffix_lookup */
+
+static void
+demofs_write_prefix_cb(
+    struct demofs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+    int                            have    = demofs_ext_from_op(op, result, &p->ext_iter);
+    uint64_t                       astart  = p->rmw_aligned_start;
+
+    demofs_bt_op_free(p->thread, op);
+
+    if (have && p->ext_iter.file_offset <= astart &&
+        astart < p->ext_iter.file_offset + p->ext_iter.length) {
+        uint64_t ee = p->ext_iter.file_offset + p->ext_iter.length;
+
+        if (ee >= astart + p->rmw_prefix_len) {
+            p->rmw_prefix_valid = p->rmw_prefix_len;
+        } else if (ee > astart) {
+            p->rmw_prefix_valid = ee - astart;
+        } else {
+            p->rmw_prefix_valid = 0;
+        }
+
+        if (p->rmw_prefix_valid > 0) {
+            p->need_prefix_read     = 1;
+            p->prefix_device_id     = p->ext_iter.device_id;
+            p->prefix_device_offset = p->ext_iter.device_offset +
+                (astart - p->ext_iter.file_offset);
+        }
+    }
+
+    demofs_write_suffix_lookup(request);
+} /* demofs_write_prefix_cb */
+
+static void
+demofs_write_prefix_lookup(struct chimera_vfs_request *request)
+{
+    struct demofs_request_private *p      = request->plugin_data;
+    struct demofs_thread          *thread = p->thread;
+    struct demofs_bt_op           *op;
+
+    if (p->rmw_prefix_len == 0) {
+        demofs_write_suffix_lookup(request);
+        return;
+    }
+
+    op = demofs_bt_op_alloc(thread);
+    if (demofs_ext_floor_async(op, thread, p->inode_stash[0], p->rmw_aligned_start,
+                               p->rec_scratch, sizeof(p->rec_scratch),
+                               demofs_write_prefix_cb, request)) {
+        demofs_write_prefix_cb(op, op->result, request);
+    }
+} /* demofs_write_prefix_lookup */
 
 static void
 demofs_write_inode_cb(
@@ -6941,19 +7399,11 @@ demofs_write_inode_cb(
     struct chimera_vfs_request    *request        = private_data;
     struct demofs_request_private *demofs_private = request->plugin_data;
     struct demofs_thread          *thread         = demofs_private->thread;
-    struct demofs_shared          *shared         = thread->shared;
-    struct evpl                   *evpl           = thread->evpl;
-    struct demofs_extent           ext_buf;
-    struct demofs_extent          *extent = &ext_buf;
-    struct demofs_extent           prefix_buf, suffix_buf;
-    int                            have;
-    uint64_t                       write_start = request->write.offset;
-    uint64_t                       write_end   = write_start + request->write.length;
+    uint64_t                       write_start    = request->write.offset;
+    uint64_t                       write_end      = write_start + request->write.length;
     uint64_t                       aligned_start, aligned_end, aligned_length;
     uint64_t                       device_id, device_offset;
-    uint64_t                       extent_start, extent_end;
     int                            rc;
-    struct timespec                now;
 
     if (unlikely(status != CHIMERA_VFS_OK)) {
         demofs_op_fail(request, demofs_private->txn, status);
@@ -6967,243 +7417,32 @@ demofs_write_inode_cb(
 
     demofs_map_attrs(thread, &request->write.r_pre_attr, inode);
 
-    // Calculate block-aligned boundaries
     aligned_start  = write_start & ~4095ULL;
     aligned_end    = (write_end + 4095ULL) & ~4095ULL;
     aligned_length = aligned_end - aligned_start;
 
-    // Calculate prefix/suffix lengths for partial blocks
-    uint32_t prefix_len = write_start - aligned_start;
-    uint32_t suffix_len = aligned_end - write_end;
-
-    demofs_private->rmw_prefix_len     = prefix_len;
-    demofs_private->rmw_suffix_len     = suffix_len;
-    demofs_private->rmw_aligned_start  = aligned_start;
-    demofs_private->rmw_aligned_length = aligned_length;
-
-    // Allocate space for the aligned write
     rc = demofs_thread_alloc_space(thread, aligned_length, &device_id, &device_offset);
-
     if (rc) {
         demofs_op_fail(request, demofs_private->txn, CHIMERA_VFS_ENOSPC);
         return;
     }
 
-    demofs_private->rmw_device_id     = device_id;
-    demofs_private->rmw_device_offset = device_offset;
+    demofs_private->rmw_prefix_len     = write_start - aligned_start;
+    demofs_private->rmw_suffix_len     = aligned_end - write_end;
+    demofs_private->rmw_aligned_start  = aligned_start;
+    demofs_private->rmw_aligned_length = aligned_length;
+    demofs_private->rmw_device_id      = device_id;
+    demofs_private->rmw_device_offset  = device_offset;
+    demofs_private->rmw_prefix_valid   = 0;
+    demofs_private->rmw_suffix_valid   = 0;
+    demofs_private->rmw_suffix_adjust  = 0;
+    demofs_private->need_prefix_read   = 0;
+    demofs_private->need_suffix_read   = 0;
+    demofs_private->inode_stash[0]     = inode;
 
-    // Check if we need to read existing data for partial blocks
-    int                   need_prefix_read = 0;
-    int                   need_suffix_read = 0;
-    struct demofs_extent *prefix_extent    = NULL;
-    struct demofs_extent *suffix_extent    = NULL;
-    uint64_t              prefix_device_id = 0, prefix_device_offset = 0;
-    uint64_t              suffix_device_id = 0, suffix_device_offset = 0;
-
-    if (prefix_len > 0) {
-        // Check if there's an existing extent covering the prefix region
-        prefix_extent = demofs_find_extent_at(thread, inode, aligned_start, &prefix_buf);
-        if (prefix_extent) {
-            uint64_t extent_end = prefix_extent->file_offset + prefix_extent->length;
-
-            // Calculate how much of the prefix is actually valid data
-            // (extent may have been truncated to non-4K boundary)
-            if (extent_end >= aligned_start + prefix_len) {
-                demofs_private->rmw_prefix_valid = prefix_len;
-            } else if (extent_end > aligned_start) {
-                demofs_private->rmw_prefix_valid = extent_end - aligned_start;
-            } else {
-                demofs_private->rmw_prefix_valid = 0;
-            }
-
-            if (demofs_private->rmw_prefix_valid > 0) {
-                need_prefix_read     = 1;
-                prefix_device_id     = prefix_extent->device_id;
-                prefix_device_offset = prefix_extent->device_offset +
-                    (aligned_start - prefix_extent->file_offset);
-            }
-        }
-    }
-
-    if (suffix_len > 0) {
-        // Check if there's an existing extent covering the suffix region
-        // The suffix starts at write_end
-        suffix_extent = demofs_find_extent_at(thread, inode, write_end, &suffix_buf);
-        if (suffix_extent) {
-            // The block containing write_end
-            uint64_t suffix_block = write_end & ~4095ULL;
-            uint64_t extent_end   = suffix_extent->file_offset + suffix_extent->length;
-
-            // Calculate how much of the suffix is actually valid data
-            // (extent may have been truncated to non-4K boundary)
-            if (extent_end >= aligned_end) {
-                demofs_private->rmw_suffix_valid = suffix_len;
-            } else if (extent_end > write_end) {
-                demofs_private->rmw_suffix_valid = extent_end - write_end;
-            } else {
-                demofs_private->rmw_suffix_valid = 0;
-            }
-
-            // Only read if the block start is within the extent
-            // If suffix_block < suffix_extent->file_offset, then the early part
-            // of the block has no data. The suffix (from write_end to aligned_end)
-            // IS covered by the extent, so read from extent start and adjust.
-            if (suffix_block >= suffix_extent->file_offset) {
-                need_suffix_read     = 1;
-                suffix_device_id     = suffix_extent->device_id;
-                suffix_device_offset = suffix_extent->device_offset +
-                    (suffix_block - suffix_extent->file_offset);
-            } else {
-                // Read from extent start, adjust in phase2 by storing offset
-                need_suffix_read     = 1;
-                suffix_device_id     = suffix_extent->device_id;
-                suffix_device_offset = suffix_extent->device_offset;
-                // Store the adjustment: how much the read buffer offset differs
-                // from the expected (write_end & 4095) position
-                demofs_private->rmw_suffix_adjust =
-                    suffix_extent->file_offset - suffix_block;
-            }
-        }
-    }
-
-    // Remove/trim extents that overlap with the aligned write region
-    have = demofs_ext_floor(thread, inode, aligned_start, extent);
-    if (!have) {
-        /* No extent at or before aligned_start - get the first extent
-         * in case there's one that starts within our write range */
-        have = demofs_ext_ceil(thread, inode, 0, extent);
-    }
-
-    while (have) {
-        uint64_t cur_fo = extent->file_offset;
-
-        extent_start = extent->file_offset;
-        extent_end   = extent_start + extent->length;
-
-        if (extent_start >= aligned_end) {
-            break;
-        }
-
-        if (extent_start >= aligned_start && extent_end <= aligned_end) {
-            // Completely inside the aligned region - remove it.
-            demofs_ext_remove(thread, demofs_private->txn, inode, cur_fo);
-        } else if (extent_start < aligned_start && extent_end > aligned_end) {
-            // Spans the whole region - split into a before part (trimmed)
-            // and an after part, then we're done (extents are disjoint).
-            uint64_t after_shift = aligned_end - extent_start;
-
-            demofs_ext_insert(thread, demofs_private->txn, inode, aligned_end,
-                              extent_end - aligned_end, extent->device_id,
-                              extent->device_offset + after_shift);
-            demofs_ext_remove(thread, demofs_private->txn, inode, cur_fo);
-            demofs_ext_insert(thread, demofs_private->txn, inode, cur_fo,
-                              aligned_start - extent_start, extent->device_id,
-                              extent->device_offset);
-            break;
-        } else if (extent_start < aligned_start && extent_end > aligned_start) {
-            // Overlaps the left edge - trim to end at aligned_start
-            // (file_offset key unchanged).
-            demofs_ext_remove(thread, demofs_private->txn, inode, cur_fo);
-            demofs_ext_insert(thread, demofs_private->txn, inode, cur_fo,
-                              aligned_start - extent_start, extent->device_id,
-                              extent->device_offset);
-        } else if (extent_start < aligned_end && extent_end > aligned_end) {
-            // Starts within the write region but extends past - move its
-            // front to aligned_end (the key changes), then we're done.
-            uint64_t shift = aligned_end - extent_start;
-
-            demofs_ext_remove(thread, demofs_private->txn, inode, cur_fo);
-            demofs_ext_insert(thread, demofs_private->txn, inode, aligned_end,
-                              extent_end - aligned_end, extent->device_id,
-                              extent->device_offset + shift);
-            break;
-        }
-
-        have = demofs_ext_next(thread, inode, cur_fo, extent);
-    }
-
-    // Create new extent for the aligned write
-    demofs_ext_insert(thread, demofs_private->txn, inode, aligned_start,
-                      aligned_length, device_id, device_offset);
-
-    // Update inode metadata
-    if (inode->size < write_end) {
-        inode->size       = write_end;
-        inode->space_used = (inode->size + 4095) & ~4095;
-    }
-
-    clock_gettime(CLOCK_REALTIME, &now);
-
-    inode->mtime_sec  = now.tv_sec;
-    inode->mtime_nsec = now.tv_nsec;
-    inode->ctime_sec  = now.tv_sec;
-    inode->ctime_nsec = now.tv_nsec;
-
-    demofs_map_attrs(thread, &request->write.r_post_attr, inode);
-
-    request->write.r_length = request->write.length;
-    request->write.r_sync   = 1;
-
-    /* All in-memory inode mutations are done.  Release the inode lock
-     * before submitting block I/O so other ops on this worker (or other
-     * workers) can proceed concurrently, and so we don't self-deadlock
-     * when SQ-full backpressure spins this worker's evpl loop. */
-    demofs_txn_unlock_inode(demofs_private->txn, inode);
-
-    // Issue RMW reads if needed
-    if (need_prefix_read || need_suffix_read) {
-        demofs_private->rmw_phase = 1;
-
-        if (need_prefix_read) {
-            // Allocate buffer and read prefix block
-            int niov = evpl_iovec_alloc(evpl, 4096, 4096, 1,
-                                        0, &demofs_private->rmw_prefix_iov);
-            if (niov > 0) {
-                demofs_private->pending++;
-                thread->pending_io++;
-                demofs_private->rmw_prefix_pending = 1;
-
-                evpl_block_read(evpl,
-                                thread->queue[prefix_device_id],
-                                &demofs_private->rmw_prefix_iov,
-                                1,
-                                prefix_device_offset,
-                                demofs_write_rmw_read_callback,
-                                request);
-            }
-        }
-
-        if (need_suffix_read) {
-            // Allocate buffer and read suffix block
-            int niov = evpl_iovec_alloc(evpl, 4096, 4096, 1,
-                                        0, &demofs_private->rmw_suffix_iov);
-            if (niov > 0) {
-                demofs_private->pending++;
-                thread->pending_io++;
-                demofs_private->rmw_suffix_pending = 1;
-
-                evpl_block_read(evpl,
-                                thread->queue[suffix_device_id],
-                                &demofs_private->rmw_suffix_iov,
-                                1,
-                                suffix_device_offset,
-                                demofs_write_rmw_read_callback,
-                                request);
-            }
-        }
-
-        // Wait for RMW reads to complete before proceeding
-        if (demofs_private->pending == 0) {
-            // No reads were actually issued (allocation failed?)
-            demofs_private->rmw_phase = 2;
-            demofs_write_phase2(thread, shared, request);
-        }
-    } else {
-        // No RMW needed, proceed directly to write
-        demofs_private->rmw_phase = 2;
-        demofs_write_phase2(thread, shared, request);
-    }
+    demofs_write_prefix_lookup(request);
 } /* demofs_write_inode_cb */
+
 
 static void
 demofs_write(

--- a/src/vfs/demofs/demofs.c
+++ b/src/vfs/demofs/demofs.c
@@ -275,10 +275,13 @@ struct demofs_inode_cache {
 #define DEMOFS_BLOCK_CACHE_BUCKET_MASK       (DEMOFS_BLOCK_CACHE_BUCKETS_PER_SHARD - 1)
 
 enum demofs_block_state {
+    DEMOFS_BLOCK_LOADING,  /* read I/O in flight; buffer not yet valid, ops wait */
     DEMOFS_BLOCK_CLEAN,    /* matches final on-disk location; evictable when unpinned */
     DEMOFS_BLOCK_DIRTY,    /* modified, pinned by >=1 txn, not yet logged */
     DEMOFS_BLOCK_LOGGED,   /* intent record durable; awaiting tail-push to final loc */
 };
+
+struct demofs_bt_op;
 
 /*
  * A cached 4 KiB on-disk block, keyed by (device_id, device_offset).  The
@@ -298,6 +301,11 @@ struct demofs_block {
     struct rcu_head      rcu;
     struct demofs_block *lru_prev, *lru_next;      /* clean+unpinned LRU (Stage 3) */
     struct demofs_block *wb_next;              /* writeback queue (Stage 3) */
+
+    /* Ops blocked on a LOADING block, woken when the read I/O completes.
+     * Protected by the owning shard lock. */
+    struct demofs_bt_op *wait_head;
+    struct demofs_bt_op *wait_tail;
 };
 
 struct demofs_block_shard {
@@ -561,6 +569,96 @@ struct demofs_thread {
     struct demofs_inode_waiter *grant_head;
     struct demofs_inode_waiter *grant_tail;
     struct evpl_doorbell        grant_doorbell;
+
+    /* Cross-thread b+tree op resumption: when a block this worker's ops are
+     * waiting on finishes loading (possibly on another worker that issued the
+     * read), the ready ops are queued here.  Same-worker resumptions drain via
+     * the deferral (no eventfd); cross-worker ones ring the doorbell. */
+    pthread_mutex_t             resume_lock;
+    struct demofs_bt_op        *resume_head;
+    struct demofs_bt_op        *resume_tail;
+    struct evpl_doorbell        resume_doorbell;
+    struct evpl_deferral        resume_deferral;
+    struct demofs_bt_op        *bt_op_free_list;
+};
+
+/* ------------------------------------------------------------------ */
+/* Async b+tree operation context                                      */
+/* ------------------------------------------------------------------ */
+
+#define DEMOFS_BT_MAX_DEPTH 16
+
+/*
+ * Result callback for an async b+tree operation.  `result` carries the record
+ * length (>= 0) or -1 (not found) for lookups, and 0/1 (not found / removed,
+ * or inserted) for remove/insert.
+ */
+typedef void (*demofs_bt_cb_t)(
+    struct demofs_bt_op *op,
+    int                  result,
+    void                *private_data);
+
+enum demofs_bt_opcode {
+    DEMOFS_BT_OP_LOOKUP_EXACT,
+    DEMOFS_BT_OP_LOOKUP_GE,
+    DEMOFS_BT_OP_LOOKUP_LE,
+    DEMOFS_BT_OP_INSERT,
+    DEMOFS_BT_OP_REMOVE,
+};
+
+enum demofs_bt_phase {
+    DEMOFS_BT_PHASE_DESCEND,
+    DEMOFS_BT_PHASE_WALK_NEXT,
+    DEMOFS_BT_PHASE_WALK_PREV,
+    DEMOFS_BT_PHASE_REBALANCE,
+    DEMOFS_BT_PHASE_COLLAPSE,
+};
+
+struct demofs_bt_path_ent {
+    uint64_t bptr;     /* node bptr (0 == embedded root, reached via the inode) */
+    uint32_t base;
+    int      ci;       /* child index descended into */
+};
+
+/*
+ * One in-flight b+tree operation.  Holds all state needed to suspend the
+ * traversal when a node is not resident (a block read is issued and the op is
+ * parked on the block's waiter list) and resume it from the same point once
+ * the block loads.  Allocated from a per-thread free list.
+ */
+struct demofs_bt_op {
+    struct demofs_thread     *thread;
+    struct demofs_txn        *txn;
+    struct demofs_inode      *inode;
+    enum demofs_bt_opcode     opcode;
+    enum demofs_bt_phase      phase;
+    struct demofs_bt_key      key;
+
+    /* insert payload (copied into op-owned storage so it survives suspension) */
+    uint8_t                   recbuf[DEMOFS_DIRENT_REC_MAX];
+    uint32_t                  reclen;
+
+    /* lookup output (caller-owned, must outlive the op) */
+    void                     *out;
+    uint32_t                  out_cap;
+    struct demofs_bt_key     *r_key;
+
+    /* traversal cursor */
+    uint64_t                  cur_bptr;
+    int                       use_root;
+
+    /* descent path for insert split / remove rebalance */
+    struct demofs_bt_path_ent path[DEMOFS_BT_MAX_DEPTH];
+    int                       depth;
+    int                       removed_idx;
+    int                       reb_level;
+
+    /* completion */
+    demofs_bt_cb_t            cb;
+    void                     *private_data;
+
+    /* block-waiter list / per-worker resume-queue linkage */
+    struct demofs_bt_op      *next;
 };
 
 static inline uint32_t
@@ -955,6 +1053,27 @@ demofs_block_hash(
     return h;
 } /* demofs_block_hash */
 
+static inline struct demofs_block_shard *
+demofs_block_shard(
+    struct demofs_block_cache *cache,
+    uint32_t                   device_id,
+    uint64_t                   device_offset)
+{
+    uint64_t hash = demofs_block_hash(device_id, device_offset);
+
+    return &cache->shards[hash & DEMOFS_BLOCK_CACHE_SHARD_MASK];
+} /* demofs_block_shard */
+
+static inline uint32_t
+demofs_block_bucket(
+    uint32_t device_id,
+    uint64_t device_offset)
+{
+    uint64_t hash = demofs_block_hash(device_id, device_offset);
+
+    return (hash >> 8) & DEMOFS_BLOCK_CACHE_BUCKET_MASK;
+} /* demofs_block_bucket */
+
 static void
 demofs_block_cache_create(struct demofs_shared *shared)
 {
@@ -1083,6 +1202,219 @@ demofs_txn_add_block(
     txn->blocks = tb;
 } /* demofs_txn_add_block */
 
+/* ------------------------------------------------------------------ */
+/* Async block fetch with per-op suspend/resume                        */
+/* ------------------------------------------------------------------ */
+
+static void demofs_bt_run(
+    struct demofs_bt_op *op);
+
+static inline struct demofs_bt_op *
+demofs_bt_op_alloc(struct demofs_thread *thread)
+{
+    struct demofs_bt_op *op = thread->bt_op_free_list;
+
+    if (op) {
+        thread->bt_op_free_list = op->next;
+    } else {
+        op = calloc(1, sizeof(*op));
+    }
+    op->next = NULL;
+    return op;
+} /* demofs_bt_op_alloc */
+
+static inline void
+demofs_bt_op_free(
+    struct demofs_thread *thread,
+    struct demofs_bt_op  *op)
+{
+    op->next                = thread->bt_op_free_list;
+    thread->bt_op_free_list = op;
+} /* demofs_bt_op_free */
+
+/*
+ * Enqueue a ready op on its owning worker's resume queue.  If the waking
+ * thread is the op's own worker, schedule a deferral (no eventfd); otherwise
+ * ring the cross-thread doorbell.
+ */
+static void
+demofs_bt_op_resume(
+    struct demofs_thread *waker,
+    struct demofs_bt_op  *op)
+{
+    struct demofs_thread *worker = op->thread;
+
+    pthread_mutex_lock(&worker->resume_lock);
+    op->next = NULL;
+    if (worker->resume_tail) {
+        worker->resume_tail->next = op;
+    } else {
+        worker->resume_head = op;
+    }
+    worker->resume_tail = op;
+    pthread_mutex_unlock(&worker->resume_lock);
+
+    if (worker == waker) {
+        evpl_defer(worker->evpl, &worker->resume_deferral);
+    } else {
+        evpl_ring_doorbell(&worker->resume_doorbell);
+    }
+} /* demofs_bt_op_resume */
+
+/* Drain this worker's resume queue, re-entering each ready op's driver. */
+static void
+demofs_bt_resume_drain(struct demofs_thread *thread)
+{
+    struct demofs_bt_op *list, *op;
+
+    pthread_mutex_lock(&thread->resume_lock);
+    list                = thread->resume_head;
+    thread->resume_head = NULL;
+    thread->resume_tail = NULL;
+    pthread_mutex_unlock(&thread->resume_lock);
+
+    while (list) {
+        op       = list;
+        list     = op->next;
+        op->next = NULL;
+        demofs_bt_run(op);
+    }
+} /* demofs_bt_resume_drain */
+
+static void
+demofs_bt_resume_doorbell_cb(
+    struct evpl          *evpl,
+    struct evpl_doorbell *doorbell)
+{
+    struct demofs_thread *thread = container_of(doorbell, struct demofs_thread,
+                                                resume_doorbell);
+
+    (void) evpl;
+    demofs_bt_resume_drain(thread);
+} /* demofs_bt_resume_doorbell_cb */
+
+static void
+demofs_bt_resume_deferral_cb(
+    struct evpl *evpl,
+    void        *private_data)
+{
+    (void) evpl;
+    demofs_bt_resume_drain(private_data);
+} /* demofs_bt_resume_deferral_cb */
+
+/* Completion context for an in-flight block read. */
+struct demofs_block_load {
+    struct demofs_block  *blk;
+    struct demofs_thread *thread;     /* worker that issued the read */
+    struct evpl_iovec     iov;
+};
+
+/* Block read completion: copy into the cache buffer, mark CLEAN, wake waiters. */
+static void
+demofs_block_load_complete(
+    struct evpl *evpl,
+    int          status,
+    void        *private_data)
+{
+    struct demofs_block_load  *ld    = private_data;
+    struct demofs_block       *blk   = ld->blk;
+    struct demofs_thread      *self  = ld->thread;
+    struct demofs_block_shard *shard = demofs_block_shard(self->shared->block_cache,
+                                                          blk->device_id, blk->device_offset);
+    struct demofs_bt_op       *waiters, *op;
+
+    if (likely(status == 0)) {
+        memcpy(blk->buffer, ld->iov.data, DEMOFS_BLOCK_SIZE);
+    }
+    evpl_iovec_release(evpl, &ld->iov);
+
+    pthread_mutex_lock(&shard->lock);
+    blk->state     = DEMOFS_BLOCK_CLEAN;
+    waiters        = blk->wait_head;
+    blk->wait_head = NULL;
+    blk->wait_tail = NULL;
+    pthread_mutex_unlock(&shard->lock);
+
+    self->pending_io--;
+    free(ld);
+
+    while (waiters) {
+        op      = waiters;
+        waiters = op->next;
+        demofs_bt_op_resume(self, op);
+    }
+} /* demofs_block_load_complete */
+
+/*
+ * Fetch the block backing a b+tree node for op.  On a resident, valid block
+ * the block is returned immediately.  Otherwise the op is parked on the
+ * block's waiter list (a read is issued if it is not already in flight) and
+ * NULL is returned; the op's driver will be re-entered once the block loads.
+ */
+static struct demofs_block *
+demofs_bt_block_get(
+    struct demofs_bt_op *op,
+    uint32_t             device_id,
+    uint64_t             device_offset)
+{
+    struct demofs_thread      *thread = op->thread;
+    struct demofs_block_cache *cache  = thread->shared->block_cache;
+    struct demofs_block_shard *shard  = demofs_block_shard(cache, device_id, device_offset);
+    uint32_t                   bucket = demofs_block_bucket(device_id, device_offset);
+    struct demofs_block       *blk;
+    struct demofs_block_load  *ld;
+    int                        issue = 0;
+
+    /* Fast path: lock-free hit on a resident, loaded block. */
+    urcu_memb_read_lock();
+    blk = demofs_block_lookup_locked(shard, bucket, device_id, device_offset);
+    if (blk && blk->state != DEMOFS_BLOCK_LOADING) {
+        urcu_memb_read_unlock();
+        return blk;
+    }
+    urcu_memb_read_unlock();
+
+    pthread_mutex_lock(&shard->lock);
+    blk = demofs_block_lookup_locked(shard, bucket, device_id, device_offset);
+    if (blk && blk->state != DEMOFS_BLOCK_LOADING) {
+        pthread_mutex_unlock(&shard->lock);
+        return blk;
+    }
+
+    if (!blk) {
+        blk                = calloc(1, sizeof(*blk));
+        blk->device_id     = device_id;
+        blk->device_offset = device_offset;
+        blk->buffer        = calloc(1, DEMOFS_BLOCK_SIZE);
+        blk->state         = DEMOFS_BLOCK_LOADING;
+        blk->hash_next     = shard->buckets[bucket];
+        rcu_assign_pointer(shard->buckets[bucket], blk);
+        issue = 1;
+    }
+
+    /* Park this op on the block's waiter list. */
+    op->next = NULL;
+    if (blk->wait_tail) {
+        blk->wait_tail->next = op;
+    } else {
+        blk->wait_head = op;
+    }
+    blk->wait_tail = op;
+    pthread_mutex_unlock(&shard->lock);
+
+    if (issue) {
+        ld         = malloc(sizeof(*ld));
+        ld->blk    = blk;
+        ld->thread = thread;
+        evpl_iovec_alloc(thread->evpl, DEMOFS_BLOCK_SIZE, DEMOFS_BLOCK_SIZE, 1, 0, &ld->iov);
+        thread->pending_io++;
+        evpl_block_read(thread->evpl, thread->queue[device_id], &ld->iov, 1,
+                        device_offset, demofs_block_load_complete, ld);
+    }
+
+    return NULL;
+} /* demofs_bt_block_get */
+
 /*
  * Ensure this (write-locked) inode's home block is resident and pinned, and
  * attached to the transaction.  Idempotent per inode: the inode caches its
@@ -1207,29 +1539,6 @@ demofs_txn_unpin_blocks(
 /* ------------------------------------------------------------------ */
 /* Per-inode b+tree                                                    */
 /* ------------------------------------------------------------------ */
-
-/* Lock-free RCU lookup of a resident block; NULL if not cached. */
-static struct demofs_block *
-demofs_block_lookup_rcu(
-    struct demofs_thread *thread,
-    uint32_t              device_id,
-    uint64_t              device_offset)
-{
-    struct demofs_block_cache *cache  = thread->shared->block_cache;
-    uint64_t                   hash   = demofs_block_hash(device_id, device_offset);
-    uint32_t                   sidx   = hash & DEMOFS_BLOCK_CACHE_SHARD_MASK;
-    uint32_t                   bucket = (hash >> 8) & DEMOFS_BLOCK_CACHE_BUCKET_MASK;
-    struct demofs_block_shard *shard  = &cache->shards[sidx];
-    struct demofs_block       *blk;
-
-    for (blk = rcu_dereference(shard->buckets[bucket]); blk;
-         blk = rcu_dereference(blk->hash_next)) {
-        if (blk->device_id == device_id && blk->device_offset == device_offset) {
-            return blk;
-        }
-    }
-    return NULL;
-} /* demofs_block_lookup_rcu */
 
 static inline int
 demofs_bt_key_cmp(
@@ -1771,8 +2080,6 @@ demofs_bt_insert(
     }
 } /* demofs_bt_insert */
 
-#define DEMOFS_BT_MAX_DEPTH 16
-
 /* A node (other than the root) is too empty and must borrow/merge once it
  * holds less than half its capacity: leaves measured in bytes (slots +
  * records), interior nodes in slot count. */
@@ -2242,12 +2549,216 @@ demofs_bt_remove(
     return 1;
 } /* demofs_bt_remove */
 
+/* ------------------------------------------------------------------ */
+/* Async b+tree operation driver                                       */
+/* ------------------------------------------------------------------ */
+
+/* Copy a leaf slot's record + key into the op's output; returns true length. */
+static inline int
+demofs_bt_op_emit(
+    struct demofs_bt_op *op,
+    void                *buf,
+    uint32_t             base,
+    int                  idx)
+{
+    struct demofs_bt_lslot *sl  = demofs_bt_lslots(buf, base);
+    uint32_t                len = sl[idx].len;
+
+    if (op->r_key) {
+        *op->r_key = sl[idx].key;
+    }
+    if (len > op->out_cap) {
+        len = op->out_cap;
+    }
+    if (op->out) {
+        memcpy(op->out, (char *) buf + base + sl[idx].off, len);
+    }
+    return (int) sl[idx].len;
+} /* demofs_bt_op_emit */
+
+static inline void
+demofs_bt_complete(
+    struct demofs_bt_op *op,
+    int                  result)
+{
+    op->cb(op, result, op->private_data);
+} /* demofs_bt_complete */
+
 /*
- * Copy out the record for an exact key match.  Read path: traverses via the
- * RCU block cache, one critical section per node.  Returns the record
- * length (copied into out, up to out_cap) or -1 if not found.  Phase 1
- * aborts if a needed node is not resident.
+ * Drive (or resume) an async b+tree operation.  The traversal suspends and
+ * returns whenever a needed node is not resident (demofs_bt_block_get parks
+ * the op on the block's waiter list); it is re-entered here from the resume
+ * queue once the block loads.  All per-step state lives in *op so the loop is
+ * safe to re-enter from the top of the current phase.
  */
+static void
+demofs_bt_run(struct demofs_bt_op *op)
+{
+    struct demofs_thread *thread = op->thread;
+    struct demofs_inode  *inode  = op->inode;
+    struct demofs_block  *blk;
+    void                 *buf;
+    uint32_t              base;
+    uint32_t              dev;
+    uint64_t              off;
+
+    switch (op->opcode) {
+        case DEMOFS_BT_OP_LOOKUP_EXACT:
+        case DEMOFS_BT_OP_LOOKUP_GE:
+        case DEMOFS_BT_OP_LOOKUP_LE:
+            break;
+        default:
+            chimera_demofs_abort("demofs_bt_run: opcode %d not async yet", op->opcode);
+            return;
+    } /* switch */
+
+    for (;; ) {
+        struct demofs_bt_node_hdr *h;
+
+        if (op->phase == DEMOFS_BT_PHASE_DESCEND && op->use_root) {
+            off  = sm_inum_to_device_offset(thread->shared->space_map, inode->inum, &dev);
+            base = DEMOFS_BT_ROOT_BASE;
+        } else {
+            off  = sm_inum_to_device_offset(thread->shared->space_map, op->cur_bptr, &dev);
+            base = 0;
+        }
+
+        blk = demofs_bt_block_get(op, dev, off);
+        if (!blk) {
+            return;     /* suspended; resumed when the block loads */
+        }
+        buf = blk->buffer;
+        h   = demofs_bt_hdr(buf, base);
+
+        if (op->phase == DEMOFS_BT_PHASE_DESCEND) {
+            if (h->level > 0) {
+                int ci = demofs_bt_interior_search(buf, base, &op->key);
+
+                op->cur_bptr = demofs_bt_islots(buf, base)[ci].child;
+                op->use_root = 0;
+                continue;
+            }
+
+            /* At the leaf. */
+            if (op->opcode == DEMOFS_BT_OP_LOOKUP_EXACT) {
+                int exact, idx = demofs_bt_leaf_search(buf, base, &op->key, &exact);
+
+                demofs_bt_complete(op, exact ? demofs_bt_op_emit(op, buf, base, idx) : -1);
+                return;
+            } else if (op->opcode == DEMOFS_BT_OP_LOOKUP_GE) {
+                int exact, idx = h->nitems ? demofs_bt_leaf_search(buf, base, &op->key, &exact) : 0;
+
+                if (idx < h->nitems) {
+                    demofs_bt_complete(op, demofs_bt_op_emit(op, buf, base, idx));
+                    return;
+                }
+                op->cur_bptr = h->next_leaf;
+                op->use_root = 0;
+                op->phase    = DEMOFS_BT_PHASE_WALK_NEXT;
+                if (op->cur_bptr == 0) {
+                    demofs_bt_complete(op, -1);
+                    return;
+                }
+                continue;
+            } else {     /* LOOKUP_LE */
+                int exact = 0;
+                int idx   = h->nitems ? demofs_bt_leaf_search(buf, base, &op->key, &exact) : 0;
+                int fidx  = h->nitems ? (exact ? idx : idx - 1) : -1;
+
+                if (fidx >= 0) {
+                    demofs_bt_complete(op, demofs_bt_op_emit(op, buf, base, fidx));
+                    return;
+                }
+                op->cur_bptr = h->prev_leaf;
+                op->use_root = 0;
+                op->phase    = DEMOFS_BT_PHASE_WALK_PREV;
+                if (op->cur_bptr == 0) {
+                    demofs_bt_complete(op, -1);
+                    return;
+                }
+                continue;
+            }
+        } else if (op->phase == DEMOFS_BT_PHASE_WALK_NEXT) {
+            if (h->nitems > 0) {
+                demofs_bt_complete(op, demofs_bt_op_emit(op, buf, 0, 0));
+                return;
+            }
+            op->cur_bptr = h->next_leaf;
+            if (op->cur_bptr == 0) {
+                demofs_bt_complete(op, -1);
+                return;
+            }
+            continue;
+        } else {     /* DEMOFS_BT_PHASE_WALK_PREV */
+            if (h->nitems > 0) {
+                demofs_bt_complete(op, demofs_bt_op_emit(op, buf, 0, h->nitems - 1));
+                return;
+            }
+            op->cur_bptr = h->prev_leaf;
+            if (op->cur_bptr == 0) {
+                demofs_bt_complete(op, -1);
+                return;
+            }
+            continue;
+        }
+    }
+} /* demofs_bt_run */
+
+/*
+ * Synchronous-completion sink for the transitional sync wrappers below: every
+ * traversal currently hits in cache, so the op completes inline before the
+ * entry point returns and we capture the result here.
+ */
+struct demofs_bt_sync {
+    int done;
+    int result;
+};
+
+static void
+demofs_bt_sync_cb(
+    struct demofs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct demofs_bt_sync *s = private_data;
+
+    (void) op;
+    s->result = result;
+    s->done   = 1;
+} /* demofs_bt_sync_cb */
+
+static int
+demofs_bt_lookup_sync(
+    struct demofs_thread       *thread,
+    struct demofs_inode        *inode,
+    enum demofs_bt_opcode       opcode,
+    const struct demofs_bt_key *key,
+    struct demofs_bt_key       *r_key,
+    void                       *out,
+    uint32_t                    out_cap)
+{
+    struct demofs_bt_op   op;
+    struct demofs_bt_sync s = { .done = 0, .result = -1 };
+
+    memset(&op, 0, sizeof(op));
+    op.thread       = thread;
+    op.inode        = inode;
+    op.opcode       = opcode;
+    op.phase        = DEMOFS_BT_PHASE_DESCEND;
+    op.key          = *key;
+    op.r_key        = r_key;
+    op.out          = out;
+    op.out_cap      = out_cap;
+    op.use_root     = 1;
+    op.cb           = demofs_bt_sync_cb;
+    op.private_data = &s;
+
+    demofs_bt_run(&op);
+    chimera_demofs_abort_if(!s.done,
+                            "b+tree lookup suspended on a cache miss (no eviction yet)");
+    return s.result;
+} /* demofs_bt_lookup_sync */
+
 static int
 demofs_bt_lookup_exact(
     struct demofs_thread       *thread,
@@ -2256,54 +2767,8 @@ demofs_bt_lookup_exact(
     void                       *out,
     uint32_t                    out_cap)
 {
-    uint32_t device_id;
-    uint64_t device_offset;
-    uint64_t bptr = 0;
-    void    *buf;
-    uint32_t base;
-    int      result   = -1;
-    int      use_root = 1;
-
-    device_offset = sm_inum_to_device_offset(thread->shared->space_map, inode->inum, &device_id);
-
-    for (;; ) {
-        struct demofs_block *blk;
-
-        urcu_memb_read_lock();
-        if (use_root) {
-            blk = demofs_block_lookup_rcu(thread, device_id, device_offset);
-        } else {
-            uint32_t cdev;
-            uint64_t coff = sm_inum_to_device_offset(thread->shared->space_map, bptr, &cdev);
-            blk = demofs_block_lookup_rcu(thread, cdev, coff);
-        }
-        chimera_demofs_abort_if(!blk, "b+tree read: node not resident (inum %lu)", inode->inum);
-
-        buf  = blk->buffer;
-        base = use_root ? DEMOFS_BT_ROOT_BASE : 0;
-
-        struct demofs_bt_node_hdr *h = demofs_bt_hdr(buf, base);
-        if (h->level == 0) {
-            int exact;
-            int idx = demofs_bt_leaf_search(buf, base, key, &exact);
-            if (exact) {
-                struct demofs_bt_lslot *sl  = demofs_bt_lslots(buf, base);
-                uint32_t                len = sl[idx].len;
-                if (len > out_cap) {
-                    len = out_cap;
-                }
-                memcpy(out, (char *) buf + base + sl[idx].off, len);
-                result = (int) sl[idx].len;
-            }
-            urcu_memb_read_unlock();
-            return result;
-        } else {
-            int ci = demofs_bt_interior_search(buf, base, key);
-            bptr = demofs_bt_islots(buf, base)[ci].child;
-            urcu_memb_read_unlock();
-            use_root = 0;
-        }
-    }
+    return demofs_bt_lookup_sync(thread, inode, DEMOFS_BT_OP_LOOKUP_EXACT,
+                                 key, NULL, out, out_cap);
 } /* demofs_bt_lookup_exact */
 
 /* Descend (floor-style) to the leaf that would hold key.  Returns the leaf
@@ -2324,88 +2789,8 @@ demofs_bt_lookup_ge(
     void                       *out,
     uint32_t                    out_cap)
 {
-    uint32_t device_id;
-    uint64_t device_offset;
-    uint64_t bptr      = 0;
-    int      use_root  = 1;
-    uint64_t next_leaf = 0;
-
-    device_offset = sm_inum_to_device_offset(thread->shared->space_map, inode->inum, &device_id);
-
-    for (;; ) {
-        struct demofs_block       *blk;
-        struct demofs_bt_node_hdr *h;
-        void                      *buf;
-        uint32_t                   base;
-
-        urcu_memb_read_lock();
-        if (use_root) {
-            blk = demofs_block_lookup_rcu(thread, device_id, device_offset);
-        } else {
-            uint32_t cdev;
-            uint64_t coff = sm_inum_to_device_offset(thread->shared->space_map, bptr, &cdev);
-            blk = demofs_block_lookup_rcu(thread, cdev, coff);
-        }
-        chimera_demofs_abort_if(!blk, "b+tree read: node not resident (inum %lu)", inode->inum);
-
-        buf  = blk->buffer;
-        base = use_root ? DEMOFS_BT_ROOT_BASE : 0;
-        h    = demofs_bt_hdr(buf, base);
-
-        if (h->level == 0) {
-            int exact;
-            int idx = demofs_bt_leaf_search(buf, base, key, &exact);
-
-            if (idx < h->nitems) {
-                struct demofs_bt_lslot *sl  = demofs_bt_lslots(buf, base);
-                uint32_t                len = sl[idx].len;
-
-                *r_key = sl[idx].key;
-                if (len > out_cap) {
-                    len = out_cap;
-                }
-                memcpy(out, (char *) buf + base + sl[idx].off, len);
-                len = sl[idx].len;
-                urcu_memb_read_unlock();
-                return (int) len;
-            }
-            next_leaf = h->next_leaf;
-            urcu_memb_read_unlock();
-
-            /* The successor is the first slot of the nearest non-empty leaf to
-             * the right.  Lazy deletion can leave emptied leaves in the chain,
-             * so walk next_leaf until a populated leaf is found. */
-            while (next_leaf) {
-                uint32_t cdev;
-                uint64_t coff = sm_inum_to_device_offset(thread->shared->space_map, next_leaf, &cdev);
-
-                urcu_memb_read_lock();
-                blk = demofs_block_lookup_rcu(thread, cdev, coff);
-                chimera_demofs_abort_if(!blk, "b+tree read: next leaf not resident");
-                h = demofs_bt_hdr(blk->buffer, 0);
-                if (h->nitems > 0) {
-                    struct demofs_bt_lslot *sl  = demofs_bt_lslots(blk->buffer, 0);
-                    uint32_t                len = sl[0].len;
-                    *r_key = sl[0].key;
-                    if (len > out_cap) {
-                        len = out_cap;
-                    }
-                    memcpy(out, (char *) blk->buffer + sl[0].off, len);
-                    len = sl[0].len;
-                    urcu_memb_read_unlock();
-                    return (int) len;
-                }
-                next_leaf = h->next_leaf;
-                urcu_memb_read_unlock();
-            }
-            return -1;     /* no key >= search */
-        } else {
-            int ci = demofs_bt_interior_search(buf, base, key);
-            bptr = demofs_bt_islots(buf, base)[ci].child;
-            urcu_memb_read_unlock();
-            use_root = 0;
-        }
-    }
+    return demofs_bt_lookup_sync(thread, inode, DEMOFS_BT_OP_LOOKUP_GE,
+                                 key, r_key, out, out_cap);
 } /* demofs_bt_lookup_ge */
 
 /*
@@ -2421,98 +2806,8 @@ demofs_bt_lookup_le(
     void                       *out,
     uint32_t                    out_cap)
 {
-    uint32_t device_id;
-    uint64_t device_offset;
-    uint64_t bptr     = 0;
-    int      use_root = 1;
-
-    device_offset = sm_inum_to_device_offset(thread->shared->space_map, inode->inum, &device_id);
-
-    for (;; ) {
-        struct demofs_block       *blk;
-        struct demofs_bt_node_hdr *h;
-        void                      *buf;
-        uint32_t                   base;
-
-        urcu_memb_read_lock();
-        if (use_root) {
-            blk = demofs_block_lookup_rcu(thread, device_id, device_offset);
-        } else {
-            uint32_t cdev;
-            uint64_t coff = sm_inum_to_device_offset(thread->shared->space_map, bptr, &cdev);
-            blk = demofs_block_lookup_rcu(thread, cdev, coff);
-        }
-        chimera_demofs_abort_if(!blk, "b+tree read: node not resident (inum %lu)", inode->inum);
-
-        buf  = blk->buffer;
-        base = use_root ? DEMOFS_BT_ROOT_BASE : 0;
-        h    = demofs_bt_hdr(buf, base);
-
-        if (h->level == 0) {
-            int      exact = 0;
-            int      idx   = h->nitems ? demofs_bt_leaf_search(buf, base, key, &exact) : 0;
-            int      fidx  = h->nitems ? (exact ? idx : idx - 1) : -1;
-            uint64_t prev;
-
-            if (fidx >= 0) {
-                struct demofs_bt_lslot *sl  = demofs_bt_lslots(buf, base);
-                uint32_t                len = sl[fidx].len;
-
-                *r_key = sl[fidx].key;
-                if (len > out_cap) {
-                    len = out_cap;
-                }
-                memcpy(out, (char *) buf + base + sl[fidx].off, len);
-                len = sl[fidx].len;
-                urcu_memb_read_unlock();
-                return (int) len;
-            }
-
-            /* No key <= search in this leaf.  Lazy deletion can leave a
-             * parent separator pointing below a leaf's true minimum (or at an
-             * emptied leaf), so the floor may be the last key of a leaf to the
-             * left.  Walk the prev chain, skipping empties. */
-            prev = h->prev_leaf;
-            urcu_memb_read_unlock();
-
-            while (prev) {
-                uint32_t                   pdev;
-                uint64_t                   poff;
-                struct demofs_block       *pblk;
-                struct demofs_bt_node_hdr *ph;
-
-                poff = sm_inum_to_device_offset(thread->shared->space_map, prev, &pdev);
-
-                urcu_memb_read_lock();
-                pblk = demofs_block_lookup_rcu(thread, pdev, poff);
-                chimera_demofs_abort_if(!pblk, "b+tree read: prev leaf not resident");
-                ph = demofs_bt_hdr(pblk->buffer, 0);
-
-                if (ph->nitems > 0) {
-                    struct demofs_bt_lslot *sl  = demofs_bt_lslots(pblk->buffer, 0);
-                    int                     li  = ph->nitems - 1;
-                    uint32_t                len = sl[li].len;
-
-                    *r_key = sl[li].key;
-                    if (len > out_cap) {
-                        len = out_cap;
-                    }
-                    memcpy(out, (char *) pblk->buffer + sl[li].off, len);
-                    len = sl[li].len;
-                    urcu_memb_read_unlock();
-                    return (int) len;
-                }
-                prev = ph->prev_leaf;
-                urcu_memb_read_unlock();
-            }
-            return -1;
-        } else {
-            int ci = demofs_bt_interior_search(buf, base, key);
-            bptr = demofs_bt_islots(buf, base)[ci].child;
-            urcu_memb_read_unlock();
-            use_root = 0;
-        }
-    }
+    return demofs_bt_lookup_sync(thread, inode, DEMOFS_BT_OP_LOOKUP_LE,
+                                 key, r_key, out, out_cap);
 } /* demofs_bt_lookup_le */
 
 /* ------------------------------------------------------------------ */
@@ -3826,6 +4121,14 @@ demofs_thread_init(
     thread->grant_tail = NULL;
     evpl_add_doorbell(evpl, &thread->grant_doorbell, demofs_grant_doorbell_cb);
 
+    /* B+tree op resume queue: doorbell (cross-thread) + deferral (same-thread). */
+    pthread_mutex_init(&thread->resume_lock, NULL);
+    thread->resume_head     = NULL;
+    thread->resume_tail     = NULL;
+    thread->bt_op_free_list = NULL;
+    evpl_add_doorbell(evpl, &thread->resume_doorbell, demofs_bt_resume_doorbell_cb);
+    evpl_deferral_init(&thread->resume_deferral, demofs_bt_resume_deferral_cb, thread);
+
     pthread_mutex_lock(&shared->lock);
     thread->thread_id = shared->num_active_threads++;
     pthread_mutex_unlock(&shared->lock);
@@ -3887,6 +4190,15 @@ demofs_thread_destroy(void *private_data)
 
     evpl_remove_doorbell(thread->evpl, &thread->grant_doorbell);
     pthread_mutex_destroy(&thread->grant_lock);
+
+    evpl_remove_doorbell(thread->evpl, &thread->resume_doorbell);
+    pthread_mutex_destroy(&thread->resume_lock);
+
+    while (thread->bt_op_free_list) {
+        struct demofs_bt_op *op = thread->bt_op_free_list;
+        thread->bt_op_free_list = op->next;
+        free(op);
+    }
 
     while (thread->txn_free_list) {
         struct demofs_txn *txn = thread->txn_free_list;

--- a/src/vfs/demofs/demofs.c
+++ b/src/vfs/demofs/demofs.c
@@ -18,6 +18,7 @@
 #include <utlist.h>
 #include <urcu.h>
 #include <urcu/urcu-memb.h>
+#include <xxhash.h>     /* XXH_INLINE_ALL set in CMakeLists; header-only */
 
 #include "common/varint.h"
 #include "common/rbtree.h"
@@ -443,9 +444,25 @@ _Static_assert(DEMOFS_DIRENT_REC_MAX <= 320,
  */
 #define DEMOFS_REDO_MAGIC     0x4F44455246534944ULL /* "DISFREDO" */
 
+/*
+ * Redo record on-log layout: this header, then num_blocks
+ * {demofs_redo_block_header, 4 KiB image} pairs, padded to a 4 KiB multiple.
+ *
+ * `magic` is the scan signature and `csum_{lo,hi}` is an XXH3-128 over the
+ * entire record (reclen bytes) computed with the csum fields zeroed.  Together
+ * they let crash recovery locate intact records anywhere in the (possibly
+ * wrapped) circular log: probe 4 KiB boundaries for the magic, then accept the
+ * record only if the 128-bit hash over `reclen` bytes verifies -- a partially
+ * overwritten or torn record fails and is skipped.  `seq` orders records
+ * (latest image of a block wins) and `tail` is the log tail at write time, so
+ * recovery bounds replay to [tail, head] from the highest-seq record.
+ */
 struct demofs_redo_header {
     uint64_t magic;
+    uint64_t csum_lo;      /* XXH3-128 of the record, csum fields zeroed */
+    uint64_t csum_hi;
     uint64_t seq;          /* monotonically increasing record sequence */
+    uint64_t tail;         /* log_tail (oldest un-pushed offset) at write time */
     uint32_t num_blocks;
     uint32_t reclen;       /* total record length, including padding */
 };
@@ -4377,7 +4394,10 @@ demofs_il_write_redo(
     p               = (char *) rec->iov.data;
     hdr             = (struct demofs_redo_header *) p;
     hdr->magic      = DEMOFS_REDO_MAGIC;
+    hdr->csum_lo    = 0;
+    hdr->csum_hi    = 0;
     hdr->seq        = il->log_seq++;
+    hdr->tail       = il->log_tail;
     hdr->num_blocks = nblocks;
     hdr->reclen     = (uint32_t) reclen;
     p              += sizeof(*hdr);
@@ -4393,6 +4413,22 @@ demofs_il_write_redo(
 
         memcpy(p, blk->buffer, DEMOFS_BLOCK_SIZE);
         p += DEMOFS_BLOCK_SIZE;
+    }
+
+    /* Zero the tail padding (reclen is 4 KiB-rounded) so the checksum covers
+     * deterministic bytes, then stamp the XXH3-128 over the whole record. */
+    {
+        char *end = (char *) rec->iov.data + reclen;
+
+        if (p < end) {
+            memset(p, 0, (size_t) (end - p));
+        }
+    }
+    {
+        XXH128_hash_t h = XXH3_128bits(rec->iov.data, reclen);
+
+        hdr->csum_lo = h.low64;
+        hdr->csum_hi = h.high64;
     }
 
     ch->cq_inflight++;

--- a/src/vfs/demofs/demofs.c
+++ b/src/vfs/demofs/demofs.c
@@ -649,6 +649,7 @@ struct demofs_bt_op {
     void                     *out;
     uint32_t                  out_cap;
     struct demofs_bt_key     *r_key;
+    struct demofs_bt_key      found_key;   /* op-owned storage for r_key */
 
     /* traversal cursor */
     uint64_t                  cur_bptr;
@@ -5554,21 +5555,48 @@ demofs_readdir_iter_inode_cb(
 } /* demofs_readdir_iter_inode_cb */
 
 static void
-demofs_readdir_iter_step(struct chimera_vfs_request *request)
+demofs_readdir_next_cb(
+    struct demofs_bt_op *op,
+    int                  result,
+    void                *private_data)
 {
-    struct demofs_request_private *p      = request->plugin_data;
-    struct demofs_thread          *thread = p->thread;
-    struct demofs_inode           *inode  = p->inode_stash[0];
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+    struct demofs_thread          *thread  = p->thread;
+    struct demofs_dirent_rec      *rec     = (struct demofs_dirent_rec *) p->rec_scratch;
 
-    if (demofs_dir_next(thread, inode, p->rd_from_hash, &p->rd_hash,
-                        &p->rd_inum, &p->rd_gen, p->rd_name, &p->rd_namelen) != 0) {
+    if (result < 0 || op->found_key.type != DEMOFS_REC_DIRENT) {
+        demofs_bt_op_free(thread, op);
         request->readdir.r_eof = 1;
         demofs_readdir_complete(request);
         return;
     }
 
+    p->rd_hash    = op->found_key.subkey;
+    p->rd_inum    = rec->inum;
+    p->rd_gen     = rec->gen;
+    p->rd_namelen = rec->name_len;
+    memcpy(p->rd_name, rec->name, rec->name_len);
+
+    demofs_bt_op_free(thread, op);
+
     demofs_inode_get_inum_async(thread, p->txn, p->rd_inum, p->rd_gen,
                                 demofs_readdir_iter_inode_cb, request);
+} /* demofs_readdir_next_cb */
+
+static void
+demofs_readdir_iter_step(struct chimera_vfs_request *request)
+{
+    struct demofs_request_private *p      = request->plugin_data;
+    struct demofs_thread          *thread = p->thread;
+    struct demofs_inode           *inode  = p->inode_stash[0];
+    struct demofs_bt_op           *op     = demofs_bt_op_alloc(thread);
+
+    if (demofs_dir_next_async(op, thread, inode, p->rd_from_hash, &op->found_key,
+                              p->rec_scratch, sizeof(p->rec_scratch),
+                              demofs_readdir_next_cb, request)) {
+        demofs_readdir_next_cb(op, op->result, request);
+    }
 } /* demofs_readdir_iter_step */
 
 static void
@@ -7431,46 +7459,33 @@ demofs_rename_at_existing_cb(
     demofs_rename_at_perform(request);
 } /* demofs_rename_at_existing_cb */
 
+/*
+ * Perform stage, async-chained: [remove dest dirent] -> insert new dirent ->
+ * remove source dirent -> commit.  old_inum/old_gen live in rd_inum/rd_gen
+ * (captured by the source lookup); the source parent stays write-locked so no
+ * re-verify lookup is needed.
+ */
+static void demofs_rename_at_perform_insert(
+    struct chimera_vfs_request *request);
+
 static void
-demofs_rename_at_perform(struct chimera_vfs_request *request)
+demofs_rename_at_perform_final_cb(
+    struct demofs_bt_op *bop,
+    int                  result,
+    void                *private_data)
 {
-    struct demofs_request_private *p              = request->plugin_data;
-    struct demofs_thread          *thread         = p->thread;
-    struct demofs_inode           *op             = p->inode_stash[0];
-    struct demofs_inode           *np             = p->inode_stash[1];
-    struct demofs_inode           *child          = p->inode_stash[2];
-    struct demofs_inode           *existing_inode = p->inode_stash[3];
-    uint64_t                       hash           = request->rename_at.name_hash;
-    uint64_t                       new_hash       = request->rename_at.new_name_hash;
-    uint64_t                       old_inum;
-    uint32_t                       old_gen;
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+    struct demofs_thread          *thread  = p->thread;
+    struct demofs_inode           *op      = p->inode_stash[0];
+    struct demofs_inode           *np      = p->inode_stash[1];
+    struct demofs_inode           *child   = p->inode_stash[2];
     struct timespec                now;
 
+    (void) result;
+    demofs_bt_op_free(thread, bop);
+
     clock_gettime(CLOCK_REALTIME, &now);
-
-    /* The source dirent was verified before we fetched the child and the
-     * source parent has been write-locked the whole time, so it must still
-     * be present. */
-    if (unlikely(demofs_dir_lookup(thread, op, hash, &old_inum, &old_gen) != 0)) {
-        demofs_rename_at_unlock_parents(request);
-        demofs_op_fail(request, p->txn, CHIMERA_VFS_ENOENT);
-        return;
-    }
-
-    if (existing_inode) {
-        if (demofs_dir_remove(thread, p->txn, np, new_hash) == 1) {
-            existing_inode->nlink--;
-            if (S_ISDIR(existing_inode->mode)) {
-                np->nlink--;
-            }
-        }
-    }
-
-    demofs_dir_insert(thread, p->txn, np, new_hash,
-                      request->rename_at.new_name, request->rename_at.new_namelen,
-                      old_inum, old_gen);
-
-    demofs_dir_remove(thread, p->txn, op, hash);
 
     if (S_ISDIR(child->mode)) {
         op->nlink--;
@@ -7493,7 +7508,129 @@ demofs_rename_at_perform(struct chimera_vfs_request *request)
 
     demofs_rename_at_unlock_parents(request);
     demofs_op_ok(request, p->txn);
+} /* demofs_rename_at_perform_final_cb */
+
+static void
+demofs_rename_at_perform_inserted_cb(
+    struct demofs_bt_op *bop,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+    struct demofs_thread          *thread  = p->thread;
+
+    (void) result;
+    demofs_bt_op_free(thread, bop);
+
+    bop = demofs_bt_op_alloc(thread);
+    if (demofs_dir_remove_async(bop, thread, p->txn, p->inode_stash[0],
+                                request->rename_at.name_hash,
+                                demofs_rename_at_perform_final_cb, request)) {
+        demofs_rename_at_perform_final_cb(bop, bop->result, request);
+    }
+} /* demofs_rename_at_perform_inserted_cb */
+
+static void
+demofs_rename_at_perform_insert(struct chimera_vfs_request *request)
+{
+    struct demofs_request_private *p      = request->plugin_data;
+    struct demofs_thread          *thread = p->thread;
+    struct demofs_bt_op           *bop    = demofs_bt_op_alloc(thread);
+
+    if (demofs_dir_insert_async(bop, thread, p->txn, p->inode_stash[1],
+                                request->rename_at.new_name_hash,
+                                request->rename_at.new_name,
+                                request->rename_at.new_namelen,
+                                p->rd_inum, p->rd_gen,
+                                demofs_rename_at_perform_inserted_cb, request)) {
+        demofs_rename_at_perform_inserted_cb(bop, bop->result, request);
+    }
+} /* demofs_rename_at_perform_insert */
+
+static void
+demofs_rename_at_perform_removed_cb(
+    struct demofs_bt_op *bop,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request        = private_data;
+    struct demofs_request_private *p              = request->plugin_data;
+    struct demofs_inode           *np             = p->inode_stash[1];
+    struct demofs_inode           *existing_inode = p->inode_stash[3];
+
+    demofs_bt_op_free(p->thread, bop);
+
+    if (result == 1) {
+        existing_inode->nlink--;
+        if (S_ISDIR(existing_inode->mode)) {
+            np->nlink--;
+        }
+    }
+
+    demofs_rename_at_perform_insert(request);
+} /* demofs_rename_at_perform_removed_cb */
+
+static void
+demofs_rename_at_perform(struct chimera_vfs_request *request)
+{
+    struct demofs_request_private *p              = request->plugin_data;
+    struct demofs_thread          *thread         = p->thread;
+    struct demofs_inode           *existing_inode = p->inode_stash[3];
+    struct demofs_bt_op           *bop;
+
+    if (existing_inode) {
+        bop = demofs_bt_op_alloc(thread);
+        if (demofs_dir_remove_async(bop, thread, p->txn, p->inode_stash[1],
+                                    request->rename_at.new_name_hash,
+                                    demofs_rename_at_perform_removed_cb, request)) {
+            demofs_rename_at_perform_removed_cb(bop, bop->result, request);
+        }
+        return;
+    }
+
+    demofs_rename_at_perform_insert(request);
 } /* demofs_rename_at_perform */
+
+/* The dest-name lookup completed; decide replace vs hardlink-shortcut. */
+static void
+demofs_rename_at_dest_cb(
+    struct demofs_bt_op *bop,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+    struct demofs_thread          *thread  = p->thread;
+    struct demofs_inode           *op      = p->inode_stash[0];
+    struct demofs_inode           *np      = p->inode_stash[1];
+    struct demofs_dirent_rec      *rec     = (struct demofs_dirent_rec *) p->rec_scratch;
+    uint64_t                       existing_inum;
+    uint32_t                       existing_gen;
+
+    demofs_bt_op_free(thread, bop);
+
+    if (result < 0) {
+        p->inode_stash[3] = NULL;
+        demofs_rename_at_perform(request);
+        return;
+    }
+
+    existing_inum = rec->inum;
+    existing_gen  = rec->gen;
+
+    /* Hardlink shortcut: source and dest already refer to the same inode. */
+    if (existing_inum == p->rd_inum && existing_gen == p->rd_gen) {
+        demofs_map_attrs(thread, &request->rename_at.r_fromdir_post_attr, op);
+        demofs_map_attrs(thread, &request->rename_at.r_todir_post_attr, np);
+        demofs_rename_at_unlock_parents(request);
+        demofs_op_ok(request, p->txn);
+        return;
+    }
+
+    demofs_inode_get_inum_async(thread, p->txn, existing_inum, existing_gen,
+                                demofs_rename_at_existing_cb, request);
+} /* demofs_rename_at_dest_cb */
 
 static void
 demofs_rename_at_child_cb(
@@ -7501,15 +7638,11 @@ demofs_rename_at_child_cb(
     int                  status,
     void                *private_data)
 {
-    struct chimera_vfs_request    *request  = private_data;
-    struct demofs_request_private *p        = request->plugin_data;
-    struct demofs_thread          *thread   = p->thread;
-    struct demofs_inode           *op       = p->inode_stash[0];
-    struct demofs_inode           *np       = p->inode_stash[1];
-    uint64_t                       hash     = request->rename_at.name_hash;
-    uint64_t                       new_hash = request->rename_at.new_name_hash;
-    uint64_t                       old_inum, existing_inum;
-    uint32_t                       old_gen, existing_gen;
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+    struct demofs_thread          *thread  = p->thread;
+    struct demofs_inode           *np      = p->inode_stash[1];
+    struct demofs_bt_op           *bop;
 
     if (unlikely(status != CHIMERA_VFS_OK)) {
         demofs_rename_at_unlock_parents(request);
@@ -7519,31 +7652,41 @@ demofs_rename_at_child_cb(
 
     p->inode_stash[2] = child;
 
-    if (unlikely(demofs_dir_lookup(thread, op, hash, &old_inum, &old_gen) != 0)) {
+    bop = demofs_bt_op_alloc(thread);
+    if (demofs_dir_lookup_async(bop, thread, np, request->rename_at.new_name_hash,
+                                p->rec_scratch, sizeof(p->rec_scratch),
+                                demofs_rename_at_dest_cb, request)) {
+        demofs_rename_at_dest_cb(bop, bop->result, request);
+    }
+} /* demofs_rename_at_child_cb */
+
+/* The source-name lookup completed; capture old inum/gen and fetch the
+ * child inode. */
+static void
+demofs_rename_at_source_cb(
+    struct demofs_bt_op *bop,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+    struct demofs_thread          *thread  = p->thread;
+    struct demofs_dirent_rec      *rec     = (struct demofs_dirent_rec *) p->rec_scratch;
+
+    demofs_bt_op_free(thread, bop);
+
+    if (result < 0) {
         demofs_rename_at_unlock_parents(request);
         demofs_op_fail(request, p->txn, CHIMERA_VFS_ENOENT);
         return;
     }
 
-    if (demofs_dir_lookup(thread, np, new_hash, &existing_inum, &existing_gen) != 0) {
-        p->inode_stash[3] = NULL;
-        demofs_rename_at_perform(request);
-        return;
-    }
+    p->rd_inum = rec->inum;
+    p->rd_gen  = rec->gen;
 
-    /* Hardlink shortcut: source and dest already refer to the same inode. */
-    if (existing_inum == old_inum && existing_gen == old_gen) {
-        demofs_map_attrs(thread, &request->rename_at.r_fromdir_post_attr, op);
-        demofs_map_attrs(thread, &request->rename_at.r_todir_post_attr, np);
-        demofs_rename_at_unlock_parents(request);
-        demofs_op_ok(request, p->txn);
-        return;
-    }
-
-    demofs_inode_get_inum_async(thread, p->txn,
-                                existing_inum, existing_gen,
-                                demofs_rename_at_existing_cb, request);
-} /* demofs_rename_at_child_cb */
+    demofs_inode_get_inum_async(thread, p->txn, rec->inum, rec->gen,
+                                demofs_rename_at_child_cb, request);
+} /* demofs_rename_at_source_cb */
 
 static void
 demofs_rename_at_have_parents(struct chimera_vfs_request *request)
@@ -7552,22 +7695,17 @@ demofs_rename_at_have_parents(struct chimera_vfs_request *request)
     struct demofs_thread          *thread = p->thread;
     struct demofs_inode           *op     = p->inode_stash[0];
     struct demofs_inode           *np     = p->inode_stash[1];
-    uint64_t                       hash   = request->rename_at.name_hash;
-    uint64_t                       old_inum;
-    uint32_t                       old_gen;
+    struct demofs_bt_op           *bop;
 
     demofs_map_attrs(thread, &request->rename_at.r_fromdir_pre_attr, op);
     demofs_map_attrs(thread, &request->rename_at.r_todir_pre_attr, np);
 
-    if (demofs_dir_lookup(thread, op, hash, &old_inum, &old_gen) != 0) {
-        demofs_rename_at_unlock_parents(request);
-        demofs_op_fail(request, p->txn, CHIMERA_VFS_ENOENT);
-        return;
+    bop = demofs_bt_op_alloc(thread);
+    if (demofs_dir_lookup_async(bop, thread, op, request->rename_at.name_hash,
+                                p->rec_scratch, sizeof(p->rec_scratch),
+                                demofs_rename_at_source_cb, request)) {
+        demofs_rename_at_source_cb(bop, bop->result, request);
     }
-
-    demofs_inode_get_inum_async(thread, p->txn,
-                                old_inum, old_gen,
-                                demofs_rename_at_child_cb, request);
 } /* demofs_rename_at_have_parents */
 
 static void

--- a/src/vfs/demofs/demofs.c
+++ b/src/vfs/demofs/demofs.c
@@ -1413,6 +1413,36 @@ demofs_txn_add_block(
     txn->blocks = tb;
 } /* demofs_txn_add_block */
 
+/*
+ * Journal bridge for the space-map allocation log: claim the AG-log block and
+ * pin it into the allocating transaction so the delta written into it rides
+ * the main redo log (durable + replayed on crash).  Passed to space_map_alloc/
+ * free as a struct sm_journal.
+ */
+struct demofs_sm_jnl {
+    struct demofs_thread *thread;
+    struct demofs_txn    *txn;
+};
+
+static void *
+demofs_sm_claim_block(
+    void    *user,
+    uint32_t device_id,
+    uint64_t device_offset,
+    int      is_new)
+{
+    struct demofs_sm_jnl *c   = user;
+    struct demofs_block  *blk = demofs_block_claim(c->thread, device_id,
+                                                   device_offset, is_new);
+
+    demofs_txn_add_block(c->txn, blk);
+    return blk->buffer;
+} /* demofs_sm_claim_block */
+
+#define DEMOFS_SM_JNL(name, thr, t)                          \
+        struct demofs_sm_jnl name ## _ctx = { (thr), (t) };  \
+        struct sm_journal    name         = { demofs_sm_claim_block, &name ## _ctx }
+
 /* ------------------------------------------------------------------ */
 /* Async block fetch with per-op suspend/resume                        */
 /* ------------------------------------------------------------------ */
@@ -1923,7 +1953,8 @@ demofs_bt_alloc_node(
     uint64_t              device_offset;
     int                   rc;
 
-    rc = space_map_alloc(shared->space_map, &thread->space_cache,
+    DEMOFS_SM_JNL(jnl, thread, txn);
+    rc = space_map_alloc(shared->space_map, &thread->space_cache, &jnl,
                          DEMOFS_BLOCK_SIZE, &device_id, &device_offset);
     chimera_demofs_abort_if(rc != 0, "b+tree node allocation failed (ENOSPC)");
 
@@ -3867,7 +3898,8 @@ demofs_inode_alloc_async(
     uint64_t              device_offset, inum;
     int                   rc;
 
-    rc = space_map_alloc(shared->space_map, &thread->space_cache,
+    DEMOFS_SM_JNL(jnl, thread, txn);
+    rc = space_map_alloc(shared->space_map, &thread->space_cache, &jnl,
                          SM_BLOCK_SIZE, &device_id, &device_offset);
     if (unlikely(rc != 0)) {
         cb(NULL, CHIMERA_VFS_ENOSPC, private_data);
@@ -4007,6 +4039,7 @@ demofs_kv_entry_release(
 static inline int
 demofs_thread_alloc_space(
     struct demofs_thread *thread,
+    struct demofs_txn    *txn,
     int64_t               desired_size,
     uint64_t             *r_device_id,
     uint64_t             *r_device_offset)
@@ -4014,7 +4047,8 @@ demofs_thread_alloc_space(
     uint32_t dev_id;
     int      rc;
 
-    rc = space_map_alloc(thread->shared->space_map, &thread->space_cache,
+    DEMOFS_SM_JNL(jnl, thread, txn);
+    rc = space_map_alloc(thread->shared->space_map, &thread->space_cache, &jnl,
                          (uint64_t) desired_size, &dev_id, r_device_offset);
 
     if (rc != 0) {
@@ -4028,11 +4062,13 @@ demofs_thread_alloc_space(
 static inline void
 demofs_thread_free_space(
     struct demofs_thread *thread,
+    struct demofs_txn    *txn,
     uint32_t              device_id,
     uint64_t              device_offset,
     uint64_t              length)
 {
-    space_map_free(thread->shared->space_map, device_id, device_offset, length);
+    DEMOFS_SM_JNL(jnl, thread, txn);
+    space_map_free(thread->shared->space_map, &jnl, device_id, device_offset, length);
 } /* demofs_thread_free_space */
 
 /* ------------------------------------------------------------------ */
@@ -4982,15 +5018,34 @@ demofs_init(const char *cfgdata)
         shared->mounted = (mode != 0);
 
         if (mode != 0) {
-            uint8_t  fsid_buf[CHIMERA_VFS_FSID_SIZE] = { 0 };
-            uint64_t rinum                           = sb.root_inum ? sb.root_inum : 2;
+            uint8_t              fsid_buf[CHIMERA_VFS_FSID_SIZE] = { 0 };
+            uint64_t             rinum                           = sb.root_inum ? sb.root_inum : 2;
+            uint32_t             rgen                            = sb.root_gen;
+            uint32_t             rdev;
+            uint64_t             roff;
+            int                  rfd;
+            struct demofs_dinode rdi;
+
+            /* The superblock's root generation is only refreshed at clean
+             * unmount, so after a crash it can be stale (0).  Read the
+             * authoritative generation from the root inode's on-disk dinode
+             * (consistent post-replay) so the mount handle matches. */
+            roff = sm_inum_to_device_offset(shared->space_map, rinum, &rdev);
+            rfd  = open(shared->device_paths[rdev], O_RDONLY);
+            if (rfd >= 0) {
+                if (pread(rfd, &rdi, sizeof(rdi), (off_t) roff) == (ssize_t) sizeof(rdi) &&
+                    rdi.inum == rinum) {
+                    rgen = rdi.gen;
+                }
+                close(rfd);
+            }
 
             shared->root_inum = rinum;
-            shared->root_gen  = sb.root_gen;
+            shared->root_gen  = rgen;
             memcpy(fsid_buf, &shared->fsid, sizeof(shared->fsid));
             shared->root_fhlen = chimera_vfs_encode_fh_inum_mount(fsid_buf,
                                                                   rinum,
-                                                                  sb.root_gen,
+                                                                  rgen,
                                                                   shared->root_fh);
         }
 
@@ -5005,6 +5060,14 @@ demofs_init(const char *cfgdata)
         chimera_demofs_abort_if(rc != 0,
                                 "Failed to write superblock to %s: %s",
                                 device0_path, strerror(errno));
+
+        /* Persistent mkfs: write an initial condensed AG-log base so each
+         * slot has a valid header before any runtime delta is journaled --
+         * otherwise a crash right after format would leave the allocator log
+         * unreadable. */
+        if (mode == 0 && shared->persistent) {
+            space_map_persist_paths(shared->space_map, shared->device_paths);
+        }
     }
     free(device0_path);
 
@@ -5066,15 +5129,14 @@ demofs_bootstrap(struct demofs_thread *thread)
 
     clock_gettime(CLOCK_REALTIME, &now);
 
-    /* The very first space-map allocation lands at block_idx 2 of AG 0 /
-     * disk 0 (block_idx 1 is reserved at format time), so the root inode
-     * gets inum 2. */
-    rc = space_map_alloc(shared->space_map, &thread->space_cache,
-                         SM_BLOCK_SIZE, &device_id, &device_offset);
-    chimera_demofs_abort_if(rc != 0, "bootstrap: failed to allocate root inode block");
-
-    inum = sm_inum_from_device_offset(shared->space_map, device_id, device_offset);
-    chimera_demofs_abort_if(inum != 2, "bootstrap: root inode is %lu, expected 2", inum);
+    /* The root inode lives at the statically-reserved block_idx 2 of AG 0 /
+     * disk 0 (inum 2).  It is reserved (not allocated through the allocator)
+     * so it is excluded from every condensed free set -- no alloc delta is
+     * needed and it can never be re-handed-out after a crash. */
+    inum          = 2;
+    device_id     = 0;
+    device_offset = sm_inum_to_device_offset(shared->space_map, inum, &device_id);
+    (void) rc;
 
     inode = demofs_inode_struct_new(inum);
 
@@ -5346,7 +5408,9 @@ demofs_thread_destroy(void *private_data)
         evpl_block_close_queue(thread->evpl, thread->queue[i]);
     }
 
-    space_map_thread_cache_return(shared->space_map, &thread->space_cache);
+    /* No txn at thread teardown; the unused reservation tail returns to the
+     * in-memory free set and is captured by the condense at clean unmount. */
+    space_map_thread_cache_return(shared->space_map, NULL, &thread->space_cache);
 
     /* Unregister the intent-log channel.  Caller must have quiesced all
      * in-flight VFS ops on this thread first. */
@@ -5665,7 +5729,7 @@ demofs_setattr_trunc_process(struct chimera_vfs_request *request)
     extent_end   = extent_start + p->ext_iter.length;
 
     if (extent_start >= new_size) {
-        demofs_thread_free_space(thread, p->ext_iter.device_id,
+        demofs_thread_free_space(thread, p->txn, p->ext_iter.device_id,
                                  p->ext_iter.device_offset,
                                  SM_ALIGN_UP(p->ext_iter.length));
     } else if (extent_end > new_size) {
@@ -5674,7 +5738,7 @@ demofs_setattr_trunc_process(struct chimera_vfs_request *request)
         uint64_t new_aligned = SM_ALIGN_UP(new_logical);
 
         if (old_aligned > new_aligned) {
-            demofs_thread_free_space(thread, p->ext_iter.device_id,
+            demofs_thread_free_space(thread, p->txn, p->ext_iter.device_id,
                                      p->ext_iter.device_offset + new_aligned,
                                      old_aligned - new_aligned);
         }
@@ -8186,7 +8250,7 @@ demofs_write_inode_cb(
     aligned_end    = (write_end + 4095ULL) & ~4095ULL;
     aligned_length = aligned_end - aligned_start;
 
-    rc = demofs_thread_alloc_space(thread, aligned_length, &device_id, &device_offset);
+    rc = demofs_thread_alloc_space(thread, demofs_private->txn, aligned_length, &device_id, &device_offset);
     if (rc) {
         demofs_op_fail(request, demofs_private->txn, CHIMERA_VFS_ENOSPC);
         return;
@@ -8469,7 +8533,7 @@ demofs_dealloc_process(struct chimera_vfs_request *request)
 
     if (es >= hole_start && ee <= hole_end) {
         /* Completely inside the hole: free + remove, then advance. */
-        demofs_thread_free_space(thread, p->ext_iter.device_id,
+        demofs_thread_free_space(thread, p->txn, p->ext_iter.device_id,
                                  p->ext_iter.device_offset,
                                  SM_ALIGN_UP(p->ext_iter.length));
         op = demofs_bt_op_alloc(thread);

--- a/src/vfs/demofs/demofs.c
+++ b/src/vfs/demofs/demofs.c
@@ -4238,6 +4238,46 @@ demofs_il_place(
 static void demofs_il_push_kick(
     struct demofs_intent_log *il);
 
+/*
+ * A record's block images are now durably home.  Transition the corresponding
+ * cache blocks LOGGED -> CLEAN so they become evictable -- but only if the
+ * block hasn't been re-logged since (blk->seq still equals this record's seq)
+ * and isn't currently pinned by an active transaction.  Checked under the
+ * shard lock so it serializes against demofs_block_claim re-dirtying the block.
+ * (A3 will additionally enqueue the cleaned block on the shard LRU and wake a
+ * buffer waiter.)
+ */
+static void
+demofs_il_clean_pushed_record(
+    struct demofs_intent_log *il,
+    struct demofs_il_record  *rec)
+{
+    struct demofs_shared      *shared = container_of(il, struct demofs_shared, intent_log);
+    struct demofs_block_cache *cache  = shared->block_cache;
+    char                      *p      = (char *) rec->iov.data + sizeof(struct demofs_redo_header);
+    uint32_t                   i;
+
+    for (i = 0; i < rec->num_blocks; i++) {
+        struct demofs_redo_block_header *bh = (struct demofs_redo_block_header *) p;
+        struct demofs_block_shard       *shard;
+        struct demofs_block             *blk;
+        uint32_t                         bucket;
+
+        p += sizeof(*bh) + DEMOFS_BLOCK_SIZE;
+
+        shard  = demofs_block_shard(cache, bh->device_id, bh->device_offset);
+        bucket = demofs_block_bucket(bh->device_id, bh->device_offset);
+
+        pthread_mutex_lock(&shard->lock);
+        blk = demofs_block_lookup_locked(shard, bucket, bh->device_id, bh->device_offset);
+        if (blk && blk->state == DEMOFS_BLOCK_LOGGED &&
+            blk->seq == rec->seq && blk->pin_count == 0) {
+            blk->state = DEMOFS_BLOCK_CLEAN;
+        }
+        pthread_mutex_unlock(&shard->lock);
+    }
+} /* demofs_il_clean_pushed_record */
+
 /* One home-write of a logged block completed. */
 static void
 demofs_il_push_block_cb(
@@ -4255,6 +4295,9 @@ demofs_il_push_block_cb(
     if (--il->push_outstanding == 0) {
         /* Whole record is durably home; trim past it and advance the tail. */
         struct demofs_il_record *rec = il->push_cur;
+
+        /* The blocks are now home -> make the (un-re-logged) ones evictable. */
+        demofs_il_clean_pushed_record(il, rec);
 
         il->push_cur = NULL;
         evpl_iovec_release(il->evpl, &rec->iov);
@@ -4439,6 +4482,11 @@ demofs_il_write_redo(
 
     for (tb = txn->blocks; tb; tb = tb->next) {
         struct demofs_block *blk = tb->block;
+
+        /* Stamp the block with this record's seq so the tail-pusher can tell,
+        * on push completion, whether the block has been re-logged since (a
+        * higher seq) -- if not, it can be marked CLEAN and made evictable. */
+        blk->seq = rec->seq;
 
         bh                = (struct demofs_redo_block_header *) p;
         bh->device_id     = blk->device_id;

--- a/src/vfs/demofs/demofs.c
+++ b/src/vfs/demofs/demofs.c
@@ -2012,11 +2012,12 @@ demofs_bt_insert_rec(
 } /* demofs_bt_insert_rec */
 
 /*
- * Insert a record into an inode's b+tree.  The inode must be write-locked
- * and its root block pinned (true for any write op that acquired it).
+ * Insert a record into an inode's b+tree.  The inode must be write-locked and
+ * its root block pinned, and the descent path must already be resident (the
+ * async driver faults it in first).  Synchronous structural modify.
  */
 static void
-demofs_bt_insert(
+demofs_bt_insert_locked(
     struct demofs_thread       *thread,
     struct demofs_txn          *txn,
     struct demofs_inode        *inode,
@@ -2070,7 +2071,7 @@ demofs_bt_insert(
         isl[1].key   = sep;
         isl[1].child = sep_bptr;
 
-        if (old_level == 0) {
+        if (old_level == 0) {     /* leaf-root grow: fix right sibling back-link */
             /* The lower half migrated from the (now interior) embedded root
              * into the new left block, so the right sibling's back-link must
              * point at the left block rather than the inode's own bptr. */
@@ -2078,7 +2079,7 @@ demofs_bt_insert(
             demofs_bt_hdr(rbuf, 0)->prev_leaf = left_bptr;
         }
     }
-} /* demofs_bt_insert */
+} /* demofs_bt_insert_locked */
 
 /* A node (other than the root) is too empty and must borrow/merge once it
  * holds less than half its capacity: leaves measured in bytes (slots +
@@ -2460,10 +2461,11 @@ demofs_bt_collapse_root(
  * Remove a key from an inode's b+tree, maintaining the B+tree invariants:
  * the leaf heap is compacted, parent separators are kept exact, and
  * underflowing non-root nodes borrow/merge with a sibling (propagating up).
- * Returns 1 if removed, 0 if not found.
+ * Returns 1 if removed, 0 if not found.  The descent path and rebalance
+ * siblings must already be resident (the async driver faults them in).
  */
 static int
-demofs_bt_remove(
+demofs_bt_remove_locked(
     struct demofs_thread       *thread,
     struct demofs_txn          *txn,
     struct demofs_inode        *inode,
@@ -2547,7 +2549,7 @@ demofs_bt_remove(
 
     demofs_bt_collapse_root(thread, txn, inode);
     return 1;
-} /* demofs_bt_remove */
+} /* demofs_bt_remove_locked */
 
 /* ------------------------------------------------------------------ */
 /* Async b+tree operation driver                                       */
@@ -2602,18 +2604,60 @@ demofs_bt_run(struct demofs_bt_op *op)
     uint32_t              dev;
     uint64_t              off;
 
-    switch (op->opcode) {
-        case DEMOFS_BT_OP_LOOKUP_EXACT:
-        case DEMOFS_BT_OP_LOOKUP_GE:
-        case DEMOFS_BT_OP_LOOKUP_LE:
-            break;
-        default:
-            chimera_demofs_abort("demofs_bt_run: opcode %d not async yet", op->opcode);
-            return;
-    } /* switch */
-
     for (;; ) {
         struct demofs_bt_node_hdr *h;
+
+        /*
+         * Remove rebalance can touch the immediate siblings of every node on
+         * the descent path; fault them all in here, then run the synchronous
+         * modify which is guaranteed not to miss.
+         */
+        if (op->phase == DEMOFS_BT_PHASE_REBALANCE) {
+            while (op->reb_level < op->depth) {
+                struct demofs_bt_path_ent *pe = &op->path[op->reb_level];
+                struct demofs_bt_node_hdr *ph;
+                int                        ci, pn;
+                void                      *pbuf;
+
+                off = (pe->bptr == 0)
+                ? sm_inum_to_device_offset(thread->shared->space_map, inode->inum, &dev)
+                : sm_inum_to_device_offset(thread->shared->space_map, pe->bptr, &dev);
+                blk = demofs_bt_block_get(op, dev, off);
+                if (!blk) {
+                    return;
+                }
+                pbuf = blk->buffer;
+                ph   = demofs_bt_hdr(pbuf, pe->base);
+                ci   = pe->ci;
+                pn   = ph->nitems;
+
+                if (op->removed_idx == 0) {
+                    if (ci - 1 >= 0) {
+                        uint64_t sb = demofs_bt_islots(pbuf, pe->base)[ci - 1].child;
+                        off = sm_inum_to_device_offset(thread->shared->space_map, sb, &dev);
+                        if (!demofs_bt_block_get(op, dev, off)) {
+                            return;
+                        }
+                    }
+                    op->removed_idx = 1;
+                }
+                if (op->removed_idx == 1) {
+                    if (ci + 1 < pn) {
+                        uint64_t sb = demofs_bt_islots(pbuf, pe->base)[ci + 1].child;
+                        off = sm_inum_to_device_offset(thread->shared->space_map, sb, &dev);
+                        if (!demofs_bt_block_get(op, dev, off)) {
+                            return;
+                        }
+                    }
+                    op->removed_idx = 2;
+                }
+                op->reb_level++;
+                op->removed_idx = 0;
+            }
+
+            demofs_bt_complete(op, demofs_bt_remove_locked(thread, op->txn, inode, &op->key));
+            return;
+        }
 
         if (op->phase == DEMOFS_BT_PHASE_DESCEND && op->use_root) {
             off  = sm_inum_to_device_offset(thread->shared->space_map, inode->inum, &dev);
@@ -2634,13 +2678,33 @@ demofs_bt_run(struct demofs_bt_op *op)
             if (h->level > 0) {
                 int ci = demofs_bt_interior_search(buf, base, &op->key);
 
+                if (op->opcode == DEMOFS_BT_OP_INSERT ||
+                    op->opcode == DEMOFS_BT_OP_REMOVE) {
+                    chimera_demofs_abort_if(op->depth >= DEMOFS_BT_MAX_DEPTH,
+                                            "b+tree op: path too deep");
+                    op->path[op->depth].bptr = op->use_root ? 0 : op->cur_bptr;
+                    op->path[op->depth].base = base;
+                    op->path[op->depth].ci   = ci;
+                    op->depth++;
+                }
                 op->cur_bptr = demofs_bt_islots(buf, base)[ci].child;
                 op->use_root = 0;
                 continue;
             }
 
             /* At the leaf. */
-            if (op->opcode == DEMOFS_BT_OP_LOOKUP_EXACT) {
+            if (op->opcode == DEMOFS_BT_OP_INSERT) {
+                demofs_bt_insert_locked(thread, op->txn, inode, &op->key,
+                                        op->recbuf, op->reclen);
+                demofs_bt_complete(op, 0);
+                return;
+            } else if (op->opcode == DEMOFS_BT_OP_REMOVE) {
+                /* Path faulted in; now fault in rebalance siblings. */
+                op->phase       = DEMOFS_BT_PHASE_REBALANCE;
+                op->reb_level   = 0;
+                op->removed_idx = 0;
+                continue;
+            } else if (op->opcode == DEMOFS_BT_OP_LOOKUP_EXACT) {
                 int exact, idx = demofs_bt_leaf_search(buf, base, &op->key, &exact);
 
                 demofs_bt_complete(op, exact ? demofs_bt_op_emit(op, buf, base, idx) : -1);
@@ -2758,6 +2822,71 @@ demofs_bt_lookup_sync(
                             "b+tree lookup suspended on a cache miss (no eviction yet)");
     return s.result;
 } /* demofs_bt_lookup_sync */
+
+/*
+ * Transitional synchronous insert: drive an INSERT op to completion.  The
+ * descent faults in the path through demofs_bt_block_get; with no eviction it
+ * always hits, so the structural modify runs inline before returning.
+ */
+static void
+demofs_bt_insert(
+    struct demofs_thread       *thread,
+    struct demofs_txn          *txn,
+    struct demofs_inode        *inode,
+    const struct demofs_bt_key *key,
+    const void                 *rec,
+    uint32_t                    reclen)
+{
+    struct demofs_bt_op   op;
+    struct demofs_bt_sync s = { .done = 0, .result = 0 };
+
+    chimera_demofs_abort_if(reclen > sizeof(op.recbuf), "b+tree record too large");
+
+    memset(&op, 0, sizeof(op));
+    op.thread       = thread;
+    op.txn          = txn;
+    op.inode        = inode;
+    op.opcode       = DEMOFS_BT_OP_INSERT;
+    op.phase        = DEMOFS_BT_PHASE_DESCEND;
+    op.key          = *key;
+    op.reclen       = reclen;
+    op.use_root     = 1;
+    op.cb           = demofs_bt_sync_cb;
+    op.private_data = &s;
+    memcpy(op.recbuf, rec, reclen);
+
+    demofs_bt_run(&op);
+    chimera_demofs_abort_if(!s.done,
+                            "b+tree insert suspended on a cache miss (no eviction yet)");
+} /* demofs_bt_insert */
+
+/* Transitional synchronous remove: drive a REMOVE op to completion. */
+static int
+demofs_bt_remove(
+    struct demofs_thread       *thread,
+    struct demofs_txn          *txn,
+    struct demofs_inode        *inode,
+    const struct demofs_bt_key *key)
+{
+    struct demofs_bt_op   op;
+    struct demofs_bt_sync s = { .done = 0, .result = 0 };
+
+    memset(&op, 0, sizeof(op));
+    op.thread       = thread;
+    op.txn          = txn;
+    op.inode        = inode;
+    op.opcode       = DEMOFS_BT_OP_REMOVE;
+    op.phase        = DEMOFS_BT_PHASE_DESCEND;
+    op.key          = *key;
+    op.use_root     = 1;
+    op.cb           = demofs_bt_sync_cb;
+    op.private_data = &s;
+
+    demofs_bt_run(&op);
+    chimera_demofs_abort_if(!s.done,
+                            "b+tree remove suspended on a cache miss (no eviction yet)");
+    return s.result;
+} /* demofs_bt_remove */
 
 static int
 demofs_bt_lookup_exact(

--- a/src/vfs/demofs/demofs.c
+++ b/src/vfs/demofs/demofs.c
@@ -6452,6 +6452,186 @@ demofs_io_callback(
     }
 } /* demofs_io_callback */
 
+/*
+ * Read extent walk (async).  The data reads themselves are already async
+ * (demofs_io_callback completes the request once pending hits 0); here the
+ * extent iteration is also async.  Hoisted state: inode_stash[0] = inode,
+ * loop_off = read_offset, loop_left = read_left, loop_pos = aligned end,
+ * rd_cursor = result-buffer assembly cursor, ext_iter = current extent.
+ */
+static void demofs_read_process(
+    struct chimera_vfs_request *request);
+
+static void
+demofs_read_finish(struct chimera_vfs_request *request)
+{
+    struct demofs_request_private *p      = request->plugin_data;
+    struct demofs_thread          *thread = p->thread;
+    struct demofs_inode           *inode  = p->inode_stash[0];
+
+    if (p->loop_left) {
+        evpl_iovec_cursor_zero(&p->rd_cursor, p->loop_left);
+    }
+
+    demofs_map_attrs(thread, &request->read.r_attr, inode);
+
+    if (p->pending == 0) {
+        demofs_read_adjust_iovecs(request, p);
+        demofs_op_ok(request, p->txn);
+    } else {
+        /* I/O is in flight; drop the inode lock so other ops proceed.  The
+         * txn commits from demofs_io_callback once all reads complete. */
+        demofs_txn_unlock_inode(p->txn, inode);
+    }
+} /* demofs_read_finish */
+
+static void
+demofs_read_walk_cb(
+    struct demofs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+
+    p->loop_have = demofs_ext_from_op(op, result, &p->ext_iter);
+    demofs_bt_op_free(p->thread, op);
+    demofs_read_process(request);
+} /* demofs_read_walk_cb */
+
+static void
+demofs_read_advance(struct chimera_vfs_request *request)
+{
+    struct demofs_request_private *p      = request->plugin_data;
+    struct demofs_thread          *thread = p->thread;
+    struct demofs_bt_op           *op     = demofs_bt_op_alloc(thread);
+
+    if (demofs_ext_next_async(op, thread, p->inode_stash[0], p->ext_iter.file_offset,
+                              p->rec_scratch, sizeof(p->rec_scratch),
+                              demofs_read_walk_cb, request)) {
+        demofs_read_walk_cb(op, op->result, request);
+    }
+} /* demofs_read_advance */
+
+static void
+demofs_read_process(struct chimera_vfs_request *request)
+{
+    struct demofs_request_private *p           = request->plugin_data;
+    struct demofs_thread          *thread      = p->thread;
+    struct demofs_shared          *shared      = thread->shared;
+    struct evpl                   *evpl        = thread->evpl;
+    struct demofs_extent          *extent      = &p->ext_iter;
+    uint64_t                       read_offset = p->loop_off;
+    uint64_t                       read_left   = p->loop_left;
+    uint64_t                       aligned_end = p->loop_pos;
+    uint64_t                       extent_end, overlap_start, overlap_length, chunk;
+    uint32_t                       chunk_niov;
+    struct evpl_iovec             *chunk_iov;
+
+    if (!(read_left && p->loop_have && extent->file_offset < aligned_end)) {
+        demofs_read_finish(request);
+        return;
+    }
+
+    if (read_offset < extent->file_offset) {
+        chunk = extent->file_offset - read_offset;
+        evpl_iovec_cursor_zero(&p->rd_cursor, chunk);
+        read_offset += chunk;
+        read_left   -= chunk;
+    }
+
+    extent_end     = extent->file_offset + extent->length;
+    overlap_start  = read_offset - extent->file_offset;
+    overlap_length = extent_end - read_offset;
+    if (overlap_length > read_left) {
+        overlap_length = read_left;
+    }
+
+    while (overlap_length) {
+        uint64_t dev_offset;
+        uint32_t dev_pad, total;
+        int      pad_niov = 0;
+
+        if (overlap_length > shared->devices[extent->device_id].max_request_size) {
+            chunk = shared->devices[extent->device_id].max_request_size;
+        } else {
+            chunk = overlap_length;
+        }
+
+        chunk_iov  = &p->iov[p->niov];
+        dev_offset = extent->device_offset + overlap_start;
+        dev_pad    = (uint32_t) (dev_offset & 4095ULL);
+
+        if (dev_pad) {
+            evpl_iovec_clone_segment(&chunk_iov[0], &thread->pad, 0, dev_pad);
+            pad_niov    = 1;
+            dev_offset -= dev_pad;
+        }
+
+        chunk_niov = evpl_iovec_cursor_move(&p->rd_cursor, &chunk_iov[pad_niov],
+                                            32, chunk, 1);
+        chunk_niov += pad_niov;
+
+        total = dev_pad + chunk;
+        if (total & 4095) {
+            evpl_iovec_clone_segment(&chunk_iov[chunk_niov], &thread->pad, 0,
+                                     4096 - (total & 4095));
+            chunk_niov++;
+        }
+
+        p->niov += chunk_niov;
+        p->pending++;
+        thread->pending_io++;
+
+        evpl_block_read(evpl, thread->queue[extent->device_id], chunk_iov,
+                        chunk_niov, dev_offset, demofs_io_callback, request);
+
+        overlap_length -= chunk;
+        overlap_start  += chunk;
+        read_offset    += chunk;
+        read_left      -= chunk;
+    }
+
+    p->loop_off  = read_offset;
+    p->loop_left = read_left;
+
+    demofs_read_advance(request);
+} /* demofs_read_process */
+
+/* First-extent selection for read: floor(read_offset), advancing if it ends
+ * at/before read_offset, or the first extent if none. */
+static void
+demofs_read_first_cb(
+    struct demofs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request     = private_data;
+    struct demofs_request_private *p           = request->plugin_data;
+    struct demofs_thread          *thread      = p->thread;
+    uint64_t                       read_offset = p->loop_off;
+    int                            have        = demofs_ext_from_op(op, result, &p->ext_iter);
+
+    demofs_bt_op_free(thread, op);
+
+    if (have && p->ext_iter.file_offset + p->ext_iter.length <= read_offset) {
+        demofs_read_advance(request);
+        return;
+    }
+    if (!have) {
+        op = demofs_bt_op_alloc(thread);
+        if (demofs_ext_ceil_async(op, thread, p->inode_stash[0], 0, p->rec_scratch,
+                                  sizeof(p->rec_scratch), demofs_read_walk_cb,
+                                  request)) {
+            demofs_read_walk_cb(op, op->result, request);
+        }
+        return;
+    }
+
+    p->loop_have = 1;
+    demofs_read_process(request);
+} /* demofs_read_first_cb */
+
 static void
 demofs_read_inode_cb(
     struct demofs_inode *inode,
@@ -6461,17 +6641,11 @@ demofs_read_inode_cb(
     struct chimera_vfs_request    *request        = private_data;
     struct demofs_request_private *demofs_private = request->plugin_data;
     struct demofs_thread          *thread         = demofs_private->thread;
-    struct demofs_shared          *shared         = thread->shared;
     struct evpl                   *evpl           = thread->evpl;
-    struct demofs_extent           ext_buf;
-    struct demofs_extent          *extent = &ext_buf;
-    int                            have;
-    uint64_t                       offset, length, read_offset, read_left;
-    uint64_t                       extent_end, overlap_start, overlap_length;
-    uint64_t                       aligned_offset, aligned_length, chunk;
-    uint32_t                       eof = 0, chunk_niov;
-    struct evpl_iovec             *chunk_iov;
-    struct evpl_iovec_cursor       cursor;
+    uint64_t                       offset, length;
+    uint64_t                       aligned_offset, aligned_length;
+    uint32_t                       eof = 0;
+    struct demofs_bt_op           *op;
 
     if (unlikely(status != CHIMERA_VFS_OK)) {
         demofs_op_fail(request, demofs_private->txn, status);
@@ -6509,123 +6683,22 @@ demofs_read_inode_cb(
     request->read.r_length = length;
     request->read.r_eof    = eof;
 
-    // Allocate iovec for full aligned size
     request->read.r_niov = evpl_iovec_alloc(evpl, aligned_length, 4096, 1,
                                             0, request->read.iov);
 
-    read_offset = aligned_offset;
-    read_left   = aligned_length;
+    evpl_iovec_cursor_init(&demofs_private->rd_cursor, request->read.iov,
+                           request->read.r_niov);
 
-    evpl_iovec_cursor_init(&cursor, request->read.iov, request->read.r_niov);
+    demofs_private->inode_stash[0] = inode;
+    demofs_private->loop_off       = aligned_offset;
+    demofs_private->loop_left      = aligned_length;
+    demofs_private->loop_pos       = aligned_offset + aligned_length;
 
-    // Find first extent that could contain our offset
-    have = demofs_ext_floor(thread, inode, read_offset, extent);
-
-    if (!have) {
-        /* No extent at or before read_offset - get the first extent
-         * in case there's one that starts within our range */
-        have = demofs_ext_ceil(thread, inode, 0, extent);
-    } else if (extent->file_offset + extent->length <= read_offset) {
-        have = demofs_ext_next(thread, inode, extent->file_offset, extent);
-    }
-
-    while (read_left && have && extent->file_offset < aligned_offset + aligned_length) {
-
-        if (read_offset < extent->file_offset) {
-            chunk = extent->file_offset - read_offset;
-            evpl_iovec_cursor_zero(&cursor, chunk);
-            read_offset += chunk;
-            read_left   -= chunk;
-        }
-
-
-        extent_end = extent->file_offset + extent->length;
-
-        // Calculate overlap with current extent
-        overlap_start  = read_offset - extent->file_offset;
-        overlap_length = extent_end - read_offset;
-
-        if (overlap_length > read_left) {
-            overlap_length = read_left;
-        }
-
-        while (overlap_length) {
-
-            if (overlap_length > shared->devices[extent->device_id].max_request_size) {
-                chunk = shared->devices[extent->device_id].max_request_size;
-            } else {
-                chunk = overlap_length;
-            }
-
-            chunk_iov = &demofs_private->iov[demofs_private->niov];
-
-            uint64_t dev_offset = extent->device_offset + overlap_start;
-            uint32_t dev_pad    = (uint32_t) (dev_offset & 4095ULL);
-            int      pad_niov   = 0;
-
-            if (dev_pad) {
-                /* Device offset is not 4K-aligned (can happen after
-                 * DEALLOCATE trims an extent at a non-block boundary).
-                 * Prepend a discard buffer so the block-device read
-                 * starts at an aligned offset. */
-                evpl_iovec_clone_segment(&chunk_iov[0], &thread->pad,
-                                         0, dev_pad);
-                pad_niov    = 1;
-                dev_offset -= dev_pad;
-            }
-
-            chunk_niov = evpl_iovec_cursor_move(&cursor,
-                                                &chunk_iov[pad_niov],
-                                                32, chunk, 1);
-            chunk_niov += pad_niov;
-
-            uint32_t total = dev_pad + chunk;
-
-            if (total & 4095) {
-                evpl_iovec_clone_segment(&chunk_iov[chunk_niov],
-                                         &thread->pad, 0,
-                                         4096 - (total & 4095));
-                chunk_niov++;
-            }
-
-            demofs_private->niov += chunk_niov;
-
-            demofs_private->pending++;
-            thread->pending_io++;
-
-            evpl_block_read(evpl,
-                            thread->queue[extent->device_id],
-                            chunk_iov,
-                            chunk_niov,
-                            dev_offset,
-                            demofs_io_callback,
-                            request);
-
-            overlap_length -= chunk;
-            overlap_start  += chunk;
-
-            read_offset += chunk;
-            read_left   -= chunk;
-        }
-
-        have = demofs_ext_next(thread, inode, extent->file_offset, extent);
-    }
-
-    if (read_left) {
-        evpl_iovec_cursor_zero(&cursor, read_left);
-    }
-
-    demofs_map_attrs(thread, &request->read.r_attr, inode);
-
-
-    if (demofs_private->pending == 0) {
-        demofs_read_adjust_iovecs(request, demofs_private);
-        demofs_op_ok(request, demofs_private->txn);
-    } else {
-        /* I/O is in flight.  Drop the inode lock now so other ops on this
-         * worker thread can proceed; the txn will be committed (with no
-         * remaining refs to unlock) from demofs_io_callback. */
-        demofs_txn_unlock_inode(demofs_private->txn, inode);
+    op = demofs_bt_op_alloc(thread);
+    if (demofs_ext_floor_async(op, thread, inode, aligned_offset, demofs_private->rec_scratch,
+                               sizeof(demofs_private->rec_scratch), demofs_read_first_cb,
+                               request)) {
+        demofs_read_first_cb(op, op->result, request);
     }
 } /* demofs_read_inode_cb */
 

--- a/src/vfs/demofs/demofs.c
+++ b/src/vfs/demofs/demofs.c
@@ -1771,9 +1771,389 @@ demofs_bt_insert(
     }
 } /* demofs_bt_insert */
 
+#define DEMOFS_BT_MAX_DEPTH 16
+
+/* A node (other than the root) is too empty and must borrow/merge once it
+ * holds less than half its capacity: leaves measured in bytes (slots +
+ * records), interior nodes in slot count. */
+static inline int
+demofs_bt_leaf_underflow(
+    void    *buf,
+    uint32_t base)
+{
+    struct demofs_bt_node_hdr *h    = demofs_bt_hdr(buf, base);
+    uint32_t                   used = h->nitems * sizeof(struct demofs_bt_lslot) +
+        (h->capacity - h->free_end);
+
+    return used * 2 < h->capacity;
+} /* demofs_bt_leaf_underflow */
+
+static inline int
+demofs_bt_interior_underflow(
+    void    *buf,
+    uint32_t base)
+{
+    struct demofs_bt_node_hdr *h    = demofs_bt_hdr(buf, base);
+    uint32_t                   maxi = (h->capacity - sizeof(struct demofs_bt_node_hdr)) /
+        sizeof(struct demofs_bt_islot);
+
+    return (uint32_t) h->nitems * 2 < maxi;
+} /* demofs_bt_interior_underflow */
+
+/* Repack a leaf's live records into a fresh heap, reclaiming the dead space
+ * left by prior slot removals.  Leaf-chain links are preserved. */
+static void
+demofs_bt_leaf_compact(
+    void    *buf,
+    uint32_t base,
+    uint32_t cap)
+{
+    struct demofs_bt_node_hdr *h  = demofs_bt_hdr(buf, base);
+    struct demofs_bt_lslot    *sl = demofs_bt_lslots(buf, base);
+    int                        n    = h->nitems, i;
+    uint64_t                   next = h->next_leaf, prev = h->prev_leaf;
+    struct demofs_bt_key      *keys    = malloc(n * sizeof(*keys) + 1);
+    uint32_t                  *lens    = malloc(n * sizeof(uint32_t) + 1);
+    char                      *scratch = malloc(cap);
+    uint32_t                   o       = 0;
+
+    for (i = 0; i < n; i++) {
+        keys[i] = sl[i].key;
+        lens[i] = sl[i].len;
+        memcpy(scratch + o, (char *) buf + base + sl[i].off, sl[i].len);
+        o += sl[i].len;
+    }
+
+    demofs_bt_node_init(buf, base, cap, 0);
+    o = 0;
+    for (i = 0; i < n; i++) {
+        demofs_bt_leaf_append(buf, base, &keys[i], scratch + o, lens[i]);
+        o += lens[i];
+    }
+    h            = demofs_bt_hdr(buf, base);
+    h->next_leaf = next;
+    h->prev_leaf = prev;
+
+    free(keys);
+    free(lens);
+    free(scratch);
+} /* demofs_bt_leaf_compact */
+
 /*
- * Remove a key from an inode's b+tree (lazy: no merge/rebalance).  Returns
- * 1 if removed, 0 if not found.  The descent dirties the path blocks.
+ * Rebalance an underflowing leaf (child index ci of the interior parent at
+ * pbuf/pbase) against an adjacent sibling: merge the two leaves if their
+ * combined contents fit in one node, otherwise redistribute evenly.  Returns
+ * 1 if the merge dropped a slot from the parent (which may now underflow), 0
+ * otherwise.  Freed leaf blocks are orphaned (reclaim deferred).
+ */
+static int
+demofs_bt_rebalance_leaf(
+    struct demofs_thread *thread,
+    struct demofs_txn    *txn,
+    void                 *pbuf,
+    uint32_t              pbase,
+    int                   ci)
+{
+    struct demofs_bt_islot    *psl = demofs_bt_islots(pbuf, pbase);
+    int                        pn  = demofs_bt_hdr(pbuf, pbase)->nitems;
+    int                        lidx, ridx, ln, rn, total, i, merged;
+    uint64_t                   l_bptr, r_bptr, l_prev, r_next;
+    void                      *lbuf, *rbuf;
+    struct demofs_bt_node_hdr *lh, *rh;
+    struct demofs_bt_key      *keys;
+    uint32_t                  *lens;
+    char                      *scratch;
+    uint32_t                   o, need;
+
+    if (pn < 2) {
+        return 0;     /* sole child of a degenerate root: collapse handles it */
+    }
+
+    if (ci + 1 < pn) {
+        lidx = ci;
+        ridx = ci + 1;
+    } else {
+        lidx = ci - 1;
+        ridx = ci;
+    }
+
+    l_bptr = psl[lidx].child;
+    r_bptr = psl[ridx].child;
+    lbuf   = demofs_bt_node_for_write(thread, txn, l_bptr);
+    rbuf   = demofs_bt_node_for_write(thread, txn, r_bptr);
+    lh     = demofs_bt_hdr(lbuf, 0);
+    rh     = demofs_bt_hdr(rbuf, 0);
+    ln     = lh->nitems;
+    rn     = rh->nitems;
+    total  = ln + rn;
+    l_prev = lh->prev_leaf;
+    r_next = rh->next_leaf;
+
+    keys    = malloc((total + 1) * sizeof(*keys));
+    lens    = malloc((total + 1) * sizeof(uint32_t));
+    scratch = malloc(2 * DEMOFS_BT_NODE_CAP);
+
+    o = 0;
+    for (i = 0; i < ln; i++) {
+        struct demofs_bt_lslot *s = demofs_bt_lslots(lbuf, 0);
+        keys[i] = s[i].key;
+        lens[i] = s[i].len;
+        memcpy(scratch + o, (char *) lbuf + s[i].off, s[i].len);
+        o += s[i].len;
+    }
+    for (i = 0; i < rn; i++) {
+        struct demofs_bt_lslot *s = demofs_bt_lslots(rbuf, 0);
+        keys[ln + i] = s[i].key;
+        lens[ln + i] = s[i].len;
+        memcpy(scratch + o, (char *) rbuf + s[i].off, s[i].len);
+        o += s[i].len;
+    }
+
+    need = sizeof(struct demofs_bt_node_hdr) +
+        total * sizeof(struct demofs_bt_lslot) + o;
+
+    if (need <= DEMOFS_BT_NODE_CAP) {
+        /* Merge everything into L; orphan R and unlink it from the chain. */
+        uint32_t off = 0;
+
+        demofs_bt_node_init(lbuf, 0, DEMOFS_BT_NODE_CAP, 0);
+        for (i = 0; i < total; i++) {
+            demofs_bt_leaf_append(lbuf, 0, &keys[i], scratch + off, lens[i]);
+            off += lens[i];
+        }
+        lh            = demofs_bt_hdr(lbuf, 0);
+        lh->prev_leaf = l_prev;
+        lh->next_leaf = r_next;
+        if (r_next) {
+            void *nn = demofs_bt_node_for_write(thread, txn, r_next);
+            demofs_bt_hdr(nn, 0)->prev_leaf = l_bptr;
+        }
+
+        for (i = ridx; i < pn - 1; i++) {
+            psl[i] = psl[i + 1];
+        }
+        demofs_bt_hdr(pbuf, pbase)->nitems = pn - 1;
+        merged                             = 1;
+    } else {
+        /* Redistribute evenly across L and R. */
+        uint32_t half = o / 2, acc = 0, off = 0;
+        int      split = 1;
+
+        for (i = 0; i < total; i++) {
+            if (acc >= half && i > 0) {
+                split = i;
+                break;
+            }
+            acc  += lens[i];
+            split = i + 1;
+        }
+        if (split < 1) {
+            split = 1;
+        }
+        if (split > total - 1) {
+            split = total - 1;
+        }
+
+        demofs_bt_node_init(lbuf, 0, DEMOFS_BT_NODE_CAP, 0);
+        for (i = 0; i < split; i++) {
+            demofs_bt_leaf_append(lbuf, 0, &keys[i], scratch + off, lens[i]);
+            off += lens[i];
+        }
+        demofs_bt_node_init(rbuf, 0, DEMOFS_BT_NODE_CAP, 0);
+        for (i = split; i < total; i++) {
+            demofs_bt_leaf_append(rbuf, 0, &keys[i], scratch + off, lens[i]);
+            off += lens[i];
+        }
+
+        lh            = demofs_bt_hdr(lbuf, 0);
+        rh            = demofs_bt_hdr(rbuf, 0);
+        lh->prev_leaf = l_prev;
+        lh->next_leaf = r_bptr;
+        rh->prev_leaf = l_bptr;
+        rh->next_leaf = r_next;
+
+        psl[ridx].key = demofs_bt_lslots(rbuf, 0)[0].key;
+        merged        = 0;
+    }
+
+    free(keys);
+    free(lens);
+    free(scratch);
+    return merged;
+} /* demofs_bt_rebalance_leaf */
+
+/*
+ * Rebalance an underflowing interior node (child index ci of parent
+ * pbuf/pbase) against a sibling.  B+tree separators are routing copies, so a
+ * merge is a plain concatenation of the two children's slots.  Returns 1 if a
+ * parent slot was dropped, 0 otherwise.
+ */
+static int
+demofs_bt_rebalance_interior(
+    struct demofs_thread *thread,
+    struct demofs_txn    *txn,
+    void                 *pbuf,
+    uint32_t              pbase,
+    int                   ci)
+{
+    struct demofs_bt_islot *psl = demofs_bt_islots(pbuf, pbase);
+    int                     pn  = demofs_bt_hdr(pbuf, pbase)->nitems;
+    int                     lidx, ridx, ln, rn, total, i, merged;
+    void                   *lbuf, *rbuf;
+    struct demofs_bt_islot  all[(2 * DEMOFS_BT_NODE_CAP / sizeof(struct demofs_bt_islot)) + 2];
+    uint32_t                maxi;
+
+    if (pn < 2) {
+        return 0;
+    }
+
+    if (ci + 1 < pn) {
+        lidx = ci;
+        ridx = ci + 1;
+    } else {
+        lidx = ci - 1;
+        ridx = ci;
+    }
+
+    lbuf  = demofs_bt_node_for_write(thread, txn, psl[lidx].child);
+    rbuf  = demofs_bt_node_for_write(thread, txn, psl[ridx].child);
+    ln    = demofs_bt_hdr(lbuf, 0)->nitems;
+    rn    = demofs_bt_hdr(rbuf, 0)->nitems;
+    total = ln + rn;
+
+    for (i = 0; i < ln; i++) {
+        all[i] = demofs_bt_islots(lbuf, 0)[i];
+    }
+    for (i = 0; i < rn; i++) {
+        all[ln + i] = demofs_bt_islots(rbuf, 0)[i];
+    }
+
+    maxi = (DEMOFS_BT_NODE_CAP - sizeof(struct demofs_bt_node_hdr)) /
+        sizeof(struct demofs_bt_islot);
+
+    if ((uint32_t) total <= maxi) {
+        for (i = 0; i < total; i++) {
+            demofs_bt_islots(lbuf, 0)[i] = all[i];
+        }
+        demofs_bt_hdr(lbuf, 0)->nitems = total;
+
+        for (i = ridx; i < pn - 1; i++) {
+            psl[i] = psl[i + 1];
+        }
+        demofs_bt_hdr(pbuf, pbase)->nitems = pn - 1;
+        merged                             = 1;
+    } else {
+        int split = total / 2;
+
+        for (i = 0; i < split; i++) {
+            demofs_bt_islots(lbuf, 0)[i] = all[i];
+        }
+        demofs_bt_hdr(lbuf, 0)->nitems = split;
+        for (i = split; i < total; i++) {
+            demofs_bt_islots(rbuf, 0)[i - split] = all[i];
+        }
+        demofs_bt_hdr(rbuf, 0)->nitems = total - split;
+
+        psl[ridx].key = demofs_bt_islots(rbuf, 0)[0].key;
+        merged        = 0;
+    }
+
+    return merged;
+} /* demofs_bt_rebalance_interior */
+
+/*
+ * Collapse the tree when the embedded root interior shrinks to a single
+ * child: pull that child up into the embedded root, provided its contents fit
+ * in the (smaller) embedded area.  Otherwise keep the degenerate one-child
+ * root until later removals make it fit.
+ */
+static void
+demofs_bt_collapse_root(
+    struct demofs_thread *thread,
+    struct demofs_txn    *txn,
+    struct demofs_inode  *inode)
+{
+    void    *root = inode->block->buffer;
+    uint32_t base = DEMOFS_BT_ROOT_BASE;
+
+    for (;; ) {
+        struct demofs_bt_node_hdr *rh = demofs_bt_hdr(root, base);
+        uint64_t                   cbptr;
+        void                      *cbuf;
+        struct demofs_bt_node_hdr *ch;
+        uint32_t                   need;
+        int                        i, n;
+
+        if (rh->level == 0 || rh->nitems != 1) {
+            break;
+        }
+
+        cbptr = demofs_bt_islots(root, base)[0].child;
+        cbuf  = demofs_bt_node_for_write(thread, txn, cbptr);
+        ch    = demofs_bt_hdr(cbuf, 0);
+        n     = ch->nitems;
+
+        if (ch->level == 0) {
+            need = sizeof(struct demofs_bt_node_hdr) +
+                n * sizeof(struct demofs_bt_lslot) +
+                (DEMOFS_BT_NODE_CAP - ch->free_end);
+        } else {
+            need = sizeof(struct demofs_bt_node_hdr) +
+                n * sizeof(struct demofs_bt_islot);
+        }
+
+        if (need > DEMOFS_BT_ROOT_CAP) {
+            break;     /* keep the one-child root */
+        }
+
+        if (ch->level == 0) {
+            struct demofs_bt_lslot *cs = demofs_bt_lslots(cbuf, 0);
+            uint64_t                cnext = ch->next_leaf, cprev = ch->prev_leaf;
+            struct demofs_bt_key   *keys    = malloc((n + 1) * sizeof(*keys));
+            uint32_t               *lens    = malloc((n + 1) * sizeof(uint32_t));
+            char                   *scratch = malloc(DEMOFS_BT_NODE_CAP);
+            uint32_t                o       = 0;
+
+            for (i = 0; i < n; i++) {
+                keys[i] = cs[i].key;
+                lens[i] = cs[i].len;
+                memcpy(scratch + o, (char *) cbuf + cs[i].off, cs[i].len);
+                o += cs[i].len;
+            }
+            demofs_bt_node_init(root, base, DEMOFS_BT_ROOT_CAP, 0);
+            o = 0;
+            for (i = 0; i < n; i++) {
+                demofs_bt_leaf_append(root, base, &keys[i], scratch + o, lens[i]);
+                o += lens[i];
+            }
+            rh            = demofs_bt_hdr(root, base);
+            rh->next_leaf = cnext;
+            rh->prev_leaf = cprev;
+            free(keys);
+            free(lens);
+            free(scratch);
+        } else {
+            struct demofs_bt_islot tmp[(DEMOFS_BT_NODE_CAP / sizeof(struct demofs_bt_islot))];
+            uint16_t               clevel = ch->level;
+
+            for (i = 0; i < n; i++) {
+                tmp[i] = demofs_bt_islots(cbuf, 0)[i];
+            }
+            demofs_bt_node_init(root, base, DEMOFS_BT_ROOT_CAP, clevel);
+            for (i = 0; i < n; i++) {
+                demofs_bt_islots(root, base)[i] = tmp[i];
+            }
+            demofs_bt_hdr(root, base)->nitems = n;
+        }
+        /* cbuf is now orphaned; physical reclaim deferred. */
+    }
+} /* demofs_bt_collapse_root */
+
+/*
+ * Remove a key from an inode's b+tree, maintaining the B+tree invariants:
+ * the leaf heap is compacted, parent separators are kept exact, and
+ * underflowing non-root nodes borrow/merge with a sibling (propagating up).
+ * Returns 1 if removed, 0 if not found.
  */
 static int
 demofs_bt_remove(
@@ -1782,15 +2162,22 @@ demofs_bt_remove(
     struct demofs_inode        *inode,
     const struct demofs_bt_key *key)
 {
-    void    *buf  = inode->block->buffer;
-    uint32_t base = DEMOFS_BT_ROOT_BASE;
+    struct {
+        void    *buf;
+        uint32_t base;
+        int      ci;
+    } path[DEMOFS_BT_MAX_DEPTH];
+    int      depth = 0;
+    void    *buf   = inode->block->buffer;
+    uint32_t base  = DEMOFS_BT_ROOT_BASE;
+    int      idx, exact, j, level;
 
+    /* Descend to the leaf, recording the interior path. */
     for (;; ) {
         struct demofs_bt_node_hdr *h = demofs_bt_hdr(buf, base);
 
         if (h->level == 0) {
             struct demofs_bt_lslot *sl = demofs_bt_lslots(buf, base);
-            int                     idx, exact, j;
 
             idx = demofs_bt_leaf_search(buf, base, key, &exact);
             if (!exact) {
@@ -1800,15 +2187,59 @@ demofs_bt_remove(
                 sl[j] = sl[j + 1];
             }
             h->nitems--;
-            return 1;
-        } else {
-            int ci = demofs_bt_interior_search(buf, base, key);
+            demofs_bt_leaf_compact(buf, base, h->capacity);
+            break;
+        }
 
-            buf = demofs_bt_node_for_write(thread, txn,
-                                           demofs_bt_islots(buf, base)[ci].child);
-            base = 0;
+        chimera_demofs_abort_if(depth >= DEMOFS_BT_MAX_DEPTH,
+                                "b+tree remove: path too deep");
+        path[depth].buf  = buf;
+        path[depth].base = base;
+        path[depth].ci   = demofs_bt_interior_search(buf, base, key);
+        buf              = demofs_bt_node_for_write(thread, txn,
+                                                    demofs_bt_islots(buf, base)[path[depth].ci].child);
+        base = 0;
+        depth++;
+    }
+
+    if (depth == 0) {
+        return 1;     /* the leaf is the embedded root; nothing more to do */
+    }
+
+    /* Removing a leaf's minimum changes its subtree min; keep the ancestor
+     * separators exact (cascading up through leftmost links). */
+    if (idx == 0 && demofs_bt_hdr(buf, base)->nitems > 0) {
+        struct demofs_bt_key new_min = demofs_bt_lslots(buf, base)[0].key;
+
+        for (level = depth - 1; level >= 0; level--) {
+            int ci = path[level].ci;
+
+            demofs_bt_islots(path[level].buf, path[level].base)[ci].key = new_min;
+            if (ci > 0) {
+                break;
+            }
         }
     }
+
+    /* Rebalance up the tree from the leaf's parent. */
+    if (demofs_bt_leaf_underflow(buf, base)) {
+        int merged = demofs_bt_rebalance_leaf(thread, txn, path[depth - 1].buf,
+                                              path[depth - 1].base, path[depth - 1].ci);
+
+        for (level = depth - 1; merged && level > 0; level--) {
+            if (demofs_bt_interior_underflow(path[level].buf, path[level].base)) {
+                merged = demofs_bt_rebalance_interior(thread, txn,
+                                                      path[level - 1].buf,
+                                                      path[level - 1].base,
+                                                      path[level - 1].ci);
+            } else {
+                merged = 0;
+            }
+        }
+    }
+
+    demofs_bt_collapse_root(thread, txn, inode);
+    return 1;
 } /* demofs_bt_remove */
 
 /*

--- a/src/vfs/demofs/demofs.c
+++ b/src/vfs/demofs/demofs.c
@@ -3124,6 +3124,58 @@ demofs_bt_collapse_root(
 } /* demofs_bt_collapse_root */
 
 /*
+ * Reclaim space owned by a deleted inode (nlink just hit 0, not open).
+ *
+ * The free count for one inode is bounded only by its tree size, but every
+ * free must ride a single transaction's redo -- an arbitrarily large inode
+ * would overflow the journal / block-I/O queue.  So we reclaim inline only the
+ * BOUNDED case: an inode whose entire tree fits in the embedded root (no child
+ * node blocks).  That covers small files (data extents in the root, <=~100) and
+ * empty/small directories.  We always free the home block.
+ *
+ * TODO(incremental-drain): a large inode (interior embedded root) still leaks
+ * its child node blocks and their data extents here.  Draining those needs a
+ * scheme that walks the tree across multiple bounded transactions (an orphan
+ * list of deleted-but-not-fully-reclaimed inodes, drained in the background).
+ * Also, a file unlinked while still open frees nothing here (deferred to close,
+ * which has no write txn) -- another known leak.
+ */
+static void
+demofs_bt_free_tree(
+    struct demofs_thread *thread,
+    struct demofs_txn    *txn,
+    struct demofs_inode  *inode)
+{
+    uint32_t                   dev;
+    uint64_t                   off = sm_inum_to_device_offset(thread->shared->space_map,
+                                                              inode->inum, &dev);
+    void                      *buf;
+    struct demofs_bt_node_hdr *h;
+
+    demofs_txn_pin_inode_block(thread, txn, inode, 0);
+    buf = inode->block->iov.data;
+    h   = demofs_bt_hdr(buf, DEMOFS_BT_ROOT_BASE);
+
+    if (h->level == 0 && S_ISREG(inode->mode)) {
+        /* Small file: every data extent is recorded in the embedded root. */
+        struct demofs_bt_lslot *s = demofs_bt_lslots(buf, DEMOFS_BT_ROOT_BASE);
+        int                     i;
+
+        for (i = 0; i < h->nitems; i++) {
+            struct demofs_extent_rec *e =
+                (struct demofs_extent_rec *) ((char *) buf + DEMOFS_BT_ROOT_BASE + s[i].off);
+
+            demofs_txn_free_space(thread, txn, e->device_id, e->device_offset,
+                                  SM_ALIGN_UP(e->length));
+        }
+    }
+
+    /* The home block stays pinned + logged (with the nlink=0 dinode); its
+     * range is reclaimed on commit. */
+    demofs_txn_free_space(thread, txn, dev, off, DEMOFS_BLOCK_SIZE);
+} /* demofs_bt_free_tree */
+
+/*
  * Remove a key from an inode's b+tree, maintaining the B+tree invariants:
  * the leaf heap is compacted, parent separators are kept exact, and
  * underflowing non-root nodes borrow/merge with a sibling (propagating up).
@@ -7134,6 +7186,8 @@ demofs_remove_at_removed_cb(
     if (inode->nlink == 0) {
         --inode->refcnt;
         if (inode->refcnt == 0) {
+            /* Fully gone (not open): reclaim its tree, data, and home block. */
+            demofs_bt_free_tree(thread, p->txn, inode);
             demofs_inode_free(thread, inode);
         }
     }

--- a/src/vfs/demofs/demofs.c
+++ b/src/vfs/demofs/demofs.c
@@ -100,6 +100,11 @@ struct demofs_request_private {
     int                   rd_namelen;
     char                  rd_name[256];
 
+    /* Scratch buffer for handlers that parse a looked-up b+tree record
+     * (e.g. a dirent's inum/gen) in their async continuation.  Sized to hold
+     * the largest record (DEMOFS_DIRENT_REC_MAX == sizeof(dirent_rec) + 256). */
+    char                  rec_scratch[320];
+
     struct evpl_iovec     iov[66];
 
     // For RMW (read-modify-write) on partial block writes
@@ -413,6 +418,8 @@ struct demofs_extent_rec {
 } __attribute__((packed));
 
 #define DEMOFS_DIRENT_REC_MAX (sizeof(struct demofs_dirent_rec) + 256)
+_Static_assert(DEMOFS_DIRENT_REC_MAX <= 320,
+               "demofs_request_private.rec_scratch must hold a full dirent record");
 
 /*
  * Intent-log redo record, written into the reserved intent-log region.
@@ -4770,6 +4777,28 @@ demofs_lookup_at_child_cb(
     demofs_op_ok(request, p->txn);
 } /* demofs_lookup_at_child_cb */
 
+/* b+tree lookup completion: parse the dirent and fetch the child inode. */
+static void
+demofs_lookup_at_dirent_cb(
+    struct demofs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+    struct demofs_dirent_rec      *rec     = (struct demofs_dirent_rec *) p->rec_scratch;
+
+    demofs_bt_op_free(p->thread, op);
+
+    if (result < 0) {
+        demofs_op_fail(request, p->txn, CHIMERA_VFS_ENOENT);
+        return;
+    }
+
+    demofs_inode_get_inum_async(p->thread, p->txn, rec->inum, rec->gen,
+                                demofs_lookup_at_child_cb, request);
+} /* demofs_lookup_at_dirent_cb */
+
 static void
 demofs_lookup_at_parent_cb(
     struct demofs_inode *parent,
@@ -4782,8 +4811,8 @@ demofs_lookup_at_parent_cb(
     const char                    *name    = request->lookup_at.component;
     uint32_t                       namelen = request->lookup_at.component_len;
     uint64_t                       hash    = request->lookup_at.component_hash;
-    uint64_t                       child_inum;
-    uint32_t                       child_gen;
+    struct demofs_bt_key           key;
+    struct demofs_bt_op           *op;
 
     if (unlikely(status != CHIMERA_VFS_OK)) {
         demofs_op_fail(request, p->txn, status);
@@ -4815,13 +4844,13 @@ demofs_lookup_at_parent_cb(
         return;
     }
 
-    if (demofs_dir_lookup(thread, parent, hash, &child_inum, &child_gen) != 0) {
-        demofs_op_fail(request, p->txn, CHIMERA_VFS_ENOENT);
-        return;
+    key = demofs_dirent_key(hash);
+    op  = demofs_bt_op_alloc(thread);
+    if (demofs_bt_lookup_async(op, thread, parent, DEMOFS_BT_OP_LOOKUP_EXACT,
+                               &key, NULL, p->rec_scratch, sizeof(p->rec_scratch),
+                               demofs_lookup_at_dirent_cb, request)) {
+        demofs_lookup_at_dirent_cb(op, op->result, request);
     }
-
-    demofs_inode_get_inum_async(thread, p->txn, child_inum, child_gen,
-                                demofs_lookup_at_child_cb, request);
 } /* demofs_lookup_at_parent_cb */
 
 static void

--- a/src/vfs/demofs/demofs.c
+++ b/src/vfs/demofs/demofs.c
@@ -667,6 +667,7 @@ struct demofs_intent_log {
     struct demofs_il_record  *push_cur;          /* record currently being pushed */
     int                       push_outstanding;  /* home writes in flight for push_cur */
     int                       redo_inflight;     /* redo writes issued, not yet in FIFO */
+    int                       iocbs_inflight;    /* block writes (redo + push) on the queue, not yet completed */
 };
 
 struct demofs_shared {
@@ -5235,7 +5236,20 @@ struct demofs_redo_ctx {
  * txn is issued in consecutive chunks sharing one redo_ctx; the record is
  * durable only when the last chunk completes.
  */
-#define DEMOFS_IL_MAX_IOV 64
+#define DEMOFS_IL_MAX_IOV    64
+
+/*
+ * The intent-log thread submits all its block writes (redo records + tail-push
+ * home writes) onto a single libaio/io_uring queue, whose submission ring is
+ * bounded (libaio_max_pending defaults to 256).  Each wake processes every
+ * channel's whole submission queue, so without a cap the redo writes for a
+ * burst of queued txns can flood the ring before any completion drains it
+ * ("too many pending iocbs").  Gate redo submission once this many writes are
+ * in flight, and resume from a completion once it drains back to the low
+ * watermark -- leaving headroom for the in-flight tail-push record's writes.
+ */
+#define DEMOFS_IL_IOCB_CAP   128
+#define DEMOFS_IL_IOCB_LOWAT 64
 
 /*
  * On-log record layout (all 4 KiB-aligned for zero-copy scatter-gather):
@@ -5387,6 +5401,11 @@ demofs_il_push_block_cb(
     (void) evpl;
     chimera_demofs_abort_if(status, "tail-push home write failed: %d", status);
 
+    /* One home write drained from the queue; resume redo at the low watermark. */
+    if (--il->iocbs_inflight == DEMOFS_IL_IOCB_LOWAT) {
+        evpl_ring_doorbell(&il->wake_doorbell);
+    }
+
     if (--il->push_outstanding == 0) {
         demofs_il_push_finish(il);
     }
@@ -5426,6 +5445,7 @@ demofs_il_push_kick(struct demofs_intent_log *il)
     /* Block I/O completes asynchronously, so no completion can fire while we
      * issue these writes; the last completion finishes the record. */
     il->push_outstanding = rec->num_blocks;
+    il->iocbs_inflight  += rec->num_blocks;    /* one home write per block below */
 
     p = (char *) rec->iovs[0].data + sizeof(struct demofs_redo_header);
     for (i = 0; i < rec->num_blocks; i++) {
@@ -5457,6 +5477,12 @@ demofs_redo_write_cb(
 
     (void) evpl;
     chimera_demofs_abort_if(status, "redo record write failed: %d", status);
+
+    /* One block write (one chunk) drained from the queue.  Resume redo
+     * submission once the queue has bled back down to the low watermark. */
+    if (--il->iocbs_inflight == DEMOFS_IL_IOCB_LOWAT) {
+        evpl_ring_doorbell(&il->wake_doorbell);
+    }
 
     /* One chunk of a possibly multi-chunk journal write landed; only the last
      * makes the whole record durable. */
@@ -5608,6 +5634,7 @@ demofs_il_write_redo(
 
     ch->cq_inflight++;
     il->redo_inflight++;
+    il->iocbs_inflight += ctx->segments;     /* one block write per chunk below */
 
     /* Issue the record in <=DEMOFS_IL_MAX_IOV-iovec chunks to consecutive
      * offsets (the on-log record is contiguous); all chunks share ctx and the
@@ -5662,6 +5689,15 @@ demofs_iq_process_channel(struct demofs_iq_channel *ch)
         struct demofs_iq_entry *slot = &ch->sq.entries[sq_head & DEMOFS_IQ_RING_MASK];
         struct demofs_iq_entry  entry;
         uint32_t                cq_tail, cq_head;
+
+        /* Don't overrun the block queue's submission ring.  A redo record is a
+         * handful of writes; stop consuming the SQ once we're at the cap and
+         * let a write completion ring the wake doorbell to resume us.  When the
+         * queue is idle, always issue at least one record so we make progress
+         * even if a single record exceeds the cap. */
+        if (il->iocbs_inflight >= DEMOFS_IL_IOCB_CAP) {
+            break;
+        }
 
         cq_tail = __atomic_load_n(&ch->cq.tail, __ATOMIC_RELAXED);
         cq_head = __atomic_load_n(&ch->cq.head, __ATOMIC_ACQUIRE);
@@ -5804,6 +5840,7 @@ demofs_intent_log_thread_init(
     il->push_cur         = NULL;
     il->push_outstanding = 0;
     il->redo_inflight    = 0;
+    il->iocbs_inflight   = 0;
 
     /* Open block queues on this thread's evpl for redo writes + tail-push. */
     il->queue = calloc(shared->num_devices, sizeof(*il->queue));
@@ -5825,19 +5862,22 @@ demofs_intent_log_thread_shutdown(
     struct demofs_shared     *shared = container_of(il, struct demofs_shared, intent_log);
     int                       i;
 
-    /* By the time this runs the VFS layer has destroyed the worker
-     * threads, which freed their channels.  Just drop the doorbell and
-     * close our block queues. */
-    evpl_remove_doorbell(evpl, &il->wake_doorbell);
-
-    /* Clean unmount: drain everything to its final on-disk location so the
+    /* By the time this runs the VFS layer has destroyed the worker threads,
+     * which freed their channels, so no new SQ work can arrive.
+     *
+     * Clean unmount: drain everything to its final on-disk location so the
      * filesystem is fully consistent at home offsets (no replay needed).
      * Pump our evpl until all in-flight redo writes have landed in the push
-     * FIFO and the tail-pusher has flushed every record home. */
+     * FIFO and the tail-pusher has flushed every record home.  Drain *before*
+     * dropping the wake doorbell: an in-flight redo/push write completing here
+     * rings the doorbell to resume submission, so it must still be open. */
     while (il->redo_inflight || il->push_cur || il->push_head) {
         demofs_il_push_kick(il);
         evpl_continue(evpl);
     }
+
+    /* All writes durable and no submitter remains; now drop the doorbell. */
+    evpl_remove_doorbell(evpl, &il->wake_doorbell);
 
     for (i = 0; i < shared->num_devices; i++) {
         evpl_block_close_queue(evpl, il->queue[i]);

--- a/src/vfs/demofs/demofs.c
+++ b/src/vfs/demofs/demofs.c
@@ -6945,6 +6945,25 @@ demofs_symlink_at(
 } /* demofs_symlink_at */
 
 static void
+demofs_readlink_done_cb(
+    struct demofs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+    struct demofs_inode           *inode   = p->inode_stash[0];
+
+    demofs_bt_op_free(p->thread, op);
+
+    chimera_demofs_abort_if(result < 0, "symlink record missing (inum %lu)", inode->inum);
+    request->readlink.r_target_length = result;
+
+    demofs_map_attrs(p->thread, &request->readlink.r_attr, inode);
+    demofs_op_ok(request, p->txn);
+} /* demofs_readlink_done_cb */
+
+static void
 demofs_readlink_inode_cb(
     struct demofs_inode *inode,
     int                  status,
@@ -6952,6 +6971,8 @@ demofs_readlink_inode_cb(
 {
     struct chimera_vfs_request    *request = private_data;
     struct demofs_request_private *p       = request->plugin_data;
+    struct demofs_bt_key           key     = { .type = DEMOFS_REC_SYMLINK, .subkey = 0 };
+    struct demofs_bt_op           *op;
 
     if (unlikely(status != CHIMERA_VFS_OK)) {
         demofs_op_fail(request, p->txn, status);
@@ -6963,17 +6984,15 @@ demofs_readlink_inode_cb(
         return;
     }
 
-    {
-        int len = demofs_symlink_get(p->thread, inode,
-                                     request->readlink.r_target,
-                                     request->readlink.target_maxlength);
-        chimera_demofs_abort_if(len < 0, "symlink record missing (inum %lu)", inode->inum);
-        request->readlink.r_target_length = len;
+    p->inode_stash[0] = inode;
+
+    op = demofs_bt_op_alloc(p->thread);
+    if (demofs_bt_lookup_async(op, p->thread, inode, DEMOFS_BT_OP_LOOKUP_EXACT,
+                               &key, NULL, request->readlink.r_target,
+                               request->readlink.target_maxlength,
+                               demofs_readlink_done_cb, request)) {
+        demofs_readlink_done_cb(op, op->result, request);
     }
-
-    demofs_map_attrs(p->thread, &request->readlink.r_attr, inode);
-
-    demofs_op_ok(request, p->txn);
 } /* demofs_readlink_inode_cb */
 
 static void

--- a/src/vfs/demofs/demofs.c
+++ b/src/vfs/demofs/demofs.c
@@ -103,6 +103,15 @@ struct demofs_request_private {
     uint32_t                 read_suffix;
     struct demofs_thread    *thread;     // Thread for tracking pending I/O
     struct demofs_txn       *txn;        // Transaction wrapping this op
+
+    /* Data-I/O admission control (see demofs_thread.io_wait_head).  When a
+     * request parks because the block queue is full, io_resume re-enters the
+     * paused path; io_reading marks a read whose extent walk has not finished,
+     * so a completion that drains its in-flight reads to zero must not finalize
+     * it while it is parked mid-walk. */
+    void                     (*io_resume)(struct chimera_vfs_request *);
+    struct chimera_vfs_request *io_wait_next;
+    int                      io_reading;
     /* Multi-inode op scratch (lookup_at parent/child, rename's 4-inode
      * chain, etc.).  Per-op semantics documented at use sites. */
     struct demofs_inode     *inode_stash[4];
@@ -675,6 +684,7 @@ struct demofs_intent_log {
     struct demofs_il_record  *push_head;
     struct demofs_il_record  *push_tail;
     struct demofs_il_record  *push_cur;          /* record currently being pushed */
+    uint32_t                  push_next;         /* next block index of push_cur to issue */
     int                       push_outstanding;  /* home writes in flight for push_cur */
     int                       redo_inflight;     /* redo writes issued, not yet in FIFO */
     int                       iocbs_inflight;    /* block writes (redo + push) on the queue, not yet completed */
@@ -743,6 +753,12 @@ struct demofs_thread {
      * b+tree in bounded batches across transactions). */
     struct demofs_drain        *drain_head, *drain_tail;
     int                         draining;
+
+    /* Data-I/O admission control: the per-thread block queues have a bounded
+     * submission ring, so a burst of concurrent (or heavily fragmented) reads
+     * and writes can overrun it.  Requests that would exceed the in-flight cap
+     * park here and are resumed from a block-I/O completion as capacity frees. */
+    struct chimera_vfs_request *io_wait_head, *io_wait_tail;
 };
 
 /* ------------------------------------------------------------------ */
@@ -1974,6 +1990,11 @@ struct demofs_block_load {
     struct demofs_thread *thread;     /* worker that issued the read */
 };
 
+/* Resume data-I/O requests parked on the admission gate (defined below); a
+ * metadata-node read shares the worker queue, so its completion frees capacity
+ * too and must wake parked requests, else they hang. */
+static void demofs_io_resume_waiters(struct demofs_thread *thread);
+
 /* Block read completion: data landed directly in blk->iov; mark CLEAN, wake. */
 static void
 demofs_block_load_complete(
@@ -2007,6 +2028,9 @@ demofs_block_load_complete(
         waiters = op->next;
         demofs_bt_op_resume(self, op);
     }
+
+    /* Freed a worker-queue slot: let any parked data-I/O requests resume. */
+    demofs_io_resume_waiters(self);
 } /* demofs_block_load_complete */
 
 /*
@@ -5392,6 +5416,8 @@ demofs_il_clean_pushed_record(
     }
 } /* demofs_il_clean_pushed_record */
 
+static void demofs_il_push_issue(struct demofs_intent_log *il);
+
 /* Finish the current record: mark its blocks evictable, release the record's
 * iovecs (header + all block clones), advance the tail, and kick the next. */
 static void
@@ -5433,7 +5459,17 @@ demofs_il_push_block_cb(
         evpl_ring_doorbell(&il->wake_doorbell);
     }
 
-    if (--il->push_outstanding == 0) {
+    --il->push_outstanding;
+
+    /* Capacity freed: issue any of this record's remaining home writes that the
+     * cap held back. */
+    if (il->push_cur && il->push_next < il->push_cur->num_blocks) {
+        demofs_il_push_issue(il);
+    }
+
+    /* All of the current record's blocks are issued and durably home. */
+    if (il->push_outstanding == 0 &&
+        il->push_cur && il->push_next == il->push_cur->num_blocks) {
         demofs_il_push_finish(il);
     }
 } /* demofs_il_push_block_cb */
@@ -5447,10 +5483,7 @@ demofs_il_push_block_cb(
 static void
 demofs_il_push_kick(struct demofs_intent_log *il)
 {
-    struct demofs_il_record         *rec;
-    struct demofs_redo_block_header *bh;
-    char                            *p;
-    uint32_t                         i;
+    struct demofs_il_record *rec;
 
     if (il->push_cur || !il->push_head) {
         return;
@@ -5461,28 +5494,48 @@ demofs_il_push_kick(struct demofs_intent_log *il)
     if (!il->push_head) {
         il->push_tail = NULL;
     }
-    rec->next    = NULL;
-    il->push_cur = rec;
+    rec->next            = NULL;
+    il->push_cur         = rec;
+    il->push_next        = 0;
+    il->push_outstanding = 0;
 
     if (rec->num_blocks == 0) {
         demofs_il_push_finish(il);
         return;
     }
 
-    /* Block I/O completes asynchronously, so no completion can fire while we
-     * issue these writes; the last completion finishes the record. */
-    il->push_outstanding = rec->num_blocks;
-    il->iocbs_inflight  += rec->num_blocks;    /* one home write per block below */
+    demofs_il_push_issue(il);
+} /* demofs_il_push_kick */
 
-    p = (char *) rec->iovs[0].data + sizeof(struct demofs_redo_header);
-    for (i = 0; i < rec->num_blocks; i++) {
-        bh = (struct demofs_redo_block_header *) p;
-        p += sizeof(*bh);
+/*
+ * Issue as many of the current record's remaining home writes as the block
+ * queue's in-flight cap allows.  A large metadata txn can have more blocks than
+ * the submission ring holds, so the rest are issued from demofs_il_push_block_cb
+ * as completions free capacity.  Shares the iocb budget with redo writes (both
+ * gate on iocbs_inflight) so the IL thread never overruns the queue.
+ */
+static void
+demofs_il_push_issue(struct demofs_intent_log *il)
+{
+    struct demofs_il_record         *rec  = il->push_cur;
+    char                            *base = (char *) rec->iovs[0].data +
+        sizeof(struct demofs_redo_header);
+    struct demofs_redo_block_header *bh;
 
-        evpl_block_write(il->evpl, il->queue[bh->device_id], &rec->iovs[1 + i], 1,
+    while (il->push_next < rec->num_blocks &&
+           il->iocbs_inflight < DEMOFS_IL_IOCB_CAP) {
+        uint32_t idx = il->push_next;
+
+        bh = (struct demofs_redo_block_header *) (base + (size_t) idx * sizeof(*bh));
+
+        il->push_next++;
+        il->push_outstanding++;
+        il->iocbs_inflight++;
+
+        evpl_block_write(il->evpl, il->queue[bh->device_id], &rec->iovs[1 + idx], 1,
                          bh->device_offset, 1 /* sync */, demofs_il_push_block_cb, il);
     }
-} /* demofs_il_push_kick */
+} /* demofs_il_push_issue */
 
 /*
  * Runs on the intent-log thread when a redo record has been written
@@ -5865,6 +5918,7 @@ demofs_intent_log_thread_init(
     il->push_head        = NULL;
     il->push_tail        = NULL;
     il->push_cur         = NULL;
+    il->push_next        = 0;
     il->push_outstanding = 0;
     il->redo_inflight    = 0;
     il->iocbs_inflight   = 0;
@@ -8623,6 +8677,67 @@ demofs_read_adjust_iovecs(
     }
 } /* demofs_read_adjust_iovecs */ /* demofs_read_adjust_iovecs */
 
+/*
+ * Data-I/O admission control.  A worker submits read/write block I/O onto its
+ * per-device queues, whose submission rings are bounded (libaio 256, io_uring
+ * 8192); fragmented reads fan out per extent and many connections (nconnect)
+ * drive concurrent requests, so unchecked submission overruns the ring.  Cap
+ * the in-flight data I/O well under the smaller ring; a request that would
+ * exceed it parks and is resumed from a completion at the low watermark.  The
+ * cap leaves headroom for the un-gated, self-limited metadata reads (one
+ * outstanding per suspended b+tree op) sharing the same queues.
+ */
+#define DEMOFS_IO_INFLIGHT_CAP   128
+#define DEMOFS_IO_INFLIGHT_LOWAT 64
+
+/*
+ * Returns 1 and parks the request if the in-flight data I/O is at the cap (the
+ * caller must then return without issuing); 0 if it is clear to submit.  resume
+ * re-enters the paused path once a completion drains the queue.
+ */
+static int
+demofs_io_gate(
+    struct demofs_thread       *thread,
+    struct chimera_vfs_request *request,
+    void                        (*resume)(struct chimera_vfs_request *))
+{
+    struct demofs_request_private *p = request->plugin_data;
+
+    if (thread->pending_io < DEMOFS_IO_INFLIGHT_CAP) {
+        return 0;
+    }
+
+    p->io_resume    = resume;
+    p->io_wait_next = NULL;
+    if (thread->io_wait_tail) {
+        struct demofs_request_private *tp = thread->io_wait_tail->plugin_data;
+        tp->io_wait_next = request;
+    } else {
+        thread->io_wait_head = request;
+    }
+    thread->io_wait_tail = request;
+    return 1;
+} /* demofs_io_gate */
+
+/* Resume parked requests while the queue has drained below the low watermark. */
+static void
+demofs_io_resume_waiters(struct demofs_thread *thread)
+{
+    while (thread->io_wait_head && thread->pending_io < DEMOFS_IO_INFLIGHT_LOWAT) {
+        struct chimera_vfs_request    *request = thread->io_wait_head;
+        struct demofs_request_private *p       = request->plugin_data;
+        void                           (*resume)(struct chimera_vfs_request *) = p->io_resume;
+
+        thread->io_wait_head = p->io_wait_next;
+        if (!thread->io_wait_head) {
+            thread->io_wait_tail = NULL;
+        }
+        p->io_wait_next = NULL;
+        p->io_resume    = NULL;
+        resume(request);
+    }
+} /* demofs_io_resume_waiters */
+
 static inline void
 demofs_io_callback(
     struct evpl *evpl,
@@ -8640,7 +8755,12 @@ demofs_io_callback(
     demofs_private->pending--;
     thread->pending_io--;
 
-    if (demofs_private->pending == 0) {
+    /* Don't finalize a read whose extent walk is still in progress (parked on
+     * the admission gate): its remaining reads have yet to be issued.  The
+     * io_reading guard is scoped to reads -- request plugin_data is pooled and
+     * not zeroed, and only demofs_read sets the flag (fresh, per op). */
+    if (demofs_private->pending == 0 &&
+        !(demofs_private->opcode == CHIMERA_VFS_OP_READ && demofs_private->io_reading)) {
         if (demofs_private->opcode == CHIMERA_VFS_OP_READ) {
             demofs_read_adjust_iovecs(request, demofs_private);
         }
@@ -8654,6 +8774,9 @@ demofs_io_callback(
             demofs_op_ok(request, demofs_private->txn);
         }
     }
+
+    /* Queue capacity freed: let any parked requests resume submitting. */
+    demofs_io_resume_waiters(thread);
 } /* demofs_io_callback */
 
 /*
@@ -8678,6 +8801,9 @@ demofs_read_finish(struct chimera_vfs_request *request)
     }
 
     demofs_map_attrs(thread, &request->read.r_attr, inode);
+
+    /* The extent walk is complete; a now-or-later finalize is safe. */
+    p->io_reading = 0;
 
     if (p->pending == 0) {
         demofs_read_adjust_iovecs(request, p);
@@ -8734,6 +8860,12 @@ demofs_read_process(struct chimera_vfs_request *request)
 
     if (!(read_left && p->loop_have && extent->file_offset < aligned_end)) {
         demofs_read_finish(request);
+        return;
+    }
+
+    /* Bound in-flight data I/O: park here (state is fully in p) and resume the
+     * walk from a completion if the queue is at the cap. */
+    if (demofs_io_gate(thread, request, demofs_read_process)) {
         return;
     }
 
@@ -8918,12 +9050,13 @@ demofs_read(
     (void) shared;
     (void) private_data;
 
-    p->opcode  = request->opcode;
-    p->status  = 0;
-    p->pending = 0;
-    p->niov    = 0;
-    p->thread  = thread;
-    p->txn     = demofs_txn_begin(thread, DEMOFS_TXN_READ);
+    p->opcode     = request->opcode;
+    p->status     = 0;
+    p->pending    = 0;
+    p->niov       = 0;
+    p->thread     = thread;
+    p->io_reading = 1;     /* cleared in demofs_read_finish when the walk ends */
+    p->txn        = demofs_txn_begin(thread, DEMOFS_TXN_READ);
 
     demofs_inode_get_fh_async(thread, p->txn,
                               request->fh, request->fh_len,
@@ -8935,6 +9068,15 @@ static void demofs_write_phase2(
     struct demofs_thread       *thread,
     struct demofs_shared       *shared,
     struct chimera_vfs_request *request);
+
+/* Admission-gate resume trampoline for the write data phase. */
+static void
+demofs_write_phase2_resume(struct chimera_vfs_request *request)
+{
+    struct demofs_request_private *p = request->plugin_data;
+
+    demofs_write_phase2(p->thread, p->thread->shared, request);
+} /* demofs_write_phase2_resume */
 
 // Callback for RMW prefix/suffix reads
 static void
@@ -8954,6 +9096,9 @@ demofs_write_rmw_read_callback(
 
     demofs_private->pending--;
     thread->pending_io--;
+
+    /* Queue capacity freed: let any parked requests resume submitting. */
+    demofs_io_resume_waiters(thread);
 
     if (demofs_private->pending == 0) {
         if (demofs_private->status) {
@@ -8994,6 +9139,14 @@ demofs_write_phase2(
     uint64_t                       write_length = request->write.length;
     uint32_t                       prefix_len   = demofs_private->rmw_prefix_len;
     uint32_t                       suffix_len   = demofs_private->rmw_suffix_len;
+
+    /* Bound in-flight data I/O: park before assembling/issuing the write if the
+     * queue is at the cap.  We gate at entry (nothing allocated yet), so resume
+     * simply re-enters phase2.  The inode lock is held until the txn is durable
+     * regardless, so parking here doesn't expose dirty state. */
+    if (demofs_io_gate(thread, request, demofs_write_phase2_resume)) {
+        return;
+    }
 
     // Build the combined write iovec:
     // [prefix (if any)] + [write data] + [suffix (if any)] + [padding to 4KB]

--- a/src/vfs/demofs/demofs.c
+++ b/src/vfs/demofs/demofs.c
@@ -723,6 +723,12 @@ struct demofs_thread {
     struct evpl_doorbell        resume_doorbell;
     struct evpl_deferral        resume_deferral;
     struct demofs_bt_op        *bt_op_free_list;
+
+    /* Background reclaim of large deleted inodes: a queue of orphan drain
+     * contexts processed one at a time on this worker (each drains its inode's
+     * b+tree in bounded batches across transactions). */
+    struct demofs_drain        *drain_head, *drain_tail;
+    int                         draining;
 };
 
 /* ------------------------------------------------------------------ */
@@ -3181,6 +3187,261 @@ demofs_bt_free_tree(
      * range is reclaimed on commit. */
     demofs_txn_free_space(thread, txn, dev, off, DEMOFS_BLOCK_SIZE);
 } /* demofs_bt_free_tree */
+
+/* Forward declarations for helpers defined later in the file. */
+static struct demofs_txn * demofs_txn_begin(
+    struct demofs_thread *thread,
+    enum demofs_txn_type  type);
+static inline void demofs_txn_abort(
+    struct demofs_txn *txn);
+static inline void demofs_txn_commit(
+    struct demofs_txn     *txn,
+    demofs_txn_commit_cb_t cb,
+    void                  *private_data);
+static void demofs_inode_free(
+    struct demofs_thread *thread,
+    struct demofs_inode  *inode);
+static void demofs_thread_free_space(
+    struct demofs_thread *thread,
+    struct demofs_txn    *txn,
+    uint32_t              device_id,
+    uint64_t              device_offset,
+    uint64_t              length);
+static int demofs_bt_remove_async(
+    struct demofs_bt_op        *op,
+    struct demofs_thread       *thread,
+    struct demofs_txn          *txn,
+    struct demofs_inode        *inode,
+    const struct demofs_bt_key *key,
+    demofs_bt_cb_t              cb,
+    void                       *private_data);
+static int demofs_bt_lookup_async(
+    struct demofs_bt_op        *op,
+    struct demofs_thread       *thread,
+    struct demofs_inode        *inode,
+    enum demofs_bt_opcode       opcode,
+    const struct demofs_bt_key *key,
+    struct demofs_bt_key       *r_key,
+    void                       *out,
+    uint32_t                    out_cap,
+    demofs_bt_cb_t              cb,
+    void                       *private_data);
+
+/* ------------------------------------------------------------------ */
+/* Background drainer: reclaim a large deleted inode incrementally.     */
+/*                                                                      */
+/* A large inode's tree can't be freed in one transaction (it would     */
+/* flood the block-I/O queue), so it is drained in bounded batches: per */
+/* transaction, remove up to DEMOFS_DRAIN_BATCH of the lowest b+tree    */
+/* entries (freeing a file extent's backing data; the remove itself     */
+/* reclaims emptied node blocks via merge), commit, repeat -- then a    */
+/* final transaction frees the home block + the inode struct.  Generic  */
+/* over entry type (extents, dirents, symlink).  Each transaction holds */
+/* only the one inode (no multi-inode lock ordering).  The orphan inode */
+/* stays cached throughout (A5 never evicts nlink==0).                  */
+/*                                                                      */
+/* In-memory queue, processed one at a time per worker.  Crash-safe     */
+/* resume via the durable orphan-list inode is a follow-up (Part B); a  */
+/* crash mid-drain currently leaks the not-yet-freed remainder.         */
+/* ------------------------------------------------------------------ */
+
+#define DEMOFS_DRAIN_BATCH 64
+
+struct demofs_drain {
+    struct demofs_thread *thread;
+    uint64_t              inum;
+    uint32_t              gen;
+    struct demofs_txn    *txn;
+    struct demofs_inode  *inode;
+    int                   batch;
+    struct demofs_bt_key  found_key;
+    uint8_t               recbuf[sizeof(struct demofs_extent_rec)];
+    struct demofs_drain  *next;
+};
+
+static void demofs_drain_kick(
+    struct demofs_thread *thread);
+static void demofs_drain_begin(
+    struct demofs_drain *d);
+
+/* Queue a deleted (nlink==0) large inode for background reclaim.  Its inode
+ * struct must stay resident until drained -- nlink==0 keeps A5 from evicting
+ * it -- and must NOT be demofs_inode_free'd by the caller (the drainer does
+ * that at the end). */
+static void
+demofs_drain_enqueue(
+    struct demofs_thread *thread,
+    uint64_t              inum,
+    uint32_t              gen)
+{
+    struct demofs_drain *d = calloc(1, sizeof(*d));
+
+    d->thread = thread;
+    d->inum   = inum;
+    d->gen    = gen;
+    if (thread->drain_tail) {
+        thread->drain_tail->next = d;
+    } else {
+        thread->drain_head = d;
+    }
+    thread->drain_tail = d;
+    demofs_drain_kick(thread);
+} /* demofs_drain_enqueue */
+
+static void
+demofs_drain_kick(struct demofs_thread *thread)
+{
+    struct demofs_drain *d;
+
+    if (thread->draining || !thread->drain_head) {
+        return;
+    }
+    d                  = thread->drain_head;
+    thread->drain_head = d->next;
+    if (!thread->drain_head) {
+        thread->drain_tail = NULL;
+    }
+    d->next          = NULL;
+    thread->draining = 1;
+    demofs_drain_begin(d);
+} /* demofs_drain_kick */
+
+static void
+demofs_drain_complete(struct demofs_drain *d)
+{
+    struct demofs_thread *thread = d->thread;
+
+    free(d);
+    thread->draining = 0;
+    demofs_drain_kick(thread);
+} /* demofs_drain_complete */
+
+static void demofs_drain_step(
+    struct demofs_drain *d);
+
+static void
+demofs_drain_acquired_cb(
+    struct demofs_inode *inode,
+    int                  status,
+    void                *priv)
+{
+    struct demofs_drain *d = priv;
+
+    /* The acquire parked behind the unlink's write lock; once granted the
+     * inode is durably nlink==0.  If the unlink aborted (or it was already
+     * reclaimed in a prior run), it isn't really gone -- skip it. */
+    if (status != CHIMERA_VFS_OK || inode->nlink != 0) {
+        demofs_txn_abort(d->txn);
+        demofs_drain_complete(d);
+        return;
+    }
+    d->inode = inode;
+    d->batch = 0;
+    demofs_drain_step(d);
+} /* demofs_drain_acquired_cb */
+
+static void
+demofs_drain_begin(struct demofs_drain *d)
+{
+    d->txn = demofs_txn_begin(d->thread, DEMOFS_TXN_WRITE);
+    demofs_inode_acquire(d->thread, d->txn, d->inum, d->gen,
+                         DEMOFS_INODE_LOCK_WRITE, demofs_drain_acquired_cb, d);
+} /* demofs_drain_begin */
+
+static void
+demofs_drain_committed_cb(
+    struct demofs_txn *txn,
+    int                status,
+    void              *priv)
+{
+    struct demofs_drain *d = priv;
+
+    (void) txn;
+    (void) status;
+    demofs_drain_begin(d);     /* next batch: fresh txn + re-acquire */
+} /* demofs_drain_committed_cb */
+
+static void
+demofs_drain_final_cb(
+    struct demofs_txn *txn,
+    int                status,
+    void              *priv)
+{
+    (void) txn;
+    (void) status;
+    demofs_drain_complete(priv);
+} /* demofs_drain_final_cb */
+
+static void
+demofs_drain_removed_cb(
+    struct demofs_bt_op *op,
+    int                  result,
+    void                *priv)
+{
+    struct demofs_drain *d = priv;
+
+    (void) result;
+    demofs_bt_op_free(d->thread, op);
+
+    if (++d->batch >= DEMOFS_DRAIN_BATCH) {
+        demofs_txn_commit(d->txn, demofs_drain_committed_cb, d);
+    } else {
+        demofs_drain_step(d);
+    }
+} /* demofs_drain_removed_cb */
+
+static void
+demofs_drain_looked_cb(
+    struct demofs_bt_op *op,
+    int                  result,
+    void                *priv)
+{
+    struct demofs_drain *d = priv;
+    struct demofs_bt_op *rop;
+
+    if (result < 0) {
+        /* Tree empty: free the home block + the inode struct, then commit. */
+        uint32_t dev;
+        uint64_t off = sm_inum_to_device_offset(d->thread->shared->space_map,
+                                                d->inum, &dev);
+
+        demofs_bt_op_free(d->thread, op);
+        demofs_txn_pin_inode_block(d->thread, d->txn, d->inode, 0);
+        demofs_txn_free_space(d->thread, d->txn, dev, off, DEMOFS_BLOCK_SIZE);
+        demofs_inode_free(d->thread, d->inode);
+        demofs_txn_commit(d->txn, demofs_drain_final_cb, d);
+        return;
+    }
+
+    /* Free a file extent's backing data before removing the record.  The
+     * remove reclaims any emptied b+tree node blocks (generic, any entry). */
+    if (d->found_key.type == DEMOFS_REC_EXTENT) {
+        struct demofs_extent_rec *e = (struct demofs_extent_rec *) d->recbuf;
+
+        demofs_thread_free_space(d->thread, d->txn, e->device_id, e->device_offset,
+                                 SM_ALIGN_UP(e->length));
+    }
+    demofs_bt_op_free(d->thread, op);
+
+    rop = demofs_bt_op_alloc(d->thread);
+    if (demofs_bt_remove_async(rop, d->thread, d->txn, d->inode, &d->found_key,
+                               demofs_drain_removed_cb, d)) {
+        demofs_drain_removed_cb(rop, rop->result, d);
+    }
+} /* demofs_drain_looked_cb */
+
+static void
+demofs_drain_step(struct demofs_drain *d)
+{
+    struct demofs_bt_op *op  = demofs_bt_op_alloc(d->thread);
+    struct demofs_bt_key key = { .type = 0, .subkey = 0 };   /* min key */
+
+    if (demofs_bt_lookup_async(op, d->thread, d->inode, DEMOFS_BT_OP_LOOKUP_GE,
+                               &key, &d->found_key, d->recbuf, sizeof(d->recbuf),
+                               demofs_drain_looked_cb, d)) {
+        demofs_drain_looked_cb(op, op->result, d);
+    }
+} /* demofs_drain_step */
 
 /*
  * Remove a key from an inode's b+tree, maintaining the B+tree invariants:
@@ -6155,6 +6416,15 @@ demofs_thread_destroy(void *private_data)
     struct demofs_thread *thread = private_data;
     struct demofs_shared *shared = thread->shared;
 
+    /* Quiesce background inode drains first: their transactions reference this
+     * thread (and, unlike VFS ops, nothing else waits for them), so they must
+     * finish before we tear the thread down.  Pump our event loop until the
+     * queue empties; the intent-log thread is still alive to complete the
+     * drain transactions we issue. */
+    while (thread->draining || thread->drain_head) {
+        evpl_continue(thread->evpl);
+    }
+
     /* Drain pending block I/O before closing queues */
     if (thread->pending_io > 0) {
         chimera_demofs_debug("demofs_thread_destroy: draining %d pending I/O operations",
@@ -7240,9 +7510,22 @@ demofs_remove_at_removed_cb(
     if (inode->nlink == 0) {
         --inode->refcnt;
         if (inode->refcnt == 0) {
-            /* Fully gone (not open): reclaim its tree, data, and home block. */
-            demofs_bt_free_tree(thread, p->txn, inode);
-            demofs_inode_free(thread, inode);
+            struct demofs_bt_node_hdr *rh;
+
+            demofs_txn_pin_inode_block(thread, p->txn, inode, 0);
+            rh = demofs_bt_hdr(inode->block->iov.data, DEMOFS_BT_ROOT_BASE);
+
+            if (rh->level == 0) {
+                /* Small inode (whole tree in the embedded root): reclaim inline. */
+                demofs_bt_free_tree(thread, p->txn, inode);
+                demofs_inode_free(thread, inode);
+            } else {
+                /* Large inode: hand to the background drainer (bounded batches)
+                 * so one delete can't flood the I/O queue.  The struct stays
+                 * resident (nlink==0 -> not evicted) until the drainer frees it;
+                 * the drainer's acquire parks until this unlink txn commits. */
+                demofs_drain_enqueue(thread, inode->inum, inode->gen);
+            }
         }
     }
 

--- a/src/vfs/demofs/demofs.c
+++ b/src/vfs/demofs/demofs.c
@@ -3094,6 +3094,89 @@ demofs_dir_next(
     return 0;
 } /* demofs_dir_next */
 
+/*
+ * Async directory-record helpers (thin wrappers over the b+tree op driver).
+ * Each returns 1 if it completed synchronously (result in op->result; the
+ * looked-up record, if any, written into rec_out), or 0 if it suspended (cb
+ * fires with the result later).  Callers parse the dirent record themselves.
+ */
+static int
+demofs_dir_lookup_async(
+    struct demofs_bt_op  *op,
+    struct demofs_thread *thread,
+    struct demofs_inode  *dir,
+    uint64_t              hash,
+    void                 *rec_out,
+    uint32_t              rec_cap,
+    demofs_bt_cb_t        cb,
+    void                 *private_data)
+{
+    struct demofs_bt_key key = demofs_dirent_key(hash);
+
+    return demofs_bt_lookup_async(op, thread, dir, DEMOFS_BT_OP_LOOKUP_EXACT,
+                                  &key, NULL, rec_out, rec_cap, cb, private_data);
+} /* demofs_dir_lookup_async */
+
+static int
+demofs_dir_next_async(
+    struct demofs_bt_op  *op,
+    struct demofs_thread *thread,
+    struct demofs_inode  *dir,
+    uint64_t              from_hash,
+    struct demofs_bt_key *r_key,
+    void                 *rec_out,
+    uint32_t              rec_cap,
+    demofs_bt_cb_t        cb,
+    void                 *private_data)
+{
+    struct demofs_bt_key key = demofs_dirent_key(from_hash);
+
+    return demofs_bt_lookup_async(op, thread, dir, DEMOFS_BT_OP_LOOKUP_GE,
+                                  &key, r_key, rec_out, rec_cap, cb, private_data);
+} /* demofs_dir_next_async */
+
+static int
+demofs_dir_insert_async(
+    struct demofs_bt_op  *op,
+    struct demofs_thread *thread,
+    struct demofs_txn    *txn,
+    struct demofs_inode  *dir,
+    uint64_t              hash,
+    const char           *name,
+    int                   namelen,
+    uint64_t              child_inum,
+    uint32_t              child_gen,
+    demofs_bt_cb_t        cb,
+    void                 *private_data)
+{
+    char                      buf[DEMOFS_DIRENT_REC_MAX];
+    struct demofs_dirent_rec *r   = (struct demofs_dirent_rec *) buf;
+    struct demofs_bt_key      key = demofs_dirent_key(hash);
+
+    r->inum     = child_inum;
+    r->gen      = child_gen;
+    r->name_len = (uint16_t) namelen;
+    memcpy(r->name, name, namelen);
+
+    return demofs_bt_insert_async(op, thread, txn, dir, &key, buf,
+                                  sizeof(*r) + namelen, cb, private_data);
+} /* demofs_dir_insert_async */
+
+static int
+demofs_dir_remove_async(
+    struct demofs_bt_op  *op,
+    struct demofs_thread *thread,
+    struct demofs_txn    *txn,
+    struct demofs_inode  *dir,
+    uint64_t              hash,
+    demofs_bt_cb_t        cb,
+    void                 *private_data)
+{
+    struct demofs_bt_key key = demofs_dirent_key(hash);
+
+    return demofs_bt_remove_async(op, thread, txn, dir, &key, cb, private_data);
+} /* demofs_dir_remove_async */
+
 static void
 demofs_symlink_set(
     struct demofs_thread *thread,
@@ -4894,6 +4977,20 @@ demofs_mkdir_at_existing_cb(
 } /* demofs_mkdir_at_existing_cb */
 
 static void
+demofs_mkdir_at_inserted_cb(
+    struct demofs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+
+    (void) result;
+    demofs_bt_op_free(p->thread, op);
+    demofs_op_ok(request, p->txn);
+} /* demofs_mkdir_at_inserted_cb */
+
+static void
 demofs_mkdir_at_alloc_cb(
     struct demofs_inode *inode,
     int                  status,
@@ -4903,6 +5000,7 @@ demofs_mkdir_at_alloc_cb(
     struct demofs_request_private *p       = request->plugin_data;
     struct demofs_thread          *thread  = p->thread;
     struct demofs_inode           *parent  = p->inode_stash[0];
+    struct demofs_bt_op           *op;
     struct timespec                now;
 
     if (unlikely(status != CHIMERA_VFS_OK)) {
@@ -4931,10 +5029,6 @@ demofs_mkdir_at_alloc_cb(
     demofs_apply_attrs(inode, request->mkdir_at.set_attr);
     demofs_map_attrs(thread, &request->mkdir_at.r_attr, inode);
 
-    demofs_dir_insert(thread, p->txn, parent, request->mkdir_at.name_hash,
-                      request->mkdir_at.name, request->mkdir_at.name_len,
-                      inode->inum, inode->gen);
-
     parent->nlink++;
     parent->mtime_sec  = now.tv_sec;
     parent->mtime_nsec = now.tv_nsec;
@@ -4943,8 +5037,37 @@ demofs_mkdir_at_alloc_cb(
 
     demofs_map_attrs(thread, &request->mkdir_at.r_dir_post_attr, parent);
 
-    demofs_op_ok(request, p->txn);
+    op = demofs_bt_op_alloc(thread);
+    if (demofs_dir_insert_async(op, thread, p->txn, parent,
+                                request->mkdir_at.name_hash, request->mkdir_at.name,
+                                request->mkdir_at.name_len, inode->inum, inode->gen,
+                                demofs_mkdir_at_inserted_cb, request)) {
+        demofs_mkdir_at_inserted_cb(op, op->result, request);
+    }
 } /* demofs_mkdir_at_alloc_cb */
+
+static void
+demofs_mkdir_at_check_cb(
+    struct demofs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+    struct demofs_thread          *thread  = p->thread;
+
+    demofs_bt_op_free(thread, op);
+
+    if (result >= 0) {
+        struct demofs_dirent_rec *rec = (struct demofs_dirent_rec *) p->rec_scratch;
+
+        demofs_inode_get_inum_async(thread, p->txn, rec->inum, rec->gen,
+                                    demofs_mkdir_at_existing_cb, request);
+        return;
+    }
+
+    demofs_inode_alloc_async(thread, p->txn, demofs_mkdir_at_alloc_cb, request);
+} /* demofs_mkdir_at_check_cb */
 
 static void
 demofs_mkdir_at_parent_cb(
@@ -4956,8 +5079,7 @@ demofs_mkdir_at_parent_cb(
     struct demofs_request_private *p       = request->plugin_data;
     struct demofs_thread          *thread  = p->thread;
     uint64_t                       hash    = request->mkdir_at.name_hash;
-    uint64_t                       existing_inum;
-    uint32_t                       existing_gen;
+    struct demofs_bt_op           *op;
 
     if (unlikely(status != CHIMERA_VFS_OK)) {
         demofs_op_fail(request, p->txn, status);
@@ -4973,15 +5095,12 @@ demofs_mkdir_at_parent_cb(
 
     p->inode_stash[0] = parent;
 
-    if (demofs_dir_lookup(thread, parent, hash, &existing_inum, &existing_gen) == 0) {
-        demofs_inode_get_inum_async(thread, p->txn,
-                                    existing_inum, existing_gen,
-                                    demofs_mkdir_at_existing_cb, request);
-        return;
+    op = demofs_bt_op_alloc(thread);
+    if (demofs_dir_lookup_async(op, thread, parent, hash, p->rec_scratch,
+                                sizeof(p->rec_scratch), demofs_mkdir_at_check_cb,
+                                request)) {
+        demofs_mkdir_at_check_cb(op, op->result, request);
     }
-
-    demofs_inode_alloc_async(thread, p->txn,
-                             demofs_mkdir_at_alloc_cb, request);
 } /* demofs_mkdir_at_parent_cb */
 
 static void

--- a/src/vfs/demofs/demofs.c
+++ b/src/vfs/demofs/demofs.c
@@ -317,7 +317,8 @@ struct demofs_bt_op;
 struct demofs_block {
     uint32_t             device_id;
     uint64_t             device_offset;        /* block-aligned; key with device_id */
-    void                *buffer;               /* DEMOFS_BLOCK_SIZE bytes */
+    struct evpl_iovec    iov;                  /* SHARED DEMOFS_BLOCK_SIZE buffer; .data may
+                                                * be NULL on a never-yet-used pool slot */
     int                  pin_count;            /* >0 => pinned, not reclaimable */
     enum demofs_block_state state;
     uint64_t             seq;                  /* update order for tail-push */
@@ -335,14 +336,14 @@ struct demofs_block_shard {
     pthread_mutex_t       lock;
     struct demofs_block **buckets;     /* [DEMOFS_BLOCK_CACHE_BUCKETS_PER_SHARD] */
 
-    /* Pre-allocated fixed buffer pool (all protected by lock).  pool is an
-     * array of nblocks blocks whose buffers carve up the pool_mem arena; they
-     * are never individually freed.  The LRU holds only CLEAN, unpinned
-     * buffers (recycle candidates), ordered least-recently-used first. */
+    /* Pre-allocated fixed pool of block structs (all protected by lock); the
+     * structs are never individually freed.  Each struct's buffer is a SHARED
+     * evpl iovec allocated lazily on first use and reused across recyclings
+     * (released only at teardown).  The LRU holds only CLEAN, unpinned buffers
+     * (recycle candidates), ordered least-recently-used first. */
     struct demofs_block  *pool;                 /* [nblocks] */
-    void                 *pool_mem;             /* nblocks * DEMOFS_BLOCK_SIZE */
     struct demofs_block  *lru_head, *lru_tail;  /* lru_head = next to recycle */
-    uint32_t              nblocks;              /* buffers owned by this shard */
+    uint32_t              nblocks;              /* block structs owned by this shard */
 };
 
 struct demofs_block_cache {
@@ -507,6 +508,12 @@ enum demofs_txn_type {
 /* A dirty block held (pinned) by a transaction until commit/log. */
 struct demofs_txn_block {
     struct demofs_block     *block;
+    /* Zero-copy snapshot of block->iov, cloned at commit on the worker under
+     * the inode write lock (content final, no COW possible there).  Moved into
+     * the redo record by the intent-log thread, so the IL thread never touches
+     * the live block->iov and the record captures this txn's committed image
+     * even if a later writer COWs the cache block. */
+    struct evpl_iovec        snap;
     struct demofs_txn_block *next;
 };
 
@@ -588,7 +595,13 @@ struct demofs_il_record {
     uint64_t                 offset;     /* byte offset in the intent-log region */
     uint64_t                 reclen;
     uint32_t                 num_blocks;
-    struct evpl_iovec        iov;
+    uint32_t                 niov;       /* 1 + num_blocks */
+    /* Scatter-gather image of the on-log record: iovs[0] is the 4 KiB-aligned
+    * header region (redo_header + per-block headers); iovs[1..num_blocks] are
+    * zero-copy refs (clones) of the cache blocks' buffers.  The same refs are
+    * handed to the tail-pusher, so a block image is copied only when a writer
+    * must fork a still-referenced block (COW), never on the log/push path. */
+    struct evpl_iovec       *iovs;
     struct demofs_il_record *next;
 };
 
@@ -1211,7 +1224,7 @@ demofs_inode_load_sync(
     {
         struct demofs_block *blk = demofs_block_claim(thread, dev, off, 0);
 
-        memcpy(blk->buffer, buf, DEMOFS_BLOCK_SIZE);
+        memcpy(blk->iov.data, buf, DEMOFS_BLOCK_SIZE);
         demofs_block_unpin(thread, blk, DEMOFS_BLOCK_CLEAN);
     }
     return inode;
@@ -1451,16 +1464,15 @@ demofs_block_cache_create(struct demofs_shared *shared)
         pthread_mutex_init(&shard->lock, NULL);
         shard->buckets = calloc(DEMOFS_BLOCK_CACHE_BUCKETS_PER_SHARD,
                                 sizeof(struct demofs_block *));
-        shard->pool     = calloc(cache->shard_cap, sizeof(struct demofs_block));
-        shard->pool_mem = calloc(cache->shard_cap, DEMOFS_BLOCK_SIZE);
+        shard->pool = calloc(cache->shard_cap, sizeof(struct demofs_block));
 
-        /* Pre-populate: every buffer starts free (unkeyed, in no bucket) and
-         * CLEAN on the LRU.  Carve the buffers out of the shared arena. */
+        /* Pre-populate the struct pool: every block starts free (unkeyed, in
+         * no bucket) and CLEAN on the LRU, with no buffer yet (iov.data NULL);
+         * the iovec is allocated on first use and reused thereafter. */
         for (j = 0; j < cache->shard_cap; j++) {
             struct demofs_block *blk = &shard->pool[j];
 
-            blk->buffer = (char *) shard->pool_mem + (size_t) j * DEMOFS_BLOCK_SIZE;
-            blk->state  = DEMOFS_BLOCK_CLEAN;
+            blk->state = DEMOFS_BLOCK_CLEAN;
             demofs_block_lru_push_tail(shard, blk);
             shard->nblocks++;
         }
@@ -1480,9 +1492,16 @@ demofs_block_cache_destroy(struct demofs_shared *shared)
 
     for (i = 0; i < DEMOFS_BLOCK_CACHE_SHARDS; i++) {
         struct demofs_block_shard *shard = &cache->shards[i];
+        uint32_t                   j;
 
-        /* Blocks are slices of the fixed pool; free the arena, not each one. */
-        free(shard->pool_mem);
+        /* Release each block's buffer (NULL evpl -> straight to the global
+         * allocator, which is correct at teardown); the structs are one pool
+         * array.  At a clean unmount every block is CLEAN (refcount 1). */
+        for (j = 0; j < shard->nblocks; j++) {
+            if (shard->pool[j].iov.data) {
+                evpl_iovec_release(NULL, &shard->pool[j].iov);
+            }
+        }
         free(shard->pool);
         free(shard->buckets);
         pthread_mutex_destroy(&shard->lock);
@@ -1514,13 +1533,31 @@ demofs_block_lookup_locked(
 } /* demofs_block_lookup_locked */
 
 /*
+ * Ensure a block has a backing buffer.  Buffers are SHARED evpl iovecs so the
+ * intent logger and tail-pusher can reference them zero-copy for I/O (and RDMA)
+ * and hand the reference across threads.  A recycled block keeps (reuses) its
+ * iovec -- a CLEAN block's buffer is referenced only by the cache (refcount 1)
+ * -- so an allocation happens only on a never-yet-used pool slot (and on COW).
+ */
+static inline void
+demofs_block_ensure_iov(
+    struct demofs_thread *thread,
+    struct demofs_block  *blk)
+{
+    if (!blk->iov.data) {
+        evpl_iovec_alloc(thread->evpl, DEMOFS_BLOCK_SIZE, DEMOFS_BLOCK_SIZE, 1,
+                         EVPL_IOVEC_FLAG_SHARED, &blk->iov);
+    }
+} /* demofs_block_ensure_iov */
+
+/*
  * Find or create the cache entry for (device_id, device_offset) and pin it.
  * On a miss a buffer is obtained from the shard pool (recycling the LRU
- * eviction candidate, or growing the pool): is_new (a freshly space-map-
- * allocated block) starts zeroed; otherwise -- always, now that eviction can
- * discard a resident CLEAN block whose content is already home -- the buffer
- * is repopulated from disk so a re-claimed evicted block keeps its contents.
- * A hit unlinks the block from the LRU (it is now pinned, not a candidate).
+ * eviction candidate): is_new (a freshly space-map-allocated block) starts
+ * zeroed; otherwise -- always, now that eviction can discard a resident CLEAN
+ * block whose content is already home -- the buffer is repopulated from disk so
+ * a re-claimed evicted block keeps its contents.  A hit unlinks the block from
+ * the LRU (it is now pinned, not a candidate).
  */
 static struct demofs_block *
 demofs_block_claim(
@@ -1547,15 +1584,16 @@ demofs_block_claim(
         blk->seq           = 0;
         blk->wait_head     = NULL;
         blk->wait_tail     = NULL;
+        demofs_block_ensure_iov(thread, blk);
 
         if (is_new) {
-            memset(blk->buffer, 0, DEMOFS_BLOCK_SIZE);
+            memset(blk->iov.data, 0, DEMOFS_BLOCK_SIZE);
         } else {
             int     fd = open(thread->shared->device_paths[device_id], O_RDONLY);
             ssize_t n  = -1;
 
             if (fd >= 0) {
-                n = pread(fd, blk->buffer, DEMOFS_BLOCK_SIZE, (off_t) device_offset);
+                n = pread(fd, blk->iov.data, DEMOFS_BLOCK_SIZE, (off_t) device_offset);
                 close(fd);
             }
             chimera_demofs_abort_if(n != (ssize_t) DEMOFS_BLOCK_SIZE,
@@ -1567,6 +1605,20 @@ demofs_block_claim(
         shard->buckets[bucket] = blk;
     } else if (blk->on_lru) {
         demofs_block_lru_unlink(shard, blk);
+    } else if (blk->state == DEMOFS_BLOCK_LOGGED) {
+        /* COW: this buffer is still referenced by an un-pushed redo record (and
+         * the tail-pusher will write it home), so it must stay immutable.  Fork
+         * a private writable copy; the old buffer rides the record to its home
+         * and is freed when the pusher releases it.  Done under the shard lock
+         * so it serializes against the pusher's LOGGED->CLEAN transition. */
+        struct evpl_iovec nv;
+
+        evpl_iovec_alloc(thread->evpl, DEMOFS_BLOCK_SIZE, DEMOFS_BLOCK_SIZE, 1,
+                         EVPL_IOVEC_FLAG_SHARED, &nv);
+        memcpy(nv.data, blk->iov.data, DEMOFS_BLOCK_SIZE);
+        evpl_iovec_release(thread->evpl, &blk->iov);
+        evpl_iovec_move(&blk->iov, &nv);
+        blk->state = DEMOFS_BLOCK_CLEAN;
     }
 
     blk->pin_count++;
@@ -1615,7 +1667,7 @@ demofs_sm_claim_block(
                                                    device_offset, is_new);
 
     demofs_txn_add_block(c->txn, blk);
-    return blk->buffer;
+    return blk->iov.data;
 } /* demofs_sm_claim_block */
 
 #define DEMOFS_SM_JNL(name, thr, t)                          \
@@ -1726,10 +1778,9 @@ demofs_bt_resume_deferral_cb(
 struct demofs_block_load {
     struct demofs_block  *blk;
     struct demofs_thread *thread;     /* worker that issued the read */
-    struct evpl_iovec     iov;
 };
 
-/* Block read completion: copy into the cache buffer, mark CLEAN, wake waiters. */
+/* Block read completion: data landed directly in blk->iov; mark CLEAN, wake. */
 static void
 demofs_block_load_complete(
     struct evpl *evpl,
@@ -1743,10 +1794,9 @@ demofs_block_load_complete(
                                                           blk->device_id, blk->device_offset);
     struct demofs_bt_op       *waiters, *op;
 
-    if (likely(status == 0)) {
-        memcpy(blk->buffer, ld->iov.data, DEMOFS_BLOCK_SIZE);
-    }
-    evpl_iovec_release(evpl, &ld->iov);
+    (void) evpl;
+    chimera_demofs_abort_if(status != 0, "block read failed off=%lu status=%d",
+                            blk->device_offset, status);
 
     pthread_mutex_lock(&shard->lock);
     blk->state     = DEMOFS_BLOCK_CLEAN;
@@ -1836,12 +1886,12 @@ demofs_bt_block_get(
     pthread_mutex_unlock(&shard->lock);
 
     if (issue) {
+        demofs_block_ensure_iov(thread, blk);
         ld         = malloc(sizeof(*ld));
         ld->blk    = blk;
         ld->thread = thread;
-        evpl_iovec_alloc(thread->evpl, DEMOFS_BLOCK_SIZE, DEMOFS_BLOCK_SIZE, 1, 0, &ld->iov);
         thread->pending_io++;
-        evpl_block_read(thread->evpl, thread->queue[device_id], &ld->iov, 1,
+        evpl_block_read(thread->evpl, thread->queue[device_id], &blk->iov, 1,
                         device_offset, demofs_block_load_complete, ld);
     }
 
@@ -1876,7 +1926,7 @@ demofs_txn_pin_inode_block(
     if (is_new) {
         /* Initialize the embedded b+tree root (empty leaf) in the new
          * inode block. */
-        demofs_bt_node_init(inode->block->buffer, DEMOFS_BT_ROOT_BASE,
+        demofs_bt_node_init(inode->block->iov.data, DEMOFS_BT_ROOT_BASE,
                             DEMOFS_BT_ROOT_CAP, 0);
     }
 } /* demofs_txn_pin_inode_block */
@@ -1891,7 +1941,7 @@ demofs_inode_flush(struct demofs_inode *inode)
         return;
     }
 
-    di = inode->block->buffer;
+    di = inode->block->iov.data;
 
     di->inum       = inode->inum;
     di->gen        = inode->gen;
@@ -2148,7 +2198,7 @@ demofs_bt_alloc_node(
     blk = demofs_block_claim(thread, device_id, device_offset, 1);
     demofs_txn_add_block(txn, blk);
 
-    demofs_bt_node_init(blk->buffer, 0, DEMOFS_BT_NODE_CAP, level);
+    demofs_bt_node_init(blk->iov.data, 0, DEMOFS_BT_NODE_CAP, level);
 
     *r_bptr = sm_inum_from_device_offset(shared->space_map, device_id, device_offset);
     return blk;
@@ -2168,7 +2218,7 @@ demofs_bt_node_for_write(
     device_offset = sm_inum_to_device_offset(thread->shared->space_map, bptr, &device_id);
     blk           = demofs_block_claim(thread, device_id, device_offset, 0);
     demofs_txn_add_block(txn, blk);
-    return blk->buffer;
+    return blk->iov.data;
 } /* demofs_bt_node_for_write */
 
 /*
@@ -2248,7 +2298,7 @@ demofs_bt_leaf_split(
     old_prev = h->prev_leaf;
 
     right = demofs_bt_alloc_node(thread, txn, 0, sep_bptr);
-    rbuf  = right->buffer;
+    rbuf  = right->iov.data;
 
     /* Rebuild the left node in place from scratch (no aliasing).  node_init
      * clears the leaf links, so they are restored explicitly below. */
@@ -2383,8 +2433,8 @@ demofs_bt_interior_insert(
         split_i = total / 2;
 
         right = demofs_bt_alloc_node(thread, txn, h->level, sep_bptr);
-        rsl   = demofs_bt_islots(right->buffer, 0);
-        rh    = demofs_bt_hdr(right->buffer, 0);
+        rsl   = demofs_bt_islots(right->iov.data, 0);
+        rh    = demofs_bt_hdr(right->iov.data, 0);
 
         h->nitems = split_i;
         for (j = 0; j < split_i; j++) {
@@ -2456,7 +2506,7 @@ demofs_bt_insert_locked(
     const void                 *rec,
     uint32_t                    reclen)
 {
-    void                *root = inode->block->buffer;
+    void                *root = inode->block->iov.data;
     struct demofs_bt_key sep;
     uint64_t             sep_bptr;
     int                  split;
@@ -2483,13 +2533,13 @@ demofs_bt_insert_locked(
         left = demofs_bt_alloc_node(thread, txn, old_level, &left_bptr);
 
         /* Copy the entire embedded root node into the new left block. */
-        memcpy((char *) left->buffer, (char *) root + DEMOFS_BT_ROOT_BASE, DEMOFS_BT_ROOT_CAP);
-        demofs_bt_hdr(left->buffer, 0)->capacity = DEMOFS_BT_NODE_CAP;
+        memcpy((char *) left->iov.data, (char *) root + DEMOFS_BT_ROOT_BASE, DEMOFS_BT_ROOT_CAP);
+        demofs_bt_hdr(left->iov.data, 0)->capacity = DEMOFS_BT_NODE_CAP;
 
         if (old_level == 0) {
-            left_min = demofs_bt_lslots(left->buffer, 0)[0].key;
+            left_min = demofs_bt_lslots(left->iov.data, 0)[0].key;
         } else {
-            left_min = demofs_bt_islots(left->buffer, 0)[0].key;
+            left_min = demofs_bt_islots(left->iov.data, 0)[0].key;
         }
 
         demofs_bt_node_init(root, DEMOFS_BT_ROOT_BASE, DEMOFS_BT_ROOT_CAP,
@@ -2812,7 +2862,7 @@ demofs_bt_collapse_root(
     struct demofs_txn    *txn,
     struct demofs_inode  *inode)
 {
-    void    *root = inode->block->buffer;
+    void    *root = inode->block->iov.data;
     uint32_t base = DEMOFS_BT_ROOT_BASE;
 
     for (;; ) {
@@ -2908,7 +2958,7 @@ demofs_bt_remove_locked(
         int      ci;
     } path[DEMOFS_BT_MAX_DEPTH];
     int      depth = 0;
-    void    *buf   = inode->block->buffer;
+    void    *buf   = inode->block->iov.data;
     uint32_t base  = DEMOFS_BT_ROOT_BASE;
     int      idx, exact, j, level;
 
@@ -3071,7 +3121,7 @@ demofs_bt_run(struct demofs_bt_op *op)
                 if (!blk) {
                     return;
                 }
-                pbuf = blk->buffer;
+                pbuf = blk->iov.data;
                 ph   = demofs_bt_hdr(pbuf, pe->base);
                 ci   = pe->ci;
                 pn   = ph->nitems;
@@ -3116,7 +3166,7 @@ demofs_bt_run(struct demofs_bt_op *op)
         if (!blk) {
             return;     /* suspended; resumed when the block loads */
         }
-        buf = blk->buffer;
+        buf = blk->iov.data;
         h   = demofs_bt_hdr(buf, base);
 
         if (op->phase == DEMOFS_BT_PHASE_DESCEND) {
@@ -4035,7 +4085,7 @@ demofs_inode_load_complete(
                                                             lc->inum, &dev);
         struct demofs_block *blk = demofs_block_claim(thread, dev, off, 0);
 
-        memcpy(blk->buffer, lc->iov.data, DEMOFS_BLOCK_SIZE);
+        memcpy(blk->iov.data, lc->iov.data, DEMOFS_BLOCK_SIZE);
         demofs_block_unpin(thread, blk, DEMOFS_BLOCK_CLEAN);
     }
 
@@ -4370,14 +4420,33 @@ struct demofs_redo_ctx {
     struct demofs_intent_log *il;
     struct demofs_iq_channel *ch;
     struct demofs_iq_entry    entry;
-    struct demofs_il_record  *rec;     /* owns the record image (iov) */
+    struct demofs_il_record  *rec;     /* owns the record image (iovs) */
+    int                       segments; /* outstanding journal writes (see below) */
 };
 
-/* Per-block home-write completion context for the tail-pusher. */
-struct demofs_push_ctx {
-    struct demofs_intent_log *il;
-    struct evpl_iovec         iov;     /* aligned copy of the block post-image */
-};
+/*
+ * A record's scatter-gather image can exceed the block backend's per-request
+ * iovec limit (io_uring caps at 64), so the journal write for a large metadata
+ * txn is issued in consecutive chunks sharing one redo_ctx; the record is
+ * durable only when the last chunk completes.
+ */
+#define DEMOFS_IL_MAX_IOV 64
+
+/*
+ * On-log record layout (all 4 KiB-aligned for zero-copy scatter-gather):
+ *   [ header region: redo_header + num_blocks * redo_block_header, 4K-padded ]
+ *   [ block 0 data (4 KiB) ][ block 1 data ] ... [ block N-1 data ]
+ * The header region is materialized into one iovec; each data block is a
+ * zero-copy clone of the cache block's buffer.
+ */
+static inline uint64_t
+demofs_il_hdr_len(uint32_t nblocks)
+{
+    uint64_t h = sizeof(struct demofs_redo_header) +
+        (uint64_t) nblocks * sizeof(struct demofs_redo_block_header);
+
+    return (h + DEMOFS_BLOCK_SIZE - 1) & ~((uint64_t) DEMOFS_BLOCK_SIZE - 1);
+} /* demofs_il_hdr_len */
 
 /* ------------------------------------------------------------------ */
 /* Tail-pusher: write logged blocks to final locations + trim the log  */
@@ -4450,7 +4519,7 @@ demofs_il_clean_pushed_record(
 {
     struct demofs_shared      *shared = container_of(il, struct demofs_shared, intent_log);
     struct demofs_block_cache *cache  = shared->block_cache;
-    char                      *p      = (char *) rec->iov.data + sizeof(struct demofs_redo_header);
+    char                      *p      = (char *) rec->iovs[0].data + sizeof(struct demofs_redo_header);
     uint32_t                   i;
 
     for (i = 0; i < rec->num_blocks; i++) {
@@ -4459,7 +4528,7 @@ demofs_il_clean_pushed_record(
         struct demofs_block             *blk;
         uint32_t                         bucket;
 
-        p += sizeof(*bh) + DEMOFS_BLOCK_SIZE;
+        p += sizeof(*bh);
 
         shard  = demofs_block_shard(cache, bh->device_id, bh->device_offset);
         bucket = demofs_block_bucket(bh->device_id, bh->device_offset);
@@ -4477,46 +4546,52 @@ demofs_il_clean_pushed_record(
     }
 } /* demofs_il_clean_pushed_record */
 
-/* One home-write of a logged block completed. */
+/* Finish the current record: mark its blocks evictable, release the record's
+* iovecs (header + all block clones), advance the tail, and kick the next. */
+static void
+demofs_il_push_finish(struct demofs_intent_log *il)
+{
+    struct demofs_il_record *rec = il->push_cur;
+
+    demofs_il_clean_pushed_record(il, rec);
+
+    il->push_cur = NULL;
+    evpl_iovecs_release(il->evpl, rec->iovs, rec->niov);
+    free(rec->iovs);
+    free(rec);
+
+    il->log_tail = il->push_head ? il->push_head->offset : il->log_head;
+
+    demofs_il_push_kick(il);
+
+    /* Space freed: re-poke channel processing in case a writer was blocked
+     * on a full log. */
+    evpl_ring_doorbell(&il->wake_doorbell);
+} /* demofs_il_push_finish */
+
+/* One home-write of a logged block completed.  private_data is the il (all
+ * outstanding writes belong to the single current record). */
 static void
 demofs_il_push_block_cb(
     struct evpl *evpl,
     int          status,
     void        *private_data)
 {
-    struct demofs_push_ctx   *pc = private_data;
-    struct demofs_intent_log *il = pc->il;
+    struct demofs_intent_log *il = private_data;
 
+    (void) evpl;
     chimera_demofs_abort_if(status, "tail-push home write failed: %d", status);
-    evpl_iovec_release(evpl, &pc->iov);
-    free(pc);
 
     if (--il->push_outstanding == 0) {
-        /* Whole record is durably home; trim past it and advance the tail. */
-        struct demofs_il_record *rec = il->push_cur;
-
-        /* The blocks are now home -> make the (un-re-logged) ones evictable. */
-        demofs_il_clean_pushed_record(il, rec);
-
-        il->push_cur = NULL;
-        evpl_iovec_release(il->evpl, &rec->iov);
-        free(rec);
-
-        il->log_tail = il->push_head ? il->push_head->offset : il->log_head;
-
-        demofs_il_push_kick(il);
-
-        /* Space freed: re-poke channel processing in case a writer was
-         * blocked on a full log. */
-        evpl_ring_doorbell(&il->wake_doorbell);
+        demofs_il_push_finish(il);
     }
 } /* demofs_il_push_block_cb */
 
 /*
- * Start pushing the oldest pending record (if idle).  Writes every block's
- * post-image, copied out of the immutable log record into an aligned iovec,
- * to its final (device, offset).  Strict oldest-first ordering means a block
- * re-logged in a later record gets its newest image written last.
+ * Start pushing the oldest pending record (if idle).  Writes each block's
+ * post-image straight from the record's zero-copy clone of the cache buffer
+ * to its final (device, offset) -- no copy.  Strict oldest-first ordering
+ * means a block re-logged in a later record gets its newest image last.
  */
 static void
 demofs_il_push_kick(struct demofs_intent_log *il)
@@ -4539,33 +4614,21 @@ demofs_il_push_kick(struct demofs_intent_log *il)
     il->push_cur = rec;
 
     if (rec->num_blocks == 0) {
-        il->push_cur = NULL;
-        evpl_iovec_release(il->evpl, &rec->iov);
-        free(rec);
-        il->log_tail = il->push_head ? il->push_head->offset : il->log_head;
-        demofs_il_push_kick(il);
+        demofs_il_push_finish(il);
         return;
     }
 
     /* Block I/O completes asynchronously, so no completion can fire while we
-     * issue these writes; the last completion trims the record. */
+     * issue these writes; the last completion finishes the record. */
     il->push_outstanding = rec->num_blocks;
 
-    p = (char *) rec->iov.data + sizeof(struct demofs_redo_header);
+    p = (char *) rec->iovs[0].data + sizeof(struct demofs_redo_header);
     for (i = 0; i < rec->num_blocks; i++) {
-        struct demofs_push_ctx *pc;
-
         bh = (struct demofs_redo_block_header *) p;
         p += sizeof(*bh);
 
-        pc     = malloc(sizeof(*pc));
-        pc->il = il;
-        evpl_iovec_alloc(il->evpl, DEMOFS_BLOCK_SIZE, DEMOFS_BLOCK_SIZE, 1, 0, &pc->iov);
-        memcpy(pc->iov.data, p, DEMOFS_BLOCK_SIZE);
-        p += DEMOFS_BLOCK_SIZE;
-
-        evpl_block_write(il->evpl, il->queue[bh->device_id], &pc->iov, 1,
-                         bh->device_offset, 1 /* sync */, demofs_il_push_block_cb, pc);
+        evpl_block_write(il->evpl, il->queue[bh->device_id], &rec->iovs[1 + i], 1,
+                         bh->device_offset, 1 /* sync */, demofs_il_push_block_cb, il);
     }
 } /* demofs_il_push_kick */
 
@@ -4589,6 +4652,12 @@ demofs_redo_write_cb(
 
     (void) evpl;
     chimera_demofs_abort_if(status, "redo record write failed: %d", status);
+
+    /* One chunk of a possibly multi-chunk journal write landed; only the last
+     * makes the whole record durable. */
+    if (--ctx->segments > 0) {
+        return;
+    }
 
     il->redo_inflight--;
 
@@ -4636,17 +4705,18 @@ demofs_il_write_redo(
     struct demofs_redo_header       *hdr;
     struct demofs_redo_block_header *bh;
     uint32_t                         nblocks = 0;
-    uint64_t                         reclen, offset;
+    uint64_t                         hdr_len, reclen, offset;
+    uint32_t                         i;
     char                            *p;
     int                              niov;
+    XXH3_state_t                     xs;
 
     for (tb = txn->blocks; tb; tb = tb->next) {
         nblocks++;
     }
 
-    reclen = sizeof(struct demofs_redo_header) +
-        (uint64_t) nblocks * (sizeof(struct demofs_redo_block_header) + DEMOFS_BLOCK_SIZE);
-    reclen = (reclen + DEMOFS_BLOCK_SIZE - 1) & ~((uint64_t) DEMOFS_BLOCK_SIZE - 1);
+    hdr_len = demofs_il_hdr_len(nblocks);
+    reclen  = hdr_len + (uint64_t) nblocks * DEMOFS_BLOCK_SIZE;
 
     /* Caller guarantees space (demofs_iq_process_channel checks demofs_il_fits
      * before consuming the SQ entry), so placement always succeeds. */
@@ -4657,10 +4727,14 @@ demofs_il_write_redo(
     rec->offset     = offset;
     rec->reclen     = reclen;
     rec->num_blocks = nblocks;
+    rec->niov       = 1 + nblocks;
+    rec->iovs       = malloc(rec->niov * sizeof(struct evpl_iovec));
     rec->next       = NULL;
 
-    niov = evpl_iovec_alloc(il->evpl, reclen, DEMOFS_BLOCK_SIZE, 1, 0, &rec->iov);
-    chimera_demofs_abort_if(niov != 1, "redo record did not fit in one iovec (%d)", niov);
+    /* iovs[0]: materialized header region (redo_header + per-block headers). */
+    niov = evpl_iovec_alloc(il->evpl, hdr_len, DEMOFS_BLOCK_SIZE, 1,
+                            EVPL_IOVEC_FLAG_SHARED, &rec->iovs[0]);
+    chimera_demofs_abort_if(niov != 1, "redo header did not fit in one iovec (%d)", niov);
 
     ctx        = malloc(sizeof(*ctx));
     ctx->il    = il;
@@ -4668,7 +4742,7 @@ demofs_il_write_redo(
     ctx->entry = *entry;
     ctx->rec   = rec;
 
-    p               = (char *) rec->iov.data;
+    p               = (char *) rec->iovs[0].data;
     hdr             = (struct demofs_redo_header *) p;
     hdr->magic      = DEMOFS_REDO_MAGIC;
     hdr->csum_lo    = 0;
@@ -4679,7 +4753,8 @@ demofs_il_write_redo(
     hdr->reclen     = (uint32_t) reclen;
     p              += sizeof(*hdr);
 
-    for (tb = txn->blocks; tb; tb = tb->next) {
+    i = 0;
+    for (tb = txn->blocks; tb; tb = tb->next, i++) {
         struct demofs_block *blk = tb->block;
 
         /* Stamp the block with this record's seq so the tail-pusher can tell,
@@ -4693,32 +4768,64 @@ demofs_il_write_redo(
         bh->device_offset = blk->device_offset;
         p                += sizeof(*bh);
 
-        memcpy(p, blk->buffer, DEMOFS_BLOCK_SIZE);
-        p += DEMOFS_BLOCK_SIZE;
+        /* Move the commit-time snapshot ref into the record (no copy, no touch
+         * of the live block->iov from this thread).  The image stays immutable
+         * until pushed home and released; a later writer COWs the cache block. */
+        evpl_iovec_move(&rec->iovs[1 + i], &tb->snap);
     }
 
-    /* Zero the tail padding (reclen is 4 KiB-rounded) so the checksum covers
-     * deterministic bytes, then stamp the XXH3-128 over the whole record. */
+    /* Zero the header-region tail padding so the checksum covers deterministic
+     * bytes, then stamp the XXH3-128 over the header region + every block. */
     {
-        char *end = (char *) rec->iov.data + reclen;
+        char *end = (char *) rec->iovs[0].data + hdr_len;
 
         if (p < end) {
             memset(p, 0, (size_t) (end - p));
         }
     }
+    XXH3_128bits_reset(&xs);
+    XXH3_128bits_update(&xs, rec->iovs[0].data, hdr_len);
+    for (i = 0; i < nblocks; i++) {
+        XXH3_128bits_update(&xs, rec->iovs[1 + i].data, DEMOFS_BLOCK_SIZE);
+    }
     {
-        XXH128_hash_t h = XXH3_128bits(rec->iov.data, reclen);
+        XXH128_hash_t h = XXH3_128bits_digest(&xs);
 
         hdr->csum_lo = h.low64;
         hdr->csum_hi = h.high64;
     }
 
+    ctx->segments = (rec->niov + DEMOFS_IL_MAX_IOV - 1) / DEMOFS_IL_MAX_IOV;
+
     ch->cq_inflight++;
     il->redo_inflight++;
 
-    evpl_block_write(il->evpl, il->queue[SM_INTENT_LOG_DEVICE],
-                     &rec->iov, 1, offset, 1 /* sync */,
-                     demofs_redo_write_cb, ctx);
+    /* Issue the record in <=DEMOFS_IL_MAX_IOV-iovec chunks to consecutive
+     * offsets (the on-log record is contiguous); all chunks share ctx and the
+     * last completion finalizes the record. */
+    {
+        uint32_t done = 0;
+        uint64_t woff = offset;
+
+        while (done < rec->niov) {
+            uint32_t cnt   = rec->niov - done;
+            uint64_t bytes = 0;
+            uint32_t k;
+
+            if (cnt > DEMOFS_IL_MAX_IOV) {
+                cnt = DEMOFS_IL_MAX_IOV;
+            }
+            for (k = 0; k < cnt; k++) {
+                bytes += rec->iovs[done + k].length;
+            }
+
+            evpl_block_write(il->evpl, il->queue[SM_INTENT_LOG_DEVICE],
+                             &rec->iovs[done], cnt, woff, 1 /* sync */,
+                             demofs_redo_write_cb, ctx);
+            woff += bytes;
+            done += cnt;
+        }
+    }
 } /* demofs_il_write_redo */
 
 /* Padded on-log length of the redo record for one transaction. */
@@ -4727,14 +4834,11 @@ demofs_il_txn_reclen(struct demofs_txn *txn)
 {
     struct demofs_txn_block *tb;
     uint32_t                 nblocks = 0;
-    uint64_t                 reclen;
 
     for (tb = txn->blocks; tb; tb = tb->next) {
         nblocks++;
     }
-    reclen = sizeof(struct demofs_redo_header) +
-        (uint64_t) nblocks * (sizeof(struct demofs_redo_block_header) + DEMOFS_BLOCK_SIZE);
-    return (reclen + DEMOFS_BLOCK_SIZE - 1) & ~((uint64_t) DEMOFS_BLOCK_SIZE - 1);
+    return demofs_il_hdr_len(nblocks) + (uint64_t) nblocks * DEMOFS_BLOCK_SIZE;
 } /* demofs_il_txn_reclen */
 
 static void
@@ -4957,6 +5061,19 @@ demofs_txn_commit(
      * (and its pinned blocks) to the intent log thread. */
     demofs_txn_flush_inodes(txn);
 
+    /* Snapshot each block's buffer (zero-copy ref) while the content is final
+     * and the inode locks are still held -- so the redo record captures this
+     * txn's committed image, immune to a later COW, and the intent-log thread
+     * never has to touch the live block->iov.  The refs are moved into the
+     * record by demofs_il_write_redo. */
+    {
+        struct demofs_txn_block *tb;
+
+        for (tb = txn->blocks; tb; tb = tb->next) {
+            evpl_iovec_clone(&tb->snap, &tb->block->iov);
+        }
+    }
+
     /* Write txn -> intent log thread via this worker's SQ.  The intent
      * log thread drops the txn's logical inode locks when it processes
      * the entry (see demofs_iq_process_channel); these are logical locks
@@ -5089,18 +5206,25 @@ demofs_recover_log(struct demofs_shared *shared)
     }
 
     for (i = 0; i < nrec; i++) {
-        struct demofs_redo_header *hdr = (struct demofs_redo_header *) (log + recs[i].offset);
-        char                      *p   = log + recs[i].offset + sizeof(*hdr);
+        struct demofs_redo_header *hdr  = (struct demofs_redo_header *) (log + recs[i].offset);
+        char                      *bhp  = log + recs[i].offset + sizeof(*hdr);
+        char                      *data = log + recs[i].offset + demofs_il_hdr_len(hdr->num_blocks);
         uint32_t                   b;
 
+        /* New layout: all per-block headers are grouped after the redo header,
+         * and the block images follow the 4 KiB-aligned header region. */
         for (b = 0; b < hdr->num_blocks; b++) {
-            struct demofs_redo_block_header *bh = (struct demofs_redo_block_header *) p;
+            struct demofs_redo_block_header *bh =
+                (struct demofs_redo_block_header *) (bhp + (size_t) b * sizeof(*bh));
+            char                            *img = data + (size_t) b * DEMOFS_BLOCK_SIZE;
 
-            p += sizeof(*bh);
             if (bh->device_id < (uint32_t) shared->num_devices && wfd[bh->device_id] >= 0) {
-                pwrite(wfd[bh->device_id], p, DEMOFS_BLOCK_SIZE, (off_t) bh->device_offset);
+                ssize_t wn = pwrite(wfd[bh->device_id], img, DEMOFS_BLOCK_SIZE,
+                                    (off_t) bh->device_offset);
+
+                chimera_demofs_abort_if(wn != (ssize_t) DEMOFS_BLOCK_SIZE,
+                                        "recovery replay pwrite failed: %zd", wn);
             }
-            p += DEMOFS_BLOCK_SIZE;
         }
     }
 
@@ -5413,14 +5537,18 @@ demofs_bootstrap(struct demofs_thread *thread)
      * eviction could discard it before the first write op logs it (CLEAN
      * blocks must be re-readable from disk).  Then detach it, evictable. */
     inode->block = demofs_block_claim(thread, device_id, device_offset, 1);
-    demofs_bt_node_init(inode->block->buffer, DEMOFS_BT_ROOT_BASE,
+    demofs_bt_node_init(inode->block->iov.data, DEMOFS_BT_ROOT_BASE,
                         DEMOFS_BT_ROOT_CAP, 0);
     demofs_inode_flush(inode);
     {
         int fd = open(shared->device_paths[device_id], O_WRONLY);
 
         if (fd >= 0) {
-            pwrite(fd, inode->block->buffer, DEMOFS_BLOCK_SIZE, (off_t) device_offset);
+            ssize_t wn = pwrite(fd, inode->block->iov.data, DEMOFS_BLOCK_SIZE,
+                                (off_t) device_offset);
+
+            chimera_demofs_abort_if(wn != (ssize_t) DEMOFS_BLOCK_SIZE,
+                                    "bootstrap root pwrite failed: %zd", wn);
             fsync(fd);
             close(fd);
         }
@@ -8051,8 +8179,14 @@ demofs_write_inserted_cb(
     request->write.r_length = request->write.length;
     request->write.r_sync   = 1;
 
-    /* In-memory mutations done; release the inode lock before block I/O. */
-    demofs_txn_unlock_inode(demofs_private->txn, inode);
+    /* Do NOT release the inode lock here.  The dirty b+tree/inode blocks are
+     * not yet protected by the intent log, so exposing them to another thread
+     * (which could read stale state or re-dirty them) is unsafe.  The data I/O
+     * below is submitted by this worker, then the txn is handed to the intent
+     * log (demofs_op_ok -> demofs_txn_commit); the intent-log thread releases
+     * the inode locks only once the record is durable (demofs_redo_write_cb ->
+     * demofs_txn_unlock_all).  The lock is a logical flag, so holding it across
+     * async I/O doesn't block the worker -- conflicting ops park as waiters. */
 
     if (demofs_private->need_prefix_read || demofs_private->need_suffix_read) {
         demofs_private->rmw_phase = 1;

--- a/src/vfs/demofs/demofs.c
+++ b/src/vfs/demofs/demofs.c
@@ -579,6 +579,7 @@ struct demofs_intent_log {
 
 struct demofs_shared {
     struct demofs_device      *devices;
+    char                     **device_paths;     /* for unmount-time persistence */
     int                        num_devices;
     struct demofs_inode_cache *inode_cache;
     struct demofs_block_cache *block_cache;
@@ -4435,8 +4436,9 @@ demofs_init(const char *cfgdata)
 
     devices_cfg = json_object_get(cfg, "devices");
 
-    shared->num_devices = json_array_size(devices_cfg);
-    shared->devices     = calloc(shared->num_devices, sizeof(*shared->devices));
+    shared->num_devices  = json_array_size(devices_cfg);
+    shared->devices      = calloc(shared->num_devices, sizeof(*shared->devices));
+    shared->device_paths = calloc(shared->num_devices, sizeof(char *));
 
     json_array_foreach(devices_cfg, i, device_cfg)
     {
@@ -4446,6 +4448,8 @@ demofs_init(const char *cfgdata)
         protocol_name = json_string_value(json_object_get(device_cfg, "type"));
         device_path   = json_string_value(json_object_get(device_cfg, "path"));
         size          = json_integer_value(json_object_get(device_cfg, "size"));
+
+        shared->device_paths[i] = strdup(device_path);
 
         if (strcmp(protocol_name, "io_uring") == 0) {
             protocol_id = EVPL_BLOCK_PROTOCOL_IO_URING;
@@ -4660,7 +4664,20 @@ demofs_destroy(void *private_data)
 
     demofs_block_cache_destroy(shared);
 
+    /* Persist the free-space map now that all device I/O has quiesced (evpl
+     * released the devices), so a later mount can reload it instead of
+     * re-handing-out in-use space.  (A future mount only trusts this once the
+     * superblock is also marked clean -- wired in the mount-detection step.) */
+    if (space_map_persist_paths(shared->space_map, shared->device_paths) != 0) {
+        chimera_demofs_error("space-map persist at unmount failed");
+    }
+
     space_map_destroy(shared->space_map);
+
+    for (int i = 0; i < shared->num_devices; i++) {
+        free(shared->device_paths[i]);
+    }
+    free(shared->device_paths);
 
     pthread_mutex_destroy(&shared->lock);
     free(shared->devices);

--- a/src/vfs/demofs/demofs.c
+++ b/src/vfs/demofs/demofs.c
@@ -16,6 +16,8 @@
 #include <limits.h>
 #include <jansson.h>
 #include <utlist.h>
+#include <urcu.h>
+#include <urcu/urcu-memb.h>
 
 #include "common/varint.h"
 #include "common/rbtree.h"
@@ -37,14 +39,14 @@
         ((type *) ((char *) (ptr) - offsetof(type, member)))
 #endif /* ifndef container_of */
 
-#define CHIMERA_DEMOFS_INODE_LIST_SHIFT  8
-#define CHIMERA_DEMOFS_INODE_NUM_LISTS   (1 << CHIMERA_DEMOFS_INODE_LIST_SHIFT)
-#define CHIMERA_DEMOFS_INODE_LIST_MASK   (CHIMERA_DEMOFS_INODE_NUM_LISTS - 1)
+/* Inode cache: sharded rb-tree keyed by inum. */
+#define DEMOFS_INODE_CACHE_SHARDS 256
+#define DEMOFS_INODE_CACHE_MASK   (DEMOFS_INODE_CACHE_SHARDS - 1)
 
-
-#define CHIMERA_DEMOFS_INODE_BLOCK_SHIFT 16
-#define CHIMERA_DEMOFS_INODE_BLOCK       (1 << CHIMERA_DEMOFS_INODE_BLOCK_SHIFT)
-#define CHIMERA_DEMOFS_INODE_BLOCK_MASK  (CHIMERA_DEMOFS_INODE_BLOCK - 1)
+/* Max inodes a single transaction can hold locked at once.  rename needs
+ * 4 (two parents, child, replaced target); others (e.g. readdir) touch
+ * many but only 2 at a time and release as they go. */
+#define DEMOFS_TXN_MAX_INODES     4
 
 #define chimera_demofs_debug(...) chimera_debug("demofs", \
                                                 __FILE__, \
@@ -157,26 +159,78 @@ struct demofs_symlink_target {
     struct demofs_symlink_target *next;
 };
 
-struct demofs_inode {
-    uint64_t             inum;
-    uint32_t             gen;
-    uint32_t             refcnt;
-    uint64_t             size;
-    uint64_t             space_used;
-    uint32_t             mode;
-    uint32_t             nlink;
-    uint32_t             uid;
-    uint32_t             gid;
-    uint64_t             rdev;
-    uint64_t             atime_sec;
-    uint64_t             ctime_sec;
-    uint64_t             mtime_sec;
-    uint32_t             atime_nsec;
-    uint32_t             ctime_nsec;
-    uint32_t             mtime_nsec;
-    struct demofs_inode *next;
+struct demofs_txn;
+struct demofs_inode;
+struct demofs_inode_waiter;
+struct demofs_block;
 
-    pthread_mutex_t      lock;
+/* Logical lock mode for an inode held by a transaction. */
+enum demofs_inode_lock_mode {
+    DEMOFS_INODE_LOCK_READ,
+    DEMOFS_INODE_LOCK_WRITE,
+};
+
+typedef void (*demofs_inode_cb_t)(
+    struct demofs_inode *inode,
+    int                  status,
+    void                *private_data);
+
+/* Defined in the block-cache section below. */
+static void demofs_txn_pin_inode_block(
+    struct demofs_thread *thread,
+    struct demofs_txn    *txn,
+    struct demofs_inode  *inode,
+    int                   is_new);
+
+/*
+ * A transaction that cannot immediately acquire an inode in the desired
+ * mode parks a waiter on the inode's FIFO wait list (protected by the
+ * inode's cache shard lock).  When the conflicting holder releases, the
+ * releasing thread grants the lock and hands the waiter to the owning
+ * worker's grant queue (+doorbell) so the continuation runs back on the
+ * transaction's own thread.
+ */
+struct demofs_inode_waiter {
+    struct demofs_txn          *txn;
+    enum demofs_inode_lock_mode mode;
+    uint32_t                    gen;     /* generation the txn referenced */
+    int                         status;  /* CHIMERA_VFS_OK or ENOENT when granted */
+    demofs_inode_cb_t           cb;
+    void                       *private_data;
+    struct demofs_inode        *inode;
+    struct demofs_inode_waiter *next;
+};
+
+struct demofs_inode {
+    uint64_t                    inum;
+    uint32_t                    gen;
+    uint32_t                    refcnt;
+    uint64_t                    size;
+    uint64_t                    space_used;
+    uint32_t                    mode;
+    uint32_t                    nlink;
+    uint32_t                    uid;
+    uint32_t                    gid;
+    uint64_t                    rdev;
+    uint64_t                    atime_sec;
+    uint64_t                    ctime_sec;
+    uint64_t                    mtime_sec;
+    uint32_t                    atime_nsec;
+    uint32_t                    ctime_nsec;
+    uint32_t                    mtime_nsec;
+
+    /* Inode-cache linkage, keyed by inum.  Lock state and the wait list
+     * below are protected by the owning shard's mutex, never held across
+     * a callback or I/O. */
+    struct rb_node              node;
+    int                         readers;     /* shared-lock holders */
+    int                         writer;      /* 0/1 exclusive holder */
+    struct demofs_inode_waiter *wait_head;
+    struct demofs_inode_waiter *wait_tail;
+
+    /* This inode's 4 KiB metadata home block in the block cache; pinned
+     * while the inode is dirty in a transaction.  NULL until first claimed. */
+    struct demofs_block        *block;
 
     union {
         struct {
@@ -193,28 +247,121 @@ struct demofs_inode {
     };
 };
 
-struct demofs_inode_list {
-    uint32_t              id;
-    uint32_t              num_blocks;
-    uint32_t              max_blocks;
-    struct demofs_inode **inode;
-    struct demofs_inode  *free_inode;
-    uint64_t              num_inodes;
-    uint64_t              total_inodes;
-    pthread_mutex_t       lock;
+struct demofs_inode_shard {
+    pthread_mutex_t lock;
+    struct rb_tree  inodes;       /* keyed by inum */
 };
 
-struct demofs_txn;
-struct demofs_txn_inode_ref;
+struct demofs_inode_cache {
+    struct demofs_inode_shard shards[DEMOFS_INODE_CACHE_SHARDS];
+};
+
+/* ------------------------------------------------------------------ */
+/* Block cache                                                         */
+/* ------------------------------------------------------------------ */
+
+#define DEMOFS_BLOCK_SHIFT                   SM_BLOCK_SHIFT  /* 12 */
+#define DEMOFS_BLOCK_SIZE                    SM_BLOCK_SIZE   /* 4096 */
+#define DEMOFS_BLOCK_CACHE_SHARDS            256
+#define DEMOFS_BLOCK_CACHE_SHARD_MASK        (DEMOFS_BLOCK_CACHE_SHARDS - 1)
+#define DEMOFS_BLOCK_CACHE_BUCKETS_PER_SHARD 1024
+#define DEMOFS_BLOCK_CACHE_BUCKET_MASK       (DEMOFS_BLOCK_CACHE_BUCKETS_PER_SHARD - 1)
+
+enum demofs_block_state {
+    DEMOFS_BLOCK_CLEAN,    /* matches final on-disk location; evictable when unpinned */
+    DEMOFS_BLOCK_DIRTY,    /* modified, pinned by >=1 txn, not yet logged */
+    DEMOFS_BLOCK_LOGGED,   /* intent record durable; awaiting tail-push to final loc */
+};
+
+/*
+ * A cached 4 KiB on-disk block, keyed by (device_id, device_offset).  The
+ * buffer is plain heap memory; block I/O copies it through a thread-local
+ * evpl_iovec so buffers are never shared across evpl instances.  Hash-chain
+ * linkage is RCU-managed for lock-free lookup; mutation happens under the
+ * owning shard lock and frees defer through call_rcu.
+ */
+struct demofs_block {
+    uint32_t             device_id;
+    uint64_t             device_offset;        /* block-aligned; key with device_id */
+    void                *buffer;               /* DEMOFS_BLOCK_SIZE bytes */
+    int                  pin_count;            /* atomic; >0 => not reclaimable */
+    enum demofs_block_state state;
+    uint64_t             seq;                  /* update order for tail-push */
+    struct demofs_block *hash_next;            /* RCU bucket chain */
+    struct rcu_head      rcu;
+    struct demofs_block *lru_prev, *lru_next;      /* clean+unpinned LRU (Stage 3) */
+    struct demofs_block *wb_next;              /* writeback queue (Stage 3) */
+};
+
+struct demofs_block_shard {
+    pthread_mutex_t       lock;
+    struct demofs_block **buckets;     /* [DEMOFS_BLOCK_CACHE_BUCKETS_PER_SHARD] */
+};
+
+struct demofs_block_cache {
+    struct demofs_block_shard shards[DEMOFS_BLOCK_CACHE_SHARDS];
+};
+
+/*
+ * On-disk inode layout, written at the front of the inode's 4 KiB block.
+ * Scalar attributes only for now; directory entries and file extents stay
+ * in memory until the b+tree block work lands.
+ */
+struct demofs_dinode {
+    uint64_t inum;
+    uint32_t gen;
+    uint32_t mode;
+    uint32_t nlink;
+    uint32_t uid;
+    uint32_t gid;
+    uint64_t rdev;
+    uint64_t size;
+    uint64_t space_used;
+    uint64_t atime_sec;
+    uint64_t mtime_sec;
+    uint64_t ctime_sec;
+    uint32_t atime_nsec;
+    uint32_t mtime_nsec;
+    uint32_t ctime_nsec;
+    uint64_t parent_inum;     /* directories only */
+    uint32_t parent_gen;
+};
+
+/*
+ * Intent-log redo record, written into the reserved intent-log region.
+ * A record is a header followed by num_blocks (block-header, 4 KiB content)
+ * pairs, padded to a 4 KiB multiple.  Full-block redo: the record carries
+ * the entire post-image of every dirty block in the transaction.
+ */
+#define DEMOFS_REDO_MAGIC 0x4F44455246534944ULL    /* "DISFREDO" */
+
+struct demofs_redo_header {
+    uint64_t magic;
+    uint64_t seq;          /* monotonically increasing record sequence */
+    uint32_t num_blocks;
+    uint32_t reclen;       /* total record length, including padding */
+};
+
+struct demofs_redo_block_header {
+    uint32_t device_id;
+    uint32_t pad;
+    uint64_t device_offset;
+};
 
 enum demofs_txn_type {
     DEMOFS_TXN_READ,
     DEMOFS_TXN_WRITE,
 };
 
-struct demofs_txn_inode_ref {
-    struct demofs_inode         *inode;
-    struct demofs_txn_inode_ref *next;
+/* A dirty block held (pinned) by a transaction until commit/log. */
+struct demofs_txn_block {
+    struct demofs_block     *block;
+    struct demofs_txn_block *next;
+};
+
+struct demofs_txn_slot {
+    struct demofs_inode *inode;
+    enum demofs_inode_lock_mode mode;
 };
 
 /* Commit completion callback.  Will be invoked exactly once per successful
@@ -227,10 +374,12 @@ typedef void (*demofs_txn_commit_cb_t)(
     void              *private_data);
 
 struct demofs_txn {
-    enum demofs_txn_type         type;
-    struct demofs_thread        *thread;
-    struct demofs_txn           *next;        /* per-thread free list link */
-    struct demofs_txn_inode_ref *refs;        /* pinned (locked) inodes */
+    enum demofs_txn_type     type;
+    struct demofs_thread    *thread;
+    struct demofs_txn       *next;         /* per-thread free list link */
+    struct demofs_txn_slot   inodes[DEMOFS_TXN_MAX_INODES];
+    int                      num_inodes;
+    struct demofs_txn_block *blocks;       /* dirty blocks pinned by this txn */
 };
 
 /*
@@ -264,6 +413,10 @@ struct demofs_iq_channel {
     struct evpl_doorbell      cq_doorbell;
     struct demofs_thread     *worker;
 
+    /* CQEs reserved for redo writes issued but not yet completed.  Owned by
+     * the intent-log thread; bounds in-flight writes to available CQ space. */
+    uint32_t                  cq_inflight;
+
     /* Lifecycle: workers append on register, set flag on unregister.
      * Intent log thread owns the slot array. */
     struct demofs_iq_channel *next_pending;
@@ -283,37 +436,52 @@ struct demofs_intent_log {
     struct demofs_iq_channel *channels[DEMOFS_IL_MAX_CHANNELS];
     pthread_mutex_t           registration_lock;
     struct demofs_iq_channel *pending_head;
+
+    /* Block queues on the intent-log thread's own evpl (one per device),
+     * used to write redo records into the reserved intent-log region. */
+    struct evpl_block_queue **queue;
+    uint64_t                  log_head;          /* next free byte in the intent-log region */
+    uint64_t                  log_seq;           /* next redo record sequence number */
 };
 
 struct demofs_shared {
-    struct demofs_device     *devices;
-    int                       num_devices;
-    struct demofs_inode_list *inode_list;
-    int                       num_inode_list;
-    struct demofs_kv_shard   *kv_shards;
-    int                       num_kv_shards;
-    int                       num_active_threads;
-    uint8_t                   root_fh[CHIMERA_VFS_FH_SIZE];
-    uint32_t                  root_fhlen;
-    uint64_t                  fsid;
-    struct space_map         *space_map;
-    struct demofs_intent_log  intent_log;
-    pthread_mutex_t           lock;
+    struct demofs_device      *devices;
+    int                        num_devices;
+    struct demofs_inode_cache *inode_cache;
+    struct demofs_block_cache *block_cache;
+    struct demofs_kv_shard    *kv_shards;
+    int                        num_kv_shards;
+    int                        num_active_threads;
+    uint8_t                    root_fh[CHIMERA_VFS_FH_SIZE];
+    uint32_t                   root_fhlen;
+    uint64_t                   fsid;
+    struct space_map          *space_map;
+    struct demofs_intent_log   intent_log;
+    pthread_mutex_t            lock;
 };
 
 struct demofs_thread {
-    struct evpl              *evpl;
-    struct demofs_shared     *shared;
-    struct evpl_block_queue **queue;
-    struct evpl_iovec         zero;
-    struct evpl_iovec         pad;
-    int                       thread_id;
-    struct slab_allocator    *allocator;
-    struct sm_thread_cache    space_cache;
-    struct demofs_txn           *txn_free_list;
-    struct demofs_txn_inode_ref *txn_ref_free_list;
-    struct demofs_iq_channel    *iq_channel;
-    int                          pending_io;
+    struct evpl                *evpl;
+    struct demofs_shared       *shared;
+    struct evpl_block_queue   **queue;
+    struct evpl_iovec           zero;
+    struct evpl_iovec           pad;
+    int                         thread_id;
+    struct slab_allocator      *allocator;
+    struct sm_thread_cache      space_cache;
+    struct demofs_txn          *txn_free_list;
+    struct demofs_inode_waiter *waiter_free_list;
+    struct demofs_iq_channel   *iq_channel;
+    int                         pending_io;
+
+    /* Cross-thread lock-grant delivery: any thread that releases an inode
+     * and grants it to a waiter belonging to this worker enqueues the
+     * granted waiter here and rings grant_doorbell, so the continuation
+     * runs back on this worker. */
+    pthread_mutex_t             grant_lock;
+    struct demofs_inode_waiter *grant_head;
+    struct demofs_inode_waiter *grant_tail;
+    struct evpl_doorbell        grant_doorbell;
 };
 
 static inline uint32_t
@@ -336,150 +504,290 @@ demofs_fh_to_inum(
     chimera_vfs_decode_fh_inum(fh, fhlen, inum, gen);
 } /* demofs_fh_to_inum */
 
-static inline struct demofs_inode *
-demofs_inode_get_inum(
-    struct demofs_shared *shared,
-    uint64_t              inum,
-    uint32_t              gen)
-{
-    uint64_t                  inum_block;
-    uint32_t                  list_id, block_id, block_index;
-    struct demofs_inode_list *inode_list;
-    struct demofs_inode      *inode;
-
-    list_id     = inum & CHIMERA_DEMOFS_INODE_LIST_MASK;
-    inum_block  = inum >> CHIMERA_DEMOFS_INODE_LIST_SHIFT;
-    block_index = inum_block & CHIMERA_DEMOFS_INODE_BLOCK_MASK;
-    block_id    = inum_block >> CHIMERA_DEMOFS_INODE_BLOCK_SHIFT;
-
-    if (unlikely(list_id >= shared->num_inode_list)) {
-        return NULL;
-    }
-
-    inode_list = &shared->inode_list[list_id];
-
-    if (unlikely(block_id >= inode_list->num_blocks)) {
-        return NULL;
-    }
-
-    inode = &inode_list->inode[block_id][block_index];
-
-    pthread_mutex_lock(&inode->lock);
-
-    if (unlikely(inode->gen != gen)) {
-        pthread_mutex_unlock(&inode->lock);
-        return NULL;
-    }
-
-    return inode;
-} /* demofs_inode_get_inum */
-
-static inline struct demofs_inode *
-demofs_inode_get_fh(
-    struct demofs_shared *shared,
-    const uint8_t        *fh,
-    int                   fhlen)
-{
-    uint64_t inum;
-    uint32_t gen;
-
-    demofs_fh_to_inum(&inum, &gen, fh, fhlen);
-
-    return demofs_inode_get_inum(shared, inum, gen);
-} /* demofs_inode_get_fh */
-
 /* ------------------------------------------------------------------ */
-/* Async inode-fetch / inode-alloc API                                 */
+/* Inode cache + logical (read/write) transaction locks                */
 /* ------------------------------------------------------------------ */
 
-typedef void (*demofs_inode_cb_t)(
-    struct demofs_inode *inode,
-    int                  status,
-    void                *private_data);
+#define DEMOFS_INODE_MODE_FOR_TXN(txn) \
+        ((txn)->type == DEMOFS_TXN_WRITE ? DEMOFS_INODE_LOCK_WRITE \
+                                         : DEMOFS_INODE_LOCK_READ)
 
-static inline struct demofs_txn_inode_ref *
-demofs_txn_ref_alloc(struct demofs_thread *thread)
+static inline struct demofs_inode_shard *
+demofs_inode_shard(
+    struct demofs_shared *shared,
+    uint64_t              inum)
 {
-    struct demofs_txn_inode_ref *r = thread->txn_ref_free_list;
+    return &shared->inode_cache->shards[inum & DEMOFS_INODE_CACHE_MASK];
+} /* demofs_inode_shard */
 
-    if (r) {
-        thread->txn_ref_free_list = r->next;
+static inline struct demofs_inode_waiter *
+demofs_waiter_alloc(struct demofs_thread *thread)
+{
+    struct demofs_inode_waiter *w = thread->waiter_free_list;
+
+    if (w) {
+        thread->waiter_free_list = w->next;
     } else {
-        r = malloc(sizeof(*r));
+        w = malloc(sizeof(*w));
     }
-    return r;
-} /* demofs_txn_ref_alloc */
+    return w;
+} /* demofs_waiter_alloc */
 
 static inline void
-demofs_txn_ref_release(
-    struct demofs_thread        *thread,
-    struct demofs_txn_inode_ref *r)
+demofs_waiter_free(
+    struct demofs_thread       *thread,
+    struct demofs_inode_waiter *w)
 {
-    r->next                   = thread->txn_ref_free_list;
-    thread->txn_ref_free_list = r;
-} /* demofs_txn_ref_release */
+    w->next                  = thread->waiter_free_list;
+    thread->waiter_free_list = w;
+} /* demofs_waiter_free */
+
+/* Record a held inode in the transaction's fixed slot array. */
+static inline void
+demofs_txn_add_slot(
+    struct demofs_txn          *txn,
+    struct demofs_inode        *inode,
+    enum demofs_inode_lock_mode mode)
+{
+    chimera_demofs_abort_if(txn->num_inodes >= DEMOFS_TXN_MAX_INODES,
+                            "demofs txn inode slots exhausted");
+    txn->inodes[txn->num_inodes].inode = inode;
+    txn->inodes[txn->num_inodes].mode  = mode;
+    txn->num_inodes++;
+} /* demofs_txn_add_slot */
+
+/* Caller must hold the inode's shard lock. */
+static inline int
+demofs_inode_lock_compatible(
+    struct demofs_inode        *inode,
+    enum demofs_inode_lock_mode mode)
+{
+    if (mode == DEMOFS_INODE_LOCK_WRITE) {
+        return inode->writer == 0 && inode->readers == 0;
+    }
+    return inode->writer == 0;
+} /* demofs_inode_lock_compatible */
+
+/* Caller must hold the inode's shard lock. */
+static inline void
+demofs_inode_lock_grant(
+    struct demofs_inode        *inode,
+    enum demofs_inode_lock_mode mode)
+{
+    if (mode == DEMOFS_INODE_LOCK_WRITE) {
+        inode->writer = 1;
+    } else {
+        inode->readers++;
+    }
+} /* demofs_inode_lock_grant */
 
 /*
- * Pin a locked inode into the transaction's ref list.  The inode must be
- * locked by the caller; ownership of the lock passes to the txn, which
- * drops it during commit or abort via demofs_txn_unlock_all().
+ * Hand a granted (or stale-failed) waiter to its owning worker so its
+ * continuation runs back on the transaction's own thread.
  */
-static inline void
-demofs_txn_pin_inode(
-    struct demofs_txn   *txn,
-    struct demofs_inode *inode)
+static void
+demofs_dispatch_grant(struct demofs_inode_waiter *w)
 {
-    struct demofs_txn_inode_ref *r = demofs_txn_ref_alloc(txn->thread);
+    struct demofs_thread *worker = w->txn->thread;
 
-    r->inode  = inode;
-    r->next   = txn->refs;
-    txn->refs = r;
-} /* demofs_txn_pin_inode */
+    pthread_mutex_lock(&worker->grant_lock);
+    w->next = NULL;
+    if (worker->grant_tail) {
+        worker->grant_tail->next = w;
+    } else {
+        worker->grant_head = w;
+    }
+    worker->grant_tail = w;
+    pthread_mutex_unlock(&worker->grant_lock);
+
+    evpl_ring_doorbell(&worker->grant_doorbell);
+} /* demofs_dispatch_grant */
 
 /*
- * Release a single pinned inode early (e.g. readdir-style iteration that
- * doesn't want every visited inode held until commit).  No-op if the
- * inode isn't in the txn's ref list.
+ * Drop one held inode lock and grant the lock to compatible FIFO waiters.
+ * Safe to call from any thread (worker for read/abort, intent-log thread
+ * for write commit); granted waiters are dispatched to their own workers.
+ */
+static void
+demofs_inode_release_one(
+    struct demofs_thread       *thread,
+    struct demofs_inode        *inode,
+    enum demofs_inode_lock_mode mode)
+{
+    struct demofs_inode_shard  *shard   = demofs_inode_shard(thread->shared, inode->inum);
+    struct demofs_inode_waiter *granted = NULL;
+    struct demofs_inode_waiter *w;
+
+    pthread_mutex_lock(&shard->lock);
+
+    if (mode == DEMOFS_INODE_LOCK_WRITE) {
+        inode->writer = 0;
+    } else {
+        inode->readers--;
+    }
+
+    while (inode->wait_head) {
+        w = inode->wait_head;
+
+        if (w->gen != inode->gen) {
+            /* The inode this waiter referenced was freed/replaced.  Fail
+             * it with ENOENT rather than handing back a stale inode. */
+            inode->wait_head = w->next;
+            if (!inode->wait_head) {
+                inode->wait_tail = NULL;
+            }
+            w->status = CHIMERA_VFS_ENOENT;
+            w->next   = granted;
+            granted   = w;
+            continue;
+        }
+
+        if (!demofs_inode_lock_compatible(inode, w->mode)) {
+            break;
+        }
+
+        inode->wait_head = w->next;
+        if (!inode->wait_head) {
+            inode->wait_tail = NULL;
+        }
+        demofs_inode_lock_grant(inode, w->mode);
+        w->status = CHIMERA_VFS_OK;
+        w->next   = granted;
+        granted   = w;
+
+        if (w->mode == DEMOFS_INODE_LOCK_WRITE) {
+            break;     /* exclusive: stop granting */
+        }
+    }
+
+    pthread_mutex_unlock(&shard->lock);
+
+    while (granted) {
+        w       = granted;
+        granted = w->next;
+        demofs_dispatch_grant(w);
+    }
+} /* demofs_inode_release_one */
+
+/*
+ * Release a single held inode early (readdir-style iteration that walks
+ * many children but only needs to hold the current one).  No-op if the
+ * inode isn't held by this txn.
  */
 static inline void
 demofs_txn_unlock_inode(
     struct demofs_txn   *txn,
     struct demofs_inode *inode)
 {
-    struct demofs_txn_inode_ref **pp = &txn->refs;
-    struct demofs_txn_inode_ref  *r;
+    int i;
 
-    while (*pp) {
-        if ((*pp)->inode == inode) {
-            r   = *pp;
-            *pp = r->next;
-            demofs_txn_ref_release(txn->thread, r);
+    for (i = 0; i < txn->num_inodes; i++) {
+        if (txn->inodes[i].inode == inode) {
+            enum demofs_inode_lock_mode mode = txn->inodes[i].mode;
+
+            txn->inodes[i] = txn->inodes[txn->num_inodes - 1];
+            txn->num_inodes--;
+            demofs_inode_release_one(txn->thread, inode, mode);
             return;
         }
-        pp = &(*pp)->next;
     }
 } /* demofs_txn_unlock_inode */
 
 /*
- * Release every inode pinned by this txn.  Called by the worker thread for
- * read-txn commits and aborts, and by the IL-side completion handler (on
- * the worker thread, via CQE doorbell) for write-txn commits.
+ * Release every inode held by this txn.  Called by the worker thread for
+ * read-txn commits and aborts, and by the intent-log thread for write-txn
+ * commits (before it pushes the CQE).
  */
 static inline void
 demofs_txn_unlock_all(struct demofs_txn *txn)
 {
-    struct demofs_thread        *thread = txn->thread;
-    struct demofs_txn_inode_ref *r      = txn->refs;
-    struct demofs_txn_inode_ref *n;
+    int i;
 
-    txn->refs = NULL;
-    while (r) {
-        n = r->next;
-        pthread_mutex_unlock(&r->inode->lock);
-        demofs_txn_ref_release(thread, r);
-        r = n;
+    for (i = 0; i < txn->num_inodes; i++) {
+        demofs_inode_release_one(txn->thread, txn->inodes[i].inode,
+                                 txn->inodes[i].mode);
     }
+    txn->num_inodes = 0;
 } /* demofs_txn_unlock_all */
+
+/*
+ * Acquire an inode in the given mode for a transaction.
+ *   1. already held by this txn -> reuse
+ *   2. in the cache -> grant if compatible, else park a waiter
+ *   3. not cached -> ENOENT (no disk fetch yet; everything created so far
+ *      is resident since we never drop or flush)
+ * The callback fires immediately on the calling thread for cases 1/2-grant
+ * and 3, or later (via the grant doorbell, on this txn's worker) once a
+ * conflicting holder releases.
+ */
+static void
+demofs_inode_acquire(
+    struct demofs_thread       *thread,
+    struct demofs_txn          *txn,
+    uint64_t                    inum,
+    uint32_t                    gen,
+    enum demofs_inode_lock_mode mode,
+    demofs_inode_cb_t           cb,
+    void                       *private_data)
+{
+    struct demofs_inode_shard  *shard;
+    struct demofs_inode        *inode;
+    struct demofs_inode_waiter *w;
+    int                         i;
+
+    for (i = 0; i < txn->num_inodes; i++) {
+        inode = txn->inodes[i].inode;
+        if (inode->inum == inum) {
+            if (unlikely(inode->gen != gen)) {
+                cb(NULL, CHIMERA_VFS_ENOENT, private_data);
+            } else {
+                cb(inode, CHIMERA_VFS_OK, private_data);
+            }
+            return;
+        }
+    }
+
+    shard = demofs_inode_shard(thread->shared, inum);
+    pthread_mutex_lock(&shard->lock);
+
+    rb_tree_query_exact(&shard->inodes, inum, inum, inode);
+
+    if (unlikely(!inode || inode->gen != gen)) {
+        pthread_mutex_unlock(&shard->lock);
+        cb(NULL, CHIMERA_VFS_ENOENT, private_data);
+        return;
+    }
+
+    if (demofs_inode_lock_compatible(inode, mode)) {
+        demofs_inode_lock_grant(inode, mode);
+        pthread_mutex_unlock(&shard->lock);
+        demofs_txn_add_slot(txn, inode, mode);
+        if (mode == DEMOFS_INODE_LOCK_WRITE) {
+            demofs_txn_pin_inode_block(thread, txn, inode, 0);
+        }
+        cb(inode, CHIMERA_VFS_OK, private_data);
+        return;
+    }
+
+    w               = demofs_waiter_alloc(thread);
+    w->txn          = txn;
+    w->mode         = mode;
+    w->gen          = gen;
+    w->cb           = cb;
+    w->private_data = private_data;
+    w->inode        = inode;
+    w->status       = CHIMERA_VFS_OK;
+    w->next         = NULL;
+
+    if (inode->wait_tail) {
+        inode->wait_tail->next = w;
+    } else {
+        inode->wait_head = w;
+    }
+    inode->wait_tail = w;
+
+    pthread_mutex_unlock(&shard->lock);
+} /* demofs_inode_acquire */
 
 static inline void
 demofs_inode_get_inum_async(
@@ -490,15 +798,8 @@ demofs_inode_get_inum_async(
     demofs_inode_cb_t     cb,
     void                 *private_data)
 {
-    struct demofs_inode *inode;
-
-    inode = demofs_inode_get_inum(thread->shared, inum, gen);
-    if (inode) {
-        demofs_txn_pin_inode(txn, inode);
-        cb(inode, CHIMERA_VFS_OK, private_data);
-    } else {
-        cb(NULL, CHIMERA_VFS_ENOENT, private_data);
-    }
+    demofs_inode_acquire(thread, txn, inum, gen,
+                         DEMOFS_INODE_MODE_FOR_TXN(txn), cb, private_data);
 } /* demofs_inode_get_inum_async */
 
 static inline void
@@ -516,6 +817,306 @@ demofs_inode_get_fh_async(
     demofs_fh_to_inum(&inum, &gen, fh, fhlen);
     demofs_inode_get_inum_async(thread, txn, inum, gen, cb, private_data);
 } /* demofs_inode_get_fh_async */
+
+/*
+ * Synchronous read-lock acquire, used by the mount-time path walk which
+ * runs before concurrent load.  Records the read lock in the txn so it is
+ * released centrally at commit.  Asserts there is no conflicting writer
+ * (cannot happen at mount); returns NULL if the inode isn't resident or
+ * the generation is stale.
+ */
+static struct demofs_inode *
+demofs_inode_acquire_sync_read(
+    struct demofs_thread *thread,
+    struct demofs_txn    *txn,
+    uint64_t              inum,
+    uint32_t              gen)
+{
+    struct demofs_inode_shard *shard;
+    struct demofs_inode       *inode;
+    int                        i;
+
+    for (i = 0; i < txn->num_inodes; i++) {
+        if (txn->inodes[i].inode->inum == inum) {
+            return txn->inodes[i].inode->gen == gen ? txn->inodes[i].inode : NULL;
+        }
+    }
+
+    shard = demofs_inode_shard(thread->shared, inum);
+    pthread_mutex_lock(&shard->lock);
+    rb_tree_query_exact(&shard->inodes, inum, inum, inode);
+    if (!inode || inode->gen != gen) {
+        pthread_mutex_unlock(&shard->lock);
+        return NULL;
+    }
+    chimera_demofs_abort_if(inode->writer,
+                            "mount path walk: inode %lu write-locked", inum);
+    inode->readers++;
+    pthread_mutex_unlock(&shard->lock);
+
+    demofs_txn_add_slot(txn, inode, DEMOFS_INODE_LOCK_READ);
+    return inode;
+} /* demofs_inode_acquire_sync_read */
+
+/* ------------------------------------------------------------------ */
+/* Block cache                                                         */
+/* ------------------------------------------------------------------ */
+
+static inline uint64_t
+demofs_block_hash(
+    uint32_t device_id,
+    uint64_t device_offset)
+{
+    uint64_t h = device_offset >> DEMOFS_BLOCK_SHIFT;
+
+    h ^= (uint64_t) device_id * 0x9e3779b97f4a7c15ULL;
+    h ^= h >> 29;
+    h *= 0xbf58476d1ce4e5b9ULL;
+    h ^= h >> 32;
+    return h;
+} /* demofs_block_hash */
+
+static void
+demofs_block_cache_create(struct demofs_shared *shared)
+{
+    struct demofs_block_cache *cache = calloc(1, sizeof(*cache));
+    int                        i;
+
+    for (i = 0; i < DEMOFS_BLOCK_CACHE_SHARDS; i++) {
+        pthread_mutex_init(&cache->shards[i].lock, NULL);
+        cache->shards[i].buckets = calloc(DEMOFS_BLOCK_CACHE_BUCKETS_PER_SHARD,
+                                          sizeof(struct demofs_block *));
+    }
+    shared->block_cache = cache;
+} /* demofs_block_cache_create */
+
+static void
+demofs_block_cache_destroy(struct demofs_shared *shared)
+{
+    struct demofs_block_cache *cache = shared->block_cache;
+    int                        i;
+    uint32_t                   b;
+
+    if (!cache) {
+        return;
+    }
+
+    for (i = 0; i < DEMOFS_BLOCK_CACHE_SHARDS; i++) {
+        struct demofs_block_shard *shard = &cache->shards[i];
+
+        for (b = 0; b < DEMOFS_BLOCK_CACHE_BUCKETS_PER_SHARD; b++) {
+            struct demofs_block *blk = shard->buckets[b];
+
+            while (blk) {
+                struct demofs_block *next = blk->hash_next;
+                free(blk->buffer);
+                free(blk);
+                blk = next;
+            }
+        }
+        free(shard->buckets);
+        pthread_mutex_destroy(&shard->lock);
+    }
+    free(cache);
+    shared->block_cache = NULL;
+} /* demofs_block_cache_destroy */
+
+/*
+ * Find a block already resident in the cache.  Lock-free RCU read; the
+ * caller must be inside an rcu read-side critical section (or hold no
+ * concurrent eviction risk, as in Stage 1/2 where blocks are never freed).
+ */
+static inline struct demofs_block *
+demofs_block_lookup_locked(
+    struct demofs_block_shard *shard,
+    uint32_t                   bucket,
+    uint32_t                   device_id,
+    uint64_t                   device_offset)
+{
+    struct demofs_block *blk;
+
+    for (blk = shard->buckets[bucket]; blk; blk = blk->hash_next) {
+        if (blk->device_id == device_id && blk->device_offset == device_offset) {
+            return blk;
+        }
+    }
+    return NULL;
+} /* demofs_block_lookup_locked */
+
+/*
+ * Find or create the cache entry for (device_id, device_offset) and pin it.
+ * If is_new is set the block was just allocated from the space map, so its
+ * buffer is zeroed and it starts DIRTY; otherwise an existing block is
+ * returned (created zeroed on a miss for now, since the read-back path is
+ * not implemented yet).
+ */
+static struct demofs_block *
+demofs_block_claim(
+    struct demofs_thread *thread,
+    uint32_t              device_id,
+    uint64_t              device_offset,
+    int                   is_new)
+{
+    struct demofs_block_cache *cache  = thread->shared->block_cache;
+    uint64_t                   hash   = demofs_block_hash(device_id, device_offset);
+    uint32_t                   sidx   = hash & DEMOFS_BLOCK_CACHE_SHARD_MASK;
+    uint32_t                   bucket = (hash >> 8) & DEMOFS_BLOCK_CACHE_BUCKET_MASK;
+    struct demofs_block_shard *shard  = &cache->shards[sidx];
+    struct demofs_block       *blk;
+
+    (void) is_new;
+
+    pthread_mutex_lock(&shard->lock);
+
+    blk = demofs_block_lookup_locked(shard, bucket, device_id, device_offset);
+    if (!blk) {
+        blk                = calloc(1, sizeof(*blk));
+        blk->device_id     = device_id;
+        blk->device_offset = device_offset;
+        blk->buffer        = calloc(1, DEMOFS_BLOCK_SIZE);
+        blk->state         = DEMOFS_BLOCK_CLEAN;
+        blk->pin_count     = 0;
+        /* Publish into the bucket chain (RCU readers will use hash_next). */
+        blk->hash_next = shard->buckets[bucket];
+        rcu_assign_pointer(shard->buckets[bucket], blk);
+    }
+
+    blk->pin_count++;
+    pthread_mutex_unlock(&shard->lock);
+
+    return blk;
+} /* demofs_block_claim */
+
+/*
+ * txn_block link nodes are allocated on the worker (when a block is pinned)
+ * but freed on the intent-log thread (when the txn's blocks are unpinned),
+ * so they use plain malloc/free rather than a per-thread free list.
+ */
+static inline void
+demofs_txn_add_block(
+    struct demofs_txn   *txn,
+    struct demofs_block *block)
+{
+    struct demofs_txn_block *tb = malloc(sizeof(*tb));
+
+    tb->block   = block;
+    tb->next    = txn->blocks;
+    txn->blocks = tb;
+} /* demofs_txn_add_block */
+
+/*
+ * Ensure this (write-locked) inode's home block is resident and pinned, and
+ * attached to the transaction.  Idempotent per inode: the inode caches its
+ * block pointer and we only claim/attach once.
+ */
+static void
+demofs_txn_pin_inode_block(
+    struct demofs_thread *thread,
+    struct demofs_txn    *txn,
+    struct demofs_inode  *inode,
+    int                   is_new)
+{
+    uint32_t device_id;
+    uint64_t device_offset;
+
+    if (inode->block) {
+        return;     /* already pinned by this txn */
+    }
+
+    device_offset = sm_inum_to_device_offset(thread->shared->space_map,
+                                             inode->inum, &device_id);
+
+    inode->block = demofs_block_claim(thread, device_id, device_offset, is_new);
+    demofs_txn_add_block(txn, inode->block);
+} /* demofs_txn_pin_inode_block */
+
+/* Serialize an inode's durable attributes into the front of its block. */
+static void
+demofs_inode_flush(struct demofs_inode *inode)
+{
+    struct demofs_dinode *di;
+
+    if (!inode->block) {
+        return;
+    }
+
+    di = inode->block->buffer;
+
+    di->inum       = inode->inum;
+    di->gen        = inode->gen;
+    di->mode       = inode->mode;
+    di->nlink      = inode->nlink;
+    di->uid        = inode->uid;
+    di->gid        = inode->gid;
+    di->rdev       = inode->rdev;
+    di->size       = inode->size;
+    di->space_used = inode->space_used;
+    di->atime_sec  = inode->atime_sec;
+    di->mtime_sec  = inode->mtime_sec;
+    di->ctime_sec  = inode->ctime_sec;
+    di->atime_nsec = inode->atime_nsec;
+    di->mtime_nsec = inode->mtime_nsec;
+    di->ctime_nsec = inode->ctime_nsec;
+    if (S_ISDIR(inode->mode)) {
+        di->parent_inum = inode->dir.parent_inum;
+        di->parent_gen  = inode->dir.parent_gen;
+    }
+
+    inode->block->state = DEMOFS_BLOCK_DIRTY;
+} /* demofs_inode_flush */
+
+/*
+ * At commit, serialize every write-locked inode into its block buffer.
+ * Runs on the worker thread (it owns the live inodes under write lock).
+ */
+static void
+demofs_txn_flush_inodes(struct demofs_txn *txn)
+{
+    int i;
+
+    for (i = 0; i < txn->num_inodes; i++) {
+        if (txn->inodes[i].mode == DEMOFS_INODE_LOCK_WRITE) {
+            demofs_inode_flush(txn->inodes[i].inode);
+        }
+    }
+} /* demofs_txn_flush_inodes */
+
+/*
+ * Unpin all blocks held by this txn, transitioning them to new_state.  Also
+ * clears each write-locked inode's cached block pointer (it is only valid
+ * while the txn holds the block pinned; a later txn re-claims it).  Used at
+ * commit (intent-log thread) and abort (worker).  Must run while the txn's
+ * inode slots are still populated (before demofs_txn_unlock_all).
+ */
+static void
+demofs_txn_unpin_blocks(
+    struct demofs_txn      *txn,
+    enum demofs_block_state new_state)
+{
+    struct demofs_thread    *thread = txn->thread;
+    struct demofs_txn_block *tb     = txn->blocks;
+    struct demofs_txn_block *n;
+    int                      i;
+
+    for (i = 0; i < txn->num_inodes; i++) {
+        if (txn->inodes[i].mode == DEMOFS_INODE_LOCK_WRITE) {
+            txn->inodes[i].inode->block = NULL;
+        }
+    }
+
+    (void) thread;
+
+    txn->blocks = NULL;
+    while (tb) {
+        struct demofs_block *blk = tb->block;
+
+        n          = tb->next;
+        blk->state = new_state;
+        __atomic_fetch_sub(&blk->pin_count, 1, __ATOMIC_RELAXED);
+        free(tb);
+        tb = n;
+    }
+} /* demofs_txn_unpin_blocks */
 
 static inline struct demofs_extent *
 demofs_extent_alloc(struct demofs_thread *thread)
@@ -577,83 +1178,40 @@ demofs_symlink_target_free(
 } /* demofs_symlink_target_free */
 
 
+/*
+ * Allocate a bare inode struct for a freshly-minted inum.  The 4 KiB
+ * metadata block on storage has already been carved out of the space map;
+ * for now we leak that block and only use its address to derive the inum.
+ */
 static inline struct demofs_inode *
-demofs_inode_alloc(
-    struct demofs_thread *thread,
-    uint32_t              list_id)
+demofs_inode_struct_new(uint64_t inum)
 {
-    struct demofs_shared     *shared = thread->shared;
-    struct demofs_inode_list *inode_list;
-    struct demofs_inode      *inodes, *inode, *last;
-    uint32_t                  bi, i, base_id;
+    struct demofs_inode *inode = calloc(1, sizeof(*inode));
 
-    inode_list = &shared->inode_list[list_id];
-
-    pthread_mutex_lock(&inode_list->lock);
-
-    inode = inode_list->free_inode;
-
-    if (!inode) {
-
-        bi = inode_list->num_blocks++;
-
-        chimera_demofs_abort_if(bi >= inode_list->max_blocks, "max inode blocks exceeded");
-
-        inodes = slab_allocator_alloc_perm(thread->allocator, CHIMERA_DEMOFS_INODE_BLOCK * sizeof(*inodes));
-
-        base_id = bi << CHIMERA_DEMOFS_INODE_BLOCK_SHIFT;
-
-        if (unlikely(!inode_list->inode)) {
-            inode_list->inode = slab_allocator_alloc_perm(thread->allocator,
-                                                          inode_list->max_blocks *
-                                                          sizeof(*inode_list->inode));
-        }
-
-        inode_list->inode[bi] = inodes;
-
-        last = NULL;
-
-        inode_list->total_inodes += CHIMERA_DEMOFS_INODE_BLOCK;
-
-        for (i = 0; i < CHIMERA_DEMOFS_INODE_BLOCK; i++) {
-            inode       = &inodes[i];
-            inode->inum = (base_id + i) << 8 | list_id;
-            pthread_mutex_init(&inode->lock, NULL);
-
-            if (inode->inum) {
-                /* Toss inode 0, we want non-zero inums */
-                inode->next = last;
-                last        = inode;
-            }
-        }
-        inode_list->free_inode = last;
-
-        inode = inode_list->free_inode;
-    }
-
-    LL_DELETE(inode_list->free_inode, inode);
-
-    inode_list->num_inodes++;
-
-    pthread_mutex_unlock(&inode_list->lock);
-
-    inode->gen++;
+    inode->inum   = inum;
+    inode->gen    = 1;
     inode->refcnt = 1;
-    inode->mode   = 0;
-
+    /* readers/writer/wait_head/wait_tail zeroed by calloc */
     return inode;
+} /* demofs_inode_struct_new */
 
-} /* demofs_inode_alloc */
-
-static inline struct demofs_inode *
-demofs_inode_alloc_thread(struct demofs_thread *thread)
+static inline void
+demofs_inode_cache_insert(
+    struct demofs_shared *shared,
+    struct demofs_inode  *inode)
 {
-    uint32_t list_id = thread->thread_id &
-        CHIMERA_DEMOFS_INODE_LIST_MASK;
+    struct demofs_inode_shard *shard = demofs_inode_shard(shared, inode->inum);
 
-    return demofs_inode_alloc(thread, list_id);
-} /* demofs_inode_alloc */
+    pthread_mutex_lock(&shard->lock);
+    rb_tree_insert(&shard->inodes, inum, inode);
+    pthread_mutex_unlock(&shard->lock);
+} /* demofs_inode_cache_insert */
 
+/*
+ * Allocate a new inode: grab a 4 KiB metadata block from the space map to
+ * mint the inum, create the in-memory inode, publish it write-locked into
+ * the cache, and record it in the transaction.
+ */
 static inline void
 demofs_inode_alloc_async(
     struct demofs_thread *thread,
@@ -661,12 +1219,32 @@ demofs_inode_alloc_async(
     demofs_inode_cb_t     cb,
     void                 *private_data)
 {
-    struct demofs_inode *inode;
+    struct demofs_shared *shared = thread->shared;
+    struct demofs_inode  *inode;
+    uint32_t              device_id;
+    uint64_t              device_offset, inum;
+    int                   rc;
 
-    (void) txn;
+    rc = space_map_alloc(shared->space_map, &thread->space_cache,
+                         SM_BLOCK_SIZE, &device_id, &device_offset);
+    if (unlikely(rc != 0)) {
+        cb(NULL, CHIMERA_VFS_ENOSPC, private_data);
+        return;
+    }
 
-    inode = demofs_inode_alloc_thread(thread);
-    cb(inode, inode ? CHIMERA_VFS_OK : CHIMERA_VFS_ENOSPC, private_data);
+    inum  = sm_inum_from_device_offset(shared->space_map, device_id, device_offset);
+    inode = demofs_inode_struct_new(inum);
+
+    /* New dirty inode: write-locked by this (write) txn from birth. */
+    inode->writer = 1;
+
+    demofs_inode_cache_insert(shared, inode);
+    demofs_txn_add_slot(txn, inode, DEMOFS_INODE_LOCK_WRITE);
+
+    /* Claim and pin the inode's freshly-allocated home block. */
+    demofs_txn_pin_inode_block(thread, txn, inode, 1);
+
+    cb(inode, CHIMERA_VFS_OK, private_data);
 } /* demofs_inode_alloc_async */
 
 static void
@@ -682,34 +1260,31 @@ demofs_dirent_release(
     }
 } /* demofs_dirent_release */
 
+/*
+ * Tear down an inode's contents when its last link/reference is dropped.
+ * We bump the generation so stale file handles return ESTALE, but we do
+ * NOT remove it from the cache or free the struct yet (no eviction), and
+ * we leak its 4 KiB metadata block.  The caller still holds the inode's
+ * write lock via the transaction; the lock is released at commit.
+ */
 static inline void
 demofs_inode_free(
     struct demofs_thread *thread,
     struct demofs_inode  *inode)
 {
-    struct demofs_shared     *shared = thread->shared;
-    struct demofs_inode_list *inode_list;
-    uint32_t                  list_id = thread->thread_id &
-        CHIMERA_DEMOFS_INODE_LIST_MASK;
-
-    inode_list = &shared->inode_list[list_id];
-
     if (S_ISREG(inode->mode)) {
         rb_tree_destroy(&inode->file.extents, demofs_extent_release, thread);
+        rb_tree_init(&inode->file.extents);
     } else if (S_ISDIR(inode->mode)) {
         rb_tree_destroy(&inode->dir.dirents, demofs_dirent_release, thread);
+        rb_tree_init(&inode->dir.dirents);
     } else if (S_ISLNK(inode->mode)) {
         demofs_symlink_target_free(thread, inode->symlink.target);
         inode->symlink.target = NULL;
     }
 
-    /* Increment generation so stale file handles return ESTALE */
     inode->gen++;
-
-    pthread_mutex_lock(&inode_list->lock);
-    LL_PREPEND(inode_list->free_inode, inode);
-    inode_list->num_inodes--;
-    pthread_mutex_unlock(&inode_list->lock);
+    inode->refcnt = 0;
 } /* demofs_inode_free */
 
 static inline struct demofs_dirent *
@@ -839,10 +1414,11 @@ demofs_txn_begin(
         txn = malloc(sizeof(*txn));
     }
 
-    txn->type   = type;
-    txn->thread = thread;
-    txn->next   = NULL;
-    txn->refs   = NULL;
+    txn->type       = type;
+    txn->thread     = thread;
+    txn->next       = NULL;
+    txn->num_inodes = 0;
+    txn->blocks     = NULL;
     return txn;
 } /* demofs_txn_begin */
 
@@ -859,7 +1435,9 @@ static inline void
 demofs_txn_abort(struct demofs_txn *txn)
 {
     /* Nothing to undo today; future intent records and deferred frees
-     * get discarded here. */
+     * get discarded here.  Drop any blocks the aborted txn pinned (their
+     * contents are discarded) and release the inode locks. */
+    demofs_txn_unpin_blocks(txn, DEMOFS_BLOCK_CLEAN);
     demofs_txn_unlock_all(txn);
     demofs_txn_release(txn);
 } /* demofs_txn_abort */
@@ -918,12 +1496,128 @@ demofs_op_ok(
 /* Intent log: SPSC ring helpers + doorbell callbacks + thread         */
 /* ------------------------------------------------------------------ */
 
+/* Completion context for an in-flight redo-record write. */
+struct demofs_redo_ctx {
+    struct demofs_intent_log *il;
+    struct demofs_iq_channel *ch;
+    struct demofs_iq_entry    entry;
+    struct evpl_iovec         iov;
+};
+
+/*
+ * Runs on the intent-log thread when a redo record has been written
+ * durably.  The transaction's changes are now recoverable, so drop the
+ * block pins (-> LOGGED, awaiting tail-push) and the inode locks, then push
+ * the completion onto the worker's CQ.
+ */
+static void
+demofs_redo_write_cb(
+    struct evpl *evpl,
+    int          status,
+    void        *private_data)
+{
+    struct demofs_redo_ctx   *ctx = private_data;
+    struct demofs_iq_channel *ch  = ctx->ch;
+    struct demofs_intent_log *il  = ctx->il;
+    uint32_t                  cq_tail;
+
+    (void) evpl;
+
+    demofs_txn_unpin_blocks(ctx->entry.txn, DEMOFS_BLOCK_LOGGED);
+    demofs_txn_unlock_all(ctx->entry.txn);
+
+    ctx->entry.status = status;
+
+    cq_tail                                       = __atomic_load_n(&ch->cq.tail, __ATOMIC_RELAXED);
+    ch->cq.entries[cq_tail & DEMOFS_IQ_RING_MASK] = ctx->entry;
+    __atomic_store_n(&ch->cq.tail, cq_tail + 1, __ATOMIC_RELEASE);
+
+    ch->cq_inflight--;
+
+    evpl_iovec_release(il->evpl, &ctx->iov);
+    free(ctx);
+
+    evpl_ring_doorbell(&ch->cq_doorbell);
+} /* demofs_redo_write_cb */
+
+/*
+ * Build a full-block redo record for one transaction and issue a durable
+ * write into the reserved intent-log region.  Runs on the intent-log thread.
+ */
+static void
+demofs_il_write_redo(
+    struct demofs_intent_log *il,
+    struct demofs_iq_channel *ch,
+    struct demofs_iq_entry   *entry)
+{
+    struct demofs_txn               *txn = entry->txn;
+    struct demofs_txn_block         *tb;
+    struct demofs_redo_ctx          *ctx;
+    struct demofs_redo_header       *hdr;
+    struct demofs_redo_block_header *bh;
+    uint32_t                         nblocks = 0;
+    uint64_t                         reclen, offset;
+    char                            *p;
+    int                              niov;
+
+    for (tb = txn->blocks; tb; tb = tb->next) {
+        nblocks++;
+    }
+
+    reclen = sizeof(struct demofs_redo_header) +
+        (uint64_t) nblocks * (sizeof(struct demofs_redo_block_header) + DEMOFS_BLOCK_SIZE);
+    reclen = (reclen + DEMOFS_BLOCK_SIZE - 1) & ~((uint64_t) DEMOFS_BLOCK_SIZE - 1);
+
+    /* Circular region; no tail/checkpoint yet, so just wrap and overwrite. */
+    if (il->log_head + reclen > SM_INTENT_LOG_OFFSET + SM_INTENT_LOG_SIZE) {
+        il->log_head = SM_INTENT_LOG_OFFSET;
+    }
+    offset        = il->log_head;
+    il->log_head += reclen;
+
+    ctx        = malloc(sizeof(*ctx));
+    ctx->il    = il;
+    ctx->ch    = ch;
+    ctx->entry = *entry;
+
+    niov = evpl_iovec_alloc(il->evpl, reclen, DEMOFS_BLOCK_SIZE, 1, 0, &ctx->iov);
+    chimera_demofs_abort_if(niov != 1, "redo record did not fit in one iovec (%d)", niov);
+
+    p               = ctx->iov.data;
+    hdr             = (struct demofs_redo_header *) p;
+    hdr->magic      = DEMOFS_REDO_MAGIC;
+    hdr->seq        = il->log_seq++;
+    hdr->num_blocks = nblocks;
+    hdr->reclen     = (uint32_t) reclen;
+    p              += sizeof(*hdr);
+
+    for (tb = txn->blocks; tb; tb = tb->next) {
+        struct demofs_block *blk = tb->block;
+
+        bh                = (struct demofs_redo_block_header *) p;
+        bh->device_id     = blk->device_id;
+        bh->pad           = 0;
+        bh->device_offset = blk->device_offset;
+        p                += sizeof(*bh);
+
+        memcpy(p, blk->buffer, DEMOFS_BLOCK_SIZE);
+        p += DEMOFS_BLOCK_SIZE;
+    }
+
+    ch->cq_inflight++;
+
+    evpl_block_write(il->evpl, il->queue[SM_INTENT_LOG_DEVICE],
+                     &ctx->iov, 1, offset, 1 /* sync */,
+                     demofs_redo_write_cb, ctx);
+} /* demofs_il_write_redo */
+
 static void
 demofs_iq_process_channel(struct demofs_iq_channel *ch)
 {
-    uint32_t sq_head   = __atomic_load_n(&ch->sq.head, __ATOMIC_RELAXED);
-    uint32_t sq_tail   = __atomic_load_n(&ch->sq.tail, __ATOMIC_ACQUIRE);
-    int      processed = 0;
+    struct demofs_intent_log *il      = &ch->worker->shared->intent_log;
+    uint32_t                  sq_head = __atomic_load_n(&ch->sq.head, __ATOMIC_RELAXED);
+    uint32_t                  sq_tail = __atomic_load_n(&ch->sq.tail, __ATOMIC_ACQUIRE);
+    int                       issued  = 0;
 
     while (sq_head != sq_tail) {
         struct demofs_iq_entry entry;
@@ -931,8 +1625,11 @@ demofs_iq_process_channel(struct demofs_iq_channel *ch)
 
         cq_tail = __atomic_load_n(&ch->cq.tail, __ATOMIC_RELAXED);
         cq_head = __atomic_load_n(&ch->cq.head, __ATOMIC_ACQUIRE);
-        if (cq_tail - cq_head >= DEMOFS_IQ_RING_SIZE) {
-            /* CQ full -- defer until worker drains + pings. */
+
+        /* Reserve a CQ slot per in-flight write so completions can't
+         * overflow the CQ.  Defer if no room; the worker's CQ drain pings
+         * us to resume. */
+        if ((cq_tail - cq_head) + ch->cq_inflight >= DEMOFS_IQ_RING_SIZE) {
             break;
         }
 
@@ -940,15 +1637,14 @@ demofs_iq_process_channel(struct demofs_iq_channel *ch)
         sq_head++;
         entry.status = 0;
 
-        ch->cq.entries[cq_tail & DEMOFS_IQ_RING_MASK] = entry;
-        __atomic_store_n(&ch->cq.tail, cq_tail + 1, __ATOMIC_RELEASE);
-
-        processed++;
+        /* Issue a durable redo write; the completion drops pins/locks and
+         * pushes the CQE (see demofs_redo_write_cb). */
+        demofs_il_write_redo(il, ch, &entry);
+        issued++;
     }
 
-    if (processed > 0) {
+    if (issued > 0) {
         __atomic_store_n(&ch->sq.head, sq_head, __ATOMIC_RELEASE);
-        evpl_ring_doorbell(&ch->cq_doorbell);
     }
 } /* demofs_iq_process_channel */
 
@@ -1030,8 +1726,8 @@ demofs_iq_cq_doorbell_cb(
         head++;
         drained++;
 
-        /* Inode pins were released by the worker before SQ enqueue (see
-         * demofs_txn_commit). */
+        /* The txn's logical inode locks were already dropped by the intent
+         * log thread (demofs_iq_process_channel); just deliver completion. */
         entry.cb(entry.txn, entry.status, entry.private_data);
         demofs_txn_release(entry.txn);
     }
@@ -1049,9 +1745,20 @@ demofs_intent_log_thread_init(
     struct evpl *evpl,
     void        *private_data)
 {
-    struct demofs_intent_log *il = private_data;
+    struct demofs_intent_log *il     = private_data;
+    struct demofs_shared     *shared = container_of(il, struct demofs_shared, intent_log);
+    int                       i;
 
-    il->evpl = evpl;
+    il->evpl     = evpl;
+    il->log_head = SM_INTENT_LOG_OFFSET;
+    il->log_seq  = 0;
+
+    /* Open block queues on this thread's evpl for redo-record writes. */
+    il->queue = calloc(shared->num_devices, sizeof(*il->queue));
+    for (i = 0; i < shared->num_devices; i++) {
+        il->queue[i] = evpl_block_open_queue(evpl, shared->devices[i].bdev);
+    }
+
     evpl_add_doorbell(evpl, &il->wake_doorbell, demofs_intent_log_wake_cb);
     __atomic_store_n(&il->ready, 1, __ATOMIC_RELEASE);
     return il;
@@ -1062,11 +1769,19 @@ demofs_intent_log_thread_shutdown(
     struct evpl *evpl,
     void        *private_data)
 {
-    struct demofs_intent_log *il = private_data;
+    struct demofs_intent_log *il     = private_data;
+    struct demofs_shared     *shared = container_of(il, struct demofs_shared, intent_log);
+    int                       i;
 
     /* By the time this runs the VFS layer has destroyed the worker
-     * threads, which freed their channels.  Just drop the doorbell. */
+     * threads, which freed their channels.  Just drop the doorbell and
+     * close our block queues. */
     evpl_remove_doorbell(evpl, &il->wake_doorbell);
+
+    for (i = 0; i < shared->num_devices; i++) {
+        evpl_block_close_queue(evpl, il->queue[i]);
+    }
+    free(il->queue);
 } /* demofs_intent_log_thread_shutdown */
 
 static inline void
@@ -1089,13 +1804,18 @@ demofs_txn_commit(
         return;
     }
 
-    /* Release all pinned inode locks BEFORE the SQ enqueue.  Otherwise
-     * SQ-full backpressure (which spins via evpl_continue) could re-enter
-     * other op callbacks that want these locks and self-deadlock. */
-    demofs_txn_unlock_all(txn);
+    /* Serialize every dirty inode into its block buffer now, on the worker
+     * that owns the live inodes under write lock, before handing the txn
+     * (and its pinned blocks) to the intent log thread. */
+    demofs_txn_flush_inodes(txn);
 
-    /* Write txn -> intent log thread via this worker's SQ.  Callback
-     * fires from the CQ doorbell back on the original worker thread. */
+    /* Write txn -> intent log thread via this worker's SQ.  The intent
+     * log thread drops the txn's logical inode locks when it processes
+     * the entry (see demofs_iq_process_channel); these are logical locks
+     * tracked in the cache, not pthread mutexes, so holding them across
+     * the SQ-full evpl_continue spin below cannot deadlock (conflicting
+     * ops simply park as waiters).  The completion callback fires from the
+     * CQ doorbell back on this worker thread. */
     shared = thread->shared;
     ch     = thread->iq_channel;
 
@@ -1124,7 +1844,6 @@ static void *
 demofs_init(const char *cfgdata)
 {
     struct demofs_shared       *shared = calloc(1, sizeof(*shared));
-    struct demofs_inode_list   *inode_list;
     struct demofs_device       *device;
     enum evpl_block_protocol_id protocol_id;
     const char                 *protocol_name, *device_path;
@@ -1215,22 +1934,15 @@ demofs_init(const char *cfgdata)
                             device0_path, strerror(errno));
     free(device0_path);
 
-    shared->num_inode_list = 255;
-    shared->inode_list     = calloc(shared->num_inode_list,
-                                    sizeof(*shared->inode_list));
-
-    for (i = 0; i < shared->num_inode_list; i++) {
-
-        inode_list = &shared->inode_list[i];
-
-        inode_list->id         = i;
-        inode_list->num_blocks = 0;
-        inode_list->max_blocks = 0;
-
-        pthread_mutex_init(&inode_list->lock, NULL);
-
-        inode_list->max_blocks = 1024 * 1024;
+    /* Inode cache: sharded rb-trees keyed by inum.  Never evicts yet. */
+    shared->inode_cache = calloc(1, sizeof(*shared->inode_cache));
+    for (i = 0; i < DEMOFS_INODE_CACHE_SHARDS; i++) {
+        rb_tree_init(&shared->inode_cache->shards[i].inodes);
+        pthread_mutex_init(&shared->inode_cache->shards[i].lock, NULL);
     }
+
+    /* Block cache: sharded RCU hash of 4 KiB device blocks. */
+    demofs_block_cache_create(shared);
 
     /* Initialize KV shards */
     shared->num_kv_shards = 256;
@@ -1267,15 +1979,33 @@ demofs_bootstrap(struct demofs_thread *thread)
     struct demofs_shared *shared = thread->shared;
     struct timespec       now;
     struct demofs_inode  *inode;
+    uint32_t              device_id;
+    uint64_t              device_offset, inum;
+    int                   rc;
+
+    /* Guard against concurrent first-touch from multiple workers. */
+    pthread_mutex_lock(&shared->lock);
+    if (shared->root_fhlen != 0) {
+        pthread_mutex_unlock(&shared->lock);
+        return;
+    }
 
     clock_gettime(CLOCK_REALTIME, &now);
 
-    inode = demofs_inode_alloc(thread, 0);
+    /* The very first space-map allocation lands at block_idx 2 of AG 0 /
+     * disk 0 (block_idx 1 is reserved at format time), so the root inode
+     * gets inum 2. */
+    rc = space_map_alloc(shared->space_map, &thread->space_cache,
+                         SM_BLOCK_SIZE, &device_id, &device_offset);
+    chimera_demofs_abort_if(rc != 0, "bootstrap: failed to allocate root inode block");
+
+    inum = sm_inum_from_device_offset(shared->space_map, device_id, device_offset);
+    chimera_demofs_abort_if(inum != 2, "bootstrap: root inode is %lu, expected 2", inum);
+
+    inode = demofs_inode_struct_new(inum);
 
     inode->size       = 4096;
     inode->space_used = 4096;
-    inode->gen        = 1;
-    inode->refcnt     = 1;
     inode->uid        = 0;
     inode->gid        = 0;
     inode->nlink      = 2;
@@ -1293,6 +2023,8 @@ demofs_bootstrap(struct demofs_thread *thread)
     inode->dir.parent_inum = inode->inum;
     inode->dir.parent_gen  = inode->gen;
 
+    demofs_inode_cache_insert(shared, inode);
+
     /* Create 16-byte fsid buffer for root FH encoding (8-byte fsid + 8 bytes padding) */
     {
         uint8_t fsid_buf[CHIMERA_VFS_FSID_SIZE] = { 0 };
@@ -1302,33 +2034,41 @@ demofs_bootstrap(struct demofs_thread *thread)
                                                               inode->gen,
                                                               shared->root_fh);
     }
+
+    pthread_mutex_unlock(&shared->lock);
 } /* demofs_bootstrap */
+
+static void
+demofs_inode_cache_release(
+    struct rb_node *node,
+    void           *private_data)
+{
+    struct demofs_inode *inode = container_of(node, struct demofs_inode, node);
+
+    (void) private_data;
+
+    /* Process is exiting; thread slab allocators are already gone, so the
+     * dirent/extent release callbacks no-op with a NULL thread.  We still
+     * own and must free the inode struct itself (heap-allocated). */
+    if (S_ISDIR(inode->mode)) {
+        rb_tree_destroy(&inode->dir.dirents, demofs_dirent_release, NULL);
+    } else if (S_ISREG(inode->mode)) {
+        rb_tree_destroy(&inode->file.extents, demofs_extent_release, NULL);
+    }
+
+    free(inode);
+} /* demofs_inode_cache_release */
 
 static void
 demofs_destroy(void *private_data)
 {
     struct demofs_shared *shared = private_data;
-    struct demofs_inode  *inode;
-    int                   i, j, k;
+    int                   i;
 
-    for (i = 0; i < shared->num_inode_list; i++) {
-        for (j = 0; j < shared->inode_list[i].num_blocks; j++) {
-            for (k = 0; k < CHIMERA_DEMOFS_INODE_BLOCK; k++) {
-                inode = &shared->inode_list[i].inode[j][k];
-
-                if (inode->gen == 0 || inode->refcnt == 0) {
-                    continue;
-                }
-
-                if (S_ISDIR(inode->mode)) {
-                    rb_tree_destroy(&inode->dir.dirents, demofs_dirent_release, NULL);
-                } else if (S_ISLNK(inode->mode)) {
-                    /* do nothing */
-                } else if (S_ISREG(inode->mode)) {
-                    rb_tree_destroy(&inode->file.extents, demofs_extent_release, NULL);
-                }
-            }
-        }
+    for (i = 0; i < DEMOFS_INODE_CACHE_SHARDS; i++) {
+        rb_tree_destroy(&shared->inode_cache->shards[i].inodes,
+                        demofs_inode_cache_release, NULL);
+        pthread_mutex_destroy(&shared->inode_cache->shards[i].lock);
     }
 
     /* Shut down the intent log thread before tearing down anything it
@@ -1342,11 +2082,13 @@ demofs_destroy(void *private_data)
         evpl_block_close_device(shared->devices[i].bdev);
     }
 
+    demofs_block_cache_destroy(shared);
+
     space_map_destroy(shared->space_map);
 
     pthread_mutex_destroy(&shared->lock);
     free(shared->devices);
-    free(shared->inode_list);
+    free(shared->inode_cache);
 
     /* Clean up KV shards */
     for (i = 0; i < shared->num_kv_shards; i++) {
@@ -1357,6 +2099,62 @@ demofs_destroy(void *private_data)
 
     free(shared);
 } /* demofs_destroy */ /* demofs_destroy */
+
+/*
+ * Runs on a worker thread when another thread has granted it one or more
+ * inode locks it was waiting on.  The lock state was already updated by
+ * the releasing thread; here we record the slot (on this, the txn's own
+ * thread) and resume the parked continuation.
+ */
+static void
+demofs_grant_doorbell_cb(
+    struct evpl          *evpl,
+    struct evpl_doorbell *doorbell)
+{
+    struct demofs_thread       *thread = container_of(doorbell,
+                                                      struct demofs_thread,
+                                                      grant_doorbell);
+    struct demofs_inode_waiter *list, *w;
+
+    (void) evpl;
+
+    pthread_mutex_lock(&thread->grant_lock);
+    list               = thread->grant_head;
+    thread->grant_head = NULL;
+    thread->grant_tail = NULL;
+    pthread_mutex_unlock(&thread->grant_lock);
+
+    while (list) {
+        demofs_inode_cb_t    cb;
+        void                *private_data;
+        struct demofs_inode *inode;
+        int                  status;
+
+        w    = list;
+        list = w->next;
+
+        cb           = w->cb;
+        private_data = w->private_data;
+        inode        = w->inode;
+        status       = w->status;
+
+        if (status == CHIMERA_VFS_OK) {
+            struct demofs_txn          *wtxn  = w->txn;
+            enum demofs_inode_lock_mode wmode = w->mode;
+
+            demofs_txn_add_slot(wtxn, inode, wmode);
+            if (wmode == DEMOFS_INODE_LOCK_WRITE) {
+                demofs_txn_pin_inode_block(thread, wtxn, inode, 0);
+            }
+        } else {
+            inode = NULL;
+        }
+
+        demofs_waiter_free(thread, w);
+
+        cb(inode, status, private_data);
+    }
+} /* demofs_grant_doorbell_cb */
 
 static void *
 demofs_thread_init(
@@ -1388,6 +2186,12 @@ demofs_thread_init(
     thread->iq_channel->worker = thread;
     evpl_add_doorbell(evpl, &thread->iq_channel->cq_doorbell,
                       demofs_iq_cq_doorbell_cb);
+
+    /* Inode lock-grant delivery queue + doorbell. */
+    pthread_mutex_init(&thread->grant_lock, NULL);
+    thread->grant_head = NULL;
+    thread->grant_tail = NULL;
+    evpl_add_doorbell(evpl, &thread->grant_doorbell, demofs_grant_doorbell_cb);
 
     pthread_mutex_lock(&shared->lock);
     thread->thread_id = shared->num_active_threads++;
@@ -1448,16 +2252,19 @@ demofs_thread_destroy(void *private_data)
         thread->iq_channel = NULL;
     }
 
+    evpl_remove_doorbell(thread->evpl, &thread->grant_doorbell);
+    pthread_mutex_destroy(&thread->grant_lock);
+
     while (thread->txn_free_list) {
         struct demofs_txn *txn = thread->txn_free_list;
         thread->txn_free_list = txn->next;
         free(txn);
     }
 
-    while (thread->txn_ref_free_list) {
-        struct demofs_txn_inode_ref *r = thread->txn_ref_free_list;
-        thread->txn_ref_free_list = r->next;
-        free(r);
+    while (thread->waiter_free_list) {
+        struct demofs_inode_waiter *w = thread->waiter_free_list;
+        thread->waiter_free_list = w->next;
+        free(w);
     }
 
     free(thread->queue);
@@ -1513,17 +2320,7 @@ demofs_map_attrs(
         attr->va_fs_files_total = CHIMERA_VFS_SYNTHETIC_FS_INODES;
         attr->va_fs_files_avail = CHIMERA_VFS_SYNTHETIC_FS_INODES;
         attr->va_fs_files_free  = CHIMERA_VFS_SYNTHETIC_FS_INODES;
-
-        for (int i = 0; i < shared->num_inode_list; i++) {
-            pthread_mutex_lock(&shared->inode_list[i].lock);
-            attr->va_fs_files_total += shared->inode_list[i].total_inodes;
-            pthread_mutex_unlock(&shared->inode_list[i].lock);
-        }
-
-        attr->va_fs_files_free  = 0;
-        attr->va_fs_files_avail = 0;
         attr->va_fsid           = shared->fsid;
-
     }
 
 } /* demofs_map_attrs */
@@ -1715,19 +2512,22 @@ demofs_setattr(
 static inline struct demofs_inode *
 demofs_lookup_path(
     struct demofs_thread *thread,
-    struct demofs_shared *shared,
+    struct demofs_txn    *txn,
     const char           *path,
     int                   pathlen)
 {
+    struct demofs_shared *shared = thread->shared;
     struct demofs_inode  *parent, *inode;
     struct demofs_dirent *dirent;
     const char           *name;
     const char           *pathc = path;
     const char           *slash;
     int                   namelen;
-    uint64_t              hash;
+    uint64_t              hash, inum;
+    uint32_t              gen;
 
-    inode = demofs_inode_get_fh(shared, shared->root_fh, shared->root_fhlen);
+    demofs_fh_to_inum(&inum, &gen, shared->root_fh, shared->root_fhlen);
+    inode = demofs_inode_acquire_sync_read(thread, txn, inum, gen);
 
     if (unlikely(!inode)) {
         return NULL;
@@ -1760,22 +2560,21 @@ demofs_lookup_path(
         rb_tree_query_exact(&inode->dir.dirents, hash, hash, dirent);
 
         if (!dirent) {
-            pthread_mutex_unlock(&inode->lock);
             return NULL;
         }
 
         parent = inode;
 
-        inode = demofs_inode_get_inum(shared, dirent->inum, dirent->gen);
+        inode = demofs_inode_acquire_sync_read(thread, txn, dirent->inum, dirent->gen);
 
-        pthread_mutex_unlock(&parent->lock);
+        /* Done with the parent now; release its slot so deep walks reuse it. */
+        demofs_txn_unlock_inode(txn, parent);
 
         if (!inode) {
             return NULL;
         }
 
         if (!S_ISDIR(inode->mode)) {
-            pthread_mutex_unlock(&inode->lock);
             return NULL;
         }
 
@@ -1797,12 +2596,14 @@ demofs_mount(
 
     (void) private_data;
 
+    (void) shared;
+
     p->thread = thread;
     p->txn    = demofs_txn_begin(thread, DEMOFS_TXN_READ);
 
-    /* demofs_lookup_path is still synchronous; it'll be converted to an
-     * async path-walker when the inode cache lands. */
-    inode = demofs_lookup_path(thread, shared, request->mount.path,
+    /* Synchronous read-locked path walk; the resolved inode (and any
+     * parents still held) are recorded in the txn and released at commit. */
+    inode = demofs_lookup_path(thread, p->txn, request->mount.path,
                                request->mount.pathlen);
 
     if (unlikely(!inode)) {
@@ -1810,9 +2611,6 @@ demofs_mount(
         return;
     }
 
-    /* demofs_lookup_path returns a locked inode; pin it so the txn
-     * commit handles the unlock centrally. */
-    demofs_txn_pin_inode(p->txn, inode);
     demofs_map_attrs(thread, &request->mount.r_attr, inode);
 
     demofs_op_ok(request, p->txn);
@@ -2237,6 +3035,14 @@ demofs_remove_at_child_cb(
 
     rb_tree_query_exact(&parent->dir.dirents, hash, hash, dirent);
 
+    /* The dirent was located before the child fetch and the parent has
+     * been write-locked throughout, so it must still be present; guard
+     * defensively to keep the derefs below provably safe. */
+    if (unlikely(!dirent)) {
+        demofs_op_fail(request, p->txn, CHIMERA_VFS_ENOENT);
+        return;
+    }
+
     clock_gettime(CLOCK_REALTIME, &now);
 
     if (S_ISDIR(inode->mode)) {
@@ -2386,6 +3192,10 @@ demofs_readdir_iter_inode_cb(
     attr.va_req_mask = request->readdir.attr_mask;
     demofs_map_attrs(thread, &attr, dirent_inode);
 
+    /* Done with this child; release its slot so the next iteration reuses
+     * it (only the directory itself stays held across the walk). */
+    demofs_txn_unlock_inode(p->txn, dirent_inode);
+
     rc = request->readdir.callback(
         dirent->inum,
         dirent->hash + DEMOFS_COOKIE_FIRST,
@@ -2480,6 +3290,9 @@ demofs_readdir_dotdot_cb(
 
     if (status == CHIMERA_VFS_OK) {
         demofs_map_attrs(p->thread, &attr, parent_inode);
+        /* Release the parent (".." target); it's distinct from the dir
+        * being read (the self-parent root case never reaches here). */
+        demofs_txn_unlock_inode(p->txn, parent_inode);
     } else {
         demofs_map_attrs(p->thread, &attr, inode);
     }
@@ -2841,6 +3654,28 @@ demofs_create_unlinked(
 } /* demofs_create_unlinked */
 
 static void
+demofs_close_inode_cb(
+    struct demofs_inode *inode,
+    int                  status,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+
+    if (unlikely(status != CHIMERA_VFS_OK)) {
+        demofs_op_fail(request, p->txn, status);
+        return;
+    }
+
+    --inode->refcnt;
+    if (inode->refcnt == 0) {
+        demofs_inode_free(p->thread, inode);
+    }
+
+    demofs_op_ok(request, p->txn);
+} /* demofs_close_inode_cb */
+
+static void
 demofs_close(
     struct demofs_thread       *thread,
     struct demofs_shared       *shared,
@@ -2856,16 +3691,11 @@ demofs_close(
     p->thread = thread;
     p->txn    = demofs_txn_begin(thread, DEMOFS_TXN_WRITE);
 
-    /* The inode pointer came in via vfs_private (set at open); take its
-     * lock and pin it into the txn so commit drops it centrally. */
-    pthread_mutex_lock(&inode->lock);
-    demofs_txn_pin_inode(p->txn, inode);
-    --inode->refcnt;
-    if (inode->refcnt == 0) {
-        demofs_inode_free(thread, inode);
-    }
-
-    demofs_op_ok(request, p->txn);
+    /* The inode pointer came in via vfs_private (set at open); re-acquire
+     * it by (inum,gen) so its write lock is tracked in the cache like any
+     * other op. */
+    demofs_inode_get_inum_async(thread, p->txn, inode->inum, inode->gen,
+                                demofs_close_inode_cb, request);
 } /* demofs_close */
 
 /*
@@ -4193,6 +5023,15 @@ demofs_rename_at_perform(struct chimera_vfs_request *request)
 
     rb_tree_query_exact(&op->dir.dirents, hash, hash, old_dirent);
 
+    /* The source dirent was verified before we fetched the child and the
+     * source parent has been write-locked the whole time, so it must still
+     * be present; guard defensively to keep the deref provably safe. */
+    if (unlikely(!old_dirent)) {
+        demofs_rename_at_unlock_parents(request);
+        demofs_op_fail(request, p->txn, CHIMERA_VFS_ENOENT);
+        return;
+    }
+
     if (existing_inode) {
         rb_tree_query_exact(&np->dir.dirents, new_hash, hash, existing_dirent);
         if (existing_dirent) {
@@ -4436,48 +5275,15 @@ demofs_rename_at(
 /* inode_stash[0] = parent dir; inode_stash[1] = link target inode (both locked) */
 
 static void
-demofs_link_at_inode_cb(
-    struct demofs_inode *inode,
-    int                  status,
-    void                *private_data)
+demofs_link_at_finish(struct chimera_vfs_request *request)
 {
-    struct chimera_vfs_request    *request = private_data;
-    struct demofs_request_private *p       = request->plugin_data;
-    struct demofs_thread          *thread  = p->thread;
-    struct demofs_inode           *parent  = p->inode_stash[0];
-    struct demofs_inode           *existing_inode;
+    struct demofs_request_private *p      = request->plugin_data;
+    struct demofs_thread          *thread = p->thread;
+    struct demofs_inode           *parent = p->inode_stash[0];
+    struct demofs_inode           *inode  = p->inode_stash[1];
     struct demofs_dirent          *dirent;
     uint64_t                       hash = request->link_at.name_hash;
     struct timespec                now;
-
-    if (unlikely(status != CHIMERA_VFS_OK)) {
-        demofs_op_fail(request, p->txn, status);
-        return;
-    }
-
-    if (unlikely(S_ISDIR(inode->mode))) {
-        demofs_op_fail(request, p->txn, CHIMERA_VFS_EISDIR);
-        return;
-    }
-
-    rb_tree_query_exact(&parent->dir.dirents, hash, hash, dirent);
-
-    if (dirent) {
-        if (request->link_at.replace && !S_ISDIR(inode->mode)) {
-            existing_inode = demofs_inode_get_inum(thread->shared,
-                                                   dirent->inum, dirent->gen);
-            chimera_demofs_abort_if(!existing_inode,
-                                    "demofs_link_at: existing_inode not found");
-            demofs_txn_pin_inode(p->txn, existing_inode);
-            existing_inode->nlink--;
-            demofs_map_attrs(thread, &request->link_at.r_replaced_attr,
-                             existing_inode);
-            rb_tree_remove(&parent->dir.dirents, &dirent->node);
-        } else {
-            demofs_op_fail(request, p->txn, CHIMERA_VFS_EEXIST);
-            return;
-        }
-    }
 
     clock_gettime(CLOCK_REALTIME, &now);
 
@@ -4497,8 +5303,73 @@ demofs_link_at_inode_cb(
     demofs_map_attrs(thread, &request->link_at.r_attr, inode);
     demofs_map_attrs(thread, &request->link_at.r_dir_post_attr, parent);
 
-
     demofs_op_ok(request, p->txn);
+} /* demofs_link_at_finish */
+
+static void
+demofs_link_at_existing_cb(
+    struct demofs_inode *existing_inode,
+    int                  status,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+
+    /* The old dirent was already removed; if its inode is still resident,
+     * drop its link count for the replace. */
+    if (status == CHIMERA_VFS_OK) {
+        existing_inode->nlink--;
+        demofs_map_attrs(p->thread, &request->link_at.r_replaced_attr,
+                         existing_inode);
+    }
+
+    demofs_link_at_finish(request);
+} /* demofs_link_at_existing_cb */
+
+static void
+demofs_link_at_inode_cb(
+    struct demofs_inode *inode,
+    int                  status,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+    struct demofs_thread          *thread  = p->thread;
+    struct demofs_inode           *parent  = p->inode_stash[0];
+    struct demofs_dirent          *dirent;
+    uint64_t                       hash = request->link_at.name_hash;
+
+    if (unlikely(status != CHIMERA_VFS_OK)) {
+        demofs_op_fail(request, p->txn, status);
+        return;
+    }
+
+    if (unlikely(S_ISDIR(inode->mode))) {
+        demofs_op_fail(request, p->txn, CHIMERA_VFS_EISDIR);
+        return;
+    }
+
+    p->inode_stash[1] = inode;
+
+    rb_tree_query_exact(&parent->dir.dirents, hash, hash, dirent);
+
+    if (dirent) {
+        if (request->link_at.replace && !S_ISDIR(inode->mode)) {
+            uint64_t einum = dirent->inum;
+            uint32_t egen  = dirent->gen;
+
+            rb_tree_remove(&parent->dir.dirents, &dirent->node);
+            demofs_dirent_free(thread, dirent);
+
+            demofs_inode_get_inum_async(thread, p->txn, einum, egen,
+                                        demofs_link_at_existing_cb, request);
+            return;
+        }
+        demofs_op_fail(request, p->txn, CHIMERA_VFS_EEXIST);
+        return;
+    }
+
+    demofs_link_at_finish(request);
 } /* demofs_link_at_inode_cb */
 
 static void

--- a/src/vfs/demofs/demofs.c
+++ b/src/vfs/demofs/demofs.c
@@ -3393,6 +3393,46 @@ demofs_ext_next_async(
                                  rec_out, rec_cap, cb, private_data);
 } /* demofs_ext_next_async */
 
+static int
+demofs_ext_insert_async(
+    struct demofs_bt_op  *op,
+    struct demofs_thread *thread,
+    struct demofs_txn    *txn,
+    struct demofs_inode  *inode,
+    uint64_t              file_offset,
+    uint64_t              length,
+    uint32_t              device_id,
+    uint64_t              device_offset,
+    demofs_bt_cb_t        cb,
+    void                 *private_data)
+{
+    struct demofs_extent_rec rec = {
+        .length        = length,
+        .device_id     = device_id,
+        .pad           = 0,
+        .device_offset = device_offset,
+    };
+    struct demofs_bt_key     key = demofs_extent_key(file_offset);
+
+    return demofs_bt_insert_async(op, thread, txn, inode, &key, &rec, sizeof(rec),
+                                  cb, private_data);
+} /* demofs_ext_insert_async */
+
+static int
+demofs_ext_remove_async(
+    struct demofs_bt_op  *op,
+    struct demofs_thread *thread,
+    struct demofs_txn    *txn,
+    struct demofs_inode  *inode,
+    uint64_t              file_offset,
+    demofs_bt_cb_t        cb,
+    void                 *private_data)
+{
+    struct demofs_bt_key key = demofs_extent_key(file_offset);
+
+    return demofs_bt_remove_async(op, thread, txn, inode, &key, cb, private_data);
+} /* demofs_ext_remove_async */
+
 /* Materialize the extent from a completed async lookup op (result + the
  * record left in op->out + the key in op->found_key).  Returns 1 if a valid
  * extent record was found, 0 otherwise. */
@@ -7125,6 +7165,294 @@ demofs_write(
 } /* demofs_write */
 
 
+/*
+ * DEALLOCATE hole-punch extent walk (async).  inode_stash[0] = inode,
+ * loop_off = hole_start, loop_left = hole_end, ext_iter = current extent.
+ */
+static void demofs_dealloc_process(
+    struct chimera_vfs_request *request);
+
+static void
+demofs_allocate_finalize(struct chimera_vfs_request *request)
+{
+    struct demofs_request_private *p      = request->plugin_data;
+    struct demofs_thread          *thread = p->thread;
+    struct demofs_inode           *inode  = p->inode_stash[0];
+    struct timespec                now;
+
+    clock_gettime(CLOCK_REALTIME, &now);
+    inode->mtime_sec  = now.tv_sec;
+    inode->mtime_nsec = now.tv_nsec;
+    inode->ctime_sec  = now.tv_sec;
+    inode->ctime_nsec = now.tv_nsec;
+
+    demofs_map_attrs(thread, &request->allocate.r_post_attr, inode);
+    demofs_op_ok(request, p->txn);
+} /* demofs_allocate_finalize */
+
+static void
+demofs_dealloc_finish(struct chimera_vfs_request *request)
+{
+    struct demofs_request_private *p     = request->plugin_data;
+    struct demofs_inode           *inode = p->inode_stash[0];
+
+    inode->space_used = (inode->size + 4095) & ~4095;
+    demofs_allocate_finalize(request);
+} /* demofs_dealloc_finish */
+
+static void
+demofs_dealloc_walk_cb(
+    struct demofs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+
+    p->loop_have = demofs_ext_from_op(op, result, &p->ext_iter);
+    demofs_bt_op_free(p->thread, op);
+    demofs_dealloc_process(request);
+} /* demofs_dealloc_walk_cb */
+
+static void
+demofs_dealloc_advance(struct chimera_vfs_request *request)
+{
+    struct demofs_request_private *p      = request->plugin_data;
+    struct demofs_thread          *thread = p->thread;
+    struct demofs_bt_op           *op     = demofs_bt_op_alloc(thread);
+
+    if (demofs_ext_next_async(op, thread, p->inode_stash[0], p->ext_iter.file_offset,
+                              p->rec_scratch, sizeof(p->rec_scratch),
+                              demofs_dealloc_walk_cb, request)) {
+        demofs_dealloc_walk_cb(op, op->result, request);
+    }
+} /* demofs_dealloc_advance */
+
+/* Generic "advance after a single async modify" continuation. */
+static void
+demofs_dealloc_modify_advance_cb(
+    struct demofs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request *request = private_data;
+
+    (void) result;
+    demofs_bt_op_free(((struct demofs_request_private *) request->plugin_data)->thread, op);
+    demofs_dealloc_advance(request);
+} /* demofs_dealloc_modify_advance_cb */
+
+static void
+demofs_dealloc_modify_finish_cb(
+    struct demofs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request *request = private_data;
+
+    (void) result;
+    demofs_bt_op_free(((struct demofs_request_private *) request->plugin_data)->thread, op);
+    demofs_dealloc_finish(request);
+} /* demofs_dealloc_modify_finish_cb */
+
+/* overlap-start: after removing the slot, reinsert the trimmed head. */
+static void
+demofs_dealloc_ostart_removed_cb(
+    struct demofs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+    struct demofs_thread          *thread  = p->thread;
+
+    (void) result;
+    demofs_bt_op_free(thread, op);
+
+    op = demofs_bt_op_alloc(thread);
+    if (demofs_ext_insert_async(op, thread, p->txn, p->inode_stash[0],
+                                p->ext_iter.file_offset,
+                                p->loop_off - p->ext_iter.file_offset,
+                                p->ext_iter.device_id, p->ext_iter.device_offset,
+                                demofs_dealloc_modify_advance_cb, request)) {
+        demofs_dealloc_modify_advance_cb(op, op->result, request);
+    }
+} /* demofs_dealloc_ostart_removed_cb */
+
+/* overlap-end: after removing, reinsert the trimmed tail at hole_end. */
+static void
+demofs_dealloc_oend_removed_cb(
+    struct demofs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+    struct demofs_thread          *thread  = p->thread;
+    uint64_t                       es      = p->ext_iter.file_offset;
+    uint64_t                       ee      = es + p->ext_iter.length;
+    uint64_t                       he      = p->loop_left;
+
+    (void) result;
+    demofs_bt_op_free(thread, op);
+
+    op = demofs_bt_op_alloc(thread);
+    if (demofs_ext_insert_async(op, thread, p->txn, p->inode_stash[0], he, ee - he,
+                                p->ext_iter.device_id,
+                                p->ext_iter.device_offset + (he - es),
+                                demofs_dealloc_modify_finish_cb, request)) {
+        demofs_dealloc_modify_finish_cb(op, op->result, request);
+    }
+} /* demofs_dealloc_oend_removed_cb */
+
+/* spans: insert tail -> remove -> insert head -> finish. */
+static void
+demofs_dealloc_spans_before_cb(
+    struct demofs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request *request = private_data;
+
+    (void) result;
+    demofs_bt_op_free(((struct demofs_request_private *) request->plugin_data)->thread, op);
+    demofs_dealloc_finish(request);
+} /* demofs_dealloc_spans_before_cb */
+
+static void
+demofs_dealloc_spans_removed_cb(
+    struct demofs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+    struct demofs_thread          *thread  = p->thread;
+
+    (void) result;
+    demofs_bt_op_free(thread, op);
+
+    op = demofs_bt_op_alloc(thread);
+    if (demofs_ext_insert_async(op, thread, p->txn, p->inode_stash[0],
+                                p->ext_iter.file_offset,
+                                p->loop_off - p->ext_iter.file_offset,
+                                p->ext_iter.device_id, p->ext_iter.device_offset,
+                                demofs_dealloc_spans_before_cb, request)) {
+        demofs_dealloc_spans_before_cb(op, op->result, request);
+    }
+} /* demofs_dealloc_spans_removed_cb */
+
+static void
+demofs_dealloc_spans_after_cb(
+    struct demofs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+    struct demofs_thread          *thread  = p->thread;
+
+    (void) result;
+    demofs_bt_op_free(thread, op);
+
+    op = demofs_bt_op_alloc(thread);
+    if (demofs_ext_remove_async(op, thread, p->txn, p->inode_stash[0],
+                                p->ext_iter.file_offset,
+                                demofs_dealloc_spans_removed_cb, request)) {
+        demofs_dealloc_spans_removed_cb(op, op->result, request);
+    }
+} /* demofs_dealloc_spans_after_cb */
+
+static void
+demofs_dealloc_process(struct chimera_vfs_request *request)
+{
+    struct demofs_request_private *p          = request->plugin_data;
+    struct demofs_thread          *thread     = p->thread;
+    uint64_t                       hole_start = p->loop_off;
+    uint64_t                       hole_end   = p->loop_left;
+    uint64_t                       es, ee;
+    struct demofs_bt_op           *op;
+
+    if (!p->loop_have) {
+        demofs_dealloc_finish(request);
+        return;
+    }
+
+    es = p->ext_iter.file_offset;
+    ee = es + p->ext_iter.length;
+
+    if (ee <= hole_start) {     /* entirely before the hole: skip */
+        demofs_dealloc_advance(request);
+        return;
+    }
+    if (es >= hole_end) {       /* at/after hole end: done */
+        demofs_dealloc_finish(request);
+        return;
+    }
+
+    if (es >= hole_start && ee <= hole_end) {
+        /* Completely inside the hole: free + remove, then advance. */
+        demofs_thread_free_space(thread, p->ext_iter.device_id,
+                                 p->ext_iter.device_offset,
+                                 SM_ALIGN_UP(p->ext_iter.length));
+        op = demofs_bt_op_alloc(thread);
+        if (demofs_ext_remove_async(op, thread, p->txn, p->inode_stash[0], es,
+                                    demofs_dealloc_modify_advance_cb, request)) {
+            demofs_dealloc_modify_advance_cb(op, op->result, request);
+        }
+    } else if (es < hole_start && ee > hole_end) {
+        /* Spans the hole: insert tail at hole_end first. */
+        op = demofs_bt_op_alloc(thread);
+        if (demofs_ext_insert_async(op, thread, p->txn, p->inode_stash[0], hole_end,
+                                    ee - hole_end, p->ext_iter.device_id,
+                                    p->ext_iter.device_offset + (hole_end - es),
+                                    demofs_dealloc_spans_after_cb, request)) {
+            demofs_dealloc_spans_after_cb(op, op->result, request);
+        }
+    } else if (es < hole_start) {
+        /* Overlaps the hole start: remove, then reinsert the head. */
+        op = demofs_bt_op_alloc(thread);
+        if (demofs_ext_remove_async(op, thread, p->txn, p->inode_stash[0], es,
+                                    demofs_dealloc_ostart_removed_cb, request)) {
+            demofs_dealloc_ostart_removed_cb(op, op->result, request);
+        }
+    } else {
+        /* Overlaps the hole end: remove, then reinsert the tail at hole_end. */
+        op = demofs_bt_op_alloc(thread);
+        if (demofs_ext_remove_async(op, thread, p->txn, p->inode_stash[0], es,
+                                    demofs_dealloc_oend_removed_cb, request)) {
+            demofs_dealloc_oend_removed_cb(op, op->result, request);
+        }
+    }
+} /* demofs_dealloc_process */
+
+static void
+demofs_dealloc_first_cb(
+    struct demofs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+    struct demofs_thread          *thread  = p->thread;
+    int                            have    = demofs_ext_from_op(op, result, &p->ext_iter);
+
+    demofs_bt_op_free(thread, op);
+
+    if (!have) {
+        op = demofs_bt_op_alloc(thread);
+        if (demofs_ext_ceil_async(op, thread, p->inode_stash[0], 0, p->rec_scratch,
+                                  sizeof(p->rec_scratch), demofs_dealloc_walk_cb,
+                                  request)) {
+            demofs_dealloc_walk_cb(op, op->result, request);
+        }
+        return;
+    }
+
+    p->loop_have = 1;
+    demofs_dealloc_process(request);
+} /* demofs_dealloc_first_cb */
+
 static void
 demofs_allocate_inode_cb(
     struct demofs_inode *inode,
@@ -7134,96 +7462,38 @@ demofs_allocate_inode_cb(
     struct chimera_vfs_request    *request = private_data;
     struct demofs_request_private *p       = request->plugin_data;
     struct demofs_thread          *thread  = p->thread;
-    struct timespec                now;
+    struct demofs_bt_op           *op;
 
     if (unlikely(status != CHIMERA_VFS_OK)) {
         demofs_op_fail(request, p->txn, status);
         return;
     }
 
-    clock_gettime(CLOCK_REALTIME, &now);
-
     demofs_map_attrs(thread, &request->allocate.r_pre_attr, inode);
+    p->inode_stash[0] = inode;
 
     if (request->allocate.flags & CHIMERA_VFS_ALLOCATE_DEALLOCATE) {
-        /* DEALLOCATE: punch hole in [offset, offset+length) */
-        uint64_t              hole_start = request->allocate.offset;
-        uint64_t              hole_end   = hole_start + request->allocate.length;
-        struct demofs_extent  ext_buf;
-        struct demofs_extent *extent = &ext_buf;
-        int                   have;
+        uint64_t hole_start = request->allocate.offset;
+        uint64_t hole_end   = hole_start + request->allocate.length;
 
         if (hole_end > inode->size) {
             hole_end = inode->size;
         }
 
         if (hole_start < hole_end) {
-            have = demofs_ext_floor(thread, inode, hole_start, extent);
-            if (!have) {
-                have = demofs_ext_ceil(thread, inode, 0, extent);
+            p->loop_off  = hole_start;
+            p->loop_left = hole_end;
+
+            op = demofs_bt_op_alloc(thread);
+            if (demofs_ext_floor_async(op, thread, inode, hole_start, p->rec_scratch,
+                                       sizeof(p->rec_scratch), demofs_dealloc_first_cb,
+                                       request)) {
+                demofs_dealloc_first_cb(op, op->result, request);
             }
-
-            while (have) {
-                uint64_t extent_start = extent->file_offset;
-                uint64_t extent_end   = extent_start + extent->length;
-                uint64_t cur_fo       = extent_start;
-
-                /* Skip extents entirely before hole */
-                if (extent_end <= hole_start) {
-                    have = demofs_ext_next(thread, inode, cur_fo, extent);
-                    continue;
-                }
-
-                /* Stop if extent starts at or after hole end */
-                if (extent_start >= hole_end) {
-                    break;
-                }
-
-                if (extent_start >= hole_start && extent_end <= hole_end) {
-                    /* Extent is completely inside hole - remove it.
-                     * Partial-overlap cases below currently leak the punched
-                     * device range (sub-block accounting), deferred. */
-                    demofs_thread_free_space(thread, extent->device_id,
-                                             extent->device_offset,
-                                             SM_ALIGN_UP(extent->length));
-                    demofs_ext_remove(thread, p->txn, inode, cur_fo);
-                } else if (extent_start < hole_start &&
-                           extent_end > hole_end) {
-                    /* Extent spans the entire hole - split it. */
-                    uint64_t after_shift = hole_end - extent_start;
-
-                    demofs_ext_insert(thread, p->txn, inode, hole_end,
-                                      extent_end - hole_end, extent->device_id,
-                                      extent->device_offset + after_shift);
-                    demofs_ext_remove(thread, p->txn, inode, cur_fo);
-                    demofs_ext_insert(thread, p->txn, inode, cur_fo,
-                                      hole_start - extent_start, extent->device_id,
-                                      extent->device_offset);
-                    break;
-                } else if (extent_start < hole_start) {
-                    /* Extent overlaps start of hole - trim end. */
-                    demofs_ext_remove(thread, p->txn, inode, cur_fo);
-                    demofs_ext_insert(thread, p->txn, inode, cur_fo,
-                                      hole_start - extent_start, extent->device_id,
-                                      extent->device_offset);
-                } else {
-                    /* Extent overlaps end of hole - trim start (key moves). */
-                    uint64_t shift = hole_end - extent_start;
-
-                    demofs_ext_remove(thread, p->txn, inode, cur_fo);
-                    demofs_ext_insert(thread, p->txn, inode, hole_end,
-                                      extent_end - hole_end, extent->device_id,
-                                      extent->device_offset + shift);
-                    break;
-                }
-
-                have = demofs_ext_next(thread, inode, cur_fo, extent);
-            }
-
-            inode->space_used = (inode->size + 4095) & ~4095;
+            return;
         }
     } else {
-        /* ALLOCATE: extend file size if needed */
+        /* ALLOCATE: extend file size if needed. */
         uint64_t new_end = request->allocate.offset + request->allocate.length;
 
         if (new_end > inode->size) {
@@ -7232,15 +7502,7 @@ demofs_allocate_inode_cb(
         }
     }
 
-    inode->mtime_sec  = now.tv_sec;
-    inode->mtime_nsec = now.tv_nsec;
-    inode->ctime_sec  = now.tv_sec;
-    inode->ctime_nsec = now.tv_nsec;
-
-    demofs_map_attrs(thread, &request->allocate.r_post_attr, inode);
-
-
-    demofs_op_ok(request, p->txn);
+    demofs_allocate_finalize(request);
 } /* demofs_allocate_inode_cb */
 
 static void

--- a/src/vfs/demofs/demofs.c
+++ b/src/vfs/demofs/demofs.c
@@ -306,21 +306,22 @@ struct demofs_bt_op;
 /*
  * A cached 4 KiB on-disk block, keyed by (device_id, device_offset).  The
  * buffer is plain heap memory; block I/O copies it through a thread-local
- * evpl_iovec so buffers are never shared across evpl instances.  Hash-chain
- * linkage is RCU-managed for lock-free lookup; mutation happens under the
- * owning shard lock and frees defer through call_rcu.
+ * evpl_iovec so buffers are never shared across evpl instances.  All fields
+ * (hash linkage, pin_count, state, LRU membership) are protected by the
+ * owning shard lock.  A buffer is an eviction candidate exactly when it is
+ * CLEAN and pin_count == 0, in which case it sits on the shard LRU
+ * (on_lru == 1); recycling reuses the least-recently-used such buffer.
  */
 struct demofs_block {
     uint32_t             device_id;
     uint64_t             device_offset;        /* block-aligned; key with device_id */
     void                *buffer;               /* DEMOFS_BLOCK_SIZE bytes */
-    int                  pin_count;            /* atomic; >0 => not reclaimable */
+    int                  pin_count;            /* >0 => pinned, not reclaimable */
     enum demofs_block_state state;
     uint64_t             seq;                  /* update order for tail-push */
-    struct demofs_block *hash_next;            /* RCU bucket chain */
-    struct rcu_head      rcu;
-    struct demofs_block *lru_prev, *lru_next;      /* clean+unpinned LRU (Stage 3) */
-    struct demofs_block *wb_next;              /* writeback queue (Stage 3) */
+    struct demofs_block *hash_next;            /* bucket chain */
+    struct demofs_block *lru_prev, *lru_next;  /* shard LRU (CLEAN + unpinned) */
+    int                  on_lru;               /* 1 iff linked on the shard LRU */
 
     /* Ops blocked on a LOADING block, woken when the read I/O completes.
      * Protected by the owning shard lock. */
@@ -342,8 +343,11 @@ struct demofs_block_shard {
 };
 
 struct demofs_block_cache {
+    uint32_t                  shard_cap;   /* max resident buffers per shard */
     struct demofs_block_shard shards[DEMOFS_BLOCK_CACHE_SHARDS];
 };
+
+#define DEMOFS_BLOCK_CACHE_DEFAULT_BLOCKS 8192  /* total; ~32 MiB of 4 KiB buffers */
 
 /*
  * On-disk inode block layout (4 KiB):
@@ -354,10 +358,10 @@ struct demofs_block_cache {
  * records in the inode's single b+tree; the root node is embedded in the
  * inode block, and deeper nodes occupy their own 4 KiB blocks.
  */
-#define DEMOFS_INODE_AREA   256
-#define DEMOFS_BT_ROOT_BASE DEMOFS_INODE_AREA
-#define DEMOFS_BT_ROOT_CAP  (DEMOFS_BLOCK_SIZE - DEMOFS_INODE_AREA)   /* 3840 */
-#define DEMOFS_BT_NODE_CAP  DEMOFS_BLOCK_SIZE                          /* 4096 */
+#define DEMOFS_INODE_AREA                 256
+#define DEMOFS_BT_ROOT_BASE               DEMOFS_INODE_AREA
+#define DEMOFS_BT_ROOT_CAP                (DEMOFS_BLOCK_SIZE - DEMOFS_INODE_AREA) /* 3840 */
+#define DEMOFS_BT_NODE_CAP                DEMOFS_BLOCK_SIZE            /* 4096 */
 
 struct demofs_dinode {
     uint64_t inum;
@@ -618,6 +622,7 @@ struct demofs_shared {
     uint32_t                   root_gen;
     int                        persistent;         /* config opt-in: detect+reload a clean FS instead of mkfs */
     int                        mounted;            /* 1 = remounted existing FS (enables inode read-back) */
+    uint32_t                   block_cache_blocks; /* total resident block-buffer cap (0 = default) */
     uint64_t                   fsid;
     struct space_map          *space_map;
     struct demofs_intent_log   intent_log;
@@ -739,6 +744,12 @@ struct demofs_bt_op {
     int                       suspended;
     int                       done;
     int                       result;
+
+    /* Blocks pinned by this op's descent so eviction can't recycle a node
+     * while we read it; released at completion.  Sized for the descent path
+     * plus the siblings a remove-rebalance can fault at each level. */
+    struct demofs_block      *pins[DEMOFS_BT_MAX_DEPTH * 4];
+    int                       npins;
 
     /* block-waiter list / per-worker resume-queue linkage */
     struct demofs_bt_op      *next;
@@ -1113,6 +1124,13 @@ static struct demofs_block * demofs_block_claim(
     uint64_t              device_offset,
     int                   is_new);
 
+/* Decrement a block's pin and set its new state; if it becomes CLEAN and
+ * unpinned it joins the shard LRU as an eviction candidate. */
+static void demofs_block_unpin(
+    struct demofs_thread   *thread,
+    struct demofs_block    *blk,
+    enum demofs_block_state new_state);
+
 static struct demofs_inode *
 demofs_inode_load_sync(
     struct demofs_thread *thread,
@@ -1180,8 +1198,7 @@ demofs_inode_load_sync(
         struct demofs_block *blk = demofs_block_claim(thread, dev, off, 0);
 
         memcpy(blk->buffer, buf, DEMOFS_BLOCK_SIZE);
-        blk->state = DEMOFS_BLOCK_CLEAN;
-        __atomic_fetch_sub(&blk->pin_count, 1, __ATOMIC_RELAXED);
+        demofs_block_unpin(thread, blk, DEMOFS_BLOCK_CLEAN);
     }
     return inode;
 } /* demofs_inode_load_sync */
@@ -1273,11 +1290,138 @@ demofs_block_bucket(
     return (hash >> 8) & DEMOFS_BLOCK_CACHE_BUCKET_MASK;
 } /* demofs_block_bucket */
 
+/* --- shard LRU (caller holds the shard lock) --------------------------- */
+
+static inline void
+demofs_block_lru_push_tail(
+    struct demofs_block_shard *shard,
+    struct demofs_block       *blk)
+{
+    blk->lru_prev = shard->lru_tail;
+    blk->lru_next = NULL;
+    if (shard->lru_tail) {
+        shard->lru_tail->lru_next = blk;
+    } else {
+        shard->lru_head = blk;
+    }
+    shard->lru_tail = blk;
+    blk->on_lru     = 1;
+} /* demofs_block_lru_push_tail */
+
+static inline void
+demofs_block_lru_unlink(
+    struct demofs_block_shard *shard,
+    struct demofs_block       *blk)
+{
+    if (!blk->on_lru) {
+        return;
+    }
+    if (blk->lru_prev) {
+        blk->lru_prev->lru_next = blk->lru_next;
+    } else {
+        shard->lru_head = blk->lru_next;
+    }
+    if (blk->lru_next) {
+        blk->lru_next->lru_prev = blk->lru_prev;
+    } else {
+        shard->lru_tail = blk->lru_prev;
+    }
+    blk->lru_prev = blk->lru_next = NULL;
+    blk->on_lru   = 0;
+} /* demofs_block_lru_unlink */
+
+/*
+ * Recycle the least-recently-used clean buffer for reuse at a new key, or
+ * allocate a fresh one.  Caller holds the shard lock.  Returns a buffer with
+ * pin_count 0 and not on the LRU, removed from its old bucket; the caller sets
+ * the new key/state and links it into the new bucket.  Grows the pool past the
+ * cap only when every buffer is pinned (no LRU victim) -- a bounded transient
+ * until block_claim learns to wait (top-down rewrite).
+ */
+static struct demofs_block *
+demofs_block_recycle_or_alloc(
+    struct demofs_block_cache *cache,
+    struct demofs_block_shard *shard)
+{
+    struct demofs_block *blk;
+
+    if (shard->nblocks >= cache->shard_cap && shard->lru_head) {
+        uint32_t             ob;
+        struct demofs_block *cur, *prev;
+
+        blk = shard->lru_head;
+        demofs_block_lru_unlink(shard, blk);
+
+        /* Unhook from its current bucket. */
+        ob   = demofs_block_bucket(blk->device_id, blk->device_offset);
+        prev = NULL;
+        for (cur = shard->buckets[ob]; cur; prev = cur, cur = cur->hash_next) {
+            if (cur == blk) {
+                if (prev) {
+                    prev->hash_next = cur->hash_next;
+                } else {
+                    shard->buckets[ob] = cur->hash_next;
+                }
+                break;
+            }
+        }
+        blk->hash_next = NULL;
+        return blk;
+    }
+
+    blk         = calloc(1, sizeof(*blk));
+    blk->buffer = calloc(1, DEMOFS_BLOCK_SIZE);
+    shard->nblocks++;
+    return blk;
+} /* demofs_block_recycle_or_alloc */
+
+static void
+demofs_block_unpin(
+    struct demofs_thread   *thread,
+    struct demofs_block    *blk,
+    enum demofs_block_state new_state)
+{
+    struct demofs_block_shard *shard = demofs_block_shard(thread->shared->block_cache,
+                                                          blk->device_id, blk->device_offset);
+
+    pthread_mutex_lock(&shard->lock);
+    blk->state = new_state;
+    if (--blk->pin_count == 0 && blk->state == DEMOFS_BLOCK_CLEAN && !blk->on_lru) {
+        demofs_block_lru_push_tail(shard, blk);
+        /* A3b: wake a buffer waiter here. */
+    }
+    pthread_mutex_unlock(&shard->lock);
+} /* demofs_block_unpin */
+
+/* Release a descent pin without changing the block's state. */
+static void
+demofs_block_release(
+    struct demofs_thread *thread,
+    struct demofs_block  *blk)
+{
+    struct demofs_block_shard *shard = demofs_block_shard(thread->shared->block_cache,
+                                                          blk->device_id, blk->device_offset);
+
+    pthread_mutex_lock(&shard->lock);
+    if (--blk->pin_count == 0 && blk->state == DEMOFS_BLOCK_CLEAN && !blk->on_lru) {
+        demofs_block_lru_push_tail(shard, blk);
+        /* A3b: wake a buffer waiter here. */
+    }
+    pthread_mutex_unlock(&shard->lock);
+} /* demofs_block_release */
+
 static void
 demofs_block_cache_create(struct demofs_shared *shared)
 {
     struct demofs_block_cache *cache = calloc(1, sizeof(*cache));
+    uint32_t                   total = shared->block_cache_blocks ?
+        shared->block_cache_blocks : DEMOFS_BLOCK_CACHE_DEFAULT_BLOCKS;
     int                        i;
+
+    cache->shard_cap = total / DEMOFS_BLOCK_CACHE_SHARDS;
+    if (cache->shard_cap == 0) {
+        cache->shard_cap = 1;
+    }
 
     for (i = 0; i < DEMOFS_BLOCK_CACHE_SHARDS; i++) {
         pthread_mutex_init(&cache->shards[i].lock, NULL);
@@ -1342,10 +1486,12 @@ demofs_block_lookup_locked(
 
 /*
  * Find or create the cache entry for (device_id, device_offset) and pin it.
- * If is_new is set the block was just allocated from the space map, so its
- * buffer is zeroed and it starts DIRTY; otherwise an existing block is
- * returned (created zeroed on a miss for now, since the read-back path is
- * not implemented yet).
+ * On a miss a buffer is obtained from the shard pool (recycling the LRU
+ * eviction candidate, or growing the pool): is_new (a freshly space-map-
+ * allocated block) starts zeroed; otherwise -- always, now that eviction can
+ * discard a resident CLEAN block whose content is already home -- the buffer
+ * is repopulated from disk so a re-claimed evicted block keeps its contents.
+ * A hit unlinks the block from the LRU (it is now pinned, not a candidate).
  */
 static struct demofs_block *
 demofs_block_claim(
@@ -1365,37 +1511,33 @@ demofs_block_claim(
 
     blk = demofs_block_lookup_locked(shard, bucket, device_id, device_offset);
     if (!blk) {
-        blk                = calloc(1, sizeof(*blk));
+        blk                = demofs_block_recycle_or_alloc(cache, shard);
         blk->device_id     = device_id;
         blk->device_offset = device_offset;
-        blk->buffer        = calloc(1, DEMOFS_BLOCK_SIZE);
         blk->state         = DEMOFS_BLOCK_CLEAN;
-        blk->pin_count     = 0;
+        blk->seq           = 0;
+        blk->wait_head     = NULL;
+        blk->wait_tail     = NULL;
 
-        /* On a remounted FS a synchronous structural modify can reference a
-         * block the async descent never faulted in -- notably a leaf merge
-         * relinking the right partner's next_leaf, which is not one of the
-         * ci-1/ci/ci+1 siblings the rebalance pre-faults.  Read its real
-         * contents from disk rather than publishing a zeroed block (which
-         * would corrupt the tree once written back).  Rare; a buffered read
-         * served from the page cache.  is_new blocks are freshly allocated,
-         * so they are correctly left zeroed. */
-        if (thread->shared->mounted && !is_new) {
-            int fd = open(thread->shared->device_paths[device_id], O_RDONLY);
+        if (is_new) {
+            memset(blk->buffer, 0, DEMOFS_BLOCK_SIZE);
+        } else {
+            int     fd = open(thread->shared->device_paths[device_id], O_RDONLY);
+            ssize_t n  = -1;
 
             if (fd >= 0) {
-                ssize_t n = pread(fd, blk->buffer, DEMOFS_BLOCK_SIZE,
-                                  (off_t) device_offset);
+                n = pread(fd, blk->buffer, DEMOFS_BLOCK_SIZE, (off_t) device_offset);
                 close(fd);
-                chimera_demofs_abort_if(n != (ssize_t) DEMOFS_BLOCK_SIZE,
-                                        "block_claim disk read failed off=%lu n=%zd",
-                                        device_offset, n);
             }
+            chimera_demofs_abort_if(n != (ssize_t) DEMOFS_BLOCK_SIZE,
+                                    "block_claim disk read failed off=%lu n=%zd",
+                                    device_offset, n);
         }
 
-        /* Publish into the bucket chain (all lookups hold the shard lock). */
         blk->hash_next         = shard->buckets[bucket];
         shard->buckets[bucket] = blk;
+    } else if (blk->on_lru) {
+        demofs_block_lru_unlink(shard, blk);
     }
 
     blk->pin_count++;
@@ -1600,6 +1742,23 @@ demofs_block_load_complete(
  * block's waiter list (a read is issued if it is not already in flight) and
  * NULL is returned; the op's driver will be re-entered once the block loads.
  */
+/* Pin a block for op's descent (so it can't be evicted while in use) and
+ * record it for release at completion.  Caller holds the shard lock. */
+static inline void
+demofs_bt_op_pin(
+    struct demofs_bt_op       *op,
+    struct demofs_block_shard *shard,
+    struct demofs_block       *blk)
+{
+    if (blk->on_lru) {
+        demofs_block_lru_unlink(shard, blk);
+    }
+    blk->pin_count++;
+    chimera_demofs_abort_if(op->npins >= (int) (sizeof(op->pins) / sizeof(op->pins[0])),
+                            "b+tree op pin list overflow");
+    op->pins[op->npins++] = blk;
+} /* demofs_bt_op_pin */
+
 static struct demofs_block *
 demofs_bt_block_get(
     struct demofs_bt_op *op,
@@ -1617,16 +1776,19 @@ demofs_bt_block_get(
     pthread_mutex_lock(&shard->lock);
     blk = demofs_block_lookup_locked(shard, bucket, device_id, device_offset);
     if (blk && blk->state != DEMOFS_BLOCK_LOADING) {
+        demofs_bt_op_pin(op, shard, blk);
         pthread_mutex_unlock(&shard->lock);
         return blk;
     }
 
     if (!blk) {
-        blk                    = calloc(1, sizeof(*blk));
+        blk                    = demofs_block_recycle_or_alloc(cache, shard);
         blk->device_id         = device_id;
         blk->device_offset     = device_offset;
-        blk->buffer            = calloc(1, DEMOFS_BLOCK_SIZE);
         blk->state             = DEMOFS_BLOCK_LOADING;
+        blk->seq               = 0;
+        blk->wait_head         = NULL;
+        blk->wait_tail         = NULL;
         blk->hash_next         = shard->buckets[bucket];
         shard->buckets[bucket] = blk;
         issue                  = 1;
@@ -1764,15 +1926,12 @@ demofs_txn_unpin_blocks(
         }
     }
 
-    (void) thread;
-
     txn->blocks = NULL;
     while (tb) {
         struct demofs_block *blk = tb->block;
 
-        n          = tb->next;
-        blk->state = new_state;
-        __atomic_fetch_sub(&blk->pin_count, 1, __ATOMIC_RELAXED);
+        n = tb->next;
+        demofs_block_unpin(thread, blk, new_state);
         free(tb);
         tb = n;
     }
@@ -2826,6 +2985,15 @@ demofs_bt_complete(
     struct demofs_bt_op *op,
     int                  result)
 {
+    int i;
+
+    /* Release the descent pins (a write op's structural blocks stay pinned by
+     * the transaction; this only drops the read pin taken during descent). */
+    for (i = 0; i < op->npins; i++) {
+        demofs_block_release(op->thread, op->pins[i]);
+    }
+    op->npins = 0;
+
     op->result = result;
     if (op->suspended) {
         op->cb(op, result, op->private_data);
@@ -3839,8 +4007,7 @@ demofs_inode_load_complete(
         struct demofs_block *blk = demofs_block_claim(thread, dev, off, 0);
 
         memcpy(blk->buffer, lc->iov.data, DEMOFS_BLOCK_SIZE);
-        blk->state = DEMOFS_BLOCK_CLEAN;
-        __atomic_fetch_sub(&blk->pin_count, 1, __ATOMIC_RELAXED);
+        demofs_block_unpin(thread, blk, DEMOFS_BLOCK_CLEAN);
     }
 
     evpl_iovec_release(thread->evpl, &lc->iov);
@@ -4273,6 +4440,10 @@ demofs_il_clean_pushed_record(
         if (blk && blk->state == DEMOFS_BLOCK_LOGGED &&
             blk->seq == rec->seq && blk->pin_count == 0) {
             blk->state = DEMOFS_BLOCK_CLEAN;
+            if (!blk->on_lru) {
+                demofs_block_lru_push_tail(shard, blk);
+                /* A3b: wake a buffer waiter here. */
+            }
         }
         pthread_mutex_unlock(&shard->lock);
     }
@@ -4998,7 +5169,9 @@ demofs_init(const char *cfgdata)
      * and the prior on-disk state is reloaded instead of reformatting.  Off by
      * default so the common case (and the test suite) reformats every mount;
      * the reload + on-disk read-back paths are exercised only under this flag. */
-    shared->persistent = json_is_true(json_object_get(cfg, "persistent"));
+    shared->persistent         = json_is_true(json_object_get(cfg, "persistent"));
+    shared->block_cache_blocks = (uint32_t) json_integer_value(
+        json_object_get(cfg, "block_cache_blocks"));
 
     json_decref(cfg);
 
@@ -5206,16 +5379,26 @@ demofs_bootstrap(struct demofs_thread *thread)
 
     demofs_inode_cache_insert(shared, inode);
 
-    /* Create the root inode's block in the cache: an embedded empty b+tree
-     * root plus the dinode.  Bootstrap is not a transaction, so leave the
-     * block resident but unpinned/detached; the first write op that touches
-     * root will re-claim and log it. */
+    /* Create the root inode's block: an embedded empty b+tree root plus the
+     * dinode.  Bootstrap is not a transaction, so write the block to its home
+     * location synchronously -- otherwise it would be CLEAN-but-not-home and
+     * eviction could discard it before the first write op logs it (CLEAN
+     * blocks must be re-readable from disk).  Then detach it, evictable. */
     inode->block = demofs_block_claim(thread, device_id, device_offset, 1);
     demofs_bt_node_init(inode->block->buffer, DEMOFS_BT_ROOT_BASE,
                         DEMOFS_BT_ROOT_CAP, 0);
     demofs_inode_flush(inode);
+    {
+        int fd = open(shared->device_paths[device_id], O_WRONLY);
+
+        if (fd >= 0) {
+            pwrite(fd, inode->block->buffer, DEMOFS_BLOCK_SIZE, (off_t) device_offset);
+            fsync(fd);
+            close(fd);
+        }
+    }
     inode->block->state = DEMOFS_BLOCK_CLEAN;
-    __atomic_fetch_sub(&inode->block->pin_count, 1, __ATOMIC_RELAXED);
+    demofs_block_unpin(thread, inode->block, DEMOFS_BLOCK_CLEAN);
     inode->block = NULL;
 
     /* Create 16-byte fsid buffer for root FH encoding (8-byte fsid + 8 bytes padding) */

--- a/src/vfs/demofs/demofs.c
+++ b/src/vfs/demofs/demofs.c
@@ -3191,6 +3191,23 @@ demofs_symlink_set(
 } /* demofs_symlink_set */
 
 static int
+demofs_symlink_set_async(
+    struct demofs_bt_op  *op,
+    struct demofs_thread *thread,
+    struct demofs_txn    *txn,
+    struct demofs_inode  *inode,
+    const void           *target,
+    int                   len,
+    demofs_bt_cb_t        cb,
+    void                 *private_data)
+{
+    struct demofs_bt_key key = { .type = DEMOFS_REC_SYMLINK, .subkey = 0 };
+
+    return demofs_bt_insert_async(op, thread, txn, inode, &key, target, len,
+                                  cb, private_data);
+} /* demofs_symlink_set_async */
+
+static int
 demofs_symlink_get(
     struct demofs_thread *thread,
     struct demofs_inode  *inode,
@@ -5298,31 +5315,23 @@ demofs_mknod_at(
 /* inode_stash[0] = parent (locked across child fetch) */
 
 static void
-demofs_remove_at_child_cb(
-    struct demofs_inode *inode,
-    int                  status,
+demofs_remove_at_removed_cb(
+    struct demofs_bt_op *op,
+    int                  result,
     void                *private_data)
 {
     struct chimera_vfs_request    *request = private_data;
     struct demofs_request_private *p       = request->plugin_data;
     struct demofs_thread          *thread  = p->thread;
     struct demofs_inode           *parent  = p->inode_stash[0];
-    uint64_t                       hash    = request->remove_at.name_hash;
+    struct demofs_inode           *inode   = p->inode_stash[1];
     struct timespec                now;
 
-    if (unlikely(status != CHIMERA_VFS_OK)) {
-        demofs_op_fail(request, p->txn, status);
-        return;
-    }
-
-    if (S_ISDIR(inode->mode) && inode->nlink > 2) {
-        demofs_op_fail(request, p->txn, CHIMERA_VFS_ENOTEMPTY);
-        return;
-    }
+    demofs_bt_op_free(thread, op);
 
     /* The dirent was located before the child fetch and the parent has been
      * write-locked throughout, so it must still be present. */
-    if (unlikely(demofs_dir_remove(thread, p->txn, parent, hash) != 1)) {
+    if (unlikely(result != 1)) {
         demofs_op_fail(request, p->txn, CHIMERA_VFS_ENOENT);
         return;
     }
@@ -5359,7 +5368,60 @@ demofs_remove_at_child_cb(
     demofs_map_attrs(thread, &request->remove_at.r_dir_post_attr, parent);
 
     demofs_op_ok(request, p->txn);
+} /* demofs_remove_at_removed_cb */
+
+static void
+demofs_remove_at_child_cb(
+    struct demofs_inode *inode,
+    int                  status,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+    struct demofs_thread          *thread  = p->thread;
+    uint64_t                       hash    = request->remove_at.name_hash;
+    struct demofs_bt_op           *op;
+
+    if (unlikely(status != CHIMERA_VFS_OK)) {
+        demofs_op_fail(request, p->txn, status);
+        return;
+    }
+
+    if (S_ISDIR(inode->mode) && inode->nlink > 2) {
+        demofs_op_fail(request, p->txn, CHIMERA_VFS_ENOTEMPTY);
+        return;
+    }
+
+    p->inode_stash[1] = inode;
+
+    op = demofs_bt_op_alloc(thread);
+    if (demofs_dir_remove_async(op, thread, p->txn, p->inode_stash[0], hash,
+                                demofs_remove_at_removed_cb, request)) {
+        demofs_remove_at_removed_cb(op, op->result, request);
+    }
 } /* demofs_remove_at_child_cb */
+
+static void
+demofs_remove_at_lookup_cb(
+    struct demofs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+    struct demofs_thread          *thread  = p->thread;
+    struct demofs_dirent_rec      *rec     = (struct demofs_dirent_rec *) p->rec_scratch;
+
+    demofs_bt_op_free(thread, op);
+
+    if (result < 0) {
+        demofs_op_fail(request, p->txn, CHIMERA_VFS_ENOENT);
+        return;
+    }
+
+    demofs_inode_get_inum_async(thread, p->txn, rec->inum, rec->gen,
+                                demofs_remove_at_child_cb, request);
+} /* demofs_remove_at_lookup_cb */
 
 static void
 demofs_remove_at_parent_cb(
@@ -5371,8 +5433,7 @@ demofs_remove_at_parent_cb(
     struct demofs_request_private *p       = request->plugin_data;
     struct demofs_thread          *thread  = p->thread;
     uint64_t                       hash    = request->remove_at.name_hash;
-    uint64_t                       child_inum;
-    uint32_t                       child_gen;
+    struct demofs_bt_op           *op;
 
     if (unlikely(status != CHIMERA_VFS_OK)) {
         demofs_op_fail(request, p->txn, status);
@@ -5386,14 +5447,14 @@ demofs_remove_at_parent_cb(
         return;
     }
 
-    if (demofs_dir_lookup(thread, parent, hash, &child_inum, &child_gen) != 0) {
-        demofs_op_fail(request, p->txn, CHIMERA_VFS_ENOENT);
-        return;
-    }
-
     p->inode_stash[0] = parent;
-    demofs_inode_get_inum_async(thread, p->txn, child_inum, child_gen,
-                                demofs_remove_at_child_cb, request);
+
+    op = demofs_bt_op_alloc(thread);
+    if (demofs_dir_lookup_async(op, thread, parent, hash, p->rec_scratch,
+                                sizeof(p->rec_scratch), demofs_remove_at_lookup_cb,
+                                request)) {
+        demofs_remove_at_lookup_cb(op, op->result, request);
+    }
 } /* demofs_remove_at_parent_cb */
 
 static void
@@ -7062,7 +7123,44 @@ demofs_seek(
                               demofs_seek_inode_cb, request);
 } /* demofs_seek */
 
-/* inode_stash[0] = parent (locked across alloc) */
+/* inode_stash[0] = parent (locked across alloc), inode_stash[1] = new symlink */
+
+static void
+demofs_symlink_at_dirent_cb(
+    struct demofs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+
+    (void) result;
+    demofs_bt_op_free(p->thread, op);
+    demofs_op_ok(request, p->txn);
+} /* demofs_symlink_at_dirent_cb */
+
+static void
+demofs_symlink_at_target_cb(
+    struct demofs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+    struct demofs_thread          *thread  = p->thread;
+    struct demofs_inode           *inode   = p->inode_stash[1];
+
+    (void) result;
+    demofs_bt_op_free(thread, op);
+
+    op = demofs_bt_op_alloc(thread);
+    if (demofs_dir_insert_async(op, thread, p->txn, p->inode_stash[0],
+                                request->symlink_at.name_hash, request->symlink_at.name,
+                                request->symlink_at.namelen, inode->inum, inode->gen,
+                                demofs_symlink_at_dirent_cb, request)) {
+        demofs_symlink_at_dirent_cb(op, op->result, request);
+    }
+} /* demofs_symlink_at_target_cb */
 
 static void
 demofs_symlink_at_alloc_cb(
@@ -7074,6 +7172,7 @@ demofs_symlink_at_alloc_cb(
     struct demofs_request_private *p       = request->plugin_data;
     struct demofs_thread          *thread  = p->thread;
     struct demofs_inode           *parent  = p->inode_stash[0];
+    struct demofs_bt_op           *op;
     struct timespec                now;
 
     if (unlikely(status != CHIMERA_VFS_OK)) {
@@ -7096,13 +7195,7 @@ demofs_symlink_at_alloc_cb(
     inode->ctime_sec  = now.tv_sec;
     inode->ctime_nsec = now.tv_nsec;
 
-    demofs_symlink_set(thread, p->txn, inode,
-                       request->symlink_at.target, request->symlink_at.targetlen);
     demofs_map_attrs(thread, &request->symlink_at.r_attr, inode);
-
-    demofs_dir_insert(thread, p->txn, parent, request->symlink_at.name_hash,
-                      request->symlink_at.name, request->symlink_at.namelen,
-                      inode->inum, inode->gen);
 
     parent->mtime_sec  = now.tv_sec;
     parent->mtime_nsec = now.tv_nsec;
@@ -7111,8 +7204,39 @@ demofs_symlink_at_alloc_cb(
 
     demofs_map_attrs(thread, &request->symlink_at.r_dir_post_attr, parent);
 
-    demofs_op_ok(request, p->txn);
+    /* Chain: insert the symlink target into the new inode's tree, then the
+     * dirent into the parent. */
+    p->inode_stash[1] = inode;
+
+    op = demofs_bt_op_alloc(thread);
+    if (demofs_symlink_set_async(op, thread, p->txn, inode,
+                                 request->symlink_at.target,
+                                 request->symlink_at.targetlen,
+                                 demofs_symlink_at_target_cb, request)) {
+        demofs_symlink_at_target_cb(op, op->result, request);
+    }
 } /* demofs_symlink_at_alloc_cb */
+
+static void
+demofs_symlink_at_check_cb(
+    struct demofs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+    struct demofs_thread          *thread  = p->thread;
+
+    demofs_bt_op_free(thread, op);
+
+    if (result >= 0) {
+        demofs_op_fail(request, p->txn, CHIMERA_VFS_EEXIST);
+        return;
+    }
+
+    demofs_map_attrs(thread, &request->symlink_at.r_dir_pre_attr, p->inode_stash[0]);
+    demofs_inode_alloc_async(thread, p->txn, demofs_symlink_at_alloc_cb, request);
+} /* demofs_symlink_at_check_cb */
 
 static void
 demofs_symlink_at_parent_cb(
@@ -7124,8 +7248,7 @@ demofs_symlink_at_parent_cb(
     struct demofs_request_private *p       = request->plugin_data;
     struct demofs_thread          *thread  = p->thread;
     uint64_t                       hash    = request->symlink_at.name_hash;
-    uint64_t                       existing_inum;
-    uint32_t                       existing_gen;
+    struct demofs_bt_op           *op;
 
     if (unlikely(status != CHIMERA_VFS_OK)) {
         demofs_op_fail(request, p->txn, status);
@@ -7137,16 +7260,14 @@ demofs_symlink_at_parent_cb(
         return;
     }
 
-    if (demofs_dir_lookup(thread, parent, hash, &existing_inum, &existing_gen) == 0) {
-        demofs_op_fail(request, p->txn, CHIMERA_VFS_EEXIST);
-        return;
-    }
-
-    demofs_map_attrs(thread, &request->symlink_at.r_dir_pre_attr, parent);
-
     p->inode_stash[0] = parent;
-    demofs_inode_alloc_async(thread, p->txn,
-                             demofs_symlink_at_alloc_cb, request);
+
+    op = demofs_bt_op_alloc(thread);
+    if (demofs_dir_lookup_async(op, thread, parent, hash, p->rec_scratch,
+                                sizeof(p->rec_scratch), demofs_symlink_at_check_cb,
+                                request)) {
+        demofs_symlink_at_check_cb(op, op->result, request);
+    }
 } /* demofs_symlink_at_parent_cb */
 
 static void
@@ -7568,6 +7689,20 @@ demofs_rename_at(
 /* inode_stash[0] = parent dir; inode_stash[1] = link target inode (both locked) */
 
 static void
+demofs_link_at_inserted_cb(
+    struct demofs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+
+    (void) result;
+    demofs_bt_op_free(p->thread, op);
+    demofs_op_ok(request, p->txn);
+} /* demofs_link_at_inserted_cb */
+
+static void
 demofs_link_at_finish(struct chimera_vfs_request *request)
 {
     struct demofs_request_private *p      = request->plugin_data;
@@ -7575,13 +7710,10 @@ demofs_link_at_finish(struct chimera_vfs_request *request)
     struct demofs_inode           *parent = p->inode_stash[0];
     struct demofs_inode           *inode  = p->inode_stash[1];
     uint64_t                       hash   = request->link_at.name_hash;
+    struct demofs_bt_op           *op;
     struct timespec                now;
 
     clock_gettime(CLOCK_REALTIME, &now);
-
-    demofs_dir_insert(thread, p->txn, parent, hash,
-                      request->link_at.name, request->link_at.namelen,
-                      inode->inum, inode->gen);
 
     inode->nlink++;
     inode->ctime_sec   = now.tv_sec;
@@ -7594,7 +7726,13 @@ demofs_link_at_finish(struct chimera_vfs_request *request)
     demofs_map_attrs(thread, &request->link_at.r_attr, inode);
     demofs_map_attrs(thread, &request->link_at.r_dir_post_attr, parent);
 
-    demofs_op_ok(request, p->txn);
+    op = demofs_bt_op_alloc(thread);
+    if (demofs_dir_insert_async(op, thread, p->txn, parent, hash,
+                                request->link_at.name, request->link_at.namelen,
+                                inode->inum, inode->gen, demofs_link_at_inserted_cb,
+                                request)) {
+        demofs_link_at_inserted_cb(op, op->result, request);
+    }
 } /* demofs_link_at_finish */
 
 static void
@@ -7617,6 +7755,56 @@ demofs_link_at_existing_cb(
     demofs_link_at_finish(request);
 } /* demofs_link_at_existing_cb */
 
+/* dir_remove of the replaced dirent completed; fetch the old inode to fix up
+ * its link count. */
+static void
+demofs_link_at_removed_cb(
+    struct demofs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+
+    (void) result;
+    demofs_bt_op_free(p->thread, op);
+    demofs_inode_get_inum_async(p->thread, p->txn, p->rd_inum, p->rd_gen,
+                                demofs_link_at_existing_cb, request);
+} /* demofs_link_at_removed_cb */
+
+static void
+demofs_link_at_check_cb(
+    struct demofs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+    struct demofs_thread          *thread  = p->thread;
+    struct demofs_dirent_rec      *rec     = (struct demofs_dirent_rec *) p->rec_scratch;
+    uint64_t                       hash    = request->link_at.name_hash;
+
+    demofs_bt_op_free(thread, op);
+
+    if (result >= 0) {
+        if (request->link_at.replace) {
+            p->rd_inum = rec->inum;
+            p->rd_gen  = rec->gen;
+
+            op = demofs_bt_op_alloc(thread);
+            if (demofs_dir_remove_async(op, thread, p->txn, p->inode_stash[0], hash,
+                                        demofs_link_at_removed_cb, request)) {
+                demofs_link_at_removed_cb(op, op->result, request);
+            }
+            return;
+        }
+        demofs_op_fail(request, p->txn, CHIMERA_VFS_EEXIST);
+        return;
+    }
+
+    demofs_link_at_finish(request);
+} /* demofs_link_at_check_cb */
+
 static void
 demofs_link_at_inode_cb(
     struct demofs_inode *inode,
@@ -7628,8 +7816,7 @@ demofs_link_at_inode_cb(
     struct demofs_thread          *thread  = p->thread;
     struct demofs_inode           *parent  = p->inode_stash[0];
     uint64_t                       hash    = request->link_at.name_hash;
-    uint64_t                       einum;
-    uint32_t                       egen;
+    struct demofs_bt_op           *op;
 
     if (unlikely(status != CHIMERA_VFS_OK)) {
         demofs_op_fail(request, p->txn, status);
@@ -7643,19 +7830,12 @@ demofs_link_at_inode_cb(
 
     p->inode_stash[1] = inode;
 
-    if (demofs_dir_lookup(thread, parent, hash, &einum, &egen) == 0) {
-        if (request->link_at.replace && !S_ISDIR(inode->mode)) {
-            demofs_dir_remove(thread, p->txn, parent, hash);
-
-            demofs_inode_get_inum_async(thread, p->txn, einum, egen,
-                                        demofs_link_at_existing_cb, request);
-            return;
-        }
-        demofs_op_fail(request, p->txn, CHIMERA_VFS_EEXIST);
-        return;
+    op = demofs_bt_op_alloc(thread);
+    if (demofs_dir_lookup_async(op, thread, parent, hash, p->rec_scratch,
+                                sizeof(p->rec_scratch), demofs_link_at_check_cb,
+                                request)) {
+        demofs_link_at_check_cb(op, op->result, request);
     }
-
-    demofs_link_at_finish(request);
 } /* demofs_link_at_inode_cb */
 
 static void

--- a/src/vfs/demofs/demofs.c
+++ b/src/vfs/demofs/demofs.c
@@ -27,6 +27,7 @@
 #include "vfs/vfs.h"
 #include "vfs/vfs_internal.h"
 #include "demofs.h"
+#include "space_map.h"
 #include "common/logging.h"
 #include "common/misc.h"
 #include "common/evpl_iovec_cursor.h"
@@ -80,6 +81,13 @@ struct demofs_request_private {
     uint32_t              read_prefix;
     uint32_t              read_suffix;
     struct demofs_thread *thread;        // Thread for tracking pending I/O
+    struct demofs_txn    *txn;           // Transaction wrapping this op
+    /* Multi-inode op scratch (lookup_at parent/child, rename's 4-inode
+     * chain, etc.).  Per-op semantics documented at use sites. */
+    struct demofs_inode  *inode_stash[4];
+    /* Small integer scratch for ops that need to carry state across
+     * async callbacks (mount path walker uses it as a path byte offset). */
+    uint32_t              op_scratch;
     struct evpl_iovec     iov[66];
 
     // For RMW (read-modify-write) on partial block writes
@@ -109,13 +117,6 @@ struct demofs_extent {
     struct demofs_extent *next;
 };
 
-struct demofs_freespace {
-    uint32_t                 device_id;
-    uint64_t                 length;
-    uint64_t                 offset;
-    struct demofs_freespace *next;
-};
-
 struct demofs_device {
     struct evpl_block_device *bdev;
     uint64_t                  id;
@@ -123,7 +124,6 @@ struct demofs_device {
     uint64_t                  max_request_size;
     char                      name[256];
     pthread_mutex_t           lock;
-    struct demofs_freespace  *free_space;
 };
 
 struct demofs_dirent {
@@ -204,10 +204,90 @@ struct demofs_inode_list {
     pthread_mutex_t       lock;
 };
 
+struct demofs_txn;
+struct demofs_txn_inode_ref;
+
+enum demofs_txn_type {
+    DEMOFS_TXN_READ,
+    DEMOFS_TXN_WRITE,
+};
+
+struct demofs_txn_inode_ref {
+    struct demofs_inode         *inode;
+    struct demofs_txn_inode_ref *next;
+};
+
+/* Commit completion callback.  Will be invoked exactly once per successful
+ * commit, with status 0 on success or a CHIMERA_VFS_* code on failure.
+ * Today commits never fail, but the signature is async-shaped so a future
+ * intent-log write can fail. */
+typedef void (*demofs_txn_commit_cb_t)(
+    struct demofs_txn *txn,
+    int                status,
+    void              *private_data);
+
+struct demofs_txn {
+    enum demofs_txn_type         type;
+    struct demofs_thread        *thread;
+    struct demofs_txn           *next;        /* per-thread free list link */
+    struct demofs_txn_inode_ref *refs;        /* pinned (locked) inodes */
+};
+
+/*
+ * Per-thread NVMe-style submission and completion queues used to hand
+ * write transactions off to the intent log thread and to receive commit
+ * completions back.  Each ring is single-producer / single-consumer:
+ *
+ *   sq:  worker (producer)        ->  intent log thread (consumer)
+ *   cq:  intent log thread (prod) ->  worker (consumer)
+ */
+#define DEMOFS_IQ_RING_SIZE 1024
+#define DEMOFS_IQ_RING_MASK (DEMOFS_IQ_RING_SIZE - 1)
+
+struct demofs_iq_entry {
+    struct demofs_txn     *txn;
+    demofs_txn_commit_cb_t cb;
+    void                  *private_data;
+    int                    status;
+};
+
+struct demofs_iq_ring {
+    /* Accessed via __atomic_* builtins. */
+    uint32_t               head;     /* consumer position */
+    uint32_t               tail;     /* producer position */
+    struct demofs_iq_entry entries[DEMOFS_IQ_RING_SIZE];
+};
+
+struct demofs_iq_channel {
+    struct demofs_iq_ring     sq;
+    struct demofs_iq_ring     cq;
+    struct evpl_doorbell      cq_doorbell;
+    struct demofs_thread     *worker;
+
+    /* Lifecycle: workers append on register, set flag on unregister.
+     * Intent log thread owns the slot array. */
+    struct demofs_iq_channel *next_pending;
+    int                       unregister_requested;
+    int                       unregister_done;
+};
+
+#define DEMOFS_IL_MAX_CHANNELS 256
+
+struct demofs_intent_log {
+    struct evpl_doorbell      wake_doorbell;
+    struct evpl              *evpl;
+    struct evpl_thread       *thread;
+    int                       ready;             /* atomic */
+    int                       shutdown;          /* atomic */
+    uint32_t                  num_channels;      /* slots[] count, intent log thread only */
+    struct demofs_iq_channel *channels[DEMOFS_IL_MAX_CHANNELS];
+    pthread_mutex_t           registration_lock;
+    struct demofs_iq_channel *pending_head;
+};
+
 struct demofs_shared {
     struct demofs_device     *devices;
     int                       num_devices;
-    int                       device_rotor;
     struct demofs_inode_list *inode_list;
     int                       num_inode_list;
     struct demofs_kv_shard   *kv_shards;
@@ -215,8 +295,9 @@ struct demofs_shared {
     int                       num_active_threads;
     uint8_t                   root_fh[CHIMERA_VFS_FH_SIZE];
     uint32_t                  root_fhlen;
-    uint64_t                  total_bytes;
     uint64_t                  fsid;
+    struct space_map         *space_map;
+    struct demofs_intent_log  intent_log;
     pthread_mutex_t           lock;
 };
 
@@ -228,8 +309,11 @@ struct demofs_thread {
     struct evpl_iovec         pad;
     int                       thread_id;
     struct slab_allocator    *allocator;
-    struct demofs_freespace  *freespace;
-    int                       pending_io;
+    struct sm_thread_cache    space_cache;
+    struct demofs_txn           *txn_free_list;
+    struct demofs_txn_inode_ref *txn_ref_free_list;
+    struct demofs_iq_channel    *iq_channel;
+    int                          pending_io;
 };
 
 static inline uint32_t
@@ -303,6 +387,135 @@ demofs_inode_get_fh(
 
     return demofs_inode_get_inum(shared, inum, gen);
 } /* demofs_inode_get_fh */
+
+/* ------------------------------------------------------------------ */
+/* Async inode-fetch / inode-alloc API                                 */
+/* ------------------------------------------------------------------ */
+
+typedef void (*demofs_inode_cb_t)(
+    struct demofs_inode *inode,
+    int                  status,
+    void                *private_data);
+
+static inline struct demofs_txn_inode_ref *
+demofs_txn_ref_alloc(struct demofs_thread *thread)
+{
+    struct demofs_txn_inode_ref *r = thread->txn_ref_free_list;
+
+    if (r) {
+        thread->txn_ref_free_list = r->next;
+    } else {
+        r = malloc(sizeof(*r));
+    }
+    return r;
+} /* demofs_txn_ref_alloc */
+
+static inline void
+demofs_txn_ref_release(
+    struct demofs_thread        *thread,
+    struct demofs_txn_inode_ref *r)
+{
+    r->next                   = thread->txn_ref_free_list;
+    thread->txn_ref_free_list = r;
+} /* demofs_txn_ref_release */
+
+/*
+ * Pin a locked inode into the transaction's ref list.  The inode must be
+ * locked by the caller; ownership of the lock passes to the txn, which
+ * drops it during commit or abort via demofs_txn_unlock_all().
+ */
+static inline void
+demofs_txn_pin_inode(
+    struct demofs_txn   *txn,
+    struct demofs_inode *inode)
+{
+    struct demofs_txn_inode_ref *r = demofs_txn_ref_alloc(txn->thread);
+
+    r->inode  = inode;
+    r->next   = txn->refs;
+    txn->refs = r;
+} /* demofs_txn_pin_inode */
+
+/*
+ * Release a single pinned inode early (e.g. readdir-style iteration that
+ * doesn't want every visited inode held until commit).  No-op if the
+ * inode isn't in the txn's ref list.
+ */
+static inline void
+demofs_txn_unlock_inode(
+    struct demofs_txn   *txn,
+    struct demofs_inode *inode)
+{
+    struct demofs_txn_inode_ref **pp = &txn->refs;
+    struct demofs_txn_inode_ref  *r;
+
+    while (*pp) {
+        if ((*pp)->inode == inode) {
+            r   = *pp;
+            *pp = r->next;
+            demofs_txn_ref_release(txn->thread, r);
+            return;
+        }
+        pp = &(*pp)->next;
+    }
+} /* demofs_txn_unlock_inode */
+
+/*
+ * Release every inode pinned by this txn.  Called by the worker thread for
+ * read-txn commits and aborts, and by the IL-side completion handler (on
+ * the worker thread, via CQE doorbell) for write-txn commits.
+ */
+static inline void
+demofs_txn_unlock_all(struct demofs_txn *txn)
+{
+    struct demofs_thread        *thread = txn->thread;
+    struct demofs_txn_inode_ref *r      = txn->refs;
+    struct demofs_txn_inode_ref *n;
+
+    txn->refs = NULL;
+    while (r) {
+        n = r->next;
+        pthread_mutex_unlock(&r->inode->lock);
+        demofs_txn_ref_release(thread, r);
+        r = n;
+    }
+} /* demofs_txn_unlock_all */
+
+static inline void
+demofs_inode_get_inum_async(
+    struct demofs_thread *thread,
+    struct demofs_txn    *txn,
+    uint64_t              inum,
+    uint32_t              gen,
+    demofs_inode_cb_t     cb,
+    void                 *private_data)
+{
+    struct demofs_inode *inode;
+
+    inode = demofs_inode_get_inum(thread->shared, inum, gen);
+    if (inode) {
+        demofs_txn_pin_inode(txn, inode);
+        cb(inode, CHIMERA_VFS_OK, private_data);
+    } else {
+        cb(NULL, CHIMERA_VFS_ENOENT, private_data);
+    }
+} /* demofs_inode_get_inum_async */
+
+static inline void
+demofs_inode_get_fh_async(
+    struct demofs_thread *thread,
+    struct demofs_txn    *txn,
+    const uint8_t        *fh,
+    int                   fhlen,
+    demofs_inode_cb_t     cb,
+    void                 *private_data)
+{
+    uint64_t inum;
+    uint32_t gen;
+
+    demofs_fh_to_inum(&inum, &gen, fh, fhlen);
+    demofs_inode_get_inum_async(thread, txn, inum, gen, cb, private_data);
+} /* demofs_inode_get_fh_async */
 
 static inline struct demofs_extent *
 demofs_extent_alloc(struct demofs_thread *thread)
@@ -441,6 +654,21 @@ demofs_inode_alloc_thread(struct demofs_thread *thread)
     return demofs_inode_alloc(thread, list_id);
 } /* demofs_inode_alloc */
 
+static inline void
+demofs_inode_alloc_async(
+    struct demofs_thread *thread,
+    struct demofs_txn    *txn,
+    demofs_inode_cb_t     cb,
+    void                 *private_data)
+{
+    struct demofs_inode *inode;
+
+    (void) txn;
+
+    inode = demofs_inode_alloc_thread(thread);
+    cb(inode, inode ? CHIMERA_VFS_OK : CHIMERA_VFS_ENOSPC, private_data);
+} /* demofs_inode_alloc_async */
+
 static void
 demofs_dirent_release(
     struct rb_node *node,
@@ -570,66 +798,327 @@ demofs_thread_alloc_space(
     uint64_t             *r_device_id,
     uint64_t             *r_device_offset)
 {
-    struct demofs_shared    *shared = thread->shared;
-    struct demofs_device    *device;
-    struct demofs_freespace *freespace;
-    uint64_t                 size;
-    uint64_t                 rsrv_size;
+    uint32_t dev_id;
+    int      rc;
 
-    size = (desired_size + 4095) & ~4095;
+    rc = space_map_alloc(thread->shared->space_map, &thread->space_cache,
+                         (uint64_t) desired_size, &dev_id, r_device_offset);
 
- again:
-
-    if (thread->freespace) {
-        freespace = thread->freespace;
-
-        if (freespace->length >= size) {
-            *r_device_id       = freespace->device_id;
-            *r_device_offset   = freespace->offset;
-            freespace->length -= size;
-            freespace->offset += size;
-            return 0;
-        }
-    }
-
-    if (!thread->freespace) {
-        thread->freespace = calloc(1, sizeof(*freespace));
-    }
-
-    pthread_mutex_lock(&shared->lock);
-
-    device = &shared->devices[shared->device_rotor];
-
-    shared->device_rotor++;
-    if (shared->device_rotor >= shared->num_devices) {
-        shared->device_rotor = 0;
-    }
-
-    thread->freespace->offset = device->free_space->offset;
-
-    rsrv_size = 1024 * 1024 * 1024;
-
-    if (device->free_space->length < rsrv_size) {
-        rsrv_size = device->free_space->length;
-    }
-
-    if (rsrv_size < size) {
-        pthread_mutex_unlock(&shared->lock);
+    if (rc != 0) {
         return CHIMERA_VFS_ENOSPC;
     }
 
-    thread->freespace->length    = rsrv_size;
-    thread->freespace->device_id = device->id;
+    *r_device_id = dev_id;
+    return 0;
+} /* demofs_thread_alloc_space */
 
-    device->free_space->length -= rsrv_size;
-    device->free_space->offset += rsrv_size;
+static inline void
+demofs_thread_free_space(
+    struct demofs_thread *thread,
+    uint32_t              device_id,
+    uint64_t              device_offset,
+    uint64_t              length)
+{
+    space_map_free(thread->shared->space_map, device_id, device_offset, length);
+} /* demofs_thread_free_space */
 
-    shared->total_bytes += rsrv_size;
+/* ------------------------------------------------------------------ */
+/* Transaction plumbing                                                */
+/* ------------------------------------------------------------------ */
 
-    pthread_mutex_unlock(&shared->lock);
+static inline struct demofs_txn *
+demofs_txn_begin(
+    struct demofs_thread *thread,
+    enum demofs_txn_type  type)
+{
+    struct demofs_txn *txn = thread->txn_free_list;
 
-    goto again;
-} /* demofs_freespace_alloc */
+    if (txn) {
+        thread->txn_free_list = txn->next;
+    } else {
+        txn = malloc(sizeof(*txn));
+    }
+
+    txn->type   = type;
+    txn->thread = thread;
+    txn->next   = NULL;
+    txn->refs   = NULL;
+    return txn;
+} /* demofs_txn_begin */
+
+static inline void
+demofs_txn_release(struct demofs_txn *txn)
+{
+    struct demofs_thread *thread = txn->thread;
+
+    txn->next             = thread->txn_free_list;
+    thread->txn_free_list = txn;
+} /* demofs_txn_release */
+
+static inline void
+demofs_txn_abort(struct demofs_txn *txn)
+{
+    /* Nothing to undo today; future intent records and deferred frees
+     * get discarded here. */
+    demofs_txn_unlock_all(txn);
+    demofs_txn_release(txn);
+} /* demofs_txn_abort */
+
+/* Synchronous commit today; placeholder for the intent log routing
+ * added in phase 3. */
+/* Forward decls — definition below. */
+static inline void demofs_txn_commit(
+    struct demofs_txn     *txn,
+    demofs_txn_commit_cb_t cb,
+    void                  *private_data);
+
+static void
+demofs_txn_request_complete_cb(
+    struct demofs_txn *txn,
+    int                status,
+    void              *private_data)
+{
+    struct chimera_vfs_request *request = private_data;
+
+    (void) txn;
+    if (status != 0 && request->status == CHIMERA_VFS_OK) {
+        request->status = status;
+    }
+    request->complete(request);
+} /* demofs_txn_request_complete_cb */
+
+/* Op-level helpers: every op ends with one of these. */
+static inline void
+demofs_op_fail(
+    struct chimera_vfs_request *request,
+    struct demofs_txn          *txn,
+    int                         status)
+{
+    request->status = status;
+    if (txn) {
+        demofs_txn_abort(txn);
+    }
+    request->complete(request);
+} /* demofs_op_fail */
+
+static inline void
+demofs_op_ok(
+    struct chimera_vfs_request *request,
+    struct demofs_txn          *txn)
+{
+    request->status = CHIMERA_VFS_OK;
+    if (txn) {
+        demofs_txn_commit(txn, demofs_txn_request_complete_cb, request);
+    } else {
+        request->complete(request);
+    }
+} /* demofs_op_ok */
+
+/* ------------------------------------------------------------------ */
+/* Intent log: SPSC ring helpers + doorbell callbacks + thread         */
+/* ------------------------------------------------------------------ */
+
+static void
+demofs_iq_process_channel(struct demofs_iq_channel *ch)
+{
+    uint32_t sq_head   = __atomic_load_n(&ch->sq.head, __ATOMIC_RELAXED);
+    uint32_t sq_tail   = __atomic_load_n(&ch->sq.tail, __ATOMIC_ACQUIRE);
+    int      processed = 0;
+
+    while (sq_head != sq_tail) {
+        struct demofs_iq_entry entry;
+        uint32_t               cq_tail, cq_head;
+
+        cq_tail = __atomic_load_n(&ch->cq.tail, __ATOMIC_RELAXED);
+        cq_head = __atomic_load_n(&ch->cq.head, __ATOMIC_ACQUIRE);
+        if (cq_tail - cq_head >= DEMOFS_IQ_RING_SIZE) {
+            /* CQ full -- defer until worker drains + pings. */
+            break;
+        }
+
+        entry = ch->sq.entries[sq_head & DEMOFS_IQ_RING_MASK];
+        sq_head++;
+        entry.status = 0;
+
+        ch->cq.entries[cq_tail & DEMOFS_IQ_RING_MASK] = entry;
+        __atomic_store_n(&ch->cq.tail, cq_tail + 1, __ATOMIC_RELEASE);
+
+        processed++;
+    }
+
+    if (processed > 0) {
+        __atomic_store_n(&ch->sq.head, sq_head, __ATOMIC_RELEASE);
+        evpl_ring_doorbell(&ch->cq_doorbell);
+    }
+} /* demofs_iq_process_channel */
+
+static void
+demofs_intent_log_drain_pending(struct demofs_intent_log *il)
+{
+    struct demofs_iq_channel *head, *ch;
+
+    pthread_mutex_lock(&il->registration_lock);
+    head             = il->pending_head;
+    il->pending_head = NULL;
+    pthread_mutex_unlock(&il->registration_lock);
+
+    while (head) {
+        ch               = head;
+        head             = ch->next_pending;
+        ch->next_pending = NULL;
+
+        chimera_demofs_abort_if(il->num_channels >= DEMOFS_IL_MAX_CHANNELS,
+                                "intent log: too many channels (%u >= %u)",
+                                il->num_channels, DEMOFS_IL_MAX_CHANNELS);
+        il->channels[il->num_channels++] = ch;
+    }
+} /* demofs_intent_log_drain_pending */
+
+static void
+demofs_intent_log_wake_cb(
+    struct evpl          *evpl,
+    struct evpl_doorbell *doorbell)
+{
+    struct demofs_intent_log *il = container_of(doorbell,
+                                                struct demofs_intent_log,
+                                                wake_doorbell);
+    uint32_t                  i;
+
+    (void) evpl;
+
+    demofs_intent_log_drain_pending(il);
+
+    /* Unregister pass: compact slots out (swap-with-tail). */
+    i = 0;
+    while (i < il->num_channels) {
+        struct demofs_iq_channel *ch = il->channels[i];
+
+        if (__atomic_load_n(&ch->unregister_requested, __ATOMIC_ACQUIRE)) {
+            uint32_t last = il->num_channels - 1;
+            if (i != last) {
+                il->channels[i] = il->channels[last];
+            }
+            il->channels[last] = NULL;
+            il->num_channels   = last;
+            __atomic_store_n(&ch->unregister_done, 1, __ATOMIC_RELEASE);
+            continue;     /* re-process index i (now a different channel) */
+        }
+        i++;
+    }
+
+    for (i = 0; i < il->num_channels; i++) {
+        demofs_iq_process_channel(il->channels[i]);
+    }
+} /* demofs_intent_log_wake_cb */
+
+static void
+demofs_iq_cq_doorbell_cb(
+    struct evpl          *evpl,
+    struct evpl_doorbell *doorbell)
+{
+    struct demofs_iq_channel *ch = container_of(doorbell,
+                                                struct demofs_iq_channel,
+                                                cq_doorbell);
+    uint32_t                  head    = __atomic_load_n(&ch->cq.head, __ATOMIC_RELAXED);
+    uint32_t                  tail    = __atomic_load_n(&ch->cq.tail, __ATOMIC_ACQUIRE);
+    int                       drained = 0;
+
+    (void) evpl;
+
+    while (head != tail) {
+        struct demofs_iq_entry entry = ch->cq.entries[head & DEMOFS_IQ_RING_MASK];
+        head++;
+        drained++;
+
+        /* Inode pins were released by the worker before SQ enqueue (see
+         * demofs_txn_commit). */
+        entry.cb(entry.txn, entry.status, entry.private_data);
+        demofs_txn_release(entry.txn);
+    }
+
+    if (drained > 0) {
+        __atomic_store_n(&ch->cq.head, head, __ATOMIC_RELEASE);
+        /* Wake the intent log thread in case it had deferred work on
+         * this channel because the CQ was full. */
+        evpl_ring_doorbell(&ch->worker->shared->intent_log.wake_doorbell);
+    }
+} /* demofs_iq_cq_doorbell_cb */
+
+static void *
+demofs_intent_log_thread_init(
+    struct evpl *evpl,
+    void        *private_data)
+{
+    struct demofs_intent_log *il = private_data;
+
+    il->evpl = evpl;
+    evpl_add_doorbell(evpl, &il->wake_doorbell, demofs_intent_log_wake_cb);
+    __atomic_store_n(&il->ready, 1, __ATOMIC_RELEASE);
+    return il;
+} /* demofs_intent_log_thread_init */
+
+static void
+demofs_intent_log_thread_shutdown(
+    struct evpl *evpl,
+    void        *private_data)
+{
+    struct demofs_intent_log *il = private_data;
+
+    /* By the time this runs the VFS layer has destroyed the worker
+     * threads, which freed their channels.  Just drop the doorbell. */
+    evpl_remove_doorbell(evpl, &il->wake_doorbell);
+} /* demofs_intent_log_thread_shutdown */
+
+static inline void
+demofs_txn_commit(
+    struct demofs_txn     *txn,
+    demofs_txn_commit_cb_t cb,
+    void                  *private_data)
+{
+    struct demofs_thread     *thread = txn->thread;
+    struct demofs_shared     *shared;
+    struct demofs_iq_channel *ch;
+    struct demofs_iq_entry   *slot;
+    uint32_t                  tail, head;
+
+    if (txn->type == DEMOFS_TXN_READ) {
+        /* Read txns don't need durability -- complete inline. */
+        demofs_txn_unlock_all(txn);
+        cb(txn, 0, private_data);
+        demofs_txn_release(txn);
+        return;
+    }
+
+    /* Release all pinned inode locks BEFORE the SQ enqueue.  Otherwise
+     * SQ-full backpressure (which spins via evpl_continue) could re-enter
+     * other op callbacks that want these locks and self-deadlock. */
+    demofs_txn_unlock_all(txn);
+
+    /* Write txn -> intent log thread via this worker's SQ.  Callback
+     * fires from the CQ doorbell back on the original worker thread. */
+    shared = thread->shared;
+    ch     = thread->iq_channel;
+
+    tail = __atomic_load_n(&ch->sq.tail, __ATOMIC_RELAXED);
+    head = __atomic_load_n(&ch->sq.head, __ATOMIC_ACQUIRE);
+
+    /* SQ-full backpressure: drain our own evpl so the CQ doorbell fires
+     * and the intent log thread gets a wake from cq_doorbell_cb. */
+    while (tail - head >= DEMOFS_IQ_RING_SIZE) {
+        evpl_continue(thread->evpl);
+        head = __atomic_load_n(&ch->sq.head, __ATOMIC_ACQUIRE);
+    }
+
+    slot               = &ch->sq.entries[tail & DEMOFS_IQ_RING_MASK];
+    slot->txn          = txn;
+    slot->cb           = cb;
+    slot->private_data = private_data;
+    slot->status       = 0;
+
+    __atomic_store_n(&ch->sq.tail, tail + 1, __ATOMIC_RELEASE);
+
+    evpl_ring_doorbell(&shared->intent_log.wake_doorbell);
+} /* demofs_txn_commit */
 
 static void *
 demofs_init(const char *cfgdata)
@@ -637,12 +1126,13 @@ demofs_init(const char *cfgdata)
     struct demofs_shared       *shared = calloc(1, sizeof(*shared));
     struct demofs_inode_list   *inode_list;
     struct demofs_device       *device;
-    struct demofs_freespace    *free_space;
     enum evpl_block_protocol_id protocol_id;
     const char                 *protocol_name, *device_path;
+    char                       *device0_path = NULL;
     int                         i, fd, rc;
     struct stat                 st;
     int64_t                     size;
+    uint64_t                   *device_sizes;
     json_t                     *cfg, *devices_cfg, *device_cfg;
     json_error_t                json_error;
 
@@ -698,12 +1188,9 @@ demofs_init(const char *cfgdata)
         chimera_demofs_info("Device %s size %lu max_request_size %lu",
                             device_path, device->size, device->max_request_size);
 
-        free_space            = calloc(1, sizeof(*free_space));
-        free_space->device_id = device->id;
-        free_space->offset    = 0;
-        free_space->length    = device->size;
-        free_space->next      = NULL;
-        device->free_space    = free_space;
+        if (i == 0) {
+            device0_path = strdup(device_path);
+        }
     }
 
     json_decref(cfg);
@@ -713,6 +1200,20 @@ demofs_init(const char *cfgdata)
 
     /* Generate a random 64-bit filesystem ID */
     shared->fsid = chimera_rand64();
+
+    device_sizes = calloc(shared->num_devices, sizeof(*device_sizes));
+    for (i = 0; i < shared->num_devices; i++) {
+        device_sizes[i] = shared->devices[i].size;
+    }
+    shared->space_map = space_map_create(device_sizes, shared->num_devices);
+    free(device_sizes);
+
+    rc = space_map_write_superblock_path(shared->space_map, device0_path,
+                                         shared->fsid);
+    chimera_demofs_abort_if(rc != 0,
+                            "Failed to write superblock to %s: %s",
+                            device0_path, strerror(errno));
+    free(device0_path);
 
     shared->num_inode_list = 255;
     shared->inode_list     = calloc(shared->num_inode_list,
@@ -740,8 +1241,25 @@ demofs_init(const char *cfgdata)
         pthread_mutex_init(&shared->kv_shards[i].lock, NULL);
     }
 
+    /* Bring up the intent log thread.  Spin until its init has registered
+     * the wake doorbell, since workers will start ringing it as soon as
+     * they begin processing requests. */
+    shared->intent_log.ready        = 0;
+    shared->intent_log.shutdown     = 0;
+    shared->intent_log.num_channels = 0;
+    shared->intent_log.pending_head = NULL;
+    pthread_mutex_init(&shared->intent_log.registration_lock, NULL);
+
+    shared->intent_log.thread = evpl_thread_create(NULL,
+                                                   demofs_intent_log_thread_init,
+                                                   demofs_intent_log_thread_shutdown,
+                                                   &shared->intent_log);
+    while (!__atomic_load_n(&shared->intent_log.ready, __ATOMIC_ACQUIRE)) {
+        /* spin briefly */
+    }
+
     return shared;
-} /* demofs_init */ /* demofs_init */
+} /* demofs_init */
 
 static void
 demofs_bootstrap(struct demofs_thread *thread)
@@ -789,11 +1307,9 @@ demofs_bootstrap(struct demofs_thread *thread)
 static void
 demofs_destroy(void *private_data)
 {
-    struct demofs_shared    *shared = private_data;
-    struct demofs_inode     *inode;
-    struct demofs_device    *device;
-    struct demofs_freespace *freespace;
-    int                      i, j, k;
+    struct demofs_shared *shared = private_data;
+    struct demofs_inode  *inode;
+    int                   i, j, k;
 
     for (i = 0; i < shared->num_inode_list; i++) {
         for (j = 0; j < shared->inode_list[i].num_blocks; j++) {
@@ -815,16 +1331,18 @@ demofs_destroy(void *private_data)
         }
     }
 
-    for (int i = 0; i < shared->num_devices; i++) {
-        device = &shared->devices[i];
-        evpl_block_close_device(shared->devices[i].bdev);
+    /* Shut down the intent log thread before tearing down anything it
+     * might still touch.  Worker threads have already unregistered their
+     * channels via the unregister handshake at this point. */
+    __atomic_store_n(&shared->intent_log.shutdown, 1, __ATOMIC_RELEASE);
+    evpl_thread_destroy(shared->intent_log.thread);
+    pthread_mutex_destroy(&shared->intent_log.registration_lock);
 
-        while (device->free_space) {
-            freespace = device->free_space;
-            LL_DELETE(device->free_space, freespace);
-            free(freespace);
-        }
+    for (int i = 0; i < shared->num_devices; i++) {
+        evpl_block_close_device(shared->devices[i].bdev);
     }
+
+    space_map_destroy(shared->space_map);
 
     pthread_mutex_destroy(&shared->lock);
     free(shared->devices);
@@ -863,9 +1381,25 @@ demofs_thread_init(
 
     thread->shared = shared;
     thread->evpl   = evpl;
+
+    /* Allocate this worker's intent-log channel and register the CQ
+     * doorbell on the worker's own evpl. */
+    thread->iq_channel         = calloc(1, sizeof(*thread->iq_channel));
+    thread->iq_channel->worker = thread;
+    evpl_add_doorbell(evpl, &thread->iq_channel->cq_doorbell,
+                      demofs_iq_cq_doorbell_cb);
+
     pthread_mutex_lock(&shared->lock);
     thread->thread_id = shared->num_active_threads++;
     pthread_mutex_unlock(&shared->lock);
+
+    /* Hand the channel to the intent log thread via the pending list. */
+    pthread_mutex_lock(&shared->intent_log.registration_lock);
+    thread->iq_channel->next_pending = shared->intent_log.pending_head;
+    shared->intent_log.pending_head  = thread->iq_channel;
+    pthread_mutex_unlock(&shared->intent_log.registration_lock);
+
+    evpl_ring_doorbell(&shared->intent_log.wake_doorbell);
 
     return thread;
 } /* demofs_thread_init */
@@ -895,8 +1429,35 @@ demofs_thread_destroy(void *private_data)
         evpl_block_close_queue(thread->evpl, thread->queue[i]);
     }
 
-    if (thread->freespace) {
-        free(thread->freespace);
+    space_map_thread_cache_return(shared->space_map, &thread->space_cache);
+
+    /* Unregister the intent-log channel.  Caller must have quiesced all
+     * in-flight VFS ops on this thread first. */
+    if (thread->iq_channel) {
+        struct demofs_iq_channel *ch = thread->iq_channel;
+
+        __atomic_store_n(&ch->unregister_requested, 1, __ATOMIC_RELEASE);
+        evpl_ring_doorbell(&shared->intent_log.wake_doorbell);
+
+        while (!__atomic_load_n(&ch->unregister_done, __ATOMIC_ACQUIRE)) {
+            /* spin */
+        }
+
+        evpl_remove_doorbell(thread->evpl, &ch->cq_doorbell);
+        free(ch);
+        thread->iq_channel = NULL;
+    }
+
+    while (thread->txn_free_list) {
+        struct demofs_txn *txn = thread->txn_free_list;
+        thread->txn_free_list = txn->next;
+        free(txn);
+    }
+
+    while (thread->txn_ref_free_list) {
+        struct demofs_txn_inode_ref *r = thread->txn_ref_free_list;
+        thread->txn_ref_free_list = r->next;
+        free(r);
     }
 
     free(thread->queue);
@@ -910,7 +1471,6 @@ demofs_map_attrs(
     struct demofs_inode      *inode)
 {
     struct demofs_shared *shared = thread->shared;
-    struct demofs_device *device;
 
     /* We always get attributes atomically with operations */
     attr->va_set_mask = CHIMERA_VFS_ATTR_ATOMIC;
@@ -946,26 +1506,13 @@ demofs_map_attrs(
 
     if (attr->va_req_mask & CHIMERA_VFS_ATTR_MASK_STATFS) {
         attr->va_set_mask      |= CHIMERA_VFS_ATTR_MASK_STATFS;
-        attr->va_fs_space_total = CHIMERA_VFS_SYNTHETIC_FS_BYTES;
-        attr->va_fs_space_used  = 0;
-        attr->va_fs_space_avail = CHIMERA_VFS_SYNTHETIC_FS_BYTES;
-        attr->va_fs_space_free  = CHIMERA_VFS_SYNTHETIC_FS_BYTES;
+        attr->va_fs_space_total = space_map_total_capacity(shared->space_map);
+        attr->va_fs_space_used  = space_map_used_bytes(shared->space_map);
+        attr->va_fs_space_free  = attr->va_fs_space_total - attr->va_fs_space_used;
+        attr->va_fs_space_avail = attr->va_fs_space_free;
         attr->va_fs_files_total = CHIMERA_VFS_SYNTHETIC_FS_INODES;
         attr->va_fs_files_avail = CHIMERA_VFS_SYNTHETIC_FS_INODES;
         attr->va_fs_files_free  = CHIMERA_VFS_SYNTHETIC_FS_INODES;
-
-        pthread_mutex_lock(&shared->lock);
-
-        for (int i = 0; i < shared->num_devices; i++) {
-            device                   = &shared->devices[i];
-            attr->va_fs_space_total += device->size;
-        }
-
-        attr->va_fs_space_used  = shared->total_bytes;
-        attr->va_fs_space_free  = attr->va_fs_space_total - attr->va_fs_space_used;
-        attr->va_fs_space_avail = attr->va_fs_space_free;
-
-        pthread_mutex_unlock(&shared->lock);
 
         for (int i = 0; i < shared->num_inode_list; i++) {
             pthread_mutex_lock(&shared->inode_list[i].lock);
@@ -1040,47 +1587,59 @@ demofs_apply_attrs(
 } /* demofs_apply_attrs */
 
 static void
+demofs_getattr_inode_cb(
+    struct demofs_inode *inode,
+    int                  status,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+
+    if (unlikely(status != CHIMERA_VFS_OK)) {
+        demofs_op_fail(request, p->txn, status);
+        return;
+    }
+
+    demofs_map_attrs(p->thread, &request->getattr.r_attr, inode);
+
+    demofs_op_ok(request, p->txn);
+} /* demofs_getattr_inode_cb */
+
+static void
 demofs_getattr(
     struct demofs_thread       *thread,
     struct demofs_shared       *shared,
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
-    struct chimera_vfs_attrs *attr = &request->getattr.r_attr;
-    struct demofs_inode      *inode;
+    struct demofs_request_private *p = request->plugin_data;
 
-    inode = demofs_inode_get_fh(shared, request->fh, request->fh_len);
+    (void) shared;
+    (void) private_data;
 
-    if (unlikely(!inode)) {
-        request->status = CHIMERA_VFS_ENOENT;
-        request->complete(request);
-        return;
-    }
+    p->thread = thread;
+    p->txn    = demofs_txn_begin(thread, DEMOFS_TXN_READ);
 
-    demofs_map_attrs(thread, attr, inode);
-
-    pthread_mutex_unlock(&inode->lock);
-
-    request->status = CHIMERA_VFS_OK;
-    request->complete(request);
+    demofs_inode_get_fh_async(thread, p->txn,
+                              request->fh, request->fh_len,
+                              demofs_getattr_inode_cb, request);
 } /* demofs_getattr */
 
 static void
-demofs_setattr(
-    struct demofs_thread       *thread,
-    struct demofs_shared       *shared,
-    struct chimera_vfs_request *request,
-    void                       *private_data)
+demofs_setattr_inode_cb(
+    struct demofs_inode *inode,
+    int                  status,
+    void                *private_data)
 {
-    struct demofs_inode *inode;
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+    struct demofs_thread          *thread  = p->thread;
 
-    inode = demofs_inode_get_fh(shared, request->fh, request->fh_len);
-
-    if (unlikely(!inode)) {
-        request->status = CHIMERA_VFS_ENOENT;
-        request->complete(request);
+    if (unlikely(status != CHIMERA_VFS_OK)) {
+        demofs_op_fail(request, p->txn, status);
         return;
     }
+
     demofs_map_attrs(thread, &request->setattr.r_pre_attr, inode);
 
     /* Handle truncation: remove/trim extents past new EOF */
@@ -1091,12 +1650,9 @@ demofs_setattr(
         uint64_t              new_size = request->setattr.set_attr->va_size;
         struct demofs_extent *extent, *next_extent;
 
-        /* Find first extent that could be affected */
         rb_tree_query_floor(&inode->file.extents, new_size, file_offset, extent);
 
         if (!extent) {
-            /* No extent at or before new_size - get the first extent
-             * in case there's one that starts past new_size */
             rb_tree_first(&inode->file.extents, extent);
         }
 
@@ -1106,13 +1662,23 @@ demofs_setattr(
 
             next_extent = rb_tree_next(&inode->file.extents, extent);
 
-            /* Remove extents that are completely past new EOF */
             if (extent_start >= new_size) {
+                demofs_thread_free_space(thread, extent->device_id,
+                                         extent->device_offset,
+                                         SM_ALIGN_UP(extent->length));
                 rb_tree_remove(&inode->file.extents, &extent->node);
                 demofs_extent_free(thread, extent);
             } else if (extent_end > new_size) {
-                /* Trim extent that straddles new EOF */
-                extent->length = new_size - extent_start;
+                uint64_t old_aligned = SM_ALIGN_UP(extent->length);
+                uint64_t new_logical = new_size - extent_start;
+                uint64_t new_aligned = SM_ALIGN_UP(new_logical);
+
+                if (old_aligned > new_aligned) {
+                    demofs_thread_free_space(thread, extent->device_id,
+                                             extent->device_offset + new_aligned,
+                                             old_aligned - new_aligned);
+                }
+                extent->length = new_logical;
             }
 
             extent = next_extent;
@@ -1120,13 +1686,30 @@ demofs_setattr(
     }
 
     demofs_apply_attrs(inode, request->setattr.set_attr);
-
     demofs_map_attrs(thread, &request->setattr.r_post_attr, inode);
 
-    pthread_mutex_unlock(&inode->lock);
 
-    request->status = CHIMERA_VFS_OK;
-    request->complete(request);
+    demofs_op_ok(request, p->txn);
+} /* demofs_setattr_inode_cb */
+
+static void
+demofs_setattr(
+    struct demofs_thread       *thread,
+    struct demofs_shared       *shared,
+    struct chimera_vfs_request *request,
+    void                       *private_data)
+{
+    struct demofs_request_private *p = request->plugin_data;
+
+    (void) shared;
+    (void) private_data;
+
+    p->thread = thread;
+    p->txn    = demofs_txn_begin(thread, DEMOFS_TXN_WRITE);
+
+    demofs_inode_get_fh_async(thread, p->txn,
+                              request->fh, request->fh_len,
+                              demofs_setattr_inode_cb, request);
 } /* demofs_setattr */
 
 static inline struct demofs_inode *
@@ -1187,6 +1770,10 @@ demofs_lookup_path(
 
         pthread_mutex_unlock(&parent->lock);
 
+        if (!inode) {
+            return NULL;
+        }
+
         if (!S_ISDIR(inode->mode)) {
             pthread_mutex_unlock(&inode->lock);
             return NULL;
@@ -1205,22 +1792,30 @@ demofs_mount(
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
-    struct demofs_inode *inode;
+    struct demofs_request_private *p = request->plugin_data;
+    struct demofs_inode           *inode;
 
-    inode = demofs_lookup_path(thread, shared, request->mount.path, request->mount.pathlen);
+    (void) private_data;
+
+    p->thread = thread;
+    p->txn    = demofs_txn_begin(thread, DEMOFS_TXN_READ);
+
+    /* demofs_lookup_path is still synchronous; it'll be converted to an
+     * async path-walker when the inode cache lands. */
+    inode = demofs_lookup_path(thread, shared, request->mount.path,
+                               request->mount.pathlen);
 
     if (unlikely(!inode)) {
-        request->status = CHIMERA_VFS_ENOENT;
-        request->complete(request);
+        demofs_op_fail(request, p->txn, CHIMERA_VFS_ENOENT);
         return;
     }
 
+    /* demofs_lookup_path returns a locked inode; pin it so the txn
+     * commit handles the unlock centrally. */
+    demofs_txn_pin_inode(p->txn, inode);
     demofs_map_attrs(thread, &request->mount.r_attr, inode);
 
-    pthread_mutex_unlock(&inode->lock);
-
-    request->status = CHIMERA_VFS_OK;
-    request->complete(request);
+    demofs_op_ok(request, p->txn);
 } /* demofs_mount */
 
 static void
@@ -1230,10 +1825,91 @@ demofs_umount(
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
-    /* No action required */
-    request->status = CHIMERA_VFS_OK;
-    request->complete(request);
+    struct demofs_request_private *p = request->plugin_data;
+
+    (void) shared;
+    (void) private_data;
+
+    p->thread = thread;
+    p->txn    = demofs_txn_begin(thread, DEMOFS_TXN_READ);
+    demofs_op_ok(request, p->txn);
 } /* demofs_umount */
+
+/* inode_stash[0] = parent dir (locked across child fetch) */
+
+static void
+demofs_lookup_at_child_cb(
+    struct demofs_inode *child,
+    int                  status,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+
+    if (unlikely(status != CHIMERA_VFS_OK)) {
+        demofs_op_fail(request, p->txn, status);
+        return;
+    }
+
+    demofs_map_attrs(p->thread, &request->lookup_at.r_attr, child);
+
+    demofs_op_ok(request, p->txn);
+} /* demofs_lookup_at_child_cb */
+
+static void
+demofs_lookup_at_parent_cb(
+    struct demofs_inode *parent,
+    int                  status,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+    struct demofs_thread          *thread  = p->thread;
+    struct demofs_dirent          *dirent;
+    const char                    *name    = request->lookup_at.component;
+    uint32_t                       namelen = request->lookup_at.component_len;
+    uint64_t                       hash    = request->lookup_at.component_hash;
+
+    if (unlikely(status != CHIMERA_VFS_OK)) {
+        demofs_op_fail(request, p->txn, status);
+        return;
+    }
+
+    if (unlikely(!S_ISDIR(parent->mode))) {
+        enum chimera_vfs_error err = S_ISLNK(parent->mode) ?
+            CHIMERA_VFS_ESYMLINK : CHIMERA_VFS_ENOTDIR;
+        demofs_op_fail(request, p->txn, err);
+        return;
+    }
+
+    demofs_map_attrs(thread, &request->lookup_at.r_dir_attr, parent);
+
+    if (namelen == 1 && name[0] == '.') {
+        demofs_map_attrs(thread, &request->lookup_at.r_attr, parent);
+        demofs_op_ok(request, p->txn);
+        return;
+    }
+
+    p->inode_stash[0] = parent;
+
+    if (namelen == 2 && name[0] == '.' && name[1] == '.') {
+        demofs_inode_get_inum_async(thread, p->txn,
+                                    parent->dir.parent_inum,
+                                    parent->dir.parent_gen,
+                                    demofs_lookup_at_child_cb, request);
+        return;
+    }
+
+    rb_tree_query_exact(&parent->dir.dirents, hash, hash, dirent);
+
+    if (!dirent) {
+        demofs_op_fail(request, p->txn, CHIMERA_VFS_ENOENT);
+        return;
+    }
+
+    demofs_inode_get_inum_async(thread, p->txn, dirent->inum, dirent->gen,
+                                demofs_lookup_at_child_cb, request);
+} /* demofs_lookup_at_parent_cb */
 
 static void
 demofs_lookup_at(
@@ -1242,97 +1918,58 @@ demofs_lookup_at(
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
-    struct demofs_inode  *inode, *child;
-    struct demofs_dirent *dirent;
-    uint64_t              hash;
-    const char           *name    = request->lookup_at.component;
-    uint32_t              namelen = request->lookup_at.component_len;
+    struct demofs_request_private *p = request->plugin_data;
 
-    hash = request->lookup_at.component_hash;
+    (void) shared;
+    (void) private_data;
 
-    inode = demofs_inode_get_fh(shared, request->fh, request->fh_len);
+    p->thread = thread;
+    p->txn    = demofs_txn_begin(thread, DEMOFS_TXN_READ);
 
-    if (unlikely(!inode)) {
-        request->status = CHIMERA_VFS_ENOENT;
-        request->complete(request);
-        return;
-    }
-
-    if (unlikely(!S_ISDIR(inode->mode))) {
-        enum chimera_vfs_error err = S_ISLNK(inode->mode) ? CHIMERA_VFS_ESYMLINK : CHIMERA_VFS_ENOTDIR;
-        pthread_mutex_unlock(&inode->lock);
-        request->status = err;
-        request->complete(request);
-        return;
-    }
-
-    demofs_map_attrs(thread, &request->lookup_at.r_dir_attr, inode);
-
-    /* Handle "." - return the directory itself */
-    if (namelen == 1 && name[0] == '.') {
-        demofs_map_attrs(thread, &request->lookup_at.r_attr, inode);
-        pthread_mutex_unlock(&inode->lock);
-        request->status = CHIMERA_VFS_OK;
-        request->complete(request);
-        return;
-    }
-
-    /* Handle ".." - return the parent directory */
-    if (namelen == 2 && name[0] == '.' && name[1] == '.') {
-        child = demofs_inode_get_inum(shared, inode->dir.parent_inum, inode->dir.parent_gen);
-        if (unlikely(!child)) {
-            pthread_mutex_unlock(&inode->lock);
-            request->status = CHIMERA_VFS_ENOENT;
-            request->complete(request);
-            return;
-        }
-        demofs_map_attrs(thread, &request->lookup_at.r_attr, child);
-        pthread_mutex_unlock(&child->lock);
-        pthread_mutex_unlock(&inode->lock);
-        request->status = CHIMERA_VFS_OK;
-        request->complete(request);
-        return;
-    }
-
-    rb_tree_query_exact(&inode->dir.dirents, hash, hash, dirent);
-
-    if (!dirent) {
-        pthread_mutex_unlock(&inode->lock);
-        request->status = CHIMERA_VFS_ENOENT;
-        request->complete(request);
-        return;
-    }
-
-    child = demofs_inode_get_inum(shared, dirent->inum, dirent->gen);
-
-    demofs_map_attrs(thread, &request->lookup_at.r_attr, child);
-
-    pthread_mutex_unlock(&child->lock);
-
-    pthread_mutex_unlock(&inode->lock);
-
-    request->status = CHIMERA_VFS_OK;
-    request->complete(request);
+    demofs_inode_get_fh_async(thread, p->txn,
+                              request->fh, request->fh_len,
+                              demofs_lookup_at_parent_cb, request);
 } /* demofs_lookup_at */
 
+/* inode_stash[0] = parent (locked across alloc / existing-inode fetch) */
+
 static void
-demofs_mkdir_at(
-    struct demofs_thread       *thread,
-    struct demofs_shared       *shared,
-    struct chimera_vfs_request *request,
-    void                       *private_data)
+demofs_mkdir_at_existing_cb(
+    struct demofs_inode *existing_inode,
+    int                  status,
+    void                *private_data)
 {
-    struct demofs_inode  *parent_inode, *inode, *existing_inode;
-    struct demofs_dirent *dirent, *existing_dirent;
-    uint64_t              hash;
-    struct timespec       now;
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+    struct demofs_inode           *parent  = p->inode_stash[0];
+
+    if (likely(status == CHIMERA_VFS_OK)) {
+        demofs_map_attrs(p->thread, &request->mkdir_at.r_attr, existing_inode);
+    }
+    demofs_map_attrs(p->thread, &request->mkdir_at.r_dir_post_attr, parent);
+
+    demofs_op_fail(request, p->txn, CHIMERA_VFS_EEXIST);
+} /* demofs_mkdir_at_existing_cb */
+
+static void
+demofs_mkdir_at_alloc_cb(
+    struct demofs_inode *inode,
+    int                  status,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+    struct demofs_thread          *thread  = p->thread;
+    struct demofs_inode           *parent  = p->inode_stash[0];
+    struct demofs_dirent          *dirent;
+    struct timespec                now;
+
+    if (unlikely(status != CHIMERA_VFS_OK)) {
+        demofs_op_fail(request, p->txn, status);
+        return;
+    }
 
     clock_gettime(CLOCK_REALTIME, &now);
-
-    hash = request->mkdir_at.name_hash;
-
-    /* Optimistically allocate an inode */
-    inode = demofs_inode_alloc_thread(thread);
 
     inode->size       = 4096;
     inode->space_used = 4096;
@@ -1348,96 +1985,128 @@ demofs_mkdir_at(
     inode->ctime_nsec = now.tv_nsec;
 
     rb_tree_init(&inode->dir.dirents);
-
-    /* Parent will be set after we validate parent_inode */
+    inode->dir.parent_inum = parent->inum;
+    inode->dir.parent_gen  = parent->gen;
 
     demofs_apply_attrs(inode, request->mkdir_at.set_attr);
-
     demofs_map_attrs(thread, &request->mkdir_at.r_attr, inode);
 
-    /* Optimistically allocate a dirent */
-    dirent = demofs_dirent_alloc(thread,
-                                 inode->inum,
-                                 inode->gen,
-                                 hash,
+    dirent = demofs_dirent_alloc(thread, inode->inum, inode->gen,
+                                 request->mkdir_at.name_hash,
                                  request->mkdir_at.name,
                                  request->mkdir_at.name_len);
+    rb_tree_insert(&parent->dir.dirents, hash, dirent);
 
-    parent_inode = demofs_inode_get_fh(shared, request->fh, request->fh_len);
+    parent->nlink++;
+    parent->mtime_sec  = now.tv_sec;
+    parent->mtime_nsec = now.tv_nsec;
+    parent->ctime_sec  = now.tv_sec;
+    parent->ctime_nsec = now.tv_nsec;
 
-    if (unlikely(!parent_inode)) {
-        request->status = CHIMERA_VFS_ENOENT;
-        request->complete(request);
-        demofs_inode_free(thread, inode);
-        demofs_dirent_free(thread, dirent);
-        return;
-    }
+    demofs_map_attrs(thread, &request->mkdir_at.r_dir_post_attr, parent);
 
-    if (!S_ISDIR(parent_inode->mode)) {
-        pthread_mutex_unlock(&parent_inode->lock);
-        request->status = CHIMERA_VFS_ENOTDIR;
-        request->complete(request);
-        demofs_inode_free(thread, inode);
-        demofs_dirent_free(thread, dirent);
-        return;
-    }
-
-    demofs_map_attrs(thread, &request->mkdir_at.r_dir_pre_attr, parent_inode);
-
-    rb_tree_query_exact(&parent_inode->dir.dirents, hash, hash, existing_dirent);
-
-    if (existing_dirent) {
-        existing_inode = demofs_inode_get_inum(shared, existing_dirent->inum, existing_dirent->gen);
-        demofs_map_attrs(thread, &request->mkdir_at.r_attr, existing_inode);
-        demofs_map_attrs(thread, &request->mkdir_at.r_dir_post_attr, parent_inode);
-        pthread_mutex_unlock(&existing_inode->lock);
-        pthread_mutex_unlock(&parent_inode->lock);
-        request->status = CHIMERA_VFS_EEXIST;
-        request->complete(request);
-        demofs_inode_free(thread, inode);
-        demofs_dirent_free(thread, dirent);
-        return;
-    }
-
-    /* Set parent pointer for ".." lookup support */
-    inode->dir.parent_inum = parent_inode->inum;
-    inode->dir.parent_gen  = parent_inode->gen;
-
-    rb_tree_insert(&parent_inode->dir.dirents, hash, dirent);
-
-    parent_inode->nlink++;
-
-    parent_inode->mtime_sec  = now.tv_sec;
-    parent_inode->mtime_nsec = now.tv_nsec;
-    parent_inode->ctime_sec  = now.tv_sec;
-    parent_inode->ctime_nsec = now.tv_nsec;
-
-    demofs_map_attrs(thread, &request->mkdir_at.r_dir_post_attr, parent_inode);
-
-    pthread_mutex_unlock(&parent_inode->lock);
-
-    request->status = CHIMERA_VFS_OK;
-    request->complete(request);
-} /* demofs_mkdir_at */
+    demofs_op_ok(request, p->txn);
+} /* demofs_mkdir_at_alloc_cb */
 
 static void
-demofs_mknod_at(
+demofs_mkdir_at_parent_cb(
+    struct demofs_inode *parent,
+    int                  status,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+    struct demofs_thread          *thread  = p->thread;
+    struct demofs_dirent          *existing_dirent;
+    uint64_t                       hash = request->mkdir_at.name_hash;
+
+    if (unlikely(status != CHIMERA_VFS_OK)) {
+        demofs_op_fail(request, p->txn, status);
+        return;
+    }
+
+    if (!S_ISDIR(parent->mode)) {
+        demofs_op_fail(request, p->txn, CHIMERA_VFS_ENOTDIR);
+        return;
+    }
+
+    demofs_map_attrs(thread, &request->mkdir_at.r_dir_pre_attr, parent);
+
+    rb_tree_query_exact(&parent->dir.dirents, hash, hash, existing_dirent);
+
+    p->inode_stash[0] = parent;
+
+    if (existing_dirent) {
+        demofs_inode_get_inum_async(thread, p->txn,
+                                    existing_dirent->inum,
+                                    existing_dirent->gen,
+                                    demofs_mkdir_at_existing_cb, request);
+        return;
+    }
+
+    demofs_inode_alloc_async(thread, p->txn,
+                             demofs_mkdir_at_alloc_cb, request);
+} /* demofs_mkdir_at_parent_cb */
+
+static void
+demofs_mkdir_at(
     struct demofs_thread       *thread,
     struct demofs_shared       *shared,
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
-    struct demofs_inode  *parent_inode, *inode, *existing_inode;
-    struct demofs_dirent *dirent, *existing_dirent;
-    uint64_t              hash;
-    struct timespec       now;
+    struct demofs_request_private *p = request->plugin_data;
+
+    (void) shared;
+    (void) private_data;
+
+    p->thread = thread;
+    p->txn    = demofs_txn_begin(thread, DEMOFS_TXN_WRITE);
+
+    demofs_inode_get_fh_async(thread, p->txn,
+                              request->fh, request->fh_len,
+                              demofs_mkdir_at_parent_cb, request);
+} /* demofs_mkdir_at */
+
+/* inode_stash[0] = parent (locked across alloc / existing fetch) */
+
+static void
+demofs_mknod_at_existing_cb(
+    struct demofs_inode *existing_inode,
+    int                  status,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+    struct demofs_inode           *parent  = p->inode_stash[0];
+
+    if (likely(status == CHIMERA_VFS_OK)) {
+        demofs_map_attrs(p->thread, &request->mknod_at.r_attr, existing_inode);
+    }
+    demofs_map_attrs(p->thread, &request->mknod_at.r_dir_post_attr, parent);
+
+    demofs_op_fail(request, p->txn, CHIMERA_VFS_EEXIST);
+} /* demofs_mknod_at_existing_cb */
+
+static void
+demofs_mknod_at_alloc_cb(
+    struct demofs_inode *inode,
+    int                  status,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+    struct demofs_thread          *thread  = p->thread;
+    struct demofs_inode           *parent  = p->inode_stash[0];
+    struct demofs_dirent          *dirent;
+    struct timespec                now;
+
+    if (unlikely(status != CHIMERA_VFS_OK)) {
+        demofs_op_fail(request, p->txn, status);
+        return;
+    }
 
     clock_gettime(CLOCK_REALTIME, &now);
-
-    hash = request->mknod_at.name_hash;
-
-    /* Optimistically allocate an inode */
-    inode = demofs_inode_alloc_thread(thread);
 
     inode->size       = 0;
     inode->space_used = 0;
@@ -1452,149 +2121,133 @@ demofs_mknod_at(
     inode->ctime_sec  = now.tv_sec;
     inode->ctime_nsec = now.tv_nsec;
 
-    /* Set mode (including file type bits) and rdev from set_attr */
     if (request->mknod_at.set_attr->va_set_mask & CHIMERA_VFS_ATTR_MODE) {
         inode->mode = request->mknod_at.set_attr->va_mode;
     } else {
         inode->mode = S_IFREG | 0644;
     }
-
     if (request->mknod_at.set_attr->va_set_mask & CHIMERA_VFS_ATTR_RDEV) {
         inode->rdev = request->mknod_at.set_attr->va_rdev;
     }
 
     demofs_apply_attrs(inode, request->mknod_at.set_attr);
-
     demofs_map_attrs(thread, &request->mknod_at.r_attr, inode);
 
-    /* Optimistically allocate a dirent */
-    dirent = demofs_dirent_alloc(thread,
-                                 inode->inum,
-                                 inode->gen,
-                                 hash,
+    dirent = demofs_dirent_alloc(thread, inode->inum, inode->gen,
+                                 request->mknod_at.name_hash,
                                  request->mknod_at.name,
                                  request->mknod_at.name_len);
+    rb_tree_insert(&parent->dir.dirents, hash, dirent);
 
-    parent_inode = demofs_inode_get_fh(shared, request->fh, request->fh_len);
+    parent->mtime_sec  = now.tv_sec;
+    parent->mtime_nsec = now.tv_nsec;
+    parent->ctime_sec  = now.tv_sec;
+    parent->ctime_nsec = now.tv_nsec;
 
-    if (unlikely(!parent_inode)) {
-        request->status = CHIMERA_VFS_ENOENT;
-        request->complete(request);
-        demofs_inode_free(thread, inode);
-        demofs_dirent_free(thread, dirent);
-        return;
-    }
+    demofs_map_attrs(thread, &request->mknod_at.r_dir_post_attr, parent);
 
-    if (!S_ISDIR(parent_inode->mode)) {
-        pthread_mutex_unlock(&parent_inode->lock);
-        request->status = CHIMERA_VFS_ENOTDIR;
-        request->complete(request);
-        demofs_inode_free(thread, inode);
-        demofs_dirent_free(thread, dirent);
-        return;
-    }
-
-    demofs_map_attrs(thread, &request->mknod_at.r_dir_pre_attr, parent_inode);
-
-    rb_tree_query_exact(&parent_inode->dir.dirents, hash, hash, existing_dirent);
-
-    if (existing_dirent) {
-        existing_inode = demofs_inode_get_inum(shared, existing_dirent->inum, existing_dirent->gen);
-        demofs_map_attrs(thread, &request->mknod_at.r_attr, existing_inode);
-        demofs_map_attrs(thread, &request->mknod_at.r_dir_post_attr, parent_inode);
-        pthread_mutex_unlock(&existing_inode->lock);
-        pthread_mutex_unlock(&parent_inode->lock);
-        request->status = CHIMERA_VFS_EEXIST;
-        request->complete(request);
-        demofs_inode_free(thread, inode);
-        demofs_dirent_free(thread, dirent);
-        return;
-    }
-
-    rb_tree_insert(&parent_inode->dir.dirents, hash, dirent);
-
-    parent_inode->mtime_sec  = now.tv_sec;
-    parent_inode->mtime_nsec = now.tv_nsec;
-    parent_inode->ctime_sec  = now.tv_sec;
-    parent_inode->ctime_nsec = now.tv_nsec;
-
-    demofs_map_attrs(thread, &request->mknod_at.r_dir_post_attr, parent_inode);
-
-    pthread_mutex_unlock(&parent_inode->lock);
-
-    request->status = CHIMERA_VFS_OK;
-    request->complete(request);
-} /* demofs_mknod_at */
+    demofs_op_ok(request, p->txn);
+} /* demofs_mknod_at_alloc_cb */
 
 static void
-demofs_remove_at(
+demofs_mknod_at_parent_cb(
+    struct demofs_inode *parent,
+    int                  status,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+    struct demofs_thread          *thread  = p->thread;
+    struct demofs_dirent          *existing_dirent;
+    uint64_t                       hash = request->mknod_at.name_hash;
+
+    if (unlikely(status != CHIMERA_VFS_OK)) {
+        demofs_op_fail(request, p->txn, status);
+        return;
+    }
+
+    if (!S_ISDIR(parent->mode)) {
+        demofs_op_fail(request, p->txn, CHIMERA_VFS_ENOTDIR);
+        return;
+    }
+
+    demofs_map_attrs(thread, &request->mknod_at.r_dir_pre_attr, parent);
+
+    rb_tree_query_exact(&parent->dir.dirents, hash, hash, existing_dirent);
+
+    p->inode_stash[0] = parent;
+
+    if (existing_dirent) {
+        demofs_inode_get_inum_async(thread, p->txn,
+                                    existing_dirent->inum,
+                                    existing_dirent->gen,
+                                    demofs_mknod_at_existing_cb, request);
+        return;
+    }
+
+    demofs_inode_alloc_async(thread, p->txn,
+                             demofs_mknod_at_alloc_cb, request);
+} /* demofs_mknod_at_parent_cb */
+
+static void
+demofs_mknod_at(
     struct demofs_thread       *thread,
     struct demofs_shared       *shared,
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
-    struct demofs_inode  *parent_inode, *inode;
-    struct demofs_dirent *dirent;
-    uint64_t              hash;
-    struct timespec       now;
+    struct demofs_request_private *p = request->plugin_data;
 
-    clock_gettime(CLOCK_REALTIME, &now);
+    (void) shared;
+    (void) private_data;
 
-    hash = request->remove_at.name_hash;
+    p->thread = thread;
+    p->txn    = demofs_txn_begin(thread, DEMOFS_TXN_WRITE);
 
-    parent_inode = demofs_inode_get_fh(shared, request->fh, request->fh_len);
+    demofs_inode_get_fh_async(thread, p->txn,
+                              request->fh, request->fh_len,
+                              demofs_mknod_at_parent_cb, request);
+} /* demofs_mknod_at */
 
-    if (unlikely(!parent_inode)) {
-        request->status = CHIMERA_VFS_ENOENT;
-        request->complete(request);
-        return;
-    }
+/* inode_stash[0] = parent (locked across child fetch) */
 
-    demofs_map_attrs(thread, &request->remove_at.r_dir_pre_attr, parent_inode);
+static void
+demofs_remove_at_child_cb(
+    struct demofs_inode *inode,
+    int                  status,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+    struct demofs_thread          *thread  = p->thread;
+    struct demofs_inode           *parent  = p->inode_stash[0];
+    struct demofs_dirent          *dirent;
+    uint64_t                       hash = request->remove_at.name_hash;
+    struct timespec                now;
 
-    if (!S_ISDIR(parent_inode->mode)) {
-        pthread_mutex_unlock(&parent_inode->lock);
-        request->status = CHIMERA_VFS_ENOTDIR;
-        request->complete(request);
-        return;
-    }
-
-    rb_tree_query_exact(&parent_inode->dir.dirents, hash, hash, dirent);
-
-    if (!dirent) {
-        pthread_mutex_unlock(&parent_inode->lock);
-        request->status = CHIMERA_VFS_ENOENT;
-        request->complete(request);
-        return;
-    }
-
-    inode = demofs_inode_get_inum(shared, dirent->inum, dirent->gen);
-
-    if (!inode) {
-        pthread_mutex_unlock(&parent_inode->lock);
-        request->status = CHIMERA_VFS_ENOENT;
-        request->complete(request);
+    if (unlikely(status != CHIMERA_VFS_OK)) {
+        demofs_op_fail(request, p->txn, status);
         return;
     }
 
     if (S_ISDIR(inode->mode) && inode->nlink > 2) {
-        pthread_mutex_unlock(&parent_inode->lock);
-        pthread_mutex_unlock(&inode->lock);
-        request->status = CHIMERA_VFS_ENOTEMPTY;
-        request->complete(request);
+        demofs_op_fail(request, p->txn, CHIMERA_VFS_ENOTEMPTY);
         return;
     }
 
+    rb_tree_query_exact(&parent->dir.dirents, hash, hash, dirent);
+
+    clock_gettime(CLOCK_REALTIME, &now);
+
     if (S_ISDIR(inode->mode)) {
-        parent_inode->nlink--;
+        parent->nlink--;
     }
+    parent->mtime_sec  = now.tv_sec;
+    parent->mtime_nsec = now.tv_nsec;
+    parent->ctime_sec  = now.tv_sec;
+    parent->ctime_nsec = now.tv_nsec;
 
-    parent_inode->mtime_sec  = now.tv_sec;
-    parent_inode->mtime_nsec = now.tv_nsec;
-    parent_inode->ctime_sec  = now.tv_sec;
-    parent_inode->ctime_nsec = now.tv_nsec;
-
-    rb_tree_remove(&parent_inode->dir.dirents, &dirent->node);
+    rb_tree_remove(&parent->dir.dirents, &dirent->node);
 
     if (S_ISDIR(inode->mode)) {
         inode->nlink = 0;
@@ -1610,21 +2263,72 @@ demofs_remove_at(
 
     if (inode->nlink == 0) {
         --inode->refcnt;
-
         if (inode->refcnt == 0) {
             demofs_inode_free(thread, inode);
         }
     }
 
-    demofs_map_attrs(thread, &request->remove_at.r_dir_post_attr, parent_inode);
-
-    pthread_mutex_unlock(&parent_inode->lock);
-    pthread_mutex_unlock(&inode->lock);
+    demofs_map_attrs(thread, &request->remove_at.r_dir_post_attr, parent);
 
     demofs_dirent_free(thread, dirent);
 
-    request->status = CHIMERA_VFS_OK;
-    request->complete(request);
+    demofs_op_ok(request, p->txn);
+} /* demofs_remove_at_child_cb */
+
+static void
+demofs_remove_at_parent_cb(
+    struct demofs_inode *parent,
+    int                  status,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+    struct demofs_thread          *thread  = p->thread;
+    struct demofs_dirent          *dirent;
+    uint64_t                       hash = request->remove_at.name_hash;
+
+    if (unlikely(status != CHIMERA_VFS_OK)) {
+        demofs_op_fail(request, p->txn, status);
+        return;
+    }
+
+    demofs_map_attrs(thread, &request->remove_at.r_dir_pre_attr, parent);
+
+    if (!S_ISDIR(parent->mode)) {
+        demofs_op_fail(request, p->txn, CHIMERA_VFS_ENOTDIR);
+        return;
+    }
+
+    rb_tree_query_exact(&parent->dir.dirents, hash, hash, dirent);
+
+    if (!dirent) {
+        demofs_op_fail(request, p->txn, CHIMERA_VFS_ENOENT);
+        return;
+    }
+
+    p->inode_stash[0] = parent;
+    demofs_inode_get_inum_async(thread, p->txn, dirent->inum, dirent->gen,
+                                demofs_remove_at_child_cb, request);
+} /* demofs_remove_at_parent_cb */
+
+static void
+demofs_remove_at(
+    struct demofs_thread       *thread,
+    struct demofs_shared       *shared,
+    struct chimera_vfs_request *request,
+    void                       *private_data)
+{
+    struct demofs_request_private *p = request->plugin_data;
+
+    (void) shared;
+    (void) private_data;
+
+    p->thread = thread;
+    p->txn    = demofs_txn_begin(thread, DEMOFS_TXN_WRITE);
+
+    demofs_inode_get_fh_async(thread, p->txn,
+                              request->fh, request->fh_len,
+                              demofs_remove_at_parent_cb, request);
 } /* demofs_remove_at */
 
 /*
@@ -1638,6 +2342,219 @@ demofs_remove_at(
 #define DEMOFS_COOKIE_DOTDOT 2
 #define DEMOFS_COOKIE_FIRST  3
 
+/*
+ * Readdir state machine.
+ *   inode_stash[0] = directory inode (locked for the whole iteration)
+ *   inode_stash[1] = (struct demofs_dirent *) cursor cast to void *
+ * r_cookie/r_eof on the request are updated as we go.
+ */
+
+static void demofs_readdir_iter_step(
+    struct chimera_vfs_request *request);
+
+static void
+demofs_readdir_complete(struct chimera_vfs_request *request)
+{
+    struct demofs_request_private *p     = request->plugin_data;
+    struct demofs_inode           *inode = p->inode_stash[0];
+
+    demofs_map_attrs(p->thread, &request->readdir.r_dir_attr, inode);
+    demofs_op_ok(request, p->txn);
+} /* demofs_readdir_complete */
+
+static void
+demofs_readdir_iter_inode_cb(
+    struct demofs_inode *dirent_inode,
+    int                  status,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+    struct demofs_thread          *thread  = p->thread;
+    struct demofs_inode           *inode   = p->inode_stash[0];
+    struct demofs_dirent          *dirent  = (struct demofs_dirent *) p->inode_stash[1];
+    struct chimera_vfs_attrs       attr;
+    int                            rc;
+
+    if (status != CHIMERA_VFS_OK) {
+        /* Stale dirent — skip. */
+        p->inode_stash[1] = (struct demofs_inode *) rb_tree_next(&inode->dir.dirents, dirent);
+        demofs_readdir_iter_step(request);
+        return;
+    }
+
+    attr.va_req_mask = request->readdir.attr_mask;
+    demofs_map_attrs(thread, &attr, dirent_inode);
+
+    rc = request->readdir.callback(
+        dirent->inum,
+        dirent->hash + DEMOFS_COOKIE_FIRST,
+        dirent->name, dirent->name_len,
+        &attr, request->proto_private_data);
+
+    request->readdir.r_cookie = dirent->hash + DEMOFS_COOKIE_FIRST;
+
+    if (rc) {
+        request->readdir.r_eof = 0;
+        demofs_readdir_complete(request);
+        return;
+    }
+
+    p->inode_stash[1] = (struct demofs_inode *) rb_tree_next(&inode->dir.dirents, dirent);
+    demofs_readdir_iter_step(request);
+} /* demofs_readdir_iter_inode_cb */
+
+static void
+demofs_readdir_iter_step(struct chimera_vfs_request *request)
+{
+    struct demofs_request_private *p      = request->plugin_data;
+    struct demofs_thread          *thread = p->thread;
+    struct demofs_dirent          *dirent = (struct demofs_dirent *) p->inode_stash[1];
+
+    if (!dirent) {
+        request->readdir.r_eof = 1;
+        demofs_readdir_complete(request);
+        return;
+    }
+
+    demofs_inode_get_inum_async(thread, p->txn, dirent->inum, dirent->gen,
+                                demofs_readdir_iter_inode_cb, request);
+} /* demofs_readdir_iter_step */
+
+static void
+demofs_readdir_start_iter(struct chimera_vfs_request *request)
+{
+    struct demofs_request_private *p      = request->plugin_data;
+    struct demofs_inode           *inode  = p->inode_stash[0];
+    uint64_t                       cookie = request->readdir.r_cookie;
+    struct demofs_dirent          *dirent;
+
+    if (cookie < DEMOFS_COOKIE_FIRST) {
+        rb_tree_first(&inode->dir.dirents, dirent);
+    } else {
+        uint64_t hash_cookie = cookie - DEMOFS_COOKIE_FIRST;
+        rb_tree_query_ceil(&inode->dir.dirents, hash_cookie + 1, hash, dirent);
+    }
+
+    p->inode_stash[1] = (struct demofs_inode *) dirent;
+    demofs_readdir_iter_step(request);
+} /* demofs_readdir_start_iter */
+
+static void
+demofs_readdir_emit_dotdot(
+    struct chimera_vfs_request *request,
+    struct chimera_vfs_attrs   *attr)
+{
+    struct demofs_request_private *p     = request->plugin_data;
+    struct demofs_inode           *inode = p->inode_stash[0];
+    int                            rc;
+
+    rc = request->readdir.callback(
+        inode->dir.parent_inum,
+        DEMOFS_COOKIE_DOTDOT,
+        "..", 2,
+        attr, request->proto_private_data);
+
+    if (rc) {
+        request->readdir.r_cookie = DEMOFS_COOKIE_DOTDOT;
+        request->readdir.r_eof    = 0;
+        demofs_readdir_complete(request);
+        return;
+    }
+    request->readdir.r_cookie = DEMOFS_COOKIE_DOTDOT;
+    demofs_readdir_start_iter(request);
+} /* demofs_readdir_emit_dotdot */
+
+static void
+demofs_readdir_dotdot_cb(
+    struct demofs_inode *parent_inode,
+    int                  status,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+    struct demofs_inode           *inode   = p->inode_stash[0];
+    struct chimera_vfs_attrs       attr;
+
+    attr.va_req_mask = request->readdir.attr_mask;
+
+    if (status == CHIMERA_VFS_OK) {
+        demofs_map_attrs(p->thread, &attr, parent_inode);
+    } else {
+        demofs_map_attrs(p->thread, &attr, inode);
+    }
+
+    demofs_readdir_emit_dotdot(request, &attr);
+} /* demofs_readdir_dotdot_cb */
+
+static void
+demofs_readdir_inode_cb(
+    struct demofs_inode *inode,
+    int                  status,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+    struct demofs_thread          *thread  = p->thread;
+    uint64_t                       cookie  = request->readdir.cookie;
+    struct chimera_vfs_attrs       attr;
+    int                            rc;
+
+    if (unlikely(status != CHIMERA_VFS_OK)) {
+        demofs_op_fail(request, p->txn, status);
+        return;
+    }
+
+    if (!S_ISDIR(inode->mode)) {
+        demofs_op_fail(request, p->txn, CHIMERA_VFS_ENOENT);
+        return;
+    }
+
+    p->inode_stash[0]         = inode;
+    request->readdir.r_cookie = cookie;
+    request->readdir.r_eof    = 1;
+
+    attr.va_req_mask = request->readdir.attr_mask;
+
+    if ((request->readdir.flags & CHIMERA_VFS_READDIR_EMIT_DOT) &&
+        cookie < DEMOFS_COOKIE_DOT) {
+        demofs_map_attrs(thread, &attr, inode);
+        rc = request->readdir.callback(
+            inode->inum, DEMOFS_COOKIE_DOT, ".", 1,
+            &attr, request->proto_private_data);
+        if (rc) {
+            request->readdir.r_cookie = DEMOFS_COOKIE_DOT;
+            request->readdir.r_eof    = 0;
+            demofs_readdir_complete(request);
+            return;
+        }
+        cookie                    = DEMOFS_COOKIE_DOT;
+        request->readdir.r_cookie = cookie;
+    }
+
+    if ((request->readdir.flags & CHIMERA_VFS_READDIR_EMIT_DOT) &&
+        cookie < DEMOFS_COOKIE_DOTDOT) {
+        if (inode->dir.parent_inum == inode->inum &&
+            inode->dir.parent_gen == inode->gen) {
+            demofs_map_attrs(thread, &attr, inode);
+            demofs_readdir_emit_dotdot(request, &attr);
+            return;
+        }
+        demofs_inode_get_inum_async(thread, p->txn,
+                                    inode->dir.parent_inum,
+                                    inode->dir.parent_gen,
+                                    demofs_readdir_dotdot_cb, request);
+        return;
+    }
+
+    if (!(request->readdir.flags & CHIMERA_VFS_READDIR_EMIT_DOT) &&
+        cookie < DEMOFS_COOKIE_DOTDOT) {
+        request->readdir.r_cookie = DEMOFS_COOKIE_DOTDOT;
+    }
+
+    demofs_readdir_start_iter(request);
+} /* demofs_readdir_inode_cb */
+
 static void
 demofs_readdir(
     struct demofs_thread       *thread,
@@ -1645,146 +2562,38 @@ demofs_readdir(
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
-    struct demofs_inode     *inode, *dirent_inode, *parent_inode;
-    struct demofs_dirent    *dirent;
-    uint64_t                 cookie      = request->readdir.cookie;
-    uint64_t                 next_cookie = 0;
-    int                      rc, eof = 1;
-    struct chimera_vfs_attrs attr;
+    struct demofs_request_private *p = request->plugin_data;
 
-    inode = demofs_inode_get_fh(shared, request->fh, request->fh_len);
+    (void) shared;
+    (void) private_data;
 
-    if (!inode) {
-        request->status = CHIMERA_VFS_ENOENT;
-        request->complete(request);
-        return;
-    }
+    p->thread = thread;
+    p->txn    = demofs_txn_begin(thread, DEMOFS_TXN_READ);
 
-    if (!S_ISDIR(inode->mode)) {
-        pthread_mutex_unlock(&inode->lock);
-        request->status = CHIMERA_VFS_ENOENT;
-        request->complete(request);
-        return;
-    }
-
-    attr.va_req_mask = request->readdir.attr_mask;
-
-    /* Handle "." and ".." entries only if requested */
-    if (request->readdir.flags & CHIMERA_VFS_READDIR_EMIT_DOT) {
-        /* Handle "." entry (cookie 0 -> 1) */
-        if (cookie < DEMOFS_COOKIE_DOT) {
-            demofs_map_attrs(thread, &attr, inode);
-
-            rc = request->readdir.callback(
-                inode->inum,
-                DEMOFS_COOKIE_DOT,
-                ".",
-                1,
-                &attr,
-                request->proto_private_data);
-
-            if (rc) {
-                next_cookie = DEMOFS_COOKIE_DOT;
-                eof         = 0;
-                goto out;
-            }
-
-            cookie = DEMOFS_COOKIE_DOT;
-        }
-
-        /* Handle ".." entry (cookie 1 -> 2) */
-        if (cookie < DEMOFS_COOKIE_DOTDOT) {
-            /* Check if parent is the same inode (root directory case) to avoid deadlock */
-            if (inode->dir.parent_inum == inode->inum &&
-                inode->dir.parent_gen == inode->gen) {
-                /* Root directory - parent is self, reuse current inode */
-                demofs_map_attrs(thread, &attr, inode);
-            } else {
-                parent_inode = demofs_inode_get_inum(shared,
-                                                     inode->dir.parent_inum,
-                                                     inode->dir.parent_gen);
-
-                if (parent_inode) {
-                    demofs_map_attrs(thread, &attr, parent_inode);
-                    pthread_mutex_unlock(&parent_inode->lock);
-                } else {
-                    demofs_map_attrs(thread, &attr, inode);
-                }
-            }
-
-            rc = request->readdir.callback(
-                inode->dir.parent_inum,
-                DEMOFS_COOKIE_DOTDOT,
-                "..",
-                2,
-                &attr,
-                request->proto_private_data);
-
-            if (rc) {
-                next_cookie = DEMOFS_COOKIE_DOTDOT;
-                eof         = 0;
-                goto out;
-            }
-
-            cookie = DEMOFS_COOKIE_DOTDOT;
-        }
-    } else {
-        /* Skip . and .. entries - advance cookie past them */
-        if (cookie < DEMOFS_COOKIE_DOTDOT) {
-            cookie = DEMOFS_COOKIE_DOTDOT;
-        }
-    }
-
-    /* Handle real directory entries (cookie >= 2) */
-    if (cookie < DEMOFS_COOKIE_FIRST) {
-        rb_tree_first(&inode->dir.dirents, dirent);
-    } else {
-        uint64_t hash_cookie = cookie - DEMOFS_COOKIE_FIRST;
-
-        rb_tree_query_ceil(&inode->dir.dirents, hash_cookie + 1, hash, dirent);
-    }
-
-    while (dirent) {
-
-        dirent_inode = demofs_inode_get_inum(shared, dirent->inum, dirent->gen);
-
-        if (!dirent_inode) {
-            dirent = rb_tree_next(&inode->dir.dirents, dirent);
-            continue;
-        }
-
-        demofs_map_attrs(thread, &attr, dirent_inode);
-
-        pthread_mutex_unlock(&dirent_inode->lock);
-
-        rc = request->readdir.callback(
-            dirent->inum,
-            dirent->hash + DEMOFS_COOKIE_FIRST,
-            dirent->name,
-            dirent->name_len,
-            &attr,
-            request->proto_private_data);
-
-        next_cookie = dirent->hash + DEMOFS_COOKIE_FIRST;
-
-        if (rc) {
-            eof = 0;
-            break;
-        }
-
-        dirent = rb_tree_next(&inode->dir.dirents, dirent);
-    }
-
- out:
-    demofs_map_attrs(thread, &request->readdir.r_dir_attr, inode);
-
-    pthread_mutex_unlock(&inode->lock);
-
-    request->status           = CHIMERA_VFS_OK;
-    request->readdir.r_cookie = next_cookie;
-    request->readdir.r_eof    = eof;
-    request->complete(request);
+    demofs_inode_get_fh_async(thread, p->txn,
+                              request->fh, request->fh_len,
+                              demofs_readdir_inode_cb, request);
 } /* demofs_readdir */
+
+static void
+demofs_open_fh_inode_cb(
+    struct demofs_inode *inode,
+    int                  status,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+
+    if (unlikely(status != CHIMERA_VFS_OK)) {
+        demofs_op_fail(request, p->txn, status);
+        return;
+    }
+
+    inode->refcnt++;
+
+    request->open_fh.r_vfs_private = (uint64_t) inode;
+    demofs_op_ok(request, p->txn);
+} /* demofs_open_fh_inode_cb */
 
 static void
 demofs_open_fh(
@@ -1793,24 +2602,160 @@ demofs_open_fh(
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
-    struct demofs_inode *inode;
+    struct demofs_request_private *p = request->plugin_data;
 
-    inode = demofs_inode_get_fh(shared, request->fh, request->fh_len);
+    (void) shared;
+    (void) private_data;
 
-    if (!inode) {
-        request->status = CHIMERA_VFS_ENOENT;
-        request->complete(request);
+    p->thread = thread;
+    p->txn    = demofs_txn_begin(thread, DEMOFS_TXN_WRITE);
+
+    demofs_inode_get_fh_async(thread, p->txn,
+                              request->fh, request->fh_len,
+                              demofs_open_fh_inode_cb, request);
+} /* demofs_open_fh */
+
+/* inode_stash[0] = parent (locked across alloc / existing-inode fetch) */
+
+static void
+demofs_open_at_finish(
+    struct chimera_vfs_request *request,
+    struct demofs_inode        *parent,
+    struct demofs_inode        *inode)
+{
+    struct demofs_request_private *p      = request->plugin_data;
+    struct demofs_thread          *thread = p->thread;
+    unsigned int                   flags  = request->open_at.flags;
+
+    if (flags & CHIMERA_VFS_OPEN_INFERRED) {
+        request->open_at.r_vfs_private = 0xdeadbeefUL;
+    } else {
+        inode->refcnt++;
+        request->open_at.r_vfs_private = (uint64_t) inode;
+    }
+
+    demofs_map_attrs(thread, &request->open_at.r_dir_post_attr, parent);
+
+    demofs_map_attrs(thread, &request->open_at.r_attr, inode);
+
+    demofs_op_ok(request, p->txn);
+} /* demofs_open_at_finish */
+
+static void
+demofs_open_at_existing_cb(
+    struct demofs_inode *inode,
+    int                  status,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+    struct demofs_inode           *parent  = p->inode_stash[0];
+
+    if (unlikely(status != CHIMERA_VFS_OK)) {
+        demofs_op_fail(request, p->txn, status);
         return;
     }
 
-    inode->refcnt++;
-    pthread_mutex_unlock(&inode->lock);
+    demofs_open_at_finish(request, parent, inode);
+} /* demofs_open_at_existing_cb */
 
-    request->open_fh.r_vfs_private = (uint64_t) inode;
+static void
+demofs_open_at_alloc_cb(
+    struct demofs_inode *inode,
+    int                  status,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+    struct demofs_thread          *thread  = p->thread;
+    struct demofs_inode           *parent  = p->inode_stash[0];
+    struct demofs_dirent          *dirent;
+    struct timespec                now;
 
-    request->status = CHIMERA_VFS_OK;
-    request->complete(request);
-} /* demofs_open_fh */
+    if (unlikely(status != CHIMERA_VFS_OK)) {
+        demofs_op_fail(request, p->txn, status);
+        return;
+    }
+
+    clock_gettime(CLOCK_REALTIME, &now);
+
+    inode->size       = 0;
+    inode->space_used = 0;
+    inode->uid        = request->cred->uid;
+    inode->gid        = request->cred->gid;
+    inode->nlink      = 1;
+    inode->mode       = S_IFREG | 0644;
+    inode->atime_sec  = now.tv_sec;
+    inode->atime_nsec = now.tv_nsec;
+    inode->mtime_sec  = now.tv_sec;
+    inode->mtime_nsec = now.tv_nsec;
+    inode->ctime_sec  = now.tv_sec;
+    inode->ctime_nsec = now.tv_nsec;
+
+    rb_tree_init(&inode->file.extents);
+    demofs_apply_attrs(inode, request->open_at.set_attr);
+
+    dirent = demofs_dirent_alloc(thread, inode->inum, inode->gen,
+                                 request->open_at.name_hash,
+                                 request->open_at.name,
+                                 request->open_at.namelen);
+    rb_tree_insert(&parent->dir.dirents, hash, dirent);
+
+    parent->mtime_sec  = now.tv_sec;
+    parent->mtime_nsec = now.tv_nsec;
+    parent->ctime_sec  = now.tv_sec;
+    parent->ctime_nsec = now.tv_nsec;
+
+    demofs_open_at_finish(request, parent, inode);
+} /* demofs_open_at_alloc_cb */
+
+static void
+demofs_open_at_parent_cb(
+    struct demofs_inode *parent,
+    int                  status,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+    struct demofs_thread          *thread  = p->thread;
+    struct demofs_dirent          *dirent;
+    unsigned int                   flags = request->open_at.flags;
+    uint64_t                       hash  = request->open_at.name_hash;
+
+    if (unlikely(status != CHIMERA_VFS_OK)) {
+        demofs_op_fail(request, p->txn, status);
+        return;
+    }
+
+    if (!S_ISDIR(parent->mode)) {
+        demofs_op_fail(request, p->txn, CHIMERA_VFS_ENOENT);
+        return;
+    }
+
+    demofs_map_attrs(thread, &request->open_at.r_dir_pre_attr, parent);
+
+    rb_tree_query_exact(&parent->dir.dirents, hash, hash, dirent);
+
+    p->inode_stash[0] = parent;
+
+    if (!dirent) {
+        if (!(flags & CHIMERA_VFS_OPEN_CREATE)) {
+            demofs_op_fail(request, p->txn, CHIMERA_VFS_ENOENT);
+            return;
+        }
+        demofs_inode_alloc_async(thread, p->txn,
+                                 demofs_open_at_alloc_cb, request);
+        return;
+    }
+
+    if (flags & CHIMERA_VFS_OPEN_EXCLUSIVE) {
+        demofs_op_fail(request, p->txn, CHIMERA_VFS_EEXIST);
+        return;
+    }
+
+    demofs_inode_get_inum_async(thread, p->txn, dirent->inum, dirent->gen,
+                                demofs_open_at_existing_cb, request);
+} /* demofs_open_at_parent_cb */
 
 static void
 demofs_open_at(
@@ -1819,132 +2764,35 @@ demofs_open_at(
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
-    struct demofs_inode  *parent_inode, *inode = NULL;
-    struct demofs_dirent *dirent;
-    uint64_t              hash;
-    unsigned int          flags = request->open_at.flags;
-    struct timespec       now;
+    struct demofs_request_private *p = request->plugin_data;
 
-    hash = request->open_at.name_hash;
+    (void) shared;
+    (void) private_data;
 
-    parent_inode = demofs_inode_get_fh(shared, request->fh, request->fh_len);
+    p->thread = thread;
+    p->txn    = demofs_txn_begin(thread, DEMOFS_TXN_WRITE);
 
-    if (unlikely(!parent_inode)) {
-        request->status = CHIMERA_VFS_ENOENT;
-        request->complete(request);
-        return;
-    }
-
-    if (!S_ISDIR(parent_inode->mode)) {
-        pthread_mutex_unlock(&parent_inode->lock);
-        request->status = CHIMERA_VFS_ENOENT;
-        request->complete(request);
-        return;
-    }
-
-    demofs_map_attrs(thread, &request->open_at.r_dir_pre_attr, parent_inode);
-
-    rb_tree_query_exact(&parent_inode->dir.dirents, hash, hash, dirent);
-
-    if (!dirent) {
-        if (!(flags & CHIMERA_VFS_OPEN_CREATE)) {
-            pthread_mutex_unlock(&parent_inode->lock);
-            request->status = CHIMERA_VFS_ENOENT;
-            request->complete(request);
-            return;
-        }
-
-        inode = demofs_inode_alloc_thread(thread);
-
-        pthread_mutex_lock(&inode->lock);
-
-        clock_gettime(CLOCK_REALTIME, &now);
-
-        inode->size       = 0;
-        inode->space_used = 0;
-        inode->uid        = request->cred->uid;
-        inode->gid        = request->cred->gid;
-        inode->nlink      = 1;
-        inode->mode       = S_IFREG |  0644;
-        inode->atime_sec  = now.tv_sec;
-        inode->atime_nsec = now.tv_nsec;
-        inode->mtime_sec  = now.tv_sec;
-        inode->mtime_nsec = now.tv_nsec;
-        inode->ctime_sec  = now.tv_sec;
-        inode->ctime_nsec = now.tv_nsec;
-
-        rb_tree_init(&inode->file.extents);
-
-        demofs_apply_attrs(inode, request->open_at.set_attr);
-
-        dirent = demofs_dirent_alloc(thread,
-                                     inode->inum,
-                                     inode->gen,
-                                     hash,
-                                     request->open_at.name,
-                                     request->open_at.namelen);
-
-        rb_tree_insert(&parent_inode->dir.dirents, hash, dirent);
-
-        parent_inode->mtime_sec  = now.tv_sec;
-        parent_inode->mtime_nsec = now.tv_nsec;
-        parent_inode->ctime_sec  = now.tv_sec;
-        parent_inode->ctime_nsec = now.tv_nsec;
-
-    } else if (flags & CHIMERA_VFS_OPEN_EXCLUSIVE) {
-        pthread_mutex_unlock(&parent_inode->lock);
-        request->status = CHIMERA_VFS_EEXIST;
-        request->complete(request);
-        return;
-    } else {
-
-        inode = demofs_inode_get_inum(shared, dirent->inum, dirent->gen);
-
-        if (!inode) {
-            pthread_mutex_unlock(&parent_inode->lock);
-            request->status = CHIMERA_VFS_ENOENT;
-            request->complete(request);
-            return;
-        }
-    }
-
-    if (flags & CHIMERA_VFS_OPEN_INFERRED) {
-        /* If this is an inferred open (ie an NFS3 create)
-         * then we aren't returning a handle so we don't need
-         * to increment the refcnt */
-
-        request->open_at.r_vfs_private = 0xdeadbeefUL;
-
-    } else {
-        inode->refcnt++;
-        request->open_at.r_vfs_private = (uint64_t) inode;
-    }
-
-    demofs_map_attrs(thread, &request->open_at.r_dir_post_attr, parent_inode);
-
-    pthread_mutex_unlock(&parent_inode->lock);
-
-    demofs_map_attrs(thread, &request->open_at.r_attr, inode);
-
-    pthread_mutex_unlock(&inode->lock);
-
-    request->status = CHIMERA_VFS_OK;
-    request->complete(request);
-
+    demofs_inode_get_fh_async(thread, p->txn,
+                              request->fh, request->fh_len,
+                              demofs_open_at_parent_cb, request);
 } /* demofs_open_at */
 
 
 static void
-demofs_create_unlinked(
-    struct demofs_thread       *thread,
-    struct demofs_shared       *shared,
-    struct chimera_vfs_request *request,
-    void                       *private_data)
+demofs_create_unlinked_alloc_cb(
+    struct demofs_inode *inode,
+    int                  status,
+    void                *private_data)
 {
-    struct demofs_inode *inode = NULL;
-    struct timespec      now;
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+    struct demofs_thread          *thread  = p->thread;
+    struct timespec                now;
 
-    inode = demofs_inode_alloc_thread(thread);
+    if (unlikely(status != CHIMERA_VFS_OK)) {
+        demofs_op_fail(request, p->txn, status);
+        return;
+    }
 
     clock_gettime(CLOCK_REALTIME, &now);
 
@@ -1953,7 +2801,7 @@ demofs_create_unlinked(
     inode->uid        = request->cred->uid;
     inode->gid        = request->cred->gid;
     inode->nlink      = 0;
-    inode->mode       = S_IFREG |  0644;
+    inode->mode       = S_IFREG | 0644;
     inode->atime_sec  = now.tv_sec;
     inode->atime_nsec = now.tv_nsec;
     inode->mtime_sec  = now.tv_sec;
@@ -1970,9 +2818,26 @@ demofs_create_unlinked(
 
     demofs_map_attrs(thread, &request->create_unlinked.r_attr, inode);
 
-    request->status = CHIMERA_VFS_OK;
-    request->complete(request);
+    demofs_op_ok(request, p->txn);
+} /* demofs_create_unlinked_alloc_cb */
 
+static void
+demofs_create_unlinked(
+    struct demofs_thread       *thread,
+    struct demofs_shared       *shared,
+    struct chimera_vfs_request *request,
+    void                       *private_data)
+{
+    struct demofs_request_private *p = request->plugin_data;
+
+    (void) shared;
+    (void) private_data;
+
+    p->thread = thread;
+    p->txn    = demofs_txn_begin(thread, DEMOFS_TXN_WRITE);
+
+    demofs_inode_alloc_async(thread, p->txn,
+                             demofs_create_unlinked_alloc_cb, request);
 } /* demofs_create_unlinked */
 
 static void
@@ -1982,22 +2847,25 @@ demofs_close(
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
-    struct demofs_inode *inode;
+    struct demofs_request_private *p     = request->plugin_data;
+    struct demofs_inode           *inode = (struct demofs_inode *) request->close.vfs_private;
 
-    inode = (struct demofs_inode *) request->close.vfs_private;
+    (void) shared;
+    (void) private_data;
 
+    p->thread = thread;
+    p->txn    = demofs_txn_begin(thread, DEMOFS_TXN_WRITE);
+
+    /* The inode pointer came in via vfs_private (set at open); take its
+     * lock and pin it into the txn so commit drops it centrally. */
     pthread_mutex_lock(&inode->lock);
-
+    demofs_txn_pin_inode(p->txn, inode);
     --inode->refcnt;
-
     if (inode->refcnt == 0) {
         demofs_inode_free(thread, inode);
     }
 
-    pthread_mutex_unlock(&inode->lock);
-
-    request->status = CHIMERA_VFS_OK;
-    request->complete(request);
+    demofs_op_ok(request, p->txn);
 } /* demofs_close */
 
 /*
@@ -2069,23 +2937,27 @@ demofs_io_callback(
 
         evpl_iovecs_release(thread->evpl, demofs_private->iov, demofs_private->niov);
 
-
-        request->status = demofs_private->status;
-        request->complete(request);
+        if (demofs_private->status != 0) {
+            demofs_op_fail(request, demofs_private->txn,
+                           demofs_private->status);
+        } else {
+            demofs_op_ok(request, demofs_private->txn);
+        }
     }
 } /* demofs_io_callback */
 
 static void
-demofs_read(
-    struct demofs_thread       *thread,
-    struct demofs_shared       *shared,
-    struct chimera_vfs_request *request,
-    void                       *private_data)
+demofs_read_inode_cb(
+    struct demofs_inode *inode,
+    int                  status,
+    void                *private_data)
 {
-    struct evpl                   *evpl = thread->evpl;
-    struct demofs_inode           *inode;
+    struct chimera_vfs_request    *request        = private_data;
+    struct demofs_request_private *demofs_private = request->plugin_data;
+    struct demofs_thread          *thread         = demofs_private->thread;
+    struct demofs_shared          *shared         = thread->shared;
+    struct evpl                   *evpl           = thread->evpl;
     struct demofs_extent          *extent;
-    struct demofs_request_private *demofs_private;
     uint64_t                       offset, length, read_offset, read_left;
     uint64_t                       extent_end, overlap_start, overlap_length;
     uint64_t                       aligned_offset, aligned_length, chunk;
@@ -2093,25 +2965,13 @@ demofs_read(
     struct evpl_iovec             *chunk_iov;
     struct evpl_iovec_cursor       cursor;
 
-    demofs_private          = request->plugin_data;
-    demofs_private->opcode  = request->opcode;
-    demofs_private->status  = 0;
-    demofs_private->pending = 0;
-    demofs_private->niov    = 0;
-    demofs_private->thread  = thread;
-
-    inode = demofs_inode_get_fh(shared, request->fh, request->fh_len);
-
-    if (unlikely(!inode)) {
-        request->status = CHIMERA_VFS_ENOENT;
-        request->complete(request);
+    if (unlikely(status != CHIMERA_VFS_OK)) {
+        demofs_op_fail(request, demofs_private->txn, status);
         return;
     }
 
     if (unlikely(!S_ISREG(inode->mode))) {
-        pthread_mutex_unlock(&inode->lock);
-        request->status = CHIMERA_VFS_EINVAL;
-        request->complete(request);
+        demofs_op_fail(request, demofs_private->txn, CHIMERA_VFS_EINVAL);
         return;
     }
 
@@ -2125,12 +2985,10 @@ demofs_read(
 
     if (unlikely(length == 0)) {
         demofs_map_attrs(thread, &request->read.r_attr, inode);
-        pthread_mutex_unlock(&inode->lock);
-        request->status        = CHIMERA_VFS_OK;
         request->read.r_niov   = 0;
         request->read.r_length = 0;
         request->read.r_eof    = eof;
-        request->complete(request);
+        demofs_op_ok(request, demofs_private->txn);
         return;
     }
 
@@ -2251,14 +3109,40 @@ demofs_read(
 
     demofs_map_attrs(thread, &request->read.r_attr, inode);
 
-    pthread_mutex_unlock(&inode->lock);
 
     if (demofs_private->pending == 0) {
-        // No block reads issued - adjust iovecs and complete immediately
         demofs_read_adjust_iovecs(request, demofs_private);
-        request->status = CHIMERA_VFS_OK;
-        request->complete(request);
+        demofs_op_ok(request, demofs_private->txn);
+    } else {
+        /* I/O is in flight.  Drop the inode lock now so other ops on this
+         * worker thread can proceed; the txn will be committed (with no
+         * remaining refs to unlock) from demofs_io_callback. */
+        demofs_txn_unlock_inode(demofs_private->txn, inode);
     }
+} /* demofs_read_inode_cb */
+
+static void
+demofs_read(
+    struct demofs_thread       *thread,
+    struct demofs_shared       *shared,
+    struct chimera_vfs_request *request,
+    void                       *private_data)
+{
+    struct demofs_request_private *p = request->plugin_data;
+
+    (void) shared;
+    (void) private_data;
+
+    p->opcode  = request->opcode;
+    p->status  = 0;
+    p->pending = 0;
+    p->niov    = 0;
+    p->thread  = thread;
+    p->txn     = demofs_txn_begin(thread, DEMOFS_TXN_READ);
+
+    demofs_inode_get_fh_async(thread, p->txn,
+                              request->fh, request->fh_len,
+                              demofs_read_inode_cb, request);
 } /* demofs_read */
 
 // Forward declaration
@@ -2468,15 +3352,16 @@ demofs_find_extent_at(
 } /* demofs_find_extent_at */
 
 static void
-demofs_write(
-    struct demofs_thread       *thread,
-    struct demofs_shared       *shared,
-    struct chimera_vfs_request *request,
-    void                       *private_data)
+demofs_write_inode_cb(
+    struct demofs_inode *inode,
+    int                  status,
+    void                *private_data)
 {
-    struct evpl                   *evpl = thread->evpl;
-    struct demofs_request_private *demofs_private;
-    struct demofs_inode           *inode;
+    struct chimera_vfs_request    *request        = private_data;
+    struct demofs_request_private *demofs_private = request->plugin_data;
+    struct demofs_thread          *thread         = demofs_private->thread;
+    struct demofs_shared          *shared         = thread->shared;
+    struct evpl                   *evpl           = thread->evpl;
     struct demofs_extent          *extent, *next_extent, *new_extent;
     uint64_t                       write_start = request->write.offset;
     uint64_t                       write_end   = write_start + request->write.length;
@@ -2486,33 +3371,13 @@ demofs_write(
     int                            rc;
     struct timespec                now;
 
-    demofs_private                      = request->plugin_data;
-    demofs_private->opcode              = request->opcode;
-    demofs_private->status              = 0;
-    demofs_private->pending             = 0;
-    demofs_private->niov                = 0;
-    demofs_private->thread              = thread;
-    demofs_private->rmw_phase           = 0;
-    demofs_private->rmw_prefix_iov.data = NULL;
-    demofs_private->rmw_suffix_iov.data = NULL;
-    demofs_private->rmw_prefix_pending  = 0;
-    demofs_private->rmw_suffix_pending  = 0;
-    demofs_private->rmw_prefix_valid    = 0;
-    demofs_private->rmw_suffix_adjust   = 0;
-    demofs_private->rmw_suffix_valid    = 0;
-
-    inode = demofs_inode_get_fh(shared, request->fh, request->fh_len);
-
-    if (unlikely(!inode)) {
-        request->status = CHIMERA_VFS_ENOENT;
-        request->complete(request);
+    if (unlikely(status != CHIMERA_VFS_OK)) {
+        demofs_op_fail(request, demofs_private->txn, status);
         return;
     }
 
     if (unlikely(!S_ISREG(inode->mode))) {
-        pthread_mutex_unlock(&inode->lock);
-        request->status = CHIMERA_VFS_EINVAL;
-        request->complete(request);
+        demofs_op_fail(request, demofs_private->txn, CHIMERA_VFS_EINVAL);
         return;
     }
 
@@ -2536,9 +3401,7 @@ demofs_write(
     rc = demofs_thread_alloc_space(thread, aligned_length, &device_id, &device_offset);
 
     if (rc) {
-        pthread_mutex_unlock(&inode->lock);
-        request->status = CHIMERA_VFS_ENOSPC;
-        request->complete(request);
+        demofs_op_fail(request, demofs_private->txn, CHIMERA_VFS_ENOSPC);
         return;
     }
 
@@ -2714,7 +3577,11 @@ demofs_write(
     request->write.r_length = request->write.length;
     request->write.r_sync   = 1;
 
-    pthread_mutex_unlock(&inode->lock);
+    /* All in-memory inode mutations are done.  Release the inode lock
+     * before submitting block I/O so other ops on this worker (or other
+     * workers) can proceed concurrently, and so we don't self-deadlock
+     * when SQ-full backpressure spins this worker's evpl loop. */
+    demofs_txn_unlock_inode(demofs_private->txn, inode);
 
     // Issue RMW reads if needed
     if (need_prefix_read || need_suffix_read) {
@@ -2769,28 +3636,58 @@ demofs_write(
         demofs_private->rmw_phase = 2;
         demofs_write_phase2(thread, shared, request);
     }
-} /* demofs_write */
-
+} /* demofs_write_inode_cb */
 
 static void
-demofs_allocate(
+demofs_write(
     struct demofs_thread       *thread,
     struct demofs_shared       *shared,
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
-    struct demofs_inode *inode;
-    struct timespec      now;
+    struct demofs_request_private *p = request->plugin_data;
 
-    clock_gettime(CLOCK_REALTIME, &now);
+    (void) shared;
+    (void) private_data;
 
-    inode = demofs_inode_get_fh(shared, request->fh, request->fh_len);
+    p->opcode              = request->opcode;
+    p->status              = 0;
+    p->pending             = 0;
+    p->niov                = 0;
+    p->thread              = thread;
+    p->rmw_phase           = 0;
+    p->rmw_prefix_iov.data = NULL;
+    p->rmw_suffix_iov.data = NULL;
+    p->rmw_prefix_pending  = 0;
+    p->rmw_suffix_pending  = 0;
+    p->rmw_prefix_valid    = 0;
+    p->rmw_suffix_adjust   = 0;
+    p->rmw_suffix_valid    = 0;
+    p->txn                 = demofs_txn_begin(thread, DEMOFS_TXN_WRITE);
 
-    if (unlikely(!inode)) {
-        request->status = CHIMERA_VFS_ENOENT;
-        request->complete(request);
+    demofs_inode_get_fh_async(thread, p->txn,
+                              request->fh, request->fh_len,
+                              demofs_write_inode_cb, request);
+} /* demofs_write */
+
+
+static void
+demofs_allocate_inode_cb(
+    struct demofs_inode *inode,
+    int                  status,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+    struct demofs_thread          *thread  = p->thread;
+    struct timespec                now;
+
+    if (unlikely(status != CHIMERA_VFS_OK)) {
+        demofs_op_fail(request, p->txn, status);
         return;
     }
+
+    clock_gettime(CLOCK_REALTIME, &now);
 
     demofs_map_attrs(thread, &request->allocate.r_pre_attr, inode);
 
@@ -2830,7 +3727,12 @@ demofs_allocate(
                 }
 
                 if (extent_start >= hole_start && extent_end <= hole_end) {
-                    /* Extent is completely inside hole - remove it */
+                    /* Extent is completely inside hole - remove it.
+                     * Partial-overlap cases below currently leak the punched
+                     * device range (sub-block accounting), deferred. */
+                    demofs_thread_free_space(thread, extent->device_id,
+                                             extent->device_offset,
+                                             SM_ALIGN_UP(extent->length));
                     rb_tree_remove(&inode->file.extents, &extent->node);
                     demofs_extent_free(thread, extent);
                 } else if (extent_start < hole_start &&
@@ -2897,36 +3799,49 @@ demofs_allocate(
 
     demofs_map_attrs(thread, &request->allocate.r_post_attr, inode);
 
-    pthread_mutex_unlock(&inode->lock);
 
-    request->status = CHIMERA_VFS_OK;
-    request->complete(request);
-} /* demofs_allocate */
+    demofs_op_ok(request, p->txn);
+} /* demofs_allocate_inode_cb */
 
 static void
-demofs_seek(
+demofs_allocate(
     struct demofs_thread       *thread,
     struct demofs_shared       *shared,
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
-    struct demofs_inode *inode;
-    uint64_t             offset = request->seek.offset;
+    struct demofs_request_private *p = request->plugin_data;
 
-    inode = demofs_inode_get_fh(shared, request->fh, request->fh_len);
+    (void) shared;
+    (void) private_data;
 
-    if (unlikely(!inode)) {
-        request->status = CHIMERA_VFS_ENOENT;
-        request->complete(request);
+    p->thread = thread;
+    p->txn    = demofs_txn_begin(thread, DEMOFS_TXN_WRITE);
+
+    demofs_inode_get_fh_async(thread, p->txn,
+                              request->fh, request->fh_len,
+                              demofs_allocate_inode_cb, request);
+} /* demofs_allocate */
+
+static void
+demofs_seek_inode_cb(
+    struct demofs_inode *inode,
+    int                  status,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+    uint64_t                       offset  = request->seek.offset;
+
+    if (unlikely(status != CHIMERA_VFS_OK)) {
+        demofs_op_fail(request, p->txn, status);
         return;
     }
 
     if (offset >= inode->size) {
-        pthread_mutex_unlock(&inode->lock);
         request->seek.r_eof    = 1;
         request->seek.r_offset = 0;
-        request->status        = CHIMERA_VFS_OK;
-        request->complete(request);
+        demofs_op_ok(request, p->txn);
         return;
     }
 
@@ -2938,7 +3853,6 @@ demofs_seek(
 
         if (extent) {
             uint64_t extent_end = extent->file_offset + extent->length;
-
             if (extent_end <= offset) {
                 extent = rb_tree_next(&inode->file.extents, extent);
             }
@@ -2946,7 +3860,6 @@ demofs_seek(
             rb_tree_first(&inode->file.extents, extent);
         }
 
-        /* Find the first extent that ends after offset */
         while (extent) {
             uint64_t extent_end = extent->file_offset + extent->length;
 
@@ -2954,21 +3867,16 @@ demofs_seek(
                 request->seek.r_offset = (extent->file_offset > offset) ?
                     extent->file_offset : offset;
                 request->seek.r_eof = 0;
-                pthread_mutex_unlock(&inode->lock);
-                request->status = CHIMERA_VFS_OK;
-                request->complete(request);
+                demofs_op_ok(request, p->txn);
                 return;
             }
 
             extent = rb_tree_next(&inode->file.extents, extent);
         }
 
-        /* No data found */
-        pthread_mutex_unlock(&inode->lock);
         request->seek.r_eof    = 1;
         request->seek.r_offset = 0;
-        request->status        = CHIMERA_VFS_OK;
-        request->complete(request);
+        demofs_op_ok(request, p->txn);
         return;
     } else {
         /* SEEK_HOLE: find first gap from offset forward */
@@ -2979,7 +3887,6 @@ demofs_seek(
 
         if (extent) {
             uint64_t extent_end = extent->file_offset + extent->length;
-
             if (extent_end <= offset) {
                 extent = rb_tree_next(&inode->file.extents, extent);
             }
@@ -2990,60 +3897,74 @@ demofs_seek(
         while (extent) {
             uint64_t extent_end = extent->file_offset + extent->length;
 
-            /* Skip extents entirely before current_pos */
             if (extent_end <= current_pos) {
                 extent = rb_tree_next(&inode->file.extents, extent);
                 continue;
             }
 
-            /* Gap before this extent - that's a hole */
             if (extent->file_offset > current_pos) {
                 request->seek.r_offset = current_pos;
                 request->seek.r_eof    = 0;
-                pthread_mutex_unlock(&inode->lock);
-                request->status = CHIMERA_VFS_OK;
-                request->complete(request);
+                demofs_op_ok(request, p->txn);
                 return;
             }
 
-            /* This extent covers current_pos, advance past it */
             current_pos = extent_end;
             extent      = rb_tree_next(&inode->file.extents, extent);
         }
 
-        /* Virtual hole at or after all extents */
         if (current_pos < inode->size) {
             request->seek.r_offset = current_pos;
         } else {
             request->seek.r_offset = inode->size;
         }
-
         request->seek.r_eof = 0;
-        pthread_mutex_unlock(&inode->lock);
-        request->status = CHIMERA_VFS_OK;
-        request->complete(request);
+        demofs_op_ok(request, p->txn);
         return;
     }
-} /* demofs_seek */
+} /* demofs_seek_inode_cb */
 
 static void
-demofs_symlink_at(
+demofs_seek(
     struct demofs_thread       *thread,
     struct demofs_shared       *shared,
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
-    struct demofs_inode  *parent_inode, *inode;
-    struct demofs_dirent *dirent, *existing_dirent;
-    uint64_t              hash;
-    struct timespec       now;
+    struct demofs_request_private *p = request->plugin_data;
+
+    (void) shared;
+    (void) private_data;
+
+    p->thread = thread;
+    p->txn    = demofs_txn_begin(thread, DEMOFS_TXN_READ);
+
+    demofs_inode_get_fh_async(thread, p->txn,
+                              request->fh, request->fh_len,
+                              demofs_seek_inode_cb, request);
+} /* demofs_seek */
+
+/* inode_stash[0] = parent (locked across alloc) */
+
+static void
+demofs_symlink_at_alloc_cb(
+    struct demofs_inode *inode,
+    int                  status,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+    struct demofs_thread          *thread  = p->thread;
+    struct demofs_inode           *parent  = p->inode_stash[0];
+    struct demofs_dirent          *dirent;
+    struct timespec                now;
+
+    if (unlikely(status != CHIMERA_VFS_OK)) {
+        demofs_op_fail(request, p->txn, status);
+        return;
+    }
 
     clock_gettime(CLOCK_REALTIME, &now);
-
-    hash = request->symlink_at.name_hash;
-
-    /* Optimistically allocate an inode */
-    inode = demofs_inode_alloc_thread(thread);
 
     inode->size       = request->symlink_at.targetlen;
     inode->space_used = request->symlink_at.targetlen;
@@ -3061,63 +3982,108 @@ demofs_symlink_at(
     inode->symlink.target = demofs_symlink_target_alloc(thread,
                                                         request->symlink_at.target,
                                                         request->symlink_at.targetlen);
-
     demofs_map_attrs(thread, &request->symlink_at.r_attr, inode);
 
-    /* Optimistically allocate a dirent */
-    dirent = demofs_dirent_alloc(thread,
-                                 inode->inum,
-                                 inode->gen,
-                                 hash,
+    dirent = demofs_dirent_alloc(thread, inode->inum, inode->gen,
+                                 request->symlink_at.name_hash,
                                  request->symlink_at.name,
                                  request->symlink_at.namelen);
+    rb_tree_insert(&parent->dir.dirents, hash, dirent);
 
-    parent_inode = demofs_inode_get_fh(shared, request->fh, request->fh_len);
+    parent->mtime_sec  = now.tv_sec;
+    parent->mtime_nsec = now.tv_nsec;
+    parent->ctime_sec  = now.tv_sec;
+    parent->ctime_nsec = now.tv_nsec;
 
-    if (!parent_inode) {
-        request->status = CHIMERA_VFS_ENOENT;
-        request->complete(request);
-        demofs_inode_free(thread, inode);
-        demofs_dirent_free(thread, dirent);
+    demofs_map_attrs(thread, &request->symlink_at.r_dir_post_attr, parent);
+
+    demofs_op_ok(request, p->txn);
+} /* demofs_symlink_at_alloc_cb */
+
+static void
+demofs_symlink_at_parent_cb(
+    struct demofs_inode *parent,
+    int                  status,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+    struct demofs_thread          *thread  = p->thread;
+    struct demofs_dirent          *existing_dirent;
+    uint64_t                       hash = request->symlink_at.name_hash;
+
+    if (unlikely(status != CHIMERA_VFS_OK)) {
+        demofs_op_fail(request, p->txn, status);
         return;
     }
 
-    if (!S_ISDIR(parent_inode->mode)) {
-        pthread_mutex_unlock(&parent_inode->lock);
-        request->status = CHIMERA_VFS_ENOTDIR;
-        request->complete(request);
-        demofs_inode_free(thread, inode);
-        demofs_dirent_free(thread, dirent);
+    if (!S_ISDIR(parent->mode)) {
+        demofs_op_fail(request, p->txn, CHIMERA_VFS_ENOTDIR);
         return;
     }
 
-    rb_tree_query_exact(&parent_inode->dir.dirents, hash, hash, existing_dirent);
+    rb_tree_query_exact(&parent->dir.dirents, hash, hash, existing_dirent);
 
     if (existing_dirent) {
-        pthread_mutex_unlock(&parent_inode->lock);
-        request->status = CHIMERA_VFS_EEXIST;
-        request->complete(request);
-        demofs_inode_free(thread, inode);
-        demofs_dirent_free(thread, dirent);
+        demofs_op_fail(request, p->txn, CHIMERA_VFS_EEXIST);
         return;
     }
 
-    demofs_map_attrs(thread, &request->symlink_at.r_dir_pre_attr, parent_inode);
+    demofs_map_attrs(thread, &request->symlink_at.r_dir_pre_attr, parent);
 
-    rb_tree_insert(&parent_inode->dir.dirents, hash, dirent);
+    p->inode_stash[0] = parent;
+    demofs_inode_alloc_async(thread, p->txn,
+                             demofs_symlink_at_alloc_cb, request);
+} /* demofs_symlink_at_parent_cb */
 
-    parent_inode->mtime_sec  = now.tv_sec;
-    parent_inode->mtime_nsec = now.tv_nsec;
-    parent_inode->ctime_sec  = now.tv_sec;
-    parent_inode->ctime_nsec = now.tv_nsec;
+static void
+demofs_symlink_at(
+    struct demofs_thread       *thread,
+    struct demofs_shared       *shared,
+    struct chimera_vfs_request *request,
+    void                       *private_data)
+{
+    struct demofs_request_private *p = request->plugin_data;
 
-    demofs_map_attrs(thread, &request->symlink_at.r_dir_post_attr, parent_inode);
+    (void) shared;
+    (void) private_data;
 
-    pthread_mutex_unlock(&parent_inode->lock);
+    p->thread = thread;
+    p->txn    = demofs_txn_begin(thread, DEMOFS_TXN_WRITE);
 
-    request->status = CHIMERA_VFS_OK;
-    request->complete(request);
+    demofs_inode_get_fh_async(thread, p->txn,
+                              request->fh, request->fh_len,
+                              demofs_symlink_at_parent_cb, request);
 } /* demofs_symlink_at */
+
+static void
+demofs_readlink_inode_cb(
+    struct demofs_inode *inode,
+    int                  status,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+
+    if (unlikely(status != CHIMERA_VFS_OK)) {
+        demofs_op_fail(request, p->txn, status);
+        return;
+    }
+
+    if (unlikely(!S_ISLNK(inode->mode))) {
+        demofs_op_fail(request, p->txn, CHIMERA_VFS_EINVAL);
+        return;
+    }
+
+    request->readlink.r_target_length = inode->symlink.target->length;
+    memcpy(request->readlink.r_target,
+           inode->symlink.target->data,
+           inode->symlink.target->length);
+
+    demofs_map_attrs(p->thread, &request->readlink.r_attr, inode);
+
+    demofs_op_ok(request, p->txn);
+} /* demofs_readlink_inode_cb */
 
 static void
 demofs_readlink(
@@ -3126,36 +4092,17 @@ demofs_readlink(
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
-    struct demofs_inode *inode;
+    struct demofs_request_private *p = request->plugin_data;
 
-    inode = demofs_inode_get_fh(shared, request->fh, request->fh_len);
+    (void) shared;
+    (void) private_data;
 
-    if (!inode) {
-        request->status = CHIMERA_VFS_ENOENT;
-        request->complete(request);
-        return;
-    }
+    p->thread = thread;
+    p->txn    = demofs_txn_begin(thread, DEMOFS_TXN_READ);
 
-    if (unlikely(!S_ISLNK(inode->mode))) {
-        pthread_mutex_unlock(&inode->lock);
-        request->status = CHIMERA_VFS_EINVAL;
-        request->complete(request);
-        return;
-    }
-
-    request->readlink.r_target_length = inode->symlink.target->length;
-
-    memcpy(request->readlink.r_target,
-           inode->symlink.target->data,
-           inode->symlink.target->length);
-
-    demofs_map_attrs(thread, &request->readlink.r_attr, inode);
-
-    pthread_mutex_unlock(&inode->lock);
-
-    request->status = CHIMERA_VFS_OK;
-
-    request->complete(request);
+    demofs_inode_get_fh_async(thread, p->txn,
+                              request->fh, request->fh_len,
+                              demofs_readlink_inode_cb, request);
 } /* demofs_readlink */
 
 static inline int
@@ -3170,181 +4117,90 @@ demofs_fh_compare(
     return memcmp(fha, fhb, minlen);
 } /* demofs_fh_compare */
 
+/*
+ * Rename state machine.  Locks are taken in fh-canonical order:
+ *
+ *   inode_stash[0] = old_parent (locked)
+ *   inode_stash[1] = new_parent (locked; aliased to [0] when same dir)
+ *   inode_stash[2] = child inode (locked)
+ *   inode_stash[3] = existing dest inode (locked, only when replacing)
+ */
+
+static void demofs_rename_at_perform(
+    struct chimera_vfs_request *request);
+
 static void
-demofs_rename_at(
-    struct demofs_thread       *thread,
-    struct demofs_shared       *shared,
-    struct chimera_vfs_request *request,
-    void                       *private_data)
+demofs_rename_at_unlock_parents(struct chimera_vfs_request *request)
 {
-    struct demofs_inode  *old_parent_inode, *new_parent_inode, *child_inode;
-    struct demofs_inode  *existing_inode = NULL;
-    struct demofs_dirent *new_dirent, *old_dirent, *existing_dirent = NULL;
-    uint64_t              hash, new_hash;
-    int                   cmp;
-    struct timespec       now;
+    struct demofs_request_private *p  = request->plugin_data;
+    struct demofs_inode           *op = p->inode_stash[0];
+    struct demofs_inode           *np = p->inode_stash[1];
+
+    if (op) {
+    }
+    if (np && np != op) {
+    }
+} /* demofs_rename_at_unlock_parents */
+
+static void
+demofs_rename_at_existing_cb(
+    struct demofs_inode *existing_inode,
+    int                  status,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+    struct demofs_inode           *child   = p->inode_stash[2];
+
+    if (status != CHIMERA_VFS_OK) {
+        /* Existing dirent referenced a stale inum — proceed without delete. */
+        p->inode_stash[3] = NULL;
+        demofs_rename_at_perform(request);
+        return;
+    }
+
+    if (S_ISDIR(child->mode) != S_ISDIR(existing_inode->mode)) {
+        int err = S_ISDIR(existing_inode->mode) ? CHIMERA_VFS_EISDIR : CHIMERA_VFS_ENOTDIR;
+        demofs_rename_at_unlock_parents(request);
+        demofs_op_fail(request, p->txn, err);
+        return;
+    }
+    if (S_ISDIR(existing_inode->mode) && existing_inode->nlink > 2) {
+        demofs_rename_at_unlock_parents(request);
+        demofs_op_fail(request, p->txn, CHIMERA_VFS_ENOTEMPTY);
+        return;
+    }
+
+    p->inode_stash[3] = existing_inode;
+    demofs_rename_at_perform(request);
+} /* demofs_rename_at_existing_cb */
+
+static void
+demofs_rename_at_perform(struct chimera_vfs_request *request)
+{
+    struct demofs_request_private *p              = request->plugin_data;
+    struct demofs_thread          *thread         = p->thread;
+    struct demofs_inode           *op             = p->inode_stash[0];
+    struct demofs_inode           *np             = p->inode_stash[1];
+    struct demofs_inode           *child          = p->inode_stash[2];
+    struct demofs_inode           *existing_inode = p->inode_stash[3];
+    struct demofs_dirent          *old_dirent, *existing_dirent = NULL, *new_dirent;
+    uint64_t                       hash     = request->rename_at.name_hash;
+    uint64_t                       new_hash = request->rename_at.new_name_hash;
+    struct timespec                now;
 
     clock_gettime(CLOCK_REALTIME, &now);
 
-    hash     = request->rename_at.name_hash;
-    new_hash = request->rename_at.new_name_hash;
+    rb_tree_query_exact(&op->dir.dirents, hash, hash, old_dirent);
 
-    cmp = demofs_fh_compare(request->fh,
-                            request->fh_len,
-                            request->rename_at.new_fh,
-                            request->rename_at.new_fhlen);
-
-    if (cmp == 0) {
-        old_parent_inode = demofs_inode_get_fh(shared,
-                                               request->fh,
-                                               request->fh_len);
-
-        if (!old_parent_inode) {
-            request->status = CHIMERA_VFS_ENOENT;
-            request->complete(request);
-            return;
-        }
-
-        if (!S_ISDIR(old_parent_inode->mode)) {
-            pthread_mutex_unlock(&old_parent_inode->lock);
-            request->status = CHIMERA_VFS_ENOTDIR;
-            request->complete(request);
-            return;
-        }
-
-        new_parent_inode = old_parent_inode;
-    } else {
-        if (cmp < 0) {
-            old_parent_inode = demofs_inode_get_fh(shared,
-                                                   request->fh,
-                                                   request->fh_len);
-
-            new_parent_inode = demofs_inode_get_fh(shared,
-                                                   request->rename_at.new_fh,
-                                                   request->rename_at.new_fhlen);
-        } else {
-            new_parent_inode = demofs_inode_get_fh(shared,
-                                                   request->rename_at.new_fh,
-                                                   request->rename_at.new_fhlen);
-            old_parent_inode = demofs_inode_get_fh(shared,
-                                                   request->fh,
-                                                   request->fh_len);
-        }
-
-        if (!old_parent_inode) {
-            request->status = CHIMERA_VFS_ENOENT;
-            request->complete(request);
-            return;
-        }
-
-        if (!S_ISDIR(old_parent_inode->mode)) {
-            pthread_mutex_unlock(&old_parent_inode->lock);
-            request->status = CHIMERA_VFS_ENOTDIR;
-            request->complete(request);
-            return;
-        }
-
-        if (!new_parent_inode) {
-            request->status = CHIMERA_VFS_ENOENT;
-            request->complete(request);
-            return;
-        }
-
-        if (!S_ISDIR(new_parent_inode->mode)) {
-            pthread_mutex_unlock(&new_parent_inode->lock);
-            request->status = CHIMERA_VFS_ENOTDIR;
-            request->complete(request);
-            return;
-        }
-    }
-
-    demofs_map_attrs(thread, &request->rename_at.r_fromdir_pre_attr, old_parent_inode);
-    demofs_map_attrs(thread, &request->rename_at.r_todir_pre_attr, new_parent_inode);
-
-    rb_tree_query_exact(&old_parent_inode->dir.dirents, hash, hash, old_dirent);
-
-    if (!old_dirent) {
-        pthread_mutex_unlock(&old_parent_inode->lock);
-        pthread_mutex_unlock(&new_parent_inode->lock);
-        request->status = CHIMERA_VFS_ENOENT;
-        request->complete(request);
-        return;
-    }
-
-    child_inode = demofs_inode_get_inum(shared, old_dirent->inum, old_dirent->gen);
-
-    if (!child_inode) {
-        pthread_mutex_unlock(&old_parent_inode->lock);
-        if (cmp != 0) {
-            pthread_mutex_unlock(&new_parent_inode->lock);
-        }
-        request->status = CHIMERA_VFS_ENOENT;
-        request->complete(request);
-        return;
-    }
-
-    /* Check if destination already exists */
-    rb_tree_query_exact(&new_parent_inode->dir.dirents, new_hash, hash, existing_dirent);
-
-    if (existing_dirent) {
-        /* Check if source and destination refer to the same inode (hardlinks).
-         * Per POSIX/Linux: if oldpath and newpath are hardlinks to the same file,
-         * rename() should do nothing and return success. */
-        if (existing_dirent->inum == old_dirent->inum &&
-            existing_dirent->gen == old_dirent->gen) {
-            /* Same inode - do nothing, just return success */
-            demofs_map_attrs(thread, &request->rename_at.r_fromdir_post_attr, old_parent_inode);
-            demofs_map_attrs(thread, &request->rename_at.r_todir_post_attr, new_parent_inode);
-            pthread_mutex_unlock(&child_inode->lock);
-            if (cmp != 0) {
-                pthread_mutex_unlock(&old_parent_inode->lock);
-                pthread_mutex_unlock(&new_parent_inode->lock);
-            } else {
-                pthread_mutex_unlock(&old_parent_inode->lock);
-            }
-
-            request->status = CHIMERA_VFS_OK;
-            request->complete(request);
-            return;
-        }
-
-        /* Destination exists - check if we can replace it */
-        existing_inode = demofs_inode_get_inum(shared, existing_dirent->inum, existing_dirent->gen);
-
-        if (existing_inode) {
-            /* Cannot rename a directory over a non-directory or vice versa */
-            if (S_ISDIR(child_inode->mode) != S_ISDIR(existing_inode->mode)) {
-                pthread_mutex_unlock(&existing_inode->lock);
-                pthread_mutex_unlock(&child_inode->lock);
-                pthread_mutex_unlock(&old_parent_inode->lock);
-                if (cmp != 0) {
-                    pthread_mutex_unlock(&new_parent_inode->lock);
-                }
-                request->status = S_ISDIR(existing_inode->mode) ? CHIMERA_VFS_EISDIR : CHIMERA_VFS_ENOTDIR;
-                request->complete(request);
-                return;
-            }
-
-            /* Cannot replace non-empty directory */
-            if (S_ISDIR(existing_inode->mode) && existing_inode->nlink > 2) {
-                pthread_mutex_unlock(&existing_inode->lock);
-                pthread_mutex_unlock(&child_inode->lock);
-                pthread_mutex_unlock(&old_parent_inode->lock);
-                if (cmp != 0) {
-                    pthread_mutex_unlock(&new_parent_inode->lock);
-                }
-                request->status = CHIMERA_VFS_ENOTEMPTY;
-                request->complete(request);
-                return;
-            }
-
-            /* Remove the existing destination entry and decrement link count */
-            rb_tree_remove(&new_parent_inode->dir.dirents, &existing_dirent->node);
+    if (existing_inode) {
+        rb_tree_query_exact(&np->dir.dirents, new_hash, hash, existing_dirent);
+        if (existing_dirent) {
+            rb_tree_remove(&np->dir.dirents, &existing_dirent->node);
             existing_inode->nlink--;
             if (S_ISDIR(existing_inode->mode)) {
-                new_parent_inode->nlink--;
+                np->nlink--;
             }
-            pthread_mutex_unlock(&existing_inode->lock);
             demofs_dirent_free(thread, existing_dirent);
         }
     }
@@ -3356,42 +4212,322 @@ demofs_rename_at(
                                      request->rename_at.new_name,
                                      request->rename_at.new_namelen);
 
-    rb_tree_insert(&new_parent_inode->dir.dirents, hash, new_dirent);
+    rb_tree_insert(&np->dir.dirents, hash, new_dirent);
+    rb_tree_remove(&op->dir.dirents, &old_dirent->node);
 
-    rb_tree_remove(&old_parent_inode->dir.dirents, &old_dirent->node);
-
-    if (S_ISDIR(child_inode->mode)) {
-        old_parent_inode->nlink--;
-        new_parent_inode->nlink++;
+    if (S_ISDIR(child->mode)) {
+        op->nlink--;
+        np->nlink++;
     }
 
-    old_parent_inode->mtime_sec  = now.tv_sec;
-    old_parent_inode->mtime_nsec = now.tv_nsec;
-    old_parent_inode->ctime_sec  = now.tv_sec;
-    old_parent_inode->ctime_nsec = now.tv_nsec;
-    new_parent_inode->mtime_sec  = now.tv_sec;
-    new_parent_inode->mtime_nsec = now.tv_nsec;
-    new_parent_inode->ctime_sec  = now.tv_sec;
-    new_parent_inode->ctime_nsec = now.tv_nsec;
-
-    demofs_map_attrs(thread, &request->rename_at.r_fromdir_post_attr, old_parent_inode);
-    demofs_map_attrs(thread, &request->rename_at.r_todir_post_attr, new_parent_inode);
-
-    if (cmp != 0) {
-        pthread_mutex_unlock(&old_parent_inode->lock);
-        pthread_mutex_unlock(&new_parent_inode->lock);
-    } else {
-        pthread_mutex_unlock(&old_parent_inode->lock);
+    op->mtime_sec  = now.tv_sec;
+    op->mtime_nsec = now.tv_nsec;
+    op->ctime_sec  = now.tv_sec;
+    op->ctime_nsec = now.tv_nsec;
+    if (np != op) {
+        np->mtime_sec  = now.tv_sec;
+        np->mtime_nsec = now.tv_nsec;
+        np->ctime_sec  = now.tv_sec;
+        np->ctime_nsec = now.tv_nsec;
     }
 
-    pthread_mutex_unlock(&child_inode->lock);
+    demofs_map_attrs(thread, &request->rename_at.r_fromdir_post_attr, op);
+    demofs_map_attrs(thread, &request->rename_at.r_todir_post_attr, np);
 
+    demofs_rename_at_unlock_parents(request);
     demofs_dirent_free(thread, old_dirent);
+    demofs_op_ok(request, p->txn);
+} /* demofs_rename_at_perform */
 
-    request->status = CHIMERA_VFS_OK;
-    request->complete(request);
+static void
+demofs_rename_at_child_cb(
+    struct demofs_inode *child,
+    int                  status,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+    struct demofs_thread          *thread  = p->thread;
+    struct demofs_inode           *op      = p->inode_stash[0];
+    struct demofs_inode           *np      = p->inode_stash[1];
+    struct demofs_dirent          *old_dirent, *existing_dirent;
+    uint64_t                       hash     = request->rename_at.name_hash;
+    uint64_t                       new_hash = request->rename_at.new_name_hash;
 
+    if (unlikely(status != CHIMERA_VFS_OK)) {
+        demofs_rename_at_unlock_parents(request);
+        demofs_op_fail(request, p->txn, status);
+        return;
+    }
+
+    p->inode_stash[2] = child;
+
+    rb_tree_query_exact(&op->dir.dirents, hash, hash, old_dirent);
+    if (unlikely(!old_dirent)) {
+        demofs_rename_at_unlock_parents(request);
+        demofs_op_fail(request, p->txn, CHIMERA_VFS_ENOENT);
+        return;
+    }
+
+    rb_tree_query_exact(&np->dir.dirents, new_hash, hash, existing_dirent);
+
+    if (!existing_dirent) {
+        p->inode_stash[3] = NULL;
+        demofs_rename_at_perform(request);
+        return;
+    }
+
+    /* Hardlink shortcut: source and dest already refer to the same inode. */
+    if (existing_dirent->inum == old_dirent->inum &&
+        existing_dirent->gen == old_dirent->gen) {
+        demofs_map_attrs(thread, &request->rename_at.r_fromdir_post_attr, op);
+        demofs_map_attrs(thread, &request->rename_at.r_todir_post_attr, np);
+        demofs_rename_at_unlock_parents(request);
+        demofs_op_ok(request, p->txn);
+        return;
+    }
+
+    demofs_inode_get_inum_async(thread, p->txn,
+                                existing_dirent->inum, existing_dirent->gen,
+                                demofs_rename_at_existing_cb, request);
+} /* demofs_rename_at_child_cb */
+
+static void
+demofs_rename_at_have_parents(struct chimera_vfs_request *request)
+{
+    struct demofs_request_private *p      = request->plugin_data;
+    struct demofs_thread          *thread = p->thread;
+    struct demofs_inode           *op     = p->inode_stash[0];
+    struct demofs_inode           *np     = p->inode_stash[1];
+    struct demofs_dirent          *old_dirent;
+    uint64_t                       hash = request->rename_at.name_hash;
+
+    demofs_map_attrs(thread, &request->rename_at.r_fromdir_pre_attr, op);
+    demofs_map_attrs(thread, &request->rename_at.r_todir_pre_attr, np);
+
+    rb_tree_query_exact(&op->dir.dirents, hash, hash, old_dirent);
+    if (!old_dirent) {
+        demofs_rename_at_unlock_parents(request);
+        demofs_op_fail(request, p->txn, CHIMERA_VFS_ENOENT);
+        return;
+    }
+
+    demofs_inode_get_inum_async(thread, p->txn,
+                                old_dirent->inum, old_dirent->gen,
+                                demofs_rename_at_child_cb, request);
+} /* demofs_rename_at_have_parents */
+
+static void
+demofs_rename_at_second_cb(
+    struct demofs_inode *inode,
+    int                  status,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+    int                            cmp;
+
+    cmp = demofs_fh_compare(request->fh, request->fh_len,
+                            request->rename_at.new_fh,
+                            request->rename_at.new_fhlen);
+
+    if (unlikely(status != CHIMERA_VFS_OK)) {
+        demofs_rename_at_unlock_parents(request);
+        demofs_op_fail(request, p->txn, status);
+        return;
+    }
+
+    if (!S_ISDIR(inode->mode)) {
+        demofs_rename_at_unlock_parents(request);
+        demofs_op_fail(request, p->txn, CHIMERA_VFS_ENOTDIR);
+        return;
+    }
+
+    if (cmp < 0) {
+        p->inode_stash[1] = inode;
+    } else {
+        p->inode_stash[0] = inode;
+    }
+    demofs_rename_at_have_parents(request);
+} /* demofs_rename_at_second_cb */
+
+static void
+demofs_rename_at_first_cb(
+    struct demofs_inode *inode,
+    int                  status,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+    struct demofs_thread          *thread  = p->thread;
+    int                            cmp;
+
+    if (unlikely(status != CHIMERA_VFS_OK)) {
+        demofs_op_fail(request, p->txn, status);
+        return;
+    }
+
+    if (!S_ISDIR(inode->mode)) {
+        demofs_op_fail(request, p->txn, CHIMERA_VFS_ENOTDIR);
+        return;
+    }
+
+    cmp = demofs_fh_compare(request->fh, request->fh_len,
+                            request->rename_at.new_fh,
+                            request->rename_at.new_fhlen);
+
+    if (cmp == 0) {
+        p->inode_stash[0] = inode;
+        p->inode_stash[1] = inode;
+        demofs_rename_at_have_parents(request);
+        return;
+    }
+
+    if (cmp < 0) {
+        p->inode_stash[0] = inode;
+        demofs_inode_get_fh_async(thread, p->txn,
+                                  request->rename_at.new_fh,
+                                  request->rename_at.new_fhlen,
+                                  demofs_rename_at_second_cb, request);
+    } else {
+        p->inode_stash[1] = inode;
+        demofs_inode_get_fh_async(thread, p->txn,
+                                  request->fh, request->fh_len,
+                                  demofs_rename_at_second_cb, request);
+    }
+} /* demofs_rename_at_first_cb */
+
+static void
+demofs_rename_at(
+    struct demofs_thread       *thread,
+    struct demofs_shared       *shared,
+    struct chimera_vfs_request *request,
+    void                       *private_data)
+{
+    struct demofs_request_private *p = request->plugin_data;
+    int                            cmp;
+
+    (void) shared;
+    (void) private_data;
+
+    p->thread         = thread;
+    p->txn            = demofs_txn_begin(thread, DEMOFS_TXN_WRITE);
+    p->inode_stash[0] = NULL;
+    p->inode_stash[1] = NULL;
+    p->inode_stash[2] = NULL;
+    p->inode_stash[3] = NULL;
+
+    cmp = demofs_fh_compare(request->fh, request->fh_len,
+                            request->rename_at.new_fh,
+                            request->rename_at.new_fhlen);
+
+    if (cmp <= 0) {
+        demofs_inode_get_fh_async(thread, p->txn,
+                                  request->fh, request->fh_len,
+                                  demofs_rename_at_first_cb, request);
+    } else {
+        demofs_inode_get_fh_async(thread, p->txn,
+                                  request->rename_at.new_fh,
+                                  request->rename_at.new_fhlen,
+                                  demofs_rename_at_first_cb, request);
+    }
 } /* demofs_rename_at */
+
+/* inode_stash[0] = parent dir; inode_stash[1] = link target inode (both locked) */
+
+static void
+demofs_link_at_inode_cb(
+    struct demofs_inode *inode,
+    int                  status,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+    struct demofs_thread          *thread  = p->thread;
+    struct demofs_inode           *parent  = p->inode_stash[0];
+    struct demofs_inode           *existing_inode;
+    struct demofs_dirent          *dirent;
+    uint64_t                       hash = request->link_at.name_hash;
+    struct timespec                now;
+
+    if (unlikely(status != CHIMERA_VFS_OK)) {
+        demofs_op_fail(request, p->txn, status);
+        return;
+    }
+
+    if (unlikely(S_ISDIR(inode->mode))) {
+        demofs_op_fail(request, p->txn, CHIMERA_VFS_EISDIR);
+        return;
+    }
+
+    rb_tree_query_exact(&parent->dir.dirents, hash, hash, dirent);
+
+    if (dirent) {
+        if (request->link_at.replace && !S_ISDIR(inode->mode)) {
+            existing_inode = demofs_inode_get_inum(thread->shared,
+                                                   dirent->inum, dirent->gen);
+            chimera_demofs_abort_if(!existing_inode,
+                                    "demofs_link_at: existing_inode not found");
+            demofs_txn_pin_inode(p->txn, existing_inode);
+            existing_inode->nlink--;
+            demofs_map_attrs(thread, &request->link_at.r_replaced_attr,
+                             existing_inode);
+            rb_tree_remove(&parent->dir.dirents, &dirent->node);
+        } else {
+            demofs_op_fail(request, p->txn, CHIMERA_VFS_EEXIST);
+            return;
+        }
+    }
+
+    clock_gettime(CLOCK_REALTIME, &now);
+
+    dirent = demofs_dirent_alloc(thread, inode->inum, inode->gen, hash,
+                                 request->link_at.name,
+                                 request->link_at.namelen);
+    rb_tree_insert(&parent->dir.dirents, hash, dirent);
+
+    inode->nlink++;
+    inode->ctime_sec   = now.tv_sec;
+    inode->ctime_nsec  = now.tv_nsec;
+    parent->mtime_sec  = now.tv_sec;
+    parent->mtime_nsec = now.tv_nsec;
+    parent->ctime_sec  = now.tv_sec;
+    parent->ctime_nsec = now.tv_nsec;
+
+    demofs_map_attrs(thread, &request->link_at.r_attr, inode);
+    demofs_map_attrs(thread, &request->link_at.r_dir_post_attr, parent);
+
+
+    demofs_op_ok(request, p->txn);
+} /* demofs_link_at_inode_cb */
+
+static void
+demofs_link_at_parent_cb(
+    struct demofs_inode *parent,
+    int                  status,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+    struct demofs_thread          *thread  = p->thread;
+
+    if (unlikely(status != CHIMERA_VFS_OK)) {
+        demofs_op_fail(request, p->txn, status);
+        return;
+    }
+
+    demofs_map_attrs(thread, &request->link_at.r_dir_pre_attr, parent);
+
+    if (!S_ISDIR(parent->mode)) {
+        demofs_op_fail(request, p->txn, CHIMERA_VFS_ENOTDIR);
+        return;
+    }
+
+    p->inode_stash[0] = parent;
+    demofs_inode_get_fh_async(thread, p->txn,
+                              request->fh, request->fh_len,
+                              demofs_link_at_inode_cb, request);
+} /* demofs_link_at_parent_cb */
 
 static void
 demofs_link_at(
@@ -3400,109 +4536,18 @@ demofs_link_at(
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
-    struct demofs_inode  *parent_inode, *inode, *existing_inode;
-    uint64_t              hash;
-    struct demofs_dirent *dirent;
-    struct timespec       now;
+    struct demofs_request_private *p = request->plugin_data;
 
-    clock_gettime(CLOCK_REALTIME, &now);
+    (void) shared;
+    (void) private_data;
 
-    hash = request->link_at.name_hash;
+    p->thread = thread;
+    p->txn    = demofs_txn_begin(thread, DEMOFS_TXN_WRITE);
 
-    parent_inode = demofs_inode_get_fh(shared,
-                                       request->link_at.dir_fh,
-                                       request->link_at.dir_fhlen);
-
-    if (!parent_inode) {
-        request->status = CHIMERA_VFS_ENOENT;
-        request->complete(request);
-        return;
-    }
-
-    demofs_map_attrs(thread, &request->link_at.r_dir_pre_attr, parent_inode);
-
-    if (!S_ISDIR(parent_inode->mode)) {
-        pthread_mutex_unlock(&parent_inode->lock);
-        request->status = CHIMERA_VFS_ENOTDIR;
-        request->complete(request);
-        return;
-    }
-
-    inode = demofs_inode_get_fh(shared, request->fh, request->fh_len);
-
-    if (!inode) {
-        pthread_mutex_unlock(&parent_inode->lock);
-        request->status = CHIMERA_VFS_ENOENT;
-        request->complete(request);
-        return;
-    }
-
-    if (unlikely(S_ISDIR(inode->mode))) {
-        pthread_mutex_unlock(&parent_inode->lock);
-        pthread_mutex_unlock(&inode->lock);
-        request->status = CHIMERA_VFS_EISDIR;
-        request->complete(request);
-        return;
-    }
-
-
-    rb_tree_query_exact(&parent_inode->dir.dirents, hash, hash, dirent);
-
-    if (dirent) {
-
-        if (request->link_at.replace && !S_ISDIR(inode->mode)) {
-
-            existing_inode = demofs_inode_get_inum(shared,
-                                                   dirent->inum,
-                                                   dirent->gen);
-
-            chimera_demofs_abort_if(!existing_inode, "demofs_link_at: existing_inode not found");
-
-            existing_inode->nlink--;
-
-            demofs_map_attrs(thread, &request->link_at.r_replaced_attr, existing_inode);
-
-            pthread_mutex_unlock(&existing_inode->lock);
-
-            rb_tree_remove(&parent_inode->dir.dirents, &dirent->node);
-
-
-        } else {
-            pthread_mutex_unlock(&parent_inode->lock);
-            pthread_mutex_unlock(&inode->lock);
-            request->status = CHIMERA_VFS_EEXIST;
-            request->complete(request);
-            return;
-        }
-    }
-
-    dirent = demofs_dirent_alloc(thread,
-                                 inode->inum,
-                                 inode->gen,
-                                 hash,
-                                 request->link_at.name,
-                                 request->link_at.namelen);
-
-    rb_tree_insert(&parent_inode->dir.dirents, hash, dirent);
-
-    inode->nlink++;
-
-    inode->ctime_sec         = now.tv_sec;
-    inode->ctime_nsec        = now.tv_nsec;
-    parent_inode->mtime_sec  = now.tv_sec;
-    parent_inode->mtime_nsec = now.tv_nsec;
-    parent_inode->ctime_sec  = now.tv_sec;
-    parent_inode->ctime_nsec = now.tv_nsec;
-
-    demofs_map_attrs(thread, &request->link_at.r_attr, inode);
-    demofs_map_attrs(thread, &request->link_at.r_dir_post_attr, parent_inode);
-
-    pthread_mutex_unlock(&parent_inode->lock);
-    pthread_mutex_unlock(&inode->lock);
-
-    request->status = CHIMERA_VFS_OK;
-    request->complete(request);
-
+    demofs_inode_get_fh_async(thread, p->txn,
+                              request->link_at.dir_fh,
+                              request->link_at.dir_fhlen,
+                              demofs_link_at_parent_cb, request);
 } /* demofs_link_at */
 
 
@@ -3513,10 +4558,16 @@ demofs_put_key(
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
-    uint64_t                hash;
-    int                     shard_idx;
-    struct demofs_kv_shard *shard;
-    struct demofs_kv_entry *entry, *existing;
+    struct demofs_request_private *p = request->plugin_data;
+    uint64_t                       hash;
+    int                            shard_idx;
+    struct demofs_kv_shard        *shard;
+    struct demofs_kv_entry        *entry, *existing;
+
+    (void) private_data;
+
+    p->thread = thread;
+    p->txn    = demofs_txn_begin(thread, DEMOFS_TXN_WRITE);
 
     hash      = chimera_vfs_hash(request->put_key.key, request->put_key.key_len);
     shard_idx = hash % shared->num_kv_shards;
@@ -3524,31 +4575,25 @@ demofs_put_key(
 
     pthread_mutex_lock(&shard->lock);
 
-    /* Check if key already exists */
     rb_tree_query_exact(&shard->entries, hash, hash, existing);
 
     if (existing) {
-        /* Update existing entry */
         slab_allocator_free(thread->allocator, existing->value, existing->value_len);
         existing->value_len = request->put_key.value_len;
         existing->value     = slab_allocator_alloc(thread->allocator, request->put_key.value_len);
         memcpy(existing->value, request->put_key.value, request->put_key.value_len);
     } else {
-        /* Insert new entry */
-        entry = demofs_kv_entry_alloc(thread,
-                                      hash,
+        entry = demofs_kv_entry_alloc(thread, hash,
                                       request->put_key.key,
                                       request->put_key.key_len,
                                       request->put_key.value,
                                       request->put_key.value_len);
-
         rb_tree_insert(&shard->entries, hash, entry);
     }
 
     pthread_mutex_unlock(&shard->lock);
 
-    request->status = CHIMERA_VFS_OK;
-    request->complete(request);
+    demofs_op_ok(request, p->txn);
 } /* demofs_put_key */
 
 static void
@@ -3558,10 +4603,16 @@ demofs_get_key(
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
-    uint64_t                hash;
-    int                     shard_idx;
-    struct demofs_kv_shard *shard;
-    struct demofs_kv_entry *entry;
+    struct demofs_request_private *p = request->plugin_data;
+    uint64_t                       hash;
+    int                            shard_idx;
+    struct demofs_kv_shard        *shard;
+    struct demofs_kv_entry        *entry;
+
+    (void) private_data;
+
+    p->thread = thread;
+    p->txn    = demofs_txn_begin(thread, DEMOFS_TXN_READ);
 
     hash      = chimera_vfs_hash(request->get_key.key, request->get_key.key_len);
     shard_idx = hash % shared->num_kv_shards;
@@ -3573,19 +4624,16 @@ demofs_get_key(
 
     if (!entry) {
         pthread_mutex_unlock(&shard->lock);
-        request->status = CHIMERA_VFS_ENOENT;
-        request->complete(request);
+        demofs_op_fail(request, p->txn, CHIMERA_VFS_ENOENT);
         return;
     }
 
-    /* Return pointer to value - caller must use before callback returns */
     request->get_key.r_value     = entry->value;
     request->get_key.r_value_len = entry->value_len;
 
     pthread_mutex_unlock(&shard->lock);
 
-    request->status = CHIMERA_VFS_OK;
-    request->complete(request);
+    demofs_op_ok(request, p->txn);
 } /* demofs_get_key */
 
 static void
@@ -3595,10 +4643,16 @@ demofs_delete_key(
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
-    uint64_t                hash;
-    int                     shard_idx;
-    struct demofs_kv_shard *shard;
-    struct demofs_kv_entry *entry;
+    struct demofs_request_private *p = request->plugin_data;
+    uint64_t                       hash;
+    int                            shard_idx;
+    struct demofs_kv_shard        *shard;
+    struct demofs_kv_entry        *entry;
+
+    (void) private_data;
+
+    p->thread = thread;
+    p->txn    = demofs_txn_begin(thread, DEMOFS_TXN_WRITE);
 
     hash      = chimera_vfs_hash(request->delete_key.key, request->delete_key.key_len);
     shard_idx = hash % shared->num_kv_shards;
@@ -3610,19 +4664,16 @@ demofs_delete_key(
 
     if (!entry) {
         pthread_mutex_unlock(&shard->lock);
-        request->status = CHIMERA_VFS_ENOENT;
-        request->complete(request);
+        demofs_op_fail(request, p->txn, CHIMERA_VFS_ENOENT);
         return;
     }
 
     rb_tree_remove(&shard->entries, &entry->node);
-
     pthread_mutex_unlock(&shard->lock);
 
     demofs_kv_entry_free(thread, entry);
 
-    request->status = CHIMERA_VFS_OK;
-    request->complete(request);
+    demofs_op_ok(request, p->txn);
 } /* demofs_delete_key */
 
 static int
@@ -3664,39 +4715,38 @@ demofs_search_keys(
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
+    struct demofs_request_private     *p = request->plugin_data;
     int                                i, rc;
     struct demofs_kv_shard            *shard;
     struct demofs_kv_entry            *entry;
     chimera_vfs_search_keys_callback_t callback = request->search_keys.callback;
 
-    /* Iterate over all shards */
+    (void) private_data;
+
+    p->thread = thread;
+    p->txn    = demofs_txn_begin(thread, DEMOFS_TXN_READ);
+
     for (i = 0; i < shared->num_kv_shards; i++) {
         shard = &shared->kv_shards[i];
 
         pthread_mutex_lock(&shard->lock);
 
-        /* Iterate over all entries in the shard */
         rb_tree_first(&shard->entries, entry);
 
         while (entry) {
-            /* Check if key is in range */
             if (demofs_kv_key_in_range(entry->key,
                                        entry->key_len,
                                        request->search_keys.start_key,
                                        request->search_keys.start_key_len,
                                        request->search_keys.end_key,
                                        request->search_keys.end_key_len)) {
-                rc = callback(entry->key,
-                              entry->key_len,
-                              entry->value,
-                              entry->value_len,
+                rc = callback(entry->key, entry->key_len,
+                              entry->value, entry->value_len,
                               request->proto_private_data);
 
                 if (rc) {
-                    /* Caller wants to abort search */
                     pthread_mutex_unlock(&shard->lock);
-                    request->status = CHIMERA_VFS_OK;
-                    request->complete(request);
+                    demofs_op_ok(request, p->txn);
                     return;
                 }
             }
@@ -3707,8 +4757,7 @@ demofs_search_keys(
         pthread_mutex_unlock(&shard->lock);
     }
 
-    request->status = CHIMERA_VFS_OK;
-    request->complete(request);
+    demofs_op_ok(request, p->txn);
 } /* demofs_search_keys */
 
 static void
@@ -3770,9 +4819,16 @@ demofs_dispatch(
             demofs_write(thread, shared, request, private_data);
             break;
         case CHIMERA_VFS_OP_COMMIT:
-            request->status = CHIMERA_VFS_OK;
-            request->complete(request);
-            break;
+        {
+            /* No-op today: writes already wait for durability before
+             * acking.  Once a real intent log lands, COMMIT will fence
+             * on outstanding intent log records. */
+            struct demofs_request_private *cp = request->plugin_data;
+            cp->thread = thread;
+            cp->txn    = demofs_txn_begin(thread, DEMOFS_TXN_READ);
+            demofs_op_ok(request, cp->txn);
+        }
+        break;
         case CHIMERA_VFS_OP_ALLOCATE:
             demofs_allocate(thread, shared, request, private_data);
             break;

--- a/src/vfs/demofs/demofs.c
+++ b/src/vfs/demofs/demofs.c
@@ -653,9 +653,14 @@ struct demofs_bt_op {
     int                       removed_idx;
     int                       reb_level;
 
-    /* completion */
+    /* completion.  cb fires only when the op actually suspended (an I/O
+     * deferred it); a fully-resident traversal completes inline and reports
+     * via `done`/`result` so callers can iterate without recursing. */
     demofs_bt_cb_t            cb;
     void                     *private_data;
+    int                       suspended;
+    int                       done;
+    int                       result;
 
     /* block-waiter list / per-worker resume-queue linkage */
     struct demofs_bt_op      *next;
@@ -1392,8 +1397,10 @@ demofs_bt_block_get(
         issue = 1;
     }
 
-    /* Park this op on the block's waiter list. */
-    op->next = NULL;
+    /* Park this op on the block's waiter list; it can no longer complete
+     * inline, so its result will be delivered via the callback. */
+    op->suspended = 1;
+    op->next      = NULL;
     if (blk->wait_tail) {
         blk->wait_tail->next = op;
     } else {
@@ -2583,7 +2590,12 @@ demofs_bt_complete(
     struct demofs_bt_op *op,
     int                  result)
 {
-    op->cb(op, result, op->private_data);
+    op->result = result;
+    if (op->suspended) {
+        op->cb(op, result, op->private_data);
+    } else {
+        op->done = 1;
+    }
 } /* demofs_bt_complete */
 
 /*
@@ -2773,24 +2785,103 @@ demofs_bt_run(struct demofs_bt_op *op)
  * traversal currently hits in cache, so the op completes inline before the
  * entry point returns and we capture the result here.
  */
-struct demofs_bt_sync {
-    int done;
-    int result;
-};
-
-static void
-demofs_bt_sync_cb(
-    struct demofs_bt_op *op,
-    int                  result,
-    void                *private_data)
+/*
+ * Start an async lookup on a caller-owned op.  Returns 1 if it completed
+ * synchronously (result in op->result, outputs already written into
+ * out/r_key), 0 if it suspended (op->cb will be invoked with the result once
+ * the deferring I/O completes).
+ */
+static int
+demofs_bt_lookup_async(
+    struct demofs_bt_op        *op,
+    struct demofs_thread       *thread,
+    struct demofs_inode        *inode,
+    enum demofs_bt_opcode       opcode,
+    const struct demofs_bt_key *key,
+    struct demofs_bt_key       *r_key,
+    void                       *out,
+    uint32_t                    out_cap,
+    demofs_bt_cb_t              cb,
+    void                       *private_data)
 {
-    struct demofs_bt_sync *s = private_data;
+    memset(op, 0, sizeof(*op));
+    op->thread       = thread;
+    op->inode        = inode;
+    op->opcode       = opcode;
+    op->phase        = DEMOFS_BT_PHASE_DESCEND;
+    op->key          = *key;
+    op->r_key        = r_key;
+    op->out          = out;
+    op->out_cap      = out_cap;
+    op->use_root     = 1;
+    op->cb           = cb;
+    op->private_data = private_data;
 
-    (void) op;
-    s->result = result;
-    s->done   = 1;
-} /* demofs_bt_sync_cb */
+    demofs_bt_run(op);
+    return op->done;
+} /* demofs_bt_lookup_async */
 
+static int
+demofs_bt_insert_async(
+    struct demofs_bt_op        *op,
+    struct demofs_thread       *thread,
+    struct demofs_txn          *txn,
+    struct demofs_inode        *inode,
+    const struct demofs_bt_key *key,
+    const void                 *rec,
+    uint32_t                    reclen,
+    demofs_bt_cb_t              cb,
+    void                       *private_data)
+{
+    chimera_demofs_abort_if(reclen > sizeof(op->recbuf), "b+tree record too large");
+
+    memset(op, 0, sizeof(*op));
+    op->thread       = thread;
+    op->txn          = txn;
+    op->inode        = inode;
+    op->opcode       = DEMOFS_BT_OP_INSERT;
+    op->phase        = DEMOFS_BT_PHASE_DESCEND;
+    op->key          = *key;
+    op->reclen       = reclen;
+    op->use_root     = 1;
+    op->cb           = cb;
+    op->private_data = private_data;
+    memcpy(op->recbuf, rec, reclen);
+
+    demofs_bt_run(op);
+    return op->done;
+} /* demofs_bt_insert_async */
+
+static int
+demofs_bt_remove_async(
+    struct demofs_bt_op        *op,
+    struct demofs_thread       *thread,
+    struct demofs_txn          *txn,
+    struct demofs_inode        *inode,
+    const struct demofs_bt_key *key,
+    demofs_bt_cb_t              cb,
+    void                       *private_data)
+{
+    memset(op, 0, sizeof(*op));
+    op->thread       = thread;
+    op->txn          = txn;
+    op->inode        = inode;
+    op->opcode       = DEMOFS_BT_OP_REMOVE;
+    op->phase        = DEMOFS_BT_PHASE_DESCEND;
+    op->key          = *key;
+    op->use_root     = 1;
+    op->cb           = cb;
+    op->private_data = private_data;
+
+    demofs_bt_run(op);
+    return op->done;
+} /* demofs_bt_remove_async */
+
+/*
+ * Synchronous wrappers used by init/mount-time paths (which run before
+ * concurrent load, so everything is resident).  They assert that the op did
+ * not suspend, since a cache miss cannot occur until block eviction exists.
+ */
 static int
 demofs_bt_lookup_sync(
     struct demofs_thread       *thread,
@@ -2801,33 +2892,14 @@ demofs_bt_lookup_sync(
     void                       *out,
     uint32_t                    out_cap)
 {
-    struct demofs_bt_op   op;
-    struct demofs_bt_sync s = { .done = 0, .result = -1 };
+    struct demofs_bt_op op;
 
-    memset(&op, 0, sizeof(op));
-    op.thread       = thread;
-    op.inode        = inode;
-    op.opcode       = opcode;
-    op.phase        = DEMOFS_BT_PHASE_DESCEND;
-    op.key          = *key;
-    op.r_key        = r_key;
-    op.out          = out;
-    op.out_cap      = out_cap;
-    op.use_root     = 1;
-    op.cb           = demofs_bt_sync_cb;
-    op.private_data = &s;
-
-    demofs_bt_run(&op);
-    chimera_demofs_abort_if(!s.done,
+    chimera_demofs_abort_if(!demofs_bt_lookup_async(&op, thread, inode, opcode, key,
+                                                    r_key, out, out_cap, NULL, NULL),
                             "b+tree lookup suspended on a cache miss (no eviction yet)");
-    return s.result;
+    return op.result;
 } /* demofs_bt_lookup_sync */
 
-/*
- * Transitional synchronous insert: drive an INSERT op to completion.  The
- * descent faults in the path through demofs_bt_block_get; with no eviction it
- * always hits, so the structural modify runs inline before returning.
- */
 static void
 demofs_bt_insert(
     struct demofs_thread       *thread,
@@ -2837,30 +2909,13 @@ demofs_bt_insert(
     const void                 *rec,
     uint32_t                    reclen)
 {
-    struct demofs_bt_op   op;
-    struct demofs_bt_sync s = { .done = 0, .result = 0 };
+    struct demofs_bt_op op;
 
-    chimera_demofs_abort_if(reclen > sizeof(op.recbuf), "b+tree record too large");
-
-    memset(&op, 0, sizeof(op));
-    op.thread       = thread;
-    op.txn          = txn;
-    op.inode        = inode;
-    op.opcode       = DEMOFS_BT_OP_INSERT;
-    op.phase        = DEMOFS_BT_PHASE_DESCEND;
-    op.key          = *key;
-    op.reclen       = reclen;
-    op.use_root     = 1;
-    op.cb           = demofs_bt_sync_cb;
-    op.private_data = &s;
-    memcpy(op.recbuf, rec, reclen);
-
-    demofs_bt_run(&op);
-    chimera_demofs_abort_if(!s.done,
+    chimera_demofs_abort_if(!demofs_bt_insert_async(&op, thread, txn, inode, key,
+                                                    rec, reclen, NULL, NULL),
                             "b+tree insert suspended on a cache miss (no eviction yet)");
 } /* demofs_bt_insert */
 
-/* Transitional synchronous remove: drive a REMOVE op to completion. */
 static int
 demofs_bt_remove(
     struct demofs_thread       *thread,
@@ -2868,24 +2923,12 @@ demofs_bt_remove(
     struct demofs_inode        *inode,
     const struct demofs_bt_key *key)
 {
-    struct demofs_bt_op   op;
-    struct demofs_bt_sync s = { .done = 0, .result = 0 };
+    struct demofs_bt_op op;
 
-    memset(&op, 0, sizeof(op));
-    op.thread       = thread;
-    op.txn          = txn;
-    op.inode        = inode;
-    op.opcode       = DEMOFS_BT_OP_REMOVE;
-    op.phase        = DEMOFS_BT_PHASE_DESCEND;
-    op.key          = *key;
-    op.use_root     = 1;
-    op.cb           = demofs_bt_sync_cb;
-    op.private_data = &s;
-
-    demofs_bt_run(&op);
-    chimera_demofs_abort_if(!s.done,
+    chimera_demofs_abort_if(!demofs_bt_remove_async(&op, thread, txn, inode, key,
+                                                    NULL, NULL),
                             "b+tree remove suspended on a cache miss (no eviction yet)");
-    return s.result;
+    return op.result;
 } /* demofs_bt_remove */
 
 static int

--- a/src/vfs/demofs/demofs.c
+++ b/src/vfs/demofs/demofs.c
@@ -534,6 +534,21 @@ struct demofs_iq_channel {
 
 #define DEMOFS_IL_MAX_CHANNELS 256
 
+/*
+ * A durably-logged redo record awaiting tail-push.  Holds the record's own
+ * immutable on-log image (iov), so the tail-pusher writes block post-images
+ * to their final locations straight from the log copy — never racing a worker
+ * that re-dirties the live cache block.
+ */
+struct demofs_il_record {
+    uint64_t                 seq;
+    uint64_t                 offset;     /* byte offset in the intent-log region */
+    uint64_t                 reclen;
+    uint32_t                 num_blocks;
+    struct evpl_iovec        iov;
+    struct demofs_il_record *next;
+};
+
 struct demofs_intent_log {
     struct evpl_doorbell      wake_doorbell;
     struct evpl              *evpl;
@@ -546,10 +561,20 @@ struct demofs_intent_log {
     struct demofs_iq_channel *pending_head;
 
     /* Block queues on the intent-log thread's own evpl (one per device),
-     * used to write redo records into the reserved intent-log region. */
+     * used both to write redo records into the intent-log region and to
+     * tail-push logged blocks to their final on-disk locations. */
     struct evpl_block_queue **queue;
     uint64_t                  log_head;          /* next free byte in the intent-log region */
+    uint64_t                  log_tail;          /* oldest un-pushed record (trim point) */
     uint64_t                  log_seq;           /* next redo record sequence number */
+
+    /* Tail-pusher (runs on this thread): FIFO of durably-logged records whose
+    * blocks have not yet been written to their final locations.  Processed
+    * strictly oldest-first so a re-logged block's newest image lands last. */
+    struct demofs_il_record  *push_head;
+    struct demofs_il_record  *push_tail;
+    struct demofs_il_record  *push_cur;          /* record currently being pushed */
+    int                       push_outstanding;  /* home writes in flight for push_cur */
 };
 
 struct demofs_shared {
@@ -3838,8 +3863,158 @@ struct demofs_redo_ctx {
     struct demofs_intent_log *il;
     struct demofs_iq_channel *ch;
     struct demofs_iq_entry    entry;
-    struct evpl_iovec         iov;
+    struct demofs_il_record  *rec;     /* owns the record image (iov) */
 };
+
+/* Per-block home-write completion context for the tail-pusher. */
+struct demofs_push_ctx {
+    struct demofs_intent_log *il;
+    struct evpl_iovec         iov;     /* aligned copy of the block post-image */
+};
+
+/* ------------------------------------------------------------------ */
+/* Tail-pusher: write logged blocks to final locations + trim the log  */
+/* ------------------------------------------------------------------ */
+
+/*
+ * Largest contiguous run available for one record (records never wrap the end
+ * of the log region; a short run at the end is simply left unused until the
+ * tail laps it).  The log is empty exactly when no record is pending.
+ */
+static uint64_t
+demofs_il_contig_free(struct demofs_intent_log *il)
+{
+    uint64_t start = SM_INTENT_LOG_OFFSET;
+    uint64_t end   = SM_INTENT_LOG_OFFSET + SM_INTENT_LOG_SIZE;
+
+    if (!il->push_head) {
+        return SM_INTENT_LOG_SIZE;
+    }
+    if (il->log_head >= il->log_tail) {
+        uint64_t run_end   = end - il->log_head;
+        uint64_t run_start = il->log_tail - start;
+
+        return run_end > run_start ? run_end : run_start;
+    }
+    return il->log_tail - il->log_head;
+} /* demofs_il_contig_free */
+
+static int
+demofs_il_fits(
+    struct demofs_intent_log *il,
+    uint64_t                  reclen)
+{
+    return demofs_il_contig_free(il) >= reclen;
+} /* demofs_il_fits */
+
+/* Choose the offset for a record of `reclen` bytes and advance log_head. */
+static uint64_t
+demofs_il_place(
+    struct demofs_intent_log *il,
+    uint64_t                  reclen)
+{
+    uint64_t end = SM_INTENT_LOG_OFFSET + SM_INTENT_LOG_SIZE;
+    uint64_t offset;
+
+    if (il->log_head + reclen > end) {
+        il->log_head = SM_INTENT_LOG_OFFSET;     /* wrap; tail of region unused */
+    }
+    offset       = il->log_head;
+    il->log_head = offset + reclen;
+    return offset;
+} /* demofs_il_place */
+
+static void demofs_il_push_kick(
+    struct demofs_intent_log *il);
+
+/* One home-write of a logged block completed. */
+static void
+demofs_il_push_block_cb(
+    struct evpl *evpl,
+    int          status,
+    void        *private_data)
+{
+    struct demofs_push_ctx   *pc = private_data;
+    struct demofs_intent_log *il = pc->il;
+
+    chimera_demofs_abort_if(status, "tail-push home write failed: %d", status);
+    evpl_iovec_release(evpl, &pc->iov);
+    free(pc);
+
+    if (--il->push_outstanding == 0) {
+        /* Whole record is durably home; trim past it and advance the tail. */
+        struct demofs_il_record *rec = il->push_cur;
+
+        il->push_cur = NULL;
+        evpl_iovec_release(il->evpl, &rec->iov);
+        free(rec);
+
+        il->log_tail = il->push_head ? il->push_head->offset : il->log_head;
+
+        demofs_il_push_kick(il);
+
+        /* Space freed: re-poke channel processing in case a writer was
+         * blocked on a full log. */
+        evpl_ring_doorbell(&il->wake_doorbell);
+    }
+} /* demofs_il_push_block_cb */
+
+/*
+ * Start pushing the oldest pending record (if idle).  Writes every block's
+ * post-image, copied out of the immutable log record into an aligned iovec,
+ * to its final (device, offset).  Strict oldest-first ordering means a block
+ * re-logged in a later record gets its newest image written last.
+ */
+static void
+demofs_il_push_kick(struct demofs_intent_log *il)
+{
+    struct demofs_il_record         *rec;
+    struct demofs_redo_block_header *bh;
+    char                            *p;
+    uint32_t                         i;
+
+    if (il->push_cur || !il->push_head) {
+        return;
+    }
+
+    rec           = il->push_head;
+    il->push_head = rec->next;
+    if (!il->push_head) {
+        il->push_tail = NULL;
+    }
+    rec->next    = NULL;
+    il->push_cur = rec;
+
+    if (rec->num_blocks == 0) {
+        il->push_cur = NULL;
+        evpl_iovec_release(il->evpl, &rec->iov);
+        free(rec);
+        il->log_tail = il->push_head ? il->push_head->offset : il->log_head;
+        demofs_il_push_kick(il);
+        return;
+    }
+
+    /* Block I/O completes asynchronously, so no completion can fire while we
+     * issue these writes; the last completion trims the record. */
+    il->push_outstanding = rec->num_blocks;
+
+    p = (char *) rec->iov.data + sizeof(struct demofs_redo_header);
+    for (i = 0; i < rec->num_blocks; i++) {
+        struct demofs_push_ctx *pc;
+
+        bh = (struct demofs_redo_block_header *) p;
+        p += sizeof(*bh);
+
+        pc     = malloc(sizeof(*pc));
+        pc->il = il;
+        evpl_iovec_alloc(il->evpl, DEMOFS_BLOCK_SIZE, DEMOFS_BLOCK_SIZE, 1, 0, &pc->iov);
+        memcpy(pc->iov.data, p, DEMOFS_BLOCK_SIZE);
+        p += DEMOFS_BLOCK_SIZE;
+
+        evpl_block_write(il->evpl, il->queue[bh->device_id], &pc->iov, 1,
+                         bh->device_offset, 1 /* sync */, demofs_il_push_block_cb, pc);
+    }
+} /* demofs_il_push_kick */
 
 /*
  * Runs on the intent-log thread when a redo record has been written
@@ -3856,9 +4031,11 @@ demofs_redo_write_cb(
     struct demofs_redo_ctx   *ctx = private_data;
     struct demofs_iq_channel *ch  = ctx->ch;
     struct demofs_intent_log *il  = ctx->il;
+    struct demofs_il_record  *rec = ctx->rec;
     uint32_t                  cq_tail;
 
     (void) evpl;
+    chimera_demofs_abort_if(status, "redo record write failed: %d", status);
 
     demofs_txn_unpin_blocks(ctx->entry.txn, DEMOFS_BLOCK_LOGGED);
     demofs_txn_unlock_all(ctx->entry.txn);
@@ -3871,9 +4048,19 @@ demofs_redo_write_cb(
 
     ch->cq_inflight--;
 
-    evpl_iovec_release(il->evpl, &ctx->iov);
+    /* The record (which owns its on-log image) is now durable; queue it for
+     * the tail-pusher.  Its iovec stays in place -- never struct-copied. */
+    rec->next = NULL;
+    if (il->push_tail) {
+        il->push_tail->next = rec;
+    } else {
+        il->push_head = rec;
+    }
+    il->push_tail = rec;
+
     free(ctx);
 
+    demofs_il_push_kick(il);
     evpl_ring_doorbell(&ch->cq_doorbell);
 } /* demofs_redo_write_cb */
 
@@ -3890,6 +4077,7 @@ demofs_il_write_redo(
     struct demofs_txn               *txn = entry->txn;
     struct demofs_txn_block         *tb;
     struct demofs_redo_ctx          *ctx;
+    struct demofs_il_record         *rec;
     struct demofs_redo_header       *hdr;
     struct demofs_redo_block_header *bh;
     uint32_t                         nblocks = 0;
@@ -3905,22 +4093,27 @@ demofs_il_write_redo(
         (uint64_t) nblocks * (sizeof(struct demofs_redo_block_header) + DEMOFS_BLOCK_SIZE);
     reclen = (reclen + DEMOFS_BLOCK_SIZE - 1) & ~((uint64_t) DEMOFS_BLOCK_SIZE - 1);
 
-    /* Circular region; no tail/checkpoint yet, so just wrap and overwrite. */
-    if (il->log_head + reclen > SM_INTENT_LOG_OFFSET + SM_INTENT_LOG_SIZE) {
-        il->log_head = SM_INTENT_LOG_OFFSET;
-    }
-    offset        = il->log_head;
-    il->log_head += reclen;
+    /* Caller guarantees space (demofs_iq_process_channel checks demofs_il_fits
+     * before consuming the SQ entry), so placement always succeeds. */
+    offset = demofs_il_place(il, reclen);
+
+    rec             = malloc(sizeof(*rec));
+    rec->seq        = il->log_seq;
+    rec->offset     = offset;
+    rec->reclen     = reclen;
+    rec->num_blocks = nblocks;
+    rec->next       = NULL;
+
+    niov = evpl_iovec_alloc(il->evpl, reclen, DEMOFS_BLOCK_SIZE, 1, 0, &rec->iov);
+    chimera_demofs_abort_if(niov != 1, "redo record did not fit in one iovec (%d)", niov);
 
     ctx        = malloc(sizeof(*ctx));
     ctx->il    = il;
     ctx->ch    = ch;
     ctx->entry = *entry;
+    ctx->rec   = rec;
 
-    niov = evpl_iovec_alloc(il->evpl, reclen, DEMOFS_BLOCK_SIZE, 1, 0, &ctx->iov);
-    chimera_demofs_abort_if(niov != 1, "redo record did not fit in one iovec (%d)", niov);
-
-    p               = ctx->iov.data;
+    p               = (char *) rec->iov.data;
     hdr             = (struct demofs_redo_header *) p;
     hdr->magic      = DEMOFS_REDO_MAGIC;
     hdr->seq        = il->log_seq++;
@@ -3944,9 +4137,25 @@ demofs_il_write_redo(
     ch->cq_inflight++;
 
     evpl_block_write(il->evpl, il->queue[SM_INTENT_LOG_DEVICE],
-                     &ctx->iov, 1, offset, 1 /* sync */,
+                     &rec->iov, 1, offset, 1 /* sync */,
                      demofs_redo_write_cb, ctx);
 } /* demofs_il_write_redo */
+
+/* Padded on-log length of the redo record for one transaction. */
+static uint64_t
+demofs_il_txn_reclen(struct demofs_txn *txn)
+{
+    struct demofs_txn_block *tb;
+    uint32_t                 nblocks = 0;
+    uint64_t                 reclen;
+
+    for (tb = txn->blocks; tb; tb = tb->next) {
+        nblocks++;
+    }
+    reclen = sizeof(struct demofs_redo_header) +
+        (uint64_t) nblocks * (sizeof(struct demofs_redo_block_header) + DEMOFS_BLOCK_SIZE);
+    return (reclen + DEMOFS_BLOCK_SIZE - 1) & ~((uint64_t) DEMOFS_BLOCK_SIZE - 1);
+} /* demofs_il_txn_reclen */
 
 static void
 demofs_iq_process_channel(struct demofs_iq_channel *ch)
@@ -3957,8 +4166,9 @@ demofs_iq_process_channel(struct demofs_iq_channel *ch)
     int                       issued  = 0;
 
     while (sq_head != sq_tail) {
-        struct demofs_iq_entry entry;
-        uint32_t               cq_tail, cq_head;
+        struct demofs_iq_entry *slot = &ch->sq.entries[sq_head & DEMOFS_IQ_RING_MASK];
+        struct demofs_iq_entry  entry;
+        uint32_t                cq_tail, cq_head;
 
         cq_tail = __atomic_load_n(&ch->cq.tail, __ATOMIC_RELAXED);
         cq_head = __atomic_load_n(&ch->cq.head, __ATOMIC_ACQUIRE);
@@ -3970,7 +4180,13 @@ demofs_iq_process_channel(struct demofs_iq_channel *ch)
             break;
         }
 
-        entry = ch->sq.entries[sq_head & DEMOFS_IQ_RING_MASK];
+        /* Back off if the log lacks room for this record; the tail-pusher
+         * rings the wake doorbell once it frees space. */
+        if (!demofs_il_fits(il, demofs_il_txn_reclen(slot->txn))) {
+            break;
+        }
+
+        entry = *slot;
         sq_head++;
         entry.status = 0;
 
@@ -4086,11 +4302,16 @@ demofs_intent_log_thread_init(
     struct demofs_shared     *shared = container_of(il, struct demofs_shared, intent_log);
     int                       i;
 
-    il->evpl     = evpl;
-    il->log_head = SM_INTENT_LOG_OFFSET;
-    il->log_seq  = 0;
+    il->evpl             = evpl;
+    il->log_head         = SM_INTENT_LOG_OFFSET;
+    il->log_tail         = SM_INTENT_LOG_OFFSET;
+    il->log_seq          = 0;
+    il->push_head        = NULL;
+    il->push_tail        = NULL;
+    il->push_cur         = NULL;
+    il->push_outstanding = 0;
 
-    /* Open block queues on this thread's evpl for redo-record writes. */
+    /* Open block queues on this thread's evpl for redo writes + tail-push. */
     il->queue = calloc(shared->num_devices, sizeof(*il->queue));
     for (i = 0; i < shared->num_devices; i++) {
         il->queue[i] = evpl_block_open_queue(evpl, shared->devices[i].bdev);
@@ -4114,6 +4335,21 @@ demofs_intent_log_thread_shutdown(
      * threads, which freed their channels.  Just drop the doorbell and
      * close our block queues. */
     evpl_remove_doorbell(evpl, &il->wake_doorbell);
+
+    /* Drop any records still awaiting tail-push.  Their block images remain
+     * durable in the intent log, so a future mount recovers them by replay
+     * (the data isn't lost; it just hasn't reached its home location). */
+    if (il->push_cur) {
+        evpl_iovec_release(evpl, &il->push_cur->iov);
+        free(il->push_cur);
+        il->push_cur = NULL;
+    }
+    while (il->push_head) {
+        struct demofs_il_record *rec = il->push_head;
+        il->push_head = rec->next;
+        evpl_iovec_release(evpl, &rec->iov);
+        free(rec);
+    }
 
     for (i = 0; i < shared->num_devices; i++) {
         evpl_block_close_queue(evpl, il->queue[i]);

--- a/src/vfs/demofs/demofs.c
+++ b/src/vfs/demofs/demofs.c
@@ -331,6 +331,14 @@ struct demofs_block {
 struct demofs_block_shard {
     pthread_mutex_t       lock;
     struct demofs_block **buckets;     /* [DEMOFS_BLOCK_CACHE_BUCKETS_PER_SHARD] */
+
+    /* Fixed buffer pool with LRU eviction (all protected by lock).  The LRU
+     * holds only CLEAN, unpinned buffers (eviction candidates), ordered
+     * least-recently-used first.  Ops that need a buffer when none are free
+     * park on the waiter list and are resumed when one is returned. */
+    struct demofs_block  *lru_head, *lru_tail;  /* lru_head = next to evict */
+    struct demofs_bt_op  *wait_head, *wait_tail; /* ops awaiting a free buffer */
+    uint32_t              nblocks;              /* buffers owned by this shard */
 };
 
 struct demofs_block_cache {
@@ -1385,9 +1393,9 @@ demofs_block_claim(
             }
         }
 
-        /* Publish into the bucket chain (RCU readers will use hash_next). */
-        blk->hash_next = shard->buckets[bucket];
-        rcu_assign_pointer(shard->buckets[bucket], blk);
+        /* Publish into the bucket chain (all lookups hold the shard lock). */
+        blk->hash_next         = shard->buckets[bucket];
+        shard->buckets[bucket] = blk;
     }
 
     blk->pin_count++;
@@ -1606,15 +1614,6 @@ demofs_bt_block_get(
     struct demofs_block_load  *ld;
     int                        issue = 0;
 
-    /* Fast path: lock-free hit on a resident, loaded block. */
-    urcu_memb_read_lock();
-    blk = demofs_block_lookup_locked(shard, bucket, device_id, device_offset);
-    if (blk && blk->state != DEMOFS_BLOCK_LOADING) {
-        urcu_memb_read_unlock();
-        return blk;
-    }
-    urcu_memb_read_unlock();
-
     pthread_mutex_lock(&shard->lock);
     blk = demofs_block_lookup_locked(shard, bucket, device_id, device_offset);
     if (blk && blk->state != DEMOFS_BLOCK_LOADING) {
@@ -1623,14 +1622,14 @@ demofs_bt_block_get(
     }
 
     if (!blk) {
-        blk                = calloc(1, sizeof(*blk));
-        blk->device_id     = device_id;
-        blk->device_offset = device_offset;
-        blk->buffer        = calloc(1, DEMOFS_BLOCK_SIZE);
-        blk->state         = DEMOFS_BLOCK_LOADING;
-        blk->hash_next     = shard->buckets[bucket];
-        rcu_assign_pointer(shard->buckets[bucket], blk);
-        issue = 1;
+        blk                    = calloc(1, sizeof(*blk));
+        blk->device_id         = device_id;
+        blk->device_offset     = device_offset;
+        blk->buffer            = calloc(1, DEMOFS_BLOCK_SIZE);
+        blk->state             = DEMOFS_BLOCK_LOADING;
+        blk->hash_next         = shard->buckets[bucket];
+        shard->buckets[bucket] = blk;
+        issue                  = 1;
     }
 
     /* Park this op on the block's waiter list; it can no longer complete

--- a/src/vfs/demofs/demofs.c
+++ b/src/vfs/demofs/demofs.c
@@ -4734,6 +4734,186 @@ demofs_getattr(
                               demofs_getattr_inode_cb, request);
 } /* demofs_getattr */
 
+/*
+ * Truncation extent walk (async): remove/trim every extent past new EOF.
+ * inode_stash[0] = inode, loop_off = new_size, ext_iter = current extent.
+ */
+static void demofs_setattr_trunc_process(
+    struct chimera_vfs_request *request);
+
+static void
+demofs_setattr_trunc_done(struct chimera_vfs_request *request)
+{
+    struct demofs_request_private *p      = request->plugin_data;
+    struct demofs_thread          *thread = p->thread;
+    struct demofs_inode           *inode  = p->inode_stash[0];
+
+    demofs_apply_attrs(inode, request->setattr.set_attr);
+    demofs_map_attrs(thread, &request->setattr.r_post_attr, inode);
+    demofs_op_ok(request, p->txn);
+} /* demofs_setattr_trunc_done */
+
+static void
+demofs_setattr_trunc_walk_cb(
+    struct demofs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+
+    p->loop_have = demofs_ext_from_op(op, result, &p->ext_iter);
+    demofs_bt_op_free(p->thread, op);
+    demofs_setattr_trunc_process(request);
+} /* demofs_setattr_trunc_walk_cb */
+
+static void
+demofs_setattr_trunc_advance(struct chimera_vfs_request *request)
+{
+    struct demofs_request_private *p      = request->plugin_data;
+    struct demofs_thread          *thread = p->thread;
+    struct demofs_bt_op           *op     = demofs_bt_op_alloc(thread);
+
+    if (demofs_ext_next_async(op, thread, p->inode_stash[0], p->ext_iter.file_offset,
+                              p->rec_scratch, sizeof(p->rec_scratch),
+                              demofs_setattr_trunc_walk_cb, request)) {
+        demofs_setattr_trunc_walk_cb(op, op->result, request);
+    }
+} /* demofs_setattr_trunc_advance */
+
+static void
+demofs_setattr_trunc_inserted_cb(
+    struct demofs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request *request = private_data;
+
+    (void) result;
+    demofs_bt_op_free(((struct demofs_request_private *) request->plugin_data)->thread, op);
+    demofs_setattr_trunc_advance(request);
+} /* demofs_setattr_trunc_inserted_cb */
+
+/* A trimmed or removed extent's slot is gone; re-insert the trimmed head
+ * (trim case) then advance, or just advance (full-remove case). */
+static void
+demofs_setattr_trunc_removed_cb(
+    struct demofs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request  = private_data;
+    struct demofs_request_private *p        = request->plugin_data;
+    struct demofs_thread          *thread   = p->thread;
+    uint64_t                       new_size = p->loop_off;
+
+    (void) result;
+    demofs_bt_op_free(thread, op);
+
+    if (p->ext_iter.file_offset + p->ext_iter.length > new_size &&
+        p->ext_iter.file_offset < new_size) {
+        /* Trim case: reinsert the surviving head [start, new_size). */
+        uint64_t new_logical = new_size - p->ext_iter.file_offset;
+
+        op = demofs_bt_op_alloc(thread);
+        {
+            struct demofs_extent_rec rec = {
+                .length        = new_logical,
+                .device_id     = p->ext_iter.device_id,
+                .pad           = 0,
+                .device_offset = p->ext_iter.device_offset,
+            };
+            struct demofs_bt_key     key = demofs_extent_key(p->ext_iter.file_offset);
+
+            if (demofs_bt_insert_async(op, thread, p->txn, p->inode_stash[0], &key,
+                                       &rec, sizeof(rec),
+                                       demofs_setattr_trunc_inserted_cb, request)) {
+                demofs_setattr_trunc_inserted_cb(op, op->result, request);
+            }
+        }
+        return;
+    }
+
+    demofs_setattr_trunc_advance(request);
+} /* demofs_setattr_trunc_removed_cb */
+
+static void
+demofs_setattr_trunc_process(struct chimera_vfs_request *request)
+{
+    struct demofs_request_private *p        = request->plugin_data;
+    struct demofs_thread          *thread   = p->thread;
+    uint64_t                       new_size = p->loop_off;
+    uint64_t                       extent_start, extent_end;
+    struct demofs_bt_op           *op;
+
+    if (!p->loop_have) {
+        demofs_setattr_trunc_done(request);
+        return;
+    }
+
+    extent_start = p->ext_iter.file_offset;
+    extent_end   = extent_start + p->ext_iter.length;
+
+    if (extent_start >= new_size) {
+        demofs_thread_free_space(thread, p->ext_iter.device_id,
+                                 p->ext_iter.device_offset,
+                                 SM_ALIGN_UP(p->ext_iter.length));
+    } else if (extent_end > new_size) {
+        uint64_t old_aligned = SM_ALIGN_UP(p->ext_iter.length);
+        uint64_t new_logical = new_size - extent_start;
+        uint64_t new_aligned = SM_ALIGN_UP(new_logical);
+
+        if (old_aligned > new_aligned) {
+            demofs_thread_free_space(thread, p->ext_iter.device_id,
+                                     p->ext_iter.device_offset + new_aligned,
+                                     old_aligned - new_aligned);
+        }
+    } else {
+        /* Extent entirely within new size: nothing to do, just advance. */
+        demofs_setattr_trunc_advance(request);
+        return;
+    }
+
+    /* Both the full-remove and trim cases start by removing the slot. */
+    op = demofs_bt_op_alloc(thread);
+    {
+        struct demofs_bt_key key = demofs_extent_key(extent_start);
+
+        if (demofs_bt_remove_async(op, thread, p->txn, p->inode_stash[0], &key,
+                                   demofs_setattr_trunc_removed_cb, request)) {
+            demofs_setattr_trunc_removed_cb(op, op->result, request);
+        }
+    }
+} /* demofs_setattr_trunc_process */
+
+/* First-extent selection for truncation: floor(new_size), else first extent. */
+static void
+demofs_setattr_trunc_first_cb(
+    struct demofs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+    struct demofs_thread          *thread  = p->thread;
+    int                            have    = demofs_ext_from_op(op, result, &p->ext_iter);
+
+    demofs_bt_op_free(thread, op);
+
+    if (!have) {
+        op = demofs_bt_op_alloc(thread);
+        if (demofs_ext_ceil_async(op, thread, p->inode_stash[0], 0, p->rec_scratch,
+                                  sizeof(p->rec_scratch), demofs_setattr_trunc_walk_cb,
+                                  request)) {
+            demofs_setattr_trunc_walk_cb(op, op->result, request);
+        }
+        return;
+    }
+
+    p->loop_have = 1;
+    demofs_setattr_trunc_process(request);
+} /* demofs_setattr_trunc_first_cb */
+
 static void
 demofs_setattr_inode_cb(
     struct demofs_inode *inode,
@@ -4743,6 +4923,7 @@ demofs_setattr_inode_cb(
     struct chimera_vfs_request    *request = private_data;
     struct demofs_request_private *p       = request->plugin_data;
     struct demofs_thread          *thread  = p->thread;
+    struct demofs_bt_op           *op;
 
     if (unlikely(status != CHIMERA_VFS_OK)) {
         demofs_op_fail(request, p->txn, status);
@@ -4751,55 +4932,25 @@ demofs_setattr_inode_cb(
 
     demofs_map_attrs(thread, &request->setattr.r_pre_attr, inode);
 
-    /* Handle truncation: remove/trim extents past new EOF */
+    /* Handle truncation: remove/trim extents past new EOF. */
     if ((request->setattr.set_attr->va_set_mask & CHIMERA_VFS_ATTR_SIZE) &&
         S_ISREG(inode->mode) &&
         request->setattr.set_attr->va_size < inode->size) {
 
-        uint64_t              new_size = request->setattr.set_attr->va_size;
-        struct demofs_extent  ext_buf;
-        struct demofs_extent *extent = &ext_buf;
-        int                   have;
+        p->inode_stash[0] = inode;
+        p->loop_off       = request->setattr.set_attr->va_size;
 
-        have = demofs_ext_floor(thread, inode, new_size, extent);
-        if (!have) {
-            have = demofs_ext_ceil(thread, inode, 0, extent);
+        op = demofs_bt_op_alloc(thread);
+        if (demofs_ext_floor_async(op, thread, inode, p->loop_off, p->rec_scratch,
+                                   sizeof(p->rec_scratch), demofs_setattr_trunc_first_cb,
+                                   request)) {
+            demofs_setattr_trunc_first_cb(op, op->result, request);
         }
-
-        while (have) {
-            uint64_t extent_start = extent->file_offset;
-            uint64_t extent_end   = extent_start + extent->length;
-            uint64_t cur_fo       = extent->file_offset;
-
-            if (extent_start >= new_size) {
-                demofs_thread_free_space(thread, extent->device_id,
-                                         extent->device_offset,
-                                         SM_ALIGN_UP(extent->length));
-                demofs_ext_remove(thread, p->txn, inode, cur_fo);
-            } else if (extent_end > new_size) {
-                uint64_t old_aligned = SM_ALIGN_UP(extent->length);
-                uint64_t new_logical = new_size - extent_start;
-                uint64_t new_aligned = SM_ALIGN_UP(new_logical);
-
-                if (old_aligned > new_aligned) {
-                    demofs_thread_free_space(thread, extent->device_id,
-                                             extent->device_offset + new_aligned,
-                                             old_aligned - new_aligned);
-                }
-                /* Trim in place by rewriting the record with the new length. */
-                demofs_ext_remove(thread, p->txn, inode, cur_fo);
-                demofs_ext_insert(thread, p->txn, inode, cur_fo, new_logical,
-                                  extent->device_id, extent->device_offset);
-            }
-
-            have = demofs_ext_next(thread, inode, cur_fo, extent);
-        }
+        return;
     }
 
     demofs_apply_attrs(inode, request->setattr.set_attr);
     demofs_map_attrs(thread, &request->setattr.r_post_attr, inode);
-
-
     demofs_op_ok(request, p->txn);
 } /* demofs_setattr_inode_cb */
 

--- a/src/vfs/demofs/demofs.c
+++ b/src/vfs/demofs/demofs.c
@@ -5144,6 +5144,20 @@ demofs_mknod_at_existing_cb(
 } /* demofs_mknod_at_existing_cb */
 
 static void
+demofs_mknod_at_inserted_cb(
+    struct demofs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+
+    (void) result;
+    demofs_bt_op_free(p->thread, op);
+    demofs_op_ok(request, p->txn);
+} /* demofs_mknod_at_inserted_cb */
+
+static void
 demofs_mknod_at_alloc_cb(
     struct demofs_inode *inode,
     int                  status,
@@ -5153,6 +5167,7 @@ demofs_mknod_at_alloc_cb(
     struct demofs_request_private *p       = request->plugin_data;
     struct demofs_thread          *thread  = p->thread;
     struct demofs_inode           *parent  = p->inode_stash[0];
+    struct demofs_bt_op           *op;
     struct timespec                now;
 
     if (unlikely(status != CHIMERA_VFS_OK)) {
@@ -5187,10 +5202,6 @@ demofs_mknod_at_alloc_cb(
     demofs_apply_attrs(inode, request->mknod_at.set_attr);
     demofs_map_attrs(thread, &request->mknod_at.r_attr, inode);
 
-    demofs_dir_insert(thread, p->txn, parent, request->mknod_at.name_hash,
-                      request->mknod_at.name, request->mknod_at.name_len,
-                      inode->inum, inode->gen);
-
     parent->mtime_sec  = now.tv_sec;
     parent->mtime_nsec = now.tv_nsec;
     parent->ctime_sec  = now.tv_sec;
@@ -5198,8 +5209,37 @@ demofs_mknod_at_alloc_cb(
 
     demofs_map_attrs(thread, &request->mknod_at.r_dir_post_attr, parent);
 
-    demofs_op_ok(request, p->txn);
+    op = demofs_bt_op_alloc(thread);
+    if (demofs_dir_insert_async(op, thread, p->txn, parent,
+                                request->mknod_at.name_hash, request->mknod_at.name,
+                                request->mknod_at.name_len, inode->inum, inode->gen,
+                                demofs_mknod_at_inserted_cb, request)) {
+        demofs_mknod_at_inserted_cb(op, op->result, request);
+    }
 } /* demofs_mknod_at_alloc_cb */
+
+static void
+demofs_mknod_at_check_cb(
+    struct demofs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+    struct demofs_thread          *thread  = p->thread;
+
+    demofs_bt_op_free(thread, op);
+
+    if (result >= 0) {
+        struct demofs_dirent_rec *rec = (struct demofs_dirent_rec *) p->rec_scratch;
+
+        demofs_inode_get_inum_async(thread, p->txn, rec->inum, rec->gen,
+                                    demofs_mknod_at_existing_cb, request);
+        return;
+    }
+
+    demofs_inode_alloc_async(thread, p->txn, demofs_mknod_at_alloc_cb, request);
+} /* demofs_mknod_at_check_cb */
 
 static void
 demofs_mknod_at_parent_cb(
@@ -5211,8 +5251,7 @@ demofs_mknod_at_parent_cb(
     struct demofs_request_private *p       = request->plugin_data;
     struct demofs_thread          *thread  = p->thread;
     uint64_t                       hash    = request->mknod_at.name_hash;
-    uint64_t                       existing_inum;
-    uint32_t                       existing_gen;
+    struct demofs_bt_op           *op;
 
     if (unlikely(status != CHIMERA_VFS_OK)) {
         demofs_op_fail(request, p->txn, status);
@@ -5228,15 +5267,12 @@ demofs_mknod_at_parent_cb(
 
     p->inode_stash[0] = parent;
 
-    if (demofs_dir_lookup(thread, parent, hash, &existing_inum, &existing_gen) == 0) {
-        demofs_inode_get_inum_async(thread, p->txn,
-                                    existing_inum, existing_gen,
-                                    demofs_mknod_at_existing_cb, request);
-        return;
+    op = demofs_bt_op_alloc(thread);
+    if (demofs_dir_lookup_async(op, thread, parent, hash, p->rec_scratch,
+                                sizeof(p->rec_scratch), demofs_mknod_at_check_cb,
+                                request)) {
+        demofs_mknod_at_check_cb(op, op->result, request);
     }
-
-    demofs_inode_alloc_async(thread, p->txn,
-                             demofs_mknod_at_alloc_cb, request);
 } /* demofs_mknod_at_parent_cb */
 
 static void
@@ -5712,6 +5748,20 @@ demofs_open_at_existing_cb(
 } /* demofs_open_at_existing_cb */
 
 static void
+demofs_open_at_inserted_cb(
+    struct demofs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+
+    (void) result;
+    demofs_bt_op_free(p->thread, op);
+    demofs_open_at_finish(request, p->inode_stash[0], p->inode_stash[1]);
+} /* demofs_open_at_inserted_cb */
+
+static void
 demofs_open_at_alloc_cb(
     struct demofs_inode *inode,
     int                  status,
@@ -5721,6 +5771,7 @@ demofs_open_at_alloc_cb(
     struct demofs_request_private *p       = request->plugin_data;
     struct demofs_thread          *thread  = p->thread;
     struct demofs_inode           *parent  = p->inode_stash[0];
+    struct demofs_bt_op           *op;
     struct timespec                now;
 
     if (unlikely(status != CHIMERA_VFS_OK)) {
@@ -5745,17 +5796,56 @@ demofs_open_at_alloc_cb(
 
     demofs_apply_attrs(inode, request->open_at.set_attr);
 
-    demofs_dir_insert(thread, p->txn, parent, request->open_at.name_hash,
-                      request->open_at.name, request->open_at.namelen,
-                      inode->inum, inode->gen);
-
     parent->mtime_sec  = now.tv_sec;
     parent->mtime_nsec = now.tv_nsec;
     parent->ctime_sec  = now.tv_sec;
     parent->ctime_nsec = now.tv_nsec;
 
-    demofs_open_at_finish(request, parent, inode);
+    p->inode_stash[1] = inode;
+
+    op = demofs_bt_op_alloc(thread);
+    if (demofs_dir_insert_async(op, thread, p->txn, parent,
+                                request->open_at.name_hash, request->open_at.name,
+                                request->open_at.namelen, inode->inum, inode->gen,
+                                demofs_open_at_inserted_cb, request)) {
+        demofs_open_at_inserted_cb(op, op->result, request);
+    }
 } /* demofs_open_at_alloc_cb */
+
+static void
+demofs_open_at_check_cb(
+    struct demofs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+    struct demofs_thread          *thread  = p->thread;
+    unsigned int                   flags   = request->open_at.flags;
+
+    demofs_bt_op_free(thread, op);
+
+    if (result < 0) {
+        if (!(flags & CHIMERA_VFS_OPEN_CREATE)) {
+            demofs_op_fail(request, p->txn, CHIMERA_VFS_ENOENT);
+            return;
+        }
+        demofs_inode_alloc_async(thread, p->txn, demofs_open_at_alloc_cb, request);
+        return;
+    }
+
+    if (flags & CHIMERA_VFS_OPEN_EXCLUSIVE) {
+        demofs_op_fail(request, p->txn, CHIMERA_VFS_EEXIST);
+        return;
+    }
+
+    {
+        struct demofs_dirent_rec *rec = (struct demofs_dirent_rec *) p->rec_scratch;
+
+        demofs_inode_get_inum_async(thread, p->txn, rec->inum, rec->gen,
+                                    demofs_open_at_existing_cb, request);
+    }
+} /* demofs_open_at_check_cb */
 
 static void
 demofs_open_at_parent_cb(
@@ -5766,10 +5856,8 @@ demofs_open_at_parent_cb(
     struct chimera_vfs_request    *request = private_data;
     struct demofs_request_private *p       = request->plugin_data;
     struct demofs_thread          *thread  = p->thread;
-    unsigned int                   flags   = request->open_at.flags;
     uint64_t                       hash    = request->open_at.name_hash;
-    uint64_t                       child_inum;
-    uint32_t                       child_gen;
+    struct demofs_bt_op           *op;
 
     if (unlikely(status != CHIMERA_VFS_OK)) {
         demofs_op_fail(request, p->txn, status);
@@ -5785,23 +5873,12 @@ demofs_open_at_parent_cb(
 
     p->inode_stash[0] = parent;
 
-    if (demofs_dir_lookup(thread, parent, hash, &child_inum, &child_gen) != 0) {
-        if (!(flags & CHIMERA_VFS_OPEN_CREATE)) {
-            demofs_op_fail(request, p->txn, CHIMERA_VFS_ENOENT);
-            return;
-        }
-        demofs_inode_alloc_async(thread, p->txn,
-                                 demofs_open_at_alloc_cb, request);
-        return;
+    op = demofs_bt_op_alloc(thread);
+    if (demofs_dir_lookup_async(op, thread, parent, hash, p->rec_scratch,
+                                sizeof(p->rec_scratch), demofs_open_at_check_cb,
+                                request)) {
+        demofs_open_at_check_cb(op, op->result, request);
     }
-
-    if (flags & CHIMERA_VFS_OPEN_EXCLUSIVE) {
-        demofs_op_fail(request, p->txn, CHIMERA_VFS_EEXIST);
-        return;
-    }
-
-    demofs_inode_get_inum_async(thread, p->txn, child_inum, child_gen,
-                                demofs_open_at_existing_cb, request);
 } /* demofs_open_at_parent_cb */
 
 static void

--- a/src/vfs/demofs/demofs.c
+++ b/src/vfs/demofs/demofs.c
@@ -4706,6 +4706,136 @@ demofs_txn_commit(
     evpl_ring_doorbell(&shared->intent_log.wake_doorbell);
 } /* demofs_txn_commit */
 
+struct demofs_recover_rec {
+    uint64_t seq;
+    uint64_t offset;     /* byte offset within the read-in log image */
+};
+
+static int
+demofs_recover_rec_cmp(
+    const void *a,
+    const void *b)
+{
+    uint64_t sa = ((const struct demofs_recover_rec *) a)->seq;
+    uint64_t sb = ((const struct demofs_recover_rec *) b)->seq;
+
+    return (sa > sb) - (sa < sb);
+} /* demofs_recover_rec_cmp */
+
+/*
+ * Crash recovery (synchronous replay): the previous instance did not unmount
+ * cleanly, so logged-but-not-yet-pushed redo records may still sit in the
+ * intent log while their home locations hold stale data.  Sweep the log for
+ * intact records -- a 4 KiB-aligned magic whose XXH3-128 over reclen bytes
+ * verifies (rejecting torn/partially-overwritten records) -- and write each
+ * block image to its home location in seq order (latest image of a block
+ * wins), then fsync.  After this the on-disk b+tree / inodes / data are
+ * consistent with the last acknowledged write, exactly as the tail-pusher
+ * would have left them.
+ *
+ * Replaying every intact record (rather than just [tail, head]) is safe: in a
+ * FIFO circular log a superseding record outlives every record it supersedes,
+ * so seq-ordered replay always lands the latest image, and re-writing an
+ * already-current block is idempotent.  Runs at mount before evpl I/O starts,
+ * so it uses plain pread/pwrite via the device paths.
+ */
+static int
+demofs_recover_log(struct demofs_shared *shared)
+{
+    char                      *log;
+    int                        fd;
+    int                       *wfd;
+    ssize_t                    n;
+    uint64_t                   o;
+    struct demofs_recover_rec *recs;
+    uint32_t                   nrec = 0, cap = 4096, i;
+
+    log = malloc(SM_INTENT_LOG_SIZE);
+    fd  = open(shared->device_paths[SM_INTENT_LOG_DEVICE], O_RDONLY);
+    if (fd < 0) {
+        free(log);
+        return -1;
+    }
+    n = pread(fd, log, SM_INTENT_LOG_SIZE, SM_INTENT_LOG_OFFSET);
+    close(fd);
+    if (n != (ssize_t) SM_INTENT_LOG_SIZE) {
+        free(log);
+        return -1;
+    }
+
+    recs = malloc(cap * sizeof(*recs));
+
+    for (o = 0; o + sizeof(struct demofs_redo_header) <= SM_INTENT_LOG_SIZE;
+         o += DEMOFS_BLOCK_SIZE) {
+        struct demofs_redo_header *hdr = (struct demofs_redo_header *) (log + o);
+        uint64_t                   lo, hi;
+        XXH128_hash_t              h;
+
+        if (hdr->magic != DEMOFS_REDO_MAGIC) {
+            continue;
+        }
+        if (hdr->reclen < sizeof(*hdr) ||
+            (hdr->reclen & (DEMOFS_BLOCK_SIZE - 1)) ||
+            o + hdr->reclen > SM_INTENT_LOG_SIZE) {
+            continue;
+        }
+        lo           = hdr->csum_lo;
+        hi           = hdr->csum_hi;
+        hdr->csum_lo = 0;
+        hdr->csum_hi = 0;
+        h            = XXH3_128bits(log + o, hdr->reclen);
+        hdr->csum_lo = lo;
+        hdr->csum_hi = hi;
+        if (h.low64 != lo || h.high64 != hi) {
+            continue;
+        }
+
+        if (nrec == cap) {
+            cap *= 2;
+            recs = realloc(recs, cap * sizeof(*recs));
+        }
+        recs[nrec].seq    = hdr->seq;
+        recs[nrec].offset = o;
+        nrec++;
+    }
+
+    qsort(recs, nrec, sizeof(*recs), demofs_recover_rec_cmp);
+
+    wfd = malloc(shared->num_devices * sizeof(int));
+    for (i = 0; i < (uint32_t) shared->num_devices; i++) {
+        wfd[i] = open(shared->device_paths[i], O_WRONLY);
+    }
+
+    for (i = 0; i < nrec; i++) {
+        struct demofs_redo_header *hdr = (struct demofs_redo_header *) (log + recs[i].offset);
+        char                      *p   = log + recs[i].offset + sizeof(*hdr);
+        uint32_t                   b;
+
+        for (b = 0; b < hdr->num_blocks; b++) {
+            struct demofs_redo_block_header *bh = (struct demofs_redo_block_header *) p;
+
+            p += sizeof(*bh);
+            if (bh->device_id < (uint32_t) shared->num_devices && wfd[bh->device_id] >= 0) {
+                pwrite(wfd[bh->device_id], p, DEMOFS_BLOCK_SIZE, (off_t) bh->device_offset);
+            }
+            p += DEMOFS_BLOCK_SIZE;
+        }
+    }
+
+    for (i = 0; i < (uint32_t) shared->num_devices; i++) {
+        if (wfd[i] >= 0) {
+            fsync(wfd[i]);
+            close(wfd[i]);
+        }
+    }
+
+    free(wfd);
+    free(recs);
+    free(log);
+    chimera_demofs_info("crash recovery: replayed %u intact intent-log records", nrec);
+    return 0;
+} /* demofs_recover_log */
+
 static void *
 demofs_init(const char *cfgdata)
 {
@@ -4792,21 +4922,30 @@ demofs_init(const char *cfgdata)
 
     pthread_mutex_init(&shared->lock, NULL);
 
-    /* Decide mkfs vs mount: a valid superblock with the CLEAN flag means the
-     * previous instance unmounted cleanly, so we can reload its persisted
-     * free-space map and skip bootstrap (the root inode faults in from disk on
-     * first access).  Anything else (no/garbage superblock, or not clean ->
-     * a crash, which needs recovery we haven't built) is treated as mkfs. */
+    /* Decide mkfs vs clean-mount vs crash-recovery from the superblock
+     * (persistent mode only):
+     *   - valid + CLEAN  -> the previous instance unmounted cleanly: reload
+     *                       its persisted free-space map and mount.
+     *   - valid + !CLEAN -> a crash: synchronously replay the intent log to
+     *                       home, then mount the now-consistent image.
+     *   - no/garbage     -> mkfs.
+     */
     {
         struct sm_superblock sb;
-        int                  mounting = 0;
+        int                  have_sb;
+        int                  mode;     /* 0 = mkfs, 1 = clean mount, 2 = recover */
 
-        if (shared->persistent &&
-            space_map_read_superblock_path(device0_path, &sb) == 0 &&
-            (sb.flags & SM_SB_CLEAN)) {
+        have_sb = shared->persistent &&
+            space_map_read_superblock_path(device0_path, &sb) == 0;
+
+        if (have_sb && (sb.flags & SM_SB_CLEAN)) {
+            mode         = 1;
             shared->fsid = sb.fsid;
-            mounting     = 1;
+        } else if (have_sb) {
+            mode         = 2;
+            shared->fsid = sb.fsid;
         } else {
+            mode         = 0;
             shared->fsid = chimera_rand64();
         }
 
@@ -4817,22 +4956,40 @@ demofs_init(const char *cfgdata)
         shared->space_map = space_map_create(device_sizes, shared->num_devices);
         free(device_sizes);
 
-        if (mounting &&
-            space_map_load_paths(shared->space_map, shared->device_paths) != 0) {
-            chimera_demofs_error("space-map reload failed; treating as fresh");
-            mounting = 0;
+        if (mode == 2) {
+            chimera_demofs_info("superblock not clean: running crash recovery");
+            demofs_recover_log(shared);
         }
 
-        shared->mounted = mounting;
+        /* Reload the persisted free-space map.  NOTE: after a crash this
+         * snapshot is the one from the last *clean* unmount, so it does not
+         * reflect allocations made since then -- reads are correct (the log
+         * replay made the home image consistent) but the in-memory allocator
+         * must be rebuilt (namespace-walk fsck, TODO) before writes are safe.
+         * For a clean mount the snapshot must load or we fall back to mkfs. */
+        if (mode != 0 &&
+            space_map_load_paths(shared->space_map, shared->device_paths) != 0) {
+            if (mode == 1) {
+                chimera_demofs_error("space-map reload failed; treating as fresh");
+                mode = 0;
+            } else {
+                chimera_demofs_error(
+                    "post-recovery space-map reload failed; allocator is fresh "
+                    "(writes unsafe until namespace-walk reconstruction)");
+            }
+        }
 
-        if (mounting) {
-            uint8_t fsid_buf[CHIMERA_VFS_FSID_SIZE] = { 0 };
+        shared->mounted = (mode != 0);
 
-            shared->root_inum = sb.root_inum;
+        if (mode != 0) {
+            uint8_t  fsid_buf[CHIMERA_VFS_FSID_SIZE] = { 0 };
+            uint64_t rinum                           = sb.root_inum ? sb.root_inum : 2;
+
+            shared->root_inum = rinum;
             shared->root_gen  = sb.root_gen;
             memcpy(fsid_buf, &shared->fsid, sizeof(shared->fsid));
             shared->root_fhlen = chimera_vfs_encode_fh_inum_mount(fsid_buf,
-                                                                  sb.root_inum,
+                                                                  rinum,
                                                                   sb.root_gen,
                                                                   shared->root_fh);
         }
@@ -4842,9 +4999,9 @@ demofs_init(const char *cfgdata)
          * clean shutdown. */
         rc = space_map_write_superblock_path(shared->space_map, device0_path,
                                              shared->fsid, 0,
-                                             mounting ? sb.root_inum : 0,
-                                             mounting ? sb.root_gen : 0,
-                                             mounting ? sb.log_seq : 0);
+                                             mode != 0 ? shared->root_inum : 0,
+                                             mode != 0 ? shared->root_gen : 0,
+                                             mode != 0 ? sb.log_seq : 0);
         chimera_demofs_abort_if(rc != 0,
                                 "Failed to write superblock to %s: %s",
                                 device0_path, strerror(errno));

--- a/src/vfs/demofs/demofs.c
+++ b/src/vfs/demofs/demofs.c
@@ -95,75 +95,76 @@ struct demofs_extent {
 };
 
 struct demofs_request_private {
-    int                      opcode;
-    int                      status;
-    int                      pending;
-    int                      niov;
-    uint32_t                 read_prefix;
-    uint32_t                 read_suffix;
-    struct demofs_thread    *thread;     // Thread for tracking pending I/O
-    struct demofs_txn       *txn;        // Transaction wrapping this op
+    int                         opcode;
+    int                         status;
+    int                         pending;
+    int                         niov;
+    uint32_t                    read_prefix;
+    uint32_t                    read_suffix;
+    struct demofs_thread       *thread;  // Thread for tracking pending I/O
+    struct demofs_txn          *txn;     // Transaction wrapping this op
 
     /* Data-I/O admission control (see demofs_thread.io_wait_head).  When a
      * request parks because the block queue is full, io_resume re-enters the
      * paused path; io_reading marks a read whose extent walk has not finished,
      * so a completion that drains its in-flight reads to zero must not finalize
      * it while it is parked mid-walk. */
-    void                     (*io_resume)(struct chimera_vfs_request *);
+    void                        (*io_resume)(
+        struct chimera_vfs_request *);
     struct chimera_vfs_request *io_wait_next;
-    int                      io_reading;
+    int                         io_reading;
     /* Multi-inode op scratch (lookup_at parent/child, rename's 4-inode
      * chain, etc.).  Per-op semantics documented at use sites. */
-    struct demofs_inode     *inode_stash[4];
+    struct demofs_inode        *inode_stash[4];
     /* Small integer scratch for ops that need to carry state across
      * async callbacks (mount path walker uses it as a path byte offset). */
-    uint32_t                 op_scratch;
+    uint32_t                    op_scratch;
 
     /* readdir iteration cursor + the current dirent copied out of the
      * b+tree (carried across the per-child inode fetch). */
-    uint64_t                 rd_from_hash;
-    uint64_t                 rd_hash;
-    uint64_t                 rd_inum;
-    uint32_t                 rd_gen;
-    int                      rd_namelen;
-    char                     rd_name[256];
+    uint64_t                    rd_from_hash;
+    uint64_t                    rd_hash;
+    uint64_t                    rd_inum;
+    uint32_t                    rd_gen;
+    int                         rd_namelen;
+    char                        rd_name[256];
 
     /* Scratch buffer for handlers that parse a looked-up b+tree record
      * (e.g. a dirent's inum/gen) in their async continuation.  Sized to hold
      * the largest record (DEMOFS_DIRENT_REC_MAX == sizeof(dirent_rec) + 256). */
-    char                     rec_scratch[320];
+    char                        rec_scratch[320];
 
     /* Extent-walk iteration state, hoisted here so an async ext_next can
      * suspend the loop and resume it.  loop_* are generic loop scalars. */
-    struct demofs_extent     ext_iter;
-    struct evpl_iovec_cursor rd_cursor;
-    uint64_t                 loop_off;
-    uint64_t                 loop_left;
-    uint64_t                 loop_pos;
-    int                      loop_have;
+    struct demofs_extent        ext_iter;
+    struct evpl_iovec_cursor    rd_cursor;
+    uint64_t                    loop_off;
+    uint64_t                    loop_left;
+    uint64_t                    loop_pos;
+    int                         loop_have;
 
-    struct evpl_iovec        iov[66];
+    struct evpl_iovec           iov[66];
 
     // For RMW (read-modify-write) on partial block writes
-    int                      rmw_phase;  // 0 = no RMW, 1 = reading, 2 = writing
-    uint64_t                 rmw_aligned_start; // Block-aligned start offset
-    uint64_t                 rmw_aligned_length;// Block-aligned length
-    uint64_t                 rmw_device_id; // Device for the new extent
-    uint64_t                 rmw_device_offset; // Device offset for the new extent
-    uint32_t                 rmw_prefix_len; // Bytes to preserve at start of first block
-    uint32_t                 rmw_suffix_len; // Bytes to preserve at end of last block
-    struct evpl_iovec        rmw_prefix_iov; // IOV for prefix data (if read from existing extent)
-    struct evpl_iovec        rmw_suffix_iov; // IOV for suffix data (if read from existing extent)
-    int                      rmw_prefix_pending;// Pending read for prefix
-    int                      rmw_suffix_pending;// Pending read for suffix
-    uint32_t                 rmw_prefix_valid; // Valid bytes in prefix (extent may be truncated)
-    uint32_t                 rmw_suffix_adjust; // Adjustment for suffix when block starts before extent
-    uint32_t                 rmw_suffix_valid; // Valid bytes in suffix (extent may be truncated)
+    int                         rmw_phase; // 0 = no RMW, 1 = reading, 2 = writing
+    uint64_t                    rmw_aligned_start; // Block-aligned start offset
+    uint64_t                    rmw_aligned_length;// Block-aligned length
+    uint64_t                    rmw_device_id; // Device for the new extent
+    uint64_t                    rmw_device_offset; // Device offset for the new extent
+    uint32_t                    rmw_prefix_len; // Bytes to preserve at start of first block
+    uint32_t                    rmw_suffix_len; // Bytes to preserve at end of last block
+    struct evpl_iovec           rmw_prefix_iov; // IOV for prefix data (if read from existing extent)
+    struct evpl_iovec           rmw_suffix_iov; // IOV for suffix data (if read from existing extent)
+    int                         rmw_prefix_pending;// Pending read for prefix
+    int                         rmw_suffix_pending;// Pending read for suffix
+    uint32_t                    rmw_prefix_valid; // Valid bytes in prefix (extent may be truncated)
+    uint32_t                    rmw_suffix_adjust; // Adjustment for suffix when block starts before extent
+    uint32_t                    rmw_suffix_valid; // Valid bytes in suffix (extent may be truncated)
     /* Carried across the async prefix/suffix lookups + trim walk. */
-    int                      need_prefix_read;
-    int                      need_suffix_read;
-    uint64_t                 prefix_device_id, prefix_device_offset;
-    uint64_t                 suffix_device_id, suffix_device_offset;
+    int                         need_prefix_read;
+    int                         need_suffix_read;
+    uint64_t                    prefix_device_id, prefix_device_offset;
+    uint64_t                    suffix_device_id, suffix_device_offset;
 };
 
 struct demofs_device {
@@ -1993,7 +1994,8 @@ struct demofs_block_load {
 /* Resume data-I/O requests parked on the admission gate (defined below); a
  * metadata-node read shares the worker queue, so its completion frees capacity
  * too and must wake parked requests, else they hang. */
-static void demofs_io_resume_waiters(struct demofs_thread *thread);
+static void demofs_io_resume_waiters(
+    struct demofs_thread *thread);
 
 /* Block read completion: data landed directly in blk->iov; mark CLEAN, wake. */
 static void
@@ -5416,7 +5418,8 @@ demofs_il_clean_pushed_record(
     }
 } /* demofs_il_clean_pushed_record */
 
-static void demofs_il_push_issue(struct demofs_intent_log *il);
+static void demofs_il_push_issue(
+    struct demofs_intent_log *il);
 
 /* Finish the current record: mark its blocks evictable, release the record's
 * iovecs (header + all block clones), advance the tail, and kick the next. */
@@ -8699,7 +8702,7 @@ static int
 demofs_io_gate(
     struct demofs_thread       *thread,
     struct chimera_vfs_request *request,
-    void                        (*resume)(struct chimera_vfs_request *))
+    void (                     *resume )(struct chimera_vfs_request *))
 {
     struct demofs_request_private *p = request->plugin_data;
 
@@ -8726,7 +8729,8 @@ demofs_io_resume_waiters(struct demofs_thread *thread)
     while (thread->io_wait_head && thread->pending_io < DEMOFS_IO_INFLIGHT_LOWAT) {
         struct chimera_vfs_request    *request = thread->io_wait_head;
         struct demofs_request_private *p       = request->plugin_data;
-        void                           (*resume)(struct chimera_vfs_request *) = p->io_resume;
+        void                           (*resume)(
+            struct chimera_vfs_request *) = p->io_resume;
 
         thread->io_wait_head = p->io_wait_next;
         if (!thread->io_wait_head) {

--- a/src/vfs/demofs/demofs.c
+++ b/src/vfs/demofs/demofs.c
@@ -50,6 +50,7 @@
  * inums; the drainer empties it. */
 #define DEMOFS_ROOT_INUM          2
 #define DEMOFS_ORPHAN_INUM        3
+#define DEMOFS_ORPHAN_GEN         1   /* permanent: created at format, never deleted */
 
 /* Max inodes a single transaction can hold locked at once.  rename needs
  * 4 (two parents, child, replaced target); others (e.g. readdir) touch
@@ -427,6 +428,7 @@ enum demofs_bt_rectype {
     DEMOFS_REC_DIRENT  = 1,
     DEMOFS_REC_EXTENT  = 2,
     DEMOFS_REC_SYMLINK = 3,
+    DEMOFS_REC_ORPHAN  = 4,   /* orphan-list inode only: subkey = orphaned inum */
 };
 
 /* B+tree key: ordered by (type, subkey).  subkey is the name hash for
@@ -678,6 +680,7 @@ struct demofs_shared {
     int                        num_active_threads;
     uint8_t                    root_fh[CHIMERA_VFS_FH_SIZE];
     uint32_t                   root_fhlen;
+    int                        orphans_scanned;    /* mount-time orphan recovery done */
     uint64_t                   root_inum;          /* for the clean-unmount superblock */
     uint32_t                   root_gen;
     int                        persistent;         /* config opt-in: detect+reload a clean FS instead of mkfs */
@@ -1269,7 +1272,8 @@ static struct demofs_inode *
 demofs_inode_load_sync(
     struct demofs_thread *thread,
     uint64_t              inum,
-    uint32_t              gen)
+    uint32_t              gen,
+    int                   allow_orphan)
 {
     struct demofs_shared      *shared = thread->shared;
     struct demofs_inode_shard *shard  = demofs_inode_shard(shared, inum);
@@ -1297,7 +1301,8 @@ demofs_inode_load_sync(
     }
 
     di = (struct demofs_dinode *) buf;
-    if (di->inum != inum || di->gen != gen || di->nlink == 0) {
+    if (di->inum != inum || di->gen != gen ||
+        (di->nlink == 0 && !allow_orphan)) {
         return NULL;
     }
 
@@ -1372,7 +1377,7 @@ demofs_inode_acquire_sync_read(
     }
     if (!inode) {
         pthread_mutex_unlock(&shard->lock);
-        inode = demofs_inode_load_sync(thread, inum, gen);
+        inode = demofs_inode_load_sync(thread, inum, gen, 0);
         if (!inode) {
             return NULL;
         }
@@ -3215,6 +3220,16 @@ static int demofs_bt_remove_async(
     const struct demofs_bt_key *key,
     demofs_bt_cb_t              cb,
     void                       *private_data);
+static int demofs_bt_insert_async(
+    struct demofs_bt_op        *op,
+    struct demofs_thread       *thread,
+    struct demofs_txn          *txn,
+    struct demofs_inode        *inode,
+    const struct demofs_bt_key *key,
+    const void                 *rec,
+    uint32_t                    reclen,
+    demofs_bt_cb_t              cb,
+    void                       *private_data);
 static int demofs_bt_lookup_async(
     struct demofs_bt_op        *op,
     struct demofs_thread       *thread,
@@ -3226,6 +3241,94 @@ static int demofs_bt_lookup_async(
     uint32_t                    out_cap,
     demofs_bt_cb_t              cb,
     void                       *private_data);
+
+/*
+ * Add (remove=0) or remove (remove=1) an entry for `inum` in the durable
+ * orphan-list inode's b+tree, within `txn`.  The orphan inode is acquired LAST
+ * (it is below every file inum and is always taken last, so it is a leaf in
+ * the lock order -> can't be in a deadlock cycle).  `done(priv)` is called
+ * once the b+tree op completes.  For an insert, the orphaned inode's gen is
+ * stored as the value (the mount scan reads it to reload the inode).
+ */
+struct demofs_orphan_op {
+    struct demofs_thread *thread;
+    struct demofs_txn    *txn;
+    uint64_t              inum;
+    uint32_t              gen;
+    int                   remove;
+    void                  (*done)(
+        void *priv);
+    void                 *priv;
+};
+
+static void
+demofs_orphan_op_done_cb(
+    struct demofs_bt_op *op,
+    int                  result,
+    void                *priv)
+{
+    struct demofs_orphan_op *o = priv;
+    void                     (*done)(
+        void *) = o->done;
+    void                    *dpriv = o->priv;
+
+    (void) result;
+    demofs_bt_op_free(o->thread, op);
+    free(o);
+    done(dpriv);
+} /* demofs_orphan_op_done_cb */
+
+static void
+demofs_orphan_op_acquired_cb(
+    struct demofs_inode *orphan_dir,
+    int                  status,
+    void                *priv)
+{
+    struct demofs_orphan_op *o = priv;
+    struct demofs_bt_op     *op;
+    struct demofs_bt_key     key = { .type = DEMOFS_REC_ORPHAN, .subkey = o->inum };
+
+    chimera_demofs_abort_if(status != CHIMERA_VFS_OK,
+                            "orphan-list inode acquire failed: %d", status);
+
+    op = demofs_bt_op_alloc(o->thread);
+    if (o->remove) {
+        if (demofs_bt_remove_async(op, o->thread, o->txn, orphan_dir, &key,
+                                   demofs_orphan_op_done_cb, o)) {
+            demofs_orphan_op_done_cb(op, op->result, o);
+        }
+    } else {
+        if (demofs_bt_insert_async(op, o->thread, o->txn, orphan_dir, &key,
+                                   &o->gen, sizeof(o->gen),
+                                   demofs_orphan_op_done_cb, o)) {
+            demofs_orphan_op_done_cb(op, op->result, o);
+        }
+    }
+} /* demofs_orphan_op_acquired_cb */
+
+static void
+demofs_orphan_op_start(
+    struct demofs_thread *thread,
+    struct demofs_txn    *txn,
+    uint64_t              inum,
+    uint32_t              gen,
+    int                   remove,
+    void (               *done )(void *priv),
+    void                 *priv)
+{
+    struct demofs_orphan_op *o = malloc(sizeof(*o));
+
+    o->thread = thread;
+    o->txn    = txn;
+    o->inum   = inum;
+    o->gen    = gen;
+    o->remove = remove;
+    o->done   = done;
+    o->priv   = priv;
+
+    demofs_inode_acquire(thread, txn, DEMOFS_ORPHAN_INUM, DEMOFS_ORPHAN_GEN,
+                         DEMOFS_INODE_LOCK_WRITE, demofs_orphan_op_acquired_cb, o);
+} /* demofs_orphan_op_start */
 
 /* ------------------------------------------------------------------ */
 /* Background drainer: reclaim a large deleted inode incrementally.     */
@@ -3274,7 +3377,16 @@ demofs_drain_enqueue(
     uint64_t              inum,
     uint32_t              gen)
 {
-    struct demofs_drain *d = calloc(1, sizeof(*d));
+    struct demofs_drain *d;
+
+    /* Test/safety knob: skip the in-session drain.  The durable orphan entry
+     * was already recorded by the unlink, so the next mount's scan reclaims
+     * it -- letting a remount deterministically exercise crash-resume. */
+    if (unlikely(getenv("DEMOFS_DRAIN_DISABLE") != NULL)) {
+        return;
+    }
+
+    d = calloc(1, sizeof(*d));
 
     d->thread = thread;
     d->inum   = inum;
@@ -3372,6 +3484,22 @@ demofs_drain_final_cb(
     demofs_drain_complete(priv);
 } /* demofs_drain_final_cb */
 
+/* The durable orphan entry is removed; finish reclaiming the inode itself
+ * (home block + struct) in the same transaction and commit. */
+static void
+demofs_drain_after_unrecord(void *priv)
+{
+    struct demofs_drain *d = priv;
+    uint32_t             dev;
+    uint64_t             off = sm_inum_to_device_offset(d->thread->shared->space_map,
+                                                        d->inum, &dev);
+
+    demofs_txn_pin_inode_block(d->thread, d->txn, d->inode, 0);
+    demofs_txn_free_space(d->thread, d->txn, dev, off, DEMOFS_BLOCK_SIZE);
+    demofs_inode_free(d->thread, d->inode);
+    demofs_txn_commit(d->txn, demofs_drain_final_cb, d);
+} /* demofs_drain_after_unrecord */
+
 static void
 demofs_drain_removed_cb(
     struct demofs_bt_op *op,
@@ -3400,16 +3528,14 @@ demofs_drain_looked_cb(
     struct demofs_bt_op *rop;
 
     if (result < 0) {
-        /* Tree empty: free the home block + the inode struct, then commit. */
-        uint32_t dev;
-        uint64_t off = sm_inum_to_device_offset(d->thread->shared->space_map,
-                                                d->inum, &dev);
-
+        /* Tree empty: remove the durable orphan entry, then (in the same txn)
+         * free the home block + inode struct.  Removing the orphan entry last
+         * means a crash before this commit just re-drains on the next mount
+         * (idempotent); the orphan inode (3) is acquired last (leaf -> no
+         * deadlock). */
         demofs_bt_op_free(d->thread, op);
-        demofs_txn_pin_inode_block(d->thread, d->txn, d->inode, 0);
-        demofs_txn_free_space(d->thread, d->txn, dev, off, DEMOFS_BLOCK_SIZE);
-        demofs_inode_free(d->thread, d->inode);
-        demofs_txn_commit(d->txn, demofs_drain_final_cb, d);
+        demofs_orphan_op_start(d->thread, d->txn, d->inum, d->gen, 1 /* remove */,
+                               demofs_drain_after_unrecord, d);
         return;
     }
 
@@ -3442,6 +3568,105 @@ demofs_drain_step(struct demofs_drain *d)
         demofs_drain_looked_cb(op, op->result, d);
     }
 } /* demofs_drain_step */
+
+/* ------------------------------------------------------------------ */
+/* Mount-time orphan recovery: re-enqueue inodes left on the durable    */
+/* orphan list by a crash mid-drain (draining is idempotent).           */
+/* ------------------------------------------------------------------ */
+
+struct demofs_orphan_ent {
+    uint64_t inum;
+    uint32_t gen;
+};
+
+/* Collect every orphan entry in the orphan-list inode's b+tree (sync walk;
+ * runs once at mount, single-threaded).  Generic recursion over node levels. */
+static void
+demofs_orphan_scan_node(
+    struct demofs_thread      *thread,
+    void                      *buf,
+    uint32_t                   base,
+    struct demofs_orphan_ent **arr,
+    uint32_t                  *n,
+    uint32_t                  *cap)
+{
+    struct demofs_bt_node_hdr *h = demofs_bt_hdr(buf, base);
+    int                        i;
+
+    if (h->level > 0) {
+        struct demofs_bt_islot *isl = demofs_bt_islots(buf, base);
+
+        for (i = 0; i < h->nitems; i++) {
+            uint32_t             cdev;
+            uint64_t             coff = sm_inum_to_device_offset(thread->shared->space_map,
+                                                                 isl[i].child, &cdev);
+            struct demofs_block *blk = demofs_block_claim(thread, cdev, coff, 0);
+
+            demofs_orphan_scan_node(thread, blk->iov.data, 0, arr, n, cap);
+            demofs_block_unpin(thread, blk, DEMOFS_BLOCK_CLEAN);
+        }
+    } else {
+        struct demofs_bt_lslot *s = demofs_bt_lslots(buf, base);
+
+        for (i = 0; i < h->nitems; i++) {
+            if (s[i].key.type != DEMOFS_REC_ORPHAN) {
+                continue;
+            }
+            if (*n == *cap) {
+                *cap *= 2;
+                *arr  = realloc(*arr, *cap * sizeof(**arr));
+            }
+            (*arr)[*n].inum = s[i].key.subkey;
+            (*arr)[*n].gen  = *(uint32_t *) ((char *) buf + base + s[i].off);
+            (*n)++;
+        }
+    }
+} /* demofs_orphan_scan_node */
+
+static void
+demofs_orphan_scan(struct demofs_thread *thread)
+{
+    struct demofs_shared     *shared = thread->shared;
+    struct demofs_inode      *odir;
+    struct demofs_block      *blk;
+    struct demofs_orphan_ent *arr;
+    uint32_t                  n = 0, cap = 16, i;
+    uint32_t                  dev;
+    uint64_t                  off;
+
+    pthread_mutex_lock(&shared->lock);
+    if (shared->orphans_scanned) {
+        pthread_mutex_unlock(&shared->lock);
+        return;
+    }
+    shared->orphans_scanned = 1;
+    pthread_mutex_unlock(&shared->lock);
+
+    /* Load the orphan-list inode (nlink 1) and read its tree from its home
+     * block, collecting every recorded orphan inum + gen. */
+    odir = demofs_inode_load_sync(thread, DEMOFS_ORPHAN_INUM, DEMOFS_ORPHAN_GEN, 0);
+    if (!odir) {
+        return;     /* not yet created (no orphans possible) */
+    }
+
+    off = sm_inum_to_device_offset(shared->space_map, DEMOFS_ORPHAN_INUM, &dev);
+    blk = demofs_block_claim(thread, dev, off, 0);
+    arr = malloc(cap * sizeof(*arr));
+    demofs_orphan_scan_node(thread, blk->iov.data, DEMOFS_BT_ROOT_BASE, &arr, &n, &cap);
+    demofs_block_unpin(thread, blk, DEMOFS_BLOCK_CLEAN);
+
+    for (i = 0; i < n; i++) {
+        /* Reload the orphaned (nlink==0) inode into cache, then enqueue it;
+         * the drainer resumes its (possibly partially-drained) tree. */
+        demofs_inode_load_sync(thread, arr[i].inum, arr[i].gen, 1 /* allow_orphan */);
+        demofs_drain_enqueue(thread, arr[i].inum, arr[i].gen);
+    }
+    free(arr);
+
+    if (n) {
+        chimera_demofs_info("orphan recovery: re-enqueued %u inode(s) for drain", n);
+    }
+} /* demofs_orphan_scan */
 
 /*
  * Remove a key from an inode's b+tree, maintaining the B+tree invariants:
@@ -7463,6 +7688,30 @@ demofs_mknod_at(
 
 /* inode_stash[0] = parent (locked across child fetch) */
 
+/* Finish a remove: map the parent's post-attrs and commit. */
+static void
+demofs_remove_at_finish(struct chimera_vfs_request *request)
+{
+    struct demofs_request_private *p      = request->plugin_data;
+    struct demofs_inode           *parent = p->inode_stash[0];
+
+    demofs_map_attrs(p->thread, &request->remove_at.r_dir_post_attr, parent);
+    demofs_op_ok(request, p->txn);
+} /* demofs_remove_at_finish */
+
+/* Continuation after a large deleted inode is recorded on the durable orphan
+ * list: enqueue it for the in-session drainer and finish the request. */
+static void
+demofs_remove_orphan_done(void *priv)
+{
+    struct chimera_vfs_request    *request = priv;
+    struct demofs_request_private *p       = request->plugin_data;
+    struct demofs_inode           *inode   = p->inode_stash[1];
+
+    demofs_drain_enqueue(p->thread, inode->inum, inode->gen);
+    demofs_remove_at_finish(request);
+} /* demofs_remove_orphan_done */
+
 static void
 demofs_remove_at_removed_cb(
     struct demofs_bt_op *op,
@@ -7520,18 +7769,21 @@ demofs_remove_at_removed_cb(
                 demofs_bt_free_tree(thread, p->txn, inode);
                 demofs_inode_free(thread, inode);
             } else {
-                /* Large inode: hand to the background drainer (bounded batches)
-                 * so one delete can't flood the I/O queue.  The struct stays
-                 * resident (nlink==0 -> not evicted) until the drainer frees it;
-                 * the drainer's acquire parks until this unlink txn commits. */
-                demofs_drain_enqueue(thread, inode->inum, inode->gen);
+                /* Large inode: record it on the durable orphan list -- atomic
+                 * with this unlink txn (the orphan inode is acquired last, a
+                 * leaf in the lock order, so no deadlock).  The continuation
+                 * enqueues it for the in-session drainer + finishes; a crash
+                 * before this txn commits leaves neither the unlink nor the
+                 * orphan record, and after it the mount scan can resume. */
+                demofs_orphan_op_start(thread, p->txn, inode->inum, inode->gen,
+                                       0 /* insert */, demofs_remove_orphan_done,
+                                       request);
+                return;
             }
         }
     }
 
-    demofs_map_attrs(thread, &request->remove_at.r_dir_post_attr, parent);
-
-    demofs_op_ok(request, p->txn);
+    demofs_remove_at_finish(request);
 } /* demofs_remove_at_removed_cb */
 
 static void
@@ -10998,6 +11250,11 @@ demofs_dispatch(
 
     if (unlikely(shared->root_fhlen == 0)) {
         demofs_bootstrap(thread);
+    }
+
+    /* Resume any inode drains left pending by a crash (once per mount). */
+    if (unlikely(!shared->orphans_scanned)) {
+        demofs_orphan_scan(thread);
     }
 
     switch (request->opcode) {

--- a/src/vfs/demofs/demofs.c
+++ b/src/vfs/demofs/demofs.c
@@ -44,6 +44,13 @@
 #define DEMOFS_INODE_CACHE_SHARDS 256
 #define DEMOFS_INODE_CACHE_MASK   (DEMOFS_INODE_CACHE_SHARDS - 1)
 
+/* Statically-reserved inums (block_idx in AG 0 / disk 0; see space_map.c).
+ * inum 2 = root; inum 3 = orphan list (deleted inodes pending incremental
+ * reclaim).  The orphan inode is a directory whose b+tree keys are orphan
+ * inums; the drainer empties it. */
+#define DEMOFS_ROOT_INUM          2
+#define DEMOFS_ORPHAN_INUM        3
+
 /* Max inodes a single transaction can hold locked at once.  rename needs
  * 4 (two parents, child, replaced target); others (e.g. readdir) touch
  * many but only 2 at a time and release as they go. */
@@ -5882,6 +5889,53 @@ demofs_bootstrap(struct demofs_thread *thread)
     inode->block->state = DEMOFS_BLOCK_CLEAN;
     demofs_block_unpin(thread, inode->block, DEMOFS_BLOCK_CLEAN);
     inode->block = NULL;
+
+    /* Statically-reserved orphan-list inode (inum 3): an empty directory whose
+     * b+tree keys are the inums of deleted-but-not-fully-reclaimed inodes.
+     * Created at format alongside root (persists; loaded from disk on remount);
+     * the incremental drainer scans it on mount and empties it. */
+    {
+        uint32_t             odev;
+        uint64_t             ooff = sm_inum_to_device_offset(shared->space_map,
+                                                             DEMOFS_ORPHAN_INUM, &odev);
+        struct demofs_inode *oin = demofs_inode_struct_new(DEMOFS_ORPHAN_INUM);
+
+        oin->size        = 4096;
+        oin->space_used  = 4096;
+        oin->nlink       = 1;
+        oin->mode        = S_IFDIR | 0700;
+        oin->atime_sec   = now.tv_sec;
+        oin->atime_nsec  = now.tv_nsec;
+        oin->mtime_sec   = now.tv_sec;
+        oin->mtime_nsec  = now.tv_nsec;
+        oin->ctime_sec   = now.tv_sec;
+        oin->ctime_nsec  = now.tv_nsec;
+        oin->parent_inum = DEMOFS_ORPHAN_INUM;
+        oin->parent_gen  = oin->gen;
+
+        demofs_inode_cache_insert(shared, oin);
+
+        oin->block = demofs_block_claim(thread, odev, ooff, 1);
+        demofs_bt_node_init(oin->block->iov.data, DEMOFS_BT_ROOT_BASE,
+                            DEMOFS_BT_ROOT_CAP, 0);
+        demofs_inode_flush(oin);
+        {
+            int fd = open(shared->device_paths[odev], O_WRONLY);
+
+            if (fd >= 0) {
+                ssize_t wn = pwrite(fd, oin->block->iov.data, DEMOFS_BLOCK_SIZE,
+                                    (off_t) ooff);
+
+                chimera_demofs_abort_if(wn != (ssize_t) DEMOFS_BLOCK_SIZE,
+                                        "bootstrap orphan pwrite failed: %zd", wn);
+                fsync(fd);
+                close(fd);
+            }
+        }
+        oin->block->state = DEMOFS_BLOCK_CLEAN;
+        demofs_block_unpin(thread, oin->block, DEMOFS_BLOCK_CLEAN);
+        oin->block = NULL;
+    }
 
     /* Create 16-byte fsid buffer for root FH encoding (8-byte fsid + 8 bytes padding) */
     {

--- a/src/vfs/demofs/demofs.c
+++ b/src/vfs/demofs/demofs.c
@@ -252,12 +252,6 @@ struct demofs_inode {
     /* Directory only: parent for ".." resolution (also persisted in dinode). */
     uint64_t                    parent_inum;
     uint32_t                    parent_gen;
-
-    /* TODO(phase 1c): extents move into the b+tree; until then regular
-     * files keep their extents in this in-memory rb-tree. */
-    struct {
-        struct rb_tree extents;
-    } file;
 };
 
 struct demofs_inode_shard {
@@ -381,6 +375,7 @@ struct demofs_bt_node_hdr {
     uint32_t free_end;     /* leaf heap top (records occupy [free_end, capacity)) */
     uint32_t reserved;
     uint64_t next_leaf;    /* leaf only: bptr of next leaf in key order (0 = none) */
+    uint64_t prev_leaf;    /* leaf only: bptr of prev leaf in key order (0 = none) */
 };
 
 struct demofs_bt_islot {          /* interior slot, 24 B */
@@ -1289,6 +1284,7 @@ demofs_bt_node_init(
     h->free_end  = capacity;
     h->reserved  = 0;
     h->next_leaf = 0;
+    h->prev_leaf = 0;
 } /* demofs_bt_node_init */
 
 /* Free bytes available in a leaf for one more (slot + record). */
@@ -1447,6 +1443,7 @@ demofs_bt_leaf_split(
     void                       *buf,
     uint32_t                    base,
     uint32_t                    cap,
+    uint64_t                    self_bptr,
     int                         insert_idx,
     const struct demofs_bt_key *nkey,
     const void                 *nrec,
@@ -1469,7 +1466,7 @@ demofs_bt_leaf_split(
     int                        i, oi, split_i;
     struct demofs_block       *right;
     void                      *rbuf;
-    uint64_t                   old_next;
+    uint64_t                   old_next, old_prev;
 
     items   = malloc(total * sizeof(*items));
     scratch = malloc(cap + nreclen);
@@ -1508,11 +1505,13 @@ demofs_bt_leaf_split(
     }
 
     old_next = h->next_leaf;
+    old_prev = h->prev_leaf;
 
     right = demofs_bt_alloc_node(thread, txn, 0, sep_bptr);
     rbuf  = right->buffer;
 
-    /* Rebuild the left node in place from scratch (no aliasing). */
+    /* Rebuild the left node in place from scratch (no aliasing).  node_init
+     * clears the leaf links, so they are restored explicitly below. */
     demofs_bt_node_init(buf, base, cap, 0);
     for (i = 0; i < split_i; i++) {
         demofs_bt_leaf_append(buf, base, &items[i].key,
@@ -1523,8 +1522,19 @@ demofs_bt_leaf_split(
                               scratch + items[i].scratch_off, items[i].len);
     }
 
+    /* Splice the new right sibling into the doubly-linked leaf chain:
+     *   self <-> right <-> old_next
+     * (self keeps its own bptr; for the embedded-root-grow case the caller
+     * fixes right->prev_leaf to the new left block afterward.) */
     demofs_bt_hdr(rbuf, 0)->next_leaf = old_next;
+    demofs_bt_hdr(rbuf, 0)->prev_leaf = self_bptr;
     h->next_leaf                      = *sep_bptr;
+    h->prev_leaf                      = old_prev;
+
+    if (old_next) {
+        void *nbuf = demofs_bt_node_for_write(thread, txn, old_next);
+        demofs_bt_hdr(nbuf, 0)->prev_leaf = *sep_bptr;
+    }
 
     *sep_key = items[split_i].key;
 
@@ -1544,6 +1554,7 @@ demofs_bt_leaf_insert(
     void                       *buf,
     uint32_t                    base,
     uint32_t                    cap,
+    uint64_t                    self_bptr,
     const struct demofs_bt_key *key,
     const void                 *rec,
     uint32_t                    reclen,
@@ -1571,8 +1582,8 @@ demofs_bt_leaf_insert(
         return 0;
     }
 
-    demofs_bt_leaf_split(thread, txn, buf, base, cap, idx, key, rec, reclen,
-                         sep_key, sep_bptr);
+    demofs_bt_leaf_split(thread, txn, buf, base, cap, self_bptr, idx, key, rec,
+                         reclen, sep_key, sep_bptr);
     return 1;
 } /* demofs_bt_leaf_insert */
 
@@ -1656,6 +1667,7 @@ demofs_bt_insert_rec(
     void                       *buf,
     uint32_t                    base,
     uint32_t                    cap,
+    uint64_t                    self_bptr,
     const struct demofs_bt_key *key,
     const void                 *rec,
     uint32_t                    reclen,
@@ -1671,8 +1683,8 @@ demofs_bt_insert_rec(
     uint64_t                   cbptr;
 
     if (h->level == 0) {
-        return demofs_bt_leaf_insert(thread, txn, buf, base, cap, key, rec, reclen,
-                                     sep_key, sep_bptr);
+        return demofs_bt_leaf_insert(thread, txn, buf, base, cap, self_bptr, key,
+                                     rec, reclen, sep_key, sep_bptr);
     }
 
     ci         = demofs_bt_interior_search(buf, base, key);
@@ -1681,7 +1693,7 @@ demofs_bt_insert_rec(
     child_buf  = demofs_bt_node_for_write(thread, txn, child_bptr);
 
     csplit = demofs_bt_insert_rec(thread, txn, child_buf, 0, DEMOFS_BT_NODE_CAP,
-                                  key, rec, reclen, &csep, &cbptr);
+                                  child_bptr, key, rec, reclen, &csep, &cbptr);
     if (!csplit) {
         return 0;
     }
@@ -1709,7 +1721,8 @@ demofs_bt_insert(
     int                  split;
 
     split = demofs_bt_insert_rec(thread, txn, root, DEMOFS_BT_ROOT_BASE,
-                                 DEMOFS_BT_ROOT_CAP, key, rec, reclen, &sep, &sep_bptr);
+                                 DEMOFS_BT_ROOT_CAP, inode->inum, key, rec, reclen,
+                                 &sep, &sep_bptr);
     if (!split) {
         return;
     }
@@ -1747,6 +1760,14 @@ demofs_bt_insert(
         isl[0].child = left_bptr;
         isl[1].key   = sep;
         isl[1].child = sep_bptr;
+
+        if (old_level == 0) {
+            /* The lower half migrated from the (now interior) embedded root
+             * into the new left block, so the right sibling's back-link must
+             * point at the left block rather than the inode's own bptr. */
+            void *rbuf = demofs_bt_node_for_write(thread, txn, sep_bptr);
+            demofs_bt_hdr(rbuf, 0)->prev_leaf = left_bptr;
+        }
     }
 } /* demofs_bt_insert */
 
@@ -1920,35 +1941,33 @@ demofs_bt_lookup_ge(
             next_leaf = h->next_leaf;
             urcu_memb_read_unlock();
 
-            if (next_leaf == 0) {
-                return -1;     /* no key >= search */
-            }
-            /* Successor is the first slot of the next leaf. */
-            bptr     = next_leaf;
-            use_root = 0;
-            {
+            /* The successor is the first slot of the nearest non-empty leaf to
+             * the right.  Lazy deletion can leave emptied leaves in the chain,
+             * so walk next_leaf until a populated leaf is found. */
+            while (next_leaf) {
                 uint32_t cdev;
-                uint64_t coff = sm_inum_to_device_offset(thread->shared->space_map, bptr, &cdev);
+                uint64_t coff = sm_inum_to_device_offset(thread->shared->space_map, next_leaf, &cdev);
 
                 urcu_memb_read_lock();
                 blk = demofs_block_lookup_rcu(thread, cdev, coff);
                 chimera_demofs_abort_if(!blk, "b+tree read: next leaf not resident");
                 h = demofs_bt_hdr(blk->buffer, 0);
-                if (h->nitems == 0) {
+                if (h->nitems > 0) {
+                    struct demofs_bt_lslot *sl  = demofs_bt_lslots(blk->buffer, 0);
+                    uint32_t                len = sl[0].len;
+                    *r_key = sl[0].key;
+                    if (len > out_cap) {
+                        len = out_cap;
+                    }
+                    memcpy(out, (char *) blk->buffer + sl[0].off, len);
+                    len = sl[0].len;
                     urcu_memb_read_unlock();
-                    return -1;
+                    return (int) len;
                 }
-                struct demofs_bt_lslot *sl  = demofs_bt_lslots(blk->buffer, 0);
-                uint32_t                len = sl[0].len;
-                *r_key = sl[0].key;
-                if (len > out_cap) {
-                    len = out_cap;
-                }
-                memcpy(out, (char *) blk->buffer + sl[0].off, len);
-                len = sl[0].len;
+                next_leaf = h->next_leaf;
                 urcu_memb_read_unlock();
-                return (int) len;
             }
+            return -1;     /* no key >= search */
         } else {
             int ci = demofs_bt_interior_search(buf, base, key);
             bptr = demofs_bt_islots(buf, base)[ci].child;
@@ -1999,20 +2018,12 @@ demofs_bt_lookup_le(
         h    = demofs_bt_hdr(buf, base);
 
         if (h->level == 0) {
-            int exact;
-            int idx = demofs_bt_leaf_search(buf, base, key, &exact);
-            int fidx;
+            int      exact = 0;
+            int      idx   = h->nitems ? demofs_bt_leaf_search(buf, base, key, &exact) : 0;
+            int      fidx  = h->nitems ? (exact ? idx : idx - 1) : -1;
+            uint64_t prev;
 
-            if (h->nitems == 0) {
-                urcu_memb_read_unlock();
-                return -1;
-            }
-            fidx = exact ? idx : idx - 1;
-            if (fidx < 0) {
-                urcu_memb_read_unlock();
-                return -1;     /* no key <= search in this (leftmost) leaf */
-            }
-            {
+            if (fidx >= 0) {
                 struct demofs_bt_lslot *sl  = demofs_bt_lslots(buf, base);
                 uint32_t                len = sl[fidx].len;
 
@@ -2025,6 +2036,45 @@ demofs_bt_lookup_le(
                 urcu_memb_read_unlock();
                 return (int) len;
             }
+
+            /* No key <= search in this leaf.  Lazy deletion can leave a
+             * parent separator pointing below a leaf's true minimum (or at an
+             * emptied leaf), so the floor may be the last key of a leaf to the
+             * left.  Walk the prev chain, skipping empties. */
+            prev = h->prev_leaf;
+            urcu_memb_read_unlock();
+
+            while (prev) {
+                uint32_t                   pdev;
+                uint64_t                   poff;
+                struct demofs_block       *pblk;
+                struct demofs_bt_node_hdr *ph;
+
+                poff = sm_inum_to_device_offset(thread->shared->space_map, prev, &pdev);
+
+                urcu_memb_read_lock();
+                pblk = demofs_block_lookup_rcu(thread, pdev, poff);
+                chimera_demofs_abort_if(!pblk, "b+tree read: prev leaf not resident");
+                ph = demofs_bt_hdr(pblk->buffer, 0);
+
+                if (ph->nitems > 0) {
+                    struct demofs_bt_lslot *sl  = demofs_bt_lslots(pblk->buffer, 0);
+                    int                     li  = ph->nitems - 1;
+                    uint32_t                len = sl[li].len;
+
+                    *r_key = sl[li].key;
+                    if (len > out_cap) {
+                        len = out_cap;
+                    }
+                    memcpy(out, (char *) pblk->buffer + sl[li].off, len);
+                    len = sl[li].len;
+                    urcu_memb_read_unlock();
+                    return (int) len;
+                }
+                prev = ph->prev_leaf;
+                urcu_memb_read_unlock();
+            }
+            return -1;
         } else {
             int ci = demofs_bt_interior_search(buf, base, key);
             bptr = demofs_bt_islots(buf, base)[ci].child;
@@ -2163,6 +2213,113 @@ demofs_symlink_get(
 
     return demofs_bt_lookup_exact(thread, inode, &key, out, cap);
 } /* demofs_symlink_get */
+
+/* ------------------------------------------------------------------ */
+/* File extents over the inode b+tree                                  */
+/* ------------------------------------------------------------------ */
+
+static inline struct demofs_bt_key
+demofs_extent_key(uint64_t file_offset)
+{
+    struct demofs_bt_key k = { .type = DEMOFS_REC_EXTENT, .subkey = file_offset };
+
+    return k;
+} /* demofs_extent_key */
+
+static void
+demofs_ext_insert(
+    struct demofs_thread *thread,
+    struct demofs_txn    *txn,
+    struct demofs_inode  *inode,
+    uint64_t              file_offset,
+    uint64_t              length,
+    uint32_t              device_id,
+    uint64_t              device_offset)
+{
+    struct demofs_extent_rec rec = {
+        .length        = length,
+        .device_id     = device_id,
+        .pad           = 0,
+        .device_offset = device_offset,
+    };
+    struct demofs_bt_key     key = demofs_extent_key(file_offset);
+
+    demofs_bt_insert(thread, txn, inode, &key, &rec, sizeof(rec));
+} /* demofs_ext_insert */
+
+static int
+demofs_ext_remove(
+    struct demofs_thread *thread,
+    struct demofs_txn    *txn,
+    struct demofs_inode  *inode,
+    uint64_t              file_offset)
+{
+    struct demofs_bt_key key = demofs_extent_key(file_offset);
+
+    return demofs_bt_remove(thread, txn, inode, &key);
+} /* demofs_ext_remove */
+
+/* Fill *out with the extent whose file_offset is the largest <= the given
+ * offset; returns 1 if found, 0 otherwise.  The node/next/buffer fields of
+ * *out are left untouched (callers only read the on-disk fields). */
+static int
+demofs_ext_floor(
+    struct demofs_thread *thread,
+    struct demofs_inode  *inode,
+    uint64_t              file_offset,
+    struct demofs_extent *out)
+{
+    struct demofs_bt_key     key = demofs_extent_key(file_offset);
+    struct demofs_bt_key     found;
+    struct demofs_extent_rec rec;
+    int                      len;
+
+    len = demofs_bt_lookup_le(thread, inode, &key, &found, &rec, sizeof(rec));
+    if (len < 0 || found.type != DEMOFS_REC_EXTENT) {
+        return 0;
+    }
+    out->file_offset   = found.subkey;
+    out->length        = (uint32_t) rec.length;
+    out->device_id     = rec.device_id;
+    out->device_offset = rec.device_offset;
+    return 1;
+} /* demofs_ext_floor */
+
+/* Fill *out with the extent whose file_offset is the smallest >= the given
+ * offset; returns 1 if found, 0 otherwise. */
+static int
+demofs_ext_ceil(
+    struct demofs_thread *thread,
+    struct demofs_inode  *inode,
+    uint64_t              file_offset,
+    struct demofs_extent *out)
+{
+    struct demofs_bt_key     key = demofs_extent_key(file_offset);
+    struct demofs_bt_key     found;
+    struct demofs_extent_rec rec;
+    int                      len;
+
+    len = demofs_bt_lookup_ge(thread, inode, &key, &found, &rec, sizeof(rec));
+    if (len < 0 || found.type != DEMOFS_REC_EXTENT) {
+        return 0;
+    }
+    out->file_offset   = found.subkey;
+    out->length        = (uint32_t) rec.length;
+    out->device_id     = rec.device_id;
+    out->device_offset = rec.device_offset;
+    return 1;
+} /* demofs_ext_ceil */
+
+/* Next extent strictly after after_file_offset. */
+static inline int
+demofs_ext_next(
+    struct demofs_thread *thread,
+    struct demofs_inode  *inode,
+    uint64_t              after_file_offset,
+    struct demofs_extent *out)
+{
+    return demofs_ext_ceil(thread, inode, after_file_offset + 1, out);
+} /* demofs_ext_next */
 
 static inline struct demofs_extent *
 demofs_extent_alloc(struct demofs_thread *thread)
@@ -2318,12 +2475,12 @@ demofs_inode_free(
     struct demofs_thread *thread,
     struct demofs_inode  *inode)
 {
-    if (S_ISREG(inode->mode)) {
-        rb_tree_destroy(&inode->file.extents, demofs_extent_release, thread);
-        rb_tree_init(&inode->file.extents);
-    }
-    /* Directory / symlink contents live in the inode's b+tree blocks, which
-     * are leaked for now (no space reclaim yet). */
+    (void) thread;
+
+    /* All inode contents (dirents, extents, symlink target) live in the
+     * inode's b+tree blocks, which are leaked for now (no space reclaim
+     * yet); the device ranges backing file extents are returned to the
+     * space map by truncate/deallocate before this point. */
 
     inode->gen++;
     inode->refcnt = 0;
@@ -3099,14 +3256,8 @@ demofs_inode_cache_release(
 
     (void) private_data;
 
-    /* Process is exiting; thread slab allocators are already gone, so the
-     * extent release callback no-ops with a NULL thread.  Directory/symlink
-     * b+tree blocks are freed via the block cache.  We still own and must
-     * free the inode struct itself (heap-allocated). */
-    if (S_ISREG(inode->mode)) {
-        rb_tree_destroy(&inode->file.extents, demofs_extent_release, NULL);
-    }
-
+    /* All inode contents live in b+tree blocks freed via the block cache;
+     * we only own and must free the inode struct itself (heap-allocated). */
     free(inode);
 } /* demofs_inode_cache_release */
 
@@ -3496,26 +3647,25 @@ demofs_setattr_inode_cb(
         request->setattr.set_attr->va_size < inode->size) {
 
         uint64_t              new_size = request->setattr.set_attr->va_size;
-        struct demofs_extent *extent, *next_extent;
+        struct demofs_extent  ext_buf;
+        struct demofs_extent *extent = &ext_buf;
+        int                   have;
 
-        rb_tree_query_floor(&inode->file.extents, new_size, file_offset, extent);
-
-        if (!extent) {
-            rb_tree_first(&inode->file.extents, extent);
+        have = demofs_ext_floor(thread, inode, new_size, extent);
+        if (!have) {
+            have = demofs_ext_ceil(thread, inode, 0, extent);
         }
 
-        while (extent) {
+        while (have) {
             uint64_t extent_start = extent->file_offset;
             uint64_t extent_end   = extent_start + extent->length;
-
-            next_extent = rb_tree_next(&inode->file.extents, extent);
+            uint64_t cur_fo       = extent->file_offset;
 
             if (extent_start >= new_size) {
                 demofs_thread_free_space(thread, extent->device_id,
                                          extent->device_offset,
                                          SM_ALIGN_UP(extent->length));
-                rb_tree_remove(&inode->file.extents, &extent->node);
-                demofs_extent_free(thread, extent);
+                demofs_ext_remove(thread, p->txn, inode, cur_fo);
             } else if (extent_end > new_size) {
                 uint64_t old_aligned = SM_ALIGN_UP(extent->length);
                 uint64_t new_logical = new_size - extent_start;
@@ -3526,10 +3676,13 @@ demofs_setattr_inode_cb(
                                              extent->device_offset + new_aligned,
                                              old_aligned - new_aligned);
                 }
-                extent->length = new_logical;
+                /* Trim in place by rewriting the record with the new length. */
+                demofs_ext_remove(thread, p->txn, inode, cur_fo);
+                demofs_ext_insert(thread, p->txn, inode, cur_fo, new_logical,
+                                  extent->device_id, extent->device_offset);
             }
 
-            extent = next_extent;
+            have = demofs_ext_next(thread, inode, cur_fo, extent);
         }
     }
 
@@ -4527,7 +4680,6 @@ demofs_open_at_alloc_cb(
     inode->ctime_sec  = now.tv_sec;
     inode->ctime_nsec = now.tv_nsec;
 
-    rb_tree_init(&inode->file.extents);
     demofs_apply_attrs(inode, request->open_at.set_attr);
 
     demofs_dir_insert(thread, p->txn, parent, request->open_at.name_hash,
@@ -4640,8 +4792,6 @@ demofs_create_unlinked_alloc_cb(
     inode->mtime_nsec = now.tv_nsec;
     inode->ctime_sec  = now.tv_sec;
     inode->ctime_nsec = now.tv_nsec;
-
-    rb_tree_init(&inode->file.extents);
 
     demofs_apply_attrs(inode, request->create_unlinked.set_attr);
 
@@ -4806,7 +4956,9 @@ demofs_read_inode_cb(
     struct demofs_thread          *thread         = demofs_private->thread;
     struct demofs_shared          *shared         = thread->shared;
     struct evpl                   *evpl           = thread->evpl;
-    struct demofs_extent          *extent;
+    struct demofs_extent           ext_buf;
+    struct demofs_extent          *extent = &ext_buf;
+    int                            have;
     uint64_t                       offset, length, read_offset, read_left;
     uint64_t                       extent_end, overlap_start, overlap_length;
     uint64_t                       aligned_offset, aligned_length, chunk;
@@ -4860,17 +5012,17 @@ demofs_read_inode_cb(
     evpl_iovec_cursor_init(&cursor, request->read.iov, request->read.r_niov);
 
     // Find first extent that could contain our offset
-    rb_tree_query_floor(&inode->file.extents, read_offset, file_offset, extent);
+    have = demofs_ext_floor(thread, inode, read_offset, extent);
 
-    if (!extent) {
+    if (!have) {
         /* No extent at or before read_offset - get the first extent
          * in case there's one that starts within our range */
-        rb_tree_first(&inode->file.extents, extent);
+        have = demofs_ext_ceil(thread, inode, 0, extent);
     } else if (extent->file_offset + extent->length <= read_offset) {
-        extent = rb_tree_next(&inode->file.extents, extent);
+        have = demofs_ext_next(thread, inode, extent->file_offset, extent);
     }
 
-    while (read_left && extent && extent->file_offset < aligned_offset + aligned_length) {
+    while (read_left && have && extent->file_offset < aligned_offset + aligned_length) {
 
         if (read_offset < extent->file_offset) {
             chunk = extent->file_offset - read_offset;
@@ -4949,7 +5101,7 @@ demofs_read_inode_cb(
             read_left   -= chunk;
         }
 
-        extent = rb_tree_next(&inode->file.extents, extent);
+        have = demofs_ext_next(thread, inode, extent->file_offset, extent);
     }
 
     if (read_left) {
@@ -5180,20 +5332,20 @@ demofs_write_phase2(
 
 } /* demofs_write_phase2 */
 
-// Find extent covering a specific file offset
+// Find the extent covering a specific file offset; fills *buf and returns
+// it, or NULL if no extent covers the offset.
 static struct demofs_extent *
 demofs_find_extent_at(
-    struct demofs_inode *inode,
-    uint64_t             file_offset)
+    struct demofs_thread *thread,
+    struct demofs_inode  *inode,
+    uint64_t              file_offset,
+    struct demofs_extent *buf)
 {
-    struct demofs_extent *extent;
+    if (demofs_ext_floor(thread, inode, file_offset, buf)) {
+        uint64_t extent_end = buf->file_offset + buf->length;
 
-    rb_tree_query_floor(&inode->file.extents, file_offset, file_offset, extent);
-
-    if (extent) {
-        uint64_t extent_end = extent->file_offset + extent->length;
-        if (file_offset >= extent->file_offset && file_offset < extent_end) {
-            return extent;
+        if (file_offset >= buf->file_offset && file_offset < extent_end) {
+            return buf;
         }
     }
 
@@ -5211,7 +5363,10 @@ demofs_write_inode_cb(
     struct demofs_thread          *thread         = demofs_private->thread;
     struct demofs_shared          *shared         = thread->shared;
     struct evpl                   *evpl           = thread->evpl;
-    struct demofs_extent          *extent, *next_extent, *new_extent;
+    struct demofs_extent           ext_buf;
+    struct demofs_extent          *extent = &ext_buf;
+    struct demofs_extent           prefix_buf, suffix_buf;
+    int                            have;
     uint64_t                       write_start = request->write.offset;
     uint64_t                       write_end   = write_start + request->write.length;
     uint64_t                       aligned_start, aligned_end, aligned_length;
@@ -5267,7 +5422,7 @@ demofs_write_inode_cb(
 
     if (prefix_len > 0) {
         // Check if there's an existing extent covering the prefix region
-        prefix_extent = demofs_find_extent_at(inode, aligned_start);
+        prefix_extent = demofs_find_extent_at(thread, inode, aligned_start, &prefix_buf);
         if (prefix_extent) {
             uint64_t extent_end = prefix_extent->file_offset + prefix_extent->length;
 
@@ -5293,7 +5448,7 @@ demofs_write_inode_cb(
     if (suffix_len > 0) {
         // Check if there's an existing extent covering the suffix region
         // The suffix starts at write_end
-        suffix_extent = demofs_find_extent_at(inode, write_end);
+        suffix_extent = demofs_find_extent_at(thread, inode, write_end, &suffix_buf);
         if (suffix_extent) {
             // The block containing write_end
             uint64_t suffix_block = write_end & ~4095ULL;
@@ -5332,81 +5487,64 @@ demofs_write_inode_cb(
     }
 
     // Remove/trim extents that overlap with the aligned write region
-    rb_tree_query_floor(&inode->file.extents, aligned_start, file_offset, extent);
-
-    if (!extent) {
+    have = demofs_ext_floor(thread, inode, aligned_start, extent);
+    if (!have) {
         /* No extent at or before aligned_start - get the first extent
          * in case there's one that starts within our write range */
-        rb_tree_first(&inode->file.extents, extent);
+        have = demofs_ext_ceil(thread, inode, 0, extent);
     }
 
-    while (extent) {
+    while (have) {
+        uint64_t cur_fo = extent->file_offset;
+
         extent_start = extent->file_offset;
         extent_end   = extent_start + extent->length;
-
-        next_extent = rb_tree_next(&inode->file.extents, extent);
 
         if (extent_start >= aligned_end) {
             break;
         }
 
-        // Check if extent is completely inside aligned region - remove it
         if (extent_start >= aligned_start && extent_end <= aligned_end) {
-            rb_tree_remove(&inode->file.extents, &extent->node);
-            demofs_extent_free(thread, extent);
-            extent = next_extent;
-            continue;
-        }
+            // Completely inside the aligned region - remove it.
+            demofs_ext_remove(thread, demofs_private->txn, inode, cur_fo);
+        } else if (extent_start < aligned_start && extent_end > aligned_end) {
+            // Spans the whole region - split into a before part (trimmed)
+            // and an after part, then we're done (extents are disjoint).
+            uint64_t after_shift = aligned_end - extent_start;
 
-        // Check if extent completely spans the write region - need to split
-        if (extent_start < aligned_start && extent_end > aligned_end) {
-            // Create new extent for the portion after aligned_end
-            struct demofs_extent *after_extent = demofs_extent_alloc(thread);
-            uint64_t              after_shift  = aligned_end - extent_start;
-
-            after_extent->device_id     = extent->device_id;
-            after_extent->device_offset = extent->device_offset + after_shift;
-            after_extent->file_offset   = aligned_end;
-            after_extent->length        = extent_end - aligned_end;
-            after_extent->buffer        = NULL;
-
-            rb_tree_insert(&inode->file.extents, file_offset, after_extent);
-
-            // Trim original extent to end at aligned_start
-            extent->length = aligned_start - extent_start;
+            demofs_ext_insert(thread, demofs_private->txn, inode, aligned_end,
+                              extent_end - aligned_end, extent->device_id,
+                              extent->device_offset + after_shift);
+            demofs_ext_remove(thread, demofs_private->txn, inode, cur_fo);
+            demofs_ext_insert(thread, demofs_private->txn, inode, cur_fo,
+                              aligned_start - extent_start, extent->device_id,
+                              extent->device_offset);
+            break;
         } else if (extent_start < aligned_start && extent_end > aligned_start) {
-            // Trim extent that extends before aligned_start AND overlaps
-            extent->length = aligned_start - extent_start;
+            // Overlaps the left edge - trim to end at aligned_start
+            // (file_offset key unchanged).
+            demofs_ext_remove(thread, demofs_private->txn, inode, cur_fo);
+            demofs_ext_insert(thread, demofs_private->txn, inode, cur_fo,
+                              aligned_start - extent_start, extent->device_id,
+                              extent->device_offset);
         } else if (extent_start < aligned_end && extent_end > aligned_end) {
-            // Trim extent that starts within write region but extends past.
-            // Must remove/re-insert because file_offset is the rb-tree key.
+            // Starts within the write region but extends past - move its
+            // front to aligned_end (the key changes), then we're done.
             uint64_t shift = aligned_end - extent_start;
 
-            rb_tree_remove(&inode->file.extents, &extent->node);
-
-            extent->file_offset    = aligned_end;
-            extent->device_offset += shift;
-            extent->length        -= shift;
-            if (extent->buffer) {
-                extent->buffer = (char *) extent->buffer + shift;
-            }
-
-            rb_tree_insert(&inode->file.extents, file_offset, extent);
+            demofs_ext_remove(thread, demofs_private->txn, inode, cur_fo);
+            demofs_ext_insert(thread, demofs_private->txn, inode, aligned_end,
+                              extent_end - aligned_end, extent->device_id,
+                              extent->device_offset + shift);
+            break;
         }
 
-        extent = next_extent;
+        have = demofs_ext_next(thread, inode, cur_fo, extent);
     }
 
     // Create new extent for the aligned write
-    new_extent = demofs_extent_alloc(thread);
-
-    new_extent->device_id     = device_id;
-    new_extent->device_offset = device_offset;
-    new_extent->file_offset   = aligned_start;
-    new_extent->length        = aligned_length;
-    new_extent->buffer        = NULL;
-
-    rb_tree_insert(&inode->file.extents, file_offset, new_extent);
+    demofs_ext_insert(thread, demofs_private->txn, inode, aligned_start,
+                      aligned_length, device_id, device_offset);
 
     // Update inode metadata
     if (inode->size < write_end) {
@@ -5544,29 +5682,28 @@ demofs_allocate_inode_cb(
         /* DEALLOCATE: punch hole in [offset, offset+length) */
         uint64_t              hole_start = request->allocate.offset;
         uint64_t              hole_end   = hole_start + request->allocate.length;
-        struct demofs_extent *extent, *next_extent;
+        struct demofs_extent  ext_buf;
+        struct demofs_extent *extent = &ext_buf;
+        int                   have;
 
         if (hole_end > inode->size) {
             hole_end = inode->size;
         }
 
         if (hole_start < hole_end) {
-            rb_tree_query_floor(&inode->file.extents, hole_start, file_offset,
-                                extent);
-
-            if (!extent) {
-                rb_tree_first(&inode->file.extents, extent);
+            have = demofs_ext_floor(thread, inode, hole_start, extent);
+            if (!have) {
+                have = demofs_ext_ceil(thread, inode, 0, extent);
             }
 
-            while (extent) {
+            while (have) {
                 uint64_t extent_start = extent->file_offset;
                 uint64_t extent_end   = extent_start + extent->length;
-
-                next_extent = rb_tree_next(&inode->file.extents, extent);
+                uint64_t cur_fo       = extent_start;
 
                 /* Skip extents entirely before hole */
                 if (extent_end <= hole_start) {
-                    extent = next_extent;
+                    have = demofs_ext_next(thread, inode, cur_fo, extent);
                     continue;
                 }
 
@@ -5582,51 +5719,38 @@ demofs_allocate_inode_cb(
                     demofs_thread_free_space(thread, extent->device_id,
                                              extent->device_offset,
                                              SM_ALIGN_UP(extent->length));
-                    rb_tree_remove(&inode->file.extents, &extent->node);
-                    demofs_extent_free(thread, extent);
+                    demofs_ext_remove(thread, p->txn, inode, cur_fo);
                 } else if (extent_start < hole_start &&
                            extent_end > hole_end) {
-                    /* Extent spans the entire hole - split it */
-                    struct demofs_extent *after_extent =
-                        demofs_extent_alloc(thread);
-                    uint64_t              after_shift = hole_end - extent_start;
+                    /* Extent spans the entire hole - split it. */
+                    uint64_t after_shift = hole_end - extent_start;
 
-                    after_extent->device_id     = extent->device_id;
-                    after_extent->device_offset = extent->device_offset +
-                        after_shift;
-                    after_extent->file_offset = hole_end;
-                    after_extent->length      = extent_end - hole_end;
-                    after_extent->buffer      = NULL;
-
-                    rb_tree_insert(&inode->file.extents, file_offset,
-                                   after_extent);
-
-                    /* Trim original extent to end at hole_start */
-                    extent->length = hole_start - extent_start;
+                    demofs_ext_insert(thread, p->txn, inode, hole_end,
+                                      extent_end - hole_end, extent->device_id,
+                                      extent->device_offset + after_shift);
+                    demofs_ext_remove(thread, p->txn, inode, cur_fo);
+                    demofs_ext_insert(thread, p->txn, inode, cur_fo,
+                                      hole_start - extent_start, extent->device_id,
+                                      extent->device_offset);
+                    break;
                 } else if (extent_start < hole_start) {
-                    /* Extent overlaps start of hole - trim end */
-                    extent->length = hole_start - extent_start;
+                    /* Extent overlaps start of hole - trim end. */
+                    demofs_ext_remove(thread, p->txn, inode, cur_fo);
+                    demofs_ext_insert(thread, p->txn, inode, cur_fo,
+                                      hole_start - extent_start, extent->device_id,
+                                      extent->device_offset);
                 } else {
-                    /* Extent overlaps end of hole - trim start.
-                     * Must remove/re-insert because file_offset is
-                     * the rb-tree key. */
+                    /* Extent overlaps end of hole - trim start (key moves). */
                     uint64_t shift = hole_end - extent_start;
 
-                    rb_tree_remove(&inode->file.extents, &extent->node);
-
-                    extent->file_offset    = hole_end;
-                    extent->device_offset += shift;
-                    extent->length        -= shift;
-
-                    if (extent->buffer) {
-                        extent->buffer = (char *) extent->buffer + shift;
-                    }
-
-                    rb_tree_insert(&inode->file.extents, file_offset,
-                                   extent);
+                    demofs_ext_remove(thread, p->txn, inode, cur_fo);
+                    demofs_ext_insert(thread, p->txn, inode, hole_end,
+                                      extent_end - hole_end, extent->device_id,
+                                      extent->device_offset + shift);
+                    break;
                 }
 
-                extent = next_extent;
+                have = demofs_ext_next(thread, inode, cur_fo, extent);
             }
 
             inode->space_used = (inode->size + 4095) & ~4095;
@@ -5680,6 +5804,7 @@ demofs_seek_inode_cb(
 {
     struct chimera_vfs_request    *request = private_data;
     struct demofs_request_private *p       = request->plugin_data;
+    struct demofs_thread          *thread  = p->thread;
     uint64_t                       offset  = request->seek.offset;
 
     if (unlikely(status != CHIMERA_VFS_OK)) {
@@ -5696,20 +5821,22 @@ demofs_seek_inode_cb(
 
     if (request->seek.what == 0) {
         /* SEEK_DATA: find first extent covering or after offset */
-        struct demofs_extent *extent;
+        struct demofs_extent  ext_buf;
+        struct demofs_extent *extent = &ext_buf;
+        int                   have;
 
-        rb_tree_query_floor(&inode->file.extents, offset, file_offset, extent);
+        have = demofs_ext_floor(thread, inode, offset, extent);
 
-        if (extent) {
+        if (have) {
             uint64_t extent_end = extent->file_offset + extent->length;
             if (extent_end <= offset) {
-                extent = rb_tree_next(&inode->file.extents, extent);
+                have = demofs_ext_next(thread, inode, extent->file_offset, extent);
             }
         } else {
-            rb_tree_first(&inode->file.extents, extent);
+            have = demofs_ext_ceil(thread, inode, 0, extent);
         }
 
-        while (extent) {
+        while (have) {
             uint64_t extent_end = extent->file_offset + extent->length;
 
             if (extent_end > offset) {
@@ -5720,7 +5847,7 @@ demofs_seek_inode_cb(
                 return;
             }
 
-            extent = rb_tree_next(&inode->file.extents, extent);
+            have = demofs_ext_next(thread, inode, extent->file_offset, extent);
         }
 
         request->seek.r_eof    = 1;
@@ -5729,25 +5856,27 @@ demofs_seek_inode_cb(
         return;
     } else {
         /* SEEK_HOLE: find first gap from offset forward */
-        struct demofs_extent *extent;
+        struct demofs_extent  ext_buf;
+        struct demofs_extent *extent = &ext_buf;
+        int                   have;
         uint64_t              current_pos = offset;
 
-        rb_tree_query_floor(&inode->file.extents, offset, file_offset, extent);
+        have = demofs_ext_floor(thread, inode, offset, extent);
 
-        if (extent) {
+        if (have) {
             uint64_t extent_end = extent->file_offset + extent->length;
             if (extent_end <= offset) {
-                extent = rb_tree_next(&inode->file.extents, extent);
+                have = demofs_ext_next(thread, inode, extent->file_offset, extent);
             }
         } else {
-            rb_tree_first(&inode->file.extents, extent);
+            have = demofs_ext_ceil(thread, inode, 0, extent);
         }
 
-        while (extent) {
+        while (have) {
             uint64_t extent_end = extent->file_offset + extent->length;
 
             if (extent_end <= current_pos) {
-                extent = rb_tree_next(&inode->file.extents, extent);
+                have = demofs_ext_next(thread, inode, extent->file_offset, extent);
                 continue;
             }
 
@@ -5759,7 +5888,7 @@ demofs_seek_inode_cb(
             }
 
             current_pos = extent_end;
-            extent      = rb_tree_next(&inode->file.extents, extent);
+            have        = demofs_ext_next(thread, inode, extent->file_offset, extent);
         }
 
         if (current_pos < inode->size) {

--- a/src/vfs/demofs/demofs.c
+++ b/src/vfs/demofs/demofs.c
@@ -575,6 +575,7 @@ struct demofs_intent_log {
     struct demofs_il_record  *push_tail;
     struct demofs_il_record  *push_cur;          /* record currently being pushed */
     int                       push_outstanding;  /* home writes in flight for push_cur */
+    int                       redo_inflight;     /* redo writes issued, not yet in FIFO */
 };
 
 struct demofs_shared {
@@ -588,6 +589,10 @@ struct demofs_shared {
     int                        num_active_threads;
     uint8_t                    root_fh[CHIMERA_VFS_FH_SIZE];
     uint32_t                   root_fhlen;
+    uint64_t                   root_inum;          /* for the clean-unmount superblock */
+    uint32_t                   root_gen;
+    int                        persistent;         /* config opt-in: detect+reload a clean FS instead of mkfs */
+    int                        mounted;            /* 1 = remounted existing FS (enables inode read-back) */
     uint64_t                   fsid;
     struct space_map          *space_map;
     struct demofs_intent_log   intent_log;
@@ -950,6 +955,15 @@ demofs_txn_unlock_all(struct demofs_txn *txn)
  * and 3, or later (via the grant doorbell, on this txn's worker) once a
  * conflicting holder releases.
  */
+static void demofs_inode_load(
+    struct demofs_thread       *thread,
+    struct demofs_txn          *txn,
+    uint64_t                    inum,
+    uint32_t                    gen,
+    enum demofs_inode_lock_mode mode,
+    demofs_inode_cb_t           cb,
+    void                       *private_data);
+
 static void
 demofs_inode_acquire(
     struct demofs_thread       *thread,
@@ -982,9 +996,24 @@ demofs_inode_acquire(
 
     rb_tree_query_exact(&shard->inodes, inum, inum, inode);
 
-    if (unlikely(!inode || inode->gen != gen)) {
+    if (unlikely(inode && inode->gen != gen)) {
+        /* Cached under a different generation: the handle is stale. */
         pthread_mutex_unlock(&shard->lock);
         cb(NULL, CHIMERA_VFS_ENOENT, private_data);
+        return;
+    }
+
+    if (unlikely(!inode)) {
+        /* Not resident.  On a freshly-formatted FS everything created is
+         * cached, so this is simply ENOENT.  On a remounted FS the inode may
+         * live on disk -- fault it in (validated against the requested gen). */
+        pthread_mutex_unlock(&shard->lock);
+        if (thread->shared->mounted &&
+            sm_inum_valid(thread->shared->space_map, inum)) {
+            demofs_inode_load(thread, txn, inum, gen, mode, cb, private_data);
+        } else {
+            cb(NULL, CHIMERA_VFS_ENOENT, private_data);
+        }
         return;
     }
 
@@ -1049,11 +1078,95 @@ demofs_inode_get_fh_async(
 } /* demofs_inode_get_fh_async */
 
 /*
+ * Synchronously fault an inode in from disk (mount-time path walk on a
+ * remounted FS).  Blocking pread is fine here: mount is rare and runs before
+ * concurrent load.  Returns a populated, cache-inserted inode or NULL.
+ */
+static struct demofs_block * demofs_block_claim(
+    struct demofs_thread *thread,
+    uint32_t              device_id,
+    uint64_t              device_offset,
+    int                   is_new);
+
+static struct demofs_inode *
+demofs_inode_load_sync(
+    struct demofs_thread *thread,
+    uint64_t              inum,
+    uint32_t              gen)
+{
+    struct demofs_shared      *shared = thread->shared;
+    struct demofs_inode_shard *shard  = demofs_inode_shard(shared, inum);
+    struct demofs_inode       *inode;
+    struct demofs_dinode      *di;
+    uint8_t                    buf[DEMOFS_BLOCK_SIZE];
+    uint32_t                   dev;
+    uint64_t                   off;
+    int                        fd;
+    ssize_t                    n;
+
+    if (!shared->mounted || !sm_inum_valid(shared->space_map, inum)) {
+        return NULL;
+    }
+
+    off = sm_inum_to_device_offset(shared->space_map, inum, &dev);
+    fd  = open(shared->device_paths[dev], O_RDONLY);
+    if (fd < 0) {
+        return NULL;
+    }
+    n = pread(fd, buf, sizeof(buf), off);
+    close(fd);
+    if (n != (ssize_t) sizeof(buf)) {
+        return NULL;
+    }
+
+    di = (struct demofs_dinode *) buf;
+    if (di->inum != inum || di->gen != gen || di->nlink == 0) {
+        return NULL;
+    }
+
+    pthread_mutex_lock(&shard->lock);
+    rb_tree_query_exact(&shard->inodes, inum, inum, inode);
+    if (!inode) {
+        inode              = calloc(1, sizeof(*inode));
+        inode->inum        = inum;
+        inode->refcnt      = 1;
+        inode->gen         = di->gen;
+        inode->mode        = di->mode;
+        inode->nlink       = di->nlink;
+        inode->uid         = di->uid;
+        inode->gid         = di->gid;
+        inode->rdev        = di->rdev;
+        inode->size        = di->size;
+        inode->space_used  = di->space_used;
+        inode->atime_sec   = di->atime_sec;
+        inode->atime_nsec  = di->atime_nsec;
+        inode->mtime_sec   = di->mtime_sec;
+        inode->mtime_nsec  = di->mtime_nsec;
+        inode->ctime_sec   = di->ctime_sec;
+        inode->ctime_nsec  = di->ctime_nsec;
+        inode->parent_inum = di->parent_inum;
+        inode->parent_gen  = di->parent_gen;
+        rb_tree_insert(&shard->inodes, inum, inode);
+    }
+    pthread_mutex_unlock(&shard->lock);
+
+    /* Seed the inode's home block into the block cache from the disk image. */
+    {
+        struct demofs_block *blk = demofs_block_claim(thread, dev, off, 0);
+
+        memcpy(blk->buffer, buf, DEMOFS_BLOCK_SIZE);
+        blk->state = DEMOFS_BLOCK_CLEAN;
+        __atomic_fetch_sub(&blk->pin_count, 1, __ATOMIC_RELAXED);
+    }
+    return inode;
+} /* demofs_inode_load_sync */
+
+/*
  * Synchronous read-lock acquire, used by the mount-time path walk which
  * runs before concurrent load.  Records the read lock in the txn so it is
- * released centrally at commit.  Asserts there is no conflicting writer
- * (cannot happen at mount); returns NULL if the inode isn't resident or
- * the generation is stale.
+ * released centrally at commit.  On a remounted FS a non-resident inode is
+ * faulted in from disk; returns NULL if it isn't on disk or the generation
+ * is stale.
  */
 static struct demofs_inode *
 demofs_inode_acquire_sync_read(
@@ -1075,9 +1188,17 @@ demofs_inode_acquire_sync_read(
     shard = demofs_inode_shard(thread->shared, inum);
     pthread_mutex_lock(&shard->lock);
     rb_tree_query_exact(&shard->inodes, inum, inum, inode);
-    if (!inode || inode->gen != gen) {
+    if (inode && inode->gen != gen) {
         pthread_mutex_unlock(&shard->lock);
         return NULL;
+    }
+    if (!inode) {
+        pthread_mutex_unlock(&shard->lock);
+        inode = demofs_inode_load_sync(thread, inum, gen);
+        if (!inode) {
+            return NULL;
+        }
+        pthread_mutex_lock(&shard->lock);
     }
     chimera_demofs_abort_if(inode->writer,
                             "mount path walk: inode %lu write-locked", inum);
@@ -3575,6 +3696,123 @@ demofs_inode_cache_insert(
 } /* demofs_inode_cache_insert */
 
 /*
+ * Fault an inode in from disk on a cache miss (remounted filesystem only).
+ * Reads the inode's home block, validates the on-disk dinode against the
+ * requested inum/gen, constructs + caches the inode, then re-drives
+ * demofs_inode_acquire (which now hits the cache and grants normally).  The
+ * inode's b+tree blocks load lazily via demofs_bt_block_get as they are
+ * traversed.
+ */
+struct demofs_inode_load_ctx {
+    struct demofs_thread *thread;
+    struct demofs_txn    *txn;
+    uint64_t              inum;
+    uint32_t              gen;
+    enum demofs_inode_lock_mode mode;
+    demofs_inode_cb_t     cb;
+    void                 *private_data;
+    struct evpl_iovec     iov;
+};
+
+static void
+demofs_inode_load_complete(
+    struct evpl *evpl,
+    int          status,
+    void        *private_data)
+{
+    struct demofs_inode_load_ctx *lc     = private_data;
+    struct demofs_thread         *thread = lc->thread;
+    struct demofs_shared         *shared = thread->shared;
+    struct demofs_dinode         *di     = (struct demofs_dinode *) lc->iov.data;
+    struct demofs_inode_shard    *shard  = demofs_inode_shard(shared, lc->inum);
+    struct demofs_inode          *inode;
+
+    if (status != 0 || di->inum != lc->inum || di->gen != lc->gen ||
+        di->nlink == 0) {
+        /* No such inode on disk (or stale generation). */
+        evpl_iovec_release(thread->evpl, &lc->iov);
+        lc->cb(NULL, CHIMERA_VFS_ENOENT, lc->private_data);
+        free(lc);
+        return;
+    }
+
+    pthread_mutex_lock(&shard->lock);
+    rb_tree_query_exact(&shard->inodes, lc->inum, inum, inode);
+    if (!inode) {
+        inode              = demofs_inode_struct_new(lc->inum);
+        inode->gen         = di->gen;
+        inode->mode        = di->mode;
+        inode->nlink       = di->nlink;
+        inode->uid         = di->uid;
+        inode->gid         = di->gid;
+        inode->rdev        = di->rdev;
+        inode->size        = di->size;
+        inode->space_used  = di->space_used;
+        inode->atime_sec   = di->atime_sec;
+        inode->atime_nsec  = di->atime_nsec;
+        inode->mtime_sec   = di->mtime_sec;
+        inode->mtime_nsec  = di->mtime_nsec;
+        inode->ctime_sec   = di->ctime_sec;
+        inode->ctime_nsec  = di->ctime_nsec;
+        inode->parent_inum = di->parent_inum;
+        inode->parent_gen  = di->parent_gen;
+        rb_tree_insert(&shard->inodes, inum, inode);
+    }
+    pthread_mutex_unlock(&shard->lock);
+
+    /* Seed the inode's home block (dinode + embedded b+tree root) into the
+     * block cache from the disk image, so the b+tree traversal and inode-block
+     * pin find the real contents instead of a zero-created block.  No writer
+     * can be modifying it yet -- the lock isn't granted until the re-acquire
+     * below. */
+    {
+        uint32_t             dev;
+        uint64_t             off = sm_inum_to_device_offset(shared->space_map,
+                                                            lc->inum, &dev);
+        struct demofs_block *blk = demofs_block_claim(thread, dev, off, 0);
+
+        memcpy(blk->buffer, lc->iov.data, DEMOFS_BLOCK_SIZE);
+        blk->state = DEMOFS_BLOCK_CLEAN;
+        __atomic_fetch_sub(&blk->pin_count, 1, __ATOMIC_RELAXED);
+    }
+
+    evpl_iovec_release(thread->evpl, &lc->iov);
+
+    /* Now resident: re-drive the acquire to grant the lock as usual. */
+    demofs_inode_acquire(thread, lc->txn, lc->inum, lc->gen, lc->mode,
+                         lc->cb, lc->private_data);
+    free(lc);
+} /* demofs_inode_load_complete */
+
+static void
+demofs_inode_load(
+    struct demofs_thread       *thread,
+    struct demofs_txn          *txn,
+    uint64_t                    inum,
+    uint32_t                    gen,
+    enum demofs_inode_lock_mode mode,
+    demofs_inode_cb_t           cb,
+    void                       *private_data)
+{
+    struct demofs_inode_load_ctx *lc = malloc(sizeof(*lc));
+    uint32_t                      dev;
+    uint64_t                      off;
+
+    off              = sm_inum_to_device_offset(thread->shared->space_map, inum, &dev);
+    lc->thread       = thread;
+    lc->txn          = txn;
+    lc->inum         = inum;
+    lc->gen          = gen;
+    lc->mode         = mode;
+    lc->cb           = cb;
+    lc->private_data = private_data;
+
+    evpl_iovec_alloc(thread->evpl, DEMOFS_BLOCK_SIZE, DEMOFS_BLOCK_SIZE, 1, 0, &lc->iov);
+    evpl_block_read(thread->evpl, thread->queue[dev], &lc->iov, 1, off,
+                    demofs_inode_load_complete, lc);
+} /* demofs_inode_load */
+
+/*
  * Allocate a new inode: grab a 4 KiB metadata block from the space map to
  * mint the inum, create the in-memory inode, publish it write-locked into
  * the cache, and record it in the transaction.
@@ -4038,6 +4276,8 @@ demofs_redo_write_cb(
     (void) evpl;
     chimera_demofs_abort_if(status, "redo record write failed: %d", status);
 
+    il->redo_inflight--;
+
     demofs_txn_unpin_blocks(ctx->entry.txn, DEMOFS_BLOCK_LOGGED);
     demofs_txn_unlock_all(ctx->entry.txn);
 
@@ -4136,6 +4376,7 @@ demofs_il_write_redo(
     }
 
     ch->cq_inflight++;
+    il->redo_inflight++;
 
     evpl_block_write(il->evpl, il->queue[SM_INTENT_LOG_DEVICE],
                      &rec->iov, 1, offset, 1 /* sync */,
@@ -4311,6 +4552,7 @@ demofs_intent_log_thread_init(
     il->push_tail        = NULL;
     il->push_cur         = NULL;
     il->push_outstanding = 0;
+    il->redo_inflight    = 0;
 
     /* Open block queues on this thread's evpl for redo writes + tail-push. */
     il->queue = calloc(shared->num_devices, sizeof(*il->queue));
@@ -4337,19 +4579,13 @@ demofs_intent_log_thread_shutdown(
      * close our block queues. */
     evpl_remove_doorbell(evpl, &il->wake_doorbell);
 
-    /* Drop any records still awaiting tail-push.  Their block images remain
-     * durable in the intent log, so a future mount recovers them by replay
-     * (the data isn't lost; it just hasn't reached its home location). */
-    if (il->push_cur) {
-        evpl_iovec_release(evpl, &il->push_cur->iov);
-        free(il->push_cur);
-        il->push_cur = NULL;
-    }
-    while (il->push_head) {
-        struct demofs_il_record *rec = il->push_head;
-        il->push_head = rec->next;
-        evpl_iovec_release(evpl, &rec->iov);
-        free(rec);
+    /* Clean unmount: drain everything to its final on-disk location so the
+     * filesystem is fully consistent at home offsets (no replay needed).
+     * Pump our evpl until all in-flight redo writes have landed in the push
+     * FIFO and the tail-pusher has flushed every record home. */
+    while (il->redo_inflight || il->push_cur || il->push_head) {
+        demofs_il_push_kick(il);
+        evpl_continue(evpl);
     }
 
     for (i = 0; i < shared->num_devices; i++) {
@@ -4489,26 +4725,74 @@ demofs_init(const char *cfgdata)
         }
     }
 
+    /* Opt-in persistence: when set, a clean superblock is detected at mount
+     * and the prior on-disk state is reloaded instead of reformatting.  Off by
+     * default so the common case (and the test suite) reformats every mount;
+     * the reload + on-disk read-back paths are exercised only under this flag. */
+    shared->persistent = json_is_true(json_object_get(cfg, "persistent"));
+
     json_decref(cfg);
 
 
     pthread_mutex_init(&shared->lock, NULL);
 
-    /* Generate a random 64-bit filesystem ID */
-    shared->fsid = chimera_rand64();
+    /* Decide mkfs vs mount: a valid superblock with the CLEAN flag means the
+     * previous instance unmounted cleanly, so we can reload its persisted
+     * free-space map and skip bootstrap (the root inode faults in from disk on
+     * first access).  Anything else (no/garbage superblock, or not clean ->
+     * a crash, which needs recovery we haven't built) is treated as mkfs. */
+    {
+        struct sm_superblock sb;
+        int                  mounting = 0;
 
-    device_sizes = calloc(shared->num_devices, sizeof(*device_sizes));
-    for (i = 0; i < shared->num_devices; i++) {
-        device_sizes[i] = shared->devices[i].size;
+        if (shared->persistent &&
+            space_map_read_superblock_path(device0_path, &sb) == 0 &&
+            (sb.flags & SM_SB_CLEAN)) {
+            shared->fsid = sb.fsid;
+            mounting     = 1;
+        } else {
+            shared->fsid = chimera_rand64();
+        }
+
+        device_sizes = calloc(shared->num_devices, sizeof(*device_sizes));
+        for (i = 0; i < shared->num_devices; i++) {
+            device_sizes[i] = shared->devices[i].size;
+        }
+        shared->space_map = space_map_create(device_sizes, shared->num_devices);
+        free(device_sizes);
+
+        if (mounting &&
+            space_map_load_paths(shared->space_map, shared->device_paths) != 0) {
+            chimera_demofs_error("space-map reload failed; treating as fresh");
+            mounting = 0;
+        }
+
+        shared->mounted = mounting;
+
+        if (mounting) {
+            uint8_t fsid_buf[CHIMERA_VFS_FSID_SIZE] = { 0 };
+
+            shared->root_inum = sb.root_inum;
+            shared->root_gen  = sb.root_gen;
+            memcpy(fsid_buf, &shared->fsid, sizeof(shared->fsid));
+            shared->root_fhlen = chimera_vfs_encode_fh_inum_mount(fsid_buf,
+                                                                  sb.root_inum,
+                                                                  sb.root_gen,
+                                                                  shared->root_fh);
+        }
+
+        /* Clear the CLEAN flag for this session: an unclean teardown then
+         * leaves it clear, so the next mount won't mistake a crash for a
+         * clean shutdown. */
+        rc = space_map_write_superblock_path(shared->space_map, device0_path,
+                                             shared->fsid, 0,
+                                             mounting ? sb.root_inum : 0,
+                                             mounting ? sb.root_gen : 0,
+                                             mounting ? sb.log_seq : 0);
+        chimera_demofs_abort_if(rc != 0,
+                                "Failed to write superblock to %s: %s",
+                                device0_path, strerror(errno));
     }
-    shared->space_map = space_map_create(device_sizes, shared->num_devices);
-    free(device_sizes);
-
-    rc = space_map_write_superblock_path(shared->space_map, device0_path,
-                                         shared->fsid);
-    chimera_demofs_abort_if(rc != 0,
-                            "Failed to write superblock to %s: %s",
-                            device0_path, strerror(errno));
     free(device0_path);
 
     /* Inode cache: sharded rb-trees keyed by inum.  Never evicts yet. */
@@ -4621,6 +4905,8 @@ demofs_bootstrap(struct demofs_thread *thread)
                                                               inode->gen,
                                                               shared->root_fh);
     }
+    shared->root_inum = inode->inum;
+    shared->root_gen  = inode->gen;
 
     pthread_mutex_unlock(&shared->lock);
 } /* demofs_bootstrap */
@@ -4664,12 +4950,25 @@ demofs_destroy(void *private_data)
 
     demofs_block_cache_destroy(shared);
 
-    /* Persist the free-space map now that all device I/O has quiesced (evpl
-     * released the devices), so a later mount can reload it instead of
-     * re-handing-out in-use space.  (A future mount only trusts this once the
-     * superblock is also marked clean -- wired in the mount-detection step.) */
-    if (space_map_persist_paths(shared->space_map, shared->device_paths) != 0) {
+    /* Clean unmount: the intent-log thread already drained every logged block
+     * to its home location, so persist the free-space map and stamp the
+     * superblock CLEAN (with the root + next log seq) so the next mount
+     * reloads instead of re-handing-out in-use space.  Done now that all
+     * device I/O has quiesced (evpl released the devices).  Only mark clean if
+     * a root actually exists (an untouched mkfs has nothing to preserve). */
+    if (!shared->persistent) {
+        /* mkfs-every-mount mode: nothing to preserve. */
+    } else if (space_map_persist_paths(shared->space_map, shared->device_paths) != 0) {
         chimera_demofs_error("space-map persist at unmount failed");
+    } else if (shared->root_fhlen != 0) {
+        int rc = space_map_write_superblock_path(shared->space_map,
+                                                 shared->device_paths[0],
+                                                 shared->fsid, SM_SB_CLEAN,
+                                                 shared->root_inum, shared->root_gen,
+                                                 shared->intent_log.log_seq);
+        if (rc != 0) {
+            chimera_demofs_error("clean-superblock write at unmount failed");
+        }
     }
 
     space_map_destroy(shared->space_map);

--- a/src/vfs/demofs/demofs.c
+++ b/src/vfs/demofs/demofs.c
@@ -75,55 +75,6 @@
 #define chimera_demofs_abort_if(cond, ...) \
         chimera_abort_if(cond, "demofs", __FILE__, __LINE__, __VA_ARGS__)
 
-struct demofs_request_private {
-    int                   opcode;
-    int                   status;
-    int                   pending;
-    int                   niov;
-    uint32_t              read_prefix;
-    uint32_t              read_suffix;
-    struct demofs_thread *thread;        // Thread for tracking pending I/O
-    struct demofs_txn    *txn;           // Transaction wrapping this op
-    /* Multi-inode op scratch (lookup_at parent/child, rename's 4-inode
-     * chain, etc.).  Per-op semantics documented at use sites. */
-    struct demofs_inode  *inode_stash[4];
-    /* Small integer scratch for ops that need to carry state across
-     * async callbacks (mount path walker uses it as a path byte offset). */
-    uint32_t              op_scratch;
-
-    /* readdir iteration cursor + the current dirent copied out of the
-     * b+tree (carried across the per-child inode fetch). */
-    uint64_t              rd_from_hash;
-    uint64_t              rd_hash;
-    uint64_t              rd_inum;
-    uint32_t              rd_gen;
-    int                   rd_namelen;
-    char                  rd_name[256];
-
-    /* Scratch buffer for handlers that parse a looked-up b+tree record
-     * (e.g. a dirent's inum/gen) in their async continuation.  Sized to hold
-     * the largest record (DEMOFS_DIRENT_REC_MAX == sizeof(dirent_rec) + 256). */
-    char                  rec_scratch[320];
-
-    struct evpl_iovec     iov[66];
-
-    // For RMW (read-modify-write) on partial block writes
-    int                   rmw_phase;     // 0 = no RMW, 1 = reading, 2 = writing
-    uint64_t              rmw_aligned_start; // Block-aligned start offset
-    uint64_t              rmw_aligned_length;// Block-aligned length
-    uint64_t              rmw_device_id; // Device for the new extent
-    uint64_t              rmw_device_offset; // Device offset for the new extent
-    uint32_t              rmw_prefix_len; // Bytes to preserve at start of first block
-    uint32_t              rmw_suffix_len; // Bytes to preserve at end of last block
-    struct evpl_iovec     rmw_prefix_iov; // IOV for prefix data (if read from existing extent)
-    struct evpl_iovec     rmw_suffix_iov; // IOV for suffix data (if read from existing extent)
-    int                   rmw_prefix_pending;// Pending read for prefix
-    int                   rmw_suffix_pending;// Pending read for suffix
-    uint32_t              rmw_prefix_valid;  // Valid bytes in prefix (extent may be truncated)
-    uint32_t              rmw_suffix_adjust; // Adjustment for suffix when block starts before extent
-    uint32_t              rmw_suffix_valid;  // Valid bytes in suffix (extent may be truncated)
-};
-
 struct demofs_extent {
     uint32_t              device_id;
     uint32_t              length;
@@ -132,6 +83,64 @@ struct demofs_extent {
     void                 *buffer;
     struct rb_node        node;
     struct demofs_extent *next;
+};
+
+struct demofs_request_private {
+    int                      opcode;
+    int                      status;
+    int                      pending;
+    int                      niov;
+    uint32_t                 read_prefix;
+    uint32_t                 read_suffix;
+    struct demofs_thread    *thread;     // Thread for tracking pending I/O
+    struct demofs_txn       *txn;        // Transaction wrapping this op
+    /* Multi-inode op scratch (lookup_at parent/child, rename's 4-inode
+     * chain, etc.).  Per-op semantics documented at use sites. */
+    struct demofs_inode     *inode_stash[4];
+    /* Small integer scratch for ops that need to carry state across
+     * async callbacks (mount path walker uses it as a path byte offset). */
+    uint32_t                 op_scratch;
+
+    /* readdir iteration cursor + the current dirent copied out of the
+     * b+tree (carried across the per-child inode fetch). */
+    uint64_t                 rd_from_hash;
+    uint64_t                 rd_hash;
+    uint64_t                 rd_inum;
+    uint32_t                 rd_gen;
+    int                      rd_namelen;
+    char                     rd_name[256];
+
+    /* Scratch buffer for handlers that parse a looked-up b+tree record
+     * (e.g. a dirent's inum/gen) in their async continuation.  Sized to hold
+     * the largest record (DEMOFS_DIRENT_REC_MAX == sizeof(dirent_rec) + 256). */
+    char                     rec_scratch[320];
+
+    /* Extent-walk iteration state, hoisted here so an async ext_next can
+     * suspend the loop and resume it.  loop_* are generic loop scalars. */
+    struct demofs_extent     ext_iter;
+    struct evpl_iovec_cursor rd_cursor;
+    uint64_t                 loop_off;
+    uint64_t                 loop_left;
+    uint64_t                 loop_pos;
+    int                      loop_have;
+
+    struct evpl_iovec        iov[66];
+
+    // For RMW (read-modify-write) on partial block writes
+    int                      rmw_phase;  // 0 = no RMW, 1 = reading, 2 = writing
+    uint64_t                 rmw_aligned_start; // Block-aligned start offset
+    uint64_t                 rmw_aligned_length;// Block-aligned length
+    uint64_t                 rmw_device_id; // Device for the new extent
+    uint64_t                 rmw_device_offset; // Device offset for the new extent
+    uint32_t                 rmw_prefix_len; // Bytes to preserve at start of first block
+    uint32_t                 rmw_suffix_len; // Bytes to preserve at end of last block
+    struct evpl_iovec        rmw_prefix_iov; // IOV for prefix data (if read from existing extent)
+    struct evpl_iovec        rmw_suffix_iov; // IOV for suffix data (if read from existing extent)
+    int                      rmw_prefix_pending;// Pending read for prefix
+    int                      rmw_suffix_pending;// Pending read for suffix
+    uint32_t                 rmw_prefix_valid; // Valid bytes in prefix (extent may be truncated)
+    uint32_t                 rmw_suffix_adjust; // Adjustment for suffix when block starts before extent
+    uint32_t                 rmw_suffix_valid; // Valid bytes in suffix (extent may be truncated)
 };
 
 struct demofs_device {
@@ -3326,6 +3335,84 @@ demofs_ext_next(
 {
     return demofs_ext_ceil(thread, inode, after_file_offset + 1, out);
 } /* demofs_ext_next */
+
+/*
+ * Async extent lookups (floor / ceil / next).  Each returns 1 if it completed
+ * synchronously, 0 if it suspended (cb fires later); on completion the result
+ * is in op->result and the record + found key are in rec_out / op->found_key.
+ * Use demofs_ext_from_op() in the callback to materialize the extent.
+ */
+static int
+demofs_ext_floor_async(
+    struct demofs_bt_op  *op,
+    struct demofs_thread *thread,
+    struct demofs_inode  *inode,
+    uint64_t              file_offset,
+    void                 *rec_out,
+    uint32_t              rec_cap,
+    demofs_bt_cb_t        cb,
+    void                 *private_data)
+{
+    struct demofs_bt_key key = demofs_extent_key(file_offset);
+    int                  r;
+
+    r = demofs_bt_lookup_async(op, thread, inode, DEMOFS_BT_OP_LOOKUP_LE,
+                               &key, &op->found_key, rec_out, rec_cap, cb, private_data);
+    return r;
+} /* demofs_ext_floor_async */
+
+static int
+demofs_ext_ceil_async(
+    struct demofs_bt_op  *op,
+    struct demofs_thread *thread,
+    struct demofs_inode  *inode,
+    uint64_t              file_offset,
+    void                 *rec_out,
+    uint32_t              rec_cap,
+    demofs_bt_cb_t        cb,
+    void                 *private_data)
+{
+    struct demofs_bt_key key = demofs_extent_key(file_offset);
+
+    return demofs_bt_lookup_async(op, thread, inode, DEMOFS_BT_OP_LOOKUP_GE,
+                                  &key, &op->found_key, rec_out, rec_cap, cb, private_data);
+} /* demofs_ext_ceil_async */
+
+static int
+demofs_ext_next_async(
+    struct demofs_bt_op  *op,
+    struct demofs_thread *thread,
+    struct demofs_inode  *inode,
+    uint64_t              after_file_offset,
+    void                 *rec_out,
+    uint32_t              rec_cap,
+    demofs_bt_cb_t        cb,
+    void                 *private_data)
+{
+    return demofs_ext_ceil_async(op, thread, inode, after_file_offset + 1,
+                                 rec_out, rec_cap, cb, private_data);
+} /* demofs_ext_next_async */
+
+/* Materialize the extent from a completed async lookup op (result + the
+ * record left in op->out + the key in op->found_key).  Returns 1 if a valid
+ * extent record was found, 0 otherwise. */
+static inline int
+demofs_ext_from_op(
+    struct demofs_bt_op  *op,
+    int                   result,
+    struct demofs_extent *out)
+{
+    struct demofs_extent_rec *rec = op->out;
+
+    if (result < 0 || op->found_key.type != DEMOFS_REC_EXTENT) {
+        return 0;
+    }
+    out->file_offset   = op->found_key.subkey;
+    out->length        = (uint32_t) rec->length;
+    out->device_id     = rec->device_id;
+    out->device_offset = rec->device_offset;
+    return 1;
+} /* demofs_ext_from_op */
 
 static inline struct demofs_extent *
 demofs_extent_alloc(struct demofs_thread *thread)
@@ -7025,6 +7112,132 @@ demofs_allocate(
                               demofs_allocate_inode_cb, request);
 } /* demofs_allocate */
 
+/*
+ * SEEK_DATA / SEEK_HOLE walk the extent map forward.  The walk is an async
+ * state machine: inode_stash[0] = inode, ext_iter = current extent,
+ * loop_have = whether ext_iter is valid, loop_pos = current scan position
+ * (SEEK_HOLE).  Each step advances via ext_next_async.
+ */
+static void demofs_seek_process(
+    struct chimera_vfs_request *request);
+
+static void
+demofs_seek_walk_cb(
+    struct demofs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+
+    p->loop_have = demofs_ext_from_op(op, result, &p->ext_iter);
+    demofs_bt_op_free(p->thread, op);
+    demofs_seek_process(request);
+} /* demofs_seek_walk_cb */
+
+static void
+demofs_seek_advance(struct chimera_vfs_request *request)
+{
+    struct demofs_request_private *p      = request->plugin_data;
+    struct demofs_thread          *thread = p->thread;
+    struct demofs_bt_op           *op     = demofs_bt_op_alloc(thread);
+
+    if (demofs_ext_next_async(op, thread, p->inode_stash[0], p->ext_iter.file_offset,
+                              p->rec_scratch, sizeof(p->rec_scratch),
+                              demofs_seek_walk_cb, request)) {
+        demofs_seek_walk_cb(op, op->result, request);
+    }
+} /* demofs_seek_advance */
+
+static void
+demofs_seek_process(struct chimera_vfs_request *request)
+{
+    struct demofs_request_private *p      = request->plugin_data;
+    struct demofs_thread          *thread = p->thread;
+    struct demofs_inode           *inode  = p->inode_stash[0];
+    uint64_t                       offset = request->seek.offset;
+    uint64_t                       extent_end;
+
+    if (request->seek.what == 0) {
+        /* SEEK_DATA: first extent whose data covers/follows offset. */
+        if (!p->loop_have) {
+            request->seek.r_eof    = 1;
+            request->seek.r_offset = 0;
+            demofs_op_ok(request, p->txn);
+            return;
+        }
+
+        extent_end = p->ext_iter.file_offset + p->ext_iter.length;
+        if (extent_end > offset) {
+            request->seek.r_offset = (p->ext_iter.file_offset > offset) ?
+                p->ext_iter.file_offset : offset;
+            request->seek.r_eof = 0;
+            demofs_op_ok(request, p->txn);
+            return;
+        }
+        demofs_seek_advance(request);
+    } else {
+        /* SEEK_HOLE: first gap from loop_pos forward. */
+        if (!p->loop_have) {
+            request->seek.r_offset = (p->loop_pos < inode->size) ?
+                p->loop_pos : inode->size;
+            request->seek.r_eof = 0;
+            demofs_op_ok(request, p->txn);
+            return;
+        }
+
+        extent_end = p->ext_iter.file_offset + p->ext_iter.length;
+        if (extent_end <= p->loop_pos) {
+            demofs_seek_advance(request);
+            return;
+        }
+        if (p->ext_iter.file_offset > p->loop_pos) {
+            request->seek.r_offset = p->loop_pos;
+            request->seek.r_eof    = 0;
+            demofs_op_ok(request, p->txn);
+            return;
+        }
+        p->loop_pos = extent_end;
+        demofs_seek_advance(request);
+    }
+
+    (void) thread;
+} /* demofs_seek_process */
+
+/* First-extent selection: floor(offset), advancing to the next extent if the
+ * floor extent ends at/before offset, or the first extent if none. */
+static void
+demofs_seek_first_cb(
+    struct demofs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct demofs_request_private *p       = request->plugin_data;
+    struct demofs_thread          *thread  = p->thread;
+    uint64_t                       offset  = request->seek.offset;
+    int                            have    = demofs_ext_from_op(op, result, &p->ext_iter);
+
+    demofs_bt_op_free(thread, op);
+
+    if (have && p->ext_iter.file_offset + p->ext_iter.length <= offset) {
+        demofs_seek_advance(request);
+        return;
+    }
+    if (!have) {
+        op = demofs_bt_op_alloc(thread);
+        if (demofs_ext_ceil_async(op, thread, p->inode_stash[0], 0, p->rec_scratch,
+                                  sizeof(p->rec_scratch), demofs_seek_walk_cb,
+                                  request)) {
+            demofs_seek_walk_cb(op, op->result, request);
+        }
+        return;
+    }
+
+    p->loop_have = 1;
+    demofs_seek_process(request);
+} /* demofs_seek_first_cb */
+
 static void
 demofs_seek_inode_cb(
     struct demofs_inode *inode,
@@ -7035,6 +7248,7 @@ demofs_seek_inode_cb(
     struct demofs_request_private *p       = request->plugin_data;
     struct demofs_thread          *thread  = p->thread;
     uint64_t                       offset  = request->seek.offset;
+    struct demofs_bt_op           *op;
 
     if (unlikely(status != CHIMERA_VFS_OK)) {
         demofs_op_fail(request, p->txn, status);
@@ -7048,86 +7262,14 @@ demofs_seek_inode_cb(
         return;
     }
 
-    if (request->seek.what == 0) {
-        /* SEEK_DATA: find first extent covering or after offset */
-        struct demofs_extent  ext_buf;
-        struct demofs_extent *extent = &ext_buf;
-        int                   have;
+    p->inode_stash[0] = inode;
+    p->loop_pos       = offset;
 
-        have = demofs_ext_floor(thread, inode, offset, extent);
-
-        if (have) {
-            uint64_t extent_end = extent->file_offset + extent->length;
-            if (extent_end <= offset) {
-                have = demofs_ext_next(thread, inode, extent->file_offset, extent);
-            }
-        } else {
-            have = demofs_ext_ceil(thread, inode, 0, extent);
-        }
-
-        while (have) {
-            uint64_t extent_end = extent->file_offset + extent->length;
-
-            if (extent_end > offset) {
-                request->seek.r_offset = (extent->file_offset > offset) ?
-                    extent->file_offset : offset;
-                request->seek.r_eof = 0;
-                demofs_op_ok(request, p->txn);
-                return;
-            }
-
-            have = demofs_ext_next(thread, inode, extent->file_offset, extent);
-        }
-
-        request->seek.r_eof    = 1;
-        request->seek.r_offset = 0;
-        demofs_op_ok(request, p->txn);
-        return;
-    } else {
-        /* SEEK_HOLE: find first gap from offset forward */
-        struct demofs_extent  ext_buf;
-        struct demofs_extent *extent = &ext_buf;
-        int                   have;
-        uint64_t              current_pos = offset;
-
-        have = demofs_ext_floor(thread, inode, offset, extent);
-
-        if (have) {
-            uint64_t extent_end = extent->file_offset + extent->length;
-            if (extent_end <= offset) {
-                have = demofs_ext_next(thread, inode, extent->file_offset, extent);
-            }
-        } else {
-            have = demofs_ext_ceil(thread, inode, 0, extent);
-        }
-
-        while (have) {
-            uint64_t extent_end = extent->file_offset + extent->length;
-
-            if (extent_end <= current_pos) {
-                have = demofs_ext_next(thread, inode, extent->file_offset, extent);
-                continue;
-            }
-
-            if (extent->file_offset > current_pos) {
-                request->seek.r_offset = current_pos;
-                request->seek.r_eof    = 0;
-                demofs_op_ok(request, p->txn);
-                return;
-            }
-
-            current_pos = extent_end;
-            have        = demofs_ext_next(thread, inode, extent->file_offset, extent);
-        }
-
-        if (current_pos < inode->size) {
-            request->seek.r_offset = current_pos;
-        } else {
-            request->seek.r_offset = inode->size;
-        }
-        request->seek.r_eof = 0;
-        demofs_op_ok(request, p->txn);
-        return;
+    op = demofs_bt_op_alloc(thread);
+    if (demofs_ext_floor_async(op, thread, inode, offset, p->rec_scratch,
+                               sizeof(p->rec_scratch), demofs_seek_first_cb,
+                               request)) {
+        demofs_seek_first_cb(op, op->result, request);
     }
 } /* demofs_seek_inode_cb */
 

--- a/src/vfs/demofs/demofs.c
+++ b/src/vfs/demofs/demofs.c
@@ -308,9 +308,11 @@ struct demofs_bt_op;
  * buffer is plain heap memory; block I/O copies it through a thread-local
  * evpl_iovec so buffers are never shared across evpl instances.  All fields
  * (hash linkage, pin_count, state, LRU membership) are protected by the
- * owning shard lock.  A buffer is an eviction candidate exactly when it is
- * CLEAN and pin_count == 0, in which case it sits on the shard LRU
- * (on_lru == 1); recycling reuses the least-recently-used such buffer.
+ * owning shard lock.  A buffer is a recycle candidate exactly when it is CLEAN
+ * and pin_count == 0, in which case it sits on the shard LRU (on_lru == 1);
+ * recycling reuses the least-recently-used such buffer.  Buffers are drawn
+ * from a pre-allocated fixed pool (shard->pool) -- a free, never-yet-keyed
+ * buffer starts CLEAN on the LRU, not in any bucket.
  */
 struct demofs_block {
     uint32_t             device_id;
@@ -333,12 +335,13 @@ struct demofs_block_shard {
     pthread_mutex_t       lock;
     struct demofs_block **buckets;     /* [DEMOFS_BLOCK_CACHE_BUCKETS_PER_SHARD] */
 
-    /* Fixed buffer pool with LRU eviction (all protected by lock).  The LRU
-     * holds only CLEAN, unpinned buffers (eviction candidates), ordered
-     * least-recently-used first.  Ops that need a buffer when none are free
-     * park on the waiter list and are resumed when one is returned. */
-    struct demofs_block  *lru_head, *lru_tail;  /* lru_head = next to evict */
-    struct demofs_bt_op  *wait_head, *wait_tail; /* ops awaiting a free buffer */
+    /* Pre-allocated fixed buffer pool (all protected by lock).  pool is an
+     * array of nblocks blocks whose buffers carve up the pool_mem arena; they
+     * are never individually freed.  The LRU holds only CLEAN, unpinned
+     * buffers (recycle candidates), ordered least-recently-used first. */
+    struct demofs_block  *pool;                 /* [nblocks] */
+    void                 *pool_mem;             /* nblocks * DEMOFS_BLOCK_SIZE */
+    struct demofs_block  *lru_head, *lru_tail;  /* lru_head = next to recycle */
     uint32_t              nblocks;              /* buffers owned by this shard */
 };
 
@@ -347,7 +350,18 @@ struct demofs_block_cache {
     struct demofs_block_shard shards[DEMOFS_BLOCK_CACHE_SHARDS];
 };
 
-#define DEMOFS_BLOCK_CACHE_DEFAULT_BLOCKS 8192  /* total; ~32 MiB of 4 KiB buffers */
+/*
+ * The block-cache pool is fixed and never blocks (see demofs_block_recycle):
+ * it must exceed the maximum pinnable set so an unpinned victim always exists.
+ * The only long-lived pins are a transaction's blocks, held from claim through
+ * LOGGED until the tail-pusher marks them CLEAN, and logging is backpressured
+ * to the intent-log size -- so the pinned set is bounded by the journal.  The
+ * default is 2x the journal (comfortable per-shard headroom over the variance),
+ * and a configured size is floored at 1.5x.
+ */
+#define DEMOFS_INTENT_LOG_BLOCKS          (SM_INTENT_LOG_SIZE / SM_BLOCK_SIZE)
+#define DEMOFS_BLOCK_CACHE_DEFAULT_BLOCKS (2 * DEMOFS_INTENT_LOG_BLOCKS)
+#define DEMOFS_BLOCK_CACHE_MIN_BLOCKS     (DEMOFS_INTENT_LOG_BLOCKS + DEMOFS_INTENT_LOG_BLOCKS / 2)
 
 /*
  * On-disk inode block layout (4 KiB):
@@ -1331,49 +1345,51 @@ demofs_block_lru_unlink(
 } /* demofs_block_lru_unlink */
 
 /*
- * Recycle the least-recently-used clean buffer for reuse at a new key, or
- * allocate a fresh one.  Caller holds the shard lock.  Returns a buffer with
- * pin_count 0 and not on the LRU, removed from its old bucket; the caller sets
- * the new key/state and links it into the new bucket.  Grows the pool past the
- * cap only when every buffer is pinned (no LRU victim) -- a bounded transient
- * until block_claim learns to wait (top-down rewrite).
+ * Recycle the least-recently-used CLEAN, unpinned buffer for reuse at a new
+ * key.  Caller holds the shard lock.  Returns a buffer with pin_count 0,
+ * unlinked from the LRU and removed from its old bucket (a no-op for a free,
+ * never-keyed buffer); the caller sets the new key/state and links it into the
+ * new bucket.
+ *
+ * The pool is fixed and never grows or blocks: the cache is provisioned larger
+ * than the maximum pinnable set (bounded by the intent log -- see the cache
+ * sizing constants), so by the pigeonhole principle the LRU is never empty.
+ * An empty LRU means every buffer in this shard is pinned -- a provisioning
+ * violation or a leaked pin (and, since the descent that called us holds pins
+ * in this shard, the precise self-deadlock condition).  Abort loudly rather
+ * than block and hang.
  */
 static struct demofs_block *
-demofs_block_recycle_or_alloc(
-    struct demofs_block_cache *cache,
-    struct demofs_block_shard *shard)
+demofs_block_recycle(struct demofs_block_shard *shard)
 {
-    struct demofs_block *blk;
+    struct demofs_block *blk = shard->lru_head;
+    struct demofs_block *cur, *prev;
+    uint32_t             ob;
 
-    if (shard->nblocks >= cache->shard_cap && shard->lru_head) {
-        uint32_t             ob;
-        struct demofs_block *cur, *prev;
+    chimera_demofs_abort_if(!blk,
+                            "block cache shard exhausted: every buffer pinned "
+                            "(raise block_cache_blocks above the intent-log size, "
+                            "or a pin was leaked)");
 
-        blk = shard->lru_head;
-        demofs_block_lru_unlink(shard, blk);
+    demofs_block_lru_unlink(shard, blk);
 
-        /* Unhook from its current bucket. */
-        ob   = demofs_block_bucket(blk->device_id, blk->device_offset);
-        prev = NULL;
-        for (cur = shard->buckets[ob]; cur; prev = cur, cur = cur->hash_next) {
-            if (cur == blk) {
-                if (prev) {
-                    prev->hash_next = cur->hash_next;
-                } else {
-                    shard->buckets[ob] = cur->hash_next;
-                }
-                break;
+    /* Unhook from its current bucket (no-op for a never-keyed free buffer:
+     * it is in no chain, so the pointer search simply finds nothing). */
+    ob   = demofs_block_bucket(blk->device_id, blk->device_offset);
+    prev = NULL;
+    for (cur = shard->buckets[ob]; cur; prev = cur, cur = cur->hash_next) {
+        if (cur == blk) {
+            if (prev) {
+                prev->hash_next = cur->hash_next;
+            } else {
+                shard->buckets[ob] = cur->hash_next;
             }
+            break;
         }
-        blk->hash_next = NULL;
-        return blk;
     }
-
-    blk         = calloc(1, sizeof(*blk));
-    blk->buffer = calloc(1, DEMOFS_BLOCK_SIZE);
-    shard->nblocks++;
+    blk->hash_next = NULL;
     return blk;
-} /* demofs_block_recycle_or_alloc */
+} /* demofs_block_recycle */
 
 static void
 demofs_block_unpin(
@@ -1388,7 +1404,6 @@ demofs_block_unpin(
     blk->state = new_state;
     if (--blk->pin_count == 0 && blk->state == DEMOFS_BLOCK_CLEAN && !blk->on_lru) {
         demofs_block_lru_push_tail(shard, blk);
-        /* A3b: wake a buffer waiter here. */
     }
     pthread_mutex_unlock(&shard->lock);
 } /* demofs_block_unpin */
@@ -1405,7 +1420,6 @@ demofs_block_release(
     pthread_mutex_lock(&shard->lock);
     if (--blk->pin_count == 0 && blk->state == DEMOFS_BLOCK_CLEAN && !blk->on_lru) {
         demofs_block_lru_push_tail(shard, blk);
-        /* A3b: wake a buffer waiter here. */
     }
     pthread_mutex_unlock(&shard->lock);
 } /* demofs_block_release */
@@ -1417,6 +1431,14 @@ demofs_block_cache_create(struct demofs_shared *shared)
     uint32_t                   total = shared->block_cache_blocks ?
         shared->block_cache_blocks : DEMOFS_BLOCK_CACHE_DEFAULT_BLOCKS;
     int                        i;
+    uint32_t                   j;
+
+    /* The pool never grows or blocks, so it must clear the maximum pinnable
+     * set; floor an under-sized configuration rather than risk the recycle
+     * abort under load. */
+    if (total < DEMOFS_BLOCK_CACHE_MIN_BLOCKS) {
+        total = DEMOFS_BLOCK_CACHE_MIN_BLOCKS;
+    }
 
     cache->shard_cap = total / DEMOFS_BLOCK_CACHE_SHARDS;
     if (cache->shard_cap == 0) {
@@ -1424,9 +1446,24 @@ demofs_block_cache_create(struct demofs_shared *shared)
     }
 
     for (i = 0; i < DEMOFS_BLOCK_CACHE_SHARDS; i++) {
-        pthread_mutex_init(&cache->shards[i].lock, NULL);
-        cache->shards[i].buckets = calloc(DEMOFS_BLOCK_CACHE_BUCKETS_PER_SHARD,
-                                          sizeof(struct demofs_block *));
+        struct demofs_block_shard *shard = &cache->shards[i];
+
+        pthread_mutex_init(&shard->lock, NULL);
+        shard->buckets = calloc(DEMOFS_BLOCK_CACHE_BUCKETS_PER_SHARD,
+                                sizeof(struct demofs_block *));
+        shard->pool     = calloc(cache->shard_cap, sizeof(struct demofs_block));
+        shard->pool_mem = calloc(cache->shard_cap, DEMOFS_BLOCK_SIZE);
+
+        /* Pre-populate: every buffer starts free (unkeyed, in no bucket) and
+         * CLEAN on the LRU.  Carve the buffers out of the shared arena. */
+        for (j = 0; j < cache->shard_cap; j++) {
+            struct demofs_block *blk = &shard->pool[j];
+
+            blk->buffer = (char *) shard->pool_mem + (size_t) j * DEMOFS_BLOCK_SIZE;
+            blk->state  = DEMOFS_BLOCK_CLEAN;
+            demofs_block_lru_push_tail(shard, blk);
+            shard->nblocks++;
+        }
     }
     shared->block_cache = cache;
 } /* demofs_block_cache_create */
@@ -1436,7 +1473,6 @@ demofs_block_cache_destroy(struct demofs_shared *shared)
 {
     struct demofs_block_cache *cache = shared->block_cache;
     int                        i;
-    uint32_t                   b;
 
     if (!cache) {
         return;
@@ -1445,16 +1481,9 @@ demofs_block_cache_destroy(struct demofs_shared *shared)
     for (i = 0; i < DEMOFS_BLOCK_CACHE_SHARDS; i++) {
         struct demofs_block_shard *shard = &cache->shards[i];
 
-        for (b = 0; b < DEMOFS_BLOCK_CACHE_BUCKETS_PER_SHARD; b++) {
-            struct demofs_block *blk = shard->buckets[b];
-
-            while (blk) {
-                struct demofs_block *next = blk->hash_next;
-                free(blk->buffer);
-                free(blk);
-                blk = next;
-            }
-        }
+        /* Blocks are slices of the fixed pool; free the arena, not each one. */
+        free(shard->pool_mem);
+        free(shard->pool);
         free(shard->buckets);
         pthread_mutex_destroy(&shard->lock);
     }
@@ -1511,7 +1540,7 @@ demofs_block_claim(
 
     blk = demofs_block_lookup_locked(shard, bucket, device_id, device_offset);
     if (!blk) {
-        blk                = demofs_block_recycle_or_alloc(cache, shard);
+        blk                = demofs_block_recycle(shard);
         blk->device_id     = device_id;
         blk->device_offset = device_offset;
         blk->state         = DEMOFS_BLOCK_CLEAN;
@@ -1782,7 +1811,7 @@ demofs_bt_block_get(
     }
 
     if (!blk) {
-        blk                    = demofs_block_recycle_or_alloc(cache, shard);
+        blk                    = demofs_block_recycle(shard);
         blk->device_id         = device_id;
         blk->device_offset     = device_offset;
         blk->state             = DEMOFS_BLOCK_LOADING;
@@ -4442,7 +4471,6 @@ demofs_il_clean_pushed_record(
             blk->state = DEMOFS_BLOCK_CLEAN;
             if (!blk->on_lru) {
                 demofs_block_lru_push_tail(shard, blk);
-                /* A3b: wake a buffer waiter here. */
             }
         }
         pthread_mutex_unlock(&shard->lock);

--- a/src/vfs/demofs/demofs.c
+++ b/src/vfs/demofs/demofs.c
@@ -90,6 +90,16 @@ struct demofs_request_private {
     /* Small integer scratch for ops that need to carry state across
      * async callbacks (mount path walker uses it as a path byte offset). */
     uint32_t              op_scratch;
+
+    /* readdir iteration cursor + the current dirent copied out of the
+     * b+tree (carried across the per-child inode fetch). */
+    uint64_t              rd_from_hash;
+    uint64_t              rd_hash;
+    uint64_t              rd_inum;
+    uint32_t              rd_gen;
+    int                   rd_namelen;
+    char                  rd_name[256];
+
     struct evpl_iovec     iov[66];
 
     // For RMW (read-modify-write) on partial block writes
@@ -175,12 +185,17 @@ typedef void (*demofs_inode_cb_t)(
     int                  status,
     void                *private_data);
 
-/* Defined in the block-cache section below. */
+/* Defined in the block-cache / b+tree sections below. */
 static void demofs_txn_pin_inode_block(
     struct demofs_thread *thread,
     struct demofs_txn    *txn,
     struct demofs_inode  *inode,
     int                   is_new);
+static inline void demofs_bt_node_init(
+    void    *buf,
+    uint32_t base,
+    uint32_t capacity,
+    uint16_t level);
 
 /*
  * A transaction that cannot immediately acquire an inode in the desired
@@ -229,22 +244,20 @@ struct demofs_inode {
     struct demofs_inode_waiter *wait_tail;
 
     /* This inode's 4 KiB metadata home block in the block cache; pinned
-     * while the inode is dirty in a transaction.  NULL until first claimed. */
+     * while the inode is dirty in a transaction.  NULL until first claimed.
+     * Directory entries, extents and the symlink target all live as keyed
+     * records in this inode's b+tree (rooted in the block at offset 256). */
     struct demofs_block        *block;
 
-    union {
-        struct {
-            struct rb_tree dirents;
-            uint64_t       parent_inum;
-            uint32_t       parent_gen;
-        } dir;
-        struct {
-            struct rb_tree extents;
-        } file;
-        struct {
-            struct demofs_symlink_target *target;
-        } symlink;
-    };
+    /* Directory only: parent for ".." resolution (also persisted in dinode). */
+    uint64_t                    parent_inum;
+    uint32_t                    parent_gen;
+
+    /* TODO(phase 1c): extents move into the b+tree; until then regular
+     * files keep their extents in this in-memory rb-tree. */
+    struct {
+        struct rb_tree extents;
+    } file;
 };
 
 struct demofs_inode_shard {
@@ -303,10 +316,19 @@ struct demofs_block_cache {
 };
 
 /*
- * On-disk inode layout, written at the front of the inode's 4 KiB block.
- * Scalar attributes only for now; directory entries and file extents stay
- * in memory until the b+tree block work lands.
+ * On-disk inode block layout (4 KiB):
+ *   [0, DEMOFS_INODE_AREA)   struct demofs_dinode (scalar attributes)
+ *   [DEMOFS_INODE_AREA, end) the inode's b+tree root node (embedded)
+ *
+ * Directory entries, file extents and the symlink target all live as keyed
+ * records in the inode's single b+tree; the root node is embedded in the
+ * inode block, and deeper nodes occupy their own 4 KiB blocks.
  */
+#define DEMOFS_INODE_AREA   256
+#define DEMOFS_BT_ROOT_BASE DEMOFS_INODE_AREA
+#define DEMOFS_BT_ROOT_CAP  (DEMOFS_BLOCK_SIZE - DEMOFS_INODE_AREA)   /* 3840 */
+#define DEMOFS_BT_NODE_CAP  DEMOFS_BLOCK_SIZE                          /* 4096 */
+
 struct demofs_dinode {
     uint64_t inum;
     uint32_t gen;
@@ -327,13 +349,75 @@ struct demofs_dinode {
     uint32_t parent_gen;
 };
 
+/* ------------------------------------------------------------------ */
+/* Per-inode b+tree (on-disk, slotted nodes)                           */
+/* ------------------------------------------------------------------ */
+
+/* Record types share one tree per inode; each occupies a key range. */
+enum demofs_bt_rectype {
+    DEMOFS_REC_DIRENT  = 1,
+    DEMOFS_REC_EXTENT  = 2,
+    DEMOFS_REC_SYMLINK = 3,
+};
+
+/* B+tree key: ordered by (type, subkey).  subkey is the name hash for
+ * dirents, the file offset for extents, 0 for the single symlink record. */
+struct demofs_bt_key {
+    uint8_t  type;
+    uint8_t  pad[7];
+    uint64_t subkey;
+};
+
+/*
+ * Slotted node header at the base of every node (embedded root or full
+ * block).  level 0 == leaf.  Interior nodes hold a fixed array of
+ * {key, child_bptr}; leaves hold a slot array of {key, off, len} plus a
+ * record heap growing down from free_end.
+ */
+struct demofs_bt_node_hdr {
+    uint16_t level;
+    uint16_t nitems;
+    uint32_t capacity;     /* usable node bytes (DEMOFS_BT_ROOT_CAP or _NODE_CAP) */
+    uint32_t free_end;     /* leaf heap top (records occupy [free_end, capacity)) */
+    uint32_t reserved;
+    uint64_t next_leaf;    /* leaf only: bptr of next leaf in key order (0 = none) */
+};
+
+struct demofs_bt_islot {          /* interior slot, 24 B */
+    struct demofs_bt_key key;
+    uint64_t             child;   /* bptr (sm disk:ag:index encoding) */
+};
+
+struct demofs_bt_lslot {          /* leaf slot, 24 B */
+    struct demofs_bt_key key;
+    uint32_t             off;     /* record offset from node base */
+    uint32_t             len;     /* record length */
+};
+
+/* Leaf record payloads (stored in the leaf heap). */
+struct demofs_dirent_rec {
+    uint64_t inum;
+    uint32_t gen;
+    uint16_t name_len;
+    char     name[];
+} __attribute__((packed));
+
+struct demofs_extent_rec {
+    uint64_t length;
+    uint32_t device_id;
+    uint32_t pad;
+    uint64_t device_offset;
+} __attribute__((packed));
+
+#define DEMOFS_DIRENT_REC_MAX (sizeof(struct demofs_dirent_rec) + 256)
+
 /*
  * Intent-log redo record, written into the reserved intent-log region.
  * A record is a header followed by num_blocks (block-header, 4 KiB content)
  * pairs, padded to a 4 KiB multiple.  Full-block redo: the record carries
  * the entire post-image of every dirty block in the transaction.
  */
-#define DEMOFS_REDO_MAGIC 0x4F44455246534944ULL    /* "DISFREDO" */
+#define DEMOFS_REDO_MAGIC     0x4F44455246534944ULL /* "DISFREDO" */
 
 struct demofs_redo_header {
     uint64_t magic;
@@ -1028,6 +1112,13 @@ demofs_txn_pin_inode_block(
 
     inode->block = demofs_block_claim(thread, device_id, device_offset, is_new);
     demofs_txn_add_block(txn, inode->block);
+
+    if (is_new) {
+        /* Initialize the embedded b+tree root (empty leaf) in the new
+         * inode block. */
+        demofs_bt_node_init(inode->block->buffer, DEMOFS_BT_ROOT_BASE,
+                            DEMOFS_BT_ROOT_CAP, 0);
+    }
 } /* demofs_txn_pin_inode_block */
 
 /* Serialize an inode's durable attributes into the front of its block. */
@@ -1058,8 +1149,8 @@ demofs_inode_flush(struct demofs_inode *inode)
     di->mtime_nsec = inode->mtime_nsec;
     di->ctime_nsec = inode->ctime_nsec;
     if (S_ISDIR(inode->mode)) {
-        di->parent_inum = inode->dir.parent_inum;
-        di->parent_gen  = inode->dir.parent_gen;
+        di->parent_inum = inode->parent_inum;
+        di->parent_gen  = inode->parent_gen;
     }
 
     inode->block->state = DEMOFS_BLOCK_DIRTY;
@@ -1117,6 +1208,961 @@ demofs_txn_unpin_blocks(
         tb = n;
     }
 } /* demofs_txn_unpin_blocks */
+
+/* ------------------------------------------------------------------ */
+/* Per-inode b+tree                                                    */
+/* ------------------------------------------------------------------ */
+
+/* Lock-free RCU lookup of a resident block; NULL if not cached. */
+static struct demofs_block *
+demofs_block_lookup_rcu(
+    struct demofs_thread *thread,
+    uint32_t              device_id,
+    uint64_t              device_offset)
+{
+    struct demofs_block_cache *cache  = thread->shared->block_cache;
+    uint64_t                   hash   = demofs_block_hash(device_id, device_offset);
+    uint32_t                   sidx   = hash & DEMOFS_BLOCK_CACHE_SHARD_MASK;
+    uint32_t                   bucket = (hash >> 8) & DEMOFS_BLOCK_CACHE_BUCKET_MASK;
+    struct demofs_block_shard *shard  = &cache->shards[sidx];
+    struct demofs_block       *blk;
+
+    for (blk = rcu_dereference(shard->buckets[bucket]); blk;
+         blk = rcu_dereference(blk->hash_next)) {
+        if (blk->device_id == device_id && blk->device_offset == device_offset) {
+            return blk;
+        }
+    }
+    return NULL;
+} /* demofs_block_lookup_rcu */
+
+static inline int
+demofs_bt_key_cmp(
+    const struct demofs_bt_key *a,
+    const struct demofs_bt_key *b)
+{
+    if (a->type != b->type) {
+        return a->type < b->type ? -1 : 1;
+    }
+    if (a->subkey != b->subkey) {
+        return a->subkey < b->subkey ? -1 : 1;
+    }
+    return 0;
+} /* demofs_bt_key_cmp */
+
+static inline struct demofs_bt_node_hdr *
+demofs_bt_hdr(
+    void    *buf,
+    uint32_t base)
+{
+    return (struct demofs_bt_node_hdr *) ((char *) buf + base);
+} /* demofs_bt_hdr */
+
+static inline struct demofs_bt_islot *
+demofs_bt_islots(
+    void    *buf,
+    uint32_t base)
+{
+    return (struct demofs_bt_islot *) ((char *) buf + base + sizeof(struct demofs_bt_node_hdr));
+} /* demofs_bt_islots */
+
+static inline struct demofs_bt_lslot *
+demofs_bt_lslots(
+    void    *buf,
+    uint32_t base)
+{
+    return (struct demofs_bt_lslot *) ((char *) buf + base + sizeof(struct demofs_bt_node_hdr));
+} /* demofs_bt_lslots */
+
+static inline void
+demofs_bt_node_init(
+    void    *buf,
+    uint32_t base,
+    uint32_t capacity,
+    uint16_t level)
+{
+    struct demofs_bt_node_hdr *h = demofs_bt_hdr(buf, base);
+
+    h->level     = level;
+    h->nitems    = 0;
+    h->capacity  = capacity;
+    h->free_end  = capacity;
+    h->reserved  = 0;
+    h->next_leaf = 0;
+} /* demofs_bt_node_init */
+
+/* Free bytes available in a leaf for one more (slot + record). */
+static inline uint32_t
+demofs_bt_leaf_free(
+    void    *buf,
+    uint32_t base)
+{
+    struct demofs_bt_node_hdr *h          = demofs_bt_hdr(buf, base);
+    uint32_t                   free_start = sizeof(*h) + h->nitems * sizeof(struct demofs_bt_lslot);
+
+    return h->free_end - free_start;
+} /* demofs_bt_leaf_free */
+
+static inline uint32_t
+demofs_bt_interior_free(
+    void    *buf,
+    uint32_t base)
+{
+    struct demofs_bt_node_hdr *h          = demofs_bt_hdr(buf, base);
+    uint32_t                   free_start = sizeof(*h) + h->nitems * sizeof(struct demofs_bt_islot);
+
+    return h->capacity - free_start;
+} /* demofs_bt_interior_free */
+
+/*
+ * Binary search a leaf for key.  Returns the index of the first slot whose
+ * key is >= the search key; sets *exact if that slot's key matches.
+ */
+static int
+demofs_bt_leaf_search(
+    void                       *buf,
+    uint32_t                    base,
+    const struct demofs_bt_key *key,
+    int                        *exact)
+{
+    struct demofs_bt_lslot *sl = demofs_bt_lslots(buf, base);
+    int                     n  = demofs_bt_hdr(buf, base)->nitems;
+    int                     lo = 0, hi = n;
+
+    *exact = 0;
+    while (lo < hi) {
+        int mid = (lo + hi) >> 1;
+        int c   = demofs_bt_key_cmp(&sl[mid].key, key);
+
+        if (c < 0) {
+            lo = mid + 1;
+        } else if (c > 0) {
+            hi = mid;
+        } else {
+            *exact = 1;
+            return mid;
+        }
+    }
+    return lo;
+} /* demofs_bt_leaf_search */
+
+/* Index of the child subtree that may contain key (largest key <= search). */
+static int
+demofs_bt_interior_search(
+    void                       *buf,
+    uint32_t                    base,
+    const struct demofs_bt_key *key)
+{
+    struct demofs_bt_islot *sl = demofs_bt_islots(buf, base);
+    int                     n  = demofs_bt_hdr(buf, base)->nitems;
+    int                     lo = 0, hi = n, ans = 0;
+
+    while (lo < hi) {
+        int mid = (lo + hi) >> 1;
+
+        if (demofs_bt_key_cmp(&sl[mid].key, key) <= 0) {
+            ans = mid;
+            lo  = mid + 1;
+        } else {
+            hi = mid;
+        }
+    }
+    return ans;
+} /* demofs_bt_interior_search */
+
+/* Append a leaf record at the end (caller guarantees sorted order + room). */
+static void
+demofs_bt_leaf_append(
+    void                       *buf,
+    uint32_t                    base,
+    const struct demofs_bt_key *key,
+    const void                 *rec,
+    uint32_t                    reclen)
+{
+    struct demofs_bt_node_hdr *h  = demofs_bt_hdr(buf, base);
+    struct demofs_bt_lslot    *sl = demofs_bt_lslots(buf, base);
+
+    h->free_end -= reclen;
+    memcpy((char *) buf + base + h->free_end, rec, reclen);
+    sl[h->nitems].key = *key;
+    sl[h->nitems].off = h->free_end;
+    sl[h->nitems].len = reclen;
+    h->nitems++;
+} /* demofs_bt_leaf_append */
+
+/* Allocate a fresh b+tree node block; returns the (pinned, txn-attached)
+ * block and its bptr.  Buffer is zeroed and initialized as an empty node. */
+static struct demofs_block *
+demofs_bt_alloc_node(
+    struct demofs_thread *thread,
+    struct demofs_txn    *txn,
+    uint16_t              level,
+    uint64_t             *r_bptr)
+{
+    struct demofs_shared *shared = thread->shared;
+    struct demofs_block  *blk;
+    uint32_t              device_id;
+    uint64_t              device_offset;
+    int                   rc;
+
+    rc = space_map_alloc(shared->space_map, &thread->space_cache,
+                         DEMOFS_BLOCK_SIZE, &device_id, &device_offset);
+    chimera_demofs_abort_if(rc != 0, "b+tree node allocation failed (ENOSPC)");
+
+    blk = demofs_block_claim(thread, device_id, device_offset, 1);
+    demofs_txn_add_block(txn, blk);
+
+    demofs_bt_node_init(blk->buffer, 0, DEMOFS_BT_NODE_CAP, level);
+
+    *r_bptr = sm_inum_from_device_offset(shared->space_map, device_id, device_offset);
+    return blk;
+} /* demofs_bt_alloc_node */
+
+/* Resolve a child bptr to its block buffer for writing (claim+pin+attach). */
+static void *
+demofs_bt_node_for_write(
+    struct demofs_thread *thread,
+    struct demofs_txn    *txn,
+    uint64_t              bptr)
+{
+    uint32_t             device_id;
+    uint64_t             device_offset;
+    struct demofs_block *blk;
+
+    device_offset = sm_inum_to_device_offset(thread->shared->space_map, bptr, &device_id);
+    blk           = demofs_block_claim(thread, device_id, device_offset, 0);
+    demofs_txn_add_block(txn, blk);
+    return blk->buffer;
+} /* demofs_bt_node_for_write */
+
+/*
+ * Split a full leaf (current node at buf/base/cap) while inserting
+ * (nkey,nrec).  The lower half stays in place; the upper half plus the new
+ * right sibling's bptr are returned via *sep_key / *sep_bptr.
+ */
+static void
+demofs_bt_leaf_split(
+    struct demofs_thread       *thread,
+    struct demofs_txn          *txn,
+    void                       *buf,
+    uint32_t                    base,
+    uint32_t                    cap,
+    int                         insert_idx,
+    const struct demofs_bt_key *nkey,
+    const void                 *nrec,
+    uint32_t                    nreclen,
+    struct demofs_bt_key       *sep_key,
+    uint64_t                   *sep_bptr)
+{
+    struct demofs_bt_node_hdr *h     = demofs_bt_hdr(buf, base);
+    struct demofs_bt_lslot    *sl    = demofs_bt_lslots(buf, base);
+    int                        n     = h->nitems;
+    int                        total = n + 1;
+
+    struct {
+        struct demofs_bt_key key;
+        uint32_t             len;
+        uint32_t             scratch_off;
+    } *items;
+    char                      *scratch;
+    uint32_t                   sp = 0, total_bytes = 0, half, acc = 0;
+    int                        i, oi, split_i;
+    struct demofs_block       *right;
+    void                      *rbuf;
+    uint64_t                   old_next;
+
+    items   = malloc(total * sizeof(*items));
+    scratch = malloc(cap + nreclen);
+
+    for (i = 0, oi = 0; i < total; i++) {
+        if (i == insert_idx) {
+            memcpy(scratch + sp, nrec, nreclen);
+            items[i].key = *nkey;
+            items[i].len = nreclen;
+        } else {
+            memcpy(scratch + sp, (char *) buf + base + sl[oi].off, sl[oi].len);
+            items[i].key = sl[oi].key;
+            items[i].len = sl[oi].len;
+            oi++;
+        }
+        items[i].scratch_off = sp;
+        sp                  += items[i].len;
+        total_bytes         += items[i].len;
+    }
+
+    half    = total_bytes / 2;
+    split_i = 1;
+    for (i = 0; i < total; i++) {
+        if (acc >= half && i > 0) {
+            split_i = i;
+            break;
+        }
+        acc    += items[i].len;
+        split_i = i + 1;
+    }
+    if (split_i < 1) {
+        split_i = 1;
+    }
+    if (split_i > total - 1) {
+        split_i = total - 1;
+    }
+
+    old_next = h->next_leaf;
+
+    right = demofs_bt_alloc_node(thread, txn, 0, sep_bptr);
+    rbuf  = right->buffer;
+
+    /* Rebuild the left node in place from scratch (no aliasing). */
+    demofs_bt_node_init(buf, base, cap, 0);
+    for (i = 0; i < split_i; i++) {
+        demofs_bt_leaf_append(buf, base, &items[i].key,
+                              scratch + items[i].scratch_off, items[i].len);
+    }
+    for (i = split_i; i < total; i++) {
+        demofs_bt_leaf_append(rbuf, 0, &items[i].key,
+                              scratch + items[i].scratch_off, items[i].len);
+    }
+
+    demofs_bt_hdr(rbuf, 0)->next_leaf = old_next;
+    h->next_leaf                      = *sep_bptr;
+
+    *sep_key = items[split_i].key;
+
+    chimera_demofs_abort_if(demofs_bt_leaf_free(buf, base) > cap ||
+                            demofs_bt_leaf_free(rbuf, 0) > DEMOFS_BT_NODE_CAP,
+                            "b+tree leaf split overflow");
+
+    free(items);
+    free(scratch);
+} /* demofs_bt_leaf_split */
+
+/* Insert (key,rec) into a leaf, splitting if needed.  Returns 1 on split. */
+static int
+demofs_bt_leaf_insert(
+    struct demofs_thread       *thread,
+    struct demofs_txn          *txn,
+    void                       *buf,
+    uint32_t                    base,
+    uint32_t                    cap,
+    const struct demofs_bt_key *key,
+    const void                 *rec,
+    uint32_t                    reclen,
+    struct demofs_bt_key       *sep_key,
+    uint64_t                   *sep_bptr)
+{
+    struct demofs_bt_node_hdr *h = demofs_bt_hdr(buf, base);
+    struct demofs_bt_lslot    *sl;
+    int                        idx, exact, j;
+
+    idx = demofs_bt_leaf_search(buf, base, key, &exact);
+    chimera_demofs_abort_if(exact, "b+tree duplicate key insert");
+
+    if (demofs_bt_leaf_free(buf, base) >= sizeof(struct demofs_bt_lslot) + reclen) {
+        sl = demofs_bt_lslots(buf, base);
+        for (j = h->nitems; j > idx; j--) {
+            sl[j] = sl[j - 1];
+        }
+        h->free_end -= reclen;
+        memcpy((char *) buf + base + h->free_end, rec, reclen);
+        sl[idx].key = *key;
+        sl[idx].off = h->free_end;
+        sl[idx].len = reclen;
+        h->nitems++;
+        return 0;
+    }
+
+    demofs_bt_leaf_split(thread, txn, buf, base, cap, idx, key, rec, reclen,
+                         sep_key, sep_bptr);
+    return 1;
+} /* demofs_bt_leaf_insert */
+
+/* Insert (key,child) into an interior node, splitting if needed. */
+static int
+demofs_bt_interior_insert(
+    struct demofs_thread       *thread,
+    struct demofs_txn          *txn,
+    void                       *buf,
+    uint32_t                    base,
+    uint32_t                    cap,
+    const struct demofs_bt_key *key,
+    uint64_t                    child,
+    struct demofs_bt_key       *sep_key,
+    uint64_t                   *sep_bptr)
+{
+    struct demofs_bt_node_hdr *h  = demofs_bt_hdr(buf, base);
+    struct demofs_bt_islot    *sl = demofs_bt_islots(buf, base);
+    int                        n  = h->nitems;
+    int                        idx, j, split_i;
+    struct demofs_block       *right;
+    struct demofs_bt_islot    *rsl;
+    struct demofs_bt_node_hdr *rh;
+
+    /* Find sorted insert position (keys are unique separators). */
+    idx = 0;
+    while (idx < n && demofs_bt_key_cmp(&sl[idx].key, key) < 0) {
+        idx++;
+    }
+
+    if (demofs_bt_interior_free(buf, base) >= sizeof(struct demofs_bt_islot)) {
+        for (j = n; j > idx; j--) {
+            sl[j] = sl[j - 1];
+        }
+        sl[idx].key   = *key;
+        sl[idx].child = child;
+        h->nitems++;
+        return 0;
+    }
+
+    /* Split: build the full set of n+1 slots in order, distribute halves. */
+    {
+        struct demofs_bt_islot all[ (DEMOFS_BT_NODE_CAP / sizeof(struct demofs_bt_islot)) + 2 ];
+        int                    total = n + 1;
+        int                    p = 0, ins = 0;
+
+        for (j = 0; j < n; j++) {
+            if (!ins && demofs_bt_key_cmp(key, &sl[j].key) < 0) {
+                all[p].key = *key; all[p].child = child; p++; ins = 1;
+            }
+            all[p++] = sl[j];
+        }
+        if (!ins) {
+            all[p].key = *key; all[p].child = child; p++;
+        }
+
+        split_i = total / 2;
+
+        right = demofs_bt_alloc_node(thread, txn, h->level, sep_bptr);
+        rsl   = demofs_bt_islots(right->buffer, 0);
+        rh    = demofs_bt_hdr(right->buffer, 0);
+
+        h->nitems = split_i;
+        for (j = 0; j < split_i; j++) {
+            sl[j] = all[j];
+        }
+        for (j = split_i; j < total; j++) {
+            rsl[j - split_i] = all[j];
+        }
+        rh->nitems = total - split_i;
+
+        *sep_key = rsl[0].key;
+        return 1;
+    }
+} /* demofs_bt_interior_insert */
+
+static int
+demofs_bt_insert_rec(
+    struct demofs_thread       *thread,
+    struct demofs_txn          *txn,
+    void                       *buf,
+    uint32_t                    base,
+    uint32_t                    cap,
+    const struct demofs_bt_key *key,
+    const void                 *rec,
+    uint32_t                    reclen,
+    struct demofs_bt_key       *sep_key,
+    uint64_t                   *sep_bptr)
+{
+    struct demofs_bt_node_hdr *h = demofs_bt_hdr(buf, base);
+    struct demofs_bt_islot    *sl;
+    int                        ci, csplit;
+    uint64_t                   child_bptr;
+    void                      *child_buf;
+    struct demofs_bt_key       csep;
+    uint64_t                   cbptr;
+
+    if (h->level == 0) {
+        return demofs_bt_leaf_insert(thread, txn, buf, base, cap, key, rec, reclen,
+                                     sep_key, sep_bptr);
+    }
+
+    ci         = demofs_bt_interior_search(buf, base, key);
+    sl         = demofs_bt_islots(buf, base);
+    child_bptr = sl[ci].child;
+    child_buf  = demofs_bt_node_for_write(thread, txn, child_bptr);
+
+    csplit = demofs_bt_insert_rec(thread, txn, child_buf, 0, DEMOFS_BT_NODE_CAP,
+                                  key, rec, reclen, &csep, &cbptr);
+    if (!csplit) {
+        return 0;
+    }
+
+    return demofs_bt_interior_insert(thread, txn, buf, base, cap, &csep, cbptr,
+                                     sep_key, sep_bptr);
+} /* demofs_bt_insert_rec */
+
+/*
+ * Insert a record into an inode's b+tree.  The inode must be write-locked
+ * and its root block pinned (true for any write op that acquired it).
+ */
+static void
+demofs_bt_insert(
+    struct demofs_thread       *thread,
+    struct demofs_txn          *txn,
+    struct demofs_inode        *inode,
+    const struct demofs_bt_key *key,
+    const void                 *rec,
+    uint32_t                    reclen)
+{
+    void                *root = inode->block->buffer;
+    struct demofs_bt_key sep;
+    uint64_t             sep_bptr;
+    int                  split;
+
+    split = demofs_bt_insert_rec(thread, txn, root, DEMOFS_BT_ROOT_BASE,
+                                 DEMOFS_BT_ROOT_CAP, key, rec, reclen, &sep, &sep_bptr);
+    if (!split) {
+        return;
+    }
+
+    /* Root overflowed: grow the tree.  Move the (post-split lower-half)
+     * root contents into a new left child, then re-form the root as an
+     * interior node pointing at the new left child and the split's right
+     * sibling. */
+    {
+        struct demofs_bt_node_hdr *rh        = demofs_bt_hdr(root, DEMOFS_BT_ROOT_BASE);
+        uint16_t                   old_level = rh->level;
+        uint64_t                   left_bptr;
+        struct demofs_block       *left;
+        struct demofs_bt_key       left_min;
+        struct demofs_bt_islot    *isl;
+
+        left = demofs_bt_alloc_node(thread, txn, old_level, &left_bptr);
+
+        /* Copy the entire embedded root node into the new left block. */
+        memcpy((char *) left->buffer, (char *) root + DEMOFS_BT_ROOT_BASE, DEMOFS_BT_ROOT_CAP);
+        demofs_bt_hdr(left->buffer, 0)->capacity = DEMOFS_BT_NODE_CAP;
+
+        if (old_level == 0) {
+            left_min = demofs_bt_lslots(left->buffer, 0)[0].key;
+        } else {
+            left_min = demofs_bt_islots(left->buffer, 0)[0].key;
+        }
+
+        demofs_bt_node_init(root, DEMOFS_BT_ROOT_BASE, DEMOFS_BT_ROOT_CAP,
+                            old_level + 1);
+        rh           = demofs_bt_hdr(root, DEMOFS_BT_ROOT_BASE);
+        rh->nitems   = 2;
+        isl          = demofs_bt_islots(root, DEMOFS_BT_ROOT_BASE);
+        isl[0].key   = left_min;
+        isl[0].child = left_bptr;
+        isl[1].key   = sep;
+        isl[1].child = sep_bptr;
+    }
+} /* demofs_bt_insert */
+
+/*
+ * Remove a key from an inode's b+tree (lazy: no merge/rebalance).  Returns
+ * 1 if removed, 0 if not found.  The descent dirties the path blocks.
+ */
+static int
+demofs_bt_remove(
+    struct demofs_thread       *thread,
+    struct demofs_txn          *txn,
+    struct demofs_inode        *inode,
+    const struct demofs_bt_key *key)
+{
+    void    *buf  = inode->block->buffer;
+    uint32_t base = DEMOFS_BT_ROOT_BASE;
+
+    for (;; ) {
+        struct demofs_bt_node_hdr *h = demofs_bt_hdr(buf, base);
+
+        if (h->level == 0) {
+            struct demofs_bt_lslot *sl = demofs_bt_lslots(buf, base);
+            int                     idx, exact, j;
+
+            idx = demofs_bt_leaf_search(buf, base, key, &exact);
+            if (!exact) {
+                return 0;
+            }
+            for (j = idx; j < h->nitems - 1; j++) {
+                sl[j] = sl[j + 1];
+            }
+            h->nitems--;
+            return 1;
+        } else {
+            int ci = demofs_bt_interior_search(buf, base, key);
+
+            buf = demofs_bt_node_for_write(thread, txn,
+                                           demofs_bt_islots(buf, base)[ci].child);
+            base = 0;
+        }
+    }
+} /* demofs_bt_remove */
+
+/*
+ * Copy out the record for an exact key match.  Read path: traverses via the
+ * RCU block cache, one critical section per node.  Returns the record
+ * length (copied into out, up to out_cap) or -1 if not found.  Phase 1
+ * aborts if a needed node is not resident.
+ */
+static int
+demofs_bt_lookup_exact(
+    struct demofs_thread       *thread,
+    struct demofs_inode        *inode,
+    const struct demofs_bt_key *key,
+    void                       *out,
+    uint32_t                    out_cap)
+{
+    uint32_t device_id;
+    uint64_t device_offset;
+    uint64_t bptr = 0;
+    void    *buf;
+    uint32_t base;
+    int      result   = -1;
+    int      use_root = 1;
+
+    device_offset = sm_inum_to_device_offset(thread->shared->space_map, inode->inum, &device_id);
+
+    for (;; ) {
+        struct demofs_block *blk;
+
+        urcu_memb_read_lock();
+        if (use_root) {
+            blk = demofs_block_lookup_rcu(thread, device_id, device_offset);
+        } else {
+            uint32_t cdev;
+            uint64_t coff = sm_inum_to_device_offset(thread->shared->space_map, bptr, &cdev);
+            blk = demofs_block_lookup_rcu(thread, cdev, coff);
+        }
+        chimera_demofs_abort_if(!blk, "b+tree read: node not resident (inum %lu)", inode->inum);
+
+        buf  = blk->buffer;
+        base = use_root ? DEMOFS_BT_ROOT_BASE : 0;
+
+        struct demofs_bt_node_hdr *h = demofs_bt_hdr(buf, base);
+        if (h->level == 0) {
+            int exact;
+            int idx = demofs_bt_leaf_search(buf, base, key, &exact);
+            if (exact) {
+                struct demofs_bt_lslot *sl  = demofs_bt_lslots(buf, base);
+                uint32_t                len = sl[idx].len;
+                if (len > out_cap) {
+                    len = out_cap;
+                }
+                memcpy(out, (char *) buf + base + sl[idx].off, len);
+                result = (int) sl[idx].len;
+            }
+            urcu_memb_read_unlock();
+            return result;
+        } else {
+            int ci = demofs_bt_interior_search(buf, base, key);
+            bptr = demofs_bt_islots(buf, base)[ci].child;
+            urcu_memb_read_unlock();
+            use_root = 0;
+        }
+    }
+} /* demofs_bt_lookup_exact */
+
+/* Descend (floor-style) to the leaf that would hold key.  Returns the leaf
+ * block (RCU lookup; aborts if not resident) without entering a critical
+ * section; the caller must re-enter RCU around its own access.  Used as a
+ * helper only where the whole traversal is inside one logic block. */
+
+/*
+ * Smallest key >= search key (ceil).  Copies the found key into *r_key and
+ * the record into out; returns record length, or -1 if no such key.
+ */
+static int
+demofs_bt_lookup_ge(
+    struct demofs_thread       *thread,
+    struct demofs_inode        *inode,
+    const struct demofs_bt_key *key,
+    struct demofs_bt_key       *r_key,
+    void                       *out,
+    uint32_t                    out_cap)
+{
+    uint32_t device_id;
+    uint64_t device_offset;
+    uint64_t bptr      = 0;
+    int      use_root  = 1;
+    uint64_t next_leaf = 0;
+
+    device_offset = sm_inum_to_device_offset(thread->shared->space_map, inode->inum, &device_id);
+
+    for (;; ) {
+        struct demofs_block       *blk;
+        struct demofs_bt_node_hdr *h;
+        void                      *buf;
+        uint32_t                   base;
+
+        urcu_memb_read_lock();
+        if (use_root) {
+            blk = demofs_block_lookup_rcu(thread, device_id, device_offset);
+        } else {
+            uint32_t cdev;
+            uint64_t coff = sm_inum_to_device_offset(thread->shared->space_map, bptr, &cdev);
+            blk = demofs_block_lookup_rcu(thread, cdev, coff);
+        }
+        chimera_demofs_abort_if(!blk, "b+tree read: node not resident (inum %lu)", inode->inum);
+
+        buf  = blk->buffer;
+        base = use_root ? DEMOFS_BT_ROOT_BASE : 0;
+        h    = demofs_bt_hdr(buf, base);
+
+        if (h->level == 0) {
+            int exact;
+            int idx = demofs_bt_leaf_search(buf, base, key, &exact);
+
+            if (idx < h->nitems) {
+                struct demofs_bt_lslot *sl  = demofs_bt_lslots(buf, base);
+                uint32_t                len = sl[idx].len;
+
+                *r_key = sl[idx].key;
+                if (len > out_cap) {
+                    len = out_cap;
+                }
+                memcpy(out, (char *) buf + base + sl[idx].off, len);
+                len = sl[idx].len;
+                urcu_memb_read_unlock();
+                return (int) len;
+            }
+            next_leaf = h->next_leaf;
+            urcu_memb_read_unlock();
+
+            if (next_leaf == 0) {
+                return -1;     /* no key >= search */
+            }
+            /* Successor is the first slot of the next leaf. */
+            bptr     = next_leaf;
+            use_root = 0;
+            {
+                uint32_t cdev;
+                uint64_t coff = sm_inum_to_device_offset(thread->shared->space_map, bptr, &cdev);
+
+                urcu_memb_read_lock();
+                blk = demofs_block_lookup_rcu(thread, cdev, coff);
+                chimera_demofs_abort_if(!blk, "b+tree read: next leaf not resident");
+                h = demofs_bt_hdr(blk->buffer, 0);
+                if (h->nitems == 0) {
+                    urcu_memb_read_unlock();
+                    return -1;
+                }
+                struct demofs_bt_lslot *sl  = demofs_bt_lslots(blk->buffer, 0);
+                uint32_t                len = sl[0].len;
+                *r_key = sl[0].key;
+                if (len > out_cap) {
+                    len = out_cap;
+                }
+                memcpy(out, (char *) blk->buffer + sl[0].off, len);
+                len = sl[0].len;
+                urcu_memb_read_unlock();
+                return (int) len;
+            }
+        } else {
+            int ci = demofs_bt_interior_search(buf, base, key);
+            bptr = demofs_bt_islots(buf, base)[ci].child;
+            urcu_memb_read_unlock();
+            use_root = 0;
+        }
+    }
+} /* demofs_bt_lookup_ge */
+
+/*
+ * Largest key <= search key (floor).  Copies the found key into *r_key and
+ * the record into out; returns record length, or -1 if no such key.
+ */
+static int
+demofs_bt_lookup_le(
+    struct demofs_thread       *thread,
+    struct demofs_inode        *inode,
+    const struct demofs_bt_key *key,
+    struct demofs_bt_key       *r_key,
+    void                       *out,
+    uint32_t                    out_cap)
+{
+    uint32_t device_id;
+    uint64_t device_offset;
+    uint64_t bptr     = 0;
+    int      use_root = 1;
+
+    device_offset = sm_inum_to_device_offset(thread->shared->space_map, inode->inum, &device_id);
+
+    for (;; ) {
+        struct demofs_block       *blk;
+        struct demofs_bt_node_hdr *h;
+        void                      *buf;
+        uint32_t                   base;
+
+        urcu_memb_read_lock();
+        if (use_root) {
+            blk = demofs_block_lookup_rcu(thread, device_id, device_offset);
+        } else {
+            uint32_t cdev;
+            uint64_t coff = sm_inum_to_device_offset(thread->shared->space_map, bptr, &cdev);
+            blk = demofs_block_lookup_rcu(thread, cdev, coff);
+        }
+        chimera_demofs_abort_if(!blk, "b+tree read: node not resident (inum %lu)", inode->inum);
+
+        buf  = blk->buffer;
+        base = use_root ? DEMOFS_BT_ROOT_BASE : 0;
+        h    = demofs_bt_hdr(buf, base);
+
+        if (h->level == 0) {
+            int exact;
+            int idx = demofs_bt_leaf_search(buf, base, key, &exact);
+            int fidx;
+
+            if (h->nitems == 0) {
+                urcu_memb_read_unlock();
+                return -1;
+            }
+            fidx = exact ? idx : idx - 1;
+            if (fidx < 0) {
+                urcu_memb_read_unlock();
+                return -1;     /* no key <= search in this (leftmost) leaf */
+            }
+            {
+                struct demofs_bt_lslot *sl  = demofs_bt_lslots(buf, base);
+                uint32_t                len = sl[fidx].len;
+
+                *r_key = sl[fidx].key;
+                if (len > out_cap) {
+                    len = out_cap;
+                }
+                memcpy(out, (char *) buf + base + sl[fidx].off, len);
+                len = sl[fidx].len;
+                urcu_memb_read_unlock();
+                return (int) len;
+            }
+        } else {
+            int ci = demofs_bt_interior_search(buf, base, key);
+            bptr = demofs_bt_islots(buf, base)[ci].child;
+            urcu_memb_read_unlock();
+            use_root = 0;
+        }
+    }
+} /* demofs_bt_lookup_le */
+
+/* ------------------------------------------------------------------ */
+/* Directory / symlink records over the inode b+tree                   */
+/* ------------------------------------------------------------------ */
+
+static inline struct demofs_bt_key
+demofs_dirent_key(uint64_t hash)
+{
+    struct demofs_bt_key k = { .type = DEMOFS_REC_DIRENT, .subkey = hash };
+
+    return k;
+} /* demofs_dirent_key */
+
+static void
+demofs_dir_insert(
+    struct demofs_thread *thread,
+    struct demofs_txn    *txn,
+    struct demofs_inode  *dir,
+    uint64_t              hash,
+    const char           *name,
+    int                   namelen,
+    uint64_t              child_inum,
+    uint32_t              child_gen)
+{
+    char                      buf[DEMOFS_DIRENT_REC_MAX];
+    struct demofs_dirent_rec *r   = (struct demofs_dirent_rec *) buf;
+    struct demofs_bt_key      key = demofs_dirent_key(hash);
+
+    r->inum     = child_inum;
+    r->gen      = child_gen;
+    r->name_len = (uint16_t) namelen;
+    memcpy(r->name, name, namelen);
+
+    demofs_bt_insert(thread, txn, dir, &key,
+                     buf, sizeof(*r) + namelen);
+} /* demofs_dir_insert */
+
+/* Returns 0 and fills the inum/gen out params if found, -1 otherwise. */
+static int
+demofs_dir_lookup(
+    struct demofs_thread *thread,
+    struct demofs_inode  *dir,
+    uint64_t              hash,
+    uint64_t             *r_inum,
+    uint32_t             *r_gen)
+{
+    char                      buf[DEMOFS_DIRENT_REC_MAX];
+    struct demofs_dirent_rec *r   = (struct demofs_dirent_rec *) buf;
+    struct demofs_bt_key      key = demofs_dirent_key(hash);
+    int                       len;
+
+    len = demofs_bt_lookup_exact(thread, dir, &key, buf, sizeof(buf));
+    if (len < 0) {
+        return -1;
+    }
+    *r_inum = r->inum;
+    *r_gen  = r->gen;
+    return 0;
+} /* demofs_dir_lookup */
+
+static int
+demofs_dir_remove(
+    struct demofs_thread *thread,
+    struct demofs_txn    *txn,
+    struct demofs_inode  *dir,
+    uint64_t              hash)
+{
+    struct demofs_bt_key key = demofs_dirent_key(hash);
+
+    return demofs_bt_remove(thread, txn, dir, &key);
+} /* demofs_dir_remove */
+
+/*
+ * Find the next directory entry whose hash is >= from_hash.  Returns 0 and
+ * fills the out params (the entry's hash, child inum/gen, name) or -1 when
+ * there are no more dirents.
+ */
+static int
+demofs_dir_next(
+    struct demofs_thread *thread,
+    struct demofs_inode  *dir,
+    uint64_t              from_hash,
+    uint64_t             *r_hash,
+    uint64_t             *r_inum,
+    uint32_t             *r_gen,
+    char                 *name,
+    int                  *r_namelen)
+{
+    char                      buf[DEMOFS_DIRENT_REC_MAX];
+    struct demofs_dirent_rec *r   = (struct demofs_dirent_rec *) buf;
+    struct demofs_bt_key      key = demofs_dirent_key(from_hash);
+    struct demofs_bt_key      found;
+    int                       len;
+
+    len = demofs_bt_lookup_ge(thread, dir, &key, &found, buf, sizeof(buf));
+    if (len < 0 || found.type != DEMOFS_REC_DIRENT) {
+        return -1;
+    }
+    *r_hash    = found.subkey;
+    *r_inum    = r->inum;
+    *r_gen     = r->gen;
+    *r_namelen = r->name_len;
+    memcpy(name, r->name, r->name_len);
+    return 0;
+} /* demofs_dir_next */
+
+static void
+demofs_symlink_set(
+    struct demofs_thread *thread,
+    struct demofs_txn    *txn,
+    struct demofs_inode  *inode,
+    const void           *target,
+    int                   len)
+{
+    struct demofs_bt_key key = { .type = DEMOFS_REC_SYMLINK, .subkey = 0 };
+
+    demofs_bt_insert(thread, txn, inode, &key, target, len);
+} /* demofs_symlink_set */
+
+static int
+demofs_symlink_get(
+    struct demofs_thread *thread,
+    struct demofs_inode  *inode,
+    void                 *out,
+    uint32_t              cap)
+{
+    struct demofs_bt_key key = { .type = DEMOFS_REC_SYMLINK, .subkey = 0 };
+
+    return demofs_bt_lookup_exact(thread, inode, &key, out, cap);
+} /* demofs_symlink_get */
 
 static inline struct demofs_extent *
 demofs_extent_alloc(struct demofs_thread *thread)
@@ -1275,13 +2321,9 @@ demofs_inode_free(
     if (S_ISREG(inode->mode)) {
         rb_tree_destroy(&inode->file.extents, demofs_extent_release, thread);
         rb_tree_init(&inode->file.extents);
-    } else if (S_ISDIR(inode->mode)) {
-        rb_tree_destroy(&inode->dir.dirents, demofs_dirent_release, thread);
-        rb_tree_init(&inode->dir.dirents);
-    } else if (S_ISLNK(inode->mode)) {
-        demofs_symlink_target_free(thread, inode->symlink.target);
-        inode->symlink.target = NULL;
     }
+    /* Directory / symlink contents live in the inode's b+tree blocks, which
+     * are leaked for now (no space reclaim yet). */
 
     inode->gen++;
     inode->refcnt = 0;
@@ -2017,13 +3059,23 @@ demofs_bootstrap(struct demofs_thread *thread)
     inode->ctime_sec  = now.tv_sec;
     inode->ctime_nsec = now.tv_nsec;
 
-    rb_tree_init(&inode->dir.dirents);
-
     /* Root directory's parent is itself for ".." lookup */
-    inode->dir.parent_inum = inode->inum;
-    inode->dir.parent_gen  = inode->gen;
+    inode->parent_inum = inode->inum;
+    inode->parent_gen  = inode->gen;
 
     demofs_inode_cache_insert(shared, inode);
+
+    /* Create the root inode's block in the cache: an embedded empty b+tree
+     * root plus the dinode.  Bootstrap is not a transaction, so leave the
+     * block resident but unpinned/detached; the first write op that touches
+     * root will re-claim and log it. */
+    inode->block = demofs_block_claim(thread, device_id, device_offset, 1);
+    demofs_bt_node_init(inode->block->buffer, DEMOFS_BT_ROOT_BASE,
+                        DEMOFS_BT_ROOT_CAP, 0);
+    demofs_inode_flush(inode);
+    inode->block->state = DEMOFS_BLOCK_CLEAN;
+    __atomic_fetch_sub(&inode->block->pin_count, 1, __ATOMIC_RELAXED);
+    inode->block = NULL;
 
     /* Create 16-byte fsid buffer for root FH encoding (8-byte fsid + 8 bytes padding) */
     {
@@ -2048,11 +3100,10 @@ demofs_inode_cache_release(
     (void) private_data;
 
     /* Process is exiting; thread slab allocators are already gone, so the
-     * dirent/extent release callbacks no-op with a NULL thread.  We still
-     * own and must free the inode struct itself (heap-allocated). */
-    if (S_ISDIR(inode->mode)) {
-        rb_tree_destroy(&inode->dir.dirents, demofs_dirent_release, NULL);
-    } else if (S_ISREG(inode->mode)) {
+     * extent release callback no-ops with a NULL thread.  Directory/symlink
+     * b+tree blocks are freed via the block cache.  We still own and must
+     * free the inode struct itself (heap-allocated). */
+    if (S_ISREG(inode->mode)) {
         rb_tree_destroy(&inode->file.extents, demofs_extent_release, NULL);
     }
 
@@ -2518,13 +3569,12 @@ demofs_lookup_path(
 {
     struct demofs_shared *shared = thread->shared;
     struct demofs_inode  *parent, *inode;
-    struct demofs_dirent *dirent;
     const char           *name;
     const char           *pathc = path;
     const char           *slash;
     int                   namelen;
-    uint64_t              hash, inum;
-    uint32_t              gen;
+    uint64_t              hash, inum, child_inum;
+    uint32_t              gen, child_gen;
 
     demofs_fh_to_inum(&inum, &gen, shared->root_fh, shared->root_fhlen);
     inode = demofs_inode_acquire_sync_read(thread, txn, inum, gen);
@@ -2557,15 +3607,13 @@ demofs_lookup_path(
 
         hash = chimera_vfs_hash(name, namelen);
 
-        rb_tree_query_exact(&inode->dir.dirents, hash, hash, dirent);
-
-        if (!dirent) {
+        if (demofs_dir_lookup(thread, inode, hash, &child_inum, &child_gen) != 0) {
             return NULL;
         }
 
         parent = inode;
 
-        inode = demofs_inode_acquire_sync_read(thread, txn, dirent->inum, dirent->gen);
+        inode = demofs_inode_acquire_sync_read(thread, txn, child_inum, child_gen);
 
         /* Done with the parent now; release its slot so deep walks reuse it. */
         demofs_txn_unlock_inode(txn, parent);
@@ -2663,10 +3711,11 @@ demofs_lookup_at_parent_cb(
     struct chimera_vfs_request    *request = private_data;
     struct demofs_request_private *p       = request->plugin_data;
     struct demofs_thread          *thread  = p->thread;
-    struct demofs_dirent          *dirent;
     const char                    *name    = request->lookup_at.component;
     uint32_t                       namelen = request->lookup_at.component_len;
     uint64_t                       hash    = request->lookup_at.component_hash;
+    uint64_t                       child_inum;
+    uint32_t                       child_gen;
 
     if (unlikely(status != CHIMERA_VFS_OK)) {
         demofs_op_fail(request, p->txn, status);
@@ -2692,20 +3741,18 @@ demofs_lookup_at_parent_cb(
 
     if (namelen == 2 && name[0] == '.' && name[1] == '.') {
         demofs_inode_get_inum_async(thread, p->txn,
-                                    parent->dir.parent_inum,
-                                    parent->dir.parent_gen,
+                                    parent->parent_inum,
+                                    parent->parent_gen,
                                     demofs_lookup_at_child_cb, request);
         return;
     }
 
-    rb_tree_query_exact(&parent->dir.dirents, hash, hash, dirent);
-
-    if (!dirent) {
+    if (demofs_dir_lookup(thread, parent, hash, &child_inum, &child_gen) != 0) {
         demofs_op_fail(request, p->txn, CHIMERA_VFS_ENOENT);
         return;
     }
 
-    demofs_inode_get_inum_async(thread, p->txn, dirent->inum, dirent->gen,
+    demofs_inode_get_inum_async(thread, p->txn, child_inum, child_gen,
                                 demofs_lookup_at_child_cb, request);
 } /* demofs_lookup_at_parent_cb */
 
@@ -2759,7 +3806,6 @@ demofs_mkdir_at_alloc_cb(
     struct demofs_request_private *p       = request->plugin_data;
     struct demofs_thread          *thread  = p->thread;
     struct demofs_inode           *parent  = p->inode_stash[0];
-    struct demofs_dirent          *dirent;
     struct timespec                now;
 
     if (unlikely(status != CHIMERA_VFS_OK)) {
@@ -2782,18 +3828,15 @@ demofs_mkdir_at_alloc_cb(
     inode->ctime_sec  = now.tv_sec;
     inode->ctime_nsec = now.tv_nsec;
 
-    rb_tree_init(&inode->dir.dirents);
-    inode->dir.parent_inum = parent->inum;
-    inode->dir.parent_gen  = parent->gen;
+    inode->parent_inum = parent->inum;
+    inode->parent_gen  = parent->gen;
 
     demofs_apply_attrs(inode, request->mkdir_at.set_attr);
     demofs_map_attrs(thread, &request->mkdir_at.r_attr, inode);
 
-    dirent = demofs_dirent_alloc(thread, inode->inum, inode->gen,
-                                 request->mkdir_at.name_hash,
-                                 request->mkdir_at.name,
-                                 request->mkdir_at.name_len);
-    rb_tree_insert(&parent->dir.dirents, hash, dirent);
+    demofs_dir_insert(thread, p->txn, parent, request->mkdir_at.name_hash,
+                      request->mkdir_at.name, request->mkdir_at.name_len,
+                      inode->inum, inode->gen);
 
     parent->nlink++;
     parent->mtime_sec  = now.tv_sec;
@@ -2815,8 +3858,9 @@ demofs_mkdir_at_parent_cb(
     struct chimera_vfs_request    *request = private_data;
     struct demofs_request_private *p       = request->plugin_data;
     struct demofs_thread          *thread  = p->thread;
-    struct demofs_dirent          *existing_dirent;
-    uint64_t                       hash = request->mkdir_at.name_hash;
+    uint64_t                       hash    = request->mkdir_at.name_hash;
+    uint64_t                       existing_inum;
+    uint32_t                       existing_gen;
 
     if (unlikely(status != CHIMERA_VFS_OK)) {
         demofs_op_fail(request, p->txn, status);
@@ -2830,14 +3874,11 @@ demofs_mkdir_at_parent_cb(
 
     demofs_map_attrs(thread, &request->mkdir_at.r_dir_pre_attr, parent);
 
-    rb_tree_query_exact(&parent->dir.dirents, hash, hash, existing_dirent);
-
     p->inode_stash[0] = parent;
 
-    if (existing_dirent) {
+    if (demofs_dir_lookup(thread, parent, hash, &existing_inum, &existing_gen) == 0) {
         demofs_inode_get_inum_async(thread, p->txn,
-                                    existing_dirent->inum,
-                                    existing_dirent->gen,
+                                    existing_inum, existing_gen,
                                     demofs_mkdir_at_existing_cb, request);
         return;
     }
@@ -2896,7 +3937,6 @@ demofs_mknod_at_alloc_cb(
     struct demofs_request_private *p       = request->plugin_data;
     struct demofs_thread          *thread  = p->thread;
     struct demofs_inode           *parent  = p->inode_stash[0];
-    struct demofs_dirent          *dirent;
     struct timespec                now;
 
     if (unlikely(status != CHIMERA_VFS_OK)) {
@@ -2931,11 +3971,9 @@ demofs_mknod_at_alloc_cb(
     demofs_apply_attrs(inode, request->mknod_at.set_attr);
     demofs_map_attrs(thread, &request->mknod_at.r_attr, inode);
 
-    dirent = demofs_dirent_alloc(thread, inode->inum, inode->gen,
-                                 request->mknod_at.name_hash,
-                                 request->mknod_at.name,
-                                 request->mknod_at.name_len);
-    rb_tree_insert(&parent->dir.dirents, hash, dirent);
+    demofs_dir_insert(thread, p->txn, parent, request->mknod_at.name_hash,
+                      request->mknod_at.name, request->mknod_at.name_len,
+                      inode->inum, inode->gen);
 
     parent->mtime_sec  = now.tv_sec;
     parent->mtime_nsec = now.tv_nsec;
@@ -2956,8 +3994,9 @@ demofs_mknod_at_parent_cb(
     struct chimera_vfs_request    *request = private_data;
     struct demofs_request_private *p       = request->plugin_data;
     struct demofs_thread          *thread  = p->thread;
-    struct demofs_dirent          *existing_dirent;
-    uint64_t                       hash = request->mknod_at.name_hash;
+    uint64_t                       hash    = request->mknod_at.name_hash;
+    uint64_t                       existing_inum;
+    uint32_t                       existing_gen;
 
     if (unlikely(status != CHIMERA_VFS_OK)) {
         demofs_op_fail(request, p->txn, status);
@@ -2971,14 +4010,11 @@ demofs_mknod_at_parent_cb(
 
     demofs_map_attrs(thread, &request->mknod_at.r_dir_pre_attr, parent);
 
-    rb_tree_query_exact(&parent->dir.dirents, hash, hash, existing_dirent);
-
     p->inode_stash[0] = parent;
 
-    if (existing_dirent) {
+    if (demofs_dir_lookup(thread, parent, hash, &existing_inum, &existing_gen) == 0) {
         demofs_inode_get_inum_async(thread, p->txn,
-                                    existing_dirent->inum,
-                                    existing_dirent->gen,
+                                    existing_inum, existing_gen,
                                     demofs_mknod_at_existing_cb, request);
         return;
     }
@@ -3019,8 +4055,7 @@ demofs_remove_at_child_cb(
     struct demofs_request_private *p       = request->plugin_data;
     struct demofs_thread          *thread  = p->thread;
     struct demofs_inode           *parent  = p->inode_stash[0];
-    struct demofs_dirent          *dirent;
-    uint64_t                       hash = request->remove_at.name_hash;
+    uint64_t                       hash    = request->remove_at.name_hash;
     struct timespec                now;
 
     if (unlikely(status != CHIMERA_VFS_OK)) {
@@ -3033,12 +4068,9 @@ demofs_remove_at_child_cb(
         return;
     }
 
-    rb_tree_query_exact(&parent->dir.dirents, hash, hash, dirent);
-
-    /* The dirent was located before the child fetch and the parent has
-     * been write-locked throughout, so it must still be present; guard
-     * defensively to keep the derefs below provably safe. */
-    if (unlikely(!dirent)) {
+    /* The dirent was located before the child fetch and the parent has been
+     * write-locked throughout, so it must still be present. */
+    if (unlikely(demofs_dir_remove(thread, p->txn, parent, hash) != 1)) {
         demofs_op_fail(request, p->txn, CHIMERA_VFS_ENOENT);
         return;
     }
@@ -3052,8 +4084,6 @@ demofs_remove_at_child_cb(
     parent->mtime_nsec = now.tv_nsec;
     parent->ctime_sec  = now.tv_sec;
     parent->ctime_nsec = now.tv_nsec;
-
-    rb_tree_remove(&parent->dir.dirents, &dirent->node);
 
     if (S_ISDIR(inode->mode)) {
         inode->nlink = 0;
@@ -3076,8 +4106,6 @@ demofs_remove_at_child_cb(
 
     demofs_map_attrs(thread, &request->remove_at.r_dir_post_attr, parent);
 
-    demofs_dirent_free(thread, dirent);
-
     demofs_op_ok(request, p->txn);
 } /* demofs_remove_at_child_cb */
 
@@ -3090,8 +4118,9 @@ demofs_remove_at_parent_cb(
     struct chimera_vfs_request    *request = private_data;
     struct demofs_request_private *p       = request->plugin_data;
     struct demofs_thread          *thread  = p->thread;
-    struct demofs_dirent          *dirent;
-    uint64_t                       hash = request->remove_at.name_hash;
+    uint64_t                       hash    = request->remove_at.name_hash;
+    uint64_t                       child_inum;
+    uint32_t                       child_gen;
 
     if (unlikely(status != CHIMERA_VFS_OK)) {
         demofs_op_fail(request, p->txn, status);
@@ -3105,15 +4134,13 @@ demofs_remove_at_parent_cb(
         return;
     }
 
-    rb_tree_query_exact(&parent->dir.dirents, hash, hash, dirent);
-
-    if (!dirent) {
+    if (demofs_dir_lookup(thread, parent, hash, &child_inum, &child_gen) != 0) {
         demofs_op_fail(request, p->txn, CHIMERA_VFS_ENOENT);
         return;
     }
 
     p->inode_stash[0] = parent;
-    demofs_inode_get_inum_async(thread, p->txn, dirent->inum, dirent->gen,
+    demofs_inode_get_inum_async(thread, p->txn, child_inum, child_gen,
                                 demofs_remove_at_child_cb, request);
 } /* demofs_remove_at_parent_cb */
 
@@ -3150,8 +4177,9 @@ demofs_remove_at(
 
 /*
  * Readdir state machine.
- *   inode_stash[0] = directory inode (locked for the whole iteration)
- *   inode_stash[1] = (struct demofs_dirent *) cursor cast to void *
+ *   inode_stash[0] = directory inode (read-locked for the whole iteration)
+ *   p->rd_from_hash = next dirent hash to fetch (>= cursor)
+ *   p->rd_* = the dirent currently being emitted (copied out of the b+tree)
  * r_cookie/r_eof on the request are updated as we go.
  */
 
@@ -3177,14 +4205,12 @@ demofs_readdir_iter_inode_cb(
     struct chimera_vfs_request    *request = private_data;
     struct demofs_request_private *p       = request->plugin_data;
     struct demofs_thread          *thread  = p->thread;
-    struct demofs_inode           *inode   = p->inode_stash[0];
-    struct demofs_dirent          *dirent  = (struct demofs_dirent *) p->inode_stash[1];
     struct chimera_vfs_attrs       attr;
     int                            rc;
 
     if (status != CHIMERA_VFS_OK) {
-        /* Stale dirent — skip. */
-        p->inode_stash[1] = (struct demofs_inode *) rb_tree_next(&inode->dir.dirents, dirent);
+        /* Stale dirent — skip to the next. */
+        p->rd_from_hash = p->rd_hash + 1;
         demofs_readdir_iter_step(request);
         return;
     }
@@ -3197,12 +4223,12 @@ demofs_readdir_iter_inode_cb(
     demofs_txn_unlock_inode(p->txn, dirent_inode);
 
     rc = request->readdir.callback(
-        dirent->inum,
-        dirent->hash + DEMOFS_COOKIE_FIRST,
-        dirent->name, dirent->name_len,
+        p->rd_inum,
+        p->rd_hash + DEMOFS_COOKIE_FIRST,
+        p->rd_name, p->rd_namelen,
         &attr, request->proto_private_data);
 
-    request->readdir.r_cookie = dirent->hash + DEMOFS_COOKIE_FIRST;
+    request->readdir.r_cookie = p->rd_hash + DEMOFS_COOKIE_FIRST;
 
     if (rc) {
         request->readdir.r_eof = 0;
@@ -3210,7 +4236,7 @@ demofs_readdir_iter_inode_cb(
         return;
     }
 
-    p->inode_stash[1] = (struct demofs_inode *) rb_tree_next(&inode->dir.dirents, dirent);
+    p->rd_from_hash = p->rd_hash + 1;
     demofs_readdir_iter_step(request);
 } /* demofs_readdir_iter_inode_cb */
 
@@ -3219,15 +4245,16 @@ demofs_readdir_iter_step(struct chimera_vfs_request *request)
 {
     struct demofs_request_private *p      = request->plugin_data;
     struct demofs_thread          *thread = p->thread;
-    struct demofs_dirent          *dirent = (struct demofs_dirent *) p->inode_stash[1];
+    struct demofs_inode           *inode  = p->inode_stash[0];
 
-    if (!dirent) {
+    if (demofs_dir_next(thread, inode, p->rd_from_hash, &p->rd_hash,
+                        &p->rd_inum, &p->rd_gen, p->rd_name, &p->rd_namelen) != 0) {
         request->readdir.r_eof = 1;
         demofs_readdir_complete(request);
         return;
     }
 
-    demofs_inode_get_inum_async(thread, p->txn, dirent->inum, dirent->gen,
+    demofs_inode_get_inum_async(thread, p->txn, p->rd_inum, p->rd_gen,
                                 demofs_readdir_iter_inode_cb, request);
 } /* demofs_readdir_iter_step */
 
@@ -3235,18 +4262,14 @@ static void
 demofs_readdir_start_iter(struct chimera_vfs_request *request)
 {
     struct demofs_request_private *p      = request->plugin_data;
-    struct demofs_inode           *inode  = p->inode_stash[0];
     uint64_t                       cookie = request->readdir.r_cookie;
-    struct demofs_dirent          *dirent;
 
     if (cookie < DEMOFS_COOKIE_FIRST) {
-        rb_tree_first(&inode->dir.dirents, dirent);
+        p->rd_from_hash = 0;
     } else {
-        uint64_t hash_cookie = cookie - DEMOFS_COOKIE_FIRST;
-        rb_tree_query_ceil(&inode->dir.dirents, hash_cookie + 1, hash, dirent);
+        p->rd_from_hash = (cookie - DEMOFS_COOKIE_FIRST) + 1;
     }
 
-    p->inode_stash[1] = (struct demofs_inode *) dirent;
     demofs_readdir_iter_step(request);
 } /* demofs_readdir_start_iter */
 
@@ -3260,7 +4283,7 @@ demofs_readdir_emit_dotdot(
     int                            rc;
 
     rc = request->readdir.callback(
-        inode->dir.parent_inum,
+        inode->parent_inum,
         DEMOFS_COOKIE_DOTDOT,
         "..", 2,
         attr, request->proto_private_data);
@@ -3347,15 +4370,15 @@ demofs_readdir_inode_cb(
 
     if ((request->readdir.flags & CHIMERA_VFS_READDIR_EMIT_DOT) &&
         cookie < DEMOFS_COOKIE_DOTDOT) {
-        if (inode->dir.parent_inum == inode->inum &&
-            inode->dir.parent_gen == inode->gen) {
+        if (inode->parent_inum == inode->inum &&
+            inode->parent_gen == inode->gen) {
             demofs_map_attrs(thread, &attr, inode);
             demofs_readdir_emit_dotdot(request, &attr);
             return;
         }
         demofs_inode_get_inum_async(thread, p->txn,
-                                    inode->dir.parent_inum,
-                                    inode->dir.parent_gen,
+                                    inode->parent_inum,
+                                    inode->parent_gen,
                                     demofs_readdir_dotdot_cb, request);
         return;
     }
@@ -3482,7 +4505,6 @@ demofs_open_at_alloc_cb(
     struct demofs_request_private *p       = request->plugin_data;
     struct demofs_thread          *thread  = p->thread;
     struct demofs_inode           *parent  = p->inode_stash[0];
-    struct demofs_dirent          *dirent;
     struct timespec                now;
 
     if (unlikely(status != CHIMERA_VFS_OK)) {
@@ -3508,11 +4530,9 @@ demofs_open_at_alloc_cb(
     rb_tree_init(&inode->file.extents);
     demofs_apply_attrs(inode, request->open_at.set_attr);
 
-    dirent = demofs_dirent_alloc(thread, inode->inum, inode->gen,
-                                 request->open_at.name_hash,
-                                 request->open_at.name,
-                                 request->open_at.namelen);
-    rb_tree_insert(&parent->dir.dirents, hash, dirent);
+    demofs_dir_insert(thread, p->txn, parent, request->open_at.name_hash,
+                      request->open_at.name, request->open_at.namelen,
+                      inode->inum, inode->gen);
 
     parent->mtime_sec  = now.tv_sec;
     parent->mtime_nsec = now.tv_nsec;
@@ -3531,9 +4551,10 @@ demofs_open_at_parent_cb(
     struct chimera_vfs_request    *request = private_data;
     struct demofs_request_private *p       = request->plugin_data;
     struct demofs_thread          *thread  = p->thread;
-    struct demofs_dirent          *dirent;
-    unsigned int                   flags = request->open_at.flags;
-    uint64_t                       hash  = request->open_at.name_hash;
+    unsigned int                   flags   = request->open_at.flags;
+    uint64_t                       hash    = request->open_at.name_hash;
+    uint64_t                       child_inum;
+    uint32_t                       child_gen;
 
     if (unlikely(status != CHIMERA_VFS_OK)) {
         demofs_op_fail(request, p->txn, status);
@@ -3547,11 +4568,9 @@ demofs_open_at_parent_cb(
 
     demofs_map_attrs(thread, &request->open_at.r_dir_pre_attr, parent);
 
-    rb_tree_query_exact(&parent->dir.dirents, hash, hash, dirent);
-
     p->inode_stash[0] = parent;
 
-    if (!dirent) {
+    if (demofs_dir_lookup(thread, parent, hash, &child_inum, &child_gen) != 0) {
         if (!(flags & CHIMERA_VFS_OPEN_CREATE)) {
             demofs_op_fail(request, p->txn, CHIMERA_VFS_ENOENT);
             return;
@@ -3566,7 +4585,7 @@ demofs_open_at_parent_cb(
         return;
     }
 
-    demofs_inode_get_inum_async(thread, p->txn, dirent->inum, dirent->gen,
+    demofs_inode_get_inum_async(thread, p->txn, child_inum, child_gen,
                                 demofs_open_at_existing_cb, request);
 } /* demofs_open_at_parent_cb */
 
@@ -4786,7 +5805,6 @@ demofs_symlink_at_alloc_cb(
     struct demofs_request_private *p       = request->plugin_data;
     struct demofs_thread          *thread  = p->thread;
     struct demofs_inode           *parent  = p->inode_stash[0];
-    struct demofs_dirent          *dirent;
     struct timespec                now;
 
     if (unlikely(status != CHIMERA_VFS_OK)) {
@@ -4809,16 +5827,13 @@ demofs_symlink_at_alloc_cb(
     inode->ctime_sec  = now.tv_sec;
     inode->ctime_nsec = now.tv_nsec;
 
-    inode->symlink.target = demofs_symlink_target_alloc(thread,
-                                                        request->symlink_at.target,
-                                                        request->symlink_at.targetlen);
+    demofs_symlink_set(thread, p->txn, inode,
+                       request->symlink_at.target, request->symlink_at.targetlen);
     demofs_map_attrs(thread, &request->symlink_at.r_attr, inode);
 
-    dirent = demofs_dirent_alloc(thread, inode->inum, inode->gen,
-                                 request->symlink_at.name_hash,
-                                 request->symlink_at.name,
-                                 request->symlink_at.namelen);
-    rb_tree_insert(&parent->dir.dirents, hash, dirent);
+    demofs_dir_insert(thread, p->txn, parent, request->symlink_at.name_hash,
+                      request->symlink_at.name, request->symlink_at.namelen,
+                      inode->inum, inode->gen);
 
     parent->mtime_sec  = now.tv_sec;
     parent->mtime_nsec = now.tv_nsec;
@@ -4839,8 +5854,9 @@ demofs_symlink_at_parent_cb(
     struct chimera_vfs_request    *request = private_data;
     struct demofs_request_private *p       = request->plugin_data;
     struct demofs_thread          *thread  = p->thread;
-    struct demofs_dirent          *existing_dirent;
-    uint64_t                       hash = request->symlink_at.name_hash;
+    uint64_t                       hash    = request->symlink_at.name_hash;
+    uint64_t                       existing_inum;
+    uint32_t                       existing_gen;
 
     if (unlikely(status != CHIMERA_VFS_OK)) {
         demofs_op_fail(request, p->txn, status);
@@ -4852,9 +5868,7 @@ demofs_symlink_at_parent_cb(
         return;
     }
 
-    rb_tree_query_exact(&parent->dir.dirents, hash, hash, existing_dirent);
-
-    if (existing_dirent) {
+    if (demofs_dir_lookup(thread, parent, hash, &existing_inum, &existing_gen) == 0) {
         demofs_op_fail(request, p->txn, CHIMERA_VFS_EEXIST);
         return;
     }
@@ -4905,10 +5919,13 @@ demofs_readlink_inode_cb(
         return;
     }
 
-    request->readlink.r_target_length = inode->symlink.target->length;
-    memcpy(request->readlink.r_target,
-           inode->symlink.target->data,
-           inode->symlink.target->length);
+    {
+        int len = demofs_symlink_get(p->thread, inode,
+                                     request->readlink.r_target,
+                                     request->readlink.target_maxlength);
+        chimera_demofs_abort_if(len < 0, "symlink record missing (inum %lu)", inode->inum);
+        request->readlink.r_target_length = len;
+    }
 
     demofs_map_attrs(p->thread, &request->readlink.r_attr, inode);
 
@@ -5014,45 +6031,37 @@ demofs_rename_at_perform(struct chimera_vfs_request *request)
     struct demofs_inode           *np             = p->inode_stash[1];
     struct demofs_inode           *child          = p->inode_stash[2];
     struct demofs_inode           *existing_inode = p->inode_stash[3];
-    struct demofs_dirent          *old_dirent, *existing_dirent = NULL, *new_dirent;
-    uint64_t                       hash     = request->rename_at.name_hash;
-    uint64_t                       new_hash = request->rename_at.new_name_hash;
+    uint64_t                       hash           = request->rename_at.name_hash;
+    uint64_t                       new_hash       = request->rename_at.new_name_hash;
+    uint64_t                       old_inum;
+    uint32_t                       old_gen;
     struct timespec                now;
 
     clock_gettime(CLOCK_REALTIME, &now);
 
-    rb_tree_query_exact(&op->dir.dirents, hash, hash, old_dirent);
-
     /* The source dirent was verified before we fetched the child and the
      * source parent has been write-locked the whole time, so it must still
-     * be present; guard defensively to keep the deref provably safe. */
-    if (unlikely(!old_dirent)) {
+     * be present. */
+    if (unlikely(demofs_dir_lookup(thread, op, hash, &old_inum, &old_gen) != 0)) {
         demofs_rename_at_unlock_parents(request);
         demofs_op_fail(request, p->txn, CHIMERA_VFS_ENOENT);
         return;
     }
 
     if (existing_inode) {
-        rb_tree_query_exact(&np->dir.dirents, new_hash, hash, existing_dirent);
-        if (existing_dirent) {
-            rb_tree_remove(&np->dir.dirents, &existing_dirent->node);
+        if (demofs_dir_remove(thread, p->txn, np, new_hash) == 1) {
             existing_inode->nlink--;
             if (S_ISDIR(existing_inode->mode)) {
                 np->nlink--;
             }
-            demofs_dirent_free(thread, existing_dirent);
         }
     }
 
-    new_dirent = demofs_dirent_alloc(thread,
-                                     old_dirent->inum,
-                                     old_dirent->gen,
-                                     new_hash,
-                                     request->rename_at.new_name,
-                                     request->rename_at.new_namelen);
+    demofs_dir_insert(thread, p->txn, np, new_hash,
+                      request->rename_at.new_name, request->rename_at.new_namelen,
+                      old_inum, old_gen);
 
-    rb_tree_insert(&np->dir.dirents, hash, new_dirent);
-    rb_tree_remove(&op->dir.dirents, &old_dirent->node);
+    demofs_dir_remove(thread, p->txn, op, hash);
 
     if (S_ISDIR(child->mode)) {
         op->nlink--;
@@ -5074,7 +6083,6 @@ demofs_rename_at_perform(struct chimera_vfs_request *request)
     demofs_map_attrs(thread, &request->rename_at.r_todir_post_attr, np);
 
     demofs_rename_at_unlock_parents(request);
-    demofs_dirent_free(thread, old_dirent);
     demofs_op_ok(request, p->txn);
 } /* demofs_rename_at_perform */
 
@@ -5084,14 +6092,15 @@ demofs_rename_at_child_cb(
     int                  status,
     void                *private_data)
 {
-    struct chimera_vfs_request    *request = private_data;
-    struct demofs_request_private *p       = request->plugin_data;
-    struct demofs_thread          *thread  = p->thread;
-    struct demofs_inode           *op      = p->inode_stash[0];
-    struct demofs_inode           *np      = p->inode_stash[1];
-    struct demofs_dirent          *old_dirent, *existing_dirent;
+    struct chimera_vfs_request    *request  = private_data;
+    struct demofs_request_private *p        = request->plugin_data;
+    struct demofs_thread          *thread   = p->thread;
+    struct demofs_inode           *op       = p->inode_stash[0];
+    struct demofs_inode           *np       = p->inode_stash[1];
     uint64_t                       hash     = request->rename_at.name_hash;
     uint64_t                       new_hash = request->rename_at.new_name_hash;
+    uint64_t                       old_inum, existing_inum;
+    uint32_t                       old_gen, existing_gen;
 
     if (unlikely(status != CHIMERA_VFS_OK)) {
         demofs_rename_at_unlock_parents(request);
@@ -5101,24 +6110,20 @@ demofs_rename_at_child_cb(
 
     p->inode_stash[2] = child;
 
-    rb_tree_query_exact(&op->dir.dirents, hash, hash, old_dirent);
-    if (unlikely(!old_dirent)) {
+    if (unlikely(demofs_dir_lookup(thread, op, hash, &old_inum, &old_gen) != 0)) {
         demofs_rename_at_unlock_parents(request);
         demofs_op_fail(request, p->txn, CHIMERA_VFS_ENOENT);
         return;
     }
 
-    rb_tree_query_exact(&np->dir.dirents, new_hash, hash, existing_dirent);
-
-    if (!existing_dirent) {
+    if (demofs_dir_lookup(thread, np, new_hash, &existing_inum, &existing_gen) != 0) {
         p->inode_stash[3] = NULL;
         demofs_rename_at_perform(request);
         return;
     }
 
     /* Hardlink shortcut: source and dest already refer to the same inode. */
-    if (existing_dirent->inum == old_dirent->inum &&
-        existing_dirent->gen == old_dirent->gen) {
+    if (existing_inum == old_inum && existing_gen == old_gen) {
         demofs_map_attrs(thread, &request->rename_at.r_fromdir_post_attr, op);
         demofs_map_attrs(thread, &request->rename_at.r_todir_post_attr, np);
         demofs_rename_at_unlock_parents(request);
@@ -5127,7 +6132,7 @@ demofs_rename_at_child_cb(
     }
 
     demofs_inode_get_inum_async(thread, p->txn,
-                                existing_dirent->inum, existing_dirent->gen,
+                                existing_inum, existing_gen,
                                 demofs_rename_at_existing_cb, request);
 } /* demofs_rename_at_child_cb */
 
@@ -5138,21 +6143,21 @@ demofs_rename_at_have_parents(struct chimera_vfs_request *request)
     struct demofs_thread          *thread = p->thread;
     struct demofs_inode           *op     = p->inode_stash[0];
     struct demofs_inode           *np     = p->inode_stash[1];
-    struct demofs_dirent          *old_dirent;
-    uint64_t                       hash = request->rename_at.name_hash;
+    uint64_t                       hash   = request->rename_at.name_hash;
+    uint64_t                       old_inum;
+    uint32_t                       old_gen;
 
     demofs_map_attrs(thread, &request->rename_at.r_fromdir_pre_attr, op);
     demofs_map_attrs(thread, &request->rename_at.r_todir_pre_attr, np);
 
-    rb_tree_query_exact(&op->dir.dirents, hash, hash, old_dirent);
-    if (!old_dirent) {
+    if (demofs_dir_lookup(thread, op, hash, &old_inum, &old_gen) != 0) {
         demofs_rename_at_unlock_parents(request);
         demofs_op_fail(request, p->txn, CHIMERA_VFS_ENOENT);
         return;
     }
 
     demofs_inode_get_inum_async(thread, p->txn,
-                                old_dirent->inum, old_dirent->gen,
+                                old_inum, old_gen,
                                 demofs_rename_at_child_cb, request);
 } /* demofs_rename_at_have_parents */
 
@@ -5281,16 +6286,14 @@ demofs_link_at_finish(struct chimera_vfs_request *request)
     struct demofs_thread          *thread = p->thread;
     struct demofs_inode           *parent = p->inode_stash[0];
     struct demofs_inode           *inode  = p->inode_stash[1];
-    struct demofs_dirent          *dirent;
-    uint64_t                       hash = request->link_at.name_hash;
+    uint64_t                       hash   = request->link_at.name_hash;
     struct timespec                now;
 
     clock_gettime(CLOCK_REALTIME, &now);
 
-    dirent = demofs_dirent_alloc(thread, inode->inum, inode->gen, hash,
-                                 request->link_at.name,
-                                 request->link_at.namelen);
-    rb_tree_insert(&parent->dir.dirents, hash, dirent);
+    demofs_dir_insert(thread, p->txn, parent, hash,
+                      request->link_at.name, request->link_at.namelen,
+                      inode->inum, inode->gen);
 
     inode->nlink++;
     inode->ctime_sec   = now.tv_sec;
@@ -5336,8 +6339,9 @@ demofs_link_at_inode_cb(
     struct demofs_request_private *p       = request->plugin_data;
     struct demofs_thread          *thread  = p->thread;
     struct demofs_inode           *parent  = p->inode_stash[0];
-    struct demofs_dirent          *dirent;
-    uint64_t                       hash = request->link_at.name_hash;
+    uint64_t                       hash    = request->link_at.name_hash;
+    uint64_t                       einum;
+    uint32_t                       egen;
 
     if (unlikely(status != CHIMERA_VFS_OK)) {
         demofs_op_fail(request, p->txn, status);
@@ -5351,15 +6355,9 @@ demofs_link_at_inode_cb(
 
     p->inode_stash[1] = inode;
 
-    rb_tree_query_exact(&parent->dir.dirents, hash, hash, dirent);
-
-    if (dirent) {
+    if (demofs_dir_lookup(thread, parent, hash, &einum, &egen) == 0) {
         if (request->link_at.replace && !S_ISDIR(inode->mode)) {
-            uint64_t einum = dirent->inum;
-            uint32_t egen  = dirent->gen;
-
-            rb_tree_remove(&parent->dir.dirents, &dirent->node);
-            demofs_dirent_free(thread, dirent);
+            demofs_dir_remove(thread, p->txn, parent, hash);
 
             demofs_inode_get_inum_async(thread, p->txn, einum, egen,
                                         demofs_link_at_existing_cb, request);

--- a/src/vfs/demofs/demofs.c
+++ b/src/vfs/demofs/demofs.c
@@ -263,6 +263,11 @@ struct demofs_inode {
     struct demofs_inode_waiter *wait_head;
     struct demofs_inode_waiter *wait_tail;
 
+    /* Eviction: an idle inode (refcnt==1, unlocked) sits on its shard's LRU
+     * as a recycle candidate.  All under the shard lock. */
+    struct demofs_inode        *lru_prev, *lru_next;
+    int                         on_lru;
+
     /* This inode's 4 KiB metadata home block in the block cache; pinned
      * while the inode is dirty in a transaction.  NULL until first claimed.
      * Directory entries, extents and the symlink target all live as keyed
@@ -275,13 +280,21 @@ struct demofs_inode {
 };
 
 struct demofs_inode_shard {
-    pthread_mutex_t lock;
-    struct rb_tree  inodes;       /* keyed by inum */
+    pthread_mutex_t      lock;
+    struct rb_tree       inodes;       /* keyed by inum */
+    struct demofs_inode *lru_head, *lru_tail; /* idle (recycle) candidates, LRU-first */
+    uint32_t             ninodes;      /* resident inodes in this shard */
 };
 
 struct demofs_inode_cache {
+    uint32_t                  shard_cap; /* soft cap before recycling kicks in */
     struct demofs_inode_shard shards[DEMOFS_INODE_CACHE_SHARDS];
 };
+
+/* Total inode cache target; per-shard cap = total / shards.  Eviction is a
+ * soft cap (grows past it when every resident inode is busy -- bounded by the
+ * live working set; the A5b waiter turns this into a hard cap). */
+#define DEMOFS_INODE_CACHE_DEFAULT_INODES    (256 * 1024)
 
 /* ------------------------------------------------------------------ */
 /* Block cache                                                         */
@@ -650,6 +663,7 @@ struct demofs_shared {
     int                        persistent;         /* config opt-in: detect+reload a clean FS instead of mkfs */
     int                        mounted;            /* 1 = remounted existing FS (enables inode read-back) */
     uint32_t                   block_cache_blocks; /* total resident block-buffer cap (0 = default) */
+    uint32_t                   inode_cache_inodes; /* total resident inode cap (0 = default) */
     uint64_t                   fsid;
     struct space_map          *space_map;
     struct demofs_intent_log   intent_log;
@@ -854,6 +868,58 @@ demofs_txn_add_slot(
     txn->num_inodes++;
 } /* demofs_txn_add_slot */
 
+/* Inode LRU (recycle candidates).  All require the owning shard lock. */
+static inline void
+demofs_inode_lru_push_tail(
+    struct demofs_inode_shard *shard,
+    struct demofs_inode       *inode)
+{
+    inode->lru_prev = shard->lru_tail;
+    inode->lru_next = NULL;
+    if (shard->lru_tail) {
+        shard->lru_tail->lru_next = inode;
+    } else {
+        shard->lru_head = inode;
+    }
+    shard->lru_tail = inode;
+    inode->on_lru   = 1;
+} /* demofs_inode_lru_push_tail */
+
+static inline void
+demofs_inode_lru_unlink(
+    struct demofs_inode_shard *shard,
+    struct demofs_inode       *inode)
+{
+    if (!inode->on_lru) {
+        return;
+    }
+    if (inode->lru_prev) {
+        inode->lru_prev->lru_next = inode->lru_next;
+    } else {
+        shard->lru_head = inode->lru_next;
+    }
+    if (inode->lru_next) {
+        inode->lru_next->lru_prev = inode->lru_prev;
+    } else {
+        shard->lru_tail = inode->lru_prev;
+    }
+    inode->lru_prev = inode->lru_next = NULL;
+    inode->on_lru   = 0;
+} /* demofs_inode_lru_unlink */
+
+/*
+ * An idle inode is a recycle candidate: no open handle (refcnt == 1, the
+ * cache's own reference), not locked, and live (nlink > 0).  Whether its
+ * dinode is durable enough to drop is checked separately at recycle time.
+ * Caller holds the shard lock.
+ */
+static inline int
+demofs_inode_idle(const struct demofs_inode *inode)
+{
+    return inode->refcnt == 1 && inode->readers == 0 &&
+           inode->writer == 0 && inode->nlink > 0;
+} /* demofs_inode_idle */
+
 /* Caller must hold the inode's shard lock. */
 static inline int
 demofs_inode_lock_compatible(
@@ -956,6 +1022,13 @@ demofs_inode_release_one(
         if (w->mode == DEMOFS_INODE_LOCK_WRITE) {
             break;     /* exclusive: stop granting */
         }
+    }
+
+    /* If nobody re-took the lock and the inode is now idle, it becomes a
+     * recycle candidate.  (Recycle re-checks evictability, so it's fine that
+     * its dinode may not be durable yet.) */
+    if (!inode->on_lru && demofs_inode_idle(inode)) {
+        demofs_inode_lru_push_tail(shard, inode);
     }
 
     pthread_mutex_unlock(&shard->lock);
@@ -1067,12 +1140,14 @@ demofs_inode_acquire(
     }
 
     if (unlikely(!inode)) {
-        /* Not resident.  On a freshly-formatted FS everything created is
-         * cached, so this is simply ENOENT.  On a remounted FS the inode may
-         * live on disk -- fault it in (validated against the requested gen). */
+        /* Not resident: either evicted (its dinode is durably home -- eviction
+         * only drops CLEAN inodes) or genuinely absent.  Fault it in from disk
+         * whenever the inum is within allocated space; the on-disk dinode read
+         * validates inum/gen/nlink and yields ENOENT if it isn't really there.
+         * (This must not gate on `mounted` -- a freshly-formatted FS evicts
+         * too, so a miss is not necessarily ENOENT.) */
         pthread_mutex_unlock(&shard->lock);
-        if (thread->shared->mounted &&
-            sm_inum_valid(thread->shared->space_map, inum)) {
+        if (sm_inum_valid(thread->shared->space_map, inum)) {
             demofs_inode_load(thread, txn, inum, gen, mode, cb, private_data);
         } else {
             cb(NULL, CHIMERA_VFS_ENOENT, private_data);
@@ -1082,6 +1157,7 @@ demofs_inode_acquire(
 
     if (demofs_inode_lock_compatible(inode, mode)) {
         demofs_inode_lock_grant(inode, mode);
+        demofs_inode_lru_unlink(shard, inode);     /* busy now, not a candidate */
         pthread_mutex_unlock(&shard->lock);
         demofs_txn_add_slot(txn, inode, mode);
         if (mode == DEMOFS_INODE_LOCK_WRITE) {
@@ -1158,6 +1234,11 @@ static void demofs_block_unpin(
     struct demofs_block    *blk,
     enum demofs_block_state new_state);
 
+/* Defined with the block-cache helpers it consults; used by the fault paths. */
+static void demofs_inode_cache_recycle_locked(
+    struct demofs_shared      *shared,
+    struct demofs_inode_shard *shard);
+
 static struct demofs_inode *
 demofs_inode_load_sync(
     struct demofs_thread *thread,
@@ -1174,7 +1255,7 @@ demofs_inode_load_sync(
     int                        fd;
     ssize_t                    n;
 
-    if (!shared->mounted || !sm_inum_valid(shared->space_map, inum)) {
+    if (!sm_inum_valid(shared->space_map, inum)) {
         return NULL;
     }
 
@@ -1197,6 +1278,7 @@ demofs_inode_load_sync(
     pthread_mutex_lock(&shard->lock);
     rb_tree_query_exact(&shard->inodes, inum, inum, inode);
     if (!inode) {
+        demofs_inode_cache_recycle_locked(shared, shard);
         inode              = calloc(1, sizeof(*inode));
         inode->inum        = inum;
         inode->refcnt      = 1;
@@ -1217,6 +1299,7 @@ demofs_inode_load_sync(
         inode->parent_inum = di->parent_inum;
         inode->parent_gen  = di->parent_gen;
         rb_tree_insert(&shard->inodes, inum, inode);
+        shard->ninodes++;
     }
     pthread_mutex_unlock(&shard->lock);
 
@@ -3997,6 +4080,71 @@ demofs_inode_struct_new(uint64_t inum)
     return inode;
 } /* demofs_inode_struct_new */
 
+/*
+ * An inode struct may be dropped only when its dinode is durably home, so a
+ * later fault re-reads current attrs from disk.  True iff the dinode's home
+ * block is CLEAN or no longer resident (it was CLEAN when evicted from the
+ * block cache, hence on disk).  Caller holds the inode shard lock; this takes
+ * the block shard lock (inode->block ordering, never the reverse).
+ */
+static int
+demofs_inode_dinode_clean(
+    struct demofs_shared *shared,
+    struct demofs_inode  *inode)
+{
+    uint32_t                   dev;
+    uint64_t                   off = sm_inum_to_device_offset(shared->space_map,
+                                                              inode->inum, &dev);
+    struct demofs_block_shard *bs     = demofs_block_shard(shared->block_cache, dev, off);
+    uint32_t                   bucket = demofs_block_bucket(dev, off);
+    struct demofs_block       *blk;
+    int                        clean;
+
+    pthread_mutex_lock(&bs->lock);
+    blk   = demofs_block_lookup_locked(bs, bucket, dev, off);
+    clean = (blk == NULL || blk->state == DEMOFS_BLOCK_CLEAN);
+    pthread_mutex_unlock(&bs->lock);
+    return clean;
+} /* demofs_inode_dinode_clean */
+
+/*
+ * Make room in a shard at/over its cap by evicting one idle, durable inode
+ * from the LRU.  Caller holds the shard lock.  The LRU is approximate -- a
+ * candidate may have gone busy since it was queued -- so each is re-validated;
+ * stale ones are unlinked (self-heal) and dinode-dirty ones skipped.  If none
+ * are evictable the pool grows past the cap (bounded by the live working set;
+ * the A5b waiter will make this a hard cap).
+ */
+static void
+demofs_inode_cache_recycle_locked(
+    struct demofs_shared      *shared,
+    struct demofs_inode_shard *shard)
+{
+    struct demofs_inode *inode, *next;
+
+    if (shard->ninodes < shared->inode_cache->shard_cap) {
+        return;
+    }
+
+    for (inode = shard->lru_head; inode; inode = next) {
+        next = inode->lru_next;
+
+        if (!demofs_inode_idle(inode)) {
+            demofs_inode_lru_unlink(shard, inode);     /* went busy; self-heal */
+            continue;
+        }
+        if (!demofs_inode_dinode_clean(shared, inode)) {
+            continue;                                  /* not durable yet; skip */
+        }
+
+        demofs_inode_lru_unlink(shard, inode);
+        rb_tree_remove(&shard->inodes, &inode->node);
+        shard->ninodes--;
+        free(inode);
+        return;
+    }
+} /* demofs_inode_cache_recycle_locked */
+
 static inline void
 demofs_inode_cache_insert(
     struct demofs_shared *shared,
@@ -4005,7 +4153,9 @@ demofs_inode_cache_insert(
     struct demofs_inode_shard *shard = demofs_inode_shard(shared, inode->inum);
 
     pthread_mutex_lock(&shard->lock);
+    demofs_inode_cache_recycle_locked(shared, shard);
     rb_tree_insert(&shard->inodes, inum, inode);
+    shard->ninodes++;
     pthread_mutex_unlock(&shard->lock);
 } /* demofs_inode_cache_insert */
 
@@ -4053,6 +4203,7 @@ demofs_inode_load_complete(
     pthread_mutex_lock(&shard->lock);
     rb_tree_query_exact(&shard->inodes, lc->inum, inum, inode);
     if (!inode) {
+        demofs_inode_cache_recycle_locked(shared, shard);
         inode              = demofs_inode_struct_new(lc->inum);
         inode->gen         = di->gen;
         inode->mode        = di->mode;
@@ -4071,6 +4222,7 @@ demofs_inode_load_complete(
         inode->parent_inum = di->parent_inum;
         inode->parent_gen  = di->parent_gen;
         rb_tree_insert(&shard->inodes, inum, inode);
+        shard->ninodes++;
     }
     pthread_mutex_unlock(&shard->lock);
 
@@ -5324,6 +5476,8 @@ demofs_init(const char *cfgdata)
     shared->persistent         = json_is_true(json_object_get(cfg, "persistent"));
     shared->block_cache_blocks = (uint32_t) json_integer_value(
         json_object_get(cfg, "block_cache_blocks"));
+    shared->inode_cache_inodes = (uint32_t) json_integer_value(
+        json_object_get(cfg, "inode_cache_inodes"));
 
     json_decref(cfg);
 
@@ -5443,8 +5597,16 @@ demofs_init(const char *cfgdata)
     }
     free(device0_path);
 
-    /* Inode cache: sharded rb-trees keyed by inum.  Never evicts yet. */
-    shared->inode_cache = calloc(1, sizeof(*shared->inode_cache));
+    /* Inode cache: sharded rb-trees keyed by inum, with per-shard LRU eviction
+     * of idle inodes (recycle candidates). */
+    shared->inode_cache            = calloc(1, sizeof(*shared->inode_cache));
+    shared->inode_cache->shard_cap = (shared->inode_cache_inodes ?
+                                      shared->inode_cache_inodes :
+                                      DEMOFS_INODE_CACHE_DEFAULT_INODES) /
+        DEMOFS_INODE_CACHE_SHARDS;
+    if (shared->inode_cache->shard_cap == 0) {
+        shared->inode_cache->shard_cap = 1;
+    }
     for (i = 0; i < DEMOFS_INODE_CACHE_SHARDS; i++) {
         rb_tree_init(&shared->inode_cache->shards[i].inodes);
         pthread_mutex_init(&shared->inode_cache->shards[i].lock, NULL);

--- a/src/vfs/demofs/space_map.c
+++ b/src/vfs/demofs/space_map.c
@@ -112,12 +112,16 @@ sm_ag_init(
     struct sm_extent *initial;
     uint64_t          total_reserved;
 
-    ag->device_id   = device_id;
-    ag->ag_index    = ag_index;
-    ag->base_offset = base_offset;
-    ag->size        = size;
-    ag->log_offset  = base_offset + pre_log_reserved;
-    ag->log_size    = SM_AG_LOG_SIZE;
+    ag->device_id       = device_id;
+    ag->ag_index        = ag_index;
+    ag->base_offset     = base_offset;
+    ag->size            = size;
+    ag->log_offset      = base_offset + pre_log_reserved;
+    ag->log_size        = SM_AG_LOG_SIZE;
+    ag->log_slot        = 0;
+    ag->log_generation  = 0;
+    ag->log_base_count  = 0;
+    ag->log_delta_count = 0;
 
     pthread_mutex_init(&ag->lock, NULL);
     rb_tree_init(&ag->free_by_offset);
@@ -648,14 +652,122 @@ space_map_read_superblock_path(
     return 0;
 } /* space_map_read_superblock_path */
 
+/*
+ * Remove the specific range [offset, offset+length) from the AG's free tree
+ * (i.e. mark it allocated), splitting the containing free extent.  Used to
+ * replay alloc deltas during reconstruction.  Caller holds ag->lock.
+ */
+static void
+sm_ag_mark_used_locked(
+    struct sm_ag *ag,
+    uint64_t      offset,
+    uint64_t      length)
+{
+    struct sm_extent *e = NULL;
+    uint64_t          e_off, e_len;
+
+    rb_tree_query_floor(&ag->free_by_offset, offset, offset, e);
+    sm_abort_if(!e || e->offset > offset ||
+                e->offset + e->length < offset + length,
+                "mark_used [%lu,%lu) not within a free extent",
+                offset, offset + length);
+
+    e_off = e->offset;
+    e_len = e->length;
+    rb_tree_remove(&ag->free_by_offset, &e->node);
+    free(e);
+
+    if (offset > e_off) {
+        struct sm_extent *l = sm_extent_new(e_off, offset - e_off);
+        rb_tree_insert(&ag->free_by_offset, offset, l);
+    }
+    if (offset + length < e_off + e_len) {
+        struct sm_extent *r = sm_extent_new(offset + length,
+                                            (e_off + e_len) - (offset + length));
+        rb_tree_insert(&ag->free_by_offset, offset, r);
+    }
+    ag->free_bytes -= length;
+} /* sm_ag_mark_used_locked */
+
+/* Serialize the AG's current free set into `slot` as a condensed base (no
+ * deltas) at `generation`.  Caller holds ag->lock.  Returns bytes written. */
+static uint64_t
+sm_ag_condense_into(
+    struct sm_ag *ag,
+    uint8_t      *slot,
+    uint64_t      generation)
+{
+    struct sm_ag_log_header *h    = (struct sm_ag_log_header *) slot;
+    struct sm_ag_log_ext    *base = (struct sm_ag_log_ext *) (slot + sizeof(*h));
+    struct sm_extent        *e;
+    uint32_t                 n       = 0;
+    uint64_t                 maxbase = (SM_AG_LOG_SLOT_SIZE - sizeof(*h)) /
+        sizeof(struct sm_ag_log_ext);
+
+    rb_tree_first(&ag->free_by_offset, e);
+    while (e) {
+        sm_abort_if(n >= maxbase, "AG condense overflow (%u extents)", n);
+        base[n].offset = e->offset;
+        base[n].length = e->length;
+        n++;
+        e = rb_tree_next(&ag->free_by_offset, e);
+    }
+
+    h->magic       = SM_AG_LOG_MAGIC;
+    h->generation  = generation;
+    h->base_count  = n;
+    h->delta_count = 0;
+    h->reserved    = 0;
+    return sizeof(*h) + (uint64_t) n * sizeof(struct sm_ag_log_ext);
+} /* sm_ag_condense_into */
+
+/* Rebuild the AG's free tree from a slot image: install the base extents,
+ * then replay the appended deltas in order.  Caller holds ag->lock. */
+static void
+sm_ag_reconstruct(
+    struct sm_ag  *ag,
+    const uint8_t *slot)
+{
+    const struct sm_ag_log_header *h      = (const struct sm_ag_log_header *) slot;
+    const struct sm_ag_log_ext    *base   = (const struct sm_ag_log_ext *) (slot + sizeof(*h));
+    const struct sm_ag_log_delta  *deltas =
+        (const struct sm_ag_log_delta *) (base + h->base_count);
+    uint32_t                       i;
+
+    rb_tree_destroy(&ag->free_by_offset, sm_extent_release, NULL);
+    rb_tree_init(&ag->free_by_offset);
+    ag->free_bytes = 0;
+
+    for (i = 0; i < h->base_count; i++) {
+        struct sm_extent *e = sm_extent_new(base[i].offset, base[i].length);
+        rb_tree_insert(&ag->free_by_offset, offset, e);
+        ag->free_bytes += base[i].length;
+    }
+    for (i = 0; i < h->delta_count; i++) {
+        if (deltas[i].op == SM_AG_LOG_OP_ALLOC) {
+            sm_ag_mark_used_locked(ag, deltas[i].offset, deltas[i].length);
+        } else {
+            sm_ag_free_locked(ag, deltas[i].offset, deltas[i].length);
+        }
+    }
+
+    ag->log_generation  = h->generation;
+    ag->log_base_count  = h->base_count;
+    ag->log_delta_count = h->delta_count;
+} /* sm_ag_reconstruct */
+
+/*
+ * Persist the allocator: condense each AG's free set into the *other* slot at
+ * generation+1 and switch to it.  (Per-transaction delta journaling, which
+ * makes interim allocations crash-durable, is layered on top of this; this
+ * full condense is what runs at clean unmount and resets the delta log.)
+ */
 int
 space_map_persist_paths(
     struct space_map *sm,
     char            **device_paths)
 {
     uint32_t d, a;
-    uint64_t maxrecs = (SM_AG_LOG_SLOT_SIZE - sizeof(struct sm_ag_snap_header)) /
-        sizeof(struct sm_ag_snap_rec);
 
     for (d = 0; d < sm->num_devices; d++) {
         struct sm_device *dev = &sm->devices[d];
@@ -666,40 +778,27 @@ space_map_persist_paths(
         }
 
         for (a = 0; a < dev->num_ags; a++) {
-            struct sm_ag             *ag   = &dev->ags[a];
-            uint8_t                  *buf  = calloc(1, SM_AG_LOG_SLOT_SIZE);
-            struct sm_ag_snap_header *h    = (struct sm_ag_snap_header *) buf;
-            struct sm_ag_snap_rec    *recs =
-                (struct sm_ag_snap_rec *) (buf + sizeof(*h));
-            struct sm_extent         *ext;
-            uint32_t                  count = 0;
-            uint64_t                  payload, aligned;
-            ssize_t                   n;
+            struct sm_ag *ag  = &dev->ags[a];
+            uint8_t      *buf = calloc(1, SM_AG_LOG_SLOT_SIZE);
+            uint32_t      slot;
+            uint64_t      gen, payload, aligned, slot_off;
+            ssize_t       n;
 
             pthread_mutex_lock(&ag->lock);
-            rb_tree_first(&ag->free_by_offset, ext);
-            while (ext) {
-                sm_abort_if(count >= maxrecs,
-                            "AG %u/%u snapshot overflow (%u extents)",
-                            d, a, count);
-                recs[count].offset = ext->offset;
-                recs[count].length = ext->length;
-                count++;
-                ext = rb_tree_next(&ag->free_by_offset, ext);
-            }
-            h->magic      = SM_AG_SNAP_MAGIC;
-            h->version    = SM_FORMAT_VERSION;
-            h->count      = count;
-            h->free_bytes = ag->free_bytes;
-            h->pad        = 0;
-            h->crc32      = 0;
-            pthread_mutex_unlock(&ag->lock);
-
-            payload  = sizeof(*h) + (uint64_t) count * sizeof(*recs);
-            h->crc32 = sm_crc32(buf, payload);
+            slot     = 1 - ag->log_slot;
+            gen      = ag->log_generation + 1;
+            payload  = sm_ag_condense_into(ag, buf, gen);
+            slot_off = ag->log_offset + (uint64_t) slot * SM_AG_LOG_SLOT_SIZE;
             aligned  = (payload + SM_BLOCK_SIZE - 1) & ~((uint64_t) SM_BLOCK_SIZE - 1);
 
-            n = pwrite(fd, buf, aligned, ag->log_offset);
+            n = pwrite(fd, buf, aligned, slot_off);
+            if (n == (ssize_t) aligned) {
+                ag->log_slot        = slot;
+                ag->log_generation  = gen;
+                ag->log_base_count  = ((struct sm_ag_log_header *) buf)->base_count;
+                ag->log_delta_count = 0;
+            }
+            pthread_mutex_unlock(&ag->lock);
             free(buf);
             if (n != (ssize_t) aligned) {
                 close(fd);
@@ -733,53 +832,47 @@ space_map_load_paths(
         }
 
         for (a = 0; a < dev->num_ags; a++) {
-            struct sm_ag            *ag = &dev->ags[a];
-            struct sm_ag_snap_header h;
-            struct sm_ag_snap_rec   *recs;
-            uint8_t                 *cbuf;
-            uint32_t                 i, stored, computed;
-            uint64_t                 payload;
-            ssize_t                  n;
+            struct sm_ag           *ag = &dev->ags[a];
+            struct sm_ag_log_header hdr[SM_AG_LOG_SLOT_COUNT];
+            uint8_t                *buf;
+            int                     best = -1;
+            uint32_t                s;
+            uint64_t                payload, slot_off;
+            ssize_t                 n;
 
-            n = pread(fd, &h, sizeof(h), ag->log_offset);
-            if (n != (ssize_t) sizeof(h) || h.magic != SM_AG_SNAP_MAGIC ||
-                h.version != SM_FORMAT_VERSION) {
+            /* Pick the live slot: highest generation with a valid magic. */
+            for (s = 0; s < SM_AG_LOG_SLOT_COUNT; s++) {
+                slot_off = ag->log_offset + (uint64_t) s * SM_AG_LOG_SLOT_SIZE;
+                n        = pread(fd, &hdr[s], sizeof(hdr[s]), slot_off);
+                if (n == (ssize_t) sizeof(hdr[s]) &&
+                    hdr[s].magic == SM_AG_LOG_MAGIC &&
+                    (best < 0 || hdr[s].generation > hdr[best].generation)) {
+                    best = (int) s;
+                }
+            }
+            if (best < 0) {
                 close(fd);
                 return -1;
             }
 
-            payload = sizeof(h) + (uint64_t) h.count * sizeof(*recs);
-            cbuf    = malloc(payload);
-            n       = pread(fd, cbuf, payload, ag->log_offset);
+            payload = sizeof(struct sm_ag_log_header) +
+                (uint64_t) hdr[best].base_count * sizeof(struct sm_ag_log_ext) +
+                (uint64_t) hdr[best].delta_count * sizeof(struct sm_ag_log_delta);
+            buf      = malloc(payload);
+            slot_off = ag->log_offset + (uint64_t) best * SM_AG_LOG_SLOT_SIZE;
+            n        = pread(fd, buf, payload, slot_off);
             if (n != (ssize_t) payload) {
-                free(cbuf);
+                free(buf);
                 close(fd);
                 return -1;
             }
-            stored                                     = h.crc32;
-            ((struct sm_ag_snap_header *) cbuf)->crc32 = 0;
-            computed                                   = sm_crc32(cbuf, payload);
-            if (stored != computed) {
-                free(cbuf);
-                close(fd);
-                return -1;
-            }
-            recs = (struct sm_ag_snap_rec *) (cbuf + sizeof(h));
 
-            /* Replace the default full-free tree with the snapshot. */
             pthread_mutex_lock(&ag->lock);
-            rb_tree_destroy(&ag->free_by_offset, sm_extent_release, NULL);
-            rb_tree_init(&ag->free_by_offset);
-            for (i = 0; i < h.count; i++) {
-                struct sm_extent *ext = sm_extent_new(recs[i].offset, recs[i].length);
-
-                rb_tree_insert(&ag->free_by_offset, offset, ext);
-            }
-            ag->free_bytes = h.free_bytes;
+            sm_ag_reconstruct(ag, buf);
+            ag->log_slot = (uint32_t) best;
+            free_total  += ag->free_bytes;
             pthread_mutex_unlock(&ag->lock);
-
-            free_total += h.free_bytes;
-            free(cbuf);
+            free(buf);
         }
         close(fd);
     }

--- a/src/vfs/demofs/space_map.c
+++ b/src/vfs/demofs/space_map.c
@@ -338,12 +338,14 @@ space_map_create(
                 pre_log_reserved = SM_SUPERBLOCK_SIZE + SM_INTENT_LOG_SIZE;
                 sm->used_bytes  += pre_log_reserved;
 
-                /* Statically reserve block_idx 1 and 2 of AG 0 / disk 0.
+                /* Statically reserve block_idx 1..3 of AG 0 / disk 0.
                  * block_idx 1 is held for a future AG header; block_idx 2 is
-                 * the root inode (inum 2), reserved (not allocated through the
-                 * allocator) so it is excluded from every condensed free set
-                 * and can never be re-handed-out after a crash. */
-                post_log_reserved = 2 * SM_BLOCK_SIZE;
+                 * the root inode (inum 2); block_idx 3 is the orphan-list inode
+                 * (inum 3, holds an entry per deleted-but-not-fully-reclaimed
+                 * inode).  All reserved (not allocated through the allocator)
+                 * so they are excluded from every condensed free set and can
+                 * never be re-handed-out after a crash. */
+                post_log_reserved = 3 * SM_BLOCK_SIZE;
                 sm->used_bytes   += post_log_reserved;
 
                 sm_abort_if(pre_log_reserved + SM_AG_LOG_SIZE +

--- a/src/vfs/demofs/space_map.c
+++ b/src/vfs/demofs/space_map.c
@@ -535,6 +535,94 @@ space_map_alloc(
     return 0;
 } /* space_map_alloc */
 
+/* Resolve and validate the AG owning [device_offset, device_offset+aligned). */
+static struct sm_ag *
+sm_free_resolve_ag(
+    struct space_map *sm,
+    uint32_t          device_id,
+    uint64_t          device_offset,
+    uint64_t          aligned,
+    const char       *who)
+{
+    struct sm_device *dev;
+    struct sm_ag     *ag;
+    uint32_t          ag_idx;
+
+    sm_abort_if(device_id >= sm->num_devices, "%s: bad device_id %u", who, device_id);
+    dev    = &sm->devices[device_id];
+    ag_idx = device_offset >> SM_AG_SIZE_LOG2;
+    sm_abort_if(ag_idx >= dev->num_ags, "%s: offset %lu past device %u",
+                who, device_offset, device_id);
+    ag = &dev->ags[ag_idx];
+    /* Frees never straddle AGs (reservations come from a single AG). */
+    sm_abort_if(device_offset + aligned > ag->base_offset + ag->size,
+                "%s: range crosses AG boundary (offset=%lu length=%lu ag_base=%lu ag_size=%lu)",
+                who, device_offset, aligned, ag->base_offset, ag->size);
+    return ag;
+} /* sm_free_resolve_ag */
+
+/*
+ * Journal a FREE delta into the AG's redo log without making the range
+ * reusable.  The delta rides the freeing transaction's redo (so a crash
+ * replays it via AG-log reconstruction), but the in-memory free is withheld
+ * until the transaction is durable -- see space_map_free_apply.  This is the
+ * intent half of a "pending free": it prevents the range from being handed out
+ * (and a still-cached/pinned metadata block from being reclaimed) before the
+ * transaction that freed it has committed.
+ */
+void
+space_map_free_journal(
+    struct space_map        *sm,
+    const struct sm_journal *jnl,
+    uint32_t                 device_id,
+    uint64_t                 device_offset,
+    uint64_t                 length)
+{
+    uint64_t      aligned = SM_ALIGN_UP(length);
+    struct sm_ag *ag;
+
+    if (aligned == 0) {
+        return;
+    }
+    ag = sm_free_resolve_ag(sm, device_id, device_offset, aligned, "space_map_free_journal");
+
+    pthread_mutex_lock(&ag->lock);
+    sm_ag_journal_delta(ag, jnl, SM_AG_LOG_OP_FREE, device_offset, aligned);
+    pthread_mutex_unlock(&ag->lock);
+} /* space_map_free_journal */
+
+/*
+ * Apply the in-memory free, returning the range to its AG's free pool.  Call
+ * once the transaction that journaled the matching FREE delta is durable.
+ */
+void
+space_map_free_apply(
+    struct space_map *sm,
+    uint32_t          device_id,
+    uint64_t          device_offset,
+    uint64_t          length)
+{
+    uint64_t      aligned = SM_ALIGN_UP(length);
+    struct sm_ag *ag;
+
+    if (aligned == 0) {
+        return;
+    }
+    ag = sm_free_resolve_ag(sm, device_id, device_offset, aligned, "space_map_free_apply");
+
+    pthread_mutex_lock(&ag->lock);
+    sm_ag_free_locked(ag, device_offset, aligned);
+    pthread_mutex_unlock(&ag->lock);
+
+    __atomic_fetch_sub(&sm->used_bytes, aligned, __ATOMIC_RELAXED);
+} /* space_map_free_apply */
+
+/*
+ * Immediate free (journal + apply in one step).  Safe only for ranges that are
+ * not referenced by any cached/pinned block and need no transactional ordering
+ * -- e.g. returning a thread's leftover reservation.  Transactional frees use
+ * the pending (journal-then-apply-on-commit) path instead.
+ */
 void
 space_map_free(
     struct space_map        *sm,
@@ -543,42 +631,8 @@ space_map_free(
     uint64_t                 device_offset,
     uint64_t                 length)
 {
-    struct sm_device *dev;
-    struct sm_ag     *ag;
-    uint32_t          ag_idx;
-    uint64_t          aligned = SM_ALIGN_UP(length);
-
-    if (aligned == 0) {
-        return;
-    }
-
-    sm_abort_if(device_id >= sm->num_devices,
-                "space_map_free: bad device_id %u", device_id);
-
-    dev = &sm->devices[device_id];
-
-    ag_idx = device_offset >> SM_AG_SIZE_LOG2;
-    sm_abort_if(ag_idx >= dev->num_ags,
-                "space_map_free: offset %lu past device %u",
-                device_offset, device_id);
-
-    ag = &dev->ags[ag_idx];
-
-    /* For now we forbid frees that straddle AG boundaries.  Callers that
-     * allocated through this allocator never see straddling because
-     * reservations come from a single AG.  Defensive abort if it ever
-     * happens. */
-    sm_abort_if(device_offset + aligned > ag->base_offset + ag->size,
-                "space_map_free: range crosses AG boundary "
-                "(offset=%lu length=%lu ag_base=%lu ag_size=%lu)",
-                device_offset, aligned, ag->base_offset, ag->size);
-
-    pthread_mutex_lock(&ag->lock);
-    sm_ag_free_locked(ag, device_offset, aligned);
-    sm_ag_journal_delta(ag, jnl, SM_AG_LOG_OP_FREE, device_offset, aligned);
-    pthread_mutex_unlock(&ag->lock);
-
-    __atomic_fetch_sub(&sm->used_bytes, aligned, __ATOMIC_RELAXED);
+    space_map_free_journal(sm, jnl, device_id, device_offset, length);
+    space_map_free_apply(sm, device_id, device_offset, length);
 } /* space_map_free */
 
 void

--- a/src/vfs/demofs/space_map.c
+++ b/src/vfs/demofs/space_map.c
@@ -639,3 +639,144 @@ space_map_read_superblock_path(
     *out = *sb;
     return 0;
 } /* space_map_read_superblock_path */
+
+int
+space_map_persist_paths(
+    struct space_map *sm,
+    char            **device_paths)
+{
+    uint32_t d, a;
+    uint64_t maxrecs = (SM_AG_LOG_SLOT_SIZE - sizeof(struct sm_ag_snap_header)) /
+        sizeof(struct sm_ag_snap_rec);
+
+    for (d = 0; d < sm->num_devices; d++) {
+        struct sm_device *dev = &sm->devices[d];
+        int               fd  = open(device_paths[d], O_WRONLY);
+
+        if (fd < 0) {
+            return -1;
+        }
+
+        for (a = 0; a < dev->num_ags; a++) {
+            struct sm_ag             *ag   = &dev->ags[a];
+            uint8_t                  *buf  = calloc(1, SM_AG_LOG_SLOT_SIZE);
+            struct sm_ag_snap_header *h    = (struct sm_ag_snap_header *) buf;
+            struct sm_ag_snap_rec    *recs =
+                (struct sm_ag_snap_rec *) (buf + sizeof(*h));
+            struct sm_extent         *ext;
+            uint32_t                  count = 0;
+            uint64_t                  payload, aligned;
+            ssize_t                   n;
+
+            pthread_mutex_lock(&ag->lock);
+            rb_tree_first(&ag->free_by_offset, ext);
+            while (ext) {
+                sm_abort_if(count >= maxrecs,
+                            "AG %u/%u snapshot overflow (%u extents)",
+                            d, a, count);
+                recs[count].offset = ext->offset;
+                recs[count].length = ext->length;
+                count++;
+                ext = rb_tree_next(&ag->free_by_offset, ext);
+            }
+            h->magic      = SM_AG_SNAP_MAGIC;
+            h->version    = SM_FORMAT_VERSION;
+            h->count      = count;
+            h->free_bytes = ag->free_bytes;
+            h->pad        = 0;
+            h->crc32      = 0;
+            pthread_mutex_unlock(&ag->lock);
+
+            payload  = sizeof(*h) + (uint64_t) count * sizeof(*recs);
+            h->crc32 = sm_crc32(buf, payload);
+            aligned  = (payload + SM_BLOCK_SIZE - 1) & ~((uint64_t) SM_BLOCK_SIZE - 1);
+
+            n = pwrite(fd, buf, aligned, ag->log_offset);
+            free(buf);
+            if (n != (ssize_t) aligned) {
+                close(fd);
+                return -1;
+            }
+        }
+
+        if (fsync(fd) != 0) {
+            close(fd);
+            return -1;
+        }
+        close(fd);
+    }
+    return 0;
+} /* space_map_persist_paths */
+
+int
+space_map_load_paths(
+    struct space_map *sm,
+    char            **device_paths)
+{
+    uint32_t d, a;
+    uint64_t free_total = 0;
+
+    for (d = 0; d < sm->num_devices; d++) {
+        struct sm_device *dev = &sm->devices[d];
+        int               fd  = open(device_paths[d], O_RDONLY);
+
+        if (fd < 0) {
+            return -1;
+        }
+
+        for (a = 0; a < dev->num_ags; a++) {
+            struct sm_ag            *ag = &dev->ags[a];
+            struct sm_ag_snap_header h;
+            struct sm_ag_snap_rec   *recs;
+            uint8_t                 *cbuf;
+            uint32_t                 i, stored, computed;
+            uint64_t                 payload;
+            ssize_t                  n;
+
+            n = pread(fd, &h, sizeof(h), ag->log_offset);
+            if (n != (ssize_t) sizeof(h) || h.magic != SM_AG_SNAP_MAGIC ||
+                h.version != SM_FORMAT_VERSION) {
+                close(fd);
+                return -1;
+            }
+
+            payload = sizeof(h) + (uint64_t) h.count * sizeof(*recs);
+            cbuf    = malloc(payload);
+            n       = pread(fd, cbuf, payload, ag->log_offset);
+            if (n != (ssize_t) payload) {
+                free(cbuf);
+                close(fd);
+                return -1;
+            }
+            stored                                     = h.crc32;
+            ((struct sm_ag_snap_header *) cbuf)->crc32 = 0;
+            computed                                   = sm_crc32(cbuf, payload);
+            if (stored != computed) {
+                free(cbuf);
+                close(fd);
+                return -1;
+            }
+            recs = (struct sm_ag_snap_rec *) (cbuf + sizeof(h));
+
+            /* Replace the default full-free tree with the snapshot. */
+            pthread_mutex_lock(&ag->lock);
+            rb_tree_destroy(&ag->free_by_offset, sm_extent_release, NULL);
+            rb_tree_init(&ag->free_by_offset);
+            for (i = 0; i < h.count; i++) {
+                struct sm_extent *ext = sm_extent_new(recs[i].offset, recs[i].length);
+
+                rb_tree_insert(&ag->free_by_offset, offset, ext);
+            }
+            ag->free_bytes = h.free_bytes;
+            pthread_mutex_unlock(&ag->lock);
+
+            free_total += h.free_bytes;
+            free(cbuf);
+        }
+        close(fd);
+    }
+
+    sm->used_bytes = sm->total_capacity > free_total ?
+        sm->total_capacity - free_total : 0;
+    return 0;
+} /* space_map_load_paths */

--- a/src/vfs/demofs/space_map.c
+++ b/src/vfs/demofs/space_map.c
@@ -556,7 +556,11 @@ int
 space_map_write_superblock_path(
     struct space_map *sm,
     const char       *device_path,
-    uint64_t          fsid)
+    uint64_t          fsid,
+    uint64_t          flags,
+    uint64_t          root_inum,
+    uint32_t          root_gen,
+    uint64_t          log_seq)
 {
     int                   fd;
     ssize_t               n;
@@ -575,6 +579,10 @@ space_map_write_superblock_path(
     sb->intent_log_device = SM_INTENT_LOG_DEVICE;
     sb->intent_log_offset = SM_INTENT_LOG_OFFSET;
     sb->intent_log_size   = SM_INTENT_LOG_SIZE;
+    sb->flags             = flags;
+    sb->root_inum         = root_inum;
+    sb->root_gen          = root_gen;
+    sb->log_seq           = log_seq;
     sb->crc32             = 0;
     sb->crc32             = sm_crc32(buf, sizeof(buf));
 

--- a/src/vfs/demofs/space_map.c
+++ b/src/vfs/demofs/space_map.c
@@ -1,0 +1,598 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#define _GNU_SOURCE
+#include <stdint.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+#include <pthread.h>
+#include <assert.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+#include "common/rbtree.h"
+#include "common/logging.h"
+
+#include "space_map.h"
+
+#ifndef container_of
+#define container_of(ptr, type, member) \
+        ((type *) ((char *) (ptr) - offsetof(type, member)))
+#endif /* ifndef container_of */
+
+#define sm_abort_if(cond, ...) \
+        chimera_abort_if(cond, "space_map", __FILE__, __LINE__, __VA_ARGS__)
+
+#define sm_info(...) \
+        chimera_info("space_map", __FILE__, __LINE__, __VA_ARGS__)
+
+/*
+ * Journal stubs.  These are the future intent-log hook points; calls land
+ * here AFTER the in-memory state has been updated.  For now the records go
+ * nowhere; replacing the body with a journal append is the next step.
+ */
+static inline void
+sm_journal_record_alloc(
+    uint32_t device_id,
+    uint64_t offset,
+    uint64_t length)
+{
+    (void) device_id;
+    (void) offset;
+    (void) length;
+} /* sm_journal_record_alloc */
+
+static inline void
+sm_journal_record_free(
+    uint32_t device_id,
+    uint64_t offset,
+    uint64_t length)
+{
+    (void) device_id;
+    (void) offset;
+    (void) length;
+} /* sm_journal_record_free */
+
+static struct sm_extent *
+sm_extent_new(
+    uint64_t offset,
+    uint64_t length)
+{
+    struct sm_extent *ext = calloc(1, sizeof(*ext));
+
+    ext->offset = offset;
+    ext->length = length;
+    return ext;
+} /* sm_extent_new */
+
+static void
+sm_extent_release(
+    struct rb_node *node,
+    void           *private_data)
+{
+    struct sm_extent *ext = container_of(node, struct sm_extent, node);
+
+    (void) private_data;
+    free(ext);
+} /* sm_extent_release */
+
+/*
+ * Initialize an AG.
+ *
+ * Layout within the AG (offsets are absolute device offsets):
+ *
+ *   [base_offset, base_offset + pre_log_reserved)    -- global reservations
+ *                                                       (e.g. superblock,
+ *                                                       intent log on AG 0
+ *                                                       of device 0)
+ *   [log_offset,  log_offset + SM_AG_LOG_SIZE)       -- this AG's space-map log
+ *   [data_base,   data_base + post_log_reserved)     -- format-time reservations
+ *                                                       at the start of the
+ *                                                       data region (e.g. the
+ *                                                       block_idx==1 inode
+ *                                                       slot on AG 0 of disk 0
+ *                                                       so root lands at
+ *                                                       inum 2)
+ *   [free_start,  base_offset + size)                -- allocatable data range
+ *
+ * `data_base` == `log_offset + SM_AG_LOG_SIZE`.
+ */
+static void
+sm_ag_init(
+    struct sm_ag *ag,
+    uint32_t      device_id,
+    uint32_t      ag_index,
+    uint64_t      base_offset,
+    uint64_t      size,
+    uint64_t      pre_log_reserved,
+    uint64_t      post_log_reserved)
+{
+    struct sm_extent *initial;
+    uint64_t          total_reserved;
+
+    ag->device_id   = device_id;
+    ag->ag_index    = ag_index;
+    ag->base_offset = base_offset;
+    ag->size        = size;
+    ag->log_offset  = base_offset + pre_log_reserved;
+    ag->log_size    = SM_AG_LOG_SIZE;
+
+    pthread_mutex_init(&ag->lock, NULL);
+    rb_tree_init(&ag->free_by_offset);
+
+    total_reserved = pre_log_reserved + SM_AG_LOG_SIZE + post_log_reserved;
+
+    if (total_reserved >= size) {
+        /* The AG is too small to hold even its own log.  This shouldn't
+         * happen for any reasonable AG size; if it does, the AG has zero
+         * usable data range. */
+        ag->free_bytes = 0;
+        return;
+    }
+
+    initial = sm_extent_new(base_offset + total_reserved,
+                            size - total_reserved);
+
+    rb_tree_insert(&ag->free_by_offset, offset, initial);
+    ag->free_bytes = size - total_reserved;
+} /* sm_ag_init */
+
+static void
+sm_ag_destroy(struct sm_ag *ag)
+{
+    rb_tree_destroy(&ag->free_by_offset, sm_extent_release, NULL);
+    pthread_mutex_destroy(&ag->lock);
+} /* sm_ag_destroy */
+
+/*
+ * Attempt to allocate `size` bytes from `ag`.  Returns 0 on success and
+ * writes the device offset (absolute) into `*r_offset`.  Returns -1 if the
+ * AG cannot satisfy the request.  Caller must hold ag->lock.
+ *
+ * First-fit walk of the by-offset tree.  An optional best-fit secondary
+ * index can be added later; the current shape supports it without changing
+ * the public API.
+ */
+static int
+sm_ag_alloc_locked(
+    struct sm_ag *ag,
+    uint64_t      size,
+    uint64_t     *r_offset)
+{
+    struct sm_extent *ext;
+
+    if (ag->free_bytes < size) {
+        return -1;
+    }
+
+    rb_tree_first(&ag->free_by_offset, ext);
+
+    while (ext) {
+        if (ext->length >= size) {
+            *r_offset = ext->offset;
+
+            if (ext->length == size) {
+                rb_tree_remove(&ag->free_by_offset, &ext->node);
+                free(ext);
+            } else {
+                /* Shrink: offset is the rb-tree key, so remove + reinsert. */
+                rb_tree_remove(&ag->free_by_offset, &ext->node);
+                ext->offset += size;
+                ext->length -= size;
+                rb_tree_insert(&ag->free_by_offset, offset, ext);
+            }
+
+            ag->free_bytes -= size;
+            return 0;
+        }
+
+        ext = rb_tree_next(&ag->free_by_offset, ext);
+    }
+
+    return -1;
+} /* sm_ag_alloc_locked */
+
+/*
+ * Return [offset, offset+length) to `ag`'s free tree, coalescing with any
+ * adjacent free neighbours.  Caller must hold ag->lock.
+ */
+static void
+sm_ag_free_locked(
+    struct sm_ag *ag,
+    uint64_t      offset,
+    uint64_t      length)
+{
+    /* Variable names avoid clashing with the rb_tree_query_floor/ceil
+     * macros, which declare locals named `floor`/`ceil`. */
+    struct sm_extent *prev_ext         = NULL;
+    struct sm_extent *next_ext         = NULL;
+    int               merged_with_prev = 0;
+
+    sm_abort_if(length == 0, "zero-length free");
+    sm_abort_if(offset < ag->base_offset ||
+                offset + length > ag->base_offset + ag->size,
+                "free out of AG bounds (offset=%lu length=%lu ag=%lu+%lu)",
+                offset, length, ag->base_offset, ag->size);
+
+    rb_tree_query_floor(&ag->free_by_offset, offset, offset, prev_ext);
+    rb_tree_query_ceil(&ag->free_by_offset, offset + length, offset, next_ext);
+
+    sm_abort_if(prev_ext && prev_ext->offset + prev_ext->length > offset,
+                "double-free or overlap at offset=%lu (prev=%lu+%lu)",
+                offset, prev_ext->offset, prev_ext->length);
+    sm_abort_if(next_ext && next_ext->offset < offset + length,
+                "double-free or overlap at offset=%lu (next=%lu+%lu)",
+                offset, next_ext->offset, next_ext->length);
+
+    if (prev_ext && prev_ext->offset + prev_ext->length == offset) {
+        prev_ext->length += length;
+        merged_with_prev  = 1;
+    }
+
+    if (merged_with_prev) {
+        if (next_ext && next_ext->offset == prev_ext->offset + prev_ext->length) {
+            prev_ext->length += next_ext->length;
+            rb_tree_remove(&ag->free_by_offset, &next_ext->node);
+            free(next_ext);
+        }
+    } else if (next_ext && next_ext->offset == offset + length) {
+        rb_tree_remove(&ag->free_by_offset, &next_ext->node);
+        next_ext->offset  = offset;
+        next_ext->length += length;
+        rb_tree_insert(&ag->free_by_offset, offset, next_ext);
+    } else {
+        struct sm_extent *fresh = sm_extent_new(offset, length);
+        rb_tree_insert(&ag->free_by_offset, offset, fresh);
+    }
+
+    ag->free_bytes += length;
+} /* sm_ag_free_locked */
+
+struct space_map *
+space_map_create(
+    const uint64_t *device_sizes,
+    uint32_t        num_devices)
+{
+    struct space_map *sm;
+    struct sm_device *dev;
+    struct sm_ag     *ag;
+    uint32_t          d, a;
+
+    sm_abort_if(num_devices == 0, "space_map_create with zero devices");
+
+    sm              = calloc(1, sizeof(*sm));
+    sm->num_devices = num_devices;
+    sm->devices     = calloc(num_devices, sizeof(*sm->devices));
+    pthread_mutex_init(&sm->lock, NULL);
+
+    for (d = 0; d < num_devices; d++) {
+        dev            = &sm->devices[d];
+        dev->device_id = d;
+        dev->size      = device_sizes[d];
+
+        dev->num_ags  = (dev->size + SM_AG_SIZE - 1) >> SM_AG_SIZE_LOG2;
+        dev->ag_rotor = 0;
+
+        sm_abort_if(dev->num_ags == 0, "device %u has zero AGs (size=%lu)",
+                    d, dev->size);
+
+        dev->ags = calloc(dev->num_ags, sizeof(*dev->ags));
+
+        sm->total_capacity += dev->size;
+
+        for (a = 0; a < dev->num_ags; a++) {
+            uint64_t base              = (uint64_t) a << SM_AG_SIZE_LOG2;
+            uint64_t span              = SM_AG_SIZE;
+            uint64_t pre_log_reserved  = 0;
+            uint64_t post_log_reserved = 0;
+
+            if (base + span > dev->size) {
+                span = dev->size - base;
+            }
+
+            if (d == SM_INTENT_LOG_DEVICE && a == 0) {
+                /* AG 0 of device 0 also hosts the superblock and the
+                 * statically-reserved intent log.  Both sit *before* the
+                 * AG's own space-map log.  Account for those bytes plus
+                 * the AG log itself so they never get handed out. */
+                pre_log_reserved = SM_SUPERBLOCK_SIZE + SM_INTENT_LOG_SIZE;
+                sm->used_bytes  += pre_log_reserved;
+
+                /* Reserve block_idx == 1 of AG 0 of disk 0 so the very
+                 * first inode allocation lands at block_idx == 2 (root
+                 * inum = 2).  block_idx == 1 is held for future bootstrap
+                 * use (e.g. an AG header). */
+                post_log_reserved = SM_BLOCK_SIZE;
+                sm->used_bytes   += post_log_reserved;
+
+                sm_abort_if(pre_log_reserved + SM_AG_LOG_SIZE +
+                            post_log_reserved > span,
+                            "device 0 AG 0 too small (%lu) to hold "
+                            "superblock+intent_log+ag_log+bootstrap (%lu)",
+                            span,
+                            pre_log_reserved + SM_AG_LOG_SIZE +
+                            post_log_reserved);
+            }
+
+            sm_abort_if(SM_AG_LOG_SIZE >= span,
+                        "AG size %lu too small to hold per-AG log %lu",
+                        span, SM_AG_LOG_SIZE);
+
+            sm->used_bytes += SM_AG_LOG_SIZE;
+
+            ag = &dev->ags[a];
+            sm_ag_init(ag, d, a, base, span,
+                       pre_log_reserved, post_log_reserved);
+        }
+    }
+
+    sm_info("Reserved intent log: device %u offset %lu size %lu",
+            (unsigned) SM_INTENT_LOG_DEVICE,
+            (uint64_t) SM_INTENT_LOG_OFFSET,
+            (uint64_t) SM_INTENT_LOG_SIZE);
+    sm_info("Per-AG log size: %lu (%u slots x %lu)",
+            (uint64_t) SM_AG_LOG_SIZE,
+            (unsigned) SM_AG_LOG_SLOT_COUNT,
+            (uint64_t) SM_AG_LOG_SLOT_SIZE);
+
+    return sm;
+} /* space_map_create */
+
+void
+space_map_destroy(struct space_map *sm)
+{
+    struct sm_device *dev;
+    uint32_t          d, a;
+
+    for (d = 0; d < sm->num_devices; d++) {
+        dev = &sm->devices[d];
+        for (a = 0; a < dev->num_ags; a++) {
+            sm_ag_destroy(&dev->ags[a]);
+        }
+        free(dev->ags);
+    }
+
+    pthread_mutex_destroy(&sm->lock);
+    free(sm->devices);
+    free(sm);
+} /* space_map_destroy */
+
+/*
+ * Attempt to reserve `want` bytes by allocating from some AG.  Walks every
+ * AG of every device starting from the rotor's current position; returns 0
+ * on success.  May return less than `want` only via the failure path; this
+ * function never returns a partial reservation.
+ */
+static int
+sm_pick_and_alloc(
+    struct space_map *sm,
+    uint64_t          want,
+    uint32_t         *r_device_id,
+    uint64_t         *r_device_offset)
+{
+    uint32_t start_dev, dev_id;
+    uint32_t d, a;
+
+    pthread_mutex_lock(&sm->lock);
+    start_dev = sm->device_rotor;
+    sm->device_rotor++;
+    if (sm->device_rotor >= sm->num_devices) {
+        sm->device_rotor = 0;
+    }
+    pthread_mutex_unlock(&sm->lock);
+
+    for (d = 0; d < sm->num_devices; d++) {
+        dev_id = (start_dev + d) % sm->num_devices;
+        struct sm_device *dev = &sm->devices[dev_id];
+        uint32_t          start_ag;
+
+        pthread_mutex_lock(&sm->lock);
+        start_ag = dev->ag_rotor;
+        dev->ag_rotor++;
+        if (dev->ag_rotor >= dev->num_ags) {
+            dev->ag_rotor = 0;
+        }
+        pthread_mutex_unlock(&sm->lock);
+
+        for (a = 0; a < dev->num_ags; a++) {
+            uint32_t      ag_idx = (start_ag + a) % dev->num_ags;
+            struct sm_ag *ag     = &dev->ags[ag_idx];
+            uint64_t      offset;
+            int           rc;
+
+            if (ag->free_bytes < want) {
+                continue;
+            }
+
+            pthread_mutex_lock(&ag->lock);
+            rc = sm_ag_alloc_locked(ag, want, &offset);
+            pthread_mutex_unlock(&ag->lock);
+
+            if (rc == 0) {
+                *r_device_id     = dev_id;
+                *r_device_offset = offset;
+                __atomic_fetch_add(&sm->used_bytes, want, __ATOMIC_RELAXED);
+                sm_journal_record_alloc(dev_id, offset, want);
+                return 0;
+            }
+        }
+    }
+
+    return -1;
+} /* sm_pick_and_alloc */
+
+int
+space_map_alloc(
+    struct space_map       *sm,
+    struct sm_thread_cache *cache,
+    uint64_t                size,
+    uint32_t               *r_device_id,
+    uint64_t               *r_device_offset)
+{
+    uint64_t need = SM_ALIGN_UP(size);
+    uint64_t want;
+    int      rc;
+
+    sm_abort_if(need == 0, "alloc of zero bytes");
+
+    if (cache->valid && cache->length >= need) {
+        *r_device_id     = cache->device_id;
+        *r_device_offset = cache->offset;
+        cache->offset   += need;
+        cache->length   -= need;
+        if (cache->length == 0) {
+            cache->valid = 0;
+        }
+        return 0;
+    }
+
+    /* Cache cannot satisfy this request.  Return the unused remainder and
+     * grab a fresh reservation. */
+    if (cache->valid) {
+        space_map_thread_cache_return(sm, cache);
+    }
+
+    want = need > SM_RESERVATION_MIN ? need : SM_RESERVATION_MIN;
+
+    /* If a reservation crosses an AG boundary it can't be contiguous, so cap
+     * the request to the AG size.  Callers requesting more than SM_AG_SIZE
+     * cannot be satisfied. */
+    if (want > SM_AG_SIZE) {
+        return -1;
+    }
+
+    rc = sm_pick_and_alloc(sm, want, &cache->device_id, &cache->offset);
+    if (rc != 0) {
+        /* Try the smaller exact size before giving up, in case fragmentation
+         * blocks the reservation but the caller's actual ask is small. */
+        if (want != need) {
+            rc = sm_pick_and_alloc(sm, need, &cache->device_id, &cache->offset);
+            if (rc == 0) {
+                cache->length = need;
+                cache->valid  = 1;
+            }
+        }
+        if (rc != 0) {
+            return rc;
+        }
+    } else {
+        cache->length = want;
+        cache->valid  = 1;
+    }
+
+    *r_device_id     = cache->device_id;
+    *r_device_offset = cache->offset;
+    cache->offset   += need;
+    cache->length   -= need;
+    if (cache->length == 0) {
+        cache->valid = 0;
+    }
+    return 0;
+} /* space_map_alloc */
+
+void
+space_map_free(
+    struct space_map *sm,
+    uint32_t          device_id,
+    uint64_t          device_offset,
+    uint64_t          length)
+{
+    struct sm_device *dev;
+    struct sm_ag     *ag;
+    uint32_t          ag_idx;
+    uint64_t          aligned = SM_ALIGN_UP(length);
+
+    if (aligned == 0) {
+        return;
+    }
+
+    sm_abort_if(device_id >= sm->num_devices,
+                "space_map_free: bad device_id %u", device_id);
+
+    dev = &sm->devices[device_id];
+
+    ag_idx = device_offset >> SM_AG_SIZE_LOG2;
+    sm_abort_if(ag_idx >= dev->num_ags,
+                "space_map_free: offset %lu past device %u",
+                device_offset, device_id);
+
+    ag = &dev->ags[ag_idx];
+
+    /* For now we forbid frees that straddle AG boundaries.  Callers that
+     * allocated through this allocator never see straddling because
+     * reservations come from a single AG.  Defensive abort if it ever
+     * happens. */
+    sm_abort_if(device_offset + aligned > ag->base_offset + ag->size,
+                "space_map_free: range crosses AG boundary "
+                "(offset=%lu length=%lu ag_base=%lu ag_size=%lu)",
+                device_offset, aligned, ag->base_offset, ag->size);
+
+    pthread_mutex_lock(&ag->lock);
+    sm_ag_free_locked(ag, device_offset, aligned);
+    pthread_mutex_unlock(&ag->lock);
+
+    __atomic_fetch_sub(&sm->used_bytes, aligned, __ATOMIC_RELAXED);
+    sm_journal_record_free(device_id, device_offset, aligned);
+} /* space_map_free */
+
+void
+space_map_thread_cache_return(
+    struct space_map       *sm,
+    struct sm_thread_cache *cache)
+{
+    if (!cache->valid || cache->length == 0) {
+        cache->valid = 0;
+        return;
+    }
+
+    space_map_free(sm, cache->device_id, cache->offset, cache->length);
+    cache->valid  = 0;
+    cache->length = 0;
+} /* space_map_thread_cache_return */
+
+int
+space_map_write_superblock_path(
+    struct space_map *sm,
+    const char       *device_path,
+    uint64_t          fsid)
+{
+    int                   fd;
+    ssize_t               n;
+    uint8_t               buf[SM_SUPERBLOCK_SIZE];
+    struct sm_superblock *sb = (struct sm_superblock *) buf;
+
+    memset(buf, 0, sizeof(buf));
+
+    sb->magic             = SM_SUPERBLOCK_MAGIC;
+    sb->version           = SM_FORMAT_VERSION;
+    sb->block_size        = SM_BLOCK_SIZE;
+    sb->ag_size           = SM_AG_SIZE;
+    sb->ag_log_size       = SM_AG_LOG_SIZE;
+    sb->fsid              = fsid;
+    sb->num_devices       = sm->num_devices;
+    sb->intent_log_device = SM_INTENT_LOG_DEVICE;
+    sb->intent_log_offset = SM_INTENT_LOG_OFFSET;
+    sb->intent_log_size   = SM_INTENT_LOG_SIZE;
+    sb->crc32             = 0; /* TODO: compute when persistence work begins */
+
+    fd = open(device_path, O_WRONLY);
+    if (fd < 0) {
+        return -1;
+    }
+
+    n = pwrite(fd, buf, sizeof(buf), SM_SUPERBLOCK_OFFSET);
+    if (n != (ssize_t) sizeof(buf)) {
+        close(fd);
+        return -1;
+    }
+
+    if (fsync(fd) != 0) {
+        close(fd);
+        return -1;
+    }
+
+    close(fd);
+    return 0;
+} /* space_map_write_superblock_path */

--- a/src/vfs/demofs/space_map.c
+++ b/src/vfs/demofs/space_map.c
@@ -575,7 +575,8 @@ space_map_write_superblock_path(
     sb->intent_log_device = SM_INTENT_LOG_DEVICE;
     sb->intent_log_offset = SM_INTENT_LOG_OFFSET;
     sb->intent_log_size   = SM_INTENT_LOG_SIZE;
-    sb->crc32             = 0; /* TODO: compute when persistence work begins */
+    sb->crc32             = 0;
+    sb->crc32             = sm_crc32(buf, sizeof(buf));
 
     fd = open(device_path, O_WRONLY);
     if (fd < 0) {
@@ -596,3 +597,45 @@ space_map_write_superblock_path(
     close(fd);
     return 0;
 } /* space_map_write_superblock_path */
+
+/*
+ * Read and validate the superblock from device 0.  Returns 0 and fills *out
+ * if a well-formed, current-version superblock with a matching CRC is present;
+ * returns -1 (no/!valid superblock -> caller should mkfs) on any mismatch.
+ */
+int
+space_map_read_superblock_path(
+    const char           *device_path,
+    struct sm_superblock *out)
+{
+    int                   fd;
+    ssize_t               n;
+    uint8_t               buf[SM_SUPERBLOCK_SIZE];
+    struct sm_superblock *sb = (struct sm_superblock *) buf;
+    uint32_t              stored, computed;
+
+    fd = open(device_path, O_RDONLY);
+    if (fd < 0) {
+        return -1;
+    }
+    n = pread(fd, buf, sizeof(buf), SM_SUPERBLOCK_OFFSET);
+    close(fd);
+    if (n != (ssize_t) sizeof(buf)) {
+        return -1;
+    }
+
+    if (sb->magic != SM_SUPERBLOCK_MAGIC || sb->version != SM_FORMAT_VERSION) {
+        return -1;
+    }
+
+    stored    = sb->crc32;
+    sb->crc32 = 0;
+    computed  = sm_crc32(buf, sizeof(buf));
+    sb->crc32 = stored;
+    if (stored != computed) {
+        return -1;
+    }
+
+    *out = *sb;
+    return 0;
+} /* space_map_read_superblock_path */

--- a/src/vfs/demofs/space_map.c
+++ b/src/vfs/demofs/space_map.c
@@ -29,31 +29,65 @@
         chimera_info("space_map", __FILE__, __LINE__, __VA_ARGS__)
 
 /*
- * Journal stubs.  These are the future intent-log hook points; calls land
- * here AFTER the in-memory state has been updated.  For now the records go
- * nowhere; replacing the body with a journal append is the next step.
+ * Append one allocation/free delta to the AG's active log slot, journaled
+ * through the current transaction (via jnl) so it rides the main redo log and
+ * is replayed on crash.  Caller holds ag->lock.  A NULL jnl (format-time or
+ * bootstrap allocations) skips logging -- those are captured in the next
+ * condensed base instead.  Deltas are appended after the condensed base in
+ * 4 KiB-aligned, 128-per-block units (no block-spanning); the delta count
+ * lives in the slot header (block 0).
+ *
+ * Runtime condensation (recycling a full delta region into a fresh base) is
+ * not yet implemented; the 4 MiB region holds ~128K deltas per AG between
+ * clean unmounts, which re-condense.  Overflow aborts (TODO).
  */
-static inline void
-sm_journal_record_alloc(
-    uint32_t device_id,
-    uint64_t offset,
-    uint64_t length)
+static void
+sm_ag_journal_delta(
+    struct sm_ag            *ag,
+    const struct sm_journal *jnl,
+    uint32_t                 op,
+    uint64_t                 offset,
+    uint64_t                 length)
 {
-    (void) device_id;
-    (void) offset;
-    (void) length;
-} /* sm_journal_record_alloc */
+    uint64_t                 slot_base, region_off, delta_byte, blk_off;
+    uint32_t                 idx, in_block;
+    struct sm_ag_log_header *h;
+    struct sm_ag_log_delta  *d;
+    void                    *blk_buf, *hdr_buf;
 
-static inline void
-sm_journal_record_free(
-    uint32_t device_id,
-    uint64_t offset,
-    uint64_t length)
-{
-    (void) device_id;
-    (void) offset;
-    (void) length;
-} /* sm_journal_record_free */
+    if (!jnl) {
+        return;
+    }
+
+    slot_base  = ag->log_offset + (uint64_t) ag->log_slot * SM_AG_LOG_SLOT_SIZE;
+    region_off = (sizeof(struct sm_ag_log_header) +
+                  (uint64_t) ag->log_base_count * sizeof(struct sm_ag_log_ext) +
+                  SM_BLOCK_SIZE - 1) & ~((uint64_t) SM_BLOCK_SIZE - 1);
+    idx = ag->log_delta_count;
+
+    delta_byte = region_off + (uint64_t) idx * sizeof(struct sm_ag_log_delta);
+    sm_abort_if(delta_byte + sizeof(struct sm_ag_log_delta) > SM_AG_LOG_SLOT_SIZE,
+                "AG %u/%u delta region full (%u deltas) -- condensation TODO",
+                ag->device_id, ag->ag_index, idx);
+
+    blk_off  = slot_base + (delta_byte & ~((uint64_t) SM_BLOCK_SIZE - 1));
+    in_block = (uint32_t) (delta_byte & (SM_BLOCK_SIZE - 1));
+
+    /* First delta in a block starts from a zeroed block; later ones modify the
+     * resident block. */
+    blk_buf   = jnl->claim_block(jnl->user, ag->device_id, blk_off, in_block == 0);
+    d         = (struct sm_ag_log_delta *) ((char *) blk_buf + in_block);
+    d->offset = offset;
+    d->length = length;
+    d->op     = op;
+    d->pad    = 0;
+    d->pad2   = 0;
+
+    hdr_buf             = jnl->claim_block(jnl->user, ag->device_id, slot_base, 0);
+    h                   = (struct sm_ag_log_header *) hdr_buf;
+    h->delta_count      = idx + 1;
+    ag->log_delta_count = idx + 1;
+} /* sm_ag_journal_delta */
 
 static struct sm_extent *
 sm_extent_new(
@@ -304,11 +338,12 @@ space_map_create(
                 pre_log_reserved = SM_SUPERBLOCK_SIZE + SM_INTENT_LOG_SIZE;
                 sm->used_bytes  += pre_log_reserved;
 
-                /* Reserve block_idx == 1 of AG 0 of disk 0 so the very
-                 * first inode allocation lands at block_idx == 2 (root
-                 * inum = 2).  block_idx == 1 is held for future bootstrap
-                 * use (e.g. an AG header). */
-                post_log_reserved = SM_BLOCK_SIZE;
+                /* Statically reserve block_idx 1 and 2 of AG 0 / disk 0.
+                 * block_idx 1 is held for a future AG header; block_idx 2 is
+                 * the root inode (inum 2), reserved (not allocated through the
+                 * allocator) so it is excluded from every condensed free set
+                 * and can never be re-handed-out after a crash. */
+                post_log_reserved = 2 * SM_BLOCK_SIZE;
                 sm->used_bytes   += post_log_reserved;
 
                 sm_abort_if(pre_log_reserved + SM_AG_LOG_SIZE +
@@ -371,10 +406,11 @@ space_map_destroy(struct space_map *sm)
  */
 static int
 sm_pick_and_alloc(
-    struct space_map *sm,
-    uint64_t          want,
-    uint32_t         *r_device_id,
-    uint64_t         *r_device_offset)
+    struct space_map        *sm,
+    const struct sm_journal *jnl,
+    uint64_t                 want,
+    uint32_t                *r_device_id,
+    uint64_t                *r_device_offset)
 {
     uint32_t start_dev, dev_id;
     uint32_t d, a;
@@ -412,13 +448,15 @@ sm_pick_and_alloc(
 
             pthread_mutex_lock(&ag->lock);
             rc = sm_ag_alloc_locked(ag, want, &offset);
+            if (rc == 0) {
+                sm_ag_journal_delta(ag, jnl, SM_AG_LOG_OP_ALLOC, offset, want);
+            }
             pthread_mutex_unlock(&ag->lock);
 
             if (rc == 0) {
                 *r_device_id     = dev_id;
                 *r_device_offset = offset;
                 __atomic_fetch_add(&sm->used_bytes, want, __ATOMIC_RELAXED);
-                sm_journal_record_alloc(dev_id, offset, want);
                 return 0;
             }
         }
@@ -429,11 +467,12 @@ sm_pick_and_alloc(
 
 int
 space_map_alloc(
-    struct space_map       *sm,
-    struct sm_thread_cache *cache,
-    uint64_t                size,
-    uint32_t               *r_device_id,
-    uint64_t               *r_device_offset)
+    struct space_map        *sm,
+    struct sm_thread_cache  *cache,
+    const struct sm_journal *jnl,
+    uint64_t                 size,
+    uint32_t                *r_device_id,
+    uint64_t                *r_device_offset)
 {
     uint64_t need = SM_ALIGN_UP(size);
     uint64_t want;
@@ -455,7 +494,7 @@ space_map_alloc(
     /* Cache cannot satisfy this request.  Return the unused remainder and
      * grab a fresh reservation. */
     if (cache->valid) {
-        space_map_thread_cache_return(sm, cache);
+        space_map_thread_cache_return(sm, jnl, cache);
     }
 
     want = need > SM_RESERVATION_MIN ? need : SM_RESERVATION_MIN;
@@ -467,12 +506,12 @@ space_map_alloc(
         return -1;
     }
 
-    rc = sm_pick_and_alloc(sm, want, &cache->device_id, &cache->offset);
+    rc = sm_pick_and_alloc(sm, jnl, want, &cache->device_id, &cache->offset);
     if (rc != 0) {
         /* Try the smaller exact size before giving up, in case fragmentation
          * blocks the reservation but the caller's actual ask is small. */
         if (want != need) {
-            rc = sm_pick_and_alloc(sm, need, &cache->device_id, &cache->offset);
+            rc = sm_pick_and_alloc(sm, jnl, need, &cache->device_id, &cache->offset);
             if (rc == 0) {
                 cache->length = need;
                 cache->valid  = 1;
@@ -498,10 +537,11 @@ space_map_alloc(
 
 void
 space_map_free(
-    struct space_map *sm,
-    uint32_t          device_id,
-    uint64_t          device_offset,
-    uint64_t          length)
+    struct space_map        *sm,
+    const struct sm_journal *jnl,
+    uint32_t                 device_id,
+    uint64_t                 device_offset,
+    uint64_t                 length)
 {
     struct sm_device *dev;
     struct sm_ag     *ag;
@@ -535,23 +575,24 @@ space_map_free(
 
     pthread_mutex_lock(&ag->lock);
     sm_ag_free_locked(ag, device_offset, aligned);
+    sm_ag_journal_delta(ag, jnl, SM_AG_LOG_OP_FREE, device_offset, aligned);
     pthread_mutex_unlock(&ag->lock);
 
     __atomic_fetch_sub(&sm->used_bytes, aligned, __ATOMIC_RELAXED);
-    sm_journal_record_free(device_id, device_offset, aligned);
 } /* space_map_free */
 
 void
 space_map_thread_cache_return(
-    struct space_map       *sm,
-    struct sm_thread_cache *cache)
+    struct space_map        *sm,
+    const struct sm_journal *jnl,
+    struct sm_thread_cache  *cache)
 {
     if (!cache->valid || cache->length == 0) {
         cache->valid = 0;
         return;
     }
 
-    space_map_free(sm, cache->device_id, cache->offset, cache->length);
+    space_map_free(sm, jnl, cache->device_id, cache->offset, cache->length);
     cache->valid  = 0;
     cache->length = 0;
 } /* space_map_thread_cache_return */

--- a/src/vfs/demofs/space_map.c
+++ b/src/vfs/demofs/space_map.c
@@ -564,6 +564,37 @@ sm_free_resolve_ag(
 } /* sm_free_resolve_ag */
 
 /*
+ * Reduce a free request to the whole blocks strictly contained in
+ * [device_offset, device_offset+length).  For an aligned offset (the common
+ * case: callers pass block-multiple lengths) this is the full range.  A
+ * sub-block, unaligned extent -- produced when DEALLOCATE / zero-range trims an
+ * extent at a non-block boundary, a mapping the read path supports via padding
+ * -- shares its partial edge blocks with the neighbouring extents carved from
+ * the same allocation, so freeing an edge could release a block another extent
+ * still maps.  Releasing only the interior is conservative (a partial edge
+ * block leaks, consistent with the filesystem's deferred-reclaim model) but
+ * never double-frees or frees a shared block.  Returns 0 if no whole block is
+ * contained (nothing to free).
+ */
+static int
+sm_free_block_range(
+    uint64_t  device_offset,
+    uint64_t  length,
+    uint64_t *r_offset,
+    uint64_t *r_length)
+{
+    uint64_t start = SM_ALIGN_UP(device_offset);
+    uint64_t end   = (device_offset + length) & ~(uint64_t) SM_BLOCK_MASK;
+
+    if (end <= start) {
+        return 0;
+    }
+    *r_offset = start;
+    *r_length = end - start;
+    return 1;
+} /* sm_free_block_range */
+
+/*
  * Journal a FREE delta into the AG's redo log without making the range
  * reusable.  The delta rides the freeing transaction's redo (so a crash
  * replays it via AG-log reconstruction), but the in-memory free is withheld
@@ -580,16 +611,16 @@ space_map_free_journal(
     uint64_t                 device_offset,
     uint64_t                 length)
 {
-    uint64_t      aligned = SM_ALIGN_UP(length);
+    uint64_t      offset, aligned;
     struct sm_ag *ag;
 
-    if (aligned == 0) {
+    if (!sm_free_block_range(device_offset, length, &offset, &aligned)) {
         return;
     }
-    ag = sm_free_resolve_ag(sm, device_id, device_offset, aligned, "space_map_free_journal");
+    ag = sm_free_resolve_ag(sm, device_id, offset, aligned, "space_map_free_journal");
 
     pthread_mutex_lock(&ag->lock);
-    sm_ag_journal_delta(ag, jnl, SM_AG_LOG_OP_FREE, device_offset, aligned);
+    sm_ag_journal_delta(ag, jnl, SM_AG_LOG_OP_FREE, offset, aligned);
     pthread_mutex_unlock(&ag->lock);
 } /* space_map_free_journal */
 
@@ -604,16 +635,16 @@ space_map_free_apply(
     uint64_t          device_offset,
     uint64_t          length)
 {
-    uint64_t      aligned = SM_ALIGN_UP(length);
+    uint64_t      offset, aligned;
     struct sm_ag *ag;
 
-    if (aligned == 0) {
+    if (!sm_free_block_range(device_offset, length, &offset, &aligned)) {
         return;
     }
-    ag = sm_free_resolve_ag(sm, device_id, device_offset, aligned, "space_map_free_apply");
+    ag = sm_free_resolve_ag(sm, device_id, offset, aligned, "space_map_free_apply");
 
     pthread_mutex_lock(&ag->lock);
-    sm_ag_free_locked(ag, device_offset, aligned);
+    sm_ag_free_locked(ag, offset, aligned);
     pthread_mutex_unlock(&ag->lock);
 
     __atomic_fetch_sub(&sm->used_bytes, aligned, __ATOMIC_RELAXED);

--- a/src/vfs/demofs/space_map.h
+++ b/src/vfs/demofs/space_map.h
@@ -71,7 +71,7 @@
  * fragmentation of a 1 GiB AG with 4 KiB blocks (~2 MiB per snapshot) with
  * comfortable headroom.
  */
-#define SM_AG_LOG_SLOT_SIZE  (4ULL << 20)                   /* 4 MiB */
+#define SM_AG_LOG_SLOT_SIZE  (4ULL << 20)  /* 4 MiB */
 #define SM_AG_LOG_SLOT_COUNT 2
 #define SM_AG_LOG_SIZE       (SM_AG_LOG_SLOT_SIZE * SM_AG_LOG_SLOT_COUNT)
 
@@ -82,7 +82,10 @@
  */
 #define SM_INTENT_LOG_DEVICE 0
 #define SM_INTENT_LOG_OFFSET SM_SUPERBLOCK_SIZE
-#define SM_INTENT_LOG_SIZE   (64ULL << 20)                  /* 64 MiB */
+#define SM_INTENT_LOG_SIZE   (64ULL << 20) /* 64 MiB */
+
+/* superblock flags */
+#define SM_SB_CLEAN          0x1ULL        /* set at clean unmount, cleared at mount */
 
 struct sm_superblock {
     uint64_t magic;
@@ -96,6 +99,12 @@ struct sm_superblock {
     uint64_t intent_log_offset;
     uint64_t intent_log_size;
     uint32_t crc32;
+    /* Mount/recovery state (covered by crc32, which is computed over the
+     * whole 4 KiB block with the crc field zeroed). */
+    uint64_t flags;
+    uint64_t root_inum;
+    uint32_t root_gen;
+    uint64_t log_seq;           /* next redo seq at clean unmount (for recovery) */
     /* Remainder of the 4 KiB block is implicit zero padding. */
 };
 
@@ -224,7 +233,11 @@ int
 space_map_write_superblock_path(
     struct space_map *sm,
     const char       *device_path,
-    uint64_t          fsid);
+    uint64_t          fsid,
+    uint64_t          flags,
+    uint64_t          root_inum,
+    uint32_t          root_gen,
+    uint64_t          log_seq);
 
 /* Read + validate the superblock from device 0; 0 on success (fills *out),
  * -1 if absent/corrupt/wrong-version (caller should mkfs). */
@@ -305,6 +318,35 @@ sm_inum_to_device_offset(
     return ag->log_offset + ag->log_size +
            (uint64_t) (block_idx - 1) * SM_BLOCK_SIZE;
 } // sm_inum_to_device_offset
+
+/*
+ * Is `inum` addressable in this space map (disk / AG / block index all in
+ * range, and the resulting block within the device)?  Used before faulting an
+ * inode block in from disk so a bogus/stale handle can't index out of bounds.
+ */
+static inline int
+sm_inum_valid(
+    const struct space_map *sm,
+    uint64_t                inum)
+{
+    uint32_t            disk, ag_idx, block_idx;
+    const struct sm_ag *ag;
+    uint64_t            off;
+
+    if (inum == 0) {
+        return 0;
+    }
+    sm_inum_decode(inum, &disk, &ag_idx, &block_idx);
+    if (disk >= sm->num_devices || block_idx == 0) {
+        return 0;
+    }
+    if (ag_idx >= sm->devices[disk].num_ags) {
+        return 0;
+    }
+    ag  = &sm->devices[disk].ags[ag_idx];
+    off = ag->log_offset + ag->log_size + (uint64_t) (block_idx - 1) * SM_BLOCK_SIZE;
+    return off + SM_BLOCK_SIZE <= ag->base_offset + ag->size;
+} // sm_inum_valid
 
 /*
  * Inverse of sm_inum_to_device_offset: given a freshly-allocated block at

--- a/src/vfs/demofs/space_map.h
+++ b/src/vfs/demofs/space_map.h
@@ -1,0 +1,257 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#pragma once
+
+#include <stdint.h>
+#include <pthread.h>
+
+#include "common/rbtree.h"
+
+/*
+ * Space map allocator for demofs.
+ *
+ * Each block device is divided into fixed-size allocation groups (AGs).
+ * Each AG owns an in-memory red-black tree of free extents keyed by
+ * device offset, protected by its own mutex.  Allocations come from a
+ * per-thread reservation cache that is refilled in chunks from an AG,
+ * so the per-allocation common case is lock-free.
+ *
+ * All state is in memory.  Mutating operations call
+ * sm_journal_record_alloc / sm_journal_record_free stubs that the future
+ * intent log will replace; this is where on-disk durability hooks in.
+ */
+
+#define SM_BLOCK_SHIFT       12
+#define SM_BLOCK_SIZE        (1ULL << SM_BLOCK_SHIFT)
+#define SM_BLOCK_MASK        (SM_BLOCK_SIZE - 1)
+
+#define SM_AG_SIZE_LOG2      30                             /* 1 GiB */
+#define SM_AG_SIZE           (1ULL << SM_AG_SIZE_LOG2)
+#define SM_AG_OFFSET_MASK    (SM_AG_SIZE - 1)
+
+#define SM_SUPERBLOCK_OFFSET 0
+#define SM_SUPERBLOCK_SIZE   4096
+#define SM_SUPERBLOCK_MAGIC  0x4D5346534B534944ULL          /* "DISKSFSM" */
+#define SM_FORMAT_VERSION    1
+
+#define SM_RESERVATION_MIN   (1ULL << 20)                   /* 1 MiB */
+
+#define SM_ALIGN_UP(x) (((x) + SM_BLOCK_MASK) & ~SM_BLOCK_MASK)
+
+/*
+ * Inode-number encoding.  A 64-bit inum is a (disk, ag, block_idx) tuple
+ * that locates a 4 KiB inode block on storage with no further indirection.
+ *
+ *     bits 63..56  disk_id    (256 disks max)
+ *     bits 55..32  ag_index   (16 M AGs / disk)
+ *     bits 31.. 0  block_idx  (1-based offset into the AG's data region)
+ *
+ * block_idx == 0 (i.e. the entire inum == 0) is reserved as "invalid".
+ * The first usable inode in any AG is at block_idx == 1; for AG 0 of disk
+ * 0 we reserve block_idx == 1 at format time so the very first allocation
+ * lands at block_idx == 2 (= inum 2 = the root inode).
+ */
+#define SM_INUM_INDEX_BITS   32
+#define SM_INUM_AG_BITS      24
+#define SM_INUM_DISK_BITS    8
+
+#define SM_INUM_INDEX_MASK   ((1ULL << SM_INUM_INDEX_BITS) - 1)
+#define SM_INUM_AG_MASK      ((1ULL << SM_INUM_AG_BITS)    - 1)
+#define SM_INUM_DISK_MASK    ((1ULL << SM_INUM_DISK_BITS)  - 1)
+
+#define SM_INUM_AG_SHIFT     SM_INUM_INDEX_BITS
+#define SM_INUM_DISK_SHIFT   (SM_INUM_INDEX_BITS + SM_INUM_AG_BITS)
+
+/*
+ * Each AG carves a fixed prefix off the front of its data range for its
+ * own space-map log.  The log is double-buffered (slot A + slot B) so
+ * condensation can ping-pong atomically.  Sized for the worst-case
+ * fragmentation of a 1 GiB AG with 4 KiB blocks (~2 MiB per snapshot) with
+ * comfortable headroom.
+ */
+#define SM_AG_LOG_SLOT_SIZE  (4ULL << 20)                   /* 4 MiB */
+#define SM_AG_LOG_SLOT_COUNT 2
+#define SM_AG_LOG_SIZE       (SM_AG_LOG_SLOT_SIZE * SM_AG_LOG_SLOT_COUNT)
+
+/*
+ * Statically-reserved intent log region.  Lives on device 0 right after
+ * the superblock; its exact location is also recorded in the superblock
+ * so future format versions can move it.  Carved out of AG 0 of device 0.
+ */
+#define SM_INTENT_LOG_DEVICE 0
+#define SM_INTENT_LOG_OFFSET SM_SUPERBLOCK_SIZE
+#define SM_INTENT_LOG_SIZE   (64ULL << 20)                  /* 64 MiB */
+
+struct sm_superblock {
+    uint64_t magic;
+    uint32_t version;
+    uint32_t block_size;
+    uint64_t ag_size;
+    uint64_t ag_log_size;
+    uint64_t fsid;
+    uint32_t num_devices;
+    uint32_t intent_log_device;
+    uint64_t intent_log_offset;
+    uint64_t intent_log_size;
+    uint32_t crc32;
+    /* Remainder of the 4 KiB block is implicit zero padding. */
+};
+
+struct sm_extent {
+    struct rb_node node;
+    uint64_t       offset;
+    uint64_t       length;
+};
+
+struct sm_ag {
+    uint32_t        device_id;
+    uint32_t        ag_index;
+    uint64_t        base_offset;
+    uint64_t        size;
+    uint64_t        log_offset;      /* absolute device offset of this AG's log */
+    uint64_t        log_size;        /* total log bytes (both slots) */
+    uint64_t        free_bytes;
+    struct rb_tree  free_by_offset;
+    pthread_mutex_t lock;
+};
+
+struct sm_device {
+    uint32_t      device_id;
+    uint64_t      size;
+    uint32_t      num_ags;
+    uint32_t      ag_rotor;
+    struct sm_ag *ags;
+};
+
+struct space_map {
+    struct sm_device *devices;
+    uint32_t          num_devices;
+    uint32_t          device_rotor;
+    uint64_t          total_capacity;
+    uint64_t          used_bytes;     /* atomic accounting for statfs */
+    pthread_mutex_t   lock;           /* protects rotors and journaled writes */
+};
+
+struct sm_thread_cache {
+    uint32_t device_id;
+    uint64_t offset;
+    uint64_t length;
+    int      valid;
+};
+
+struct space_map *
+space_map_create(
+    const uint64_t *device_sizes,
+    uint32_t        num_devices);
+
+void
+space_map_destroy(
+    struct space_map *sm);
+
+int
+space_map_alloc(
+    struct space_map       *sm,
+    struct sm_thread_cache *cache,
+    uint64_t                size,
+    uint32_t               *r_device_id,
+    uint64_t               *r_device_offset);
+
+void
+space_map_free(
+    struct space_map *sm,
+    uint32_t          device_id,
+    uint64_t          device_offset,
+    uint64_t          length);
+
+void
+space_map_thread_cache_return(
+    struct space_map       *sm,
+    struct sm_thread_cache *cache);
+
+/*
+ * Synchronously write a stub superblock to offset 0 of `device_path` by
+ * opening the file directly with pwrite + fsync.  Done at format time
+ * (before evpl claims the device) so we avoid any reentrancy with the
+ * VFS dispatch loop.
+ */
+int
+space_map_write_superblock_path(
+    struct space_map *sm,
+    const char       *device_path,
+    uint64_t          fsid);
+
+static inline uint64_t
+space_map_total_capacity(const struct space_map *sm)
+{
+    return sm->total_capacity;
+} // space_map_total_capacity
+
+static inline uint64_t
+space_map_used_bytes(const struct space_map *sm)
+{
+    return __atomic_load_n(&sm->used_bytes, __ATOMIC_RELAXED);
+} // space_map_used_bytes
+
+static inline uint64_t
+sm_inum_make(
+    uint32_t disk,
+    uint32_t ag,
+    uint32_t idx)
+{
+    return ((uint64_t) (disk & SM_INUM_DISK_MASK) << SM_INUM_DISK_SHIFT) |
+           ((uint64_t) (ag   & SM_INUM_AG_MASK) << SM_INUM_AG_SHIFT)   |
+           ((uint64_t) (idx  & SM_INUM_INDEX_MASK));
+} // sm_inum_make
+
+static inline void
+sm_inum_decode(
+    uint64_t  inum,
+    uint32_t *r_disk,
+    uint32_t *r_ag,
+    uint32_t *r_idx)
+{
+    *r_idx  = (uint32_t) (inum & SM_INUM_INDEX_MASK);
+    *r_ag   = (uint32_t) ((inum >> SM_INUM_AG_SHIFT)   & SM_INUM_AG_MASK);
+    *r_disk = (uint32_t) ((inum >> SM_INUM_DISK_SHIFT) & SM_INUM_DISK_MASK);
+} // sm_inum_decode
+
+/*
+ * Resolve an inum to its on-disk location.  Returns the device offset of
+ * the inode's 4 KiB block and stores the disk id in *r_disk.  The caller
+ * must ensure inum != 0.
+ */
+static inline uint64_t
+sm_inum_to_device_offset(
+    const struct space_map *sm,
+    uint64_t                inum,
+    uint32_t               *r_disk)
+{
+    uint32_t            disk, ag_idx, block_idx;
+    const struct sm_ag *ag;
+
+    sm_inum_decode(inum, &disk, &ag_idx, &block_idx);
+    ag      = &sm->devices[disk].ags[ag_idx];
+    *r_disk = disk;
+    return ag->log_offset + ag->log_size +
+           (uint64_t) (block_idx - 1) * SM_BLOCK_SIZE;
+} // sm_inum_to_device_offset
+
+/*
+ * Inverse of sm_inum_to_device_offset: given a freshly-allocated block at
+ * (disk, offset), compute the inum that addresses it.
+ */
+static inline uint64_t
+sm_inum_from_device_offset(
+    const struct space_map *sm,
+    uint32_t                disk,
+    uint64_t                offset)
+{
+    uint32_t            ag_idx    = (uint32_t) (offset >> SM_AG_SIZE_LOG2);
+    const struct sm_ag *ag        = &sm->devices[disk].ags[ag_idx];
+    uint64_t            data_base = ag->log_offset + ag->log_size;
+    uint32_t            block_idx = (uint32_t) ((offset - data_base) / SM_BLOCK_SIZE) + 1;
+
+    return sm_inum_make(disk, ag_idx, block_idx);
+} // sm_inum_from_device_offset

--- a/src/vfs/demofs/space_map.h
+++ b/src/vfs/demofs/space_map.h
@@ -105,11 +105,31 @@ struct sm_ag_log_ext {          /* condensed base free extent */
     uint64_t length;
 };
 
+/* 32 bytes so 128 deltas tile a 4 KiB block exactly (no block-spanning). */
 struct sm_ag_log_delta {
     uint64_t offset;
     uint64_t length;
     uint32_t op;
     uint32_t pad;
+    uint64_t pad2;
+};
+
+#define SM_AG_LOG_DELTAS_PER_BLOCK (SM_BLOCK_SIZE / sizeof(struct sm_ag_log_delta))
+
+/*
+ * Journal bridge: space_map calls back into demofs to fetch the 4 KiB AG-log
+ * block at (device_id, device_offset), pinned into the current transaction so
+ * the delta it writes rides the main redo log.  is_new starts from a zeroed
+ * block (first use of a delta block) rather than reading disk.  A NULL journal
+ * (e.g. format-time or bootstrap allocations) skips delta logging.
+ */
+struct sm_journal {
+    void *(*claim_block)(
+        void    *user,
+        uint32_t device_id,
+        uint64_t device_offset,
+        int      is_new);
+    void *user;
 };
 
 /*
@@ -227,23 +247,26 @@ space_map_destroy(
 
 int
 space_map_alloc(
-    struct space_map       *sm,
-    struct sm_thread_cache *cache,
-    uint64_t                size,
-    uint32_t               *r_device_id,
-    uint64_t               *r_device_offset);
+    struct space_map        *sm,
+    struct sm_thread_cache  *cache,
+    const struct sm_journal *jnl,
+    uint64_t                 size,
+    uint32_t                *r_device_id,
+    uint64_t                *r_device_offset);
 
 void
 space_map_free(
-    struct space_map *sm,
-    uint32_t          device_id,
-    uint64_t          device_offset,
-    uint64_t          length);
+    struct space_map        *sm,
+    const struct sm_journal *jnl,
+    uint32_t                 device_id,
+    uint64_t                 device_offset,
+    uint64_t                 length);
 
 void
 space_map_thread_cache_return(
-    struct space_map       *sm,
-    struct sm_thread_cache *cache);
+    struct space_map        *sm,
+    const struct sm_journal *jnl,
+    struct sm_thread_cache  *cache);
 
 /*
  * Synchronously write a stub superblock to offset 0 of `device_path` by

--- a/src/vfs/demofs/space_map.h
+++ b/src/vfs/demofs/space_map.h
@@ -262,6 +262,23 @@ space_map_free(
     uint64_t                 device_offset,
     uint64_t                 length);
 
+/* Pending free: journal the FREE delta now (rides the txn redo), apply the
+ * in-memory free only once that txn is durable. */
+void
+space_map_free_journal(
+    struct space_map        *sm,
+    const struct sm_journal *jnl,
+    uint32_t                 device_id,
+    uint64_t                 device_offset,
+    uint64_t                 length);
+
+void
+space_map_free_apply(
+    struct space_map *sm,
+    uint32_t          device_id,
+    uint64_t          device_offset,
+    uint64_t          length);
+
 void
 space_map_thread_cache_return(
     struct space_map        *sm,

--- a/src/vfs/demofs/space_map.h
+++ b/src/vfs/demofs/space_map.h
@@ -128,6 +128,27 @@ struct sm_extent {
     uint64_t       length;
 };
 
+/*
+ * On-disk free-space snapshot, written to slot A of each AG's log region at
+ * clean unmount and reloaded at mount.  Header + a packed array of free
+ * extents (absolute device offsets) covering exactly that AG.
+ */
+#define SM_AG_SNAP_MAGIC 0x50414E53534B4944ULL          /* "DIKSSNAP" */
+
+struct sm_ag_snap_header {
+    uint64_t magic;
+    uint32_t version;
+    uint32_t count;     /* number of free-extent records following */
+    uint64_t free_bytes;
+    uint32_t crc32;     /* over header (crc32=0) + the records */
+    uint32_t pad;
+};
+
+struct sm_ag_snap_rec {
+    uint64_t offset;
+    uint64_t length;
+};
+
 struct sm_ag {
     uint32_t        device_id;
     uint32_t        ag_index;
@@ -211,6 +232,23 @@ int
 space_map_read_superblock_path(
     const char           *device_path,
     struct sm_superblock *out);
+
+/*
+ * Persist the free-space map to each AG's on-disk log slot (clean unmount),
+ * and reload it (mount).  device_paths[d] is the path of device d.  persist
+ * returns 0 on success; load returns 0 if every AG's snapshot validated and
+ * the in-memory free trees were rebuilt from them, -1 otherwise (caller
+ * should treat the filesystem as needing mkfs / recovery).
+ */
+int
+space_map_persist_paths(
+    struct space_map *sm,
+    char            **device_paths);
+
+int
+space_map_load_paths(
+    struct space_map *sm,
+    char            **device_paths);
 
 static inline uint64_t
 space_map_total_capacity(const struct space_map *sm)

--- a/src/vfs/demofs/space_map.h
+++ b/src/vfs/demofs/space_map.h
@@ -76,6 +76,43 @@
 #define SM_AG_LOG_SIZE       (SM_AG_LOG_SLOT_SIZE * SM_AG_LOG_SLOT_COUNT)
 
 /*
+ * On-disk per-AG allocation log.  Each slot begins with this header, followed
+ * by `base_count` condensed free-extent records (the free set at the last
+ * condensation) and then `delta_count` allocation/free delta records appended
+ * since.  The free set is reconstructed at mount as base + replayed deltas.
+ * `generation` selects the live slot (highest valid wins); condensation
+ * rewrites the *other* slot at generation+1 and switches.  Integrity of the
+ * slot's 4 KiB blocks is provided by the main intent log (every block that a
+ * delta or condensation touches rides a redo record), so the header carries
+ * no separate checksum -- a torn condensation simply leaves the older slot
+ * live.
+ */
+#define SM_AG_LOG_MAGIC      0x474F4C47414B5344ULL     /* "DSKAGLOG" */
+
+#define SM_AG_LOG_OP_ALLOC   0u /* [offset,len) was handed out: remove from free */
+#define SM_AG_LOG_OP_FREE    1u /* [offset,len) was returned:   add to free */
+
+struct sm_ag_log_header {
+    uint64_t magic;
+    uint64_t generation;
+    uint32_t base_count;
+    uint32_t delta_count;
+    uint64_t reserved;
+};
+
+struct sm_ag_log_ext {          /* condensed base free extent */
+    uint64_t offset;
+    uint64_t length;
+};
+
+struct sm_ag_log_delta {
+    uint64_t offset;
+    uint64_t length;
+    uint32_t op;
+    uint32_t pad;
+};
+
+/*
  * Statically-reserved intent log region.  Lives on device 0 right after
  * the superblock; its exact location is also recorded in the superblock
  * so future format versions can move it.  Carved out of AG 0 of device 0.
@@ -137,27 +174,6 @@ struct sm_extent {
     uint64_t       length;
 };
 
-/*
- * On-disk free-space snapshot, written to slot A of each AG's log region at
- * clean unmount and reloaded at mount.  Header + a packed array of free
- * extents (absolute device offsets) covering exactly that AG.
- */
-#define SM_AG_SNAP_MAGIC 0x50414E53534B4944ULL          /* "DIKSSNAP" */
-
-struct sm_ag_snap_header {
-    uint64_t magic;
-    uint32_t version;
-    uint32_t count;     /* number of free-extent records following */
-    uint64_t free_bytes;
-    uint32_t crc32;     /* over header (crc32=0) + the records */
-    uint32_t pad;
-};
-
-struct sm_ag_snap_rec {
-    uint64_t offset;
-    uint64_t length;
-};
-
 struct sm_ag {
     uint32_t        device_id;
     uint32_t        ag_index;
@@ -168,6 +184,12 @@ struct sm_ag {
     uint64_t        free_bytes;
     struct rb_tree  free_by_offset;
     pthread_mutex_t lock;
+
+    /* On-disk allocation-log state (protected by lock). */
+    uint32_t        log_slot;        /* active slot index (0 or 1) */
+    uint64_t        log_generation;  /* generation of the active slot */
+    uint32_t        log_base_count;  /* condensed base extents in the active slot */
+    uint32_t        log_delta_count; /* deltas appended since the last condense */
 };
 
 struct sm_device {

--- a/src/vfs/demofs/space_map.h
+++ b/src/vfs/demofs/space_map.h
@@ -99,6 +99,29 @@ struct sm_superblock {
     /* Remainder of the 4 KiB block is implicit zero padding. */
 };
 
+/*
+ * IEEE CRC-32 (bitwise; used for the superblock and, later, intent-log redo
+ * records).  Adequate for these low-frequency / one-record-at-a-time paths.
+ */
+static inline uint32_t
+sm_crc32(
+    const void *data,
+    size_t      len)
+{
+    const uint8_t *p   = data;
+    uint32_t       crc = 0xFFFFFFFFu;
+    size_t         i;
+    int            k;
+
+    for (i = 0; i < len; i++) {
+        crc ^= p[i];
+        for (k = 0; k < 8; k++) {
+            crc = (crc >> 1) ^ (0xEDB88320u & (uint32_t) (-(int32_t) (crc & 1)));
+        }
+    }
+    return ~crc;
+} /* sm_crc32 */
+
 struct sm_extent {
     struct rb_node node;
     uint64_t       offset;
@@ -181,6 +204,13 @@ space_map_write_superblock_path(
     struct space_map *sm,
     const char       *device_path,
     uint64_t          fsid);
+
+/* Read + validate the superblock from device 0; 0 on success (fills *out),
+ * -1 if absent/corrupt/wrong-version (caller should mkfs). */
+int
+space_map_read_superblock_path(
+    const char           *device_path,
+    struct sm_superblock *out);
 
 static inline uint64_t
 space_map_total_capacity(const struct space_map *sm)


### PR DESCRIPTION
This branch turns `demofs` into a persistent, crash-consistent on-disk filesystem — an async, journaled VFS backend — built up over the commits on `diskfs`.

## What's here

**On-disk structure + async engine**
- Per-inode on-disk b+tree (dirents, extents, symlink targets) with split/merge/join, driven by a fully async op machinery (block waiter + doorbell + resumable op driver). Every VFS entry point (lookup, readdir, read, write/RMW, setattr/truncate, seek, mkdir/mknod/open/symlink/link/remove/rename) is converted to async b+tree ops.
- Log-structured AG space allocator (condense + reconstruct); per-transaction allocator deltas are journaled through the redo log (crash-safe allocator).

**Durability / crash recovery**
- Write-ahead intent log (full-block redo) with XXH3-128 per-record checksums + embedded tail; synchronous replay on mount; real superblock with CRC + clean/unclean detection. File data is written to its home location before the metadata transaction commits, and the inode write lock is held until the record is durable (dirty blocks are never visible to another thread before the log protects them).
- Tail-pusher pushes committed block images home and trims the log.

**Caches + eviction**
- Block cache: 256 shards, fixed pre-allocated pool with LRU recycling, provisioned above the journal so it never blocks (asserts on exhaustion rather than deadlocking).
- Inode cache: per-shard LRU eviction of idle inodes (recycle + re-fault), with async flag-based inode locks that suspend the operation rather than block the worker.

**Zero-copy hot path + COW**
- Block buffers are SHARED evpl iovecs; the intent logger and tail-pusher reference them zero-copy — a block image is copied only when a writer forks a still-referenced LOGGED block (COW) — with a streaming-checksummed scatter-gather on-log record format.

**Metadata space reclaim**
- Pending free-on-commit (a freed range's delta is journaled, but the in-memory free is withheld until the txn is durable). b+tree shrink reclaims merged node blocks; small deleted inodes reclaim inline; large deleted inodes are reclaimed by a background incremental drainer (bounded batches per transaction) backed by a durable orphan-list inode for crash-safe resume.

## Validation
fsx (truncate / eviction / COW churn) and the demofs ctest suite pass under ASan, modulo the pre-existing NFS4-layer flakes noted below; remount/recovery is clean.

## Known follow-ups (intended for parallel work)
- **Durability barrier — highest priority.** Writes currently complete from the device's volatile cache: there is no fsync/FUA/barrier (devices are O_DIRECT and the `sync` arg to the block layer is ignored). So diskfs is crash-*consistent* against process crashes (kill -9, daemon restart) but **not durable against power loss**. Needs a flush/FUA at journal commit and before log trim, with group commit.
- I/O errors currently abort the daemon instead of returning EIO and staying mountable.
- Transaction abort does not roll back in-memory allocator *alloc* deltas (frees are already pending-on-commit).
- Incremental-drainer crash-resume (the orphans-found branch) is built on validated pieces but lacks a persistent-device crash-injection test harness; the `DEMOFS_DRAIN_DISABLE` knob is in place to drive one.
- Deleted-inode in-memory struct leak (the space is reclaimed; the struct is not); block-buffer fragmentation (evpl 2 MiB sub-allocation vs 4 KiB blocks); inode-cache hard-cap waiter.
- Pre-existing NFS4-layer flakes (`cthon`/`nametest`/`rewinddir` on `*_nfs4_demofs_*`) — confirmed independent of this work.
