### PR TITLE
nfs: enforce open deny modes on io

### DIFF
--- a/src/server/nfs/nfs4_proc_read.c
+++ b/src/server/nfs/nfs4_proc_read.c
@@ -5,6 +5,7 @@
 #include "nfs4_procs.h"
 #include "server/server.h"
 #include "nfs4_status.h"
+#include "nfs4_session.h"
 #include "nfs4_state.h"
 #include "vfs/vfs_procs.h"
 #include "vfs/vfs_release.h"
@@ -102,6 +103,7 @@ chimera_nfs4_read(
     void                           *state_void;
     uint8_t                         state_type;
     struct chimera_vfs_open_handle *state_handle;
+    struct nfs_open_state          *open_state;
     struct evpl_iovec              *iov;
     nfsstat4                        status;
 
@@ -121,6 +123,19 @@ chimera_nfs4_read(
             res->status = NFS4ERR_NOFILEHANDLE;
             chimera_nfs4_compound_complete(req, NFS4_OK);
             return;
+        }
+
+        if (req->session && req->session->client_unified) {
+            status = nfs_client_check_io_denied(req->session->client_unified,
+                                                NULL,
+                                                req->fh,
+                                                req->fhlen,
+                                                OPEN4_SHARE_ACCESS_READ);
+            if (status != NFS4_OK) {
+                res->status = status;
+                chimera_nfs4_compound_complete(req, res->status);
+                return;
+            }
         }
 
         chimera_vfs_open_fh(thread->vfs_thread, &req->cred,
@@ -161,9 +176,21 @@ chimera_nfs4_read(
     }
 
     if (state_type == NFS4_SLOT_TYPE_OPEN) {
-        state_handle = ((struct nfs_open_state *) state_void)->handle;
+        open_state   = state_void;
+        state_handle = open_state->handle;
     } else {
+        open_state   = ((struct nfs_lock_state *) state_void)->open_state;
         state_handle = ((struct nfs_lock_state *) state_void)->handle;
+    }
+
+    status = nfs_open_state_check_io_denied(open_state,
+                                            OPEN4_SHARE_ACCESS_READ);
+    if (status != NFS4_OK) {
+        nfs_state_table_release(table, state_void, state_type,
+                                thread->vfs_thread);
+        res->status = status;
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
     }
 
     req->nfs_state_ref  = state_void;

--- a/src/server/nfs/nfs4_proc_write.c
+++ b/src/server/nfs/nfs4_proc_write.c
@@ -5,6 +5,7 @@
 #include "nfs4_procs.h"
 #include "server/server.h"
 #include "nfs4_status.h"
+#include "nfs4_session.h"
 #include "nfs4_state.h"
 #include "vfs/vfs_procs.h"
 #include "vfs/vfs_release.h"
@@ -107,6 +108,7 @@ chimera_nfs4_write(
     void                           *state_void;
     uint8_t                         state_type;
     struct chimera_vfs_open_handle *state_handle;
+    struct nfs_open_state          *open_state;
     nfsstat4                        status;
 
     req->nfs_state_ref = NULL;
@@ -140,6 +142,21 @@ chimera_nfs4_write(
             evpl_iovecs_release(thread->evpl, args->data.iov, args->data.niov);
             chimera_nfs4_compound_complete(req, NFS4_OK);
             return;
+        }
+
+        if (req->session && req->session->client_unified) {
+            status = nfs_client_check_io_denied(req->session->client_unified,
+                                                NULL,
+                                                req->fh,
+                                                req->fhlen,
+                                                OPEN4_SHARE_ACCESS_WRITE);
+            if (status != NFS4_OK) {
+                res->status = status;
+                evpl_iovecs_release(thread->evpl, args->data.iov,
+                                    args->data.niov);
+                chimera_nfs4_compound_complete(req, res->status);
+                return;
+            }
         }
 
         chimera_vfs_open_fh(thread->vfs_thread, &req->cred,
@@ -182,9 +199,22 @@ chimera_nfs4_write(
     }
 
     if (state_type == NFS4_SLOT_TYPE_OPEN) {
-        state_handle = ((struct nfs_open_state *) state_void)->handle;
+        open_state   = state_void;
+        state_handle = open_state->handle;
     } else {
+        open_state   = ((struct nfs_lock_state *) state_void)->open_state;
         state_handle = ((struct nfs_lock_state *) state_void)->handle;
+    }
+
+    status = nfs_open_state_check_io_denied(open_state,
+                                            OPEN4_SHARE_ACCESS_WRITE);
+    if (status != NFS4_OK) {
+        nfs_state_table_release(table, state_void, state_type,
+                                thread->vfs_thread);
+        res->status = status;
+        evpl_iovecs_release(thread->evpl, args->data.iov, args->data.niov);
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
     }
 
     req->nfs_state_ref  = state_void;

--- a/src/server/nfs/nfs4_state.c
+++ b/src/server/nfs/nfs4_state.c
@@ -831,6 +831,59 @@ nfs_client_check_share_conflict(
     return status;
 } /* nfs_client_check_share_conflict */
 
+nfsstat4
+nfs_client_check_io_denied(
+    struct nfs_client     *client,
+    struct nfs_open_owner *requesting_owner,
+    const uint8_t         *fh,
+    uint16_t               fh_len,
+    uint32_t               requested_access)
+{
+    struct nfs_open_owner *oo, *oo_tmp;
+    nfsstat4               status           = NFS4_OK;
+
+    if (fh_len > NFS4_FHSIZE) {
+        return NFS4ERR_BAD_STATEID;
+    }
+
+    pthread_mutex_lock(&client->lock);
+
+    HASH_ITER(hh, client->open_owners_by_str, oo, oo_tmp)
+    {
+        struct nfs_open_state *peer = NULL;
+
+        if (oo == requesting_owner) {
+            continue;
+        }
+
+        pthread_mutex_lock(&oo->lock);
+        HASH_FIND(hh, oo->states_by_fh, fh, fh_len, peer);
+        if (peer && (peer->share_deny & requested_access)) {
+            status = NFS4ERR_LOCKED;
+        }
+        pthread_mutex_unlock(&oo->lock);
+
+        if (status != NFS4_OK) {
+            break;
+        }
+    }
+
+    pthread_mutex_unlock(&client->lock);
+    return status;
+} /* nfs_client_check_io_denied */
+
+nfsstat4
+nfs_open_state_check_io_denied(
+    struct nfs_open_state *requesting_state,
+    uint32_t               requested_access)
+{
+    return nfs_client_check_io_denied(requesting_state->owner->client,
+                                      requesting_state->owner,
+                                      requesting_state->fh,
+                                      requesting_state->fh_len,
+                                      requested_access);
+} /* nfs_open_state_check_io_denied */
+
 void
 nfs_open_state_coalesce(
     struct nfs_open_state  *state,

--- a/src/server/nfs/nfs4_state.c
+++ b/src/server/nfs/nfs4_state.c
@@ -840,7 +840,7 @@ nfs_client_check_io_denied(
     uint32_t               requested_access)
 {
     struct nfs_open_owner *oo, *oo_tmp;
-    nfsstat4               status           = NFS4_OK;
+    nfsstat4               status = NFS4_OK;
 
     if (fh_len > NFS4_FHSIZE) {
         return NFS4ERR_BAD_STATEID;

--- a/src/server/nfs/nfs4_state.h
+++ b/src/server/nfs/nfs4_state.h
@@ -603,6 +603,22 @@ nfs_client_check_share_conflict(
     uint32_t               requested_access,
     uint32_t               requested_deny);
 
+/* Check whether I/O through `requesting_state` conflicts with another
+ * open_owner's deny bits on the same file.  Returns NFS4ERR_LOCKED for
+ * denied READ/WRITE operations, as required by RFC 7530 §16.25. */
+SYMBOL_EXPORT nfsstat4
+nfs_open_state_check_io_denied(
+    struct nfs_open_state *requesting_state,
+    uint32_t               requested_access);
+
+SYMBOL_EXPORT nfsstat4
+nfs_client_check_io_denied(
+    struct nfs_client     *client,
+    struct nfs_open_owner *requesting_owner,
+    const uint8_t         *fh,
+    uint16_t               fh_len,
+    uint32_t               requested_access);
+
 /* Re-open: merge share bits onto an existing state, bump its seqid, and
  * write the (now-updated) stateid to `out_stateid`. */
 SYMBOL_EXPORT void
@@ -729,4 +745,3 @@ nfs_client_touch(struct nfs_client *client)
     atomic_store_explicit((_Atomic uint64_t *) &client->last_touch_ns,
                           nfs_lease_now_ns(), memory_order_relaxed);
 } /* nfs_client_touch */
-


### PR DESCRIPTION
## Summary
- add an NFSv4 share-deny check for READ and WRITE
- return NFS4ERR_LOCKED when peer OPEN deny bits block special-stateid or open/lock-stateid I/O
- reuse the implicit v4.0 session client for all-zero stateid checks

## Testing
- cmake --build build --target chimera
- PYNFS_TIMEOUT=300 ctest --test-dir build -R 'chimera/pynfs/open_memfs_nfs4\.0$' --output-on-failure
  - OPEN23 and OPEN27 now pass
  - the suite still reports unrelated OPEN20 and OPEN4 failures