### PR TITLE
nfs: fix memfs open permission and exclusive verifier

### DIFF
--- a/src/server/nfs/nfs4_proc_open.c
+++ b/src/server/nfs/nfs4_proc_open.c
@@ -711,20 +711,20 @@ chimera_nfs4_open_parent_complete(
                  * (bytes 4-7), which is the same strategy used by Linux nfsd. */
                 attr->va_set_mask |= CHIMERA_VFS_ATTR_ATIME | CHIMERA_VFS_ATTR_MTIME;
                 memcpy(&verf_part, args->openhow.how.ch_createboth.cva_verf, 4);
-                attr->va_atime.tv_sec = verf_part;
+                attr->va_atime.tv_sec  = verf_part;
                 attr->va_atime.tv_nsec = 0;
                 memcpy(&verf_part, args->openhow.how.ch_createboth.cva_verf + 4, 4);
-                attr->va_mtime.tv_sec = verf_part;
+                attr->va_mtime.tv_sec  = verf_part;
                 attr->va_mtime.tv_nsec = 0;
                 break;
             case EXCLUSIVE4:
                 flags            |= CHIMERA_VFS_OPEN_EXCLUSIVE;
                 attr->va_set_mask = CHIMERA_VFS_ATTR_ATIME | CHIMERA_VFS_ATTR_MTIME;
                 memcpy(&verf_part, args->openhow.how.createverf, 4);
-                attr->va_atime.tv_sec = verf_part;
+                attr->va_atime.tv_sec  = verf_part;
                 attr->va_atime.tv_nsec = 0;
                 memcpy(&verf_part, args->openhow.how.createverf + 4, 4);
-                attr->va_mtime.tv_sec = verf_part;
+                attr->va_mtime.tv_sec  = verf_part;
                 attr->va_mtime.tv_nsec = 0;
                 break;
         } /* switch */

--- a/src/server/nfs/nfs4_proc_open.c
+++ b/src/server/nfs/nfs4_proc_open.c
@@ -645,6 +645,7 @@ chimera_nfs4_open_parent_complete(
     unsigned int              flags = 0;
     nfsstat4                  status;
     struct chimera_vfs_attrs *attr;
+    uint32_t                  verf_part;
 
     req->handle = parent_handle;
 
@@ -709,17 +710,21 @@ chimera_nfs4_open_parent_complete(
                  * For now encode the verifier in atime.tv_sec (bytes 0-3) and mtime.tv_sec
                  * (bytes 4-7), which is the same strategy used by Linux nfsd. */
                 attr->va_set_mask |= CHIMERA_VFS_ATTR_ATIME | CHIMERA_VFS_ATTR_MTIME;
-                memcpy(&attr->va_atime.tv_sec, args->openhow.how.ch_createboth.cva_verf, 4);
+                memcpy(&verf_part, args->openhow.how.ch_createboth.cva_verf, 4);
+                attr->va_atime.tv_sec = verf_part;
                 attr->va_atime.tv_nsec = 0;
-                memcpy(&attr->va_mtime.tv_sec, args->openhow.how.ch_createboth.cva_verf + 4, 4);
+                memcpy(&verf_part, args->openhow.how.ch_createboth.cva_verf + 4, 4);
+                attr->va_mtime.tv_sec = verf_part;
                 attr->va_mtime.tv_nsec = 0;
                 break;
             case EXCLUSIVE4:
                 flags            |= CHIMERA_VFS_OPEN_EXCLUSIVE;
                 attr->va_set_mask = CHIMERA_VFS_ATTR_ATIME | CHIMERA_VFS_ATTR_MTIME;
-                memcpy(&attr->va_atime.tv_sec, args->openhow.how.createverf, 4);
+                memcpy(&verf_part, args->openhow.how.createverf, 4);
+                attr->va_atime.tv_sec = verf_part;
                 attr->va_atime.tv_nsec = 0;
-                memcpy(&attr->va_mtime.tv_sec, args->openhow.how.createverf + 4, 4);
+                memcpy(&verf_part, args->openhow.how.createverf + 4, 4);
+                attr->va_mtime.tv_sec = verf_part;
                 attr->va_mtime.tv_nsec = 0;
                 break;
         } /* switch */

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-only
 
 #include <stdint.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <pthread.h>
 #include <string.h>
@@ -998,16 +999,19 @@ memfs_apply_attrs(
 } /* memfs_apply_attrs */
 
 static int
-memfs_cred_can_write(
+memfs_cred_can_access(
     const struct memfs_inode      *inode,
-    const struct chimera_vfs_cred *cred)
+    const struct chimera_vfs_cred *cred,
+    uint32_t                       user_bit,
+    uint32_t                       group_bit,
+    uint32_t                       other_bit)
 {
     if (cred->uid == 0) {
         return 1;
     }
 
     if ((uint64_t) cred->uid == inode->uid) {
-        return !!(inode->mode & S_IWUSR);
+        return !!(inode->mode & user_bit);
     }
 
     int in_group = ((uint64_t) cred->gid == inode->gid);
@@ -1019,10 +1023,26 @@ memfs_cred_can_write(
     }
 
     if (in_group) {
-        return !!(inode->mode & S_IWGRP);
+        return !!(inode->mode & group_bit);
     }
 
-    return !!(inode->mode & S_IWOTH);
+    return !!(inode->mode & other_bit);
+} /* memfs_cred_can_access */
+
+static int
+memfs_cred_can_read(
+    const struct memfs_inode      *inode,
+    const struct chimera_vfs_cred *cred)
+{
+    return memfs_cred_can_access(inode, cred, S_IRUSR, S_IRGRP, S_IROTH);
+} /* memfs_cred_can_read */
+
+static int
+memfs_cred_can_write(
+    const struct memfs_inode      *inode,
+    const struct chimera_vfs_cred *cred)
+{
+    return memfs_cred_can_access(inode, cred, S_IWUSR, S_IWGRP, S_IWOTH);
 } /* memfs_cred_can_write */
 
 static void
@@ -2076,6 +2096,24 @@ memfs_open_at(
         request->status = CHIMERA_VFS_ENOTDIR;
         request->complete(request);
         return;
+    }
+
+    if (!(flags & CHIMERA_VFS_OPEN_INFERRED)) {
+        bool allowed;
+
+        if (flags & CHIMERA_VFS_OPEN_READ_ONLY) {
+            allowed = memfs_cred_can_read(inode, request->cred);
+        } else {
+            allowed = memfs_cred_can_write(inode, request->cred);
+        }
+
+        if (!allowed) {
+            pthread_mutex_unlock(&inode->lock);
+            pthread_mutex_unlock(&parent_inode->lock);
+            request->status = CHIMERA_VFS_EACCES;
+            request->complete(request);
+            return;
+        }
     }
 
     if (flags & CHIMERA_VFS_OPEN_INFERRED) {


### PR DESCRIPTION
## Summary
- enforce memfs read/write mode bits during non-inferred OPEN
- return VFS EACCES before NFS share-conflict handling for denied opens
- store EXCLUSIVE4 verifier parts by assignment instead of partial memcpy into time_t

## Testing
- cmake --build build --target chimera
- PYNFS_TIMEOUT=300 ctest --test-dir build -R 'chimera/pynfs/open_memfs_nfs4\.0$' --output-on-failure
  - OPEN20 and OPEN4 now pass
  - the suite still reports OPEN23/OPEN27 on this branch because PR #349 is separate and not included