### PR TITLE
nfs: initialize lock owner seqid state

### DIFF
--- a/src/server/nfs/nfs4_proc_lock.c
+++ b/src/server/nfs/nfs4_proc_lock.c
@@ -68,8 +68,12 @@ chimera_nfs4_lock_finish(
             if (lo) {
                 pthread_mutex_lock(&lo->lock);
                 lo->seqid = lock_seqid;
-                /* No replay cache on a brand-new lock_owner; the open_owner
-                 * cache above is the authoritative replay surface. */
+                /* The initial LOCK is replayed through the open_owner seqid,
+                 * but the lock_owner must still be marked initialized so the
+                 * next existing-lock-owner request cannot pick an arbitrary
+                 * fresh seqid. */
+                nfs4_replay_record(&lo->replay, lock_seqid, OP_LOCK,
+                                   status, cache_stateid);
                 pthread_mutex_unlock(&lo->lock);
             }
         } else {

--- a/src/server/nfs/nfs4_proc_locku.c
+++ b/src/server/nfs/nfs4_proc_locku.c
@@ -81,7 +81,7 @@ chimera_nfs4_locku(
                                     thread->vfs_thread);
             req->nfs_state_ref = NULL;
             res->status        = NFS4ERR_BAD_SEQID;
-            chimera_nfs4_compound_complete(req, NFS4_OK);
+            chimera_nfs4_compound_complete(req, res->status);
             return;
         }
         pthread_mutex_unlock(&lock_owner->lock);


### PR DESCRIPTION
## Summary
- mark a newly created NFSv4.0 lock owner as initialized when the first LOCK completes
- reject later non-sequential LOCK/LOCKU seqids instead of treating the lock owner as fresh
- return the correct compound status for LOCKU bad-seqid responses

## Testing
- cmake --build build --target chimera
- PYNFS_TIMEOUT=300 ctest --test-dir build -R 'chimera/pynfs/(lock|locku)_memfs_nfs4\.0$' --output-on-failure
  - LOCK8a, LKU6, and LKU6b now pass
  - remaining failures are existing range/expiry/stateid-ordering cases: LKU2, LOCK13, LOCKMRG, LKU10, LKUOVER, LKU7