### PR TITLE
nfs: harden interrupted callback and event wakeups

### DIFF
--- a/src/server/nfs/nfs4_callback.c
+++ b/src/server/nfs/nfs4_callback.c
@@ -107,10 +107,13 @@ nfs4_cb_addr_reachable(
         return false;
     }
 
-    rc = connect(fd, (struct sockaddr *) &sin, sizeof(sin));
+    do {
+        rc = connect(fd, (struct sockaddr *) &sin, sizeof(sin));
+    } while (rc < 0 && errno == EINTR);
+
     if (rc == 0) {
         ok = true;
-    } else if (errno == EINPROGRESS) {
+    } else if (errno == EINPROGRESS || errno == EALREADY) {
         /* Connection underway; treat as reachable.  evpl will redo its own
          * connect immediately after, which the listening peer accepts. */
         ok = true;


### PR DESCRIPTION
Update libevpl to include chimera-nas/libevpl#56, which retries interrupted eventfd wakeups and improves diagnostics when eventfd writes fail.\n\nAlso harden the NFSv4 callback reachability preflight by retrying a nonblocking connect() if it is interrupted, and treating EALREADY like EINPROGRESS.\n\nValidation:\n- make syntax-check\n- cmake --build build --target evpl\n- cmake --build build --target chimera_nfs\n- ctest --test-dir build -R 'libevpl/core/|libevpl/socket/rand_full_duplex_stream_tcp' --output-on-failure --timeout 300