### PR TITLE
nfs: align delegation protocol advertisement

### DIFF
--- a/src/server/nfs/nfs4_attr.h
+++ b/src/server/nfs/nfs4_attr.h
@@ -252,7 +252,8 @@ chimera_nfs4_marshall_attrs(
     void                           *attrs,
     uint32_t                       *attrvals_len,
     uint8_t                         minorversion,
-    uint32_t                        pnfs_layout_type)
+    uint32_t                        pnfs_layout_type,
+    int                             nfs4_delegations)
 {
     /* pnfs_layout_type is the single layouttype4 this file's backend supports
      * (LAYOUT4_FLEX_FILES 0x4 or LAYOUT4_BLOCK_VOLUME 0x3), or 0 when pNFS is
@@ -324,8 +325,11 @@ chimera_nfs4_marshall_attrs(
                                             (pnfs_layout_type ? (1UL << (FATTR4_FS_LAYOUT_TYPES - 32)) : 0));
 
             if (minorversion >= 1) {
-                uint32_t word2 = (1 << (FATTR4_SUPPATTR_EXCLCREAT - 64)) |
-                    (1 << (FATTR4_OPEN_ARGUMENTS - 64));
+                uint32_t word2 = (1 << (FATTR4_SUPPATTR_EXCLCREAT - 64));
+
+                if (nfs4_delegations) {
+                    word2 |= (1 << (FATTR4_OPEN_ARGUMENTS - 64));
+                }
 
                 /* Extended attributes (RFC 8276) are an NFSv4.2 feature. */
                 if (minorversion >= 2) {
@@ -687,7 +691,8 @@ chimera_nfs4_marshall_attrs(
                                             (1UL << (FATTR4_OWNER_GROUP - 32)));
         }
 
-        if (req_mask[2] & (1 << (FATTR4_OPEN_ARGUMENTS - 64))) {
+        if (nfs4_delegations &&
+            (req_mask[2] & (1 << (FATTR4_OPEN_ARGUMENTS - 64)))) {
             rsp_mask[2]  |= (1 << (FATTR4_OPEN_ARGUMENTS - 64));
             *num_rsp_mask = 3;
 

--- a/src/server/nfs/nfs4_op_matrix.h
+++ b/src/server/nfs/nfs4_op_matrix.h
@@ -118,8 +118,9 @@ static const struct nfs4_op_info nfs4_op_support[NFS4_OP_MAX + 1] = {
     },
     [OP_FREE_STATEID] =         { NFS4_OP_V41 | NFS4_OP_V42,               0
     },
-    [OP_GET_DIR_DELEGATION] =   { NFS4_OP_V41 | NFS4_OP_V42,               0
-    },
+    /* Directory delegations are distinct from OPEN file delegations and are
+     * not implemented.  Leave OP_GET_DIR_DELEGATION unsupported so clients
+     * receive NFS4ERR_NOTSUPP instead of passing dispatch with no handler. */
     [OP_GETDEVICEINFO] =        { NFS4_OP_V41 | NFS4_OP_V42,               0
     },
     [OP_GETDEVICELIST] =        { NFS4_OP_V41 | NFS4_OP_V42,               0
@@ -142,8 +143,8 @@ static const struct nfs4_op_info nfs4_op_support[NFS4_OP_MAX + 1] = {
     },
     [OP_TEST_STATEID] =         { NFS4_OP_V41 | NFS4_OP_V42,               0
     },
-    [OP_WANT_DELEGATION] =      { NFS4_OP_V41 | NFS4_OP_V42,               0
-    },
+    /* Explicit post-OPEN delegation requests are not implemented.  OPEN may
+     * still grant file delegations when nfs4_delegations is enabled. */
     [OP_DESTROY_CLIENTID] =     { NFS4_OP_V41 | NFS4_OP_V42,               NFS4_OP_FLAG_NO_REQ_SESSION
     },
     [OP_RECLAIM_COMPLETE] =     { NFS4_OP_V41 | NFS4_OP_V42,               0

--- a/src/server/nfs/nfs4_proc_getattr.c
+++ b/src/server/nfs/nfs4_proc_getattr.c
@@ -66,7 +66,9 @@ chimera_nfs4_getattr_finish(
                                 req->minorversion,
                                 chimera_nfs4_pnfs_layout_type(req->thread->vfs_thread,
                                                               req->thread->shared->vfs,
-                                                              req->fh, req->fhlen));
+                                                              req->fh, req->fhlen),
+                                chimera_server_config_get_nfs4_delegations(
+                                    req->thread->shared->config));
 
     if (req->handle) {
         chimera_vfs_release(req->thread->vfs_thread, req->handle);

--- a/src/server/nfs/nfs4_proc_readdir.c
+++ b/src/server/nfs/nfs4_proc_readdir.c
@@ -5,6 +5,7 @@
 #include "nfs4_procs.h"
 #include "nfs4_attr.h"
 #include "nfs4_status.h"
+#include "server/server.h"
 #include "vfs/vfs_procs.h"
 #include "vfs/vfs_release.h"
 
@@ -68,7 +69,9 @@ chimera_nfs4_readdir_callback(
                                 /* entries share the directory's backend/fs */
                                 chimera_nfs4_pnfs_layout_type(req->thread->vfs_thread,
                                                               req->thread->shared->vfs,
-                                                              req->fh, req->fhlen));
+                                                              req->fh, req->fhlen),
+                                chimera_server_config_get_nfs4_delegations(
+                                    req->thread->shared->config));
 
     dbuf_cur = req->encoding->dbuf->used - dbuf_before;
 

--- a/src/server/nfs/nfs4_proc_verify.c
+++ b/src/server/nfs/nfs4_proc_verify.c
@@ -7,6 +7,7 @@
 #include "nfs4_procs.h"
 #include "nfs4_status.h"
 #include "nfs4_attr.h"
+#include "server/server.h"
 #include "vfs/vfs_procs.h"
 #include "vfs/vfs_release.h"
 
@@ -87,7 +88,9 @@ chimera_nfs4_verify_complete(
                                 req->minorversion,
                                 chimera_nfs4_pnfs_layout_type(req->thread->vfs_thread,
                                                               req->thread->shared->vfs,
-                                                              req->fh, req->fhlen));
+                                                              req->fh, req->fhlen),
+                                chimera_server_config_get_nfs4_delegations(
+                                    req->thread->shared->config));
 
     bool match = (num_out_mask == args->num_attrmask) &&
         (memcmp(out_mask, args->attrmask,

--- a/src/server/nfs/nfs4_root.c
+++ b/src/server/nfs/nfs4_root.c
@@ -156,7 +156,8 @@ nfs4_root_readdir_lookup_callback(
                                 entry->attrs.attr_vals.data,
                                 &entry->attrs.attr_vals.len,
                                 0,
-                                0 /* pNFS not advertised on the pseudo-fs root */);
+                                0, /* pNFS not advertised on the pseudo-fs root */
+                                0);
 } /* nfs4_root_readdir_lookup_callback */
 
 struct nfs4_root_readdir_itr_ctx {

--- a/src/server/nfs/tests/CMakeLists.txt
+++ b/src/server/nfs/tests/CMakeLists.txt
@@ -33,3 +33,11 @@ target_include_directories(test_replay_slot PRIVATE
     ${NFS_COMMON_INCLUDE_DIR})
 target_link_libraries(test_replay_slot chimera_vfs chimera_common evpl evpl_rpc2 pthread uuid urcu urcu-common)
 add_test(NAME chimera/server/nfs/replay_slot COMMAND test_replay_slot)
+
+add_executable(test_protocol_advertise test_protocol_advertise.c)
+target_include_directories(test_protocol_advertise PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/..
+    ${CMAKE_SOURCE_DIR}/src
+    ${NFS_COMMON_INCLUDE_DIR})
+target_link_libraries(test_protocol_advertise chimera_vfs chimera_common evpl evpl_rpc2 pthread uuid urcu urcu-common)
+add_test(NAME chimera/server/nfs/protocol_advertise COMMAND test_protocol_advertise)

--- a/src/server/nfs/tests/test_protocol_advertise.c
+++ b/src/server/nfs/tests/test_protocol_advertise.c
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "nfs_internal.h"
+#include "nfs4_xdr.h"
+#include "nfs4_attr.h"
+#include "nfs4_op_matrix.h"
+
+static uint32_t
+get_u32(
+    const uint8_t *buf,
+    int            index)
+{
+    return chimera_nfs_ntoh32(((const uint32_t *) buf)[index]);
+} /* get_u32 */
+
+static void
+test_unimplemented_delegation_ops_not_advertised(void)
+{
+    assert(nfs4_op_check_minor(OP_GET_DIR_DELEGATION, 1, 1, true) == NFS4ERR_NOTSUPP);
+    assert(nfs4_op_check_minor(OP_GET_DIR_DELEGATION, 2, 1, true) == NFS4ERR_NOTSUPP);
+    assert(nfs4_op_check_minor(OP_WANT_DELEGATION, 1, 1, true) == NFS4ERR_NOTSUPP);
+    assert(nfs4_op_check_minor(OP_WANT_DELEGATION, 2, 1, true) == NFS4ERR_NOTSUPP);
+} /* test_unimplemented_delegation_ops_not_advertised */
+
+static void
+test_open_arguments_supported_attrs_follows_delegation_config(void)
+{
+    struct chimera_vfs_attrs attr;
+    uint32_t                 req_mask[3] = { 0 };
+    uint32_t                 rsp_mask[3] = { 0 };
+    uint32_t                 num_rsp_mask;
+    uint32_t                 attrvals_len;
+    uint8_t                  attrvals[256];
+
+    memset(&attr, 0, sizeof(attr));
+    req_mask[0] = (1 << FATTR4_SUPPORTED_ATTRS);
+
+    chimera_nfs4_marshall_attrs(&attr, 3, req_mask, &num_rsp_mask, rsp_mask, 3,
+                                attrvals, &attrvals_len, 1, 0, 0);
+
+    assert(num_rsp_mask == 1);
+    assert(rsp_mask[0] == (1 << FATTR4_SUPPORTED_ATTRS));
+    assert(get_u32(attrvals, 0) == 3);
+    assert((get_u32(attrvals, 3) & (1 << (FATTR4_OPEN_ARGUMENTS - 64))) == 0);
+
+    memset(rsp_mask, 0, sizeof(rsp_mask));
+    memset(attrvals, 0, sizeof(attrvals));
+    chimera_nfs4_marshall_attrs(&attr, 3, req_mask, &num_rsp_mask, rsp_mask, 3,
+                                attrvals, &attrvals_len, 1, 0, 1);
+
+    assert(num_rsp_mask == 1);
+    assert(rsp_mask[0] == (1 << FATTR4_SUPPORTED_ATTRS));
+    assert(get_u32(attrvals, 0) == 3);
+    assert((get_u32(attrvals, 3) & (1 << (FATTR4_OPEN_ARGUMENTS - 64))) != 0);
+} /* test_open_arguments_supported_attrs_follows_delegation_config */
+
+static void
+test_open_arguments_attr_follows_delegation_config(void)
+{
+    struct chimera_vfs_attrs attr;
+    uint32_t                 req_mask[3] = { 0 };
+    uint32_t                 rsp_mask[3] = { 0 };
+    uint32_t                 num_rsp_mask;
+    uint32_t                 attrvals_len;
+    uint8_t                  attrvals[256];
+
+    memset(&attr, 0, sizeof(attr));
+    req_mask[2] = (1 << (FATTR4_OPEN_ARGUMENTS - 64));
+
+    chimera_nfs4_marshall_attrs(&attr, 3, req_mask, &num_rsp_mask, rsp_mask, 3,
+                                attrvals, &attrvals_len, 1, 0, 0);
+
+    assert(num_rsp_mask == 0);
+    assert(attrvals_len == 0);
+    assert((rsp_mask[2] & (1 << (FATTR4_OPEN_ARGUMENTS - 64))) == 0);
+
+    memset(rsp_mask, 0, sizeof(rsp_mask));
+    memset(attrvals, 0, sizeof(attrvals));
+    chimera_nfs4_marshall_attrs(&attr, 3, req_mask, &num_rsp_mask, rsp_mask, 3,
+                                attrvals, &attrvals_len, 1, 0, 1);
+
+    assert(num_rsp_mask == 3);
+    assert(attrvals_len == 40);
+    assert((rsp_mask[2] & (1 << (FATTR4_OPEN_ARGUMENTS - 64))) != 0);
+    assert(get_u32(attrvals, 4) == 1);
+    assert(get_u32(attrvals, 5) ==
+           ((1 << OPEN_ARGS_SHARE_ACCESS_WANT_ANY_DELEG) |
+            (1 << OPEN_ARGS_SHARE_ACCESS_WANT_NO_DELEG)));
+} /* test_open_arguments_attr_follows_delegation_config */
+
+int
+main(void)
+{
+    test_unimplemented_delegation_ops_not_advertised();
+    test_open_arguments_supported_attrs_follows_delegation_config();
+    test_open_arguments_attr_follows_delegation_config();
+
+    return 0;
+} /* main */


### PR DESCRIPTION
## Summary
- stop advertising unimplemented NFSv4.1+ OP_GET_DIR_DELEGATION and OP_WANT_DELEGATION in the op matrix
- make FATTR4_OPEN_ARGUMENTS advertisement conditional on nfs4_delegations so file delegation support is only reported when enabled
- add unit coverage for delegation op support and OPEN argument advertisement

## Tests
- cmake -S . -B /tmp/op46-deleg-build
- cmake --build /tmp/op46-deleg-build --target test_protocol_advertise
- ctest --test-dir /tmp/op46-deleg-build -R chimera/server/nfs/protocol_advertise --output-on-failure
- cmake --build /tmp/op46-deleg-build --target chimera_nfs