### PR TITLE
nfs: tighten write state validation

### DIFF
--- a/src/server/nfs/nfs4_proc_write.c
+++ b/src/server/nfs/nfs4_proc_write.c
@@ -75,7 +75,7 @@ chimera_nfs4_write_open_callback(
     if (error_code != CHIMERA_VFS_OK) {
         res->status = chimera_nfs4_errno_to_nfsstat4(error_code);
         evpl_iovecs_release(req->thread->evpl, args->data.iov, args->data.niov);
-        chimera_nfs4_compound_complete(req, NFS4_OK);
+        chimera_nfs4_compound_complete(req, res->status);
         return;
     }
 
@@ -140,7 +140,7 @@ chimera_nfs4_write(
         if (req->fhlen == 0) {
             res->status = NFS4ERR_NOFILEHANDLE;
             evpl_iovecs_release(thread->evpl, args->data.iov, args->data.niov);
-            chimera_nfs4_compound_complete(req, NFS4_OK);
+            chimera_nfs4_compound_complete(req, res->status);
             return;
         }
 
@@ -185,7 +185,7 @@ chimera_nfs4_write(
         if (req->fhlen == 0) {
             res->status = NFS4ERR_NOFILEHANDLE;
             evpl_iovecs_release(thread->evpl, args->data.iov, args->data.niov);
-            chimera_nfs4_compound_complete(req, NFS4_OK);
+            chimera_nfs4_compound_complete(req, res->status);
             return;
         }
         req->args_write4 = args;
@@ -204,6 +204,32 @@ chimera_nfs4_write(
     } else {
         open_state   = ((struct nfs_lock_state *) state_void)->open_state;
         state_handle = ((struct nfs_lock_state *) state_void)->handle;
+    }
+
+    if (req->minorversion == 0) {
+        uint32_t current_seqid = (state_type == NFS4_SLOT_TYPE_OPEN) ?
+            open_state->seqid :
+            ((struct nfs_lock_state *) state_void)->seqid;
+
+        status = nfs4_stateid_check_seqid(current_seqid,
+                                          args->stateid.seqid);
+        if (status != NFS4_OK) {
+            nfs_state_table_release(table, state_void, state_type,
+                                    thread->vfs_thread);
+            res->status = status;
+            evpl_iovecs_release(thread->evpl, args->data.iov, args->data.niov);
+            chimera_nfs4_compound_complete(req, res->status);
+            return;
+        }
+    }
+
+    if ((open_state->share_access & OPEN4_SHARE_ACCESS_WRITE) == 0) {
+        nfs_state_table_release(table, state_void, state_type,
+                                thread->vfs_thread);
+        res->status = NFS4ERR_OPENMODE;
+        evpl_iovecs_release(thread->evpl, args->data.iov, args->data.niov);
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
     }
 
     status = nfs_open_state_check_io_denied(open_state,


### PR DESCRIPTION
Fix narrow NFSv4 WRITE validation gaps found by pynfs memfs.

- propagate WRITE precondition failures as the compound status
- reject NFSv4.0 old/future stateid seqids before VFS dispatch
- reject WRITE through an open state lacking write access with NFS4ERR_OPENMODE

Validation:
- cmake --build build --target chimera
- PYNFS_TIMEOUT=120 bash /worktrees/pynfs2/scripts/pynfs_test_wrapper.sh build/src/daemon/chimera memfs 0 /opt/pynfs WRT8 WRT12 WRT7
