### PR TITLE
nfs: reject expired clientids in create_session

### DIFF
--- a/src/server/nfs/nfs4_session.c
+++ b/src/server/nfs/nfs4_session.c
@@ -633,6 +633,9 @@ nfs4_client_create_session_classify(
     if (!c) {
         out->action = NFS4_CS_ERROR;
         out->status = NFS4ERR_STALE_CLIENTID;
+    } else if (c->unified && c->unified->expired) {
+        out->action = NFS4_CS_ERROR;
+        out->status = NFS4ERR_STALE_CLIENTID;
     } else if (csa_sequence == c->nfs4_client_cs_seqid) {
         /* Retransmit of the last request, or -- before any request -- the
          * contrived (eir_sequenceid - 1) value (RFC 8881 §18.36.4). */

--- a/src/server/nfs/nfs4_state.c
+++ b/src/server/nfs/nfs4_state.c
@@ -499,9 +499,10 @@ nfs_client_alloc(
 
     chimera_nfs_abort_if(c == NULL, "nfs_client_alloc OOM");
 
-    c->client_id = client_id;
-    c->verifier  = verifier;
-    c->minor     = minor;
+    c->client_id     = client_id;
+    c->verifier      = verifier;
+    c->minor         = minor;
+    c->last_touch_ns = nfs_lease_now_ns();
     if (owner_len > NFS4_OPAQUE_LIMIT) {
         owner_len = NFS4_OPAQUE_LIMIT;
     }


### PR DESCRIPTION
Fix the narrow EXCHANGE_ID/CREATE_SESSION lease expiry conformance gap found by pynfs.

The lease sweeper marks unified clients expired, but CREATE_SESSION still accepted their clientids. Reject those records as NFS4ERR_STALE_CLIENTID and stamp newly allocated unified clients immediately so the first lease interval is measured from identity creation.

Validation:
- cmake --build build --target chimera
- make syntax-check
- PYNFS_TIMEOUT=180 bash /worktrees/pynfs2/scripts/pynfs_test_wrapper.sh build/src/daemon/chimera memfs 1 /opt/pynfs EID9
- PYNFS_TIMEOUT=180 bash /worktrees/pynfs2/scripts/pynfs_test_wrapper.sh build/src/daemon/chimera memfs 2 /opt/pynfs EID9
