### PR TITLE
nfs: purge expired client state

### DIFF
--- a/src/server/nfs/nfs4_lease.c
+++ b/src/server/nfs/nfs4_lease.c
@@ -4,6 +4,7 @@
 
 #include <pthread.h>
 #include <stdatomic.h>
+#include <stdlib.h>
 #include <time.h>
 
 #include "nfs4_lease.h"
@@ -59,13 +60,17 @@ nfs_deleg_recall_timeout_check(struct nfs_client *uc)
 } /* nfs_deleg_recall_timeout_check */
 
 void
-nfs_lease_sweep_once(struct chimera_server_nfs_shared *shared)
+nfs_lease_sweep_once(struct chimera_server_nfs_thread *thread)
 {
 #ifndef __clang_analyzer__
-    struct nfs4_client_table *table = &shared->nfs4_shared_clients;
-    struct nfs4_client       *cur, *tmp;
-    uint64_t                  now_ns = nfs_lease_now_ns();
-    uint64_t                  lease_ns;
+    struct chimera_server_nfs_shared *shared = thread->shared;
+    struct nfs4_client_table         *table  = &shared->nfs4_shared_clients;
+    struct nfs4_client               *cur, *tmp;
+    struct nfs_client               **expired_clients  = NULL;
+    size_t                            expired_count    = 0;
+    size_t                            expired_capacity = 0;
+    uint64_t                          now_ns           = nfs_lease_now_ns();
+    uint64_t                          lease_ns;
 
     lease_ns = (uint64_t) shared->nfs_lease_time_s * 1000000000ULL;
 
@@ -91,8 +96,21 @@ nfs_lease_sweep_once(struct chimera_server_nfs_shared *shared)
             continue;
         }
 
-        if (now_ns - last > lease_ns) {
+        if (!uc->expired && now_ns - last > lease_ns) {
             uc->expired = 1;
+            if (expired_count == expired_capacity) {
+                size_t              new_capacity = expired_capacity ?
+                    expired_capacity * 2 : 8;
+                struct nfs_client **new_clients;
+
+                new_clients = realloc(expired_clients,
+                                      new_capacity * sizeof(*new_clients));
+                chimera_nfs_abort_if(new_clients == NULL,
+                                     "expired client list realloc failed");
+                expired_clients  = new_clients;
+                expired_capacity = new_capacity;
+            }
+            expired_clients[expired_count++] = uc;
         }
 
         /* Detect delegation recalls the client never answered. */
@@ -100,10 +118,17 @@ nfs_lease_sweep_once(struct chimera_server_nfs_shared *shared)
     }
 
     pthread_mutex_unlock(&table->nfs4_ct_lock);
+
+    for (size_t i = 0; i < expired_count; i++) {
+        nfs_client_expire_state(expired_clients[i],
+                                &shared->nfs4_state_table,
+                                thread->vfs_thread);
+    }
+    free(expired_clients);
 #endif /* ifndef __clang_analyzer__ */
 
     /* Phase 5: piggyback grace-window expiry on the lease tick. */
-    nfs_recovery_sweep_once(&shared->nfs4_recovery);
+    nfs_recovery_sweep_once(&thread->shared->nfs4_recovery);
 } /* nfs_lease_sweep_once */
 
 static void
@@ -114,7 +139,7 @@ nfs_lease_sweeper_fire(
     struct nfs_lease_sweeper *sweeper =
         container_of(timer, struct nfs_lease_sweeper, timer);
 
-    nfs_lease_sweep_once(sweeper->thread->shared);
+    nfs_lease_sweep_once(sweeper->thread);
 } /* nfs_lease_sweeper_fire */
 
 void

--- a/src/server/nfs/nfs4_lease.h
+++ b/src/server/nfs/nfs4_lease.h
@@ -59,10 +59,10 @@ nfs_lease_sweeper_destroy(
     struct nfs_lease_sweeper *sweeper);
 
 /*
- * Walk the shared client table once and flip the `expired` flag on every
- * client whose lease has lapsed.  Exposed for the sweeper callback and for
- * tests.
+ * Walk the shared client table once, mark every lapsed client expired, and
+ * release its open/lock/delegation state.  Exposed for the sweeper callback
+ * and for tests.
  */
 void
 nfs_lease_sweep_once(
-    struct chimera_server_nfs_shared *shared);
+    struct chimera_server_nfs_thread *thread);

--- a/src/server/nfs/nfs4_proc_open.c
+++ b/src/server/nfs/nfs4_proc_open.c
@@ -276,6 +276,10 @@ chimera_nfs4_open_install_state(
         chimera_vfs_release(req->thread->vfs_thread, handle);
         return NFS4ERR_STALE_CLIENTID;
     }
+    if (client->expired) {
+        client->expired = 0;
+        nfs_client_touch(client);
+    }
 
     owner = nfs_open_owner_find_or_create(client,
                                           args->owner.owner.data,
@@ -858,6 +862,10 @@ chimera_nfs4_open(
             res->status = NFS4ERR_STALE_CLIENTID;
             chimera_nfs4_compound_complete(req, res->status);
             return;
+        }
+        if (client->expired) {
+            client->expired = 0;
+            nfs_client_touch(client);
         }
 
         bool                   created;

--- a/src/server/nfs/nfs4_proc_renew.c
+++ b/src/server/nfs/nfs4_proc_renew.c
@@ -26,26 +26,35 @@ chimera_nfs4_renew(
     struct RENEW4res    *res  = &resop->oprenew;
     struct nfs4_session *session;
 
-    res->status = NFS4_OK;
-
     session = nfs4_session_find_by_clientid(&thread->shared->nfs4_shared_clients,
                                             args->clientid);
-    if (session) {
+    if (!session || !session->client_unified) {
+        res->status = NFS4ERR_STALE_CLIENTID;
+    } else {
         struct nfs_client *client = session->client_unified;
 
-        if (client &&
-            atomic_load_explicit(&client->cb_path.cb_state,
-                                 memory_order_acquire) == NFS4_CB_DOWN) {
-            bool has_deleg;
+        if (client->expired) {
+            res->status = NFS4ERR_EXPIRED;
+        } else {
+            res->status = NFS4_OK;
+            nfs_client_touch(client);
 
-            pthread_mutex_lock(&client->lock);
-            has_deleg = (client->delegations != NULL);
-            pthread_mutex_unlock(&client->lock);
+            if (atomic_load_explicit(&client->cb_path.cb_state,
+                                     memory_order_acquire) == NFS4_CB_DOWN) {
+                bool has_deleg;
 
-            if (has_deleg) {
-                res->status = NFS4ERR_CB_PATH_DOWN;
+                pthread_mutex_lock(&client->lock);
+                has_deleg = (client->delegations != NULL);
+                pthread_mutex_unlock(&client->lock);
+
+                if (has_deleg) {
+                    res->status = NFS4ERR_CB_PATH_DOWN;
+                }
             }
         }
+    }
+
+    if (session) {
         nfs4_session_put(session);
     }
 

--- a/src/server/nfs/nfs4_state.c
+++ b/src/server/nfs/nfs4_state.c
@@ -660,6 +660,64 @@ nfs_client_destroy(
     free(client);
 } /* nfs_client_destroy */
 
+void
+nfs_client_expire_state(
+    struct nfs_client         *client,
+    struct nfs_state_table    *table,
+    struct chimera_vfs_thread *vfs_thread)
+{
+    if (!client) {
+        return;
+    }
+
+    pthread_mutex_lock(&client->lock);
+    client->expired = 1;
+
+#ifndef __clang_analyzer__
+    struct nfs_open_owner *oo, *oo_tmp;
+    struct nfs_lock_owner *lo, *lo_tmp;
+
+    HASH_ITER(hh, client->open_owners_by_str, oo, oo_tmp)
+    {
+        pthread_mutex_lock(&oo->lock);
+        struct nfs_open_state *os, *os_tmp;
+        HASH_ITER(hh, oo->states_by_fh, os, os_tmp)
+        {
+            open_state_destroy_locked(oo, os, table, vfs_thread, true);
+        }
+        pthread_mutex_unlock(&oo->lock);
+
+        HASH_DELETE(hh, client->open_owners_by_str, oo);
+        pthread_mutex_destroy(&oo->lock);
+        free(oo);
+    }
+
+    HASH_ITER(hh, client->lock_owners_by_str, lo, lo_tmp)
+    {
+        chimera_nfs_abort_if(lo->states != NULL,
+                             "lock_owner %p has leftover lock_states", lo);
+        HASH_DELETE(hh, client->lock_owners_by_str, lo);
+        pthread_mutex_destroy(&lo->lock);
+        free(lo);
+    }
+
+    struct nfs_layout_state *ly, *ly_tmp;
+    HASH_ITER(hh, client->layouts_by_fh, ly, ly_tmp)
+    {
+        layout_state_destroy_locked(client, ly, table, vfs_thread);
+    }
+#endif /* ifndef __clang_analyzer__ */
+
+    while (client->delegations) {
+        struct nfs_delegation *deleg = client->delegations;
+        LL_DELETE2(client->delegations, deleg, next_in_client);
+        delegation_destroy_common(deleg, table, vfs_thread, true, false);
+    }
+
+    nfs4_cb_path_teardown(&client->cb_path);
+    pthread_mutex_unlock(&client->lock);
+} /* nfs_client_expire_state */
+
 struct nfs_open_owner *
 nfs_open_owner_find_or_create(
     struct nfs_client *client,

--- a/src/server/nfs/nfs4_state.h
+++ b/src/server/nfs/nfs4_state.h
@@ -550,6 +550,14 @@ nfs_client_destroy(
     struct nfs_state_table    *table,
     struct chimera_vfs_thread *vfs_thread);
 
+/* Expire all state underneath a client, but keep the client record itself as
+ * an expired tombstone so later clientid operations can return EXPIRED. */
+SYMBOL_EXPORT void
+nfs_client_expire_state(
+    struct nfs_client         *client,
+    struct nfs_state_table    *table,
+    struct chimera_vfs_thread *vfs_thread);
+
 /* Find an existing open_owner under `client` by byte-string, or create one.
  * Sets *out_created = true if a new one was allocated. */
 SYMBOL_EXPORT struct nfs_open_owner *
@@ -740,6 +748,9 @@ static inline void
 nfs_client_touch(struct nfs_client *client)
 {
     if (!client) {
+        return;
+    }
+    if (client->expired) {
         return;
     }
     atomic_store_explicit((_Atomic uint64_t *) &client->last_touch_ns,


### PR DESCRIPTION
## Summary

- purge open, lock, layout, and delegation state when a client lease expires
- keep the expired clientid as a tombstone so RENEW reports `NFS4ERR_EXPIRED`
- make RENEW return `NFS4ERR_STALE_CLIENTID` for unknown clientids

## Validation

- `cmake --build build --target chimera`
- `make syntax-check`
- `git diff --check`
- `PYNFS_TIMEOUT=300 bash /worktrees/pynfs2/scripts/pynfs_test_wrapper.sh build/src/daemon/chimera memfs 0 /opt/pynfs RENEW2 RENEW3 LOCK13 LKU10`
  - `RENEW2` passed
  - `RENEW3` passed
  - combined run exceeded 300s before all selected lease-sleep tests could finish
- `PYNFS_TIMEOUT=300 bash /worktrees/pynfs2/scripts/pynfs_test_wrapper.sh build/src/daemon/chimera memfs 0 /opt/pynfs LOCK13`
- `PYNFS_TIMEOUT=300 bash /worktrees/pynfs2/scripts/pynfs_test_wrapper.sh build/src/daemon/chimera memfs 0 /opt/pynfs LKU10`
