### PR TITLE
metrics: include libevpl metrics in the /metrics endpoint

### DIFF
--- a/src/metrics/metrics.c
+++ b/src/metrics/metrics.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/metrics/metrics.c
+++ b/src/metrics/metrics.c
@@ -46,7 +46,10 @@ chimera_metrics_notify(
 {
     struct chimera_metrics *metrics = private_data;
     struct evpl_iovec       iov;
+    char                   *buf;
+    int                     cap;
     ssize_t                 len;
+    int                     evpl_len;
     int                     n;
 
     switch (notify_type) {
@@ -66,7 +69,15 @@ chimera_metrics_notify(
                 break;
             }
 
-            len = prometheus_metrics_scrape(metrics->metrics, (char *) evpl_iovec_data(&iov), evpl_iovec_length(&iov));
+            buf = (char *) evpl_iovec_data(&iov);
+            cap = evpl_iovec_length(&iov);
+
+            /* Chimera's own metrics first, then libevpl's appended into
+             * the remaining space.  Both emit Prometheus text format and
+             * use disjoint name prefixes (chimera_* vs evpl_*), so the
+             * concatenation is a valid single exposition page.
+             */
+            len = prometheus_metrics_scrape(metrics->metrics, buf, cap);
 
             if (len < 0) {
                 evpl_iovec_release(evpl, &iov);
@@ -74,6 +85,17 @@ chimera_metrics_notify(
                 evpl_http_server_dispatch_default(request, 500);
                 break;
             }
+
+            evpl_len = evpl_metrics_scrape(buf + len, cap - len);
+
+            if (evpl_len < 0) {
+                evpl_iovec_release(evpl, &iov);
+                evpl_http_server_set_response_length(request, 0);
+                evpl_http_server_dispatch_default(request, 500);
+                break;
+            }
+
+            len += evpl_len;
 
             evpl_iovec_set_length(&iov, len);
 


### PR DESCRIPTION
## Summary

libevpl's own Prometheus metrics were not exposed on chimera's `:9000/metrics`. This bumps libevpl and concatenates its scrape output onto chimera's own.

- **Submodule bump** picks up libevpl's internal metrics registry and the `evpl_metrics_scrape()` API (chimera-nas/libevpl#61), plus per-block-device latency, request-size and queue-depth metrics (chimera-nas/libevpl#62).
- The `/metrics` handler now scrapes chimera's registry, then appends `evpl_metrics_scrape()` into the remaining buffer space. Both emit Prometheus text format and use disjoint name prefixes (`chimera_*` vs `evpl_*`), so the result is a valid single exposition page.

## What's now exposed

- `evpl_allocator_*` — slab/buffer counters and gauges
- `evpl_block_latency_nanoseconds`, `evpl_block_request_bytes`, `evpl_block_queue_depth` — per block device, labelled `{device, type}`

## Validation

Verified live against a diskfs/io_uring daemon: a single `GET /metrics` returns `chimera_*`, `evpl_allocator_*`, and `evpl_block_*` families together (HTTP 200), with the block series carrying `device`/`type` labels and queue depth returning to 0 when idle.