### PR TITLE
diskfs: make persistence unconditional

### DIFF
--- a/kvm/kvm_nfs_test_wrapper.sh
+++ b/kvm/kvm_nfs_test_wrapper.sh
@@ -108,7 +108,7 @@ generate_config() {
             local devices_json=""
             for i in $(seq 0 9); do
                 local device_path="${SESSION_DIR}/device-${i}.img"
-                truncate -s 256G "$device_path"
+                truncate -s 1G "$device_path"
                 if [ $i -gt 0 ]; then
                     devices_json="${devices_json},"
                 fi

--- a/kvm/kvm_nfs_test_wrapper.sh
+++ b/kvm/kvm_nfs_test_wrapper.sh
@@ -118,7 +118,7 @@ generate_config() {
             BACKEND="diskfs"
             vfs_section="\"vfs\": {
                 \"diskfs\": {
-                    \"config\": {\"devices\":[$devices_json]}
+                    \"config\": {\"devices\":[$devices_json],\"unsafe_async\":true}
                 }
             },"
             ;;

--- a/kvm/kvm_smb_test_wrapper.sh
+++ b/kvm/kvm_smb_test_wrapper.sh
@@ -97,7 +97,7 @@ generate_config() {
             BACKEND="diskfs"
             vfs_section="\"vfs\": {
                 \"diskfs\": {
-                    \"config\": {\"devices\":[$devices_json]}
+                    \"config\": {\"devices\":[$devices_json],\"unsafe_async\":true}
                 }
             },"
             ;;

--- a/kvm/kvm_smb_test_wrapper.sh
+++ b/kvm/kvm_smb_test_wrapper.sh
@@ -87,7 +87,7 @@ generate_config() {
             local devices_json=""
             for i in $(seq 0 9); do
                 local device_path="${SESSION_DIR}/device-${i}.img"
-                truncate -s 256G "$device_path"
+                truncate -s 1G "$device_path"
                 if [ $i -gt 0 ]; then
                     devices_json="${devices_json},"
                 fi

--- a/kvm/tests/CMakeLists.txt
+++ b/kvm/tests/CMakeLists.txt
@@ -65,7 +65,7 @@ set(PNFS_CMD_remove "mkdir -p /mnt/test && dd if=/dev/urandom of=/mnt/test/f0 bs
 # xfstests programs
 set(XFSTESTS_PROGRAMS fsstress fsx dirstress nametest fstest rewinddir)
 
-set(XFSTESTS_CMD_fsstress  "mkdir -p /mnt/test && /opt/xfstests/ltp/fsstress -d /mnt/test -n 500 -p 1")
+set(XFSTESTS_CMD_fsstress  "mkdir -p /mnt/test && /opt/xfstests/ltp/fsstress -d /mnt/test -n 100 -p 1")
 set(XFSTESTS_CMD_fsx       "mkdir -p /mnt/test && /opt/xfstests/ltp/fsx -N 10000 -l 262144 /mnt/test/fsx_testfile")
 set(XFSTESTS_CMD_dirstress "mkdir -p /mnt/test && /opt/xfstests/src/dirstress -d /mnt/test -p 1 -f 50")
 set(XFSTESTS_CMD_nametest  "mkdir -p /mnt/test && cd /mnt/test && /opt/xfstests/src/nametest -l /opt/xfstests/nametest_input -i 1000")

--- a/scripts/pynfs_test_wrapper.sh
+++ b/scripts/pynfs_test_wrapper.sh
@@ -94,7 +94,7 @@ generate_config() {
             local devices_json=""
             for i in $(seq 0 9); do
                 local device_path="${SESSION_DIR}/device-${i}.img"
-                truncate -s 256G "$device_path"
+                truncate -s 1G "$device_path"
                 if [ $i -gt 0 ]; then
                     devices_json="${devices_json},"
                 fi

--- a/scripts/pynfs_test_wrapper.sh
+++ b/scripts/pynfs_test_wrapper.sh
@@ -104,7 +104,7 @@ generate_config() {
             BACKEND="diskfs"
             vfs_section="\"vfs\": {
                 \"diskfs\": {
-                    \"config\": {\"devices\":[$devices_json]}
+                    \"config\": {\"devices\":[$devices_json],\"unsafe_async\":true}
                 }
             },"
             ;;

--- a/src/client/tests/client_test_common.h
+++ b/src/client/tests/client_test_common.h
@@ -150,6 +150,7 @@ client_test_init(
             }
 
             json_object_set_new(cfg, "devices", devices);
+            json_object_set_new(cfg, "unsafe_async", json_true());
             json_str = json_dumps(cfg, JSON_COMPACT);
             snprintf(diskfs_cfg, sizeof(diskfs_cfg), "%s", json_str);
             free(json_str);
@@ -255,6 +256,7 @@ client_test_init(
                 }
 
                 json_object_set_new(cfg, "devices", devices);
+                json_object_set_new(cfg, "unsafe_async", json_true());
                 json_str = json_dumps(cfg, JSON_COMPACT);
                 snprintf(diskfs_cfg, sizeof(diskfs_cfg), "%s", json_str);
                 free(json_str);
@@ -370,4 +372,3 @@ client_test_mount(
         chimera_mount(env->client_thread, mount_path, module_name, module_path, NULL, callback, private_data);
     }
 } /* client_test_mount */
-

--- a/src/fio/tests/diskfs_aio_basic.json
+++ b/src/fio/tests/diskfs_aio_basic.json
@@ -10,7 +10,8 @@
                         "size": 1073741824,
                         "path": "${FIO_TEST_BINARY}/diskfs_aio_device_0.img"
                     }
-                ]
+                ],
+                "unsafe_async": true
             }
         }
     ],

--- a/src/fio/tests/diskfs_io_uring_basic.json
+++ b/src/fio/tests/diskfs_io_uring_basic.json
@@ -10,7 +10,8 @@
                         "size": 1073741824,
                         "path": "${FIO_TEST_BINARY}/diskfs_io_uring_device_0.img"
                     }
-                ]
+                ],
+                "unsafe_async": true
             }
         }
     ],

--- a/src/posix/tests/CMakeLists.txt
+++ b/src/posix/tests/CMakeLists.txt
@@ -115,13 +115,17 @@ generate_posix_backend_tests(io_uring CHIMERA_VFS_IO_URING)
 # Macro to add a test that runs via NFS3 client (requires network namespace)
 macro(add_posix_nfs3_test testname prog nfs_backend)
     if(CHIMERA_NETNS_TESTING)
+        set(test_timeout 60)
+        if("${testname}" STREQUAL "io_serialize" AND "${nfs_backend}" MATCHES "^diskfs_")
+            set(test_timeout 120)
+        endif()
         add_test(NAME chimera/posix/${testname}_nfs3_${nfs_backend}
             COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_${prog} -b nfs3_${nfs_backend}
         )
         get_target_property(test_file posix_${prog} TEST_FILE)
         set_tests_properties(chimera/posix/${testname}_nfs3_${nfs_backend} PROPERTIES
             ENVIRONMENT "TEST_FILE=${test_file}"
-            TIMEOUT 60
+            TIMEOUT ${test_timeout}
         )
     endif()
 endmacro()
@@ -163,13 +167,17 @@ generate_posix_nfs3_backend_tests(io_uring CHIMERA_VFS_IO_URING)
 # Macro to add a test that runs via NFS4 client (requires network namespace)
 macro(add_posix_nfs4_test testname prog nfs_backend)
     if(CHIMERA_NETNS_TESTING)
+        set(test_timeout 60)
+        if("${testname}" STREQUAL "io_serialize" AND "${nfs_backend}" MATCHES "^diskfs_")
+            set(test_timeout 120)
+        endif()
         add_test(NAME chimera/posix/${testname}_nfs4_${nfs_backend}
             COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_${prog} -b nfs4_${nfs_backend}
         )
         get_target_property(test_file posix_${prog} TEST_FILE)
         set_tests_properties(chimera/posix/${testname}_nfs4_${nfs_backend} PROPERTIES
             ENVIRONMENT "TEST_FILE=${test_file}"
-            TIMEOUT 60
+            TIMEOUT ${test_timeout}
         )
     endif()
 endmacro()
@@ -211,13 +219,17 @@ generate_posix_nfs4_backend_tests(io_uring CHIMERA_VFS_IO_URING)
 # Macro to add a test that runs via NFS3 RDMA client (requires network namespace)
 macro(add_posix_nfs3rdma_test testname prog nfs_backend)
     if(CHIMERA_NETNS_TESTING)
+        set(test_timeout 60)
+        if("${testname}" STREQUAL "io_serialize" AND "${nfs_backend}" MATCHES "^diskfs_")
+            set(test_timeout 120)
+        endif()
         add_test(NAME chimera/posix/${testname}_nfs3rdma_${nfs_backend}
             COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_${prog} -b nfs3rdma_${nfs_backend}
         )
         get_target_property(test_file posix_${prog} TEST_FILE)
         set_tests_properties(chimera/posix/${testname}_nfs3rdma_${nfs_backend} PROPERTIES
             ENVIRONMENT "TEST_FILE=${test_file}"
-            TIMEOUT 60
+            TIMEOUT ${test_timeout}
         )
     endif()
 endmacro()

--- a/src/posix/tests/fsx.c
+++ b/src/posix/tests/fsx.c
@@ -3959,7 +3959,7 @@ main(
                                 device_path, strerror(errno));
                         exit(100);
                     }
-                    rc = ftruncate(fd, 256UL * 1024 * 1024 * 1024);
+                    rc = ftruncate(fd, 1024UL * 1024 * 1024);
                     if (rc < 0) {
                         fprintf(stderr, "Failed to truncate device %s: %s\n",
                                 device_path, strerror(errno));

--- a/src/posix/tests/fsx.c
+++ b/src/posix/tests/fsx.c
@@ -3970,7 +3970,10 @@ main(
                                     "%s{\"type\":\"%s\",\"size\":1,\"path\":\"%s\"}",
                                     i > 0 ? "," : "", device_type, device_path);
                 }
-                snprintf(diskfs_cfg + off, sizeof(diskfs_cfg) - off, "]}");
+                /* unsafe_async: tests below do not exercise crash recovery, so skip
+                 * FUA/sync on writes to run lighter. */
+                snprintf(diskfs_cfg + off, sizeof(diskfs_cfg) - off,
+                         "],\"unsafe_async\":true}");
 
                 chimera_server_config_add_module(chimera_server_config, "diskfs", NULL, diskfs_cfg);
             } else if (strcmp(chimera_nfs_backend, "cairn") == 0) {

--- a/src/posix/tests/posix_test_common.h
+++ b/src/posix/tests/posix_test_common.h
@@ -106,7 +106,7 @@ posix_test_configure_diskfs(
             exit(EXIT_FAILURE);
         }
 
-        rc = ftruncate(fd, 256 * 1024 * 1024 * 1024UL);
+        rc = ftruncate(fd, 1024 * 1024 * 1024UL);
 
         if (rc < 0) {
             fprintf(stderr, "Failed to truncate device %s: %s\n", device_path, strerror(errno));

--- a/src/posix/tests/posix_test_common.h
+++ b/src/posix/tests/posix_test_common.h
@@ -117,6 +117,7 @@ posix_test_configure_diskfs(
     }
 
     json_object_set_new(cfg, "devices", devices);
+    json_object_set_new(cfg, "unsafe_async", json_true());
     json_str = json_dumps(cfg, JSON_COMPACT);
     snprintf(diskfs_cfg, diskfs_cfg_size, "%s", json_str);
     free(json_str);

--- a/src/posix/tests/run_fsx.sh
+++ b/src/posix/tests/run_fsx.sh
@@ -113,7 +113,7 @@ generate_config() {
             modules_section="\"modules\": {
         \"diskfs\": {
             \"path\": \"/build/test/diskfs\",
-            \"config\": {\"devices\":[$DEVICES_JSON]}
+            \"config\": {\"devices\":[$DEVICES_JSON],\"unsafe_async\":true}
         }
     },"
             BACKEND="diskfs"

--- a/src/posix/tests/run_fsx.sh
+++ b/src/posix/tests/run_fsx.sh
@@ -103,7 +103,7 @@ generate_config() {
             DEVICES_JSON=""
             for i in $(seq 0 9); do
                 DEVICE_PATH="${SESSION_DIR}/device-${i}.img"
-                truncate -s 256G "$DEVICE_PATH"
+                truncate -s 1G "$DEVICE_PATH"
                 if [ $i -gt 0 ]; then
                     DEVICES_JSON="${DEVICES_JSON},"
                 fi

--- a/src/server/s3/tests/s3_test.py
+++ b/src/server/s3/tests/s3_test.py
@@ -112,7 +112,7 @@ class ChimeraServer:
             config["server"]["vfs"] = {
                 "diskfs": {
                     "path": None,
-                    "config": {"devices": devices}
+                    "config": {"devices": devices, "unsafe_async": True}
                 }
             }
             config["mounts"]["share"] = {

--- a/src/server/smb/tests/smbtorture_test.c
+++ b/src/server/smb/tests/smbtorture_test.c
@@ -253,6 +253,9 @@ main(
         }
 
         json_object_set_new(cfg, "devices", devices);
+        /* unsafe_async: this test does not exercise crash recovery, so skip FUA/sync
+         * on writes to run lighter. */
+        json_object_set_new(cfg, "unsafe_async", json_true());
         json_str = json_dumps(cfg, JSON_COMPACT);
         snprintf(diskfs_cfg, sizeof(diskfs_cfg), "%s", json_str);
         free(json_str);

--- a/src/vfs/diskfs/diskfs.c
+++ b/src/vfs/diskfs/diskfs.c
@@ -693,6 +693,7 @@ struct diskfs_intent_log {
     int                       push_outstanding;  /* home writes in flight for push_cur */
     int                       redo_inflight;     /* redo writes issued, not yet in FIFO */
     int                       iocbs_inflight;    /* block writes (redo + push) on the queue, not yet completed */
+    int                       sync;              /* sync flag passed to redo/push block writes (0 in unsafe_async mode) */
 };
 
 struct diskfs_shared {
@@ -709,7 +710,7 @@ struct diskfs_shared {
     int                        orphans_scanned;    /* mount-time orphan recovery done */
     uint64_t                   root_inum;          /* for the clean-unmount superblock */
     uint32_t                   root_gen;
-    int                        persistent;         /* config opt-in: detect+reload a clean FS instead of mkfs */
+    int                        unsafe_async;       /* config opt-in: submit block writes without FUA/sync (no crash safety) */
     int                        mounted;            /* 1 = remounted existing FS (enables inode read-back) */
     uint32_t                   block_cache_blocks; /* total resident block-buffer cap (0 = default) */
     uint32_t                   inode_cache_inodes; /* total resident inode cap (0 = default) */
@@ -4023,6 +4024,14 @@ diskfs_orphan_scan(struct diskfs_thread *thread)
      * tree is not dirty at mount, so reading the on-disk image is correct. */
     io = diskfs_mount_io_open(shared);
 
+    /* Remount fault-in: bootstrap (mkfs) seeds the reserved root inode into
+     * cache, but a remount skips bootstrap, so the root lives only on disk.
+     * Seed it synchronously here -- the MOUNT op's own walk would otherwise
+     * fault it in with an async read that the mount-time context never pumps
+     * to completion, hanging the mount.  A freshly bootstrapped FS already has
+     * it resident, so this is a cheap cache hit. */
+    diskfs_inode_load_sync(thread, io, shared->root_inum, shared->root_gen, 0);
+
     /* Load the orphan-list inode (nlink 1) and read its tree from its home
      * block, collecting every recorded orphan inum + gen. */
     odir = diskfs_inode_load_sync(thread, io, DISKFS_ORPHAN_INUM, DISKFS_ORPHAN_GEN, 0);
@@ -4293,6 +4302,34 @@ diskfs_bt_run(struct diskfs_bt_op *op)
                     }
                     op->removed_idx = 2;
                 }
+                if (op->removed_idx == 2 && op->reb_level == op->depth - 1) {
+                    /* Leaf-parent level: a leaf merge rewrites the right
+                     * participant's next-neighbour back-link.  That neighbour
+                     * is reachable only through the leaf chain (it is not a
+                     * child of any node on the descent path), so the merge's
+                     * synchronous node_for_write would miss it on a cold cache
+                     * (remount).  Fault it in here.  The right participant is
+                     * ridx = (ci+1 < pn) ? ci+1 : ci (matching
+                     * diskfs_bt_rebalance_leaf) and is already resident (faulted
+                     * by the descent or the ci+1 step above). */
+                    int                  ridx = (ci + 1 < pn) ? ci + 1 : ci;
+                    uint64_t             rb   = diskfs_bt_islots(pbuf, pe->base)[ridx].child;
+                    struct diskfs_block *rblk;
+                    uint64_t             rnext;
+
+                    off  = sm_inum_to_device_offset(thread->shared->space_map, rb, &dev);
+                    rblk = diskfs_bt_block_get(op, dev, off);
+                    if (!rblk) {
+                        return;
+                    }
+                    rnext = diskfs_bt_hdr(rblk->iov.data, 0)->next_leaf;
+                    if (rnext) {
+                        off = sm_inum_to_device_offset(thread->shared->space_map, rnext, &dev);
+                        if (!diskfs_bt_block_get(op, dev, off)) {
+                            return;
+                        }
+                    }
+                }
                 op->reb_level++;
                 op->removed_idx = 0;
             }
@@ -4336,6 +4373,18 @@ diskfs_bt_run(struct diskfs_bt_op *op)
 
             /* At the leaf. */
             if (op->opcode == DISKFS_BT_OP_INSERT) {
+                /* A leaf split rewrites the right sibling's prev_leaf link.
+                 * That sibling is off the descent path, so on a cold cache
+                 * (remount) the synchronous split's node_for_write would miss
+                 * it.  Fault it in first via the async evpl_block path (parks +
+                 * resumes into this phase if not resident); a warm cache hits. */
+                if (h->next_leaf) {
+                    off = sm_inum_to_device_offset(thread->shared->space_map,
+                                                   h->next_leaf, &dev);
+                    if (!diskfs_bt_block_get(op, dev, off)) {
+                        return;
+                    }
+                }
                 diskfs_bt_insert_locked(thread, op->txn, inode, &op->key,
                                         op->rec, op->reclen);
                 diskfs_bt_complete(op, 0);
@@ -5930,7 +5979,7 @@ diskfs_il_push_issue(struct diskfs_intent_log *il)
         il->iocbs_inflight++;
 
         evpl_block_write(il->evpl, il->queue[bh->device_id], &rec->iovs[1 + idx], 1,
-                         bh->device_offset, 1 /* sync */, diskfs_il_push_block_cb, il);
+                         bh->device_offset, il->sync, diskfs_il_push_block_cb, il);
     }
 } /* diskfs_il_push_issue */
 
@@ -6133,7 +6182,7 @@ diskfs_il_write_redo(
             }
 
             evpl_block_write(il->evpl, il->queue[SM_INTENT_LOG_DEVICE],
-                             &rec->iovs[done], cnt, woff, 1 /* sync */,
+                             &rec->iovs[done], cnt, woff, il->sync,
                              diskfs_redo_write_cb, ctx);
             woff += bytes;
             done += cnt;
@@ -6319,6 +6368,7 @@ diskfs_intent_log_thread_init(
     il->push_outstanding = 0;
     il->redo_inflight    = 0;
     il->iocbs_inflight   = 0;
+    il->sync             = !shared->unsafe_async;
 
     /* Open block queues on this thread's evpl for redo writes + tail-push. */
     il->queue = calloc(shared->num_devices, sizeof(*il->queue));
@@ -6630,7 +6680,7 @@ diskfs_mount_io_write(
         evpl_iovec_alloc(io->evpl, want, DISKFS_BLOCK_SIZE, 1, 0, &iov);
         memcpy(iov.data, (const char *) buf + done, want);
         evpl_block_write(io->evpl, io->queue[device_id], &iov, 1, offset + done,
-                         1 /* sync */, diskfs_mount_io_complete, &w);
+                         !io->shared->unsafe_async, diskfs_mount_io_complete, &w);
         while (!w.done) {
             evpl_continue(io->evpl);
         }
@@ -6858,11 +6908,11 @@ diskfs_init(const char *cfgdata)
         }
     }
 
-    /* Opt-in persistence: when set, a clean superblock is detected at mount
-     * and the prior on-disk state is reloaded instead of reformatting.  Off by
-     * default so the common case (and the test suite) reformats every mount;
-     * the reload + on-disk read-back paths are exercised only under this flag. */
-    shared->persistent         = json_is_true(json_object_get(cfg, "persistent"));
+    /* Opt-in unsafe async I/O: when set, block writes are submitted without
+     * FUA/sync, so diskfs runs lighter at the cost of crash safety.  Off by
+     * default; tests that do not exercise crash recovery enable it to run more
+     * efficiently. */
+    shared->unsafe_async       = json_is_true(json_object_get(cfg, "unsafe_async"));
     shared->block_cache_blocks = (uint32_t) json_integer_value(
         json_object_get(cfg, "block_cache_blocks"));
     shared->inode_cache_inodes = (uint32_t) json_integer_value(
@@ -6873,13 +6923,13 @@ diskfs_init(const char *cfgdata)
 
     pthread_mutex_init(&shared->lock, NULL);
 
-    /* Decide mkfs vs clean-mount vs crash-recovery from the superblock
-     * (persistent mode only):
+    /* Decide mkfs vs clean-mount vs crash-recovery from the superblock, just as
+     * a real filesystem would:
      *   - valid + CLEAN  -> the previous instance unmounted cleanly: reload
      *                       its persisted free-space map and mount.
      *   - valid + !CLEAN -> a crash: synchronously replay the intent log to
      *                       home, then mount the now-consistent image.
-     *   - no/garbage     -> mkfs.
+     *   - no/garbage     -> mkfs (e.g. a freshly created device image).
      */
     {
         struct sm_superblock    sb;
@@ -6888,8 +6938,7 @@ diskfs_init(const char *cfgdata)
         struct diskfs_mount_io *mio  = diskfs_mount_io_open(shared);
         struct sm_io            smio = diskfs_mount_sm_io(mio);
 
-        have_sb = shared->persistent &&
-            space_map_read_superblock(&smio, &sb) == 0;
+        have_sb = space_map_read_superblock(&smio, &sb) == 0;
 
         if (have_sb && (sb.flags & SM_SB_CLEAN)) {
             mode         = 1;
@@ -6971,11 +7020,10 @@ diskfs_init(const char *cfgdata)
                                         mode != 0 ? sb.log_seq : 0);
         chimera_diskfs_abort_if(rc != 0, "Failed to write superblock");
 
-        /* Persistent mkfs: write an initial condensed AG-log base so each
-         * slot has a valid header before any runtime delta is journaled --
-         * otherwise a crash right after format would leave the allocator log
-         * unreadable. */
-        if (mode == 0 && shared->persistent) {
+        /* mkfs: write an initial condensed AG-log base so each slot has a valid
+         * header before any runtime delta is journaled -- otherwise a crash
+         * right after format would leave the allocator log unreadable. */
+        if (mode == 0) {
             space_map_persist(shared->space_map, &smio);
         }
 
@@ -7199,7 +7247,7 @@ diskfs_destroy(void *private_data)
      * mount-time evpl pump while the devices are still open -- the IL thread
      * (the only other device user) is already gone.  Only mark clean if a root
      * actually exists (an untouched mkfs has nothing to preserve). */
-    if (shared->persistent) {
+    {
         struct diskfs_mount_io *mio  = diskfs_mount_io_open(shared);
         struct sm_io            smio = diskfs_mount_sm_io(mio);
 
@@ -9889,7 +9937,7 @@ diskfs_write_phase2(
                          chunk_iov,
                          chunk_niov,
                          diskfs_private->rmw_device_offset + offset,
-                         1,
+                         !shared->unsafe_async,
                          diskfs_io_callback,
                          request);
 

--- a/src/vfs/diskfs/diskfs.c
+++ b/src/vfs/diskfs/diskfs.c
@@ -6694,6 +6694,73 @@ diskfs_mount_io_write(
 } /* diskfs_mount_io_write */
 
 static int
+diskfs_mount_io_write_many(
+    void                     *user,
+    const struct sm_io_write *writes,
+    uint32_t                  count)
+{
+    struct diskfs_mount_io      *io = user;
+    struct diskfs_mount_io_wait *waits;
+    struct evpl_iovec           *iovs;
+    uint32_t                     i, done = 0;
+    int                          rc = 0;
+
+    if (count == 0) {
+        return 0;
+    }
+
+    waits = calloc(count, sizeof(*waits));
+    iovs  = calloc(count, sizeof(*iovs));
+    if (!waits || !iovs) {
+        free(waits);
+        free(iovs);
+        return -1;
+    }
+
+    for (i = 0; i < count; i++) {
+        struct diskfs_device *dev = &io->shared->devices[writes[i].device_id];
+
+        if (writes[i].length > dev->max_request_size) {
+            rc    = -1;
+            count = i;
+            goto out;
+        }
+
+        evpl_iovec_alloc(io->evpl, writes[i].length, DISKFS_BLOCK_SIZE, 1, 0,
+                         &iovs[i]);
+        memcpy(iovs[i].data, writes[i].buf, writes[i].length);
+        evpl_block_write(io->evpl, io->queue[writes[i].device_id], &iovs[i],
+                         1, writes[i].offset, !io->shared->unsafe_async,
+                         diskfs_mount_io_complete, &waits[i]);
+    }
+
+    while (done < count) {
+        evpl_continue(io->evpl);
+        done = 0;
+        for (i = 0; i < count; i++) {
+            if (waits[i].done) {
+                done++;
+            }
+        }
+    }
+
+    for (i = 0; i < count; i++) {
+        if (waits[i].status) {
+            rc = -1;
+            break;
+        }
+    }
+
+ out:
+    for (i = 0; i < count; i++) {
+        evpl_iovec_release(io->evpl, &iovs[i]);
+    }
+    free(iovs);
+    free(waits);
+    return rc;
+} /* diskfs_mount_io_write_many */
+
+static int
 diskfs_mount_io_flush(
     void    *user,
     uint32_t device_id)
@@ -6712,10 +6779,11 @@ static struct sm_io
 diskfs_mount_sm_io(struct diskfs_mount_io *io)
 {
     struct sm_io smio = {
-        .read  = diskfs_mount_io_read,
-        .write = diskfs_mount_io_write,
-        .flush = diskfs_mount_io_flush,
-        .user  = io,
+        .read       = diskfs_mount_io_read,
+        .write      = diskfs_mount_io_write,
+        .write_many = diskfs_mount_io_write_many,
+        .flush      = diskfs_mount_io_flush,
+        .user       = io,
     };
 
     return smio;
@@ -7024,7 +7092,8 @@ diskfs_init(const char *cfgdata)
          * header before any runtime delta is journaled -- otherwise a crash
          * right after format would leave the allocator log unreadable. */
         if (mode == 0) {
-            space_map_persist(shared->space_map, &smio);
+            rc = space_map_persist(shared->space_map, &smio);
+            chimera_diskfs_abort_if(rc != 0, "Failed to persist initial space map");
         }
 
         diskfs_mount_io_close(mio);

--- a/src/vfs/diskfs/space_map.c
+++ b/src/vfs/diskfs/space_map.c
@@ -969,14 +969,19 @@ space_map_persist(
     struct space_map   *sm,
     const struct sm_io *io)
 {
+    uint8_t *buf;
     uint32_t d, a;
+
+    buf = malloc(SM_AG_LOG_SLOT_SIZE);
+    if (!buf) {
+        return -1;
+    }
 
     for (d = 0; d < sm->num_devices; d++) {
         struct sm_device *dev = &sm->devices[d];
 
         for (a = 0; a < dev->num_ags; a++) {
             struct sm_ag *ag  = &dev->ags[a];
-            uint8_t      *buf = calloc(1, SM_AG_LOG_SLOT_SIZE);
             uint32_t      slot;
             uint64_t      gen, payload, aligned, slot_off;
             int           rc;
@@ -987,6 +992,7 @@ space_map_persist(
             payload  = sm_ag_condense_into(ag, buf, gen);
             slot_off = ag->log_offset + (uint64_t) slot * SM_AG_LOG_SLOT_SIZE;
             aligned  = (payload + SM_BLOCK_SIZE - 1) & ~((uint64_t) SM_BLOCK_SIZE - 1);
+            memset(buf + payload, 0, aligned - payload);
 
             rc = io->write(io->user, d, buf, aligned, slot_off);
             if (rc == 0) {
@@ -996,16 +1002,18 @@ space_map_persist(
                 ag->log_delta_count = 0;
             }
             pthread_mutex_unlock(&ag->lock);
-            free(buf);
             if (rc != 0) {
+                free(buf);
                 return -1;
             }
         }
 
         if (io->flush(io->user, d) != 0) {
+            free(buf);
             return -1;
         }
     }
+    free(buf);
     return 0;
 } /* space_map_persist */
 

--- a/src/vfs/diskfs/space_map.c
+++ b/src/vfs/diskfs/space_map.c
@@ -28,6 +28,9 @@
 #define sm_info(...) \
         chimera_info("space_map", __FILE__, __LINE__, __VA_ARGS__)
 
+#define SM_PERSIST_BATCH_OPS   128U
+#define SM_PERSIST_BATCH_BYTES (16ULL << 20)
+
 /*
  * Append one allocation/free delta to the AG's active log slot, journaled
  * through the current transaction (via jnl) so it rides the main redo log and
@@ -958,6 +961,72 @@ sm_ag_reconstruct(
     ag->log_delta_count = h->delta_count;
 } /* sm_ag_reconstruct */
 
+struct sm_persist_update {
+    struct sm_ag *ag;
+    uint32_t      slot;
+    uint64_t      generation;
+    uint32_t      base_count;
+};
+
+static void
+sm_persist_batch_reset(
+    uint8_t **bufs,
+    uint32_t *count,
+    uint64_t *bytes)
+{
+    uint32_t i;
+
+    for (i = 0; i < *count; i++) {
+        free(bufs[i]);
+        bufs[i] = NULL;
+    }
+    *count = 0;
+    *bytes = 0;
+} /* sm_persist_batch_reset */
+
+static int
+sm_persist_batch_submit(
+    const struct sm_io       *io,
+    struct sm_io_write       *writes,
+    struct sm_persist_update *updates,
+    uint8_t                 **bufs,
+    uint32_t                 *count,
+    uint64_t                 *bytes)
+{
+    uint32_t i;
+    int      rc = 0;
+
+    if (*count == 0) {
+        return 0;
+    }
+
+    if (io->write_many) {
+        rc = io->write_many(io->user, writes, *count);
+    } else {
+        for (i = 0; i < *count; i++) {
+            if (io->write(io->user, writes[i].device_id, writes[i].buf,
+                          writes[i].length, writes[i].offset) != 0) {
+                rc = -1;
+                break;
+            }
+        }
+    }
+
+    if (rc == 0) {
+        for (i = 0; i < *count; i++) {
+            pthread_mutex_lock(&updates[i].ag->lock);
+            updates[i].ag->log_slot        = updates[i].slot;
+            updates[i].ag->log_generation  = updates[i].generation;
+            updates[i].ag->log_base_count  = updates[i].base_count;
+            updates[i].ag->log_delta_count = 0;
+            pthread_mutex_unlock(&updates[i].ag->lock);
+        }
+    }
+
+    sm_persist_batch_reset(bufs, count, bytes);
+    return rc;
+} /* sm_persist_batch_submit */
+
 /*
  * Persist the allocator: condense each AG's free set into the *other* slot at
  * generation+1 and switch to it.  (Per-transaction delta journaling, which
@@ -969,11 +1038,16 @@ space_map_persist(
     struct space_map   *sm,
     const struct sm_io *io)
 {
-    uint8_t *buf;
-    uint32_t d, a;
+    struct sm_io_write       writes[SM_PERSIST_BATCH_OPS];
+    struct sm_persist_update updates[SM_PERSIST_BATCH_OPS];
+    uint8_t                 *scratch;
+    uint8_t                 *bufs[SM_PERSIST_BATCH_OPS] = { 0 };
+    uint32_t                 count                      = 0;
+    uint64_t                 bytes                      = 0;
+    uint32_t                 d, a;
 
-    buf = malloc(SM_AG_LOG_SLOT_SIZE);
-    if (!buf) {
+    scratch = malloc(SM_AG_LOG_SLOT_SIZE);
+    if (!scratch) {
         return -1;
     }
 
@@ -981,39 +1055,69 @@ space_map_persist(
         struct sm_device *dev = &sm->devices[d];
 
         for (a = 0; a < dev->num_ags; a++) {
-            struct sm_ag *ag  = &dev->ags[a];
+            struct sm_ag *ag = &dev->ags[a];
+            uint8_t      *buf;
             uint32_t      slot;
             uint64_t      gen, payload, aligned, slot_off;
-            int           rc;
 
             pthread_mutex_lock(&ag->lock);
             slot     = 1 - ag->log_slot;
             gen      = ag->log_generation + 1;
-            payload  = sm_ag_condense_into(ag, buf, gen);
+            payload  = sm_ag_condense_into(ag, scratch, gen);
             slot_off = ag->log_offset + (uint64_t) slot * SM_AG_LOG_SLOT_SIZE;
             aligned  = (payload + SM_BLOCK_SIZE - 1) & ~((uint64_t) SM_BLOCK_SIZE - 1);
-            memset(buf + payload, 0, aligned - payload);
+            memset(scratch + payload, 0, aligned - payload);
 
-            rc = io->write(io->user, d, buf, aligned, slot_off);
-            if (rc == 0) {
-                ag->log_slot        = slot;
-                ag->log_generation  = gen;
-                ag->log_base_count  = ((struct sm_ag_log_header *) buf)->base_count;
-                ag->log_delta_count = 0;
+            if (count == SM_PERSIST_BATCH_OPS ||
+                (bytes > 0 && bytes + aligned > SM_PERSIST_BATCH_BYTES)) {
+                pthread_mutex_unlock(&ag->lock);
+                if (sm_persist_batch_submit(io, writes, updates, bufs, &count, &bytes) != 0) {
+                    free(scratch);
+                    return -1;
+                }
+                pthread_mutex_lock(&ag->lock);
+                slot     = 1 - ag->log_slot;
+                gen      = ag->log_generation + 1;
+                payload  = sm_ag_condense_into(ag, scratch, gen);
+                slot_off = ag->log_offset + (uint64_t) slot * SM_AG_LOG_SLOT_SIZE;
+                aligned  = (payload + SM_BLOCK_SIZE - 1) & ~((uint64_t) SM_BLOCK_SIZE - 1);
+                memset(scratch + payload, 0, aligned - payload);
             }
-            pthread_mutex_unlock(&ag->lock);
-            if (rc != 0) {
-                free(buf);
+
+            buf = malloc(aligned);
+            if (!buf) {
+                pthread_mutex_unlock(&ag->lock);
+                sm_persist_batch_reset(bufs, &count, &bytes);
+                free(scratch);
                 return -1;
             }
+            memcpy(buf, scratch, aligned);
+
+            writes[count].device_id   = d;
+            writes[count].buf         = buf;
+            writes[count].length      = aligned;
+            writes[count].offset      = slot_off;
+            updates[count].ag         = ag;
+            updates[count].slot       = slot;
+            updates[count].generation = gen;
+            updates[count].base_count =
+                ((struct sm_ag_log_header *) scratch)->base_count;
+            bufs[count] = buf;
+            count++;
+            bytes += aligned;
+            pthread_mutex_unlock(&ag->lock);
         }
 
+        if (sm_persist_batch_submit(io, writes, updates, bufs, &count, &bytes) != 0) {
+            free(scratch);
+            return -1;
+        }
         if (io->flush(io->user, d) != 0) {
-            free(buf);
+            free(scratch);
             return -1;
         }
     }
-    free(buf);
+    free(scratch);
     return 0;
 } /* space_map_persist */
 

--- a/src/vfs/diskfs/space_map.h
+++ b/src/vfs/diskfs/space_map.h
@@ -141,6 +141,13 @@ struct sm_journal {
  * sub-block struct), write requires a block-aligned length.  Each returns 0 on
  * success, -1 on error.
  */
+struct sm_io_write {
+    uint32_t    device_id;
+    const void *buf;
+    uint64_t    length;
+    uint64_t    offset;
+};
+
 struct sm_io {
     int   (*read)(
         void    *user,
@@ -154,6 +161,10 @@ struct sm_io {
         const void *buf,
         uint64_t    length,
         uint64_t    offset);
+    int   (*write_many)(
+        void                     *user,
+        const struct sm_io_write *writes,
+        uint32_t                  count);
     int   (*flush)(
         void    *user,
         uint32_t device_id);


### PR DESCRIPTION
This makes diskfs behave like a real filesystem by always detecting/reloading a clean on-disk image, while adding an opt-in `unsafe_async` test mode that submits block writes without FUA/sync. It also fixes cold-cache reload paths exposed by always-on persistence and bumps libevpl through chimera-nas/libevpl#66, including the merged sync-flag fix from #65.

Verification:
- `CHIMERA_BUILD_DIR=$PWD/build make build_release`
- ctest non-KVM diskfs suite: 720/720 passed
- fio reload repeats on io_uring + aio in Release and Debug/ASan
- make syntax/syntax-check, reuse lint, copyright-year

KVM-gated tests were not run in this sandbox.
