### PR TITLE
nfs4: validate object type before LOCKT

### DIFF
--- a/pynfs/stable-passing-tests.txt
+++ b/pynfs/stable-passing-tests.txt
@@ -1197,9 +1197,12 @@ chimera/pynfs/lockt/LKT9_memfs_nfs4.0
 chimera/pynfs/lockt/LKTOVER_memfs_nfs4.0
 chimera/pynfs/lockt/LOCK1_memfs_nfs4.0
 chimera/pynfs/lockt/LKT1_linux_nfs4.0
+chimera/pynfs/lockt/LKT2a_linux_nfs4.0
 chimera/pynfs/lockt/LKT2b_linux_nfs4.0
+chimera/pynfs/lockt/LKT2c_linux_nfs4.0
 chimera/pynfs/lockt/LKT2d_linux_nfs4.0
 chimera/pynfs/lockt/LKT2f_linux_nfs4.0
+chimera/pynfs/lockt/LKT2s_linux_nfs4.0
 chimera/pynfs/lockt/LKT3_linux_nfs4.0
 chimera/pynfs/lockt/LKT4_linux_nfs4.0
 chimera/pynfs/lockt/LKT5_linux_nfs4.0
@@ -1210,9 +1213,12 @@ chimera/pynfs/lockt/LKT9_linux_nfs4.0
 chimera/pynfs/lockt/LKTOVER_linux_nfs4.0
 chimera/pynfs/lockt/LOCK1_linux_nfs4.0
 chimera/pynfs/lockt/LKT1_io_uring_nfs4.0
+chimera/pynfs/lockt/LKT2a_io_uring_nfs4.0
 chimera/pynfs/lockt/LKT2b_io_uring_nfs4.0
+chimera/pynfs/lockt/LKT2c_io_uring_nfs4.0
 chimera/pynfs/lockt/LKT2d_io_uring_nfs4.0
 chimera/pynfs/lockt/LKT2f_io_uring_nfs4.0
+chimera/pynfs/lockt/LKT2s_io_uring_nfs4.0
 chimera/pynfs/lockt/LKT3_io_uring_nfs4.0
 chimera/pynfs/lockt/LKT4_io_uring_nfs4.0
 chimera/pynfs/lockt/LKT5_io_uring_nfs4.0

--- a/src/server/nfs/nfs4_proc_lockt.c
+++ b/src/server/nfs/nfs4_proc_lockt.c
@@ -163,7 +163,9 @@ chimera_nfs4_lockt(
     chimera_vfs_open_fh(thread->vfs_thread, &req->cred,
                         req->fh,
                         req->fhlen,
-                        CHIMERA_VFS_OPEN_INFERRED,
+                        CHIMERA_VFS_OPEN_INFERRED |
+                        CHIMERA_VFS_OPEN_PATH |
+                        CHIMERA_VFS_OPEN_NOFOLLOW,
                         chimera_nfs4_lockt_open_complete,
                         req);
 } /* chimera_nfs4_lockt */


### PR DESCRIPTION
## Summary
- open LOCKT current filehandles as no-follow path handles before probing file type
- prevent linux/io_uring special-file open behavior from leaking NXIO/SERVERFAULT into LOCKT responses
- enable the LKT2a/LKT2c/LKT2s linux and io_uring pynfs cases that now pass

## Testing
- cmake --build build/Release -j 128
- ctest --test-dir build/Release -R '^chimera/pynfs/lockt/LKT2(a|b|c|d|f|s)_(memfs|linux|io_uring|diskfs_io_uring|diskfs_aio|cairn)_nfs4\.0$' -j 64 --timeout 60 --output-on-failure