### PR TITLE
DO NOT MERGE — CI flake hunt + fsx_nfs4/cthon EINVAL diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,3 +201,5 @@ Chimera uses JSON configuration files to define shares and runtime parameters:
 # Questions or feedback?
 
 Come say hi on [Discord](https://discord.gg/hnRkvQFecq) — it's the best place to ask questions, share what you're building, or follow along with development.
+
+We welcome contributions of all kinds, from bug reports to new VFS backends.

--- a/src/server/nfs/nfs4_proc_read.c
+++ b/src/server/nfs/nfs4_proc_read.c
@@ -24,6 +24,17 @@ chimera_nfs4_read_complete(
     struct nfs_request *req = private_data;
     struct READ4res    *res = &req->res_compound.resarray[req->index].opread;
 
+    /* FLAKEDBG: capture NFS4-level READ params on any error (fsx_nfs4 EINVAL
+     * flake also hits READ).  Fires only on error.  REMOVE before merge. */
+    if (error_code != CHIMERA_VFS_OK) {
+        struct READ4args *rargs = &req->args_compound->argarray[req->index].opread;
+        chimera_nfs_error(
+            "FLAKEDBG nfs4_read err=%d off=%lu count=%u r_count=%u niov=%d "
+            "fhlen=%d handle=%p ref=%p",
+            error_code, rargs->offset, rargs->count, count, niov,
+            req->fhlen, req->handle, req->nfs_state_ref);
+    }
+
     if (error_code == CHIMERA_VFS_OK) {
         res->status             = NFS4_OK;
         res->resok4.eof         = eof;

--- a/src/server/nfs/nfs4_proc_write.c
+++ b/src/server/nfs/nfs4_proc_write.c
@@ -31,6 +31,22 @@ chimera_nfs4_write_complete(
     struct WRITE4args  *args = req->args_write4;
     struct WRITE4res   *res  = &req->res_compound.resarray[req->index].opwrite;
 
+    /* FLAKEDBG: capture NFS4-level WRITE params at the moment of any error so
+     * a CI hit of the fsx_nfs4/cthon EINVAL flake tells us whether the server
+     * received bad args (offset/length/iov) or the backend corrupted them.
+     * Fires only on error -> no steady-state spam.  REMOVE before merge. */
+    if (error_code != CHIMERA_VFS_OK) {
+        chimera_nfs_error(
+            "FLAKEDBG nfs4_write err=%d off=%lu len=%u niov=%d iov0=%p/%u "
+            "fhlen=%d special=%d handle=%p ref=%p",
+            error_code, args->offset, args->data.length, args->data.niov,
+            args->data.niov ? args->data.iov[0].data : NULL,
+            args->data.niov ? args->data.iov[0].length : 0,
+            req->fhlen,
+            chimera_nfs4_write_stateid_is_special(&args->stateid),
+            req->handle, req->nfs_state_ref);
+    }
+
     /* Release write iovecs here on the server thread, not in VFS backend.
      * The iovecs were allocated on this thread and must be released here
      * to avoid cross-thread access to non-atomic refcounts.

--- a/src/vfs/io_uring/io_uring.c
+++ b/src/vfs/io_uring/io_uring.c
@@ -413,6 +413,20 @@ chimera_io_uring_reap(
                         request->read.r_length = cqe->res;
                         request->read.r_eof    = (cqe->res < request->read.length);
                     } else {
+                        /* FLAKEDBG: fsx_nfs4 EINVAL flake (preadv -> EINVAL).
+                         * Log fd + I/O params to see if a bad iov/offset reached
+                         * the syscall.  REMOVE before merge. */
+                        if (-cqe->res == EINVAL) {
+                            chimera_vfs_error(
+                                "FLAKEDBG io_uring_read EINVAL fd=%d off=%lu len=%u "
+                                "niov=%d iov0=%p/%u",
+                                request->read.handle ?
+                                (int) request->read.handle->vfs_private : -1,
+                                request->read.offset, request->read.length,
+                                request->read.niov,
+                                request->read.niov ? request->read.iov[0].data : NULL,
+                                request->read.niov ? request->read.iov[0].length : 0);
+                        }
                         request->status = chimera_linux_errno_to_status(-cqe->res);
                     }
                 } else {
@@ -442,6 +456,20 @@ chimera_io_uring_reap(
                     request->status         = CHIMERA_VFS_OK;
                     request->write.r_length = cqe->res;
                 } else {
+                    /* FLAKEDBG: fsx_nfs4 EINVAL flake (pwritev -> EINVAL).
+                     * Log fd + I/O params to see if a bad iov/offset reached the
+                     * syscall.  REMOVE before merge. */
+                    if (-cqe->res == EINVAL) {
+                        chimera_vfs_error(
+                            "FLAKEDBG io_uring_write EINVAL fd=%d off=%lu len=%u "
+                            "niov=%d iov0=%p/%u",
+                            request->write.handle ?
+                            (int) request->write.handle->vfs_private : -1,
+                            request->write.offset, request->write.length,
+                            request->write.niov,
+                            request->write.niov ? request->write.iov[0].data : NULL,
+                            request->write.niov ? request->write.iov[0].length : 0);
+                    }
                     request->status         = chimera_linux_errno_to_status(-cqe->res);
                     request->write.r_length = 0;
                 }

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -2420,6 +2420,20 @@ memfs_write(
     }
 
     if (!S_ISREG(inode->mode)) {
+        /* FLAKEDBG: fsx_nfs4 EINVAL flake -- a WRITE resolved to a non-regular
+         * inode.  Log how it resolved (cached handle->vfs_private vs fh lookup)
+         * plus the inode identity, to distinguish a stale/reused handle from a
+         * corrupted fh.  Fires only on the bug -> no spam.  REMOVE before merge. */
+        chimera_vfs_error(
+            "FLAKEDBG memfs_write non-reg mode=0%o inum=%lu gen=%u via_private=%d "
+            "handle=%p vfs_private=0x%lx fh_len=%u off=%lu len=%u niov=%d",
+            inode->mode, inode->inum, inode->gen,
+            request->write.handle && request->write.handle->vfs_private ? 1 : 0,
+            (void *) request->write.handle,
+            (unsigned long) (request->write.handle ?
+                             request->write.handle->vfs_private : 0),
+            request->fh_len, request->write.offset, request->write.length,
+            (int) request->write.niov);
         request->status = S_ISDIR(inode->mode) ?
             CHIMERA_VFS_EISDIR : CHIMERA_VFS_EINVAL;
         pthread_mutex_unlock(&inode->lock);


### PR DESCRIPTION
## ⚠️ DO NOT MERGE

This is a **flake-hunt probe branch**. It exists only to exercise CI and to
carry **temporary diagnostic instrumentation**. Nothing here is intended for
`main` — the real flake fixes land as their own PRs (e.g. #518 delegations,
#526 courteous lease). **Nobody should merge this.**

## Current contents

1. A no-op trigger commit to run the pipeline against current `main`.
2. **`FLAKEDBG` diagnostics** for the intermittent NFS4 WRITE/READ `EINVAL`
   (status 22) flake hit by `fsx_nfs4_*` and `cthon_special_bigfile_nfs4_*`
   (all backends, NFS4-only; also surfaces as a client-side teardown SEGV in
   `evpl_get_hf_monotonic_time` after fsx aborts on the EINVAL).

   All logs fire **only on the failure path** (no steady-state spam):
   - `nfs4_proc_write` / `nfs4_proc_read` completion — NFS4-level params on any
     backend error (offset, length, niov, iov0 base/len, fhlen, special-stateid,
     handle, state-ref).
   - `memfs_write` `!S_ISREG` — inode mode/inum and whether the inode resolved
     via the cached `handle->vfs_private` vs an fh lookup (stale-handle vs bad-fh).
   - `io_uring` read/write — fd + offset/len/iov on a `preadv`/`pwritev` EINVAL.

   Grep CI logs for `FLAKEDBG`. Cross-referencing the NFS4-entry params against
   the backend's view will show whether the server received bad args or they
   were corrupted en route. **All of this must be reverted before any merge.**