### PR TITLE
nfs: reject invalid object types in pynfs paths

### DIFF
--- a/src/server/nfs/nfs4_proc_write.c
+++ b/src/server/nfs/nfs4_proc_write.c
@@ -10,6 +10,7 @@
 #include "vfs/vfs_procs.h"
 #include "vfs/vfs_release.h"
 #include "evpl/evpl.h"
+#include <sys/stat.h>
 
 static inline int
 chimera_nfs4_write_stateid_is_special(const struct stateid4 *sid)
@@ -95,6 +96,71 @@ chimera_nfs4_write_open_callback(
                       req);
 } /* chimera_nfs4_write_open_callback */
 
+static void
+chimera_nfs4_write_typecheck_complete(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *attr,
+    void                     *private_data)
+{
+    struct nfs_request *req  = private_data;
+    struct WRITE4args  *args = &req->args_compound->argarray[req->index].opwrite;
+    struct WRITE4res   *res  = &req->res_compound.resarray[req->index].opwrite;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        res->status = chimera_nfs4_errno_to_nfsstat4(error_code);
+        evpl_iovecs_release(req->thread->evpl, args->data.iov, args->data.niov);
+        chimera_vfs_release(req->thread->vfs_thread, req->handle);
+        req->handle = NULL;
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    if ((attr->va_set_mask & CHIMERA_VFS_ATTR_MODE) &&
+        !S_ISREG(attr->va_mode)) {
+        res->status = S_ISDIR(attr->va_mode) ? NFS4ERR_ISDIR : NFS4ERR_INVAL;
+        evpl_iovecs_release(req->thread->evpl, args->data.iov, args->data.niov);
+        chimera_vfs_release(req->thread->vfs_thread, req->handle);
+        req->handle = NULL;
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    chimera_vfs_release(req->thread->vfs_thread, req->handle);
+    req->handle = NULL;
+
+    chimera_vfs_open_fh(req->thread->vfs_thread, &req->cred,
+                        req->fh,
+                        req->fhlen,
+                        CHIMERA_VFS_OPEN_INFERRED,
+                        chimera_nfs4_write_open_callback,
+                        req);
+} /* chimera_nfs4_write_typecheck_complete */
+
+static void
+chimera_nfs4_write_typecheck_open_callback(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *handle,
+    void                           *private_data)
+{
+    struct nfs_request *req  = private_data;
+    struct WRITE4args  *args = &req->args_compound->argarray[req->index].opwrite;
+    struct WRITE4res   *res  = &req->res_compound.resarray[req->index].opwrite;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        res->status = chimera_nfs4_errno_to_nfsstat4(error_code);
+        evpl_iovecs_release(req->thread->evpl, args->data.iov, args->data.niov);
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    req->handle = handle;
+    chimera_vfs_getattr(req->thread->vfs_thread, &req->cred,
+                        handle,
+                        CHIMERA_VFS_ATTR_MODE,
+                        chimera_nfs4_write_typecheck_complete,
+                        req);
+} /* chimera_nfs4_write_typecheck_open_callback */
+
 void
 chimera_nfs4_write(
     struct chimera_server_nfs_thread *thread,
@@ -162,8 +228,9 @@ chimera_nfs4_write(
         chimera_vfs_open_fh(thread->vfs_thread, &req->cred,
                             req->fh,
                             req->fhlen,
-                            CHIMERA_VFS_OPEN_INFERRED,
-                            chimera_nfs4_write_open_callback,
+                            CHIMERA_VFS_OPEN_INFERRED | CHIMERA_VFS_OPEN_PATH |
+                            CHIMERA_VFS_OPEN_NOFOLLOW,
+                            chimera_nfs4_write_typecheck_open_callback,
                             req);
         return;
     }
@@ -192,8 +259,9 @@ chimera_nfs4_write(
         chimera_vfs_open_fh(thread->vfs_thread, &req->cred,
                             req->fh,
                             req->fhlen,
-                            CHIMERA_VFS_OPEN_INFERRED,
-                            chimera_nfs4_write_open_callback,
+                            CHIMERA_VFS_OPEN_INFERRED | CHIMERA_VFS_OPEN_PATH |
+                            CHIMERA_VFS_OPEN_NOFOLLOW,
+                            chimera_nfs4_write_typecheck_open_callback,
                             req);
         return;
     }

--- a/src/vfs/cairn/cairn.c
+++ b/src/vfs/cairn/cairn.c
@@ -1627,6 +1627,15 @@ cairn_setattr(
 
     inode = ih.inode;
 
+    if ((request->setattr.set_attr->va_set_mask & CHIMERA_VFS_ATTR_SIZE) &&
+        !S_ISREG(inode->mode)) {
+        cairn_inode_handle_release(&ih);
+        request->status = S_ISDIR(inode->mode) ?
+            CHIMERA_VFS_EISDIR : CHIMERA_VFS_EINVAL;
+        request->complete(request);
+        return;
+    }
+
     cairn_map_attrs(shared, &request->setattr.r_pre_attr, inode);
 
     /* Handle truncation: remove extents past new EOF when size decreases */
@@ -2262,7 +2271,7 @@ cairn_readdir(
 
     if (!S_ISDIR(inode->mode)) {
         cairn_inode_handle_release(&ih);
-        request->status = CHIMERA_VFS_ENOENT;
+        request->status = CHIMERA_VFS_ENOTDIR;
         request->complete(request);
         return;
     }
@@ -2429,6 +2438,15 @@ cairn_open_fh(
     }
 
     inode = ih.inode;
+
+    if ((request->open_fh.flags & CHIMERA_VFS_OPEN_DIRECTORY) &&
+        !S_ISDIR(inode->mode)) {
+        cairn_inode_handle_release(&ih);
+        request->status = CHIMERA_VFS_ENOTDIR;
+        request->complete(request);
+        return;
+    }
+
     inode->refcnt++;
 
     request->open_fh.r_vfs_private = (uint64_t) inode->inum;
@@ -2473,7 +2491,7 @@ cairn_open_at(
 
     if (!S_ISDIR(parent_inode->mode)) {
         cairn_inode_handle_release(&parent_ih);
-        request->status = CHIMERA_VFS_ENOENT;
+        request->status = CHIMERA_VFS_ENOTDIR;
         request->complete(request);
         return;
     }
@@ -2544,6 +2562,16 @@ cairn_open_at(
         inode = child_ih.inode;
 
         cairn_dirent_handle_release(&dh);
+    }
+
+    if ((flags & CHIMERA_VFS_OPEN_DIRECTORY) && !S_ISDIR(inode->mode)) {
+        cairn_inode_handle_release(&parent_ih);
+        if (!is_new_inode) {
+            cairn_inode_handle_release(&child_ih);
+        }
+        request->status = CHIMERA_VFS_ENOTDIR;
+        request->complete(request);
+        return;
     }
 
     if (flags & CHIMERA_VFS_OPEN_INFERRED) {

--- a/src/vfs/diskfs/diskfs.c
+++ b/src/vfs/diskfs/diskfs.c
@@ -7935,6 +7935,14 @@ diskfs_setattr_inode_cb(
         return;
     }
 
+    if ((request->setattr.set_attr->va_set_mask & CHIMERA_VFS_ATTR_SIZE) &&
+        !S_ISREG(inode->mode)) {
+        diskfs_op_fail(request, p->txn,
+                       S_ISDIR(inode->mode) ?
+                       CHIMERA_VFS_EISDIR : CHIMERA_VFS_EINVAL);
+        return;
+    }
+
     diskfs_map_attrs(thread, &request->setattr.r_pre_attr, inode);
 
     /* Handle truncation: remove/trim extents past new EOF. */
@@ -8985,7 +8993,7 @@ diskfs_readdir_inode_cb(
     }
 
     if (!S_ISDIR(inode->mode)) {
-        diskfs_op_fail(request, p->txn, CHIMERA_VFS_ENOENT);
+        diskfs_op_fail(request, p->txn, CHIMERA_VFS_ENOTDIR);
         return;
     }
 
@@ -9068,6 +9076,12 @@ diskfs_open_fh_inode_cb(
         return;
     }
 
+    if ((request->open_fh.flags & CHIMERA_VFS_OPEN_DIRECTORY) &&
+        !S_ISDIR(inode->mode)) {
+        diskfs_op_fail(request, p->txn, CHIMERA_VFS_ENOTDIR);
+        return;
+    }
+
     inode->refcnt++;
 
     request->open_fh.r_vfs_private = (uint64_t) inode;
@@ -9132,6 +9146,12 @@ diskfs_open_at_existing_cb(
 
     if (unlikely(status != CHIMERA_VFS_OK)) {
         diskfs_op_fail(request, p->txn, status);
+        return;
+    }
+
+    if ((request->open_at.flags & CHIMERA_VFS_OPEN_DIRECTORY) &&
+        !S_ISDIR(inode->mode)) {
+        diskfs_op_fail(request, p->txn, CHIMERA_VFS_ENOTDIR);
         return;
     }
 
@@ -9256,7 +9276,7 @@ diskfs_open_at_parent_cb(
     }
 
     if (!S_ISDIR(parent->mode)) {
-        diskfs_op_fail(request, p->txn, CHIMERA_VFS_ENOENT);
+        diskfs_op_fail(request, p->txn, CHIMERA_VFS_ENOTDIR);
         return;
     }
 


### PR DESCRIPTION
Fix several pynfs object-type validation failures by rejecting invalid object types before backend operations can report backend-specific or misleading errors.

Changes:
- Return ENOTDIR for diskfs/cairn READDIR and directory-open paths when the object is not a directory.
- Reject SETATTR(size) on non-regular diskfs/cairn objects, returning ISDIR for directories and INVAL for other special types.
- Type-check NFSv4 WRITE special/delegation filehandle paths with a no-follow mode lookup before reopening for write, returning ISDIR for directories and INVAL for other non-regular objects.

Validation:
- cmake --build build --target chimera
- git diff --check
- ctest --test-dir build -R '^chimera/pynfs/(readdir/RDDR5(a|b|c|f|r|s)|setattr/SATT12(a|b|c|d|f|s)|write/WRT6(a|b|c|d|f|s)|open/OPEN12)_.*_nfs4\.0$' --output-on-failure --test-output-size-failed 65536 -j 24 (114/114 passed)