### PR TITLE
diskfs: require explicit initialize for mkfs

### DIFF
--- a/scripts/pynfs_test_wrapper.sh
+++ b/scripts/pynfs_test_wrapper.sh
@@ -106,7 +106,7 @@ generate_config() {
             BACKEND="diskfs"
             vfs_section="\"vfs\": {
                 \"diskfs\": {
-                    \"config\": {\"devices\":[$devices_json],\"unsafe_async\":true}
+                    \"config\": {\"initialize\":true,\"devices\":[$devices_json],\"unsafe_async\":true}
                 }
             },"
             ;;

--- a/src/client/tests/client_test_common.h
+++ b/src/client/tests/client_test_common.h
@@ -149,6 +149,7 @@ client_test_init(
                 close(fd);
             }
 
+            json_object_set_new(cfg, "initialize", json_true());
             json_object_set_new(cfg, "devices", devices);
             json_object_set_new(cfg, "unsafe_async", json_true());
             json_str = json_dumps(cfg, JSON_COMPACT);
@@ -255,6 +256,7 @@ client_test_init(
                     close(fd);
                 }
 
+                json_object_set_new(cfg, "initialize", json_true());
                 json_object_set_new(cfg, "devices", devices);
                 json_object_set_new(cfg, "unsafe_async", json_true());
                 json_str = json_dumps(cfg, JSON_COMPACT);

--- a/src/fio/tests/diskfs_aio_basic.json
+++ b/src/fio/tests/diskfs_aio_basic.json
@@ -4,6 +4,7 @@
             "module": "diskfs",
             "module_path": "${CMAKE_BINARY_DIR}/src/vfs/diskfs/libchimera_vfs_diskfs.so",
             "config": {
+                "initialize": true,
                 "devices": [
                     {
                         "type": "libaio",

--- a/src/fio/tests/diskfs_io_uring_basic.json
+++ b/src/fio/tests/diskfs_io_uring_basic.json
@@ -4,6 +4,7 @@
             "module": "diskfs",
             "module_path": "${CMAKE_BINARY_DIR}/src/vfs/diskfs/libchimera_vfs_diskfs.so",
             "config": {
+                "initialize": true,
                 "devices": [
                     {
                         "type": "io_uring",

--- a/src/posix/tests/fsx.c
+++ b/src/posix/tests/fsx.c
@@ -3973,7 +3973,7 @@ main(
                 /* unsafe_async: tests below do not exercise crash recovery, so skip
                  * FUA/sync on writes to run lighter. */
                 snprintf(diskfs_cfg + off, sizeof(diskfs_cfg) - off,
-                         "],\"unsafe_async\":true}");
+                         "],\"initialize\":true,\"unsafe_async\":true}");
 
                 chimera_server_config_add_module(chimera_server_config, "diskfs", NULL, diskfs_cfg);
             } else if (strcmp(chimera_nfs_backend, "cairn") == 0) {

--- a/src/posix/tests/posix_test_common.h
+++ b/src/posix/tests/posix_test_common.h
@@ -116,6 +116,7 @@ posix_test_configure_diskfs(
         close(fd);
     }
 
+    json_object_set_new(cfg, "initialize", json_true());
     json_object_set_new(cfg, "devices", devices);
     json_object_set_new(cfg, "unsafe_async", json_true());
     json_str = json_dumps(cfg, JSON_COMPACT);

--- a/src/posix/tests/run_fsx.sh
+++ b/src/posix/tests/run_fsx.sh
@@ -113,7 +113,7 @@ generate_config() {
             modules_section="\"modules\": {
         \"diskfs\": {
             \"path\": \"/build/test/diskfs\",
-            \"config\": {\"devices\":[$DEVICES_JSON],\"unsafe_async\":true}
+            \"config\": {\"initialize\":true,\"devices\":[$DEVICES_JSON],\"unsafe_async\":true}
         }
     },"
             BACKEND="diskfs"

--- a/src/server/s3/tests/s3_test.py
+++ b/src/server/s3/tests/s3_test.py
@@ -112,7 +112,7 @@ class ChimeraServer:
             config["server"]["vfs"] = {
                 "diskfs": {
                     "path": None,
-                    "config": {"devices": devices, "unsafe_async": True}
+                    "config": {"initialize": True, "devices": devices, "unsafe_async": True}
                 }
             }
             config["mounts"]["share"] = {

--- a/src/server/smb/tests/smbtorture_test.c
+++ b/src/server/smb/tests/smbtorture_test.c
@@ -252,6 +252,7 @@ main(
             close(fd);
         }
 
+        json_object_set_new(cfg, "initialize", json_true());
         json_object_set_new(cfg, "devices", devices);
         /* unsafe_async: this test does not exercise crash recovery, so skip FUA/sync
          * on writes to run lighter. */

--- a/src/vfs/diskfs/diskfs.c
+++ b/src/vfs/diskfs/diskfs.c
@@ -6927,6 +6927,7 @@ diskfs_init(const char *cfgdata)
     uint64_t                   *device_sizes;
     json_t                     *cfg, *devices_cfg, *device_cfg;
     json_error_t                json_error;
+    int                         initialize;
 
 
     cfg = json_loads(cfgdata, 0, &json_error);
@@ -6998,6 +6999,7 @@ diskfs_init(const char *cfgdata)
      * FUA/sync, so diskfs runs lighter at the cost of crash safety.  Off by
      * default; tests that do not exercise crash recovery enable it to run more
      * efficiently. */
+    initialize                 = json_object_get(cfg, "initialize") != NULL;
     shared->unsafe_async       = json_is_true(json_object_get(cfg, "unsafe_async"));
     shared->block_cache_blocks = (uint32_t) json_integer_value(
         json_object_get(cfg, "block_cache_blocks"));
@@ -7011,11 +7013,12 @@ diskfs_init(const char *cfgdata)
 
     /* Decide mkfs vs clean-mount vs crash-recovery from the superblock, just as
      * a real filesystem would:
-     *   - valid + CLEAN  -> the previous instance unmounted cleanly: reload
-     *                       its persisted free-space map and mount.
-     *   - valid + !CLEAN -> a crash: synchronously replay the intent log to
-     *                       home, then mount the now-consistent image.
-     *   - no/garbage     -> mkfs (e.g. a freshly created device image).
+     *   - initialize present -> mkfs, regardless of any existing contents.
+     *   - valid + CLEAN      -> previous instance unmounted cleanly: reload
+     *                           the persisted free-space map and mount.
+     *   - valid + !CLEAN     -> crash: replay the intent log to home, then
+     *                           mount the now-consistent image.
+     *   - no/garbage         -> fail; callers must opt in to mkfs.
      */
     {
         struct sm_superblock    sb;
@@ -7026,15 +7029,22 @@ diskfs_init(const char *cfgdata)
 
         have_sb = space_map_read_superblock(&smio, &sb) == 0;
 
-        if (have_sb && (sb.flags & SM_SB_CLEAN)) {
+        if (initialize) {
+            if (have_sb) {
+                chimera_diskfs_info(
+                    "initialize=true: ignoring existing superblock and formatting fresh");
+            }
+            mode         = 0;
+            shared->fsid = chimera_rand64();
+        } else if (have_sb && (sb.flags & SM_SB_CLEAN)) {
             mode         = 1;
             shared->fsid = sb.fsid;
         } else if (have_sb) {
             mode         = 2;
             shared->fsid = sb.fsid;
         } else {
-            mode         = 0;
-            shared->fsid = chimera_rand64();
+            chimera_diskfs_abort(
+                "diskfs superblock missing or invalid; specify initialize to format");
         }
 
         device_sizes = calloc(shared->num_devices, sizeof(*device_sizes));
@@ -7049,21 +7059,18 @@ diskfs_init(const char *cfgdata)
             diskfs_recover_log(shared, mio);
         }
 
-        /* Reload the persisted free-space map.  NOTE: after a crash this
-         * snapshot is the one from the last *clean* unmount, so it does not
-         * reflect allocations made since then -- reads are correct (the log
-         * replay made the home image consistent) but the in-memory allocator
-         * must be rebuilt (namespace-walk fsck, TODO) before writes are safe.
-         * For a clean mount the snapshot must load or we fall back to mkfs. */
+        /* Reload the persisted free-space map.  The allocator is authoritative
+         * for future writes; after recovery, mounting without it would let new
+         * allocations overlap live metadata/data until namespace-walk rebuild
+         * exists. */
         if (mode != 0 &&
             space_map_load(shared->space_map, &smio) != 0) {
             if (mode == 1) {
-                chimera_diskfs_error("space-map reload failed; treating as fresh");
-                mode = 0;
+                chimera_diskfs_abort("space-map reload failed");
             } else {
-                chimera_diskfs_error(
-                    "post-recovery space-map reload failed; allocator is fresh "
-                    "(writes unsafe until namespace-walk reconstruction)");
+                chimera_diskfs_abort(
+                    "post-recovery space-map reload failed; refusing unsafe mount "
+                    "until namespace-walk reconstruction is implemented");
             }
         }
 


### PR DESCRIPTION
## Summary
- make diskfs format only when the initialize key is present
- fail mounting when initialize is absent and no valid filesystem exists
- abort instead of silently formatting on space-map reload failures
- mark diskfs test configs that create fresh device images with initialize

## Testing
- git diff --check
- cmake -S . -B /tmp/diskfs-fail-build -DCMAKE_BUILD_TYPE=Debug -DIO_URING_ENABLED=OFF -DDISABLE_TESTS=ON
- cmake --build /tmp/diskfs-fail-build --target chimera_vfs_diskfs -j2