### PR TITLE
nfs4: fix v4.0 owner replay edge cases

### DIFF
--- a/src/server/nfs/nfs.c
+++ b/src/server/nfs/nfs.c
@@ -33,6 +33,49 @@
 #define NFS_PROGIDX_MAX        5
 
 static void
+nfs4_v40_drc_init(struct nfs4_v40_drc *drc)
+{
+    pthread_mutex_init(&drc->lock, NULL);
+} /* nfs4_v40_drc_init */
+
+static void
+nfs4_v40_drc_destroy(struct nfs4_v40_drc *drc)
+{
+    pthread_mutex_lock(&drc->lock);
+    for (uint32_t i = 0; i < NFS4_V40_DRC_SLOTS; i++) {
+        struct nfs4_v40_drc_entry *entry = &drc->entries[i];
+
+        free(entry->buf);
+        entry->buf   = NULL;
+        entry->len   = 0;
+        entry->valid = 0;
+    }
+    drc->bytes = 0;
+    pthread_mutex_unlock(&drc->lock);
+    pthread_mutex_destroy(&drc->lock);
+} /* nfs4_v40_drc_destroy */
+
+static void
+nfs4_v40_drc_remove_conn(
+    struct nfs4_v40_drc   *drc,
+    struct evpl_rpc2_conn *conn)
+{
+    pthread_mutex_lock(&drc->lock);
+    for (uint32_t i = 0; i < NFS4_V40_DRC_SLOTS; i++) {
+        struct nfs4_v40_drc_entry *entry = &drc->entries[i];
+
+        if (entry->valid && entry->conn == conn) {
+            drc->bytes -= entry->len;
+            free(entry->buf);
+            entry->buf   = NULL;
+            entry->len   = 0;
+            entry->valid = 0;
+        }
+    }
+    pthread_mutex_unlock(&drc->lock);
+} /* nfs4_v40_drc_remove_conn */
+
+static void
 chimera_nfs_init_metrics(
     struct chimera_server_nfs_shared *shared,
     struct evpl_rpc2_program         *program)
@@ -241,6 +284,7 @@ nfs_server_init(
     nfs4_client_table_init(&shared->nfs4_shared_clients);
     nfs_state_table_init(&shared->nfs4_state_table);
     nfs_layout_table_init(&shared->nfs4_layout_table);
+    nfs4_v40_drc_init(&shared->v40_drc);
     pthread_mutex_init(&shared->nfs4_pnfs_devcache.lock, NULL);
     shared->nfs4_pnfs_devcache.count = 0;
 
@@ -510,6 +554,7 @@ nfs_server_destroy(void *data)
     }
 
     nlm_state_destroy(&shared->nlm_state);
+    nfs4_v40_drc_destroy(&shared->v40_drc);
 
     free(shared);
 } /* nfs_server_destroy */
@@ -539,6 +584,8 @@ chimera_nfs_server_notify(
             evpl_rpc2_conn_get_local_address(conn, local_addr, sizeof(local_addr));
             evpl_rpc2_conn_get_remote_address(conn, remote_addr, sizeof(remote_addr));
             chimera_nfs_debug("Client disconnected from %s to %s", remote_addr, local_addr);
+
+            nfs4_v40_drc_remove_conn(&shared->v40_drc, conn);
 
             priv = evpl_rpc2_conn_get_private_data(conn);
             if (!priv) {

--- a/src/server/nfs/nfs4_proc_close.c
+++ b/src/server/nfs/nfs4_proc_close.c
@@ -33,6 +33,18 @@ chimera_nfs4_close(
                                      &state_type);
 
     if (status != NFS4_OK) {
+        struct nfs4_replay_cache replay;
+
+        if (is_v40 &&
+            nfs_state_table_lookup_replay(table, &args->open_stateid,
+                                          OP_CLOSE, args->seqid,
+                                          &replay) == NFS4_OK) {
+            res->status       = replay.status;
+            res->open_stateid = replay.stateid;
+            chimera_nfs4_compound_complete(req, res->status);
+            return;
+        }
+
         res->status = status;
         chimera_nfs4_compound_complete(req, res->status);
         return;

--- a/src/server/nfs/nfs4_proc_compound.c
+++ b/src/server/nfs/nfs4_proc_compound.c
@@ -73,12 +73,12 @@ nfs4_replay_cached_body_offset(
 } /* nfs4_replay_cached_body_offset */
 
 static int
-nfs4_send_cached_reply(
+nfs4_send_cached_reply_buf(
     struct chimera_server_nfs_thread *thread,
-    struct nfs_request               *req)
+    struct nfs_request               *req,
+    const uint8_t                    *cached,
+    uint32_t                          cached_len)
 {
-    const uint8_t     *cached     = req->replay_slot->cached_buf;
-    uint32_t           cached_len = req->replay_slot->cached_len;
     uint32_t           body_offset, body_len, reserve;
     struct evpl_iovec *msg_iov;
     int                niov;
@@ -108,7 +108,173 @@ nfs4_send_cached_reply(
                                          msg_iov,
                                          1,
                                          body_len + reserve);
+} /* nfs4_send_cached_reply_buf */
+
+static int
+nfs4_send_cached_reply(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_request               *req)
+{
+    return nfs4_send_cached_reply_buf(thread,
+                                      req,
+                                      req->replay_slot->cached_buf,
+                                      req->replay_slot->cached_len);
 } /* nfs4_send_cached_reply */
+
+static void
+nfs4_release_write_args(
+    struct chimera_server_nfs_thread *thread,
+    struct COMPOUND4args             *args)
+{
+    for (uint32_t i = 0; i < args->num_argarray; i++) {
+        struct nfs_argop4 *ap = &args->argarray[i];
+
+        if (ap->argop == OP_WRITE && ap->opwrite.data.niov) {
+            evpl_iovecs_release(thread->evpl,
+                                ap->opwrite.data.iov,
+                                ap->opwrite.data.niov);
+            ap->opwrite.data.niov = 0;
+        }
+    }
+} /* nfs4_release_write_args */
+
+static bool
+nfs4_v40_drc_lookup(
+    struct nfs4_v40_drc   *drc,
+    struct evpl_rpc2_conn *conn,
+    uint32_t               xid,
+    uint8_t              **out_buf,
+    uint32_t              *out_len)
+{
+    uint8_t *buf = NULL;
+    uint32_t len = 0;
+
+    pthread_mutex_lock(&drc->lock);
+    for (uint32_t i = 0; i < NFS4_V40_DRC_SLOTS; i++) {
+        struct nfs4_v40_drc_entry *entry = &drc->entries[i];
+
+        if (entry->valid && entry->conn == conn && entry->xid == xid) {
+            len = entry->len;
+            buf = malloc(len);
+            if (buf) {
+                memcpy(buf, entry->buf, len);
+            }
+            break;
+        }
+    }
+    pthread_mutex_unlock(&drc->lock);
+
+    if (!buf) {
+        return false;
+    }
+
+    *out_buf = buf;
+    *out_len = len;
+    return true;
+} /* nfs4_v40_drc_lookup */
+
+static void
+nfs4_v40_drc_insert(
+    struct nfs4_v40_drc     *drc,
+    struct evpl_rpc2_conn   *conn,
+    uint32_t                 xid,
+    const struct evpl_iovec *iov,
+    int                      niov,
+    int                      total_length)
+{
+    struct nfs4_v40_drc_entry *entry;
+    uint8_t                   *buf;
+    size_t                     offset = 0;
+
+    if (total_length <= 0 ||
+        (uint32_t) total_length > NFS4_MAX_CACHED_RESPONSE_SIZE) {
+        return;
+    }
+
+    buf = malloc((size_t) total_length);
+    if (!buf) {
+        return;
+    }
+
+    for (int i = 0; i < niov; i++) {
+        memcpy(buf + offset, iov[i].data, iov[i].length);
+        offset += iov[i].length;
+    }
+
+    pthread_mutex_lock(&drc->lock);
+
+    for (uint32_t i = 0; i < NFS4_V40_DRC_SLOTS; i++) {
+        entry = &drc->entries[i];
+        if (entry->valid && entry->conn == conn && entry->xid == xid) {
+            drc->bytes -= entry->len;
+            free(entry->buf);
+            entry->buf  = buf;
+            entry->len  = (uint32_t) total_length;
+            drc->bytes += entry->len;
+            pthread_mutex_unlock(&drc->lock);
+            return;
+        }
+    }
+
+    while (drc->bytes + (uint32_t) total_length > NFS4_MAX_REPLY_CACHE_BYTES) {
+        entry     = &drc->entries[drc->next];
+        drc->next = (drc->next + 1) % NFS4_V40_DRC_SLOTS;
+        if (!entry->valid) {
+            break;
+        }
+        drc->bytes -= entry->len;
+        free(entry->buf);
+        entry->buf   = NULL;
+        entry->len   = 0;
+        entry->valid = 0;
+    }
+
+    entry     = &drc->entries[drc->next];
+    drc->next = (drc->next + 1) % NFS4_V40_DRC_SLOTS;
+    if (entry->valid) {
+        drc->bytes -= entry->len;
+        free(entry->buf);
+    }
+
+    entry->conn  = conn;
+    entry->xid   = xid;
+    entry->len   = (uint32_t) total_length;
+    entry->buf   = buf;
+    entry->valid = 1;
+    drc->bytes  += entry->len;
+
+    pthread_mutex_unlock(&drc->lock);
+} /* nfs4_v40_drc_insert */
+
+static void
+nfs4_v40_drc_capture_reply(
+    const struct evpl_iovec *iov,
+    int                      niov,
+    int                      total_length,
+    void                    *private_data)
+{
+    struct nfs_request *req = private_data;
+
+    if (!req || req->minorversion != 0) {
+        return;
+    }
+
+    nfs4_v40_drc_insert(&req->thread->shared->v40_drc,
+                        req->conn,
+                        req->encoding->xid,
+                        iov,
+                        niov,
+                        total_length);
+} /* nfs4_v40_drc_capture_reply */
+
+static void
+nfs4_v40_drc_arm_capture(struct nfs_request *req)
+{
+    if (req->encoding) {
+        req->encoding->reply_capture_cb      = nfs4_v40_drc_capture_reply;
+        req->encoding->reply_capture_private = req;
+    }
+} /* nfs4_v40_drc_arm_capture */
 
 void
 chimera_nfs4_compound_process(
@@ -133,15 +299,7 @@ chimera_nfs4_compound_process(
         /* XDR clones a +1 ref on every WRITE4args.data; the retransmit
          * we are about to discard had its args unmarshalled but will
          * never dispatch, so release any cloned iovecs here. */
-        for (uint32_t i = 0; i < req->args_compound->num_argarray; i++) {
-            struct nfs_argop4 *ap = &req->args_compound->argarray[i];
-            if (ap->argop == OP_WRITE && ap->opwrite.data.niov) {
-                evpl_iovecs_release(thread->evpl,
-                                    ap->opwrite.data.iov,
-                                    ap->opwrite.data.niov);
-                ap->opwrite.data.niov = 0;
-            }
-        }
+        nfs4_release_write_args(thread, req->args_compound);
         rc = nfs4_send_cached_reply(thread, req);
         chimera_nfs_abort_if(rc, "Failed to send cached RPC2 reply");
         req->replay_slot = NULL;
@@ -504,6 +662,26 @@ chimera_nfs4_compound(
     req->open_4_0_owner              = NULL;
     req->lock_4_0_open_owner         = NULL;
     req->lock_4_0_lock_owner         = NULL;
+
+    if (args->minorversion == 0) {
+        uint8_t *cached_buf;
+        uint32_t cached_len;
+
+        if (nfs4_v40_drc_lookup(&thread->shared->v40_drc,
+                                conn,
+                                encoding->xid,
+                                &cached_buf,
+                                &cached_len)) {
+            nfs4_release_write_args(thread, args);
+            rc = nfs4_send_cached_reply_buf(thread, req, cached_buf, cached_len);
+            free(cached_buf);
+            chimera_nfs_abort_if(rc, "Failed to send cached RPC2 reply");
+            nfs_request_free(thread, req);
+            return;
+        }
+
+        nfs4_v40_drc_arm_capture(req);
+    }
 
     /* Chimera implements NFS v4.0, v4.1 and v4.2 (minorversions 0–2).
      * Reject unknown minor versions with NFS4ERR_MINOR_VERS_MISMATCH per

--- a/src/server/nfs/nfs4_proc_lock.c
+++ b/src/server/nfs/nfs4_proc_lock.c
@@ -257,7 +257,7 @@ chimera_nfs4_lock(
                 nfs_state_table_release(table, open_state,
                                         NFS4_SLOT_TYPE_OPEN,
                                         thread->vfs_thread);
-                chimera_nfs4_compound_complete(req, NFS4_OK);
+                chimera_nfs4_compound_complete(req, res->status);
                 return;
             }
             if (cls != NFS4_SEQID_NEW) {
@@ -353,7 +353,7 @@ chimera_nfs4_lock(
                                         NFS4_SLOT_TYPE_LOCK,
                                         thread->vfs_thread);
                 req->nfs_state_ref = NULL;
-                chimera_nfs4_compound_complete(req, NFS4_OK);
+                chimera_nfs4_compound_complete(req, res->status);
                 return;
             }
             if (cls != NFS4_SEQID_NEW) {

--- a/src/server/nfs/nfs4_proc_locku.c
+++ b/src/server/nfs/nfs4_proc_locku.c
@@ -72,7 +72,7 @@ chimera_nfs4_locku(
             nfs_state_table_release(table, lock_state, NFS4_SLOT_TYPE_LOCK,
                                     thread->vfs_thread);
             req->nfs_state_ref = NULL;
-            chimera_nfs4_compound_complete(req, NFS4_OK);
+            chimera_nfs4_compound_complete(req, res->status);
             return;
         }
         if (seqid_class != NFS4_SEQID_NEW) {
@@ -101,12 +101,18 @@ chimera_nfs4_locku(
     /* NFS uses UINT64_MAX to mean "to end of file"; vfs_state uses 0. */
     vfs_length = args->length == UINT64_MAX ? 0 : args->length;
 
-    /* RFC 7530 §16.12.4: the unlock range must match a held range exactly.
-     * Find and detach it from this lock_state. */
+    /* RFC 7530 §16.12.4: unlock the specified byte range.  This server tracks
+     * granted ranges as whole extents, so handle the common full-cover case by
+     * removing the held range when it is contained in the unlock range. */
     prev  = NULL;
     match = NULL;
     for (rl = lock_state->range_leases; rl; rl = rl->next) {
-        if (rl->lease.offset == args->offset && rl->lease.length == vfs_length) {
+        uint64_t lock_start = rl->lease.offset;
+        uint64_t lock_len   = rl->lease.length;
+        uint64_t lock_end   = lock_len ? lock_start + lock_len : UINT64_MAX;
+        uint64_t unlock_end = vfs_length ? args->offset + vfs_length : UINT64_MAX;
+
+        if (args->offset <= lock_start && unlock_end >= lock_end) {
             match = rl;
             break;
         }

--- a/src/server/nfs/nfs4_proc_open.c
+++ b/src/server/nfs/nfs4_proc_open.c
@@ -891,7 +891,7 @@ chimera_nfs4_open(
             res->resok4.num_attrset                = 0;
             res->resok4.delegation.delegation_type = OPEN_DELEGATE_NONE;
             pthread_mutex_unlock(&owner->lock);
-            chimera_nfs4_compound_complete(req, NFS4_OK);
+            chimera_nfs4_compound_complete(req, res->status);
             return;
         }
 

--- a/src/server/nfs/nfs4_proc_open_confirm.c
+++ b/src/server/nfs/nfs4_proc_open_confirm.c
@@ -71,7 +71,7 @@ chimera_nfs4_open_confirm(
         pthread_mutex_unlock(&owner->lock);
         nfs_state_table_release(table, open_state, NFS4_SLOT_TYPE_OPEN,
                                 thread->vfs_thread);
-        chimera_nfs4_compound_complete(req, NFS4_OK);
+        chimera_nfs4_compound_complete(req, res->status);
         return;
     }
 

--- a/src/server/nfs/nfs4_proc_open_downgrade.c
+++ b/src/server/nfs/nfs4_proc_open_downgrade.c
@@ -75,7 +75,7 @@ chimera_nfs4_open_downgrade(
             pthread_mutex_unlock(&owner->lock);
             nfs_state_table_release(table, open_state, NFS4_SLOT_TYPE_OPEN,
                                     thread->vfs_thread);
-            chimera_nfs4_compound_complete(req, NFS4_OK);
+            chimera_nfs4_compound_complete(req, res->status);
             return;
         }
         if (seqid_class != NFS4_SEQID_NEW) {

--- a/src/server/nfs/nfs4_state.c
+++ b/src/server/nfs/nfs4_state.c
@@ -169,6 +169,7 @@ nfs_state_table_alloc(
     slot->generation += 1;          /* every (re)use advances generation */
     slot->type        = type;
     slot->state       = NULL;       /* installed separately */
+    slot->replay.valid = 0;
 
     *out_shard      = shard_idx;
     *out_slot_idx   = slot_idx;
@@ -218,6 +219,7 @@ nfs_state_table_free_slot(
                          slot_idx, shard->slots_used);
 
     slot              = &shard->slots[slot_idx];
+    slot->replay.valid = 0;
     slot->type        = NFS4_SLOT_TYPE_FREE;
     slot->state       = NULL;
     slot->generation += 1;          /* invalidate any extant stateid */
@@ -226,6 +228,38 @@ nfs_state_table_free_slot(
 
     pthread_rwlock_unlock(&shard->lock);
 } /* nfs_state_table_free_slot */
+
+static void
+nfs_state_table_free_slot_replay(
+    struct nfs_state_table        *table,
+    uint8_t                        shard_idx,
+    uint32_t                       slot_idx,
+    const struct nfs4_replay_cache *replay)
+{
+    struct nfs_state_shard *shard = &table->shards[shard_idx];
+    struct nfs_state_slot  *slot;
+
+    pthread_rwlock_wrlock(&shard->lock);
+
+    chimera_nfs_abort_if(slot_idx >= shard->slots_used,
+                         "free of unallocated slot %u/%u",
+                         slot_idx, shard->slots_used);
+
+    slot = &shard->slots[slot_idx];
+    if (replay && replay->valid) {
+        slot->replay            = *replay;
+        slot->replay_generation = slot->generation;
+    } else {
+        slot->replay.valid = 0;
+    }
+    slot->type        = NFS4_SLOT_TYPE_FREE;
+    slot->state       = NULL;
+    slot->generation += 1;
+
+    (void) shard_push_free_locked(shard, slot_idx);
+
+    pthread_rwlock_unlock(&shard->lock);
+} /* nfs_state_table_free_slot_replay */
 
 /* Like nfs_state_table_free_slot, but for a slot whose owning client was
  * purged.  The generation is left unchanged so a stateid the client still
@@ -395,6 +429,49 @@ nfs_state_table_acquire(
 
     return status;
 } /* nfs_state_table_acquire */
+
+nfsstat4
+nfs_state_table_lookup_replay(
+    struct nfs_state_table   *table,
+    const struct stateid4    *sid,
+    uint32_t                  op,
+    uint32_t                  seqid,
+    struct nfs4_replay_cache *out_replay)
+{
+    struct nfs4_stateid_view view;
+    struct nfs_state_shard  *shard;
+    struct nfs_state_slot   *slot;
+
+    nfs4_stateid_decode(&view, sid);
+    if (view.epoch != table->epoch) {
+        return NFS4ERR_STALE_STATEID;
+    }
+    if (view.version != NFS4_STATEID_VERSION ||
+        view.shard >= NFS_STATE_NUM_SHARDS) {
+        return NFS4ERR_BAD_STATEID;
+    }
+
+    shard = &table->shards[view.shard];
+    pthread_rwlock_rdlock(&shard->lock);
+
+    if (view.slot_idx >= shard->slots_used) {
+        pthread_rwlock_unlock(&shard->lock);
+        return NFS4ERR_BAD_STATEID;
+    }
+
+    slot = &shard->slots[view.slot_idx];
+    if (!slot->replay.valid ||
+        slot->replay_generation != view.generation ||
+        slot->replay.op != op ||
+        slot->replay.seqid != seqid) {
+        pthread_rwlock_unlock(&shard->lock);
+        return NFS4ERR_BAD_STATEID;
+    }
+
+    *out_replay = slot->replay;
+    pthread_rwlock_unlock(&shard->lock);
+    return NFS4_OK;
+} /* nfs_state_table_lookup_replay */
 
 /* Forward decls for cleanup paths used by release. */
 static void
@@ -567,6 +644,9 @@ open_state_destroy_locked(
 
     if (expire) {
         nfs_state_table_expire_slot(table, state->shard, state->slot_idx);
+    } else if (owner->replay.valid && owner->replay.op == OP_CLOSE) {
+        nfs_state_table_free_slot_replay(table, state->shard, state->slot_idx,
+                                         &owner->replay);
     } else {
         nfs_state_table_free_slot(table, state->shard, state->slot_idx);
     }

--- a/src/server/nfs/nfs4_state.c
+++ b/src/server/nfs/nfs4_state.c
@@ -165,10 +165,10 @@ nfs_state_table_alloc(
         slot_idx = shard->slots_used++;
     }
 
-    slot              = &shard->slots[slot_idx];
-    slot->generation += 1;          /* every (re)use advances generation */
-    slot->type        = type;
-    slot->state       = NULL;       /* installed separately */
+    slot               = &shard->slots[slot_idx];
+    slot->generation  += 1;         /* every (re)use advances generation */
+    slot->type         = type;
+    slot->state        = NULL;      /* installed separately */
     slot->replay.valid = 0;
 
     *out_shard      = shard_idx;
@@ -218,11 +218,11 @@ nfs_state_table_free_slot(
                          "free of unallocated slot %u/%u",
                          slot_idx, shard->slots_used);
 
-    slot              = &shard->slots[slot_idx];
+    slot               = &shard->slots[slot_idx];
     slot->replay.valid = 0;
-    slot->type        = NFS4_SLOT_TYPE_FREE;
-    slot->state       = NULL;
-    slot->generation += 1;          /* invalidate any extant stateid */
+    slot->type         = NFS4_SLOT_TYPE_FREE;
+    slot->state        = NULL;
+    slot->generation  += 1;         /* invalidate any extant stateid */
 
     (void) shard_push_free_locked(shard, slot_idx);
 
@@ -231,9 +231,9 @@ nfs_state_table_free_slot(
 
 static void
 nfs_state_table_free_slot_replay(
-    struct nfs_state_table        *table,
-    uint8_t                        shard_idx,
-    uint32_t                       slot_idx,
+    struct nfs_state_table         *table,
+    uint8_t                         shard_idx,
+    uint32_t                        slot_idx,
     const struct nfs4_replay_cache *replay)
 {
     struct nfs_state_shard *shard = &table->shards[shard_idx];

--- a/src/server/nfs/nfs4_state.h
+++ b/src/server/nfs/nfs4_state.h
@@ -441,11 +441,11 @@ void nfs_layout_state_put(
 #define NFS4_SLOT_TYPE_LAYOUT  5
 
 struct nfs_state_slot {
-    void                     *state;
-    uint32_t                  generation;
-    uint8_t                   type;
-    uint32_t                  replay_generation;
-    struct nfs4_replay_cache  replay;
+    void                    *state;
+    uint32_t                 generation;
+    uint8_t                  type;
+    uint32_t                 replay_generation;
+    struct nfs4_replay_cache replay;
 };
 
 struct nfs_state_shard {
@@ -521,10 +521,10 @@ SYMBOL_EXPORT nfsstat4 nfs_state_table_acquire(
  * original CLOSE invalidated the stateid, but must still receive the cached
  * owner-seqid reply. */
 SYMBOL_EXPORT nfsstat4 nfs_state_table_lookup_replay(
-    struct nfs_state_table  *table,
-    const struct stateid4   *sid,
-    uint32_t                 op,
-    uint32_t                 seqid,
+    struct nfs_state_table   *table,
+    const struct stateid4    *sid,
+    uint32_t                  op,
+    uint32_t                  seqid,
     struct nfs4_replay_cache *out_replay);
 
 /* Drop the ref taken by acquire.  If this was the last ref and the state has

--- a/src/server/nfs/nfs4_state.h
+++ b/src/server/nfs/nfs4_state.h
@@ -441,9 +441,11 @@ void nfs_layout_state_put(
 #define NFS4_SLOT_TYPE_LAYOUT  5
 
 struct nfs_state_slot {
-    void    *state;
-    uint32_t generation;
-    uint8_t  type;
+    void                     *state;
+    uint32_t                  generation;
+    uint8_t                   type;
+    uint32_t                  replay_generation;
+    struct nfs4_replay_cache  replay;
 };
 
 struct nfs_state_shard {
@@ -513,6 +515,17 @@ SYMBOL_EXPORT nfsstat4 nfs_state_table_acquire(
     uint8_t                 want_type,                     /* 0 = ANY */
     void                  **out_state,
     uint8_t                *out_type);
+
+/* Lookup a replay tombstone left by a just-destroyed state slot.  This is
+ * intentionally narrow: NFSv4.0 CLOSE retransmits can arrive after the
+ * original CLOSE invalidated the stateid, but must still receive the cached
+ * owner-seqid reply. */
+SYMBOL_EXPORT nfsstat4 nfs_state_table_lookup_replay(
+    struct nfs_state_table  *table,
+    const struct stateid4   *sid,
+    uint32_t                 op,
+    uint32_t                 seqid,
+    struct nfs4_replay_cache *out_replay);
 
 /* Drop the ref taken by acquire.  If this was the last ref and the state has
  * been marked destroyed, performs cleanup (releases the VFS handle, frees

--- a/src/server/nfs/nfs_common.h
+++ b/src/server/nfs/nfs_common.h
@@ -190,6 +190,23 @@ struct nfs4_replay_metrics {
     struct prometheus_gauge_instance   *bytes_in_use;
 };
 
+#define NFS4_V40_DRC_SLOTS NFS4_MAX_REPLY_CACHE_SLOTS
+
+struct nfs4_v40_drc_entry {
+    struct evpl_rpc2_conn *conn;
+    uint32_t               xid;
+    uint32_t               len;
+    uint8_t                valid;
+    void                  *buf;
+};
+
+struct nfs4_v40_drc {
+    pthread_mutex_t           lock;
+    uint32_t                  next;
+    uint32_t                  bytes;
+    struct nfs4_v40_drc_entry entries[NFS4_V40_DRC_SLOTS];
+};
+
 struct chimera_server_nfs_shared {
 
     const struct chimera_server_config *config;
@@ -238,6 +255,7 @@ struct chimera_server_nfs_shared {
     struct prometheus_histogram        *op_histogram;
     struct prometheus_metrics          *metrics;
     struct nfs4_replay_metrics          replay_metrics;
+    struct nfs4_v40_drc                 v40_drc;
 };
 
 /* Forward decl for the per-thread lease sweeper (defined in nfs4_lease.h). */


### PR DESCRIPTION
Fix NFSv4.0 replay handling for the pynfs replay suite.

Changes:
- Complete replayed OPEN/LOCK/LOCKU/OPEN_CONFIRM/OPEN_DOWNGRADE compounds with the cached operation status instead of forcing NFS4_OK.
- Allow LOCKU to release a held range fully covered by the requested unlock range.
- Preserve a narrow CLOSE replay tombstone after CLOSE destroys the open state, so retransmitted CLOSE can return the cached owner-seqid reply instead of NFS4ERR_BAD_STATEID.
- Update libevpl to the merged RPC2 request-XID exposure from chimera-nas/libevpl#71.
- Add a bounded NFSv4.0 duplicate request cache keyed by connection and RPC XID, with cached reply capture/replay and disconnect cleanup. This covers non-owner replay such as successful CREATE/MKDIR.

Validation:
- `cmake --build build --target chimera`
- `ctest --test-dir build -R '^chimera/pynfs/(replay/RPLY|sequence/SEQ(9|10b)).*_memfs_nfs4\.[012]$' --output-on-failure --test-output-size-failed 65536 -j 24`
  - Passed all enabled tests in the slice: 22 passed, 6 disabled by the ctest matrix.
- Direct wrapper runs for the disabled v4.0 replay cases:
  - `RPLY14`: passed.
  - `RPLY2 RPLY3 RPLY6 RPLY7 RPLY9`: passed.
