### PR TITLE
kvm: pass initialize=true to diskfs in NFS/SMB test wrappers

### DIFF
--- a/kvm/kvm_nfs_test_wrapper.sh
+++ b/kvm/kvm_nfs_test_wrapper.sh
@@ -118,7 +118,7 @@ generate_config() {
             BACKEND="diskfs"
             vfs_section="\"vfs\": {
                 \"diskfs\": {
-                    \"config\": {\"devices\":[$devices_json],\"unsafe_async\":true}
+                    \"config\": {\"initialize\":true,\"devices\":[$devices_json],\"unsafe_async\":true}
                 }
             },"
             ;;

--- a/kvm/kvm_smb_test_wrapper.sh
+++ b/kvm/kvm_smb_test_wrapper.sh
@@ -97,7 +97,7 @@ generate_config() {
             BACKEND="diskfs"
             vfs_section="\"vfs\": {
                 \"diskfs\": {
-                    \"config\": {\"devices\":[$devices_json],\"unsafe_async\":true}
+                    \"config\": {\"initialize\":true,\"devices\":[$devices_json],\"unsafe_async\":true}
                 }
             },"
             ;;


### PR DESCRIPTION
## Problem

#507 ("diskfs: require explicit initialize for mkfs") made diskfs refuse to format unless the config carries an explicit \`initialize\` key — otherwise it aborts at mount:

\`\`\`
diskfs superblock missing or invalid; specify initialize to format  (FATAL)
→ chimera daemon exited prematurely
\`\`\`

#507 updated the **netns** harnesses (\`pynfs_test_wrapper.sh\`, \`run_fsx.sh\`, \`smbtorture_test.c\`, fio configs) to pass \`"initialize":true\`, but did **not** update the **KVM** wrappers. So every KVM diskfs test starts a daemon against freshly-truncated device images **without** \`initialize\` → the daemon aborts at mount.

This breaks all `diskfs_aio` / `diskfs_io_uring` KVM tests (xfstests + cthon + smb) — ~360 failures — while memfs/cairn/linux pass. It was merged with #507's own devcontainer Test jobs red, so it now fails every PR's CI via the merge-into-main build.

## Fix

Add \`"initialize":true\` to the diskfs config in `kvm/kvm_nfs_test_wrapper.sh` and `kvm/kvm_smb_test_wrapper.sh`, matching the netns wrappers. The KVM wrappers truncate fresh 1G device images each run, so mkfs-on-start is the intended behavior. (pnfs wrapper uses a memfs DS and is unaffected.)