### PR TITLE
diskfs: pNFS flex-files and block (RFC 5663) layout support

### DIFF
--- a/kvm/kvm_pnfs_block_test_wrapper.sh
+++ b/kvm/kvm_pnfs_block_test_wrapper.sh
@@ -1,0 +1,202 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+#
+# SPDX-License-Identifier: Unlicense
+
+# Usage: kvm_pnfs_block_test_wrapper.sh <vmlinuz> <rootfs.qcow2> <chimera_binary> <backend> <test_cmd>
+#
+# Orchestrates a pNFS *block* layout (RFC 5663) setup and a QEMU VM to exercise
+# it.  Unlike flex-files there is no data server: the file data lives on a block
+# device the *client* can reach directly.
+#
+# 1. A raw "data" disk image is created and a SIMPLE-volume signature is written
+#    at a fixed offset.  diskfs is told about this device as a "remote" data
+#    device (size + deviceid + signature) -- the chimera daemon NEVER opens it;
+#    it only tracks free space on it and hands out block extents.  The disk is
+#    attached to the VM as a virtio-SCSI disk (/dev/sda).  It MUST be SCSI
+#    (not virtio-blk): blkmapd identifies candidate disks via an SG_IO SCSI
+#    INQUIRY, which virtio-blk does not support.
+# 2. A block-mode chimera metadata server (diskfs, block_layout=true) runs on
+#    10.0.0.1:2049 with a local metadata device.
+# 3. The VM boots, starts blkmapd (which matches the advertised signature to
+#    /dev/sda), mounts the MDS vers=4.1, and runs the workload.  On LAYOUTGET
+#    the MDS allocates extents on the remote volume and returns a block layout;
+#    the client reads/writes the data directly to /dev/sda.  Because the MDS has
+#    no access to the data device it rejects inline READ/WRITE with EINVAL, so a
+#    drop-caches re-read that still matches proves the block layout was used.
+
+set -u
+
+ARCH=$(uname -m)
+if [ "$ARCH" = "aarch64" ]; then
+    QEMU_BIN="qemu-system-aarch64"
+    QEMU_MACHINE="-machine virt"
+    QEMU_CONSOLE="ttyAMA0"
+else
+    QEMU_BIN="qemu-system-x86_64"
+    QEMU_MACHINE="-machine q35,usb=off"
+    QEMU_CONSOLE="ttyS0"
+fi
+
+VMLINUZ=$1; shift
+ROOTFS=$1; shift
+CHIMERA_BINARY=$1; shift
+BACKEND=$1; shift
+TEST_CMD_ARG="$*"
+
+INITRD="$(dirname "$VMLINUZ")/initrd"
+if [ -f "$INITRD" ]; then
+    QEMU_INITRD="-initrd $INITRD"
+else
+    QEMU_INITRD=""
+fi
+
+NETNS_NAME="kvm_pnfsblk_$$_$(date +%s%N)"
+TAP_NAME="tapb_$$"
+LOG_FILE=$(mktemp /tmp/kvm_pnfsblk_test_XXXXXX.log)
+BUILD_DIR=$(dirname "$(dirname "$CHIMERA_BINARY")")
+SESSION_DIR=$(mktemp -d "${BUILD_DIR}/kvm_pnfsblk_session_XXXXXX")
+MDS_CONFIG="${SESSION_DIR}/mds.json"
+MDS_LOG="${SESSION_DIR}/mds.log"
+DATA_IMG="${SESSION_DIR}/data.img"
+MDS_PID=""
+
+MDS_IP="10.0.0.1"
+MDS_PORT=2049
+
+# Data volume: size, stable deviceid, and a SIMPLE-volume content signature at
+# offset 0 that blkmapd matches against /dev/sda.
+DATA_SIZE=2147483648
+DEVICEID="00112233445566778899aabbccddeeff"
+SIG_OFFSET=0
+SIG_MAGIC="CHIMERAPNFSBLK01"
+SIG_HEX=$(printf '%s' "$SIG_MAGIC" | od -An -v -tx1 | tr -d ' \n')
+
+cleanup() {
+    if [ -n "$MDS_PID" ]; then
+        kill "$MDS_PID" 2>/dev/null || true
+        for i in $(seq 1 30); do
+            kill -0 "$MDS_PID" 2>/dev/null || break
+            sleep 0.1
+        done
+        kill -9 "$MDS_PID" 2>/dev/null || true
+        wait "$MDS_PID" 2>/dev/null || true
+    fi
+    if [ -f "$LOG_FILE" ]; then
+        echo "=== Guest serial log ==="
+        cat "$LOG_FILE"
+    fi
+    if [ -f "$MDS_LOG" ]; then
+        echo "=== Metadata server log (tail) ==="
+        tail -30 "$MDS_LOG"
+    fi
+    ip netns delete "${NETNS_NAME}" 2>/dev/null || true
+    rm -f "$LOG_FILE"
+    rm -rf "$SESSION_DIR"
+}
+trap cleanup EXIT
+
+# The block-mode metadata server: a local metadata device (device 0) plus the
+# remote data device (device 1) described purely by config.
+generate_mds_config() {
+    local device_type="io_uring"
+    [ "$BACKEND" = "diskfs_aio" ] && device_type="libaio"
+    local meta="${SESSION_DIR}/mds-meta.img"
+    truncate -s 4G "$meta"
+
+    cat > "$MDS_CONFIG" << EOF
+{
+    "server": {
+        "threads": 4,
+        "external_portmap": false,
+        "vfs": {
+            "diskfs": {
+                "config": {
+                    "initialize": true,
+                    "unsafe_async": true,
+                    "block_layout": true,
+                    "devices": [
+                        { "type": "${device_type}", "size": 4294967296, "path": "${meta}" },
+                        { "role": "remote", "size": ${DATA_SIZE}, "deviceid": "${DEVICEID}",
+                          "signature": { "offset": ${SIG_OFFSET}, "bytes": "${SIG_HEX}" } }
+                    ]
+                }
+            }
+        },
+        "pnfs": { "enabled": true }
+    },
+    "mounts": { "share": { "module": "diskfs", "path": "/" } },
+    "exports": { "/share": { "path": "/share" } }
+}
+EOF
+}
+
+wait_for_port() {
+    local ip="$1" port="$2" pid="$3"
+    for i in $(seq 1 50); do
+        if ip netns exec "${NETNS_NAME}" bash -c "echo > /dev/tcp/${ip}/${port}" 2>/dev/null; then
+            return 0
+        fi
+        if ! kill -0 "$pid" 2>/dev/null; then
+            echo "chimera daemon (pid $pid) exited prematurely" >&2
+            return 1
+        fi
+        sleep 0.1
+    done
+    echo "timed out waiting for ${ip}:${port}" >&2
+    return 1
+}
+
+ulimit -l unlimited
+echo 16777216 > /proc/sys/fs/aio-max-nr 2>/dev/null || true
+
+# The signed data disk the client will reach as /dev/sda (virtio-SCSI).
+truncate -s "$DATA_SIZE" "$DATA_IMG"
+printf '%s' "$SIG_MAGIC" | dd of="$DATA_IMG" bs=1 conv=notrunc 2>/dev/null
+
+# Network namespace + TAP for the VM.
+ip netns add "${NETNS_NAME}"
+ip netns exec "${NETNS_NAME}" ip link set lo up
+ip netns exec "${NETNS_NAME}" ip tuntap add dev "${TAP_NAME}" mode tap
+ip netns exec "${NETNS_NAME}" ip addr add 10.0.0.1/24 dev "${TAP_NAME}"
+ip netns exec "${NETNS_NAME}" ip link set "${TAP_NAME}" up
+
+generate_mds_config
+ip netns exec "${NETNS_NAME}" "$CHIMERA_BINARY" -c "$MDS_CONFIG" > "$MDS_LOG" 2>&1 &
+MDS_PID=$!
+wait_for_port "$MDS_IP" "$MDS_PORT" "$MDS_PID" || exit 1
+echo "=== pNFS block metadata server up on ${MDS_IP}:${MDS_PORT} ==="
+
+# Boot the VM: rootfs as vda (virtio-blk), the signed data volume as /dev/sda
+# (virtio-SCSI, so blkmapd can SG_IO-identify it).  The test command
+# (see kvm/tests/CMakeLists.txt PNFS_BLOCK_CMD_*) starts blkmapd, mounts the MDS
+# and runs the workload -- it owns ordering because blkmapd must be up before
+# the first LAYOUTGET.
+TEST_CMD="${TEST_CMD_ARG}"
+
+ip netns exec "${NETNS_NAME}" "$QEMU_BIN" \
+    -enable-kvm -smp 4 -m 1G -cpu host \
+    -kernel "$VMLINUZ" \
+    $QEMU_INITRD \
+    $QEMU_MACHINE \
+    -nodefaults \
+    -drive file="$ROOTFS",if=virtio,format=qcow2,snapshot=on \
+    -device virtio-scsi-pci,id=scsi0 \
+    -drive file="$DATA_IMG",if=none,id=dd0,format=raw,snapshot=on \
+    -device scsi-hd,drive=dd0,bus=scsi0.0,serial=CHIMERADATA01 \
+    -netdev tap,id=net0,ifname="${TAP_NAME}",script=no,downscript=no \
+    -device virtio-net-pci,netdev=net0,romfile="" \
+    -serial stdio \
+    -nographic \
+    -no-reboot \
+    -append "root=/dev/vda rw console=${QEMU_CONSOLE} net.ifnames=0 biosdevname=0 quiet panic=-1 test_cmd=\"${TEST_CMD}\" init=/init.sh" \
+    2>/dev/null | tee "$LOG_FILE"
+
+if ! kill -0 "$MDS_PID" 2>/dev/null; then
+    wait "$MDS_PID" 2>/dev/null
+    echo "=== chimera MDS (pid $MDS_PID) DIED during the test (exit $?) ==="
+    MDS_PID=""
+fi
+
+EXIT_CODE=$(grep -oP 'CHIMERA_KVM_EXIT_CODE=\K[0-9]+' "$LOG_FILE" | tail -1)
+exit ${EXIT_CODE:-1}

--- a/kvm/kvm_pnfs_test_wrapper.sh
+++ b/kvm/kvm_pnfs_test_wrapper.sh
@@ -126,10 +126,30 @@ EOF
 # The metadata server runs the namespace on the requested backend, nfs-mounts
 # the data server's export at /ds0 (control path, over NFSv4 so no portmap is
 # needed), and steers file data to it via server.pnfs (backing_path "/ds0").
+#
+# In flex-files mode the MDS holds only namespace + the opaque pNFS blob per
+# file (data lives on the DS), so a diskfs MDS needs only a small metadata
+# device.  memfs needs no backing device.
 generate_mds_config() {
+    local module="$BACKEND"
+    local vfs_section=""
+
     case "$BACKEND" in
         memfs) ;;
-        *) echo "pNFS test only supports the memfs backend, got ${BACKEND}" >&2; exit 1 ;;
+        diskfs_io_uring | diskfs_aio)
+            local device_type="io_uring"
+            [ "$BACKEND" = "diskfs_aio" ] && device_type="libaio"
+            local devices_json=""
+            for i in 0 1; do
+                local device_path="${SESSION_DIR}/mds-device-${i}.img"
+                truncate -s 16G "$device_path"
+                [ "$i" -gt 0 ] && devices_json="${devices_json},"
+                devices_json="${devices_json}{\"type\":\"${device_type}\",\"size\":1,\"path\":\"${device_path}\"}"
+            done
+            module="diskfs"
+            vfs_section="\"vfs\": { \"diskfs\": { \"config\": { \"initialize\": true, \"unsafe_async\": true, \"devices\": [${devices_json}] } } },"
+            ;;
+        *) echo "pNFS flex test supports memfs/diskfs backends, got ${BACKEND}" >&2; exit 1 ;;
     esac
 
     cat > "$MDS_CONFIG" << EOF
@@ -137,6 +157,7 @@ generate_mds_config() {
     "server": {
         "threads": 4,
         "external_portmap": false,
+        ${vfs_section}
         "pnfs": {
             "enabled": true,
             "data_servers": [
@@ -145,7 +166,7 @@ generate_mds_config() {
         }
     },
     "mounts": {
-        "share": { "module": "${BACKEND}", "path": "/" },
+        "share": { "module": "${module}", "path": "/" },
         "ds0": { "module": "nfs", "path": "${DS_IP}:/ds_export", "options": "vers=4,port=${DS_PORT}" }
     },
     "exports": { "/share": { "path": "/share" } }

--- a/kvm/tests/CMakeLists.txt
+++ b/kvm/tests/CMakeLists.txt
@@ -6,6 +6,7 @@ set(CHIMERA_BINARY ${CMAKE_BINARY_DIR}/src/daemon/chimera)
 set(NFS_WRAPPER ${CMAKE_SOURCE_DIR}/kvm/kvm_nfs_test_wrapper.sh)
 set(SMB_WRAPPER ${CMAKE_SOURCE_DIR}/kvm/kvm_smb_test_wrapper.sh)
 set(PNFS_WRAPPER ${CMAKE_SOURCE_DIR}/kvm/kvm_pnfs_test_wrapper.sh)
+set(PNFS_BLOCK_WRAPPER ${CMAKE_SOURCE_DIR}/kvm/kvm_pnfs_block_test_wrapper.sh)
 
 set(KVM_BACKENDS memfs linux)
 
@@ -20,6 +21,54 @@ endif()
 if(HAVE_LIBAIO)
     list(APPEND KVM_BACKENDS diskfs_aio)
 endif()
+
+# Backends that implement pNFS flex-files (persist the opaque layout blob):
+# memfs and diskfs.  The diskfs MDS uses a small metadata device; file data
+# still lives on the memfs data server.
+set(PNFS_BACKENDS memfs)
+if(IO_URING_ENABLED)
+    list(APPEND PNFS_BACKENDS diskfs_io_uring)
+endif()
+if(HAVE_LIBAIO)
+    list(APPEND PNFS_BACKENDS diskfs_aio)
+endif()
+
+# pNFS block layout (RFC 5663): diskfs-only (it sources block layouts).  The
+# data lives on a signed virtio-SCSI disk the client reaches directly as
+# /dev/sda; the MDS only allocates extents and never touches it.
+set(PNFS_BLOCK_BACKENDS)
+if(IO_URING_ENABLED)
+    list(APPEND PNFS_BLOCK_BACKENDS diskfs_io_uring)
+endif()
+if(HAVE_LIBAIO)
+    list(APPEND PNFS_BLOCK_BACKENDS diskfs_aio)
+endif()
+
+# Linux block-layout client bring-up, prepended to every block workload.  These
+# requirements were nailed down empirically:
+#   - rpc_pipefs must be mounted at /run/rpc_pipefs -- where this blkmapd build
+#     opens the nfs/blocklayout upcall pipe.
+#   - blocklayoutdriver must be loaded and blkmapd running before the first
+#     LAYOUTGET so it can resolve the device.
+#   - blkmapd identifies candidate disks via an SG_IO SCSI INQUIRY, so the data
+#     disk is presented as virtio-SCSI (see the wrapper); virtio-blk is invisible
+#     to it.
+# In every workload the MDS rejects inline data I/O (no access to the data disk),
+# so a drop-caches re-read that still matches proves the block layout drove the
+# I/O directly to /dev/sda.
+set(PNFS_BLOCK_SETUP "mkdir -p /run/rpc_pipefs && mount -t rpc_pipefs rpc_pipefs /run/rpc_pipefs && modprobe blocklayoutdriver && /usr/sbin/blkmapd && sleep 1 && mount -t nfs -o vers=4.1,tcp 10.0.0.1:/share /mnt")
+
+set(PNFS_BLOCK_PROGRAMS rw remove recall_truncate)
+
+# rw: write 8 MiB through the layout, assert LAYOUTGET, drop caches, read back.
+set(PNFS_BLOCK_WL_rw "mkdir -p /mnt/test && dd if=/dev/urandom of=/tmp/orig bs=1M count=8 2>/dev/null && cp /tmp/orig /mnt/test/f0 && sync && grep -qi LAYOUTGET /proc/self/mountstats && (echo 3 > /proc/sys/vm/drop_caches 2>/dev/null || true) && cmp /tmp/orig /mnt/test/f0")
+# remove: write via the layout, then unlink -- exercises freeing the file's
+# extents on the remote data device (relocated-AG-log allocator) + cleanup.
+set(PNFS_BLOCK_WL_remove "mkdir -p /mnt/test && dd if=/dev/urandom of=/mnt/test/f0 bs=1M count=4 2>/dev/null && sync && grep -qi LAYOUTGET /proc/self/mountstats && rm /mnt/test/f0 && ! test -e /mnt/test/f0")
+# recall_truncate: write 8 MiB, truncate to 4 MiB while a layout may be held
+# (MDS recalls + defers), then verify the surviving 4 MiB is intact -- exercises
+# the truncate path freeing remote extents past EOF + the recall machinery.
+set(PNFS_BLOCK_WL_recall_truncate "mkdir -p /mnt/test && dd if=/dev/urandom of=/tmp/orig bs=1M count=8 2>/dev/null && cp /tmp/orig /mnt/test/f0 && sync && grep -qi LAYOUTGET /proc/self/mountstats && truncate -s 4194304 /mnt/test/f0 && (echo 3 > /proc/sys/vm/drop_caches 2>/dev/null || true) && head -c 4194304 /tmp/orig > /tmp/orig4 && cmp /tmp/orig4 /mnt/test/f0")
 
 set(NFS_VERSIONS 3 4.0 4.1 4.2)
 
@@ -136,16 +185,33 @@ foreach(image_spec ${KVM_IMAGES})
     endif()
 
     # pNFS (NFSv4.1) tests: a metadata server steering data to a separate memfs
-    # data server, both in one netns.  memfs-only (only memfs implements
-    # layouts) and 4.1-only (pNFS requires a session).
+    # data server, both in one netns.  Flex-files backends only (memfs, diskfs)
+    # and 4.1-only (pNFS requires a session).
     foreach(prog ${PNFS_PROGRAMS})
-        add_test(NAME chimera/kvm/${IMAGE_NAME}/pnfs/${prog}_memfs_nfs4.1
-            COMMAND bash ${PNFS_WRAPPER}
-                    ${IMAGE_DIR}/vmlinuz ${IMAGE_DIR}/rootfs.qcow2
-                    ${CHIMERA_BINARY} memfs 4.1
-                    "${PNFS_CMD_${prog}}")
-        set_tests_properties(chimera/kvm/${IMAGE_NAME}/pnfs/${prog}_memfs_nfs4.1
-            PROPERTIES LABELS "kvm;${IMAGE_NAME};pnfs" PROCESSORS 2)
+        foreach(pbackend ${PNFS_BACKENDS})
+            add_test(NAME chimera/kvm/${IMAGE_NAME}/pnfs/${prog}_${pbackend}_nfs4.1
+                COMMAND bash ${PNFS_WRAPPER}
+                        ${IMAGE_DIR}/vmlinuz ${IMAGE_DIR}/rootfs.qcow2
+                        ${CHIMERA_BINARY} ${pbackend} 4.1
+                        "${PNFS_CMD_${prog}}")
+            set_tests_properties(chimera/kvm/${IMAGE_NAME}/pnfs/${prog}_${pbackend}_nfs4.1
+                PROPERTIES LABELS "kvm;${IMAGE_NAME};pnfs" PROCESSORS 2)
+        endforeach()
+    endforeach()
+
+    # pNFS block layout (RFC 5663): diskfs sources block layouts; the client
+    # does data I/O directly to the signed virtio-SCSI data disk (/dev/sda),
+    # never through the MDS (which can't reach it).
+    foreach(prog ${PNFS_BLOCK_PROGRAMS})
+        foreach(pbackend ${PNFS_BLOCK_BACKENDS})
+            add_test(NAME chimera/kvm/${IMAGE_NAME}/pnfs/block_${prog}_${pbackend}_nfs4.1
+                COMMAND bash ${PNFS_BLOCK_WRAPPER}
+                        ${IMAGE_DIR}/vmlinuz ${IMAGE_DIR}/rootfs.qcow2
+                        ${CHIMERA_BINARY} ${pbackend}
+                        "${PNFS_BLOCK_SETUP} && ${PNFS_BLOCK_WL_${prog}}")
+            set_tests_properties(chimera/kvm/${IMAGE_NAME}/pnfs/block_${prog}_${pbackend}_nfs4.1
+                PROPERTIES LABELS "kvm;${IMAGE_NAME};pnfs" PROCESSORS 2)
+        endforeach()
     endforeach()
 
     # SMB cthon04 tests

--- a/src/server/nfs/nfs4_attr.h
+++ b/src/server/nfs/nfs4_attr.h
@@ -362,6 +362,14 @@ chimera_nfs4_marshall_attrs(
                     word2 |= (1 << (FATTR4_LAYOUT_TYPES - 64));
                 }
 
+                /* The block layout (RFC 5663) requires the server to advertise
+                 * the layout block size + alignment, or the client's block
+                 * layout driver refuses to initialize. */
+                if (pnfs_layout_type == 0x3) {
+                    word2 |= (1 << (FATTR4_LAYOUT_BLKSIZE - 64)) |
+                        (1 << (FATTR4_LAYOUT_ALIGNMENT - 64));
+                }
+
                 chimera_nfs4_attr_append_uint32(&attrs, word2);
             }
         }
@@ -685,6 +693,22 @@ chimera_nfs4_marshall_attrs(
 
             chimera_nfs4_attr_append_uint32(&attrs, 1); /* layouttype4<> count */
             chimera_nfs4_attr_append_uint32(&attrs, pnfs_layout_type); /* per-backend */
+        }
+
+        /* Block layout (RFC 5663) block size + alignment (attrs 65, 66).  The
+         * client's block layout driver requires a non-zero blksize <= PAGE_SIZE
+         * to initialize.  We allocate and align block extents to 4 KiB. */
+        if (pnfs_layout_type == 0x3 &&
+            (req_mask[2] & (1 << (FATTR4_LAYOUT_BLKSIZE - 64)))) {
+            rsp_mask[2]  |= (1 << (FATTR4_LAYOUT_BLKSIZE - 64));
+            *num_rsp_mask = 3;
+            chimera_nfs4_attr_append_uint32(&attrs, 4096);
+        }
+        if (pnfs_layout_type == 0x3 &&
+            (req_mask[2] & (1 << (FATTR4_LAYOUT_ALIGNMENT - 64)))) {
+            rsp_mask[2]  |= (1 << (FATTR4_LAYOUT_ALIGNMENT - 64));
+            *num_rsp_mask = 3;
+            chimera_nfs4_attr_append_uint32(&attrs, 4096);
         }
 
         if ((req_mask[2] & (1 << (FATTR4_XATTR_SUPPORT - 64))) &&

--- a/src/server/nfs/nfs4_pnfs.c
+++ b/src/server/nfs/nfs4_pnfs.c
@@ -673,8 +673,15 @@ lg_sourced_cb(
         chimera_nfs_abort_if(body == NULL || lo == NULL, "Failed to allocate space");
         body_len = chimera_nfs4_encode_block_layout(body, segments, num_segments);
 
-        lo->lo_offset           = args->loga_offset;
-        lo->lo_length           = UINT64_MAX;
+        /* Cover exactly the contiguous span the extents describe (from the
+         * requested offset to the end of the last segment); a block client
+         * rejects a layout whose lo_length doesn't match its extents. */
+        uint64_t        blk_end = segments[num_segments - 1].offset +
+            segments[num_segments - 1].length;
+
+        lo->lo_offset = args->loga_offset;
+        lo->lo_length = blk_end > args->loga_offset ?
+            blk_end - args->loga_offset : 0;
         lo->lo_iomode           = args->loga_iomode;
         lo->lo_content.loc_type = LAYOUT4_BLOCK_VOLUME;
         rc                      = xdr_dbuf_opaque_copy(&lo->lo_content.loc_body, body,

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -1039,10 +1039,11 @@ chimera_server_init(
                                    config->cache_ttl,
                                    metrics);
 
-    /* Publish the pNFS data-server table into the VFS layer so both the
-     * backend (steering / layout construction) and the NFS protocol layer
-     * (GETDEVICEINFO) read from a single authoritative table. */
-    if (config->pnfs_enabled && config->pnfs_num_ds > 0) {
+    /* Enable the pNFS feature whenever configured.  Orchestrated flex-files
+     * needs a data-server table (below); a layout-sourcing backend (e.g. diskfs
+     * block mode) produces its own layouts and needs no data servers, so the
+     * feature is enabled with an empty table. */
+    if (config->pnfs_enabled) {
         chimera_vfs_pnfs_set_enabled(server->vfs, 1);
         for (i = 0; i < config->pnfs_num_ds; i++) {
             chimera_vfs_pnfs_add_device(server->vfs,

--- a/src/vfs/diskfs/diskfs.c
+++ b/src/vfs/diskfs/diskfs.c
@@ -177,12 +177,21 @@ struct diskfs_request_private {
 };
 
 struct diskfs_device {
-    struct evpl_block_device *bdev;
+    struct evpl_block_device *bdev;            /* NULL for a REMOTE (pNFS data) device */
     uint64_t                  id;
     uint64_t                  size;
     uint64_t                  max_request_size;
     char                      name[256];
     pthread_mutex_t           lock;
+
+    /* Block-mode (pNFS) device identity.  role == SM_DEV_REMOTE means this
+     * device's storage lives outside this system: diskfs allocates space on it
+     * and hands the layout to the block client but never opens or touches it. */
+    uint32_t                  role;             /* SM_DEV_LOCAL | SM_DEV_REMOTE */
+    uint8_t                   deviceid[SM_DEVICEID_SIZE];
+    uint64_t                  sig_offset;
+    uint32_t                  sig_len;
+    uint8_t                   sig[SM_SIG_MAX];
 };
 
 struct diskfs_dirent {
@@ -452,6 +461,7 @@ enum diskfs_bt_rectype {
     DISKFS_REC_SYMLINK = 3,
     DISKFS_REC_ORPHAN  = 4,   /* orphan-list inode only: subkey = orphaned inum */
     DISKFS_REC_XATTR   = 5,
+    DISKFS_REC_PNFS    = 6,   /* regular file: opaque pNFS layout blob (flex-files) */
 };
 
 /* B+tree key: ordered by (type, subkey).  subkey is the name hash for
@@ -732,6 +742,7 @@ struct diskfs_shared {
     int                        mounted;            /* 1 = remounted existing FS (enables inode read-back) */
     uint32_t                   block_cache_blocks; /* total resident block-buffer cap (0 = default) */
     uint32_t                   inode_cache_inodes; /* total resident inode cap (0 = default) */
+    int                        block_layout;       /* config opt-in: advertise pNFS block layouts */
     uint64_t                   fsid;
     struct space_map          *space_map;
     struct diskfs_intent_log   intent_log;
@@ -746,7 +757,8 @@ struct diskfs_thread {
     struct evpl_iovec           pad;
     int                         thread_id;
     struct slab_allocator      *allocator;
-    struct sm_thread_cache      space_cache;
+    struct sm_thread_cache      space_cache;       /* metadata (LOCAL devices) */
+    struct sm_thread_cache      data_space_cache;  /* block-mode file data (REMOTE devices) */
     struct diskfs_txn          *txn_free_list;
     struct diskfs_inode_waiter *waiter_free_list;
     struct diskfs_iq_channel   *iq_channel;
@@ -2760,7 +2772,7 @@ diskfs_bt_alloc_node(
      * never journals -- hence no_suspend and the rc != 0 abort. */
     DISKFS_SM_JNL(jnl, thread, txn, diskfs_sm_no_suspend, NULL);
     rc = space_map_alloc(shared->space_map, &thread->space_cache, &jnl,
-                         DISKFS_BLOCK_SIZE, &device_id, &device_offset);
+                         SM_DEV_LOCAL, DISKFS_BLOCK_SIZE, &device_id, &device_offset);
     chimera_diskfs_abort_if(rc != 0, "b+tree node allocation failed (ENOSPC)");
 
     blk = diskfs_block_claim(thread, device_id, device_offset, 1);
@@ -4272,7 +4284,7 @@ diskfs_bt_run(struct diskfs_bt_op *op)
              * modify can never exhaust the reservation and journal. */
             DISKFS_SM_JNL(jnl, thread, op->txn, diskfs_bt_op_resume_cb, op);
             int rrc = space_map_reserve(thread->shared->space_map,
-                                        &thread->space_cache, &jnl,
+                                        &thread->space_cache, &jnl, SM_DEV_LOCAL,
                                         (uint64_t) (DISKFS_BT_MAX_DEPTH + 2) * DISKFS_BLOCK_SIZE);
 
             if (rrc == SM_AGAIN) {
@@ -5458,7 +5470,7 @@ diskfs_inode_alloc_async(
 
     DISKFS_SM_JNL(jnl, thread, txn, diskfs_inode_alloc_resume, actx);
     rc = space_map_alloc(shared->space_map, &thread->space_cache, &jnl,
-                         SM_BLOCK_SIZE, &device_id, &device_offset);
+                         SM_DEV_LOCAL, SM_BLOCK_SIZE, &device_id, &device_offset);
     if (rc == SM_AGAIN) {
         return;     /* parked; diskfs_inode_alloc_resume re-runs (owns actx) */
     }
@@ -5620,11 +5632,21 @@ diskfs_thread_alloc_space(
     void ( *resume )(struct diskfs_thread *, void *),
     void *resume_arg)
 {
-    uint32_t dev_id;
-    int      rc;
+    uint32_t                dev_id;
+    int                     rc;
+    struct space_map       *sm = thread->shared->space_map;
+
+    /* File data goes to REMOTE (pNFS data) devices when this is a block-mode
+     * filesystem, and to LOCAL devices otherwise; each class draws from its own
+     * per-thread reservation cache so a local metadata reservation and a remote
+     * data reservation never collide. */
+    int                     remote = space_map_has_remote(sm);
+    uint32_t                role   = remote ? SM_DEV_REMOTE : SM_DEV_LOCAL;
+    struct sm_thread_cache *cache  = remote ? &thread->data_space_cache :
+        &thread->space_cache;
 
     DISKFS_SM_JNL(jnl, thread, txn, resume, resume_arg);
-    rc = space_map_alloc(thread->shared->space_map, &thread->space_cache, &jnl,
+    rc = space_map_alloc(sm, cache, &jnl, role,
                          (uint64_t) desired_size, &dev_id, r_device_offset);
 
     if (rc == SM_AGAIN) {
@@ -6411,7 +6433,9 @@ diskfs_intent_log_thread_init(
     /* Open block queues on this thread's evpl for redo writes + tail-push. */
     il->queue = calloc(shared->num_devices, sizeof(*il->queue));
     for (i = 0; i < shared->num_devices; i++) {
-        il->queue[i] = evpl_block_open_queue(evpl, shared->devices[i].bdev);
+        /* Remote (pNFS data) devices have no local handle: leave queue NULL. */
+        il->queue[i] = shared->devices[i].bdev ?
+            evpl_block_open_queue(evpl, shared->devices[i].bdev) : NULL;
     }
 
     evpl_add_doorbell(evpl, &il->wake_doorbell, diskfs_intent_log_wake_cb);
@@ -6446,7 +6470,9 @@ diskfs_intent_log_thread_shutdown(
     evpl_remove_doorbell(evpl, &il->wake_doorbell);
 
     for (i = 0; i < shared->num_devices; i++) {
-        evpl_block_close_queue(evpl, il->queue[i]);
+        if (il->queue[i]) {
+            evpl_block_close_queue(evpl, il->queue[i]);
+        }
     }
     free(il->queue);
 } /* diskfs_intent_log_thread_shutdown */
@@ -6629,7 +6655,8 @@ diskfs_mount_io_open(struct diskfs_shared *shared)
     io->evpl   = evpl_create(NULL);
     io->queue  = calloc(shared->num_devices, sizeof(*io->queue));
     for (i = 0; i < shared->num_devices; i++) {
-        io->queue[i] = evpl_block_open_queue(io->evpl, shared->devices[i].bdev);
+        io->queue[i] = shared->devices[i].bdev ?
+            evpl_block_open_queue(io->evpl, shared->devices[i].bdev) : NULL;
     }
     return io;
 } /* diskfs_mount_io_open */
@@ -6640,7 +6667,9 @@ diskfs_mount_io_close(struct diskfs_mount_io *io)
     int i;
 
     for (i = 0; i < io->shared->num_devices; i++) {
-        evpl_block_close_queue(io->evpl, io->queue[i]);
+        if (io->queue[i]) {
+            evpl_block_close_queue(io->evpl, io->queue[i]);
+        }
     }
     free(io->queue);
     evpl_destroy(io->evpl);
@@ -6933,6 +6962,47 @@ diskfs_recover_log(
     return 0;
 } /* diskfs_recover_log */
 
+SYMBOL_EXPORT struct chimera_vfs_module vfs_diskfs;
+
+/*
+ * Decode a hex string (e.g. "deadbeef" or "de:ad:be:ef") into up to `max`
+ * bytes; returns the number of bytes decoded.  Used for the block-mode device
+ * id and SIMPLE-volume signature, which are configured as hex.
+ */
+static uint32_t
+diskfs_parse_hex(
+    const char *hex,
+    uint8_t    *out,
+    uint32_t    max)
+{
+    uint32_t n  = 0;
+    int      hi = -1;
+
+    if (!hex) {
+        return 0;
+    }
+    for (; *hex && n < max; hex++) {
+        int v;
+
+        if (*hex >= '0' && *hex <= '9') {
+            v = *hex - '0';
+        } else if (*hex >= 'a' && *hex <= 'f') {
+            v = *hex - 'a' + 10;
+        } else if (*hex >= 'A' && *hex <= 'F') {
+            v = *hex - 'A' + 10;
+        } else {
+            continue;   /* skip separators (':', '-', spaces) */
+        }
+        if (hi < 0) {
+            hi = v;
+        } else {
+            out[n++] = (uint8_t) ((hi << 4) | v);
+            hi       = -1;
+        }
+    }
+    return n;
+} /* diskfs_parse_hex */
+
 static void *
 diskfs_init(const char *cfgdata)
 {
@@ -6944,7 +7014,7 @@ diskfs_init(const char *cfgdata)
     int                         i, fd, rc;
     struct stat                 st;
     int64_t                     size;
-    uint64_t                   *device_sizes;
+    struct sm_device_cfg       *dev_cfg;
     json_t                     *cfg, *devices_cfg, *device_cfg;
     json_error_t                json_error;
     int                         initialize;
@@ -6962,13 +7032,49 @@ diskfs_init(const char *cfgdata)
 
     json_array_foreach(devices_cfg, i, device_cfg)
     {
+        const char *role_name;
+
         device     = &shared->devices[i];
         device->id = i;
 
         protocol_name = json_string_value(json_object_get(device_cfg, "type"));
         device_path   = json_string_value(json_object_get(device_cfg, "path"));
         size          = json_integer_value(json_object_get(device_cfg, "size"));
+        role_name     = json_string_value(json_object_get(device_cfg, "role"));
 
+        /* A "remote" device models pNFS-block data storage outside this system:
+         * diskfs tracks its free space but never opens it.  Its size, stable
+         * deviceid and SIMPLE-volume signature come from config; its AG logs are
+         * relocated onto the local metadata device by the allocator. */
+        if (role_name && strcmp(role_name, "remote") == 0) {
+            json_t *sig_cfg = json_object_get(device_cfg, "signature");
+
+            chimera_diskfs_abort_if(i == 0, "device 0 must be a local metadata device");
+
+            device->role             = SM_DEV_REMOTE;
+            device->bdev             = NULL;
+            device->size             = size;
+            device->max_request_size = 0;
+            shared->device_paths[i]  = strdup(device_path ? device_path : "");
+            snprintf(device->name, sizeof(device->name), "%s",
+                     device_path ? device_path : "remote");
+
+            diskfs_parse_hex(json_string_value(json_object_get(device_cfg, "deviceid")),
+                             device->deviceid, SM_DEVICEID_SIZE);
+            if (json_is_object(sig_cfg)) {
+                device->sig_offset = json_integer_value(json_object_get(sig_cfg, "offset"));
+                device->sig_len    = diskfs_parse_hex(
+                    json_string_value(json_object_get(sig_cfg, "bytes")),
+                    device->sig, SM_SIG_MAX);
+            }
+
+            chimera_diskfs_info("Remote data device %s size %lu sig_off %lu sig_len %u",
+                                device->name, device->size, device->sig_offset,
+                                device->sig_len);
+            continue;
+        }
+
+        device->role            = SM_DEV_LOCAL;
         shared->device_paths[i] = strdup(device_path);
 
         if (strcmp(protocol_name, "io_uring") == 0) {
@@ -7019,10 +7125,24 @@ diskfs_init(const char *cfgdata)
      * FUA/sync, so diskfs runs lighter at the cost of crash safety.  Off by
      * default; tests that do not exercise crash recovery enable it to run more
      * efficiently. */
-    initialize                 = json_object_get(cfg, "initialize") != NULL;
-    shared->unsafe_async       = json_is_true(json_object_get(cfg, "unsafe_async"));
+    initialize           = json_object_get(cfg, "initialize") != NULL;
+    shared->unsafe_async = json_is_true(json_object_get(cfg, "unsafe_async"));
+    /* Opt-in pNFS block layout mode: diskfs sources RFC 5663 block layouts and
+     * keeps file data on remote (data-only) devices. */
+    shared->block_layout       = json_is_true(json_object_get(cfg, "block_layout"));
     shared->block_cache_blocks = (uint32_t) json_integer_value(
         json_object_get(cfg, "block_cache_blocks"));
+
+    /* Block mode and orchestrated flex-files are mutually exclusive per module
+     * (the NFS server routes on CAP_LAYOUT_SOURCE before CAP_LAYOUT).  A diskfs
+     * module is loaded once per daemon with one config, so switch the module's
+     * advertised layout capability here: block mode SOURCEs block layouts,
+     * otherwise we persist the orchestrated flex blob (default). */
+    if (shared->block_layout) {
+        vfs_diskfs.capabilities &= ~(uint64_t) CHIMERA_VFS_CAP_LAYOUT;
+        vfs_diskfs.capabilities |= CHIMERA_VFS_CAP_LAYOUT_SOURCE |
+            CHIMERA_VFS_CAP_LAYOUT_CLASS_BLOCK;
+    }
     shared->inode_cache_inodes = (uint32_t) json_integer_value(
         json_object_get(cfg, "inode_cache_inodes"));
 
@@ -7067,12 +7187,33 @@ diskfs_init(const char *cfgdata)
                 "diskfs superblock missing or invalid; specify initialize to format");
         }
 
-        device_sizes = calloc(shared->num_devices, sizeof(*device_sizes));
+        dev_cfg = calloc(shared->num_devices, sizeof(*dev_cfg));
         for (i = 0; i < shared->num_devices; i++) {
-            device_sizes[i] = shared->devices[i].size;
+            struct diskfs_device *dv = &shared->devices[i];
+
+            dev_cfg[i].size = dv->size;
+            dev_cfg[i].role = dv->role;
+            if (dv->role == SM_DEV_REMOTE) {
+                memcpy(dev_cfg[i].deviceid, dv->deviceid, SM_DEVICEID_SIZE);
+                dev_cfg[i].sig_offset = dv->sig_offset;
+                dev_cfg[i].sig_len    = dv->sig_len;
+                memcpy(dev_cfg[i].sig, dv->sig, dv->sig_len);
+            }
         }
-        shared->space_map = space_map_create(device_sizes, shared->num_devices);
-        free(device_sizes);
+        shared->space_map = space_map_create(dev_cfg, shared->num_devices);
+        free(dev_cfg);
+
+        /* On a persistent remount the relocated-log map is recomputed from the
+         * device cfg; it must match what the superblock recorded or the remote
+         * AG logs would be read from the wrong offsets. */
+        if (mode != 0) {
+            chimera_diskfs_abort_if(
+                sb.num_remote_devices != shared->space_map->num_remote_devices ||
+                sb.remote_log_offset != shared->space_map->remote_log_offset ||
+                sb.remote_log_size != shared->space_map->remote_log_size,
+                "device configuration changed since last mount (remote-log region "
+                "mismatch): refusing to mount to avoid corrupting relocated AG logs");
+        }
 
         if (mode == 2) {
             chimera_diskfs_info("superblock not clean: running crash recovery");
@@ -7380,7 +7521,9 @@ diskfs_destroy(void *private_data)
     }
 
     for (int i = 0; i < shared->num_devices; i++) {
-        evpl_block_close_device(shared->devices[i].bdev);
+        if (shared->devices[i].bdev) {
+            evpl_block_close_device(shared->devices[i].bdev);
+        }
     }
 
     diskfs_block_cache_destroy(shared);
@@ -7483,7 +7626,9 @@ diskfs_thread_init(
     thread->queue = calloc(shared->num_devices, sizeof(*thread->queue));
 
     for (int i = 0; i < shared->num_devices; i++) {
-        thread->queue[i] = evpl_block_open_queue(evpl, shared->devices[i].bdev);
+        /* Remote (pNFS data) devices have no local handle: leave queue NULL. */
+        thread->queue[i] = shared->devices[i].bdev ?
+            evpl_block_open_queue(evpl, shared->devices[i].bdev) : NULL;
     }
 
     thread->shared = shared;
@@ -7557,12 +7702,16 @@ diskfs_thread_destroy(void *private_data)
     slab_allocator_destroy(thread->allocator);
 
     for (int i = 0; i < shared->num_devices; i++) {
+        if (!thread->queue[i]) {
+            continue;
+        }
         evpl_block_close_queue(thread->evpl, thread->queue[i]);
     }
 
     /* No txn at thread teardown; the unused reservation tail returns to the
      * in-memory free set and is captured by the condense at clean unmount. */
     space_map_thread_cache_return(shared->space_map, NULL, &thread->space_cache);
+    space_map_thread_cache_return(shared->space_map, NULL, &thread->data_space_cache);
 
     /* Unregister the intent-log channel.  Caller must have quiesced all
      * in-flight VFS ops on this thread first. */
@@ -7653,6 +7802,25 @@ diskfs_map_attrs(
     if (attr->va_req_mask & CHIMERA_VFS_ATTR_FSID) {
         attr->va_set_mask |= CHIMERA_VFS_ATTR_FSID;
         attr->va_fsid      = shared->fsid;
+    }
+
+    /*
+     * Opaque pNFS layout state (flex-files), persisted verbatim for the NFS
+     * server as the single DISKFS_REC_PNFS record in this inode's b+tree.  A
+     * file that carries a layout blob has its data on the data server, never
+     * local extents, so the record always lives in the resident embedded root
+     * -- the sync lookup never suspends (same invariant as the symlink record).
+     */
+    if (attr->va_req_mask & CHIMERA_VFS_ATTR_PNFS_LAYOUT) {
+        struct diskfs_bt_key pnfs_key = { .type = DISKFS_REC_PNFS, .subkey = 0 };
+        int                  len      = diskfs_bt_lookup_exact(thread, inode, &pnfs_key,
+                                                               attr->va_pnfs,
+                                                               CHIMERA_VFS_PNFS_LAYOUT_MAX);
+
+        if (len >= 0) {
+            attr->va_set_mask |= CHIMERA_VFS_ATTR_PNFS_LAYOUT;
+            attr->va_pnfs_len  = len;
+        }
     }
 
     if (attr->va_req_mask & CHIMERA_VFS_ATTR_MASK_STATFS) {
@@ -7946,6 +8114,32 @@ diskfs_setattr_trunc_first_cb(
     diskfs_setattr_trunc_process(request);
 } /* diskfs_setattr_trunc_first_cb */
 
+/*
+ * Completion for a setattr that also persisted a pNFS layout blob: the
+ * DISKFS_REC_PNFS record is now in the b+tree (resident root, so the insert
+ * never split), so map the post attrs and commit.
+ */
+static void
+diskfs_setattr_pnfs_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+    struct diskfs_thread          *thread  = p->thread;
+
+    diskfs_bt_op_free(thread, op);
+
+    if (unlikely(result < 0)) {
+        diskfs_op_fail(request, p->txn, CHIMERA_VFS_EIO);
+        return;
+    }
+
+    diskfs_map_attrs(thread, &request->setattr.r_post_attr, p->inode_stash[0]);
+    diskfs_op_ok(request, p->txn);
+} /* diskfs_setattr_pnfs_cb */
+
 static void
 diskfs_setattr_inode_cb(
     struct diskfs_inode *inode,
@@ -7990,6 +8184,26 @@ diskfs_setattr_inode_cb(
     }
 
     diskfs_apply_attrs(inode, request->setattr.set_attr);
+
+    /* Persist the opaque pNFS layout blob as this inode's single PNFS record. */
+    if (request->setattr.set_attr->va_set_mask & CHIMERA_VFS_ATTR_PNFS_LAYOUT) {
+        struct diskfs_bt_key key      = { .type = DISKFS_REC_PNFS, .subkey = 0 };
+        uint32_t             blob_len = request->setattr.set_attr->va_pnfs_len;
+
+        if (blob_len > CHIMERA_VFS_PNFS_LAYOUT_MAX) {
+            blob_len = CHIMERA_VFS_PNFS_LAYOUT_MAX;
+        }
+
+        p->inode_stash[0] = inode;
+        op                = diskfs_bt_op_alloc(thread);
+        if (diskfs_bt_insert_async(op, thread, p->txn, inode, &key,
+                                   request->setattr.set_attr->va_pnfs, blob_len,
+                                   diskfs_setattr_pnfs_cb, request)) {
+            diskfs_setattr_pnfs_cb(op, op->result, request);
+        }
+        return;
+    }
+
     diskfs_map_attrs(thread, &request->setattr.r_post_attr, inode);
     diskfs_op_ok(request, p->txn);
 } /* diskfs_setattr_inode_cb */
@@ -9871,8 +10085,17 @@ diskfs_read(
 {
     struct diskfs_request_private *p = request->plugin_data;
 
-    (void) shared;
     (void) private_data;
+
+    /* Block-mode shares keep all file data on remote (pNFS) devices the server
+     * can't touch, so inline reads are impossible -- the client must use a
+     * block layout.  Reject so a non-pNFS read doesn't dereference a NULL
+     * device queue. */
+    if (unlikely(shared->block_layout)) {
+        request->status = CHIMERA_VFS_EINVAL;
+        request->complete(request);
+        return;
+    }
 
     p->opcode     = request->opcode;
     p->status     = 0;
@@ -10682,8 +10905,16 @@ diskfs_write(
 {
     struct diskfs_request_private *p = request->plugin_data;
 
-    (void) shared;
     (void) private_data;
+
+    /* Block-mode data lives on remote (pNFS) devices: writes go directly from
+     * the client to the volume via an RW layout, never inline through the
+     * server (which has no handle for those devices). */
+    if (unlikely(shared->block_layout)) {
+        request->status = CHIMERA_VFS_EINVAL;
+        request->complete(request);
+        return;
+    }
 
     p->opcode              = request->opcode;
     p->status              = 0;
@@ -12656,6 +12887,362 @@ diskfs_remove_xattr(
                               diskfs_remove_xattr_inode_cb, request);
 } /* diskfs_remove_xattr */
 
+/* ------------------------------------------------------------------ */
+/* pNFS block layout (CHIMERA_VFS_OP_GET_LAYOUT, RFC 5663)             */
+/* ------------------------------------------------------------------ */
+/*
+ * Produce a block layout for [offset, offset+length): walk the inode's extent
+ * b+tree, emit one block segment per backed run, and (for an RW layout) allocate
+ * + record extents over unbacked gaps so the client can write directly to the
+ * remote data volume.  The allocation rides p->txn; diskfs_op_ok commits the
+ * txn (making the extent records durable) BEFORE the layout is returned, so a
+ * crash can never re-hand-out a block the client is about to write.  Block-mode
+ * shares keep file data on REMOTE devices, so blk_vol_offset is the extent's
+ * absolute device offset on that volume (the signature region is reserved out
+ * of allocation, so no extent overlaps it).  Freshly-allocated / beyond-EOF
+ * ranges are INVALID_DATA; ranges within the committed size are READ_WRITE/READ
+ * (the size advances only on LAYOUTCOMMIT).
+ */
+#define DISKFS_LAYOUT_GAP_MAX  (256ULL << 20)
+#define DISKFS_LAYOUTIOMODE_RW 2     /* LAYOUTIOMODE4_RW */
+
+static void diskfs_get_layout_process(
+    struct chimera_vfs_request *request);
+
+static void
+diskfs_layout_add_device(
+    struct chimera_vfs_request *request,
+    struct diskfs_shared       *shared,
+    uint32_t                    device_id)
+{
+    struct diskfs_device             *dev = &shared->devices[device_id];
+    struct chimera_vfs_layout_device *ld;
+    uint32_t                          i;
+
+    for (i = 0; i < request->get_layout.r_num_devices; i++) {
+        if (memcmp(request->get_layout.r_devices[i].deviceid, dev->deviceid,
+                   SM_DEVICEID_SIZE) == 0) {
+            return;
+        }
+    }
+    if (request->get_layout.r_num_devices >= CHIMERA_VFS_LAYOUT_MAX_DEVICES) {
+        return;
+    }
+    ld = &request->get_layout.r_devices[request->get_layout.r_num_devices++];
+    memset(ld, 0, sizeof(*ld));
+    memcpy(ld->deviceid, dev->deviceid, SM_DEVICEID_SIZE);
+    ld->layout_class   = CHIMERA_VFS_LAYOUT_CLASS_BLOCK;
+    ld->blk_vol_size   = dev->size;
+    ld->blk_sig_offset = dev->sig_offset;
+    ld->blk_sig_len    = dev->sig_len;
+    memcpy(ld->blk_sig, dev->sig, dev->sig_len);
+} /* diskfs_layout_add_device */
+
+/* Append one block segment [file_off, file_off+len) -> (device_id, vol_off). */
+static void
+diskfs_layout_emit(
+    struct chimera_vfs_request *request,
+    struct diskfs_shared       *shared,
+    uint64_t                    file_off,
+    uint64_t                    len,
+    uint32_t                    device_id,
+    uint64_t                    vol_off,
+    uint32_t                    state)
+{
+    struct chimera_vfs_layout_segment *seg =
+        &request->get_layout.r_segments[request->get_layout.r_num_segments++];
+
+    memset(seg, 0, sizeof(*seg));
+    seg->offset = file_off;
+    seg->length = len;
+    seg->iomode = request->get_layout.iomode;
+    memcpy(seg->deviceid, shared->devices[device_id].deviceid, SM_DEVICEID_SIZE);
+    seg->blk_vol_offset = vol_off;
+    seg->blk_state      = state;
+    diskfs_layout_add_device(request, shared, device_id);
+} /* diskfs_layout_emit */
+
+static void
+diskfs_get_layout_finish(struct chimera_vfs_request *request)
+{
+    struct diskfs_request_private *p = request->plugin_data;
+
+    request->get_layout.r_layout_class = CHIMERA_VFS_LAYOUT_CLASS_BLOCK;
+    /* Commits the txn (durably persisting any new extent records) before the
+     * layout is handed back; a pure-READ layout has nothing journaled. */
+    diskfs_op_ok(request, p->txn);
+} /* diskfs_get_layout_finish */
+
+/* Advance the walk to the next extent after the current one, then re-process. */
+static void
+diskfs_get_layout_walk_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+
+    p->loop_have = diskfs_ext_from_op(op, result, &p->ext_iter);
+    diskfs_bt_op_free(p->thread, op);
+    diskfs_get_layout_process(request);
+} /* diskfs_get_layout_walk_cb */
+
+static void
+diskfs_get_layout_advance(struct chimera_vfs_request *request)
+{
+    struct diskfs_request_private *p      = request->plugin_data;
+    struct diskfs_thread          *thread = p->thread;
+    struct diskfs_bt_op           *op     = diskfs_bt_op_alloc(thread);
+
+    if (diskfs_ext_next_async(op, thread, p->inode_stash[0], p->ext_iter.file_offset,
+                              p->rec_scratch, sizeof(p->rec_scratch),
+                              diskfs_get_layout_walk_cb, request)) {
+        diskfs_get_layout_walk_cb(op, op->result, request);
+    }
+} /* diskfs_get_layout_advance */
+
+/* The freshly-allocated gap extent is now in the b+tree (durable on commit);
+* emit it as INVALID_DATA and continue (the held ext_iter is still valid). */
+static void
+diskfs_get_layout_inserted_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+    struct diskfs_thread          *thread  = p->thread;
+    struct diskfs_inode           *inode   = p->inode_stash[0];
+
+    diskfs_bt_op_free(thread, op);
+
+    if (unlikely(result < 0)) {
+        diskfs_op_fail(request, p->txn, CHIMERA_VFS_EIO);
+        return;
+    }
+
+    inode->space_used += p->rmw_aligned_length;
+
+    diskfs_layout_emit(request, thread->shared, p->rmw_aligned_start,
+                       p->rmw_aligned_length, (uint32_t) p->rmw_device_id,
+                       p->rmw_device_offset, CHIMERA_VFS_BLOCK_INVALID_DATA);
+
+    p->loop_off += p->rmw_aligned_length;
+    diskfs_get_layout_process(request);
+} /* diskfs_get_layout_inserted_cb */
+
+/* Allocate one gap extent at p->loop_off (length p->rmw_aligned_length) and
+ * insert it.  Re-driven by the allocator on SM_AGAIN. */
+static void
+diskfs_get_layout_do_alloc(
+    struct diskfs_thread *thread,
+    void                 *arg)
+{
+    struct chimera_vfs_request    *request = arg;
+    struct diskfs_request_private *p       = request->plugin_data;
+    struct diskfs_bt_op           *op;
+    uint64_t                       dev_id, dev_off;
+    int                            rc;
+
+    rc = diskfs_thread_alloc_space(thread, p->txn, (int64_t) p->rmw_aligned_length,
+                                   &dev_id, &dev_off,
+                                   diskfs_get_layout_do_alloc, request);
+    if (rc == SM_AGAIN) {
+        return;     /* parked; re-driven into this function */
+    }
+    if (rc != 0) {
+        diskfs_op_fail(request, p->txn, rc);
+        return;
+    }
+
+    p->rmw_device_id     = dev_id;
+    p->rmw_device_offset = dev_off;
+    p->rmw_aligned_start = p->loop_off;
+
+    op = diskfs_bt_op_alloc(thread);
+    if (diskfs_ext_insert_async(op, thread, p->txn, p->inode_stash[0],
+                                p->loop_off, p->rmw_aligned_length,
+                                (uint32_t) dev_id, dev_off,
+                                diskfs_get_layout_inserted_cb, request)) {
+        diskfs_get_layout_inserted_cb(op, op->result, request);
+    }
+} /* diskfs_get_layout_do_alloc */
+
+static void
+diskfs_get_layout_process(struct chimera_vfs_request *request)
+{
+    struct diskfs_request_private *p      = request->plugin_data;
+    struct diskfs_thread          *thread = p->thread;
+    struct diskfs_shared          *shared = thread->shared;
+    struct diskfs_inode           *inode  = p->inode_stash[0];
+    struct diskfs_extent          *ext    = &p->ext_iter;
+    int                            rw     = request->get_layout.iomode == DISKFS_LAYOUTIOMODE_RW;
+    uint64_t                       size   = inode->size;
+    uint64_t                       end    = p->loop_pos;
+
+    /* Done: range covered, or no more segment slots (client re-LAYOUTGETs). */
+    if (p->loop_off >= end ||
+        request->get_layout.r_num_segments >= request->get_layout.max_segments) {
+        diskfs_get_layout_finish(request);
+        return;
+    }
+
+    if (p->loop_have && ext->file_offset <= p->loop_off &&
+        ext->file_offset + ext->length > p->loop_off) {
+        /* Backed run at the cursor. */
+        uint64_t ext_end = ext->file_offset + ext->length;
+        uint64_t seg_end = ext_end < end ? ext_end : end;
+        uint64_t vol_off = ext->device_offset + (p->loop_off - ext->file_offset);
+
+        if (rw && p->loop_off < size && seg_end > size) {
+            /* Straddles committed size: written part then unwritten part. */
+            uint64_t split = size;
+            diskfs_layout_emit(request, shared, p->loop_off, split - p->loop_off,
+                               ext->device_id, vol_off, CHIMERA_VFS_BLOCK_READ_WRITE_DATA);
+            diskfs_layout_emit(request, shared, split, seg_end - split,
+                               ext->device_id, vol_off + (split - p->loop_off),
+                               CHIMERA_VFS_BLOCK_INVALID_DATA);
+        } else {
+            uint32_t state = rw ?
+                (p->loop_off < size ? CHIMERA_VFS_BLOCK_READ_WRITE_DATA :
+                 CHIMERA_VFS_BLOCK_INVALID_DATA) : CHIMERA_VFS_BLOCK_READ_DATA;
+            diskfs_layout_emit(request, shared, p->loop_off, seg_end - p->loop_off,
+                               ext->device_id, vol_off, state);
+        }
+        p->loop_off = seg_end;
+        diskfs_get_layout_advance(request);
+        return;
+    }
+
+    /* Gap from the cursor to the next extent (or the end of the range). */
+    {
+        uint64_t gap_end = (p->loop_have && ext->file_offset < end) ?
+            ext->file_offset : end;
+
+        if (!rw) {
+            /* Read of a hole: skip it (the client reads zeros). */
+            p->loop_off = gap_end;
+            diskfs_get_layout_process(request);
+            return;
+        }
+
+        uint64_t gap_len = gap_end - p->loop_off;
+        if (gap_len > DISKFS_LAYOUT_GAP_MAX) {
+            gap_len = DISKFS_LAYOUT_GAP_MAX;
+        }
+        p->rmw_aligned_length = gap_len;
+        diskfs_get_layout_do_alloc(thread, request);
+    }
+} /* diskfs_get_layout_process */
+
+static void
+diskfs_get_layout_first_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+    struct diskfs_thread          *thread  = p->thread;
+
+    p->loop_have = diskfs_ext_from_op(op, result, &p->ext_iter);
+    diskfs_bt_op_free(thread, op);
+
+    /* A floor extent entirely before the cursor doesn't overlap: step to the
+     * next one so the cursor sees the first extent at or after loop_off. */
+    if (p->loop_have &&
+        p->ext_iter.file_offset + p->ext_iter.length <= p->loop_off) {
+        diskfs_get_layout_advance(request);
+        return;
+    }
+    diskfs_get_layout_process(request);
+} /* diskfs_get_layout_first_cb */
+
+static void
+diskfs_get_layout_inode_cb(
+    struct diskfs_inode *inode,
+    int                  status,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+    struct diskfs_thread          *thread  = p->thread;
+    struct diskfs_shared          *shared  = thread->shared;
+    uint64_t                       off, end;
+    struct diskfs_bt_op           *op;
+
+    if (unlikely(status != CHIMERA_VFS_OK)) {
+        diskfs_op_fail(request, p->txn, status);
+        return;
+    }
+    if (unlikely(!S_ISREG(inode->mode))) {
+        diskfs_op_fail(request, p->txn, CHIMERA_VFS_EINVAL);
+        return;
+    }
+
+    off = request->get_layout.offset & ~(uint64_t) (DISKFS_BLOCK_SIZE - 1);
+    end = (request->get_layout.offset + request->get_layout.length +
+           DISKFS_BLOCK_SIZE - 1) & ~(uint64_t) (DISKFS_BLOCK_SIZE - 1);
+
+    /* A READ layout is never returned past the committed size (the client reads
+     * zeros for a hole / beyond EOF). */
+    if (request->get_layout.iomode != DISKFS_LAYOUTIOMODE_RW) {
+        uint64_t size_end = (inode->size + DISKFS_BLOCK_SIZE - 1) &
+            ~(uint64_t) (DISKFS_BLOCK_SIZE - 1);
+        if (end > size_end) {
+            end = size_end;
+        }
+    }
+
+    p->inode_stash[0] = inode;
+    p->loop_off       = off;
+    p->loop_pos       = end;
+
+    request->get_layout.r_layout_class = CHIMERA_VFS_LAYOUT_CLASS_BLOCK;
+    request->get_layout.r_num_segments = 0;
+    request->get_layout.r_num_devices  = 0;
+
+    if (off >= end) {
+        diskfs_get_layout_finish(request);
+        return;
+    }
+
+    (void) shared;
+    op = diskfs_bt_op_alloc(thread);
+    if (diskfs_ext_floor_async(op, thread, inode, off, p->rec_scratch,
+                               sizeof(p->rec_scratch), diskfs_get_layout_first_cb,
+                               request)) {
+        diskfs_get_layout_first_cb(op, op->result, request);
+    }
+} /* diskfs_get_layout_inode_cb */
+
+static void
+diskfs_get_layout(
+    struct diskfs_thread       *thread,
+    struct diskfs_shared       *shared,
+    struct chimera_vfs_request *request,
+    void                       *private_data)
+{
+    struct diskfs_request_private *p = request->plugin_data;
+    int                            rw;
+
+    (void) private_data;
+
+    if (unlikely(!shared->block_layout)) {
+        request->status = CHIMERA_VFS_ENOTSUP;
+        request->complete(request);
+        return;
+    }
+
+    rw        = request->get_layout.iomode == DISKFS_LAYOUTIOMODE_RW;
+    p->thread = thread;
+    p->txn    = diskfs_txn_begin(thread, rw ? DISKFS_TXN_WRITE : DISKFS_TXN_READ);
+
+    diskfs_inode_get_fh_async(thread, p->txn, request->fh, request->fh_len,
+                              diskfs_get_layout_inode_cb, request);
+} /* diskfs_get_layout */
+
 static void
 diskfs_dispatch(
     struct chimera_vfs_request *request,
@@ -12772,6 +13359,9 @@ diskfs_dispatch(
         case CHIMERA_VFS_OP_REMOVE_XATTR:
             diskfs_remove_xattr(thread, shared, request, private_data);
             break;
+        case CHIMERA_VFS_OP_GET_LAYOUT:
+            diskfs_get_layout(thread, shared, request, private_data);
+            break;
         default:
             chimera_diskfs_error("diskfs_dispatch: unknown operation %d",
                                  request->opcode);
@@ -12785,7 +13375,7 @@ SYMBOL_EXPORT struct chimera_vfs_module vfs_diskfs = {
     .name         = "diskfs",
     .fh_magic     = CHIMERA_VFS_FH_MAGIC_DISKFS,
     .capabilities = CHIMERA_VFS_CAP_CREATE_UNLINKED | CHIMERA_VFS_CAP_FS | CHIMERA_VFS_CAP_KV |
-        CHIMERA_VFS_CAP_FS_RELATIVE_OP | CHIMERA_VFS_CAP_XATTR,
+        CHIMERA_VFS_CAP_FS_RELATIVE_OP | CHIMERA_VFS_CAP_XATTR | CHIMERA_VFS_CAP_LAYOUT,
     .init           = diskfs_init,
     .destroy        = diskfs_destroy,
     .thread_init    = diskfs_thread_init,

--- a/src/vfs/diskfs/space_map.c
+++ b/src/vfs/diskfs/space_map.c
@@ -94,11 +94,11 @@ sm_ag_journal_claim(
     blk_off        = slot_base + (delta_byte & ~((uint64_t) SM_BLOCK_SIZE - 1));
     slot->in_block = (uint32_t) (delta_byte & (SM_BLOCK_SIZE - 1));
 
-    slot->hdr_buf = jnl->claim_block(jnl->user, ag->device_id, slot_base, 0);
+    slot->hdr_buf = jnl->claim_block(jnl->user, ag->log_device_id, slot_base, 0);
     if (!slot->hdr_buf) {
         return SM_AGAIN;
     }
-    slot->blk_buf = jnl->claim_block(jnl->user, ag->device_id, blk_off,
+    slot->blk_buf = jnl->claim_block(jnl->user, ag->log_device_id, blk_off,
                                      slot->in_block == 0);
     if (!slot->blk_buf) {
         return SM_AGAIN;
@@ -159,25 +159,12 @@ sm_extent_release(
 } /* sm_extent_release */
 
 /*
- * Initialize an AG.
- *
- * Layout within the AG (offsets are absolute device offsets):
- *
- *   [base_offset, base_offset + pre_log_reserved)    -- global reservations
- *                                                       (e.g. superblock,
- *                                                       intent log on AG 0
- *                                                       of device 0)
- *   [log_offset,  log_offset + SM_AG_LOG_SIZE)       -- this AG's space-map log
- *   [data_base,   data_base + post_log_reserved)     -- format-time reservations
- *                                                       at the start of the
- *                                                       data region (e.g. the
- *                                                       block_idx==1 inode
- *                                                       slot on AG 0 of disk 0
- *                                                       so root lands at
- *                                                       inum 2)
- *   [free_start,  base_offset + size)                -- allocatable data range
- *
- * `data_base` == `log_offset + SM_AG_LOG_SIZE`.
+ * Initialize an AG.  Offsets are absolute device offsets.  The log lives on
+ * `log_device_id` at `log_offset` (for a LOCAL AG this is the AG's own device,
+ * carved off the front of the AG; for a relocated REMOTE AG it is a slot on the
+ * local metadata device).  The allocatable data range is [data_off, data_off +
+ * data_len) on the AG's own device -- the caller computes it so that the log
+ * (LOCAL) and any format-time / signature reservations are excluded.
  */
 static void
 sm_ag_init(
@@ -186,17 +173,19 @@ sm_ag_init(
     uint32_t      ag_index,
     uint64_t      base_offset,
     uint64_t      size,
-    uint64_t      pre_log_reserved,
-    uint64_t      post_log_reserved)
+    uint32_t      log_device_id,
+    uint64_t      log_offset,
+    uint64_t      data_off,
+    uint64_t      data_len)
 {
     struct sm_extent *initial;
-    uint64_t          total_reserved;
 
     ag->device_id       = device_id;
     ag->ag_index        = ag_index;
     ag->base_offset     = base_offset;
     ag->size            = size;
-    ag->log_offset      = base_offset + pre_log_reserved;
+    ag->log_device_id   = log_device_id;
+    ag->log_offset      = log_offset;
     ag->log_size        = SM_AG_LOG_SIZE;
     ag->log_slot        = 0;
     ag->log_generation  = 0;
@@ -206,21 +195,16 @@ sm_ag_init(
     pthread_mutex_init(&ag->lock, NULL);
     rb_tree_init(&ag->free_by_offset);
 
-    total_reserved = pre_log_reserved + SM_AG_LOG_SIZE + post_log_reserved;
-
-    if (total_reserved >= size) {
-        /* The AG is too small to hold even its own log.  This shouldn't
-         * happen for any reasonable AG size; if it does, the AG has zero
-         * usable data range. */
+    if ((int64_t) data_len <= 0) {
+        /* AG too small to hold even its own log + reservations: no data range. */
         ag->free_bytes = 0;
         return;
     }
 
-    initial = sm_extent_new(base_offset + total_reserved,
-                            size - total_reserved);
+    initial = sm_extent_new(data_off, data_len);
 
     rb_tree_insert(&ag->free_by_offset, offset, initial);
-    ag->free_bytes = size - total_reserved;
+    ag->free_bytes = data_len;
 } /* sm_ag_init */
 
 static void
@@ -336,82 +320,127 @@ sm_ag_free_locked(
 
 struct space_map *
 space_map_create(
-    const uint64_t *device_sizes,
-    uint32_t        num_devices)
+    const struct sm_device_cfg *cfg,
+    uint32_t                    num_devices)
 {
     struct space_map *sm;
     struct sm_device *dev;
     struct sm_ag     *ag;
     uint32_t          d, a;
+    uint32_t          remote_ag_total = 0;
+    uint64_t          region_base, reloc_cursor;
 
     sm_abort_if(num_devices == 0, "space_map_create with zero devices");
+    sm_abort_if(cfg[0].role != SM_DEV_LOCAL,
+                "device 0 must be a local metadata device");
 
     sm              = calloc(1, sizeof(*sm));
     sm->num_devices = num_devices;
     sm->devices     = calloc(num_devices, sizeof(*sm->devices));
     pthread_mutex_init(&sm->lock, NULL);
 
+    /* Pass 1: size each device and count remote AGs so the relocated-log
+     * region (which is reserved out of device 0's AG 0) can be sized first. */
     for (d = 0; d < num_devices; d++) {
         dev            = &sm->devices[d];
         dev->device_id = d;
-        dev->size      = device_sizes[d];
-
-        dev->num_ags  = (dev->size + SM_AG_SIZE - 1) >> SM_AG_SIZE_LOG2;
-        dev->ag_rotor = 0;
+        dev->size      = cfg[d].size;
+        dev->role      = cfg[d].role;
+        dev->ag_rotor  = 0;
+        dev->num_ags   = (dev->size + SM_AG_SIZE - 1) >> SM_AG_SIZE_LOG2;
 
         sm_abort_if(dev->num_ags == 0, "device %u has zero AGs (size=%lu)",
                     d, dev->size);
 
-        dev->ags = calloc(dev->num_ags, sizeof(*dev->ags));
+        if (dev->role == SM_DEV_REMOTE) {
+            memcpy(dev->deviceid, cfg[d].deviceid, SM_DEVICEID_SIZE);
+            dev->sig_offset = cfg[d].sig_offset;
+            dev->sig_len    = cfg[d].sig_len > SM_SIG_MAX ? SM_SIG_MAX : cfg[d].sig_len;
+            memcpy(dev->sig, cfg[d].sig, dev->sig_len);
+            sm_abort_if(dev->sig_offset + dev->sig_len > SM_AG_SIZE,
+                        "device %u signature must lie within the first AG", d);
+            remote_ag_total += dev->num_ags;
+            sm->num_remote_devices++;
+        }
 
+        dev->ags            = calloc(dev->num_ags, sizeof(*dev->ags));
         sm->total_capacity += dev->size;
+    }
+
+    /* The relocated remote-AG-log region sits on device 0, between the intent
+     * log and AG 0's own space-map log.  Deterministic (device,ag)->slot map. */
+    region_base           = SM_SUPERBLOCK_SIZE + SM_INTENT_LOG_SIZE;
+    sm->remote_log_offset = region_base;
+    sm->remote_log_size   = (uint64_t) remote_ag_total * SM_AG_LOG_SIZE;
+    reloc_cursor          = region_base;
+
+    /* Pass 2: lay out each AG. */
+    for (d = 0; d < num_devices; d++) {
+        dev = &sm->devices[d];
 
         for (a = 0; a < dev->num_ags; a++) {
-            uint64_t base              = (uint64_t) a << SM_AG_SIZE_LOG2;
-            uint64_t span              = SM_AG_SIZE;
-            uint64_t pre_log_reserved  = 0;
-            uint64_t post_log_reserved = 0;
+            uint64_t base = (uint64_t) a << SM_AG_SIZE_LOG2;
+            uint64_t span = SM_AG_SIZE;
+            uint32_t log_device_id;
+            uint64_t log_offset, data_off, data_end;
 
             if (base + span > dev->size) {
                 span = dev->size - base;
             }
 
-            if (d == SM_INTENT_LOG_DEVICE && a == 0) {
-                /* AG 0 of device 0 also hosts the superblock and the
-                 * statically-reserved intent log.  Both sit *before* the
-                 * AG's own space-map log.  Account for those bytes plus
-                 * the AG log itself so they never get handed out. */
-                pre_log_reserved = SM_SUPERBLOCK_SIZE + SM_INTENT_LOG_SIZE;
-                sm->used_bytes  += pre_log_reserved;
+            ag = &dev->ags[a];
 
-                /* Statically reserve block_idx 1..3 of AG 0 / disk 0.
-                 * block_idx 1 is held for a future AG header; block_idx 2 is
-                 * the root inode (inum 2); block_idx 3 is the orphan-list inode
-                 * (inum 3, holds an entry per deleted-but-not-fully-reclaimed
-                 * inode).  All reserved (not allocated through the allocator)
-                 * so they are excluded from every condensed free set and can
-                 * never be re-handed-out after a crash. */
-                post_log_reserved = 3 * SM_BLOCK_SIZE;
-                sm->used_bytes   += post_log_reserved;
+            if (dev->role == SM_DEV_REMOTE) {
+                /* Remote (data-only) device: log relocated to device 0, the
+                 * whole AG is allocatable data (AG 0 also excludes the
+                 * signature region at the front). */
+                log_device_id = SM_INTENT_LOG_DEVICE;
+                log_offset    = reloc_cursor;
+                reloc_cursor += SM_AG_LOG_SIZE;
 
-                sm_abort_if(pre_log_reserved + SM_AG_LOG_SIZE +
-                            post_log_reserved > span,
-                            "device 0 AG 0 too small (%lu) to hold "
-                            "superblock+intent_log+ag_log+bootstrap (%lu)",
-                            span,
-                            pre_log_reserved + SM_AG_LOG_SIZE +
-                            post_log_reserved);
+                data_off = base;
+                if (a == 0 && dev->sig_len) {
+                    data_off        = base + SM_ALIGN_UP(dev->sig_offset + dev->sig_len);
+                    sm->used_bytes += data_off - base;
+                }
+                data_end = base + span;
+                sm_ag_init(ag, d, a, base, span, log_device_id, log_offset,
+                           data_off, data_end > data_off ? data_end - data_off : 0);
+                continue;
             }
 
-            sm_abort_if(SM_AG_LOG_SIZE >= span,
-                        "AG size %lu too small to hold per-AG log %lu",
-                        span, SM_AG_LOG_SIZE);
+            /* Local device: the AG's log is carved off the front of the AG. */
+            log_device_id = d;
+            log_offset    = base;
+
+            if (d == SM_INTENT_LOG_DEVICE && a == 0) {
+                /* AG 0 of device 0 also hosts the superblock, the intent log
+                 * and the relocated remote-AG-log region, all *before* this
+                 * AG's own log.  Then 3 bootstrap inode blocks after the log
+                 * (block_idx 1=AG header, 2=root inode, 3=orphan list). */
+                uint64_t pre_log = SM_SUPERBLOCK_SIZE + SM_INTENT_LOG_SIZE +
+                    sm->remote_log_size;
+                uint64_t post_log = 3 * SM_BLOCK_SIZE;
+
+                log_offset      = base + pre_log;
+                sm->used_bytes += pre_log + post_log;
+
+                data_off = log_offset + SM_AG_LOG_SIZE + post_log;
+                sm_abort_if(pre_log + SM_AG_LOG_SIZE + post_log > span,
+                            "device 0 AG 0 too small (%lu) to hold superblock+"
+                            "intent_log+remote_log_region(%lu)+ag_log+bootstrap",
+                            span, sm->remote_log_size);
+            } else {
+                data_off = log_offset + SM_AG_LOG_SIZE;
+                sm_abort_if(SM_AG_LOG_SIZE >= span,
+                            "AG size %lu too small to hold per-AG log %lu",
+                            span, SM_AG_LOG_SIZE);
+            }
 
             sm->used_bytes += SM_AG_LOG_SIZE;
-
-            ag = &dev->ags[a];
-            sm_ag_init(ag, d, a, base, span,
-                       pre_log_reserved, post_log_reserved);
+            data_end        = base + span;
+            sm_ag_init(ag, d, a, base, span, log_device_id, log_offset,
+                       data_off, data_end > data_off ? data_end - data_off : 0);
         }
     }
 
@@ -423,6 +452,12 @@ space_map_create(
             (uint64_t) SM_AG_LOG_SIZE,
             (unsigned) SM_AG_LOG_SLOT_COUNT,
             (uint64_t) SM_AG_LOG_SLOT_SIZE);
+    if (sm->num_remote_devices) {
+        sm_info("Block mode: %u remote data device(s); relocated AG-log region "
+                "on device %u offset %lu size %lu",
+                sm->num_remote_devices, (unsigned) SM_INTENT_LOG_DEVICE,
+                sm->remote_log_offset, sm->remote_log_size);
+    }
 
     return sm;
 } /* space_map_create */
@@ -456,6 +491,7 @@ static int
 sm_pick_and_alloc(
     struct space_map        *sm,
     const struct sm_journal *jnl,
+    uint32_t                 role,
     uint64_t                 want,
     uint32_t                *r_device_id,
     uint64_t                *r_device_offset)
@@ -475,6 +511,12 @@ sm_pick_and_alloc(
         dev_id = (start_dev + d) % sm->num_devices;
         struct sm_device *dev = &sm->devices[dev_id];
         uint32_t          start_ag;
+
+        /* Block mode keeps metadata on LOCAL devices and data on REMOTE
+         * devices; a role-matched allocation skips the other class. */
+        if (dev->role != role) {
+            continue;
+        }
 
         pthread_mutex_lock(&sm->lock);
         start_ag = dev->ag_rotor;
@@ -527,6 +569,7 @@ space_map_reserve(
     struct space_map        *sm,
     struct sm_thread_cache  *cache,
     const struct sm_journal *jnl,
+    uint32_t                 role,
     uint64_t                 min_bytes)
 {
     uint64_t need = SM_ALIGN_UP(min_bytes);
@@ -559,7 +602,7 @@ space_map_reserve(
         return -1;
     }
 
-    rc = sm_pick_and_alloc(sm, jnl, want, &cache->device_id, &cache->offset);
+    rc = sm_pick_and_alloc(sm, jnl, role, want, &cache->device_id, &cache->offset);
     if (rc == SM_AGAIN) {
         return SM_AGAIN;
     }
@@ -567,7 +610,7 @@ space_map_reserve(
         /* Try the smaller exact size before giving up, in case fragmentation
          * blocks the reservation but the caller's actual ask is small. */
         if (want != need) {
-            rc = sm_pick_and_alloc(sm, jnl, need, &cache->device_id, &cache->offset);
+            rc = sm_pick_and_alloc(sm, jnl, role, need, &cache->device_id, &cache->offset);
             if (rc == SM_AGAIN) {
                 return SM_AGAIN;
             }
@@ -591,6 +634,7 @@ space_map_alloc(
     struct space_map        *sm,
     struct sm_thread_cache  *cache,
     const struct sm_journal *jnl,
+    uint32_t                 role,
     uint64_t                 size,
     uint32_t                *r_device_id,
     uint64_t                *r_device_offset)
@@ -603,7 +647,7 @@ space_map_alloc(
     /* Ensure the cache covers `need` (refilling -- journals, may SM_AGAIN),
      * then dole from it.  Callers that have front-loaded the reservation via
      * space_map_reserve hit the fast path here with no journaling. */
-    rc = space_map_reserve(sm, cache, jnl, need);
+    rc = space_map_reserve(sm, cache, jnl, role, need);
     if (rc != 0) {
         return rc;     /* SM_AGAIN or -1 (ENOSPC) */
     }
@@ -799,22 +843,26 @@ space_map_write_superblock(
 
     memset(buf, 0, sizeof(buf));
 
-    sb->magic             = SM_SUPERBLOCK_MAGIC;
-    sb->version           = SM_FORMAT_VERSION;
-    sb->block_size        = SM_BLOCK_SIZE;
-    sb->ag_size           = SM_AG_SIZE;
-    sb->ag_log_size       = SM_AG_LOG_SIZE;
-    sb->fsid              = fsid;
-    sb->num_devices       = sm->num_devices;
-    sb->intent_log_device = SM_INTENT_LOG_DEVICE;
-    sb->intent_log_offset = SM_INTENT_LOG_OFFSET;
-    sb->intent_log_size   = SM_INTENT_LOG_SIZE;
-    sb->flags             = flags;
-    sb->root_inum         = root_inum;
-    sb->root_gen          = root_gen;
-    sb->log_seq           = log_seq;
-    sb->crc32             = 0;
-    sb->crc32             = sm_crc32(buf, sizeof(buf));
+    sb->magic              = SM_SUPERBLOCK_MAGIC;
+    sb->version            = SM_FORMAT_VERSION;
+    sb->block_size         = SM_BLOCK_SIZE;
+    sb->ag_size            = SM_AG_SIZE;
+    sb->ag_log_size        = SM_AG_LOG_SIZE;
+    sb->fsid               = fsid;
+    sb->num_devices        = sm->num_devices;
+    sb->intent_log_device  = SM_INTENT_LOG_DEVICE;
+    sb->intent_log_offset  = SM_INTENT_LOG_OFFSET;
+    sb->intent_log_size    = SM_INTENT_LOG_SIZE;
+    sb->flags              = flags;
+    sb->root_inum          = root_inum;
+    sb->root_gen           = root_gen;
+    sb->log_seq            = log_seq;
+    sb->num_remote_devices = sm->num_remote_devices;
+    sb->remote_log_device  = SM_INTENT_LOG_DEVICE;
+    sb->remote_log_offset  = sm->remote_log_offset;
+    sb->remote_log_size    = sm->remote_log_size;
+    sb->crc32              = 0;
+    sb->crc32              = sm_crc32(buf, sizeof(buf));
 
     if (io->write(io->user, 0, buf, sizeof(buf), SM_SUPERBLOCK_OFFSET) != 0) {
         return -1;
@@ -1093,7 +1141,9 @@ space_map_persist(
             }
             memcpy(buf, scratch, aligned);
 
-            writes[count].device_id   = d;
+            /* The log lives on log_device_id (== d for local AGs, the local
+             * metadata device for a relocated remote AG). */
+            writes[count].device_id   = ag->log_device_id;
             writes[count].buf         = buf;
             writes[count].length      = aligned;
             writes[count].offset      = slot_off;
@@ -1107,10 +1157,19 @@ space_map_persist(
             bytes += aligned;
             pthread_mutex_unlock(&ag->lock);
         }
+    }
 
-        if (sm_persist_batch_submit(io, writes, updates, bufs, &count, &bytes) != 0) {
-            free(scratch);
-            return -1;
+    /* Submit the final partial batch. */
+    if (sm_persist_batch_submit(io, writes, updates, bufs, &count, &bytes) != 0) {
+        free(scratch);
+        return -1;
+    }
+
+    /* Flush only devices that hold real storage; remote data devices have no
+     * local handle and never received writes (their logs rode device 0). */
+    for (d = 0; d < sm->num_devices; d++) {
+        if (sm->devices[d].role != SM_DEV_LOCAL) {
+            continue;
         }
         if (io->flush(io->user, d) != 0) {
             free(scratch);
@@ -1140,10 +1199,12 @@ space_map_load(
             uint32_t                s;
             uint64_t                payload, slot_off;
 
-            /* Pick the live slot: highest generation with a valid magic. */
+            /* Pick the live slot: highest generation with a valid magic.  The
+             * log lives on log_device_id (the local metadata device for a
+             * relocated remote AG). */
             for (s = 0; s < SM_AG_LOG_SLOT_COUNT; s++) {
                 slot_off = ag->log_offset + (uint64_t) s * SM_AG_LOG_SLOT_SIZE;
-                if (io->read(io->user, d, &hdr[s], sizeof(hdr[s]), slot_off) == 0 &&
+                if (io->read(io->user, ag->log_device_id, &hdr[s], sizeof(hdr[s]), slot_off) == 0 &&
                     hdr[s].magic == SM_AG_LOG_MAGIC &&
                     (best < 0 || hdr[s].generation > hdr[best].generation)) {
                     best = (int) s;
@@ -1158,7 +1219,7 @@ space_map_load(
                 (uint64_t) hdr[best].delta_count * sizeof(struct sm_ag_log_delta);
             buf      = malloc(payload);
             slot_off = ag->log_offset + (uint64_t) best * SM_AG_LOG_SLOT_SIZE;
-            if (io->read(io->user, d, buf, payload, slot_off) != 0) {
+            if (io->read(io->user, ag->log_device_id, buf, payload, slot_off) != 0) {
                 free(buf);
                 return -1;
             }

--- a/src/vfs/diskfs/space_map.h
+++ b/src/vfs/diskfs/space_map.h
@@ -201,6 +201,14 @@ struct sm_superblock {
     uint64_t root_inum;
     uint32_t root_gen;
     uint64_t log_seq;           /* next redo seq at clean unmount (for recovery) */
+    /* Block-mode (pNFS) relocated-AG-log region: where the AG logs for remote
+     * data devices live on the local metadata device (device 0), recorded so a
+     * persistent remount can validate the deterministic (device,ag)->slot map.
+     * remote_log_size == 0 means no remote devices (today's layout). */
+    uint32_t num_remote_devices;
+    uint32_t remote_log_device;     /* device holding relocated logs (== 0) */
+    uint64_t remote_log_offset;     /* region base on remote_log_device */
+    uint64_t remote_log_size;       /* total region bytes */
     /* Remainder of the 4 KiB block is implicit zero padding. */
 };
 
@@ -227,6 +235,36 @@ sm_crc32(
     return ~crc;
 } /* sm_crc32 */
 
+/*
+ * Device roles.  LOCAL devices hold all metadata (superblock, intent log,
+ * inodes/b+trees) and may hold data.  REMOTE devices model storage that lives
+ * outside this system for pNFS block layouts: diskfs tracks their free space
+ * but never opens them (no evpl_block handle); their AG logs are relocated onto
+ * a LOCAL device, and they hold only file data, accessed directly by the pNFS
+ * block client.  Device 0 must be LOCAL.
+ */
+#define SM_DEV_LOCAL     0
+#define SM_DEV_REMOTE    1
+
+#define SM_DEVICEID_SIZE 16
+#define SM_SIG_MAX       64
+
+/*
+ * Per-device configuration handed to space_map_create.  For LOCAL devices only
+ * `size` and `role` matter.  REMOTE devices additionally carry the stable
+ * 16-byte pNFS deviceid and an RFC 5663 SIMPLE-volume content signature
+ * {sig_offset, sig[0..sig_len)} that the block client matches against its local
+ * disks (provisioned out of band; diskfs never writes it).
+ */
+struct sm_device_cfg {
+    uint64_t size;
+    uint32_t role;
+    uint8_t  deviceid[SM_DEVICEID_SIZE];
+    uint64_t sig_offset;
+    uint32_t sig_len;
+    uint8_t  sig[SM_SIG_MAX];
+};
+
 struct sm_extent {
     struct rb_node node;
     uint64_t       offset;
@@ -238,7 +276,10 @@ struct sm_ag {
     uint32_t        ag_index;
     uint64_t        base_offset;
     uint64_t        size;
-    uint64_t        log_offset;      /* absolute device offset of this AG's log */
+    uint32_t        log_device_id;   /* device whose storage holds this AG's log
+                                      * (always LOCAL; == device_id unless this
+                                      * AG tracks a relocated REMOTE device) */
+    uint64_t        log_offset;      /* absolute offset of this AG's log on log_device_id */
     uint64_t        log_size;        /* total log bytes (both slots) */
     uint64_t        free_bytes;
     struct rb_tree  free_by_offset;
@@ -256,6 +297,11 @@ struct sm_device {
     uint64_t      size;
     uint32_t      num_ags;
     uint32_t      ag_rotor;
+    uint32_t      role;                       /* SM_DEV_LOCAL | SM_DEV_REMOTE */
+    uint8_t       deviceid[SM_DEVICEID_SIZE];  /* REMOTE: pNFS deviceid */
+    uint64_t      sig_offset;                 /* REMOTE: SIMPLE-volume signature */
+    uint32_t      sig_len;
+    uint8_t       sig[SM_SIG_MAX];
     struct sm_ag *ags;
 };
 
@@ -266,6 +312,13 @@ struct space_map {
     uint64_t          total_capacity;
     uint64_t          used_bytes;     /* atomic accounting for statfs */
     pthread_mutex_t   lock;           /* protects rotors and journaled writes */
+
+    /* Relocated remote-AG-log region on device 0 (block mode); zero if no
+     * remote devices.  Deterministic from the device cfg, recomputed on mount
+     * and cross-checked against the superblock. */
+    uint32_t          num_remote_devices;
+    uint64_t          remote_log_offset;
+    uint64_t          remote_log_size;
 };
 
 struct sm_thread_cache {
@@ -277,8 +330,8 @@ struct sm_thread_cache {
 
 struct space_map *
 space_map_create(
-    const uint64_t *device_sizes,
-    uint32_t        num_devices);
+    const struct sm_device_cfg *cfg,
+    uint32_t                    num_devices);
 
 void
 space_map_destroy(
@@ -306,16 +359,27 @@ space_map_reserve(
     struct space_map        *sm,
     struct sm_thread_cache  *cache,
     const struct sm_journal *jnl,
+    uint32_t                 role,
     uint64_t                 min_bytes);
 
+/* `role` (SM_DEV_LOCAL/SM_DEV_REMOTE) restricts the allocation to devices of
+ * that class: block mode places metadata on LOCAL and data on REMOTE devices.
+ * With no remote devices everything is LOCAL (today's single-pool behavior). */
 int
 space_map_alloc(
     struct space_map        *sm,
     struct sm_thread_cache  *cache,
     const struct sm_journal *jnl,
+    uint32_t                 role,
     uint64_t                 size,
     uint32_t                *r_device_id,
     uint64_t                *r_device_offset);
+
+static inline int
+space_map_has_remote(const struct space_map *sm)
+{
+    return sm->num_remote_devices > 0;
+} // space_map_has_remote
 
 int
 space_map_free(


### PR DESCRIPTION
Adds pNFS support to the `diskfs` backend in both forms the NFS server already
implements: orchestrated **flex-files** (RFC 8435) and backend-sourced **block
volume** layouts (RFC 5663). diskfs becomes the first backend to exercise the
block (layout-sourcing) path.

### Flex-files
diskfs persists the opaque per-file pNFS layout blob as a new `DISKFS_REC_PNFS`
b+tree record, round-tripped through getattr/setattr, and advertises
`CHIMERA_VFS_CAP_LAYOUT` — mirroring memfs. The MDS steers file data to a data
server exactly as before.

### Block (RFC 5663), config-gated via `block_layout`
- **Device roles:** config tags each device `local` (metadata) or `remote`
  (data). Remote devices model storage outside this system — diskfs tracks their
  free space but never opens them (no `evpl_block` handle); their size, 16-byte
  deviceid and SIMPLE-volume signature come from config. The pNFS block client
  does all data I/O directly to those disks.
- **Allocator:** each remote AG's log is relocated onto the local metadata
  device (a deterministic region on device 0, recorded in the superblock and
  revalidated on remount). Metadata allocates from local devices and file data
  from remote devices (role-filtered `space_map` + a second per-thread data
  reservation cache). The zero-remote-device path is byte-identical to before.
- **GET_LAYOUT:** a resumable async handler walks the inode extent tree, emits
  block segments, and for RW gaps allocates + records extents, committing the
  transaction (durably) before returning the layout so a crash can never
  re-hand-out a block the client is about to write. Freshly-allocated /
  beyond-EOF ranges are `INVALID_DATA`; ranges within the committed size are
  `READ_WRITE`/`READ` (size advances on LAYOUTCOMMIT). Block-mode shares are
  pNFS-only — inline read/write is rejected (the server can't reach the data
  devices).

### NFS server enablement
- Enable the pNFS feature whenever configured, not only when a data-server table
  is present — a layout-sourcing backend produces its own layouts and needs no
  data servers.
- Advertise/emit `FATTR4_LAYOUT_BLKSIZE` / `LAYOUT_ALIGNMENT` for block layouts
  (the Linux block layout driver refuses to initialize without a blksize), and
  size a block LAYOUTGET reply to the exact extent span.

### Tests
KVM Linux-client coverage for both forms: flex `rw`/`recall_truncate`/
`recall_truncate_xclient`/`remove` (memfs + diskfs) and block
`rw`/`remove`/`recall_truncate` (diskfs io_uring/aio). The block tests attach a
signed virtio-SCSI data disk the server never touches and verify, via a
drop-caches re-read, that I/O went through the block layout directly to the disk
(the MDS rejects inline I/O). All flex + block pNFS KVM tests pass; the
non-pNFS diskfs path is unchanged.
