### PR TITLE
nfs4: renew/revive client lease on EXCHANGE_ID and CREATE_SESSION

### DIFF
--- a/src/server/nfs/nfs4_proc_exchange_id.c
+++ b/src/server/nfs/nfs4_proc_exchange_id.c
@@ -106,6 +106,13 @@ chimera_nfs4_exchange_id(
                   &eid.clientid, sizeof(eid.clientid), c);
         if (c) {
             uc = c->unified;
+            /* EXCHANGE_ID is client liveness: renew the lease so a client
+             * mid-handshake (EXCHANGE_ID -> CREATE_SESSION -> first SEQUENCE)
+             * is not expired by the lease sweep before it establishes a
+             * session. */
+            if (uc) {
+                nfs_client_touch(uc);
+            }
         }
         pthread_mutex_unlock(&thread->shared->nfs4_shared_clients.nfs4_ct_lock);
         if (uc) {

--- a/src/server/nfs/nfs4_session.c
+++ b/src/server/nfs/nfs4_session.c
@@ -630,10 +630,20 @@ nfs4_client_create_session_classify(
     HASH_FIND(nfs4_client_hh_by_id, table->nfs4_ct_clients_by_id,
               &client_id, sizeof(client_id), c);
 
+    if (c && c->unified) {
+        /* CREATE_SESSION is client liveness on a clientid the server still
+         * holds.  If the lease sweep had marked the client courtesy-expired
+         * (e.g. its EXCHANGE_ID -> CREATE_SESSION handshake stalled past the
+         * lease under load), revive it rather than returning STALE_CLIENTID:
+         * the clientid is valid and the client is plainly alive.  Clear
+         * expired first so the renew (a no-op on an expired client) takes
+         * hold, then renew so the window to the client's first SEQUENCE cannot
+         * trip the sweep. */
+        c->unified->expired = 0;
+        nfs_client_touch(c->unified);
+    }
+
     if (!c) {
-        out->action = NFS4_CS_ERROR;
-        out->status = NFS4ERR_STALE_CLIENTID;
-    } else if (c->unified && c->unified->expired) {
         out->action = NFS4_CS_ERROR;
         out->status = NFS4ERR_STALE_CLIENTID;
     } else if (csa_sequence == c->nfs4_client_cs_seqid) {


### PR DESCRIPTION
## Problem

The recurring `COUR7` (`st_courtesy.testExpiringManyClients`) CI flake is a real NFS4.1 lease bug, not test timing.

A client's lease clock (`last_touch_ns`) is renewed **only by SEQUENCE**. `EXCHANGE_ID` and `CREATE_SESSION` don't renew it, and `nfs4_client_create_session_classify` rejected an already-expired client record with `NFS4ERR_STALE_CLIENTID`.

So if a client's `EXCHANGE_ID -> CREATE_SESSION -> first-SEQUENCE` handshake takes longer than the lease — easy under heavy CI load (32 parallel ASan tests creating 1000 clients), and with the short 5s lease the pynfs suite uses — the 1 Hz lease sweep marks it `expired` mid-handshake, and its own `CREATE_SESSION` then fails `STALE_CLIENTID` even though the clientid was just issued and is still in the table. Clientids are a monotonic counter (no reuse), confirming the record was the client's own.

## Fix

- **EXCHANGE_ID** renews the client lease (`nfs_client_touch`) — it's a client-liveness operation.
- **CREATE_SESSION** renews the lease and **revives** a courtesy-expired-but-present client (clear `expired`, then renew) instead of returning `STALE_CLIENTID`. A client actively doing CREATE_SESSION on a clientid the server still holds is alive; reviving it is the correct courteous-server behavior.

## Validation

Built locally and reproduced deterministically with a new pynfs probe (EXCHANGE_ID, idle past the lease, then CREATE_SESSION):
- **without** this change: `CREATE_SESSION -> NFS4ERR_STALE_CLIENTID` (fail)
- **with** this change: pass (client revived)

Stable courteous tests `COUR2`–`COUR7` all pass with the fix; `COUR7` (the flake) passes.