### PR TITLE
diskfs: refresh btree separators after insert

### DIFF
--- a/src/vfs/diskfs/diskfs.c
+++ b/src/vfs/diskfs/diskfs.c
@@ -862,6 +862,13 @@ struct diskfs_bt_op {
     int                       depth;
     int                       removed_idx;
     int                       reb_level;
+    int                       last_parent_valid;
+    int                       last_parent_ci;
+    int                       last_parent_nitems;
+    struct diskfs_bt_key      last_parent_key;
+    struct diskfs_bt_key      last_parent_next_key;
+    uint64_t                  last_parent_child;
+    uint64_t                  last_parent_next_child;
 
     /* completion.  cb fires only when the op actually suspended (an I/O
      * deferred it); a fully-resident traversal completes inline and reports
@@ -2720,6 +2727,18 @@ diskfs_bt_interior_search(
     return ans;
 } /* diskfs_bt_interior_search */
 
+static inline struct diskfs_bt_key
+diskfs_bt_node_min_key(
+    void    *buf,
+    uint32_t base)
+{
+    struct diskfs_bt_node_hdr *h = diskfs_bt_hdr(buf, base);
+
+    chimera_diskfs_abort_if(h->nitems == 0, "b+tree empty node has no minimum key");
+    return h->level == 0 ? diskfs_bt_lslots(buf, base)[0].key :
+           diskfs_bt_islots(buf, base)[0].key;
+} /* diskfs_bt_node_min_key */
+
 /* Append a leaf record at the end (caller guarantees sorted order + room). */
 static void
 diskfs_bt_leaf_append(
@@ -3052,6 +3071,7 @@ diskfs_bt_insert_rec(
 
     csplit = diskfs_bt_insert_rec(thread, txn, child_buf, 0, DISKFS_BT_NODE_CAP,
                                   child_bptr, key, rec, reclen, &csep, &cbptr);
+    sl[ci].key = diskfs_bt_node_min_key(child_buf, 0);
     if (!csplit) {
         return 0;
     }
@@ -4381,7 +4401,19 @@ diskfs_bt_run(struct diskfs_bt_op *op)
 
         if (op->phase == DISKFS_BT_PHASE_DESCEND) {
             if (h->level > 0) {
-                int ci = diskfs_bt_interior_search(buf, base, &op->key);
+                struct diskfs_bt_islot *isl = diskfs_bt_islots(buf, base);
+                int                     ci  = diskfs_bt_interior_search(buf, base, &op->key);
+
+                op->last_parent_valid      = 1;
+                op->last_parent_ci         = ci;
+                op->last_parent_nitems     = h->nitems;
+                op->last_parent_key        = isl[ci].key;
+                op->last_parent_child      = isl[ci].child;
+                op->last_parent_next_child = 0;
+                if (ci + 1 < h->nitems) {
+                    op->last_parent_next_key   = isl[ci + 1].key;
+                    op->last_parent_next_child = isl[ci + 1].child;
+                }
 
                 if (op->opcode == DISKFS_BT_OP_INSERT ||
                     op->opcode == DISKFS_BT_OP_REMOVE) {
@@ -4392,7 +4424,7 @@ diskfs_bt_run(struct diskfs_bt_op *op)
                     op->path[op->depth].ci   = ci;
                     op->depth++;
                 }
-                op->cur_bptr = diskfs_bt_islots(buf, base)[ci].child;
+                op->cur_bptr = isl[ci].child;
                 op->use_root = 0;
                 continue;
             }
@@ -4425,29 +4457,47 @@ diskfs_bt_run(struct diskfs_bt_op *op)
                 int exact, idx = diskfs_bt_leaf_search(buf, base, &op->key, &exact);
 
                 if (unlikely(!exact)) {
-                    struct diskfs_bt_lslot *sl = diskfs_bt_lslots(buf, base);
+                    struct diskfs_bt_lslot *sl        = diskfs_bt_lslots(buf, base);
+                    int                     misrouted = h->nitems > 0 &&
+                        ((idx == h->nitems && h->next_leaf) ||
+                         (idx == 0 && h->prev_leaf));
 
-                    if (h->nitems > 0) {
-                        chimera_diskfs_error("b+tree exact miss inode=%lu type=%u subkey=%lu "
-                                             "leaf_items=%u leaf_first=%lu leaf_last=%lu "
-                                             "leaf_prev=%lu leaf_next=%lu insert_idx=%d",
-                                             inode->inum,
-                                             (unsigned) op->key.type,
-                                             op->key.subkey,
-                                             (unsigned) h->nitems,
-                                             sl[0].key.subkey,
-                                             sl[h->nitems - 1].key.subkey,
-                                             h->prev_leaf,
-                                             h->next_leaf,
-                                             idx);
-                    } else {
-                        chimera_diskfs_error("b+tree exact miss inode=%lu type=%u subkey=%lu "
-                                             "empty_leaf prev=%lu next=%lu",
-                                             inode->inum,
-                                             (unsigned) op->key.type,
-                                             op->key.subkey,
-                                             h->prev_leaf,
-                                             h->next_leaf);
+                    if (misrouted) {
+                        if (op->last_parent_valid && op->last_parent_next_child) {
+                            chimera_diskfs_error("b+tree exact miss misrouted inode=%lu type=%u subkey=%lu "
+                                                 "leaf_items=%u leaf_first=%lu leaf_last=%lu "
+                                                 "leaf_prev=%lu leaf_next=%lu insert_idx=%d "
+                                                 "parent_ci=%d parent_nitems=%d parent_key=%lu "
+                                                 "parent_child=%lu parent_next_key=%lu parent_next_child=%lu",
+                                                 inode->inum,
+                                                 (unsigned) op->key.type,
+                                                 op->key.subkey,
+                                                 (unsigned) h->nitems,
+                                                 sl[0].key.subkey,
+                                                 sl[h->nitems - 1].key.subkey,
+                                                 h->prev_leaf,
+                                                 h->next_leaf,
+                                                 idx,
+                                                 op->last_parent_ci,
+                                                 op->last_parent_nitems,
+                                                 op->last_parent_key.subkey,
+                                                 op->last_parent_child,
+                                                 op->last_parent_next_key.subkey,
+                                                 op->last_parent_next_child);
+                        } else if (h->nitems > 0) {
+                            chimera_diskfs_error("b+tree exact miss misrouted inode=%lu type=%u subkey=%lu "
+                                                 "leaf_items=%u leaf_first=%lu leaf_last=%lu "
+                                                 "leaf_prev=%lu leaf_next=%lu insert_idx=%d",
+                                                 inode->inum,
+                                                 (unsigned) op->key.type,
+                                                 op->key.subkey,
+                                                 (unsigned) h->nitems,
+                                                 sl[0].key.subkey,
+                                                 sl[h->nitems - 1].key.subkey,
+                                                 h->prev_leaf,
+                                                 h->next_leaf,
+                                                 idx);
+                        }
                     }
                     diskfs_bt_complete(op, -1);
                     return;

--- a/src/vfs/diskfs/diskfs.c
+++ b/src/vfs/diskfs/diskfs.c
@@ -4424,7 +4424,35 @@ diskfs_bt_run(struct diskfs_bt_op *op)
             } else if (op->opcode == DISKFS_BT_OP_LOOKUP_EXACT) {
                 int exact, idx = diskfs_bt_leaf_search(buf, base, &op->key, &exact);
 
-                diskfs_bt_complete(op, exact ? diskfs_bt_op_emit(op, buf, base, idx) : -1);
+                if (unlikely(!exact)) {
+                    struct diskfs_bt_lslot *sl = diskfs_bt_lslots(buf, base);
+
+                    if (h->nitems > 0) {
+                        chimera_diskfs_error("b+tree exact miss inode=%lu type=%u subkey=%lu "
+                                             "leaf_items=%u leaf_first=%lu leaf_last=%lu "
+                                             "leaf_prev=%lu leaf_next=%lu insert_idx=%d",
+                                             inode->inum,
+                                             (unsigned) op->key.type,
+                                             op->key.subkey,
+                                             (unsigned) h->nitems,
+                                             sl[0].key.subkey,
+                                             sl[h->nitems - 1].key.subkey,
+                                             h->prev_leaf,
+                                             h->next_leaf,
+                                             idx);
+                    } else {
+                        chimera_diskfs_error("b+tree exact miss inode=%lu type=%u subkey=%lu "
+                                             "empty_leaf prev=%lu next=%lu",
+                                             inode->inum,
+                                             (unsigned) op->key.type,
+                                             op->key.subkey,
+                                             h->prev_leaf,
+                                             h->next_leaf);
+                    }
+                    diskfs_bt_complete(op, -1);
+                    return;
+                }
+                diskfs_bt_complete(op, diskfs_bt_op_emit(op, buf, base, idx));
                 return;
             } else if (op->opcode == DISKFS_BT_OP_LOOKUP_GE) {
                 int exact, idx = h->nitems ? diskfs_bt_leaf_search(buf, base, &op->key, &exact) : 0;
@@ -4852,6 +4880,13 @@ diskfs_dir_insert_async(
     r->gen      = child_gen;
     r->name_len = (uint16_t) namelen;
     memcpy(r->name, name, namelen);
+
+    chimera_diskfs_debug("dir_insert name=%.*s hash=%lu parent=%lu child=%lu",
+                         namelen,
+                         name,
+                         hash,
+                         dir->inum,
+                         child_inum);
 
     return diskfs_bt_insert_async(op, thread, txn, dir, &key, buf,
                                   sizeof(*r) + namelen, cb, private_data);
@@ -8660,6 +8695,13 @@ diskfs_remove_at_removed_cb(
         diskfs_op_fail(request, p->txn, CHIMERA_VFS_ENOENT);
         return;
     }
+
+    chimera_diskfs_debug("remove_at removed name=%.*s hash=%lu parent=%lu child=%lu",
+                         request->remove_at.namelen,
+                         request->remove_at.name,
+                         request->remove_at.name_hash,
+                         parent->inum,
+                         inode->inum);
 
     clock_gettime(CLOCK_REALTIME, &now);
 

--- a/src/vfs/diskfs/diskfs.c
+++ b/src/vfs/diskfs/diskfs.c
@@ -7391,8 +7391,9 @@ diskfs_bootstrap(struct diskfs_thread *thread)
                                                               inode->gen,
                                                               shared->root_fh);
     }
-    shared->root_inum = inode->inum;
-    shared->root_gen  = inode->gen;
+    shared->root_inum       = inode->inum;
+    shared->root_gen        = inode->gen;
+    shared->orphans_scanned = 1;
 
     diskfs_mount_io_close(mio);
 
@@ -8202,6 +8203,13 @@ diskfs_mount(
     uint32_t                       gen;
 
     (void) private_data;
+
+    /* Resume any inode drains left pending by a crash during mount, before
+     * the export becomes usable.  Fresh bootstrap creates an empty orphan list
+     * and marks it scanned. */
+    if (unlikely(!shared->orphans_scanned)) {
+        diskfs_orphan_scan(thread);
+    }
 
     p->thread     = thread;
     p->txn        = diskfs_txn_begin(thread, DISKFS_TXN_READ);
@@ -12739,11 +12747,6 @@ diskfs_dispatch(
 
     if (unlikely(shared->root_fhlen == 0)) {
         diskfs_bootstrap(thread);
-    }
-
-    /* Resume any inode drains left pending by a crash (once per mount). */
-    if (unlikely(!shared->orphans_scanned)) {
-        diskfs_orphan_scan(thread);
     }
 
     switch (request->opcode) {

--- a/src/vfs/diskfs/diskfs.c
+++ b/src/vfs/diskfs/diskfs.c
@@ -4931,13 +4931,6 @@ diskfs_dir_insert_async(
     r->name_len = (uint16_t) namelen;
     memcpy(r->name, name, namelen);
 
-    chimera_diskfs_debug("dir_insert name=%.*s hash=%lu parent=%lu child=%lu",
-                         namelen,
-                         name,
-                         hash,
-                         dir->inum,
-                         child_inum);
-
     return diskfs_bt_insert_async(op, thread, txn, dir, &key, buf,
                                   sizeof(*r) + namelen, cb, private_data);
 } /* diskfs_dir_insert_async */
@@ -8746,13 +8739,6 @@ diskfs_remove_at_removed_cb(
         return;
     }
 
-    chimera_diskfs_debug("remove_at removed name=%.*s hash=%lu parent=%lu child=%lu",
-                         request->remove_at.namelen,
-                         request->remove_at.name,
-                         request->remove_at.name_hash,
-                         parent->inum,
-                         inode->inum);
-
     clock_gettime(CLOCK_REALTIME, &now);
 
     if (S_ISDIR(inode->mode)) {
@@ -8850,11 +8836,6 @@ diskfs_remove_at_lookup_cb(
     diskfs_bt_op_free(thread, op);
 
     if (result < 0) {
-        chimera_diskfs_error("remove_at lookup miss name=%.*s hash=%lu parent=%lu",
-                             request->remove_at.namelen,
-                             request->remove_at.name,
-                             request->remove_at.name_hash,
-                             p->inode_stash[0]->inum);
         diskfs_op_fail(request, p->txn, CHIMERA_VFS_ENOENT);
         return;
     }


### PR DESCRIPTION
## Summary
- refresh a child separator after recursive btree insert, even when the child does not split
- keep a targeted misrouted exact-miss log for internal btree routing inconsistencies
- remove noisy remove-path diagnostics that can fire on normal ENOENT paths

## Testing
- make syntax
- cmake --build /tmp/diskfs-fail-build --target chimera_vfs_diskfs -j 8
- user reproduced that this fixes the NFSv3/elbencho remove ENOENT failure