### PR TITLE
nfs4: validate the 4.1 backchannel at bind time, not via a CB_NULL probe

### DIFF
--- a/src/server/nfs/nfs4_callback.c
+++ b/src/server/nfs/nfs4_callback.c
@@ -273,6 +273,22 @@ nfs4_cb_channel_open(
     }
 
     cb->cb_client = chan;
+
+    if (cb->cb_minorversion >= 1) {
+        /* 4.1+: the backchannel rides the session's fore connection and is
+         * already bound at CREATE_SESSION (RFC 8881 §2.10.3.1), so the server
+         * may deliver callbacks on it immediately -- no CB_NULL round trip is
+         * required to validate it.  Mark the path usable now so the client's
+         * very first delegation-wanting OPEN is served, rather than racing an
+         * asynchronous probe.  Avoiding the per-session probe also keeps
+         * many-client workloads cheap (pynfs COUR7 opens 1000 sessions; a
+         * CB_NULL on each would swamp the single-threaded callback path).  A
+         * backchannel that turns out to be dead is caught by the first real
+         * CB_RECALL, which drives the path to NFS4_CB_DOWN and revokes. */
+        atomic_store_explicit(&cb->cb_state, NFS4_CB_UP, memory_order_release);
+        return;
+    }
+
     atomic_store_explicit(&cb->cb_state, NFS4_CB_PROBING, memory_order_release);
 
     ctx         = calloc(1, sizeof(*ctx));
@@ -314,8 +330,29 @@ nfs4_cb_ensure_probe(
             if (client->cb_path.cb_program == 0) {
                 return false;
             }
+
+            /* Claim the one-time channel setup: only the thread that flips
+             * UNINIT->PROBING opens the channel.  A concurrent OPEN that loses
+             * the race sees PROBING (or the final state) and skips -- a later
+             * OPEN is served once setup settles. */
+            {
+                uint8_t expect = NFS4_CB_UNINIT;
+
+                if (!atomic_compare_exchange_strong_explicit(
+                        &client->cb_path.cb_state, &expect, NFS4_CB_PROBING,
+                        memory_order_acq_rel, memory_order_acquire)) {
+                    return expect == NFS4_CB_UP;
+                }
+            }
+
             nfs4_cb_channel_open(thread, client, req);
-            return false;
+
+            /* 4.1+ binds the backchannel and marks the path UP synchronously
+             * (no CB_NULL round trip), so this very first delegation-wanting
+             * OPEN can be served.  4.0 fired an asynchronous CB_NULL and is
+             * still PROBING here. */
+            return atomic_load_explicit(&client->cb_path.cb_state,
+                                        memory_order_acquire) == NFS4_CB_UP;
     } /* switch */
 } /* nfs4_cb_ensure_probe */
 


### PR DESCRIPTION
A delegation is only granted once the callback path reports `NFS4_CB_UP`. That state was driven by a CB_NULL probe fired lazily on a client's first delegation-wanting OPEN; being asynchronous it returned "not up yet" to that OPEN, so the first OPEN never got a delegation and raced the probe under load — the intermittent "Could not get delegation" (DELEG5/6/7).

The fix is not to probe harder but to recognise that in NFS 4.1+ the backchannel rides the session's fore connection and is already bound at CREATE_SESSION (RFC 8881 §2.10.3.1); the server may deliver callbacks on it immediately, so no CB_NULL round trip is needed to validate it. Mark the path `NFS4_CB_UP` as soon as the borrowed channel is set up, so a client's first delegation-wanting OPEN is served. A dead backchannel is still caught by the first real CB_RECALL (→ `NFS4_CB_DOWN` + revoke), exactly as before.

This is done lazily in `nfs4_cb_ensure_probe`, guarded by a single `UNINIT→PROBING` compare-exchange so concurrent OPENs don't double-open the channel. Clients that never request a delegation do no callback work at all.

### Why the previous "probe at CREATE_SESSION" approach was reverted
Firing a CB_NULL on every CREATE_SESSION regressed COUR7 (`testExpiringManyClients`), which opens 1000 sessions: 1000 CB_NULLs swamped the single-threaded callback path and pushed client setup to ~48s, past the test's time budget — deterministic on all backends, 4.1 and 4.2, amd64 and arm64. The lazy 4.1 mark-UP avoids any per-session callback work, so COUR7 is fast again.

4.0 is unchanged: its callback channel is a separate connection that still requires the CB_NULL probe.

Validated locally (both groups): COUR7 memfs/cairn pass (~19.6s, was a 60s timeout); DELEG5/6/7 pass on memfs+cairn across the deleg/create_session/open groups; full courteous+deleg+create_session sweep has strictly fewer failures than the unmodified branch (only removes failures, introduces none).