### PR TITLE
diskfs: pNFS SCSI layout (RFC 8154) hardware-ID device matching

### DIFF
--- a/kvm/kvm_pnfs_scsi_test_wrapper.sh
+++ b/kvm/kvm_pnfs_scsi_test_wrapper.sh
@@ -1,0 +1,221 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+#
+# SPDX-License-Identifier: Unlicense
+
+# Usage: kvm_pnfs_scsi_test_wrapper.sh <vmlinuz> <rootfs.qcow2> <chimera_binary> <backend> <test_cmd>
+#
+# Orchestrates a pNFS *SCSI* layout (RFC 8154) setup and a QEMU VM to exercise
+# it.  Like the block layout there is no data server: file data lives on a block
+# device the *client* reaches directly.  Unlike block (RFC 5663), the client
+# matches the device strictly by its *hardware identifier* -- the SCSI VPD-0x83
+# designator (here a NAA WWN) -- with NOTHING written to the data disk.
+#
+# 1. A raw "data" disk image is created (left entirely blank -- the whole point
+#    of SCSI layout is that no content signature is needed).  It is attached to
+#    the VM as a virtio-SCSI disk carrying a WWN, so the guest kernel exposes a
+#    VPD-0x83 NAA designator at /dev/disk/by-id/wwn-0x...  diskfs is told about
+#    this device as a "remote" data device (size + deviceid + scsi designator);
+#    the chimera daemon NEVER opens it -- it only tracks free space and hands
+#    out block extents.
+# 2. A SCSI-mode chimera metadata server (diskfs, scsi_layout=true) runs on
+#    10.0.0.1:2049 with a local metadata device.
+# 3. The VM boots, loads the kernel block/SCSI layout driver, mounts the MDS
+#    vers=4.1, and runs the workload.  On LAYOUTGET the MDS allocates extents on
+#    the remote volume and returns a SCSI layout naming the LU by its designator;
+#    the kernel matches /dev/sd? by WWN in-kernel (no blkmapd upcall) and does
+#    READ/WRITE directly to it.  Because the MDS has no access to the data device
+#    it rejects inline READ/WRITE with EINVAL, so a drop-caches re-read that still
+#    matches proves the SCSI layout was used.
+#
+# IMPORTANT (bring-up finding): the Linux SCSI layout client issues a MANDATORY
+# SCSI PERSISTENT RESERVE OUT (REGISTER) to the matched LU before using the
+# layout.  This wrapper's data disk is an emulated virtio-SCSI scsi-hd, which
+# does NOT implement persistent reservations, so the client's registration fails
+# ("Invalid command operation code") and the guest kernel then Oopses in its
+# failed-registration cleanup path.  Up to that point the server side works
+# end-to-end: the client parses our GETDEVICEINFO, matches /dev/sd? by its NAA
+# WWN ("pNFS: using block device sda"), and reaches LAYOUTGET -- i.e. the
+# hardware-ID matching this layout type exists for is proven.  To run the data
+# path you must back the LU with a PR-CAPABLE target (an LIO/tcmu device, or a
+# real SAS/FC/iSCSI LU) and pass it through (e.g. scsi-block + qemu-pr-helper,
+# which forwards PR to the host device).  Emulated scsi-hd cannot do this, and
+# qemu-pr-helper has no real device to forward to, so the ctest entries are
+# registered DISABLED (see kvm/tests/CMakeLists.txt); this script stays runnable
+# for manual use against PR-capable storage.  The server itself issues no
+# reservations in v1 (revocation is recall-only).
+
+set -u
+
+ARCH=$(uname -m)
+if [ "$ARCH" = "aarch64" ]; then
+    QEMU_BIN="qemu-system-aarch64"
+    QEMU_MACHINE="-machine virt"
+    QEMU_CONSOLE="ttyAMA0"
+else
+    QEMU_BIN="qemu-system-x86_64"
+    QEMU_MACHINE="-machine q35,usb=off"
+    QEMU_CONSOLE="ttyS0"
+fi
+
+VMLINUZ=$1; shift
+ROOTFS=$1; shift
+CHIMERA_BINARY=$1; shift
+BACKEND=$1; shift
+TEST_CMD_ARG="$*"
+
+INITRD="$(dirname "$VMLINUZ")/initrd"
+if [ -f "$INITRD" ]; then
+    QEMU_INITRD="-initrd $INITRD"
+else
+    QEMU_INITRD=""
+fi
+
+NETNS_NAME="kvm_pnfsscsi_$$_$(date +%s%N)"
+TAP_NAME="taps_$$"
+LOG_FILE=$(mktemp /tmp/kvm_pnfsscsi_test_XXXXXX.log)
+BUILD_DIR=$(dirname "$(dirname "$CHIMERA_BINARY")")
+SESSION_DIR=$(mktemp -d "${BUILD_DIR}/kvm_pnfsscsi_session_XXXXXX")
+MDS_CONFIG="${SESSION_DIR}/mds.json"
+MDS_LOG="${SESSION_DIR}/mds.log"
+DATA_IMG="${SESSION_DIR}/data.img"
+MDS_PID=""
+
+MDS_IP="10.0.0.1"
+MDS_PORT=2049
+
+# Data volume: size, stable deviceid, and a SCSI VPD-0x83 NAA designator the
+# client matches against /dev/disk/by-id/wwn-0x<WWN>.  The WWN is the disk's
+# hardware identity; nothing is written to the disk to identify it.
+DATA_SIZE=2147483648
+DEVICEID="00112233445566778899aabbccddeeff"
+WWN="5000c500deadbeef"
+
+cleanup() {
+    if [ -n "$MDS_PID" ]; then
+        kill "$MDS_PID" 2>/dev/null || true
+        for i in $(seq 1 30); do
+            kill -0 "$MDS_PID" 2>/dev/null || break
+            sleep 0.1
+        done
+        kill -9 "$MDS_PID" 2>/dev/null || true
+        wait "$MDS_PID" 2>/dev/null || true
+    fi
+    if [ -f "$LOG_FILE" ]; then
+        echo "=== Guest serial log ==="
+        cat "$LOG_FILE"
+    fi
+    if [ -f "$MDS_LOG" ]; then
+        echo "=== Metadata server log (tail) ==="
+        tail -30 "$MDS_LOG"
+    fi
+    ip netns delete "${NETNS_NAME}" 2>/dev/null || true
+    rm -f "$LOG_FILE"
+    rm -rf "$SESSION_DIR"
+}
+trap cleanup EXIT
+
+# The SCSI-mode metadata server: a local metadata device (device 0) plus the
+# remote data device (device 1) described purely by config -- identified by its
+# SCSI NAA designator rather than a content signature.
+generate_mds_config() {
+    local device_type="io_uring"
+    [ "$BACKEND" = "diskfs_aio" ] && device_type="libaio"
+    local meta="${SESSION_DIR}/mds-meta.img"
+    truncate -s 4G "$meta"
+
+    cat > "$MDS_CONFIG" << EOF
+{
+    "server": {
+        "threads": 4,
+        "external_portmap": false,
+        "vfs": {
+            "diskfs": {
+                "config": {
+                    "initialize": true,
+                    "unsafe_async": true,
+                    "scsi_layout": true,
+                    "devices": [
+                        { "type": "${device_type}", "size": 4294967296, "path": "${meta}" },
+                        { "role": "remote", "size": ${DATA_SIZE}, "deviceid": "${DEVICEID}",
+                          "scsi": { "designator_type": "naa", "code_set": "binary",
+                                    "id": "${WWN}", "pr_key": 1 } }
+                    ]
+                }
+            }
+        },
+        "pnfs": { "enabled": true }
+    },
+    "mounts": { "share": { "module": "diskfs", "path": "/" } },
+    "exports": { "/share": { "path": "/share" } }
+}
+EOF
+}
+
+wait_for_port() {
+    local ip="$1" port="$2" pid="$3"
+    for i in $(seq 1 50); do
+        if ip netns exec "${NETNS_NAME}" bash -c "echo > /dev/tcp/${ip}/${port}" 2>/dev/null; then
+            return 0
+        fi
+        if ! kill -0 "$pid" 2>/dev/null; then
+            echo "chimera daemon (pid $pid) exited prematurely" >&2
+            return 1
+        fi
+        sleep 0.1
+    done
+    echo "timed out waiting for ${ip}:${port}" >&2
+    return 1
+}
+
+ulimit -l unlimited
+echo 16777216 > /proc/sys/fs/aio-max-nr 2>/dev/null || true
+
+# The (blank) data disk the client will reach as a virtio-SCSI LU, matched by WWN.
+truncate -s "$DATA_SIZE" "$DATA_IMG"
+
+# Network namespace + TAP for the VM.
+ip netns add "${NETNS_NAME}"
+ip netns exec "${NETNS_NAME}" ip link set lo up
+ip netns exec "${NETNS_NAME}" ip tuntap add dev "${TAP_NAME}" mode tap
+ip netns exec "${NETNS_NAME}" ip addr add 10.0.0.1/24 dev "${TAP_NAME}"
+ip netns exec "${NETNS_NAME}" ip link set "${TAP_NAME}" up
+
+generate_mds_config
+ip netns exec "${NETNS_NAME}" "$CHIMERA_BINARY" -c "$MDS_CONFIG" > "$MDS_LOG" 2>&1 &
+MDS_PID=$!
+wait_for_port "$MDS_IP" "$MDS_PORT" "$MDS_PID" || exit 1
+echo "=== pNFS SCSI metadata server up on ${MDS_IP}:${MDS_PORT} ==="
+
+# Boot the VM: rootfs as vda (virtio-blk), the blank data volume as a virtio-SCSI
+# LU carrying a WWN so the guest exposes a VPD-0x83 designator.  The test command
+# (see kvm/tests/CMakeLists.txt PNFS_SCSI_SETUP) loads the layout driver, mounts
+# the MDS and runs the workload.
+TEST_CMD="${TEST_CMD_ARG}"
+
+ip netns exec "${NETNS_NAME}" "$QEMU_BIN" \
+    -enable-kvm -smp 4 -m 1G -cpu host \
+    -kernel "$VMLINUZ" \
+    $QEMU_INITRD \
+    $QEMU_MACHINE \
+    -nodefaults \
+    -drive file="$ROOTFS",if=virtio,format=qcow2,snapshot=on \
+    -device virtio-scsi-pci,id=scsi0 \
+    -drive file="$DATA_IMG",if=none,id=dd0,format=raw,snapshot=on \
+    -device scsi-hd,drive=dd0,bus=scsi0.0,wwn=0x${WWN} \
+    -netdev tap,id=net0,ifname="${TAP_NAME}",script=no,downscript=no \
+    -device virtio-net-pci,netdev=net0,romfile="" \
+    -serial stdio \
+    -nographic \
+    -no-reboot \
+    -append "root=/dev/vda rw console=${QEMU_CONSOLE} net.ifnames=0 biosdevname=0 quiet panic=-1 test_cmd=\"${TEST_CMD}\" init=/init.sh" \
+    2>/dev/null | tee "$LOG_FILE"
+
+if ! kill -0 "$MDS_PID" 2>/dev/null; then
+    wait "$MDS_PID" 2>/dev/null
+    echo "=== chimera MDS (pid $MDS_PID) DIED during the test (exit $?) ==="
+    MDS_PID=""
+fi
+
+EXIT_CODE=$(grep -oP 'CHIMERA_KVM_EXIT_CODE=\K[0-9]+' "$LOG_FILE" | tail -1)
+exit ${EXIT_CODE:-1}

--- a/kvm/tests/CMakeLists.txt
+++ b/kvm/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ set(NFS_WRAPPER ${CMAKE_SOURCE_DIR}/kvm/kvm_nfs_test_wrapper.sh)
 set(SMB_WRAPPER ${CMAKE_SOURCE_DIR}/kvm/kvm_smb_test_wrapper.sh)
 set(PNFS_WRAPPER ${CMAKE_SOURCE_DIR}/kvm/kvm_pnfs_test_wrapper.sh)
 set(PNFS_BLOCK_WRAPPER ${CMAKE_SOURCE_DIR}/kvm/kvm_pnfs_block_test_wrapper.sh)
+set(PNFS_SCSI_WRAPPER ${CMAKE_SOURCE_DIR}/kvm/kvm_pnfs_scsi_test_wrapper.sh)
 
 set(KVM_BACKENDS memfs linux)
 
@@ -69,6 +70,32 @@ set(PNFS_BLOCK_WL_remove "mkdir -p /mnt/test && dd if=/dev/urandom of=/mnt/test/
 # (MDS recalls + defers), then verify the surviving 4 MiB is intact -- exercises
 # the truncate path freeing remote extents past EOF + the recall machinery.
 set(PNFS_BLOCK_WL_recall_truncate "mkdir -p /mnt/test && dd if=/dev/urandom of=/tmp/orig bs=1M count=8 2>/dev/null && cp /tmp/orig /mnt/test/f0 && sync && grep -qi LAYOUTGET /proc/self/mountstats && truncate -s 4194304 /mnt/test/f0 && (echo 3 > /proc/sys/vm/drop_caches 2>/dev/null || true) && head -c 4194304 /tmp/orig > /tmp/orig4 && cmp /tmp/orig4 /mnt/test/f0")
+
+# pNFS SCSI layout (RFC 8154): diskfs-only.  Same remote-data path as block, but
+# the client matches the LU strictly by its SCSI VPD-0x83 hardware designator (a
+# NAA WWN) -- nothing is written to the data disk.  See
+# kvm_pnfs_scsi_test_wrapper.sh; the data disk is virtio-SCSI with a WWN.
+set(PNFS_SCSI_BACKENDS)
+if(IO_URING_ENABLED)
+    list(APPEND PNFS_SCSI_BACKENDS diskfs_io_uring)
+endif()
+if(HAVE_LIBAIO)
+    list(APPEND PNFS_SCSI_BACKENDS diskfs_aio)
+endif()
+
+# Linux SCSI-layout client bring-up.  Unlike block, SCSI layout resolves devices
+# in-kernel by VPD-0x83 designator (no blkmapd upcall, no rpc_pipefs); the same
+# blocklayoutdriver module registers the SCSI layout type.  As with block, the
+# MDS rejects inline data I/O, so a drop-caches re-read that still matches proves
+# the SCSI layout drove the I/O directly to the LU.
+set(PNFS_SCSI_SETUP "modprobe blocklayoutdriver && mount -t nfs -o vers=4.1,tcp 10.0.0.1:/share /mnt")
+
+# Reuse the block workloads verbatim (the layout type differs, the data path
+# does not).
+set(PNFS_SCSI_PROGRAMS rw remove recall_truncate)
+set(PNFS_SCSI_WL_rw "${PNFS_BLOCK_WL_rw}")
+set(PNFS_SCSI_WL_remove "${PNFS_BLOCK_WL_remove}")
+set(PNFS_SCSI_WL_recall_truncate "${PNFS_BLOCK_WL_recall_truncate}")
 
 set(NFS_VERSIONS 3 4.0 4.1 4.2)
 
@@ -211,6 +238,36 @@ foreach(image_spec ${KVM_IMAGES})
                         "${PNFS_BLOCK_SETUP} && ${PNFS_BLOCK_WL_${prog}}")
             set_tests_properties(chimera/kvm/${IMAGE_NAME}/pnfs/block_${prog}_${pbackend}_nfs4.1
                 PROPERTIES LABELS "kvm;${IMAGE_NAME};pnfs" PROCESSORS 2)
+        endforeach()
+    endforeach()
+
+    # pNFS SCSI layout (RFC 8154): diskfs sources SCSI layouts; the client does
+    # data I/O directly to a virtio-SCSI LU it matches by WWN (VPD-0x83), never
+    # through the MDS (which can't reach it).  Nothing is written to the disk to
+    # identify it.
+    #
+    # DISABLED in this harness, by design.  Bring-up confirmed the server side
+    # works end-to-end: the Linux client parses our GETDEVICEINFO SCSI device
+    # address, matches /dev/sda by its NAA WWN ("pNFS: using block device sda"),
+    # and proceeds to LAYOUTGET.  But the Linux SCSI layout client then issues a
+    # *mandatory* SCSI PERSISTENT RESERVE OUT (REGISTER) to the LU, and qemu's
+    # emulated scsi-hd does not implement persistent reservations ("Invalid
+    # command operation code" -> "failed to register key" -> a kernel Oops in
+    # the failed-registration cleanup path).  qemu-pr-helper only forwards PR to
+    # a *real* host SCSI device, so a file-backed emulated disk cannot satisfy
+    # this; a PR-capable target (LIO/tcmu or real SAS/FC/iSCSI/NVMe-PR LU) is
+    # required.  The wrapper is kept runnable for manual use against such a
+    # target; see kvm_pnfs_scsi_test_wrapper.sh.
+    foreach(prog ${PNFS_SCSI_PROGRAMS})
+        foreach(pbackend ${PNFS_SCSI_BACKENDS})
+            add_test(NAME chimera/kvm/${IMAGE_NAME}/pnfs/scsi_${prog}_${pbackend}_nfs4.1
+                COMMAND bash ${PNFS_SCSI_WRAPPER}
+                        ${IMAGE_DIR}/vmlinuz ${IMAGE_DIR}/rootfs.qcow2
+                        ${CHIMERA_BINARY} ${pbackend}
+                        "${PNFS_SCSI_SETUP} && ${PNFS_SCSI_WL_${prog}}")
+            set_tests_properties(chimera/kvm/${IMAGE_NAME}/pnfs/scsi_${prog}_${pbackend}_nfs4.1
+                PROPERTIES LABELS "kvm;${IMAGE_NAME};pnfs" PROCESSORS 2
+                           DISABLED TRUE)
         endforeach()
     endforeach()
 

--- a/src/server/nfs/nfs4_attr.h
+++ b/src/server/nfs/nfs4_attr.h
@@ -35,7 +35,8 @@
  * The single pNFS layouttype4 this file's backend supports, for FATTR4
  * advertisement: LAYOUT4_FLEX_FILES (0x4) for an orchestrated backend
  * (CHIMERA_VFS_CAP_LAYOUT) or a flex-sourcing backend, LAYOUT4_BLOCK_VOLUME
- * (0x3) for a block-sourcing backend, or 0 when pNFS is off/unsupported.
+ * (0x3) for a block-sourcing backend, LAYOUT4_SCSI (0x5) for a SCSI-sourcing
+ * backend, or 0 when pNFS is off/unsupported.
  */
 static inline uint32_t
 chimera_nfs4_pnfs_layout_type(
@@ -53,6 +54,9 @@ chimera_nfs4_pnfs_layout_type(
     caps = chimera_vfs_module_capabilities(vfs_thread, fh, fhlen);
 
     if (caps & CHIMERA_VFS_CAP_LAYOUT_SOURCE) {
+        if (caps & CHIMERA_VFS_CAP_LAYOUT_CLASS_SCSI) {
+            return 0x5;
+        }
         return (caps & CHIMERA_VFS_CAP_LAYOUT_CLASS_BLOCK) ? 0x3 : 0x4;
     }
     if (caps & CHIMERA_VFS_CAP_LAYOUT) {
@@ -362,10 +366,10 @@ chimera_nfs4_marshall_attrs(
                     word2 |= (1 << (FATTR4_LAYOUT_TYPES - 64));
                 }
 
-                /* The block layout (RFC 5663) requires the server to advertise
-                 * the layout block size + alignment, or the client's block
-                 * layout driver refuses to initialize. */
-                if (pnfs_layout_type == 0x3) {
+                /* The block (RFC 5663) and SCSI (RFC 8154) layouts require the
+                 * server to advertise the layout block size + alignment, or the
+                 * client's layout driver refuses to initialize. */
+                if (pnfs_layout_type == 0x3 || pnfs_layout_type == 0x5) {
                     word2 |= (1 << (FATTR4_LAYOUT_BLKSIZE - 64)) |
                         (1 << (FATTR4_LAYOUT_ALIGNMENT - 64));
                 }
@@ -695,16 +699,17 @@ chimera_nfs4_marshall_attrs(
             chimera_nfs4_attr_append_uint32(&attrs, pnfs_layout_type); /* per-backend */
         }
 
-        /* Block layout (RFC 5663) block size + alignment (attrs 65, 66).  The
-         * client's block layout driver requires a non-zero blksize <= PAGE_SIZE
-         * to initialize.  We allocate and align block extents to 4 KiB. */
-        if (pnfs_layout_type == 0x3 &&
+        /* Block (RFC 5663) and SCSI (RFC 8154) layout block size + alignment
+         * (attrs 65, 66).  The client's layout driver requires a non-zero
+         * blksize <= PAGE_SIZE to initialize.  We allocate and align extents to
+         * 4 KiB. */
+        if ((pnfs_layout_type == 0x3 || pnfs_layout_type == 0x5) &&
             (req_mask[2] & (1 << (FATTR4_LAYOUT_BLKSIZE - 64)))) {
             rsp_mask[2]  |= (1 << (FATTR4_LAYOUT_BLKSIZE - 64));
             *num_rsp_mask = 3;
             chimera_nfs4_attr_append_uint32(&attrs, 4096);
         }
-        if (pnfs_layout_type == 0x3 &&
+        if ((pnfs_layout_type == 0x3 || pnfs_layout_type == 0x5) &&
             (req_mask[2] & (1 << (FATTR4_LAYOUT_ALIGNMENT - 64)))) {
             rsp_mask[2]  |= (1 << (FATTR4_LAYOUT_ALIGNMENT - 64));
             *num_rsp_mask = 3;

--- a/src/server/nfs/nfs4_pnfs.c
+++ b/src/server/nfs/nfs4_pnfs.c
@@ -27,9 +27,20 @@
 #define NFS4_PNFS_STRIPE_UNIT    1048576U /* 1 MiB                              */
 #define LAYOUT4_FLEX_FILES       0x4     /* RFC 8435; not in the generated XDR */
 #define LAYOUT4_BLOCK_VOLUME     0x3     /* RFC 5663; not in the generated XDR */
+#define LAYOUT4_SCSI             0x5     /* RFC 8154; not in the generated XDR */
 
 /* RFC 5663 §2.2.1 pnfs_block_volume_type4 */
 #define PNFS_BLOCK_VOLUME_SIMPLE 0
+
+/* RFC 8154 §2.4.1 pnfs_scsi_volume_type4 (SLICE=1, CONCAT=2, STRIPE=3, BASE=4) */
+#define PNFS_SCSI_VOLUME_BASE    4
+
+/* RFC 8154 §2.2 pnfs_scsi_code_set4 / pnfs_scsi_designator_type4 */
+#define PS_CODE_SET_BINARY       1
+#define PS_CODE_SET_ASCII        2
+#define PS_DESIGNATOR_T10        1
+#define PS_DESIGNATOR_EUI64      2
+#define PS_DESIGNATOR_NAA        3
 
 /* --- minimal XDR append helpers (network byte order) --------------------- */
 
@@ -102,6 +113,10 @@ static uint32_t
 chimera_nfs4_encode_block_device_addr(
     uint8_t                                *buf,
     const struct chimera_vfs_layout_device *dev);
+static uint32_t
+chimera_nfs4_encode_scsi_device_addr(
+    uint8_t                                *buf,
+    const struct chimera_vfs_layout_device *dev);
 static int
 nfs_pnfs_devcache_find(
     struct nfs_pnfs_devcache         *cache,
@@ -139,19 +154,37 @@ chimera_nfs4_getdeviceinfo(
     } else if (nfs_pnfs_devcache_find(&thread->shared->nfs4_pnfs_devcache,
                                       args->gdia_device_id, &dev)) {
         /* Backend-sourced: device came from a get_layout response. */
-        out_type = (dev.layout_class == CHIMERA_VFS_LAYOUT_CLASS_BLOCK)
-                   ? LAYOUT4_BLOCK_VOLUME : LAYOUT4_FLEX_FILES;
+        switch (dev.layout_class) {
+            case CHIMERA_VFS_LAYOUT_CLASS_BLOCK:
+                out_type = LAYOUT4_BLOCK_VOLUME;
+                break;
+            case CHIMERA_VFS_LAYOUT_CLASS_SCSI:
+                out_type = LAYOUT4_SCSI;
+                break;
+            default:
+                out_type = LAYOUT4_FLEX_FILES;
+                break;
+        } /* switch */
         if (args->gdia_layout_type != out_type) {
             res->gdir_status = NFS4ERR_UNKNOWN_LAYOUTTYPE;
             chimera_nfs4_compound_complete(req, res->gdir_status);
             return;
         }
-        body_len = (out_type == LAYOUT4_BLOCK_VOLUME)
-                   ? chimera_nfs4_encode_block_device_addr(body, &dev)
-                   : chimera_nfs4_encode_ff_device_addr(body, dev.netid, dev.uaddr);
+        switch (out_type) {
+            case LAYOUT4_BLOCK_VOLUME:
+                body_len = chimera_nfs4_encode_block_device_addr(body, &dev);
+                break;
+            case LAYOUT4_SCSI:
+                body_len = chimera_nfs4_encode_scsi_device_addr(body, &dev);
+                break;
+            default:
+                body_len = chimera_nfs4_encode_ff_device_addr(body, dev.netid, dev.uaddr);
+                break;
+        } /* switch */
     } else {
         res->gdir_status = (args->gdia_layout_type != LAYOUT4_FLEX_FILES &&
-                            args->gdia_layout_type != LAYOUT4_BLOCK_VOLUME)
+                            args->gdia_layout_type != LAYOUT4_BLOCK_VOLUME &&
+                            args->gdia_layout_type != LAYOUT4_SCSI)
                            ? NFS4ERR_UNKNOWN_LAYOUTTYPE : NFS4ERR_INVAL;
         chimera_nfs4_compound_complete(req, res->gdir_status);
         return;
@@ -286,6 +319,61 @@ chimera_nfs4_encode_block_device_addr(
 
     return (uint8_t *) p - buf;
 } /* chimera_nfs4_encode_block_device_addr */
+
+/*
+ * Encode a pnfs_scsi_layout4 (RFC 8154 §2.4.3) into buf for the
+ * layout_content4.loc_body opaque: sl_extents<>, one pnfs_scsi_extent4 per
+ * backend-supplied segment.  The SCSI extent is wire-identical to the block
+ * extent (deviceid, file offset/length, storage offset, state) so this mirrors
+ * chimera_nfs4_encode_block_layout exactly.
+ */
+static uint32_t
+chimera_nfs4_encode_scsi_layout(
+    uint8_t                                 *buf,
+    const struct chimera_vfs_layout_segment *segs,
+    uint32_t                                 nseg)
+{
+    void    *p = buf;
+    uint32_t i;
+
+    pnfs_put_u32(&p, nseg);                           /* sl_extents<> count    */
+
+    for (i = 0; i < nseg; i++) {
+        memcpy(p, segs[i].deviceid, NFS4_DEVICEID4_SIZE); /* se_vol_id         */
+        p += NFS4_DEVICEID4_SIZE;
+        pnfs_put_u64(&p, segs[i].offset);             /* se_file_offset        */
+        pnfs_put_u64(&p, segs[i].length);             /* se_length             */
+        pnfs_put_u64(&p, segs[i].blk_vol_offset);     /* se_storage_offset     */
+        pnfs_put_u32(&p, segs[i].blk_state);          /* se_state              */
+    }
+
+    return (uint8_t *) p - buf;
+} /* chimera_nfs4_encode_scsi_layout */
+
+/*
+ * Encode a pnfs_scsi_deviceaddr4 (RFC 8154 §2.4.1) into buf for the
+ * device_addr4.da_addr_body opaque: sda_volumes<> describing the volume
+ * topology.  v1: a single PNFS_SCSI_VOLUME_BASE volume identified by its SCSI
+ * VPD-0x83 designator (a hardware id; nothing is written to the disk) plus the
+ * persistent-reservation key the client registers with.
+ */
+static uint32_t
+chimera_nfs4_encode_scsi_device_addr(
+    uint8_t                                *buf,
+    const struct chimera_vfs_layout_device *dev)
+{
+    void *p = buf;
+
+    pnfs_put_u32(&p, 1);                              /* sda_volumes<> count   */
+    pnfs_put_u32(&p, PNFS_SCSI_VOLUME_BASE);          /* pnfs_scsi_volume4 type*/
+    /* pnfs_scsi_base_volume_info4: designator (inlined) + reservation key. */
+    pnfs_put_u32(&p, dev->scsi_code_set);             /* sbv_code_set          */
+    pnfs_put_u32(&p, dev->scsi_desig_type);           /* sbv_designator_type   */
+    pnfs_put_opaque(&p, dev->scsi_desig, dev->scsi_desig_len); /* sbv_designator<> */
+    pnfs_put_u64(&p, dev->scsi_pr_key);               /* sbv_pr_key            */
+
+    return (uint8_t *) p - buf;
+} /* chimera_nfs4_encode_scsi_device_addr */
 
 /* --- sourced-layout device cache (deviceid -> descriptor) ---------------- */
 
@@ -636,8 +724,17 @@ lg_sourced_cb(
         return;
     }
 
-    loc_type = (layout_class == CHIMERA_VFS_LAYOUT_CLASS_BLOCK)
-               ? LAYOUT4_BLOCK_VOLUME : LAYOUT4_FLEX_FILES;
+    switch (layout_class) {
+        case CHIMERA_VFS_LAYOUT_CLASS_BLOCK:
+            loc_type = LAYOUT4_BLOCK_VOLUME;
+            break;
+        case CHIMERA_VFS_LAYOUT_CLASS_SCSI:
+            loc_type = LAYOUT4_SCSI;
+            break;
+        default:
+            loc_type = LAYOUT4_FLEX_FILES;
+            break;
+    } /* switch */
     if (loc_type != args->loga_layout_type) {
         ff_lg_fail(ctx, NFS4ERR_UNKNOWN_LAYOUTTYPE);
         return;
@@ -664,26 +761,31 @@ lg_sourced_cb(
      * this layout; CB_LAYOUTRECALL rides the shared delegation channel. */
     nfs4_cb_ensure_probe(req->thread, client, req);
 
-    if (loc_type == LAYOUT4_BLOCK_VOLUME) {
+    if (loc_type == LAYOUT4_BLOCK_VOLUME || loc_type == LAYOUT4_SCSI) {
         uint8_t        *body = xdr_dbuf_alloc_space(1024, req->encoding->dbuf);
         struct layout4 *lo   = xdr_dbuf_alloc_space(sizeof(*lo), req->encoding->dbuf);
         uint32_t        body_len;
         int             rc;
 
         chimera_nfs_abort_if(body == NULL || lo == NULL, "Failed to allocate space");
-        body_len = chimera_nfs4_encode_block_layout(body, segments, num_segments);
+
+        /* The SCSI extent (RFC 8154) is wire-identical to the block extent
+        * (RFC 5663); only the layout type and device descriptor differ. */
+        body_len = (loc_type == LAYOUT4_SCSI)
+                   ? chimera_nfs4_encode_scsi_layout(body, segments, num_segments)
+                   : chimera_nfs4_encode_block_layout(body, segments, num_segments);
 
         /* Cover exactly the contiguous span the extents describe (from the
-         * requested offset to the end of the last segment); a block client
+         * requested offset to the end of the last segment); a block/SCSI client
          * rejects a layout whose lo_length doesn't match its extents. */
-        uint64_t        blk_end = segments[num_segments - 1].offset +
+        uint64_t blk_end = segments[num_segments - 1].offset +
             segments[num_segments - 1].length;
 
         lo->lo_offset = args->loga_offset;
         lo->lo_length = blk_end > args->loga_offset ?
             blk_end - args->loga_offset : 0;
         lo->lo_iomode           = args->loga_iomode;
-        lo->lo_content.loc_type = LAYOUT4_BLOCK_VOLUME;
+        lo->lo_content.loc_type = loc_type;
         rc                      = xdr_dbuf_opaque_copy(&lo->lo_content.loc_body, body,
                                                        body_len, req->encoding->dbuf);
         chimera_nfs_abort_if(rc, "Failed to copy layout body");
@@ -754,7 +856,10 @@ ff_lg_open_cb(
          * client's requested type must match it. */
         uint32_t want_class, ok_type;
 
-        if (caps & CHIMERA_VFS_CAP_LAYOUT_CLASS_BLOCK) {
+        if (caps & CHIMERA_VFS_CAP_LAYOUT_CLASS_SCSI) {
+            want_class = CHIMERA_VFS_LAYOUT_CLASS_SCSI;
+            ok_type    = LAYOUT4_SCSI;
+        } else if (caps & CHIMERA_VFS_CAP_LAYOUT_CLASS_BLOCK) {
             want_class = CHIMERA_VFS_LAYOUT_CLASS_BLOCK;
             ok_type    = LAYOUT4_BLOCK_VOLUME;
         } else {
@@ -812,7 +917,8 @@ chimera_nfs4_layoutget(
      * for this file depends on its backend (validated in ff_lg_open_cb once the
      * backend's capabilities are known). */
     if (args->loga_layout_type != LAYOUT4_FLEX_FILES &&
-        args->loga_layout_type != LAYOUT4_BLOCK_VOLUME) {
+        args->loga_layout_type != LAYOUT4_BLOCK_VOLUME &&
+        args->loga_layout_type != LAYOUT4_SCSI) {
         res->logr_status = NFS4ERR_UNKNOWN_LAYOUTTYPE;
         chimera_nfs4_compound_complete(req, res->logr_status);
         return;
@@ -852,7 +958,8 @@ chimera_nfs4_layoutreturn(
     }
 
     if (args->lora_layout_type != LAYOUT4_FLEX_FILES &&
-        args->lora_layout_type != LAYOUT4_BLOCK_VOLUME) {
+        args->lora_layout_type != LAYOUT4_BLOCK_VOLUME &&
+        args->lora_layout_type != LAYOUT4_SCSI) {
         res->lorr_status = NFS4ERR_UNKNOWN_LAYOUTTYPE;
         chimera_nfs4_compound_complete(req, res->lorr_status);
         return;

--- a/src/vfs/diskfs/diskfs.c
+++ b/src/vfs/diskfs/diskfs.c
@@ -192,6 +192,15 @@ struct diskfs_device {
     uint64_t                  sig_offset;
     uint32_t                  sig_len;
     uint8_t                   sig[SM_SIG_MAX];
+
+    /* SCSI-layout (RFC 8154) hardware identity: the LU's VPD-0x83 designator a
+     * pNFS-SCSI client matches against (nothing written to the data disk).
+     * Used when the share is in scsi_layout mode instead of sig_*. */
+    uint32_t                  scsi_code_set;     /* 1=binary, 2=ascii */
+    uint32_t                  scsi_desig_type;   /* 1=T10, 2=EUI64, 3=NAA */
+    uint32_t                  scsi_desig_len;
+    uint8_t                   scsi_desig[32];
+    uint64_t                  scsi_pr_key;
 };
 
 struct diskfs_dirent {
@@ -749,6 +758,7 @@ struct diskfs_shared {
     uint32_t                   block_cache_blocks; /* total resident block-buffer cap (0 = default) */
     uint32_t                   inode_cache_inodes; /* total resident inode cap (0 = default) */
     int                        block_layout;       /* config opt-in: advertise pNFS block layouts */
+    int                        scsi_layout;        /* config opt-in: advertise pNFS SCSI layouts  */
     uint64_t                   fsid;
     struct space_map          *space_map;
     struct diskfs_intent_log   intent_log;
@@ -7182,7 +7192,8 @@ diskfs_init(const char *cfgdata)
          * deviceid and SIMPLE-volume signature come from config; its AG logs are
          * relocated onto the local metadata device by the allocator. */
         if (role_name && strcmp(role_name, "remote") == 0) {
-            json_t *sig_cfg = json_object_get(device_cfg, "signature");
+            json_t *sig_cfg  = json_object_get(device_cfg, "signature");
+            json_t *scsi_cfg = json_object_get(device_cfg, "scsi");
 
             chimera_diskfs_abort_if(i == 0, "device 0 must be a local metadata device");
 
@@ -7196,16 +7207,40 @@ diskfs_init(const char *cfgdata)
 
             diskfs_parse_hex(json_string_value(json_object_get(device_cfg, "deviceid")),
                              device->deviceid, SM_DEVICEID_SIZE);
+            /* A remote device carries either a SIMPLE-volume content signature
+             * (block layout, RFC 5663) or a SCSI VPD-0x83 designator (SCSI
+             * layout, RFC 8154); the share-level mode flag selects which. */
             if (json_is_object(sig_cfg)) {
                 device->sig_offset = json_integer_value(json_object_get(sig_cfg, "offset"));
                 device->sig_len    = diskfs_parse_hex(
                     json_string_value(json_object_get(sig_cfg, "bytes")),
                     device->sig, SM_SIG_MAX);
             }
+            if (json_is_object(scsi_cfg)) {
+                const char *dtype = json_string_value(
+                    json_object_get(scsi_cfg, "designator_type"));
+                const char *cset = json_string_value(
+                    json_object_get(scsi_cfg, "code_set"));
 
-            chimera_diskfs_info("Remote data device %s size %lu sig_off %lu sig_len %u",
-                                device->name, device->size, device->sig_offset,
-                                device->sig_len);
+                /* Default binary NAA -- the common SAS/FC/iSCSI WWID form. */
+                device->scsi_desig_type = 3; /* NAA */
+                if (dtype && strcmp(dtype, "eui64") == 0) {
+                    device->scsi_desig_type = 2;
+                } else if (dtype && strcmp(dtype, "t10") == 0) {
+                    device->scsi_desig_type = 1;
+                }
+                device->scsi_code_set  = (cset && strcmp(cset, "ascii") == 0) ? 2 : 1;
+                device->scsi_desig_len = diskfs_parse_hex(
+                    json_string_value(json_object_get(scsi_cfg, "id")),
+                    device->scsi_desig, sizeof(device->scsi_desig));
+                device->scsi_pr_key = json_integer_value(
+                    json_object_get(scsi_cfg, "pr_key"));
+            }
+
+            chimera_diskfs_info(
+                "Remote data device %s size %lu sig_len %u scsi_desig_len %u",
+                device->name, device->size, device->sig_len,
+                device->scsi_desig_len);
             continue;
         }
 
@@ -7262,21 +7297,29 @@ diskfs_init(const char *cfgdata)
      * efficiently. */
     initialize           = json_object_get(cfg, "initialize") != NULL;
     shared->unsafe_async = json_is_true(json_object_get(cfg, "unsafe_async"));
-    /* Opt-in pNFS block layout mode: diskfs sources RFC 5663 block layouts and
-     * keeps file data on remote (data-only) devices. */
+    /* Opt-in pNFS block / SCSI layout mode: diskfs sources RFC 5663 block or
+     * RFC 8154 SCSI layouts and keeps file data on remote (data-only) devices.
+     * Both share the same remote-device data path and allocator; they differ
+     * only in how the client identifies the disk (content signature vs. SCSI
+     * hardware designator) and the encoded layout type. */
     shared->block_layout       = json_is_true(json_object_get(cfg, "block_layout"));
+    shared->scsi_layout        = json_is_true(json_object_get(cfg, "scsi_layout"));
     shared->block_cache_blocks = (uint32_t) json_integer_value(
         json_object_get(cfg, "block_cache_blocks"));
 
-    /* Block mode and orchestrated flex-files are mutually exclusive per module
-     * (the NFS server routes on CAP_LAYOUT_SOURCE before CAP_LAYOUT).  A diskfs
-     * module is loaded once per daemon with one config, so switch the module's
-     * advertised layout capability here: block mode SOURCEs block layouts,
-     * otherwise we persist the orchestrated flex blob (default). */
-    if (shared->block_layout) {
+    chimera_diskfs_abort_if(shared->block_layout && shared->scsi_layout,
+                            "block_layout and scsi_layout are mutually exclusive");
+
+    /* Layout-sourcing mode and orchestrated flex-files are mutually exclusive
+     * per module (the NFS server routes on CAP_LAYOUT_SOURCE before CAP_LAYOUT).
+     * A diskfs module is loaded once per daemon with one config, so switch the
+     * module's advertised layout capability here: a sourcing mode SOURCEs block
+     * or SCSI layouts, otherwise we persist the orchestrated flex blob. */
+    if (shared->block_layout || shared->scsi_layout) {
         vfs_diskfs.capabilities &= ~(uint64_t) CHIMERA_VFS_CAP_LAYOUT;
         vfs_diskfs.capabilities |= CHIMERA_VFS_CAP_LAYOUT_SOURCE |
-            CHIMERA_VFS_CAP_LAYOUT_CLASS_BLOCK;
+            (shared->scsi_layout ? CHIMERA_VFS_CAP_LAYOUT_CLASS_SCSI
+                                 : CHIMERA_VFS_CAP_LAYOUT_CLASS_BLOCK);
     }
     shared->inode_cache_inodes = (uint32_t) json_integer_value(
         json_object_get(cfg, "inode_cache_inodes"));
@@ -10230,11 +10273,11 @@ diskfs_read(
 
     (void) private_data;
 
-    /* Block-mode shares keep all file data on remote (pNFS) devices the server
-     * can't touch, so inline reads are impossible -- the client must use a
-     * block layout.  Reject so a non-pNFS read doesn't dereference a NULL
-     * device queue. */
-    if (unlikely(shared->block_layout)) {
+    /* Block/SCSI-mode shares keep all file data on remote (pNFS) devices the
+     * server can't touch, so inline reads are impossible -- the client must use
+     * a layout.  Reject so a non-pNFS read doesn't dereference a NULL device
+     * queue. */
+    if (unlikely(shared->block_layout || shared->scsi_layout)) {
         request->status = CHIMERA_VFS_EINVAL;
         request->complete(request);
         return;
@@ -11050,10 +11093,10 @@ diskfs_write(
 
     (void) private_data;
 
-    /* Block-mode data lives on remote (pNFS) devices: writes go directly from
-     * the client to the volume via an RW layout, never inline through the
+    /* Block/SCSI-mode data lives on remote (pNFS) devices: writes go directly
+     * from the client to the volume via an RW layout, never inline through the
      * server (which has no handle for those devices). */
-    if (unlikely(shared->block_layout)) {
+    if (unlikely(shared->block_layout || shared->scsi_layout)) {
         request->status = CHIMERA_VFS_EINVAL;
         request->complete(request);
         return;
@@ -13074,11 +13117,26 @@ diskfs_layout_add_device(
     ld = &request->get_layout.r_devices[request->get_layout.r_num_devices++];
     memset(ld, 0, sizeof(*ld));
     memcpy(ld->deviceid, dev->deviceid, SM_DEVICEID_SIZE);
-    ld->layout_class   = CHIMERA_VFS_LAYOUT_CLASS_BLOCK;
-    ld->blk_vol_size   = dev->size;
-    ld->blk_sig_offset = dev->sig_offset;
-    ld->blk_sig_len    = dev->sig_len;
-    memcpy(ld->blk_sig, dev->sig, dev->sig_len);
+
+    if (shared->scsi_layout) {
+        /* SCSI layout (RFC 8154): the client matches the LU by its VPD-0x83
+         * hardware designator; nothing is written to the disk. */
+        ld->layout_class    = CHIMERA_VFS_LAYOUT_CLASS_SCSI;
+        ld->blk_vol_size    = dev->size;
+        ld->scsi_code_set   = dev->scsi_code_set;
+        ld->scsi_desig_type = dev->scsi_desig_type;
+        ld->scsi_desig_len  = dev->scsi_desig_len;
+        memcpy(ld->scsi_desig, dev->scsi_desig, dev->scsi_desig_len);
+        ld->scsi_pr_key = dev->scsi_pr_key;
+    } else {
+        /* Block layout (RFC 5663): the client matches the disk by a content
+         * signature read at a fixed offset. */
+        ld->layout_class   = CHIMERA_VFS_LAYOUT_CLASS_BLOCK;
+        ld->blk_vol_size   = dev->size;
+        ld->blk_sig_offset = dev->sig_offset;
+        ld->blk_sig_len    = dev->sig_len;
+        memcpy(ld->blk_sig, dev->sig, dev->sig_len);
+    }
 } /* diskfs_layout_add_device */
 
 /* Append one block segment [file_off, file_off+len) -> (device_id, vol_off). */
@@ -13110,7 +13168,8 @@ diskfs_get_layout_finish(struct chimera_vfs_request *request)
 {
     struct diskfs_request_private *p = request->plugin_data;
 
-    request->get_layout.r_layout_class = CHIMERA_VFS_LAYOUT_CLASS_BLOCK;
+    request->get_layout.r_layout_class = p->thread->shared->scsi_layout
+        ? CHIMERA_VFS_LAYOUT_CLASS_SCSI : CHIMERA_VFS_LAYOUT_CLASS_BLOCK;
     /* Commits the txn (durably persisting any new extent records) before the
      * layout is handed back; a pure-READ layout has nothing journaled. */
     diskfs_op_ok(request, p->txn);
@@ -13342,7 +13401,8 @@ diskfs_get_layout_inode_cb(
     p->loop_off       = off;
     p->loop_pos       = end;
 
-    request->get_layout.r_layout_class = CHIMERA_VFS_LAYOUT_CLASS_BLOCK;
+    request->get_layout.r_layout_class = shared->scsi_layout
+        ? CHIMERA_VFS_LAYOUT_CLASS_SCSI : CHIMERA_VFS_LAYOUT_CLASS_BLOCK;
     request->get_layout.r_num_segments = 0;
     request->get_layout.r_num_devices  = 0;
 
@@ -13351,7 +13411,6 @@ diskfs_get_layout_inode_cb(
         return;
     }
 
-    (void) shared;
     op = diskfs_bt_op_alloc(thread);
     if (diskfs_ext_floor_async(op, thread, inode, off, p->rec_scratch,
                                sizeof(p->rec_scratch), diskfs_get_layout_first_cb,
@@ -13372,7 +13431,7 @@ diskfs_get_layout(
 
     (void) private_data;
 
-    if (unlikely(!shared->block_layout)) {
+    if (unlikely(!shared->block_layout && !shared->scsi_layout)) {
         request->status = CHIMERA_VFS_ENOTSUP;
         request->complete(request);
         return;

--- a/src/vfs/diskfs/space_map.c
+++ b/src/vfs/diskfs/space_map.c
@@ -155,8 +155,14 @@ space_map_active_log_blocks(
             delta_off = slot_base + (delta_byte & ~((uint64_t) SM_BLOCK_SIZE - 1));
             in_block  = (uint32_t) (delta_byte & (SM_BLOCK_SIZE - 1));
 
+            /* The log physically lives on log_device_id (== device_id for a
+             * local AG, but the local metadata device for a block-mode remote
+             * AG whose log is relocated); slot_base/delta_off are offsets on
+             * that device, and the journal claims these blocks under it, so the
+             * warm read and cache key must use log_device_id -- using device_id
+             * would read a queue-less remote device and crash. */
             if (count < max_blocks) {
-                blocks[count].device_id     = ag->device_id;
+                blocks[count].device_id     = ag->log_device_id;
                 blocks[count].device_offset = slot_base;
                 count++;
             }
@@ -165,7 +171,7 @@ space_map_active_log_blocks(
              * claim will create a fresh zeroed block and will not read disk.
              * Only warm the current delta block when it already exists. */
             if (in_block != 0 && delta_off != slot_base && count < max_blocks) {
-                blocks[count].device_id     = ag->device_id;
+                blocks[count].device_id     = ag->log_device_id;
                 blocks[count].device_offset = delta_off;
                 count++;
             }

--- a/src/vfs/vfs.h
+++ b/src/vfs/vfs.h
@@ -1031,6 +1031,7 @@ struct chimera_vfs_handle_state {
 #define CHIMERA_VFS_CAP_LAYOUT_SOURCE      (1U << 15)
 #define CHIMERA_VFS_CAP_LAYOUT_CLASS_FLEX  (1U << 16) /* produces flex-files (RFC 8435)  */
 #define CHIMERA_VFS_CAP_LAYOUT_CLASS_BLOCK (1U << 17) /* produces block volume (RFC 5663)*/
+#define CHIMERA_VFS_CAP_LAYOUT_CLASS_SCSI  (1U << 19) /* produces SCSI volume (RFC 8154) */
 
 struct chimera_vfs_module {
     /* Required

--- a/src/vfs/vfs_pnfs.h
+++ b/src/vfs/vfs_pnfs.h
@@ -27,10 +27,10 @@
  * DS export directory under which the MDS creates backing files.
  */
 
-#define CHIMERA_PNFS_MAX_DS               8
-#define CHIMERA_VFS_DEVICEID_SIZE         16 /* == NFS4_DEVICEID4_SIZE */
-#define CHIMERA_VFS_MOUNTID_SIZE          16 /* == CHIMERA_VFS_MOUNT_ID_SIZE */
-#define CHIMERA_PNFS_BACKING_MAX          256
+#define CHIMERA_PNFS_MAX_DS             8
+#define CHIMERA_VFS_DEVICEID_SIZE       16   /* == NFS4_DEVICEID4_SIZE */
+#define CHIMERA_VFS_MOUNTID_SIZE        16   /* == CHIMERA_VFS_MOUNT_ID_SIZE */
+#define CHIMERA_PNFS_BACKING_MAX        256
 
 struct chimera_vfs;
 
@@ -44,12 +44,13 @@ struct chimera_vfs;
  * fields (a volume-relative extent); which are meaningful is set by the layout
  * class.
  */
-#define CHIMERA_VFS_LAYOUT_MAX_SEGMENTS   8
-#define CHIMERA_VFS_LAYOUT_MAX_DEVICES    4
+#define CHIMERA_VFS_LAYOUT_MAX_SEGMENTS 8
+#define CHIMERA_VFS_LAYOUT_MAX_DEVICES  4
 
 enum chimera_vfs_layout_class {
     CHIMERA_VFS_LAYOUT_CLASS_FLEX  = 1,   /* flex-files (RFC 8435)   */
     CHIMERA_VFS_LAYOUT_CLASS_BLOCK = 2,   /* block volume (RFC 5663) */
+    CHIMERA_VFS_LAYOUT_CLASS_SCSI  = 3,   /* SCSI volume (RFC 8154)  */
 };
 
 /* Block-extent state, numerically the RFC 5663 pnfs_block_extent_state4. */
@@ -88,6 +89,16 @@ struct chimera_vfs_layout_device {
     uint64_t blk_sig_offset;
     uint32_t blk_sig_len;
     uint8_t  blk_sig[64];
+
+    /* SCSI (RFC 8154): a single BASE volume the client matches to a local LU
+     * by its SCSI VPD-0x83 designator (a hardware identifier; nothing is
+     * written to the disk).  scsi_pr_key is the persistent-reservation key the
+     * client registers with -- the server does not issue reservations in v1. */
+    uint32_t scsi_code_set;                /* PS_CODE_SET_BINARY=1 / _ASCII=2         */
+    uint32_t scsi_desig_type;              /* PS_DESIGNATOR_T10=1 / _EUI64=2 / _NAA=3 */
+    uint32_t scsi_desig_len;
+    uint8_t  scsi_desig[32];
+    uint64_t scsi_pr_key;
 };
 
 struct chimera_vfs_ds {


### PR DESCRIPTION
Adds the pNFS **SCSI layout (RFC 8154, `LAYOUT4_SCSI`)** to diskfs, so it can present remote LUNs to pNFS clients matched **strictly by their SCSI VPD-0x83 hardware designator** (NAA WWID / EUI-64) — with *nothing* written to the data disk. Builds on the flex + block layout work merged in #514.

### Why a new layout type
The block layout (RFC 5663, #514) can only identify a disk by a *content signature* read at a fixed offset — it requires something recognizable already on the disk. Matching a SAN/NVMeoF LUN by its intrinsic hardware identity, with nothing written to it, is a property of a different layout type: the SCSI layout (RFC 8154), which identifies a volume by its VPD-0x83 designator.

### What changed
The SCSI extent (`pnfs_scsi_extent4`) is wire-identical to the block extent, so the diskfs allocator, the `get_layout` walk, and `chimera_vfs_layout_segment` are **unchanged**. The deltas are confined to the layout-class tag, the device descriptor (a designator instead of a signature), and the device-addr / layout-body XDR encoders.

- **vfs**: `CHIMERA_VFS_LAYOUT_CLASS_SCSI` + a SCSI designator variant on `chimera_vfs_layout_device`; `CAP_LAYOUT_CLASS_SCSI`.
- **nfs**: advertise `LAYOUT4_SCSI` (0x5) and the block-size/alignment attrs; hand-encode `pnfs_scsi_deviceaddr4` (a BASE volume carrying the VPD-0x83 designator + the client's reservation key) and `pnfs_scsi_layout4`; route SCSI through `GETDEVICEINFO` / `LAYOUTGET` / `LAYOUTRETURN`.
- **diskfs**: a `"scsi"` remote-device config block + a `"scsi_layout"` share flag (mutually exclusive with `block_layout`); fill the SCSI descriptor on `get_layout`.

### Fencing — deferred by design
v1 advertises the per-LU persistent-reservation key (the client registers it) but the MDS issues **no** reservations; revocation stays recall-only, as it is for block. Server-issued PR fencing/PREEMPT is a follow-on.

### KVM bring-up finding
Bring-up confirmed the **server side works end-to-end**: the Linux client parses our `GETDEVICEINFO`, matches the data disk by its NAA WWN (`pNFS: using block device sda`), and reaches `LAYOUTGET`. The client then issues a **mandatory** SCSI `PERSISTENT RESERVE OUT` to register its key, which qemu's emulated `scsi-hd` cannot service (and `qemu-pr-helper` only forwards PR to a real host SCSI device). A self-contained netns+qemu harness therefore can't exercise the data path, so the SCSI ctests are registered **`DISABLED`** with a full explanation; the wrapper stays runnable for manual use against a PR-capable target (LIO/tcmu or a real SAS/FC/iSCSI/NVMe-PR LU).

---

### Also includes a block-mode mount-crash fix
While rebasing onto current `main`, the block pNFS KVM tests started crashing at mount — a regression from the log-warming work (#521) interacting with the block-mode relocated-log design (#514). `space_map_active_log_blocks()` reported each warmed log block under the AG's *tracked* `device_id`, but a block-mode AG backed by a remote (data-only) device has its log relocated to the local metadata device. Warming then issued a block read against the queue-less remote device and SEGV'd at mount. Fixed to use `ag->log_device_id` (matching every other log-I/O site). This fixes `chimera/kvm/*/pnfs/block_*` on `main`, not just this branch. (The intermittent `fsx_nfs4_*` failures are the known pre-existing NFS4 flake, unrelated.)
