### PR TITLE
diskfs: warm first-writer paths

### DIFF
--- a/src/vfs/diskfs/diskfs.c
+++ b/src/vfs/diskfs/diskfs.c
@@ -416,6 +416,10 @@ struct diskfs_block_cache {
 #define DISKFS_BLOCK_CACHE_DEFAULT_BLOCKS (2 * DISKFS_INTENT_LOG_BLOCKS)
 #define DISKFS_BLOCK_CACHE_MIN_BLOCKS     (DISKFS_INTENT_LOG_BLOCKS + DISKFS_INTENT_LOG_BLOCKS / 2)
 
+/* Cache-warm allocator journal blocks for the AGs most likely to receive the
+ * first metadata allocations.  This does not reserve or journal space. */
+#define DISKFS_AG_LOG_WARM_AGS            64
+
 /*
  * On-disk inode block layout (4 KiB):
  *   [0, DISKFS_INODE_AREA)   struct diskfs_dinode (scalar attributes)
@@ -667,6 +671,7 @@ struct diskfs_iq_channel {
     struct diskfs_iq_channel *next_pending;
     int                       unregister_requested;
     int                       unregister_done;
+    int                       registered;
 };
 
 #define DISKFS_IL_MAX_CHANNELS 256
@@ -736,6 +741,7 @@ struct diskfs_shared {
     uint8_t                    root_fh[CHIMERA_VFS_FH_SIZE];
     uint32_t                   root_fhlen;
     int                        orphans_scanned;    /* mount-time orphan recovery done */
+    int                        ag_logs_warmed;     /* mount-time allocator log warmup done */
     uint64_t                   root_inum;          /* for the clean-unmount superblock */
     uint32_t                   root_gen;
     int                        unsafe_async;       /* config opt-in: submit block writes without FUA/sync (no crash safety) */
@@ -1503,6 +1509,48 @@ diskfs_inode_load_sync(
     }
     return inode;
 } /* diskfs_inode_load_sync */
+
+static void
+diskfs_warm_ag_logs(struct diskfs_thread *thread)
+{
+    struct diskfs_shared   *shared = thread->shared;
+    struct sm_log_block     blocks[DISKFS_AG_LOG_WARM_AGS * 2];
+    struct diskfs_mount_io *io;
+    uint8_t                 buf[DISKFS_BLOCK_SIZE];
+    uint32_t                nblocks;
+
+    pthread_mutex_lock(&shared->lock);
+    if (shared->ag_logs_warmed) {
+        pthread_mutex_unlock(&shared->lock);
+        return;
+    }
+    shared->ag_logs_warmed = 1;
+    pthread_mutex_unlock(&shared->lock);
+
+    nblocks = space_map_active_log_blocks(shared->space_map,
+                                          DISKFS_AG_LOG_WARM_AGS,
+                                          blocks,
+                                          sizeof(blocks) / sizeof(blocks[0]));
+    if (nblocks == 0) {
+        return;
+    }
+
+    io = diskfs_mount_io_open(shared);
+    for (uint32_t i = 0; i < nblocks; i++) {
+        struct diskfs_block *blk;
+
+        if (diskfs_mount_io_read(io, blocks[i].device_id, buf,
+                                 sizeof(buf), blocks[i].device_offset) != 0) {
+            continue;
+        }
+
+        blk = diskfs_block_claim(thread, blocks[i].device_id,
+                                 blocks[i].device_offset, 1);
+        memcpy(blk->iov.data, buf, sizeof(buf));
+        diskfs_block_unpin(thread, blk, DISKFS_BLOCK_CLEAN);
+    }
+    diskfs_mount_io_close(io);
+} /* diskfs_warm_ag_logs */
 
 /* ------------------------------------------------------------------ */
 /* Block cache                                                         */
@@ -4471,11 +4519,13 @@ diskfs_bt_run(struct diskfs_bt_op *op)
                 if (unlikely(!exact)) {
                     struct diskfs_bt_lslot *sl        = diskfs_bt_lslots(buf, base);
                     int                     misrouted = h->nitems > 0 &&
-                        ((idx == h->nitems && h->next_leaf) ||
-                         (idx == 0 && h->prev_leaf));
+                        op->last_parent_valid &&
+                        (diskfs_bt_key_cmp(&op->key, &op->last_parent_key) < 0 ||
+                         (op->last_parent_next_child &&
+                          diskfs_bt_key_cmp(&op->key, &op->last_parent_next_key) >= 0));
 
                     if (misrouted) {
-                        if (op->last_parent_valid && op->last_parent_next_child) {
+                        if (op->last_parent_next_child) {
                             chimera_diskfs_error("b+tree exact miss misrouted inode=%lu type=%u subkey=%lu "
                                                  "leaf_items=%u leaf_first=%lu leaf_last=%lu "
                                                  "leaf_prev=%lu leaf_next=%lu insert_idx=%d "
@@ -4496,10 +4546,12 @@ diskfs_bt_run(struct diskfs_bt_op *op)
                                                  op->last_parent_child,
                                                  op->last_parent_next_key.subkey,
                                                  op->last_parent_next_child);
-                        } else if (h->nitems > 0) {
+                        } else {
                             chimera_diskfs_error("b+tree exact miss misrouted inode=%lu type=%u subkey=%lu "
                                                  "leaf_items=%u leaf_first=%lu leaf_last=%lu "
-                                                 "leaf_prev=%lu leaf_next=%lu insert_idx=%d",
+                                                 "leaf_prev=%lu leaf_next=%lu insert_idx=%d "
+                                                 "parent_ci=%d parent_nitems=%d parent_key=%lu "
+                                                 "parent_child=%lu",
                                                  inode->inum,
                                                  (unsigned) op->key.type,
                                                  op->key.subkey,
@@ -4508,7 +4560,11 @@ diskfs_bt_run(struct diskfs_bt_op *op)
                                                  sl[h->nitems - 1].key.subkey,
                                                  h->prev_leaf,
                                                  h->next_leaf,
-                                                 idx);
+                                                 idx,
+                                                 op->last_parent_ci,
+                                                 op->last_parent_nitems,
+                                                 op->last_parent_key.subkey,
+                                                 op->last_parent_child);
                         }
                     }
                     diskfs_bt_complete(op, -1);
@@ -6413,6 +6469,7 @@ diskfs_intent_log_drain_pending(struct diskfs_intent_log *il)
                                 "intent log: too many channels (%u >= %u)",
                                 il->num_channels, DISKFS_IL_MAX_CHANNELS);
         il->channels[il->num_channels++] = ch;
+        __atomic_store_n(&ch->registered, 1, __ATOMIC_RELEASE);
     }
 } /* diskfs_intent_log_drain_pending */
 
@@ -7746,6 +7803,10 @@ diskfs_thread_init(
     pthread_mutex_unlock(&shared->intent_log.registration_lock);
 
     evpl_ring_doorbell(&shared->intent_log.wake_doorbell);
+    while (!__atomic_load_n(&thread->iq_channel->registered, __ATOMIC_ACQUIRE)) {
+        /* Wait until the intent-log thread has installed this channel so the
+         * first write does not also pay channel registration latency. */
+    }
 
     return thread;
 } /* diskfs_thread_init */
@@ -8424,6 +8485,7 @@ diskfs_mount(
     if (unlikely(!shared->orphans_scanned)) {
         diskfs_orphan_scan(thread);
     }
+    diskfs_warm_ag_logs(thread);
 
     p->thread     = thread;
     p->txn        = diskfs_txn_begin(thread, DISKFS_TXN_READ);

--- a/src/vfs/diskfs/space_map.c
+++ b/src/vfs/diskfs/space_map.c
@@ -106,6 +106,81 @@ sm_ag_journal_claim(
     return 0;
 } /* sm_ag_journal_claim */
 
+uint32_t
+space_map_active_log_blocks(
+    struct space_map    *sm,
+    uint32_t             max_ags,
+    struct sm_log_block *blocks,
+    uint32_t             max_blocks)
+{
+    uint32_t count      = 0;
+    uint32_t warmed_ags = 0;
+    uint32_t start_dev;
+
+    if (!sm || !blocks || max_ags == 0 || max_blocks == 0 || sm->num_devices == 0) {
+        return 0;
+    }
+
+    pthread_mutex_lock(&sm->lock);
+    start_dev = sm->device_rotor % sm->num_devices;
+    pthread_mutex_unlock(&sm->lock);
+
+    for (uint32_t di = 0; di < sm->num_devices && warmed_ags < max_ags; di++) {
+        struct sm_device *dev = &sm->devices[(start_dev + di) % sm->num_devices];
+        uint32_t          start_ag;
+
+        if (dev->num_ags == 0) {
+            continue;
+        }
+
+        pthread_mutex_lock(&sm->lock);
+        start_ag = dev->ag_rotor % dev->num_ags;
+        pthread_mutex_unlock(&sm->lock);
+
+        for (uint32_t ai = 0; ai < dev->num_ags && warmed_ags < max_ags; ai++) {
+            struct sm_ag *ag = &dev->ags[(start_ag + ai) % dev->num_ags];
+            uint64_t      slot_base;
+            uint64_t      region_off;
+            uint64_t      delta_byte;
+            uint64_t      delta_off;
+            uint32_t      in_block;
+
+            pthread_mutex_lock(&ag->lock);
+            slot_base  = ag->log_offset + (uint64_t) ag->log_slot * SM_AG_LOG_SLOT_SIZE;
+            region_off = (sizeof(struct sm_ag_log_header) +
+                          (uint64_t) ag->log_base_count * sizeof(struct sm_ag_log_ext) +
+                          SM_BLOCK_SIZE - 1) & ~((uint64_t) SM_BLOCK_SIZE - 1);
+            delta_byte = region_off +
+                (uint64_t) ag->log_delta_count * sizeof(struct sm_ag_log_delta);
+            delta_off = slot_base + (delta_byte & ~((uint64_t) SM_BLOCK_SIZE - 1));
+            in_block  = (uint32_t) (delta_byte & (SM_BLOCK_SIZE - 1));
+
+            if (count < max_blocks) {
+                blocks[count].device_id     = ag->device_id;
+                blocks[count].device_offset = slot_base;
+                count++;
+            }
+
+            /* If the next delta starts at a block boundary, the normal journal
+             * claim will create a fresh zeroed block and will not read disk.
+             * Only warm the current delta block when it already exists. */
+            if (in_block != 0 && delta_off != slot_base && count < max_blocks) {
+                blocks[count].device_id     = ag->device_id;
+                blocks[count].device_offset = delta_off;
+                count++;
+            }
+            pthread_mutex_unlock(&ag->lock);
+
+            warmed_ags++;
+            if (count == max_blocks) {
+                return count;
+            }
+        }
+    }
+
+    return count;
+} /* space_map_active_log_blocks */
+
 /* Write the delta into the pre-claimed log blocks.  Caller holds ag->lock and
  * has already mutated the free tree; this cannot fault. */
 static void

--- a/src/vfs/diskfs/space_map.h
+++ b/src/vfs/diskfs/space_map.h
@@ -328,6 +328,11 @@ struct sm_thread_cache {
     int      valid;
 };
 
+struct sm_log_block {
+    uint32_t device_id;
+    uint64_t device_offset;
+};
+
 struct space_map *
 space_map_create(
     const struct sm_device_cfg *cfg,
@@ -411,6 +416,13 @@ space_map_thread_cache_return(
     struct space_map        *sm,
     const struct sm_journal *jnl,
     struct sm_thread_cache  *cache);
+
+uint32_t
+space_map_active_log_blocks(
+    struct space_map    *sm,
+    uint32_t             max_ags,
+    struct sm_log_block *blocks,
+    uint32_t             max_blocks);
 
 /*
  * Write a stub superblock to offset 0 of device 0 through the mount-time


### PR DESCRIPTION
## Summary
- warm active diskfs space-map AG log blocks during mount so first metadata allocation avoids cold journal-block reads
- wait for worker intent-log channel registration during thread init instead of first write
- tighten the exact-miss btree diagnostic so normal misses between a leaf's last key and the next separator are not logged as errors

## Tests
- make syntax
- cmake --build /tmp/diskfs-fail-build --target chimera_vfs_diskfs -j 8