### PR TITLE
nfs4: harden exchange-id lease and SSV decode

### DIFF
--- a/src/nfs_common/nfs4.x
+++ b/src/nfs_common/nfs4.x
@@ -267,7 +267,9 @@ typedef uint64_t        nfs_cookie4;
 typedef opaque  nfs_fh4<NFS4_FHSIZE>;
 typedef uint64_t        offset4;
 typedef uint32_t        qop4;
-typedef opaque  sec_oid4<>;
+struct sec_oid4 {
+        opaque oid<>;
+};
 typedef uint32_t        sequenceid4;
 typedef uint32_t        seqid4;
 typedef opaque  sessionid4[NFS4_SESSIONID_SIZE];

--- a/src/server/nfs/nfs4_proc_secinfo.c
+++ b/src/server/nfs/nfs4_proc_secinfo.c
@@ -38,13 +38,13 @@ chimera_nfs4_secinfo_complete(
     res->resok4 = xdr_dbuf_alloc_space(2 * sizeof(struct secinfo4), req->encoding->dbuf);
     chimera_nfs_abort_if(res->resok4 == NULL, "Failed to allocate space");
 
-    res->num_resok4                     = 2;
-    res->resok4[0].flavor               = AUTH_SYS;
-    res->resok4[1].flavor               = RPCSEC_GSS;
-    res->resok4[1].flavor_info.oid.len  = sizeof(krb5_oid);
-    res->resok4[1].flavor_info.oid.data = (void *) krb5_oid;
-    res->resok4[1].flavor_info.qop      = 0;
-    res->resok4[1].flavor_info.service  = RPC_GSS_SVC_NONE;
+    res->num_resok4                         = 2;
+    res->resok4[0].flavor                   = AUTH_SYS;
+    res->resok4[1].flavor                   = RPCSEC_GSS;
+    res->resok4[1].flavor_info.oid.oid.len  = sizeof(krb5_oid);
+    res->resok4[1].flavor_info.oid.oid.data = (void *) krb5_oid;
+    res->resok4[1].flavor_info.qop          = 0;
+    res->resok4[1].flavor_info.service      = RPC_GSS_SVC_NONE;
 
     res->status = NFS4_OK;
     chimera_nfs4_compound_complete(req, NFS4_OK);

--- a/src/server/nfs/nfs4_session.c
+++ b/src/server/nfs/nfs4_session.c
@@ -630,6 +630,12 @@ nfs4_client_create_session_classify(
     HASH_FIND(nfs4_client_hh_by_id, table->nfs4_ct_clients_by_id,
               &client_id, sizeof(client_id), c);
 
+    if (c && c->unified && !c->nfs4_client_confirmed && c->unified->expired) {
+        out->action = NFS4_CS_ERROR;
+        out->status = NFS4ERR_STALE_CLIENTID;
+        goto out_unlock;
+    }
+
     if (c && c->unified) {
         /* CREATE_SESSION is client liveness on a clientid the server still
          * holds.  If the lease sweep had marked the client courtesy-expired
@@ -671,6 +677,7 @@ nfs4_client_create_session_classify(
         out->status = NFS4ERR_SEQ_MISORDERED;
     }
 
+ out_unlock:
     pthread_mutex_unlock(&table->nfs4_ct_lock);
 } /* nfs4_client_create_session_classify */
 


### PR DESCRIPTION
## Summary

- keep expired unconfirmed NFSv4.1/v4.2 clientids stale at CREATE_SESSION instead of reviving them
- represent sec_oid4 as a one-field struct so generated XDR correctly decodes arrays of sec_oid4 in SP4_SSV EXCHANGE_ID arguments
- update SECINFO's RPCSEC_GSS OID initialization for the wrapped sec_oid4 type

## Notes

This fixes EID9 with the accompanying pynfs short-lease robustness fix pushed to chimera-fast-ci.

For EID50, this fixes the RPC GARBAGE_ARGS decode failure. The test now reaches the higher-level unsupported SSV path and fails because Chimera does not implement SP4_SSV/SET_SSV yet.

## Testing

- cmake --build build --target chimera -j 24
- PYNFS_TIMEOUT=300 ctest --test-dir build -R 'chimera/pynfs/exchange_id/EID9_memfs_nfs4\.[12]' --output-on-failure --test-output-size-failed 20000
- PYNFS_TIMEOUT=300 ctest --test-dir build -R 'chimera/pynfs/(exchange_id/(EID1|EID1a|EID1b|EID9|EID50)_memfs_nfs4\.[12]|secinfo/.*memfs_nfs4\.0)' --output-on-failure --test-output-size-failed 12000

The final focused run passed all listed tests except EID50 for both v4.1 and v4.2, which now fail after successful decode because SSV is not implemented.
