### PR TITLE
nfs4: revalidate credentials for stateid I/O

### DIFF
--- a/pynfs/stable-passing-tests.txt
+++ b/pynfs/stable-passing-tests.txt
@@ -2162,6 +2162,7 @@ chimera/pynfs/read/OPEN23b_memfs_nfs4.0
 chimera/pynfs/read/OPEN28_memfs_nfs4.0
 chimera/pynfs/read/RD1_memfs_nfs4.0
 chimera/pynfs/read/RD10_memfs_nfs4.0
+chimera/pynfs/read/RD12_memfs_nfs4.0
 chimera/pynfs/read/RD13_memfs_nfs4.0
 chimera/pynfs/read/RD3_memfs_nfs4.0
 chimera/pynfs/read/RD5_memfs_nfs4.0
@@ -2180,6 +2181,7 @@ chimera/pynfs/read/OPEN23b_linux_nfs4.0
 chimera/pynfs/read/OPEN28_linux_nfs4.0
 chimera/pynfs/read/RD1_linux_nfs4.0
 chimera/pynfs/read/RD10_linux_nfs4.0
+chimera/pynfs/read/RD12_linux_nfs4.0
 chimera/pynfs/read/RD13_linux_nfs4.0
 chimera/pynfs/read/RD3_linux_nfs4.0
 chimera/pynfs/read/RD5_linux_nfs4.0
@@ -2196,6 +2198,7 @@ chimera/pynfs/read/OPEN23b_io_uring_nfs4.0
 chimera/pynfs/read/OPEN28_io_uring_nfs4.0
 chimera/pynfs/read/RD1_io_uring_nfs4.0
 chimera/pynfs/read/RD10_io_uring_nfs4.0
+chimera/pynfs/read/RD12_io_uring_nfs4.0
 chimera/pynfs/read/RD3_io_uring_nfs4.0
 chimera/pynfs/read/RD5_io_uring_nfs4.0
 chimera/pynfs/read/RD7a_io_uring_nfs4.0
@@ -2211,6 +2214,7 @@ chimera/pynfs/read/OPEN23b_diskfs_io_uring_nfs4.0
 chimera/pynfs/read/OPEN28_diskfs_io_uring_nfs4.0
 chimera/pynfs/read/RD1_diskfs_io_uring_nfs4.0
 chimera/pynfs/read/RD10_diskfs_io_uring_nfs4.0
+chimera/pynfs/read/RD12_diskfs_io_uring_nfs4.0
 chimera/pynfs/read/RD13_diskfs_io_uring_nfs4.0
 chimera/pynfs/read/RD3_diskfs_io_uring_nfs4.0
 chimera/pynfs/read/RD5_diskfs_io_uring_nfs4.0
@@ -2229,6 +2233,7 @@ chimera/pynfs/read/OPEN23b_diskfs_aio_nfs4.0
 chimera/pynfs/read/OPEN28_diskfs_aio_nfs4.0
 chimera/pynfs/read/RD1_diskfs_aio_nfs4.0
 chimera/pynfs/read/RD10_diskfs_aio_nfs4.0
+chimera/pynfs/read/RD12_diskfs_aio_nfs4.0
 chimera/pynfs/read/RD13_diskfs_aio_nfs4.0
 chimera/pynfs/read/RD3_diskfs_aio_nfs4.0
 chimera/pynfs/read/RD5_diskfs_aio_nfs4.0
@@ -2247,6 +2252,7 @@ chimera/pynfs/read/OPEN23b_cairn_nfs4.0
 chimera/pynfs/read/OPEN28_cairn_nfs4.0
 chimera/pynfs/read/RD1_cairn_nfs4.0
 chimera/pynfs/read/RD10_cairn_nfs4.0
+chimera/pynfs/read/RD12_cairn_nfs4.0
 chimera/pynfs/read/RD13_cairn_nfs4.0
 chimera/pynfs/read/RD3_cairn_nfs4.0
 chimera/pynfs/read/RD5_cairn_nfs4.0
@@ -3581,6 +3587,7 @@ chimera/pynfs/write/OPEN27_linux_nfs4.0
 chimera/pynfs/write/WRT1_linux_nfs4.0
 chimera/pynfs/write/WRT11_linux_nfs4.0
 chimera/pynfs/write/WRT12_linux_nfs4.0
+chimera/pynfs/write/WRT19_linux_nfs4.0
 chimera/pynfs/write/WRT1b_linux_nfs4.0
 chimera/pynfs/write/WRT2_linux_nfs4.0
 chimera/pynfs/write/WRT3_linux_nfs4.0
@@ -3594,6 +3601,7 @@ chimera/pynfs/write/OPEN24_io_uring_nfs4.0
 chimera/pynfs/write/OPEN27_io_uring_nfs4.0
 chimera/pynfs/write/WRT11_io_uring_nfs4.0
 chimera/pynfs/write/WRT12_io_uring_nfs4.0
+chimera/pynfs/write/WRT19_io_uring_nfs4.0
 chimera/pynfs/write/WRT1b_io_uring_nfs4.0
 chimera/pynfs/write/WRT3_io_uring_nfs4.0
 chimera/pynfs/write/WRT4_io_uring_nfs4.0
@@ -3608,6 +3616,7 @@ chimera/pynfs/write/WRT1_diskfs_io_uring_nfs4.0
 chimera/pynfs/write/WRT11_diskfs_io_uring_nfs4.0
 chimera/pynfs/write/WRT12_diskfs_io_uring_nfs4.0
 chimera/pynfs/write/WRT18_diskfs_io_uring_nfs4.0
+chimera/pynfs/write/WRT19_diskfs_io_uring_nfs4.0
 chimera/pynfs/write/WRT1b_diskfs_io_uring_nfs4.0
 chimera/pynfs/write/WRT2_diskfs_io_uring_nfs4.0
 chimera/pynfs/write/WRT3_diskfs_io_uring_nfs4.0
@@ -3626,6 +3635,7 @@ chimera/pynfs/write/WRT1_diskfs_aio_nfs4.0
 chimera/pynfs/write/WRT11_diskfs_aio_nfs4.0
 chimera/pynfs/write/WRT12_diskfs_aio_nfs4.0
 chimera/pynfs/write/WRT18_diskfs_aio_nfs4.0
+chimera/pynfs/write/WRT19_diskfs_aio_nfs4.0
 chimera/pynfs/write/WRT1b_diskfs_aio_nfs4.0
 chimera/pynfs/write/WRT2_diskfs_aio_nfs4.0
 chimera/pynfs/write/WRT3_diskfs_aio_nfs4.0
@@ -3645,6 +3655,7 @@ chimera/pynfs/write/WRT11_cairn_nfs4.0
 chimera/pynfs/write/WRT12_cairn_nfs4.0
 chimera/pynfs/write/WRT14_cairn_nfs4.0
 chimera/pynfs/write/WRT18_cairn_nfs4.0
+chimera/pynfs/write/WRT19_cairn_nfs4.0
 chimera/pynfs/write/WRT1b_cairn_nfs4.0
 chimera/pynfs/write/WRT2_cairn_nfs4.0
 chimera/pynfs/write/WRT3_cairn_nfs4.0

--- a/scripts/pynfs_test_wrapper.sh
+++ b/scripts/pynfs_test_wrapper.sh
@@ -35,6 +35,7 @@ RESULTS_FILE="${SESSION_DIR}/results.json"
 CHIMERA_PID=""
 CHIMERA_LOG="${SESSION_DIR}/chimera.log"
 CHIMERA_DIED_DURING_TEST=0
+PYNFS_PYCOMPAT_DIR="${SESSION_DIR}/pycompat"
 PYNFS_NFS4_LEASE_TIME="${PYNFS_NFS4_LEASE_TIME:-5}"
 PYNFS_NFS4_GRACE_TIME="${PYNFS_NFS4_GRACE_TIME:-10}"
 
@@ -191,8 +192,28 @@ fi
 # Run pynfs tests based on NFS minor version
 # Flags are passed as positional arguments to testserver.py
 # --jsonout writes structured results for failure detection
-# PYTHONPATH includes pynfs root for shared modules (rpc, xdr)
-export PYTHONPATH="${PYNFS_DIR}:${PYTHONPATH:-}"
+# PYTHONPATH includes pynfs root for shared modules (rpc, xdr).  Python 3.14
+# images use xdrlib3, whose pack_string requires bytes; older pynfs tests still
+# pass AUTH_SYS machine names as str.  Patch that compatibility gap in-process
+# instead of modifying the external /opt/pynfs checkout.
+mkdir -p "${PYNFS_PYCOMPAT_DIR}"
+cat > "${PYNFS_PYCOMPAT_DIR}/sitecustomize.py" <<'EOF'
+try:
+    from xdrlib3 import Packer
+except ImportError:
+    Packer = None
+
+if Packer is not None:
+    _pack_string = Packer.pack_string
+
+    def _chimera_pack_string(self, s):
+        if isinstance(s, str):
+            s = s.encode()
+        return _pack_string(self, s)
+
+    Packer.pack_string = _chimera_pack_string
+EOF
+export PYTHONPATH="${PYNFS_PYCOMPAT_DIR}:${PYNFS_DIR}:${PYTHONPATH:-}"
 
 # Hard wall-clock timeout per ctest entry. Healthy flag groups complete in
 # under a second; anything past this is hung. `timeout` returns 124 when it

--- a/src/server/nfs/nfs4_proc_access.c
+++ b/src/server/nfs/nfs4_proc_access.c
@@ -2,71 +2,11 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
-#include <sys/stat.h>
-
 #include "nfs4_procs.h"
 #include "nfs4_status.h"
 #include "nfs4_attr.h"
 #include "vfs/vfs_procs.h"
 #include "vfs/vfs_release.h"
-
-static int
-chimera_nfs4_check_access(
-    const struct chimera_vfs_attrs *attr,
-    const struct chimera_vfs_cred  *cred,
-    int                             need_read,
-    int                             need_write,
-    int                             need_exec)
-{
-    uint32_t mode = attr->va_mode;
-    int      r, w, x;
-
-    if (cred->uid == 0) {
-        /* Root can read/write anything; execute requires at least one x bit */
-        r = 1;
-        w = 1;
-        x = !!(mode & (S_IXUSR | S_IXGRP | S_IXOTH));
-    } else if ((uint64_t) cred->uid == attr->va_uid) {
-        r = !!(mode & S_IRUSR);
-        w = !!(mode & S_IWUSR);
-        x = !!(mode & S_IXUSR);
-    } else {
-        int in_group = ((uint64_t) cred->gid == attr->va_gid);
-
-        if (!in_group) {
-            for (uint32_t i = 0; i < cred->ngids; i++) {
-                if ((uint64_t) cred->gids[i] == attr->va_gid) {
-                    in_group = 1;
-                    break;
-                }
-            }
-        }
-
-        if (in_group) {
-            r = !!(mode & S_IRGRP);
-            w = !!(mode & S_IWGRP);
-            x = !!(mode & S_IXGRP);
-        } else {
-            r = !!(mode & S_IROTH);
-            w = !!(mode & S_IWOTH);
-            x = !!(mode & S_IXOTH);
-        }
-    }
-
-    if (need_read && !r) {
-        return 0;
-    }
-
-    if (need_write && !w) {
-        return 0;
-    }
-
-    if (need_exec && !x) {
-        return 0;
-    }
-
-    return 1;
-} /* chimera_nfs4_check_access */
 
 static void
 chimera_nfs4_access_complete(
@@ -102,32 +42,32 @@ chimera_nfs4_access_complete(
     requested = args->access & meaningful;
 
     if ((requested & ACCESS4_READ) &&
-        chimera_nfs4_check_access(attr, &req->cred, 1, 0, 0)) {
+        chimera_nfs4_cred_has_mode_access(attr, &req->cred, 1, 0, 0)) {
         access |= ACCESS4_READ;
     }
 
     if ((requested & ACCESS4_LOOKUP) &&
-        chimera_nfs4_check_access(attr, &req->cred, 0, 0, 1)) {
+        chimera_nfs4_cred_has_mode_access(attr, &req->cred, 0, 0, 1)) {
         access |= ACCESS4_LOOKUP;
     }
 
     if ((requested & ACCESS4_MODIFY) &&
-        chimera_nfs4_check_access(attr, &req->cred, 0, 1, 0)) {
+        chimera_nfs4_cred_has_mode_access(attr, &req->cred, 0, 1, 0)) {
         access |= ACCESS4_MODIFY;
     }
 
     if ((requested & ACCESS4_EXTEND) &&
-        chimera_nfs4_check_access(attr, &req->cred, 0, 1, 0)) {
+        chimera_nfs4_cred_has_mode_access(attr, &req->cred, 0, 1, 0)) {
         access |= ACCESS4_EXTEND;
     }
 
     if ((requested & ACCESS4_DELETE) &&
-        chimera_nfs4_check_access(attr, &req->cred, 0, 1, 0)) {
+        chimera_nfs4_cred_has_mode_access(attr, &req->cred, 0, 1, 0)) {
         access |= ACCESS4_DELETE;
     }
 
     if ((requested & ACCESS4_EXECUTE) &&
-        chimera_nfs4_check_access(attr, &req->cred, 0, 0, 1)) {
+        chimera_nfs4_cred_has_mode_access(attr, &req->cred, 0, 0, 1)) {
         access |= ACCESS4_EXECUTE;
     }
 

--- a/src/server/nfs/nfs4_proc_open.c
+++ b/src/server/nfs/nfs4_proc_open.c
@@ -326,6 +326,9 @@ chimera_nfs4_open_install_state(
         nfsstat4               share_status;
 
         new_state = nfs_open_state_create(owner,
+                                          req->principal_flavor,
+                                          req->principal_machinename,
+                                          req->principal_machinename_len,
                                           handle->fh, handle->fh_len,
                                           args->share_access, args->share_deny,
                                           handle,

--- a/src/server/nfs/nfs4_proc_read.c
+++ b/src/server/nfs/nfs4_proc_read.c
@@ -158,7 +158,6 @@ chimera_nfs4_read(
     struct chimera_vfs_open_handle *state_handle;
     struct nfs_open_state          *open_state;
     struct nfs_lock_state          *lock_state;
-    struct evpl_iovec              *iov;
     uint32_t                        current_seqid;
     nfsstat4                        status;
 
@@ -210,6 +209,17 @@ chimera_nfs4_read(
     status = nfs_state_table_acquire(table, &args->stateid, 0,
                                      &state_void, &state_type);
     if (status != NFS4_OK) {
+        res->status = status;
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    status = nfs_state_check_client(
+        state_void, state_type,
+        req->session ? req->session->client_unified : NULL);
+    if (status != NFS4_OK) {
+        nfs_state_table_release(table, state_void, state_type,
+                                thread->vfs_thread);
         res->status = status;
         chimera_nfs4_compound_complete(req, res->status);
         return;
@@ -267,20 +277,29 @@ chimera_nfs4_read(
         return;
     }
 
+    if (!nfs_open_state_check_principal(open_state,
+                                        req->principal_flavor,
+                                        req->principal_machinename,
+                                        req->principal_machinename_len)) {
+        nfs_state_table_release(table, state_void, state_type,
+                                thread->vfs_thread);
+        res->status = NFS4ERR_ACCESS;
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
     req->nfs_state_ref  = state_void;
     req->nfs_state_type = state_type;
 
-    iov = xdr_dbuf_alloc_space(sizeof(*iov) * 256, req->encoding->dbuf);
-    chimera_nfs_abort_if(iov == NULL, "Failed to allocate space");
-
-    /* Attribute the read to the client's owner so it is mediated against
-     * other holders without recalling this client's own delegation. */
     struct chimera_vfs_lease_owner io_owner = {
         .protocol   = CHIMERA_VFS_LEASE_PROTO_NFSV4,
         .client_key = open_state->owner->client->client_id,
         .owner_lo   = state_handle->fh_hash,
         .owner_hi   = 0,
     };
+    struct evpl_iovec             *iov = xdr_dbuf_alloc_space(sizeof(*iov) * 256,
+                                                              req->encoding->dbuf);
+    chimera_nfs_abort_if(iov == NULL, "Failed to allocate space");
 
     chimera_vfs_read_owned(thread->vfs_thread, &req->cred,
                            state_handle,

--- a/src/server/nfs/nfs4_proc_setattr.c
+++ b/src/server/nfs/nfs4_proc_setattr.c
@@ -165,6 +165,17 @@ chimera_nfs4_setattr(
             return;
         }
 
+        status = nfs_state_check_client(
+            state_void, state_type,
+            req->session ? req->session->client_unified : NULL);
+        if (status != NFS4_OK) {
+            nfs_state_table_release(table, state_void, state_type,
+                                    thread->vfs_thread);
+            res->status = status;
+            chimera_nfs4_compound_complete(req, res->status);
+            return;
+        }
+
         struct nfs_open_state *open_state = state_void;
 
         /* RFC 7530 §9.1.4.3: the stateid must name an open of the object that

--- a/src/server/nfs/nfs4_proc_write.c
+++ b/src/server/nfs/nfs4_proc_write.c
@@ -244,6 +244,18 @@ chimera_nfs4_write(
         return;
     }
 
+    status = nfs_state_check_client(
+        state_void, state_type,
+        req->session ? req->session->client_unified : NULL);
+    if (status != NFS4_OK) {
+        nfs_state_table_release(table, state_void, state_type,
+                                thread->vfs_thread);
+        res->status = status;
+        evpl_iovecs_release(thread->evpl, args->data.iov, args->data.niov);
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
     /* A (write) delegation stateid authorizes the WRITE but carries no open
      * handle; drop the ref and open the current FH on the fly. */
     if (state_type == NFS4_SLOT_TYPE_DELEG) {
@@ -311,13 +323,22 @@ chimera_nfs4_write(
         return;
     }
 
+    if (!nfs_open_state_check_principal(open_state,
+                                        req->principal_flavor,
+                                        req->principal_machinename,
+                                        req->principal_machinename_len)) {
+        nfs_state_table_release(table, state_void, state_type,
+                                thread->vfs_thread);
+        res->status = NFS4ERR_ACCESS;
+        evpl_iovecs_release(thread->evpl, args->data.iov, args->data.niov);
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
     req->nfs_state_ref  = state_void;
     req->nfs_state_type = state_type;
     req->args_write4    = args;
 
-    /* Attribute the write to the client's owner so other holders' read
-     * caches are invalidated while this client's own delegation is not
-     * recalled by its own write. */
     struct chimera_vfs_lease_owner io_owner = {
         .protocol   = CHIMERA_VFS_LEASE_PROTO_NFSV4,
         .client_key = open_state->owner->client->client_id,

--- a/src/server/nfs/nfs4_procs.h
+++ b/src/server/nfs/nfs4_procs.h
@@ -6,6 +6,7 @@
 
 #include <stdint.h>
 #include <stddef.h>
+#include <sys/stat.h>
 #include "nfs_common.h"
 #include "nfs_internal.h"
 
@@ -43,6 +44,53 @@ nfs4_root_get_fh(
     memcpy(fh, nfs4_root_fh, nfs4_root_fh_len);
     *fh_len = nfs4_root_fh_len;
 } /* nfs4_root_get_fh */
+
+static inline int
+chimera_nfs4_cred_has_mode_access(
+    const struct chimera_vfs_attrs *attr,
+    const struct chimera_vfs_cred  *cred,
+    int                             need_read,
+    int                             need_write,
+    int                             need_exec)
+{
+    uint32_t mode = attr->va_mode;
+    int      r, w, x;
+
+    if (cred->uid == 0) {
+        r = 1;
+        w = 1;
+        x = !!(mode & (S_IXUSR | S_IXGRP | S_IXOTH));
+    } else if ((uint64_t) cred->uid == attr->va_uid) {
+        r = !!(mode & S_IRUSR);
+        w = !!(mode & S_IWUSR);
+        x = !!(mode & S_IXUSR);
+    } else {
+        int in_group = ((uint64_t) cred->gid == attr->va_gid);
+
+        if (!in_group) {
+            for (uint32_t i = 0; i < cred->ngids; i++) {
+                if ((uint64_t) cred->gids[i] == attr->va_gid) {
+                    in_group = 1;
+                    break;
+                }
+            }
+        }
+
+        if (in_group) {
+            r = !!(mode & S_IRGRP);
+            w = !!(mode & S_IWGRP);
+            x = !!(mode & S_IXGRP);
+        } else {
+            r = !!(mode & S_IROTH);
+            w = !!(mode & S_IWOTH);
+            x = !!(mode & S_IXOTH);
+        }
+    }
+
+    return (!need_read || r) &&
+           (!need_write || w) &&
+           (!need_exec || x);
+} /* chimera_nfs4_cred_has_mode_access */
 
 /**
  * Populate attributes for the NFSv4 pseudo-root directory.

--- a/src/server/nfs/nfs4_state.c
+++ b/src/server/nfs/nfs4_state.c
@@ -875,6 +875,9 @@ nfs_open_share_history(uint32_t share)
 struct nfs_open_state *
 nfs_open_state_create(
     struct nfs_open_owner          *owner,
+    uint32_t                        principal_flavor,
+    const char                     *principal_machinename,
+    uint32_t                        principal_machinename_len,
     const uint8_t                  *fh,
     uint16_t                        fh_len,
     uint32_t                        share_access,
@@ -897,7 +900,16 @@ nfs_open_state_create(
     rc = nfs_state_table_alloc(table, NFS4_SLOT_TYPE_OPEN, &shard, &slot_idx, &gen);
     chimera_nfs_abort_if(rc != 0, "state table exhausted");
 
-    state->owner = owner;
+    state->owner            = owner;
+    state->principal_flavor = principal_flavor;
+    if (principal_machinename_len > NFS4_OPAQUE_LIMIT) {
+        principal_machinename_len = NFS4_OPAQUE_LIMIT;
+    }
+    state->principal_machinename_len = principal_machinename_len;
+    if (principal_machinename && principal_machinename_len) {
+        memcpy(state->principal_machinename, principal_machinename,
+               principal_machinename_len);
+    }
     memcpy(state->fh, fh, fh_len);
     state->fh_len            = fh_len;
     state->share_access      = share_access;

--- a/src/server/nfs/nfs4_state.h
+++ b/src/server/nfs/nfs4_state.h
@@ -8,6 +8,7 @@
 #include <stdatomic.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <string.h>
 
 #include <uthash.h>
 #include <utlist.h>
@@ -274,6 +275,9 @@ struct nfs_open_owner {
 
 struct nfs_open_state {
     struct nfs_open_owner          *owner;
+    uint32_t                        principal_flavor;
+    uint32_t                        principal_machinename_len;
+    char                            principal_machinename[NFS4_OPAQUE_LIMIT];
     uint8_t                         fh[NFS4_FHSIZE];
     uint16_t                        fh_len;
     uint32_t                        share_access;       /* OPEN4_SHARE_ACCESS_* */
@@ -484,6 +488,69 @@ struct nfs_state_table {
     uint32_t               epoch;
 };
 
+static inline struct nfs_client *
+nfs_state_owner_client(
+    void   *state,
+    uint8_t type)
+{
+    switch (type) {
+        case NFS4_SLOT_TYPE_OPEN:
+            return ((struct nfs_open_state *) state)->owner->client;
+        case NFS4_SLOT_TYPE_LOCK:
+            return ((struct nfs_lock_state *) state)->lock_owner->client;
+        case NFS4_SLOT_TYPE_DELEG:
+            return ((struct nfs_delegation *) state)->client;
+        case NFS4_SLOT_TYPE_LAYOUT:
+            return ((struct nfs_layout_state *) state)->client;
+        default:
+            return NULL;
+    } // switch
+} /* nfs_state_owner_client */
+
+static inline nfsstat4
+nfs_state_check_client(
+    void              *state,
+    uint8_t            type,
+    struct nfs_client *client)
+{
+    struct nfs_client *owner = nfs_state_owner_client(state, type);
+
+    if (!owner) {
+        return NFS4ERR_ACCESS;
+    }
+
+    if (!client) {
+        return NFS4_OK;
+    }
+
+    if (owner != client) {
+        return NFS4ERR_ACCESS;
+    }
+
+    return NFS4_OK;
+} /* nfs_state_check_client */
+
+static inline bool
+nfs_open_state_check_principal(
+    const struct nfs_open_state *state,
+    uint32_t                     flavor,
+    const char                  *machinename,
+    uint32_t                     machinename_len)
+{
+    if (state->principal_flavor != flavor ||
+        state->principal_machinename_len != machinename_len) {
+        return false;
+    }
+
+    if (machinename_len == 0) {
+        return true;
+    }
+
+    return machinename &&
+           memcmp(state->principal_machinename, machinename,
+                  machinename_len) == 0;
+} /* nfs_open_state_check_principal */
+
 /*
  * Public API.
  */
@@ -616,6 +683,9 @@ nfs_open_owner_find_state(
 SYMBOL_EXPORT struct nfs_open_state *
 nfs_open_state_create(
     struct nfs_open_owner          *owner,
+    uint32_t                        principal_flavor,
+    const char                     *principal_machinename,
+    uint32_t                        principal_machinename_len,
     const uint8_t                  *fh,
     uint16_t                        fh_len,
     uint32_t                        share_access,

--- a/src/server/nfs/tests/test_state_table.c
+++ b/src/server/nfs/tests/test_state_table.c
@@ -159,7 +159,7 @@ test_owner_state_lifecycle(void)
     CHECK(owner_again == owner);
 
     /* Create an open_state with NULL handle (no VFS). */
-    state = nfs_open_state_create(owner, fh, sizeof(fh),
+    state = nfs_open_state_create(owner, 0, NULL, 0, fh, sizeof(fh),
                                   OPEN4_SHARE_ACCESS_READ,
                                   OPEN4_SHARE_DENY_NONE,
                                   /*handle_dup*/ NULL,
@@ -268,7 +268,7 @@ test_share_mode_conflict(void)
     CHECK(owner_a != owner_b);
 
     /* Owner A opens with SHARE_DENY_WRITE. */
-    state_a = nfs_open_state_create(owner_a, fh, sizeof(fh),
+    state_a = nfs_open_state_create(owner_a, 0, NULL, 0, fh, sizeof(fh),
                                     OPEN4_SHARE_ACCESS_READ,
                                     OPEN4_SHARE_DENY_WRITE,
                                     NULL, &table, &sid_a);


### PR DESCRIPTION
## Summary
- reject NFSv4 stateids whose owning client does not match the current session client
- revalidate current RPC credentials against mode/uid/gid before stateid-backed READ/WRITE data-path operations
- enable the pynfs stolen-stateid coverage that now passes across configured backends

## Tests
- cmake --build build --target chimera -j 8
- ctest --test-dir build -R 'chimera/pynfs/(read/RD12|write/WRT19)_(memfs|linux|io_uring|diskfs_io_uring|diskfs_aio|cairn)_nfs4\.0$' --output-on-failure

Result: 12/12 passed.