### PR TITLE
nfs4: preserve unchecked recreate semantics

### DIFF
--- a/src/server/nfs/nfs4_proc_open.c
+++ b/src/server/nfs/nfs4_proc_open.c
@@ -597,6 +597,14 @@ struct nfs4_open_lookup_regular_ctx {
     unsigned int              flags;
 };
 
+struct nfs4_open_unchecked_ctx {
+    struct nfs_request       *req;
+    struct chimera_vfs_attrs *attr;
+    const char               *name;
+    uint32_t                  namelen;
+    unsigned int              flags;
+};
+
 static void
 chimera_nfs4_open_lookup_regular_complete(
     enum chimera_vfs_error    error_code,
@@ -640,6 +648,52 @@ chimera_nfs4_open_lookup_regular_complete(
                         chimera_nfs4_open_at_complete,
                         req);
 } /* chimera_nfs4_open_lookup_regular_complete */
+
+static void
+chimera_nfs4_open_unchecked_lookup_complete(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *existing_attr,
+    struct chimera_vfs_attrs *dir_attr,
+    void                     *private_data)
+{
+    struct nfs4_open_unchecked_ctx *ctx           = private_data;
+    struct nfs_request             *req           = ctx->req;
+    struct OPEN4res                *res           = &req->res_compound.resarray[req->index].opopen;
+    struct chimera_vfs_open_handle *parent_handle = req->handle;
+
+    (void) existing_attr;
+    (void) dir_attr;
+
+    if (error_code == CHIMERA_VFS_OK) {
+        /* RFC 7530 OPEN/UNCHECKED recreate: create attrs are ignored for an
+         * existing object, except size=0 truncates the file. */
+        if ((ctx->attr->va_set_mask & CHIMERA_VFS_ATTR_SIZE) &&
+            ctx->attr->va_size == 0) {
+            ctx->attr->va_set_mask = CHIMERA_VFS_ATTR_SIZE;
+            ctx->attr->va_req_mask = CHIMERA_VFS_ATTR_SIZE;
+        } else {
+            ctx->attr->va_set_mask = 0;
+            ctx->attr->va_req_mask = 0;
+        }
+    } else if (error_code != CHIMERA_VFS_ENOENT) {
+        res->status = chimera_nfs4_errno_to_nfsstat4(error_code);
+        chimera_vfs_release(req->thread->vfs_thread, parent_handle);
+        chimera_nfs4_open_complete(req, res->status);
+        return;
+    }
+
+    chimera_vfs_open_at(req->thread->vfs_thread, &req->cred,
+                        parent_handle,
+                        ctx->name,
+                        ctx->namelen,
+                        ctx->flags,
+                        ctx->attr,
+                        CHIMERA_VFS_ATTR_FH | CHIMERA_VFS_ATTR_MODE,
+                        CHIMERA_VFS_ATTR_MTIME,
+                        CHIMERA_VFS_ATTR_MTIME,
+                        chimera_nfs4_open_at_complete,
+                        req);
+} /* chimera_nfs4_open_unchecked_lookup_complete */
 
 static void
 chimera_nfs4_open_claim_fh_complete(
@@ -827,6 +881,29 @@ chimera_nfs4_open_parent_complete(
                 return;
             }
 
+            if (args->openhow.opentype == OPEN4_CREATE &&
+                args->openhow.how.mode == UNCHECKED4) {
+                struct nfs4_open_unchecked_ctx *ctx;
+
+                ctx = xdr_dbuf_alloc_space(sizeof(*ctx), req->encoding->dbuf);
+                chimera_nfs_abort_if(ctx == NULL, "Failed to allocate space");
+                ctx->req     = req;
+                ctx->attr    = attr;
+                ctx->name    = args->claim.file.data;
+                ctx->namelen = args->claim.file.len;
+                ctx->flags   = flags;
+
+                chimera_vfs_lookup_at(req->thread->vfs_thread, &req->cred,
+                                      parent_handle,
+                                      args->claim.file.data,
+                                      args->claim.file.len,
+                                      0,
+                                      0,
+                                      chimera_nfs4_open_unchecked_lookup_complete,
+                                      ctx);
+                return;
+            }
+
             chimera_vfs_open_at(req->thread->vfs_thread, &req->cred,
                                 parent_handle,
                                 args->claim.file.data,
@@ -871,6 +948,29 @@ chimera_nfs4_open_parent_complete(
                                       CHIMERA_VFS_ATTR_MODE,
                                       0,
                                       chimera_nfs4_open_lookup_regular_complete,
+                                      ctx);
+                return;
+            }
+
+            if (args->openhow.opentype == OPEN4_CREATE &&
+                args->openhow.how.mode == UNCHECKED4) {
+                struct nfs4_open_unchecked_ctx *ctx;
+
+                ctx = xdr_dbuf_alloc_space(sizeof(*ctx), req->encoding->dbuf);
+                chimera_nfs_abort_if(ctx == NULL, "Failed to allocate space");
+                ctx->req     = req;
+                ctx->attr    = attr;
+                ctx->name    = args->claim.delegate_cur_info.file.data;
+                ctx->namelen = args->claim.delegate_cur_info.file.len;
+                ctx->flags   = flags;
+
+                chimera_vfs_lookup_at(req->thread->vfs_thread, &req->cred,
+                                      parent_handle,
+                                      args->claim.delegate_cur_info.file.data,
+                                      args->claim.delegate_cur_info.file.len,
+                                      0,
+                                      0,
+                                      chimera_nfs4_open_unchecked_lookup_complete,
                                       ctx);
                 return;
             }

--- a/src/vfs/cairn/cairn.c
+++ b/src/vfs/cairn/cairn.c
@@ -2641,6 +2641,14 @@ cairn_open_at(
         }
     }
 
+    if (!is_new_inode &&
+        (request->open_at.set_attr->va_set_mask & CHIMERA_VFS_ATTR_SIZE) &&
+        request->open_at.set_attr->va_size == 0 &&
+        S_ISREG(inode->mode)) {
+        cairn_apply_attrs(inode, request->open_at.set_attr);
+        inode->space_used = 0;
+    }
+
     if (flags & CHIMERA_VFS_OPEN_INFERRED) {
         /* If this is an inferred open (ie an NFS3 create)
          * then we aren't returning a handle so we don't need

--- a/src/vfs/diskfs/diskfs.c
+++ b/src/vfs/diskfs/diskfs.c
@@ -9594,6 +9594,13 @@ diskfs_open_at_existing_cb(
         }
     }
 
+    if ((request->open_at.set_attr->va_set_mask & CHIMERA_VFS_ATTR_SIZE) &&
+        request->open_at.set_attr->va_size == 0 &&
+        S_ISREG(inode->mode)) {
+        diskfs_apply_attrs(inode, request->open_at.set_attr);
+        inode->space_used = 0;
+    }
+
     diskfs_open_at_finish(request, parent, inode);
 } /* diskfs_open_at_existing_cb */
 

--- a/src/vfs/io_uring/io_uring.c
+++ b/src/vfs/io_uring/io_uring.c
@@ -236,6 +236,13 @@ chimera_io_uring_reap(
 
                         parent_fd = request->open_at.handle->vfs_private;
 
+                        if (request->open_at.set_attr->va_set_mask & CHIMERA_VFS_ATTR_SIZE) {
+                            if (ftruncate(cqe->res, request->open_at.set_attr->va_size) < 0) {
+                                request->status = chimera_linux_errno_to_status(errno);
+                                break;
+                            }
+                        }
+
                         sqe = chimera_io_uring_get_sqe(thread, request, 1, 0);
 
                         if (request->open_at.flags & CHIMERA_VFS_OPEN_NOFOLLOW) {
@@ -1016,7 +1023,10 @@ chimera_io_uring_open_at(
 
     flags = 0;
 
-    if (request->open_at.flags & (CHIMERA_VFS_OPEN_READ_ONLY | CHIMERA_VFS_OPEN_PATH | CHIMERA_VFS_OPEN_DIRECTORY)) {
+    if (request->open_at.flags & (CHIMERA_VFS_OPEN_PATH | CHIMERA_VFS_OPEN_DIRECTORY)) {
+        flags |= O_RDONLY;
+    } else if ((request->open_at.flags & CHIMERA_VFS_OPEN_READ_ONLY) &&
+               !(request->open_at.set_attr->va_set_mask & CHIMERA_VFS_ATTR_SIZE)) {
         flags |= O_RDONLY;
     } else {
         flags |= O_RDWR;


### PR DESCRIPTION
OPEN/UNCHECKED recreate must ignore create attributes for existing files, except size=0 truncates. Normalize that in the NFS OPEN path before calling backend open, and make the diskfs/cairn existing-open paths honor the size-zero truncate case. This also applies size attrs during io_uring open completion so initial creates report the requested size.\n\nValidation:\n- cmake --build build --target chimera -j 8\n- /usr/bin/env PYNFS_TIMEOUT=300 ctest --test-dir build -R 'chimera/pynfs/open/OPEN2_(memfs|linux|io_uring|diskfs_io_uring|diskfs_aio|cairn)_nfs4\.[012]$' --output-on-failure --timeout 180 -j 8