### PR TITLE
vfs: enforce diskfs and cairn open access

### DIFF
--- a/src/vfs/cairn/cairn.c
+++ b/src/vfs/cairn/cairn.c
@@ -1576,6 +1576,53 @@ cairn_apply_attrs(
 
 } /* cairn_apply_attrs */
 
+static bool
+cairn_cred_can_access(
+    const struct cairn_inode      *inode,
+    const struct chimera_vfs_cred *cred,
+    uint32_t                       user_bit,
+    uint32_t                       group_bit,
+    uint32_t                       other_bit)
+{
+    if (cred->uid == 0) {
+        return true;
+    }
+
+    if ((uint64_t) cred->uid == inode->uid) {
+        return !!(inode->mode & user_bit);
+    }
+
+    bool in_group = ((uint64_t) cred->gid == inode->gid);
+
+    for (uint32_t i = 0; !in_group && i < cred->ngids; i++) {
+        if ((uint64_t) cred->gids[i] == inode->gid) {
+            in_group = true;
+        }
+    }
+
+    if (in_group) {
+        return !!(inode->mode & group_bit);
+    }
+
+    return !!(inode->mode & other_bit);
+} /* cairn_cred_can_access */
+
+static bool
+cairn_cred_can_read(
+    const struct cairn_inode      *inode,
+    const struct chimera_vfs_cred *cred)
+{
+    return cairn_cred_can_access(inode, cred, S_IRUSR, S_IRGRP, S_IROTH);
+} /* cairn_cred_can_read */
+
+static bool
+cairn_cred_can_write(
+    const struct cairn_inode      *inode,
+    const struct chimera_vfs_cred *cred)
+{
+    return cairn_cred_can_access(inode, cred, S_IWUSR, S_IWGRP, S_IWOTH);
+} /* cairn_cred_can_write */
+
 static void
 cairn_getattr(
     struct cairn_thread        *thread,
@@ -2572,6 +2619,26 @@ cairn_open_at(
         request->status = CHIMERA_VFS_ENOTDIR;
         request->complete(request);
         return;
+    }
+
+    if (!(flags & CHIMERA_VFS_OPEN_INFERRED)) {
+        bool allowed;
+
+        if (flags & CHIMERA_VFS_OPEN_READ_ONLY) {
+            allowed = cairn_cred_can_read(inode, request->cred);
+        } else {
+            allowed = cairn_cred_can_write(inode, request->cred);
+        }
+
+        if (!allowed) {
+            cairn_inode_handle_release(&parent_ih);
+            if (!is_new_inode) {
+                cairn_inode_handle_release(&child_ih);
+            }
+            request->status = CHIMERA_VFS_EACCES;
+            request->complete(request);
+            return;
+        }
     }
 
     if (flags & CHIMERA_VFS_OPEN_INFERRED) {

--- a/src/vfs/diskfs/diskfs.c
+++ b/src/vfs/diskfs/diskfs.c
@@ -8020,6 +8020,53 @@ diskfs_apply_attrs(
 
 } /* diskfs_apply_attrs */
 
+static bool
+diskfs_cred_can_access(
+    const struct diskfs_inode     *inode,
+    const struct chimera_vfs_cred *cred,
+    uint32_t                       user_bit,
+    uint32_t                       group_bit,
+    uint32_t                       other_bit)
+{
+    if (cred->uid == 0) {
+        return true;
+    }
+
+    if ((uint64_t) cred->uid == inode->uid) {
+        return !!(inode->mode & user_bit);
+    }
+
+    bool in_group = ((uint64_t) cred->gid == inode->gid);
+
+    for (uint32_t i = 0; !in_group && i < cred->ngids; i++) {
+        if ((uint64_t) cred->gids[i] == inode->gid) {
+            in_group = true;
+        }
+    }
+
+    if (in_group) {
+        return !!(inode->mode & group_bit);
+    }
+
+    return !!(inode->mode & other_bit);
+} /* diskfs_cred_can_access */
+
+static bool
+diskfs_cred_can_read(
+    const struct diskfs_inode     *inode,
+    const struct chimera_vfs_cred *cred)
+{
+    return diskfs_cred_can_access(inode, cred, S_IRUSR, S_IRGRP, S_IROTH);
+} /* diskfs_cred_can_read */
+
+static bool
+diskfs_cred_can_write(
+    const struct diskfs_inode     *inode,
+    const struct chimera_vfs_cred *cred)
+{
+    return diskfs_cred_can_access(inode, cred, S_IWUSR, S_IWGRP, S_IWOTH);
+} /* diskfs_cred_can_write */
+
 static void
 diskfs_getattr_inode_cb(
     struct diskfs_inode *inode,
@@ -9530,6 +9577,21 @@ diskfs_open_at_existing_cb(
         !S_ISDIR(inode->mode)) {
         diskfs_op_fail(request, p->txn, CHIMERA_VFS_ENOTDIR);
         return;
+    }
+
+    if (!(request->open_at.flags & CHIMERA_VFS_OPEN_INFERRED)) {
+        bool allowed;
+
+        if (request->open_at.flags & CHIMERA_VFS_OPEN_READ_ONLY) {
+            allowed = diskfs_cred_can_read(inode, request->cred);
+        } else {
+            allowed = diskfs_cred_can_write(inode, request->cred);
+        }
+
+        if (!allowed) {
+            diskfs_op_fail(request, p->txn, CHIMERA_VFS_EACCES);
+            return;
+        }
     }
 
     diskfs_open_at_finish(request, parent, inode);


### PR DESCRIPTION
diskfs and cairn accepted opens that should fail DAC permission checks, allowing NFSv4 share-state conflict handling to return SHARE_DENIED before ACCESS. Add uid/gid/mode checks matching memfs for non-inferred open_at so inaccessible files fail with EACCES at the backend.\n\nValidation:\n- cmake --build build --target chimera -j 8\n- /usr/bin/env PYNFS_TIMEOUT=300 ctest --test-dir build -R 'chimera/pynfs/open/OPEN20_(memfs|linux|io_uring|diskfs_io_uring|diskfs_aio|cairn)_nfs4\.0$' --output-on-failure --timeout 180 -j 6