### PR TITLE
vfs: report read EOF at file end

### DIFF
--- a/src/vfs/cairn/cairn.c
+++ b/src/vfs/cairn/cairn.c
@@ -2751,7 +2751,7 @@ cairn_read(
         request->status        = CHIMERA_VFS_OK;
         request->read.r_niov   = 0;
         request->read.r_length = 0;
-        request->read.r_eof    = 1;
+        request->read.r_eof    = 0;
         request->complete(request);
         return;
     }
@@ -2786,7 +2786,7 @@ cairn_read(
         return;
     }
 
-    if (offset + length > inode->size) {
+    if (length >= inode->size - offset) {
         length = inode->size - offset;
         eof    = 1;
     }

--- a/src/vfs/diskfs/diskfs.c
+++ b/src/vfs/diskfs/diskfs.c
@@ -10229,8 +10229,11 @@ diskfs_read_inode_cb(
     offset = request->read.offset;
     length = request->read.length;
 
-    if (offset + length > inode->size) {
-        length = inode->size > offset ? inode->size - offset : 0;
+    if (offset >= inode->size) {
+        length = 0;
+        eof    = 1;
+    } else if (length >= inode->size - offset) {
+        length = inode->size - offset;
         eof    = 1;
     }
 

--- a/src/vfs/io_uring/io_uring.c
+++ b/src/vfs/io_uring/io_uring.c
@@ -374,7 +374,23 @@ chimera_io_uring_reap(
                     }
                 } else {
                     if (cqe->res == 0) {
-                        chimera_linux_statx_to_attr(&request->read.r_attr, (struct statx *) request->plugin_data);
+                        stx = (struct statx *) request->plugin_data;
+
+                        if (request->read.r_attr.va_req_mask & CHIMERA_VFS_ATTR_MASK_STAT) {
+                            chimera_linux_statx_to_attr(&request->read.r_attr, stx);
+                        }
+
+                        if (request->status == CHIMERA_VFS_OK) {
+                            request->read.r_eof =
+                                (request->read.length > 0 &&
+                                 request->read.offset + request->read.r_length >= stx->stx_size);
+                        } else if (request->status == CHIMERA_VFS_EINVAL &&
+                                   request->read.offset >= stx->stx_size) {
+                            request->status        = CHIMERA_VFS_OK;
+                            request->read.r_length = 0;
+                            request->read.r_niov   = 0;
+                            request->read.r_eof    = 1;
+                        }
                     }
                 }
                 break;
@@ -1274,7 +1290,7 @@ chimera_io_uring_read(
         request->status        = CHIMERA_VFS_OK;
         request->read.r_niov   = 0;
         request->read.r_length = 0;
-        request->read.r_eof    = 1;
+        request->read.r_eof    = 0;
         if (request->read.r_attr.va_req_mask & CHIMERA_VFS_ATTR_MASK_STAT) {
             sqe = chimera_io_uring_get_sqe(thread, request, 1, 0);
             io_uring_prep_statx(sqe, fd, "", AT_EMPTY_PATH, AT_STATX_SYNC_AS_STAT, stx);
@@ -1316,10 +1332,8 @@ chimera_io_uring_read(
 
     io_uring_prep_readv(sqe, fd, iov, request->read.r_niov, request->read.offset);
 
-    if (request->read.r_attr.va_req_mask & CHIMERA_VFS_ATTR_MASK_STAT) {
-        sqe = chimera_io_uring_get_sqe(thread, request, 1, 0);
-        io_uring_prep_statx(sqe, fd, "", AT_EMPTY_PATH, AT_STATX_SYNC_AS_STAT, stx);
-    }
+    sqe = chimera_io_uring_get_sqe(thread, request, 1, 0);
+    io_uring_prep_statx(sqe, fd, "", AT_EMPTY_PATH, AT_STATX_SYNC_AS_STAT, stx);
 
     evpl_defer(thread->evpl, &thread->deferral);
 } /* chimera_io_uring_read */

--- a/src/vfs/linux/linux.c
+++ b/src/vfs/linux/linux.c
@@ -881,6 +881,7 @@ chimera_linux_read(
     int                          fd, i;
     ssize_t                      len, left = request->read.length;
     struct iovec                *iov;
+    struct stat                  st;
 
     /* Handle 0-byte reads specially - preadv with uninitialized iov causes EFAULT */
     if (request->read.length == 0) {
@@ -888,7 +889,7 @@ chimera_linux_read(
         chimera_linux_map_attrs(CHIMERA_VFS_FH_MAGIC_LINUX, &request->read.r_attr, fd);
         request->read.r_niov   = 0;
         request->read.r_length = 0;
-        request->read.r_eof    = 1;
+        request->read.r_eof    = 0;
         request->status        = CHIMERA_VFS_OK;
         request->complete(request);
         return;
@@ -922,6 +923,21 @@ chimera_linux_read(
                  request->read.offset);
 
     if (len < 0) {
+        if (errno == EINVAL &&
+            fstat(fd, &st) == 0 &&
+            request->read.offset >= (uint64_t) st.st_size) {
+            evpl_iovecs_release(evpl, request->read.iov, request->read.r_niov);
+
+            chimera_linux_map_attrs(CHIMERA_VFS_FH_MAGIC_LINUX, &request->read.r_attr, fd);
+
+            request->read.r_niov   = 0;
+            request->read.r_length = 0;
+            request->read.r_eof    = 1;
+            request->status        = CHIMERA_VFS_OK;
+            request->complete(request);
+            return;
+        }
+
         request->status = chimera_linux_errno_to_status(errno);
 
         evpl_iovecs_release(evpl, request->read.iov, request->read.r_niov);
@@ -938,10 +954,19 @@ chimera_linux_read(
         request->read.r_niov = 0;
     }
 
-    chimera_linux_map_attrs(CHIMERA_VFS_FH_MAGIC_LINUX, &request->read.r_attr, fd);
+    if (fstat(fd, &st) == 0) {
+        if (request->read.r_attr.va_req_mask & CHIMERA_VFS_ATTR_MASK_STAT) {
+            chimera_linux_stat_to_attr(&request->read.r_attr, &st);
+        }
+
+        request->read.r_eof = (request->read.offset + len >= (uint64_t) st.st_size);
+    } else {
+        chimera_linux_map_attrs(CHIMERA_VFS_FH_MAGIC_LINUX, &request->read.r_attr, fd);
+
+        request->read.r_eof = (len < request->read.length);
+    }
 
     request->read.r_length = len;
-    request->read.r_eof    = (len < request->read.length);
 
     request->status = CHIMERA_VFS_OK;
     request->complete(request);

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -2283,8 +2283,8 @@ memfs_read(
         return;
     }
 
-    if (offset + length >= inode->size) {
-        length = inode->size > offset ? inode->size - offset : 0;
+    if (length >= inode->size - offset) {
+        length = inode->size - offset;
         eof    = 1;
     }
 


### PR DESCRIPTION
## Summary
- report EOF for reads that end exactly at file size across VFS backends
- keep zero-count reads from reporting EOF
- translate linux/io_uring far-offset EINVAL reads into successful EOF reads after confirming file size

## Testing
- cmake --build build --target chimera -j 8
- ctest --test-dir build -R '^chimera/pynfs/(read/(RD5a|RD6)|write/(WRT13|WRT16))_(linux|io_uring|diskfs_io_uring|diskfs_aio|cairn|memfs)_nfs4\.0$' --output-on-failure
- ctest --test-dir build -R '^chimera/pynfs/(read/(RD5a|RD6|RD13)|write/(WRT1|WRT2|WRT13|WRT16))_(memfs|linux|io_uring|diskfs_io_uring|diskfs_aio|cairn)_nfs4\.0$' --output-on-failure