### PR TITLE
vfs: keep zero-length write mtime unchanged

### DIFF
--- a/src/server/nfs/nfs4_proc_write.c
+++ b/src/server/nfs/nfs4_proc_write.c
@@ -128,6 +128,12 @@ chimera_nfs4_write_typecheck_complete(
     chimera_vfs_release(req->thread->vfs_thread, req->handle);
     req->handle = NULL;
 
+    if (args->data.length == 0) {
+        req->args_write4 = args;
+        chimera_nfs4_write_complete(CHIMERA_VFS_OK, 0, 1, NULL, NULL, req);
+        return;
+    }
+
     chimera_vfs_open_fh(req->thread->vfs_thread, &req->cred,
                         req->fh,
                         req->fhlen,
@@ -338,6 +344,11 @@ chimera_nfs4_write(
     req->nfs_state_ref  = state_void;
     req->nfs_state_type = state_type;
     req->args_write4    = args;
+
+    if (args->data.length == 0) {
+        chimera_nfs4_write_complete(CHIMERA_VFS_OK, 0, 1, NULL, NULL, req);
+        return;
+    }
 
     struct chimera_vfs_lease_owner io_owner = {
         .protocol   = CHIMERA_VFS_LEASE_PROTO_NFSV4,

--- a/src/vfs/cairn/cairn.c
+++ b/src/vfs/cairn/cairn.c
@@ -3067,6 +3067,17 @@ cairn_write(
 
     cairn_map_attrs(shared, &request->write.r_pre_attr, inode);
 
+    if (request->write.length == 0) {
+        cairn_map_attrs(shared, &request->write.r_post_attr, inode);
+        cairn_inode_handle_release(&ih);
+
+        request->status         = CHIMERA_VFS_OK;
+        request->write.r_length = 0;
+        request->write.r_sync   = 1;
+        request->complete(request);
+        return;
+    }
+
     if (inode->size > request->write.offset) {
         cairn_punch_hole(thread, shared, inode, request->write.offset, request->write.length);
     }

--- a/src/vfs/diskfs/diskfs.c
+++ b/src/vfs/diskfs/diskfs.c
@@ -11762,6 +11762,15 @@ diskfs_write_inode_cb(
 
     diskfs_map_attrs(thread, &request->write.r_pre_attr, inode);
 
+    if (request->write.length == 0) {
+        diskfs_map_attrs(thread, &request->write.r_post_attr, inode);
+
+        request->write.r_length = 0;
+        request->write.r_sync   = 1;
+        diskfs_op_ok(request, diskfs_private->txn);
+        return;
+    }
+
     aligned_start  = write_start & ~4095ULL;
     aligned_end    = (write_end + 4095ULL) & ~4095ULL;
     aligned_length = aligned_end - aligned_start;


### PR DESCRIPTION
## Summary
- keep zero-length writes from mutating diskfs/cairn mtime/change state
- short-circuit validated NFSv4 zero-byte WRITE before backend dispatch so io_uring also preserves time_modify after #532 exposed real GETATTR timestamps
- rebased onto current main to include #532/#533 fixes

## Tests
- cmake --build build --target chimera -j 8
- ctest --test-dir build -R '^chimera/pynfs/write/WRT4_(memfs|linux|io_uring|diskfs_io_uring|diskfs_aio|cairn)_nfs4\.0$' --output-on-failure
- ctest --test-dir build -R '^chimera/pynfs/write/(WRT13|WRT16)_(diskfs_io_uring|diskfs_aio|cairn)_nfs4\.0$' --output-on-failure --timeout 300