### PR TITLE
vfs: let the VFS core own READ data buffers (CAP_READ_PROVIDES_BUFFERS)

### DIFF
--- a/src/vfs/cairn/cairn.c
+++ b/src/vfs/cairn/cairn.c
@@ -4609,11 +4609,17 @@ cairn_dispatch(
 } /* cairn_dispatch */
 
 SYMBOL_EXPORT struct chimera_vfs_module vfs_cairn = {
-    .name         = "cairn",
-    .fh_magic     = CHIMERA_VFS_FH_MAGIC_CAIRN,
-    .capabilities = CHIMERA_VFS_CAP_BLOCKING | CHIMERA_VFS_CAP_FS | CHIMERA_VFS_CAP_KV |
+    .name     = "cairn",
+    .fh_magic = CHIMERA_VFS_FH_MAGIC_CAIRN,
+    /* CAP_READ_PROVIDES_BUFFERS: cairn_read fills a single contiguous buffer it
+     * allocates itself (SHARED, so the CAP_BLOCKING worker->connection-thread
+     * release is safe).  TODO: drop this cap and convert cairn_read to scatter
+     * its RocksDB extent fill across VFS-core-provided buffers via an
+     * append-blob cursor, like diskfs/linux/io_uring, so it can use cheaper
+     * non-SHARED connection-thread buffers. */
+    .capabilities   = CHIMERA_VFS_CAP_BLOCKING | CHIMERA_VFS_CAP_FS | CHIMERA_VFS_CAP_KV |
         CHIMERA_VFS_CAP_FS_RELATIVE_OP | CHIMERA_VFS_CAP_ATOMIC_HANDLE_STATE |
-        CHIMERA_VFS_CAP_XATTR,
+        CHIMERA_VFS_CAP_XATTR | CHIMERA_VFS_CAP_READ_PROVIDES_BUFFERS,
     .init           = cairn_init,
     .destroy        = cairn_destroy,
     .thread_init    = cairn_thread_init,

--- a/src/vfs/diskfs/diskfs.c
+++ b/src/vfs/diskfs/diskfs.c
@@ -10557,49 +10557,12 @@ diskfs_close(
 } /* diskfs_close */
 
 /*
- * Adjust read iovecs: skip prefix padding and trim to actual read length.
- * Called after block reads complete (or when no reads needed).
+ * Read iovecs are now owned and finalized by the VFS core: it allocates the
+ * 4 KiB-aligned buffers on the connection thread (diskfs lacks
+ * CAP_READ_PROVIDES_BUFFERS), and chimera_vfs_read_complete() skips the prefix
+ * pad and trims to r_length after the request bounces back.  diskfs only fills
+ * the provided buffers and reports r_length/r_eof.
  */
-static inline void
-diskfs_read_adjust_iovecs(
-    struct chimera_vfs_request    *request,
-    struct diskfs_request_private *diskfs_private)
-{
-    if (request->read.r_niov == 0) {
-        return;
-    }
-
-    // Adjust first iovec to skip prefix (alignment padding)
-    request->read.iov[0].data   += diskfs_private->read_prefix;
-    request->read.iov[0].length -= diskfs_private->read_prefix;
-
-    // Calculate total length across all iovecs
-    uint64_t total = 0;
-
-    for (int i = 0; i < request->read.r_niov; i++) {
-        total += request->read.iov[i].length;
-    }
-
-    // Trim excess from the last iovec(s) if needed
-    // Use r_length (actual capped length), not length (original request)
-    // NOTE: Do NOT decrement r_niov here - we must keep the count of allocated
-    // iovecs so they all get properly released by the caller.
-    if (total > request->read.r_length) {
-        uint64_t excess = total - request->read.r_length;
-        int      last   = request->read.r_niov - 1;
-
-        while (excess > 0 && last >= 0) {
-            if (request->read.iov[last].length <= excess) {
-                excess                        -= request->read.iov[last].length;
-                request->read.iov[last].length = 0;
-                last--;
-            } else {
-                request->read.iov[last].length -= excess;
-                excess                          = 0;
-            }
-        }
-    }
-} /* diskfs_read_adjust_iovecs */ /* diskfs_read_adjust_iovecs */
 
 /*
  * Data-I/O admission control.  A worker submits read/write block I/O onto its
@@ -10686,10 +10649,9 @@ diskfs_io_callback(
      * not zeroed, and only diskfs_read sets the flag (fresh, per op). */
     if (diskfs_private->pending == 0 &&
         !(diskfs_private->opcode == CHIMERA_VFS_OP_READ && diskfs_private->io_reading)) {
-        if (diskfs_private->opcode == CHIMERA_VFS_OP_READ) {
-            diskfs_read_adjust_iovecs(request, diskfs_private);
-        }
-
+        /* Release the per-chunk device-I/O iovec refs (slices of the
+        * VFS-provided read buffers); the VFS core trims and releases
+        * request->read.iov itself after the request bounces back. */
         evpl_iovecs_release(thread->evpl, diskfs_private->iov, diskfs_private->niov);
 
         if (diskfs_private->status != 0) {
@@ -10731,7 +10693,6 @@ diskfs_read_finish(struct chimera_vfs_request *request)
     p->io_reading = 0;
 
     if (p->pending == 0) {
-        diskfs_read_adjust_iovecs(request, p);
         diskfs_op_ok(request, p->txn);
     } else {
         /* I/O is in flight; drop the inode lock so other ops proceed.  The
@@ -10907,7 +10868,6 @@ diskfs_read_inode_cb(
     struct chimera_vfs_request    *request        = private_data;
     struct diskfs_request_private *diskfs_private = request->plugin_data;
     struct diskfs_thread          *thread         = diskfs_private->thread;
-    struct evpl                   *evpl           = thread->evpl;
     uint64_t                       offset, length;
     uint64_t                       aligned_offset, aligned_length;
     uint32_t                       eof = 0;
@@ -10946,17 +10906,20 @@ diskfs_read_inode_cb(
     aligned_offset = offset & ~4095ULL;
     aligned_length = ((offset + length + 4095ULL) & ~4095ULL) - aligned_offset;
 
-    diskfs_private->read_prefix = offset - aligned_offset;
-    diskfs_private->read_suffix = aligned_length - length;
-
     request->read.r_length = length;
     request->read.r_eof    = eof;
 
-    request->read.r_niov = evpl_iovec_alloc(evpl, aligned_length, 4096, 1,
-                                            0, request->read.iov);
+    /* The VFS core allocated the 4 KiB-aligned read buffers on the connection
+     * thread (diskfs does not advertise CAP_READ_PROVIDES_BUFFERS) and placed
+     * them in request->read.iov.  Fill them via the cursor; the VFS core skips
+     * the prefix pad and trims to r_length on completion.  Its allocation is
+     * sized from the unclamped count, so it always covers our (EOF-clamped)
+     * aligned_length. */
+    chimera_diskfs_abort_if(request->read.buffers_provided == 0,
+                            "diskfs read dispatched without VFS-provided buffers");
 
     evpl_iovec_cursor_init(&diskfs_private->rd_cursor, request->read.iov,
-                           request->read.r_niov);
+                           request->read.buffers_provided);
 
     diskfs_private->inode_stash[0] = inode;
     diskfs_private->loop_off       = aligned_offset;

--- a/src/vfs/io_uring/io_uring.c
+++ b/src/vfs/io_uring/io_uring.c
@@ -405,20 +405,15 @@ chimera_io_uring_reap(
                 break;
             case CHIMERA_VFS_OP_READ:
                 if (handle->slot == 0) {
+                    /* The VFS core owns request->read.iov (allocated on the
+                     * connection thread); it trims/releases the buffers on
+                     * completion, so io_uring only reports the outcome here. */
                     if (cqe->res >= 0) {
                         request->status        = CHIMERA_VFS_OK;
                         request->read.r_length = cqe->res;
                         request->read.r_eof    = (cqe->res < request->read.length);
-
-                        if (cqe->res == 0) {
-                            evpl_iovecs_release(evpl, request->read.iov, request->read.r_niov);
-                            request->read.r_niov = 0;
-                        }
-
                     } else {
                         request->status = chimera_linux_errno_to_status(-cqe->res);
-
-                        evpl_iovecs_release(evpl, request->read.iov, request->read.r_niov);
                     }
                 } else {
                     if (cqe->res == 0) {
@@ -1323,7 +1318,6 @@ chimera_io_uring_read(
 {
     struct chimera_io_uring_thread *thread = private_data;
     struct io_uring_sqe            *sqe;
-    struct evpl                    *evpl = thread->evpl;
     int                             fd, i;
     ssize_t                         left = request->read.length;
     struct iovec                   *iov;
@@ -1353,23 +1347,32 @@ chimera_io_uring_read(
 
     sqe = chimera_io_uring_get_sqe(thread, request, 0, 0);
 
-    request->read.r_niov = evpl_iovec_alloc(evpl,
-                                            request->read.length,
-                                            4096,
-                                            8,
-                                            EVPL_IOVEC_FLAG_SHARED, request->read.iov);
+    /* The VFS core allocated the read buffers on the connection thread
+     * (io_uring does not advertise CAP_READ_PROVIDES_BUFFERS) and placed them
+     * in request->read.iov, padded to a 4 KiB boundary on both sides.  Build
+     * the readv vector from them: offset the first buffer by aligned_prefix so
+     * file offset `offset` lands where the VFS core trims to on completion, and
+     * cap the vector at the requested length.  The VFS core owns the buffers --
+     * io_uring neither allocates nor releases them. */
+    chimera_io_uring_abort_if(request->read.buffers_provided == 0,
+                              "io_uring read dispatched without VFS-provided buffers");
 
     stx      = (struct statx *) scratch;
     scratch += sizeof(*stx);
 
     iov = (struct iovec *) scratch;
 
-    for (i = 0; left && i < request->read.r_niov; i++) {
+    for (i = 0; left && i < request->read.buffers_provided; i++) {
 
         iov[i].iov_base = request->read.iov[i].data;
         iov[i].iov_len  = request->read.iov[i].length;
 
-        if (iov[i].iov_len > left) {
+        if (i == 0) {
+            iov[i].iov_base = (char *) iov[i].iov_base + request->read.aligned_prefix;
+            iov[i].iov_len -= request->read.aligned_prefix;
+        }
+
+        if (iov[i].iov_len > (size_t) left) {
             iov[i].iov_len = left;
         }
 
@@ -1378,7 +1381,7 @@ chimera_io_uring_read(
 
     fd = (int) request->read.handle->vfs_private;
 
-    io_uring_prep_readv(sqe, fd, iov, request->read.r_niov, request->read.offset);
+    io_uring_prep_readv(sqe, fd, iov, i, request->read.offset);
 
     sqe = chimera_io_uring_get_sqe(thread, request, 1, 0);
     io_uring_prep_statx(sqe, fd, "", AT_EMPTY_PATH, AT_STATX_SYNC_AS_STAT, stx);

--- a/src/vfs/linux/linux.c
+++ b/src/vfs/linux/linux.c
@@ -880,11 +880,12 @@ chimera_linux_read(
     void                       *private_data)
 {
     struct chimera_linux_thread *thread = private_data;
-    struct evpl                 *evpl   = thread->evpl;
     int                          fd, i;
     ssize_t                      len, left = request->read.length;
     struct iovec                *iov;
     struct stat                  st;
+
+    (void) thread;
 
     /* Handle 0-byte reads specially - preadv with uninitialized iov causes EFAULT */
     if (request->read.length == 0) {
@@ -898,20 +899,29 @@ chimera_linux_read(
         return;
     }
 
-    request->read.r_niov = evpl_iovec_alloc(evpl,
-                                            request->read.length,
-                                            4096,
-                                            8,
-                                            EVPL_IOVEC_FLAG_SHARED, request->read.iov);
+    /* The VFS core allocated the read buffers on the connection thread (linux
+     * does not advertise CAP_READ_PROVIDES_BUFFERS) and placed them in
+     * request->read.iov, padded to a 4 KiB boundary on both sides.  Build the
+     * preadv vector from them: offset the first buffer by aligned_prefix so
+     * file offset `offset` lands where the VFS core trims to on completion, and
+     * cap the vector at the requested length.  The VFS core owns the buffers --
+     * linux neither allocates nor releases them. */
+    chimera_vfs_abort_if(request->read.buffers_provided == 0,
+                         "linux read dispatched without VFS-provided buffers");
 
     iov = request->plugin_data;
 
-    for (i = 0; left && i < request->read.r_niov; i++) {
+    for (i = 0; left && i < request->read.buffers_provided; i++) {
 
         iov[i].iov_base = request->read.iov[i].data;
         iov[i].iov_len  = request->read.iov[i].length;
 
-        if (iov[i].iov_len > left) {
+        if (i == 0) {
+            iov[i].iov_base = (char *) iov[i].iov_base + request->read.aligned_prefix;
+            iov[i].iov_len -= request->read.aligned_prefix;
+        }
+
+        if (iov[i].iov_len > (size_t) left) {
             iov[i].iov_len = left;
         }
 
@@ -922,18 +932,18 @@ chimera_linux_read(
 
     len = preadv(fd,
                  iov,
-                 request->read.r_niov,
+                 i,
                  request->read.offset);
 
     if (len < 0) {
+        /* Reading at/after EOF surfaces as EINVAL on some backends; report it
+         * as a clean zero-length EOF read.  The VFS core owns request->read.iov
+         * and releases it on completion (r_length stays 0 here). */
         if (errno == EINVAL &&
             fstat(fd, &st) == 0 &&
             request->read.offset >= (uint64_t) st.st_size) {
-            evpl_iovecs_release(evpl, request->read.iov, request->read.r_niov);
-
             chimera_linux_map_attrs(CHIMERA_VFS_FH_MAGIC_LINUX, &request->read.r_attr, fd);
 
-            request->read.r_niov   = 0;
             request->read.r_length = 0;
             request->read.r_eof    = 1;
             request->status        = CHIMERA_VFS_OK;
@@ -941,20 +951,11 @@ chimera_linux_read(
             return;
         }
 
-        request->status = chimera_linux_errno_to_status(errno);
-
-        evpl_iovecs_release(evpl, request->read.iov, request->read.r_niov);
-
-        request->read.r_niov   = 0;
+        request->status        = chimera_linux_errno_to_status(errno);
         request->read.r_length = 0;
         request->read.r_eof    = 0;
         request->complete(request);
         return;
-    }
-
-    if (len == 0) {
-        evpl_iovecs_release(evpl, request->read.iov, request->read.r_niov);
-        request->read.r_niov = 0;
     }
 
     if (fstat(fd, &st) == 0) {

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -2245,6 +2245,15 @@ memfs_read(
     offset = request->read.offset;
     length = request->read.length;
 
+    /* memfs advertises CAP_READ_PROVIDES_BUFFERS: it returns zero-copy refs to
+     * its own SHARED block iovecs, so the VFS core never pre-allocates buffers
+     * for it (buffers_provided is always 0).  If a future VFS data cache ever
+     * hands memfs buffers to populate, this is where memfs would memcpy its
+     * block data into request->read.iov instead of cloning refs below. */
+    chimera_memfs_abort_if(request->read.buffers_provided,
+                           "memfs read received VFS-provided buffers but only "
+                           "implements the zero-copy ref path");
+
     if (unlikely(length == 0)) {
         request->status        = CHIMERA_VFS_OK;
         request->read.r_niov   = 0;
@@ -4494,7 +4503,8 @@ SYMBOL_EXPORT struct chimera_vfs_module vfs_memfs = {
     .capabilities = CHIMERA_VFS_CAP_CREATE_UNLINKED | CHIMERA_VFS_CAP_FS | CHIMERA_VFS_CAP_KV |
         CHIMERA_VFS_CAP_FS_RELATIVE_OP |
         CHIMERA_VFS_CAP_COPY_RANGE | CHIMERA_VFS_CAP_CLONE_RANGE | CHIMERA_VFS_CAP_MOVE_RANGE |
-        CHIMERA_VFS_CAP_XATTR | CHIMERA_VFS_CAP_LAYOUT | CHIMERA_VFS_CAP_ATOMIC_HANDLE_STATE,
+        CHIMERA_VFS_CAP_XATTR | CHIMERA_VFS_CAP_LAYOUT | CHIMERA_VFS_CAP_ATOMIC_HANDLE_STATE |
+        CHIMERA_VFS_CAP_READ_PROVIDES_BUFFERS,
     .init           = memfs_init,
     .destroy        = memfs_destroy,
     .thread_init    = memfs_thread_init,

--- a/src/vfs/nfs/nfs.c
+++ b/src/vfs/nfs/nfs.c
@@ -305,10 +305,13 @@ chimera_nfs_dispatch(
 } /* chimera_nfs_dispatch */
 
 SYMBOL_EXPORT struct chimera_vfs_module vfs_nfs = {
-    .name         = "nfs",
-    .fh_magic     = CHIMERA_VFS_FH_MAGIC_NFS,
-    .capabilities = CHIMERA_VFS_CAP_OPEN_FILE_REQUIRED | CHIMERA_VFS_CAP_FS | CHIMERA_VFS_CAP_FS_RELATIVE_OP |
-        CHIMERA_VFS_CAP_FS_LOCK,
+    .name     = "nfs",
+    .fh_magic = CHIMERA_VFS_FH_MAGIC_NFS,
+    /* CAP_READ_PROVIDES_BUFFERS: the proxy returns the data buffers handed up
+     * by its upstream RPC reply (it reassigns request->read.iov), so the VFS
+     * core must not pre-allocate buffers for it. */
+    .capabilities   = CHIMERA_VFS_CAP_OPEN_FILE_REQUIRED | CHIMERA_VFS_CAP_FS | CHIMERA_VFS_CAP_FS_RELATIVE_OP |
+        CHIMERA_VFS_CAP_FS_LOCK | CHIMERA_VFS_CAP_READ_PROVIDES_BUFFERS,
     .init           = chimera_nfs_init,
     .destroy        = chimera_nfs_destroy,
     .thread_init    = chimera_nfs_thread_init,

--- a/src/vfs/vfs.h
+++ b/src/vfs/vfs.h
@@ -646,6 +646,16 @@ struct chimera_vfs_request {
             uint32_t                        r_length;
             uint32_t                        r_eof;
             struct chimera_vfs_attrs        r_attr;
+            /* Set by the VFS core when it pre-allocated the read buffers on the
+             * connection thread (backend lacks CAP_READ_PROVIDES_BUFFERS).
+             * buffers_provided = number of iovecs placed in iov[]; aligned_prefix
+             * = offset - (offset & ~4095), the leading pad bytes the backend read
+             * but the client did not ask for.  The backend fills the buffers
+             * (data for file offset `offset` lands at buffer position
+             * aligned_prefix) and sets r_length/r_eof; the VFS core trims the
+             * prefix/tail and sets r_niov in chimera_vfs_read_complete(). */
+            int                             buffers_provided;
+            uint32_t                        aligned_prefix;
         } read;
 
         struct {
@@ -1027,19 +1037,19 @@ struct chimera_vfs_handle_state {
  * chimera_vfs_get_xattr / set_xattr / list_xattrs / remove_xattr.
  * Surfaced over NFSv4.2 (RFC 8276). Modules that leave this unset
  * cause the VFS layer to return ENOTSUP. */
-#define CHIMERA_VFS_CAP_XATTR              (1U << 18)
+#define CHIMERA_VFS_CAP_XATTR                 (1U << 18)
 
 /* setxattr_option4 values (RFC 8276 §8) passed to chimera_vfs_set_xattr().
  * Kept numerically identical to the on-the-wire NFSv4.2 enum. */
-#define CHIMERA_VFS_XATTR_EITHER           0  /* create or replace */
-#define CHIMERA_VFS_XATTR_CREATE           1  /* must not already exist */
-#define CHIMERA_VFS_XATTR_REPLACE          2  /* must already exist */
+#define CHIMERA_VFS_XATTR_EITHER              0 /* create or replace */
+#define CHIMERA_VFS_XATTR_CREATE              1 /* must not already exist */
+#define CHIMERA_VFS_XATTR_REPLACE             2 /* must already exist */
 
 /* Module persists the opaque CHIMERA_VFS_ATTR_PNFS_LAYOUT attribute, so the NFS
  * server can store per-file pNFS layout state on it and hand out pNFS layouts.
  * This is the "orchestrated" model: the module is a passive vessel and the NFS
  * server produces the layout (creating data-server backing files itself). */
-#define CHIMERA_VFS_CAP_LAYOUT             (1U << 14)
+#define CHIMERA_VFS_CAP_LAYOUT                (1U << 14)
 
 /* Module SOURCES the layout itself: it already knows where a file's data
  * physically lives and synthesizes a protocol-neutral layout via
@@ -1047,10 +1057,22 @@ struct chimera_vfs_handle_state {
  * what the module returns) and does NO orchestration.  Mutually exclusive in
  * effect with CHIMERA_VFS_CAP_LAYOUT for a given file.  Exactly one of the
  * class bits below should accompany it. */
-#define CHIMERA_VFS_CAP_LAYOUT_SOURCE      (1U << 15)
-#define CHIMERA_VFS_CAP_LAYOUT_CLASS_FLEX  (1U << 16) /* produces flex-files (RFC 8435)  */
-#define CHIMERA_VFS_CAP_LAYOUT_CLASS_BLOCK (1U << 17) /* produces block volume (RFC 5663)*/
-#define CHIMERA_VFS_CAP_LAYOUT_CLASS_SCSI  (1U << 19) /* produces SCSI volume (RFC 8154) */
+#define CHIMERA_VFS_CAP_LAYOUT_SOURCE         (1U << 15)
+#define CHIMERA_VFS_CAP_LAYOUT_CLASS_FLEX     (1U << 16) /* produces flex-files (RFC 8435)  */
+#define CHIMERA_VFS_CAP_LAYOUT_CLASS_BLOCK    (1U << 17) /* produces block volume (RFC 5663)*/
+#define CHIMERA_VFS_CAP_LAYOUT_CLASS_SCSI     (1U << 19) /* produces SCSI volume (RFC 8154) */
+
+/* If set, the backend provides the memory for READ data itself (e.g. memfs
+ * returns refs to its in-memory SHARED block iovecs; the nfs proxy returns the
+ * buffers handed up by its upstream RPC reply).  If UNSET, the VFS core
+ * allocates the read buffers on the connection thread BEFORE dispatch and
+ * places them in request->read.iov (request->read.buffers_provided != 0); the
+ * backend MUST read into those buffers and must NOT allocate its own.  Keeping
+ * read-buffer ownership on the connection thread is what makes the delegation
+ * (worker-thread) read path safe without SHARED iovecs -- the buffers are
+ * allocated and released on the same (connection) thread.  See
+ * chimera_vfs_read_owned() / chimera_vfs_read_complete(). */
+#define CHIMERA_VFS_CAP_READ_PROVIDES_BUFFERS (1U << 20)
 
 struct chimera_vfs_module {
     /* Required

--- a/src/vfs/vfs_proc_read.c
+++ b/src/vfs/vfs_proc_read.c
@@ -9,6 +9,56 @@
 #include "vfs_attr_cache.h"
 #include "common/macros.h"
 
+/* Finalize VFS-core-provided read buffers on the success path.  The backend
+ * read the 4 KiB-aligned range into request->read.iov starting at buffer offset
+ * 0 (== file offset `offset - aligned_prefix`) and reported r_length (the bytes
+ * the client actually asked for and that exist).  Skip the leading prefix pad
+ * and trim trailing length so the iovecs sum to exactly r_length.  r_niov is
+ * kept at the full provided count so the reply path releases every buffer we
+ * allocated (trailing buffers simply shrink to length 0).  Mirrors what each
+ * backend used to do for its own buffers (e.g. diskfs_read_adjust_iovecs). */
+static void
+chimera_vfs_read_finalize_buffers(struct chimera_vfs_request *request)
+{
+    struct evpl_iovec *iov      = request->read.iov;
+    int                provided = request->read.buffers_provided;
+    uint32_t           prefix   = request->read.aligned_prefix;
+    uint64_t           total;
+    int                i;
+
+    if (request->read.r_length == 0) {
+        evpl_iovecs_release(request->thread->evpl, iov, provided);
+        request->read.r_niov = 0;
+        return;
+    }
+
+    iov[0].data   += prefix;
+    iov[0].length -= prefix;
+
+    total = 0;
+    for (i = 0; i < provided; i++) {
+        total += iov[i].length;
+    }
+
+    if (total > request->read.r_length) {
+        uint64_t excess = total - request->read.r_length;
+        int      last   = provided - 1;
+
+        while (excess > 0 && last >= 0) {
+            if (iov[last].length >= excess) {
+                iov[last].length -= excess;
+                excess            = 0;
+            } else {
+                excess          -= iov[last].length;
+                iov[last].length = 0;
+                last--;
+            }
+        }
+    }
+
+    request->read.r_niov = provided;
+} /* chimera_vfs_read_finalize_buffers */
+
 static void
 chimera_vfs_read_complete(struct chimera_vfs_request *request)
 {
@@ -17,6 +67,21 @@ chimera_vfs_read_complete(struct chimera_vfs_request *request)
     /* Release the implicit-lease pin taken before dispatch (no-op when none
      * was taken). */
     chimera_vfs_io_lease_release(request);
+
+    /* Account for buffers the VFS core allocated on behalf of a backend that
+     * does not provide its own read memory.  On success, trim them to the
+     * requested range; on any error the reply sends nothing, so release them
+     * here (the reply path only releases on the success leg). */
+    if (request->read.buffers_provided) {
+        if (request->status == CHIMERA_VFS_OK) {
+            chimera_vfs_read_finalize_buffers(request);
+        } else {
+            evpl_iovecs_release(request->thread->evpl, request->read.iov,
+                                request->read.buffers_provided);
+            request->read.r_niov   = 0;
+            request->read.r_length = 0;
+        }
+    }
 
     /* Only refresh the attr cache when the caller actually requested stat
      * attributes (e.g. NFSv3 READ, which carries post_op_attr).  READ is
@@ -82,8 +147,35 @@ chimera_vfs_read_owned(
     request->read.r_eof              = 0;
     request->read.r_attr.va_req_mask = attr_mask;
     request->read.r_attr.va_set_mask = 0;
+    request->read.buffers_provided   = 0;
+    request->read.aligned_prefix     = 0;
     request->proto_callback          = callback;
     request->proto_private_data      = private_data;
+
+    /* Buffer ownership.  Backends that advertise CAP_READ_PROVIDES_BUFFERS
+     * supply their own read memory (memfs returns refs to its SHARED in-memory
+     * blocks; the nfs proxy returns its upstream reply buffers).  For everyone
+     * else the VFS core allocates the buffers HERE, on the connection thread,
+     * padded to a 4 KiB boundary on both sides.  The (possibly worker-thread)
+     * backend then only fills them; because the connection thread that
+     * allocated them is also the one that releases them after the reply, no
+     * cross-thread / SHARED iovec is required. */
+    if (count > 0 &&
+        !(request->module->capabilities & CHIMERA_VFS_CAP_READ_PROVIDES_BUFFERS)) {
+        uint64_t aligned_offset = offset & ~4095ULL;
+        uint64_t aligned_end    = (offset + count + 4095ULL) & ~4095ULL;
+        uint32_t aligned_length = (uint32_t) (aligned_end - aligned_offset);
+        int      n;
+
+        n = evpl_iovec_alloc(thread->evpl, aligned_length, 4096, niov, 0,
+                             request->read.iov);
+        chimera_vfs_abort_if(n <= 0,
+                             "vfs read: failed to allocate %u read-buffer bytes",
+                             aligned_length);
+
+        request->read.buffers_provided = n;
+        request->read.aligned_prefix   = (uint32_t) (offset - aligned_offset);
+    }
 
     /* Mediate the read through the lease layer (acquire/hold the implicit
      * lease for a leaseless actor, recalling another holder's conflicting


### PR DESCRIPTION
## Summary

Make ownership of READ data buffers an explicit VFS contract instead of a per-backend accident.

Previously each backend allocated the read buffer on whatever thread ran the op. Under delegation that is a worker thread, but the reply (and, over RDMA, the RDMA write + the buffer release) runs on the connection thread. diskfs allocated **non-SHARED** buffers, so the cross-thread release corrupted the allocator free-list — observed as garbage RPC decodes, RDMA `WR_FLUSH_ERR`, and a SIGSEGV when async delegation was enabled over RDMA. The other backends papered over this by allocating `EVPL_IOVEC_FLAG_SHARED` (correct, but paying atomic-refcount cost on every read).

## Approach

New capability `CHIMERA_VFS_CAP_READ_PROVIDES_BUFFERS`:

- **Set** → the backend provides its own read memory. Used by `memfs` (zero-copy refs to its in-memory SHARED blocks — the cheapest path), the `nfs` proxy (it returns the buffers from its upstream reply), and `cairn` (still self-allocs a single contiguous SHARED buffer; conversion left as a follow-up — see below).
- **Unset** → the VFS core allocates the read buffers on the **connection thread** before dispatch, padded to a 4 KiB boundary on both sides, into `request->read.iov`. The backend only fills them and reports `r_length`/`r_eof`; `chimera_vfs_read_complete()` skips the leading prefix pad, trims to `r_length`, sets `r_niov`, and releases the buffers (on the same connection thread that allocated them). Used by `diskfs`, `linux`, `io_uring`.

Because the buffers are allocated and released on the connection thread, the worker-thread fill needs no SHARED iovec: the worker's refcount work all completes before the completion doorbell hands the request back, so the buffer is only ever touched by one thread at a time.

## Notes

- The default (no cap) is the safe connection-thread path, so new backends inherit correctness; opting in is the optimization.
- This covers READ only. Other ops that allocate reply buffers on the worker (readdir/readlink/getxattr/listxattr) still have the original latent cross-thread pattern and should be audited separately.
- `cairn` keeps the cap for now: its RocksDB extent fill writes a single contiguous buffer via direct pointer arithmetic; converting it to scatter across the provided iovecs via an append-blob cursor needs its own change + cairn test validation. A `TODO` marks it.

## Validation

`chimera/posix/fsx_*` (unaligned random read/write with shadow-compare) and `cthon_basic` across memfs / linux / cairn / diskfs-io_uring / diskfs-aio, over direct POSIX, NFS3, and NFS4, plus the `pynfs/read` suite — all pass. (io_uring's read path is covered by the KVM fsx suite; it mirrors the linux conversion.)
