### PR TITLE
vfs: map an oversize SETATTR size to FBIG on linux and io_uring

### DIFF
--- a/pynfs/stable-passing-tests.txt
+++ b/pynfs/stable-passing-tests.txt
@@ -3043,6 +3043,7 @@ chimera/pynfs/setattr/SATT12c_linux_nfs4.0
 chimera/pynfs/setattr/SATT12d_linux_nfs4.0
 chimera/pynfs/setattr/SATT12f_linux_nfs4.0
 chimera/pynfs/setattr/SATT12s_linux_nfs4.0
+chimera/pynfs/setattr/SATT12x_linux_nfs4.0
 chimera/pynfs/setattr/SATT13_linux_nfs4.0
 chimera/pynfs/setattr/SATT14_linux_nfs4.0
 chimera/pynfs/setattr/SATT16_linux_nfs4.0
@@ -3087,6 +3088,7 @@ chimera/pynfs/setattr/SATT12c_io_uring_nfs4.0
 chimera/pynfs/setattr/SATT12d_io_uring_nfs4.0
 chimera/pynfs/setattr/SATT12f_io_uring_nfs4.0
 chimera/pynfs/setattr/SATT12s_io_uring_nfs4.0
+chimera/pynfs/setattr/SATT12x_io_uring_nfs4.0
 chimera/pynfs/setattr/SATT13_io_uring_nfs4.0
 chimera/pynfs/setattr/SATT14_io_uring_nfs4.0
 chimera/pynfs/setattr/SATT16_io_uring_nfs4.0

--- a/src/vfs/io_uring/io_uring.c
+++ b/src/vfs/io_uring/io_uring.c
@@ -735,6 +735,17 @@ chimera_io_uring_setattr(
     }
 
     if (request->setattr.set_attr->va_set_mask & CHIMERA_VFS_ATTR_SIZE) {
+        // A size that does not fit in a signed off_t cannot be set on any
+        // backing filesystem (truncate would see it as negative and fail
+        // EINVAL).  Report it as "file too large" so NFS returns FBIG rather
+        // than INVAL.
+        if (request->setattr.set_attr->va_size > (uint64_t) INT64_MAX) {
+            chimera_restore_privilege(request->cred);
+            request->status = CHIMERA_VFS_EFBIG;
+            request->complete(request);
+            return;
+        }
+
         // fd might be O_PATH which doesn't support ftruncate directly,
         // so use truncate() on /proc/self/fd/N path which follows the symlink
         char procpath[64];

--- a/src/vfs/linux/linux.c
+++ b/src/vfs/linux/linux.c
@@ -216,6 +216,14 @@ chimera_linux_set_attrs(
     }
 
     if (set_mask & CHIMERA_VFS_ATTR_SIZE) {
+        // A size that does not fit in a signed off_t cannot be set on any
+        // backing filesystem (truncate would see it as negative and fail
+        // EINVAL).  Report it as "file too large" so NFS returns FBIG rather
+        // than INVAL.
+        if (attr->va_size > (uint64_t) INT64_MAX) {
+            return -EFBIG;
+        }
+
         // dirfd might be O_PATH which doesn't support ftruncate directly,
         // so use truncate() on /proc/self/fd/N path which follows the symlink
         char procpath[64];


### PR DESCRIPTION
## Summary

`SETATTR` with the size attribute set to a value that does not fit in a signed `off_t` (for example `U64_MAX`) wrapped to a negative length. `truncate()` then failed with `EINVAL`, and NFS returned `NFS4ERR_INVAL`. RFC 7530 expects a size the server cannot accommodate to yield `NFS4ERR_FBIG` (or succeed).

This rejects such a size up front with `EFBIG` (→ `NFS4ERR_FBIG`) in the `linux` and `io_uring` backends, before calling `truncate`. The other backends (memfs, diskfs, cairn) already returned an accepted status.

## Tests

Enables pynfs 4.0 `setattr/SATT12x` (`testMaxSizeFile`) for `linux` and `io_uring` (memfs, diskfs_io_uring, diskfs_aio, cairn already enabled). Verified passing in Release and Debug (ASan) builds.