### PR TITLE
io_uring: request the full statx attribute mask

### DIFF
--- a/src/vfs/io_uring/io_uring.c
+++ b/src/vfs/io_uring/io_uring.c
@@ -304,7 +304,8 @@ chimera_io_uring_reap(
 
                         sqe = chimera_io_uring_get_sqe(thread, request, 2, 0);
 
-                        io_uring_prep_statx(sqe, parent_fd, "", AT_EMPTY_PATH, AT_STATX_SYNC_AS_STAT, dir_stx);
+                        io_uring_prep_statx(sqe, parent_fd, "", AT_EMPTY_PATH | AT_STATX_SYNC_AS_STAT,
+                                            CHIMERA_IO_URING_STATX_MASK, dir_stx);
 
                         evpl_defer(thread->evpl, &thread->deferral);
 
@@ -375,11 +376,13 @@ chimera_io_uring_reap(
 
                     sqe = chimera_io_uring_get_sqe(thread, request, 1, 0);
 
-                    io_uring_prep_statx(sqe, parent_fd, fullname, 0, AT_STATX_SYNC_AS_STAT, stx);
+                    io_uring_prep_statx(sqe, parent_fd, fullname, AT_STATX_SYNC_AS_STAT,
+                                        CHIMERA_IO_URING_STATX_MASK, stx);
 
                     sqe = chimera_io_uring_get_sqe(thread, request, 2, 0);
 
-                    io_uring_prep_statx(sqe, parent_fd, "", AT_EMPTY_PATH, AT_STATX_SYNC_AS_STAT, dir_stx);
+                    io_uring_prep_statx(sqe, parent_fd, "", AT_EMPTY_PATH | AT_STATX_SYNC_AS_STAT,
+                                        CHIMERA_IO_URING_STATX_MASK, dir_stx);
 
                     evpl_defer(thread->evpl, &thread->deferral);
                 } else if (handle->slot == 1) {
@@ -626,7 +629,9 @@ chimera_io_uring_getattr(
 
     stx = (struct statx *) scratch;
 
-    io_uring_prep_statx(sqe, fd, "", AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW, AT_STATX_SYNC_AS_STAT, stx);
+    io_uring_prep_statx(sqe, fd, "",
+                        AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW | AT_STATX_SYNC_AS_STAT,
+                        CHIMERA_IO_URING_STATX_MASK, stx);
 
     evpl_defer(thread->evpl, &thread->deferral);
 } /* io_uring_getattr */
@@ -893,7 +898,8 @@ chimera_io_uring_lookup_at(
 
     sqe = chimera_io_uring_get_sqe(thread, request, 0, 0);
 
-    io_uring_prep_statx(sqe, parent_fd, fullname, AT_SYMLINK_NOFOLLOW, AT_STATX_SYNC_AS_STAT, stx);
+    io_uring_prep_statx(sqe, parent_fd, fullname, AT_SYMLINK_NOFOLLOW | AT_STATX_SYNC_AS_STAT,
+                        CHIMERA_IO_URING_STATX_MASK, stx);
 
     evpl_defer(thread->evpl, &thread->deferral);
 } /* io_uring_lookup */
@@ -1346,7 +1352,8 @@ chimera_io_uring_read(
         request->read.r_eof    = 0;
         if (request->read.r_attr.va_req_mask & CHIMERA_VFS_ATTR_MASK_STAT) {
             sqe = chimera_io_uring_get_sqe(thread, request, 1, 0);
-            io_uring_prep_statx(sqe, fd, "", AT_EMPTY_PATH, AT_STATX_SYNC_AS_STAT, stx);
+            io_uring_prep_statx(sqe, fd, "", AT_EMPTY_PATH | AT_STATX_SYNC_AS_STAT,
+                                CHIMERA_IO_URING_STATX_MASK, stx);
             evpl_defer(thread->evpl, &thread->deferral);
         } else {
             /* No attrs requested and no readv to submit: complete inline. */
@@ -1395,7 +1402,8 @@ chimera_io_uring_read(
     io_uring_prep_readv(sqe, fd, iov, i, request->read.offset);
 
     sqe = chimera_io_uring_get_sqe(thread, request, 1, 0);
-    io_uring_prep_statx(sqe, fd, "", AT_EMPTY_PATH, AT_STATX_SYNC_AS_STAT, stx);
+    io_uring_prep_statx(sqe, fd, "", AT_EMPTY_PATH | AT_STATX_SYNC_AS_STAT,
+                        CHIMERA_IO_URING_STATX_MASK, stx);
 
     evpl_defer(thread->evpl, &thread->deferral);
 } /* chimera_io_uring_read */


### PR DESCRIPTION
## Summary

The io_uring `statx` submissions passed `AT_STATX_SYNC_AS_STAT` (which is `0`) as the statx **mask** argument instead of as a flag. With a zero mask the kernel does not populate the timestamp fields, so `getattr` — and the read, lookup, mkdir and open post-attr paths — returned `ctime`/`mtime`/`atime` of `0`.

This is usually hidden by the attribute cache, which is seeded from the open/create path that uses the correct mask. But a `WRITE` clears its post-attrs and thus invalidates the cache entry; the next `GETATTR` then fell through to the zero-mask `statx` and reported `ctime == 0`. A standalone liburing reproduction confirmed `mask=0` returns `ctime=0` while `mask=STATX_BASIC_STATS` returns the real value.

The fix passes `STATX_BASIC_STATS` as the mask (keeping `AT_STATX_SYNC_AS_STAT` as a flag) on every `statx` submission.

## Note on WRT18

An earlier revision of this PR also enabled `write/WRT18` (`testChangeGranularityWrite`) for `linux`/`io_uring`; **CI showed that was unsound and it has been dropped.** WRT18 requires the change attribute to strictly advance across four writes in one compound. For the passthrough backends the change attribute is the host file's `ctime`, whose resolution is bounded by the backing filesystem — on a coarse-granularity fs (the CI devcontainer's) the writes share a `ctime`, so even the `linux` backend (which never had the zero-mask bug) failed. WRT18 stays enabled only for memfs/diskfs/cairn, which stamp `ctime` from `clock_gettime` per op. Making the passthrough change attribute monotonic (e.g. via `STATX_CHANGE_COOKIE` / `i_version`) is a possible follow-up.

## Tests

No new test enabled. The full io_uring suite (getattr/read/lookup/create/setattr) passes, exercising every changed statx path; `ctest` was green except for the now-removed WRT18 entries.