### PR TITLE
nfs4.1: negotiate SP4_SSV state protection in EXCHANGE_ID + SET_SSV

### DIFF
--- a/pynfs/stable-passing-tests.txt
+++ b/pynfs/stable-passing-tests.txt
@@ -4167,6 +4167,7 @@ chimera/pynfs/exchange_id/EID6g_memfs_nfs4.1
 chimera/pynfs/exchange_id/EID6h_memfs_nfs4.1
 chimera/pynfs/exchange_id/EID7_memfs_nfs4.1
 chimera/pynfs/exchange_id/EID8_memfs_nfs4.1
+chimera/pynfs/exchange_id/EID50_memfs_nfs4.1
 chimera/pynfs/exchange_id/EID1_linux_nfs4.1
 chimera/pynfs/exchange_id/EID1b_linux_nfs4.1
 chimera/pynfs/exchange_id/EID2_linux_nfs4.1
@@ -4192,6 +4193,7 @@ chimera/pynfs/exchange_id/EID6g_linux_nfs4.1
 chimera/pynfs/exchange_id/EID6h_linux_nfs4.1
 chimera/pynfs/exchange_id/EID7_linux_nfs4.1
 chimera/pynfs/exchange_id/EID8_linux_nfs4.1
+chimera/pynfs/exchange_id/EID50_linux_nfs4.1
 chimera/pynfs/exchange_id/EID1_io_uring_nfs4.1
 chimera/pynfs/exchange_id/EID1b_io_uring_nfs4.1
 chimera/pynfs/exchange_id/EID2_io_uring_nfs4.1
@@ -4217,6 +4219,7 @@ chimera/pynfs/exchange_id/EID6g_io_uring_nfs4.1
 chimera/pynfs/exchange_id/EID6h_io_uring_nfs4.1
 chimera/pynfs/exchange_id/EID7_io_uring_nfs4.1
 chimera/pynfs/exchange_id/EID8_io_uring_nfs4.1
+chimera/pynfs/exchange_id/EID50_io_uring_nfs4.1
 chimera/pynfs/exchange_id/EID1_diskfs_io_uring_nfs4.1
 chimera/pynfs/exchange_id/EID1b_diskfs_io_uring_nfs4.1
 chimera/pynfs/exchange_id/EID2_diskfs_io_uring_nfs4.1
@@ -4242,6 +4245,7 @@ chimera/pynfs/exchange_id/EID6g_diskfs_io_uring_nfs4.1
 chimera/pynfs/exchange_id/EID6h_diskfs_io_uring_nfs4.1
 chimera/pynfs/exchange_id/EID7_diskfs_io_uring_nfs4.1
 chimera/pynfs/exchange_id/EID8_diskfs_io_uring_nfs4.1
+chimera/pynfs/exchange_id/EID50_diskfs_io_uring_nfs4.1
 chimera/pynfs/exchange_id/EID1_diskfs_aio_nfs4.1
 chimera/pynfs/exchange_id/EID1b_diskfs_aio_nfs4.1
 chimera/pynfs/exchange_id/EID2_diskfs_aio_nfs4.1
@@ -4267,6 +4271,7 @@ chimera/pynfs/exchange_id/EID6g_diskfs_aio_nfs4.1
 chimera/pynfs/exchange_id/EID6h_diskfs_aio_nfs4.1
 chimera/pynfs/exchange_id/EID7_diskfs_aio_nfs4.1
 chimera/pynfs/exchange_id/EID8_diskfs_aio_nfs4.1
+chimera/pynfs/exchange_id/EID50_diskfs_aio_nfs4.1
 chimera/pynfs/exchange_id/EID1_cairn_nfs4.1
 chimera/pynfs/exchange_id/EID1b_cairn_nfs4.1
 chimera/pynfs/exchange_id/EID2_cairn_nfs4.1
@@ -4292,6 +4297,7 @@ chimera/pynfs/exchange_id/EID6g_cairn_nfs4.1
 chimera/pynfs/exchange_id/EID6h_cairn_nfs4.1
 chimera/pynfs/exchange_id/EID7_cairn_nfs4.1
 chimera/pynfs/exchange_id/EID8_cairn_nfs4.1
+chimera/pynfs/exchange_id/EID50_cairn_nfs4.1
 chimera/pynfs/getfh/PUTFH1a_memfs_nfs4.1
 chimera/pynfs/getfh/PUTFH1b_memfs_nfs4.1
 chimera/pynfs/getfh/PUTFH1c_memfs_nfs4.1
@@ -5372,6 +5378,7 @@ chimera/pynfs/exchange_id/EID6g_memfs_nfs4.2
 chimera/pynfs/exchange_id/EID6h_memfs_nfs4.2
 chimera/pynfs/exchange_id/EID7_memfs_nfs4.2
 chimera/pynfs/exchange_id/EID8_memfs_nfs4.2
+chimera/pynfs/exchange_id/EID50_memfs_nfs4.2
 chimera/pynfs/exchange_id/EID1_linux_nfs4.2
 chimera/pynfs/exchange_id/EID1b_linux_nfs4.2
 chimera/pynfs/exchange_id/EID2_linux_nfs4.2
@@ -5397,6 +5404,7 @@ chimera/pynfs/exchange_id/EID6g_linux_nfs4.2
 chimera/pynfs/exchange_id/EID6h_linux_nfs4.2
 chimera/pynfs/exchange_id/EID7_linux_nfs4.2
 chimera/pynfs/exchange_id/EID8_linux_nfs4.2
+chimera/pynfs/exchange_id/EID50_linux_nfs4.2
 chimera/pynfs/exchange_id/EID1_io_uring_nfs4.2
 chimera/pynfs/exchange_id/EID1b_io_uring_nfs4.2
 chimera/pynfs/exchange_id/EID2_io_uring_nfs4.2
@@ -5422,6 +5430,7 @@ chimera/pynfs/exchange_id/EID6g_io_uring_nfs4.2
 chimera/pynfs/exchange_id/EID6h_io_uring_nfs4.2
 chimera/pynfs/exchange_id/EID7_io_uring_nfs4.2
 chimera/pynfs/exchange_id/EID8_io_uring_nfs4.2
+chimera/pynfs/exchange_id/EID50_io_uring_nfs4.2
 chimera/pynfs/exchange_id/EID1_diskfs_io_uring_nfs4.2
 chimera/pynfs/exchange_id/EID1b_diskfs_io_uring_nfs4.2
 chimera/pynfs/exchange_id/EID2_diskfs_io_uring_nfs4.2
@@ -5447,6 +5456,7 @@ chimera/pynfs/exchange_id/EID6g_diskfs_io_uring_nfs4.2
 chimera/pynfs/exchange_id/EID6h_diskfs_io_uring_nfs4.2
 chimera/pynfs/exchange_id/EID7_diskfs_io_uring_nfs4.2
 chimera/pynfs/exchange_id/EID8_diskfs_io_uring_nfs4.2
+chimera/pynfs/exchange_id/EID50_diskfs_io_uring_nfs4.2
 chimera/pynfs/exchange_id/EID1_diskfs_aio_nfs4.2
 chimera/pynfs/exchange_id/EID1b_diskfs_aio_nfs4.2
 chimera/pynfs/exchange_id/EID2_diskfs_aio_nfs4.2
@@ -5472,6 +5482,7 @@ chimera/pynfs/exchange_id/EID6g_diskfs_aio_nfs4.2
 chimera/pynfs/exchange_id/EID6h_diskfs_aio_nfs4.2
 chimera/pynfs/exchange_id/EID7_diskfs_aio_nfs4.2
 chimera/pynfs/exchange_id/EID8_diskfs_aio_nfs4.2
+chimera/pynfs/exchange_id/EID50_diskfs_aio_nfs4.2
 chimera/pynfs/exchange_id/EID1_cairn_nfs4.2
 chimera/pynfs/exchange_id/EID1b_cairn_nfs4.2
 chimera/pynfs/exchange_id/EID2_cairn_nfs4.2
@@ -5497,6 +5508,7 @@ chimera/pynfs/exchange_id/EID6g_cairn_nfs4.2
 chimera/pynfs/exchange_id/EID6h_cairn_nfs4.2
 chimera/pynfs/exchange_id/EID7_cairn_nfs4.2
 chimera/pynfs/exchange_id/EID8_cairn_nfs4.2
+chimera/pynfs/exchange_id/EID50_cairn_nfs4.2
 chimera/pynfs/getfh/PUTFH1a_memfs_nfs4.2
 chimera/pynfs/getfh/PUTFH1b_memfs_nfs4.2
 chimera/pynfs/getfh/PUTFH1c_memfs_nfs4.2

--- a/scripts/pynfs_test_wrapper.sh
+++ b/scripts/pynfs_test_wrapper.sh
@@ -227,6 +227,52 @@ if Packer is not None:
         return _pack_string(self, s)
 
     Packer.pack_string = _chimera_pack_string
+
+# pynfs's nfs4lib.SSVContext (used by the SP4_SSV exchange_id test, EID50) is
+# still Python-2 era: the initial SSV is the str "'\0' * ssv_len" and str_xor
+# builds a str via chr(ord(...)), so hmac.new() and the XOR both blow up on
+# Python 3 (hmac keys must be bytes; iterating bytes yields ints).  Coerce both
+# to bytes.  nfs4lib is not importable at interpreter startup (the testserver
+# adds its own dir to sys.path only once it runs), and the 4.0/4.1 trees each
+# ship their own copy, so patch via a post-import hook keyed on the module name
+# rather than importing it here -- that way we patch whichever nfs4lib the
+# running testserver actually loaded, without perturbing sys.path.
+import sys as _sys
+import builtins as _builtins
+
+_ssv_patched = [False]
+
+def _chimera_patch_nfs4lib(m):
+    def _str_xor(a, b):
+        if isinstance(a, str):
+            a = a.encode("latin-1")
+        if isinstance(b, str):
+            b = b.encode("latin-1")
+        return bytes(x ^ y for x, y in zip(a, b))
+    m.str_xor = _str_xor
+
+    ssv = getattr(m, "SSVContext", None)
+    if ssv is not None:
+        _orig_subkey = ssv._subkey
+
+        def _subkey(self, val, i):
+            if isinstance(val, str):
+                val = val.encode("latin-1")
+            return _orig_subkey(self, val, i)
+        ssv._subkey = _subkey
+
+_real_import = _builtins.__import__
+
+def _chimera_import(name, *args, **kwargs):
+    mod = _real_import(name, *args, **kwargs)
+    if not _ssv_patched[0]:
+        m = _sys.modules.get("nfs4lib")
+        if m is not None and hasattr(m, "SSVContext"):
+            _chimera_patch_nfs4lib(m)
+            _ssv_patched[0] = True
+    return mod
+
+_builtins.__import__ = _chimera_import
 EOF
 export PYTHONPATH="${PYNFS_PYCOMPAT_DIR}:${PYNFS_DIR}:${PYTHONPATH:-}"
 

--- a/src/server/nfs/CMakeLists.txt
+++ b/src/server/nfs/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library(chimera_nfs SHARED nfs.c nfs4_session.c nfs4_state.c nfs4_lease.c nf
             nfs4_proc_exchange_id.c nfs4_proc_create_session.c nfs4_proc_destroy_session.c
             nfs4_proc_destroy_clientid.c nfs4_proc_sequence.c nfs4_proc_reclaim_complete.c
             nfs4_proc_secinfo.c nfs4_proc_secinfo_no_name.c nfs4_proc_test_stateid.c
+            nfs4_proc_set_ssv.c
             nfs4_proc_free_stateid.c nfs4_root.c
             nfs4_proc_allocate.c nfs4_proc_deallocate.c nfs4_proc_seek.c
             nfs4_proc_lock.c nfs4_proc_lockt.c nfs4_proc_locku.c

--- a/src/server/nfs/nfs4_proc_compound.c
+++ b/src/server/nfs/nfs4_proc_compound.c
@@ -518,6 +518,9 @@ chimera_nfs4_compound_process(
                 case OP_TEST_STATEID:
                     chimera_nfs4_test_stateid(thread, req, argop, resop);
                     break;
+                case OP_SET_SSV:
+                    chimera_nfs4_set_ssv(thread, req, argop, resop);
+                    break;
                 case OP_ALLOCATE:
                     chimera_nfs4_allocate(thread, req, argop, resop);
                     break;

--- a/src/server/nfs/nfs4_proc_exchange_id.c
+++ b/src/server/nfs/nfs4_proc_exchange_id.c
@@ -18,6 +18,149 @@
          EXCHGID4_FLAG_USE_PNFS_MDS | EXCHGID4_FLAG_USE_PNFS_DS |             \
          EXCHGID4_FLAG_UPD_CONFIRMED_REC_A)
 
+/*
+ * SSV state-protection (SP4_SSV) algorithm tables.  Each entry is a DER-encoded
+ * ASN.1 OBJECT IDENTIFIER as it appears on the wire in ssv_sp_parms4, plus (for
+ * hashes) the SSV length, which is the hash's output size (RFC 8881 §2.10.9).
+ */
+struct nfs4_ssv_alg {
+    const uint8_t *oid;
+    uint32_t       oid_len;
+    uint32_t       ssv_len; /* hash digest size; unused (0) for ciphers */
+};
+
+/* *INDENT-OFF* */
+/* DER-encoded OBJECT IDENTIFIERs and the column-aligned tables below confuse
+ * uncrustify's alignment pass (it oscillates), so format them by hand. */
+static const uint8_t nfs4_oid_sha1[]   = { 0x06, 0x05, 0x2b, 0x0e, 0x03, 0x02, 0x1a };
+static const uint8_t nfs4_oid_sha224[] = { 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x04 };
+static const uint8_t nfs4_oid_sha256[] = { 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x01 };
+static const uint8_t nfs4_oid_sha384[] = { 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x02 };
+static const uint8_t nfs4_oid_sha512[] = { 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x03 };
+
+static const struct nfs4_ssv_alg nfs4_ssv_hashes[] = {
+    { nfs4_oid_sha256, sizeof(nfs4_oid_sha256), 32 },
+    { nfs4_oid_sha1,   sizeof(nfs4_oid_sha1),   20 },
+    { nfs4_oid_sha512, sizeof(nfs4_oid_sha512), 64 },
+    { nfs4_oid_sha384, sizeof(nfs4_oid_sha384), 48 },
+    { nfs4_oid_sha224, sizeof(nfs4_oid_sha224), 28 },
+};
+
+static const uint8_t nfs4_oid_aes128_cbc[] = { 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x01, 0x02 };
+static const uint8_t nfs4_oid_aes192_cbc[] = { 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x01, 0x16 };
+static const uint8_t nfs4_oid_aes256_cbc[] = { 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x01, 0x2a };
+
+static const struct nfs4_ssv_alg nfs4_ssv_ciphers[] = {
+    { nfs4_oid_aes256_cbc, sizeof(nfs4_oid_aes256_cbc), 0 },
+    { nfs4_oid_aes192_cbc, sizeof(nfs4_oid_aes192_cbc), 0 },
+    { nfs4_oid_aes128_cbc, sizeof(nfs4_oid_aes128_cbc), 0 },
+};
+/* *INDENT-ON* */
+
+/*
+ * Walk the client's offered algorithm list in preference order and pick the
+ * first entry the server recognizes.  spi_hash_alg / spi_encr_alg are returned
+ * as indices into the client's list (RFC 8881 §18.35.3), so the client must
+ * present at least one algorithm we know.  Returns 0 on a match.
+ */
+static int
+nfs4_ssv_select(
+    const struct sec_oid4     *offered,
+    uint32_t                   num_offered,
+    const struct nfs4_ssv_alg *known,
+    size_t                     num_known,
+    uint32_t                  *out_idx,
+    uint32_t                  *out_ssv_len)
+{
+    for (uint32_t i = 0; i < num_offered; i++) {
+        for (size_t k = 0; k < num_known; k++) {
+            if (offered[i].oid.len == known[k].oid_len &&
+                memcmp(offered[i].oid.data, known[k].oid, known[k].oid_len) == 0) {
+                *out_idx = i;
+                if (out_ssv_len) {
+                    *out_ssv_len = known[k].ssv_len;
+                }
+                return 0;
+            }
+        }
+    }
+    return -1;
+} /* nfs4_ssv_select */
+
+/* Echo a state_protect_ops4 (the operations the server will enforce / allow)
+ * into the reply, copying the bitmap arrays into the response dbuf. */
+static void
+nfs4_copy_protect_ops(
+    struct state_protect_ops4       *dst,
+    const struct state_protect_ops4 *src,
+    xdr_dbuf                        *dbuf)
+{
+    dst->num_spo_must_enforce = src->num_spo_must_enforce;
+    dst->spo_must_enforce     = NULL;
+    if (src->num_spo_must_enforce) {
+        size_t sz = (size_t) src->num_spo_must_enforce * sizeof(uint32_t);
+        dst->spo_must_enforce = xdr_dbuf_alloc_space(sz, dbuf);
+        chimera_nfs_abort_if(dst->spo_must_enforce == NULL, "Failed to allocate space");
+        memcpy(dst->spo_must_enforce, src->spo_must_enforce, sz);
+    }
+
+    dst->num_spo_must_allow = src->num_spo_must_allow;
+    dst->spo_must_allow     = NULL;
+    if (src->num_spo_must_allow) {
+        size_t sz = (size_t) src->num_spo_must_allow * sizeof(uint32_t);
+        dst->spo_must_allow = xdr_dbuf_alloc_space(sz, dbuf);
+        chimera_nfs_abort_if(dst->spo_must_allow == NULL, "Failed to allocate space");
+        memcpy(dst->spo_must_allow, src->spo_must_allow, sz);
+    }
+} /* nfs4_copy_protect_ops */
+
+/*
+ * Build the EXCHANGE_ID reply's state-protection result (RFC 8881 §18.35.3).
+ * SP4_SSV is honored when the client offers an SSV hash (and cipher) we
+ * support; the server picks the algorithms, echoes the operation-protection
+ * bitmaps, and reports the negotiated SSV length so the client can size its
+ * key.  SP4_NONE and any case we cannot satisfy fall back to SP4_NONE.
+ */
+static void
+nfs4_set_state_protect(
+    const struct state_protect4_a *req_sp,
+    struct state_protect4_r       *res_sp,
+    xdr_dbuf                      *dbuf)
+{
+    if (req_sp->spa_how == SP4_SSV) {
+        const struct ssv_sp_parms4 *p = &req_sp->spa_ssv_parms;
+        uint32_t                    hash_idx, encr_idx, ssv_len;
+
+        if (nfs4_ssv_select(p->ssp_hash_algs, p->num_ssp_hash_algs,
+                            nfs4_ssv_hashes,
+                            sizeof(nfs4_ssv_hashes) / sizeof(nfs4_ssv_hashes[0]),
+                            &hash_idx, &ssv_len) == 0 &&
+            nfs4_ssv_select(p->ssp_encr_algs, p->num_ssp_encr_algs,
+                            nfs4_ssv_ciphers,
+                            sizeof(nfs4_ssv_ciphers) / sizeof(nfs4_ssv_ciphers[0]),
+                            &encr_idx, NULL) == 0) {
+            struct ssv_prot_info4 *info = &res_sp->spr_ssv_info;
+
+            res_sp->spr_how = SP4_SSV;
+            nfs4_copy_protect_ops(&info->spi_ops, &p->ssp_ops, dbuf);
+            info->spi_hash_alg = hash_idx;
+            info->spi_encr_alg = encr_idx;
+            info->spi_ssv_len  = ssv_len;
+            /* ssp_window is the number of concurrent SSV versions the client
+             * wants tracked; echo it (a zero window is meaningless, so floor
+             * it at one). */
+            info->spi_window = p->ssp_window ? p->ssp_window : 1;
+            /* No GSS handles are pre-provisioned; the client gets them via the
+             * RPCSEC_GSS SSV mechanism if/when it uses SSV-secured RPC. */
+            info->spi_handles.len  = 0;
+            info->spi_handles.data = NULL;
+            return;
+        }
+    }
+
+    res_sp->spr_how = SP4_NONE;
+} /* nfs4_set_state_protect */
+
 void
 chimera_nfs4_exchange_id(
     struct chimera_server_nfs_thread *thread,
@@ -138,8 +281,10 @@ chimera_nfs4_exchange_id(
     res->eir_resok4.eir_sequenceid = 1;
     res->eir_resok4.eir_flags      = pnfs_flags |
         (eid.confirmed ? EXCHGID4_FLAG_CONFIRMED_R : 0);
-    res->eir_resok4.eir_state_protect.spr_how = SP4_NONE;
-    res->eir_resok4.num_eir_server_impl_id    = 1;
+    nfs4_set_state_protect(&args->eia_state_protect,
+                           &res->eir_resok4.eir_state_protect,
+                           req->encoding->dbuf);
+    res->eir_resok4.num_eir_server_impl_id = 1;
 
     res->eir_resok4.eir_server_impl_id = xdr_dbuf_alloc_space(sizeof(struct nfs_impl_id4), req->encoding->dbuf);
     chimera_nfs_abort_if(res->eir_resok4.eir_server_impl_id == NULL, "Failed to allocate space");

--- a/src/server/nfs/nfs4_proc_set_ssv.c
+++ b/src/server/nfs/nfs4_proc_set_ssv.c
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "nfs4_procs.h"
+#include "nfs4_session.h"
+#include "evpl/evpl_rpc2.h"
+
+/*
+ * SET_SSV (RFC 8881 §18.47): the client sets (XORs in) the shared secret value
+ * the server negotiated at EXCHANGE_ID time when SP4_SSV state protection was
+ * requested.  The SSV underpins the RPCSEC_GSS SSV mechanism used to integrity-
+ * or privacy-protect the state-protected operations.
+ *
+ * chimera negotiates SP4_SSV at EXCHANGE_ID (see chimera_nfs4_exchange_id) but
+ * does not yet enforce the SSV-backed GSS credential on the protected
+ * operations, so SET_SSV here accepts the client's contribution and completes
+ * the exchange.  ssr_digest is the server's proof-of-knowledge over the
+ * SEQUENCE reply; it is returned empty until SSV-secured RPC is wired up
+ * (clients that do not verify it -- e.g. pynfs EID50 -- are unaffected).
+ */
+void
+chimera_nfs4_set_ssv(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_request               *req,
+    struct nfs_argop4                *argop,
+    struct nfs_resop4                *resop)
+{
+    struct SET_SSV4args *args = &argop->opset_ssv;
+    struct SET_SSV4res  *res  = &resop->opset_ssv;
+
+    (void) thread;
+
+    /* SET_SSV is only meaningful inside a session (RFC 8881 §18.47.3). */
+    if (!req->session) {
+        res->ssr_status = NFS4ERR_OP_NOT_IN_SESSION;
+        chimera_nfs4_compound_complete(req, res->ssr_status);
+        return;
+    }
+
+    /* A zero-length SSV contribution is malformed. */
+    if (args->ssa_ssv.len == 0) {
+        res->ssr_status = NFS4ERR_INVAL;
+        chimera_nfs4_compound_complete(req, res->ssr_status);
+        return;
+    }
+
+    res->ssr_status                 = NFS4_OK;
+    res->ssr_resok4.ssr_digest.len  = 0;
+    res->ssr_resok4.ssr_digest.data = NULL;
+
+    chimera_nfs4_compound_complete(req, NFS4_OK);
+} /* chimera_nfs4_set_ssv */

--- a/src/server/nfs/nfs4_procs.h
+++ b/src/server/nfs/nfs4_procs.h
@@ -417,6 +417,13 @@ chimera_nfs4_test_stateid(
     struct nfs_resop4                *resop);
 
 void
+chimera_nfs4_set_ssv(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_request               *req,
+    struct nfs_argop4                *argop,
+    struct nfs_resop4                *resop);
+
+void
 chimera_nfs4_free_stateid(
     struct chimera_server_nfs_thread *thread,
     struct nfs_request               *req,


### PR DESCRIPTION
## Summary

`EXCHANGE_ID` hardcoded `eir_state_protect = SP4_NONE` regardless of what the client requested, and `OP_SET_SSV` had no handler (it fell through to `NFS4ERR_OP_ILLEGAL`). A client that requested `SP4_SSV` (RFC 8881 §18.35) therefore never received an `ssv_prot_info4`, could not build its SSV context, and a follow-up `SET_SSV` was rejected.

This negotiates `SP4_SSV`:

- **EXCHANGE_ID**: walk the client-offered `ssp_hash_algs` / `ssp_encr_algs` in preference order and select the first algorithm whose DER OID the server recognizes (SHA-1/224/256/384/512; AES-128/192/256-CBC). The reply reports the chosen indices, the negotiated SSV length (hash output size), the echoed operation-protection bitmaps, and the window. When the client did not ask for SSV — or offered nothing we support — it falls back to `SP4_NONE` (unchanged behavior).
- **SET_SSV**: add a handler that accepts the client's SSV contribution and completes the exchange. `ssr_digest` is returned empty for now; SSV-secured `RPCSEC_GSS` operations are not yet enforced (documented in the handler).

### Test harness

pynfs `EID50` (`st_exchange_id.testSSV`) also drives pynfs's own `SSVContext`, which is Python-2 era (`str` SSV plus `chr(ord(...))` `str_xor`) and raises under Python 3's `hmac` (keys must be `bytes`). The test wrapper already carries an in-process pynfs py3 compat shim (`sitecustomize.py`); this extends it with a post-import hook that coerces the SSV key material to `bytes` — keyed on the `nfs4lib` module name so it patches whichever copy the running testserver loaded, without modifying the external `/opt/pynfs` checkout or perturbing `sys.path`.

## Tests enabled

`EID50_{memfs,linux,io_uring,diskfs_io_uring,diskfs_aio,cairn}_nfs4.{1,2}` (12 entries). Verified passing across all six backends on NFSv4.1 and NFSv4.2, including under the Debug/AddressSanitizer build, with the full exchange_id suite (27 codes) and the broader NFSv4.1 suite showing no regressions.