### PR TITLE
pynfs: wait for daemon readiness in the pNFS flex wrapper

### DIFF
--- a/scripts/pynfs_pnfs_test_wrapper.sh
+++ b/scripts/pynfs_pnfs_test_wrapper.sh
@@ -93,25 +93,39 @@ cat > "$MDS_CONFIG" << EOF
 }
 EOF
 
-wait_for_port() {
-    local port="$1" pid="$2"
-    for i in $(seq 1 50); do
-        ip netns exec "${NETNS_NAME}" bash -c "echo > /dev/tcp/127.0.0.1/${port}" 2>/dev/null && return 0
+# Wait until a chimera daemon is genuinely ready: both its log says so and the
+# NFS port accepts.  The port can start listening during protocol init -- before
+# a metadata server has mounted the data server and resolved its backing root --
+# so gating on the port alone races under load (the MDS appears "up" while it is
+# still resolving /ds0).  Requiring "Server is ready." (logged only after the
+# mount + backing-root resolution complete) closes that window.
+wait_for_ready() {
+    local port="$1" pid="$2" log="$3"
+    for i in $(seq 1 100); do
+        if grep -q "Server is ready." "$log" 2>/dev/null &&
+           ip netns exec "${NETNS_NAME}" bash -c "echo > /dev/tcp/127.0.0.1/${port}" 2>/dev/null; then
+            return 0
+        fi
         kill -0 "$pid" 2>/dev/null || { echo "chimera (pid $pid) exited early" >&2; return 1; }
         sleep 0.1
     done
-    echo "timed out waiting for 127.0.0.1:${port}" >&2; return 1
+    echo "timed out waiting for 127.0.0.1:${port} to become ready" >&2; return 1
 }
 
 ip netns add "${NETNS_NAME}"
 ip netns exec "${NETNS_NAME}" ip link set lo up
 
+# The data server must be fully ready before the metadata server starts, since
+# the MDS nfs-mounts it during its own startup.
 DS_PID=$(run_chimera "$DS_CONFIG" "$DS_LOG")
-wait_for_port "$DS_PORT" "$DS_PID" || exit 1
+wait_for_ready "$DS_PORT" "$DS_PID" "$DS_LOG" || exit 1
 echo "=== pNFS data server up on 127.0.0.1:${DS_PORT} ==="
 
+# The MDS logs "backing root resolved" before "Server is ready.", so once it is
+# ready the backing root is guaranteed resolved -- the grep below is then a hard
+# confirmation rather than a racy probe.
 MDS_PID=$(run_chimera "$MDS_CONFIG" "$MDS_LOG")
-wait_for_port "$MDS_PORT" "$MDS_PID" || exit 1
+wait_for_ready "$MDS_PORT" "$MDS_PID" "$MDS_LOG" || exit 1
 grep -q "backing root resolved" "$MDS_LOG" || {
     echo "MDS did not resolve its data-server backing root:" >&2
     grep -iE "pNFS|backing|nfs|error" "$MDS_LOG" | tail -10 >&2; exit 1


### PR DESCRIPTION
## Summary

The flex (pNFS) test wrapper brings up a data server (DS) and a metadata server (MDS), then runs pynfs's `flex` suite against the MDS. It gated startup on the **TCP port accepting** a connection:

- start DS → wait for `:2050` to accept → start MDS → wait for `:2049` to accept → `grep "backing root resolved"` in the MDS log.

But a chimera daemon starts listening during *protocol initialization* — **before** a metadata server has nfs-mounted its data server and resolved its backing root. Under the heavy parallel ASan CI run, the MDS port comes up while it is still resolving `/ds0`, so the one-shot grep runs too early and the test aborts with:

```
MDS did not resolve its data-server backing root
```

a load-dependent false failure that clusters across flex tests (`FFLOR*`, `FFLS*`) — e.g. `FFLORFBIGWRITE`, `FFLORNOSPC`, `FFLS2` failing together in a single Debug job while passing in isolation.

## Fix

Gate startup on `"Server is ready."` in the daemon log **in addition to** the port probe (mirroring the non-pNFS `pynfs_test_wrapper.sh`). `"Server is ready."` is logged only after the mount and backing-root resolution complete, so:

- the DS is fully ready before the MDS mounts it, and
- by the time the MDS is ready the backing root is already resolved — the existing `grep` becomes a hard confirmation rather than a race.

No server/protocol changes. Verified all 27 `pynfs/flex/*` tests pass with the hardened wrapper.