### PR TITLE
metrics: convert latency histograms to stopwatch time histograms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ add_definitions(-DCHIMERA_VERSION="${CHIMERA_VERSION}")
 add_definitions(-DCHIMERA_STATE_DIR="${CMAKE_INSTALL_PREFIX}/share/state")
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/ext/libevpl/ext/prometheus-c)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/ext/libevpl/ext/prometheus-c/ext/stopwatch)
 
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)

--- a/src/server/nfs/nfs.c
+++ b/src/server/nfs/nfs.c
@@ -158,8 +158,8 @@ nfs_server_init(
     NLM_V4_init(&shared->nlm_v4);
 
     shared->metrics      = metrics;
-    shared->op_histogram = prometheus_metrics_create_histogram_exponential(metrics, "chimera_nfs_op_latency",
-                                                                           "The latency of NFS operations", 24);
+    shared->op_histogram = prometheus_metrics_create_histogram_time(metrics, "chimera_nfs_op_latency_nanoseconds",
+                                                                    "The latency of NFS operations in nanoseconds", 34);
 
     /* NFS4.1 SEQUENCE replay cache metrics.  One counter with an "op"
      * label distinguishes outcomes; a gauge tracks total bytes held in

--- a/src/vfs/diskfs/diskfs.c
+++ b/src/vfs/diskfs/diskfs.c
@@ -796,13 +796,13 @@ struct diskfs_txn {
 #define DISKFS_IQ_RING_MASK (DISKFS_IQ_RING_SIZE - 1)
 
 struct diskfs_iq_entry {
-    struct diskfs_txn     *txn;
-    diskfs_txn_commit_cb_t cb;
-    void                  *private_data;
-    struct timespec        enqueue_time;
-    struct timespec        submit_time;
-    struct timespec        durable_time;
-    int                    status;
+    struct diskfs_txn          *txn;
+    diskfs_txn_commit_cb_t      cb;
+    void                       *private_data;
+    struct prometheus_stopwatch enqueue_time;
+    struct prometheus_stopwatch submit_time;
+    struct prometheus_stopwatch durable_time;
+    int                         status;
 };
 
 struct diskfs_iq_ring {
@@ -1025,9 +1025,9 @@ diskfs_metrics_init(
     m->txn_bytes = prometheus_metrics_create_histogram_exponential(
         metrics, "chimera_diskfs_txn_bytes",
         "Diskfs dirty bytes per transaction", 32);
-    m->txn_latency = prometheus_metrics_create_histogram_exponential(
-        metrics, "chimera_diskfs_txn_latency",
-        "Diskfs transaction latency in nanoseconds", 32);
+    m->txn_latency = prometheus_metrics_create_histogram_time(
+        metrics, "chimera_diskfs_txn_latency_nanoseconds",
+        "Diskfs transaction latency in nanoseconds", 34);
     m->pending_io = prometheus_metrics_create_gauge(
         metrics, "chimera_diskfs_pending_io",
         "Diskfs outstanding worker block I/O");
@@ -1334,6 +1334,16 @@ diskfs_metric_histogram_sample(
         prometheus_histogram_sample(inst, value ? (int64_t) value : 1);
     }
 } /* diskfs_metric_histogram_sample */
+
+static inline void
+diskfs_metric_time_sample(
+    struct prometheus_histogram_instance *inst,
+    struct prometheus_stopwatch          *sw)
+{
+    if (inst) {
+        prometheus_time_histogram_sample(inst, sw);
+    }
+} /* diskfs_metric_time_sample */
 
 static inline void
 diskfs_metric_inode_cache(
@@ -6766,13 +6776,13 @@ diskfs_redo_write_cb(
         return;
     }
 
-    clock_gettime(CLOCK_MONOTONIC, &ctx->entry.durable_time);
-    diskfs_metric_histogram_sample(
+    prometheus_stopwatch_start(&ctx->entry.durable_time);
+    diskfs_metric_time_sample(
         il->metrics.txn_latency[DISKFS_METRIC_TXN_SUBMIT_TO_DURABLE],
-        chimera_get_elapsed_ns(&ctx->entry.durable_time, &ctx->entry.submit_time));
-    diskfs_metric_histogram_sample(
+        &ctx->entry.submit_time);
+    diskfs_metric_time_sample(
         il->metrics.txn_latency[DISKFS_METRIC_TXN_QUEUE_TO_DURABLE],
-        chimera_get_elapsed_ns(&ctx->entry.durable_time, &ctx->entry.enqueue_time));
+        &ctx->entry.enqueue_time);
 
     il->redo_inflight--;
     diskfs_il_metrics_update(il);
@@ -7010,10 +7020,10 @@ diskfs_iq_process_channel(struct diskfs_iq_channel *ch)
         sq_head++;
         entry.status = 0;
 
-        clock_gettime(CLOCK_MONOTONIC, &entry.submit_time);
-        diskfs_metric_histogram_sample(
+        prometheus_stopwatch_start(&entry.submit_time);
+        diskfs_metric_time_sample(
             il->metrics.txn_latency[DISKFS_METRIC_TXN_QUEUE_TO_SUBMIT],
-            chimera_get_elapsed_ns(&entry.submit_time, &entry.enqueue_time));
+            &entry.enqueue_time);
 
         /* Issue a durable redo write; the completion drops pins/locks and
          * pushes the CQE (see diskfs_redo_write_cb). */
@@ -7105,20 +7115,15 @@ diskfs_iq_cq_doorbell_cb(
 
     while (head != tail) {
         struct diskfs_iq_entry entry = ch->cq.entries[head & DISKFS_IQ_RING_MASK];
-        struct timespec        now;
-        uint64_t               elapsed;
-
         head++;
         drained++;
 
-        clock_gettime(CLOCK_MONOTONIC, &now);
-        elapsed = chimera_get_elapsed_ns(&now, &entry.enqueue_time);
-        diskfs_metric_histogram_sample(
+        diskfs_metric_time_sample(
             ch->worker->metrics.txn_latency[DISKFS_METRIC_TXN_QUEUE_TO_CALLBACK],
-            elapsed);
-        diskfs_metric_histogram_sample(
+            &entry.enqueue_time);
+        diskfs_metric_time_sample(
             ch->worker->metrics.txn_latency[DISKFS_METRIC_TXN_DURABLE_TO_CALLBACK],
-            chimera_get_elapsed_ns(&now, &entry.durable_time));
+            &entry.durable_time);
 
         /* The txn's logical inode locks were already dropped by the intent
          * log thread (diskfs_iq_process_channel); just deliver completion. */
@@ -7279,7 +7284,7 @@ diskfs_txn_commit_finish(
     slot->cb           = cb;
     slot->private_data = private_data;
     slot->status       = 0;
-    clock_gettime(CLOCK_MONOTONIC, &slot->enqueue_time);
+    prometheus_stopwatch_start(&slot->enqueue_time);
 
     __atomic_store_n(&ch->sq.tail, tail + 1, __ATOMIC_RELEASE);
 

--- a/src/vfs/vfs.c
+++ b/src/vfs/vfs.c
@@ -396,10 +396,10 @@ chimera_vfs_init(
 
     if (metrics) {
         vfs->metrics.metrics    = metrics;
-        vfs->metrics.op_latency = prometheus_metrics_create_histogram_exponential(metrics,
-                                                                                  "chimera_vfs_op_latency",
-                                                                                  "The latency of VFS operations",
-                                                                                  24);
+        vfs->metrics.op_latency = prometheus_metrics_create_histogram_time(metrics,
+                                                                           "chimera_vfs_op_latency_nanoseconds",
+                                                                           "The latency of VFS operations in nanoseconds",
+                                                                           34);
 
         vfs->metrics.op_latency_series = calloc(CHIMERA_VFS_OP_NUM, sizeof(struct prometheus_histogram_series *));
 
@@ -659,7 +659,6 @@ SYMBOL_EXPORT void
 chimera_vfs_watchdog(struct chimera_vfs_thread *thread)
 {
     struct chimera_vfs_request *request;
-    struct timespec             now;
     uint64_t                    elapsed;
 
     request = thread->active_requests;
@@ -668,9 +667,7 @@ chimera_vfs_watchdog(struct chimera_vfs_thread *thread)
         return;
     }
 
-    clock_gettime(CLOCK_MONOTONIC, &now);
-
-    elapsed = chimera_get_elapsed_ns(&now, &request->start_time);
+    elapsed = prometheus_stopwatch_elapsed_ns(&request->start_time);
 
     if (elapsed > 10000000000UL) {
         chimera_vfs_debug("oldest request has been active for %lu ns", elapsed);

--- a/src/vfs/vfs.h
+++ b/src/vfs/vfs.h
@@ -13,6 +13,7 @@
 #include "vfs_pnfs.h"
 #include "vfs_lease_types.h"
 #include "evpl/evpl.h"
+#include "prometheus-c.h"
 
 #define CHIMERA_VFS_PATH_MAX 4096
 #define CHIMERA_VFS_NAME_MAX 256
@@ -310,7 +311,7 @@ struct chimera_vfs_request {
     enum chimera_vfs_error             status;
     chimera_vfs_complete_callback_t    complete;
     chimera_vfs_complete_callback_t    complete_delegate;
-    struct timespec                    start_time;
+    struct prometheus_stopwatch        start_time;
     uint64_t                           elapsed_ns;
 
     /* Points to one page of memory that the plugin may use as desired */

--- a/src/vfs/vfs_internal.h
+++ b/src/vfs/vfs_internal.h
@@ -191,7 +191,7 @@ chimera_vfs_request_alloc_common(
     request->active_prev = NULL;
     request->active_next = NULL;
 
-    clock_gettime(CLOCK_MONOTONIC, &request->start_time);
+    prometheus_stopwatch_start(&request->start_time);
 
     thread->num_active_requests++;
     DL_APPEND2(thread->active_requests, request, active_prev, active_next);
@@ -313,14 +313,11 @@ chimera_vfs_complete(struct chimera_vfs_request *request)
 {
     struct chimera_vfs_thread *thread = request->thread;
 
-    struct timespec            now;
-
-    clock_gettime(CLOCK_MONOTONIC, &now);
-
-    request->elapsed_ns = chimera_get_elapsed_ns(&now, &request->start_time);
+    request->elapsed_ns = prometheus_stopwatch_elapsed_ns(&request->start_time);
 
     if (thread->metrics.op_latency_series) {
-        prometheus_histogram_sample(thread->metrics.op_latency_series[request->opcode], request->elapsed_ns);
+        prometheus_time_histogram_sample(thread->metrics.op_latency_series[request->opcode],
+                                         &request->start_time);
     }
 
     chimera_vfs_dump_reply(request);


### PR DESCRIPTION
Advances the libevpl submodule to the stopwatch TSC timing work (libevpl #78) and converts chimera's latency histograms to the new `PROMETHEUS_HISTOGRAM_TIME` type it brings in.

## libevpl dependency
Bumps `ext/libevpl` to `main` (#78), which adds prometheus-c's time-histogram type and moves libevpl's own timekeeping onto the stopwatch TSC timer.

## Histogram conversions
- **VFS `op_latency`**, **diskfs `txn_latency`**, and **NFS `op_latency`** are now time histograms: a caller-owned `prometheus_stopwatch` is started at the operation's begin and sampled at completion. Buckets accumulate in TSC cycles and are converted to nanoseconds only at scrape, so the per-op hot path avoids `clock_gettime` and the per-sample fixed-point conversion. Metric names gain an explicit `_nanoseconds` suffix.
- The VFS request carries the stopwatch in place of its `start` timespec; the stuck-request watchdog and the request dump derive elapsed ns from it via `prometheus_stopwatch_elapsed_ns()`.
- diskfs keeps its per-phase enqueue/submit/durable timepoints, now as stopwatches; `txn_blocks`/`txn_bytes` remain plain exponential histograms.
- `stopwatch.h` is reached through the prometheus-c submodule's vendored copy.

Note: the `_nanoseconds` suffix renames `chimera_{vfs_op,diskfs_txn,nfs_op}_latency`; dashboards/alerts referencing the old names need updating.