### PR TITLE
pynfs: give DELEG6 enough lease headroom

### DIFF
--- a/pynfs/CMakeLists.txt
+++ b/pynfs/CMakeLists.txt
@@ -56,10 +56,14 @@ set(PYNFS_EXTRA_currentstateid nopnfs)
 # revoked before the recall round-trips -- a load-dependent false failure.  These
 # tests perform no lease-scaled sleeps, so a longer lease adds no wall-clock cost.
 # Keyed by pynfs flag; listed codes get PYNFS_LEASE_OVERRIDE_SECONDS.  DELEG6
-# (4.0 testRenew) is deliberately excluded: it scales its own sleeps to the lease
-# period, so a longer lease would slow it down / trip the per-test timeout.
+# (4.0 testRenew) also scales its own sleeps to the lease period, but it first
+# drives an unanswered CB_RECALL; with the wrapper's 5s default lease, Chimera's
+# 15s recall-failure path can expire the delegation holder before the test sends
+# RENEW.  Give it a lease beyond the recall window and a matching timeout.
 set(PYNFS_LEASE_OVERRIDE_SECONDS 30)
-set(PYNFS_LEASE_OVERRIDE_delegations DELEG1 DELEG4 DELEG5 DELEG7 DELEG9 DELEG14)
+set(PYNFS_LEASE_OVERRIDE_delegations DELEG1 DELEG4 DELEG5 DELEG6 DELEG7 DELEG9 DELEG14)
+set(PYNFS_LEASE_OVERRIDE_SECONDS_delegations 40)
+set(PYNFS_TIMEOUT_delegations 180)
 set(PYNFS_LEASE_OVERRIDE_deleg DELEG8)
 
 # Courteous-server tests (st_courtesy.py, COUR1-COUR7) need a longer lease for a

--- a/pynfs/stable-passing-tests.txt
+++ b/pynfs/stable-passing-tests.txt
@@ -6255,9 +6255,15 @@ chimera/pynfs/flex/FFST1_memfs_nfs4.1
 chimera/pynfs/delegations/DELEG1_memfs_nfs4.0
 chimera/pynfs/delegations/DELEG4_memfs_nfs4.0
 chimera/pynfs/delegations/DELEG5_memfs_nfs4.0
+chimera/pynfs/delegations/DELEG6_memfs_nfs4.0
 chimera/pynfs/delegations/DELEG7_memfs_nfs4.0
 chimera/pynfs/delegations/DELEG9_memfs_nfs4.0
 chimera/pynfs/delegations/DELEG14_memfs_nfs4.0
+chimera/pynfs/delegations/DELEG6_linux_nfs4.0
+chimera/pynfs/delegations/DELEG6_io_uring_nfs4.0
+chimera/pynfs/delegations/DELEG6_diskfs_io_uring_nfs4.0
+chimera/pynfs/delegations/DELEG6_diskfs_aio_nfs4.0
+chimera/pynfs/delegations/DELEG6_cairn_nfs4.0
 chimera/pynfs/deleg/DELEG8_memfs_nfs4.1
 chimera/pynfs/create_session/DELEG5_memfs_nfs4.2
 chimera/pynfs/create_session/DELEG6_memfs_nfs4.2


### PR DESCRIPTION
DELEG6 disables the v4.0 callback server, drives a conflicting OPEN, then sends RENEW after half the advertised lease. The pynfs wrapper default lease is 5s, but Chimera's unanswered delegation recall path can take ~15s before marking the callback path down. That lets the test client's lease expire before it reaches RENEW, producing NFS4ERR_EXPIRED instead of NFS4_OK/NFS4ERR_CB_PATH_DOWN.\n\nThis gives DELEG6 the delegations-suite lease override with a 40s lease and a matching wrapper timeout, then promotes the six v4.0 backend DELEG6 tests that now pass.\n\nVerification:\n- PYNFS_NFS4_LEASE_TIME=40 PYNFS_TIMEOUT=180 bash /worktrees/pynfs2/scripts/pynfs_test_wrapper.sh build/src/daemon/chimera memfs 0 /opt/pynfs DELEG6\n- ctest --test-dir build -R 'chimera/pynfs/delegations/DELEG6_.*_nfs4\.0$' --output-on-failure -j 6