### PR TITLE
vfs: get clock_gettime off the per-request hot path via the stopwatch

### DIFF
--- a/src/server/nfs/nfs4_lease.c
+++ b/src/server/nfs/nfs4_lease.c
@@ -18,17 +18,11 @@
 
 #define NFS_LEASE_SWEEP_INTERVAL_US 1000000   /* 1 Hz */
 
-/* True once `deadline` (CLOCK_MONOTONIC) has elapsed. */
+/* True once `deadline` (stopwatch ticks) has elapsed. */
 static inline bool
-nfs_deleg_deadline_passed(const struct timespec *deadline)
+nfs_deleg_deadline_passed(uint64_t deadline)
 {
-    struct timespec now;
-
-    clock_gettime(CLOCK_MONOTONIC, &now);
-    if (now.tv_sec != deadline->tv_sec) {
-        return now.tv_sec > deadline->tv_sec;
-    }
-    return now.tv_nsec >= deadline->tv_nsec;
+    return chimera_vfs_now_ticks() >= deadline;
 } /* nfs_deleg_deadline_passed */
 
 /* If any of `uc`'s delegations has an outstanding recall that has gone
@@ -46,7 +40,7 @@ nfs_deleg_recall_timeout_check(struct nfs_client *uc)
     {
         if (deleg->lease_held &&
             deleg->lease.break_state == CHIMERA_VFS_BREAK_BREAKING &&
-            nfs_deleg_deadline_passed(&deleg->lease.break_deadline)) {
+            nfs_deleg_deadline_passed(deleg->lease.break_deadline)) {
             timed_out = true;
             break;
         }

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -619,7 +619,7 @@ memfs_init(
     struct timespec          now;
     uint32_t                 block_size = CHIMERA_MEMFS_BLOCK_SIZE_DEFAULT;
 
-    clock_gettime(CLOCK_REALTIME, &now);
+    chimera_vfs_realtime(&now);
 
     pthread_mutex_init(&shared->lock, NULL);
 
@@ -929,7 +929,7 @@ memfs_apply_attrs(
     struct timespec now;
     uint64_t        set_mask = attr->va_set_mask;
 
-    clock_gettime(CLOCK_REALTIME, &now);
+    chimera_vfs_realtime(&now);
 
     attr->va_set_mask = CHIMERA_VFS_ATTR_ATOMIC;
 
@@ -1487,7 +1487,7 @@ memfs_mkdir_at(
     struct timespec           now;
     uint64_t                  hash;
 
-    clock_gettime(CLOCK_REALTIME, &now);
+    chimera_vfs_realtime(&now);
 
     hash = request->mkdir_at.name_hash;
 
@@ -1597,7 +1597,7 @@ memfs_mknod_at(
     struct timespec           now;
     uint64_t                  hash;
 
-    clock_gettime(CLOCK_REALTIME, &now);
+    chimera_vfs_realtime(&now);
 
     hash = request->mknod_at.name_hash;
 
@@ -1708,7 +1708,7 @@ memfs_remove_at(
     struct timespec      now;
     uint64_t             hash;
 
-    clock_gettime(CLOCK_REALTIME, &now);
+    chimera_vfs_realtime(&now);
 
     hash = request->remove_at.name_hash;
 
@@ -2008,7 +2008,7 @@ memfs_open_at(
     struct timespec      now;
     uint64_t             hash;
 
-    clock_gettime(CLOCK_REALTIME, &now);
+    chimera_vfs_realtime(&now);
 
     hash = request->open_at.name_hash;
 
@@ -2166,7 +2166,7 @@ memfs_create_unlinked(
     struct memfs_inode *inode = NULL;
     struct timespec     now;
 
-    clock_gettime(CLOCK_REALTIME, &now);
+    chimera_vfs_realtime(&now);
 
     inode = memfs_inode_alloc_thread(thread);
 
@@ -2240,7 +2240,7 @@ memfs_read(
     int                      niov = 0;
     struct timespec          now;
 
-    clock_gettime(CLOCK_REALTIME, &now);
+    chimera_vfs_realtime(&now);
 
     offset = request->read.offset;
     length = request->read.length;
@@ -2392,7 +2392,7 @@ memfs_write(
     uint32_t                 block_offset, left, block_len;
     struct timespec          now;
 
-    clock_gettime(CLOCK_REALTIME, &now);
+    chimera_vfs_realtime(&now);
 
     const uint32_t           block_size  = shared->block_size;
     const uint32_t           block_shift = shared->block_shift;
@@ -2586,7 +2586,7 @@ memfs_allocate(
     struct memfs_inode *inode;
     struct timespec     now;
 
-    clock_gettime(CLOCK_REALTIME, &now);
+    chimera_vfs_realtime(&now);
 
     if (request->allocate.handle->vfs_private) {
         inode = (struct memfs_inode *) request->allocate.handle->vfs_private;
@@ -2863,7 +2863,7 @@ memfs_copy_range(
         }
     }
 
-    clock_gettime(CLOCK_REALTIME, &now);
+    chimera_vfs_realtime(&now);
 
     /* Lock in deterministic order to avoid AB/BA deadlock */
     if (src_inode == dst_inode) {
@@ -3066,7 +3066,7 @@ memfs_move_range(
         }
     }
 
-    clock_gettime(CLOCK_REALTIME, &now);
+    chimera_vfs_realtime(&now);
 
     if (src_inode == dst_inode) {
         pthread_mutex_lock(&src_inode->lock);
@@ -3208,7 +3208,7 @@ memfs_clone_range(
         }
     }
 
-    clock_gettime(CLOCK_REALTIME, &now);
+    chimera_vfs_realtime(&now);
 
     if (src_inode == dst_inode) {
         pthread_mutex_lock(&src_inode->lock);
@@ -3426,7 +3426,7 @@ memfs_symlink_at(
     struct timespec      now;
     uint64_t             hash;
 
-    clock_gettime(CLOCK_REALTIME, &now);
+    chimera_vfs_realtime(&now);
 
     hash = request->symlink_at.name_hash;
 
@@ -3571,7 +3571,7 @@ memfs_rename_at(
     struct timespec      now;
     uint64_t             hash, new_hash;
 
-    clock_gettime(CLOCK_REALTIME, &now);
+    chimera_vfs_realtime(&now);
 
     hash     = request->rename_at.name_hash;
     new_hash = request->rename_at.new_name_hash;
@@ -3803,7 +3803,7 @@ memfs_link_at(
     struct timespec      now;
     uint64_t             hash;
 
-    clock_gettime(CLOCK_REALTIME, &now);
+    chimera_vfs_realtime(&now);
 
     hash = request->link_at.name_hash;
 
@@ -4270,7 +4270,7 @@ memfs_set_xattr(
         inode->xattrs = xattr;
     }
 
-    clock_gettime(CLOCK_REALTIME, &now);
+    chimera_vfs_realtime(&now);
     inode->ctime = now;
 
     memfs_map_attrs(shared, &request->set_xattr.r_post_attr, inode, request->fh);
@@ -4369,7 +4369,7 @@ memfs_remove_xattr(
     free(xattr->value);
     free(xattr);
 
-    clock_gettime(CLOCK_REALTIME, &now);
+    chimera_vfs_realtime(&now);
     inode->ctime = now;
 
     memfs_map_attrs(shared, &request->remove_xattr.r_post_attr, inode, request->fh);

--- a/src/vfs/root/vfs_root.c
+++ b/src/vfs/root/vfs_root.c
@@ -139,7 +139,7 @@ chimera_vfs_root_getattr(
     attr->va_uid   = 0;
     attr->va_gid   = 0;
     attr->va_size  = 4096;
-    clock_gettime(CLOCK_REALTIME, &attr->va_atime);
+    chimera_vfs_realtime(&attr->va_atime);
     attr->va_mtime = attr->va_atime;
     attr->va_ctime = attr->va_atime;
     attr->va_ino   = 2;
@@ -204,7 +204,7 @@ chimera_vfs_root_lookup_getattr_callback(
         dir_attr->va_uid   = 0;
         dir_attr->va_gid   = 0;
         dir_attr->va_size  = 4096;
-        clock_gettime(CLOCK_REALTIME, &dir_attr->va_atime);
+        chimera_vfs_realtime(&dir_attr->va_atime);
         dir_attr->va_mtime = dir_attr->va_atime;
         dir_attr->va_ctime = dir_attr->va_atime;
         dir_attr->va_ino   = 2;
@@ -310,7 +310,7 @@ chimera_vfs_root_mount(
     attr->va_uid   = 0;
     attr->va_gid   = 0;
     attr->va_size  = 4096;
-    clock_gettime(CLOCK_REALTIME, &attr->va_atime);
+    chimera_vfs_realtime(&attr->va_atime);
     attr->va_mtime = attr->va_atime;
     attr->va_ctime = attr->va_atime;
     attr->va_ino   = 2;

--- a/src/vfs/vfs.c
+++ b/src/vfs/vfs.c
@@ -41,6 +41,33 @@
 #include "common/macros.h"
 #include "prometheus-c.h"
 
+SYMBOL_EXPORT struct chimera_vfs_clock chimera_vfs_clock;
+
+SYMBOL_EXPORT void
+chimera_vfs_clock_init(void)
+{
+    struct timespec ts;
+
+    if (chimera_vfs_clock.initialized) {
+        return; /* process-global singleton; first vfs wins */
+    }
+
+    stopwatch_context_init(&chimera_vfs_clock.ctx);
+
+    clock_gettime(CLOCK_REALTIME, &ts);
+    chimera_vfs_clock.base_wall_ns = (uint64_t) ts.tv_sec * 1000000000ULL + (uint64_t) ts.tv_nsec;
+    stopwatch_start(&chimera_vfs_clock.ctx, &chimera_vfs_clock.base_sw);
+    chimera_vfs_clock.delta_ns         = 0;
+    chimera_vfs_clock.last_refresh     = 0;
+    chimera_vfs_clock.refresh_interval = chimera_vfs_ns_to_ticks(1000000000ULL); /* ~1s */
+    chimera_vfs_clock.initialized      = 1;
+} /* chimera_vfs_clock_init */
+
+SYMBOL_EXPORT void
+chimera_vfs_clock_shutdown(void)
+{
+    chimera_vfs_clock.initialized = 0;
+} /* chimera_vfs_clock_shutdown */
 
 static void
 chimera_vfs_delegation_drain(struct chimera_vfs_delegation_thread *delegation_thread)
@@ -144,13 +171,10 @@ chimera_vfs_close_thread_sweep(
     uint64_t                         min_age)
 {
     struct chimera_vfs_thread      *thread = close_thread->vfs_thread;
-    struct timespec                 now;
-    uint64_t                        count = 0;
+    uint64_t                        count  = 0;
     struct chimera_vfs_open_handle *handles, *handle;
 
-    clock_gettime(CLOCK_MONOTONIC, &now);
-
-    handles = chimera_vfs_open_cache_defer_close(cache, &now, min_age, &count);
+    handles = chimera_vfs_open_cache_defer_close(cache, chimera_vfs_now_ticks(), min_age, &count);
 
     while (handles) {
 
@@ -387,6 +411,9 @@ chimera_vfs_init(
     void                      *handle;
     const char                *effective_kv_module;
 
+    /* Bring up the process-wide TSC clock before any cache/timestamp use. */
+    chimera_vfs_clock_init();
+
     vfs = calloc(1, sizeof(*vfs));
 
     /* Synthesize machine name for identification */
@@ -613,6 +640,8 @@ chimera_vfs_destroy(struct chimera_vfs *vfs)
         free(vfs->metrics.op_latency_series);
         prometheus_histogram_destroy(vfs->metrics.metrics, vfs->metrics.op_latency);
     }
+
+    chimera_vfs_clock_shutdown();
 
     free(vfs);
 } /* chimera_vfs_destroy */

--- a/src/vfs/vfs.h
+++ b/src/vfs/vfs.h
@@ -14,6 +14,7 @@
 #include "vfs_lease_types.h"
 #include "evpl/evpl.h"
 #include "prometheus-c.h"
+#include "vfs_clock.h"
 
 #define CHIMERA_VFS_PATH_MAX 4096
 #define CHIMERA_VFS_NAME_MAX 256
@@ -152,7 +153,7 @@ struct chimera_vfs_open_handle {
         struct chimera_vfs_request     *request,
         struct chimera_vfs_open_handle *handle);
     struct chimera_vfs_request     *request;
-    struct timespec                 timestamp;
+    uint64_t                        timestamp; /* stopwatch ticks */
     struct chimera_vfs_open_handle *bucket_next;
     struct chimera_vfs_open_handle *bucket_prev;
     struct chimera_vfs_open_handle *prev;

--- a/src/vfs/vfs_attr_cache.h
+++ b/src/vfs/vfs_attr_cache.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -13,7 +13,7 @@ struct chimera_vfs_attr_cache_entry {
     uint64_t                 key;
     uint64_t                 score;
     struct rcu_head          rcu;
-    struct timespec          expiration;
+    uint64_t                 expiration; /* stopwatch ticks */
     union {
         struct chimera_vfs_attr_cache_entry *next; /* when on the free list */
         struct chimera_vfs_attr_cache_shard *shard; /* when not in the free list */
@@ -177,9 +177,8 @@ chimera_vfs_attr_cache_lookup(
     struct chimera_vfs_attr_cache_shard  *shard;
     struct chimera_vfs_attr_cache_entry **slot, **slot_end;
     int                                   rc;
-    struct timespec                       now;
+    uint64_t                              now = chimera_vfs_now_ticks();
 
-    clock_gettime(CLOCK_MONOTONIC, &now);
     shard = &cache->shards[fh_hash & cache->num_shards_mask];
 
     slot = &shard->entries[(fh_hash & cache->num_slots_mask) << cache->num_entries_bits];
@@ -195,7 +194,7 @@ chimera_vfs_attr_cache_lookup(
 
         if (entry &&
             entry->key == fh_hash &&
-            chimera_timespec_cmp(&entry->expiration, &now) >= 0 &&
+            entry->expiration >= now &&
             chimera_memequal(entry->attr.va_fh, entry->attr.va_fh_len, fh, fh_len)) {
 
             *r_attr = entry->attr;
@@ -271,8 +270,8 @@ chimera_vfs_attr_cache_insert(
         entry->score = 0;
         entry->attr  = *attr;
 
-        clock_gettime(CLOCK_MONOTONIC, &entry->expiration);
-        entry->expiration.tv_sec += cache->ttl;
+        entry->expiration = chimera_vfs_now_ticks() +
+            chimera_vfs_ns_to_ticks((uint64_t) cache->ttl * 1000000000ULL);
 
         entry->attr.va_set_mask |= CHIMERA_VFS_ATTR_FH;
         memcpy(entry->attr.va_fh, fh, fh_len);

--- a/src/vfs/vfs_clock.h
+++ b/src/vfs/vfs_clock.h
@@ -1,0 +1,123 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#pragma once
+
+#include <stdint.h>
+#include <time.h>
+#include "stopwatch.h"
+
+/*
+ * Process-wide VFS clock backed by the stopwatch TSC timer.
+ *
+ * Monotonic time is read directly from the stopwatch (a single unfenced rdtsc
+ * on the TSC path) and is used for cache TTLs, lease deadlines, etc.
+ *
+ * Wall-clock time (for file timestamps) is reconstructed without a per-call
+ * clock_gettime: at init we capture base_wall_ns paired with a base stopwatch,
+ * and a correction delta_ns = real_now - (base_wall + elapsed_ticks). The
+ * delta is refreshed lazily and inline: whenever a caller finds more than
+ * ~1s of ticks have elapsed since the last refresh, it re-reads CLOCK_REALTIME
+ * and updates the delta. No background thread, no lock; the delta/last-refresh
+ * accesses are plain 64-bit reads/writes (relaxed atomics == one mov on
+ * x86-64). A stale delta only costs up to ~1s of drift, corrected on the next
+ * crossing.
+ */
+struct chimera_vfs_clock {
+    struct stopwatch_context ctx;
+    struct stopwatch         base_sw;         /* started at init */
+    uint64_t                 base_wall_ns;    /* CLOCK_REALTIME ns at init */
+    uint64_t                 delta_ns;        /* wall-vs-tsc correction (relaxed) */
+    uint64_t                 last_refresh;    /* ticks at last delta refresh (relaxed) */
+    uint64_t                 refresh_interval;/* ticks between refreshes (~1s) */
+    int                      initialized;
+};
+
+extern struct chimera_vfs_clock chimera_vfs_clock;
+
+void chimera_vfs_clock_init(
+    void);
+
+void chimera_vfs_clock_shutdown(
+    void);
+
+/* Monotonic time in stopwatch ticks since init. */
+static inline uint64_t
+chimera_vfs_now_ticks(void)
+{
+    return stopwatch_read_ticks(&chimera_vfs_clock.ctx, &chimera_vfs_clock.base_sw);
+} /* chimera_vfs_now_ticks */
+
+static inline uint64_t
+chimera_vfs_ns_to_ticks(uint64_t ns)
+{
+    return stopwatch_ns_to_ticks(&chimera_vfs_clock.ctx, ns);
+} /* chimera_vfs_ns_to_ticks */
+
+static inline uint64_t
+chimera_vfs_ticks_to_ns(uint64_t ticks)
+{
+    return stopwatch_ticks_to_ns(&chimera_vfs_clock.ctx, ticks);
+} /* chimera_vfs_ticks_to_ns */
+
+/* Monotonic nanoseconds elapsed since a tick stamp taken with
+ * chimera_vfs_now_ticks(). Clamped to 0 if the stamp is in the future. */
+static inline uint64_t
+chimera_vfs_elapsed_ns(uint64_t since_ticks)
+{
+    uint64_t now = chimera_vfs_now_ticks();
+
+    return now > since_ticks ? chimera_vfs_ticks_to_ns(now - since_ticks) : 0;
+} /* chimera_vfs_elapsed_ns */
+
+/* Recompute the wall-vs-tsc correction from CLOCK_REALTIME. Called inline from
+ * the hot path at most ~once/sec (per the refresh interval). Racing callers
+ * simply recompute the same value; the relaxed stores need no lock. */
+static inline void
+chimera_vfs_clock_refresh(uint64_t now_ticks)
+{
+    struct timespec ts;
+    uint64_t        actual, elapsed;
+
+    clock_gettime(CLOCK_REALTIME, &ts);
+    actual  = (uint64_t) ts.tv_sec * 1000000000ULL + (uint64_t) ts.tv_nsec;
+    elapsed = chimera_vfs_ticks_to_ns(now_ticks);
+
+    __atomic_store_n(&chimera_vfs_clock.delta_ns, actual - chimera_vfs_clock.base_wall_ns - elapsed,
+                     __ATOMIC_RELAXED);
+    __atomic_store_n(&chimera_vfs_clock.last_refresh, now_ticks, __ATOMIC_RELAXED);
+} /* chimera_vfs_clock_refresh */
+
+/* Current wall-clock time in nanoseconds, reconstructed from the TSC. */
+static inline uint64_t
+chimera_vfs_wall_ns(void)
+{
+    uint64_t now_ticks = chimera_vfs_now_ticks();
+
+    if (unlikely(now_ticks - __atomic_load_n(&chimera_vfs_clock.last_refresh, __ATOMIC_RELAXED) >
+                 chimera_vfs_clock.refresh_interval)) {
+        chimera_vfs_clock_refresh(now_ticks);
+    }
+
+    return chimera_vfs_clock.base_wall_ns + chimera_vfs_ticks_to_ns(now_ticks) +
+           __atomic_load_n(&chimera_vfs_clock.delta_ns, __ATOMIC_RELAXED);
+} /* chimera_vfs_wall_ns */
+
+/* Fill ts with the current wall-clock time. Equivalent to
+ * clock_gettime(CLOCK_REALTIME, ts) but without the per-call syscall/read;
+ * falls back to clock_gettime if the clock has not been initialized yet. */
+static inline void
+chimera_vfs_realtime(struct timespec *ts)
+{
+    uint64_t ns;
+
+    if (unlikely(!chimera_vfs_clock.initialized)) {
+        clock_gettime(CLOCK_REALTIME, ts);
+        return;
+    }
+
+    ns          = chimera_vfs_wall_ns();
+    ts->tv_sec  = ns / 1000000000ULL;
+    ts->tv_nsec = ns % 1000000000ULL;
+} /* chimera_vfs_realtime */

--- a/src/vfs/vfs_lease_types.h
+++ b/src/vfs/vfs_lease_types.h
@@ -117,7 +117,7 @@ struct chimera_vfs_lease {
 
     enum chimera_vfs_break_state break_state;
     uint8_t                        break_needed_mode;
-    struct timespec                break_deadline;
+    uint64_t                       break_deadline; /* stopwatch ticks */
 
     /* For a SHARE probe only: a caching (handle) lease held under this same
      * key is the requester's own lease (SMB2 same-client, same lease key) and

--- a/src/vfs/vfs_name_cache.h
+++ b/src/vfs/vfs_name_cache.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -14,7 +14,7 @@ struct chimera_vfs_name_cache_entry {
     uint8_t         child_fh_len;
     uint16_t        name_len;
     int64_t         score;
-    struct timespec expiration;
+    uint64_t        expiration; /* stopwatch ticks */
     struct rcu_head rcu;
     union {
         struct chimera_vfs_name_cache_entry *next; /* when on the free list */
@@ -187,9 +187,7 @@ chimera_vfs_name_cache_lookup(
     struct chimera_vfs_name_cache_entry **slot, **slot_end;
     uint64_t                              key = fh_hash ^ name_hash;
     int                                   rc;
-    struct timespec                       now;
-
-    clock_gettime(CLOCK_MONOTONIC, &now);
+    uint64_t                              now = chimera_vfs_now_ticks();
 
     shard = &cache->shards[key & cache->num_shards_mask];
 
@@ -205,7 +203,7 @@ chimera_vfs_name_cache_lookup(
         entry = rcu_dereference(*slot);
 
         if (entry && entry->key == key &&
-            chimera_timespec_cmp(&entry->expiration, &now) >= 0 &&
+            entry->expiration >= now &&
             chimera_memequal(entry->parent_fh, entry->parent_fh_len, fh, fh_len) &&
             chimera_memequal(entry->child_name, entry->name_len, name, name_len)) {
 
@@ -258,9 +256,7 @@ chimera_vfs_name_cache_insert(
     struct chimera_vfs_name_cache_shard  *shard;
     struct chimera_vfs_name_cache_entry **slot, **slot_end, **slot_best;
     uint64_t                              key = fh_hash ^ name_hash;
-    struct timespec                       now;
-
-    clock_gettime(CLOCK_MONOTONIC, &now);
+    uint64_t                              now = chimera_vfs_now_ticks();
 
     shard = &cache->shards[key & cache->num_shards_mask];
 
@@ -292,8 +288,7 @@ chimera_vfs_name_cache_insert(
     entry->shard         = shard;
     entry->score         = 0;
 
-    entry->expiration.tv_sec  = now.tv_sec + cache->ttl;
-    entry->expiration.tv_nsec = now.tv_nsec;
+    entry->expiration = now + chimera_vfs_ns_to_ticks((uint64_t) cache->ttl * 1000000000ULL);
 
     memcpy(entry->parent_fh, fh, fh_len);
 
@@ -339,7 +334,7 @@ chimera_vfs_name_cache_insert(
             continue;
         }
 
-        if (chimera_timespec_cmp(&best_entry->expiration, &now) < 0) {
+        if (best_entry->expiration < now) {
             /* This entry is expired, so its effectively empty */
             old_entry->score = -1;
         }
@@ -350,7 +345,7 @@ chimera_vfs_name_cache_insert(
 
         if ((best_entry->score > old_entry->score) ||
             (best_entry->score == old_entry->score &&
-             chimera_timespec_cmp(&best_entry->expiration, &old_entry->expiration) < 0)) {
+             best_entry->expiration < old_entry->expiration)) {
             best_entry = old_entry;
             slot_best  = slot;
         }

--- a/src/vfs/vfs_open_cache.h
+++ b/src/vfs/vfs_open_cache.h
@@ -311,7 +311,7 @@ chimera_vfs_open_cache_release(
                                   close_hash, NULL, NULL);
                 return;
             }
-            clock_gettime(CLOCK_MONOTONIC, &handle->timestamp);
+            handle->timestamp = chimera_vfs_now_ticks();
             DL_APPEND(shard->pending_close, handle);
         }
     }
@@ -623,7 +623,7 @@ chimera_vfs_open_cache_insert(
 static inline struct chimera_vfs_open_handle *
 chimera_vfs_open_cache_defer_close(
     struct vfs_open_cache *cache,
-    struct timespec       *timestamp,
+    uint64_t               now_ticks,
     uint64_t               min_age,
     uint64_t              *r_count)
 {
@@ -640,7 +640,8 @@ chimera_vfs_open_cache_defer_close(
 
             handle = shard->pending_close;
 
-            elapsed = chimera_get_elapsed_ns(timestamp, &handle->timestamp);
+            elapsed = now_ticks > handle->timestamp ?
+                chimera_vfs_ticks_to_ns(now_ticks - handle->timestamp) : 0;
 
             if (elapsed < min_age) {
                 break;
@@ -717,8 +718,7 @@ chimera_vfs_open_cache_mark_for_close_by_mount(
         for (handle = shard->handles; handle; handle = handle->bucket_next) {
             if (memcmp(handle->fh, mount_id, CHIMERA_VFS_MOUNT_ID_SIZE) == 0) {
                 /* Set timestamp to 0 so it will be closed immediately */
-                handle->timestamp.tv_sec  = 0;
-                handle->timestamp.tv_nsec = 0;
+                handle->timestamp = 0;
                 count++;
             }
         }
@@ -953,7 +953,7 @@ chimera_vfs_open_cache_release_doc(
                               close_hash, NULL, NULL);
             return 0;
         }
-        clock_gettime(CLOCK_MONOTONIC, &handle->timestamp);
+        handle->timestamp = chimera_vfs_now_ticks();
         DL_APPEND(shard->pending_close, handle);
     }
 

--- a/src/vfs/vfs_rpl_cache.h
+++ b/src/vfs/vfs_rpl_cache.h
@@ -28,7 +28,7 @@ struct chimera_vfs_rpl_cache_entry {
     uint16_t        parent_fh_len;
     uint16_t        name_len;
     int64_t         score;
-    struct timespec expiration;
+    uint64_t        expiration; /* stopwatch ticks */
     struct rcu_head rcu;
     union {
         struct chimera_vfs_rpl_cache_entry *next;  /* when on free list */
@@ -180,9 +180,7 @@ chimera_vfs_rpl_cache_lookup(
     struct chimera_vfs_rpl_cache_shard  *shard;
     struct chimera_vfs_rpl_cache_entry **slot, **slot_end;
     uint64_t                             key = child_fh_hash;
-    struct timespec                      now;
-
-    clock_gettime(CLOCK_MONOTONIC, &now);
+    uint64_t                             now = chimera_vfs_now_ticks();
 
     shard = &cache->shards[key & cache->num_shards_mask];
 
@@ -195,7 +193,7 @@ chimera_vfs_rpl_cache_lookup(
         entry = rcu_dereference(*slot);
 
         if (entry && entry->fwd_key == key &&
-            chimera_timespec_cmp(&entry->expiration, &now) >= 0 &&
+            entry->expiration >= now &&
             chimera_memequal(entry->child_fh, entry->child_fh_len,
                              child_fh, child_fh_len)) {
 
@@ -310,9 +308,7 @@ chimera_vfs_rpl_cache_insert(
     struct chimera_vfs_rpl_cache_entry **slot, **slot_end, **slot_best;
     uint64_t                             fwd_key = child_fh_hash;
     uint64_t                             rev_key = parent_fh_hash ^ name_hash;
-    struct timespec                      now;
-
-    clock_gettime(CLOCK_MONOTONIC, &now);
+    uint64_t                             now     = chimera_vfs_now_ticks();
 
     shard = &cache->shards[fwd_key & cache->num_shards_mask];
 
@@ -336,8 +332,7 @@ chimera_vfs_rpl_cache_insert(
     entry->shard         = shard;
     entry->score         = 0;
 
-    entry->expiration.tv_sec  = now.tv_sec + cache->ttl;
-    entry->expiration.tv_nsec = now.tv_nsec;
+    entry->expiration = now + chimera_vfs_ns_to_ticks((uint64_t) cache->ttl * 1000000000ULL);
 
     memcpy(entry->child_fh, child_fh, child_fh_len);
     memcpy(entry->parent_fh, parent_fh, parent_fh_len);
@@ -377,13 +372,13 @@ chimera_vfs_rpl_cache_insert(
             continue;
         }
 
-        if (chimera_timespec_cmp(&old_entry->expiration, &now) < 0) {
+        if (old_entry->expiration < now) {
             old_entry->score = -1;
         }
 
         if ((best_entry->score > old_entry->score) ||
             (best_entry->score == old_entry->score &&
-             chimera_timespec_cmp(&best_entry->expiration, &old_entry->expiration) < 0)) {
+             best_entry->expiration < old_entry->expiration)) {
             best_entry = old_entry;
             slot_best  = slot;
         }

--- a/src/vfs/vfs_state.c
+++ b/src/vfs/vfs_state.c
@@ -53,32 +53,21 @@ chimera_vfs_state_pump_io(
     struct chimera_vfs_state      *state,
     struct chimera_vfs_file_state *file);
 
-/* Milliseconds elapsed from `then` to `now` (both CLOCK_MONOTONIC).  Clamps
+/* Milliseconds elapsed from `then` to `now` (both stopwatch ticks).  Clamps
  * to 0 if `now` precedes `then`. */
 static inline uint64_t
 chimera_vfs_elapsed_ms(
-    const struct timespec *then,
-    const struct timespec *now)
+    uint64_t then,
+    uint64_t now)
 {
-    if (now->tv_sec < then->tv_sec ||
-        (now->tv_sec == then->tv_sec && now->tv_nsec < then->tv_nsec)) {
-        return 0;
-    }
-    return (uint64_t) (now->tv_sec - then->tv_sec) * 1000ULL +
-           (uint64_t) (now->tv_nsec - then->tv_nsec) / 1000000ULL;
+    return now > then ? chimera_vfs_ticks_to_ns(now - then) / 1000000ULL : 0;
 } /* chimera_vfs_elapsed_ms */
 
-/* True if `lease`'s break deadline has elapsed (CLOCK_MONOTONIC). */
+/* True if `lease`'s break deadline has elapsed (stopwatch ticks). */
 static inline bool
 chimera_vfs_break_deadline_passed(const struct chimera_vfs_lease *lease)
 {
-    struct timespec now;
-
-    clock_gettime(CLOCK_MONOTONIC, &now);
-    if (now.tv_sec != lease->break_deadline.tv_sec) {
-        return now.tv_sec > lease->break_deadline.tv_sec;
-    }
-    return now.tv_nsec >= lease->break_deadline.tv_nsec;
+    return chimera_vfs_now_ticks() >= lease->break_deadline;
 } /* chimera_vfs_break_deadline_passed */
 
 /* -------------------------------------------------------------------- */
@@ -1066,7 +1055,6 @@ chimera_vfs_lease_begin_break(
     uint32_t                  deadline_ms)
 {
     struct chimera_vfs_file_state *file = lease->file;
-    struct timespec                now;
     chimera_vfs_lease_break_cb_t   cb;
     void                          *cb_priv;
     bool                           should_invoke;
@@ -1085,16 +1073,10 @@ chimera_vfs_lease_begin_break(
     if (should_invoke) {
         lease->break_state       = CHIMERA_VFS_BREAK_BREAKING;
         lease->break_needed_mode = needed_mode;
-        clock_gettime(CLOCK_MONOTONIC, &now);
-        now.tv_sec  += deadline_ms / 1000;
-        now.tv_nsec += (long) (deadline_ms % 1000) * 1000000L;
-        if (now.tv_nsec >= 1000000000L) {
-            now.tv_sec  += 1;
-            now.tv_nsec -= 1000000000L;
-        }
-        lease->break_deadline = now;
-        cb                    = lease->owner.break_cb;
-        cb_priv               = lease->owner.cb_private;
+        lease->break_deadline    = chimera_vfs_now_ticks() +
+            chimera_vfs_ns_to_ticks((uint64_t) deadline_ms * 1000000ULL);
+        cb      = lease->owner.break_cb;
+        cb_priv = lease->owner.cb_private;
     } else {
         cb      = NULL;
         cb_priv = NULL;
@@ -1663,7 +1645,7 @@ chimera_vfs_io_try(
             file->implicit_lease.mode.granted = target;
         }
         file->implicit_inflight++;
-        clock_gettime(CLOCK_MONOTONIC, &file->implicit_last_used);
+        file->implicit_last_used = chimera_vfs_now_ticks();
         pthread_mutex_unlock(&file->lock);
 
         if (activated) {
@@ -1816,10 +1798,8 @@ chimera_vfs_state_reap_idle(
     uint64_t                  idle_ms)
 {
 #define CHIMERA_VFS_STATE_REAP_BATCH 64
-    struct timespec now;
-    int             b;
-
-    clock_gettime(CLOCK_MONOTONIC, &now);
+    uint64_t now = chimera_vfs_now_ticks();
+    int      b;
 
     for (b = 0; b < CHIMERA_VFS_STATE_NUM_BUCKETS; b++) {
         struct chimera_vfs_state_bucket *bucket = &state->buckets[b];
@@ -1852,7 +1832,7 @@ chimera_vfs_state_reap_idle(
             reapable = file->implicit_active &&
                 !file->implicit_draining &&
                 file->implicit_inflight == 0 &&
-                chimera_vfs_elapsed_ms(&file->implicit_last_used, &now) >= idle_ms;
+                chimera_vfs_elapsed_ms(file->implicit_last_used, now) >= idle_ms;
             if (reapable) {
                 file->implicit_draining = 1;
             }

--- a/src/vfs/vfs_state.h
+++ b/src/vfs/vfs_state.h
@@ -62,7 +62,7 @@ struct chimera_vfs_file_state {
     uint8_t                             implicit_active;    /* linked in share_resvs */
     uint8_t                             implicit_draining;  /* recall in progress */
     uint32_t                            implicit_inflight;  /* in-flight ops pinning it */
-    struct timespec                     implicit_last_used; /* CLOCK_MONOTONIC */
+    uint64_t                            implicit_last_used; /* stopwatch ticks */
 
     /* FIFO queue of acquires waiting on a break to complete. */
     struct chimera_vfs_pending_acquire *pending_head;


### PR DESCRIPTION
Adds a process-wide VFS clock backed by the stopwatch TSC timer and moves chimera's per-RPC / per-VFS-request timekeeping onto it, eliminating `clock_gettime` from those hot paths.

## The clock (`src/vfs/vfs_clock.h`)
A global stopwatch context, anchored to `CLOCK_REALTIME` once at vfs init.
- **Monotonic:** `chimera_vfs_now_ticks()` is a single unfenced `rdtsc` + subtract on the TSC path.
- **Wall-clock:** `chimera_vfs_realtime()` reconstructs time as `base_wall + elapsed_ticks + delta`. `delta` is refreshed **lazily and inline** — no background thread — the first caller past a ~1s interval re-reads `CLOCK_REALTIME` and updates it. `delta`/`last_refresh` use relaxed atomics (a plain 64-bit access on x86-64, no lock), so racing callers simply recompute the same value and a stale delta costs at most ~1s of drift, corrected on the next crossing.

## Monotonic sites → ticks
TTL/deadline comparisons become plain integer compares: attribute cache, name cache, NFSv4.1 replay cache, open-handle cache, and the lease layer (break deadlines, idle reaper) — plus the NFS delegation deadline that reads the lease `break_deadline`.

## Wall-clock sites → anchored clock
File-timestamp stamping in `memfs` and `vfs_root` now uses `chimera_vfs_realtime()` instead of a per-operation `clock_gettime(CLOCK_REALTIME)`.

Wall-clock-bearing user-cache TTLs and one-time setup paths are intentionally left on `clock_gettime`.

Builds clean under `-Werror`; the NFS `state_table` / `replay_slot` unit tests (which exercise the converted lease state and replay cache) pass.