### PR TITLE
nfs4: expire unconfirmed clientids after lease

### DIFF
--- a/src/server/nfs/nfs4_lease.c
+++ b/src/server/nfs/nfs4_lease.c
@@ -104,6 +104,14 @@ nfs_lease_sweep_once(struct chimera_server_nfs_thread *thread)
                 /* A conflicting acquirer reclaimed one of this courtesy
                  * client's leases: tear it down now. */
                 reap = true;
+            } else if (!cur->nfs4_client_confirmed) {
+                /* RFC 8881 §18.35.3: an unconfirmed EXCHANGE_ID record that
+                 * is not confirmed by CREATE_SESSION within a lease period is
+                 * stale.  Courtesy only applies after the client has proven
+                 * possession of the clientid. */
+                if (now_ns - last > lease_ns) {
+                    reap = true;
+                }
             } else if (courtesy) {
                 /* Already in courtesy: reap once the courtesy window closes. */
                 if (now_ns >= uc->courtesy_deadline_ns) {

--- a/src/server/nfs/nfs4_session.c
+++ b/src/server/nfs/nfs4_session.c
@@ -631,7 +631,9 @@ nfs4_client_create_session_classify(
     HASH_FIND(nfs4_client_hh_by_id, table->nfs4_ct_clients_by_id,
               &client_id, sizeof(client_id), c);
 
-    if (c && c->unified && !c->nfs4_client_confirmed && c->unified->expired) {
+    if (c && c->unified && !c->nfs4_client_confirmed &&
+        (c->unified->expired ||
+         atomic_load_explicit(&c->unified->courtesy, memory_order_acquire))) {
         out->action = NFS4_CS_ERROR;
         out->status = NFS4ERR_STALE_CLIENTID;
         goto out_unlock;


### PR DESCRIPTION
## Summary
- expire unconfirmed EXCHANGE_ID client records instead of putting them into courtesy
- reject CREATE_SESSION for unconfirmed clientids already expired or in courtesy state
- preserve courteous revival for confirmed clients

## Testing
- cmake --build build --target chimera -j 8
- /usr/bin/env PYNFS_TIMEOUT=120 ctest --test-dir build -R '^chimera/pynfs/exchange_id/EID9_.*nfs4\.[12]$' --output-on-failure -j 1
- /usr/bin/env PYNFS_TIMEOUT=120 ctest --test-dir build -R '^chimera/pynfs/courteous/COUR1_(memfs|linux)_nfs4\.[12]$' --output-on-failure -j 2
- git diff --check