### PR TITLE
build: define _LGPL_SOURCE for the urcu-using trees (inline liburcu read-side)

### DIFF
--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -2,6 +2,11 @@
 #
 # SPDX-License-Identifier: LGPL-2.1-only
 
+# Inline the liburcu read-side primitives for the server TUs that touch the RCU
+# caches (nfs/s3/smb/rest + server.c).  See src/vfs/CMakeLists.txt; deliberately
+# not set for the GPL fio plugin.  chimera is LGPL-2.1.
+add_compile_definitions(_LGPL_SOURCE)
+
 add_library(chimera_server SHARED server.c)
 target_link_libraries(chimera_server chimera_nfs chimera_s3 chimera_smb chimera_rest chimera_vfs evpl unwind)
 

--- a/src/vfs/CMakeLists.txt
+++ b/src/vfs/CMakeLists.txt
@@ -2,6 +2,15 @@
 #
 # SPDX-License-Identifier: LGPL-2.1-only
 
+# Give liburcu the inlined read-side primitives (rcu_read_lock/unlock,
+# rcu_dereference): without _LGPL_SOURCE liburcu links the out-of-line
+# cross-library functions, adding a PLT call + barrier per RCU op on the hot
+# paths.  Applies to this directory and all subdirectories (the VFS core, the
+# RCU caches, and the backend modules under it -- every urcu user lives here or
+# under src/server).  Deliberately NOT set for src/fio (the GPL fio plugin,
+# which does not use urcu directly).  chimera is LGPL-2.1.
+add_compile_definitions(_LGPL_SOURCE)
+
 add_library(chimera_vfs SHARED vfs.c vfs_lsan.c
             vfs_proc_mount.c vfs_proc_umount.c
             vfs_proc_mkdir_at.c vfs_proc_mknod_at.c vfs_proc_close.c vfs_proc_open_fh.c


### PR DESCRIPTION
Without `_LGPL_SOURCE`, liburcu links the out-of-line library versions of the read-side primitives, so every `rcu_read_lock`/`rcu_read_unlock`/`rcu_dereference` is a cross-library PLT call (plus the memb-flavor memory barrier) — measurable overhead on the RCU-cache hot paths (attr/name/user/mount/rpl caches, and the diskfs inode/block caches). A disassembly of the diskfs read path showed ~5 such PLT calls per read. Defining `_LGPL_SOURCE` before the urcu headers switches to `urcu/static/*`, inlining them to a TLS update + barrier / a plain load.

Added as a directory-scoped definition on the two trees that actually use urcu — `src/vfs` (the VFS core, the RCU caches, and the backend modules under it) and `src/server` (nfs/s3/smb/rest) — covering every urcu consumer in the tree.

Deliberately **not** applied to `src/fio`: that plugin is GPL-licensed and does not use urcu directly (it links chimera, which does). chimera itself is LGPL-2.1, so the assertion is correct. Verified via `compile_commands.json` that `fio.c` has no `-D_LGPL_SOURCE` while `vfs.c` / `server/nfs` do.

No behavioural change — inlining only.