### PR TITLE
fio: support mount options and mark engine diskless; bump libevpl

### DIFF
--- a/src/fio/fio.c
+++ b/src/fio/fio.c
@@ -314,6 +314,8 @@ fio_chimera_init(struct thread_data *td)
 
             if (mounts) {
 
+                mount_ctx.total = json_array_size(mounts);
+
                 json_array_foreach(mounts, i, mount)
                 {
                     module      = json_object_get(mount, "module");
@@ -325,14 +327,19 @@ fio_chimera_init(struct thread_data *td)
                         return EINVAL;
                     }
 
-                    fprintf(stderr, "Mounting %s:%s at %s\n", json_string_value(module),
-                            json_string_value(module_path), json_string_value(mount_point));
+                    /* Optional comma-separated mount options (e.g. "rdma", "vers=4", "port=20049"). */
+                    json_t     *mount_opts = json_object_get(mount, "options");
+                    const char *opts_str   = mount_opts ? json_string_value(mount_opts) : NULL;
+
+                    fprintf(stderr, "Mounting %s:%s at %s options=%s\n", json_string_value(module),
+                            json_string_value(module_path), json_string_value(mount_point),
+                            opts_str ? opts_str : "");
 
                     chimera_mount(client_thread,
                                   json_string_value(mount_point),
                                   json_string_value(module),
                                   json_string_value(module_path),
-                                  NULL,
+                                  opts_str,
                                   mount_callback,
                                   &mount_ctx);
                 }
@@ -568,7 +575,7 @@ SYMBOL_EXPORT struct ioengine_ops ioengine =
 {
     .name               = "chimera",
     .version            = FIO_IOOPS_VERSION,
-    .flags              = 0,
+    .flags              = FIO_DISKLESSIO,
     .init               = fio_chimera_init,
     .post_init          = fio_chimera_post_init,
     .cleanup            = fio_chimera_cleanup,


### PR DESCRIPTION
## Summary

Makes the fio `chimera` ioengine usable against network-backed VFS modules (NFS over TCP/RDMA), and bumps libevpl.

- **Pass mount options through.** The engine now reads an optional per-mount `"options"` string from the JSON config and hands it to `chimera_mount()` (previously hardcoded `NULL`). This exposes the existing mount-option machinery to fio runs, e.g. `"options": "rdma"`, `"vers=4"`, or `"port=20049"`.
- **Mark the engine `FIO_DISKLESSIO`.** This is a userspace client that does no local-disk I/O, so fio must not lay files out on the local filesystem. Without the flag, fio created/extended files on the real root FS while the engine opened unrelated files over the network.
- **Fix the mount-wait loop.** `mount_ctx.total` was never assigned, so `while (complete < total)` never iterated. Synchronous in-memory mounts (memfs/diskfs) happened to complete inline, but async network mounts (NFS) were torn down before completing. Set `total = json_array_size(mounts)` so the init thread pumps the event loop until the mount actually finishes.
- **Bump libevpl** to pick up chimera-nas/libevpl#80 (drop the per-call AUTH_SYS debug log that was flooding/serializing the RPC hot path).

## Example

```json
{
    "mounts": [
        { "module": "nfs", "module_path": "10.0.0.1:/export",
          "mount_point": "/nfs", "options": "rdma" }
    ]
}
```