### PR TITLE
build: keep frame pointers in all build types; bump libevpl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,12 @@ if(CMAKE_BUILD_TYPE STREQUAL "Release")
     add_definitions(-O3)
 endif()
 
+# Keep frame pointers in every build type so that perf and other
+# frame-pointer-based profilers can unwind call stacks (the cost at -O3 is
+# negligible and the unwind reliability is worth it for production profiling).
+# Mirrors the same setting in the bundled libevpl.
+add_definitions(-fno-omit-frame-pointer)
+
 add_definitions(-g -Wall -Werror -Wno-unused-function)
 add_definitions(-fvisibility=hidden)
 


### PR DESCRIPTION
## Summary

Release builds compile with `-O3`, which omits the frame pointer. That breaks frame-pointer-based stack unwinding in `perf` (`--call-graph fp`) and similar profilers against Release binaries — exactly the builds we profile in production. DWARF call graphs are a heavy workaround (large captures, dropped samples under load).

This:
- Adds `-fno-omit-frame-pointer` unconditionally so it applies to **every** build type (Debug already enabled it alongside AddressSanitizer; this guarantees Release keeps it too).
- Bumps the bundled libevpl `9348ae4 → 704edbc` to pick up the matching change there (chimera-nas/libevpl#81), so `fp` unwinding is reliable across the whole stack. The bump also includes libevpl #80.

## Rationale

The runtime cost of preserving the frame pointer at `-O3` is negligible, while reliable low-overhead `fp` call-graph profiling on optimized builds is high-value for diagnosing throughput/latency.