### PR TITLE
smb: validate SMB2 TreeId and stale session id per request

### DIFF
--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -646,6 +646,13 @@ chimera_smb_compound_advance(struct chimera_smb_compound *compound)
                  request->smb2_hdr.command != SMB2_TREE_CONNECT &&
                  request->smb2_hdr.command != SMB2_TREE_DISCONNECT &&
                  request->smb2_hdr.command != SMB2_ECHO)) {
+        /* A WRITE parsed before this point cloned its payload iovecs; the
+         * write handler that would normally release them is being skipped, so
+         * free them here to avoid leaking the data buffer on the reject path
+         * (e.g. a write against an invalid/foreign TID). */
+        if (request->smb2_hdr.command == SMB2_WRITE) {
+            evpl_iovecs_release(compound->thread->evpl, request->write.iov, request->write.niov);
+        }
         chimera_smb_complete_request(request, SMB2_STATUS_NETWORK_NAME_DELETED);
         return;
     }
@@ -867,10 +874,16 @@ chimera_smb_server_handle_smb2(
                                sizeof(request->session_handle->signing_key));
 
                     } else {
+                        /* The header names a session id that no longer maps to
+                         * a live session (e.g. one that has been logged off, or
+                         * a bogus id).  Per MS-SMB2 3.3.5.2.9 this is answered
+                         * with STATUS_USER_SESSION_DELETED rather than tearing
+                         * down the transport. */
                         chimera_smb_error("Received SMB2 message with invalid session id %lx", request->smb2_hdr.
                                           session_id);
-                        chimera_smb_request_free(thread, request);
-                        evpl_close(evpl, conn->bind);
+                        request->session_handle                      = NULL;
+                        compound->requests[compound->num_requests++] = request;
+                        chimera_smb_complete_request(request, SMB2_STATUS_USER_SESSION_DELETED);
                         return;
                     }
                 }

--- a/src/server/smb/smb_proc_tree_connect.c
+++ b/src/server/smb/smb_proc_tree_connect.c
@@ -54,47 +54,38 @@ chimera_smb_tree_connect(struct chimera_smb_request *request)
             chimera_smb_complete_request(request, SMB2_STATUS_BAD_NETWORK_NAME);
             return;
         }
+    }
 
-        tree = NULL;
+    /* Each TREE_CONNECT establishes a distinct tree connection with its own
+     * unique TreeId, even when several connections target the same share
+     * (MS-SMB2 3.3.5.7).  Allocating a fresh tree per request keeps a file
+     * opened under one TID from being reachable via another TID, since open
+     * files are scoped to their tree. */
+    tree        = chimera_smb_tree_alloc(shared);
+    tree->type  = request->tree_connect.is_ipc ? CHIMERA_SMB_TREE_TYPE_PIPE : CHIMERA_SMB_TREE_TYPE_SHARE;
+    tree->share = share;
 
-        pthread_mutex_lock(&session->lock);
+    pthread_mutex_lock(&session->lock);
 
-        for (i = 1; i < session->max_trees; i++) {
-            if (session->trees[i] && session->trees[i]->share == share) {
-                tree = session->trees[i];
-                break;
-            }
+    for (i = 1; i < session->max_trees; i++) {
+
+        if (!session->trees[i]) {
+            break;
         }
     }
 
-    if (tree) {
-        tree->refcnt++;
+    if (i < session->max_trees) {
+        tree->tree_id     = i;
+        session->trees[i] = tree;
     } else {
 
-        tree        = chimera_smb_tree_alloc(shared);
-        tree->type  = request->tree_connect.is_ipc ? CHIMERA_SMB_TREE_TYPE_PIPE : CHIMERA_SMB_TREE_TYPE_SHARE;
-        tree->share = share;
+        tree->tree_id = session->max_trees;
 
-        for (i = 1; i < session->max_trees; i++) {
+        session->max_trees *= 2;
+        session->trees      = realloc(session->trees,
+                                      session->max_trees * sizeof(struct chimera_smb_tree *));
 
-            if (!session->trees[i]) {
-                break;
-            }
-        }
-
-        if (i < session->max_trees) {
-            tree->tree_id     = i;
-            session->trees[i] = tree;
-        } else {
-
-            tree->tree_id = session->max_trees;
-
-            session->max_trees *= 2;
-            session->trees      = realloc(session->trees,
-                                          session->max_trees * sizeof(struct chimera_smb_tree *));
-
-            session->trees[tree->tree_id] = tree;
-        }
+        session->trees[tree->tree_id] = tree;
     }
 
     pthread_mutex_unlock(&session->lock);

--- a/src/server/smb/smb_proc_tree_disconnect.c
+++ b/src/server/smb/smb_proc_tree_disconnect.c
@@ -12,8 +12,12 @@ chimera_smb_tree_disconnect(struct chimera_smb_request *request)
     struct chimera_server_smb_thread *thread  = request->compound->thread;
     struct chimera_smb_session       *session = request->session_handle->session;
 
+    /* A TREE_DISCONNECT carrying a TreeId that does not map to a live tree
+     * connection on this session (e.g. an already-disconnected or never-valid
+     * TID) must be rejected with NETWORK_NAME_DELETED rather than silently
+     * succeeding (MS-SMB2 3.3.5.7). */
     if (!request->tree) {
-        chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
+        chimera_smb_complete_request(request, SMB2_STATUS_NETWORK_NAME_DELETED);
         return;
     }
 

--- a/src/server/smb/smb_proc_write.c
+++ b/src/server/smb/smb_proc_write.c
@@ -113,6 +113,11 @@ chimera_smb_write(struct chimera_smb_request *request)
     request->write.open_file = chimera_smb_open_file_resolve(request, &request->write.file_id);
 
     if (unlikely(!request->write.open_file)) {
+        /* The file id does not resolve to a live open under this tree (e.g. a
+         * write issued against a foreign/wrong TID).  Release the write payload
+         * iovecs that parse cloned, since the normal completion path in
+         * chimera_smb_write_callback is being skipped. */
+        evpl_iovecs_release(evpl, request->write.iov, request->write.niov);
         chimera_smb_complete_request(request, SMB2_STATUS_FILE_CLOSED);
         return;
     }

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -295,12 +295,14 @@ set(SMBTORTURE_SUITES
 # lists as suites are verified against them.
 set(SMBTORTURE_ENABLED_memfs
     smb2.check-sharemode
+    smb2.connect
     smb2.create_no_streams
     smb2.notify-inotify
     smb2.secleak
     smb2.session.signing-aes-128-cmac
     smb2.set-sparse-ioctl
     smb2.sharemode
+    smb2.tcon
     smb2.winattr2
     # smb2.acls_non_canonical and smb2.async_dosmode pass on x86_64 but fail on
     # arm64 CI; left disabled until the arch difference is understood.


### PR DESCRIPTION
## Summary

The SMB2 server did not properly validate the per-request TreeId (TID) or
reject operations on stale session ids. Two Samba `smbtorture` conformance
tests surfaced this on the memfs backend:

- `smb2.tcon` emitted `WARNING!: * server allows write with wrong TID` — a
  write sent with a foreign/wrong TID succeeded instead of failing.
- `smb2.connect` failed at `connect.c:234` (`tdis should fail`) — a second
  TREE_DISCONNECT of an already-disconnected tree returned `NT_STATUS_OK`
  instead of `NT_STATUS_NETWORK_NAME_DELETED`.

## Root cause

- **Duplicate TreeId on same-share reconnect.** `chimera_smb_tree_connect`
  scanned the session's trees and, when a second `TREE_CONNECT` targeted the
  same share, reused that tree (bumping its refcnt) and returned the *same*
  TreeId. Open files are scoped per-tree, so the "wrong TID" write in
  `smb2.tcon` resolved against the very tree the handle was opened on and
  succeeded. Each `TREE_CONNECT` now establishes a **distinct tree with its
  own unique TreeId** (MS-SMB2 3.3.5.7); a handle opened under one TID is no
  longer reachable through another TID (the existing per-tree open-file
  scoping then correctly rejects the foreign-TID write with `FILE_CLOSED`).

- **Disconnected/invalid TID resolved as success.**
  `chimera_smb_tree_disconnect` returned `SUCCESS` whenever the header TID did
  not map to a live tree. It now returns `NETWORK_NAME_DELETED` for a TID that
  is already disconnected or was never valid.

- **Stale session id dropped the connection.** The dispatch path tore down the
  transport (`evpl_close`) when a request named a session id that no longer
  mapped to a live session (e.g. a logged-off session, or the invalid VUID
  `smb2.tcon` sends). Per MS-SMB2 3.3.5.2.9 the server now replies with
  `USER_SESSION_DELETED` and keeps the connection up. (This was the blocking
  failure once the TID fixes let both tests progress further.)

## Notes

- Compound RELATED operations are unaffected: they intentionally inherit the
  previous request's tree/session and skip the per-request TID/session lookup.
- The two error paths newly exercised by these fixes (open-file-resolve miss in
  `chimera_smb_write`, and the NULL-tree reject in compound dispatch) now
  release the WRITE payload iovecs that parse had cloned, which would otherwise
  leak the data buffer (caught by AddressSanitizer).
- `smb2.tcon` and `smb2.connect` are added to `SMBTORTURE_ENABLED_memfs`.
  `smb2.sharemode`, `smb2.create_no_streams`, and `smb2.check-sharemode` still
  pass with no regression. `smb2.compound` crashes inside the Samba
  `smbtorture` client itself on the first case (`related1`) — verified to be
  pre-existing on `main`, unrelated to this change, and that suite remains
  disabled.