### PR TITLE
smb/tests: run smbtorture on the linux/io_uring passthrough backends

### DIFF
--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -703,7 +703,14 @@ main(
                                 module, path, name,
                                 mount_options ? " options=" : "",
                                 mount_options ? mount_options : "");
-            chimera_server_mount(server, name, module, path, mount_options);
+
+            if (chimera_server_mount(server, name, module, path, mount_options) != 0) {
+                /* A silently-failed mount leaves shares/exports pointing at a
+                 * nonexistent root, so clients later see confusing errors
+                 * (e.g. SMB NETWORK_NAME_DELETED).  Surface it here instead. */
+                chimera_server_error("Failed to mount %s://%s to /%s",
+                                     module, path, name);
+            }
         }
     }
 

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -290,9 +290,9 @@ set(SMBTORTURE_SUITES
 # in the same change.  This lets the remaining work be parallelized across
 # branches without a perpetually-red test run.
 #
-# Only the memfs backend is seeded today (mirroring the WPTS suite, which also
-# runs memfs-only).  The other backends start fully disabled; populate their
-# lists as suites are verified against them.
+# The memfs and passthrough (linux/io_uring) backends are seeded today.  The
+# remaining backends start fully disabled; populate their lists as suites are
+# verified against them.
 set(SMBTORTURE_ENABLED_memfs
     smb2.check-sharemode
     smb2.create_no_streams
@@ -305,11 +305,36 @@ set(SMBTORTURE_ENABLED_memfs
     # smb2.acls_non_canonical and smb2.async_dosmode pass on x86_64 but fail on
     # arm64 CI; left disabled until the arch difference is understood.
 )
-set(SMBTORTURE_ENABLED_linux)
+# The linux and io_uring passthrough backends share an implementation and pass
+# the same set.  They expose the share root as a real local directory whose
+# filesystem must support name_to_handle_at(2) (see smbtorture_test.c).
+set(SMBTORTURE_ENABLED_linux
+    smb2.check-sharemode
+    smb2.create_no_streams
+    smb2.deny
+    smb2.notify-inotify
+    smb2.secleak
+    smb2.session.signing-aes-128-cmac
+    smb2.set-sparse-ioctl
+    smb2.sharemode
+    smb2.winattr2
+    # smb2.acls_non_canonical passes on x86_64 but, like memfs, is left disabled
+    # pending the arm64 difference.
+)
+set(SMBTORTURE_ENABLED_io_uring
+    smb2.check-sharemode
+    smb2.create_no_streams
+    smb2.deny
+    smb2.notify-inotify
+    smb2.secleak
+    smb2.session.signing-aes-128-cmac
+    smb2.set-sparse-ioctl
+    smb2.sharemode
+    smb2.winattr2
+)
 set(SMBTORTURE_ENABLED_diskfs_io_uring)
 set(SMBTORTURE_ENABLED_diskfs_aio)
 set(SMBTORTURE_ENABLED_cairn)
-set(SMBTORTURE_ENABLED_io_uring)
 
 macro(add_smbtorture_backend_tests backend)
     foreach(SUITE ${SMBTORTURE_SUITES})

--- a/src/server/smb/tests/smbtorture_test.c
+++ b/src/server/smb/tests/smbtorture_test.c
@@ -18,6 +18,7 @@
  *                  diskfs_aio, cairn) - default: memfs
  */
 
+#define _GNU_SOURCE
 #include "common/logging.h"
 #include "prometheus-c.h"
 #include "server/server.h"
@@ -117,6 +118,49 @@ run_smbtorture(
     return -1;
 } /* run_smbtorture */
 
+/* The linux and io_uring passthrough backends derive their VFS file handles
+* from name_to_handle_at(2).  A container/overlay rootfs (and the /tmp that
+* sits on it) returns EOPNOTSUPP for that call, which makes the passthrough
+* mount fail -- after which every CREATE against the share root resolves to
+* nothing and the server replies NETWORK_NAME_DELETED.  Such backends need
+* their share root on a filesystem that supports file handles (e.g. tmpfs).
+* Backends that store their own data (memfs/diskfs/cairn) are unaffected. */
+static int
+fs_supports_file_handles(const char *dir)
+{
+    struct {
+        struct file_handle fh;
+        unsigned char      buf[MAX_HANDLE_SZ];
+    } h;
+    int mount_id;
+
+    h.fh.handle_bytes = MAX_HANDLE_SZ;
+
+    return name_to_handle_at(AT_FDCWD, dir, &h.fh, &mount_id, 0) == 0;
+} /* fs_supports_file_handles */
+
+/* Pick a base directory for the session.  Passthrough backends require one
+ * whose filesystem supports name_to_handle_at(2); everything else keeps the
+ * historical /tmp.  Returns NULL if no suitable directory is available. */
+static const char *
+pick_session_base(int needs_file_handles)
+{
+    static const char *candidates[] = { "/tmp", "/dev/shm" };
+    unsigned           i;
+
+    if (!needs_file_handles) {
+        return "/tmp";
+    }
+
+    for (i = 0; i < sizeof(candidates) / sizeof(candidates[0]); i++) {
+        if (fs_supports_file_handles(candidates[i])) {
+            return candidates[i];
+        }
+    }
+
+    return NULL;
+} /* pick_session_base */
+
 static void
 print_usage(const char *prog)
 {
@@ -194,10 +238,22 @@ main(
         return EXIT_FAILURE;
     }
 
-    /* Create session directory */
+    /* Create session directory.  Passthrough backends need it on a
+     * file-handle-capable filesystem (see pick_session_base). */
+    int         needs_file_handles = strcmp(backend, "linux") == 0 ||
+        strcmp(backend, "io_uring") == 0;
+    const char *session_base = pick_session_base(needs_file_handles);
+
+    if (!session_base) {
+        fprintf(stderr,
+                "No filesystem supporting name_to_handle_at(2) found for the "
+                "'%s' passthrough backend (tried /tmp, /dev/shm)\n", backend);
+        return EXIT_FAILURE;
+    }
+
     clock_gettime(CLOCK_MONOTONIC, &tv);
     snprintf(env.session_dir, sizeof(env.session_dir),
-             "/tmp/smbtorture_test_%d_%lu", getpid(), tv.tv_sec);
+             "%s/smbtorture_test_%d_%lu", session_base, getpid(), tv.tv_sec);
 
     if (mkdir(env.session_dir, 0755) < 0 && errno != EEXIST) {
         fprintf(stderr, "Failed to create session directory: %s\n", strerror(errno));
@@ -290,20 +346,31 @@ main(
     }
 
     /* Mount filesystem */
+    int mount_rc;
+
     if (strcmp(backend, "memfs") == 0) {
-        chimera_server_mount(env.server, "share", "memfs", "/", NULL);
+        mount_rc = chimera_server_mount(env.server, "share", "memfs", "/", NULL);
     } else if (strcmp(backend, "linux") == 0) {
-        chimera_server_mount(env.server, "share", "linux", env.session_dir, NULL);
+        mount_rc = chimera_server_mount(env.server, "share", "linux", env.session_dir, NULL);
     } else if (strcmp(backend, "io_uring") == 0) {
-        chimera_server_mount(env.server, "share", "io_uring", env.session_dir, NULL);
+        mount_rc = chimera_server_mount(env.server, "share", "io_uring", env.session_dir, NULL);
     } else if (strcmp(backend, "diskfs_io_uring") == 0 ||
                strcmp(backend, "diskfs_aio") == 0) {
-        chimera_server_mount(env.server, "share", "diskfs", "/", NULL);
+        mount_rc = chimera_server_mount(env.server, "share", "diskfs", "/", NULL);
     } else if (strcmp(backend, "cairn") == 0) {
-        chimera_server_mount(env.server, "share", "cairn", "/", NULL);
+        mount_rc = chimera_server_mount(env.server, "share", "cairn", "/", NULL);
     } else {
         fprintf(stderr, "Unknown backend: %s\n", backend);
         test_cleanup(&env, 0);
+        return EXIT_FAILURE;
+    }
+
+    /* A failed mount leaves the share pointing at nothing, so every CREATE
+     * would come back as NETWORK_NAME_DELETED.  Fail loudly instead. */
+    if (mount_rc != 0) {
+        fprintf(stderr, "Failed to mount '%s' backend at %s: vfs error %d\n",
+                backend, env.session_dir, mount_rc);
+        test_cleanup(&env, 1);
         return EXIT_FAILURE;
     }
 


### PR DESCRIPTION
## Summary

The `linux` and `io_uring` passthrough backends were registered as smbtorture
ctest entries but had **no** suites enabled, and they were broken end-to-end:
every suite died on its opening `CREATE` with `STATUS_NETWORK_NAME_DELETED`.

Root cause is a **silent mount failure**, not the SMB revalidate path that
reports it. The passthrough backends derive their VFS file handles via
`name_to_handle_at(2)`. The test put each backend's share root on `/tmp`,
which in the CI container is **overlayfs** — and overlayfs returns
`EOPNOTSUPP` for `name_to_handle_at`. The `chimera_server_mount()` return
value was discarded, so the mount failed quietly, no `share` mount-table
entry was ever created, and the tree-root lookup in
`chimera_smb_revalidate_tree` then resolved to nothing and replied
`NETWORK_NAME_DELETED`. (Verified: `/tmp`, `/run`, `/var/tmp`, `$HOME` are all
overlayfs and fail; tmpfs `/dev/shm` supports file handles.)

Changes:
- **`smbtorture_test.c`**: place the passthrough share root on a
  file-handle-capable filesystem (prefer `/tmp`, fall back to tmpfs
  `/dev/shm`); other backends keep `/tmp`. Check the mount result and fail
  loudly instead of producing a cryptic `NETWORK_NAME_DELETED` downstream.
- **`CMakeLists.txt`**: enable the nine smbtorture suites that now pass on
  both passthrough backends (`check-sharemode`, `create_no_streams`, `deny`,
  `notify-inotify`, `secleak`, `session.signing-aes-128-cmac`,
  `set-sparse-ioctl`, `sharemode`, `winattr2`). `acls_non_canonical` passes on
  x86_64 but is left disabled for arm64 parity with memfs.
- **`daemon.c`**: the daemon ignored the same `chimera_server_mount()` return
  value, so a misconfigured/unsupported mount failed silently in production
  too; it now logs an error.

## Verification

- All 18 enabled passthrough suites (9 × linux + io_uring) pass via `ctest`
  under the Debug/ASan build (`100% tests passed, 0 failed`), confirmed stable
  across repeated runs.
- No regression: memfs/diskfs/cairn still pass and still use `/tmp`.
- `make syntax-check`, `reuse-lint`, `copyright-check` clean; Release and
  Debug builds succeed.