### PR TITLE
smb2: cap QUERY_DIRECTORY output buffer at MaxTransactSize (fix compound_find hang)

### DIFF
--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -146,6 +146,14 @@ struct chimera_smb_conn;
 
 #define CHIMERA_SMB_REQUEST_FLAG_SIGN 0x01
 
+/* MaxTransactSize advertised in NEGOTIATE.  QUERY_DIRECTORY / QUERY_INFO
+ * output is bounded by this per MS-SMB2, so it doubles as the cap on the
+ * single contiguous reply buffer the server allocates for a FIND.  It must
+ * stay <= the libevpl per-buffer size (2 MiB) because that reply buffer is
+ * allocated as a single iovec (max_iovecs == 1); a request larger than one
+ * evpl buffer cannot be satisfied with one iovec. */
+#define CHIMERA_SMB_MAX_TRANSACT_SIZE (1 * 1024 * 1024)
+
 struct chimera_smb_rename_info {
     uint8_t                         replace_if_exist;
     struct chimera_vfs_open_handle *new_parent_handle;

--- a/src/server/smb/smb_proc_negotiate.c
+++ b/src/server/smb/smb_proc_negotiate.c
@@ -118,7 +118,7 @@ chimera_smb_negotiate(struct chimera_smb_request *request)
     request->negotiate.r_dialect           = dialect;
     request->negotiate.r_security_mode     = SMB2_SIGNING_ENABLED;
     request->negotiate.r_capabilities      = conn->capabilities;
-    request->negotiate.r_max_transact_size = 1 * 1024 * 1024;
+    request->negotiate.r_max_transact_size = CHIMERA_SMB_MAX_TRANSACT_SIZE;
     request->negotiate.r_max_read_size     = 8 * 1024 * 1024;
     request->negotiate.r_max_write_size    = 8 * 1024 * 1024;
     request->negotiate.r_system_time       = chimera_nt_time(&now);

--- a/src/server/smb/smb_proc_query_directory.c
+++ b/src/server/smb/smb_proc_query_directory.c
@@ -302,6 +302,19 @@ chimera_smb_query_directory(struct chimera_smb_request *request)
         request->query_directory.open_file->position = 0;
     }
 
+    /* The reply buffer is allocated below as a single contiguous iovec
+     * (max_iovecs == 1).  A client may advertise an OutputBufferLength far
+     * larger than the negotiated MaxTransactSize (smbtorture's
+     * compound_find_close uses 8 MiB), which cannot be satisfied by one
+     * libevpl buffer and would otherwise spin evpl_iovec_alloc() forever.
+     * Cap the buffer at MaxTransactSize; the readdir callback honours the
+     * same bound, and a client that wants more simply re-issues the FIND
+     * for the next batch (MS-SMB2 §3.3.5.18 allows returning fewer bytes
+     * than OutputBufferLength). */
+    if (request->query_directory.max_output_length > CHIMERA_SMB_MAX_TRANSACT_SIZE) {
+        request->query_directory.max_output_length = CHIMERA_SMB_MAX_TRANSACT_SIZE;
+    }
+
     evpl_iovec_alloc(evpl,
                      request->query_directory.max_output_length,
                      4096,

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -295,6 +295,7 @@ set(SMBTORTURE_SUITES
 # verified against them.
 set(SMBTORTURE_ENABLED_memfs
     smb2.check-sharemode
+    smb2.compound_find
     smb2.connect
     smb2.create_no_streams
     smb2.notify-inotify


### PR DESCRIPTION
## Summary

Several SMB2 smbtorture suites hung the server until the 120s test
timeout. This fixes the `smb2.compound_find` hang.

## Root cause

`smb2.compound_find.compound_find_close` issues a FIND
(QUERY_DIRECTORY) with an **8 MiB** `OutputBufferLength`.
`chimera_smb_query_directory()` allocates the reply as a **single
contiguous iovec**:

```c
evpl_iovec_alloc(evpl, request->query_directory.max_output_length,
                 4096, /* alignment */ 1 /* max_iovecs */, 0, &iov);
```

The libevpl per-buffer size is 2 MiB. When the requested length exceeds
one buffer and `max_iovecs == 1`, `evpl_iovec_alloc()` cannot place the
data and **spins forever**: it repeatedly releases the under-sized
buffer and re-allocates a fresh one without ever reaching the
out-of-slots error return. The SMB thread never returns from the
allocator, so the connection (and the whole suite) deadlocks.

Confirmed by instrumenting the dispatch path: the FIND was dispatched,
`chimera_vfs_readdir` was never reached, and every server thread sat
idle in `epoll_wait` — a lost completion, not a crash. The two passing
subtests (`compound_find_related`, `compound_find_unrelated`) use a
256-byte buffer that fits in one evpl buffer; only `compound_find_close`
requests 8 MiB.

## Fix

Cap `max_output_length` at the negotiated `MaxTransactSize` (1 MiB)
before allocating the FIND reply buffer. Per MS-SMB2 §3.3.5.18 the
server may return fewer bytes than the client's `OutputBufferLength`;
the client simply re-issues the FIND for the next batch. The readdir
callback already bounds serialization by `max_output_length`, so the
capped value also keeps the fill within the allocated buffer.

The literal `MaxTransactSize` advertised in NEGOTIATE is promoted to a
shared constant (`CHIMERA_SMB_MAX_TRANSACT_SIZE`) so the advertised size
and the FIND cap stay in lock-step, with a note that it must remain
<= the libevpl buffer size since the reply is a single iovec.

`smb2.compound_find` is added to `SMBTORTURE_ENABLED_memfs`.

## Verification

- `smb2.compound_find` now PASSES on memfs (all three subtests incl.
  `compound_find_close`), in both Debug (ASan) and Release builds.
- Nearby suites not regressed: `smb2.sharemode`,
  `smb2.create_no_streams`, `smb2.check-sharemode`, `smb2.winattr2`,
  `smb2.set-sparse-ioctl`, `smb2.notify-inotify`, `smb2.secleak`,
  `smb2.session.signing-aes-128-cmac` all still PASS on memfs.
- `make syntax-check` passes; SPDX years current.

## Notes / out of scope

- The underlying `evpl_iovec_alloc()` infinite loop on an
  over-buffer-sized single-iovec request is a latent libevpl defect
  (it should return -1 rather than spin). The chimera-side cap is the
  correct fix here regardless, since the server should not request
  multi-MiB single-iovec FIND buffers. A similar latent pattern exists
  on the SMB2 RDMA write path (`smb_proc_write.c`), which these TCP
  tests do not exercise; left untouched.
- The other hanging suites flagged alongside compound_find
  (`smb2.notify`, `smb2.change_notify_disabled`, `smb2.mkdir`) have
  **distinct** root causes (CHANGE_NOTIFY parks with no reply; a CREATE
  on an "invalid dir" never completes) and are not addressed here.