### PR TITLE
smb2: select an encryption cipher in the NEGOTIATE response

### DIFF
--- a/src/server/smb/smb_proc_negotiate.c
+++ b/src/server/smb/smb_proc_negotiate.c
@@ -260,6 +260,31 @@ build_signing_capabilities_response(
     return 4;
 } /* build_signing_capabilities_response */
 
+/* Build the SMB2_ENCRYPTION_CAPABILITIES response context:
+ *   CipherCount(2)=1, Ciphers[1](2)=selected cipher.
+ * The selected cipher is echoed so the client's per-session nonce bookkeeping
+ * is well-formed; Chimera does not activate encryption (see cipher selection
+ * in chimera_smb_select_negotiated_algorithms). */
+static int
+build_encryption_capabilities_response(
+    struct chimera_smb_conn    *conn,
+    struct chimera_smb_request *request,
+    uint8_t                    *out,
+    uint32_t                    out_size)
+{
+    (void) request;
+
+    if (conn->negotiated.cipher_id == 0 || out_size < 4) {
+        return -1;
+    }
+
+    out[0] = 1; out[1] = 0; /* CipherCount */
+    out[2] = conn->negotiated.cipher_id & 0xff;
+    out[3] = (conn->negotiated.cipher_id >> 8) & 0xff;
+
+    return 4;
+} /* build_encryption_capabilities_response */
+
 /* The negotiate-response context emitters. Only consulted when the negotiated
  * dialect is 3.1.1; each entry emits only if the client sent the matching
  * request context (need_mask_bit).
@@ -267,14 +292,18 @@ build_signing_capabilities_response(
  * PreauthIntegrity is implemented: the server selects SHA-512, returns a salt,
  * maintains Connection.PreauthIntegrityHashValue across NEGOTIATE/SESSION_SETUP
  * (smb.c), and derives the 3.1.1 signing key bound to that hash. AES-CMAC
- * signing negotiation is implemented; GMAC, encryption, compression and
+ * signing negotiation is implemented. The encryption context echoes a selected
+ * cipher (required so the client's session nonce bookkeeping is well-formed)
+ * but Chimera does not activate encryption; GMAC, compression and
  * RdmaTransform contexts are not yet emitted. */
 static const struct chimera_smb_negotiate_response_emitter smb_negotiate_response_emitters[] = {
-    { CHIMERA_SMB_NEGOTIATE_CTX_PREAUTH, SMB2_PREAUTH_INTEGRITY_CAPABILITIES,
+    { CHIMERA_SMB_NEGOTIATE_CTX_PREAUTH,    SMB2_PREAUTH_INTEGRITY_CAPABILITIES,
       build_preauth_integrity_response },
-    { CHIMERA_SMB_NEGOTIATE_CTX_SIGNING, SMB2_SIGNING_CAPABILITIES,
+    { CHIMERA_SMB_NEGOTIATE_CTX_ENCRYPTION, SMB2_ENCRYPTION_CAPABILITIES,
+      build_encryption_capabilities_response },
+    { CHIMERA_SMB_NEGOTIATE_CTX_SIGNING,    SMB2_SIGNING_CAPABILITIES,
       build_signing_capabilities_response },
-    { 0,                                 0,                                  NULL }
+    { 0,                                    0,                                     NULL}
 };
 
 /* Build the negotiate context list into ctx_buf. Returns total bytes written
@@ -739,6 +768,41 @@ chimera_smb_select_negotiated_algorithms(
             if (request->negotiate.signing_in.algs[i] == SMB2_SIGNING_AES_CMAC) {
                 conn->negotiated.signing_alg = SMB2_SIGNING_AES_CMAC;
                 break;
+            }
+        }
+    }
+
+    /* SMB 3.1.1: when the client offers an ENCRYPTION_CAPABILITIES context, the
+     * server MUST select a cipher and echo it back in the response context (or
+     * return AES-128-CCM as a default per MS-SMB2 3.3.5.4). The selected cipher
+     * is NOT used to actually encrypt traffic here — encryption is only ever
+     * activated when the server also advertises SMB2_GLOBAL_CAP_ENCRYPTION or
+     * sets SMB2_SESSION_FLAG_ENCRYPT_DATA, neither of which Chimera does.
+     *
+     * Selecting a cipher is nonetheless required for protocol correctness: a
+     * Samba client (smbtorture) records Connection.CipherId from this context
+     * and uses it to size the per-session AEAD nonce space.  Leaving CipherId
+     * at 0 makes the client compute a zero nonce-space, and a later
+     * shallow-copy of the session (smb2.compound.related1, durable-open,
+     * replay) then aborts — crashing the client.  Echo a chosen cipher so the
+     * client's session bookkeeping is well-formed. */
+    if (conn->dialect == SMB2_DIALECT_3_1_1 &&
+        (request->negotiate.ctx_present_mask & CHIMERA_SMB_NEGOTIATE_CTX_ENCRYPTION)) {
+        static const uint16_t preferred[] = {
+            SMB2_ENCRYPTION_AES_128_GCM,
+            SMB2_ENCRYPTION_AES_256_GCM,
+            SMB2_ENCRYPTION_AES_128_CCM,
+            SMB2_ENCRYPTION_AES_256_CCM,
+        };
+        int                   i, j;
+
+        for (i = 0; i < (int) (sizeof(preferred) / sizeof(preferred[0])) &&
+             conn->negotiated.cipher_id == 0; i++) {
+            for (j = 0; j < request->negotiate.encryption_in.cipher_count; j++) {
+                if (request->negotiate.encryption_in.ciphers[j] == preferred[i]) {
+                    conn->negotiated.cipher_id = preferred[i];
+                    break;
+                }
             }
         }
     }

--- a/src/server/smb/smb_proc_negotiate.c
+++ b/src/server/smb/smb_proc_negotiate.c
@@ -303,7 +303,7 @@ static const struct chimera_smb_negotiate_response_emitter smb_negotiate_respons
       build_encryption_capabilities_response },
     { CHIMERA_SMB_NEGOTIATE_CTX_SIGNING,    SMB2_SIGNING_CAPABILITIES,
       build_signing_capabilities_response },
-    { 0,                                    0,                                     NULL}
+    { 0,                                    0,                                     NULL }
 };
 
 /* Build the negotiate context list into ctx_buf. Returns total bytes written


### PR DESCRIPTION
## Summary

The Samba `smbtorture` client SEGFAULTs partway through several SMB2 suites
(`smb2.compound`, crashing at `smb2.compound.related1`; also `smb2.durable-open`
and `smb2.replay`) on all backends. The crash is the *client* dying, elicited by
a non-conformant server NEGOTIATE response.

## Root cause

When an SMB 3.1.1 client offers an `SMB2_ENCRYPTION_CAPABILITIES` negotiate
context, MS-SMB2 (3.3.5.4) requires the server to select one of the offered
ciphers and echo it back in an `SMB2_ENCRYPTION_CAPABILITIES` response context.
Chimera parsed the client's context but never selected a cipher and never emitted
the response context, so the client's negotiated `CipherId` stayed 0.

The Samba client records `Connection.CipherId` from that response context and
uses it to size the per-session AEAD nonce space
(`smb2cli_session_set_session_key`: cipher 0 -> `nonce_high_max = 0`). When the
torture tests later shallow-copy the session
(`smbXcli_session_shallow_copy`, used by `smb2.compound.related1`,
`durable-open`, `replay`), that function treats a zero `nonce_high_max` as
nonce-space exhaustion, frees the copy, and returns `NULL`. The test then passes
the `NULL` to `smb2cli_session_set_id_and_flags()`, which dereferences it and
crashes the client. This was confirmed by disassembling the installed Samba
client libraries and matching the crash backtrace
(`smb2cli_session_set_id_and_flags+0x4`).

## Fix

In the NEGOTIATE path, when the client offers an encryption context, select a
cipher (preferring AES-128-GCM) from the offered list and emit an
`SMB2_ENCRYPTION_CAPABILITIES` response context echoing it.

The cipher is only *negotiated*, not *used*: encryption stays off because the
server advertises neither `SMB2_GLOBAL_CAP_ENCRYPTION` (capabilities) nor the
per-session `SMB2_SESSION_FLAG_ENCRYPT_DATA` flag, so all traffic remains
unencrypted exactly as before. Selecting the cipher only makes the client's
session bookkeeping well-formed, which is what stops the crash.

## Validation (memfs)

- `smb2.compound.related1` now PASSES (smbtorture no longer crashes); the whole
  `smb2.compound` suite no longer SEGFAULTs the client (exits with ordinary
  test-failure status instead of signal 11).
- Previously-green memfs suites are unaffected: `smb2.sharemode`,
  `smb2.create_no_streams`, `smb2.check-sharemode`,
  `smb2.session.signing-aes-128-cmac`, `smb2.set-sparse-ioctl`, `smb2.winattr2`
  all still PASS.

The affected suites are intentionally **not** added to the CMake allowlists:
beyond the crash they still have pre-existing, unrelated functional gaps
(e.g. `smb2.compound.related2..9` exercise compound-related status propagation
and IOCTLs that return `NT_STATUS_NOT_IMPLEMENTED`; `smb2.durable-open.reopen3`
hits a separate client crash in `smb2_composite_unlink_send` rooted in the
durable-handle path). Those are distinct from this client-crash bug and out of
scope here, so enabling the suites would leave the run red.