### PR TITLE
smb: guard session refcnt and sessions hash under sessions_lock on release

### DIFF
--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -1023,7 +1023,12 @@ chimera_smb_session_release(
     struct chimera_smb_tree *tree;
     int                      destroy = 0;
 
-    pthread_mutex_lock(&session->lock);
+    /* refcnt and shared->sessions membership are guarded by sessions_lock,
+     * the same lock chimera_smb_session_alloc/lookup/authorize hold when they
+     * set, increment, or HASH_ADD.  Releasing under session->lock instead would
+     * race the lookup refcnt++ (lost update -> premature free) and modify the
+     * shared hash unprotected (double HASH_DEL on an emptied table crashes). */
+    pthread_mutex_lock(&shared->sessions_lock);
 
     chimera_smb_abort_if(session->refcnt == 0, "session refcnt is 0 at release");
 
@@ -1036,7 +1041,7 @@ chimera_smb_session_release(
         }
     }
 
-    pthread_mutex_unlock(&session->lock);
+    pthread_mutex_unlock(&shared->sessions_lock);
 
     if (destroy) {
 


### PR DESCRIPTION
## Summary

`chimera_smb_session_release` updated `session->refcnt` and ran `HASH_DEL(shared->sessions, ...)` under `session->lock`, while every other accessor of that refcount and that hash holds `shared->sessions_lock`:

- `chimera_smb_session_alloc` — `refcnt = 1`
- `chimera_smb_session_lookup` — `refcnt++` and `HASH_FIND`
- `chimera_smb_session_authorize` — `HASH_ADD`

Two different mutexes guarding one refcount and one hash table is not mutual exclusion. Under rapid connection churn across server threads, one connection's teardown `HASH_DEL` races another connection's `HASH_ADD`/`HASH_FIND` on `shared->sessions` (and the refcount RMWs lose updates), corrupting the table until its head pointer is left NULL. The next `HASH_DEL` then evaluates `(head)->hh.tbl` on a NULL head — a read at offset `0x10` (`hh` sits at offset 16 in `struct chimera_smb_session`) — crashing the connection thread:

```
SEGV on unknown address 0x000000000010 (READ)
  chimera_smb_session_release  smb_internal.h  (HASH_DEL line)
  chimera_smb_conn_free        smb_internal.h:1187
  chimera_smb_server_notify    smb.c:1322
  evpl_bind_destroy            bind.c:219
```

## Fix

Take `shared->sessions_lock` for the `refcnt--` and the `HASH_DEL`, so all access to the session refcount and the global session table uses one lock. `session->lock` continues to guard the per-session `trees[]` array exclusively; the two locks are never held simultaneously, so no new lock-ordering edge is introduced.

## Validation

Found by a full-matrix smbtorture run (every suite × every backend) under Debug/ASan; surfaced on connection-churning suites (`oplock`, `compound_async`, `credits`).

- **Before:** a parallel smbtorture burst (oplock/compound_async/credits/lease across linux/diskfs_aio/memfs) hit the `SEGV @0x10` within a couple of rounds.
- **After:** 30 churn rounds × 6 parallel suites — zero crashes.
- The 8 memfs-enabled smbtorture suites still pass 100% (incl. `secleak` and `session.signing-aes-128-cmac`); uncrustify and the copyright-year check are clean.