### PR TITLE
smb2: set SMB2_FLAGS_SIGNED on server-signed responses

### DIFF
--- a/src/server/smb/smb_signing.c
+++ b/src/server/smb/smb_signing.c
@@ -473,6 +473,18 @@ chimera_smb_sign_compound(
                 return -1;
             }
 
+            /* A signed response MUST advertise SMB2_FLAGS_SIGNED (MS-SMB2
+             * 3.3.4.1.1), and the signature is computed over the header *with*
+             * that flag set.  The reply header inherits the request's flags, so
+             * a response to a request the client itself signed already carries
+             * the bit — but the final SESSION_SETUP response is signed by the
+             * server even though the establishing request was unsigned.  Set
+             * the flag here, before computing the MAC, so (a) the value we sign
+             * matches the bytes the client verifies and (b) a client with
+             * signing required does not treat the response as unsigned (which
+             * mishandles channel/session setup and can crash it). */
+            hdr->flags |= SMB2_FLAGS_SIGNED;
+
             switch (conn->dialect) {
                 case SMB2_DIALECT_2_0_2:
                 case SMB2_DIALECT_2_1:


### PR DESCRIPTION
## Summary

While root-causing the `smb2.session.bind2` smbtorture client crash, I found a real SMB2 signing non-conformance in the server and fixed it here. **Note up front:** this fix is a correctness improvement on its own, but it does *not* by itself stop the `bind2` crash — see "On the bind2 crash" below for the honest root cause of that.

## The signing bug (what this PR fixes)

When the server signs a reply, `chimera_smb_sign_compound()` computed a valid signature into the header but never set `SMB2_FLAGS_SIGNED`. It relied on the reply header inheriting the request's flags. That happens to work for ordinary operations — the client signs the request, so the reply inherits the SIGNED bit — but the **final SESSION_SETUP success response is signed by the server even though the session-establishing request is unsigned**. So that response went out with a valid signature but a *clear* `SMB2_FLAGS_SIGNED` flag.

Per MS-SMB2 3.3.4.1.1 a signed message MUST advertise `SMB2_FLAGS_SIGNED`, and the signature is computed over the header *with that flag set*. A client that requires signing treats a response lacking the flag as unsigned and rejects / mishandles the session.

Captured on the wire before the fix (final SESSION_SETUP response): a non-zero `Signature` field but `Flags: 0x00000011` (SIGNED bit clear). With signing only *enabled*, clients skip verifying it; with signing *required*, they reject it ("Bad SMB2 signature").

The fix sets the flag in `chimera_smb_sign_compound()` **before** computing the MAC, so (a) the bytes we sign match the bytes the client verifies and (b) signing-required clients accept the response.

## Validation

- `smb2.session.signing-hmac-sha-256`, `smb2.session.signing-aes-128-cmac`, `smb2.session.signing-aes-128-gmac` — pass (these exercise signed session setup + signed ops + client-side signature verification across 2.1/3.x).
- `smb2.sharemode`, `smb2.check-sharemode`, `smb2.create_no_streams` — still pass on memfs.
- For SMB 3.1.1, the SESSION_SETUP response is folded into the preauth-integrity hash *after* signing, so the flag is now part of both the bytes signed and the bytes hashed — consistent with the client.

## On the bind2 crash (not fixed here, and not server-fixable)

The `smb2.session.bind2` client SEGFAULT is a **bug in the Samba smbtorture test itself**, triggered by a *conformant* server response:

- `test_session_bind2` takes an early `goto done` if the first `smb2_create(io1f1)` fails. Its `done:` cleanup unconditionally dereferences `transport3->conn` and `transport2->conn`, which are still NULL at that point (the second/third connections haven't been set up yet) -> NULL-deref SIGSEGV in the client.
- On the passthrough/disk backends (linux, io_uring, diskfs, cairn) that initial CREATE in the share root returns `STATUS_ACCESS_DENIED` — the share root is owned by root (0755) and the SMB user maps to a non-root uid, so this is *correct* POSIX permission enforcement. That triggers the early bail and the client's NULL-transport crash.
- On memfs the root is not permission-enforced, the CREATE succeeds, the test proceeds past the early bail, and the NULL-transport cleanup is never reached — which is exactly why bind2 does not crash on memfs.

So the crash is not a server response defect; it cannot be fixed server-side in a spec-correct way. `bind2` is therefore intentionally left out of every `SMBTORTURE_ENABLED_*` allowlist.