### PR TITLE
smb2: implement LastWriteTime semantics (sentinels, EndOfFile vs Allocation, sticky write time)

### DIFF
--- a/src/server/smb/smb_attr.h
+++ b/src/server/smb/smb_attr.h
@@ -360,6 +360,21 @@ chimera_smb_marshal_fs_full_size_info(
 
 } /* chimera_smb_marshal_fs_full_size_info */
 
+/* A timestamp field in a SET FileBasicInformation request carries one of
+ * three sentinel values that all mean "do not change this field":
+ *   0                 (NTTIME_OMIT)   - leave unchanged
+ *   0xFFFFFFFFFFFFFFFF (NTTIME_FREEZE) - leave unchanged, stop auto-updates
+ *   0xFFFFFFFFFFFFFFFE (NTTIME_THAW)   - leave unchanged, resume auto-updates
+ * Any other value is a real timestamp to store.  (MS-FSCC 2.4.7; the
+ * freeze/thaw values are exercised by smbtorture's smb2.timestamps.) */
+static inline int
+chimera_smb_time_is_omit(uint64_t nttime)
+{
+    return nttime == 0 ||
+           nttime == UINT64_MAX ||
+           nttime == UINT64_MAX - 1;
+} /* chimera_smb_time_is_omit */
+
 static inline void
 chimera_smb_unmarshal_basic_info(
     const struct chimera_smb_attrs *smb_attrs,
@@ -368,18 +383,27 @@ chimera_smb_unmarshal_basic_info(
     attr->va_req_mask = 0;
     attr->va_set_mask = 0;
 
-    chimera_nt_to_epoch(smb_attrs->smb_atime, &attr->va_atime);
-    chimera_nt_to_epoch(smb_attrs->smb_mtime, &attr->va_mtime);
-    chimera_nt_to_epoch(smb_attrs->smb_ctime, &attr->va_ctime);
+    /* Each timestamp is only applied when the client supplied a real value;
+     * the omit/freeze/thaw sentinels leave the stored value alone. */
+    if (!chimera_smb_time_is_omit(smb_attrs->smb_atime)) {
+        chimera_nt_to_epoch(smb_attrs->smb_atime, &attr->va_atime);
+        attr->va_req_mask |= CHIMERA_VFS_ATTR_ATIME;
+        attr->va_set_mask |= CHIMERA_VFS_ATTR_ATIME;
+    }
 
-    attr->va_req_mask |= CHIMERA_VFS_ATTR_ATIME | CHIMERA_VFS_ATTR_MTIME | CHIMERA_VFS_ATTR_CTIME;
-    attr->va_set_mask |= CHIMERA_VFS_ATTR_ATIME | CHIMERA_VFS_ATTR_MTIME | CHIMERA_VFS_ATTR_CTIME;
+    if (!chimera_smb_time_is_omit(smb_attrs->smb_mtime)) {
+        chimera_nt_to_epoch(smb_attrs->smb_mtime, &attr->va_mtime);
+        attr->va_req_mask |= CHIMERA_VFS_ATTR_MTIME;
+        attr->va_set_mask |= CHIMERA_VFS_ATTR_MTIME;
+    }
 
-    /* Creation/birth time: 0 means "no change" and -1 (0xFFFF...) means
-     * "do not change, and freeze against system updates" (MS-FSCC 2.4.7).
-     * In both cases leave the stored value alone. */
-    if (smb_attrs->smb_crttime != 0 &&
-        smb_attrs->smb_crttime != UINT64_MAX) {
+    if (!chimera_smb_time_is_omit(smb_attrs->smb_ctime)) {
+        chimera_nt_to_epoch(smb_attrs->smb_ctime, &attr->va_ctime);
+        attr->va_req_mask |= CHIMERA_VFS_ATTR_CTIME;
+        attr->va_set_mask |= CHIMERA_VFS_ATTR_CTIME;
+    }
+
+    if (!chimera_smb_time_is_omit(smb_attrs->smb_crttime)) {
         chimera_nt_to_epoch(smb_attrs->smb_crttime, &attr->va_btime);
         attr->va_req_mask |= CHIMERA_VFS_ATTR_BTIME;
         attr->va_set_mask |= CHIMERA_VFS_ATTR_BTIME;

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -371,6 +371,10 @@ struct chimera_smb_request {
             uint32_t                        r_rdma_status;
             struct chimera_smb_file_id      file_id;
             struct chimera_smb_open_file   *open_file;
+            /* Holds the pre-write mtime restored after a write through a
+             * write-time-sticky handle (chimera_vfs_setattr keeps this pointer
+             * across the async call, so it must live in the request). */
+            struct chimera_vfs_attrs        restore_attrs;
             struct chimera_smb_rdma_element rdma_elements[8];
             struct evpl_iovec               iov[256];
             struct evpl_iovec               chunk_iov[256];

--- a/src/server/smb/smb_proc_set_info.c
+++ b/src/server/smb/smb_proc_set_info.c
@@ -156,6 +156,55 @@ chimera_smb_set_info_link_process(struct chimera_smb_request *request)
     }
 } /* chimera_smb_set_info_link_process */
 
+/* Resolve a FileAllocationInformation set once the current size is known.
+ * Truncate (and advance LastWriteTime) only when the requested allocation is
+ * below the current EOF; otherwise leave the data/EOF alone and just touch the
+ * inode so ChangeTime advances. */
+static void
+chimera_smb_set_info_allocation_getattr_callback(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *attr,
+    void                     *private_data)
+{
+    struct chimera_smb_request *request    = private_data;
+    uint64_t                    alloc_size = request->set_info.vfs_attrs.va_size;
+    uint64_t                    cur_size;
+
+    if (unlikely(error_code)) {
+        chimera_smb_open_file_release(request, request->set_info.open_file);
+        chimera_smb_complete_request(request, SMB2_STATUS_INTERNAL_ERROR);
+        return;
+    }
+
+    cur_size = attr->va_size;
+
+    request->set_info.vfs_attrs.va_req_mask = CHIMERA_VFS_ATTR_SIZE;
+    request->set_info.vfs_attrs.va_set_mask = CHIMERA_VFS_ATTR_SIZE;
+
+    if (alloc_size < cur_size) {
+        request->set_info.vfs_attrs.va_size = alloc_size;
+        if (!(request->set_info.open_file->flags & CHIMERA_SMB_OPEN_FILE_WRITE_TIME_STICKY)) {
+            request->set_info.vfs_attrs.va_mtime.tv_nsec = CHIMERA_VFS_TIME_NOW;
+            request->set_info.vfs_attrs.va_req_mask     |= CHIMERA_VFS_ATTR_MTIME;
+            request->set_info.vfs_attrs.va_set_mask     |= CHIMERA_VFS_ATTR_MTIME;
+        }
+    } else {
+        /* No EOF change: re-set the unchanged size so the backend advances
+         * ChangeTime without disturbing LastWriteTime. */
+        request->set_info.vfs_attrs.va_size = cur_size;
+    }
+
+    chimera_vfs_setattr(
+        request->compound->thread->vfs_thread,
+        &request->session_handle->session->cred,
+        request->set_info.open_file->handle,
+        &request->set_info.vfs_attrs,
+        0,
+        0,
+        chimera_smb_set_info_callback,
+        request);
+} /* chimera_smb_set_info_allocation_getattr_callback */
+
 void
 chimera_smb_set_info(struct chimera_smb_request *request)
 {
@@ -174,6 +223,13 @@ chimera_smb_set_info(struct chimera_smb_request *request)
 
                     chimera_smb_unmarshal_basic_info(&request->set_info.attrs, &request->set_info.vfs_attrs);
 
+                    /* An explicit (non-sentinel) write-time set hands control of
+                     * the LastWriteTime to this handle: its own subsequent writes
+                     * and size-sets must stop advancing it (MS-FSA sticky mtime). */
+                    if (request->set_info.vfs_attrs.va_set_mask & CHIMERA_VFS_ATTR_MTIME) {
+                        request->set_info.open_file->flags |= CHIMERA_SMB_OPEN_FILE_WRITE_TIME_STICKY;
+                    }
+
                     chimera_vfs_setattr(
                         request->compound->thread->vfs_thread,
                         &request->session_handle->session->cred,
@@ -185,12 +241,16 @@ chimera_smb_set_info(struct chimera_smb_request *request)
                         request);
                     break;
                 case SMB2_FILE_ENDOFFILE_INFO:
-                case SMB2_FILE_ALLOCATION_INFO:
-                    /* AllocationInfo strictly only truncates when alloc <
-                     * EOF (MS-FSCC §2.4.4).  We collapse it to setattr(size)
-                     * because Windows always follows up with set-EOF in the
-                     * save flow, and a stand-alone shrink still truncates. */
                     chimera_smb_unmarshal_end_of_file_info(&request->set_info.attrs, &request->set_info.vfs_attrs);
+
+                    /* Setting EndOfFile advances the LastWriteTime (it changes
+                     * the file's data extent), unless this handle has taken
+                     * sticky control of the write time. */
+                    if (!(request->set_info.open_file->flags & CHIMERA_SMB_OPEN_FILE_WRITE_TIME_STICKY)) {
+                        request->set_info.vfs_attrs.va_mtime.tv_nsec = CHIMERA_VFS_TIME_NOW;
+                        request->set_info.vfs_attrs.va_req_mask     |= CHIMERA_VFS_ATTR_MTIME;
+                        request->set_info.vfs_attrs.va_set_mask     |= CHIMERA_VFS_ATTR_MTIME;
+                    }
 
                     chimera_vfs_setattr(
                         request->compound->thread->vfs_thread,
@@ -200,6 +260,23 @@ chimera_smb_set_info(struct chimera_smb_request *request)
                         0,
                         0,
                         chimera_smb_set_info_callback,
+                        request);
+                    break;
+                case SMB2_FILE_ALLOCATION_INFO:
+                    /* AllocationInfo only changes the file when the requested
+                     * allocation is below the current EOF, in which case the
+                     * file is truncated to it (MS-FSCC §2.4.4).  A truncation
+                     * advances LastWriteTime; a grow/hint only touches
+                     * ChangeTime.  Both need the current size to decide, so this
+                     * is resolved in the getattr callback. */
+                    chimera_smb_unmarshal_end_of_file_info(&request->set_info.attrs, &request->set_info.vfs_attrs);
+
+                    chimera_vfs_getattr(
+                        request->compound->thread->vfs_thread,
+                        &request->session_handle->session->cred,
+                        request->set_info.open_file->handle,
+                        CHIMERA_VFS_ATTR_SIZE,
+                        chimera_smb_set_info_allocation_getattr_callback,
                         request);
                     break;
                 case SMB2_FILE_DISPOSITION_INFO:

--- a/src/server/smb/smb_proc_write.c
+++ b/src/server/smb/smb_proc_write.c
@@ -9,6 +9,33 @@
 #include "vfs/vfs_notify.h"
 #include "vfs/vfs_state.h"
 
+/* A write-time-sticky handle needs the pre-write mtime back from the VFS so the
+ * write callback can restore it; otherwise no pre-attrs are requested. */
+static inline uint64_t
+chimera_smb_write_pre_attr_mask(const struct chimera_smb_open_file *open_file)
+{
+    return (open_file->flags & CHIMERA_SMB_OPEN_FILE_WRITE_TIME_STICKY)
+           ? CHIMERA_VFS_ATTR_MTIME : 0;
+} /* chimera_smb_write_pre_attr_mask */
+
+/* Completion for the mtime-restore setattr issued after a write through a
+ * write-time-sticky handle.  The write itself already succeeded; a failed
+ * restore leaves a slightly-advanced write time but is not worth failing the
+ * write over, so we always report success. */
+static void
+chimera_smb_write_sticky_restore_callback(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *pre_attr,
+    struct chimera_vfs_attrs *set_attr,
+    struct chimera_vfs_attrs *post_attr,
+    void                     *private_data)
+{
+    struct chimera_smb_request *request = private_data;
+
+    chimera_smb_open_file_release(request, request->write.open_file);
+    chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
+} /* chimera_smb_write_sticky_restore_callback */
+
 static void
 chimera_smb_write_callback(
     enum chimera_vfs_error    error_code,
@@ -35,6 +62,28 @@ chimera_smb_write_callback(
                                 request->write.open_file->name,
                                 request->write.open_file->name_len,
                                 NULL, 0);
+    }
+
+    /* A handle that explicitly set its write time has "taken control" of it:
+     * the backend bumped mtime as a side effect of this write, so restore it to
+     * the pre-write value (reported in pre_attr) to keep it frozen. */
+    if (!error_code &&
+        (request->write.open_file->flags & CHIMERA_SMB_OPEN_FILE_WRITE_TIME_STICKY) &&
+        (pre_attr->va_set_mask & CHIMERA_VFS_ATTR_MTIME)) {
+
+        request->write.restore_attrs.va_req_mask = 0;
+        request->write.restore_attrs.va_set_mask = CHIMERA_VFS_ATTR_MTIME;
+        request->write.restore_attrs.va_mtime    = pre_attr->va_mtime;
+
+        chimera_vfs_setattr(thread->vfs_thread,
+                            &request->session_handle->session->cred,
+                            request->write.open_file->handle,
+                            &request->write.restore_attrs,
+                            0,
+                            0,
+                            chimera_smb_write_sticky_restore_callback,
+                            request);
+        return;
     }
 
     chimera_smb_open_file_release(private_data, request->write.open_file);
@@ -89,7 +138,7 @@ chimera_smb_rdma_read_callback(
             request->write.offset,
             request->write.length,
             !!(request->write.flags & SMB2_WRITEFLAG_WRITE_THROUGH),
-            0,
+            chimera_smb_write_pre_attr_mask(request->write.open_file),
             0,
             request->write.iov,
             request->write.niov,
@@ -179,7 +228,7 @@ chimera_smb_write(struct chimera_smb_request *request)
             request->write.offset,
             request->write.length,
             !!(request->write.flags & SMB2_WRITEFLAG_WRITE_THROUGH),
-            0,
+            chimera_smb_write_pre_attr_mask(request->write.open_file),
             0,
             request->write.iov,
             request->write.niov,

--- a/src/server/smb/smb_session.h
+++ b/src/server/smb/smb_session.h
@@ -34,6 +34,11 @@ struct chimera_smb_file_id {
  * (atomically with the open).  On final close the record must be deleted from
  * that backend so a restart doesn't resurrect a closed handle. */
 #define CHIMERA_SMB_OPEN_FILE_PERSISTED            0x00000010
+/* The client explicitly set the LastWriteTime on this handle (a real value, not
+ * an omit/freeze sentinel).  Per MS-FSA, the handle has "taken control" of the
+ * write time: subsequent implicit updates from this handle (data writes,
+ * EndOfFile/Allocation sets) must not advance it for the life of the open. */
+#define CHIMERA_SMB_OPEN_FILE_WRITE_TIME_STICKY    0x00000020
 
 /* Bits identifying which CREATE contexts a client supplied on the open. Mirrored
  * from request->create.ctx_present_mask into the open file so later phases

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -336,6 +336,7 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.set-sparse-ioctl
     smb2.sharemode
     smb2.tcon
+    smb2.timestamps
     smb2.winattr2
     # Unified-ACL coverage: every smb2.acls subtest runs green individually.
     # The combined smb2.acls suite stays disabled (shared-process deltree


### PR DESCRIPTION
## Summary

Brings the SMB2 server's LastWriteTime handling in line with MS-FSA / MS-FSCC, greening the `smb2.timestamps` smbtorture suite on the memfs backend (was 5/17 subtests failing).

Three behaviours were missing or wrong:

- **Write-time sentinels.** A `SET FileBasicInformation` timestamp of `0` (OMIT), `-1` (FREEZE) or `-2` (THAW) means "do not change this field." This was only honored for creation time; `atime`/`mtime`/`ctime` were always overwritten, so an omitted field was clobbered with a year-1601 value. Now all four fields honor the sentinels. *(fixes `freeze-thaw`, `delayed-write-vs-setbasic`)*

- **EndOfFile vs AllocationInfo.** Setting `EndOfFile` advances LastWriteTime (it changes the data extent). Setting `AllocationInfo` does **not**, unless the requested allocation is below the current EOF — in which case the file is truncated and the write time advances. The previous code collapsed both into `setattr(size=value)`, which never advanced the write time and also spuriously grew files on an allocation hint. *(fixes `delayed-write-vs-seteof`, `modern_write_time_update-2`)*

- **Sticky write time.** Once a handle explicitly sets a real write time it has "taken control" of it: that handle's own subsequent data writes and size sets stop advancing the write time (per-handle, for the life of the open), while other handles' writes still do. Sticky writes restore the pre-write mtime reported by the VFS. *(fixes `modern_write_time_update-1`)*

All changes are in the SMB layer; no VFS API or backend changes.

`smb2.timestamps` is enabled for **memfs** only. The other backends have pre-existing timestamp-storage gaps unrelated to this change (cairn stores no birth time, diskfs rejects the basic-info set, and the passthrough backends can't round-trip out-of-range `time_t`), so they stay disabled.

Not addressed here (different root causes, not write-time semantics): `smb2.timestamp_resolution.resolution1` (needs the Windows deferred/2-second write-time model), `smb2.setinfo` (CREATE returns INVALID_PARAMETER), `smb2.mkdir` (CREATE hang).

## Verification

- `smb2.timestamps` passes on memfs (17/17) under both Debug (ASan) and Release.
- No regressions in the currently-enabled memfs suites (check-sharemode, sharemode, set-sparse-ioctl, create_no_streams, winattr2, compound_find, connect, notify-inotify, secleak, tcon, session.signing-aes-128-cmac).
- `make syntax-check`, `copyright-check`, `reuse-lint`, Release/Debug builds, and scan-build (`build_clang`, "No bugs found") all clean.