### PR TITLE
smb2: fix durable-handle teardown semantics and per-session 3.1.1 preauth signing

### DIFF
--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -490,6 +490,15 @@ chimera_smb_compound_reply(struct chimera_smb_compound *compound)
         chimera_smb_preauth_extend(conn->preauth_hash,
                                    (uint8_t *) evpl_iovec_data(&reply_iov[0]) + reply_hdr_len,
                                    preauth_fold_len);
+
+        /* Once the NEGOTIATE response is folded in, conn->preauth_hash holds
+         * the post-NEGOTIATE baseline (MS-SMB2 Connection.PreauthIntegrity
+         * HashValue).  Snapshot it so each subsequent session's preauth hash
+         * can restart from here (see the request-fold path). */
+        if (compound->requests[0]->smb2_hdr.command == SMB2_NEGOTIATE) {
+            memcpy(conn->negotiate_preauth_hash, conn->preauth_hash,
+                   sizeof(conn->negotiate_preauth_hash));
+        }
     }
 
     if (conn->protocol == EVPL_DATAGRAM_RDMACM_RC) {
@@ -1059,12 +1068,24 @@ chimera_smb_server_handle_smb2(
     /* SMB 3.1.1 preauth integrity: fold the raw NEGOTIATE / SESSION_SETUP
      * request into the running hash before dispatch, so the SESSION_SETUP
      * handler derives the signing key over a hash that includes this request.
-     * Maintained unconditionally for these commands; only consumed at 3.1.1. */
+     * Maintained unconditionally for these commands; only consumed at 3.1.1.
+     *
+     * A SESSION_SETUP whose header SessionId is 0 starts a brand-new
+     * authentication (the first leg of a new session, including a re-auth
+     * after LOGOFF on the same connection).  Per MS-SMB2 3.3.5.5.3 that
+     * session's preauth hash restarts from the post-NEGOTIATE baseline, not
+     * from whatever earlier sessions accumulated -- otherwise the signing key
+     * is derived over the wrong hash and the client rejects the session. */
     if (compound->num_requests > 0 &&
         (compound->requests[0]->smb2_hdr.command == SMB2_NEGOTIATE ||
          compound->requests[0]->smb2_hdr.command == SMB2_SESSION_SETUP)) {
         uint8_t *msg = malloc(length);
         if (msg) {
+            if (compound->requests[0]->smb2_hdr.command == SMB2_SESSION_SETUP &&
+                compound->requests[0]->smb2_hdr.session_id == 0) {
+                memcpy(conn->preauth_hash, conn->negotiate_preauth_hash,
+                       sizeof(conn->preauth_hash));
+            }
             evpl_iovec_cursor_copy(&preauth_cursor, msg, length);
             chimera_smb_preauth_extend(conn->preauth_hash, msg, length);
             free(msg);
@@ -1419,6 +1440,7 @@ chimera_smb_server_accept(
     memset(&conn->gssapi_ctx, 0, sizeof(conn->gssapi_ctx));
     /* SMB 3.1.1 preauth-integrity hash starts at zero for each connection. */
     memset(conn->preauth_hash, 0, sizeof(conn->preauth_hash));
+    memset(conn->negotiate_preauth_hash, 0, sizeof(conn->negotiate_preauth_hash));
     conn->rdma_niov   = 0;
     conn->rdma_length = 0;
 
@@ -1492,6 +1514,15 @@ chimera_smb_server_thread_destroy(void *data)
     struct chimera_smb_conn           *conn;
     struct chimera_smb_compound       *compound;
     struct chimera_smb_session_handle *session_handle;
+
+    /* Release any durable/persistent handles still parked in the shared
+     * registry while this thread's vfs_thread is alive.  Each parked open
+     * pins a VFS open handle; leaving it referenced makes the VFS close
+     * thread spin and chimera_vfs_destroy hang.  Must run before the
+     * free_open_files drain below so the released opens are reclaimed. */
+    if (thread->shared->config.persistent_handles) {
+        chimera_smb_durable_drain_all(thread);
+    }
 
     while (thread->free_compounds) {
         compound = thread->free_compounds;

--- a/src/server/smb/smb_durable.c
+++ b/src/server/smb/smb_durable.c
@@ -360,6 +360,67 @@ chimera_smb_durable_sweep(struct chimera_server_smb_thread *thread)
     }
 } /* chimera_smb_durable_sweep */
 
+/* Release every registry entry's live open at thread shutdown.  A parked
+ * durable/persistent handle keeps its VFS open handle referenced
+ * indefinitely; without this the VFS close thread can never reach a
+ * quiescent (zero open handles) state and chimera_vfs_destroy hangs.
+ *
+ * Runs from the SMB thread-destroy path, which still has a live vfs_thread
+ * (protocols are destroyed before the VFS, precisely so they can release
+ * their open handles).  By that point all connections are gone, so any
+ * remaining entry with a live open_file is orphaned state to reclaim --
+ * persistent handles included (their in-memory open must be released even
+ * though the on-disk record is intentionally left for restart recovery).
+ * Cold entries (open_file == NULL) only hold bookkeeping, freed by
+ * chimera_smb_durable_table_destroy.
+ *
+ * Only the VFS open handle is released here; the open's leases / share
+ * reservation / byte-range locks are deliberately NOT drained.  Draining a
+ * lease pumps any pending acquire queued behind it (e.g. a blocking lock
+ * whose connection already dropped), whose completion callback would try to
+ * send a reply -- allocating a reply iovec on this teardown thread for a
+ * dead connection, which trips the cross-thread iovec guard.  At shutdown
+ * those pending waiters have no live connection to answer, so dropping them
+ * is correct; the leftover lease objects are reclaimed wholesale when
+ * chimera_vfs_state_destroy frees the per-file state (it never walks the
+ * lease lists), and no operation runs after thread destroy to observe a
+ * dangling lease. */
+SYMBOL_EXPORT void
+chimera_smb_durable_drain_all(struct chimera_server_smb_thread *thread)
+{
+    struct chimera_server_smb_shared *shared = thread->shared;
+    struct chimera_smb_durable_entry *entry, *tmp;
+    struct chimera_smb_durable_entry *reap = NULL;
+
+    pthread_mutex_lock(&shared->durable.lock);
+
+    HASH_ITER(hh, shared->durable.by_pid, entry, tmp)
+    {
+        if (!entry->open_file) {
+            continue;
+        }
+        HASH_DELETE(hh, shared->durable.by_pid, entry);
+        entry->reap_next = reap;
+        reap             = entry;
+    }
+
+    pthread_mutex_unlock(&shared->durable.lock);
+
+    while (reap) {
+        struct chimera_smb_open_file *open_file = reap->open_file;
+        entry = reap;
+        reap  = reap->reap_next;
+
+        if (open_file->handle) {
+            chimera_vfs_release(thread->vfs_thread, open_file->handle);
+            open_file->handle = NULL;
+        }
+        chimera_smb_open_file_free(thread, open_file);
+
+        free(entry);
+    }
+} /* chimera_smb_durable_drain_all */
+
 /* ------------------------------------------------------------------ *
 *  Record (de)serialization for backend persistence                  *
 * ------------------------------------------------------------------ */

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -645,10 +645,18 @@ struct chimera_smb_conn {
     uint8_t                            client_guid[16];
     uint8_t                            client_security_mode;
     uint32_t                           client_capabilities;
-    /* SMB 3.1.1 preauth-integrity running hash (SHA-512), extended over the
-     * NEGOTIATE and SESSION_SETUP request/response chain. Reset per connection
-     * at accept. Only consumed when the negotiated dialect is 3.1.1. */
+    /* SMB 3.1.1 preauth-integrity running hash (SHA-512).  preauth_hash is the
+     * per-session-setup running value: it is reset to negotiate_preauth_hash at
+     * the start of every new authentication (a SESSION_SETUP whose header
+     * SessionId is 0) and then extended over that session's SESSION_SETUP
+     * request/response chain, so the signing key derives over the per-session
+     * hash MS-SMB2 3.3.5.5.3 mandates -- not a value that keeps accumulating
+     * across multiple sessions / logoff-reauth on the same connection.
+     * negotiate_preauth_hash is the post-NEGOTIATE baseline (MS-SMB2
+     * Connection.PreauthIntegrityHashValue).  Both reset per connection at
+     * accept; only consumed when the negotiated dialect is 3.1.1. */
     uint8_t                            preauth_hash[SMB2_PREAUTH_HASH_SIZE];
+    uint8_t                            negotiate_preauth_hash[SMB2_PREAUTH_HASH_SIZE];
     uint32_t                           requests_completed;
     int                                rdma_max_send;
     int                                rdma_niov;
@@ -807,6 +815,13 @@ void
 chimera_smb_durable_sweep(
     struct chimera_server_smb_thread *thread);
 
+/* Release every registry entry's live open at thread shutdown so the VFS
+ * close thread can drain.  Without this a parked durable handle's VFS open
+ * handle leaks and chimera_vfs_destroy hangs waiting for it. */
+void
+chimera_smb_durable_drain_all(
+    struct chimera_server_smb_thread *thread);
+
 /* Purge a parked (disconnected) durable open by persistent id when a new
  * conflicting open arrives.  Returns true iff found+purged.  No-op for live,
  * persistent, cold, or unknown ids. */
@@ -908,7 +923,8 @@ static inline void
 chimera_smb_tree_free(
     struct chimera_server_smb_thread *thread,
     struct chimera_server_smb_shared *shared,
-    struct chimera_smb_tree          *tree);
+    struct chimera_smb_tree          *tree,
+    bool                              preserve_durable);
 
 /*
  * Open-file lifetime model (current; Phase 3 will change this):
@@ -1058,7 +1074,8 @@ static inline void
 chimera_smb_session_release(
     struct chimera_server_smb_thread *thread,
     struct chimera_server_smb_shared *shared,
-    struct chimera_smb_session       *session)
+    struct chimera_smb_session       *session,
+    bool                              preserve_durable)
 {
     struct chimera_smb_tree *tree;
     int                      destroy = 0;
@@ -1090,7 +1107,7 @@ chimera_smb_session_release(
 
             if (tree) {
                 session->trees[i] = NULL;
-                chimera_smb_tree_free(thread, shared, tree);
+                chimera_smb_tree_free(thread, shared, tree, preserve_durable);
             }
         }
 
@@ -1229,7 +1246,10 @@ chimera_smb_conn_free(
             session_handle->ctx = GSS_C_NO_CONTEXT;
         }
 
-        chimera_smb_session_release(thread, thread->shared, session_handle->session);
+        /* The transport for this connection has dropped: any durable handle
+         * left open on a session whose last channel this was must be preserved
+         * for reconnect (preserve_durable = true). */
+        chimera_smb_session_release(thread, thread->shared, session_handle->session, true);
 
         chimera_smb_session_handle_free(thread, session_handle);
     }
@@ -1289,7 +1309,8 @@ static inline void
 chimera_smb_tree_free(
     struct chimera_server_smb_thread *thread,
     struct chimera_server_smb_shared *shared,
-    struct chimera_smb_tree          *tree)
+    struct chimera_smb_tree          *tree,
+    bool                              preserve_durable)
 {
     struct chimera_smb_open_file *open_file, *tmp;
     int                           i;
@@ -1303,14 +1324,22 @@ chimera_smb_tree_free(
             chimera_smb_abort_if(open_file->refcnt == 0, "open file refcnt is 0 at tree destruction");
             HASH_DELETE(hh, tree->open_files[i], open_file);
 
-            /* Durable/persistent opens survive the connection: keep the object
-             * allocated with its leases, share reservation, byte-range locks
-             * and VFS handle intact, and hand ownership to the durable registry
-             * with a reconnect deadline.  Do NOT mark CLOSED (a reconnect must
-             * be able to re-home it), drain locks, release sharemode, or free.
-             * The single tree reference becomes the registry's reference, so
-             * refcnt is left untouched (steady-state 1). */
-            if (open_file->durable_flags) {
+            /* A durable/persistent open survives the teardown of its session
+             * (connection loss or a graceful LOGOFF, MS-SMB2 3.3.5.6): keep the
+             * object allocated with its leases, share reservation, byte-range
+             * locks and VFS handle intact, and hand ownership to the durable
+             * registry with a reconnect deadline.  Do NOT mark CLOSED (a
+             * reconnect must be able to re-home it), drain locks, release
+             * sharemode, or free.  The single tree reference becomes the
+             * registry's reference, so refcnt is left untouched (steady-state 1).
+             *
+             * A TREE_DISCONNECT (preserve_durable == false) is the client
+             * explicitly relinquishing every open on that tree (MS-SMB2
+             * 3.3.5.7); the durable property does not apply, so fall through to
+             * the normal close path, which also forgets the registry entry --
+             * a later durable reconnect with the stale FileId then correctly
+             * returns OBJECT_NAME_NOT_FOUND. */
+            if (open_file->durable_flags && preserve_durable) {
                 open_file->flags      |= CHIMERA_SMB_OPEN_FILE_PARKED;
                 open_file->create_conn = NULL;
                 /* park acquires the registry lock under this bucket lock —
@@ -1330,6 +1359,13 @@ chimera_smb_tree_free(
             open_file->refcnt--;
 
             if (open_file->refcnt == 0) {
+                /* Final teardown of a live durable open on a graceful
+                 * tree/session teardown: drop its registry entry so a later
+                 * reconnect with the stale FileId is not matched against a
+                 * freed open_file. */
+                if (open_file->durable_flags) {
+                    chimera_smb_durable_forget(shared, open_file->file_id.pid);
+                }
                 chimera_smb_open_file_drain_locks(thread, open_file);
                 if (open_file->handle) {
                     chimera_vfs_release(thread->vfs_thread, open_file->handle);

--- a/src/server/smb/smb_proc_logoff.c
+++ b/src/server/smb/smb_proc_logoff.c
@@ -20,7 +20,10 @@ chimera_smb_logoff(struct chimera_smb_request *request)
 
     chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
 
-    chimera_smb_session_release(thread, thread->shared, session_handle->session);
+    /* MS-SMB2 3.3.5.6: LOGOFF closes the session's non-durable opens but
+     * DISASSOCIATES (preserves) any durable/persistent handle so a later
+     * session on the same transport can durably reconnect it. */
+    chimera_smb_session_release(thread, thread->shared, session_handle->session, true);
 
     HASH_DELETE(hh, conn->session_handles, session_handle);
 

--- a/src/server/smb/smb_proc_session_setup.c
+++ b/src/server/smb/smb_proc_session_setup.c
@@ -285,7 +285,9 @@ chimera_smb_session_setup(struct chimera_smb_request *request)
              * remove it there before freeing — otherwise connection teardown
              * iterates it again and double-releases the session. */
             HASH_DEL(conn->session_handles, request->session_handle);
-            chimera_smb_session_release(thread, shared, request->session_handle->session);
+            /* Auth failed: the session was never authorized and holds no
+             * durable opens, so nothing to preserve. */
+            chimera_smb_session_release(thread, shared, request->session_handle->session, false);
             chimera_smb_session_handle_free(thread, request->session_handle);
             request->session_handle   = NULL;
             conn->last_session_handle = NULL;

--- a/src/server/smb/smb_proc_tree_disconnect.c
+++ b/src/server/smb/smb_proc_tree_disconnect.c
@@ -27,7 +27,10 @@ chimera_smb_tree_disconnect(struct chimera_smb_request *request)
 
     if (request->tree->refcnt == 0) {
         session->trees[request->tree->tree_id] = NULL;
-        chimera_smb_tree_free(thread, thread->shared, request->tree);
+        /* A graceful TREE_DISCONNECT relinquishes every open on the tree
+         * (MS-SMB2 3.3.5.7); durable handles are closed, not preserved
+         * (preserve_durable = false). */
+        chimera_smb_tree_free(thread, thread->shared, request->tree, false);
     }
 
     pthread_mutex_unlock(&session->lock);

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -324,6 +324,12 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.compound_find
     smb2.connect
     smb2.create_no_streams
+    # SMB3 durable/persistent handle suites that pass end-to-end on memfs with
+    # the in-memory durable registry (the harness runs the server with
+    # persistent handles enabled).  smb2.durable-open / -v2-open still have
+    # individual gaps and stay disabled until fully green.
+    smb2.durable-open-disconnect
+    smb2.durable-v2-delay
     smb2.notify-inotify
     smb2.secleak
     smb2.session.signing-aes-128-cmac

--- a/src/server/smb/tests/smbtorture_test.c
+++ b/src/server/smb/tests/smbtorture_test.c
@@ -265,6 +265,13 @@ main(
     /* Initialize server configuration */
     config = chimera_server_config_init();
 
+    /* Exercise the real SMB3 durable/persistent-handle path (as the WPTS
+     * harness does via CHIMERA_SMB_PERSISTENT).  Without it the server refuses
+     * every durable grant, and the durable smbtorture suites take their
+     * not-granted failure branch -- which in several tests leaves a tree/session
+     * pointer NULL and then dereferences it in cleanup, crashing the client. */
+    chimera_server_config_set_smb_persistent_handles(config, 1);
+
     /* Configure backend-specific modules */
     if (strcmp(backend, "diskfs_io_uring") == 0 ||
         strcmp(backend, "diskfs_aio") == 0) {


### PR DESCRIPTION
## Summary

The Samba `smbtorture` durable-handle suites crashed the client (PANIC, Signal 11) on every backend, in `smb2.durable-open.reopen3` and `smb2.replay.dhv2-pending2n-vs-oplock-sane`. Both crashes are the *client* NULL-dereferencing a tree/session pointer in its own cleanup, provoked by non-conformant server responses on the durable path. Root-causing surfaced three distinct server defects plus a shutdown hang, all only reachable once durable/persistent handles are actually exercised.

### Root causes and fixes

1. **Durable path was never exercised by the harness.** `smbtorture_test.c` never set `persistent_handles`, so the server refused every durable grant. Several durable tests then take their not-granted failure branch, which leaves `tree2`/`tree` NULL and dereferences it in cleanup (`smb2_util_unlink`/`smb2_util_close` on a NULL tree) → client SEGV. Enable persistent handles in the harness, matching what the WPTS harness already does via `CHIMERA_SMB_PERSISTENT`, so the real durable code runs.

2. **Durable teardown ignored *how* the handle was relinquished.** `chimera_smb_tree_free` parked durable opens unconditionally, so even a graceful `TREE_DISCONNECT` preserved the handle. Per MS-SMB2 3.3.5.7 a TREE_DISCONNECT closes every open on the tree (`reopen3` asserts the later durable reconnect returns `OBJECT_NAME_NOT_FOUND`), while 3.3.5.6 LOGOFF and an unexpected connection loss *preserve* durable handles (`reopen4` asserts the reconnect succeeds). Thread a `preserve_durable` flag through `tree_free`/`session_release`: TREE_DISCONNECT closes and forgets the registry entry; LOGOFF and connection drop park for reconnect.

3. **SMB 3.1.1 per-session preauth hash was connection-wide.** `reopen4` logs off and re-authenticates a new session on the same transport. The preauth-integrity running hash was a single `conn->preauth_hash`, so the second session's signing key was derived over a hash that still included the first session's SESSION_SETUP messages; the modern Samba client rejected the session and crashed in cleanup. Snapshot the post-NEGOTIATE baseline (`Connection.PreauthIntegrityHashValue`) and restart the running hash from it whenever a SESSION_SETUP with header `SessionId == 0` begins a new authentication (MS-SMB2 3.3.5.5.3). This is a general multi-session-per-connection signing fix, not durable-specific.

4. **Shutdown hang / cross-thread iovec abort.** A parked durable open pins its VFS open handle, so `chimera_vfs_destroy` hangs waiting for the close thread to drain. Release parked durable opens at SMB thread destroy (`chimera_smb_durable_drain_all`), releasing only the VFS open handle — deliberately *not* draining the open's leases/locks, since that would pump a pending acquire (a blocking lock from an already-dropped connection) whose completion callback would allocate a reply iovec on the teardown thread and trip the cross-thread iovec guard. The leftover lease state is reclaimed wholesale by `chimera_vfs_state_destroy`.

### Results (memfs)

- `smb2.durable-open.reopen3` and `reopen4`: now fully PASS (were Signal 11).
- `smb2.replay.dhv2-pending2n-vs-oplock-sane`: no longer crashes — reaches an ordinary failure (deep durable-replay semantics remain unimplemented; the full `smb2.replay` suite stays disabled).
- `smb2.durable-open-disconnect` and `smb2.durable-v2-delay`: now fully green — added to `SMBTORTURE_ENABLED_memfs`.
- All previously-green memfs suites still pass (`sharemode`, `create_no_streams`, `check-sharemode`, `connect`, `tcon`, the ACL subtests, etc.); no crashes/aborts/leaks under ASan+LSan.

`smb2.durable-open` overall is 12/25 on memfs; the remaining failures are unfinished durable semantics, so the suite stays disabled in the allowlist.