### PR TITLE
smb: add named-stream (ADS) support on memfs

### DIFF
--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -375,6 +375,11 @@ main(
         chimera_server_config_set_smb_persistent_handles(server_config, json_is_true(json_value));
     }
 
+    json_value = json_object_get(server_params, "smb_named_streams");
+    if (json_is_boolean(json_value)) {
+        chimera_server_config_set_smb_named_streams(server_config, json_is_true(json_value));
+    }
+
     json_value = json_object_get(server_params, "nfs4_session_slots");
     if (json_is_integer(json_value)) {
         int_value = json_integer_value(json_value);

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -69,6 +69,7 @@ struct chimera_server_config {
     int                                   smb_num_dialects;
     uint32_t                              smb_dialects[16];
     int                                   smb_persistent_handles;
+    int                                   smb_named_streams;
     int                                   smb_num_nic_info;
     uint32_t                              anonuid;
     uint32_t                              anongid;
@@ -145,6 +146,11 @@ chimera_server_config_init(void)
     /* SMB3 durable/persistent handles are off by default; they are an
      * opt-in feature gated by the "smb_persistent_handles" config flag. */
     config->smb_persistent_handles = 0;
+
+    /* Named streams (SMB ADS) are off by default; opt-in via the
+     * "smb_named_streams" config flag and only honored on backends that
+     * advertise CHIMERA_VFS_CAP_NAMED_STREAMS. */
+    config->smb_named_streams = 0;
 
     // SMB auth config defaults - local NTLM only
     config->smb_auth.winbind_enabled    = 0;
@@ -269,6 +275,20 @@ chimera_server_config_get_smb_persistent_handles(const struct chimera_server_con
 {
     return config->smb_persistent_handles;
 } /* chimera_server_config_get_smb_persistent_handles */
+
+SYMBOL_EXPORT void
+chimera_server_config_set_smb_named_streams(
+    struct chimera_server_config *config,
+    int                           enable)
+{
+    config->smb_named_streams = enable;
+} /* chimera_server_config_set_smb_named_streams */
+
+SYMBOL_EXPORT int
+chimera_server_config_get_smb_named_streams(const struct chimera_server_config *config)
+{
+    return config->smb_named_streams;
+} /* chimera_server_config_get_smb_named_streams */
 
 SYMBOL_EXPORT void
 chimera_server_config_set_max_open_files(

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -90,6 +90,15 @@ chimera_server_config_get_smb_persistent_handles(
     const struct chimera_server_config *config);
 
 void
+chimera_server_config_set_smb_named_streams(
+    struct chimera_server_config *config,
+    int                           enable);
+
+int
+chimera_server_config_get_smb_named_streams(
+    const struct chimera_server_config *config);
+
+void
 chimera_server_config_set_cache_ttl(
     struct chimera_server_config *config,
     int                           ttl);

--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -153,9 +153,14 @@ chimera_smb_server_init(
 
     shared->config.soft_fail_bad_req  = chimera_server_config_get_soft_fail_bad_req(config);
     shared->config.persistent_handles = chimera_server_config_get_smb_persistent_handles(config);
+    shared->config.named_streams      = chimera_server_config_get_smb_named_streams(config);
 
     if (shared->config.persistent_handles) {
         chimera_smb_info("SMB3 durable/persistent handles enabled (in-memory state)");
+    }
+
+    if (shared->config.named_streams) {
+        chimera_smb_info("SMB named streams (ADS) enabled");
     }
 
     shared->vfs     = vfs;

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -117,6 +117,7 @@ struct chimera_smb_config {
     int                            num_nic_info;
     int                            soft_fail_bad_req;
     int                            persistent_handles;
+    int                            named_streams;
     uint32_t                       capabilities;
     uint32_t                       dialects[16];
     struct chimera_smb_nic_info    nic_info[16];
@@ -348,6 +349,15 @@ struct chimera_smb_request {
             uint8_t                         persist_value[CHIMERA_SMB_DURABLE_VALUE_MAX];
             char                            parent_path[SMB_FILENAME_MAX];
             char                           *name;
+            /* Named-stream (ADS) suffix parsed off the final path component.
+             * has_stream is set when the create targets "file:stream[:$DATA]";
+             * stream_name holds the bare stream name and `name`/name_len are
+             * trimmed to the base file.  base_oh is the base file's open handle
+             * held across the chained chimera_vfs_open_stream. */
+            uint8_t                         has_stream;
+            uint16_t                        stream_name_len;
+            char                            stream_name[SMB_FILENAME_MAX];
+            struct chimera_vfs_open_handle *base_oh;
         } create;
 
         struct  {
@@ -502,30 +512,38 @@ struct chimera_smb_request {
             }                               cc_chunks[CHIMERA_SMB_COPYCHUNK_MAX];
         } ioctl;
         struct {
-            uint8_t                       info_type;
-            uint8_t                       info_class;
-            uint32_t                      addl_info;
-            uint32_t                      flags;
-            uint32_t                      output_length;
-            struct chimera_smb_file_id    file_id;
-            struct chimera_smb_attrs      r_attrs;
-            struct chimera_smb_fs_attrs   r_fs_attrs;
-            struct chimera_smb_open_file *open_file;
+            uint8_t                         info_type;
+            uint8_t                         info_class;
+            uint32_t                        addl_info;
+            uint32_t                        flags;
+            uint32_t                        output_length;
+            struct chimera_smb_file_id      file_id;
+            struct chimera_smb_attrs        r_attrs;
+            struct chimera_smb_fs_attrs     r_fs_attrs;
+            struct chimera_smb_open_file   *open_file;
             /* Security descriptor built in the getattr callback and emitted by
              * the reply builder (SMB2_INFO_SECURITY). */
-            uint8_t                       sec_buf[2048];
-            uint32_t                      sec_buf_len;
+            uint8_t                         sec_buf[2048];
+            uint32_t                        sec_buf_len;
             /* When the SD references identities not yet in the cache, the
              * getattr'd owner/group/mode + ACL are copied here so the SD can be
              * built after an async identity resolve completes (the live attrs
              * are only valid during the getattr callback). */
-            uint32_t                      sd_uid;
-            uint32_t                      sd_gid;
-            uint32_t                      sd_mode;
-            int                           sd_has_acl;
-            int                           sd_pending;
-            uint8_t                       sd_acl_storage[sizeof(struct chimera_acl) +
-                                                         64 * sizeof(struct chimera_ace)];
+            uint32_t                        sd_uid;
+            uint32_t                        sd_gid;
+            uint32_t                        sd_mode;
+            int                             sd_has_acl;
+            int                             sd_pending;
+            uint8_t                         sd_acl_storage[sizeof(struct chimera_acl) +
+                                                           64 * sizeof(struct chimera_ace)];
+            /* FileStreamInformation: the packed VFS list_streams records are
+             * held here from the list_streams callback until the reply builder
+             * emits them as MS-FSCC FILE_STREAM_INFORMATION entries.
+             * stream_base_handle is a temporary handle on the base file. */
+            struct chimera_vfs_open_handle *stream_base_handle;
+            uint32_t                        stream_record_len;
+            uint32_t                        stream_record_count;
+            uint8_t                         stream_records[4096];
         } query_info;
 
         struct {

--- a/src/server/smb/smb_proc_close.c
+++ b/src/server/smb/smb_proc_close.c
@@ -100,6 +100,57 @@ chimera_smb_close_doc_open_parent_callback(
         request);
 } /* chimera_smb_close_doc_open_parent_callback */
 
+/* Completion of a stream delete-on-close remove_stream. */
+static void
+chimera_smb_close_stream_remove_callback(
+    enum chimera_vfs_error          error_code,
+    const struct chimera_vfs_attrs *pre_attr,
+    const struct chimera_vfs_attrs *post_attr,
+    void                           *private_data)
+{
+    struct chimera_smb_request *request    = private_data;
+    struct chimera_vfs_thread  *vfs_thread = request->compound->thread->vfs_thread;
+
+    if (error_code) {
+        chimera_smb_debug("stream delete-on-close: remove_stream failed (error %d)",
+                          error_code);
+    }
+
+    chimera_vfs_release(vfs_thread, request->close.parent_handle);
+    chimera_smb_open_file_release(request, request->close.open_file);
+    chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
+} /* chimera_smb_close_stream_remove_callback */
+
+/* The base file is open; remove the named stream that was flagged
+ * delete-on-close. */
+static void
+chimera_smb_close_stream_open_callback(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *oh,
+    void                           *private_data)
+{
+    struct chimera_smb_request   *request    = private_data;
+    struct chimera_vfs_thread    *vfs_thread = request->compound->thread->vfs_thread;
+    struct chimera_smb_open_file *open_file  = request->close.open_file;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        chimera_smb_open_file_release(request, open_file);
+        chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
+        return;
+    }
+
+    request->close.parent_handle = oh;
+
+    chimera_vfs_remove_stream(
+        vfs_thread,
+        &request->session_handle->session->cred,
+        oh,
+        open_file->stream_name,
+        open_file->stream_name_len,
+        chimera_smb_close_stream_remove_callback,
+        request);
+} /* chimera_smb_close_stream_open_callback */
+
 /*
  * Release the VFS handle and check for delete-on-close.
  *
@@ -113,6 +164,7 @@ chimera_smb_close_release(struct chimera_smb_request *request)
     struct chimera_smb_open_file *open_file  = request->close.open_file;
     struct chimera_vfs_thread    *vfs_thread = request->compound->thread->vfs_thread;
     int                           need_doc;
+    int                           stream_delete;
 
     if (!open_file->handle) {
         chimera_smb_open_file_release(request, open_file);
@@ -120,12 +172,33 @@ chimera_smb_close_release(struct chimera_smb_request *request)
         return;
     }
 
+    /* A named stream flagged delete-on-close removes only the stream (never
+     * the base file) and never armed the VFS doc mechanism. */
+    stream_delete = (open_file->flags & CHIMERA_SMB_OPEN_FILE_FLAG_STREAM) &&
+        (open_file->flags & CHIMERA_SMB_OPEN_FILE_FLAG_DELETE_ON_CLOSE) &&
+        open_file->base_fh_len > 0;
+
     need_doc = chimera_vfs_release_doc(vfs_thread,
                                        open_file->handle,
                                        &request->close.doc_info);
 
     /* Detach VFS handle — it has been released (or consumed by DOC) */
     open_file->handle = NULL;
+
+    if (stream_delete) {
+        /* The stream handle is released above; open the base file and remove
+         * the stream.  open_file (with stream_name/base_fh) stays valid until
+         * the remove completes. */
+        chimera_vfs_open_fh(
+            vfs_thread,
+            &request->session_handle->session->cred,
+            open_file->base_fh,
+            open_file->base_fh_len,
+            CHIMERA_VFS_OPEN_INFERRED | CHIMERA_VFS_OPEN_PATH,
+            chimera_smb_close_stream_open_callback,
+            request);
+        return;
+    }
 
     if (need_doc && request->close.doc_info.parent_fh_len > 0) {
         chimera_vfs_open_fh(

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -123,6 +123,10 @@ chimera_smb_create_gen_open_file(
     open_file->name_len = name_len;
     memcpy(open_file->name, name, open_file->name_len);
 
+    /* Stream identity is set by the named-stream create path; default to none. */
+    open_file->stream_name_len = 0;
+    open_file->base_fh_len     = 0;
+
     /* Check share mode conflicts for regular file opens.
      * Attribute-only opens (READ_ATTRIBUTES, SYNCHRONIZE, etc.)
      * bypass share mode enforcement, matching Windows/NTFS behavior.
@@ -799,6 +803,137 @@ chimera_smb_create_mkdir_callback(
 
 } /* chimera_smb_create_mkdir_callback */
 
+/* Completion of the chained chimera_vfs_open_stream for a "file:stream" CREATE.
+ * Builds the SMB open_file around the STREAM handle (so reads/writes/setinfo
+ * target the stream) and marshals the reply (base metadata + stream size). */
+static void
+chimera_smb_create_open_stream_callback(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *stream_oh,
+    struct chimera_vfs_attrs       *attr,
+    void                           *private_data)
+{
+    struct chimera_smb_request     *request    = private_data;
+    struct chimera_vfs_thread      *vfs_thread = request->compound->thread->vfs_thread;
+    struct chimera_vfs_open_handle *base_oh    = request->create.base_oh;
+    struct chimera_smb_open_file   *open_file;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        uint32_t status;
+
+        if (error_code == CHIMERA_VFS_ENOENT) {
+            /* Opening a non-existent stream (FILE_OPEN / FILE_OVERWRITE). */
+            status = SMB2_STATUS_OBJECT_NAME_NOT_FOUND;
+        } else if (error_code == CHIMERA_VFS_EEXIST) {
+            status = SMB2_STATUS_OBJECT_NAME_COLLISION;
+        } else {
+            status = chimera_smb_create_error_status(error_code);
+        }
+        chimera_vfs_release(vfs_thread, base_oh);
+        request->create.base_oh = NULL;
+        chimera_smb_create_release_parent(request);
+        chimera_smb_complete_request(request, status);
+        return;
+    }
+
+    request->create.r_created = stream_oh ? stream_oh->r_created : 0;
+
+    open_file = chimera_smb_create_gen_open_file_normal(
+        request,
+        request->create.parent_handle->fh,
+        request->create.parent_handle->fh_len,
+        request->create.name,
+        request->create.name_len,
+        request->create.create_options & SMB2_FILE_DELETE_ON_CLOSE,
+        0,             /* a named stream is never a directory */
+        stream_oh);
+
+    if (!open_file) {
+        chimera_smb_create_release_handle(vfs_thread, stream_oh);
+        chimera_vfs_release(vfs_thread, base_oh);
+        request->create.base_oh = NULL;
+        chimera_smb_create_release_parent(request);
+        chimera_smb_complete_request(request, SMB2_STATUS_SHARING_VIOLATION);
+        return;
+    }
+
+    open_file->flags          |= CHIMERA_SMB_OPEN_FILE_FLAG_STREAM;
+    open_file->stream_name_len = request->create.stream_name_len;
+    memcpy(open_file->stream_name, request->create.stream_name,
+           request->create.stream_name_len);
+    open_file->base_fh_len = base_oh->fh_len;
+    memcpy(open_file->base_fh, base_oh->fh, base_oh->fh_len);
+
+    request->create.r_open_file = open_file;
+
+    open_file->granted_access = chimera_smb_create_granted_access(request, attr);
+    open_file->maximal_access =
+        chimera_vfs_access_check(attr, &request->session_handle->session->cred,
+                                 CHIMERA_ACE_MASK_ALL);
+
+    /* attr carries the base file's metadata with the stream's size/alloc. */
+    chimera_smb_marshal_attrs(attr, &request->create.r_attrs);
+
+    /* The base handle is no longer needed; the stream handle owns the I/O. */
+    chimera_vfs_release(vfs_thread, base_oh);
+    request->create.base_oh = NULL;
+
+    chimera_smb_create_release_parent(request);
+    chimera_smb_open_file_release(request, open_file);
+    chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
+} /* chimera_smb_create_open_stream_callback */
+
+/* The base file is open; open (and per the disposition create/truncate) the
+ * named stream on it.  Gated on the backend advertising named-stream support. */
+static void
+chimera_smb_create_open_stream_chain(
+    struct chimera_smb_request     *request,
+    struct chimera_vfs_open_handle *base_oh)
+{
+    struct chimera_vfs_thread *vfs_thread = request->compound->thread->vfs_thread;
+    unsigned int               sflags     = 0;
+
+    if (!(base_oh->vfs_module->capabilities & CHIMERA_VFS_CAP_NAMED_STREAMS)) {
+        chimera_vfs_release(vfs_thread, base_oh);
+        chimera_smb_create_release_parent(request);
+        chimera_smb_complete_request(request, SMB2_STATUS_OBJECT_NAME_INVALID);
+        return;
+    }
+
+    /* The disposition applies to the stream. */
+    switch (request->create.create_disposition) {
+        case SMB2_FILE_OPEN:
+            break;
+        case SMB2_FILE_OVERWRITE:
+            sflags |= CHIMERA_VFS_OPEN_TRUNCATE;
+            break;
+        case SMB2_FILE_CREATE:
+            sflags |= CHIMERA_VFS_OPEN_CREATE | CHIMERA_VFS_OPEN_EXCLUSIVE;
+            break;
+        case SMB2_FILE_OPEN_IF:
+            sflags |= CHIMERA_VFS_OPEN_CREATE;
+            break;
+        case SMB2_FILE_OVERWRITE_IF:
+        case SMB2_FILE_SUPERSEDE:
+            sflags |= CHIMERA_VFS_OPEN_CREATE | CHIMERA_VFS_OPEN_TRUNCATE;
+            break;
+    } /* switch */
+
+    request->create.base_oh = base_oh;
+
+    chimera_vfs_open_stream(
+        vfs_thread,
+        &request->session_handle->session->cred,
+        base_oh,
+        request->create.stream_name,
+        request->create.stream_name_len,
+        sflags,
+        NULL,
+        CHIMERA_VFS_ATTR_MASK_STAT | CHIMERA_VFS_ATTR_BTIME | CHIMERA_VFS_ATTR_ACL,
+        chimera_smb_create_open_stream_callback,
+        request);
+} /* chimera_smb_create_open_stream_chain */
+
 static inline void
 chimera_smb_create_open_at_callback(
     enum chimera_vfs_error          error_code,
@@ -830,6 +965,13 @@ chimera_smb_create_open_at_callback(
         chimera_vfs_release(vfs_thread, oh);
         chimera_vfs_release(vfs_thread, request->create.parent_handle);
         chimera_smb_complete_request(request, SMB2_STATUS_ACCESS_DENIED);
+        return;
+    }
+
+    /* Named-stream open: the base file is now open; open the stream on it and
+     * build the SMB open_file around the stream handle. */
+    if (request->create.has_stream) {
+        chimera_smb_create_open_stream_chain(request, oh);
         return;
     }
 
@@ -1231,30 +1373,50 @@ chimera_smb_create_issue_open(struct chimera_smb_request *request)
         flags |= CHIMERA_VFS_OPEN_NOFOLLOW;
     }
 
-    switch (request->create.create_disposition) {
-        case SMB2_FILE_OPEN:
-        case SMB2_FILE_OVERWRITE:
-            /* Open existing only; never create. */
-            break;
-        case SMB2_FILE_SUPERSEDE:
-        case SMB2_FILE_OPEN_IF:
-        case SMB2_FILE_CREATE:
-        case SMB2_FILE_OVERWRITE_IF:
-            flags |= CHIMERA_VFS_OPEN_CREATE;
-            break;
-    } /* switch */
+    if (request->create.has_stream) {
+        /* For a named-stream open the disposition applies to the STREAM, not
+         * the base file.  Open the base file, creating it if the disposition
+         * can create, but never truncate it and never collide on it — the
+         * stream's create/exclusive/truncate semantics are applied by the
+         * chained chimera_vfs_open_stream. */
+        switch (request->create.create_disposition) {
+            case SMB2_FILE_OPEN:
+            case SMB2_FILE_OVERWRITE:
+                /* Base must already exist. */
+                break;
+            default:
+                flags |= CHIMERA_VFS_OPEN_CREATE;
+                break;
+        } /* switch */
+    } else {
+        switch (request->create.create_disposition) {
+            case SMB2_FILE_OPEN:
+            case SMB2_FILE_OVERWRITE:
+                /* Open existing only; never create. */
+                break;
+            case SMB2_FILE_SUPERSEDE:
+            case SMB2_FILE_OPEN_IF:
+            case SMB2_FILE_CREATE:
+            case SMB2_FILE_OVERWRITE_IF:
+                flags |= CHIMERA_VFS_OPEN_CREATE;
+                break;
+        } /* switch */
 
-    /* Replacing a file's contents truncates it and stamps it ARCHIVE
-    * (MS-FSCC).  OPEN_TRUNCATE makes the backend apply both to an existing
-    * file (a fresh create already starts empty with these attrs). */
-    if (chimera_smb_disposition_overwrites(request->create.create_disposition)) {
-        flags                                      |= CHIMERA_VFS_OPEN_TRUNCATE;
-        request->create.set_attr.va_dos_attributes |= SMB2_FILE_ATTRIBUTE_ARCHIVE;
-        request->create.set_attr.va_req_mask       |= CHIMERA_VFS_ATTR_DOS_ATTRIBUTES;
-        request->create.set_attr.va_set_mask       |= CHIMERA_VFS_ATTR_DOS_ATTRIBUTES;
+        /* Replacing a file's contents truncates it and stamps it ARCHIVE
+        * (MS-FSCC).  OPEN_TRUNCATE makes the backend apply both to an existing
+        * file (a fresh create already starts empty with these attrs). */
+        if (chimera_smb_disposition_overwrites(request->create.create_disposition)) {
+            flags                                      |= CHIMERA_VFS_OPEN_TRUNCATE;
+            request->create.set_attr.va_dos_attributes |= SMB2_FILE_ATTRIBUTE_ARCHIVE;
+            request->create.set_attr.va_req_mask       |= CHIMERA_VFS_ATTR_DOS_ATTRIBUTES;
+            request->create.set_attr.va_set_mask       |= CHIMERA_VFS_ATTR_DOS_ATTRIBUTES;
+        }
     }
 
-    if (chimera_smb_create_persist_prepare(request, request->create.parent_handle)) {
+    /* Persistent-handle grants are keyed by the base file name; skip them for
+     * stream opens this phase. */
+    if (!request->create.has_stream &&
+        chimera_smb_create_persist_prepare(request, request->create.parent_handle)) {
         chimera_vfs_open_at_hs(
             vfs_thread,
             &request->session_handle->session->cred,
@@ -1370,8 +1532,11 @@ chimera_smb_create_open_parent_callback(
             chimera_smb_create_mkdir_callback,
             request);
 
-    } else if (chimera_smb_disposition_overwrites(request->create.create_disposition)) {
-        /* Check the existing file's DOS attributes before overwriting. */
+    } else if (!request->create.has_stream &&
+               chimera_smb_disposition_overwrites(request->create.create_disposition)) {
+        /* Check the existing file's DOS attributes before overwriting.  A
+         * stream open never truncates the base file, so this base-file check is
+         * skipped for streams (the disposition applies to the stream). */
         chimera_vfs_lookup_at(
             vfs_thread,
             &request->session_handle->session->cred,
@@ -1602,6 +1767,75 @@ chimera_smb_durable_reconnect(struct chimera_smb_request *request)
                         request);
 } /* chimera_smb_durable_reconnect */
 
+/* Parse an SMB stream-name suffix out of the final path component
+ * ("file:stream[:$DATA]").  On return *r_base_len is the length of the base
+ * file name (the bytes before the first ':'); when a non-empty named stream is
+ * present *r_has_stream is set and *r_stream / *r_stream_len point at the bare
+ * stream name.  The unnamed default data fork ("file::$DATA") parses with
+ * has_stream = 0 (open the base file).  Returns SMB2_STATUS_SUCCESS, or
+ * SMB2_STATUS_OBJECT_NAME_INVALID for malformed/unsupported syntax (only the
+ * $DATA stream type is supported). */
+static uint32_t
+chimera_smb_parse_stream_name(
+    const char  *name,
+    uint16_t     name_len,
+    uint16_t    *r_base_len,
+    const char **r_stream,
+    uint16_t    *r_stream_len,
+    uint8_t     *r_has_stream)
+{
+    const char *colon = memchr(name, ':', name_len);
+    const char *rest, *type, *colon2;
+    uint16_t    base_len, rest_len, stream_len;
+
+    *r_has_stream = 0;
+
+    if (!colon) {
+        *r_base_len = name_len;
+        return SMB2_STATUS_SUCCESS;
+    }
+
+    base_len = (uint16_t) (colon - name);
+    rest     = colon + 1;
+    rest_len = name_len - base_len - 1;
+
+    /* Split an optional ":$TYPE" suffix off the stream name. */
+    colon2 = memchr(rest, ':', rest_len);
+    if (colon2) {
+        stream_len = (uint16_t) (colon2 - rest);
+        type       = colon2 + 1;
+        uint16_t type_len = rest_len - stream_len - 1;
+
+        /* Only the $DATA stream type is supported. */
+        if (type_len != 5 || strncasecmp(type, "$DATA", 5) != 0) {
+            return SMB2_STATUS_OBJECT_NAME_INVALID;
+        }
+    } else {
+        stream_len = rest_len;   /* implied $DATA */
+    }
+
+    /* Stream names cannot contain path separators. */
+    if (memchr(rest, '\\', stream_len) || memchr(rest, '/', stream_len)) {
+        return SMB2_STATUS_OBJECT_NAME_INVALID;
+    }
+
+    if (stream_len == 0) {
+        /* "file::$DATA" is the default data fork (open the base file); a bare
+         * trailing "file:" with neither name nor type is malformed. */
+        if (!colon2) {
+            return SMB2_STATUS_OBJECT_NAME_INVALID;
+        }
+        *r_base_len = base_len;
+        return SMB2_STATUS_SUCCESS;
+    }
+
+    *r_has_stream = 1;
+    *r_base_len   = base_len;
+    *r_stream     = rest;
+    *r_stream_len = stream_len;
+    return SMB2_STATUS_SUCCESS;
+} /* chimera_smb_parse_stream_name */
+
 void
 chimera_smb_create(struct chimera_smb_request *request)
 {
@@ -1610,13 +1844,45 @@ chimera_smb_create(struct chimera_smb_request *request)
     enum chimera_smb_pipe_magic   pipe_magic;
     chimera_smb_pipe_transceive_t transceive;
 
-    /* Reject stream-name syntax (file:stream[:$DATA]) — streams unsupported.
-     * Done here rather than in parse so the OBJECT_NAME_INVALID response is
-     * returned to the client instead of triggering a parse-error disconnect. */
+    request->create.has_stream = 0;
+    request->create.base_oh    = NULL;
+
+    /* Handle stream-name syntax (file:stream[:$DATA]).  When named streams are
+     * disabled (config off, or the backend lacks the capability) the legacy
+     * behavior is preserved: reject any ':' name with OBJECT_NAME_INVALID.
+     * Done here rather than in parse so the response is returned to the client
+     * instead of triggering a parse-error disconnect. */
     if (request->create.name_len > 0 &&
         memchr(request->create.name, ':', request->create.name_len)) {
-        chimera_smb_complete_request(request, SMB2_STATUS_OBJECT_NAME_INVALID);
-        return;
+
+        if (!request->compound->thread->shared->config.named_streams) {
+            chimera_smb_complete_request(request, SMB2_STATUS_OBJECT_NAME_INVALID);
+            return;
+        }
+
+        const char *sname      = NULL;
+        uint16_t    base_len   = request->create.name_len;
+        uint16_t    sname_len  = 0;
+        uint8_t     has_stream = 0;
+        uint32_t    pstatus    = chimera_smb_parse_stream_name(
+            request->create.name, request->create.name_len,
+            &base_len, &sname, &sname_len, &has_stream);
+
+        if (pstatus != SMB2_STATUS_SUCCESS) {
+            chimera_smb_complete_request(request, pstatus);
+            return;
+        }
+
+        /* Trim the final component to the base file; the stream (if any) is
+         * opened after the base file via chimera_vfs_open_stream. */
+        request->create.name_len       = base_len;
+        request->create.name[base_len] = '\0';
+
+        if (has_stream) {
+            request->create.has_stream      = 1;
+            request->create.stream_name_len = sname_len;
+            memcpy(request->create.stream_name, sname, sname_len);
+        }
     }
 
     /* No persistent-handle grant by default; set by the reconnect path (cold

--- a/src/server/smb/smb_proc_query_info.c
+++ b/src/server/smb/smb_proc_query_info.c
@@ -7,6 +7,8 @@
 #include "smb_string.h"
 #include "common/misc.h"
 #include "vfs/vfs.h"
+#include "vfs/vfs_procs.h"
+#include "vfs/vfs_release.h"
 
 static void
 chimera_smb_query_info_getattr_callback(
@@ -68,6 +70,180 @@ chimera_smb_query_info_getattr_callback(
     }
 } /* chimera_smb_query_info_getattr_callback */
 
+/* Walk the packed VFS list_streams records and either measure (cursor == NULL)
+ * or emit MS-FSCC 2.4.43 FILE_STREAM_INFORMATION entries.  Each entry is
+ *   NextEntryOffset(4) StreamNameLength(4) StreamSize(8) StreamAllocationSize(8)
+ *   StreamName(UTF-16LE)
+ * where the name is ":<stream>:$DATA" (the default fork is "::$DATA").  Returns
+ * the total output byte length. */
+static uint32_t
+chimera_smb_emit_stream_info(
+    struct chimera_smb_iconv_ctx *iconv,
+    const uint8_t                *records,
+    uint32_t                      records_len,
+    uint32_t                      count,
+    struct evpl_iovec_cursor     *cursor)
+{
+    uint32_t in      = 0;
+    uint32_t out     = 0;
+    uint32_t emitted = 0;
+
+    while (in < records_len && emitted < count) {
+        struct chimera_vfs_stream_entry entry;
+        const char                     *sname;
+        char                            disp[SMB_FILENAME_MAX + 8];
+        uint16_t                        name16[SMB_FILENAME_MAX + 8];
+        int                             name16_len;
+        uint32_t                        disp_len, entry_size, aligned, next, p;
+
+        memcpy(&entry, records + in, sizeof(entry));
+        sname = (const char *) (records + in + sizeof(entry));
+
+        /* ":" + stream-name + ":$DATA"  (default fork name_len == 0 -> "::$DATA") */
+        disp[0] = ':';
+        memcpy(disp + 1, sname, entry.name_len);
+        memcpy(disp + 1 + entry.name_len, ":$DATA", 6);
+        disp_len = 1 + entry.name_len + 6;
+
+        name16_len = chimera_smb_utf8_to_utf16le(iconv, disp, disp_len,
+                                                 name16, sizeof(name16));
+        if (name16_len < 0) {
+            name16_len = 0;
+        }
+
+        entry_size = 24 + (uint32_t) name16_len;
+        aligned    = (entry_size + 7) & ~7u;
+
+        emitted++;
+        next = (emitted < count) ? aligned : 0;
+
+        if (cursor) {
+            evpl_iovec_cursor_append_uint32(cursor, next);
+            evpl_iovec_cursor_append_uint32(cursor, (uint32_t) name16_len);
+            evpl_iovec_cursor_append_uint64(cursor, entry.size);
+            evpl_iovec_cursor_append_uint64(cursor, entry.alloc);
+            if (name16_len > 0) {
+                evpl_iovec_cursor_append_blob_unaligned(cursor, name16, name16_len);
+            }
+            for (p = entry_size; p < aligned; p++) {
+                evpl_iovec_cursor_append_uint8(cursor, 0);
+            }
+        }
+
+        out += aligned;
+        in  += (sizeof(entry) + entry.name_len + 7) & ~7u;
+    }
+
+    return out;
+} /* chimera_smb_emit_stream_info */
+
+static void
+chimera_smb_query_stream_info_list_callback(
+    enum chimera_vfs_error error_code,
+    const void            *records,
+    uint32_t               records_len,
+    uint32_t               count,
+    uint32_t               eof,
+    uint64_t               cookie,
+    void                  *private_data)
+{
+    struct chimera_smb_request *request    = private_data;
+    struct chimera_vfs_thread  *vfs_thread = request->compound->thread->vfs_thread;
+
+    chimera_vfs_release(vfs_thread, request->query_info.stream_base_handle);
+    request->query_info.stream_base_handle = NULL;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        chimera_smb_open_file_release(request, request->query_info.open_file);
+        chimera_smb_complete_request(request,
+                                     error_code == CHIMERA_VFS_ERANGE ?
+                                     SMB2_STATUS_INFO_LENGTH_MISMATCH :
+                                     SMB2_STATUS_INTERNAL_ERROR);
+        return;
+    }
+
+    memcpy(request->query_info.stream_records, records, records_len);
+    request->query_info.stream_record_len   = records_len;
+    request->query_info.stream_record_count = count;
+
+    request->query_info.output_length = chimera_smb_emit_stream_info(
+        &request->compound->thread->iconv_ctx,
+        request->query_info.stream_records,
+        records_len,
+        count,
+        NULL);
+
+    chimera_smb_open_file_release(request, request->query_info.open_file);
+    chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
+} /* chimera_smb_query_stream_info_list_callback */
+
+static void
+chimera_smb_query_stream_info_open_callback(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *oh,
+    void                           *private_data)
+{
+    struct chimera_smb_request       *request = private_data;
+    struct chimera_server_smb_thread *thread  = request->compound->thread;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        chimera_smb_open_file_release(request, request->query_info.open_file);
+        chimera_smb_complete_request(request, SMB2_STATUS_INTERNAL_ERROR);
+        return;
+    }
+
+    request->query_info.stream_base_handle = oh;
+
+    chimera_vfs_list_streams(
+        thread->vfs_thread,
+        &request->session_handle->session->cred,
+        oh,
+        0,
+        request->query_info.stream_records,
+        sizeof(request->query_info.stream_records),
+        chimera_smb_query_stream_info_list_callback,
+        request);
+} /* chimera_smb_query_stream_info_open_callback */
+
+static void
+chimera_smb_query_stream_info(struct chimera_smb_request *request)
+{
+    struct chimera_server_smb_thread *thread    = request->compound->thread;
+    struct chimera_smb_open_file     *open_file = request->query_info.open_file;
+    const uint8_t                    *base_fh;
+    uint32_t                          base_fh_len;
+
+    /* Gate: named streams must be enabled and the backend must support them;
+     * otherwise behave as before (class not implemented). */
+    if (!thread->shared->config.named_streams ||
+        !(open_file->handle->vfs_module->capabilities & CHIMERA_VFS_CAP_NAMED_STREAMS)) {
+        chimera_smb_open_file_release(request, open_file);
+        chimera_smb_complete_request(request, SMB2_STATUS_NOT_IMPLEMENTED);
+        return;
+    }
+
+    /* Enumerate the streams of the BASE file.  For a stream open the base fh is
+     * stored on the open_file; otherwise the open's own handle is the base. */
+    if (open_file->flags & CHIMERA_SMB_OPEN_FILE_FLAG_STREAM) {
+        base_fh     = open_file->base_fh;
+        base_fh_len = open_file->base_fh_len;
+    } else {
+        base_fh     = open_file->handle->fh;
+        base_fh_len = open_file->handle->fh_len;
+    }
+
+    request->query_info.stream_base_handle = NULL;
+
+    chimera_vfs_open_fh(
+        thread->vfs_thread,
+        &request->session_handle->session->cred,
+        base_fh,
+        base_fh_len,
+        CHIMERA_VFS_OPEN_PATH,
+        chimera_smb_query_stream_info_open_callback,
+        request);
+} /* chimera_smb_query_stream_info */
+
 void
 chimera_smb_query_info(struct chimera_smb_request *request)
 {
@@ -128,6 +304,11 @@ chimera_smb_query_info(struct chimera_smb_request *request)
                 case SMB2_FILE_FULL_EA_INFO:
                     request->query_info.output_length = 8;
                     break;
+                case SMB2_FILE_STREAM_INFO:
+                    /* Output length depends on the enumerated stream set, so
+                     * this class drives its own async list_streams flow. */
+                    chimera_smb_query_stream_info(request);
+                    return;
                 default:
                     status = SMB2_STATUS_NOT_IMPLEMENTED;
                     break;
@@ -233,6 +414,14 @@ chimera_smb_query_info_reply(
                 case SMB2_FILE_FULL_EA_INFO:
                     evpl_iovec_cursor_append_uint32(reply_cursor, 0);
                     evpl_iovec_cursor_append_uint32(reply_cursor, 0);
+                    break;
+                case SMB2_FILE_STREAM_INFO:
+                    chimera_smb_emit_stream_info(
+                        &request->compound->thread->iconv_ctx,
+                        request->query_info.stream_records,
+                        request->query_info.stream_record_len,
+                        request->query_info.stream_record_count,
+                        reply_cursor);
                     break;
                 default:
                     chimera_smb_abort("%s: unsupported file information class: %d",

--- a/src/server/smb/smb_proc_set_info.c
+++ b/src/server/smb/smb_proc_set_info.c
@@ -284,21 +284,31 @@ chimera_smb_set_info(struct chimera_smb_request *request)
                     if (request->set_info.attrs.smb_disposition) {
                         request->set_info.open_file->flags |=
                             CHIMERA_SMB_OPEN_FILE_FLAG_DELETE_ON_CLOSE;
-                        /* Propagate to VFS handle for final-close deletion */
-                        chimera_vfs_set_delete_on_close(
-                            request->compound->thread->vfs_thread,
-                            request->set_info.open_file->handle,
-                            request->set_info.open_file->parent_fh,
-                            request->set_info.open_file->parent_fh_len,
-                            request->set_info.open_file->name,
-                            request->set_info.open_file->name_len,
-                            &request->session_handle->session->cred);
+                        /* A named-stream delete-on-close removes only the stream
+                         * (via chimera_vfs_remove_stream in the close handler),
+                         * never the base file -- so do NOT arm the VFS doc
+                         * mechanism (which would remove_at the whole file). */
+                        if (!(request->set_info.open_file->flags &
+                              CHIMERA_SMB_OPEN_FILE_FLAG_STREAM)) {
+                            /* Propagate to VFS handle for final-close deletion */
+                            chimera_vfs_set_delete_on_close(
+                                request->compound->thread->vfs_thread,
+                                request->set_info.open_file->handle,
+                                request->set_info.open_file->parent_fh,
+                                request->set_info.open_file->parent_fh_len,
+                                request->set_info.open_file->name,
+                                request->set_info.open_file->name_len,
+                                &request->session_handle->session->cred);
+                        }
                     } else {
                         request->set_info.open_file->flags &=
                             ~CHIMERA_SMB_OPEN_FILE_FLAG_DELETE_ON_CLOSE;
-                        chimera_vfs_clear_delete_on_close(
-                            request->compound->thread->vfs_thread,
-                            request->set_info.open_file->handle);
+                        if (!(request->set_info.open_file->flags &
+                              CHIMERA_SMB_OPEN_FILE_FLAG_STREAM)) {
+                            chimera_vfs_clear_delete_on_close(
+                                request->compound->thread->vfs_thread,
+                                request->set_info.open_file->handle);
+                        }
                     }
                     chimera_smb_open_file_release(request, request->set_info.open_file);
                     chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);

--- a/src/server/smb/smb_session.h
+++ b/src/server/smb/smb_session.h
@@ -39,6 +39,10 @@ struct chimera_smb_file_id {
  * write time: subsequent implicit updates from this handle (data writes,
  * EndOfFile/Allocation sets) must not advance it for the life of the open. */
 #define CHIMERA_SMB_OPEN_FILE_WRITE_TIME_STICKY    0x00000020
+/* This open targets a named stream (SMB ADS).  open_file->handle is the VFS
+ * stream handle; stream_name + base_fh identify the stream for enumeration and
+ * delete-on-close (which removes only the stream, not the base file). */
+#define CHIMERA_SMB_OPEN_FILE_FLAG_STREAM          0x00000040
 
 /* Bits identifying which CREATE contexts a client supplied on the open. Mirrored
  * from request->create.ctx_present_mask into the open file so later phases
@@ -140,6 +144,13 @@ struct chimera_smb_open_file {
     uint8_t                          parent_fh[CHIMERA_VFS_FH_SIZE];
     char                             name[SMB_FILENAME_MAX];
     uint16_t                         pattern[SMB_FILENAME_MAX];
+    /* Named-stream (ADS) identity, valid when CHIMERA_SMB_OPEN_FILE_FLAG_STREAM
+     * is set.  base_fh is the file the stream hangs off (open_file->handle's fh
+     * points at the stream itself). */
+    uint16_t                         stream_name_len;
+    char                             stream_name[SMB_FILENAME_MAX];
+    uint16_t                         base_fh_len;
+    uint8_t                          base_fh[CHIMERA_VFS_FH_SIZE];
 };
 
 #define CHIMERA_SMB_OPEN_FILE_BUCKETS     256

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -338,6 +338,16 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.tcon
     smb2.timestamps
     smb2.winattr2
+    # Named-stream (ADS) support is implemented on memfs (config-gated
+    # smb_named_streams + CHIMERA_VFS_CAP_NAMED_STREAMS): create/read/write/
+    # enumerate (FileStreamInformation)/delete of named streams all work and
+    # several smb2.streams subtests pass (sharemodes, rename, create-disposition,
+    # zero-byte).  The full smb2.streams / smb2.sdread / smb2.ioctl-on-stream
+    # suites are NOT yet green -- remaining gaps are stream share-mode/sharing-
+    # violation semantics, FILE_ATTRIBUTE reporting on stream handles, stream-
+    # name validation edge cases, directory-stream handling, and rename-with-an-
+    # open-stream -- so those suites stay disabled until fully passing.  The test
+    # harness (smbtorture_test.c) already flips smb_named_streams on for them.
     # Unified-ACL coverage: every smb2.acls subtest runs green individually.
     # The combined smb2.acls suite stays disabled (shared-process deltree
     # cleanup cascade, see above).

--- a/src/server/smb/tests/smbtorture_test.c
+++ b/src/server/smb/tests/smbtorture_test.c
@@ -272,6 +272,18 @@ main(
      * pointer NULL and then dereferences it in cleanup, crashing the client. */
     chimera_server_config_set_smb_persistent_handles(config, 1);
 
+    /* CTest invokes this binary once per suite.  Enable named-stream (ADS)
+     * support only for the stream suites, so the negative smb2.create_no_streams
+     * suite still runs with the feature off on the same backend. */
+    for (i = 0; i < num_tests; i++) {
+        if (strcmp(tests[i], "smb2.streams") == 0 ||
+            strcmp(tests[i], "smb2.ioctl-on-stream") == 0 ||
+            strcmp(tests[i], "smb2.sdread") == 0) {
+            chimera_server_config_set_smb_named_streams(config, 1);
+            break;
+        }
+    }
+
     /* Configure backend-specific modules */
     if (strcmp(backend, "diskfs_io_uring") == 0 ||
         strcmp(backend, "diskfs_aio") == 0) {

--- a/src/vfs/CMakeLists.txt
+++ b/src/vfs/CMakeLists.txt
@@ -32,6 +32,8 @@ add_library(chimera_vfs SHARED vfs.c vfs_lsan.c
             vfs_proc_getparent.c vfs_notify.c vfs_state.c vfs_dump.c
             vfs_proc_get_xattr.c vfs_proc_set_xattr.c
             vfs_proc_list_xattrs.c vfs_proc_remove_xattr.c
+            vfs_proc_open_stream.c vfs_proc_list_streams.c
+            vfs_proc_remove_stream.c
             vfs_pnfs.c vfs_proc_get_layout.c)
 
 target_compile_definitions(chimera_vfs PRIVATE

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -80,6 +80,17 @@ struct memfs_block {
     struct evpl_iovec    iov[CHIMERA_MEMFS_BLOCK_MAX_IOV];
 };
 
+/* A regular file's data fork: a sparse array of fixed-size blocks.  The inode's
+ * default (unnamed) data fork lives in the inode union as `file`; each named
+ * stream carries its own fork.  Note the default fork's logical size lives in
+ * inode->size / inode->space_used (shared with the stat path), whereas a named
+ * stream keeps its own size/space_used (see struct memfs_named_stream). */
+struct memfs_fork {
+    struct memfs_block **blocks;
+    unsigned int         num_blocks;
+    unsigned int         max_blocks;
+};
+
 struct memfs_dirent {
     uint64_t             inum;
     uint32_t             gen;
@@ -119,6 +130,33 @@ struct memfs_xattr {
     uint32_t            value_len;
 };
 
+/* A named stream (SMB Alternate Data Stream) hung off a regular-file inode.
+ * It is an independent data fork with its own size, but shares the base file's
+ * metadata.  `id` is a stable, never-reused per-inode identifier used to encode
+ * the stream into a file handle.  `linked` is 1 while the stream is present in
+ * inode->streams (analogous to nlink); `refcnt` counts open handles.  An
+ * unlinked stream with open handles survives until its last close. */
+struct memfs_named_stream {
+    struct memfs_named_stream *next;
+    char                      *name;
+    uint16_t                   name_len;
+    uint8_t                    linked;
+    uint32_t                   id;
+    uint32_t                   refcnt;
+    uint64_t                   size;
+    uint64_t                   space_used;
+    struct memfs_fork          fork;
+};
+
+/* Per-open descriptor for a named-stream handle.  A stream open stores
+ * `(uintptr_t)desc | 1` in the open handle's vfs_private; the low tag bit
+ * distinguishes it from a plain inode pointer (heap pointers are >= 8-aligned).
+ * `stream == NULL` denotes the default/unnamed fork. */
+struct memfs_stream_open {
+    struct memfs_inode        *inode;
+    struct memfs_named_stream *stream;
+};
+
 /* Opaque per-file pNFS layout state (CHIMERA_VFS_ATTR_PNFS_LAYOUT).  memfs
  * persists and returns this blob verbatim via getattr/setattr; only the NFS
  * server interprets it.  Present (non-NULL) once the NFS server has recorded a
@@ -129,27 +167,33 @@ struct memfs_remote {
 };
 
 struct memfs_inode {
-    uint64_t             inum;
-    uint32_t             gen;
-    uint32_t             refcnt;
-    uint64_t             size;
-    uint64_t             space_used;
-    uint32_t             mode;
-    uint32_t             nlink;
-    uint32_t             uid;
-    uint32_t             gid;
-    uint64_t             rdev;
-    uint32_t             dos_attributes;
-    struct chimera_acl  *acl; /* NULL => mode-derived; CAP_ACL_NATIVE storage */
-    struct timespec      atime;
-    struct timespec      mtime;
-    struct timespec      ctime;
-    struct timespec      btime;
-    struct memfs_inode  *next;
-    struct memfs_xattr  *xattrs;
-    struct memfs_remote *remote;   /* non-NULL => pNFS stub (data lives on a DS) */
+    uint64_t                   inum;
+    uint32_t                   gen;
+    uint32_t                   refcnt;
+    uint64_t                   size;
+    uint64_t                   space_used;
+    uint32_t                   mode;
+    uint32_t                   nlink;
+    uint32_t                   uid;
+    uint32_t                   gid;
+    uint64_t                   rdev;
+    uint32_t                   dos_attributes;
+    struct chimera_acl        *acl; /* NULL => mode-derived; CAP_ACL_NATIVE storage */
+    struct timespec            atime;
+    struct timespec            mtime;
+    struct timespec            ctime;
+    struct timespec            btime;
+    struct memfs_inode        *next;
+    struct memfs_xattr        *xattrs;
+    struct memfs_remote       *remote; /* non-NULL => pNFS stub (data lives on a DS) */
 
-    pthread_mutex_t      lock;
+    /* Named streams (SMB ADS) attached to a regular file.  NULL when none.
+     * next_stream_id is a monotonic per-inode id allocator (ids are never
+     * reused so a stale stream file handle resolves to nothing). */
+    struct memfs_named_stream *streams;
+    uint32_t                   next_stream_id;
+
+    pthread_mutex_t            lock;
 
     union {
         struct {
@@ -157,11 +201,7 @@ struct memfs_inode {
             uint64_t       parent_inum;
             uint32_t       parent_gen;
         } dir;
-        struct {
-            struct memfs_block **blocks;
-            unsigned int         num_blocks;
-            unsigned int         max_blocks;
-        } file;
+        struct memfs_fork file;
         struct {
             struct memfs_symlink_target *target;
         } symlink;
@@ -212,6 +252,84 @@ memfs_fh_to_inum(
 {
     chimera_vfs_decode_fh_inum(fh, fhlen, inum, gen);
 } /* memfs_fh_to_inum */
+
+/* A named-stream file handle is the base file's inum+gen fragment with a
+ * non-zero stream id varint appended.  The base inum/gen still decode with the
+ * shared chimera_vfs_decode_fh_inum (which ignores the trailing bytes), so the
+ * stream handle resolves to the base inode; the stream id selects the fork. */
+static inline uint32_t
+memfs_encode_stream_fh(
+    const void *parent_fh,
+    uint64_t    inum,
+    uint32_t    gen,
+    uint32_t    stream_id,
+    void       *out_fh)
+{
+    uint8_t *fh  = out_fh;
+    uint8_t *ptr = fh + CHIMERA_VFS_MOUNT_ID_SIZE;
+
+    memcpy(fh, parent_fh, CHIMERA_VFS_MOUNT_ID_SIZE);
+    ptr += chimera_encode_uint64(inum, ptr);
+    ptr += chimera_encode_uint32(gen, ptr);
+    ptr += chimera_encode_uint32(stream_id, ptr);
+
+    return ptr - fh;
+} /* memfs_encode_stream_fh */
+
+static inline void
+memfs_decode_stream_fh(
+    const void *fh,
+    int         fhlen,
+    uint64_t   *inum,
+    uint32_t   *gen,
+    uint32_t   *stream_id)
+{
+    const uint8_t *ptr = (const uint8_t *) fh + CHIMERA_VFS_MOUNT_ID_SIZE;
+    const uint8_t *end = (const uint8_t *) fh + fhlen;
+
+    ptr += chimera_decode_uint64(ptr, inum);
+    ptr += chimera_decode_uint32(ptr, gen);
+
+    if (ptr < end) {
+        chimera_decode_uint32(ptr, stream_id);
+    } else {
+        *stream_id = 0;
+    }
+} /* memfs_decode_stream_fh */
+
+static inline struct memfs_named_stream *
+memfs_stream_find_by_name(
+    struct memfs_inode *inode,
+    const char         *name,
+    uint32_t            name_len)
+{
+    struct memfs_named_stream *stream;
+
+    for (stream = inode->streams; stream; stream = stream->next) {
+        if (stream->name_len == name_len &&
+            memcmp(stream->name, name, name_len) == 0) {
+            return stream;
+        }
+    }
+
+    return NULL;
+} /* memfs_stream_find_by_name */
+
+static inline struct memfs_named_stream *
+memfs_stream_find_by_id(
+    struct memfs_inode *inode,
+    uint32_t            id)
+{
+    struct memfs_named_stream *stream;
+
+    for (stream = inode->streams; stream; stream = stream->next) {
+        if (stream->id == id) {
+            return stream;
+        }
+    }
+
+    return NULL;
+} /* memfs_stream_find_by_id */
 
 static inline struct memfs_inode *
 memfs_inode_get_inum(
@@ -264,6 +382,58 @@ memfs_inode_get_fh(
 
     return memfs_inode_get_inum(shared, inum, gen);
 } /* memfs_inode_get_fh */
+
+/* Resolve (and lock) the base inode plus target named stream for a handle-based
+ * data op.  Prefers the open handle's vfs_private: a tagged value (low bit set)
+ * points at a struct memfs_stream_open (carrying base inode + named stream);
+ * an untagged non-zero value is a plain base-inode pointer; zero falls back to
+ * decoding the file handle (which may itself carry a stream id).  Returns the
+ * locked inode or NULL (caller maps to ENOENT).  *out_stream is the target
+ * named fork, or NULL for the default/unnamed fork. */
+static inline struct memfs_inode *
+memfs_resolve_io(
+    struct memfs_shared            *shared,
+    struct chimera_vfs_open_handle *handle,
+    const uint8_t                  *fh,
+    int                             fhlen,
+    struct memfs_named_stream     **out_stream)
+{
+    uint64_t            vp = handle ? handle->vfs_private : 0;
+    struct memfs_inode *inode;
+
+    *out_stream = NULL;
+
+    if (vp & 1) {
+        struct memfs_stream_open *so =
+            (struct memfs_stream_open *) (uintptr_t) (vp & ~1ULL);
+
+        inode = so->inode;
+        pthread_mutex_lock(&inode->lock);
+        *out_stream = so->stream;
+        return inode;
+    }
+
+    if (vp) {
+        inode = (struct memfs_inode *) (uintptr_t) vp;
+        pthread_mutex_lock(&inode->lock);
+        return inode;
+    }
+
+    {
+        uint64_t inum;
+        uint32_t gen, sid = 0;
+
+        memfs_decode_stream_fh(fh, fhlen, &inum, &gen, &sid);
+
+        inode = memfs_inode_get_inum(shared, inum, gen);
+
+        if (inode && sid) {
+            *out_stream = memfs_stream_find_by_id(inode, sid);
+        }
+
+        return inode;
+    }
+} /* memfs_resolve_io */
 
 static inline struct memfs_block *
 memfs_block_alloc(struct memfs_thread *thread)
@@ -413,6 +583,8 @@ memfs_inode_alloc(
     inode->acl            = NULL;
     inode->xattrs         = NULL;
     inode->remote         = NULL;
+    inode->streams        = NULL;
+    inode->next_stream_id = 0;
 
     return inode;
 
@@ -494,6 +666,63 @@ memfs_inode_truncate_blocks(
     inode->file.max_blocks = 0;
 } /* memfs_inode_truncate_blocks */
 
+/* Free all data blocks of an arbitrary fork (a named stream's fork) and reset
+ * its block tracking.  The fork's logical size is the caller's concern. */
+static void
+memfs_fork_free_blocks(
+    struct memfs_thread *thread,
+    struct memfs_fork   *fork)
+{
+    unsigned int i;
+
+    if (fork->blocks) {
+        for (i = 0; i < fork->num_blocks; i++) {
+            if (fork->blocks[i]) {
+                memfs_block_free(thread, fork->blocks[i]);
+                fork->blocks[i] = NULL;
+            }
+        }
+        free(fork->blocks);
+        fork->blocks = NULL;
+    }
+    fork->num_blocks = 0;
+    fork->max_blocks = 0;
+} /* memfs_fork_free_blocks */
+
+/* Free a single named-stream node (its fork blocks, name and the node itself).
+ * The node must already be unlinked from inode->streams. */
+static void
+memfs_stream_node_free(
+    struct memfs_thread       *thread,
+    struct memfs_named_stream *stream)
+{
+    memfs_fork_free_blocks(thread, &stream->fork);
+    free(stream->name);
+    free(stream);
+} /* memfs_stream_node_free */
+
+/* Unlink and (where possible) free every named stream attached to an inode,
+ * used when the base file is freed or superseded.  A stream with open handles
+ * is unlinked but not freed; its last close releases it.  When called from
+ * memfs_inode_free the inode's refcnt is already zero, so no stream can have an
+ * open handle and every node is freed here. */
+static void
+memfs_streams_free_all(
+    struct memfs_thread *thread,
+    struct memfs_inode  *inode)
+{
+    struct memfs_named_stream *stream;
+
+    while (inode->streams) {
+        stream         = inode->streams;
+        inode->streams = stream->next;
+        stream->linked = 0;
+        if (stream->refcnt == 0) {
+            memfs_stream_node_free(thread, stream);
+        }
+    }
+} /* memfs_streams_free_all */
+
 static void
 memfs_inode_free(
     struct memfs_thread *thread,
@@ -525,6 +754,11 @@ memfs_inode_free(
 
     /* Extended attributes hang off every inode type. */
     memfs_xattr_free_all(inode);
+
+    /* Named streams cascade with the base file. */
+    if (inode->streams) {
+        memfs_streams_free_all(thread, inode);
+    }
 
     if (inode->remote) {
         free(inode->remote);
@@ -818,6 +1052,33 @@ memfs_destroy(void *private_data)
                         free(inode->file.blocks);
                     }
 
+                    /* Named-stream forks are freed the same way as the main
+                     * fork (direct release, not via the per-thread freelist,
+                     * which is gone by destroy time). */
+                    while (inode->streams) {
+                        struct memfs_named_stream *stream = inode->streams;
+                        unsigned int               sbi;
+
+                        inode->streams = stream->next;
+
+                        for (sbi = 0; sbi < stream->fork.num_blocks; sbi++) {
+                            if (stream->fork.blocks[sbi]) {
+                                for (iovi = 0;
+                                     iovi < stream->fork.blocks[sbi]->niov;
+                                     iovi++) {
+                                    evpl_iovec_release(NULL,
+                                                       &stream->fork.blocks[sbi]->iov[iovi]);
+                                }
+                                free(stream->fork.blocks[sbi]);
+                            }
+                        }
+                        if (stream->fork.blocks) {
+                            free(stream->fork.blocks);
+                        }
+                        free(stream->name);
+                        free(stream);
+                    }
+
                     /* Stubs are always regular files; free the remote
                      * descriptor here so we never touch the uninitialized
                      * fields of never-allocated free-list inodes. */
@@ -991,6 +1252,35 @@ memfs_map_attrs(
     }
 
 } /* memfs_map_attrs */
+
+/* Map attributes for a (possibly named-stream) data fork.  Metadata is always
+* the base inode's; for a named stream the reported size/allocation come from
+* the stream's own fork and the returned file handle encodes the stream id. */
+static inline void
+memfs_map_attrs_fork(
+    struct memfs_shared       *shared,
+    struct chimera_vfs_attrs  *attr,
+    struct memfs_inode        *inode,
+    struct memfs_named_stream *stream,
+    const void                *base_fh)
+{
+    memfs_map_attrs(shared, attr, inode, base_fh);
+
+    if (!stream) {
+        return;
+    }
+
+    if (attr->va_set_mask & CHIMERA_VFS_ATTR_SIZE) {
+        attr->va_size       = stream->size;
+        attr->va_space_used = stream->space_used;
+    }
+
+    if (attr->va_set_mask & CHIMERA_VFS_ATTR_FH) {
+        attr->va_fh_len = memfs_encode_stream_fh(base_fh, inode->inum,
+                                                 inode->gen, stream->id,
+                                                 attr->va_fh);
+    }
+} /* memfs_map_attrs_fork */
 
 static inline void
 memfs_apply_attrs(
@@ -1173,9 +1463,11 @@ memfs_getattr(
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
-    struct memfs_inode *inode;
+    struct memfs_inode        *inode;
+    struct memfs_named_stream *stream;
 
-    inode = memfs_inode_get_fh(shared, request->fh, request->fh_len);
+    inode = memfs_resolve_io(shared, request->getattr.handle,
+                             request->fh, request->fh_len, &stream);
 
     if (unlikely(!inode)) {
         request->status = CHIMERA_VFS_ENOENT;
@@ -1183,7 +1475,7 @@ memfs_getattr(
         return;
     }
 
-    memfs_map_attrs(shared, &request->getattr.r_attr, inode, request->fh);
+    memfs_map_attrs_fork(shared, &request->getattr.r_attr, inode, stream, request->fh);
 
     pthread_mutex_unlock(&inode->lock);
 
@@ -1228,10 +1520,14 @@ memfs_setattr(
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
-    struct memfs_inode       *inode;
-    struct chimera_vfs_attrs *attr = request->setattr.set_attr;
+    struct memfs_inode        *inode;
+    struct memfs_named_stream *stream;
+    struct memfs_fork         *fork;
+    uint64_t                  *p_size, *p_space_used;
+    struct chimera_vfs_attrs  *attr = request->setattr.set_attr;
 
-    inode = memfs_inode_get_fh(shared, request->fh, request->fh_len);
+    inode = memfs_resolve_io(shared, request->setattr.handle,
+                             request->fh, request->fh_len, &stream);
 
     if (unlikely(!inode)) {
         request->status = CHIMERA_VFS_ENOENT;
@@ -1241,7 +1537,8 @@ memfs_setattr(
 
     /* SETATTR(SIZE) is only meaningful for regular files. RFC 7530 §5.7:
      * directories must report ISDIR; symlinks should report SYMLINK or
-     * INVAL; other non-regular file types report INVAL. */
+     * INVAL; other non-regular file types report INVAL.  (A named-stream
+     * handle always resolves to a regular base inode, so streams pass.) */
     if ((attr->va_set_mask & CHIMERA_VFS_ATTR_SIZE) &&
         !S_ISREG(inode->mode)) {
         enum chimera_vfs_error err;
@@ -1256,12 +1553,16 @@ memfs_setattr(
         return;
     }
 
-    memfs_map_attrs(shared, &request->setattr.r_pre_attr, inode, request->fh);
+    fork         = stream ? &stream->fork : &inode->file;
+    p_size       = stream ? &stream->size : &inode->size;
+    p_space_used = stream ? &stream->space_used : &inode->space_used;
+
+    memfs_map_attrs_fork(shared, &request->setattr.r_pre_attr, inode, stream, request->fh);
 
     /* Handle truncation: free blocks past new EOF and zero partial block */
     if ((attr->va_set_mask & CHIMERA_VFS_ATTR_SIZE) &&
         S_ISREG(inode->mode) &&
-        attr->va_size < inode->size) {
+        attr->va_size < *p_size) {
 
         struct evpl   *evpl           = thread->evpl;
         const uint32_t block_size     = shared->block_size;
@@ -1273,11 +1574,11 @@ memfs_setattr(
         uint64_t       bi;
 
         /* Free blocks that are entirely past the new EOF */
-        if (inode->file.blocks) {
-            for (bi = new_num_blocks; bi < inode->file.num_blocks; bi++) {
-                if (inode->file.blocks[bi]) {
-                    memfs_block_free(thread, inode->file.blocks[bi]);
-                    inode->file.blocks[bi] = NULL;
+        if (fork->blocks) {
+            for (bi = new_num_blocks; bi < fork->num_blocks; bi++) {
+                if (fork->blocks[bi]) {
+                    memfs_block_free(thread, fork->blocks[bi]);
+                    fork->blocks[bi] = NULL;
                 }
             }
         }
@@ -1288,11 +1589,11 @@ memfs_setattr(
         if (new_size > 0 && (new_size & block_mask)) {
             uint64_t last_block_idx = (new_size - 1) >> block_shift;
 
-            if (inode->file.blocks &&
-                last_block_idx < inode->file.num_blocks &&
-                inode->file.blocks[last_block_idx]) {
+            if (fork->blocks &&
+                last_block_idx < fork->num_blocks &&
+                fork->blocks[last_block_idx]) {
 
-                struct memfs_block      *old_block = inode->file.blocks[last_block_idx];
+                struct memfs_block      *old_block = fork->blocks[last_block_idx];
                 struct memfs_block      *new_block;
                 struct evpl_iovec_cursor old_cursor;
                 uint32_t                 offset_in_block = new_size &
@@ -1324,24 +1625,34 @@ memfs_setattr(
                 memfs_block_free(thread, old_block);
 
                 /* Replace old block with new block */
-                inode->file.blocks[last_block_idx] = new_block;
+                fork->blocks[last_block_idx] = new_block;
             }
         }
 
         /* Only update num_blocks if blocks array exists.
          * If blocks is NULL (sparse file extended via setattr), keep num_blocks=0. */
-        if (inode->file.blocks) {
-            inode->file.num_blocks = new_num_blocks;
-            inode->space_used      = new_num_blocks * block_size;
+        if (fork->blocks) {
+            fork->num_blocks = new_num_blocks;
+            *p_space_used    = new_num_blocks * block_size;
         } else {
-            inode->file.num_blocks = 0;
-            inode->space_used      = 0;
+            fork->num_blocks = 0;
+            *p_space_used    = 0;
         }
     }
 
-    memfs_apply_attrs(inode, attr);
+    /* Apply the new logical size to the resolved fork ourselves (the base
+     * inode's size lives on the inode, a stream's on its node), then mask the
+     * SIZE bit off so memfs_apply_attrs only touches base-inode metadata. */
+    if ((attr->va_set_mask & CHIMERA_VFS_ATTR_SIZE) && S_ISREG(inode->mode)) {
+        *p_size            = attr->va_size;
+        attr->va_set_mask &= ~CHIMERA_VFS_ATTR_SIZE;
+        memfs_apply_attrs(inode, attr);
+        attr->va_set_mask |= CHIMERA_VFS_ATTR_SIZE;
+    } else {
+        memfs_apply_attrs(inode, attr);
+    }
 
-    memfs_map_attrs(shared, &request->setattr.r_post_attr, inode, request->fh);
+    memfs_map_attrs_fork(shared, &request->setattr.r_post_attr, inode, stream, request->fh);
 
     pthread_mutex_unlock(&inode->lock);
 
@@ -2213,9 +2524,14 @@ memfs_open_at(
         }
 
         /* Overwrite/supersede disposition: replace the existing file's
-         * contents (truncate to zero) and apply the new attributes. */
+         * contents (truncate to zero) and apply the new attributes.  NTFS
+         * drops a file's named streams on SUPERSEDE/OVERWRITE, so discard them
+         * on the explicit truncate-on-open path (but not on a plain create). */
         if ((flags & CHIMERA_VFS_OPEN_TRUNCATE) && S_ISREG(inode->mode)) {
             memfs_inode_truncate_blocks(thread, inode);
+            if (inode->streams) {
+                memfs_streams_free_all(thread, inode);
+            }
             inode->size       = 0;
             inode->space_used = 0;
             memfs_apply_attrs(inode, request->open_at.set_attr);
@@ -2319,19 +2635,44 @@ memfs_close(
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
-    struct memfs_inode *inode;
+    struct memfs_inode        *inode;
+    struct memfs_named_stream *stream    = NULL;
+    struct memfs_stream_open  *stream_op = NULL;
+    uint64_t                   vp        = request->close.vfs_private;
 
-    inode = (struct memfs_inode *) request->close.vfs_private;
+    if (vp & 1) {
+        stream_op = (struct memfs_stream_open *) (uintptr_t) (vp & ~1ULL);
+        inode     = stream_op->inode;
+        stream    = stream_op->stream;
+    } else {
+        inode = (struct memfs_inode *) (uintptr_t) vp;
+    }
 
     pthread_mutex_lock(&inode->lock);
+
+    /* Release the stream node first.  An unlinked stream (removed by
+     * remove_stream while still open) is no longer in inode->streams, so the
+     * inode_free cascade below would miss it -- free it here on its last
+     * close, independent of whether the inode itself is being freed. */
+    if (stream && stream->refcnt > 0) {
+        stream->refcnt--;
+    }
+    if (stream && stream->refcnt == 0 && !stream->linked) {
+        memfs_stream_node_free(thread, stream);
+    }
 
     --inode->refcnt;
 
     if (inode->refcnt == 0) {
+        /* Frees the inode and cascades its remaining (still-linked) streams. */
         memfs_inode_free(thread, inode);
     }
 
     pthread_mutex_unlock(&inode->lock);
+
+    if (stream_op) {
+        free(stream_op);
+    }
 
     request->status = CHIMERA_VFS_OK;
     request->complete(request);
@@ -2344,16 +2685,19 @@ memfs_read(
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
-    struct memfs_inode      *inode;
-    struct memfs_block      *block;
-    struct evpl_iovec_cursor cursor;
-    uint64_t                 offset, length;
-    uint32_t                 eof = 0;
-    uint64_t                 first_block, last_block, max_iov, bi;
-    uint32_t                 block_offset, left, block_len;
-    struct evpl_iovec       *iov;
-    int                      niov = 0;
-    struct timespec          now;
+    struct memfs_inode        *inode;
+    struct memfs_named_stream *stream;
+    struct memfs_fork         *fork;
+    uint64_t                   fork_size;
+    struct memfs_block        *block;
+    struct evpl_iovec_cursor   cursor;
+    uint64_t                   offset, length;
+    uint32_t                   eof = 0;
+    uint64_t                   first_block, last_block, max_iov, bi;
+    uint32_t                   block_offset, left, block_len;
+    struct evpl_iovec         *iov;
+    int                        niov = 0;
+    struct timespec            now;
 
     chimera_vfs_realtime(&now);
 
@@ -2378,27 +2722,25 @@ memfs_read(
         return;
     }
 
-    if (request->read.handle->vfs_private) {
-        inode = (struct memfs_inode *) request->read.handle->vfs_private;
-        pthread_mutex_lock(&inode->lock);
-    } else {
-        inode = memfs_inode_get_fh(shared, request->fh, request->fh_len);
+    inode = memfs_resolve_io(shared, request->read.handle,
+                             request->fh, request->fh_len, &stream);
 
-        if (unlikely(!inode)) {
-            request->status = CHIMERA_VFS_ENOENT;
-            request->complete(request);
-            return;
-        }
-
+    if (unlikely(!inode)) {
+        request->status = CHIMERA_VFS_ENOENT;
+        request->complete(request);
+        return;
     }
+
+    fork      = stream ? &stream->fork : &inode->file;
+    fork_size = stream ? stream->size : inode->size;
 
     /* Read authorization is enforced by the VFS-layer ACL gate (and the
      * credential-keyed open cache), not by an ACL-blind mode check here -- so
      * main's memfs_cred_can_read() check is intentionally dropped on this
      * branch (it is undefined here and would double-evaluate / ignore ACLs). */
 
-    if (unlikely(inode->size <= offset)) {
-        memfs_map_attrs(shared, &request->read.r_attr, inode, request->fh);
+    if (unlikely(fork_size <= offset)) {
+        memfs_map_attrs_fork(shared, &request->read.r_attr, inode, stream, request->fh);
         pthread_mutex_unlock(&inode->lock);
         request->status        = CHIMERA_VFS_OK;
         request->read.r_niov   = 0;
@@ -2408,8 +2750,8 @@ memfs_read(
         return;
     }
 
-    if (length >= inode->size - offset) {
-        length = inode->size - offset;
+    if (length >= fork_size - offset) {
+        length = fork_size - offset;
         eof    = 1;
     }
 
@@ -2417,7 +2759,7 @@ memfs_read(
         /* Nothing to read. Returning early also avoids the
          * (offset + length - 1) underflow below that would spin the
          * block loop on a zero-length request. */
-        memfs_map_attrs(shared, &request->read.r_attr, inode, request->fh);
+        memfs_map_attrs_fork(shared, &request->read.r_attr, inode, stream, request->fh);
         pthread_mutex_unlock(&inode->lock);
         request->status        = CHIMERA_VFS_OK;
         request->read.r_niov   = 0;
@@ -2448,8 +2790,8 @@ memfs_read(
             block_len = block_size - block_offset;
         }
 
-        if (inode->file.blocks && bi < inode->file.num_blocks) {
-            block = inode->file.blocks[bi];
+        if (fork->blocks && bi < fork->num_blocks) {
+            block = fork->blocks[bi];
         } else {
             block = NULL;
         }
@@ -2478,7 +2820,7 @@ memfs_read(
 
     inode->atime = now;
 
-    memfs_map_attrs(shared, &request->read.r_attr, inode, request->fh);
+    memfs_map_attrs_fork(shared, &request->read.r_attr, inode, stream, request->fh);
 
     pthread_mutex_unlock(&inode->lock);
 
@@ -2497,19 +2839,22 @@ memfs_write(
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
-    struct evpl             *evpl = thread->evpl;
-    struct memfs_inode      *inode;
-    struct memfs_block     **blocks, *block, *old_block;
-    struct evpl_iovec_cursor cursor, old_block_cursor;
-    uint64_t                 first_block, last_block, bi;
-    uint32_t                 block_offset, left, block_len;
-    struct timespec          now;
+    struct evpl               *evpl = thread->evpl;
+    struct memfs_inode        *inode;
+    struct memfs_named_stream *stream;
+    struct memfs_fork         *fork;
+    uint64_t                  *p_size, *p_space_used;
+    struct memfs_block       **blocks, *block, *old_block;
+    struct evpl_iovec_cursor   cursor, old_block_cursor;
+    uint64_t                   first_block, last_block, bi;
+    uint32_t                   block_offset, left, block_len;
+    struct timespec            now;
 
     chimera_vfs_realtime(&now);
 
-    const uint32_t           block_size  = shared->block_size;
-    const uint32_t           block_shift = shared->block_shift;
-    const uint32_t           block_mask  = shared->block_mask;
+    const uint32_t             block_size  = shared->block_size;
+    const uint32_t             block_shift = shared->block_shift;
+    const uint32_t             block_mask  = shared->block_mask;
 
     evpl_iovec_cursor_init(&cursor, request->write.iov, request->write.niov);
 
@@ -2519,17 +2864,13 @@ memfs_write(
         block_shift;
     left = request->write.length;
 
-    if (request->write.handle->vfs_private) {
-        inode = (struct memfs_inode *) request->write.handle->vfs_private;
-        pthread_mutex_lock(&inode->lock);
-    } else {
-        inode = memfs_inode_get_fh(shared, request->fh, request->fh_len);
+    inode = memfs_resolve_io(shared, request->write.handle,
+                             request->fh, request->fh_len, &stream);
 
-        if (unlikely(!inode)) {
-            request->status = CHIMERA_VFS_ENOENT;
-            request->complete(request);
-            return;
-        }
+    if (unlikely(!inode)) {
+        request->status = CHIMERA_VFS_ENOENT;
+        request->complete(request);
+        return;
     }
 
     if (!S_ISREG(inode->mode)) {
@@ -2540,16 +2881,20 @@ memfs_write(
         return;
     }
 
+    fork         = stream ? &stream->fork : &inode->file;
+    p_size       = stream ? &stream->size : &inode->size;
+    p_space_used = stream ? &stream->space_used : &inode->space_used;
+
     /* Write access is enforced at the VFS layer (credential-keyed gate); see
      * the note in memfs_open_at. */
 
-    memfs_map_attrs(shared, &request->write.r_pre_attr, inode, request->fh);
+    memfs_map_attrs_fork(shared, &request->write.r_pre_attr, inode, stream, request->fh);
 
     if (request->write.length == 0) {
         /* A zero-length write changes nothing. Returning early also avoids
          * the (offset + length - 1) underflow above, which drives last_block
          * to a huge value and spins the 32-bit block-growth loop forever. */
-        memfs_map_attrs(shared, &request->write.r_post_attr, inode, request->fh);
+        memfs_map_attrs_fork(shared, &request->write.r_post_attr, inode, stream, request->fh);
         pthread_mutex_unlock(&inode->lock);
         request->status         = CHIMERA_VFS_OK;
         request->write.r_length = 0;
@@ -2558,11 +2903,11 @@ memfs_write(
         return;
     }
 
-    if (inode->file.max_blocks <= last_block || !inode->file.blocks) {
+    if (fork->max_blocks <= last_block || !fork->blocks) {
         struct memfs_block **new_blocks;
         unsigned int         new_max_blocks;
 
-        blocks = inode->file.blocks;
+        blocks = fork->blocks;
 
         new_max_blocks = 1024;
 
@@ -2581,22 +2926,22 @@ memfs_write(
 
         if (blocks) {
             memcpy(new_blocks, blocks,
-                   inode->file.num_blocks * sizeof(struct memfs_block *));
+                   fork->num_blocks * sizeof(struct memfs_block *));
             free(blocks);
         }
 
-        memset(new_blocks + inode->file.num_blocks,
+        memset(new_blocks + fork->num_blocks,
                0,
-               (new_max_blocks - inode->file.num_blocks) *
+               (new_max_blocks - fork->num_blocks) *
                sizeof(struct memfs_block *));
 
-        inode->file.blocks     = new_blocks;
-        inode->file.max_blocks = new_max_blocks;
+        fork->blocks     = new_blocks;
+        fork->max_blocks = new_max_blocks;
     }
 
     /* Only increase num_blocks, never decrease it during write */
-    if (last_block + 1 > inode->file.num_blocks) {
-        inode->file.num_blocks = last_block + 1;
+    if (last_block + 1 > fork->num_blocks) {
+        fork->num_blocks = last_block + 1;
     }
 
     for (bi = first_block; bi <= last_block; bi++) {
@@ -2607,7 +2952,7 @@ memfs_write(
             block_len = left;
         }
 
-        old_block = inode->file.blocks ? inode->file.blocks[bi] : NULL;
+        old_block = fork->blocks ? fork->blocks[bi] : NULL;
 
         block = memfs_block_alloc(thread);
 
@@ -2641,7 +2986,7 @@ memfs_write(
                                        block_size - block_len -
                                        block_offset);
 
-                inode->file.blocks[bi] = NULL;
+                fork->blocks[bi] = NULL;
                 memfs_block_free(thread, old_block);
             } else {
                 memset(block->iov[0].data, 0, block_offset);
@@ -2651,7 +2996,7 @@ memfs_write(
             }
         } else if (old_block) {
             /* Full block overwrite: free the old block */
-            inode->file.blocks[bi] = NULL;
+            fork->blocks[bi] = NULL;
             memfs_block_free(thread, old_block);
         }
 
@@ -2659,20 +3004,20 @@ memfs_write(
                                block->iov[0].data + block_offset,
                                block_len);
 
-        inode->file.blocks[bi] = block;
-        block_offset           = 0;
-        left                  -= block_len;
+        fork->blocks[bi] = block;
+        block_offset     = 0;
+        left            -= block_len;
     }
 
-    if (inode->size < request->write.offset + request->write.length) {
-        inode->size       = request->write.offset + request->write.length;
-        inode->space_used = (inode->size + 4095) & ~4095;
+    if (*p_size < request->write.offset + request->write.length) {
+        *p_size       = request->write.offset + request->write.length;
+        *p_space_used = (*p_size + 4095) & ~4095;
     }
 
     inode->mtime = now;
     inode->ctime = now;
 
-    memfs_map_attrs(shared, &request->write.r_post_attr, inode, request->fh);
+    memfs_map_attrs_fork(shared, &request->write.r_post_attr, inode, stream, request->fh);
 
     pthread_mutex_unlock(&inode->lock);
 
@@ -2691,26 +3036,29 @@ memfs_allocate(
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
-    struct evpl        *evpl = thread->evpl;
-    struct memfs_inode *inode;
-    struct timespec     now;
+    struct evpl               *evpl = thread->evpl;
+    struct memfs_inode        *inode;
+    struct memfs_named_stream *stream;
+    struct memfs_fork         *fork;
+    uint64_t                  *p_size, *p_space_used;
+    struct timespec            now;
 
     chimera_vfs_realtime(&now);
 
-    if (request->allocate.handle->vfs_private) {
-        inode = (struct memfs_inode *) request->allocate.handle->vfs_private;
-        pthread_mutex_lock(&inode->lock);
-    } else {
-        inode = memfs_inode_get_fh(shared, request->fh, request->fh_len);
+    inode = memfs_resolve_io(shared, request->allocate.handle,
+                             request->fh, request->fh_len, &stream);
 
-        if (unlikely(!inode)) {
-            request->status = CHIMERA_VFS_ENOENT;
-            request->complete(request);
-            return;
-        }
+    if (unlikely(!inode)) {
+        request->status = CHIMERA_VFS_ENOENT;
+        request->complete(request);
+        return;
     }
 
-    memfs_map_attrs(shared, &request->allocate.r_pre_attr, inode, request->fh);
+    fork         = stream ? &stream->fork : &inode->file;
+    p_size       = stream ? &stream->size : &inode->size;
+    p_space_used = stream ? &stream->space_used : &inode->space_used;
+
+    memfs_map_attrs_fork(shared, &request->allocate.r_pre_attr, inode, stream, request->fh);
 
     if (request->allocate.flags & CHIMERA_VFS_ALLOCATE_DEALLOCATE) {
         /* DEALLOCATE: punch hole in [offset, offset+length) */
@@ -2720,16 +3068,16 @@ memfs_allocate(
         uint64_t       hole_end    = hole_start + request->allocate.length;
         uint64_t       first_block, last_block, bi;
 
-        if (hole_end > inode->size) {
-            hole_end = inode->size;
+        if (hole_end > *p_size) {
+            hole_end = *p_size;
         }
 
-        if (hole_start < hole_end && inode->file.blocks) {
+        if (hole_start < hole_end && fork->blocks) {
             first_block = hole_start >> block_shift;
             last_block  = (hole_end - 1) >> block_shift;
 
-            for (bi = first_block; bi <= last_block && bi < inode->file.num_blocks; bi++) {
-                if (!inode->file.blocks[bi]) {
+            for (bi = first_block; bi <= last_block && bi < fork->num_blocks; bi++) {
+                if (!fork->blocks[bi]) {
                     continue;
                 }
 
@@ -2738,11 +3086,11 @@ memfs_allocate(
 
                 if (hole_start <= block_start && hole_end >= block_end) {
                     /* Entire block is within hole - free it */
-                    memfs_block_free(thread, inode->file.blocks[bi]);
-                    inode->file.blocks[bi] = NULL;
+                    memfs_block_free(thread, fork->blocks[bi]);
+                    fork->blocks[bi] = NULL;
                 } else {
                     /* Partial block - COW and zero the hole portion */
-                    struct memfs_block      *old_block = inode->file.blocks[bi];
+                    struct memfs_block      *old_block = fork->blocks[bi];
                     struct memfs_block      *new_block;
                     struct evpl_iovec_cursor old_cursor;
                     uint32_t                 zero_start, zero_end;
@@ -2777,15 +3125,15 @@ memfs_allocate(
                            zero_end - zero_start);
 
                     memfs_block_free(thread, old_block);
-                    inode->file.blocks[bi] = new_block;
+                    fork->blocks[bi] = new_block;
                 }
             }
 
-            inode->space_used = 0;
+            *p_space_used = 0;
 
-            for (bi = 0; bi < inode->file.num_blocks; bi++) {
-                if (inode->file.blocks[bi]) {
-                    inode->space_used += block_size;
+            for (bi = 0; bi < fork->num_blocks; bi++) {
+                if (fork->blocks[bi]) {
+                    *p_space_used += block_size;
                 }
             }
         }
@@ -2793,15 +3141,15 @@ memfs_allocate(
         /* ALLOCATE: extend file size if needed */
         uint64_t new_end = request->allocate.offset + request->allocate.length;
 
-        if (new_end > inode->size) {
-            inode->size = new_end;
+        if (new_end > *p_size) {
+            *p_size = new_end;
         }
     }
 
     inode->mtime = now;
     inode->ctime = now;
 
-    memfs_map_attrs(shared, &request->allocate.r_post_attr, inode, request->fh);
+    memfs_map_attrs_fork(shared, &request->allocate.r_post_attr, inode, stream, request->fh);
 
     pthread_mutex_unlock(&inode->lock);
 
@@ -2936,6 +3284,15 @@ memfs_copy_range(
 
     if (request->copy_range.src_handle->vfs_module !=
         request->copy_range.dst_handle->vfs_module) {
+        request->status = CHIMERA_VFS_ENOTSUP;
+        request->complete(request);
+        return;
+    }
+
+    /* Range copy between named streams is not supported; a tagged vfs_private
+     * is a stream descriptor, not an inode pointer. */
+    if ((request->copy_range.src_handle->vfs_private & 1) ||
+        (request->copy_range.dst_handle->vfs_private & 1)) {
         request->status = CHIMERA_VFS_ENOTSUP;
         request->complete(request);
         return;
@@ -3156,6 +3513,14 @@ memfs_move_range(
         return;
     }
 
+    /* Range move between named streams is not supported. */
+    if ((request->move_range.src_handle->vfs_private & 1) ||
+        (request->move_range.dst_handle->vfs_private & 1)) {
+        request->status = CHIMERA_VFS_ENOTSUP;
+        request->complete(request);
+        return;
+    }
+
     src_inode = (struct memfs_inode *) request->move_range.src_handle->vfs_private;
     dst_inode = (struct memfs_inode *) request->move_range.dst_handle->vfs_private;
 
@@ -3298,6 +3663,14 @@ memfs_clone_range(
         return;
     }
 
+    /* Range clone between named streams is not supported. */
+    if ((request->clone_range.src_handle->vfs_private & 1) ||
+        (request->clone_range.dst_handle->vfs_private & 1)) {
+        request->status = CHIMERA_VFS_ENOTSUP;
+        request->complete(request);
+        return;
+    }
+
     src_inode = (struct memfs_inode *) request->clone_range.src_handle->vfs_private;
     dst_inode = (struct memfs_inode *) request->clone_range.dst_handle->vfs_private;
 
@@ -3430,24 +3803,26 @@ memfs_seek(
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
-    struct memfs_inode *inode;
-    uint64_t            offset = request->seek.offset;
-    uint64_t            bi, block_start;
+    struct memfs_inode        *inode;
+    struct memfs_named_stream *stream;
+    struct memfs_fork         *fork;
+    uint64_t                   fork_size;
+    uint64_t                   offset = request->seek.offset;
+    uint64_t                   bi, block_start;
 
-    if (request->seek.handle->vfs_private) {
-        inode = (struct memfs_inode *) request->seek.handle->vfs_private;
-        pthread_mutex_lock(&inode->lock);
-    } else {
-        inode = memfs_inode_get_fh(shared, request->fh, request->fh_len);
+    inode = memfs_resolve_io(shared, request->seek.handle,
+                             request->fh, request->fh_len, &stream);
 
-        if (unlikely(!inode)) {
-            request->status = CHIMERA_VFS_ENOENT;
-            request->complete(request);
-            return;
-        }
+    if (unlikely(!inode)) {
+        request->status = CHIMERA_VFS_ENOENT;
+        request->complete(request);
+        return;
     }
 
-    if (offset >= inode->size) {
+    fork      = stream ? &stream->fork : &inode->file;
+    fork_size = stream ? stream->size : inode->size;
+
+    if (offset >= fork_size) {
         pthread_mutex_unlock(&inode->lock);
         request->seek.r_eof    = 1;
         request->seek.r_offset = 0;
@@ -3462,8 +3837,8 @@ memfs_seek(
         /* SEEK_DATA: find first non-NULL block from offset forward */
         bi = offset >> block_shift;
 
-        while (bi < inode->file.num_blocks) {
-            if (inode->file.blocks && inode->file.blocks[bi]) {
+        while (bi < fork->num_blocks) {
+            if (fork->blocks && fork->blocks[bi]) {
                 block_start = bi << block_shift;
 
                 request->seek.r_offset = (block_start > offset) ?
@@ -3488,8 +3863,8 @@ memfs_seek(
         /* SEEK_HOLE: find first NULL block or past num_blocks from offset */
         bi = offset >> block_shift;
 
-        while (bi < inode->file.num_blocks) {
-            if (!inode->file.blocks || !inode->file.blocks[bi]) {
+        while (bi < fork->num_blocks) {
+            if (!fork->blocks || !fork->blocks[bi]) {
                 block_start = bi << block_shift;
 
                 request->seek.r_offset = (block_start > offset) ?
@@ -3504,15 +3879,15 @@ memfs_seek(
         }
 
         /* Virtual hole at EOF - all blocks are data */
-        request->seek.r_offset = inode->file.num_blocks <<
+        request->seek.r_offset = fork->num_blocks <<
             block_shift;
 
         if (request->seek.r_offset < offset) {
             request->seek.r_offset = offset;
         }
 
-        if (request->seek.r_offset >= inode->size) {
-            request->seek.r_offset = inode->size;
+        if (request->seek.r_offset >= fork_size) {
+            request->seek.r_offset = fork_size;
         }
 
         request->seek.r_eof = 0;
@@ -4490,6 +4865,220 @@ memfs_remove_xattr(
 } /* memfs_remove_xattr */
 
 static void
+memfs_open_stream(
+    struct memfs_thread        *thread,
+    struct memfs_shared        *shared,
+    struct chimera_vfs_request *request,
+    void                       *private_data)
+{
+    struct memfs_inode        *inode;
+    struct memfs_named_stream *stream;
+    struct memfs_stream_open  *so;
+    unsigned int               flags = request->open_stream.flags;
+    struct timespec            now;
+
+    chimera_vfs_realtime(&now);
+
+    inode = memfs_inode_get_fh(shared, request->fh, request->fh_len);
+
+    if (unlikely(!inode)) {
+        request->status = CHIMERA_VFS_ENOENT;
+        request->complete(request);
+        return;
+    }
+
+    /* Named streams attach only to regular files. */
+    if (!S_ISREG(inode->mode)) {
+        pthread_mutex_unlock(&inode->lock);
+        request->status = CHIMERA_VFS_EINVAL;
+        request->complete(request);
+        return;
+    }
+
+    stream = memfs_stream_find_by_name(inode, request->open_stream.name,
+                                       request->open_stream.namelen);
+
+    if (!stream) {
+        if (!(flags & CHIMERA_VFS_OPEN_CREATE)) {
+            pthread_mutex_unlock(&inode->lock);
+            request->status = CHIMERA_VFS_ENOENT;
+            request->complete(request);
+            return;
+        }
+
+        stream       = calloc(1, sizeof(*stream));
+        stream->name = malloc(request->open_stream.namelen);
+        memcpy(stream->name, request->open_stream.name,
+               request->open_stream.namelen);
+        stream->name_len               = request->open_stream.namelen;
+        stream->id                     = ++inode->next_stream_id;
+        stream->linked                 = 1;
+        stream->next                   = inode->streams;
+        inode->streams                 = stream;
+        inode->mtime                   = now;
+        inode->ctime                   = now;
+        request->open_stream.r_created = 1;
+    } else if (flags & CHIMERA_VFS_OPEN_EXCLUSIVE) {
+        pthread_mutex_unlock(&inode->lock);
+        request->status = CHIMERA_VFS_EEXIST;
+        request->complete(request);
+        return;
+    } else if (flags & CHIMERA_VFS_OPEN_TRUNCATE) {
+        memfs_fork_free_blocks(thread, &stream->fork);
+        stream->size       = 0;
+        stream->space_used = 0;
+        inode->mtime       = now;
+        inode->ctime       = now;
+    }
+
+    /* A stream open pins both the stream node and the base inode. */
+    stream->refcnt++;
+    inode->refcnt++;
+
+    so         = malloc(sizeof(*so));
+    so->inode  = inode;
+    so->stream = stream;
+
+    request->open_stream.r_vfs_private = (uint64_t) (uintptr_t) so | 1ULL;
+
+    memfs_map_attrs_fork(shared, &request->open_stream.r_attr, inode, stream,
+                         request->fh);
+
+    pthread_mutex_unlock(&inode->lock);
+
+    request->status = CHIMERA_VFS_OK;
+    request->complete(request);
+} /* memfs_open_stream */
+
+static void
+memfs_list_streams(
+    struct memfs_thread        *thread,
+    struct memfs_shared        *shared,
+    struct chimera_vfs_request *request,
+    void                       *private_data)
+{
+    struct memfs_inode             *inode;
+    struct memfs_named_stream      *stream;
+    uint8_t                        *buf    = request->list_streams.buffer;
+    uint32_t                        max    = request->list_streams.max_bytes;
+    uint32_t                        offset = 0;
+    uint32_t                        count  = 0;
+    struct chimera_vfs_stream_entry entry;
+    uint32_t                        rec;
+
+    inode = memfs_inode_get_fh(shared, request->fh, request->fh_len);
+
+    if (unlikely(!inode)) {
+        request->status = CHIMERA_VFS_ENOENT;
+        request->complete(request);
+        return;
+    }
+
+    /* Default unnamed data fork ("::$DATA"), reported first with an empty name
+     * so the SMB layer can format it as the default stream. */
+    rec = sizeof(entry);
+    if (offset + rec > max) {
+        pthread_mutex_unlock(&inode->lock);
+        request->status = CHIMERA_VFS_ERANGE;
+        request->complete(request);
+        return;
+    }
+    entry.size     = inode->size;
+    entry.alloc    = inode->space_used;
+    entry.name_len = 0;
+    memcpy(buf + offset, &entry, sizeof(entry));
+    offset += rec;
+    offset  = (offset + 7) & ~7u;
+    count++;
+
+    for (stream = inode->streams; stream; stream = stream->next) {
+        rec = sizeof(entry) + stream->name_len;
+        if (offset + rec > max) {
+            pthread_mutex_unlock(&inode->lock);
+            request->status = CHIMERA_VFS_ERANGE;
+            request->complete(request);
+            return;
+        }
+        entry.size     = stream->size;
+        entry.alloc    = stream->space_used;
+        entry.name_len = stream->name_len;
+        memcpy(buf + offset, &entry, sizeof(entry));
+        memcpy(buf + offset + sizeof(entry), stream->name, stream->name_len);
+        offset += rec;
+        offset  = (offset + 7) & ~7u;
+        count++;
+    }
+
+    pthread_mutex_unlock(&inode->lock);
+
+    request->list_streams.r_len    = offset;
+    request->list_streams.r_count  = count;
+    request->list_streams.r_eof    = 1;
+    request->list_streams.r_cookie = 0;
+    request->status                = CHIMERA_VFS_OK;
+    request->complete(request);
+} /* memfs_list_streams */
+
+static void
+memfs_remove_stream(
+    struct memfs_thread        *thread,
+    struct memfs_shared        *shared,
+    struct chimera_vfs_request *request,
+    void                       *private_data)
+{
+    struct memfs_inode        *inode;
+    struct memfs_named_stream *stream, **pprev;
+    struct timespec            now;
+
+    chimera_vfs_realtime(&now);
+
+    inode = memfs_inode_get_fh(shared, request->fh, request->fh_len);
+
+    if (unlikely(!inode)) {
+        request->status = CHIMERA_VFS_ENOENT;
+        request->complete(request);
+        return;
+    }
+
+    memfs_map_attrs(shared, &request->remove_stream.r_pre_attr, inode, request->fh);
+
+    pprev = &inode->streams;
+    for (stream = inode->streams; stream; stream = stream->next) {
+        if (stream->name_len == request->remove_stream.namelen &&
+            memcmp(stream->name, request->remove_stream.name,
+                   request->remove_stream.namelen) == 0) {
+            break;
+        }
+        pprev = &stream->next;
+    }
+
+    if (!stream) {
+        pthread_mutex_unlock(&inode->lock);
+        request->status = CHIMERA_VFS_ENOENT;
+        request->complete(request);
+        return;
+    }
+
+    /* Unlink from the inode's stream list.  If no handle holds it open, free it
+     * now; otherwise it survives (unlinked) until its last close. */
+    *pprev         = stream->next;
+    stream->linked = 0;
+
+    if (stream->refcnt == 0) {
+        memfs_stream_node_free(thread, stream);
+    }
+
+    inode->ctime = now;
+
+    memfs_map_attrs(shared, &request->remove_stream.r_post_attr, inode, request->fh);
+
+    pthread_mutex_unlock(&inode->lock);
+
+    request->status = CHIMERA_VFS_OK;
+    request->complete(request);
+} /* memfs_remove_stream */
+
+static void
 memfs_dispatch(
     struct chimera_vfs_request *request,
     void                       *private_data)
@@ -4597,6 +5186,15 @@ memfs_dispatch(
         case CHIMERA_VFS_OP_REMOVE_XATTR:
             memfs_remove_xattr(thread, shared, request, private_data);
             break;
+        case CHIMERA_VFS_OP_OPEN_STREAM:
+            memfs_open_stream(thread, shared, request, private_data);
+            break;
+        case CHIMERA_VFS_OP_LIST_STREAMS:
+            memfs_list_streams(thread, shared, request, private_data);
+            break;
+        case CHIMERA_VFS_OP_REMOVE_STREAM:
+            memfs_remove_stream(thread, shared, request, private_data);
+            break;
         default:
             chimera_memfs_error("memfs_dispatch: unknown operation %d",
                                 request->opcode);
@@ -4613,7 +5211,8 @@ SYMBOL_EXPORT struct chimera_vfs_module vfs_memfs = {
         CHIMERA_VFS_CAP_FS_RELATIVE_OP |
         CHIMERA_VFS_CAP_COPY_RANGE | CHIMERA_VFS_CAP_CLONE_RANGE | CHIMERA_VFS_CAP_MOVE_RANGE |
         CHIMERA_VFS_CAP_ACL_NATIVE | CHIMERA_VFS_CAP_XATTR | CHIMERA_VFS_CAP_LAYOUT |
-        CHIMERA_VFS_CAP_ATOMIC_HANDLE_STATE | CHIMERA_VFS_CAP_READ_PROVIDES_BUFFERS,
+        CHIMERA_VFS_CAP_ATOMIC_HANDLE_STATE | CHIMERA_VFS_CAP_READ_PROVIDES_BUFFERS |
+        CHIMERA_VFS_CAP_NAMED_STREAMS,
     .init           = memfs_init,
     .destroy        = memfs_destroy,
     .thread_init    = memfs_thread_init,

--- a/src/vfs/vfs.h
+++ b/src/vfs/vfs.h
@@ -84,7 +84,10 @@ struct chimera_vfs_mount_options {
 #define CHIMERA_VFS_OP_LIST_XATTRS      34
 #define CHIMERA_VFS_OP_REMOVE_XATTR     35
 #define CHIMERA_VFS_OP_GET_LAYOUT       36
-#define CHIMERA_VFS_OP_NUM              37
+#define CHIMERA_VFS_OP_OPEN_STREAM      37
+#define CHIMERA_VFS_OP_LIST_STREAMS     38
+#define CHIMERA_VFS_OP_REMOVE_STREAM    39
+#define CHIMERA_VFS_OP_NUM              40
 
 #define CHIMERA_VFS_OPEN_CREATE         (1U << 0)
 #define CHIMERA_VFS_OPEN_PATH           (1U << 1)
@@ -314,6 +317,15 @@ struct chimera_vfs_request_handle {
 };
 
 #define CHIMERA_VFS_REQUEST_MAX_HANDLES 3
+
+/* One enumerated named stream, packed back-to-back in the list_streams reply
+ * buffer.  `name_len` bytes of (un-terminated) stream name follow this header;
+ * the next record begins at the following 8-byte-aligned offset. */
+struct chimera_vfs_stream_entry {
+    uint64_t size;        /* stream end-of-file */
+    uint64_t alloc;       /* stream allocation size */
+    uint16_t name_len;    /* bytes of name that follow this struct */
+};
 
 struct chimera_vfs_request {
     struct chimera_vfs_thread         *thread;
@@ -895,6 +907,45 @@ struct chimera_vfs_request {
             struct chimera_vfs_attrs        r_post_attr;
         } remove_xattr;
 
+        /* Named streams (SMB Alternate Data Streams).  Gated by
+         * CHIMERA_VFS_CAP_NAMED_STREAMS.  open_stream opens/creates a named
+         * data fork on the base file referenced by `handle`; it returns a
+         * file handle (in r_attr.va_fh) and r_vfs_private exactly like open_at
+         * so the VFS open cache can wrap it.  list_streams enumerates the
+         * file's streams (the default unnamed fork first), each as a packed
+         * struct chimera_vfs_stream_entry. */
+        struct {
+            struct chimera_vfs_open_handle *handle;       /* base file handle */
+            const char                     *name;         /* stream name (no ":$DATA") */
+            uint32_t                        namelen;
+            uint32_t                        flags;        /* CHIMERA_VFS_OPEN_* */
+            struct chimera_vfs_attrs       *set_attr;
+            struct chimera_vfs_attrs        r_attr;       /* base meta + stream size; va_fh = stream fh */
+            uint64_t                        r_vfs_private;
+            uint8_t                         r_created;
+        } open_stream;
+
+        struct {
+            struct chimera_vfs_open_handle *handle;       /* base file handle */
+            uint64_t                        cookie;
+            void                           *buffer;       /* caller-provided buffer */
+            uint32_t                        max_bytes;
+            /* buffer is filled with packed chimera_vfs_stream_entry records,
+             * each followed by name_len bytes of (un-terminated) name. */
+            uint32_t                        r_len;        /* bytes written to buffer */
+            uint32_t                        r_count;      /* number of streams written */
+            uint32_t                        r_eof;
+            uint64_t                        r_cookie;
+        } list_streams;
+
+        struct {
+            struct chimera_vfs_open_handle *handle;       /* base file handle */
+            const char                     *name;
+            uint32_t                        namelen;
+            struct chimera_vfs_attrs        r_pre_attr;
+            struct chimera_vfs_attrs        r_post_attr;
+        } remove_stream;
+
         /* pNFS: a layout-sourcing backend (CHIMERA_VFS_CAP_LAYOUT_SOURCE)
          * describes where the file's data physically lives.  The NFS server
          * encodes the returned segments/devices into a flex-files or block
@@ -1107,6 +1158,14 @@ struct chimera_vfs_handle_state {
  * and "enforces the ACL" are different properties (memfs/cairn store but do not
  * enforce; linux/io_uring enforce in-kernel but do not store the rich ACL). */
 #define CHIMERA_VFS_CAP_DELEGATES_DAC         (1U << 21)
+
+/* If set, the module supports named streams (SMB Alternate Data Streams) on
+ * regular files via chimera_vfs_open_stream / list_streams / remove_stream.
+ * A named stream is an independent data fork addressed by name; it shares the
+ * base file's metadata (mode/owner/timestamps/ACL) but has its own size and
+ * content.  Modules that leave this unset cause the VFS layer to return
+ * ENOTSUP.  Currently only memfs advertises it. */
+#define CHIMERA_VFS_CAP_NAMED_STREAMS         (1U << 22)
 
 struct chimera_vfs_module {
     /* Required

--- a/src/vfs/vfs_dump.c
+++ b/src/vfs/vfs_dump.c
@@ -48,6 +48,9 @@ chimera_vfs_op_name(unsigned int opcode)
         case CHIMERA_VFS_OP_LIST_XATTRS: return "ListXattrs";
         case CHIMERA_VFS_OP_REMOVE_XATTR: return "RemoveXattr";
         case CHIMERA_VFS_OP_GET_LAYOUT: return "GetLayout";
+        case CHIMERA_VFS_OP_OPEN_STREAM: return "OpenStream";
+        case CHIMERA_VFS_OP_LIST_STREAMS: return "ListStreams";
+        case CHIMERA_VFS_OP_REMOVE_STREAM: return "RemoveStream";
         default: return "Unknown";
     } /* switch */
 

--- a/src/vfs/vfs_proc_list_streams.c
+++ b/src/vfs/vfs_proc_list_streams.c
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "vfs/vfs_procs.h"
+#include "vfs_internal.h"
+#include "common/macros.h"
+
+static void
+chimera_vfs_list_streams_complete(struct chimera_vfs_request *request)
+{
+    chimera_vfs_list_streams_callback_t callback = request->proto_callback;
+
+    chimera_vfs_complete(request);
+
+    callback(request->status,
+             request->list_streams.buffer,
+             request->list_streams.r_len,
+             request->list_streams.r_count,
+             request->list_streams.r_eof,
+             request->list_streams.r_cookie,
+             request->proto_private_data);
+
+    chimera_vfs_request_free(request->thread, request);
+} /* chimera_vfs_list_streams_complete */
+
+SYMBOL_EXPORT void
+chimera_vfs_list_streams(
+    struct chimera_vfs_thread          *thread,
+    const struct chimera_vfs_cred      *cred,
+    struct chimera_vfs_open_handle     *handle,
+    uint64_t                            cookie,
+    void                               *buffer,
+    uint32_t                            max_bytes,
+    chimera_vfs_list_streams_callback_t callback,
+    void                               *private_data)
+{
+    struct chimera_vfs_request *request;
+
+    if (!(handle->vfs_module->capabilities & CHIMERA_VFS_CAP_NAMED_STREAMS)) {
+        callback(CHIMERA_VFS_ENOTSUP, NULL, 0, 0, 1, 0, private_data);
+        return;
+    }
+
+    request = chimera_vfs_request_alloc_by_handle(thread, cred, handle);
+
+    if (CHIMERA_VFS_IS_ERR(request)) {
+        callback(CHIMERA_VFS_PTR_ERR(request), NULL, 0, 0, 1, 0, private_data);
+        return;
+    }
+
+    request->opcode                 = CHIMERA_VFS_OP_LIST_STREAMS;
+    request->complete               = chimera_vfs_list_streams_complete;
+    request->list_streams.handle    = handle;
+    request->list_streams.cookie    = cookie;
+    request->list_streams.buffer    = buffer;
+    request->list_streams.max_bytes = max_bytes;
+    request->list_streams.r_len     = 0;
+    request->list_streams.r_count   = 0;
+    request->list_streams.r_eof     = 0;
+    request->list_streams.r_cookie  = 0;
+    request->proto_callback         = callback;
+    request->proto_private_data     = private_data;
+
+    chimera_vfs_dispatch(request);
+} /* chimera_vfs_list_streams */

--- a/src/vfs/vfs_proc_open_stream.c
+++ b/src/vfs/vfs_proc_open_stream.c
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "vfs/vfs_procs.h"
+#include "vfs_internal.h"
+#include "vfs_open_cache.h"
+#include "common/macros.h"
+
+static void
+chimera_vfs_open_stream_hdl_callback(
+    struct chimera_vfs_request     *request,
+    struct chimera_vfs_open_handle *handle)
+{
+    chimera_vfs_open_stream_callback_t callback = request->proto_callback;
+
+    if (handle) {
+        handle->r_created = request->open_stream.r_created;
+    }
+
+    chimera_vfs_complete(request);
+
+    callback(request->status,
+             handle,
+             &request->open_stream.r_attr,
+             request->proto_private_data);
+
+    chimera_vfs_request_free(request->thread, request);
+} /* chimera_vfs_open_stream_hdl_callback */
+
+static void
+chimera_vfs_open_stream_complete(struct chimera_vfs_request *request)
+{
+    struct chimera_vfs_thread *thread = request->thread;
+    uint64_t                   fh_hash;
+
+    if (request->status == CHIMERA_VFS_OK) {
+        chimera_vfs_abort_if(!(request->open_stream.r_attr.va_set_mask & CHIMERA_VFS_ATTR_FH),
+                             "open_stream: no fh returned from vfs module");
+
+        fh_hash = chimera_vfs_hash(request->open_stream.r_attr.va_fh,
+                                   request->open_stream.r_attr.va_fh_len);
+
+        chimera_vfs_open_cache_insert(
+            thread,
+            thread->vfs->vfs_open_file_cache,
+            request->module,
+            request,
+            request->open_stream.r_attr.va_fh,
+            request->open_stream.r_attr.va_fh_len,
+            fh_hash,
+            request->open_stream.r_vfs_private,
+            request->open_stream.flags,
+            chimera_vfs_open_stream_hdl_callback);
+    } else {
+        chimera_vfs_open_stream_hdl_callback(request, NULL);
+    }
+} /* chimera_vfs_open_stream_complete */
+
+SYMBOL_EXPORT void
+chimera_vfs_open_stream(
+    struct chimera_vfs_thread         *thread,
+    const struct chimera_vfs_cred     *cred,
+    struct chimera_vfs_open_handle    *handle,
+    const char                        *name,
+    uint32_t                           namelen,
+    uint32_t                           flags,
+    struct chimera_vfs_attrs          *set_attr,
+    uint64_t                           attr_mask,
+    chimera_vfs_open_stream_callback_t callback,
+    void                              *private_data)
+{
+    struct chimera_vfs_request *request;
+
+    if (!(handle->vfs_module->capabilities & CHIMERA_VFS_CAP_NAMED_STREAMS)) {
+        callback(CHIMERA_VFS_ENOTSUP, NULL, NULL, private_data);
+        return;
+    }
+
+    request = chimera_vfs_request_alloc_by_handle(thread, cred, handle);
+
+    if (CHIMERA_VFS_IS_ERR(request)) {
+        callback(CHIMERA_VFS_PTR_ERR(request), NULL, NULL, private_data);
+        return;
+    }
+
+    request->opcode                         = CHIMERA_VFS_OP_OPEN_STREAM;
+    request->complete                       = chimera_vfs_open_stream_complete;
+    request->open_stream.handle             = handle;
+    request->open_stream.name               = name;
+    request->open_stream.namelen            = namelen;
+    request->open_stream.flags              = flags;
+    request->open_stream.set_attr           = set_attr;
+    request->open_stream.r_vfs_private      = 0;
+    request->open_stream.r_created          = 0;
+    request->open_stream.r_attr.va_req_mask = attr_mask | CHIMERA_VFS_ATTR_FH |
+        CHIMERA_VFS_ATTR_MASK_CACHEABLE;
+    request->open_stream.r_attr.va_set_mask = 0;
+    request->proto_callback                 = callback;
+    request->proto_private_data             = private_data;
+
+    chimera_vfs_dispatch(request);
+} /* chimera_vfs_open_stream */

--- a/src/vfs/vfs_proc_remove_stream.c
+++ b/src/vfs/vfs_proc_remove_stream.c
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "vfs/vfs_procs.h"
+#include "vfs_internal.h"
+#include "common/macros.h"
+
+static void
+chimera_vfs_remove_stream_complete(struct chimera_vfs_request *request)
+{
+    chimera_vfs_remove_stream_callback_t callback = request->proto_callback;
+
+    chimera_vfs_complete(request);
+
+    callback(request->status,
+             &request->remove_stream.r_pre_attr,
+             &request->remove_stream.r_post_attr,
+             request->proto_private_data);
+
+    chimera_vfs_request_free(request->thread, request);
+} /* chimera_vfs_remove_stream_complete */
+
+SYMBOL_EXPORT void
+chimera_vfs_remove_stream(
+    struct chimera_vfs_thread           *thread,
+    const struct chimera_vfs_cred       *cred,
+    struct chimera_vfs_open_handle      *handle,
+    const char                          *name,
+    uint32_t                             namelen,
+    chimera_vfs_remove_stream_callback_t callback,
+    void                                *private_data)
+{
+    struct chimera_vfs_request *request;
+
+    if (!(handle->vfs_module->capabilities & CHIMERA_VFS_CAP_NAMED_STREAMS)) {
+        callback(CHIMERA_VFS_ENOTSUP, NULL, NULL, private_data);
+        return;
+    }
+
+    request = chimera_vfs_request_alloc_by_handle(thread, cred, handle);
+
+    if (CHIMERA_VFS_IS_ERR(request)) {
+        callback(CHIMERA_VFS_PTR_ERR(request), NULL, NULL, private_data);
+        return;
+    }
+
+    request->opcode                                = CHIMERA_VFS_OP_REMOVE_STREAM;
+    request->complete                              = chimera_vfs_remove_stream_complete;
+    request->remove_stream.handle                  = handle;
+    request->remove_stream.name                    = name;
+    request->remove_stream.namelen                 = namelen;
+    request->remove_stream.r_pre_attr.va_req_mask  = 0;
+    request->remove_stream.r_pre_attr.va_set_mask  = 0;
+    request->remove_stream.r_post_attr.va_req_mask = 0;
+    request->remove_stream.r_post_attr.va_set_mask = 0;
+    request->proto_callback                        = callback;
+    request->proto_private_data                    = private_data;
+
+    chimera_vfs_dispatch(request);
+} /* chimera_vfs_remove_stream */

--- a/src/vfs/vfs_procs.h
+++ b/src/vfs/vfs_procs.h
@@ -917,3 +917,74 @@ chimera_vfs_remove_xattr(
     uint32_t                            namelen,
     chimera_vfs_remove_xattr_callback_t callback,
     void                               *private_data);
+
+/*
+ * Named-stream (SMB Alternate Data Stream) operations.
+ * Gated by CHIMERA_VFS_CAP_NAMED_STREAMS.
+ */
+
+/* Open (and optionally create/truncate) a named data fork on the base file
+ * referenced by `handle`.  On success `oh` is a VFS open handle for the
+ * stream: read/write/getattr/setattr against it operate on the stream's own
+ * data and size, while metadata (mode/owner/timestamps) mirror the base file.
+ * `set_attr` may be NULL.  Stream-open `flags` use CHIMERA_VFS_OPEN_* (CREATE/
+ * EXCLUSIVE/TRUNCATE) with the same semantics as chimera_vfs_open_at. */
+typedef void (*chimera_vfs_open_stream_callback_t)(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *oh,
+    struct chimera_vfs_attrs       *attr,
+    void                           *private_data);
+
+void
+chimera_vfs_open_stream(
+    struct chimera_vfs_thread         *thread,
+    const struct chimera_vfs_cred     *cred,
+    struct chimera_vfs_open_handle    *handle,
+    const char                        *name,
+    uint32_t                           namelen,
+    uint32_t                           flags,
+    struct chimera_vfs_attrs          *set_attr,
+    uint64_t                           attr_mask,
+    chimera_vfs_open_stream_callback_t callback,
+    void                              *private_data);
+
+/* Enumerate the named streams of the base file referenced by `handle`.  The
+ * buffer is filled with packed struct chimera_vfs_stream_entry records (each
+ * followed by name_len name bytes); the default unnamed data fork is reported
+ * first as an entry with an empty name and the file's size. */
+typedef void (*chimera_vfs_list_streams_callback_t)(
+    enum chimera_vfs_error error_code,
+    const void            *records,  /* packed chimera_vfs_stream_entry + names */
+    uint32_t               records_len,
+    uint32_t               count,
+    uint32_t               eof,
+    uint64_t               cookie,
+    void                  *private_data);
+
+void
+chimera_vfs_list_streams(
+    struct chimera_vfs_thread          *thread,
+    const struct chimera_vfs_cred      *cred,
+    struct chimera_vfs_open_handle     *handle,
+    uint64_t                            cookie,
+    void                               *buffer,
+    uint32_t                            max_bytes,
+    chimera_vfs_list_streams_callback_t callback,
+    void                               *private_data);
+
+/* Remove a single named stream from the base file referenced by `handle`. */
+typedef void (*chimera_vfs_remove_stream_callback_t)(
+    enum chimera_vfs_error          error_code,
+    const struct chimera_vfs_attrs *pre_attr,
+    const struct chimera_vfs_attrs *post_attr,
+    void                           *private_data);
+
+void
+chimera_vfs_remove_stream(
+    struct chimera_vfs_thread           *thread,
+    const struct chimera_vfs_cred       *cred,
+    struct chimera_vfs_open_handle      *handle,
+    const char                          *name,
+    uint32_t                             namelen,
+    chimera_vfs_remove_stream_callback_t callback,
+    void                                *private_data);


### PR DESCRIPTION
## Summary

Adds SMB2 Alternate Data Stream (named-stream) support, double-gated by a new JSON config flag `smb_named_streams` (default off) **and** a per-backend VFS capability `CHIMERA_VFS_CAP_NAMED_STREAMS`. Only **memfs** advertises the capability; when either gate is off the prior behavior is preserved (reject `:` names with `OBJECT_NAME_INVALID`, `FileStreamInformation` → `NOT_IMPLEMENTED`).

### VFS core
- New `OPEN_STREAM` / `LIST_STREAMS` / `REMOVE_STREAM` operations + wrappers, mirroring the existing xattr plumbing.
- `OPEN_STREAM` returns a cached open handle like `OPEN_AT`, so read/write/getattr/setattr flow through the stream handle unchanged.

### memfs
- Named streams stored as **embedded data forks** on the inode (the union `file` member becomes a `struct memfs_fork`; named streams are a linked list with their own size/blocks). Metadata stays on the single base inode (SMB-correct) with one lock — no cross-inode locking.
- A tagged `vfs_private` descriptor routes the data-path handlers to the right fork; stream file handles encode a per-inode stream id.
- Stream lifecycle is reference-counted with deferred free for delete-while-open; streams cascade on base-file delete, `OPEN_TRUNCATE` supersede, and shutdown (ASan-clean).

### SMB server
- Parse `file:stream[:$DATA]`, open the base file then chain `chimera_vfs_open_stream` — the disposition applies to the **stream**, never truncating the base file.
- Implement `FileStreamInformation` enumeration (MS-FSCC 2.4.43).
- Route stream delete-on-close through `remove_stream` rather than the base-file delete-on-close path.
- Config plumbed end-to-end (`server.c/h`, `daemon.c`, `smb_internal.h`, `smb.c`) mirroring `smb_persistent_handles`.

### Tests
- The smbtorture harness flips `smb_named_streams` on **per stream suite**, so `smb2.create_no_streams` still runs (and passes) with the feature off — verifying the gate.
- `smb2.streams` / `smb2.sdread` / `smb2.ioctl-on-stream` are **not yet fully green** and remain disabled (smbtorture gates per whole suite). Passing `smb2.streams` subtests: sharemodes, rename, create-disposition, zero-byte. Remaining gaps left for follow-up: stream share-mode/sharing-violation semantics, `FILE_ATTRIBUTE` reporting on stream handles, stream-name validation edge cases, directory streams, and rename-with-an-open-stream.

### Notes
- Pre-existing (out of scope, flagged in code): `CHIMERA_VFS_CAP_READ_PROVIDES_BUFFERS` and `CHIMERA_VFS_CAP_ACL_NATIVE` are both defined as `(1U << 20)` in `vfs.h`.