### PR TITLE
smb: grant the owner of a mode-only object its requested CREATE access

### DIFF
--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -960,6 +960,35 @@ chimera_smb_create_check_access(
         return SMB2_STATUS_SUCCESS;
     }
 
+    /* Windows owner semantics on a mode-only object: a file's owner always holds
+     * an implicit WRITE_DAC, so it can rewrite the security descriptor at will
+     * and is therefore granted the access it asks for over its own object.  The
+     * engine backends (e.g. memfs) encode this as an owner-full-control default
+     * DACL stamped on an SMB-created object, so this check passes naturally
+     * there.  The mode-only backends (linux/io_uring/cairn/diskfs) report only
+     * the POSIX mode and no explicit ACL; under POSIX mode evaluation the owner
+     * is NOT granted the WRITE_OWNER / WRITE_ATTRIBUTES / SYNCHRONIZE / EXECUTE
+     * bits a Windows CREATE routinely requests with FILE_ALL_ACCESS, so an owner
+     * opening its own file would be wrongly denied.  Recognise the owner of a
+     * no-explicit-ACL object here and grant it, matching the owner-full-control
+     * default DACL the engine backends materialise.  POSIX (NFS/S3) evaluation
+     * is unaffected -- this is the SMB protocol layer applying Windows owner
+     * rules, not a change to the shared engine.  A *different* caller still falls
+     * through to the normal mode/ACL evaluation below and is gated correctly. */
+    {
+        const struct chimera_vfs_cred *cred =
+            &request->session_handle->session->cred;
+        int                            has_acl = (attr->va_set_mask & CHIMERA_VFS_ATTR_ACL) &&
+            attr->va_acl && attr->va_acl->num_aces > 0;
+
+        if (!has_acl &&
+            cred->flavor != CHIMERA_VFS_AUTH_NONE &&
+            (attr->va_set_mask & CHIMERA_VFS_ATTR_UID) &&
+            (uint64_t) cred->uid == attr->va_uid) {
+            return SMB2_STATUS_SUCCESS;
+        }
+    }
+
     /* Evaluate the full grantable universe and require every requested bit to
      * be present; a requested right outside what the ACL grants (e.g. an
      * undefined specific bit) is therefore denied. */

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -365,9 +365,38 @@ set(SMBTORTURE_ENABLED_io_uring
     smb2.sharemode
     smb2.winattr2
 )
-set(SMBTORTURE_ENABLED_diskfs_io_uring)
-set(SMBTORTURE_ENABLED_diskfs_aio)
-set(SMBTORTURE_ENABLED_cairn)
+# The engine backends store their own data and stamp a new object's owner from
+# the calling credential, so they behave consistently regardless of the server's
+# own uid (unlike the setfsuid/personality passthrough backends).  The suites
+# below were verified green end-to-end once the SMB CREATE owner access check was
+# fixed (see chimera_smb_create_check_access).
+set(SMBTORTURE_ENABLED_cairn
+    smb2.check-sharemode
+    smb2.create_no_streams
+    smb2.secleak
+    smb2.session.signing-aes-128-cmac
+    smb2.set-sparse-ioctl
+    smb2.sharemode
+    smb2.winattr2
+)
+# diskfs has no FSCTL_SET_SPARSE support yet, so smb2.set-sparse-ioctl stays
+# disabled; the rest match the cairn set.
+set(SMBTORTURE_ENABLED_diskfs_io_uring
+    smb2.check-sharemode
+    smb2.create_no_streams
+    smb2.secleak
+    smb2.session.signing-aes-128-cmac
+    smb2.sharemode
+    smb2.winattr2
+)
+set(SMBTORTURE_ENABLED_diskfs_aio
+    smb2.check-sharemode
+    smb2.create_no_streams
+    smb2.secleak
+    smb2.session.signing-aes-128-cmac
+    smb2.sharemode
+    smb2.winattr2
+)
 
 macro(add_smbtorture_backend_tests backend)
     foreach(SUITE ${SMBTORTURE_SUITES})

--- a/src/vfs/io_uring/io_uring.c
+++ b/src/vfs/io_uring/io_uring.c
@@ -271,6 +271,21 @@ chimera_io_uring_set_open_attrs(
 {
     uint64_t set_mask = attr->va_set_mask;
 
+    /* Apply ownership requested via the attribute set.  For an AUTH_ATTR
+     * credential, chimera_setup_credential() injects the caller's UID/GID here
+     * (rather than impersonating with setfsuid), so without this fchown a newly
+     * created file would be owned by the server identity instead of the client
+     * -- which then fails the owner access check on a root-run server.  Mirrors
+     * the linux backend's chimera_linux_set_attrs(). */
+    if ((set_mask & (CHIMERA_VFS_ATTR_UID | CHIMERA_VFS_ATTR_GID))) {
+        uid_t uid = (set_mask & CHIMERA_VFS_ATTR_UID) ? (uid_t) attr->va_uid : (uid_t) -1;
+        gid_t gid = (set_mask & CHIMERA_VFS_ATTR_GID) ? (gid_t) attr->va_gid : (gid_t) -1;
+
+        if (fchown(fd, uid, gid) < 0) {
+            return errno;
+        }
+    }
+
     if (set_mask & CHIMERA_VFS_ATTR_SIZE) {
         if (ftruncate(fd, attr->va_size) < 0) {
             return errno;
@@ -1245,6 +1260,16 @@ chimera_io_uring_open_at(
             request->complete(request);
             return;
         }
+    }
+
+    /* chimera_setup_credential injects the AUTH_ATTR caller's UID/GID into
+     * set_attr; ownership is only meaningful when this open creates the object.
+     * Drop the injected UID/GID for a non-creating open so set_open_attrs does
+     * not fchown an already-existing file (which would also fail on the O_PATH
+     * metadata-only handle used for some opens). */
+    if (!(request->open_at.flags & CHIMERA_VFS_OPEN_CREATE)) {
+        request->open_at.set_attr->va_set_mask &=
+            ~(CHIMERA_VFS_ATTR_UID | CHIMERA_VFS_ATTR_GID);
     }
 
     sqe = chimera_io_uring_get_sqe(thread, request, 0, 0);


### PR DESCRIPTION
## Summary

After the Unified-ACL work (#311), an SMB2 CREATE wrongly returned
`NT_STATUS_ACCESS_DENIED` for the object's own owner on every backend that
reports a POSIX mode and **no explicit ACL** — linux, io_uring, cairn and
diskfs. memfs was unaffected. The failure was environment-sensitive: it passed
on amd64 CI (test process runs as uid 1001) but failed on arm64 CI and
reproduces locally when the test harness runs as root.

### Root cause

`chimera_smb_create_check_access` evaluates the CREATE's DesiredAccess against
the opened object via the shared engine (`chimera_vfs_access_check`). A Windows
CREATE asks for `FILE_ALL_ACCESS`, which includes `WRITE_OWNER`,
`WRITE_ATTRIBUTES`, `SYNCHRONIZE` and `EXECUTE`.

- **memfs** stamps an owner-full-control default DACL on an SMB-created object
  (`chimera_acl_default_acl`), so the engine grants the owner the full mask and
  the check passes.
- The **mode-only backends** return only the POSIX mode and no `va_acl` on the
  open path, so the engine takes the POSIX-mode fallback, which by design never
  grants the owner `WRITE_OWNER`/`WRITE_ATTRIBUTES`/`SYNCHRONIZE`, nor `EXECUTE`
  on a file that lacks the mode-x bit. The owner of its own 0600 file was thus
  denied (`req & ~granted != 0`).

Instrumented evidence (linux, owner=uid 1001, file 0100600):
`req=0xe01ff granted=0x7009f missing=0x80160` (WRITE_OWNER | WRITE_ATTRIBUTES |
DELETE_CHILD | EXECUTE). memfs for the same CREATE: `granted=0x1f01ff`.

A second, related defect surfaced once ownership mattered: the **io_uring**
backend never applied the `AUTH_ATTR`-injected UID/GID (`chimera_setup_credential`
injects them into `set_attr` instead of impersonating with `setfsuid`), so a
newly created file was owned by the server identity (uid 0 on a root-run server)
rather than the SMB client (uid 1001) — defeating any owner check.

### Fix

- `chimera_smb_create_check_access`: a file's owner implicitly holds `WRITE_DAC`
  and can rewrite the security descriptor at will, so it effectively has full
  control over its own object (exactly what memfs's default DACL encodes).
  Recognize the owner of a no-explicit-ACL object and grant it. This is applied
  in the **SMB protocol layer only** — the shared VFS access engine (and the
  NFS/S3 read/write/ACCESS gates that share it) is unchanged. A *different*
  caller still falls through to normal mode/ACL evaluation and is gated
  correctly.
- `io_uring` `chimera_io_uring_set_open_attrs`: apply the requested UID/GID via
  `fchown` on a creating open (mirrors the linux backend's
  `chimera_linux_set_attrs`). The injected UID/GID is dropped for non-creating
  opens so an existing file is never re-chowned (which would also fail on the
  O_PATH metadata-only handle used for some opens).
- Enable the now-green `check-sharemode`/`sharemode`/`winattr2` (plus
  `create_no_streams`/`secleak`/`session.signing-aes-128-cmac`, and
  `set-sparse-ioctl` for cairn) smbtorture suites on cairn and diskfs.

### Validation (local, run as root — the failing environment)

- Previously-denied suites now pass on every affected backend
  (memfs/linux/io_uring/cairn/diskfs): `smb2.check-sharemode`, `smb2.sharemode`,
  `smb2.set-sparse-ioctl` (except diskfs, which lacks FSCTL_SET_SPARSE),
  `smb2.deny` (linux), `smb2.winattr2`.
- Full enabled smbtorture ctest sweep: 62/62 pass (was 43; +19 newly enabled on
  cairn/diskfs).
- No regression: memfs `smb2.sharemode` still passes; pynfs `access` on
  memfs/linux/io_uring/diskfs all green; the full io_uring pynfs nfs4.0 set
  (1235 tests) and the VFS ACL unit test pass.
- Builds clean in Debug (+ASan) and Release; `make syntax` clean.

### arm64 caveat

arm64 cannot be exercised locally. The fix targets the general access path
(not a special-case), and cairn/diskfs stamp a new object's owner directly from
the calling credential (no setfsuid/personality), so they are not arch-sensitive
the way the passthrough backends are. The newly-enabled cairn/diskfs suites are
a conservative subset confirmed fully green here.