### PR TITLE
smb2: read/write boundary fixes + cairn/diskfs NT ACL storage; enable smb2.read/rw on all backends

### DIFF
--- a/src/server/smb/smb_proc_ioctl.c
+++ b/src/server/smb/smb_proc_ioctl.c
@@ -164,7 +164,9 @@ chimera_smb_ioctl(struct chimera_smb_request *request)
             break;
 
         default:
-            chimera_smb_complete_request(request, SMB2_STATUS_NOT_IMPLEMENTED);
+            /* MS-SMB2 3.3.5.15: an FSCTL the server does not implement is
+             * rejected with STATUS_NOT_SUPPORTED. */
+            chimera_smb_complete_request(request, SMB2_STATUS_NOT_SUPPORTED);
             break;
     } /* switch */
 } /* chimera_smb_ioctl */

--- a/src/server/smb/smb_proc_read.c
+++ b/src/server/smb/smb_proc_read.c
@@ -36,12 +36,18 @@ chimera_smb_read_callback(
     request->read.niov     = niov;
     request->read.r_length = count;
 
+    /* The data iovecs the VFS filled into request->read.iov are injected into
+     * the reply (and so released) only on the SUCCESS path below.  Any path
+     * that completes with an error status emits a bare SMB2 error response
+     * instead, so those iovecs must be released here to avoid a leak. */
     if (error_code) {
+        evpl_iovecs_release(evpl, request->read.iov, niov);
         chimera_smb_complete_request(private_data, SMB2_STATUS_INTERNAL_ERROR);
         return;
     }
 
     if (count == 0 && request->read.length > 0) {
+        evpl_iovecs_release(evpl, request->read.iov, niov);
         chimera_smb_complete_request(private_data, SMB2_STATUS_END_OF_FILE);
         return;
     }
@@ -49,6 +55,7 @@ chimera_smb_read_callback(
     /* MS-SMB2 §3.3.5.12: if MinimumCount is set and the actual bytes read
      * is less than MinimumCount, return STATUS_END_OF_FILE. */
     if (request->read.minimum > 0 && count < request->read.minimum) {
+        evpl_iovecs_release(evpl, request->read.iov, niov);
         chimera_smb_complete_request(private_data, SMB2_STATUS_END_OF_FILE);
         return;
     }
@@ -115,13 +122,17 @@ chimera_smb_read(struct chimera_smb_request *request)
         return;
     }
 
-    /* MS-SMB2: FileOffset > 0x7FFFFFFFFFFFFFFF, offset+length overflows,
-     * length exceeds MaxReadSize, or MinimumCount > Length must fail with
-     * INVALID_PARAMETER. */
+    /* MS-SMB2 3.3.5.12: fail with INVALID_PARAMETER when the starting offset
+     * is beyond the maximum file size (INT64_MAX), when the last byte to read
+     * would extend past it, or when Length exceeds MaxReadSize.  A
+     * MinimumCount larger than Length (or than the bytes actually available)
+     * is NOT a parameter error: the read proceeds and the callback returns
+     * END_OF_FILE when fewer than MinimumCount bytes are read.  Because the
+     * first clause bounds offset to INT64_MAX, the offset+length sum cannot
+     * overflow uint64. */
     if (request->read.offset > 0x7FFFFFFFFFFFFFFFULL ||
-        request->read.offset + request->read.length < request->read.offset ||
-        request->read.length > (8 * 1024 * 1024) ||
-        request->read.minimum > request->read.length) {
+        request->read.offset + request->read.length > 0x7FFFFFFFFFFFFFFFULL ||
+        request->read.length > (8 * 1024 * 1024)) {
         chimera_smb_open_file_release(request, request->read.open_file);
         chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
         return;

--- a/src/server/smb/smb_proc_write.c
+++ b/src/server/smb/smb_proc_write.c
@@ -9,6 +9,11 @@
 #include "vfs/vfs_notify.h"
 #include "vfs/vfs_state.h"
 
+/* Maximum supported file size, matching the Windows/Samba value
+ * (0xFFFFFFF0000 == 2^44 - 2^16).  A write whose last byte would extend past
+ * this is rejected with INVALID_PARAMETER. */
+#define CHIMERA_SMB_MAX_FILE_SIZE 0xfffffff0000ULL
+
 /* A write-time-sticky handle needs the pre-write mtime back from the VFS so the
  * write callback can restore it; otherwise no pre-attrs are requested. */
 static inline uint64_t
@@ -168,6 +173,20 @@ chimera_smb_write(struct chimera_smb_request *request)
          * chimera_smb_write_callback is being skipped. */
         evpl_iovecs_release(evpl, request->write.iov, request->write.niov);
         chimera_smb_complete_request(request, SMB2_STATUS_FILE_CLOSED);
+        return;
+    }
+
+    /* MS-SMB2 3.3.5.13: reject writes whose offset is beyond the maximum file
+    * size (INT64_MAX) and writes whose last byte would extend past the
+    * server's maximum supported file size.  A zero-length write at any
+    * in-range offset is permitted (it changes nothing).  The first clause
+    * bounds offset to INT64_MAX, so the offset+length sum cannot overflow. */
+    if (request->write.offset > 0x7FFFFFFFFFFFFFFFULL ||
+        (request->write.length > 0 &&
+         request->write.offset + request->write.length > CHIMERA_SMB_MAX_FILE_SIZE)) {
+        evpl_iovecs_release(evpl, request->write.iov, request->write.niov);
+        chimera_smb_open_file_release(request, request->write.open_file);
+        chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
         return;
     }
 

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -320,6 +320,8 @@ set(SMBTORTURE_SUITES
 # remaining backends start fully disabled; populate their lists as suites are
 # verified against them.
 set(SMBTORTURE_ENABLED_memfs
+    smb2.read
+    smb2.rw
     smb2.check-sharemode
     smb2.compound_find
     smb2.connect
@@ -359,6 +361,8 @@ set(SMBTORTURE_ENABLED_memfs
 # the same set.  They expose the share root as a real local directory whose
 # filesystem must support name_to_handle_at(2) (see smbtorture_test.c).
 set(SMBTORTURE_ENABLED_linux
+    smb2.read
+    smb2.rw
     smb2.check-sharemode
     smb2.compound_find
     smb2.create_no_streams
@@ -374,6 +378,8 @@ set(SMBTORTURE_ENABLED_linux
     # pending the arm64 difference.
 )
 set(SMBTORTURE_ENABLED_io_uring
+    smb2.read
+    smb2.rw
     smb2.check-sharemode
     smb2.compound_find
     smb2.create_no_streams
@@ -392,6 +398,8 @@ set(SMBTORTURE_ENABLED_io_uring
 # below were verified green end-to-end once the SMB CREATE owner access check was
 # fixed (see chimera_smb_create_check_access).
 set(SMBTORTURE_ENABLED_cairn
+    smb2.read
+    smb2.rw
     smb2.check-sharemode
     smb2.compound_find
     smb2.create_no_streams
@@ -409,6 +417,8 @@ set(SMBTORTURE_ENABLED_cairn
 # stays disabled (no FSCTL_SET_SPARSE support yet); both block backends share
 # the diskfs module and enable the same set.
 set(SMBTORTURE_ENABLED_diskfs_common
+    smb2.read
+    smb2.rw
     smb2.check-sharemode
     smb2.compound_find
     smb2.create_no_streams

--- a/src/vfs/cairn/cairn.c
+++ b/src/vfs/cairn/cairn.c
@@ -839,6 +839,75 @@ cairn_map_acl(
     attr->va_set_mask |= CHIMERA_VFS_ATTR_ACL;
 } /* cairn_map_acl */
 
+/*
+ * Seed a freshly-created child's ACL, mirroring memfs_inherit_acl():
+ *   1. An explicit ACL supplied at create is stored as-is.
+ *   2. Otherwise inherit the parent's inheritable ACEs, if any.
+ *   3. Otherwise, for an SMB-originated create (windows_default), store a
+ *      Windows-style default DACL granting the owner full control while
+ *      leaving the POSIX mode intact (plain mode would deny e.g. FILE_EXECUTE
+ *      and WRITE_OWNER on a 0644 file).
+ *   4. Otherwise leave the child mode-derived (no stored ACL).
+ * The ACL is written into the current meta transaction, so the create's own
+ * attribute readback (cairn_map_acl) reflects it immediately.
+ */
+static void
+cairn_inherit_acl(
+    struct cairn_thread            *thread,
+    struct cairn_inode             *child,
+    uint64_t                        parent_inum,
+    const struct chimera_vfs_attrs *set_attr,
+    int                             windows_default)
+{
+    static __thread uint8_t pbuf[CAIRN_ACL_STRUCT_SCRATCH];
+    struct chimera_acl     *pacl   = (struct chimera_acl *) pbuf;
+    int                     is_dir = S_ISDIR(child->mode);
+    uint16_t                want   = CHIMERA_ACE_FLAG_FILE_INHERIT |
+        (is_dir ? CHIMERA_ACE_FLAG_DIR_INHERIT : 0);
+
+    if ((set_attr->va_set_mask & CHIMERA_VFS_ATTR_ACL) &&
+        set_attr->va_acl && set_attr->va_acl->num_aces) {
+        cairn_put_acl(thread, child->inum, set_attr->va_acl);
+        child->mode = (child->mode & S_IFMT) | chimera_acl_to_mode(set_attr->va_acl);
+        return;
+    }
+
+    if (cairn_load_acl(thread, parent_inum, pacl)) {
+        int has_inh = 0;
+
+        for (unsigned i = 0; i < pacl->num_aces; i++) {
+            if (pacl->aces[i].flags & want) {
+                has_inh = 1;
+                break;
+            }
+        }
+
+        if (has_inh) {
+            unsigned            cap = pacl->num_aces * 2;
+            struct chimera_acl *tmp = malloc(chimera_acl_size(cap));
+            int                 n   = chimera_acl_inherit(pacl, is_dir,
+                                                          child->mode & 07777, tmp, cap);
+
+            if (n > 0) {
+                cairn_put_acl(thread, child->inum, tmp);
+                child->mode = (child->mode & S_IFMT) | chimera_acl_to_mode(tmp);
+                free(tmp);
+                return;
+            }
+            free(tmp);
+        }
+    }
+
+    if (windows_default) {
+        uint8_t             buf[sizeof(struct chimera_acl) + 4 * sizeof(struct chimera_ace)];
+        struct chimera_acl *def = (struct chimera_acl *) buf;
+
+        if (chimera_acl_default_acl(child->mode & 07777, def, 4) > 0) {
+            cairn_put_acl(thread, child->inum, def);
+        }
+    }
+} /* cairn_inherit_acl */
+
 static inline void
 cairn_remove_directory_contents(
     struct cairn_thread *thread,
@@ -2172,7 +2241,12 @@ cairn_mkdir_at(
 
     cairn_apply_attrs(&inode, request->mkdir_at.set_attr);
 
+    cairn_inherit_acl(thread, &inode, parent_inode->inum,
+                      request->mkdir_at.set_attr,
+                      request->cred->flavor == CHIMERA_VFS_AUTH_ATTR);
+
     cairn_map_attrs(shared, &request->mkdir_at.r_attr, &inode);
+    cairn_map_acl(thread, &request->mkdir_at.r_attr, &inode);
 
     dirent_value.inum     = inode.inum;
     dirent_value.name_len = request->mkdir_at.name_len;
@@ -2730,6 +2804,10 @@ cairn_open_at(
 
         cairn_apply_attrs(&new_inode, request->open_at.set_attr);
 
+        cairn_inherit_acl(thread, &new_inode, parent_inode->inum,
+                          request->open_at.set_attr,
+                          request->cred->flavor == CHIMERA_VFS_AUTH_ATTR);
+
         new_dirent_value.inum     = new_inode.inum;
         new_dirent_value.name_len = request->open_at.namelen;
         memcpy(new_dirent_value.name, request->open_at.name, request->open_at.namelen);
@@ -2817,6 +2895,7 @@ cairn_open_at(
 
     cairn_map_attrs(shared, &request->open_at.r_dir_post_attr, parent_inode);
     cairn_map_attrs(shared, &request->open_at.r_attr, inode);
+    cairn_map_acl(thread, &request->open_at.r_attr, inode);
 
     cairn_put_inode(thread, parent_inode);
     cairn_put_inode(thread, inode);

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -2915,7 +2915,11 @@ memfs_write(
             new_max_blocks <<= 1;
         }
 
-        new_blocks = malloc(new_max_blocks * sizeof(struct memfs_block *));
+        /* calloc (not malloc+memset) so a sparse write at a high block index
+         * does not force the whole pointer array resident: large allocations
+         * are served by mmap and the unwritten tail stays backed by the zero
+         * page until a block is actually stored there. */
+        new_blocks = calloc(new_max_blocks, sizeof(struct memfs_block *));
 
         if (!new_blocks) {
             pthread_mutex_unlock(&inode->lock);
@@ -2929,11 +2933,6 @@ memfs_write(
                    fork->num_blocks * sizeof(struct memfs_block *));
             free(blocks);
         }
-
-        memset(new_blocks + fork->num_blocks,
-               0,
-               (new_max_blocks - fork->num_blocks) *
-               sizeof(struct memfs_block *));
 
         fork->blocks     = new_blocks;
         fork->max_blocks = new_max_blocks;


### PR DESCRIPTION
## Summary

Greens the Samba `smbtorture` `smb2.read` and `smb2.rw` suites on every backend (memfs, cairn, diskfs io_uring/aio, and the linux/io_uring passthroughs) and enables them in CI.

**Read/write boundary handling** (`smb_proc_read.c`, `smb_proc_write.c`, `smb_proc_ioctl.c`, memfs):
- `MinimumCount > Length` is no longer treated as `INVALID_PARAMETER` — per MS-SMB2 the read proceeds and returns `END_OF_FILE` when fewer than `MinimumCount` bytes are read.
- Reads reject `offset+length` beyond `INT64_MAX`; writes reject `offset > INT64_MAX` and a last byte past the max file size (`0xfffffff0000`), while still allowing zero-length writes at any in-range offset.
- Fixed an iovec leak: an error/`END_OF_FILE` read completion emits a bare SMB2 error body and never calls `read_reply`, so the VFS-filled data iovecs were leaked.
- Unknown FSCTLs now return `NOT_SUPPORTED` (was `NOT_IMPLEMENTED`) so `smb2.read.bug14607` skips its Samba-internal test FSCTL.
- memfs grew its flat block-pointer array with `malloc`+`memset`, forcing a ~2 GB resident allocation for the `rw.invalid` sparse write at `MAXFILESIZE-1`; switched to `calloc` so the unwritten tail stays on the zero page (peak RSS ~2.1 GB → ~200 MiB).

**NT ACL storage on cairn and diskfs** — both now persist an owner-full-control default DACL on an SMB-flavor create (cairn via its KV store; diskfs inline in the inode home area so reads never descend the extent tree). This is a foundation for full `smb2.acls` support on those backends and complements the SMB-layer owner-access grant + io_uring create-chown already in #569 (which covers the linux/io_uring passthroughs).

Verified green via ctest in Debug (ASan) and Release; the full enabled smbtorture matrix and a broad NFS pynfs sample across backends pass with no regressions.