### PR TITLE
smb2: store birth time in cairn/diskfs; enable smb2.timestamps on native backends

### DIFF
--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -360,6 +360,11 @@ set(SMBTORTURE_ENABLED_memfs
 # The linux and io_uring passthrough backends share an implementation and pass
 # the same set.  They expose the share root as a real local directory whose
 # filesystem must support name_to_handle_at(2) (see smbtorture_test.c).
+# smb2.timestamps stays disabled here: the suite sets an arbitrary create time
+# (incl. far-future / pre-1970 values) and reads it back, but a real Linux
+# filesystem has no API to set a file's birth time, so the create-time
+# round-trip is unsupportable on the passthrough backends (it works on the
+# native backends, which persist btime in their own inode metadata).
 set(SMBTORTURE_ENABLED_linux
     smb2.read
     smb2.rw
@@ -409,6 +414,9 @@ set(SMBTORTURE_ENABLED_cairn
     smb2.set-sparse-ioctl
     smb2.sharemode
     smb2.tcon
+    # Native btime storage in the cairn inode lets the SMB create-time round-trip
+    # and the LastWriteTime write-time/sticky semantics pass end-to-end.
+    smb2.timestamps
     smb2.winattr2
 )
 # diskfs is a native-ACL backend: it stores each inode's ACL as a
@@ -427,6 +435,10 @@ set(SMBTORTURE_ENABLED_diskfs_common
     smb2.session.signing-aes-128-cmac
     smb2.sharemode
     smb2.tcon
+    # Native btime storage in the diskfs inode (in-memory + on-disk dinode) lets
+    # the SMB create-time round-trip and LastWriteTime semantics pass; both block
+    # backends share the diskfs module.
+    smb2.timestamps
     smb2.winattr2
     ${SMBTORTURE_ACLS_SUBTESTS}
 )

--- a/src/vfs/cairn/cairn.c
+++ b/src/vfs/cairn/cairn.c
@@ -178,6 +178,7 @@ struct cairn_inode {
     struct timespec atime;
     struct timespec mtime;
     struct timespec ctime;
+    struct timespec btime;
 };
 
 struct cairn_inode_handle {
@@ -1216,6 +1217,7 @@ cairn_init(
         inode.atime = now;
         inode.mtime = now;
         inode.ctime = now;
+        inode.btime = now;
 
         super.fsid = chimera_rand64();
 
@@ -1696,6 +1698,13 @@ cairn_map_attrs(
         attr->va_rdev       = inode->rdev;
     }
 
+    /* Birth time (SMB create time) is tracked natively but lives outside
+     * MASK_STAT, so map it only when explicitly requested. */
+    if (attr->va_req_mask & CHIMERA_VFS_ATTR_BTIME) {
+        attr->va_set_mask |= CHIMERA_VFS_ATTR_BTIME;
+        attr->va_btime     = inode->btime;
+    }
+
     if (attr->va_req_mask & CHIMERA_VFS_ATTR_FSID) {
         attr->va_set_mask |= CHIMERA_VFS_ATTR_FSID;
         attr->va_fsid      = shared->fsid;
@@ -1760,6 +1769,15 @@ cairn_apply_attrs(
             inode->mtime = now;
         } else {
             inode->mtime = attr->va_mtime;
+        }
+    }
+
+    if (set_mask & CHIMERA_VFS_ATTR_BTIME) {
+        attr->va_set_mask |= CHIMERA_VFS_ATTR_BTIME;
+        if (attr->va_btime.tv_nsec == CHIMERA_VFS_TIME_NOW) {
+            inode->btime = now;
+        } else {
+            inode->btime = attr->va_btime;
         }
     }
 
@@ -2238,6 +2256,7 @@ cairn_mkdir_at(
     inode.atime       = now;
     inode.mtime       = now;
     inode.ctime       = now;
+    inode.btime       = now;
 
     cairn_apply_attrs(&inode, request->mkdir_at.set_attr);
 
@@ -2341,6 +2360,7 @@ cairn_mknod_at(
     inode.atime       = now;
     inode.mtime       = now;
     inode.ctime       = now;
+    inode.btime       = now;
 
     /* Set mode (including file type bits) and rdev from set_attr */
     if (request->mknod_at.set_attr->va_set_mask & CHIMERA_VFS_ATTR_MODE) {
@@ -2800,6 +2820,7 @@ cairn_open_at(
         new_inode.atime      = now;
         new_inode.mtime      = now;
         new_inode.ctime      = now;
+        new_inode.btime      = now;
         new_inode.refcnt     = 1;
 
         cairn_apply_attrs(&new_inode, request->open_at.set_attr);
@@ -3661,6 +3682,7 @@ cairn_symlink_at(
     new_inode.atime      = now;
     new_inode.mtime      = now;
     new_inode.ctime      = now;
+    new_inode.btime      = now;
 
     dirent_value.inum     = new_inode.inum;
     dirent_value.name_len = request->symlink_at.namelen;

--- a/src/vfs/diskfs/diskfs.c
+++ b/src/vfs/diskfs/diskfs.c
@@ -454,9 +454,11 @@ struct diskfs_inode {
     uint64_t                    atime_sec;
     uint64_t                    ctime_sec;
     uint64_t                    mtime_sec;
+    uint64_t                    btime_sec;
     uint32_t                    atime_nsec;
     uint32_t                    ctime_nsec;
     uint32_t                    mtime_nsec;
+    uint32_t                    btime_nsec;
 
     /* Inode-cache linkage, keyed by inum.  Lock state and the wait list
      * below are protected by the owning shard's mutex, never held across
@@ -611,9 +613,11 @@ struct diskfs_dinode {
     uint64_t atime_sec;
     uint64_t mtime_sec;
     uint64_t ctime_sec;
+    uint64_t btime_sec;
     uint32_t atime_nsec;
     uint32_t mtime_nsec;
     uint32_t ctime_nsec;
+    uint32_t btime_nsec;
     uint64_t parent_inum;     /* directories only */
     uint32_t parent_gen;
 };
@@ -2124,6 +2128,8 @@ diskfs_inode_load_sync(
         inode->mtime_nsec  = di->mtime_nsec;
         inode->ctime_sec   = di->ctime_sec;
         inode->ctime_nsec  = di->ctime_nsec;
+        inode->btime_sec   = di->btime_sec;
+        inode->btime_nsec  = di->btime_nsec;
         inode->parent_inum = di->parent_inum;
         inode->parent_gen  = di->parent_gen;
         rb_tree_insert(&shard->inodes, inum, inode);
@@ -3208,9 +3214,11 @@ diskfs_inode_flush(struct diskfs_inode *inode)
     di->atime_sec  = inode->atime_sec;
     di->mtime_sec  = inode->mtime_sec;
     di->ctime_sec  = inode->ctime_sec;
+    di->btime_sec  = inode->btime_sec;
     di->atime_nsec = inode->atime_nsec;
     di->mtime_nsec = inode->mtime_nsec;
     di->ctime_nsec = inode->ctime_nsec;
+    di->btime_nsec = inode->btime_nsec;
     if (S_ISDIR(inode->mode)) {
         di->parent_inum = inode->parent_inum;
         di->parent_gen  = inode->parent_gen;
@@ -6070,6 +6078,8 @@ diskfs_inode_load_complete(
         inode->mtime_nsec  = di->mtime_nsec;
         inode->ctime_sec   = di->ctime_sec;
         inode->ctime_nsec  = di->ctime_nsec;
+        inode->btime_sec   = di->btime_sec;
+        inode->btime_nsec  = di->btime_nsec;
         inode->parent_inum = di->parent_inum;
         inode->parent_gen  = di->parent_gen;
         rb_tree_insert(&shard->inodes, inum, inode);
@@ -8229,6 +8239,8 @@ diskfs_bootstrap(struct diskfs_thread *thread)
     inode->mtime_nsec = now.tv_nsec;
     inode->ctime_sec  = now.tv_sec;
     inode->ctime_nsec = now.tv_nsec;
+    inode->btime_sec  = now.tv_sec;
+    inode->btime_nsec = now.tv_nsec;
 
     /* Root directory's parent is itself for ".." lookup */
     inode->parent_inum = inode->inum;
@@ -8273,6 +8285,8 @@ diskfs_bootstrap(struct diskfs_thread *thread)
         oin->mtime_nsec  = now.tv_nsec;
         oin->ctime_sec   = now.tv_sec;
         oin->ctime_nsec  = now.tv_nsec;
+        oin->btime_sec   = now.tv_sec;
+        oin->btime_nsec  = now.tv_nsec;
         oin->parent_inum = DISKFS_ORPHAN_INUM;
         oin->parent_gen  = oin->gen;
 
@@ -8803,6 +8817,14 @@ diskfs_map_attrs(
         attr->va_rdev          = inode->rdev;
     }
 
+    /* Birth time (SMB create time) is tracked natively but lives outside
+     * MASK_STAT, so map it only when explicitly requested. */
+    if (attr->va_req_mask & CHIMERA_VFS_ATTR_BTIME) {
+        attr->va_set_mask     |= CHIMERA_VFS_ATTR_BTIME;
+        attr->va_btime.tv_sec  = inode->btime_sec;
+        attr->va_btime.tv_nsec = inode->btime_nsec;
+    }
+
     if (attr->va_req_mask & CHIMERA_VFS_ATTR_FSID) {
         attr->va_set_mask |= CHIMERA_VFS_ATTR_FSID;
         attr->va_fsid      = shared->fsid;
@@ -8909,6 +8931,17 @@ diskfs_apply_attrs(
         } else {
             inode->mtime_sec  = attr->va_mtime.tv_sec;
             inode->mtime_nsec = attr->va_mtime.tv_nsec;
+        }
+    }
+
+    if (set_mask & CHIMERA_VFS_ATTR_BTIME) {
+        attr->va_set_mask |= CHIMERA_VFS_ATTR_BTIME;
+        if (attr->va_btime.tv_nsec == CHIMERA_VFS_TIME_NOW) {
+            inode->btime_sec  = now.tv_sec;
+            inode->btime_nsec = now.tv_nsec;
+        } else {
+            inode->btime_sec  = attr->va_btime.tv_sec;
+            inode->btime_nsec = attr->va_btime.tv_nsec;
         }
     }
 
@@ -9617,6 +9650,8 @@ diskfs_mkdir_at_alloc_cb(
     inode->mtime_nsec = now.tv_nsec;
     inode->ctime_sec  = now.tv_sec;
     inode->ctime_nsec = now.tv_nsec;
+    inode->btime_sec  = now.tv_sec;
+    inode->btime_nsec = now.tv_nsec;
 
     inode->parent_inum = parent->inum;
     inode->parent_gen  = parent->gen;
@@ -9791,6 +9826,8 @@ diskfs_mknod_at_alloc_cb(
     inode->mtime_nsec = now.tv_nsec;
     inode->ctime_sec  = now.tv_sec;
     inode->ctime_nsec = now.tv_nsec;
+    inode->btime_sec  = now.tv_sec;
+    inode->btime_nsec = now.tv_nsec;
 
     if (request->mknod_at.set_attr->va_set_mask & CHIMERA_VFS_ATTR_MODE) {
         inode->mode = request->mknod_at.set_attr->va_mode;
@@ -10582,6 +10619,8 @@ diskfs_open_at_alloc_cb(
     inode->mtime_nsec = now.tv_nsec;
     inode->ctime_sec  = now.tv_sec;
     inode->ctime_nsec = now.tv_nsec;
+    inode->btime_sec  = now.tv_sec;
+    inode->btime_nsec = now.tv_nsec;
 
     diskfs_apply_attrs(inode, request->open_at.set_attr);
 
@@ -10726,6 +10765,8 @@ diskfs_create_unlinked_alloc_cb(
     inode->mtime_nsec = now.tv_nsec;
     inode->ctime_sec  = now.tv_sec;
     inode->ctime_nsec = now.tv_nsec;
+    inode->btime_sec  = now.tv_sec;
+    inode->btime_nsec = now.tv_nsec;
 
     diskfs_apply_attrs(inode, request->create_unlinked.set_attr);
 
@@ -12680,6 +12721,8 @@ diskfs_symlink_at_alloc_cb(
     inode->mtime_nsec = now.tv_nsec;
     inode->ctime_sec  = now.tv_sec;
     inode->ctime_nsec = now.tv_nsec;
+    inode->btime_sec  = now.tv_sec;
+    inode->btime_nsec = now.tv_nsec;
 
     diskfs_map_attrs(thread, &request->symlink_at.r_attr, inode);
 


### PR DESCRIPTION
## Summary

The `smb2.timestamps` conformance suite was greened on memfs only by #565 (LastWriteTime omit sentinels, EndOfFile-vs-Allocation, sticky write time). It still failed on `cairn`, `diskfs_aio`, and `diskfs_io_uring` because those backends never tracked a birth time (btime): SMB `create_time` always read back as 0, so every create-time assertion in the suite failed — even though the write-time/sticky semantics from #565 already worked there.

This adds native btime storage to both native-metadata backends:

- **cairn**: a `btime` field in the inode, seeded at every create site and wired through `cairn_map_attrs` (getattr) and `cairn_apply_attrs` (setattr, honoring the `CHIMERA_VFS_TIME_NOW` sentinel like atime/mtime).
- **diskfs**: `btime_sec`/`btime_nsec` in both the in-memory inode and the on-disk dinode, seeded at every create site, persisted via the inode flush/load paths, and wired through map/apply the same way. The dinode grows by 12 bytes, well within the 256-byte inode area.

The SMB layer already requests and round-trips `CHIMERA_VFS_ATTR_BTIME` (proven by memfs), so no protocol-layer change is needed — purely backend storage.

`smb2.timestamps` now passes 17/17 on cairn and both diskfs block backends; the suite is enabled in their CMakeLists allowlists.

## Passthrough backends left disabled

`linux` and `io_uring` (passthrough) stay disabled for `smb2.timestamps`: the suite sets an arbitrary create time (including far-future and pre-1970 values) and reads it back, but a real Linux filesystem has no API to set a file's birth time, so the create-time round-trip is fundamentally unsupportable there. Documented in the allowlist.

## Validation

- `smb2.timestamps` 17/17 on `cairn`, `diskfs_aio`, `diskfs_io_uring`; still 17/17 on `memfs`; correctly Disabled on `linux`/`io_uring`.
- Regression run of the cairn/diskfs smbtorture allowlist plus the posix/client `stat`/`chmod`/`chown`/`cthon_basic`/`rename`/`remove`/`link` suites on those backends — all green.