### PR TITLE
smb2: reject ".." path components in CREATE; fix memfs root ".." deadlock

### DIFF
--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -1864,6 +1864,33 @@ chimera_smb_parse_stream_name(
     return SMB2_STATUS_SUCCESS;
 } /* chimera_smb_parse_stream_name */
 
+/* Return non-zero if a '/'-separated path contains a ".." component.  After
+ * parsing, the CREATE parent path is '/'-separated (the wire backslashes were
+ * converted), so this scans for an exact ".." between separators. */
+static inline int
+chimera_smb_path_has_dotdot(
+    const char *path,
+    int         len)
+{
+    const char *p   = path;
+    const char *end = path + len;
+
+    while (p < end) {
+        const char *comp = p;
+
+        while (p < end && *p != '/') {
+            p++;
+        }
+        if (p - comp == 2 && comp[0] == '.' && comp[1] == '.') {
+            return 1;
+        }
+        if (p < end) {
+            p++;
+        }
+    }
+    return 0;
+} /* chimera_smb_path_has_dotdot */
+
 void
 chimera_smb_create(struct chimera_smb_request *request)
 {
@@ -1918,6 +1945,20 @@ chimera_smb_create(struct chimera_smb_request *request)
      * an undefined CreateDisposition. */
     if (request->create.create_disposition > SMB2_FILE_OVERWRITE_IF) {
         chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
+        return;
+    }
+
+    /* Reject any ".." path component.  Windows clients canonicalize these away
+     * before sending, so the server never needs to resolve one; letting it
+     * reach the VFS would walk above the share root (a traversal escape on the
+     * passthrough backends).  MS-SMB2 returns STATUS_OBJECT_PATH_SYNTAX_BAD.
+     * Completed here (not in parse) so the client gets a response rather than a
+     * connection drop. */
+    if ((request->create.name_len == 2 &&
+         request->create.name[0] == '.' && request->create.name[1] == '.') ||
+        chimera_smb_path_has_dotdot(request->create.parent_path,
+                                    request->create.parent_path_len)) {
+        chimera_smb_complete_request(request, SMB2_STATUS_OBJECT_PATH_SYNTAX_BAD);
         return;
     }
 

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -321,6 +321,7 @@ set(SMBTORTURE_SUITES
 # verified against them.
 set(SMBTORTURE_ENABLED_memfs
     smb2.maximum_allowed
+    smb2.mkdir
     smb2.openattr
     smb2.read
     smb2.rw
@@ -368,6 +369,7 @@ set(SMBTORTURE_ENABLED_memfs
 # round-trip is unsupportable on the passthrough backends (it works on the
 # native backends, which persist btime in their own inode metadata).
 set(SMBTORTURE_ENABLED_linux
+    smb2.mkdir
     smb2.read
     smb2.rw
     smb2.check-sharemode
@@ -385,6 +387,7 @@ set(SMBTORTURE_ENABLED_linux
     # pending the arm64 difference.
 )
 set(SMBTORTURE_ENABLED_io_uring
+    smb2.mkdir
     smb2.read
     smb2.rw
     smb2.check-sharemode
@@ -405,6 +408,7 @@ set(SMBTORTURE_ENABLED_io_uring
 # below were verified green end-to-end once the SMB CREATE owner access check was
 # fixed (see chimera_smb_create_check_access).
 set(SMBTORTURE_ENABLED_cairn
+    smb2.mkdir
     smb2.read
     smb2.rw
     smb2.check-sharemode
@@ -427,6 +431,7 @@ set(SMBTORTURE_ENABLED_cairn
 # stays disabled (no FSCTL_SET_SPARSE support yet); both block backends share
 # the diskfs module and enable the same set.
 set(SMBTORTURE_ENABLED_diskfs_common
+    smb2.mkdir
     smb2.read
     smb2.rw
     smb2.check-sharemode

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -1856,8 +1856,19 @@ memfs_lookup_at(
         return;
     }
 
-    /* Handle ".." - return the parent directory */
+    /* Handle ".." - return the parent directory.  The root directory is its
+     * own parent, so locking the parent here would re-lock the inode we
+     * already hold and deadlock on the non-recursive mutex; resolve ".." to
+     * the directory itself in that case (mirrors the readdir ".." handling). */
     if (namelen == 2 && name[0] == '.' && name[1] == '.') {
+        if (inode->dir.parent_inum == inode->inum &&
+            inode->dir.parent_gen == inode->gen) {
+            memfs_map_attrs(shared, &request->lookup_at.r_attr, inode, request->fh);
+            pthread_mutex_unlock(&inode->lock);
+            request->status = CHIMERA_VFS_OK;
+            request->complete(request);
+            return;
+        }
         child = memfs_inode_get_inum(shared, inode->dir.parent_inum, inode->dir.parent_gen);
         if (unlikely(!child)) {
             pthread_mutex_unlock(&inode->lock);


### PR DESCRIPTION
## Summary

An SMB2 CREATE whose path contained a `..` component (e.g. `mkdir "..\..\.."`) was passed straight through to the VFS path walk. On memfs the walk reached `memfs_lookup_at`'s `..` branch, which locks the directory inode and then locks its parent — but the root directory is its own parent, so it re-locked a non-recursive mutex and **deadlocked the worker thread**. This is a protocol-agnostic DoS (any `..` lookup on the share root, including via NFS), and on the passthrough backends resolving `..` would also walk above the share root.

Fixes both layers:

- **`smb_proc_create`**: reject any `..` path component up front with `STATUS_OBJECT_PATH_SYNTAX_BAD` (what Windows/Samba return). Done in the handler, not the parser, so the client gets a proper response instead of a connection drop.
- **`memfs_lookup_at`**: when the directory is its own parent (root), resolve `..` to the directory itself instead of re-locking — mirroring the existing readdir `..` handling.

Enables `smb2.mkdir` on all backends (memfs, linux, io_uring, cairn, diskfs), verified green via the netns smbtorture harness.