### PR TITLE
smb2: release parent handle on CREATE overwrite-check error paths

### DIFF
--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -1469,6 +1469,7 @@ chimera_smb_create_overwrite_check_callback(
         /* OVERWRITE requires an existing file; OVERWRITE_IF / SUPERSEDE
          * create it. */
         if (request->create.create_disposition == SMB2_FILE_OVERWRITE) {
+            chimera_smb_create_release_parent(request);
             chimera_smb_complete_request(request, SMB2_STATUS_OBJECT_NAME_NOT_FOUND);
             return;
         }
@@ -1477,6 +1478,7 @@ chimera_smb_create_overwrite_check_callback(
     }
 
     if (error_code != CHIMERA_VFS_OK) {
+        chimera_smb_create_release_parent(request);
         chimera_smb_complete_request(request, chimera_smb_create_error_status(error_code));
         return;
     }
@@ -1490,6 +1492,7 @@ chimera_smb_create_overwrite_check_callback(
          !(requested & SMB2_FILE_ATTRIBUTE_HIDDEN)) ||
         ((existing & SMB2_FILE_ATTRIBUTE_SYSTEM) &&
          !(requested & SMB2_FILE_ATTRIBUTE_SYSTEM))) {
+        chimera_smb_create_release_parent(request);
         chimera_smb_complete_request(request, SMB2_STATUS_ACCESS_DENIED);
         return;
     }

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -320,6 +320,7 @@ set(SMBTORTURE_SUITES
 # remaining backends start fully disabled; populate their lists as suites are
 # verified against them.
 set(SMBTORTURE_ENABLED_memfs
+    smb2.openattr
     smb2.read
     smb2.rw
     smb2.check-sharemode


### PR DESCRIPTION
## Summary

`chimera_smb_create_overwrite_check_callback` opens the parent directory handle (`request->create.parent_handle`) before deciding whether an existing file may be overwritten. Its three error early-returns — OVERWRITE on a missing file, a VFS lookup error, and the DOS-attribute `ACCESS_DENIED` for a read-only/hidden/system target — completed the request **without releasing that handle**, whereas the success paths release it via `chimera_smb_create_issue_open`.

Each leaked reference pins the directory's open-cache entry with a non-zero `opencnt`, so it never moves to the deferred-close list. At server shutdown `chimera_vfs_close_thread_sweep` loops forever waiting for the cache to drain, hanging teardown. `smb2.openattr` triggers this by repeatedly overwriting read-only files (each → `ACCESS_DENIED`): the test itself passes, but the server never shuts down.

Releases the parent handle on all three error paths. Enables `smb2.openattr` on memfs (verified green, with clean shutdown, via the netns smbtorture harness).