### PR TITLE
smb: defer invalid-session compound requests instead of crashing

### DIFF
--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -659,6 +659,13 @@ chimera_smb_compound_advance(struct chimera_smb_compound *compound)
         }
     }
 
+    /* A request the parser could not set up (e.g. invalid session id) carries a
+     * deferred status; complete it here, in order, rather than dispatching. */
+    if (unlikely(request->flags & CHIMERA_SMB_REQUEST_FLAG_PARSE_FAILED)) {
+        chimera_smb_complete_request(request, request->status);
+        return;
+    }
+
     /* Reject commands that require a valid tree connection */
     if (unlikely(!request->tree &&
                  request->smb2_hdr.command != SMB2_NEGOTIATE &&
@@ -899,13 +906,20 @@ chimera_smb_server_handle_smb2(
                          * a live session (e.g. one that has been logged off, or
                          * a bogus id).  Per MS-SMB2 3.3.5.2.9 this is answered
                          * with STATUS_USER_SESSION_DELETED rather than tearing
-                         * down the transport. */
+                         * down the transport.  Defer the failure: mark the
+                         * request and let the dispatcher complete it in order.
+                         * Completing it here would advance complete_requests out
+                         * of order (this request is not at the head of the
+                         * chain), leaving an earlier compounded request never
+                         * dispatched yet still replied to -- e.g. a CREATE whose
+                         * response is then built over uninitialized attributes. */
                         chimera_smb_error("Received SMB2 message with invalid session id %lx", request->smb2_hdr.
                                           session_id);
                         request->session_handle                      = NULL;
+                        request->status                              = SMB2_STATUS_USER_SESSION_DELETED;
+                        request->flags                              |= CHIMERA_SMB_REQUEST_FLAG_PARSE_FAILED;
                         compound->requests[compound->num_requests++] = request;
-                        chimera_smb_complete_request(request, SMB2_STATUS_USER_SESSION_DELETED);
-                        return;
+                        goto next_compound_request;
                     }
                 }
             }
@@ -1053,6 +1067,7 @@ chimera_smb_server_handle_smb2(
             return;
         }
 
+ next_compound_request:
         more_requests = request->smb2_hdr.next_command != 0;
 
         if (more_requests) {

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -151,7 +151,12 @@ struct chimera_smb_share {
 
 struct chimera_smb_conn;
 
-#define CHIMERA_SMB_REQUEST_FLAG_SIGN 0x01
+#define CHIMERA_SMB_REQUEST_FLAG_SIGN         0x01
+/* Set during compound parsing when a request cannot be set up (e.g. its header
+* names an invalid session id).  The request is still added to the compound so
+* the dispatcher completes it -- in order -- with request->status, instead of
+* the parser completing it out of order and corrupting the compound counter. */
+#define CHIMERA_SMB_REQUEST_FLAG_PARSE_FAILED 0x02
 
 /* MaxTransactSize advertised in NEGOTIATE.  QUERY_DIRECTORY / QUERY_INFO
  * output is bounded by this per MS-SMB2, so it doubles as the cap on the
@@ -159,7 +164,7 @@ struct chimera_smb_conn;
  * stay <= the libevpl per-buffer size (2 MiB) because that reply buffer is
  * allocated as a single iovec (max_iovecs == 1); a request larger than one
  * evpl buffer cannot be satisfied with one iovec. */
-#define CHIMERA_SMB_MAX_TRANSACT_SIZE (1 * 1024 * 1024)
+#define CHIMERA_SMB_MAX_TRANSACT_SIZE         (1 * 1024 * 1024)
 
 struct chimera_smb_rename_info {
     uint8_t                         replace_if_exist;


### PR DESCRIPTION
## Summary

A compound request whose **non-first** request names an **invalid session id** crashes the SMB server — a client-triggerable abort/DoS. `smb2.compound.invalid2` reproduces it on every backend.

### Root cause

The compound parse loop handled a bad session id by completing that request immediately and returning:

```c
chimera_smb_complete_request(request, SMB2_STATUS_USER_SESSION_DELETED);
return;
```

But that request is not at the head of the chain. `chimera_smb_complete_request` advances `complete_requests`, so it stepped **past an earlier compounded CREATE that was never dispatched**. `compound_reply` then saw the CREATE's default `SUCCESS` status and built a full CREATE response over its **uninitialized `r_attrs`**, tripping the `chimera_smb_append_network_open_info` assertion (`smb_attr.h`) → `abort()`. In the parallel CI matrix this surfaced as a *timeout* (server died mid-suite, client hung).

### Fix

Defer the failure: mark the request `CHIMERA_SMB_REQUEST_FLAG_PARSE_FAILED` with its status, keep parsing the rest of the chain, and let `chimera_smb_compound_advance` complete it **in order**. The earlier CREATE now dispatches and replies normally, and each request in the compound gets its own response.

### Validation

- `smb2.compound` now runs to completion with **0 crashes on all six backends** (memfs, linux, io_uring, cairn, diskfs_io_uring, diskfs_aio); previously it aborted the server.
- The already-green smbtorture suites are unaffected and ASan-clean.
- The remaining `smb2.compound` subtest failures are conformance (related/unrelated abort-status propagation) and are tracked separately — this PR only removes the crash.