### PR TITLE
smb2: make FILE_CREATE exclusive and reject invalid CreateDisposition

### DIFF
--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -1394,9 +1394,15 @@ chimera_smb_create_issue_open(struct chimera_smb_request *request)
             case SMB2_FILE_OVERWRITE:
                 /* Open existing only; never create. */
                 break;
+            case SMB2_FILE_CREATE:
+                /* FILE_CREATE must fail if the file already exists; open it
+                 * exclusively so the backend returns EEXIST
+                 * (-> OBJECT_NAME_COLLISION) rather than opening the existing
+                 * file. */
+                flags |= CHIMERA_VFS_OPEN_CREATE | CHIMERA_VFS_OPEN_EXCLUSIVE;
+                break;
             case SMB2_FILE_SUPERSEDE:
             case SMB2_FILE_OPEN_IF:
-            case SMB2_FILE_CREATE:
             case SMB2_FILE_OVERWRITE_IF:
                 flags |= CHIMERA_VFS_OPEN_CREATE;
                 break;
@@ -1883,6 +1889,14 @@ chimera_smb_create(struct chimera_smb_request *request)
             request->create.stream_name_len = sname_len;
             memcpy(request->create.stream_name, sname, sname_len);
         }
+    }
+
+    /* Reject create dispositions outside the defined range
+     * (SUPERSEDE..OVERWRITE_IF).  MS-SMB2 returns STATUS_INVALID_PARAMETER for
+     * an undefined CreateDisposition. */
+    if (request->create.create_disposition > SMB2_FILE_OVERWRITE_IF) {
+        chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
+        return;
     }
 
     /* No persistent-handle grant by default; set by the reconnect path (cold


### PR DESCRIPTION
## Summary

- **FILE_CREATE was not exclusive.** A CREATE with disposition `FILE_CREATE` mapped to a plain `CHIMERA_VFS_OPEN_CREATE`, so creating a file that already existed silently **opened the existing file** and returned `SUCCESS` instead of `STATUS_OBJECT_NAME_COLLISION`. That is a data-integrity hazard — an exclusive create could alias/clobber a pre-existing file. (Directory `FILE_CREATE` was unaffected; it goes through `mkdir_at`, which already returns `EEXIST`.) FILE_CREATE now opens with `CHIMERA_VFS_OPEN_EXCLUSIVE`, so the backend returns `EEXIST` → collision.

- **Undefined CreateDisposition was accepted.** A `CreateDisposition` outside the defined range (`SUPERSEDE`..`OVERWRITE_IF`) was silently treated as open-existing; it now returns `STATUS_INVALID_PARAMETER` per MS-SMB2.

Fixes the collision cases exercised by `smb2.create.open` and `smb2.delete-on-close-perms` (CREATE-on-existing). Verified no regression across the enabled memfs CREATE-heavy suites (create_no_streams, sharemode, durable, timestamps, acls, read, rw). The full `smb2.create` suite is not yet enabled — other subtests still require settable change-time, AllocationSize reporting, and quota/impersonation semantics.