### PR TITLE
smb: process all compounded requests; scope FileId inheritance to related

### DIFF
--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -42,15 +42,6 @@ chimera_smb_is_error_status(unsigned int status)
            status != SMB2_STATUS_NOTIFY_ENUM_DIR;
 } /* chimera_smb_is_error_status */
 
-static inline int
-chimera_smb_status_should_abort(unsigned int status)
-{
-    return status != SMB2_STATUS_SUCCESS &&
-           status != SMB2_STATUS_MORE_PROCESSING_REQUIRED &&
-           status != SMB2_STATUS_NO_MORE_FILES &&
-           status != SMB2_STATUS_NOTIFY_ENUM_DIR;
-} /* chimera_smb_status_should_abort */
-
 static void *
 chimera_smb_server_init(
     const struct chimera_server_config *config,
@@ -573,34 +564,6 @@ chimera_smb_compound_reply(struct chimera_smb_compound *compound)
     chimera_smb_compound_free(thread, compound);
 } /* chimera_smb_compound_reply */
 
-static inline void
-chimera_smb_compound_abort(struct chimera_smb_compound *compound)
-{
-    struct chimera_smb_request *next;
-
-    if (compound->complete_requests < compound->num_requests) {
-        next = compound->requests[compound->complete_requests];
-
-        /* Propagate session/tree from prior request for related operations,
-         * even on the abort path.  Otherwise an aborted related Close (for
-         * example, after a failed Create in a Create+Close compound) will
-         * have a NULL session_handle and the signing pass will fail,
-         * causing the entire connection to be torn down. */
-        if (next->smb2_hdr.flags & SMB2_FLAGS_RELATED_OPERATIONS) {
-            if (!next->session_handle && compound->saved_session_handle) {
-                next->session_handle = compound->saved_session_handle;
-            }
-            if (!next->tree && compound->saved_tree) {
-                next->tree = compound->saved_tree;
-            }
-        }
-
-        chimera_smb_complete_request(next, SMB2_STATUS_REQUEST_ABORTED);
-    } else {
-        chimera_smb_compound_reply(compound);
-    }
-} /* chimera_smb_compound_abort */
-
 void
 chimera_smb_complete_request(
     struct chimera_smb_request *request,
@@ -626,11 +589,14 @@ chimera_smb_complete_request(
         compound->saved_tree    = request->tree;
     }
 
-    if (chimera_smb_status_should_abort(status)) {
-        chimera_smb_compound_abort(compound);
-    } else {
-        chimera_smb_compound_advance(compound);
-    }
+    /* Always advance to the next compounded request -- even after a failure.
+     * MS-SMB2 processes every request in the chain: a related request inherits
+     * the prior (possibly now-invalid) FileId/Session/Tree and fails naturally
+     * (e.g. STATUS_FILE_CLOSED), an unrelated request is independent.  Aborting
+     * the remainder with STATUS_REQUEST_ABORTED is non-conformant (no client
+     * expects it) and skipped earlier requests entirely.  Every command handler
+     * already completes gracefully when its FileId does not resolve. */
+    chimera_smb_compound_advance(compound);
 } /* chimera_smb_complete_request */
 
 static inline void

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -1448,17 +1448,21 @@ chimera_smb_open_file_resolve(
 
     chimera_smb_abort_if(!tree, "tree is NULL");
 
+    /* A UINT64_MAX FileId inherits the previous request's FileId, but only in a
+     * related compound (MS-SMB2 3.3.5.2.7.2).  For an unrelated request it is
+     * just an invalid handle and must resolve to FILE_CLOSED, not the prior
+     * request's file. */
     if (unlikely(file_id->pid == UINT64_MAX)) {
-        if (request->compound->saved_file_id.pid == UINT64_MAX) {
-            chimera_smb_error("Attempted to lookup invalid file id");
+        if (!(request->smb2_hdr.flags & SMB2_FLAGS_RELATED_OPERATIONS) ||
+            request->compound->saved_file_id.pid == UINT64_MAX) {
             return NULL;
         }
         file_id->pid = request->compound->saved_file_id.pid;
     }
 
     if (unlikely(file_id->vid == UINT64_MAX)) {
-        if (request->compound->saved_file_id.vid == UINT64_MAX) {
-            chimera_smb_error("Attempted to lookup invalid file id");
+        if (!(request->smb2_hdr.flags & SMB2_FLAGS_RELATED_OPERATIONS) ||
+            request->compound->saved_file_id.vid == UINT64_MAX) {
             return NULL;
         }
         file_id->vid = request->compound->saved_file_id.vid;
@@ -1575,17 +1579,20 @@ chimera_smb_open_file_close(
 
     chimera_smb_abort_if(!tree, "tree is NULL");
 
+    /* Only a related compound request inherits the previous request's FileId
+     * from a UINT64_MAX placeholder; for an unrelated request it is an invalid
+     * handle and must report FILE_CLOSED (MS-SMB2 3.3.5.2.7.2). */
     if (unlikely(file_id->pid == UINT64_MAX)) {
-        if (request->compound->saved_file_id.pid == UINT64_MAX) {
-            chimera_smb_error("Attempted to close invalid file id");
+        if (!(request->smb2_hdr.flags & SMB2_FLAGS_RELATED_OPERATIONS) ||
+            request->compound->saved_file_id.pid == UINT64_MAX) {
             return NULL;
         }
         file_id->pid = request->compound->saved_file_id.pid;
     }
 
     if (unlikely(file_id->vid == UINT64_MAX)) {
-        if (request->compound->saved_file_id.vid == UINT64_MAX) {
-            chimera_smb_error("Attempted to close invalid file id");
+        if (!(request->smb2_hdr.flags & SMB2_FLAGS_RELATED_OPERATIONS) ||
+            request->compound->saved_file_id.vid == UINT64_MAX) {
             return NULL;
         }
         file_id->vid = request->compound->saved_file_id.vid;


### PR DESCRIPTION
## Summary

**Layered on top of #577** (base branch `smb-compound-defer-bad-session`) — review/merge that one first.

chimera aborted the rest of a compound as soon as one request returned an error, completing the remainder with `STATUS_REQUEST_ABORTED`. That is non-conformant: per MS-SMB2 3.3.5.2.7.2 the server processes **every** request in the chain — a *related* request inherits the previous request's (possibly now-invalid) FileId/Session/Tree and fails naturally (e.g. `STATUS_FILE_CLOSED`); an *unrelated* request is independent. No SMB2 client expects `REQUEST_ABORTED`, and the cascade also skipped earlier requests entirely.

### Changes

- **`chimera_smb_complete_request` always advances** to the next compounded request instead of abort-cascading. Every command handler already completes gracefully when its FileId does not resolve, so a request that inherits an invalid handle returns `STATUS_FILE_CLOSED` rather than aborting the chain. Removes the now-unused `chimera_smb_compound_abort` / `chimera_smb_status_should_abort`.
- **FileId inheritance is scoped to related requests.** A `UINT64_MAX` FileId means "use the previous request's FileId" only when `SMB2_FLAGS_RELATED_OPERATIONS` is set; for an unrelated request it is an invalid handle and resolves to `STATUS_FILE_CLOSED` instead of wrongly reusing the prior open file.

### Validation

- `smb2.compound.related2` and `smb2.compound.unrelated1` now pass on **all six backends** (memfs, linux, io_uring, cairn, diskfs_io_uring, diskfs_aio).
- The already-green smbtorture suites (connect/read/rw/tcon/sharemode/compound_find/…) are unchanged and ASan-clean; `smb2.compound` runs with no crashes on every backend.
- Remaining `smb2.compound` subtest failures are separate feature gaps (compound IOCTL / CHANGE_NOTIFY, interim/async responses, oplock break, padding) and are out of scope here.