### PR TITLE
smb2: advance the durable-handle conformance suites (durable-open / durable-v2-open)

### DIFF
--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -927,6 +927,22 @@ chimera_smb_server_handle_smb2(
             request->session_handle = NULL;
         }
 
+        /* A session closed by a PreviousSessionId reconnect lingers, still
+         * referenced by its original connection, until that connection drops.
+         * Requests that resolve to it are answered USER_SESSION_DELETED
+         * (MS-SMB2 3.3.5.2.9).  Defer the failure exactly like the invalid-id
+         * case above: completing it inline would advance complete_requests out
+         * of order within a compound. */
+        if (unlikely(request->session_handle &&
+                     (request->session_handle->session->flags &
+                      CHIMERA_SMB_SESSION_DELETED))) {
+            request->session_handle                      = NULL;
+            request->status                              = SMB2_STATUS_USER_SESSION_DELETED;
+            request->flags                              |= CHIMERA_SMB_REQUEST_FLAG_PARSE_FAILED;
+            compound->requests[compound->num_requests++] = request;
+            goto next_compound_request;
+        }
+
         if (request->smb2_hdr.flags & SMB2_FLAGS_SIGNED) {
             uint8_t *signing_key;
 

--- a/src/server/smb/smb_durable.c
+++ b/src/server/smb/smb_durable.c
@@ -267,10 +267,15 @@ chimera_smb_durable_claim(
         *status = SMB2_STATUS_OBJECT_NAME_NOT_FOUND;
     } else if (create_guid && memcmp(entry->create_guid, create_guid, 16) != 0) {
         *status = SMB2_STATUS_OBJECT_NAME_NOT_FOUND;
-    } else if (client_guid && memcmp(entry->client_guid, client_guid, 16) != 0) {
-        /* Reconnect from a different client.  MS-SMB2 3.3.5.9.7: a ClientGuid
-         * mismatch must fail with STATUS_OBJECT_NAME_NOT_FOUND (the handle is
-         * simply not visible to this client), not ACCESS_DENIED. */
+    } else if (had_lease && client_guid &&
+               memcmp(entry->client_guid, client_guid, 16) != 0) {
+        /* Reconnect from a different client.  MS-SMB2 3.3.5.9.7 binds the
+         * ClientGuid check to leased opens only: when the surviving open holds a
+         * lease, a ClientGuid mismatch fails with STATUS_OBJECT_NAME_NOT_FOUND
+         * (the handle is not visible to this client).  An oplock-only durable
+         * handle has no such binding — it may be reconnected from a new
+         * transport with a different ClientGuid (identity is the persistent id,
+         * plus the create_guid for v2). */
         *status = SMB2_STATUS_OBJECT_NAME_NOT_FOUND;
     } else if (had_lease && !has_lease_ctx) {
         /* 3.3.5.9.7: open holds a lease but the reconnect omitted the lease
@@ -280,10 +285,15 @@ chimera_smb_durable_claim(
                memcmp(entry->open_file->lease_key, lease_key, 16) != 0) {
         /* 3.3.5.9.7: lease key in the reconnect does not match the open's. */
         *status = SMB2_STATUS_OBJECT_NAME_NOT_FOUND;
-    } else if (entry->name_len != name_len || memcmp(entry->name, name, name_len) != 0) {
-        /* Filename mismatch: with a lease this is INVALID_PARAMETER (3.3.5.9.7),
-         * otherwise the handle simply isn't found under that name. */
-        *status = had_lease ? SMB2_STATUS_INVALID_PARAMETER : SMB2_STATUS_OBJECT_NAME_NOT_FOUND;
+    } else if (had_lease && name_len > 0 &&
+               (entry->name_len != name_len ||
+                memcmp(entry->name, name, name_len) != 0)) {
+        /* A leased reconnect that names a (non-empty) file other than the one
+         * the handle was opened on is malformed (MS-SMB2 3.3.5.9.7).  An empty
+         * name -- the usual durable-reconnect form, always so for v2 -- and a
+         * non-lease (oplock) reconnect both ignore the name entirely: the
+         * handle's identity is its persistent id, plus the create_guid for v2. */
+        *status = SMB2_STATUS_INVALID_PARAMETER;
     } else if (entry->cold) {
         /* Recovered-after-restart entry: there is no live open to re-home.
          * Remove it and tell the caller to re-open the file (cold reclaim);

--- a/src/server/smb/smb_durable.c
+++ b/src/server/smb/smb_durable.c
@@ -267,15 +267,16 @@ chimera_smb_durable_claim(
         *status = SMB2_STATUS_OBJECT_NAME_NOT_FOUND;
     } else if (create_guid && memcmp(entry->create_guid, create_guid, 16) != 0) {
         *status = SMB2_STATUS_OBJECT_NAME_NOT_FOUND;
-    } else if (had_lease && client_guid &&
+    } else if ((had_lease || entry->persistent) && client_guid &&
                memcmp(entry->client_guid, client_guid, 16) != 0) {
         /* Reconnect from a different client.  MS-SMB2 3.3.5.9.7 binds the
-         * ClientGuid check to leased opens only: when the surviving open holds a
+         * ClientGuid check to leased opens: when the surviving open holds a
          * lease, a ClientGuid mismatch fails with STATUS_OBJECT_NAME_NOT_FOUND
-         * (the handle is not visible to this client).  An oplock-only durable
+         * (the handle is not visible to this client).  An oplock-only *durable*
          * handle has no such binding — it may be reconnected from a new
          * transport with a different ClientGuid (identity is the persistent id,
-         * plus the create_guid for v2). */
+         * plus the create_guid for v2).  Persistent handles keep the check
+         * regardless (their reclaim is governed by create_guid + owner). */
         *status = SMB2_STATUS_OBJECT_NAME_NOT_FOUND;
     } else if (had_lease && !has_lease_ctx) {
         /* 3.3.5.9.7: open holds a lease but the reconnect omitted the lease

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -312,10 +312,10 @@ struct chimera_smb_request {
              * CREATED Create Action in the reply. */
             uint8_t                         r_created;
             /* Set by the durable-reconnect path: this CREATE is reclaiming a
-             * surviving open, not opening a new one.  The access was granted at
-             * the original open, and MS-SMB2 has the reconnect ignore the
-             * DesiredAccess / CreateOptions / etc. fields entirely, so the
-             * getattr-reply callback must not re-run the ACL access check. */
+            * surviving open, not opening a new one.  The access was granted at
+            * the original open, and MS-SMB2 has the reconnect ignore the
+            * DesiredAccess / CreateOptions / etc. fields entirely, so the
+            * getattr-reply callback must not re-run the ACL access check. */
             uint8_t                         reconnect;
             /* CREATE contexts the client sent (CHIMERA_SMB_CREATE_CTX_* bits).
              * Phase-0 stubs set the bit and capture a minimum set of fields needed

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -1152,6 +1152,26 @@ chimera_smb_session_release(
     }
 } /* chimera_smb_session_free */
 
+/* MS-SMB2 3.3.4.4 open-preservation rule: a durable open holding byte-range
+ * locks survives a disconnect only if it also holds a batch oplock or a
+ * WRITE-caching lease -- otherwise the locks cannot be safely maintained across
+ * the gap, so the open is closed rather than parked (a later reconnect then gets
+ * OBJECT_NAME_NOT_FOUND).  Every other durable open is preservable. */
+static inline bool
+chimera_smb_durable_open_preservable(const struct chimera_smb_open_file *open_file)
+{
+    if (open_file->lock_entries) {
+        bool write_caching =
+            (open_file->oplock_level == SMB2_OPLOCK_LEVEL_BATCH) ||
+            (open_file->lease_state & SMB2_LEASE_WRITE_CACHING);
+
+        if (!write_caching) {
+            return false;
+        }
+    }
+    return true;
+} /* chimera_smb_durable_open_preservable */
+
 /* Park every durable/persistent open held by `session` for reconnect, leaving
  * the rest of the session in place.  Used when a PreviousSessionId reconnect
  * closes this session out from under its still-live connection (MS-SMB2
@@ -1183,7 +1203,8 @@ chimera_smb_session_park_durables(
             HASH_ITER(hh, tree->open_files[b], open_file, tmp)
             {
                 if (!open_file->durable_flags ||
-                    (open_file->flags & CHIMERA_SMB_OPEN_FILE_PARKED)) {
+                    (open_file->flags & CHIMERA_SMB_OPEN_FILE_PARKED) ||
+                    !chimera_smb_durable_open_preservable(open_file)) {
                     continue;
                 }
                 HASH_DELETE(hh, tree->open_files[b], open_file);
@@ -1466,7 +1487,8 @@ chimera_smb_tree_free(
              * the normal close path, which also forgets the registry entry --
              * a later durable reconnect with the stale FileId then correctly
              * returns OBJECT_NAME_NOT_FOUND. */
-            if (open_file->durable_flags && preserve_durable) {
+            if (open_file->durable_flags && preserve_durable &&
+                chimera_smb_durable_open_preservable(open_file)) {
                 open_file->flags      |= CHIMERA_SMB_OPEN_FILE_PARKED;
                 open_file->create_conn = NULL;
                 /* park acquires the registry lock under this bucket lock —

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -311,6 +311,12 @@ struct chimera_smb_request {
              * the file/dir (vs opened an existing one) — drives the OPENED vs
              * CREATED Create Action in the reply. */
             uint8_t                         r_created;
+            /* Set by the durable-reconnect path: this CREATE is reclaiming a
+             * surviving open, not opening a new one.  The access was granted at
+             * the original open, and MS-SMB2 has the reconnect ignore the
+             * DesiredAccess / CreateOptions / etc. fields entirely, so the
+             * getattr-reply callback must not re-run the ACL access check. */
+            uint8_t                         reconnect;
             /* CREATE contexts the client sent (CHIMERA_SMB_CREATE_CTX_* bits).
              * Phase-0 stubs set the bit and capture a minimum set of fields needed
              * by the response emit; Phase 1/3 will populate the rest. */
@@ -1145,6 +1151,100 @@ chimera_smb_session_release(
         pthread_mutex_unlock(&shared->sessions_lock);
     }
 } /* chimera_smb_session_free */
+
+/* Park every durable/persistent open held by `session` for reconnect, leaving
+ * the rest of the session in place.  Used when a PreviousSessionId reconnect
+ * closes this session out from under its still-live connection (MS-SMB2
+ * 3.3.5.5.3): the durable handles must be parked immediately so the new
+ * connection can reclaim them, while the session's remaining (non-durable) opens
+ * and trees are torn down normally when the old connection finally drops -- on
+ * its own thread, avoiding a cross-thread VFS-handle release.  Parking is pure
+ * shared-state manipulation under the bucket and registry locks, so it is safe
+ * to run from the new connection's thread. */
+static inline void
+chimera_smb_session_park_durables(
+    struct chimera_server_smb_shared *shared,
+    struct chimera_smb_session       *session)
+{
+    int i, b;
+
+    pthread_mutex_lock(&session->lock);
+
+    for (i = 0; i < session->max_trees; i++) {
+        struct chimera_smb_tree      *tree = session->trees[i];
+        struct chimera_smb_open_file *open_file, *tmp;
+
+        if (!tree) {
+            continue;
+        }
+
+        for (b = 0; b < CHIMERA_SMB_OPEN_FILE_BUCKETS; b++) {
+            pthread_mutex_lock(&tree->open_files_lock[b]);
+            HASH_ITER(hh, tree->open_files[b], open_file, tmp)
+            {
+                if (!open_file->durable_flags ||
+                    (open_file->flags & CHIMERA_SMB_OPEN_FILE_PARKED)) {
+                    continue;
+                }
+                HASH_DELETE(hh, tree->open_files[b], open_file);
+                open_file->flags      |= CHIMERA_SMB_OPEN_FILE_PARKED;
+                open_file->create_conn = NULL;
+                chimera_smb_durable_park(shared, open_file);
+            }
+            pthread_mutex_unlock(&tree->open_files_lock[b]);
+        }
+    }
+
+    pthread_mutex_unlock(&session->lock);
+} /* chimera_smb_session_park_durables */
+
+/* MS-SMB2 3.3.5.5.3: a SESSION_SETUP carrying a non-zero PreviousSessionId asks
+ * the server to close that earlier session of the same user once the new one is
+ * established (a client reconnecting on a fresh transport, e.g. for durable-
+ * handle reclaim).  Mark the prior session deleted and unlink it from the global
+ * table without freeing it: its original connection still holds a reference, so
+ * requests still arriving there get STATUS_USER_SESSION_DELETED.  Its durable
+ * handles are parked immediately so the new connection can reclaim them.  Never
+ * invalidate the new session itself, and only act when the requesting user
+ * matches the prior session's owner. */
+static inline void
+chimera_smb_session_invalidate_previous(
+    struct chimera_server_smb_thread *thread,
+    struct chimera_server_smb_shared *shared,
+    uint64_t                          prev_session_id,
+    struct chimera_smb_session       *new_session)
+{
+    struct chimera_smb_session *prev;
+
+    if (prev_session_id == 0 || prev_session_id == new_session->session_id) {
+        return;
+    }
+
+    pthread_mutex_lock(&shared->sessions_lock);
+
+    HASH_FIND(hh, shared->sessions, &prev_session_id, sizeof(uint64_t), prev);
+
+    if (prev && prev != new_session &&
+        (prev->flags & CHIMERA_SMB_SESSION_AUTHORIZED) &&
+        prev->cred.uid == new_session->cred.uid) {
+        /* Clear AUTHORIZED and unlink here so the later refcnt-driven
+         * chimera_smb_session_release() does not HASH_DEL a second time.  Hold a
+         * reference across the park so a concurrent release cannot free it. */
+        prev->flags |= CHIMERA_SMB_SESSION_DELETED;
+        prev->flags &= ~CHIMERA_SMB_SESSION_AUTHORIZED;
+        HASH_DEL(shared->sessions, prev);
+        prev->refcnt++;
+    } else {
+        prev = NULL;
+    }
+
+    pthread_mutex_unlock(&shared->sessions_lock);
+
+    if (prev) {
+        chimera_smb_session_park_durables(shared, prev);
+        chimera_smb_session_release(thread, shared, prev, true);
+    }
+} /* chimera_smb_session_invalidate_previous */
 
 
 static inline struct chimera_smb_session_handle *

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -1220,19 +1220,25 @@ chimera_smb_create_open_getattr_callback(
         request->create.r_open_file->flags |= CHIMERA_SMB_OPEN_FILE_FLAG_DIRECTORY;
     }
 
-    uint32_t access_status = chimera_smb_create_check_access(request, attr);
+    /* A durable reconnect reclaims an already-open handle: access was granted at
+     * the original open and the reconnect's DesiredAccess field is ignored
+     * (MS-SMB2 3.3.5.9.7/.12), so do not re-run the ACL check or recompute the
+     * granted/maximal access — the surviving open carries them already. */
+    if (!request->create.reconnect) {
+        uint32_t access_status = chimera_smb_create_check_access(request, attr);
 
-    if (access_status != SMB2_STATUS_SUCCESS) {
-        chimera_smb_open_file_release(request, request->create.r_open_file);
-        chimera_smb_complete_request(request, access_status);
-        return;
+        if (access_status != SMB2_STATUS_SUCCESS) {
+            chimera_smb_open_file_release(request, request->create.r_open_file);
+            chimera_smb_complete_request(request, access_status);
+            return;
+        }
+
+        request->create.r_open_file->granted_access =
+            chimera_smb_create_granted_access(request, attr);
+        request->create.r_open_file->maximal_access =
+            chimera_vfs_access_check(attr, &request->session_handle->session->cred,
+                                     CHIMERA_ACE_MASK_ALL);
     }
-
-    request->create.r_open_file->granted_access =
-        chimera_smb_create_granted_access(request, attr);
-    request->create.r_open_file->maximal_access =
-        chimera_vfs_access_check(attr, &request->session_handle->session->cred,
-                                 CHIMERA_ACE_MASK_ALL);
 
     chimera_smb_open_file_release(request, request->create.r_open_file);
 
@@ -1783,6 +1789,7 @@ chimera_smb_durable_reconnect(struct chimera_smb_request *request)
 
     request->create.r_open_file        = open_file;
     request->create.create_disposition = SMB2_FILE_OPEN; /* reply emits OPENED */
+    request->create.reconnect          = 1; /* skip ACL re-check on the reply path */
     request->compound->saved_file_id   = open_file->file_id;
 
     /* Refresh the network-open-info from the surviving handle, then reply.
@@ -1940,10 +1947,21 @@ chimera_smb_create(struct chimera_smb_request *request)
         }
     }
 
+    /* A durable-handle reconnect (DH2C/DHnC) reclaims an already-open handle and
+     * ignores the create fields entirely -- CreateDisposition, file name, access
+     * and the rest are not interpreted (MS-SMB2 3.3.5.9.7/.12) -- so the field
+     * validations below must not run for it; it is dispatched straight to
+     * chimera_smb_durable_reconnect. */
+    bool is_durable_reconnect =
+        request->compound->thread->shared->config.persistent_handles &&
+        (request->create.ctx_present_mask &
+         (CHIMERA_SMB_CREATE_CTX_DH2C | CHIMERA_SMB_CREATE_CTX_DHNC)) != 0;
+
     /* Reject create dispositions outside the defined range
      * (SUPERSEDE..OVERWRITE_IF).  MS-SMB2 returns STATUS_INVALID_PARAMETER for
      * an undefined CreateDisposition. */
-    if (request->create.create_disposition > SMB2_FILE_OVERWRITE_IF) {
+    if (!is_durable_reconnect &&
+        request->create.create_disposition > SMB2_FILE_OVERWRITE_IF) {
         chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
         return;
     }
@@ -1954,10 +1972,11 @@ chimera_smb_create(struct chimera_smb_request *request)
      * passthrough backends).  MS-SMB2 returns STATUS_OBJECT_PATH_SYNTAX_BAD.
      * Completed here (not in parse) so the client gets a response rather than a
      * connection drop. */
-    if ((request->create.name_len == 2 &&
-         request->create.name[0] == '.' && request->create.name[1] == '.') ||
-        chimera_smb_path_has_dotdot(request->create.parent_path,
-                                    request->create.parent_path_len)) {
+    if (!is_durable_reconnect &&
+        ((request->create.name_len == 2 &&
+          request->create.name[0] == '.' && request->create.name[1] == '.') ||
+         chimera_smb_path_has_dotdot(request->create.parent_path,
+                                     request->create.parent_path_len))) {
         chimera_smb_complete_request(request, SMB2_STATUS_OBJECT_PATH_SYNTAX_BAD);
         return;
     }
@@ -1965,6 +1984,7 @@ chimera_smb_create(struct chimera_smb_request *request)
     /* No persistent-handle grant by default; set by the reconnect path (cold
      * reclaim) or chimera_smb_create_persist_prepare for a fresh grant. */
     request->create.persist_pid = 0;
+    request->create.reconnect   = 0;
 
     if (request->tree->type == CHIMERA_SMB_TREE_TYPE_PIPE) {
 
@@ -1997,6 +2017,14 @@ chimera_smb_create(struct chimera_smb_request *request)
 
     } else {
 
+        /* Durable-handle reconnect short-circuits the normal open path: the
+         * file is already open (parked); we just reclaim and re-home it.  It
+         * ignores all create fields, so it runs before the DOC access check. */
+        if (is_durable_reconnect) {
+            chimera_smb_durable_reconnect(request);
+            return;
+        }
+
         /* MS-SMB2 3.3.5.9: if FILE_DELETE_ON_CLOSE is set in CreateOptions,
          * the create must also request DELETE access (DELETE, GENERIC_ALL, or
          * MAXIMUM_ALLOWED, which resolves to a superset). Otherwise fail with
@@ -2005,15 +2033,6 @@ chimera_smb_create(struct chimera_smb_request *request)
             !(request->create.desired_access &
               (SMB2_DELETE | SMB2_GENERIC_ALL | SMB2_MAXIMUM_ALLOWED))) {
             chimera_smb_complete_request(request, SMB2_STATUS_ACCESS_DENIED);
-            return;
-        }
-
-        /* Durable-handle reconnect short-circuits the normal open path: the
-         * file is already open (parked); we just reclaim and re-home it. */
-        if (request->compound->thread->shared->config.persistent_handles &&
-            (request->create.ctx_present_mask &
-             (CHIMERA_SMB_CREATE_CTX_DH2C | CHIMERA_SMB_CREATE_CTX_DHNC))) {
-            chimera_smb_durable_reconnect(request);
             return;
         }
 

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -386,7 +386,13 @@ chimera_smb_create_gen_open_file(
         bool backend_copy_safe =
             (oh->vfs_module->capabilities & CHIMERA_VFS_CAP_COPY_RANGE) != 0;
 
-        if (req_vfs != 0 && caching_touches_data && backend_copy_safe) {
+        /* An explicitly requested SMB2 lease (RqLs) is acquired even for an
+         * attribute-only ("stat") open: a handle/read-caching lease is about the
+         * handle, not data access, and such an open is still eligible for a
+         * durable handle (MS-SMB2).  The caching_touches_data gate only governs
+         * the implicit legacy-oplock path, where an attribute probe must not
+         * acquire an oplock. */
+        if (req_vfs != 0 && (caching_touches_data || via_rqls) && backend_copy_safe) {
             file_state = chimera_vfs_state_get(vfs_state,
                                                oh->fh, oh->fh_len,
                                                oh->fh_hash, true);
@@ -1731,8 +1737,19 @@ chimera_smb_durable_reconnect(struct chimera_smb_request *request)
     bool                              cold = false;
     int                               bucket;
 
-    /* MS-SMB2 3.3.5.9.7: a v1 durable reconnect (DHnC) that also carries a v2
-     * durable request/reconnect context is malformed. */
+    /* Reject malformed reconnect-context combinations:
+     *   - DH2C (3.3.5.9.12) must stand alone: combining it with ANY other
+     *     durable context (DHnQ, DH2Q, or DHnC) is INVALID_PARAMETER.
+     *   - DHnC (3.3.5.9.7) may carry a v1 durable *request* (DHnQ) -- the request
+     *     is simply ignored -- but combining it with a v2 context (DH2Q or DH2C)
+     *     is INVALID_PARAMETER.
+     * So a lone DHnC, a lone DH2C, or DHnC+DHnQ are all valid reconnects. */
+    if ((ctx & CHIMERA_SMB_CREATE_CTX_DH2C) &&
+        (ctx & (CHIMERA_SMB_CREATE_CTX_DHNQ | CHIMERA_SMB_CREATE_CTX_DH2Q |
+                CHIMERA_SMB_CREATE_CTX_DHNC))) {
+        chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
+        return;
+    }
     if ((ctx & CHIMERA_SMB_CREATE_CTX_DHNC) &&
         (ctx & (CHIMERA_SMB_CREATE_CTX_DH2Q | CHIMERA_SMB_CREATE_CTX_DH2C))) {
         chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);

--- a/src/server/smb/smb_proc_lock.c
+++ b/src/server/smb/smb_proc_lock.c
@@ -285,6 +285,11 @@ chimera_smb_lock(struct chimera_smb_request *request)
      * independently, matching Windows handle-based lock semantics. */
     entry->lease.owner.owner_lo = open_file->file_id.pid;
     entry->lease.owner.owner_hi = open_file->file_id.vid;
+    /* Point at the owning open so the range-vs-caching conflict check can tell
+     * that a byte-range lock and the same open's caching lease (whose owner
+     * identity is the lease key, not the file id) belong together and must not
+     * break each other. */
+    entry->lease.owner.cb_private = open_file;
 
     request->lock.entry = entry;
 

--- a/src/server/smb/smb_proc_query_info.c
+++ b/src/server/smb/smb_proc_query_info.c
@@ -284,6 +284,10 @@ chimera_smb_query_info(struct chimera_smb_request *request)
                     /* GrantedAccess of this handle; no backend attrs needed. */
                     request->query_info.output_length = SMB2_FILE_ACCESS_INFO_SIZE;
                     break;
+                case SMB2_FILE_POSITION_INFO:
+                    /* CurrentByteOffset is per-handle state; no backend attrs. */
+                    request->query_info.output_length = SMB2_FILE_POSITION_INFO_SIZE;
+                    break;
                 case SMB2_FILE_COMPRESSION_INFO:
                     request->query_info.output_length = SMB2_FILE_COMPRESSION_INFO_SIZE;
                     getattr_mask                      = CHIMERA_VFS_ATTR_MASK_STAT;
@@ -407,6 +411,11 @@ chimera_smb_query_info_reply(
                     evpl_iovec_cursor_append_uint32(
                         reply_cursor,
                         request->query_info.open_file->granted_access);
+                    break;
+                case SMB2_FILE_POSITION_INFO:
+                    evpl_iovec_cursor_append_uint64(
+                        reply_cursor,
+                        request->query_info.open_file->position);
                     break;
                 case SMB2_FILE_ALL_INFO:
                     chimera_smb_append_all_info(reply_cursor, request->query_info.open_file, &request->query_info.

--- a/src/server/smb/smb_proc_session_setup.c
+++ b/src/server/smb/smb_proc_session_setup.c
@@ -269,6 +269,14 @@ chimera_smb_session_setup(struct chimera_smb_request *request)
             chimera_smb_session_authorize(shared, session);
         }
 
+        /* If the client named a previous session (reconnect on a fresh
+         * transport), close it now that this one is established. */
+        if (request->session_setup.prev_session_id) {
+            chimera_smb_session_invalidate_previous(thread, shared,
+                                                    request->session_setup.prev_session_id,
+                                                    session);
+        }
+
         chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
     } else if (rc == 1) {
         // Continue needed

--- a/src/server/smb/smb_session.h
+++ b/src/server/smb/smb_session.h
@@ -180,6 +180,11 @@ struct chimera_smb_tree {
 };
 
 #define CHIMERA_SMB_SESSION_AUTHORIZED 0x1
+/* The session was closed out from under its connection by a SESSION_SETUP that
+ * named it in PreviousSessionId (MS-SMB2 3.3.5.5.3).  It is unlinked from the
+ * global table but kept alive while its original connection still references it;
+ * requests arriving on that connection are answered STATUS_USER_SESSION_DELETED. */
+#define CHIMERA_SMB_SESSION_DELETED    0x2
 
 struct chimera_smb_session {
     uint64_t                    session_id;

--- a/src/server/smb/tests/phase0_contexts_test.c
+++ b/src/server/smb/tests/phase0_contexts_test.c
@@ -943,6 +943,7 @@ test_durable_register_park_claim(void)
     uint8_t                           guid[16];
     uint8_t                           cguid[16];
     uint8_t                           other[16];
+    uint8_t                           lkey[16];
     uint32_t                          status;
     bool                              cold;
     int                               i;
@@ -954,6 +955,7 @@ test_durable_register_park_claim(void)
         guid[i]  = (uint8_t) (0x10 + i);
         cguid[i] = (uint8_t) (0x20 + i);
         other[i] = (uint8_t) (0x90 + i);
+        lkey[i]  = (uint8_t) (0x30 + i);
     }
     of.file_id.pid        = 0xABCDEF;
     of.durable_flags      = CHIMERA_SMB_DURABLE_V2;
@@ -982,21 +984,37 @@ test_durable_register_park_claim(void)
         TEST_PASS("durable: create-guid mismatch rejected");
     }
 
-    /* Wrong client GUID is ACCESS_DENIED. */
+    /* An oplock-only (no-lease) durable handle is not bound to the ClientGuid:
+     * a reconnect from a different ClientGuid reclaims it (MS-SMB2 3.3.5.9.7
+     * binds the GUID check to leased opens).  of.oplock_level is 0 here. */
     claimed = chimera_smb_durable_claim(shared, 0xABCDEF, guid, other, "foo.txt", 7, false, NULL, &cold, &status);
-    if (claimed != NULL || status != SMB2_STATUS_OBJECT_NAME_NOT_FOUND) {
-        TEST_FAIL("durable: client-guid mismatch -> OBJECT_NAME_NOT_FOUND");
+    if (claimed == &of && status == SMB2_STATUS_SUCCESS) {
+        TEST_PASS("durable: oplock reconnect ignores client-guid");
     } else {
-        TEST_PASS("durable: client-guid mismatch -> OBJECT_NAME_NOT_FOUND");
+        TEST_FAIL("durable: oplock reconnect ignores client-guid");
     }
 
-    /* Matching reconnect succeeds and returns the surviving open. */
-    claimed = chimera_smb_durable_claim(shared, 0xABCDEF, guid, cguid, "foo.txt", 7, false, NULL, &cold, &status);
+    /* The reclaim above made the handle live again; re-park it. */
+    chimera_smb_durable_park(shared, &of);
+
+    /* A *leased* handle IS bound to the ClientGuid: a mismatch is rejected. */
+    of.oplock_level = SMB2_OPLOCK_LEVEL_LEASE;
+    memcpy(of.lease_key, lkey, 16);
+    claimed = chimera_smb_durable_claim(shared, 0xABCDEF, guid, other, "foo.txt", 7, true, lkey, &cold, &status);
+    if (claimed != NULL || status != SMB2_STATUS_OBJECT_NAME_NOT_FOUND) {
+        TEST_FAIL("durable: leased reconnect rejects client-guid mismatch");
+    } else {
+        TEST_PASS("durable: leased reconnect rejects client-guid mismatch");
+    }
+
+    /* Matching reconnect (correct ClientGuid + lease key) reclaims the open. */
+    claimed = chimera_smb_durable_claim(shared, 0xABCDEF, guid, cguid, "foo.txt", 7, true, lkey, &cold, &status);
     if (claimed == &of && status == SMB2_STATUS_SUCCESS) {
         TEST_PASS("durable: matching reconnect reclaims the open");
     } else {
         TEST_FAIL("durable: matching reconnect reclaims the open");
     }
+    of.oplock_level = 0;
 
     /* A second reconnect must fail — the handle is now live again. */
     claimed = chimera_smb_durable_claim(shared, 0xABCDEF, guid, cguid, "foo.txt", 7, false, NULL, &cold, &status);

--- a/src/vfs/vfs_state.c
+++ b/src/vfs/vfs_state.c
@@ -455,6 +455,15 @@ chimera_vfs_state_would_conflict(
                 if (chimera_vfs_lease_owner_equal(&cur->owner, &probe->owner)) {
                     continue;
                 }
+                /* A byte-range lock and a caching lease held by the SAME open do
+                 * not break each other: an SMB open's caching lease is keyed by
+                 * its lease key while its range locks are keyed by the file id,
+                 * so owner_equal does not catch them, but cb_private points at
+                 * the common owning open on both. */
+                if (probe->owner.cb_private &&
+                    cur->owner.cb_private == probe->owner.cb_private) {
+                    continue;
+                }
                 /* A read range lock conflicts with a W cache on another
                  * client (their writes may be cached); a write range lock
                  * conflicts with any R/W cache on another client. */


### PR DESCRIPTION
## Summary

Fixes a cluster of SMB3 durable-handle bugs surfaced by the Samba `smb2.durable-open` and `smb2.durable-v2-open` smbtorture suites. On memfs these go from **12/25 → 22/25** (durable-open) and **13/33 → 21/33** (durable-v2-open), with no regressions to the currently-enabled smbtorture suites (read, rw, sharemode, check-sharemode, tcon, durable-open-disconnect, durable-v2-delay on memfs + linux) or the `phase0_contexts_test` unit test.

### What's fixed

- **PreviousSessionId session reconnect (MS-SMB2 3.3.5.5.3).** A `SESSION_SETUP` carrying a non-zero `PreviousSessionId` now closes the prior session of the same user: it is marked deleted and unlinked from the global table (so requests still arriving on its original connection get `STATUS_USER_SESSION_DELETED`), and its durable handles are parked immediately so the new connection can reclaim them. Parking is pure shared-state, so it is safe to run from the new connection's thread; the rest of the old session is torn down normally when its connection drops. *(reopen1a, reopen1a-lease)*

- **Lease-gated ClientGuid binding (3.3.5.9.7).** The durable-reconnect ClientGuid check now applies only when the surviving open held a lease (or is persistent). An oplock-only durable handle reconnects from any ClientGuid; leased and persistent handles keep the binding. *(reopen1a, reopen2)*

- **Reconnect is a pure reclaim.** A durable reconnect no longer re-runs the ACL access check or matches the filename for non-lease / empty-name reconnects (the reconnect's `DesiredAccess`/`CreateOptions` are ignored per spec); a leased reconnect naming a different non-empty file returns `INVALID_PARAMETER`. *(reopen2, reopen2-lease, reopen2-lease-v2)*

- **Byte-range locks + durable handles.** A lock and the same open's caching lease no longer break each other (they have distinct owner identities — file id vs lease key — now reconciled via the owning open), which previously self-broke an RWH lease and dropped the connection. Durable preservation now follows MS-SMB2 3.3.4.4: an open holding byte-range locks survives a disconnect only with a batch oplock or WRITE-caching lease. *(lock-oplock, lock-lease, lock-noW-lease)*

- **Malformed reconnect-context validation (3.3.5.9.12).** Reject mixing `DH2C` with any other durable context, and `DHnC` with a v2 context (a `DHnC`+`DHnQ` pair stays valid, request ignored). *(create-blob)*

- **Leased stat-open durability + FILE_POSITION_INFORMATION.** An explicitly requested SMB2 lease is acquired even on an attribute-only open (so a leased stat open is durable-eligible), and `GETINFO FilePositionInformation` is implemented. *(stat-open, file-position)*

### Not yet addressed (left disabled, follow-ups)

The two suites are **not** added to the smbtorture allowlist because the remaining subtests need larger, riskier work:

- **Lease arbitration + keep/purge of disconnected durables** (`two-different-lease`, `nonstat-and-lease`, `statRH-and-lease`, the `keep-disconnected-*` / `purge-disconnected-*` family, `delete_on_close1`). These require a holistic rework: RH/handle caching must be shareable (not exclusive), WRITE caching capped to the sole opener, metadata-only opens tracked, the conflicting-open purge ordered *before* the VFS open, and async break-during-create. A scoped attempt at this regressed the oplock break/purge path and was reverted, consistent with it being a single interdependent change rather than incremental fixes.
- **`durable-v2-setinfo`**: a handle's own `SETATTR` (EndOfFile) recalls its own lease via the VFS-core metadata-recall path (shared with NFSv4); exempting the operating open needs a change to that shared layer.
- **`alloc-size` / `read-only`**: initial-allocation reporting and READONLY-at-create are memfs attribute-feature gaps, independent of durable handles.
- **`app-instance`**: AppInstanceId takeover is unimplemented.