### PR TITLE
smb2: close connection on short frame instead of aborting the server

### DIFF
--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -837,6 +837,24 @@ chimera_smb_server_handle_smb2(
 
     while (left) {
 
+        /* A well-formed SMB2 message always begins with a 64-byte header
+        * followed by at least the 2-byte StructureSize.  A frame too short
+        * to contain that is malformed -- e.g. the 5-byte Samba "exit"+code
+        * "suicide" packet that several torture tests (oplock.levelII502,
+        * etc.) send to make a forked smbd drop the connection.  chimera is
+        * threaded, so blindly copying the header out of a short buffer trips
+        * evpl_iovec_cursor_copy's abort() and takes down the whole server.
+        * Recycle the compound and close just this connection instead. */
+        if (unlikely(left < (int) (sizeof(request->smb2_hdr) +
+                                   sizeof(request->request_struct_size)))) {
+            chimera_smb_error(
+                "Received SMB2 frame too short for a header (%d bytes); "
+                "closing connection", left);
+            chimera_smb_compound_free(thread, compound);
+            evpl_close(evpl, conn->bind);
+            return;
+        }
+
         evpl_iovec_cursor_reset_consumed(request_cursor);
 
         request = chimera_smb_request_alloc(thread);


### PR DESCRIPTION
## Problem

`chimera_smb_server_handle_smb2()` unconditionally copies a 64-byte SMB2 header out of every inbound frame. A frame shorter than that underruns the receive buffer and trips `evpl_iovec_cursor_copy()`'s `abort()`, taking down the **entire multi-threaded server**.

This is a remote, unauthenticated denial of service: any peer can crash the server (and every other connection it serves) with a single sub-64-byte frame.

## How it shows up

It's hit in practice by the Samba `smbtorture` suite. The `smbXcli_conn_samba_suicide()` helper — used by `smb2.oplock.levelII502` and friends — sends a 5-byte `"exit"`+exitcode packet to make the server drop that connection. Samba's fork-per-connection model exits just that child process; chimera is threaded, so the `abort()` killed the whole process. In the `smb2.oplock` ctest this surfaced as a mid-suite `SIGABRT` (and, depending on timing, a CI timeout/hang on some backends).

Backtrace:

```
abort ()
evpl_iovec_cursor_copy (... length=64) at common/evpl_iovec_cursor.h:102
chimera_smb_server_handle_smb2 (... length=5) at server/smb/smb.c:894
chimera_smb_server_handle_tcp (... length=9) at server/smb/smb.c:1454
```

## Fix

Guard the dispatch loop: a valid SMB2 message is at least a 64-byte header plus the 2-byte `StructureSize`, so treat anything shorter as malformed — recycle the compound and close just that one connection instead of reading past the buffer.

This also gives the suicide packet its intended effect: the targeted connection's leases/oplocks are released, which lets the affected oplock subtests proceed past the suicide step (they then fail later on the separate, pre-existing exclusive/batch-oplock-grant gap, which this PR does not address).

## Verification

- `smb2.oplock.levelII502` (memfs): no longer aborts; server stays up and the connection closes gracefully.
- Full `smb2.oplock` run (memfs): 0 aborts, completes in ~57s (was crashing); remaining failures are the unrelated oplock-grant gap.
- No regression on enabled suites: `smb2.connect`, `smb2.check-sharemode`, `smb2.sharemode` still pass.