### PR TITLE
smb2: compound request validation (session/FileId inheritance, unknown opcodes)

### DIFF
--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -42,15 +42,6 @@ chimera_smb_is_error_status(unsigned int status)
            status != SMB2_STATUS_NOTIFY_ENUM_DIR;
 } /* chimera_smb_is_error_status */
 
-static inline int
-chimera_smb_status_should_abort(unsigned int status)
-{
-    return status != SMB2_STATUS_SUCCESS &&
-           status != SMB2_STATUS_MORE_PROCESSING_REQUIRED &&
-           status != SMB2_STATUS_NO_MORE_FILES &&
-           status != SMB2_STATUS_NOTIFY_ENUM_DIR;
-} /* chimera_smb_status_should_abort */
-
 static void *
 chimera_smb_server_init(
     const struct chimera_server_config *config,
@@ -573,34 +564,6 @@ chimera_smb_compound_reply(struct chimera_smb_compound *compound)
     chimera_smb_compound_free(thread, compound);
 } /* chimera_smb_compound_reply */
 
-static inline void
-chimera_smb_compound_abort(struct chimera_smb_compound *compound)
-{
-    struct chimera_smb_request *next;
-
-    if (compound->complete_requests < compound->num_requests) {
-        next = compound->requests[compound->complete_requests];
-
-        /* Propagate session/tree from prior request for related operations,
-         * even on the abort path.  Otherwise an aborted related Close (for
-         * example, after a failed Create in a Create+Close compound) will
-         * have a NULL session_handle and the signing pass will fail,
-         * causing the entire connection to be torn down. */
-        if (next->smb2_hdr.flags & SMB2_FLAGS_RELATED_OPERATIONS) {
-            if (!next->session_handle && compound->saved_session_handle) {
-                next->session_handle = compound->saved_session_handle;
-            }
-            if (!next->tree && compound->saved_tree) {
-                next->tree = compound->saved_tree;
-            }
-        }
-
-        chimera_smb_complete_request(next, SMB2_STATUS_REQUEST_ABORTED);
-    } else {
-        chimera_smb_compound_reply(compound);
-    }
-} /* chimera_smb_compound_abort */
-
 void
 chimera_smb_complete_request(
     struct chimera_smb_request *request,
@@ -626,11 +589,14 @@ chimera_smb_complete_request(
         compound->saved_tree    = request->tree;
     }
 
-    if (chimera_smb_status_should_abort(status)) {
-        chimera_smb_compound_abort(compound);
-    } else {
-        chimera_smb_compound_advance(compound);
-    }
+    /* Always advance to the next compounded request -- even after a failure.
+     * MS-SMB2 processes every request in the chain: a related request inherits
+     * the prior (possibly now-invalid) FileId/Session/Tree and fails naturally
+     * (e.g. STATUS_FILE_CLOSED), an unrelated request is independent.  Aborting
+     * the remainder with STATUS_REQUEST_ABORTED is non-conformant (no client
+     * expects it) and skipped earlier requests entirely.  Every command handler
+     * already completes gracefully when its FileId does not resolve. */
+    chimera_smb_compound_advance(compound);
 } /* chimera_smb_complete_request */
 
 static inline void
@@ -649,14 +615,38 @@ chimera_smb_compound_advance(struct chimera_smb_compound *compound)
 
     request = compound->requests[compound->complete_requests];
 
-    /* Propagate session/tree from previous request for compound related operations */
     if (request->smb2_hdr.flags & SMB2_FLAGS_RELATED_OPERATIONS) {
+        /* A related request inherits the session and tree from the preceding
+         * request in the chain (MS-SMB2 3.3.5.2.7.2). */
         if (compound->saved_session_handle) {
             request->session_handle = compound->saved_session_handle;
         }
         if (compound->saved_tree) {
             request->tree = compound->saved_tree;
         }
+
+        /* If the preceding request established no session -- because it failed,
+         * or because the chain illegally opened with a related request -- the
+         * inherited context is invalid.  Windows/Samba answer this with
+         * STATUS_INVALID_PARAMETER (the chained-request session check in
+         * source3/smbd/smb2_server.c), not NETWORK_NAME_DELETED. */
+        if (unlikely(!request->session_handle)) {
+            chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
+            return;
+        }
+    } else {
+        /* An unrelated request breaks the related chain: clear the saved
+         * context so a following related request cannot inherit stale session,
+         * tree, or FileId state from before this request.  This mirrors Samba
+         * resetting last_session_id and compat_chain_fsp on every non-chained
+         * request; it is what makes an unrelated request that fails to resolve
+         * its session leave a subsequent related request with no session. */
+        compound->saved_session_handle = NULL;
+        compound->saved_tree           = NULL;
+        compound->saved_session_id     = UINT64_MAX;
+        compound->saved_tree_id        = UINT64_MAX;
+        compound->saved_file_id.pid    = UINT64_MAX;
+        compound->saved_file_id.vid    = UINT64_MAX;
     }
 
     /* A request the parser could not set up (e.g. invalid session id) carries a
@@ -744,7 +734,9 @@ chimera_smb_compound_advance(struct chimera_smb_compound *compound)
             chimera_smb_oplock_break(request);
             break;
         default:
-            chimera_smb_complete_request(request, SMB2_STATUS_NOT_IMPLEMENTED);
+            /* Opcode outside the valid SMB2 range (0x00..0x12); Windows/Samba
+             * fail an unknown command with STATUS_INVALID_PARAMETER. */
+            chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
             break;
     } /* switch */
 

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -1448,17 +1448,21 @@ chimera_smb_open_file_resolve(
 
     chimera_smb_abort_if(!tree, "tree is NULL");
 
+    /* A UINT64_MAX FileId inherits the previous request's FileId, but only in a
+     * related compound (MS-SMB2 3.3.5.2.7.2).  For an unrelated request it is
+     * just an invalid handle and must resolve to FILE_CLOSED, not the prior
+     * request's file. */
     if (unlikely(file_id->pid == UINT64_MAX)) {
-        if (request->compound->saved_file_id.pid == UINT64_MAX) {
-            chimera_smb_error("Attempted to lookup invalid file id");
+        if (!(request->smb2_hdr.flags & SMB2_FLAGS_RELATED_OPERATIONS) ||
+            request->compound->saved_file_id.pid == UINT64_MAX) {
             return NULL;
         }
         file_id->pid = request->compound->saved_file_id.pid;
     }
 
     if (unlikely(file_id->vid == UINT64_MAX)) {
-        if (request->compound->saved_file_id.vid == UINT64_MAX) {
-            chimera_smb_error("Attempted to lookup invalid file id");
+        if (!(request->smb2_hdr.flags & SMB2_FLAGS_RELATED_OPERATIONS) ||
+            request->compound->saved_file_id.vid == UINT64_MAX) {
             return NULL;
         }
         file_id->vid = request->compound->saved_file_id.vid;
@@ -1575,17 +1579,20 @@ chimera_smb_open_file_close(
 
     chimera_smb_abort_if(!tree, "tree is NULL");
 
+    /* Only a related compound request inherits the previous request's FileId
+     * from a UINT64_MAX placeholder; for an unrelated request it is an invalid
+     * handle and must report FILE_CLOSED (MS-SMB2 3.3.5.2.7.2). */
     if (unlikely(file_id->pid == UINT64_MAX)) {
-        if (request->compound->saved_file_id.pid == UINT64_MAX) {
-            chimera_smb_error("Attempted to close invalid file id");
+        if (!(request->smb2_hdr.flags & SMB2_FLAGS_RELATED_OPERATIONS) ||
+            request->compound->saved_file_id.pid == UINT64_MAX) {
             return NULL;
         }
         file_id->pid = request->compound->saved_file_id.pid;
     }
 
     if (unlikely(file_id->vid == UINT64_MAX)) {
-        if (request->compound->saved_file_id.vid == UINT64_MAX) {
-            chimera_smb_error("Attempted to close invalid file id");
+        if (!(request->smb2_hdr.flags & SMB2_FLAGS_RELATED_OPERATIONS) ||
+            request->compound->saved_file_id.vid == UINT64_MAX) {
             return NULL;
         }
         file_id->vid = request->compound->saved_file_id.vid;


### PR DESCRIPTION
## Summary

Fixes the compound-request status-code conformance gaps in `smb2.compound`,
taking it from **4 to 9 passing subtests on every backend** (memfs, linux,
io_uring, cairn, diskfs_io_uring, diskfs_aio). `invalid1`, `invalid2`,
`invalid3`, `invalid4` and `related9` now pass.

The behaviour was reverse-engineered from Samba's server
(`source3/smbd/smb2_server.c`) and validated against the Samba 4.23.6
`smbtorture` client; statuses match Windows/Samba per MS-SMB2 3.3.5.2.7.2.

### Changes

- **Process the whole chain, never abort-cascade.** Drop the
  `STATUS_REQUEST_ABORTED` cascade that fired on the first failing request:
  a related request inherits the prior request's session/tree/FileId and
  fails naturally; an unrelated request is independent. The UINT64_MAX
  FileId placeholder is now only substituted for *related* requests.

- **Unrelated request resets the chain context.** Clear the saved
  session/tree/FileId when an unrelated request is dispatched, so a later
  related request cannot inherit stale context from before it (mirrors
  Samba resetting `last_session_id` / `compat_chain_fsp` on every
  non-chained request). Fixes `invalid2`/`invalid3`.

- **Sessionless related request → `STATUS_INVALID_PARAMETER`.** A related
  request whose inherited session could not be resolved (the preceding
  request established none, or the chain illegally opened with a related
  request) now returns `INVALID_PARAMETER` instead of
  `NETWORK_NAME_DELETED`. Fixes `invalid1` and `related9`.

- **Unknown SMB2 opcode → `STATUS_INVALID_PARAMETER`.** Opcodes outside
  0x00..0x12 return `INVALID_PARAMETER` rather than `NOT_IMPLEMENTED`.
  Fixes `invalid4`.

The remaining `smb2.compound` failures are unrelated feature gaps
(IOCTL/FSCTL, change-notify, oplock break, named streams, async interim
responses), tracked separately.

### Note on base

The first bullet (process-all-requests + related-only FileId inheritance)
is the content of PR #579, which was merged into the `smb-compound-defer-bad-session`
feature branch rather than `main`, so it never reached `main`. This PR
re-includes it as the prerequisite for the new validation fixes. If you'd
rather land #579 to `main` separately, I can rebase this on top of it.

### Validation

- `smb2.compound` 4→9 subtests on all 6 backends; no crashes/hangs.
- `smb2.compound_find` still 100% green (no regression).
- Regression sweep green on memfs: read, rw, sharemode, check-sharemode,
  create_no_streams, connect, tcon, mkdir, winattr2, secleak.