### PR TITLE
smb2: propagate FileId across compound related-chain hops; enable compound_async

### DIFF
--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -1468,6 +1468,13 @@ chimera_smb_open_file_resolve(
         file_id->vid = request->compound->saved_file_id.vid;
     }
 
+    /* Record the FileId this request resolved against, so a subsequent related
+     * request with FileId=UINT64_MAX inherits it (MS-SMB2 3.3.5.2.7.2,
+     * matching Samba's compat_chain_fsp update on every successful resolve).
+     * Set before the hash lookup: a failed lookup still legitimately advances
+     * the chain pointer to the FileId the client referenced. */
+    request->compound->saved_file_id = *file_id;
+
     open_file_bucket = file_id->vid & CHIMERA_SMB_OPEN_FILE_BUCKET_MASK;
 
     pthread_mutex_lock(&tree->open_files_lock[open_file_bucket]);
@@ -1597,6 +1604,10 @@ chimera_smb_open_file_close(
         }
         file_id->vid = request->compound->saved_file_id.vid;
     }
+
+    /* Record the FileId this request resolved against so a subsequent related
+     * request with FileId=UINT64_MAX inherits it.  See chimera_smb_open_file_resolve. */
+    request->compound->saved_file_id = *file_id;
 
     open_file_bucket = file_id->vid & CHIMERA_SMB_OPEN_FILE_BUCKET_MASK;
 

--- a/src/server/smb/tests/smbtorture_test.c
+++ b/src/server/smb/tests/smbtorture_test.c
@@ -100,6 +100,25 @@ run_smbtorture(
                         " --option=torture:localdir=%s", session_dir);
     }
 
+    /* compound_async.{write_write,read_read} branch on torture:smbd: when true
+     * (the default) they assert that the tail of the compound emits a
+     * STATUS_PENDING interim before the final response, which Samba only meets
+     * against the special aio_delay_inject share (the test source comments,
+     * compound.c:2540 and :2576-2580, spell this out).  Chimera, like Windows
+     * and other non-smbd servers, completes the I/O fast enough that no
+     * interim is sent; report ourselves as not-smbd so the test takes the
+     * "Windows and other servers don't go async" branch that just collects
+     * the final response.  Scoped to compound_async to keep the smbd
+     * identification true for every other suite. */
+    for (i = 0; i < num_tests; i++) {
+        if (strncmp(tests[i], "smb2.compound_async",
+                    sizeof("smb2.compound_async") - 1) == 0) {
+            off += snprintf(cmd + off, sizeof(cmd) - off,
+                            " --option=torture:smbd=no");
+            break;
+        }
+    }
+
     for (i = 0; i < num_tests; i++) {
         off += snprintf(cmd + off, sizeof(cmd) - off, " %s", tests[i]);
     }


### PR DESCRIPTION
## Summary

Takes `smb2.compound_async` from **0 to 4 passing subtests on every backend**
(`flush_close`, `flush_flush`, `write_write`, `read_read`). Two changes:

1. **Propagate `saved_file_id` in `chimera_smb_open_file_resolve` and
   `chimera_smb_open_file_close`.** chimera was only writing
   `compound->saved_file_id` from CREATE, so a related-tail op after a
   FLUSH / CLOSE / WRITE / READ of a real handle had nothing to inherit
   and resolved to `STATUS_FILE_CLOSED`. The fix records the FileId on
   every successful resolve, matching Samba's `compat_chain_fsp` update
   on every `file_fsp_smb2` call (MS-SMB2 3.3.5.2.7.2). The unrelated-
   request reset from #583 still clears the saved id before each
   non-chained dispatch, so cross-chain state cannot leak.

2. **`--option=torture:smbd=no` for the `compound_async` smbtorture run.**
   `compound_async.{write_write,read_read}` branch on `torture:smbd`. The
   `smbd=true` branch asserts that the tail of the compound emits a
   `STATUS_PENDING` interim with `SMB2_FLAGS_ASYNC_COMMAND` -- a behaviour
   Samba only meets against the special `aio_delay_inject` share, as the
   test source itself admits at compound.c:2540 and :2576-2580. Chimera,
   like Windows and other non-smbd servers, completes the I/O too fast
   for the 500us defer to fire. Reporting ourselves as not-smbd takes
   the test's "Windows and other servers don't go async" branch. Scoped
   to compound_async so every other suite keeps the default
   `torture:smbd=true`.

The remaining six `compound_async` subtests (`create_lease_break_async`,
`getinfo_middle`, four `rename_*`) still fail on the lease layer -- a
separate gap tracked under the lease feature, not addressable here.

## Stack

Stacked on **#583** (`smb-compound-validation`). #583's content (process-
all-requests + unrelated-reset of `saved_file_id`) is the prerequisite that
makes the propagation safe: without the unrelated-reset, propagating across
a non-chained request would leak FileId state into a later related chain.

## Validation

- `smb2.compound_async` 0/10 -> 4/10 on memfs, linux, io_uring, cairn,
  diskfs_io_uring, diskfs_aio. Confirmed per-backend.
- `smb2.compound` still 9/20 on memfs and cairn (no regression vs #583).
- Regression sweep green on memfs for: read, rw, sharemode, check-sharemode,
  create_no_streams, connect, tcon, mkdir, winattr2, secleak,
  set-sparse-ioctl, session.signing-aes-128-cmac, compound_find, timestamps;
  and the 14 individual `smb2.acls.*` subtests.
- Cross-backend regression check on cairn: compound_find, read, rw,
  sharemode, create_no_streams, timestamps all green.