### PR TITLE
smb2: generic async-interim (STATUS_PENDING) response infrastructure

### DIFF
--- a/src/server/smb/CMakeLists.txt
+++ b/src/server/smb/CMakeLists.txt
@@ -12,7 +12,7 @@ add_library(chimera_smb SHARED
     smb_proc_reparse.c smb_proc_change_notify.c smb_proc_cancel.c
     smb_proc_sparse.c smb_proc_copychunk.c
     smb_proc_lock.c smb_proc_oplock_break.c
-    smb_notify.c smb_sharemode.c smb_ntlm.c smb_durable.c
+    smb_notify.c smb_async_interim.c smb_sharemode.c smb_ntlm.c smb_durable.c
     smb_wbclient.c smb_auth.c smb_gssapi.c
     #idl/ndr_dcerpc.c
 )

--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -20,6 +20,7 @@
 #include "server/server.h"
 #include "evpl/evpl.h"
 #include "smb_internal.h"
+#include "smb_async_interim.h"
 #include "smb_wbclient.h"
 #include "smb_procs.h"
 #include "smb_notify.h"
@@ -571,6 +572,15 @@ chimera_smb_complete_request(
 {
     struct chimera_smb_compound *compound = request->compound;
 
+    /* If an async-interim timer is armed, cancel it first.  If the timer has
+     * not yet fired this is a synchronous fast path -- no interim was sent
+     * and the request will reply normally below.  If the timer already fired,
+     * an interim is on the wire, request->async_id is set, and the reply
+     * builder will tag the final response with SMB2_FLAGS_ASYNC_COMMAND. */
+    if (unlikely(request->async.armed)) {
+        chimera_smb_async_interim_cancel(request);
+    }
+
     request->status = status;
 
     compound->complete_requests++;
@@ -673,6 +683,37 @@ chimera_smb_compound_advance(struct chimera_smb_compound *compound)
         }
         chimera_smb_complete_request(request, SMB2_STATUS_NETWORK_NAME_DELETED);
         return;
+    }
+
+    /* Arm an async-interim timer for READ / WRITE / FLUSH when this request is
+     * the tail of a compound (or a singleton).  If the handler completes within
+     * the defer window, chimera_smb_complete_request cancels the timer and no
+     * interim is sent.  If the underlying VFS op takes longer, the timer fires
+     * a standalone STATUS_PENDING with SMB2_FLAGS_ASYNC_COMMAND and an AsyncId
+     * the client can use to correlate the eventual final response (and to
+     * cancel via SMB2_CANCEL).
+     *
+     * Mid-compound async on the same commands is NOT enforced as
+     * STATUS_INTERNAL_ERROR here: chimera handlers for these commands either
+     * complete in-line on fast backends or via a callback that marshals back to
+     * the conn thread.  Either way no interim fires mid-chain, and a
+     * mid-chain ban would falsely fail a legitimately-fast mid-compound
+     * FLUSH/WRITE/READ.  When a future producer (oplock break, lease break)
+     * adds a genuinely long-running mid-chain op, the mid-chain ban can be
+     * added alongside it. */
+    if (compound->complete_requests + 1 == compound->num_requests) {
+        switch (request->smb2_hdr.command) {
+            case SMB2_READ:
+            case SMB2_WRITE:
+            case SMB2_FLUSH:
+                /* Samba uses 500us for READ/WRITE; FLUSH gets the same
+                 * threshold (the suite's flush-flush test allows OK or
+                 * INTERNAL_ERROR on a deferred flush). */
+                chimera_smb_async_interim_arm(request, 500);
+                break;
+            default:
+                break;
+        } /* switch */
     }
 
     switch (request->smb2_hdr.command) {

--- a/src/server/smb/smb_async_interim.c
+++ b/src/server/smb/smb_async_interim.c
@@ -1,0 +1,191 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * Generic SMB2 async-interim (STATUS_PENDING) infrastructure.
+ *
+ * The dispatch site arms a one-shot timer on a defer-eligible request just
+ * before calling the command handler.  If the handler completes within the
+ * defer window (the common case on memfs/io_uring), chimera_smb_complete_request
+ * removes the timer and the request proceeds synchronously.  If the timer
+ * fires first, this file emits a standalone interim response carrying
+ * SMB2_FLAGS_ASYNC_COMMAND and an AsyncId = the original MessageId (Samba's
+ * convention), so the client knows the request is in flight and can later
+ * correlate the final response by AsyncId.  When the handler eventually
+ * completes, the existing reply builder sees request->async_id != 0 and emits
+ * the final response with the same flag.
+ *
+ * The whole machinery runs on the request's owning conn thread (the dispatch
+ * site, the timer fire, and chimera_smb_complete_request all serialise on the
+ * single-threaded evpl loop), so no locks are needed.
+ *
+ * CHANGE_NOTIFY keeps its own bespoke interim path in smb_notify.c for now;
+ * that path predates this one and is correct.  A future cleanup can fold it
+ * in once this path is exercised by an actually-async producer (oplock break,
+ * lease break, blocking lock).
+ */
+
+#include <string.h>
+#include <stddef.h>
+
+#include "smb_internal.h"
+#include "smb_async_interim.h"
+#include "smb_signing.h"
+#include "smb2.h"
+
+#include "evpl/evpl.h"
+
+/* Standalone SMB2 message: 4 byte NetBIOS header + 64 byte SMB2 header +
+ * 9 byte SMB2 error response body.  Same shape as
+ * chimera_smb_notify_send_interim. */
+#define CHIMERA_SMB_ASYNC_INTERIM_LEN 77
+
+static void
+chimera_smb_async_interim_unlink(
+    struct chimera_smb_conn    *conn,
+    struct chimera_smb_request *request)
+{
+    struct chimera_smb_request **pp = &conn->parked_requests;
+
+    while (*pp) {
+        if (*pp == request) {
+            *pp                      = request->async.park_next;
+            request->async.park_next = NULL;
+            return;
+        }
+        pp = &(*pp)->async.park_next;
+    }
+} /* chimera_smb_async_interim_unlink */
+
+static void
+chimera_smb_async_interim_fire(
+    struct evpl       *evpl,
+    struct evpl_timer *timer)
+{
+    struct chimera_smb_request  *request = (struct chimera_smb_request *)
+        ((char *) timer - offsetof(struct chimera_smb_request, async.timer));
+    struct chimera_smb_compound *compound = request->compound;
+    struct chimera_smb_conn     *conn     = compound->conn;
+    struct smb2_header          *hdr;
+    struct evpl_iovec            iov;
+    uint8_t                     *buf;
+    int                          smb2_len;
+    uint32_t                     nb;
+
+    /* Assign the AsyncId.  Samba uses the original MessageId; chimera follows
+     * suit -- there is no separate id space and the client correlates by it. */
+    request->async_id = request->smb2_hdr.message_id;
+
+    evpl_iovec_alloc(evpl, CHIMERA_SMB_ASYNC_INTERIM_LEN, 8, 1, 0, &iov);
+    buf = iov.data;
+    memset(buf, 0, CHIMERA_SMB_ASYNC_INTERIM_LEN);
+
+    /* NetBIOS framing length filled in below. */
+    hdr                          = (struct smb2_header *) (buf + 4);
+    hdr->protocol_id[0]          = 0xFE;
+    hdr->protocol_id[1]          = 'S';
+    hdr->protocol_id[2]          = 'M';
+    hdr->protocol_id[3]          = 'B';
+    hdr->struct_size             = 64;
+    hdr->credit_charge           = request->async.credit_charge;
+    hdr->status                  = SMB2_STATUS_PENDING;
+    hdr->command                 = request->smb2_hdr.command;
+    hdr->credit_request_response = request->async.credit_request
+        ? request->async.credit_request : 1;
+    hdr->flags = SMB2_FLAGS_SERVER_TO_REDIR |
+        SMB2_FLAGS_ASYNC_COMMAND;
+    hdr->message_id     = request->smb2_hdr.message_id;
+    hdr->async.async_id = request->async_id;
+    hdr->session_id     = request->async.session_id;
+
+    /* Error response body: StructureSize(2) + ErrorContextCount(1) +
+     * Reserved(1) + ByteCount(4) + pad(1). */
+    buf[4 + sizeof(*hdr) + 0] = 9;
+
+    smb2_len = (int) sizeof(*hdr) + 9;
+    nb       = __builtin_bswap32((uint32_t) smb2_len);
+    memcpy(buf, &nb, 4);
+
+    if (request->async.signed_session) {
+        chimera_smb_sign_message(conn->thread->signing_ctx,
+                                 request->async.dialect,
+                                 request->async.signing_key,
+                                 buf + 4,
+                                 smb2_len);
+    }
+
+    iov.length = CHIMERA_SMB_ASYNC_INTERIM_LEN;
+    evpl_sendv(evpl, conn->bind, &iov, 1, iov.length, EVPL_SEND_FLAG_TAKE_REF);
+} /* chimera_smb_async_interim_fire */
+
+void
+chimera_smb_async_interim_arm(
+    struct chimera_smb_request *request,
+    uint64_t                    delay_us)
+{
+    struct chimera_smb_compound *compound = request->compound;
+    struct chimera_smb_conn     *conn     = compound->conn;
+
+    request->async.armed          = 1;
+    request->async.credit_charge  = request->smb2_hdr.credit_charge;
+    request->async.credit_request = request->smb2_hdr.credit_request_response;
+    request->async.dialect        = conn->dialect;
+    request->async.session_id     = request->smb2_hdr.session_id;
+
+    /* Sign the interim iff the original request was signed (same rule as the
+     * change-notify path).  An unsigned async reply on a signed session is
+     * rejected by Windows clients. */
+    if ((request->smb2_hdr.flags & SMB2_FLAGS_SIGNED) &&
+        request->session_handle) {
+        request->async.signed_session = 1;
+        memcpy(request->async.signing_key,
+               request->session_handle->signing_key,
+               sizeof(request->async.signing_key));
+    } else {
+        request->async.signed_session = 0;
+    }
+
+    /* Link onto the conn's parked-requests list so CANCEL can find this
+     * request by AsyncId and conn_free can drain it on teardown. */
+    request->async.park_next = conn->parked_requests;
+    conn->parked_requests    = request;
+
+    evpl_add_oneshot_timer(compound->thread->evpl,
+                           &request->async.timer,
+                           chimera_smb_async_interim_fire,
+                           delay_us);
+} /* chimera_smb_async_interim_arm */
+
+void
+chimera_smb_async_interim_cancel(struct chimera_smb_request *request)
+{
+    struct chimera_smb_compound *compound = request->compound;
+    struct chimera_smb_conn     *conn     = compound->conn;
+
+    /* Documented safe whether or not the oneshot has already fired. */
+    evpl_remove_timer(compound->thread->evpl, &request->async.timer);
+
+    chimera_smb_async_interim_unlink(conn, request);
+
+    request->async.armed = 0;
+
+    /* Deliberately do NOT clear request->async_id.  If the timer had already
+     * fired, the interim is on the wire and the compound reply builder must
+     * still set SMB2_FLAGS_ASYNC_COMMAND with this AsyncId on the final
+     * response so the client correlates the two halves. */
+} /* chimera_smb_async_interim_cancel */
+
+void
+chimera_smb_async_interim_drain(struct chimera_smb_conn *conn)
+{
+    struct chimera_server_smb_thread *thread = conn->thread;
+    struct chimera_smb_request       *request;
+
+    while ((request = conn->parked_requests) != NULL) {
+        conn->parked_requests    = request->async.park_next;
+        request->async.park_next = NULL;
+        request->async.armed     = 0;
+        evpl_remove_timer(thread->evpl, &request->async.timer);
+    }
+} /* chimera_smb_async_interim_drain */

--- a/src/server/smb/smb_async_interim.h
+++ b/src/server/smb/smb_async_interim.h
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#pragma once
+
+#include <stdint.h>
+
+struct chimera_smb_request;
+
+/* Arm a one-shot timer that, if not cancelled within delay_us, emits a
+ * standalone SMB2 STATUS_PENDING interim response for the request and leaves
+ * request->async_id set so the eventual final response carries a matching
+ * SMB2_FLAGS_ASYNC_COMMAND.
+ *
+ * Snapshots the signing key, session_id, dialect, credit fields, and the
+ * signed-session bit at arm time so the fire path does not race with
+ * concurrent session teardown for the signing material.
+ *
+ * Must be called on the request's conn thread (the dispatch site).  The
+ * timer fires on the same thread.  If chimera_smb_complete_request runs
+ * first (the synchronous fast path) it calls _cancel and the timer is
+ * removed before its first opportunity to fire. */
+void
+chimera_smb_async_interim_arm(
+    struct chimera_smb_request *request,
+    uint64_t                    delay_us);
+
+/* Cancel an armed interim timer.  Idempotent: evpl_remove_timer after a
+ * oneshot has fired is a documented no-op.  Unlinks the request from the
+ * conn's parked list and clears the armed bit.  Does NOT clear
+ * request->async_id: if the timer had already fired, an interim is on the
+ * wire and the final response must echo the AsyncId. */
+void
+chimera_smb_async_interim_cancel(
+    struct chimera_smb_request *request);

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -212,6 +212,21 @@ struct chimera_smb_request {
     struct chimera_smb_compound       *compound;
     struct chimera_smb_request        *next;
 
+    /* Generic async-interim (STATUS_PENDING) state.  Populated at dispatch
+     * time by chimera_smb_async_interim_arm and consumed by the timer fire
+     * path in smb_async_interim.c.  armed == 0 outside an arm/cancel window. */
+    struct {
+        struct evpl_timer           timer;
+        struct chimera_smb_request *park_next;
+        uint8_t                     signing_key[16];
+        uint64_t                    session_id;
+        uint16_t                    dialect;
+        uint16_t                    credit_charge;
+        uint16_t                    credit_request;
+        uint8_t                     signed_session;
+        uint8_t                     armed;
+    } async;
+
     union {
 
         struct {
@@ -707,6 +722,10 @@ struct chimera_smb_conn {
     struct chimera_smb_tree           *last_tree;
     struct chimera_smb_session_handle *session_handles;
     struct chimera_smb_notify_request *parked_notifies;  /* parked CHANGE_NOTIFY requests */
+    /* Requests with an armed async-interim timer (smb_async_interim.c).  CANCEL
+     * walks this list by AsyncId; conn_free drains it before tearing down the
+     * bind. */
+    struct chimera_smb_request        *parked_requests;
     struct chimera_server_smb_thread  *thread;
     struct evpl_bind                  *bind;
     struct chimera_smb_conn           *prev;
@@ -1019,10 +1038,12 @@ chimera_smb_request_alloc(struct chimera_server_smb_thread *thread)
         request = calloc(1, sizeof(*request));
     }
 
-    request->status   = SMB2_STATUS_SUCCESS;
-    request->flags    = 0;
-    request->async_id = 0;
-    request->tree     = NULL;
+    request->status          = SMB2_STATUS_SUCCESS;
+    request->flags           = 0;
+    request->async_id        = 0;
+    request->tree            = NULL;
+    request->async.armed     = 0;
+    request->async.park_next = NULL;
 
     return request;
 } /* chimera_smb_request_alloc */
@@ -1190,6 +1211,12 @@ void chimera_smb_notify_cancel(
 void chimera_smb_notify_drop(
     struct chimera_smb_notify_request *nr);
 
+/* Defined in smb_async_interim.c -- forward-declared here so the inline
+ * chimera_smb_conn_free below can call drain without including the header
+ * (which would create a cycle through smb_internal.h). */
+void chimera_smb_async_interim_drain(
+    struct chimera_smb_conn *conn);
+
 static inline void
 chimera_smb_conn_free(
     struct chimera_server_smb_thread *thread,
@@ -1204,6 +1231,13 @@ chimera_smb_conn_free(
     while (conn->parked_notifies) {
         chimera_smb_notify_drop(conn->parked_notifies);
     }
+
+    /* Remove any armed async-interim timers and unlink their requests from
+     * the parked list.  A late VFS callback that still reaches
+     * chimera_smb_complete_request will see request->async.armed == 0 and
+     * skip the cancel.  We do not free the request here -- it is still
+     * owned by its compound, which will tear down through the normal path. */
+    chimera_smb_async_interim_drain(conn);
 
     /* Drain any lease-break notifications still queued for this connection and
      * mark it tearing-down so a break_cb racing on another thread won't enqueue

--- a/src/server/smb/smb_proc_cancel.c
+++ b/src/server/smb/smb_proc_cancel.c
@@ -27,6 +27,7 @@ chimera_smb_cancel(struct chimera_smb_request *request)
 {
     struct chimera_smb_conn           *conn = request->compound->conn;
     struct chimera_smb_notify_request *nr;
+    struct chimera_smb_request        *parked;
     uint64_t                           target_id;
 
     /* CANCEL targets either an async_id (if ASYNC flag set) or message_id */
@@ -40,10 +41,22 @@ chimera_smb_cancel(struct chimera_smb_request *request)
     for (nr = conn->parked_notifies; nr; nr = nr->next) {
         if (nr->async_id == target_id) {
             chimera_smb_notify_cancel(nr);
+            goto done;
+        }
+    }
+
+    /* Search async-interim-armed I/O requests on this connection.  For now
+     * the underlying VFS op is not cancellable from SMB2_CANCEL; absorb the
+     * cancel silently.  A future phase can plumb through to
+     * chimera_vfs_*_cancel where backends support it. */
+    for (parked = conn->parked_requests; parked;
+         parked = parked->async.park_next) {
+        if (parked->async_id == target_id) {
             break;
         }
     }
 
+ done:
     /* CANCEL has no response per MS-SMB2.  Use STATUS_PENDING so the
      * compound reply builder skips this slot — no reply body is ever
      * emitted for SMB2_CANCEL.  (There is therefore no


### PR DESCRIPTION
## Summary

Adds a reusable defer-and-emit-interim path that the dispatch site arms
on defer-eligible commands (READ, WRITE, FLUSH) when they are the tail
of their compound:

- Handler completes within 500us window -> `chimera_smb_complete_request`
  cancels the timer, request replies synchronously, no interim sent.
- Underlying VFS op takes longer -> timer fires a standalone SMB2
  `STATUS_PENDING` with `SMB2_FLAGS_ASYNC_COMMAND` and an `AsyncId` set to
  the original MessageId (Samba's convention).  The eventual final reply
  picks up `request->async_id != 0` and tags itself with the same flag.

New file `src/server/smb/smb_async_interim.c` hosts the
`arm` / `cancel` / `fire` / `drain` helpers.  `arm` snapshots the
signing key, dialect, session id, credit fields, and signed-session bit
on the request itself -- same pattern `smb_proc_change_notify.c` uses --
so the fire path does not race with concurrent session teardown for the
signing material.

## State threading

- `chimera_smb_request.async` substruct (timer + park_next + signing
  snapshot + armed) reuses the existing free-list-allocated request, no
  extra alloc cost; `chimera_smb_request_alloc` zeros it.
- `chimera_smb_conn.parked_requests` singly-linked list head; CANCEL
  walks it by AsyncId; `chimera_smb_conn_free` drains it before tearing
  down the bind.
- `chimera_smb_complete_request` gains a one-line cancel hook at the
  top.  `chimera_smb_compound_advance` arms in front of the dispatch
  switch when the command is defer-eligible AND this slot is the tail.

The whole machinery runs on the request's owning conn thread (dispatch,
timer fire, complete_request all serialise on the single-threaded evpl
loop), so no locks are needed.

## Mid-chain async deliberately NOT failed with INTERNAL_ERROR

MS-SMB2 reserves `STATUS_INTERNAL_ERROR` for a mid-compound op that goes
async, but chimera's current READ/WRITE/FLUSH producers either complete
in-line or via a callback that marshals back to the conn thread, so no
interim ever fires mid-chain today.  A mid-chain ban would falsely fail
a legitimately-fast mid-compound `FLUSH+WRITE`, `WRITE+CLOSE`, etc.
When a future producer (oplock break, lease break, blocking lock) adds
a genuinely long-running mid-chain op, the rule can be added alongside
it.

## CHANGE_NOTIFY left bespoke

`smb_notify.c`'s existing interim path is correct and already tested.
The two paths do not conflict (separate `parked_notifies` /
`parked_requests` lists; CANCEL walks both).  Folding notify in is a
later cleanup, not gated on test wins.

## Test wins

**None by itself.**  The infrastructure only ever emits an interim when
an underlying op exceeds 500us, which none of chimera's current VFS
operations do.  This is foundation for the eventual oplock-break /
lease-break / blocking-lock work.

## Validation (no regressions)

- `smb2.compound_async` stays 4/10 (Phase 1 wins from #584 intact).
- `smb2.compound` 9/20.
- `smb2.notify-inotify` green.
- Memfs sweep: compound, compound_find, compound_async, read, rw,
  sharemode, check-sharemode, create_no_streams, connect, tcon, mkdir,
  winattr2, secleak, timestamps, notify-inotify.
- Cairn + io_uring cross-backend: 9 compound + 4 compound_async on each.

## Stack

Stacked on **#584** (`smb-compound-fileid-propagate`), which itself stacks
on **#583** (`smb-compound-validation`).