### PR TITLE
smb: SMB3 transport encryption, AES-128-GMAC signing, and session-auth fixes

### DIFF
--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -380,6 +380,27 @@ main(
         chimera_server_config_set_smb_named_streams(server_config, json_is_true(json_value));
     }
 
+    /* smb_encryption: "off"|"enabled"|"required" (or a boolean/integer 0/1/2). */
+    json_value = json_object_get(server_params, "smb_encryption");
+    if (json_is_string(json_value)) {
+        const char *enc  = json_string_value(json_value);
+        int         mode = 0;
+        if (strcmp(enc, "required") == 0) {
+            mode = 2;
+        } else if (strcmp(enc, "enabled") == 0 || strcmp(enc, "on") == 0) {
+            mode = 1;
+        } else if (strcmp(enc, "off") == 0 || strcmp(enc, "disabled") == 0) {
+            mode = 0;
+        } else {
+            chimera_server_error("Invalid smb_encryption value '%s' (expected off/enabled/required)", enc);
+        }
+        chimera_server_config_set_smb_encryption(server_config, mode);
+    } else if (json_is_integer(json_value)) {
+        chimera_server_config_set_smb_encryption(server_config, (int) json_integer_value(json_value));
+    } else if (json_is_boolean(json_value)) {
+        chimera_server_config_set_smb_encryption(server_config, json_is_true(json_value) ? 1 : 0);
+    }
+
     json_value = json_object_get(server_params, "nfs4_session_slots");
     if (json_is_integer(json_value)) {
         int_value = json_integer_value(json_value);

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -70,6 +70,8 @@ struct chimera_server_config {
     uint32_t                              smb_dialects[16];
     int                                   smb_persistent_handles;
     int                                   smb_named_streams;
+    int                                   smb_signing_required;
+    int                                   smb_encryption;
     int                                   smb_num_nic_info;
     uint32_t                              anonuid;
     uint32_t                              anongid;
@@ -151,6 +153,15 @@ chimera_server_config_init(void)
      * "smb_named_streams" config flag and only honored on backends that
      * advertise CHIMERA_VFS_CAP_NAMED_STREAMS. */
     config->smb_named_streams = 0;
+
+    /* Server signing is advertised as enabled-but-optional by default; the
+     * "smb_signing_required" config flag makes the server advertise signing as
+     * mandatory (SMB2_SIGNING_REQUIRED). */
+    config->smb_signing_required = 0;
+
+    /* SMB3 transport encryption is off by default; the "smb_encryption" config
+     * flag enables (1) or requires (2) it. */
+    config->smb_encryption = 0;
 
     // SMB auth config defaults - local NTLM only
     config->smb_auth.winbind_enabled    = 0;
@@ -289,6 +300,34 @@ chimera_server_config_get_smb_named_streams(const struct chimera_server_config *
 {
     return config->smb_named_streams;
 } /* chimera_server_config_get_smb_named_streams */
+
+SYMBOL_EXPORT void
+chimera_server_config_set_smb_signing_required(
+    struct chimera_server_config *config,
+    int                           required)
+{
+    config->smb_signing_required = required;
+} /* chimera_server_config_set_smb_signing_required */
+
+SYMBOL_EXPORT int
+chimera_server_config_get_smb_signing_required(const struct chimera_server_config *config)
+{
+    return config->smb_signing_required;
+} /* chimera_server_config_get_smb_signing_required */
+
+SYMBOL_EXPORT void
+chimera_server_config_set_smb_encryption(
+    struct chimera_server_config *config,
+    int                           mode)
+{
+    config->smb_encryption = mode;
+} /* chimera_server_config_set_smb_encryption */
+
+SYMBOL_EXPORT int
+chimera_server_config_get_smb_encryption(const struct chimera_server_config *config)
+{
+    return config->smb_encryption;
+} /* chimera_server_config_get_smb_encryption */
 
 SYMBOL_EXPORT void
 chimera_server_config_set_max_open_files(

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -99,6 +99,24 @@ chimera_server_config_get_smb_named_streams(
     const struct chimera_server_config *config);
 
 void
+chimera_server_config_set_smb_signing_required(
+    struct chimera_server_config *config,
+    int                           required);
+
+int
+chimera_server_config_get_smb_signing_required(
+    const struct chimera_server_config *config);
+
+void
+chimera_server_config_set_smb_encryption(
+    struct chimera_server_config *config,
+    int                           mode);
+
+int
+chimera_server_config_get_smb_encryption(
+    const struct chimera_server_config *config);
+
+void
 chimera_server_config_set_cache_ttl(
     struct chimera_server_config *config,
     int                           ttl);

--- a/src/server/smb/CMakeLists.txt
+++ b/src/server/smb/CMakeLists.txt
@@ -8,7 +8,7 @@ add_library(chimera_smb SHARED
     smb_proc_set_info.c smb_proc_tree_disconnect.c smb_proc_logoff.c
     smb_proc_write.c smb_proc_read.c smb_proc_query_info.c
     smb_proc_query_directory.c smb_proc_ioctl.c smb_proc_flush.c smb_proc_echo.c
-    smb_lsarpc.c smb_signing.c smb_proc_set_info_rename.c smb_proc_security.c
+    smb_lsarpc.c smb_signing.c smb_encrypt.c smb_proc_set_info_rename.c smb_proc_security.c
     smb_proc_reparse.c smb_proc_change_notify.c smb_proc_cancel.c
     smb_proc_sparse.c smb_proc_copychunk.c
     smb_proc_lock.c smb_proc_oplock_break.c

--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -25,6 +25,7 @@
 #include "smb_notify.h"
 #include "smb_dump.h"
 #include "smb_signing.h"
+#include "smb_encrypt.h"
 #include "xxhash.h"
 
 static const uint8_t SMB2_PROTOCOL_ID[4] = { 0xFE, 'S', 'M', 'B' };
@@ -145,6 +146,8 @@ chimera_smb_server_init(
     shared->config.soft_fail_bad_req  = chimera_server_config_get_soft_fail_bad_req(config);
     shared->config.persistent_handles = chimera_server_config_get_smb_persistent_handles(config);
     shared->config.named_streams      = chimera_server_config_get_smb_named_streams(config);
+    shared->config.signing_required   = chimera_server_config_get_smb_signing_required(config);
+    shared->config.encryption         = chimera_server_config_get_smb_encryption(config);
 
     if (shared->config.persistent_handles) {
         chimera_smb_info("SMB3 durable/persistent handles enabled (in-memory state)");
@@ -497,6 +500,70 @@ chimera_smb_compound_reply(struct chimera_smb_compound *compound)
         }
     }
 
+    /* SMB3 transport encryption: wrap the signed reply in a TRANSFORM header
+     * when the request arrived encrypted, or when the session negotiated
+     * encryption.  The NEGOTIATE / SESSION_SETUP responses themselves precede
+     * key establishment and are always sent signed-but-plaintext. */
+    {
+        struct chimera_smb_session *enc_session = NULL;
+
+        if (compound->num_requests > 0 && compound->requests[0]->session_handle) {
+            enc_session = compound->requests[0]->session_handle->session;
+        }
+
+        if (enc_session && (enc_session->flags & CHIMERA_SMB_SESSION_ENCRYPT_DATA)) {
+            uint16_t cmd0 = compound->requests[0]->smb2_hdr.command;
+
+            if (compound->received_encrypted ||
+                (cmd0 != SMB2_NEGOTIATE && cmd0 != SMB2_SESSION_SETUP)) {
+                struct evpl_iovec enc_iov;
+                uint64_t          nonce;
+                int               enc_total;
+
+                if (conn->protocol == EVPL_DATAGRAM_RDMACM_RC) {
+                    /* SMB-Direct encryption is not yet implemented. */
+                    chimera_smb_error("SMB3 encryption over RDMA is not supported");
+                    evpl_iovecs_release(evpl, reply_iov, reply_niov);
+                    evpl_close(evpl, conn->bind);
+                    chimera_smb_compound_free(thread, compound);
+                    return;
+                }
+
+                nonce = atomic_fetch_add(&enc_session->enc_nonce_counter, 1);
+
+                rc = chimera_smb_encrypt_compound(thread->encrypt_ctx, evpl,
+                                                  enc_session->cipher_id,
+                                                  enc_session->enc_key,
+                                                  enc_session->enc_key_len,
+                                                  nonce, enc_session->session_id,
+                                                  reply_iov, reply_niov,
+                                                  reply_payload_length, reply_hdr_len,
+                                                  &enc_iov);
+
+                if (rc != 0) {
+                    evpl_iovecs_release(evpl, reply_iov, reply_niov);
+                    evpl_close(evpl, conn->bind);
+                    chimera_smb_compound_free(thread, compound);
+                    return;
+                }
+
+                enc_total = reply_hdr_len + (int) sizeof(struct smb2_transform_header) +
+                    reply_payload_length;
+
+                /* The encrypted message length excludes the NetBIOS framing. */
+                netbios_hdr       = evpl_iovec_data(&enc_iov);
+                netbios_hdr->word = __builtin_bswap32(
+                    (int) sizeof(struct smb2_transform_header) + reply_payload_length);
+
+                evpl_sendv(evpl, conn->bind, &enc_iov, 1, enc_total, EVPL_SEND_FLAG_TAKE_REF);
+
+                evpl_iovecs_release(evpl, reply_iov, reply_niov);
+                chimera_smb_compound_free(thread, compound);
+                return;
+            }
+        }
+    }
+
     if (conn->protocol == EVPL_DATAGRAM_RDMACM_RC) {
 
         /* direct_hdr was set above under this same protocol check; assert the
@@ -663,6 +730,13 @@ chimera_smb_compound_advance(struct chimera_smb_compound *compound)
                  request->smb2_hdr.command != SMB2_LOGOFF &&
                  request->smb2_hdr.command != SMB2_TREE_CONNECT &&
                  request->smb2_hdr.command != SMB2_TREE_DISCONNECT &&
+                 /* SMB2_CANCEL of an async request carries an AsyncId in the
+                  * header where a sync request carries the TreeId, so it never
+                  * resolves a tree.  It targets a parked request on the
+                  * connection (looked up by async_id), not a share, and emits
+                  * no reply — let it through with a NULL tree rather than
+                  * bouncing it with NETWORK_NAME_DELETED. */
+                 request->smb2_hdr.command != SMB2_CANCEL &&
                  request->smb2_hdr.command != SMB2_ECHO)) {
         /* A WRITE parsed before this point cloned its payload iovecs; the
          * write handler that would normally release them is being skipped, so
@@ -798,7 +872,8 @@ chimera_smb_server_handle_smb2(
     struct chimera_server_smb_thread *thread,
     struct chimera_smb_conn          *conn,
     struct evpl_iovec_cursor         *request_cursor,
-    int                               length)
+    int                               length,
+    int                               received_encrypted)
 {
     struct chimera_smb_compound       *compound;
     struct chimera_smb_request        *request;
@@ -822,8 +897,9 @@ chimera_smb_server_handle_smb2(
     compound->saved_session_handle = NULL;
     compound->saved_tree           = NULL;
 
-    compound->num_requests      = 0;
-    compound->complete_requests = 0;
+    compound->num_requests       = 0;
+    compound->complete_requests  = 0;
+    compound->received_encrypted = received_encrypted;
 
     left = length;
 
@@ -953,7 +1029,13 @@ chimera_smb_server_handle_smb2(
             goto next_compound_request;
         }
 
-        if (request->smb2_hdr.flags & SMB2_FLAGS_SIGNED) {
+        /* SESSION_SETUP requests are never signature-verified at dispatch: the
+         * final NTLM message is signed with a session key the server only
+         * derives while *processing* this very request, so the key isn't
+         * available here yet.  The NTLM exchange authenticates the request, and
+         * the success reply is signed (proving the server's key). */
+        if ((request->smb2_hdr.flags & SMB2_FLAGS_SIGNED) &&
+            request->smb2_hdr.command != SMB2_SESSION_SETUP) {
             uint8_t *signing_key;
 
             request->flags |= CHIMERA_SMB_REQUEST_FLAG_SIGN;
@@ -1245,8 +1327,9 @@ chimera_smb_server_handle_smb1(
     compound->saved_session_handle = NULL;
     compound->saved_tree           = NULL;
 
-    compound->num_requests      = 0;
-    compound->complete_requests = 0;
+    compound->num_requests       = 0;
+    compound->complete_requests  = 0;
+    compound->received_encrypted = 0;
 
     request->compound       = compound;
     request->session_handle = NULL;
@@ -1340,13 +1423,79 @@ chimera_smb_server_handle_rdma(
 
     if (direct_hdr->remaining_length == 0) {
         evpl_iovec_cursor_init(&request_cursor, conn->rdma_iov, conn->rdma_niov);
-        chimera_smb_server_handle_smb2(evpl, thread, conn, &request_cursor, conn->rdma_length);
+        chimera_smb_server_handle_smb2(evpl, thread, conn, &request_cursor, conn->rdma_length, 0);
         conn->rdma_niov   = 0;
         conn->rdma_length = 0;
     }
 
 } /* chimera_smb_server_handle_rdma */
 
+
+/*
+ * Decrypt a TRANSFORM-wrapped (SMB3 encrypted) message and feed the plaintext
+ * SMB2 message into the normal dispatch path.  request_cursor is positioned at
+ * the transform header (after the 4-byte NetBIOS framing); length is the
+ * transform header plus ciphertext byte count.
+ */
+static void
+chimera_smb_server_handle_transform(
+    struct evpl                      *evpl,
+    struct chimera_server_smb_thread *thread,
+    struct chimera_smb_conn          *conn,
+    struct evpl_iovec_cursor         *request_cursor,
+    int                               length)
+{
+    struct smb2_transform_header th;
+    struct evpl_iovec_cursor     peek_cursor = *request_cursor;
+    struct evpl_iovec_cursor     plain_cursor;
+    struct chimera_smb_session  *session;
+    struct evpl_iovec            plain_iov;
+    int                          plain_len, rc;
+
+    if (length < (int) sizeof(th)) {
+        chimera_smb_error("Truncated SMB3 transform message (%d bytes)", length);
+        evpl_close(evpl, conn->bind);
+        return;
+    }
+
+    /* Peek the transform header for its SessionId, then look up the session for
+     * its decryption key and negotiated cipher. */
+    evpl_iovec_cursor_copy(&peek_cursor, &th, sizeof(th));
+
+    session = chimera_smb_session_lookup(thread->shared, th.session_id);
+
+    if (!session || !(session->flags & CHIMERA_SMB_SESSION_ENCRYPT_DATA)) {
+        chimera_smb_error("Encrypted SMB2 message for unknown/non-encrypting session %lx",
+                          th.session_id);
+        if (session) {
+            chimera_smb_session_release(thread, thread->shared, session, true);
+        }
+        evpl_close(evpl, conn->bind);
+        return;
+    }
+
+    rc = chimera_smb_decrypt_message(thread->encrypt_ctx, evpl,
+                                     session->cipher_id, session->dec_key,
+                                     session->enc_key_len, request_cursor, length,
+                                     &plain_iov, &plain_len);
+
+    chimera_smb_session_release(thread, thread->shared, session, true);
+
+    if (rc != 0) {
+        evpl_close(evpl, conn->bind);
+        return;
+    }
+
+    /* The decrypted plaintext is a complete (possibly compound) SMB2 message.
+     * Dispatch it as if received in the clear, flagging the compound so its
+     * reply is encrypted.  Request handlers that outlive this call take their
+     * own refs on the buffer, so releasing our initial ref here is safe. */
+    evpl_iovec_cursor_init(&plain_cursor, &plain_iov, 1);
+
+    chimera_smb_server_handle_smb2(evpl, thread, conn, &plain_cursor, plain_len, 1);
+
+    evpl_iovec_release(evpl, &plain_iov);
+} /* chimera_smb_server_handle_transform */
 
 static void
 chimera_smb_server_handle_tcp(
@@ -1364,17 +1513,25 @@ chimera_smb_server_handle_tcp(
     evpl_iovec_cursor_init(&request_cursor, iov, niov);
     evpl_iovec_cursor_copy(&request_cursor, &netbios_hdr, sizeof(netbios_hdr));
 
-    if (likely(conn->smbvers == 2)) {
-        chimera_smb_server_handle_smb2(evpl, thread, conn, &request_cursor, length - 4);
-        return;
-    }
-
+    /* Peek the protocol id up front (even on the smbvers==2 fast path): once a
+     * 3.x dialect is negotiated, encrypted TRANSFORM messages (0xFD 'S' 'M' 'B')
+     * can arrive interleaved with plaintext SMB2 (0xFE 'S' 'M' 'B'). */
     peek_cursor = request_cursor;
     evpl_iovec_cursor_get_uint32(&peek_cursor, &smb_hdr);
 
+    if (smb_hdr == 0x424d53fd) {
+        chimera_smb_server_handle_transform(evpl, thread, conn, &request_cursor, length - 4);
+        return;
+    }
+
+    if (likely(conn->smbvers == 2)) {
+        chimera_smb_server_handle_smb2(evpl, thread, conn, &request_cursor, length - 4, 0);
+        return;
+    }
+
     if (smb_hdr == 0x424d53fe) {
         conn->smbvers = 2;
-        chimera_smb_server_handle_smb2(evpl, thread, conn, &request_cursor, length - 4);
+        chimera_smb_server_handle_smb2(evpl, thread, conn, &request_cursor, length - 4, 0);
     } else if (smb_hdr == 0x424d53ff) {
         chimera_smb_server_handle_smb1(evpl, thread, conn, iov, niov, length);
     } else {
@@ -1531,6 +1688,7 @@ chimera_smb_server_thread_init(
     thread->shared      = shared;
     thread->evpl        = evpl;
     thread->signing_ctx = chimera_smb_signing_ctx_create();
+    thread->encrypt_ctx = chimera_smb_encrypt_ctx_create();
 
     chimera_smb_iconv_init(&thread->iconv_ctx);
     chimera_smb_notify_thread_init(thread);
@@ -1610,6 +1768,7 @@ chimera_smb_server_thread_destroy(void *data)
 
     chimera_smb_iconv_destroy(&thread->iconv_ctx);
     chimera_smb_signing_ctx_destroy(thread->signing_ctx);
+    chimera_smb_encrypt_ctx_destroy(thread->encrypt_ctx);
 
     free(thread);
 } /* smb_server_thread_destroy */

--- a/src/server/smb/smb2.h
+++ b/src/server/smb/smb2.h
@@ -570,6 +570,35 @@ struct smb2_header {
     uint8_t  signature[16];
 };
 
+/*
+ * SMB2 TRANSFORM_HEADER (MS-SMB2 §2.2.41) — prepended to an AEAD-encrypted SMB2
+ * message.  The 16-byte signature field holds the AEAD authentication tag; the
+ * AEAD associated data (AAD) is exactly the 32 bytes starting at the nonce
+ * field (offset 20) through the end of the header.  The ciphertext follows the
+ * header and is original_message_size bytes long.
+ */
+struct smb2_transform_header {
+    uint8_t  protocol_id[4]; /* 0xFD 'S' 'M' 'B' */
+    uint8_t  signature[16];  /* AEAD tag */
+    uint8_t  nonce[16];      /* AAD begins here */
+    uint32_t original_message_size;
+    uint16_t reserved;
+    uint16_t flags;          /* 3.1.1: encrypted flag; 3.0.x: encryption algorithm */
+    uint64_t session_id;     /* AAD ends after this field */
+} __attribute__((packed));
+
+_Static_assert(sizeof(struct smb2_transform_header) == 52,
+               "SMB2 TRANSFORM_HEADER must be 52 bytes");
+
+/* TransformHeader.ProtocolId and Flags (MS-SMB2 §2.2.41) */
+#define SMB2_TRANSFORM_PROTO_ID        { 0xFD, 'S', 'M', 'B' }
+#define SMB2_TRANSFORM_FLAGS_ENCRYPTED 0x0001
+
+/* Byte offset and length of the AEAD associated data within the transform
+ * header: from the Nonce field (offset 20) through the end of the header. */
+#define SMB2_TRANSFORM_AAD_OFFSET      20
+#define SMB2_TRANSFORM_AAD_SIZE        32
+
 enum smb2_command {
     SMB2_NEGOTIATE       = 0,
     SMB2_SESSION_SETUP   = 1,
@@ -643,6 +672,11 @@ typedef uint8_t smb2_guid[SMB2_GUID_SIZE];
 #define SMB2_ENCRYPTION_AES_128_GCM                 0x0002
 #define SMB2_ENCRYPTION_AES_256_CCM                 0x0003
 #define SMB2_ENCRYPTION_AES_256_GCM                 0x0004
+
+/* SMB2 SESSION_SETUP response SessionFlags (MS-SMB2 §2.2.6) */
+#define SMB2_SESSION_FLAG_IS_GUEST                  0x0001
+#define SMB2_SESSION_FLAG_IS_NULL                   0x0002
+#define SMB2_SESSION_FLAG_ENCRYPT_DATA              0x0004
 
 /* SMB2_SIGNING_CAPABILITIES Algorithm IDs */
 #define SMB2_SIGNING_HMAC_SHA256                    0x0000

--- a/src/server/smb/smb_encrypt.c
+++ b/src/server/smb/smb_encrypt.c
@@ -1,0 +1,375 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include <string.h>
+#include <stdlib.h>
+#include <openssl/evp.h>
+
+#include "smb_encrypt.h"
+#include "smb_signing.h"
+#include "common/evpl_iovec_cursor.h"
+#include "evpl/evpl.h"
+#include "smb_internal.h"
+#include "smb2.h"
+
+struct chimera_smb_encrypt_ctx {
+    EVP_CIPHER     *aes_128_ccm;
+    EVP_CIPHER     *aes_128_gcm;
+    EVP_CIPHER     *aes_256_ccm;
+    EVP_CIPHER     *aes_256_gcm;
+    EVP_CIPHER_CTX *cctx;
+};
+
+struct chimera_smb_encrypt_ctx *
+chimera_smb_encrypt_ctx_create(void)
+{
+    struct chimera_smb_encrypt_ctx *ctx = calloc(1, sizeof(*ctx));
+
+    if (!ctx) {
+        return NULL;
+    }
+
+    ctx->aes_128_ccm = EVP_CIPHER_fetch(NULL, "AES-128-CCM", NULL);
+    ctx->aes_128_gcm = EVP_CIPHER_fetch(NULL, "AES-128-GCM", NULL);
+    ctx->aes_256_ccm = EVP_CIPHER_fetch(NULL, "AES-256-CCM", NULL);
+    ctx->aes_256_gcm = EVP_CIPHER_fetch(NULL, "AES-256-GCM", NULL);
+
+    chimera_smb_abort_if(!ctx->aes_128_ccm || !ctx->aes_128_gcm ||
+                         !ctx->aes_256_ccm || !ctx->aes_256_gcm,
+                         "Failed to fetch SMB3 AEAD ciphers");
+
+    ctx->cctx = EVP_CIPHER_CTX_new();
+
+    chimera_smb_abort_if(!ctx->cctx, "Failed to allocate SMB3 cipher context");
+
+    return ctx;
+} /* chimera_smb_encrypt_ctx_create */
+
+void
+chimera_smb_encrypt_ctx_destroy(struct chimera_smb_encrypt_ctx *ctx)
+{
+    if (!ctx) {
+        return;
+    }
+    EVP_CIPHER_CTX_free(ctx->cctx);
+    EVP_CIPHER_free(ctx->aes_128_ccm);
+    EVP_CIPHER_free(ctx->aes_128_gcm);
+    EVP_CIPHER_free(ctx->aes_256_ccm);
+    EVP_CIPHER_free(ctx->aes_256_gcm);
+    free(ctx);
+} /* chimera_smb_encrypt_ctx_destroy */
+
+/* Map a negotiated cipher id to its EVP cipher, key length and nonce length. */
+static EVP_CIPHER *
+smb_cipher_for_id(
+    struct chimera_smb_encrypt_ctx *ctx,
+    uint16_t                        cipher_id,
+    size_t                         *key_len,
+    int                            *nonce_len,
+    int                            *is_ccm)
+{
+    switch (cipher_id) {
+        case SMB2_ENCRYPTION_AES_128_CCM:
+            *key_len = 16; *nonce_len = 11; *is_ccm = 1;
+            return ctx->aes_128_ccm;
+        case SMB2_ENCRYPTION_AES_128_GCM:
+            *key_len = 16; *nonce_len = 12; *is_ccm = 0;
+            return ctx->aes_128_gcm;
+        case SMB2_ENCRYPTION_AES_256_CCM:
+            *key_len = 32; *nonce_len = 11; *is_ccm = 1;
+            return ctx->aes_256_ccm;
+        case SMB2_ENCRYPTION_AES_256_GCM:
+            *key_len = 32; *nonce_len = 12; *is_ccm = 0;
+            return ctx->aes_256_gcm;
+        default:
+            return NULL;
+    } /* switch */
+} /* smb_cipher_for_id */
+
+int
+chimera_smb_derive_encryption_keys(
+    int            dialect,
+    uint16_t       cipher_id,
+    const void    *session_key,
+    size_t         session_key_len,
+    const uint8_t *preauth_hash,
+    uint8_t       *enc_key_out,
+    uint8_t       *dec_key_out,
+    size_t        *key_len_out)
+{
+    /* SMB 3.0/3.0.2 KDF labels/contexts (MS-SMB2 §3.1.4.2, pre-3.1.1 branch).
+     * The label is always "SMB2AESCCM" even when GCM is negotiated; the context
+     * "ServerIn " carries a *trailing space*. */
+    static const char label30[]   = "SMB2AESCCM";       /* incl NUL per spec */
+    static const char ctx30_enc[] = "ServerOut";        /* server -> client  */
+    static const char ctx30_dec[] = "ServerIn ";        /* client -> server (trailing space) */
+    /* SMB 3.1.1 labels; context = PreauthIntegrityHashValue. */
+    static const char label311_enc[] = "SMBS2CCipherKey"; /* server -> client */
+    static const char label311_dec[] = "SMBC2SCipherKey"; /* client -> server */
+
+    size_t            key_len;
+    int               nonce_len, is_ccm, ok_e, ok_d;
+
+    (void) nonce_len;
+    (void) is_ccm;
+
+    switch (cipher_id) {
+        case SMB2_ENCRYPTION_AES_128_CCM:
+        case SMB2_ENCRYPTION_AES_128_GCM:
+            key_len = 16;
+            break;
+        case SMB2_ENCRYPTION_AES_256_CCM:
+        case SMB2_ENCRYPTION_AES_256_GCM:
+            key_len = 32;
+            break;
+        default:
+            chimera_smb_error("Unknown SMB3 cipher id 0x%x in key derivation", cipher_id);
+            return -1;
+    } /* switch */
+
+    if (dialect == SMB2_DIALECT_3_1_1) {
+        if (!preauth_hash) {
+            chimera_smb_error("SMB 3.1.1 encryption key derivation without preauth hash");
+            return -1;
+        }
+        ok_e = kdf_counter_hmac_sha256_ossl3(session_key, session_key_len,
+                                             label311_enc, sizeof(label311_enc),
+                                             preauth_hash, SMB2_PREAUTH_HASH_SIZE,
+                                             enc_key_out, key_len);
+        ok_d = kdf_counter_hmac_sha256_ossl3(session_key, session_key_len,
+                                             label311_dec, sizeof(label311_dec),
+                                             preauth_hash, SMB2_PREAUTH_HASH_SIZE,
+                                             dec_key_out, key_len);
+    } else {
+        /* SMB 3.0 / 3.0.2 */
+        ok_e = kdf_counter_hmac_sha256_ossl3(session_key, session_key_len,
+                                             label30, sizeof(label30),
+                                             (const uint8_t *) ctx30_enc, sizeof(ctx30_enc),
+                                             enc_key_out, key_len);
+        ok_d = kdf_counter_hmac_sha256_ossl3(session_key, session_key_len,
+                                             label30, sizeof(label30),
+                                             (const uint8_t *) ctx30_dec, sizeof(ctx30_dec),
+                                             dec_key_out, key_len);
+    }
+
+    if (!ok_e || !ok_d) {
+        chimera_smb_error("SMB3 encryption key derivation failed");
+        return -1;
+    }
+
+    *key_len_out = key_len;
+    return 0;
+} /* chimera_smb_derive_encryption_keys */
+
+/* Lay the 64-bit message counter little-endian into the low bytes of the
+ * cipher nonce; remaining bytes stay zero (MS-SMB2 §3.1.4.3). */
+static void
+smb_build_nonce(
+    uint8_t *nonce16,
+    int      nonce_len,
+    uint64_t counter)
+{
+    memset(nonce16, 0, 16);
+    for (int i = 0; i < 8 && i < nonce_len; i++) {
+        nonce16[i] = (uint8_t) (counter >> (8 * i));
+    }
+} /* smb_build_nonce */
+
+int
+chimera_smb_encrypt_compound(
+    struct chimera_smb_encrypt_ctx *ctx,
+    struct evpl                    *evpl,
+    uint16_t                        cipher_id,
+    const uint8_t                  *key,
+    size_t                          key_len,
+    uint64_t                        nonce_counter,
+    uint64_t                        session_id,
+    struct evpl_iovec              *plain_iov,
+    int                             plain_niov,
+    int                             plain_len,
+    int                             transport_hdr_len,
+    struct evpl_iovec              *out_iov)
+{
+    struct smb2_transform_header *th;
+    struct evpl_iovec_cursor      cursor;
+    EVP_CIPHER                   *cipher;
+    EVP_CIPHER_CTX               *c = ctx->cctx;
+    uint8_t                      *out, *ct;
+    uint8_t                       nonce[16];
+    size_t                        ck_len;
+    int                           nonce_len, is_ccm, outl, total;
+
+    cipher = smb_cipher_for_id(ctx, cipher_id, &ck_len, &nonce_len, &is_ccm);
+
+    if (!cipher || ck_len != key_len) {
+        chimera_smb_error("Invalid cipher/key for SMB3 encryption (id 0x%x)", cipher_id);
+        return -1;
+    }
+
+    total = transport_hdr_len + (int) sizeof(*th) + plain_len;
+
+    if (evpl_iovec_alloc(evpl, total, 8, 1, 0, out_iov) < 1) {
+        chimera_smb_error("Failed to allocate SMB3 encryption output buffer");
+        return -1;
+    }
+
+    out = evpl_iovec_data(out_iov);
+    th  = (struct smb2_transform_header *) (out + transport_hdr_len);
+    ct  = out + transport_hdr_len + sizeof(*th);
+
+    /* Gather the plaintext SMB2 message (skipping the transport framing) into
+     * the output ciphertext region; AEAD encrypts it in place below. */
+    evpl_iovec_cursor_init(&cursor, plain_iov, plain_niov);
+    evpl_iovec_cursor_skip(&cursor, transport_hdr_len);
+    evpl_iovec_cursor_copy(&cursor, ct, plain_len);
+
+    smb_build_nonce(nonce, nonce_len, nonce_counter);
+
+    /* Build the transform header (the Signature field is the AEAD tag, filled
+     * after encryption; bytes [20..52) are the AEAD associated data). */
+    static const uint8_t proto[4] = SMB2_TRANSFORM_PROTO_ID;
+    memcpy(th->protocol_id, proto, 4);
+    memset(th->signature, 0, sizeof(th->signature));
+    memcpy(th->nonce, nonce, sizeof(th->nonce));
+    th->original_message_size = plain_len;
+    th->reserved              = 0;
+    th->flags                 = SMB2_TRANSFORM_FLAGS_ENCRYPTED;
+    th->session_id            = session_id;
+
+    if (EVP_EncryptInit_ex(c, cipher, NULL, NULL, NULL) != 1) {
+        goto err;
+    }
+
+    if (is_ccm) {
+        if (EVP_CIPHER_CTX_ctrl(c, EVP_CTRL_CCM_SET_IVLEN, nonce_len, NULL) != 1 ||
+            EVP_CIPHER_CTX_ctrl(c, EVP_CTRL_CCM_SET_TAG, 16, NULL) != 1 ||
+            EVP_EncryptInit_ex(c, NULL, NULL, key, nonce) != 1 ||
+            /* CCM: declare total plaintext length, then AAD length, up front. */
+            EVP_EncryptUpdate(c, NULL, &outl, NULL, plain_len) != 1 ||
+            EVP_EncryptUpdate(c, NULL, &outl, ((uint8_t *) th) + SMB2_TRANSFORM_AAD_OFFSET,
+                              SMB2_TRANSFORM_AAD_SIZE) != 1 ||
+            EVP_EncryptUpdate(c, ct, &outl, ct, plain_len) != 1 ||
+            EVP_EncryptFinal_ex(c, ct + outl, &outl) != 1 ||
+            EVP_CIPHER_CTX_ctrl(c, EVP_CTRL_CCM_GET_TAG, 16, th->signature) != 1) {
+            goto err;
+        }
+    } else {
+        if (EVP_CIPHER_CTX_ctrl(c, EVP_CTRL_GCM_SET_IVLEN, nonce_len, NULL) != 1 ||
+            EVP_EncryptInit_ex(c, NULL, NULL, key, nonce) != 1 ||
+            EVP_EncryptUpdate(c, NULL, &outl, ((uint8_t *) th) + SMB2_TRANSFORM_AAD_OFFSET,
+                              SMB2_TRANSFORM_AAD_SIZE) != 1 ||
+            EVP_EncryptUpdate(c, ct, &outl, ct, plain_len) != 1 ||
+            EVP_EncryptFinal_ex(c, ct + outl, &outl) != 1 ||
+            EVP_CIPHER_CTX_ctrl(c, EVP_CTRL_GCM_GET_TAG, 16, th->signature) != 1) {
+            goto err;
+        }
+    }
+
+    evpl_iovec_set_length(out_iov, total);
+    return 0;
+
+ err:
+    chimera_smb_error("SMB3 encryption failed (cipher id 0x%x)", cipher_id);
+    evpl_iovec_release(evpl, out_iov);
+    return -1;
+} /* chimera_smb_encrypt_compound */
+
+int
+chimera_smb_decrypt_message(
+    struct chimera_smb_encrypt_ctx *ctx,
+    struct evpl                    *evpl,
+    uint16_t                        cipher_id,
+    const uint8_t                  *key,
+    size_t                          key_len,
+    struct evpl_iovec_cursor       *cursor,
+    int                             length,
+    struct evpl_iovec              *plain_out,
+    int                            *plain_len_out)
+{
+    struct smb2_transform_header th;
+    static const uint8_t         proto[4] = SMB2_TRANSFORM_PROTO_ID;
+    EVP_CIPHER                  *cipher;
+    EVP_CIPHER_CTX              *c = ctx->cctx;
+    uint8_t                     *pt;
+    size_t                       ck_len;
+    int                          nonce_len, is_ccm, outl, ct_len;
+
+    cipher = smb_cipher_for_id(ctx, cipher_id, &ck_len, &nonce_len, &is_ccm);
+
+    if (!cipher || ck_len != key_len) {
+        chimera_smb_error("Invalid cipher/key for SMB3 decryption (id 0x%x)", cipher_id);
+        return -1;
+    }
+
+    if (length < (int) sizeof(th)) {
+        chimera_smb_error("Truncated SMB3 transform message (%d bytes)", length);
+        return -1;
+    }
+
+    evpl_iovec_cursor_copy(cursor, &th, sizeof(th));
+
+    if (memcmp(th.protocol_id, proto, 4) != 0) {
+        chimera_smb_error("Invalid SMB3 transform protocol id");
+        return -1;
+    }
+
+    ct_len = (int) th.original_message_size;
+
+    if (ct_len < (int) sizeof(struct smb2_header) ||
+        ct_len > length - (int) sizeof(th)) {
+        chimera_smb_error("Invalid SMB3 transform original_message_size %d", ct_len);
+        return -1;
+    }
+
+    if (evpl_iovec_alloc(evpl, ct_len, 8, 1, 0, plain_out) < 1) {
+        chimera_smb_error("Failed to allocate SMB3 decryption buffer");
+        return -1;
+    }
+
+    pt = evpl_iovec_data(plain_out);
+
+    /* Gather ciphertext into the output buffer; AEAD decrypts it in place. */
+    evpl_iovec_cursor_copy(cursor, pt, ct_len);
+
+    if (EVP_DecryptInit_ex(c, cipher, NULL, NULL, NULL) != 1) {
+        goto err;
+    }
+
+    if (is_ccm) {
+        if (EVP_CIPHER_CTX_ctrl(c, EVP_CTRL_CCM_SET_IVLEN, nonce_len, NULL) != 1 ||
+            EVP_CIPHER_CTX_ctrl(c, EVP_CTRL_CCM_SET_TAG, 16, th.signature) != 1 ||
+            EVP_DecryptInit_ex(c, NULL, NULL, key, th.nonce) != 1 ||
+            EVP_DecryptUpdate(c, NULL, &outl, NULL, ct_len) != 1 ||
+            EVP_DecryptUpdate(c, NULL, &outl, ((uint8_t *) &th) + SMB2_TRANSFORM_AAD_OFFSET,
+                              SMB2_TRANSFORM_AAD_SIZE) != 1) {
+            goto err;
+        }
+        /* For CCM the ciphertext-processing update returns <=0 on tag failure. */
+        if (EVP_DecryptUpdate(c, pt, &outl, pt, ct_len) <= 0) {
+            goto err;
+        }
+    } else {
+        if (EVP_CIPHER_CTX_ctrl(c, EVP_CTRL_GCM_SET_IVLEN, nonce_len, NULL) != 1 ||
+            EVP_DecryptInit_ex(c, NULL, NULL, key, th.nonce) != 1 ||
+            EVP_DecryptUpdate(c, NULL, &outl, ((uint8_t *) &th) + SMB2_TRANSFORM_AAD_OFFSET,
+                              SMB2_TRANSFORM_AAD_SIZE) != 1 ||
+            EVP_DecryptUpdate(c, pt, &outl, pt, ct_len) != 1 ||
+            EVP_CIPHER_CTX_ctrl(c, EVP_CTRL_GCM_SET_TAG, 16, th.signature) != 1) {
+            goto err;
+        }
+        /* GCM verifies the tag at finalization. */
+        if (EVP_DecryptFinal_ex(c, pt + outl, &outl) <= 0) {
+            goto err;
+        }
+    }
+
+    evpl_iovec_set_length(plain_out, ct_len);
+    *plain_len_out = ct_len;
+    return 0;
+
+ err:
+    chimera_smb_error("SMB3 decryption / tag verification failed (cipher id 0x%x)", cipher_id);
+    evpl_iovec_release(evpl, plain_out);
+    return -1;
+} /* chimera_smb_decrypt_message */

--- a/src/server/smb/smb_encrypt.h
+++ b/src/server/smb/smb_encrypt.h
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#pragma once
+
+struct evpl;
+struct evpl_iovec;
+struct evpl_iovec_cursor;
+struct chimera_smb_encrypt_ctx;
+
+/*
+ * SMB3 transport encryption (MS-SMB2 §3.1.4.3 / §3.3.4.1.4).  Mirrors the
+ * signing context: a per-thread object pre-fetches the AEAD ciphers and holds a
+ * reusable EVP_CIPHER_CTX (which is NOT thread-safe, hence per-thread).
+ */
+struct chimera_smb_encrypt_ctx *
+chimera_smb_encrypt_ctx_create(
+    void);
+
+void
+chimera_smb_encrypt_ctx_destroy(
+    struct chimera_smb_encrypt_ctx *ctx);
+
+/*
+ * Derive the per-session encryption (server->client) and decryption
+ * (client->server) keys from the raw NTLM/GSSAPI session key.  cipher_id is the
+ * negotiated SMB2_ENCRYPTION_* id and selects the key length (16 or 32 bytes).
+ * preauth_hash (64 bytes) is required for SMB 3.1.1, ignored otherwise.
+ * Returns 0 on success, -1 on failure.
+ */
+int
+chimera_smb_derive_encryption_keys(
+    int            dialect,
+    uint16_t       cipher_id,
+    const void    *session_key,
+    size_t         session_key_len,
+    const uint8_t *preauth_hash,
+    uint8_t       *enc_key_out,
+    uint8_t       *dec_key_out,
+    size_t        *key_len_out);
+
+/*
+ * Encrypt an assembled plaintext SMB2 reply.  plain_iov/plain_niov describe the
+ * full reply buffer whose first transport_hdr_len bytes are the (unencrypted)
+ * transport framing; plain_len is the SMB2 message length that follows it.
+ * Produces a single contiguous out_iov laid out as
+ *   [transport_hdr_len bytes reserved][52-byte TRANSFORM header][ciphertext],
+ * with the AEAD tag written into the transform Signature field.  The caller
+ * fills the reserved transport header and sends out_iov.  Returns 0 on success.
+ */
+int
+chimera_smb_encrypt_compound(
+    struct chimera_smb_encrypt_ctx *ctx,
+    struct evpl                    *evpl,
+    uint16_t                        cipher_id,
+    const uint8_t                  *key,
+    size_t                          key_len,
+    uint64_t                        nonce_counter,
+    uint64_t                        session_id,
+    struct evpl_iovec              *plain_iov,
+    int                             plain_niov,
+    int                             plain_len,
+    int                             transport_hdr_len,
+    struct evpl_iovec              *out_iov);
+
+/*
+ * Decrypt a TRANSFORM message.  cursor is positioned at the transform header
+ * (immediately after the 4-byte NetBIOS framing); length is the transform
+ * header plus ciphertext byte count.  cipher_id/key/key_len come from the
+ * session named by the transform header's SessionId (the caller looks it up).
+ * On success allocates plain_out (caller must evpl_iovec_release it) holding the
+ * decrypted SMB2 message, sets *plain_len_out, and returns 0.  On a malformed
+ * header or AEAD tag-verification failure returns -1 (nothing allocated).
+ */
+int
+chimera_smb_decrypt_message(
+    struct chimera_smb_encrypt_ctx *ctx,
+    struct evpl                    *evpl,
+    uint16_t                        cipher_id,
+    const uint8_t                  *key,
+    size_t                          key_len,
+    struct evpl_iovec_cursor       *cursor,
+    int                             length,
+    struct evpl_iovec              *plain_out,
+    int                            *plain_len_out);

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -118,6 +118,13 @@ struct chimera_smb_config {
     int                            soft_fail_bad_req;
     int                            persistent_handles;
     int                            named_streams;
+    /* When set, the server advertises signing as mandatory
+     * (SMB2_SIGNING_REQUIRED) in NEGOTIATE and FSCTL_VALIDATE_NEGOTIATE_INFO,
+     * so conforming clients sign every request. */
+    int                            signing_required;
+    /* SMB3 transport encryption policy: 0 = off (no encryption advertised),
+     * 1 = enabled (offered, used when the client opts in), 2 = required. */
+    int                            encryption;
     uint32_t                       capabilities;
     uint32_t                       dialects[16];
     struct chimera_smb_nic_info    nic_info[16];
@@ -617,6 +624,9 @@ struct chimera_smb_request {
 struct chimera_smb_compound {
     int                                num_requests;
     int                                complete_requests;
+    /* Set when this compound arrived wrapped in a TRANSFORM header; its reply
+     * MUST then be encrypted (MS-SMB2 §3.3.4.1.4). */
+    int                                received_encrypted;
     uint64_t                           saved_session_id;
     uint64_t                           saved_tree_id;
     struct chimera_smb_file_id         saved_file_id;
@@ -632,6 +642,10 @@ struct chimera_smb_session_handle {
     uint64_t                           session_id;
     struct chimera_smb_session        *session;
     uint8_t                            signing_key[16];
+    uint8_t                            enc_key[32];
+    uint8_t                            dec_key[32];
+    size_t                             enc_key_len;
+    uint16_t                           cipher_id;
     struct UT_hash_handle              hh;
     struct chimera_smb_session_handle *next;
     gss_ctx_id_t                       ctx;
@@ -926,6 +940,7 @@ struct chimera_server_smb_thread {
     struct chimera_smb_session_handle  *free_session_handles;
     struct chimera_smb_open_file       *free_open_files;
     struct chimera_smb_signing_ctx     *signing_ctx;
+    struct chimera_smb_encrypt_ctx     *encrypt_ctx;
     struct chimera_smb_iconv_ctx        iconv_ctx;
 
     /* Notify doorbell: VFS callbacks push ready notify requests here,
@@ -1057,9 +1072,16 @@ chimera_smb_session_alloc(struct chimera_server_smb_shared *shared)
         pthread_mutex_init(&session->lock, NULL);
     }
 
-    session->session_id = chimera_rand64();
-    session->flags      = 0;
-    session->refcnt     = 1;
+    /* Keep the session id within 32 bits (non-zero).  The wire field is 64
+     * bits, but Windows/Samba hand out small ids and some clients (and the
+     * smb2.session-id torture test) round-trip the id through a uint32_t.  A
+     * full 64-bit random id would be silently truncated by such clients and
+     * then fail to match on the next request. */
+    do {
+        session->session_id = chimera_rand64() & 0xFFFFFFFFULL;
+    } while (session->session_id == 0);
+    session->flags  = 0;
+    session->refcnt = 1;
 
     pthread_mutex_unlock(&shared->sessions_lock);
 

--- a/src/server/smb/smb_notify.c
+++ b/src/server/smb/smb_notify.c
@@ -320,6 +320,7 @@ chimera_smb_notify_send_interim(struct chimera_smb_notify_request *nr)
     if (nr->signed_session) {
         chimera_smb_sign_message(nr->thread->signing_ctx,
                                  nr->conn->dialect,
+                                 nr->conn->negotiated.signing_alg,
                                  nr->signing_key,
                                  buf + 4,
                                  smb2_len);
@@ -565,6 +566,7 @@ chimera_smb_notify_send_response(struct chimera_smb_notify_request *nr)
     if (nr->signed_session) {
         chimera_smb_sign_message(nr->thread->signing_ctx,
                                  nr->conn->dialect,
+                                 nr->conn->negotiated.signing_alg,
                                  nr->signing_key,
                                  buf + 4,
                                  smb2_len);
@@ -673,6 +675,7 @@ chimera_smb_notify_cancel(struct chimera_smb_notify_request *nr)
     if (nr->signed_session) {
         chimera_smb_sign_message(nr->thread->signing_ctx,
                                  nr->conn->dialect,
+                                 nr->conn->negotiated.signing_alg,
                                  nr->signing_key,
                                  buf + 4,
                                  smb2_len);

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -1089,8 +1089,14 @@ chimera_smb_create_check_access(
      * the file-open level here -- doing so would wrongly deny an owner removing
      * a child whose inherited ACL omits DELETE.  (Full parent DELETE_CHILD
      * evaluation is a follow-up.) */
+    /* SYNCHRONIZE is not a meaningful open-time access gate: Windows includes it
+     * in every generic right and clients request it on essentially every open,
+     * so it is always grantable on a successful open.  Treat it like
+     * MAXIMUM_ALLOWED and do not require an explicit ACE for it (otherwise a
+     * plain mode-derived object such as a freshly mounted share root, whose
+     * synthesised ACEs carry no SYNCHRONIZE bit, would deny every open). */
     req = da & ~(SMB2_MAXIMUM_ALLOWED | SMB2_ACCESS_SYSTEM_SECURITY |
-                 SMB2_DELETE |
+                 SMB2_DELETE | SMB2_SYNCHRONIZE |
                  SMB2_GENERIC_READ | SMB2_GENERIC_WRITE |
                  SMB2_GENERIC_EXECUTE | SMB2_GENERIC_ALL);
 

--- a/src/server/smb/smb_proc_ioctl.c
+++ b/src/server/smb/smb_proc_ioctl.c
@@ -89,8 +89,14 @@ chimera_smb_ioctl(struct chimera_smb_request *request)
 
             request->ioctl.r_capabilities = conn->capabilities;
             memcpy(request->ioctl.r_guid, shared->guid, 16);
+            /* Must echo the SecurityMode advertised in NEGOTIATE; a mismatch
+             * looks like a downgrade attack and the client drops the
+             * connection (MS-SMB2 3.3.5.15.12). */
             request->ioctl.r_security_mode = SMB2_SIGNING_ENABLED;
-            request->ioctl.r_dialect       = conn->dialect;
+            if (shared->config.signing_required) {
+                request->ioctl.r_security_mode |= SMB2_SIGNING_REQUIRED;
+            }
+            request->ioctl.r_dialect = conn->dialect;
 
             chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
             break;

--- a/src/server/smb/smb_proc_negotiate.c
+++ b/src/server/smb/smb_proc_negotiate.c
@@ -110,13 +110,25 @@ chimera_smb_negotiate(struct chimera_smb_request *request)
     if (dialect >= 0x300 && shared->config.persistent_handles) {
         conn->capabilities |= SMB2_GLOBAL_CAP_PERSISTENT_HANDLES;
     }
+    /* Encryption is advertised via SMB2_GLOBAL_CAP_ENCRYPTION for 3.0/3.0.2;
+     * for 3.1.1 it is negotiated through the encryption-capabilities context
+     * instead and the capability bit MUST NOT be set (MS-SMB2 §3.3.5.4). */
+    if (dialect >= 0x300 && dialect < 0x311 && shared->config.encryption) {
+        conn->capabilities |= SMB2_GLOBAL_CAP_ENCRYPTION;
+    }
 
     if (request->negotiate.security_mode & SMB2_SIGNING_REQUIRED) {
         conn->flags |= CHIMERA_SMB_CONN_FLAG_SIGNING_REQUIRED;
     }
 
-    request->negotiate.r_dialect           = dialect;
-    request->negotiate.r_security_mode     = SMB2_SIGNING_ENABLED;
+    request->negotiate.r_dialect       = dialect;
+    request->negotiate.r_security_mode = SMB2_SIGNING_ENABLED;
+    if (shared->config.signing_required) {
+        /* Server signing = mandatory: advertise REQUIRED so clients sign
+         * every request (smb2.session-require-signing / bug15397). */
+        request->negotiate.r_security_mode |= SMB2_SIGNING_REQUIRED;
+        conn->flags                        |= CHIMERA_SMB_CONN_FLAG_SIGNING_REQUIRED;
+    }
     request->negotiate.r_capabilities      = conn->capabilities;
     request->negotiate.r_max_transact_size = CHIMERA_SMB_MAX_TRANSACT_SIZE;
     request->negotiate.r_max_read_size     = 8 * 1024 * 1024;
@@ -249,7 +261,10 @@ build_signing_capabilities_response(
 {
     (void) request;
 
-    if (conn->negotiated.signing_alg == 0 || out_size < 4) {
+    /* Only emitted when the client sent a SIGNING_CAPABILITIES context (the
+     * emitter table gates on that), so echo the selected algorithm — including
+     * HMAC-SHA256, whose id is 0. */
+    if (out_size < 4) {
         return -1;
     }
 
@@ -760,32 +775,55 @@ chimera_smb_select_negotiated_algorithms(
         }
     }
 
-    if (conn->dialect == SMB2_DIALECT_3_1_1 &&
-        (request->negotiate.ctx_present_mask & CHIMERA_SMB_NEGOTIATE_CTX_SIGNING)) {
-        int i;
+    /* The 3.1.1 default signing algorithm is AES-128-CMAC (MS-SMB2 §3.3.5.4);
+     * negotiated.signing_alg always holds the effective algorithm (note that
+     * HMAC-SHA256 has id 0, so a separate default avoids any 0-as-unset
+     * ambiguity in the signing dispatch). */
+    if (conn->dialect == SMB2_DIALECT_3_1_1) {
+        conn->negotiated.signing_alg = SMB2_SIGNING_AES_CMAC;
 
-        for (i = 0; i < request->negotiate.signing_in.alg_count; i++) {
-            if (request->negotiate.signing_in.algs[i] == SMB2_SIGNING_AES_CMAC) {
-                conn->negotiated.signing_alg = SMB2_SIGNING_AES_CMAC;
-                break;
+        if (request->negotiate.ctx_present_mask & CHIMERA_SMB_NEGOTIATE_CTX_SIGNING) {
+            /* Server preference order; all three are implemented
+             * (smb_signing.c).  Pick the highest-preference algorithm the
+             * client offered. */
+            static const uint16_t preferred[] = {
+                SMB2_SIGNING_AES_GMAC,
+                SMB2_SIGNING_AES_CMAC,
+                SMB2_SIGNING_HMAC_SHA256,
+            };
+            int                   i, j, found = 0;
+
+            for (i = 0; i < (int) (sizeof(preferred) / sizeof(preferred[0])) && !found; i++) {
+                for (j = 0; j < request->negotiate.signing_in.alg_count; j++) {
+                    if (request->negotiate.signing_in.algs[j] == preferred[i]) {
+                        conn->negotiated.signing_alg = preferred[i];
+                        found                        = 1;
+                        break;
+                    }
+                }
+            }
+
+            /* Client offered only algorithms we do not support: do not echo a
+             * SIGNING_CAPABILITIES context, and fall back to the CMAC default
+             * (which the client also defaults to when it sees no echo). */
+            if (!found) {
+                conn->negotiated.ctx_present_mask &= ~CHIMERA_SMB_NEGOTIATE_CTX_SIGNING;
             }
         }
     }
 
     /* SMB 3.1.1: when the client offers an ENCRYPTION_CAPABILITIES context, the
      * server MUST select a cipher and echo it back in the response context (or
-     * return AES-128-CCM as a default per MS-SMB2 3.3.5.4). The selected cipher
-     * is NOT used to actually encrypt traffic here — encryption is only ever
-     * activated when the server also advertises SMB2_GLOBAL_CAP_ENCRYPTION or
-     * sets SMB2_SESSION_FLAG_ENCRYPT_DATA, neither of which Chimera does.
+     * return AES-128-CCM as a default per MS-SMB2 3.3.5.4).
      *
-     * Selecting a cipher is nonetheless required for protocol correctness: a
-     * Samba client (smbtorture) records Connection.CipherId from this context
-     * and uses it to size the per-session AEAD nonce space.  Leaving CipherId
-     * at 0 makes the client compute a zero nonce-space, and a later
-     * shallow-copy of the session (smb2.compound.related1, durable-open,
-     * replay) then aborts — crashing the client.  Echo a chosen cipher so the
-     * client's session bookkeeping is well-formed. */
+     * We select the cipher here unconditionally (even when encryption is
+     * disabled in config), because a Samba client (smbtorture) records
+     * Connection.CipherId from this context and uses it to size the per-session
+     * AEAD nonce space.  Leaving CipherId at 0 makes the client compute a zero
+     * nonce-space, and a later shallow-copy of the session
+     * (smb2.compound.related1, durable-open, replay) then aborts — crashing the
+     * client.  Whether traffic is actually encrypted is decided separately at
+     * SESSION_SETUP, gated on shared->config.encryption. */
     if (conn->dialect == SMB2_DIALECT_3_1_1 &&
         (request->negotiate.ctx_present_mask & CHIMERA_SMB_NEGOTIATE_CTX_ENCRYPTION)) {
         static const uint16_t preferred[] = {
@@ -805,6 +843,13 @@ chimera_smb_select_negotiated_algorithms(
                 }
             }
         }
+    } else if (conn->dialect >= SMB2_DIALECT_3_0 &&
+               conn->dialect < SMB2_DIALECT_3_1_1 &&
+               conn->thread->shared->config.encryption) {
+        /* SMB 3.0/3.0.2 has no encryption-capabilities context; the only cipher
+         * is AES-128-CCM (MS-SMB2 §3.1.4.3).  Set it so SESSION_SETUP can derive
+         * keys when encryption is enabled. */
+        conn->negotiated.cipher_id = SMB2_ENCRYPTION_AES_128_CCM;
     }
 } /* chimera_smb_select_negotiated_algorithms */
 

--- a/src/server/smb/smb_proc_session_setup.c
+++ b/src/server/smb/smb_proc_session_setup.c
@@ -5,6 +5,7 @@
 #include "smb_internal.h"
 #include "smb_procs.h"
 #include "smb_signing.h"
+#include "smb_encrypt.h"
 #include "smb_auth.h"
 #include "smb_wbclient.h"
 #include "vfs/vfs.h"
@@ -173,6 +174,13 @@ chimera_smb_session_setup(struct chimera_smb_request *request)
         int         is_ad_user = 0;
         char        sid_buf[SMB_WBCLIENT_SID_MAX_LEN];
 
+        /* Raw session key saved for SMB3 encryption key derivation below; an
+         * anonymous/guest (null) session has no usable key and is never
+         * encrypted. */
+        uint8_t     session_key_saved[32];
+        size_t      session_key_saved_len = 0;
+        int         is_anonymous          = 0;
+
         if (mech == SMB_AUTH_MECH_NTLM) {
             uint8_t session_key[SMB_NTLM_SESSION_KEY_SIZE];
 
@@ -183,6 +191,8 @@ chimera_smb_session_setup(struct chimera_smb_request *request)
                                                SMB_NTLM_SESSION_KEY_SIZE,
                                                conn->dialect == SMB2_DIALECT_3_1_1 ?
                                                conn->preauth_hash : NULL);
+                memcpy(session_key_saved, session_key, SMB_NTLM_SESSION_KEY_SIZE);
+                session_key_saved_len = SMB_NTLM_SESSION_KEY_SIZE;
             }
 
             uid        = smb_ntlm_get_uid(&conn->ntlm_ctx);
@@ -216,6 +226,8 @@ chimera_smb_session_setup(struct chimera_smb_request *request)
                                                SMB_GSSAPI_SESSION_KEY_SIZE,
                                                conn->dialect == SMB2_DIALECT_3_1_1 ?
                                                conn->preauth_hash : NULL);
+                memcpy(session_key_saved, session_key, SMB_GSSAPI_SESSION_KEY_SIZE);
+                session_key_saved_len = SMB_GSSAPI_SESSION_KEY_SIZE;
             }
 
             // Map Kerberos principal to Unix credentials via winbind
@@ -264,8 +276,39 @@ chimera_smb_session_setup(struct chimera_smb_request *request)
         // Set session credentials
         chimera_vfs_cred_init_attr(&session->cred, uid, gid, ngids, gids);
 
+        /* SMB3 transport encryption: derive per-session keys from the raw
+         * session key.  Skipped for anonymous/guest (null) sessions, which have
+         * no usable key and are never encrypted (MS-SMB2 §3.3.5.5.3). */
+        if (shared->config.encryption &&
+            conn->negotiated.cipher_id != 0 &&
+            conn->dialect >= SMB2_DIALECT_3_0 &&
+            session_key_saved_len > 0 &&
+            !is_anonymous) {
+            size_t klen = 0;
+
+            if (chimera_smb_derive_encryption_keys(
+                    conn->dialect, conn->negotiated.cipher_id,
+                    session_key_saved, session_key_saved_len,
+                    conn->dialect == SMB2_DIALECT_3_1_1 ? conn->preauth_hash : NULL,
+                    session_handle->enc_key, session_handle->dec_key, &klen) == 0) {
+                session_handle->enc_key_len = klen;
+                session_handle->cipher_id   = conn->negotiated.cipher_id;
+                session->flags             |= CHIMERA_SMB_SESSION_ENCRYPT_DATA;
+            }
+        }
+
         if (!(session->flags & CHIMERA_SMB_SESSION_AUTHORIZED)) {
             memcpy(session->signing_key, session_handle->signing_key, sizeof(session_handle->signing_key));
+            if (session->flags & CHIMERA_SMB_SESSION_ENCRYPT_DATA) {
+                memcpy(session->enc_key, session_handle->enc_key, sizeof(session->enc_key));
+                memcpy(session->dec_key, session_handle->dec_key, sizeof(session->dec_key));
+                session->enc_key_len = session_handle->enc_key_len;
+                session->cipher_id   = session_handle->cipher_id;
+                /* Seed the server's monotonic per-session nonce counter.  It is
+                 * never reset for the session's lifetime; reusing a GCM nonce
+                 * would be catastrophic. */
+                atomic_store(&session->enc_nonce_counter, 1);
+            }
             chimera_smb_session_authorize(shared, session);
         }
 
@@ -315,10 +358,18 @@ chimera_smb_session_setup_reply(
     struct chimera_smb_conn *conn                   = request->compound->conn;
     uint16_t                 security_buffer_offset = sizeof(struct smb2_header) + 8;
     uint16_t                 security_buffer_length = conn->ntlm_output_len;
+    uint16_t                 session_flags          = 0;
+
+    /* SessionFlags (MS-SMB2 §2.2.6): advertise per-session encryption so the
+     * client encrypts subsequent requests on this session. */
+    if (request->session_handle &&
+        (request->session_handle->session->flags & CHIMERA_SMB_SESSION_ENCRYPT_DATA)) {
+        session_flags |= SMB2_SESSION_FLAG_ENCRYPT_DATA;
+    }
 
     evpl_iovec_cursor_append_uint16(reply_cursor, SMB2_SESSION_SETUP_REPLY_SIZE);
 
-    evpl_iovec_cursor_append_uint16(reply_cursor, 0);
+    evpl_iovec_cursor_append_uint16(reply_cursor, session_flags);
 
     evpl_iovec_cursor_append_uint16(reply_cursor, security_buffer_offset);
 

--- a/src/server/smb/smb_session.h
+++ b/src/server/smb/smb_session.h
@@ -6,6 +6,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <stdatomic.h>
 #include <pthread.h>
 #include <uthash.h>
 
@@ -179,12 +180,13 @@ struct chimera_smb_tree {
     uint8_t                       fh[CHIMERA_VFS_FH_SIZE];
 };
 
-#define CHIMERA_SMB_SESSION_AUTHORIZED 0x1
+#define CHIMERA_SMB_SESSION_AUTHORIZED   0x1
 /* The session was closed out from under its connection by a SESSION_SETUP that
  * named it in PreviousSessionId (MS-SMB2 3.3.5.5.3).  It is unlinked from the
  * global table but kept alive while its original connection still references it;
  * requests arriving on that connection are answered STATUS_USER_SESSION_DELETED. */
-#define CHIMERA_SMB_SESSION_DELETED    0x2
+#define CHIMERA_SMB_SESSION_DELETED      0x2
+#define CHIMERA_SMB_SESSION_ENCRYPT_DATA 0x4
 
 struct chimera_smb_session {
     uint64_t                    session_id;
@@ -199,6 +201,17 @@ struct chimera_smb_session {
 
     int                         max_trees;
     uint8_t                     signing_key[16];
+
+    /* SMB3 transport encryption (set when CHIMERA_SMB_SESSION_ENCRYPT_DATA).
+     * enc_key encrypts server->client responses; dec_key decrypts
+     * client->server requests.  enc_nonce_counter is the server's strictly
+     * monotonic per-session message counter (never reused for a key — GCM nonce
+     * reuse is catastrophic), shared across all channels of the session. */
+    uint8_t                     enc_key[32];
+    uint8_t                     dec_key[32];
+    size_t                      enc_key_len;
+    uint16_t                    cipher_id;
+    _Atomic uint64_t            enc_nonce_counter;
 
     struct chimera_vfs_cred     cred;
 };

--- a/src/server/smb/smb_signing.c
+++ b/src/server/smb/smb_signing.c
@@ -15,8 +15,9 @@
 #include "smb2.h"
 
 struct chimera_smb_signing_ctx {
-    EVP_MAC *hmac_mac;
-    EVP_MAC *cmac_mac;
+    EVP_MAC    *hmac_mac;
+    EVP_MAC    *cmac_mac;
+    EVP_CIPHER *gcm;        /* AES-128-GCM, used as GMAC for AES-128-GMAC signing */
 };
 
 struct chimera_smb_signing_ctx *
@@ -36,6 +37,10 @@ chimera_smb_signing_ctx_create(void)
 
     chimera_smb_abort_if(!ctx->cmac_mac, "Failed to fetch CMAC MAC");
 
+    ctx->gcm = EVP_CIPHER_fetch(NULL, "AES-128-GCM", NULL);
+
+    chimera_smb_abort_if(!ctx->gcm, "Failed to fetch AES-128-GCM cipher");
+
     return ctx;
 } /* chimera_smb_signing_ctx_new */
 
@@ -44,6 +49,7 @@ chimera_smb_signing_ctx_destroy(struct chimera_smb_signing_ctx *ctx)
 {
     EVP_MAC_free(ctx->hmac_mac);
     EVP_MAC_free(ctx->cmac_mac);
+    EVP_CIPHER_free(ctx->gcm);
     free(ctx);
 } /* chimera_smb_signing_ctx_destroy */
 
@@ -343,6 +349,142 @@ chimera_smb_request_cmac_aes_128_cbc(
     return ok;
 }   // evpl_iovec_cursor_cmac_aes_128_cbc
 
+/*
+ * AES-128-GMAC over the SMB2 message (MS-SMB2 §3.1.4.1).  GMAC is AES-128-GCM
+ * used purely as a MAC: the entire message is fed as associated data with no
+ * plaintext, and the 16-byte authentication tag is the signature.
+ *
+ * The 12-byte IV is the 64-bit MessageId followed by a 32-bit value carrying
+ * the SERVER_TO_REDIR flag (and ASYNC for CANCEL).  The associated data is the
+ * SMB2 header with its signature field zeroed, followed by the message body —
+ * identical to feeding the full 64-byte header (signature already zero) plus
+ * the body, which is how the HMAC/CMAC paths above operate.
+ */
+static inline int
+chimera_smb_request_gmac_aes_128(
+    struct chimera_smb_signing_ctx *ctx,
+    struct smb2_header             *hdr,
+    struct evpl_iovec_cursor       *cursor,
+    int                             length,
+    const uint8_t                  *key,
+    size_t                          keylen,
+    uint8_t                        *out_sig16)
+{
+    int             ok = -1, chunk, left = length, outl;
+    EVP_CIPHER_CTX *c = NULL;
+    uint8_t         iv[12];
+    uint32_t        high_bits;
+
+    high_bits = hdr->flags & SMB2_FLAGS_SERVER_TO_REDIR;
+    if (hdr->command == SMB2_CANCEL) {
+        high_bits |= SMB2_FLAGS_ASYNC_COMMAND;
+    }
+
+    memset(iv, 0, sizeof(iv));
+    memcpy(iv, &hdr->message_id, 8);   /* MessageId, little-endian on host */
+    iv[8]  = (uint8_t) (high_bits & 0xff);
+    iv[9]  = (uint8_t) ((high_bits >> 8) & 0xff);
+    iv[10] = (uint8_t) ((high_bits >> 16) & 0xff);
+    iv[11] = (uint8_t) ((high_bits >> 24) & 0xff);
+
+    c = EVP_CIPHER_CTX_new();
+    if (!c) {
+        goto done;
+    }
+
+    if (EVP_EncryptInit_ex(c, ctx->gcm, NULL, NULL, NULL) != 1 ||
+        EVP_CIPHER_CTX_ctrl(c, EVP_CTRL_GCM_SET_IVLEN, sizeof(iv), NULL) != 1 ||
+        EVP_EncryptInit_ex(c, NULL, NULL, key, iv) != 1) {
+        goto done;
+    }
+
+    if (keylen < 16) {
+        goto done;
+    }
+
+    /* AAD: the 64-byte header (signature field zero) ... */
+    if (EVP_EncryptUpdate(c, NULL, &outl, (uint8_t *) hdr, sizeof(*hdr)) != 1) {
+        goto done;
+    }
+
+    /* ... followed by the message body. */
+    while (left && cursor->niov) {
+
+        chunk = cursor->iov->length - cursor->offset;
+
+        if (left < chunk) {
+            chunk = left;
+        }
+
+        if (EVP_EncryptUpdate(c, NULL, &outl, cursor->iov->data + cursor->offset, chunk) != 1) {
+            goto done;
+        }
+
+        left             -= chunk;
+        cursor->offset   += chunk;
+        cursor->consumed += chunk;
+
+        if (cursor->offset == cursor->iov->length) {
+            cursor->iov++;
+            cursor->niov--;
+            cursor->offset = 0;
+        }
+    }
+
+    if (left) {
+        goto done;
+    }
+
+    if (EVP_EncryptFinal_ex(c, NULL, &outl) != 1 ||
+        EVP_CIPHER_CTX_ctrl(c, EVP_CTRL_GCM_GET_TAG, 16, out_sig16) != 1) {
+        goto done;
+    }
+
+    ok = 0;
+
+ done:
+    if (c) {
+        EVP_CIPHER_CTX_free(c);
+    }
+    return ok;
+} /* chimera_smb_request_gmac_aes_128 */
+
+/*
+ * Compute the SMB2 signature for a message using the algorithm negotiated for
+ * the connection: HMAC-SHA256 for 2.x, AES-128-CMAC for 3.0/3.0.2, and the
+ * SMB 3.1.1 negotiated signing algorithm (GMAC / CMAC / HMAC-SHA256) for 3.1.1.
+ */
+static int
+chimera_smb_compute_signature(
+    struct chimera_smb_signing_ctx *ctx,
+    struct chimera_smb_conn        *conn,
+    struct smb2_header             *hdr,
+    struct evpl_iovec_cursor       *cursor,
+    int                             length,
+    const uint8_t                  *key,
+    uint8_t                        *out_sig16)
+{
+    switch (conn->dialect) {
+        case SMB2_DIALECT_2_0_2:
+        case SMB2_DIALECT_2_1:
+            return chimera_smb_request_hmac_sha256(ctx, hdr, cursor, length, key, 16, out_sig16);
+        case SMB2_DIALECT_3_0:
+        case SMB2_DIALECT_3_0_2:
+            return chimera_smb_request_cmac_aes_128_cbc(ctx, hdr, cursor, length, key, 16, out_sig16);
+        case SMB2_DIALECT_3_1_1:
+            switch (conn->negotiated.signing_alg) {
+                case SMB2_SIGNING_AES_GMAC:
+                    return chimera_smb_request_gmac_aes_128(ctx, hdr, cursor, length, key, 16, out_sig16);
+                case SMB2_SIGNING_HMAC_SHA256:
+                    return chimera_smb_request_hmac_sha256(ctx, hdr, cursor, length, key, 16, out_sig16);
+                default:
+                    return chimera_smb_request_cmac_aes_128_cbc(ctx, hdr, cursor, length, key, 16, out_sig16);
+            } /* switch */
+        default:
+            return -1;
+    } /* switch */
+} /* chimera_smb_compute_signature */
+
 int
 chimera_smb_verify_signature(
     struct chimera_smb_signing_ctx *ctx,
@@ -361,44 +503,13 @@ chimera_smb_verify_signature(
     memcpy(&signature, &request->smb2_hdr.signature, sizeof(signature));
     memset(request->smb2_hdr.signature, 0, sizeof(request->smb2_hdr.signature));
 
-    switch (conn->dialect) {
-        case SMB2_DIALECT_2_0_2:
-        case SMB2_DIALECT_2_1:
-            rc = chimera_smb_request_hmac_sha256(
-                ctx,
-                &request->smb2_hdr,
-                cursor,
-                length,
-                signing_key,
-                16,
-                calculated);
+    rc = chimera_smb_compute_signature(ctx, conn, &request->smb2_hdr, cursor,
+                                       length, signing_key, calculated);
 
-            if (unlikely(rc != 0)) {
-                chimera_smb_error("Failed to calculate sha256 signature");
-                return rc;
-            }
-            break;
-        case SMB2_DIALECT_3_0:
-        case SMB2_DIALECT_3_0_2:
-        case SMB2_DIALECT_3_1_1:
-            rc = chimera_smb_request_cmac_aes_128_cbc(
-                ctx,
-                &request->smb2_hdr,
-                cursor,
-                length,
-                signing_key,
-                16,
-                calculated);
-
-            if (unlikely(rc != 0)) {
-                chimera_smb_error("Failed to calculate cmac_aes_128_cbc signature");
-                return rc;
-            }
-            break;
-        default:
-            chimera_smb_error("Signed messages with unsupported dialect %x", conn->dialect);
-            return -1;
-    } /* switch */
+    if (unlikely(rc != 0)) {
+        chimera_smb_error("Failed to calculate signature for dialect %x", conn->dialect);
+        return rc;
+    }
 
     if (unlikely(memcmp(signature, calculated, sizeof(signature)) != 0)) {
         format_hex(recv_sig, sizeof(recv_sig), signature, sizeof(signature));
@@ -485,45 +596,15 @@ chimera_smb_sign_compound(
              * mishandles channel/session setup and can crash it). */
             hdr->flags |= SMB2_FLAGS_SIGNED;
 
-            switch (conn->dialect) {
-                case SMB2_DIALECT_2_0_2:
-                case SMB2_DIALECT_2_1:
+            rc = chimera_smb_compute_signature(ctx, conn, hdr, &cursor,
+                                               payload_length,
+                                               session_handle->signing_key,
+                                               signature);
 
-                    rc = chimera_smb_request_hmac_sha256(
-                        ctx,
-                        hdr,
-                        &cursor,
-                        payload_length,
-                        session_handle->signing_key,
-                        16,
-                        signature);
-
-                    if (unlikely(rc != 0)) {
-                        chimera_smb_error("Failed to calculate signature");
-                        return rc;
-                    }
-                    break;
-                case SMB2_DIALECT_3_0:
-                case SMB2_DIALECT_3_0_2:
-                case SMB2_DIALECT_3_1_1:
-                    rc = chimera_smb_request_cmac_aes_128_cbc(
-                        ctx,
-                        hdr,
-                        &cursor,
-                        payload_length,
-                        session_handle->signing_key,
-                        16,
-                        signature);
-
-                    if (unlikely(rc != 0)) {
-                        chimera_smb_error("Failed to calculate signature");
-                        return rc;
-                    }
-                    break;
-                default:
-                    chimera_smb_error("Unsupported dialect for signing %x", conn->dialect);
-                    return -1;
-            } /* switch */
+            if (unlikely(rc != 0)) {
+                chimera_smb_error("Failed to calculate signature for dialect %x", conn->dialect);
+                return rc;
+            }
 
             memcpy(hdr->signature, signature, sizeof(signature));
         } else {
@@ -553,6 +634,7 @@ int
 chimera_smb_sign_message(
     struct chimera_smb_signing_ctx *ctx,
     int                             dialect,
+    int                             signing_alg,
     const uint8_t                  *signing_key,
     uint8_t                        *smb2_buf,
     int                             smb2_len)
@@ -584,10 +666,28 @@ chimera_smb_sign_message(
             break;
         case SMB2_DIALECT_3_0:
         case SMB2_DIALECT_3_0_2:
-        case SMB2_DIALECT_3_1_1:
             rc = chimera_smb_request_cmac_aes_128_cbc(ctx, hdr, &cursor,
                                                       body_len,
                                                       signing_key, 16, signature);
+            break;
+        case SMB2_DIALECT_3_1_1:
+            switch (signing_alg) {
+                case SMB2_SIGNING_AES_GMAC:
+                    rc = chimera_smb_request_gmac_aes_128(ctx, hdr, &cursor,
+                                                          body_len,
+                                                          signing_key, 16, signature);
+                    break;
+                case SMB2_SIGNING_HMAC_SHA256:
+                    rc = chimera_smb_request_hmac_sha256(ctx, hdr, &cursor,
+                                                         body_len,
+                                                         signing_key, 16, signature);
+                    break;
+                default:
+                    rc = chimera_smb_request_cmac_aes_128_cbc(ctx, hdr, &cursor,
+                                                              body_len,
+                                                              signing_key, 16, signature);
+                    break;
+            } /* switch */
             break;
         default:
             return -1;

--- a/src/server/smb/smb_signing.h
+++ b/src/server/smb/smb_signing.h
@@ -26,6 +26,22 @@ chimera_smb_derive_signing_key(
     size_t         session_key_len,
     const uint8_t *preauth_hash);
 
+/*
+ * SP800-108 counter-mode KDF (HMAC-SHA256), the primitive behind SMB3 signing
+ * and encryption key derivation.  Returns 1 on success, 0 on failure.  Pass
+ * label/context lengths INCLUDING any trailing NUL the spec requires.
+ */
+int
+kdf_counter_hmac_sha256_ossl3(
+    const uint8_t *key,
+    size_t         key_len,
+    const void    *label,
+    size_t         label_len,
+    const uint8_t *context,
+    size_t         ctx_len,
+    uint8_t       *out,
+    size_t         out_len);
+
 /* Extend an SMB 3.1.1 preauth-integrity hash in place: hash = SHA512(hash||msg). */
 void
 chimera_smb_preauth_extend(
@@ -60,6 +76,7 @@ int
 chimera_smb_sign_message(
     struct chimera_smb_signing_ctx *ctx,
     int                             dialect,
+    int                             signing_alg,
     const uint8_t                  *signing_key,
     uint8_t                        *smb2_buf,
     int                             smb2_len);

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -337,6 +337,8 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.durable-v2-delay
     smb2.notify-inotify
     smb2.secleak
+    smb2.session-id
+    smb2.session-require-signing
     smb2.session.signing-aes-128-cmac
     smb2.set-sparse-ioctl
     smb2.sharemode

--- a/src/server/smb/tests/smbtorture_test.c
+++ b/src/server/smb/tests/smbtorture_test.c
@@ -356,6 +356,17 @@ main(
                                          "/build/test/cairn", cairn_cfg);
     }
 
+    /* The smb2.session-require-signing suite checks that the server advertises
+     * mandatory signing (security_mode SIGNING_REQUIRED|ENABLED).  That is a
+     * per-server policy, so enable it only when running that suite to avoid
+     * forcing signing on every other suite's connections. */
+    for (i = 0; i < num_tests; i++) {
+        if (strstr(tests[i], "session-require-signing") != NULL) {
+            chimera_server_config_set_smb_signing_required(config, 1);
+            break;
+        }
+    }
+
     /* Initialize server */
     env.server = chimera_server_init(config, env.metrics);
     if (!env.server) {


### PR DESCRIPTION
Implements SMB3 transport encryption end-to-end, plus the signing/auth
prerequisites it depends on. All new behaviour is config-gated and off by
default, so this is inert unless `smb_encryption`/`smb_signing_required` are set.

## SMB3 transport encryption (`smb_encryption` = off/enabled/required, default off)
- New `smb_encrypt.c/.h`: AES-128/256 CCM and GCM, the SMB2 TRANSFORM header,
  per-direction key derivation (3.0/3.0.2 `ServerIn`/`ServerOut`, 3.1.1
  `SMBC2S`/`SMBS2CCipherKey`) and a per-session monotonic nonce counter.
- NEGOTIATE advertises `SMB2_GLOBAL_CAP_ENCRYPTION` for 3.0/3.0.2 and selects
  the 3.0.x cipher; 3.1.1 negotiates via the encryption-capabilities context.
- SESSION_SETUP derives the per-session keys and sets
  `SMB2_SESSION_FLAG_ENCRYPT_DATA`.
- Inbound TRANSFORM messages are decrypted and dispatched; replies for an
  encrypted session (or a received-encrypted compound) are wrapped and
  encrypted on the TCP path. RDMA encryption is guarded off (not yet supported).

## AES-128-GMAC signing
- Implement AES-128-GMAC (`smb_signing.c`) and full GMAC/CMAC/HMAC-SHA256
  signing-algorithm negotiation and dispatch (3.1.1 default remains CMAC).

## Other
- `smb2.session-id`: allocate 32-bit non-zero session ids — clients round-trip
  the id through a `uint32_t`.
- `smb2.session-require-signing`: `smb_signing_required` knob; NEGOTIATE and
  FSCTL_VALIDATE_NEGOTIATE_INFO advertise SIGNING_REQUIRED; dispatch skips
  verifying the inbound SESSION_SETUP (its key is derived while processing it).
- Do not gate SYNCHRONIZE as an open-time access right (it is always grantable
  on a successful open); fixes opening a mode-only share root.

Enables `smb2.session-id` and `smb2.session-require-signing` on memfs. The
`smb2.session` `signing-*`/`encryption-*` smbtorture suites remain disabled:
they additionally require BATCH-oplock grants and encrypted async CHANGE_NOTIFY
responses, which are out of scope here.