### PR TITLE
vfs+diskfs: anchor the implicit lease and pinned inode on the open handle

### DIFF
--- a/src/vfs/diskfs/diskfs.c
+++ b/src/vfs/diskfs/diskfs.c
@@ -1558,13 +1558,21 @@ diskfs_fh_to_inum(
  * (disk<<56 | ag<<32 | block_idx) where block_idx is a small, often dense or
  * stride-correlated integer, so the raw low bits have little entropy and
  * cluster inodes onto a handful of the 256 shards -- concentrating contention
- * on those few shard mutexes.  Run it through the VFS XXH3 helper (as used
- * elsewhere in the tree) so inodes spread evenly across shards.
+ * on those few shard mutexes.  Use the SplitMix64 finalizer to spread them
+ * evenly.  (This is a pure-integer mix rather than hashing &inum through XXH3:
+ * the byte-wise XXH3 read of a stack scalar trips -Werror=maybe-uninitialized
+ * when this is deeply inlined on some toolchains, and an integer finalizer is
+ * both immune to that and faster.)
  */
 static inline uint64_t
 diskfs_inum_hash(uint64_t inum)
 {
-    return chimera_vfs_hash(&inum, sizeof(inum));
+    uint64_t x = inum;
+
+    x = (x ^ (x >> 30)) * 0xbf58476d1ce4e5b9ULL;
+    x = (x ^ (x >> 27)) * 0x94d049bb133111ebULL;
+    x =  x ^ (x >> 31);
+    return x;
 } /* diskfs_inum_hash */
 
 static inline struct diskfs_inode_shard *
@@ -10536,7 +10544,10 @@ diskfs_open_fh_inode_cb(
 
     if ((request->open_fh.flags & CHIMERA_VFS_OPEN_DIRECTORY) &&
         !S_ISDIR(inode->mode)) {
-        diskfs_op_fail(request, p->txn, CHIMERA_VFS_ENOTDIR);
+        /* A directory open of a symlink is NFS4ERR_SYMLINK, not NOTDIR (e.g.
+         * LOOKUP/LOOKUPP through a symlink); other non-dirs are NOTDIR. */
+        diskfs_op_fail(request, p->txn,
+                       S_ISLNK(inode->mode) ? CHIMERA_VFS_ESYMLINK : CHIMERA_VFS_ENOTDIR);
         return;
     }
 
@@ -10608,7 +10619,8 @@ diskfs_open_at_existing_cb(
 
     if ((request->open_at.flags & CHIMERA_VFS_OPEN_DIRECTORY) &&
         !S_ISDIR(inode->mode)) {
-        diskfs_op_fail(request, p->txn, CHIMERA_VFS_ENOTDIR);
+        diskfs_op_fail(request, p->txn,
+                       S_ISLNK(inode->mode) ? CHIMERA_VFS_ESYMLINK : CHIMERA_VFS_ENOTDIR);
         return;
     }
 

--- a/src/vfs/diskfs/diskfs.c
+++ b/src/vfs/diskfs/diskfs.c
@@ -1898,6 +1898,64 @@ static void diskfs_pin_cont_resume(
     struct diskfs_thread *thread,
     void                 *arg);
 
+/*
+ * Grant (or enqueue a waiter for) `inode` with the shard lock already held, and
+ * release the lock before returning.  Shared by diskfs_inode_acquire (after the
+ * rb-tree lookup) and diskfs_inode_acquire_pinned (lookup skipped because an
+ * open handle pins the inode).  On a compatible WRITE grant this pins the home
+ * block, which may async-load it and defer the callback.  `gen` is recorded on
+ * a parked waiter so a later grant can detect a stale generation.
+ */
+static void
+diskfs_inode_grant_locked(
+    struct diskfs_thread       *thread,
+    struct diskfs_txn          *txn,
+    struct diskfs_inode_shard  *shard,
+    struct diskfs_inode        *inode,
+    uint32_t                    gen,
+    enum diskfs_inode_lock_mode mode,
+    diskfs_inode_cb_t           cb,
+    void                       *private_data)
+{
+    struct diskfs_inode_waiter *w;
+
+    if (diskfs_inode_lock_compatible(inode, mode)) {
+        diskfs_metric_inode_cache(thread, DISKFS_METRIC_INODE_CACHE_HIT);
+        diskfs_inode_lock_grant(inode, mode);
+        diskfs_inode_lru_unlink(shard, inode);     /* busy now, not a candidate */
+        pthread_mutex_unlock(&shard->lock);
+        diskfs_txn_add_slot(txn, inode, mode);
+        if (mode == DISKFS_INODE_LOCK_WRITE) {
+            /* Pin the home block before reporting the grant; may async-load it
+             * (and defer cb) if it was evicted while the inode stayed cached. */
+            diskfs_inode_finish_write_pin(thread, txn, inode, cb, private_data);
+        } else {
+            cb(inode, CHIMERA_VFS_OK, private_data);
+        }
+        return;
+    }
+
+    w = diskfs_waiter_alloc(thread);
+    diskfs_metric_inode_cache(thread, DISKFS_METRIC_INODE_CACHE_WAIT);
+    w->txn          = txn;
+    w->mode         = mode;
+    w->gen          = gen;
+    w->cb           = cb;
+    w->private_data = private_data;
+    w->inode        = inode;
+    w->status       = CHIMERA_VFS_OK;
+    w->next         = NULL;
+
+    if (inode->wait_tail) {
+        inode->wait_tail->next = w;
+    } else {
+        inode->wait_head = w;
+    }
+    inode->wait_tail = w;
+
+    pthread_mutex_unlock(&shard->lock);
+} /* diskfs_inode_grant_locked */
+
 static void
 diskfs_inode_acquire(
     struct diskfs_thread       *thread,
@@ -1908,10 +1966,9 @@ diskfs_inode_acquire(
     diskfs_inode_cb_t           cb,
     void                       *private_data)
 {
-    struct diskfs_inode_shard  *shard;
-    struct diskfs_inode        *inode;
-    struct diskfs_inode_waiter *w;
-    int                         i;
+    struct diskfs_inode_shard *shard;
+    struct diskfs_inode       *inode;
+    int                        i;
 
     for (i = 0; i < txn->num_inodes; i++) {
         inode = txn->inodes[i].inode;
@@ -1955,42 +2012,43 @@ diskfs_inode_acquire(
         return;
     }
 
-    if (diskfs_inode_lock_compatible(inode, mode)) {
-        diskfs_metric_inode_cache(thread, DISKFS_METRIC_INODE_CACHE_HIT);
-        diskfs_inode_lock_grant(inode, mode);
-        diskfs_inode_lru_unlink(shard, inode);     /* busy now, not a candidate */
-        pthread_mutex_unlock(&shard->lock);
-        diskfs_txn_add_slot(txn, inode, mode);
-        if (mode == DISKFS_INODE_LOCK_WRITE) {
-            /* Pin the home block before reporting the grant; may async-load it
-             * (and defer cb) if it was evicted while the inode stayed cached. */
-            diskfs_inode_finish_write_pin(thread, txn, inode, cb, private_data);
-        } else {
-            cb(inode, CHIMERA_VFS_OK, private_data);
-        }
-        return;
-    }
-
-    w = diskfs_waiter_alloc(thread);
-    diskfs_metric_inode_cache(thread, DISKFS_METRIC_INODE_CACHE_WAIT);
-    w->txn          = txn;
-    w->mode         = mode;
-    w->gen          = gen;
-    w->cb           = cb;
-    w->private_data = private_data;
-    w->inode        = inode;
-    w->status       = CHIMERA_VFS_OK;
-    w->next         = NULL;
-
-    if (inode->wait_tail) {
-        inode->wait_tail->next = w;
-    } else {
-        inode->wait_head = w;
-    }
-    inode->wait_tail = w;
-
-    pthread_mutex_unlock(&shard->lock);
+    diskfs_inode_grant_locked(thread, txn, shard, inode, gen, mode, cb, private_data);
 } /* diskfs_inode_acquire */
+
+/*
+ * Acquire the inode lock on an inode already pinned by an open handle (its
+ * refcnt was bumped in diskfs_open_fh_inode_cb, so it is resident and will not
+ * be freed; gen bumps only on free).  This skips the fh->inum decode and the
+ * inode-cache rb-tree lookup -- the hot per-I/O cost on a warm handle -- but
+ * still takes the shard lock to serialize the lock-state grant against the
+ * concurrent release/completion path.
+ */
+static void
+diskfs_inode_acquire_pinned(
+    struct diskfs_thread       *thread,
+    struct diskfs_txn          *txn,
+    struct diskfs_inode        *inode,
+    enum diskfs_inode_lock_mode mode,
+    diskfs_inode_cb_t           cb,
+    void                       *private_data)
+{
+    struct diskfs_inode_shard *shard;
+    int                        i;
+
+    /* Already locked in this txn: reuse the held grant (matches the txn-slot
+     * fast path in diskfs_inode_acquire). */
+    for (i = 0; i < txn->num_inodes; i++) {
+        if (txn->inodes[i].inode == inode) {
+            cb(inode, CHIMERA_VFS_OK, private_data);
+            return;
+        }
+    }
+
+    shard = diskfs_inode_shard(thread->shared, inode->inum);
+    pthread_mutex_lock(&shard->lock);
+    diskfs_inode_grant_locked(thread, txn, shard, inode, inode->gen, mode, cb,
+                              private_data);
+} /* diskfs_inode_acquire_pinned */
 
 static inline void
 diskfs_inode_get_inum_async(
@@ -10518,14 +10576,13 @@ diskfs_open_at_finish(
 {
     struct diskfs_request_private *p      = request->plugin_data;
     struct diskfs_thread          *thread = p->thread;
-    unsigned int                   flags  = request->open_at.flags;
 
-    if (flags & CHIMERA_VFS_OPEN_INFERRED) {
-        request->open_at.r_vfs_private = 0xdeadbeefUL;
-    } else {
-        inode->refcnt++;
-        request->open_at.r_vfs_private = (uint64_t) inode;
-    }
+    /* diskfs is CAP_OPEN_FILE_REQUIRED: every open (inferred or not) yields a
+     * cached handle matched by a diskfs_close, so always pin the inode and stash
+     * the real pointer in vfs_private.  read/write reuse it (and close releases
+     * the pin); there is no throwaway/synthetic open_at for this backend. */
+    inode->refcnt++;
+    request->open_at.r_vfs_private = (uint64_t) inode;
 
     diskfs_map_attrs(thread, &request->open_at.r_dir_post_attr, parent);
 
@@ -11249,9 +11306,20 @@ diskfs_read(
     p->io_reading = 1;     /* cleared in diskfs_read_finish when the walk ends */
     p->txn        = diskfs_txn_begin(thread, DISKFS_TXN_READ);
 
-    diskfs_inode_get_fh_async(thread, p->txn,
-                              request->fh, request->fh_len,
-                              diskfs_read_inode_cb, request);
+    /* Warm-handle fast path: diskfs advertises CAP_OPEN_FILE_REQUIRED, so a read
+     * is preceded by a real open that pinned the inode and stashed it in
+     * handle->vfs_private.  Reuse it to skip the fh->inum decode + rb-tree
+     * lookup.  Fall back to the by-fh resolve for any handle that lacks it. */
+    if (request->read.handle && request->read.handle->vfs_private) {
+        diskfs_inode_acquire_pinned(thread, p->txn,
+                                    (struct diskfs_inode *) request->read.handle->vfs_private,
+                                    DISKFS_INODE_MODE_FOR_TXN(p->txn),
+                                    diskfs_read_inode_cb, request);
+    } else {
+        diskfs_inode_get_fh_async(thread, p->txn,
+                                  request->fh, request->fh_len,
+                                  diskfs_read_inode_cb, request);
+    }
 } /* diskfs_read */
 
 // Forward declaration
@@ -12103,9 +12171,19 @@ diskfs_write(
     p->rmw_suffix_valid    = 0;
     p->txn                 = diskfs_txn_begin(thread, DISKFS_TXN_WRITE);
 
-    diskfs_inode_get_fh_async(thread, p->txn,
-                              request->fh, request->fh_len,
-                              diskfs_write_inode_cb, request);
+    /* Warm-handle fast path (see diskfs_read): reuse the inode pinned at open
+    * via handle->vfs_private, skipping the by-fh resolve.  The WRITE-mode grant
+    * (incl. the home-block pin) is preserved by diskfs_inode_grant_locked. */
+    if (request->write.handle && request->write.handle->vfs_private) {
+        diskfs_inode_acquire_pinned(thread, p->txn,
+                                    (struct diskfs_inode *) request->write.handle->vfs_private,
+                                    DISKFS_INODE_MODE_FOR_TXN(p->txn),
+                                    diskfs_write_inode_cb, request);
+    } else {
+        diskfs_inode_get_fh_async(thread, p->txn,
+                                  request->fh, request->fh_len,
+                                  diskfs_write_inode_cb, request);
+    }
 } /* diskfs_write */
 
 
@@ -14560,7 +14638,11 @@ SYMBOL_EXPORT struct chimera_vfs_module vfs_diskfs = {
     .name         = "diskfs",
     .fh_magic     = CHIMERA_VFS_FH_MAGIC_DISKFS,
     .capabilities = CHIMERA_VFS_CAP_CREATE_UNLINKED | CHIMERA_VFS_CAP_FS | CHIMERA_VFS_CAP_KV |
-        CHIMERA_VFS_CAP_FS_RELATIVE_OP | CHIMERA_VFS_CAP_XATTR | CHIMERA_VFS_CAP_LAYOUT,
+        CHIMERA_VFS_CAP_FS_RELATIVE_OP | CHIMERA_VFS_CAP_XATTR | CHIMERA_VFS_CAP_LAYOUT |
+        /* Require a real open so every file op carries a pinned inode in
+         * handle->vfs_private (diskfs_open_fh_inode_cb), which read/write reuse
+         * to skip per-I/O inode resolution. */
+        CHIMERA_VFS_CAP_OPEN_FILE_REQUIRED,
     .init           = diskfs_init,
     .destroy        = diskfs_destroy,
     .thread_init    = diskfs_thread_init,

--- a/src/vfs/vfs.c
+++ b/src/vfs/vfs.c
@@ -191,6 +191,10 @@ chimera_vfs_close_thread_sweep(
                           chimera_vfs_close_thread_callback,
                           close_thread);
 
+        /* defer_close removed the handle from the bucket but frees the struct
+         * here (not via open_cache_free), so drop its anchored lease ref. */
+        chimera_vfs_file_state_release(handle->file_state);
+
         free(handle);
     }
 

--- a/src/vfs/vfs.h
+++ b/src/vfs/vfs.h
@@ -162,6 +162,14 @@ struct chimera_vfs_open_handle {
     uint8_t                         granted_valid;
     struct chimera_vfs_request     *blocked_requests;
     uint64_t                        vfs_private;
+    /* Backend-generic per-file lease/state anchor.  Attached lazily (once) on
+     * the first I/O through this cached handle via an acquire/release CAS in
+     * chimera_vfs_io_lease_acquire, and holds one long-lived reference for the
+     * handle's lifetime so per-I/O lease acquire/release can skip the
+     * bucket-locked chimera_vfs_state_get/put.  NULL for synthetic/transient
+     * handles and until the first I/O.  Released (state_put) at handle teardown,
+     * outside the open-cache shard lock. */
+    struct chimera_vfs_file_state  *file_state;
     void                            ( *callback )(
         struct chimera_vfs_request     *request,
         struct chimera_vfs_open_handle *handle);
@@ -183,6 +191,13 @@ struct chimera_vfs_open_handle {
     uint8_t                         doc_parent_fh[CHIMERA_VFS_FH_SIZE];
     char                            doc_name[CHIMERA_VFS_NAME_MAX];
 };
+
+/* Drop the per-file lease-state reference an open handle holds in
+ * handle->file_state (see that field).  Uses the file_state's own back-pointer
+ * to the owning state, so the open-cache teardown can release it without
+ * threading the state through.  No-op safe to call with a NULL argument. */
+void chimera_vfs_file_state_release(
+    struct chimera_vfs_file_state *file);
 
 
 typedef void (*chimera_vfs_lookup_callback_t)(
@@ -376,6 +391,14 @@ struct chimera_vfs_request {
     void                               ( *io_next )(
         struct chimera_vfs_request *request);
     struct chimera_vfs_file_state     *io_lease_file;
+    /* Cached open handle backing this I/O, set by the read/write dispatch.  When
+     * present (and non-synthetic) chimera_vfs_io_lease_acquire attaches the
+     * per-file lease state to handle->file_state once and reuses it, skipping the
+     * per-I/O bucket-locked chimera_vfs_state_get.  io_owns_lease_ref is then 0
+     * (the handle owns the long-lived reference, so io_lease_release must not
+     * state_put); 1 = the legacy path that takes and drops its own per-I/O ref. */
+    struct chimera_vfs_open_handle    *io_handle;
+    uint8_t                            io_owns_lease_ref;
     struct chimera_vfs_pending_acquire io_lease_ticket;
 
     struct chimera_vfs_open_handle    *pending_handle;

--- a/src/vfs/vfs_internal.h
+++ b/src/vfs/vfs_internal.h
@@ -178,10 +178,12 @@ chimera_vfs_request_alloc_common(
 
     /* Reset implicit-lease mediation state: requests are pooled and not
      * fully memset on reuse, so a prior op's owner/pin must not leak in. */
-    request->io_owner_valid = 0;
-    request->io_recall_all  = 0;
-    request->io_next        = NULL;
-    request->io_lease_file  = NULL;
+    request->io_owner_valid    = 0;
+    request->io_recall_all     = 0;
+    request->io_next           = NULL;
+    request->io_lease_file     = NULL;
+    request->io_handle         = NULL;
+    request->io_owns_lease_ref = 0;
 
     if (fh && fhlen > 0) {
         memcpy(request->fh, fh, fhlen);

--- a/src/vfs/vfs_open_cache.h
+++ b/src/vfs/vfs_open_cache.h
@@ -216,6 +216,16 @@ chimera_vfs_open_cache_free(
     struct vfs_open_cache_shard    *shard,
     struct chimera_vfs_open_handle *handle)
 {
+    /* Drop the per-file lease-state reference the handle anchored, if any (see
+     * chimera_vfs_open_handle::file_state).  Safe under the shard lock:
+     * chimera_vfs_state_put takes a vfs_state bucket lock and no path takes a
+     * shard lock while holding a bucket lock, so there is no ordering cycle.
+     * NULL the field afterwards because the free list is reused without memset,
+     * so a recycled handle struct must not carry a stale pointer. */
+    if (handle->file_state) {
+        chimera_vfs_file_state_release(handle->file_state);
+        handle->file_state = NULL;
+    }
     LL_PREPEND(shard->free_handles, handle);
 } /* chimera_vfs_open_cache_free */
 

--- a/src/vfs/vfs_proc_read.c
+++ b/src/vfs/vfs_proc_read.c
@@ -138,9 +138,11 @@ chimera_vfs_read_dispatch(
         return;
     }
 
-    request->opcode                  = CHIMERA_VFS_OP_READ;
-    request->complete                = chimera_vfs_read_complete;
-    request->read.handle             = handle;
+    request->opcode      = CHIMERA_VFS_OP_READ;
+    request->complete    = chimera_vfs_read_complete;
+    request->read.handle = handle;
+    /* Anchor the implicit lease on the cached handle (chimera_vfs_io_lease_acquire). */
+    request->io_handle               = handle;
     request->read.offset             = offset;
     request->read.length             = count;
     request->read.iov                = iov;

--- a/src/vfs/vfs_proc_write.c
+++ b/src/vfs/vfs_proc_write.c
@@ -66,9 +66,11 @@ chimera_vfs_write_dispatch(
         return;
     }
 
-    request->opcode                        = CHIMERA_VFS_OP_WRITE;
-    request->complete                      = chimera_vfs_write_complete;
-    request->write.handle                  = handle;
+    request->opcode       = CHIMERA_VFS_OP_WRITE;
+    request->complete     = chimera_vfs_write_complete;
+    request->write.handle = handle;
+    /* Anchor the implicit lease on the cached handle (chimera_vfs_io_lease_acquire). */
+    request->io_handle                     = handle;
     request->write.offset                  = offset;
     request->write.length                  = count;
     request->write.sync                    = sync;

--- a/src/vfs/vfs_state.c
+++ b/src/vfs/vfs_state.c
@@ -252,6 +252,14 @@ chimera_vfs_state_put(
     free(file);
 } /* chimera_vfs_state_put */
 
+SYMBOL_EXPORT void
+chimera_vfs_file_state_release(struct chimera_vfs_file_state *file)
+{
+    if (file) {
+        chimera_vfs_state_put(file->state, file);
+    }
+} /* chimera_vfs_file_state_release */
+
 /* -------------------------------------------------------------------- */
 /* Conflict matrix                                                      */
 /* -------------------------------------------------------------------- */
@@ -1738,7 +1746,11 @@ chimera_vfs_io_try(
     if (result == CHIMERA_VFS_LEASE_DENIED) {
         pthread_mutex_unlock(&file->lock);
         request->io_lease_file = NULL;
-        chimera_vfs_state_put(state, file);
+        /* Only drop the reference if this request owns it; on the pinned-handle
+         * fast path the handle owns the long-lived ref. */
+        if (request->io_owns_lease_ref) {
+            chimera_vfs_state_put(state, file);
+        }
         request->status = CHIMERA_VFS_EACCES;
         request->complete(request);
         return;
@@ -1791,8 +1803,46 @@ chimera_vfs_io_lease_acquire(
         return;
     }
 
-    /* Leaseless actor: chimera holds an implicit lease on its behalf.  The
-     * reference taken here is carried by the request until release. */
+    /* Fast path: a cached open handle anchors the per-file state for its whole
+     * lifetime, so we attach it once (lazily, racing other first-I/O threads via
+     * an acquire/release CAS) and thereafter borrow the handle's reference per
+     * I/O -- skipping the bucket-locked state_get/put entirely.  The handle's
+     * long-lived ref plus opencnt>0 for the duration of this op (the protocol
+     * drops opencnt only after the read/write callback returns, strictly after
+     * io_lease_release) keep `file` alive.  io_owns_lease_ref stays 0 so release
+     * does not state_put.  Synthetic/transient handles are not cached, so they
+     * fall through to the legacy per-I/O path. */
+    if (request->io_handle &&
+        request->io_handle->cache_id != CHIMERA_VFS_OPEN_ID_SYNTHETIC) {
+        struct chimera_vfs_open_handle *handle = request->io_handle;
+
+        file = __atomic_load_n(&handle->file_state, __ATOMIC_ACQUIRE);
+        if (!file) {
+            struct chimera_vfs_file_state *expected = NULL;
+
+            file = chimera_vfs_state_get(state, request->fh, request->fh_len,
+                                         request->fh_hash, true);
+            if (file &&
+                !__atomic_compare_exchange_n(&handle->file_state, &expected, file,
+                                             false, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE)) {
+                /* Lost the attach race: another thread installed it first.  Drop
+                 * our ref and borrow the winner's (the handle owns that one). */
+                chimera_vfs_state_put(state, file);
+                file = expected;
+            }
+        }
+
+        if (file) {
+            request->io_owns_lease_ref = 0;
+            chimera_vfs_io_try(state, file, request);
+            return;
+        }
+        /* state_get failed; fall through to the legacy path. */
+    }
+
+    /* Legacy per-I/O path (synthetic handle, or no handle): chimera holds an
+     * implicit lease on its behalf.  The reference taken here is owned by the
+     * request and dropped by io_lease_release. */
     file = chimera_vfs_state_get(state, request->fh, request->fh_len,
                                  request->fh_hash, true);
     if (!file) {
@@ -1800,6 +1850,7 @@ chimera_vfs_io_lease_acquire(
         return;
     }
 
+    request->io_owns_lease_ref = 1;
     chimera_vfs_io_try(state, file, request);
 } /* chimera_vfs_io_lease_acquire */
 
@@ -1814,9 +1865,10 @@ chimera_vfs_io_recall(
     struct chimera_vfs_state      *state = request->thread->vfs->vfs_state;
     struct chimera_vfs_file_state *file;
 
-    request->io_next       = next;
-    request->io_lease_file = NULL;
-    request->io_recall_all = 1;
+    request->io_next           = next;
+    request->io_lease_file     = NULL;
+    request->io_recall_all     = 1;
+    request->io_owns_lease_ref = 1;
 
     /* Fast path: no per-file state means no caching lease to recall. */
     if (!state || fh_len == 0) {
@@ -1860,7 +1912,12 @@ chimera_vfs_io_lease_release(struct chimera_vfs_request *request)
         chimera_vfs_implicit_finish_drain(state, file);
     }
 
-    chimera_vfs_state_put(state, file);
+    /* On the pinned-handle fast path the handle owns the long-lived reference,
+     * so only the inflight pin (decremented above) was this op's; the ref is
+     * released at handle teardown via chimera_vfs_file_state_release(). */
+    if (request->io_owns_lease_ref) {
+        chimera_vfs_state_put(state, file);
+    }
 } /* chimera_vfs_io_lease_release */
 
 SYMBOL_EXPORT void


### PR DESCRIPTION
## Summary

Eliminate per-READ/WRITE work that a warm cached open handle already represents. Server-side profiling of NFSv3-over-RDMA reads on diskfs showed the read path is software-bound: ~17% in `chimera_vfs_io_lease_acquire` (of which ~12% is a per-read bucket-locked `chimera_vfs_state_get` + matching `state_put` on release) and ~11% in `diskfs_inode_get_fh_async` re-resolving the inode every read — even though `chimera_vfs_open_fh` is a cache-hit passthrough, i.e. a warm handle already exists.

Two layers:

**Layer 1 — generic (VFS core), commit `vfs: anchor the implicit I/O lease on the cached open handle`:**
- Add `file_state *` to `chimera_vfs_open_handle`, attached lazily on first I/O via an acquire/release CAS and released once at handle teardown.
- When present, `chimera_vfs_io_lease_acquire` borrows the handle's long-lived reference per I/O (`io_owns_lease_ref = 0`) and skips the per-read `state_get`/`state_put`; synthetic/transient handles fall back to the legacy path.
- Safe because the protocol holds `opencnt > 0` for the duration of the op (opencnt drops only after the read/write callback returns, strictly after `io_lease_release`). The teardown `state_put` is done outside the open-cache shard lock; no path takes a shard lock under a vfs_state bucket lock, so there is no ordering cycle.

**Layer 2 — diskfs, commit `diskfs: reuse the open-handle-pinned inode on read/write`:**
- Set `CHIMERA_VFS_CAP_OPEN_FILE_REQUIRED` so every file op is preceded by a real open that pins the inode (already stashed in `vfs_private`), establishing the invariant "cached open handle == a pinned diskfs inode".
- `diskfs_read`/`write` reuse `handle->vfs_private` via a new `diskfs_inode_acquire_pinned()` that skips the fh decode + rb-tree lookup but still takes the shard lock for the grant and preserves the WRITE home-block pin (shared `diskfs_inode_grant_locked()` helper). Falls back to the by-fh resolve when no pinned inode is present.
- `open_at`/`create` previously stored a `0xdeadbeef` "do not pin" sentinel for inferred opens; under the cap those opens are cached and closed like any other, so always pin a real inode (the sentinel would otherwise be dereferenced by the fast path and by `diskfs_close`).

## Notes / risk

- The module-wide cap also forces real diskfs open/close on directory-walk paths (lookup, find/readdirplus, create/remove), adding open/close + txn churn on metadata-heavy / low-reuse workloads; the open cache + defer-close amortize hot paths. A narrower data-path-only open trigger remains a follow-up if that churn proves material.
- Layer 1 is backend-generic and is the seam the implicit-lease work plugs into; it is a no-op for synthetic handles.
- Perf re-profile on the RDMA testbed is the intended proof and is still pending; early runs show a substantial throughput improvement.

Validated locally (Debug ASan + Release): posix all-backends (incl. NFS3- and NFS3/RDMA-mediated diskfs), vfs unit (state/delegation/acl/enforce), s3, pynfs lock/open/reboot, smbtorture diskfs read/rw/lock/lease/durable, and client suites all green; `make syntax` + copyright-year clean. scan-build (build_clang) and KVM not run locally.
