### PR TITLE
fio: add chimera_log option to redirect/silence chimera+evpl logging

### DIFF
--- a/src/common/logging.c
+++ b/src/common/logging.c
@@ -123,12 +123,14 @@ static const char *level_string[] = {
 #define CHIMERA_LOG_BUF_SIZE 1024 * 1024
 
 char              *ChimeraLogBuffers[2];
-int                ChimeraLogIndex   = 0;
-char              *ChimeraLogBuf     = NULL;
-char              *ChimeraLogBufPtr  = NULL;
-volatile int       ChimeraLogRun     = 1;
-SYMBOL_EXPORT int  ChimeraLogLevel   = CHIMERA_LOG_INFO;
-pthread_mutex_t    ChimeraLogBufLock = PTHREAD_MUTEX_INITIALIZER;
+int                ChimeraLogIndex    = 0;
+char              *ChimeraLogBuf      = NULL;
+char              *ChimeraLogBufPtr   = NULL;
+volatile int       ChimeraLogRun      = 1;
+SYMBOL_EXPORT int  ChimeraLogLevel    = CHIMERA_LOG_INFO;
+FILE              *ChimeraLogFile     = NULL; /* NULL => write to stdout */
+int                ChimeraLogDisabled = 0;
+pthread_mutex_t    ChimeraLogBufLock  = PTHREAD_MUTEX_INITIALIZER;
 pthread_t          ChimeraLogThread;
 pthread_once_t     ChimeraLogOnce = PTHREAD_ONCE_INIT;
 
@@ -137,6 +139,7 @@ chimera_log_thread(void *arg)
 {
     int   i;
     char *tmp;
+    FILE *out = ChimeraLogFile ? ChimeraLogFile : stdout;
 
     while (ChimeraLogRun || ChimeraLogBufPtr > ChimeraLogBuf) {
 
@@ -149,14 +152,19 @@ chimera_log_thread(void *arg)
             ChimeraLogBufPtr = ChimeraLogBuf;
             pthread_mutex_unlock(&ChimeraLogBufLock);
 
-            fprintf(stdout, "%s", tmp);
-            fflush(stdout);
+            fprintf(out, "%s", tmp);
+            fflush(out);
         }
         usleep(1000);
     }
 
     for (i = 0; i < 2; ++i) {
         free(ChimeraLogBuffers[i]);
+    }
+
+    if (ChimeraLogFile) {
+        fclose(ChimeraLogFile);
+        ChimeraLogFile = NULL;
     }
 
     return NULL;
@@ -219,6 +227,16 @@ chimera_log_thread_init(void)
 {
     int i;
 
+    if (ChimeraLogDisabled) {
+        /*
+         * Logging is disabled: don't allocate buffers or start the logging
+         * thread.  Clear ChimeraLogRun so chimera_log_flush()/the atexit
+         * handler don't try to join a thread that was never created.
+         */
+        ChimeraLogRun = 0;
+        return;
+    }
+
     for (i = 0; i < 2; ++i) {
         ChimeraLogBuffers[i] = calloc(CHIMERA_LOG_BUF_SIZE, sizeof(char));
     }
@@ -246,6 +264,19 @@ chimera_log_init(void)
 } /* chimera_log_init */
 
 SYMBOL_EXPORT void
+chimera_log_set_file(FILE *fp)
+{
+    ChimeraLogFile     = fp;
+    ChimeraLogDisabled = 0;
+} /* chimera_log_set_file */
+
+SYMBOL_EXPORT void
+chimera_log_disable(void)
+{
+    ChimeraLogDisabled = 1;
+} /* chimera_log_disable */
+
+SYMBOL_EXPORT void
 chimera_vlog(
     const char *level,
     const char *mod,
@@ -257,6 +288,10 @@ chimera_vlog(
     struct timespec ts;
     struct tm       tm_info;
     uint64_t        pid, tid;
+
+    if (ChimeraLogDisabled) {
+        return;
+    }
 
     clock_gettime(CLOCK_REALTIME, &ts);
 

--- a/src/common/logging.h
+++ b/src/common/logging.h
@@ -1,10 +1,11 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
 #pragma once
 
 #include <stdarg.h>
+#include <stdio.h>
 
 extern int ChimeraLogLevel;
 
@@ -14,6 +15,21 @@ extern int ChimeraLogLevel;
 #define CHIMERA_LOG_DEBUG 4
 
 void chimera_log_init(
+    void);
+
+/*
+ * Redirect chimera (and any evpl logging routed through chimera_vlog) output to
+ * the given stream instead of the default stdout.  The stream is closed when
+ * logging is flushed/torn down.  Must be called before chimera_log_init().
+ */
+void chimera_log_set_file(
+    FILE *fp);
+
+/*
+ * Disable logging entirely: chimera_vlog drops all messages and no logging
+ * thread is started.  Must be called before chimera_log_init().
+ */
+void chimera_log_disable(
     void);
 
 void chimera_enable_crash_handler(

--- a/src/fio/fio.c
+++ b/src/fio/fio.c
@@ -57,6 +57,7 @@ struct chimera_fio_thread {
 struct chimera_options {
     void *pad;
     char *config;
+    char *logfile;
 };
 
 static struct fio_option options[] = {
@@ -66,6 +67,16 @@ static struct fio_option options[] = {
         .type     = FIO_OPT_STR_STORE,
         .off1     = offsetof(struct chimera_options, config),
         .help     = "Set path to chimera config file",
+        .category = FIO_OPT_C_ENGINE,
+        .group    = FIO_OPT_G_INVALID,
+    },
+    {
+        .name  = "chimera_log",
+        .lname = "Chimera Log Filename",
+        .type  = FIO_OPT_STR_STORE,
+        .off1  = offsetof(struct chimera_options, logfile),
+        .help  =
+            "Direct chimera and evpl log output to this file (truncated at start of run); if unset, chimera logging is disabled",
         .category = FIO_OPT_C_ENGINE,
         .group    = FIO_OPT_G_INVALID,
     },
@@ -246,6 +257,20 @@ fio_chimera_init(struct thread_data *td)
     pthread_mutex_lock(&ChimeraClientMutex);
 
     if (ChimeraClient == NULL) {
+
+        if (o->logfile) {
+            FILE *logfp = fopen(o->logfile, "w");
+
+            if (!logfp) {
+                fprintf(stderr, "Failed to open chimera log file %s\n", o->logfile);
+                pthread_mutex_unlock(&ChimeraClientMutex);
+                return EINVAL;
+            }
+
+            chimera_log_set_file(logfp);
+        } else {
+            chimera_log_disable();
+        }
 
         chimera_log_init();
 


### PR DESCRIPTION
## Summary

The chimera fio engine routed all chimera and evpl log output to `stdout`, mixing it with fio's own output. This adds a `chimera_log` engine option to control where that logging goes:

- **unset** — chimera logging is disabled entirely (`chimera_vlog` drops all messages and no logging thread is started)
- **`chimera_log=<path>`** — chimera *and* evpl logging is written to the given file, which is **truncated at the start of the run**

Because evpl logging is already routed through `chimera_vlog`, both chimera and evpl output follow the same destination automatically.

## Usage

```ini
[global]
ioengine=external:.../chimera.so
chimera_config=my.json
chimera_log=/tmp/chimera.log    # omit this line to silence chimera logging
```

## Implementation

- **`src/common/logging.{c,h}`** — the logging core only ever wrote to `stdout` from its background thread. Added two small public hooks, called before `chimera_log_init()`:
  - `chimera_log_set_file(FILE *fp)` — the log thread writes to `fp` instead of `stdout` and `fclose()`s it on teardown.
  - `chimera_log_disable()` — `chimera_vlog()` drops every message and no logging thread is started (clears `ChimeraLogRun` so the flush/atexit/signal paths don't try to join a thread that was never created).

  Default behavior is unchanged for the daemon and tests (no call → buffered to `stdout`).
- **`src/fio/fio.c`** — added the `chimera_log` option; in `fio_chimera_init` (before `chimera_log_init()` / `evpl_set_log_fn`) it either opens+redirects or disables.

## Notes

- Truncation happens once, by the first thread to initialize the shared client (the same place the config is parsed), consistent with how the engine already handles global setup.
- The plugin's own one-time `fprintf(stderr, ...)` status/error lines (config-load, mount, open-failure) are intentionally left on stderr — they're not part of the logging subsystem and are useful if a run fails to start. The high-volume per-op chimera/evpl logging is what now goes to the file (or nowhere).
