### PR TITLE
config: shared "common" section for evpl huge-page/slab tuning

### DIFF
--- a/src/common/common_config.h
+++ b/src/common/common_config.h
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#pragma once
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <jansson.h>
+
+#include "evpl/evpl.h"
+
+/*
+ * Parse a size from a JSON value.  A bare integer is taken as a byte count; a
+ * string may carry a single K/M/G suffix (1024-based, optional trailing
+ * "iB"/"B"), e.g. 2097152 or "2M" or "1G".  Returns 0 and stores the byte
+ * count on success, -1 if the value is not a usable size.
+ */
+static inline int
+chimera_parse_size(
+    const json_t *val,
+    uint64_t     *out)
+{
+    if (json_is_integer(val)) {
+        json_int_t v = json_integer_value(val);
+
+        if (v < 0) {
+            return -1;
+        }
+        *out = (uint64_t) v;
+        return 0;
+    }
+
+    if (json_is_string(val)) {
+        const char        *s    = json_string_value(val);
+        char              *end  = NULL;
+        uint64_t           mult = 1;
+        unsigned long long n    = strtoull(s, &end, 0);
+
+        if (end == s) {
+            return -1;
+        }
+
+        while (*end == ' ') {
+            end++;
+        }
+
+        if (*end) {
+            switch (*end) {
+                case 'k': case 'K': mult = 1024ULL; break;
+                case 'm': case 'M': mult = 1024ULL * 1024; break;
+                case 'g': case 'G': mult = 1024ULL * 1024 * 1024; break;
+                default: return -1;
+            } /* switch */
+            end++;
+            if (*end == 'i') {
+                end++;
+            }
+            if (*end == 'B' || *end == 'b') {
+                end++;
+            }
+            if (*end != '\0') {
+                return -1;
+            }
+        }
+
+        *out = (uint64_t) n * mult;
+        return 0;
+    }
+
+    return -1;
+} /* chimera_parse_size */
+
+/*
+ * Apply the shared "common" config section -- parsed identically by the server
+ * and the client -- onto an evpl global config, before evpl_init().  Recognised
+ * keys: huge_pages (bool), huge_page_size (size), slab_size (size).  A missing
+ * "common" section, missing keys, or malformed values leave the corresponding
+ * evpl defaults untouched.  `root` is the parsed top-level config object (may be
+ * NULL).
+ */
+static inline void
+chimera_apply_common_config(
+    json_t                    *root,
+    struct evpl_global_config *cfg)
+{
+    json_t  *common, *val;
+    uint64_t size;
+
+    if (!root) {
+        return;
+    }
+
+    common = json_object_get(root, "common");
+    if (!json_is_object(common)) {
+        return;
+    }
+
+    val = json_object_get(common, "huge_pages");
+    if (json_is_boolean(val)) {
+        evpl_global_config_set_huge_pages(cfg, json_boolean_value(val));
+    } else if (json_is_integer(val)) {
+        evpl_global_config_set_huge_pages(cfg, json_integer_value(val) != 0);
+    }
+
+    val = json_object_get(common, "huge_page_size");
+    if (val && chimera_parse_size(val, &size) == 0) {
+        evpl_global_config_set_huge_page_size(cfg, size);
+    }
+
+    val = json_object_get(common, "slab_size");
+    if (val && chimera_parse_size(val, &size) == 0) {
+        evpl_global_config_set_slab_size(cfg, size);
+    }
+} /* chimera_apply_common_config */

--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -21,6 +21,7 @@
 #include "vfs/vfs_pnfs.h"
 #include "server/server_internal.h"
 #include "common/logging.h"
+#include "common/common_config.h"
 #include "metrics/metrics.h"
 #include "daemon.h"
 
@@ -314,6 +315,10 @@ main(
             rest_ssl_key  = auto_key_path;
         }
     }
+
+    /* Apply the shared "common" config section (huge pages / slab size) parsed
+     * from the same file, last, so it overrides the hardcoded defaults above. */
+    chimera_apply_common_config(config, evpl_global_config);
 
     evpl_init(evpl_global_config);
 

--- a/src/fio/fio.c
+++ b/src/fio/fio.c
@@ -20,6 +20,7 @@
 #include "optgroup.h"
 
 #include "common/macros.h"
+#include "common/common_config.h"
 
 
 #define chimera_fio_debug(...) chimera_debug("fio", __FILE__, __LINE__, __VA_ARGS__)
@@ -303,6 +304,17 @@ fio_chimera_init(struct thread_data *td)
 
         struct chimera_vfs_cred root_cred;
         chimera_vfs_cred_init_unix(&root_cred, 0, 0, 0, NULL);
+
+        /* Initialize evpl before the client (and the first evpl_create below),
+         * applying the shared "common" config (huge pages / slab size) from the
+         * loaded config.  `config` may be NULL when no config file was given. */
+        {
+            struct evpl_global_config *evpl_config = evpl_global_config_init();
+
+            chimera_apply_common_config(config, evpl_config);
+            evpl_init(evpl_config);
+        }
+
         ChimeraClient = chimera_client_init(ChimeraClientConfig, &root_cred, ChimeraMetrics);
 
         evpl          = evpl_create(NULL);


### PR DESCRIPTION
## Summary

Add a top-level **`common`** config section — parsed identically by the **server** (daemon) and the **client** (client library + fio engine) — that maps onto the evpl global config before `evpl_init()`:

- `huge_pages` (bool)
- `huge_page_size` (size: integer bytes, or a string like `"2M"` / `"1G"`)
- `slab_size` (size)

This lets a deployment select the hugetlb pool that backs evpl slabs (e.g. 1 GiB pages reserved for DMA) instead of being stuck on the kernel default size, which is what stranded the reserved memory and caused the server to OOM under sustained load.

## Change

- New shared header `src/common/common_config.h`: `chimera_apply_common_config(root, cfg)` parses the `common` object and calls the evpl setters; `chimera_parse_size()` accepts a raw byte count or a `K`/`M`/`G` suffix.
- **Server** (`daemon.c`): applies the section last, so it overrides the daemon's hardcoded evpl defaults, right before `evpl_init()`.
- **Client** (`client.c` `chimera_client_init_json`, and `fio.c`): these previously relied on lazy `evpl_create(NULL)` initialization with defaults. They now build an evpl global config, apply the `common` section, and call `evpl_init()` explicitly before the first `evpl_create()` — the same pattern the daemon already uses.
- Bumps the **libevpl** submodule to pick up `evpl_global_config_set_huge_page_size()`.

Example:
```json
"common": { "huge_pages": true, "huge_page_size": "1G", "slab_size": "1G" }
```

## Dependency

Requires **chimera-nas/libevpl#83** (adds `evpl_global_config_set_huge_page_size`). The submodule is bumped to that branch tip; it should be re-pointed to the merged commit on libevpl `main` once #83 lands.

## Validation

- Unit-tested `chimera_parse_size` (integers, `2M`/`1G`/`512K`/`1GiB`, and rejected garbage / non-power-of-two / negatives).
- Daemon starts and shuts down cleanly with a `common` section across valid/invalid sizes and huge_pages on/off.
- End-to-end: with `huge_pages:true, huge_page_size:"2M", slab_size:"1G"` and `preallocate_slabs:2`, the 2 MiB free-hugepage count dropped by exactly 1024 (= 2 × 1 GiB ÷ 2 MiB) while running and was released on shutdown — confirming the configured size reaches the allocator and that a 1 GiB slab is correctly backed by 512 × 2 MiB pages.
