### PR TITLE
nfs/client: add nolock mount option to disable NLM locking

### DIFF
--- a/src/vfs/nfs/nfs3_mount.c
+++ b/src/vfs/nfs/nfs3_mount.c
@@ -66,6 +66,31 @@ chimera_nfs_mount_get_port(
     return default_port;
 } /* chimera_nfs_mount_get_port */
 
+/*
+ * Get the nolock mount option - returns 1 if locking (NLM) should be
+ * disabled, 0 otherwise.  Mirrors the Linux NFS client "nolock" option:
+ * when present the client does not contact the server's lock manager and
+ * byte-range lock operations are not forwarded over the wire.  Locking is
+ * enabled by default ("lock").
+ */
+static int
+chimera_nfs_mount_get_nolock(const struct chimera_vfs_mount_options *options)
+{
+    int i;
+
+    for (i = 0; i < options->num_options; i++) {
+        if (strcmp(options->options[i].key, "nolock") == 0) {
+            return 1;
+        }
+        /* Accept an explicit "lock" as the positive form (the default). */
+        if (strcmp(options->options[i].key, "lock") == 0) {
+            return 0;
+        }
+    }
+
+    return 0;
+} /* chimera_nfs_mount_get_nolock */
+
 static void
 chimera_mount_mountd_mnt_callback(
     struct evpl                 *evpl,
@@ -242,6 +267,14 @@ chimera_nfs3_mount_nfs_null_callback(
 
     if (status != 0) {
         chimera_nfs3_mount_discover_callback(server_thread, status);
+        return;
+    }
+
+    /* "nolock" mount option: skip NLM discovery entirely.  nlm_endpoint is
+     * left NULL so no lock-manager connection is made and byte-range lock
+     * operations short-circuit to ENOTSUP (see chimera_nfs3_lock). */
+    if (server_thread->server->nolock) {
+        chimera_nfs3_mount_discover_callback(server_thread, 0);
         return;
     }
 
@@ -492,6 +525,8 @@ chimera_nfs3_mount(
         if (server->use_rdma) {
             server->nfs_port = chimera_nfs_mount_get_port(&request->mount.options, CHIMERA_NFS_RDMA_PORT);
         }
+
+        server->nolock = chimera_nfs_mount_get_nolock(&request->mount.options);
 
         strncpy(server->hostname, hostname, hostnamelen);
 

--- a/src/vfs/nfs/nfs_internal.h
+++ b/src/vfs/nfs/nfs_internal.h
@@ -115,6 +115,7 @@ struct chimera_nfs_client_server {
     int                                 nfsvers;
     int                                 index;
     int                                 use_rdma;
+    int                                 nolock;
     enum evpl_protocol_id               rdma_protocol;
 
     struct evpl_endpoint               *portmap_endpoint;


### PR DESCRIPTION
## Summary

Adds a `nolock` mount option to the chimera NFS VFS client, mirroring the Linux NFS client option of the same name. Locking remains **enabled by default** (`lock`); passing `nolock` disables the NLM (Network Lock Manager) sidecar.

When `nolock` is set, the client:
- skips the portmap `GETPORT` lookup for NLM (program 100021) during mount discovery, and
- leaves `nlm_endpoint` NULL, so no NLM connection is ever established.

Byte-range lock operations then short-circuit through the existing `!nlm_conn` path in `chimera_nfs3_lock`, returning `ENOTSUP` rather than being forwarded over the wire.

## Motivation

Even an RDMA NFSv3 mount opens a persistent **TCP** connection to the server's lock manager (default port 32803), because NLM — like portmap and mountd — is not defined over RDMA. For single-client / benchmark mounts that don't need cross-client lock coordination, `nolock` drops that dependency and the extra connection, matching long-standing Linux behavior.

## Scope / notes

- v3-only, which is where NLM lives. The option is ignored for NFSv4 (locking is integral to the protocol there; no separate lock manager).
- Lock ops under `nolock` return `ENOTSUP` via the pre-existing "NLM unavailable" path (same behavior as mounting a server that doesn't register NLM). This deliberately does **not** silently grant unenforced local locks. If Linux-style local-only lock *success* is desired, that's a larger follow-up that would route locks through the VFS local lock layer.