### PR TITLE
config: move preallocate_slabs/threads to the common section

### DIFF
--- a/src/common/common_config.h
+++ b/src/common/common_config.h
@@ -112,4 +112,14 @@ chimera_apply_common_config(
     if (val && chimera_parse_size(val, &size) == 0) {
         evpl_global_config_set_slab_size(cfg, size);
     }
+
+    val = json_object_get(common, "preallocate_slabs");
+    if (json_is_integer(val)) {
+        evpl_global_config_set_preallocate_slabs(cfg, json_integer_value(val));
+    }
+
+    val = json_object_get(common, "preallocate_threads");
+    if (json_is_integer(val)) {
+        evpl_global_config_set_preallocate_threads(cfg, json_integer_value(val));
+    }
 } /* chimera_apply_common_config */

--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -275,21 +275,6 @@ main(
                                             flavor == CHIMERA_TCP_FLAVOR_XLIO);
     }
 
-    if (server_params) {
-        json_t *prealloc_slabs_value   = json_object_get(server_params, "preallocate_slabs");
-        json_t *prealloc_threads_value = json_object_get(server_params, "preallocate_threads");
-
-        if (prealloc_slabs_value && json_is_integer(prealloc_slabs_value)) {
-            evpl_global_config_set_preallocate_slabs(evpl_global_config,
-                                                     json_integer_value(prealloc_slabs_value));
-        }
-
-        if (prealloc_threads_value && json_is_integer(prealloc_threads_value)) {
-            evpl_global_config_set_preallocate_threads(evpl_global_config,
-                                                       json_integer_value(prealloc_threads_value));
-        }
-    }
-
     /* Configure TLS if HTTPS is enabled */
     if (rest_https_port != 0) {
         if (rest_ssl_cert && rest_ssl_key) {


### PR DESCRIPTION
## Summary

Move the slab-preallocation settings from the `server` section to the shared `common` section, so the client honors them too.

`preallocate_slabs` and `preallocate_threads` were parsed only from the `server` block in `daemon.c`, so only the daemon could preallocate evpl slabs at startup — the fio client engine ignored them. They now live in `common` (parsed by `chimera_apply_common_config`, before `evpl_init`), with identical semantics, so both the daemon and the client pick them up when provided.

```json
"common": {
  "huge_pages": true, "huge_page_size": "1G", "slab_size": "1G",
  "preallocate_slabs": 64, "preallocate_threads": 4
}
```

## Change
- `src/common/common_config.h`: parse `preallocate_slabs` / `preallocate_threads` and call the evpl setters.
- `src/daemon/daemon.c`: drop the now-redundant `server`-section parsing.

## Validation
- End-to-end: with `preallocate_slabs: 3` in `common` (+ `huge_pages:true, huge_page_size:"2M", slab_size:"1G"`), the daemon's free 2 MiB hugepage count dropped by exactly 1536 (= 3 × 1 GiB ÷ 2 MiB) at startup — confirming preallocation is driven from `common`.
- fio + client test suites green (148).
