### PR TITLE
metrics: add common.metrics_file to dump a final scrape at shutdown

### DIFF
--- a/src/common/common_config.h
+++ b/src/common/common_config.h
@@ -113,3 +113,34 @@ chimera_apply_common_config(
         evpl_global_config_set_slab_size(cfg, size);
     }
 } /* chimera_apply_common_config */
+
+/*
+ * Return the path configured in the shared "common" section's "metrics_file"
+ * key, or NULL if the section or key is absent (or not a string).  This is the
+ * file into which a process dumps a final Prometheus scrape at shutdown -- the
+ * same exposition served live at :PORT/metrics -- so that metrics survive
+ * process exit even when a run is too short to scrape while it is running.  The
+ * returned pointer is owned by `root` and is only valid until json_decref(root);
+ * copy it if it must outlive the parsed config.
+ */
+static inline const char *
+chimera_common_metrics_file(json_t *root)
+{
+    json_t *common, *val;
+
+    if (!root) {
+        return NULL;
+    }
+
+    common = json_object_get(root, "common");
+    if (!json_is_object(common)) {
+        return NULL;
+    }
+
+    val = json_object_get(common, "metrics_file");
+    if (json_is_string(val)) {
+        return json_string_value(val);
+    }
+
+    return NULL;
+} /* chimera_common_metrics_file */

--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -795,6 +795,16 @@ main(
 
     chimera_server_destroy(server);
 
+    /* Optionally persist a final metrics scrape (common.metrics_file) before
+     * tearing down the registry, so short-lived runs keep their metrics. */
+    {
+        const char *metrics_file = chimera_common_metrics_file(config);
+
+        if (metrics_file) {
+            chimera_metrics_dump_file(chimera_metrics_get(metrics), metrics_file);
+        }
+    }
+
     chimera_metrics_destroy(metrics);
 
     chimera_server_info("Server shutdown complete.");

--- a/src/fio/fio.c
+++ b/src/fio/fio.c
@@ -41,6 +41,7 @@ int                           ChimeraNumClients   = 0;
 struct prometheus_metrics    *ChimeraMetrics      = NULL;
 struct chimera_client_config *ChimeraClientConfig = NULL;
 struct chimera_client        *ChimeraClient       = NULL;
+char                         *ChimeraMetricsFile  = NULL;
 
 struct chimera_fio_thread {
     int                              event_head;
@@ -215,8 +216,17 @@ fio_chimera_atexit(void)
 
     if (ChimeraNumClients == 0) {
 
+        /* Persist a final metrics scrape (common.metrics_file) before the
+         * registry is destroyed; fio runs are often too short to scrape live. */
+        if (ChimeraMetricsFile) {
+            chimera_metrics_dump_file(ChimeraMetrics, ChimeraMetricsFile);
+        }
+
         chimera_destroy(ChimeraClient);
         prometheus_metrics_destroy(ChimeraMetrics);
+
+        free(ChimeraMetricsFile);
+        ChimeraMetricsFile = NULL;
     }
 
     pthread_mutex_unlock(&ChimeraClientMutex);
@@ -338,6 +348,16 @@ fio_chimera_init(struct thread_data *td)
 
             chimera_apply_common_config(config, evpl_config);
             evpl_init(evpl_config);
+        }
+
+        /* Stash the shutdown metrics-dump path while the config is still
+         * loaded; it is consumed in fio_chimera_atexit() after config is freed. */
+        {
+            const char *metrics_file = chimera_common_metrics_file(config);
+
+            if (metrics_file) {
+                ChimeraMetricsFile = strdup(metrics_file);
+            }
         }
 
         ChimeraClient = chimera_client_init(ChimeraClientConfig, &root_cred, ChimeraMetrics);

--- a/src/metrics/metrics.c
+++ b/src/metrics/metrics.c
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include "evpl/evpl.h"
@@ -192,3 +193,67 @@ chimera_metrics_get(struct chimera_metrics *metrics)
 {
     return metrics->metrics;
 } /* chimera_metrics_get */
+
+SYMBOL_EXPORT int
+chimera_metrics_dump_file(
+    struct prometheus_metrics *metrics,
+    const char                *path)
+{
+    FILE  *fp;
+    char  *buf;
+    int    cap = 4 * 1024 * 1024;
+    int    len, evpl_len;
+    size_t written;
+
+    if (!path) {
+        return 0;
+    }
+
+    buf = malloc(cap);
+
+    if (!buf) {
+        chimera_metrics_error("Failed to allocate buffer to dump metrics to %s", path);
+        return -1;
+    }
+
+    /* Same concatenation the live /metrics endpoint produces: chimera's own
+     * registry first, then libevpl's appended into the remaining space.  Both
+     * emit Prometheus text format with disjoint name prefixes (chimera_* vs
+     * evpl_*), so the result is a single valid exposition page.
+     */
+    len = prometheus_metrics_scrape(metrics, buf, cap);
+
+    if (len < 0) {
+        chimera_metrics_error("Failed to scrape chimera metrics for %s", path);
+        free(buf);
+        return -1;
+    }
+
+    evpl_len = evpl_metrics_scrape(buf + len, cap - len);
+
+    if (evpl_len > 0) {
+        len += evpl_len;
+    }
+
+    fp = fopen(path, "w");
+
+    if (!fp) {
+        chimera_metrics_error("Failed to open metrics file %s for writing", path);
+        free(buf);
+        return -1;
+    }
+
+    written = fwrite(buf, 1, len, fp);
+
+    fclose(fp);
+    free(buf);
+
+    if (written != (size_t) len) {
+        chimera_metrics_error("Short write dumping metrics to %s", path);
+        return -1;
+    }
+
+    chimera_metrics_info("Wrote %d bytes of metrics to %s", len, path);
+
+    return 0;
+} /* chimera_metrics_dump_file */

--- a/src/metrics/metrics.h
+++ b/src/metrics/metrics.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -16,3 +16,14 @@ void chimera_metrics_destroy(
 
 struct prometheus_metrics * chimera_metrics_get(
     struct chimera_metrics *metrics);
+
+/*
+ * Scrape chimera's prometheus registry plus libevpl's metrics and write the
+ * combined Prometheus text exposition (identical to GET :PORT/metrics) to
+ * `path`, truncating it.  Intended to be called once at shutdown so that very
+ * short-lived processes can retain their metrics after exiting.  No-op when
+ * `path` is NULL.  Returns 0 on success, -1 on error.
+ */
+int chimera_metrics_dump_file(
+    struct prometheus_metrics *metrics,
+    const char                *path);


### PR DESCRIPTION
## Summary

Adds a `metrics_file` key to the shared `common` section of the chimera JSON config. When set, the process writes one final Prometheus scrape at shutdown — the same exposition served live at `:PORT/metrics` (chimera's registry plus libevpl's metrics, concatenated) — into that file, truncating it. Default unset/NULL preserves existing behavior.

This covers short-lived runs that exit before scraping the live endpoint is practical — notably fio via the chimera ioengine, whose `chimera_config` points at a chimera JSON config and so picks this up for free.

## Changes

- **`common/common_config.h`** — `chimera_common_metrics_file()` reads `common.metrics_file` (sibling to the existing `huge_pages`/`slab_size` parsing).
- **`metrics/metrics.c` + `metrics.h`** — `chimera_metrics_dump_file(prometheus_metrics *, path)`: scrapes chimera + libevpl metrics into a buffer and writes the file. No-op when path is NULL; returns 0/-1.
- **`daemon/daemon.c`** (server) — dumps after server teardown, before destroying the metrics registry, reading the path from the still-loaded config.
- **`fio/fio.c`** (client) — stashes the path during init (the config is freed there) and dumps in the `atexit` handler before destroying the registry.

## Notes

- The dump runs on the main thread while the metrics HTTP thread is still alive, i.e. the same concurrency profile as a live HTTP scrape, which is already supported.
- Example config:
  ```json
  "common": { "metrics_file": "/tmp/chimera-metrics.prom" }
  ```