### PR TITLE
Bump libevpl; move tcp_flavor to common config and honor it on the client

### DIFF
--- a/src/client/client.c
+++ b/src/client/client.c
@@ -14,6 +14,7 @@
 #include "client.h"
 #include "client_internal.h"
 #include "common/macros.h"
+#include "common/common_config.h"
 #include "vfs/vfs.h"
 #include "vfs/vfs_procs.h"
 #include "prometheus-c.h"
@@ -80,6 +81,14 @@ chimera_client_config_add_module(
 
     config->num_modules++;
 } /* chimera_client_config_add_module */
+
+SYMBOL_EXPORT void
+chimera_client_config_set_tcp_flavor(
+    struct chimera_client_config *config,
+    enum chimera_tcp_flavor       flavor)
+{
+    config->tcp_flavor = flavor;
+} /* chimera_client_config_set_tcp_flavor */
 
 SYMBOL_EXPORT struct chimera_client_thread *
 chimera_client_thread_init(
@@ -150,6 +159,10 @@ chimera_client_init(
                                    config->cache_ttl,
                                    metrics);
 
+    /* Propagate the common TCP flavor so VFS client modules (e.g. nfs)
+     * open outbound connections with the same transport. */
+    chimera_vfs_set_tcp_flavor(client->vfs, config->tcp_flavor);
+
     /* Initialize the root file handle after VFS is initialized */
     chimera_vfs_get_root_fh(client->root_fh, &client->root_fh_len);
 
@@ -197,6 +210,9 @@ chimera_client_init_json(
         free(config);
         return NULL;
     }
+
+    /* TCP transport flavor lives in the shared top-level "common" section. */
+    config->tcp_flavor = chimera_common_tcp_flavor(root);
 
     config_section = json_object_get(root, "config");
 

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -29,6 +29,11 @@ chimera_client_config_add_module(
     const char                   *module_path,
     const char                   *config_data);
 
+void
+chimera_client_config_set_tcp_flavor(
+    struct chimera_client_config *config,
+    enum chimera_tcp_flavor       flavor);
+
 struct chimera_client *
 chimera_client_init(
     const struct chimera_client_config *config,

--- a/src/client/client_internal.h
+++ b/src/client/client_internal.h
@@ -364,6 +364,7 @@ struct chimera_client_config {
     int                           async_delegation_threads;
     int                           cache_ttl;
     int                           max_fds;
+    enum chimera_tcp_flavor       tcp_flavor;
     char                          kv_module[64];
     struct chimera_vfs_module_cfg modules[CHIMERA_CLIENT_MAX_MODULES];
     int                           num_modules;

--- a/src/common/common_config.h
+++ b/src/common/common_config.h
@@ -6,9 +6,47 @@
 
 #include <stdlib.h>
 #include <stdint.h>
+#include <strings.h>
 #include <jansson.h>
 
 #include "evpl/evpl.h"
+#include "common/tcp_flavor.h"
+
+/*
+ * Read the TCP transport flavor from the top-level "common" section.  This is
+ * the shared setting honored by both the server (listen sockets) and the
+ * client (outbound connections).  Defaults to CHIMERA_TCP_FLAVOR_PLAIN when
+ * absent or unrecognized.  `root` is the parsed top-level config (may be NULL).
+ */
+static inline enum chimera_tcp_flavor
+chimera_common_tcp_flavor(json_t *root)
+{
+    json_t *common, *val;
+    const char *s;
+
+    if (!root) {
+        return CHIMERA_TCP_FLAVOR_PLAIN;
+    }
+
+    common = json_object_get(root, "common");
+    if (!json_is_object(common)) {
+        return CHIMERA_TCP_FLAVOR_PLAIN;
+    }
+
+    val = json_object_get(common, "tcp_flavor");
+    if (!json_is_string(val)) {
+        return CHIMERA_TCP_FLAVOR_PLAIN;
+    }
+
+    s = json_string_value(val);
+    if (strcasecmp(s, "xlio") == 0) {
+        return CHIMERA_TCP_FLAVOR_XLIO;
+    } else if (strcasecmp(s, "io_uring") == 0) {
+        return CHIMERA_TCP_FLAVOR_IO_URING;
+    }
+
+    return CHIMERA_TCP_FLAVOR_PLAIN;
+} /* chimera_common_tcp_flavor */
 
 /*
  * Parse a size from a JSON value.  A bare integer is taken as a byte count; a
@@ -86,6 +124,12 @@ chimera_apply_common_config(
 {
     json_t  *common, *val;
     uint64_t size;
+
+    /* Only enable XLIO in libevpl when the common tcp_flavor selects it;
+     * libevpl otherwise spins up XLIO polling in every worker thread. Done
+     * unconditionally (chimera_common_tcp_flavor handles a missing section). */
+    evpl_global_config_set_xlio_enabled(cfg,
+                                        chimera_common_tcp_flavor(root) == CHIMERA_TCP_FLAVOR_XLIO);
 
     if (!root) {
         return;

--- a/src/common/tcp_flavor.h
+++ b/src/common/tcp_flavor.h
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#pragma once
+
+#include "evpl/evpl.h"
+
+/*
+ * TCP transport "flavor" selects which evpl stream backend is used for
+ * plain (non-RDMA) TCP connections.  It is a process-wide / common setting
+ * honored by both the server (listen sockets) and the client (outbound NFS
+ * connections), so it lives here rather than in the server config.
+ */
+enum chimera_tcp_flavor {
+    CHIMERA_TCP_FLAVOR_PLAIN    = 0,
+    CHIMERA_TCP_FLAVOR_IO_URING = 1,
+    CHIMERA_TCP_FLAVOR_XLIO     = 2,
+};
+
+/* Map a TCP flavor to the corresponding evpl stream protocol. */
+static inline enum evpl_protocol_id
+chimera_tcp_flavor_to_protocol(enum chimera_tcp_flavor flavor)
+{
+    switch (flavor) {
+        case CHIMERA_TCP_FLAVOR_IO_URING:
+            return EVPL_STREAM_IO_URING_TCP;
+        case CHIMERA_TCP_FLAVOR_XLIO:
+            return EVPL_STREAM_XLIO_TCP;
+        case CHIMERA_TCP_FLAVOR_PLAIN:
+        default:
+            return EVPL_STREAM_SOCKET_TCP;
+    } /* switch */
+} /* chimera_tcp_flavor_to_protocol */

--- a/src/daemon/chimera.json
+++ b/src/daemon/chimera.json
@@ -1,4 +1,7 @@
 {
+    "common": {
+	"tcp_flavor": "plain"
+    },
     "server": {
 	"threads": 16,
 	"sync_delegation": true,

--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -249,31 +249,8 @@ main(
     evpl_global_config_set_huge_pages(evpl_global_config, 1);
     evpl_global_config_set_libaio_max_pending(evpl_global_config, 1024);
 
-    /* Only enable XLIO in libevpl when we actually plan to use it.
-     * libevpl defaults xlio_enabled=1 and starts XLIO's polling
-     * machinery in every worker thread regardless of whether any
-     * socket binds to EVPL_STREAM_XLIO_TCP — that's pure overhead
-     * for plain-TCP and RDMA deployments.
-     */
-    {
-        enum chimera_tcp_flavor flavor = CHIMERA_TCP_FLAVOR_PLAIN;
-        json_t                 *flavor_value;
-
-        if (server_params) {
-            flavor_value = json_object_get(server_params, "tcp_flavor");
-            if (flavor_value && json_is_string(flavor_value)) {
-                const char *s = json_string_value(flavor_value);
-                if (strcasecmp(s, "xlio") == 0) {
-                    flavor = CHIMERA_TCP_FLAVOR_XLIO;
-                } else if (strcasecmp(s, "io_uring") == 0) {
-                    flavor = CHIMERA_TCP_FLAVOR_IO_URING;
-                }
-            }
-        }
-
-        evpl_global_config_set_xlio_enabled(evpl_global_config,
-                                            flavor == CHIMERA_TCP_FLAVOR_XLIO);
-    }
+    /* XLIO enable/disable is derived from the common tcp_flavor and applied
+     * by chimera_apply_common_config() below, before evpl_init(). */
 
     if (server_params) {
         json_t *prealloc_slabs_value   = json_object_get(server_params, "preallocate_slabs");
@@ -564,19 +541,7 @@ main(
         chimera_server_config_set_soft_fail_bad_req(server_config, 1);
     }
 
-    json_value = json_object_get(server_params, "tcp_flavor");
-    if (json_is_string(json_value)) {
-        str_value = json_string_value(json_value);
-        if (strcasecmp(str_value, "plain") == 0) {
-            chimera_server_config_set_tcp_flavor(server_config, CHIMERA_TCP_FLAVOR_PLAIN);
-        } else if (strcasecmp(str_value, "io_uring") == 0) {
-            chimera_server_config_set_tcp_flavor(server_config, CHIMERA_TCP_FLAVOR_IO_URING);
-        } else if (strcasecmp(str_value, "xlio") == 0) {
-            chimera_server_config_set_tcp_flavor(server_config, CHIMERA_TCP_FLAVOR_XLIO);
-        } else {
-            chimera_server_error("Unknown tcp_flavor '%s', defaulting to plain", str_value);
-        }
-    }
+    chimera_server_config_set_tcp_flavor(server_config, chimera_common_tcp_flavor(config));
 
     // Parse SMB auth configuration
     json_t *smb_auth = json_object_get(server_params, "smb_auth");

--- a/src/fio/fio.c
+++ b/src/fio/fio.c
@@ -327,6 +327,10 @@ fio_chimera_init(struct thread_data *td)
             }
         }
 
+        /* Honor the shared common tcp_flavor for outbound client connections. */
+        chimera_client_config_set_tcp_flavor(ChimeraClientConfig,
+                                             chimera_common_tcp_flavor(config));
+
         struct chimera_vfs_cred root_cred;
         chimera_vfs_cred_init_unix(&root_cred, 0, 0, 0, NULL);
 

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -863,15 +863,7 @@ chimera_server_config_get_tcp_flavor(const struct chimera_server_config *config)
 SYMBOL_EXPORT enum evpl_protocol_id
 chimera_server_config_get_tcp_stream_protocol(const struct chimera_server_config *config)
 {
-    switch (config->tcp_flavor) {
-        case CHIMERA_TCP_FLAVOR_IO_URING:
-            return EVPL_STREAM_IO_URING_TCP;
-        case CHIMERA_TCP_FLAVOR_XLIO:
-            return EVPL_STREAM_XLIO_TCP;
-        case CHIMERA_TCP_FLAVOR_PLAIN:
-        default:
-            return EVPL_STREAM_SOCKET_TCP;
-    } /* switch */
+    return chimera_tcp_flavor_to_protocol(config->tcp_flavor);
 } /* chimera_server_config_get_tcp_stream_protocol */
 
 static void
@@ -1142,6 +1134,10 @@ chimera_server_init(
                                    config->kv_module,
                                    config->cache_ttl,
                                    metrics);
+
+    /* Propagate the common TCP flavor so VFS client modules (e.g. nfs)
+     * open outbound connections with the same transport. */
+    chimera_vfs_set_tcp_flavor(server->vfs, config->tcp_flavor);
 
     /* Enable the pNFS feature whenever configured.  Orchestrated flex-files
      * needs a data-server table (below); a layout-sourcing backend (e.g. diskfs

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -31,12 +31,6 @@ struct chimera_server_config_smb_nic {
     uint8_t  rdma;
 };
 
-enum chimera_tcp_flavor {
-    CHIMERA_TCP_FLAVOR_PLAIN    = 0,
-    CHIMERA_TCP_FLAVOR_IO_URING = 1,
-    CHIMERA_TCP_FLAVOR_XLIO     = 2,
-};
-
 
 struct chimera_server_config *
 chimera_server_config_init(

--- a/src/vfs/nfs/nfs.c
+++ b/src/vfs/nfs/nfs.c
@@ -92,6 +92,9 @@ chimera_nfs_init(
     shared->servers     = calloc(shared->max_servers, sizeof(*shared->servers));
     shared->servers_map = NULL;
 
+    /* Default until the common tcp_flavor is observed at mount time. */
+    shared->tcp_protocol = EVPL_STREAM_SOCKET_TCP;
+
     PORTMAP_V2_init(&shared->portmap_v2);
     NFS_MOUNT_V3_init(&shared->mount_v3);
     NFS_V3_init(&shared->nfs_v3);
@@ -243,6 +246,10 @@ chimera_nfs_dispatch(
     int                               nfsvers;
 
     if (request->opcode == CHIMERA_VFS_OP_MOUNT) {
+        /* Resolve the common TCP flavor for outbound connections from the
+         * VFS once we have a thread/vfs in hand. Constant per process. */
+        shared->tcp_protocol = chimera_tcp_flavor_to_protocol(request->thread->vfs->tcp_flavor);
+
         nfsvers = chimera_nfs_get_mount_version(&request->mount.options);
         if (nfsvers < 0) {
             chimera_nfsclient_error("Invalid NFS version in mount options");

--- a/src/vfs/nfs/nfs3_mount.c
+++ b/src/vfs/nfs/nfs3_mount.c
@@ -315,7 +315,7 @@ chimera_portmap_getport_nfs_callback(
     server->nfs_endpoint = evpl_endpoint_create(server->hostname, port);
 
     server_thread->nfs_conn = evpl_rpc2_client_connect(server_thread->thread->rpc2_thread,
-                                                       EVPL_STREAM_SOCKET_TCP,
+                                                       server_thread->shared->tcp_protocol,
                                                        server->nfs_endpoint,
                                                        NULL, 0, NULL);
 
@@ -401,7 +401,7 @@ chimera_portmap_getport_mountd_callback(
     server->mount_endpoint = evpl_endpoint_create(server->hostname, port);
 
     server_thread->mount_conn = evpl_rpc2_client_connect(server_thread->thread->rpc2_thread,
-                                                         EVPL_STREAM_SOCKET_TCP,
+                                                         server_thread->shared->tcp_protocol,
                                                          server->mount_endpoint,
                                                          NULL, 0, NULL);
 
@@ -562,7 +562,7 @@ chimera_nfs3_mount(
         server->portmap_endpoint = evpl_endpoint_create(server->hostname, 111);
 
         server_thread->portmap_conn = evpl_rpc2_client_connect(thread->rpc2_thread,
-                                                               EVPL_STREAM_SOCKET_TCP,
+                                                               server_thread->shared->tcp_protocol,
                                                                server->portmap_endpoint,
                                                                NULL, 0, NULL);
 

--- a/src/vfs/nfs/nfs4_mount.c
+++ b/src/vfs/nfs/nfs4_mount.c
@@ -790,7 +790,7 @@ chimera_nfs4_mount(
         /* Create NFS endpoint and connect */
         server->nfs_endpoint = evpl_endpoint_create(server->hostname, server->nfs_port);
 
-        proto = server->use_rdma ? server->rdma_protocol : EVPL_STREAM_SOCKET_TCP;
+        proto = server->use_rdma ? server->rdma_protocol : server_thread->shared->tcp_protocol;
 
         server_thread->nfs_conn = evpl_rpc2_client_connect(
             thread->rpc2_thread,

--- a/src/vfs/nfs/nfs_internal.h
+++ b/src/vfs/nfs/nfs_internal.h
@@ -170,6 +170,11 @@ struct chimera_nfs_shared {
 
     struct prometheus_histogram       *op_histogram;
     struct prometheus_metrics         *metrics;
+
+    /* evpl stream protocol for outbound plain-TCP connections, resolved from
+     * the common tcp_flavor setting (chimera_vfs->tcp_flavor) at mount time.
+     * Defaults to EVPL_STREAM_SOCKET_TCP. */
+    enum evpl_protocol_id tcp_protocol;
 };
 
 struct chimera_nfs_thread {
@@ -252,7 +257,7 @@ chimera_nfs_thread_get_server_thread(
     if (unlikely(!server_thread->nfs_conn)) {
         enum evpl_protocol_id proto = server_thread->server->use_rdma
                                       ? server_thread->server->rdma_protocol
-                                      : EVPL_STREAM_SOCKET_TCP;
+                                      : server_thread->shared->tcp_protocol;
         server_thread->nfs_conn = evpl_rpc2_client_connect(thread->rpc2_thread,
                                                            proto,
                                                            server_thread->server->nfs_endpoint,
@@ -261,7 +266,7 @@ chimera_nfs_thread_get_server_thread(
 
     if (unlikely(!server_thread->nlm_conn && server_thread->server->nlm_endpoint)) {
         server_thread->nlm_conn = evpl_rpc2_client_connect(thread->rpc2_thread,
-                                                           EVPL_STREAM_SOCKET_TCP,
+                                                           server_thread->shared->tcp_protocol,
                                                            server_thread->server->nlm_endpoint,
                                                            NULL, 0, NULL);
     }

--- a/src/vfs/vfs.c
+++ b/src/vfs/vfs.c
@@ -539,6 +539,14 @@ chimera_vfs_init(
     return vfs;
 } /* chimera_vfs_init */
 
+SYMBOL_EXPORT void
+chimera_vfs_set_tcp_flavor(
+    struct chimera_vfs     *vfs,
+    enum chimera_tcp_flavor flavor)
+{
+    vfs->tcp_flavor = flavor;
+} /* chimera_vfs_set_tcp_flavor */
+
 SYMBOL_EXPORT int
 chimera_vfs_fh_is_plausible(
     struct chimera_vfs_thread *thread,

--- a/src/vfs/vfs.h
+++ b/src/vfs/vfs.h
@@ -15,6 +15,7 @@
 #include "evpl/evpl.h"
 #include "prometheus-c.h"
 #include "vfs_clock.h"
+#include "common/tcp_flavor.h"
 
 #define CHIMERA_VFS_PATH_MAX 4096
 #define CHIMERA_VFS_NAME_MAX 256
@@ -1333,6 +1334,7 @@ struct chimera_vfs {
     struct chimera_vfs_delegation_thread *async_delegation_threads;
     struct chimera_vfs_close_thread       close_thread;
     struct chimera_vfs_metrics            metrics;
+    enum chimera_tcp_flavor               tcp_flavor;
     int                                   machine_name_len;
     char                                  machine_name[256];
 };
@@ -1380,6 +1382,14 @@ chimera_vfs_init(
 void
 chimera_vfs_destroy(
     struct chimera_vfs *vfs);
+
+/* Select the TCP transport flavor used for outbound (client) connections.
+ * Defaults to CHIMERA_TCP_FLAVOR_PLAIN; honored by VFS modules that open
+ * their own TCP connections (e.g. the NFS client). */
+void
+chimera_vfs_set_tcp_flavor(
+    struct chimera_vfs     *vfs,
+    enum chimera_tcp_flavor flavor);
 
 /* Get the root pseudo-filesystem's file handle */
 void


### PR DESCRIPTION
## Summary

Two related changes:

1. **Bump the libevpl submodule** to current `main`, pulling in:
   - rdmacm: record local address on the client connect path (#84) — fixes RDMA client connections logging `(NULL)` as the local address
   - rdmacm: check `ibv_alloc_td` / parent_domain allocation failures (#82)
   - core: configurable hugetlb page size for slab allocation (#83)

2. **Move `tcp_flavor` out of the `server` config section into the shared top-level `common` section, and make the client honor it.**

## tcp_flavor changes

`tcp_flavor` (`plain` / `io_uring` / `xlio`) selects the evpl stream backend for non-RDMA TCP. It was server-only: parsed from the `"server"` JSON block and used solely for the server's listen sockets. The client (NFS VFS module) ignored it and always opened plain `EVPL_STREAM_SOCKET_TCP` connections.

- The `enum chimera_tcp_flavor` and a `chimera_tcp_flavor_to_protocol()` helper move to a lightweight common header (`common/tcp_flavor.h`), out of `server.h`.
- Parsing moves into the existing shared `common/common_config.h` (the same place `huge_pages`/`slab_size` are read), via a new `chimera_common_tcp_flavor(root)` that reads the top-level `"common"` section. Both the daemon and the fio client already call into this header, so the setting is now parsed identically on both sides.
- The XLIO enable/disable decision (an evpl global setting) folds into `chimera_apply_common_config()`, so the daemon and the fio client both derive it from the common `tcp_flavor` — removing the daemon's bespoke copy.
- The flavor is plumbed to `struct chimera_vfs` via a new `chimera_vfs_set_tcp_flavor()`; the server and client both set it after `chimera_vfs_init()`.
- The NFS VFS client resolves it once at mount time (`chimera_nfs_shared.tcp_protocol`) and uses it for all outbound plain-TCP connections — portmap, mountd, NFS-over-TCP, and NLM — instead of hardcoding `EVPL_STREAM_SOCKET_TCP`.

`tcp_flavor` is now read only from `"common"`; the old `"server"` location is no longer consulted. The example config gains a `"common"` block documenting the key.

Built clean (release) and all client tests link.