### PR TITLE
diskfs: overwrite in place, real fallocate, and extent coalescing

### DIFF
--- a/src/vfs/diskfs/diskfs.c
+++ b/src/vfs/diskfs/diskfs.c
@@ -101,6 +101,7 @@ struct diskfs_extent {
     uint32_t              length;
     uint64_t              device_offset;
     uint64_t              file_offset;
+    uint32_t              flags;       /* DISKFS_EXT_* */
     void                 *buffer;
     struct rb_node        node;
     struct diskfs_extent *next;
@@ -680,10 +681,15 @@ struct diskfs_dirent_rec {
     char     name[];
 } __attribute__((packed));
 
+/* extent_rec.flags bits */
+#define DISKFS_EXT_UNWRITTEN 0x1u   /* space reserved (e.g. fallocate) but never
+                                     * written: reads return zeros, the first
+                                     * write clears the bit */
+
 struct diskfs_extent_rec {
     uint64_t length;
     uint32_t device_id;
-    uint32_t pad;
+    uint32_t flags;
     uint64_t device_offset;
 } __attribute__((packed));
 
@@ -5657,12 +5663,13 @@ diskfs_ext_insert(
     uint64_t              file_offset,
     uint64_t              length,
     uint32_t              device_id,
-    uint64_t              device_offset)
+    uint64_t              device_offset,
+    uint32_t              flags)
 {
     struct diskfs_extent_rec rec = {
         .length        = length,
         .device_id     = device_id,
-        .pad           = 0,
+        .flags         = flags,
         .device_offset = device_offset,
     };
     struct diskfs_bt_key     key = diskfs_extent_key(file_offset);
@@ -5705,6 +5712,7 @@ diskfs_ext_floor(
     out->length        = (uint32_t) rec.length;
     out->device_id     = rec.device_id;
     out->device_offset = rec.device_offset;
+    out->flags         = rec.flags;
     return 1;
 } /* diskfs_ext_floor */
 
@@ -5730,6 +5738,7 @@ diskfs_ext_ceil(
     out->length        = (uint32_t) rec.length;
     out->device_id     = rec.device_id;
     out->device_offset = rec.device_offset;
+    out->flags         = rec.flags;
     return 1;
 } /* diskfs_ext_ceil */
 
@@ -5811,13 +5820,14 @@ diskfs_ext_insert_async(
     uint64_t              length,
     uint32_t              device_id,
     uint64_t              device_offset,
+    uint32_t              flags,
     diskfs_bt_cb_t        cb,
     void                 *private_data)
 {
     struct diskfs_extent_rec rec = {
         .length        = length,
         .device_id     = device_id,
-        .pad           = 0,
+        .flags         = flags,
         .device_offset = device_offset,
     };
     struct diskfs_bt_key     key = diskfs_extent_key(file_offset);
@@ -5859,6 +5869,7 @@ diskfs_ext_from_op(
     out->length        = (uint32_t) rec->length;
     out->device_id     = rec->device_id;
     out->device_offset = rec->device_offset;
+    out->flags         = rec->flags;
     return 1;
 } /* diskfs_ext_from_op */
 
@@ -9075,7 +9086,7 @@ diskfs_setattr_trunc_removed_cb(
             struct diskfs_extent_rec rec = {
                 .length        = new_logical,
                 .device_id     = p->ext_iter.device_id,
-                .pad           = 0,
+                .flags         = p->ext_iter.flags,
                 .device_offset = p->ext_iter.device_offset,
             };
             struct diskfs_bt_key     key = diskfs_extent_key(p->ext_iter.file_offset);
@@ -11055,6 +11066,16 @@ diskfs_read_process(struct chimera_vfs_request *request)
         overlap_length = read_left;
     }
 
+    if (extent->flags & DISKFS_EXT_UNWRITTEN) {
+        /* Space is reserved (fallocate) but was never written: it reads back
+         * as zeros, with no device I/O.  Fill the cursor like a hole and skip
+         * the read loop. */
+        evpl_iovec_cursor_zero(&p->rd_cursor, overlap_length);
+        read_offset   += overlap_length;
+        read_left     -= overlap_length;
+        overlap_length = 0;
+    }
+
     while (overlap_length) {
         uint64_t dev_offset;
         uint32_t dev_pad, total;
@@ -11597,7 +11618,7 @@ diskfs_write_trim_done(struct chimera_vfs_request *request)
 
     if (diskfs_ext_insert_async(op, thread, p->txn, p->inode_stash[0],
                                 p->rmw_aligned_start, p->rmw_aligned_length,
-                                p->rmw_device_id, p->rmw_device_offset,
+                                p->rmw_device_id, p->rmw_device_offset, 0,
                                 diskfs_write_inserted_cb, request)) {
         diskfs_write_inserted_cb(op, op->result, request);
     }
@@ -11676,6 +11697,7 @@ diskfs_write_trim_spans_removed_cb(
     if (diskfs_ext_insert_async(op, thread, p->txn, p->inode_stash[0],
                                 p->ext_iter.file_offset, astart - p->ext_iter.file_offset,
                                 p->ext_iter.device_id, p->ext_iter.device_offset,
+                                p->ext_iter.flags,
                                 diskfs_write_trim_spans_before_cb, request)) {
         diskfs_write_trim_spans_before_cb(op, op->result, request);
     }
@@ -11721,6 +11743,7 @@ diskfs_write_trim_oleft_removed_cb(
     if (diskfs_ext_insert_async(op, thread, p->txn, p->inode_stash[0],
                                 p->ext_iter.file_offset, astart - p->ext_iter.file_offset,
                                 p->ext_iter.device_id, p->ext_iter.device_offset,
+                                p->ext_iter.flags,
                                 diskfs_write_trim_advance_cb, request)) {
         diskfs_write_trim_advance_cb(op, op->result, request);
     }
@@ -11747,6 +11770,7 @@ diskfs_write_trim_oright_removed_cb(
     if (diskfs_ext_insert_async(op, thread, p->txn, p->inode_stash[0], aend, ee - aend,
                                 p->ext_iter.device_id,
                                 p->ext_iter.device_offset + (aend - es),
+                                p->ext_iter.flags,
                                 diskfs_write_trim_spans_before_cb, request)) {
         diskfs_write_trim_spans_before_cb(op, op->result, request);
     }
@@ -11788,6 +11812,7 @@ diskfs_write_trim_process(struct chimera_vfs_request *request)
         if (diskfs_ext_insert_async(op, thread, p->txn, p->inode_stash[0], aend,
                                     ee - aend, p->ext_iter.device_id,
                                     p->ext_iter.device_offset + (aend - es),
+                                    p->ext_iter.flags,
                                     diskfs_write_trim_spans_after_cb, request)) {
             diskfs_write_trim_spans_after_cb(op, op->result, request);
         }
@@ -12218,6 +12243,7 @@ diskfs_dealloc_ostart_removed_cb(
                                 p->ext_iter.file_offset,
                                 p->loop_off - p->ext_iter.file_offset,
                                 p->ext_iter.device_id, p->ext_iter.device_offset,
+                                p->ext_iter.flags,
                                 diskfs_dealloc_modify_advance_cb, request)) {
         diskfs_dealloc_modify_advance_cb(op, op->result, request);
     }
@@ -12244,6 +12270,7 @@ diskfs_dealloc_oend_removed_cb(
     if (diskfs_ext_insert_async(op, thread, p->txn, p->inode_stash[0], he, ee - he,
                                 p->ext_iter.device_id,
                                 p->ext_iter.device_offset + (he - es),
+                                p->ext_iter.flags,
                                 diskfs_dealloc_modify_finish_cb, request)) {
         diskfs_dealloc_modify_finish_cb(op, op->result, request);
     }
@@ -12281,6 +12308,7 @@ diskfs_dealloc_spans_removed_cb(
                                 p->ext_iter.file_offset,
                                 p->loop_off - p->ext_iter.file_offset,
                                 p->ext_iter.device_id, p->ext_iter.device_offset,
+                                p->ext_iter.flags,
                                 diskfs_dealloc_spans_before_cb, request)) {
         diskfs_dealloc_spans_before_cb(op, op->result, request);
     }
@@ -12350,6 +12378,7 @@ diskfs_dealloc_process(struct chimera_vfs_request *request)
         if (diskfs_ext_insert_async(op, thread, p->txn, p->inode_stash[0], hole_end,
                                     ee - hole_end, p->ext_iter.device_id,
                                     p->ext_iter.device_offset + (hole_end - es),
+                                    p->ext_iter.flags,
                                     diskfs_dealloc_spans_after_cb, request)) {
             diskfs_dealloc_spans_after_cb(op, op->result, request);
         }
@@ -12397,6 +12426,176 @@ diskfs_dealloc_first_cb(
     diskfs_dealloc_process(request);
 } /* diskfs_dealloc_first_cb */
 
+/*
+ * ALLOCATE (fallocate, non-deallocate): reserve real backing space for every
+ * gap in the requested range by allocating blocks and recording them as
+ * UNWRITTEN extents.  Such extents read back as zeros (no device I/O) until
+ * the first write, which clears the bit and overwrites the reserved blocks in
+ * place.  This makes ALLOCATE genuinely reserve space without zero-filling it.
+ *
+ * Async walk over the inode's extent map (all state in p):
+ *   loop_off  = current 4 KiB-aligned offset being examined
+ *   loop_pos  = 4 KiB-aligned end of the requested range
+ *   loop_left = end of the gap currently being filled
+ * A single extent is capped so one space-map reservation can satisfy it; a
+ * larger gap is filled by several contiguous extents (coalesced on insert).
+ */
+#define DISKFS_ALLOCATE_MAX_EXTENT (256ULL << 20)
+
+static void diskfs_allocate_reserve_step(
+    struct chimera_vfs_request *request);
+static void diskfs_allocate_do_alloc(
+    struct chimera_vfs_request *request);
+
+static void
+diskfs_allocate_alloc_resume(
+    struct diskfs_thread *thread,
+    void                 *arg)
+{
+    (void) thread;
+    diskfs_allocate_do_alloc((struct chimera_vfs_request *) arg);
+} /* diskfs_allocate_alloc_resume */
+
+static void
+diskfs_allocate_inserted_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+
+    (void) result;
+    diskfs_bt_op_free(p->thread, op);
+
+    if (p->loop_off < p->loop_left) {
+        diskfs_allocate_do_alloc(request);      /* more of this gap */
+    } else {
+        diskfs_allocate_reserve_step(request);  /* on to the next gap */
+    }
+} /* diskfs_allocate_inserted_cb */
+
+static void
+diskfs_allocate_do_alloc(struct chimera_vfs_request *request)
+{
+    struct diskfs_request_private *p      = request->plugin_data;
+    struct diskfs_thread          *thread = p->thread;
+    struct diskfs_bt_op           *op;
+    uint64_t                       off = p->loop_off;
+    uint64_t                       dev_id, dev_off, chunk;
+    int                            rc;
+
+    chunk = p->loop_left - off;
+    if (chunk > DISKFS_ALLOCATE_MAX_EXTENT) {
+        chunk = DISKFS_ALLOCATE_MAX_EXTENT;
+    }
+
+    rc = diskfs_thread_alloc_space(thread, p->txn, (int64_t) chunk,
+                                   &dev_id, &dev_off,
+                                   diskfs_allocate_alloc_resume, request);
+    if (rc == SM_AGAIN) {
+        return;     /* parked; resume re-drives diskfs_allocate_do_alloc */
+    }
+    if (rc) {
+        diskfs_op_fail(request, p->txn, CHIMERA_VFS_ENOSPC);
+        return;
+    }
+
+    /* Advance before inserting: the insert may complete inline and re-enter
+     * diskfs_allocate_inserted_cb, which reads loop_off. */
+    p->loop_off = off + chunk;
+
+    op = diskfs_bt_op_alloc(thread);
+    if (diskfs_ext_insert_async(op, thread, p->txn, p->inode_stash[0],
+                                off, chunk, (uint32_t) dev_id, dev_off,
+                                DISKFS_EXT_UNWRITTEN,
+                                diskfs_allocate_inserted_cb, request)) {
+        diskfs_allocate_inserted_cb(op, op->result, request);
+    }
+} /* diskfs_allocate_do_alloc */
+
+static void
+diskfs_allocate_holeend_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+    struct diskfs_extent           next;
+    int                            have;
+
+    have = diskfs_ext_from_op(op, result, &next);
+    diskfs_bt_op_free(p->thread, op);
+
+    /* The gap runs from loop_off to the next extent, clamped to the end. */
+    p->loop_left = p->loop_pos;
+    if (have && next.file_offset < p->loop_left) {
+        p->loop_left = next.file_offset;
+    }
+    diskfs_allocate_do_alloc(request);
+} /* diskfs_allocate_holeend_cb */
+
+static void
+diskfs_allocate_floor_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+    struct diskfs_thread          *thread  = p->thread;
+    struct diskfs_extent           e;
+    int                            have;
+
+    have = diskfs_ext_from_op(op, result, &e);
+    diskfs_bt_op_free(thread, op);
+
+    if (have && e.file_offset + e.length > p->loop_off) {
+        /* Already backed (written or unwritten): skip past this extent. */
+        p->loop_off = e.file_offset + e.length;
+        diskfs_allocate_reserve_step(request);
+        return;
+    }
+
+    /* Hole at loop_off: find where it ends (next extent at/after loop_off). */
+    op = diskfs_bt_op_alloc(thread);
+    if (diskfs_ext_ceil_async(op, thread, p->inode_stash[0], p->loop_off,
+                              p->rec_scratch, sizeof(p->rec_scratch),
+                              diskfs_allocate_holeend_cb, request)) {
+        diskfs_allocate_holeend_cb(op, op->result, request);
+    }
+} /* diskfs_allocate_floor_cb */
+
+static void
+diskfs_allocate_reserve_step(struct chimera_vfs_request *request)
+{
+    struct diskfs_request_private *p      = request->plugin_data;
+    struct diskfs_thread          *thread = p->thread;
+    struct diskfs_bt_op           *op;
+
+    if (p->loop_off >= p->loop_pos) {
+        /* Reservation complete; extend the logical size if the request did. */
+        struct diskfs_inode *inode   = p->inode_stash[0];
+        uint64_t             new_end = request->allocate.offset +
+            request->allocate.length;
+
+        if (new_end > inode->size) {
+            inode->size       = new_end;
+            inode->space_used = (inode->size + 4095) & ~4095;
+        }
+        diskfs_allocate_finalize(request);
+        return;
+    }
+
+    op = diskfs_bt_op_alloc(thread);
+    if (diskfs_ext_floor_async(op, thread, p->inode_stash[0], p->loop_off,
+                               p->rec_scratch, sizeof(p->rec_scratch),
+                               diskfs_allocate_floor_cb, request)) {
+        diskfs_allocate_floor_cb(op, op->result, request);
+    }
+} /* diskfs_allocate_reserve_step */
+
 static void
 diskfs_allocate_inode_cb(
     struct diskfs_inode *inode,
@@ -12436,14 +12635,15 @@ diskfs_allocate_inode_cb(
             }
             return;
         }
-    } else {
-        /* ALLOCATE: extend file size if needed. */
-        uint64_t new_end = request->allocate.offset + request->allocate.length;
-
-        if (new_end > inode->size) {
-            inode->size       = new_end;
-            inode->space_used = (inode->size + 4095) & ~4095;
-        }
+    } else if (request->allocate.length) {
+        /* ALLOCATE: reserve backing space for any gap in the (block-aligned)
+         * requested range as UNWRITTEN extents, then extend the size.  The
+         * walk drives diskfs_allocate_finalize when it completes. */
+        p->loop_off = request->allocate.offset & ~4095ULL;
+        p->loop_pos = (request->allocate.offset + request->allocate.length +
+                       4095ULL) & ~4095ULL;
+        diskfs_allocate_reserve_step(request);
+        return;
     }
 
     diskfs_allocate_finalize(request);
@@ -14253,7 +14453,7 @@ diskfs_get_layout_do_alloc(
     op = diskfs_bt_op_alloc(thread);
     if (diskfs_ext_insert_async(op, thread, p->txn, p->inode_stash[0],
                                 p->loop_off, p->rmw_aligned_length,
-                                (uint32_t) dev_id, dev_off,
+                                (uint32_t) dev_id, dev_off, 0,
                                 diskfs_get_layout_inserted_cb, request)) {
         diskfs_get_layout_inserted_cb(op, op->result, request);
     }

--- a/src/vfs/diskfs/diskfs.c
+++ b/src/vfs/diskfs/diskfs.c
@@ -12891,8 +12891,14 @@ diskfs_allocate_floor_cb(
     diskfs_bt_op_free(thread, op);
 
     if (have && e.file_offset + e.length > p->loop_off) {
-        /* Already backed (written or unwritten): skip past this extent. */
-        p->loop_off = e.file_offset + e.length;
+        /* Already backed (written or unwritten): skip past this extent.  Round
+         * up to the next block: an extent that ends mid-block (e.g. a partial
+         * last block left by truncate) physically owns the rest of that block,
+         * so a gap allocation must start at the next block boundary.  Starting
+         * at an unaligned file_offset would pair it with a block-aligned device
+         * offset from the space map, breaking the file==device block alignment
+         * that diskfs's block I/O relies on. */
+        p->loop_off = (e.file_offset + e.length + 4095) & ~4095ULL;
         diskfs_allocate_reserve_step(request);
         return;
     }

--- a/src/vfs/diskfs/diskfs.c
+++ b/src/vfs/diskfs/diskfs.c
@@ -12024,8 +12024,7 @@ diskfs_write_suffix_cb(
 
     if (have && p->ext_iter.file_offset <= write_end &&
         write_end < p->ext_iter.file_offset + p->ext_iter.length) {
-        uint64_t suffix_block = write_end & ~4095ULL;
-        uint64_t ee           = p->ext_iter.file_offset + p->ext_iter.length;
+        uint64_t ee = p->ext_iter.file_offset + p->ext_iter.length;
 
         if (ee >= aend) {
             p->rmw_suffix_valid = p->rmw_suffix_len;
@@ -12035,17 +12034,18 @@ diskfs_write_suffix_cb(
             p->rmw_suffix_valid = 0;
         }
 
-        if (suffix_block >= p->ext_iter.file_offset) {
-            p->need_suffix_read     = 1;
-            p->suffix_device_id     = p->ext_iter.device_id;
-            p->suffix_device_offset = p->ext_iter.device_offset +
-                (suffix_block - p->ext_iter.file_offset);
-        } else {
-            p->need_suffix_read     = 1;
-            p->suffix_device_id     = p->ext_iter.device_id;
-            p->suffix_device_offset = p->ext_iter.device_offset;
-            p->rmw_suffix_adjust    = p->ext_iter.file_offset - suffix_block;
-        }
+        /* Read the block-aligned device offset that physically holds write_end.
+         * The extent maps file write_end to device_offset + (write_end -
+         * file_offset); rounding that down to a block gives a 4 KiB-aligned
+         * read (required by O_DIRECT/libaio) whose write_end byte sits at
+         * index (write_end & 4095) -- so no separate adjust is needed even
+         * when the extent starts mid-block (e.g. a punch-created extent whose
+         * file_offset/device_offset are unaligned but congruent mod 4096). */
+        p->need_suffix_read     = 1;
+        p->suffix_device_id     = p->ext_iter.device_id;
+        p->suffix_device_offset = (p->ext_iter.device_offset +
+                                   (write_end - p->ext_iter.file_offset)) & ~4095ULL;
+        p->rmw_suffix_adjust = 0;
     }
 
     diskfs_write_trim_start(request);

--- a/src/vfs/diskfs/diskfs.c
+++ b/src/vfs/diskfs/diskfs.c
@@ -187,6 +187,13 @@ struct diskfs_request_private {
     int                         need_suffix_read;
     uint64_t                    prefix_device_id, prefix_device_offset;
     uint64_t                    suffix_device_id, suffix_device_offset;
+
+    /* Coalescing-insert descriptor (diskfs_ext_put): the extent to record,
+     * merged with a contiguous predecessor when possible; ci_cont runs after. */
+    uint64_t                    ci_off, ci_len, ci_devoff;
+    uint32_t                    ci_devid, ci_flags;
+    void                        (*ci_cont)(
+        struct chimera_vfs_request *);
 };
 
 struct diskfs_device {
@@ -11511,14 +11518,121 @@ static void diskfs_write_trim_process(
 static void diskfs_write_trim_done(
     struct chimera_vfs_request *request);
 
-/* Tail: inode metadata, unlock, RMW reads, phase2. */
+/*
+ * Insert a data extent, coalescing it with the immediately-preceding extent
+ * when the two are logically + physically contiguous and share the same
+ * written-ness -- so a sequential run of writes/allocations collapses into a
+ * single extent record instead of one record per write.  The descriptor
+ * (ci_off/ci_len/ci_devid/ci_devoff/ci_flags) and the continuation (ci_cont)
+ * live in the request private.  bt_insert aborts on a duplicate key, so a
+ * merge removes the predecessor and re-inserts the widened extent at its key.
+ */
 static void
-diskfs_write_inserted_cb(
+diskfs_ext_put_insert(
+    struct chimera_vfs_request *request);
+
+static void
+diskfs_ext_put_inserted_cb(
     struct diskfs_bt_op *op,
     int                  result,
     void                *private_data)
 {
-    struct chimera_vfs_request    *request        = private_data;
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+
+    (void) result;
+    diskfs_bt_op_free(p->thread, op);
+    p->ci_cont(request);
+} /* diskfs_ext_put_inserted_cb */
+
+static void
+diskfs_ext_put_insert(struct chimera_vfs_request *request)
+{
+    struct diskfs_request_private *p      = request->plugin_data;
+    struct diskfs_thread          *thread = p->thread;
+    struct diskfs_bt_op           *op     = diskfs_bt_op_alloc(thread);
+
+    if (diskfs_ext_insert_async(op, thread, p->txn, p->inode_stash[0],
+                                p->ci_off, p->ci_len, p->ci_devid, p->ci_devoff,
+                                p->ci_flags, diskfs_ext_put_inserted_cb, request)) {
+        diskfs_ext_put_inserted_cb(op, op->result, request);
+    }
+} /* diskfs_ext_put_insert */
+
+static void
+diskfs_ext_put_removed_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+
+    (void) result;
+    diskfs_bt_op_free(p->thread, op);
+    diskfs_ext_put_insert(request);
+} /* diskfs_ext_put_removed_cb */
+
+static void
+diskfs_ext_put_floor_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+    struct diskfs_thread          *thread  = p->thread;
+    struct diskfs_extent           prev;
+    int                            have;
+
+    have = diskfs_ext_from_op(op, result, &prev);
+    diskfs_bt_op_free(thread, op);
+
+    if (have && prev.flags == p->ci_flags && prev.device_id == p->ci_devid &&
+        prev.file_offset + prev.length == p->ci_off &&
+        prev.device_offset + prev.length == p->ci_devoff) {
+        /* Contiguous predecessor: widen it (remove then re-insert at its key). */
+        p->ci_off    = prev.file_offset;
+        p->ci_len   += prev.length;
+        p->ci_devoff = prev.device_offset;
+
+        op = diskfs_bt_op_alloc(thread);
+        if (diskfs_ext_remove_async(op, thread, p->txn, p->inode_stash[0],
+                                    prev.file_offset, diskfs_ext_put_removed_cb,
+                                    request)) {
+            diskfs_ext_put_removed_cb(op, op->result, request);
+        }
+        return;
+    }
+
+    diskfs_ext_put_insert(request);
+} /* diskfs_ext_put_floor_cb */
+
+static void
+diskfs_ext_put(struct chimera_vfs_request *request)
+{
+    struct diskfs_request_private *p      = request->plugin_data;
+    struct diskfs_thread          *thread = p->thread;
+    struct diskfs_bt_op           *op;
+
+    if (p->ci_off == 0) {
+        diskfs_ext_put_insert(request);     /* nothing precedes offset 0 */
+        return;
+    }
+
+    op = diskfs_bt_op_alloc(thread);
+    if (diskfs_ext_floor_async(op, thread, p->inode_stash[0], p->ci_off - 1,
+                               p->rec_scratch, sizeof(p->rec_scratch),
+                               diskfs_ext_put_floor_cb, request)) {
+        diskfs_ext_put_floor_cb(op, op->result, request);
+    }
+} /* diskfs_ext_put */
+
+/* Tail shared by every write path (in-place, unwritten-split, redirect):
+ * stamp inode metadata, then RMW reads (if any) -> phase2 data write. */
+static void
+diskfs_write_finish_map(struct chimera_vfs_request *request)
+{
     struct diskfs_request_private *diskfs_private = request->plugin_data;
     struct diskfs_thread          *thread         = diskfs_private->thread;
     struct diskfs_shared          *shared         = thread->shared;
@@ -11526,9 +11640,6 @@ diskfs_write_inserted_cb(
     struct diskfs_inode           *inode          = diskfs_private->inode_stash[0];
     uint64_t                       write_end      = request->write.offset + request->write.length;
     struct timespec                now;
-
-    (void) result;
-    diskfs_bt_op_free(thread, op);
 
     if (inode->size < write_end) {
         inode->size       = write_end;
@@ -11607,21 +11718,22 @@ diskfs_write_inserted_cb(
         diskfs_private->rmw_phase = 2;
         diskfs_write_phase2(thread, shared, request);
     }
-} /* diskfs_write_inserted_cb */
+} /* diskfs_write_finish_map */
 
+/* Redirect path: record the freshly-allocated extent (coalescing it with a
+ * contiguous predecessor -- e.g. a sequential append), then run the tail. */
 static void
 diskfs_write_trim_done(struct chimera_vfs_request *request)
 {
-    struct diskfs_request_private *p      = request->plugin_data;
-    struct diskfs_thread          *thread = p->thread;
-    struct diskfs_bt_op           *op     = diskfs_bt_op_alloc(thread);
+    struct diskfs_request_private *p = request->plugin_data;
 
-    if (diskfs_ext_insert_async(op, thread, p->txn, p->inode_stash[0],
-                                p->rmw_aligned_start, p->rmw_aligned_length,
-                                p->rmw_device_id, p->rmw_device_offset, 0,
-                                diskfs_write_inserted_cb, request)) {
-        diskfs_write_inserted_cb(op, op->result, request);
-    }
+    p->ci_off    = p->rmw_aligned_start;
+    p->ci_len    = p->rmw_aligned_length;
+    p->ci_devid  = (uint32_t) p->rmw_device_id;
+    p->ci_devoff = p->rmw_device_offset;
+    p->ci_flags  = 0;
+    p->ci_cont   = diskfs_write_finish_map;
+    diskfs_ext_put(request);
 } /* diskfs_write_trim_done */
 
 static void
@@ -11799,15 +11911,27 @@ diskfs_write_trim_process(struct chimera_vfs_request *request)
         return;
     }
 
+    /* The aligned region's data is being redirected to freshly-allocated
+     * blocks (rmw_device_offset), so the old device blocks backing the part of
+     * this extent that the region covers are now garbage and must be freed --
+     * otherwise every overwrite leaks space.  (The in-place paths never reach
+     * here; they reuse the existing blocks and free nothing.) */
     if (es >= astart && ee <= aend) {
-        /* Completely inside the aligned region: remove, then advance. */
+        /* Completely inside the aligned region: free + remove, then advance. */
+        diskfs_thread_free_space(thread, p->txn, p->ext_iter.device_id,
+                                 p->ext_iter.device_offset,
+                                 SM_ALIGN_UP(p->ext_iter.length));
         op = diskfs_bt_op_alloc(thread);
         if (diskfs_ext_remove_async(op, thread, p->txn, p->inode_stash[0], es,
                                     diskfs_write_trim_advance_cb, request)) {
             diskfs_write_trim_advance_cb(op, op->result, request);
         }
     } else if (es < astart && ee > aend) {
-        /* Spans the region: insert tail at aligned_end first. */
+        /* Spans the region: free the covered middle, then insert tail at
+         * aligned_end first. */
+        diskfs_thread_free_space(thread, p->txn, p->ext_iter.device_id,
+                                 p->ext_iter.device_offset + (astart - es),
+                                 p->rmw_aligned_length);
         op = diskfs_bt_op_alloc(thread);
         if (diskfs_ext_insert_async(op, thread, p->txn, p->inode_stash[0], aend,
                                     ee - aend, p->ext_iter.device_id,
@@ -11817,14 +11941,21 @@ diskfs_write_trim_process(struct chimera_vfs_request *request)
             diskfs_write_trim_spans_after_cb(op, op->result, request);
         }
     } else if (es < astart && ee > astart) {
-        /* Overlaps the left edge: remove, reinsert the head. */
+        /* Overlaps the left edge: free the covered tail, remove, reinsert the
+         * head. */
+        diskfs_thread_free_space(thread, p->txn, p->ext_iter.device_id,
+                                 p->ext_iter.device_offset + (astart - es),
+                                 ee - astart);
         op = diskfs_bt_op_alloc(thread);
         if (diskfs_ext_remove_async(op, thread, p->txn, p->inode_stash[0], es,
                                     diskfs_write_trim_oleft_removed_cb, request)) {
             diskfs_write_trim_oleft_removed_cb(op, op->result, request);
         }
     } else if (es < aend && ee > aend) {
-        /* Starts within, extends past: remove, reinsert tail at aligned_end. */
+        /* Starts within, extends past: free the covered head, remove, reinsert
+         * tail at aligned_end. */
+        diskfs_thread_free_space(thread, p->txn, p->ext_iter.device_id,
+                                 p->ext_iter.device_offset, aend - es);
         op = diskfs_bt_op_alloc(thread);
         if (diskfs_ext_remove_async(op, thread, p->txn, p->inode_stash[0], es,
                                     diskfs_write_trim_oright_removed_cb, request)) {
@@ -11996,41 +12127,56 @@ diskfs_write_prefix_lookup(struct chimera_vfs_request *request)
     }
 } /* diskfs_write_prefix_lookup */
 
-/* Retry context for the write's data-space allocation when a reservation
- * refill parks on a cold AG-log block; the continuation re-enters
- * diskfs_write_inode_cb with the (already write-locked) inode. */
-struct diskfs_write_alloc_ctx {
-    struct diskfs_inode        *inode;
-    struct chimera_vfs_request *request;
-};
-
+/* Forward declarations for the write classify -> placement chain. */
+static void diskfs_write_classify_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *private_data);
+static void diskfs_write_redirect_alloc(
+    struct chimera_vfs_request *request);
 static void diskfs_write_alloc_resume(
     struct diskfs_thread *thread,
     void                 *arg);
+static void diskfs_write_split_start(
+    struct chimera_vfs_request *request);
 
+/*
+ * A write is dispatched here with the inode write-locked.  Compute the 4 KiB-
+ * aligned region, then classify it (diskfs_write_classify_cb) against the
+ * extent at/just-before aligned_start:
+ *
+ *   - one existing extent fully covers the region -> overwrite IN PLACE:
+ *       written   -> no map mutation at all (the hot random-overwrite path:
+ *                    no allocate, no free, no b+tree churn);
+ *       unwritten -> overwrite in place + split the covered range to written
+ *                    (fallocate first-touch);
+ *   - otherwise (hole / partial / multi-extent span) -> allocate fresh blocks
+ *     and redirect, freeing the old covered blocks (diskfs_write_trim_*).
+ *
+ * Multi-extent-cover redirects for now; coalescing keeps written runs in a
+ * single extent so contiguous regions collapse to the in-place case.
+ */
 static void
 diskfs_write_inode_cb(
     struct diskfs_inode *inode,
     int                  status,
     void                *private_data)
 {
-    struct chimera_vfs_request    *request        = private_data;
-    struct diskfs_request_private *diskfs_private = request->plugin_data;
-    struct diskfs_thread          *thread         = diskfs_private->thread;
-    uint64_t                       write_start    = request->write.offset;
-    uint64_t                       write_end      = write_start + request->write.length;
-    uint64_t                       aligned_start, aligned_end, aligned_length;
-    uint64_t                       device_id, device_offset;
-    struct diskfs_write_alloc_ctx *wctx;
-    int                            rc;
+    struct chimera_vfs_request    *request     = private_data;
+    struct diskfs_request_private *p           = request->plugin_data;
+    struct diskfs_thread          *thread      = p->thread;
+    uint64_t                       write_start = request->write.offset;
+    uint64_t                       write_end   = write_start + request->write.length;
+    uint64_t                       aligned_start, aligned_end;
+    struct diskfs_bt_op           *op;
 
     if (unlikely(status != CHIMERA_VFS_OK)) {
-        diskfs_op_fail(request, diskfs_private->txn, status);
+        diskfs_op_fail(request, p->txn, status);
         return;
     }
 
     if (unlikely(!S_ISREG(inode->mode))) {
-        diskfs_op_fail(request, diskfs_private->txn, CHIMERA_VFS_EINVAL);
+        diskfs_op_fail(request, p->txn, CHIMERA_VFS_EINVAL);
         return;
     }
 
@@ -12041,56 +12187,257 @@ diskfs_write_inode_cb(
 
         request->write.r_length = 0;
         request->write.r_sync   = 1;
-        diskfs_op_ok(request, diskfs_private->txn);
+        diskfs_op_ok(request, p->txn);
         return;
     }
 
-    aligned_start  = write_start & ~4095ULL;
-    aligned_end    = (write_end + 4095ULL) & ~4095ULL;
-    aligned_length = aligned_end - aligned_start;
+    aligned_start = write_start & ~4095ULL;
+    aligned_end   = (write_end + 4095ULL) & ~4095ULL;
 
-    wctx          = malloc(sizeof(*wctx));
-    wctx->inode   = inode;
-    wctx->request = request;
-    rc            = diskfs_thread_alloc_space(thread, diskfs_private->txn, aligned_length,
-                                              &device_id, &device_offset,
-                                              diskfs_write_alloc_resume, wctx);
+    p->rmw_prefix_len     = write_start - aligned_start;
+    p->rmw_suffix_len     = aligned_end - write_end;
+    p->rmw_aligned_start  = aligned_start;
+    p->rmw_aligned_length = aligned_end - aligned_start;
+    p->rmw_prefix_valid   = 0;
+    p->rmw_suffix_valid   = 0;
+    p->rmw_suffix_adjust  = 0;
+    p->need_prefix_read   = 0;
+    p->need_suffix_read   = 0;
+    p->inode_stash[0]     = inode;
+
+    op = diskfs_bt_op_alloc(thread);
+    if (diskfs_ext_floor_async(op, thread, inode, aligned_start, p->rec_scratch,
+                               sizeof(p->rec_scratch), diskfs_write_classify_cb,
+                               request)) {
+        diskfs_write_classify_cb(op, op->result, request);
+    }
+} /* diskfs_write_inode_cb */
+
+static void
+diskfs_write_classify_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+    struct diskfs_thread          *thread  = p->thread;
+    uint64_t                       astart  = p->rmw_aligned_start;
+    uint64_t                       aend    = astart + p->rmw_aligned_length;
+    struct diskfs_extent           e;
+    int                            have;
+
+    have = diskfs_ext_from_op(op, result, &e);
+    diskfs_bt_op_free(thread, op);
+
+    if (have && e.file_offset <= astart && e.file_offset + e.length >= aend) {
+        /* Single extent fully covers the region: overwrite its blocks in
+         * place at the matching device offset. */
+        p->rmw_device_id     = e.device_id;
+        p->rmw_device_offset = e.device_offset + (astart - e.file_offset);
+
+        if (e.flags & DISKFS_EXT_UNWRITTEN) {
+            /* The un-overwritten bytes of the first/last block are zeros (not
+             * stale data), so phase2 zero-fills the prefix/suffix -- no RMW
+             * read.  Split the covered range to written. */
+            p->ext_iter = e;
+            diskfs_write_split_start(request);
+        } else {
+            /* RMW the partial first/last blocks from these same in-place
+             * blocks; the extent map is left untouched. */
+            if (p->rmw_prefix_len) {
+                p->need_prefix_read     = 1;
+                p->prefix_device_id     = e.device_id;
+                p->prefix_device_offset = p->rmw_device_offset;
+                p->rmw_prefix_valid     = p->rmw_prefix_len;
+            }
+            if (p->rmw_suffix_len) {
+                uint64_t write_end    = request->write.offset + request->write.length;
+                uint64_t suffix_block = write_end & ~4095ULL;
+
+                p->need_suffix_read     = 1;
+                p->suffix_device_id     = e.device_id;
+                p->suffix_device_offset = e.device_offset +
+                    (suffix_block - e.file_offset);
+                p->rmw_suffix_valid = p->rmw_suffix_len;
+            }
+            diskfs_write_finish_map(request);
+        }
+        return;
+    }
+
+    /* Hole / partial / multi-extent span: allocate fresh blocks and redirect. */
+    diskfs_write_redirect_alloc(request);
+} /* diskfs_write_classify_cb */
+
+static void
+diskfs_write_redirect_alloc(struct chimera_vfs_request *request)
+{
+    struct diskfs_request_private *p      = request->plugin_data;
+    struct diskfs_thread          *thread = p->thread;
+    uint64_t                       dev_id, dev_off;
+    int                            rc;
+
+    rc = diskfs_thread_alloc_space(thread, p->txn,
+                                   (int64_t) p->rmw_aligned_length,
+                                   &dev_id, &dev_off,
+                                   diskfs_write_alloc_resume, request);
     if (rc == SM_AGAIN) {
-        return;     /* parked; diskfs_write_alloc_resume re-runs (owns wctx) */
+        return;     /* parked; diskfs_write_alloc_resume re-runs */
     }
-    free(wctx);
     if (rc) {
-        diskfs_op_fail(request, diskfs_private->txn, CHIMERA_VFS_ENOSPC);
+        diskfs_op_fail(request, p->txn, CHIMERA_VFS_ENOSPC);
         return;
     }
 
-    diskfs_private->rmw_prefix_len     = write_start - aligned_start;
-    diskfs_private->rmw_suffix_len     = aligned_end - write_end;
-    diskfs_private->rmw_aligned_start  = aligned_start;
-    diskfs_private->rmw_aligned_length = aligned_length;
-    diskfs_private->rmw_device_id      = device_id;
-    diskfs_private->rmw_device_offset  = device_offset;
-    diskfs_private->rmw_prefix_valid   = 0;
-    diskfs_private->rmw_suffix_valid   = 0;
-    diskfs_private->rmw_suffix_adjust  = 0;
-    diskfs_private->need_prefix_read   = 0;
-    diskfs_private->need_suffix_read   = 0;
-    diskfs_private->inode_stash[0]     = inode;
+    p->rmw_device_id     = dev_id;
+    p->rmw_device_offset = dev_off;
 
     diskfs_write_prefix_lookup(request);
-} /* diskfs_write_inode_cb */
+} /* diskfs_write_redirect_alloc */
 
 static void
 diskfs_write_alloc_resume(
     struct diskfs_thread *thread,
     void                 *arg)
 {
-    struct diskfs_write_alloc_ctx c = *(struct diskfs_write_alloc_ctx *) arg;
-
     (void) thread;
-    free(arg);
-    diskfs_write_inode_cb(c.inode, CHIMERA_VFS_OK, c.request);
+    diskfs_write_redirect_alloc((struct chimera_vfs_request *) arg);
 } /* diskfs_write_alloc_resume */
+
+/*
+ * Unwritten-extent in-place split: the write lands inside a reserved-but-
+ * unwritten extent e=[es,ee) (stashed in p->ext_iter).  Its blocks are
+ * overwritten in place; re-record the map as
+ *     [es,astart) unwritten | [astart,aend) written | [aend,ee) unwritten
+ * (head/tail only when non-empty; the written middle reuses e's blocks at
+ * rmw_device_offset).  remove -> insert middle -> [head] -> [tail] -> tail.
+ */
+static void
+diskfs_write_split_tail_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+
+    (void) result;
+    diskfs_bt_op_free(p->thread, op);
+    diskfs_write_finish_map(request);
+} /* diskfs_write_split_tail_cb */
+
+static void
+diskfs_write_split_finish_tail(struct chimera_vfs_request *request)
+{
+    struct diskfs_request_private *p      = request->plugin_data;
+    struct diskfs_thread          *thread = p->thread;
+    uint64_t                       es     = p->ext_iter.file_offset;
+    uint64_t                       ee     = es + p->ext_iter.length;
+    uint64_t                       aend   = p->rmw_aligned_start + p->rmw_aligned_length;
+    struct diskfs_bt_op           *op;
+
+    if (ee > aend) {
+        op = diskfs_bt_op_alloc(thread);
+        if (diskfs_ext_insert_async(op, thread, p->txn, p->inode_stash[0], aend,
+                                    ee - aend, p->ext_iter.device_id,
+                                    p->ext_iter.device_offset + (aend - es),
+                                    DISKFS_EXT_UNWRITTEN,
+                                    diskfs_write_split_tail_cb, request)) {
+            diskfs_write_split_tail_cb(op, op->result, request);
+        }
+    } else {
+        diskfs_write_finish_map(request);
+    }
+} /* diskfs_write_split_finish_tail */
+
+static void
+diskfs_write_split_head_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+
+    (void) result;
+    diskfs_bt_op_free(p->thread, op);
+    diskfs_write_split_finish_tail(request);
+} /* diskfs_write_split_head_cb */
+
+static void
+diskfs_write_split_finish_head(struct chimera_vfs_request *request)
+{
+    struct diskfs_request_private *p      = request->plugin_data;
+    struct diskfs_thread          *thread = p->thread;
+    uint64_t                       es     = p->ext_iter.file_offset;
+    uint64_t                       astart = p->rmw_aligned_start;
+    struct diskfs_bt_op           *op;
+
+    if (es < astart) {
+        op = diskfs_bt_op_alloc(thread);
+        if (diskfs_ext_insert_async(op, thread, p->txn, p->inode_stash[0], es,
+                                    astart - es, p->ext_iter.device_id,
+                                    p->ext_iter.device_offset,
+                                    DISKFS_EXT_UNWRITTEN,
+                                    diskfs_write_split_head_cb, request)) {
+            diskfs_write_split_head_cb(op, op->result, request);
+        }
+    } else {
+        diskfs_write_split_finish_tail(request);
+    }
+} /* diskfs_write_split_finish_head */
+
+static void
+diskfs_write_split_mid_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+
+    (void) result;
+    diskfs_bt_op_free(p->thread, op);
+    diskfs_write_split_finish_head(request);
+} /* diskfs_write_split_mid_cb */
+
+static void
+diskfs_write_split_removed_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+    struct diskfs_thread          *thread  = p->thread;
+
+    (void) result;
+    diskfs_bt_op_free(thread, op);
+
+    /* Insert the written middle, reusing e's blocks (rmw_device_offset). */
+    op = diskfs_bt_op_alloc(thread);
+    if (diskfs_ext_insert_async(op, thread, p->txn, p->inode_stash[0],
+                                p->rmw_aligned_start, p->rmw_aligned_length,
+                                (uint32_t) p->rmw_device_id, p->rmw_device_offset, 0,
+                                diskfs_write_split_mid_cb, request)) {
+        diskfs_write_split_mid_cb(op, op->result, request);
+    }
+} /* diskfs_write_split_removed_cb */
+
+static void
+diskfs_write_split_start(struct chimera_vfs_request *request)
+{
+    struct diskfs_request_private *p      = request->plugin_data;
+    struct diskfs_thread          *thread = p->thread;
+    struct diskfs_bt_op           *op     = diskfs_bt_op_alloc(thread);
+
+    if (diskfs_ext_remove_async(op, thread, p->txn, p->inode_stash[0],
+                                p->ext_iter.file_offset,
+                                diskfs_write_split_removed_cb, request)) {
+        diskfs_write_split_removed_cb(op, op->result, request);
+    }
+} /* diskfs_write_split_start */
 
 
 static void
@@ -12457,31 +12804,23 @@ diskfs_allocate_alloc_resume(
 } /* diskfs_allocate_alloc_resume */
 
 static void
-diskfs_allocate_inserted_cb(
-    struct diskfs_bt_op *op,
-    int                  result,
-    void                *private_data)
+diskfs_allocate_next(struct chimera_vfs_request *request)
 {
-    struct chimera_vfs_request    *request = private_data;
-    struct diskfs_request_private *p       = request->plugin_data;
-
-    (void) result;
-    diskfs_bt_op_free(p->thread, op);
+    struct diskfs_request_private *p = request->plugin_data;
 
     if (p->loop_off < p->loop_left) {
         diskfs_allocate_do_alloc(request);      /* more of this gap */
     } else {
         diskfs_allocate_reserve_step(request);  /* on to the next gap */
     }
-} /* diskfs_allocate_inserted_cb */
+} /* diskfs_allocate_next */
 
 static void
 diskfs_allocate_do_alloc(struct chimera_vfs_request *request)
 {
     struct diskfs_request_private *p      = request->plugin_data;
     struct diskfs_thread          *thread = p->thread;
-    struct diskfs_bt_op           *op;
-    uint64_t                       off = p->loop_off;
+    uint64_t                       off    = p->loop_off;
     uint64_t                       dev_id, dev_off, chunk;
     int                            rc;
 
@@ -12501,17 +12840,17 @@ diskfs_allocate_do_alloc(struct chimera_vfs_request *request)
         return;
     }
 
-    /* Advance before inserting: the insert may complete inline and re-enter
-     * diskfs_allocate_inserted_cb, which reads loop_off. */
-    p->loop_off = off + chunk;
-
-    op = diskfs_bt_op_alloc(thread);
-    if (diskfs_ext_insert_async(op, thread, p->txn, p->inode_stash[0],
-                                off, chunk, (uint32_t) dev_id, dev_off,
-                                DISKFS_EXT_UNWRITTEN,
-                                diskfs_allocate_inserted_cb, request)) {
-        diskfs_allocate_inserted_cb(op, op->result, request);
-    }
+    /* Advance before recording: diskfs_ext_put may complete inline and run
+     * diskfs_allocate_next, which reads loop_off.  Record the reserved chunk
+     * as an unwritten extent, coalescing contiguous chunks into one. */
+    p->loop_off  = off + chunk;
+    p->ci_off    = off;
+    p->ci_len    = chunk;
+    p->ci_devid  = (uint32_t) dev_id;
+    p->ci_devoff = dev_off;
+    p->ci_flags  = DISKFS_EXT_UNWRITTEN;
+    p->ci_cont   = diskfs_allocate_next;
+    diskfs_ext_put(request);
 } /* diskfs_allocate_do_alloc */
 
 static void


### PR DESCRIPTION
## Problem

Random 4K write performance on diskfs was poor. Auditing the write path
confirmed it still behaved like the old log-structured demofs: **every**
write redirected — allocate a fresh block, trim/remove the old extent,
insert a new one, write the data to the new location — even for a plain
overwrite of an already-allocated, aligned block. Worse, the trim path
removed the old extent records but **never freed their device blocks**,
so every overwrite also leaked space. And `ALLOCATE` reserved nothing.

This PR makes diskfs behave like the traditional journaled filesystem it
now is.

## Changes

**(a) `ALLOCATE` actually reserves space** — via a new `UNWRITTEN` extent
flag (reusing the dead `pad` field of the on-disk extent record). The op
walks the requested range and allocates real backing blocks for each gap
as unwritten extents. Unwritten extents read back as zeros with no
device I/O; the first write clears the bit. No zero-fill, so reserving a
large region stays cheap.

**(b) Overwrite already-allocated extents in place** — classify the
aligned write region against the extent at its start:
- a single existing extent fully covers it → overwrite those blocks in
  place. Written extent → the map is untouched (no allocate, no free, no
  b+tree mutation — just the data write + mtime). Unwritten extent →
  write in place and split the covered range to written.
- otherwise (hole / partial / multi-extent span) → allocate and redirect
  as before, **now freeing the old covered blocks** (fixes the leak).

**(d) Coalesce contiguous extents** — when a newly recorded extent is
logically + physically contiguous with its predecessor and shares its
written-ness, widen the predecessor instead of adding a record, so a
sequential run of appends (or fallocate chunks) collapses to one extent.

Honoring protocol durability without over-committing **(c)** — honoring
NFS3 UNSTABLE (drop FUA for unstable writes) and making `COMMIT` fence —
is deliberately **left for a focused follow-up**, since it carries a
data-ordering subtlety on the redirect path and is independently
testable.

## Crash semantics

Metadata (size, mtime, the extent map) stays journaled in every case. In
place data overwrite trades per-block data atomicity for the in-flight
write — the data=ordered model of a traditional journaled filesystem,
rather than the previous copy-on-write-grade per-block atomicity.

## Testing

- Debug + Release build clean; `scan-build` reports no bugs.
- fsx data-integrity (fallocate / punch-hole / zero-range / overwrite /
  truncate, all verified): 3×300k-op runs on diskfs io_uring + a 200k
  run on diskfs aio, all `A-OK`.
- Full non-KVM diskfs suite (pynfs all groups incl. sparse/write/read/
  commit/setattr, plus posix fsx/fsstress over POSIX/NFS3/NFS3-RDMA/NFS4)
  green.
