### PR TITLE
vfs: fix close-thread shutdown deadlock under load

### DIFF
--- a/src/vfs/vfs.c
+++ b/src/vfs/vfs.c
@@ -207,33 +207,40 @@ chimera_vfs_close_thread_wake_shutdown(
     struct evpl_doorbell *doorbell)
 {
     struct chimera_vfs_close_thread *close_thread = container_of(doorbell, struct chimera_vfs_close_thread, doorbell);
+    int                              shutdown     = close_thread->shutdown;
     uint64_t                         min_age, count;
 
-    pthread_mutex_lock(&close_thread->lock);
+    min_age = shutdown ? 0 : 100000000UL;
 
-    if (close_thread->shutdown) {
-        min_age = 0;
-    } else {
-        min_age = 100000000UL;
-    }
-
+    /* Sweep OUTSIDE close_thread->lock.  A close can re-enter this thread's
+     * event loop -- diskfs commit drains its submission queue with a nested
+     * evpl_continue() -- which re-fires this doorbell (and the periodic timer)
+     * on this same thread; holding the lock across the sweep would self-deadlock
+     * when the re-entrant callback tries to re-acquire it.  The lock guards only
+     * the shutdown cond handshake with chimera_vfs_destroy, and the sweep state
+     * it touches (num_pending, the open caches) is owned by this thread / the
+     * per-shard cache locks, so it needs no protection here. */
     count  = chimera_vfs_close_thread_sweep(evpl, close_thread, close_thread->vfs->vfs_open_path_cache, min_age);
     count += chimera_vfs_close_thread_sweep(evpl, close_thread, close_thread->vfs->vfs_open_file_cache, min_age);
 
-    if (close_thread->shutdown && count == 0 && close_thread->num_pending == 0) {
-        pthread_cond_signal(&close_thread->cond);
+    if (!shutdown) {
+        return;
+    }
+
+    if (count == 0 && close_thread->num_pending == 0) {
+        /* Fully drained: hand off to the waiter in chimera_vfs_destroy.  Signal
+         * under the lock so the wakeup can't be lost against its cond_wait. */
+        pthread_mutex_lock(&close_thread->lock);
         close_thread->signaled = 1;
+        pthread_cond_signal(&close_thread->cond);
         pthread_mutex_unlock(&close_thread->lock);
         return;
     }
 
-    if (close_thread->shutdown) {
-        evpl_ring_doorbell(doorbell);
-    }
+    /* Closes still in flight -- keep sweeping until they complete. */
+    evpl_ring_doorbell(doorbell);
 
-    pthread_mutex_unlock(&close_thread->lock);
-
-} /* chimera_vfs_close_thread_wake */
+} /* chimera_vfs_close_thread_wake_shutdown */
 
 static void
 chimera_vfs_close_thread_wake_timer(
@@ -243,14 +250,14 @@ chimera_vfs_close_thread_wake_timer(
     struct chimera_vfs_close_thread *close_thread = container_of(timer, struct chimera_vfs_close_thread, timer);
     uint64_t                         min_age;
 
-    pthread_mutex_lock(&close_thread->lock);
-
     min_age = 100000000UL;
 
+    /* No lock: the periodic sweep touches only this thread's state (num_pending)
+     * and the open caches (guarded by their own per-shard locks).  Holding
+     * close_thread->lock here would self-deadlock if a close re-enters the event
+     * loop and re-fires this timer (see chimera_vfs_close_thread_wake_shutdown). */
     chimera_vfs_close_thread_sweep(evpl, close_thread, close_thread->vfs->vfs_open_path_cache, min_age);
     chimera_vfs_close_thread_sweep(evpl, close_thread, close_thread->vfs->vfs_open_file_cache, min_age);
-
-    pthread_mutex_unlock(&close_thread->lock);
 
     /* Drop implicit I/O leases that have gone idle, bounding resident
      * per-file state for write-once / read-once workloads. */


### PR DESCRIPTION
## Problem

Ctrl-C'ing the server after it has been under load can hang in shutdown. A worker is stuck self-deadlocked on `close_thread->lock`:

```
chimera_vfs_close_thread_wake_timer        <- holds close_thread->lock
  chimera_vfs_close_thread_sweep
    chimera_vfs_close -> diskfs_close -> diskfs_txn_commit
      diskfs_txn_commit_finish
        evpl_continue(thread->evpl)         <- SQ-full backpressure pump, re-enters the loop
          chimera_vfs_close_thread_wake_timer  <- timer re-fires on the same thread
            pthread_mutex_lock(close_thread->lock)  <- already held -> DEADLOCK
```

The close-thread's timer and shutdown-doorbell handlers held `close_thread->lock` across the whole sweep, i.e. across the `chimera_vfs_close()` calls themselves. A close can re-enter the close-thread's own event loop — a diskfs commit drains a full intent-log submission queue with a nested `evpl_continue()` — which re-fires the periodic timer (and the shutdown doorbell) on the same thread. The re-entrant handler then blocks trying to re-acquire the lock it already holds. The thread never returns, so it never drains the CQ, the SQ never empties, and the outer commit spin never completes → hard shutdown hang.

It needs both write-pinned handles to flush *and* enough backlog to fill the intent-log SQ, which is why it only shows up on Ctrl-C after load.

## Fix

`close_thread->lock` never actually protected the sweep:
- `num_pending` is mutated only on the close-thread (incremented in the sweep, decremented in the close callback).
- The open caches are guarded by their own per-shard locks inside `defer_close()`.

The lock's only real job is the shutdown cond handshake with `chimera_vfs_destroy()`.

So: sweep **outside** the lock, and take it only around the cond signal (kept under the lock so the wakeup can't be lost against `chimera_vfs_destroy`'s `cond_wait`). The periodic timer handler needs no lock at all. `defer_close()` drains the entire eligible set per call, so a re-entrant sweep finds nothing and unwinds rather than recursing.

## Validation

- All 87 memfs pynfs access/lookup/write tests pass; each starts and cleanly shuts down a server, exercising the shutdown handshake this touches.
- The diskfs deadlock path requires VFIO and can't be reproduced in the sandbox; fix verified by analysis of the re-entrancy.