### PR TITLE
s3/tests: fix -Wstringop-truncation under ASan release builds

### DIFF
--- a/src/posix/tests/test_opendir.c
+++ b/src/posix/tests/test_opendir.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -185,8 +185,7 @@ test_seekdir_telldir(void)
         fprintf(stderr, "Second readdir failed\n");
         exit(1);
     }
-    strncpy(saved_name, entry->d_name, sizeof(saved_name) - 1);
-    saved_name[sizeof(saved_name) - 1] = '\0';
+    snprintf(saved_name, sizeof(saved_name), "%s", entry->d_name);
     fprintf(stderr, "Second entry: %s\n", saved_name);
 
     // Seek back to saved position

--- a/src/server/s3/s3_auth.c
+++ b/src/server/s3/s3_auth.c
@@ -818,8 +818,7 @@ build_canonical_request_v4(
     char       *saveptr;
     char        header_lower[256];
 
-    strncpy(signed_headers_copy, signed_headers, sizeof(signed_headers_copy) - 1);
-    signed_headers_copy[sizeof(signed_headers_copy) - 1] = '\0';
+    snprintf(signed_headers_copy, sizeof(signed_headers_copy), "%s", signed_headers);
 
     header_name = strtok_r(signed_headers_copy, ";", &saveptr);
     while (header_name) {


### PR DESCRIPTION
## Problem

A sanitized release build (`-O3` + AddressSanitizer) fails on `-Werror`:

```
s3_auth.c:821:5: error: '__builtin_strncpy' output may be truncated copying 1023 bytes from a string of length 1023 [-Werror=stringop-truncation]
test_opendir.c:188:5: error: '__builtin_strncpy' output may be truncated copying 255 bytes from a string of length 255 [-Werror=stringop-truncation]
```

Both sites use the correct `strncpy(dst, src, sizeof(dst)-1)` + explicit `dst[sizeof(dst)-1]='\0'` idiom. The code is fine, but GCC's `-Wstringop-truncation` analyzes the `strncpy` in isolation and warns whenever the source could be as long as the bound — it doesn't credit the following NUL store. The warning only fires under `-O3` + ASan (ASan changes inlining enough that GCC can prove the source length), so a plain release build is clean but a sanitized one is not. Making the buffer larger does not help — the warning is about the call shape, not the size.

## Fix

Replace both with `snprintf(dst, sizeof(dst), "%s", src)`, which truncates and NUL-terminates with no warning. Both sources are NUL-terminated C strings, so the change is behavior-preserving.

## Verification

A full `-O3` + ASan build (`ninja -k 0`) reports exactly these two `stringop-truncation` errors tree-wide and nothing else; after this change both translation units compile clean under the same flags, and the normal release build is unaffected. Other call sites use the same idiom but don't trip the warning (GCC can't prove their source length), so they're left untouched to keep the change minimal.