### PR TITLE
nfs4: defer OPEN delegation grant on an in-flight 4.0 CB_NULL probe

### DIFF
--- a/src/server/nfs/nfs4_callback.c
+++ b/src/server/nfs/nfs4_callback.c
@@ -27,6 +27,7 @@
 #include "nfs4_callback.h"
 #include "nfs4_state.h"
 #include "nfs4_session.h"
+#include "nfs4_procs.h"
 #include "nfs_common.h"
 #include "nfs_internal.h"
 #include "vfs/vfs_state.h"
@@ -140,6 +141,7 @@ nfs4_cb_null_complete(
 {
     struct nfs4_cb_probe_ctx *ctx    = private_data;
     struct nfs_client        *client = ctx->client;
+    struct nfs_request       *waiters;
 
     (void) evpl;
     (void) verf;
@@ -152,6 +154,19 @@ nfs4_cb_null_complete(
                               memory_order_release);
         chimera_nfs_error("NFS4 callback path probe failed (status %d) for client %lu",
                           status, client->client_id);
+    }
+
+    /* Resume any OPENs that parked while the probe was in flight.  Runs on
+     * the channel's owner thread (this completion fires from this thread's
+     * evpl), the same thread the OPEN parked from, so the list mutation is
+     * race-free without a lock. */
+    waiters                       = client->cb_path.probe_waiters;
+    client->cb_path.probe_waiters = NULL;
+    while (waiters) {
+        struct nfs_request *req = waiters;
+        waiters         = req->probe_next;
+        req->probe_next = NULL;
+        chimera_nfs4_open_resume_after_probe(req);
     }
 
     free(ctx);
@@ -347,58 +362,124 @@ nfs4_cb_channel_open(
                                     ctx);
 } /* nfs4_cb_channel_open */
 
+/*
+ * Internal driver.  Returns the post-action cb_state so callers can decide
+ * what to do with it; also reports (via *triggered_out) whether THIS call
+ * was the one that flipped UNINIT->PROBING.
+ */
+static uint8_t
+nfs4_cb_probe_drive(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_client                *client,
+    struct nfs_request               *req,
+    bool                             *triggered_out)
+{
+    uint8_t state;
+
+    if (triggered_out) {
+        *triggered_out = false;
+    }
+
+    state = atomic_load_explicit(&client->cb_path.cb_state,
+                                 memory_order_acquire);
+
+    if (state != NFS4_CB_UNINIT) {
+        return state;
+    }
+
+    /* No callback program captured at all -> client never asked to be able
+     * to receive callbacks; report DOWN so callers skip delegation. */
+    if (client->cb_path.cb_program == 0) {
+        return NFS4_CB_DOWN;
+    }
+
+    /* Claim the one-time channel setup: only the thread that flips
+     * UNINIT->PROBING opens the channel.  A concurrent OPEN that loses the
+     * race sees the post-CAS state and reacts to that instead. */
+    {
+        uint8_t expect = NFS4_CB_UNINIT;
+
+        if (!atomic_compare_exchange_strong_explicit(
+                &client->cb_path.cb_state, &expect, NFS4_CB_PROBING,
+                memory_order_acq_rel, memory_order_acquire)) {
+            return expect;
+        }
+    }
+
+    if (triggered_out) {
+        *triggered_out = true;
+    }
+
+    nfs4_cb_channel_open(thread, client, req);
+
+    /* 4.1+ binds the backchannel and marks the path UP synchronously (no
+     * CB_NULL round trip).  4.0 fired an asynchronous CB_NULL and is still
+     * PROBING here. */
+    return atomic_load_explicit(&client->cb_path.cb_state,
+                                memory_order_acquire);
+} /* nfs4_cb_probe_drive */
+
 bool
 nfs4_cb_ensure_probe(
     struct chimera_server_nfs_thread *thread,
     struct nfs_client                *client,
     struct nfs_request               *req)
 {
-    uint8_t state;
-
     if (!client) {
         return false;
     }
+    return nfs4_cb_probe_drive(thread, client, req, NULL) == NFS4_CB_UP;
+} /* nfs4_cb_ensure_probe */
 
-    state = atomic_load_explicit(&client->cb_path.cb_state, memory_order_acquire);
+enum nfs4_cb_grant_decision
+nfs4_cb_grant_probe(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_client                *client,
+    struct nfs_request               *req)
+{
+    uint8_t state;
+    bool triggered = false;
+
+    if (!client) {
+        return NFS4_CB_GRANT_NO_PATH;
+    }
+
+    state = nfs4_cb_probe_drive(thread, client, req, &triggered);
 
     switch (state) {
         case NFS4_CB_UP:
-            return true;
+            return NFS4_CB_GRANT_PATH_UP;
         case NFS4_CB_PROBING:
+            /* If THIS call kicked the probe, preserve the historical
+             * behavior: the kicking OPEN proceeds without a delegation.
+             * (This is how chimera has always behaved on 4.0 -- the very
+             * first delegation-wanting OPEN never gets a delegation, and a
+             * follow-up OPEN is the one that lands it.  Changing that for
+             * the kicking OPEN itself would also start handing out
+             * delegations on OPENs that historically did not get them,
+             * which some pynfs tests rely on -- e.g. DELEG15d sets up an
+             * undelegated file via a plain c.create_file before requesting
+             * a delegation on a different file.)  Only OPENs that find the
+             * probe already in flight defer. */
+            return triggered ? NFS4_CB_GRANT_NO_PATH : NFS4_CB_GRANT_DEFER;
         case NFS4_CB_DOWN:
-            return false;
-        case NFS4_CB_UNINIT:
         default:
-            /* No callback program captured at all -> client never asked to be
-             * able to receive callbacks; cannot delegate. */
-            if (client->cb_path.cb_program == 0) {
-                return false;
-            }
-
-            /* Claim the one-time channel setup: only the thread that flips
-             * UNINIT->PROBING opens the channel.  A concurrent OPEN that loses
-             * the race sees PROBING (or the final state) and skips -- a later
-             * OPEN is served once setup settles. */
-            {
-                uint8_t expect = NFS4_CB_UNINIT;
-
-                if (!atomic_compare_exchange_strong_explicit(
-                        &client->cb_path.cb_state, &expect, NFS4_CB_PROBING,
-                        memory_order_acq_rel, memory_order_acquire)) {
-                    return expect == NFS4_CB_UP;
-                }
-            }
-
-            nfs4_cb_channel_open(thread, client, req);
-
-            /* 4.1+ binds the backchannel and marks the path UP synchronously
-             * (no CB_NULL round trip), so this very first delegation-wanting
-             * OPEN can be served.  4.0 fired an asynchronous CB_NULL and is
-             * still PROBING here. */
-            return atomic_load_explicit(&client->cb_path.cb_state,
-                                        memory_order_acquire) == NFS4_CB_UP;
+            return NFS4_CB_GRANT_NO_PATH;
     } /* switch */
-} /* nfs4_cb_ensure_probe */
+} /* nfs4_cb_grant_probe */
+
+void
+nfs4_cb_probe_park(
+    struct nfs_client  *client,
+    struct nfs_request *req)
+{
+    /* probe_waiters is owned by chan->owner_thread; the OPEN handler runs on
+     * the same thread, and the only producer of completions (nfs4_cb_null_
+     * complete) runs there too, so no lock is needed.  LIFO is fine -- the
+     * order in which deferred OPENs resume doesn't affect correctness. */
+    req->probe_next               = client->cb_path.probe_waiters;
+    client->cb_path.probe_waiters = req;
+} /* nfs4_cb_probe_park */
 
 /* ---------------------------------------------------------------------- */
 /* CB_RECALL                                                              */

--- a/src/server/nfs/nfs4_callback.h
+++ b/src/server/nfs/nfs4_callback.h
@@ -112,6 +112,34 @@ bool nfs4_cb_ensure_probe(
     struct nfs_request               *req);
 
 /*
+ * Tri-state grant decision: like nfs4_cb_ensure_probe, but distinguishes the
+ * just-triggered-probe case (NO_PATH; current behavior — the OPEN proceeds
+ * without a delegation) from someone-else-already-probing (DEFER; the OPEN
+ * parks until the probe completes, then resumes via nfs4_cb_probe_resume_open).
+ * Used by the OPEN delegation-grant path.
+ */
+enum nfs4_cb_grant_decision {
+    NFS4_CB_GRANT_PATH_UP,   /* cb_state == UP: grant may proceed */
+    NFS4_CB_GRANT_NO_PATH,   /* cb_state DOWN, or UNINIT->PROBING just kicked */
+    NFS4_CB_GRANT_DEFER,     /* cb_state == PROBING: caller must park */
+};
+
+enum nfs4_cb_grant_decision nfs4_cb_grant_probe(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_client                *client,
+    struct nfs_request               *req);
+
+/*
+ * Park `req` on `client`'s cb_path probe-waiters list, to be resumed when the
+ * in-flight CB_NULL probe completes.  Must be called immediately after
+ * nfs4_cb_grant_probe returns NFS4_CB_GRANT_DEFER, on the channel's owner
+ * thread (the OPEN handler runs there).
+ */
+void nfs4_cb_probe_park(
+    struct nfs_client  *client,
+    struct nfs_request *req);
+
+/*
  * Begin recalling `deleg` by sending CB_RECALL to its client.  Safe to call
  * from any thread; the work is marshalled to the channel's owner thread.
  * Takes a transient ref on `deleg` for the in-flight recall.  If no usable

--- a/src/server/nfs/nfs4_proc_open.c
+++ b/src/server/nfs/nfs4_proc_open.c
@@ -113,8 +113,16 @@ chimera_nfs4_open_acquire_share(
  *     lease conflict matrix).
  * Otherwise the response carries OPEN_DELEGATE_NONE.  Must be called on the
  * client's connection thread (it may kick a CB_NULL probe).
+ *
+ * Returns true when the OPEN's response has been parked on the cb_path's
+ * probe-waiters list (a CB_NULL probe is in flight for this client and a
+ * concurrent earlier OPEN already triggered it).  In that case the caller
+ * MUST NOT call chimera_nfs4_open_complete -- the probe completion will
+ * resume the OPEN via chimera_nfs4_open_resume_after_probe.  Returns false
+ * for the normal path (granted or not), where the caller continues with
+ * chimera_nfs4_open_complete.
  */
-static void
+static bool
 chimera_nfs4_open_grant_delegation(
     struct nfs_request *req,
     struct OPEN4res    *res)
@@ -139,13 +147,13 @@ chimera_nfs4_open_grant_delegation(
     res->resok4.delegation.delegation_type = OPEN_DELEGATE_NONE;
 
     if (!chimera_server_config_get_nfs4_delegations(thread->shared->config)) {
-        return;
+        return false;
     }
     if (!client) {
-        return;
+        return false;
     }
     if (args->claim.claim != CLAIM_NULL && args->claim.claim != CLAIM_FH) {
-        return;
+        return false;
     }
 
     /* RFC 8881 §18.16: honor an explicit "no delegation wanted" request.  On
@@ -157,7 +165,7 @@ chimera_nfs4_open_grant_delegation(
             res->resok4.delegation.od_whynone.ond_why                    = WND4_NOT_WANTED;
             res->resok4.delegation.od_whynone.ond_server_will_push_deleg = 0;
         }
-        return;
+        return false;
     }
 
     /* A write open earns a write delegation; otherwise a pure-read open earns
@@ -169,12 +177,27 @@ chimera_nfs4_open_grant_delegation(
         deleg_type = OPEN_DELEGATE_READ;
         lease_mode = CHIMERA_VFS_LEASE_MODE_R;
     } else {
-        return;
+        return false;
     }
 
-    if (!nfs4_cb_ensure_probe(thread, client, req)) {
-        return;
-    }
+    /* Tri-state probe gate.  PATH_UP grants below; NO_PATH is the historical
+     * "no delegation this time" path (either DOWN, or this very OPEN just
+     * kicked the probe); DEFER parks the OPEN on the cb_path until the in-
+     * flight CB_NULL probe completes (handled by nfs4_cb_null_complete via
+     * chimera_nfs4_open_resume_after_probe).  Deferring is what lets a
+     * second OPEN that lands during the probe still receive a delegation,
+     * without changing the kicking OPEN's behavior -- so pynfs DELEG22's
+     * second OPEN gets the delegation it expects, while DELEG15d's plain
+     * c.create_file (which kicks the probe) continues to receive none. */
+    switch (nfs4_cb_grant_probe(thread, client, req)) {
+        case NFS4_CB_GRANT_PATH_UP:
+            break;
+        case NFS4_CB_GRANT_NO_PATH:
+            return false;
+        case NFS4_CB_GRANT_DEFER:
+            nfs4_cb_probe_park(client, req);
+            return true;
+    } /* switch */
 
     /* fh_hash must match the open-cache / SHARE-lease hashing so the
      * delegation and conflicting opens land on the same file_state. */
@@ -191,7 +214,7 @@ chimera_nfs4_open_grant_delegation(
     }
     pthread_mutex_unlock(&client->lock);
     if (exists) {
-        return;
+        return false;
     }
 
     deleg = nfs_delegation_create(client, deleg_type,
@@ -219,7 +242,7 @@ chimera_nfs4_open_grant_delegation(
     if (!file_state) {
         nfs_delegation_destroy(deleg, &thread->shared->nfs4_state_table,
                                thread->vfs_thread);
-        return;
+        return false;
     }
     deleg->file_state = file_state;
 
@@ -231,7 +254,7 @@ chimera_nfs4_open_grant_delegation(
         deleg->file_state = NULL;
         nfs_delegation_destroy(deleg, &thread->shared->nfs4_state_table,
                                thread->vfs_thread);
-        return;
+        return false;
     }
     deleg->lease_held = true;
 
@@ -255,6 +278,7 @@ chimera_nfs4_open_grant_delegation(
     perms->access_mask = ACE4_READ_DATA;
     perms->who.len     = sizeof(everyone) - 1;
     perms->who.data    = (void *) everyone;
+    return false;
 } /* chimera_nfs4_open_grant_delegation */
 
 /*
@@ -433,6 +457,24 @@ chimera_nfs4_open_complete(
     chimera_nfs4_compound_complete(req, status);
 } /* chimera_nfs4_open_complete */
 
+/*
+ * Resume an OPEN that parked on the cb_path probe-waiters list while a
+ * 4.0 CB_NULL probe was in flight.  Called by nfs4_cb_null_complete on the
+ * channel's owner thread, once cb_state has settled to UP or DOWN.  Re-runs
+ * the grant decision -- it can no longer DEFER -- and completes the OPEN.
+ */
+void
+chimera_nfs4_open_resume_after_probe(struct nfs_request *req)
+{
+    struct OPEN4res *res = &req->res_compound.resarray[req->index].opopen;
+    bool             deferred;
+
+    deferred = chimera_nfs4_open_grant_delegation(req, res);
+    chimera_nfs_abort_if(deferred,
+                         "OPEN resume after probe re-deferred");
+    chimera_nfs4_open_complete(req, NFS4_OK);
+} /* chimera_nfs4_open_resume_after_probe */
+
 static void
 chimera_nfs4_open_exclusive_verify(
     enum chimera_vfs_error          error_code,
@@ -506,9 +548,14 @@ chimera_nfs4_open_exclusive_verify(
              OPEN4_RESULT_LOCKTYPE_POSIX : 0);
     }
     res->resok4.num_attrset = 0;
-    chimera_nfs4_open_grant_delegation(req, res);
 
+    /* Release the parent handle before grant_delegation so the cb-probe
+    * defer path (which returns without completing the OPEN) does not leak
+    * it -- the resume callback only knows how to call open_complete. */
     chimera_vfs_release(req->thread->vfs_thread, parent_handle);
+    if (chimera_nfs4_open_grant_delegation(req, res)) {
+        return; /* parked; resume from nfs4_cb_null_complete */
+    }
     chimera_nfs4_open_complete(req, NFS4_OK);
 } /* chimera_nfs4_open_exclusive_verify */
 
@@ -593,7 +640,6 @@ chimera_nfs4_open_at_complete(
              OPEN4_RESULT_LOCKTYPE_POSIX : 0);
     }
     res->resok4.num_attrset = 0;
-    chimera_nfs4_open_grant_delegation(req, res);
 
     if (args->openhow.opentype == OPEN4_CREATE &&
         (args->openhow.how.mode == UNCHECKED4 || args->openhow.how.mode == GUARDED4)) {
@@ -617,7 +663,13 @@ chimera_nfs4_open_at_complete(
 
     chimera_nfs4_set_changeinfo(&res->resok4.cinfo, dir_pre_attr, dir_post_attr);
 
+    /* Release the parent handle before grant_delegation so the cb-probe
+    * defer path (which returns without completing the OPEN) does not leak
+    * it -- the resume callback only knows how to call open_complete. */
     chimera_vfs_release(req->thread->vfs_thread, parent_handle);
+    if (chimera_nfs4_open_grant_delegation(req, res)) {
+        return; /* parked; resume from nfs4_cb_null_complete */
+    }
 
     chimera_nfs4_open_complete(req, NFS4_OK);
 } /* chimera_nfs4_open_at_complete */
@@ -773,10 +825,14 @@ chimera_nfs4_open_claim_fh_complete(
              OPEN4_RESULT_LOCKTYPE_POSIX : 0);
     }
     res->resok4.num_attrset = 0;
-    chimera_nfs4_open_grant_delegation(req, res);
 
+    /* Release the parent handle before grant_delegation so the cb-probe
+    * defer path (which returns without completing the OPEN) does not leak
+    * it -- the resume callback only knows how to call open_complete. */
     chimera_vfs_release(req->thread->vfs_thread, parent_handle);
-
+    if (chimera_nfs4_open_grant_delegation(req, res)) {
+        return; /* parked; resume from nfs4_cb_null_complete */
+    }
     chimera_nfs4_open_complete(req, NFS4_OK);
 } /* chimera_nfs4_open_claim_fh_complete */
 

--- a/src/server/nfs/nfs4_procs.h
+++ b/src/server/nfs/nfs4_procs.h
@@ -276,6 +276,17 @@ chimera_nfs4_open(
     struct nfs_argop4                *argop,
     struct nfs_resop4                *resop);
 
+/*
+ * Resume an OPEN that parked on a 4.0 CB_NULL probe (see
+ * NFS4_CB_GRANT_DEFER in nfs4_callback.h).  Called by
+ * nfs4_cb_null_complete on the channel's owner thread, once cb_state has
+ * been written to UP or DOWN.  Re-runs the delegation grant decision and
+ * completes the OPEN.
+ */
+void
+chimera_nfs4_open_resume_after_probe(
+    struct nfs_request *req);
+
 void
 chimera_nfs4_create(
     struct chimera_server_nfs_thread *thread,

--- a/src/server/nfs/nfs4_state.h
+++ b/src/server/nfs/nfs4_state.h
@@ -16,6 +16,8 @@
 #include "nfs4_xdr.h"
 #include "nfs4_stateid.h"
 #include "nfs4_lease.h"
+
+struct nfs_request;
 #include "vfs/vfs.h"
 #include "vfs/vfs_state.h"
 #include "common/macros.h"
@@ -115,6 +117,13 @@ struct nfs4_cb_path {
     /* Lazily-established outbound channel (4.0) or borrowed backchannel (4.1).
      * Owned/serviced by a single NFS thread; see nfs4_callback.c. */
     struct nfs4_cb_client *cb_client;
+    /* OPENs deferred while a 4.0 CB_NULL probe is in flight: the very first
+     * delegation-wanting OPEN flips UNINIT->PROBING and skips the grant
+     * (current behavior); a second OPEN that arrives during PROBING parks
+     * here instead of skipping, and nfs4_cb_null_complete resumes them all
+     * with the final cb_state.  Linked via nfs_request->probe_next.  Owned
+     * by chan->owner_thread; no extra synchronization needed. */
+    struct nfs_request    *probe_waiters;
 };
 
 /*

--- a/src/server/nfs/nfs_common.h
+++ b/src/server/nfs/nfs_common.h
@@ -128,6 +128,10 @@ struct nfs_request {
     uint32_t                          replay_slot_id;
     uint8_t                           replay_action;
     struct nfs_request               *next;
+    /* Park slot used while this request is awaiting a 4.0 callback-channel
+     * CB_NULL probe completion (see nfs4_callback.c probe-defer path).
+     * Owned by chan->owner_thread; no extra synchronization needed. */
+    struct nfs_request               *probe_next;
     union {
         struct mountargs3       *args_mount;
         struct ACCESS3args      *args_access;

--- a/src/server/nfs/tests/test_replay_slot.c
+++ b/src/server/nfs/tests/test_replay_slot.c
@@ -35,6 +35,14 @@
 #define TEST_SLOTS   4
 #define TEST_MAXRESP 4096
 
+/* nfs4_callback.c references this from nfs4_cb_null_complete, which this
+ * unit test never exercises -- stub it to satisfy the link. */
+void
+chimera_nfs4_open_resume_after_probe(struct nfs_request *req)
+{
+    (void) req;
+} /* chimera_nfs4_open_resume_after_probe */
+
 /*
  * Build a session attached to a fresh client table.  Caller frees with
  * destroy_session_table().  No NFS conn / encoding is created here --


### PR DESCRIPTION
## Problem

`DELEG22` (`st_delegation.testServerSelfConflict2`) intermittently fails on the fastest backends (memfs, io_uring) when ctest runs under heavy `-j` parallelism. Most recent sighting was PR #595 CI: 2 of 6 backends failed.

```
DELEG22  st_delegation.testServerSelfConflict2  : FAILURE
         Could not get delegation
```

The test does:

```python
c.init_connection(...)
time.sleep(0.5)
res = c.create_file(...)              # OPEN #1
if got_deleg: return                  # early-out: PASS
res = c.open_file(...)                # OPEN #2 (same file, same client)
if no_deleg: t.fail("Could not get delegation")
```

Chimera's grant rule (RFC 7530 §10.1) is that a delegation is granted only once the callback path is validated. For 4.0 that validation is an asynchronous `CB_NULL` probe fired lazily by the first delegation-wanting OPEN. The OPEN that kicks the probe never gets a delegation; later OPENs do, once `cb_state` flips `UP`.

DELEG22's two OPENs are back-to-back: the only thing between them is the test client parsing the first response. Under load on the fastest backends, that gap is shorter than the `CB_NULL` round-trip, so OPEN #2 finds the probe still in flight (`NFS4_CB_PROBING`) and is also denied — the test fails.

PR #518 fixed the same shape of race for 4.1 by marking the backchannel `UP` at session-bind. 4.0 has no equivalent synchronous binding point, so the lazy probe is the right default; what's missing is that a second OPEN arriving during the probe has no way to wait for it.

## Fix

Add a narrow defer path: an OPEN that finds the probe already in flight parks on the cb_path, and `nfs4_cb_null_complete` resumes it once `cb_state` has settled.

- `nfs4_cb_grant_probe()` is a tri-state variant of `nfs4_cb_ensure_probe` used by the OPEN grant path. It distinguishes the OPEN that just kicked the probe (`NO_PATH` — historical behavior, no delegation on this OPEN) from a concurrent OPEN that finds the probe already in flight (`DEFER` — park).
- `chimera_nfs4_open_grant_delegation()` now returns a bool; on `DEFER` it parks the request on the cb_path's new `probe_waiters` list and its caller skips `chimera_nfs4_open_complete`.
- `nfs4_cb_null_complete()` walks `probe_waiters` after writing the final `cb_state`, resuming each parked OPEN via the new `chimera_nfs4_open_resume_after_probe()` helper.

The waiter list is owned by `chan->owner_thread`; the OPEN handler and the probe completion both run on that thread, so no lock is needed. 4.1 never defers — `nfs4_cb_grant_probe` sees `UP` from the bind-time treatment.

## Why the OPEN that kicks the probe is left untouched

An eager always-grant approach (e.g. firing the probe at `SETCLIENTID_CONFIRM` so it has completed by the first OPEN) regresses **DELEG15d** (`st_delegation.testRenameOver`). DELEG15d opens a file plain, then asks for a delegation on a different file, and relies on the first OPEN *not* delegating — because pynfs's `cb_server` only registers a recall handler for one delegation per client. Granting on both opens leaves the second `CB_RECALL` unhandled and the deleg force-revoked when its 5 s recall deadline expires, surfaced to the test as `NFS4ERR_DELEG_REVOKED` on the prior `DELEGRETURN`. The defer-on-`PROBING` shape preserves the old kicking-OPEN behavior and only changes what happens to OPENs that find the probe already in flight.

## Validation

Locally on amd64 Release, repeated under `ctest -j 32`:

- `DELEG22` across all 6 backends — 8 runs of 12/12 pass.
- `DELEG15d` across all 6 backends, same load — 8 runs of 12/12 pass (this exercises the don't-grant-on-kick guarantee).
- Broader `delegations` + `deleg` + `courteous` + `destroy_session` matrix (4.0 + 4.1 + 4.2) — 467 of 468 pass. The single subprocess-killed entry is `COUR7_cairn_nfs4.2` hitting the pre-existing post-shutdown hang (chimera process stuck in state `D` post-`Server shutdown complete.`, same as before this change).