### PR TITLE
vfs: scale RCU cache reclaim with per-thread magazines + per-CPU workers

### DIFF
--- a/src/vfs/tests/vfs_notify_test.c
+++ b/src/vfs/tests/vfs_notify_test.c
@@ -420,6 +420,7 @@ static void
 test_rpl_cache_cross_shard_invalidate(void)
 {
     struct chimera_vfs_rpl_cache *cache;
+    struct chimera_vfs_thread     thread = { 0 }; /* zeroed magazines */
     uint8_t                       child_fh[CHIMERA_VFS_FH_SIZE];
     uint8_t                       parent_fh[CHIMERA_VFS_FH_SIZE];
     char                          name[]   = "myfile";
@@ -464,7 +465,7 @@ test_rpl_cache_cross_shard_invalidate(void)
     CHECK(found_cross_shard,
           "found a child_fh / parent_fh pair landing in different shards");
 
-    chimera_vfs_rpl_cache_insert(cache,
+    chimera_vfs_rpl_cache_insert(&thread, cache,
                                  child_hash,
                                  child_fh, sizeof(child_fh),
                                  parent_fh, sizeof(parent_fh),

--- a/src/vfs/vfs.c
+++ b/src/vfs/vfs.c
@@ -426,6 +426,16 @@ chimera_vfs_init(
     /* Bring up the process-wide TSC clock before any cache/timestamp use. */
     chimera_vfs_clock_init();
 
+    /* Scale RCU reclaim across CPUs: spawn one call_rcu worker per CPU so the
+     * fungible-cache retire callbacks (attr/name/rpl) keep up with per-request
+     * churn.  Without this liburcu uses a single default worker for the whole
+     * process.  Best-effort -- on failure call_rcu falls back to that default
+     * worker. */
+    if (create_all_cpu_call_rcu_data(0) != 0) {
+        chimera_vfs_error("Failed to create per-CPU call_rcu workers; "
+                          "falling back to the default RCU reclaim thread");
+    }
+
     vfs = calloc(1, sizeof(*vfs));
 
     /* Synthesize machine name for identification */
@@ -662,6 +672,10 @@ chimera_vfs_destroy(struct chimera_vfs *vfs)
     chimera_vfs_open_cache_destroy(vfs->vfs_open_path_cache);
     chimera_vfs_open_cache_destroy(vfs->vfs_open_file_cache);
 
+    /* All RCU caches are destroyed above and each drained via rcu_barrier(), so
+     * no callbacks remain; tear down the per-CPU call_rcu workers. */
+    free_all_cpu_call_rcu_data();
+
     if (vfs->metrics.op_latency) {
         for (int i = 0; i < CHIMERA_VFS_OP_NUM; i++) {
             prometheus_histogram_destroy_series(vfs->metrics.op_latency, vfs->metrics.op_latency_series[i]);
@@ -835,6 +849,12 @@ chimera_vfs_thread_destroy(struct chimera_vfs_thread *thread)
                                                          thread->metrics.op_latency_series[i]);
         }
         free(thread->metrics.op_latency_series);
+    }
+
+    /* Return this thread's recycled RCU cache entries to their pool depots so
+     * they are reclaimed at cache destroy (the pools outlive the threads). */
+    for (i = 0; i < CHIMERA_RCU_POOL_COUNT; i++) {
+        chimera_rcu_magazine_drain(&thread->rcu_magazines[i]);
     }
 
     free(thread);

--- a/src/vfs/vfs.h
+++ b/src/vfs/vfs.h
@@ -26,6 +26,24 @@ struct chimera_vfs_user;
 struct chimera_vfs_user_cache;
 struct prometheus_metrics;
 
+/* RCU recycle pools: one per fungible cache (attr/name/rpl).  The per-thread
+ * magazine type is defined here (no urcu dependency) so chimera_vfs_thread can
+ * embed it; the pool itself and the helpers live in vfs_rcu_pool.h. */
+enum chimera_rcu_pool_id {
+    CHIMERA_RCU_POOL_ATTR = 0,
+    CHIMERA_RCU_POOL_NAME,
+    CHIMERA_RCU_POOL_RPL,
+    CHIMERA_RCU_POOL_COUNT
+};
+
+#define CHIMERA_RCU_MAGAZINE_CAP 64
+
+struct chimera_rcu_node;
+struct chimera_rcu_magazine {
+    struct chimera_rcu_node *head;
+    uint32_t                 count;
+};
+
 /* FSSTAT values used with builtin backends until statvfs tracking is implemented */
 #define CHIMERA_VFS_SYNTHETIC_FS_BYTES   ((uint64_t) 100 * 1024 * 1024 * 1024)
 #define CHIMERA_VFS_SYNTHETIC_FS_INODES  (1024 * 1024)
@@ -1366,6 +1384,8 @@ struct chimera_vfs_thread {
     struct evpl                         *evpl;
     struct chimera_vfs                  *vfs;
     void                                *module_private[CHIMERA_VFS_FH_MAGIC_MAX];
+    /* Thread-local recycle magazines for the fungible RCU caches. */
+    struct chimera_rcu_magazine          rcu_magazines[CHIMERA_RCU_POOL_COUNT];
     struct chimera_vfs_find_result      *free_find_results;
     struct chimera_vfs_request          *free_requests;
     struct chimera_vfs_request          *active_requests;

--- a/src/vfs/vfs_attr_cache.h
+++ b/src/vfs/vfs_attr_cache.h
@@ -5,27 +5,22 @@
 #pragma once
 
 #include "vfs/vfs.h"
+#include "vfs/vfs_rcu_pool.h"
 #include <urcu.h>
 #include <urcu/urcu-memb.h>
 #include "prometheus-c.h"
 
 struct chimera_vfs_attr_cache_entry {
+    struct chimera_rcu_node  rnode; /* must be first: aliases the entry pointer */
     uint64_t                 key;
     uint64_t                 score;
-    struct rcu_head          rcu;
     uint64_t                 expiration; /* stopwatch ticks */
-    union {
-        struct chimera_vfs_attr_cache_entry *next; /* when on the free list */
-        struct chimera_vfs_attr_cache_shard *shard; /* when not in the free list */
-    };
     struct chimera_vfs_attrs attr;
 };
 
 struct chimera_vfs_attr_cache_shard {
     struct chimera_vfs_attr_cache_entry **entries;
-    struct chimera_vfs_attr_cache_entry  *free_entries;
     pthread_mutex_t                       entry_lock;
-    pthread_mutex_t                       free_lock;
     struct prometheus_counter_instance   *insert;
     struct prometheus_counter_instance   *hit;
     struct prometheus_counter_instance   *miss;
@@ -42,6 +37,7 @@ struct chimera_vfs_attr_cache {
     uint32_t                             num_shards_mask;
     uint32_t                             num_entries_mask;
     uint64_t                             ttl;
+    struct chimera_rcu_pool              pool;
     struct chimera_vfs_attr_cache_shard *shards;
     struct prometheus_metrics           *metrics;
     struct prometheus_counter           *attr_cache;
@@ -60,8 +56,7 @@ chimera_vfs_attr_cache_create(
 {
     struct chimera_vfs_attr_cache       *cache;
     struct chimera_vfs_attr_cache_shard *shard;
-    struct chimera_vfs_attr_cache_entry *entry;
-    int                                  i, j;
+    int                                  i;
 
     cache = calloc(1, sizeof(struct chimera_vfs_attr_cache));
 
@@ -69,6 +64,9 @@ chimera_vfs_attr_cache_create(
     cache->num_slots_bits   = num_slots_bits;
     cache->num_entries_bits = entries_per_slot_bits;
     cache->ttl              = ttl;
+
+    chimera_rcu_pool_init(&cache->pool, CHIMERA_RCU_POOL_ATTR,
+                          sizeof(struct chimera_vfs_attr_cache_entry));
 
     cache->num_shards  = 1 << num_shards_bits;
     cache->num_slots   = 1 << num_slots_bits;
@@ -101,13 +99,7 @@ chimera_vfs_attr_cache_create(
         shard          = &cache->shards[i];
         shard->entries = calloc(cache->num_slots * cache->num_entries, sizeof(struct chimera_vfs_attr_cache_entry *));
 
-        for (j = 0; j < cache->num_slots * cache->num_entries; j++) {
-            entry = calloc(1, sizeof(struct chimera_vfs_attr_cache_entry));
-            LL_PREPEND(shard->free_entries, entry);
-        }
-
         pthread_mutex_init(&shard->entry_lock, NULL);
-        pthread_mutex_init(&shard->free_lock, NULL);
 
         if (metrics) {
             shard->insert = prometheus_counter_series_create_instance(cache->insert_series);
@@ -144,15 +136,10 @@ chimera_vfs_attr_cache_destroy(struct chimera_vfs_attr_cache *cache)
 
         free(shard->entries);
 
-        while (shard->free_entries) {
-            entry               = shard->free_entries;
-            shard->free_entries = entry->next;
-            free(entry);
-        }
-
         pthread_mutex_destroy(&shard->entry_lock);
-        pthread_mutex_destroy(&shard->free_lock);
     }
+
+    chimera_rcu_pool_destroy(&cache->pool);
 
     if (cache->metrics) {
         prometheus_counter_destroy_series(cache->attr_cache, cache->insert_series);
@@ -218,18 +205,8 @@ chimera_vfs_attr_cache_lookup(
 } /* chimera_vfs_name_cache_lookup */
 
 static inline void
-chimera_vfs_attr_cache_free_entry_rcu(struct rcu_head *head)
-{
-    struct chimera_vfs_attr_cache_entry *entry = container_of(head, struct chimera_vfs_attr_cache_entry, rcu);
-    struct chimera_vfs_attr_cache_shard *shard = entry->shard;
-
-    pthread_mutex_lock(&shard->free_lock);
-    LL_PREPEND(shard->free_entries, entry);
-    pthread_mutex_unlock(&shard->free_lock);
-} /* chimera_name_cache_free_entry_rcu */
-
-static inline void
 chimera_vfs_attr_cache_insert(
+    struct chimera_vfs_thread     *thread,
     struct chimera_vfs_attr_cache *cache,
     uint64_t                       fh_hash,
     const void                    *fh,
@@ -250,23 +227,10 @@ chimera_vfs_attr_cache_insert(
 
     if ((attr->va_set_mask & CHIMERA_VFS_ATTR_MASK_STAT) == CHIMERA_VFS_ATTR_MASK_STAT) {
 
-        pthread_mutex_lock(&shard->free_lock);
-
-        entry = shard->free_entries;
-
-        if (entry) {
-            LL_DELETE(shard->free_entries, entry);
-        }
-
-        pthread_mutex_unlock(&shard->free_lock);
-
-
-        if (!entry) {
-            entry = calloc(1, sizeof(struct chimera_vfs_attr_cache_entry));
-        }
+        entry = (struct chimera_vfs_attr_cache_entry *)
+            chimera_rcu_pool_alloc(&thread->rcu_magazines[CHIMERA_RCU_POOL_ATTR], &cache->pool);
 
         entry->key   = fh_hash;
-        entry->shard = shard;
         entry->score = 0;
         entry->attr  = *attr;
 
@@ -313,7 +277,7 @@ chimera_vfs_attr_cache_insert(
     urcu_memb_read_unlock();
 
     if (best_entry) {
-        call_rcu(&best_entry->rcu, chimera_vfs_attr_cache_free_entry_rcu);
+        call_rcu(&best_entry->rnode.rcu, chimera_rcu_pool_retire);
     }
 
 } /* chimera_vfs_attr_cache_insert */

--- a/src/vfs/vfs_name_cache.h
+++ b/src/vfs/vfs_name_cache.h
@@ -5,31 +5,26 @@
 #pragma once
 
 #include "vfs/vfs.h"
+#include "vfs/vfs_rcu_pool.h"
 #include <urcu.h>
 #include <urcu/urcu-memb.h>
 
 struct chimera_vfs_name_cache_entry {
-    uint64_t        key;
-    uint8_t         parent_fh_len;
-    uint8_t         child_fh_len;
-    uint16_t        name_len;
-    int64_t         score;
-    uint64_t        expiration; /* stopwatch ticks */
-    struct rcu_head rcu;
-    union {
-        struct chimera_vfs_name_cache_entry *next; /* when on the free list */
-        struct chimera_vfs_name_cache_shard *shard; /* when not in the free list */
-    };
-    uint8_t         parent_fh[CHIMERA_VFS_FH_SIZE];
-    uint8_t         child_fh[CHIMERA_VFS_FH_SIZE];
-    char            child_name[CHIMERA_VFS_NAME_MAX];
+    struct chimera_rcu_node rnode; /* must be first: aliases the entry pointer */
+    uint64_t                key;
+    uint8_t                 parent_fh_len;
+    uint8_t                 child_fh_len;
+    uint16_t                name_len;
+    int64_t                 score;
+    uint64_t                expiration; /* stopwatch ticks */
+    uint8_t                 parent_fh[CHIMERA_VFS_FH_SIZE];
+    uint8_t                 child_fh[CHIMERA_VFS_FH_SIZE];
+    char                    child_name[CHIMERA_VFS_NAME_MAX];
 };
 
 struct chimera_vfs_name_cache_shard {
     struct chimera_vfs_name_cache_entry **entries;
-    struct chimera_vfs_name_cache_entry  *free_entries;
     pthread_mutex_t                       entry_lock;
-    pthread_mutex_t                       free_lock;
     struct prometheus_counter_instance   *miss;
     struct prometheus_counter_instance   *hit;
     struct prometheus_counter_instance   *insert;
@@ -46,6 +41,7 @@ struct chimera_vfs_name_cache {
     uint32_t                             num_shards_mask;
     uint32_t                             num_entries_mask;
     uint64_t                             ttl;
+    struct chimera_rcu_pool              pool;
     struct chimera_vfs_name_cache_shard *shards;
     struct prometheus_metrics           *metrics;
     struct prometheus_counter           *name_cache;
@@ -64,8 +60,7 @@ chimera_vfs_name_cache_create(
 {
     struct chimera_vfs_name_cache       *cache;
     struct chimera_vfs_name_cache_shard *shard;
-    struct chimera_vfs_name_cache_entry *entry;
-    int                                  i, j;
+    int                                  i;
 
     cache = calloc(1, sizeof(struct chimera_vfs_name_cache));
 
@@ -73,9 +68,13 @@ chimera_vfs_name_cache_create(
     cache->num_slots_bits   = num_slots_bits;
     cache->num_entries_bits = entries_per_slot_bits;
     cache->ttl              = ttl;
-    cache->num_shards       = 1 << num_shards_bits;
-    cache->num_slots        = 1 << num_slots_bits;
-    cache->num_entries      = 1 << entries_per_slot_bits;
+
+    chimera_rcu_pool_init(&cache->pool, CHIMERA_RCU_POOL_NAME,
+                          sizeof(struct chimera_vfs_name_cache_entry));
+
+    cache->num_shards  = 1 << num_shards_bits;
+    cache->num_slots   = 1 << num_slots_bits;
+    cache->num_entries = 1 << entries_per_slot_bits;
 
     cache->num_slots_mask   = cache->num_slots - 1;
     cache->num_shards_mask  = cache->num_shards - 1;
@@ -105,13 +104,7 @@ chimera_vfs_name_cache_create(
         shard          = &cache->shards[i];
         shard->entries = calloc(cache->num_slots * cache->num_entries, sizeof(struct chimera_vfs_name_cache_entry *));
 
-        for (j = 0; j < cache->num_slots * cache->num_entries; j++) {
-            entry = calloc(1, sizeof(struct chimera_vfs_name_cache_entry));
-            LL_PREPEND(shard->free_entries, entry);
-        }
-
         pthread_mutex_init(&shard->entry_lock, NULL);
-        pthread_mutex_init(&shard->free_lock, NULL);
 
         shard->miss   = prometheus_counter_series_create_instance(cache->miss_series);
         shard->hit    = prometheus_counter_series_create_instance(cache->hit_series);
@@ -148,15 +141,10 @@ chimera_vfs_name_cache_destroy(struct chimera_vfs_name_cache *cache)
 
         free(shard->entries);
 
-        while (shard->free_entries) {
-            entry               = shard->free_entries;
-            shard->free_entries = entry->next;
-            free(entry);
-        }
-
         pthread_mutex_destroy(&shard->entry_lock);
-        pthread_mutex_destroy(&shard->free_lock);
     }
+
+    chimera_rcu_pool_destroy(&cache->pool);
 
     if (cache->metrics) {
         prometheus_counter_destroy_series(cache->name_cache, cache->miss_series);
@@ -230,18 +218,8 @@ chimera_vfs_name_cache_lookup(
 } /* chimera_vfs_name_cache_lookup */
 
 static inline void
-chimera_name_cache_free_entry_rcu(struct rcu_head *head)
-{
-    struct chimera_vfs_name_cache_entry *entry = container_of(head, struct chimera_vfs_name_cache_entry, rcu);
-    struct chimera_vfs_name_cache_shard *shard = entry->shard;
-
-    pthread_mutex_lock(&shard->free_lock);
-    LL_PREPEND(shard->free_entries, entry);
-    pthread_mutex_unlock(&shard->free_lock);
-} /* chimera_name_cache_free_entry_rcu */
-
-static inline void
 chimera_vfs_name_cache_insert(
+    struct chimera_vfs_thread     *thread,
     struct chimera_vfs_name_cache *cache,
     uint64_t                       fh_hash,
     const void                    *fh,
@@ -266,26 +244,13 @@ chimera_vfs_name_cache_insert(
 
     slot_best = slot;
 
-    pthread_mutex_lock(&shard->free_lock);
-
-    entry = shard->free_entries;
-
-    if (entry) {
-        LL_DELETE(shard->free_entries, entry);
-    }
-
-    pthread_mutex_unlock(&shard->free_lock);
-
-
-    if (!entry) {
-        entry = calloc(1, sizeof(struct chimera_vfs_name_cache_entry));
-    }
+    entry = (struct chimera_vfs_name_cache_entry *)
+        chimera_rcu_pool_alloc(&thread->rcu_magazines[CHIMERA_RCU_POOL_NAME], &cache->pool);
 
     entry->key           = key;
     entry->parent_fh_len = fh_len;
     entry->child_fh_len  = child_fh_len;
     entry->name_len      = name_len;
-    entry->shard         = shard;
     entry->score         = 0;
 
     entry->expiration = now + chimera_vfs_ns_to_ticks((uint64_t) cache->ttl * 1000000000ULL);
@@ -362,7 +327,7 @@ chimera_vfs_name_cache_insert(
     urcu_memb_read_unlock();
 
     if (best_entry) {
-        call_rcu(&best_entry->rcu, chimera_name_cache_free_entry_rcu);
+        call_rcu(&best_entry->rnode.rcu, chimera_rcu_pool_retire);
     }
 
 } /* chimera_vfs_name_cache_insert */
@@ -415,7 +380,7 @@ chimera_vfs_name_cache_remove(
     urcu_memb_read_unlock();
 
     if (removed_entry) {
-        call_rcu(&removed_entry->rcu, chimera_name_cache_free_entry_rcu);
+        call_rcu(&removed_entry->rnode.rcu, chimera_rcu_pool_retire);
     }
 
-} /* chimera_vfs_name_cache_insert */
+} /* chimera_vfs_name_cache_remove */

--- a/src/vfs/vfs_notify.c
+++ b/src/vfs/vfs_notify.c
@@ -333,8 +333,14 @@ chimera_vfs_notify_resolve_getparent_cb(
         return;
     }
 
-    /* Cache the result for future events */
-    chimera_vfs_rpl_cache_insert(notify->rpl_cache,
+    /* Cache the result for future events.  This callback runs on the same
+     * worker thread chimera_vfs_notify_resolve dispatched getparent on, so its
+     * magazine is the correct thread-local pool to recycle from. */
+    struct chimera_vfs_thread *rpl_thread = notify->vfs->num_sync_delegation_threads > 0 ?
+        notify->vfs->sync_delegation_threads[0].vfs_thread :
+        notify->vfs->close_thread.vfs_thread;
+
+    chimera_vfs_rpl_cache_insert(rpl_thread, notify->rpl_cache,
                                  chimera_vfs_hash(pev->walk_fh, pev->walk_fh_len),
                                  pev->walk_fh,
                                  pev->walk_fh_len,

--- a/src/vfs/vfs_proc_allocate.c
+++ b/src/vfs/vfs_proc_allocate.c
@@ -13,7 +13,7 @@ chimera_vfs_allocate_complete(struct chimera_vfs_request *request)
     chimera_vfs_allocate_callback_t callback = request->proto_callback;
 
     if (request->status == CHIMERA_VFS_OK) {
-        chimera_vfs_attr_cache_insert(request->thread->vfs->vfs_attr_cache,
+        chimera_vfs_attr_cache_insert(request->thread, request->thread->vfs->vfs_attr_cache,
                                       request->allocate.handle->fh_hash,
                                       request->allocate.handle->fh,
                                       request->allocate.handle->fh_len,

--- a/src/vfs/vfs_proc_clone_range.c
+++ b/src/vfs/vfs_proc_clone_range.c
@@ -14,7 +14,7 @@ chimera_vfs_clone_range_complete(struct chimera_vfs_request *request)
     chimera_vfs_clone_range_callback_t callback = request->proto_callback;
 
     if (request->status == CHIMERA_VFS_OK) {
-        chimera_vfs_attr_cache_insert(request->thread->vfs->vfs_attr_cache,
+        chimera_vfs_attr_cache_insert(request->thread, request->thread->vfs->vfs_attr_cache,
                                       request->clone_range.dst_handle->fh_hash,
                                       request->clone_range.dst_handle->fh,
                                       request->clone_range.dst_handle->fh_len,

--- a/src/vfs/vfs_proc_commit.c
+++ b/src/vfs/vfs_proc_commit.c
@@ -13,7 +13,7 @@ chimera_vfs_commit_complete(struct chimera_vfs_request *request)
     chimera_vfs_commit_callback_t callback = request->proto_callback;
 
     if (request->status == CHIMERA_VFS_OK) {
-        chimera_vfs_attr_cache_insert(request->thread->vfs->vfs_attr_cache,
+        chimera_vfs_attr_cache_insert(request->thread, request->thread->vfs->vfs_attr_cache,
                                       request->commit.handle->fh_hash,
                                       request->commit.handle->fh,
                                       request->commit.handle->fh_len,

--- a/src/vfs/vfs_proc_copy_range.c
+++ b/src/vfs/vfs_proc_copy_range.c
@@ -14,7 +14,7 @@ chimera_vfs_copy_range_complete(struct chimera_vfs_request *request)
     chimera_vfs_copy_range_callback_t callback = request->proto_callback;
 
     if (request->status == CHIMERA_VFS_OK) {
-        chimera_vfs_attr_cache_insert(request->thread->vfs->vfs_attr_cache,
+        chimera_vfs_attr_cache_insert(request->thread, request->thread->vfs->vfs_attr_cache,
                                       request->copy_range.dst_handle->fh_hash,
                                       request->copy_range.dst_handle->fh,
                                       request->copy_range.dst_handle->fh_len,

--- a/src/vfs/vfs_proc_create_unlinked.c
+++ b/src/vfs/vfs_proc_create_unlinked.c
@@ -20,7 +20,7 @@ chimera_vfs_create_unlinked_hdl_callback(
     chimera_vfs_create_unlinked_callback_t callback = request->proto_callback;
 
     if (request->status == CHIMERA_VFS_OK) {
-        chimera_vfs_attr_cache_insert(thread->vfs->vfs_attr_cache,
+        chimera_vfs_attr_cache_insert(thread, thread->vfs->vfs_attr_cache,
                                       chimera_vfs_hash(request->create_unlinked.r_attr.va_fh, request->create_unlinked.
                                                        r_attr.
                                                        va_fh_len),

--- a/src/vfs/vfs_proc_getattr.c
+++ b/src/vfs/vfs_proc_getattr.c
@@ -17,7 +17,7 @@ chimera_vfs_getattr_complete(struct chimera_vfs_request *request)
     chimera_vfs_getattr_callback_t callback   = request->proto_callback;
 
     if (request->status == CHIMERA_VFS_OK) {
-        chimera_vfs_attr_cache_insert(attr_cache,
+        chimera_vfs_attr_cache_insert(thread, attr_cache,
                                       request->getattr.handle->fh_hash,
                                       request->getattr.handle->fh,
                                       request->getattr.handle->fh_len,

--- a/src/vfs/vfs_proc_getrootfh.c
+++ b/src/vfs/vfs_proc_getrootfh.c
@@ -18,7 +18,7 @@ chimera_vfs_getrootfh_complete(struct chimera_vfs_request *request)
 
 
     if (request->status == CHIMERA_VFS_OK) {
-        chimera_vfs_attr_cache_insert(attr_cache,
+        chimera_vfs_attr_cache_insert(thread, attr_cache,
                                       request->fh_hash,
                                       request->fh,
                                       request->fh_len,

--- a/src/vfs/vfs_proc_link_at.c
+++ b/src/vfs/vfs_proc_link_at.c
@@ -23,7 +23,7 @@ chimera_vfs_link_at_complete(struct chimera_vfs_request *request)
 
 
     if (request->status == CHIMERA_VFS_OK) {
-        chimera_vfs_name_cache_insert(name_cache,
+        chimera_vfs_name_cache_insert(thread, name_cache,
                                       request->link_at.dir_fh_hash,
                                       request->link_at.dir_fh,
                                       request->link_at.dir_fhlen,
@@ -33,20 +33,20 @@ chimera_vfs_link_at_complete(struct chimera_vfs_request *request)
                                       request->fh,
                                       request->fh_len);
 
-        chimera_vfs_attr_cache_insert(attr_cache,
+        chimera_vfs_attr_cache_insert(thread, attr_cache,
                                       request->link_at.dir_fh_hash,
                                       request->link_at.dir_fh,
                                       request->link_at.dir_fhlen,
                                       &request->link_at.r_dir_post_attr);
 
-        chimera_vfs_attr_cache_insert(attr_cache,
+        chimera_vfs_attr_cache_insert(thread, attr_cache,
                                       request->fh_hash,
                                       request->fh,
                                       request->fh_len,
                                       &request->link_at.r_attr);
 
         if (request->link_at.r_replaced_attr.va_set_mask & CHIMERA_VFS_ATTR_FH) {
-            chimera_vfs_attr_cache_insert(attr_cache,
+            chimera_vfs_attr_cache_insert(thread, attr_cache,
                                           request->link_at.r_replaced_attr.va_fh_hash,
                                           request->link_at.r_replaced_attr.va_fh,
                                           request->link_at.r_replaced_attr.va_fh_len,

--- a/src/vfs/vfs_proc_lookup_at.c
+++ b/src/vfs/vfs_proc_lookup_at.c
@@ -23,7 +23,7 @@ chimera_vfs_lookup_at_complete(struct chimera_vfs_request *request)
     chimera_vfs_lookup_at_callback_t callback   = request->proto_callback;
 
     if (request->status == CHIMERA_VFS_OK) {
-        chimera_vfs_name_cache_insert(name_cache,
+        chimera_vfs_name_cache_insert(thread, name_cache,
                                       request->lookup_at.handle->fh_hash,
                                       request->lookup_at.handle->fh,
                                       request->lookup_at.handle->fh_len,
@@ -33,14 +33,14 @@ chimera_vfs_lookup_at_complete(struct chimera_vfs_request *request)
                                       request->lookup_at.r_attr.va_fh,
                                       request->lookup_at.r_attr.va_fh_len);
 
-        chimera_vfs_attr_cache_insert(attr_cache,
+        chimera_vfs_attr_cache_insert(thread, attr_cache,
                                       chimera_vfs_hash(request->lookup_at.r_attr.va_fh, request->lookup_at.r_attr.
                                                        va_fh_len),
                                       request->lookup_at.r_attr.va_fh,
                                       request->lookup_at.r_attr.va_fh_len,
                                       &request->lookup_at.r_attr);
 
-        chimera_vfs_attr_cache_insert(attr_cache,
+        chimera_vfs_attr_cache_insert(thread, attr_cache,
                                       request->lookup_at.handle->fh_hash,
                                       request->lookup_at.handle->fh,
                                       request->lookup_at.handle->fh_len,

--- a/src/vfs/vfs_proc_mkdir_at.c
+++ b/src/vfs/vfs_proc_mkdir_at.c
@@ -29,7 +29,7 @@ chimera_vfs_mkdir_at_complete(struct chimera_vfs_request *request)
                                 request->mkdir_at.name_len,
                                 NULL, 0);
 
-        chimera_vfs_name_cache_insert(cache,
+        chimera_vfs_name_cache_insert(thread, cache,
                                       request->mkdir_at.handle->fh_hash,
                                       request->mkdir_at.handle->fh,
                                       request->mkdir_at.handle->fh_len,
@@ -39,13 +39,13 @@ chimera_vfs_mkdir_at_complete(struct chimera_vfs_request *request)
                                       request->mkdir_at.r_attr.va_fh,
                                       request->mkdir_at.r_attr.va_fh_len);
 
-        chimera_vfs_attr_cache_insert(thread->vfs->vfs_attr_cache,
+        chimera_vfs_attr_cache_insert(thread, thread->vfs->vfs_attr_cache,
                                       request->mkdir_at.handle->fh_hash,
                                       request->mkdir_at.handle->fh,
                                       request->mkdir_at.handle->fh_len,
                                       &request->mkdir_at.r_dir_post_attr);
 
-        chimera_vfs_attr_cache_insert(thread->vfs->vfs_attr_cache,
+        chimera_vfs_attr_cache_insert(thread, thread->vfs->vfs_attr_cache,
                                       chimera_vfs_hash(request->mkdir_at.r_attr.va_fh, request->mkdir_at.r_attr.
                                                        va_fh_len)
                                       ,

--- a/src/vfs/vfs_proc_mknod_at.c
+++ b/src/vfs/vfs_proc_mknod_at.c
@@ -20,7 +20,7 @@ chimera_vfs_mknod_at_complete(struct chimera_vfs_request *request)
     chimera_vfs_mknod_at_callback_t callback = request->proto_callback;
 
     if (request->status == CHIMERA_VFS_OK) {
-        chimera_vfs_name_cache_insert(cache,
+        chimera_vfs_name_cache_insert(thread, cache,
                                       request->mknod_at.handle->fh_hash,
                                       request->mknod_at.handle->fh,
                                       request->mknod_at.handle->fh_len,
@@ -30,13 +30,13 @@ chimera_vfs_mknod_at_complete(struct chimera_vfs_request *request)
                                       request->mknod_at.r_attr.va_fh,
                                       request->mknod_at.r_attr.va_fh_len);
 
-        chimera_vfs_attr_cache_insert(thread->vfs->vfs_attr_cache,
+        chimera_vfs_attr_cache_insert(thread, thread->vfs->vfs_attr_cache,
                                       request->mknod_at.handle->fh_hash,
                                       request->mknod_at.handle->fh,
                                       request->mknod_at.handle->fh_len,
                                       &request->mknod_at.r_dir_post_attr);
 
-        chimera_vfs_attr_cache_insert(thread->vfs->vfs_attr_cache,
+        chimera_vfs_attr_cache_insert(thread, thread->vfs->vfs_attr_cache,
                                       chimera_vfs_hash(request->mknod_at.r_attr.va_fh, request->mknod_at.r_attr.
                                                        va_fh_len)
                                       ,

--- a/src/vfs/vfs_proc_move_range.c
+++ b/src/vfs/vfs_proc_move_range.c
@@ -14,12 +14,12 @@ chimera_vfs_move_range_complete(struct chimera_vfs_request *request)
     chimera_vfs_move_range_callback_t callback = request->proto_callback;
 
     if (request->status == CHIMERA_VFS_OK) {
-        chimera_vfs_attr_cache_insert(request->thread->vfs->vfs_attr_cache,
+        chimera_vfs_attr_cache_insert(request->thread, request->thread->vfs->vfs_attr_cache,
                                       request->move_range.dst_handle->fh_hash,
                                       request->move_range.dst_handle->fh,
                                       request->move_range.dst_handle->fh_len,
                                       &request->move_range.r_dst_post_attr);
-        chimera_vfs_attr_cache_insert(request->thread->vfs->vfs_attr_cache,
+        chimera_vfs_attr_cache_insert(request->thread, request->thread->vfs->vfs_attr_cache,
                                       request->move_range.src_handle->fh_hash,
                                       request->move_range.src_handle->fh,
                                       request->move_range.src_handle->fh_len,

--- a/src/vfs/vfs_proc_open_at.c
+++ b/src/vfs/vfs_proc_open_at.c
@@ -21,7 +21,7 @@ chimera_vfs_open_at_hdl_callback(
     chimera_vfs_open_at_callback_t callback = request->proto_callback;
 
     if (request->status == CHIMERA_VFS_OK) {
-        chimera_vfs_name_cache_insert(cache,
+        chimera_vfs_name_cache_insert(thread, cache,
                                       request->open_at.handle->fh_hash,
                                       request->open_at.handle->fh,
                                       request->open_at.handle->fh_len,
@@ -31,13 +31,13 @@ chimera_vfs_open_at_hdl_callback(
                                       request->open_at.r_attr.va_fh,
                                       request->open_at.r_attr.va_fh_len);
 
-        chimera_vfs_attr_cache_insert(thread->vfs->vfs_attr_cache,
+        chimera_vfs_attr_cache_insert(thread, thread->vfs->vfs_attr_cache,
                                       request->open_at.handle->fh_hash,
                                       request->open_at.handle->fh,
                                       request->open_at.handle->fh_len,
                                       &request->open_at.r_dir_post_attr);
 
-        chimera_vfs_attr_cache_insert(thread->vfs->vfs_attr_cache,
+        chimera_vfs_attr_cache_insert(thread, thread->vfs->vfs_attr_cache,
                                       chimera_vfs_hash(request->open_at.r_attr.va_fh, request->open_at.r_attr.
                                                        va_fh_len),
                                       request->open_at.r_attr.va_fh,

--- a/src/vfs/vfs_proc_read.c
+++ b/src/vfs/vfs_proc_read.c
@@ -95,7 +95,7 @@ chimera_vfs_read_complete(struct chimera_vfs_request *request)
      * inserting here would only evict a valid entry. */
     if (request->status == CHIMERA_VFS_OK &&
         (request->read.r_attr.va_set_mask & CHIMERA_VFS_ATTR_MASK_STAT) == CHIMERA_VFS_ATTR_MASK_STAT) {
-        chimera_vfs_attr_cache_insert(request->thread->vfs->vfs_attr_cache,
+        chimera_vfs_attr_cache_insert(request->thread, request->thread->vfs->vfs_attr_cache,
                                       request->read.handle->fh_hash,
                                       request->read.handle->fh,
                                       request->read.handle->fh_len,

--- a/src/vfs/vfs_proc_remove_at.c
+++ b/src/vfs/vfs_proc_remove_at.c
@@ -59,7 +59,7 @@ chimera_vfs_remove_at_complete(struct chimera_vfs_request *request)
                                 request->remove_at.namelen,
                                 NULL, 0);
 
-        chimera_vfs_name_cache_insert(name_cache,
+        chimera_vfs_name_cache_insert(thread, name_cache,
                                       request->remove_at.handle->fh_hash,
                                       request->remove_at.handle->fh,
                                       request->remove_at.handle->fh_len,
@@ -69,14 +69,14 @@ chimera_vfs_remove_at_complete(struct chimera_vfs_request *request)
                                       NULL,
                                       0);
 
-        chimera_vfs_attr_cache_insert(attr_cache,
+        chimera_vfs_attr_cache_insert(thread, attr_cache,
                                       request->remove_at.handle->fh_hash,
                                       request->remove_at.handle->fh,
                                       request->remove_at.handle->fh_len,
                                       &request->remove_at.r_dir_post_attr);
 
         if (request->remove_at.r_removed_attr.va_set_mask & CHIMERA_VFS_ATTR_FH) {
-            chimera_vfs_attr_cache_insert(attr_cache,
+            chimera_vfs_attr_cache_insert(thread, attr_cache,
                                           chimera_vfs_hash(request->remove_at.r_removed_attr.va_fh, request->remove_at.
                                                            r_removed_attr.va_fh_len),
                                           request->remove_at.r_removed_attr.va_fh,

--- a/src/vfs/vfs_proc_setattr.c
+++ b/src/vfs/vfs_proc_setattr.c
@@ -78,7 +78,7 @@ chimera_vfs_setattr_complete(struct chimera_vfs_request *request)
     chimera_vfs_setattr_callback_t callback = request->proto_callback;
 
     if (request->status == CHIMERA_VFS_OK) {
-        chimera_vfs_attr_cache_insert(thread->vfs->vfs_attr_cache,
+        chimera_vfs_attr_cache_insert(thread, thread->vfs->vfs_attr_cache,
                                       request->fh_hash,
                                       request->fh,
                                       request->fh_len,

--- a/src/vfs/vfs_proc_symlink_at.c
+++ b/src/vfs/vfs_proc_symlink_at.c
@@ -23,7 +23,7 @@ chimera_vfs_symlink_at_complete(struct chimera_vfs_request *request)
 
 
     if (request->status == CHIMERA_VFS_OK) {
-        chimera_vfs_name_cache_insert(name_cache,
+        chimera_vfs_name_cache_insert(thread, name_cache,
                                       request->fh_hash,
                                       request->fh,
                                       request->fh_len,
@@ -33,13 +33,13 @@ chimera_vfs_symlink_at_complete(struct chimera_vfs_request *request)
                                       request->symlink_at.r_attr.va_fh,
                                       request->symlink_at.r_attr.va_fh_len);
 
-        chimera_vfs_attr_cache_insert(attr_cache,
+        chimera_vfs_attr_cache_insert(thread, attr_cache,
                                       request->fh_hash,
                                       request->fh,
                                       request->fh_len,
                                       &request->symlink_at.r_dir_post_attr);
 
-        chimera_vfs_attr_cache_insert(attr_cache,
+        chimera_vfs_attr_cache_insert(thread, attr_cache,
                                       chimera_vfs_hash(request->symlink_at.r_attr.va_fh, request->symlink_at.r_attr.
                                                        va_fh_len),
                                       request->symlink_at.r_attr.va_fh,

--- a/src/vfs/vfs_proc_write.c
+++ b/src/vfs/vfs_proc_write.c
@@ -22,7 +22,7 @@ chimera_vfs_write_complete(struct chimera_vfs_request *request)
     chimera_vfs_io_lease_release(request);
 
     if (request->status == CHIMERA_VFS_OK) {
-        chimera_vfs_attr_cache_insert(request->thread->vfs->vfs_attr_cache,
+        chimera_vfs_attr_cache_insert(request->thread, request->thread->vfs->vfs_attr_cache,
                                       request->write.handle->fh_hash,
                                       request->write.handle->fh,
                                       request->write.handle->fh_len,

--- a/src/vfs/vfs_rcu_pool.h
+++ b/src/vfs/vfs_rcu_pool.h
@@ -1,0 +1,166 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#pragma once
+
+/*
+ * Shared recycle pool for the fungible, hot-path RCU caches (attribute, name
+ * and reverse-path-lookup).  Each such cache retires a displaced entry with
+ * call_rcu; after a grace period the entry is recycled rather than freed.
+ *
+ * The pool decouples the producer (call_rcu reclaim workers, possibly one per
+ * CPU) from the consumers (per-request inserts on the VFS worker threads):
+ *
+ *   - A single per-pool depot is a liburcu wait-free stack.  Retire pushes onto
+ *     it with cds_wfs_push (wait-free, multi-producer -- no lock, so multiple
+ *     per-CPU reclaim workers never contend).
+ *   - Each VFS worker thread keeps a thread-local magazine (a plain LIFO with
+ *     no atomics).  Alloc pops from the magazine; on a miss it refills a whole
+ *     batch from the depot in one shot (cds_wfs_pop_all_blocking takes the
+ *     stack's internal mutex once, amortized over the batch), capping the
+ *     magazine so one thread cannot hoard the pool.  On a cold pool it falls
+ *     back to calloc (a one-time cost; entries are recycled forever after).
+ *
+ * Entries are never returned to the heap during runtime -- they cycle through
+ * depot -> magazine -> in-use -> (grace period) -> depot.
+ */
+
+#include <stdlib.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <urcu.h>
+#include <urcu/urcu-memb.h>
+#include <urcu/wfstack.h>
+
+#include "vfs/vfs.h" /* enum chimera_rcu_pool_id, struct chimera_rcu_magazine */
+
+struct chimera_rcu_pool;
+
+/*
+ * Embedded as the FIRST member of every recyclable cache entry, so a
+ * struct chimera_rcu_node * aliases the entry pointer.  `rcu` and `pool` are
+ * live during the retire window; `wfs`/`mag_next` alias because an entry is on
+ * the depot or in a magazine, never both.
+ */
+struct chimera_rcu_node {
+    struct rcu_head          rcu;   /* deferred-free grace-period linkage */
+    struct chimera_rcu_pool *pool;  /* depot this entry returns to */
+    union {
+        struct cds_wfs_node      wfs;      /* linked on the pool depot */
+        struct chimera_rcu_node *mag_next; /* linked on a thread magazine */
+    };
+};
+
+struct chimera_rcu_pool {
+    struct cds_wfs_stack depot;
+    size_t               entry_size;
+    int                  id;
+};
+
+static inline void
+chimera_rcu_pool_init(
+    struct chimera_rcu_pool *pool,
+    int                      id,
+    size_t                   entry_size)
+{
+    cds_wfs_init(&pool->depot);
+    pool->id         = id;
+    pool->entry_size = entry_size;
+} /* chimera_rcu_pool_init */
+
+/*
+ * call_rcu callback: a retired entry has cleared its grace period; return it to
+ * its pool depot.  Wait-free; safe from any (per-CPU) reclaim worker.
+ */
+static inline void
+chimera_rcu_pool_retire(struct rcu_head *head)
+{
+    struct chimera_rcu_node *node = caa_container_of(head, struct chimera_rcu_node, rcu);
+
+    cds_wfs_node_init(&node->wfs);
+    cds_wfs_push(&node->pool->depot, &node->wfs);
+} /* chimera_rcu_pool_retire */
+
+/*
+ * Obtain a recycled (or freshly calloc'd) entry for `pool`, using the calling
+ * thread's magazine.  Returns a node whose entry fields the caller overwrites.
+ */
+static inline struct chimera_rcu_node *
+chimera_rcu_pool_alloc(
+    struct chimera_rcu_magazine *mag,
+    struct chimera_rcu_pool     *pool)
+{
+    struct chimera_rcu_node *node;
+    struct cds_wfs_head     *batch;
+    struct cds_wfs_node     *wn, *wn_safe;
+
+    if (!mag->head) {
+        /* Refill a batch from the depot under one internal-mutex acquisition;
+         * keep up to the cap, push any surplus back. */
+        batch = cds_wfs_pop_all_blocking(&pool->depot);
+        if (batch) {
+            cds_wfs_for_each_blocking_safe(batch, wn, wn_safe)
+            {
+                node = caa_container_of(wn, struct chimera_rcu_node, wfs);
+                if (mag->count < CHIMERA_RCU_MAGAZINE_CAP) {
+                    node->mag_next = mag->head;
+                    mag->head      = node;
+                    mag->count++;
+                } else {
+                    cds_wfs_node_init(&node->wfs);
+                    cds_wfs_push(&pool->depot, &node->wfs);
+                }
+            }
+        }
+    }
+
+    if (mag->head) {
+        node      = mag->head;
+        mag->head = node->mag_next;
+        mag->count--;
+    } else {
+        node = calloc(1, pool->entry_size);
+    }
+
+    node->pool = pool;
+    return node;
+} /* chimera_rcu_pool_alloc */
+
+/* Push every entry in a thread magazine back to its depot (at thread destroy). */
+static inline void
+chimera_rcu_magazine_drain(struct chimera_rcu_magazine *mag)
+{
+    struct chimera_rcu_node *node;
+
+    while (mag->head) {
+        node      = mag->head;
+        mag->head = node->mag_next;
+        cds_wfs_node_init(&node->wfs);
+        cds_wfs_push(&node->pool->depot, &node->wfs);
+    }
+    mag->count = 0;
+} /* chimera_rcu_magazine_drain */
+
+/*
+ * Free every entry on the depot and destroy it.  Call only after rcu_barrier()
+ * (so all pending retires have landed) and after all thread magazines have been
+ * drained.  In-use entries still held in cache slots are freed by the cache.
+ */
+static inline void
+chimera_rcu_pool_destroy(struct chimera_rcu_pool *pool)
+{
+    struct cds_wfs_head     *batch;
+    struct cds_wfs_node     *wn, *wn_safe;
+    struct chimera_rcu_node *node;
+
+    batch = cds_wfs_pop_all_blocking(&pool->depot);
+    if (batch) {
+        cds_wfs_for_each_blocking_safe(batch, wn, wn_safe)
+        {
+            node = caa_container_of(wn, struct chimera_rcu_node, wfs);
+            free(node);
+        }
+    }
+    cds_wfs_destroy(&pool->depot);
+} /* chimera_rcu_pool_destroy */

--- a/src/vfs/vfs_rpl_cache.h
+++ b/src/vfs/vfs_rpl_cache.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "vfs/vfs.h"
+#include "vfs/vfs_rcu_pool.h"
 #include "vfs_internal.h"
 #include "common/misc.h"
 #include <urcu.h>
@@ -22,29 +23,23 @@
  */
 
 struct chimera_vfs_rpl_cache_entry {
-    uint64_t        fwd_key;        /* hash(child_fh) */
-    uint64_t        rev_key;        /* hash(parent_fh) ^ hash(name) */
-    uint16_t        child_fh_len;
-    uint16_t        parent_fh_len;
-    uint16_t        name_len;
-    int64_t         score;
-    uint64_t        expiration; /* stopwatch ticks */
-    struct rcu_head rcu;
-    union {
-        struct chimera_vfs_rpl_cache_entry *next;  /* when on free list */
-        struct chimera_vfs_rpl_cache_shard *shard; /* when active */
-    };
-    uint8_t         child_fh[CHIMERA_VFS_FH_SIZE];
-    uint8_t         parent_fh[CHIMERA_VFS_FH_SIZE];
-    char            name[CHIMERA_VFS_NAME_MAX];
+    struct chimera_rcu_node rnode; /* must be first: aliases the entry pointer */
+    uint64_t                fwd_key; /* hash(child_fh) */
+    uint64_t                rev_key; /* hash(parent_fh) ^ hash(name) */
+    uint16_t                child_fh_len;
+    uint16_t                parent_fh_len;
+    uint16_t                name_len;
+    int64_t                 score;
+    uint64_t                expiration; /* stopwatch ticks */
+    uint8_t                 child_fh[CHIMERA_VFS_FH_SIZE];
+    uint8_t                 parent_fh[CHIMERA_VFS_FH_SIZE];
+    char                    name[CHIMERA_VFS_NAME_MAX];
 };
 
 struct chimera_vfs_rpl_cache_shard {
     struct chimera_vfs_rpl_cache_entry **fwd_entries; /* forward index slots */
     struct chimera_vfs_rpl_cache_entry **rev_entries; /* reverse index slots */
-    struct chimera_vfs_rpl_cache_entry  *free_entries;
     pthread_mutex_t                      entry_lock;
-    pthread_mutex_t                      free_lock;
 };
 
 struct chimera_vfs_rpl_cache {
@@ -58,6 +53,7 @@ struct chimera_vfs_rpl_cache {
     uint32_t                            num_shards_mask;
     uint32_t                            num_entries_mask;
     uint64_t                            ttl;
+    struct chimera_rcu_pool             pool;
     struct chimera_vfs_rpl_cache_shard *shards;
 };
 
@@ -70,8 +66,7 @@ chimera_vfs_rpl_cache_create(
 {
     struct chimera_vfs_rpl_cache       *cache;
     struct chimera_vfs_rpl_cache_shard *shard;
-    struct chimera_vfs_rpl_cache_entry *entry;
-    int                                 i, j;
+    int                                 i;
 
     cache = calloc(1, sizeof(*cache));
 
@@ -79,9 +74,13 @@ chimera_vfs_rpl_cache_create(
     cache->num_slots_bits   = num_slots_bits;
     cache->num_entries_bits = entries_per_slot_bits;
     cache->ttl              = ttl;
-    cache->num_shards       = 1 << num_shards_bits;
-    cache->num_slots        = 1 << num_slots_bits;
-    cache->num_entries      = 1 << entries_per_slot_bits;
+
+    chimera_rcu_pool_init(&cache->pool, CHIMERA_RCU_POOL_RPL,
+                          sizeof(struct chimera_vfs_rpl_cache_entry));
+
+    cache->num_shards  = 1 << num_shards_bits;
+    cache->num_slots   = 1 << num_slots_bits;
+    cache->num_entries = 1 << entries_per_slot_bits;
 
     cache->num_slots_mask   = cache->num_slots - 1;
     cache->num_shards_mask  = cache->num_shards - 1;
@@ -98,13 +97,7 @@ chimera_vfs_rpl_cache_create(
         shard->rev_entries = calloc(cache->num_slots * cache->num_entries,
                                     sizeof(struct chimera_vfs_rpl_cache_entry *));
 
-        for (j = 0; j < cache->num_slots * cache->num_entries; j++) {
-            entry = calloc(1, sizeof(*entry));
-            LL_PREPEND(shard->free_entries, entry);
-        }
-
         pthread_mutex_init(&shard->entry_lock, NULL);
-        pthread_mutex_init(&shard->free_lock, NULL);
     }
 
     return cache;
@@ -114,7 +107,6 @@ static inline void
 chimera_vfs_rpl_cache_destroy(struct chimera_vfs_rpl_cache *cache)
 {
     struct chimera_vfs_rpl_cache_shard *shard;
-    struct chimera_vfs_rpl_cache_entry *entry;
     int                                 i, j;
 
     if (!cache) {
@@ -135,31 +127,14 @@ chimera_vfs_rpl_cache_destroy(struct chimera_vfs_rpl_cache *cache)
         free(shard->fwd_entries);
         free(shard->rev_entries);
 
-        while (shard->free_entries) {
-            entry               = shard->free_entries;
-            shard->free_entries = entry->next;
-            free(entry);
-        }
-
         pthread_mutex_destroy(&shard->entry_lock);
-        pthread_mutex_destroy(&shard->free_lock);
     }
+
+    chimera_rcu_pool_destroy(&cache->pool);
 
     free(cache->shards);
     free(cache);
 } /* chimera_vfs_rpl_cache_destroy */
-
-static inline void
-chimera_vfs_rpl_cache_free_entry_rcu(struct rcu_head *head)
-{
-    struct chimera_vfs_rpl_cache_entry *entry =
-        container_of(head, struct chimera_vfs_rpl_cache_entry, rcu);
-    struct chimera_vfs_rpl_cache_shard *shard = entry->shard;
-
-    pthread_mutex_lock(&shard->free_lock);
-    LL_PREPEND(shard->free_entries, entry);
-    pthread_mutex_unlock(&shard->free_lock);
-} /* chimera_vfs_rpl_cache_free_entry_rcu */
 
 /*
  * Forward lookup: child_fh -> (parent_fh, name)
@@ -292,6 +267,7 @@ chimera_vfs_rpl_cache_rev_insert(
  */
 static inline void
 chimera_vfs_rpl_cache_insert(
+    struct chimera_vfs_thread    *thread,
     struct chimera_vfs_rpl_cache *cache,
     uint64_t                      child_fh_hash,
     const void                   *child_fh,
@@ -312,24 +288,15 @@ chimera_vfs_rpl_cache_insert(
 
     shard = &cache->shards[fwd_key & cache->num_shards_mask];
 
-    /* Allocate entry from free list */
-    pthread_mutex_lock(&shard->free_lock);
-    entry = shard->free_entries;
-    if (entry) {
-        LL_DELETE(shard->free_entries, entry);
-    }
-    pthread_mutex_unlock(&shard->free_lock);
-
-    if (!entry) {
-        entry = calloc(1, sizeof(*entry));
-    }
+    /* Recycle an entry from the pool (thread magazine -> depot -> calloc) */
+    entry = (struct chimera_vfs_rpl_cache_entry *)
+        chimera_rcu_pool_alloc(&thread->rcu_magazines[CHIMERA_RCU_POOL_RPL], &cache->pool);
 
     entry->fwd_key       = fwd_key;
     entry->rev_key       = rev_key;
     entry->child_fh_len  = child_fh_len;
     entry->parent_fh_len = parent_fh_len;
     entry->name_len      = name_len;
-    entry->shard         = shard;
     entry->score         = 0;
 
     entry->expiration = now + chimera_vfs_ns_to_ticks((uint64_t) cache->ttl * 1000000000ULL);
@@ -400,7 +367,7 @@ chimera_vfs_rpl_cache_insert(
     urcu_memb_read_unlock();
 
     if (best_entry) {
-        call_rcu(&best_entry->rcu, chimera_vfs_rpl_cache_free_entry_rcu);
+        call_rcu(&best_entry->rnode.rcu, chimera_rcu_pool_retire);
     }
 } /* chimera_vfs_rpl_cache_insert */
 
@@ -485,6 +452,6 @@ chimera_vfs_rpl_cache_invalidate(
     urcu_memb_read_unlock();
 
     if (removed_entry) {
-        call_rcu(&removed_entry->rcu, chimera_vfs_rpl_cache_free_entry_rcu);
+        call_rcu(&removed_entry->rnode.rcu, chimera_rcu_pool_retire);
     }
 } /* chimera_vfs_rpl_cache_invalidate */


### PR DESCRIPTION
## Problem

A high-rate NFS read benchmark grows server RSS steadily (~1 GB/s) in **release** builds. Diagnosis: it's **not a leak** (LSan-clean, reachable, drained at clean exit) and **not glibc arena fragmentation** (same growth under ASan's allocator). It's **RCU reclaim falling behind**.

The attribute cache is updated on every NFS3 READ; each update retires an entry via `call_rcu`. Two bottlenecks let the producer outrun the reclaimer, so the entry pool ratchets up without bound:

1. **One `call_rcu` worker.** liburcu lazily creates a single default worker for the whole process — 80 read threads feed one consumer.
2. **Per-shard free-list lock contention.** The fungible caches (attr/name/rpl) recycle entries through a per-shard free list guarded by a mutex that both inserts (pop) and the `call_rcu` callback (push) contend on. When the free list drains, inserts `calloc` new entries that are never returned to the heap at runtime.

## Change

A shared recycle pool (`src/vfs/vfs_rcu_pool.h`) for the three fungible caches:

- **Depot = liburcu wait-free stack** (`cds_wfs_stack`). The retire callback `cds_wfs_push`es onto it — wait-free, multi-producer, **no lock**, so multiple per-CPU reclaim workers never contend.
- **Per-thread magazine** in front. Alloc pops from the thread-local magazine; on a miss it refills a batch from the depot in one shot (`cds_wfs_pop_all_blocking`, one internal-mutex acquisition amortized over the batch), caps the magazine, and pushes any surplus back so one thread can't hoard the pool. Cold-pool fallback is `calloc` (one-time; entries recycle forever after).

The attr/name/rpl entries embed a `chimera_rcu_node` first member, drop their per-shard `free_entries`/`free_lock`, and their `*_insert` takes the calling `chimera_vfs_thread`. Thread teardown drains magazines back to the depots; cache destroy frees the depot after `rcu_barrier()`.

Separately, `create_all_cpu_call_rcu_data(0)` at VFS init spawns one `call_rcu` worker per CPU (`call_rcu` routes by CPU); `free_all_cpu_call_rcu_data()` at shutdown after the caches drain. This also helps the direct-free RCU caches (user/mount/s3 cred).

## Out of scope (follow-up)
Eliminating the per-read attr-cache **churn** itself (in-place same-key/only-atime update so a re-read retires nothing). This PR scales reclaim and removes the lock; the in-place fix removes the garbage at the source.

## Validation
- Full Release and Debug (ASan + `EVPL_IOVEC_TRACE`) builds clean.
- `vfs/notify_test` 65/65 (exercises the rpl pool: alloc/retire/depot/destroy) under ASan/LSan, no leaks.
- 239 memfs pynfs tests (access/lookup/getattr/read/write/create/rename) pass under ASan/LSan — attr+name pools on the live path, leak-checked at each server shutdown.
- The memory-growth fix itself is validated by the author on the node-3 benchmark (release RSS should plateau; cleanup spread across per-CPU `call_rcu` threads).