### PR TITLE
vfs: shard the RCU recycle depot per-CPU and bound the magazine refill

### DIFF
--- a/src/vfs/vfs_rcu_pool.h
+++ b/src/vfs/vfs_rcu_pool.h
@@ -9,18 +9,21 @@
  * and reverse-path-lookup).  Each such cache retires a displaced entry with
  * call_rcu; after a grace period the entry is recycled rather than freed.
  *
- * The pool decouples the producer (call_rcu reclaim workers, possibly one per
- * CPU) from the consumers (per-request inserts on the VFS worker threads):
+ * The pool decouples the producer (call_rcu reclaim workers, one per CPU) from
+ * the consumers (per-request inserts on the VFS worker threads):
  *
- *   - A single per-pool depot is a liburcu wait-free stack.  Retire pushes onto
- *     it with cds_wfs_push (wait-free, multi-producer -- no lock, so multiple
- *     per-CPU reclaim workers never contend).
- *   - Each VFS worker thread keeps a thread-local magazine (a plain LIFO with
- *     no atomics).  Alloc pops from the magazine; on a miss it refills a whole
- *     batch from the depot in one shot (cds_wfs_pop_all_blocking takes the
- *     stack's internal mutex once, amortized over the batch), capping the
- *     magazine so one thread cannot hoard the pool.  On a cold pool it falls
- *     back to calloc (a one-time cost; entries are recycled forever after).
+ *   - The depot is striped per CPU: an array of liburcu wait-free stacks, one
+ *     per CPU, each on its own cache line.  Because the per-CPU call_rcu worker
+ *     reclaims an entry on the same CPU the read retired it on, and the next
+ *     read on that CPU re-allocates it, an entry's whole recycle lifecycle
+ *     stays on one core's stack -- near-zero cross-core traffic.  Retire pushes
+ *     with cds_wfs_push (wait-free, no lock).
+ *   - Each VFS worker thread keeps a thread-local magazine (a plain LIFO, no
+ *     atomics).  Alloc pops from the magazine; on a miss it refills up to
+ *     CHIMERA_RCU_MAGAZINE_CAP entries from this CPU's depot stripe under a
+ *     single pop-lock acquisition (bounded work -- it never walks the whole
+ *     stack).  On a cold stripe it falls back to calloc (one-time; entries are
+ *     recycled forever after).
  *
  * Entries are never returned to the heap during runtime -- they cycle through
  * depot -> magazine -> in-use -> (grace period) -> depot.
@@ -29,11 +32,17 @@
 #include <stdlib.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <string.h>
+#include <unistd.h>
 #include <urcu.h>
 #include <urcu/urcu-memb.h>
 #include <urcu/wfstack.h>
 
 #include "vfs/vfs.h" /* enum chimera_rcu_pool_id, struct chimera_rcu_magazine */
+
+/* sched_getcpu() without forcing _GNU_SOURCE on every includer of this header. */
+extern int sched_getcpu(
+    void);
 
 struct chimera_rcu_pool;
 
@@ -41,22 +50,54 @@ struct chimera_rcu_pool;
  * Embedded as the FIRST member of every recyclable cache entry, so a
  * struct chimera_rcu_node * aliases the entry pointer.  `rcu` and `pool` are
  * live during the retire window; `wfs`/`mag_next` alias because an entry is on
- * the depot or in a magazine, never both.
+ * a depot stripe or in a magazine, never both.
  */
 struct chimera_rcu_node {
     struct rcu_head          rcu;   /* deferred-free grace-period linkage */
-    struct chimera_rcu_pool *pool;  /* depot this entry returns to */
+    struct chimera_rcu_pool *pool;  /* pool this entry returns to */
     union {
-        struct cds_wfs_node      wfs;      /* linked on the pool depot */
+        struct cds_wfs_node      wfs;      /* linked on a depot stripe */
         struct chimera_rcu_node *mag_next; /* linked on a thread magazine */
     };
 };
 
+/* One depot stripe per CPU, each on its own cache line to avoid false sharing
+ * of the adjacent pop locks. */
+struct chimera_rcu_depot {
+    struct cds_wfs_stack stack;
+} __attribute__((aligned(64)));
+
 struct chimera_rcu_pool {
-    struct cds_wfs_stack depot;
-    size_t               entry_size;
-    int                  id;
+    struct chimera_rcu_depot *depots; /* [n_stripes], one per CPU */
+    uint32_t                  stripe_mask;
+    uint32_t                  n_stripes;
+    size_t                    entry_size;
+    int                       id;
 };
+
+static inline uint32_t
+chimera_rcu_round_pow2(uint32_t v)
+{
+    if (v < 1) {
+        v = 1;
+    }
+    v--;
+    v |= v >> 1;
+    v |= v >> 2;
+    v |= v >> 4;
+    v |= v >> 8;
+    v |= v >> 16;
+    return v + 1;
+} /* chimera_rcu_round_pow2 */
+
+/* Depot stripe for the calling CPU. */
+static inline uint32_t
+chimera_rcu_stripe(const struct chimera_rcu_pool *pool)
+{
+    int cpu = sched_getcpu();
+
+    return (cpu < 0 ? 0u : (uint32_t) cpu) & pool->stripe_mask;
+} /* chimera_rcu_stripe */
 
 static inline void
 chimera_rcu_pool_init(
@@ -64,14 +105,27 @@ chimera_rcu_pool_init(
     int                      id,
     size_t                   entry_size)
 {
-    cds_wfs_init(&pool->depot);
-    pool->id         = id;
-    pool->entry_size = entry_size;
+    long     ncpu = sysconf(_SC_NPROCESSORS_ONLN);
+    uint32_t n    = chimera_rcu_round_pow2(ncpu > 0 ? (uint32_t) ncpu : 1);
+    uint32_t i;
+    size_t   bytes = (size_t) n * sizeof(struct chimera_rcu_depot);
+
+    pool->n_stripes   = n;
+    pool->stripe_mask = n - 1;
+    pool->entry_size  = entry_size;
+    pool->id          = id;
+
+    pool->depots = aligned_alloc(64, bytes);
+    memset(pool->depots, 0, bytes);
+
+    for (i = 0; i < n; i++) {
+        cds_wfs_init(&pool->depots[i].stack);
+    }
 } /* chimera_rcu_pool_init */
 
 /*
  * call_rcu callback: a retired entry has cleared its grace period; return it to
- * its pool depot.  Wait-free; safe from any (per-CPU) reclaim worker.
+ * this CPU's depot stripe.  Wait-free; safe from any per-CPU reclaim worker.
  */
 static inline void
 chimera_rcu_pool_retire(struct rcu_head *head)
@@ -79,7 +133,7 @@ chimera_rcu_pool_retire(struct rcu_head *head)
     struct chimera_rcu_node *node = caa_container_of(head, struct chimera_rcu_node, rcu);
 
     cds_wfs_node_init(&node->wfs);
-    cds_wfs_push(&node->pool->depot, &node->wfs);
+    cds_wfs_push(&node->pool->depots[chimera_rcu_stripe(node->pool)].stack, &node->wfs);
 } /* chimera_rcu_pool_retire */
 
 /*
@@ -92,27 +146,25 @@ chimera_rcu_pool_alloc(
     struct chimera_rcu_pool     *pool)
 {
     struct chimera_rcu_node *node;
-    struct cds_wfs_head     *batch;
-    struct cds_wfs_node     *wn, *wn_safe;
 
     if (!mag->head) {
-        /* Refill a batch from the depot under one internal-mutex acquisition;
-         * keep up to the cap, push any surplus back. */
-        batch = cds_wfs_pop_all_blocking(&pool->depot);
-        if (batch) {
-            cds_wfs_for_each_blocking_safe(batch, wn, wn_safe)
-            {
-                node = caa_container_of(wn, struct chimera_rcu_node, wfs);
-                if (mag->count < CHIMERA_RCU_MAGAZINE_CAP) {
-                    node->mag_next = mag->head;
-                    mag->head      = node;
-                    mag->count++;
-                } else {
-                    cds_wfs_node_init(&node->wfs);
-                    cds_wfs_push(&pool->depot, &node->wfs);
-                }
+        /* Refill up to the cap from this CPU's stripe under one pop-lock
+        * acquisition.  Bounded work -- we never walk the whole stack. */
+        struct cds_wfs_stack *depot = &pool->depots[chimera_rcu_stripe(pool)].stack;
+        struct cds_wfs_node  *wn;
+
+        cds_wfs_pop_lock(depot);
+        while (mag->count < CHIMERA_RCU_MAGAZINE_CAP) {
+            wn = __cds_wfs_pop_blocking(depot);
+            if (!wn) {
+                break;
             }
+            node           = caa_container_of(wn, struct chimera_rcu_node, wfs);
+            node->mag_next = mag->head;
+            mag->head      = node;
+            mag->count++;
         }
+        cds_wfs_pop_unlock(depot);
     }
 
     if (mag->head) {
@@ -127,7 +179,7 @@ chimera_rcu_pool_alloc(
     return node;
 } /* chimera_rcu_pool_alloc */
 
-/* Push every entry in a thread magazine back to its depot (at thread destroy). */
+/* Push every entry in a thread magazine back to a depot (at thread destroy). */
 static inline void
 chimera_rcu_magazine_drain(struct chimera_rcu_magazine *mag)
 {
@@ -137,7 +189,7 @@ chimera_rcu_magazine_drain(struct chimera_rcu_magazine *mag)
         node      = mag->head;
         mag->head = node->mag_next;
         cds_wfs_node_init(&node->wfs);
-        cds_wfs_push(&node->pool->depot, &node->wfs);
+        cds_wfs_push(&node->pool->depots[chimera_rcu_stripe(node->pool)].stack, &node->wfs);
     }
     mag->count = 0;
 } /* chimera_rcu_magazine_drain */
@@ -153,14 +205,19 @@ chimera_rcu_pool_destroy(struct chimera_rcu_pool *pool)
     struct cds_wfs_head     *batch;
     struct cds_wfs_node     *wn, *wn_safe;
     struct chimera_rcu_node *node;
+    uint32_t                 i;
 
-    batch = cds_wfs_pop_all_blocking(&pool->depot);
-    if (batch) {
-        cds_wfs_for_each_blocking_safe(batch, wn, wn_safe)
-        {
-            node = caa_container_of(wn, struct chimera_rcu_node, wfs);
-            free(node);
+    for (i = 0; i < pool->n_stripes; i++) {
+        batch = cds_wfs_pop_all_blocking(&pool->depots[i].stack);
+        if (batch) {
+            cds_wfs_for_each_blocking_safe(batch, wn, wn_safe)
+            {
+                node = caa_container_of(wn, struct chimera_rcu_node, wfs);
+                free(node);
+            }
         }
+        cds_wfs_destroy(&pool->depots[i].stack);
     }
-    cds_wfs_destroy(&pool->depot);
+
+    free(pool->depots);
 } /* chimera_rcu_pool_destroy */


### PR DESCRIPTION
## Problem

PR #598 fixed the NFS-read memory growth but **regressed read throughput badly**. A profile under load showed **~92% self time in `chimera_vfs_read_complete`** (the attr-cache insert is `static inline`, so `chimera_rcu_pool_alloc` is inlined there), with `pthread_mutex_lock` at **<0.5%** and syscalls ~0.5% — so it's pure CPU, not lock or `membarrier` contention.

The culprit was the magazine refill:

```c
batch = cds_wfs_pop_all_blocking(&pool->depot);   // detaches the ENTIRE depot
cds_wfs_for_each_blocking_safe(batch, ...) {
    if (mag->count < CAP) keep;                    // keep 64
    else cds_wfs_push(... surplus ...);            // push the rest back, a CAS each
}
```

`pop_all` grabs the **whole depot**, which holds the cache's entire free pool — thousands of entries for a real working set. So every refill walked and re-CAS'd thousands of nodes, bouncing the depot head cache line across all 80 read threads: **O(free-pool) work per refill, inlined onto the read hot path.** The unit/pynfs tests never built a large enough depot to expose it.

## Fix

1. **Bounded refill.** Pop at most `CHIMERA_RCU_MAGAZINE_CAP` entries under a single `cds_wfs_pop_lock()` / `__cds_wfs_pop_blocking()` loop — no `pop_all`, no push-back. Surplus stays on the stack for the next consumer. O(CAP) per refill, one mutex acquisition per ~CAP allocs.
2. **Per-CPU striping.** The depot is now an array of wait-free stacks, one per CPU (rounded up to a power of two), each cache-line aligned. Retire and refill index by `sched_getcpu()`. Combined with the per-CPU `call_rcu` workers, an entry retired by a read on CPU N is reclaimed on N's worker and re-allocated by a thread on N — its whole recycle lifecycle stays on one core's stack, near-zero cross-core traffic on this extremely hot path.

Public pool API unchanged; only `vfs_rcu_pool.h` internals change. Memory stays bounded exactly as #598 made it.

## Validation
- Release + Debug (ASan + `EVPL_IOVEC_TRACE`) build clean.
- `vfs/notify_test` 65/65 and 239 memfs pynfs tests (access/lookup/getattr/read/write/create/rename) pass under ASan/LSan, no leaks.
- Throughput re-validated by the author on the node-3 benchmark.