### PR TITLE
fio: size the evpl buffer to the largest job's I/O pool

### DIFF
--- a/src/fio/fio.c
+++ b/src/fio/fio.c
@@ -57,10 +57,11 @@ struct chimera_fio_thread {
 };
 
 struct chimera_options {
-    void *pad;
-    char *config;
-    char *logfile;
-    int   debug;
+    void              *pad;
+    char              *config;
+    char              *logfile;
+    int                debug;
+    unsigned long long buffer_size;
 };
 
 static struct fio_option options[] = {
@@ -89,6 +90,16 @@ static struct fio_option options[] = {
         .type     = FIO_OPT_BOOL,
         .off1     = offsetof(struct chimera_options, debug),
         .help     = "Enable debug-level chimera logging (same as the daemon's -d)",
+        .def      = "0",
+        .category = FIO_OPT_C_ENGINE,
+        .group    = FIO_OPT_G_INVALID,
+    },
+    {
+        .name     = "chimera_buffer_size",
+        .lname    = "Chimera evpl buffer size",
+        .type     = FIO_OPT_STR_VAL,
+        .off1     = offsetof(struct chimera_options, buffer_size),
+        .help     = "Override the libevpl buffer size in bytes; 0 (default) auto-sizes to the largest job's iodepth*bs",
         .def      = "0",
         .category = FIO_OPT_C_ENGINE,
         .group    = FIO_OPT_G_INVALID,
@@ -199,8 +210,20 @@ fio_chimera_iomem_alloc(
     size_t              total_mem)
 {
     struct chimera_fio_thread *chimera_thread = td->io_ops_data;
+    int                        niov;
 
-    evpl_iovec_alloc(chimera_thread->evpl, total_mem, 4096, 1, 0, &chimera_thread->iov);
+    /* The whole I/O pool must fit in one contiguous registered evpl buffer.
+     * buffer_size was sized for the largest job at init, so this should always
+     * succeed; fail loudly rather than hand fio a garbage orig_buffer if it
+     * ever doesn't (e.g. a pool larger than the configured buffer). */
+    niov = evpl_iovec_alloc(chimera_thread->evpl, total_mem, 4096, 1, 0, &chimera_thread->iov);
+
+    if (niov != 1) {
+        chimera_fio_fatal(
+            "I/O buffer pool of %zu bytes exceeds the libevpl buffer size; "
+            "raise chimera_buffer_size", total_mem);
+        return 1;
+    }
 
     td->orig_buffer = evpl_iovec_data(&chimera_thread->iov);
 
@@ -362,8 +385,49 @@ fio_chimera_init(struct thread_data *td)
          * loaded config.  `config` may be NULL when no config file was given. */
         {
             struct evpl_global_config *evpl_config = evpl_global_config_init();
+            uint64_t                   buffer_size = 2 * 1024 * 1024; /* evpl default */
+            uint64_t                   page        = (uint64_t) sysconf(_SC_PAGESIZE);
+            uint64_t                   slab_size;
 
             chimera_apply_common_config(config, evpl_config);
+
+            /* The engine backs each fio thread's entire I/O buffer pool
+             * (iodepth * bs) with a SINGLE contiguous, RDMA-registered evpl
+             * iovec, so the evpl buffer must be at least as large as the
+             * biggest job's pool.  evpl_init() bakes the buffer size in and
+             * runs once for the whole process, so size it here for the largest
+             * job across all jobs (matches fio's own sizing in backend.c). */
+            for_each_td(t)
+            {
+                struct chimera_options *to   = t->eo;
+                uint64_t                pool = (uint64_t) t->o.iodepth * td_max_bs(t);
+
+                if (t->o.odirect || t->o.mem_align) {
+                    pool += page + t->o.mem_align;
+                }
+                if (pool > buffer_size) {
+                    buffer_size = pool;
+                }
+                if (to && to->buffer_size > buffer_size) {
+                    buffer_size = to->buffer_size;
+                }
+            }
+            end_for_each();
+
+            /* Round up to a 2 MiB multiple. */
+            buffer_size = (buffer_size + (2 * 1024 * 1024 - 1)) & ~((uint64_t) (2 * 1024 * 1024) - 1);
+
+            evpl_global_config_set_buffer_size(evpl_config, buffer_size);
+
+            /* Keep several buffers per slab (buffers_per_slab = slab / buffer). */
+            slab_size = 4 * buffer_size;
+            if (slab_size > (uint64_t) 1024 * 1024 * 1024) {
+                evpl_global_config_set_slab_size(evpl_config, slab_size);
+            }
+
+            chimera_fio_info("evpl buffer size %lu bytes (largest fio I/O pool)",
+                             (unsigned long) buffer_size);
+
             evpl_init(evpl_config);
         }
 


### PR DESCRIPTION
## Problem

The fio engine backs each thread's **entire** I/O buffer pool (`iodepth × bs`) with a **single** contiguous, RDMA-registered evpl iovec:

```c
evpl_iovec_alloc(evpl, total_mem, 4096, /*max_iovecs*/ 1, 0, &iov);
td->orig_buffer = evpl_iovec_data(&iov);
```

An evpl iovec can't span more than one buffer, and `buffer_size` defaults to **2 MB**. So when `iodepth × bs > 2 MB`, the alloc returns **-1**, the engine ignored the return, and `orig_buffer` was left pointing at garbage — the fio thread **silently wedged in setup** (`f=0`, no I/O ever issued, server idle). Reproduced with `bs=512k iodepth=32` (16 MB pool); `bs≤34k × 32` (≤1 MB) worked.

This is required to be one contiguous registered region: fio hands the engine one contiguous `orig_buffer` and the write path `evpl_iovec_clone_segment`s a slice of that single registered iovec to RDMA-send (zero-copy). libevpl has no API to register external memory and `buffer_size` is global-only, so the only way to back a >2 MB contiguous registered region is to make evpl's buffer big enough.

## Change (`src/fio/fio.c`)

- **Auto-size before `evpl_init`** (which runs once and bakes `buffer_size` in): scan all jobs with `for_each_td` and set `buffer_size` to the largest job's `iodepth × td_max_bs` plus fio's `odirect`/`mem_align` slack (matching fio's own sizing in `backend.c:1373`), rounded up to 2 MiB. Bump `slab_size` to keep ≥4 buffers per slab.
- **`chimera_buffer_size` option** — explicit override (bytes; 0 = auto).
- **Hard check in `iomem_alloc`** — if the pool still doesn't fit, fail loudly with a clear message instead of handing fio a garbage buffer.

Read and write data paths are unchanged and stay zero-copy — the write still clones one registered region, now backed by a big-enough buffer. Memory cost is bounded: only jobs with large `iodepth × bs` raise the buffer size; small/read jobs stay at 2 MB.

## Validation
Plugin builds and links clean. Can't be exercised in the sandbox (needs a live RDMA server); functional validation is the author's node-3 run — the `bs=512k iodepth=32` layout job that previously wedged at `f=0` should now issue writes (`NFSPROC3_WRITE` / `block_io_bytes{write,data}` climb on `:9000`, and the chosen buffer size is logged to `chimera_log`).