### PR TITLE
vfs: relatime + skip redundant attr-cache inserts on reads

### DIFF
--- a/src/vfs/cairn/cairn.c
+++ b/src/vfs/cairn/cairn.c
@@ -2980,6 +2980,12 @@ cairn_read(
 
     inode = ih.inode;
 
+    /* relatime: only stamp atime when the file changed since last access or the
+     * recorded atime is a day stale, so steady-state reads neither rewrite the
+     * inode to RocksDB nor churn the VFS attr cache. */
+    need_atime = need_atime &&
+        chimera_vfs_relatime_needs_update(&inode->atime, &inode->mtime, &inode->ctime, &now);
+
     if (offset >= inode->size) {
         cairn_map_attrs(shared, &request->read.r_attr, inode);
         cairn_inode_handle_release(&ih);

--- a/src/vfs/diskfs/diskfs.c
+++ b/src/vfs/diskfs/diskfs.c
@@ -934,6 +934,7 @@ struct diskfs_shared {
     uint64_t                   root_inum;          /* for the clean-unmount superblock */
     uint32_t                   root_gen;
     int                        unsafe_async;       /* config opt-in: submit block writes without FUA/sync (no crash safety) */
+    int                        noatime;            /* config opt-in: never update atime on read (default: relatime) */
     int                        mounted;            /* 1 = remounted existing FS (enables inode read-back) */
     uint32_t                   block_cache_blocks; /* total resident block-buffer cap (0 = default) */
     uint32_t                   inode_cache_inodes; /* total resident inode cap (0 = default) */
@@ -8054,6 +8055,7 @@ diskfs_init(
      * efficiently. */
     initialize           = json_object_get(cfg, "initialize") != NULL;
     shared->unsafe_async = json_is_true(json_object_get(cfg, "unsafe_async"));
+    shared->noatime      = json_is_true(json_object_get(cfg, "noatime"));
     /* Opt-in pNFS block / SCSI layout mode: diskfs sources RFC 5663 block or
      * RFC 8154 SCSI layouts and keeps file data on remote (data-only) devices.
      * Both share the same remote-device data path and allocator; they differ
@@ -11067,11 +11069,15 @@ diskfs_read_finish(struct chimera_vfs_request *request)
 
     if (p->pending == 0) {
         diskfs_op_ok(request, p->txn);
-    } else {
+    } else if (p->txn->type == DISKFS_TXN_READ) {
         /* I/O is in flight; drop the inode lock so other ops proceed.  The
          * txn commits from diskfs_io_callback once all reads complete. */
         diskfs_txn_unlock_inode(p->txn, inode);
     }
+    /* A relatime atime bump upgraded this read to a WRITE txn: keep the inode
+     * locked until the redo is durable (like the write path) -- io_callback
+     * runs diskfs_op_ok at pending==0 and the intent-log thread releases the
+     * lock once committed. */
 } /* diskfs_read_finish */
 
 static void
@@ -11284,6 +11290,49 @@ diskfs_read_inode_cb(
         request->read.r_eof    = eof;
         diskfs_op_ok(request, diskfs_private->txn);
         return;
+    }
+
+    /*
+     * relatime atime maintenance (data-returning reads only).  Reads run as a
+     * READ txn; if relatime says atime is due for a bump we can't journal it
+     * under a read lock, so abort and re-run the whole read under a WRITE txn.
+     * On the (rare) re-entry the txn is already WRITE: pin the inode block and
+     * stamp atime only (never ctime); the WRITE commit journals it.
+     */
+    if (diskfs_private->txn->type == DISKFS_TXN_WRITE) {
+        struct timespec now;
+
+        chimera_vfs_realtime(&now);
+        diskfs_txn_pin_inode_block(thread, diskfs_private->txn, inode, 0);
+        inode->atime_sec  = now.tv_sec;
+        inode->atime_nsec = now.tv_nsec;
+    } else if (!thread->shared->noatime) {
+        struct timespec atime = { inode->atime_sec, inode->atime_nsec };
+        struct timespec mtime = { inode->mtime_sec, inode->mtime_nsec };
+        struct timespec ctime = { inode->ctime_sec, inode->ctime_nsec };
+        struct timespec now;
+
+        chimera_vfs_realtime(&now);
+
+        if (chimera_vfs_relatime_needs_update(&atime, &mtime, &ctime, &now)) {
+            struct diskfs_inode *pinned =
+                (request->read.handle && request->read.handle->vfs_private) ?
+                (struct diskfs_inode *) request->read.handle->vfs_private : NULL;
+
+            diskfs_txn_abort(diskfs_private->txn);
+            diskfs_private->txn = diskfs_txn_begin(thread, DISKFS_TXN_WRITE);
+
+            if (pinned) {
+                diskfs_inode_acquire_pinned(thread, diskfs_private->txn, pinned,
+                                            DISKFS_INODE_MODE_FOR_TXN(diskfs_private->txn),
+                                            diskfs_read_inode_cb, request);
+            } else {
+                diskfs_inode_get_fh_async(thread, diskfs_private->txn,
+                                          request->fh, request->fh_len,
+                                          diskfs_read_inode_cb, request);
+            }
+            return;
+        }
     }
 
     aligned_offset = offset & ~4095ULL;

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -229,6 +229,7 @@ struct memfs_shared {
     uint32_t                 block_size;
     uint32_t                 block_shift;
     uint32_t                 block_mask;
+    int                      noatime;     /* config: disable atime updates on read */
     pthread_mutex_t          lock;
 };
 
@@ -937,6 +938,10 @@ memfs_init(
                 shared->fsid = strtoull(json_string_value(fsid_cfg), NULL, 0);
             }
         }
+
+        /* noatime disables read atime updates entirely; default (off) keeps
+         * relatime semantics. */
+        shared->noatime = json_is_true(json_object_get(cfg, "noatime"));
 
         json_decref(cfg);
     }
@@ -2829,7 +2834,13 @@ memfs_read(
         left        -= block_len;
     }
 
-    inode->atime = now;
+    /* relatime: only advance atime when the file changed since last access or
+     * the recorded atime is a day stale, so steady-state reads return identical
+     * attrs (and stop churning the VFS attr cache). */
+    if (!shared->noatime &&
+        chimera_vfs_relatime_needs_update(&inode->atime, &inode->mtime, &inode->ctime, &now)) {
+        inode->atime = now;
+    }
 
     memfs_map_attrs_fork(shared, &request->read.r_attr, inode, stream, request->fh);
 

--- a/src/vfs/vfs_attr_cache.h
+++ b/src/vfs/vfs_attr_cache.h
@@ -24,6 +24,7 @@ struct chimera_vfs_attr_cache_shard {
     struct prometheus_counter_instance   *insert;
     struct prometheus_counter_instance   *hit;
     struct prometheus_counter_instance   *miss;
+    struct prometheus_counter_instance   *skip;
 };
 
 struct chimera_vfs_attr_cache {
@@ -44,6 +45,7 @@ struct chimera_vfs_attr_cache {
     struct prometheus_counter_series    *insert_series;
     struct prometheus_counter_series    *hit_series;
     struct prometheus_counter_series    *miss_series;
+    struct prometheus_counter_series    *skip_series;
 };
 
 static inline struct chimera_vfs_attr_cache *
@@ -92,6 +94,9 @@ chimera_vfs_attr_cache_create(
         cache->miss_series = prometheus_counter_create_series(cache->attr_cache,
                                                               (const char *[]) { "op" },
                                                               (const char *[]) { "miss" }, 1);
+        cache->skip_series = prometheus_counter_create_series(cache->attr_cache,
+                                                              (const char *[]) { "op" },
+                                                              (const char *[]) { "skip" }, 1);
     }
 
     for (i = 0; i < cache->num_shards; i++) {
@@ -105,6 +110,7 @@ chimera_vfs_attr_cache_create(
             shard->insert = prometheus_counter_series_create_instance(cache->insert_series);
             shard->hit    = prometheus_counter_series_create_instance(cache->hit_series);
             shard->miss   = prometheus_counter_series_create_instance(cache->miss_series);
+            shard->skip   = prometheus_counter_series_create_instance(cache->skip_series);
         }
     }
 
@@ -126,6 +132,7 @@ chimera_vfs_attr_cache_destroy(struct chimera_vfs_attr_cache *cache)
         prometheus_counter_series_destroy_instance(cache->insert_series, shard->insert);
         prometheus_counter_series_destroy_instance(cache->hit_series, shard->hit);
         prometheus_counter_series_destroy_instance(cache->miss_series, shard->miss);
+        prometheus_counter_series_destroy_instance(cache->skip_series, shard->skip);
 
         for (j = 0; j < cache->num_slots * cache->num_entries; j++) {
             if (shard->entries[j]) {
@@ -145,6 +152,7 @@ chimera_vfs_attr_cache_destroy(struct chimera_vfs_attr_cache *cache)
         prometheus_counter_destroy_series(cache->attr_cache, cache->insert_series);
         prometheus_counter_destroy_series(cache->attr_cache, cache->hit_series);
         prometheus_counter_destroy_series(cache->attr_cache, cache->miss_series);
+        prometheus_counter_destroy_series(cache->attr_cache, cache->skip_series);
         prometheus_counter_destroy(cache->metrics, cache->attr_cache);
     }
 
@@ -281,3 +289,88 @@ chimera_vfs_attr_cache_insert(
     }
 
 } /* chimera_vfs_attr_cache_insert */
+
+/*
+ * Do two attr sets carry the same change-significant fields?  ctime is the
+ * metadata catch-all (it advances on any mode/uid/gid/size/mtime change), mtime
+ * covers data writes, size guards truncate/append, and atime is included so a
+ * relatime atime bump is treated as a change and refreshes the entry.
+ */
+static inline int
+chimera_vfs_attrs_times_equal(
+    const struct chimera_vfs_attrs *a,
+    const struct chimera_vfs_attrs *b)
+{
+    return a->va_size == b->va_size &&
+           a->va_mtime.tv_sec == b->va_mtime.tv_sec &&
+           a->va_mtime.tv_nsec == b->va_mtime.tv_nsec &&
+           a->va_ctime.tv_sec == b->va_ctime.tv_sec &&
+           a->va_ctime.tv_nsec == b->va_ctime.tv_nsec &&
+           a->va_atime.tv_sec == b->va_atime.tv_sec &&
+           a->va_atime.tv_nsec == b->va_atime.tv_nsec;
+} /* chimera_vfs_attrs_times_equal */
+
+/*
+ * Refresh the cached attrs for a non-mutating op (read/getattr/lookup/commit).
+ * Such ops almost never change the attributes, so instead of unconditionally
+ * inserting (alloc + shard mutex + RCU retire) we first do a lock-free RCU
+ * lookup; if a live entry already holds these exact change-significant fields,
+ * there is nothing to do.  Only on a miss / expiry / genuine change do we fall
+ * through to the full insert.  Mutating ops should call _insert directly -- for
+ * them the compare would always miss and just waste an RCU scan.
+ *
+ * Skipping does not refresh the entry's TTL (the entry was already live), so a
+ * hot read-only object re-inserts at most once per TTL.
+ */
+static inline void
+chimera_vfs_attr_cache_refresh(
+    struct chimera_vfs_thread     *thread,
+    struct chimera_vfs_attr_cache *cache,
+    uint64_t                       fh_hash,
+    const void                    *fh,
+    int                            fh_len,
+    struct chimera_vfs_attrs      *attr)
+{
+    struct chimera_vfs_attr_cache_entry  *entry;
+    struct chimera_vfs_attr_cache_shard  *shard;
+    struct chimera_vfs_attr_cache_entry **slot, **slot_end;
+    int                                   unchanged = 0;
+    uint64_t                              now       = chimera_vfs_now_ticks();
+
+    /* Only stat-complete attrs are cacheable (same gate as _insert). */
+    if ((attr->va_set_mask & CHIMERA_VFS_ATTR_MASK_STAT) != CHIMERA_VFS_ATTR_MASK_STAT) {
+        return;
+    }
+
+    shard = &cache->shards[fh_hash & cache->num_shards_mask];
+
+    slot = &shard->entries[(fh_hash & cache->num_slots_mask) << cache->num_entries_bits];
+
+    slot_end = slot + cache->num_entries;
+
+    urcu_memb_read_lock();
+
+    while (slot < slot_end) {
+        entry = rcu_dereference(*slot);
+
+        if (entry &&
+            entry->key == fh_hash &&
+            entry->expiration >= now &&
+            chimera_memequal(entry->attr.va_fh, entry->attr.va_fh_len, fh, fh_len)) {
+
+            unchanged = chimera_vfs_attrs_times_equal(&entry->attr, attr);
+            break;
+        }
+
+        slot++;
+    }
+
+    urcu_memb_read_unlock();
+
+    if (unchanged) {
+        prometheus_counter_increment(shard->skip);
+        return;
+    }
+
+    chimera_vfs_attr_cache_insert(thread, cache, fh_hash, fh, fh_len, attr);
+} /* chimera_vfs_attr_cache_refresh */

--- a/src/vfs/vfs_attrs.h
+++ b/src/vfs/vfs_attrs.h
@@ -138,3 +138,44 @@ struct chimera_vfs_attrs {
      */
     uint8_t             va_fh[CHIMERA_VFS_FH_SIZE + 16];
 };
+
+/* relatime: update atime on a read at most once per this period when the file
+ * is otherwise idle (matches the Linux default). */
+#define CHIMERA_VFS_RELATIME_PERIOD_SEC (24 * 60 * 60)
+
+static inline int
+chimera_vfs_timespec_ge(
+    const struct timespec *a,
+    const struct timespec *b)
+{
+    if (a->tv_sec != b->tv_sec) {
+        return a->tv_sec > b->tv_sec;
+    }
+    return a->tv_nsec >= b->tv_nsec;
+} /* chimera_vfs_timespec_ge */
+
+/*
+ * relatime policy: should a read bump atime?  Update only if the file was
+ * modified or its metadata changed since the last access (mtime/ctime >= atime),
+ * or the recorded atime is more than a day stale.  Mirrors the Linux kernel's
+ * relatime_need_update.  The resulting bump must touch atime ONLY -- never ctime
+ * -- so that after a bump conditions 1 and 2 are false until the next write.
+ */
+static inline int
+chimera_vfs_relatime_needs_update(
+    const struct timespec *atime,
+    const struct timespec *mtime,
+    const struct timespec *ctime,
+    const struct timespec *now)
+{
+    if (chimera_vfs_timespec_ge(mtime, atime)) {
+        return 1;
+    }
+    if (chimera_vfs_timespec_ge(ctime, atime)) {
+        return 1;
+    }
+    if (now->tv_sec - atime->tv_sec >= CHIMERA_VFS_RELATIME_PERIOD_SEC) {
+        return 1;
+    }
+    return 0;
+} /* chimera_vfs_relatime_needs_update */

--- a/src/vfs/vfs_proc_commit.c
+++ b/src/vfs/vfs_proc_commit.c
@@ -13,11 +13,11 @@ chimera_vfs_commit_complete(struct chimera_vfs_request *request)
     chimera_vfs_commit_callback_t callback = request->proto_callback;
 
     if (request->status == CHIMERA_VFS_OK) {
-        chimera_vfs_attr_cache_insert(request->thread, request->thread->vfs->vfs_attr_cache,
-                                      request->commit.handle->fh_hash,
-                                      request->commit.handle->fh,
-                                      request->commit.handle->fh_len,
-                                      &request->commit.r_post_attr);
+        chimera_vfs_attr_cache_refresh(request->thread, request->thread->vfs->vfs_attr_cache,
+                                       request->commit.handle->fh_hash,
+                                       request->commit.handle->fh,
+                                       request->commit.handle->fh_len,
+                                       &request->commit.r_post_attr);
     }
 
     chimera_vfs_complete(request);

--- a/src/vfs/vfs_proc_getattr.c
+++ b/src/vfs/vfs_proc_getattr.c
@@ -17,11 +17,11 @@ chimera_vfs_getattr_complete(struct chimera_vfs_request *request)
     chimera_vfs_getattr_callback_t callback   = request->proto_callback;
 
     if (request->status == CHIMERA_VFS_OK) {
-        chimera_vfs_attr_cache_insert(thread, attr_cache,
-                                      request->getattr.handle->fh_hash,
-                                      request->getattr.handle->fh,
-                                      request->getattr.handle->fh_len,
-                                      &request->getattr.r_attr);
+        chimera_vfs_attr_cache_refresh(thread, attr_cache,
+                                       request->getattr.handle->fh_hash,
+                                       request->getattr.handle->fh,
+                                       request->getattr.handle->fh_len,
+                                       &request->getattr.r_attr);
     }
 
     chimera_vfs_complete(request);

--- a/src/vfs/vfs_proc_getrootfh.c
+++ b/src/vfs/vfs_proc_getrootfh.c
@@ -18,11 +18,11 @@ chimera_vfs_getrootfh_complete(struct chimera_vfs_request *request)
 
 
     if (request->status == CHIMERA_VFS_OK) {
-        chimera_vfs_attr_cache_insert(thread, attr_cache,
-                                      request->fh_hash,
-                                      request->fh,
-                                      request->fh_len,
-                                      &request->getrootfh.r_attr);
+        chimera_vfs_attr_cache_refresh(thread, attr_cache,
+                                       request->fh_hash,
+                                       request->fh,
+                                       request->fh_len,
+                                       &request->getrootfh.r_attr);
     }
 
     chimera_vfs_complete(

--- a/src/vfs/vfs_proc_lookup_at.c
+++ b/src/vfs/vfs_proc_lookup_at.c
@@ -33,18 +33,18 @@ chimera_vfs_lookup_at_complete(struct chimera_vfs_request *request)
                                       request->lookup_at.r_attr.va_fh,
                                       request->lookup_at.r_attr.va_fh_len);
 
-        chimera_vfs_attr_cache_insert(thread, attr_cache,
-                                      chimera_vfs_hash(request->lookup_at.r_attr.va_fh, request->lookup_at.r_attr.
-                                                       va_fh_len),
-                                      request->lookup_at.r_attr.va_fh,
-                                      request->lookup_at.r_attr.va_fh_len,
-                                      &request->lookup_at.r_attr);
+        chimera_vfs_attr_cache_refresh(thread, attr_cache,
+                                       chimera_vfs_hash(request->lookup_at.r_attr.va_fh, request->lookup_at.r_attr.
+                                                        va_fh_len),
+                                       request->lookup_at.r_attr.va_fh,
+                                       request->lookup_at.r_attr.va_fh_len,
+                                       &request->lookup_at.r_attr);
 
-        chimera_vfs_attr_cache_insert(thread, attr_cache,
-                                      request->lookup_at.handle->fh_hash,
-                                      request->lookup_at.handle->fh,
-                                      request->lookup_at.handle->fh_len,
-                                      &request->lookup_at.r_dir_attr);
+        chimera_vfs_attr_cache_refresh(thread, attr_cache,
+                                       request->lookup_at.handle->fh_hash,
+                                       request->lookup_at.handle->fh,
+                                       request->lookup_at.handle->fh_len,
+                                       &request->lookup_at.r_dir_attr);
     }
 
     chimera_vfs_complete(request);

--- a/src/vfs/vfs_proc_read.c
+++ b/src/vfs/vfs_proc_read.c
@@ -95,11 +95,11 @@ chimera_vfs_read_complete(struct chimera_vfs_request *request)
      * inserting here would only evict a valid entry. */
     if (request->status == CHIMERA_VFS_OK &&
         (request->read.r_attr.va_set_mask & CHIMERA_VFS_ATTR_MASK_STAT) == CHIMERA_VFS_ATTR_MASK_STAT) {
-        chimera_vfs_attr_cache_insert(request->thread, request->thread->vfs->vfs_attr_cache,
-                                      request->read.handle->fh_hash,
-                                      request->read.handle->fh,
-                                      request->read.handle->fh_len,
-                                      &request->read.r_attr);
+        chimera_vfs_attr_cache_refresh(request->thread, request->thread->vfs->vfs_attr_cache,
+                                       request->read.handle->fh_hash,
+                                       request->read.handle->fh,
+                                       request->read.handle->fh_len,
+                                       &request->read.r_attr);
     }
 
     chimera_vfs_complete(request);


### PR DESCRIPTION
## Problem

NFSv3 READ carries post-op attrs, so the VFS read completion path inserted into
the attribute cache on **every** read -- allocating an entry, taking the shard
mutex, publishing it, and `call_rcu`-retiring the old one -- even when the attrs
were byte-identical to what was already cached. Under sustained reads that is
pure churn: a per-op allocation, per-op shard-lock contention, and a steady
stream of RCU retirements.

## Changes

**Compare-and-skip, gated by op intent** (`vfs_attr_cache.h`): a new
`chimera_vfs_attr_cache_refresh()` does a lock-free RCU lookup and, when a live
entry already matches the new attrs on the change-significant fields
(mtime/ctime/atime/size), returns without touching the cache. The non-mutating
ops (read, getattr, lookup target+parent, commit, getrootfh) use it; mutating
ops keep calling `_insert` directly (for them the compare would always miss). A
`skip` counter sits beside insert/hit/miss.

**relatime in the native backends** so reads return *stable* attrs (otherwise an
atime bump every read would defeat the compare). A shared
`chimera_vfs_relatime_needs_update()` mirrors the Linux rule (bump only if
mtime/ctime >= atime or atime is >24h stale; never touches ctime):
- **memfs**: was strict-atime (every read); now relatime.
- **cairn**: was a per-read RocksDB inode rewrite; now only on the relatime tick.
- **diskfs**: didn't touch atime at all; now relatime via a read-txn ->
  write-txn upgrade -- a read runs read-only, and only when a bump is due does
  it abort, re-run under a WRITE txn, stamp atime, and journal it. Steady-state
  reads stay read-only transactions.

Each backend gets a `noatime` config knob (default off = relatime).

## Why relatime is safe

atime is advisory; almost nothing reads it, and the two historical consumers
(mail "new mail" detection, age-based cleanup) are preserved by the mtime/ctime
and 24h rules. NFS atime was never synchronous and clients cache it loosely.
This is the Linux default since 2.6.30. For diskfs in particular, strict atime
would mean a journal write per read -- self-defeating.

## Testing

- Debug + Release build clean; `scan-build`: no bugs.
- Functional (ASan): memfs/cairn read/write/getattr/lookup/setattr/commit/access
  + fsx/fsstress (416), diskfs read/write/getattr/setattr/sparse/commit/lock +
  fsx/fsstress (380), VFS getattr/lookup/access/read/verify (468) -- all green.
- **Churn proof**: 200 sustained server reads of one file moved `insert` by +1
  (the single relatime atime bump) and `skip` by ~2200 -- the read path no
  longer mutates the cache.
- **diskfs relatime** validated against a real NFS4.2 kernel mount: atime bumps
  once after a write, stays stable on subsequent reads, persists across remount;
  4 concurrent fsx-with-fallocate workers (15k ops each) pass with no hang or
  corruption.
