### PR TITLE
nfs/client: RDMA zero-copy reads land in the caller's buffer (read_into Phase 2)

### DIFF
--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 add_library(chimera_client SHARED client.c client_dispatch.c
             client_mount.c client_umount.c
-            client_open.c client_mkdir.c client_mknod.c client_close.c client_read.c client_write.c
+            client_open.c client_mkdir.c client_mknod.c client_close.c client_read.c client_read_into.c client_write.c
             client_symlink.c client_link.c client_remove.c client_rename.c
             client_readlink.c client_stat.c client_readdir.c client_statfs.c
             client_copy_range.c client_clone_range.c)

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -201,6 +201,29 @@ chimera_writerv(
     chimera_write_callback_t        callback,
     void                           *private_data);
 
+/* Zero-copy read into caller-provided evpl_iovec(s).  Like chimera_read(), but
+ * the data lands directly in `iov` (over RDMA the buffers become the server's
+ * write target -- no copy).  The caller owns `iov` (borrow): keep the buffers
+ * alive until the callback fires, then release them.  The callback reports the
+ * byte count and eof; the data is already in the caller's buffers. */
+typedef void (*chimera_read_into_callback_t)(
+    struct chimera_client_thread *thread,
+    enum chimera_vfs_error        status,
+    uint32_t                      count,
+    uint32_t                      eof,
+    void                         *private_data);
+
+void
+chimera_read_into(
+    struct chimera_client_thread   *thread,
+    struct chimera_vfs_open_handle *handle,
+    uint64_t                        offset,
+    uint32_t                        length,
+    struct evpl_iovec              *iov,
+    int                             niov,
+    chimera_read_into_callback_t    callback,
+    void                           *private_data);
+
 
 void
 chimera_close(

--- a/src/client/client_internal.h
+++ b/src/client/client_internal.h
@@ -146,6 +146,23 @@ struct chimera_client_request {
             struct evpl_iovec               iov[CHIMERA_CLIENT_IOV_MAX];
         } read;
 
+        /* For chimera_read_into - caller provides destination evpl_iovec(s).
+         * dest_iov is a borrowed shallow copy of the caller's buffers (the
+         * caller keeps its own refs alive until the callback); iov is scratch
+         * the VFS core/backend works through. */
+        struct {
+            struct chimera_vfs_open_handle *handle;
+            uint64_t                        offset;
+            uint32_t                        length;
+            uint32_t                        result_count;
+            uint32_t                        result_eof;
+            int                             dest_niov;
+            chimera_read_into_callback_t    callback;
+            void                           *private_data;
+            struct evpl_iovec               dest_iov[CHIMERA_CLIENT_IOV_MAX];
+            struct evpl_iovec               iov[CHIMERA_CLIENT_IOV_MAX];
+        } read_into;
+
         /* For chimera_write - caller provides a simple buffer */
         struct {
             struct chimera_vfs_open_handle *handle;

--- a/src/client/client_read_into.c
+++ b/src/client/client_read_into.c
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "client_read_into.h"
+
+SYMBOL_EXPORT void
+chimera_read_into(
+    struct chimera_client_thread   *thread,
+    struct chimera_vfs_open_handle *handle,
+    uint64_t                        offset,
+    uint32_t                        length,
+    struct evpl_iovec              *iov,
+    int                             niov,
+    chimera_read_into_callback_t    callback,
+    void                           *private_data)
+{
+    struct chimera_client_request *request;
+
+    request = chimera_client_request_alloc(thread);
+
+    request->opcode                 = CHIMERA_CLIENT_OP_READ;
+    request->read_into.callback     = callback;
+    request->read_into.private_data = private_data;
+    request->read_into.handle       = handle;
+    request->read_into.offset       = offset;
+    request->read_into.length       = length;
+    request->read_into.dest_niov    = niov;
+
+    /* Borrow the caller's destination buffers: shallow-copy the iovec structs
+     * (same underlying buffer) without taking a ref.  The caller guarantees the
+     * buffers stay alive until the callback. */
+    for (int i = 0; i < niov; i++) {
+        request->read_into.dest_iov[i] = iov[i];
+    }
+
+    chimera_dispatch_read_into(thread, request);
+} /* chimera_read_into */

--- a/src/client/client_read_into.h
+++ b/src/client/client_read_into.h
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#pragma once
+
+#include "client_internal.h"
+
+static void
+chimera_read_into_complete(
+    enum chimera_vfs_error    error_code,
+    uint32_t                  count,
+    uint32_t                  eof,
+    struct evpl_iovec        *iov,
+    int                       niov,
+    struct chimera_vfs_attrs *attr,
+    void                     *private_data)
+{
+    struct chimera_client_request *request       = private_data;
+    struct chimera_client_thread  *client_thread = request->thread;
+    chimera_read_into_callback_t   callback      = request->read_into.callback;
+    void                          *callback_arg  = request->read_into.private_data;
+
+    /* The data has already landed in the caller's destination buffers; iov/niov
+     * just reference them.  The caller owns and releases those buffers, so we
+     * release nothing here. */
+    request->read_into.result_count = count;
+    request->read_into.result_eof   = eof;
+
+    chimera_client_request_free(client_thread, request);
+
+    callback(client_thread, error_code, count, eof, callback_arg);
+} /* chimera_read_into_complete */
+
+static inline void
+chimera_dispatch_read_into(
+    struct chimera_client_thread  *thread,
+    struct chimera_client_request *request)
+{
+    chimera_vfs_read_into(thread->vfs_thread,
+                          &thread->client->cred,
+                          request->read_into.handle,
+                          request->read_into.offset,
+                          request->read_into.length,
+                          request->read_into.iov,
+                          CHIMERA_CLIENT_IOV_MAX,
+                          request->read_into.dest_iov,
+                          request->read_into.dest_niov,
+                          0,
+                          chimera_read_into_complete,
+                          request);
+} /* chimera_dispatch_read_into */

--- a/src/client/tests/CMakeLists.txt
+++ b/src/client/tests/CMakeLists.txt
@@ -41,6 +41,12 @@ if(CHIMERA_NETNS_TESTING)
     add_test(NAME chimera/client/basic COMMAND client_basic)
 endif()
 
+add_executable(client_read_into read_into.c)
+target_link_libraries(client_read_into chimera_client evpl prometheus-c)
+if(CHIMERA_NETNS_TESTING)
+    add_test(NAME chimera/client/read_into COMMAND client_read_into)
+endif()
+
 # List of test programs
 set(CLIENT_TEST_PROGRAMS
     test_symlink

--- a/src/client/tests/read_into.c
+++ b/src/client/tests/read_into.c
@@ -1,0 +1,202 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * End-to-end check of chimera_read_into(): write a known pattern to a memfs
+ * file, read it back into a caller-provided evpl_iovec, and verify the bytes
+ * landed in that buffer.  memfs advertises CAP_READ_PROVIDES_BUFFERS, so this
+ * exercises the VFS-core scatter-copy fallback in chimera_vfs_read_into().
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "client/client.h"
+#include "evpl/evpl.h"
+#include "prometheus-c.h"
+
+#define TEST_LEN 65536
+
+struct op_ctx {
+    int      done;
+    int      status;
+    uint32_t count;
+};
+
+static void
+mount_callback(
+    struct chimera_client_thread *client,
+    enum chimera_vfs_error        status,
+    void                         *private_data)
+{
+    struct op_ctx *ctx = private_data;
+
+    ctx->status = status;
+    ctx->done   = 1;
+} /* mount_callback */
+
+static void
+open_callback(
+    struct chimera_client_thread   *client,
+    enum chimera_vfs_error          status,
+    struct chimera_vfs_open_handle *oh,
+    void                           *private_data)
+{
+    struct chimera_vfs_open_handle **handle = private_data;
+
+    *handle = oh;
+} /* open_callback */
+
+static void
+write_callback(
+    struct chimera_client_thread *client,
+    enum chimera_vfs_error        status,
+    void                         *private_data)
+{
+    struct op_ctx *ctx = private_data;
+
+    ctx->status = status;
+    ctx->done   = 1;
+} /* write_callback */
+
+static void
+read_into_callback(
+    struct chimera_client_thread *client,
+    enum chimera_vfs_error        status,
+    uint32_t                      count,
+    uint32_t                      eof,
+    void                         *private_data)
+{
+    struct op_ctx *ctx = private_data;
+
+    ctx->status = status;
+    ctx->count  = count;
+    ctx->done   = 1;
+} /* read_into_callback */
+
+static void
+wait_done(
+    struct evpl   *evpl,
+    struct op_ctx *ctx)
+{
+    while (!ctx->done) {
+        evpl_continue(evpl);
+    }
+} /* wait_done */
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    struct chimera_client          *client;
+    struct chimera_client_config   *config;
+    struct chimera_client_thread   *thread;
+    struct evpl                    *evpl;
+    struct chimera_vfs_open_handle *file_handle = NULL;
+    struct prometheus_metrics      *metrics;
+    struct op_ctx                   ctx;
+    struct chimera_vfs_cred         root_cred;
+    char                           *pattern;
+    struct evpl_iovec               wiov, riov[2];
+    char                           *got;
+    int                             niov;
+    int                             i;
+
+    chimera_log_init();
+
+    metrics = prometheus_metrics_create(NULL, NULL, 0);
+
+    evpl   = evpl_create(NULL);
+    config = chimera_client_config_init();
+
+    chimera_vfs_cred_init_unix(&root_cred, 0, 0, 0, NULL);
+    client = chimera_client_init(config, &root_cred, metrics);
+    thread = chimera_client_thread_init(evpl, client);
+
+    ctx = (struct op_ctx) { 0 };
+    chimera_mount(thread, "/memfs", "memfs", "/", NULL, mount_callback, &ctx);
+    wait_done(evpl, &ctx);
+    if (ctx.status != 0) {
+        fprintf(stderr, "mount failed: %d\n", ctx.status);
+        return 1;
+    }
+
+    chimera_open(thread, "/memfs/rifile", 13, CHIMERA_VFS_OPEN_CREATE,
+                 open_callback, &file_handle);
+    while (!file_handle) {
+        evpl_continue(evpl);
+    }
+
+    /* Build a known pattern and write it through the zero-copy write path. */
+    pattern = malloc(TEST_LEN);
+    for (i = 0; i < TEST_LEN; i++) {
+        pattern[i] = (char) (i * 31 + 7);
+    }
+
+    niov = evpl_iovec_alloc(evpl, TEST_LEN, 1, 1, 0, &wiov);
+    if (niov != 1) {
+        fprintf(stderr, "write iovec alloc failed\n");
+        return 1;
+    }
+    memcpy(wiov.data, pattern, TEST_LEN);
+
+    ctx = (struct op_ctx) { 0 };
+    chimera_writerv(thread, file_handle, 0, TEST_LEN, &wiov, 1, write_callback, &ctx);
+    wait_done(evpl, &ctx);
+    if (ctx.status != 0) {
+        fprintf(stderr, "write failed: %d\n", ctx.status);
+        return 1;
+    }
+
+    /* Read it back into a caller-provided two-segment destination, so the
+     * VFS-core scatter-copy spans more than one destination iovec. */
+    for (i = 0; i < 2; i++) {
+        niov = evpl_iovec_alloc(evpl, TEST_LEN / 2, 1, 1, 0, &riov[i]);
+        if (niov != 1) {
+            fprintf(stderr, "read iovec alloc failed\n");
+            return 1;
+        }
+        memset(riov[i].data, 0, TEST_LEN / 2);
+    }
+
+    ctx = (struct op_ctx) { 0 };
+    chimera_read_into(thread, file_handle, 0, TEST_LEN, riov, 2, read_into_callback, &ctx);
+    wait_done(evpl, &ctx);
+    if (ctx.status != 0) {
+        fprintf(stderr, "read_into failed: %d\n", ctx.status);
+        return 1;
+    }
+
+    if (ctx.count != TEST_LEN) {
+        fprintf(stderr, "read_into short: got %u want %u\n", ctx.count, TEST_LEN);
+        return 1;
+    }
+
+    /* Reassemble the two destination segments and compare to the pattern. */
+    got = malloc(TEST_LEN);
+    memcpy(got, riov[0].data, TEST_LEN / 2);
+    memcpy(got + TEST_LEN / 2, riov[1].data, TEST_LEN / 2);
+
+    if (memcmp(got, pattern, TEST_LEN) != 0) {
+        fprintf(stderr, "read_into data mismatch\n");
+        return 1;
+    }
+
+    fprintf(stderr, "read_into round-trip of %d bytes (2 dst segments) verified\n", TEST_LEN);
+
+    evpl_iovec_release(evpl, &riov[0]);
+    evpl_iovec_release(evpl, &riov[1]);
+    chimera_close(thread, file_handle);
+    free(got);
+    free(pattern);
+
+    chimera_client_thread_shutdown(evpl, thread);
+    chimera_destroy(client);
+    prometheus_metrics_destroy(metrics);
+    evpl_destroy(evpl);
+
+    return 0;
+} /* main */

--- a/src/fio/fio.c
+++ b/src/fio/fio.c
@@ -537,43 +537,24 @@ static void
 fio_chimera_read_callback(
     struct chimera_client_thread *thread,
     enum chimera_vfs_error        status,
-    struct evpl_iovec            *iov,
-    int                           niov,
+    uint32_t                      count,
+    uint32_t                      eof,
     void                         *private_data)
 {
     struct io_u               *io_u           = private_data;
     struct thread_data        *td             = io_u->mmap_data;
     struct chimera_fio_thread *chimera_thread = td->io_ops_data;
-    uint64_t                   returned       = 0;
-    uint32_t                   left, chunk, i;
-    void                      *p;
 
-    if (td->o.verify) {
-        left = io_u->xfer_buflen;
-        p    = io_u->xfer_buf;
-
-        for (i = 0; i < niov && left; i++) {
-
-            chunk = left < iov[i].length ? left : iov[i].length;
-            memcpy(p, iov[i].data, chunk);
-            p    += chunk;
-            left -= chunk;
-        }
-    }
-
-    for (i = 0; i < niov; i++) {
-        returned += iov[i].length;
-        evpl_iovec_release(chimera_thread->evpl, &iov[i]);
-    }
-
-    /* Report what actually came back rather than blindly crediting the full
+    /* The data has already landed directly in io_u->xfer_buf (chimera_read_into
+     * targeted it), so there is no copy here -- fio's verify reads it in place.
+     * Report what actually came back rather than blindly crediting the full
      * request: a backend error fails the I/O, and a short read (e.g. past EOF)
      * leaves a residual so fio only counts the bytes that were really moved. */
     if (status != CHIMERA_VFS_OK) {
         io_u->error = EIO;
     } else {
         io_u->error = 0;
-        io_u->resid = returned < io_u->xfer_buflen ? io_u->xfer_buflen - returned : 0;
+        io_u->resid = count < io_u->xfer_buflen ? io_u->xfer_buflen - count : 0;
     }
 
     fio_chimera_ring_enqueue(chimera_thread, io_u);
@@ -617,9 +598,21 @@ fio_chimera_queue(
 
     switch (io_u->ddir) {
         case DDIR_READ:
-            chimera_read(chimera_thread->client, fh, io_u->offset, io_u->xfer_buflen,
-                         fio_chimera_read_callback, io_u);
-            break;
+        {
+            unsigned int buf_offset = (unsigned int) ((char *) io_u->xfer_buf -
+                                                      (char *) evpl_iovec_data(&chimera_thread->iov));
+
+            /* Land the read directly in io_u's slice of our registered buffer.
+            * read_into borrows the iovec; the underlying buffer stays alive via
+            * chimera_thread->iov, so we can release this clone immediately. */
+            evpl_iovec_clone_segment(&iov, &chimera_thread->iov, buf_offset, io_u->xfer_buflen);
+
+            chimera_read_into(chimera_thread->client, fh, io_u->offset, io_u->xfer_buflen,
+                              &iov, 1, fio_chimera_read_callback, io_u);
+
+            evpl_iovec_release(chimera_thread->evpl, &iov);
+        }
+        break;
         case DDIR_WRITE:
         {
             unsigned int buf_offset = (unsigned int) ((char *) io_u->xfer_buf -

--- a/src/posix/CMakeLists.txt
+++ b/src/posix/CMakeLists.txt
@@ -9,6 +9,7 @@ add_library(chimera_posix SHARED
             posix_open.c
             posix_close.c
             posix_read.c
+            posix_read_into.c
             posix_write.c
             posix_pread.c
             posix_pwrite.c

--- a/src/posix/posix.h
+++ b/src/posix/posix.h
@@ -19,6 +19,7 @@
 struct chimera_posix_client;
 struct chimera_client_config;
 struct prometheus_metrics;
+struct evpl_iovec;
 
 struct chimera_posix_client *
 chimera_posix_init(
@@ -151,6 +152,25 @@ chimera_posix_pread64(
     void   *buf,
     size_t  count,
     int64_t offset);
+
+/* Native zero-copy reads into caller-provided evpl_iovec(s).  The data lands
+ * directly in `iov` (no copy into a separate buffer); the caller owns `iov` and
+ * must allocate it from the evpl allocator so it is RDMA-registered.  Returns
+ * the byte count read, or -1 with errno set. */
+ssize_t
+chimera_posix_read_into(
+    int                fd,
+    struct evpl_iovec *iov,
+    int                niov,
+    size_t             count);
+
+ssize_t
+chimera_posix_pread_into(
+    int                fd,
+    struct evpl_iovec *iov,
+    int                niov,
+    size_t             count,
+    off_t              offset);
 
 ssize_t
 chimera_posix_pwrite(

--- a/src/posix/posix_read_into.c
+++ b/src/posix/posix_read_into.c
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include <errno.h>
+
+#include "posix_internal.h"
+#include "../client/client_read_into.h"
+
+static void
+chimera_posix_read_into_callback(
+    struct chimera_client_thread *thread,
+    enum chimera_vfs_error        status,
+    uint32_t                      count,
+    uint32_t                      eof,
+    void                         *private_data)
+{
+    struct chimera_posix_completion *comp    = private_data;
+    struct chimera_client_request   *request = comp->request;
+
+    /* The data is already in the caller's evpl_iovec(s) -- nothing to copy. */
+    if (status == CHIMERA_VFS_OK) {
+        request->sync_result = (ssize_t) count;
+    }
+
+    chimera_posix_complete(comp, status);
+} /* chimera_posix_read_into_callback */
+
+static void
+chimera_posix_read_into_exec(
+    struct chimera_client_thread  *thread,
+    struct chimera_client_request *request)
+{
+    chimera_dispatch_read_into(thread, request);
+} /* chimera_posix_read_into_exec */
+
+static ssize_t
+chimera_posix_read_into_common(
+    int                fd,
+    struct evpl_iovec *iov,
+    int                niov,
+    size_t             count,
+    off_t              offset,
+    int                use_fd_offset)
+{
+    struct chimera_posix_client    *posix  = chimera_posix_get_global();
+    struct chimera_posix_worker    *worker = chimera_posix_choose_worker(posix);
+    struct chimera_client_request   req;
+    struct chimera_posix_completion comp;
+    struct chimera_posix_fd_entry  *entry;
+
+    if (niov < 0 || niov > CHIMERA_CLIENT_IOV_MAX) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    entry = chimera_posix_fd_acquire(posix, fd, CHIMERA_POSIX_FD_IO_ACTIVE);
+
+    if (!entry) {
+        return -1;
+    }
+
+    chimera_posix_completion_init(&comp, &req);
+
+    req.opcode                 = CHIMERA_CLIENT_OP_READ;
+    req.read_into.callback     = chimera_posix_read_into_callback;
+    req.read_into.private_data = &comp;
+    req.read_into.handle       = entry->handle;
+    req.read_into.offset       = use_fd_offset ? entry->offset : (uint64_t) offset;
+    req.read_into.length       = count;
+    req.read_into.dest_niov    = niov;
+
+    for (int i = 0; i < niov; i++) {
+        req.read_into.dest_iov[i] = iov[i];
+    }
+
+    chimera_posix_worker_enqueue(worker, &req, chimera_posix_read_into_exec);
+
+    int     err = chimera_posix_wait(&comp);
+
+    if (!err && use_fd_offset && req.sync_result >= 0) {
+        entry->offset += (uint64_t) req.sync_result;
+    }
+
+    ssize_t ret = req.sync_result;
+
+    chimera_posix_completion_destroy(&comp);
+
+    chimera_posix_fd_release(entry, CHIMERA_POSIX_FD_IO_ACTIVE);
+
+    if (err) {
+        errno = err;
+        return -1;
+    }
+
+    return ret;
+} /* chimera_posix_read_into_common */
+
+SYMBOL_EXPORT ssize_t
+chimera_posix_read_into(
+    int                fd,
+    struct evpl_iovec *iov,
+    int                niov,
+    size_t             count)
+{
+    return chimera_posix_read_into_common(fd, iov, niov, count, 0, 1);
+} /* chimera_posix_read_into */
+
+SYMBOL_EXPORT ssize_t
+chimera_posix_pread_into(
+    int                fd,
+    struct evpl_iovec *iov,
+    int                niov,
+    size_t             count,
+    off_t              offset)
+{
+    return chimera_posix_read_into_common(fd, iov, niov, count, offset, 0);
+} /* chimera_posix_pread_into */

--- a/src/server/nfs/nfs4_callback.c
+++ b/src/server/nfs/nfs4_callback.c
@@ -357,7 +357,7 @@ nfs4_cb_channel_open(
                                     thread->evpl,
                                     nfs4_cb_chan_conn(chan),
                                     NULL,
-                                    0, 0, 0,
+                                    0, 0, NULL, 0, 0,
                                     nfs4_cb_null_complete,
                                     ctx);
 } /* nfs4_cb_channel_open */
@@ -713,7 +713,7 @@ nfs4_cb_recall_send(
                                             conn,
                                             credp,
                                             &args,
-                                            0, 0, 0,
+                                            0, 0, NULL, 0, 0,
                                             nfs4_cb_recall_complete,
                                             ctx);
     }
@@ -841,7 +841,7 @@ nfs4_cb_layoutrecall(
                                             conn,
                                             credp,
                                             &args,
-                                            0, 0, 0,
+                                            0, 0, NULL, 0, 0,
                                             nfs4_cb_layoutrecall_complete,
                                             ctx);
     }
@@ -1084,7 +1084,7 @@ nfs4_cb_getattr_send(
                                             conn,
                                             credp,
                                             &args,
-                                            0, 0, 0,
+                                            0, 0, NULL, 0, 0,
                                             nfs4_cb_getattr_complete,
                                             w);
     }

--- a/src/server/nfs/nfs_external_portmap.c
+++ b/src/server/nfs/nfs_external_portmap.c
@@ -158,7 +158,7 @@ register_service(
                                            ctx->portmap_conn,
                                            NULL,
                                            &mapping,
-                                           0, 0, 0,
+                                           0, 0, NULL, 0, 0,
                                            portmap_set_callback, ctx);
 } /* register_service */
 
@@ -186,7 +186,7 @@ unregister_service(
                                              ctx->portmap_conn,
                                              NULL,
                                              &mapping,
-                                             0, 0, 0,
+                                             0, 0, NULL, 0, 0,
                                              portmap_unset_callback, ctx);
 } /* unregister_service */
 

--- a/src/server/nfs/nfs_nlm.c
+++ b/src/server/nfs/nfs_nlm.c
@@ -189,7 +189,7 @@ chimera_nfs_nlm4_test_open_cb(
 
     if (ctx->proc == 16) {
         shared->nlm_v4.send_call_NLMPROC4_TEST_RES(&shared->nlm_v4.rpc2, evpl,
-                                                   ctx->conn, NULL, &res, 0, 0, 0,
+                                                   ctx->conn, NULL, &res, 0, 0, NULL, 0, 0,
                                                    NULL, NULL);
     } else {
         rc = shared->nlm_v4.send_reply_NLMPROC4_TEST(evpl, NULL, &res, encoding);
@@ -264,7 +264,8 @@ chimera_nfs_nlm4_lock_acquire_cb(
             rc = shared->nlm_v4.send_reply_NLMPROC4_LOCK(evpl, NULL, &res, encoding);
             break;
         case 17:
-            shared->nlm_v4.send_call_NLMPROC4_LOCK_RES(&shared->nlm_v4.rpc2, evpl, ctx->conn, NULL, &res, 0, 0, 0, NULL,
+            shared->nlm_v4.send_call_NLMPROC4_LOCK_RES(&shared->nlm_v4.rpc2, evpl, ctx->conn, NULL, &res, 0, 0, NULL, 0,
+                                                       0, NULL,
                                                        NULL);
             break;
         default:
@@ -307,7 +308,8 @@ chimera_nfs_nlm4_lock_open_cb(
                 rc = shared->nlm_v4.send_reply_NLMPROC4_LOCK(evpl, NULL, &res, encoding);
                 break;
             case 17:
-                shared->nlm_v4.send_call_NLMPROC4_LOCK_RES(&shared->nlm_v4.rpc2, evpl, ctx->conn, NULL, &res, 0, 0, 0,
+                shared->nlm_v4.send_call_NLMPROC4_LOCK_RES(&shared->nlm_v4.rpc2, evpl, ctx->conn, NULL, &res, 0, 0, NULL
+                                                           , 0, 0,
                                                            NULL, NULL);
                 break;
             default:
@@ -339,7 +341,8 @@ chimera_nfs_nlm4_lock_open_cb(
                 rc = shared->nlm_v4.send_reply_NLMPROC4_LOCK(evpl, NULL, &res, encoding);
                 break;
             case 17:
-                shared->nlm_v4.send_call_NLMPROC4_LOCK_RES(&shared->nlm_v4.rpc2, evpl, ctx->conn, NULL, &res, 0, 0, 0,
+                shared->nlm_v4.send_call_NLMPROC4_LOCK_RES(&shared->nlm_v4.rpc2, evpl, ctx->conn, NULL, &res, 0, 0, NULL
+                                                           , 0, 0,
                                                            NULL, NULL);
                 break;
             default:
@@ -428,7 +431,8 @@ chimera_nfs_nlm4_do_test(
         err_res.cookie.data    = args->cookie.data;
         err_res.test_stat.stat = NLM4_DENIED_NOLOCKS;
         if (proc == 16) {
-            shared->nlm_v4.send_call_NLMPROC4_TEST_RES(&shared->nlm_v4.rpc2, evpl, conn, NULL, &err_res, 0, 0, 0, NULL,
+            shared->nlm_v4.send_call_NLMPROC4_TEST_RES(&shared->nlm_v4.rpc2, evpl, conn, NULL, &err_res, 0, 0, NULL, 0,
+                                                       0, NULL,
                                                        NULL);
         } else {
             int oom_rc = shared->nlm_v4.send_reply_NLMPROC4_TEST(evpl, NULL, &err_res, encoding);
@@ -587,7 +591,8 @@ chimera_nfs_nlm4_do_lock(
                 rc = shared->nlm_v4.send_reply_NLMPROC4_LOCK(evpl, NULL, &res, encoding);
                 break;
             case 17:
-                shared->nlm_v4.send_call_NLMPROC4_LOCK_RES(&shared->nlm_v4.rpc2, evpl, conn, NULL, &res, 0, 0, 0, NULL,
+                shared->nlm_v4.send_call_NLMPROC4_LOCK_RES(&shared->nlm_v4.rpc2, evpl, conn, NULL, &res, 0, 0, NULL, 0,
+                                                           0, NULL,
                                                            NULL);
                 break;
             default:
@@ -634,7 +639,8 @@ chimera_nfs_nlm4_do_lock(
                 rc = shared->nlm_v4.send_reply_NLMPROC4_LOCK(evpl, NULL, &res, encoding);
                 break;
             case 17:
-                shared->nlm_v4.send_call_NLMPROC4_LOCK_RES(&shared->nlm_v4.rpc2, evpl, ctx->conn, NULL, &res, 0, 0, 0,
+                shared->nlm_v4.send_call_NLMPROC4_LOCK_RES(&shared->nlm_v4.rpc2, evpl, ctx->conn, NULL, &res, 0, 0, NULL
+                                                           , 0, 0,
                                                            NULL, NULL);
                 break;
             default:
@@ -809,7 +815,8 @@ chimera_nfs_nlm4_do_unlock(
         res.cookie.data = args->cookie.data;
         res.stat        = NLM4_GRANTED;
         if (proc == 18) {
-            shared->nlm_v4.send_call_NLMPROC4_UNLOCK_RES(&shared->nlm_v4.rpc2, evpl, conn, NULL, &res, 0, 0, 0, NULL,
+            shared->nlm_v4.send_call_NLMPROC4_UNLOCK_RES(&shared->nlm_v4.rpc2, evpl, conn, NULL, &res, 0, 0, NULL, 0, 0,
+                                                         NULL,
                                                          NULL);
         } else {
             rc = shared->nlm_v4.send_reply_NLMPROC4_UNLOCK(evpl, NULL, &res, encoding);
@@ -834,7 +841,8 @@ chimera_nfs_nlm4_do_unlock(
         res.cookie.data = args->cookie.data;
         res.stat        = NLM4_GRANTED;
         if (proc == 18) {
-            shared->nlm_v4.send_call_NLMPROC4_UNLOCK_RES(&shared->nlm_v4.rpc2, evpl, conn, NULL, &res, 0, 0, 0, NULL,
+            shared->nlm_v4.send_call_NLMPROC4_UNLOCK_RES(&shared->nlm_v4.rpc2, evpl, conn, NULL, &res, 0, 0, NULL, 0, 0,
+                                                         NULL,
                                                          NULL);
         } else {
             rc = shared->nlm_v4.send_reply_NLMPROC4_UNLOCK(evpl, NULL, &res, encoding);
@@ -869,7 +877,8 @@ chimera_nfs_nlm4_do_unlock(
     res.stat        = NLM4_GRANTED;
 
     if (proc == 18) {
-        shared->nlm_v4.send_call_NLMPROC4_UNLOCK_RES(&shared->nlm_v4.rpc2, evpl, conn, NULL, &res, 0, 0, 0, NULL,
+        shared->nlm_v4.send_call_NLMPROC4_UNLOCK_RES(&shared->nlm_v4.rpc2, evpl, conn, NULL, &res, 0, 0, NULL, 0, 0,
+                                                     NULL,
                                                      NULL);
     } else {
         rc = shared->nlm_v4.send_reply_NLMPROC4_UNLOCK(evpl, NULL, &res, encoding);
@@ -978,7 +987,8 @@ chimera_nfs_nlm4_cancel_msg(
     res.cookie.len  = args->cookie.len;
     res.cookie.data = args->cookie.data;
     res.stat        = NLM4_GRANTED;
-    shared->nlm_v4.send_call_NLMPROC4_CANCEL_RES(&shared->nlm_v4.rpc2, evpl, conn, NULL, &res, 0, 0, 0, NULL, NULL);
+    shared->nlm_v4.send_call_NLMPROC4_CANCEL_RES(&shared->nlm_v4.rpc2, evpl, conn, NULL, &res, 0, 0, NULL, 0, 0, NULL,
+                                                 NULL);
 } /* chimera_nfs_nlm4_cancel_msg */
 
 void

--- a/src/vfs/nfs/nfs3_close.c
+++ b/src/vfs/nfs/nfs3_close.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -85,7 +85,7 @@ chimera_nfs3_close_do_silly_remove(
 
     ctx->shared->nfs_v3.send_call_NFSPROC3_REMOVE(&ctx->shared->nfs_v3.rpc2, ctx->thread->evpl,
                                                   server_thread->nfs_conn, &rpc2_cred, &args,
-                                                  0, 0, 0,
+                                                  0, 0, NULL, 0, 0,
                                                   chimera_nfs3_close_remove_callback, request);
 } /* chimera_nfs3_close_do_silly_remove */
 
@@ -154,7 +154,7 @@ chimera_nfs3_close_do_commit(
 
     ctx->shared->nfs_v3.send_call_NFSPROC3_COMMIT(&ctx->shared->nfs_v3.rpc2, ctx->thread->evpl,
                                                   server_thread->nfs_conn, &rpc2_cred, &args,
-                                                  0, 0, 0,
+                                                  0, 0, NULL, 0, 0,
                                                   chimera_nfs3_close_commit_callback, request);
 } /* chimera_nfs3_close_do_commit */
 

--- a/src/vfs/nfs/nfs3_commit.c
+++ b/src/vfs/nfs/nfs3_commit.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -85,6 +85,6 @@ chimera_nfs3_commit(
                                request->thread->vfs->machine_name_len);
 
     shared->nfs_v3.send_call_NFSPROC3_COMMIT(&shared->nfs_v3.rpc2, thread->evpl, server_thread->nfs_conn, &rpc2_cred,
-                                             &args, 0, 0, 0, chimera_nfs3_commit_callback, request);
+                                             &args, 0, 0, NULL, 0, 0, chimera_nfs3_commit_callback, request);
 } /* chimera_nfs3_commit */
 

--- a/src/vfs/nfs/nfs3_getattr.c
+++ b/src/vfs/nfs/nfs3_getattr.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -64,7 +64,7 @@ chimera_nfs3_getattr(
                                request->thread->vfs->machine_name_len);
 
     shared->nfs_v3.send_call_NFSPROC3_GETATTR(&shared->nfs_v3.rpc2, thread->evpl, server_thread->nfs_conn, &rpc2_cred,
-                                              &args, 0, 0, 0, chimera_nfs3_getattr_callback, request);
+                                              &args, 0, 0, NULL, 0, 0, chimera_nfs3_getattr_callback, request);
 
 } /* chimera_nfs3_getattr */
 

--- a/src/vfs/nfs/nfs3_link_at.c
+++ b/src/vfs/nfs/nfs3_link_at.c
@@ -81,6 +81,6 @@ chimera_nfs3_link_at(
                                request->thread->vfs->machine_name_len);
 
     shared->nfs_v3.send_call_NFSPROC3_LINK(&shared->nfs_v3.rpc2, thread->evpl, server_thread->nfs_conn, &rpc2_cred,
-                                           &args, 0, 0, 0, chimera_nfs3_link_callback, request);
+                                           &args, 0, 0, NULL, 0, 0, chimera_nfs3_link_callback, request);
 } /* chimera_nfs3_link_at */
 

--- a/src/vfs/nfs/nfs3_lock.c
+++ b/src/vfs/nfs/nfs3_lock.c
@@ -163,7 +163,7 @@ chimera_nfs3_do_lock(
 
         shared->nlm_v4.send_call_NLMPROC4_UNLOCK(&shared->nlm_v4.rpc2, thread->evpl,
                                                  server_thread->nlm_conn, &rpc2_cred,
-                                                 &args, 0, 0, 0,
+                                                 &args, 0, 0, NULL, 0, 0,
                                                  chimera_nfs3_unlock_callback, request);
 
     } else if (request->lock.flags & CHIMERA_VFS_LOCK_TEST) {
@@ -185,7 +185,7 @@ chimera_nfs3_do_lock(
 
         shared->nlm_v4.send_call_NLMPROC4_TEST(&shared->nlm_v4.rpc2, thread->evpl,
                                                server_thread->nlm_conn, &rpc2_cred,
-                                               &args, 0, 0, 0,
+                                               &args, 0, 0, NULL, 0, 0,
                                                chimera_nfs3_test_callback, request);
 
     } else {
@@ -210,7 +210,7 @@ chimera_nfs3_do_lock(
 
         shared->nlm_v4.send_call_NLMPROC4_LOCK(&shared->nlm_v4.rpc2, thread->evpl,
                                                server_thread->nlm_conn, &rpc2_cred,
-                                               &args, 0, 0, 0,
+                                               &args, 0, 0, NULL, 0, 0,
                                                chimera_nfs3_lock_callback, request);
     }
 } /* chimera_nfs3_do_lock */
@@ -308,7 +308,7 @@ chimera_nfs3_lock(
 
         shared->nfs_v3.send_call_NFSPROC3_GETATTR(&shared->nfs_v3.rpc2, thread->evpl,
                                                   server_thread->nfs_conn, &rpc2_cred,
-                                                  &getattr_args, 0, 0, 0,
+                                                  &getattr_args, 0, 0, NULL, 0, 0,
                                                   chimera_nfs3_lock_getattr_callback, request);
     } else {
         chimera_nfs3_do_lock(thread, shared, server_thread, request);

--- a/src/vfs/nfs/nfs3_lookup_at.c
+++ b/src/vfs/nfs/nfs3_lookup_at.c
@@ -88,6 +88,6 @@ chimera_nfs3_lookup_at(
                                request->thread->vfs->machine_name_len);
 
     shared->nfs_v3.send_call_NFSPROC3_LOOKUP(&shared->nfs_v3.rpc2, thread->evpl, server_thread->nfs_conn, &rpc2_cred,
-                                             &args, 0, 0, 0, chimera_nfs3_lookup_callback, request);
+                                             &args, 0, 0, NULL, 0, 0, chimera_nfs3_lookup_callback, request);
 } /* chimera_nfs3_lookup_at */
 

--- a/src/vfs/nfs/nfs3_mkdir_at.c
+++ b/src/vfs/nfs/nfs3_mkdir_at.c
@@ -89,6 +89,6 @@ chimera_nfs3_mkdir_at(
                                request->thread->vfs->machine_name_len);
 
     shared->nfs_v3.send_call_NFSPROC3_MKDIR(&shared->nfs_v3.rpc2, thread->evpl, server_thread->nfs_conn, &rpc2_cred,
-                                            &args, 0, 0, 0, chimera_nfs3_mkdir_callback, request);
+                                            &args, 0, 0, NULL, 0, 0, chimera_nfs3_mkdir_callback, request);
 } /* chimera_nfs3_mkdir_at */
 

--- a/src/vfs/nfs/nfs3_mknod_at.c
+++ b/src/vfs/nfs/nfs3_mknod_at.c
@@ -116,5 +116,5 @@ chimera_nfs3_mknod_at(
                                request->thread->vfs->machine_name_len);
 
     shared->nfs_v3.send_call_NFSPROC3_MKNOD(&shared->nfs_v3.rpc2, thread->evpl, server_thread->nfs_conn, &rpc2_cred,
-                                            &args, 0, 0, 0, chimera_nfs3_mknod_callback, request);
+                                            &args, 0, 0, NULL, 0, 0, chimera_nfs3_mknod_callback, request);
 } /* chimera_nfs3_mknod_at */

--- a/src/vfs/nfs/nfs3_mount.c
+++ b/src/vfs/nfs/nfs3_mount.c
@@ -207,7 +207,7 @@ chimera_nfs3_mount_process_mount(
                                               server_thread->mount_conn,
                                               NULL,
                                               &mount_arg,
-                                              0, 0, 0,
+                                              0, 0, NULL, 0, 0,
                                               chimera_mount_mountd_mnt_callback, mount);
 }     /* chimera_nfs3_mount_process_mount */
 
@@ -289,7 +289,7 @@ chimera_nfs3_mount_nfs_null_callback(
                                                   server_thread->portmap_conn,
                                                   NULL,
                                                   &mapping,
-                                                  0, 0, 0,
+                                                  0, 0, NULL, 0, 0,
                                                   chimera_portmap_getport_nlm_callback, server_thread);
 } /* chimera_nfs3_mount_nfs_null_callback */
 
@@ -323,7 +323,7 @@ chimera_portmap_getport_nfs_callback(
                                            server_thread->thread->evpl,
                                            server_thread->nfs_conn,
                                            NULL,
-                                           0, 0, 0,
+                                           0, 0, NULL, 0, 0,
                                            chimera_nfs3_mount_nfs_null_callback, server_thread);
 
 } /* chimera_portmap_getport_nfs_callback */
@@ -360,7 +360,7 @@ chimera_mount_mountd_null_callback(
                                                server_thread->thread->evpl,
                                                server_thread->nfs_conn,
                                                NULL,
-                                               0, 0, 0,
+                                               0, 0, NULL, 0, 0,
                                                chimera_nfs3_mount_nfs_null_callback, server_thread);
     } else {
         /* For TCP, use portmap to discover NFS port */
@@ -374,7 +374,7 @@ chimera_mount_mountd_null_callback(
                                                       server_thread->portmap_conn,
                                                       NULL,
                                                       &mapping,
-                                                      0, 0, 0,
+                                                      0, 0, NULL, 0, 0,
                                                       chimera_portmap_getport_nfs_callback, server_thread);
     }
 } /* chimera_mount_mountd_null_callback */
@@ -409,7 +409,7 @@ chimera_portmap_getport_mountd_callback(
                                                server_thread->thread->evpl,
                                                server_thread->mount_conn,
                                                NULL,
-                                               0, 0, 0,
+                                               0, 0, NULL, 0, 0,
                                                chimera_mount_mountd_null_callback, server_thread);
 } /* chimera_portmap_getport_mountd_callback */
 
@@ -441,7 +441,7 @@ chimera_portmap_null_callback(
                                                   server_thread->portmap_conn,
                                                   NULL,
                                                   &mapping,
-                                                  0, 0, 0,
+                                                  0, 0, NULL, 0, 0,
                                                   chimera_portmap_getport_mountd_callback, server_thread);
 } /* chimera_portmap_null_callback */
 
@@ -575,7 +575,7 @@ chimera_nfs3_mount(
                                                    thread->evpl,
                                                    server_thread->portmap_conn,
                                                    NULL,
-                                                   0, 0, 0,
+                                                   0, 0, NULL, 0, 0,
                                                    chimera_portmap_null_callback, server_thread);
     }
 } /* chimera_nfs3_mount */

--- a/src/vfs/nfs/nfs3_open_at.c
+++ b/src/vfs/nfs/nfs3_open_at.c
@@ -181,7 +181,8 @@ chimera_nfs3_open_at(
 
         shared->nfs_v3.send_call_NFSPROC3_CREATE(&shared->nfs_v3.rpc2, thread->evpl, server_thread->nfs_conn, &rpc2_cred
                                                  ,
-                                                 &create_args, 0, 0, 0, chimera_nfs3_open_at_create_callback, request);
+                                                 &create_args, 0, 0, NULL, 0, 0, chimera_nfs3_open_at_create_callback,
+                                                 request);
     } else {
         chimera_nfs3_map_fh(request->fh, request->fh_len, &fh, &fhlen);
 
@@ -193,7 +194,7 @@ chimera_nfs3_open_at(
         shared->nfs_v3.send_call_NFSPROC3_LOOKUP(&shared->nfs_v3.rpc2, thread->evpl, server_thread->nfs_conn, &rpc2_cred
                                                  ,
                                                  &lookup_args,
-                                                 0, 0, 0,
+                                                 0, 0, NULL, 0, 0,
                                                  chimera_nfs3_open_at_lookup_callback, request);
 
     }

--- a/src/vfs/nfs/nfs3_read.c
+++ b/src/vfs/nfs/nfs3_read.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -75,6 +75,18 @@ chimera_nfs3_read(
     chimera_nfs_init_rpc2_cred(&rpc2_cred, request->cred,
                                request->thread->vfs->machine_name,
                                request->thread->vfs->machine_name_len);
+
+    /* read_into over RDMA: have the server RDMA-write the reply data straight
+     * into the caller's destination buffer (the RPC write chunk) instead of an
+     * internally allocated one, and tell the VFS core the data landed in dest so
+     * it skips the copy.  Single-iovec dest only; otherwise fall back to copy. */
+    if (server_thread->nfs_conn->rdma && request->read.dest_provided &&
+        request->read.dest_niov == 1) {
+        evpl_rpc2_conn_set_write_chunk_dest(server_thread->nfs_conn,
+                                            request->read.dest_iov,
+                                            request->read.dest_niov);
+        request->read.landed_in_dest = 1;
+    }
 
     shared->nfs_v3.send_call_NFSPROC3_READ(&shared->nfs_v3.rpc2, thread->evpl, server_thread->nfs_conn, &rpc2_cred,
                                            &args, 0, request->read.length, 0, chimera_nfs3_read_callback, request);

--- a/src/vfs/nfs/nfs3_read.c
+++ b/src/vfs/nfs/nfs3_read.c
@@ -79,16 +79,20 @@ chimera_nfs3_read(
     /* read_into over RDMA: have the server RDMA-write the reply data straight
      * into the caller's destination buffer (the RPC write chunk) instead of an
      * internally allocated one, and tell the VFS core the data landed in dest so
-     * it skips the copy.  Single-iovec dest only; otherwise fall back to copy. */
+     * it skips the copy.  Single-iovec dest only; otherwise fall back to copy
+     * (write_chunk_iov NULL -> libevpl allocates the chunk). */
+    struct evpl_iovec *write_chunk_iov  = NULL;
+    int                write_chunk_niov = 0;
+
     if (server_thread->nfs_conn->rdma && request->read.dest_provided &&
         request->read.dest_niov == 1) {
-        evpl_rpc2_conn_set_write_chunk_dest(server_thread->nfs_conn,
-                                            request->read.dest_iov,
-                                            request->read.dest_niov);
+        write_chunk_iov              = request->read.dest_iov;
+        write_chunk_niov             = request->read.dest_niov;
         request->read.landed_in_dest = 1;
     }
 
     shared->nfs_v3.send_call_NFSPROC3_READ(&shared->nfs_v3.rpc2, thread->evpl, server_thread->nfs_conn, &rpc2_cred,
-                                           &args, 0, request->read.length, 0, chimera_nfs3_read_callback, request);
+                                           &args, 0, request->read.length, write_chunk_iov, write_chunk_niov, 0,
+                                           chimera_nfs3_read_callback, request);
 } /* chimera_nfs3_read */
 

--- a/src/vfs/nfs/nfs3_readdir.c
+++ b/src/vfs/nfs/nfs3_readdir.c
@@ -128,6 +128,6 @@ chimera_nfs3_readdir(
 
     shared->nfs_v3.send_call_NFSPROC3_READDIRPLUS(&shared->nfs_v3.rpc2, thread->evpl, server_thread->nfs_conn, &
                                                   rpc2_cred,
-                                                  &args, 0, 0, 0, chimera_nfs3_readdir_callback, request);
+                                                  &args, 0, 0, NULL, 0, 0, chimera_nfs3_readdir_callback, request);
 } /* chimera_nfs3_readdir */
 

--- a/src/vfs/nfs/nfs3_readlink.c
+++ b/src/vfs/nfs/nfs3_readlink.c
@@ -74,6 +74,6 @@ chimera_nfs3_readlink(
                                request->thread->vfs->machine_name_len);
 
     shared->nfs_v3.send_call_NFSPROC3_READLINK(&shared->nfs_v3.rpc2, thread->evpl, server_thread->nfs_conn, &rpc2_cred,
-                                               &args, 0, 0, 0, chimera_nfs3_readlink_callback, request);
+                                               &args, 0, 0, NULL, 0, 0, chimera_nfs3_readlink_callback, request);
 } /* chimera_nfs3_readlink */
 

--- a/src/vfs/nfs/nfs3_remove_at.c
+++ b/src/vfs/nfs/nfs3_remove_at.c
@@ -129,7 +129,7 @@ chimera_nfs3_remove_do_silly_rename(
 
     ctx->shared->nfs_v3.send_call_NFSPROC3_RENAME(&ctx->shared->nfs_v3.rpc2, ctx->thread->evpl,
                                                   server_thread->nfs_conn, &rpc2_cred, &args,
-                                                  0, 0, 0,
+                                                  0, 0, NULL, 0, 0,
                                                   chimera_nfs3_remove_rename_callback, request);
 } /* chimera_nfs3_remove_do_silly_rename */
 
@@ -165,7 +165,7 @@ chimera_nfs3_remove_do_remove(
 
     ctx->shared->nfs_v3.send_call_NFSPROC3_REMOVE(&ctx->shared->nfs_v3.rpc2, ctx->thread->evpl,
                                                   server_thread->nfs_conn, &rpc2_cred, &args,
-                                                  0, 0, 0,
+                                                  0, 0, NULL, 0, 0,
                                                   chimera_nfs3_remove_callback, request);
 } /* chimera_nfs3_remove_do_remove */
 

--- a/src/vfs/nfs/nfs3_rename_at.c
+++ b/src/vfs/nfs/nfs3_rename_at.c
@@ -94,7 +94,7 @@ chimera_nfs3_rename_do_rename(
 
     ctx->shared->nfs_v3.send_call_NFSPROC3_RENAME(&ctx->shared->nfs_v3.rpc2, ctx->thread->evpl,
                                                   server_thread->nfs_conn, &rpc2_cred, &args,
-                                                  0, 0, 0,
+                                                  0, 0, NULL, 0, 0,
                                                   chimera_nfs3_rename_callback, request);
 } /* chimera_nfs3_rename_do_rename */
 
@@ -164,7 +164,7 @@ chimera_nfs3_rename_do_silly_link(
 
     ctx->shared->nfs_v3.send_call_NFSPROC3_LINK(&ctx->shared->nfs_v3.rpc2, ctx->thread->evpl,
                                                 server_thread->nfs_conn, &rpc2_cred, &args,
-                                                0, 0, 0,
+                                                0, 0, NULL, 0, 0,
                                                 chimera_nfs3_rename_link_callback, request);
 } /* chimera_nfs3_rename_do_silly_link */
 

--- a/src/vfs/nfs/nfs3_setattr.c
+++ b/src/vfs/nfs/nfs3_setattr.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -71,6 +71,6 @@ chimera_nfs3_setattr(
                                request->thread->vfs->machine_name_len);
 
     shared->nfs_v3.send_call_NFSPROC3_SETATTR(&shared->nfs_v3.rpc2, thread->evpl, server_thread->nfs_conn, &rpc2_cred,
-                                              &args, 0, 0, 0, chimera_nfs3_setattr_callback, request);
+                                              &args, 0, 0, NULL, 0, 0, chimera_nfs3_setattr_callback, request);
 } /* chimera_nfs3_setattr */
 

--- a/src/vfs/nfs/nfs3_symlink_at.c
+++ b/src/vfs/nfs/nfs3_symlink_at.c
@@ -96,7 +96,7 @@ chimera_nfs3_symlink_at(
                                request->thread->vfs->machine_name_len);
 
     shared->nfs_v3.send_call_NFSPROC3_SYMLINK(&shared->nfs_v3.rpc2, thread->evpl, server_thread->nfs_conn, &rpc2_cred,
-                                              &args, 0, 0, 0,
+                                              &args, 0, 0, NULL, 0, 0,
                                               chimera_nfs3_symlink_callback, request);
 } /* chimera_nfs3_symlink_at */
 

--- a/src/vfs/nfs/nfs3_write.c
+++ b/src/vfs/nfs/nfs3_write.c
@@ -93,5 +93,5 @@ chimera_nfs3_write(
                                request->thread->vfs->machine_name_len);
 
     shared->nfs_v3.send_call_NFSPROC3_WRITE(&shared->nfs_v3.rpc2, thread->evpl, server_thread->nfs_conn, &rpc2_cred,
-                                            &args, 1, 0, 0, chimera_nfs3_write_callback, request);
+                                            &args, 1, 0, NULL, 0, 0, chimera_nfs3_write_callback, request);
 } /* chimera_nfs3_write */

--- a/src/vfs/nfs/nfs4_getattr.c
+++ b/src/vfs/nfs/nfs4_getattr.c
@@ -136,7 +136,7 @@ chimera_nfs4_getattr(
         server_thread->nfs_conn,
         &rpc2_cred,
         &args,
-        0, 0, 0,
+        0, 0, NULL, 0, 0,
         chimera_nfs4_getattr_callback,
         request);
 } /* chimera_nfs4_getattr */

--- a/src/vfs/nfs/nfs4_link_at.c
+++ b/src/vfs/nfs/nfs4_link_at.c
@@ -166,7 +166,7 @@ chimera_nfs4_link_at(
         server_thread->nfs_conn,
         &rpc2_cred,
         &args,
-        0, 0, 0,
+        0, 0, NULL, 0, 0,
         chimera_nfs4_link_callback,
         request);
 } /* chimera_nfs4_link_at */

--- a/src/vfs/nfs/nfs4_lookup_at.c
+++ b/src/vfs/nfs/nfs4_lookup_at.c
@@ -235,7 +235,7 @@ chimera_nfs4_lookup_at(
         server_thread->nfs_conn,
         &rpc2_cred,
         &args,
-        0, 0, 0,
+        0, 0, NULL, 0, 0,
         chimera_nfs4_lookup_callback,
         request);
 } /* chimera_nfs4_lookup_at */

--- a/src/vfs/nfs/nfs4_mkdir_at.c
+++ b/src/vfs/nfs/nfs4_mkdir_at.c
@@ -186,7 +186,7 @@ chimera_nfs4_mkdir_at(
         server_thread->nfs_conn,
         &rpc2_cred,
         &args,
-        0, 0, 0,
+        0, 0, NULL, 0, 0,
         chimera_nfs4_mkdir_callback,
         request);
 } /* chimera_nfs4_mkdir_at */

--- a/src/vfs/nfs/nfs4_mount.c
+++ b/src/vfs/nfs/nfs4_mount.c
@@ -255,7 +255,7 @@ chimera_nfs4_mount_get_root_fh(
         server_thread->nfs_conn,
         NULL,
         &args,
-        0, 0, 0,
+        0, 0, NULL, 0, 0,
         chimera_nfs4_mount_get_root_fh_callback,
         request);
 } /* chimera_nfs4_mount_get_root_fh */
@@ -338,7 +338,7 @@ chimera_nfs4_mount_reclaim_complete(
         server_thread->nfs_conn,
         NULL,
         &args,
-        0, 0, 0,
+        0, 0, NULL, 0, 0,
         chimera_nfs4_mount_reclaim_complete_callback,
         request);
 } /* chimera_nfs4_mount_reclaim_complete */
@@ -468,7 +468,7 @@ chimera_nfs4_mount_create_session(
         server_thread->nfs_conn,
         NULL,
         &args,
-        0, 0, 0,
+        0, 0, NULL, 0, 0,
         chimera_nfs4_mount_create_session_callback,
         request);
 } /* chimera_nfs4_mount_create_session */
@@ -578,7 +578,7 @@ chimera_nfs4_mount_exchange_id(
         server_thread->nfs_conn,
         NULL,
         &args,
-        0, 0, 0,
+        0, 0, NULL, 0, 0,
         chimera_nfs4_mount_exchange_id_callback,
         request);
 } /* chimera_nfs4_mount_exchange_id */
@@ -814,7 +814,7 @@ chimera_nfs4_mount(
             thread->evpl,
             server_thread->nfs_conn,
             NULL,
-            0, 0, 0,
+            0, 0, NULL, 0, 0,
             chimera_nfs4_mount_null_callback,
             request);
     } else {

--- a/src/vfs/nfs/nfs4_open_at.c
+++ b/src/vfs/nfs/nfs4_open_at.c
@@ -243,7 +243,7 @@ chimera_nfs4_open_at(
         server_thread->nfs_conn,
         &rpc2_cred,
         &args,
-        0, 0, 0,
+        0, 0, NULL, 0, 0,
         chimera_nfs4_open_at_callback,
         request);
 } /* chimera_nfs4_open_at */

--- a/src/vfs/nfs/nfs4_read.c
+++ b/src/vfs/nfs/nfs4_read.c
@@ -155,12 +155,15 @@ chimera_nfs4_read(
      * destination buffer (the COMPOUND's RDMA write chunk) and tell the VFS core
      * to skip the copy.  The write chunk carries the READ4resok data field the
      * same way as the internally-allocated chunk; only the buffer source
-     * changes.  Single-iovec dest only; otherwise fall back to copy. */
+     * changes.  Single-iovec dest only; otherwise fall back to copy
+     * (write_chunk_iov NULL -> libevpl allocates the chunk). */
+    struct evpl_iovec *write_chunk_iov  = NULL;
+    int                write_chunk_niov = 0;
+
     if (server_thread->nfs_conn->rdma && request->read.dest_provided &&
         request->read.dest_niov == 1) {
-        evpl_rpc2_conn_set_write_chunk_dest(server_thread->nfs_conn,
-                                            request->read.dest_iov,
-                                            request->read.dest_niov);
+        write_chunk_iov              = request->read.dest_iov;
+        write_chunk_niov             = request->read.dest_niov;
         request->read.landed_in_dest = 1;
     }
 
@@ -170,7 +173,7 @@ chimera_nfs4_read(
         server_thread->nfs_conn,
         &rpc2_cred,
         &args,
-        0, request->read.length, 0,
+        0, request->read.length, write_chunk_iov, write_chunk_niov, 0,
         chimera_nfs4_read_callback,
         request);
 } /* chimera_nfs4_read */

--- a/src/vfs/nfs/nfs4_read.c
+++ b/src/vfs/nfs/nfs4_read.c
@@ -151,6 +151,19 @@ chimera_nfs4_read(
                                request->thread->vfs->machine_name,
                                request->thread->vfs->machine_name_len);
 
+    /* read_into over RDMA: land the READ reply data directly in the caller's
+     * destination buffer (the COMPOUND's RDMA write chunk) and tell the VFS core
+     * to skip the copy.  The write chunk carries the READ4resok data field the
+     * same way as the internally-allocated chunk; only the buffer source
+     * changes.  Single-iovec dest only; otherwise fall back to copy. */
+    if (server_thread->nfs_conn->rdma && request->read.dest_provided &&
+        request->read.dest_niov == 1) {
+        evpl_rpc2_conn_set_write_chunk_dest(server_thread->nfs_conn,
+                                            request->read.dest_iov,
+                                            request->read.dest_niov);
+        request->read.landed_in_dest = 1;
+    }
+
     shared->nfs_v4.send_call_NFSPROC4_COMPOUND(
         &shared->nfs_v4.rpc2,
         thread->evpl,

--- a/src/vfs/nfs/nfs4_readdir.c
+++ b/src/vfs/nfs/nfs4_readdir.c
@@ -384,7 +384,7 @@ chimera_nfs4_readdir(
         server_thread->nfs_conn,
         &rpc2_cred,
         &args,
-        0, 0, 0,
+        0, 0, NULL, 0, 0,
         chimera_nfs4_readdir_callback,
         request);
 } /* chimera_nfs4_readdir */

--- a/src/vfs/nfs/nfs4_readlink.c
+++ b/src/vfs/nfs/nfs4_readlink.c
@@ -136,7 +136,7 @@ chimera_nfs4_readlink(
         server_thread->nfs_conn,
         &rpc2_cred,
         &args,
-        0, 0, 0,
+        0, 0, NULL, 0, 0,
         chimera_nfs4_readlink_callback,
         request);
 } /* chimera_nfs4_readlink */ /* chimera_nfs4_readlink */

--- a/src/vfs/nfs/nfs4_remove_at.c
+++ b/src/vfs/nfs/nfs4_remove_at.c
@@ -138,7 +138,7 @@ chimera_nfs4_remove_at(
         server_thread->nfs_conn,
         &rpc2_cred,
         &args,
-        0, 0, 0,
+        0, 0, NULL, 0, 0,
         chimera_nfs4_remove_callback,
         request);
 } /* chimera_nfs4_remove_at */

--- a/src/vfs/nfs/nfs4_rename_at.c
+++ b/src/vfs/nfs/nfs4_rename_at.c
@@ -168,7 +168,7 @@ chimera_nfs4_rename_at(
         server_thread->nfs_conn,
         &rpc2_cred,
         &args,
-        0, 0, 0,
+        0, 0, NULL, 0, 0,
         chimera_nfs4_rename_callback,
         request);
 } /* chimera_nfs4_rename_at */

--- a/src/vfs/nfs/nfs4_setattr.c
+++ b/src/vfs/nfs/nfs4_setattr.c
@@ -227,7 +227,7 @@ chimera_nfs4_setattr(
         server_thread->nfs_conn,
         &rpc2_cred,
         &args,
-        0, 0, 0,
+        0, 0, NULL, 0, 0,
         chimera_nfs4_setattr_callback,
         request);
 } /* chimera_nfs4_setattr */ /* chimera_nfs4_setattr */

--- a/src/vfs/nfs/nfs4_symlink_at.c
+++ b/src/vfs/nfs/nfs4_symlink_at.c
@@ -190,7 +190,7 @@ chimera_nfs4_symlink_at(
         server_thread->nfs_conn,
         &rpc2_cred,
         &args,
-        0, 0, 0,
+        0, 0, NULL, 0, 0,
         chimera_nfs4_symlink_callback,
         request);
 } /* chimera_nfs4_symlink_at */

--- a/src/vfs/nfs/nfs4_write.c
+++ b/src/vfs/nfs/nfs4_write.c
@@ -164,7 +164,7 @@ chimera_nfs4_write(
         server_thread->nfs_conn,
         &rpc2_cred,
         &args,
-        1, 0, 0,
+        1, 0, NULL, 0, 0,
         chimera_nfs4_write_callback,
         request);
 } /* chimera_nfs4_write */

--- a/src/vfs/vfs.h
+++ b/src/vfs/vfs.h
@@ -722,6 +722,17 @@ struct chimera_vfs_request {
              * prefix/tail and sets r_niov in chimera_vfs_read_complete(). */
             int                             buffers_provided;
             uint32_t                        aligned_prefix;
+            /* read_into: the caller supplied its own destination buffers
+             * (dest_iov/dest_niov) and wants the data landed there.  iov/niov
+             * above are the scratch the core/backend works in.  On completion
+             * the VFS core scatter-copies the result into dest_iov -- unless a
+             * backend was able to land the data directly in dest (e.g. the NFS
+             * proxy used dest as the RDMA write chunk), in which case it sets
+             * landed_in_dest and the core skips the copy. */
+            struct evpl_iovec              *dest_iov;
+            int                             dest_niov;
+            int                             dest_provided;
+            int                             landed_in_dest;
         } read;
 
         struct {

--- a/src/vfs/vfs_proc_read.c
+++ b/src/vfs/vfs_proc_read.c
@@ -62,6 +62,47 @@ chimera_vfs_read_finalize_buffers(struct chimera_vfs_request *request)
     request->read.r_niov = provided;
 } /* chimera_vfs_read_finalize_buffers */
 
+/* Scatter-copy up to `length` bytes from a source iovec vector into a
+ * destination iovec vector (used by read_into when a backend could not land the
+ * data directly in the caller's buffers). */
+static void
+chimera_vfs_read_iovec_copy(
+    struct evpl_iovec *dst,
+    int                dst_niov,
+    struct evpl_iovec *src,
+    int                src_niov,
+    uint32_t           length)
+{
+    int      di = 0, si = 0;
+    uint32_t doff = 0, soff = 0, copied = 0;
+
+    while (copied < length && di < dst_niov && si < src_niov) {
+        uint32_t davail = dst[di].length - doff;
+        uint32_t savail = src[si].length - soff;
+        uint32_t chunk  = davail < savail ? davail : savail;
+
+        if (chunk > length - copied) {
+            chunk = length - copied;
+        }
+
+        if (chunk) {
+            memcpy((char *) dst[di].data + doff, (char *) src[si].data + soff, chunk);
+            doff   += chunk;
+            soff   += chunk;
+            copied += chunk;
+        }
+
+        if (doff == dst[di].length) {
+            di++;
+            doff = 0;
+        }
+        if (soff == src[si].length) {
+            si++;
+            soff = 0;
+        }
+    }
+} /* chimera_vfs_read_iovec_copy */
+
 static void
 chimera_vfs_read_complete(struct chimera_vfs_request *request)
 {
@@ -84,6 +125,26 @@ chimera_vfs_read_complete(struct chimera_vfs_request *request)
             request->read.r_niov   = 0;
             request->read.r_length = 0;
         }
+    }
+
+    /* read_into: the caller wants the data in its own destination buffers.
+     * Unless a backend already landed it there (landed_in_dest), copy the
+     * result out of the scratch/backend buffers into dest and release those
+     * source buffers on the caller's behalf (read_into has no reply path that
+     * would otherwise consume and release them).  The caller owns dest and
+     * releases it itself, so the callback hands dest back as iov/niov. */
+    if (request->read.dest_provided) {
+        if (request->status == CHIMERA_VFS_OK && !request->read.landed_in_dest) {
+            chimera_vfs_read_iovec_copy(request->read.dest_iov,
+                                        request->read.dest_niov,
+                                        request->read.iov,
+                                        request->read.r_niov,
+                                        request->read.r_length);
+            evpl_iovecs_release(request->thread->evpl, request->read.iov,
+                                request->read.r_niov);
+        }
+        request->read.iov    = request->read.dest_iov;
+        request->read.r_niov = request->read.dest_niov;
     }
 
     /* Only refresh the attr cache when the caller actually requested stat
@@ -124,6 +185,8 @@ chimera_vfs_read_dispatch(
     uint32_t                              count,
     struct evpl_iovec                    *iov,
     int                                   niov,
+    struct evpl_iovec                    *dest_iov,
+    int                                   dest_niov,
     uint64_t                              attr_mask,
     const struct chimera_vfs_lease_owner *io_owner,
     chimera_vfs_read_callback_t           callback,
@@ -154,6 +217,10 @@ chimera_vfs_read_dispatch(
     request->read.r_attr.va_set_mask = 0;
     request->read.buffers_provided   = 0;
     request->read.aligned_prefix     = 0;
+    request->read.dest_iov           = dest_iov;
+    request->read.dest_niov          = dest_niov;
+    request->read.dest_provided      = (dest_iov != NULL);
+    request->read.landed_in_dest     = 0;
     request->proto_callback          = callback;
     request->proto_private_data      = private_data;
 
@@ -198,6 +265,8 @@ struct chimera_vfs_read_gate {
     uint32_t                              count;
     struct evpl_iovec                    *iov;
     int                                   niov;
+    struct evpl_iovec                    *dest_iov;
+    int                                   dest_niov;
     uint64_t                              attr_mask;
     const struct chimera_vfs_lease_owner *io_owner;
     chimera_vfs_read_callback_t           callback;
@@ -230,13 +299,17 @@ chimera_vfs_read_gate_complete(
 
     chimera_vfs_read_dispatch(gate->thread, gate->cred, gate->handle,
                               gate->offset, gate->count, gate->iov, gate->niov,
+                              gate->dest_iov, gate->dest_niov,
                               gate->attr_mask, gate->io_owner, gate->callback,
                               gate->private_data);
     free(gate);
 } /* chimera_vfs_read_gate_complete */
 
-SYMBOL_EXPORT void
-chimera_vfs_read_owned(
+/* Common path for chimera_vfs_read{,_owned,_into}: mediate the read through the
+ * optional ACL gate, then dispatch.  dest_iov is NULL for the plain reads and
+ * the caller's destination for read_into. */
+static void
+chimera_vfs_read_submit(
     struct chimera_vfs_thread            *thread,
     const struct chimera_vfs_cred        *cred,
     struct chimera_vfs_open_handle       *handle,
@@ -244,6 +317,8 @@ chimera_vfs_read_owned(
     uint32_t                              count,
     struct evpl_iovec                    *iov,
     int                                   niov,
+    struct evpl_iovec                    *dest_iov,
+    int                                   dest_niov,
     uint64_t                              attr_mask,
     const struct chimera_vfs_lease_owner *io_owner,
     chimera_vfs_read_callback_t           callback,
@@ -269,6 +344,8 @@ chimera_vfs_read_owned(
             gate->count        = count;
             gate->iov          = iov;
             gate->niov         = niov;
+            gate->dest_iov     = dest_iov;
+            gate->dest_niov    = dest_niov;
             gate->attr_mask    = attr_mask;
             gate->io_owner     = io_owner;
             gate->callback     = callback;
@@ -282,7 +359,26 @@ chimera_vfs_read_owned(
     }
 
     chimera_vfs_read_dispatch(thread, cred, handle, offset, count, iov, niov,
-                              attr_mask, io_owner, callback, private_data);
+                              dest_iov, dest_niov, attr_mask, io_owner, callback,
+                              private_data);
+} /* chimera_vfs_read_submit */
+
+SYMBOL_EXPORT void
+chimera_vfs_read_owned(
+    struct chimera_vfs_thread            *thread,
+    const struct chimera_vfs_cred        *cred,
+    struct chimera_vfs_open_handle       *handle,
+    uint64_t                              offset,
+    uint32_t                              count,
+    struct evpl_iovec                    *iov,
+    int                                   niov,
+    uint64_t                              attr_mask,
+    const struct chimera_vfs_lease_owner *io_owner,
+    chimera_vfs_read_callback_t           callback,
+    void                                 *private_data)
+{
+    chimera_vfs_read_submit(thread, cred, handle, offset, count, iov, niov,
+                            NULL, 0, attr_mask, io_owner, callback, private_data);
 } /* chimera_vfs_read_owned */
 
 SYMBOL_EXPORT void
@@ -298,6 +394,26 @@ chimera_vfs_read(
     chimera_vfs_read_callback_t     callback,
     void                           *private_data)
 {
-    chimera_vfs_read_owned(thread, cred, handle, offset, count, iov, niov,
-                           attr_mask, NULL, callback, private_data);
+    chimera_vfs_read_submit(thread, cred, handle, offset, count, iov, niov,
+                            NULL, 0, attr_mask, NULL, callback, private_data);
 } /* chimera_vfs_read */
+
+SYMBOL_EXPORT void
+chimera_vfs_read_into(
+    struct chimera_vfs_thread      *thread,
+    const struct chimera_vfs_cred  *cred,
+    struct chimera_vfs_open_handle *handle,
+    uint64_t                        offset,
+    uint32_t                        count,
+    struct evpl_iovec              *work_iov,
+    int                             work_niov,
+    struct evpl_iovec              *dest_iov,
+    int                             dest_niov,
+    uint64_t                        attr_mask,
+    chimera_vfs_read_callback_t     callback,
+    void                           *private_data)
+{
+    chimera_vfs_read_submit(thread, cred, handle, offset, count,
+                            work_iov, work_niov, dest_iov, dest_niov,
+                            attr_mask, NULL, callback, private_data);
+} /* chimera_vfs_read_into */

--- a/src/vfs/vfs_procs.h
+++ b/src/vfs/vfs_procs.h
@@ -457,6 +457,28 @@ chimera_vfs_read_owned(
     chimera_vfs_read_callback_t           callback,
     void                                 *private_data);
 
+/* As chimera_vfs_read(), but the caller supplies its own destination buffers
+ * (dest_iov/dest_niov) for the data to land in.  work_iov/work_niov is scratch
+ * the core/backend reads through; on completion the data is guaranteed to be in
+ * dest_iov (zero-copy where a backend can land it there directly, a scatter-
+ * copy otherwise).  The caller retains ownership of dest_iov (borrow): it must
+ * keep the buffers alive until the callback and release them afterwards.  The
+ * callback's iov/niov reference dest_iov. */
+void
+chimera_vfs_read_into(
+    struct chimera_vfs_thread      *thread,
+    const struct chimera_vfs_cred  *cred,
+    struct chimera_vfs_open_handle *handle,
+    uint64_t                        offset,
+    uint32_t                        count,
+    struct evpl_iovec              *work_iov,
+    int                             work_niov,
+    struct evpl_iovec              *dest_iov,
+    int                             dest_niov,
+    uint64_t                        attrmask,
+    chimera_vfs_read_callback_t     callback,
+    void                           *private_data);
+
 typedef void (*chimera_vfs_write_callback_t)(
     enum chimera_vfs_error    error_code,
     uint32_t                  length,


### PR DESCRIPTION
## What

Phase 2 of `read_into` — the RDMA zero-copy payoff. When a read carries caller-provided destination buffers (`chimera_vfs_read_into`, from #603) and the upstream NFS connection is RDMA, the NFS client arms the READ's RPC **write chunk** to *be* the caller's buffer (`evpl_rpc2_conn_set_write_chunk_dest`), so the server RDMA-writes the reply data straight into it — **no copy** — and sets `read.landed_in_dest` so the VFS core skips its scatter-copy fallback.

- `nfs3_read.c` (NFS3 READ) and `nfs4_read.c` (NFS4 READ COMPOUND) both arm it. The write chunk carries the READ data field exactly as the internally-allocated chunk did; only the buffer source changes.
- Single-iovec dest only; **TCP and multi-iovec dest fall back to the Phase-1 copy** (correct, just not zero-copy).

End to end: `fio` (NFS3-RDMA) → `chimera_read_into` (#603) → VFS core → NFS client arms the write chunk → server RDMA-writes into fio's `xfer_buf`. No per-read copy anywhere on the read path.

## Submodule

Bumps libevpl to the `rpc2-write-chunk-dest` branch tip for `evpl_rpc2_conn_set_write_chunk_dest()`. **Re-bump to libevpl `main` after chimera-nas/libevpl#85 merges.**

## Dependencies / stacking

- Depends on **#603** (read_into Phase 1) and **chimera-nas/libevpl#85**.
- Stacked on the #603 branch — until #603 merges, this PR's diff also shows the Phase-1 commit. It shrinks to just the NFS changes + submodule bump once #603 lands.

## Validation

libevpl#85 adds a `rdma_ddp` `read_into` case proving the server RDMA-writes into the exact armed buffer (zero-copy) over the software-RDMA emulation. The chimera RDMA path itself needs a live RDMA rig — author validation on node-3: the `fio` NFS3-RDMA read job should show correct data (`verify=crc32c`) with the old per-read copy gone from `perf`, and throughput/CPU improved vs the Phase-1 copy path. Builds clean; Phase-1 memfs copy path (the `client_read_into` test) still green.