### PR TITLE
smb2: finish CHANGE_NOTIFY semantics and add change_notify_disabled

### DIFF
--- a/src/server/server.c
+++ b/src/server/server.c
@@ -72,6 +72,7 @@ struct chimera_server_config {
     int                                   smb_named_streams;
     int                                   smb_signing_required;
     int                                   smb_encryption;
+    int                                   smb_notify_disabled;
     int                                   smb_num_nic_info;
     uint32_t                              anonuid;
     uint32_t                              anongid;
@@ -162,6 +163,10 @@ chimera_server_config_init(void)
     /* SMB3 transport encryption is off by default; the "smb_encryption" config
      * flag enables (1) or requires (2) it. */
     config->smb_encryption = 0;
+
+    /* CHANGE_NOTIFY is enabled by default; the "smb_notify_disabled" flag makes
+     * the server reject CHANGE_NOTIFY with STATUS_NOT_IMPLEMENTED. */
+    config->smb_notify_disabled = 0;
 
     // SMB auth config defaults - local NTLM only
     config->smb_auth.winbind_enabled    = 0;
@@ -328,6 +333,20 @@ chimera_server_config_get_smb_encryption(const struct chimera_server_config *con
 {
     return config->smb_encryption;
 } /* chimera_server_config_get_smb_encryption */
+
+SYMBOL_EXPORT void
+chimera_server_config_set_smb_notify_disabled(
+    struct chimera_server_config *config,
+    int                           disabled)
+{
+    config->smb_notify_disabled = disabled;
+} /* chimera_server_config_set_smb_notify_disabled */
+
+SYMBOL_EXPORT int
+chimera_server_config_get_smb_notify_disabled(const struct chimera_server_config *config)
+{
+    return config->smb_notify_disabled;
+} /* chimera_server_config_get_smb_notify_disabled */
 
 SYMBOL_EXPORT void
 chimera_server_config_set_max_open_files(

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -111,6 +111,15 @@ chimera_server_config_get_smb_encryption(
     const struct chimera_server_config *config);
 
 void
+chimera_server_config_set_smb_notify_disabled(
+    struct chimera_server_config *config,
+    int                           disabled);
+
+int
+chimera_server_config_get_smb_notify_disabled(
+    const struct chimera_server_config *config);
+
+void
 chimera_server_config_set_cache_ttl(
     struct chimera_server_config *config,
     int                           ttl);

--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -148,6 +148,7 @@ chimera_smb_server_init(
     shared->config.named_streams      = chimera_server_config_get_smb_named_streams(config);
     shared->config.signing_required   = chimera_server_config_get_smb_signing_required(config);
     shared->config.encryption         = chimera_server_config_get_smb_encryption(config);
+    shared->config.notify_disabled    = chimera_server_config_get_smb_notify_disabled(config);
 
     if (shared->config.persistent_handles) {
         chimera_smb_info("SMB3 durable/persistent handles enabled (in-memory state)");

--- a/src/server/smb/smb2.h
+++ b/src/server/smb/smb2.h
@@ -673,6 +673,9 @@ typedef uint8_t smb2_guid[SMB2_GUID_SIZE];
 #define SMB2_ENCRYPTION_AES_256_CCM                 0x0003
 #define SMB2_ENCRYPTION_AES_256_GCM                 0x0004
 
+/* SMB2 SESSION_SETUP request Flags (MS-SMB2 §2.2.5) */
+#define SMB2_SESSION_FLAG_BINDING                   0x01
+
 /* SMB2 SESSION_SETUP response SessionFlags (MS-SMB2 §2.2.6) */
 #define SMB2_SESSION_FLAG_IS_GUEST                  0x0001
 #define SMB2_SESSION_FLAG_IS_NULL                   0x0002

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -26,6 +26,7 @@
 #include "smb_ntlm.h"
 #include "smb_gssapi.h"
 #include "smb_sharemode.h"
+#include "smb_notify.h"
 #include "vfs/vfs_acl.h"
 #include "vfs/vfs_idmap.h"
 #include "vfs/vfs_release.h"
@@ -125,6 +126,11 @@ struct chimera_smb_config {
     /* SMB3 transport encryption policy: 0 = off (no encryption advertised),
      * 1 = enabled (offered, used when the client opts in), 2 = required. */
     int                            encryption;
+    /* When set, CHANGE_NOTIFY is disabled for the server's shares: the
+     * handler returns STATUS_NOT_IMPLEMENTED immediately instead of arming
+     * a watch (the "change notify = no" share behaviour Windows exposes;
+     * smb2.change_notify_disabled expects this). */
+    int                            notify_disabled;
     uint32_t                       capabilities;
     uint32_t                       dialects[16];
     struct chimera_smb_nic_info    nic_info[16];
@@ -1482,8 +1488,10 @@ chimera_smb_tree_free(
     struct chimera_smb_tree          *tree,
     bool                              preserve_durable)
 {
-    struct chimera_smb_open_file *open_file, *tmp;
-    int                           i;
+    struct chimera_smb_open_file    *open_file, *tmp;
+    struct chimera_smb_notify_state *gc_states = NULL;
+    struct chimera_smb_notify_state *nstate;
+    int                              i;
 
     for (i = 0; i < CHIMERA_SMB_OPEN_FILE_BUCKETS; i++) {
 
@@ -1519,6 +1527,22 @@ chimera_smb_tree_free(
                 continue;
             }
 
+            /* Detach any CHANGE_NOTIFY watch/parked request from this open and
+             * defer its teardown until after the bucket lock is dropped:
+             * completing a parked request releases the open_file reference it
+             * holds, which re-takes this same bucket lock.  A parked request
+             * keeps refcnt > 0, so the open_file is NOT freed in this loop —
+             * its final release happens in the deferred chimera_smb_notify_close
+             * below.  A watch with no parked request holds no reference, so the
+             * open_file is freed here and the deferred close just frees the
+             * detached state + destroys the VFS watch. */
+            nstate = open_file->notify_state;
+            if (nstate) {
+                open_file->notify_state = NULL;
+                nstate->gc_next         = gc_states;
+                gc_states               = nstate;
+            }
+
             open_file->flags |= CHIMERA_SMB_OPEN_FILE_CLOSED;
 
             if (open_file->type == CHIMERA_SMB_OPEN_FILE_TYPE_FILE &&
@@ -1546,6 +1570,19 @@ chimera_smb_tree_free(
         }
 
         pthread_mutex_unlock(&tree->open_files_lock[i]);
+    }
+
+    /* Tear down notify state detached above, now that no bucket lock is held.
+     * For a still-parked request this sends STATUS_NOTIFY_CLEANUP (the
+     * connection is alive on a TREE_DISCONNECT / LOGOFF) and releases the
+     * open_file reference it held — its final reference, so the open is freed
+     * here.  During hard connection teardown chimera_smb_conn_free has already
+     * dropped the parked requests silently, so there is nothing to send and
+     * only the watch + state are freed. */
+    while (gc_states) {
+        nstate    = gc_states;
+        gc_states = nstate->gc_next;
+        chimera_smb_notify_close(shared->vfs->vfs_notify, nstate);
     }
 
     pthread_mutex_lock(&shared->trees_lock);

--- a/src/server/smb/smb_notify.c
+++ b/src/server/smb/smb_notify.c
@@ -376,20 +376,35 @@ chimera_smb_notify_callback(
 /* ----------------------------------------------------------------
  * Build and send an async CHANGE_NOTIFY response with events.
  * Must be called on the SMB thread that owns the connection.
+ *
+ * cleanup == 0: normal event delivery.  A spurious wakeup (no matching
+ *   events drained) leaves the request parked for the next event and
+ *   returns without sending.  Status is SUCCESS (NOTIFY_ENUM_DIR on
+ *   overflow).
+ *
+ * cleanup == 1: the watched open is being torn down (explicit CLOSE,
+ *   TREE_DISCONNECT, LOGOFF).  The request is ALWAYS completed — never
+ *   left parked.  Any buffered events are still drained and returned, but
+ *   the status is STATUS_NOTIFY_CLEANUP (MS-SMB2 3.3.4.4) so the client
+ *   learns the watch is gone.  Windows returns the buffered records
+ *   alongside CLEANUP (smb2.notify.dir expects num_changes > 0 with
+ *   NOTIFY_CLEANUP), so we serialize them exactly as the SUCCESS path does.
  * ---------------------------------------------------------------- */
-void
-chimera_smb_notify_send_response(struct chimera_smb_notify_request *nr)
+static void
+chimera_smb_notify_do_send_response(
+    struct chimera_smb_notify_request *nr,
+    struct chimera_smb_notify_state   *state,
+    int                                cleanup)
 {
-    struct chimera_smb_open_file    *open_file = nr->open_file;
-    struct chimera_smb_notify_state *state     = open_file->notify_state;
-    struct chimera_vfs_notify_event  events[16];
-    int                              overflowed = 0;
-    int                              nevents;
-    struct evpl_iovec                iov;
-    uint8_t                         *buf, *p;
-    int                              total_alloc;
-    int                              notify_data_len;
-    uint32_t                         status;
+    struct chimera_vfs_notify_event events[16];
+    int                             overflowed = 0;
+    int                             deleted    = 0;
+    int                             nevents;
+    struct evpl_iovec               iov;
+    uint8_t                        *buf, *p;
+    int                             total_alloc;
+    int                             notify_data_len;
+    uint32_t                        status;
 
     if (!state || !state->watch) {
         /* close already tore down the state behind us; nr was reaped
@@ -413,9 +428,16 @@ chimera_smb_notify_send_response(struct chimera_smb_notify_request *nr)
 
     nevents = chimera_vfs_notify_drain(state->watch, events, 16, &overflowed);
 
-    if (nevents == 0 && !overflowed) {
+    /* The watched directory may have been removed out from under this
+     * request (delete-on-close on another handle).  That terminates the
+     * notify with STATUS_DELETE_PENDING and, like the cleanup path, must
+     * complete the request rather than leave it parked. */
+    deleted = chimera_vfs_notify_watch_take_deleted(state->watch);
+
+    if (nevents == 0 && !overflowed && !cleanup && !deleted) {
         /* Spurious wakeup — leave nr parked so the next event re-arms
-         * the ready queue via the callback.  Just clear the queued flag. */
+         * the ready queue via the callback.  Just clear the queued flag.
+         * On the cleanup/deleted paths we must complete the request. */
         nr->on_ready_queue = 0;
         pthread_mutex_unlock(&state->lock);
         return;
@@ -441,19 +463,43 @@ chimera_smb_notify_send_response(struct chimera_smb_notify_request *nr)
         nevents = j;
     }
 
-    if (nevents == 0 && !overflowed) {
+    if (nevents == 0 && !overflowed && !cleanup && !deleted) {
         /* All drained events were filtered out — treat as a spurious
          * wakeup.  Leave state->pending == nr so the next matching
          * event (which by then will satisfy emit's enqueue-time filter,
-         * since watch_update narrowed the mask) rewakes us. */
+         * since watch_update narrowed the mask) rewakes us.  On the
+         * cleanup/deleted paths we must still complete the request. */
         nr->on_ready_queue = 0;
         pthread_mutex_unlock(&state->lock);
         return;
     }
 
-    /* Claim the request before sending the response. */
-    state->pending     = NULL;
-    nr->on_ready_queue = 0;
+    /* Claim the request before sending the response.  If a VFS callback
+     * queued nr on the thread ready list (the cleanup path can reach here
+     * with on_ready_queue still set, since it is not entered from the
+     * doorbell), pluck it out so the doorbell handler never dispatches a
+     * freed nr.  When we ARE called from the doorbell, nr has already been
+     * removed from thread->notify_ready and the search is a harmless
+     * no-op.  state->lock (outer) -> notify_ready_lock (inner) matches the
+     * order taken by chimera_smb_notify_callback. */
+    state->pending = NULL;
+    if (nr->on_ready_queue) {
+        struct chimera_server_smb_thread   *thread = nr->thread;
+        struct chimera_smb_notify_request **pp;
+
+        pthread_mutex_lock(&thread->notify_ready_lock);
+        pp = &thread->notify_ready;
+        while (*pp) {
+            if (*pp == nr) {
+                *pp            = nr->ready_next;
+                nr->ready_next = NULL;
+                break;
+            }
+            pp = &(*pp)->ready_next;
+        }
+        pthread_mutex_unlock(&thread->notify_ready_lock);
+        nr->on_ready_queue = 0;
+    }
 
     pthread_mutex_unlock(&state->lock);
 
@@ -495,7 +541,9 @@ chimera_smb_notify_send_response(struct chimera_smb_notify_request *nr)
     /* Serialize FILE_NOTIFY_INFORMATION records */
     uint8_t *data_start = p;
 
-    if (overflowed) {
+    /* A deleted watch (or an overflow) returns no records — the client
+     * learns the outcome from the status code alone. */
+    if (overflowed || deleted) {
         nevents = 0;
     }
 
@@ -545,7 +593,17 @@ chimera_smb_notify_send_response(struct chimera_smb_notify_request *nr)
      * with no notify data so the client knows to rescan the directory.
      * Returning STATUS_SUCCESS with zero records would be ambiguous —
      * some clients interpret that as "no events". */
-    status = overflowed ? SMB2_STATUS_NOTIFY_ENUM_DIR : SMB2_STATUS_SUCCESS;
+    /* DELETE_PENDING (watched object removed) takes precedence over the
+     * overflow/cleanup/success classification. */
+    if (deleted) {
+        status = SMB2_STATUS_DELETE_PENDING;
+    } else if (overflowed) {
+        status = SMB2_STATUS_NOTIFY_ENUM_DIR;
+    } else if (cleanup) {
+        status = SMB2_STATUS_NOTIFY_CLEANUP;
+    } else {
+        status = SMB2_STATUS_SUCCESS;
+    }
     chimera_smb_notify_build_header(buf, nr, status);
 
     /* Fill in reply body */
@@ -578,7 +636,30 @@ chimera_smb_notify_send_response(struct chimera_smb_notify_request *nr)
 
     chimera_smb_notify_unlink(nr);
     chimera_smb_notify_request_free(nr);
+} /* chimera_smb_notify_do_send_response */
+
+void
+chimera_smb_notify_send_response(struct chimera_smb_notify_request *nr)
+{
+    /* Doorbell path: the watch state is still attached to the open file. */
+    chimera_smb_notify_do_send_response(nr, nr->open_file->notify_state, 0);
 } /* chimera_smb_notify_send_response */
+
+/*
+ * Complete a parked CHANGE_NOTIFY because its watched open is being torn
+ * down (CLOSE / TREE_DISCONNECT / LOGOFF).  Sends STATUS_NOTIFY_CLEANUP
+ * with any buffered events and frees the request.  `state` is passed
+ * explicitly because the teardown caller may have already detached it from
+ * open_file->notify_state (see chimera_smb_tree_free) to preserve the
+ * free-list invariant that a recycled open_file has notify_state == NULL.
+ */
+void
+chimera_smb_notify_complete_cleanup(
+    struct chimera_smb_notify_request *nr,
+    struct chimera_smb_notify_state   *state)
+{
+    chimera_smb_notify_do_send_response(nr, state, 1);
+} /* chimera_smb_notify_complete_cleanup */
 
 /* ----------------------------------------------------------------
  * Reap a notify request from any state it may be in:
@@ -733,18 +814,23 @@ chimera_smb_notify_close(
         return;
     }
 
-    /* Take a non-owning peek at the outstanding nr — chimera_smb_notify_cancel
-     * does the actual claim under state->lock, which also extracts nr from
+    /* Take a non-owning peek at the outstanding nr — complete_cleanup does
+     * the actual claim under state->lock, which also extracts nr from
      * thread->notify_ready if a callback already queued it.  This is the
-     * key fix for the "ready-queued notify lost on close" race: cancel is
-     * the only path that can pluck a queued-but-not-yet-dispatched request
-     * out of the ready queue. */
+     * key fix for the "ready-queued notify lost on close" race: the
+     * completion path is the only one that can pluck a queued-but-not-yet-
+     * dispatched request out of the ready queue.
+     *
+     * Per MS-SMB2 3.3.4.4, a pending CHANGE_NOTIFY whose handle is closed
+     * (or whose tree/session is torn down) completes with
+     * STATUS_NOTIFY_CLEANUP, carrying any buffered records — NOT
+     * STATUS_CANCELLED, which is reserved for an explicit SMB2 CANCEL. */
     pthread_mutex_lock(&state->lock);
     nr = state->pending;
     pthread_mutex_unlock(&state->lock);
 
     if (nr) {
-        chimera_smb_notify_cancel(nr);
+        chimera_smb_notify_complete_cleanup(nr, state);
     }
 
     if (state->watch) {

--- a/src/server/smb/smb_notify.h
+++ b/src/server/smb/smb_notify.h
@@ -72,6 +72,11 @@ struct chimera_smb_notify_state {
     pthread_mutex_t                    lock;
     struct chimera_vfs_notify_watch   *watch;
     struct chimera_smb_notify_request *pending;  /* parked request, or NULL */
+    /* Transient single-threaded linkage used only by tree/session teardown
+     * (chimera_smb_tree_free) to collect detached states and tear them down
+     * after the open_files bucket lock is released — chimera_smb_notify_close
+     * re-takes that lock via the parked request's open_file release. */
+    struct chimera_smb_notify_state   *gc_next;
 };
 
 /*
@@ -131,6 +136,18 @@ chimera_smb_notify_cancel(
 void
 chimera_smb_notify_drop(
     struct chimera_smb_notify_request *nr);
+
+/*
+ * Complete a parked CHANGE_NOTIFY because its watched open is being torn
+ * down (CLOSE / TREE_DISCONNECT / LOGOFF).  Sends STATUS_NOTIFY_CLEANUP
+ * with any buffered events and frees the request.  Use this instead of
+ * chimera_smb_notify_cancel (which is reserved for an explicit SMB2
+ * CANCEL and returns STATUS_CANCELLED).
+ */
+void
+chimera_smb_notify_complete_cleanup(
+    struct chimera_smb_notify_request *nr,
+    struct chimera_smb_notify_state   *state);
 
 /*
  * Clean up notify state for an open file being closed.

--- a/src/server/smb/smb_proc_cancel.c
+++ b/src/server/smb/smb_proc_cancel.c
@@ -25,23 +25,56 @@ chimera_smb_parse_cancel(
 void
 chimera_smb_cancel(struct chimera_smb_request *request)
 {
-    struct chimera_smb_conn           *conn = request->compound->conn;
-    struct chimera_smb_notify_request *nr;
+    struct chimera_smb_conn           *conn     = request->compound->conn;
+    struct chimera_smb_notify_request *nr       = NULL;
+    struct chimera_smb_notify_request *match    = NULL;
+    struct chimera_smb_notify_request *fallback = NULL;
     uint64_t                           target_id;
+    int                                async;
 
-    /* CANCEL targets either an async_id (if ASYNC flag set) or message_id */
-    if (request->smb2_hdr.flags & SMB2_FLAGS_ASYNC_COMMAND) {
+    /* A CANCEL targets an async_id when SMB2_FLAGS_ASYNC_COMMAND is set
+     * (the client received our interim STATUS_PENDING and learned the
+     * AsyncId), otherwise it targets a MessageId.  See MS-SMB2 3.2.4.24. */
+    async = (request->smb2_hdr.flags & SMB2_FLAGS_ASYNC_COMMAND) != 0;
+
+    if (async) {
         target_id = request->smb2_hdr.async.async_id;
     } else {
         target_id = request->smb2_hdr.message_id;
     }
 
-    /* Search parked CHANGE_NOTIFY requests on this connection */
+    /* Search parked CHANGE_NOTIFY requests on this connection.  The list is
+     * single-threaded under the connection's SMB thread, so no lock. */
     for (nr = conn->parked_notifies; nr; nr = nr->next) {
-        if (nr->async_id == target_id) {
-            chimera_smb_notify_cancel(nr);
-            break;
+        if (async) {
+            if (nr->async_id == target_id) {
+                match = nr;
+                break;
+            }
+        } else if (target_id != 0) {
+            if (nr->message_id == target_id) {
+                match = nr;
+                break;
+            }
+        } else if (!fallback && nr->session_id == request->smb2_hdr.session_id) {
+            /* A Samba client whose negotiated signing algorithm is below
+             * AES-128-GMAC (chimera only implements CMAC) sends a *sync*
+             * CANCEL carrying MessageId 0 as a sentinel for "the
+             * outstanding async request on this session" rather than the
+             * real MessageId (libcli smbXcli_base.c sets cancel_mid=0 in
+             * that case).  Match the most recently parked notify for the
+             * session as a fallback so these cancels are honoured instead
+             * of leaking the parked request forever. */
+            fallback = nr;
         }
+    }
+
+    if (!match && !async && target_id == 0) {
+        match = fallback;
+    }
+
+    if (match) {
+        chimera_smb_notify_cancel(match);
     }
 
     /* CANCEL has no response per MS-SMB2.  Use STATUS_PENDING so the

--- a/src/server/smb/smb_proc_change_notify.c
+++ b/src/server/smb/smb_proc_change_notify.c
@@ -50,6 +50,15 @@ chimera_smb_change_notify(struct chimera_smb_request *request)
     int                                nevents;
     struct chimera_vfs_notify         *vfs_notify;
 
+    /* When change notify is disabled for the server's shares (the Windows
+     * "change notify = no" behaviour), reject the request outright with
+     * STATUS_NOT_IMPLEMENTED rather than arming a watch that would never
+     * fire — matching MS-SMB2 and smb2.change_notify_disabled. */
+    if (thread->shared->config.notify_disabled) {
+        chimera_smb_complete_request(request, SMB2_STATUS_NOT_IMPLEMENTED);
+        return;
+    }
+
     /* Resolve the open file */
     open_file = chimera_smb_open_file_resolve(request, &request->change_notify.file_id);
 
@@ -62,6 +71,15 @@ chimera_smb_change_notify(struct chimera_smb_request *request)
     if (!(open_file->flags & CHIMERA_SMB_OPEN_FILE_FLAG_DIRECTORY)) {
         chimera_smb_open_file_release(request, open_file);
         chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
+        return;
+    }
+
+    /* MS-SMB2 3.3.5.19: the open must hold FILE_LIST_DIRECTORY (== READ_DATA)
+     * to watch the directory; otherwise reject with STATUS_ACCESS_DENIED
+     * (smb2.notify.handle-permissions). */
+    if (!(open_file->granted_access & SMB2_FILE_LIST_DIRECTORY)) {
+        chimera_smb_open_file_release(request, open_file);
+        chimera_smb_complete_request(request, SMB2_STATUS_ACCESS_DENIED);
         return;
     }
 

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -687,6 +687,11 @@ chimera_smb_create_release_parent(struct chimera_smb_request *request)
     }
 } /* chimera_smb_create_release_parent */
 
+static inline uint32_t
+chimera_smb_create_granted_access(
+    struct chimera_smb_request     *request,
+    const struct chimera_vfs_attrs *attr);
+
 static inline void
 chimera_smb_create_mkdir_open_callback(
     enum chimera_vfs_error          error_code,
@@ -720,6 +725,20 @@ chimera_smb_create_mkdir_open_callback(
     }
 
     request->create.r_open_file = open_file;
+
+    /* Record the access this open was granted.  The other create/open
+     * completion paths do this; without it a freshly-created directory
+     * handle carries a stale granted_access (a recycled open_file can hold
+     * 0), which breaks any access decision keyed on it (e.g. the
+     * FILE_LIST_DIRECTORY gate on CHANGE_NOTIFY).  The creator of a new
+     * object holds full control, so MAXIMUM_ALLOWED resolves to the full
+     * mask; a specific-bits open was granted exactly what it requested. */
+    if (request->create.desired_access & SMB2_MAXIMUM_ALLOWED) {
+        open_file->granted_access = CHIMERA_ACE_MASK_ALL;
+    } else {
+        open_file->granted_access = chimera_smb_create_granted_access(request, NULL);
+    }
+    open_file->maximal_access = CHIMERA_ACE_MASK_ALL;
 
     chimera_smb_create_release_parent(request);
     chimera_smb_open_file_release(request, open_file);

--- a/src/server/smb/smb_proc_security.c
+++ b/src/server/smb/smb_proc_security.c
@@ -684,6 +684,24 @@ chimera_smb_set_security_setattr_callback(
     struct chimera_smb_request *request = private_data;
     unsigned int                status;
 
+    /* A successful security-descriptor change is an attribute change on the
+     * object; fire a CHANGE_NOTIFY (ATTRS_CHANGED, which the SECURITY/ALL
+     * completion filter maps to) on the parent so watchers see it — same as
+     * the basic-info setattr path (smb2.notify.security).  Emit before
+     * releasing the open_file since we read its parent_fh/name. */
+    if (error_code == CHIMERA_VFS_OK &&
+        request->set_info.open_file->parent_fh_len > 0) {
+        struct chimera_server_smb_thread *thread = request->compound->thread;
+
+        chimera_vfs_notify_emit(thread->shared->vfs->vfs_notify,
+                                request->set_info.open_file->parent_fh,
+                                request->set_info.open_file->parent_fh_len,
+                                CHIMERA_VFS_NOTIFY_ATTRS_CHANGED,
+                                request->set_info.open_file->name,
+                                request->set_info.open_file->name_len,
+                                NULL, 0);
+    }
+
     chimera_smb_open_file_release(request, request->set_info.open_file);
 
     switch (error_code) {

--- a/src/server/smb/smb_proc_session_setup.c
+++ b/src/server/smb/smb_proc_session_setup.c
@@ -329,15 +329,33 @@ chimera_smb_session_setup(struct chimera_smb_request *request)
         chimera_smb_error("Authentication failed (mechanism: %s)", smb_auth_mech_name(mech));
         chimera_smb_complete_request(request, SMB2_STATUS_LOGON_FAILURE);
 
+        /* A failed channel-bind (SMB2_SESSION_FLAG_BINDING) must NOT tear the
+         * existing session down — the established channel(s) survive.  Only a
+         * failed initial auth (never-authorized session) or a failed non-binding
+         * REAUTH invalidates the session. */
+        int is_binding = (request->session_setup.flags &
+                          SMB2_SESSION_FLAG_BINDING) != 0;
+
         if (request->session_handle &&
-            (!(request->session_handle->session->flags & CHIMERA_SMB_SESSION_AUTHORIZED))) {
+            !((request->session_handle->session->flags &
+               CHIMERA_SMB_SESSION_AUTHORIZED) && is_binding)) {
             /* The handle was registered in conn->session_handles when the
              * session was allocated (possibly on an earlier interim leg), so
              * remove it there before freeing — otherwise connection teardown
-             * iterates it again and double-releases the session. */
+             * iterates it again and double-releases the session.
+             *
+             * This tears the session down on auth failure in two cases:
+             *   - a brand-new session whose initial authentication failed
+             *     (never authorized);
+             *   - a failed REAUTH of an already-authorized session, which
+             *     MS-SMB2 invalidates.  The LOGON_FAILURE reply above was
+             *     already built with the still-valid handle; releasing the
+             *     session now frees its trees, which completes any pending
+             *     CHANGE_NOTIFY with STATUS_NOTIFY_CLEANUP
+             *     (smb2.notify.invalid-reauth) and makes the SessionId
+             *     invalid for subsequent requests.  A failed auth holds no
+             *     preservable durable opens, so nothing to preserve. */
             HASH_DEL(conn->session_handles, request->session_handle);
-            /* Auth failed: the session was never authorized and holds no
-             * durable opens, so nothing to preserve. */
             chimera_smb_session_release(thread, shared, request->session_handle->session, false);
             chimera_smb_session_handle_free(thread, request->session_handle);
             request->session_handle   = NULL;

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -243,9 +243,38 @@ set(SMBTORTURE_ACLS_SUBTESTS
     smb2.acls.OVERWRITE_READ_ONLY_FILE
 )
 
+# Like smb2.acls, the combined smb2.notify suite shares one server process and
+# trips over the same smb2_deltree per-subtest cleanup cascade (a non-empty
+# directory whose delete-on-close is believed to have succeeded lingers and the
+# stale state breaks later subtests).  Each subtest passes cleanly in its own
+# server process, so the notify behaviour is covered by registering the
+# individual subtests as separate ctests.  The combined suite stays visible but
+# disabled (see below); greening it is tracked as the shared deltree follow-up.
+set(SMBTORTURE_NOTIFY_SUBTESTS
+    smb2.notify.tcon
+    smb2.notify.dir
+    smb2.notify.mask
+    smb2.notify.tdis
+    smb2.notify.tdis1
+    smb2.notify.close
+    smb2.notify.logoff
+    smb2.notify.invalid-reauth
+    smb2.notify.basedir
+    smb2.notify.double
+    smb2.notify.file
+    smb2.notify.tcp
+    smb2.notify.overflow
+    smb2.notify.rmdir1
+    smb2.notify.rmdir2
+    smb2.notify.rmdir3
+    smb2.notify.rmdir4
+    smb2.notify.handle-permissions
+)
+
 set(SMBTORTURE_SUITES
     smb2.acls
     ${SMBTORTURE_ACLS_SUBTESTS}
+    ${SMBTORTURE_NOTIFY_SUBTESTS}
     smb2.acls_non_canonical
     smb2.async_dosmode
     smb2.change_notify_disabled
@@ -320,6 +349,7 @@ set(SMBTORTURE_SUITES
 # remaining backends start fully disabled; populate their lists as suites are
 # verified against them.
 set(SMBTORTURE_ENABLED_memfs
+    smb2.change_notify_disabled
     smb2.maximum_allowed
     smb2.mkdir
     smb2.openattr
@@ -359,6 +389,12 @@ set(SMBTORTURE_ENABLED_memfs
     # The combined smb2.acls suite stays disabled (shared-process deltree
     # cleanup cascade, see above).
     ${SMBTORTURE_ACLS_SUBTESTS}
+    # CHANGE_NOTIFY coverage: these notify subtests pass individually on memfs.
+    # The combined smb2.notify suite stays disabled (same deltree cascade).
+    # Remaining notify subtests (valid-req, mask-change, session-reconnect,
+    # tree, rec) need deeper features (recursive-buffer accuracy, per-session
+    # preauth for PreviousSessionId) and are left disabled.
+    ${SMBTORTURE_NOTIFY_SUBTESTS}
     # smb2.acls_non_canonical and smb2.async_dosmode pass on x86_64 but fail on
     # arm64 CI; left disabled until the arch difference is understood.
 )
@@ -371,6 +407,7 @@ set(SMBTORTURE_ENABLED_memfs
 # round-trip is unsupportable on the passthrough backends (it works on the
 # native backends, which persist btime in their own inode metadata).
 set(SMBTORTURE_ENABLED_linux
+    smb2.change_notify_disabled
     smb2.mkdir
     smb2.read
     smb2.rw
@@ -389,6 +426,7 @@ set(SMBTORTURE_ENABLED_linux
     # pending the arm64 difference.
 )
 set(SMBTORTURE_ENABLED_io_uring
+    smb2.change_notify_disabled
     smb2.mkdir
     smb2.read
     smb2.rw
@@ -412,6 +450,7 @@ set(SMBTORTURE_ENABLED_io_uring
 # KV (like diskfs), so it also runs the smb2.acls subtests now that set_security
 # (cairn_setattr SET-ACL) persists the descriptor.
 set(SMBTORTURE_ENABLED_cairn
+    smb2.change_notify_disabled
     smb2.mkdir
     smb2.read
     smb2.rw
@@ -436,6 +475,7 @@ set(SMBTORTURE_ENABLED_cairn
 # stays disabled (no FSCTL_SET_SPARSE support yet); both block backends share
 # the diskfs module and enable the same set.
 set(SMBTORTURE_ENABLED_diskfs_common
+    smb2.change_notify_disabled
     smb2.mkdir
     smb2.read
     smb2.rw

--- a/src/server/smb/tests/smbtorture_test.c
+++ b/src/server/smb/tests/smbtorture_test.c
@@ -367,6 +367,17 @@ main(
         }
     }
 
+    /* The change_notify_disabled suite expects the server to reject
+     * CHANGE_NOTIFY with STATUS_NOT_IMPLEMENTED (the "change notify = no"
+     * share policy).  Enable that policy only for that suite — every other
+     * suite needs CHANGE_NOTIFY working. */
+    for (i = 0; i < num_tests; i++) {
+        if (strstr(tests[i], "change_notify_disabled") != NULL) {
+            chimera_server_config_set_smb_notify_disabled(config, 1);
+            break;
+        }
+    }
+
     /* Initialize server */
     env.server = chimera_server_init(config, env.metrics);
     if (!env.server) {

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -1814,6 +1814,100 @@ memfs_umount(
     request->complete(request);
 } /* memfs_umount */
 
+/*
+ * Reverse-path-lookup: given a directory FH, return its parent's FH and the
+ * directory's own name within that parent.  The change-notify subtree
+ * resolver walks the ancestor directory chain with this (memfs advertises
+ * CHIMERA_VFS_CAP_RPL), so it only ever needs to resolve directories — which
+ * track their parent via dir.parent_inum/parent_gen.
+ */
+static void
+memfs_getparent(
+    struct memfs_thread        *thread,
+    struct memfs_shared        *shared,
+    struct chimera_vfs_request *request,
+    void                       *private_data)
+{
+    struct memfs_inode  *inode, *parent_inode;
+    struct memfs_dirent *dirent;
+    uint64_t             parent_inum;
+    uint32_t             parent_gen;
+    uint64_t             child_inum;
+    uint32_t             child_gen;
+    int                  found = 0;
+
+    inode = memfs_inode_get_fh(shared, request->fh, request->fh_len);
+
+    if (unlikely(!inode)) {
+        request->status = CHIMERA_VFS_ENOENT;
+        request->complete(request);
+        return;
+    }
+
+    if (unlikely(!S_ISDIR(inode->mode))) {
+        pthread_mutex_unlock(&inode->lock);
+        request->status = CHIMERA_VFS_ENOTDIR;
+        request->complete(request);
+        return;
+    }
+
+    child_inum  = inode->inum;
+    child_gen   = inode->gen;
+    parent_inum = inode->dir.parent_inum;
+    parent_gen  = inode->dir.parent_gen;
+
+    pthread_mutex_unlock(&inode->lock);
+
+    /* Encode the parent FH using the child FH as the magic/mount template. */
+    request->getparent.r_parent_fh_len =
+        chimera_vfs_encode_fh_inum_parent(request->fh, parent_inum, parent_gen,
+                                          request->getparent.r_parent_fh);
+    request->getparent.r_name_len = 0;
+
+    /* The root directory is its own parent: there is no enclosing name.  The
+     * resolver detects the mount root by FH and stops, so an empty name is
+     * fine here. */
+    if (parent_inum == child_inum && parent_gen == child_gen) {
+        request->status = CHIMERA_VFS_OK;
+        request->complete(request);
+        return;
+    }
+
+    parent_inode = memfs_inode_get_inum(shared, parent_inum, parent_gen);
+
+    if (unlikely(!parent_inode)) {
+        request->status = CHIMERA_VFS_ENOENT;
+        request->complete(request);
+        return;
+    }
+
+    /* Scan the parent's entries for the one pointing back at this child. */
+    rb_tree_first(&parent_inode->dir.dirents, dirent);
+
+    while (dirent) {
+        if (dirent->inum == child_inum && dirent->gen == child_gen) {
+            uint16_t nlen = dirent->name_len;
+            if (nlen > sizeof(request->getparent.r_name)) {
+                nlen = sizeof(request->getparent.r_name);
+            }
+            memcpy(request->getparent.r_name, dirent->name, nlen);
+            request->getparent.r_name_len = nlen;
+            found                         = 1;
+            break;
+        }
+        dirent = rb_tree_next(&parent_inode->dir.dirents, dirent);
+    }
+
+    pthread_mutex_unlock(&parent_inode->lock);
+
+    /* A missing name (child unlinked from the parent mid-walk) is not fatal
+     * for the resolver — it still has the parent FH to continue upward. */
+    (void) found;
+
+    request->status = CHIMERA_VFS_OK;
+    request->complete(request);
+} /* memfs_getparent */
+
 static void
 memfs_lookup_at(
     struct memfs_thread        *thread,
@@ -5106,6 +5200,9 @@ memfs_dispatch(
         case CHIMERA_VFS_OP_LOOKUP_AT:
             memfs_lookup_at(thread, shared, request, private_data);
             break;
+        case CHIMERA_VFS_OP_GETPARENT:
+            memfs_getparent(thread, shared, request, private_data);
+            break;
         case CHIMERA_VFS_OP_GETATTR:
             memfs_getattr(thread, shared, request, private_data);
             break;
@@ -5222,7 +5319,7 @@ SYMBOL_EXPORT struct chimera_vfs_module vfs_memfs = {
         CHIMERA_VFS_CAP_COPY_RANGE | CHIMERA_VFS_CAP_CLONE_RANGE | CHIMERA_VFS_CAP_MOVE_RANGE |
         CHIMERA_VFS_CAP_ACL_NATIVE | CHIMERA_VFS_CAP_XATTR | CHIMERA_VFS_CAP_LAYOUT |
         CHIMERA_VFS_CAP_ATOMIC_HANDLE_STATE | CHIMERA_VFS_CAP_READ_PROVIDES_BUFFERS |
-        CHIMERA_VFS_CAP_NAMED_STREAMS,
+        CHIMERA_VFS_CAP_NAMED_STREAMS | CHIMERA_VFS_CAP_RPL,
     .init           = memfs_init,
     .destroy        = memfs_destroy,
     .thread_init    = memfs_thread_init,

--- a/src/vfs/vfs_notify.c
+++ b/src/vfs/vfs_notify.c
@@ -726,11 +726,19 @@ chimera_vfs_notify_watch_update(
      * exact-mode events carry a bare filename.  Delivering a stale path
      * to a non-tree consumer (or vice versa) would mislead the client,
      * and we have no per-event mode tag to filter selectively.  Force
-     * the client to rescan via overflow semantics. */
+     * the client to rescan via overflow semantics — but ONLY if there is
+     * actually something queued (or an overflow already pending).  When
+     * the ring is empty (the common case of a client re-arming a fresh
+     * watch with a different recursion flag) signalling a spurious
+     * overflow would make the very next CHANGE_NOTIFY complete
+     * immediately with STATUS_NOTIFY_ENUM_DIR instead of parking
+     * (smb2.notify.rec / mask-change). */
     pthread_mutex_lock(&watch->lock);
-    watch->ring_head  = 0;
-    watch->ring_count = 0;
-    watch->overflowed = 1;
+    if (watch->ring_count > 0 || watch->overflowed) {
+        watch->ring_head  = 0;
+        watch->ring_count = 0;
+        watch->overflowed = 1;
+    }
     pthread_mutex_unlock(&watch->lock);
 
     /* watch_tree flipped — relink in mount entries' subtree list. */
@@ -865,6 +873,19 @@ chimera_vfs_notify_drain(
 
     return count;
 } /* chimera_vfs_notify_drain */
+
+SYMBOL_EXPORT int
+chimera_vfs_notify_watch_take_deleted(struct chimera_vfs_notify_watch *watch)
+{
+    int deleted;
+
+    pthread_mutex_lock(&watch->lock);
+    deleted        = watch->deleted;
+    watch->deleted = 0;
+    pthread_mutex_unlock(&watch->lock);
+
+    return deleted;
+} /* chimera_vfs_notify_watch_take_deleted */
 
 /*
  * Lock invariants for the emit/destroy/callback dance:
@@ -1147,3 +1168,45 @@ chimera_vfs_notify_emit(
     /* Start the resolve chain */
     chimera_vfs_notify_resolve(pev);
 } /* chimera_vfs_notify_emit */
+
+SYMBOL_EXPORT void
+chimera_vfs_notify_emit_delete(
+    struct chimera_vfs_notify *notify,
+    const uint8_t             *fh,
+    uint16_t                   fh_len)
+{
+    struct chimera_vfs_notify_bucket *bucket;
+    struct chimera_vfs_notify_watch  *watch;
+    uint64_t                          fh_hash;
+    int                               bi;
+
+    if (!notify) {
+        return;
+    }
+
+    /* Only exact watches matter: CHANGE_NOTIFY is armed on a handle to the
+     * object itself, so a watch keyed on the removed object's own FH is the
+     * one that must learn it is gone.  (Subtree watchers on an ancestor are
+     * handled by the regular DIR_REMOVED emit on the parent.) */
+    fh_hash = chimera_vfs_hash(fh, fh_len);
+    bi      = chimera_vfs_notify_bucket_index(fh_hash);
+    bucket  = &notify->buckets[bi];
+
+    pthread_mutex_lock(&bucket->lock);
+
+    for (watch = bucket->watches; watch; watch = watch->next) {
+        if (watch->dir_fh_len == fh_len &&
+            memcmp(watch->dir_fh, fh, fh_len) == 0) {
+
+            pthread_mutex_lock(&watch->lock);
+            watch->deleted = 1;
+            pthread_mutex_unlock(&watch->lock);
+
+            if (watch->callback) {
+                watch->callback(watch, watch->private_data);
+            }
+        }
+    }
+
+    pthread_mutex_unlock(&bucket->lock);
+} /* chimera_vfs_notify_emit_delete */

--- a/src/vfs/vfs_notify.h
+++ b/src/vfs/vfs_notify.h
@@ -53,6 +53,10 @@ struct chimera_vfs_notify_watch {
     int                              ring_head;  /* next write position */
     int                              ring_count; /* number of pending events */
     int                              overflowed;
+    /* Set when the watched object itself was removed.  Drained via
+     * chimera_vfs_notify_watch_take_deleted(); the SMB layer maps it to
+     * STATUS_DELETE_PENDING on the pending CHANGE_NOTIFY. */
+    int                              deleted;
 
     chimera_vfs_notify_callback_t    callback;
     void                            *private_data;
@@ -184,6 +188,16 @@ chimera_vfs_notify_drain(
     int                              max_events,
     int                             *overflowed);
 
+/*
+ * Atomically read and clear a watch's "deleted" flag.  Returns non-zero if
+ * the watched object had been removed since the last call.  The SMB layer
+ * polls this alongside drain to complete a pending CHANGE_NOTIFY with
+ * STATUS_DELETE_PENDING.
+ */
+int
+chimera_vfs_notify_watch_take_deleted(
+    struct chimera_vfs_notify_watch *watch);
+
 void
 chimera_vfs_notify_emit(
     struct chimera_vfs_notify *notify,
@@ -194,3 +208,15 @@ chimera_vfs_notify_emit(
     uint16_t                   name_len,
     const char                *old_name,
     uint16_t                   old_name_len);
+
+/*
+ * Signal that the object identified by `fh` was itself removed.  Marks every
+ * exact watch on that FH deleted and fires its callback, so a pending
+ * CHANGE_NOTIFY on a handle to the now-deleted directory completes with
+ * STATUS_DELETE_PENDING instead of parking forever.
+ */
+void
+chimera_vfs_notify_emit_delete(
+    struct chimera_vfs_notify *notify,
+    const uint8_t             *fh,
+    uint16_t                   fh_len);

--- a/src/vfs/vfs_proc_remove_at.c
+++ b/src/vfs/vfs_proc_remove_at.c
@@ -59,6 +59,22 @@ chimera_vfs_remove_at_complete(struct chimera_vfs_request *request)
                                 request->remove_at.namelen,
                                 NULL, 0);
 
+        /* Signal any CHANGE_NOTIFY armed on a handle to the object that was
+         * just removed (its own FH, distinct from the parent emit above) so
+         * that pending request completes with STATUS_DELETE_PENDING rather
+         * than parking forever.  Prefer the caller-supplied child FH; fall
+         * back to the FH the backend reported for the removed entry. */
+        if (request->remove_at.child_fh && request->remove_at.child_fh_len > 0) {
+            chimera_vfs_notify_emit_delete(thread->vfs->vfs_notify,
+                                           request->remove_at.child_fh,
+                                           request->remove_at.child_fh_len);
+        } else if (request->remove_at.r_removed_attr.va_set_mask &
+                   CHIMERA_VFS_ATTR_FH) {
+            chimera_vfs_notify_emit_delete(thread->vfs->vfs_notify,
+                                           request->remove_at.r_removed_attr.va_fh,
+                                           request->remove_at.r_removed_attr.va_fh_len);
+        }
+
         chimera_vfs_name_cache_insert(thread, name_cache,
                                       request->remove_at.handle->fh_hash,
                                       request->remove_at.handle->fh,


### PR DESCRIPTION
Brings the SMB2 CHANGE_NOTIFY implementation up to the behaviour the Samba `smb2.notify` conformance suite expects, and adds the "change notify disabled" share policy.

**Result:** 18/23 `smb2.notify` subtests now pass on memfs and are enabled per-subtest (mirroring `smb2.acls` — the combined suite stays disabled because of the shared-process `smb2_deltree` cleanup cascade). `smb2.change_notify_disabled` passes and is enabled on all six backends.

### VFS notify core (`vfs_notify.c`/`.h`, `vfs_proc_remove_at.c`, `memfs.c`)
- `chimera_vfs_notify_emit_delete()` + a per-watch `deleted` flag: when a watched directory is removed (delete-on-close via another handle), the pending CHANGE_NOTIFY on a handle to it completes with `STATUS_DELETE_PENDING` instead of parking forever (`rmdir1-4`).
- `watch_update` only raises overflow on a `watch_tree` flip when the ring actually held events, so re-arming a fresh watch with a different recursion flag no longer spuriously completes with `NOTIFY_ENUM_DIR` (`rec`/`mask-change` re-arm).
- memfs implements `getparent` + advertises `CHIMERA_VFS_CAP_RPL`, so the recursive subtree resolver builds real relative paths (`basedir`).

### SMB CHANGE_NOTIFY (`smb_notify.c`, `smb_proc_change_notify.c`)
- CLOSE / TREE_DISCONNECT / LOGOFF complete a pending CHANGE_NOTIFY with `STATUS_NOTIFY_CLEANUP` (carrying any buffered records) rather than `STATUS_CANCELLED` (reserved for an explicit SMB2 CANCEL); `tree_free` tears down notify state without leaking the watch (`tdis1`/`close`/`logoff`/`dir`).
- A deleted watch maps to `STATUS_DELETE_PENDING`.
- Reject CHANGE_NOTIFY on a handle lacking `FILE_LIST_DIRECTORY` with `STATUS_ACCESS_DENIED` (`handle-permissions`).
- Return `STATUS_NOT_IMPLEMENTED` when the share has change-notify disabled.

### SMB CANCEL (`smb_proc_cancel.c`)
- Match the target async-by-AsyncId / sync-by-MessageId, and treat a sync CANCEL with `MessageId == 0` (sent by clients whose negotiated signing algorithm is below AES-128-GMAC) as the outstanding notify on that session.

### SMB CREATE (`smb_proc_create.c`)
- Set `granted_access`/`maximal_access` on the create-new-directory path; it was previously left stale (a recycled `open_file` could carry `0`), which made any access decision keyed on it unreliable.

### SMB SET_INFO security (`smb_proc_security.c`)
- Emit `ATTRS_CHANGED` on a successful DACL change, like the basic-info setattr path.

### SMB session setup (`smb_proc_session_setup.c`)
- A failed *non-binding* reauth of an authorized session tears the session down (completing pending notifies with `STATUS_NOTIFY_CLEANUP` and invalidating the SessionId); a failed channel bind leaves it intact.

### Config (`server.c`/`.h`, `smb.c`, `smb_internal.h`)
- Add `smb_notify_disabled` plumbing; the smbtorture harness enables it only for the `change_notify_disabled` suite.

### Not included (left disabled, follow-ups)
`valid-req` (sticky-overflow semantics), `tree`/`rec`/`mask-change` (deep recursive-buffer accuracy), and `session-reconnect` (PreviousSessionId teardown on top of the per-session preauth from #566).