### PR TITLE
diskfs: zero-copy device write for block-aligned overwrites

### DIFF
--- a/src/vfs/diskfs/diskfs.c
+++ b/src/vfs/diskfs/diskfs.c
@@ -11895,6 +11895,54 @@ diskfs_write_phase2(
         return;
     }
 
+    /* Zero-copy fast path: a fully block-aligned overwrite has no RMW prefix or
+    * suffix (and therefore no sub-block padding), so the staged buffer would be
+    * a byte-for-byte copy of the caller's write data.  When the data is a single
+    * block-aligned segment that fits a single device request, hand the caller's
+    * iovec straight to the device and skip the per-write staging copy entirely.
+    *
+    * The single-segment, 4K-aligned gate is required for correctness, not just
+    * the win: the device backend (libaio/io_uring O_DIRECT, VFIO) needs each
+    * segment block-aligned in address and length.  That holds for an RDMA write,
+    * where the data lands in one registered, 4K-aligned buffer -- the same buffer
+    * the read path DMAs device reads into.  It does NOT hold for a write whose
+    * payload arrived as many unaligned fragments (e.g. an RPC reassembled from
+    * TCP record marks); those must take the staging path below, which coalesces
+    * them into aligned device blocks.  Feeding raw unaligned segments to the
+    * device silently drops the I/O -> the request never completes -> hang.
+    *
+    * Lifetime: the VFS core retains ownership of request->write.iov and releases
+    * it only after this op completes (i.e. after the device write), so borrowing
+    * it here is safe.  We do not add it to diskfs_private->iov, so io_callback
+    * (which only releases diskfs_private->iov[0..niov]) leaves it untouched. */
+    if (prefix_len == 0 && suffix_len == 0 && write_length > 0 &&
+        diskfs_private->rmw_aligned_length == write_length &&
+        request->write.niov == 1 &&
+        (((uintptr_t) request->write.iov[0].data & 4095) == 0) &&
+        write_length <= shared->devices[diskfs_private->rmw_device_id].max_request_size) {
+
+        diskfs_private->pending = 1;
+        diskfs_private->niov    = 0;
+
+        diskfs_pending_io_add(thread, 1);
+
+        diskfs_metric_block_io(thread, DISKFS_METRIC_IO_WRITE,
+                               DISKFS_METRIC_IO_DATA, write_length);
+        diskfs_metric_block_io_device(thread, diskfs_private->rmw_device_id,
+                                      DISKFS_METRIC_IO_WRITE,
+                                      DISKFS_METRIC_IO_DATA, write_length);
+
+        evpl_block_write(evpl,
+                         thread->queue[diskfs_private->rmw_device_id],
+                         request->write.iov,
+                         request->write.niov,
+                         diskfs_private->rmw_device_offset,
+                         !shared->unsafe_async,
+                         diskfs_io_callback,
+                         request);
+        return;
+    }
+
     // Build the combined write iovec:
     // [prefix (if any)] + [write data] + [suffix (if any)] + [padding to 4KB]
 


### PR DESCRIPTION
## Summary

A random-4K-write CPU profile of the diskfs server showed `__memmove_avx512_unaligned_erms` at ~12% under the write path. The cause is in `diskfs_write_phase2`: it always assembles the write into a **freshly allocated, 4K-aligned device buffer** (`evpl_iovec_cursor_get_blob`) before issuing `evpl_block_write`. That staging copy exists to coalesce the read-modify-write `prefix + data + suffix + padding` into contiguous 4K device blocks.

For a **fully block-aligned overwrite** there is no prefix, suffix, or sub-block padding, so the staged buffer is a byte-for-byte copy of the caller's write data — pure overhead. This is the write-side analog of the `read_into` zero-copy work (#603/#605), where device reads now land directly in the caller's buffer.

## Change

Add a fast path in `diskfs_write_phase2`: when the write is fully block-aligned (`prefix_len == 0 && suffix_len == 0`, hence no padding) and fits a single device request, hand the caller's iovecs straight to `evpl_block_write` and skip the staging allocation + copy entirely. Any unaligned or oversized write still takes the existing staging path unchanged.

## Safety

- The caller's write iovecs are the same registered RDMA landing buffers the read path already DMAs device reads *into*, so they are device-DMA capable.
- The VFS core retains ownership of `request->write.iov` and releases it only after the op completes (i.e. after the device write), so borrowing it through the async device write is safe — the request is not completed until `diskfs_io_callback` fires on device completion.
- The borrowed iovecs are **not** added to `diskfs_private->iov`, so `io_callback` (which only releases `diskfs_private->iov[0..niov]`) leaves them untouched.

## Validation

- Real kernel NFS4.2 → diskfs, 4K block-aligned `oflag=direct` random overwrites of preallocated files (exactly this fast path): data integrity verified by md5 across a cold daemon restart + reload (`DATA PASS`), ASan-clean, clean shutdown.
- Unaligned / sub-block / oversized writes provably fall through to the unchanged staging path; CI's `fsx`/`fsstress` diskfs suites cover them.