### PR TITLE
smb2: grant exclusive/batch oplocks with a real break/ack state machine (partial)

### DIFF
--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -139,13 +139,13 @@ chimera_smb_create_gen_open_file(
      * otherwise it drops to LEVEL_II.  Pure attribute/EA opens break nothing
      * (stat-open).  No-op on the first open; skips the opener's own lease. */
     if (type == CHIMERA_SMB_OPEN_FILE_TYPE_FILE && tree->share && oh) {
-        uint32_t da   = open_file->desired_access;
-        uint32_t disp = request->create.create_disposition;
+        uint32_t da        = open_file->desired_access;
+        uint32_t disp      = request->create.create_disposition;
         bool     truncates =
             disp == SMB2_FILE_OVERWRITE ||
             disp == SMB2_FILE_OVERWRITE_IF ||
             disp == SMB2_FILE_SUPERSEDE;
-        bool break_trigger =
+        bool     break_trigger =
             (da & (SMB2_FILE_READ_DATA | SMB2_FILE_WRITE_DATA |
                    SMB2_FILE_APPEND_DATA | SMB2_FILE_EXECUTE |
                    SMB2_GENERIC_READ | SMB2_GENERIC_WRITE |
@@ -334,10 +334,10 @@ chimera_smb_create_gen_open_file(
     if (type == CHIMERA_SMB_OPEN_FILE_TYPE_FILE && oh) {
         struct chimera_vfs_state      *vfs_state = thread->vfs_thread->vfs->vfs_state;
         struct chimera_vfs_file_state *file_state;
-        uint8_t                        req_smb         = 0;
-        uint8_t                        req_vfs         = 0;
-        bool                           via_rqls        = false;
-        struct chimera_vfs_lease      *conflict        = NULL;
+        uint8_t                        req_smb  = 0;
+        uint8_t                        req_vfs  = 0;
+        bool                           via_rqls = false;
+        struct chimera_vfs_lease      *conflict = NULL;
         enum chimera_vfs_lease_result  result;
 
         if (request->create.ctx_present_mask & CHIMERA_SMB_CREATE_CTX_RQLS) {
@@ -364,23 +364,23 @@ chimera_smb_create_gen_open_file(
         }
 
         /* SMB lease bits use R=0x01, H=0x02, W=0x04 — a different layout from
-        * vfs_state's R/W/H mask, so map field-by-field.  We grant the full
-        * requested set: read caching (R → LEVEL_II), write caching
-        * (W → EXCLUSIVE) and handle caching (H → BATCH).  The vfs_state
-        * conflict matrix keeps W single-writer-exclusive and H
-        * single-holder-exclusive, and the SMB layer breaks holders when a
-        * conflicting open / write / byte-range-lock / delete arrives.
-        *
-        * The two coherence hazards that previously forced a read-only policy
-        * (W and H withheld) are now handled in the break path rather than by
-        * withholding the cache:
-        *   - delete-of-open-file: unlink / rename / delete-on-close break the
-        *     H (handle-caching) holder so its deferred-close handle is recalled
-        *     before the remove (smb_proc_close.c / set_info / rename) — fixes
-        *     the old cthon op_unlk EBUSY.
-        *   - server-side copy: COPYCHUNK breaks the source's caching lease to
-        *     force a flush before it reads (smb_proc_copychunk.c) — fixes the
-        *     old fsx READ BAD DATA. */
+         * vfs_state's R/W/H mask, so map field-by-field.  We grant the full
+         * requested set: read caching (R → LEVEL_II), write caching
+         * (W → EXCLUSIVE) and handle caching (H → BATCH).  The vfs_state
+         * conflict matrix keeps W single-writer-exclusive and H
+         * single-holder-exclusive, and the SMB layer breaks holders when a
+         * conflicting open / write / byte-range-lock / delete arrives.
+         *
+         * The two coherence hazards that previously forced a read-only policy
+         * (W and H withheld) are now handled in the break path rather than by
+         * withholding the cache:
+         *   - delete-of-open-file: unlink / rename / delete-on-close break the
+         *     H (handle-caching) holder so its deferred-close handle is recalled
+         *     before the remove (smb_proc_close.c / set_info / rename) — fixes
+         *     the old cthon op_unlk EBUSY.
+         *   - server-side copy: COPYCHUNK breaks the source's caching lease to
+         *     force a flush before it reads (smb_proc_copychunk.c) — fixes the
+         *     old fsx READ BAD DATA. */
         if (req_smb & SMB2_LEASE_READ_CACHING) {
             req_vfs |= CHIMERA_VFS_LEASE_MODE_R;
         }
@@ -457,20 +457,28 @@ chimera_smb_create_gen_open_file(
                                                       &open_file->caching_lease,
                                                       &conflict);
 
-                /* Another handle already holds a caching oplock/lease.  We
-                 * cannot keep an exclusive/write cache, but we can settle for a
-                 * shared read lease, which coexists with the (now downgraded)
-                 * holder -- this is how a 2nd open ends up with LEVEL_II.
-                 *   - BREAKING: try_insert just kicked off the holder's break.
-                 *   - DENIED: the holder was already broken to a shared read by
-                 *     the break-on-open above (its lease is ACKED, no longer
-                 *     IDLE-breakable), so a write cache is refused; a read cache
-                 *     still coexists.
-                 * Either way, retry for read-only caching (LEVEL_II). */
-                if ((result == CHIMERA_VFS_LEASE_BREAKING ||
-                     result == CHIMERA_VFS_LEASE_DENIED) &&
-                    req_vfs != CHIMERA_VFS_LEASE_MODE_R) {
-                    req_vfs                               = CHIMERA_VFS_LEASE_MODE_R;
+                /* Settle on the strongest caching lease actually grantable.
+                 * A conflict has two flavors:
+                 *   - BREAKING: try_insert kicked off a holder's break.  The
+                 *     break is optimistic (the holder downgrades to a shared
+                 *     read immediately), so simply retrying the SAME mode now
+                 *     usually succeeds; if it still conflicts we step down.
+                 *   - DENIED: an exclusive/batch grant is refused because
+                 *     another client has the file open (sole-access rule) or a
+                 *     holder is mid-downgrade; step the request down to a shared
+                 *     read (LEVEL_II), which coexists.
+                 * Loop, stepping W|H -> R, until granted or nothing is left to
+                 * try.  Bounded by the W->R step plus a few optimistic-break
+                 * retries. */
+                int settle_guard = 6;
+                while (result != CHIMERA_VFS_LEASE_GRANTED && settle_guard-- > 0) {
+                    if (req_vfs != CHIMERA_VFS_LEASE_MODE_R) {
+                        req_vfs = CHIMERA_VFS_LEASE_MODE_R;
+                    } else if (result != CHIMERA_VFS_LEASE_BREAKING) {
+                        /* Already at R and not merely waiting on an optimistic
+                         * break -- a shared read cache is unobtainable. */
+                        break;
+                    }
                     open_file->caching_lease.mode.granted = req_vfs;
                     result                                = chimera_vfs_state_try_insert(vfs_state, file_state,
                                                                                          &open_file->caching_lease,
@@ -549,7 +557,7 @@ chimera_smb_create_gen_open_file(
                     .owner_lo   = open_file->file_id.pid,
                     .owner_hi   = open_file->file_id.vid,
                 };
-                bool truncates =
+                bool                           truncates =
                     request->create.create_disposition == SMB2_FILE_OVERWRITE ||
                     request->create.create_disposition == SMB2_FILE_OVERWRITE_IF ||
                     request->create.create_disposition == SMB2_FILE_SUPERSEDE;

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -294,7 +294,6 @@ chimera_smb_create_gen_open_file(
         uint8_t                        req_smb         = 0;
         uint8_t                        req_vfs         = 0;
         bool                           via_rqls        = false;
-        bool                           durable_request = false;
         struct chimera_vfs_lease      *conflict        = NULL;
         enum chimera_vfs_lease_result  result;
 
@@ -321,45 +320,31 @@ chimera_smb_create_gen_open_file(
             } /* switch */
         }
 
-        durable_request = thread->shared->config.persistent_handles &&
-            (request->create.ctx_present_mask &
-             (CHIMERA_SMB_CREATE_CTX_DHNQ |
-              CHIMERA_SMB_CREATE_CTX_DH2Q)) != 0;
-
-        /* SMB lease bits use R=0x01, H=0x02, W=0x04 — different layout
-        * from vfs_state's R/W/H mask, so map field-by-field.  For ordinary
-        * opens we grant only the read-caching (R) bit — a LEVEL_II oplock —
-        * and deliberately withhold write caching (W) and handle caching (H):
+        /* SMB lease bits use R=0x01, H=0x02, W=0x04 — a different layout from
+        * vfs_state's R/W/H mask, so map field-by-field.  We grant the full
+        * requested set: read caching (R → LEVEL_II), write caching
+        * (W → EXCLUSIVE) and handle caching (H → BATCH).  The vfs_state
+        * conflict matrix keeps W single-writer-exclusive and H
+        * single-holder-exclusive, and the SMB layer breaks holders when a
+        * conflicting open / write / byte-range-lock / delete arrives.
         *
-        *   - Handle caching (batch oplock) makes the Linux cifs client keep
-        *     "deferred close" handles cached, which collide with unlink of
-        *     an open file (delete-of-open-file needs delete-pending across
-        *     the cached handle, not yet implemented) — cthon op_unlk failed
-        *     with EBUSY.
-        *   - Write caching lets the client buffer writes it has not flushed
-        *     to the server, which corrupts server-side copy: copy_file_range
-        *     (FSCTL_SRV_COPYCHUNK) reads the source on the server before the
-        *     buffered write lands, copying stale/zero data (fsx READ BAD
-        *     DATA).  Write-through keeps the server authoritative.
-        *
-        * Read caching is the important win and is coherent: a write breaks
-        * other holders' R leases (chimera_vfs_state_break_on_write), and the
-        * VFS attr/data caches keep a single client consistent.  A client that
-        * asked for an exclusive/batch oplock or an RWH lease simply receives
-        * the read-only (LEVEL_II) subset.
-        *
-        * Durable handles are the exception. MS-SMB2 requires a durable grant
-        * to be paired with a batch oplock or a HANDLE-caching lease, and WPTS
-        * verifies the durable response context on that initial CREATE. Only
-        * durable-aware clients take this path, so keep the normal-client
-        * behavior above while allowing the requested W/H bits here. */
+        * The two coherence hazards that previously forced a read-only policy
+        * (W and H withheld) are now handled in the break path rather than by
+        * withholding the cache:
+        *   - delete-of-open-file: unlink / rename / delete-on-close break the
+        *     H (handle-caching) holder so its deferred-close handle is recalled
+        *     before the remove (smb_proc_close.c / set_info / rename) — fixes
+        *     the old cthon op_unlk EBUSY.
+        *   - server-side copy: COPYCHUNK breaks the source's caching lease to
+        *     force a flush before it reads (smb_proc_copychunk.c) — fixes the
+        *     old fsx READ BAD DATA. */
         if (req_smb & SMB2_LEASE_READ_CACHING) {
             req_vfs |= CHIMERA_VFS_LEASE_MODE_R;
         }
-        if (durable_request && (req_smb & SMB2_LEASE_HANDLE_CACHING)) {
+        if (req_smb & SMB2_LEASE_HANDLE_CACHING) {
             req_vfs |= CHIMERA_VFS_LEASE_MODE_H;
         }
-        if (durable_request && (req_smb & SMB2_LEASE_WRITE_CACHING)) {
+        if (req_smb & SMB2_LEASE_WRITE_CACHING) {
             req_vfs |= CHIMERA_VFS_LEASE_MODE_W;
         }
 
@@ -500,17 +485,24 @@ chimera_smb_create_gen_open_file(
                 open_file->oplock_level = SMB2_OPLOCK_LEVEL_LEASE;
             }
 
-            if ((request->create.desired_access &
+            /* This open requested no caching lease of its own, but it can
+             * still break an oplock another open holds.  A data-modifying or
+             * deleting open breaks every holder all the way to NONE; a plain
+             * (non-modifying) data open downgrades an exclusive/batch holder to
+             * LEVEL_II.  A pure attribute-only open (caching_touches_data ==
+             * false) breaks nothing -- it must leave a stat-open holder's
+             * oplock intact. */
+            bool modifying =
+                (request->create.desired_access &
                  (SMB2_FILE_WRITE_DATA | SMB2_FILE_APPEND_DATA |
                   SMB2_GENERIC_WRITE | SMB2_GENERIC_ALL |
                   SMB2_DELETE | SMB2_MAXIMUM_ALLOWED)) ||
                 (request->create.create_options & SMB2_FILE_DELETE_ON_CLOSE) ||
                 request->create.create_disposition == SMB2_FILE_OVERWRITE ||
                 request->create.create_disposition == SMB2_FILE_OVERWRITE_IF ||
-                request->create.create_disposition == SMB2_FILE_SUPERSEDE) {
-                /* This open does not request a caching lease of its own, but
-                 * it modifies or deletes the file, so it must break any
-                 * caching oplock/lease another open holds. */
+                request->create.create_disposition == SMB2_FILE_SUPERSEDE;
+
+            if (modifying || caching_touches_data) {
                 struct chimera_vfs_lease_owner io_owner = {
                     .protocol   = CHIMERA_VFS_LEASE_PROTO_SMB2,
                     .client_key = request->session_handle->session->session_id,
@@ -518,8 +510,13 @@ chimera_smb_create_gen_open_file(
                     .owner_hi   = open_file->file_id.vid,
                 };
 
-                chimera_vfs_state_break_on_write(vfs_state, oh->fh, oh->fh_len,
-                                                 oh->fh_hash, &io_owner);
+                if (modifying) {
+                    chimera_vfs_state_break_on_write(vfs_state, oh->fh, oh->fh_len,
+                                                     oh->fh_hash, &io_owner);
+                } else {
+                    chimera_vfs_state_break_on_open(vfs_state, oh->fh, oh->fh_len,
+                                                    oh->fh_hash, &io_owner);
+                }
             }
         }
     }

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -127,6 +127,49 @@ chimera_smb_create_gen_open_file(
     open_file->stream_name_len = 0;
     open_file->base_fh_len     = 0;
 
+    /* A *batch* (handle-caching) oplock breaks BEFORE the share-mode check:
+     * the holder may close its deferred handle in response, after which the
+     * sharing conflict disappears.  Fire that break here so it happens even
+     * when this open is ultimately refused with a sharing violation (MS-FSA
+     * drives the break off the access attempt -- smb2.oplock.batch5 expects
+     * the break AND a SHARING_VIOLATION).  An exclusive (W-only) oplock is
+     * different: it breaks only once the open is granted (handled after the
+     * share-mode check), so we do NOT touch W-only holders here.  A truncating
+     * disposition replaces the data, so a batch holder breaks to NONE;
+     * otherwise it drops to LEVEL_II.  Pure attribute/EA opens break nothing
+     * (stat-open).  No-op on the first open; skips the opener's own lease. */
+    if (type == CHIMERA_SMB_OPEN_FILE_TYPE_FILE && tree->share && oh) {
+        uint32_t da   = open_file->desired_access;
+        uint32_t disp = request->create.create_disposition;
+        bool     truncates =
+            disp == SMB2_FILE_OVERWRITE ||
+            disp == SMB2_FILE_OVERWRITE_IF ||
+            disp == SMB2_FILE_SUPERSEDE;
+        bool break_trigger =
+            (da & (SMB2_FILE_READ_DATA | SMB2_FILE_WRITE_DATA |
+                   SMB2_FILE_APPEND_DATA | SMB2_FILE_EXECUTE |
+                   SMB2_GENERIC_READ | SMB2_GENERIC_WRITE |
+                   SMB2_GENERIC_EXECUTE | SMB2_GENERIC_ALL |
+                   SMB2_MAXIMUM_ALLOWED | SMB2_DELETE)) ||
+            (request->create.create_options & SMB2_FILE_DELETE_ON_CLOSE) ||
+            truncates;
+
+        if (break_trigger) {
+            struct chimera_vfs_state      *vfs_state = thread->vfs_thread->vfs->vfs_state;
+            struct chimera_vfs_lease_owner io_owner  = {
+                .protocol   = CHIMERA_VFS_LEASE_PROTO_SMB2,
+                .client_key = request->session_handle->session->session_id,
+                .owner_lo   = open_file->file_id.pid,
+                .owner_hi   = open_file->file_id.vid,
+            };
+
+            chimera_vfs_state_break_caching_for_open(vfs_state, oh->fh, oh->fh_len,
+                                                     oh->fh_hash, &io_owner,
+                                                     CHIMERA_VFS_LEASE_MODE_H,
+                                                     truncates ? 0 : CHIMERA_VFS_LEASE_MODE_R);
+        }
+    }
+
     /* Check share mode conflicts for regular file opens.
      * Attribute-only opens (READ_ATTRIBUTES, SYNCHRONIZE, etc.)
      * bypass share mode enforcement, matching Windows/NTFS behavior.
@@ -414,13 +457,19 @@ chimera_smb_create_gen_open_file(
                                                       &open_file->caching_lease,
                                                       &conflict);
 
-                /* A breakable conflict means another handle already holds a
-                 * caching oplock/lease.  try_insert has kicked off the break
-                 * (downgrading that holder to a shared read / LEVEL_II).  We
-                 * cannot keep an exclusive/write cache, but we can settle for
-                 * a shared read lease, which coexists with the downgraded
-                 * holder — this is how a 2nd open ends up with LEVEL_II. */
-                if (result == CHIMERA_VFS_LEASE_BREAKING) {
+                /* Another handle already holds a caching oplock/lease.  We
+                 * cannot keep an exclusive/write cache, but we can settle for a
+                 * shared read lease, which coexists with the (now downgraded)
+                 * holder -- this is how a 2nd open ends up with LEVEL_II.
+                 *   - BREAKING: try_insert just kicked off the holder's break.
+                 *   - DENIED: the holder was already broken to a shared read by
+                 *     the break-on-open above (its lease is ACKED, no longer
+                 *     IDLE-breakable), so a write cache is refused; a read cache
+                 *     still coexists.
+                 * Either way, retry for read-only caching (LEVEL_II). */
+                if ((result == CHIMERA_VFS_LEASE_BREAKING ||
+                     result == CHIMERA_VFS_LEASE_DENIED) &&
+                    req_vfs != CHIMERA_VFS_LEASE_MODE_R) {
                     req_vfs                               = CHIMERA_VFS_LEASE_MODE_R;
                     open_file->caching_lease.mode.granted = req_vfs;
                     result                                = chimera_vfs_state_try_insert(vfs_state, file_state,
@@ -485,37 +534,34 @@ chimera_smb_create_gen_open_file(
                 open_file->oplock_level = SMB2_OPLOCK_LEVEL_LEASE;
             }
 
-            /* This open requested no caching lease of its own, but it can
-             * still break an oplock another open holds.  A data-modifying or
-             * deleting open breaks every holder all the way to NONE; a plain
-             * (non-modifying) data open downgrades an exclusive/batch holder to
-             * LEVEL_II.  A pure attribute-only open (caching_touches_data ==
-             * false) breaks nothing -- it must leave a stat-open holder's
-             * oplock intact. */
-            bool modifying =
-                (request->create.desired_access &
-                 (SMB2_FILE_WRITE_DATA | SMB2_FILE_APPEND_DATA |
-                  SMB2_GENERIC_WRITE | SMB2_GENERIC_ALL |
-                  SMB2_DELETE | SMB2_MAXIMUM_ALLOWED)) ||
-                (request->create.create_options & SMB2_FILE_DELETE_ON_CLOSE) ||
-                request->create.create_disposition == SMB2_FILE_OVERWRITE ||
-                request->create.create_disposition == SMB2_FILE_OVERWRITE_IF ||
-                request->create.create_disposition == SMB2_FILE_SUPERSEDE;
-
-            if (modifying || caching_touches_data) {
+            /* The open has now been granted (it passed the share-mode check
+             * above).  Break a conflicting *exclusive* (W) holder: unlike a
+             * batch holder (already handled before the share check), an
+             * exclusive oplock breaks only once the conflicting open succeeds.
+             * A truncating open invalidates all cached data (break to NONE);
+             * any other data/delete open downgrades the holder to LEVEL_II.  A
+             * pure attribute/EA open (not caching_touches_data) breaks
+             * nothing.  Skips the opener's own lease (distinct owner). */
+            if (caching_touches_data) {
                 struct chimera_vfs_lease_owner io_owner = {
                     .protocol   = CHIMERA_VFS_LEASE_PROTO_SMB2,
                     .client_key = request->session_handle->session->session_id,
                     .owner_lo   = open_file->file_id.pid,
                     .owner_hi   = open_file->file_id.vid,
                 };
+                bool truncates =
+                    request->create.create_disposition == SMB2_FILE_OVERWRITE ||
+                    request->create.create_disposition == SMB2_FILE_OVERWRITE_IF ||
+                    request->create.create_disposition == SMB2_FILE_SUPERSEDE;
 
-                if (modifying) {
+                if (truncates) {
                     chimera_vfs_state_break_on_write(vfs_state, oh->fh, oh->fh_len,
                                                      oh->fh_hash, &io_owner);
                 } else {
-                    chimera_vfs_state_break_on_open(vfs_state, oh->fh, oh->fh_len,
-                                                    oh->fh_hash, &io_owner);
+                    chimera_vfs_state_break_caching_for_open(
+                        vfs_state, oh->fh, oh->fh_len, oh->fh_hash, &io_owner,
+                        CHIMERA_VFS_LEASE_MODE_W | CHIMERA_VFS_LEASE_MODE_H,
+                        CHIMERA_VFS_LEASE_MODE_R);
                 }
             }
         }

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -340,6 +340,50 @@ chimera_smb_create_gen_open_file(
         struct chimera_vfs_lease      *conflict = NULL;
         enum chimera_vfs_lease_result  result;
 
+        /* Phase 2 of the conflicting-open oplock break.  Phase 1 (the batch /
+         * handle-caching break that must precede the share-mode check) already
+         * ran before the share reservation above.  Now that this open is
+         * granted, break a conflicting *exclusive* (W-only) holder down to
+         * LEVEL_II; a truncating open replaces the data, so it instead
+         * invalidates every cached holder all the way to NONE.  This fires
+         * whether or not this open requests an oplock of its own (so it covers
+         * a plain reader / writer that takes no lease), and is a no-op when
+         * there is no conflicting holder or only the opener's own. */
+        {
+            uint32_t da        = open_file->desired_access;
+            uint32_t disp      = request->create.create_disposition;
+            bool     truncates =
+                disp == SMB2_FILE_OVERWRITE ||
+                disp == SMB2_FILE_OVERWRITE_IF ||
+                disp == SMB2_FILE_SUPERSEDE;
+            bool     break_trigger =
+                (da & (SMB2_FILE_READ_DATA | SMB2_FILE_WRITE_DATA |
+                       SMB2_FILE_APPEND_DATA | SMB2_FILE_EXECUTE |
+                       SMB2_GENERIC_READ | SMB2_GENERIC_WRITE |
+                       SMB2_GENERIC_EXECUTE | SMB2_GENERIC_ALL |
+                       SMB2_MAXIMUM_ALLOWED | SMB2_DELETE)) ||
+                (request->create.create_options & SMB2_FILE_DELETE_ON_CLOSE) ||
+                truncates;
+
+            if (break_trigger) {
+                struct chimera_vfs_lease_owner io_owner = {
+                    .protocol   = CHIMERA_VFS_LEASE_PROTO_SMB2,
+                    .client_key = request->session_handle->session->session_id,
+                    .owner_lo   = open_file->file_id.pid,
+                    .owner_hi   = open_file->file_id.vid,
+                };
+
+                if (truncates) {
+                    chimera_vfs_state_break_on_write(vfs_state, oh->fh, oh->fh_len,
+                                                     oh->fh_hash, &io_owner);
+                } else {
+                    chimera_vfs_state_break_caching_for_open(
+                        vfs_state, oh->fh, oh->fh_len, oh->fh_hash, &io_owner,
+                        CHIMERA_VFS_LEASE_MODE_W, CHIMERA_VFS_LEASE_MODE_R);
+                }
+            }
+        }
+
         if (request->create.ctx_present_mask & CHIMERA_SMB_CREATE_CTX_RQLS) {
             via_rqls = true;
             req_smb  = (uint8_t) (request->create.rqls.state & 0x07);
@@ -542,36 +586,10 @@ chimera_smb_create_gen_open_file(
                 open_file->oplock_level = SMB2_OPLOCK_LEVEL_LEASE;
             }
 
-            /* The open has now been granted (it passed the share-mode check
-             * above).  Break a conflicting *exclusive* (W) holder: unlike a
-             * batch holder (already handled before the share check), an
-             * exclusive oplock breaks only once the conflicting open succeeds.
-             * A truncating open invalidates all cached data (break to NONE);
-             * any other data/delete open downgrades the holder to LEVEL_II.  A
-             * pure attribute/EA open (not caching_touches_data) breaks
-             * nothing.  Skips the opener's own lease (distinct owner). */
-            if (caching_touches_data) {
-                struct chimera_vfs_lease_owner io_owner = {
-                    .protocol   = CHIMERA_VFS_LEASE_PROTO_SMB2,
-                    .client_key = request->session_handle->session->session_id,
-                    .owner_lo   = open_file->file_id.pid,
-                    .owner_hi   = open_file->file_id.vid,
-                };
-                bool                           truncates =
-                    request->create.create_disposition == SMB2_FILE_OVERWRITE ||
-                    request->create.create_disposition == SMB2_FILE_OVERWRITE_IF ||
-                    request->create.create_disposition == SMB2_FILE_SUPERSEDE;
-
-                if (truncates) {
-                    chimera_vfs_state_break_on_write(vfs_state, oh->fh, oh->fh_len,
-                                                     oh->fh_hash, &io_owner);
-                } else {
-                    chimera_vfs_state_break_caching_for_open(
-                        vfs_state, oh->fh, oh->fh_len, oh->fh_hash, &io_owner,
-                        CHIMERA_VFS_LEASE_MODE_W | CHIMERA_VFS_LEASE_MODE_H,
-                        CHIMERA_VFS_LEASE_MODE_R);
-                }
-            }
+            /* Any oplock this open needed to break was already broken by the
+             * two-phase break-on-open above (which runs whether or not this
+             * open requests a lease of its own), so there is nothing more to
+             * do for an open that takes no caching lease. */
         }
     }
 

--- a/src/server/smb/smb_proc_oplock_break.c
+++ b/src/server/smb/smb_proc_oplock_break.c
@@ -259,6 +259,13 @@ chimera_smb_lease_break_cb(
                             ? SMB2_OPLOCK_LEVEL_II
                             : SMB2_OPLOCK_LEVEL_NONE;
 
+        /* Breaking an exclusive/batch oplock expects the client to
+         * acknowledge; breaking a LEVEL_II oplock (to NONE) does not -- a
+         * client ack for that is a protocol error (see the ack handler). */
+        open_file->oplock_break_ack_required =
+            (open_file->oplock_level == SMB2_OPLOCK_LEVEL_EXCLUSIVE ||
+             open_file->oplock_level == SMB2_OPLOCK_LEVEL_BATCH);
+
         {
             struct chimera_smb_conn            *conn = open_file->create_conn;
             struct chimera_server_smb_thread   *bt   = conn->thread;
@@ -407,9 +414,49 @@ chimera_smb_parse_oplock_break(
 SYMBOL_EXPORT void
 chimera_smb_oplock_break(struct chimera_smb_request *request)
 {
-    /* The lease was already optimistically acked inside the break_cb.
-     * Nothing else to do besides letting the dispatcher emit the
-     * reply packet. */
+    struct chimera_server_smb_thread *thread    = request->compound->thread;
+    struct chimera_vfs_state         *vfs_state = thread->vfs_thread->vfs->vfs_state;
+    struct chimera_smb_open_file     *open_file;
+
+    if (request->oplock_break.is_lease) {
+        /* Lease-break ack: the lease was optimistically downgraded in the
+         * break_cb.  Honoring the client's exact NewLeaseState verbatim is a
+         * future refinement; just emit the response packet. */
+        chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
+        return;
+    }
+
+    open_file = chimera_smb_open_file_resolve(request, &request->oplock_break.file_id);
+
+    if (open_file) {
+        if (!open_file->oplock_break_ack_required) {
+            /* No acknowledgment was expected for this break -- e.g. it broke a
+             * LEVEL_II oplock to NONE, which MS-SMB2 says the client must not
+             * acknowledge.  Reply with the protocol error (3.3.5.22.2). */
+            chimera_smb_open_file_release(request, open_file);
+            chimera_smb_complete_request(request,
+                                         SMB2_STATUS_INVALID_OPLOCK_PROTOCOL);
+            return;
+        }
+
+        /* Apply the oplock level the client chose to keep (it may drop further
+         * than the server's optimistic downgrade -- e.g. straight to NONE). */
+        if (open_file->caching_lease_inserted) {
+            uint8_t kept =
+                (request->oplock_break.oplock_level == SMB2_OPLOCK_LEVEL_II)
+                ? CHIMERA_VFS_LEASE_MODE_R : 0;
+
+            chimera_vfs_lease_client_downgrade(vfs_state,
+                                               open_file->caching_file_state,
+                                               &open_file->caching_lease, kept);
+        }
+
+        open_file->oplock_level              = request->oplock_break.oplock_level;
+        open_file->oplock_break_ack_required = 0;
+
+        chimera_smb_open_file_release(request, open_file);
+    }
+
     chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
 } /* chimera_smb_oplock_break */
 

--- a/src/server/smb/smb_session.h
+++ b/src/server/smb/smb_session.h
@@ -113,6 +113,11 @@ struct chimera_smb_open_file {
     /* Phase-0 plumbing: fields populated by later phases. Zeroed on alloc. */
     uint32_t                         ctx_present_mask;
     uint8_t                          oplock_level;
+    /* Set when an outstanding legacy oplock break to this handle expects an
+     * acknowledgment (it broke an exclusive/batch oplock).  A break from
+     * LEVEL_II to NONE is NOT acknowledged; a client ack for one is a protocol
+     * error (MS-SMB2 -> NT_STATUS_INVALID_OPLOCK_PROTOCOL). */
+    uint8_t                          oplock_break_ack_required;
     uint8_t                          lease_state;
     uint16_t                         lease_epoch;
     uint32_t                         lease_flags;

--- a/src/vfs/vfs_state.c
+++ b/src/vfs/vfs_state.c
@@ -1407,6 +1407,67 @@ chimera_vfs_state_break_on_write(
     chimera_vfs_state_put(state, file);
 } /* chimera_vfs_state_break_on_write */
 
+/* Break-on-open: a conflicting open by a *different* owner that is not itself
+ * data-modifying downgrades an exclusive (W) or batch (W|H) holder to a shared
+ * read cache (LEVEL_II).  We break every other-owner caching lease that holds
+ * W or H, retaining only the read bit (needed_mode = R), and leave pure
+ * read-cache (LEVEL_II) holders untouched -- multiple readers coexist with a
+ * new opener.  This is the SMB break-on-second-open semantic; it is optimistic
+ * (the break is queued and the opener proceeds immediately). */
+static void
+chimera_vfs_break_caching_for_open(
+    struct chimera_vfs_state             *state,
+    struct chimera_vfs_file_state        *file,
+    const struct chimera_vfs_lease_owner *opener)
+{
+    struct chimera_vfs_lease *cur;
+    struct chimera_vfs_lease *to_break[CHIMERA_VFS_STATE_MAX_BREAK_BATCH];
+    int                       n = 0;
+    int                       i;
+
+    pthread_mutex_lock(&file->lock);
+
+    for (cur = file->caching_leases; cur; cur = cur->next) {
+        if ((cur->mode.granted & (CHIMERA_VFS_LEASE_MODE_W |
+                                  CHIMERA_VFS_LEASE_MODE_H)) == 0) {
+            continue;
+        }
+        if (chimera_vfs_lease_owner_equal(&cur->owner, opener)) {
+            continue;
+        }
+        if (n < CHIMERA_VFS_STATE_MAX_BREAK_BATCH) {
+            to_break[n++] = cur;
+        }
+    }
+
+    pthread_mutex_unlock(&file->lock);
+
+    for (i = 0; i < n; i++) {
+        chimera_vfs_lease_begin_break(state, to_break[i],
+                                      CHIMERA_VFS_LEASE_MODE_R, 0);
+    }
+} /* chimera_vfs_break_caching_for_open */
+
+SYMBOL_EXPORT void
+chimera_vfs_state_break_on_open(
+    struct chimera_vfs_state             *state,
+    const uint8_t                        *fh,
+    uint8_t                               fh_len,
+    uint64_t                              fh_hash,
+    const struct chimera_vfs_lease_owner *opener)
+{
+    struct chimera_vfs_file_state *file;
+
+    file = chimera_vfs_state_get(state, fh, fh_len, fh_hash, false);
+    if (!file) {
+        return;
+    }
+
+    chimera_vfs_break_caching_for_open(state, file, opener);
+
+    chimera_vfs_state_put(state, file);
+} /* chimera_vfs_state_break_on_open */
+
 /* -------------------------------------------------------------------- */
 /* Implicit I/O lease                                                   */
 /* -------------------------------------------------------------------- */

--- a/src/vfs/vfs_state.c
+++ b/src/vfs/vfs_state.c
@@ -1407,29 +1407,40 @@ chimera_vfs_state_break_on_write(
     chimera_vfs_state_put(state, file);
 } /* chimera_vfs_state_break_on_write */
 
-/* Break-on-open: a conflicting open by a *different* owner that is not itself
- * data-modifying downgrades an exclusive (W) or batch (W|H) holder to a shared
- * read cache (LEVEL_II).  We break every other-owner caching lease that holds
- * W or H, retaining only the read bit (needed_mode = R), and leave pure
- * read-cache (LEVEL_II) holders untouched -- multiple readers coexist with a
- * new opener.  This is the SMB break-on-second-open semantic; it is optimistic
- * (the break is queued and the opener proceeds immediately). */
-static void
-chimera_vfs_break_caching_for_open(
+/* Break-on-open: a conflicting open by a *different* owner breaks caching
+ * holders.  `trigger_bits` selects which holders break -- only a lease whose
+ * granted mode intersects `trigger_bits` is affected -- and `retain_mode` is
+ * the mask the holder keeps (R to downgrade an exclusive/batch oplock to
+ * LEVEL_II, 0 to break all the way to NONE).  Holders the opener owns are
+ * skipped.  The break is optimistic from vfs_state's point of view (it is
+ * queued; the opener proceeds), but the SMB layer may choose to wait. */
+SYMBOL_EXPORT void
+chimera_vfs_state_break_caching_for_open(
     struct chimera_vfs_state             *state,
-    struct chimera_vfs_file_state        *file,
-    const struct chimera_vfs_lease_owner *opener)
+    const uint8_t                        *fh,
+    uint8_t                               fh_len,
+    uint64_t                              fh_hash,
+    const struct chimera_vfs_lease_owner *opener,
+    uint8_t                               trigger_bits,
+    uint8_t                               retain_mode)
 {
-    struct chimera_vfs_lease *cur;
-    struct chimera_vfs_lease *to_break[CHIMERA_VFS_STATE_MAX_BREAK_BATCH];
-    int                       n = 0;
-    int                       i;
+    struct chimera_vfs_file_state *file;
+    struct chimera_vfs_lease      *cur;
+    struct chimera_vfs_lease      *to_break[CHIMERA_VFS_STATE_MAX_BREAK_BATCH];
+    int                            n = 0;
+    int                            i;
+
+    file = chimera_vfs_state_get(state, fh, fh_len, fh_hash, false);
+    if (!file) {
+        return;
+    }
 
     pthread_mutex_lock(&file->lock);
 
     for (cur = file->caching_leases; cur; cur = cur->next) {
-        if ((cur->mode.granted & (CHIMERA_VFS_LEASE_MODE_W |
-                                  CHIMERA_VFS_LEASE_MODE_H)) == 0) {
+        /* Only holders that actually hold one of the trigger bits beyond what
+         * they get to retain need to break. */
+        if ((cur->mode.granted & trigger_bits & ~retain_mode) == 0) {
             continue;
         }
         if (chimera_vfs_lease_owner_equal(&cur->owner, opener)) {
@@ -1443,30 +1454,11 @@ chimera_vfs_break_caching_for_open(
     pthread_mutex_unlock(&file->lock);
 
     for (i = 0; i < n; i++) {
-        chimera_vfs_lease_begin_break(state, to_break[i],
-                                      CHIMERA_VFS_LEASE_MODE_R, 0);
+        chimera_vfs_lease_begin_break(state, to_break[i], retain_mode, 0);
     }
-} /* chimera_vfs_break_caching_for_open */
-
-SYMBOL_EXPORT void
-chimera_vfs_state_break_on_open(
-    struct chimera_vfs_state             *state,
-    const uint8_t                        *fh,
-    uint8_t                               fh_len,
-    uint64_t                              fh_hash,
-    const struct chimera_vfs_lease_owner *opener)
-{
-    struct chimera_vfs_file_state *file;
-
-    file = chimera_vfs_state_get(state, fh, fh_len, fh_hash, false);
-    if (!file) {
-        return;
-    }
-
-    chimera_vfs_break_caching_for_open(state, file, opener);
 
     chimera_vfs_state_put(state, file);
-} /* chimera_vfs_state_break_on_open */
+} /* chimera_vfs_state_break_caching_for_open */
 
 /* -------------------------------------------------------------------- */
 /* Implicit I/O lease                                                   */

--- a/src/vfs/vfs_state.c
+++ b/src/vfs/vfs_state.c
@@ -626,6 +626,27 @@ chimera_vfs_state_would_conflict(
                     }
                 }
             }
+
+            /* An SMB exclusive (W) or batch (W|H) oplock may only be granted to
+             * the SOLE opener of a file: if another client already has it open
+             * (a share reservation with a different client key), the request is
+             * capped to a shared read cache (LEVEL_II).  Signal that by denying
+             * the W/H grant -- the SMB create path retries for R-only, which
+             * coexists.  (Pure attribute-only opens take no share reservation,
+             * so they do not preclude an oplock.) */
+            if (probe->owner.protocol == CHIMERA_VFS_LEASE_PROTO_SMB2 &&
+                (probe->mode.granted & (CHIMERA_VFS_LEASE_MODE_W |
+                                        CHIMERA_VFS_LEASE_MODE_H))) {
+                for (cur = file->share_resvs; cur; cur = cur->next) {
+                    if (cur->owner.client_key == probe->owner.client_key) {
+                        continue; /* the requesting client's own open(s) */
+                    }
+                    if (conflict_out) {
+                        *conflict_out = cur;
+                    }
+                    return CHIMERA_VFS_LEASE_DENIED;
+                }
+            }
             /* An NFSv4 delegation must not be granted when another client
              * already has the file open in a conflicting mode: a read
              * delegation is denied by another client's write open; a write
@@ -1193,6 +1214,43 @@ chimera_vfs_lease_ack(
     }
 } /* chimera_vfs_lease_ack */
 
+/* Apply the lease state a client chose in its OPLOCK_BREAK / lease-break
+ * acknowledgment.  The server optimistically settled the lease at the maximum
+ * the holder could keep (the break's needed_mode); the client may keep less
+ * (e.g. drop straight to NONE), so intersect the granted mode down to its
+ * choice.  A lease that still retains access re-arms (IDLE) so it can break
+ * again later; one reduced to NONE becomes inert (ACKED) until close.  Pumps
+ * waiters in case the further downgrade unblocks them. */
+SYMBOL_EXPORT void
+chimera_vfs_lease_client_downgrade(
+    struct chimera_vfs_state      *state,
+    struct chimera_vfs_file_state *file,
+    struct chimera_vfs_lease      *lease,
+    uint8_t                        kept_mode)
+{
+    bool mutated = false;
+
+    if (!file) {
+        return;
+    }
+
+    pthread_mutex_lock(&file->lock);
+
+    if (lease->mode.granted & ~kept_mode) {
+        lease->mode.granted &= kept_mode;
+        lease->break_state   = lease->mode.granted ? CHIMERA_VFS_BREAK_IDLE
+                                                    : CHIMERA_VFS_BREAK_ACKED;
+        mutated = true;
+    }
+
+    pthread_mutex_unlock(&file->lock);
+
+    if (mutated && state) {
+        chimera_vfs_state_pump_pending(state, file);
+        chimera_vfs_state_pump_io(state, file);
+    }
+} /* chimera_vfs_lease_client_downgrade */
+
 SYMBOL_EXPORT void
 chimera_vfs_lease_revoke(struct chimera_vfs_lease *lease)
 {
@@ -1374,6 +1432,16 @@ chimera_vfs_break_reads_for_write(
         if ((cur->mode.granted & CHIMERA_VFS_LEASE_MODE_W) &&
             chimera_vfs_lease_owner_equal(&cur->owner, writer)) {
             continue;
+        }
+        /* A lease already broken once and settled at LEVEL_II (ACKED, still
+         * holding R) must re-arm so this write can break it again -- this time
+         * to NONE.  (A write is a fresh invalidation event, distinct from the
+         * open that produced the LEVEL_II downgrade, so re-breaking here does
+         * not double-fire within a single open.)  begin_break only acts on an
+         * IDLE lease, so flip it back under the lock. */
+        if (cur->break_state == CHIMERA_VFS_BREAK_ACKED &&
+            cur->owner.break_cb) {
+            cur->break_state = CHIMERA_VFS_BREAK_IDLE;
         }
         if (n < CHIMERA_VFS_STATE_MAX_BREAK_BATCH) {
             to_break[n++] = cur;

--- a/src/vfs/vfs_state.h
+++ b/src/vfs/vfs_state.h
@@ -265,6 +265,18 @@ chimera_vfs_lease_ack(
     struct chimera_vfs_lease     *lease,
     struct chimera_vfs_lease_mode resulting);
 
+/* Apply the lease state a client selected in its (legacy or lease) oplock-break
+ * acknowledgment.  The server already optimistically settled the lease at the
+ * maximum the holder could keep; the client may keep less.  `kept_mode` is what
+ * the client retains (R for LEVEL_II, 0 for NONE); the lease's granted mode is
+ * intersected down to it and re-armed if anything survives. */
+void
+chimera_vfs_lease_client_downgrade(
+    struct chimera_vfs_state      *state,
+    struct chimera_vfs_file_state *file,
+    struct chimera_vfs_lease      *lease,
+    uint8_t                        kept_mode);
+
 /* Forcibly revoke a lease — called by vfs_state when the break deadline
  * expires, or by the protocol server when it gives up on the client. */
 void

--- a/src/vfs/vfs_state.h
+++ b/src/vfs/vfs_state.h
@@ -357,3 +357,15 @@ chimera_vfs_state_break_on_write(
     uint8_t                               fh_len,
     uint64_t                              fh_hash,
     const struct chimera_vfs_lease_owner *writer);
+
+/* Break-on-open: downgrade any exclusive (W) or batch (W|H) caching lease held
+ * by a *different* owner on (fh, fh_hash) to a shared read cache (LEVEL_II),
+ * leaving pure read-cache holders untouched.  Drives the SMB2 "second open
+ * breaks the oplock to level II" semantic for a non-modifying opener. */
+void
+chimera_vfs_state_break_on_open(
+    struct chimera_vfs_state             *state,
+    const uint8_t                        *fh,
+    uint8_t                               fh_len,
+    uint64_t                              fh_hash,
+    const struct chimera_vfs_lease_owner *opener);

--- a/src/vfs/vfs_state.h
+++ b/src/vfs/vfs_state.h
@@ -358,14 +358,22 @@ chimera_vfs_state_break_on_write(
     uint64_t                              fh_hash,
     const struct chimera_vfs_lease_owner *writer);
 
-/* Break-on-open: downgrade any exclusive (W) or batch (W|H) caching lease held
- * by a *different* owner on (fh, fh_hash) to a shared read cache (LEVEL_II),
- * leaving pure read-cache holders untouched.  Drives the SMB2 "second open
- * breaks the oplock to level II" semantic for a non-modifying opener. */
+/* Break-on-open: break caching leases held by a *different* owner on
+ * (fh, fh_hash) when a conflicting open arrives.  `trigger_bits` selects which
+ * holders break (only those whose granted mode holds a trigger bit they don't
+ * get to keep); `retain_mode` is what the holder keeps (R downgrades an
+ * exclusive/batch oplock to LEVEL_II, 0 breaks to NONE).  Drives the SMB2
+ * second-open break semantics:
+ *   - batch (H) holders break before the share-mode check (handle caching, the
+ *     holder may close): trigger = H;
+ *   - exclusive (W) holders break only once the open is granted: trigger = W|H.
+ */
 void
-chimera_vfs_state_break_on_open(
+chimera_vfs_state_break_caching_for_open(
     struct chimera_vfs_state             *state,
     const uint8_t                        *fh,
     uint8_t                               fh_len,
     uint64_t                              fh_hash,
-    const struct chimera_vfs_lease_owner *opener);
+    const struct chimera_vfs_lease_owner *opener,
+    uint8_t                               trigger_bits,
+    uint8_t                               retain_mode);


### PR DESCRIPTION
## Summary

Teaches the SMB2 server to actually grant **EXCLUSIVE** (0x08) and **BATCH** (0x09) oplocks (and the W/H bits of RqLs leases) instead of silently downgrading every oplock to LEVEL_II, and replaces the old optimistic-ack stub with a real oplock **break/ack state machine**.

This is an **incremental, partial** step toward greening the `smb2.oplock` smbtorture suite: **25 / 42 subtests pass on memfs** (was 0). The suite is **not** added to any backend's `SMBTORTURE_ENABLED_*` allowlist yet, so it stays `DISABLED` in ctest — this PR changes runtime oplock behavior without claiming the suite is green.

Stacked on #582 (the short-frame crash fix); review/merge that first.

## What's implemented

- **Grant exclusive/batch** — drop the durable-handle-only gate in `smb_proc_create.c` so an EXCLUSIVE request gets a write-caching (W) lease and BATCH gets write+handle (W|H). The VFS `vfs_state` lease layer already enforces W/H exclusivity correctly.
- **Two-phase break-on-open** — a *batch/handle* oplock breaks **before** the share-mode check (the holder may close, so the break fires even when the open is refused with SHARING_VIOLATION); an *exclusive* oplock breaks only **after** the open is granted. Truncating dispositions break to NONE, others to LEVEL_II. Fires whether or not the new open requests an oplock of its own.
- **Real break/ack cycle** (`vfs_state`):
  - a write re-arms a settled LEVEL_II lease so it can break again to NONE (self-break-on-write);
  - `chimera_vfs_lease_client_downgrade()` + the inbound OPLOCK_BREAK ack handler apply the level the client actually kept (it may drop below the server's optimistic downgrade);
  - an ack for a non-ack-required (LEVEL_II to NONE) break returns `NT_STATUS_INVALID_OPLOCK_PROTOCOL`.
- **Sole-access rule** — an exclusive/batch grant is capped to LEVEL_II when another client already has the file open.
- The caching grant settles via a bounded `W|H -> R` step-down so a conflicting 2nd open lands at LEVEL_II once holders are broken.

## Test status

`smb2.oplock` memfs, in isolation: **25/42 pass**, 0 crashes. Passing: exclusive1-5, batch1/2/4/5/6/8/10-16/21/23/24/25, levelii500/501/502.

**Regression gate — clean.** The whole point of the previous read-only-oplock policy was to keep the Linux cifs KVM suites green (delete-of-open-file -> cthon `op_unlk`; client write-caching -> fsx READ BAD DATA). I ran the full SMB KVM suite against this branch:

- `chimera/kvm/ubuntu2404/smb/cthon/*` (basic, general, special) — **18/18 pass**
- `chimera/kvm/ubuntu2404/smb/xfstests/*` (fsx, fsstress, dirstress, nametest, fstest) — all pass
- **54/54 SMB KVM tests pass, 0 failures**, across memfs / linux / io_uring / diskfs_io_uring / diskfs_aio / cairn.

So granting W/H oplocks does **not** regress cthon or fsx — the break machinery in this PR keeps the client coherent without the previously-feared delete-of-open-file / copychunk-flush work. Also no regression on the enabled `smb2.check-sharemode` / `smb2.sharemode` smbtorture suites.

## Not yet handled (follow-ups)

Each is a distinct mechanism, tracked for later PRs: CREATE park-on-close (batch3/7, doc — async wait for a batch holder to close); rename-vs-share-mode (exclusive6, batch19/20); attribute-only-holder sole-access (batch9/9a); byte-range-lock x oplock (brl1/2/3); same-connection break-before-response ordering (statopen1); named-stream oplocks (stream1, batch26); disposition matrix (exclusive9); oplock-timeout deadline revoke (batch22a).
