### PR TITLE
pynfs: raise the readdir-suite wrapper timeout to 180s (RDDR8b arm64 flake)

### DIFF
--- a/pynfs/CMakeLists.txt
+++ b/pynfs/CMakeLists.txt
@@ -120,6 +120,20 @@ set(PYNFS_LEASE_OVERRIDE_destroy_session DSESS9002 DSESS9003)
 set(PYNFS_LEASE_OVERRIDE_SECONDS_destroy_session 40)
 set(PYNFS_TIMEOUT_destroy_session 180)
 
+# The readdir suite carries one CPU-bound code, RDDR8b
+# (st_readdir.testDircountVarious), which loops 300 sequential READDIR
+# compounds through pynfs's pure-Python RPC client.  On amd64 it runs in
+# ~20s wall clock; on the emulated-arm64 devcontainer CI runner (Python
+# under QEMU TCG, 3-5x slower) it bumps against the wrapper's 60s default
+# and all six backends in that job time out together at ~62s.  Server side
+# is irrelevant -- chimera's READDIR finishes in microseconds for these
+# parameters; the budget is purely the client's Python-cost x 300 calls.
+# Raise the readdir-suite timeout to give RDDR8b headroom on the slow
+# runner; the other readdir codes finish in well under 1s, so a higher
+# cap is a no-op for them.  Matches the headroom used for the (similarly
+# pynfs-client-bound) delegations and destroy_session suites.
+set(PYNFS_TIMEOUT_readdir 180)
+
 function(pynfs_codes_for_flag flag minor out_var)
     if("${minor}" STREQUAL "0")
         set(testserver ${PYNFS_DIR}/nfs4.0/testserver.py)


### PR DESCRIPTION
## Problem

The pynfs `readdir` suite intermittently fails its `RDDR8b` code on the **devcontainer arm64 Release** runner, killing all six backends in the same job at ~62 s wall clock. Most recent sighting: PR #608's CI run [#26742892458](https://github.com/chimera-nas/chimera/actions/runs/26742892458) — job 78811100920 — tests 2465 / 2483 / 2501 / 2519 / 2537 / 2555 (`memfs`, `linux`, `io_uring`, `diskfs_io_uring`, `diskfs_aio`, `cairn`), each timing out at ~62 s. This is unrelated to PR #608's diff and to chimera correctness.

The failure mode in the wrapper output is the wrapper-level kill, not a stuck request:

```
RDDR8b   st_readdir.testDircountVarious : RUNNING
=== PyNFS wall-clock timeout (60s) — killed ===
```

## Root cause

`testDircountVarious` (`pynfs/nfs4.0/servertests/st_readdir.py:189`) loops 300 sequential READDIR compounds through pynfs's pure-Python single-threaded RPC client. Each call is one synchronous XDR-pack + `send_record` + `recv_record` + XDR-unpack round trip; the per-call cost is dominated by Python work, not the wire or the server.

On amd64 the test runs in ~20 s wall clock across all four passing backends, and `user` time tracks `real` — it's CPU-bound on the pynfs client, not blocked on chimera:

```
memfs:               real    0m20.278s
diskfs_io_uring:     real    0m20.507s
diskfs_aio:          real    0m21.036s
cairn:               real    0m20.485s
```

20 s fits in the wrapper's 60 s default. The CI runner is emulated arm64 (per the existing self-hosted ARC/devcontainer setup) where Python under QEMU TCG runs roughly 3–5× slower, so wall clock goes to ~60–100 s and bumps the kill. All six backends in the same job hit it at almost the same wall-clock time because they share the runner under the same Python cost — this is the same shape as the WRT15 client-bound case we've already documented.

Chimera's READDIR for these parameters (`dircount=8172, maxcount=32768`, 100 entries) finishes in microseconds — there's no server bug here, the budget is the client's Python cost times 300 calls.

## Fix

The CMakeLists already has the `PYNFS_TIMEOUT_<flag>` knob — 180 s for `delegations`/`destroy_session`, 90 s for `courteous`. Add the same for `readdir`:

```cmake
set(PYNFS_TIMEOUT_readdir 180)
```

Every other readdir code completes in well under 1 s, so the higher cap is a no-op for them and only loosens the ceiling on the one code that actually approaches it.