### PR TITLE
nfs4.2: derive FATTR4_XATTR_SUPPORT from backend capability (#422)

### DIFF
--- a/src/server/nfs/nfs4_attr.h
+++ b/src/server/nfs/nfs4_attr.h
@@ -67,6 +67,23 @@ chimera_nfs4_pnfs_layout_type(
     return 0;
 } /* chimera_nfs4_pnfs_layout_type */
 
+/*
+ * Returns 1 if the file identified by fh is backed by a VFS module that
+ * implements extended attributes (CHIMERA_VFS_CAP_XATTR), else 0. Used to set
+ * the per-object NFSv4.2 FATTR4_XATTR_SUPPORT value (RFC 8276) from the actual
+ * backend capability rather than a constant. Unlike pNFS, xattr has no
+ * server-wide feature gate, so the capability bit is the sole signal.
+ */
+static inline int
+chimera_nfs4_xattr_supported(
+    struct chimera_vfs_thread *vfs_thread,
+    const void                *fh,
+    int                        fhlen)
+{
+    return (chimera_vfs_module_capabilities(vfs_thread, fh, fhlen) &
+            CHIMERA_VFS_CAP_XATTR) ? 1 : 0;
+} /* chimera_nfs4_xattr_supported */
+
 static inline uint64_t
 chimera_nfs4_attr2mask(
     uint32_t *words,
@@ -346,6 +363,7 @@ chimera_nfs4_marshall_attrs(
     uint32_t                        max_attrvals,
     uint8_t                         minorversion,
     uint32_t                        pnfs_layout_type,
+    int                             xattr_supported,
     int                             nfs4_delegations,
     uint32_t                        lease_time_s)
 {
@@ -817,8 +835,9 @@ chimera_nfs4_marshall_attrs(
             rsp_mask[2]  |= (1 << (FATTR4_XATTR_SUPPORT - 64));
             *num_rsp_mask = 3;
 
-            /* memfs and the other validated backends support xattrs. */
-            chimera_nfs4_attr_append_uint32(&attrs, 1);
+            /* Per-object: TRUE only if this file's backend implements xattrs
+             * (CHIMERA_VFS_CAP_XATTR). See RFC 8276 sec 8.2.1 - per-fs attribute. */
+            chimera_nfs4_attr_append_uint32(&attrs, xattr_supported);
         }
 
         if (req_mask[2] & (1 << (FATTR4_SUPPATTR_EXCLCREAT - 64))) {

--- a/src/server/nfs/nfs4_proc_getattr.c
+++ b/src/server/nfs/nfs4_proc_getattr.c
@@ -94,6 +94,8 @@ chimera_nfs4_getattr_finish(
                                 chimera_nfs4_pnfs_layout_type(req->thread->vfs_thread,
                                                               req->thread->shared->vfs,
                                                               req->fh, req->fhlen),
+                                chimera_nfs4_xattr_supported(req->thread->vfs_thread,
+                                                             req->fh, req->fhlen),
                                 chimera_server_config_get_nfs4_delegations(
                                     req->thread->shared->config),
                                 req->thread->shared->nfs_lease_time_s);

--- a/src/server/nfs/nfs4_proc_readdir.c
+++ b/src/server/nfs/nfs4_proc_readdir.c
@@ -76,6 +76,8 @@ chimera_nfs4_readdir_callback(
                                 chimera_nfs4_pnfs_layout_type(req->thread->vfs_thread,
                                                               req->thread->shared->vfs,
                                                               req->fh, req->fhlen),
+                                chimera_nfs4_xattr_supported(req->thread->vfs_thread,
+                                                             req->fh, req->fhlen),
                                 chimera_server_config_get_nfs4_delegations(
                                     req->thread->shared->config),
                                 req->thread->shared->nfs_lease_time_s);

--- a/src/server/nfs/nfs4_proc_verify.c
+++ b/src/server/nfs/nfs4_proc_verify.c
@@ -98,6 +98,8 @@ chimera_nfs4_verify_complete(
                                 chimera_nfs4_pnfs_layout_type(req->thread->vfs_thread,
                                                               req->thread->shared->vfs,
                                                               req->fh, req->fhlen),
+                                chimera_nfs4_xattr_supported(req->thread->vfs_thread,
+                                                             req->fh, req->fhlen),
                                 chimera_server_config_get_nfs4_delegations(
                                     req->thread->shared->config),
                                 req->thread->shared->nfs_lease_time_s);

--- a/src/server/nfs/nfs4_root.c
+++ b/src/server/nfs/nfs4_root.c
@@ -159,6 +159,7 @@ nfs4_root_readdir_lookup_callback(
                                 256,
                                 0,
                                 0, /* pNFS not advertised on the pseudo-fs root */
+                                0, /* pseudo-fs root has no xattr-capable backend */
                                 0,
                                 ctx->lease_time_s);
 } /* nfs4_root_readdir_lookup_callback */

--- a/src/server/nfs/tests/test_protocol_advertise.c
+++ b/src/server/nfs/tests/test_protocol_advertise.c
@@ -43,7 +43,7 @@ test_open_arguments_supported_attrs_follows_delegation_config(void)
     req_mask[0] = (1 << FATTR4_SUPPORTED_ATTRS);
 
     chimera_nfs4_marshall_attrs(&attr, 3, req_mask, &num_rsp_mask, rsp_mask, 3,
-                                attrvals, &attrvals_len, sizeof(attrvals), 1, 0, 0, 60);
+                                attrvals, &attrvals_len, sizeof(attrvals), 1, 0, 0, 0, 60);
 
     assert(num_rsp_mask == 1);
     assert(rsp_mask[0] == (1 << FATTR4_SUPPORTED_ATTRS));
@@ -53,7 +53,7 @@ test_open_arguments_supported_attrs_follows_delegation_config(void)
     memset(rsp_mask, 0, sizeof(rsp_mask));
     memset(attrvals, 0, sizeof(attrvals));
     chimera_nfs4_marshall_attrs(&attr, 3, req_mask, &num_rsp_mask, rsp_mask, 3,
-                                attrvals, &attrvals_len, sizeof(attrvals), 1, 0, 1, 60);
+                                attrvals, &attrvals_len, sizeof(attrvals), 1, 0, 0, 1, 60);
 
     assert(num_rsp_mask == 1);
     assert(rsp_mask[0] == (1 << FATTR4_SUPPORTED_ATTRS));
@@ -75,7 +75,7 @@ test_open_arguments_attr_follows_delegation_config(void)
     req_mask[2] = (1 << (FATTR4_OPEN_ARGUMENTS - 64));
 
     chimera_nfs4_marshall_attrs(&attr, 3, req_mask, &num_rsp_mask, rsp_mask, 3,
-                                attrvals, &attrvals_len, sizeof(attrvals), 1, 0, 0, 60);
+                                attrvals, &attrvals_len, sizeof(attrvals), 1, 0, 0, 0, 60);
 
     assert(num_rsp_mask == 0);
     assert(attrvals_len == 0);
@@ -84,7 +84,7 @@ test_open_arguments_attr_follows_delegation_config(void)
     memset(rsp_mask, 0, sizeof(rsp_mask));
     memset(attrvals, 0, sizeof(attrvals));
     chimera_nfs4_marshall_attrs(&attr, 3, req_mask, &num_rsp_mask, rsp_mask, 3,
-                                attrvals, &attrvals_len, sizeof(attrvals), 1, 0, 1, 60);
+                                attrvals, &attrvals_len, sizeof(attrvals), 1, 0, 0, 1, 60);
 
     assert(num_rsp_mask == 3);
     assert(attrvals_len == 40);
@@ -95,12 +95,48 @@ test_open_arguments_attr_follows_delegation_config(void)
             (1 << OPEN_ARGS_SHARE_ACCESS_WANT_NO_DELEG)));
 } /* test_open_arguments_attr_follows_delegation_config */
 
+static void
+test_xattr_support_value_follows_backend_capability(void)
+{
+    struct chimera_vfs_attrs attr;
+    uint32_t                 req_mask[3] = { 0 };
+    uint32_t                 rsp_mask[3] = { 0 };
+    uint32_t                 num_rsp_mask;
+    uint32_t                 attrvals_len;
+    uint8_t                  attrvals[256];
+
+    memset(&attr, 0, sizeof(attr));
+    req_mask[2] = (1 << (FATTR4_XATTR_SUPPORT - 64));
+
+    /* xattr_supported = 0 -> the per-object value encodes FALSE. */
+    chimera_nfs4_marshall_attrs(&attr, 3, req_mask, &num_rsp_mask, rsp_mask, 3,
+                                attrvals, &attrvals_len, sizeof(attrvals), 2, 0, 0, 0, 60);
+
+    assert(num_rsp_mask == 3);
+    assert(attrvals_len == 4);
+    assert((rsp_mask[2] & (1 << (FATTR4_XATTR_SUPPORT - 64))) != 0);
+    assert(get_u32(attrvals, 0) == 0);
+
+    memset(rsp_mask, 0, sizeof(rsp_mask));
+    memset(attrvals, 0, sizeof(attrvals));
+
+    /* xattr_supported = 1 -> the per-object value encodes TRUE. */
+    chimera_nfs4_marshall_attrs(&attr, 3, req_mask, &num_rsp_mask, rsp_mask, 3,
+                                attrvals, &attrvals_len, sizeof(attrvals), 2, 0, 1, 0, 60);
+
+    assert(num_rsp_mask == 3);
+    assert(attrvals_len == 4);
+    assert((rsp_mask[2] & (1 << (FATTR4_XATTR_SUPPORT - 64))) != 0);
+    assert(get_u32(attrvals, 0) == 1);
+} /* test_xattr_support_value_follows_backend_capability */
+
 int
 main(void)
 {
     test_unimplemented_delegation_ops_not_advertised();
     test_open_arguments_supported_attrs_follows_delegation_config();
     test_open_arguments_attr_follows_delegation_config();
+    test_xattr_support_value_follows_backend_capability();
 
     return 0;
 } /* main */


### PR DESCRIPTION
## Problem

Audit finding **NFS42-017** (#422): the NFSv4.2 server returned `FATTR4_XATTR_SUPPORT = TRUE` for every object at minor version 2 regardless of which VFS backend backs it. The hardcoded value lived at `nfs4_attr.h`, whose own comment admitted the limitation. A backend that does not implement xattrs would advertise support and then fail the actual GET/SET/LIST/REMOVE_XATTR ops with ENOTSUP, misleading clients (the Linux client wires up its xattr handlers off this attribute).

## Fix

Derive the per-object value from the file's VFS module capability (`CHIMERA_VFS_CAP_XATTR`) at marshal time, via a new `chimera_nfs4_xattr_supported()` helper threaded into `chimera_nfs4_marshall_attrs` — mirroring exactly how `pnfs_layout_type` is already computed per-filehandle and passed in.

The `supported_attrs` word-2 bit stays advertised unconditionally at mv2 (the server understands the attribute); only the TRUE/FALSE **value** becomes backend-derived.

## Why per-filehandle, and why the supported_attrs bit stays unconditional

- RFC 8276 §8.2.1 defines `xattr_support` as a per-filesystem read-only attribute whose value legitimately varies across a namespace.
- Both reference servers do exactly this: **Linux knfsd** evaluates it per-inode (`xattr_supports_user_prefix()`), **nfs-ganesha** per-export (`fs_supports(fso_xattr_support)`), and both keep the `supported_attrs` bit static while varying only the value — consistent with the spec's discover-then-query contract.
- Chimera binds one export → one mount → exactly one VFS module today (no junctions), so an export can't straddle backends; but deriving per-filehandle matches the spec/reference behavior and is future-proof if junctions are ever added.

## Changes

- `nfs4_attr.h`: new `chimera_nfs4_xattr_supported()` helper; new `xattr_supported` param on `chimera_nfs4_marshall_attrs`; value site emits it instead of a constant.
- `nfs4_proc_getattr.c` / `nfs4_proc_readdir.c` / `nfs4_proc_verify.c`: pass the computed value off `req->fh`.
- `nfs4_root.c`: pass `0` (the pseudo-fs root has no xattr-capable backend).
- `tests/test_protocol_advertise.c`: updated existing calls + new `test_xattr_support_value_follows_backend_capability` regression test (value tracks the capability at mv2).

All five current backends declare `CHIMERA_VFS_CAP_XATTR`, so no runtime behavior changes today; the advertisement is now correct for any future backend that omits it.

Closes #422