### PR TITLE
nfs/mount: complete MOUNTD procedures (DUMP/UMNTALL/EXPORT) + rmtab table

### DIFF
--- a/src/nfs_common/mount.x
+++ b/src/nfs_common/mount.x
@@ -45,6 +45,19 @@ struct mountbody {
  mountbody *ml_next;
 };
 
+/*
+ * RFC 1813 declares MOUNTPROC3_DUMP as returning a bare "mountlist"
+ * (an optional mountbody pointer).  xdrzcc does not emit the leading
+ * "value-follows" boolean for a procedure that returns a bare optional
+ * pointer, so wrap it in a one-field struct -- the wire encoding of an
+ * optional pointer inside a struct is identical to RFC's mountlist
+ * (bool + chained mountbody), and the wrapper also lets DUMP return an
+ * empty list (mounts == NULL) without a NULL deref.
+ */
+struct mountdumpres {
+ mountbody *mounts;
+};
+
 struct mountres3_ok {
  fhandle3   fhandle;
  int        auth_flavors<>;
@@ -65,7 +78,7 @@ program NFS_MOUNT {
  version NFS_MOUNT_V3 {
   void      MOUNTPROC3_NULL(void)    = 0;
   mountres3 MOUNTPROC3_MNT(mountarg3)  = 1;
-  mountbody* MOUNTPROC3_DUMP(void)    = 2;
+  mountdumpres MOUNTPROC3_DUMP(void)  = 2;
   void      MOUNTPROC3_UMNT(mountarg3) = 3;
   void      MOUNTPROC3_UMNTALL(void) = 4;
   exportres MOUNTPROC3_EXPORT(void)  = 5;

--- a/src/nfs_common/mount.x
+++ b/src/nfs_common/mount.x
@@ -1,6 +1,7 @@
 
 /*
  * SPDX-FileCopyrightText: IETF Trust and the persons identified
+ * SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
  * SPDX-License-Identifier: BSD-3-Clause
  */
  

--- a/src/server/nfs/nfs.c
+++ b/src/server/nfs/nfs.c
@@ -375,6 +375,7 @@ nfs_server_init(
     }
 
     pthread_mutex_init(&shared->exports_lock, NULL);
+    pthread_mutex_init(&shared->mount_entries_lock, NULL);
     return shared;
 } /* nfs_server_init */
 
@@ -440,6 +441,7 @@ nfs_server_destroy(void *data)
 {
     struct chimera_server_nfs_shared *shared = data;
     struct chimera_nfs_export        *export;
+    struct chimera_nfs_mount_entry   *mount_entry;
     struct evpl                      *evpl;
     struct chimera_vfs_thread        *vfs_thread;
 
@@ -552,6 +554,14 @@ nfs_server_destroy(void *data)
         shared->num_exports--;
         chimera_nfs_abort_if(shared->num_exports < 0, "num_exports went negative");
         free(export);
+    }
+
+    while (shared->mount_entries) {
+        mount_entry = shared->mount_entries;
+        LL_DELETE(shared->mount_entries, mount_entry);
+        shared->num_mount_entries--;
+        chimera_nfs_abort_if(shared->num_mount_entries < 0, "num_mount_entries went negative");
+        free(mount_entry);
     }
 
     nlm_state_destroy(&shared->nlm_state);

--- a/src/server/nfs/nfs_common.h
+++ b/src/server/nfs/nfs_common.h
@@ -176,6 +176,20 @@ struct chimera_nfs_export {
     struct chimera_nfs_export *next;
 };
 
+/*
+ * In-memory rmtab-style mount-entry table (RFC 1813 App. I).  MOUNTPROC3_MNT
+ * records an entry, UMNT/UMNTALL remove them, and DUMP enumerates them
+ * (showmount -a/-d).  Advisory only and not persisted across restart.
+ * hostname is the caller's address (port stripped); directory is the
+ * client-requested export path.
+ */
+struct chimera_nfs_mount_entry {
+    char                            hostname[64];
+    char                            directory[MNTPATHLEN + 1];
+    struct chimera_nfs_mount_entry *prev;
+    struct chimera_nfs_mount_entry *next;
+};
+
 /* Prometheus instances for the NFS4.1 SEQUENCE replay cache.  All
  * counters are best-effort (not atomic); contention is low because
  * SEQUENCE handling is per-session under that session's lock. */
@@ -231,6 +245,10 @@ struct chimera_server_nfs_shared {
     struct chimera_nfs_export          *exports;
     pthread_mutex_t                     exports_lock;
     int                                 num_exports;
+
+    struct chimera_nfs_mount_entry     *mount_entries;
+    pthread_mutex_t                     mount_entries_lock;
+    int                                 num_mount_entries;
     struct evpl_endpoint               *nfs_endpoint;
     struct evpl_endpoint               *mount_endpoint;
     struct evpl_endpoint               *portmap_endpoint;

--- a/src/server/nfs/nfs_mount.c
+++ b/src/server/nfs/nfs_mount.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-only
 
 #include <stdio.h>
+#include <string.h>
 #include <utlist.h>
 
 #include "nfs.h"
@@ -11,6 +12,139 @@
 #include "nfs_mount.h"
 #include "vfs/vfs.h"
 #include "vfs/vfs_procs.h"
+
+/*
+ * Derive the rmtab hostname for a connection: the caller's remote address with
+ * the transport port stripped (IPv4 "addr:port" and IPv6 "[addr]:port").
+ */
+static void
+chimera_nfs_mount_client_host(
+    struct evpl_rpc2_conn *conn,
+    char                  *out,
+    int                    out_len)
+{
+    char   addr[64];
+    char  *rbracket, *colon;
+    size_t n;
+
+    evpl_rpc2_conn_get_remote_address(conn, addr, sizeof(addr));
+
+    if (addr[0] == '[') {
+        /* IPv6 "[addr]:port" -> addr */
+        rbracket = strchr(addr, ']');
+        if (rbracket) {
+            n = rbracket - (addr + 1);
+            if (n >= (size_t) out_len) {
+                n = out_len - 1;
+            }
+            memcpy(out, addr + 1, n);
+            out[n] = '\0';
+            return;
+        }
+    }
+
+    /* IPv4 "addr:port" -> addr */
+    snprintf(out, out_len, "%s", addr);
+    colon = strrchr(out, ':');
+    if (colon) {
+        *colon = '\0';
+    }
+} /* chimera_nfs_mount_client_host */
+
+/*
+ * Record a mount entry in the rmtab.  Deduplicates on (hostname, directory)
+ * so a re-mount does not create a second entry.
+ */
+static void
+chimera_nfs_mount_record(
+    struct chimera_server_nfs_shared *shared,
+    const char                       *hostname,
+    const char                       *directory)
+{
+    struct chimera_nfs_mount_entry *entry;
+
+    pthread_mutex_lock(&shared->mount_entries_lock);
+
+    LL_FOREACH(shared->mount_entries, entry)
+    {
+        if (strcmp(entry->hostname, hostname) == 0 &&
+            strcmp(entry->directory, directory) == 0) {
+            pthread_mutex_unlock(&shared->mount_entries_lock);
+            return;
+        }
+    }
+
+    entry = calloc(1, sizeof(*entry));
+    snprintf(entry->hostname, sizeof(entry->hostname), "%s", hostname);
+    snprintf(entry->directory, sizeof(entry->directory), "%s", directory);
+    LL_PREPEND(shared->mount_entries, entry);
+    shared->num_mount_entries++;
+
+    pthread_mutex_unlock(&shared->mount_entries_lock);
+} /* chimera_nfs_mount_record */
+
+/* Remove the rmtab entry matching (hostname, directory), if any (UMNT). */
+static void
+chimera_nfs_mount_remove(
+    struct chimera_server_nfs_shared *shared,
+    const char                       *hostname,
+    const char                       *directory)
+{
+    struct chimera_nfs_mount_entry *entry, *tmp;
+
+    pthread_mutex_lock(&shared->mount_entries_lock);
+    LL_FOREACH_SAFE(shared->mount_entries, entry, tmp)
+    {
+        if (strcmp(entry->hostname, hostname) == 0 &&
+            strcmp(entry->directory, directory) == 0) {
+            LL_DELETE(shared->mount_entries, entry);
+            shared->num_mount_entries--;
+            chimera_nfs_abort_if(shared->num_mount_entries < 0,
+                                 "num_mount_entries went negative");
+            free(entry);
+            break;
+        }
+    }
+    pthread_mutex_unlock(&shared->mount_entries_lock);
+} /* chimera_nfs_mount_remove */
+
+/* Remove all rmtab entries for a host (UMNTALL). */
+static void
+chimera_nfs_mount_remove_host(
+    struct chimera_server_nfs_shared *shared,
+    const char                       *hostname)
+{
+    struct chimera_nfs_mount_entry *entry, *tmp;
+
+    pthread_mutex_lock(&shared->mount_entries_lock);
+    LL_FOREACH_SAFE(shared->mount_entries, entry, tmp)
+    {
+        if (strcmp(entry->hostname, hostname) == 0) {
+            LL_DELETE(shared->mount_entries, entry);
+            shared->num_mount_entries--;
+            chimera_nfs_abort_if(shared->num_mount_entries < 0,
+                                 "num_mount_entries went negative");
+            free(entry);
+        }
+    }
+    pthread_mutex_unlock(&shared->mount_entries_lock);
+} /* chimera_nfs_mount_remove_host */
+
+/* Copy an XDR mount path argument into a NUL-terminated, length-bounded buffer. */
+static void
+chimera_nfs_mount_copy_path(
+    const xdr_string *path,
+    char             *out,
+    int               out_len)
+{
+    uint32_t len = path->len;
+
+    if (len > (uint32_t) (out_len - 1)) {
+        len = out_len - 1;
+    }
+    memcpy(out, path->str, len);
+    out[len] = '\0';
+} /* chimera_nfs_mount_copy_path */
 
 void
 chimera_nfs_mount_null(
@@ -85,6 +219,8 @@ chimera_nfs_mount_mnt(
     char                             *full_path = NULL;
     uint8_t                           root_fh[CHIMERA_VFS_FH_SIZE];
     uint32_t                          root_fh_len;
+    char                              hostname[64];
+    char                              directory[MNTPATHLEN + 1];
 
     req = nfs_request_alloc(thread, conn, encoding);
 
@@ -100,6 +236,17 @@ chimera_nfs_mount_mnt(
         chimera_nfs_mount_lookup_complete(CHIMERA_VFS_ENOENT, NULL, req);
         return;
     }
+
+    /*
+     * Record the mount in the rmtab keyed by the client-requested path (which
+     * is what UMNT will present and what showmount displays).  The export
+     * resolved, so the subsequent VFS lookup of its root is expected to
+     * succeed; recording here keeps the advisory rmtab simple without
+     * threading the path through the async completion.
+     */
+    chimera_nfs_mount_client_host(conn, hostname, sizeof(hostname));
+    chimera_nfs_mount_copy_path(&args->path, directory, sizeof(directory));
+    chimera_nfs_mount_record(shared, hostname, directory);
 
     chimera_vfs_get_root_fh(root_fh, &root_fh_len);
     chimera_vfs_lookup(thread->vfs_thread,
@@ -126,7 +273,44 @@ chimera_nfs_mount_dump(
     struct evpl_rpc2_encoding *encoding,
     void                      *private_data)
 {
-    chimera_nfs_debug("Received MOUNTPROC3_DUMP request");
+    struct chimera_server_nfs_thread *thread = private_data;
+    struct chimera_server_nfs_shared *shared = thread->shared;
+    struct chimera_nfs_mount_entry   *entry;
+    struct mountdumpres               res;
+    struct mountbody                 *head = NULL, *tail = NULL, *node;
+    int                               rc;
+
+    pthread_mutex_lock(&shared->mount_entries_lock);
+    LL_FOREACH(shared->mount_entries, entry)
+    {
+        node = xdr_dbuf_alloc_space(sizeof(*node), encoding->dbuf);
+        if (!node) {
+            chimera_nfs_error("MOUNTPROC3_DUMP: reply buffer exhausted, truncating mount list");
+            break;
+        }
+        node->ml_next = NULL;
+
+        if (xdr_dbuf_alloc_string(&node->ml_hostname, entry->hostname,
+                                  strlen(entry->hostname), encoding->dbuf) ||
+            xdr_dbuf_alloc_string(&node->ml_directory, entry->directory,
+                                  strlen(entry->directory), encoding->dbuf)) {
+            chimera_nfs_error("MOUNTPROC3_DUMP: reply buffer exhausted, truncating mount list");
+            break;
+        }
+
+        if (tail) {
+            tail->ml_next = node;
+        } else {
+            head = node;
+        }
+        tail = node;
+    }
+    pthread_mutex_unlock(&shared->mount_entries_lock);
+
+    res.mounts = head;
+
+    rc = shared->mount_v3.send_reply_MOUNTPROC3_DUMP(evpl, NULL, &res, encoding);
+    chimera_nfs_abort_if(rc, "Failed to send RPC2 reply");
 } /* chimera_nfs_mount_dump */
 
 void
@@ -140,7 +324,13 @@ chimera_nfs_mount_umnt(
 {
     struct chimera_server_nfs_thread *thread = private_data;
     struct chimera_server_nfs_shared *shared = thread->shared;
+    char                              hostname[64];
+    char                              directory[MNTPATHLEN + 1];
     int                               rc;
+
+    chimera_nfs_mount_client_host(conn, hostname, sizeof(hostname));
+    chimera_nfs_mount_copy_path(&args->path, directory, sizeof(directory));
+    chimera_nfs_mount_remove(shared, hostname, directory);
 
     rc = shared->mount_v3.send_reply_MOUNTPROC3_UMNT(evpl, NULL, encoding);
     chimera_nfs_abort_if(rc, "Failed to send RPC2 reply");
@@ -154,7 +344,16 @@ chimera_nfs_mount_umntall(
     struct evpl_rpc2_encoding *encoding,
     void                      *private_data)
 {
-    chimera_nfs_debug("Received MOUNTPROC3_UMNTALL request");
+    struct chimera_server_nfs_thread *thread = private_data;
+    struct chimera_server_nfs_shared *shared = thread->shared;
+    char                              hostname[64];
+    int                               rc;
+
+    chimera_nfs_mount_client_host(conn, hostname, sizeof(hostname));
+    chimera_nfs_mount_remove_host(shared, hostname);
+
+    rc = shared->mount_v3.send_reply_MOUNTPROC3_UMNTALL(evpl, NULL, encoding);
+    chimera_nfs_abort_if(rc, "Failed to send RPC2 reply");
 } /* chimera_nfs_mount_umntall */
 
 void
@@ -167,11 +366,41 @@ chimera_nfs_mount_export(
 {
     struct chimera_server_nfs_thread *thread = private_data;
     struct chimera_server_nfs_shared *shared = thread->shared;
-    struct exportres                  export;
+    struct chimera_nfs_export        *export;
+    struct exportres                  res;
+    struct exportnode                *head = NULL, *tail = NULL, *node;
     int                               rc;
 
-    export.exports = NULL;
+    pthread_mutex_lock(&shared->exports_lock);
+    LL_FOREACH(shared->exports, export)
+    {
+        node = xdr_dbuf_alloc_space(sizeof(*node), encoding->dbuf);
+        if (!node) {
+            chimera_nfs_error("MOUNTPROC3_EXPORT: reply buffer exhausted, truncating export list");
+            break;
+        }
+        /* No per-export group restriction; ex_groups == NULL means exported to
+         * everyone.  Per-client access control is tracked separately (#69). */
+        node->ex_groups = NULL;
+        node->ex_next   = NULL;
 
-    rc = shared->mount_v3.send_reply_MOUNTPROC3_EXPORT(evpl, NULL, &export, encoding);
+        if (xdr_dbuf_alloc_string(&node->ex_dir, export->name,
+                                  strlen(export->name), encoding->dbuf)) {
+            chimera_nfs_error("MOUNTPROC3_EXPORT: reply buffer exhausted, truncating export list");
+            break;
+        }
+
+        if (tail) {
+            tail->ex_next = node;
+        } else {
+            head = node;
+        }
+        tail = node;
+    }
+    pthread_mutex_unlock(&shared->exports_lock);
+
+    res.exports = head;
+
+    rc = shared->mount_v3.send_reply_MOUNTPROC3_EXPORT(evpl, NULL, &res, encoding);
     chimera_nfs_abort_if(rc, "Failed to send RPC2 reply");
 } /* chimera_nfs_mount_export */

--- a/src/server/nfs/nfs_mount.c
+++ b/src/server/nfs/nfs_mount.c
@@ -90,10 +90,10 @@ chimera_nfs_mount_remove(
     const char                       *hostname,
     const char                       *directory)
 {
-    struct chimera_nfs_mount_entry *entry, *tmp;
+    struct chimera_nfs_mount_entry *entry;
 
     pthread_mutex_lock(&shared->mount_entries_lock);
-    LL_FOREACH_SAFE(shared->mount_entries, entry, tmp)
+    LL_FOREACH(shared->mount_entries, entry)
     {
         if (strcmp(entry->hostname, hostname) == 0 &&
             strcmp(entry->directory, directory) == 0) {
@@ -114,19 +114,27 @@ chimera_nfs_mount_remove_host(
     struct chimera_server_nfs_shared *shared,
     const char                       *hostname)
 {
-    struct chimera_nfs_mount_entry *entry, *tmp;
+    struct chimera_nfs_mount_entry *entry, *next, *keep = NULL;
 
     pthread_mutex_lock(&shared->mount_entries_lock);
-    LL_FOREACH_SAFE(shared->mount_entries, entry, tmp)
-    {
+    /* Single pass partitioning the list: free entries for this host, re-link
+     * the survivors.  next is captured before any free so the cursor never
+     * touches freed memory. */
+    entry = shared->mount_entries;
+    while (entry) {
+        next = entry->next;
         if (strcmp(entry->hostname, hostname) == 0) {
-            LL_DELETE(shared->mount_entries, entry);
             shared->num_mount_entries--;
             chimera_nfs_abort_if(shared->num_mount_entries < 0,
                                  "num_mount_entries went negative");
             free(entry);
+        } else {
+            entry->next = keep;
+            keep        = entry;
         }
+        entry = next;
     }
+    shared->mount_entries = keep;
     pthread_mutex_unlock(&shared->mount_entries_lock);
 } /* chimera_nfs_mount_remove_host */
 


### PR DESCRIPTION
## Summary

The NFSv3 MOUNT (mountd) handlers were stubbed. `MOUNTPROC3_DUMP` and `MOUNTPROC3_UMNTALL` only logged a debug line and **sent no RPC reply at all**, so real clients hang until timeout; `MOUNTPROC3_EXPORT` always returned an empty list (`showmount -e` and automounters saw nothing); and there was no rmtab-style mount-entry table, so DUMP/UMNTALL had nothing to report.

This completes the MOUNTD procedures, closing the four audit issues in `feat:mount`.

Closes #375, #376, #377, #378.

## Changes

- **In-memory rmtab** — added `struct chimera_nfs_mount_entry` and `mount_entries` / `mount_entries_lock` / `num_mount_entries` to `chimera_server_nfs_shared`, modeled on the existing exports table. `MNT` records an entry (deduped on host+dir), `UMNT` removes the matching one, `UMNTALL` removes all entries for the caller host. The hostname is the caller's remote address with the `:port` stripped (IPv4 and IPv6). Advisory and in-memory only per RFC 1813 — not persisted across restart.
- **DUMP / EXPORT** build their reply linked lists in the reply dbuf (same idiom as the nfs3 readdir path), with a defensive truncate-and-stop if the dbuf fills. EXPORT enumerates the configured exports; `ex_groups` is left `NULL` (exported to everyone) since per-client export access control is tracked separately (#69).
- **xdrzcc top-level optional-pointer fix** — wrapped the DUMP return in a one-field struct (`mountdumpres { mountbody *mounts; }`). xdrzcc does not emit the leading "value-follows" boolean for a procedure that returns a *bare* top-level optional pointer (`mountbody*`), which produced a malformed reply (`showmount -a` → "RPC: Can't decode result") and would NULL-deref on the empty list. The wire encoding of an in-struct optional pointer is identical to RFC 1813's `mountlist`. (`EXPORT` already worked because it returns the wrapper struct `exportres`.)

## Validation

Verified live against a real Linux NFSv3 client (memfs `/nfs1` export):

- `showmount -e` lists `/nfs1`
- `showmount -a` is empty before mount (no hang/crash), shows `<client-ip>:/nfs1` after; `showmount -d` lists `/nfs1`
- `umount` removes the entry; re-mounting dedups to a single entry
- Release and Debug (ASan) builds clean; uncrustify and copyright-year clean

The KVM cthon NFS3 suites are the CI integration path for this.

## Out of scope

Related `feat:mount`/audit issues left for separate work: #374 (NSM/statd `SM_PROG 100024`), #382 (UDP transport), #381 (RPCSEC_GSS), #69 (per-client export access control).