### PR TITLE
nfs4: terminate the COMPOUND on ALLOCATE/DEALLOCATE/SEEK errors and honor special stateids

### DIFF
--- a/src/server/nfs/nfs4_proc_allocate.c
+++ b/src/server/nfs/nfs4_proc_allocate.c
@@ -24,13 +24,47 @@ chimera_nfs4_allocate_complete(
         res->ar_status = chimera_nfs4_errno_to_nfsstat4(error_code);
     }
 
-    nfs_state_table_release(&req->thread->shared->nfs4_state_table,
-                            req->nfs_state_ref, req->nfs_state_type,
-                            req->thread->vfs_thread);
-    req->nfs_state_ref = NULL;
+    if (req->nfs_state_ref) {
+        nfs_state_table_release(&req->thread->shared->nfs4_state_table,
+                                req->nfs_state_ref, req->nfs_state_type,
+                                req->thread->vfs_thread);
+        req->nfs_state_ref = NULL;
+    } else if (req->handle) {
+        /* Special stateid: release the on-the-fly handle we opened. */
+        chimera_vfs_release(req->thread->vfs_thread, req->handle);
+        req->handle = NULL;
+    }
 
-    chimera_nfs4_compound_complete(req, NFS4_OK);
+    chimera_nfs4_compound_complete(req, res->ar_status);
 } /* chimera_nfs4_allocate_complete */
+
+static void
+chimera_nfs4_allocate_open_callback(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *handle,
+    void                           *private_data)
+{
+    struct nfs_request   *req  = private_data;
+    struct ALLOCATE4args *args = &req->args_compound->argarray[req->index].opallocate;
+    struct ALLOCATE4res  *res  = &req->res_compound.resarray[req->index].opallocate;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        res->ar_status = chimera_nfs4_errno_to_nfsstat4(error_code);
+        chimera_nfs4_compound_complete(req, res->ar_status);
+        return;
+    }
+
+    req->handle = handle;
+
+    chimera_vfs_allocate(req->thread->vfs_thread, &req->cred,
+                         handle,
+                         args->aa_offset,
+                         args->aa_length,
+                         0,
+                         0, 0,
+                         chimera_nfs4_allocate_complete,
+                         req);
+} /* chimera_nfs4_allocate_open_callback */
 
 void
 chimera_nfs4_allocate(
@@ -47,11 +81,38 @@ chimera_nfs4_allocate(
     struct chimera_vfs_open_handle *state_handle;
     nfsstat4                        status;
 
+    req->nfs_state_ref = NULL;
+    req->handle        = NULL;
+
+    /* NFS4.1 current-stateid substitution (RFC 8881 §16.2.3.1.2). */
+    chimera_nfs4_resolve_current_stateid(req, &args->aa_stateid);
+
+    /*
+     * RFC 8881 §8.2.3 requires ALLOCATE to honor the special stateids.  These
+     * carry no state-table entry, so open the current FH on the fly instead of
+     * consulting the state table.
+     */
+    if (nfs4_stateid_is_special(&args->aa_stateid)) {
+        if (req->fhlen == 0) {
+            res->ar_status = NFS4ERR_NOFILEHANDLE;
+            chimera_nfs4_compound_complete(req, res->ar_status);
+            return;
+        }
+
+        chimera_vfs_open_fh(thread->vfs_thread, &req->cred,
+                            req->fh,
+                            req->fhlen,
+                            CHIMERA_VFS_OPEN_INFERRED,
+                            chimera_nfs4_allocate_open_callback,
+                            req);
+        return;
+    }
+
     status = nfs_state_table_acquire(table, &args->aa_stateid, 0,
                                      &state_void, &state_type);
     if (status != NFS4_OK) {
         res->ar_status = status;
-        chimera_nfs4_compound_complete(req, NFS4_OK);
+        chimera_nfs4_compound_complete(req, res->ar_status);
         return;
     }
 

--- a/src/server/nfs/nfs4_proc_deallocate.c
+++ b/src/server/nfs/nfs4_proc_deallocate.c
@@ -24,13 +24,49 @@ chimera_nfs4_deallocate_complete(
         res->dr_status = chimera_nfs4_errno_to_nfsstat4(error_code);
     }
 
-    nfs_state_table_release(&req->thread->shared->nfs4_state_table,
-                            req->nfs_state_ref, req->nfs_state_type,
-                            req->thread->vfs_thread);
-    req->nfs_state_ref = NULL;
+    if (req->nfs_state_ref) {
+        nfs_state_table_release(&req->thread->shared->nfs4_state_table,
+                                req->nfs_state_ref, req->nfs_state_type,
+                                req->thread->vfs_thread);
+        req->nfs_state_ref = NULL;
+    } else if (req->handle) {
+        /* Special stateid: release the on-the-fly handle we opened. */
+        chimera_vfs_release(req->thread->vfs_thread, req->handle);
+        req->handle = NULL;
+    }
 
-    chimera_nfs4_compound_complete(req, NFS4_OK);
+    chimera_nfs4_compound_complete(req, res->dr_status);
 } /* chimera_nfs4_deallocate_complete */
+
+static void
+chimera_nfs4_deallocate_open_callback(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *handle,
+    void                           *private_data)
+{
+    struct nfs_request     *req  = private_data;
+    struct DEALLOCATE4args *args = &req->args_compound->argarray[req->index].
+        opdeallocate;
+    struct DEALLOCATE4res  *res = &req->res_compound.resarray[req->index].
+        opdeallocate;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        res->dr_status = chimera_nfs4_errno_to_nfsstat4(error_code);
+        chimera_nfs4_compound_complete(req, res->dr_status);
+        return;
+    }
+
+    req->handle = handle;
+
+    chimera_vfs_allocate(req->thread->vfs_thread, &req->cred,
+                         handle,
+                         args->da_offset,
+                         args->da_length,
+                         CHIMERA_VFS_ALLOCATE_DEALLOCATE,
+                         0, 0,
+                         chimera_nfs4_deallocate_complete,
+                         req);
+} /* chimera_nfs4_deallocate_open_callback */
 
 void
 chimera_nfs4_deallocate(
@@ -47,11 +83,38 @@ chimera_nfs4_deallocate(
     struct chimera_vfs_open_handle *state_handle;
     nfsstat4                        status;
 
+    req->nfs_state_ref = NULL;
+    req->handle        = NULL;
+
+    /* NFS4.1 current-stateid substitution (RFC 8881 §16.2.3.1.2). */
+    chimera_nfs4_resolve_current_stateid(req, &args->da_stateid);
+
+    /*
+     * RFC 8881 §8.2.3 requires DEALLOCATE to honor the special stateids.  These
+     * carry no state-table entry, so open the current FH on the fly instead of
+     * consulting the state table.
+     */
+    if (nfs4_stateid_is_special(&args->da_stateid)) {
+        if (req->fhlen == 0) {
+            res->dr_status = NFS4ERR_NOFILEHANDLE;
+            chimera_nfs4_compound_complete(req, res->dr_status);
+            return;
+        }
+
+        chimera_vfs_open_fh(thread->vfs_thread, &req->cred,
+                            req->fh,
+                            req->fhlen,
+                            CHIMERA_VFS_OPEN_INFERRED,
+                            chimera_nfs4_deallocate_open_callback,
+                            req);
+        return;
+    }
+
     status = nfs_state_table_acquire(table, &args->da_stateid, 0,
                                      &state_void, &state_type);
     if (status != NFS4_OK) {
         res->dr_status = status;
-        chimera_nfs4_compound_complete(req, NFS4_OK);
+        chimera_nfs4_compound_complete(req, res->dr_status);
         return;
     }
 

--- a/src/server/nfs/nfs4_proc_seek.c
+++ b/src/server/nfs/nfs4_proc_seek.c
@@ -26,13 +26,45 @@ chimera_nfs4_seek_complete(
         res->sa_status = chimera_nfs4_errno_to_nfsstat4(error_code);
     }
 
-    nfs_state_table_release(&req->thread->shared->nfs4_state_table,
-                            req->nfs_state_ref, req->nfs_state_type,
-                            req->thread->vfs_thread);
-    req->nfs_state_ref = NULL;
+    if (req->nfs_state_ref) {
+        nfs_state_table_release(&req->thread->shared->nfs4_state_table,
+                                req->nfs_state_ref, req->nfs_state_type,
+                                req->thread->vfs_thread);
+        req->nfs_state_ref = NULL;
+    } else if (req->handle) {
+        /* Special stateid: release the on-the-fly handle we opened. */
+        chimera_vfs_release(req->thread->vfs_thread, req->handle);
+        req->handle = NULL;
+    }
 
-    chimera_nfs4_compound_complete(req, NFS4_OK);
+    chimera_nfs4_compound_complete(req, res->sa_status);
 } /* chimera_nfs4_seek_complete */
+
+static void
+chimera_nfs4_seek_open_callback(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *handle,
+    void                           *private_data)
+{
+    struct nfs_request *req  = private_data;
+    struct SEEK4args   *args = &req->args_compound->argarray[req->index].opseek;
+    struct SEEK4res    *res  = &req->res_compound.resarray[req->index].opseek;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        res->sa_status = chimera_nfs4_errno_to_nfsstat4(error_code);
+        chimera_nfs4_compound_complete(req, res->sa_status);
+        return;
+    }
+
+    req->handle = handle;
+
+    chimera_vfs_seek(req->thread->vfs_thread, &req->cred,
+                     handle,
+                     args->sa_offset,
+                     args->sa_what,
+                     chimera_nfs4_seek_complete,
+                     req);
+} /* chimera_nfs4_seek_open_callback */
 
 void
 chimera_nfs4_seek(
@@ -49,11 +81,38 @@ chimera_nfs4_seek(
     struct chimera_vfs_open_handle *state_handle;
     nfsstat4                        status;
 
+    req->nfs_state_ref = NULL;
+    req->handle        = NULL;
+
+    /* NFS4.1 current-stateid substitution (RFC 8881 §16.2.3.1.2). */
+    chimera_nfs4_resolve_current_stateid(req, &args->sa_stateid);
+
+    /*
+     * RFC 8881 §8.2.3 requires SEEK to honor the special stateids.  These carry
+     * no state-table entry, so open the current FH on the fly instead of
+     * consulting the state table.
+     */
+    if (nfs4_stateid_is_special(&args->sa_stateid)) {
+        if (req->fhlen == 0) {
+            res->sa_status = NFS4ERR_NOFILEHANDLE;
+            chimera_nfs4_compound_complete(req, res->sa_status);
+            return;
+        }
+
+        chimera_vfs_open_fh(thread->vfs_thread, &req->cred,
+                            req->fh,
+                            req->fhlen,
+                            CHIMERA_VFS_OPEN_INFERRED | CHIMERA_VFS_OPEN_READ_ONLY,
+                            chimera_nfs4_seek_open_callback,
+                            req);
+        return;
+    }
+
     status = nfs_state_table_acquire(table, &args->sa_stateid, 0,
                                      &state_void, &state_type);
     if (status != NFS4_OK) {
         res->sa_status = status;
-        chimera_nfs4_compound_complete(req, NFS4_OK);
+        chimera_nfs4_compound_complete(req, res->sa_status);
         return;
     }
 


### PR DESCRIPTION
Fixes #406.

## Problem

ALLOCATE, DEALLOCATE, and SEEK set their op-specific status on a VFS error but then passed a hardcoded `NFS4_OK` to `chimera_nfs4_compound_complete()`. Because that `status` argument is what drives COMPOUND termination, the overall `res_compound.status` stayed `NFS4_OK` and the server kept processing later operations in the compound. Per RFC 7862 §15.1.1 / RFC 5661 §16.2.4, a failed operation MUST stop the COMPOUND. COPY already does this correctly via `res->cr_status`.

## Fix

**Compound termination.** Pass the op's own status field (`ar_status` / `dr_status` / `sa_status`) in both the completion callback and the state-acquire-failure early return, matching READ/WRITE/COPY. On success the field is `NFS4_OK`, so the happy path is unchanged.

**Special-stateid handling (latent bug the above exposed).** Fixing termination surfaced that these three ops never honored the NFSv4 special stateids — the anonymous all-zeros and READ-bypass all-ones. They fed the special stateid straight into `nfs_state_table_acquire()`, which rejects it; until now that error was *masked* by the very `NFS4_OK` bug above, so the client saw a false success. The ops now mirror the existing READ/WRITE handling:

- call `chimera_nfs4_resolve_current_stateid()` (NFS4.1 current-stateid substitution),
- detect `nfs4_stateid_is_special()` and open the current filehandle on the fly via `chimera_vfs_open_fh()` instead of consulting the state table,
- release the synthetic handle in the completion callback.

The on-the-fly open uses real R/W access for ALLOCATE/DEALLOCATE and R/O for SEEK (not `O_PATH`), so the passthrough backends can `fallocate()` / `lseek()` the resulting fd.

## Verification

- pynfs `sparse` suite (ALLOC1/2/3) now passes on **all** backends (memfs, linux, io_uring, diskfs×2, cairn); ALLOC2/ALLOC3 exercise the special stateids.
- 1030 related pynfs tests (read/write/copy/currentstateid/lock/close/open) pass under the ASan debug build.
- posix NFSv4 fsstress/fstest/dirstress (memfs + diskfs) pass.
- Debug (ASan) and Release both build clean; uncrustify and copyright-year checks pass.