### PR TITLE
config: map common.rdmacm_tos onto the RDMA QP traffic class

### DIFF
--- a/src/common/common_config.h
+++ b/src/common/common_config.h
@@ -112,7 +112,9 @@ chimera_parse_size(
 /*
  * Apply the shared "common" config section -- parsed identically by the server
  * and the client -- onto an evpl global config, before evpl_init().  Recognised
- * keys: huge_pages (bool), huge_page_size (size), slab_size (size).  A missing
+ * keys: huge_pages (bool), huge_page_size (size), slab_size (size),
+ * preallocate_slabs/threads (int), rdmacm_tos (int, RoCEv2 ToS byte =
+ * DSCP << 2; e.g. 104 for DSCP 26).  A missing
  * "common" section, missing keys, or malformed values leave the corresponding
  * evpl defaults untouched.  `root` is the parsed top-level config object (may be
  * NULL).
@@ -165,6 +167,15 @@ chimera_apply_common_config(
     val = json_object_get(common, "preallocate_threads");
     if (json_is_integer(val)) {
         evpl_global_config_set_preallocate_threads(cfg, json_integer_value(val));
+    }
+
+    /* RoCEv2 traffic class: stamp this ToS byte on every RDMA QP so the fabric's
+     * lossless priority (PFC) actually carries chimera traffic.  ToS = DSCP << 2,
+     * so DSCP 26 -> 104.  Without it QPs default to ToS 0 (DSCP 0) and land in
+     * the switch's default, lossy class regardless of PFC config. */
+    val = json_object_get(common, "rdmacm_tos");
+    if (json_is_integer(val)) {
+        evpl_global_config_set_rdmacm_tos(cfg, (uint8_t) json_integer_value(val));
     }
 } /* chimera_apply_common_config */
 


### PR DESCRIPTION
## Summary

libevpl already supports stamping a ToS byte on every RDMA QP (`evpl_global_config_set_rdmacm_tos` → `rdma_set_option(RDMA_OPTION_ID_TOS)`), but chimera never set it and exposed no config knob — so every chimera RoCE packet leaves with **ToS 0 / DSCP 0**.

On a switched RoCEv2 fabric that means all chimera traffic lands in the switch's **default (lossy) class** no matter how PFC is configured on the intended lossless priority — the fabric's PFC/ECN never applies to chimera traffic (on either the server or the client).

## Change

Wire a `rdmacm_tos` key through `chimera_apply_common_config`, so it is parsed identically by the **daemon** (server) and the **fio engine** (client) — both already call that function before `evpl_init()`. The value is the raw RoCEv2 ToS byte (= DSCP << 2):

```json
"common": { "rdmacm_tos": 104 }
```
(104 = DSCP 26 << 2, the common RoCEv2 priority-3 lossless class.)

Unset leaves the evpl default (0 / unmarked), so behavior is unchanged for anyone not opting in.

## Validation

- Clean release + debug builds; `make syntax-check` clean.
- Daemon starts and accepts `common.rdmacm_tos` with no parse error.
- Header is compiled into both the daemon and the fio engine, so the same key works on server and client.