### PR TITLE
smb2/acl: enable smb2.acls_non_canonical via inherited-canonicalize knob

### DIFF
--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -368,6 +368,11 @@ main(
         chimera_server_config_set_smb_encryption(server_config, json_is_true(json_value) ? 1 : 0);
     }
 
+    json_value = json_object_get(server_params, "smb_acl_inherited_canonicalize");
+    if (json_is_boolean(json_value)) {
+        chimera_server_config_set_smb_acl_inherited_canonicalize(server_config, json_is_true(json_value));
+    }
+
     json_value = json_object_get(server_params, "nfs4_session_slots");
     if (json_is_integer(json_value)) {
         int_value = json_integer_value(json_value);

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -73,6 +73,7 @@ struct chimera_server_config {
     int                                   smb_signing_required;
     int                                   smb_encryption;
     int                                   smb_notify_disabled;
+    int                                   smb_acl_inherited_canonicalize;
     int                                   smb_num_nic_info;
     uint32_t                              anonuid;
     uint32_t                              anongid;
@@ -167,6 +168,15 @@ chimera_server_config_init(void)
     /* CHANGE_NOTIFY is enabled by default; the "smb_notify_disabled" flag makes
      * the server reject CHANGE_NOTIFY with STATUS_NOT_IMPLEMENTED. */
     config->smb_notify_disabled = 0;
+
+    /* Windows-style canonicalisation of the DACL_AUTO_INHERITED bit on
+     * SET_SECURITY: a client-supplied AUTO_INHERITED without the matching
+     * AUTO_INHERIT_REQ is silently stripped before storage (the default,
+     * matching Samba's "acl flag inherited canonicalization = yes" and the
+     * Windows server reference behaviour).  Set to 0 to preserve the bit
+     * verbatim (Samba's "= no" mode that the smb2.acls_non_canonical suite
+     * exercises). */
+    config->smb_acl_inherited_canonicalize = 1;
 
     // SMB auth config defaults - local NTLM only
     config->smb_auth.winbind_enabled    = 0;
@@ -347,6 +357,20 @@ chimera_server_config_get_smb_notify_disabled(const struct chimera_server_config
 {
     return config->smb_notify_disabled;
 } /* chimera_server_config_get_smb_notify_disabled */
+
+SYMBOL_EXPORT void
+chimera_server_config_set_smb_acl_inherited_canonicalize(
+    struct chimera_server_config *config,
+    int                           enable)
+{
+    config->smb_acl_inherited_canonicalize = enable;
+} /* chimera_server_config_set_smb_acl_inherited_canonicalize */
+
+SYMBOL_EXPORT int
+chimera_server_config_get_smb_acl_inherited_canonicalize(const struct chimera_server_config *config)
+{
+    return config->smb_acl_inherited_canonicalize;
+} /* chimera_server_config_get_smb_acl_inherited_canonicalize */
 
 SYMBOL_EXPORT void
 chimera_server_config_set_max_open_files(

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -120,6 +120,15 @@ chimera_server_config_get_smb_notify_disabled(
     const struct chimera_server_config *config);
 
 void
+chimera_server_config_set_smb_acl_inherited_canonicalize(
+    struct chimera_server_config *config,
+    int                           enable);
+
+int
+chimera_server_config_get_smb_acl_inherited_canonicalize(
+    const struct chimera_server_config *config);
+
+void
 chimera_server_config_set_cache_ttl(
     struct chimera_server_config *config,
     int                           ttl);

--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -143,12 +143,13 @@ chimera_smb_server_init(
                          shared->config.auth.kerberos_keytab[0] ? shared->config.auth.kerberos_keytab : "(default)");
     }
 
-    shared->config.soft_fail_bad_req  = chimera_server_config_get_soft_fail_bad_req(config);
-    shared->config.persistent_handles = chimera_server_config_get_smb_persistent_handles(config);
-    shared->config.named_streams      = chimera_server_config_get_smb_named_streams(config);
-    shared->config.signing_required   = chimera_server_config_get_smb_signing_required(config);
-    shared->config.encryption         = chimera_server_config_get_smb_encryption(config);
-    shared->config.notify_disabled    = chimera_server_config_get_smb_notify_disabled(config);
+    shared->config.soft_fail_bad_req          = chimera_server_config_get_soft_fail_bad_req(config);
+    shared->config.persistent_handles         = chimera_server_config_get_smb_persistent_handles(config);
+    shared->config.named_streams              = chimera_server_config_get_smb_named_streams(config);
+    shared->config.signing_required           = chimera_server_config_get_smb_signing_required(config);
+    shared->config.encryption                 = chimera_server_config_get_smb_encryption(config);
+    shared->config.notify_disabled            = chimera_server_config_get_smb_notify_disabled(config);
+    shared->config.acl_inherited_canonicalize = chimera_server_config_get_smb_acl_inherited_canonicalize(config);
 
     if (shared->config.persistent_handles) {
         chimera_smb_info("SMB3 durable/persistent handles enabled (in-memory state)");

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -131,6 +131,10 @@ struct chimera_smb_config {
      * a watch (the "change notify = no" share behaviour Windows exposes;
      * smb2.change_notify_disabled expects this). */
     int                            notify_disabled;
+    /* Windows-style canonicalisation of the DACL_AUTO_INHERITED bit on
+     * SET_SECURITY; see chimera_server_config_set_smb_acl_inherited_canonicalize
+     * for semantics.  Default 1 (canonical). */
+    int                            acl_inherited_canonicalize;
     uint32_t                       capabilities;
     uint32_t                       dialects[16];
     struct chimera_smb_nic_info    nic_info[16];

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -2455,9 +2455,21 @@ parse_ctx_secd(
     uint32_t                    data_len,
     struct chimera_smb_request *request)
 {
+    /* The create-context parser is also exercised standalone by
+     * phase0_contexts_test with a zeroed request (no compound/thread/shared),
+     * so fall back to canonical behaviour when the server context is not
+     * reachable. */
+    int canonicalize = 1;
+
+    if (request->compound) {
+        canonicalize = request->compound->thread->shared->config.
+            acl_inherited_canonicalize;
+    }
+
     chimera_smb_parse_sd_to_acl(data, data_len, &request->create.set_attr,
                                 request->create.acl_storage,
-                                sizeof(request->create.acl_storage));
+                                sizeof(request->create.acl_storage),
+                                canonicalize);
 } /* parse_ctx_secd */
 
 static void

--- a/src/server/smb/smb_proc_security.c
+++ b/src/server/smb/smb_proc_security.c
@@ -333,7 +333,8 @@ chimera_smb_sd_to_acl(
     struct chimera_acl       *acl,
     unsigned                  acl_max_aces,
     struct chimera_vfs       *vfs,
-    struct smb_unres_sids    *unres)
+    struct smb_unres_sids    *unres,
+    int                       canonicalize_inherited)
 {
     uint32_t offset_owner, offset_group, offset_dacl;
     uint32_t value;
@@ -458,12 +459,20 @@ chimera_smb_sd_to_acl(
 
         acl->num_aces   = n;
         acl->ctrl_flags = 0;
-        /* The stored DACL is in auto-inherit mode only when the client both
-         * requested it (AUTO_INHERIT_REQ) and marked the descriptor as
-         * auto-inherited (AUTO_INHERITED) -- REQ alone does not.  PROTECTED is
-         * stored as-is. */
-        if ((sd_control & SE_DACL_AUTO_INHERIT_REQ) &&
-            (sd_control & SE_DACL_AUTO_INHERITED)) {
+        /* AUTO_INHERITED canonicalisation.  Canonical (Windows / Samba's
+         * "acl flag inherited canonicalization = yes" default) requires the
+         * client to set both AUTO_INHERIT_REQ and AUTO_INHERITED for the
+         * stored DACL to be in auto-inherit mode -- AUTO_INHERITED alone is
+         * stripped (the smb2.acls.INHERITFLAGS suite enforces this).
+         * Non-canonical (Samba's "= no" mode the smb2.acls_non_canonical
+         * suite exercises) preserves AUTO_INHERITED verbatim regardless of
+         * REQ.  PROTECTED is stored as-is in both modes. */
+        if (canonicalize_inherited) {
+            if ((sd_control & SE_DACL_AUTO_INHERIT_REQ) &&
+                (sd_control & SE_DACL_AUTO_INHERITED)) {
+                acl->ctrl_flags |= CHIMERA_ACL_CTRL_AUTO_INHERITED;
+            }
+        } else if (sd_control & SE_DACL_AUTO_INHERITED) {
             acl->ctrl_flags |= CHIMERA_ACL_CTRL_AUTO_INHERITED;
         }
         if (sd_control & SE_DACL_PROTECTED) {
@@ -785,7 +794,8 @@ chimera_smb_parse_sd_to_acl(
     uint32_t                  sd_len,
     struct chimera_vfs_attrs *attrs,
     void                     *acl_buf,
-    uint32_t                  acl_buf_len)
+    uint32_t                  acl_buf_len,
+    int                       canonicalize_inherited)
 {
     struct chimera_acl *acl     = acl_buf;
     unsigned            acl_max = (acl_buf_len - sizeof(struct chimera_acl)) /
@@ -793,7 +803,8 @@ chimera_smb_parse_sd_to_acl(
 
     /* Create-time SD parse: algorithmic/well-known SIDs only (no authority
      * handle here); real-SID resolution happens on SET_SECURITY. */
-    chimera_smb_sd_to_acl(sd_buf, sd_len, attrs, acl, acl_max, NULL, NULL);
+    chimera_smb_sd_to_acl(sd_buf, sd_len, attrs, acl, acl_max, NULL, NULL,
+                          canonicalize_inherited);
 } /* chimera_smb_parse_sd_to_acl */
 
 /* Decode the (saved) security descriptor into vfs_attrs + ACL.  Returns the
@@ -816,7 +827,9 @@ chimera_smb_set_decode_sd(
     chimera_smb_sd_to_acl(request->set_info.sec_buf,
                           request->set_info.sec_buf_len,
                           vfs_attrs, acl_buf, acl_max,
-                          request->compound->thread->shared->vfs, unres);
+                          request->compound->thread->shared->vfs, unres,
+                          request->compound->thread->shared->config.
+                          acl_inherited_canonicalize);
 } /* chimera_smb_set_decode_sd */
 
 /* Apply the decoded vfs_attrs (or complete early if nothing changed). */

--- a/src/server/smb/smb_procs.h
+++ b/src/server/smb/smb_procs.h
@@ -208,7 +208,8 @@ void chimera_smb_parse_sd_to_acl(
     uint32_t                  sd_len,
     struct chimera_vfs_attrs *attrs,
     void                     *acl_buf,
-    uint32_t                  acl_buf_len);
+    uint32_t                  acl_buf_len,
+    int                       canonicalize_inherited);
 
 int chimera_smb_parse_echo(
     struct evpl_iovec_cursor   *request_cursor,

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -395,8 +395,14 @@ set(SMBTORTURE_ENABLED_memfs
     # tree, rec) need deeper features (recursive-buffer accuracy, per-session
     # preauth for PreviousSessionId) and are left disabled.
     ${SMBTORTURE_NOTIFY_SUBTESTS}
-    # smb2.acls_non_canonical and smb2.async_dosmode pass on x86_64 but fail on
-    # arm64 CI; left disabled until the arch difference is understood.
+    # Non-canonical AUTO_INHERITED semantics: with the
+    # smb_acl_inherited_canonicalize knob set to 0 (the harness flips it for
+    # this suite only), SECINFO_DACL set+get round-trips the AUTO_INHERITED
+    # bit verbatim instead of stripping it when AUTO_INHERIT_REQ is absent
+    # (Samba's "acl flag inherited canonicalization = no" mode).
+    smb2.acls_non_canonical
+    # smb2.async_dosmode passes on x86_64 but fails on arm64 CI; left
+    # disabled until the arch difference is understood.
 )
 # The linux and io_uring passthrough backends share an implementation and pass
 # the same set.  They expose the share root as a real local directory whose
@@ -445,8 +451,9 @@ set(SMBTORTURE_ENABLED_linux
     smb2.notify.tcp
     smb2.notify.tdis
     smb2.notify.tdis1
-    # smb2.acls_non_canonical passes on x86_64 but, like memfs, is left disabled
-    # pending the arm64 difference.
+    # smb2.acls_non_canonical stays disabled here: the passthrough backends
+    # don't persist ACLs (set is projected to POSIX mode, get is synthesised
+    # from mode bits), so the AUTO_INHERITED control bit can't round-trip.
 )
 set(SMBTORTURE_ENABLED_io_uring
     smb2.change_notify_disabled
@@ -531,6 +538,7 @@ set(SMBTORTURE_ENABLED_cairn
     smb2.notify.tdis
     smb2.notify.tdis1
     ${SMBTORTURE_ACLS_SUBTESTS}
+    smb2.acls_non_canonical
 )
 # diskfs is a native-ACL backend: it stores each inode's ACL as a
 # DISKFS_REC_ACL b+tree record and seeds/inherits it on create, so it adds the
@@ -580,6 +588,7 @@ set(SMBTORTURE_ENABLED_diskfs_common
     smb2.notify.tdis
     smb2.notify.tdis1
     ${SMBTORTURE_ACLS_SUBTESTS}
+    smb2.acls_non_canonical
 )
 set(SMBTORTURE_ENABLED_diskfs_io_uring ${SMBTORTURE_ENABLED_diskfs_common})
 set(SMBTORTURE_ENABLED_diskfs_aio ${SMBTORTURE_ENABLED_diskfs_common})

--- a/src/server/smb/tests/smbtorture_test.c
+++ b/src/server/smb/tests/smbtorture_test.c
@@ -284,6 +284,19 @@ main(
         }
     }
 
+    /* The smb2.acls_non_canonical suite asserts Samba's
+     * "acl flag inherited canonicalization = no" behaviour: the
+     * DACL_AUTO_INHERITED bit round-trips verbatim even when the client
+     * sets it without AUTO_INHERIT_REQ.  The smb2.acls.INHERITFLAGS suite
+     * asserts the opposite (Windows-canonical) behaviour, so the knob is
+     * flipped only for the non-canonical suite. */
+    for (i = 0; i < num_tests; i++) {
+        if (strcmp(tests[i], "smb2.acls_non_canonical") == 0) {
+            chimera_server_config_set_smb_acl_inherited_canonicalize(config, 0);
+            break;
+        }
+    }
+
     /* Configure backend-specific modules */
     if (strcmp(backend, "diskfs_io_uring") == 0 ||
         strcmp(backend, "diskfs_aio") == 0) {


### PR DESCRIPTION
## Summary

The smbtorture `smb2.acls_non_canonical` suite asserts Samba's *"acl flag inherited canonicalization = no"* semantics: when a client SETs a SECINFO_DACL with `SEC_DESC_DACL_AUTO_INHERITED` but without `SEC_DESC_DACL_AUTO_INHERIT_REQ`, the bit must round-trip verbatim on the next QUERY rather than being silently stripped. chimera was always stripping (the Windows-canonical behaviour the existing `smb2.acls.INHERITFLAGS` suite checks), so the suite failed at the round-trip assertion on every backend.

- Add a server config knob `smb_acl_inherited_canonicalize` (default 1, matching Windows and Samba's default). When 0 the SET parser preserves `AUTO_INHERITED` verbatim instead of requiring `AUTO_INHERIT_REQ` as a co-condition; `PROTECTED` handling and inheritance propagation are unchanged.
- Plumbed through `chimera_server_config`, `chimera_smb_config`, the JSON daemon config, and `chimera_smb_sd_to_acl` / `chimera_smb_parse_sd_to_acl` (the CREATE-context SecD parser falls back to canonical when invoked standalone by `phase0_contexts_test`).
- The smbtorture harness flips the knob off only for the `smb2.acls_non_canonical` suite, so `smb2.acls.INHERITFLAGS` continues to enforce the canonical semantics on the same backend without a separate process.
- Enable `smb2.acls_non_canonical` on every native-ACL backend (memfs / cairn / diskfs_io_uring / diskfs_aio). Linux/io_uring stay disabled because they down-project ACLs to POSIX mode on SET and synthesise them from mode bits on GET, so the AUTO_INHERITED control bit has nowhere to live across set+get.

Closes a "Tier 1" gap from the `acls_non_canonical` smbtorture failure across all backends.