### PR TITLE
vfs/smb: persist DOS attributes in cairn and diskfs (smb2.openattr)

### DIFF
--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -406,6 +406,11 @@ set(SMBTORTURE_ENABLED_memfs
 # filesystem has no API to set a file's birth time, so the create-time
 # round-trip is unsupportable on the passthrough backends (it works on the
 # native backends, which persist btime in their own inode metadata).
+# smb2.openattr stays disabled for the same reason: it round-trips DOS
+# attributes (READONLY/HIDDEN/SYSTEM/ARCHIVE) that a real Linux filesystem has
+# no native API to store, so they cannot be persisted on a passthrough mount
+# (it works on the native backends, which persist dos_attributes in their inode
+# metadata).
 set(SMBTORTURE_ENABLED_linux
     smb2.change_notify_disabled
     smb2.mkdir
@@ -452,6 +457,9 @@ set(SMBTORTURE_ENABLED_io_uring
 set(SMBTORTURE_ENABLED_cairn
     smb2.change_notify_disabled
     smb2.mkdir
+    # Native DOS-attribute storage in the cairn inode lets the SMB
+    # create/overwrite-truncate attribute round-trip pass end-to-end.
+    smb2.openattr
     smb2.read
     smb2.rw
     smb2.check-sharemode
@@ -477,6 +485,9 @@ set(SMBTORTURE_ENABLED_cairn
 set(SMBTORTURE_ENABLED_diskfs_common
     smb2.change_notify_disabled
     smb2.mkdir
+    # Native DOS-attribute storage in the diskfs inode (in-memory + on-disk
+    # dinode) lets the SMB create/overwrite-truncate attribute round-trip pass.
+    smb2.openattr
     smb2.read
     smb2.rw
     smb2.check-sharemode

--- a/src/vfs/cairn/cairn.c
+++ b/src/vfs/cairn/cairn.c
@@ -179,6 +179,7 @@ struct cairn_inode {
     struct timespec mtime;
     struct timespec ctime;
     struct timespec btime;
+    uint32_t        dos_attributes;
 };
 
 struct cairn_inode_handle {
@@ -1213,11 +1214,12 @@ cairn_init(
          * enforcement a root-owned 0755 root would refuse all creation by
          * non-root clients on this engine-authoritative backend.  Subdirs are
          * still created owned by their creator with 0755. */
-        inode.mode  = S_IFDIR | 0777;
-        inode.atime = now;
-        inode.mtime = now;
-        inode.ctime = now;
-        inode.btime = now;
+        inode.mode           = S_IFDIR | 0777;
+        inode.atime          = now;
+        inode.mtime          = now;
+        inode.ctime          = now;
+        inode.btime          = now;
+        inode.dos_attributes = 0;
 
         super.fsid = chimera_rand64();
 
@@ -1696,6 +1698,11 @@ cairn_map_attrs(
         attr->va_ino        = inode->inum;
         attr->va_dev        = (42UL << 32) | 42;
         attr->va_rdev       = inode->rdev;
+
+        /* cairn persists DOS attributes natively, so report them alongside
+         * stat (matching memfs). */
+        attr->va_set_mask      |= CHIMERA_VFS_ATTR_DOS_ATTRIBUTES;
+        attr->va_dos_attributes = inode->dos_attributes;
     }
 
     /* Birth time (SMB create time) is tracked natively but lives outside
@@ -1779,6 +1786,11 @@ cairn_apply_attrs(
         } else {
             inode->btime = attr->va_btime;
         }
+    }
+
+    if (set_mask & CHIMERA_VFS_ATTR_DOS_ATTRIBUTES) {
+        attr->va_set_mask    |= CHIMERA_VFS_ATTR_DOS_ATTRIBUTES;
+        inode->dos_attributes = attr->va_dos_attributes;
     }
 
     inode->ctime = now;
@@ -2210,18 +2222,19 @@ cairn_mkdir_at(
     }
 
     cairn_alloc_inum(thread, &inode);
-    inode.parent_inum = parent_inode->inum; /* Set parent for ".." lookup */
-    inode.size        = 4096;
-    inode.space_used  = 4096;
-    inode.uid         = request->cred->uid;
-    inode.gid         = request->cred->gid;
-    inode.nlink       = 2;
-    inode.rdev        = 0;
-    inode.mode        = S_IFDIR | 0755;
-    inode.atime       = now;
-    inode.mtime       = now;
-    inode.ctime       = now;
-    inode.btime       = now;
+    inode.parent_inum    = parent_inode->inum; /* Set parent for ".." lookup */
+    inode.size           = 4096;
+    inode.space_used     = 4096;
+    inode.uid            = request->cred->uid;
+    inode.gid            = request->cred->gid;
+    inode.nlink          = 2;
+    inode.rdev           = 0;
+    inode.mode           = S_IFDIR | 0755;
+    inode.atime          = now;
+    inode.mtime          = now;
+    inode.ctime          = now;
+    inode.btime          = now;
+    inode.dos_attributes = 0;
 
     cairn_apply_attrs(&inode, request->mkdir_at.set_attr);
 
@@ -2315,17 +2328,18 @@ cairn_mknod_at(
     }
 
     cairn_alloc_inum(thread, &inode);
-    inode.parent_inum = parent_inode->inum;
-    inode.size        = 0;
-    inode.space_used  = 0;
-    inode.uid         = request->cred->uid;
-    inode.gid         = request->cred->gid;
-    inode.nlink       = 1;
-    inode.rdev        = 0;
-    inode.atime       = now;
-    inode.mtime       = now;
-    inode.ctime       = now;
-    inode.btime       = now;
+    inode.parent_inum    = parent_inode->inum;
+    inode.size           = 0;
+    inode.space_used     = 0;
+    inode.uid            = request->cred->uid;
+    inode.gid            = request->cred->gid;
+    inode.nlink          = 1;
+    inode.rdev           = 0;
+    inode.atime          = now;
+    inode.mtime          = now;
+    inode.ctime          = now;
+    inode.btime          = now;
+    inode.dos_attributes = 0;
 
     /* Set mode (including file type bits) and rdev from set_attr */
     if (request->mknod_at.set_attr->va_set_mask & CHIMERA_VFS_ATTR_MODE) {
@@ -2776,18 +2790,19 @@ cairn_open_at(
         is_new_inode = 1;
 
         cairn_alloc_inum(thread, &new_inode);
-        new_inode.size       = 0;
-        new_inode.space_used = 0;
-        new_inode.uid        = request->cred->uid;
-        new_inode.gid        = request->cred->gid;
-        new_inode.nlink      = 1;
-        new_inode.rdev       = 0;
-        new_inode.mode       = S_IFREG |  0644;
-        new_inode.atime      = now;
-        new_inode.mtime      = now;
-        new_inode.ctime      = now;
-        new_inode.btime      = now;
-        new_inode.refcnt     = 1;
+        new_inode.size           = 0;
+        new_inode.space_used     = 0;
+        new_inode.uid            = request->cred->uid;
+        new_inode.gid            = request->cred->gid;
+        new_inode.nlink          = 1;
+        new_inode.rdev           = 0;
+        new_inode.mode           = S_IFREG |  0644;
+        new_inode.atime          = now;
+        new_inode.mtime          = now;
+        new_inode.ctime          = now;
+        new_inode.btime          = now;
+        new_inode.dos_attributes = 0;
+        new_inode.refcnt         = 1;
 
         cairn_apply_attrs(&new_inode, request->open_at.set_attr);
 
@@ -2845,10 +2860,22 @@ cairn_open_at(
      * mishandles SMB control-only opens.  Access is enforced by the ACL-aware
      * VFS gate and the protocol create-time check, as on memfs/diskfs. */
 
-    if (!is_new_inode &&
-        (request->open_at.set_attr->va_set_mask & CHIMERA_VFS_ATTR_SIZE) &&
-        request->open_at.set_attr->va_size == 0 &&
-        S_ISREG(inode->mode)) {
+    if (!is_new_inode && S_ISREG(inode->mode) &&
+        (flags & CHIMERA_VFS_OPEN_TRUNCATE)) {
+        /* Overwrite/supersede disposition: replace the existing file's
+         * contents (truncate to zero) and apply the new attributes (including
+         * DOS attributes), mirroring memfs.  The SMB layer conveys the truncate
+         * via OPEN_TRUNCATE rather than a SIZE=0 set_attr, so key off the flag. */
+        if (inode->size) {
+            cairn_punch_hole(thread, shared, inode, 0, inode->size);
+        }
+        inode->size       = 0;
+        inode->space_used = 0;
+        cairn_apply_attrs(inode, request->open_at.set_attr);
+    } else if (!is_new_inode &&
+               (request->open_at.set_attr->va_set_mask & CHIMERA_VFS_ATTR_SIZE) &&
+               request->open_at.set_attr->va_size == 0 &&
+               S_ISREG(inode->mode)) {
         cairn_apply_attrs(inode, request->open_at.set_attr);
         inode->space_used = 0;
     }
@@ -3629,17 +3656,18 @@ cairn_symlink_at(
     }
 
     cairn_alloc_inum(thread, &new_inode);
-    new_inode.size       = request->symlink_at.targetlen;
-    new_inode.space_used = request->symlink_at.targetlen;
-    new_inode.uid        = request->cred->uid;
-    new_inode.gid        = request->cred->gid;
-    new_inode.nlink      = 1;
-    new_inode.rdev       = 0;
-    new_inode.mode       = S_IFLNK | 0755;
-    new_inode.atime      = now;
-    new_inode.mtime      = now;
-    new_inode.ctime      = now;
-    new_inode.btime      = now;
+    new_inode.size           = request->symlink_at.targetlen;
+    new_inode.space_used     = request->symlink_at.targetlen;
+    new_inode.uid            = request->cred->uid;
+    new_inode.gid            = request->cred->gid;
+    new_inode.nlink          = 1;
+    new_inode.rdev           = 0;
+    new_inode.mode           = S_IFLNK | 0755;
+    new_inode.atime          = now;
+    new_inode.mtime          = now;
+    new_inode.ctime          = now;
+    new_inode.btime          = now;
+    new_inode.dos_attributes = 0;
 
     dirent_value.inum     = new_inode.inum;
     dirent_value.name_len = request->symlink_at.namelen;

--- a/src/vfs/diskfs/diskfs.c
+++ b/src/vfs/diskfs/diskfs.c
@@ -467,6 +467,7 @@ struct diskfs_inode {
     uint32_t                    ctime_nsec;
     uint32_t                    mtime_nsec;
     uint32_t                    btime_nsec;
+    uint32_t                    dos_attributes;
 
     /* Inode-cache linkage, keyed by inum.  Lock state and the wait list
      * below are protected by the owning shard's mutex, never held across
@@ -626,6 +627,7 @@ struct diskfs_dinode {
     uint32_t mtime_nsec;
     uint32_t ctime_nsec;
     uint32_t btime_nsec;
+    uint32_t dos_attributes;
     uint64_t parent_inum;     /* directories only */
     uint32_t parent_gen;
 };
@@ -2254,27 +2256,28 @@ diskfs_inode_load_sync(
     rb_tree_query_exact(&shard->inodes, inum, inum, inode);
     if (!inode) {
         diskfs_inode_cache_recycle_locked(shared, shard);
-        inode              = calloc(1, sizeof(*inode));
-        inode->inum        = inum;
-        inode->refcnt      = 1;
-        inode->gen         = di->gen;
-        inode->mode        = di->mode;
-        inode->nlink       = di->nlink;
-        inode->uid         = di->uid;
-        inode->gid         = di->gid;
-        inode->rdev        = di->rdev;
-        inode->size        = di->size;
-        inode->space_used  = di->space_used;
-        inode->atime_sec   = di->atime_sec;
-        inode->atime_nsec  = di->atime_nsec;
-        inode->mtime_sec   = di->mtime_sec;
-        inode->mtime_nsec  = di->mtime_nsec;
-        inode->ctime_sec   = di->ctime_sec;
-        inode->ctime_nsec  = di->ctime_nsec;
-        inode->btime_sec   = di->btime_sec;
-        inode->btime_nsec  = di->btime_nsec;
-        inode->parent_inum = di->parent_inum;
-        inode->parent_gen  = di->parent_gen;
+        inode                 = calloc(1, sizeof(*inode));
+        inode->inum           = inum;
+        inode->refcnt         = 1;
+        inode->gen            = di->gen;
+        inode->mode           = di->mode;
+        inode->nlink          = di->nlink;
+        inode->uid            = di->uid;
+        inode->gid            = di->gid;
+        inode->rdev           = di->rdev;
+        inode->size           = di->size;
+        inode->space_used     = di->space_used;
+        inode->atime_sec      = di->atime_sec;
+        inode->atime_nsec     = di->atime_nsec;
+        inode->mtime_sec      = di->mtime_sec;
+        inode->mtime_nsec     = di->mtime_nsec;
+        inode->ctime_sec      = di->ctime_sec;
+        inode->ctime_nsec     = di->ctime_nsec;
+        inode->btime_sec      = di->btime_sec;
+        inode->btime_nsec     = di->btime_nsec;
+        inode->dos_attributes = di->dos_attributes;
+        inode->parent_inum    = di->parent_inum;
+        inode->parent_gen     = di->parent_gen;
         rb_tree_insert(&shard->inodes, inum, inode);
         shard->ninodes++;
         diskfs_metric_inode_cache(thread, DISKFS_METRIC_INODE_CACHE_LOAD);
@@ -3345,23 +3348,24 @@ diskfs_inode_flush(struct diskfs_inode *inode)
 
     di = inode->block->iov.data;
 
-    di->inum       = inode->inum;
-    di->gen        = inode->gen;
-    di->mode       = inode->mode;
-    di->nlink      = inode->nlink;
-    di->uid        = inode->uid;
-    di->gid        = inode->gid;
-    di->rdev       = inode->rdev;
-    di->size       = inode->size;
-    di->space_used = inode->space_used;
-    di->atime_sec  = inode->atime_sec;
-    di->mtime_sec  = inode->mtime_sec;
-    di->ctime_sec  = inode->ctime_sec;
-    di->btime_sec  = inode->btime_sec;
-    di->atime_nsec = inode->atime_nsec;
-    di->mtime_nsec = inode->mtime_nsec;
-    di->ctime_nsec = inode->ctime_nsec;
-    di->btime_nsec = inode->btime_nsec;
+    di->inum           = inode->inum;
+    di->gen            = inode->gen;
+    di->mode           = inode->mode;
+    di->nlink          = inode->nlink;
+    di->uid            = inode->uid;
+    di->gid            = inode->gid;
+    di->rdev           = inode->rdev;
+    di->size           = inode->size;
+    di->space_used     = inode->space_used;
+    di->atime_sec      = inode->atime_sec;
+    di->mtime_sec      = inode->mtime_sec;
+    di->ctime_sec      = inode->ctime_sec;
+    di->btime_sec      = inode->btime_sec;
+    di->atime_nsec     = inode->atime_nsec;
+    di->mtime_nsec     = inode->mtime_nsec;
+    di->ctime_nsec     = inode->ctime_nsec;
+    di->btime_nsec     = inode->btime_nsec;
+    di->dos_attributes = inode->dos_attributes;
     if (S_ISDIR(inode->mode)) {
         di->parent_inum = inode->parent_inum;
         di->parent_gen  = inode->parent_gen;
@@ -6211,25 +6215,26 @@ diskfs_inode_load_complete(
     rb_tree_query_exact(&shard->inodes, lc->inum, inum, inode);
     if (!inode) {
         diskfs_inode_cache_recycle_locked(shared, shard);
-        inode              = diskfs_inode_struct_new(lc->inum);
-        inode->gen         = di->gen;
-        inode->mode        = di->mode;
-        inode->nlink       = di->nlink;
-        inode->uid         = di->uid;
-        inode->gid         = di->gid;
-        inode->rdev        = di->rdev;
-        inode->size        = di->size;
-        inode->space_used  = di->space_used;
-        inode->atime_sec   = di->atime_sec;
-        inode->atime_nsec  = di->atime_nsec;
-        inode->mtime_sec   = di->mtime_sec;
-        inode->mtime_nsec  = di->mtime_nsec;
-        inode->ctime_sec   = di->ctime_sec;
-        inode->ctime_nsec  = di->ctime_nsec;
-        inode->btime_sec   = di->btime_sec;
-        inode->btime_nsec  = di->btime_nsec;
-        inode->parent_inum = di->parent_inum;
-        inode->parent_gen  = di->parent_gen;
+        inode                 = diskfs_inode_struct_new(lc->inum);
+        inode->gen            = di->gen;
+        inode->mode           = di->mode;
+        inode->nlink          = di->nlink;
+        inode->uid            = di->uid;
+        inode->gid            = di->gid;
+        inode->rdev           = di->rdev;
+        inode->size           = di->size;
+        inode->space_used     = di->space_used;
+        inode->atime_sec      = di->atime_sec;
+        inode->atime_nsec     = di->atime_nsec;
+        inode->mtime_sec      = di->mtime_sec;
+        inode->mtime_nsec     = di->mtime_nsec;
+        inode->ctime_sec      = di->ctime_sec;
+        inode->ctime_nsec     = di->ctime_nsec;
+        inode->btime_sec      = di->btime_sec;
+        inode->btime_nsec     = di->btime_nsec;
+        inode->dos_attributes = di->dos_attributes;
+        inode->parent_inum    = di->parent_inum;
+        inode->parent_gen     = di->parent_gen;
         rb_tree_insert(&shard->inodes, inum, inode);
         shard->ninodes++;
         diskfs_metric_inode_cache(thread, DISKFS_METRIC_INODE_CACHE_LOAD);
@@ -8699,15 +8704,16 @@ diskfs_bootstrap(struct diskfs_thread *thread)
      * enforcement a root-owned 0755 root would refuse all creation by non-root
      * clients on this engine-authoritative backend (matches memfs/cairn).
      * Subdirs are still created owned by their creator with 0755. */
-    inode->mode       = S_IFDIR | 0777;
-    inode->atime_sec  = now.tv_sec;
-    inode->atime_nsec = now.tv_nsec;
-    inode->mtime_sec  = now.tv_sec;
-    inode->mtime_nsec = now.tv_nsec;
-    inode->ctime_sec  = now.tv_sec;
-    inode->ctime_nsec = now.tv_nsec;
-    inode->btime_sec  = now.tv_sec;
-    inode->btime_nsec = now.tv_nsec;
+    inode->mode           = S_IFDIR | 0777;
+    inode->atime_sec      = now.tv_sec;
+    inode->atime_nsec     = now.tv_nsec;
+    inode->mtime_sec      = now.tv_sec;
+    inode->mtime_nsec     = now.tv_nsec;
+    inode->ctime_sec      = now.tv_sec;
+    inode->ctime_nsec     = now.tv_nsec;
+    inode->btime_sec      = now.tv_sec;
+    inode->btime_nsec     = now.tv_nsec;
+    inode->dos_attributes = 0;
 
     /* Root directory's parent is itself for ".." lookup */
     inode->parent_inum = inode->inum;
@@ -8742,20 +8748,21 @@ diskfs_bootstrap(struct diskfs_thread *thread)
                                                              DISKFS_ORPHAN_INUM, &odev);
         struct diskfs_inode *oin = diskfs_inode_struct_new(DISKFS_ORPHAN_INUM);
 
-        oin->size        = 4096;
-        oin->space_used  = 4096;
-        oin->nlink       = 1;
-        oin->mode        = S_IFDIR | 0700;
-        oin->atime_sec   = now.tv_sec;
-        oin->atime_nsec  = now.tv_nsec;
-        oin->mtime_sec   = now.tv_sec;
-        oin->mtime_nsec  = now.tv_nsec;
-        oin->ctime_sec   = now.tv_sec;
-        oin->ctime_nsec  = now.tv_nsec;
-        oin->btime_sec   = now.tv_sec;
-        oin->btime_nsec  = now.tv_nsec;
-        oin->parent_inum = DISKFS_ORPHAN_INUM;
-        oin->parent_gen  = oin->gen;
+        oin->size           = 4096;
+        oin->space_used     = 4096;
+        oin->nlink          = 1;
+        oin->mode           = S_IFDIR | 0700;
+        oin->atime_sec      = now.tv_sec;
+        oin->atime_nsec     = now.tv_nsec;
+        oin->mtime_sec      = now.tv_sec;
+        oin->mtime_nsec     = now.tv_nsec;
+        oin->ctime_sec      = now.tv_sec;
+        oin->ctime_nsec     = now.tv_nsec;
+        oin->btime_sec      = now.tv_sec;
+        oin->btime_nsec     = now.tv_nsec;
+        oin->dos_attributes = 0;
+        oin->parent_inum    = DISKFS_ORPHAN_INUM;
+        oin->parent_gen     = oin->gen;
 
         diskfs_inode_cache_insert(shared, oin);
 
@@ -9295,6 +9302,11 @@ diskfs_map_attrs(
         attr->va_ino           = inode->inum;
         attr->va_dev           = (42UL << 32) | 42;
         attr->va_rdev          = inode->rdev;
+
+        /* diskfs persists DOS attributes natively (in-memory + on-disk
+         * dinode), so report them alongside stat (matching memfs/cairn). */
+        attr->va_set_mask      |= CHIMERA_VFS_ATTR_DOS_ATTRIBUTES;
+        attr->va_dos_attributes = inode->dos_attributes;
     }
 
     /* Birth time (SMB create time) is tracked natively but lives outside
@@ -9423,6 +9435,11 @@ diskfs_apply_attrs(
             inode->btime_sec  = attr->va_btime.tv_sec;
             inode->btime_nsec = attr->va_btime.tv_nsec;
         }
+    }
+
+    if (set_mask & CHIMERA_VFS_ATTR_DOS_ATTRIBUTES) {
+        attr->va_set_mask    |= CHIMERA_VFS_ATTR_DOS_ATTRIBUTES;
+        inode->dos_attributes = attr->va_dos_attributes;
     }
 
     inode->ctime_sec  = now.tv_sec;
@@ -10118,20 +10135,21 @@ diskfs_mkdir_at_alloc_cb(
 
     clock_gettime(CLOCK_REALTIME, &now);
 
-    inode->size       = 4096;
-    inode->space_used = 4096;
-    inode->uid        = request->cred->uid;
-    inode->gid        = request->cred->gid;
-    inode->nlink      = 2;
-    inode->mode       = S_IFDIR | 0755;
-    inode->atime_sec  = now.tv_sec;
-    inode->atime_nsec = now.tv_nsec;
-    inode->mtime_sec  = now.tv_sec;
-    inode->mtime_nsec = now.tv_nsec;
-    inode->ctime_sec  = now.tv_sec;
-    inode->ctime_nsec = now.tv_nsec;
-    inode->btime_sec  = now.tv_sec;
-    inode->btime_nsec = now.tv_nsec;
+    inode->size           = 4096;
+    inode->space_used     = 4096;
+    inode->uid            = request->cred->uid;
+    inode->gid            = request->cred->gid;
+    inode->nlink          = 2;
+    inode->mode           = S_IFDIR | 0755;
+    inode->atime_sec      = now.tv_sec;
+    inode->atime_nsec     = now.tv_nsec;
+    inode->mtime_sec      = now.tv_sec;
+    inode->mtime_nsec     = now.tv_nsec;
+    inode->ctime_sec      = now.tv_sec;
+    inode->ctime_nsec     = now.tv_nsec;
+    inode->btime_sec      = now.tv_sec;
+    inode->btime_nsec     = now.tv_nsec;
+    inode->dos_attributes = 0;
 
     inode->parent_inum = parent->inum;
     inode->parent_gen  = parent->gen;
@@ -10294,20 +10312,21 @@ diskfs_mknod_at_alloc_cb(
 
     clock_gettime(CLOCK_REALTIME, &now);
 
-    inode->size       = 0;
-    inode->space_used = 0;
-    inode->uid        = request->cred->uid;
-    inode->gid        = request->cred->gid;
-    inode->nlink      = 1;
-    inode->rdev       = 0;
-    inode->atime_sec  = now.tv_sec;
-    inode->atime_nsec = now.tv_nsec;
-    inode->mtime_sec  = now.tv_sec;
-    inode->mtime_nsec = now.tv_nsec;
-    inode->ctime_sec  = now.tv_sec;
-    inode->ctime_nsec = now.tv_nsec;
-    inode->btime_sec  = now.tv_sec;
-    inode->btime_nsec = now.tv_nsec;
+    inode->size           = 0;
+    inode->space_used     = 0;
+    inode->uid            = request->cred->uid;
+    inode->gid            = request->cred->gid;
+    inode->nlink          = 1;
+    inode->rdev           = 0;
+    inode->atime_sec      = now.tv_sec;
+    inode->atime_nsec     = now.tv_nsec;
+    inode->mtime_sec      = now.tv_sec;
+    inode->mtime_nsec     = now.tv_nsec;
+    inode->ctime_sec      = now.tv_sec;
+    inode->ctime_nsec     = now.tv_nsec;
+    inode->btime_sec      = now.tv_sec;
+    inode->btime_nsec     = now.tv_nsec;
+    inode->dos_attributes = 0;
 
     if (request->mknod_at.set_attr->va_set_mask & CHIMERA_VFS_ATTR_MODE) {
         inode->mode = request->mknod_at.set_attr->va_mode;
@@ -11046,11 +11065,20 @@ diskfs_open_at_existing_cb(
      * and would ignore a stored ACL that grants more (or less) than the mode.
      * (Mirrors the memfs and cairn backends.) */
 
-    if ((request->open_at.set_attr->va_set_mask & CHIMERA_VFS_ATTR_SIZE) &&
-        request->open_at.set_attr->va_size == 0 &&
-        S_ISREG(inode->mode)) {
-        diskfs_apply_attrs(inode, request->open_at.set_attr);
+    /* Overwrite/supersede disposition: replace the existing file's contents
+     * (truncate to zero) and apply the new attributes (including DOS
+     * attributes), mirroring memfs/cairn.  The SMB layer conveys the truncate
+     * via the OPEN_TRUNCATE flag rather than a SIZE=0 set_attr, so honor both.
+     * As with the pre-existing SIZE=0 path, this resets EOF without reclaiming
+     * the data extents here (the open flow finishes synchronously); a non-empty
+     * file's extents are reclaimed lazily / on the async setattr-truncate path. */
+    if (S_ISREG(inode->mode) &&
+        ((request->open_at.flags & CHIMERA_VFS_OPEN_TRUNCATE) ||
+         ((request->open_at.set_attr->va_set_mask & CHIMERA_VFS_ATTR_SIZE) &&
+          request->open_at.set_attr->va_size == 0))) {
+        inode->size       = 0;
         inode->space_used = 0;
+        diskfs_apply_attrs(inode, request->open_at.set_attr);
     }
 
     diskfs_open_at_finish(request, parent, inode);
@@ -11090,20 +11118,21 @@ diskfs_open_at_alloc_cb(
 
     clock_gettime(CLOCK_REALTIME, &now);
 
-    inode->size       = 0;
-    inode->space_used = 0;
-    inode->uid        = request->cred->uid;
-    inode->gid        = request->cred->gid;
-    inode->nlink      = 1;
-    inode->mode       = S_IFREG | 0644;
-    inode->atime_sec  = now.tv_sec;
-    inode->atime_nsec = now.tv_nsec;
-    inode->mtime_sec  = now.tv_sec;
-    inode->mtime_nsec = now.tv_nsec;
-    inode->ctime_sec  = now.tv_sec;
-    inode->ctime_nsec = now.tv_nsec;
-    inode->btime_sec  = now.tv_sec;
-    inode->btime_nsec = now.tv_nsec;
+    inode->size           = 0;
+    inode->space_used     = 0;
+    inode->uid            = request->cred->uid;
+    inode->gid            = request->cred->gid;
+    inode->nlink          = 1;
+    inode->mode           = S_IFREG | 0644;
+    inode->atime_sec      = now.tv_sec;
+    inode->atime_nsec     = now.tv_nsec;
+    inode->mtime_sec      = now.tv_sec;
+    inode->mtime_nsec     = now.tv_nsec;
+    inode->ctime_sec      = now.tv_sec;
+    inode->ctime_nsec     = now.tv_nsec;
+    inode->btime_sec      = now.tv_sec;
+    inode->btime_nsec     = now.tv_nsec;
+    inode->dos_attributes = 0;
 
     diskfs_apply_attrs(inode, request->open_at.set_attr);
 
@@ -11236,20 +11265,21 @@ diskfs_create_unlinked_alloc_cb(
 
     clock_gettime(CLOCK_REALTIME, &now);
 
-    inode->size       = 0;
-    inode->space_used = 0;
-    inode->uid        = request->cred->uid;
-    inode->gid        = request->cred->gid;
-    inode->nlink      = 0;
-    inode->mode       = S_IFREG | 0644;
-    inode->atime_sec  = now.tv_sec;
-    inode->atime_nsec = now.tv_nsec;
-    inode->mtime_sec  = now.tv_sec;
-    inode->mtime_nsec = now.tv_nsec;
-    inode->ctime_sec  = now.tv_sec;
-    inode->ctime_nsec = now.tv_nsec;
-    inode->btime_sec  = now.tv_sec;
-    inode->btime_nsec = now.tv_nsec;
+    inode->size           = 0;
+    inode->space_used     = 0;
+    inode->uid            = request->cred->uid;
+    inode->gid            = request->cred->gid;
+    inode->nlink          = 0;
+    inode->mode           = S_IFREG | 0644;
+    inode->atime_sec      = now.tv_sec;
+    inode->atime_nsec     = now.tv_nsec;
+    inode->mtime_sec      = now.tv_sec;
+    inode->mtime_nsec     = now.tv_nsec;
+    inode->ctime_sec      = now.tv_sec;
+    inode->ctime_nsec     = now.tv_nsec;
+    inode->btime_sec      = now.tv_sec;
+    inode->btime_nsec     = now.tv_nsec;
+    inode->dos_attributes = 0;
 
     diskfs_apply_attrs(inode, request->create_unlinked.set_attr);
 
@@ -13787,20 +13817,21 @@ diskfs_symlink_at_alloc_cb(
 
     clock_gettime(CLOCK_REALTIME, &now);
 
-    inode->size       = request->symlink_at.targetlen;
-    inode->space_used = request->symlink_at.targetlen;
-    inode->uid        = request->cred->uid;
-    inode->gid        = request->cred->gid;
-    inode->nlink      = 1;
-    inode->mode       = S_IFLNK | 0755;
-    inode->atime_sec  = now.tv_sec;
-    inode->atime_nsec = now.tv_nsec;
-    inode->mtime_sec  = now.tv_sec;
-    inode->mtime_nsec = now.tv_nsec;
-    inode->ctime_sec  = now.tv_sec;
-    inode->ctime_nsec = now.tv_nsec;
-    inode->btime_sec  = now.tv_sec;
-    inode->btime_nsec = now.tv_nsec;
+    inode->size           = request->symlink_at.targetlen;
+    inode->space_used     = request->symlink_at.targetlen;
+    inode->uid            = request->cred->uid;
+    inode->gid            = request->cred->gid;
+    inode->nlink          = 1;
+    inode->mode           = S_IFLNK | 0755;
+    inode->atime_sec      = now.tv_sec;
+    inode->atime_nsec     = now.tv_nsec;
+    inode->mtime_sec      = now.tv_sec;
+    inode->mtime_nsec     = now.tv_nsec;
+    inode->ctime_sec      = now.tv_sec;
+    inode->ctime_nsec     = now.tv_nsec;
+    inode->btime_sec      = now.tv_sec;
+    inode->btime_nsec     = now.tv_nsec;
+    inode->dos_attributes = 0;
 
     diskfs_map_attrs(thread, &request->symlink_at.r_attr, inode);
 


### PR DESCRIPTION
## Summary

The `smb2.openattr` smbtorture suite round-trips DOS file attributes (`READONLY`/`HIDDEN`/`SYSTEM`/`ARCHIVE`) through an SMB2 create + overwrite-truncate. It passed on **memfs** (which stores a per-inode `dos_attributes` word) but was disabled on **cairn** and **diskfs**, which dropped the attribute entirely — the truncate reported `0x20` (ARCHIVE) instead of `0x21` (READONLY|ARCHIVE):

```
source4/torture/smb2/attr.c:212: [2] getatr check failed. [0x80] trunc [0x1] got attr 0x20, should be 0x21
```

This enables the suite on cairn and both diskfs backends by replicating the memfs persistence pattern (the same shape used for native btime in #573).

## Two gaps, fixed per backend

1. **No native DOS-attribute storage.** Add a `dos_attributes` field to the cairn inode and the diskfs in-memory inode + on-disk dinode (with load/flush serialization), report it within `MASK_STAT` on getattr, persist it in `{cairn,diskfs}_apply_attrs`, and initialize it on every inode-creation path.

2. **Overwrite-truncate ignored the new attributes.** The SMB layer conveys an overwriting disposition via the `OPEN_TRUNCATE` flag (not a `SIZE=0` set_attr), but cairn/diskfs only applied `set_attr` on the `SIZE=0` path — so the ARCHIVE/READONLY stamp was never written to an existing file. `open_at` now honors `OPEN_TRUNCATE` (truncate to zero + apply `set_attr`), matching memfs. cairn additionally frees the data extents (`punch_hole`) on this path; diskfs resets EOF and reclaims extents lazily, consistent with its pre-existing `SIZE=0` path.

The passthrough backends (linux/io_uring) stay disabled: a real Linux filesystem has no native API to store these DOS bits — the same reason `smb2.timestamps` is disabled there.

## Notes

- Fixed a self-inflicted hazard caught in review: the bulk field-init edit had also landed a `dos_attributes = 0` inside the `btime == NOW` branch of `diskfs_apply_attrs`, which would have wiped DOS attrs on a create-time-only SETINFO. Removed.

## Verification

- `smb2.openattr` passes on memfs / cairn / diskfs_io_uring / diskfs_aio (via ctest); linux/io_uring correctly remain Disabled.
- No regression in `smb2.rw` / `smb2.timestamps` / `smb2.winattr2` / `smb2.sharemode` / `smb2.create_no_streams` / `smb2.compound_find` on cairn and diskfs.
- NFS3 cthon (basic + truncate) and direct POSIX `fstest`/`dirstress`/`nametest` pass on cairn and diskfs (guards the diskfs dinode layout change and the truncate-path change).