### PR TITLE
vfs/notify: don't overflow subtree watches on mount-root emits

### DIFF
--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -526,8 +526,8 @@ set(SMBTORTURE_ENABLED_cairn
     smb2.timestamps
     smb2.winattr2
     # CHANGE_NOTIFY subtests run cleanly in isolation (combined smb2.notify
-    # suite still trips the shared-process deltree cascade).  cairn does not
-    # support the notify.basedir case yet.
+    # suite still trips the shared-process deltree cascade).
+    smb2.notify.basedir
     smb2.notify.close
     smb2.notify.dir
     smb2.notify.double
@@ -579,8 +579,8 @@ set(SMBTORTURE_ENABLED_diskfs_common
     smb2.timestamps
     smb2.winattr2
     # CHANGE_NOTIFY subtests run cleanly in isolation (combined smb2.notify
-    # suite still trips the shared-process deltree cascade).  diskfs does not
-    # support the notify.basedir case yet.
+    # suite still trips the shared-process deltree cascade).
+    smb2.notify.basedir
     smb2.notify.close
     smb2.notify.dir
     smb2.notify.double

--- a/src/vfs/vfs_notify.c
+++ b/src/vfs/vfs_notify.c
@@ -1047,7 +1047,24 @@ chimera_vfs_notify_emit(
          * Windows correctly interprets as "rescan the directory".  A
          * synthetic FILE_MODIFIED on "." would be ambiguous: a client
          * could legitimately read it as "the watched directory itself
-         * was modified" rather than "an unknown descendant changed". */
+         * was modified" rather than "an unknown descendant changed".
+         *
+         * If the event is on the mount root, no subtree watch can be
+         * an ancestor of the affected entry: subtree watches live at
+         * or below the mount root, so the affected entry (mount-root/
+         * leaf) is either AT a watch's root (the entry IS the watched
+         * dir — not a descendant, not reportable) or is a sibling of a
+         * watch ancestor.  Either way the event must not enqueue into
+         * any subtree watch, and overflowing would wrongly trigger a
+         * NOTIFY_ENUM_DIR rescan.  Mirror the RPL resolver's depth-1
+         * at_root short-circuit and just return. */
+        if (me->root_fh_len > 0 &&
+            dir_fh_len == me->root_fh_len &&
+            memcmp(dir_fh, me->root_fh, dir_fh_len) == 0) {
+            pthread_mutex_unlock(&notify->mount_entries_lock);
+            return;
+        }
+
         for (watch = me->subtree_watches; watch; watch = watch->subtree_next) {
             /* Skip if the event is on the watched directory itself
              * (already handled by exact match above). */


### PR DESCRIPTION
## Summary

- When a SET_INFO on a directory that lives directly under the mount root emits a notify event, the subtree-watch fallback in `chimera_vfs_notify_emit` (used by backends without `CHIMERA_VFS_CAP_RPL` -- cairn, diskfs, io_uring) currently overflows every subtree watch on the mount.  That turns a SET_INFO on a *watched* directory into a spurious `STATUS_NOTIFY_ENUM_DIR` rescan for any recursive watcher of that directory -- the exact failure mode `smbtorture` `smb2.notify.basedir` catches.
- A subtree watch's root always lives at or below the mount root, so an event on the mount root can never have a subtree-watch root as an ancestor: the affected entry is either AT a subtree watch's root (the event is for the watched dir itself, not a descendant) or a sibling of an ancestor (also not a descendant).  Mirror the RPL resolver's depth-1 `at_root` short-circuit in the `!has_rpl` branch and just return.
- Enables `smb2.notify.basedir` on `cairn` and `diskfs` (both diskfs variants).  `io_uring` already happened to pass it because `tree2`'s open of the watched directory via `smb2_util_setatr` -- which does not pass `NTCREATEX_OPTIONS_DIRECTORY` -- fails silently and the emit never reaches the server; with the fix the behaviour is correct rather than incidental there.

## Verification

```
$ ctest -R 'smbtorture_smb2_notify_basedir' --output-on-failure -j 4
6/6 tests passed, 0 tests failed
```

Verified across all 6 backends individually (memfs, cairn, linux, io_uring, diskfs_io_uring, diskfs_aio); none of the other enabled `smb2.notify.*` subtests regress.  Full `ctest -R smbtorture` still passes (276/276).