### PR TITLE
vfs/smb: round-trip caller-supplied timestamps on setattr (smb2.setinfo)

### DIFF
--- a/src/server/smb/smb_attr.h
+++ b/src/server/smb/smb_attr.h
@@ -383,31 +383,48 @@ chimera_smb_unmarshal_basic_info(
     attr->va_req_mask = 0;
     attr->va_set_mask = 0;
 
-    /* Each timestamp is only applied when the client supplied a real value;
-     * the omit/freeze/thaw sentinels leave the stored value alone. */
+    /* MS-FSCC 2.4.7 FileBasicInformation: a non-zero timestamp replaces the
+     * stored value; a zero (or freeze/thaw sentinel) means "don't change".
+     * Carry every time field through to the backend even when it is omitted,
+     * using the TIME_OMIT sentinel — that way the implicit ctime bump (which
+     * apply_attrs would otherwise stamp because the co-present DOS-attribute
+     * change is a metadata write) is suppressed for the fields the client
+     * asked to leave alone.  apply_attrs treats TIME_OMIT as "preserve". */
     if (!chimera_smb_time_is_omit(smb_attrs->smb_atime)) {
         chimera_nt_to_epoch(smb_attrs->smb_atime, &attr->va_atime);
-        attr->va_req_mask |= CHIMERA_VFS_ATTR_ATIME;
-        attr->va_set_mask |= CHIMERA_VFS_ATTR_ATIME;
+    } else {
+        attr->va_atime.tv_sec  = 0;
+        attr->va_atime.tv_nsec = CHIMERA_VFS_TIME_OMIT;
     }
+    attr->va_req_mask |= CHIMERA_VFS_ATTR_ATIME;
+    attr->va_set_mask |= CHIMERA_VFS_ATTR_ATIME;
 
     if (!chimera_smb_time_is_omit(smb_attrs->smb_mtime)) {
         chimera_nt_to_epoch(smb_attrs->smb_mtime, &attr->va_mtime);
-        attr->va_req_mask |= CHIMERA_VFS_ATTR_MTIME;
-        attr->va_set_mask |= CHIMERA_VFS_ATTR_MTIME;
+    } else {
+        attr->va_mtime.tv_sec  = 0;
+        attr->va_mtime.tv_nsec = CHIMERA_VFS_TIME_OMIT;
     }
+    attr->va_req_mask |= CHIMERA_VFS_ATTR_MTIME;
+    attr->va_set_mask |= CHIMERA_VFS_ATTR_MTIME;
 
     if (!chimera_smb_time_is_omit(smb_attrs->smb_ctime)) {
         chimera_nt_to_epoch(smb_attrs->smb_ctime, &attr->va_ctime);
-        attr->va_req_mask |= CHIMERA_VFS_ATTR_CTIME;
-        attr->va_set_mask |= CHIMERA_VFS_ATTR_CTIME;
+    } else {
+        attr->va_ctime.tv_sec  = 0;
+        attr->va_ctime.tv_nsec = CHIMERA_VFS_TIME_OMIT;
     }
+    attr->va_req_mask |= CHIMERA_VFS_ATTR_CTIME;
+    attr->va_set_mask |= CHIMERA_VFS_ATTR_CTIME;
 
     if (!chimera_smb_time_is_omit(smb_attrs->smb_crttime)) {
         chimera_nt_to_epoch(smb_attrs->smb_crttime, &attr->va_btime);
-        attr->va_req_mask |= CHIMERA_VFS_ATTR_BTIME;
-        attr->va_set_mask |= CHIMERA_VFS_ATTR_BTIME;
+    } else {
+        attr->va_btime.tv_sec  = 0;
+        attr->va_btime.tv_nsec = CHIMERA_VFS_TIME_OMIT;
     }
+    attr->va_req_mask |= CHIMERA_VFS_ATTR_BTIME;
+    attr->va_set_mask |= CHIMERA_VFS_ATTR_BTIME;
 
     /* A FileAttributes value of 0 means "no change" (MS-FSCC 2.4.7); any
      * non-zero value replaces the persisted DOS attribute set. */

--- a/src/vfs/cairn/cairn.c
+++ b/src/vfs/cairn/cairn.c
@@ -1765,7 +1765,7 @@ cairn_apply_attrs(
         attr->va_set_mask |= CHIMERA_VFS_ATTR_ATIME;
         if (attr->va_atime.tv_nsec == CHIMERA_VFS_TIME_NOW) {
             inode->atime = now;
-        } else {
+        } else if (attr->va_atime.tv_nsec != CHIMERA_VFS_TIME_OMIT) {
             inode->atime = attr->va_atime;
         }
     }
@@ -1774,7 +1774,7 @@ cairn_apply_attrs(
         attr->va_set_mask |= CHIMERA_VFS_ATTR_MTIME;
         if (attr->va_mtime.tv_nsec == CHIMERA_VFS_TIME_NOW) {
             inode->mtime = now;
-        } else {
+        } else if (attr->va_mtime.tv_nsec != CHIMERA_VFS_TIME_OMIT) {
             inode->mtime = attr->va_mtime;
         }
     }
@@ -1783,7 +1783,7 @@ cairn_apply_attrs(
         attr->va_set_mask |= CHIMERA_VFS_ATTR_BTIME;
         if (attr->va_btime.tv_nsec == CHIMERA_VFS_TIME_NOW) {
             inode->btime = now;
-        } else {
+        } else if (attr->va_btime.tv_nsec != CHIMERA_VFS_TIME_OMIT) {
             inode->btime = attr->va_btime;
         }
     }
@@ -1793,7 +1793,19 @@ cairn_apply_attrs(
         inode->dos_attributes = attr->va_dos_attributes;
     }
 
-    inode->ctime = now;
+    /* ctime: round-trip a caller-supplied change_time (SMB FileBasicInformation
+     * SetInfo) or preserve it on TIME_OMIT; otherwise stamp it with now for the
+     * implicit metadata change.  See memfs_apply_attrs() for the rationale. */
+    if (set_mask & CHIMERA_VFS_ATTR_CTIME) {
+        attr->va_set_mask |= CHIMERA_VFS_ATTR_CTIME;
+        if (attr->va_ctime.tv_nsec == CHIMERA_VFS_TIME_NOW) {
+            inode->ctime = now;
+        } else if (attr->va_ctime.tv_nsec != CHIMERA_VFS_TIME_OMIT) {
+            inode->ctime = attr->va_ctime;
+        }
+    } else {
+        inode->ctime = now;
+    }
 
 } /* cairn_apply_attrs */
 

--- a/src/vfs/diskfs/diskfs.c
+++ b/src/vfs/diskfs/diskfs.c
@@ -9869,7 +9869,7 @@ diskfs_apply_attrs(
         if (attr->va_atime.tv_nsec == CHIMERA_VFS_TIME_NOW) {
             inode->atime_sec  = now.tv_sec;
             inode->atime_nsec = now.tv_nsec;
-        } else {
+        } else if (attr->va_atime.tv_nsec != CHIMERA_VFS_TIME_OMIT) {
             inode->atime_sec  = attr->va_atime.tv_sec;
             inode->atime_nsec = attr->va_atime.tv_nsec;
         }
@@ -9880,7 +9880,7 @@ diskfs_apply_attrs(
         if (attr->va_mtime.tv_nsec == CHIMERA_VFS_TIME_NOW) {
             inode->mtime_sec  = now.tv_sec;
             inode->mtime_nsec = now.tv_nsec;
-        } else {
+        } else if (attr->va_mtime.tv_nsec != CHIMERA_VFS_TIME_OMIT) {
             inode->mtime_sec  = attr->va_mtime.tv_sec;
             inode->mtime_nsec = attr->va_mtime.tv_nsec;
         }
@@ -9891,7 +9891,7 @@ diskfs_apply_attrs(
         if (attr->va_btime.tv_nsec == CHIMERA_VFS_TIME_NOW) {
             inode->btime_sec  = now.tv_sec;
             inode->btime_nsec = now.tv_nsec;
-        } else {
+        } else if (attr->va_btime.tv_nsec != CHIMERA_VFS_TIME_OMIT) {
             inode->btime_sec  = attr->va_btime.tv_sec;
             inode->btime_nsec = attr->va_btime.tv_nsec;
         }
@@ -9902,8 +9902,22 @@ diskfs_apply_attrs(
         inode->dos_attributes = attr->va_dos_attributes;
     }
 
-    inode->ctime_sec  = now.tv_sec;
-    inode->ctime_nsec = now.tv_nsec;
+    /* ctime: round-trip a caller-supplied change_time (SMB FileBasicInformation
+     * SetInfo) or preserve it on TIME_OMIT; otherwise stamp it with now for the
+     * implicit metadata change.  See memfs_apply_attrs() for the rationale. */
+    if (set_mask & CHIMERA_VFS_ATTR_CTIME) {
+        attr->va_set_mask |= CHIMERA_VFS_ATTR_CTIME;
+        if (attr->va_ctime.tv_nsec == CHIMERA_VFS_TIME_NOW) {
+            inode->ctime_sec  = now.tv_sec;
+            inode->ctime_nsec = now.tv_nsec;
+        } else if (attr->va_ctime.tv_nsec != CHIMERA_VFS_TIME_OMIT) {
+            inode->ctime_sec  = attr->va_ctime.tv_sec;
+            inode->ctime_nsec = attr->va_ctime.tv_nsec;
+        }
+    } else {
+        inode->ctime_sec  = now.tv_sec;
+        inode->ctime_nsec = now.tv_nsec;
+    }
 
 } /* diskfs_apply_attrs */
 

--- a/src/vfs/io_uring/io_uring.c
+++ b/src/vfs/io_uring/io_uring.c
@@ -294,26 +294,37 @@ chimera_io_uring_set_open_attrs(
 
     if (set_mask & (CHIMERA_VFS_ATTR_ATIME | CHIMERA_VFS_ATTR_MTIME)) {
         struct timespec times[2];
+        int             have_any = 0;
 
         if (set_mask & CHIMERA_VFS_ATTR_ATIME) {
-            times[0] = attr->va_atime;
             if (attr->va_atime.tv_nsec == CHIMERA_VFS_TIME_NOW) {
                 times[0].tv_nsec = UTIME_NOW;
+                have_any         = 1;
+            } else if (attr->va_atime.tv_nsec == CHIMERA_VFS_TIME_OMIT) {
+                times[0].tv_nsec = UTIME_OMIT;
+            } else {
+                times[0] = attr->va_atime;
+                have_any = 1;
             }
         } else {
             times[0].tv_nsec = UTIME_OMIT;
         }
 
         if (set_mask & CHIMERA_VFS_ATTR_MTIME) {
-            times[1] = attr->va_mtime;
             if (attr->va_mtime.tv_nsec == CHIMERA_VFS_TIME_NOW) {
                 times[1].tv_nsec = UTIME_NOW;
+                have_any         = 1;
+            } else if (attr->va_mtime.tv_nsec == CHIMERA_VFS_TIME_OMIT) {
+                times[1].tv_nsec = UTIME_OMIT;
+            } else {
+                times[1] = attr->va_mtime;
+                have_any = 1;
             }
         } else {
             times[1].tv_nsec = UTIME_OMIT;
         }
 
-        if (futimens(fd, times) < 0) {
+        if (have_any && futimens(fd, times) < 0) {
             return errno;
         }
     }
@@ -892,12 +903,17 @@ chimera_io_uring_setattr(
 
     if (request->setattr.set_attr->va_set_mask & (CHIMERA_VFS_ATTR_ATIME | CHIMERA_VFS_ATTR_MTIME)) {
         struct timespec times[2];
+        int             have_any = 0;
 
         if (request->setattr.set_attr->va_set_mask & CHIMERA_VFS_ATTR_ATIME) {
             if (request->setattr.set_attr->va_atime.tv_nsec == CHIMERA_VFS_TIME_NOW) {
                 times[0].tv_nsec = UTIME_NOW;
+                have_any         = 1;
+            } else if (request->setattr.set_attr->va_atime.tv_nsec == CHIMERA_VFS_TIME_OMIT) {
+                times[0].tv_nsec = UTIME_OMIT;
             } else {
                 times[0] = request->setattr.set_attr->va_atime;
+                have_any = 1;
             }
 
             request->setattr.set_attr->va_set_mask |= CHIMERA_VFS_ATTR_ATIME;
@@ -908,8 +924,12 @@ chimera_io_uring_setattr(
         if (request->setattr.set_attr->va_set_mask & CHIMERA_VFS_ATTR_MTIME) {
             if (request->setattr.set_attr->va_mtime.tv_nsec == CHIMERA_VFS_TIME_NOW) {
                 times[1].tv_nsec = UTIME_NOW;
+                have_any         = 1;
+            } else if (request->setattr.set_attr->va_mtime.tv_nsec == CHIMERA_VFS_TIME_OMIT) {
+                times[1].tv_nsec = UTIME_OMIT;
             } else {
                 times[1] = request->setattr.set_attr->va_mtime;
+                have_any = 1;
             }
 
             request->setattr.set_attr->va_set_mask |= CHIMERA_VFS_ATTR_MTIME;
@@ -917,16 +937,18 @@ chimera_io_uring_setattr(
             times[1].tv_nsec = UTIME_OMIT;
         }
 
-        rc = utimensat(fd, "", times, AT_SYMLINK_NOFOLLOW | AT_EMPTY_PATH);
+        if (have_any) {
+            rc = utimensat(fd, "", times, AT_SYMLINK_NOFOLLOW | AT_EMPTY_PATH);
 
-        if (rc) {
-            chimera_io_uring_error("io_uring_setattr: utimensat() failed: %s",
-                                   strerror(errno));
+            if (rc) {
+                chimera_io_uring_error("io_uring_setattr: utimensat() failed: %s",
+                                       strerror(errno));
 
-            chimera_restore_privilege(request->cred);
-            request->status = chimera_linux_errno_to_status(errno);
-            request->complete(request);
-            return;
+                chimera_restore_privilege(request->cred);
+                request->status = chimera_linux_errno_to_status(errno);
+                request->complete(request);
+                return;
+            }
         }
     }
 

--- a/src/vfs/linux/linux.c
+++ b/src/vfs/linux/linux.c
@@ -253,12 +253,17 @@ chimera_linux_set_attrs(
 
     if (set_mask & (CHIMERA_VFS_ATTR_ATIME | CHIMERA_VFS_ATTR_MTIME)) {
         struct timespec times[2];
+        int             have_any = 0;
 
         if (set_mask & CHIMERA_VFS_ATTR_ATIME) {
             if (attr->va_atime.tv_nsec == CHIMERA_VFS_TIME_NOW) {
                 times[0].tv_nsec = UTIME_NOW;
+                have_any         = 1;
+            } else if (attr->va_atime.tv_nsec == CHIMERA_VFS_TIME_OMIT) {
+                times[0].tv_nsec = UTIME_OMIT;
             } else {
                 times[0] = attr->va_atime;
+                have_any = 1;
             }
 
             attr->va_set_mask |= CHIMERA_VFS_ATTR_ATIME;
@@ -269,8 +274,12 @@ chimera_linux_set_attrs(
         if (set_mask & CHIMERA_VFS_ATTR_MTIME) {
             if (attr->va_mtime.tv_nsec == CHIMERA_VFS_TIME_NOW) {
                 times[1].tv_nsec = UTIME_NOW;
+                have_any         = 1;
+            } else if (attr->va_mtime.tv_nsec == CHIMERA_VFS_TIME_OMIT) {
+                times[1].tv_nsec = UTIME_OMIT;
             } else {
                 times[1] = attr->va_mtime;
+                have_any = 1;
             }
 
             attr->va_set_mask |= CHIMERA_VFS_ATTR_MTIME;
@@ -278,13 +287,15 @@ chimera_linux_set_attrs(
             times[1].tv_nsec = UTIME_OMIT;
         }
 
-        rc = utimensat(dirfd, path, times, AT_SYMLINK_NOFOLLOW | AT_EMPTY_PATH);
+        if (have_any) {
+            rc = utimensat(dirfd, path, times, AT_SYMLINK_NOFOLLOW | AT_EMPTY_PATH);
 
-        if (rc) {
-            chimera_linux_error("linux_setattr: utimensat() failed: %s",
-                                strerror(errno));
+            if (rc) {
+                chimera_linux_error("linux_setattr: utimensat() failed: %s",
+                                    strerror(errno));
 
-            return -errno;
+                return -errno;
+            }
         }
     }
 

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -1328,7 +1328,7 @@ memfs_apply_attrs(
         attr->va_set_mask |= CHIMERA_VFS_ATTR_ATIME;
         if (attr->va_atime.tv_nsec == CHIMERA_VFS_TIME_NOW) {
             inode->atime = now;
-        } else {
+        } else if (attr->va_atime.tv_nsec != CHIMERA_VFS_TIME_OMIT) {
             inode->atime = attr->va_atime;
         }
     }
@@ -1337,7 +1337,7 @@ memfs_apply_attrs(
         attr->va_set_mask |= CHIMERA_VFS_ATTR_MTIME;
         if (attr->va_mtime.tv_nsec == CHIMERA_VFS_TIME_NOW) {
             inode->mtime = now;
-        } else {
+        } else if (attr->va_mtime.tv_nsec != CHIMERA_VFS_TIME_OMIT) {
             inode->mtime = attr->va_mtime;
         }
     }
@@ -1369,7 +1369,7 @@ memfs_apply_attrs(
         attr->va_set_mask |= CHIMERA_VFS_ATTR_BTIME;
         if (attr->va_btime.tv_nsec == CHIMERA_VFS_TIME_NOW) {
             inode->btime = now;
-        } else {
+        } else if (attr->va_btime.tv_nsec != CHIMERA_VFS_TIME_OMIT) {
             inode->btime = attr->va_btime;
         }
     }
@@ -1386,7 +1386,24 @@ memfs_apply_attrs(
                attr->va_pnfs_len : CHIMERA_VFS_PNFS_LAYOUT_MAX);
     }
 
-    inode->ctime = now;
+    /* ctime: an SMB SetInfo(FileBasicInformation) carries an explicit
+     * change_time and MS-FSCC requires the server to round-trip it (the
+     * change is to the caller-supplied value, not "now").  TIME_OMIT means
+     * the caller asked to preserve the stored value — this is how the SMB
+     * layer suppresses the implicit ctime bump on a FileBasicInformation
+     * SetInfo whose ChangeTime field was zero.  POSIX semantics still apply
+     * to any other metadata change — if the caller did not supply CTIME at
+     * all (NFS chmod/chown, etc.), stamp it with `now`. */
+    if (set_mask & CHIMERA_VFS_ATTR_CTIME) {
+        attr->va_set_mask |= CHIMERA_VFS_ATTR_CTIME;
+        if (attr->va_ctime.tv_nsec == CHIMERA_VFS_TIME_NOW) {
+            inode->ctime = now;
+        } else if (attr->va_ctime.tv_nsec != CHIMERA_VFS_TIME_OMIT) {
+            inode->ctime = attr->va_ctime;
+        }
+    } else {
+        inode->ctime = now;
+    }
 
 } /* memfs_apply_attrs */
 

--- a/src/vfs/vfs_attrs.h
+++ b/src/vfs/vfs_attrs.h
@@ -90,6 +90,14 @@ struct chimera_acl;
 
 #define CHIMERA_VFS_TIME_NOW            ((1l << 30) - 3l)
 
+/* Sentinel: "preserve the existing value, don't bump implicitly".  Used by
+ * SMB SetInfo(FileBasicInformation) to convey MS-FSCC 2.4.7's "a zero
+ * timestamp means don't change" semantics: the SMB layer must always carry
+ * the time-attr bit in set_mask (so the implicit ctime bump that would
+ * otherwise fire on the co-present DOS-attribute change is suppressed), but
+ * a value of TIME_OMIT means the backend should leave that timestamp alone. */
+#define CHIMERA_VFS_TIME_OMIT           ((1l << 30) - 4l)
+
 struct chimera_vfs_attrs {
     uint64_t            va_req_mask;
     uint64_t            va_set_mask;


### PR DESCRIPTION
MS-FSCC 2.4.7 `SetFileInformation(FileBasicInformation)` lets a client set the file's `CreationTime` / `LastAccessTime` / `LastWriteTime` / `ChangeTime` explicitly, or omit any of them by sending 0 (or the freeze/thaw sentinels) to mean "don't change this field". In particular:

    SetInfo(BASIC, ctime = T)                  -> ChangeTime = T
    SetInfo(BASIC, ctime = 0, attrib = NORMAL) -> ChangeTime = T (preserved)

The smb2.setinfo conformance suite verifies this: a zero ChangeTime in a FileBasicInformation SetInfo MUST NOT bump the stored ChangeTime, even though the co-present DOS-attribute change is a metadata write that would otherwise advance ctime under POSIX.

### Two bugs blocking this

1. **`chimera_smb_unmarshal_basic_info`** only set `CHIMERA_VFS_ATTR_{ATIME,MTIME,CTIME,BTIME}` in the request's `set_mask` when the wire field was non-zero. An omitted ChangeTime therefore left `CHIMERA_VFS_ATTR_CTIME` out of `set_mask` entirely, and `apply_attrs` (below) bumped ctime to "now" because it could not tell the caller meant "preserve".
2. **`memfs_apply_attrs` / `cairn_apply_attrs` / `diskfs_apply_attrs`** unconditionally stamped `inode->ctime = now` at the end of every setattr, ignoring any explicit ChangeTime the caller supplied — so even `SetInfo(BASIC, ctime = T)` was overwritten with the current wall clock.

### Fix

- New `CHIMERA_VFS_TIME_OMIT` sentinel ("preserve the stored value, don't bump implicitly"), peer to the existing `CHIMERA_VFS_TIME_NOW`.
- `chimera_smb_unmarshal_basic_info` now always carries `ATIME/MTIME/CTIME/BTIME` in the request `set_mask`, with `TIME_OMIT` in any field the client zeroed. That's the explicit signal `apply_attrs` needs to suppress the implicit ctime bump when the co-present change is just a DOS-attribute write.
- `memfs` / `cairn` / `diskfs` `apply_attrs` honour `TIME_OMIT` for all four timestamps (skip the write) and honour an explicit `CHIMERA_VFS_ATTR_CTIME` in `set_mask`: `TIME_NOW` → bump to now, `TIME_OMIT` → preserve, any other value → store as-is. **ctime still bumps implicitly when CTIME is *not* in `set_mask`** (NFS chmod/chown, S3 metadata change), preserving POSIX semantics for non-SMB callers.
- `linux` / `io_uring` `set_attrs` map `TIME_OMIT` to `UTIME_OMIT` and skip the `utimensat` call entirely when no atime/mtime would actually change (avoids a spurious syscall on a pure attribute-bit SetInfo from SMB).

### What this greens

- **smb2.setinfo**'s `change_time round-trip` check now passes on memfs/cairn/diskfs. The suite still trips later on `FILE_ATTRIBUTE_NORMAL` fallback and `FILE_ATTRIBUTE_DIRECTORY`-on-file validation — both outside the scope of this fix; left for follow-ups.
- **smb2.async_dosmode** flips from memfs-only-green to passing on cairn + diskfs as a side benefit (the suite reads back attributes after a write and was being thrown by the spurious ctime updates).

Verified end-to-end against `smb2.timestamps`, `smb2.openattr`, `smb2.acls.*`, and the read/rw/share-mode/secleak/notify suites on every native backend — all stay green.