### PR TITLE
smb2: fix FileNamesInformation marshalling + rename access gating

### DIFF
--- a/src/server/smb/smb_proc_close.c
+++ b/src/server/smb/smb_proc_close.c
@@ -24,6 +24,26 @@ chimera_smb_close_durable_delete_callback(
     (void) private_data;
 } /* chimera_smb_close_durable_delete_callback */
 
+/* Map a delete-on-close remove_at failure to the SMB CLOSE response status.
+ * MS-FSA close semantics: the close itself succeeds, but the delete failure
+ * (ENOTEMPTY on a non-empty directory most commonly, also EACCES) must be
+ * reported to the client so it knows the object survived.  Silently turning
+ * every failure into SUCCESS makes smb2_deltree believe its recursive teardown
+ * worked, leaving a stale BASEDIR / leftover entries that wreck the next
+ * subtest's setup. */
+static inline uint32_t
+chimera_smb_close_doc_status(enum chimera_vfs_error error_code)
+{
+    switch (error_code) {
+        case CHIMERA_VFS_OK:        return SMB2_STATUS_SUCCESS;
+        case CHIMERA_VFS_ENOTEMPTY: return SMB2_STATUS_DIRECTORY_NOT_EMPTY;
+        case CHIMERA_VFS_EACCES:
+        case CHIMERA_VFS_EPERM:     return SMB2_STATUS_ACCESS_DENIED;
+        case CHIMERA_VFS_ENOENT:    return SMB2_STATUS_OBJECT_NAME_NOT_FOUND;
+        default:                    return SMB2_STATUS_INTERNAL_ERROR;
+    } /* switch */
+} /* chimera_smb_close_doc_status */
+
 static void
 chimera_smb_close_doc_remove_callback(
     enum chimera_vfs_error    error_code,
@@ -53,7 +73,7 @@ chimera_smb_close_doc_remove_callback(
 
     chimera_smb_open_file_release(request, request->close.open_file);
 
-    chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
+    chimera_smb_complete_request(request, chimera_smb_close_doc_status(error_code));
 } /* chimera_smb_close_doc_remove_callback */
 
 static void

--- a/src/server/smb/smb_proc_query_directory.c
+++ b/src/server/smb/smb_proc_query_directory.c
@@ -148,7 +148,9 @@ chimera_smb_query_directory_readdir_callback(
             expected_length = 94 + namelen_padded;
             break;
         case SMB2_FILE_NAMES_INFORMATION:
-            expected_length = 64 + namelen_padded;
+            /* MS-FSCC 2.4.27 FileNamesInformation fixed header:
+             * NextEntryOffset(4) + FileIndex(4) + FileNameLength(4) = 12. */
+            expected_length = 12 + namelen_padded;
             break;
         case SMB2_FILE_FULL_DIRECTORY_INFORMATION:
             expected_length = 68 + namelen_padded;
@@ -230,6 +232,9 @@ chimera_smb_query_directory_readdir_callback(
 
             break;
         case SMB2_FILE_NAMES_INFORMATION:
+            /* FileIndex (0 = unspecified per MS-FSCC) + FileNameLength + name.
+             * NextEntryOffset was already written at the top of the entry. */
+            evpl_iovec_cursor_append_uint32(&entry_cursor, file_index);
             evpl_iovec_cursor_append_uint32(&entry_cursor, namelen * 2);
 
             namebuf = evpl_iovec_cursor_data(&entry_cursor);

--- a/src/server/smb/smb_proc_set_info_rename.c
+++ b/src/server/smb/smb_proc_set_info_rename.c
@@ -90,7 +90,25 @@ chimera_smb_set_info_rename_callback(
 
     chimera_smb_open_file_release(request, open_file);
 
-    chimera_smb_complete_request(request, error_code ? SMB2_STATUS_INTERNAL_ERROR : SMB2_STATUS_SUCCESS);
+    /* Map the rename_at failure (if any) back to the SMB status the client
+    * needs.  EACCES/EPERM commonly surface from the engine's DELETE_CHILD /
+    * sharing-violation gates and must be reported as ACCESS_DENIED, not
+    * INTERNAL_ERROR — a STATUS_INTERNAL_ERROR makes smbtorture treat the
+    * server as broken instead of asserting on the actual returned code. */
+    uint32_t status;
+    switch (error_code) {
+        case CHIMERA_VFS_OK:        status = SMB2_STATUS_SUCCESS; break;
+        case CHIMERA_VFS_EACCES:
+        case CHIMERA_VFS_EPERM:     status = SMB2_STATUS_ACCESS_DENIED; break;
+        case CHIMERA_VFS_EEXIST:    status = SMB2_STATUS_OBJECT_NAME_COLLISION; break;
+        case CHIMERA_VFS_ENOENT:    status = SMB2_STATUS_OBJECT_NAME_NOT_FOUND; break;
+        case CHIMERA_VFS_ENOTEMPTY: status = SMB2_STATUS_DIRECTORY_NOT_EMPTY; break;
+        case CHIMERA_VFS_EISDIR:    status = SMB2_STATUS_FILE_IS_A_DIRECTORY; break;
+        case CHIMERA_VFS_ENOTDIR:   status = SMB2_STATUS_NOT_A_DIRECTORY; break;
+        default:                    status = SMB2_STATUS_INTERNAL_ERROR; break;
+    } /* switch */
+
+    chimera_smb_complete_request(request, status);
 } /* chimera_smb_set_info_rename_callback */
 
 static void
@@ -323,6 +341,19 @@ chimera_smb_set_info_rename_process(struct chimera_smb_request *request)
     struct chimera_vfs_thread      *vfs_thread  = request->compound->thread->vfs_thread;
     struct chimera_smb_tree        *tree        = request->tree;
     struct chimera_smb_rename_info *rename_info = &request->set_info.rename_info;
+    struct chimera_smb_open_file   *open_file   = request->set_info.open_file;
+
+    /* MS-FSA 2.1.5.14.11.1 SetInfo(FileRenameInformation): if the handle was
+     * not opened with DELETE access, the rename MUST fail with ACCESS_DENIED
+     * (the rename removes the old name from its parent and adds a new one, so
+     * the source handle's GrantedAccess must include DELETE).  Gate here, ahead
+     * of the destination-existence probe — otherwise a target collision would
+     * surface as OBJECT_NAME_COLLISION and mask the real authorization error. */
+    if (!(open_file->granted_access & SMB2_DELETE)) {
+        chimera_smb_open_file_release(request, open_file);
+        chimera_smb_complete_request(request, SMB2_STATUS_ACCESS_DENIED);
+        return;
+    }
 
     if (rename_info->new_parent_len) {
         /* Moving to a different directory - lookup the new parent path */


### PR DESCRIPTION
The smb2.rename suite was failing 9 of its 13 subtests, and the comments next to `SMBTORTURE_ACLS_SUBTESTS` / `SMBTORTURE_NOTIFY_SUBTESTS` in the test CMakeLists.txt blamed a *"shared-process smb2_deltree cleanup cascade"* for multiple combined suites' inability to run in CI.  Three bugs converge in this area; addressing all three unlocks a sizable chunk of the conformance matrix:

### 1. `SMB2_FILE_NAMES_INFORMATION` marshalling is broken (the deltree cascade root cause)

The `query_directory` handler claimed `expected_length = 64 + namelen` per entry and only wrote `NextEntryOffset + FileNameLength` (8 bytes), missing `FileIndex` and over-reserving 56 bytes of header.  Per MS-FSCC 2.4.27 the fixed header is **12 bytes** (`NextEntryOffset + FileIndex + FileNameLength`).  With the wrong stride the client followed `NextEntryOffset` into garbage on the very first entry and the enumeration terminated with zero results.

Samba's `smb2_deltree` uses exactly this info-level (`SMB2_FIND_NAME_INFO`) to walk a directory's contents — so it never saw any of the files inside BASEDIR, never recursively unlinked them, and proceeded to issue a delete-on-close on the parent (which then could not actually unlink it).  Every smbtorture suite that uses `smb2_deltree` to tear down its BASEDIR between subtests was hitting the same cascade.

Fix: emit the 12-byte header, include `FileIndex`.

### 2. The close-time delete-on-close failure was swallowed

When `chimera_vfs_remove_at` from `chimera_smb_close_doc_remove_callback` returned an error (most commonly `ENOTEMPTY` against a non-empty directory), the close response was still `SMB2_STATUS_SUCCESS`.  That made `smb2_deltree`'s fall-back recursion impossible: the very first `smb2_util_unlink(BASEDIR)` "succeeded", `smb2_deltree` returned 1 thinking it was done, and the next subtest's setup collided on the stale directory.

Fix: surface the actual failure (`ENOTEMPTY → STATUS_DIRECTORY_NOT_EMPTY`, `EACCES → STATUS_ACCESS_DENIED`, etc.) so `smb2_deltree` knows to fall through and walk the directory.

### 3. `SetInfo(FileRenameInformation)` did not gate on the open handle's GrantedAccess

MS-FSA 2.1.5.14.11.1 requires `DELETE` access on the source open before a rename — without it the server must return `STATUS_ACCESS_DENIED`.  Chimera let the rename proceed to the destination lookup, so a missing-DELETE handle would either succeed (silently bypassing the access model) or, when the destination already existed, surface as `OBJECT_NAME_COLLISION` and mask the real authorization error.

Fix: gate on `open_file->granted_access & SMB2_DELETE` at the entry to `chimera_smb_set_info_rename_process`, ahead of any I/O.

While in this area, also map `chimera_smb_set_info_rename_callback`'s `error_code` into the proper SMB status (`EACCES → ACCESS_DENIED`, `EEXIST → OBJECT_NAME_COLLISION`, etc.) instead of collapsing every failure to `STATUS_INTERNAL_ERROR` — that previously made smbtorture treat the server as broken instead of asserting on the actual returned code, hiding the real disagreement.

### Net effect

| Suite                                     | Before  | After     |
|---|---|---|
| `smb2.rename.simple_nodelete`             | FAIL (`OK` should be `ACCESS_DENIED`) | **PASS** |
| `smb2.rename.no_sharing`                  | FAIL (cascade)                         | **PASS** |
| `smb2.rename.share_delete_no_delete_access` | FAIL (cascade)                       | **PASS** |
| `smb2.rename.msword`                      | FAIL (cascade)                         | **PASS** |
| `smb2.rename.rename_dir_openfile`         | FAIL (cascade)                         | **PASS** |
| `smb2.rename.rename-open`                 | FAIL (cascade)                         | **PASS** |
| **`smb2.acls` (combined suite)**          | FAIL (cascade — `SMBTORTURE_ACLS_SUBTESTS` registered them individually as a workaround) | **PASS** |
| `smb2.timestamps`, `smb2.openattr`, `smb2.async_dosmode`, every other enabled suite | green | green (no regressions) |

Worth a follow-up CMakeLists change to enable the combined `smb2.acls` suite (and re-evaluate the `SMBTORTURE_NOTIFY_SUBTESTS` / `smb2.notify` situation).

### Still failing in smb2.rename

Three subtests still fail with `NT_STATUS_OK should be SHARING_VIOLATION` — `share_delete_and_delete_access`, `no_share_delete_but_delete_access`, `no_share_delete_no_delete_access`.  They test the share-mode interaction with rename when a second handle has the target open without `FILE_SHARE_DELETE`.  That gate is a separate sharemode-enforcement gap and out of scope here.