### PR TITLE
config: move VFS delegation settings to the shared "common" section

### DIFF
--- a/chimera-docker.json
+++ b/chimera-docker.json
@@ -1,9 +1,11 @@
 {
-    "server": {
-        "threads": 4,
+    "common": {
         "sync_delegation_threads": 8,
         "async_delegation": false,
-        "async_delegation_threads": 8,
+        "async_delegation_threads": 8
+    },
+    "server": {
+        "threads": 4,
         "rest_http_port": 8080
     },
     "mounts": {

--- a/src/client/client.c
+++ b/src/client/client.c
@@ -90,6 +90,28 @@ chimera_client_config_set_tcp_flavor(
     config->tcp_flavor = flavor;
 } /* chimera_client_config_set_tcp_flavor */
 
+SYMBOL_EXPORT void
+chimera_client_config_set_delegation(
+    struct chimera_client_config *config,
+    int                           sync_delegation,
+    int                           sync_delegation_threads,
+    int                           async_delegation,
+    int                           async_delegation_threads)
+{
+    if (sync_delegation >= 0) {
+        config->sync_delegation = sync_delegation;
+    }
+    if (sync_delegation_threads >= 0) {
+        config->sync_delegation_threads = sync_delegation_threads;
+    }
+    if (async_delegation >= 0) {
+        config->async_delegation = async_delegation;
+    }
+    if (async_delegation_threads >= 0) {
+        config->async_delegation_threads = async_delegation_threads;
+    }
+} /* chimera_client_config_set_delegation */
+
 SYMBOL_EXPORT struct chimera_client_thread *
 chimera_client_thread_init(
     struct evpl           *evpl,
@@ -274,6 +296,20 @@ chimera_client_init_json(
                                                  mod_config ? mod_config : "");
             }
         }
+    }
+
+    /* The delegation pools are VFS-level; their canonical home is the shared
+     * "common" section.  Apply it last so it overrides any legacy values from
+     * the "config" section above. */
+    {
+        struct chimera_common_delegation deleg;
+
+        chimera_common_delegation_config(root, &deleg);
+        chimera_client_config_set_delegation(config,
+                                             deleg.sync_delegation,
+                                             deleg.sync_delegation_threads,
+                                             deleg.async_delegation,
+                                             deleg.async_delegation_threads);
     }
 
     client = chimera_client_init(config, cred, metrics);

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -34,6 +34,19 @@ chimera_client_config_set_tcp_flavor(
     struct chimera_client_config *config,
     enum chimera_tcp_flavor       flavor);
 
+/*
+ * Override the VFS delegation-pool settings.  Each argument is applied only when
+ * >= 0; pass -1 to leave the current value untouched.  Mirrors the "common"
+ * section keys parsed by chimera_common_delegation_config().
+ */
+void
+chimera_client_config_set_delegation(
+    struct chimera_client_config *config,
+    int                           sync_delegation,
+    int                           sync_delegation_threads,
+    int                           async_delegation,
+    int                           async_delegation_threads);
+
 struct chimera_client *
 chimera_client_init(
     const struct chimera_client_config *config,

--- a/src/common/common_config.h
+++ b/src/common/common_config.h
@@ -180,6 +180,69 @@ chimera_apply_common_config(
 } /* chimera_apply_common_config */
 
 /*
+ * Delegation-pool settings parsed from the shared top-level "common" section.
+ * These are VFS-level parameters (the sync/async delegation thread pools live in
+ * the VFS core), so they are honored identically by the server (daemon) and the
+ * client (fio engine, client library).  Each field defaults to -1, meaning "not
+ * set in the common section" -- the caller then leaves its own default (or a
+ * value parsed from a legacy server/config section) untouched.
+ */
+struct chimera_common_delegation {
+    int sync_delegation;            /* 0/1, or -1 if unset */
+    int sync_delegation_threads;    /* >=0, or -1 if unset */
+    int async_delegation;           /* 0/1, or -1 if unset */
+    int async_delegation_threads;   /* >=0, or -1 if unset */
+};
+
+/*
+ * Populate `out` from the "common" section's delegation keys (sync_delegation,
+ * sync_delegation_threads, async_delegation, async_delegation_threads).  A
+ * missing section or key leaves the corresponding field at -1.  `root` is the
+ * parsed top-level config object (may be NULL).
+ */
+static inline void
+chimera_common_delegation_config(
+    json_t                           *root,
+    struct chimera_common_delegation *out)
+{
+    json_t *common, *val;
+
+    out->sync_delegation          = -1;
+    out->sync_delegation_threads  = -1;
+    out->async_delegation         = -1;
+    out->async_delegation_threads = -1;
+
+    if (!root) {
+        return;
+    }
+
+    common = json_object_get(root, "common");
+    if (!json_is_object(common)) {
+        return;
+    }
+
+    val = json_object_get(common, "sync_delegation");
+    if (json_is_boolean(val)) {
+        out->sync_delegation = json_is_true(val);
+    }
+
+    val = json_object_get(common, "sync_delegation_threads");
+    if (json_is_integer(val)) {
+        out->sync_delegation_threads = (int) json_integer_value(val);
+    }
+
+    val = json_object_get(common, "async_delegation");
+    if (json_is_boolean(val)) {
+        out->async_delegation = json_is_true(val);
+    }
+
+    val = json_object_get(common, "async_delegation_threads");
+    if (json_is_integer(val)) {
+        out->async_delegation_threads = (int) json_integer_value(val);
+    }
+} /* chimera_common_delegation_config */
+
+/*
  * Return the path configured in the shared "common" section's "metrics_file"
  * key, or NULL if the section or key is absent (or not a string).  This is the
  * file into which a process dumps a final Prometheus scrape at shutdown -- the

--- a/src/daemon/chimera.json
+++ b/src/daemon/chimera.json
@@ -1,13 +1,13 @@
 {
     "common": {
-	"tcp_flavor": "plain"
-    },
-    "server": {
-	"threads": 16,
+	"tcp_flavor": "plain",
 	"sync_delegation": true,
 	"sync_delegation_threads": 1,
 	"async_delegation": false,
 	"async_delegation_threads": 8
+    },
+    "server": {
+	"threads": 16
     },
     "mounts": {
 	"memfs_dir": {

--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -337,6 +337,27 @@ main(
         chimera_server_config_set_async_delegation_threads(server_config, int_value);
     }
 
+    /* The delegation pools are VFS-level; their canonical home is the shared
+     * "common" section.  Apply it after the legacy "server" keys above so it
+     * takes precedence. */
+    {
+        struct chimera_common_delegation deleg;
+
+        chimera_common_delegation_config(config, &deleg);
+        if (deleg.sync_delegation >= 0) {
+            chimera_server_config_set_sync_delegation(server_config, deleg.sync_delegation);
+        }
+        if (deleg.sync_delegation_threads >= 0) {
+            chimera_server_config_set_sync_delegation_threads(server_config, deleg.sync_delegation_threads);
+        }
+        if (deleg.async_delegation >= 0) {
+            chimera_server_config_set_async_delegation(server_config, deleg.async_delegation);
+        }
+        if (deleg.async_delegation_threads >= 0) {
+            chimera_server_config_set_async_delegation_threads(server_config, deleg.async_delegation_threads);
+        }
+    }
+
     json_value = json_object_get(server_params, "smb_persistent_handles");
     if (json_is_boolean(json_value)) {
         chimera_server_config_set_smb_persistent_handles(server_config, json_is_true(json_value));

--- a/src/fio/fio.c
+++ b/src/fio/fio.c
@@ -377,6 +377,20 @@ fio_chimera_init(struct thread_data *td)
         chimera_client_config_set_tcp_flavor(ChimeraClientConfig,
                                              chimera_common_tcp_flavor(config));
 
+        /* VFS delegation pools are configured in the shared "common" section;
+         * apply them so the fio engine can, e.g., disable delegation entirely
+         * ("sync_delegation": false) and run VFS ops inline on the job thread. */
+        {
+            struct chimera_common_delegation deleg;
+
+            chimera_common_delegation_config(config, &deleg);
+            chimera_client_config_set_delegation(ChimeraClientConfig,
+                                                 deleg.sync_delegation,
+                                                 deleg.sync_delegation_threads,
+                                                 deleg.async_delegation,
+                                                 deleg.async_delegation_threads);
+        }
+
         struct chimera_vfs_cred root_cred;
         chimera_vfs_cred_init_unix(&root_cred, 0, 0, 0, NULL);
 


### PR DESCRIPTION
The sync/async delegation thread pools live in the VFS core, so their configuration is a VFS-level parameter rather than a server-only one. This promotes the four keys — `sync_delegation`, `sync_delegation_threads`, `async_delegation`, `async_delegation_threads` — to the shared top-level `"common"` section so they are honored identically by the daemon, the client library, and the fio engine.

## Motivation

The fio engine never parsed these keys at all, so a direct-VFS fio run always used the built-in defaults (sync delegation on, 64 threads) with no way to tune or disable delegation. With this change a fio config can disable delegation entirely:

```json
"common": {
    "sync_delegation": false,
    "async_delegation": false
}
```

which passes 0 to both pools in `chimera_vfs_init`, so VFS ops run inline on the job thread.

## Changes

- **`common_config.h`**: new `chimera_common_delegation_config()` helper and `struct chimera_common_delegation` (each field defaults to `-1` meaning "unset", so an absent key leaves the caller’s own default untouched).
- **client**: new `chimera_client_config_set_delegation()` setter (applies only `>= 0` values); both the JSON parser and the fio engine apply the common section.
- **daemon / client**: the `common` section is applied *after* the legacy `"server"`/`"config"` keys, so it takes precedence while those older locations keep working as a deprecated fallback — existing configs are not broken.
- **`chimera.json` / `chimera-docker.json`**: relocated the keys into `"common"` to model the canonical home.

Backward compatible: configs that still set these under `"server"` (daemon) or `"config"` (client) continue to work; `"common"` simply wins when present.