### PR TITLE
fio: log to chimera log file, link metrics lib, bump libevpl

### DIFF
--- a/src/fio/CMakeLists.txt
+++ b/src/fio/CMakeLists.txt
@@ -1,11 +1,11 @@
-# SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+# SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 #
 # SPDX-License-Identifier: LGPL-2.1-only
 
 include_directories(/fio)
 add_library(chimera_fio SHARED fio.c)
 
-target_link_libraries(chimera_fio chimera_client jansson)
+target_link_libraries(chimera_fio chimera_client chimera_metrics jansson)
 
 install(TARGETS chimera_fio DESTINATION lib)
 

--- a/src/fio/fio.c
+++ b/src/fio/fio.c
@@ -332,11 +332,11 @@ fio_chimera_init(struct thread_data *td)
 
         if (o->config) {
 
-            fprintf(stderr, "Loading config file %s\n", o->config);
+            chimera_fio_info("Loading config file %s", o->config);
             config = json_load_file(o->config, 0, NULL);
 
             if (!config) {
-                fprintf(stderr, "Failed to load config file %s\n", o->config);
+                chimera_fio_error("Failed to load config file %s", o->config);
                 return EINVAL;
             }
 
@@ -350,7 +350,7 @@ fio_chimera_init(struct thread_data *td)
                     config_obj  = json_object_get(module, "config");
 
                     if (!module_name || !module_path) {
-                        fprintf(stderr, "Invalid module config\n");
+                        chimera_fio_error("Invalid module config");
                         return EINVAL;
                     }
 
@@ -360,8 +360,9 @@ fio_chimera_init(struct thread_data *td)
                         config_str = json_dumps(config_obj, JSON_COMPACT);
                     }
 
-                    fprintf(stderr, "Loading module %s path %s config %s\n", json_string_value(module_name),
-                            json_string_value(module_path), config_str ? config_str : "");
+                    chimera_fio_info("Loading module %s path %s",
+                                     json_string_value(module_name),
+                                     json_string_value(module_path));
 
                     chimera_client_config_add_module(ChimeraClientConfig, json_string_value(module_name),
                                                      json_string_value(module_path), config_str ? config_str : "");
@@ -475,7 +476,7 @@ fio_chimera_init(struct thread_data *td)
                     mount_point = json_object_get(mount, "mount_point");
 
                     if (!module || !module_path || !mount_point) {
-                        fprintf(stderr, "Invalid mount config\n");
+                        chimera_fio_error("Invalid mount config");
                         return EINVAL;
                     }
 
@@ -483,9 +484,9 @@ fio_chimera_init(struct thread_data *td)
                     json_t     *mount_opts = json_object_get(mount, "options");
                     const char *opts_str   = mount_opts ? json_string_value(mount_opts) : NULL;
 
-                    fprintf(stderr, "Mounting %s:%s at %s options=%s\n", json_string_value(module),
-                            json_string_value(module_path), json_string_value(mount_point),
-                            opts_str ? opts_str : "");
+                    chimera_fio_info("Mounting %s:%s at %s options=%s", json_string_value(module),
+                                     json_string_value(module_path), json_string_value(mount_point),
+                                     opts_str ? opts_str : "");
 
                     chimera_mount(client_thread,
                                   json_string_value(mount_point),
@@ -501,7 +502,7 @@ fio_chimera_init(struct thread_data *td)
                 }
 
                 if (mount_ctx.status != 0) {
-                    fprintf(stderr, "Failed to mount test module\n");
+                    chimera_fio_error("Failed to mount test module");
                     return 1;
                 }
             }
@@ -659,7 +660,7 @@ fio_chimera_open_callback(
     struct chimera_vfs_open_handle **fhp = private_data;
 
     if (status != CHIMERA_VFS_OK) {
-        fprintf(stderr, "Failed to open file\n");
+        chimera_fio_error("Failed to open file (status %d)", status);
         *fhp = NULL;
         return;
     }


### PR DESCRIPTION
Three small fixes to the userspace fio engine and its dependencies.

## Bump libevpl submodule
Picks up the VFIO CQ-buffer zeroing fix ([libevpl#90](https://github.com/chimera-nas/libevpl/pull/90)): the NVMe completion-queue buffer was never zeroed, so once enough queues were created that the allocator recycled dirty memory, a stale phase bit was read as a phantom completion (garbage `cid` → out-of-bounds `callbacks[]` → crash/hang). This bit the fio engine driving diskfs directly (a queue per `(thread, device)` across many threads).

## Link the metrics library into the fio plugin
The plugin calls `chimera_metrics_dump_file()` / `chimera_metrics_get()` (to honor `common.metrics_file`), but `src/fio/CMakeLists.txt` only linked `chimera_client`. Shared libs allow undefined symbols at link time, so it built fine and only failed at process exit:
```
fio: symbol lookup error: .../libchimera_fio.so: undefined symbol: chimera_metrics_dump_file
```
Adding `chimera_metrics` to the link puts `libchimera_metrics.so` in the plugin's `NEEDED` list; verified with `ldd -r` that the symbol now resolves.

## Move plugin logging into the chimera log file
The engine's startup messages (config load, module load, mount) were going to stdout/stderr. Route them through `chimera_fio_info`/`chimera_fio_error` so they land in the configured chimera log file like the rest of the stack, and drop the verbose module-config JSON dump. The one pre-log-init message ("failed to open chimera log file") stays on stderr, since the log isn't open yet at that point.