### PR TITLE
smb2: report stored DOS attributes faithfully + persist ARCHIVE on create (smb2.winattr)

### DIFF
--- a/src/server/smb/smb_attr.h
+++ b/src/server/smb/smb_attr.h
@@ -154,12 +154,26 @@ chimera_smb_marshal_basic_attrs(
             break;
     } // switch
 
-    /* A regular file always reports at least ARCHIVE when it carries none of
-     * the settable attribute bits (so e.g. a sparse-but-otherwise-plain file
-     * still shows ARCHIVE, matching Windows). */
-    if ((smb_attr->smb_attributes & SMB_DOS_ATTR_SETTABLE) == 0 &&
-        (attr->va_mode & S_IFMT) == S_IFREG) {
-        smb_attr->smb_attributes |= SMB2_FILE_ATTRIBUTE_ARCHIVE;
+    /* SMB never reports an all-zero attribute word for a regular file.  How the
+     * empty set is filled depends on whether the backend persists DOS bits:
+     *
+     *  - Backend persists them (DOS_ATTRIBUTES in set_mask): report exactly what
+     *    is stored.  An empty set is FILE_ATTRIBUTE_NORMAL (0x80) -- a file
+     *    explicitly cleared to NORMAL must read back NORMAL, not a synthesized
+     *    ARCHIVE (smb2.winattr).  ARCHIVE is stamped and persisted at
+     *    create/modify time instead (see chimera_smb_create_issue_open).
+     *
+     *  - Backend does not persist them (passthrough linux/io_uring): synthesize
+     *    ARCHIVE for a plain file, matching Windows' default for a new file,
+     *    since there is no stored value to honor. */
+    if ((attr->va_mode & S_IFMT) == S_IFREG) {
+        if (attr->va_set_mask & CHIMERA_VFS_ATTR_DOS_ATTRIBUTES) {
+            if (smb_attr->smb_attributes == 0) {
+                smb_attr->smb_attributes |= SMB2_FILE_ATTRIBUTE_NORMAL;
+            }
+        } else if ((smb_attr->smb_attributes & SMB_DOS_ATTR_SETTABLE) == 0) {
+            smb_attr->smb_attributes |= SMB2_FILE_ATTRIBUTE_ARCHIVE;
+        }
     }
     smb_attr->smb_attr_mask |= SMB_ATTR_ATTRIBUTES;
 } /* chimera_smb_marshal_basic_attrs */

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -1464,15 +1464,26 @@ chimera_smb_create_issue_open(struct chimera_smb_request *request)
                 break;
         } /* switch */
 
-        /* Replacing a file's contents truncates it and stamps it ARCHIVE
-        * (MS-FSCC).  OPEN_TRUNCATE makes the backend apply both to an existing
-        * file (a fresh create already starts empty with these attrs). */
+        /* Replacing an existing file's contents truncates it; OPEN_TRUNCATE
+         * makes the backend do that (a fresh create already starts empty). */
         if (chimera_smb_disposition_overwrites(request->create.create_disposition)) {
-            flags                                      |= CHIMERA_VFS_OPEN_TRUNCATE;
-            request->create.set_attr.va_dos_attributes |= SMB2_FILE_ATTRIBUTE_ARCHIVE;
-            request->create.set_attr.va_req_mask       |= CHIMERA_VFS_ATTR_DOS_ATTRIBUTES;
-            request->create.set_attr.va_set_mask       |= CHIMERA_VFS_ATTR_DOS_ATTRIBUTES;
+            flags |= CHIMERA_VFS_OPEN_TRUNCATE;
         }
+    }
+
+    /* A file is stamped FILE_ATTRIBUTE_ARCHIVE when it is created, and again
+     * when an overwrite/supersede replaces its contents (MS-FSCC).  Both reduce
+     * to "request ARCHIVE on any create-capable open": the backend applies
+     * set_attr only when it actually creates the inode or truncates it on an
+     * overwrite, so an existing file opened without truncation keeps its stored
+     * attributes (e.g. one explicitly cleared to NORMAL).  ARCHIVE must be
+     * persisted at create time, not synthesized on read (see
+     * chimera_smb_marshal_basic_attrs).  OPEN_TRUNCATE covers a plain OVERWRITE
+     * of an existing file (which never carries OPEN_CREATE). */
+    if (flags & (CHIMERA_VFS_OPEN_CREATE | CHIMERA_VFS_OPEN_TRUNCATE)) {
+        request->create.set_attr.va_dos_attributes |= SMB2_FILE_ATTRIBUTE_ARCHIVE;
+        request->create.set_attr.va_req_mask       |= CHIMERA_VFS_ATTR_DOS_ATTRIBUTES;
+        request->create.set_attr.va_set_mask       |= CHIMERA_VFS_ATTR_DOS_ATTRIBUTES;
     }
 
     /* Persistent-handle grants are keyed by the base file name; skip them for

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -353,6 +353,10 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.maximum_allowed
     smb2.mkdir
     smb2.openattr
+    # Path-based set/get of the DOS attribute combinations round-trips through
+    # the persisted dos_attributes; a file cleared to NORMAL reads back NORMAL
+    # (no synthesized ARCHIVE), and the create/setinfo paths stamp ARCHIVE.
+    smb2.winattr
     smb2.read
     smb2.rw
     smb2.check-sharemode
@@ -424,11 +428,13 @@ set(SMBTORTURE_ENABLED_memfs
 # filesystem has no API to set a file's birth time, so the create-time
 # round-trip is unsupportable on the passthrough backends (it works on the
 # native backends, which persist btime in their own inode metadata).
-# smb2.openattr stays disabled for the same reason: it round-trips DOS
-# attributes (READONLY/HIDDEN/SYSTEM/ARCHIVE) that a real Linux filesystem has
-# no native API to store, so they cannot be persisted on a passthrough mount
-# (it works on the native backends, which persist dos_attributes in their inode
-# metadata).
+# smb2.openattr and smb2.winattr stay disabled for the same reason: they
+# round-trip DOS attributes (READONLY/HIDDEN/SYSTEM/ARCHIVE) that a real Linux
+# filesystem has no native API to store, so they cannot be persisted on a
+# passthrough mount.  In particular winattr clears a file to NORMAL and expects
+# it back, but a passthrough file has no stored DOS set, so it falls back to a
+# synthesized ARCHIVE (it works on the native backends, which persist
+# dos_attributes in their inode metadata).
 set(SMBTORTURE_ENABLED_linux
     smb2.change_notify_disabled
     smb2.mkdir
@@ -524,6 +530,8 @@ set(SMBTORTURE_ENABLED_cairn
     # async_dosmode variant exercises the same code paths concurrently.
     smb2.openattr
     smb2.async_dosmode
+    # Path-based DOS attribute set/get round-trip (incl. clear-to-NORMAL).
+    smb2.winattr
     smb2.read
     smb2.rw
     smb2.check-sharemode
@@ -584,6 +592,8 @@ set(SMBTORTURE_ENABLED_diskfs_common
     # concurrently.
     smb2.openattr
     smb2.async_dosmode
+    # Path-based DOS attribute set/get round-trip (incl. clear-to-NORMAL).
+    smb2.winattr
     smb2.read
     smb2.rw
     smb2.check-sharemode


### PR DESCRIPTION
## Summary

`smb2.winattr` round-trips every DOS-attribute combination through a path-based SET_INFO / GET_INFO, including clearing a file back to `FILE_ATTRIBUTE_NORMAL`. It failed identically on **all** backends (memfs included), so the gap was in the SMB layer, not the backends.

The attribute marshaller synthesized `FILE_ATTRIBUTE_ARCHIVE` on every read for a regular file with no settable DOS bits. That masked the absence of create-time ARCHIVE storage and, worse, made a file explicitly cleared to `NORMAL` (a `FileBasicInformation` set with `attrib=NORMAL` clears every settable bit) read back as `ARCHIVE` rather than `NORMAL`.

### Fix (matches Windows / MS-FSCC)

- **`chimera_smb_marshal_basic_attrs`** — when the backend persists DOS attributes (`DOS_ATTRIBUTES` in `va_set_mask`), report exactly what is stored and fill an empty set with `FILE_ATTRIBUTE_NORMAL`; ARCHIVE is no longer synthesized on read. Backends that do **not** persist DOS bits (the linux/io_uring passthrough) keep the legacy ARCHIVE synthesis, since there is no stored value to honor.
- **`chimera_smb_create_issue_open`** — stamp `FILE_ATTRIBUTE_ARCHIVE` into the create `set_attr` for any create-capable or truncating open, so a newly created or overwritten file persists ARCHIVE. The backend applies `set_attr` only when it actually creates the inode or truncates on overwrite, so an existing file opened without truncation keeps its stored attributes. This subsumes the previous overwrite-only stamp.

### Enablement

Enables `smb2.winattr` on the native DOS-storing backends (memfs, cairn, both diskfs block backends). It stays disabled on the passthrough backends for the same reason as `smb2.openattr`: a real Linux filesystem has no API to persist DOS attributes, so clear-to-NORMAL cannot round-trip.

### Verification

Full smbtorture matrix green across all backends (280/280 enabled). `openattr`, `winattr2`, `timestamps`, `rw`, and `durable-open-disconnect` (whose create response asserts ARCHIVE) verified unaffected by the marshal/create changes.

### Notes / follow-ups (not in this PR)

- `smb2.async_dosmode` already passes on the native backends locally, but is left disabled per its existing in-tree note about an arm64 CI failure.
- `smb2.dosmode` is **not** a DOS-storage gap — it requires the `hide files` / `hide dot files` share presentation policy (it creates files with NORMAL and expects them reported HIDDEN purely from share config). That's a separate feature.