### PR TITLE
vfs/io_uring: own newly-created objects with the caller's UID/GID

### DIFF
--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -479,15 +479,29 @@ set(SMBTORTURE_ENABLED_io_uring
     smb2.sharemode
     smb2.tcon
     smb2.winattr2
-    # io_uring passes a subset of the CHANGE_NOTIFY subtests; the rest
-    # (notify.close/dir/invalid-reauth/logoff/mask/rmdir1/rmdir3) still fail
-    # here despite passing on the plain linux passthrough, pending a follow-up.
+    # CHANGE_NOTIFY subtests run cleanly in isolation; the combined smb2.notify
+    # suite stays disabled (a different set of subtests it still runs hang the
+    # whole suite — see the per-subtest list below for what we cover).  The
+    # io_uring allowlist now matches the other passthrough/native backends:
+    # the previously io_uring-only failures all turned on the just-created
+    # directory's owner matching the caller.  io_uring runs SMB (AUTH_ATTR)
+    # opens without impersonation, so its asynchronous mkdir/mknod were leaving
+    # the new object owned by the server identity (root); the post-create
+    # fchownat in chimera_io_uring_reap now mirrors what the linux backend does
+    # via chimera_linux_set_attrs.
     smb2.notify.basedir
+    smb2.notify.close
+    smb2.notify.dir
     smb2.notify.double
     smb2.notify.file
     smb2.notify.handle-permissions
+    smb2.notify.invalid-reauth
+    smb2.notify.logoff
+    smb2.notify.mask
     smb2.notify.overflow
+    smb2.notify.rmdir1
     smb2.notify.rmdir2
+    smb2.notify.rmdir3
     smb2.notify.rmdir4
     smb2.notify.tcon
     smb2.notify.tcp

--- a/src/vfs/io_uring/io_uring.c
+++ b/src/vfs/io_uring/io_uring.c
@@ -486,6 +486,29 @@ chimera_io_uring_reap(
 
                     parent_fd = request->mkdir_at.handle->vfs_private;
 
+                    /* SMB (AUTH_ATTR) does not impersonate the caller, so the
+                     * mkdir runs as the server identity and the new directory
+                     * is owned by the server -- which then fails the owner-
+                     * default access check on any subsequent open by the
+                     * client.  chimera_setup_credential injected the caller's
+                     * UID/GID into set_attr above; apply them now so the
+                     * directory ends up owned by the requesting principal,
+                     * matching what the linux backend does via
+                     * chimera_linux_set_attrs.  fchownat is a fast metadata
+                     * call (no I/O) and is gated on AUTH_ATTR injection. */
+                    if (request->status == CHIMERA_VFS_OK) {
+                        uint64_t mask = request->mkdir_at.set_attr->va_set_mask;
+                        if (mask & (CHIMERA_VFS_ATTR_UID | CHIMERA_VFS_ATTR_GID)) {
+                            uid_t uid = (mask & CHIMERA_VFS_ATTR_UID)
+                                ? (uid_t) request->mkdir_at.set_attr->va_uid : (uid_t) -1;
+                            gid_t gid = (mask & CHIMERA_VFS_ATTR_GID)
+                                ? (gid_t) request->mkdir_at.set_attr->va_gid : (gid_t) -1;
+                            if (fchownat(parent_fd, fullname, uid, gid, 0) < 0) {
+                                request->status = chimera_linux_errno_to_status(errno);
+                            }
+                        }
+                    }
+
                     sqe = chimera_io_uring_get_sqe(thread, request, 1, 0);
 
                     io_uring_prep_statx(sqe, parent_fd, fullname, AT_STATX_SYNC_AS_STAT,
@@ -1437,6 +1460,25 @@ chimera_io_uring_mknod_at(
         request->status = chimera_linux_errno_to_status(mknodat_errno);
         request->complete(request);
         return;
+    }
+
+    /* SMB (AUTH_ATTR) does not impersonate the caller, so mknodat ran as
+     * the server identity; apply the caller's UID/GID that
+     * chimera_setup_credential injected.  Mirrors symlink_at's fchownat. */
+    {
+        uint64_t mask = request->mknod_at.set_attr->va_set_mask;
+        if (mask & (CHIMERA_VFS_ATTR_UID | CHIMERA_VFS_ATTR_GID)) {
+            uid_t uid = (mask & CHIMERA_VFS_ATTR_UID)
+                ? (uid_t) request->mknod_at.set_attr->va_uid : (uid_t) -1;
+            gid_t gid = (mask & CHIMERA_VFS_ATTR_GID)
+                ? (gid_t) request->mknod_at.set_attr->va_gid : (gid_t) -1;
+            if (fchownat(fd, fullname, uid, gid, AT_SYMLINK_NOFOLLOW) < 0) {
+                chimera_restore_privilege(request->cred);
+                request->status = chimera_linux_errno_to_status(errno);
+                request->complete(request);
+                return;
+            }
+        }
     }
 
     chimera_linux_map_child_attrs(CHIMERA_VFS_FH_MAGIC_IO_URING,


### PR DESCRIPTION
The io_uring backend's async `mkdir_at` and `mknod_at` run the create through `io_uring_prep_mkdirat` / `mknodat` carrying only the server's identity: `chimera_setup_credential` for `AUTH_ATTR` (the SMB cred flavor) just injects the caller's UID/GID into `set_attr` — it does **not** `setfsuid` — and the post-create reap path was not applying that injection.  Every SMB-created directory therefore ended up owned by root (the chimera daemon's uid), and any subsequent open by the requesting client failed the owner-default access check in `chimera_smb_create_check_access` (`cred->uid 1001` vs `attr->va_uid 0` → `ACCESS_DENIED`).

This was the underlying cause of seven smbtorture `smb2.notify` subtests failing on io_uring but not on the plain linux passthrough — both backends share the protocol/auth paths, but `linux_mkdir_at` runs `chimera_linux_set_attrs` after the mkdir, which `fchownat`s the new directory to the injected UID/GID.

### Fix

Apply the same `fchownat` in the io_uring reap after a successful mkdir (synchronously, before the `statx` that reads the attrs back), and in `mknod_at` after the synchronous `mknodat` (mirroring `symlink_at`'s existing post-`symlinkat` `fchownat`).

`fchownat` is a fast metadata-only call and is gated on the `AUTH_ATTR` injection actually setting the UID/GID bits in `set_mask`, so it is a no-op for `AUTH_UNIX` callers that already took the registered-personality path.

### Net effect

| Subtest | Before | After |
|---|---|---|
| `smb2.notify.close` (io_uring) | FAIL (`ACCESS_DENIED`) | **PASS** |
| `smb2.notify.dir` (io_uring) | FAIL (`ACCESS_DENIED`) | **PASS** |
| `smb2.notify.invalid-reauth` (io_uring) | FAIL (`ACCESS_DENIED`) | **PASS** |
| `smb2.notify.logoff` (io_uring) | FAIL (`ACCESS_DENIED`) | **PASS** |
| `smb2.notify.mask` (io_uring) | FAIL (`ACCESS_DENIED`) | **PASS** |
| `smb2.notify.rmdir1` (io_uring) | FAIL (`ACCESS_DENIED`) | **PASS** |
| `smb2.notify.rmdir3` (io_uring) | FAIL (`ACCESS_DENIED`) | **PASS** |
| Every other enabled smbtorture suite on every backend | green | green (no regressions, 283/283) |

The io_uring notify allowlist now mirrors the `linux` / `cairn` / `diskfs` allowlists (18 subtests each).  The combined `smb2.notify` suite stays disabled across all backends; that one is gated on a separate gap (`session-reconnect` hangs because pending CHANGE_NOTIFY on a previous session is not reaped when `PreviousSessionId` invalidates it), tracked as a follow-up.