### PR TITLE
diskfs: deallocate whole devices at mkfs for a clean slate

### DIFF
--- a/src/vfs/diskfs/diskfs.c
+++ b/src/vfs/diskfs/diskfs.c
@@ -8355,6 +8355,32 @@ diskfs_mount_io_flush(
     return w.status ? -1 : 0;
 } /* diskfs_mount_io_flush */
 
+/* Discard (deallocate) a device byte range, pumping the mount-time evpl to
+ * completion.  Used at mkfs to clear whole devices.  Backends without native
+ * discard treat it as a no-op success. */
+static int
+diskfs_mount_io_discard(
+    void    *user,
+    uint32_t device_id,
+    uint64_t offset,
+    uint64_t length)
+{
+    struct diskfs_mount_io     *io = user;
+    struct diskfs_mount_io_wait w  = { 0, 0 };
+
+    if (device_id >= (uint32_t) io->shared->num_devices ||
+        !io->queue[device_id]) {
+        return -1;
+    }
+
+    evpl_block_discard(io->evpl, io->queue[device_id], offset, length,
+                       diskfs_mount_io_complete, &w);
+    while (!w.done) {
+        evpl_continue(io->evpl);
+    }
+    return w.status ? -1 : 0;
+} /* diskfs_mount_io_discard */
+
 static struct sm_io
 diskfs_mount_sm_io(struct diskfs_mount_io *io)
 {
@@ -8818,6 +8844,28 @@ diskfs_init(
                                                                   rinum,
                                                                   rgen,
                                                                   shared->root_fh);
+        }
+
+        /* Fresh format: deallocate every device before writing any metadata,
+         * so the filesystem starts on a clean slate.  This drops the drives'
+         * stale FTL mappings (resetting GC/wear state) and makes cold-cache
+         * behavior reproducible run to run.  Deallocate is only a hint and the
+         * post-discard read value is unspecified, but diskfs never relies on
+         * device-provided zeros (unwritten extents read as zeros from the
+         * b+tree), so a device that ignores it is harmless.  Backends without
+         * native discard treat it as a no-op success. */
+        if (mode == 0) {
+            for (i = 0; i < shared->num_devices; i++) {
+                if (!shared->devices[i].bdev) {
+                    continue;
+                }
+                if (diskfs_mount_io_discard(mio, i, 0,
+                                            shared->devices[i].size) != 0) {
+                    chimera_diskfs_info(
+                        "device %d: full-device discard failed or unsupported; "
+                        "continuing format", i);
+                }
+            }
         }
 
         /* Clear the CLEAN flag for this session: an unclean teardown then


### PR DESCRIPTION
Bumps libevpl to pick up the new block ops (chimera-nas/libevpl#91, merged) and uses them to deallocate every device, full-range, during `initialize` (mkfs) — before any metadata is written.

## Why

A fresh filesystem currently starts on top of whatever the drives last held. Under sustained random-write benchmarking that means each run inherits the garbage-collection / wear shadow of the previous run, which shows up as wildly uneven, multi-millisecond device latency excursions and makes cold-cache numbers irreproducible. Deallocating up front drops the drives' stale FTL mappings, resetting GC/wear state so every format starts from a known-clean device.

## What

- Submodule bump `ce9fd0f → e5bba7d` (libevpl#91: `evpl_block_discard` = NVMe DSM Deallocate, plus `evpl_block_write_zeroes`).
- New `diskfs_mount_io_discard`, mirroring `diskfs_mount_io_flush` (pumps the mount-time evpl to completion).
- In the mkfs path (`mode == 0`), discard each device `[0, size)` before writing the superblock.

## Safety

- Deallocate is only a hint and the post-discard read value is unspecified — but diskfs never relies on device-provided zeros (unwritten extents read as zeros from the b+tree, and mkfs writes its own metadata), so a device that ignores the hint is harmless.
- A discard failure just logs and continues the format; it never aborts mkfs.
- Backends without native discard (file-backed io_uring/libaio) treat it as a no-op success, so non-NVMe deployments and tests are unaffected.
- Confined to `initialize`/mkfs — never runs on a normal mount or recovery, so it can't touch existing data.

## Note

Placed after the existing `num_devices` loops (just before the superblock write) rather than earlier in the block: an earlier placement perturbed GCC `-O3 -Walloc-size-larger-than` analysis of the nearby `dev_cfg = calloc(num_devices, …)` and tripped a false positive.