### PR TITLE
vfs: convert userspace-RCU to QSBR with event-loop quiescence

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,14 @@ execute_process(COMMAND ln -sf ${CMAKE_BINARY_DIR}/compile_commands.json ${CMAKE
 add_definitions(-DCHIMERA_VERSION="${CHIMERA_VERSION}")
 add_definitions(-DCHIMERA_STATE_DIR="${CMAKE_INSTALL_PREFIX}/share/state")
 
+# chimera uses userspace-RCU in the QSBR flavor process-wide.  <urcu/urcu-qsbr.h>
+# clears the unprefixed RCU API map (rcu_read_lock, call_rcu, rcu_barrier, ...)
+# at the end of the header unless URCU_API_MAP is defined, so we set it globally:
+# any TU that (even transitively) includes a chimera RCU header -- the VFS caches,
+# the mount table, the identity/cred caches -- needs the map kept active.  It is
+# a no-op for TUs that include no urcu headers (e.g. the fio plugin).
+add_definitions(-DURCU_API_MAP)
+
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/ext/libevpl/ext/prometheus-c)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/ext/libevpl/ext/prometheus-c/ext/stopwatch)
 

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -4,7 +4,8 @@
 
 # Inline the liburcu read-side primitives for the server TUs that touch the RCU
 # caches (nfs/s3/smb/rest + server.c).  See src/vfs/CMakeLists.txt; deliberately
-# not set for the GPL fio plugin.  chimera is LGPL-2.1.
+# not set for the GPL fio plugin.  chimera is LGPL-2.1.  (URCU_API_MAP, selecting
+# the unprefixed QSBR API, is set project-wide in the top-level CMakeLists.txt.)
 add_compile_definitions(_LGPL_SOURCE)
 
 add_library(chimera_server SHARED server.c)

--- a/src/server/nfs/CMakeLists.txt
+++ b/src/server/nfs/CMakeLists.txt
@@ -36,7 +36,7 @@ add_library(chimera_nfs SHARED nfs.c nfs4_session.c nfs4_state.c nfs4_lease.c nf
             nfs4_pnfs.c nfs4_cb.c nfs4_layout_table.c)
 
 target_compile_definitions(chimera_nfs PRIVATE XXH_INLINE_ALL)
-target_link_libraries(chimera_nfs chimera_nfs_common chimera_common evpl evpl_rpc2 pthread uuid urcu urcu-common)
+target_link_libraries(chimera_nfs chimera_nfs_common chimera_common evpl evpl_rpc2 pthread uuid urcu-qsbr urcu-common)
 
 install(TARGETS chimera_nfs DESTINATION lib)
 

--- a/src/server/nfs/nfs4_proc_lookupp.c
+++ b/src/server/nfs/nfs4_proc_lookupp.c
@@ -21,7 +21,7 @@ chimera_nfs4_fh_is_vfs_mount_root(
         return false;
     }
 
-    urcu_memb_read_lock();
+    urcu_qsbr_read_lock();
     mount = chimera_vfs_mount_table_lookup(vfs->mount_table, fh);
     if (mount &&
         mount->pathlen > 0 &&
@@ -29,7 +29,7 @@ chimera_nfs4_fh_is_vfs_mount_root(
         memcmp(mount->root_fh, fh, fhlen) == 0) {
         is_root = true;
     }
-    urcu_memb_read_unlock();
+    urcu_qsbr_read_unlock();
 
     return is_root;
 } /* chimera_nfs4_fh_is_vfs_mount_root */

--- a/src/server/nfs/tests/CMakeLists.txt
+++ b/src/server/nfs/tests/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 # Unit test for the unified NFSv4 state model (Phases 1-4).
 add_executable(test_state_table test_state_table.c)
-target_link_libraries(test_state_table chimera_nfs chimera_server chimera_vfs chimera_nfs_common chimera_common evpl evpl_rpc2 pthread uuid urcu urcu-common)
+target_link_libraries(test_state_table chimera_nfs chimera_server chimera_vfs chimera_nfs_common chimera_common evpl evpl_rpc2 pthread uuid urcu-qsbr urcu-common)
 target_include_directories(test_state_table PRIVATE
     ${CMAKE_SOURCE_DIR}/src
     ${CMAKE_SOURCE_DIR}/src/server/nfs
@@ -31,7 +31,7 @@ target_include_directories(test_replay_slot PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/..
     ${CMAKE_SOURCE_DIR}/src
     ${NFS_COMMON_INCLUDE_DIR})
-target_link_libraries(test_replay_slot chimera_vfs chimera_common evpl evpl_rpc2 pthread uuid urcu urcu-common)
+target_link_libraries(test_replay_slot chimera_vfs chimera_common evpl evpl_rpc2 pthread uuid urcu-qsbr urcu-common)
 add_test(NAME chimera/server/nfs/replay_slot COMMAND test_replay_slot)
 
 add_executable(test_protocol_advertise test_protocol_advertise.c)
@@ -39,5 +39,5 @@ target_include_directories(test_protocol_advertise PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/..
     ${CMAKE_SOURCE_DIR}/src
     ${NFS_COMMON_INCLUDE_DIR})
-target_link_libraries(test_protocol_advertise chimera_vfs chimera_common evpl evpl_rpc2 pthread uuid urcu urcu-common)
+target_link_libraries(test_protocol_advertise chimera_vfs chimera_common evpl evpl_rpc2 pthread uuid urcu-qsbr urcu-common)
 add_test(NAME chimera/server/nfs/protocol_advertise COMMAND test_protocol_advertise)

--- a/src/server/s3/s3_auth.c
+++ b/src/server/s3/s3_auth.c
@@ -10,7 +10,7 @@
 #include <openssl/hmac.h>
 #include <openssl/bio.h>
 #include <openssl/buffer.h>
-#include <urcu.h>
+#include <urcu/urcu-qsbr.h>
 
 #include "evpl/evpl_http.h"
 #include "s3_auth.h"

--- a/src/server/s3/s3_cred_cache.h
+++ b/src/server/s3/s3_cred_cache.h
@@ -8,8 +8,7 @@
 #include <string.h>
 #include <pthread.h>
 #include <time.h>
-#include <urcu.h>
-#include <urcu/urcu-memb.h>
+#include <urcu/urcu-qsbr.h>
 #include <xxhash.h>
 
 #define CHIMERA_S3_ACCESS_KEY_MAX 128
@@ -88,8 +87,10 @@ chimera_s3_cred_cache_expiry_thread(void *arg)
     struct timespec               ts;
     int                           i;
 
-    urcu_memb_register_thread();
-
+    /* Pure writer: sweeps expired creds (rcu_assign + call_rcu) under the
+     * per-bucket locks, never takes an RCU read lock.  Not registered as a
+     * QSBR reader -- a thread parked in cond_timedwait must not sit in the
+     * grace-period quorum. */
     pthread_mutex_lock(&cache->expiry_lock);
 
     while (!cache->shutdown) {
@@ -125,8 +126,6 @@ chimera_s3_cred_cache_expiry_thread(void *arg)
     }
 
     pthread_mutex_unlock(&cache->expiry_lock);
-
-    urcu_memb_unregister_thread();
 
     return NULL;
 } // chimera_s3_cred_cache_expiry_thread
@@ -173,7 +172,7 @@ chimera_s3_cred_cache_destroy(struct chimera_s3_cred_cache *cache)
 
     pthread_join(cache->expiry_thread, NULL);
 
-    urcu_memb_barrier();
+    urcu_qsbr_barrier();
 
     for (i = 0; i < cache->num_buckets; i++) {
         cred = cache->buckets[i].head;

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -5,7 +5,7 @@
 
 # SMB authentication test program
 add_executable(smb_auth_test smb_auth_test.c)
-target_link_libraries(smb_auth_test chimera_vfs urcu urcu-cds)
+target_link_libraries(smb_auth_test chimera_vfs urcu-qsbr urcu-cds)
 target_include_directories(smb_auth_test PRIVATE ${CMAKE_SOURCE_DIR}/src)
 
 add_test(NAME chimera/server/smb/auth_test

--- a/src/server/smb/tests/smb_auth_test.c
+++ b/src/server/smb/tests/smb_auth_test.c
@@ -22,8 +22,7 @@
 #include <assert.h>
 #include <unistd.h>
 #include <time.h>
-#include <urcu.h>
-#include <urcu/urcu-memb.h>
+#include <urcu/urcu-qsbr.h>
 
 #include "vfs/vfs.h"
 #include "vfs/vfs_user_cache.h"
@@ -117,7 +116,7 @@ test_local_ntlm_auth(void)
                                NULL, 0, 0, 0, NULL, 1);
 
     /* Verify user was added to cache */
-    urcu_memb_read_lock();
+    urcu_qsbr_read_lock();
 
     user = chimera_vfs_user_cache_lookup_by_name(cache, "johndoe");
     if (user && user->uid == 1000 && user->gid == 1000) {
@@ -150,7 +149,7 @@ test_local_ntlm_auth(void)
         TEST_PASS("Username lookup is case-insensitive");
     }
 
-    urcu_memb_read_unlock();
+    urcu_qsbr_read_unlock();
 
     /* Cleanup */
     chimera_vfs_user_cache_destroy(cache);
@@ -175,7 +174,7 @@ test_user_lookup_by_uid(void)
     chimera_vfs_user_cache_add(cache, "user1001", NULL, NULL, NULL, 1001, 1001, 0, NULL, 1);
     chimera_vfs_user_cache_add(cache, "user2000", NULL, NULL, NULL, 2000, 2000, 0, NULL, 1);
 
-    urcu_memb_read_lock();
+    urcu_qsbr_read_lock();
 
     user = chimera_vfs_user_cache_lookup_by_uid(cache, 1000);
     if (user && strcmp(user->username, "user1000") == 0) {
@@ -198,7 +197,7 @@ test_user_lookup_by_uid(void)
         TEST_FAIL("Lookup non-existent UID should return NULL");
     }
 
-    urcu_memb_read_unlock();
+    urcu_qsbr_read_unlock();
 
     chimera_vfs_user_cache_destroy(cache);
 } /* test_user_lookup_by_uid */
@@ -222,7 +221,7 @@ test_supplementary_groups(void)
     chimera_vfs_user_cache_add(cache, "multigroup", NULL, NULL, NULL,
                                1000, 1000, 5, gids, 1);
 
-    urcu_memb_read_lock();
+    urcu_qsbr_read_lock();
 
     user = chimera_vfs_user_cache_lookup_by_name(cache, "multigroup");
     if (user && user->ngids == 5) {
@@ -253,7 +252,7 @@ test_supplementary_groups(void)
         TEST_FAIL("User with no supplementary groups");
     }
 
-    urcu_memb_read_unlock();
+    urcu_qsbr_read_unlock();
 
     chimera_vfs_user_cache_destroy(cache);
 } /* test_supplementary_groups */
@@ -282,7 +281,7 @@ test_user_caching_with_sid(void)
                                ad_sid,
                                10001, 10001, 2, test_gids, 0);
 
-    urcu_memb_read_lock();
+    urcu_qsbr_read_lock();
 
     user = chimera_vfs_user_cache_lookup_by_name(cache, "aduser@TEST.LOCAL");
 
@@ -309,7 +308,7 @@ test_user_caching_with_sid(void)
         TEST_FAIL("AD user lookup failed");
     }
 
-    urcu_memb_read_unlock();
+    urcu_qsbr_read_unlock();
 
     chimera_vfs_user_cache_destroy(cache);
 } /* test_user_caching_with_sid */
@@ -371,7 +370,7 @@ test_user_full_fields(void)
                                sid,
                                1001, 1001, 3, gids, 1);
 
-    urcu_memb_read_lock();
+    urcu_qsbr_read_lock();
 
     user = chimera_vfs_user_cache_lookup_by_name(cache, "fulluser");
 
@@ -403,7 +402,7 @@ test_user_full_fields(void)
         TEST_FAIL("Full user lookup failed");
     }
 
-    urcu_memb_read_unlock();
+    urcu_qsbr_read_unlock();
 
     chimera_vfs_user_cache_destroy(cache);
 } /* test_user_full_fields */
@@ -427,21 +426,21 @@ test_user_update(void)
                                "S-1-5-21-111-222-333-1000",
                                1000, 1000, 0, NULL, 0);
 
-    urcu_memb_read_lock();
+    urcu_qsbr_read_lock();
     user = chimera_vfs_user_cache_lookup_by_name(cache, "updateme");
     if (user && user->uid == 1000) {
         TEST_PASS("Initial user add");
     } else {
         TEST_FAIL("Initial user add");
     }
-    urcu_memb_read_unlock();
+    urcu_qsbr_read_unlock();
 
     /* Update the same user with different UID */
     chimera_vfs_user_cache_add(cache, "updateme", NULL, NULL,
                                "S-1-5-21-111-222-333-2000",
                                2000, 2000, 0, NULL, 0);
 
-    urcu_memb_read_lock();
+    urcu_qsbr_read_lock();
     user = chimera_vfs_user_cache_lookup_by_name(cache, "updateme");
     if (user && user->uid == 2000) {
         TEST_PASS("User update replaces old entry");
@@ -450,7 +449,7 @@ test_user_update(void)
     } else {
         TEST_FAIL("User update behavior");
     }
-    urcu_memb_read_unlock();
+    urcu_qsbr_read_unlock();
 
     chimera_vfs_user_cache_destroy(cache);
 } /* test_user_update */
@@ -557,7 +556,7 @@ test_cache_capacity(void)
     }
 
     /* Check how many users are still in cache */
-    urcu_memb_read_lock();
+    urcu_qsbr_read_lock();
     for (int i = 0; i < 16; i++) {
         snprintf(username, sizeof(username), "user%d", i);
         user = chimera_vfs_user_cache_lookup_by_name(cache, username);
@@ -565,7 +564,7 @@ test_cache_capacity(void)
             found_count++;
         }
     }
-    urcu_memb_read_unlock();
+    urcu_qsbr_read_unlock();
 
     fprintf(stderr, "  Found %d of 16 users in cache (capacity=8)\n", found_count);
 
@@ -626,7 +625,7 @@ main(
         } /* switch */
     }
 
-    urcu_memb_register_thread();
+    urcu_qsbr_register_thread();
 
     fprintf(stderr, "Running SMB authentication tests...\n");
     fprintf(stderr, "Mode: %s\n",
@@ -654,7 +653,7 @@ main(
         test_kerberos_auth();
     }
 
-    urcu_memb_unregister_thread();
+    urcu_qsbr_unregister_thread();
 
     fprintf(stderr, "\n========================================\n");
     fprintf(stderr, "Results: %d passed, %d failed, %d skipped\n",

--- a/src/vfs/CMakeLists.txt
+++ b/src/vfs/CMakeLists.txt
@@ -9,6 +9,8 @@
 # RCU caches, and the backend modules under it -- every urcu user lives here or
 # under src/server).  Deliberately NOT set for src/fio (the GPL fio plugin,
 # which does not use urcu directly).  chimera is LGPL-2.1.
+# (URCU_API_MAP, which selects the unprefixed QSBR API, is set project-wide in
+# the top-level CMakeLists.txt.)
 add_compile_definitions(_LGPL_SOURCE)
 
 add_library(chimera_vfs SHARED vfs.c vfs_lsan.c
@@ -62,7 +64,7 @@ endif()
 target_link_libraries(chimera_vfs
     chimera_vfs_root chimera_vfs_memfs chimera_vfs_linux chimera_vfs_diskfs
     chimera_vfs_nfs
-    chimera_common prometheus-c xxhash dl urcu)
+    chimera_common prometheus-c xxhash dl urcu-qsbr)
 
 if (CHIMERA_VFS_IO_URING)
     target_link_libraries(chimera_vfs chimera_vfs_io_uring)

--- a/src/vfs/diskfs/diskfs.c
+++ b/src/vfs/diskfs/diskfs.c
@@ -16,8 +16,7 @@
 #include <limits.h>
 #include <jansson.h>
 #include <utlist.h>
-#include <urcu.h>
-#include <urcu/urcu-memb.h>
+#include <urcu/urcu-qsbr.h>
 #include <xxhash.h>     /* XXH_INLINE_ALL set in CMakeLists; header-only */
 
 #include "common/varint.h"

--- a/src/vfs/tests/CMakeLists.txt
+++ b/src/vfs/tests/CMakeLists.txt
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: LGPL-2.1-only
 
 add_executable(vfs_user_cache_test vfs_user_cache_test.c)
-target_link_libraries(vfs_user_cache_test chimera_vfs urcu)
+target_link_libraries(vfs_user_cache_test chimera_vfs urcu-qsbr)
 add_test(chimera/vfs/user_cache_test vfs_user_cache_test)
 
 add_executable(vfs_kv_test vfs_kv_test.c)
@@ -21,7 +21,7 @@ if(CAIRN_ENABLED)
 endif()
 
 add_executable(vfs_notify_test vfs_notify_test.c)
-target_link_libraries(vfs_notify_test chimera_vfs urcu)
+target_link_libraries(vfs_notify_test chimera_vfs urcu-qsbr)
 add_test(chimera/vfs/notify_test vfs_notify_test)
 
 add_executable(vfs_state_test vfs_state_test.c)
@@ -41,5 +41,5 @@ target_link_libraries(vfs_idmap_test chimera_vfs)
 add_test(chimera/vfs/idmap_test vfs_idmap_test)
 
 add_executable(vfs_identity_test vfs_identity_test.c)
-target_link_libraries(vfs_identity_test chimera_vfs chimera_vfs_memfs evpl urcu)
+target_link_libraries(vfs_identity_test chimera_vfs chimera_vfs_memfs evpl urcu-qsbr)
 add_test(chimera/vfs/identity_test vfs_identity_test)

--- a/src/vfs/tests/vfs_notify_test.c
+++ b/src/vfs/tests/vfs_notify_test.c
@@ -27,7 +27,7 @@
 #include "vfs/vfs_rpl_cache.h"
 #include "common/logging.h"
 
-#include <urcu/urcu-memb.h>
+#include <urcu/urcu-qsbr.h>
 
 static int passed = 0;
 static int failed = 0;
@@ -1065,7 +1065,7 @@ main(
 
     /* Required for the RPL cache test — its insert/invalidate paths
      * use call_rcu which relies on the URCU thread registry. */
-    urcu_memb_register_thread();
+    urcu_qsbr_register_thread();
 
     test_init_destroy();
     test_watch_create_destroy();
@@ -1092,6 +1092,6 @@ main(
     fprintf(stderr, "Results: %d passed, %d failed\n", passed, failed);
     fprintf(stderr, "========================================\n");
 
-    urcu_memb_unregister_thread();
+    urcu_qsbr_unregister_thread();
     return failed == 0 ? 0 : 1;
 } /* main */

--- a/src/vfs/tests/vfs_user_cache_test.c
+++ b/src/vfs/tests/vfs_user_cache_test.c
@@ -8,8 +8,7 @@
 #undef NDEBUG
 #include <assert.h>
 #include <unistd.h>
-#include <urcu.h>
-#include <urcu/urcu-memb.h>
+#include <urcu/urcu-qsbr.h>
 
 #include "vfs/vfs_user_cache.h"
 
@@ -23,7 +22,7 @@ test_empty_lookups(void)
 
     cache = chimera_vfs_user_cache_create(64, 600);
 
-    urcu_memb_read_lock();
+    urcu_qsbr_read_lock();
 
     user = chimera_vfs_user_cache_lookup_by_name(cache, "nonexistent");
     assert(user == NULL);
@@ -33,7 +32,7 @@ test_empty_lookups(void)
 
     assert(chimera_vfs_user_cache_is_member(cache, 9999, 9999) == 0);
 
-    urcu_memb_read_unlock();
+    urcu_qsbr_read_unlock();
 
     chimera_vfs_user_cache_destroy(cache);
 
@@ -52,7 +51,7 @@ test_add_and_lookup(void)
     chimera_vfs_user_cache_add(cache, "alice", "$6$salt$hash",
                                "cleartext", NULL, 1000, 1000, 2, gids, 1);
 
-    urcu_memb_read_lock();
+    urcu_qsbr_read_lock();
 
     user = chimera_vfs_user_cache_lookup_by_name(cache, "alice");
     assert(user != NULL);
@@ -69,7 +68,7 @@ test_add_and_lookup(void)
     assert(user != NULL);
     assert(strcmp(user->username, "alice") == 0);
 
-    urcu_memb_read_unlock();
+    urcu_qsbr_read_unlock();
 
     chimera_vfs_user_cache_destroy(cache);
 
@@ -92,7 +91,7 @@ test_gid_lookup(void)
     chimera_vfs_user_cache_add(cache, "bob", NULL, NULL, NULL,
                                1001, 1001, 2, bob_gids, 1);
 
-    urcu_memb_read_lock();
+    urcu_qsbr_read_lock();
 
     /* Both alice and bob are in group 100 */
     count = chimera_vfs_user_cache_lookup_by_gid(cache, 100, results, 16);
@@ -113,7 +112,7 @@ test_gid_lookup(void)
     assert(count == 1);
     assert(strcmp(results[0]->username, "alice") == 0);
 
-    urcu_memb_read_unlock();
+    urcu_qsbr_read_unlock();
 
     chimera_vfs_user_cache_destroy(cache);
 
@@ -136,9 +135,9 @@ test_remove(void)
     assert(rc == 0);
 
     /* Wait for RCU grace period */
-    urcu_memb_synchronize_rcu();
+    urcu_qsbr_synchronize_rcu();
 
-    urcu_memb_read_lock();
+    urcu_qsbr_read_lock();
 
     user = chimera_vfs_user_cache_lookup_by_name(cache, "alice");
     assert(user == NULL);
@@ -146,7 +145,7 @@ test_remove(void)
     user = chimera_vfs_user_cache_lookup_by_uid(cache, 1000);
     assert(user == NULL);
 
-    urcu_memb_read_unlock();
+    urcu_qsbr_read_unlock();
 
     /* Removing non-existent user should return -1 */
     rc = chimera_vfs_user_cache_remove(cache, "alice");
@@ -169,10 +168,10 @@ test_ttl_expiration(void)
     chimera_vfs_user_cache_add(cache, "temp_user", NULL, NULL, NULL,
                                2000, 2000, 0, NULL, 0);
 
-    urcu_memb_read_lock();
+    urcu_qsbr_read_lock();
     user = chimera_vfs_user_cache_lookup_by_name(cache, "temp_user");
     assert(user != NULL);
-    urcu_memb_read_unlock();
+    urcu_qsbr_read_unlock();
 
     /* Sleep long enough for TTL to expire and expiry thread to run.
      * The expiry thread sleeps up to 60s, so we manually trigger
@@ -192,12 +191,12 @@ test_ttl_expiration(void)
     usleep(100000);
 
     /* Wait for RCU grace period */
-    urcu_memb_synchronize_rcu();
+    urcu_qsbr_synchronize_rcu();
 
-    urcu_memb_read_lock();
+    urcu_qsbr_read_lock();
     user = chimera_vfs_user_cache_lookup_by_name(cache, "temp_user");
     assert(user == NULL);
-    urcu_memb_read_unlock();
+    urcu_qsbr_read_unlock();
 
     chimera_vfs_user_cache_destroy(cache);
 
@@ -229,11 +228,11 @@ test_pinned_no_expire(void)
 
     usleep(100000);
 
-    urcu_memb_read_lock();
+    urcu_qsbr_read_lock();
     user = chimera_vfs_user_cache_lookup_by_name(cache, "pinned_user");
     assert(user != NULL);
     assert(user->pinned == 1);
-    urcu_memb_read_unlock();
+    urcu_qsbr_read_unlock();
 
     chimera_vfs_user_cache_destroy(cache);
 
@@ -251,7 +250,7 @@ test_is_member(void)
     chimera_vfs_user_cache_add(cache, "alice", NULL, NULL, NULL,
                                1000, 1000, 3, gids, 1);
 
-    urcu_memb_read_lock();
+    urcu_qsbr_read_lock();
 
     /* Primary group */
     assert(chimera_vfs_user_cache_is_member(cache, 1000, 1000) == 1);
@@ -267,7 +266,7 @@ test_is_member(void)
     /* Non-existent user */
     assert(chimera_vfs_user_cache_is_member(cache, 8888, 1000) == 0);
 
-    urcu_memb_read_unlock();
+    urcu_qsbr_read_unlock();
 
     chimera_vfs_user_cache_destroy(cache);
 
@@ -291,7 +290,7 @@ test_sid_index(void)
     chimera_vfs_user_cache_add(cache, "bob", NULL, NULL, NULL,
                                1001, 1001, 0, NULL, 1);
 
-    urcu_memb_read_lock();
+    urcu_qsbr_read_lock();
 
     user = chimera_vfs_user_cache_lookup_by_sid(cache, "S-1-5-21-111-222-333-1105");
     assert(user != NULL);
@@ -306,15 +305,15 @@ test_sid_index(void)
     assert(chimera_vfs_user_cache_lookup_by_sid(cache, "S-1-5-21-9-9-9-9") == NULL);
     assert(chimera_vfs_user_cache_lookup_by_sid(cache, "") == NULL);
 
-    urcu_memb_read_unlock();
+    urcu_qsbr_read_unlock();
 
     /* Removing the user also unindexes its SID. */
     chimera_vfs_user_cache_remove(cache, "alice");
-    urcu_memb_synchronize_rcu();
-    urcu_memb_read_lock();
+    urcu_qsbr_synchronize_rcu();
+    urcu_qsbr_read_lock();
     assert(chimera_vfs_user_cache_lookup_by_sid(cache,
                                                 "S-1-5-21-111-222-333-1105") == NULL);
-    urcu_memb_read_unlock();
+    urcu_qsbr_read_unlock();
 
     chimera_vfs_user_cache_destroy(cache);
 
@@ -324,7 +323,7 @@ test_sid_index(void)
 int
 main(void)
 {
-    urcu_memb_register_thread();
+    urcu_qsbr_register_thread();
 
     fprintf(stderr, "Running vfs_user_cache tests:\n");
 
@@ -339,7 +338,7 @@ main(void)
 
     fprintf(stderr, "All tests passed.\n");
 
-    urcu_memb_unregister_thread();
+    urcu_qsbr_unregister_thread();
 
     return 0;
 } /* main */

--- a/src/vfs/vfs.c
+++ b/src/vfs/vfs.c
@@ -751,6 +751,67 @@ chimera_vfs_watchdog(struct chimera_vfs_thread *thread)
 
 } /* chimera_vfs_watchdog_callback */
 
+/*
+ * userspace-RCU runs in QSBR mode: read-side locks are free, but every
+ * registered thread must announce quiescent states (or step out of the
+ * grace-period quorum while it blocks), or grace periods stall process-wide.
+ * The event-loop threads are the only RCU readers, so they are the only
+ * threads we register; the loop hooks drive their quiescence:
+ *
+ *   iteration_end -> quiescent state once per evpl_continue() pass
+ *   pre_wait      -> go offline before a (possibly indefinite) core wait
+ *   post_wait     -> come back online before post-wait callbacks read RCU data
+ *
+ * (The cache maintenance / identity-resolver threads are pure writers --
+ * call_rcu + rcu_assign, no read side -- so they are not registered at all and
+ * never gate a grace period; see vfs_user_cache.h, vfs_identity.c,
+ * s3_cred_cache.h.)
+ */
+static void
+chimera_vfs_rcu_quiescent(
+    struct evpl *evpl,
+    void        *private_data)
+{
+    (void) evpl;
+    (void) private_data;
+    urcu_qsbr_quiescent_state();
+} /* chimera_vfs_rcu_quiescent */
+
+static void
+chimera_vfs_rcu_offline(
+    struct evpl *evpl,
+    void        *private_data)
+{
+    (void) evpl;
+    (void) private_data;
+    urcu_qsbr_thread_offline();
+} /* chimera_vfs_rcu_offline */
+
+static void
+chimera_vfs_rcu_online(
+    struct evpl *evpl,
+    void        *private_data)
+{
+    (void) evpl;
+    (void) private_data;
+    urcu_qsbr_thread_online();
+} /* chimera_vfs_rcu_online */
+
+static const struct evpl_loop_hooks chimera_vfs_rcu_hooks = {
+    .iteration_end = chimera_vfs_rcu_quiescent,
+    .pre_wait      = chimera_vfs_rcu_offline,
+    .post_wait     = chimera_vfs_rcu_online,
+};
+
+/*
+ * One OS thread can enter chimera_vfs_thread_init more than once -- e.g. a
+ * server VFS module (diskfs) loaded in-process gives the thread an inner VFS
+ * context on top of the outer one.  liburcu aborts on a double register, so
+ * register (and install the loop hooks) exactly once per thread, on the first
+ * entry, and tear down on the last.  Thread-local, so no locking is needed.
+ */
+static __thread int chimera_vfs_rcu_refs;
+
 SYMBOL_EXPORT struct chimera_vfs_thread *
 chimera_vfs_thread_init(
     struct evpl        *evpl,
@@ -787,7 +848,10 @@ chimera_vfs_thread_init(
         }
     }
 
-    urcu_memb_register_thread();
+    if (chimera_vfs_rcu_refs++ == 0) {
+        urcu_qsbr_register_thread();
+        evpl_set_loop_hooks(evpl, &chimera_vfs_rcu_hooks);
+    }
 
     pthread_mutex_init(
         &thread->lock,
@@ -871,9 +935,12 @@ chimera_vfs_thread_destroy(struct chimera_vfs_thread *thread)
         chimera_rcu_magazine_drain(&thread->rcu_magazines[i]);
     }
 
-    free(thread);
+    if (--chimera_vfs_rcu_refs == 0) {
+        evpl_set_loop_hooks(thread->evpl, NULL);
+        urcu_qsbr_unregister_thread();
+    }
 
-    urcu_memb_unregister_thread();
+    free(thread);
 } /* chimera_vfs_thread_destroy */
 
 void
@@ -961,7 +1028,7 @@ chimera_vfs_identity_uid_to_sid(
     const struct chimera_vfs_user *user;
     int                            rc = -1;
 
-    urcu_memb_read_lock();
+    urcu_qsbr_read_lock();
 
     user = chimera_vfs_user_cache_lookup_by_uid(vfs->vfs_user_cache, uid);
 
@@ -974,7 +1041,7 @@ chimera_vfs_identity_uid_to_sid(
         }
     }
 
-    urcu_memb_read_unlock();
+    urcu_qsbr_read_unlock();
 
     return rc;
 } /* chimera_vfs_identity_uid_to_sid */
@@ -988,7 +1055,7 @@ chimera_vfs_identity_sid_to_uid(
     const struct chimera_vfs_user *user;
     int                            rc = -1;
 
-    urcu_memb_read_lock();
+    urcu_qsbr_read_lock();
 
     user = chimera_vfs_user_cache_lookup_by_sid(vfs->vfs_user_cache, sid);
 
@@ -997,7 +1064,7 @@ chimera_vfs_identity_sid_to_uid(
         rc   = 0;
     }
 
-    urcu_memb_read_unlock();
+    urcu_qsbr_read_unlock();
 
     return rc;
 } /* chimera_vfs_identity_sid_to_uid */

--- a/src/vfs/vfs_attr_cache.h
+++ b/src/vfs/vfs_attr_cache.h
@@ -6,8 +6,7 @@
 
 #include "vfs/vfs.h"
 #include "vfs/vfs_rcu_pool.h"
-#include <urcu.h>
-#include <urcu/urcu-memb.h>
+#include <urcu/urcu-qsbr.h>
 #include "prometheus-c.h"
 
 struct chimera_vfs_attr_cache_entry {
@@ -182,7 +181,7 @@ chimera_vfs_attr_cache_lookup(
 
     rc = -1;
 
-    urcu_memb_read_lock();
+    urcu_qsbr_read_lock();
 
     while (slot < slot_end) {
         entry = rcu_dereference(*slot);
@@ -201,7 +200,7 @@ chimera_vfs_attr_cache_lookup(
         slot++;
     }
 
-    urcu_memb_read_unlock();
+    urcu_qsbr_read_unlock();
 
     if (rc == 0) {
         prometheus_counter_increment(shard->hit);
@@ -253,7 +252,7 @@ chimera_vfs_attr_cache_insert(
         entry = NULL;
     }
 
-    urcu_memb_read_lock();
+    urcu_qsbr_read_lock();
 
     pthread_mutex_lock(&shard->entry_lock);
 
@@ -282,7 +281,7 @@ chimera_vfs_attr_cache_insert(
 
     pthread_mutex_unlock(&shard->entry_lock);
 
-    urcu_memb_read_unlock();
+    urcu_qsbr_read_unlock();
 
     if (best_entry) {
         call_rcu(&best_entry->rnode.rcu, chimera_rcu_pool_retire);
@@ -348,7 +347,7 @@ chimera_vfs_attr_cache_refresh(
 
     slot_end = slot + cache->num_entries;
 
-    urcu_memb_read_lock();
+    urcu_qsbr_read_lock();
 
     while (slot < slot_end) {
         entry = rcu_dereference(*slot);
@@ -365,7 +364,7 @@ chimera_vfs_attr_cache_refresh(
         slot++;
     }
 
-    urcu_memb_read_unlock();
+    urcu_qsbr_read_unlock();
 
     if (unchanged) {
         prometheus_counter_increment(shard->skip);

--- a/src/vfs/vfs_identity.c
+++ b/src/vfs/vfs_identity.c
@@ -90,7 +90,7 @@ chimera_vfs_identity_cache_probe(
     const struct chimera_vfs_user *user  = NULL;
     int                            found = 0;
 
-    urcu_memb_read_lock();
+    urcu_qsbr_read_lock();
 
     switch (key) {
         case CHIMERA_VFS_IDENTITY_BY_UID:
@@ -112,7 +112,7 @@ chimera_vfs_identity_cache_probe(
         found = 1;
     }
 
-    urcu_memb_read_unlock();
+    urcu_qsbr_read_unlock();
 
     return found;
 } /* chimera_vfs_identity_cache_probe */
@@ -151,8 +151,12 @@ chimera_vfs_identity_worker(void *arg)
     struct chimera_vfs_identity         *identity = arg;
     struct chimera_vfs_identity_request *req;
 
-    urcu_memb_register_thread();
-
+    /* Pure writer: this worker only runs miss handlers and populates the cache
+     * (call_rcu + rcu_assign), never taking an RCU read lock -- the read-side
+     * probe runs on the evpl threads.  So it is not registered as a QSBR
+     * reader; registering it would put a thread that blocks in cond_wait and in
+     * NSS/winbind resolution into the grace-period quorum and stall reclamation
+     * process-wide. */
     pthread_mutex_lock(&identity->lock);
 
     while (1) {
@@ -196,8 +200,6 @@ chimera_vfs_identity_worker(void *arg)
     }
 
     pthread_mutex_unlock(&identity->lock);
-
-    urcu_memb_unregister_thread();
 
     return NULL;
 } /* chimera_vfs_identity_worker */

--- a/src/vfs/vfs_internal.h
+++ b/src/vfs/vfs_internal.h
@@ -127,13 +127,13 @@ chimera_vfs_get_module(
         return NULL;
     }
 
-    urcu_memb_read_lock();
+    urcu_qsbr_read_lock();
 
     mount = chimera_vfs_mount_table_lookup(vfs->mount_table, fh);
 
     module = mount ? mount->module : NULL;
 
-    urcu_memb_read_unlock();
+    urcu_qsbr_read_unlock();
 
     return module;
 } /* chimera_vfs_get_module */

--- a/src/vfs/vfs_mount_table.h
+++ b/src/vfs/vfs_mount_table.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -7,8 +7,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <pthread.h>
-#include <urcu.h>
-#include <urcu/urcu-memb.h>
+#include <urcu/urcu-qsbr.h>
 #include "vfs/vfs.h"
 #include "vfs/vfs_fh.h"
 
@@ -186,7 +185,7 @@ chimera_vfs_mount_table_lookup_attrs(
     index  = chimera_vfs_mount_table_bucket_index(mount_id);
     bucket = index & table->num_buckets_mask;
 
-    urcu_memb_read_lock();
+    urcu_qsbr_read_lock();
 
     entry = rcu_dereference(table->buckets[bucket]);
 
@@ -201,7 +200,7 @@ chimera_vfs_mount_table_lookup_attrs(
         entry = rcu_dereference(entry->next);
     }
 
-    urcu_memb_read_unlock();
+    urcu_qsbr_read_unlock();
 
     return rc;
 } /* chimera_vfs_mount_table_lookup_attrs */
@@ -209,8 +208,8 @@ chimera_vfs_mount_table_lookup_attrs(
 /*
  * Lookup full mount pointer by mount ID.
  * Returns mount pointer or NULL if not found.
- * IMPORTANT: Caller MUST call urcu_memb_read_lock() before and
- * urcu_memb_read_unlock() after using the returned pointer.
+ * IMPORTANT: Caller MUST call urcu_qsbr_read_lock() before and
+ * urcu_qsbr_read_unlock() after using the returned pointer.
  */
 static inline struct chimera_vfs_mount *
 chimera_vfs_mount_table_lookup(
@@ -250,7 +249,7 @@ chimera_vfs_mount_table_count(struct chimera_vfs_mount_table *table)
     uint32_t                              i;
     int                                   count = 0;
 
-    urcu_memb_read_lock();
+    urcu_qsbr_read_lock();
 
     for (i = 0; i < table->num_buckets; i++) {
         entry = rcu_dereference(table->buckets[i]);
@@ -260,7 +259,7 @@ chimera_vfs_mount_table_count(struct chimera_vfs_mount_table *table)
         }
     }
 
-    urcu_memb_read_unlock();
+    urcu_qsbr_read_unlock();
 
     return count;
 } /* chimera_vfs_mount_table_count */
@@ -288,7 +287,7 @@ chimera_vfs_mount_table_foreach(
     uint32_t                              i;
     int                                   rc = 0;
 
-    urcu_memb_read_lock();
+    urcu_qsbr_read_lock();
 
     for (i = 0; i < table->num_buckets && rc == 0; i++) {
         entry = rcu_dereference(table->buckets[i]);
@@ -298,7 +297,7 @@ chimera_vfs_mount_table_foreach(
         }
     }
 
-    urcu_memb_read_unlock();
+    urcu_qsbr_read_unlock();
 
     return rc;
 } /* chimera_vfs_mount_table_foreach */
@@ -322,7 +321,7 @@ chimera_vfs_mount_table_find_by_path(
     struct chimera_vfs_mount             *found = NULL;
     uint32_t                              i;
 
-    urcu_memb_read_lock();
+    urcu_qsbr_read_lock();
 
     for (i = 0; i < table->num_buckets && !found; i++) {
         entry = rcu_dereference(table->buckets[i]);
@@ -338,7 +337,7 @@ chimera_vfs_mount_table_find_by_path(
         }
     }
 
-    urcu_memb_read_unlock();
+    urcu_qsbr_read_unlock();
 
     return found;
 } /* chimera_vfs_mount_table_find_by_path */
@@ -406,7 +405,7 @@ chimera_vfs_mount_table_lookup_root_fh_by_name(
     uint32_t                              i;
     int                                   rc = -1;
 
-    urcu_memb_read_lock();
+    urcu_qsbr_read_lock();
 
     for (i = 0; i < table->num_buckets && rc != 0; i++) {
         entry = rcu_dereference(table->buckets[i]);
@@ -421,7 +420,7 @@ chimera_vfs_mount_table_lookup_root_fh_by_name(
         }
     }
 
-    urcu_memb_read_unlock();
+    urcu_qsbr_read_unlock();
 
     return rc;
 } /* chimera_vfs_mount_table_lookup_root_fh_by_name */

--- a/src/vfs/vfs_name_cache.h
+++ b/src/vfs/vfs_name_cache.h
@@ -6,8 +6,7 @@
 
 #include "vfs/vfs.h"
 #include "vfs/vfs_rcu_pool.h"
-#include <urcu.h>
-#include <urcu/urcu-memb.h>
+#include <urcu/urcu-qsbr.h>
 
 struct chimera_vfs_name_cache_entry {
     struct chimera_rcu_node rnode; /* must be first: aliases the entry pointer */
@@ -185,7 +184,7 @@ chimera_vfs_name_cache_lookup(
 
     rc = -1;
 
-    urcu_memb_read_lock();
+    urcu_qsbr_read_lock();
 
     while (slot < slot_end) {
         entry = rcu_dereference(*slot);
@@ -206,7 +205,7 @@ chimera_vfs_name_cache_lookup(
         slot++;
     }
 
-    urcu_memb_read_unlock();
+    urcu_qsbr_read_unlock();
 
     if (rc == 0) {
         prometheus_counter_increment(shard->hit);
@@ -265,7 +264,7 @@ chimera_vfs_name_cache_insert(
         memcpy(entry->child_name, name, name_len);
     }
 
-    urcu_memb_read_lock();
+    urcu_qsbr_read_lock();
 
     pthread_mutex_lock(&shard->entry_lock);
 
@@ -324,7 +323,7 @@ chimera_vfs_name_cache_insert(
 
     pthread_mutex_unlock(&shard->entry_lock);
 
-    urcu_memb_read_unlock();
+    urcu_qsbr_read_unlock();
 
     if (best_entry) {
         call_rcu(&best_entry->rnode.rcu, chimera_rcu_pool_retire);
@@ -353,7 +352,7 @@ chimera_vfs_name_cache_remove(
 
     slot_end = slot + cache->num_entries;
 
-    urcu_memb_read_lock();
+    urcu_qsbr_read_lock();
 
     pthread_mutex_lock(&shard->entry_lock);
 
@@ -377,7 +376,7 @@ chimera_vfs_name_cache_remove(
 
     pthread_mutex_unlock(&shard->entry_lock);
 
-    urcu_memb_read_unlock();
+    urcu_qsbr_read_unlock();
 
     if (removed_entry) {
         call_rcu(&removed_entry->rnode.rcu, chimera_rcu_pool_retire);

--- a/src/vfs/vfs_notify.c
+++ b/src/vfs/vfs_notify.c
@@ -128,7 +128,7 @@ chimera_vfs_notify_get_mount_entry(
          * that preserves mount_id while changing root_fh or RPL
          * capability would not.  Document and revisit if it matters. */
         if (notify->vfs) {
-            urcu_memb_read_lock();
+            urcu_qsbr_read_lock();
             mount = chimera_vfs_mount_table_lookup(notify->vfs->mount_table, mount_id);
             if (mount) {
                 memcpy(me->root_fh, mount->root_fh, mount->root_fh_len);
@@ -137,7 +137,7 @@ chimera_vfs_notify_get_mount_entry(
                     me->has_rpl = (mount->module->capabilities & CHIMERA_VFS_CAP_RPL) != 0;
                 }
             }
-            urcu_memb_read_unlock();
+            urcu_qsbr_read_unlock();
         }
 
         HASH_ADD(hh, notify->mount_entries, mount_id, CHIMERA_VFS_MOUNT_ID_SIZE, me);

--- a/src/vfs/vfs_rcu_pool.h
+++ b/src/vfs/vfs_rcu_pool.h
@@ -37,8 +37,7 @@
 #include <stdint.h>
 #include <string.h>
 #include <unistd.h>
-#include <urcu.h>
-#include <urcu/urcu-memb.h>
+#include <urcu/urcu-qsbr.h>
 #include <urcu/wfstack.h>
 
 #include "vfs/vfs.h" /* enum chimera_rcu_pool_id, struct chimera_rcu_magazine */

--- a/src/vfs/vfs_rpl_cache.h
+++ b/src/vfs/vfs_rpl_cache.h
@@ -8,8 +8,7 @@
 #include "vfs/vfs_rcu_pool.h"
 #include "vfs_internal.h"
 #include "common/misc.h"
-#include <urcu.h>
-#include <urcu/urcu-memb.h>
+#include <urcu/urcu-qsbr.h>
 
 /*
  * RPL (Reverse Path Lookup) Cache
@@ -162,7 +161,7 @@ chimera_vfs_rpl_cache_lookup(
     slot     = &shard->fwd_entries[(key & cache->num_slots_mask) << cache->num_entries_bits];
     slot_end = slot + cache->num_entries;
 
-    urcu_memb_read_lock();
+    urcu_qsbr_read_lock();
 
     while (slot < slot_end) {
         entry = rcu_dereference(*slot);
@@ -178,14 +177,14 @@ chimera_vfs_rpl_cache_lookup(
             memcpy(r_name, entry->name, entry->name_len);
             entry->score++;
 
-            urcu_memb_read_unlock();
+            urcu_qsbr_read_unlock();
             return 0;
         }
 
         slot++;
     }
 
-    urcu_memb_read_unlock();
+    urcu_qsbr_read_unlock();
     return -1;
 } /* chimera_vfs_rpl_cache_lookup */
 
@@ -306,7 +305,7 @@ chimera_vfs_rpl_cache_insert(
     memcpy(entry->name, name, name_len);
 
     /* Insert into forward index */
-    urcu_memb_read_lock();
+    urcu_qsbr_read_lock();
     pthread_mutex_lock(&shard->entry_lock);
 
     slot     = &shard->fwd_entries[(fwd_key & cache->num_slots_mask) << cache->num_entries_bits];
@@ -364,7 +363,7 @@ chimera_vfs_rpl_cache_insert(
     chimera_vfs_rpl_cache_rev_insert(cache, shard, entry);
 
     pthread_mutex_unlock(&shard->entry_lock);
-    urcu_memb_read_unlock();
+    urcu_qsbr_read_unlock();
 
     if (best_entry) {
         call_rcu(&best_entry->rnode.rcu, chimera_rcu_pool_retire);
@@ -396,7 +395,7 @@ chimera_vfs_rpl_cache_invalidate(
      * (the caller knows only the parent_fh + name), so scan every shard's
      * reverse index.  Invalidation runs on rename/remove which is far
      * less frequent than lookup. */
-    urcu_memb_read_lock();
+    urcu_qsbr_read_lock();
 
     for (shard_idx = 0; shard_idx < cache->num_shards; shard_idx++) {
         shard = &cache->shards[shard_idx];
@@ -449,7 +448,7 @@ chimera_vfs_rpl_cache_invalidate(
         }
     }
 
-    urcu_memb_read_unlock();
+    urcu_qsbr_read_unlock();
 
     if (removed_entry) {
         call_rcu(&removed_entry->rnode.rcu, chimera_rcu_pool_retire);

--- a/src/vfs/vfs_user_cache.h
+++ b/src/vfs/vfs_user_cache.h
@@ -9,8 +9,7 @@
 #include <string.h>
 #include <pthread.h>
 #include <time.h>
-#include <urcu.h>
-#include <urcu/urcu-memb.h>
+#include <urcu/urcu-qsbr.h>
 
 #include "vfs_cred.h"
 #include "vfs_internal.h"
@@ -167,8 +166,10 @@ chimera_vfs_user_cache_expiry_thread(void *arg)
     struct timespec                ts;
     int                            i;
 
-    urcu_memb_register_thread();
-
+    /* Pure writer: sweeps expired entries under the write lock (rcu_assign +
+     * call_rcu), never takes an RCU read lock.  Not registered as a QSBR
+     * reader -- a thread parked in cond_timedwait must not sit in the
+     * grace-period quorum. */
     pthread_mutex_lock(&cache->expiry_lock);
 
     while (!cache->shutdown) {
@@ -209,8 +210,6 @@ chimera_vfs_user_cache_expiry_thread(void *arg)
     }
 
     pthread_mutex_unlock(&cache->expiry_lock);
-
-    urcu_memb_unregister_thread();
 
     return NULL;
 } // chimera_vfs_user_cache_expiry_thread
@@ -259,7 +258,7 @@ chimera_vfs_user_cache_destroy(struct chimera_vfs_user_cache *cache)
 
     pthread_join(cache->expiry_thread, NULL);
 
-    urcu_memb_barrier();
+    urcu_qsbr_barrier();
 
     for (i = 0; i < cache->num_buckets; i++) {
         user = cache->name_buckets[i].head;


### PR DESCRIPTION
Switches all of chimera's userspace-RCU usage from the **memb** flavor to **QSBR** (`liburcu-qsbr`). In QSBR the read side is free — `rcu_read_lock`/`rcu_read_unlock` compile to nothing — which removes per-op RCU cost from the hot lookup paths (attr/name/rpl/user/cred caches, mount table, NFS/S3 lookup). Depends on, and bumps the submodule to, **chimera-nas/libevpl#92** (event-loop hooks, merged).

QSBR's contract is that every *registered* thread must announce quiescent states, or step out of the grace-period quorum while it blocks — otherwise a single thread asleep in `epoll` stalls reclamation process-wide (`synchronize_rcu` hangs, `call_rcu` callbacks never fire). So this is mostly a *registration model* change, not just a flavor rename. It also supersedes the `__thread`-refcount band-aid that was floating around for the in-process-diskfs double-`thread_init`.

### What changed

**Event-loop quiescence (the readers).** `chimera_vfs_thread_init` installs `evpl_set_loop_hooks`:
- `iteration_end → rcu_quiescent_state()` — once per `evpl_continue()` pass.
- `pre_wait → rcu_thread_offline()`, `post_wait → rcu_thread_online()` — bracket the (possibly indefinite, `wait_ms` defaults to -1) core wait, so an idle thread leaves the quorum while parked in epoll and rejoins before it touches any RCU data. The offline→online transition also doubles as the periodic quiescence announcement for busy poll-mode threads.

**Centralized registration.** Only the event-loop threads are RCU readers, so only they register — once per thread, at the single `thread_init` chokepoint where the hooks are installed, refcounted per-thread so an OS thread that enters twice (a server VFS module like diskfs loaded in-process on top of the outer context) doesn't double-register and abort.

**Standalone threads de-registered.** The user-cache and s3-cred expiry sweepers and the identity resolver are **pure writers** (`call_rcu` + `rcu_assign`, never an RCU read lock — the only read-side probe runs on the evpl threads). They are no longer registered: registering a thread that parks in `cond_wait`/blocking NSS would put it in the quorum and stall reclamation. `call_rcu` does not require a registered caller.

**Mechanical.** `urcu_memb_* → urcu_qsbr_*`; include `<urcu/urcu-qsbr.h>` instead of the memb header + `<urcu.h>` (which forces the memb flavor); link `liburcu-qsbr`. `URCU_API_MAP` is set project-wide so the unprefixed API (`call_rcu`, `rcu_barrier`, `rcu_read_lock`) stays mapped to QSBR — the flavor header clears that map at its end otherwise.

### Validation

- Daemon, all server/vfs libs, client, and diskfs build and link against `liburcu-qsbr`.
- `vfs/user_cache_test`, `vfs/notify_test`, `vfs/identity_test` pass under QSBR (the identity test exercises both the de-registered writer worker and the evpl-thread reader path).
- **Not yet validated in CI sandbox:** the silent-stall failure mode (an idle thread parked in epoll while another churns `call_rcu`) needs a server soak watching RSS stay flat — that's the acceptance test for the registration audit being complete.

### Note

The daemon still pulls in plain `liburcu.so` via libevpl's `evpl_rpc2` (a vestigial `urcu` link — libevpl uses no RCU). It's inert (no memb symbol is ever called) and harmless; a libevpl-side cleanup can drop that link separately.