### PR TITLE
smb2: enforce per-handle write access (smb2.deny on native backends)

### DIFF
--- a/src/server/smb/smb_proc_write.c
+++ b/src/server/smb/smb_proc_write.c
@@ -176,6 +176,25 @@ chimera_smb_write(struct chimera_smb_request *request)
         return;
     }
 
+    /* MS-SMB2 3.3.5.13: a WRITE request must be rejected with ACCESS_DENIED
+     * when the open does not carry write access.  The handle's desired_access
+     * may still be in NT generic form (GENERIC_WRITE / GENERIC_ALL /
+     * MAXIMUM_ALLOWED), so accept any access bit that resolves to write data;
+     * only an open lacking all of them (as smbtorture's deny test deliberately
+     * constructs: SEC_FILE_READ_DATA only, no write bit) should be denied
+     * here.  Without this gate, native backends -- which run the write through
+     * the VFS regardless of the per-handle access mask -- silently accept
+     * writes on read-only handles, while the passthrough backends are caught
+     * by the underlying kernel open. */
+    if (!(request->write.open_file->desired_access &
+          (SMB2_FILE_WRITE_DATA | SMB2_FILE_APPEND_DATA |
+           SMB2_GENERIC_WRITE | SMB2_GENERIC_ALL | SMB2_MAXIMUM_ALLOWED))) {
+        evpl_iovecs_release(evpl, request->write.iov, request->write.niov);
+        chimera_smb_open_file_release(request, request->write.open_file);
+        chimera_smb_complete_request(request, SMB2_STATUS_ACCESS_DENIED);
+        return;
+    }
+
     /* MS-SMB2 3.3.5.13: reject writes whose offset is beyond the maximum file
     * size (INT64_MAX) and writes whose last byte would extend past the
     * server's maximum supported file size.  A zero-length write at any

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -359,6 +359,12 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.compound_find
     smb2.connect
     smb2.create_no_streams
+    # The denytest matrix opens a file twice and probes which reads/writes are
+    # actually serviced; passing requires both the share-mode conflict matrix
+    # and per-handle granted-access enforcement on the write path
+    # (chimera_smb_write).  The native backends now match the passthrough
+    # backends here.
+    smb2.deny
     # SMB3 durable/persistent handle suites that pass end-to-end on memfs with
     # the in-memory durable registry (the harness runs the server with
     # persistent handles enabled).  smb2.durable-open / -v2-open still have
@@ -530,6 +536,9 @@ set(SMBTORTURE_ENABLED_cairn
     smb2.compound_find
     smb2.connect
     smb2.create_no_streams
+    # See SMBTORTURE_ENABLED_memfs above: greened by the per-handle write
+    # access gate in chimera_smb_write.
+    smb2.deny
     smb2.notify-inotify
     smb2.secleak
     smb2.session-id
@@ -590,6 +599,9 @@ set(SMBTORTURE_ENABLED_diskfs_common
     smb2.compound_find
     smb2.connect
     smb2.create_no_streams
+    # See SMBTORTURE_ENABLED_memfs above: greened by the per-handle write
+    # access gate in chimera_smb_write.
+    smb2.deny
     smb2.notify-inotify
     smb2.secleak
     smb2.session-id


### PR DESCRIPTION
## Summary

A SMB2 WRITE on a handle that was not opened with any write-capable access right (`FILE_WRITE_DATA`, `FILE_APPEND_DATA`, `GENERIC_WRITE`, `GENERIC_ALL`, `MAXIMUM_ALLOWED`) must fail with `STATUS_ACCESS_DENIED`.

`chimera_smb_read` already gates the analogous read case, but `chimera_smb_write` was passing straight through to the VFS, so the native backends (memfs / cairn / diskfs_io_uring / diskfs_aio) silently accepted writes on read-only handles. The passthrough backends (linux / io_uring) were saved by the underlying kernel's open mode, which is why `smb2.deny` only failed on the native backends.

## Symptom

`smb2.deny` opens a file twice (table-driven across the 96 share/access combinations on `.exe` + `.dat`) and asks: which reads and which writes actually go through on the second handle? Without the gate, a `SEC_FILE_READ_DATA`-only second open accepted writes and reported `A_RW` instead of `A_R`:

```
3: denytest2.exe NTCREATEX_SHARE_ACCESS_READ|NTCREATEX_SHARE_ACCESS_DELETE
   SEC_FILE_READ_DATA|SEC_FILE_WRITE_DATA
   NTCREATEX_SHARE_ACCESS_READ|NTCREATEX_SHARE_ACCESS_WRITE|NTCREATEX_SHARE_ACCESS_DELETE
   SEC_FILE_READ_DATA
   RW (correct=R)
```

## Fix

Add a per-handle write access gate at the top of `chimera_smb_write`, mirroring the existing read-side check, and enable `smb2.deny` on the four native backends; it was already enabled on `linux` and `io_uring` (where the kernel open enforces this).

## Verification

```
$ ctest -R smbtorture_smb2_deny_ -j 6
1/6 smb2_deny_memfs            Passed
2/6 smb2_deny_io_uring         Passed
3/6 smb2_deny_linux            Passed
4/6 smb2_deny_diskfs_io_uring  Passed
5/6 smb2_deny_cairn            Passed
6/6 smb2_deny_diskfs_aio       Passed
```

Full smbtorture matrix (294 enabled tests across the 6 backends) stays green.