### PR TITLE
diskfs: bump block cache for smb2.maxfid (65520-fid) test

### DIFF
--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -304,6 +304,7 @@ set(SMBTORTURE_SUITES
     smb2.lease
     smb2.lock
     smb2.maximum_allowed
+    smb2.maxfid
     smb2.mkdir
     smb2.name-mangling
     smb2.notify
@@ -599,6 +600,12 @@ set(SMBTORTURE_ENABLED_cairn
 # the diskfs module and enable the same set.
 set(SMBTORTURE_ENABLED_diskfs_common
     smb2.change_notify_disabled
+    # 65520-fid stress test.  The harness raises diskfs's block_cache_blocks
+    # for both diskfs backends (see smbtorture_test.c) so the working set --
+    # pinned inode home blocks + LOGGED journal blocks awaiting tail-push --
+    # fits without the per-shard pin exhaustion the default cache hits at
+    # this scale.
+    smb2.maxfid
     smb2.mkdir
     # Native DOS-attribute storage in the diskfs inode (in-memory + on-disk
     # dinode) lets the SMB create/overwrite-truncate attribute round-trip

--- a/src/server/smb/tests/smbtorture_test.c
+++ b/src/server/smb/tests/smbtorture_test.c
@@ -345,6 +345,22 @@ main(
         /* unsafe_async: this test does not exercise crash recovery, so skip FUA/sync
          * on writes to run lighter. */
         json_object_set_new(cfg, "unsafe_async", json_true());
+        /* smb2.maxfid keeps 65520 file handles open across ~256 inode-cache
+         * shards; the inode home blocks stay pinned by the open handles and
+         * concurrent close traffic also pins LOGGED blocks (held until tail
+         * push).  The default cache (32768 blocks across 256 shards ≈ 128 per
+         * shard) is too small for this skew and aborts with either
+         *   - "b+tree lookup suspended on a cache miss"  (sync wrapper hits a
+         *     non-resident block on the ACL descent), or
+         *   - "block cache shard exhausted: every buffer pinned"
+         *     (recycle finds no clean victim in a hot shard).
+         * Both are diskfs cache-sizing issues, not protocol bugs.  Bump the
+         * cache for these tests so the working set fits.  TODO: replace this
+         * test-side workaround with a runtime fix -- either a cross-shard
+         * victim search (so pinned skew in one shard can draw from another)
+         * or making diskfs_map_attrs's ACL lookup tolerate suspension.  See
+         * diskfs.c:5665 and :2542 for the abort sites. */
+        json_object_set_new(cfg, "block_cache_blocks", json_integer(262144));
         json_str = json_dumps(cfg, JSON_COMPACT);
         snprintf(diskfs_cfg, sizeof(diskfs_cfg), "%s", json_str);
         free(json_str);


### PR DESCRIPTION
The smbtorture `smb2.maxfid` suite opens 65520 files at once.  On the diskfs backend (both `diskfs_io_uring` and `diskfs_aio`) the default block cache — 32768 blocks across 256 shards, ~128 per shard — is too small for this scale and aborts with one of two patterns depending on how the workload skews across shards:

- **\"b+tree lookup suspended on a cache miss (no eviction yet)\"** (`diskfs.c:5665`) — a sync wrapper hits a non-resident block on the ACL descent inside `diskfs_map_attrs`; the op suspends and the sync wrapper has no way to wait.
- **\"block cache shard exhausted: every buffer pinned (raise block_cache_blocks above the intent-log size, or a pin was leaked)\"** (`diskfs.c:2542`) — `diskfs_block_recycle` finds no CLEAN, unpinned victim in a hot shard, because all of its blocks are pinned (inode home blocks held by the open handles, plus LOGGED journal blocks awaiting tail push).

Both abort sites are diskfs cache-sizing / sync-wrapper-vs-eviction issues, not protocol bugs.  Bumping `block_cache_blocks` to 262144 (256 shards × 1024 blocks/shard, 1 GiB total) in the SMB smbtorture harness gives the working set enough headroom and both backends pass cleanly:

```
ctest -R smbtorture_smb2_maxfid_diskfs -j1
 Test #8309: ...maxfid_diskfs_io_uring ...   Passed   14.57 sec
 Test #8400: ...maxfid_diskfs_aio       ...   Passed   14.06 sec
```

The change is purely a config knob the backend already exposes; no diskfs source is touched.

### Why the test-side workaround, not a runtime fix

The proper runtime fixes — either:

1. make `diskfs_map_attrs`'s ACL lookup async so the sync wrapper at `diskfs.c:5665` stops aborting on a benign cache miss, or
2. let `diskfs_block_recycle` search across shards (or back the block cache with a global victim pool) so per-shard pin skew can draw headroom from a less loaded shard,

are both larger and out of scope here.  The TODO in `smbtorture_test.c` points at the two abort sites so the follow-up has a starting place.

### Allowlist

- Add `smb2.maxfid` to `SMBTORTURE_SUITES` and to the `diskfs_common` allowlist so ctest reports it as a real green for both diskfs backends.
- The other backends (memfs, linux, io_uring, cairn) remain `Disabled` in this PR — a parallel \"maxfid on 4 backends\" PR enables them.