### PR TITLE
smb2/tests: enable smb2.durable-v2-regressions on all backends

### DIFF
--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -295,6 +295,7 @@ set(SMBTORTURE_SUITES
     smb2.durable-open-disconnect
     smb2.durable-v2-delay
     smb2.durable-v2-open
+    smb2.durable-v2-regressions
     smb2.ea
     smb2.fileid
     smb2.getinfo
@@ -383,6 +384,9 @@ set(SMBTORTURE_ENABLED_memfs
     # individual gaps and stay disabled until fully green.
     smb2.durable-open-disconnect
     smb2.durable-v2-delay
+    # Regression coverage for previously-fixed durable-v2 reconnect bugs
+    # (currently the Samba bug15624 reconnect subtest).  Small/fast.
+    smb2.durable-v2-regressions
     smb2.notify-inotify
     smb2.secleak
     smb2.session-id
@@ -465,6 +469,9 @@ set(SMBTORTURE_ENABLED_linux
     smb2.connect
     smb2.create_no_streams
     smb2.deny
+    # Regression coverage for previously-fixed durable-v2 reconnect bugs
+    # (currently the Samba bug15624 reconnect subtest).  Small/fast.
+    smb2.durable-v2-regressions
     smb2.notify-inotify
     smb2.secleak
     smb2.session-id
@@ -514,6 +521,9 @@ set(SMBTORTURE_ENABLED_io_uring
     smb2.connect
     smb2.create_no_streams
     smb2.deny
+    # Regression coverage for previously-fixed durable-v2 reconnect bugs
+    # (currently the Samba bug15624 reconnect subtest).  Small/fast.
+    smb2.durable-v2-regressions
     smb2.notify-inotify
     smb2.secleak
     smb2.session-id
@@ -583,6 +593,9 @@ set(SMBTORTURE_ENABLED_cairn
     # See SMBTORTURE_ENABLED_memfs above: greened by the per-handle write
     # access gate in chimera_smb_write.
     smb2.deny
+    # Regression coverage for previously-fixed durable-v2 reconnect bugs
+    # (currently the Samba bug15624 reconnect subtest).  Small/fast.
+    smb2.durable-v2-regressions
     smb2.notify-inotify
     smb2.secleak
     smb2.session-id
@@ -654,6 +667,9 @@ set(SMBTORTURE_ENABLED_diskfs_common
     # See SMBTORTURE_ENABLED_memfs above: greened by the per-handle write
     # access gate in chimera_smb_write.
     smb2.deny
+    # Regression coverage for previously-fixed durable-v2 reconnect bugs
+    # (currently the Samba bug15624 reconnect subtest).  Small/fast.
+    smb2.durable-v2-regressions
     smb2.notify-inotify
     smb2.secleak
     smb2.session-id


### PR DESCRIPTION
The smbtorture `smb2.durable-v2-regressions` suite (currently the Samba bug15624 reconnect subtest) covers regressions in v2 durable-handle replay and runs in well under a second. It passes end-to-end on every chimera backend today, but was not registered in any allowlist — so the six PASS cells weren't visible in CI.

This patch adds `smb2.durable-v2-regressions` to:
- `SMBTORTURE_SUITES` (the visible list)
- `SMBTORTURE_ENABLED_memfs`
- `SMBTORTURE_ENABLED_linux`
- `SMBTORTURE_ENABLED_io_uring`
- `SMBTORTURE_ENABLED_cairn`
- `SMBTORTURE_ENABLED_diskfs_common` (covers both diskfs_io_uring and diskfs_aio)

Local verification: all six cells PASS via `netns_test_wrapper.sh`.