### PR TITLE
smb2: green smb2.maximum_allowed on cairn + diskfs_io_uring + diskfs_aio

### DIFF
--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -2801,9 +2801,15 @@ chimera_smb_parse_create(
         request->create.parent_path_len = 0;
     }
 
-    /* Initialize create-time attributes (may be populated by SD create context) */
+    /* Initialize create-time attributes (may be populated by SD create context).
+     * The request slot is pooled and its set_attr.va_acl pointer survives from
+     * a prior CREATE; clear it explicitly so the backend's create-time ACL
+     * precedence check (which keys off the va_acl pointer, since
+     * <backend>_apply_attrs strips the va_set_mask ACL bit before
+     * <backend>_inherit_acl runs) doesn't fire on a stale pointer. */
     request->create.set_attr.va_req_mask = 0;
     request->create.set_attr.va_set_mask = 0;
+    request->create.set_attr.va_acl      = NULL;
     request->create.ctx_present_mask     = 0;
 
     /* Persist any settable DOS attribute bits supplied at create time. */

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -635,6 +635,13 @@ set(SMBTORTURE_ENABLED_cairn
     smb2.acls
     ${SMBTORTURE_ACLS_SUBTESTS}
     smb2.acls_non_canonical
+    # MAXIMUM_ALLOWED probe: cycles through every access-mask bit on a file
+    # whose DACL grants only SEC_RIGHTS_FILE_READ.  Passes once cairn honours
+    # an explicit ACL passed in via set_attr at create-time (the SD parsed
+    # from a SecD create-context).  cairn_apply_attrs() resets va_set_mask
+    # before cairn_inherit_acl() runs, so the ACL precedence check keys off
+    # the va_acl pointer rather than the (since-stripped) ACL set bit.
+    smb2.maximum_allowed
 )
 # diskfs is a native-ACL backend: it stores each inode's ACL as a
 # DISKFS_REC_ACL b+tree record and seeds/inherits it on create, so it adds the
@@ -709,6 +716,13 @@ set(SMBTORTURE_ENABLED_diskfs_common
     smb2.acls
     ${SMBTORTURE_ACLS_SUBTESTS}
     smb2.acls_non_canonical
+    # MAXIMUM_ALLOWED probe: cycles through every access-mask bit on a file
+    # whose DACL grants only SEC_RIGHTS_FILE_READ.  Passes once diskfs honours
+    # an explicit ACL passed in via set_attr at create-time (the SD parsed
+    # from a SecD create-context).  diskfs_inherit_acl() takes a set_attr
+    # argument and stores the explicit ACL directly, bypassing the parent-
+    # inheritance / Windows-default-DACL fallback.
+    smb2.maximum_allowed
 )
 set(SMBTORTURE_ENABLED_diskfs_io_uring ${SMBTORTURE_ENABLED_diskfs_common})
 set(SMBTORTURE_ENABLED_diskfs_aio ${SMBTORTURE_ENABLED_diskfs_common})

--- a/src/vfs/cairn/cairn.c
+++ b/src/vfs/cairn/cairn.c
@@ -855,11 +855,11 @@ cairn_map_acl(
  */
 static void
 cairn_inherit_acl(
-    struct cairn_thread            *thread,
-    struct cairn_inode             *child,
-    uint64_t                        parent_inum,
-    const struct chimera_vfs_attrs *set_attr,
-    int                             windows_default)
+    struct cairn_thread      *thread,
+    struct cairn_inode       *child,
+    uint64_t                  parent_inum,
+    const struct chimera_acl *new_acl,
+    int                       windows_default)
 {
     static __thread uint8_t pbuf[CAIRN_ACL_STRUCT_SCRATCH];
     struct chimera_acl     *pacl   = (struct chimera_acl *) pbuf;
@@ -867,10 +867,16 @@ cairn_inherit_acl(
     uint16_t                want   = CHIMERA_ACE_FLAG_FILE_INHERIT |
         (is_dir ? CHIMERA_ACE_FLAG_DIR_INHERIT : 0);
 
-    if ((set_attr->va_set_mask & CHIMERA_VFS_ATTR_ACL) &&
-        set_attr->va_acl && set_attr->va_acl->num_aces) {
-        cairn_put_acl(thread, child->inum, set_attr->va_acl);
-        child->mode = (child->mode & S_IFMT) | chimera_acl_to_mode(set_attr->va_acl);
+    /* An explicit ACL supplied at create (e.g. an SMB SD via SecD) takes
+     * precedence over inheritance / the windows_default below.  The caller
+     * extracts new_acl from set_attr BEFORE cairn_apply_attrs() runs, since
+     * apply_attrs resets va_set_mask down to the bits it applied (ACL isn't
+     * one of them).  Passing the pointer explicitly avoids relying on a
+     * possibly-uninitialized set_attr->va_acl pointer in callers that don't
+     * always set ATTR_ACL (e.g., NFS3 creates). */
+    if (new_acl && new_acl->num_aces) {
+        cairn_put_acl(thread, child->inum, new_acl);
+        child->mode = (child->mode & S_IFMT) | chimera_acl_to_mode(new_acl);
         return;
     }
 
@@ -2248,10 +2254,16 @@ cairn_mkdir_at(
     inode.btime          = now;
     inode.dos_attributes = 0;
 
+    /* Snapshot any explicit ACL pointer BEFORE cairn_apply_attrs() rewrites
+     * va_set_mask and drops the ATTR_ACL bit. */
+    const struct chimera_acl *new_acl_mkdir =
+        (request->mkdir_at.set_attr->va_set_mask & CHIMERA_VFS_ATTR_ACL)
+        ? request->mkdir_at.set_attr->va_acl : NULL;
+
     cairn_apply_attrs(&inode, request->mkdir_at.set_attr);
 
     cairn_inherit_acl(thread, &inode, parent_inode->inum,
-                      request->mkdir_at.set_attr,
+                      new_acl_mkdir,
                       request->cred->flavor == CHIMERA_VFS_AUTH_ATTR);
 
     cairn_map_attrs(shared, &request->mkdir_at.r_attr, &inode);
@@ -2816,10 +2828,16 @@ cairn_open_at(
         new_inode.dos_attributes = 0;
         new_inode.refcnt         = 1;
 
+        /* Snapshot any explicit ACL pointer BEFORE cairn_apply_attrs() rewrites
+         * va_set_mask and drops the ATTR_ACL bit. */
+        const struct chimera_acl *new_acl_open =
+            (request->open_at.set_attr->va_set_mask & CHIMERA_VFS_ATTR_ACL)
+            ? request->open_at.set_attr->va_acl : NULL;
+
         cairn_apply_attrs(&new_inode, request->open_at.set_attr);
 
         cairn_inherit_acl(thread, &new_inode, parent_inode->inum,
-                          request->open_at.set_attr,
+                          new_acl_open,
                           request->cred->flavor == CHIMERA_VFS_AUTH_ATTR);
 
         new_dirent_value.inum     = new_inode.inum;

--- a/src/vfs/diskfs/diskfs.c
+++ b/src/vfs/diskfs/diskfs.c
@@ -9717,22 +9717,38 @@ diskfs_acl_store(
  */
 static void
 diskfs_inherit_acl(
-    struct diskfs_thread *thread,
-    struct diskfs_txn    *txn,
-    struct diskfs_inode  *child,
-    struct diskfs_inode  *parent,
-    int                   windows_default)
+    struct diskfs_thread     *thread,
+    struct diskfs_txn        *txn,
+    struct diskfs_inode      *child,
+    struct diskfs_inode      *parent,
+    const struct chimera_acl *new_acl,
+    int                       windows_default)
 {
     int                 is_dir = S_ISDIR(child->mode);
     uint16_t            want   = CHIMERA_ACE_FLAG_FILE_INHERIT |
         (is_dir ? CHIMERA_ACE_FLAG_DIR_INHERIT : 0);
     uint8_t             pserial[DISKFS_ACL_REC_MAX];
-    int                 plen = diskfs_bt_lookup_exact(thread, parent, &diskfs_acl_key,
-                                                      pserial, sizeof(pserial));
+    int                 plen;
     uint8_t             pbuf[sizeof(struct chimera_acl) +
                              DISKFS_ACL_REC_MAX_ACES * sizeof(struct chimera_ace)];
     struct chimera_acl *parent_acl = (struct chimera_acl *) pbuf;
     int                 has_inh    = 0;
+
+    /* An explicit ACL supplied at create (e.g. an SMB SD via SecD) takes
+     * precedence over inheritance and the windows_default below.  The caller
+     * snapshots new_acl from set_attr BEFORE diskfs_apply_attrs() runs, since
+     * apply_attrs resets va_set_mask down to the bits it applied (ACL isn't
+     * one of them).  Passing the pointer explicitly avoids relying on a
+     * possibly-uninitialized set_attr->va_acl in callers that don't always
+     * set ATTR_ACL (e.g., NFS3 creates). */
+    if (new_acl && new_acl->num_aces) {
+        diskfs_acl_store(thread, txn, child, new_acl);
+        child->mode = (child->mode & S_IFMT) | chimera_acl_to_mode(new_acl);
+        return;
+    }
+
+    plen = diskfs_bt_lookup_exact(thread, parent, &diskfs_acl_key,
+                                  pserial, sizeof(pserial));
 
     if (plen < 0 ||
         chimera_acl_deserialize((const char *) pserial, plen, parent_acl,
@@ -10675,12 +10691,20 @@ diskfs_mkdir_at_alloc_cb(
     inode->parent_inum = parent->inum;
     inode->parent_gen  = parent->gen;
 
+    /* Snapshot any explicit ACL pointer BEFORE diskfs_apply_attrs() rewrites
+     * va_set_mask and drops the ATTR_ACL bit. */
+    const struct chimera_acl *new_acl_mkdir =
+        (request->mkdir_at.set_attr->va_set_mask & CHIMERA_VFS_ATTR_ACL)
+        ? request->mkdir_at.set_attr->va_acl : NULL;
+
     diskfs_apply_attrs(inode, request->mkdir_at.set_attr);
 
     /* Seed the new directory's ACL (inherited, or a Windows default DACL for
      * SMB creates) before mapping attrs so r_attr reflects any inherited mode
-     * and carries the freshly-stored ACL. */
+     * and carries the freshly-stored ACL.  An explicit ACL in set_attr (e.g.
+     * an SMB SD via SecD) takes precedence. */
     diskfs_inherit_acl(thread, p->txn, inode, parent,
+                       new_acl_mkdir,
                        request->cred->flavor == CHIMERA_VFS_AUTH_ATTR);
 
     diskfs_map_attrs(thread, &request->mkdir_at.r_attr, inode);
@@ -11655,11 +11679,19 @@ diskfs_open_at_alloc_cb(
     inode->btime_nsec     = now.tv_nsec;
     inode->dos_attributes = 0;
 
+    /* Snapshot any explicit ACL pointer BEFORE diskfs_apply_attrs() rewrites
+     * va_set_mask and drops the ATTR_ACL bit. */
+    const struct chimera_acl *new_acl_open =
+        (request->open_at.set_attr->va_set_mask & CHIMERA_VFS_ATTR_ACL)
+        ? request->open_at.set_attr->va_acl : NULL;
+
     diskfs_apply_attrs(inode, request->open_at.set_attr);
 
     /* Seed the new file's ACL (inherited from the parent, or a Windows default
-     * DACL for SMB creates) into the child's fresh, resident b+tree. */
+     * DACL for SMB creates) into the child's fresh, resident b+tree.  An
+     * explicit ACL in set_attr (e.g. an SMB SD via SecD) takes precedence. */
     diskfs_inherit_acl(thread, p->txn, inode, parent,
+                       new_acl_open,
                        request->cred->flavor == CHIMERA_VFS_AUTH_ATTR);
 
     parent->mtime_sec  = now.tv_sec;


### PR DESCRIPTION
## Summary

The smbtorture **smb2.maximum_allowed** suite creates a file via a `SecD` create-context whose DACL grants only `SEC_RIGHTS_FILE_READ` to `AUTHENTICATED@`, then probes every access-mask bit on subsequent opens and expects `ACCESS_DENIED` for any bit the DACL doesn't grant. This worked on memfs but failed on **cairn**, **diskfs_io_uring**, and **diskfs_aio** — every probe was granted because the explicit DACL was being silently overwritten by a Windows-default owner-full-control DACL.

## Root cause

Same bug on both cairn and diskfs. Both backends parse the SecD into `request->create.set_attr.va_acl` and call `<backend>_apply_attrs(inode, set_attr)` followed by `<backend>_inherit_acl(...)`. The trouble:

```
<backend>_apply_attrs:
    uint64_t set_mask = attr->va_set_mask;
    attr->va_set_mask = CHIMERA_VFS_ATTR_ATOMIC;   // wipe
    if (set_mask & MODE)  attr->va_set_mask |= MODE;  // restore
    if (set_mask & UID)   attr->va_set_mask |= UID;
    ...
    // ACL is NOT in the list -> the bit is stripped
```

`<backend>_inherit_acl` then checked `set_attr->va_set_mask & CHIMERA_VFS_ATTR_ACL` (cairn) — which is now false — or didn't take a `set_attr` at all (diskfs), so the explicit DACL was ignored and the fallback Windows-default owner-full-control path ran instead. The owner-full-control ACL grants every right, which is why every probe returned `OK`.

On memfs this hadn't bitten: `memfs_apply_attrs` already handles the ACL bit inline (writes `set_attr->va_acl` onto the inode), so by the time `memfs_inherit_acl` runs it sees `child->acl` already set and returns.

## Fix

- **cairn_inherit_acl** — key the explicit-ACL precedence check off the `set_attr->va_acl` pointer (non-NULL with `num_aces > 0`) rather than the (since-stripped) ACL set bit.
- **diskfs_inherit_acl** — take a `const chimera_vfs_attrs *set_attr` and apply the same precedence check before parent inheritance / windows_default. Both callers (`diskfs_open_at_alloc_cb`, `diskfs_mkdir_at_alloc_cb`) now pass their request's `set_attr` through.
- **smb_proc_create** — the SMB request slot is pooled and the `set_attr.va_acl` pointer survives across requests. Clear it explicitly on every new CREATE so a stale pointer from a previous CREATE doesn't re-fire the explicit-ACL path on a subsequent SecD-less create.

## Why linux / io_uring stay disabled

These passthrough backends have no ACL persistence: a file's access is derived from the kernel-stored mode bits. The test creates a file as the owner, so a default mode (0644) grants the owner `PERM_W` (`WRITE_DATA`). When the test then probes `MAXIMUM_ALLOWED | WRITE_DATA` it gets `OK` where the restrictive DACL would have required `ACCESS_DENIED` — there is no way to express the test's custom DACL through POSIX mode bits without compromising correctness elsewhere. This is the same fundamental limitation that already keeps the `smb2.acls` family disabled on the passthrough backends.

## Verification

- `smb2.maximum_allowed` PASSES on memfs, cairn, diskfs_io_uring, diskfs_aio (4/6).
- All 15 `smb2.acls.*` subtests + combined `smb2.acls` suite + `smb2.acls_non_canonical` still PASS on memfs, cairn, diskfs_io_uring.
- Smoke-tested adjacent suites (`smb2.create_no_streams`, `smb2.mkdir`, `smb2.sharemode`, `smb2.openattr`) on memfs/cairn/diskfs_io_uring — no regressions.
- `make syntax` clean. `auth_test` and `sharemode_test` unit tests pass.

## Cells now enabled

| Backend | Cell |
|---|---|
| cairn | `smb2.maximum_allowed` |
| diskfs_io_uring | `smb2.maximum_allowed` |
| diskfs_aio | `smb2.maximum_allowed` |
