### PR TITLE
client: implement chimera_fstat (stat by open handle)

### DIFF
--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -6,7 +6,7 @@ add_library(chimera_client SHARED client.c client_dispatch.c
             client_mount.c client_umount.c
             client_open.c client_mkdir.c client_mknod.c client_close.c client_read.c client_read_into.c client_write.c
             client_symlink.c client_link.c client_remove.c client_rename.c
-            client_readlink.c client_stat.c client_readdir.c client_statfs.c
+            client_readlink.c client_stat.c client_fstat.c client_readdir.c client_statfs.c
             client_copy_range.c client_clone_range.c)
 target_link_libraries(chimera_client chimera_vfs evpl prometheus-c jansson)
 

--- a/src/client/client_fstat.c
+++ b/src/client/client_fstat.c
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "client_fstat.h"
+
+SYMBOL_EXPORT void
+chimera_fstat(
+    struct chimera_client_thread   *thread,
+    struct chimera_vfs_open_handle *handle,
+    chimera_fstat_callback_t        callback,
+    void                           *private_data)
+{
+    struct chimera_client_request *request;
+
+    request = chimera_client_request_alloc(thread);
+
+    request->opcode             = CHIMERA_CLIENT_OP_FSTAT;
+    request->fstat.handle       = handle;
+    request->fstat.callback     = callback;
+    request->fstat.private_data = private_data;
+
+    chimera_dispatch_fstat(thread, request);
+} /* chimera_fstat */

--- a/src/client/tests/CMakeLists.txt
+++ b/src/client/tests/CMakeLists.txt
@@ -55,6 +55,7 @@ set(CLIENT_TEST_PROGRAMS
     test_rename
     test_readlink
     test_stat
+    test_fstat
 )
 
 # Create test programs

--- a/src/client/tests/test_fstat.c
+++ b/src/client/tests/test_fstat.c
@@ -1,0 +1,168 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "client_test_common.h"
+
+struct fstat_ctx {
+    int                 done;
+    int                 status;
+    struct chimera_stat st;
+};
+
+static void
+fstat_callback(
+    struct chimera_client_thread *client,
+    enum chimera_vfs_error        status,
+    const struct chimera_stat    *st,
+    void                         *private_data)
+{
+    struct fstat_ctx *ctx = private_data;
+
+    ctx->status = status;
+    if (st) {
+        ctx->st = *st;
+    }
+    ctx->done = 1;
+} /* fstat_callback */
+
+struct open_ctx {
+    int                             done;
+    enum chimera_vfs_error          status;
+    struct chimera_vfs_open_handle *handle;
+};
+
+static void
+open_complete(
+    struct chimera_client_thread   *client,
+    enum chimera_vfs_error          status,
+    struct chimera_vfs_open_handle *oh,
+    void                           *private_data)
+{
+    struct open_ctx *ctx = private_data;
+
+    ctx->status = status;
+    ctx->handle = oh;
+    ctx->done   = 1;
+} /* open_complete */
+
+struct mount_ctx {
+    int done;
+    int status;
+};
+
+static void
+mount_callback(
+    struct chimera_client_thread *client,
+    enum chimera_vfs_error        status,
+    void                         *private_data)
+{
+    struct mount_ctx *ctx = private_data;
+
+    ctx->status = status;
+    ctx->done   = 1;
+} /* mount_callback */
+
+static void
+unmount_callback(
+    struct chimera_client_thread *client,
+    enum chimera_vfs_error        status,
+    void                         *private_data)
+{
+    struct mount_ctx *ctx = private_data;
+
+    ctx->status = status;
+    ctx->done   = 1;
+} /* unmount_callback */
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    struct test_env  env;
+    struct mount_ctx mount_ctx = { 0 };
+    struct open_ctx  open_ctx  = { 0 };
+    struct fstat_ctx fstat_ctx = { 0 };
+
+    client_test_init(&env, argv, argc);
+
+    client_test_mount(&env, "/test", mount_callback, &mount_ctx);
+
+    while (!mount_ctx.done) {
+        evpl_continue(env.evpl);
+    }
+
+    if (mount_ctx.status != 0) {
+        fprintf(stderr, "Failed to mount test module\n");
+        client_test_fail(&env);
+    }
+
+    /* Create a file and keep the open handle for fstat. */
+    chimera_open(env.client_thread, "/test/fstatfile", 15, CHIMERA_VFS_OPEN_CREATE,
+                 open_complete, &open_ctx);
+
+    while (!open_ctx.done) {
+        evpl_continue(env.evpl);
+    }
+
+    if (open_ctx.status != 0 || open_ctx.handle == NULL) {
+        fprintf(stderr, "Failed to create test file\n");
+        client_test_fail(&env);
+    }
+
+    /* fstat the open handle and verify the attributes. */
+    chimera_fstat(env.client_thread, open_ctx.handle, fstat_callback, &fstat_ctx);
+
+    while (!fstat_ctx.done) {
+        evpl_continue(env.evpl);
+    }
+
+    if (fstat_ctx.status != 0) {
+        fprintf(stderr, "Failed to fstat open handle: %d\n", fstat_ctx.status);
+        client_test_fail(&env);
+    }
+
+    if (fstat_ctx.st.st_uid != env.cred.uid || fstat_ctx.st.st_gid != env.cred.gid) {
+        fprintf(stderr, "fstat: expected uid=%u gid=%u, got uid=%lu gid=%lu\n",
+                env.cred.uid, env.cred.gid,
+                (unsigned long) fstat_ctx.st.st_uid,
+                (unsigned long) fstat_ctx.st.st_gid);
+        client_test_fail(&env);
+    }
+
+    if (!S_ISREG(fstat_ctx.st.st_mode)) {
+        fprintf(stderr, "fstat: expected a regular file, got mode 0%lo\n",
+                (unsigned long) fstat_ctx.st.st_mode);
+        client_test_fail(&env);
+    }
+
+    if (fstat_ctx.st.st_ino == 0) {
+        fprintf(stderr, "Warning: fstat st_ino is 0\n");
+    }
+
+    fprintf(stderr, "fstat: uid=%lu gid=%lu mode=0%lo ino=%lu (ok)\n",
+            (unsigned long) fstat_ctx.st.st_uid,
+            (unsigned long) fstat_ctx.st.st_gid,
+            (unsigned long) fstat_ctx.st.st_mode,
+            (unsigned long) fstat_ctx.st.st_ino);
+
+    chimera_close(env.client_thread, open_ctx.handle);
+
+    memset(&mount_ctx, 0, sizeof(mount_ctx));
+
+    chimera_umount(env.client_thread, "/test", unmount_callback, &mount_ctx);
+
+    while (!mount_ctx.done) {
+        evpl_continue(env.evpl);
+    }
+
+    if (mount_ctx.status != 0) {
+        fprintf(stderr, "Failed to unmount /test\n");
+        client_test_fail(&env);
+    }
+
+    client_test_success(&env);
+
+    return 0;
+} /* main */

--- a/src/client/tests/test_fstat.c
+++ b/src/client/tests/test_fstat.c
@@ -28,7 +28,7 @@ fstat_callback(
 
 struct open_ctx {
     int                             done;
-    enum chimera_vfs_error          status;
+    enum chimera_vfs_error status;
     struct chimera_vfs_open_handle *handle;
 };
 


### PR DESCRIPTION
## Problem

`chimera_fstat()` is declared in `client.h` and otherwise fully plumbed —
the `CHIMERA_CLIENT_OP_FSTAT` opcode, the `request->fstat` member, and the
`chimera_dispatch_fstat()` helper in `client_fstat.h` all exist — but the
**public entry point was never defined**. As a result `chimera_fstat` is an
undefined symbol in `libchimera_client.so`, so any consumer that links it
fails to resolve the symbol at load time (e.g. `dlopen` of a plugin that
calls it).

## Fix

Add `src/client/client_fstat.c` defining the public `chimera_fstat()`,
mirroring `chimera_stat()`: allocate a client request, populate the `fstat`
fields, and dispatch via the existing `chimera_dispatch_fstat()` (which
issues a VFS `getattr` on the open handle with `CHIMERA_VFS_ATTR_MASK_STAT`).

Add a `test_fstat` client test that opens a file and verifies the fstat'd
attributes (uid/gid match the credential, regular-file mode, nonzero inode).
Registered alongside the other client tests for all backends/users.

Verified locally: `chimera_fstat` is now exported (`nm -D`), and
`test_fstat -b memfs` passes (`uid=0 gid=0 mode=0100644 ino!=0`).

Note: `chimera_fstatfs()` has the same missing-definition gap and can be
addressed similarly in a follow-up.