### PR TITLE
nfs/pnfs: configurable DS NFS version + distinct v4.1 data-server identity

### DIFF
--- a/kvm/kvm_pnfs_test_wrapper.sh
+++ b/kvm/kvm_pnfs_test_wrapper.sh
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Unlicense
 
-# Usage: kvm_pnfs_test_wrapper.sh <vmlinuz> <rootfs.qcow2> <chimera_binary> <backend> <nfsver> <test_cmd>
+# Usage: kvm_pnfs_test_wrapper.sh <vmlinuz> <rootfs.qcow2> <chimera_binary> <backend> <nfsver> <ds_version> <test_cmd>
 #
 # Orchestrates an NFSv4.1 flex-files pNFS setup and a QEMU VM to exercise it:
 # 1. Starts a chimera *data server* (plain memfs) on 10.0.0.1:2050, exporting a
@@ -14,12 +14,17 @@
 #    portmap is needed) and steers each file's data to it.
 # 3. Boots a QEMU VM which mounts the MDS with vers=4.1 and runs the test.
 #
+# <ds_version> selects the NFS version the client uses for the direct data path
+# to the data server (advertised in ff_device_addr4.ffda_versions): "3" for the
+# NFSv3 data path, "4.1" for the NFSv4.1 data path.  The client->MDS mount is
+# always 4.1 (pNFS requires a session); ds_version is independent of it.
+#
 # On the first LAYOUTGET the MDS creates a backing file on the data server and
 # hands the client a flex-files layout pointing at the DS's native handle; the
-# client then does NFSv3 READ/WRITE straight to the data server.  memfs FHs are
-# version-independent, so the v4 control path and the v3 data path address the
-# same backing file.  A workload that reads back what it wrote proves the client
-# reached the data server via the layout.
+# client then does READ/WRITE straight to the data server over the configured
+# DS version.  memfs FHs are version-independent, so the v4 control path and the
+# v3/v4.1 data path address the same backing file.  A workload that reads back
+# what it wrote proves the client reached the data server via the layout.
 
 set -u
 
@@ -39,12 +44,19 @@ ROOTFS=$1; shift
 CHIMERA_BINARY=$1; shift
 BACKEND=$1; shift
 NFS_VERSION=$1; shift
+DS_VERSION=$1; shift
 TEST_CMD_ARG="$*"
 
 # pNFS requires NFSv4.1+.
 case "$NFS_VERSION" in
     4.1 | 4.2) ;;
     *) echo "pNFS test requires NFS 4.1+, got ${NFS_VERSION}" >&2; exit 1 ;;
+esac
+
+# The DS data path is either NFSv3 or NFSv4.1.
+case "$DS_VERSION" in
+    3 | 4.1) ;;
+    *) echo "pNFS DS version must be 3 or 4.1, got ${DS_VERSION}" >&2; exit 1 ;;
 esac
 
 INITRD="$(dirname "$VMLINUZ")/initrd"
@@ -70,8 +82,15 @@ MDS_IP="10.0.0.1"
 DS_IP="10.0.0.1"
 MDS_PORT=2049
 DS_PORT=2050
-# RFC 5665 universal address for DS_IP:2050 -> port 2050 = 8*256 + 2
-DS_UADDR="${DS_IP}.8.2"
+
+# NFSv4.1 DS I/O is session-based, and the Linux client keys its sessions on the
+# server's network address: a v4.1 DS that shares the MDS's address collides in
+# the client's transport switch ("addr already in xprt switch") and the data
+# path never comes up.  Give the v4.1 DS its own address (the v3 DS is stateless
+# and works fine co-located with the MDS, so it keeps 10.0.0.1).
+if [ "$DS_VERSION" = "4.1" ]; then
+    DS_IP="10.0.0.6"
+fi
 
 cleanup() {
     for pid in "$MDS_PID" "$DS_PID"; do
@@ -107,6 +126,10 @@ trap cleanup EXIT
 # portmap/mountd (port coexistence with the MDS) and serves READ/WRITE
 # statelessly by file handle, which is exactly what the client's direct pNFS
 # I/O needs.
+#
+# nfs_server_scope is distinct from the MDS's (default 42): for a v4.1 DS the
+# client keys server identity on EXCHANGE_ID scope, and an identical scope makes
+# it coalesce the DS with the MDS and misroute the data path.  Harmless for v3.
 generate_ds_config() {
     cat > "$DS_CONFIG" << EOF
 {
@@ -115,6 +138,7 @@ generate_ds_config() {
         "nfs_port": ${DS_PORT},
         "data_server": true,
         "external_portmap": true,
+        "nfs_server_scope": 43,
         "metrics_port": 9001
     },
     "mounts": { "ds_data": { "module": "memfs", "path": "/" } },
@@ -161,7 +185,7 @@ generate_mds_config() {
         "pnfs": {
             "enabled": true,
             "data_servers": [
-                { "netid": "tcp", "uaddr": "${DS_UADDR}", "backing_path": "/ds0" }
+                { "netid": "tcp", "uaddr": "${DS_IP}:${DS_PORT}", "version": "${DS_VERSION}", "backing_path": "/ds0" }
             ]
         }
     },
@@ -202,6 +226,9 @@ ip netns exec "${NETNS_NAME}" ip addr add 10.0.0.1/24 dev "${TAP_NAME}"
 # server address, so a guest mounting both 10.0.0.1 and 10.0.0.5 acts as two
 # distinct pNFS clients -- enough to exercise inter-client layout recall.
 ip netns exec "${NETNS_NAME}" ip addr add 10.0.0.5/24 dev "${TAP_NAME}"
+# A dedicated address for the data server so a v4.1 (session-based) DS does not
+# collide with the MDS's address in the client's transport switch.
+ip netns exec "${NETNS_NAME}" ip addr add 10.0.0.6/24 dev "${TAP_NAME}"
 ip netns exec "${NETNS_NAME}" ip link set "${TAP_NAME}" up
 
 # 1. Start the data server (must be up before the MDS, which mounts it at boot).

--- a/kvm/tests/CMakeLists.txt
+++ b/kvm/tests/CMakeLists.txt
@@ -214,15 +214,27 @@ foreach(image_spec ${KVM_IMAGES})
     # pNFS (NFSv4.1) tests: a metadata server steering data to a separate memfs
     # data server, both in one netns.  Flex-files backends only (memfs, diskfs)
     # and 4.1-only (pNFS requires a session).
-    foreach(prog ${PNFS_PROGRAMS})
-        foreach(pbackend ${PNFS_BACKENDS})
-            add_test(NAME chimera/kvm/${IMAGE_NAME}/pnfs/${prog}_${pbackend}_nfs4.1
-                COMMAND bash ${PNFS_WRAPPER}
-                        ${IMAGE_DIR}/vmlinuz ${IMAGE_DIR}/rootfs.qcow2
-                        ${CHIMERA_BINARY} ${pbackend} 4.1
-                        "${PNFS_CMD_${prog}}")
-            set_tests_properties(chimera/kvm/${IMAGE_NAME}/pnfs/${prog}_${pbackend}_nfs4.1
-                PROPERTIES LABELS "kvm;${IMAGE_NAME};pnfs" PROCESSORS 2)
+    #
+    # The client->MDS mount is always 4.1; PNFS_DS_VERSIONS selects the NFS
+    # version of the direct client->DS data path (advertised in the flex-files
+    # device's ffda_versions).  The v3 DS keeps the historical test names (no
+    # suffix); the v4.1 DS adds a "_dsv4.1" suffix.
+    set(PNFS_DS_VERSIONS 3 4.1)
+    foreach(dsver ${PNFS_DS_VERSIONS})
+        set(dssuffix "")
+        if(NOT dsver STREQUAL "3")
+            set(dssuffix "_dsv${dsver}")
+        endif()
+        foreach(prog ${PNFS_PROGRAMS})
+            foreach(pbackend ${PNFS_BACKENDS})
+                add_test(NAME chimera/kvm/${IMAGE_NAME}/pnfs/${prog}_${pbackend}_nfs4.1${dssuffix}
+                    COMMAND bash ${PNFS_WRAPPER}
+                            ${IMAGE_DIR}/vmlinuz ${IMAGE_DIR}/rootfs.qcow2
+                            ${CHIMERA_BINARY} ${pbackend} 4.1 ${dsver}
+                            "${PNFS_CMD_${prog}}")
+                set_tests_properties(chimera/kvm/${IMAGE_NAME}/pnfs/${prog}_${pbackend}_nfs4.1${dssuffix}
+                    PROPERTIES LABELS "kvm;${IMAGE_NAME};pnfs" PROCESSORS 2)
+            endforeach()
         endforeach()
     endforeach()
 

--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-only
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <signal.h>
 #include <string.h>
 #include <strings.h>
@@ -146,6 +147,50 @@ generate_self_signed_cert(
     }
     return rc;
 } /* generate_self_signed_cert */
+
+/*
+ * Translate a human-friendly pNFS data-server address into the RFC 5665
+ * universal address the flex-files layout carries on the wire.  Accepts a bare
+ * host ("10.0.0.2") or host:port ("10.0.0.2:2050"); when the port is omitted it
+ * defaults by transport -- 20049 for "rdma"/"rdma6", else 2049 (the IANA nfs /
+ * nfsrdma ports).  The wire form appends the port as two octets,
+ * "h.h.h.h.p_hi.p_lo" (port == p_hi*256 + p_lo).  Returns 0 on success.
+ */
+static int
+chimera_pnfs_uaddr_from_human(
+    const char *netid,
+    const char *human,
+    char       *out,
+    size_t      out_size)
+{
+    char        host[48];   /* bounds the universal address into out[64] */
+    const char *colon = strchr(human, ':');
+    long        port;
+
+    if (colon) {
+        size_t hlen = (size_t) (colon - human);
+        if (hlen == 0 || hlen >= sizeof(host)) {
+            return -1;
+        }
+        memcpy(host, human, hlen);
+        host[hlen] = '\0';
+        port       = strtol(colon + 1, NULL, 10);
+    } else {
+        if (snprintf(host, sizeof(host), "%s", human) >= (int) sizeof(host)) {
+            return -1;
+        }
+        port = (netid && (strcmp(netid, "rdma") == 0 || strcmp(netid, "rdma6") == 0))
+               ? 20049 : 2049;
+    }
+
+    if (port <= 0 || port > 65535) {
+        return -1;
+    }
+
+    snprintf(out, out_size, "%s.%u.%u", host,
+             (unsigned) ((port >> 8) & 0xff), (unsigned) (port & 0xff));
+    return 0;
+} /* chimera_pnfs_uaddr_from_human */
 
 int
 main(
@@ -477,6 +522,15 @@ main(
         chimera_server_config_set_nfs_port(server_config, int_value);
     }
 
+    /* NFSv4.1 server identity (EXCHANGE_ID server scope).  Set a distinct value
+     * on independent servers that do not share state -- e.g. a pNFS data server
+     * co-deployed with its MDS -- so v4.1 clients do not coalesce them. */
+    json_value = json_object_get(server_params, "nfs_server_scope");
+    if (json_is_integer(json_value)) {
+        chimera_server_config_set_nfs_server_scope(server_config,
+                                                   (uint64_t) json_integer_value(json_value));
+    }
+
     /* Data-server mode: bind only the NFSv4 service (no portmap/mount/NLM) so
      * a pNFS data server can run alongside an MDS on the same host. */
     json_value = json_object_get(server_params, "data_server");
@@ -501,10 +555,14 @@ main(
                 const char *netid_str   = json_string_value(json_object_get(ds_entry, "netid"));
                 const char *uaddr_str   = json_string_value(json_object_get(ds_entry, "uaddr"));
                 const char *backing_str = json_string_value(json_object_get(ds_entry, "backing_path"));
+                json_t     *version_val = json_object_get(ds_entry, "version");
+                char        wire_uaddr[64];
 
                 /* uaddr: the DS network address handed to clients in the
-                 * layout.  backing_path: the chimera path where this DS export
-                 * is mounted via the nfs module, under which the MDS creates
+                 * layout, given human-friendly as "host" or "host:port" and
+                 * converted to the RFC 5665 universal address below.
+                 * backing_path: the chimera path where this DS export is
+                 * mounted via the nfs module, under which the MDS creates
                  * backing files. */
                 if (!uaddr_str || !backing_str) {
                     chimera_server_error(
@@ -513,7 +571,42 @@ main(
                     continue;
                 }
 
-                chimera_server_config_add_pnfs_ds(server_config, netid_str, uaddr_str, backing_str);
+                if (!netid_str) {
+                    netid_str = "tcp";
+                }
+
+                /* "version": which NFS version the client uses to reach the DS,
+                 * advertised in ff_device_addr4.ffda_versions.  Accepts an
+                 * integer (3 / 4) or a string ("3", "4.0", "4.1").  NFSv4
+                 * defaults to minor version 1 (pNFS).  Default: NFSv3. */
+                int ds_version = 3, ds_minor = 0;
+                if (json_is_string(version_val)) {
+                    const char *vs  = json_string_value(version_val);
+                    const char *dot = strchr(vs, '.');
+                    ds_version = atoi(vs);
+                    ds_minor   = dot ? atoi(dot + 1) : (ds_version >= 4 ? 1 : 0);
+                } else if (json_is_integer(version_val)) {
+                    ds_version = (int) json_integer_value(version_val);
+                    ds_minor   = ds_version >= 4 ? 1 : 0;
+                }
+
+                if (ds_version != 3 && ds_version != 4) {
+                    chimera_server_error(
+                        "pNFS data_server[%zu] version %d unsupported (use 3 or 4); skipping",
+                        ds_i, ds_version);
+                    continue;
+                }
+
+                if (chimera_pnfs_uaddr_from_human(netid_str, uaddr_str,
+                                                  wire_uaddr, sizeof(wire_uaddr)) != 0) {
+                    chimera_server_error(
+                        "pNFS data_server[%zu] invalid uaddr \"%s\"; skipping",
+                        ds_i, uaddr_str);
+                    continue;
+                }
+
+                chimera_server_config_add_pnfs_ds(server_config, netid_str, wire_uaddr,
+                                                  backing_str, ds_version, ds_minor);
             }
         }
     }

--- a/src/server/nfs/nfs4_pnfs.c
+++ b/src/server/nfs/nfs4_pnfs.c
@@ -88,7 +88,9 @@ static uint32_t
 chimera_nfs4_encode_ff_device_addr(
     uint8_t    *buf,
     const char *netid,
-    const char *uaddr)
+    const char *uaddr,
+    uint32_t    version,
+    uint32_t    minorversion)
 {
     void *p = buf;
 
@@ -97,10 +99,11 @@ chimera_nfs4_encode_ff_device_addr(
     pnfs_put_opaque(&p, netid, strlen(netid));
     pnfs_put_opaque(&p, uaddr, strlen(uaddr));
 
-    /* ffda_versions<>: one entry advertising NFSv3, loosely coupled. */
+    /* ffda_versions<>: one entry advertising the configured NFS version
+     * (NFSv3 or NFSv4.x), loosely coupled. */
     pnfs_put_u32(&p, 1);
-    pnfs_put_u32(&p, 3);                      /* ffdv_version          */
-    pnfs_put_u32(&p, 0);                      /* ffdv_minorversion     */
+    pnfs_put_u32(&p, version);                /* ffdv_version          */
+    pnfs_put_u32(&p, minorversion);           /* ffdv_minorversion     */
     pnfs_put_u32(&p, NFS4_PNFS_STRIPE_UNIT);  /* ffdv_rsize            */
     pnfs_put_u32(&p, NFS4_PNFS_STRIPE_UNIT);  /* ffdv_wsize            */
     pnfs_put_u32(&p, 0);                      /* ffdv_tightly_coupled=false */
@@ -150,7 +153,9 @@ chimera_nfs4_getdeviceinfo(
         (ds = chimera_vfs_pnfs_find_device(vfs, args->gdia_device_id)) != NULL) {
         /* Orchestrated flex: device lives in the chimera DS table. */
         out_type = LAYOUT4_FLEX_FILES;
-        body_len = chimera_nfs4_encode_ff_device_addr(body, ds->netid, ds->uaddr);
+        body_len = chimera_nfs4_encode_ff_device_addr(body, ds->netid, ds->uaddr,
+                                                      (uint32_t) ds->version,
+                                                      (uint32_t) ds->minorversion);
     } else if (nfs_pnfs_devcache_find(&thread->shared->nfs4_pnfs_devcache,
                                       args->gdia_device_id, &dev)) {
         /* Backend-sourced: device came from a get_layout response. */
@@ -178,7 +183,9 @@ chimera_nfs4_getdeviceinfo(
                 body_len = chimera_nfs4_encode_scsi_device_addr(body, &dev);
                 break;
             default:
-                body_len = chimera_nfs4_encode_ff_device_addr(body, dev.netid, dev.uaddr);
+                /* Backend-sourced flex device: not driven by the data_servers
+                 * config, so advertise NFSv3 as before. */
+                body_len = chimera_nfs4_encode_ff_device_addr(body, dev.netid, dev.uaddr, 3, 0);
                 break;
         } /* switch */
     } else {

--- a/src/server/nfs/nfs4_proc_exchange_id.c
+++ b/src/server/nfs/nfs4_proc_exchange_id.c
@@ -168,11 +168,20 @@ chimera_nfs4_exchange_id(
     struct nfs_argop4                *argop,
     struct nfs_resop4                *resop)
 {
-    struct EXCHANGE_ID4args       *args         = &argop->opexchange_id;
-    struct EXCHANGE_ID4res        *res          = &resop->opexchange_id;
-    uint64_t                       owner_major  = 42;
-    uint64_t                       owner_minor  = 42;
-    uint64_t                       server_scope = 42;
+    struct EXCHANGE_ID4args *args = &argop->opexchange_id;
+    struct EXCHANGE_ID4res  *res  = &resop->opexchange_id;
+    /* NFSv4.1 server identity.  A client treats two server addresses as the same
+     * server (shared state, eligible for trunking) when both the server-owner
+     * major id AND the server scope match (RFC 8881 sec 2.10.5); the Linux
+     * trunking-detection path keys on the major id.  Independent chimera servers
+     * that do not share state -- e.g. a pNFS data server co-deployed with its
+     * MDS -- must therefore differ in both, or the client coalesces them and
+     * misroutes the data path.  The "nfs_server_scope" knob sets both (default
+     * 42, preserving prior behavior). */
+    uint64_t                       server_scope = chimera_server_config_get_nfs_server_scope(
+        thread->shared->config);
+    uint64_t                       owner_major = server_scope;
+    uint64_t                       owner_minor = 42;
     struct timespec                now;
     struct nfs4_client_principal   principal;
     struct nfs4_exchange_id_result eid;

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -46,6 +46,7 @@ struct chimera_server_config {
     int                                   nfs_lockmgr_port;
     int                                   nfs_port;
     int                                   nfs_data_server;
+    uint64_t                              nfs_server_scope;
     int                                   external_portmap;
     char                                  portmap_hostname[256];
     int                                   soft_fail_bad_req;
@@ -92,6 +93,8 @@ struct chimera_server_config {
         char netid[8];
         char uaddr[64];
         char backing_path[CHIMERA_PNFS_BACKING_MAX];
+        int  version;                     /* NFS version the client uses for DS I/O */
+        int  minorversion;                /* NFS minor version (4.x)                */
     }                                     pnfs_ds[CHIMERA_PNFS_MAX_DS];
 };
 
@@ -196,6 +199,15 @@ chimera_server_config_init(void)
      * service so a pNFS data server can coexist with an MDS on one host. */
     config->nfs_port        = 2049;
     config->nfs_data_server = 0;
+
+    /* NFSv4.1 server identity (EXCHANGE_ID eir_server_scope).  Clients treat two
+     * server addresses returning the same scope as the same server (shared
+     * state, eligible for trunking).  Independent chimera servers that do not
+     * share state -- e.g. a pNFS data server co-deployed with its MDS -- must
+     * advertise distinct scopes or the client coalesces them and misroutes I/O.
+     * Default preserves the historical value; override per instance via
+     * "nfs_server_scope". */
+    config->nfs_server_scope = 42;
 
     config->cache_ttl = 60;
 
@@ -529,7 +541,9 @@ chimera_server_config_add_pnfs_ds(
     struct chimera_server_config *config,
     const char                   *netid,
     const char                   *uaddr,
-    const char                   *backing_path)
+    const char                   *backing_path,
+    int                           version,
+    int                           minorversion)
 {
     struct chimera_server_config_pnfs_ds *ds;
     int                                   idx;
@@ -544,6 +558,8 @@ chimera_server_config_add_pnfs_ds(
     snprintf(ds->netid, sizeof(ds->netid), "%s", netid ? netid : "tcp");
     snprintf(ds->uaddr, sizeof(ds->uaddr), "%s", uaddr ? uaddr : "");
     snprintf(ds->backing_path, sizeof(ds->backing_path), "%s", backing_path ? backing_path : "");
+    ds->version      = version ? version : 3;
+    ds->minorversion = minorversion;
 
     return idx;
 } /* chimera_server_config_add_pnfs_ds */
@@ -575,6 +591,20 @@ chimera_server_config_get_nfs_data_server(const struct chimera_server_config *co
 {
     return config->nfs_data_server;
 } /* chimera_server_config_get_nfs_data_server */
+
+SYMBOL_EXPORT void
+chimera_server_config_set_nfs_server_scope(
+    struct chimera_server_config *config,
+    uint64_t                      scope)
+{
+    config->nfs_server_scope = scope;
+} /* chimera_server_config_set_nfs_server_scope */
+
+SYMBOL_EXPORT uint64_t
+chimera_server_config_get_nfs_server_scope(const struct chimera_server_config *config)
+{
+    return config->nfs_server_scope;
+} /* chimera_server_config_get_nfs_server_scope */
 
 SYMBOL_EXPORT void
 chimera_server_config_set_nfs_rdma_hostname(
@@ -1192,7 +1222,9 @@ chimera_server_init(
             chimera_vfs_pnfs_add_device(server->vfs,
                                         config->pnfs_ds[i].netid,
                                         config->pnfs_ds[i].uaddr,
-                                        config->pnfs_ds[i].backing_path);
+                                        config->pnfs_ds[i].backing_path,
+                                        config->pnfs_ds[i].version,
+                                        config->pnfs_ds[i].minorversion);
         }
         chimera_server_info("pNFS enabled with %d data server(s)", config->pnfs_num_ds);
     }

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -258,7 +258,9 @@ chimera_server_config_add_pnfs_ds(
     struct chimera_server_config *config,
     const char                   *netid,
     const char                   *uaddr,
-    const char                   *backing_path);
+    const char                   *backing_path,
+    int                           version,
+    int                           minorversion);
 
 /* After mounts are established, resolve each pNFS data server's backing root
  * (its nfs-mounted export directory) into the device table so the MDS can
@@ -283,6 +285,15 @@ chimera_server_config_set_nfs_data_server(
 
 int
 chimera_server_config_get_nfs_data_server(
+    const struct chimera_server_config *config);
+
+void
+chimera_server_config_set_nfs_server_scope(
+    struct chimera_server_config *config,
+    uint64_t                      scope);
+
+uint64_t
+chimera_server_config_get_nfs_server_scope(
     const struct chimera_server_config *config);
 
 void

--- a/src/vfs/vfs_pnfs.c
+++ b/src/vfs/vfs_pnfs.c
@@ -57,7 +57,9 @@ chimera_vfs_pnfs_add_device(
     struct chimera_vfs *vfs,
     const char         *netid,
     const char         *uaddr,
-    const char         *backing_path)
+    const char         *backing_path,
+    int                 version,
+    int                 minorversion)
 {
     struct chimera_vfs_pnfs *pnfs = vfs->pnfs;
     struct chimera_vfs_ds   *ds;
@@ -80,6 +82,8 @@ chimera_vfs_pnfs_add_device(
     snprintf(ds->netid, sizeof(ds->netid), "%s", netid ? netid : "tcp");
     snprintf(ds->uaddr, sizeof(ds->uaddr), "%s", uaddr ? uaddr : "");
     snprintf(ds->backing_path, sizeof(ds->backing_path), "%s", backing_path ? backing_path : "");
+    ds->version      = version ? version : 3;
+    ds->minorversion = minorversion;
 
     ds->root_fh_len = 0;
 

--- a/src/vfs/vfs_pnfs.h
+++ b/src/vfs/vfs_pnfs.h
@@ -105,6 +105,8 @@ struct chimera_vfs_ds {
     uint8_t  deviceid[CHIMERA_VFS_DEVICEID_SIZE]; /* stable id advertised to clients */
     char     netid[8];                            /* RFC5665 netid, e.g. "tcp"       */
     char     uaddr[64];                           /* RFC5665 universal address (DS)  */
+    int      version;                             /* NFS version advertised for DS   */
+    int      minorversion;                        /* NFS minor version (4.x)         */
     char     backing_path[CHIMERA_PNFS_BACKING_MAX]; /* chimera path where the DS is
                                                       * nfs-mounted, e.g. "/ds0"     */
     /* Resolved once the backing mount is established: the DS export root as an
@@ -148,7 +150,9 @@ int chimera_vfs_pnfs_add_device(
     struct chimera_vfs *vfs,
     const char         *netid,
     const char         *uaddr,
-    const char         *backing_path);
+    const char         *backing_path,
+    int                 version,
+    int                 minorversion);
 
 /* Record the resolved DS backing-root file handle for device idx. */
 void chimera_vfs_pnfs_set_device_root(


### PR DESCRIPTION
## Summary

Makes the pNFS flex-files data-server table friendlier to configure, lets a data server use an **NFSv4.1** data path (not just NFSv3), and fixes the server-identity collision that prevented a v4.1 DS from working.

- **Human-friendly `uaddr`.** `data_servers[].uaddr` now accepts a bare host (`10.0.0.2`) or `host:port` (`10.0.0.2:2050`) and is converted to the RFC 5665 universal address (`h.h.h.h.p_hi.p_lo`) at config-load time. When the port is omitted it defaults by transport: **20049 for `rdma`/`rdma6`, else 2049**.

- **Per-DS NFS `version`.** `data_servers[].version` (`3`, or `"4.1"`/`4`) selects the NFS version the client uses for the direct client→DS data path, driving `ff_device_addr4.ffda_versions` (`ffdv_version`/`ffdv_minorversion`) instead of the previously hardcoded NFSv3. Default remains NFSv3, so existing configs are unchanged on the wire.

- **`nfs_server_scope` knob (the fix).** A session-based NFSv4.1 data server that advertises the *same* NFSv4.1 server identity as the MDS gets coalesced by the Linux flex-files client — the client's trunking detection keys on `so_major_id`, sees a match, folds the DS transport into the MDS session (`addr already in xprt switch`), and misroutes DS I/O back to the MDS (which holds no data for pNFS files), truncating read-back to a single page. The new `nfs_server_scope` knob sets **both** `so_major_id` and `server_scope` in the EXCHANGE_ID reply (default `42`, preserving prior behavior); giving a data server a distinct value makes the client treat it as its own server. (A v3 DS is stateless/filehandle-keyed and is unaffected — it works co-located on the MDS's address and identity.)

## Implementation

- `daemon.c` — parse human-friendly `uaddr` + convert; parse `version`; parse `nfs_server_scope`.
- `server.{c,h}` — `nfs_server_scope` config field + accessors; `version`/`minorversion` on the pNFS DS config entry.
- `vfs_pnfs.{c,h}` — carry `version`/`minorversion` on `chimera_vfs_ds`.
- `nfs4_pnfs.c` — encode `ffdv_version`/`ffdv_minorversion` from the DS entry (backend-sourced flex devices keep advertising NFSv3).
- `nfs4_proc_exchange_id.c` — derive `so_major_id` and `server_scope` from the knob.

## Tests

`kvm/kvm_pnfs_test_wrapper.sh` gains a `<ds_version>` argument (and a dedicated DS address + distinct `nfs_server_scope` for the v4.1 case); `kvm/tests/CMakeLists.txt` runs the full flex-files workload matrix (`rw`, `recall_truncate`, `recall_truncate_xclient`, `remove`) against both a v3 and a v4.1 data server across memfs and both diskfs backends. All 24 pNFS KVM tests pass locally.