### PR TITLE
client: implement chimera_commit, chimera_ftruncate, chimera_fstatfs

### DIFF
--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(chimera_client SHARED client.c client_dispatch.c
             client_open.c client_mkdir.c client_mknod.c client_close.c client_read.c client_read_into.c client_write.c
             client_symlink.c client_link.c client_remove.c client_rename.c
             client_readlink.c client_stat.c client_fstat.c client_readdir.c client_statfs.c
+            client_fstatfs.c client_commit.c client_ftruncate.c
             client_copy_range.c client_clone_range.c)
 target_link_libraries(chimera_client chimera_vfs evpl prometheus-c jansson)
 

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -444,10 +444,27 @@ typedef void (*chimera_fsetattr_callback_t)(
     enum chimera_vfs_error        status,
     void                         *private_data);
 
+/* Set the size of an open file (ftruncate). */
+void
+chimera_ftruncate(
+    struct chimera_client_thread   *thread,
+    struct chimera_vfs_open_handle *handle,
+    uint64_t                        size,
+    chimera_fsetattr_callback_t     callback,
+    void                           *private_data);
+
 typedef void (*chimera_commit_callback_t)(
     struct chimera_client_thread *client,
     enum chimera_vfs_error        status,
     void                         *private_data);
+
+/* Flush an open file's data to stable storage (fsync). */
+void
+chimera_commit(
+    struct chimera_client_thread   *thread,
+    struct chimera_vfs_open_handle *handle,
+    chimera_commit_callback_t       callback,
+    void                           *private_data);
 
 typedef void (*chimera_lock_callback_t)(
     struct chimera_client_thread *client,

--- a/src/client/client_commit.c
+++ b/src/client/client_commit.c
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "client_commit.h"
+
+SYMBOL_EXPORT void
+chimera_commit(
+    struct chimera_client_thread   *thread,
+    struct chimera_vfs_open_handle *handle,
+    chimera_commit_callback_t       callback,
+    void                           *private_data)
+{
+    struct chimera_client_request *request;
+
+    request = chimera_client_request_alloc(thread);
+
+    request->opcode              = CHIMERA_CLIENT_OP_COMMIT;
+    request->commit.handle       = handle;
+    request->commit.callback     = callback;
+    request->commit.private_data = private_data;
+
+    chimera_dispatch_commit(thread, request);
+} /* chimera_commit */

--- a/src/client/client_fstatfs.c
+++ b/src/client/client_fstatfs.c
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "client_fstatfs.h"
+
+SYMBOL_EXPORT void
+chimera_fstatfs(
+    struct chimera_client_thread   *thread,
+    struct chimera_vfs_open_handle *handle,
+    chimera_fstatfs_callback_t      callback,
+    void                           *private_data)
+{
+    struct chimera_client_request *request;
+
+    request = chimera_client_request_alloc(thread);
+
+    request->opcode               = CHIMERA_CLIENT_OP_FSTATFS;
+    request->fstatfs.handle       = handle;
+    request->fstatfs.callback     = callback;
+    request->fstatfs.private_data = private_data;
+
+    chimera_dispatch_fstatfs(thread, request);
+} /* chimera_fstatfs */

--- a/src/client/client_ftruncate.c
+++ b/src/client/client_ftruncate.c
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "client_fsetattr.h"
+
+/*
+ * Set the size of an open file (ftruncate). Implemented as an fsetattr that sets
+ * only the size attribute, mirroring how the POSIX layer's chimera_posix_ftruncate
+ * drives the same dispatch helper.
+ */
+SYMBOL_EXPORT void
+chimera_ftruncate(
+    struct chimera_client_thread   *thread,
+    struct chimera_vfs_open_handle *handle,
+    uint64_t                        size,
+    chimera_fsetattr_callback_t     callback,
+    void                           *private_data)
+{
+    struct chimera_client_request *request;
+
+    request = chimera_client_request_alloc(thread);
+
+    request->opcode                = CHIMERA_CLIENT_OP_FSETATTR;
+    request->fsetattr.handle       = handle;
+    request->fsetattr.callback     = callback;
+    request->fsetattr.private_data = private_data;
+
+    request->fsetattr.set_attr.va_req_mask = 0;
+    request->fsetattr.set_attr.va_set_mask = CHIMERA_VFS_ATTR_SIZE;
+    request->fsetattr.set_attr.va_size     = size;
+
+    chimera_dispatch_fsetattr(thread, request);
+} /* chimera_ftruncate */

--- a/src/client/tests/CMakeLists.txt
+++ b/src/client/tests/CMakeLists.txt
@@ -56,6 +56,7 @@ set(CLIENT_TEST_PROGRAMS
     test_readlink
     test_stat
     test_fstat
+    test_ftruncate
 )
 
 # Create test programs

--- a/src/client/tests/test_ftruncate.c
+++ b/src/client/tests/test_ftruncate.c
@@ -1,0 +1,212 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "client_test_common.h"
+
+struct op_ctx {
+    int done;
+    enum chimera_vfs_error status;
+};
+
+struct fstat_ctx {
+    int                 done;
+    enum chimera_vfs_error status;
+    struct chimera_stat st;
+};
+
+struct statfs_ctx {
+    int                    done;
+    enum chimera_vfs_error status;
+    struct chimera_statvfs st;
+};
+
+struct open_ctx {
+    int                             done;
+    enum chimera_vfs_error status;
+    struct chimera_vfs_open_handle *handle;
+};
+
+static void
+op_callback(
+    struct chimera_client_thread *client,
+    enum chimera_vfs_error        status,
+    void                         *private_data)
+{
+    struct op_ctx *ctx = private_data;
+
+    ctx->status = status;
+    ctx->done   = 1;
+} /* op_callback */
+
+static void
+fstat_callback(
+    struct chimera_client_thread *client,
+    enum chimera_vfs_error        status,
+    const struct chimera_stat    *st,
+    void                         *private_data)
+{
+    struct fstat_ctx *ctx = private_data;
+
+    ctx->status = status;
+    if (st) {
+        ctx->st = *st;
+    }
+    ctx->done = 1;
+} /* fstat_callback */
+
+static void
+statfs_callback(
+    struct chimera_client_thread *client,
+    enum chimera_vfs_error        status,
+    const struct chimera_statvfs *st,
+    void                         *private_data)
+{
+    struct statfs_ctx *ctx = private_data;
+
+    ctx->status = status;
+    if (st) {
+        ctx->st = *st;
+    }
+    ctx->done = 1;
+} /* statfs_callback */
+
+static void
+open_complete(
+    struct chimera_client_thread   *client,
+    enum chimera_vfs_error          status,
+    struct chimera_vfs_open_handle *oh,
+    void                           *private_data)
+{
+    struct open_ctx *ctx = private_data;
+
+    ctx->status = status;
+    ctx->handle = oh;
+    ctx->done   = 1;
+} /* open_complete */
+
+struct mount_ctx {
+    int done;
+    int status;
+};
+
+static void
+mount_callback(
+    struct chimera_client_thread *client,
+    enum chimera_vfs_error        status,
+    void                         *private_data)
+{
+    struct mount_ctx *ctx = private_data;
+
+    ctx->status = status;
+    ctx->done   = 1;
+} /* mount_callback */
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    struct test_env   env;
+    struct mount_ctx  mount_ctx  = { 0 };
+    struct open_ctx   open_ctx   = { 0 };
+    struct op_ctx     op_ctx     = { 0 };
+    struct fstat_ctx  fstat_ctx  = { 0 };
+    struct statfs_ctx statfs_ctx = { 0 };
+    const uint64_t    new_size   = 1048576; /* 1 MiB */
+
+    client_test_init(&env, argv, argc);
+
+    client_test_mount(&env, "/test", mount_callback, &mount_ctx);
+
+    while (!mount_ctx.done) {
+        evpl_continue(env.evpl);
+    }
+
+    if (mount_ctx.status != 0) {
+        fprintf(stderr, "Failed to mount test module\n");
+        client_test_fail(&env);
+    }
+
+    /* Create a file. */
+    chimera_open(env.client_thread, "/test/ftruncfile", 16, CHIMERA_VFS_OPEN_CREATE,
+                 open_complete, &open_ctx);
+
+    while (!open_ctx.done) {
+        evpl_continue(env.evpl);
+    }
+
+    if (open_ctx.status != 0 || open_ctx.handle == NULL) {
+        fprintf(stderr, "Failed to create test file\n");
+        client_test_fail(&env);
+    }
+
+    /* ftruncate to new_size, then fstat to verify the size took effect. */
+    chimera_ftruncate(env.client_thread, open_ctx.handle, new_size, op_callback, &op_ctx);
+
+    while (!op_ctx.done) {
+        evpl_continue(env.evpl);
+    }
+
+    if (op_ctx.status != 0) {
+        fprintf(stderr, "ftruncate failed: %d\n", op_ctx.status);
+        client_test_fail(&env);
+    }
+
+    chimera_fstat(env.client_thread, open_ctx.handle, fstat_callback, &fstat_ctx);
+
+    while (!fstat_ctx.done) {
+        evpl_continue(env.evpl);
+    }
+
+    if (fstat_ctx.status != 0) {
+        fprintf(stderr, "fstat after ftruncate failed: %d\n", fstat_ctx.status);
+        client_test_fail(&env);
+    }
+
+    if (fstat_ctx.st.st_size != new_size) {
+        fprintf(stderr, "ftruncate: expected size %lu, got %lu\n",
+                (unsigned long) new_size, (unsigned long) fstat_ctx.st.st_size);
+        client_test_fail(&env);
+    }
+
+    fprintf(stderr, "ftruncate: size=%lu (ok)\n", (unsigned long) fstat_ctx.st.st_size);
+
+    /* commit (fsync) the file. */
+    memset(&op_ctx, 0, sizeof(op_ctx));
+
+    chimera_commit(env.client_thread, open_ctx.handle, op_callback, &op_ctx);
+
+    while (!op_ctx.done) {
+        evpl_continue(env.evpl);
+    }
+
+    if (op_ctx.status != 0) {
+        fprintf(stderr, "commit failed: %d\n", op_ctx.status);
+        client_test_fail(&env);
+    }
+
+    fprintf(stderr, "commit: ok\n");
+
+    /* fstatfs on the open handle. */
+    chimera_fstatfs(env.client_thread, open_ctx.handle, statfs_callback, &statfs_ctx);
+
+    while (!statfs_ctx.done) {
+        evpl_continue(env.evpl);
+    }
+
+    if (statfs_ctx.status != 0) {
+        fprintf(stderr, "fstatfs failed: %d\n", statfs_ctx.status);
+        client_test_fail(&env);
+    }
+
+    fprintf(stderr, "fstatfs: f_bsize=%lu f_blocks=%lu (ok)\n",
+            (unsigned long) statfs_ctx.st.f_bsize,
+            (unsigned long) statfs_ctx.st.f_blocks);
+
+    chimera_close(env.client_thread, open_ctx.handle);
+
+    client_test_success(&env);
+
+    return 0;
+} /* main */


### PR DESCRIPTION
Follow-up to #639 (`chimera_fstat`). Three more public client entry points were
declared and/or fully plumbed — the `CHIMERA_CLIENT_OP_*` opcodes, the
`request->{commit,fsetattr,fstatfs}` members, and the
`chimera_dispatch_{commit,fsetattr,fstatfs}` helpers all exist — but the public
functions were **never defined**, so they were undefined symbols in
`libchimera_client.so` (the same gap #639 fixed for `chimera_fstat`).

## Changes
Define them, mirroring `client_stat.c` / `client_fstat.c`:
- **`chimera_commit(handle, …)`** — flush an open file to stable storage (fsync),
  via `chimera_dispatch_commit`.
- **`chimera_ftruncate(handle, size, …)`** — set an open file's size, via an
  fsetattr that sets only `CHIMERA_VFS_ATTR_SIZE` (the same shape
  `chimera_posix_ftruncate` already uses).
- **`chimera_fstatfs(handle, …)`** — filesystem stats by open handle (already
  declared in `client.h`), via `chimera_dispatch_fstatfs`.

Declares `chimera_commit` / `chimera_ftruncate` in `client.h` (`chimera_fstatfs`
already was). Adds a `test_ftruncate` client test: ftruncate a file, fstat to
confirm the new size, then commit and fstatfs the handle.

## Why
These complete the async client API the elbencho backend plugin (#642) needs for
its fsync / truncate / preallocate backend operations; they're also generally
useful client API completions. Verified locally: all three symbols now export
(`nm -D`) and `test_ftruncate -b memfs` passes.