### PR TITLE
nfs/pnfs: support a co-located (local-backing) data server + LAYOUTERROR + dump names

### DIFF
--- a/kvm/kvm_pnfs_test_wrapper.sh
+++ b/kvm/kvm_pnfs_test_wrapper.sh
@@ -45,6 +45,7 @@ CHIMERA_BINARY=$1; shift
 BACKEND=$1; shift
 NFS_VERSION=$1; shift
 DS_VERSION=$1; shift
+TOPOLOGY=$1; shift
 TEST_CMD_ARG="$*"
 
 # pNFS requires NFSv4.1+.
@@ -57,6 +58,25 @@ esac
 case "$DS_VERSION" in
     3 | 4.1) ;;
     *) echo "pNFS DS version must be 3 or 4.1, got ${DS_VERSION}" >&2; exit 1 ;;
+esac
+
+# Topology:
+#   split    - a dedicated data-server daemon, reached by the MDS over the nfs
+#              proxy module (the backing handle is proxy-wrapped).
+#   combined - one daemon is both MDS and DS, backed by a LOCAL mount (no nfs
+#              proxy); exercises the local-backing layout path where the DS
+#              handle is the backing handle as-is.  v3 data path only (a v4.1 DS
+#              at the MDS's own address/identity would be coalesced by the
+#              client).
+case "$TOPOLOGY" in
+    split) ;;
+    combined)
+        if [ "$DS_VERSION" != "3" ]; then
+            echo "combined topology supports only ds_version=3, got ${DS_VERSION}" >&2
+            exit 1
+        fi
+        ;;
+    *) echo "topology must be split or combined, got ${TOPOLOGY}" >&2; exit 1 ;;
 esac
 
 INITRD="$(dirname "$VMLINUZ")/initrd"
@@ -198,6 +218,54 @@ generate_mds_config() {
 EOF
 }
 
+# Combined topology: one daemon is both the MDS and its own data server, backed
+# by a LOCAL mount (data_servers backing_path "/share" -> the local "share"
+# mount, not the nfs proxy).  The MDS creates backing files locally and serves
+# the client's direct v3 DS I/O itself, so the layout must hand the client the
+# backing handle as-is (no proxy wrapper to strip) -- the local-backing path.
+generate_combined_config() {
+    local module="$BACKEND"
+    local vfs_section=""
+
+    case "$BACKEND" in
+        memfs) ;;
+        diskfs_io_uring | diskfs_aio)
+            local device_type="io_uring"
+            [ "$BACKEND" = "diskfs_aio" ] && device_type="libaio"
+            local devices_json=""
+            for i in 0 1; do
+                local device_path="${SESSION_DIR}/mds-device-${i}.img"
+                truncate -s 16G "$device_path"
+                [ "$i" -gt 0 ] && devices_json="${devices_json},"
+                devices_json="${devices_json}{\"type\":\"${device_type}\",\"size\":1,\"path\":\"${device_path}\"}"
+            done
+            module="diskfs"
+            vfs_section="\"vfs\": { \"diskfs\": { \"config\": { \"initialize\": true, \"unsafe_async\": true, \"devices\": [${devices_json}] } } },"
+            ;;
+        *) echo "pNFS flex test supports memfs/diskfs backends, got ${BACKEND}" >&2; exit 1 ;;
+    esac
+
+    cat > "$MDS_CONFIG" << EOF
+{
+    "server": {
+        "threads": 4,
+        "external_portmap": false,
+        ${vfs_section}
+        "pnfs": {
+            "enabled": true,
+            "data_servers": [
+                { "netid": "tcp", "uaddr": "${MDS_IP}:${MDS_PORT}", "version": "3", "backing_path": "/share" }
+            ]
+        }
+    },
+    "mounts": {
+        "share": { "module": "${module}", "path": "/" }
+    },
+    "exports": { "/share": { "path": "/share" } }
+}
+EOF
+}
+
 wait_for_port() {
     local ip="$1" port="$2" pid="$3"
     for i in $(seq 1 50); do
@@ -231,15 +299,20 @@ ip netns exec "${NETNS_NAME}" ip addr add 10.0.0.5/24 dev "${TAP_NAME}"
 ip netns exec "${NETNS_NAME}" ip addr add 10.0.0.6/24 dev "${TAP_NAME}"
 ip netns exec "${NETNS_NAME}" ip link set "${TAP_NAME}" up
 
-# 1. Start the data server (must be up before the MDS, which mounts it at boot).
-generate_ds_config
-ip netns exec "${NETNS_NAME}" "$CHIMERA_BINARY" -c "$DS_CONFIG" > "$DS_LOG" 2>&1 &
-DS_PID=$!
-wait_for_port "$DS_IP" "$DS_PORT" "$DS_PID" || exit 1
-echo "=== pNFS data server up on ${DS_IP}:${DS_PORT} ==="
+if [ "$TOPOLOGY" = "split" ]; then
+    # 1. Start the data server (must be up before the MDS, which mounts it at boot).
+    generate_ds_config
+    ip netns exec "${NETNS_NAME}" "$CHIMERA_BINARY" -c "$DS_CONFIG" > "$DS_LOG" 2>&1 &
+    DS_PID=$!
+    wait_for_port "$DS_IP" "$DS_PORT" "$DS_PID" || exit 1
+    echo "=== pNFS data server up on ${DS_IP}:${DS_PORT} ==="
 
-# 2. Start the metadata server; it nfs-mounts the data server at boot.
-generate_mds_config
+    # 2. Start the metadata server; it nfs-mounts the data server at boot.
+    generate_mds_config
+else
+    # Combined: a single daemon is both MDS and its own (local-backed) DS.
+    generate_combined_config
+fi
 ip netns exec "${NETNS_NAME}" "$CHIMERA_BINARY" -c "$MDS_CONFIG" > "$MDS_LOG" 2>&1 &
 MDS_PID=$!
 wait_for_port "$MDS_IP" "$MDS_PORT" "$MDS_PID" || exit 1

--- a/kvm/tests/CMakeLists.txt
+++ b/kvm/tests/CMakeLists.txt
@@ -230,11 +230,28 @@ foreach(image_spec ${KVM_IMAGES})
                 add_test(NAME chimera/kvm/${IMAGE_NAME}/pnfs/${prog}_${pbackend}_nfs4.1${dssuffix}
                     COMMAND bash ${PNFS_WRAPPER}
                             ${IMAGE_DIR}/vmlinuz ${IMAGE_DIR}/rootfs.qcow2
-                            ${CHIMERA_BINARY} ${pbackend} 4.1 ${dsver}
+                            ${CHIMERA_BINARY} ${pbackend} 4.1 ${dsver} split
                             "${PNFS_CMD_${prog}}")
                 set_tests_properties(chimera/kvm/${IMAGE_NAME}/pnfs/${prog}_${pbackend}_nfs4.1${dssuffix}
                     PROPERTIES LABELS "kvm;${IMAGE_NAME};pnfs" PROCESSORS 2)
             endforeach()
+        endforeach()
+    endforeach()
+
+    # Combined topology: one daemon is both MDS and its own data server, backed
+    # by a LOCAL mount rather than the nfs proxy.  This exercises the
+    # local-backing layout path (the DS handle handed to the client is the
+    # backing handle as-is); a v3 data path, since the self-DS shares the MDS's
+    # address.  Named with a "_combined" suffix.
+    foreach(prog ${PNFS_PROGRAMS})
+        foreach(pbackend ${PNFS_BACKENDS})
+            add_test(NAME chimera/kvm/${IMAGE_NAME}/pnfs/${prog}_${pbackend}_nfs4.1_combined
+                COMMAND bash ${PNFS_WRAPPER}
+                        ${IMAGE_DIR}/vmlinuz ${IMAGE_DIR}/rootfs.qcow2
+                        ${CHIMERA_BINARY} ${pbackend} 4.1 3 combined
+                        "${PNFS_CMD_${prog}}")
+            set_tests_properties(chimera/kvm/${IMAGE_NAME}/pnfs/${prog}_${pbackend}_nfs4.1_combined
+                PROPERTIES LABELS "kvm;${IMAGE_NAME};pnfs" PROCESSORS 2)
         endforeach()
     endforeach()
 

--- a/src/server/nfs/nfs4_dump.c
+++ b/src/server/nfs/nfs4_dump.c
@@ -280,6 +280,106 @@ _nfs4_dump_compound(
                                   req, i + 1, args->num_argarray);
                 break;
 
+            case OP_SECINFO:
+                chimera_nfs_debug("NFS4 Request %p: %02d/%02d SecInfo",
+                                  req, i + 1, args->num_argarray);
+                break;
+
+            case OP_BACKCHANNEL_CTL:
+                chimera_nfs_debug("NFS4 Request %p: %02d/%02d BackchannelCtl",
+                                  req, i + 1, args->num_argarray);
+                break;
+
+            case OP_BIND_CONN_TO_SESSION:
+                chimera_nfs_debug("NFS4 Request %p: %02d/%02d BindConnToSession",
+                                  req, i + 1, args->num_argarray);
+                break;
+
+            case OP_FREE_STATEID:
+                chimera_nfs_debug("NFS4 Request %p: %02d/%02d FreeStateId",
+                                  req, i + 1, args->num_argarray);
+                break;
+
+            case OP_SET_SSV:
+                chimera_nfs_debug("NFS4 Request %p: %02d/%02d SetSSV",
+                                  req, i + 1, args->num_argarray);
+                break;
+
+            case OP_GETDEVICEINFO:
+                chimera_nfs_debug("NFS4 Request %p: %02d/%02d GetDeviceInfo",
+                                  req, i + 1, args->num_argarray);
+                break;
+
+            case OP_GETDEVICELIST:
+                chimera_nfs_debug("NFS4 Request %p: %02d/%02d GetDeviceList",
+                                  req, i + 1, args->num_argarray);
+                break;
+
+            case OP_LAYOUTGET:
+                chimera_nfs_debug("NFS4 Request %p: %02d/%02d LayoutGet",
+                                  req, i + 1, args->num_argarray);
+                break;
+
+            case OP_LAYOUTCOMMIT:
+                chimera_nfs_debug("NFS4 Request %p: %02d/%02d LayoutCommit",
+                                  req, i + 1, args->num_argarray);
+                break;
+
+            case OP_LAYOUTRETURN:
+                chimera_nfs_debug("NFS4 Request %p: %02d/%02d LayoutReturn",
+                                  req, i + 1, args->num_argarray);
+                break;
+
+            case OP_LAYOUTSTATS:
+                chimera_nfs_debug("NFS4 Request %p: %02d/%02d LayoutStats",
+                                  req, i + 1, args->num_argarray);
+                break;
+
+            case OP_LAYOUTERROR:
+                chimera_nfs_debug("NFS4 Request %p: %02d/%02d LayoutError",
+                                  req, i + 1, args->num_argarray);
+                break;
+
+            case OP_ALLOCATE:
+                chimera_nfs_debug("NFS4 Request %p: %02d/%02d Allocate",
+                                  req, i + 1, args->num_argarray);
+                break;
+
+            case OP_DEALLOCATE:
+                chimera_nfs_debug("NFS4 Request %p: %02d/%02d Deallocate",
+                                  req, i + 1, args->num_argarray);
+                break;
+
+            case OP_COPY:
+                chimera_nfs_debug("NFS4 Request %p: %02d/%02d Copy",
+                                  req, i + 1, args->num_argarray);
+                break;
+
+            case OP_SEEK:
+                chimera_nfs_debug("NFS4 Request %p: %02d/%02d Seek",
+                                  req, i + 1, args->num_argarray);
+                break;
+
+            case OP_GETXATTR:
+                chimera_nfs_debug("NFS4 Request %p: %02d/%02d GetXattr",
+                                  req, i + 1, args->num_argarray);
+                break;
+
+            case OP_SETXATTR:
+                chimera_nfs_debug("NFS4 Request %p: %02d/%02d SetXattr",
+                                  req, i + 1, args->num_argarray);
+                break;
+
+            case OP_LISTXATTRS:
+                chimera_nfs_debug("NFS4 Request %p: %02d/%02d ListXattrs",
+                                  req, i + 1, args->num_argarray);
+                break;
+
+            case OP_REMOVEXATTR:
+                chimera_nfs_debug("NFS4 Request %p: %02d/%02d RemoveXattr",
+                                  req, i + 1, args->num_argarray);
+                break;
+
             default:
                 chimera_nfs_debug("NFS4 Request %p: %02d/%02d Unknown op=%d",
                                   req, i + 1, args->num_argarray,

--- a/src/server/nfs/nfs4_pnfs.c
+++ b/src/server/nfs/nfs4_pnfs.c
@@ -521,13 +521,28 @@ ff_lg_emit(struct ff_layoutget_ctx *ctx)
         return;
     }
 
-    /* Unpack [deviceid][backing-fh-len][backing-fh]; recover the DS's native v3
-     * handle by skipping the nfs-module prefix. */
+    /* Unpack [deviceid][backing-fh-len][backing-fh]. */
     deviceid       = ctx->blob;
     backing_fh_len = ctx->blob[CHIMERA_VFS_DEVICEID_SIZE];
     backing_fh     = ctx->blob + CHIMERA_VFS_DEVICEID_SIZE + 1;
-    native_fh      = backing_fh + FF_BLOB_FH_SKIP;
-    native_fh_len  = backing_fh_len - FF_BLOB_FH_SKIP;
+
+    /* Recover the handle the client will use against the data server.  A remote
+     * DS is reached through the nfs proxy module, so the backing handle is the
+     * proxy's [mount-id][...] wrapper around the DS's native handle -- skip the
+     * wrapper.  A *local* DS (the MDS is also a data server, backed by a local
+     * mount) is served by this same server over NFS, so the DS handle IS the
+     * backing handle as stored -- skipping would corrupt it (see backing_local
+     * in chimera_server_pnfs_resolve). */
+    const struct chimera_vfs_ds *ds =
+        chimera_vfs_pnfs_find_device(req->thread->shared->vfs, deviceid);
+
+    if (ds && ds->backing_local) {
+        native_fh     = backing_fh;
+        native_fh_len = backing_fh_len;
+    } else {
+        native_fh     = backing_fh + FF_BLOB_FH_SKIP;
+        native_fh_len = backing_fh_len - FF_BLOB_FH_SKIP;
+    }
 
     client_short_id = (uint32_t) client->client_id;
 
@@ -651,9 +666,18 @@ ff_lg_dsroot_cb(
     /* One backing file per MDS file, named by its fileid (flat on the DS). */
     snprintf(ctx->backing_name, sizeof(ctx->backing_name), "%016lx", ctx->fileid);
 
+    /* Backing files are internal data containers; real access control is the
+     * client's OPEN against the MDS metadata file.  flex-files steers DS I/O
+     * with synthetic, per-iomode principals (ffds_user "0" for RW, "1" for
+     * READ), so the backing object must be reachable by both.  A dedicated DS
+     * in data_server mode serves them statelessly (bypassing the permission
+     * check), but a co-located DS (the MDS is also the data server, local
+     * backing) enforces it -- with mode 0600/owner-root the synthetic READ
+     * principal is denied and the client spins re-fetching the layout.  Create
+     * them world-rw so both topologies work. */
     memset(&ctx->set_attr, 0, sizeof(ctx->set_attr));
     ctx->set_attr.va_set_mask = CHIMERA_VFS_ATTR_MODE;
-    ctx->set_attr.va_mode     = S_IFREG | 0600;
+    ctx->set_attr.va_mode     = S_IFREG | 0666;
 
     chimera_vfs_open_at(req->thread->vfs_thread, &req->cred, ctx->ds_root_handle,
                         ctx->backing_name, strlen(ctx->backing_name),
@@ -1057,6 +1081,30 @@ chimera_nfs4_layoutstats(
     }
     chimera_nfs4_compound_complete(req, res->lsr_status);
 } /* chimera_nfs4_layoutstats */
+
+void
+chimera_nfs4_layouterror(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_request               *req,
+    struct nfs_argop4                *argop,
+    struct nfs_resop4                *resop)
+{
+    struct LAYOUTERROR4res *res = &resop->oplayouterror;
+
+    (void) argop;
+
+    /* LAYOUTERROR (RFC 7862 §15.x, used by flex-files RFC 8435 §6) lets the
+     * client report a data-server I/O error to the MDS so it can, e.g., pick a
+     * different mirror.  Chimera hands out a single-mirror layout and does not
+     * yet act on the report, so accept and acknowledge rather than returning
+     * NFS4ERR_NOTSUPP (which makes the client re-report). */
+    if (!chimera_vfs_pnfs_feature_enabled(thread->shared->vfs)) {
+        res->ler_status = NFS4ERR_NOTSUPP;
+    } else {
+        res->ler_status = NFS4_OK;
+    }
+    chimera_nfs4_compound_complete(req, res->ler_status);
+} /* chimera_nfs4_layouterror */
 
 static void
 chimera_nfs4_layoutcommit_setattr_complete(

--- a/src/server/nfs/nfs4_proc_compound.c
+++ b/src/server/nfs/nfs4_proc_compound.c
@@ -557,6 +557,9 @@ chimera_nfs4_compound_process(
                 case OP_LAYOUTSTATS:
                     chimera_nfs4_layoutstats(thread, req, argop, resop);
                     break;
+                case OP_LAYOUTERROR:
+                    chimera_nfs4_layouterror(thread, req, argop, resop);
+                    break;
                 case OP_GETDEVICELIST:
                     chimera_nfs4_getdevicelist(thread, req, argop, resop);
                     break;

--- a/src/server/nfs/nfs4_procs.h
+++ b/src/server/nfs/nfs4_procs.h
@@ -527,6 +527,13 @@ chimera_nfs4_layoutstats(
     struct nfs_resop4                *resop);
 
 void
+chimera_nfs4_layouterror(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_request               *req,
+    struct nfs_argop4                *argop,
+    struct nfs_resop4                *resop);
+
+void
 chimera_nfs4_getxattr(
     struct chimera_server_nfs_thread *thread,
     struct nfs_request               *req,

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -1061,10 +1061,19 @@ chimera_server_pnfs_resolve(struct chimera_server *server)
         }
 
         chimera_vfs_pnfs_set_device_root(vfs, i, m->root_fh, m->root_fh_len);
-        chimera_server_info("pNFS data server %d backing root resolved via '%s' (module=%s path=%s root_fh_len=%d)",
-                            i, ds->backing_path,
-                            m->module ? m->module->name : "?",
-                            m->path ? m->path : "?", m->root_fh_len);
+
+        /* If the backing mount is not the nfs proxy, the data server is local
+         * to this node: this server itself serves the backing handle, so the
+         * handle handed to the client is the backing handle as-is (no proxy
+         * wrapper to strip).  See chimera_nfs4_encode_ff_layout callers. */
+        ds->backing_local = (m->module &&
+                             m->module->fh_magic != CHIMERA_VFS_FH_MAGIC_NFS) ? 1 : 0;
+
+        chimera_server_info(
+            "pNFS data server %d backing root resolved via '%s' (module=%s path=%s root_fh_len=%d local=%d)",
+            i, ds->backing_path,
+            m->module ? m->module->name : "?",
+            m->path ? m->path : "?", m->root_fh_len, ds->backing_local);
         resolved++;
     }
 

--- a/src/vfs/vfs_pnfs.h
+++ b/src/vfs/vfs_pnfs.h
@@ -107,6 +107,12 @@ struct chimera_vfs_ds {
     char     uaddr[64];                           /* RFC5665 universal address (DS)  */
     int      version;                             /* NFS version advertised for DS   */
     int      minorversion;                        /* NFS minor version (4.x)         */
+    uint8_t  backing_local;                       /* 1 = backing is a local (non-nfs)
+                                                   * mount served by this server, so
+                                                   * the DS handle is the backing
+                                                   * handle as-is; 0 = nfs-proxy DS,
+                                                   * strip the wrapper to recover the
+                                                   * remote native handle            */
     char     backing_path[CHIMERA_PNFS_BACKING_MAX]; /* chimera path where the DS is
                                                       * nfs-mounted, e.g. "/ds0"     */
     /* Resolved once the backing mount is established: the DS export root as an


### PR DESCRIPTION
Re-targets the local-backing work to **main**. (It was previously merged into the `pnfs-ds-version-scope` feature branch by mistake in #643 — that branch's prerequisite, #640, has since landed on main, so this is the same fix rebased onto current main.)

## Summary

Makes a flex-files **data server co-located with the MDS** (the MDS is also a DS, backed by a *local* mount instead of the `nfs` proxy) work end to end, and closes two smaller gaps the work surfaced. A co-located/local-backing DS hit **two** distinct bugs, both fixed here:

### 1. Filehandle derivation (writes)
`ff_lg_emit` assumed every DS is reached through the `nfs` proxy module, so it blindly stripped the proxy mount-id wrapper (`FF_BLOB_FH_SKIP`) from the stored backing handle to recover the DS's native handle. For a **local** backing mount there is no wrapper, so the client was handed a 1-byte garbage handle and its direct I/O looped re-fetching the layout. `chimera_server_pnfs_resolve` now records whether each DS's backing mount is the nfs proxy or a local module (`chimera_vfs_ds.backing_local`, keyed on the mount module's `fh_magic`); the layout encoder hands the client the backing handle **as-is** for a local DS and only strips the wrapper for a remote proxy DS. Remote/split behavior is unchanged.

### 2. Backing-file permissions (reads)
Backing files were created mode `0600`/owner-root. flex-files steers DS I/O with synthetic per-iomode principals (`ffds_user` `"0"` for RW, `"1"` for READ). A dedicated DS in `data_server` mode serves backing I/O statelessly and **bypasses** the permission check, but a co-located DS **enforces** it — so writes (as uid 0) worked while reads (as uid 1) were denied and the client spun re-fetching the layout. Backing files are now created world-rw; they are internal data containers and the real access control is the client's OPEN against the MDS metadata file (the model `data_server` mode already relies on).

### Also
- **LAYOUTERROR (op 64):** accept-and-acknowledge (like LAYOUTSTATS) instead of `NFS4ERR_NOTSUPP`, which made the client re-report.
- **Dump op names:** the NFS4 compound dumper learned the pNFS / 4.2 / xattr op names so they stop logging as `Unknown op=N` (cosmetic; those ops were already handled by the dispatcher).

## Tests

The KVM pNFS wrapper gains a **`combined`** topology (one daemon = MDS + local-backing DS, v3 data path); `kvm/tests/CMakeLists.txt` runs the full flex-files workload matrix (`rw`, `recall_truncate`, `recall_truncate_xclient`, `remove`) against it across memfs and both diskfs backends. All 12 combined-topology tests pass locally, and the existing split-topology tests still pass.