### PR TITLE
server: add "create" mount option to create the backend path before mounting

### DIFF
--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -799,10 +799,42 @@ main(
             path          = json_string_value(json_object_get(mount, "path"));
             mount_options = json_string_value(json_object_get(mount, "options"));
 
-            chimera_server_info("Mounting %s://%s to /%s%s%s...",
+            /* "create": create the backend directory path (and any missing
+             * parents) before mounting, for backends initialized empty.  May be
+             * `true` (mode 0755) or an object `{ "mode": "0755" }` -- the mode
+             * is an octal string; created dirs are owned 0/0. */
+            json_t  *create_val  = json_object_get(mount, "create");
+            int      do_create   = 0;
+            uint32_t create_mode = 0755;
+
+            if (json_is_true(create_val)) {
+                do_create = 1;
+            } else if (json_is_object(create_val)) {
+                json_t *mode_val = json_object_get(create_val, "mode");
+                do_create = 1;
+                if (json_is_string(mode_val)) {
+                    create_mode = (uint32_t) strtol(json_string_value(mode_val), NULL, 8);
+                } else if (json_is_integer(mode_val)) {
+                    create_mode = (uint32_t) json_integer_value(mode_val);
+                }
+            }
+
+            chimera_server_info("Mounting %s://%s to /%s%s%s%s...",
                                 module, path, name,
                                 mount_options ? " options=" : "",
-                                mount_options ? mount_options : "");
+                                mount_options ? mount_options : "",
+                                do_create ? " (create)" : "");
+
+            if (do_create && module && path) {
+                if (chimera_server_mkpath(server, module, path, create_mode) != 0) {
+                    /* Hard fail: the operator asked for the path to be created
+                     * and it could not be, so do not silently mount a missing
+                     * or wrong target. */
+                    chimera_server_error("Failed to create mount path %s://%s for /%s",
+                                         module, path, name);
+                    exit(1);
+                }
+            }
 
             if (chimera_server_mount(server, name, module, path, mount_options) != 0) {
                 /* A silently-failed mount leaves shares/exports pointing at a

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -20,3 +20,5 @@ add_subdirectory(s3)
 add_subdirectory(smb)
 
 add_subdirectory(rest)
+
+add_subdirectory(tests)

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -8,6 +8,7 @@
 #include <unistd.h>
 #include <pthread.h>
 #include <sys/resource.h>
+#include <sys/stat.h>
 #include <sys/socket.h>
 #include <netdb.h>
 #include <arpa/inet.h>
@@ -24,6 +25,8 @@
 #include "vfs/vfs_procs.h"
 #include "vfs/vfs_pnfs.h"
 #include "vfs/vfs_mount_table.h"
+#include "vfs/vfs_cred.h"
+#include "vfs/vfs_release.h"
 #include "common/macros.h"
 #include "server/server.h"
 #include "smb/smb2.h"
@@ -1030,6 +1033,278 @@ chimera_server_mount(
     return ctx.status;
 
 } /* chimera_server_create_share */
+
+/*
+ * Ensure a directory path exists inside a backend before it is mounted, for the
+ * "create" mount option.  A backend's MOUNT op only walks the path read-only
+ * (it returns ENOENT for a missing component), and creating a directory needs
+ * an open handle to its parent -- which in turn needs the backend registered in
+ * the mount table.  So: transiently mount the backend root, walk the target
+ * path component by component creating any that are missing, unmount, and let
+ * the caller perform the real mount of the now-existing path.
+ *
+ * Synchronous (init-time) wrapper around an async lookup-or-mkdir chain, driven
+ * on a private evpl like chimera_server_mount.  Returns 0 on success.
+ */
+#define CHIMERA_MKPATH_TMP_NAME "__chimera_mkpath_tmp"
+
+struct chimera_mkpath_ctx {
+    struct chimera_vfs             *vfs;
+    struct chimera_vfs_thread      *thread;
+    char                            path[256];
+    int                             pathlen;
+    int                             offset;
+    uint32_t                        mode;
+    struct chimera_vfs_open_handle *oh;      /* current parent directory */
+    char                            comp[256];
+    int                             complen;
+    uint8_t                         child_fh[CHIMERA_VFS_FH_SIZE + 16];
+    uint32_t                        child_fh_len;
+    struct chimera_vfs_attrs        set_attr;
+    enum chimera_vfs_error status;
+    int                             done;
+};
+
+static void chimera_mkpath_next(
+    struct chimera_mkpath_ctx *ctx);
+
+static void
+chimera_mkpath_umount_cb(
+    struct chimera_vfs_thread *thread,
+    enum chimera_vfs_error     status,
+    void                      *private_data)
+{
+    struct chimera_mkpath_ctx *ctx = private_data;
+
+    ctx->done = 1;
+} /* chimera_mkpath_umount_cb */
+
+/* Release the current handle and tear down the transient root mount, recording
+ * the final walk status.  Both the success and failure paths funnel here. */
+static void
+chimera_mkpath_finish(
+    struct chimera_mkpath_ctx *ctx,
+    enum chimera_vfs_error     status)
+{
+    ctx->status = status;
+
+    if (ctx->oh) {
+        chimera_vfs_release(ctx->thread, ctx->oh);
+        ctx->oh = NULL;
+    }
+
+    chimera_vfs_umount(ctx->thread, chimera_vfs_get_server_cred(),
+                       CHIMERA_MKPATH_TMP_NAME, chimera_mkpath_umount_cb, ctx);
+} /* chimera_mkpath_finish */
+
+/* The just-resolved/created child becomes the new parent; descend. */
+static void
+chimera_mkpath_descend_cb(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *oh,
+    void                           *private_data)
+{
+    struct chimera_mkpath_ctx *ctx = private_data;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        chimera_mkpath_finish(ctx, error_code);
+        return;
+    }
+
+    if (ctx->oh) {
+        chimera_vfs_release(ctx->thread, ctx->oh);
+    }
+    ctx->oh = oh;
+    chimera_mkpath_next(ctx);
+} /* chimera_mkpath_descend_cb */
+
+static void
+chimera_mkpath_open_child(struct chimera_mkpath_ctx *ctx)
+{
+    chimera_vfs_open_fh(ctx->thread, chimera_vfs_get_server_cred(),
+                        ctx->child_fh, ctx->child_fh_len,
+                        CHIMERA_VFS_OPEN_DIRECTORY | CHIMERA_VFS_OPEN_PATH,
+                        chimera_mkpath_descend_cb, ctx);
+} /* chimera_mkpath_open_child */
+
+static void
+chimera_mkpath_mkdir_cb(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *set_attr,
+    struct chimera_vfs_attrs *attr,
+    struct chimera_vfs_attrs *dir_pre_attr,
+    struct chimera_vfs_attrs *dir_post_attr,
+    void                     *private_data)
+{
+    struct chimera_mkpath_ctx *ctx = private_data;
+
+    if (error_code != CHIMERA_VFS_OK || attr->va_fh_len == 0) {
+        chimera_mkpath_finish(ctx, error_code != CHIMERA_VFS_OK ? error_code : CHIMERA_VFS_EIO);
+        return;
+    }
+
+    memcpy(ctx->child_fh, attr->va_fh, attr->va_fh_len);
+    ctx->child_fh_len = attr->va_fh_len;
+    chimera_mkpath_open_child(ctx);
+} /* chimera_mkpath_mkdir_cb */
+
+static void
+chimera_mkpath_lookup_cb(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *attr,
+    struct chimera_vfs_attrs *dir_attr,
+    void                     *private_data)
+{
+    struct chimera_mkpath_ctx *ctx = private_data;
+
+    if (error_code == CHIMERA_VFS_OK) {
+        /* Component already exists; descend into it. */
+        if (attr->va_fh_len == 0) {
+            chimera_mkpath_finish(ctx, CHIMERA_VFS_EIO);
+            return;
+        }
+        memcpy(ctx->child_fh, attr->va_fh, attr->va_fh_len);
+        ctx->child_fh_len = attr->va_fh_len;
+        chimera_mkpath_open_child(ctx);
+        return;
+    }
+
+    if (error_code == CHIMERA_VFS_ENOENT) {
+        memset(&ctx->set_attr, 0, sizeof(ctx->set_attr));
+        ctx->set_attr.va_set_mask = CHIMERA_VFS_ATTR_MODE |
+            CHIMERA_VFS_ATTR_UID | CHIMERA_VFS_ATTR_GID;
+        ctx->set_attr.va_mode = S_IFDIR | (ctx->mode & 07777);
+        ctx->set_attr.va_uid  = 0;
+        ctx->set_attr.va_gid  = 0;
+
+        chimera_vfs_mkdir_at(ctx->thread, chimera_vfs_get_server_cred(), ctx->oh,
+                             ctx->comp, ctx->complen, &ctx->set_attr,
+                             CHIMERA_VFS_ATTR_FH, 0, 0,
+                             chimera_mkpath_mkdir_cb, ctx);
+        return;
+    }
+
+    chimera_mkpath_finish(ctx, error_code);
+} /* chimera_mkpath_lookup_cb */
+
+/* Advance to the next '/'-separated component; when none remain the path is
+ * fully present and we finish successfully. */
+static void
+chimera_mkpath_next(struct chimera_mkpath_ctx *ctx)
+{
+    int start;
+
+    while (ctx->offset < ctx->pathlen && ctx->path[ctx->offset] == '/') {
+        ctx->offset++;
+    }
+
+    if (ctx->offset >= ctx->pathlen) {
+        chimera_mkpath_finish(ctx, CHIMERA_VFS_OK);
+        return;
+    }
+
+    start = ctx->offset;
+    while (ctx->offset < ctx->pathlen && ctx->path[ctx->offset] != '/') {
+        ctx->offset++;
+    }
+
+    ctx->complen = ctx->offset - start;
+    if (ctx->complen >= (int) sizeof(ctx->comp)) {
+        chimera_mkpath_finish(ctx, CHIMERA_VFS_ENAMETOOLONG);
+        return;
+    }
+    memcpy(ctx->comp, ctx->path + start, ctx->complen);
+    ctx->comp[ctx->complen] = '\0';
+
+    chimera_vfs_lookup_at(ctx->thread, chimera_vfs_get_server_cred(), ctx->oh,
+                          ctx->comp, ctx->complen, CHIMERA_VFS_ATTR_FH, 0,
+                          chimera_mkpath_lookup_cb, ctx);
+} /* chimera_mkpath_next */
+
+static void
+chimera_mkpath_root_open_cb(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *oh,
+    void                           *private_data)
+{
+    struct chimera_mkpath_ctx *ctx = private_data;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        chimera_mkpath_finish(ctx, error_code);
+        return;
+    }
+    ctx->oh = oh;
+    chimera_mkpath_next(ctx);
+} /* chimera_mkpath_root_open_cb */
+
+static void
+chimera_mkpath_mounted_cb(
+    struct chimera_vfs_thread *thread,
+    enum chimera_vfs_error     status,
+    void                      *private_data)
+{
+    struct chimera_mkpath_ctx *ctx = private_data;
+    struct chimera_vfs_mount  *m;
+
+    if (status != CHIMERA_VFS_OK) {
+        /* Root mount failed -- nothing registered, nothing to unmount. */
+        ctx->status = status;
+        ctx->done   = 1;
+        return;
+    }
+
+    m = chimera_vfs_mount_table_find_by_path(ctx->vfs->mount_table,
+                                             CHIMERA_MKPATH_TMP_NAME,
+                                             strlen(CHIMERA_MKPATH_TMP_NAME));
+    if (!m) {
+        chimera_mkpath_finish(ctx, CHIMERA_VFS_EIO);
+        return;
+    }
+
+    chimera_vfs_open_fh(thread, chimera_vfs_get_server_cred(),
+                        m->root_fh, m->root_fh_len,
+                        CHIMERA_VFS_OPEN_DIRECTORY | CHIMERA_VFS_OPEN_PATH,
+                        chimera_mkpath_root_open_cb, ctx);
+} /* chimera_mkpath_mounted_cb */
+
+SYMBOL_EXPORT int
+chimera_server_mkpath(
+    struct chimera_server *server,
+    const char            *module_name,
+    const char            *module_path,
+    uint32_t               mode)
+{
+    struct evpl              *evpl;
+    struct chimera_mkpath_ctx ctx;
+
+    memset(&ctx, 0, sizeof(ctx));
+
+    if (!module_name || !module_path ||
+        strlen(module_path) >= sizeof(ctx.path)) {
+        return -1;
+    }
+
+    evpl        = evpl_create(NULL);
+    ctx.vfs     = server->vfs;
+    ctx.thread  = chimera_vfs_thread_init(evpl, server->vfs);
+    ctx.mode    = mode ? mode : 0755;
+    ctx.status  = CHIMERA_VFS_OK;
+    ctx.pathlen = snprintf(ctx.path, sizeof(ctx.path), "%s", module_path);
+
+    /* Transiently mount the backend root so we have a handle to walk under. */
+    chimera_vfs_mount(ctx.thread, chimera_vfs_get_server_cred(),
+                      CHIMERA_MKPATH_TMP_NAME, module_name, "/", NULL,
+                      chimera_mkpath_mounted_cb, &ctx);
+
+    while (!ctx.done) {
+        evpl_continue(evpl);
+    }
+
+    chimera_vfs_thread_destroy(ctx.thread);
+    evpl_destroy(evpl);
+
+    return ctx.status == CHIMERA_VFS_OK ? 0 : -1;
+} /* chimera_server_mkpath */
 
 SYMBOL_EXPORT int
 chimera_server_pnfs_resolve(struct chimera_server *server)

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -453,6 +453,16 @@ chimera_server_mount(
     const char            *module_path,
     const char            *options);
 
+/* Ensure module_path exists inside module_name (creating intermediate dirs with
+ * the given mode, owner 0/0) before it is mounted -- backs the "create" mount
+ * option.  Returns 0 on success, -1 if any component could not be created. */
+int
+chimera_server_mkpath(
+    struct chimera_server *server,
+    const char            *module_name,
+    const char            *module_path,
+    uint32_t               mode);
+
 int
 chimera_server_create_bucket(
     struct chimera_server *server,

--- a/src/server/tests/CMakeLists.txt
+++ b/src/server/tests/CMakeLists.txt
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+#
+# SPDX-License-Identifier: LGPL-2.1-only
+
+# Daemon-level mount tests run a real chimera daemon in a network namespace.
+if(CHIMERA_NETNS_TESTING)
+    add_test(
+        NAME chimera/server/mount_create
+        COMMAND ${CMAKE_SOURCE_DIR}/scripts/netns_test_wrapper.sh
+                bash ${CMAKE_CURRENT_SOURCE_DIR}/mount_create_test.sh
+                ${CMAKE_BINARY_DIR}/src/daemon/chimera
+    )
+    set_tests_properties(chimera/server/mount_create PROPERTIES TIMEOUT 60)
+endif()

--- a/src/server/tests/mount_create_test.sh
+++ b/src/server/tests/mount_create_test.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+#
+# SPDX-License-Identifier: Unlicense
+#
+# Exercises the per-mount "create" option: the daemon creates a not-yet-existing
+# backend directory path (and any intermediate directories) before mounting it.
+#
+# memfs initializes empty, so mounting /a/b/c/d only succeeds if mkpath created
+# the path; the second mount of /a/b/e additionally exercises descending into
+# the already-created /a/b.  Both create-mounts are exported, so the daemon only
+# reaches "Server is ready" with both exports registered if the paths were
+# created and mounted successfully.
+
+set -u
+
+BIN=${1:?usage: mount_create_test.sh <chimera_binary>}
+
+SESSION=$(mktemp -d)
+CFG="$SESSION/config.json"
+LOG="$SESSION/daemon.log"
+PID=""
+
+cleanup() {
+    [ -n "$PID" ] && kill -9 "$PID" 2>/dev/null
+    rm -rf "$SESSION"
+}
+trap cleanup EXIT
+
+cat > "$CFG" <<'EOF'
+{
+    "server": {
+        "threads": 2,
+        "nfs_port": 21049,
+        "data_server": true,
+        "external_portmap": true,
+        "metrics_port": 0
+    },
+    "mounts": {
+        "deep":    { "module": "memfs", "path": "/a/b/c/d", "create": { "mode": "0750" } },
+        "sibling": { "module": "memfs", "path": "/a/b/e",   "create": true }
+    },
+    "exports": {
+        "/deep":    { "path": "/deep" },
+        "/sibling": { "path": "/sibling" }
+    }
+}
+EOF
+
+"$BIN" -c "$CFG" > "$LOG" 2>&1 &
+PID=$!
+
+for _ in $(seq 1 100); do
+    grep -q "Server is ready" "$LOG" 2>/dev/null && break
+    kill -0 "$PID" 2>/dev/null || break
+    sleep 0.1
+done
+
+kill -TERM "$PID" 2>/dev/null
+
+fail() {
+    echo "FAIL: $1"
+    echo "--- daemon log ---"
+    cat "$LOG"
+    exit 1
+}
+
+grep -q "Server is ready" "$LOG"              || fail "daemon did not start (create-mount failed?)"
+grep -qi "Failed to create mount path" "$LOG" && fail "mount-path creation reported failure"
+grep -q "Adding NFS export /deep" "$LOG"      || fail "/deep export missing (deep create-mount failed)"
+grep -q "Adding NFS export /sibling" "$LOG"   || fail "/sibling export missing (sibling create-mount failed)"
+
+echo "PASS: create-mount built /a/b/c/d and /a/b/e on an empty memfs backend"
+exit 0


### PR DESCRIPTION
## Summary

Adds an optional per-mount **`create`** flag to the daemon `mounts` section that creates the backend directory path (and any missing parents) before mounting it. This makes it practical to lay out an export tree on a freshly `initialize`d backend (e.g. diskfs) — today a backend's MOUNT op only walks the path read-only and fails with `ENOENT` if a component doesn't exist.

```json
"mounts": {
  "exports": { "module": "diskfs", "path": "/data/exports", "create": true },
  "scratch": { "module": "diskfs", "path": "/data/scratch", "create": { "mode": "0770" } }
}
```

- `create` may be `true` (mode `0755`) or an object `{ "mode": "<octal-string>" }`. Created directories are owned `0/0`.
- If the path cannot be created, the daemon **hard-fails** rather than silently mounting a missing/wrong target.
- Scope is the `mounts` section only.

## Implementation

Generic, in the server layer — **no per-backend changes**. New `chimera_server_mkpath()`: creating a directory needs an open handle to its parent, which needs the backend registered in the mount table, so it

1. transiently mounts the backend **root**,
2. walks the target path component by component, issuing `lookup`-or-`mkdir` for each (descending into any that already exist),
3. unmounts the transient root,

and the daemon then performs the normal mount of the now-existing path. Works for any backend that supports `MKDIR`.

## Test

`src/server/tests/mount_create_test.sh` (netns, no KVM) starts a daemon with two **shared-prefix** create-mounts (`/a/b/c/d` and `/a/b/e`) on an empty memfs and asserts both are created, mounted, and exported — covering both the create-new and descend-into-existing paths. Registered as `chimera/server/mount_create`, gated on `CHIMERA_NETNS_TESTING`; passes in ~0.16 s. Also validated manually that the second mount creates only the missing tail component (`e`) and reuses the existing `/a/b`.

## Motivation

Among other things this lets a co-located pNFS MDS+DS node use a dedicated backing subtree (created at startup) instead of sharing the export root.