### PR TITLE
nfs/client: RFC 8881-compliant NFSv4.1 session slot management

### DIFF
--- a/src/vfs/nfs/CMakeLists.txt
+++ b/src/vfs/nfs/CMakeLists.txt
@@ -39,6 +39,7 @@ add_library(chimera_vfs_nfs SHARED
     nfs4_open_at.c
     nfs4_open_fh.c
     nfs4_read.c
+    nfs4_slot.c
     nfs4_readdir.c
     nfs4_readlink.c
     nfs4_remove_at.c

--- a/src/vfs/nfs/nfs.c
+++ b/src/vfs/nfs/nfs.c
@@ -115,7 +115,6 @@ chimera_nfs_destroy(void *private_data)
         if (shared->servers[i]) {
             /* Free NFS4 session if present */
             if (shared->servers[i]->nfs4_session) {
-                free(shared->servers[i]->nfs4_session->slot_seqids);
                 pthread_mutex_destroy(&shared->servers[i]->nfs4_session->lock);
                 free(shared->servers[i]->nfs4_session);
             }
@@ -164,7 +163,10 @@ chimera_nfs_notify(
     struct evpl_rpc2_notify *notify,
     void                    *private_data)
 {
-    char local_addr[80], remote_addr[80];
+    struct chimera_nfs_thread               *nfs_thread = private_data;
+    struct chimera_nfs_client_server_thread *server_thread;
+    char                                     local_addr[80], remote_addr[80];
+    int                                      i;
 
     switch (notify->notify_type) {
         case EVPL_RPC2_NOTIFY_CONNECTED:
@@ -176,6 +178,18 @@ chimera_nfs_notify(
             evpl_rpc2_conn_get_local_address(conn, local_addr, sizeof(local_addr));
             evpl_rpc2_conn_get_remote_address(conn, remote_addr, sizeof(remote_addr));
             chimera_nfsclient_info("Disconnected from %s to %s", local_addr, remote_addr);
+
+            /* rpc2 drops in-flight calls on disconnect without firing their
+             * callbacks.  Error-complete the NFS4.1 requests stranded on this
+             * connection's slot table and reset it so the next op re-establishes
+             * cleanly (rather than hanging and leaking slots). */
+            for (i = 0; nfs_thread && i < nfs_thread->max_server_threads; i++) {
+                server_thread = nfs_thread->server_threads[i];
+                if (server_thread && server_thread->nfs_conn == conn) {
+                    chimera_nfs4_slot_table_reset(nfs_thread->evpl, &server_thread->slots);
+                    break;
+                }
+            }
             break;
     } /* switch */
 } /* chimera_nfs_notify */
@@ -191,6 +205,10 @@ chimera_nfs_thread_init(
 
     thread->shared = shared;
     thread->evpl   = evpl;
+
+    /* Count client threads so the NFS4.1 fore-channel slot pool can be
+     * partitioned evenly (max_slots / nfs_thread_count) per thread. */
+    atomic_fetch_add(&shared->nfs_thread_count, 1);
 
     programs[0] = &shared->mount_v3.rpc2;
     programs[1] = &shared->portmap_v2.rpc2;
@@ -220,15 +238,20 @@ chimera_nfs_thread_destroy(void *private_data)
         free(open_handle);
     }
 
+    /* Tear down the rpc2 thread first: it disconnects every connection, which
+     * fires chimera_nfs_notify(DISCONNECTED) -> chimera_nfs4_slot_table_reset,
+     * and that walks thread->server_threads.  Freeing the server_threads before
+     * this would be a use-after-free. */
+    evpl_rpc2_thread_destroy(thread->rpc2_thread);
+
     for (i = 0; i < thread->max_server_threads; i++) {
         if (thread->server_threads[i]) {
+            chimera_nfs4_slot_table_destroy(&thread->server_threads[i]->slots);
             free(thread->server_threads[i]);
         }
     }
 
     free(thread->server_threads);
-
-    evpl_rpc2_thread_destroy(thread->rpc2_thread);
 
     free(thread);
 } /* chimera_nfs_thread_destroy */

--- a/src/vfs/nfs/nfs4_getattr.c
+++ b/src/vfs/nfs/nfs4_getattr.c
@@ -106,11 +106,6 @@ chimera_nfs4_getattr(
 
     /* Op 0: SEQUENCE */
     argarray[0].argop = OP_SEQUENCE;
-    memcpy(argarray[0].opsequence.sa_sessionid, session->sessionid, NFS4_SESSIONID_SIZE);
-    argarray[0].opsequence.sa_sequenceid     = chimera_nfs4_get_sequenceid(session, server_thread->slot_id);
-    argarray[0].opsequence.sa_slotid         = server_thread->slot_id;
-    argarray[0].opsequence.sa_highest_slotid = session->max_slots - 1;
-    argarray[0].opsequence.sa_cachethis      = 0;
 
     /* Op 1: PUTFH - set current file handle */
     argarray[1].argop               = OP_PUTFH;
@@ -130,14 +125,16 @@ chimera_nfs4_getattr(
                                request->thread->vfs->machine_name,
                                request->thread->vfs->machine_name_len);
 
-    shared->nfs_v4.send_call_NFSPROC4_COMPOUND(
-        &shared->nfs_v4.rpc2,
-        thread->evpl,
-        server_thread->nfs_conn,
-        &rpc2_cred,
+    chimera_nfs4_compound_call(
+        thread,
+        shared,
+        server_thread,
+        request,
         &args,
+        &rpc2_cred,
         0, 0, NULL, 0, 0,
         chimera_nfs4_getattr_callback,
-        request);
+        request,
+        chimera_nfs4_dispatch, private_data);
 } /* chimera_nfs4_getattr */
 

--- a/src/vfs/nfs/nfs4_link_at.c
+++ b/src/vfs/nfs/nfs4_link_at.c
@@ -132,11 +132,6 @@ chimera_nfs4_link_at(
 
     /* Op 0: SEQUENCE */
     argarray[0].argop = OP_SEQUENCE;
-    memcpy(argarray[0].opsequence.sa_sessionid, session->sessionid, NFS4_SESSIONID_SIZE);
-    argarray[0].opsequence.sa_sequenceid     = chimera_nfs4_get_sequenceid(session, server_thread->slot_id);
-    argarray[0].opsequence.sa_slotid         = server_thread->slot_id;
-    argarray[0].opsequence.sa_highest_slotid = session->max_slots - 1;
-    argarray[0].opsequence.sa_cachethis      = 0;
 
     /* Op 1: PUTFH - set current FH to source file (the file to link) */
     argarray[1].argop               = OP_PUTFH;
@@ -160,13 +155,15 @@ chimera_nfs4_link_at(
                                request->thread->vfs->machine_name,
                                request->thread->vfs->machine_name_len);
 
-    shared->nfs_v4.send_call_NFSPROC4_COMPOUND(
-        &shared->nfs_v4.rpc2,
-        thread->evpl,
-        server_thread->nfs_conn,
-        &rpc2_cred,
+    chimera_nfs4_compound_call(
+        thread,
+        shared,
+        server_thread,
+        request,
         &args,
+        &rpc2_cred,
         0, 0, NULL, 0, 0,
         chimera_nfs4_link_callback,
-        request);
+        request,
+        chimera_nfs4_dispatch, private_data);
 } /* chimera_nfs4_link_at */

--- a/src/vfs/nfs/nfs4_lookup_at.c
+++ b/src/vfs/nfs/nfs4_lookup_at.c
@@ -184,11 +184,6 @@ chimera_nfs4_lookup_at(
 
     /* Op 0: SEQUENCE */
     argarray[0].argop = OP_SEQUENCE;
-    memcpy(argarray[0].opsequence.sa_sessionid, session->sessionid, NFS4_SESSIONID_SIZE);
-    argarray[0].opsequence.sa_sequenceid     = chimera_nfs4_get_sequenceid(session, server_thread->slot_id);
-    argarray[0].opsequence.sa_slotid         = server_thread->slot_id;
-    argarray[0].opsequence.sa_highest_slotid = session->max_slots - 1;
-    argarray[0].opsequence.sa_cachethis      = 0;
 
     /* Op 1: PUTFH - set current file handle to parent directory */
     argarray[1].argop               = OP_PUTFH;
@@ -229,13 +224,15 @@ chimera_nfs4_lookup_at(
                                request->thread->vfs->machine_name,
                                request->thread->vfs->machine_name_len);
 
-    shared->nfs_v4.send_call_NFSPROC4_COMPOUND(
-        &shared->nfs_v4.rpc2,
-        thread->evpl,
-        server_thread->nfs_conn,
-        &rpc2_cred,
+    chimera_nfs4_compound_call(
+        thread,
+        shared,
+        server_thread,
+        request,
         &args,
+        &rpc2_cred,
         0, 0, NULL, 0, 0,
         chimera_nfs4_lookup_callback,
-        request);
+        request,
+        chimera_nfs4_dispatch, private_data);
 } /* chimera_nfs4_lookup_at */

--- a/src/vfs/nfs/nfs4_mkdir_at.c
+++ b/src/vfs/nfs/nfs4_mkdir_at.c
@@ -144,11 +144,6 @@ chimera_nfs4_mkdir_at(
 
     /* Op 0: SEQUENCE */
     argarray[0].argop = OP_SEQUENCE;
-    memcpy(argarray[0].opsequence.sa_sessionid, session->sessionid, NFS4_SESSIONID_SIZE);
-    argarray[0].opsequence.sa_sequenceid     = chimera_nfs4_get_sequenceid(session, server_thread->slot_id);
-    argarray[0].opsequence.sa_slotid         = server_thread->slot_id;
-    argarray[0].opsequence.sa_highest_slotid = session->max_slots - 1;
-    argarray[0].opsequence.sa_cachethis      = 0;
 
     /* Op 1: PUTFH - set current file handle to parent directory */
     argarray[1].argop               = OP_PUTFH;
@@ -180,13 +175,15 @@ chimera_nfs4_mkdir_at(
                                request->thread->vfs->machine_name,
                                request->thread->vfs->machine_name_len);
 
-    shared->nfs_v4.send_call_NFSPROC4_COMPOUND(
-        &shared->nfs_v4.rpc2,
-        thread->evpl,
-        server_thread->nfs_conn,
-        &rpc2_cred,
+    chimera_nfs4_compound_call(
+        thread,
+        shared,
+        server_thread,
+        request,
         &args,
+        &rpc2_cred,
         0, 0, NULL, 0, 0,
         chimera_nfs4_mkdir_callback,
-        request);
+        request,
+        chimera_nfs4_dispatch, private_data);
 } /* chimera_nfs4_mkdir_at */

--- a/src/vfs/nfs/nfs4_mount.c
+++ b/src/vfs/nfs/nfs4_mount.c
@@ -35,6 +35,38 @@ static void chimera_nfs4_mount_get_root_fh(
     struct chimera_nfs_client_server_thread *server_thread,
     struct chimera_vfs_request              *request);
 
+/* Slot-exhaustion replay shims: chimera_nfs4_compound_call parks a request when
+ * no session slot is free and replays it through these when one frees.  ctx is
+ * the server_thread; each just re-runs its mount step (which rebuilds args). */
+static void
+chimera_nfs4_mount_get_root_fh_retry(
+    struct chimera_nfs_thread  *thread,
+    struct chimera_nfs_shared  *shared,
+    struct chimera_vfs_request *request,
+    void                       *ctx)
+{
+    (void) thread;
+    (void) shared;
+    chimera_nfs4_mount_get_root_fh((struct chimera_nfs_client_server_thread *) ctx, request);
+} /* chimera_nfs4_mount_get_root_fh_retry */
+
+static void
+chimera_nfs4_mount_reclaim_complete(
+    struct chimera_nfs_client_server_thread *server_thread,
+    struct chimera_vfs_request              *request);
+
+static void
+chimera_nfs4_mount_reclaim_complete_retry(
+    struct chimera_nfs_thread  *thread,
+    struct chimera_nfs_shared  *shared,
+    struct chimera_vfs_request *request,
+    void                       *ctx)
+{
+    (void) thread;
+    (void) shared;
+    chimera_nfs4_mount_reclaim_complete((struct chimera_nfs_client_server_thread *) ctx, request);
+} /* chimera_nfs4_mount_reclaim_complete_retry */
+
 /* Get the RDMA protocol from mount options */
 static enum evpl_protocol_id
 chimera_nfs4_mount_get_rdma_protocol(const struct chimera_vfs_mount_options *options)
@@ -223,13 +255,8 @@ chimera_nfs4_mount_get_root_fh(
     args.argarray     = argarray;
     args.num_argarray = 5;
 
-    /* Op 0: SEQUENCE */
+    /* Op 0: SEQUENCE (slot fields filled by chimera_nfs4_compound_call) */
     argarray[0].argop = OP_SEQUENCE;
-    memcpy(argarray[0].opsequence.sa_sessionid, session->sessionid, NFS4_SESSIONID_SIZE);
-    argarray[0].opsequence.sa_sequenceid     = chimera_nfs4_get_sequenceid(session, 0);
-    argarray[0].opsequence.sa_slotid         = 0;  /* Use slot 0 for mount operation */
-    argarray[0].opsequence.sa_highest_slotid = session->max_slots - 1;
-    argarray[0].opsequence.sa_cachethis      = 0;
 
     /* Op 1: PUTROOTFH */
     argarray[1].argop = OP_PUTROOTFH;
@@ -249,15 +276,13 @@ chimera_nfs4_mount_get_root_fh(
     argarray[4].opgetattr.attr_request     = attr_request;
     argarray[4].opgetattr.num_attr_request = 2;
 
-    shared->nfs_v4.send_call_NFSPROC4_COMPOUND(
-        &shared->nfs_v4.rpc2,
-        server_thread->thread->evpl,
-        server_thread->nfs_conn,
-        NULL,
-        &args,
-        0, 0, NULL, 0, 0,
-        chimera_nfs4_mount_get_root_fh_callback,
-        request);
+    (void) session;
+
+    chimera_nfs4_compound_call(
+        server_thread->thread, shared, server_thread, request,
+        &args, NULL, 0, 0, NULL, 0, 0,
+        chimera_nfs4_mount_get_root_fh_callback, request,
+        chimera_nfs4_mount_get_root_fh_retry, server_thread);
 } /* chimera_nfs4_mount_get_root_fh */
 
 /*
@@ -320,27 +345,20 @@ chimera_nfs4_mount_reclaim_complete(
     args.argarray     = argarray;
     args.num_argarray = 2;
 
-    /* Op 0: SEQUENCE (slot 0, shared with the mount-time root lookup). */
+    /* Op 0: SEQUENCE (slot fields filled by chimera_nfs4_compound_call). */
     argarray[0].argop = OP_SEQUENCE;
-    memcpy(argarray[0].opsequence.sa_sessionid, session->sessionid, NFS4_SESSIONID_SIZE);
-    argarray[0].opsequence.sa_sequenceid     = chimera_nfs4_get_sequenceid(session, 0);
-    argarray[0].opsequence.sa_slotid         = 0;
-    argarray[0].opsequence.sa_highest_slotid = session->max_slots - 1;
-    argarray[0].opsequence.sa_cachethis      = 0;
 
     /* Op 1: RECLAIM_COMPLETE, global (rca_one_fs == FALSE). */
     argarray[1].argop                         = OP_RECLAIM_COMPLETE;
     argarray[1].opreclaim_complete.rca_one_fs = 0;
 
-    shared->nfs_v4.send_call_NFSPROC4_COMPOUND(
-        &shared->nfs_v4.rpc2,
-        server_thread->thread->evpl,
-        server_thread->nfs_conn,
-        NULL,
-        &args,
-        0, 0, NULL, 0, 0,
-        chimera_nfs4_mount_reclaim_complete_callback,
-        request);
+    (void) session;
+
+    chimera_nfs4_compound_call(
+        server_thread->thread, shared, server_thread, request,
+        &args, NULL, 0, 0, NULL, 0, 0,
+        chimera_nfs4_mount_reclaim_complete_callback, request,
+        chimera_nfs4_mount_reclaim_complete_retry, server_thread);
 } /* chimera_nfs4_mount_reclaim_complete */
 
 /*
@@ -360,7 +378,6 @@ chimera_nfs4_mount_create_session_callback(
     struct chimera_nfs_client_server        *server        = server_thread->server;
     struct chimera_nfs4_client_session      *session;
     struct CREATE_SESSION4resok             *cs_res;
-    uint32_t                                 i;
 
     if (status != 0) {
         chimera_nfsclient_error("NFS4 CREATE_SESSION RPC failed: %d", status);
@@ -391,15 +408,12 @@ chimera_nfs4_mount_create_session_callback(
     session = server->nfs4_session;
     memcpy(session->sessionid, cs_res->csr_sessionid, NFS4_SESSIONID_SIZE);
 
-    /* Use the server's fore channel max requests as the number of slots */
-    session->max_slots    = cs_res->csr_fore_chan_attrs.ca_maxrequests;
-    session->next_slot_id = 1;  /* Start at 1, slot 0 is used by mount thread */
-
-    /* Allocate per-slot sequence IDs */
-    session->slot_seqids = calloc(session->max_slots, sizeof(uint32_t));
-    for (i = 0; i < session->max_slots; i++) {
-        session->slot_seqids[i] = 1; /* Start at 1 per RFC 5661 */
-    }
+    /* The server's granted fore-channel ca_maxrequests is the global slot count.
+     * Per-thread connections claim disjoint blocks from [0, max_slots) lazily;
+     * see chimera_nfs4_compound_call / chimera_nfs4_slot_table_init. */
+    session->max_slots      = cs_res->csr_fore_chan_attrs.ca_maxrequests;
+    session->next_unclaimed = 0;
+    session->overflow_rr    = 0;
 
     chimera_nfsclient_info("NFS4 CREATE_SESSION successful, clientid=%lu, max_slots=%u",
                            (unsigned long) session->clientid, session->max_slots);

--- a/src/vfs/nfs/nfs4_open_at.c
+++ b/src/vfs/nfs/nfs4_open_at.c
@@ -168,11 +168,6 @@ chimera_nfs4_open_at(
 
     /* Op 0: SEQUENCE */
     argarray[0].argop = OP_SEQUENCE;
-    memcpy(argarray[0].opsequence.sa_sessionid, session->sessionid, NFS4_SESSIONID_SIZE);
-    argarray[0].opsequence.sa_sequenceid     = chimera_nfs4_get_sequenceid(session, server_thread->slot_id);
-    argarray[0].opsequence.sa_slotid         = server_thread->slot_id;
-    argarray[0].opsequence.sa_highest_slotid = session->max_slots - 1;
-    argarray[0].opsequence.sa_cachethis      = 0;
 
     /* Op 1: PUTFH - set current file handle to parent directory */
     argarray[1].argop               = OP_PUTFH;
@@ -237,13 +232,15 @@ chimera_nfs4_open_at(
                                request->thread->vfs->machine_name,
                                request->thread->vfs->machine_name_len);
 
-    shared->nfs_v4.send_call_NFSPROC4_COMPOUND(
-        &shared->nfs_v4.rpc2,
-        thread->evpl,
-        server_thread->nfs_conn,
-        &rpc2_cred,
+    chimera_nfs4_compound_call(
+        thread,
+        shared,
+        server_thread,
+        request,
         &args,
+        &rpc2_cred,
         0, 0, NULL, 0, 0,
         chimera_nfs4_open_at_callback,
-        request);
+        request,
+        chimera_nfs4_dispatch, private_data);
 } /* chimera_nfs4_open_at */

--- a/src/vfs/nfs/nfs4_read.c
+++ b/src/vfs/nfs/nfs4_read.c
@@ -121,11 +121,6 @@ chimera_nfs4_read(
 
     /* Op 0: SEQUENCE */
     argarray[0].argop = OP_SEQUENCE;
-    memcpy(argarray[0].opsequence.sa_sessionid, session->sessionid, NFS4_SESSIONID_SIZE);
-    argarray[0].opsequence.sa_sequenceid     = chimera_nfs4_get_sequenceid(session, server_thread->slot_id);
-    argarray[0].opsequence.sa_slotid         = server_thread->slot_id;
-    argarray[0].opsequence.sa_highest_slotid = session->max_slots - 1;
-    argarray[0].opsequence.sa_cachethis      = 0;
 
     /* Op 1: PUTFH */
     argarray[1].argop               = OP_PUTFH;
@@ -167,13 +162,15 @@ chimera_nfs4_read(
         request->read.landed_in_dest = 1;
     }
 
-    shared->nfs_v4.send_call_NFSPROC4_COMPOUND(
-        &shared->nfs_v4.rpc2,
-        thread->evpl,
-        server_thread->nfs_conn,
-        &rpc2_cred,
+    chimera_nfs4_compound_call(
+        thread,
+        shared,
+        server_thread,
+        request,
         &args,
+        &rpc2_cred,
         0, request->read.length, write_chunk_iov, write_chunk_niov, 0,
         chimera_nfs4_read_callback,
-        request);
+        request,
+        chimera_nfs4_dispatch, private_data);
 } /* chimera_nfs4_read */

--- a/src/vfs/nfs/nfs4_readdir.c
+++ b/src/vfs/nfs/nfs4_readdir.c
@@ -335,11 +335,6 @@ chimera_nfs4_readdir(
 
     /* Op 0: SEQUENCE */
     argarray[0].argop = OP_SEQUENCE;
-    memcpy(argarray[0].opsequence.sa_sessionid, session->sessionid, NFS4_SESSIONID_SIZE);
-    argarray[0].opsequence.sa_sequenceid     = chimera_nfs4_get_sequenceid(session, server_thread->slot_id);
-    argarray[0].opsequence.sa_slotid         = server_thread->slot_id;
-    argarray[0].opsequence.sa_highest_slotid = session->max_slots - 1;
-    argarray[0].opsequence.sa_cachethis      = 0;
 
     /* Op 1: PUTFH - set current file handle to directory */
     argarray[1].argop               = OP_PUTFH;
@@ -378,13 +373,15 @@ chimera_nfs4_readdir(
                                request->thread->vfs->machine_name,
                                request->thread->vfs->machine_name_len);
 
-    shared->nfs_v4.send_call_NFSPROC4_COMPOUND(
-        &shared->nfs_v4.rpc2,
-        thread->evpl,
-        server_thread->nfs_conn,
-        &rpc2_cred,
+    chimera_nfs4_compound_call(
+        thread,
+        shared,
+        server_thread,
+        request,
         &args,
+        &rpc2_cred,
         0, 0, NULL, 0, 0,
         chimera_nfs4_readdir_callback,
-        request);
+        request,
+        chimera_nfs4_dispatch, private_data);
 } /* chimera_nfs4_readdir */

--- a/src/vfs/nfs/nfs4_readlink.c
+++ b/src/vfs/nfs/nfs4_readlink.c
@@ -112,11 +112,6 @@ chimera_nfs4_readlink(
 
     /* Op 0: SEQUENCE */
     argarray[0].argop = OP_SEQUENCE;
-    memcpy(argarray[0].opsequence.sa_sessionid, session->sessionid, NFS4_SESSIONID_SIZE);
-    argarray[0].opsequence.sa_sequenceid     = chimera_nfs4_get_sequenceid(session, server_thread->slot_id);
-    argarray[0].opsequence.sa_slotid         = server_thread->slot_id;
-    argarray[0].opsequence.sa_highest_slotid = session->max_slots - 1;
-    argarray[0].opsequence.sa_cachethis      = 0;
 
     /* Op 1: PUTFH - set current FH to the symlink */
     argarray[1].argop               = OP_PUTFH;
@@ -130,14 +125,16 @@ chimera_nfs4_readlink(
                                request->thread->vfs->machine_name,
                                request->thread->vfs->machine_name_len);
 
-    shared->nfs_v4.send_call_NFSPROC4_COMPOUND(
-        &shared->nfs_v4.rpc2,
-        thread->evpl,
-        server_thread->nfs_conn,
-        &rpc2_cred,
+    chimera_nfs4_compound_call(
+        thread,
+        shared,
+        server_thread,
+        request,
         &args,
+        &rpc2_cred,
         0, 0, NULL, 0, 0,
         chimera_nfs4_readlink_callback,
-        request);
+        request,
+        chimera_nfs4_dispatch, private_data);
 } /* chimera_nfs4_readlink */ /* chimera_nfs4_readlink */
 

--- a/src/vfs/nfs/nfs4_remove_at.c
+++ b/src/vfs/nfs/nfs4_remove_at.c
@@ -112,11 +112,6 @@ chimera_nfs4_remove_at(
 
     /* Op 0: SEQUENCE */
     argarray[0].argop = OP_SEQUENCE;
-    memcpy(argarray[0].opsequence.sa_sessionid, session->sessionid, NFS4_SESSIONID_SIZE);
-    argarray[0].opsequence.sa_sequenceid     = chimera_nfs4_get_sequenceid(session, server_thread->slot_id);
-    argarray[0].opsequence.sa_slotid         = server_thread->slot_id;
-    argarray[0].opsequence.sa_highest_slotid = session->max_slots - 1;
-    argarray[0].opsequence.sa_cachethis      = 0;
 
     /* Op 1: PUTFH - set current file handle to parent directory */
     argarray[1].argop               = OP_PUTFH;
@@ -132,13 +127,15 @@ chimera_nfs4_remove_at(
                                request->thread->vfs->machine_name,
                                request->thread->vfs->machine_name_len);
 
-    shared->nfs_v4.send_call_NFSPROC4_COMPOUND(
-        &shared->nfs_v4.rpc2,
-        thread->evpl,
-        server_thread->nfs_conn,
-        &rpc2_cred,
+    chimera_nfs4_compound_call(
+        thread,
+        shared,
+        server_thread,
+        request,
         &args,
+        &rpc2_cred,
         0, 0, NULL, 0, 0,
         chimera_nfs4_remove_callback,
-        request);
+        request,
+        chimera_nfs4_dispatch, private_data);
 } /* chimera_nfs4_remove_at */

--- a/src/vfs/nfs/nfs4_rename_at.c
+++ b/src/vfs/nfs/nfs4_rename_at.c
@@ -132,11 +132,6 @@ chimera_nfs4_rename_at(
 
     /* Op 0: SEQUENCE */
     argarray[0].argop = OP_SEQUENCE;
-    memcpy(argarray[0].opsequence.sa_sessionid, session->sessionid, NFS4_SESSIONID_SIZE);
-    argarray[0].opsequence.sa_sequenceid     = chimera_nfs4_get_sequenceid(session, server_thread->slot_id);
-    argarray[0].opsequence.sa_slotid         = server_thread->slot_id;
-    argarray[0].opsequence.sa_highest_slotid = session->max_slots - 1;
-    argarray[0].opsequence.sa_cachethis      = 0;
 
     /* Op 1: PUTFH - set current FH to source directory */
     argarray[1].argop               = OP_PUTFH;
@@ -162,13 +157,15 @@ chimera_nfs4_rename_at(
                                request->thread->vfs->machine_name,
                                request->thread->vfs->machine_name_len);
 
-    shared->nfs_v4.send_call_NFSPROC4_COMPOUND(
-        &shared->nfs_v4.rpc2,
-        thread->evpl,
-        server_thread->nfs_conn,
-        &rpc2_cred,
+    chimera_nfs4_compound_call(
+        thread,
+        shared,
+        server_thread,
+        request,
         &args,
+        &rpc2_cred,
         0, 0, NULL, 0, 0,
         chimera_nfs4_rename_callback,
-        request);
+        request,
+        chimera_nfs4_dispatch, private_data);
 } /* chimera_nfs4_rename_at */

--- a/src/vfs/nfs/nfs4_setattr.c
+++ b/src/vfs/nfs/nfs4_setattr.c
@@ -184,11 +184,6 @@ chimera_nfs4_setattr(
 
     /* Op 0: SEQUENCE */
     argarray[0].argop = OP_SEQUENCE;
-    memcpy(argarray[0].opsequence.sa_sessionid, session->sessionid, NFS4_SESSIONID_SIZE);
-    argarray[0].opsequence.sa_sequenceid     = chimera_nfs4_get_sequenceid(session, server_thread->slot_id);
-    argarray[0].opsequence.sa_slotid         = server_thread->slot_id;
-    argarray[0].opsequence.sa_highest_slotid = session->max_slots - 1;
-    argarray[0].opsequence.sa_cachethis      = 0;
 
     /* Op 1: PUTFH - set current file handle */
     argarray[1].argop               = OP_PUTFH;
@@ -221,13 +216,15 @@ chimera_nfs4_setattr(
                                request->thread->vfs->machine_name,
                                request->thread->vfs->machine_name_len);
 
-    shared->nfs_v4.send_call_NFSPROC4_COMPOUND(
-        &shared->nfs_v4.rpc2,
-        thread->evpl,
-        server_thread->nfs_conn,
-        &rpc2_cred,
+    chimera_nfs4_compound_call(
+        thread,
+        shared,
+        server_thread,
+        request,
         &args,
+        &rpc2_cred,
         0, 0, NULL, 0, 0,
         chimera_nfs4_setattr_callback,
-        request);
+        request,
+        chimera_nfs4_dispatch, private_data);
 } /* chimera_nfs4_setattr */ /* chimera_nfs4_setattr */

--- a/src/vfs/nfs/nfs4_slot.c
+++ b/src/vfs/nfs/nfs4_slot.c
@@ -1,0 +1,451 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * NFSv4.1 client fore-channel session-slot layer (RFC 8881 §2.10.6).
+ *
+ * Every NFSv4.1 COMPOUND the client sends carries a SEQUENCE op naming a session
+ * slot and that slot's sequenceid.  The protocol allows only ONE outstanding
+ * request per slot at a time, and the slot's sequenceid must advance by exactly
+ * one per accepted request; sending a second request on a busy slot (or with a
+ * mismatched seqid) is rejected with NFS4ERR_SEQ_MISORDERED.  The previous client
+ * gave each thread a single slot and merely incremented its seqid per call, so a
+ * thread with more than one COMPOUND in flight (pipelined I/O, or back-to-back
+ * compounds) collided.
+ *
+ * This layer fixes that.  The session owns the global slot space (max_slots,
+ * granted by CREATE_SESSION).  Each per-thread connection
+ * (chimera_nfs_client_server_thread) claims a disjoint block of slot indices
+ * once and manages them entirely thread-locally -- a server_thread is touched by
+ * exactly one evpl thread, so acquire/release/park/wake need no locking; only
+ * the one-time block claim takes session->lock.  When all of a thread's slots
+ * are busy, further requests are parked and replayed (same thread) as slots
+ * free, never sent on a busy slot.
+ */
+
+#include <stdlib.h>
+
+#include "nfs_internal.h"
+
+/* Upper bound on a thread's slot block, so an early claim (when few threads have
+ * registered yet) cannot grab the whole pool and starve later threads. */
+#define CHIMERA_NFS4_MAX_SLOTS_PER_THREAD 16
+
+/* In-flight wrapper context: what rpc2 carries as private_data so the reply can
+ * free the slot and then invoke the caller's real callback. */
+struct chimera_nfs4_compound_ctx {
+    struct chimera_nfs_client_server_thread *server_thread;
+    uint32_t                                 slot_local;   /* index into slots[] */
+    uint32_t                                 seqid;        /* seqid we sent       */
+    void                                     (*real_cb)(
+        struct evpl *,
+        const struct evpl_rpc2_verf *,
+        struct COMPOUND4res *,
+        int,
+        void *);
+    void                                    *real_private;
+    struct chimera_nfs4_compound_ctx        *prev, *next;  /* inflight dll        */
+    struct chimera_nfs4_compound_ctx        *fl_next;      /* freelist            */
+};
+
+/* A request parked because no slot was free; replayed when one frees. */
+struct chimera_nfs4_parked {
+    struct chimera_nfs_thread  *thread;
+    struct chimera_nfs_shared  *shared;
+    struct chimera_vfs_request *request;
+    chimera_nfs4_retry_fn       retry_fn;
+    void                       *retry_ctx;
+    struct chimera_nfs4_parked *next;
+};
+
+/* ---- per-thread pools (no locking; single owning evpl thread) ----------- */
+
+static struct chimera_nfs4_compound_ctx *
+chimera_nfs4_ctx_alloc(struct chimera_nfs4_slot_table *st)
+{
+    struct chimera_nfs4_compound_ctx *ctx = st->ctx_freelist;
+
+    if (ctx) {
+        st->ctx_freelist = ctx->fl_next;
+    } else {
+        ctx = calloc(1, sizeof(*ctx));
+    }
+    return ctx;
+} /* chimera_nfs4_ctx_alloc */
+
+static void
+chimera_nfs4_ctx_free(
+    struct chimera_nfs4_slot_table   *st,
+    struct chimera_nfs4_compound_ctx *ctx)
+{
+    ctx->fl_next     = st->ctx_freelist;
+    st->ctx_freelist = ctx;
+} /* chimera_nfs4_ctx_free */
+
+static void
+chimera_nfs4_inflight_add(
+    struct chimera_nfs4_slot_table   *st,
+    struct chimera_nfs4_compound_ctx *ctx)
+{
+    ctx->prev = NULL;
+    ctx->next = st->inflight;
+    if (st->inflight) {
+        st->inflight->prev = ctx;
+    }
+    st->inflight = ctx;
+} /* chimera_nfs4_inflight_add */
+
+static void
+chimera_nfs4_inflight_remove(
+    struct chimera_nfs4_slot_table   *st,
+    struct chimera_nfs4_compound_ctx *ctx)
+{
+    if (ctx->prev) {
+        ctx->prev->next = ctx->next;
+    } else {
+        st->inflight = ctx->next;
+    }
+    if (ctx->next) {
+        ctx->next->prev = ctx->prev;
+    }
+    ctx->prev = ctx->next = NULL;
+} /* chimera_nfs4_inflight_remove */
+
+static void
+chimera_nfs4_park(
+    struct chimera_nfs4_slot_table *st,
+    struct chimera_nfs_thread      *thread,
+    struct chimera_nfs_shared      *shared,
+    struct chimera_vfs_request     *request,
+    chimera_nfs4_retry_fn           retry_fn,
+    void                           *retry_ctx)
+{
+    struct chimera_nfs4_parked *p = st->parked_freelist;
+
+    if (p) {
+        st->parked_freelist = p->next;
+    } else {
+        p = calloc(1, sizeof(*p));
+    }
+
+    p->thread    = thread;
+    p->shared    = shared;
+    p->request   = request;
+    p->retry_fn  = retry_fn;
+    p->retry_ctx = retry_ctx;
+    p->next      = NULL;
+
+    if (st->wait_tail) {
+        st->wait_tail->next = p;
+    } else {
+        st->wait_head = p;
+    }
+    st->wait_tail = p;
+} /* chimera_nfs4_park */
+
+static struct chimera_nfs4_parked *
+chimera_nfs4_park_pop(struct chimera_nfs4_slot_table *st)
+{
+    struct chimera_nfs4_parked *p = st->wait_head;
+
+    if (p) {
+        st->wait_head = p->next;
+        if (!st->wait_head) {
+            st->wait_tail = NULL;
+        }
+    }
+    return p;
+} /* chimera_nfs4_park_pop */
+
+/* ---- slot table block claim + acquire/release --------------------------- */
+
+static void
+chimera_nfs4_slot_table_init(
+    struct chimera_nfs4_slot_table     *st,
+    struct chimera_nfs4_client_session *session,
+    struct chimera_nfs_shared          *shared)
+{
+    uint32_t cap, remaining, base, n, i;
+    int      nthreads, overflow = 0;
+
+    nthreads = atomic_load(&shared->nfs_thread_count);
+    if (nthreads < 1) {
+        nthreads = 1;
+    }
+
+    cap = session->max_slots / (uint32_t) nthreads;
+    if (cap < 1) {
+        cap = 1;
+    }
+    if (cap > CHIMERA_NFS4_MAX_SLOTS_PER_THREAD) {
+        cap = CHIMERA_NFS4_MAX_SLOTS_PER_THREAD;
+    }
+
+    pthread_mutex_lock(&session->lock);
+    remaining = session->max_slots - session->next_unclaimed;
+    if (remaining == 0) {
+        /* Pool exhausted: only happens with more client threads than the
+         * server's granted slots (default 64).  Alias an existing slot index;
+         * those (rare) threads then share a slot and serialize through it. */
+        base                 = session->overflow_rr;
+        session->overflow_rr = (session->overflow_rr + 1) % session->max_slots;
+        n                    = 1;
+        overflow             = 1;
+    } else {
+        n                        = cap < remaining ? cap : remaining;
+        base                     = session->next_unclaimed;
+        session->next_unclaimed += n;
+    }
+    pthread_mutex_unlock(&session->lock);
+
+    if (overflow) {
+        chimera_nfsclient_error(
+            "NFS4 session slot pool exhausted (max_slots=%u, threads=%d); "
+            "sharing slot %u. Raise server.nfs4_session_slots.",
+            session->max_slots, nthreads, base);
+    }
+
+    st->slots      = calloc(n, sizeof(*st->slots));
+    st->free_stack = calloc(n, sizeof(*st->free_stack));
+    st->num_slots  = n;
+    st->free_top   = (int) n;
+
+    for (i = 0; i < n; i++) {
+        st->slots[i].global_id = base + i;
+        st->slots[i].seqid     = 1;             /* RFC 8881: first request seqid 1 */
+        st->slots[i].in_use    = 0;
+        st->free_stack[i]      = n - 1 - i;     /* hand out low indices first      */
+    }
+
+    st->initialized = 1;
+} /* chimera_nfs4_slot_table_init */
+
+/* Returns a free local slot index, or -1 if all owned slots are busy. */
+static int
+chimera_nfs4_slot_acquire(struct chimera_nfs4_slot_table *st)
+{
+    uint32_t local;
+
+    if (st->free_top == 0) {
+        return -1;
+    }
+
+    local                   = st->free_stack[--st->free_top];
+    st->slots[local].in_use = 1;
+    return (int) local;
+} /* chimera_nfs4_slot_acquire */
+
+static void
+chimera_nfs4_slot_release(
+    struct chimera_nfs4_slot_table *st,
+    uint32_t                        local)
+{
+    st->slots[local].in_use        = 0;
+    st->free_stack[st->free_top++] = local;
+} /* chimera_nfs4_slot_release */
+
+/* ---- the reply wrapper -------------------------------------------------- */
+
+static void
+chimera_nfs4_compound_call_cb(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    struct COMPOUND4res         *res,
+    int                          status,
+    void                        *private_data)
+{
+    struct chimera_nfs4_compound_ctx *ctx  = private_data;
+    struct chimera_nfs4_slot_table   *st   = &ctx->server_thread->slots;
+    struct chimera_nfs4_slot         *slot = &st->slots[ctx->slot_local];
+    struct chimera_nfs4_parked       *p;
+
+    void                              (*real_cb)(
+        struct evpl *,
+        const struct evpl_rpc2_verf *,
+        struct COMPOUND4res *,
+        int,
+        void *);
+    void                             *real_private;
+
+    chimera_nfs4_inflight_remove(st, ctx);
+
+    /* Advance the slot's seqid only when the server accepted the SEQUENCE
+    * (RFC 8881 §2.10.6.1).  On a transport error or a SEQUENCE error, leave it
+    * so the slot stays replayable; we surface the error to the caller. */
+    if (status == 0 && res && res->num_resarray >= 1 &&
+        res->resarray[0].opsequence.sr_status == NFS4_OK) {
+        slot->seqid = ctx->seqid + 1;
+    }
+
+    chimera_nfs4_slot_release(st, ctx->slot_local);
+
+    real_cb      = ctx->real_cb;
+    real_private = ctx->real_private;
+    chimera_nfs4_ctx_free(st, ctx);
+
+    /* Deliver to the caller first: a follow-on COMPOUND it issues (e.g. a close
+     * sending LAYOUTRETURN after LAYOUTCOMMIT) gets the just-freed slot. */
+    real_cb(evpl, verf, res, status, real_private);
+
+    /* Then wake parked requests for any slots still free.  Each replay
+     * re-dispatches the op, which re-enters chimera_nfs4_compound_call and
+     * acquires a slot (re-entrant same-thread send is safe). */
+    while (st->free_top > 0 && st->wait_head) {
+        p = chimera_nfs4_park_pop(st);
+        chimera_nfs4_retry_fn       rf = p->retry_fn;
+        struct chimera_nfs_thread  *t  = p->thread;
+        struct chimera_nfs_shared  *sh = p->shared;
+        struct chimera_vfs_request *rq = p->request;
+        void                       *rc = p->retry_ctx;
+        p->next             = st->parked_freelist;
+        st->parked_freelist = p;
+        rf(t, sh, rq, rc);
+    }
+} /* chimera_nfs4_compound_call_cb */
+
+void
+chimera_nfs4_compound_call(
+    struct chimera_nfs_thread *thread,
+    struct chimera_nfs_shared *shared,
+    struct chimera_nfs_client_server_thread *server_thread,
+    struct chimera_vfs_request *request,
+    struct COMPOUND4args *args,
+    const struct evpl_rpc2_cred *cred,
+    int ddp,
+    int max_rdma_write_chunk,
+    struct evpl_iovec *write_chunk_iov,
+    int write_chunk_niov,
+    int max_rdma_reply_chunk,
+    void ( *cb )(struct evpl *, const struct evpl_rpc2_verf *,
+                 struct COMPOUND4res *, int, void *),
+    void *cb_private,
+    chimera_nfs4_retry_fn retry_fn,
+    void *retry_ctx)
+{
+    struct chimera_nfs4_client_session *session = server_thread->server->nfs4_session;
+    struct chimera_nfs4_slot_table     *st      = &server_thread->slots;
+    struct chimera_nfs4_slot           *slot;
+    struct chimera_nfs4_compound_ctx   *ctx;
+    int                                 local;
+
+    if (unlikely(!st->initialized)) {
+        chimera_nfs4_slot_table_init(st, session, shared);
+    }
+
+    local = chimera_nfs4_slot_acquire(st);
+    if (local < 0) {
+        /* No slot free: park and replay when one frees.  Must not send on a
+         * busy slot (that is the NFS4ERR_SEQ_MISORDERED bug). */
+        chimera_nfs4_park(st, thread, shared, request, retry_fn, retry_ctx);
+        return;
+    }
+
+    slot = &st->slots[local];
+
+    args->argarray[0].argop = OP_SEQUENCE;
+    memcpy(args->argarray[0].opsequence.sa_sessionid, session->sessionid, NFS4_SESSIONID_SIZE);
+    args->argarray[0].opsequence.sa_sequenceid     = slot->seqid;
+    args->argarray[0].opsequence.sa_slotid         = slot->global_id;
+    args->argarray[0].opsequence.sa_highest_slotid = session->max_slots - 1;
+    args->argarray[0].opsequence.sa_cachethis      = 0;
+
+    ctx                = chimera_nfs4_ctx_alloc(st);
+    ctx->server_thread = server_thread;
+    ctx->slot_local    = (uint32_t) local;
+    ctx->seqid         = slot->seqid;
+    ctx->real_cb       = cb;
+    ctx->real_private  = cb_private;
+    chimera_nfs4_inflight_add(st, ctx);
+
+    shared->nfs_v4.send_call_NFSPROC4_COMPOUND(
+        &shared->nfs_v4.rpc2,
+        thread->evpl,
+        server_thread->nfs_conn,
+        cred,
+        args,
+        ddp, max_rdma_write_chunk, write_chunk_iov, write_chunk_niov, max_rdma_reply_chunk,
+        chimera_nfs4_compound_call_cb,
+        ctx);
+} /* chimera_nfs4_compound_call */
+
+void
+chimera_nfs4_slot_table_destroy(struct chimera_nfs4_slot_table *st)
+{
+    struct chimera_nfs4_compound_ctx *ctx;
+    struct chimera_nfs4_parked       *p;
+
+    while (st->ctx_freelist) {
+        ctx              = st->ctx_freelist;
+        st->ctx_freelist = ctx->fl_next;
+        free(ctx);
+    }
+    /* Any still-inflight ctxs are owned by pending replies; on teardown the
+     * connection is gone, so just free them. */
+    while (st->inflight) {
+        ctx          = st->inflight;
+        st->inflight = ctx->next;
+        free(ctx);
+    }
+    while (st->parked_freelist) {
+        p                   = st->parked_freelist;
+        st->parked_freelist = p->next;
+        free(p);
+    }
+    while (st->wait_head) {
+        p             = st->wait_head;
+        st->wait_head = p->next;
+        free(p);
+    }
+    st->wait_tail = NULL;
+    free(st->slots);
+    free(st->free_stack);
+    st->slots       = NULL;
+    st->free_stack  = NULL;
+    st->num_slots   = 0;
+    st->free_top    = 0;
+    st->initialized = 0;
+} /* chimera_nfs4_slot_table_destroy */
+
+void
+chimera_nfs4_slot_table_reset(
+    struct evpl                    *evpl,
+    struct chimera_nfs4_slot_table *st)
+{
+    struct chimera_nfs4_compound_ctx *ctx;
+    struct chimera_nfs4_parked       *p;
+    uint32_t                          i;
+
+    if (!st->initialized) {
+        return;
+    }
+
+    /* Error-complete everything that was in flight on the dropped connection.
+     * rpc2 already freed the underlying calls without invoking their callbacks,
+     * so we must run them here (non-zero status -> the op completes with an
+     * error rather than hanging). */
+    while (st->inflight) {
+        ctx          = st->inflight;
+        st->inflight = ctx->next;
+        ctx->prev    = ctx->next = NULL;
+        ctx->real_cb(evpl, NULL, NULL, 1 /* error */, ctx->real_private);
+        chimera_nfs4_ctx_free(st, ctx);
+    }
+
+    /* Parked requests never went on the wire; error-complete them too. */
+    while ((p = chimera_nfs4_park_pop(st)) != NULL) {
+        p->request->status = CHIMERA_VFS_EIO;
+        p->request->complete(p->request);
+        p->next             = st->parked_freelist;
+        st->parked_freelist = p;
+    }
+
+    /* All slots are free again.  seqids are left as-is: a lost request the
+    * server did process would yield NFS4ERR_SEQ_MISORDERED on the next reuse,
+    * which we surface as an error (full recovery is a separate effort). */
+    for (i = 0; i < st->num_slots; i++) {
+        st->slots[i].in_use = 0;
+        st->free_stack[i]   = st->num_slots - 1 - i;
+    }
+    st->free_top = (int) st->num_slots;
+} /* chimera_nfs4_slot_table_reset */

--- a/src/vfs/nfs/nfs4_symlink_at.c
+++ b/src/vfs/nfs/nfs4_symlink_at.c
@@ -146,11 +146,6 @@ chimera_nfs4_symlink_at(
 
     /* Op 0: SEQUENCE */
     argarray[0].argop = OP_SEQUENCE;
-    memcpy(argarray[0].opsequence.sa_sessionid, session->sessionid, NFS4_SESSIONID_SIZE);
-    argarray[0].opsequence.sa_sequenceid     = chimera_nfs4_get_sequenceid(session, server_thread->slot_id);
-    argarray[0].opsequence.sa_slotid         = server_thread->slot_id;
-    argarray[0].opsequence.sa_highest_slotid = session->max_slots - 1;
-    argarray[0].opsequence.sa_cachethis      = 0;
 
     /* Op 1: PUTFH - set current FH to directory */
     argarray[1].argop               = OP_PUTFH;
@@ -184,13 +179,15 @@ chimera_nfs4_symlink_at(
                                request->thread->vfs->machine_name,
                                request->thread->vfs->machine_name_len);
 
-    shared->nfs_v4.send_call_NFSPROC4_COMPOUND(
-        &shared->nfs_v4.rpc2,
-        thread->evpl,
-        server_thread->nfs_conn,
-        &rpc2_cred,
+    chimera_nfs4_compound_call(
+        thread,
+        shared,
+        server_thread,
+        request,
         &args,
+        &rpc2_cred,
         0, 0, NULL, 0, 0,
         chimera_nfs4_symlink_callback,
-        request);
+        request,
+        chimera_nfs4_dispatch, private_data);
 } /* chimera_nfs4_symlink_at */

--- a/src/vfs/nfs/nfs4_umount.c
+++ b/src/vfs/nfs/nfs4_umount.c
@@ -22,9 +22,9 @@ chimera_nfs4_umount(
 
     server->refcnt--;
 
-    /* Free session when last mount is removed */
+    /* Free session when last mount is removed.  Per-thread slot tables are
+     * freed in chimera_nfs_thread_destroy (they live on the server_threads). */
     if (server->refcnt == 0 && server->nfs4_session) {
-        free(server->nfs4_session->slot_seqids);
         pthread_mutex_destroy(&server->nfs4_session->lock);
         free(server->nfs4_session);
         server->nfs4_session = NULL;

--- a/src/vfs/nfs/nfs4_write.c
+++ b/src/vfs/nfs/nfs4_write.c
@@ -125,11 +125,6 @@ chimera_nfs4_write(
 
     /* Op 0: SEQUENCE */
     argarray[0].argop = OP_SEQUENCE;
-    memcpy(argarray[0].opsequence.sa_sessionid, session->sessionid, NFS4_SESSIONID_SIZE);
-    argarray[0].opsequence.sa_sequenceid     = chimera_nfs4_get_sequenceid(session, server_thread->slot_id);
-    argarray[0].opsequence.sa_slotid         = server_thread->slot_id;
-    argarray[0].opsequence.sa_highest_slotid = session->max_slots - 1;
-    argarray[0].opsequence.sa_cachethis      = 0;
 
     /* Op 1: PUTFH */
     argarray[1].argop               = OP_PUTFH;
@@ -158,13 +153,15 @@ chimera_nfs4_write(
                                request->thread->vfs->machine_name,
                                request->thread->vfs->machine_name_len);
 
-    shared->nfs_v4.send_call_NFSPROC4_COMPOUND(
-        &shared->nfs_v4.rpc2,
-        thread->evpl,
-        server_thread->nfs_conn,
-        &rpc2_cred,
+    chimera_nfs4_compound_call(
+        thread,
+        shared,
+        server_thread,
+        request,
         &args,
+        &rpc2_cred,
         1, 0, NULL, 0, 0,
         chimera_nfs4_write_callback,
-        request);
+        request,
+        chimera_nfs4_dispatch, private_data);
 } /* chimera_nfs4_write */

--- a/src/vfs/nfs/nfs_internal.h
+++ b/src/vfs/nfs/nfs_internal.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <stdint.h>
+#include <stdatomic.h>
 #include <string.h>
 #include <pthread.h>
 #include <sys/stat.h>
@@ -82,18 +83,51 @@ enum chimera_nfs_client_mount_state {
 
 /*
  * NFS4 client session state
- * Holds the session information established via EXCHANGE_ID + CREATE_SESSION
+ * Holds the session information established via EXCHANGE_ID + CREATE_SESSION.
+ *
+ * RFC 8881 §2.10.6.1 requires one outstanding request per fore-channel slot,
+ * each slot carrying its own monotonic sequenceid.  The session owns the global
+ * slot space (max_slots, granted by CREATE_SESSION); each per-thread connection
+ * (chimera_nfs_client_server_thread) claims a disjoint block of slot indices
+ * from `next_unclaimed` (under `lock`, once) and manages them thread-locally.
  */
 struct chimera_nfs4_client_session {
-    pthread_mutex_t lock;
+    pthread_mutex_t lock;          /* guards next_unclaimed / overflow_rr only   */
     uint8_t         sessionid[NFS4_SESSIONID_SIZE];
     uint64_t        clientid;
-    uint32_t        max_slots;     /* Maximum slots from server (ca_maxrequests) */
-    uint32_t        next_slot_id;  /* Next slot ID to assign to a thread */
-    uint32_t       *slot_seqids;   /* Per-slot sequence IDs (array of max_slots) */
+    uint32_t        max_slots;     /* fore-channel slots granted (ca_maxrequests) */
+    uint32_t        next_unclaimed; /* next free global slot index to hand out    */
+    uint32_t        overflow_rr;   /* round-robin alias when the pool is exhausted */
 };
 
 struct chimera_nfs_client_mount;
+struct chimera_nfs4_compound_ctx;   /* in-flight wrapper context (nfs4_slot.c)   */
+struct chimera_nfs4_parked;                  /* queued request awaiting a slot (nfs4_slot.c) */
+
+/* One owned fore-channel slot. */
+struct chimera_nfs4_slot {
+    uint32_t global_id;                      /* sa_slotid to send on the wire               */
+    uint32_t seqid;                          /* next sa_sequenceid; starts at 1             */
+    uint8_t  in_use;                         /* 1 == one request outstanding on this slot   */
+};
+
+/*
+ * Per-(thread,server) fore-channel slot table.  Touched by exactly one evpl
+ * thread (its owning chimera_nfs_thread), so all of acquire/release/park/wake
+ * are lock-free; only the one-time block claim takes session->lock.
+ */
+struct chimera_nfs4_slot_table {
+    int                               initialized;
+    uint32_t                          num_slots;
+    struct chimera_nfs4_slot         *slots; /* [num_slots]                */
+    uint32_t                         *free_stack;   /* local indices not in use   */
+    int                               free_top;
+    struct chimera_nfs4_parked       *wait_head;    /* FIFO of parked requests    */
+    struct chimera_nfs4_parked       *wait_tail;
+    struct chimera_nfs4_parked       *parked_freelist;
+    struct chimera_nfs4_compound_ctx *inflight;     /* dll, for disconnect reset  */
+    struct chimera_nfs4_compound_ctx *ctx_freelist;
+};
 
 struct chimera_nfs_client_server_thread {
     struct chimera_nfs_thread        *thread;
@@ -105,7 +139,7 @@ struct chimera_nfs_client_server_thread {
     struct evpl_rpc2_conn            *nfs_conn;
     struct evpl_rpc2_conn            *nlm_conn;
 
-    uint32_t                          slot_id;     /* This thread's assigned NFS4.1 slot */
+    struct chimera_nfs4_slot_table    slots;        /* NFS4.1 fore-channel slots  */
 };
 
 struct chimera_nfs_client_server {
@@ -161,6 +195,10 @@ struct chimera_nfs_shared {
     int                                max_servers;
     pthread_mutex_t                    lock;
 
+    /* Number of NFS client (evpl) threads, counted at thread_init; used to size
+     * each thread's fore-channel slot block (max_slots / nfs_thread_count). */
+    _Atomic int                        nfs_thread_count;
+
     struct PORTMAP_V2                  portmap_v2;
     struct NFS_MOUNT_V3                mount_v3;
     struct NFS_V3                      nfs_v3;
@@ -215,7 +253,6 @@ chimera_nfs_thread_get_server_thread(
     int                        fhlen)
 {
     struct chimera_nfs_client_server_thread *server_thread = NULL;
-    struct chimera_nfs4_client_session      *session;
     int                                      index;
 
     if (unlikely(fhlen < CHIMERA_VFS_MOUNT_ID_SIZE + 1)) {
@@ -240,16 +277,8 @@ chimera_nfs_thread_get_server_thread(
         thread->server_threads[index]->thread = thread;
         thread->server_threads[index]->shared = thread->shared;
         thread->server_threads[index]->server = thread->shared->servers[index];
-
-        /* Assign a slot ID for NFS4.1 sessions */
-        session = thread->shared->servers[index]->nfs4_session;
-        if (session && session->max_slots > 0) {
-            /* Round-robin slot assignment. If more threads than slots, they share. */
-            pthread_mutex_lock(&session->lock);
-            thread->server_threads[index]->slot_id = session->next_slot_id % session->max_slots;
-            session->next_slot_id++;
-            pthread_mutex_unlock(&session->lock);
-        }
+        /* The NFS4.1 fore-channel slot block is claimed lazily on the first
+         * COMPOUND through chimera_nfs4_compound_call() (nfs4_slot.c). */
     }
 
     server_thread = thread->server_threads[index];
@@ -301,23 +330,6 @@ chimera_nfs4_map_fh(
     *mapped_fh    = (uint8_t *) fh + CHIMERA_VFS_MOUNT_ID_SIZE + 1;
     *mapped_fhlen = fhlen - CHIMERA_VFS_MOUNT_ID_SIZE - 1;
 } // chimera_nfs4_map_fh
-
-/*
- * Get the next sequence ID for an NFS4 session and increment it
- */
-static inline uint32_t
-chimera_nfs4_get_sequenceid(
-    struct chimera_nfs4_client_session *session,
-    uint32_t                            slot_id)
-{
-    uint32_t seqid;
-
-    pthread_mutex_lock(&session->lock);
-    seqid = session->slot_seqids[slot_id]++;
-    pthread_mutex_unlock(&session->lock);
-
-    return seqid;
-} // chimera_nfs4_get_sequenceid // chimera_nfs4_get_sequenceid
 
 /*
  * Byte-order conversion helpers
@@ -634,6 +646,54 @@ void chimera_nfs4_dispatch(
     struct chimera_nfs_shared *,
     struct chimera_vfs_request *,
     void *);
+
+/* ---- NFSv4.1 session fore-channel slot layer (nfs4_slot.c) -------------- */
+
+/* How a parked request is replayed once a slot frees.  For plain VFS ops this
+ * is chimera_nfs4_dispatch (re-routes by request->opcode); internal multi-step
+ * issuers (mount, pNFS) pass a shim that re-runs that step. */
+typedef void (*chimera_nfs4_retry_fn)(
+    struct chimera_nfs_thread *,
+    struct chimera_nfs_shared *,
+    struct chimera_vfs_request *,
+    void *);
+
+/*
+ * Issue an NFSv4.1 COMPOUND with correct session-slot discipline (one
+ * outstanding request per slot, monotonic per-slot seqid).  argarray[0] must be
+ * an OP_SEQUENCE placeholder (argop set); this fills sa_sessionid/sa_slotid/
+ * sa_sequenceid/sa_highest_slotid/sa_cachethis from an acquired slot, sends, and
+ * frees the slot when the reply arrives before invoking `cb`.  If no slot is
+ * free the request is parked and replayed via (retry_fn, retry_ctx) when one
+ * frees.  `cb`/`cb_private` are the caller's original COMPOUND callback/arg.
+ */
+void chimera_nfs4_compound_call(
+    struct chimera_nfs_thread *thread,
+    struct chimera_nfs_shared *shared,
+    struct chimera_nfs_client_server_thread *server_thread,
+    struct chimera_vfs_request *request,
+    struct COMPOUND4args *args,
+    const struct evpl_rpc2_cred *cred,
+    int ddp,
+    int max_rdma_write_chunk,
+    struct evpl_iovec *write_chunk_iov,
+    int write_chunk_niov,
+    int max_rdma_reply_chunk,
+    void ( *cb )(struct evpl *, const struct evpl_rpc2_verf *,
+                 struct COMPOUND4res *, int, void *),
+    void *cb_private,
+    chimera_nfs4_retry_fn retry_fn,
+    void *retry_ctx);
+
+/* Free a server_thread's slot table (called from thread teardown). */
+void chimera_nfs4_slot_table_destroy(
+    struct chimera_nfs4_slot_table *st);
+
+/* On connection loss: error-complete in-flight + parked requests and reset the
+ * slot table so the next op re-establishes cleanly. */
+void chimera_nfs4_slot_table_reset(
+    struct evpl                    *evpl,
+    struct chimera_nfs4_slot_table *st);
 
 void chimera_nfs3_mount(
     struct chimera_nfs_thread *,


### PR DESCRIPTION
## Context

The NFS4 client (the VFS proxy module in `src/vfs/nfs/`) violated NFSv4.1's
"one outstanding request per session slot" rule. It gave each thread a single
slot and merely incremented that slot's sequenceid per call, so a thread with
more than one COMPOUND in flight — pipelined I/O, or back-to-back compounds —
put multiple outstanding requests on one slot with colliding seqids, which the
server rejects with `NFS4ERR_SEQ_MISORDERED`. This is latent at low concurrency
but breaks pipelined workloads.

## Change

A fore-channel session-slot layer (new `nfs4_slot.c`):

- The session owns the global slot space (`ca_maxrequests`, granted by
  CREATE_SESSION). Each per-`(thread, server)` connection claims a disjoint
  block of slot indices once and manages it **thread-locally** — a
  `server_thread` is touched by exactly one evpl thread, so acquire / release /
  park / wake need no locking; only the one-time block claim takes
  `session->lock`.
- `chimera_nfs4_compound_call()` acquires a slot, fills the SEQUENCE op
  (sessionid / slotid / per-slot seqid / highest_slotid / cachethis), sends, and
  frees the slot when the reply arrives **before** invoking the caller's
  callback — enforcing one outstanding request per slot with a monotonic
  per-slot seqid. A follow-on COMPOUND the callback issues (e.g. a close sending
  LAYOUTRETURN after LAYOUTCOMMIT) reuses the just-freed slot.
- When all of a thread's slots are busy, requests are **parked and replayed**
  (same thread) as slots free — never sent on a busy slot. The 13 plain VFS ops
  route through the wrapper with the default replay (re-dispatch by
  `request->opcode`); mount's `reclaim_complete` / `get_root_fh` use explicit
  replay shims.
- On disconnect, in-flight and parked requests are error-completed and the slot
  table is reset (no hang / no leak), since rpc2 drops in-flight calls without
  firing their callbacks.

Multiple connections share one session, associated by the server's
bind-on-SEQUENCE (`nfs4_proc_sequence.c`), so no `BIND_CONN_TO_SESSION` is
needed — this matches how nconnect already interoperates.

## Verification

Release build + full daemon link clean; `uncrustify --check` clean. A proxy
mounting an upstream NFSv4.1 server, kernel-mounted and driven with 240
concurrent file ops (well past the per-thread slot count, so parking is
exercised): all data verified, **zero `NFS4ERR_SEQ_MISORDERED`**, no crashes.

## Deferred

- Full session recovery (seqid rollback / automatic replay, BADSESSION-driven
  re-CREATE_SESSION with in-flight migration).
- Dynamic slot-table resize honoring `sr_target_highest_slotid`.

This unblocks the in-progress pNFS client work, which will rebase on top.
