### PR TITLE
Add VFS mount management REST API, admin CLI, and SMB e2e test

### DIFF
--- a/src/admin/README.md
+++ b/src/admin/README.md
@@ -47,6 +47,31 @@ with ChimeraAdminClient(host="localhost", port=8080) as client:
     client.delete_user("svc")
 ```
 
+## Command-line interface
+
+The package provides a CLI, invoked as a module:
+
+```bash
+# Global connection options precede the resource and action
+python3 -m chimera_admin --host localhost --port 8080 version
+
+# VFS mounts
+python3 -m chimera_admin mount list
+python3 -m chimera_admin mount get data
+python3 -m chimera_admin mount create data --module linux --path /srv/data
+python3 -m chimera_admin mount delete data
+
+# Users, NFS exports, SMB shares, and S3 buckets
+python3 -m chimera_admin user create alice --uid 1000 --gid 1000
+python3 -m chimera_admin export create home /home
+python3 -m chimera_admin share list
+python3 -m chimera_admin bucket delete photos
+```
+
+Use `--https` (optionally with `--no-verify-ssl`) for TLS endpoints.
+Results are printed as JSON; run `python3 -m chimera_admin <resource> --help`
+for the available actions.
+
 ## Configuration
 
 The REST API must be enabled in the Chimera server configuration:

--- a/src/admin/chimera_admin/__main__.py
+++ b/src/admin/chimera_admin/__main__.py
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Package entry point so the CLI can be run as ``python3 -m chimera_admin``."""
+
+import sys
+
+from .cli import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/admin/chimera_admin/cli.py
+++ b/src/admin/chimera_admin/cli.py
@@ -1,0 +1,203 @@
+# SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Command-line interface for the Chimera NAS REST API.
+
+Run as a module:
+
+    python3 -m chimera_admin [--host H] [--port P] [--https] <resource> <action> ...
+
+Examples:
+
+    python3 -m chimera_admin version
+    python3 -m chimera_admin mount list
+    python3 -m chimera_admin mount create data --module linux --path /srv/data
+    python3 -m chimera_admin user create alice --uid 1000 --gid 1000
+"""
+
+import argparse
+import json
+import sys
+
+from .client import ChimeraAdminClient, ChimeraAdminError
+
+
+def _client(args) -> ChimeraAdminClient:
+    """Build a client from parsed global arguments."""
+    return ChimeraAdminClient(
+        host=args.host,
+        port=args.port,
+        timeout=args.timeout,
+        verify_ssl=not args.no_verify_ssl,
+        use_https=args.https,
+    )
+
+
+def _delete_and_msg(method, ident: str, noun: str) -> str:
+    """Run a delete method and return a confirmation message."""
+    method(ident)
+    return f"{noun} '{ident}' deleted"
+
+
+def _add_crud_commands(sub, noun: str, label: str) -> None:
+    """Add list/get/create/delete commands for a name+path resource.
+
+    Covers exports, shares, and buckets, which share an identical REST
+    shape. Client methods are resolved by convention: ``list_<noun>s``,
+    ``get_<noun>``, ``create_<noun>``, ``delete_<noun>``.
+    """
+    plural = noun + "s"
+    res = sub.add_parser(noun, help=f"Manage {label}s")
+    actions = res.add_subparsers(dest="action", required=True)
+
+    p = actions.add_parser("list", help=f"List {label}s")
+    p.set_defaults(func=lambda c, a: getattr(c, f"list_{plural}")())
+
+    p = actions.add_parser("get", help=f"Get a {label}")
+    p.add_argument("name")
+    p.set_defaults(func=lambda c, a: getattr(c, f"get_{noun}")(a.name))
+
+    p = actions.add_parser("create", help=f"Create a {label}")
+    p.add_argument("name")
+    p.add_argument("path", help="VFS path for the resource")
+    p.set_defaults(
+        func=lambda c, a: getattr(c, f"create_{noun}")(a.name, a.path))
+
+    p = actions.add_parser("delete", help=f"Delete a {label}")
+    p.add_argument("name")
+    p.set_defaults(
+        func=lambda c, a: _delete_and_msg(
+            getattr(c, f"delete_{noun}"), a.name, noun))
+
+
+def _add_user_commands(sub) -> None:
+    """Add the ``user`` resource commands."""
+    res = sub.add_parser("user", help="Manage builtin users")
+    actions = res.add_subparsers(dest="action", required=True)
+
+    p = actions.add_parser("list", help="List users")
+    p.set_defaults(func=lambda c, a: c.list_users())
+
+    p = actions.add_parser("get", help="Get a user")
+    p.add_argument("username")
+    p.set_defaults(func=lambda c, a: c.get_user(a.username))
+
+    p = actions.add_parser("create", help="Create a user")
+    p.add_argument("username")
+    p.add_argument("--uid", type=int, help="User ID (default: 0)")
+    p.add_argument("--gid", type=int, help="Primary group ID (default: 0)")
+    p.add_argument("--password", help="Plaintext password")
+    p.add_argument("--smbpasswd", help="SMB/NTLM password hash")
+    p.add_argument(
+        "--supplementary-gid", type=int, action="append", dest="gids",
+        metavar="GID", help="Supplementary group ID (repeatable, max 64)")
+    p.set_defaults(func=lambda c, a: c.create_user(
+        a.username, uid=a.uid, gid=a.gid, password=a.password,
+        smbpasswd=a.smbpasswd, gids=a.gids))
+
+    p = actions.add_parser("delete", help="Delete a user")
+    p.add_argument("username")
+    p.set_defaults(
+        func=lambda c, a: _delete_and_msg(
+            c.delete_user, a.username, "user"))
+
+
+def _add_mount_commands(sub) -> None:
+    """Add the ``mount`` resource commands."""
+    res = sub.add_parser("mount", help="Manage VFS mounts")
+    actions = res.add_subparsers(dest="action", required=True)
+
+    p = actions.add_parser("list", help="List VFS mounts")
+    p.set_defaults(func=lambda c, a: c.list_mounts())
+
+    p = actions.add_parser("get", help="Get a VFS mount")
+    p.add_argument("name")
+    p.set_defaults(func=lambda c, a: c.get_mount(a.name))
+
+    p = actions.add_parser("create", help="Create a VFS mount")
+    p.add_argument("name")
+    p.add_argument(
+        "--module", required=True, help="VFS module (e.g. linux, memfs)")
+    p.add_argument(
+        "--path", required=True, help="Backing path for the module")
+    p.add_argument("--options", help="Module-specific options string")
+    p.set_defaults(func=lambda c, a: c.create_mount(
+        a.name, module=a.module, path=a.path, options=a.options))
+
+    p = actions.add_parser("delete", help="Delete a VFS mount")
+    p.add_argument("name")
+    p.set_defaults(
+        func=lambda c, a: _delete_and_msg(c.delete_mount, a.name, "mount"))
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the top-level argument parser."""
+    parser = argparse.ArgumentParser(
+        prog="python3 -m chimera_admin",
+        description="Command-line client for the Chimera NAS REST API.")
+    parser.add_argument(
+        "--host", default="localhost",
+        help="Server hostname or IP (default: localhost)")
+    parser.add_argument(
+        "--port", type=int, default=8080,
+        help="REST API port (default: 8080)")
+    parser.add_argument(
+        "--https", action="store_true", help="Use HTTPS instead of HTTP")
+    parser.add_argument(
+        "--no-verify-ssl", action="store_true",
+        help="Do not verify TLS certificates")
+    parser.add_argument(
+        "--timeout", type=int, default=30,
+        help="Request timeout in seconds (default: 30)")
+
+    sub = parser.add_subparsers(dest="resource", required=True)
+
+    p = sub.add_parser("version", help="Show server version")
+    p.set_defaults(func=lambda c, a: c.get_version())
+
+    _add_user_commands(sub)
+    _add_crud_commands(sub, "export", "NFS export")
+    _add_crud_commands(sub, "share", "SMB share")
+    _add_crud_commands(sub, "bucket", "S3 bucket")
+    _add_mount_commands(sub)
+
+    return parser
+
+
+def _emit(result) -> None:
+    """Print a handler result: strings as-is, everything else as JSON."""
+    if result is None:
+        return
+    if isinstance(result, str):
+        print(result)
+    else:
+        print(json.dumps(result, indent=2, sort_keys=True))
+
+
+def main(argv=None) -> int:
+    """Entry point for ``python3 -m chimera_admin``."""
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    client = _client(args)
+    try:
+        result = args.func(client, args)
+    except ChimeraAdminError as e:
+        msg = str(e)
+        if e.status_code is not None:
+            msg = f"{msg} (HTTP {e.status_code})"
+        print(f"error: {msg}", file=sys.stderr)
+        return 1
+    except ValueError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 2
+    finally:
+        client.close()
+
+    _emit(result)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/admin/chimera_admin/client.py
+++ b/src/admin/chimera_admin/client.py
@@ -358,6 +358,75 @@ class ChimeraAdminClient:
         """
         self._request_no_content("DELETE", f"/api/v1/buckets/{name}")
 
+    # VFS Mounts API
+
+    def list_mounts(self) -> list:
+        """List all VFS mounts.
+
+        Returns:
+            List of mount dictionaries, each with "name", "module", and
+            "path" keys.
+
+        Raises:
+            ChimeraAdminError: If the request fails
+        """
+        return self._request("GET", "/api/v1/mounts")
+
+    def get_mount(self, name: str) -> dict:
+        """Get a specific VFS mount by name.
+
+        Args:
+            name: The mount name to look up. Leading slashes are normalized
+                away server-side to match how the mount was registered.
+
+        Returns:
+            Mount dictionary with "name", "module", and "path" keys.
+
+        Raises:
+            ChimeraAdminError: If the request fails or mount not found
+        """
+        return self._request("GET", f"/api/v1/mounts/{name}")
+
+    def create_mount(
+        self,
+        name: str,
+        module: str,
+        path: str,
+        options: Optional[str] = None,
+    ) -> dict:
+        """Create a new VFS mount.
+
+        Args:
+            name: Mount name (the VFS mount path).
+            module: VFS module backing the mount (e.g. "linux", "memfs").
+            path: Backing path passed to the module.
+            options: Optional module-specific options string.
+
+        Returns:
+            Response message.
+
+        Raises:
+            ChimeraAdminError: If the request fails (e.g. 400 for missing
+                fields, 500 if the server fails to create the mount).
+        """
+        data = {"name": name, "module": module, "path": path}
+        if options is not None:
+            data["options"] = options
+        return self._request("POST", "/api/v1/mounts", json=data)
+
+    def delete_mount(self, name: str) -> None:
+        """Delete a VFS mount.
+
+        Args:
+            name: Mount name to delete.
+
+        Raises:
+            ChimeraAdminError: If the request fails, the mount is not found
+                (404), or the mount is still in use by a share, export, or
+                bucket (409).
+        """
+        self._request_no_content("DELETE", f"/api/v1/mounts/{name}")
+
     def _request_no_content(
         self,
         method: str,

--- a/src/admin/tests/test_api.py
+++ b/src/admin/tests/test_api.py
@@ -115,6 +115,45 @@ class TestBucketsAPI:
         assert exc_info.value.status_code == 404
 
 
+class TestMountsAPI:
+    """Test the VFS Mounts API endpoints."""
+
+    def test_list_mounts(self, client):
+        """Test listing VFS mounts includes the configured mount."""
+        mounts = client.list_mounts()
+        assert isinstance(mounts, list)
+        # The test config defines a "testshare" memfs mount.
+        assert any(m["name"] == "testshare" for m in mounts)
+
+    def test_get_mount(self, client):
+        """Test fetching the configured mount."""
+        mount = client.get_mount("testshare")
+        assert mount["name"] == "testshare"
+        assert mount["module"] == "memfs"
+
+    def test_get_mount_not_found(self, client):
+        """Test getting a nonexistent mount."""
+        with pytest.raises(ChimeraAdminError) as exc_info:
+            client.get_mount("nonexistent_mount")
+        assert exc_info.value.status_code == 404
+
+    def test_create_get_delete_mount(self, client):
+        """Test creating, fetching, and deleting a mount."""
+        name = "sdk_test_mount"
+        try:
+            client.create_mount(name, module="memfs", path="/")
+
+            mount = client.get_mount(name)
+            assert mount["name"] == name
+            assert mount["module"] == "memfs"
+        finally:
+            client.delete_mount(name)
+
+        with pytest.raises(ChimeraAdminError) as exc_info:
+            client.get_mount(name)
+        assert exc_info.value.status_code == 404
+
+
 class TestHTTPS:
     """Test HTTPS API endpoints with self-signed certificate."""
 
@@ -142,3 +181,8 @@ class TestHTTPS:
         """Test listing buckets over HTTPS."""
         buckets = https_client.list_buckets()
         assert isinstance(buckets, list)
+
+    def test_https_list_mounts(self, https_client):
+        """Test listing mounts over HTTPS."""
+        mounts = https_client.list_mounts()
+        assert isinstance(mounts, list)

--- a/src/admin/tests/test_e2e_smb.py
+++ b/src/admin/tests/test_e2e_smb.py
@@ -1,0 +1,125 @@
+# SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""End-to-end SMB pipeline test.
+
+Drives the full multi-protocol lifecycle against a live daemon: create a user
+with an SMB password, mount a memfs backend, expose it as an SMB share, connect
+over SMB with the real smbclient binary, and verify the mount-in-use (409)
+guard before tearing everything down.
+
+Management operations go through the Python SDK client (what the CLI wraps);
+the data path uses the system smbclient.
+"""
+
+import os
+import shutil
+import subprocess
+
+import pytest
+from chimera_admin import ChimeraAdminError
+
+USER = "testuser1"
+PASSWORD = "systest"
+MOUNT = "smbmount"
+SHARE = "smb1"
+SHARE_PATH = "/smbmount"
+
+# The daemon binds the privileged SMB port 445, and smbclient must be present.
+# Skip cleanly elsewhere rather than fail.
+pytestmark = [
+    pytest.mark.skipif(
+        shutil.which("smbclient") is None, reason="smbclient not installed"
+    ),
+    pytest.mark.skipif(
+        os.geteuid() != 0,
+        reason="daemon must bind privileged SMB port 445 (needs root)",
+    ),
+]
+
+
+def _smbclient(host, share, user, password, command, timeout=30):
+    """Run a single smbclient command against the server.
+
+    Mirrors the invocation proven in the C smbclient_auth_test.c NTLM test:
+    ``smbclient //host/share -U user%password -c '<command>'`` with no extra
+    flags. Returns the CompletedProcess.
+    """
+    return subprocess.run(
+        [
+            "smbclient",
+            f"//{host}/{share}",
+            "-U",
+            f"{user}%{password}",
+            "-c",
+            command,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+class TestSmbPipeline:
+    """Exercise the user -> mount -> share -> SMB access -> teardown flow."""
+
+    def test_full_smb_pipeline(self, client, chimera_server):
+        """Walk the entire pipeline end to end against the session daemon."""
+        host, _ = chimera_server
+
+        created = {"user": False, "mount": False, "share": False}
+        try:
+            # 1. User with an SMB password (stored plaintext; the server
+            #    computes the NTLM hash on the fly).
+            client.create_user(USER, uid=1000, gid=1000, smbpasswd=PASSWORD)
+            created["user"] = True
+
+            # 2. memfs mount; appears in the VFS namespace at /smbmount.
+            client.create_mount(MOUNT, module="memfs", path="/")
+            created["mount"] = True
+
+            # 3. SMB share backed by that mount.
+            client.create_share(SHARE, SHARE_PATH)
+            created["share"] = True
+
+            # 4. Data path: authenticate over SMB and list the share root.
+            result = _smbclient(host, SHARE, USER, PASSWORD, "ls")
+            assert result.returncode == 0, (
+                "smbclient ls failed (rc="
+                f"{result.returncode})\nstdout:\n{result.stdout}\n"
+                f"stderr:\n{result.stderr}"
+            )
+
+            # 5. Deleting the mount must fail while the share references it.
+            with pytest.raises(ChimeraAdminError) as exc_info:
+                client.delete_mount(MOUNT)
+            assert exc_info.value.status_code == 409
+
+            # 6. Remove the share, then the mount succeeds.
+            client.delete_share(SHARE)
+            created["share"] = False
+
+            client.delete_mount(MOUNT)
+            created["mount"] = False
+
+            client.delete_user(USER)
+            created["user"] = False
+        finally:
+            # Best-effort cleanup so a mid-test failure does not leak resources
+            # into the session daemon shared with the other test modules.
+            if created["share"]:
+                try:
+                    client.delete_share(SHARE)
+                except ChimeraAdminError:
+                    pass
+            if created["mount"]:
+                try:
+                    client.delete_mount(MOUNT)
+                except ChimeraAdminError:
+                    pass
+            if created["user"]:
+                try:
+                    client.delete_user(USER)
+                except ChimeraAdminError:
+                    pass

--- a/src/server/rest/CMakeLists.txt
+++ b/src/server/rest/CMakeLists.txt
@@ -9,6 +9,7 @@ add_library(chimera_rest SHARED
     rest.c
     rest_users.c
     rest_shares.c
+    rest_mounts.c
     rest_swagger.c
     rest_debug.c
 )

--- a/src/server/rest/rest.c
+++ b/src/server/rest/rest.c
@@ -99,6 +99,27 @@ void chimera_rest_handle_buckets_delete(
     struct chimera_rest_thread *,
     const char *);
 
+void chimera_rest_handle_mounts_list(
+    struct evpl *,
+    struct evpl_http_request *,
+    struct chimera_rest_thread *);
+void chimera_rest_handle_mounts_get(
+    struct evpl *,
+    struct evpl_http_request *,
+    struct chimera_rest_thread *,
+    const char *);
+void chimera_rest_handle_mounts_create(
+    struct evpl *,
+    struct evpl_http_request *,
+    struct chimera_rest_thread *,
+    const char *,
+    int);
+void chimera_rest_handle_mounts_delete(
+    struct evpl *,
+    struct evpl_http_request *,
+    struct chimera_rest_thread *,
+    const char *);
+
 /* External handlers from rest_swagger.c */
 void chimera_rest_handle_swagger_ui(
     struct evpl *,
@@ -130,6 +151,7 @@ enum chimera_rest_post_handler {
     REST_POST_EXPORTS_CREATE,
     REST_POST_SHARES_CREATE,
     REST_POST_BUCKETS_CREATE,
+    REST_POST_MOUNTS_CREATE,
     REST_POST_DEBUG_FSOP,
 };
 
@@ -202,6 +224,10 @@ chimera_rest_notify(
         case REST_POST_BUCKETS_CREATE:
             chimera_rest_handle_buckets_create(evpl, request, thread,
                                                body, body_len);
+            break;
+        case REST_POST_MOUNTS_CREATE:
+            chimera_rest_handle_mounts_create(evpl, request, thread,
+                                              body, body_len);
             break;
         case REST_POST_DEBUG_FSOP:
             chimera_rest_handle_debug_fsop(evpl, request, thread,
@@ -544,6 +570,35 @@ chimera_rest_dispatch(
             } else if (req_type == EVPL_HTTP_REQUEST_TYPE_DELETE) {
                 chimera_rest_handle_buckets_delete(evpl, request, thread,
                                                    param);
+            } else {
+                chimera_rest_handle_method_not_allowed(evpl, request);
+            }
+            return;
+        }
+    }
+
+    /* Mounts API: /api/v1/mounts */
+    if (url_len == 14 && strncmp(url, "/api/v1/mounts", 14) == 0) {
+        if (req_type == EVPL_HTTP_REQUEST_TYPE_GET) {
+            chimera_rest_handle_mounts_list(evpl, request, thread);
+        } else if (req_type == EVPL_HTTP_REQUEST_TYPE_POST) {
+            struct chimera_rest_post_ctx *ctx;
+            ctx          = calloc(1, sizeof(*ctx));
+            ctx->handler = REST_POST_MOUNTS_CREATE;
+            *notify_data = ctx;
+        } else {
+            chimera_rest_handle_method_not_allowed(evpl, request);
+        }
+        return;
+    }
+
+    if (chimera_rest_url_starts_with(url, url_len, "/api/v1/mounts/", 15)) {
+        chimera_rest_extract_path_param(url, url_len, 15, param, sizeof(param));
+        if (param[0] != '\0') {
+            if (req_type == EVPL_HTTP_REQUEST_TYPE_GET) {
+                chimera_rest_handle_mounts_get(evpl, request, thread, param);
+            } else if (req_type == EVPL_HTTP_REQUEST_TYPE_DELETE) {
+                chimera_rest_handle_mounts_delete(evpl, request, thread, param);
             } else {
                 chimera_rest_handle_method_not_allowed(evpl, request);
             }

--- a/src/server/rest/rest_mounts.c
+++ b/src/server/rest/rest_mounts.c
@@ -1,0 +1,249 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <jansson.h>
+
+#include "evpl/evpl.h"
+#include "evpl/evpl_http.h"
+#include "server/server.h"
+#include "vfs/vfs_error.h"
+#include "vfs/vfs_procs.h"
+#include "rest_internal.h"
+
+/* ======================== VFS Mounts ======================== */
+
+struct mount_list_ctx {
+    json_t *array;
+};
+
+static int
+mount_to_json_callback(
+    const char *mount_path,
+    const char *module_name,
+    const char *module_path,
+    void       *data)
+{
+    struct mount_list_ctx *ctx = data;
+    json_t                *obj;
+
+    obj = json_object();
+    json_object_set_new(obj, "name", json_string(mount_path));
+    json_object_set_new(obj, "module", json_string(module_name));
+    json_object_set_new(obj, "path", json_string(module_path));
+
+    json_array_append_new(ctx->array, obj);
+
+    return 0;
+} /* mount_to_json_callback */
+
+void
+chimera_rest_handle_mounts_list(
+    struct evpl                *evpl,
+    struct evpl_http_request   *request,
+    struct chimera_rest_thread *thread)
+{
+    struct mount_list_ctx ctx;
+
+    ctx.array = json_array();
+
+    chimera_server_iterate_mounts(thread->shared->server,
+                                  mount_to_json_callback, &ctx);
+
+    chimera_rest_send_json(evpl, request, 200, ctx.array);
+} /* chimera_rest_handle_mounts_list */
+
+struct mount_get_ctx {
+    const char *name;
+    json_t     *result;
+};
+
+static int
+mount_get_callback(
+    const char *mount_path,
+    const char *module_name,
+    const char *module_path,
+    void       *data)
+{
+    struct mount_get_ctx *ctx = data;
+
+    if (strcmp(mount_path, ctx->name) != 0) {
+        return 0;
+    }
+
+    ctx->result = json_object();
+    json_object_set_new(ctx->result, "name", json_string(mount_path));
+    json_object_set_new(ctx->result, "module", json_string(module_name));
+    json_object_set_new(ctx->result, "path", json_string(module_path));
+
+    return 1;
+} /* mount_get_callback */
+
+void
+chimera_rest_handle_mounts_get(
+    struct evpl                *evpl,
+    struct evpl_http_request   *request,
+    struct chimera_rest_thread *thread,
+    const char                 *name)
+{
+    struct mount_get_ctx ctx;
+    const char          *path = name;
+
+    /* Mount paths are registered with leading slashes stripped, so normalize
+     * the requested name the same way before matching. */
+    while (*path == '/') {
+        path++;
+    }
+
+    ctx.name   = path;
+    ctx.result = NULL;
+
+    chimera_server_iterate_mounts(thread->shared->server,
+                                  mount_get_callback, &ctx);
+
+    if (!ctx.result) {
+        chimera_rest_send_error(evpl, request, 404, "Not Found",
+                                "Mount does not exist");
+        return;
+    }
+
+    chimera_rest_send_json(evpl, request, 200, ctx.result);
+} /* chimera_rest_handle_mounts_get */
+
+/*
+ * Mount and umount are asynchronous VFS operations.  They are driven on this
+ * REST thread's own VFS thread (thread->vfs_thread) rather than via the
+ * blocking chimera_server_mount/unmount helpers, which spin up a throwaway
+ * evpl and register a fresh VFS thread -- doing so from an already
+ * RCU-registered REST worker aborts on a liburcu double-registration.  The
+ * HTTP reply is dispatched from the completion callback.
+ */
+
+struct mount_create_ctx {
+    struct evpl              *evpl;
+    struct evpl_http_request *request;
+    json_t                   *root;
+};
+
+static void
+mount_create_complete(
+    struct chimera_vfs_thread *vfs_thread,
+    enum chimera_vfs_error     status,
+    void                      *private_data)
+{
+    struct mount_create_ctx *ctx = private_data;
+    json_t                  *obj;
+
+    if (status == CHIMERA_VFS_OK) {
+        obj = json_object();
+        json_object_set_new(obj, "message", json_string("Mount created"));
+        chimera_rest_send_json(ctx->evpl, ctx->request, 201, obj);
+    } else {
+        chimera_rest_send_error(ctx->evpl, ctx->request, 500,
+                                "Internal Server Error",
+                                "Failed to create mount");
+    }
+
+    json_decref(ctx->root);
+    free(ctx);
+} /* mount_create_complete */
+
+void
+chimera_rest_handle_mounts_create(
+    struct evpl                *evpl,
+    struct evpl_http_request   *request,
+    struct chimera_rest_thread *thread,
+    const char                 *body,
+    int                         body_len)
+{
+    json_t                  *root;
+    json_error_t             error;
+    const char              *name;
+    const char              *module;
+    const char              *path;
+    const char              *options;
+    struct mount_create_ctx *ctx;
+
+    root = json_loadb(body, body_len, 0, &error);
+    if (!root) {
+        chimera_rest_send_error(evpl, request, 400, "Bad Request",
+                                error.text);
+        return;
+    }
+
+    name    = json_string_value(json_object_get(root, "name"));
+    module  = json_string_value(json_object_get(root, "module"));
+    path    = json_string_value(json_object_get(root, "path"));
+    options = json_string_value(json_object_get(root, "options"));
+
+    if (!name || !module || !path) {
+        json_decref(root);
+        chimera_rest_send_error(evpl, request, 400, "Bad Request",
+                                "Missing required fields: name, module, path");
+        return;
+    }
+
+    /* chimera_vfs_mount stores the name/path pointers until the operation
+     * completes, so the parsed JSON (which owns those strings) is kept alive
+     * in the context and released in the completion callback. */
+    ctx          = malloc(sizeof(*ctx));
+    ctx->evpl    = evpl;
+    ctx->request = request;
+    ctx->root    = root;
+
+    chimera_vfs_mount(thread->vfs_thread, NULL, name, module, path, options,
+                      mount_create_complete, ctx);
+} /* chimera_rest_handle_mounts_create */
+
+struct mount_delete_ctx {
+    struct evpl              *evpl;
+    struct evpl_http_request *request;
+};
+
+static void
+mount_delete_complete(
+    struct chimera_vfs_thread *vfs_thread,
+    enum chimera_vfs_error     status,
+    void                      *private_data)
+{
+    struct mount_delete_ctx *ctx = private_data;
+
+    if (status == CHIMERA_VFS_ENOENT) {
+        chimera_rest_send_error(ctx->evpl, ctx->request, 404, "Not Found",
+                                "Mount does not exist");
+    } else if (status != CHIMERA_VFS_OK) {
+        chimera_rest_send_error(ctx->evpl, ctx->request, 500,
+                                "Internal Server Error",
+                                "Failed to delete mount");
+    } else {
+        evpl_http_server_dispatch_default(ctx->request, 204);
+    }
+
+    free(ctx);
+} /* mount_delete_complete */
+
+void
+chimera_rest_handle_mounts_delete(
+    struct evpl                *evpl,
+    struct evpl_http_request   *request,
+    struct chimera_rest_thread *thread,
+    const char                 *name)
+{
+    struct mount_delete_ctx *ctx;
+
+    if (chimera_server_mount_in_use(thread->shared->server, name)) {
+        chimera_rest_send_error(evpl, request, 409, "Conflict",
+                                "Mount is in use by a share, export, or bucket");
+        return;
+    }
+
+    ctx          = malloc(sizeof(*ctx));
+    ctx->evpl    = evpl;
+    ctx->request = request;
+
+    chimera_vfs_umount(thread->vfs_thread, NULL, name, mount_delete_complete,
+                       ctx);
+} /* chimera_rest_handle_mounts_delete */

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -1306,6 +1306,44 @@ chimera_server_mkpath(
     return ctx.status == CHIMERA_VFS_OK ? 0 : -1;
 } /* chimera_server_mkpath */
 
+static void
+chimera_server_umount_callback(
+    struct chimera_vfs_thread *thread,
+    enum chimera_vfs_error     status,
+    void                      *private_data)
+{
+    struct mount_ctx *ctx = private_data;
+
+    ctx->done   = 1;
+    ctx->status = status;
+} /* chimera_server_umount_callback */
+
+SYMBOL_EXPORT int
+chimera_server_unmount(
+    struct chimera_server *server,
+    const char            *mount_path)
+{
+    struct evpl               *evpl;
+    struct chimera_vfs_thread *thread;
+    struct mount_ctx           ctx = { .done = 0, .status = 0 };
+
+    evpl = evpl_create(NULL);
+
+    thread = chimera_vfs_thread_init(evpl, server->vfs);
+
+    chimera_vfs_umount(thread, NULL, mount_path, chimera_server_umount_callback, &ctx);
+
+    while (!ctx.done) {
+        evpl_continue(evpl);
+    }
+
+    chimera_vfs_thread_destroy(thread);
+
+    evpl_destroy(evpl);
+
+    return ctx.status;
+} /* chimera_server_unmount */
+
 SYMBOL_EXPORT int
 chimera_server_pnfs_resolve(struct chimera_server *server)
 {
@@ -1755,6 +1793,129 @@ chimera_server_iterate_buckets(
 
     chimera_s3_iterate_buckets(server->s3_shared, callback, data);
 } /* chimera_server_iterate_buckets */
+
+struct mount_iterate_ctx {
+    chimera_server_mount_iterate_cb callback;
+    void                           *data;
+};
+
+static int
+mount_iterate_wrapper(
+    struct chimera_vfs_mount *mount,
+    void                     *data)
+{
+    struct mount_iterate_ctx *ctx = data;
+
+    return ctx->callback(mount->path,
+                         mount->module ? mount->module->name : "",
+                         mount->module_path ? mount->module_path : "",
+                         ctx->data);
+} /* mount_iterate_wrapper */
+
+SYMBOL_EXPORT void
+chimera_server_iterate_mounts(
+    struct chimera_server          *server,
+    chimera_server_mount_iterate_cb callback,
+    void                           *data)
+{
+    struct mount_iterate_ctx ctx = { .callback = callback, .data = data };
+
+    chimera_vfs_mount_table_foreach(server->vfs->mount_table,
+                                    mount_iterate_wrapper, &ctx);
+} /* chimera_server_iterate_mounts */
+
+struct mount_in_use_ctx {
+    struct chimera_vfs *vfs;
+    const char         *target;
+    int                 target_len;
+    int                 in_use;
+};
+
+/*
+ * Resolve the path of a share/export/bucket to its owning mount and flag a
+ * match against the target mount.  Paths are normalized (leading slashes
+ * stripped) the same way chimera_vfs_mount registers them.  Returns non-zero
+ * once a match is found to stop the enclosing iteration early.
+ */
+static int
+mount_in_use_check_path(
+    struct mount_in_use_ctx *ctx,
+    const char              *path)
+{
+    struct chimera_vfs_mount *mount;
+
+    while (*path == '/') {
+        path++;
+    }
+
+    mount = chimera_vfs_mount_table_find_by_path(ctx->vfs->mount_table,
+                                                 path, strlen(path));
+
+    if (mount &&
+        mount->pathlen == (uint32_t) ctx->target_len &&
+        memcmp(mount->path, ctx->target, ctx->target_len) == 0) {
+        ctx->in_use = 1;
+        return 1;
+    }
+
+    return 0;
+} /* mount_in_use_check_path */
+
+static int
+mount_in_use_share_cb(
+    const struct chimera_smb_share *share,
+    void                           *data)
+{
+    return mount_in_use_check_path(data, chimera_smb_share_get_path(share));
+} /* mount_in_use_share_cb */
+
+static int
+mount_in_use_export_cb(
+    const struct chimera_nfs_export *export,
+    void                            *data)
+{
+    return mount_in_use_check_path(data, chimera_nfs_export_get_path(export));
+} /* mount_in_use_export_cb */
+
+static int
+mount_in_use_bucket_cb(
+    const struct s3_bucket *bucket,
+    void                   *data)
+{
+    return mount_in_use_check_path(data, chimera_s3_bucket_get_path(bucket));
+} /* mount_in_use_bucket_cb */
+
+SYMBOL_EXPORT int
+chimera_server_mount_in_use(
+    struct chimera_server *server,
+    const char            *mount_path)
+{
+    struct mount_in_use_ctx ctx;
+    const char             *target = mount_path;
+
+    while (*target == '/') {
+        target++;
+    }
+
+    ctx.vfs        = server->vfs;
+    ctx.target     = target;
+    ctx.target_len = strlen(target);
+    ctx.in_use     = 0;
+
+    if (server->smb_shared) {
+        chimera_smb_iterate_shares(server->smb_shared, mount_in_use_share_cb, &ctx);
+    }
+
+    if (!ctx.in_use && server->nfs_shared) {
+        chimera_nfs_iterate_exports(server->nfs_shared, mount_in_use_export_cb, &ctx);
+    }
+
+    if (!ctx.in_use && server->s3_shared) {
+        chimera_s3_iterate_buckets(server->s3_shared, mount_in_use_bucket_cb, &ctx);
+    }
+
+    return ctx.in_use;
+} /* chimera_server_mount_in_use */
 
 SYMBOL_EXPORT struct chimera_vfs *
 chimera_server_get_vfs(struct chimera_server *server)

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -464,6 +464,28 @@ chimera_server_mkpath(
     uint32_t               mode);
 
 int
+chimera_server_unmount(
+    struct chimera_server *server,
+    const char            *mount_path);
+
+int
+chimera_server_mount_in_use(
+    struct chimera_server *server,
+    const char            *mount_path);
+
+typedef int (*chimera_server_mount_iterate_cb)(
+    const char *mount_path,
+    const char *module_name,
+    const char *module_path,
+    void       *data);
+
+void
+chimera_server_iterate_mounts(
+    struct chimera_server          *server,
+    chimera_server_mount_iterate_cb callback,
+    void                           *data);
+
+int
 chimera_server_create_bucket(
     struct chimera_server *server,
     const char            *bucket_name,

--- a/src/vfs/vfs.h
+++ b/src/vfs/vfs.h
@@ -1332,6 +1332,7 @@ struct chimera_vfs_mount_attrs {
 struct chimera_vfs_mount {
     struct chimera_vfs_module     *module;
     char                          *path;
+    char                          *module_path;
     uint32_t                       pathlen;
     int                            root_fh_len;
     void                          *mount_private;

--- a/src/vfs/vfs_mount_table.h
+++ b/src/vfs/vfs_mount_table.h
@@ -91,6 +91,7 @@ chimera_vfs_mount_table_destroy(struct chimera_vfs_mount_table *table)
             next = entry->next;
             /* Free the mount and its path */
             free(entry->mount->path);
+            free(entry->mount->module_path);
             free(entry->mount);
             free(entry);
             entry = next;

--- a/src/vfs/vfs_proc_mount.c
+++ b/src/vfs/vfs_proc_mount.c
@@ -129,6 +129,7 @@ chimera_vfs_mount_complete(struct chimera_vfs_request *request)
 
     mount->module        = request->mount.module;
     mount->path          = strdup(request->mount.mount_path);
+    mount->module_path   = strdup(request->mount.path ? request->mount.path : "");
     mount->pathlen       = strlen(request->mount.mount_path);
     mount->mount_private = request->mount.r_mount_private;
 

--- a/src/vfs/vfs_proc_umount.c
+++ b/src/vfs/vfs_proc_umount.c
@@ -23,6 +23,7 @@ chimera_vfs_umount_complete(struct chimera_vfs_request *request)
     chimera_vfs_request_free(thread, request);
 
     free(request->umount.mount->path);
+    free(request->umount.mount->module_path);
     free(request->umount.mount);
 
 } /* chimera_vfs_umount */


### PR DESCRIPTION
Add a REST endpoint set under /api/v1/mounts for managing VFS mounts:
  GET    /api/v1/mounts          list all mounts
  GET    /api/v1/mounts/{name}   fetch a single mount
  POST   /api/v1/mounts          create a mount (name, module, path, options)
  DELETE /api/v1/mounts/{name}   remove a mount

New rest_mounts.c implements the handlers; rest.c registers the routes and POST dispatch. Server-side support adds chimera_server_unmount, chimera_server_iterate_mounts, and chimera_server_mount_in_use, the latter rejecting deletes (409) while a share, export, or bucket still references the mount. Each mount tracks its backing module path via a new module_path field on struct chimera_vfs_mount, populated on mount and freed on umount and table destroy, so the API can report it. Mount paths are normalized (leading slashes stripped) to match how chimera_vfs_mount registers them.

The create/delete handlers drive chimera_vfs_mount/chimera_vfs_umount asynchronously on the REST thread's own vfs_thread and reply from the completion callback, mirroring rest_debug.c. They must not use the blocking chimera_server_mount/unmount helpers: those spin up a throwaway evpl and register a fresh VFS thread, which aborts on a liburcu double-registration when called from an already-registered REST worker thread.

Admin SDK (src/admin):
  - client.py: list_mounts/get_mount/create_mount/delete_mount
  - cli.py + __main__.py: CLI invoked as python3 -m chimera_admin, covering version, users, exports, shares, buckets, and mounts (argparse, no new dependencies)
  - README: document the CLI
  - tests: unit tests for the mounts API plus an end-to-end SMB pipeline test that creates a user/mount/share, connects with smbclient, verifies the in-use (409) guard, and tears everything down