### PR TITLE
smb2: support the SMB 2.0.2 dialect

### DIFF
--- a/src/server/server.c
+++ b/src/server/server.c
@@ -145,11 +145,12 @@ chimera_server_config_init(void)
     config->rest_debug_fsops         = 0;
     config->tcp_flavor               = CHIMERA_TCP_FLAVOR_PLAIN;
 
-    config->smb_num_dialects = 4;
-    config->smb_dialects[0]  = SMB2_DIALECT_2_1;
-    config->smb_dialects[1]  = SMB2_DIALECT_3_0;
-    config->smb_dialects[2]  = SMB2_DIALECT_3_0_2;
-    config->smb_dialects[3]  = SMB2_DIALECT_3_1_1;
+    config->smb_num_dialects = 5;
+    config->smb_dialects[0]  = SMB2_DIALECT_2_0_2;
+    config->smb_dialects[1]  = SMB2_DIALECT_2_1;
+    config->smb_dialects[2]  = SMB2_DIALECT_3_0;
+    config->smb_dialects[3]  = SMB2_DIALECT_3_0_2;
+    config->smb_dialects[4]  = SMB2_DIALECT_3_1_1;
 
     config->smb_num_nic_info = 0;
 

--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -1244,6 +1244,12 @@ chimera_smb_server_handle_smb1(
     uint8_t                     *dialects, *bp;
     char                        *dialect;
     int                          matched = 0;
+    /* Dialect the SMB1 multi-protocol negotiate resolves to: 0x02ff (the
+     * SMB2 wildcard, meaning "send a real SMB2 NEGOTIATE next") when the
+     * client offers "SMB 2.???", or 0x0202 when it offers the specific
+     * "SMB 2.002" string (MS-SMB2 3.3.5.3.1).  The wildcard takes precedence
+     * if both are present. */
+    uint16_t                     smb1_dialect = 0;
 
     evpl_iovec_cursor_init(&request_cursor, iov, niov);
     evpl_iovec_cursor_copy(&request_cursor, &netbios_hdr, sizeof(netbios_hdr));
@@ -1304,7 +1310,14 @@ chimera_smb_server_handle_smb1(
         }
 
         if (strcmp(dialect, "SMB 2.???") == 0) {
+            matched      = 1;
+            smb1_dialect = 0x02ff;
+        } else if (strcmp(dialect, "SMB 2.002") == 0) {
             matched = 1;
+            /* Don't let "SMB 2.002" clobber a wildcard already seen. */
+            if (smb1_dialect == 0) {
+                smb1_dialect = SMB2_DIALECT_2_0_2;
+            }
         }
 
         bp++;
@@ -1361,7 +1374,7 @@ chimera_smb_server_handle_smb1(
     memset(request->negotiate.client_guid, 0, sizeof(request->negotiate.client_guid));
     request->negotiate.negotiate_context_offset = 0;
     request->negotiate.negotiate_context_count  = 0;
-    request->negotiate.dialects[0]              = 0x02ff;
+    request->negotiate.dialects[0]              = smb1_dialect;
 
     compound->requests[compound->num_requests++] = request;
 


### PR DESCRIPTION
## Summary

Adds support for the **SMB 2.0.2** dialect (0x0202), which the server previously rejected.

Two failure modes are fixed:
- A client negotiating only 2.0.2 over a direct SMB2 NEGOTIATE got `STATUS_INVALID_PARAMETER` and the connection was dropped, because 2.0.2 was absent from the default dialect set (only 2.1/3.0/3.0.2/3.1.1 were accepted).
- The SMB1 multi-protocol negotiate only recognized the `"SMB 2.???"` wildcard, so an old-style negotiate offering `"SMB 2.002"` matched no SMB2 dialect and was dropped.

## Changes
- `server.c`: add `SMB2_DIALECT_2_0_2` to the default negotiated-dialect list.
- `smb.c`: in the SMB1 multi-protocol negotiate handler, recognize the `"SMB 2.002"` dialect string and resolve it to 0x0202; the `"SMB 2.???"` wildcard still takes precedence when both are present (MS-SMB2 3.3.5.3.1).

2.0.2 needs no new feature plumbing — every capability gate keys on `dialect >= 0x210` (large-MTU, leasing) or `>= 0x300` (multichannel, persistent handles, encryption), and signing already handles 2.0.2, so the older dialect simply negotiates none of those.

## Verification
WPTS MS-SMB2 cases `BVT_Negotiate_SMB2002` and `BVT_Negotiate_Compatible_2002` now pass. Ran the full Negotiate + ValidateNegotiateInfo families: no regressions (the 7 remaining failures there are pre-existing 3.1.1 encryption-context cases unrelated to this change).