### PR TITLE
smb2: answer FSCTL_SRV_ENUMERATE_SNAPSHOTS with an empty array

### DIFF
--- a/src/server/smb/smb2.h
+++ b/src/server/smb/smb2.h
@@ -930,6 +930,7 @@ typedef uint8_t smb2_guid[SMB2_GUID_SIZE];
 #define SMB2_FSCTL_SRV_COPYCHUNK                    0x001440F2
 #define SMB2_FSCTL_SRV_COPYCHUNK_WRITE              0x001480F2
 #define SMB2_FSCTL_CREATE_OR_GET_OBJECT_ID          0x000900C0
+#define SMB2_FSCTL_SRV_ENUMERATE_SNAPSHOTS          0x00144064
 
 #define SMB2_IO_REPARSE_TAG_NFS                     0x80000014
 #define SMB2_IO_REPARSE_TAG_SYMLINK                 0xA000000C

--- a/src/server/smb/smb_proc_ioctl.c
+++ b/src/server/smb/smb_proc_ioctl.c
@@ -213,6 +213,31 @@ chimera_smb_ioctl(struct chimera_smb_request *request)
             chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
             break;
 
+        case SMB2_FSCTL_SRV_ENUMERATE_SNAPSHOTS:
+            /* MS-SMB2 3.3.5.15.1 / MS-FSCC 2.3.20: enumerate the previous
+             * versions (VSS snapshots) of the open.  We don't expose
+             * snapshots, so return an empty SRV_SNAPSHOT_ARRAY (all counts
+             * zero) with SUCCESS rather than NOT_SUPPORTED — that is what a
+             * server with no snapshots reports, and clients expect it. */
+            open_file = chimera_smb_open_file_resolve(request, &request->ioctl.file_id);
+
+            if (unlikely(!open_file)) {
+                chimera_smb_complete_request(request, SMB2_STATUS_FILE_CLOSED);
+                return;
+            }
+
+            chimera_smb_open_file_release(request, open_file);
+
+            /* The SRV_SNAPSHOT_ARRAY response is a 12-byte header; the client
+             * must offer at least that much output space. */
+            if (request->ioctl.max_output_response < 12) {
+                chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
+                return;
+            }
+
+            chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
+            break;
+
         default:
             /* MS-SMB2 3.3.5.15: an FSCTL the server does not implement is
              * rejected with STATUS_NOT_SUPPORTED. */
@@ -260,6 +285,9 @@ chimera_smb_ioctl_reply(
             break;
         case SMB2_FSCTL_CREATE_OR_GET_OBJECT_ID:
             output_length = 64; /* FILE_OBJECTID_BUFFER (type 1) */
+            break;
+        case SMB2_FSCTL_SRV_ENUMERATE_SNAPSHOTS:
+            output_length = 12; /* SRV_SNAPSHOT_ARRAY header, empty list */
             break;
     } /* switch */
 
@@ -351,6 +379,14 @@ chimera_smb_ioctl_reply(
             break;
         case SMB2_FSCTL_CREATE_OR_GET_OBJECT_ID:
             evpl_iovec_cursor_append_blob(reply_cursor, request->ioctl.oid_buffer, 64);
+            break;
+        case SMB2_FSCTL_SRV_ENUMERATE_SNAPSHOTS:
+            /* Empty SRV_SNAPSHOT_ARRAY (MS-FSCC 2.3.20): no snapshots, none
+             * returned, zero array bytes.  With NumberOfSnapShotsReturned == 0
+             * the SnapShots[] array is absent. */
+            evpl_iovec_cursor_append_uint32(reply_cursor, 0); /* NumberOfSnapShots */
+            evpl_iovec_cursor_append_uint32(reply_cursor, 0); /* NumberOfSnapShotsReturned */
+            evpl_iovec_cursor_append_uint32(reply_cursor, 0); /* SnapShotArraySize */
             break;
         default:
             break;


### PR DESCRIPTION
## Summary

The server rejected `FSCTL_SRV_ENUMERATE_SNAPSHOTS` with `STATUS_NOT_SUPPORTED`. A server that exposes no previous versions (VSS snapshots) is expected to **succeed** and return an empty `SRV_SNAPSHOT_ARRAY` — that is what Windows and Samba do, and what clients (e.g. the Explorer "Previous Versions" tab) expect.

## Change
Handle the FSCTL in `smb_proc_ioctl.c`: resolve the open and, given enough output buffer, return `STATUS_SUCCESS` with `NumberOfSnapShots = NumberOfSnapShotsReturned = SnapShotArraySize = 0` (MS-FSCC 2.3.20 — with zero snapshots returned the `SnapShots[]` array is absent). Adds the `SMB2_FSCTL_SRV_ENUMERATE_SNAPSHOTS` (0x00144064) constant.

## Verification / scope
WPTS `BVT_EnumerateSnapShots` now confirms the response (`FSCTL_SRV_ENUMERATE_SNAPSHOTS should succeed, actually server returns STATUS_SUCCESS`) instead of seeing `NOT_SUPPORTED`.

Note: this WPTS case is designed for a SUT configured with **actual** previous versions — its final assertion `versionArray.Length == NumberOfSnapShotsReturned + 2` is unsatisfiable when the SDK forces the `SnapShots` field to zero length for `NumberOfSnapShotsReturned == 0` (`[Size("NumberOfSnapShotsReturned == 0 ? 0 : SnapShotArraySize")]`). With no snapshots configured the case goes **Inconclusive** after validating the SUCCESS response, rather than failing — moving it out of the failure column. The server-side correctness fix is the point; greening that test would require chimera to actually expose snapshots.