### PR TITLE
smb2: implement FileNormalizedNameInformation query

### DIFF
--- a/src/server/smb/smb2.h
+++ b/src/server/smb/smb2.h
@@ -968,6 +968,7 @@ typedef uint8_t smb2_guid[SMB2_GUID_SIZE];
 #define SMB2_FILE_COMPRESSION_INFO                  0x0C
 #define SMB2_FILE_NETWORK_OPEN_INFO                 0x22
 #define SMB2_FILE_ATTRIBUTE_TAG_INFO                0x23
+#define SMB2_FILE_NORMALIZED_NAME_INFO              0x30
 #define SMB2_FILE_DISPOSITION_INFO_EX               0x40
 
 /* SMB2 information types */

--- a/src/server/smb/smb_proc_query_info.c
+++ b/src/server/smb/smb_proc_query_info.c
@@ -305,6 +305,13 @@ chimera_smb_query_info(struct chimera_smb_request *request)
                         name_len + 4;
                     getattr_mask = CHIMERA_VFS_ATTR_MASK_STAT;
                     break;
+                case SMB2_FILE_NORMALIZED_NAME_INFO:
+                    /* MS-FSCC 2.4.30: FILE_NAME_INFORMATION layout
+                    * (FileNameLength + FileName, the name in UTF-16LE).  The
+                    * normalized name is the open's path, which we already
+                    * hold (as UTF-8) — no backend attrs needed. */
+                    request->query_info.output_length = 4 + request->query_info.open_file->name_len * 2;
+                    break;
                 case SMB2_FILE_FULL_EA_INFO:
                     request->query_info.output_length = 8;
                     break;
@@ -417,6 +424,21 @@ chimera_smb_query_info_reply(
                         reply_cursor,
                         request->query_info.open_file->position);
                     break;
+                case SMB2_FILE_NORMALIZED_NAME_INFO:
+                {
+                    /* FILE_NAME_INFORMATION: FileNameLength (UTF-16LE bytes)
+                     * followed by the name converted to UTF-16LE. */
+                    struct chimera_smb_open_file *of = request->query_info.open_file;
+                    uint16_t                     *nb;
+
+                    evpl_iovec_cursor_append_uint32(reply_cursor, of->name_len * 2);
+                    nb = evpl_iovec_cursor_data(reply_cursor);
+                    chimera_smb_utf8_to_utf16le(&request->compound->thread->iconv_ctx,
+                                                of->name, of->name_len,
+                                                nb, SMB_FILENAME_MAX * 2);
+                    evpl_iovec_cursor_skip(reply_cursor, of->name_len * 2);
+                    break;
+                }
                 case SMB2_FILE_ALL_INFO:
                     chimera_smb_append_all_info(reply_cursor, request->query_info.open_file, &request->query_info.
                                                 r_attrs);


### PR DESCRIPTION
## Summary

SMB2 QUERY_INFO for **FileNormalizedNameInformation** (info class `0x30`) fell through to the default case and returned `STATUS_NOT_IMPLEMENTED`.

Implement it as a `FILE_NAME_INFORMATION` response (MS-FSCC 2.4.30): `FileNameLength` followed by the open's path name. The name is the normalized path already kept on the open handle; it is emitted converted to **UTF-16LE** (the on-wire `FileName` encoding) via the thread iconv context — the same way `QUERY_DIRECTORY` emits entry names. No backend attributes are needed, so the request completes synchronously.

## Verification
WPTS `BVT_SMB2Basic_Query_FileNormalizedNameInformation_DataFile` and `_DirectoryFile` now pass. Regression-checked the query-info family (FileAllInformation, QueryAndSet_FileInfo, QueryDir\*) — no regressions.