### PR TITLE
smb2: per-share + global SMB3 encryption, pass the WPTS encryption suite

### DIFF
--- a/scripts/wpts_smb_test_wrapper.sh
+++ b/scripts/wpts_smb_test_wrapper.sh
@@ -101,7 +101,14 @@ generate_config() {
         if [ "${CHIMERA_SMB_PERSISTENT:-0}" = "1" ] && [ "$share" = "FileShare" ]; then
             share_ca=', "continuous_availability": true'
         fi
-        shares="${shares}${sep}\"${share}\": {\"path\": \"/${share}\"${share_ca}}"
+        # SMBEncrypted is the designated per-share-encrypted share (matches
+        # EncryptedFileShare in the ptfconfig); flag it so TREE_CONNECT
+        # advertises SMB2_SHAREFLAG_ENCRYPT_DATA and its traffic is encrypted.
+        local share_enc=""
+        if [ "${CHIMERA_SMB_ENCRYPTION:-0}" = "1" ] && [ "$share" = "SMBEncrypted" ]; then
+            share_enc=', "encrypt_data": true'
+        fi
+        shares="${shares}${sep}\"${share}\": {\"path\": \"/${share}\"${share_ca}${share_enc}}"
         sep=",
         "
     done
@@ -127,11 +134,20 @@ generate_config() {
         \"smb_min_dialect\": \"2.0.2\","
     fi
 
+    # Enable SMB3 transport encryption when requested. "enabled" turns on global
+    # (whole-session) encryption AND lets the per-share SMBEncrypted share opt in;
+    # default off keeps the rest of the suite on the cleartext path.
+    local encryption_line=""
+    if [ "${CHIMERA_SMB_ENCRYPTION:-0}" = "1" ]; then
+        encryption_line='"smb_encryption": "enabled",'
+    fi
+
     cat > "$CONFIG_FILE" << EOF
 {
     "server": {
         ${persistent_line}
         ${multichannel_line}
+        ${encryption_line}
         "threads": 4,
         "delegation_threads": 4,
         "external_portmap": false
@@ -232,6 +248,19 @@ if [ "${CHIMERA_SMB_MULTICHANNEL:-0}" = "1" ]; then
     sed -i \
         -e "s#<Property name=\"SutAlternativeIPAddress\" value=\"\"/>#<Property name=\"SutAlternativeIPAddress\" value=\"${SUT_IP2}\"/>#" \
         "$staged_smb2"
+fi
+
+# When encryption is enabled, advertise it to the driver so the Encryption cases
+# become applicable: declare support, the cipher list chimera offers, the
+# per-share encrypted share, and that global encrypt-data is on.
+if [ "${CHIMERA_SMB_ENCRYPTION:-0}" = "1" ]; then
+    staged="${WPTS_BIN_DIR}/CommonTestSuite.deployment.ptfconfig"
+    sed -i \
+        -e 's#<Property name="IsEncryptionSupported" value="false"/>#<Property name="IsEncryptionSupported" value="true"/>#' \
+        -e 's#<Property name="IsGlobalEncryptDataEnabled" value="false"/>#<Property name="IsGlobalEncryptDataEnabled" value="true"/>#' \
+        -e 's#<Property name="EncryptedFileShare" value=""/>#<Property name="EncryptedFileShare" value="SMBEncrypted"/>#' \
+        -e 's#<Property name="SutSupportedEncryptionAlgorithms" value=""/>#<Property name="SutSupportedEncryptionAlgorithms" value="ENCRYPTION_AES128_CCM;ENCRYPTION_AES128_GCM;ENCRYPTION_AES256_CCM;ENCRYPTION_AES256_GCM"/>#' \
+        "$staged"
 fi
 
 mkdir -p "$RESULT_DIR"

--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -881,12 +881,17 @@ main(
     if (shares) {
         json_object_foreach(shares, name, share)
         {
-            json_t *ca = json_object_get(share, "continuous_availability");
+            json_t *ca  = json_object_get(share, "continuous_availability");
+            json_t *enc = json_object_get(share, "encrypt_data");
 
             path = json_string_value(json_object_get(share, "path"));
             chimera_server_info("Adding SMB share %s -> %s", name, path);
             chimera_server_create_share(server, name, path,
                                         json_is_true(ca) ? 1 : 0);
+
+            if (json_is_true(enc)) {
+                chimera_server_share_set_encrypt_data(server, name);
+            }
         }
     }
 

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -1468,6 +1468,19 @@ chimera_server_share_set_access_based_enum(
 } /* chimera_server_share_set_access_based_enum */
 
 SYMBOL_EXPORT int
+chimera_server_share_set_encrypt_data(
+    struct chimera_server *server,
+    const char            *share_name)
+{
+    if (!server->smb_shared) {
+        return -1;
+    }
+
+    return chimera_smb_share_set_encrypt_data(server->smb_shared,
+                                              share_name);
+} /* chimera_server_share_set_encrypt_data */
+
+SYMBOL_EXPORT int
 chimera_server_create_export(
     struct chimera_server *server,
     const char            *name,

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -509,6 +509,11 @@ chimera_server_share_set_access_based_enum(
     const char            *share_name);
 
 int
+chimera_server_share_set_encrypt_data(
+    struct chimera_server *server,
+    const char            *share_name);
+
+int
 chimera_server_create_export(
     struct chimera_server *server,
     const char            *share_name,

--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -518,9 +518,10 @@ chimera_smb_compound_reply(struct chimera_smb_compound *compound)
     }
 
     /* SMB3 transport encryption: wrap the signed reply in a TRANSFORM header
-     * when the request arrived encrypted, or when the session negotiated
-     * encryption.  The NEGOTIATE / SESSION_SETUP responses themselves precede
-     * key establishment and are always sent signed-but-plaintext. */
+     * when the request arrived encrypted, when the session negotiated global
+     * encryption, or when it targets a per-share-encrypted tree.  The NEGOTIATE
+     * / SESSION_SETUP responses themselves precede key establishment and are
+     * always sent signed-but-plaintext. */
     {
         struct chimera_smb_session *enc_session = NULL;
 
@@ -528,11 +529,16 @@ chimera_smb_compound_reply(struct chimera_smb_compound *compound)
             enc_session = compound->requests[0]->session_handle->session;
         }
 
-        if (enc_session && (enc_session->flags & CHIMERA_SMB_SESSION_ENCRYPT_DATA)) {
-            uint16_t cmd0 = compound->requests[0]->smb2_hdr.command;
+        if (enc_session && enc_session->enc_key_len > 0) {
+            uint16_t                 cmd0         = compound->requests[0]->smb2_hdr.command;
+            struct chimera_smb_tree *tree0        = compound->requests[0]->tree;
+            int                      tree_encrypt = tree0 && tree0->share &&
+                tree0->share->encrypt_data;
 
             if (compound->received_encrypted ||
-                (cmd0 != SMB2_NEGOTIATE && cmd0 != SMB2_SESSION_SETUP)) {
+                (cmd0 != SMB2_NEGOTIATE && cmd0 != SMB2_SESSION_SETUP &&
+                 ((enc_session->flags & CHIMERA_SMB_SESSION_ENCRYPT_DATA) ||
+                  tree_encrypt))) {
                 struct evpl_iovec enc_iov;
                 uint64_t          nonce;
                 int               enc_total;
@@ -1050,8 +1056,16 @@ chimera_smb_server_handle_smb2(
          * final NTLM message is signed with a session key the server only
          * derives while *processing* this very request, so the key isn't
          * available here yet.  The NTLM exchange authenticates the request, and
-         * the success reply is signed (proving the server's key). */
+         * the success reply is signed (proving the server's key).
+         *
+         * Messages received inside a TRANSFORM (received_encrypted) are also not
+         * signature-verified: the AEAD tag already authenticated the whole
+         * message, and per MS-SMB2 §3.3.5.2.9 the server skips signing
+         * verification for a successfully decrypted request.  Such inner SMB2
+         * headers commonly carry SMB2_FLAGS_SIGNED with a zeroed Signature
+         * field, which would otherwise fail verification. */
         if ((request->smb2_hdr.flags & SMB2_FLAGS_SIGNED) &&
+            !received_encrypted &&
             request->smb2_hdr.command != SMB2_SESSION_SETUP) {
             uint8_t *signing_key;
 
@@ -1091,6 +1105,30 @@ chimera_smb_server_handle_smb2(
                 evpl_close(evpl, conn->bind);
                 return;
             }
+        } else if (!received_encrypted &&
+                   !(request->smb2_hdr.flags & SMB2_FLAGS_SIGNED) &&
+                   !(request->smb2_hdr.flags & SMB2_FLAGS_RELATED_OPERATIONS) &&
+                   request->smb2_hdr.command != SMB2_NEGOTIATE &&
+                   request->smb2_hdr.command != SMB2_SESSION_SETUP &&
+                   request->smb2_hdr.command != SMB2_ECHO &&
+                   ((conn->flags & CHIMERA_SMB_CONN_FLAG_SIGNING_REQUIRED) ||
+                    (request->session_handle && request->session_handle->session &&
+                     (request->session_handle->session->flags &
+                      CHIMERA_SMB_SESSION_ENCRYPT_DATA)))) {
+            /* MS-SMB2 §3.3.5.2.9 / §3.3.5.7: once a session requires protection —
+             * because signing is required, or because global encryption marked
+             * the session encrypt-all (Session.EncryptData) — every
+             * post-authentication request must be either signed or encrypted.
+             * An unsigned, unencrypted request (e.g. a bare TREE_CONNECT) is a
+             * protocol violation; tear the connection down.  SESSION_SETUP is
+             * exempt (its signing key is only derived while processing it), as
+             * are NEGOTIATE and ECHO; compound related operations inherit the
+             * lead request's protection so only the unrelated lead is checked. */
+            chimera_smb_error("Unsigned, unencrypted request (cmd %u) on a protected connection; disconnecting",
+                              request->smb2_hdr.command);
+            chimera_smb_request_free(thread, request);
+            evpl_close(evpl, conn->bind);
+            return;
         }
 
         if (unlikely(!request->session_handle &&
@@ -1500,7 +1538,11 @@ chimera_smb_server_handle_transform(
 
     session = chimera_smb_session_lookup(thread->shared, th.session_id);
 
-    if (!session || !(session->flags & CHIMERA_SMB_SESSION_ENCRYPT_DATA)) {
+    /* Decrypt whenever the session holds derived keys.  This is broader than the
+     * global ENCRYPT_DATA flag: a per-share-encrypted tree makes the client
+     * encrypt even when the session is not globally encrypt-all, and we can
+     * always decrypt traffic we hold keys for. */
+    if (!session || session->enc_key_len == 0) {
         chimera_smb_error("Encrypted SMB2 message for unknown/non-encrypting session %lx",
                           th.session_id);
         if (session) {
@@ -1857,6 +1899,30 @@ chimera_smb_share_set_access_based_enum(
 
     return rc;
 } /* chimera_smb_share_set_access_based_enum */
+
+SYMBOL_EXPORT int
+chimera_smb_share_set_encrypt_data(
+    void       *smb_shared,
+    const char *name)
+{
+    struct chimera_server_smb_shared *shared = smb_shared;
+    struct chimera_smb_share         *cur;
+    int                               rc = -1;
+
+    pthread_mutex_lock(&shared->shares_lock);
+    LL_FOREACH(shared->shares, cur)
+    {
+        if (strcasecmp(cur->name, name) == 0) {
+            cur->encrypt_data         = true;
+            shared->any_share_encrypt = 1;
+            rc                        = 0;
+            break;
+        }
+    }
+    pthread_mutex_unlock(&shared->shares_lock);
+
+    return rc;
+} /* chimera_smb_share_set_encrypt_data */
 
 
 SYMBOL_EXPORT int

--- a/src/server/smb/smb.h
+++ b/src/server/smb/smb.h
@@ -22,6 +22,13 @@ chimera_smb_share_set_access_based_enum(
     void       *smb_shared,
     const char *name);
 
+/* Enable per-share SMB3 encryption (SMB2_SHAREFLAG_ENCRYPT_DATA) on a named
+ * share. */
+int
+chimera_smb_share_set_encrypt_data(
+    void       *smb_shared,
+    const char *name);
+
 int
 chimera_smb_remove_share(
     void       *smb_shared,

--- a/src/server/smb/smb2.h
+++ b/src/server/smb/smb2.h
@@ -632,6 +632,7 @@ typedef uint8_t smb2_guid[SMB2_GUID_SIZE];
 
 // SMB2 TREE_CONNECT response ShareFlags
 #define SMB2_SHAREFLAG_ACCESS_BASED_DIRECTORY_ENUM  0x00000800
+#define SMB2_SHAREFLAG_ENCRYPT_DATA                 0x00008000 // Per-share encryption (SMB 3.0+)
 
 // SMB2/3 Negotiate Capabilities
 #define SMB2_GLOBAL_CAP_DFS                         0x00000001 // Server supports DFS

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -161,6 +161,11 @@ struct chimera_smb_share {
      * from the global smb_persistent_handles flag; a per-share config knob
      * will replace that later. */
     bool                               continuous_availability;
+    /* Per-share SMB3 encryption (MS-SMB2 §2.2.10 SMB2_SHAREFLAG_ENCRYPT_DATA):
+     * advertised at TREE_CONNECT and enforced so all traffic on this tree must
+     * be encrypted (an unsigned, unencrypted access is rejected).  Independent
+     * of the global smb_encryption knob. */
+    bool                               encrypt_data;
     /* Set once the share's backend has been scanned for persisted handle
      * records at first use (best-effort, idempotent recovery). */
     bool                               durable_recovered;
@@ -829,6 +834,11 @@ struct chimera_server_smb_shared {
     pthread_mutex_t                  sessions_lock;
     struct chimera_smb_share        *shares;
     pthread_mutex_t                  shares_lock;
+    /* Set when any share has encrypt_data enabled.  Used by SESSION_SETUP to
+     * decide whether to derive per-session encryption keys even when the global
+     * smb_encryption knob is off (a client may still tree-connect to a
+     * per-share-encrypted share). */
+    int                              any_share_encrypt;
     struct chimera_smb_tree         *free_trees;
     pthread_mutex_t                  trees_lock;
     /* Monotonic, process-global allocator for file persistent ids.  Replaces

--- a/src/server/smb/smb_proc_session_setup.c
+++ b/src/server/smb/smb_proc_session_setup.c
@@ -300,8 +300,16 @@ chimera_smb_session_setup(struct chimera_smb_request *request)
 
         /* SMB3 transport encryption: derive per-session keys from the raw
          * session key.  Skipped for anonymous/guest (null) sessions, which have
-         * no usable key and are never encrypted (MS-SMB2 §3.3.5.5.3). */
-        if (shared->config.encryption &&
+         * no usable key and are never encrypted (MS-SMB2 §3.3.5.5.3).
+         *
+         * Keys are derived whenever encryption is possible at all -- either the
+         * global smb_encryption knob OR any per-share encrypt_data share --
+         * because a client may tree-connect to a per-share-encrypted share even
+         * when global encryption is off.  The global knob alone decides whether
+         * the whole session is marked encrypt-all (CHIMERA_SMB_SESSION_ENCRYPT_
+         * DATA); per-share encryption leaves the flag clear and encrypts per
+         * tree (see the reply path in smb.c). */
+        if ((shared->config.encryption || shared->any_share_encrypt) &&
             conn->negotiated.cipher_id != 0 &&
             conn->dialect >= SMB2_DIALECT_3_0 &&
             session_key_saved_len > 0 &&
@@ -315,13 +323,15 @@ chimera_smb_session_setup(struct chimera_smb_request *request)
                     session_handle->enc_key, session_handle->dec_key, &klen) == 0) {
                 session_handle->enc_key_len = klen;
                 session_handle->cipher_id   = conn->negotiated.cipher_id;
-                session->flags             |= CHIMERA_SMB_SESSION_ENCRYPT_DATA;
+                if (shared->config.encryption) {
+                    session->flags |= CHIMERA_SMB_SESSION_ENCRYPT_DATA;
+                }
             }
         }
 
         if (!(session->flags & CHIMERA_SMB_SESSION_AUTHORIZED)) {
             memcpy(session->signing_key, session_handle->signing_key, sizeof(session_handle->signing_key));
-            if (session->flags & CHIMERA_SMB_SESSION_ENCRYPT_DATA) {
+            if (session_handle->enc_key_len > 0) {
                 memcpy(session->enc_key, session_handle->enc_key, sizeof(session->enc_key));
                 memcpy(session->dec_key, session_handle->dec_key, sizeof(session->dec_key));
                 session->enc_key_len = session_handle->enc_key_len;

--- a/src/server/smb/smb_proc_tree_connect.c
+++ b/src/server/smb/smb_proc_tree_connect.c
@@ -120,6 +120,12 @@ chimera_smb_tree_connect_reply(
             request->tree->share->access_based_enum) {
             share_flags |= SMB2_SHAREFLAG_ACCESS_BASED_DIRECTORY_ENUM;
         }
+        /* Per-share encryption: tell the client to encrypt all traffic on this
+         * tree (MS-SMB2 §2.2.10 / §3.3.5.7). */
+        if (request->tree && request->tree->share &&
+            request->tree->share->encrypt_data) {
+            share_flags |= SMB2_SHAREFLAG_ENCRYPT_DATA;
+        }
         evpl_iovec_cursor_append_uint32(reply_cursor, share_flags);
     }
 

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -246,11 +246,10 @@ if(CHIMERA_NETNS_TESTING AND WPTS_DOTNET AND WPTS_SMB2_DLL AND WPTS_ARCH_SUPPORT
     #     (write-through) to avoid the cthon/fsx client-cache corruption hazards
     #     documented in chimera_smb_create.
     #   - MultipleChannel_EncryptionOnBothChannels and the two
-    #     MultipleChannel_Negative_Encryption* cases need SMB3 per-share
-    #     encryption (SMB2_SHAREFLAG_ENCRYPT_DATA advertisement + enforcement);
-    #     only session-wide (global) encryption is implemented today, so these
-    #     are reported Inconclusive (skipped), matching the ptfconfig's
-    #     IsEncryptionSupported=false.
+    #     MultipleChannel_Negative_Encryption* cases need the multichannel and
+    #     encryption harnesses combined (a second NIC AND smb_encryption on the
+    #     same run); the two ptfconfig fixtures are wired independently today, so
+    #     these are reported Inconclusive (skipped).
     set(WPTS_SMB2_MULTICHANNEL_ALLOWLIST
         BVT_MultipleChannel_NicRedundantOnBoth
         MultipleChannel_NicRedundantOnClient
@@ -271,6 +270,36 @@ if(CHIMERA_NETNS_TESTING AND WPTS_DOTNET AND WPTS_SMB2_DLL AND WPTS_ARCH_SUPPORT
             TIMEOUT 180
             RESOURCE_LOCK wpts_smb_bin
             ENVIRONMENT "WPTS_BIN_DIR=${WPTS_BIN_DIR};DOTNET=${WPTS_DOTNET};CHIMERA_SMB_MULTICHANNEL=1")
+    endforeach()
+
+    # SMB3 transport-encryption cases.  These need the daemon run with
+    # smb_encryption enabled (the wrapper sets it from CHIMERA_SMB_ENCRYPTION,
+    # which also flags the SMBEncrypted share for per-share encryption and flips
+    # the encryption ptfconfig capabilities: IsEncryptionSupported,
+    # IsGlobalEncryptDataEnabled, EncryptedFileShare and the cipher list).
+    set(WPTS_SMB2_ENCRYPTION_ALLOWLIST
+        BVT_Encryption_GlobalEncryptionEnabled
+        BVT_Encryption_PerShareEncryptionEnabled
+        BVT_Encryption_SMB311
+        BVT_Encryption_SMB311_CCM
+        BVT_Encryption_SMB311_GCM
+        BVT_Encryption_SMB311_AES_256_CCM
+        BVT_Encryption_SMB311_AES_256_GCM
+        BVT_Negotiate_SMB311_Preauthentication_Encryption_CCM
+        BVT_Negotiate_SMB311_Preauthentication_Encryption_GCM
+        BVT_Negotiate_SMB311_Preauthentication_Encryption_AES_256_CCM
+        BVT_Negotiate_SMB311_Preauthentication_Encryption_AES_256_GCM
+        BVT_TreeMgmt_SMB311_Disconnect_NoSignedNoEncryptedTreeConnect)
+
+    foreach(tc ${WPTS_SMB2_ENCRYPTION_ALLOWLIST})
+        add_test(NAME chimera/server/smb/wpts/memfs_encryption/${tc}
+            COMMAND ${CMAKE_SOURCE_DIR}/scripts/wpts_smb_test_wrapper.sh
+                    ${CHIMERA_DAEMON} memfs "Name=${tc}")
+        set_tests_properties(chimera/server/smb/wpts/memfs_encryption/${tc} PROPERTIES
+            LABELS "smb;wpts;encryption"
+            TIMEOUT 180
+            RESOURCE_LOCK wpts_smb_bin
+            ENVIRONMENT "WPTS_BIN_DIR=${WPTS_BIN_DIR};DOTNET=${WPTS_DOTNET};CHIMERA_SMB_ENCRYPTION=1")
     endforeach()
 
     message(STATUS "WPTS MS-SMB2 tests: enabled (${WPTS_BIN_DIR}, ${WPTS_DOTNET})")


### PR DESCRIPTION
## Summary

PR #586 landed the SMB3 transport-encryption data path but gated it entirely behind the `smb_encryption` knob (default off) and had **no per-share encryption**, so the Microsoft WPTS (MS-SMB2) encryption conformance cases could not run. This makes SMB 3.1.1 server encryption fully exercisable and greens the WPTS encryption suite (12/12).

## Changes

**Per-share encryption (new)**
- `encrypt_data` flag on `chimera_smb_share` with a setter chain (`chimera_smb_share_set_encrypt_data` → `chimera_server_share_set_encrypt_data`) and a `"encrypt_data": true` per-share JSON knob in the daemon.
- Add `SMB2_SHAREFLAG_ENCRYPT_DATA` and advertise it at TREE_CONNECT for an `encrypt_data` share.

**Gating decoupled from the global knob**
- Derive per-session keys when global encryption is enabled **or** any share opts in (`any_share_encrypt`); the session-wide encrypt-all flag (`CHIMERA_SMB_SESSION_ENCRYPT_DATA`) stays set only for global encryption.
- Inbound TRANSFORMs decrypt on keys-present; a reply is encrypted when the session is encrypt-all, the request arrived encrypted, or its target tree requires encryption.

**Two dispatch fixes (latent; only reachable once encryption runs)**
- Skip signature verification for messages received inside a TRANSFORM — the AEAD tag already authenticates them and their inner SMB2 headers carry a zeroed Signature (MS-SMB2 §3.3.5.2.9). Verifying it dropped connections from any encrypting, signing-capable client.
- Disconnect an unsigned **and** unencrypted post-authentication request on a signing-required or encrypt-all session (MS-SMB2 §3.3.5.7).

**Test wiring**
- New `wpts/memfs_encryption` allowlist (12 cases) registered to run automatically wherever WPTS is available, plus the wrapper / ptfconfig `CHIMERA_SMB_ENCRYPTION` knob that turns on global + per-share encryption and declares the supported ciphers.

## Validation
- WPTS encryption **12/12**; base WPTS allowlist 39/39 and persistent 24/24 unchanged.
- Full smbtorture memfs 109/109; session-id / require-signing / signing-aes-128-cmac green on memfs, cairn, linux, diskfs.
- smbclient SMB3.1.1 interop across AES-128/256 CCM+GCM (global) and per-share encryption with global off.