### PR TITLE
nfs4: implement BIND_CONN_TO_SESSION (op 41)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -16,7 +16,7 @@ ARG ENABLE_WPTS=1
 # a SHA rather than a moving branch makes the image reproducible and, critically,
 # busts the Docker layer cache whenever pynfs is bumped -- otherwise the cached
 # clone layer keeps shipping a stale pynfs.  Bump this SHA when pynfs changes.
-ARG PYNFS_REF=c4bf18d62947e793752c1f77ab180ce75533f14d
+ARG PYNFS_REF=b861f7b8211b4dc798b88a7e81b300fb4615189c
 # Pinned Microsoft Windows Protocol Test Suites (WPTS) FileServer release.
 ARG WPTS_VERSION=4.26.3.0
 

--- a/pynfs/CMakeLists.txt
+++ b/pynfs/CMakeLists.txt
@@ -26,9 +26,9 @@ set(PYNFS_FLAGS_0
 
 # NFSv4.1 test flags
 set(PYNFS_FLAGS_1
-    compound courteous create_session currentstateid deleg destroy_clientid
-    destroy_session exchange_id getfh lookup lookupp open putfh reclaim_complete
-    rename sequence verify xattr)
+    bind_conn_to_session compound courteous create_session currentstateid deleg
+    destroy_clientid destroy_session exchange_id getfh lookup lookupp open putfh
+    reclaim_complete rename sequence verify xattr)
 
 # NFSv4.2 test flags (4.1 flags plus copy and sparse)
 set(PYNFS_FLAGS_2 ${PYNFS_FLAGS_1} copy sparse)

--- a/src/server/nfs/CMakeLists.txt
+++ b/src/server/nfs/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(chimera_nfs SHARED nfs.c nfs4_session.c nfs4_state.c nfs4_lease.c nf
             nfs4_proc_read.c nfs4_proc_write.c nfs4_proc_copy.c nfs4_proc_commit.c nfs4_proc_readlink.c
             nfs4_proc_setattr.c nfs4_proc_link.c nfs4_proc_rename.c nfs4_proc_savefh.c nfs4_proc_restorefh.c
             nfs4_proc_exchange_id.c nfs4_proc_create_session.c nfs4_proc_destroy_session.c
+            nfs4_proc_bind_conn_to_session.c
             nfs4_proc_destroy_clientid.c nfs4_proc_sequence.c nfs4_proc_reclaim_complete.c
             nfs4_proc_secinfo.c nfs4_proc_secinfo_no_name.c nfs4_proc_test_stateid.c
             nfs4_proc_set_ssv.c

--- a/src/server/nfs/nfs4_proc_bind_conn_to_session.c
+++ b/src/server/nfs/nfs4_proc_bind_conn_to_session.c
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "nfs4_procs.h"
+#include "nfs4_session.h"
+#include "nfs4_state.h"
+#include "nfs4_callback.h"
+#include "evpl/evpl_rpc2.h"
+
+/*
+ * BIND_CONN_TO_SESSION (RFC 8881 §18.34 / §2.10.3.1).  Associates the
+ * connection this request arrived on with an existing session, in the fore
+ * channel, the back channel, or both.
+ *
+ * The fore-channel association is normally implicit: SEQUENCE already calls
+ * nfs4_session_bind_conn() on every request (see nfs4_proc_sequence.c), so a
+ * client doing nconnect-style trunking never needs this op for the fore
+ * channel.  The reason this op matters is the *back* channel: the callback
+ * channel used for delegation recalls is pinned to whichever connection
+ * carried CREATE_SESSION with CREATE_SESSION4_FLAG_CONN_BACK_CHAN.  When that
+ * connection drops, a client re-establishes callbacks by binding the back
+ * channel to a surviving connection here -- the same repoint + recall re-drive
+ * that CREATE_SESSION performs (see nfs4_proc_create_session.c).
+ *
+ * The op carries no cb_program / sec_parms, so (unlike CREATE_SESSION /
+ * BACKCHANNEL_CTL) it does not change the callback program or credentials --
+ * those were established earlier; we only repoint the transport.
+ *
+ * Chimera multiplexes both channels over a single TCP connection, so binding
+ * either direction makes both available at no extra cost; the _OR_BOTH
+ * variants are therefore honored as "both" (matching Linux nfsd).
+ */
+void
+chimera_nfs4_bind_conn_to_session(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_request               *req,
+    struct nfs_argop4                *argop,
+    struct nfs_resop4                *resop)
+{
+    struct BIND_CONN_TO_SESSION4args *args = &argop->opbind_conn_to_session;
+    struct BIND_CONN_TO_SESSION4res  *res  = &resop->opbind_conn_to_session;
+    struct nfs4_session              *session;
+    bool                              bind_fore, bind_back;
+    channel_dir_from_server4          reply_dir;
+
+    session = nfs4_session_lookup(&thread->shared->nfs4_shared_clients,
+                                  args->bctsa_sessid);
+    if (!session) {
+        res->bctsr_status = NFS4ERR_BADSESSION;
+        chimera_nfs4_compound_complete(req, NFS4ERR_BADSESSION);
+        return;
+    }
+
+    switch (args->bctsa_dir) {
+        case CDFC4_FORE:
+            bind_fore = true;
+            bind_back = false;
+            reply_dir = CDFS4_FORE;
+            break;
+        case CDFC4_BACK:
+            bind_fore = false;
+            bind_back = true;
+            reply_dir = CDFS4_BACK;
+            break;
+        case CDFC4_FORE_OR_BOTH:
+        case CDFC4_BACK_OR_BOTH:
+            bind_fore = true;
+            bind_back = true;
+            reply_dir = CDFS4_BOTH;
+            break;
+        default:
+            nfs4_session_put(session);
+            res->bctsr_status = NFS4ERR_INVAL;
+            chimera_nfs4_compound_complete(req, NFS4ERR_INVAL);
+            return;
+    } /* switch */
+
+    /* Bind the conn to the session (idempotent; takes the conn's own +1 ref
+     * unless it is already bound to this session).  This holds a ref before we
+     * drop the lookup ref below, mirroring SEQUENCE. */
+    if (bind_fore || bind_back) {
+        nfs4_session_bind_conn(req->conn, session);
+    }
+
+    if (bind_back) {
+        /* Repoint the backchannel transport to this connection and re-drive any
+         * delegation recall that was stuck with no live backchannel (RFC 8881
+         * §20.4.1; the same path CREATE_SESSION uses for DSESS9003). */
+        session->nfs4_session_backchannel_conn = req->conn;
+        nfs4_cb_resend_recalls_on_rebind(thread, session->client_unified, req);
+    }
+
+    /* Drop the +1 from nfs4_session_lookup; the conn's ref keeps the session
+     * alive for the rest of this compound. */
+    nfs4_session_put(session);
+
+    res->bctsr_status = NFS4_OK;
+    memcpy(res->bctsr_resok4.bctsr_sessid, session->nfs4_session_id,
+           NFS4_SESSIONID_SIZE);
+    res->bctsr_resok4.bctsr_dir = reply_dir;
+    /* We never run an RDMA backchannel; honestly decline RDMA mode. */
+    res->bctsr_resok4.bctsr_use_conn_in_rdma_mode = false;
+
+    chimera_nfs4_compound_complete(req, NFS4_OK);
+} /* chimera_nfs4_bind_conn_to_session */

--- a/src/server/nfs/nfs4_proc_compound.c
+++ b/src/server/nfs/nfs4_proc_compound.c
@@ -515,6 +515,9 @@ chimera_nfs4_compound_process(
                 case OP_BACKCHANNEL_CTL:
                     chimera_nfs4_backchannel_ctl(thread, req, argop, resop);
                     break;
+                case OP_BIND_CONN_TO_SESSION:
+                    chimera_nfs4_bind_conn_to_session(thread, req, argop, resop);
+                    break;
                 case OP_TEST_STATEID:
                     chimera_nfs4_test_stateid(thread, req, argop, resop);
                     break;

--- a/src/server/nfs/nfs4_procs.h
+++ b/src/server/nfs/nfs4_procs.h
@@ -449,6 +449,13 @@ chimera_nfs4_backchannel_ctl(
     struct nfs_resop4                *resop);
 
 void
+chimera_nfs4_bind_conn_to_session(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_request               *req,
+    struct nfs_argop4                *argop,
+    struct nfs_resop4                *resop);
+
+void
 chimera_nfs4_secinfo(
     struct chimera_server_nfs_thread *thread,
     struct nfs_request               *req,


### PR DESCRIPTION
## Summary

Implements `OP_BIND_CONN_TO_SESSION` (NFSv4.1, RFC 8881 §18.34), which previously fell through to `NFS4ERR_NOTSUPP`.

**Why it matters.** Fore-channel binding is already implicit in `OP_SEQUENCE` (`nfs4_proc_sequence.c` calls `nfs4_session_bind_conn()` on every request), and RFC 8881 §2.10.3.1 lets a server not enforce explicit binding — so `nconnect`-style trunking already works without this op. The capability implicit binding *cannot* provide is **backchannel (re)association**: the callback channel used for delegation recalls is pinned to whichever connection carried `CREATE_SESSION` with `CONN_BACK_CHAN`. When that connection drops (routine under trunking/failover), a conformant 4.1 client issues `BIND_CONN_TO_SESSION` on a surviving connection to restore callbacks. We were rejecting that, which can wedge delegation-recall recovery.

## Implementation

New handler `src/server/nfs/nfs4_proc_bind_conn_to_session.c`, wired into the compound dispatcher. It reuses existing primitives only — no new session/VFS helpers:

- Looks up the session → `NFS4ERR_BADSESSION` if unknown; validates the direction → `NFS4ERR_INVAL` otherwise.
- **Fore** bind reuses `nfs4_session_bind_conn()` (same refcount + disconnect-cleanup path as `OP_SEQUENCE`).
- **Back** bind repoints `nfs4_session_backchannel_conn` to the connection and re-drives any stuck delegation recalls via `nfs4_cb_resend_recalls_on_rebind()` — the same path `CREATE_SESSION` uses.
- Both channels multiplex over one TCP connection, so `*_OR_BOTH` reports `CDFS4_BOTH`; RDMA mode is honestly declined.

| `bctsa_dir` | `bctsr_dir` |
|---|---|
| `CDFC4_FORE` | `CDFS4_FORE` |
| `CDFC4_BACK` | `CDFS4_BACK` |
| `CDFC4_FORE_OR_BOTH` | `CDFS4_BOTH` |
| `CDFC4_BACK_OR_BOTH` | `CDFS4_BOTH` |

## Testing

New `chimera-nas/pynfs` suite `st_bind_conn_to_session.py` (BIND1–3, `bind_conn_to_session` flag), driving op 41 over a real **second connection** (pynfs `connect()` + `compound(pipe=…)`): fore-bind + usability, the full direction→direction mapping, and `NFS4ERR_BADSESSION`. Wired into the matrix via a new flag in `pynfs/CMakeLists.txt`; `PYNFS_REF` bumped to the fork commit.

- New tests: **36/36 pass** (3 codes × memfs/linux/io_uring/diskfs_io_uring/diskfs_aio/cairn × nfs4.1 + nfs4.2).
- Regression: session suites (sequence/create_session/destroy_session incl. DSESS backchannel-rebind) and delegation suites unregressed.

Functional backchannel-failover (recall delivered over a re-bound connection) remains covered indirectly by the existing DSESS9002/9003 recall tests; an explicit failover test is a possible follow-up.