### PR TITLE
smb2: pass WPTS MS-SMB2 MultipleChannel session-binding tests

### DIFF
--- a/scripts/wpts_smb_test_wrapper.sh
+++ b/scripts/wpts_smb_test_wrapper.sh
@@ -39,6 +39,11 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WPTS_PTFCONFIG_DIR="${WPTS_PTFCONFIG_DIR:-${SCRIPT_DIR}/../src/server/smb/tests/wpts}"
 
 SUT_IP="10.0.0.1"
+# Second SUT IP for SMB3 multichannel (a redundant "NIC"). Only wired up when
+# CHIMERA_SMB_MULTICHANNEL=1; the WPTS MultipleChannel cases establish the
+# alternative channel against it (and the main channel queries it back via
+# FSCTL_QUERY_NETWORK_INTERFACE_INFO).
+SUT_IP2="10.0.0.2"
 NETNS_NAME="wpts_smb_$$_$(date +%s%N)"
 DUMMY_IF="wpts0"
 BUILD_DIR=$(dirname "$(dirname "$CHIMERA_BINARY")")
@@ -109,10 +114,24 @@ generate_config() {
         persistent_line='"smb_persistent_handles": true,'
     fi
 
+    # Advertise two NICs for SMB3 multichannel when requested.  The daemon
+    # reports these back over FSCTL_QUERY_NETWORK_INTERFACE_INFO so the WPTS
+    # MultipleChannel cases can discover the alternative server address.
+    local multichannel_line=""
+    if [ "${CHIMERA_SMB_MULTICHANNEL:-0}" = "1" ]; then
+        multichannel_line="\"smb_multichannel\": [{\"address\": \"${SUT_IP}\", \"speed\": 10, \"rdma\": false}, {\"address\": \"${SUT_IP2}\", \"speed\": 10, \"rdma\": false}],"
+        # The MultipleChannel_Negative_SMB2002 case establishes its main channel
+        # with the original SMB 2.0.2 dialect (then verifies the bind is refused),
+        # so the multichannel harness lowers the dialect floor to 2.0.2.
+        multichannel_line="${multichannel_line}
+        \"smb_min_dialect\": \"2.0.2\","
+    fi
+
     cat > "$CONFIG_FILE" << EOF
 {
     "server": {
         ${persistent_line}
+        ${multichannel_line}
         "threads": 4,
         "delegation_threads": 4,
         "external_portmap": false
@@ -145,6 +164,12 @@ ip netns add "${NETNS_NAME}"
 ip netns exec "${NETNS_NAME}" ip link set lo up
 ip netns exec "${NETNS_NAME}" ip link add "${DUMMY_IF}" type dummy
 ip netns exec "${NETNS_NAME}" ip addr add "${SUT_IP}/24" dev "${DUMMY_IF}"
+# Second address on the same dummy interface for multichannel: both the SUT's
+# alternative NIC and the driver's second client NIC live here (loopback-routed
+# within the netns, so a single device carrying both addresses is sufficient).
+if [ "${CHIMERA_SMB_MULTICHANNEL:-0}" = "1" ]; then
+    ip netns exec "${NETNS_NAME}" ip addr add "${SUT_IP2}/24" dev "${DUMMY_IF}"
+fi
 ip netns exec "${NETNS_NAME}" ip link set "${DUMMY_IF}" up
 
 # Start the chimera daemon inside the netns
@@ -191,6 +216,22 @@ if [ "${CHIMERA_SMB_PERSISTENT:-0}" = "1" ]; then
         -e 's#<Property name="CAShareName" value=""/>#<Property name="CAShareName" value="FileShare"/>#' \
         -e "s#<Property name=\"CAShareServerName\" value=\"\"/>#<Property name=\"CAShareServerName\" value=\"${SUT_IP}\"/>#" \
         "$staged"
+fi
+
+# When multichannel is enabled, advertise the capability and the second
+# server/client NIC addresses so the WPTS MultipleChannel cases become
+# applicable (they assert serverIps.Count > 1 and the IsMultiChannelCapable
+# capability; otherwise they are Inconclusive/skipped).
+if [ "${CHIMERA_SMB_MULTICHANNEL:-0}" = "1" ]; then
+    staged_common="${WPTS_BIN_DIR}/CommonTestSuite.deployment.ptfconfig"
+    staged_smb2="${WPTS_BIN_DIR}/MS-SMB2_ServerTestSuite.deployment.ptfconfig"
+    sed -i \
+        -e 's#<Property name="IsMultiChannelCapable" value="false"/>#<Property name="IsMultiChannelCapable" value="true"/>#' \
+        -e "s#<Property name=\"ClientNic2IPAddress\" value=\"\"/>#<Property name=\"ClientNic2IPAddress\" value=\"${SUT_IP2}\"/>#" \
+        "$staged_common"
+    sed -i \
+        -e "s#<Property name=\"SutAlternativeIPAddress\" value=\"\"/>#<Property name=\"SutAlternativeIPAddress\" value=\"${SUT_IP2}\"/>#" \
+        "$staged_smb2"
 fi
 
 mkdir -p "$RESULT_DIR"

--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -413,6 +413,32 @@ main(
         chimera_server_config_set_smb_named_streams(server_config, json_is_true(json_value));
     }
 
+    /* smb_min_dialect: lowest SMB2 dialect to advertise ("2.0.2"|"2.1"|"3.0"|
+     * "3.0.2"|"3.1.1").  Defaults to 2.1; lower it to 2.0.2 only where a client
+     * (e.g. a conformance suite) explicitly needs the original SMB2 dialect. */
+    json_value = json_object_get(server_params, "smb_min_dialect");
+    if (json_is_string(json_value)) {
+        const char *d = json_string_value(json_value);
+        uint32_t    min_dialect;
+
+        if (strcmp(d, "2.0.2") == 0) {
+            min_dialect = 0x0202;
+        } else if (strcmp(d, "2.1") == 0) {
+            min_dialect = 0x0210;
+        } else if (strcmp(d, "3.0") == 0) {
+            min_dialect = 0x0300;
+        } else if (strcmp(d, "3.0.2") == 0) {
+            min_dialect = 0x0302;
+        } else if (strcmp(d, "3.1.1") == 0) {
+            min_dialect = 0x0311;
+        } else {
+            chimera_server_error("Invalid smb_min_dialect value '%s' "
+                                 "(expected 2.0.2/2.1/3.0/3.0.2/3.1.1)", d);
+            return 1;
+        }
+        chimera_server_config_set_smb_min_dialect(server_config, min_dialect);
+    }
+
     /* smb_encryption: "off"|"enabled"|"required" (or a boolean/integer 0/1/2). */
     json_value = json_object_get(server_params, "smb_encryption");
     if (json_is_string(json_value)) {

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -853,6 +853,34 @@ chimera_server_config_get_smb_dialects(
     return config->smb_dialects[index];
 } /* chimera_server_config_get_smb_dialects */
 
+SYMBOL_EXPORT void
+chimera_server_config_set_smb_min_dialect(
+    struct chimera_server_config *config,
+    uint32_t                      min_dialect)
+{
+    /* Every SMB2/3 dialect chimera can speak, ascending.  The advertised set is
+     * this list filtered to >= min_dialect, so lowering the floor (e.g. to
+     * SMB 2.0.2) just widens the bottom of the range.  The default floor is
+     * SMB 2.1; SMB 2.0.2 is off by default because it lacks large-MTU/leasing
+     * and is only needed by conformance cases that explicitly request it. */
+    static const uint32_t all_dialects[] = {
+        SMB2_DIALECT_2_0_2,
+        SMB2_DIALECT_2_1,
+        SMB2_DIALECT_3_0,
+        SMB2_DIALECT_3_0_2,
+        SMB2_DIALECT_3_1_1,
+    };
+    int                   n = 0;
+
+    for (unsigned int i = 0; i < sizeof(all_dialects) / sizeof(all_dialects[0]); i++) {
+        if (all_dialects[i] >= min_dialect) {
+            config->smb_dialects[n++] = all_dialects[i];
+        }
+    }
+
+    config->smb_num_dialects = n;
+} /* chimera_server_config_set_smb_min_dialect */
+
 SYMBOL_EXPORT int
 chimera_server_config_get_smb_num_nic_info(const struct chimera_server_config *config)
 {

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -407,6 +407,11 @@ chimera_server_config_get_smb_dialects(
     const struct chimera_server_config *config,
     int                                 index);
 
+void
+chimera_server_config_set_smb_min_dialect(
+    struct chimera_server_config *config,
+    uint32_t                      min_dialect);
+
 int
 chimera_server_config_get_smb_num_nic_info(
     const struct chimera_server_config *config);

--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -488,17 +488,32 @@ chimera_smb_compound_reply(struct chimera_smb_compound *compound)
     if (compound->num_requests > 0 &&
         (compound->requests[0]->smb2_hdr.command == SMB2_NEGOTIATE ||
          compound->requests[0]->smb2_hdr.command == SMB2_SESSION_SETUP)) {
-        chimera_smb_preauth_extend(conn->preauth_hash,
-                                   (uint8_t *) evpl_iovec_data(&reply_iov[0]) + reply_hdr_len,
-                                   preauth_fold_len);
 
-        /* Once the NEGOTIATE response is folded in, conn->preauth_hash holds
-         * the post-NEGOTIATE baseline (MS-SMB2 Connection.PreauthIntegrity
-         * HashValue).  Snapshot it so each subsequent session's preauth hash
-         * can restart from here (see the request-fold path). */
-        if (compound->requests[0]->smb2_hdr.command == SMB2_NEGOTIATE) {
-            memcpy(conn->negotiate_preauth_hash, conn->preauth_hash,
-                   sizeof(conn->negotiate_preauth_hash));
+        /* A SESSION_SETUP that completes with a hard error contributes nothing
+         * to the preauth-integrity hash: the client folds a SESSION_SETUP
+         * exchange only when the response is SUCCESS or MORE_PROCESSING_REQUIRED
+         * (MS-SMB2 3.3.5.5.3), so roll the request fold back to the pre-request
+         * snapshot and skip folding the error response.  Without this a failed
+         * authentication leg (e.g. an invalid first channel-bind) would poison
+         * the hash and the next leg's signing key would not match the client's.
+         * NEGOTIATE always reaches here on success, so it is never rolled back. */
+        if (compound->requests[0]->smb2_hdr.command == SMB2_SESSION_SETUP &&
+            chimera_smb_is_error_status(compound->requests[0]->status)) {
+            memcpy(conn->preauth_hash, conn->preauth_hash_presession,
+                   sizeof(conn->preauth_hash));
+        } else {
+            chimera_smb_preauth_extend(conn->preauth_hash,
+                                       (uint8_t *) evpl_iovec_data(&reply_iov[0]) + reply_hdr_len,
+                                       preauth_fold_len);
+
+            /* Once the NEGOTIATE response is folded in, conn->preauth_hash holds
+             * the post-NEGOTIATE baseline (MS-SMB2 Connection.PreauthIntegrity
+             * HashValue).  Snapshot it so each subsequent session's preauth hash
+             * can restart from here (see the request-fold path). */
+            if (compound->requests[0]->smb2_hdr.command == SMB2_NEGOTIATE) {
+                memcpy(conn->negotiate_preauth_hash, conn->preauth_hash,
+                       sizeof(conn->negotiate_preauth_hash));
+            }
         }
     }
 
@@ -1215,6 +1230,12 @@ chimera_smb_server_handle_smb2(
                 compound->requests[0]->smb2_hdr.session_id == 0) {
                 memcpy(conn->preauth_hash, conn->negotiate_preauth_hash,
                        sizeof(conn->preauth_hash));
+            }
+            /* Snapshot before folding a SESSION_SETUP so a leg that fails
+             * authentication can be rolled back (see the reply-fold path). */
+            if (compound->requests[0]->smb2_hdr.command == SMB2_SESSION_SETUP) {
+                memcpy(conn->preauth_hash_presession, conn->preauth_hash,
+                       sizeof(conn->preauth_hash_presession));
             }
             evpl_iovec_cursor_copy(&preauth_cursor, msg, length);
             chimera_smb_preauth_extend(conn->preauth_hash, msg, length);

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -718,6 +718,16 @@ struct chimera_smb_conn {
      * accept; only consumed when the negotiated dialect is 3.1.1. */
     uint8_t                            preauth_hash[SMB2_PREAUTH_HASH_SIZE];
     uint8_t                            negotiate_preauth_hash[SMB2_PREAUTH_HASH_SIZE];
+    /* Snapshot of preauth_hash taken just before a SESSION_SETUP request is
+     * folded in.  A SESSION_SETUP that completes with a hard error (anything
+     * other than SUCCESS / MORE_PROCESSING_REQUIRED) must leave no trace in the
+     * preauth-integrity hash -- the client only folds requests whose response
+     * is SUCCESS or MORE_PROCESSING (MS-SMB2 3.3.5.5.3), so a failed
+     * authentication leg (e.g. the deliberately-invalid first bind in
+     * MultipleChannel_SecondChannelSessionSetupFailAtFirstTime) is rolled back
+     * to this snapshot so the next, successful leg derives its signing key over
+     * the same hash the client used. */
+    uint8_t                            preauth_hash_presession[SMB2_PREAUTH_HASH_SIZE];
     uint32_t                           requests_completed;
     int                                rdma_max_send;
     int                                rdma_niov;

--- a/src/server/smb/smb_proc_session_setup.c
+++ b/src/server/smb/smb_proc_session_setup.c
@@ -111,9 +111,30 @@ chimera_smb_session_setup(struct chimera_smb_request *request)
         input_len = 0;
     }
 
+    /* SMB3 multichannel session binding (MS-SMB2 3.3.5.5.3).  A SESSION_SETUP
+     * whose SMB2_SESSION_FLAG_BINDING bit is set asks to add this connection as
+     * an additional channel of an existing session.  The server MUST reject the
+     * bind with STATUS_REQUEST_NOT_ACCEPTED when the connection's dialect is not
+     * in the SMB 3.x family (or the server is not multichannel-capable — chimera
+     * always is).  Caught before authentication so a 2.x client never binds. */
+    if ((request->session_setup.flags & SMB2_SESSION_FLAG_BINDING) &&
+        conn->dialect < SMB2_DIALECT_3_0) {
+        chimera_smb_complete_request(request, SMB2_STATUS_REQUEST_NOT_ACCEPTED);
+        evpl_iovecs_release(thread->evpl, request->session_setup.input_iov,
+                            request->session_setup.input_niov);
+        return;
+    }
+
     // Detect authentication mechanism
     mech = smb_auth_detect_mechanism(input, input_len);
     chimera_smb_debug("Session setup: detected mechanism %s", smb_auth_mech_name(mech));
+
+    /* A security buffer the server cannot parse as a recognised mechanism token
+     * is a malformed request, not an authentication failure: MS-SMB2 answers it
+     * with STATUS_INVALID_PARAMETER rather than STATUS_LOGON_FAILURE (the
+     * GSS/SSPI layer reports SEC_E_INVALID_TOKEN).  Track it so the failure
+     * completion below returns the right status. */
+    int bad_token = 0;
 
     // Route to appropriate handler
     switch (mech) {
@@ -132,7 +153,8 @@ chimera_smb_session_setup(struct chimera_smb_request *request)
 
         default:
             chimera_smb_error("Unknown authentication mechanism");
-            rc = -1;
+            rc        = -1;
+            bad_token = 1;
             break;
     } /* switch */
 
@@ -327,7 +349,9 @@ chimera_smb_session_setup(struct chimera_smb_request *request)
     } else {
         // Authentication failed
         chimera_smb_error("Authentication failed (mechanism: %s)", smb_auth_mech_name(mech));
-        chimera_smb_complete_request(request, SMB2_STATUS_LOGON_FAILURE);
+        chimera_smb_complete_request(request,
+                                     bad_token ? SMB2_STATUS_INVALID_PARAMETER :
+                                     SMB2_STATUS_LOGON_FAILURE);
 
         /* A failed channel-bind (SMB2_SESSION_FLAG_BINDING) must NOT tear the
          * existing session down — the established channel(s) survive.  Only a

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -201,6 +201,47 @@ if(CHIMERA_NETNS_TESTING AND WPTS_DOTNET AND WPTS_SMB2_DLL AND WPTS_ARCH_SUPPORT
             ENVIRONMENT "WPTS_BIN_DIR=${WPTS_BIN_DIR};DOTNET=${WPTS_DOTNET};CHIMERA_SMB_PERSISTENT=1")
     endforeach()
 
+    # SMB3 multichannel cases.  The wrapper runs the daemon with a second NIC
+    # address (so FSCTL_QUERY_NETWORK_INTERFACE_INFO advertises an alternative
+    # server address) and flips the multichannel ptfconfig capabilities when
+    # CHIMERA_SMB_MULTICHANNEL=1.  Allowlist = the MultipleChannel cases confirmed
+    # green against the current server: the NIC-redundancy bind matrix, the
+    # 2.x-dialect bind rejection (STATUS_REQUEST_NOT_ACCEPTED), cross-channel
+    # byte-range locking, and the 3.1.1 second-channel preauth-integrity case.
+    #
+    # Left out (each a distinct unimplemented feature, not a multichannel gap):
+    #   - MultipleChannel_FileLease needs write/handle-caching lease break
+    #     delivery; chimera deliberately grants only read-caching leases
+    #     (write-through) to avoid the cthon/fsx client-cache corruption hazards
+    #     documented in chimera_smb_create.
+    #   - MultipleChannel_EncryptionOnBothChannels and the two
+    #     MultipleChannel_Negative_Encryption* cases need SMB3 per-share
+    #     encryption (SMB2_SHAREFLAG_ENCRYPT_DATA advertisement + enforcement);
+    #     only session-wide (global) encryption is implemented today, so these
+    #     are reported Inconclusive (skipped), matching the ptfconfig's
+    #     IsEncryptionSupported=false.
+    set(WPTS_SMB2_MULTICHANNEL_ALLOWLIST
+        BVT_MultipleChannel_NicRedundantOnBoth
+        MultipleChannel_NicRedundantOnClient
+        MultipleChannel_NicRedundantOnServer
+        MultipleChannel_MultiChannelOnSameNic
+        MultipleChannel_Negative_SMB21
+        MultipleChannel_Negative_SMB2002
+        MultipleChannel_LockUnlockOnDiffChannel
+        MultipleChannel_LockUnlockOnSameChannel
+        MultipleChannel_SecondChannelSessionSetupFailAtFirstTime)
+
+    foreach(tc ${WPTS_SMB2_MULTICHANNEL_ALLOWLIST})
+        add_test(NAME chimera/server/smb/wpts/memfs_multichannel/${tc}
+            COMMAND ${CMAKE_SOURCE_DIR}/scripts/wpts_smb_test_wrapper.sh
+                    ${CHIMERA_DAEMON} memfs "Name=${tc}")
+        set_tests_properties(chimera/server/smb/wpts/memfs_multichannel/${tc} PROPERTIES
+            LABELS "smb;wpts;multichannel"
+            TIMEOUT 180
+            RESOURCE_LOCK wpts_smb_bin
+            ENVIRONMENT "WPTS_BIN_DIR=${WPTS_BIN_DIR};DOTNET=${WPTS_DOTNET};CHIMERA_SMB_MULTICHANNEL=1")
+    endforeach()
+
     message(STATUS "WPTS MS-SMB2 tests: enabled (${WPTS_BIN_DIR}, ${WPTS_DOTNET})")
 elseif(CHIMERA_NETNS_TESTING AND WPTS_DOTNET AND WPTS_SMB2_DLL AND NOT WPTS_ARCH_SUPPORTED)
     message(STATUS "WPTS MS-SMB2 tests: disabled "


### PR DESCRIPTION
## Summary

Greens the WPTS MS-SMB2 **MultipleChannel** category — 9 conformance cases covering SMB3 session binding across channels: the NIC-redundancy bind matrix (`NicRedundantOnBoth/Client/Server`), same-NIC binding, 2.x-dialect bind rejection, cross-channel byte-range locking, and the 3.1.1 second-channel preauth-integrity case.

Multichannel was already functional with real Windows clients; the binding signing-key derivation was correct (each bound channel derives its key from that connection's own NTLM session key + per-connection preauth hash, matching the WPTS client). The failures were in narrower conformance corners.

## Server changes (all in the shared SMB2 auth path)

- **Session binding (MS-SMB2 3.3.5.5.3):** reject `SMB2_SESSION_FLAG_BINDING` on a pre-3.x connection with `STATUS_REQUEST_NOT_ACCEPTED`.
- **Malformed token:** a security buffer that does not parse as a recognised mechanism token is a malformed request — answer `STATUS_INVALID_PARAMETER`, not `STATUS_LOGON_FAILURE`. (The WPTS client keys its retry behaviour off this status.)
- **Preauth-integrity rollback:** a `SESSION_SETUP` that completes with a hard error must leave no trace in the connection's preauth hash — the client only folds an exchange whose response is `SUCCESS`/`MORE_PROCESSING_REQUIRED`. A snapshot is taken before the request fold and restored on failure; without it a failed first channel-bind poisoned the hash and the retry's signing key no longer matched.
- **Configurable dialect floor:** `server.smb_min_dialect` (default `2.1`) lets a deployment advertise SMB 2.0.2 when a peer needs the original dialect.

## Test harness

`wpts_smb_test_wrapper.sh` gains a `CHIMERA_SMB_MULTICHANNEL` mode: a second SUT NIC address (advertised back via `FSCTL_QUERY_NETWORK_INTERFACE_INFO`), the multichannel ptfconfig capabilities, and the 2.0.2 dialect floor. A new CMake allowlist registers the green MultipleChannel cases.

## Out of scope (documented in the allowlist as distinct unimplemented features)

- `MultipleChannel_FileLease` — needs write/handle-caching lease-break delivery (chimera grants read-caching/write-through only, to avoid the documented cthon/fsx client-cache hazards).
- The encryption cases — need SMB3 **per-share** encryption (`SMB2_SHAREFLAG_ENCRYPT_DATA`); only session-wide encryption exists today, so they report Inconclusive (skipped).
- `BVT_Replay_WriteWithInvalidChannelSequence` — needs durable-V2 + ChannelSequence validation.

## Validation

All run green via ctest: 9 multichannel + 39 WPTS memfs + 24 WPTS persistent + 18 smbtorture session suites (no regression from the shared auth-path changes). Release + Debug/ASan builds clean; `make syntax` and copyright-year checks pass.