### PR TITLE
docs: skin Just the Docs to match chimeraproject.io

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -5,12 +5,15 @@
 title: chimera
 description: chimera documentation
 theme: just-the-docs
-color_scheme: dark
+# chimera scheme skins Just the Docs to match chimeraproject.io
+# (see _sass/color_schemes/chimera.scss and _sass/custom/).
+color_scheme: chimera
 
+# Origin only; the /chimera path is the baseurl. The Pages workflow re-passes
+# the same value via --baseurl at build time.
+url: https://chimeraproject.io
+baseurl: /chimera
 
-url: https://chimeraproject.io/chimera
-
-aux_links:
-  GitHub: https://github.com/chimera-nas/chimera
-  Discord: https://discord.gg/hnRkvQFecq
+# GitHub / Discord live in the shared top bar (_includes/chimera_topbar.html),
+# so the theme's own aux links are disabled to avoid duplication.
 

--- a/docs/_includes/chimera_footer.html
+++ b/docs/_includes/chimera_footer.html
@@ -1,0 +1,51 @@
+{%- comment -%}
+SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+SPDX-License-Identifier: Unlicense
+
+Site footer mirroring chimeraproject.io. Marquee pages are absolute (site
+root); the docs API reference is served from this Jekyll build.
+{%- endcomment -%}
+<footer class="site-foot">
+  <div class="shell">
+    <div class="cols">
+      <div>
+        <a class="brand" href="https://chimeraproject.io/" style="margin-bottom:12px">
+          <span class="brand-mark" aria-hidden="true">
+            <svg viewBox="0 0 22 22" fill="none">
+              <path d="M3 11 L11 3 L19 11 L11 19 Z" stroke="currentColor" stroke-width="1.4"/>
+              <path d="M7 11 L11 7 L15 11 L11 15 Z" fill="currentColor" opacity="0.85"/>
+            </svg>
+          </span>
+          chimeraproject
+        </a>
+        <p style="margin-top:14px;max-width:36ch">Two C libraries for building distributed storage in user space: a multi-protocol NAS stack and the I/O runtime it runs on.</p>
+      </div>
+      <div>
+        <h4>chimera</h4>
+        <a href="https://chimeraproject.io/chimera.html">Intro</a>
+        <a href="https://chimeraproject.io/chimera-architecture.html">Architecture</a>
+        <a href="https://chimeraproject.io/chimera-performance.html">Performance</a>
+        <a href="https://chimeraproject.io/chimera-status.html">Status</a>
+      </div>
+      <div>
+        <h4>Docs</h4>
+        <a href="{{ '/' | relative_url }}">Home</a>
+        <a href="{{ '/quickstart' | relative_url }}">Quick start</a>
+        <a href="{{ '/building' | relative_url }}">Building</a>
+        <a href="{{ '/api-reference' | relative_url }}">API reference</a>
+      </div>
+      <div>
+        <h4>Source</h4>
+        <a href="https://github.com/chimera-nas" target="_blank" rel="noopener">GitHub org</a>
+        <a href="https://github.com/chimera-nas/chimera" target="_blank" rel="noopener">chimera-nas/chimera</a>
+        <a href="https://github.com/chimera-nas/libevpl" target="_blank" rel="noopener">chimera-nas/libevpl</a>
+        <a href="https://discord.gg/hnRkvQFecq" target="_blank" rel="noopener">Discord</a>
+      </div>
+    </div>
+    <div class="meta">
+      <span>License — LGPL-2.1</span>
+      <span>&copy; 2026 the chimeraproject contributors</span>
+      <span style="margin-left:auto">Not yet a production system.</span>
+    </div>
+  </div>
+</footer>

--- a/docs/_includes/chimera_topbar.html
+++ b/docs/_includes/chimera_topbar.html
@@ -1,0 +1,33 @@
+{%- comment -%}
+SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+SPDX-License-Identifier: Unlicense
+
+Full-width top bar mirroring chimeraproject.io so the docs feel continuous with
+the main site. Cross-site links are absolute (the docs live under /chimera,
+the marquee pages live at the site root).
+{%- endcomment -%}
+<header class="topbar">
+  <div class="shell topbar-inner">
+    <a class="brand" href="https://chimeraproject.io/">
+      <span class="brand-mark" aria-hidden="true">
+        <svg viewBox="0 0 22 22" fill="none">
+          <path d="M3 11 L11 3 L19 11 L11 19 Z" stroke="currentColor" stroke-width="1.4"/>
+          <path d="M7 11 L11 7 L15 11 L11 15 Z" fill="currentColor" opacity="0.85"/>
+        </svg>
+      </span>
+      chimeraproject
+    </a>
+    <div class="proj-tabs">
+      <a class="proj-tab active" href="https://chimeraproject.io/chimera.html">chimera</a>
+      <a class="proj-tab" href="https://chimeraproject.io/libevpl.html">libevpl</a>
+    </div>
+    <nav class="nav">
+      <a href="{{ '/' | relative_url }}" class="current">Docs</a>
+      <a class="gh" href="https://github.com/chimera-nas/chimera" target="_blank" rel="noopener">
+        <svg viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/></svg>
+        GitHub
+      </a>
+      <a class="gh" href="https://discord.gg/hnRkvQFecq" target="_blank" rel="noopener" title="Discord"><svg viewBox="0 -28.5 256 256" fill="currentColor" aria-hidden="true" style="width:14px;height:14px"><path d="M216.856 16.597A208.502 208.502 0 0 0 164.042 0c-2.275 4.113-4.933 9.645-6.766 14.046-19.692-2.961-39.203-2.961-58.533 0-1.832-4.4-4.55-9.933-6.846-14.046a207.809 207.809 0 0 0-52.855 16.638C5.618 67.147-3.443 116.4 1.087 164.956c22.169 16.555 43.653 26.612 64.775 33.193A161.094 161.094 0 0 0 79.735 175.3a136.413 136.413 0 0 1-21.846-10.632 108.636 108.636 0 0 0 5.355-4.237c42.122 19.702 87.89 19.702 129.51 0a131.66 131.66 0 0 0 5.355 4.237 136.07 136.07 0 0 1-21.886 10.653c4.006 8.02 8.638 15.67 13.873 22.848 21.142-6.58 42.646-16.637 64.815-33.213 5.316-56.288-9.08-105.09-38.056-148.36ZM85.474 135.095c-12.645 0-23.015-11.805-23.015-26.18s10.149-26.2 23.015-26.2c12.867 0 23.236 11.804 23.015 26.2.02 14.375-10.148 26.18-23.015 26.18Zm85.051 0c-12.645 0-23.014-11.805-23.014-26.18s10.148-26.2 23.014-26.2c12.867 0 23.236 11.804 23.015 26.2 0 14.375-10.148 26.18-23.015 26.18Z"/></svg>Discord</a>
+    </nav>
+  </div>
+</header>

--- a/docs/_includes/chimera_tweaks.html
+++ b/docs/_includes/chimera_tweaks.html
@@ -1,0 +1,85 @@
+{%- comment -%}
+SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+SPDX-License-Identifier: Unlicense
+
+Theme / accent / density tweak panel, ported from chimeraproject.io. Drives the
+[data-theme] attribute and the --accent / --density custom properties that the
+docs colour scheme is wired to.
+{%- endcomment -%}
+<button class="tweaks-fab" id="tweaks-fab" aria-label="Open tweaks">&#9881;</button>
+<div class="tweaks" id="tweaks" role="dialog" aria-label="Tweaks">
+  <div class="tweaks-title">
+    Tweaks
+    <button class="tweaks-close" id="tweaks-close" aria-label="Close">&times;</button>
+  </div>
+  <div class="tweaks-row">
+    <label>Theme</label>
+    <div class="seg" id="seg-theme">
+      <button data-val="dark" class="active">Dark</button>
+      <button data-val="light">Light</button>
+    </div>
+  </div>
+  <div class="tweaks-row">
+    <label>Accent</label>
+    <div class="swatches" id="swatches">
+      <button data-h="55"  style="background: oklch(72% 0.15 55)"  class="active" title="Ember"></button>
+      <button data-h="145" style="background: oklch(72% 0.15 145)" title="Lichen"></button>
+      <button data-h="260" style="background: oklch(72% 0.15 260)" title="Cobalt"></button>
+      <button data-h="320" style="background: oklch(72% 0.15 320)" title="Magenta"></button>
+      <button data-h="80"  style="background: oklch(72% 0.06 80)"  title="Stone"></button>
+    </div>
+  </div>
+  <div class="tweaks-row">
+    <label>Density</label>
+    <div class="seg" id="seg-density">
+      <button data-val="0.85">Compact</button>
+      <button data-val="1" class="active">Default</button>
+      <button data-val="1.2">Roomy</button>
+    </div>
+  </div>
+</div>
+<script>
+(function () {
+  var fab = document.getElementById("tweaks-fab");
+  var panel = document.getElementById("tweaks");
+  if (!fab || !panel) return;
+  fab.addEventListener("click", function () { panel.classList.toggle("open"); });
+  document.getElementById("tweaks-close").addEventListener("click", function () {
+    panel.classList.remove("open");
+  });
+
+  function bindSeg(id, fn) {
+    var seg = document.getElementById(id);
+    seg.querySelectorAll("button").forEach(function (b) {
+      b.addEventListener("click", function () {
+        seg.querySelectorAll("button").forEach(function (x) {
+          x.classList.toggle("active", x === b);
+        });
+        fn(b.dataset.val);
+      });
+    });
+  }
+  bindSeg("seg-theme", function (v) {
+    if (v === "dark") document.documentElement.removeAttribute("data-theme");
+    else document.documentElement.setAttribute("data-theme", v);
+  });
+  bindSeg("seg-density", function (v) {
+    document.documentElement.style.setProperty("--density", v);
+  });
+  document.getElementById("swatches").querySelectorAll("button").forEach(function (b) {
+    b.addEventListener("click", function () {
+      document.getElementById("swatches").querySelectorAll("button").forEach(function (x) {
+        x.classList.toggle("active", x === b);
+      });
+      var h = b.dataset.h;
+      var light = document.documentElement.getAttribute("data-theme") === "light";
+      var L = light ? "58%" : "72%";
+      var C = h === "80" ? "0.06" : (light ? "0.14" : "0.15");
+      document.documentElement.style.setProperty("--accent", "oklch(" + L + " " + C + " " + h + ")");
+      document.documentElement.style.setProperty("--accent-soft", light
+        ? "oklch(92% 0.04 " + h + ")"
+        : "oklch(26% 0.06 " + h + ")");
+    });
+  });
+})();
+</script>

--- a/docs/_includes/head_custom.html
+++ b/docs/_includes/head_custom.html
@@ -1,0 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+
+SPDX-License-Identifier: Unlicense
+-->
+<!-- Match the typefaces used by the top-level chimeraproject.io site. -->
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Serif:ital,wght@0,300;0,400;1,400&family=IBM+Plex+Sans:wght@400;500&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -1,0 +1,62 @@
+---
+layout: table_wrappers
+---
+
+<!--
+SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+
+SPDX-License-Identifier: Unlicense
+
+Overrides the Just the Docs default layout to wrap the page in the shared
+chimeraproject.io top bar and footer. Kept deliberately close to the upstream
+0.12.0 layout so it is easy to re-sync; the only additions are the
+chimera_topbar / chimera_footer / chimera_tweaks includes.
+-->
+
+<!DOCTYPE html>
+
+<html lang="{{ site.lang | default: 'en-US' }}">
+{% include head.html %}
+<body>
+  <a class="skip-to-main" href="#main-content">Skip to main content</a>
+  {% include icons/icons.html %}
+  {% include chimera_topbar.html %}
+  {% if page.nav_enabled == true %}
+    {% include components/sidebar.html %}
+  {% elsif layout.nav_enabled == true and page.nav_enabled == nil %}
+    {% include components/sidebar.html %}
+  {% elsif site.nav_enabled != false and layout.nav_enabled == nil and page.nav_enabled == nil %}
+    {% include components/sidebar.html %}
+  {% endif %}
+  <div class="main" id="top">
+    {% include components/header.html %}
+    <div class="main-content-wrap">
+      {% include components/breadcrumbs.html %}
+      <div id="main-content" class="main-content">
+        <main>
+          {% if site.heading_anchors != false %}
+            {% include vendor/anchor_headings.html html=content beforeHeading="true" anchorBody="<svg viewBox=\"0 0 16 16\" aria-hidden=\"true\"><use xlink:href=\"#svg-link\"></use></svg>" anchorClass="anchor-heading" anchorAttrs="aria-labelledby=\"%html_id%\"" %}
+          {% else %}
+            {{ content }}
+          {% endif %}
+
+          {% if page.has_toc != false %}
+            {% include components/children_nav.html %}
+          {% endif %}
+        </main>
+        {% include components/footer.html %}
+      </div>
+    </div>
+    {% if site.search_enabled != false %}
+      {% include components/search_footer.html %}
+    {% endif %}
+  </div>
+
+  {% include chimera_footer.html %}
+  {% include chimera_tweaks.html %}
+
+  {% if site.mermaid %}
+    {% include components/mermaid.html %}
+  {% endif %}
+</body>
+</html>

--- a/docs/_sass/color_schemes/chimera.scss
+++ b/docs/_sass/color_schemes/chimera.scss
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: Unlicense
+
+// Chimera documentation colour scheme.
+//
+// We build on Just the Docs' stock `dark` scheme (which also pulls in the
+// accessible github-dark Pygments theme for code highlighting), then re-point
+// the palette at the chimeraproject.io tokens.
+//
+// Surfaces that the theme only ever uses in plain `color` / `background` /
+// `border` declarations are wired to the runtime CSS custom properties defined
+// in _sass/custom/custom.scss, so the docs honour the same [data-theme]
+// light/dark switch as the main site. The handful of variables that Just the
+// Docs feeds through Sass colour functions (darken(), rgba(), ...) must stay
+// concrete colours; those are sRGB conversions of the corresponding oklch
+// tokens (dark theme).
+
+@import "color_schemes/dark";
+
+// Runtime-themeable surfaces (safe: never passed through a Sass colour fn).
+$body-background-color: var(--bg);
+$sidebar-color: var(--bg);
+$body-text-color: var(--fg-soft);
+$body-heading-color: var(--fg);
+$nav-child-link-color: var(--fg-soft);
+$code-background-color: var(--surface);
+$search-background-color: var(--surface);
+$table-background-color: var(--surface);
+$search-result-preview-color: var(--muted);
+
+// Concrete colours (consumed by darken()/rgba() in the theme's component SCSS).
+$link-color: #eb883b; // --accent  oklch(72% 0.15 55)
+$btn-primary-color: #eb883b;
+$border-color: #27241f; // --border  oklch(26% 0.01 80)
+$base-button-color: #1a1814; // --surface-2 oklch(21% 0.008 80)
+$feedback-color: #1a1814;

--- a/docs/_sass/custom/custom.scss
+++ b/docs/_sass/custom/custom.scss
@@ -1,0 +1,223 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: Unlicense
+
+// Chimera docs skin for Just the Docs.
+//
+// 1. Design tokens copied verbatim from chimeraproject.io/styles.css so the
+//    docs share the exact same palette (and honour the [data-theme] switch).
+// 2. The shared top bar / footer / tweak-panel chrome.
+// 3. The handful of layout offsets needed to slot Just the Docs' fixed sidebar
+//    underneath the full-width top bar.
+
+// ---------------------------------------------------------------------------
+// 1. Design tokens (chimeraproject.io)
+// ---------------------------------------------------------------------------
+:root {
+  --bg: oklch(13% 0.008 80);
+  --surface: oklch(17% 0.008 80);
+  --surface-2: oklch(21% 0.008 80);
+  --fg: oklch(94% 0.008 80);
+  --fg-soft: oklch(82% 0.008 80);
+  --muted: oklch(60% 0.010 80);
+  --subtle: oklch(45% 0.010 80);
+  --border: oklch(26% 0.010 80);
+  --border-strong: oklch(36% 0.010 80);
+  --accent: oklch(72% 0.15 55);
+  --accent-soft: oklch(26% 0.06 50);
+  --accent-fg: oklch(15% 0.010 80);
+  --warn: oklch(76% 0.13 75);
+  --good: oklch(72% 0.12 150);
+  --bad: oklch(68% 0.16 25);
+
+  --font-serif: "IBM Plex Serif", "Source Serif 4", Georgia, serif;
+  --font-sans: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --font-mono: "JetBrains Mono", "IBM Plex Mono", ui-monospace, "SF Mono", Menlo, monospace;
+
+  --maxw: 1200px;
+  --pad-x: clamp(20px, 4vw, 56px);
+  --density: 1;
+  --topbar-h: 52px;
+}
+
+[data-theme="light"] {
+  --bg: oklch(98% 0.006 80);
+  --surface: oklch(96% 0.008 80);
+  --surface-2: oklch(93% 0.008 80);
+  --fg: oklch(18% 0.012 80);
+  --fg-soft: oklch(30% 0.012 80);
+  --muted: oklch(45% 0.010 80);
+  --subtle: oklch(62% 0.010 80);
+  --border: oklch(88% 0.010 80);
+  --border-strong: oklch(78% 0.010 80);
+  --accent: oklch(58% 0.14 48);
+  --accent-soft: oklch(92% 0.04 50);
+  --accent-fg: oklch(99% 0.006 80);
+}
+
+// Subtle background grid, behind all content (sidebar bg is opaque).
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background-image:
+    linear-gradient(to right, color-mix(in oklab, var(--fg) 4%, transparent) 1px, transparent 1px),
+    linear-gradient(to bottom, color-mix(in oklab, var(--fg) 4%, transparent) 1px, transparent 1px);
+  background-size: 56px 56px;
+  z-index: -1;
+  opacity: 0.5;
+  mask-image: radial-gradient(ellipse at top, black 30%, transparent 80%);
+  -webkit-mask-image: radial-gradient(ellipse at top, black 30%, transparent 80%);
+}
+
+::selection { background: var(--accent); color: var(--accent-fg); }
+
+// Content links track the runtime accent (theme + swatch aware).
+.main-content a:not(.btn):not(.anchor-heading) {
+  color: var(--accent);
+  text-decoration-color: var(--border-strong);
+  text-underline-offset: 3px;
+}
+.main-content a:not(.btn):not(.anchor-heading):hover {
+  color: var(--accent);
+  text-decoration-color: var(--accent);
+}
+
+// ---------------------------------------------------------------------------
+// 2. Shared chrome (top bar / footer / tweaks) — from chimeraproject.io
+// ---------------------------------------------------------------------------
+.shell { max-width: var(--maxw); margin: 0 auto; padding: 0 var(--pad-x); }
+
+.topbar {
+  position: sticky; top: 0; z-index: 50;
+  background: color-mix(in oklab, var(--bg) 92%, transparent);
+  backdrop-filter: saturate(140%) blur(10px);
+  -webkit-backdrop-filter: saturate(140%) blur(10px);
+  border-bottom: 1px solid var(--border-strong);
+  font-family: var(--font-mono);
+  color: var(--fg);
+}
+.topbar-inner { display: flex; align-items: center; gap: 24px; height: var(--topbar-h); }
+.brand {
+  display: inline-flex; align-items: center; gap: 10px;
+  font-family: var(--font-mono); font-size: 14px; font-weight: 500;
+  letter-spacing: 0; text-decoration: none; color: var(--fg); flex-shrink: 0;
+}
+.brand-mark { width: 18px; height: 18px; display: inline-grid; place-items: center; color: var(--accent); }
+.brand-mark svg { width: 100%; height: 100%; }
+
+.proj-tabs {
+  display: inline-flex; margin-left: 4px;
+  border: 1px solid var(--border-strong); border-radius: 3px;
+  overflow: hidden; flex-shrink: 0;
+}
+.proj-tab {
+  font-family: var(--font-mono); font-size: 12px; padding: 5px 10px;
+  white-space: nowrap; text-decoration: none; color: var(--fg-soft);
+  border-right: 1px solid var(--border-strong); background: transparent;
+  transition: background 120ms, color 120ms;
+}
+.proj-tab:last-child { border-right: 0; }
+.proj-tab:hover { background: var(--surface); color: var(--fg); }
+.proj-tab.active { background: var(--accent); color: var(--accent-fg); }
+
+.topbar .nav { display: flex; align-items: center; gap: 2px; margin-left: auto; font-size: 13px; min-width: 0; }
+.topbar .nav a { padding: 6px 10px; border-radius: 3px; text-decoration: none; color: var(--fg-soft); font-family: var(--font-mono); }
+.topbar .nav a:hover { background: var(--surface); color: var(--fg); }
+.topbar .nav a.current { color: var(--fg); background: var(--surface); }
+.topbar .nav a.current::before { content: "\00bb \00a0"; color: var(--accent); }
+.topbar .nav .gh {
+  display: inline-flex; align-items: center; gap: 6px; padding: 5px 10px;
+  border: 1px solid var(--border-strong); border-radius: 3px; margin-left: 8px; color: var(--fg-soft);
+}
+.topbar .nav .gh:hover { border-color: var(--accent); background: var(--surface); color: var(--fg); }
+.topbar .nav .gh:hover::before { content: ""; }
+.topbar .nav .gh svg { width: 13px; height: 13px; }
+
+footer.site-foot {
+  border-top: 1px solid var(--border);
+  padding: 48px 0 56px;
+  color: var(--muted); font-size: 13px; font-family: var(--font-mono);
+  background: var(--bg);
+}
+footer.site-foot .cols { display: grid; grid-template-columns: 2fr repeat(3, 1fr); gap: 32px; }
+footer.site-foot h4 {
+  font-family: var(--font-mono); font-size: 10px; font-weight: 500;
+  text-transform: uppercase; letter-spacing: 0.16em; color: var(--muted); margin-bottom: 12px;
+}
+footer.site-foot p { margin: 0; }
+footer.site-foot a { display: block; padding: 3px 0; color: var(--fg-soft); text-decoration: none; }
+footer.site-foot a:hover { color: var(--accent); }
+footer.site-foot .meta {
+  margin-top: 40px; padding-top: 20px; border-top: 1px solid var(--border);
+  display: flex; gap: 24px; flex-wrap: wrap;
+  font-family: var(--font-mono); font-size: 10px; text-transform: uppercase; letter-spacing: 0.12em;
+}
+
+.tweaks-fab {
+  position: fixed; right: 20px; bottom: 20px; z-index: 80;
+  width: 38px; height: 38px; border-radius: 3px;
+  background: var(--surface); color: var(--fg);
+  border: 1px solid var(--border-strong); cursor: pointer;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.28);
+  display: grid; place-items: center; font-family: var(--font-mono); font-size: 14px;
+}
+.tweaks-fab:hover { border-color: var(--accent); color: var(--accent); }
+.tweaks {
+  position: fixed; right: 20px; bottom: 68px; z-index: 80; width: 280px;
+  background: var(--bg); border: 1px solid var(--border-strong);
+  border-radius: 4px; padding: 16px; box-shadow: 0 16px 48px rgba(0, 0, 0, 0.4);
+  display: none; font-family: var(--font-mono);
+}
+.tweaks.open { display: block; }
+.tweaks-title {
+  font-family: var(--font-mono); font-size: 10px; text-transform: uppercase; letter-spacing: 0.16em;
+  color: var(--muted); margin-bottom: 14px; display: flex; justify-content: space-between; align-items: center;
+}
+.tweaks-row { margin: 14px 0; }
+.tweaks-row label {
+  display: block; font-size: 10px; color: var(--muted); margin-bottom: 6px;
+  font-family: var(--font-mono); text-transform: uppercase; letter-spacing: 0.12em;
+}
+.seg { display: inline-flex; border: 1px solid var(--border-strong); border-radius: 3px; overflow: hidden; }
+.seg button {
+  font-family: var(--font-mono); font-size: 12px; padding: 5px 10px; border: 0;
+  background: transparent; color: var(--fg-soft); cursor: pointer; border-right: 1px solid var(--border-strong);
+}
+.seg button:last-child { border-right: 0; }
+.seg button.active { background: var(--accent); color: var(--accent-fg); }
+.swatches { display: flex; gap: 8px; }
+.swatches button { width: 22px; height: 22px; border-radius: 3px; border: 1px solid var(--border-strong); cursor: pointer; padding: 0; }
+.swatches button.active { outline: 1px solid var(--accent); outline-offset: 2px; }
+.tweaks-close { background: transparent; border: 0; cursor: pointer; color: var(--muted); font-size: 16px; line-height: 1; }
+
+// ---------------------------------------------------------------------------
+// 3. Slot Just the Docs' fixed sidebar / footer under the full-width top bar
+// ---------------------------------------------------------------------------
+@include mq(md) {
+  .side-bar {
+    top: var(--topbar-h);
+    height: calc(100vh - var(--topbar-h));
+  }
+
+  footer.site-foot {
+    margin-left: $nav-width-md;
+  }
+}
+
+@include mq(lg) {
+  footer.site-foot {
+    // Mirror .main's left margin so the fixed sidebar never overlaps the footer.
+    // stylelint-disable-next-line function-name-case
+    margin-left: Max(
+      #{$nav-width},
+      calc((100% - #{$nav-width + $content-width}) / 2 + #{$nav-width})
+    );
+  }
+}
+
+@media (max-width: 760px) {
+  .topbar .nav a:not(.gh) { display: none; }
+  footer.site-foot .cols { grid-template-columns: 1fr 1fr; }
+}

--- a/docs/_sass/custom/setup.scss
+++ b/docs/_sass/custom/setup.scss
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: Unlicense
+
+// Variable overrides applied before Just the Docs' component styles are
+// compiled. This is where we re-point the theme's typography and metrics at
+// the chimeraproject.io design language (mono-forward body, serif headings,
+// tight 3px radii). Colours live in _sass/color_schemes/chimera.scss.
+
+$mono-font-family: "JetBrains Mono", "IBM Plex Mono", ui-monospace, "SF Mono",
+  menlo, monospace;
+$body-font-family: $mono-font-family;
+$body-heading-font-family: "IBM Plex Serif", "Source Serif 4", georgia, serif;
+
+$border-radius: 3px;


### PR DESCRIPTION
## Summary

Retool the Jekyll docs pipeline (`docs/`) so the generated documentation shares the look and chrome of the top-level **chimeraproject.io** site, instead of the stock Just the Docs appearance. This skins Just the Docs rather than replacing it, so we keep search, the auto sidebar nav, TOC, and code highlighting while matching the marquee site.

## What changed

- **New color scheme** `_sass/color_schemes/chimera.scss` — builds on JTD's `dark` scheme (which also brings the github-dark Pygments theme), then re-points the palette at the chimeraproject.io oklch tokens. Surfaces that are only used in plain `color`/`background`/`border` are wired to runtime `var(--token)` (so they honour the `[data-theme]` switch); the handful of vars JTD feeds through Sass colour functions (`darken()`, `rgba()`) stay concrete sRGB conversions of the same oklch values.
- **Typography + tokens** — `IBM Plex Serif` headings, `JetBrains Mono` body/labels, 3px radii (`_sass/custom/setup.scss`), and the full oklch token set incl. a `[data-theme=light]` variant (`_sass/custom/custom.scss`).
- **Shared chrome** — full-width top bar, footer, and the theme/accent/density "Tweaks" panel ported from the main site (`_includes/chimera_topbar.html`, `chimera_footer.html`, `chimera_tweaks.html`, `head_custom.html`), layered into a thin `_layouts/default.html` override kept close to upstream 0.12.0 for easy re-syncing. Cross-site links are absolute to the site root; docs-internal links use `relative_url`.
- **Layout glue** — slot JTD's fixed sidebar/footer underneath the 52px top bar.
- **Config fix** — `_config.yml` had `url:` set to the full `…/chimera` path, which combined with the workflow's `--baseurl /chimera` doubled every `jekyll-seo-tag` canonical/`og:url` (`…/chimera/chimera/`). Set `url:` to the origin and add `baseurl: /chimera` (CI re-passes the same value).

## Verification

- `bundle exec jekyll build` succeeds (only pre-existing JTD Sass deprecation warnings).
- Output contains the tokens/chrome/fonts; github-dark code theme wins the cascade; canonical URLs are correct; `reuse lint` passes (770/770).

## Follow-ups (not in this PR)

- `docs/api.html` (Redoc) is a standalone page still on Redoc's default light theme — can be themed to match.
- The 4 colour-function-bound vars are baked dark-theme hex, so the Tweaks "Light" toggle themes everything except those; can be made `var()`-driven for pixel-clean light mode.
