### PR TITLE
smb2: fix daemon abort on LOGOFF after a pooled connection is reused

### DIFF
--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -1462,6 +1462,15 @@ chimera_smb_conn_free(
         chimera_smb_session_handle_free(thread, session_handle);
     }
 
+    /* last_session_handle is a raw cache into session_handles (above); the
+     * loop just freed every entry, so drop the dangling pointer before this
+     * conn struct is returned to the free list.  Otherwise a later reuse of
+     * the pooled conn (chimera_smb_conn_alloc) inherits a pointer to a freed,
+     * recycled handle, and the session-resolution fast path hands it out for
+     * a request whose session id happens to match the recycled handle's
+     * current session -- which then aborts in chimera_smb_logoff. */
+    conn->last_session_handle = NULL;
+
     if (conn->nascent_ctx != GSS_C_NO_CONTEXT) {
         gss_delete_sec_context(&conn->gss_minor, &conn->nascent_ctx, NULL);
         conn->nascent_ctx = GSS_C_NO_CONTEXT;

--- a/src/server/smb/smb_proc_logoff.c
+++ b/src/server/smb/smb_proc_logoff.c
@@ -15,8 +15,14 @@ chimera_smb_logoff(struct chimera_smb_request *request)
 
     HASH_FIND(hh, conn->session_handles, &request->smb2_hdr.session_id, sizeof(uint64_t), session_handle);
 
-    chimera_smb_abort_if(!session_handle,
-                         "Received SMB2 LOGOFF request for unknown session, should have been caught by session setup");
+    if (!session_handle) {
+        /* No session for this id on this connection.  Per MS-SMB2 3.3.5.6 /
+         * 3.3.5.2.9 a LOGOFF that does not resolve to a session is answered
+         * with STATUS_USER_SESSION_DELETED -- never a server abort (that would
+         * be a remotely triggerable crash). */
+        chimera_smb_complete_request(request, SMB2_STATUS_USER_SESSION_DELETED);
+        return;
+    }
 
     chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
 


### PR DESCRIPTION
## Summary

A multichannel WPTS run aborted the daemon at `smb_proc_logoff.c` with *"LOGOFF request for unknown session"* (`signal 6`). It reproduces when several SMB connections are served on one daemon and a connection drops without an explicit LOGOFF (common in the `MultipleChannel_*` cases).

## Root cause

Connection structs are pooled (`thread->free_conns`). `chimera_smb_conn_free()` deletes and frees every session handle in the connection's table when the transport drops, **but never clears `conn->last_session_handle`** — a raw cache pointer into that table. The freed handle returns to the per-thread free list and is recycled by a later connection, while the pooled `conn` struct (reused by `chimera_smb_conn_alloc`) still points at it.

The session-resolution fast path in `handle_smb2` trusts `last_session_handle` whenever `last_session_handle->session->session_id` matches the request's session id. For the recycled handle that can match by coincidence, so it hands LOGOFF a handle that is **not** actually in `conn->session_handles` — and the handler's `HASH_FIND`-or-abort fired.

Instrumented confirmation at the crash: `req_sh == last_session_handle`, but `table_count = 0` (the conn's session-handle table was empty) and the handle's stored `session_id` was stale (a previous session's id), proving `last_session_handle` was a dangling/recycled pointer.

## Fixes
1. **Root cause** — clear `conn->last_session_handle` in `chimera_smb_conn_free()` after the session-handle table is emptied, so a pooled/reused connection never inherits a dangling cache pointer. (This mirrors the existing `lease_break_tearing_down` reset-on-reuse convention.)
2. **Defense + spec correctness** — `chimera_smb_logoff()` now answers an unresolved session id with `STATUS_USER_SESSION_DELETED` (MS-SMB2 3.3.5.6 / 3.3.5.2.9) instead of a fatal abort. A LOGOFF must never be a remotely-triggerable daemon crash.

## Verification
- The full `MultipleChannel` + `NetworkInterfaceInfo` family now runs to completion against a **single** daemon: 12 pass / 2 fail / 3 skip, **no crash** (previously the daemon aborted on the third case and the remaining tests cascaded as connection failures).
- No regressions in the session / tree / create-close / durable-handle families (all remaining failures are pre-existing, non-allowlisted feature gaps).