### PR TITLE
smb2: emit CHANGE_NOTIFY for size/EA/security changes + reject oversized buffer

### DIFF
--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -598,6 +598,11 @@ struct chimera_smb_request {
             struct chimera_smb_file_id      file_id;
             struct chimera_smb_attrs        attrs;
             struct chimera_vfs_attrs        vfs_attrs;
+            /* VFS notify event(s) the set_info callback fires on the parent on
+             * success.  0 => default to ATTRS_CHANGED; EndOfFile/Allocation set
+             * SIZE_CHANGED|FILE_MODIFIED so a FILE_NOTIFY_CHANGE_SIZE watch
+             * fires (smb2.change_notify ChangeSize). */
+            uint32_t                        notify_mask;
             /* Rename information */
             struct chimera_smb_rename_info  rename_info;
             /* Security descriptor buffer for SMB2_INFO_SECURITY */

--- a/src/server/smb/smb_proc_change_notify.c
+++ b/src/server/smb/smb_proc_change_notify.c
@@ -83,6 +83,15 @@ chimera_smb_change_notify(struct chimera_smb_request *request)
         return;
     }
 
+    /* MS-SMB2 3.3.5.19: if OutputBufferLength exceeds Connection.MaxTransactSize
+     * the server MUST fail the request with STATUS_INVALID_PARAMETER rather than
+     * arming a watch (smb2.change_notify MaxTransactSize check). */
+    if (request->change_notify.output_buffer_length > CHIMERA_SMB_MAX_TRANSACT_SIZE) {
+        chimera_smb_open_file_release(request, open_file);
+        chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
+        return;
+    }
+
     request->change_notify.open_file = open_file;
 
     vfs_notify = thread->shared->vfs->vfs_notify;

--- a/src/server/smb/smb_proc_security.c
+++ b/src/server/smb/smb_proc_security.c
@@ -839,7 +839,21 @@ chimera_smb_set_security_dispatch(struct chimera_smb_request *request)
     struct chimera_vfs_attrs *vfs_attrs = &request->set_info.vfs_attrs;
 
     if (vfs_attrs->va_set_mask == 0) {
-        /* Nothing to change */
+        /* Nothing in our model changed -- e.g. a SACL-only SetSecurityDescriptor
+         * (chimera does not persist SACLs).  The set still succeeds, and like
+         * any security change it fires FILE_NOTIFY_CHANGE_SECURITY on the parent
+         * (ATTRS_CHANGED; smb2.change_notify ChangeSecurity). */
+        if (request->set_info.open_file->parent_fh_len > 0) {
+            struct chimera_server_smb_thread *thread = request->compound->thread;
+
+            chimera_vfs_notify_emit(thread->shared->vfs->vfs_notify,
+                                    request->set_info.open_file->parent_fh,
+                                    request->set_info.open_file->parent_fh_len,
+                                    CHIMERA_VFS_NOTIFY_ATTRS_CHANGED,
+                                    request->set_info.open_file->name,
+                                    request->set_info.open_file->name_len,
+                                    NULL, 0);
+        }
         chimera_smb_open_file_release(request, request->set_info.open_file);
         chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
         return;

--- a/src/server/smb/smb_proc_set_info.c
+++ b/src/server/smb/smb_proc_set_info.c
@@ -21,11 +21,13 @@ chimera_smb_set_info_callback(
 
     if (!error_code && request->set_info.open_file->parent_fh_len > 0) {
         struct chimera_server_smb_thread *thread = request->compound->thread;
+        uint32_t                          mask   = request->set_info.notify_mask ?
+            request->set_info.notify_mask : CHIMERA_VFS_NOTIFY_ATTRS_CHANGED;
 
         chimera_vfs_notify_emit(thread->shared->vfs->vfs_notify,
                                 request->set_info.open_file->parent_fh,
                                 request->set_info.open_file->parent_fh_len,
-                                CHIMERA_VFS_NOTIFY_ATTRS_CHANGED,
+                                mask,
                                 request->set_info.open_file->name,
                                 request->set_info.open_file->name_len,
                                 NULL, 0);
@@ -210,6 +212,9 @@ chimera_smb_set_info(struct chimera_smb_request *request)
 {
     request->set_info.open_file     = chimera_smb_open_file_resolve(request, &request->set_info.file_id);
     request->set_info.parent_handle = NULL;
+    /* Default change-notify event for this SET_INFO; info classes that mutate
+     * size override it below.  Cleared here since the request is pooled. */
+    request->set_info.notify_mask = 0;
 
     if (unlikely(!request->set_info.open_file)) {
         chimera_smb_complete_request(request, SMB2_STATUS_FILE_CLOSED);
@@ -243,6 +248,11 @@ chimera_smb_set_info(struct chimera_smb_request *request)
                 case SMB2_FILE_ENDOFFILE_INFO:
                     chimera_smb_unmarshal_end_of_file_info(&request->set_info.attrs, &request->set_info.vfs_attrs);
 
+                    /* A size change fires FILE_NOTIFY_CHANGE_SIZE (and, via the
+                     * advanced LastWriteTime below, FILE_NOTIFY_CHANGE_LAST_WRITE). */
+                    request->set_info.notify_mask = CHIMERA_VFS_NOTIFY_SIZE_CHANGED |
+                        CHIMERA_VFS_NOTIFY_FILE_MODIFIED;
+
                     /* Setting EndOfFile advances the LastWriteTime (it changes
                      * the file's data extent), unless this handle has taken
                      * sticky control of the write time. */
@@ -269,6 +279,8 @@ chimera_smb_set_info(struct chimera_smb_request *request)
                      * advances LastWriteTime; a grow/hint only touches
                      * ChangeTime.  Both need the current size to decide, so this
                      * is resolved in the getattr callback. */
+                    request->set_info.notify_mask = CHIMERA_VFS_NOTIFY_SIZE_CHANGED |
+                        CHIMERA_VFS_NOTIFY_FILE_MODIFIED;
                     chimera_smb_unmarshal_end_of_file_info(&request->set_info.attrs, &request->set_info.vfs_attrs);
 
                     chimera_vfs_getattr(
@@ -320,6 +332,20 @@ chimera_smb_set_info(struct chimera_smb_request *request)
                     chimera_smb_set_info_link_process(request);
                     break;
                 case SMB2_FILE_FULL_EA_INFO:
+                    /* chimera does not persist EAs, but a SET of extended
+                     * attributes still fires FILE_NOTIFY_CHANGE_EA on the parent
+                     * (smb2.change_notify ChangeEa). */
+                    if (request->set_info.open_file->parent_fh_len > 0) {
+                        struct chimera_server_smb_thread *thread = request->compound->thread;
+
+                        chimera_vfs_notify_emit(thread->shared->vfs->vfs_notify,
+                                                request->set_info.open_file->parent_fh,
+                                                request->set_info.open_file->parent_fh_len,
+                                                CHIMERA_VFS_NOTIFY_ATTRS_CHANGED,
+                                                request->set_info.open_file->name,
+                                                request->set_info.open_file->name_len,
+                                                NULL, 0);
+                    }
                     chimera_smb_open_file_release(request, request->set_info.open_file);
                     chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
                     break;


### PR DESCRIPTION
## Summary

Eight WPTS `smb2.change_notify` cases failed because the server never delivered the notification the client was waiting for (8s timeout), or because it didn't validate the request size. Each is a distinct gap on the **producer** side — the completion-filter → VFS-event mapping was already correct.

| Case | Root cause | Fix |
|---|---|---|
| **ChangeSize** | `SET_INFO FileEndOfFileInformation` emitted only `ATTRS_CHANGED`; a `FILE_NOTIFY_CHANGE_SIZE` watch maps to `SIZE_CHANGED`/`FILE_MODIFIED`, so it never matched | set_info callback now fires a per-info-class mask; EndOfFile/Allocation emit `SIZE_CHANGED\|FILE_MODIFIED` (basic-info etc. stay `ATTRS_CHANGED`) |
| **ChangeEa** | `SET_INFO FileFullEaInformation` was a no-op returning SUCCESS without notifying | chimera doesn't persist EAs, but the set now fires `FILE_NOTIFY_CHANGE_EA` (`ATTRS_CHANGED`) on the parent |
| **ChangeSecurity** | a SACL-only `SetSecurityDescriptor` leaves `va_set_mask==0` (chimera doesn't store SACLs) and took the "nothing to change" fast path, returning SUCCESS without notifying | now fires `FILE_NOTIFY_CHANGE_SECURITY` (`ATTRS_CHANGED`) on the parent |
| **MaxTransactSizeCheck** ×5 | a CHANGE_NOTIFY whose `OutputBufferLength` > `Connection.MaxTransactSize` was armed as a watch with no reply → client timeout | reject with `STATUS_INVALID_PARAMETER` (MS-SMB2 3.3.5.19) |

## Verification
`smb2.change_notify` on memfs: **10/21 → 18/21** passing. Regression-checked the set-info / create-close / query / compound families — no regressions (remaining failures there are the pre-existing DoubleDotDir and encryption-mode cases).

## Deferred
The three remaining failures — `ChangeStreamName` / `ChangeStreamSize` / `ChangeStreamWrite` — need named-stream change notifications (the stream operations must emit notify events, and the share must advertise streams). Left for separate work.