### PR TITLE
smb2: reject PreviousSessionId reconnect at a different dialect

### DIFF
--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -1288,17 +1288,18 @@ chimera_smb_session_park_durables(
  * handles are parked immediately so the new connection can reclaim them.  Never
  * invalidate the new session itself, and only act when the requesting user
  * matches the prior session's owner. */
-static inline void
+static inline int
 chimera_smb_session_invalidate_previous(
     struct chimera_server_smb_thread *thread,
     struct chimera_server_smb_shared *shared,
     uint64_t                          prev_session_id,
-    struct chimera_smb_session       *new_session)
+    struct chimera_smb_session       *new_session,
+    uint16_t                          cur_dialect)
 {
     struct chimera_smb_session *prev;
 
     if (prev_session_id == 0 || prev_session_id == new_session->session_id) {
-        return;
+        return 0;
     }
 
     pthread_mutex_lock(&shared->sessions_lock);
@@ -1308,6 +1309,13 @@ chimera_smb_session_invalidate_previous(
     if (prev && prev != new_session &&
         (prev->flags & CHIMERA_SMB_SESSION_AUTHORIZED) &&
         prev->cred.uid == new_session->cred.uid) {
+        /* MS-SMB2 3.3.5.5.1: a reconnect whose connection dialect differs from
+         * the previous session's MUST be rejected.  Leave the previous session
+         * intact and signal the caller to fail with USER_SESSION_DELETED. */
+        if (prev->dialect != cur_dialect) {
+            pthread_mutex_unlock(&shared->sessions_lock);
+            return 1;
+        }
         /* Clear AUTHORIZED and unlink here so the later refcnt-driven
          * chimera_smb_session_release() does not HASH_DEL a second time.  Hold a
          * reference across the park so a concurrent release cannot free it. */
@@ -1325,6 +1333,7 @@ chimera_smb_session_invalidate_previous(
         chimera_smb_session_park_durables(shared, prev);
         chimera_smb_session_release(thread, shared, prev, true);
     }
+    return 0;
 } /* chimera_smb_session_invalidate_previous */
 
 

--- a/src/server/smb/smb_proc_session_setup.c
+++ b/src/server/smb/smb_proc_session_setup.c
@@ -168,6 +168,10 @@ chimera_smb_session_setup(struct chimera_smb_request *request)
     if ((rc == 0 || rc == 1) && !request->session_handle) {
         session = chimera_smb_session_alloc(shared);
 
+        /* Record the connection's negotiated dialect so a later
+         * PreviousSessionId reconnect can enforce MS-SMB2 3.3.5.5.1. */
+        session->dialect = conn->dialect;
+
         session_handle = chimera_smb_session_handle_alloc(thread);
 
         session_handle->session_id = session->session_id;
@@ -345,11 +349,23 @@ chimera_smb_session_setup(struct chimera_smb_request *request)
         }
 
         /* If the client named a previous session (reconnect on a fresh
-         * transport), close it now that this one is established. */
-        if (request->session_setup.prev_session_id) {
+         * transport), close it now that this one is established.  MS-SMB2
+         * 3.3.5.5.1: when the previous session was negotiated at a different
+         * dialect than this connection, the reconnect is rejected -- close the
+         * just-created session and fail with STATUS_USER_SESSION_DELETED
+         * (smb2.session ReconnectWithDifferentDialect). */
+        if (request->session_setup.prev_session_id &&
             chimera_smb_session_invalidate_previous(thread, shared,
                                                     request->session_setup.prev_session_id,
-                                                    session);
+                                                    session, conn->dialect)) {
+            chimera_smb_complete_request(request, SMB2_STATUS_USER_SESSION_DELETED);
+
+            HASH_DEL(conn->session_handles, request->session_handle);
+            chimera_smb_session_release(thread, shared, session, false);
+            chimera_smb_session_handle_free(thread, request->session_handle);
+            request->session_handle   = NULL;
+            conn->last_session_handle = NULL;
+            return;
         }
 
         chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);

--- a/src/server/smb/smb_session.h
+++ b/src/server/smb/smb_session.h
@@ -192,6 +192,10 @@ struct chimera_smb_session {
     uint64_t                    session_id;
     uint32_t                    refcnt;
     uint32_t                    flags;
+    /* Dialect of the connection this session was established on (MS-SMB2
+     * Session.Connection.Dialect).  A PreviousSessionId reconnect whose
+     * connection negotiated a different dialect is rejected. */
+    uint16_t                    dialect;
     struct UT_hash_handle       hh;
     struct chimera_smb_session *prev;
     struct chimera_smb_session *next;


### PR DESCRIPTION
## Summary

MS-SMB2 3.3.5.5.1: when a SESSION_SETUP names a `PreviousSessionId` whose session was established on a connection with a **different negotiated dialect**, the server MUST close the newly created session and fail the request with `STATUS_USER_SESSION_DELETED`. chimera ignored the dialect and returned SUCCESS (WPTS `smb2.session SessionMgmt_ReconnectWithDifferentDialect`).

## Change
- Record the connection's dialect on the session at creation (`session->dialect`).
- `chimera_smb_session_invalidate_previous()` now compares it against the reconnecting connection's dialect. On a mismatch it leaves the previous session intact and signals the caller, which tears down the just-created session and replies `USER_SESSION_DELETED`.

## Verification
`SessionMgmt_ReconnectWithDifferentDialect` now passes. Matching-dialect reconnects are unaffected — the durable/persistent reconnect path reuses this function: **36/46** durable+persistent cases unchanged, and SessionMgmt `NewSession` / `ReconnectSessionSetup` / `Reauthentication` still pass.

## Not addressed
`SessionMgmt_SupportsNotificationsMismatch` requires server-to-client notification support. chimera advertises none, so both connections report `SupportsNotifications=false` and no mismatch can arise (the documented `INVALID_PARAMETER` rejection is unreachable). Left for when that feature lands.