### PR TITLE
smb2: advertise SMB2_SHAREFLAG_COMPRESS_DATA on compressed shares

### DIFF
--- a/src/server/smb/smb2.h
+++ b/src/server/smb/smb2.h
@@ -695,6 +695,7 @@ typedef uint8_t smb2_guid[SMB2_GUID_SIZE];
 // SMB2 TREE_CONNECT response ShareFlags
 #define SMB2_SHAREFLAG_ACCESS_BASED_DIRECTORY_ENUM  0x00000800
 #define SMB2_SHAREFLAG_ENCRYPT_DATA                 0x00008000 // Per-share encryption (SMB 3.0+)
+#define SMB2_SHAREFLAG_COMPRESS_DATA                0x00100000 // Share supports compression (SMB 3.1.1+)
 
 // SMB2/3 Negotiate Capabilities
 #define SMB2_GLOBAL_CAP_DFS                         0x00000001 // Server supports DFS

--- a/src/server/smb/smb_proc_tree_connect.c
+++ b/src/server/smb/smb_proc_tree_connect.c
@@ -126,6 +126,14 @@ chimera_smb_tree_connect_reply(
             request->tree->share->encrypt_data) {
             share_flags |= SMB2_SHAREFLAG_ENCRYPT_DATA;
         }
+        /* SMB3 transport compression is a global server capability (no per-share
+         * knob).  When it is enabled, advertise that disk shares support
+         * compressing their data so conforming clients may compress traffic on
+         * this tree (MS-SMB2 §2.2.10 SMB2_SHAREFLAG_COMPRESS_DATA). */
+        if (!request->tree_connect.is_ipc &&
+            request->compound->thread->shared->config.compression) {
+            share_flags |= SMB2_SHAREFLAG_COMPRESS_DATA;
+        }
         evpl_iovec_cursor_append_uint32(reply_cursor, share_flags);
     }
 

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -300,7 +300,8 @@ if(CHIMERA_NETNS_TESTING AND WPTS_DOTNET AND WPTS_SMB2_DLL AND WPTS_ARCH_SUPPORT
         SMB2Compression_InvalidCompressedPacketLength
         SMB2Compression_InvalidCompressionAlgorithm
         SMB2Compression_InvalidDecompressedProtocolId
-        SMB2Compression_LZ77_LargeFile)
+        SMB2Compression_LZ77_LargeFile
+        TreeMgmt_SMB311_COMPRESS_DATA)
 
     foreach(tc ${WPTS_SMB2_COMPRESSION_ALLOWLIST})
         add_test(NAME chimera/server/smb/wpts/memfs_compression/${tc}


### PR DESCRIPTION
## Summary

When SMB3 transport compression is enabled (`smb_compression`), the TREE_CONNECT response for a disk share now sets `SMB2_SHAREFLAG_COMPRESS_DATA` (0x00100000) in the ShareFlags field, per MS-SMB2 §2.2.10. Previously the server advertised only the caching/other flags, so a client could not tell the share supported compressing its data.

## Details

- Added the `SMB2_SHAREFLAG_COMPRESS_DATA` constant to `smb2.h`.
- In `chimera_smb_tree_connect_reply`, set the flag when the global compression capability is enabled. The daemon models compression as a server-wide capability (`shared->config.compression`), not per-share, so the flag follows the global knob. It is skipped for IPC$ trees and is never set when compression is off, so non-compression clients/tests are unaffected.

## Test

Enables WPTS case `TreeMgmt_SMB311_COMPRESS_DATA` in the compression-mode allowlist (`src/server/smb/tests/CMakeLists.txt`). The case now passes via ctest; the compression-mode TreeMgmt + Compression suite stays green (39 passed, 0 failed), and with compression off the flag is not advertised (the case self-skips and smbtorture `smb2.tcon` is unaffected).