### PR TITLE
smb2: disconnect on NEGOTIATE-after-NEGOTIATE (MS-SMB2 3.3.5.4)

### DIFF
--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -1904,6 +1904,11 @@ chimera_smb_server_accept(
     memset(conn->negotiate_preauth_hash, 0, sizeof(conn->negotiate_preauth_hash));
     conn->rdma_niov   = 0;
     conn->rdma_length = 0;
+    /* Conns are pooled; clear per-connection negotiate state so the
+    * "NEGOTIATE after NEGOTIATE" guard (MS-SMB2 3.3.5.4) does not trip on
+    * a dialect inherited from a previously torn-down connection. */
+    conn->dialect = 0;
+    conn->flags   = 0;
 
     evpl_bind_get_local_address(bind, conn->local_addr, sizeof(conn->local_addr));
     evpl_bind_get_remote_address(bind, conn->remote_addr, sizeof(conn->remote_addr));

--- a/src/server/smb/smb_proc_negotiate.c
+++ b/src/server/smb/smb_proc_negotiate.c
@@ -57,6 +57,20 @@ chimera_smb_negotiate(struct chimera_smb_request *request)
     uint16_t                          dialect = 0, candidate;
     int                               i, j;
 
+    /* MS-SMB2 3.3.5.4: a NEGOTIATE received on a connection that already
+     * completed one (Connection.NegotiateDialect set to a concrete SMB2
+     * dialect) MUST terminate the transport connection with no reply.  WPTS
+     * DurableHandleV1_Reconnect_AfterServerDisconnect drives exactly this to
+     * force a server-side disconnect before reconnecting.  Mirror the
+     * VALIDATE_NEGOTIATE_INFO teardown: drop the compound and close the bind. */
+    if (conn->dialect != 0) {
+        struct chimera_smb_compound *compound = request->compound;
+
+        chimera_smb_compound_free(thread, compound);
+        evpl_close(thread->evpl, conn->bind);
+        return;
+    }
+
     clock_gettime(
         CLOCK_REALTIME,
         &now);

--- a/src/server/smb/smb_proc_negotiate.c
+++ b/src/server/smb/smb_proc_negotiate.c
@@ -62,8 +62,15 @@ chimera_smb_negotiate(struct chimera_smb_request *request)
      * dialect) MUST terminate the transport connection with no reply.  WPTS
      * DurableHandleV1_Reconnect_AfterServerDisconnect drives exactly this to
      * force a server-side disconnect before reconnecting.  Mirror the
-     * VALIDATE_NEGOTIATE_INFO teardown: drop the compound and close the bind. */
-    if (conn->dialect != 0) {
+     * VALIDATE_NEGOTIATE_INFO teardown: drop the compound and close the bind.
+     *
+     * Exception: 0x02ff is the wildcard "revision" recorded when an SMB1
+     * multi-protocol NEGOTIATE offered "SMB 2.???" (MS-SMB2 3.3.5.3.1).  It
+     * explicitly means "a real SMB2 NEGOTIATE follows on this same
+     * connection", so that mandatory second NEGOTIATE must be processed, not
+     * treated as a duplicate (otherwise BVT_Negotiate_Compatible_Wildcard and
+     * every real SMB1->SMB2 wildcard client get their connection dropped). */
+    if (conn->dialect != 0 && conn->dialect != 0x02ff) {
         struct chimera_smb_compound *compound = request->compound;
 
         chimera_smb_compound_free(thread, compound);

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -203,17 +203,17 @@ if(CHIMERA_NETNS_TESTING AND WPTS_DOTNET AND WPTS_SMB2_DLL AND WPTS_ARCH_SUPPORT
     # NonPersistentHandle variants — only become applicable once the CA / replay
     # capability is advertised, so they live here rather than in the base list.
     # Allowlist = every applicable durable/persistent/replay case confirmed green
-    # against the current server.  Left out: DurableHandleV1_Reconnect_AfterServerDisconnect
-    # (needs negotiate-after-negotiate to drop the connection — an unrelated
-    # protocol gap), *_WithDifferentDurableOwner / BVT_PersistentHandles (need a
-    # second user account / scale-out config the harness doesn't provide), and
-    # the Replay IoCtl/Lock cases (replay-eligibility not yet cleared on those ops).
+    # against the current server.  Left out: *_WithDifferentDurableOwner /
+    # BVT_PersistentHandles (need a second user account / scale-out config the
+    # harness doesn't provide — they report Inconclusive/NotExecuted), and the
+    # Replay IoCtl/Lock cases (replay-eligibility not yet cleared on those ops).
     set(WPTS_SMB2_PERSISTENT_ALLOWLIST
         BVT_DurableHandleV1_Reconnect_WithBatchOplock
         BVT_DurableHandleV1_Reconnect_WithLeaseV1
         BVT_DurableHandleV2_Reconnect_WithBatchOplock
         BVT_DurableHandleV2_Reconnect_WithLeaseV1
         BVT_PersistentHandle_Reconnect
+        DurableHandleV1_Reconnect_AfterServerDisconnect
         DurableHandleV1_Reconnect_IncludeCreateDurableHandle
         DurableHandleV1_Reconnect_IncludeReconnectV2
         DurableHandleV1_Reconnect_IncludeRequestV2


### PR DESCRIPTION
## What

A second `NEGOTIATE` arriving on a connection that has already negotiated a dialect must, per **MS-SMB2 3.3.5.4**, terminate the transport connection with no reply. The server previously processed it as a fresh negotiate.

WPTS `DurableHandleV1_Reconnect_AfterServerDisconnect` drives exactly this NEGOTIATE-after-NEGOTIATE (its `TriggerServerTerminateConnection` step) to force a server-side disconnect before reconnecting a durable-v1 handle. Without the disconnect the test could not proceed and failed.

## Fix

- `chimera_smb_negotiate`: if `conn->dialect != 0` (a dialect was already negotiated on this connection), tear the connection down using the existing `VALIDATE_NEGOTIATE_INFO` teardown pattern (free the compound, `evpl_close` the bind), with no reply.
- `chimera_smb_server_accept`: conns are pooled and reused, so clear `conn->dialect` and `conn->flags` on accept. This prevents a dialect inherited from a previously torn-down connection from tripping the new guard on a genuine first negotiate.

## Tests enabled

- `DurableHandleV1_Reconnect_AfterServerDisconnect` added to the WPTS persistent allowlist (verified green via ctest).

## Not enabled (infeasible in this harness)

- `DurableHandleV1_Reconnect_WithDifferentDurableOwner` (MS-SMB2 3.3.5.9.7) and `DurableHandleV2_Reconnect_WithDifferentDurableOwner` (MS-SMB2 3.3.5.9.12) require a second non-admin user account (`NonAdminUserName`) that the WPTS ptfconfig harness does not provision. Both return `Assert.Inconclusive` / NotExecuted regardless of server behavior, so no server change can make them run here. The stale "Left out" allowlist comment is updated accordingly.

## Regression check

- Full WPTS `DurableHandle|PersistentHandle` persistent suite: all allowlisted cases pass; remaining failures are the pre-existing `Replay_*_IoCtl_*` / `Replay_*_Lock_*` cases (not allowlisted) and the NonAdminUserName/SharePath Inconclusive cases.
- Samba smbtorture `smb2.durable-open` and `smb2.durable-v2-open` on memfs: no change vs baseline (the pre-existing `alloc-size` and lease-arbitration/keep-purge-cluster failures are unrelated to the negotiate path).