### PR TITLE
smb2: advertise IPv6 network interfaces in FSCTL_QUERY_NETWORK_INTERFACE_INFO

### DIFF
--- a/scripts/wpts_smb_test_wrapper.sh
+++ b/scripts/wpts_smb_test_wrapper.sh
@@ -44,6 +44,11 @@ SUT_IP="10.0.0.1"
 # alternative channel against it (and the main channel queries it back via
 # FSCTL_QUERY_NETWORK_INTERFACE_INFO).
 SUT_IP2="10.0.0.2"
+# IPv6 SUT address for SMB3 multichannel. Only wired up when
+# CHIMERA_SMB_MULTICHANNEL=1; the NetworkInterfaceInfo_Query_ReturnsIPv4IPv6
+# case requires the server to advertise both an IPv4 and an IPv6 interface over
+# FSCTL_QUERY_NETWORK_INTERFACE_INFO. ULA address (RFC 4193).
+SUT_IPV6="fd00::1"
 NETNS_NAME="wpts_smb_$$_$(date +%s%N)"
 DUMMY_IF="wpts0"
 BUILD_DIR=$(dirname "$(dirname "$CHIMERA_BINARY")")
@@ -134,7 +139,7 @@ generate_config() {
     # MultipleChannel cases can discover the alternative server address.
     local multichannel_line=""
     if [ "${CHIMERA_SMB_MULTICHANNEL:-0}" = "1" ]; then
-        multichannel_line="\"smb_multichannel\": [{\"address\": \"${SUT_IP}\", \"speed\": 10, \"rdma\": false}, {\"address\": \"${SUT_IP2}\", \"speed\": 10, \"rdma\": false}],"
+        multichannel_line="\"smb_multichannel\": [{\"address\": \"${SUT_IP}\", \"speed\": 10, \"rdma\": false}, {\"address\": \"${SUT_IP2}\", \"speed\": 10, \"rdma\": false}, {\"address\": \"${SUT_IPV6}\", \"speed\": 10, \"rdma\": false}],"
         # The MultipleChannel_Negative_SMB2002 case establishes its main channel
         # with the original SMB 2.0.2 dialect (then verifies the bind is refused),
         # so the multichannel harness lowers the dialect floor to 2.0.2.
@@ -194,6 +199,9 @@ ip netns exec "${NETNS_NAME}" ip addr add "${SUT_IP}/24" dev "${DUMMY_IF}"
 # within the netns, so a single device carrying both addresses is sufficient).
 if [ "${CHIMERA_SMB_MULTICHANNEL:-0}" = "1" ]; then
     ip netns exec "${NETNS_NAME}" ip addr add "${SUT_IP2}/24" dev "${DUMMY_IF}"
+    # IPv6 address so the daemon can advertise an AF_INET6 interface over
+    # FSCTL_QUERY_NETWORK_INTERFACE_INFO (NetworkInterfaceInfo_Query_ReturnsIPv4IPv6).
+    ip netns exec "${NETNS_NAME}" ip -6 addr add "${SUT_IPV6}/64" dev "${DUMMY_IF}"
 fi
 ip netns exec "${NETNS_NAME}" ip link set "${DUMMY_IF}" up
 

--- a/src/server/smb/smb_proc_ioctl.c
+++ b/src/server/smb/smb_proc_ioctl.c
@@ -335,18 +335,22 @@ chimera_smb_ioctl_reply(
                 evpl_iovec_cursor_append_uint32(reply_cursor, caps); /* capabilities (RSS) */
                 evpl_iovec_cursor_append_uint32(reply_cursor, 0); /* reserved */
                 evpl_iovec_cursor_append_uint64(reply_cursor, nic_info->speed); /* speed */
+                /* SOCKADDR_STORAGE.ss_family is the Windows AF_* value on the
+                 * wire (MS-DTYP / MS-SMB2 3.2.4.20.10): 2 == AF_INET,
+                 * 23 (0x17) == AF_INET6.  Linux's AF_INET6 (10) differs, so map
+                 * it explicitly. */
                 evpl_iovec_cursor_append_uint16(reply_cursor, nic_info->addr.ss_family == AF_INET ? 2 :
-                                                10);                                                                    /* AF_INET */
+                                                23);                                                                    /* Windows AF_INET / AF_INET6 */
                 evpl_iovec_cursor_append_uint16(reply_cursor, 0); /* port */
                 if (nic_info->addr.ss_family == AF_INET) {
                     evpl_iovec_cursor_append_blob(reply_cursor,
                                                   &((struct sockaddr_in *) &nic_info->addr)->sin_addr.s_addr,
-                                                  4);                                                                   /* address: 10.67.25.209 */
+                                                  4);                                                                   /* IPv4 address */
                 } else {
                     evpl_iovec_cursor_append_blob(reply_cursor,
                                                   &((struct sockaddr_in6 *) &nic_info->addr)->sin6_addr.
                                                   s6_addr,
-                                                  16);                                                                  /* address: 10.67.25.209 */
+                                                  16);                                                                  /* IPv6 address */
                 }
                 evpl_iovec_cursor_zero(reply_cursor, 120); /* ifname length */
             }

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -344,6 +344,7 @@ if(CHIMERA_NETNS_TESTING AND WPTS_DOTNET AND WPTS_SMB2_DLL AND WPTS_ARCH_SUPPORT
         MultipleChannel_SecondChannelSessionSetupFailAtFirstTime
         NetworkInterfaceInfo_ChangeConnection_BindCurrentSession
         NetworkInterfaceInfo_Query_ReturnsErrorStatus
+        NetworkInterfaceInfo_Query_ReturnsIPv4IPv6
         )
 
     foreach(tc ${WPTS_SMB2_MULTICHANNEL_ALLOWLIST})


### PR DESCRIPTION
## Summary

The SMB2 `FSCTL_QUERY_NETWORK_INTERFACE_INFO` handler built each `NETWORK_INTERFACE_INFO` record's `SOCKADDR_STORAGE` using the Linux `AF_INET6` constant (10) as the `Family` for IPv6 NICs. On the wire, MS-DTYP / MS-SMB2 use the Windows `AF_*` numbering (`2` == `AF_INET`, `23` (`0x17`) == `AF_INET6`), so an SMB client cannot decode an advertised IPv6 address. (IPv4 was already correct at `2`.)

### Daemon
- `smb_proc_ioctl.c`: emit Windows `AF_INET6` (`23`) instead of the Linux value (`10`) for IPv6 interfaces in the network-interface-info reply. IPv4 continues to emit `2`. The config parsing and 4-vs-16-byte address encoding already supported IPv6.

### Test harness
- `scripts/wpts_smb_test_wrapper.sh`: when `CHIMERA_SMB_MULTICHANNEL=1`, add a ULA IPv6 address (`fd00::1/64`) to the netns dummy interface and to the `smb_multichannel` config so the daemon advertises both an IPv4 and an IPv6 interface. All IPv6 additions are gated on the multichannel flag, so other modes are unaffected.

### WPTS case enabled
- `NetworkInterfaceInfo_Query_ReturnsIPv4IPv6` added to the `WPTS_SMB2_MULTICHANNEL_ALLOWLIST`. The case requires the server to advertise both an `AF_INET` (2) and an `AF_INET6` (23) interface; it now passes (verified via ctest). The combined MultipleChannel + NetworkInterface run shows no regressions among previously-passing cases (the lone `MultipleChannel_FileLease` failure is pre-existing and out of scope).