### PR TITLE
smb2: correct SMB 3.1.1 NEGOTIATE context handling

### DIFF
--- a/scripts/wpts_smb_test_wrapper.sh
+++ b/scripts/wpts_smb_test_wrapper.sh
@@ -272,15 +272,19 @@ if [ "${CHIMERA_SMB_MULTICHANNEL:-0}" = "1" ]; then
 fi
 
 # When encryption is enabled, advertise it to the driver so the Encryption cases
-# become applicable: declare support, the cipher list chimera offers, the
-# per-share encrypted share, and that global encrypt-data is on.
+# become applicable: declare support, the per-share encrypted share, and that
+# global encrypt-data is on. SutSupportedEncryptionAlgorithms is set
+# unconditionally in the fixture: even in baseline mode the SMB 3.1.1 NEGOTIATE
+# selects and echoes a CipherId from the client's offered list (transport
+# encryption is decided separately at SESSION_SETUP), so the driver must always
+# know the cipher set to validate the echoed Connection.CipherId
+# (BVT_Negotiate_SMB311).
 if [ "${CHIMERA_SMB_ENCRYPTION:-0}" = "1" ]; then
     staged="${WPTS_BIN_DIR}/CommonTestSuite.deployment.ptfconfig"
     sed -i \
         -e 's#<Property name="IsEncryptionSupported" value="false"/>#<Property name="IsEncryptionSupported" value="true"/>#' \
         -e 's#<Property name="IsGlobalEncryptDataEnabled" value="false"/>#<Property name="IsGlobalEncryptDataEnabled" value="true"/>#' \
         -e 's#<Property name="EncryptedFileShare" value=""/>#<Property name="EncryptedFileShare" value="SMBEncrypted"/>#' \
-        -e 's#<Property name="SutSupportedEncryptionAlgorithms" value=""/>#<Property name="SutSupportedEncryptionAlgorithms" value="ENCRYPTION_AES128_CCM;ENCRYPTION_AES128_GCM;ENCRYPTION_AES256_CCM;ENCRYPTION_AES256_GCM"/>#' \
         "$staged"
 fi
 

--- a/src/server/smb/smb2.h
+++ b/src/server/smb/smb2.h
@@ -543,6 +543,12 @@
 #define SMB2_STATUS_SERVER_UNAVAILABLE                0xC0000466
 #define SMB2_STATUS_FILE_NOT_AVAILABLE                0xC0000467
 
+/* STATUS_SMB_NO_PREAUTH_INTEGRITY_HASH_OVERLAP (MS-SMB2 §3.3.5.4): returned
+ * from a SMB 3.1.1 NEGOTIATE when the client's
+ * SMB2_PREAUTH_INTEGRITY_CAPABILITIES HashAlgorithms array contains no hash
+ * algorithm the server supports. */
+#define SMB2_STATUS_SMB_NO_PREAUTH_INTEGRITY_OVERLAP  0xC05D0000
+
 /* Warning codes */
 #define SMB2_STATUS_BUFFER_OVERFLOW                   0x80000005
 #define SMB2_STATUS_STOPPED_ON_SYMLINK                0x8000002D

--- a/src/server/smb/smb_proc_negotiate.c
+++ b/src/server/smb/smb_proc_negotiate.c
@@ -141,13 +141,18 @@ chimera_smb_negotiate(struct chimera_smb_request *request)
     conn->dialect = dialect;
 
     /* SMB 3.1.1 mandates a PreauthIntegrityCapabilities context offering a
-     * hash algorithm we support (SHA-512). Per MS-SMB2 3.3.5.4, a 3.1.1
-     * NEGOTIATE without it (or offering no supported hash) fails with
-     * STATUS_INVALID_PARAMETER. */
+     * hash algorithm we support (SHA-512). Per MS-SMB2 §3.3.5.4:
+     *   - if no PreauthIntegrity context is present at all, fail with
+     *     STATUS_INVALID_PARAMETER;
+     *   - if the context is present but its HashAlgorithms array contains no
+     *     algorithm we support, fail with
+     *     STATUS_SMB_NO_PREAUTH_INTEGRITY_HASH_OVERLAP (0xC05D0000). */
     if (dialect == SMB2_DIALECT_3_1_1) {
+        int have_preauth_ctx =
+            (request->negotiate.ctx_present_mask & CHIMERA_SMB_NEGOTIATE_CTX_PREAUTH) != 0;
         int have_sha512 = 0;
 
-        if (request->negotiate.ctx_present_mask & CHIMERA_SMB_NEGOTIATE_CTX_PREAUTH) {
+        if (have_preauth_ctx) {
             for (i = 0; i < request->negotiate.preauth_in.hash_alg_count; i++) {
                 if (request->negotiate.preauth_in.hash_algs[i] == SMB2_PREAUTH_HASH_SHA_512) {
                     have_sha512 = 1;
@@ -157,7 +162,11 @@ chimera_smb_negotiate(struct chimera_smb_request *request)
         }
 
         if (!have_sha512) {
-            chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
+            chimera_smb_complete_request(
+                request,
+                have_preauth_ctx ?
+                SMB2_STATUS_SMB_NO_PREAUTH_INTEGRITY_OVERLAP :
+                SMB2_STATUS_INVALID_PARAMETER);
             return;
         }
     }
@@ -553,8 +562,12 @@ parse_neg_ctx_compression(
     uint16_t count, i;
 
     /* MS-SMB2 §3.3.5.4: fail NEGOTIATE if DataLength is below the fixed
-     * SMB2_COMPRESSION_CAPABILITIES size (8 bytes) or CompressionAlgorithmCount
-     * is zero.  These are reported as fatal by the dispatcher. */
+     * SMB2_COMPRESSION_CAPABILITIES size (8 bytes).  A
+     * CompressionAlgorithmCount of zero is tolerated (treated as "no
+     * compression offered") — Windows accepts it and returns success, and the
+     * WPTS Negotiate_SMB311_WithAllContexts case (which sends an empty
+     * compression context when the client lists no compression algorithms)
+     * asserts STATUS_SUCCESS. */
     if (data_len < 8) {
         return -1;
     }
@@ -562,8 +575,12 @@ parse_neg_ctx_compression(
     /* data + 2: 2-byte padding (ignored) */
     request->negotiate.compression_in.flags = smb_wire_le32(data + 4);
 
-    if (count == 0 ||
-        count > sizeof(request->negotiate.compression_in.algs) / sizeof(uint16_t)) {
+    if (count == 0) {
+        request->negotiate.compression_in.alg_count = 0;
+        return 0;
+    }
+
+    if (count > sizeof(request->negotiate.compression_in.algs) / sizeof(uint16_t)) {
         return -1;
     }
     if ((uint32_t) 8 + (uint32_t) count * 2u > data_len) {

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -121,6 +121,7 @@ if(CHIMERA_NETNS_TESTING AND WPTS_DOTNET AND WPTS_SMB2_DLL AND WPTS_ARCH_SUPPORT
         BVT_Negotiate_SMB21
         BVT_Negotiate_SMB30
         BVT_Negotiate_SMB302
+        BVT_Negotiate_SMB311
         BVT_Negotiate_SMB311_Preauthentication
         BVT_Negotiate_SigningEnabled
         BVT_OpLockBreak
@@ -164,8 +165,10 @@ if(CHIMERA_NETNS_TESTING AND WPTS_DOTNET AND WPTS_SMB2_DLL AND WPTS_ARCH_SUPPORT
         InvalidCreateRequestStructureSize
         Negotiate_SMB311_ContextID_NetName
         Negotiate_SMB311_InvalidCipher
+        Negotiate_SMB311_InvalidHashAlgorithm
         Negotiate_SMB311_IsTransportCapabilitiesSupported
         Negotiate_SMB311_SigningCapability
+        Negotiate_SMB311_WithAllContexts
         Negotiate_SMB311_WithCompressionContextWithoutIntegrityContext
         Negotiate_SMB311_WithEncryptionAndCompressionContextsWithoutIntegrityContext
         Negotiate_SMB311_WithEncryptionContextWithoutIntegrityContext

--- a/src/server/smb/tests/wpts/CommonTestSuite.deployment.ptfconfig
+++ b/src/server/smb/tests/wpts/CommonTestSuite.deployment.ptfconfig
@@ -80,7 +80,7 @@
       <Property name="IsRDMATransformSupported" value="false"/>
       <Property name="IsChainedCompressionSupported" value="false"/>
       <Property name="IsMultiCreditSupported" value="true"/>
-      <Property name="SutSupportedEncryptionAlgorithms" value=""/>
+      <Property name="SutSupportedEncryptionAlgorithms" value="ENCRYPTION_AES128_CCM;ENCRYPTION_AES128_GCM;ENCRYPTION_AES256_CCM;ENCRYPTION_AES256_GCM"/>
       <Property name="SupportedCompressionAlgorithms" value=""/>
 
       <Property name="UnsupportedIoCtlCodes" value="FSCTL_OFFLOAD_READ;FSCTL_OFFLOAD_WRITE;FSCTL_FILE_LEVEL_TRIM"/>


### PR DESCRIPTION
Fixes three MS-SMB2 §3.3.5.4 NEGOTIATE-context edge cases surfaced by the WPTS conformance suite (baseline mode, memfs backend) and enables the three corresponding cases in the WPTS allowlist.

## Fixes

1. **Preauth-integrity hash overlap** (`Negotiate_SMB311_InvalidHashAlgorithm`): when a 3.1.1 NEGOTIATE carries an `SMB2_PREAUTH_INTEGRITY_CAPABILITIES` context whose `HashAlgorithms` array offers no algorithm the server supports, the server now fails with `STATUS_SMB_NO_PREAUTH_INTEGRITY_HASH_OVERLAP` (0xC05D0000) instead of `STATUS_INVALID_PARAMETER`. A completely absent preauth context still yields `STATUS_INVALID_PARAMETER`. New status constant added to `smb2.h`.

2. **Empty compression context** (`Negotiate_SMB311_WithAllContexts`): an `SMB2_COMPRESSION_CAPABILITIES` context with `CompressionAlgorithmCount == 0` is now tolerated (treated as "no compression offered") instead of being rejected as a fatal `STATUS_INVALID_PARAMETER`. Windows accepts it and the WPTS all-contexts case asserts `STATUS_SUCCESS`; the WPTS client emits an empty compression context whenever the client lists no compression algorithms.

3. **CipherId echo validation** (`BVT_Negotiate_SMB311`): the server already selects and echoes a `CipherId` from the client's `SMB2_ENCRYPTION_CAPABILITIES` context independent of whether transport encryption is enabled (cipher selection happens at NEGOTIATE; whether traffic is actually encrypted is decided at SESSION_SETUP). The WPTS driver, however, only learned the SUT cipher set in encryption mode, so in baseline mode it could not validate the echoed `Connection.CipherId`. `SutSupportedEncryptionAlgorithms` is now populated unconditionally in the pinned ptfconfig fixture (and the now-redundant encryption-mode `sed` dropped from the wrapper). No server behavior change for this one — it is a test-config fix.

## Validation

- All three target WPTS cases pass via the real ctest path (`wpts/memfs/...`).
- Full enabled Negotiate WPTS set: 27/27 pass, no regressions; the broader Negotiate filter run went from 24→31 passing (the four encryption-BVT cipher-echo cases also benefit from the unconditional cipher-list config).
- Regression guard: Samba smbtorture session + validate-negotiate + connect suites (memfs) all green (47/47 and 7/7), since these are only exercised in devcontainer CI.
- `uncrustify --check` clean, `reuse lint` compliant, Release + Debug builds clean.