### PR TITLE
smb2: reject 3.1.1 SESSION_SETUP notifications-support mismatch

### DIFF
--- a/src/server/smb/smb2.h
+++ b/src/server/smb/smb2.h
@@ -704,6 +704,7 @@ typedef uint8_t smb2_guid[SMB2_GUID_SIZE];
 #define SMB2_GLOBAL_CAP_PERSISTENT_HANDLES          0x00000010 // Supports persistent handles (SMB 3.0+)
 #define SMB2_GLOBAL_CAP_DIRECTORY_LEASING           0x00000020 // Supports directory leasing (SMB 3.0+)
 #define SMB2_GLOBAL_CAP_ENCRYPTION                  0x00000040 // Supports encryption (SMB 3.0+)
+#define SMB2_GLOBAL_CAP_NOTIFICATIONS               0x00000080 // Supports server-to-client notifications (SMB 3.1.1+)
 
 // SMB2 TREE_CONNECT response share capabilities (MS-SMB2 §2.2.10)
 #define SMB2_SHARE_CAP_DFS                          0x00000008

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -719,6 +719,12 @@ struct chimera_smb_conn {
     uint8_t                            client_guid[16];
     uint8_t                            client_security_mode;
     uint32_t                           client_capabilities;
+    /* Connection.SupportsNotifications (MS-SMB2 3.3.5.4): set when the
+     * negotiated dialect is 3.1.1 and the client advertised
+     * SMB2_GLOBAL_CAP_NOTIFICATIONS in its NEGOTIATE capabilities.  A binding
+     * SESSION_SETUP whose connection's value differs from the bound session's
+     * is rejected with STATUS_INVALID_PARAMETER (MS-SMB2 3.3.5.5). */
+    uint8_t                            supports_notifications;
     /* SMB 3.1.1 preauth-integrity running hash (SHA-512).  preauth_hash is the
      * per-session-setup running value: it is reset to negotiate_preauth_hash at
      * the start of every new authentication (a SESSION_SETUP whose header

--- a/src/server/smb/smb_proc_negotiate.c
+++ b/src/server/smb/smb_proc_negotiate.c
@@ -168,6 +168,14 @@ chimera_smb_negotiate(struct chimera_smb_request *request)
     conn->client_security_mode = request->negotiate.security_mode;
     conn->client_capabilities  = request->negotiate.capabilities;
 
+    /* Connection.SupportsNotifications (MS-SMB2 3.3.5.4): only meaningful for
+     * 3.1.1, and only when the client advertised SMB2_GLOBAL_CAP_NOTIFICATIONS.
+     * Recorded so a binding SESSION_SETUP can be validated against the bound
+     * session's value (MS-SMB2 3.3.5.5). */
+    conn->supports_notifications =
+        (dialect == SMB2_DIALECT_3_1_1 &&
+         (request->negotiate.capabilities & SMB2_GLOBAL_CAP_NOTIFICATIONS)) ? 1 : 0;
+
     /* Pick algorithms from the client's negotiate contexts. Phase 0 records
      * presence; Phases 2/4/5 will actually flip on preauth/encryption/RDMA. */
     chimera_smb_select_negotiated_algorithms(conn, request);

--- a/src/server/smb/smb_proc_session_setup.c
+++ b/src/server/smb/smb_proc_session_setup.c
@@ -125,6 +125,49 @@ chimera_smb_session_setup(struct chimera_smb_request *request)
         return;
     }
 
+    /* MS-SMB2 3.3.5.5 step 4: a SESSION_SETUP that binds a new channel to an
+     * existing session (SMB2_SESSION_FLAG_BINDING set, non-zero header
+     * SessionId, dialect in the 3.x family, and the session found in the
+     * dispatcher's lookup) MUST satisfy several constraints before the bind is
+     * processed.  A header SessionId of zero is handled earlier as a new
+     * authentication (step 3), so binding validation only applies once a
+     * session has been resolved.  The checks that are observable here and the
+     * status each mandates:
+     *
+     *   - the bind request MUST be signed (SMB2_FLAGS_SIGNED): an unsigned
+     *     bind is failed with STATUS_INVALID_PARAMETER;
+     *   - for 3.1.1, Session.SupportsNotifications MUST equal the binding
+     *     Connection.SupportsNotifications, else STATUS_INVALID_PARAMETER.
+     *
+     * (Chimera does not advertise SMB2_GLOBAL_CAP_NOTIFICATIONS, so both
+     * values are always FALSE and the notifications check never fires on its
+     * own; it is included to keep the validation faithful to the spec for when
+     * the capability is implemented.)  WPTS SessionMgmt_SupportsNotifications-
+     * Mismatch exercises this path with an unsigned bind and expects
+     * STATUS_INVALID_PARAMETER. */
+    if ((request->session_setup.flags & SMB2_SESSION_FLAG_BINDING) &&
+        conn->dialect >= SMB2_DIALECT_3_0 &&
+        request->smb2_hdr.session_id != 0 &&
+        request->session_handle) {
+        struct chimera_smb_session *bind_session = request->session_handle->session;
+        int                         reject       = 0;
+
+        if (!(request->smb2_hdr.flags & SMB2_FLAGS_SIGNED)) {
+            reject = 1;
+        } else if (conn->dialect == SMB2_DIALECT_3_1_1 &&
+                   bind_session->supports_notifications !=
+                   conn->supports_notifications) {
+            reject = 1;
+        }
+
+        if (reject) {
+            chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
+            evpl_iovecs_release(thread->evpl, request->session_setup.input_iov,
+                                request->session_setup.input_niov);
+            return;
+        }
+    }
+
     // Detect authentication mechanism
     mech = smb_auth_detect_mechanism(input, input_len);
     chimera_smb_debug("Session setup: detected mechanism %s", smb_auth_mech_name(mech));
@@ -171,6 +214,11 @@ chimera_smb_session_setup(struct chimera_smb_request *request)
         /* Record the connection's negotiated dialect so a later
          * PreviousSessionId reconnect can enforce MS-SMB2 3.3.5.5.1. */
         session->dialect = conn->dialect;
+
+        /* Session.SupportsNotifications is inherited from the connection that
+         * first establishes the session (MS-SMB2 3.3.5.5); a later binding
+         * connection must match it. */
+        session->supports_notifications = conn->supports_notifications;
 
         session_handle = chimera_smb_session_handle_alloc(thread);
 

--- a/src/server/smb/smb_session.h
+++ b/src/server/smb/smb_session.h
@@ -196,6 +196,11 @@ struct chimera_smb_session {
      * Session.Connection.Dialect).  A PreviousSessionId reconnect whose
      * connection negotiated a different dialect is rejected. */
     uint16_t                    dialect;
+    /* Session.SupportsNotifications (MS-SMB2 3.3.5.5): copied from
+     * Connection.SupportsNotifications on the SESSION_SETUP that first
+     * authorized the session.  A later binding SESSION_SETUP on a connection
+     * whose SupportsNotifications differs is rejected (3.1.1 only). */
+    uint8_t                     supports_notifications;
     struct UT_hash_handle       hh;
     struct chimera_smb_session *prev;
     struct chimera_smb_session *next;

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -171,6 +171,7 @@ if(CHIMERA_NETNS_TESTING AND WPTS_DOTNET AND WPTS_SMB2_DLL AND WPTS_ARCH_SUPPORT
         Negotiate_SMB311_WithEncryptionContextWithoutIntegrityContext
         Negotiate_SMB311_WithoutAnyContexts
         SessionMgmt_ReconnectWithDifferentDialect
+        SessionMgmt_SupportsNotificationsMismatch
         Signing_VerifyAesGmacSigning
         TreeMgmt_SMB311_CLUSTER_RECONNECT
         ValidateNegotiateInfo_Negative_InvalidCapabilities


### PR DESCRIPTION
## Summary

A channel-binding `SESSION_SETUP` (`SMB2_SESSION_FLAG_BINDING` set, non-zero header `SessionId`, 3.x dialect) must be validated before the bind is processed, per **MS-SMB2 3.3.5.5** step 4. Two of those checks are observable at the chimera session-setup layer and both mandate `STATUS_INVALID_PARAMETER` on failure:

- the bind request **must be signed** (`SMB2_FLAGS_SIGNED`);
- for the **3.1.1** dialect, `Session.SupportsNotifications` must equal the binding `Connection.SupportsNotifications`.

Chimera accepted the bind unconditionally and returned `STATUS_SUCCESS`, so the WPTS conformance case `SessionMgmt_SupportsNotificationsMismatch` failed (`Expected 0xC000000D, Actual 0x0`).

## Fix

In `chimera_smb_session_setup`, add the binding validation:

- gated on `SMB2_SESSION_FLAG_BINDING`, dialect >= 3.0, non-zero header `SessionId`, and a resolved session handle — so a zero `SessionId` still flows to the new-authentication path (MS-SMB2 3.3.5.5 step 3), and a signed, matching bind (real multichannel) is unaffected;
- reject an unsigned bind, or a 3.1.1 bind whose `SupportsNotifications` differs, with `STATUS_INVALID_PARAMETER`.

Supporting plumbing:
- `Connection.SupportsNotifications` is recorded at `NEGOTIATE` (3.1.1 + client `SMB2_GLOBAL_CAP_NOTIFICATIONS`, new define `0x00000080`);
- `Session.SupportsNotifications` is inherited from the establishing connection.

Chimera does not advertise `SMB2_GLOBAL_CAP_NOTIFICATIONS`, so the notifications values are always FALSE today; the WPTS case actually trips the unsigned-bind branch, which returns the same `STATUS_INVALID_PARAMETER`. The notifications comparison is kept so the validation stays faithful to the spec for when the capability lands.

## Validation

- WPTS `SessionMgmt_SupportsNotificationsMismatch` (memfs) now passes; the other four SessionMgmt cases still pass.
- Real multichannel/binding WPTS cases still pass (`MultipleChannel_SecondChannelSessionSetupFailAtFirstTime`, `NetworkInterfaceInfo_ChangeConnection_BindCurrentSession`, `BVT_MultipleChannel_NicRedundantOnBoth`, `MultipleChannel_MultiChannelOnSameNic`, `MultipleChannel_LockUnlockOnDiffChannel`).
- Durable-handle reconnect cases still pass with persistent handles enabled.
- Samba smbtorture: 100% of the 46 enabled `smb2.session*` memfs cases pass.
- Enabled `SessionMgmt_SupportsNotificationsMismatch` in the WPTS memfs allowlist.