### PR TITLE
nfs/pnfs: flex-files pNFS client (DS I/O, CB_LAYOUTRECALL, RDMA DS) + cooperative session slots

### DIFF
--- a/kvm/kvm_pnfs_proxy_test_wrapper.sh
+++ b/kvm/kvm_pnfs_proxy_test_wrapper.sh
@@ -161,7 +161,7 @@ generate_mds_config() {
         "pnfs": {
             "enabled": true,
             "data_servers": [
-                { "netid": "tcp", "uaddr": "${BE_IP}:${DS_PORT}", "version": "3", "backing_path": "/ds0" }
+                { "tcp": "${BE_IP}:${DS_PORT}", "rdma": "${BE_IP}:20050", "version": "3", "backing_path": "/ds0" }
             ]
         }
     },
@@ -312,6 +312,16 @@ if ! grep -qE "Connected.* to ${BE_IP}:${DS_PORT}" "$PROXY_LOG"; then
     exit 1
 fi
 echo "=== verified: proxy drove direct data-server I/O via a flex-files layout ==="
+
+# The DS device advertises BOTH an rdma and a tcp netaddr (see the MDS config).
+# The proxy mounts the MDS over TCP, so it must select the tcp netaddr for the
+# DS (had it wrongly picked rdma it would have tried RDMA to a non-RDMA port).
+if ! grep -q "GETDEVICEINFO ok: netid=tcp" "$PROXY_LOG"; then
+    echo "=== wrong DS transport selected from a multi-netaddr device ===" >&2
+    grep -iE "getdeviceinfo|registered DS" "$PROXY_LOG" | tail -10 >&2
+    exit 1
+fi
+echo "=== verified: proxy selected the tcp netaddr from an rdma+tcp device ==="
 
 # For recall workloads, assert the proxy actually received + handled the recall.
 if echo "$TEST_CMD_ARG" | grep -q "RECALL_EXPECTED"; then

--- a/kvm/kvm_pnfs_proxy_test_wrapper.sh
+++ b/kvm/kvm_pnfs_proxy_test_wrapper.sh
@@ -1,0 +1,326 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+#
+# SPDX-License-Identifier: Unlicense
+
+# Usage: kvm_pnfs_proxy_test_wrapper.sh <vmlinuz> <rootfs.qcow2> <chimera_binary> <backend> <test_cmd>
+#
+# Exercises chimera's *own* NFSv4.1 pNFS CLIENT (the nfs VFS proxy module)
+# against chimera's pNFS server.  Three chimera daemons plus a guest VM:
+#
+#   1. A *data server* (plain memfs, data_server mode) in the backend netns.
+#   2. A pNFS *metadata server* (the requested backend) in the backend netns,
+#      which nfs-mounts the data server and steers file data to it.
+#   3. A *proxy* in the frontend netns: a full NFS server whose backing store is
+#      the nfs VFS module mounting the MDS with pNFS enabled (options=...,pnfs).
+#      So the proxy IS a pNFS client -- it fetches layouts from the MDS, drives
+#      READ/WRITE straight to the data server, and (this is the point) receives
+#      the MDS's CB_LAYOUTRECALL over the back channel it established.
+#   4. A guest VM mounts the proxy over plain NFSv4.1 and runs the workload.
+#
+# The proxy must be a *full* server (it advertises USE_NON_PNFS in EXCHANGE_ID,
+# so a regular client can mount it); a data_server advertises USE_PNFS_DS and the
+# Linux client rejects it.  A full proxy binds the fixed NFS/SMB/S3 ports, so it
+# cannot share a netns with the MDS -- hence two netns joined by a veth: the MDS
+# and DS in `be` (10.0.1.0/24), the proxy and the VM's TAP in `fe`.  The proxy
+# reaches the MDS/DS over the veth; the VM reaches the proxy over the TAP.
+#
+# pNFS engaged iff the proxy opened a direct connection to the data server (it
+# only does so to service a layout); the wrapper asserts that from the DS log.
+# A recall workload (truncate -> MDS SETATTR -> CB_LAYOUTRECALL to the proxy) is
+# asserted from the proxy log.
+
+set -u
+
+ARCH=$(uname -m)
+if [ "$ARCH" = "aarch64" ]; then
+    QEMU_BIN="qemu-system-aarch64"
+    QEMU_MACHINE="-machine virt"
+    QEMU_CONSOLE="ttyAMA0"
+else
+    QEMU_BIN="qemu-system-x86_64"
+    QEMU_MACHINE="-machine q35,usb=off"
+    QEMU_CONSOLE="ttyS0"
+fi
+
+VMLINUZ=$1; shift
+ROOTFS=$1; shift
+CHIMERA_BINARY=$1; shift
+BACKEND=$1; shift
+TEST_CMD_ARG="$*"
+
+INITRD="$(dirname "$VMLINUZ")/initrd"
+if [ -f "$INITRD" ]; then
+    QEMU_INITRD="-initrd $INITRD"
+else
+    QEMU_INITRD=""
+fi
+
+BE_NS="kvm_pnfsproxy_be_$$_$(date +%s%N)"
+FE_NS="kvm_pnfsproxy_fe_$$_$(date +%s%N)"
+TAP_NAME="tap_$$"
+VETH_BE="vbe_$$"
+VETH_FE="vfe_$$"
+LOG_FILE=$(mktemp /tmp/kvm_pnfs_proxy_test_XXXXXX.log)
+BUILD_DIR=$(dirname "$(dirname "$CHIMERA_BINARY")")
+SESSION_DIR=$(mktemp -d "${BUILD_DIR}/kvm_pnfs_proxy_session_XXXXXX")
+DS_CONFIG="${SESSION_DIR}/ds.json"
+MDS_CONFIG="${SESSION_DIR}/mds.json"
+PROXY_CONFIG="${SESSION_DIR}/proxy.json"
+DS_LOG="${SESSION_DIR}/ds.log"
+MDS_LOG="${SESSION_DIR}/mds.log"
+PROXY_LOG="${SESSION_DIR}/proxy.log"
+DS_PID=""
+MDS_PID=""
+PROXY_PID=""
+
+# Backend netns addresses (MDS + DS), reached by the proxy over the veth.
+BE_IP="10.0.1.1"
+MDS_PORT=2049
+DS_PORT=2050
+# Frontend netns: the proxy serves the VM here; TAP host side is PROXY_IP.
+PROXY_IP="10.0.0.1"
+PROXY_PORT=2049
+
+cleanup() {
+    for pid in "$PROXY_PID" "$MDS_PID" "$DS_PID"; do
+        if [ -n "$pid" ]; then
+            kill "$pid" 2>/dev/null || true
+            for i in $(seq 1 30); do
+                kill -0 "$pid" 2>/dev/null || break
+                sleep 0.1
+            done
+            kill -9 "$pid" 2>/dev/null || true
+            wait "$pid" 2>/dev/null || true
+        fi
+    done
+    if [ -f "$LOG_FILE" ]; then
+        echo "=== Guest serial log ==="
+        cat "$LOG_FILE"
+    fi
+    for lbl in "Data server:$DS_LOG" "Metadata server:$MDS_LOG" "Proxy:$PROXY_LOG"; do
+        f="${lbl#*:}"
+        [ -f "$f" ] && { echo "=== ${lbl%%:*} log (tail) ==="; tail -25 "$f"; }
+    done
+    ip netns delete "${FE_NS}" 2>/dev/null || true
+    ip netns delete "${BE_NS}" 2>/dev/null || true
+    ip link delete "${VETH_BE}" 2>/dev/null || true
+    rm -f "$LOG_FILE"
+    rm -rf "$SESSION_DIR"
+}
+trap cleanup EXIT
+
+# Data server: plain memfs, data_server mode (NFS-only, stateless by handle).
+generate_ds_config() {
+    cat > "$DS_CONFIG" << EOF
+{
+    "server": {
+        "threads": 2,
+        "nfs_port": ${DS_PORT},
+        "data_server": true,
+        "external_portmap": true,
+        "nfs_server_scope": 43,
+        "metrics_port": 9001
+    },
+    "mounts": { "ds_data": { "module": "memfs", "path": "/" } },
+    "exports": { "/ds_export": { "path": "/ds_data" } }
+}
+EOF
+}
+
+# Metadata server: the namespace on the requested backend, nfs-mounts the DS at
+# /ds0 (control path), and steers file data to it via server.pnfs (v3 data path).
+generate_mds_config() {
+    local module="$BACKEND"
+    local vfs_section=""
+
+    case "$BACKEND" in
+        memfs) ;;
+        diskfs_io_uring | diskfs_aio)
+            local device_type="io_uring"
+            [ "$BACKEND" = "diskfs_aio" ] && device_type="libaio"
+            local devices_json=""
+            for i in 0 1; do
+                local device_path="${SESSION_DIR}/mds-device-${i}.img"
+                truncate -s 16G "$device_path"
+                [ "$i" -gt 0 ] && devices_json="${devices_json},"
+                devices_json="${devices_json}{\"type\":\"${device_type}\",\"size\":1,\"path\":\"${device_path}\"}"
+            done
+            module="diskfs"
+            vfs_section="\"vfs\": { \"diskfs\": { \"config\": { \"initialize\": true, \"unsafe_async\": true, \"devices\": [${devices_json}] } } },"
+            ;;
+        *) echo "pNFS proxy test supports memfs/diskfs backends, got ${BACKEND}" >&2; exit 1 ;;
+    esac
+
+    cat > "$MDS_CONFIG" << EOF
+{
+    "server": {
+        "threads": 4,
+        "external_portmap": false,
+        ${vfs_section}
+        "pnfs": {
+            "enabled": true,
+            "data_servers": [
+                { "netid": "tcp", "uaddr": "${BE_IP}:${DS_PORT}", "version": "3", "backing_path": "/ds0" }
+            ]
+        }
+    },
+    "mounts": {
+        "share": { "module": "${module}", "path": "/" },
+        "ds0": { "module": "nfs", "path": "${BE_IP}:/ds_export", "options": "vers=4,port=${DS_PORT}" }
+    },
+    "exports": { "/share": { "path": "/share" } }
+}
+EOF
+}
+
+# Proxy: a full NFS server whose backing store is the nfs module mounting the MDS
+# with pNFS enabled.  It serves the VM plain NFSv4.1 and is itself the pNFS
+# client under test.
+generate_proxy_config() {
+    cat > "$PROXY_CONFIG" << EOF
+{
+    "server": {
+        "threads": 4,
+        "nfs_port": ${PROXY_PORT},
+        "external_portmap": false,
+        "metrics_port": 9002
+    },
+    "mounts": {
+        "pshare": { "module": "nfs", "path": "${BE_IP}:/share", "options": "vers=4,pnfs,port=${MDS_PORT}" }
+    },
+    "exports": { "/pshare": { "path": "/pshare" } }
+}
+EOF
+}
+
+wait_for_port() {
+    local ns="$1" ip="$2" port="$3" pid="$4"
+    for i in $(seq 1 50); do
+        if ip netns exec "${ns}" bash -c "echo > /dev/tcp/${ip}/${port}" 2>/dev/null; then
+            return 0
+        fi
+        if ! kill -0 "$pid" 2>/dev/null; then
+            echo "chimera daemon (pid $pid) exited prematurely" >&2
+            return 1
+        fi
+        sleep 0.1
+    done
+    echo "timed out waiting for ${ip}:${port}" >&2
+    return 1
+}
+
+ulimit -l unlimited
+echo 16777216 > /proc/sys/fs/aio-max-nr 2>/dev/null || true
+
+# Two netns joined by a veth.  Backend (be) holds the MDS + DS; frontend (fe)
+# holds the proxy and the VM's TAP.
+ip netns add "${BE_NS}"
+ip netns add "${FE_NS}"
+ip link add "${VETH_BE}" type veth peer name "${VETH_FE}"
+ip link set "${VETH_BE}" netns "${BE_NS}"
+ip link set "${VETH_FE}" netns "${FE_NS}"
+
+ip netns exec "${BE_NS}" ip link set lo up
+ip netns exec "${BE_NS}" ip addr add "${BE_IP}/24" dev "${VETH_BE}"
+ip netns exec "${BE_NS}" ip link set "${VETH_BE}" up
+
+ip netns exec "${FE_NS}" ip link set lo up
+ip netns exec "${FE_NS}" ip addr add 10.0.1.2/24 dev "${VETH_FE}"
+ip netns exec "${FE_NS}" ip link set "${VETH_FE}" up
+ip netns exec "${FE_NS}" ip tuntap add dev "${TAP_NAME}" mode tap
+ip netns exec "${FE_NS}" ip addr add "${PROXY_IP}/24" dev "${TAP_NAME}"
+ip netns exec "${FE_NS}" ip link set "${TAP_NAME}" up
+
+# 1. Data server (must be up before the MDS, which mounts it at boot).
+generate_ds_config
+ip netns exec "${BE_NS}" "$CHIMERA_BINARY" -c "$DS_CONFIG" > "$DS_LOG" 2>&1 &
+DS_PID=$!
+wait_for_port "${BE_NS}" "$BE_IP" "$DS_PORT" "$DS_PID" || exit 1
+echo "=== pNFS data server up on ${BE_IP}:${DS_PORT} (be) ==="
+
+# 2. Metadata server (nfs-mounts the DS at boot).
+generate_mds_config
+ip netns exec "${BE_NS}" "$CHIMERA_BINARY" -c "$MDS_CONFIG" > "$MDS_LOG" 2>&1 &
+MDS_PID=$!
+wait_for_port "${BE_NS}" "$BE_IP" "$MDS_PORT" "$MDS_PID" || exit 1
+echo "=== pNFS metadata server up on ${BE_IP}:${MDS_PORT} (be) ==="
+grep -q "backing root resolved" "$MDS_LOG" || {
+    echo "MDS did not resolve its data-server backing root:" >&2
+    grep -iE "pNFS|backing|nfs|error" "$MDS_LOG" | tail -10 >&2
+    exit 1
+}
+
+# 3. Proxy (the pNFS client under test): mounts the MDS with pNFS at boot.
+generate_proxy_config
+ip netns exec "${FE_NS}" "$CHIMERA_BINARY" -c "$PROXY_CONFIG" > "$PROXY_LOG" 2>&1 &
+PROXY_PID=$!
+wait_for_port "${FE_NS}" "$PROXY_IP" "$PROXY_PORT" "$PROXY_PID" || exit 1
+echo "=== pNFS proxy up on ${PROXY_IP}:${PROXY_PORT} (fe) ==="
+grep -q "pnfs_mds=1" "$PROXY_LOG" || {
+    echo "Proxy did not negotiate pNFS-MDS with the metadata server:" >&2
+    grep -iE "EXCHANGE_ID|pnfs|back-channel|error" "$PROXY_LOG" | tail -10 >&2
+    exit 1
+}
+grep -q "back-channel session established" "$PROXY_LOG" || {
+    echo "Proxy did not establish its NFSv4.1 back channel:" >&2
+    grep -iE "back-channel|EXCHANGE_ID|error" "$PROXY_LOG" | tail -10 >&2
+    exit 1
+}
+echo "=== proxy negotiated pNFS-MDS + established back channel ==="
+
+# 4. Boot the VM, mount the proxy over plain NFSv4.1, run the workload.
+NFS_MOUNT_OPTS="vers=4.1,tcp"
+TEST_CMD="mount -t nfs -o ${NFS_MOUNT_OPTS} ${PROXY_IP}:/pshare /mnt && ${TEST_CMD_ARG}"
+
+ip netns exec "${FE_NS}" "$QEMU_BIN" \
+    -enable-kvm -smp 4 -m 1G -cpu host \
+    -kernel "$VMLINUZ" \
+    $QEMU_INITRD \
+    $QEMU_MACHINE \
+    -nodefaults \
+    -drive file="$ROOTFS",if=virtio,format=qcow2,snapshot=on \
+    -netdev tap,id=net0,ifname="${TAP_NAME}",script=no,downscript=no \
+    -device virtio-net-pci,netdev=net0,romfile="" \
+    -serial stdio \
+    -nographic \
+    -no-reboot \
+    -append "root=/dev/vda rw console=${QEMU_CONSOLE} net.ifnames=0 biosdevname=0 quiet panic=-1 test_cmd=\"${TEST_CMD}\" init=/init.sh" \
+    2>/dev/null | tee "$LOG_FILE"
+
+for pid in "$PROXY_PID" "$MDS_PID" "$DS_PID"; do
+    if ! kill -0 "$pid" 2>/dev/null; then
+        wait "$pid" 2>/dev/null
+        echo "=== A chimera daemon (pid $pid) DIED during the test (exit $?) ==="
+        [ "$pid" = "$PROXY_PID" ] && PROXY_PID=""
+        [ "$pid" = "$MDS_PID" ] && MDS_PID=""
+        [ "$pid" = "$DS_PID" ] && DS_PID=""
+    fi
+done
+
+EXIT_CODE=$(grep -oP 'CHIMERA_KVM_EXIT_CODE=\K[0-9]+' "$LOG_FILE" | tail -1)
+if [ "${EXIT_CODE:-1}" != "0" ]; then
+    exit "${EXIT_CODE:-1}"
+fi
+
+# Workload succeeded in the guest; now assert the data really traversed pNFS:
+# the proxy opens a connection to the data server (10.0.1.1:DS_PORT) only to
+# service a layout.  Its absence means the proxy silently fell back to MDS I/O.
+if ! grep -qE "Connected.* to ${BE_IP}:${DS_PORT}" "$PROXY_LOG"; then
+    echo "=== pNFS NOT exercised: proxy never connected to the data server ===" >&2
+    grep -iE "layoutget|getdeviceinfo|pnfs|Connected" "$PROXY_LOG" | tail -15 >&2
+    exit 1
+fi
+echo "=== verified: proxy drove direct data-server I/O via a flex-files layout ==="
+
+# For recall workloads, assert the proxy actually received + handled the recall.
+if echo "$TEST_CMD_ARG" | grep -q "RECALL_EXPECTED"; then
+    if ! grep -q "CB_LAYOUTRECALL" "$PROXY_LOG"; then
+        echo "=== recall NOT delivered: proxy logged no CB_LAYOUTRECALL ===" >&2
+        grep -iE "layoutrecall|back-channel|fenced" "$PROXY_LOG" | tail -15 >&2
+        exit 1
+    fi
+    echo "=== verified: proxy received + handled CB_LAYOUTRECALL ==="
+fi
+
+exit 0

--- a/kvm/kvm_pnfs_test_wrapper.sh
+++ b/kvm/kvm_pnfs_test_wrapper.sh
@@ -205,7 +205,7 @@ generate_mds_config() {
         "pnfs": {
             "enabled": true,
             "data_servers": [
-                { "netid": "tcp", "uaddr": "${DS_IP}:${DS_PORT}", "version": "${DS_VERSION}", "backing_path": "/ds0" }
+                { "tcp": "${DS_IP}:${DS_PORT}", "version": "${DS_VERSION}", "backing_path": "/ds0" }
             ]
         }
     },
@@ -254,7 +254,7 @@ generate_combined_config() {
         "pnfs": {
             "enabled": true,
             "data_servers": [
-                { "netid": "tcp", "uaddr": "${MDS_IP}:${MDS_PORT}", "version": "3", "backing_path": "/share" }
+                { "tcp": "${MDS_IP}:${MDS_PORT}", "version": "3", "backing_path": "/share" }
             ]
         }
     },

--- a/kvm/tests/CMakeLists.txt
+++ b/kvm/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ set(SMB_WRAPPER ${CMAKE_SOURCE_DIR}/kvm/kvm_smb_test_wrapper.sh)
 set(PNFS_WRAPPER ${CMAKE_SOURCE_DIR}/kvm/kvm_pnfs_test_wrapper.sh)
 set(PNFS_BLOCK_WRAPPER ${CMAKE_SOURCE_DIR}/kvm/kvm_pnfs_block_test_wrapper.sh)
 set(PNFS_SCSI_WRAPPER ${CMAKE_SOURCE_DIR}/kvm/kvm_pnfs_scsi_test_wrapper.sh)
+set(PNFS_PROXY_WRAPPER ${CMAKE_SOURCE_DIR}/kvm/kvm_pnfs_proxy_test_wrapper.sh)
 
 set(KVM_BACKENDS memfs linux)
 
@@ -138,6 +139,21 @@ set(PNFS_CMD_recall_truncate_xclient "mkdir -p /mnt2 /mnt/test && mount -t nfs -
 # and the name is gone from the namespace.
 set(PNFS_CMD_remove "mkdir -p /mnt/test && dd if=/dev/urandom of=/mnt/test/f0 bs=1M count=4 2>/dev/null && sync && grep -qi LAYOUTGET /proc/self/mountstats && rm /mnt/test/f0 && ! test -e /mnt/test/f0")
 
+# pNFS PROXY workloads: exercise chimera's own pNFS *client* (the nfs VFS proxy
+# module) against chimera's pNFS server.  The guest mounts a chimera proxy over
+# plain NFSv4.1; the proxy is the pNFS client (LAYOUTGET/GETDEVICEINFO + direct
+# DS I/O + back-channel CB_LAYOUTRECALL).  So, unlike the direct pNFS tests, the
+# guest mount has no LAYOUTGET in its own mountstats -- the wrapper asserts pNFS
+# engagement (proxy->DS connection) and recall delivery from the proxy's logs.
+set(PNFS_PROXY_PROGRAMS rw recall_truncate)
+set(PNFS_PROXY_CMD_rw "mkdir -p /mnt/test && dd if=/dev/urandom of=/tmp/orig bs=1M count=8 2>/dev/null && cp /tmp/orig /mnt/test/f0 && sync && (echo 3 > /proc/sys/vm/drop_caches 2>/dev/null || true) && cmp /tmp/orig /mnt/test/f0")
+
+# Truncating a file the proxy holds a layout for makes the proxy issue a SETATTR
+# to the MDS, which recalls the layout from the proxy over its back channel; the
+# proxy fences DS I/O and the truncate completes.  The "RECALL_EXPECTED" token
+# tells the wrapper to additionally assert the proxy logged a CB_LAYOUTRECALL.
+set(PNFS_PROXY_CMD_recall_truncate ": RECALL_EXPECTED; mkdir -p /mnt/test && dd if=/dev/urandom of=/tmp/orig bs=1M count=8 2>/dev/null && cp /tmp/orig /mnt/test/f0 && sync && truncate -s 4194304 /mnt/test/f0 && (echo 3 > /proc/sys/vm/drop_caches 2>/dev/null || true) && head -c 4194304 /tmp/orig > /tmp/orig4 && cmp /tmp/orig4 /mnt/test/f0")
+
 # xfstests programs
 set(XFSTESTS_PROGRAMS fsstress fsx dirstress nametest fstest rewinddir)
 
@@ -251,6 +267,23 @@ foreach(image_spec ${KVM_IMAGES})
                         ${CHIMERA_BINARY} ${pbackend} 4.1 3 combined
                         "${PNFS_CMD_${prog}}")
             set_tests_properties(chimera/kvm/${IMAGE_NAME}/pnfs/${prog}_${pbackend}_nfs4.1_combined
+                PROPERTIES LABELS "kvm;${IMAGE_NAME};pnfs" PROCESSORS 2)
+        endforeach()
+    endforeach()
+
+    # pNFS PROXY tests: chimera's own pNFS client (the nfs VFS proxy) against
+    # chimera's pNFS server.  Three daemons across two netns -- MDS + DS in the
+    # backend netns, a full-server proxy (the pNFS client under test) in the
+    # frontend netns with the guest -- joined by a veth.  v3 data path; the
+    # client->MDS mount and proxy back channel are 4.1.
+    foreach(prog ${PNFS_PROXY_PROGRAMS})
+        foreach(pbackend ${PNFS_BACKENDS})
+            add_test(NAME chimera/kvm/${IMAGE_NAME}/pnfs/proxy_${prog}_${pbackend}_nfs4.1
+                COMMAND bash ${PNFS_PROXY_WRAPPER}
+                        ${IMAGE_DIR}/vmlinuz ${IMAGE_DIR}/rootfs.qcow2
+                        ${CHIMERA_BINARY} ${pbackend}
+                        "${PNFS_PROXY_CMD_${prog}}")
+            set_tests_properties(chimera/kvm/${IMAGE_NAME}/pnfs/proxy_${prog}_${pbackend}_nfs4.1
                 PROPERTIES LABELS "kvm;${IMAGE_NAME};pnfs" PROCESSORS 2)
         endforeach()
     endforeach()

--- a/scripts/pynfs_pnfs_test_wrapper.sh
+++ b/scripts/pynfs_pnfs_test_wrapper.sh
@@ -33,7 +33,6 @@ MDS_PID=""
 
 MDS_PORT=2049
 DS_PORT=2050
-DS_UADDR="127.0.0.1.8.2"   # RFC 5665 uaddr for 127.0.0.1:2050 (2050 = 8*256+2)
 PYNFS_TIMEOUT="${PYNFS_TIMEOUT:-60}"
 PYNFS_NFS4_LEASE_TIME="${PYNFS_NFS4_LEASE_TIME:-5}"
 PYNFS_NFS4_GRACE_TIME="${PYNFS_NFS4_GRACE_TIME:-10}"
@@ -83,7 +82,7 @@ cat > "$MDS_CONFIG" << EOF
         "nfs4_lease_time": ${PYNFS_NFS4_LEASE_TIME},
         "nfs4_grace_time": ${PYNFS_NFS4_GRACE_TIME},
         "pnfs": { "enabled": true,
-                  "data_servers": [ { "netid": "tcp", "uaddr": "${DS_UADDR}", "backing_path": "/ds0" } ] }
+                  "data_servers": [ { "tcp": "127.0.0.1:${DS_PORT}", "backing_path": "/ds0" } ] }
     },
     "mounts": {
         "share": { "module": "memfs", "path": "/" },

--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -587,27 +587,28 @@ main(
             json_t *ds_entry;
             json_array_foreach(data_servers, ds_i, ds_entry)
             {
-                const char *netid_str   = json_string_value(json_object_get(ds_entry, "netid"));
-                const char *uaddr_str   = json_string_value(json_object_get(ds_entry, "uaddr"));
+                const char *tcp_str     = json_string_value(json_object_get(ds_entry, "tcp"));
+                const char *rdma_str    = json_string_value(json_object_get(ds_entry, "rdma"));
                 const char *backing_str = json_string_value(json_object_get(ds_entry, "backing_path"));
                 json_t     *version_val = json_object_get(ds_entry, "version");
-                char        wire_uaddr[64];
+                char        wire_tcp[64];
+                char        wire_rdma[64];
+                char       *wire_rdma_p = NULL;
 
-                /* uaddr: the DS network address handed to clients in the
-                 * layout, given human-friendly as "host" or "host:port" and
-                 * converted to the RFC 5665 universal address below.
-                 * backing_path: the chimera path where this DS export is
+                /* "tcp" (required): the DS's TCP address handed to clients,
+                 * given human-friendly as "host" or "host:port" (port defaults
+                 * to 2049) and advertised as the "tcp" netaddr.
+                 * "rdma" (optional): an additional RDMA address (port defaults
+                 * to 20049) advertised as a preferred "rdma" netaddr alongside
+                 * tcp, so RDMA-capable clients use RDMA and others fall back to
+                 * tcp.  backing_path: the chimera path where this DS export is
                  * mounted via the nfs module, under which the MDS creates
                  * backing files. */
-                if (!uaddr_str || !backing_str) {
+                if (!tcp_str || !backing_str) {
                     chimera_server_error(
-                        "pNFS data_server[%zu] requires \"uaddr\" and \"backing_path\"; skipping",
+                        "pNFS data_server[%zu] requires \"tcp\" and \"backing_path\"; skipping",
                         ds_i);
                     continue;
-                }
-
-                if (!netid_str) {
-                    netid_str = "tcp";
                 }
 
                 /* "version": which NFS version the client uses to reach the DS,
@@ -632,16 +633,27 @@ main(
                     continue;
                 }
 
-                if (chimera_pnfs_uaddr_from_human(netid_str, uaddr_str,
-                                                  wire_uaddr, sizeof(wire_uaddr)) != 0) {
+                if (chimera_pnfs_uaddr_from_human("tcp", tcp_str,
+                                                  wire_tcp, sizeof(wire_tcp)) != 0) {
                     chimera_server_error(
-                        "pNFS data_server[%zu] invalid uaddr \"%s\"; skipping",
-                        ds_i, uaddr_str);
+                        "pNFS data_server[%zu] invalid tcp address \"%s\"; skipping",
+                        ds_i, tcp_str);
                     continue;
                 }
 
-                chimera_server_config_add_pnfs_ds(server_config, netid_str, wire_uaddr,
-                                                  backing_str, ds_version, ds_minor);
+                if (rdma_str) {
+                    if (chimera_pnfs_uaddr_from_human("rdma", rdma_str,
+                                                      wire_rdma, sizeof(wire_rdma)) != 0) {
+                        chimera_server_error(
+                            "pNFS data_server[%zu] invalid rdma address \"%s\"; skipping RDMA advert",
+                            ds_i, rdma_str);
+                    } else {
+                        wire_rdma_p = wire_rdma;
+                    }
+                }
+
+                chimera_server_config_add_pnfs_ds(server_config, "tcp", wire_tcp,
+                                                  wire_rdma_p, backing_str, ds_version, ds_minor);
             }
         }
     }

--- a/src/server/nfs/nfs4_pnfs.c
+++ b/src/server/nfs/nfs4_pnfs.c
@@ -87,17 +87,25 @@ pnfs_put_opaque(
 static uint32_t
 chimera_nfs4_encode_ff_device_addr(
     uint8_t    *buf,
-    const char *netid,
-    const char *uaddr,
+    const char *netid0,
+    const char *uaddr0,
+    const char *netid1,
+    const char *uaddr1,
     uint32_t    version,
     uint32_t    minorversion)
 {
-    void *p = buf;
+    void    *p         = buf;
+    uint32_t num_addrs = (netid1 && uaddr1 && uaddr1[0]) ? 2 : 1;
 
-    /* ffda_netaddrs: multipath_list4 (a netaddr4<>) with one entry. */
-    pnfs_put_u32(&p, 1);
-    pnfs_put_opaque(&p, netid, strlen(netid));
-    pnfs_put_opaque(&p, uaddr, strlen(uaddr));
+    /* ffda_netaddrs: multipath_list4 (a netaddr4<>).  A client picks any entry
+     * it can reach; the preferred transport (e.g. rdma) is listed first. */
+    pnfs_put_u32(&p, num_addrs);
+    pnfs_put_opaque(&p, netid0, strlen(netid0));
+    pnfs_put_opaque(&p, uaddr0, strlen(uaddr0));
+    if (num_addrs == 2) {
+        pnfs_put_opaque(&p, netid1, strlen(netid1));
+        pnfs_put_opaque(&p, uaddr1, strlen(uaddr1));
+    }
 
     /* ffda_versions<>: one entry advertising the configured NFS version
      * (NFSv3 or NFSv4.x), loosely coupled. */
@@ -151,11 +159,21 @@ chimera_nfs4_getdeviceinfo(
 
     if (args->gdia_layout_type == LAYOUT4_FLEX_FILES &&
         (ds = chimera_vfs_pnfs_find_device(vfs, args->gdia_device_id)) != NULL) {
-        /* Orchestrated flex: device lives in the chimera DS table. */
+        /* Orchestrated flex: device lives in the chimera DS table.  When an RDMA
+         * uaddr is configured, advertise it first (preferred) with the primary
+         * (tcp) netaddr as a fallback. */
         out_type = LAYOUT4_FLEX_FILES;
-        body_len = chimera_nfs4_encode_ff_device_addr(body, ds->netid, ds->uaddr,
-                                                      (uint32_t) ds->version,
-                                                      (uint32_t) ds->minorversion);
+        if (ds->rdma_uaddr[0]) {
+            body_len = chimera_nfs4_encode_ff_device_addr(body, "rdma", ds->rdma_uaddr,
+                                                          ds->netid, ds->uaddr,
+                                                          (uint32_t) ds->version,
+                                                          (uint32_t) ds->minorversion);
+        } else {
+            body_len = chimera_nfs4_encode_ff_device_addr(body, ds->netid, ds->uaddr,
+                                                          NULL, NULL,
+                                                          (uint32_t) ds->version,
+                                                          (uint32_t) ds->minorversion);
+        }
     } else if (nfs_pnfs_devcache_find(&thread->shared->nfs4_pnfs_devcache,
                                       args->gdia_device_id, &dev)) {
         /* Backend-sourced: device came from a get_layout response. */
@@ -184,8 +202,9 @@ chimera_nfs4_getdeviceinfo(
                 break;
             default:
                 /* Backend-sourced flex device: not driven by the data_servers
-                 * config, so advertise NFSv3 as before. */
-                body_len = chimera_nfs4_encode_ff_device_addr(body, dev.netid, dev.uaddr, 3, 0);
+                 * config, so advertise NFSv3 over a single netaddr as before. */
+                body_len = chimera_nfs4_encode_ff_device_addr(body, dev.netid, dev.uaddr,
+                                                              NULL, NULL, 3, 0);
                 break;
         } /* switch */
     } else {

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -223,8 +223,12 @@ chimera_server_config_init(void)
 
     /* Default NFSv4.1 fore-channel session slots (server cap on the number
      * of concurrent SEQUENCE requests a client may have outstanding per
-     * session).  Mirrors NFS4_MAX_REPLY_CACHE_SLOTS in the NFS server. */
-    config->nfs4_session_slots = 64;
+     * session).  The chimera proxy client partitions slots one block per evpl
+     * thread, so a high-thread-count client (e.g. fio numjobs) needs this many
+     * slots or surplus threads collide on a shared slot; 256 covers typical
+     * fan-out out of the box and the replay-slot table sizes to it.  Raise
+     * further for very wide clients. */
+    config->nfs4_session_slots = 256;
 
     /* NFSv4 protocol delegations (OPEN_DELEGATE_READ/WRITE) are disabled by
      * default.  When off, every OPEN returns OPEN_DELEGATE_NONE and the

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -96,6 +96,7 @@ struct chimera_server_config {
     struct chimera_server_config_pnfs_ds {
         char netid[8];
         char uaddr[64];
+        char rdma_uaddr[64];              /* optional RDMA netaddr (empty = none)   */
         char backing_path[CHIMERA_PNFS_BACKING_MAX];
         int  version;                     /* NFS version the client uses for DS I/O */
         int  minorversion;                /* NFS minor version (4.x)                */
@@ -564,6 +565,7 @@ chimera_server_config_add_pnfs_ds(
     struct chimera_server_config *config,
     const char                   *netid,
     const char                   *uaddr,
+    const char                   *rdma_uaddr,
     const char                   *backing_path,
     int                           version,
     int                           minorversion)
@@ -580,6 +582,7 @@ chimera_server_config_add_pnfs_ds(
 
     snprintf(ds->netid, sizeof(ds->netid), "%s", netid ? netid : "tcp");
     snprintf(ds->uaddr, sizeof(ds->uaddr), "%s", uaddr ? uaddr : "");
+    snprintf(ds->rdma_uaddr, sizeof(ds->rdma_uaddr), "%s", rdma_uaddr ? rdma_uaddr : "");
     snprintf(ds->backing_path, sizeof(ds->backing_path), "%s", backing_path ? backing_path : "");
     ds->version      = version ? version : 3;
     ds->minorversion = minorversion;
@@ -1605,6 +1608,7 @@ chimera_server_init(
             chimera_vfs_pnfs_add_device(server->vfs,
                                         config->pnfs_ds[i].netid,
                                         config->pnfs_ds[i].uaddr,
+                                        config->pnfs_ds[i].rdma_uaddr,
                                         config->pnfs_ds[i].backing_path,
                                         config->pnfs_ds[i].version,
                                         config->pnfs_ds[i].minorversion);

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -267,6 +267,7 @@ chimera_server_config_add_pnfs_ds(
     struct chimera_server_config *config,
     const char                   *netid,
     const char                   *uaddr,
+    const char                   *rdma_uaddr,
     const char                   *backing_path,
     int                           version,
     int                           minorversion);

--- a/src/vfs/nfs/CMakeLists.txt
+++ b/src/vfs/nfs/CMakeLists.txt
@@ -39,6 +39,7 @@ add_library(chimera_vfs_nfs SHARED
     nfs4_mknod_at.c
     nfs4_open_at.c
     nfs4_open_fh.c
+    nfs4_pnfs.c
     nfs4_read.c
     nfs4_slot.c
     nfs4_readdir.c

--- a/src/vfs/nfs/nfs.c
+++ b/src/vfs/nfs/nfs.c
@@ -88,6 +88,8 @@ chimera_nfs_init(
 
     pthread_mutex_init(&shared->lock, NULL);
     pthread_mutex_init(&shared->cb_lock, NULL);
+    pthread_mutex_init(&shared->pnfs_devcache.lock, NULL);
+    pthread_mutex_init(&shared->pnfs_layout_lock, NULL);
 
     shared->max_servers = 64;
     shared->servers     = calloc(shared->max_servers, sizeof(*shared->servers));
@@ -135,6 +137,9 @@ chimera_nfs_destroy(void *private_data)
 
     free(shared->mounts);
     free(shared->servers);
+
+    pthread_mutex_destroy(&shared->pnfs_devcache.lock);
+    pthread_mutex_destroy(&shared->pnfs_layout_lock);
 
     free(shared);
 } /* chimera_nfs_destroy */

--- a/src/vfs/nfs/nfs.c
+++ b/src/vfs/nfs/nfs.c
@@ -128,6 +128,7 @@ chimera_nfs_destroy(void *private_data)
         if (shared->servers[i]) {
             /* Free NFS4 session if present */
             if (shared->servers[i]->nfs4_session) {
+                chimera_nfs4_session_pool_destroy(shared->servers[i]->nfs4_session);
                 pthread_mutex_destroy(&shared->servers[i]->nfs4_session->lock);
                 free(shared->servers[i]->nfs4_session);
             }
@@ -233,8 +234,8 @@ chimera_nfs_thread_init(
     thread->shared = shared;
     thread->evpl   = evpl;
 
-    /* Count client threads so the NFS4.1 fore-channel slot pool can be
-     * partitioned evenly (max_slots / nfs_thread_count) per thread. */
+    /* Count live client threads: the NFS4.1 fore-channel slot layer reserves a
+     * floor slot per thread and sizes each thread's soft borrow cap from this. */
     atomic_fetch_add(&shared->nfs_thread_count, 1);
 
     programs[0] = &shared->mount_v3.rpc2;
@@ -282,12 +283,16 @@ chimera_nfs_thread_destroy(void *private_data)
 
     for (i = 0; i < thread->max_server_threads; i++) {
         if (thread->server_threads[i]) {
-            chimera_nfs4_slot_table_destroy(&thread->server_threads[i]->slots);
+            chimera_nfs4_slot_table_destroy(thread->server_threads[i]);
             free(thread->server_threads[i]);
         }
     }
 
     free(thread->server_threads);
+
+    /* Drop this thread from the live count so the slot floor/fair-cap math does
+     * not drift upward across thread churn (mirrors the thread_init increment). */
+    atomic_fetch_sub(&thread->shared->nfs_thread_count, 1);
 
     free(thread);
 } /* chimera_nfs_thread_destroy */

--- a/src/vfs/nfs/nfs.c
+++ b/src/vfs/nfs/nfs.c
@@ -189,6 +189,16 @@ chimera_nfs_notify(
             evpl_rpc2_conn_get_local_address(conn, local_addr, sizeof(local_addr));
             evpl_rpc2_conn_get_remote_address(conn, remote_addr, sizeof(remote_addr));
             chimera_nfsclient_info("Connected from %s to %s", local_addr, remote_addr);
+
+            /* An RDMA conn is only now usable for rkey-advertising ops; release
+             * any pNFS DS I/O parked waiting for it. */
+            for (i = 0; nfs_thread && i < nfs_thread->max_server_threads; i++) {
+                server_thread = nfs_thread->server_threads[i];
+                if (server_thread && server_thread->nfs_conn == conn) {
+                    chimera_nfs4_pnfs_conn_connected(server_thread);
+                    break;
+                }
+            }
             break;
         case EVPL_RPC2_NOTIFY_DISCONNECTED:
             evpl_rpc2_conn_get_local_address(conn, local_addr, sizeof(local_addr));
@@ -202,6 +212,7 @@ chimera_nfs_notify(
             for (i = 0; nfs_thread && i < nfs_thread->max_server_threads; i++) {
                 server_thread = nfs_thread->server_threads[i];
                 if (server_thread && server_thread->nfs_conn == conn) {
+                    chimera_nfs4_pnfs_conn_failed(server_thread);
                     chimera_nfs4_slot_table_reset(nfs_thread->evpl, &server_thread->slots);
                     break;
                 }

--- a/src/vfs/nfs/nfs4_cb.c
+++ b/src/vfs/nfs/nfs4_cb.c
@@ -291,7 +291,7 @@ chimera_nfs4_cb_create_session_callback(
     memcpy(session->sessionid, cs_res->csr_sessionid, NFS4_SESSIONID_SIZE);
     session->max_slots      = cs_res->csr_fore_chan_attrs.ca_maxrequests;
     session->next_unclaimed = 0;
-    session->overflow_rr    = 0;
+    session->claimed_blocks = 0;
 
     pthread_mutex_lock(&shared->lock);
     server->nfs4_session = session;
@@ -337,9 +337,14 @@ chimera_nfs4_cb_create_session(struct chimera_nfs4_cb_establish *item)
     cs_args->csa_fore_chan_attrs.ca_maxresponsesize        = 1024 * 1024;
     cs_args->csa_fore_chan_attrs.ca_maxresponsesize_cached = 0;
     cs_args->csa_fore_chan_attrs.ca_maxoperations          = 64;
-    cs_args->csa_fore_chan_attrs.ca_maxrequests            = 64;
-    cs_args->csa_fore_chan_attrs.ca_rdma_ird               = NULL;
-    cs_args->csa_fore_chan_attrs.num_ca_rdma_ird           = 0;
+    /* Request the fore-channel slot count configured for this server (the
+     * `slots=` mount option, default CHIMERA_NFS4_DEFAULT_SESSION_SLOTS).  The
+     * client partitions slots one block per evpl thread, so the session needs
+     * at least as many slots as there are client threads (e.g. fio numjobs);
+     * the server clamps this to its own nfs4_session_slots. */
+    cs_args->csa_fore_chan_attrs.ca_maxrequests  = server->requested_session_slots;
+    cs_args->csa_fore_chan_attrs.ca_rdma_ird     = NULL;
+    cs_args->csa_fore_chan_attrs.num_ca_rdma_ird = 0;
 
     /* Back channel: a single slot is enough -- the server serialises recalls. */
     cs_args->csa_back_chan_attrs.ca_headerpadsize          = 0;

--- a/src/vfs/nfs/nfs4_cb.c
+++ b/src/vfs/nfs/nfs4_cb.c
@@ -289,9 +289,11 @@ chimera_nfs4_cb_create_session_callback(
     cs_res = &res->resarray[0].opcreate_session.csr_resok4;
 
     memcpy(session->sessionid, cs_res->csr_sessionid, NFS4_SESSIONID_SIZE);
-    session->max_slots      = cs_res->csr_fore_chan_attrs.ca_maxrequests;
-    session->next_unclaimed = 0;
-    session->claimed_blocks = 0;
+    session->max_slots = cs_res->csr_fore_chan_attrs.ca_maxrequests;
+
+    /* Allocate the session-global fore-channel slot pool now that the granted
+    * slot count is known; threads borrow/return ids from it (nfs4_slot.c). */
+    chimera_nfs4_session_pool_init(session);
 
     pthread_mutex_lock(&shared->lock);
     server->nfs4_session = session;

--- a/src/vfs/nfs/nfs4_cb.c
+++ b/src/vfs/nfs/nfs4_cb.c
@@ -379,8 +379,10 @@ chimera_nfs4_cb_exchange_id_callback(
     int                          status,
     void                        *private_data)
 {
-    struct chimera_nfs4_cb_establish   *item = private_data;
+    struct chimera_nfs4_cb_establish   *item   = private_data;
+    struct chimera_nfs_client_server   *server = item->server_thread->server;
     struct chimera_nfs4_client_session *session;
+    struct EXCHANGE_ID4resok           *eid_res;
 
     (void) evpl;
     (void) verf;
@@ -394,9 +396,16 @@ chimera_nfs4_cb_exchange_id_callback(
         return;
     }
 
+    eid_res = &res->resarray[0].opexchange_id.eir_resok4;
+
     session = calloc(1, sizeof(*session));
     pthread_mutex_init(&session->lock, NULL);
-    session->clientid = res->resarray[0].opexchange_id.eir_resok4.eir_clientid;
+    session->clientid = eid_res->eir_clientid;
+
+    /* The MDS confirms pNFS support by echoing USE_PNFS_MDS; only then does the
+     * client issue LAYOUTGET.  Otherwise it transparently stays non-pNFS. */
+    server->mds_pnfs_capable = server->pnfs_requested &&
+        (eid_res->eir_flags & EXCHGID4_FLAG_USE_PNFS_MDS) != 0;
 
     item->session = session;
 
@@ -438,7 +447,10 @@ chimera_nfs4_cb_exchange_id(struct chimera_nfs4_cb_establish *item)
     eid_args->eia_clientowner.co_ownerid.data = (uint8_t *) server->nfs4_owner_id;
     eid_args->eia_clientowner.co_ownerid.len  = server->nfs4_owner_id_len;
 
-    eid_args->eia_flags                 = EXCHGID4_FLAG_USE_NON_PNFS;
+    /* Advertise pNFS-MDS use when the mount asked for it; the MDS confirms by
+     * echoing USE_PNFS_MDS in eir_flags (checked in the reply). */
+    eid_args->eia_flags = server->pnfs_requested
+        ? EXCHGID4_FLAG_USE_PNFS_MDS : EXCHGID4_FLAG_USE_NON_PNFS;
     eid_args->eia_state_protect.spa_how = SP4_NONE;
     eid_args->eia_client_impl_id        = NULL;
     eid_args->num_eia_client_impl_id    = 0;

--- a/src/vfs/nfs/nfs4_cb.c
+++ b/src/vfs/nfs/nfs4_cb.c
@@ -407,6 +407,9 @@ chimera_nfs4_cb_exchange_id_callback(
     server->mds_pnfs_capable = server->pnfs_requested &&
         (eid_res->eir_flags & EXCHGID4_FLAG_USE_PNFS_MDS) != 0;
 
+    chimera_nfsclient_info("NFS4 EXCHANGE_ID ok: clientid=%lu pnfs_mds=%d",
+                           (unsigned long) session->clientid, server->mds_pnfs_capable);
+
     item->session = session;
 
     chimera_nfs4_cb_create_session(item);

--- a/src/vfs/nfs/nfs4_close.c
+++ b/src/vfs/nfs/nfs4_close.c
@@ -4,6 +4,7 @@
 
 #include "nfs_internal.h"
 #include "nfs4_open_state.h"
+#include "nfs4_pnfs.h"
 
 void
 chimera_nfs4_close(
@@ -20,6 +21,17 @@ chimera_nfs4_close(
     if (!open_state) {
         request->status = CHIMERA_VFS_OK;
         request->complete(request);
+        return;
+    }
+
+    /* Drop this file's layout from the recall registry before it is freed.
+     * Idempotent: a no-op unless the layout reached VALID (or was fenced). */
+    chimera_nfs4_pnfs_layout_unregister(shared, &open_state->layout);
+
+    /* If a pNFS layout is held, report the new size to the MDS (LAYOUTCOMMIT)
+     * and return the layout (LAYOUTRETURN) before freeing.  When it takes the
+     * request it frees the open state and completes asynchronously. */
+    if (chimera_nfs4_pnfs_close(thread, shared, request, open_state)) {
         return;
     }
 

--- a/src/vfs/nfs/nfs4_mount.c
+++ b/src/vfs/nfs/nfs4_mount.c
@@ -14,8 +14,13 @@
 #include "vfs/vfs_internal.h"
 #include "vfs/vfs_fh.h"
 
-#define CHIMERA_NFS4_DEFAULT_PORT 2049
-#define CHIMERA_NFS4_RDMA_PORT    20049
+#define CHIMERA_NFS4_DEFAULT_PORT          2049
+#define CHIMERA_NFS4_RDMA_PORT             20049
+
+/* Default fore-channel slots requested at CREATE_SESSION when the `slots=`
+ * mount option is absent.  Generous so the client is not the artificial limit;
+ * the server clamps it to its own nfs4_session_slots. */
+#define CHIMERA_NFS4_DEFAULT_SESSION_SLOTS 1024
 
 struct chimera_nfs4_mount_ctx {
     struct chimera_nfs_client_server_thread *server_thread;
@@ -96,6 +101,30 @@ chimera_nfs4_mount_get_port(
 
     return default_port;
 } /* chimera_nfs4_mount_get_port */
+
+/* Get the requested fore-channel session slot count (ca_maxrequests) from the
+ * `slots=` mount option, or default_slots when absent/invalid. */
+static int
+chimera_nfs4_mount_get_session_slots(
+    const struct chimera_vfs_mount_options *options,
+    int                                     default_slots)
+{
+    int i;
+
+    for (i = 0; i < options->num_options; i++) {
+        if (strcmp(options->options[i].key, "slots") == 0) {
+            if (options->options[i].value) {
+                int slots = atoi(options->options[i].value);
+
+                if (slots > 0) {
+                    return slots;
+                }
+            }
+        }
+    }
+
+    return default_slots;
+} /* chimera_nfs4_mount_get_session_slots */
 
 /* Return 1 if the `pnfs` mount option is present (enables pNFS-MDS). */
 static int
@@ -566,6 +595,10 @@ chimera_nfs4_mount(
 
         /* pNFS opt-in (default off); confirmed against eir_flags at EXCHANGE_ID. */
         server->pnfs_requested = chimera_nfs4_mount_get_pnfs(&request->mount.options);
+
+        /* Fore-channel session slots to request at CREATE_SESSION. */
+        server->requested_session_slots = chimera_nfs4_mount_get_session_slots(
+            &request->mount.options, CHIMERA_NFS4_DEFAULT_SESSION_SLOTS);
 
         /* Get port (default 2049 for TCP, 20049 for RDMA) */
         port = chimera_nfs4_mount_get_port(&request->mount.options,

--- a/src/vfs/nfs/nfs4_mount.c
+++ b/src/vfs/nfs/nfs4_mount.c
@@ -97,6 +97,24 @@ chimera_nfs4_mount_get_port(
     return default_port;
 } /* chimera_nfs4_mount_get_port */
 
+/* Return 1 if the `pnfs` mount option is present (enables pNFS-MDS). */
+static int
+chimera_nfs4_mount_get_pnfs(const struct chimera_vfs_mount_options *options)
+{
+    int i;
+
+    for (i = 0; i < options->num_options; i++) {
+        if (strcmp(options->options[i].key, "pnfs") == 0) {
+            if (!options->options[i].value ||
+                strcmp(options->options[i].value, "0") != 0) {
+                return 1;
+            }
+        }
+    }
+
+    return 0;
+} /* chimera_nfs4_mount_get_pnfs */
+
 /*
  * Callback for SEQUENCE + PUTROOTFH + GETFH + GETATTR compound
  * This is the final step of mount - we have the root file handle
@@ -545,6 +563,9 @@ chimera_nfs4_mount(
         /* Parse RDMA options */
         server->rdma_protocol = chimera_nfs4_mount_get_rdma_protocol(&request->mount.options);
         server->use_rdma      = server->rdma_protocol != 0;
+
+        /* pNFS opt-in (default off); confirmed against eir_flags at EXCHANGE_ID. */
+        server->pnfs_requested = chimera_nfs4_mount_get_pnfs(&request->mount.options);
 
         /* Get port (default 2049 for TCP, 20049 for RDMA) */
         port = chimera_nfs4_mount_get_port(&request->mount.options,

--- a/src/vfs/nfs/nfs4_open_state.h
+++ b/src/vfs/nfs/nfs4_open_state.h
@@ -10,6 +10,7 @@
 #include <string.h>
 #include "vfs/vfs.h"
 #include "nfs4_xdr.h"
+#include "nfs4_pnfs.h"
 
 /*
  * NFS4 Open State
@@ -23,19 +24,26 @@
  */
 
 struct chimera_nfs4_open_state {
-    uint8_t                 server_index;  /* NFS server index for dispatch routing */
-    struct stateid4         stateid;       /* NFS4 stateid for this open */
-    uint32_t                seqid;         /* Sequence ID for state operations */
-    uint32_t                access;        /* Share access mode */
-    atomic_int              dirty;         /* Count of uncommitted unstable writes */
-    int                     silly_renamed; /* File has been silly renamed */
-    uint8_t                 dir_fh_len;    /* Directory fh for silly remove on close */
-    uint8_t                 dir_fh[CHIMERA_VFS_FH_SIZE];
+    uint8_t                    server_index; /* NFS server index for dispatch routing */
+    struct stateid4            stateid;    /* NFS4 stateid for this open */
+    uint32_t                   seqid;      /* Sequence ID for state operations */
+    uint32_t                   access;     /* Share access mode */
+    atomic_int                 dirty;      /* Count of uncommitted unstable writes */
+    int                        silly_renamed; /* File has been silly renamed */
+    uint8_t                    dir_fh_len; /* Directory fh for silly remove on close */
+    uint8_t                    dir_fh[CHIMERA_VFS_FH_SIZE];
 
     /*
      * Credentials for silly remove on close.
      */
-    struct chimera_vfs_cred silly_remove_cred;
+    struct chimera_vfs_cred    silly_remove_cred;
+
+    /*
+     * pNFS (flex-files) per-file layout.  Zero-initialized by calloc means
+     * layout.state == CHIMERA_NFS4_LAYOUT_NONE (no layout yet); only touched
+     * when pNFS is enabled and the MDS is pNFS-capable.
+     */
+    struct chimera_nfs4_layout layout;
 };
 
 /*
@@ -50,6 +58,7 @@ chimera_nfs4_open_state_alloc(void)
     if (state) {
         atomic_init(&state->dirty, 0);
         state->seqid = 1;
+        pthread_mutex_init(&state->layout.acq_lock, NULL);
     }
 
     return state;
@@ -61,6 +70,7 @@ chimera_nfs4_open_state_alloc(void)
 static inline void
 chimera_nfs4_open_state_free(struct chimera_nfs4_open_state *state)
 {
+    pthread_mutex_destroy(&state->layout.acq_lock);
     free(state);
 } /* chimera_nfs4_open_state_free */
 

--- a/src/vfs/nfs/nfs4_pnfs.c
+++ b/src/vfs/nfs/nfs4_pnfs.c
@@ -568,6 +568,55 @@ chimera_nfs4_pnfs_replay(
     }
 } /* chimera_nfs4_pnfs_replay */
 
+/*
+ * The DS connection reached CONNECTED (from chimera_nfs_notify).  Mark it ready
+ * and replay any DS I/O that parked waiting for the RDMA QP to bind.  Runs on
+ * the connection's own evpl thread, so conn_waiters is touched single-threaded.
+ */
+void
+chimera_nfs4_pnfs_conn_connected(struct chimera_nfs_client_server_thread *server_thread)
+{
+    struct chimera_vfs_request *waiters, *w, *next;
+
+    server_thread->nfs_conn_ready = 1;
+
+    waiters                     = server_thread->conn_waiters;
+    server_thread->conn_waiters = NULL;
+
+    for (w = waiters; w; w = next) {
+        next    = w->next;
+        w->next = NULL;
+        if (w->opcode == CHIMERA_VFS_OP_READ) {
+            chimera_nfs4_read(server_thread->thread, server_thread->shared, w, server_thread->thread);
+        } else {
+            chimera_nfs4_write(server_thread->thread, server_thread->shared, w, server_thread->thread);
+        }
+    }
+} /* chimera_nfs4_pnfs_conn_connected */
+
+/*
+ * The DS connection dropped (or never connected) before its parked I/O could
+ * run.  Mark it not-ready and error-complete the waiters rather than leaking
+ * them; the upper VFS layer decides whether to retry.
+ */
+void
+chimera_nfs4_pnfs_conn_failed(struct chimera_nfs_client_server_thread *server_thread)
+{
+    struct chimera_vfs_request *waiters, *w, *next;
+
+    server_thread->nfs_conn_ready = 0;
+
+    waiters                     = server_thread->conn_waiters;
+    server_thread->conn_waiters = NULL;
+
+    for (w = waiters; w; w = next) {
+        next      = w->next;
+        w->next   = NULL;
+        w->status = CHIMERA_VFS_EIO;
+        w->complete(w);
+    }
+} /* chimera_nfs4_pnfs_conn_failed */
+
 /* ----------------------------------------------------------------------- */
 /* Layout registry + back-channel CB_LAYOUTRECALL                          */
 /* ----------------------------------------------------------------------- */
@@ -1116,6 +1165,14 @@ chimera_nfs4_pnfs_ds_read(
         return 0;       /* DS unreachable: caller falls back to MDS. */
     }
 
+    if (!ds_thread->nfs_conn_ready) {
+        /* Fresh RDMA DS conn: a READ may advertise an rkey for its reply data,
+         * which the QP cannot do until CONNECTED.  Park until then. */
+        request->next           = ds_thread->conn_waiters;
+        ds_thread->conn_waiters = request;
+        return 1;
+    }
+
     args.file.data.data = seg->ds_fh;
     args.file.data.len  = seg->ds_fh_len;
     args.offset         = request->read.offset;
@@ -1215,6 +1272,15 @@ chimera_nfs4_pnfs_ds_write(
     if (!ds_thread || !ds_thread->nfs_conn) {
         chimera_nfsclient_error("pNFS DS write: DS server %d unreachable, using MDS", ds_server_index);
         return 0;       /* DS unreachable: caller falls back to MDS. */
+    }
+
+    if (!ds_thread->nfs_conn_ready) {
+        /* Fresh RDMA DS conn: the WRITE advertises an rkey for its data, which
+         * the QP cannot do until CONNECTED.  Park until then (see
+         * nfs_conn_ready) -- replayed by chimera_nfs4_pnfs_conn_connected. */
+        request->next           = ds_thread->conn_waiters;
+        ds_thread->conn_waiters = request;
+        return 1;
     }
 
     chimera_nfsclient_debug("pNFS DS write -> server %d off=%lu len=%u",

--- a/src/vfs/nfs/nfs4_pnfs.c
+++ b/src/vfs/nfs/nfs4_pnfs.c
@@ -1,0 +1,1514 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * NFSv4.1 pNFS CLIENT, flex-files layout (RFC 8435).  See nfs4_pnfs.h for the
+ * overall model.  This file:
+ *   - hand-decodes the opaque ff_layout4 (loc_body) and ff_device_addr4
+ *     (da_addr_body), the read-side inverse of the server's encoders in
+ *     src/server/nfs/nfs4_pnfs.c;
+ *   - drives LAYOUTGET + GETDEVICEINFO to the MDS to acquire a layout and
+ *     resolve its data server, registering the DS as another
+ *     chimera_nfs_client_server;
+ *   - redirects READ/WRITE to the DS over NFSv3 (reusing the v3 send path);
+ *   - on close, reports the new size to the MDS (LAYOUTCOMMIT) and returns the
+ *     layout (LAYOUTRETURN).
+ *
+ * Every failure path falls back to MDS I/O; pNFS never makes an op fail that
+ * would otherwise have succeeded.
+ */
+
+#include <string.h>
+#include <stdlib.h>
+
+#include "nfs_internal.h"
+#include "nfs4_open_state.h"
+#include "nfs4_pnfs.h"
+#include "nfs_common/nfs3_status.h"
+
+#define CHIMERA_NFS4_PNFS_MAXCOUNT     4096
+
+/* On-wire size of a stateid4: 4-byte seqid + NFS4_OTHER_SIZE (12) bytes. */
+#define CHIMERA_NFS4_STATEID_WIRE_SIZE 16
+
+/* Synthetic DS file handle = [mount_id][server_index][ds_fh]; size for the
+ * largest possible ds_fh so the on-stack buffer can never overflow. */
+#define CHIMERA_NFS4_DS_FH_MAX         (CHIMERA_VFS_MOUNT_ID_SIZE + 1 + CHIMERA_VFS_FH_SIZE)
+
+/* ---------------------------------------------------------------------------
+* Bounds-checked XDR decode cursor (read-side inverse of the server's
+* pnfs_put_u32/u64/opaque).  On any short read the cursor latches `err`, and
+* every subsequent get is a no-op, so a malformed body yields a clean failure
+* (and an MDS fallback) rather than an out-of-bounds read.
+* ------------------------------------------------------------------------- */
+
+struct pnfs_cursor {
+    const uint8_t *p;
+    const uint8_t *end;
+    int            err;
+};
+
+static inline void
+pnfs_cursor_init(
+    struct pnfs_cursor *c,
+    const void         *data,
+    uint32_t            len)
+{
+    c->p   = data;
+    c->end = (const uint8_t *) data + len;
+    c->err = (data == NULL && len > 0);
+} /* pnfs_cursor_init */
+
+static inline uint32_t
+pnfs_get_u32(struct pnfs_cursor *c)
+{
+    uint32_t v;
+
+    if (c->err || c->p + sizeof(uint32_t) > c->end) {
+        c->err = 1;
+        return 0;
+    }
+    memcpy(&v, c->p, sizeof(v));
+    c->p += sizeof(uint32_t);
+    return chimera_nfs_ntoh32(v);
+} /* pnfs_get_u32 */
+
+static inline uint64_t
+pnfs_get_u64(struct pnfs_cursor *c)
+{
+    uint64_t v;
+
+    if (c->err || c->p + sizeof(uint64_t) > c->end) {
+        c->err = 1;
+        return 0;
+    }
+    memcpy(&v, c->p, sizeof(v));
+    c->p += sizeof(uint64_t);
+    return chimera_nfs_ntoh64(v);
+} /* pnfs_get_u64 */
+
+/* Skip `n` raw bytes (no padding). */
+static inline void
+pnfs_skip(
+    struct pnfs_cursor *c,
+    uint32_t            n)
+{
+    if (c->err || c->p + n > c->end) {
+        c->err = 1;
+        return;
+    }
+    c->p += n;
+} /* pnfs_skip */
+
+/*
+ * Read an XDR opaque<>/string<> (4-byte length, bytes, pad to 4) into out (up
+ * to outcap bytes); *outlen receives the true length.  The bytes are skipped in
+ * the cursor regardless of outcap so following fields stay aligned.
+ */
+static inline void
+pnfs_get_opaque(
+    struct pnfs_cursor *c,
+    void               *out,
+    uint32_t            outcap,
+    uint32_t           *outlen)
+{
+    uint32_t len = pnfs_get_u32(c);
+    uint32_t pad;
+
+    if (c->err) {
+        *outlen = 0;
+        return;
+    }
+
+    pad = (4 - (len & 3)) & 3;
+
+    if (c->p + len + pad > c->end) {
+        c->err  = 1;
+        *outlen = 0;
+        return;
+    }
+
+    if (out && len <= outcap) {
+        memcpy(out, c->p, len);
+        *outlen = len;
+    } else {
+        /* Caller's buffer too small (or no copy requested): report the length
+         * but don't copy a truncated value the caller might misuse. */
+        *outlen = (out && len > outcap) ? 0 : len;
+    }
+
+    c->p += len + pad;
+} /* pnfs_get_opaque */
+
+/* ---------------------------------------------------------------------------
+* Flex-files body decoders (inverse of chimera_nfs4_encode_ff_* in the server).
+* ------------------------------------------------------------------------- */
+
+/*
+ * Decode an ff_layout4 (loc_body) into a single layout segment.  We expect
+ * chimera's whole-file, one-mirror, one-data-server layout: read the device id
+ * and the data server's native file handle, and ignore the rest (efficiency,
+ * stateid, user/group, flags).  Returns 0 on success.
+ */
+static int
+chimera_nfs4_decode_ff_layout(
+    const void                        *body,
+    uint32_t                           body_len,
+    struct chimera_vfs_layout_segment *seg)
+{
+    struct pnfs_cursor c;
+    uint32_t           num_mirrors, num_ds, num_fh;
+
+    pnfs_cursor_init(&c, body, body_len);
+
+    pnfs_get_u64(&c);                              /* ffl_stripe_unit            */
+
+    num_mirrors = pnfs_get_u32(&c);                /* ffl_mirrors<>              */
+    if (c.err || num_mirrors < 1) {
+        return -1;
+    }
+
+    num_ds = pnfs_get_u32(&c);                     /* ffm_data_servers<>         */
+    if (c.err || num_ds < 1) {
+        return -1;
+    }
+
+    pnfs_skip(&c, CHIMERA_VFS_DEVICEID_SIZE);       /* read ffds_deviceid below   */
+    if (!c.err) {
+        memcpy(seg->deviceid, c.p - CHIMERA_VFS_DEVICEID_SIZE, CHIMERA_VFS_DEVICEID_SIZE);
+    }
+
+    pnfs_get_u32(&c);                              /* ffds_efficiency            */
+    pnfs_skip(&c, CHIMERA_NFS4_STATEID_WIRE_SIZE); /* ffds_stateid (anonymous)   */
+
+    num_fh = pnfs_get_u32(&c);                     /* ffds_fh_vers<> count       */
+    if (c.err || num_fh < 1) {
+        return -1;
+    }
+
+    seg->ds_fh_len = 0;
+    pnfs_get_opaque(&c, seg->ds_fh, sizeof(seg->ds_fh), &seg->ds_fh_len);
+    if (c.err || seg->ds_fh_len == 0) {
+        return -1;
+    }
+
+    /* Any additional fh_vers entries, then ffds_user/ffds_group/flags, are not
+    * needed by the client; stop here.  (We only required the first handle.) */
+    return 0;
+} /* chimera_nfs4_decode_ff_layout */
+
+/*
+ * Decode an ff_device_addr4 (da_addr_body) into a device descriptor: the first
+ * netaddr4 {netid, uaddr} and the first ff_version entry (NFS version the DS
+ * speaks).  Returns 0 on success.
+ */
+static int
+chimera_nfs4_decode_ff_device_addr(
+    const void                       *body,
+    uint32_t                          body_len,
+    struct chimera_vfs_layout_device *dev,
+    int                              *ds_version,
+    int                              *ds_minorversion)
+{
+    struct pnfs_cursor c;
+    uint32_t           num_addrs, num_vers, netid_len, uaddr_len;
+
+    pnfs_cursor_init(&c, body, body_len);
+
+    num_addrs = pnfs_get_u32(&c);                  /* ffda_netaddrs<>            */
+    if (c.err || num_addrs < 1) {
+        return -1;
+    }
+
+    netid_len = 0;
+    pnfs_get_opaque(&c, dev->netid, sizeof(dev->netid) - 1, &netid_len);
+    dev->netid[netid_len < sizeof(dev->netid) ? netid_len : 0] = '\0';
+
+    uaddr_len = 0;
+    pnfs_get_opaque(&c, dev->uaddr, sizeof(dev->uaddr) - 1, &uaddr_len);
+    if (c.err || uaddr_len == 0 || uaddr_len >= sizeof(dev->uaddr)) {
+        return -1;
+    }
+    dev->uaddr[uaddr_len] = '\0';
+
+    num_vers = pnfs_get_u32(&c);                   /* ffda_versions<>            */
+    if (c.err || num_vers < 1) {
+        return -1;
+    }
+
+    *ds_version      = (int) pnfs_get_u32(&c);     /* ffdv_version               */
+    *ds_minorversion = (int) pnfs_get_u32(&c);     /* ffdv_minorversion          */
+    /* ffdv_rsize, ffdv_wsize, ffdv_tightly_coupled follow; not needed. */
+
+    if (c.err) {
+        return -1;
+    }
+
+    dev->layout_class = CHIMERA_VFS_LAYOUT_CLASS_FLEX;
+    return 0;
+} /* chimera_nfs4_decode_ff_device_addr */
+
+/* ---------------------------------------------------------------------------
+* RFC 5665 universal address parse (mirror of the server's nfs4_cb_parse_uaddr):
+* "<host>.<p1>.<p2>"  =>  host string + TCP port (p1*256 + p2).
+* ------------------------------------------------------------------------- */
+
+static int
+chimera_nfs4_parse_uaddr(
+    const char *uaddr,
+    char       *host,
+    size_t      hostsz,
+    int        *out_port)
+{
+    char   buf[80];
+    char  *last_dot, *second_dot;
+    int    hi, lo;
+    size_t hostlen;
+
+    if (!uaddr || uaddr[0] == '\0') {
+        return -1;
+    }
+
+    snprintf(buf, sizeof(buf), "%s", uaddr);
+
+    last_dot = strrchr(buf, '.');
+    if (!last_dot) {
+        return -1;
+    }
+    *last_dot = '\0';
+    lo        = atoi(last_dot + 1);
+
+    second_dot = strrchr(buf, '.');
+    if (!second_dot) {
+        return -1;
+    }
+    *second_dot = '\0';
+    hi          = atoi(second_dot + 1);
+
+    hostlen = strlen(buf);
+    if (hostlen == 0 || hostlen >= hostsz) {
+        return -1;
+    }
+    memcpy(host, buf, hostlen + 1);
+    *out_port = (hi << 8) | lo;
+    return 0;
+} /* chimera_nfs4_parse_uaddr */
+
+/* ---------------------------------------------------------------------------
+* Client device cache (deviceid -> resolved DS server slot + descriptor).
+* ------------------------------------------------------------------------- */
+
+static int
+chimera_nfs4_devcache_find(
+    struct chimera_nfs4_client_devcache *cache,
+    const uint8_t                       *deviceid,
+    int                                 *server_index)
+{
+    uint32_t i;
+    int      found = 0;
+
+    pthread_mutex_lock(&cache->lock);
+    for (i = 0; i < cache->count; i++) {
+        if (cache->entries[i].valid &&
+            memcmp(cache->entries[i].deviceid, deviceid, CHIMERA_VFS_DEVICEID_SIZE) == 0) {
+            *server_index = cache->entries[i].server_index;
+            found         = 1;
+            break;
+        }
+    }
+    pthread_mutex_unlock(&cache->lock);
+    return found;
+} /* chimera_nfs4_devcache_find */
+
+static void
+chimera_nfs4_devcache_put(
+    struct chimera_nfs4_client_devcache    *cache,
+    const struct chimera_vfs_layout_device *dev,
+    int                                     server_index)
+{
+    uint32_t i;
+
+    pthread_mutex_lock(&cache->lock);
+
+    for (i = 0; i < cache->count; i++) {
+        if (cache->entries[i].valid &&
+            memcmp(cache->entries[i].deviceid, dev->deviceid, CHIMERA_VFS_DEVICEID_SIZE) == 0) {
+            cache->entries[i].device       = *dev;
+            cache->entries[i].server_index = server_index;
+            pthread_mutex_unlock(&cache->lock);
+            return;
+        }
+    }
+
+    if (cache->count < CHIMERA_NFS4_CLIENT_DEVCACHE_MAX) {
+        i = cache->count++;
+        memcpy(cache->entries[i].deviceid, dev->deviceid, CHIMERA_VFS_DEVICEID_SIZE);
+        cache->entries[i].device       = *dev;
+        cache->entries[i].server_index = server_index;
+        cache->entries[i].valid        = 1;
+    }
+
+    pthread_mutex_unlock(&cache->lock);
+} /* chimera_nfs4_devcache_put */
+
+/* ---------------------------------------------------------------------------
+* Data-server registration: a DS becomes another chimera_nfs_client_server in
+* shared->servers[], reusing the array-growth pattern from chimera_nfs4_mount.
+* Deduplicated by (host, port).  Returns the server index, or -1.
+* ------------------------------------------------------------------------- */
+
+static int
+chimera_nfs4_pnfs_register_ds(
+    struct chimera_nfs_shared *shared,
+    const char                *host,
+    int                        port,
+    int                        version)
+{
+    struct chimera_nfs_client_server **new_servers, *server;
+    int                                i, idx = -1;
+
+    pthread_mutex_lock(&shared->lock);
+
+    for (i = 0; i < shared->max_servers; i++) {
+        if (shared->servers[i] && shared->servers[i]->is_ds &&
+            shared->servers[i]->nfs_port == port &&
+            strcmp(shared->servers[i]->hostname, host) == 0) {
+            pthread_mutex_unlock(&shared->lock);
+            return i;
+        }
+    }
+
+    for (i = 0; i < shared->max_servers; i++) {
+        if (shared->servers[i] == NULL) {
+            idx = i;
+            break;
+        }
+    }
+
+    if (idx < 0) {
+        /* Expand server array (same scheme as chimera_nfs4_mount). */
+        idx                  = shared->max_servers;
+        shared->max_servers *= 2;
+        new_servers          = calloc(shared->max_servers, sizeof(*new_servers));
+        memcpy(new_servers, shared->servers, (shared->max_servers / 2) * sizeof(*new_servers));
+        free(shared->servers);
+        shared->servers = new_servers;
+    }
+
+    /* A 1-byte server index is encoded into the file handle; cap accordingly. */
+    if (idx > 255) {
+        pthread_mutex_unlock(&shared->lock);
+        return -1;
+    }
+
+    server           = calloc(1, sizeof(*server));
+    server->shared   = shared;
+    server->state    = CHIMERA_NFS_CLIENT_SERVER_STATE_DISCOVERED;
+    server->refcnt   = 1;
+    server->nfsvers  = version ? version : 3;
+    server->is_ds    = 1;
+    server->index    = idx;
+    server->nfs_port = port;
+    snprintf(server->hostname, sizeof(server->hostname), "%s", host);
+
+    server->nfs_endpoint = evpl_endpoint_create(server->hostname, server->nfs_port);
+
+    shared->servers[idx] = server;
+
+    pthread_mutex_unlock(&shared->lock);
+
+    chimera_nfsclient_info("pNFS: registered DS %s:%d as server index %d (v%d)",
+                           host, port, idx, server->nfsvers);
+
+    return idx;
+} /* chimera_nfs4_pnfs_register_ds */
+
+/* ---------------------------------------------------------------------------
+* Layout acquisition state machine (LAYOUTGET -> GETDEVICEINFO).  Its context
+* lives in request->plugin_data for the duration of the acquisition; on
+* completion (success or failure) it re-dispatches the original read/write,
+* which then either takes the DS path (VALID) or falls back to the MDS (UNAVAIL).
+* ------------------------------------------------------------------------- */
+
+struct chimera_nfs4_acquire_ctx {
+    struct chimera_nfs_thread               *thread;
+    struct chimera_nfs_shared               *shared;
+    void                                    *private_data;
+    struct chimera_nfs_client_server_thread *mds_thread;
+    struct chimera_nfs4_open_state          *open_state;
+    void                                     ( *redispatch )(
+        struct chimera_nfs_thread *,
+        struct chimera_nfs_shared *,
+        struct chimera_vfs_request *,
+        void *);
+    uint8_t                                  deviceid[CHIMERA_VFS_DEVICEID_SIZE];
+};
+
+/*
+ * These pNFS compounds (LAYOUTGET/GETDEVICEINFO to the MDS, LAYOUTCOMMIT/
+ * LAYOUTRETURN at close) go through chimera_nfs4_compound_call(), which parks
+ * the request when no session slot is free and replays it via these shims when
+ * one frees.  Each just re-runs its step, rebuilding args from the ctx that
+ * already lives in request->plugin_data (the acquire ctx, or the close ctx).
+ */
+static void chimera_nfs4_getdeviceinfo(
+    struct chimera_vfs_request      *request,
+    struct chimera_nfs4_acquire_ctx *actx);
+static void chimera_nfs4_layoutget(
+    struct chimera_vfs_request      *request,
+    struct chimera_nfs4_acquire_ctx *actx);
+static void chimera_nfs4_pnfs_layoutcommit(
+    struct chimera_vfs_request *request);
+static void chimera_nfs4_pnfs_layoutreturn(
+    struct chimera_vfs_request *request);
+
+static void
+chimera_nfs4_getdeviceinfo_retry(
+    struct chimera_nfs_thread  *thread,
+    struct chimera_nfs_shared  *shared,
+    struct chimera_vfs_request *request,
+    void                       *ctx)
+{
+    (void) thread;
+    (void) shared;
+    (void) ctx;
+    chimera_nfs4_getdeviceinfo(request, request->plugin_data);
+} /* chimera_nfs4_getdeviceinfo_retry */
+
+static void
+chimera_nfs4_layoutget_retry(
+    struct chimera_nfs_thread  *thread,
+    struct chimera_nfs_shared  *shared,
+    struct chimera_vfs_request *request,
+    void                       *ctx)
+{
+    (void) thread;
+    (void) shared;
+    (void) ctx;
+    chimera_nfs4_layoutget(request, request->plugin_data);
+} /* chimera_nfs4_layoutget_retry */
+
+static void
+chimera_nfs4_layoutcommit_retry(
+    struct chimera_nfs_thread  *thread,
+    struct chimera_nfs_shared  *shared,
+    struct chimera_vfs_request *request,
+    void                       *ctx)
+{
+    (void) thread;
+    (void) shared;
+    (void) ctx;
+    chimera_nfs4_pnfs_layoutcommit(request);
+} /* chimera_nfs4_layoutcommit_retry */
+
+static void
+chimera_nfs4_layoutreturn_retry(
+    struct chimera_nfs_thread  *thread,
+    struct chimera_nfs_shared  *shared,
+    struct chimera_vfs_request *request,
+    void                       *ctx)
+{
+    (void) thread;
+    (void) shared;
+    (void) ctx;
+    chimera_nfs4_pnfs_layoutreturn(request);
+} /* chimera_nfs4_layoutreturn_retry */
+
+/* Re-dispatch a single request to the right op entry point. */
+static void
+chimera_nfs4_pnfs_replay(
+    struct chimera_nfs4_layout *layout,
+    struct chimera_vfs_request *request)
+{
+    if (request->opcode == CHIMERA_VFS_OP_READ) {
+        chimera_nfs4_read(layout->acq_thread, layout->acq_shared, request, layout->acq_private);
+    } else {
+        chimera_nfs4_write(layout->acq_thread, layout->acq_shared, request, layout->acq_private);
+    }
+} /* chimera_nfs4_pnfs_replay */
+
+/* ----------------------------------------------------------------------- */
+/* Layout registry + back-channel CB_LAYOUTRECALL                          */
+/* ----------------------------------------------------------------------- */
+
+void
+chimera_nfs4_pnfs_layout_register(
+    struct chimera_nfs_shared  *shared,
+    struct chimera_nfs4_layout *layout)
+{
+    pthread_mutex_lock(&shared->pnfs_layout_lock);
+    if (!layout->registered) {
+        layout->registered   = 1;
+        layout->reg_next     = shared->pnfs_layouts;
+        shared->pnfs_layouts = layout;
+    }
+    pthread_mutex_unlock(&shared->pnfs_layout_lock);
+} /* chimera_nfs4_pnfs_layout_register */
+
+void
+chimera_nfs4_pnfs_layout_unregister(
+    struct chimera_nfs_shared  *shared,
+    struct chimera_nfs4_layout *layout)
+{
+    struct chimera_nfs4_layout **pp;
+
+    pthread_mutex_lock(&shared->pnfs_layout_lock);
+    if (layout->registered) {
+        for (pp = &shared->pnfs_layouts; *pp; pp = &(*pp)->reg_next) {
+            if (*pp == layout) {
+                *pp = layout->reg_next;
+                break;
+            }
+        }
+        layout->reg_next   = NULL;
+        layout->registered = 0;
+    }
+    pthread_mutex_unlock(&shared->pnfs_layout_lock);
+} /* chimera_nfs4_pnfs_layout_unregister */
+
+/*
+ * Fence a recalled layout: stop the client using it for DS I/O.  Storing
+ * UNAVAIL makes subsequent reads/writes fall back to the MDS, and makes close
+ * skip the (now invalid) LAYOUTCOMMIT/LAYOUTRETURN -- the MDS drops the layout
+ * on our recall reply, so there is nothing to commit or return to.  Caller holds
+ * shared->pnfs_layout_lock, so the layout cannot be unregistered/freed under us.
+ */
+static void
+chimera_nfs4_cb_fence_layout(struct chimera_nfs4_layout *layout)
+{
+    atomic_store(&layout->state, CHIMERA_NFS4_LAYOUT_UNAVAIL);
+} /* chimera_nfs4_cb_fence_layout */
+
+/*
+ * Strong CB_LAYOUTRECALL handler (overrides the weak default in nfs4_cb.c).
+ * Runs on the back-channel control thread.  Find the recalled layout(s) for this
+ * MDS in the registry and fence them, then answer NFS4ERR_NOMATCHING_LAYOUT: the
+ * chimera MDS drops the layout and resumes the conflicting operation on any
+ * non-OK reply (NFS4_OK would make it block waiting for a LAYOUTRETURN we are
+ * not in a position to issue from here).  Fencing first guarantees the client
+ * has already stopped using the layout the MDS is about to drop.
+ */
+nfsstat4
+chimera_nfs4_cb_layoutrecall(
+    struct chimera_nfs_shared        *shared,
+    struct chimera_nfs_client_server *server,
+    struct CB_LAYOUTRECALL4args      *args)
+{
+    struct chimera_nfs4_layout *layout;
+    layoutrecall_type4          rtype   = args->clora_recall.lor_recalltype;
+    const uint8_t              *rfh     = NULL;
+    uint32_t                    rfh_len = 0;
+    int                         fenced  = 0;
+
+    if (rtype == LAYOUTRECALL4_FILE) {
+        rfh     = args->clora_recall.lor_layout.lor_fh.data;
+        rfh_len = args->clora_recall.lor_layout.lor_fh.len;
+    }
+
+    pthread_mutex_lock(&shared->pnfs_layout_lock);
+    for (layout = shared->pnfs_layouts; layout; layout = layout->reg_next) {
+        uint8_t *remote_fh;
+        int      remote_fh_len;
+
+        /* Only layouts belonging to the MDS that issued this recall.  The
+         * server index is encoded at byte CHIMERA_VFS_MOUNT_ID_SIZE of the
+         * local file handle. */
+        if (layout->file_fh_len <= CHIMERA_VFS_MOUNT_ID_SIZE ||
+            layout->file_fh[CHIMERA_VFS_MOUNT_ID_SIZE] != server->index) {
+            continue;
+        }
+
+        if (rtype == LAYOUTRECALL4_FILE) {
+            /* Match the remote (MDS) file handle the recall names against the
+             * remote portion of our local handle. */
+            chimera_nfs4_map_fh(layout->file_fh, layout->file_fh_len,
+                                &remote_fh, &remote_fh_len);
+            if ((uint32_t) remote_fh_len != rfh_len ||
+                memcmp(remote_fh, rfh, rfh_len) != 0) {
+                continue;
+            }
+        }
+        /* LAYOUTRECALL4_FSID / _ALL: chimera's MDS only issues FILE recalls,
+         * but fence every layout for this server as a safe superset. */
+
+        chimera_nfs4_cb_fence_layout(layout);
+        fenced++;
+    }
+    pthread_mutex_unlock(&shared->pnfs_layout_lock);
+
+    chimera_nfsclient_info("pNFS CB_LAYOUTRECALL type=%u fenced=%d layout(s) for server %d",
+                           rtype, fenced, server->index);
+
+    /* Whether or not we held it, tell the MDS to drop it (we are not returning
+     * it from the back channel); fencing already stopped our DS I/O. */
+    return NFS4ERR_NOMATCHING_LAYOUT;
+} /* chimera_nfs4_cb_layoutrecall */
+
+static void
+chimera_nfs4_acquire_finish(
+    struct chimera_vfs_request      *request,
+    struct chimera_nfs4_acquire_ctx *actx,
+    int                              valid)
+{
+    struct chimera_nfs4_open_state *open_state = actx->open_state;
+    struct chimera_nfs4_layout     *layout     = &open_state->layout;
+    struct chimera_vfs_request     *waiters, *w, *next;
+
+    /* A now-usable layout joins the registry so a back-channel CB_LAYOUTRECALL
+     * can find and fence it; do this before publishing VALID so a recall that
+     * races the first DS I/O always sees it. */
+    if (valid) {
+        chimera_nfs4_pnfs_layout_register(actx->shared, layout);
+    }
+
+    /* Publish the resolved state, then drain any requests that parked while we
+     * were ACQUIRING.  The lock orders against late parkers in the read/write
+     * path, which re-check the state under the same lock. */
+    atomic_store(&layout->state, valid ? CHIMERA_NFS4_LAYOUT_VALID : CHIMERA_NFS4_LAYOUT_UNAVAIL);
+
+    pthread_mutex_lock(&layout->acq_lock);
+    waiters             = layout->acq_waiters;
+    layout->acq_waiters = NULL;
+    pthread_mutex_unlock(&layout->acq_lock);
+
+    /* The request that triggered acquisition is re-dispatched first. */
+    actx->redispatch(actx->thread, actx->shared, request, actx->private_data);
+
+    for (w = waiters; w; w = next) {
+        next    = w->next;
+        w->next = NULL;
+        chimera_nfs4_pnfs_replay(layout, w);
+    }
+} /* chimera_nfs4_acquire_finish */
+
+static void
+chimera_nfs4_getdeviceinfo_callback(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    struct COMPOUND4res         *res,
+    int                          status,
+    void                        *private_data)
+{
+    struct chimera_vfs_request      *request = private_data;
+    struct chimera_nfs4_acquire_ctx *actx    = request->plugin_data;
+    struct GETDEVICEINFO4res        *gdi;
+    struct chimera_vfs_layout_device dev;
+    char                             host[80];
+    int                              port, ds_version = 3, ds_minorversion = 0;
+    int                              server_index;
+
+    if (unlikely(status) || res->status != NFS4_OK || res->num_resarray < 2) {
+        chimera_nfsclient_error("pNFS GETDEVICEINFO rpc failed: status=%d comp=%d nres=%d",
+                                status, res ? res->status : -1, res ? res->num_resarray : -1);
+        chimera_nfs4_acquire_finish(request, actx, 0);
+        return;
+    }
+
+    gdi = &res->resarray[1].opgetdeviceinfo;
+    if (gdi->gdir_status != NFS4_OK) {
+        chimera_nfsclient_error("pNFS GETDEVICEINFO op failed: gdir_status=%d", gdi->gdir_status);
+        chimera_nfs4_acquire_finish(request, actx, 0);
+        return;
+    }
+
+    if (gdi->gdir_resok4.gdir_device_addr.da_layout_type != CHIMERA_NFS4_LAYOUT4_FLEX_FILES) {
+        chimera_nfsclient_error("pNFS GETDEVICEINFO wrong da_layout_type=%u",
+                                gdi->gdir_resok4.gdir_device_addr.da_layout_type);
+        chimera_nfs4_acquire_finish(request, actx, 0);
+        return;
+    }
+
+    memset(&dev, 0, sizeof(dev));
+    memcpy(dev.deviceid, actx->deviceid, CHIMERA_VFS_DEVICEID_SIZE);
+
+    if (chimera_nfs4_decode_ff_device_addr(
+            gdi->gdir_resok4.gdir_device_addr.da_addr_body.data,
+            gdi->gdir_resok4.gdir_device_addr.da_addr_body.len,
+            &dev, &ds_version, &ds_minorversion) != 0) {
+        chimera_nfsclient_error("pNFS GETDEVICEINFO ff_device_addr decode failed (len=%u)",
+                                gdi->gdir_resok4.gdir_device_addr.da_addr_body.len);
+        chimera_nfs4_acquire_finish(request, actx, 0);
+        return;
+    }
+    chimera_nfsclient_info("pNFS GETDEVICEINFO ok: uaddr=%s ds_version=%d", dev.uaddr, ds_version);
+
+    /* First cut: only NFSv3 data servers are supported. */
+    if (ds_version != 3) {
+        chimera_nfsclient_info("pNFS: DS advertises NFSv%d (only v3 supported); using MDS",
+                               ds_version);
+        chimera_nfs4_acquire_finish(request, actx, 0);
+        return;
+    }
+
+    if (chimera_nfs4_parse_uaddr(dev.uaddr, host, sizeof(host), &port) != 0) {
+        chimera_nfs4_acquire_finish(request, actx, 0);
+        return;
+    }
+
+    server_index = chimera_nfs4_pnfs_register_ds(actx->shared, host, port, ds_version);
+    if (server_index < 0) {
+        chimera_nfs4_acquire_finish(request, actx, 0);
+        return;
+    }
+
+    chimera_nfs4_devcache_put(&actx->shared->pnfs_devcache, &dev, server_index);
+
+    actx->open_state->layout.ds_server_index = server_index;
+    chimera_nfs4_acquire_finish(request, actx, 1);
+} /* chimera_nfs4_getdeviceinfo_callback */
+
+static void
+chimera_nfs4_getdeviceinfo(
+    struct chimera_vfs_request      *request,
+    struct chimera_nfs4_acquire_ctx *actx)
+{
+    struct chimera_nfs_shared               *shared        = actx->shared;
+    struct chimera_nfs_client_server_thread *server_thread = actx->mds_thread;
+    struct chimera_nfs4_client_session      *session       = server_thread->server->nfs4_session;
+    struct COMPOUND4args                     args;
+    struct nfs_argop4                        argarray[2];
+    struct evpl_rpc2_cred                    rpc2_cred;
+
+    memset(&args, 0, sizeof(args));
+    args.minorversion = 1;
+    args.argarray     = argarray;
+    args.num_argarray = 2;
+
+    argarray[0].argop = OP_SEQUENCE;   /* slot fields filled by compound_call */
+
+    argarray[1].argop = OP_GETDEVICEINFO;
+    memcpy(argarray[1].opgetdeviceinfo.gdia_device_id, actx->deviceid, CHIMERA_VFS_DEVICEID_SIZE);
+    argarray[1].opgetdeviceinfo.gdia_layout_type      = CHIMERA_NFS4_LAYOUT4_FLEX_FILES;
+    argarray[1].opgetdeviceinfo.gdia_maxcount         = CHIMERA_NFS4_PNFS_MAXCOUNT;
+    argarray[1].opgetdeviceinfo.gdia_notify_types     = NULL;
+    argarray[1].opgetdeviceinfo.num_gdia_notify_types = 0;
+
+    chimera_nfs_init_rpc2_cred(&rpc2_cred, request->cred,
+                               request->thread->vfs->machine_name,
+                               request->thread->vfs->machine_name_len);
+
+    (void) session;
+
+    chimera_nfs4_compound_call(
+        actx->thread, shared, server_thread, request,
+        &args, &rpc2_cred, 0, 0, NULL, 0, 0,
+        chimera_nfs4_getdeviceinfo_callback, request,
+        chimera_nfs4_getdeviceinfo_retry, request);
+} /* chimera_nfs4_getdeviceinfo */
+
+static void
+chimera_nfs4_layoutget_callback(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    struct COMPOUND4res         *res,
+    int                          status,
+    void                        *private_data)
+{
+    struct chimera_vfs_request      *request    = private_data;
+    struct chimera_nfs4_acquire_ctx *actx       = request->plugin_data;
+    struct chimera_nfs4_open_state  *open_state = actx->open_state;
+    struct LAYOUTGET4res            *lg;
+    struct layout4                  *lo;
+    int                              server_index;
+
+    if (unlikely(status) || res->status != NFS4_OK || res->num_resarray < 3) {
+        chimera_nfsclient_error("pNFS LAYOUTGET rpc failed: status=%d comp=%d nres=%d",
+                                status, res ? res->status : -1, res ? res->num_resarray : -1);
+        chimera_nfs4_acquire_finish(request, actx, 0);
+        return;
+    }
+
+    lg = &res->resarray[2].oplayoutget;
+    if (lg->logr_status != NFS4_OK || lg->logr_resok4.num_logr_layout < 1) {
+        chimera_nfsclient_error("pNFS LAYOUTGET op failed: logr_status=%d num_layout=%d",
+                                lg->logr_status, lg->logr_resok4.num_logr_layout);
+        chimera_nfs4_acquire_finish(request, actx, 0);
+        return;
+    }
+
+    lo = &lg->logr_resok4.logr_layout[0];
+    if (lo->lo_content.loc_type != CHIMERA_NFS4_LAYOUT4_FLEX_FILES) {
+        chimera_nfsclient_error("pNFS LAYOUTGET wrong loc_type=%u", lo->lo_content.loc_type);
+        chimera_nfs4_acquire_finish(request, actx, 0);
+        return;
+    }
+
+    if (chimera_nfs4_decode_ff_layout(lo->lo_content.loc_body.data,
+                                      lo->lo_content.loc_body.len,
+                                      &open_state->layout.segments[0]) != 0) {
+        chimera_nfsclient_error("pNFS LAYOUTGET ff_layout decode failed (body_len=%u)",
+                                lo->lo_content.loc_body.len);
+        chimera_nfs4_acquire_finish(request, actx, 0);
+        return;
+    }
+    chimera_nfsclient_info("pNFS LAYOUTGET ok: iomode=%u ds_fh_len=%u",
+                           lo->lo_iomode, open_state->layout.segments[0].ds_fh_len);
+
+    open_state->layout.segments[0].offset = lo->lo_offset;
+    open_state->layout.segments[0].length = lo->lo_length;
+    open_state->layout.segments[0].iomode = lo->lo_iomode;
+    open_state->layout.num_segments       = 1;
+    open_state->layout.iomode             = lo->lo_iomode;
+    open_state->layout.layout_stateid     = lg->logr_resok4.logr_stateid;
+    open_state->layout.return_on_close    = lg->logr_resok4.logr_return_on_close;
+
+    memcpy(actx->deviceid, open_state->layout.segments[0].deviceid, CHIMERA_VFS_DEVICEID_SIZE);
+
+    /* Device already resolved?  Reuse the cached DS server slot. */
+    if (chimera_nfs4_devcache_find(&actx->shared->pnfs_devcache, actx->deviceid, &server_index)) {
+        open_state->layout.ds_server_index = server_index;
+        chimera_nfs4_acquire_finish(request, actx, 1);
+        return;
+    }
+
+    chimera_nfs4_getdeviceinfo(request, actx);
+} /* chimera_nfs4_layoutget_callback */
+
+static void
+chimera_nfs4_layoutget(
+    struct chimera_vfs_request      *request,
+    struct chimera_nfs4_acquire_ctx *actx)
+{
+    struct chimera_nfs_shared               *shared        = actx->shared;
+    struct chimera_nfs_client_server_thread *server_thread = actx->mds_thread;
+    struct chimera_nfs4_client_session      *session       = server_thread->server->nfs4_session;
+    struct COMPOUND4args                     args;
+    struct nfs_argop4                        argarray[3];
+    struct evpl_rpc2_cred                    rpc2_cred;
+    uint8_t                                 *fh;
+    int                                      fhlen;
+
+    chimera_nfs4_map_fh(request->fh, request->fh_len, &fh, &fhlen);
+
+    /* Stash the file's own local handle so close can address it to the MDS. */
+    memcpy(actx->open_state->layout.file_fh, request->fh, request->fh_len);
+    actx->open_state->layout.file_fh_len = request->fh_len;
+
+    memset(&args, 0, sizeof(args));
+    args.minorversion = 1;
+    args.argarray     = argarray;
+    args.num_argarray = 3;
+
+    argarray[0].argop = OP_SEQUENCE;   /* slot fields filled by compound_call */
+
+    argarray[1].argop               = OP_PUTFH;
+    argarray[1].opputfh.object.data = fh;
+    argarray[1].opputfh.object.len  = fhlen;
+
+    /* Request a whole-file RW layout: it serves both reads and writes, so the
+     * client never has to upgrade a read layout to write. */
+    argarray[2].argop                                = OP_LAYOUTGET;
+    argarray[2].oplayoutget.loga_signal_layout_avail = 0;
+    argarray[2].oplayoutget.loga_layout_type         = CHIMERA_NFS4_LAYOUT4_FLEX_FILES;
+    argarray[2].oplayoutget.loga_iomode              = LAYOUTIOMODE4_RW;
+    argarray[2].oplayoutget.loga_offset              = 0;
+    argarray[2].oplayoutget.loga_length              = UINT64_MAX;
+    argarray[2].oplayoutget.loga_minlength           = 0;
+    memset(&argarray[2].oplayoutget.loga_stateid, 0, sizeof(argarray[2].oplayoutget.loga_stateid));
+    argarray[2].oplayoutget.loga_maxcount = CHIMERA_NFS4_PNFS_MAXCOUNT;
+
+    chimera_nfs_init_rpc2_cred(&rpc2_cred, request->cred,
+                               request->thread->vfs->machine_name,
+                               request->thread->vfs->machine_name_len);
+
+    (void) session;
+
+    chimera_nfs4_compound_call(
+        actx->thread, shared, server_thread, request,
+        &args, &rpc2_cred, 0, 0, NULL, 0, 0,
+        chimera_nfs4_layoutget_callback, request,
+        chimera_nfs4_layoutget_retry, request);
+} /* chimera_nfs4_layoutget */
+
+/*
+ * Kick off layout acquisition.  Caller has already won the NONE->ACQUIRING
+ * transition.  Stores its context in plugin_data and starts LAYOUTGET.
+ */
+static void
+chimera_nfs4_layout_acquire(
+    struct chimera_nfs_thread               *thread,
+    struct chimera_nfs_shared               *shared,
+    struct chimera_vfs_request              *request,
+    void                                    *private_data,
+    struct chimera_nfs_client_server_thread *mds_thread,
+    struct chimera_nfs4_open_state          *open_state,
+    void (                                  *redispatch )(
+        struct chimera_nfs_thread *,
+        struct chimera_nfs_shared *,
+        struct chimera_vfs_request *,
+        void *))
+{
+    struct chimera_nfs4_acquire_ctx *actx = request->plugin_data;
+
+    actx->thread       = thread;
+    actx->shared       = shared;
+    actx->private_data = private_data;
+    actx->mds_thread   = mds_thread;
+    actx->open_state   = open_state;
+    actx->redispatch   = redispatch;
+
+    /* Replay context for any requests that park while this acquisition runs. */
+    open_state->layout.acq_thread  = thread;
+    open_state->layout.acq_shared  = shared;
+    open_state->layout.acq_private = private_data;
+
+    chimera_nfs4_layoutget(request, actx);
+} /* chimera_nfs4_layout_acquire */
+
+/* ---------------------------------------------------------------------------
+* Segment lookup + DS file-handle synthesis.
+* ------------------------------------------------------------------------- */
+
+/*
+ * Return the layout segment fully covering [offset, offset+length), or NULL.
+ * First cut: whole-file single segment, so this is a single containment test.
+ */
+static struct chimera_vfs_layout_segment *
+chimera_nfs4_layout_find_segment(
+    struct chimera_nfs4_layout *layout,
+    uint64_t                    offset,
+    uint64_t                    length)
+{
+    struct chimera_vfs_layout_segment *seg;
+    uint64_t                           seg_end;
+
+    if (layout->num_segments < 1) {
+        return NULL;
+    }
+
+    seg = &layout->segments[0];
+
+    if (offset < seg->offset) {
+        return NULL;
+    }
+
+    if (seg->length != UINT64_MAX) {
+        seg_end = seg->offset + seg->length;
+        if (offset + length > seg_end) {
+            return NULL;
+        }
+    }
+
+    return seg;
+} /* chimera_nfs4_layout_find_segment */
+
+/* Build the synthetic DS file handle [mount_id][ds_index][ds_fh] in `out`. */
+static int
+chimera_nfs4_build_ds_fh(
+    const struct chimera_vfs_request        *request,
+    int                                      ds_server_index,
+    const struct chimera_vfs_layout_segment *seg,
+    uint8_t                                 *out)
+{
+    int len = 0;
+
+    memcpy(out, request->fh, CHIMERA_VFS_MOUNT_ID_SIZE);   /* mount_id (opaque)  */
+    out[CHIMERA_VFS_MOUNT_ID_SIZE] = (uint8_t) ds_server_index;
+    len                            = CHIMERA_VFS_MOUNT_ID_SIZE + 1;
+    memcpy(out + len, seg->ds_fh, seg->ds_fh_len);
+    len += seg->ds_fh_len;
+    return len;
+} /* chimera_nfs4_build_ds_fh */
+
+/* ---------------------------------------------------------------------------
+* DS READ (NFSv3).
+* ------------------------------------------------------------------------- */
+
+static void
+chimera_nfs4_pnfs_ds_read_callback(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    struct READ3res             *res,
+    int                          status,
+    void                        *private_data)
+{
+    struct chimera_vfs_request *request = private_data;
+
+    if (unlikely(status)) {
+        request->status = CHIMERA_VFS_EFAULT;
+        request->complete(request);
+        return;
+    }
+
+    if (res->status != NFS3_OK) {
+        request->status = nfs3_client_status_to_chimera_vfs_error(res->status);
+        request->complete(request);
+        return;
+    }
+
+    request->read.r_length = res->resok.count;
+    request->read.r_eof    = res->resok.eof;
+    request->read.r_niov   = res->resok.data.niov;
+    request->read.iov      = res->resok.data.iov;
+    request->status        = CHIMERA_VFS_OK;
+    request->complete(request);
+} /* chimera_nfs4_pnfs_ds_read_callback */
+
+static int
+chimera_nfs4_pnfs_ds_read(
+    struct chimera_nfs_thread         *thread,
+    struct chimera_nfs_shared         *shared,
+    struct chimera_vfs_request        *request,
+    struct chimera_vfs_layout_segment *seg,
+    int                                ds_server_index)
+{
+    struct chimera_nfs_client_server_thread *ds_thread;
+    struct READ3args                         args;
+    struct evpl_rpc2_cred                    rpc2_cred;
+    uint8_t                                  ds_fh[CHIMERA_NFS4_DS_FH_MAX];
+    int                                      ds_fhlen;
+    struct evpl_iovec                       *write_chunk_iov  = NULL;
+    int                                      write_chunk_niov = 0;
+
+    ds_fhlen  = chimera_nfs4_build_ds_fh(request, ds_server_index, seg, ds_fh);
+    ds_thread = chimera_nfs_thread_get_server_thread(thread, ds_fh, ds_fhlen);
+
+    if (!ds_thread || !ds_thread->nfs_conn) {
+        return 0;       /* DS unreachable: caller falls back to MDS. */
+    }
+
+    args.file.data.data = seg->ds_fh;
+    args.file.data.len  = seg->ds_fh_len;
+    args.offset         = request->read.offset;
+    args.count          = request->read.length;
+
+    chimera_nfs_init_rpc2_cred(&rpc2_cred, request->cred,
+                               request->thread->vfs->machine_name,
+                               request->thread->vfs->machine_name_len);
+
+    if (ds_thread->nfs_conn->rdma && request->read.dest_provided &&
+        request->read.dest_niov == 1) {
+        write_chunk_iov              = request->read.dest_iov;
+        write_chunk_niov             = request->read.dest_niov;
+        request->read.landed_in_dest = 1;
+    }
+
+    shared->nfs_v3.send_call_NFSPROC3_READ(
+        &shared->nfs_v3.rpc2, thread->evpl, ds_thread->nfs_conn, &rpc2_cred,
+        &args, 0, request->read.length, write_chunk_iov, write_chunk_niov, 0,
+        chimera_nfs4_pnfs_ds_read_callback, request);
+    return 1;
+} /* chimera_nfs4_pnfs_ds_read */
+
+/* ---------------------------------------------------------------------------
+* DS WRITE (NFSv3).
+* ------------------------------------------------------------------------- */
+
+struct chimera_nfs4_pnfs_ds_write_ctx {
+    struct chimera_nfs4_open_state *open_state;
+    uint64_t                        end_offset;   /* offset + length */
+};
+
+static void
+chimera_nfs4_pnfs_ds_write_callback(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    struct WRITE3res            *res,
+    int                          status,
+    void                        *private_data)
+{
+    struct chimera_vfs_request            *request = private_data;
+    struct chimera_nfs4_pnfs_ds_write_ctx *ctx     = request->plugin_data;
+    struct chimera_nfs4_layout            *layout  = &ctx->open_state->layout;
+    uint64_t                               cur;
+
+    if (unlikely(status)) {
+        chimera_nfsclient_error("pNFS DS write rpc failed: status=%d", status);
+        request->status = CHIMERA_VFS_EFAULT;
+        request->complete(request);
+        return;
+    }
+
+    if (res->status != NFS3_OK) {
+        chimera_nfsclient_error("pNFS DS write NFS3 error: status=%d", res->status);
+        request->status = nfs3_client_status_to_chimera_vfs_error(res->status);
+        request->complete(request);
+        return;
+    }
+
+    /* Data lives on the DS; the MDS only learns the new file size when the
+     * client reports it via LAYOUTCOMMIT (the layout leaves NO_LAYOUTCOMMIT
+     * clear).  Track the high-water mark (atomic max, races with sibling
+     * writes) and remember to commit on close. */
+    cur = atomic_load(&layout->last_write_offset);
+    while (ctx->end_offset > cur &&
+           !atomic_compare_exchange_weak(&layout->last_write_offset, &cur, ctx->end_offset)) {
+        /* cur reloaded by compare_exchange_weak; retry until our value is not
+         * larger or the swap wins. */
+    }
+    layout->layoutcommit_needed = 1;
+
+    request->write.r_sync   = res->resok.committed;
+    request->write.r_length = res->resok.count;
+    request->status         = CHIMERA_VFS_OK;
+    request->complete(request);
+} /* chimera_nfs4_pnfs_ds_write_callback */
+
+static int
+chimera_nfs4_pnfs_ds_write(
+    struct chimera_nfs_thread         *thread,
+    struct chimera_nfs_shared         *shared,
+    struct chimera_vfs_request        *request,
+    struct chimera_nfs4_open_state    *open_state,
+    struct chimera_vfs_layout_segment *seg,
+    int                                ds_server_index)
+{
+    struct chimera_nfs_client_server_thread *ds_thread;
+    struct chimera_nfs4_pnfs_ds_write_ctx   *ctx;
+    struct WRITE3args                        args;
+    struct evpl_rpc2_cred                    rpc2_cred;
+    uint8_t                                  ds_fh[CHIMERA_NFS4_DS_FH_MAX];
+    int                                      ds_fhlen;
+
+    ds_fhlen  = chimera_nfs4_build_ds_fh(request, ds_server_index, seg, ds_fh);
+    ds_thread = chimera_nfs_thread_get_server_thread(thread, ds_fh, ds_fhlen);
+
+    if (!ds_thread || !ds_thread->nfs_conn) {
+        chimera_nfsclient_error("pNFS DS write: DS server %d unreachable, using MDS", ds_server_index);
+        return 0;       /* DS unreachable: caller falls back to MDS. */
+    }
+
+    chimera_nfsclient_debug("pNFS DS write -> server %d off=%lu len=%u",
+                            ds_server_index, request->write.offset, request->write.length);
+
+    ctx             = request->plugin_data;
+    ctx->open_state = open_state;
+    ctx->end_offset = request->write.offset + request->write.length;
+
+    args.file.data.data = seg->ds_fh;
+    args.file.data.len  = seg->ds_fh_len;
+    args.offset         = request->write.offset;
+    args.count          = request->write.length;
+    args.stable         = request->write.sync;
+    args.data.iov       = request->write.iov;
+    args.data.niov      = request->write.niov;
+    args.data.length    = request->write.length;
+
+    chimera_nfs_init_rpc2_cred(&rpc2_cred, request->cred,
+                               request->thread->vfs->machine_name,
+                               request->thread->vfs->machine_name_len);
+
+    shared->nfs_v3.send_call_NFSPROC3_WRITE(
+        &shared->nfs_v3.rpc2, thread->evpl, ds_thread->nfs_conn, &rpc2_cred,
+        &args, 1, 0, NULL, 0, 0, chimera_nfs4_pnfs_ds_write_callback, request);
+    return 1;
+} /* chimera_nfs4_pnfs_ds_write */
+
+/* ---------------------------------------------------------------------------
+* Read/write redirect entry points (called from chimera_nfs4_read/write).
+* ------------------------------------------------------------------------- */
+
+/*
+ * Try to park `request` while a layout acquisition is in flight.  Returns 1 if
+ * the request was parked (it will be replayed when acquisition resolves), or 0
+ * if acquisition already finished (the caller should re-evaluate the now-final
+ * state).  Parking, rather than falling back to the MDS, is required: an MDS
+ * I/O here would land a compound on the same NFSv4.1 session slot as the
+ * in-flight LAYOUTGET/GETDEVICEINFO and be rejected as NFS4ERR_SEQ_MISORDERED.
+ */
+static int
+chimera_nfs4_pnfs_try_park(
+    struct chimera_nfs4_layout *layout,
+    struct chimera_vfs_request *request)
+{
+    int parked = 0;
+
+    pthread_mutex_lock(&layout->acq_lock);
+    if (atomic_load(&layout->state) == CHIMERA_NFS4_LAYOUT_ACQUIRING) {
+        request->next       = layout->acq_waiters;
+        layout->acq_waiters = request;
+        parked              = 1;
+    }
+    pthread_mutex_unlock(&layout->acq_lock);
+
+    return parked;
+} /* chimera_nfs4_pnfs_try_park */
+
+int
+chimera_nfs4_pnfs_read(
+    struct chimera_nfs_thread               *thread,
+    struct chimera_nfs_shared               *shared,
+    struct chimera_vfs_request              *request,
+    void                                    *private_data,
+    struct chimera_nfs_client_server_thread *server_thread,
+    struct chimera_nfs4_open_state          *open_state)
+{
+    struct chimera_nfs4_layout        *layout = &open_state->layout;
+    struct chimera_vfs_layout_segment *seg;
+    int                                expected;
+
+    if (!server_thread->server->mds_pnfs_capable) {
+        return 0;
+    }
+
+    for ( ;;) {
+        switch (atomic_load(&layout->state)) {
+            case CHIMERA_NFS4_LAYOUT_VALID:
+                seg = chimera_nfs4_layout_find_segment(layout, request->read.offset, request->read.length);
+                if (!seg || layout->ds_server_index < 0) {
+                    return 0;
+                }
+                return chimera_nfs4_pnfs_ds_read(thread, shared, request, seg, layout->ds_server_index);
+
+            case CHIMERA_NFS4_LAYOUT_NONE:
+                expected = CHIMERA_NFS4_LAYOUT_NONE;
+                if (atomic_compare_exchange_strong(&layout->state, &expected, CHIMERA_NFS4_LAYOUT_ACQUIRING)) {
+                    chimera_nfs4_layout_acquire(thread, shared, request, private_data,
+                                                server_thread, open_state, chimera_nfs4_read);
+                    return 1;
+                }
+                continue;       /* lost the race; re-evaluate (now ACQUIRING). */
+
+            case CHIMERA_NFS4_LAYOUT_ACQUIRING:
+                if (chimera_nfs4_pnfs_try_park(layout, request)) {
+                    return 1;
+                }
+                continue;       /* acquisition just resolved; re-evaluate. */
+
+            default:            /* UNAVAIL */
+                return 0;
+        } /* switch */
+    }
+} /* chimera_nfs4_pnfs_read */
+
+int
+chimera_nfs4_pnfs_write(
+    struct chimera_nfs_thread               *thread,
+    struct chimera_nfs_shared               *shared,
+    struct chimera_vfs_request              *request,
+    void                                    *private_data,
+    struct chimera_nfs_client_server_thread *server_thread,
+    struct chimera_nfs4_open_state          *open_state)
+{
+    struct chimera_nfs4_layout        *layout = &open_state->layout;
+    struct chimera_vfs_layout_segment *seg;
+    int                                expected;
+
+    if (!server_thread->server->mds_pnfs_capable) {
+        return 0;
+    }
+
+    for ( ;;) {
+        switch (atomic_load(&layout->state)) {
+            case CHIMERA_NFS4_LAYOUT_VALID:
+                if (layout->iomode != LAYOUTIOMODE4_RW) {
+                    return 0;       /* read-only layout: write through the MDS. */
+                }
+                seg = chimera_nfs4_layout_find_segment(layout, request->write.offset, request->write.length);
+                if (!seg || layout->ds_server_index < 0) {
+                    return 0;
+                }
+                return chimera_nfs4_pnfs_ds_write(thread, shared, request, open_state, seg, layout->ds_server_index);
+
+            case CHIMERA_NFS4_LAYOUT_NONE:
+                expected = CHIMERA_NFS4_LAYOUT_NONE;
+                if (atomic_compare_exchange_strong(&layout->state, &expected, CHIMERA_NFS4_LAYOUT_ACQUIRING)) {
+                    chimera_nfs4_layout_acquire(thread, shared, request, private_data,
+                                                server_thread, open_state, chimera_nfs4_write);
+                    return 1;
+                }
+                continue;
+
+            case CHIMERA_NFS4_LAYOUT_ACQUIRING:
+                if (chimera_nfs4_pnfs_try_park(layout, request)) {
+                    return 1;
+                }
+                continue;
+
+            default:            /* UNAVAIL */
+                return 0;
+        } /* switch */
+    }
+} /* chimera_nfs4_pnfs_write */
+
+/* ---------------------------------------------------------------------------
+* Close-time LAYOUTCOMMIT + LAYOUTRETURN.
+* ------------------------------------------------------------------------- */
+
+struct chimera_nfs4_pnfs_close_ctx {
+    struct chimera_nfs_thread               *thread;
+    struct chimera_nfs_shared               *shared;
+    struct chimera_nfs_client_server_thread *mds_thread;
+    struct chimera_nfs4_open_state          *open_state;
+};
+
+static void chimera_nfs4_pnfs_layoutreturn(
+    struct chimera_vfs_request *request);
+
+static void
+chimera_nfs4_pnfs_close_done(struct chimera_vfs_request *request)
+{
+    struct chimera_nfs4_pnfs_close_ctx *cctx = request->plugin_data;
+
+    chimera_nfs4_open_state_free(cctx->open_state);
+    request->status = CHIMERA_VFS_OK;
+    request->complete(request);
+} /* chimera_nfs4_pnfs_close_done */
+
+static void
+chimera_nfs4_pnfs_layoutreturn_callback(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    struct COMPOUND4res         *res,
+    int                          status,
+    void                        *private_data)
+{
+    /* LAYOUTRETURN result is advisory at close: whether or not the MDS accepted
+     * it, the client is done with the layout.  Always finish the close. */
+    chimera_nfs4_pnfs_close_done(private_data);
+} /* chimera_nfs4_pnfs_layoutreturn_callback */
+
+static void
+chimera_nfs4_pnfs_layoutcommit_callback(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    struct COMPOUND4res         *res,
+    int                          status,
+    void                        *private_data)
+{
+    /* Commit is best-effort; proceed to return the layout regardless. */
+    chimera_nfsclient_info("pNFS LAYOUTCOMMIT done: rpc=%d comp=%d", status, res ? res->status : -1);
+    chimera_nfs4_pnfs_layoutreturn(private_data);
+} /* chimera_nfs4_pnfs_layoutcommit_callback */
+
+static void
+chimera_nfs4_pnfs_layoutreturn(struct chimera_vfs_request *request)
+{
+    struct chimera_nfs4_pnfs_close_ctx      *cctx          = request->plugin_data;
+    struct chimera_nfs_shared               *shared        = cctx->shared;
+    struct chimera_nfs_client_server_thread *server_thread = cctx->mds_thread;
+    struct chimera_nfs4_client_session      *session       = server_thread->server->nfs4_session;
+    struct chimera_nfs4_layout              *layout        = &cctx->open_state->layout;
+    struct COMPOUND4args                     args;
+    struct nfs_argop4                        argarray[3];
+    struct evpl_rpc2_cred                    rpc2_cred;
+    uint8_t                                 *fh;
+    int                                      fhlen;
+
+    chimera_nfs4_map_fh(layout->file_fh, layout->file_fh_len, &fh, &fhlen);
+
+    memset(&args, 0, sizeof(args));
+    args.minorversion = 1;
+    args.argarray     = argarray;
+    args.num_argarray = 3;
+
+    argarray[0].argop = OP_SEQUENCE;   /* slot fields filled by compound_call */
+
+    argarray[1].argop               = OP_PUTFH;
+    argarray[1].opputfh.object.data = fh;
+    argarray[1].opputfh.object.len  = fhlen;
+
+    argarray[2].argop                                                    = OP_LAYOUTRETURN;
+    argarray[2].oplayoutreturn.lora_reclaim                              = 0;
+    argarray[2].oplayoutreturn.lora_layout_type                          = CHIMERA_NFS4_LAYOUT4_FLEX_FILES;
+    argarray[2].oplayoutreturn.lora_iomode                               = LAYOUTIOMODE4_ANY;
+    argarray[2].oplayoutreturn.lora_layoutreturn.lr_returntype           = LAYOUTRETURN4_FILE;
+    argarray[2].oplayoutreturn.lora_layoutreturn.lr_layout.lrf_offset    = 0;
+    argarray[2].oplayoutreturn.lora_layoutreturn.lr_layout.lrf_length    = UINT64_MAX;
+    argarray[2].oplayoutreturn.lora_layoutreturn.lr_layout.lrf_stateid   = layout->layout_stateid;
+    argarray[2].oplayoutreturn.lora_layoutreturn.lr_layout.lrf_body.data = NULL;
+    argarray[2].oplayoutreturn.lora_layoutreturn.lr_layout.lrf_body.len  = 0;
+
+    chimera_nfs_init_rpc2_cred(&rpc2_cred, request->cred,
+                               request->thread->vfs->machine_name,
+                               request->thread->vfs->machine_name_len);
+
+    (void) session;
+
+    chimera_nfs4_compound_call(
+        cctx->thread, shared, server_thread, request,
+        &args, &rpc2_cred, 0, 0, NULL, 0, 0,
+        chimera_nfs4_pnfs_layoutreturn_callback, request,
+        chimera_nfs4_layoutreturn_retry, request);
+} /* chimera_nfs4_pnfs_layoutreturn */
+
+static void
+chimera_nfs4_pnfs_layoutcommit(struct chimera_vfs_request *request)
+{
+    struct chimera_nfs4_pnfs_close_ctx      *cctx          = request->plugin_data;
+    struct chimera_nfs_shared               *shared        = cctx->shared;
+    struct chimera_nfs_client_server_thread *server_thread = cctx->mds_thread;
+    struct chimera_nfs4_client_session      *session       = server_thread->server->nfs4_session;
+    struct chimera_nfs4_layout              *layout        = &cctx->open_state->layout;
+    struct COMPOUND4args                     args;
+    struct nfs_argop4                        argarray[3];
+    struct evpl_rpc2_cred                    rpc2_cred;
+    uint8_t                                 *fh;
+    int                                      fhlen;
+    uint64_t                                 high;
+
+    chimera_nfs4_map_fh(layout->file_fh, layout->file_fh_len, &fh, &fhlen);
+
+    memset(&args, 0, sizeof(args));
+    args.minorversion = 1;
+    args.argarray     = argarray;
+    args.num_argarray = 3;
+
+    argarray[0].argop = OP_SEQUENCE;   /* slot fields filled by compound_call */
+
+    argarray[1].argop               = OP_PUTFH;
+    argarray[1].opputfh.object.data = fh;
+    argarray[1].opputfh.object.len  = fhlen;
+
+    argarray[2].argop                       = OP_LAYOUTCOMMIT;
+    argarray[2].oplayoutcommit.loca_offset  = 0;
+    argarray[2].oplayoutcommit.loca_length  = UINT64_MAX;
+    argarray[2].oplayoutcommit.loca_reclaim = 0;
+    argarray[2].oplayoutcommit.loca_stateid = layout->layout_stateid;
+    /* Report the last byte written so the MDS can set the file size. */
+    high                                                           = atomic_load(&layout->last_write_offset);
+    argarray[2].oplayoutcommit.loca_last_write_offset.no_newoffset = 1;
+    argarray[2].oplayoutcommit.loca_last_write_offset.no_offset    = high ? high - 1 : 0;
+    argarray[2].oplayoutcommit.loca_time_modify.nt_timechanged     = 0;
+    argarray[2].oplayoutcommit.loca_layoutupdate.lou_type          = CHIMERA_NFS4_LAYOUT4_FLEX_FILES;
+    argarray[2].oplayoutcommit.loca_layoutupdate.lou_body.data     = NULL;
+    argarray[2].oplayoutcommit.loca_layoutupdate.lou_body.len      = 0;
+
+    chimera_nfs_init_rpc2_cred(&rpc2_cred, request->cred,
+                               request->thread->vfs->machine_name,
+                               request->thread->vfs->machine_name_len);
+
+    (void) session;
+
+    chimera_nfs4_compound_call(
+        cctx->thread, shared, server_thread, request,
+        &args, &rpc2_cred, 0, 0, NULL, 0, 0,
+        chimera_nfs4_pnfs_layoutcommit_callback, request,
+        chimera_nfs4_layoutcommit_retry, request);
+} /* chimera_nfs4_pnfs_layoutcommit */
+
+int
+chimera_nfs4_pnfs_close(
+    struct chimera_nfs_thread      *thread,
+    struct chimera_nfs_shared      *shared,
+    struct chimera_vfs_request     *request,
+    struct chimera_nfs4_open_state *open_state)
+{
+    struct chimera_nfs4_layout              *layout = &open_state->layout;
+    struct chimera_nfs_client_server_thread *mds_thread;
+    struct chimera_nfs4_pnfs_close_ctx      *cctx;
+
+    if (atomic_load(&layout->state) != CHIMERA_NFS4_LAYOUT_VALID ||
+        layout->file_fh_len == 0) {
+        return 0;       /* no layout held: caller frees + completes. */
+    }
+
+    mds_thread = chimera_nfs_thread_get_server_thread(thread, layout->file_fh, layout->file_fh_len);
+    if (!mds_thread || !mds_thread->nfs_conn || !mds_thread->server->nfs4_session) {
+        return 0;
+    }
+
+    cctx             = request->plugin_data;
+    cctx->thread     = thread;
+    cctx->shared     = shared;
+    cctx->mds_thread = mds_thread;
+    cctx->open_state = open_state;
+
+    if (layout->layoutcommit_needed) {
+        chimera_nfs4_pnfs_layoutcommit(request);
+    } else {
+        chimera_nfs4_pnfs_layoutreturn(request);
+    }
+    return 1;
+} /* chimera_nfs4_pnfs_close */

--- a/src/vfs/nfs/nfs4_pnfs.c
+++ b/src/vfs/nfs/nfs4_pnfs.c
@@ -203,16 +203,24 @@ chimera_nfs4_decode_ff_layout(
  * netaddr4 {netid, uaddr} and the first ff_version entry (NFS version the DS
  * speaks).  Returns 0 on success.
  */
+static inline int
+chimera_nfs4_netid_is_rdma(const char *netid)
+{
+    return strcmp(netid, "rdma") == 0 || strcmp(netid, "rdma6") == 0;
+} /* chimera_nfs4_netid_is_rdma */
+
 static int
 chimera_nfs4_decode_ff_device_addr(
     const void                       *body,
     uint32_t                          body_len,
     struct chimera_vfs_layout_device *dev,
     int                              *ds_version,
-    int                              *ds_minorversion)
+    int                              *ds_minorversion,
+    int                               prefer_rdma)
 {
     struct pnfs_cursor c;
-    uint32_t           num_addrs, num_vers, netid_len, uaddr_len;
+    uint32_t           num_addrs, num_vers, i;
+    int                have = 0, ideal = 0;
 
     pnfs_cursor_init(&c, body, body_len);
 
@@ -221,16 +229,44 @@ chimera_nfs4_decode_ff_device_addr(
         return -1;
     }
 
-    netid_len = 0;
-    pnfs_get_opaque(&c, dev->netid, sizeof(dev->netid) - 1, &netid_len);
-    dev->netid[netid_len < sizeof(dev->netid) ? netid_len : 0] = '\0';
+    /* The server may advertise several transports for one DS (e.g. rdma + tcp).
+     * Consume them all (to stay aligned) and keep the preferred one: an RDMA
+     * netaddr when prefer_rdma, otherwise a non-RDMA (tcp) one.  Falls back to
+     * the first usable netaddr if the preferred class is not offered. */
+    for (i = 0; i < num_addrs; i++) {
+        char     netid_tmp[sizeof(dev->netid)];
+        char     uaddr_tmp[sizeof(dev->uaddr)];
+        uint32_t netid_len = 0, uaddr_len = 0;
+        int      preferred;
 
-    uaddr_len = 0;
-    pnfs_get_opaque(&c, dev->uaddr, sizeof(dev->uaddr) - 1, &uaddr_len);
-    if (c.err || uaddr_len == 0 || uaddr_len >= sizeof(dev->uaddr)) {
+        pnfs_get_opaque(&c, netid_tmp, sizeof(netid_tmp) - 1, &netid_len);
+        netid_tmp[netid_len < sizeof(netid_tmp) ? netid_len : 0] = '\0';
+
+        pnfs_get_opaque(&c, uaddr_tmp, sizeof(uaddr_tmp) - 1, &uaddr_len);
+        if (c.err) {
+            return -1;
+        }
+        if (uaddr_len == 0 || uaddr_len >= sizeof(uaddr_tmp)) {
+            continue;       /* unusable address; skip but stay aligned */
+        }
+        uaddr_tmp[uaddr_len] = '\0';
+
+        preferred = prefer_rdma ? chimera_nfs4_netid_is_rdma(netid_tmp)
+                                : !chimera_nfs4_netid_is_rdma(netid_tmp);
+
+        if (!have || (preferred && !ideal)) {
+            snprintf(dev->netid, sizeof(dev->netid), "%s", netid_tmp);
+            snprintf(dev->uaddr, sizeof(dev->uaddr), "%s", uaddr_tmp);
+            have = 1;
+            if (preferred) {
+                ideal = 1;
+            }
+        }
+    }
+
+    if (!have) {
         return -1;
     }
-    dev->uaddr[uaddr_len] = '\0';
 
     num_vers = pnfs_get_u32(&c);                   /* ffda_versions<>            */
     if (c.err || num_vers < 1) {
@@ -363,7 +399,9 @@ chimera_nfs4_pnfs_register_ds(
     struct chimera_nfs_shared *shared,
     const char                *host,
     int                        port,
-    int                        version)
+    int                        version,
+    int                        use_rdma,
+    enum evpl_protocol_id      rdma_protocol)
 {
     struct chimera_nfs_client_server **new_servers, *server;
     int                                i, idx = -1;
@@ -402,14 +440,16 @@ chimera_nfs4_pnfs_register_ds(
         return -1;
     }
 
-    server           = calloc(1, sizeof(*server));
-    server->shared   = shared;
-    server->state    = CHIMERA_NFS_CLIENT_SERVER_STATE_DISCOVERED;
-    server->refcnt   = 1;
-    server->nfsvers  = version ? version : 3;
-    server->is_ds    = 1;
-    server->index    = idx;
-    server->nfs_port = port;
+    server                = calloc(1, sizeof(*server));
+    server->shared        = shared;
+    server->state         = CHIMERA_NFS_CLIENT_SERVER_STATE_DISCOVERED;
+    server->refcnt        = 1;
+    server->nfsvers       = version ? version : 3;
+    server->is_ds         = 1;
+    server->index         = idx;
+    server->nfs_port      = port;
+    server->use_rdma      = use_rdma;
+    server->rdma_protocol = use_rdma ? rdma_protocol : 0;
     snprintf(server->hostname, sizeof(server->hostname), "%s", host);
 
     server->nfs_endpoint = evpl_endpoint_create(server->hostname, server->nfs_port);
@@ -418,8 +458,8 @@ chimera_nfs4_pnfs_register_ds(
 
     pthread_mutex_unlock(&shared->lock);
 
-    chimera_nfsclient_info("pNFS: registered DS %s:%d as server index %d (v%d)",
-                           host, port, idx, server->nfsvers);
+    chimera_nfsclient_info("pNFS: registered DS %s:%d as server index %d (v%d, %s)",
+                           host, port, idx, server->nfsvers, use_rdma ? "rdma" : "tcp");
 
     return idx;
 } /* chimera_nfs4_pnfs_register_ds */
@@ -697,6 +737,10 @@ chimera_nfs4_getdeviceinfo_callback(
     char                             host[80];
     int                              port, ds_version = 3, ds_minorversion = 0;
     int                              server_index;
+    /* Prefer an RDMA data path when the MDS was mounted over RDMA; the device
+     * may advertise both an rdma and a tcp netaddr, and we pick accordingly. */
+    int                              prefer_rdma = actx->mds_thread->server->use_rdma;
+    int                              ds_use_rdma;
 
     if (unlikely(status) || res->status != NFS4_OK || res->num_resarray < 2) {
         chimera_nfsclient_error("pNFS GETDEVICEINFO rpc failed: status=%d comp=%d nres=%d",
@@ -725,13 +769,15 @@ chimera_nfs4_getdeviceinfo_callback(
     if (chimera_nfs4_decode_ff_device_addr(
             gdi->gdir_resok4.gdir_device_addr.da_addr_body.data,
             gdi->gdir_resok4.gdir_device_addr.da_addr_body.len,
-            &dev, &ds_version, &ds_minorversion) != 0) {
+            &dev, &ds_version, &ds_minorversion, prefer_rdma) != 0) {
         chimera_nfsclient_error("pNFS GETDEVICEINFO ff_device_addr decode failed (len=%u)",
                                 gdi->gdir_resok4.gdir_device_addr.da_addr_body.len);
         chimera_nfs4_acquire_finish(request, actx, 0);
         return;
     }
-    chimera_nfsclient_info("pNFS GETDEVICEINFO ok: uaddr=%s ds_version=%d", dev.uaddr, ds_version);
+    ds_use_rdma = chimera_nfs4_netid_is_rdma(dev.netid);
+    chimera_nfsclient_info("pNFS GETDEVICEINFO ok: netid=%s uaddr=%s ds_version=%d",
+                           dev.netid, dev.uaddr, ds_version);
 
     /* First cut: only NFSv3 data servers are supported. */
     if (ds_version != 3) {
@@ -746,7 +792,9 @@ chimera_nfs4_getdeviceinfo_callback(
         return;
     }
 
-    server_index = chimera_nfs4_pnfs_register_ds(actx->shared, host, port, ds_version);
+    server_index = chimera_nfs4_pnfs_register_ds(actx->shared, host, port, ds_version,
+                                                 ds_use_rdma,
+                                                 actx->mds_thread->server->rdma_protocol);
     if (server_index < 0) {
         chimera_nfs4_acquire_finish(request, actx, 0);
         return;

--- a/src/vfs/nfs/nfs4_pnfs.h
+++ b/src/vfs/nfs/nfs4_pnfs.h
@@ -1,0 +1,150 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#pragma once
+
+/*
+ * NFSv4.1 pNFS CLIENT support (flex-files, RFC 8435).
+ *
+ * The chimera NFS4 client is a VFS proxy module.  When pNFS is enabled on a
+ * mount and the metadata server (MDS) confirms USE_PNFS_MDS, the client fetches
+ * a flex-files layout for a file (LAYOUTGET), resolves the data server it points
+ * at (GETDEVICEINFO), and then drives READ/WRITE straight to that data server
+ * (DS) over NFSv3 -- a DS is modeled as another dynamically-registered
+ * chimera_nfs_client_server, so DS I/O reuses the existing v3 send path.  On
+ * close the client reports the new high-water mark back to the MDS
+ * (LAYOUTCOMMIT) and returns the layout (LAYOUTRETURN).
+ *
+ * pNFS is a pure optimization overlay: whenever it is disabled, the MDS is not
+ * pNFS-capable, no usable layout exists, or any step fails, the client behaves
+ * exactly as the non-pNFS path and issues the I/O to the MDS.
+ *
+ * The opaque loc_body (ff_layout4) and da_addr_body (ff_device_addr4) are
+ * hand-decoded here, the read-side inverse of the server's hand-encoders in
+ * src/server/nfs/nfs4_pnfs.c (the flex-files XDR is not in the generated
+ * nfs4.x).  Block-layout decoding is intentionally deferred (Phase 2).
+ */
+
+#include <stdint.h>
+#include <stdatomic.h>
+#include <pthread.h>
+
+#include "vfs/vfs.h"
+#include "vfs/vfs_pnfs.h"     /* chimera_vfs_layout_segment / _device, classes */
+#include "nfs4_xdr.h"         /* struct stateid4 */
+
+/* Layout-type wire constants.  LAYOUT4_BLOCK_VOLUME is in the generated
+ * layouttype4 enum; flex-files (0x4) is not, so define it explicitly exactly as
+ * the server does. */
+#define CHIMERA_NFS4_LAYOUT4_FLEX_FILES   0x4
+#define CHIMERA_NFS4_LAYOUT4_BLOCK_VOLUME 0x3
+
+/* First cut: chimera's MDS hands out whole-file, single-mirror, single-DS
+* flex-files layouts, so one segment is all the client tracks per file. */
+#define CHIMERA_NFS4_CLIENT_MAX_SEGMENTS  1
+
+/* Per-file layout-acquisition state (atomic, drives one-shot LAYOUTGET). */
+enum chimera_nfs4_layout_acq_state {
+    CHIMERA_NFS4_LAYOUT_NONE      = 0,  /* calloc zero: not yet attempted     */
+    CHIMERA_NFS4_LAYOUT_ACQUIRING = 1,  /* a LAYOUTGET is in flight           */
+    CHIMERA_NFS4_LAYOUT_VALID     = 2,  /* layout + device resolved, usable   */
+    CHIMERA_NFS4_LAYOUT_UNAVAIL   = 3,  /* sticky: acquisition failed, use MDS */
+};
+
+/*
+ * Per-open-file decoded layout, embedded in chimera_nfs4_open_state.  Embedded
+ * (not a pointer) so allocation never races across threads; the `state` field
+ * gates concurrent first-touch with an atomic compare-exchange.
+ */
+struct chimera_nfs4_layout {
+    atomic_int                        state;        /* enum ..._acq_state       */
+    uint32_t                          iomode;       /* LAYOUTIOMODE4 we hold    */
+    struct stateid4                   layout_stateid; /* from LAYOUTGET          */
+    uint32_t                          num_segments;
+    struct chimera_vfs_layout_segment segments[CHIMERA_NFS4_CLIENT_MAX_SEGMENTS];
+    int                               ds_server_index; /* resolved DS server slot */
+    int                               return_on_close;
+    int                               layoutcommit_needed;
+    /* Highest byte+1 written via the DS, reported to the MDS at LAYOUTCOMMIT.
+     * Atomic because concurrent writes on a shared open handle each update it;
+     * losing the max would truncate the file size the MDS records. */
+    _Atomic uint64_t                  last_write_offset;
+
+    /* The file's own local handle, captured at LAYOUTGET, so close can PUTFH it
+     * to the MDS for LAYOUTCOMMIT/LAYOUTRETURN (close carries no fh). */
+    uint8_t                           file_fh[CHIMERA_VFS_FH_SIZE];
+    uint32_t                          file_fh_len;
+
+    /* Membership in shared->pnfs_layouts (the layout registry), so the
+     * back-channel CB_LAYOUTRECALL handler can find this layout by file handle
+     * and fence its DS I/O.  Guarded by shared->pnfs_layout_lock. */
+    int                               registered;
+    struct chimera_nfs4_layout       *reg_next;
+
+    /* While state == ACQUIRING, concurrent read/write requests for this file
+     * are parked here (linked via request->next) instead of being sent to the
+     * MDS -- a fallback would inject a compound on the same NFSv4.1 session slot
+     * as the in-flight LAYOUTGET/GETDEVICEINFO and the server would reject the
+     * out-of-order seqid (NFS4ERR_SEQ_MISORDERED).  They are replayed once
+     * acquisition resolves.  acq_thread/shared/private are the dispatch context
+     * captured when acquisition started, used to replay parked requests. */
+    pthread_mutex_t                   acq_lock;
+    struct chimera_vfs_request       *acq_waiters;
+    struct chimera_nfs_thread        *acq_thread;
+    struct chimera_nfs_shared        *acq_shared;
+    void                             *acq_private;
+};
+
+struct chimera_nfs_thread;
+struct chimera_nfs_shared;
+struct chimera_nfs_client_server_thread;
+struct chimera_nfs4_open_state;
+
+/*
+ * Read/write redirect entry points.  Each returns 1 if it took ownership of the
+ * request (a DS I/O was issued, or a layout acquisition was kicked off and the
+ * request will be re-dispatched on completion), or 0 if the caller should fall
+ * back to issuing the I/O to the MDS.  server_thread is the MDS server thread.
+ */
+int chimera_nfs4_pnfs_read(
+    struct chimera_nfs_thread               *thread,
+    struct chimera_nfs_shared               *shared,
+    struct chimera_vfs_request              *request,
+    void                                    *private_data,
+    struct chimera_nfs_client_server_thread *server_thread,
+    struct chimera_nfs4_open_state          *open_state);
+
+int chimera_nfs4_pnfs_write(
+    struct chimera_nfs_thread               *thread,
+    struct chimera_nfs_shared               *shared,
+    struct chimera_vfs_request              *request,
+    void                                    *private_data,
+    struct chimera_nfs_client_server_thread *server_thread,
+    struct chimera_nfs4_open_state          *open_state);
+
+/*
+ * Close-time layout teardown.  Returns 1 if it took ownership of the request
+ * (it will asynchronously LAYOUTCOMMIT/LAYOUTRETURN, then free the open state
+ * and complete the request), or 0 if there was no layout and the caller should
+ * free + complete as usual.
+ */
+int chimera_nfs4_pnfs_close(
+    struct chimera_nfs_thread      *thread,
+    struct chimera_nfs_shared      *shared,
+    struct chimera_vfs_request     *request,
+    struct chimera_nfs4_open_state *open_state);
+
+/*
+ * Layout registry (shared->pnfs_layouts).  register publishes a now-VALID
+ * layout so a back-channel CB_LAYOUTRECALL can find it; unregister removes it
+ * before the owning open state is freed.  Both are idempotent and safe to call
+ * for layouts that were never registered.
+ */
+void chimera_nfs4_pnfs_layout_register(
+    struct chimera_nfs_shared  *shared,
+    struct chimera_nfs4_layout *layout);
+
+void chimera_nfs4_pnfs_layout_unregister(
+    struct chimera_nfs_shared  *shared,
+    struct chimera_nfs4_layout *layout);

--- a/src/vfs/nfs/nfs4_read.c
+++ b/src/vfs/nfs/nfs4_read.c
@@ -4,6 +4,7 @@
 
 #include "nfs_internal.h"
 #include "nfs4_open_state.h"
+#include "nfs4_pnfs.h"
 
 struct chimera_nfs4_read_ctx {
     struct chimera_nfs_thread        *thread;
@@ -104,11 +105,19 @@ chimera_nfs4_read(
         return;
     }
 
+    open_state = (struct chimera_nfs4_open_state *) request->read.handle->vfs_private;
+
+    /* pNFS overlay: if a flex-files layout covers this read, drive it straight
+     * to the data server (or acquire the layout first).  Returns 1 if it took
+     * the request; 0 means fall through to the MDS read below. */
+    if (open_state &&
+        chimera_nfs4_pnfs_read(thread, shared, request, private_data, server_thread, open_state)) {
+        return;
+    }
+
     ctx         = request->plugin_data;
     ctx->thread = thread;
     ctx->server = server;
-
-    open_state = (struct chimera_nfs4_open_state *) request->read.handle->vfs_private;
 
     chimera_nfs4_map_fh(request->fh, request->fh_len, &fh, &fhlen);
 

--- a/src/vfs/nfs/nfs4_slot.c
+++ b/src/vfs/nfs/nfs4_slot.c
@@ -9,34 +9,58 @@
  * slot and that slot's sequenceid.  The protocol allows only ONE outstanding
  * request per slot at a time, and the slot's sequenceid must advance by exactly
  * one per accepted request; sending a second request on a busy slot (or with a
- * mismatched seqid) is rejected with NFS4ERR_SEQ_MISORDERED.  The previous client
- * gave each thread a single slot and merely incremented its seqid per call, so a
- * thread with more than one COMPOUND in flight (pipelined I/O, or back-to-back
- * compounds) collided.
+ * mismatched seqid) is rejected with NFS4ERR_SEQ_MISORDERED.
  *
- * This layer fixes that.  The session owns the global slot space (max_slots,
- * granted by CREATE_SESSION).  Each per-thread connection
- * (chimera_nfs_client_server_thread) claims a disjoint block of slot indices
- * once and manages them entirely thread-locally -- a server_thread is touched by
- * exactly one evpl thread, so acquire/release/park/wake need no locking; only
- * the one-time block claim takes session->lock.  When all of a thread's slots
- * are busy, further requests are parked and replayed (same thread) as slots
- * free, never sent on a busy slot.
+ * Slots are shared cooperatively across the client's evpl threads.  The session
+ * owns the global slot space (max_slots, granted by CREATE_SESSION) as a pool of
+ * free slot ids plus a per-id seqid array.  Each per-thread connection keeps:
+ *   - a FLOOR of slots claimed once and never returned (>=1, so the thread always
+ *     owns a slot and can always make progress -- see the wakeup note below), and
+ *   - a thread-local stack of additional BORROWED ids it tops up from / returns to
+ *     the shared pool in BATCHES under session->lock.
+ * Steady-state acquire/release is a thread-local stack pop/push (no lock, no
+ * atomics); the session lock is taken only on a batch borrow/return/floor-claim or
+ * when the server changes the slot-use limit -- amortized ~1/REFILL_BATCH, never
+ * per operation.  A busy thread can therefore run far more than its even share in
+ * flight while idle threads hand slots back.
+ *
+ * When a thread momentarily has no free owned slot it PARKS the request and
+ * replays it from its OWN reply callback as one of its in-flight slots frees.
+ * Parked requests are only ever woken from the owning thread's reply callback
+ * (there is no cross-thread wakeup), so a thread must always own >=1 slot or a
+ * parked request could hang with nothing to wake it.  The floor guarantees this;
+ * it requires usable >= live_threads, enforced by a hard abort at floor-claim.
+ *
+ * Dynamic limit (RFC 8881 §2.10.6.1): the server advertises a target slot-use
+ * limit via sr_target_highest_slotid.  The client tracks it as `usable` and drains
+ * its working set toward it -- the borrow pool only lends ids < usable and retires
+ * higher ids until the target grows again -- while floor ids (always valid, < the
+ * negotiated max_slots) keep every thread alive.
  */
 
 #include <stdlib.h>
 
 #include "nfs_internal.h"
 
-/* Upper bound on a thread's slot block, so an early claim (when few threads have
- * registered yet) cannot grab the whole pool and starve later threads. */
-#define CHIMERA_NFS4_MAX_SLOTS_PER_THREAD 16
+/* Slot id a thread keeps for life (never returned except at teardown). */
+#define CHIMERA_NFS4_FLOOR_SLOTS  1u
+/* Slots grabbed/returned per shared-pool transaction (amortizes the lock). */
+#define CHIMERA_NFS4_REFILL_BATCH 8u
+#define CHIMERA_NFS4_RETURN_BATCH 8u
+/* A thread returns idle slots once it is sitting on more than HIGH_WATER free,
+ * draining down to LOW_WATER.  HIGH_WATER > FLOOR + REFILL_BATCH avoids a single
+ * borrow immediately tripping a return (thrash). */
+#define CHIMERA_NFS4_HIGH_WATER   16
+#define CHIMERA_NFS4_LOW_WATER    8
+/* Slack above the even per-thread share a thread may borrow, so it can burst into
+ * idle capacity without monopolizing the pool. */
+#define CHIMERA_NFS4_CAP_SLACK    4u
 
 /* In-flight wrapper context: what rpc2 carries as private_data so the reply can
  * free the slot and then invoke the caller's real callback. */
 struct chimera_nfs4_compound_ctx {
     struct chimera_nfs_client_server_thread *server_thread;
-    uint32_t                                 slot_local;   /* index into slots[] */
+    uint32_t                                 slot_id;      /* global slot id sent */
     uint32_t                                 seqid;        /* seqid we sent       */
     void                                     (*real_cb)(
         struct evpl *,
@@ -158,7 +182,150 @@ chimera_nfs4_park_pop(struct chimera_nfs4_slot_table *st)
     return p;
 } /* chimera_nfs4_park_pop */
 
-/* ---- slot table block claim + acquire/release --------------------------- */
+/* ---- session-global slot pool (all helpers run under session->lock) ----- */
+
+void
+chimera_nfs4_session_pool_init(struct chimera_nfs4_client_session *session)
+{
+    uint32_t i, n = session->max_slots;
+
+    session->slot_seqid  = calloc(n, sizeof(*session->slot_seqid));
+    session->free_ids    = calloc(n, sizeof(*session->free_ids));
+    session->retired_ids = calloc(n, sizeof(*session->retired_ids));
+
+    /* All ids start usable and free; push so low ids come off the top first
+     * (floors/borrows then cluster at the low end of the id space). */
+    for (i = 0; i < n; i++) {
+        session->slot_seqid[i] = 1;                 /* RFC 8881: first seqid is 1 */
+        session->free_ids[i]   = n - 1 - i;
+    }
+    session->free_count     = n;
+    session->retired_count  = 0;
+    session->claimed_floors = 0;
+    atomic_store(&session->usable, n);
+    atomic_store(&session->target_usable, n);
+} /* chimera_nfs4_session_pool_init */
+
+void
+chimera_nfs4_session_pool_destroy(struct chimera_nfs4_client_session *session)
+{
+    free(session->slot_seqid);
+    free(session->free_ids);
+    free(session->retired_ids);
+    session->slot_seqid  = NULL;
+    session->free_ids    = NULL;
+    session->retired_ids = NULL;
+} /* chimera_nfs4_session_pool_destroy */
+
+/* Apply a pending server slot-use-limit change (sr_target).  Shrinking moves
+ * now-out-of-range free ids aside to retired_ids; growing brings them back.
+ * usable is clamped to >= claimed_floors (we can never reclaim a thread's floor
+ * slot) and <= max_slots.  O(pool) but runs only when the target actually
+ * changes -- never on the steady-state hot path. */
+static void
+chimera_nfs4_pool_apply_target(struct chimera_nfs4_client_session *session)
+{
+    uint32_t want = atomic_load_explicit(&session->target_usable, memory_order_relaxed);
+    uint32_t cur  = atomic_load_explicit(&session->usable, memory_order_relaxed);
+    uint32_t floor_min, i, w;
+
+    floor_min = session->claimed_floors ? session->claimed_floors : 1;
+    if (want < floor_min) {
+        want = floor_min;
+    }
+    if (want > session->max_slots) {
+        want = session->max_slots;
+    }
+    if (want == cur) {
+        return;
+    }
+
+    if (want < cur) {
+        /* Shrink: retire free ids that are now >= want. */
+        w = 0;
+        for (i = 0; i < session->free_count; i++) {
+            uint32_t id = session->free_ids[i];
+            if (id < want) {
+                session->free_ids[w++] = id;
+            } else {
+                session->retired_ids[session->retired_count++] = id;
+            }
+        }
+        session->free_count = w;
+    } else {
+        /* Grow: bring retired ids that are now < want back into circulation. */
+        w = 0;
+        for (i = 0; i < session->retired_count; i++) {
+            uint32_t id = session->retired_ids[i];
+            if (id < want) {
+                session->free_ids[session->free_count++] = id;
+            } else {
+                session->retired_ids[w++] = id;
+            }
+        }
+        session->retired_count = w;
+    }
+
+    atomic_store_explicit(&session->usable, want, memory_order_relaxed);
+} /* chimera_nfs4_pool_apply_target */
+
+/* Borrow up to `want` ids from the shared pool into the thread's local_free,
+ * reserving one slot for every live thread that has not yet claimed its floor so
+ * a late floor-claim cannot be starved.  Returns the number borrowed. */
+static uint32_t
+chimera_nfs4_pool_borrow(
+    struct chimera_nfs4_client_session *session,
+    struct chimera_nfs4_slot_table     *st,
+    struct chimera_nfs_shared          *shared,
+    uint32_t                            want)
+{
+    uint32_t reserve, avail, take, i;
+    int      live;
+
+    chimera_nfs4_pool_apply_target(session);
+
+    live = atomic_load(&shared->nfs_thread_count);
+    if (live < 0) {
+        live = 0;
+    }
+    reserve = (uint32_t) live > session->claimed_floors ?
+        (uint32_t) live - session->claimed_floors : 0;
+
+    avail = session->free_count > reserve ? session->free_count - reserve : 0;
+    take  = want < avail ? want : avail;
+
+    for (i = 0; i < take; i++) {
+        st->local_free[st->local_free_top++] = session->free_ids[--session->free_count];
+    }
+    st->leased += take;
+    return take;
+} /* chimera_nfs4_pool_borrow */
+
+/* Return `count` idle ids from the thread's local_free back to the shared pool
+ * (or retired, if the limit shrank below them). */
+static void
+chimera_nfs4_pool_return(
+    struct chimera_nfs4_client_session *session,
+    struct chimera_nfs4_slot_table     *st,
+    uint32_t                            count)
+{
+    uint32_t usable, i;
+
+    chimera_nfs4_pool_apply_target(session);
+    usable = atomic_load_explicit(&session->usable, memory_order_relaxed);
+
+    for (i = 0; i < count; i++) {
+        uint32_t id = st->local_free[--st->local_free_top];
+        if (id < usable) {
+            session->free_ids[session->free_count++] = id;
+        } else {
+            session->retired_ids[session->retired_count++] = id;
+        }
+    }
+    st->leased -= count;
+} /* chimera_nfs4_pool_return */
+
+/* ---- per-thread slot table: floor claim + reset/destroy ----------------- */
 
 static void
 chimera_nfs4_slot_table_init(
@@ -166,101 +333,154 @@ chimera_nfs4_slot_table_init(
     struct chimera_nfs4_client_session *session,
     struct chimera_nfs_shared          *shared)
 {
-    uint32_t fair, remaining, takeable, base, n, i;
-    int      nthreads, others;
+    uint32_t i;
+    int      live;
 
-    nthreads = atomic_load(&shared->nfs_thread_count);
-    if (nthreads < 1) {
-        nthreads = 1;
-    }
-
-    /* Fair share of the global slot pool for one thread (>=1), bounded so an
-     * early claim does not grab a huge block while few threads have registered. */
-    fair = session->max_slots / (uint32_t) nthreads;
-    if (fair < 1) {
-        fair = 1;
-    }
-    if (fair > CHIMERA_NFS4_MAX_SLOTS_PER_THREAD) {
-        fair = CHIMERA_NFS4_MAX_SLOTS_PER_THREAD;
-    }
+    st->local_free     = calloc(session->max_slots, sizeof(*st->local_free));
+    st->local_free_top = 0;
+    st->leased         = 0;
+    st->floor          = 0;
+    st->cached_target  = atomic_load(&session->target_usable);
 
     pthread_mutex_lock(&session->lock);
 
-    remaining = session->max_slots - session->next_unclaimed;
+    chimera_nfs4_pool_apply_target(session);
 
-    /* Invariant: the session must have at least as many slots as client threads,
-     * so every thread gets at least one private slot.  If a thread cannot claim
-     * even one slot, that invariant is violated -- abort loudly rather than
-     * silently aliasing a slot across threads (which breaks one-outstanding-per-
-     * slot and yields NFS4ERR_SEQ_MISORDERED).  Provision more slots via the
-     * `slots=` mount option and/or server.nfs4_session_slots. */
-    chimera_nfsclient_abort_if(remaining == 0,
+    live = atomic_load(&shared->nfs_thread_count);
+    if (live < 1) {
+        live = 1;
+    }
+
+    /* Claim the per-thread floor.  Requires the session to have at least as many
+     * usable slots as live client threads; if a thread cannot get even one slot,
+     * that invariant is violated -- abort loudly (parked requests would have no
+     * in-flight slot to wake them).  Raise `slots=` / server.nfs4_session_slots
+     * above the client thread count. */
+    chimera_nfsclient_abort_if(session->free_count == 0,
                                "NFS4 session fore-channel slots exhausted: max_slots=%u but the "
                                "client has %d threads -- every thread needs at least one slot.  "
                                "Raise the `slots=` mount option and/or server.nfs4_session_slots "
                                "above the client thread count.",
-                               session->max_slots, nthreads);
+                               session->max_slots, live);
 
-    /* Reserve one slot for each thread that has registered but not yet claimed a
-     * block, so this (possibly early) claim cannot starve a later thread and
-     * trip the abort above even though max_slots > threads. */
-    session->claimed_blocks++;
-    others = nthreads - (int) session->claimed_blocks;
-    if (others < 0) {
-        others = 0;
+    session->claimed_floors++;
+    for (i = 0; i < CHIMERA_NFS4_FLOOR_SLOTS && session->free_count > 0; i++) {
+        st->local_free[st->local_free_top++] = session->free_ids[--session->free_count];
+        st->leased++;
+        st->floor++;
     }
-    if ((uint32_t) others >= remaining) {
-        takeable = 1;                       /* tight: one slot per remaining thread */
-    } else {
-        takeable = remaining - (uint32_t) others;
-    }
-
-    n                        = fair < takeable ? fair : takeable; /* both >= 1, and n <= remaining */
-    base                     = session->next_unclaimed;
-    session->next_unclaimed += n;
 
     pthread_mutex_unlock(&session->lock);
-
-    st->slots      = calloc(n, sizeof(*st->slots));
-    st->free_stack = calloc(n, sizeof(*st->free_stack));
-    st->num_slots  = n;
-    st->free_top   = (int) n;
-
-    for (i = 0; i < n; i++) {
-        st->slots[i].global_id = base + i;
-        st->slots[i].seqid     = 1;             /* RFC 8881: first request seqid 1 */
-        st->slots[i].in_use    = 0;
-        st->free_stack[i]      = n - 1 - i;     /* hand out low indices first      */
-    }
 
     st->initialized = 1;
 } /* chimera_nfs4_slot_table_init */
 
-/* Returns a free local slot index, or -1 if all owned slots are busy. */
-static int
-chimera_nfs4_slot_acquire(struct chimera_nfs4_slot_table *st)
+void
+chimera_nfs4_slot_table_reset(
+    struct evpl                    *evpl,
+    struct chimera_nfs4_slot_table *st)
 {
-    uint32_t local;
+    struct chimera_nfs4_compound_ctx *ctx;
+    struct chimera_nfs4_parked       *p;
 
-    if (st->free_top == 0) {
-        return -1;
+    if (!st->initialized) {
+        return;
     }
 
-    local                   = st->free_stack[--st->free_top];
-    st->slots[local].in_use = 1;
-    return (int) local;
-} /* chimera_nfs4_slot_acquire */
+    /* Error-complete everything that was in flight on the dropped connection.
+     * rpc2 already freed the underlying calls without invoking their callbacks,
+     * so we run them here (non-zero status -> the op completes with an error
+     * rather than hanging).  The slot id returns to this thread's local_free --
+     * NOT to the shared pool: the id is still leased to this thread and would be
+     * double-issued if another thread borrowed it. */
+    while (st->inflight) {
+        ctx                                  = st->inflight;
+        st->inflight                         = ctx->next;
+        ctx->prev                            = ctx->next = NULL;
+        st->local_free[st->local_free_top++] = ctx->slot_id;
+        ctx->real_cb(evpl, NULL, NULL, 1 /* error */, ctx->real_private);
+        chimera_nfs4_ctx_free(st, ctx);
+    }
 
-static void
-chimera_nfs4_slot_release(
-    struct chimera_nfs4_slot_table *st,
-    uint32_t                        local)
+    /* Parked requests never went on the wire; error-complete them too. */
+    while ((p = chimera_nfs4_park_pop(st)) != NULL) {
+        p->request->status = CHIMERA_VFS_EIO;
+        p->request->complete(p->request);
+        p->next             = st->parked_freelist;
+        st->parked_freelist = p;
+    }
+
+    /* seqids are left as-is: a lost request the server did process would yield
+     * NFS4ERR_SEQ_MISORDERED on the next reuse, surfaced as an error (full
+     * session recovery is a separate effort). */
+} /* chimera_nfs4_slot_table_reset */
+
+void
+chimera_nfs4_slot_table_destroy(struct chimera_nfs_client_server_thread *server_thread)
 {
-    st->slots[local].in_use        = 0;
-    st->free_stack[st->free_top++] = local;
-} /* chimera_nfs4_slot_release */
+    struct chimera_nfs4_slot_table     *st      = &server_thread->slots;
+    struct chimera_nfs4_client_session *session =
+        server_thread->server ? server_thread->server->nfs4_session : NULL;
+    struct chimera_nfs4_compound_ctx   *ctx;
+    struct chimera_nfs4_parked         *p;
 
-/* ---- the reply wrapper -------------------------------------------------- */
+    if (st->initialized && session) {
+        /* Reclaim any still-inflight ctxs (reset normally drained them first);
+         * their ids return to local_free, then the whole lease goes back to the
+         * shared pool so a torn-down thread does not leak slots. */
+        while (st->inflight) {
+            ctx                                  = st->inflight;
+            st->inflight                         = ctx->next;
+            st->local_free[st->local_free_top++] = ctx->slot_id;
+        }
+
+        pthread_mutex_lock(&session->lock);
+        chimera_nfs4_pool_apply_target(session);
+        {
+            uint32_t usable = atomic_load_explicit(&session->usable, memory_order_relaxed);
+            while (st->local_free_top > 0) {
+                uint32_t id = st->local_free[--st->local_free_top];
+                if (id < usable) {
+                    session->free_ids[session->free_count++] = id;
+                } else {
+                    session->retired_ids[session->retired_count++] = id;
+                }
+            }
+        }
+        if (session->claimed_floors >= st->floor) {
+            session->claimed_floors -= st->floor;
+        }
+        st->leased = 0;
+        st->floor  = 0;
+        pthread_mutex_unlock(&session->lock);
+    }
+
+    while (st->ctx_freelist) {
+        ctx              = st->ctx_freelist;
+        st->ctx_freelist = ctx->fl_next;
+        free(ctx);
+    }
+    while (st->inflight) {
+        ctx          = st->inflight;
+        st->inflight = ctx->next;
+        free(ctx);
+    }
+    while (st->parked_freelist) {
+        p                   = st->parked_freelist;
+        st->parked_freelist = p->next;
+        free(p);
+    }
+    while ((p = chimera_nfs4_park_pop(st)) != NULL) {
+        free(p);
+    }
+    st->wait_tail = NULL;
+    free(st->local_free);
+    st->local_free     = NULL;
+    st->local_free_top = 0;
+    st->initialized    = 0;
+} /* chimera_nfs4_slot_table_destroy */
+
+/* ---- the wrapper + reply handler ---------------------------------------- */
 
 static void
 chimera_nfs4_compound_call_cb(
@@ -270,30 +490,62 @@ chimera_nfs4_compound_call_cb(
     int                          status,
     void                        *private_data)
 {
-    struct chimera_nfs4_compound_ctx *ctx  = private_data;
-    struct chimera_nfs4_slot_table   *st   = &ctx->server_thread->slots;
-    struct chimera_nfs4_slot         *slot = &st->slots[ctx->slot_local];
-    struct chimera_nfs4_parked       *p;
+    struct chimera_nfs4_compound_ctx        *ctx           = private_data;
+    struct chimera_nfs_client_server_thread *server_thread = ctx->server_thread;
+    struct chimera_nfs4_slot_table          *st            = &server_thread->slots;
+    struct chimera_nfs4_client_session      *session       = server_thread->server->nfs4_session;
+    struct chimera_nfs4_parked              *p;
 
-    void                              (*real_cb)(
+    void                                     (*real_cb)(
         struct evpl *,
         const struct evpl_rpc2_verf *,
         struct COMPOUND4res *,
         int,
         void *);
-    void                             *real_private;
+    void                                    *real_private;
 
     chimera_nfs4_inflight_remove(st, ctx);
 
     /* Advance the slot's seqid only when the server accepted the SEQUENCE
-    * (RFC 8881 §2.10.6.1).  On a transport error or a SEQUENCE error, leave it
-    * so the slot stays replayable; we surface the error to the caller. */
+     * (RFC 8881 §2.10.6.1).  On a transport error or a SEQUENCE error, leave it
+     * so the slot stays replayable; we surface the error to the caller.  This
+     * write happens-before the id can be returned to the shared pool below. */
     if (status == 0 && res && res->num_resarray >= 1 &&
         res->resarray[0].opsequence.sr_status == NFS4_OK) {
-        slot->seqid = ctx->seqid + 1;
+        session->slot_seqid[ctx->slot_id] = ctx->seqid + 1;
+
+        /* Track a server-driven slot-use-limit change cheaply (plain compare);
+         * the actual pool adjustment is applied under the lock at the next
+         * batch borrow/return. */
+        uint32_t target = res->resarray[0].opsequence.sr_resok4.sr_target_highest_slotid + 1;
+        if (target != st->cached_target) {
+            st->cached_target = target;
+            atomic_store_explicit(&session->target_usable, target, memory_order_relaxed);
+        }
     }
 
-    chimera_nfs4_slot_release(st, ctx->slot_local);
+    /* The freed id returns to this thread's local stack (lock-free). */
+    st->local_free[st->local_free_top++] = ctx->slot_id;
+
+    /* If we are sitting on plenty of idle slots and have no one waiting, hand a
+     * batch back to the shared pool so other threads can use them.  (A high free
+     * count already means we are not slot-starved; an empty park FIFO means no
+     * pending demand.)  Done before real_cb / the park drain so the lock is never
+     * held across a send. */
+    if (st->local_free_top > CHIMERA_NFS4_HIGH_WATER && st->wait_head == NULL) {
+        uint32_t returnable = (uint32_t) st->local_free_top - CHIMERA_NFS4_LOW_WATER;
+        uint32_t keep_floor = st->leased > st->floor ? st->leased - st->floor : 0;
+        uint32_t cnt        = returnable < CHIMERA_NFS4_RETURN_BATCH ? returnable : CHIMERA_NFS4_RETURN_BATCH;
+
+        if (cnt > keep_floor) {
+            cnt = keep_floor;
+        }
+        if (cnt > 0) {
+            pthread_mutex_lock(&session->lock);
+            chimera_nfs4_pool_return(session, st, cnt);
+            pthread_mutex_unlock(&session->lock);
+        }
+    }
 
     real_cb      = ctx->real_cb;
     real_private = ctx->real_private;
@@ -306,7 +558,7 @@ chimera_nfs4_compound_call_cb(
     /* Then wake parked requests for any slots still free.  Each replay
      * re-dispatches the op, which re-enters chimera_nfs4_compound_call and
      * acquires a slot (re-entrant same-thread send is safe). */
-    while (st->free_top > 0 && st->wait_head) {
+    while (st->local_free_top > 0 && st->wait_head) {
         p = chimera_nfs4_park_pop(st);
         chimera_nfs4_retry_fn       rf = p->retry_fn;
         struct chimera_nfs_thread  *t  = p->thread;
@@ -340,35 +592,59 @@ chimera_nfs4_compound_call(
 {
     struct chimera_nfs4_client_session *session = server_thread->server->nfs4_session;
     struct chimera_nfs4_slot_table     *st      = &server_thread->slots;
-    struct chimera_nfs4_slot           *slot;
     struct chimera_nfs4_compound_ctx   *ctx;
-    int                                 local;
+    uint32_t                            id, usable;
 
     if (unlikely(!st->initialized)) {
         chimera_nfs4_slot_table_init(st, session, shared);
     }
 
-    local = chimera_nfs4_slot_acquire(st);
-    if (local < 0) {
-        /* No slot free: park and replay when one frees.  Must not send on a
-         * busy slot (that is the NFS4ERR_SEQ_MISORDERED bug). */
-        chimera_nfs4_park(st, thread, shared, request, retry_fn, retry_ctx);
-        return;
+    /* Acquire a free owned slot.  Hot path: pop the thread-local stack.  If empty,
+     * top up a batch from the shared pool -- but only up to a soft fair cap, so a
+     * greedy thread bursts into idle capacity without monopolizing the pool. */
+    if (st->local_free_top == 0) {
+        int      live  = atomic_load(&shared->nfs_thread_count);
+        uint32_t share = atomic_load_explicit(&session->usable, memory_order_relaxed) /
+            (uint32_t) (live > 0 ? live : 1);
+        uint32_t fair_cap = (share > CHIMERA_NFS4_FLOOR_SLOTS ? share : CHIMERA_NFS4_FLOOR_SLOTS) +
+            CHIMERA_NFS4_CAP_SLACK;
+
+        if (st->leased < fair_cap) {
+            uint32_t want = fair_cap - st->leased;
+            if (want > CHIMERA_NFS4_REFILL_BATCH) {
+                want = CHIMERA_NFS4_REFILL_BATCH;
+            }
+            pthread_mutex_lock(&session->lock);
+            chimera_nfs4_pool_borrow(session, st, shared, want);
+            pthread_mutex_unlock(&session->lock);
+        }
+
+        if (st->local_free_top == 0) {
+            /* No slot free and at/over the fair cap (or pool empty): park and
+             * replay when one of this thread's in-flight slots frees.  The floor
+             * guarantees there is always such an in-flight slot. */
+            chimera_nfs4_park(st, thread, shared, request, retry_fn, retry_ctx);
+            return;
+        }
     }
 
-    slot = &st->slots[local];
+    id     = st->local_free[--st->local_free_top];
+    usable = atomic_load_explicit(&session->usable, memory_order_relaxed);
 
     args->argarray[0].argop = OP_SEQUENCE;
     memcpy(args->argarray[0].opsequence.sa_sessionid, session->sessionid, NFS4_SESSIONID_SIZE);
-    args->argarray[0].opsequence.sa_sequenceid     = slot->seqid;
-    args->argarray[0].opsequence.sa_slotid         = slot->global_id;
-    args->argarray[0].opsequence.sa_highest_slotid = session->max_slots - 1;
+    args->argarray[0].opsequence.sa_sequenceid = session->slot_seqid[id];
+    args->argarray[0].opsequence.sa_slotid     = id;
+    /* Advertise the highest slot id we might use: the live limit, but never below
+     * the id we are actually sending on (a floor id may briefly exceed `usable`
+     * after a shrink -- still < the negotiated max, so always valid on the wire). */
+    args->argarray[0].opsequence.sa_highest_slotid = (id >= usable ? id : usable - 1);
     args->argarray[0].opsequence.sa_cachethis      = 0;
 
     ctx                = chimera_nfs4_ctx_alloc(st);
     ctx->server_thread = server_thread;
-    ctx->slot_local    = (uint32_t) local;
-    ctx->seqid         = slot->seqid;
+    ctx->slot_id       = id;
+    ctx->seqid         = session->slot_seqid[id];
     ctx->real_cb       = cb;
     ctx->real_private  = cb_private;
     chimera_nfs4_inflight_add(st, ctx);
@@ -383,84 +659,3 @@ chimera_nfs4_compound_call(
         chimera_nfs4_compound_call_cb,
         ctx);
 } /* chimera_nfs4_compound_call */
-
-void
-chimera_nfs4_slot_table_destroy(struct chimera_nfs4_slot_table *st)
-{
-    struct chimera_nfs4_compound_ctx *ctx;
-    struct chimera_nfs4_parked       *p;
-
-    while (st->ctx_freelist) {
-        ctx              = st->ctx_freelist;
-        st->ctx_freelist = ctx->fl_next;
-        free(ctx);
-    }
-    /* Any still-inflight ctxs are owned by pending replies; on teardown the
-     * connection is gone, so just free them. */
-    while (st->inflight) {
-        ctx          = st->inflight;
-        st->inflight = ctx->next;
-        free(ctx);
-    }
-    while (st->parked_freelist) {
-        p                   = st->parked_freelist;
-        st->parked_freelist = p->next;
-        free(p);
-    }
-    while (st->wait_head) {
-        p             = st->wait_head;
-        st->wait_head = p->next;
-        free(p);
-    }
-    st->wait_tail = NULL;
-    free(st->slots);
-    free(st->free_stack);
-    st->slots       = NULL;
-    st->free_stack  = NULL;
-    st->num_slots   = 0;
-    st->free_top    = 0;
-    st->initialized = 0;
-} /* chimera_nfs4_slot_table_destroy */
-
-void
-chimera_nfs4_slot_table_reset(
-    struct evpl                    *evpl,
-    struct chimera_nfs4_slot_table *st)
-{
-    struct chimera_nfs4_compound_ctx *ctx;
-    struct chimera_nfs4_parked       *p;
-    uint32_t                          i;
-
-    if (!st->initialized) {
-        return;
-    }
-
-    /* Error-complete everything that was in flight on the dropped connection.
-     * rpc2 already freed the underlying calls without invoking their callbacks,
-     * so we must run them here (non-zero status -> the op completes with an
-     * error rather than hanging). */
-    while (st->inflight) {
-        ctx          = st->inflight;
-        st->inflight = ctx->next;
-        ctx->prev    = ctx->next = NULL;
-        ctx->real_cb(evpl, NULL, NULL, 1 /* error */, ctx->real_private);
-        chimera_nfs4_ctx_free(st, ctx);
-    }
-
-    /* Parked requests never went on the wire; error-complete them too. */
-    while ((p = chimera_nfs4_park_pop(st)) != NULL) {
-        p->request->status = CHIMERA_VFS_EIO;
-        p->request->complete(p->request);
-        p->next             = st->parked_freelist;
-        st->parked_freelist = p;
-    }
-
-    /* All slots are free again.  seqids are left as-is: a lost request the
-    * server did process would yield NFS4ERR_SEQ_MISORDERED on the next reuse,
-    * which we surface as an error (full recovery is a separate effort). */
-    for (i = 0; i < st->num_slots; i++) {
-        st->slots[i].in_use = 0;
-        st->free_stack[i]   = st->num_slots - 1 - i;
-    }
-    st->free_top = (int) st->num_slots;
-} /* chimera_nfs4_slot_table_reset */

--- a/src/vfs/nfs/nfs4_slot.c
+++ b/src/vfs/nfs/nfs4_slot.c
@@ -166,45 +166,60 @@ chimera_nfs4_slot_table_init(
     struct chimera_nfs4_client_session *session,
     struct chimera_nfs_shared          *shared)
 {
-    uint32_t cap, remaining, base, n, i;
-    int      nthreads, overflow = 0;
+    uint32_t fair, remaining, takeable, base, n, i;
+    int      nthreads, others;
 
     nthreads = atomic_load(&shared->nfs_thread_count);
     if (nthreads < 1) {
         nthreads = 1;
     }
 
-    cap = session->max_slots / (uint32_t) nthreads;
-    if (cap < 1) {
-        cap = 1;
+    /* Fair share of the global slot pool for one thread (>=1), bounded so an
+     * early claim does not grab a huge block while few threads have registered. */
+    fair = session->max_slots / (uint32_t) nthreads;
+    if (fair < 1) {
+        fair = 1;
     }
-    if (cap > CHIMERA_NFS4_MAX_SLOTS_PER_THREAD) {
-        cap = CHIMERA_NFS4_MAX_SLOTS_PER_THREAD;
+    if (fair > CHIMERA_NFS4_MAX_SLOTS_PER_THREAD) {
+        fair = CHIMERA_NFS4_MAX_SLOTS_PER_THREAD;
     }
 
     pthread_mutex_lock(&session->lock);
-    remaining = session->max_slots - session->next_unclaimed;
-    if (remaining == 0) {
-        /* Pool exhausted: only happens with more client threads than the
-         * server's granted slots (default 64).  Alias an existing slot index;
-         * those (rare) threads then share a slot and serialize through it. */
-        base                 = session->overflow_rr;
-        session->overflow_rr = (session->overflow_rr + 1) % session->max_slots;
-        n                    = 1;
-        overflow             = 1;
-    } else {
-        n                        = cap < remaining ? cap : remaining;
-        base                     = session->next_unclaimed;
-        session->next_unclaimed += n;
-    }
-    pthread_mutex_unlock(&session->lock);
 
-    if (overflow) {
-        chimera_nfsclient_error(
-            "NFS4 session slot pool exhausted (max_slots=%u, threads=%d); "
-            "sharing slot %u. Raise server.nfs4_session_slots.",
-            session->max_slots, nthreads, base);
+    remaining = session->max_slots - session->next_unclaimed;
+
+    /* Invariant: the session must have at least as many slots as client threads,
+     * so every thread gets at least one private slot.  If a thread cannot claim
+     * even one slot, that invariant is violated -- abort loudly rather than
+     * silently aliasing a slot across threads (which breaks one-outstanding-per-
+     * slot and yields NFS4ERR_SEQ_MISORDERED).  Provision more slots via the
+     * `slots=` mount option and/or server.nfs4_session_slots. */
+    chimera_nfsclient_abort_if(remaining == 0,
+                               "NFS4 session fore-channel slots exhausted: max_slots=%u but the "
+                               "client has %d threads -- every thread needs at least one slot.  "
+                               "Raise the `slots=` mount option and/or server.nfs4_session_slots "
+                               "above the client thread count.",
+                               session->max_slots, nthreads);
+
+    /* Reserve one slot for each thread that has registered but not yet claimed a
+     * block, so this (possibly early) claim cannot starve a later thread and
+     * trip the abort above even though max_slots > threads. */
+    session->claimed_blocks++;
+    others = nthreads - (int) session->claimed_blocks;
+    if (others < 0) {
+        others = 0;
     }
+    if ((uint32_t) others >= remaining) {
+        takeable = 1;                       /* tight: one slot per remaining thread */
+    } else {
+        takeable = remaining - (uint32_t) others;
+    }
+
+    n                        = fair < takeable ? fair : takeable; /* both >= 1, and n <= remaining */
+    base                     = session->next_unclaimed;
+    session->next_unclaimed += n;
+
+    pthread_mutex_unlock(&session->lock);
 
     st->slots      = calloc(n, sizeof(*st->slots));
     st->free_stack = calloc(n, sizeof(*st->free_stack));

--- a/src/vfs/nfs/nfs4_umount.c
+++ b/src/vfs/nfs/nfs4_umount.c
@@ -25,6 +25,7 @@ chimera_nfs4_umount(
     /* Free session when last mount is removed.  Per-thread slot tables are
      * freed in chimera_nfs_thread_destroy (they live on the server_threads). */
     if (server->refcnt == 0 && server->nfs4_session) {
+        chimera_nfs4_session_pool_destroy(server->nfs4_session);
         pthread_mutex_destroy(&server->nfs4_session->lock);
         free(server->nfs4_session);
         server->nfs4_session = NULL;

--- a/src/vfs/nfs/nfs4_write.c
+++ b/src/vfs/nfs/nfs4_write.c
@@ -4,6 +4,7 @@
 
 #include "nfs_internal.h"
 #include "nfs4_open_state.h"
+#include "nfs4_pnfs.h"
 #include "vfs/vfs_error.h"
 
 struct chimera_nfs4_write_ctx {
@@ -108,10 +109,19 @@ chimera_nfs4_write(
         return;
     }
 
+    open_state = (struct chimera_nfs4_open_state *) request->write.handle->vfs_private;
+
+    /* pNFS overlay: if a flex-files RW layout covers this write, drive it
+    * straight to the data server (or acquire the layout first).  Returns 1 if
+    * it took the request; 0 means fall through to the MDS write below. */
+    if (open_state &&
+        chimera_nfs4_pnfs_write(thread, shared, request, private_data, server_thread, open_state)) {
+        return;
+    }
+
     ctx             = request->plugin_data;
     ctx->thread     = thread;
     ctx->server     = server;
-    open_state      = (struct chimera_nfs4_open_state *) request->write.handle->vfs_private;
     ctx->open_state = open_state;
 
     chimera_nfs4_map_fh(request->fh, request->fh_len, &fh, &fhlen);

--- a/src/vfs/nfs/nfs_internal.h
+++ b/src/vfs/nfs/nfs_internal.h
@@ -12,6 +12,7 @@
 #include <endian.h>
 #include <utlist.h>
 #include "vfs/vfs.h"
+#include "vfs/vfs_pnfs.h"
 #include "evpl/evpl.h"
 #include "portmap_xdr.h"
 #include "nfs_mount_xdr.h"
@@ -102,13 +103,14 @@ struct chimera_nfs4_client_session {
 
 struct chimera_nfs_client_mount;
 struct chimera_nfs4_compound_ctx;   /* in-flight wrapper context (nfs4_slot.c)   */
-struct chimera_nfs4_parked;                  /* queued request awaiting a slot (nfs4_slot.c) */
+struct chimera_nfs4_parked;         /* queued request awaiting a slot (nfs4_slot.c) */
+struct chimera_nfs4_layout;         /* per-file pNFS layout (nfs4_pnfs.h)        */
 
 /* One owned fore-channel slot. */
 struct chimera_nfs4_slot {
-    uint32_t global_id;                      /* sa_slotid to send on the wire               */
-    uint32_t seqid;                          /* next sa_sequenceid; starts at 1             */
-    uint8_t  in_use;                         /* 1 == one request outstanding on this slot   */
+    uint32_t global_id;             /* sa_slotid to send on the wire               */
+    uint32_t seqid;                 /* next sa_sequenceid; starts at 1             */
+    uint8_t  in_use;                /* 1 == one request outstanding on this slot   */
 };
 
 /*
@@ -193,6 +195,14 @@ struct chimera_nfs_client_server {
      * (shared->cb_thread).  CREATE_SESSION binds the back channel to it, so the
      * server can deliver CB_COMPOUND here for the life of the session. */
     struct evpl_rpc2_conn              *cb_conn;
+
+    /* pNFS (flex-files).  pnfs_requested is set from the `pnfs` mount option;
+     * mds_pnfs_capable is set true once EXCHANGE_ID confirms USE_PNFS_MDS.
+     * is_ds marks a server that was registered as a data server (reached for
+     * direct DS I/O), not an MDS mount. */
+    int                                 pnfs_requested;
+    int                                 mds_pnfs_capable;
+    int                                 is_ds;
 };
 
 struct chimera_nfs_client_mount {
@@ -210,24 +220,54 @@ struct chimera_nfs_client_open_handle {
     struct chimera_nfs_client_open_handle *next;
 };
 
-struct chimera_nfs_shared {
-    struct chimera_nfs_client_mount   *mounts;
+/*
+ * Client-side device cache (deviceid -> resolved DS server slot + decoded
+ * device), mirror of the server's nfs_pnfs_devcache.  Populated by
+ * GETDEVICEINFO so device resolution happens once per deviceid.
+ */
+#define CHIMERA_NFS4_CLIENT_DEVCACHE_MAX 64
 
-    struct chimera_nfs_client_server **servers;
-    struct chimera_nfs_client_server  *servers_map;
-    int                                max_servers;
-    pthread_mutex_t                    lock;
+struct chimera_nfs4_client_devcache_entry {
+    uint8_t                          deviceid[CHIMERA_VFS_DEVICEID_SIZE];
+    int                              valid;
+    int                              server_index;  /* resolved DS server slot */
+    struct chimera_vfs_layout_device device;
+};
+
+struct chimera_nfs4_client_devcache {
+    pthread_mutex_t                           lock;
+    uint32_t                                  count;
+    struct chimera_nfs4_client_devcache_entry entries[CHIMERA_NFS4_CLIENT_DEVCACHE_MAX];
+};
+
+struct chimera_nfs_shared {
+    struct chimera_nfs_client_mount    *mounts;
+
+    struct chimera_nfs_client_server  **servers;
+    struct chimera_nfs_client_server   *servers_map;
+    int                                 max_servers;
+    pthread_mutex_t                     lock;
 
     /* Number of NFS client (evpl) threads, counted at thread_init; used to size
      * each thread's fore-channel slot block (max_slots / nfs_thread_count). */
-    _Atomic int                        nfs_thread_count;
+    _Atomic int                         nfs_thread_count;
 
-    struct PORTMAP_V2                  portmap_v2;
-    struct NFS_MOUNT_V3                mount_v3;
-    struct NFS_V3                      nfs_v3;
-    struct NFS_V4                      nfs_v4;
-    struct NFS_V4_CB                   nfs_v4_cb;
-    struct NLM_V4                      nlm_v4;
+    /* pNFS client device cache (flex-files). */
+    struct chimera_nfs4_client_devcache pnfs_devcache;
+
+    /* pNFS layout registry: active (VALID / fenced) flex-files layouts, so the
+     * back-channel CB_LAYOUTRECALL handler can find one by file handle and fence
+     * its DS I/O.  Layouts are embedded in open states; this list links them via
+     * layout->reg_next under pnfs_layout_lock. */
+    pthread_mutex_t                     pnfs_layout_lock;
+    struct chimera_nfs4_layout         *pnfs_layouts;
+
+    struct PORTMAP_V2                   portmap_v2;
+    struct NFS_MOUNT_V3                 mount_v3;
+    struct NFS_V3                       nfs_v3;
+    struct NFS_V4                       nfs_v4;
+    struct NFS_V4_CB                    nfs_v4_cb;
+    struct NLM_V4                       nlm_v4;
 
     /* Back-channel control thread (nfs4_cb.c).  A single dedicated evpl thread
      * owns a persistent connection per server (server->cb_conn) on which it runs
@@ -235,16 +275,16 @@ struct chimera_nfs_shared {
      * incoming CB_COMPOUND.  Started lazily on the first NFSv4.1 mount.  Mount
      * threads request establishment by pushing onto cb_establish_queue (under
      * cb_lock) and ringing cb_doorbell. */
-    struct evpl_thread                *cb_thread;
-    struct evpl                       *cb_evpl;
-    struct evpl_rpc2_thread           *cb_rpc2_thread;
-    struct evpl_doorbell               cb_doorbell;
-    pthread_mutex_t                    cb_lock;
-    struct chimera_nfs4_cb_establish  *cb_establish_queue;
-    int                                cb_started;
+    struct evpl_thread                 *cb_thread;
+    struct evpl                        *cb_evpl;
+    struct evpl_rpc2_thread            *cb_rpc2_thread;
+    struct evpl_doorbell                cb_doorbell;
+    pthread_mutex_t                     cb_lock;
+    struct chimera_nfs4_cb_establish   *cb_establish_queue;
+    int                                 cb_started;
 
-    struct prometheus_histogram       *op_histogram;
-    struct prometheus_metrics         *metrics;
+    struct prometheus_histogram        *op_histogram;
+    struct prometheus_metrics          *metrics;
 
     /* evpl stream protocol for outbound plain-TCP connections, resolved from
      * the common tcp_flavor setting (chimera_vfs->tcp_flavor) at mount time.

--- a/src/vfs/nfs/nfs_internal.h
+++ b/src/vfs/nfs/nfs_internal.h
@@ -88,48 +88,58 @@ enum chimera_nfs_client_mount_state {
  *
  * RFC 8881 §2.10.6.1 requires one outstanding request per fore-channel slot,
  * each slot carrying its own monotonic sequenceid.  The session owns the global
- * slot space (max_slots, granted by CREATE_SESSION); each per-thread connection
- * (chimera_nfs_client_server_thread) claims a disjoint block of slot indices
- * from `next_unclaimed` (under `lock`, once) and manages them thread-locally.
+ * slot space (max_slots, granted by CREATE_SESSION).  Slot ids are handed out
+ * cooperatively (nfs4_slot.c): each per-thread connection keeps a private floor
+ * of slots plus a batch it borrows from / returns to this shared pool, so a busy
+ * thread can use far more than its even share while idle threads give slots back.
+ * `lock` is taken only on batched borrow/return/floor-claim/target-change, never
+ * per operation.
  */
 struct chimera_nfs4_client_session {
-    pthread_mutex_t lock;          /* guards next_unclaimed / claimed_blocks only */
-    uint8_t         sessionid[NFS4_SESSIONID_SIZE];
-    uint64_t        clientid;
-    uint32_t        max_slots;     /* fore-channel slots granted (ca_maxrequests) */
-    uint32_t        next_unclaimed; /* next free global slot index to hand out    */
-    uint32_t        claimed_blocks; /* threads that have claimed a block so far;  *
-                                    * used to reserve >=1 slot for each thread   *
-                                    * that has not claimed yet (no over-grab).   */
+    pthread_mutex_t  lock;          /* guards the pool + usable; NOT per-op        */
+    uint8_t          sessionid[NFS4_SESSIONID_SIZE];
+    uint64_t         clientid;
+    uint32_t         max_slots;     /* fore-channel slots granted (ca_maxrequests) */
+    _Atomic uint32_t usable;        /* applied usable count = clamp(target+1, ...,   *
+                                     * max_slots); relaxed-read on the hot path to  *
+                                     * fill sa_highest_slotid, written under lock.  */
+    _Atomic uint32_t target_usable; /* server-requested usable (sr_target+1); set   *
+                                     * relaxed on a reply when it changes, applied  *
+                                     * to `usable` + pool under lock at next batch.  */
+    uint32_t        *slot_seqid;    /* [max_slots] next sa_sequenceid per id (>=1)  */
+    uint32_t        *free_ids;      /* [max_slots] pool of available ids < usable   */
+    uint32_t         free_count;    /* top of free_ids stack                        */
+    uint32_t        *retired_ids;   /* [max_slots] ids >= usable, parked on shrink  */
+    uint32_t         retired_count; /* top of retired_ids stack                     */
+    uint32_t         claimed_floors; /* threads that have claimed a floor so far;   *
+                                     * reserve >=1 id for each unclaimed thread.   */
 };
 
 struct chimera_nfs_client_mount;
 struct chimera_nfs4_compound_ctx;   /* in-flight wrapper context (nfs4_slot.c)   */
-struct chimera_nfs4_parked;         /* queued request awaiting a slot (nfs4_slot.c) */
-struct chimera_nfs4_layout;         /* per-file pNFS layout (nfs4_pnfs.h)        */
-
-/* One owned fore-channel slot. */
-struct chimera_nfs4_slot {
-    uint32_t global_id;             /* sa_slotid to send on the wire               */
-    uint32_t seqid;                 /* next sa_sequenceid; starts at 1             */
-    uint8_t  in_use;                /* 1 == one request outstanding on this slot   */
-};
+struct chimera_nfs4_parked;                   /* queued request awaiting a slot (nfs4_slot.c) */
+struct chimera_nfs4_layout;                   /* per-file pNFS layout (nfs4_pnfs.h)        */
 
 /*
  * Per-(thread,server) fore-channel slot table.  Touched by exactly one evpl
- * thread (its owning chimera_nfs_thread), so all of acquire/release/park/wake
- * are lock-free; only the one-time block claim takes session->lock.
+ * thread (its owning chimera_nfs_thread), so acquire/release/park/wake are
+ * lock-free; only batched borrow/return from the session pool takes
+ * session->lock.  `local_free` holds this thread's currently-owned, not-in-use
+ * global slot ids (a small stack); per-id seqids live in session->slot_seqid.
  */
 struct chimera_nfs4_slot_table {
     int                               initialized;
-    uint32_t                          num_slots;
-    struct chimera_nfs4_slot         *slots; /* [num_slots]                */
-    uint32_t                         *free_stack;   /* local indices not in use   */
-    int                               free_top;
-    struct chimera_nfs4_parked       *wait_head;    /* FIFO of parked requests    */
+    uint32_t                         *local_free;    /* [max_slots] owned-free ids */
+    int                               local_free_top; /* top of local_free stack   */
+    uint32_t                          leased; /* ids owned (floor+borrowed) */
+    uint32_t                          floor;  /* reserved ids, never returned *
+                                               * except at teardown          */
+    uint32_t                          cached_target; /* last-seen sr_target+1; cheap *
+                                                      * change detect, no per-op atomic */
+    struct chimera_nfs4_parked       *wait_head;     /* FIFO of parked requests    */
     struct chimera_nfs4_parked       *wait_tail;
     struct chimera_nfs4_parked       *parked_freelist;
-    struct chimera_nfs4_compound_ctx *inflight;     /* dll, for disconnect reset  */
+    struct chimera_nfs4_compound_ctx *inflight;      /* dll, for disconnect reset  */
     struct chimera_nfs4_compound_ctx *ctx_freelist;
 };
 
@@ -839,9 +849,17 @@ void chimera_nfs4_compound_call(
     chimera_nfs4_retry_fn retry_fn,
     void *retry_ctx);
 
-/* Free a server_thread's slot table (called from thread teardown). */
+/* Allocate/free the session-global fore-channel slot pool (slot_seqid, free_ids,
+ * retired_ids) once max_slots is known at CREATE_SESSION. */
+void chimera_nfs4_session_pool_init(
+    struct chimera_nfs4_client_session *session);
+void chimera_nfs4_session_pool_destroy(
+    struct chimera_nfs4_client_session *session);
+
+/* Free a server_thread's slot table (called from thread teardown).  Returns the
+ * thread's leased slot ids (floor + borrowed) to the session pool first. */
 void chimera_nfs4_slot_table_destroy(
-    struct chimera_nfs4_slot_table *st);
+    struct chimera_nfs_client_server_thread *server_thread);
 
 /* On connection loss: error-complete in-flight + parked requests and reset the
  * slot table so the next op re-establishes cleanly. */

--- a/src/vfs/nfs/nfs_internal.h
+++ b/src/vfs/nfs/nfs_internal.h
@@ -141,6 +141,14 @@ struct chimera_nfs_client_server_thread {
     struct evpl_rpc2_conn            *nfs_conn;
     struct evpl_rpc2_conn            *nlm_conn;
 
+    /* nfs_conn readiness.  RDMA forbids advertising an rkey (a bulk read/write
+     * RDMA chunk) before the QP is bound to a device, i.e. before
+     * EVPL_RPC2_NOTIFY_CONNECTED -- so a freshly-created RDMA conn is NOT ready
+     * and pNFS DS I/O parks on conn_waiters until CONNECTED fires.  TCP tolerates
+     * send-before-connect, so a TCP conn is marked ready at creation. */
+    int                               nfs_conn_ready;
+    struct chimera_vfs_request       *conn_waiters;
+
     struct chimera_nfs4_slot_table    slots;        /* NFS4.1 fore-channel slots  */
 };
 
@@ -379,6 +387,9 @@ chimera_nfs_thread_get_server_thread(
                                                            proto,
                                                            server_thread->server->nfs_endpoint,
                                                            NULL, 0, NULL);
+        /* TCP can be used immediately; an RDMA conn must reach CONNECTED before
+         * any rkey-advertising op (see nfs_conn_ready). */
+        server_thread->nfs_conn_ready = !server_thread->server->use_rdma;
     }
 
     if (unlikely(!server_thread->nlm_conn && server_thread->server->nlm_endpoint)) {
@@ -828,6 +839,14 @@ void chimera_nfs4_slot_table_destroy(
 void chimera_nfs4_slot_table_reset(
     struct evpl                    *evpl,
     struct chimera_nfs4_slot_table *st);
+
+/* pNFS DS-connection readiness (nfs4_pnfs.c), driven from chimera_nfs_notify:
+ * replay DS I/O parked until the RDMA conn connected, or error-complete it if
+ * the conn dropped first. */
+void chimera_nfs4_pnfs_conn_connected(
+    struct chimera_nfs_client_server_thread *server_thread);
+void chimera_nfs4_pnfs_conn_failed(
+    struct chimera_nfs_client_server_thread *server_thread);
 
 void chimera_nfs3_mount(
     struct chimera_nfs_thread *,

--- a/src/vfs/nfs/nfs_internal.h
+++ b/src/vfs/nfs/nfs_internal.h
@@ -93,12 +93,14 @@ enum chimera_nfs_client_mount_state {
  * from `next_unclaimed` (under `lock`, once) and manages them thread-locally.
  */
 struct chimera_nfs4_client_session {
-    pthread_mutex_t lock;          /* guards next_unclaimed / overflow_rr only   */
+    pthread_mutex_t lock;          /* guards next_unclaimed / claimed_blocks only */
     uint8_t         sessionid[NFS4_SESSIONID_SIZE];
     uint64_t        clientid;
     uint32_t        max_slots;     /* fore-channel slots granted (ca_maxrequests) */
     uint32_t        next_unclaimed; /* next free global slot index to hand out    */
-    uint32_t        overflow_rr;   /* round-robin alias when the pool is exhausted */
+    uint32_t        claimed_blocks; /* threads that have claimed a block so far;  *
+                                    * used to reserve >=1 slot for each thread   *
+                                    * that has not claimed yet (no over-grab).   */
 };
 
 struct chimera_nfs_client_mount;
@@ -192,6 +194,13 @@ struct chimera_nfs_client_server {
     struct chimera_vfs_request         *pending_mounts;
 
     char                                hostname[256];
+
+    /* Fore-channel session slots this client requests at CREATE_SESSION
+     * (ca_maxrequests).  The client partitions slots one block per evpl thread,
+     * so this should be >= the client thread count or surplus threads share a
+     * slot and collide (NFS4ERR_SEQ_MISORDERED).  Set from the `slots=` mount
+     * option; the server clamps it to its own nfs4_session_slots. */
+    int                                 requested_session_slots;
 
     /* NFS4-specific fields (only used when nfsvers == 4) */
     struct chimera_nfs4_client_session *nfs4_session;

--- a/src/vfs/vfs_pnfs.c
+++ b/src/vfs/vfs_pnfs.c
@@ -57,6 +57,7 @@ chimera_vfs_pnfs_add_device(
     struct chimera_vfs *vfs,
     const char         *netid,
     const char         *uaddr,
+    const char         *rdma_uaddr,
     const char         *backing_path,
     int                 version,
     int                 minorversion)
@@ -81,6 +82,7 @@ chimera_vfs_pnfs_add_device(
 
     snprintf(ds->netid, sizeof(ds->netid), "%s", netid ? netid : "tcp");
     snprintf(ds->uaddr, sizeof(ds->uaddr), "%s", uaddr ? uaddr : "");
+    snprintf(ds->rdma_uaddr, sizeof(ds->rdma_uaddr), "%s", rdma_uaddr ? rdma_uaddr : "");
     snprintf(ds->backing_path, sizeof(ds->backing_path), "%s", backing_path ? backing_path : "");
     ds->version      = version ? version : 3;
     ds->minorversion = minorversion;

--- a/src/vfs/vfs_pnfs.h
+++ b/src/vfs/vfs_pnfs.h
@@ -105,6 +105,10 @@ struct chimera_vfs_ds {
     uint8_t  deviceid[CHIMERA_VFS_DEVICEID_SIZE]; /* stable id advertised to clients */
     char     netid[8];                            /* RFC5665 netid, e.g. "tcp"       */
     char     uaddr[64];                           /* RFC5665 universal address (DS)  */
+    /* Optional second (RDMA) universal address.  When non-empty the device
+     * advertises BOTH this "rdma" netaddr (preferred) and the "tcp" netaddr
+     * above, so RDMA-capable clients use RDMA and others fall back to TCP. */
+    char     rdma_uaddr[64];
     int      version;                             /* NFS version advertised for DS   */
     int      minorversion;                        /* NFS minor version (4.x)         */
     uint8_t  backing_local;                       /* 1 = backing is a local (non-nfs)
@@ -156,6 +160,7 @@ int chimera_vfs_pnfs_add_device(
     struct chimera_vfs *vfs,
     const char         *netid,
     const char         *uaddr,
+    const char         *rdma_uaddr,
     const char         *backing_path,
     int                 version,
     int                 minorversion);


### PR DESCRIPTION
## Summary

Implements an **NFSv4.1 flex-files pNFS client** in the `nfs` VFS proxy module: the client acquires file layouts from an MDS and reads/writes data directly to the data servers, with full layout-recall handling over the back channel (merged in #649). Built and validated against chimera's own pNFS server.

## What's included

**Flex-files pNFS client** (`src/vfs/nfs/nfs4_pnfs.c`, new):
- `LAYOUTGET` + `GETDEVICEINFO` acquire a whole-file flex-files layout and resolve its data server (registered as another `chimera_nfs_client_server`); `READ`/`WRITE` redirect to the DS over NFSv3; close reports size via `LAYOUTCOMMIT` and releases the layout via `LAYOUTRETURN`. `ff_layout4` / `ff_device_addr4` are hand-decoded.
- `EXCHANGE_ID` advertises `USE_PNFS_MDS` and records `mds_pnfs_capable`; pNFS is opt-in via the `pnfs` mount option and transparently falls back to plain NFSv4.1 when the server isn't an MDS.

**CB_LAYOUTRECALL handling:**
- A layout registry tracks active VALID layouts so the back-channel handler can match a recalled MDS file handle, fence further DS I/O (state → UNAVAIL, falling back to the MDS), and answer `NFS4ERR_NOMATCHING_LAYOUT`. This clears the concurrent multi-file hang that occurred when the MDS recalled layouts for a client with no callback channel.

**RDMA data servers + dual advertisement:**
- The server advertises both `rdma` and `tcp` netaddrs for a DS (configurable, `tcp` required / `rdma` optional, ports optional); the client prefers RDMA when present. DS I/O parks until the RDMA connection is bound to a device (avoids advertising an rkey before the QP is up), then replays.

**Cooperative session-slot layer** (`src/vfs/nfs/nfs4_slot.c` rework):
- Configurable fore-channel slots (`slots=` mount option; server default `nfs4_session_slots` raised 64 → 256).
- Replaces the fixed per-thread block (≤16/thread, statically divided) with a floor-plus-shared-pool magazine: a busy thread borrows beyond its even share while idle threads return slots, with a lock-free hot path (the session lock is taken only on batched borrow/return, never per op). Honors the server's dynamic `sr_target_highest_slotid` limit. A 1-slot per-thread floor guarantees same-thread wakeup; under-provisioning (`usable < threads`) fails loudly.

**Testing infrastructure:**
- A netns-based KVM test (`kvm_pnfs_proxy_test_wrapper.sh`) exercises chimera's pNFS client against its own pNFS server (proxy topology) across memfs / diskfs backends, including the layout-recall path.

## Notes

- Builds on the NFSv4.1 back channel (#649) and the session-slot foundation, both already on main.
- Known follow-ups (flagged in code): proactively `LAYOUTCOMMIT` the size on recall so a non-truncate `SETATTR` racing uncommitted DS writes can't leave the MDS size stale; fence a recall that races an in-flight (not-yet-registered) `LAYOUTGET`.

All 498 `posix/*_nfs4_*` tests pass under Release and Debug/ASan across memfs/cairn/diskfs/linux/io_uring; the pNFS proxy KVM tests pass on memfs and diskfs.
