### PR TITLE
s3/tests: poll the S3 port for readiness instead of a fixed sleep

### DIFF
--- a/src/server/s3/tests/s3_test.py
+++ b/src/server/s3/tests/s3_test.py
@@ -17,6 +17,7 @@ import json
 import os
 import shutil
 import signal
+import socket
 import subprocess
 import sys
 import tempfile
@@ -168,12 +169,22 @@ class ChimeraServer:
             stderr=subprocess.PIPE if not self.debug else None,
         )
 
-        # Wait for server to be ready
-        time.sleep(1)
-
-        if self.process.poll() is not None:
-            stdout, stderr = self.process.communicate()
-            raise RuntimeError(f"Server failed to start: {stderr.decode() if stderr else 'unknown error'}")
+        # Wait for the S3 port to actually accept connections. A fixed sleep
+        # races the daemon's bind under load (parallel ctest on a busy runner),
+        # producing intermittent "Connection refused" in the boto3 client.
+        s3_port = 5000
+        deadline = time.time() + 30
+        while True:
+            if self.process.poll() is not None:
+                stdout, stderr = self.process.communicate()
+                raise RuntimeError(f"Server failed to start: {stderr.decode() if stderr else 'unknown error'}")
+            try:
+                with socket.create_connection(('127.0.0.1', s3_port), timeout=1):
+                    break
+            except OSError:
+                if time.time() >= deadline:
+                    raise RuntimeError(f"Server S3 port 127.0.0.1:{s3_port} not ready after 30s")
+                time.sleep(0.1)
 
         print("Server started successfully")
 


### PR DESCRIPTION
## Problem
The boto3 S3 test harness (`src/server/s3/tests/s3_test.py`) waited a fixed `time.sleep(1)` after spawning the chimera daemon before connecting. Under parallel ctest on a loaded CI runner the daemon process is alive but has not yet **bound its S3 port** within that 1s window, so the boto3 client intermittently fails with `[Errno 111] Connection refused`.

Observed as a flaky `chimera/server/s3/boto3_v4_cairn_streaming` failure on the rocky9 job (the test passes locally and on retry). Each S3 test runs in its own network namespace, so this is purely a startup-readiness timing issue — not a port collision.

## Fix
Replace the fixed sleep with a connect-poll against `127.0.0.1:5000` (the daemon's S3 port), retrying for up to 30s. The process-liveness check is preserved (still fails fast with captured stderr if the daemon dies during startup). The common case is unaffected or slightly faster — the poll returns the instant the port is listening.

## Verification
- `boto3_v4_cairn_streaming`, `boto3_v4_memfs_put`, `boto3_v4_cairn_multipart` all pass via ctest after the change.
- Python syntax validated.