### PR TITLE
vfs: add memkv + sqlite KV-only backends; default-KV fallback for non-KV backends

### DIFF
--- a/src/server/server.c
+++ b/src/server/server.c
@@ -256,14 +256,20 @@ chimera_server_config_init(void)
     config->modules[3].config_data[0] = '\0';
     config->modules[3].module_path[0] = '\0';
 
-    config->num_modules = 4;
-
-#ifdef HAVE_IO_URING
-    strncpy(config->modules[4].module_name, "io_uring", sizeof(config->modules[4].module_name));
+    /* memkv is the default KV backend (see chimera_vfs_init); register it
+     * unconditionally so zero-config deployments always have a KV store. */
+    strncpy(config->modules[4].module_name, "memkv", sizeof(config->modules[4].module_name));
     config->modules[4].config_data[0] = '\0';
     config->modules[4].module_path[0] = '\0';
 
     config->num_modules = 5;
+
+#ifdef HAVE_IO_URING
+    strncpy(config->modules[5].module_name, "io_uring", sizeof(config->modules[5].module_name));
+    config->modules[5].config_data[0] = '\0';
+    config->modules[5].module_path[0] = '\0';
+
+    config->num_modules = 6;
 #endif /* ifdef HAVE_IO_URING */
 
     return config;

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -256,21 +256,18 @@ chimera_server_config_init(void)
     config->modules[3].config_data[0] = '\0';
     config->modules[3].module_path[0] = '\0';
 
-    /* memkv is the default KV backend (see chimera_vfs_init); register it
-     * unconditionally so zero-config deployments always have a KV store. */
-    strncpy(config->modules[4].module_name, "memkv", sizeof(config->modules[4].module_name));
+    config->num_modules = 4;
+
+#ifdef HAVE_IO_URING
+    strncpy(config->modules[4].module_name, "io_uring", sizeof(config->modules[4].module_name));
     config->modules[4].config_data[0] = '\0';
     config->modules[4].module_path[0] = '\0';
 
     config->num_modules = 5;
-
-#ifdef HAVE_IO_URING
-    strncpy(config->modules[5].module_name, "io_uring", sizeof(config->modules[5].module_name));
-    config->modules[5].config_data[0] = '\0';
-    config->modules[5].module_path[0] = '\0';
-
-    config->num_modules = 6;
 #endif /* ifdef HAVE_IO_URING */
+
+    /* The default KV module (memkv) is auto-registered by chimera_vfs_init; it
+     * need not be listed here. */
 
     return config;
 } /* chimera_server_config_init */

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -1346,9 +1346,12 @@ chimera_smb_disposition_overwrites(uint32_t disposition)
 } /* chimera_smb_disposition_overwrites */
 
 /* Decide whether this open is a persistent-handle grant whose record must be
- * persisted atomically with the open, and if so build the handle-state
- * descriptor (request->create.persist_*).  Returns true if persisting; the
- * caller then opens via chimera_vfs_open_at_hs. */
+ * persisted with the open, and if so build the handle-state descriptor
+ * (request->create.persist_*).  Returns true if persisting; the caller then
+ * opens via chimera_vfs_open_at_hs.  The record is persisted atomically by
+ * backends advertising CAP_ATOMIC_HANDLE_STATE, or by the VFS core into the
+ * default KV for backends without native KV (see
+ * chimera_vfs_can_persist_handle_state). */
 static bool
 chimera_smb_create_persist_prepare(
     struct chimera_smb_request     *request,
@@ -1371,8 +1374,8 @@ chimera_smb_create_persist_prepare(
         return false;
     }
 
-    if (!parent_handle || !parent_handle->vfs_module ||
-        !(parent_handle->vfs_module->capabilities & CHIMERA_VFS_CAP_ATOMIC_HANDLE_STATE)) {
+    if (!chimera_vfs_can_persist_handle_state(request->compound->thread->vfs_thread,
+                                              parent_handle)) {
         return false;
     }
 

--- a/src/vfs/CMakeLists.txt
+++ b/src/vfs/CMakeLists.txt
@@ -48,6 +48,7 @@ install(TARGETS chimera_vfs DESTINATION lib)
 
 add_subdirectory(root)
 add_subdirectory(memfs)
+add_subdirectory(memkv)
 add_subdirectory(linux)
 add_subdirectory(nfs)
 
@@ -61,13 +62,29 @@ if (CAIRN_ENABLED)
     add_subdirectory(cairn)
 endif()
 
+# sqlite KV backend: built when the sqlite3 development headers are available.
+find_path(SQLITE3_INCLUDE_DIR sqlite3.h)
+find_library(SQLITE3_LIBRARY sqlite3)
+if (SQLITE3_INCLUDE_DIR AND SQLITE3_LIBRARY)
+    set(SQLITE_ENABLED TRUE)
+    message(STATUS "sqlite3 found (${SQLITE3_LIBRARY}); building chimera_vfs_sqlite")
+    add_subdirectory(sqlite)
+else ()
+    set(SQLITE_ENABLED FALSE)
+    message(STATUS "sqlite3 not found; skipping chimera_vfs_sqlite")
+endif()
+
 target_link_libraries(chimera_vfs
-    chimera_vfs_root chimera_vfs_memfs chimera_vfs_linux chimera_vfs_diskfs
+    chimera_vfs_root chimera_vfs_memfs chimera_vfs_memkv chimera_vfs_linux chimera_vfs_diskfs
     chimera_vfs_nfs
     chimera_common prometheus-c xxhash dl urcu-qsbr)
 
 if (CHIMERA_VFS_IO_URING)
     target_link_libraries(chimera_vfs chimera_vfs_io_uring)
+endif()
+
+if (SQLITE_ENABLED)
+    target_link_libraries(chimera_vfs chimera_vfs_sqlite)
 endif()
 
 if (DEMFS_ENABLED)

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -107,21 +107,6 @@ struct memfs_symlink_target {
     struct memfs_symlink_target *next;
 };
 
-struct memfs_kv_entry {
-    uint64_t               hash;
-    uint32_t               key_len;
-    uint32_t               value_len;
-    struct rb_node         node;
-    struct memfs_kv_entry *next;
-    void                  *key;
-    void                  *value;
-};
-
-struct memfs_kv_shard {
-    struct rb_tree  entries;
-    pthread_mutex_t lock;
-};
-
 struct memfs_xattr {
     struct memfs_xattr *next;
     char               *name;
@@ -220,8 +205,6 @@ struct memfs_inode_list {
 struct memfs_shared {
     struct memfs_inode_list *inode_list;
     int                      num_inode_list;
-    struct memfs_kv_shard   *kv_shards;
-    int                      num_kv_shards;
     int                      num_active_threads;
     uint8_t                  root_fh[CHIMERA_VFS_FH_SIZE];
     uint32_t                 root_fhlen;
@@ -241,7 +224,6 @@ struct memfs_thread {
     struct memfs_dirent         *free_dirent;
     struct memfs_symlink_target *free_symlink_target;
     struct memfs_block          *free_block;
-    struct memfs_kv_entry       *free_kv_entry;
 };
 
 static inline void
@@ -827,60 +809,6 @@ memfs_dirent_release(
 } /* memfs_dirent_release */
 
 
-static inline struct memfs_kv_entry *
-memfs_kv_entry_alloc(
-    struct memfs_thread *thread,
-    uint64_t             hash,
-    const void          *key,
-    uint32_t             key_len,
-    const void          *value,
-    uint32_t             value_len)
-{
-    struct memfs_kv_entry *entry;
-
-    entry = thread->free_kv_entry;
-
-    if (entry) {
-        LL_DELETE(thread->free_kv_entry, entry);
-        /* Free old key/value if reusing */
-        free(entry->key);
-        free(entry->value);
-    } else {
-        entry = malloc(sizeof(*entry));
-    }
-
-    entry->hash      = hash;
-    entry->key_len   = key_len;
-    entry->value_len = value_len;
-    entry->key       = malloc(key_len);
-    entry->value     = malloc(value_len);
-    memcpy(entry->key, key, key_len);
-    memcpy(entry->value, value, value_len);
-
-    return entry;
-
-} /* memfs_kv_entry_alloc */
-
-static inline void
-memfs_kv_entry_free(
-    struct memfs_thread   *thread,
-    struct memfs_kv_entry *entry)
-{
-    LL_PREPEND(thread->free_kv_entry, entry);
-} /* memfs_kv_entry_free */
-
-static void
-memfs_kv_entry_release(
-    struct rb_node *node,
-    void           *private_data)
-{
-    struct memfs_kv_entry *entry = container_of(node, struct memfs_kv_entry, node);
-
-    free(entry->key);
-    free(entry->value);
-    free(entry);
-} /* memfs_kv_entry_release */
-
 static void *
 memfs_init(
     const char                *cfgdata,
@@ -963,15 +891,6 @@ memfs_init(
         inode_list->max_blocks = 0;
 
         pthread_mutex_init(&inode_list->lock, NULL);
-    }
-
-    /* Initialize KV shards */
-    shared->num_kv_shards = 256;
-    shared->kv_shards     = calloc(shared->num_kv_shards, sizeof(*shared->kv_shards));
-
-    for (i = 0; i < shared->num_kv_shards; i++) {
-        rb_tree_init(&shared->kv_shards[i].entries);
-        pthread_mutex_init(&shared->kv_shards[i].lock, NULL);
     }
 
     inode = memfs_inode_alloc(shared, 0);
@@ -1100,13 +1019,6 @@ memfs_destroy(void *private_data)
     pthread_mutex_destroy(&shared->lock);
     free(shared->inode_list);
 
-    /* Clean up KV shards */
-    for (i = 0; i < shared->num_kv_shards; i++) {
-        rb_tree_destroy(&shared->kv_shards[i].entries, memfs_kv_entry_release, NULL);
-        pthread_mutex_destroy(&shared->kv_shards[i].lock);
-    }
-    free(shared->kv_shards);
-
     free(shared);
 } /* memfs_destroy */
 
@@ -1137,7 +1049,6 @@ memfs_thread_destroy(void *private_data)
     struct memfs_dirent         *dirent;
     struct memfs_symlink_target *target;
     struct memfs_block          *block;
-    struct memfs_kv_entry       *kv_entry;
 
     evpl_iovec_release(thread->evpl, &thread->zero);
 
@@ -1158,14 +1069,6 @@ memfs_thread_destroy(void *private_data)
         block = thread->free_block;
         LL_DELETE(thread->free_block, block);
         free(block);
-    }
-
-    while (thread->free_kv_entry) {
-        kv_entry = thread->free_kv_entry;
-        LL_DELETE(thread->free_kv_entry, kv_entry);
-        free(kv_entry->key);
-        free(kv_entry->value);
-        free(kv_entry);
     }
 
     free(thread);
@@ -2523,12 +2426,6 @@ memfs_readdir(
     request->complete(request);
 } /* memfs_readdir */
 
-static inline void
-memfs_store_handle_state(
-    struct memfs_thread             *thread,
-    struct memfs_shared             *shared,
-    struct chimera_vfs_handle_state *hs);
-
 static void
 memfs_open_fh(
     struct memfs_thread        *thread,
@@ -2550,8 +2447,6 @@ memfs_open_fh(
     pthread_mutex_unlock(&inode->lock);
 
     request->open_fh.r_vfs_private = (uint64_t) inode;
-
-    memfs_store_handle_state(thread, shared, request->open_fh.handle_state);
 
     request->status = CHIMERA_VFS_OK;
     request->complete(request);
@@ -2705,8 +2600,6 @@ memfs_open_at(
     memfs_map_attrs(shared, &request->open_at.r_attr, inode, request->fh);
 
     pthread_mutex_unlock(&inode->lock);
-
-    memfs_store_handle_state(thread, shared, request->open_at.handle_state);
 
     request->status = CHIMERA_VFS_OK;
     request->complete(request);
@@ -4549,232 +4442,6 @@ memfs_link_at(
 } /* memfs_link_at */
 
 
-/* Insert-or-replace a KV pair in the sharded store.  Shared by the generic
- * PUT_KEY op and the atomic handle-state store on open. */
-static void
-memfs_kv_store(
-    struct memfs_thread *thread,
-    struct memfs_shared *shared,
-    const void          *key,
-    uint32_t             key_len,
-    const void          *value,
-    uint32_t             value_len)
-{
-    uint64_t               hash;
-    int                    shard_idx;
-    struct memfs_kv_shard *shard;
-    struct memfs_kv_entry *entry, *existing;
-
-    hash      = chimera_vfs_hash(key, key_len);
-    shard_idx = hash % shared->num_kv_shards;
-    shard     = &shared->kv_shards[shard_idx];
-
-    pthread_mutex_lock(&shard->lock);
-
-    rb_tree_query_exact(&shard->entries, hash, hash, existing);
-
-    if (existing) {
-        free(existing->value);
-        existing->value_len = value_len;
-        existing->value     = malloc(value_len);
-        memcpy(existing->value, value, value_len);
-    } else {
-        entry = memfs_kv_entry_alloc(thread, hash, key, key_len, value, value_len);
-        rb_tree_insert(&shard->entries, hash, entry);
-    }
-
-    pthread_mutex_unlock(&shard->lock);
-} /* memfs_kv_store */
-
-/* Honor an optional atomic handle-state record carried on an open.  memfs is
- * synchronous, so storing it inline before completing the open is trivially
- * atomic with respect to the open itself. */
-static inline void
-memfs_store_handle_state(
-    struct memfs_thread             *thread,
-    struct memfs_shared             *shared,
-    struct chimera_vfs_handle_state *hs)
-{
-    if (hs) {
-        memfs_kv_store(thread, shared, hs->key, hs->key_len, hs->value, hs->value_len);
-    }
-} /* memfs_store_handle_state */
-
-static void
-memfs_put_key(
-    struct memfs_thread        *thread,
-    struct memfs_shared        *shared,
-    struct chimera_vfs_request *request,
-    void                       *private_data)
-{
-    memfs_kv_store(thread, shared,
-                   request->put_key.key, request->put_key.key_len,
-                   request->put_key.value, request->put_key.value_len);
-
-    request->status = CHIMERA_VFS_OK;
-    request->complete(request);
-} /* memfs_put_key */
-
-static void
-memfs_get_key(
-    struct memfs_thread        *thread,
-    struct memfs_shared        *shared,
-    struct chimera_vfs_request *request,
-    void                       *private_data)
-{
-    uint64_t               hash;
-    int                    shard_idx;
-    struct memfs_kv_shard *shard;
-    struct memfs_kv_entry *entry;
-
-    hash      = chimera_vfs_hash(request->get_key.key, request->get_key.key_len);
-    shard_idx = hash % shared->num_kv_shards;
-    shard     = &shared->kv_shards[shard_idx];
-
-    pthread_mutex_lock(&shard->lock);
-
-    rb_tree_query_exact(&shard->entries, hash, hash, entry);
-
-    if (!entry) {
-        pthread_mutex_unlock(&shard->lock);
-        request->status = CHIMERA_VFS_ENOENT;
-        request->complete(request);
-        return;
-    }
-
-    /* Return pointer to value - caller must use before callback returns */
-    request->get_key.r_value     = entry->value;
-    request->get_key.r_value_len = entry->value_len;
-
-    pthread_mutex_unlock(&shard->lock);
-
-    request->status = CHIMERA_VFS_OK;
-    request->complete(request);
-} /* memfs_get_key */
-
-static void
-memfs_delete_key(
-    struct memfs_thread        *thread,
-    struct memfs_shared        *shared,
-    struct chimera_vfs_request *request,
-    void                       *private_data)
-{
-    uint64_t               hash;
-    int                    shard_idx;
-    struct memfs_kv_shard *shard;
-    struct memfs_kv_entry *entry;
-
-    hash      = chimera_vfs_hash(request->delete_key.key, request->delete_key.key_len);
-    shard_idx = hash % shared->num_kv_shards;
-    shard     = &shared->kv_shards[shard_idx];
-
-    pthread_mutex_lock(&shard->lock);
-
-    rb_tree_query_exact(&shard->entries, hash, hash, entry);
-
-    if (!entry) {
-        pthread_mutex_unlock(&shard->lock);
-        request->status = CHIMERA_VFS_ENOENT;
-        request->complete(request);
-        return;
-    }
-
-    rb_tree_remove(&shard->entries, &entry->node);
-
-    pthread_mutex_unlock(&shard->lock);
-
-    memfs_kv_entry_free(thread, entry);
-
-    request->status = CHIMERA_VFS_OK;
-    request->complete(request);
-} /* memfs_delete_key */
-
-static int
-memfs_kv_key_in_range(
-    const void *key,
-    uint32_t    key_len,
-    const void *start_key,
-    uint32_t    start_key_len,
-    const void *end_key,
-    uint32_t    end_key_len)
-{
-    int cmp;
-
-    /* Compare key to start_key */
-    if (start_key_len > 0) {
-        cmp = memcmp(key, start_key,
-                     key_len < start_key_len ? key_len : start_key_len);
-        if (cmp < 0 || (cmp == 0 && key_len < start_key_len)) {
-            return 0; /* key < start_key */
-        }
-    }
-
-    /* Compare key to end_key */
-    if (end_key_len > 0) {
-        cmp = memcmp(key, end_key,
-                     key_len < end_key_len ? key_len : end_key_len);
-        if (cmp > 0 || (cmp == 0 && key_len > end_key_len)) {
-            return 0; /* key > end_key */
-        }
-    }
-
-    return 1; /* key is in range [start_key, end_key] */
-} /* memfs_kv_key_in_range */
-
-static void
-memfs_search_keys(
-    struct memfs_thread        *thread,
-    struct memfs_shared        *shared,
-    struct chimera_vfs_request *request,
-    void                       *private_data)
-{
-    int                                i, rc;
-    struct memfs_kv_shard             *shard;
-    struct memfs_kv_entry             *entry;
-    chimera_vfs_search_keys_callback_t callback = request->search_keys.callback;
-
-    /* Iterate over all shards */
-    for (i = 0; i < shared->num_kv_shards; i++) {
-        shard = &shared->kv_shards[i];
-
-        pthread_mutex_lock(&shard->lock);
-
-        /* Iterate over all entries in the shard */
-        rb_tree_first(&shard->entries, entry);
-
-        while (entry) {
-            /* Check if key is in range */
-            if (memfs_kv_key_in_range(entry->key,
-                                      entry->key_len,
-                                      request->search_keys.start_key,
-                                      request->search_keys.start_key_len,
-                                      request->search_keys.end_key,
-                                      request->search_keys.end_key_len)) {
-                rc = callback(entry->key,
-                              entry->key_len,
-                              entry->value,
-                              entry->value_len,
-                              request->proto_private_data);
-
-                if (rc) {
-                    /* Caller wants to abort search */
-                    pthread_mutex_unlock(&shard->lock);
-                    request->status = CHIMERA_VFS_OK;
-                    request->complete(request);
-                    return;
-                }
-            }
-
-            entry = rb_tree_next(&shard->entries, entry);
-        }
-
-        pthread_mutex_unlock(&shard->lock);
-    }
-
-    request->status = CHIMERA_VFS_OK;
-    request->complete(request);
-} /* memfs_search_keys */
-
 static inline struct memfs_xattr *
 memfs_xattr_find(
     struct memfs_inode *inode,
@@ -5297,18 +4964,6 @@ memfs_dispatch(
         case CHIMERA_VFS_OP_LINK_AT:
             memfs_link_at(thread, shared, request, private_data);
             break;
-        case CHIMERA_VFS_OP_PUT_KEY:
-            memfs_put_key(thread, shared, request, private_data);
-            break;
-        case CHIMERA_VFS_OP_GET_KEY:
-            memfs_get_key(thread, shared, request, private_data);
-            break;
-        case CHIMERA_VFS_OP_DELETE_KEY:
-            memfs_delete_key(thread, shared, request, private_data);
-            break;
-        case CHIMERA_VFS_OP_SEARCH_KEYS:
-            memfs_search_keys(thread, shared, request, private_data);
-            break;
         case CHIMERA_VFS_OP_GET_XATTR:
             memfs_get_xattr(thread, shared, request, private_data);
             break;
@@ -5342,11 +4997,11 @@ memfs_dispatch(
 SYMBOL_EXPORT struct chimera_vfs_module vfs_memfs = {
     .name         = "memfs",
     .fh_magic     = CHIMERA_VFS_FH_MAGIC_MEMFS,
-    .capabilities = CHIMERA_VFS_CAP_CREATE_UNLINKED | CHIMERA_VFS_CAP_FS | CHIMERA_VFS_CAP_KV |
+    .capabilities = CHIMERA_VFS_CAP_CREATE_UNLINKED | CHIMERA_VFS_CAP_FS |
         CHIMERA_VFS_CAP_FS_RELATIVE_OP |
         CHIMERA_VFS_CAP_COPY_RANGE | CHIMERA_VFS_CAP_CLONE_RANGE | CHIMERA_VFS_CAP_MOVE_RANGE |
         CHIMERA_VFS_CAP_ACL_NATIVE | CHIMERA_VFS_CAP_XATTR | CHIMERA_VFS_CAP_LAYOUT |
-        CHIMERA_VFS_CAP_ATOMIC_HANDLE_STATE | CHIMERA_VFS_CAP_READ_PROVIDES_BUFFERS |
+        CHIMERA_VFS_CAP_READ_PROVIDES_BUFFERS |
         CHIMERA_VFS_CAP_NAMED_STREAMS | CHIMERA_VFS_CAP_RPL,
     .init           = memfs_init,
     .destroy        = memfs_destroy,

--- a/src/vfs/memkv/CMakeLists.txt
+++ b/src/vfs/memkv/CMakeLists.txt
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+#
+# SPDX-License-Identifier: LGPL-2.1-only
+
+add_library(chimera_vfs_memkv SHARED
+    memkv.c
+)
+
+target_compile_definitions(chimera_vfs_memkv PRIVATE
+    XXH_INLINE_ALL
+    $<$<STREQUAL:${CMAKE_SYSTEM_PROCESSOR},aarch64>:XXH_VECTOR=XXH_NEON>
+    $<$<NOT:$<STREQUAL:${CMAKE_SYSTEM_PROCESSOR},aarch64>>:XXH_VECTOR=XXH_AVX2>
+)
+
+target_link_libraries(chimera_vfs_memkv jansson)
+
+install(TARGETS chimera_vfs_memkv DESTINATION lib)

--- a/src/vfs/memkv/memkv.c
+++ b/src/vfs/memkv/memkv.c
@@ -1,0 +1,440 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * memkv: an in-memory, key-value-only VFS backend (CHIMERA_VFS_CAP_KV, no
+ * filesystem).  It is the default backing store for the VFS KV API and for
+ * handle-state records of filesystem backends that cannot persist KV natively.
+ *
+ * Storage is a fixed set of hash-sharded red-black trees keyed by
+ * chimera_vfs_hash(key); each shard has its own mutex so unrelated keys do not
+ * contend.  This is the same design that previously lived inside memfs.
+ */
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <pthread.h>
+#include <jansson.h>
+#include <utlist.h>
+
+#include "common/rbtree.h"
+
+#include "vfs/vfs.h"
+#include "vfs/vfs_internal.h"
+#include "memkv.h"
+#include "common/logging.h"
+#include "common/macros.h"
+
+#ifndef container_of
+#define container_of(ptr, type, member) \
+        ((type *) ((char *) (ptr) - offsetof(type, member)))
+#endif /* ifndef container_of */
+
+#define CHIMERA_MEMKV_DEFAULT_SHARDS 256
+
+#define chimera_memkv_error(...) chimera_error("memkv", \
+                                               __FILE__, \
+                                               __LINE__, \
+                                               __VA_ARGS__)
+#define chimera_memkv_abort_if(cond, ...) \
+        chimera_abort_if(cond, "memkv", __FILE__, __LINE__, __VA_ARGS__)
+
+struct memkv_entry {
+    uint64_t            hash;
+    uint32_t            key_len;
+    uint32_t            value_len;
+    struct rb_node      node;
+    struct memkv_entry *next;
+    void               *key;
+    void               *value;
+};
+
+struct memkv_shard {
+    struct rb_tree  entries;
+    pthread_mutex_t lock;
+};
+
+struct memkv_shared {
+    struct memkv_shard *shards;
+    int                 num_shards;
+};
+
+struct memkv_thread {
+    struct memkv_shared *shared;
+    struct memkv_entry  *free_entry;
+};
+
+static inline struct memkv_entry *
+memkv_entry_alloc(
+    struct memkv_thread *thread,
+    uint64_t             hash,
+    const void          *key,
+    uint32_t             key_len,
+    const void          *value,
+    uint32_t             value_len)
+{
+    struct memkv_entry *entry;
+
+    entry = thread->free_entry;
+
+    if (entry) {
+        LL_DELETE(thread->free_entry, entry);
+        /* Free old key/value if reusing */
+        free(entry->key);
+        free(entry->value);
+    } else {
+        entry = malloc(sizeof(*entry));
+    }
+
+    entry->hash      = hash;
+    entry->key_len   = key_len;
+    entry->value_len = value_len;
+    entry->key       = malloc(key_len);
+    entry->value     = malloc(value_len);
+    memcpy(entry->key, key, key_len);
+    memcpy(entry->value, value, value_len);
+
+    return entry;
+} /* memkv_entry_alloc */
+
+static inline void
+memkv_entry_free(
+    struct memkv_thread *thread,
+    struct memkv_entry  *entry)
+{
+    LL_PREPEND(thread->free_entry, entry);
+} /* memkv_entry_free */
+
+static void
+memkv_entry_release(
+    struct rb_node *node,
+    void           *private_data)
+{
+    struct memkv_entry *entry = container_of(node, struct memkv_entry, node);
+
+    free(entry->key);
+    free(entry->value);
+    free(entry);
+} /* memkv_entry_release */
+
+static void *
+memkv_init(
+    const char                *cfgdata,
+    struct prometheus_metrics *metrics)
+{
+    (void) metrics;
+    struct memkv_shared *shared = calloc(1, sizeof(*shared));
+    int                  i;
+
+    shared->num_shards = CHIMERA_MEMKV_DEFAULT_SHARDS;
+
+    if (cfgdata && cfgdata[0] != '\0') {
+        json_error_t json_error;
+        json_t      *cfg = json_loads(cfgdata, 0, &json_error);
+
+        chimera_memkv_abort_if(!cfg, "Failed to parse memkv config: %s",
+                               json_error.text);
+
+        json_t      *shards = json_object_get(cfg, "num_shards");
+        if (shards && json_is_integer(shards)) {
+            json_int_t v = json_integer_value(shards);
+            if (v > 0 && v <= 65536) {
+                shared->num_shards = (int) v;
+            }
+        }
+
+        json_decref(cfg);
+    }
+
+    shared->shards = calloc(shared->num_shards, sizeof(*shared->shards));
+
+    for (i = 0; i < shared->num_shards; i++) {
+        rb_tree_init(&shared->shards[i].entries);
+        pthread_mutex_init(&shared->shards[i].lock, NULL);
+    }
+
+    return shared;
+} /* memkv_init */
+
+static void
+memkv_destroy(void *private_data)
+{
+    struct memkv_shared *shared = private_data;
+    int                  i;
+
+    for (i = 0; i < shared->num_shards; i++) {
+        rb_tree_destroy(&shared->shards[i].entries, memkv_entry_release, NULL);
+        pthread_mutex_destroy(&shared->shards[i].lock);
+    }
+    free(shared->shards);
+    free(shared);
+} /* memkv_destroy */
+
+static void *
+memkv_thread_init(
+    struct evpl *evpl,
+    void        *private_data)
+{
+    struct memkv_shared *shared = private_data;
+    struct memkv_thread *thread = calloc(1, sizeof(*thread));
+
+    (void) evpl;
+    thread->shared = shared;
+
+    return thread;
+} /* memkv_thread_init */
+
+static void
+memkv_thread_destroy(void *private_data)
+{
+    struct memkv_thread *thread = private_data;
+    struct memkv_entry  *entry;
+
+    while (thread->free_entry) {
+        entry = thread->free_entry;
+        LL_DELETE(thread->free_entry, entry);
+        free(entry->key);
+        free(entry->value);
+        free(entry);
+    }
+
+    free(thread);
+} /* memkv_thread_destroy */
+
+static void
+memkv_put_key(
+    struct memkv_thread        *thread,
+    struct memkv_shared        *shared,
+    struct chimera_vfs_request *request)
+{
+    uint64_t            hash;
+    int                 shard_idx;
+    struct memkv_shard *shard;
+    struct memkv_entry *entry, *existing;
+
+    hash      = chimera_vfs_hash(request->put_key.key, request->put_key.key_len);
+    shard_idx = hash % shared->num_shards;
+    shard     = &shared->shards[shard_idx];
+
+    pthread_mutex_lock(&shard->lock);
+
+    rb_tree_query_exact(&shard->entries, hash, hash, existing);
+
+    if (existing) {
+        free(existing->value);
+        existing->value_len = request->put_key.value_len;
+        existing->value     = malloc(request->put_key.value_len);
+        memcpy(existing->value, request->put_key.value, request->put_key.value_len);
+    } else {
+        entry = memkv_entry_alloc(thread, hash,
+                                  request->put_key.key, request->put_key.key_len,
+                                  request->put_key.value, request->put_key.value_len);
+        rb_tree_insert(&shard->entries, hash, entry);
+    }
+
+    pthread_mutex_unlock(&shard->lock);
+
+    request->status = CHIMERA_VFS_OK;
+    request->complete(request);
+} /* memkv_put_key */
+
+static void
+memkv_get_key(
+    struct memkv_thread        *thread,
+    struct memkv_shared        *shared,
+    struct chimera_vfs_request *request)
+{
+    uint64_t            hash;
+    int                 shard_idx;
+    struct memkv_shard *shard;
+    struct memkv_entry *entry;
+
+    hash      = chimera_vfs_hash(request->get_key.key, request->get_key.key_len);
+    shard_idx = hash % shared->num_shards;
+    shard     = &shared->shards[shard_idx];
+
+    pthread_mutex_lock(&shard->lock);
+
+    rb_tree_query_exact(&shard->entries, hash, hash, entry);
+
+    if (!entry) {
+        pthread_mutex_unlock(&shard->lock);
+        request->status = CHIMERA_VFS_ENOENT;
+        request->complete(request);
+        return;
+    }
+
+    /* Return pointer to value - caller must use before callback returns */
+    request->get_key.r_value     = entry->value;
+    request->get_key.r_value_len = entry->value_len;
+
+    pthread_mutex_unlock(&shard->lock);
+
+    request->status = CHIMERA_VFS_OK;
+    request->complete(request);
+} /* memkv_get_key */
+
+static void
+memkv_delete_key(
+    struct memkv_thread        *thread,
+    struct memkv_shared        *shared,
+    struct chimera_vfs_request *request)
+{
+    uint64_t            hash;
+    int                 shard_idx;
+    struct memkv_shard *shard;
+    struct memkv_entry *entry;
+
+    hash      = chimera_vfs_hash(request->delete_key.key, request->delete_key.key_len);
+    shard_idx = hash % shared->num_shards;
+    shard     = &shared->shards[shard_idx];
+
+    pthread_mutex_lock(&shard->lock);
+
+    rb_tree_query_exact(&shard->entries, hash, hash, entry);
+
+    if (!entry) {
+        pthread_mutex_unlock(&shard->lock);
+        request->status = CHIMERA_VFS_ENOENT;
+        request->complete(request);
+        return;
+    }
+
+    rb_tree_remove(&shard->entries, &entry->node);
+
+    pthread_mutex_unlock(&shard->lock);
+
+    memkv_entry_free(thread, entry);
+
+    request->status = CHIMERA_VFS_OK;
+    request->complete(request);
+} /* memkv_delete_key */
+
+static int
+memkv_key_in_range(
+    const void *key,
+    uint32_t    key_len,
+    const void *start_key,
+    uint32_t    start_key_len,
+    const void *end_key,
+    uint32_t    end_key_len)
+{
+    int cmp;
+
+    /* Compare key to start_key */
+    if (start_key_len > 0) {
+        cmp = memcmp(key, start_key,
+                     key_len < start_key_len ? key_len : start_key_len);
+        if (cmp < 0 || (cmp == 0 && key_len < start_key_len)) {
+            return 0; /* key < start_key */
+        }
+    }
+
+    /* Compare key to end_key */
+    if (end_key_len > 0) {
+        cmp = memcmp(key, end_key,
+                     key_len < end_key_len ? key_len : end_key_len);
+        if (cmp > 0 || (cmp == 0 && key_len > end_key_len)) {
+            return 0; /* key > end_key */
+        }
+    }
+
+    return 1; /* key is in range [start_key, end_key] */
+} /* memkv_key_in_range */
+
+static void
+memkv_search_keys(
+    struct memkv_thread        *thread,
+    struct memkv_shared        *shared,
+    struct chimera_vfs_request *request)
+{
+    int                                i, rc;
+    struct memkv_shard                *shard;
+    struct memkv_entry                *entry;
+    chimera_vfs_search_keys_callback_t callback = request->search_keys.callback;
+
+    (void) thread;
+
+    /* Iterate over all shards (entries are hash-ordered, not key-ordered, so a
+     * full scan with an in-range filter is required). */
+    for (i = 0; i < shared->num_shards; i++) {
+        shard = &shared->shards[i];
+
+        pthread_mutex_lock(&shard->lock);
+
+        rb_tree_first(&shard->entries, entry);
+
+        while (entry) {
+            if (memkv_key_in_range(entry->key,
+                                   entry->key_len,
+                                   request->search_keys.start_key,
+                                   request->search_keys.start_key_len,
+                                   request->search_keys.end_key,
+                                   request->search_keys.end_key_len)) {
+                rc = callback(entry->key,
+                              entry->key_len,
+                              entry->value,
+                              entry->value_len,
+                              request->proto_private_data);
+
+                if (rc) {
+                    /* Caller wants to abort search */
+                    pthread_mutex_unlock(&shard->lock);
+                    request->status = CHIMERA_VFS_OK;
+                    request->complete(request);
+                    return;
+                }
+            }
+
+            entry = rb_tree_next(&shard->entries, entry);
+        }
+
+        pthread_mutex_unlock(&shard->lock);
+    }
+
+    request->status = CHIMERA_VFS_OK;
+    request->complete(request);
+} /* memkv_search_keys */
+
+static void
+memkv_dispatch(
+    struct chimera_vfs_request *request,
+    void                       *private_data)
+{
+    struct memkv_thread *thread = private_data;
+    struct memkv_shared *shared = thread->shared;
+
+    switch (request->opcode) {
+        case CHIMERA_VFS_OP_PUT_KEY:
+            memkv_put_key(thread, shared, request);
+            break;
+        case CHIMERA_VFS_OP_GET_KEY:
+            memkv_get_key(thread, shared, request);
+            break;
+        case CHIMERA_VFS_OP_DELETE_KEY:
+            memkv_delete_key(thread, shared, request);
+            break;
+        case CHIMERA_VFS_OP_SEARCH_KEYS:
+            memkv_search_keys(thread, shared, request);
+            break;
+        default:
+            chimera_memkv_error("memkv_dispatch: unsupported operation %d",
+                                request->opcode);
+            request->status = CHIMERA_VFS_ENOTSUP;
+            request->complete(request);
+            break;
+    } /* switch */
+} /* memkv_dispatch */
+
+SYMBOL_EXPORT struct chimera_vfs_module vfs_memkv = {
+    .name           = "memkv",
+    .fh_magic       = CHIMERA_VFS_FH_MAGIC_MEMKV,
+    .capabilities   = CHIMERA_VFS_CAP_KV,
+    .init           = memkv_init,
+    .destroy        = memkv_destroy,
+    .thread_init    = memkv_thread_init,
+    .thread_destroy = memkv_thread_destroy,
+    .dispatch       = memkv_dispatch,
+};

--- a/src/vfs/memkv/memkv.h
+++ b/src/vfs/memkv/memkv.h
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#pragma once
+
+#include "vfs/vfs.h"
+
+extern struct chimera_vfs_module vfs_memkv;

--- a/src/vfs/sqlite/CMakeLists.txt
+++ b/src/vfs/sqlite/CMakeLists.txt
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+#
+# SPDX-License-Identifier: LGPL-2.1-only
+
+add_library(chimera_vfs_sqlite SHARED
+    sqlite.c
+)
+
+target_include_directories(chimera_vfs_sqlite PRIVATE ${SQLITE3_INCLUDE_DIR})
+
+target_link_libraries(chimera_vfs_sqlite jansson ${SQLITE3_LIBRARY})
+
+install(TARGETS chimera_vfs_sqlite DESTINATION lib)

--- a/src/vfs/sqlite/sqlite.c
+++ b/src/vfs/sqlite/sqlite.c
@@ -1,0 +1,380 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * sqlite: a persistent, key-value-only VFS backend (CHIMERA_VFS_CAP_KV, no
+ * filesystem).  Keys and values are stored as opaque BLOBs in a single table
+ * with the key as the primary key:
+ *
+ *     CREATE TABLE kv (key BLOB PRIMARY KEY, value BLOB NOT NULL) WITHOUT ROWID;
+ *
+ * The database runs in WAL journal mode so multiple reader threads and a writer
+ * can operate concurrently.  Each VFS thread owns its own sqlite3 connection
+ * (sqlite connections are not safe to share across threads); the module is
+ * declared CAP_BLOCKING so the synchronous sqlite calls run on delegation
+ * threads rather than the event-loop core threads.
+ */
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sqlite3.h>
+#include <jansson.h>
+
+#include "vfs/vfs.h"
+#include "vfs/vfs_internal.h"
+#include "sqlite.h"
+#include "common/logging.h"
+#include "common/macros.h"
+
+#define CHIMERA_SQLITE_BUSY_TIMEOUT_MS 5000
+
+#define chimera_sqlite_error(...) chimera_error("sqlite", \
+                                                __FILE__, \
+                                                __LINE__, \
+                                                __VA_ARGS__)
+#define chimera_sqlite_abort_if(cond, ...) \
+        chimera_abort_if(cond, "sqlite", __FILE__, __LINE__, __VA_ARGS__)
+
+struct sqlite_shared {
+    char *path;
+};
+
+struct sqlite_thread {
+    struct sqlite_shared *shared;
+    sqlite3              *db;
+    sqlite3_stmt         *put_stmt;
+    sqlite3_stmt         *get_stmt;
+    sqlite3_stmt         *del_stmt;
+};
+
+static void *
+sqlite_init(
+    const char                *cfgdata,
+    struct prometheus_metrics *metrics)
+{
+    (void) metrics;
+    struct sqlite_shared *shared = calloc(1, sizeof(*shared));
+    json_error_t          json_error;
+    json_t               *cfg;
+    const char           *path;
+    sqlite3              *db;
+    char                 *errmsg = NULL;
+    int                   rc;
+
+    chimera_sqlite_abort_if(!cfgdata || cfgdata[0] == '\0',
+                            "sqlite: config required ('path' missing)");
+
+    cfg = json_loads(cfgdata, 0, &json_error);
+    chimera_sqlite_abort_if(!cfg, "sqlite: failed to parse config: %s",
+                            json_error.text);
+
+    path = json_string_value(json_object_get(cfg, "path"));
+    chimera_sqlite_abort_if(!path, "sqlite: 'path' missing in config");
+
+    shared->path = strdup(path);
+
+    /* Open once at init to create the schema and switch the database file into
+     * WAL mode (WAL is a persistent property of the file, so per-thread
+     * connections opened later inherit it). */
+    rc = sqlite3_open(shared->path, &db);
+    chimera_sqlite_abort_if(rc != SQLITE_OK, "sqlite: cannot open '%s': %s",
+                            shared->path, sqlite3_errmsg(db));
+
+    rc = sqlite3_exec(db,
+                      "PRAGMA journal_mode=WAL;"
+                      "PRAGMA synchronous=NORMAL;"
+                      "CREATE TABLE IF NOT EXISTS kv ("
+                      "  key   BLOB PRIMARY KEY,"
+                      "  value BLOB NOT NULL"
+                      ") WITHOUT ROWID;",
+                      NULL, NULL, &errmsg);
+    chimera_sqlite_abort_if(rc != SQLITE_OK, "sqlite: schema init failed: %s",
+                            errmsg ? errmsg : "(unknown)");
+    sqlite3_free(errmsg);
+
+    sqlite3_close(db);
+
+    json_decref(cfg);
+
+    return shared;
+} /* sqlite_init */
+
+static void
+sqlite_destroy(void *private_data)
+{
+    struct sqlite_shared *shared = private_data;
+
+    free(shared->path);
+    free(shared);
+} /* sqlite_destroy */
+
+static void *
+sqlite_thread_init(
+    struct evpl *evpl,
+    void        *private_data)
+{
+    struct sqlite_shared *shared = private_data;
+    struct sqlite_thread *thread = calloc(1, sizeof(*thread));
+    int                   rc;
+
+    (void) evpl;
+    thread->shared = shared;
+
+    rc = sqlite3_open(shared->path, &thread->db);
+    chimera_sqlite_abort_if(rc != SQLITE_OK, "sqlite: thread open '%s': %s",
+                            shared->path, sqlite3_errmsg(thread->db));
+
+    sqlite3_busy_timeout(thread->db, CHIMERA_SQLITE_BUSY_TIMEOUT_MS);
+    sqlite3_exec(thread->db, "PRAGMA synchronous=NORMAL;", NULL, NULL, NULL);
+
+    rc = sqlite3_prepare_v2(thread->db,
+                            "INSERT OR REPLACE INTO kv(key,value) VALUES(?,?)",
+                            -1, &thread->put_stmt, NULL);
+    chimera_sqlite_abort_if(rc != SQLITE_OK, "sqlite: prepare put: %s",
+                            sqlite3_errmsg(thread->db));
+
+    rc = sqlite3_prepare_v2(thread->db,
+                            "SELECT value FROM kv WHERE key=?",
+                            -1, &thread->get_stmt, NULL);
+    chimera_sqlite_abort_if(rc != SQLITE_OK, "sqlite: prepare get: %s",
+                            sqlite3_errmsg(thread->db));
+
+    rc = sqlite3_prepare_v2(thread->db,
+                            "DELETE FROM kv WHERE key=?",
+                            -1, &thread->del_stmt, NULL);
+    chimera_sqlite_abort_if(rc != SQLITE_OK, "sqlite: prepare delete: %s",
+                            sqlite3_errmsg(thread->db));
+
+    return thread;
+} /* sqlite_thread_init */
+
+static void
+sqlite_thread_destroy(void *private_data)
+{
+    struct sqlite_thread *thread = private_data;
+
+    sqlite3_finalize(thread->put_stmt);
+    sqlite3_finalize(thread->get_stmt);
+    sqlite3_finalize(thread->del_stmt);
+    sqlite3_close(thread->db);
+    free(thread);
+} /* sqlite_thread_destroy */
+
+static void
+sqlite_put_key(
+    struct sqlite_thread       *thread,
+    struct chimera_vfs_request *request)
+{
+    sqlite3_stmt *stmt = thread->put_stmt;
+    int           rc;
+
+    sqlite3_bind_blob(stmt, 1, request->put_key.key, request->put_key.key_len, SQLITE_STATIC);
+    sqlite3_bind_blob(stmt, 2, request->put_key.value, request->put_key.value_len, SQLITE_STATIC);
+
+    rc = sqlite3_step(stmt);
+
+    sqlite3_reset(stmt);
+    sqlite3_clear_bindings(stmt);
+
+    if (rc != SQLITE_DONE) {
+        chimera_sqlite_error("put_key step failed: %s", sqlite3_errmsg(thread->db));
+        request->status = CHIMERA_VFS_EIO;
+    } else {
+        request->status = CHIMERA_VFS_OK;
+    }
+
+    request->complete(request);
+} /* sqlite_put_key */
+
+static void
+sqlite_get_key(
+    struct sqlite_thread       *thread,
+    struct chimera_vfs_request *request)
+{
+    sqlite3_stmt *stmt = thread->get_stmt;
+    int           rc;
+
+    sqlite3_bind_blob(stmt, 1, request->get_key.key, request->get_key.key_len, SQLITE_STATIC);
+
+    rc = sqlite3_step(stmt);
+
+    if (rc == SQLITE_ROW) {
+        const void *value     = sqlite3_column_blob(stmt, 0);
+        int         value_len = sqlite3_column_bytes(stmt, 0);
+
+        /* The column blob pointer is only valid until the next step/reset.  Copy
+         * it into the request-owned scratch so it survives the reset below and
+         * remains valid for the caller's callback, which (because this op is
+         * CAP_BLOCKING) runs later on the originating thread after the
+         * completion is bounced back from the delegation thread. */
+        if (value_len > CHIMERA_VFS_PLUGIN_DATA_SIZE) {
+            chimera_sqlite_error("get_key value too large: %d > %d",
+                                 value_len, CHIMERA_VFS_PLUGIN_DATA_SIZE);
+            sqlite3_reset(stmt);
+            sqlite3_clear_bindings(stmt);
+            request->status = CHIMERA_VFS_EIO;
+            request->complete(request);
+            return;
+        }
+
+        memcpy(request->plugin_data, value, value_len);
+        request->get_key.r_value     = request->plugin_data;
+        request->get_key.r_value_len = value_len;
+
+        sqlite3_reset(stmt);
+        sqlite3_clear_bindings(stmt);
+
+        request->status = CHIMERA_VFS_OK;
+        request->complete(request);
+        return;
+    }
+
+    sqlite3_reset(stmt);
+    sqlite3_clear_bindings(stmt);
+
+    if (rc == SQLITE_DONE) {
+        request->status = CHIMERA_VFS_ENOENT;
+    } else {
+        chimera_sqlite_error("get_key step failed: %s", sqlite3_errmsg(thread->db));
+        request->status = CHIMERA_VFS_EIO;
+    }
+
+    request->complete(request);
+} /* sqlite_get_key */
+
+static void
+sqlite_delete_key(
+    struct sqlite_thread       *thread,
+    struct chimera_vfs_request *request)
+{
+    sqlite3_stmt *stmt = thread->del_stmt;
+    int           rc, changes;
+
+    sqlite3_bind_blob(stmt, 1, request->delete_key.key, request->delete_key.key_len, SQLITE_STATIC);
+
+    rc      = sqlite3_step(stmt);
+    changes = sqlite3_changes(thread->db);
+
+    sqlite3_reset(stmt);
+    sqlite3_clear_bindings(stmt);
+
+    if (rc != SQLITE_DONE) {
+        chimera_sqlite_error("delete_key step failed: %s", sqlite3_errmsg(thread->db));
+        request->status = CHIMERA_VFS_EIO;
+    } else if (changes == 0) {
+        request->status = CHIMERA_VFS_ENOENT;
+    } else {
+        request->status = CHIMERA_VFS_OK;
+    }
+
+    request->complete(request);
+} /* sqlite_delete_key */
+
+static void
+sqlite_search_keys(
+    struct sqlite_thread       *thread,
+    struct chimera_vfs_request *request)
+{
+    chimera_vfs_search_keys_callback_t callback  = request->search_keys.callback;
+    const void                        *start     = request->search_keys.start_key;
+    uint32_t                           start_len = request->search_keys.start_key_len;
+    const void                        *end       = request->search_keys.end_key;
+    uint32_t                           end_len   = request->search_keys.end_key_len;
+    sqlite3_stmt                      *stmt      = NULL;
+    const char                        *sql;
+    int                                bind_idx = 1;
+    int                                rc, aborted = 0;
+
+    /* BLOB comparison in sqlite is bytewise (memcmp with the shorter blob
+     * ordering first), matching the range semantics used by the other KV
+     * backends.  Both bounds are inclusive. */
+    if (start_len && end_len) {
+        sql = "SELECT key,value FROM kv WHERE key>=? AND key<=? ORDER BY key";
+    } else if (start_len) {
+        sql = "SELECT key,value FROM kv WHERE key>=? ORDER BY key";
+    } else if (end_len) {
+        sql = "SELECT key,value FROM kv WHERE key<=? ORDER BY key";
+    } else {
+        sql = "SELECT key,value FROM kv ORDER BY key";
+    }
+
+    rc = sqlite3_prepare_v2(thread->db, sql, -1, &stmt, NULL);
+    if (rc != SQLITE_OK) {
+        chimera_sqlite_error("search_keys prepare failed: %s", sqlite3_errmsg(thread->db));
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+
+    if (start_len) {
+        sqlite3_bind_blob(stmt, bind_idx++, start, start_len, SQLITE_STATIC);
+    }
+    if (end_len) {
+        sqlite3_bind_blob(stmt, bind_idx++, end, end_len, SQLITE_STATIC);
+    }
+
+    while ((rc = sqlite3_step(stmt)) == SQLITE_ROW) {
+        const void *key       = sqlite3_column_blob(stmt, 0);
+        int         key_len   = sqlite3_column_bytes(stmt, 0);
+        const void *value     = sqlite3_column_blob(stmt, 1);
+        int         value_len = sqlite3_column_bytes(stmt, 1);
+
+        if (callback(key, key_len, value, value_len, request->proto_private_data)) {
+            aborted = 1;
+            break;
+        }
+    }
+
+    sqlite3_finalize(stmt);
+
+    if (!aborted && rc != SQLITE_DONE && rc != SQLITE_ROW) {
+        chimera_sqlite_error("search_keys step failed: %s", sqlite3_errmsg(thread->db));
+        request->status = CHIMERA_VFS_EIO;
+    } else {
+        request->status = CHIMERA_VFS_OK;
+    }
+
+    request->complete(request);
+} /* sqlite_search_keys */
+
+static void
+sqlite_dispatch(
+    struct chimera_vfs_request *request,
+    void                       *private_data)
+{
+    struct sqlite_thread *thread = private_data;
+
+    switch (request->opcode) {
+        case CHIMERA_VFS_OP_PUT_KEY:
+            sqlite_put_key(thread, request);
+            break;
+        case CHIMERA_VFS_OP_GET_KEY:
+            sqlite_get_key(thread, request);
+            break;
+        case CHIMERA_VFS_OP_DELETE_KEY:
+            sqlite_delete_key(thread, request);
+            break;
+        case CHIMERA_VFS_OP_SEARCH_KEYS:
+            sqlite_search_keys(thread, request);
+            break;
+        default:
+            chimera_sqlite_error("sqlite_dispatch: unsupported operation %d",
+                                 request->opcode);
+            request->status = CHIMERA_VFS_ENOTSUP;
+            request->complete(request);
+            break;
+    } /* switch */
+} /* sqlite_dispatch */
+
+SYMBOL_EXPORT struct chimera_vfs_module vfs_sqlite = {
+    .name           = "sqlite",
+    .fh_magic       = CHIMERA_VFS_FH_MAGIC_SQLITE,
+    .capabilities   = CHIMERA_VFS_CAP_KV | CHIMERA_VFS_CAP_BLOCKING,
+    .init           = sqlite_init,
+    .destroy        = sqlite_destroy,
+    .thread_init    = sqlite_thread_init,
+    .thread_destroy = sqlite_thread_destroy,
+    .dispatch       = sqlite_dispatch,
+};

--- a/src/vfs/sqlite/sqlite.h
+++ b/src/vfs/sqlite/sqlite.h
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#pragma once
+
+#include "vfs/vfs.h"
+
+extern struct chimera_vfs_module vfs_sqlite;

--- a/src/vfs/tests/CMakeLists.txt
+++ b/src/vfs/tests/CMakeLists.txt
@@ -7,7 +7,11 @@ target_link_libraries(vfs_user_cache_test chimera_vfs urcu-qsbr)
 add_test(chimera/vfs/user_cache_test vfs_user_cache_test)
 
 add_executable(vfs_kv_test vfs_kv_test.c)
-target_link_libraries(vfs_kv_test chimera_vfs chimera_vfs_memfs evpl)
+target_link_libraries(vfs_kv_test chimera_vfs chimera_vfs_memkv evpl)
+if (SQLITE_ENABLED)
+    target_link_libraries(vfs_kv_test chimera_vfs_sqlite)
+    target_compile_definitions(vfs_kv_test PRIVATE CHIMERA_KV_TEST_SQLITE=1)
+endif()
 add_test(chimera/vfs/kv_test vfs_kv_test)
 
 add_executable(vfs_async_delegation_test vfs_async_delegation_test.c)

--- a/src/vfs/tests/vfs_async_delegation_test.c
+++ b/src/vfs/tests/vfs_async_delegation_test.c
@@ -4,7 +4,7 @@
 
 /*
  * Exercises the async delegation thread pool with a non-BLOCKING backend
- * (memfs). Verifies:
+ * (memkv). Verifies:
  *   - Operations complete end-to-end when routed through the async pool.
  *   - Module dispatch runs on a delegation thread, not the caller thread.
  *   - Same hash key consistently lands on the same delegation thread.
@@ -266,7 +266,7 @@ run_phase(
     assert(metrics != NULL);
 
     memset(module_cfgs, 0, sizeof(module_cfgs));
-    strncpy(module_cfgs[0].module_name, "memfs", sizeof(module_cfgs[0].module_name) - 1);
+    strncpy(module_cfgs[0].module_name, "memkv", sizeof(module_cfgs[0].module_name) - 1);
 
     ctx.evpl = evpl_create(NULL);
     assert(ctx.evpl != NULL);

--- a/src/vfs/tests/vfs_enforce_test.c
+++ b/src/vfs/tests/vfs_enforce_test.c
@@ -361,7 +361,7 @@ main(
     char **argv)
 {
     struct test_ctx               ctx = { 0 };
-    struct chimera_vfs_module_cfg module_cfgs[1];
+    struct chimera_vfs_module_cfg module_cfgs[2];
     struct prometheus_metrics    *metrics;
     struct chimera_vfs_cred       owner, other;
     struct chimera_vfs_attrs      sattr;
@@ -380,11 +380,12 @@ main(
 
     memset(module_cfgs, 0, sizeof(module_cfgs));
     strncpy(module_cfgs[0].module_name, "memfs", sizeof(module_cfgs[0].module_name) - 1);
+    strncpy(module_cfgs[1].module_name, "memkv", sizeof(module_cfgs[1].module_name) - 1);
 
     ctx.evpl = evpl_create(NULL);
     assert(ctx.evpl != NULL);
 
-    ctx.vfs = chimera_vfs_init(0, 0, module_cfgs, 1, "memfs", 60, metrics);
+    ctx.vfs = chimera_vfs_init(0, 0, module_cfgs, 2, "memkv", 60, metrics);
     assert(ctx.vfs != NULL);
 
     ctx.vfs_thread = chimera_vfs_thread_init(ctx.evpl, ctx.vfs);

--- a/src/vfs/tests/vfs_identity_test.c
+++ b/src/vfs/tests/vfs_identity_test.c
@@ -55,7 +55,7 @@ main(
     struct chimera_vfs           *vfs;
     struct chimera_vfs_thread    *thread;
     struct evpl                  *evpl;
-    struct chimera_vfs_module_cfg module_cfgs[1];
+    struct chimera_vfs_module_cfg module_cfgs[2];
     struct prometheus_metrics    *metrics;
     struct probe                  p;
     struct passwd                *root_pw;
@@ -68,11 +68,13 @@ main(
     memset(module_cfgs, 0, sizeof(module_cfgs));
     strncpy(module_cfgs[0].module_name, "memfs",
             sizeof(module_cfgs[0].module_name) - 1);
+    strncpy(module_cfgs[1].module_name, "memkv",
+            sizeof(module_cfgs[1].module_name) - 1);
 
     evpl = evpl_create(NULL);
     assert(evpl != NULL);
 
-    vfs = chimera_vfs_init(0, 0, module_cfgs, 1, "memfs", 60, metrics);
+    vfs = chimera_vfs_init(0, 0, module_cfgs, 2, "memkv", 60, metrics);
     assert(vfs != NULL);
 
     thread = chimera_vfs_thread_init(evpl, vfs);

--- a/src/vfs/tests/vfs_kv_test.c
+++ b/src/vfs/tests/vfs_kv_test.c
@@ -349,14 +349,65 @@ test_nonexistent_key(struct test_ctx *ctx)
     TEST_PASS("operations on nonexistent key return ENOENT");
 } /* test_nonexistent_key */
 
+/* Run the full KV test suite against a single KV-only backend. */
+static void
+run_suite(
+    const char                *kv_name,
+    const char                *kv_config,
+    struct prometheus_metrics *metrics)
+{
+    struct test_ctx               ctx = { 0 };
+    struct chimera_vfs_module_cfg module_cfgs[1];
+
+    memset(module_cfgs, 0, sizeof(module_cfgs));
+    strncpy(module_cfgs[0].module_name, kv_name, sizeof(module_cfgs[0].module_name) - 1);
+    if (kv_config) {
+        strncpy(module_cfgs[0].config_data, kv_config, sizeof(module_cfgs[0].config_data) - 1);
+    }
+
+    ctx.evpl = evpl_create(NULL);
+    assert(ctx.evpl != NULL);
+
+    /* 4 sync delegation threads so a CAP_BLOCKING backend (sqlite) is exercised
+     * through the delegation pool and completion bounce-back. */
+    ctx.vfs = chimera_vfs_init(
+        4,              /* num_sync_delegation_threads */
+        0,              /* num_async_delegation_threads */
+        module_cfgs,
+        1,              /* num_modules */
+        kv_name,        /* kv_module_name */
+        60,             /* cache_ttl */
+        metrics);
+    assert(ctx.vfs != NULL);
+
+    ctx.vfs_thread = chimera_vfs_thread_init(ctx.evpl, ctx.vfs);
+    assert(ctx.vfs_thread != NULL);
+
+    fprintf(stderr, "Running KV API tests with %s backend...\n", kv_name);
+
+    test_put_get_delete(&ctx);
+    test_update_value(&ctx);
+    test_search_keys(&ctx);
+    test_binary_keys_values(&ctx);
+    test_nonexistent_key(&ctx);
+
+    fprintf(stderr, "All KV tests passed for %s!\n", kv_name);
+
+    chimera_vfs_thread_destroy(ctx.vfs_thread);
+    chimera_vfs_destroy(ctx.vfs);
+    evpl_destroy(ctx.evpl);
+} /* run_suite */
+
 int
 main(
     int    argc,
     char **argv)
 {
-    struct test_ctx               ctx = { 0 };
-    struct chimera_vfs_module_cfg module_cfgs[2];
-    struct prometheus_metrics    *metrics;
+    struct prometheus_metrics *metrics;
+    char                       tmpl[] = "/tmp/chimera_sqlite_kv_test_XXXXXX";
+    char                      *db_dir;
+    char                       sqlite_cfg[256];
+    char                       rmcmd[320];
 
     chimera_log_init();
 
@@ -364,45 +415,30 @@ main(
     metrics = prometheus_metrics_create(NULL, NULL, 0);
     assert(metrics != NULL);
 
-    /* Initialize memfs module config */
-    memset(module_cfgs, 0, sizeof(module_cfgs));
-    strncpy(module_cfgs[0].module_name, "memfs", sizeof(module_cfgs[0].module_name) - 1);
+    /* In-memory KV-only backend. */
+    run_suite("memkv", NULL, metrics);
 
-    /* Create event loop */
-    ctx.evpl = evpl_create(NULL);
-    assert(ctx.evpl != NULL);
+#ifdef CHIMERA_KV_TEST_SQLITE
+    /* Persistent sqlite KV-only backend (WAL, single table). */
+    db_dir = mkdtemp(tmpl);
+    assert(db_dir != NULL);
+    snprintf(sqlite_cfg, sizeof(sqlite_cfg), "{\"path\":\"%s/kv.db\"}", db_dir);
 
-    /* Initialize VFS with memfs as KV module (default) */
-    ctx.vfs = chimera_vfs_init(
-        4,              /* num_sync_delegation_threads */
-        0,              /* num_async_delegation_threads */
-        module_cfgs,
-        1,              /* num_modules */
-        "",             /* kv_module_name - empty means use default (memfs) */
-        60,             /* cache_ttl */
-        metrics);
+    run_suite("sqlite", sqlite_cfg, metrics);
 
-    assert(ctx.vfs != NULL);
-
-    /* Initialize VFS thread */
-    ctx.vfs_thread = chimera_vfs_thread_init(ctx.evpl, ctx.vfs);
-    assert(ctx.vfs_thread != NULL);
-
-    fprintf(stderr, "Running KV API tests with memfs backend...\n");
-
-    /* Run tests */
-    test_put_get_delete(&ctx);
-    test_update_value(&ctx);
-    test_search_keys(&ctx);
-    test_binary_keys_values(&ctx);
-    test_nonexistent_key(&ctx);
+    snprintf(rmcmd, sizeof(rmcmd), "rm -rf %s", db_dir);
+    if (system(rmcmd) != 0) {
+        fprintf(stderr, "warning: failed to remove %s\n", db_dir);
+    }
+#else  /* ifdef CHIMERA_KV_TEST_SQLITE */
+    (void) db_dir;
+    (void) tmpl;
+    (void) sqlite_cfg;
+    (void) rmcmd;
+#endif /* ifdef CHIMERA_KV_TEST_SQLITE */
 
     fprintf(stderr, "All KV tests passed!\n");
 
-    /* Cleanup */
-    chimera_vfs_thread_destroy(ctx.vfs_thread);
-    chimera_vfs_destroy(ctx.vfs);
-    evpl_destroy(ctx.evpl);
     prometheus_metrics_destroy(metrics);
 
     return 0;

--- a/src/vfs/vfs.c
+++ b/src/vfs/vfs.c
@@ -517,8 +517,11 @@ chimera_vfs_init(
         chimera_vfs_register(vfs, module, module_cfgs[i].config_data);
     }
 
-    /* Set up KV module - default to memfs if not specified */
-    effective_kv_module = (kv_module_name && kv_module_name[0] != '\0') ? kv_module_name : "memfs";
+    /* Set up the default KV module - a KV-only backend (memkv or sqlite) that
+     * backs the global KV API and stores handle-state/KV records on behalf of
+     * filesystem backends that cannot persist them natively.  Defaults to the
+     * in-memory memkv when not specified. */
+    effective_kv_module = (kv_module_name && kv_module_name[0] != '\0') ? kv_module_name : "memkv";
 
     /* Find and validate the KV module */
     vfs->kv_module = NULL;
@@ -576,6 +579,24 @@ chimera_vfs_fh_is_plausible(
 {
     return chimera_vfs_get_module(thread, fh, fhlen) != NULL;
 } /* chimera_vfs_fh_is_plausible */
+
+SYMBOL_EXPORT int
+chimera_vfs_can_persist_handle_state(
+    struct chimera_vfs_thread      *thread,
+    struct chimera_vfs_open_handle *handle)
+{
+    if (!handle || !handle->vfs_module) {
+        return 0;
+    }
+
+    /* Either the backend persists handle-state atomically with the open, or the
+     * VFS core can persist it to the default KV on the backend's behalf. */
+    if (handle->vfs_module->capabilities & CHIMERA_VFS_CAP_ATOMIC_HANDLE_STATE) {
+        return 1;
+    }
+
+    return thread->vfs->kv_module != NULL;
+} /* chimera_vfs_can_persist_handle_state */
 
 /* Capabilities of the backend module owning fh, or 0 if no mount matches.
  * Lets callers without an open handle (e.g. the NFS attribute marshaller)

--- a/src/vfs/vfs.c
+++ b/src/vfs/vfs.c
@@ -27,6 +27,7 @@
 #include "vfs/vfs_pnfs.h"
 #include "vfs/vfs_mount_table.h"
 #include "vfs/memfs/memfs.h"
+#include "vfs/memkv/memkv.h"
 #include "vfs/linux/linux.h"
 
 #ifdef HAVE_IO_URING
@@ -523,13 +524,33 @@ chimera_vfs_init(
      * in-memory memkv when not specified. */
     effective_kv_module = (kv_module_name && kv_module_name[0] != '\0') ? kv_module_name : "memkv";
 
-    /* Find and validate the KV module */
+    /* Find the KV module among those already registered. */
     vfs->kv_module = NULL;
     for (int i = 0; i < CHIMERA_VFS_FH_MAGIC_MAX; i++) {
         if (vfs->modules[i] && strcmp(vfs->modules[i]->name, effective_kv_module) == 0) {
             vfs->kv_module = vfs->modules[i];
             break;
         }
+    }
+
+    /* The default KV is a VFS-core facility, not a share backend, so callers
+     * need not list it among module_cfgs.  If it wasn't explicitly registered,
+     * auto-register it from its built-in symbol (vfs_memkv / vfs_sqlite, linked
+     * into chimera_vfs). */
+    if (!vfs->kv_module) {
+        if (strcmp(effective_kv_module, "memkv") == 0) {
+            /* memkv is built into chimera_vfs; reference it directly so the
+            * symbol is always retained regardless of linker --as-needed. */
+            module = &vfs_memkv;
+        } else {
+            snprintf(modsym, sizeof(modsym), "vfs_%s", effective_kv_module);
+            module = dlsym(RTLD_DEFAULT, modsym);
+        }
+        chimera_vfs_abort_if(!module,
+                             "KV module '%s' not found (symbol vfs_%s)",
+                             effective_kv_module, effective_kv_module);
+        chimera_vfs_register(vfs, module, NULL);
+        vfs->kv_module = vfs->modules[module->fh_magic];
     }
 
     chimera_vfs_abort_if(!vfs->kv_module,

--- a/src/vfs/vfs.h
+++ b/src/vfs/vfs.h
@@ -1058,7 +1058,11 @@ enum CHIMERA_FS_FH_MAGIC {
     CHIMERA_VFS_FH_MAGIC_CAIRN    = 4,
     CHIMERA_VFS_FH_MAGIC_DISKFS   = 5,
     CHIMERA_VFS_FH_MAGIC_NFS      = 6,
-    CHIMERA_VFS_FH_MAGIC_MAX      = 7
+    /* KV-only backends (no filesystem; never serve a file handle, but occupy a
+     * module slot so they can be selected as the default KV module). */
+    CHIMERA_VFS_FH_MAGIC_MEMKV    = 7,
+    CHIMERA_VFS_FH_MAGIC_SQLITE   = 8,
+    CHIMERA_VFS_FH_MAGIC_MAX      = 9
 
 };
 

--- a/src/vfs/vfs_internal.h
+++ b/src/vfs/vfs_internal.h
@@ -139,6 +139,46 @@ chimera_vfs_get_module(
 } /* chimera_vfs_get_module */
 
 /*
+ * Routing decision for an fh-routed KV operation (handle-state put on open,
+ * delete_key_at, search_keys_at).
+ *
+ *   - If the backend serving `fh` implements KV natively (CHIMERA_VFS_CAP_KV,
+ *     e.g. cairn/diskfs), the op is dispatched to that backend and the record
+ *     is stored co-located with the file (no key transformation).
+ *
+ *   - Otherwise the op is dispatched to the configured default KV module, and
+ *     keys are namespaced with a single leading byte equal to the source
+ *     backend's fh_magic.  Because every handle on a backend shares one
+ *     fh_magic, the open/delete/search paths agree on the namespace, and keys
+ *     from different backends can never collide in the shared default KV.
+ */
+struct chimera_vfs_kv_route {
+    struct chimera_vfs_module *module;   /* where the op is dispatched          */
+    int                        fallback; /* 1 = default KV w/ ns prefix; 0 = native */
+    uint8_t                    ns;       /* namespace byte (source fh_magic)    */
+};
+
+static inline void
+chimera_vfs_kv_route_fh(
+    struct chimera_vfs_thread   *thread,
+    const void                  *fh,
+    int                          fhlen,
+    struct chimera_vfs_kv_route *route)
+{
+    struct chimera_vfs_module *module = chimera_vfs_get_module(thread, fh, fhlen);
+
+    if (module && (module->capabilities & CHIMERA_VFS_CAP_KV)) {
+        route->module   = module;
+        route->fallback = 0;
+        route->ns       = 0;
+    } else {
+        route->module   = thread->vfs->kv_module;
+        route->fallback = 1;
+        route->ns       = module ? module->fh_magic : (uint8_t) CHIMERA_VFS_FH_MAGIC_ROOT;
+    }
+} /* chimera_vfs_kv_route_fh */
+
+/*
  * Common request allocation helper with capability enforcement.
  * Returns ERR_PTR on failure:
  *   - CHIMERA_VFS_ESTALE if module is NULL

--- a/src/vfs/vfs_proc_delete_key.c
+++ b/src/vfs/vfs_proc_delete_key.c
@@ -47,10 +47,13 @@ chimera_vfs_delete_key(
     chimera_vfs_dispatch(request);
 } /* chimera_vfs_delete_key */
 
-/* Delete a key from the backend that serves `fh` (rather than the global
- * kv_module), so handle-state records persisted alongside a file are removed
- * from the same backend.  The key is copied into the request scratch so the
- * caller need not keep it alive across the async dispatch. */
+/* Delete a key associated with the backend that serves `fh`, so handle-state
+ * records persisted alongside a file are removed from the same place they were
+ * written.  If that backend has native KV the op is dispatched to it; otherwise
+ * it routes to the default KV module with the key namespaced by the source
+ * backend's fh_magic (see chimera_vfs_kv_route_fh).  The key is copied into the
+ * request scratch so the caller need not keep it alive across the async
+ * dispatch. */
 SYMBOL_EXPORT void
 chimera_vfs_delete_key_at(
     struct chimera_vfs_thread        *thread,
@@ -63,21 +66,41 @@ chimera_vfs_delete_key_at(
     void                             *private_data)
 {
     struct chimera_vfs_request *request;
+    struct chimera_vfs_kv_route route;
+    uint8_t                    *scratch;
 
-    request = chimera_vfs_request_alloc_by_hash(thread, cred, fh, fhlen,
-                                                chimera_vfs_hash(fh, fhlen));
+    chimera_vfs_kv_route_fh(thread, fh, fhlen, &route);
+
+    if (route.fallback) {
+        request = chimera_vfs_request_alloc_common(thread, NULL, route.module,
+                                                   NULL, 0,
+                                                   chimera_vfs_hash(key, key_len),
+                                                   CHIMERA_VFS_CAP_KV);
+    } else {
+        request = chimera_vfs_request_alloc_by_hash(thread, cred, fh, fhlen,
+                                                    chimera_vfs_hash(fh, fhlen));
+    }
 
     if (CHIMERA_VFS_IS_ERR(request)) {
         callback(CHIMERA_VFS_PTR_ERR(request), private_data);
         return;
     }
 
-    memcpy(request->plugin_data, key, key_len);
+    scratch = request->plugin_data;
+
+    if (route.fallback) {
+        scratch[0] = route.ns;
+        memcpy(scratch + 1, key, key_len);
+        request->delete_key.key     = scratch;
+        request->delete_key.key_len = key_len + 1;
+    } else {
+        memcpy(scratch, key, key_len);
+        request->delete_key.key     = scratch;
+        request->delete_key.key_len = key_len;
+    }
 
     request->opcode             = CHIMERA_VFS_OP_DELETE_KEY;
     request->complete           = chimera_vfs_delete_key_complete;
-    request->delete_key.key     = request->plugin_data;
-    request->delete_key.key_len = key_len;
     request->proto_callback     = callback;
     request->proto_private_data = private_data;
 

--- a/src/vfs/vfs_proc_open_at.c
+++ b/src/vfs/vfs_proc_open_at.c
@@ -63,7 +63,7 @@ chimera_vfs_open_at_hdl_callback(
 } /* chimera_vfs_open_at_hdl_callback */
 
 static void
-chimera_vfs_open_complete(struct chimera_vfs_request *request)
+chimera_vfs_open_finish(struct chimera_vfs_request *request)
 {
     struct chimera_vfs_thread      *thread = request->thread;
     uint64_t                        fh_hash;
@@ -119,6 +119,52 @@ chimera_vfs_open_complete(struct chimera_vfs_request *request)
     } else {
         chimera_vfs_open_at_hdl_callback(request, NULL);
     }
+} /* chimera_vfs_open_finish */
+
+/* Continuation after the non-atomic handle-state record has been persisted to
+ * the default KV (best-effort: a failure leaves the file open without its
+ * durable record, which only the in-memory backends ever hit). */
+static void
+chimera_vfs_open_hs_put_complete(
+    enum chimera_vfs_error error_code,
+    void                  *private_data)
+{
+    struct chimera_vfs_request *request = private_data;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        chimera_vfs_error("open_at: failed to persist handle-state to default KV: %d",
+                          error_code);
+    }
+
+    chimera_vfs_open_finish(request);
+} /* chimera_vfs_open_hs_put_complete */
+
+static void
+chimera_vfs_open_complete(struct chimera_vfs_request *request)
+{
+    struct chimera_vfs_handle_state *hs = request->open_at.handle_state;
+
+    /* Backends that persist handle-state atomically (CAP_ATOMIC_HANDLE_STATE)
+     * have already stored it as part of the open.  For backends without native
+     * KV, the VFS core persists the record to the default KV instead, keyed by
+     * the new file's fh so close/recovery find it on the same backend.  This is
+     * a separate, non-atomic put; it is only reached by in-memory backends
+     * (memfs) and passthrough, where cross-crash atomicity is moot. */
+    if (request->status == CHIMERA_VFS_OK && hs &&
+        !(request->module->capabilities & CHIMERA_VFS_CAP_ATOMIC_HANDLE_STATE) &&
+        request->thread->vfs->kv_module &&
+        (request->open_at.r_attr.va_set_mask & CHIMERA_VFS_ATTR_FH)) {
+
+        chimera_vfs_put_key_at(request->thread, request->cred,
+                               request->open_at.r_attr.va_fh,
+                               request->open_at.r_attr.va_fh_len,
+                               hs->key, hs->key_len,
+                               hs->value, hs->value_len,
+                               chimera_vfs_open_hs_put_complete, request);
+        return;
+    }
+
+    chimera_vfs_open_finish(request);
 } /* chimera_vfs_open_complete */
 
 SYMBOL_EXPORT void

--- a/src/vfs/vfs_proc_put_key.c
+++ b/src/vfs/vfs_proc_put_key.c
@@ -48,3 +48,68 @@ chimera_vfs_put_key(
 
     chimera_vfs_dispatch(request);
 } /* chimera_vfs_put_key */
+
+/* Store a key/value associated with the backend that serves `fh`.  If that
+ * backend has native KV the record is stored co-located with the file;
+ * otherwise it routes to the default KV with the key namespaced by the source
+ * backend's fh_magic (see chimera_vfs_kv_route_fh) so it can later be found by
+ * chimera_vfs_search_keys_at / removed by chimera_vfs_delete_key_at on the same
+ * fh.  Both key and value are copied into the request scratch so the caller
+ * need not keep them alive across the async dispatch. */
+SYMBOL_EXPORT void
+chimera_vfs_put_key_at(
+    struct chimera_vfs_thread     *thread,
+    const struct chimera_vfs_cred *cred,
+    const void                    *fh,
+    int                            fhlen,
+    const void                    *key,
+    uint32_t                       key_len,
+    const void                    *value,
+    uint32_t                       value_len,
+    chimera_vfs_put_key_callback_t callback,
+    void                          *private_data)
+{
+    struct chimera_vfs_request *request;
+    struct chimera_vfs_kv_route route;
+    uint8_t                    *scratch;
+    uint32_t                    key_off;
+
+    chimera_vfs_kv_route_fh(thread, fh, fhlen, &route);
+
+    if (route.fallback) {
+        request = chimera_vfs_request_alloc_common(thread, NULL, route.module,
+                                                   NULL, 0,
+                                                   chimera_vfs_hash(fh, fhlen),
+                                                   CHIMERA_VFS_CAP_KV);
+    } else {
+        request = chimera_vfs_request_alloc_by_hash(thread, cred, fh, fhlen,
+                                                    chimera_vfs_hash(fh, fhlen));
+    }
+
+    if (CHIMERA_VFS_IS_ERR(request)) {
+        callback(CHIMERA_VFS_PTR_ERR(request), private_data);
+        return;
+    }
+
+    scratch = request->plugin_data;
+    key_off = 0;
+
+    if (route.fallback) {
+        scratch[0] = route.ns;
+        key_off    = 1;
+    }
+
+    memcpy(scratch + key_off, key, key_len);
+    memcpy(scratch + key_off + key_len, value, value_len);
+
+    request->opcode             = CHIMERA_VFS_OP_PUT_KEY;
+    request->complete           = chimera_vfs_put_key_complete;
+    request->put_key.key        = scratch;
+    request->put_key.key_len    = key_off + key_len;
+    request->put_key.value      = scratch + key_off + key_len;
+    request->put_key.value_len  = value_len;
+    request->proto_callback     = callback;
+    request->proto_private_data = private_data;
+
+    chimera_vfs_dispatch(request);
+} /* chimera_vfs_put_key_at */

--- a/src/vfs/vfs_proc_search_keys.c
+++ b/src/vfs/vfs_proc_search_keys.c
@@ -53,10 +53,50 @@ chimera_vfs_search_keys(
     chimera_vfs_dispatch(request);
 } /* chimera_vfs_search_keys */
 
-/* Search a key range in the backend that serves `fh` (rather than the global
- * kv_module), used to enumerate handle-state records on a specific share's
- * backend at startup.  start/end keys are copied into the request scratch so
- * the caller need not keep them alive across the async dispatch. */
+/* When an fh-routed search is served by the default KV (the backend lacks
+ * native KV), keys are stored with a 1-byte namespace prefix.  These
+ * trampolines live in request->plugin_data and strip that prefix back off so
+ * the caller observes exactly the keys it stored, identical to the native
+ * path. */
+struct chimera_vfs_kv_ns_search_ctx {
+    chimera_vfs_search_keys_callback_t user_callback;
+    chimera_vfs_search_keys_complete_t user_complete;
+    void                              *user_private;
+    uint8_t                            ns_len;
+};
+
+static int
+chimera_vfs_kv_ns_search_cb(
+    const void *key,
+    uint32_t    key_len,
+    const void *value,
+    uint32_t    value_len,
+    void       *private_data)
+{
+    struct chimera_vfs_kv_ns_search_ctx *ctx = private_data;
+
+    return ctx->user_callback((const uint8_t *) key + ctx->ns_len,
+                              key_len - ctx->ns_len,
+                              value, value_len, ctx->user_private);
+} /* chimera_vfs_kv_ns_search_cb */
+
+static void
+chimera_vfs_kv_ns_search_complete(
+    enum chimera_vfs_error error_code,
+    void                  *private_data)
+{
+    struct chimera_vfs_kv_ns_search_ctx *ctx = private_data;
+
+    ctx->user_complete(error_code, ctx->user_private);
+} /* chimera_vfs_kv_ns_search_complete */
+
+/* Search a key range associated with the backend that serves `fh`, used to
+ * enumerate handle-state records for a specific share at startup.  If that
+ * backend has native KV the search runs there; otherwise it routes to the
+ * default KV with the range namespaced by the source backend's fh_magic (see
+ * chimera_vfs_kv_route_fh), and the prefix is stripped from results before they
+ * reach the caller.  start/end keys are copied into the request scratch so the
+ * caller need not keep them alive across the async dispatch. */
 SYMBOL_EXPORT void
 chimera_vfs_search_keys_at(
     struct chimera_vfs_thread         *thread,
@@ -72,33 +112,84 @@ chimera_vfs_search_keys_at(
     void                              *private_data)
 {
     struct chimera_vfs_request *request;
+    struct chimera_vfs_kv_route route;
     uint8_t                    *scratch;
 
-    request = chimera_vfs_request_alloc_by_hash(thread, cred, fh, fhlen,
-                                                chimera_vfs_hash(fh, fhlen));
+    chimera_vfs_kv_route_fh(thread, fh, fhlen, &route);
+
+    if (route.fallback) {
+        request = chimera_vfs_request_alloc_common(thread, NULL, route.module,
+                                                   NULL, 0,
+                                                   chimera_vfs_hash(fh, fhlen),
+                                                   CHIMERA_VFS_CAP_KV);
+    } else {
+        request = chimera_vfs_request_alloc_by_hash(thread, cred, fh, fhlen,
+                                                    chimera_vfs_hash(fh, fhlen));
+    }
 
     if (CHIMERA_VFS_IS_ERR(request)) {
         complete(CHIMERA_VFS_PTR_ERR(request), private_data);
         return;
     }
 
-    scratch = request->plugin_data;
-    if (start_key_len) {
-        memcpy(scratch, start_key, start_key_len);
-    }
-    if (end_key_len) {
-        memcpy(scratch + start_key_len, end_key, end_key_len);
-    }
+    request->opcode   = CHIMERA_VFS_OP_SEARCH_KEYS;
+    request->complete = chimera_vfs_search_keys_complete;
 
-    request->opcode                    = CHIMERA_VFS_OP_SEARCH_KEYS;
-    request->complete                  = chimera_vfs_search_keys_complete;
-    request->search_keys.start_key     = start_key_len ? scratch : NULL;
-    request->search_keys.start_key_len = start_key_len;
-    request->search_keys.end_key       = end_key_len ? scratch + start_key_len : NULL;
-    request->search_keys.end_key_len   = end_key_len;
-    request->search_keys.callback      = callback;
-    request->proto_callback            = complete;
-    request->proto_private_data        = private_data;
+    if (route.fallback) {
+        struct chimera_vfs_kv_ns_search_ctx *ctx = request->plugin_data;
+        uint8_t                             *p;
+        uint32_t                             off;
+
+        ctx->user_callback = callback;
+        ctx->user_complete = complete;
+        ctx->user_private  = private_data;
+        ctx->ns_len        = 1;
+
+        off = (sizeof(*ctx) + 7) & ~7u;
+        p   = (uint8_t *) request->plugin_data + off;
+
+        /* start = ns || start_key */
+        p[0] = route.ns;
+        if (start_key_len) {
+            memcpy(p + 1, start_key, start_key_len);
+        }
+        request->search_keys.start_key     = p;
+        request->search_keys.start_key_len = start_key_len + 1;
+        p                                 += start_key_len + 1;
+
+        /* end = ns || end_key when bounded; otherwise the next namespace byte,
+         * an upper bound that keeps the scan inside this backend's namespace. */
+        if (end_key_len) {
+            p[0] = route.ns;
+            memcpy(p + 1, end_key, end_key_len);
+            request->search_keys.end_key     = p;
+            request->search_keys.end_key_len = end_key_len + 1;
+        } else {
+            p[0]                             = (uint8_t) (route.ns + 1);
+            request->search_keys.end_key     = p;
+            request->search_keys.end_key_len = 1;
+        }
+
+        request->search_keys.callback = chimera_vfs_kv_ns_search_cb;
+        request->proto_callback       = chimera_vfs_kv_ns_search_complete;
+        request->proto_private_data   = ctx;
+    } else {
+        scratch = request->plugin_data;
+        if (start_key_len) {
+            memcpy(scratch, start_key, start_key_len);
+        }
+        if (end_key_len) {
+            memcpy(scratch + start_key_len, end_key, end_key_len);
+        }
+
+        request->search_keys.start_key     = start_key_len ? scratch : NULL;
+        request->search_keys.start_key_len = start_key_len;
+        request->search_keys.end_key       = end_key_len ? scratch + start_key_len : NULL;
+        request->search_keys.end_key_len   = end_key_len;
+        request->search_keys.callback      = callback;
+        request->proto_callback            = complete;
+        request->proto_private_data        = private_data;
+    }
 
     chimera_vfs_dispatch(request);
 } /* chimera_vfs_search_keys_at */

--- a/src/vfs/vfs_procs.h
+++ b/src/vfs/vfs_procs.h
@@ -674,6 +674,22 @@ chimera_vfs_put_key(
     chimera_vfs_put_key_callback_t callback,
     void                          *private_data);
 
+/* fh-routed put: store a key/value associated with the backend serving `fh`
+ * (used to persist handle-state for backends without native KV; see
+ * chimera_vfs_kv_route_fh). */
+void
+chimera_vfs_put_key_at(
+    struct chimera_vfs_thread     *thread,
+    const struct chimera_vfs_cred *cred,
+    const void                    *fh,
+    int                            fhlen,
+    const void                    *key,
+    uint32_t                       key_len,
+    const void                    *value,
+    uint32_t                       value_len,
+    chimera_vfs_put_key_callback_t callback,
+    void                          *private_data);
+
 void
 chimera_vfs_get_key(
     struct chimera_vfs_thread     *thread,
@@ -681,6 +697,15 @@ chimera_vfs_get_key(
     uint32_t                       key_len,
     chimera_vfs_get_key_callback_t callback,
     void                          *private_data);
+
+/* True if a handle-state record can be persisted for an open on `handle`'s
+ * backend: either the backend persists it atomically (CAP_ATOMIC_HANDLE_STATE)
+ * or a default KV module is configured to hold it.  Used by the SMB server to
+ * decide whether a durable/persistent open can be granted. */
+int
+chimera_vfs_can_persist_handle_state(
+    struct chimera_vfs_thread      *thread,
+    struct chimera_vfs_open_handle *handle);
 
 void
 chimera_vfs_delete_key(


### PR DESCRIPTION
## Summary

Makes the VFS key-value (KV) API a first-class concern instead of a feature embedded in filesystem backends.

- **New KV-only backends** (`CAP_KV`, not `CAP_FS`):
  - `memkv` (`src/vfs/memkv/`) — in-memory, hash-sharded rb-tree (the implementation previously embedded in memfs).
  - `sqlite` (`src/vfs/sqlite/`) — persistent, single `kv(key BLOB PRIMARY KEY, value BLOB) WITHOUT ROWID` table in **WAL** mode with a per-thread connection so multiple readers and a writer operate concurrently. `CAP_KV | CAP_BLOCKING`. Built when `libsqlite3-dev` is present (`SQLITE_ENABLED`).
- **New fh_magic** `MEMKV=7` / `SQLITE=8`; `CHIMERA_VFS_FH_MAGIC_MAX` bumped `7 -> 9` (it sizes the module array).
- **KV removed from memfs** (moved to memkv), including its atomic-handle-state storage. `cairn`/`diskfs` keep their native co-located KV, where atomic crash-consistent handle-state still matters.
- **`kv_module` config repurposed as the "default KV"** (`memkv` or `sqlite`, default `memkv`); `memkv` is registered unconditionally so zero-config deployments always have a KV store.
- **Default-KV fallback for backends without native KV.** fh-routed KV ops (handle-state put on open, `delete_key_at`, `search_keys_at`) dispatch to the file's own backend when it has `CAP_KV`; otherwise they route to the default KV with keys **namespaced by a 1-byte source-backend `fh_magic` prefix**. Because every handle on a backend shares one fh_magic, the open/close/recovery paths agree on the namespace, and keys from different backends can never collide in the shared default KV. Search results strip the prefix transparently. SMB3 durable/persistent-handle opens now work on backends without native KV (memfs/linux/io_uring) via a non-atomic default-KV put, gated by `chimera_vfs_can_persist_handle_state()`.

## Notes

- The global KV API (`put_key`/`get_key`/`delete_key`/`search_keys`, no fh) is left un-namespaced; it has no production callers and so cannot collide with the fh-namespaced fallback keys.
- The handle-state fallback put is intentionally non-atomic (a separate put after the open). It is only reached by backends that aren't crash-durable anyway (memfs in-memory); true atomicity is preserved on cairn/diskfs, which keep native KV.

## Validation

- All 5 `chimera/vfs/*` unit tests pass; `kv_test` now exercises **both** memkv and sqlite (the sqlite arm runs only when built).
- All 36 `chimera/server/smb/wpts/memfs_persistent/*` durable-handle tests pass — full coverage of the fallback path (persist-on-open -> reconnect -> close-delete -> replay) on a memfs share.
- `make syntax` / uncrustify, SPDX headers, and copyright-year are clean.