### PR TITLE
smb2: fix AppInstanceId open matching across sequential opens

### DIFF
--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -3108,6 +3108,20 @@ chimera_smb_parse_create(
     request->create.set_attr.va_acl      = NULL;
     request->create.ctx_present_mask     = 0;
 
+    /* The request slot is pooled, so the AppInstanceId/AppInstanceVersion
+     * fields survive from a prior CREATE on this same slot.  Each create
+     * context is parsed only when present on the wire, so a CREATE that
+     * carries an AppInstanceId but no AppInstanceVersion (or no AppInstanceId
+     * at all) would otherwise inherit the stale version/GUID and apply the
+     * wrong AppInstanceVersion force-close rule.  This is invisible when each
+     * test runs against a fresh daemon but corrupts the decision in a
+     * sequential run.  Reset them explicitly before parsing the contexts. */
+    request->create.app_version_present = 0;
+    request->create.app_version_high    = 0;
+    request->create.app_version_low     = 0;
+    memset(request->create.app_instance_id, 0,
+           sizeof(request->create.app_instance_id));
+
     /* Persist any settable DOS attribute bits supplied at create time. */
     if (request->create.file_attributes & SMB_DOS_ATTR_SETTABLE) {
         request->create.set_attr.va_dos_attributes =


### PR DESCRIPTION
## Root cause

The 7 WPTS AppInstanceId/AppInstanceVersion tests each pass when run against a fresh daemon (the ctest allowlist starts a new daemon per case), but in the full sequential run against one daemon exactly 2 fail, inverted:

- `Negative_AppInstanceVersion_SMB311_NoVersion` — expects reject `0xC00000B6`, got `0x0` SUCCESS.
- `AppInstanceVersion_SMB302_SMB311` — expects SUCCESS `0x0`, got `0xC00000B6` reject.

The CREATE request slot is pooled and reused across requests. The AppInstanceId and AppInstanceVersion create contexts are parsed only when present on the wire, but `chimera_smb_parse_create` never reset `request->create.app_instance_id` / `app_version_present` / `app_version_high` / `app_version_low` before parsing the contexts (it only reset `ctx_present_mask`, `set_attr`, etc.).

So a CREATE that carried an AppInstanceId but **no** AppInstanceVersion (or no AppInstanceId at all) inherited the stale version/GUID left by a prior CREATE on the same pooled slot. The AppInstanceVersion force-close rule (MS-SMB2 3.3.5.9.7 / 3.3.5.9.16) was then applied against the wrong version-presence and values:

- the no-version reopen inherited a stale `app_version_present=1` and wrongly succeeded;
- the versioned reopen inherited stale high/low and was wrongly rejected with `STATUS_FILE_FORCED_CLOSED`.

This was invisible per-test because a fresh daemon starts with a zeroed slot. Instrumenting the scan loop showed each test uses a distinct random AppInstanceId (the same-GUID/connection-reuse hypothesis did not hold) and that the *request's own* version fields were stale, not the stored opens.

## The fix

Reset the AppInstanceId GUID and the AppInstanceVersion fields in `chimera_smb_parse_create` before parsing the create contexts, alongside the existing per-request resets.

## Verification

- Full WPTS AppInstance set against one daemon: `Failed: 0, Passed: 7` (was 2/5).
- Per-test ctest (`-R AppInstance`, fresh-daemon path): green.
- smbtorture create/durable on memfs (18/18) and cairn (15/15): green.