### PR TITLE
nfs/pnfs client: commit file size to the MDS on COMMIT (fix proxy close-to-open)

### DIFF
--- a/src/vfs/nfs/nfs4_commit.c
+++ b/src/vfs/nfs/nfs4_commit.c
@@ -1,8 +1,10 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
 #include "nfs_internal.h"
+#include "nfs4_open_state.h"
+#include "nfs4_pnfs.h"
 
 void
 chimera_nfs4_commit(
@@ -11,7 +13,19 @@ chimera_nfs4_commit(
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
+    struct chimera_nfs4_open_state *open_state =
+        request->commit.handle ?
+        (struct chimera_nfs4_open_state *) request->commit.handle->vfs_private : NULL;
+
+    /* If a pNFS layout collected dirty writes (sent to the data server), turn
+     * this COMMIT into a LAYOUTCOMMIT so the MDS learns the new file size before
+     * we acknowledge -- otherwise a re-open would race the deferred close-time
+     * LAYOUTCOMMIT and read back a stale size. */
+    if (open_state &&
+        chimera_nfs4_pnfs_commit(thread, shared, request, open_state)) {
+        return;
+    }
+
     request->status = CHIMERA_VFS_OK;
     request->complete(request);
 } /* chimera_nfs4_commit */
-

--- a/src/vfs/nfs/nfs4_pnfs.c
+++ b/src/vfs/nfs/nfs4_pnfs.c
@@ -1244,7 +1244,14 @@ chimera_nfs4_pnfs_ds_write_callback(
     }
     layout->layoutcommit_needed = 1;
 
-    request->write.r_sync   = res->resok.committed;
+    /* Report UNSTABLE regardless of the DS's committed level: the data is on the
+     * DS, but the MDS only learns the new file size from a LAYOUTCOMMIT, which
+     * this proxy issues lazily (close-time, deferred by the open-handle cache).
+     * Forcing UNSTABLE makes the upper client issue a COMMIT on close/sync, which
+     * chimera_nfs4_commit turns into a LAYOUTCOMMIT -- so a re-open sees the real
+     * size.  Reporting the DS's FILE_SYNC here would let the client skip COMMIT
+     * and read back a stale (often zero) size, breaking close-to-open. */
+    request->write.r_sync   = CHIMERA_VFS_WRITE_UNSTABLE;
     request->write.r_length = res->resok.count;
     request->status         = CHIMERA_VFS_OK;
     request->complete(request);
@@ -1626,3 +1633,133 @@ chimera_nfs4_pnfs_close(
     }
     return 1;
 } /* chimera_nfs4_pnfs_close */
+
+/* ---------------------------------------------------------------------------
+* Commit-time LAYOUTCOMMIT: flush the file size to the MDS WITHOUT releasing the
+* layout (the file stays open).  pNFS DS writes are reported UNSTABLE (see
+* chimera_nfs4_pnfs_ds_write_callback), so the upper client issues a COMMIT on
+* close/sync; that COMMIT lands here and is turned into a LAYOUTCOMMIT so a
+* subsequent open observes the real size instead of the stale pre-commit one
+* (the close-time LAYOUTCOMMIT alone is deferred by the open-handle cache and
+* loses the close-to-open race).
+* ------------------------------------------------------------------------- */
+
+static void chimera_nfs4_pnfs_commit_send(
+    struct chimera_vfs_request *request);
+
+static void
+chimera_nfs4_pnfs_commit_retry(
+    struct chimera_nfs_thread  *thread,
+    struct chimera_nfs_shared  *shared,
+    struct chimera_vfs_request *request,
+    void                       *ctx)
+{
+    (void) thread;
+    (void) shared;
+    (void) ctx;
+    chimera_nfs4_pnfs_commit_send(request);
+} /* chimera_nfs4_pnfs_commit_retry */
+
+static void
+chimera_nfs4_pnfs_commit_callback(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    struct COMPOUND4res         *res,
+    int                          status,
+    void                        *private_data)
+{
+    struct chimera_vfs_request         *request = private_data;
+    struct chimera_nfs4_pnfs_close_ctx *cctx    = request->plugin_data;
+
+    /* On success the MDS now reflects the high-water size, so a later
+     * close/commit with no new writes can skip the round-trip.  On error leave
+     * layoutcommit_needed set so close-time LAYOUTCOMMIT retries the flush. */
+    if (status == 0 && res && res->status == NFS4_OK) {
+        cctx->open_state->layout.layoutcommit_needed = 0;
+    }
+
+    request->status = CHIMERA_VFS_OK;
+    request->complete(request);
+} /* chimera_nfs4_pnfs_commit_callback */
+
+static void
+chimera_nfs4_pnfs_commit_send(struct chimera_vfs_request *request)
+{
+    struct chimera_nfs4_pnfs_close_ctx      *cctx          = request->plugin_data;
+    struct chimera_nfs_shared               *shared        = cctx->shared;
+    struct chimera_nfs_client_server_thread *server_thread = cctx->mds_thread;
+    struct chimera_nfs4_layout              *layout        = &cctx->open_state->layout;
+    struct COMPOUND4args                     args;
+    struct nfs_argop4                        argarray[3];
+    struct evpl_rpc2_cred                    rpc2_cred;
+    uint8_t                                 *fh;
+    int                                      fhlen;
+    uint64_t                                 high;
+
+    chimera_nfs4_map_fh(layout->file_fh, layout->file_fh_len, &fh, &fhlen);
+
+    memset(&args, 0, sizeof(args));
+    args.minorversion = 1;
+    args.argarray     = argarray;
+    args.num_argarray = 3;
+
+    argarray[0].argop = OP_SEQUENCE;   /* slot fields filled by compound_call */
+
+    argarray[1].argop               = OP_PUTFH;
+    argarray[1].opputfh.object.data = fh;
+    argarray[1].opputfh.object.len  = fhlen;
+
+    argarray[2].argop                                              = OP_LAYOUTCOMMIT;
+    argarray[2].oplayoutcommit.loca_offset                         = 0;
+    argarray[2].oplayoutcommit.loca_length                         = UINT64_MAX;
+    argarray[2].oplayoutcommit.loca_reclaim                        = 0;
+    argarray[2].oplayoutcommit.loca_stateid                        = layout->layout_stateid;
+    high                                                           = atomic_load(&layout->last_write_offset);
+    argarray[2].oplayoutcommit.loca_last_write_offset.no_newoffset = 1;
+    argarray[2].oplayoutcommit.loca_last_write_offset.no_offset    = high ? high - 1 : 0;
+    argarray[2].oplayoutcommit.loca_time_modify.nt_timechanged     = 0;
+    argarray[2].oplayoutcommit.loca_layoutupdate.lou_type          = CHIMERA_NFS4_LAYOUT4_FLEX_FILES;
+    argarray[2].oplayoutcommit.loca_layoutupdate.lou_body.data     = NULL;
+    argarray[2].oplayoutcommit.loca_layoutupdate.lou_body.len      = 0;
+
+    chimera_nfs_init_rpc2_cred(&rpc2_cred, request->cred,
+                               request->thread->vfs->machine_name,
+                               request->thread->vfs->machine_name_len);
+
+    chimera_nfs4_compound_call(
+        cctx->thread, shared, server_thread, request,
+        &args, &rpc2_cred, 0, 0, NULL, 0, 0,
+        chimera_nfs4_pnfs_commit_callback, request,
+        chimera_nfs4_pnfs_commit_retry, request);
+} /* chimera_nfs4_pnfs_commit_send */
+
+int
+chimera_nfs4_pnfs_commit(
+    struct chimera_nfs_thread      *thread,
+    struct chimera_nfs_shared      *shared,
+    struct chimera_vfs_request     *request,
+    struct chimera_nfs4_open_state *open_state)
+{
+    struct chimera_nfs4_layout              *layout = &open_state->layout;
+    struct chimera_nfs_client_server_thread *mds_thread;
+    struct chimera_nfs4_pnfs_close_ctx      *cctx;
+
+    if (atomic_load(&layout->state) != CHIMERA_NFS4_LAYOUT_VALID ||
+        layout->file_fh_len == 0 || !layout->layoutcommit_needed) {
+        return 0;       /* nothing to flush: caller completes the commit OK. */
+    }
+
+    mds_thread = chimera_nfs_thread_get_server_thread(thread, layout->file_fh, layout->file_fh_len);
+    if (!mds_thread || !mds_thread->nfs_conn || !mds_thread->server->nfs4_session) {
+        return 0;
+    }
+
+    cctx             = request->plugin_data;
+    cctx->thread     = thread;
+    cctx->shared     = shared;
+    cctx->mds_thread = mds_thread;
+    cctx->open_state = open_state;
+
+    chimera_nfs4_pnfs_commit_send(request);
+    return 1;
+} /* chimera_nfs4_pnfs_commit */

--- a/src/vfs/nfs/nfs4_pnfs.h
+++ b/src/vfs/nfs/nfs4_pnfs.h
@@ -136,6 +136,19 @@ int chimera_nfs4_pnfs_close(
     struct chimera_nfs4_open_state *open_state);
 
 /*
+ * Commit-time layout flush.  Returns 1 if it took ownership of the request (a
+ * LAYOUTCOMMIT was issued to report the file's high-water size to the MDS and
+ * the request will complete on its reply), or 0 if there is nothing to flush
+ * and the caller should complete the commit itself.  Unlike close, the layout
+ * is NOT returned -- the file stays open.
+ */
+int chimera_nfs4_pnfs_commit(
+    struct chimera_nfs_thread      *thread,
+    struct chimera_nfs_shared      *shared,
+    struct chimera_vfs_request     *request,
+    struct chimera_nfs4_open_state *open_state);
+
+/*
  * Layout registry (shared->pnfs_layouts).  register publishes a now-VALID
  * layout so a back-channel CB_LAYOUTRECALL can find it; unregister removes it
  * before the owning open state is freed.  Both are idempotent and safe to call


### PR DESCRIPTION
## Problem

The `chimera/kvm/*/pnfs/proxy_*` tests have been timing out (300s) on **every** PR's CI run — regardless of what the PR changes — making them noise that blocks unrelated work. They are not flaky in the usual sense; they expose a real correctness bug in the pNFS *proxy* client (chimera's own `nfs` VFS module acting as an NFSv4.1/pNFS client).

## Root cause

A pNFS write lands its data on the **data server**; the **MDS** only learns the new file size from a `LAYOUTCOMMIT`. The proxy client issued `LAYOUTCOMMIT` only when it closed the *backing* handle — and that close is deferred by the VFS open-handle cache's TTL-based close-sweep, **not** driven by the guest's CLOSE. On top of that, the client reported DS writes with the DS's `FILE_SYNC` committed level, so the upper client never sent a `COMMIT`, and `chimera_nfs4_commit` was a no-op.

Net effect: after a writer closes a file, its size is not committed to the MDS for several seconds. A reader that opens in that window sees a **stale size — typically 0**, violating close-to-open consistency.

That is exactly what the proxy tests do (`cp → sync → drop_caches → cmp`):

- With a **memfs** MDS the deferred `LAYOUTCOMMIT` usually lands before the read, so it passes locally.
- With a **diskfs** MDS (slower), or under CI's concurrent load, it loses the race ~100% of the time. The read-back sees an empty/partial file, and on the guest's *hard* NFS mount a stale/stuck proxy surfaces as the `nfs_wb_all` 300s timeout seen in CI.

Reproduced deterministically by pinning the daemons+VM to a small CPU set (`taskset -c 0-5`): `stat` right after `cp`+`sync`+`drop_caches` reports size `0`; the correct size only appears ~2s later when the deferred `LAYOUTCOMMIT` lands.

The bug predates the recent session-slot work (reproduces before those commits); it has been latent since the proxy client was introduced.

## Fix

Drive the size flush from the guest's `COMMIT` — the standard pNFS client shape:

- **Report pNFS DS writes as `UNSTABLE`** instead of the DS's `FILE_SYNC`. The data is on the DS but the size is not yet on the MDS, so from a close-to-open standpoint the write genuinely isn't stable yet; `UNSTABLE` makes the upper client issue a `COMMIT` on close/sync.
- **Implement `chimera_nfs4_commit`** (was a no-op): when the open file holds a dirty layout, issue a `LAYOUTCOMMIT` reporting the high-water size and complete the `COMMIT` only once the MDS has acknowledged it. The layout is **not** returned — the file stays open — so it's cheaper than the close path and re-runs if later writes redirty the layout.

## Validation (pinned to force the CI race locally)

- `diskfs_io_uring` `proxy_rw` under contention: **0/6 → 6/6**
- full kvm proxy suite (24 tests) under contention: **24/24** (twice)
- non-proxy + combined pNFS kvm: **36/36**; posix nfs4: **498/498** (no regression)
- `stat` right after `cp`+`sync`+`drop_caches`: size `0` → correct, both memfs and diskfs

## Follow-up (not in this PR)

Under an extreme amplification (64 MB write pinned to 4 CPUs) a separate robustness issue remains: libevpl's synchronous `connect()` aborts the daemon on `ECONNREFUSED` (`tcp.c`), and a large parked-write replay burst can stall. These are beyond the 8 MB CI workload and are tracked separately.