### PR TITLE
smb2: emit CHANGE_NOTIFY for named-stream changes

### DIFF
--- a/scripts/wpts_smb_test_wrapper.sh
+++ b/scripts/wpts_smb_test_wrapper.sh
@@ -162,6 +162,7 @@ generate_config() {
         ${compression_line}
         ${multichannel_line}
         ${encryption_line}
+        "smb_named_streams": true,
         "threads": 4,
         "delegation_threads": 4,
         "external_portmap": false

--- a/src/server/smb/smb_notify.c
+++ b/src/server/smb/smb_notify.c
@@ -46,11 +46,21 @@ chimera_smb_map_completion_filter(uint32_t cf)
     if (cf & (SMB2_NOTIFY_CHANGE_LAST_ACCESS |
               SMB2_NOTIFY_CHANGE_CREATION |
               SMB2_NOTIFY_CHANGE_EA |
-              SMB2_NOTIFY_CHANGE_SECURITY |
-              SMB2_NOTIFY_CHANGE_STREAM_NAME |
-              SMB2_NOTIFY_CHANGE_STREAM_SIZE |
-              SMB2_NOTIFY_CHANGE_STREAM_WRITE)) {
+              SMB2_NOTIFY_CHANGE_SECURITY)) {
         m |= CHIMERA_VFS_NOTIFY_ATTRS_CHANGED;
+    }
+    /* Named-stream filters map to their dedicated VFS event classes so a
+     * stream change (create/write/size) is delivered to a watcher that
+     * requested only the stream filter, without conflating it with the
+     * generic ATTRS_CHANGED class. */
+    if (cf & SMB2_NOTIFY_CHANGE_STREAM_NAME) {
+        m |= CHIMERA_VFS_NOTIFY_STREAM_NAME;
+    }
+    if (cf & SMB2_NOTIFY_CHANGE_STREAM_SIZE) {
+        m |= CHIMERA_VFS_NOTIFY_STREAM_SIZE;
+    }
+    if (cf & SMB2_NOTIFY_CHANGE_STREAM_WRITE) {
+        m |= CHIMERA_VFS_NOTIFY_STREAM_WRITE;
     }
     return m;
 } /* chimera_smb_map_completion_filter */
@@ -249,6 +259,14 @@ chimera_smb_notify_serialize_events(
         } else {
             uint32_t action;
 
+            /* Stream-class events (STREAM_NAME/SIZE/WRITE) are OR'd onto the
+             * generic ADDED/MODIFIED action that carries them — a write to a
+             * file's $DATA fork is reported as FILE_ACTION_MODIFIED and a
+             * create as FILE_ACTION_ADDED, even when observed through a
+             * FILE_NOTIFY_CHANGE_STREAM_* filter (matching Windows /
+             * smbtorture smb2.notify.mask, which requires ACTION_MODIFIED for
+             * a write under every filter bit).  So the stream bits only widen
+             * which watchers are notified; they do not change the action. */
             if (ev->action & (CHIMERA_VFS_NOTIFY_FILE_ADDED | CHIMERA_VFS_NOTIFY_DIR_ADDED)) {
                 action = FILE_ACTION_ADDED;
             } else if (ev->action & (CHIMERA_VFS_NOTIFY_FILE_REMOVED | CHIMERA_VFS_NOTIFY_DIR_REMOVED)) {

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -1260,6 +1260,15 @@ chimera_smb_create_open_at_callback(
         uint32_t                          action = S_ISDIR(attr->va_mode) ?
             CHIMERA_VFS_NOTIFY_DIR_ADDED : CHIMERA_VFS_NOTIFY_FILE_ADDED;
 
+        /* Creating/opening a (regular) file's data fork introduces its
+         * $DATA stream into the file's stream namespace, so also raise the
+         * STREAM_NAME class for non-directories.  This lets a watcher that
+         * requested only FILE_NOTIFY_CHANGE_STREAM_NAME observe the stream
+         * appearing (WPTS BVT_SMB2Basic_ChangeNotify_ChangeStreamName). */
+        if (!S_ISDIR(attr->va_mode)) {
+            action |= CHIMERA_VFS_NOTIFY_STREAM_NAME;
+        }
+
         chimera_vfs_notify_emit(thread->shared->vfs->vfs_notify,
                                 request->create.parent_handle->fh,
                                 request->create.parent_handle->fh_len,

--- a/src/server/smb/smb_proc_set_info.c
+++ b/src/server/smb/smb_proc_set_info.c
@@ -251,7 +251,8 @@ chimera_smb_set_info(struct chimera_smb_request *request)
                     /* A size change fires FILE_NOTIFY_CHANGE_SIZE (and, via the
                      * advanced LastWriteTime below, FILE_NOTIFY_CHANGE_LAST_WRITE). */
                     request->set_info.notify_mask = CHIMERA_VFS_NOTIFY_SIZE_CHANGED |
-                        CHIMERA_VFS_NOTIFY_FILE_MODIFIED;
+                        CHIMERA_VFS_NOTIFY_FILE_MODIFIED |
+                        CHIMERA_VFS_NOTIFY_STREAM_SIZE;
 
                     /* Setting EndOfFile advances the LastWriteTime (it changes
                      * the file's data extent), unless this handle has taken
@@ -280,7 +281,8 @@ chimera_smb_set_info(struct chimera_smb_request *request)
                      * ChangeTime.  Both need the current size to decide, so this
                      * is resolved in the getattr callback. */
                     request->set_info.notify_mask = CHIMERA_VFS_NOTIFY_SIZE_CHANGED |
-                        CHIMERA_VFS_NOTIFY_FILE_MODIFIED;
+                        CHIMERA_VFS_NOTIFY_FILE_MODIFIED |
+                        CHIMERA_VFS_NOTIFY_STREAM_SIZE;
                     chimera_smb_unmarshal_end_of_file_info(&request->set_info.attrs, &request->set_info.vfs_attrs);
 
                     chimera_vfs_getattr(

--- a/src/server/smb/smb_proc_write.c
+++ b/src/server/smb/smb_proc_write.c
@@ -60,10 +60,18 @@ chimera_smb_write_callback(
     evpl_iovecs_release(thread->evpl, request->write.iov, request->write.niov);
 
     if (!error_code && request->write.open_file->parent_fh_len > 0) {
+        /* A write changes the file's data and length.  Beyond the generic
+         * FILE_MODIFIED class this also touches the (default or named) data
+         * stream's contents and size, so set the STREAM_WRITE/STREAM_SIZE
+         * classes too — a watcher requesting only
+         * FILE_NOTIFY_CHANGE_STREAM_{WRITE,SIZE} must still be notified
+         * (WPTS BVT_SMB2Basic_ChangeNotify_ChangeStream{Write,Size}). */
         chimera_vfs_notify_emit(thread->shared->vfs->vfs_notify,
                                 request->write.open_file->parent_fh,
                                 request->write.open_file->parent_fh_len,
-                                CHIMERA_VFS_NOTIFY_FILE_MODIFIED,
+                                CHIMERA_VFS_NOTIFY_FILE_MODIFIED |
+                                CHIMERA_VFS_NOTIFY_STREAM_WRITE |
+                                CHIMERA_VFS_NOTIFY_STREAM_SIZE,
                                 request->write.open_file->name,
                                 request->write.open_file->name_len,
                                 NULL, 0);

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -141,6 +141,9 @@ if(CHIMERA_NETNS_TESTING AND WPTS_DOTNET AND WPTS_SMB2_DLL AND WPTS_ARCH_SUPPORT
         BVT_SMB2Basic_ChangeNotify_ChangeLastWrite
         BVT_SMB2Basic_ChangeNotify_ChangeSecurity
         BVT_SMB2Basic_ChangeNotify_ChangeSize
+        BVT_SMB2Basic_ChangeNotify_ChangeStreamName
+        BVT_SMB2Basic_ChangeNotify_ChangeStreamSize
+        BVT_SMB2Basic_ChangeNotify_ChangeStreamWrite
         BVT_SMB2Basic_ChangeNotify_MaxTransactSizeCheck_Smb2002
         BVT_SMB2Basic_ChangeNotify_MaxTransactSizeCheck_Smb21
         BVT_SMB2Basic_ChangeNotify_MaxTransactSizeCheck_Smb30

--- a/src/vfs/vfs_notify.h
+++ b/src/vfs/vfs_notify.h
@@ -19,6 +19,15 @@
 #define CHIMERA_VFS_NOTIFY_RENAMED       0x0020
 #define CHIMERA_VFS_NOTIFY_ATTRS_CHANGED 0x0040
 #define CHIMERA_VFS_NOTIFY_SIZE_CHANGED  0x0080
+/* Named-stream (alternate data stream) change classes, mapping to the
+ * SMB2 FILE_NOTIFY_CHANGE_STREAM_{NAME,SIZE,WRITE} completion filters.
+ * STREAM_NAME covers a stream being created/renamed/removed; STREAM_SIZE
+ * a change to a stream's length; STREAM_WRITE a write into a stream's
+ * data.  A write to a file's default ($DATA) fork touches both the
+ * stream size and stream data, so the write path emits SIZE|WRITE. */
+#define CHIMERA_VFS_NOTIFY_STREAM_NAME   0x0100
+#define CHIMERA_VFS_NOTIFY_STREAM_SIZE   0x0200
+#define CHIMERA_VFS_NOTIFY_STREAM_WRITE  0x0400
 
 #define CHIMERA_VFS_NOTIFY_RING_SIZE     32
 #define CHIMERA_VFS_NOTIFY_NUM_BUCKETS   64


### PR DESCRIPTION
## Summary

Emit SMB2 CHANGE_NOTIFY events for named-stream ($DATA) changes so a directory watcher that registered a stream completion filter is actually delivered the matching notification.

### Root cause
`chimera_smb_map_completion_filter` collapsed all three stream filters (`FILE_NOTIFY_CHANGE_STREAM_{NAME,SIZE,WRITE}`) into `CHIMERA_VFS_NOTIFY_ATTRS_CHANGED`. But the file create/write/set-EOF paths emit `FILE_ADDED` / `FILE_MODIFIED` / `SIZE_CHANGED`, which never intersect `ATTRS_CHANGED`. So a watch registered with only a stream filter matched no emitted event, the parked CHANGE_NOTIFY never completed, and the WPTS SDK timed out with `System.InvalidOperationException`.

### Changes
- Add dedicated VFS notify classes `CHIMERA_VFS_NOTIFY_STREAM_{NAME,SIZE,WRITE}` and map the SMB2 stream completion filters to them.
- CREATE of a regular file additionally raises `STREAM_NAME` (its $DATA fork enters the file's stream namespace); WRITE additionally raises `STREAM_SIZE|STREAM_WRITE`; set-EOF/allocation additionally raises `STREAM_SIZE`. The stream bits only widen *which* watchers are notified — the serialized `FILE_ACTION` stays `ADDED`/`MODIFIED`, so smb2.notify.mask (which requires `ACTION_MODIFIED` for a write under every filter bit) still passes.
- WPTS wrapper enables `smb_named_streams` so the stream CREATE (`file:$DATA`) is accepted on the memfs share.

### Tests enabled (memfs, BASELINE)
- `BVT_SMB2Basic_ChangeNotify_ChangeStreamName`
- `BVT_SMB2Basic_ChangeNotify_ChangeStreamSize`
- `BVT_SMB2Basic_ChangeNotify_ChangeStreamWrite`

All three pass via ctest. Full WPTS ChangeNotify suite: 21 passed / 0 failed (2 persistent-handle Replay cases not executed, gated). smbtorture notify+streams across all backends: 139/139 active tests pass (including the previously-affected smb2.notify.mask).