### PR TITLE
smb2: VFS-owned oplock/lease leases (exclusive/batch oplocks + SMB2 lease break arbitration)

### DIFF
--- a/src/server/smb/CMakeLists.txt
+++ b/src/server/smb/CMakeLists.txt
@@ -12,7 +12,7 @@ add_library(chimera_smb SHARED
     smb_proc_reparse.c smb_proc_change_notify.c smb_proc_cancel.c
     smb_proc_sparse.c smb_proc_copychunk.c
     smb_proc_lock.c smb_proc_oplock_break.c
-    smb_notify.c smb_sharemode.c smb_ntlm.c smb_durable.c
+    smb_notify.c smb_async_interim.c smb_sharemode.c smb_ntlm.c smb_durable.c
     smb_wbclient.c smb_auth.c smb_gssapi.c
     #idl/ndr_dcerpc.c
 )

--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -20,6 +20,7 @@
 #include "server/server.h"
 #include "evpl/evpl.h"
 #include "smb_internal.h"
+#include "smb_async_interim.h"
 #include "smb_wbclient.h"
 #include "smb_procs.h"
 #include "smb_notify.h"
@@ -767,6 +768,14 @@ chimera_smb_complete_request(
     unsigned int                status)
 {
     struct chimera_smb_compound *compound = request->compound;
+
+    /* If an async-interim is pending for this request, retire it.  An interim
+     * STATUS_PENDING has already gone out (request->async_id is set), so the
+     * reply builder below will tag the final response with
+     * SMB2_FLAGS_ASYNC_COMMAND and the matching AsyncId. */
+    if (unlikely(request->async.armed)) {
+        chimera_smb_async_interim_cancel(request);
+    }
 
     request->status = status;
 

--- a/src/server/smb/smb2.h
+++ b/src/server/smb/smb2.h
@@ -852,6 +852,9 @@ typedef uint8_t smb2_guid[SMB2_GUID_SIZE];
 #define SMB2_LEASE_HANDLE_CACHING                   0x02
 #define SMB2_LEASE_WRITE_CACHING                    0x04
 
+/* LeaseFlags in the CREATE-response RqLs context (MS-SMB2 2.2.14.2.10/11) */
+#define SMB2_LEASE_FLAG_BREAK_IN_PROGRESS           0x00000002
+
 #define SMB2_CREATE_REQUEST_LEASE_SIZE              32
 #define SMB2_CREATE_REQUEST_LEASE_V2_SIZE           52
 #define SMB2_OPLOCK_BREAK_NOTIFY_LEASE_SIZE         44

--- a/src/server/smb/smb2.h
+++ b/src/server/smb/smb2.h
@@ -852,8 +852,10 @@ typedef uint8_t smb2_guid[SMB2_GUID_SIZE];
 #define SMB2_LEASE_HANDLE_CACHING                   0x02
 #define SMB2_LEASE_WRITE_CACHING                    0x04
 
-/* LeaseFlags in the CREATE-response RqLs context (MS-SMB2 2.2.14.2.10/11) */
+/* LeaseFlags in the RqLs create request/response context (MS-SMB2 2.2.13.2.8/
+ * 2.2.14.2.10/11) */
 #define SMB2_LEASE_FLAG_BREAK_IN_PROGRESS           0x00000002
+#define SMB2_LEASE_FLAG_PARENT_LEASE_KEY_SET        0x00000004
 
 #define SMB2_CREATE_REQUEST_LEASE_SIZE              32
 #define SMB2_CREATE_REQUEST_LEASE_V2_SIZE           52

--- a/src/server/smb/smb_async_interim.c
+++ b/src/server/smb/smb_async_interim.c
@@ -1,0 +1,185 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * Generic SMB2 async-interim (STATUS_PENDING) infrastructure.  See
+ * smb_async_interim.h for the policy: an interim is emitted the instant a
+ * handler decides it must block on an external event (oplock/lease break ack,
+ * blocking lock, change notify) -- never on a latency threshold.
+ *
+ * The interim carries SMB2_FLAGS_ASYNC_COMMAND and an AsyncId = the original
+ * MessageId (Samba's convention), so the client can correlate and cancel the
+ * eventual final response (which the reply builder tags with the same AsyncId
+ * because request->async_id is left set).
+ *
+ * Everything runs on the request's owning conn thread (the block decision, the
+ * eventual completion, and SMB2_CANCEL all serialise on the single-threaded
+ * evpl loop), so no locks are needed.
+ *
+ * CHANGE_NOTIFY keeps its own bespoke interim path in smb_notify.c for now; the
+ * two do not conflict (separate parked lists, CANCEL walks both).
+ */
+
+#include <string.h>
+#include <stddef.h>
+
+#include "smb_internal.h"
+#include "smb_async_interim.h"
+#include "smb_signing.h"
+#include "smb2.h"
+
+#include "evpl/evpl.h"
+
+/* Standalone SMB2 message: 4 byte NetBIOS header + 64 byte SMB2 header +
+ * 9 byte SMB2 error response body.  Same shape as
+ * chimera_smb_notify_send_interim. */
+#define CHIMERA_SMB_ASYNC_INTERIM_LEN 77
+
+static void
+chimera_smb_async_interim_unlink(
+    struct chimera_smb_conn    *conn,
+    struct chimera_smb_request *request)
+{
+    struct chimera_smb_request **pp = &conn->parked_requests;
+
+    while (*pp) {
+        if (*pp == request) {
+            *pp                      = request->async.park_next;
+            request->async.park_next = NULL;
+            return;
+        }
+        pp = &(*pp)->async.park_next;
+    }
+} /* chimera_smb_async_interim_unlink */
+
+/* Build and send a standalone STATUS_PENDING interim for `request` on its conn.
+ * Caller has populated the request->async snapshot fields and set async_id. */
+static void
+chimera_smb_async_interim_send(struct chimera_smb_request *request)
+{
+    struct chimera_smb_compound *compound = request->compound;
+    struct chimera_smb_conn     *conn     = compound->conn;
+    struct evpl                 *evpl     = conn->thread->evpl;
+    struct smb2_header          *hdr;
+    struct evpl_iovec            iov;
+    uint8_t                     *buf;
+    int                          smb2_len;
+    uint32_t                     nb;
+
+    evpl_iovec_alloc(evpl, CHIMERA_SMB_ASYNC_INTERIM_LEN, 8, 1, 0, &iov);
+    buf = iov.data;
+    memset(buf, 0, CHIMERA_SMB_ASYNC_INTERIM_LEN);
+
+    /* NetBIOS framing length filled in below. */
+    hdr                          = (struct smb2_header *) (buf + 4);
+    hdr->protocol_id[0]          = 0xFE;
+    hdr->protocol_id[1]          = 'S';
+    hdr->protocol_id[2]          = 'M';
+    hdr->protocol_id[3]          = 'B';
+    hdr->struct_size             = 64;
+    hdr->credit_charge           = request->async.credit_charge;
+    hdr->status                  = SMB2_STATUS_PENDING;
+    hdr->command                 = request->smb2_hdr.command;
+    hdr->credit_request_response = request->async.credit_request
+        ? request->async.credit_request : 1;
+    hdr->flags          = SMB2_FLAGS_SERVER_TO_REDIR | SMB2_FLAGS_ASYNC_COMMAND;
+    hdr->message_id     = request->smb2_hdr.message_id;
+    hdr->async.async_id = request->async_id;
+    hdr->session_id     = request->async.session_id;
+
+    /* Error response body: StructureSize(2)=9 + ErrorContextCount(1) +
+     * Reserved(1) + ByteCount(4) + pad(1). */
+    buf[4 + sizeof(*hdr) + 0] = 9;
+
+    smb2_len = (int) sizeof(*hdr) + 9;
+    nb       = __builtin_bswap32((uint32_t) smb2_len);
+    memcpy(buf, &nb, 4);
+
+    if (request->async.signed_session) {
+        chimera_smb_sign_message(conn->thread->signing_ctx,
+                                 request->async.dialect,
+                                 conn->negotiated.signing_alg,
+                                 request->async.signing_key,
+                                 buf + 4,
+                                 smb2_len);
+    }
+
+    iov.length = CHIMERA_SMB_ASYNC_INTERIM_LEN;
+    evpl_sendv(evpl, conn->bind, &iov, 1, iov.length, EVPL_SEND_FLAG_TAKE_REF);
+} /* chimera_smb_async_interim_send */
+
+void
+chimera_smb_async_interim_begin(struct chimera_smb_request *request)
+{
+    struct chimera_smb_compound *compound = request->compound;
+    struct chimera_smb_conn     *conn     = compound->conn;
+
+    /* Already pending (e.g. begin called twice) -- nothing to do. */
+    if (request->async.armed) {
+        return;
+    }
+
+    request->async.armed          = 1;
+    request->async.credit_charge  = request->smb2_hdr.credit_charge;
+    request->async.credit_request = request->smb2_hdr.credit_request_response;
+    request->async.dialect        = conn->dialect;
+    request->async.session_id     = request->smb2_hdr.session_id;
+
+    /* Sign the interim iff the original request was signed (same rule as the
+     * change-notify path); an unsigned async reply on a signed session is
+     * rejected by Windows clients. */
+    if ((request->smb2_hdr.flags & SMB2_FLAGS_SIGNED) &&
+        request->session_handle) {
+        request->async.signed_session = 1;
+        memcpy(request->async.signing_key,
+               request->session_handle->signing_key,
+               sizeof(request->async.signing_key));
+    } else {
+        request->async.signed_session = 0;
+    }
+
+    /* AsyncId = the original MessageId (Samba's convention; the client
+     * correlates and cancels by it). */
+    request->async_id = request->smb2_hdr.message_id;
+
+    /* Link onto the conn's parked-requests list so SMB2_CANCEL can find this
+     * request by AsyncId and conn_free can drain it on teardown. */
+    request->async.park_next = conn->parked_requests;
+    conn->parked_requests    = request;
+
+    chimera_smb_async_interim_send(request);
+} /* chimera_smb_async_interim_begin */
+
+void
+chimera_smb_async_interim_cancel(struct chimera_smb_request *request)
+{
+    struct chimera_smb_compound *compound = request->compound;
+    struct chimera_smb_conn     *conn     = compound->conn;
+
+    /* Safe whether or not a timer was ever armed: evpl_remove_timer no-ops when
+     * the timer is not in the heap. */
+    evpl_remove_timer(compound->thread->evpl, &request->async.timer);
+
+    chimera_smb_async_interim_unlink(conn, request);
+
+    request->async.armed = 0;
+
+    /* Deliberately do NOT clear request->async_id: an interim is on the wire, so
+     * the compound reply builder must set SMB2_FLAGS_ASYNC_COMMAND with this
+     * AsyncId on the final response so the client correlates the two halves. */
+} /* chimera_smb_async_interim_cancel */
+
+void
+chimera_smb_async_interim_drain(struct chimera_smb_conn *conn)
+{
+    struct chimera_server_smb_thread *thread = conn->thread;
+    struct chimera_smb_request       *request;
+
+    while ((request = conn->parked_requests) != NULL) {
+        conn->parked_requests    = request->async.park_next;
+        request->async.park_next = NULL;
+        request->async.armed     = 0;
+        evpl_remove_timer(thread->evpl, &request->async.timer);
+    }
+} /* chimera_smb_async_interim_drain */

--- a/src/server/smb/smb_async_interim.h
+++ b/src/server/smb/smb_async_interim.h
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#pragma once
+
+#include <stdint.h>
+
+struct chimera_smb_request;
+struct chimera_smb_conn;
+
+/*
+ * Generic SMB2 async-interim (STATUS_PENDING) infrastructure.
+ *
+ * An SMB2 server sends an interim response in exactly one situation: the
+ * request cannot be completed now because it must wait on an event the server
+ * cannot satisfy synchronously -- an oplock/lease break acknowledgment
+ * (MS-SMB2 3.3.5.9), a blocking byte-range lock (3.3.5.14), or a directory
+ * change notification (3.3.5.19).  The interim is sent at the moment the server
+ * decides to block: it carries STATUS_PENDING, SMB2_FLAGS_ASYNC_COMMAND, and an
+ * AsyncId (= the original MessageId, Samba's convention) so the client can
+ * correlate -- and cancel (SMB2_CANCEL) -- the eventual final response.  When
+ * the handler later completes, the reply builder sees request->async_id != 0 and
+ * tags the final response with the same AsyncId.
+ *
+ * There is deliberately NO latency-threshold trigger: an ordinary request that
+ * is merely slow is not made async (the client's request timeout is on the order
+ * of tens of seconds, so a sub-second op never needs an interim, and forcing one
+ * just adds a wasted round-trip).  Async is driven by the block decision, never
+ * by a timer.
+ *
+ * The whole machinery runs on the request's owning conn thread (dispatch, the
+ * block decision, and chimera_smb_complete_request all serialise on the
+ * single-threaded evpl loop), so no locks are needed.
+ */
+
+/* Emit an interim STATUS_PENDING response for `request` immediately and mark it
+ * pending: assigns request->async_id, links the request on its conn's
+ * parked_requests list (so SMB2_CANCEL can find it and conn_free can drain it),
+ * and leaves request->async_id set so the eventual final response carries a
+ * matching SMB2_FLAGS_ASYNC_COMMAND.  Call this the instant a handler decides it
+ * must block on an external event, before returning without completing. */
+void
+chimera_smb_async_interim_begin(
+    struct chimera_smb_request *request);
+
+/* Cancel a pending interim: remove the (possibly never-armed) timer, unlink the
+ * request from its conn's parked list, and clear the armed bit.  Idempotent.
+ * Does NOT clear request->async_id -- if an interim was sent, the final response
+ * must still echo the AsyncId.  Called from chimera_smb_complete_request. */
+void
+chimera_smb_async_interim_cancel(
+    struct chimera_smb_request *request);
+
+/* Drain all pending interim requests on a connection being torn down: unlink
+ * them and remove any armed timers.  The requests themselves are not freed --
+ * they remain owned by their compounds, which tear down through the normal
+ * path. */
+void
+chimera_smb_async_interim_drain(
+    struct chimera_smb_conn *conn);

--- a/src/server/smb/smb_durable.c
+++ b/src/server/smb/smb_durable.c
@@ -385,21 +385,27 @@ chimera_smb_durable_sweep(struct chimera_server_smb_thread *thread)
  * Cold entries (open_file == NULL) only hold bookkeeping, freed by
  * chimera_smb_durable_table_destroy.
  *
- * Only the VFS open handle is released here; the open's leases / share
- * reservation / byte-range locks are deliberately NOT drained.  Draining a
- * lease pumps any pending acquire queued behind it (e.g. a blocking lock
- * whose connection already dropped), whose completion callback would try to
- * send a reply -- allocating a reply iovec on this teardown thread for a
- * dead connection, which trips the cross-thread iovec guard.  At shutdown
- * those pending waiters have no live connection to answer, so dropping them
- * is correct; the leftover lease objects are reclaimed wholesale when
- * chimera_vfs_state_destroy frees the per-file state (it never walks the
- * lease lists), and no operation runs after thread destroy to observe a
- * dangling lease. */
+ * The open's share reservation / byte-range locks are deliberately NOT drained
+ * via chimera_smb_open_file_drain_locks: that releases the lease with a pump,
+ * and pumping a pending acquire queued behind it (e.g. a blocking lock whose
+ * connection already dropped) runs a completion callback that allocates a reply
+ * iovec on this teardown thread for a dead connection, tripping the cross-thread
+ * iovec guard.  At shutdown those waiters have no live connection to answer, so
+ * dropping them is correct.  The embedded share/range leases are reclaimed
+ * wholesale when chimera_vfs_state_destroy frees the per-file state (it never
+ * walks the lease lists).
+ *
+ * The caching grant (oplock / SMB2 lease), however, is a standalone heap object
+ * the SMB layer owns -- vfs_state_destroy frees the per-file state but never the
+ * grant -- so a parked handle's grant must be released here explicitly or it
+ * leaks.  Release it with pump=false to free the grant memory (and unlink its
+ * lease) without waking a waiter on a dead connection. */
 SYMBOL_EXPORT void
 chimera_smb_durable_drain_all(struct chimera_server_smb_thread *thread)
 {
-    struct chimera_server_smb_shared *shared = thread->shared;
+    struct chimera_server_smb_shared *shared    = thread->shared;
+    struct chimera_vfs_state         *vfs_state =
+        thread->vfs_thread->vfs->vfs_state;
     struct chimera_smb_durable_entry *entry, *tmp;
     struct chimera_smb_durable_entry *reap = NULL;
 
@@ -425,6 +431,19 @@ chimera_smb_durable_drain_all(struct chimera_server_smb_thread *thread)
         if (open_file->handle) {
             chimera_vfs_release(thread->vfs_thread, open_file->handle);
             open_file->handle = NULL;
+        }
+        /* Release the standalone caching grant (vfs_state_destroy won't); no
+         * pump -- there is no live connection left to answer a woken waiter. */
+        if (open_file->grant) {
+            chimera_smb_grant_remove_member(open_file->grant, open_file);
+            chimera_vfs_caching_grant_release(vfs_state, open_file->grant,
+                                              false /*pump*/);
+            open_file->grant                  = NULL;
+            open_file->caching_lease_inserted = false;
+        }
+        if (open_file->caching_file_state) {
+            chimera_vfs_state_put(vfs_state, open_file->caching_file_state);
+            open_file->caching_file_state = NULL;
         }
         chimera_smb_open_file_free(thread, open_file);
 

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -487,6 +487,15 @@ struct chimera_smb_request {
             uint8_t                            r_is_directory;
             uint32_t                           r_granted_access;
             uint32_t                           r_maximal_access;
+            /* Deferred-response park (MS-SMB2 3.3.5.9 pending-open): when this open
+             * triggered an ack-required lease break, its SUCCESS response is held
+             * until the holder acknowledges.  park_next links it on the tree's
+             * parked_creates list; park_fh identifies the file whose break it
+             * awaits (resumed when that file's caching leases settle). */
+            struct chimera_smb_request        *park_next;
+            uint8_t                            park_fh[CHIMERA_VFS_FH_SIZE];
+            uint8_t                            park_fh_len;
+            uint64_t                           park_fh_hash;
         } create;
 
         struct  {
@@ -1626,7 +1635,9 @@ chimera_smb_tree_alloc(struct chimera_server_smb_shared *shared)
         for (int i = 0; i < CHIMERA_SMB_OPEN_FILE_BUCKETS; i++) {
             pthread_mutex_init(&tree->open_files_lock[i], NULL);
         }
+        pthread_mutex_init(&tree->parked_lock, NULL);
     }
+    tree->parked_creates = NULL;
 
     tree->fh_expiration.tv_sec  = 0;
     tree->fh_expiration.tv_nsec = 0;

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -301,6 +301,24 @@ struct chimera_smb_request {
     struct chimera_smb_compound       *compound;
     struct chimera_smb_request        *next;
 
+    /* Generic async-interim (STATUS_PENDING) state, managed by
+     * smb_async_interim.c.  Populated when a handler decides it must block on an
+     * external event and calls chimera_smb_async_interim_begin; cleared by
+     * chimera_smb_complete_request / _cancel.  armed == 0 outside a pending
+     * window.  The timer field is reserved for a future block deadline driver
+     * (begin does not arm it today; cancel/drain remove it as a safe no-op). */
+    struct {
+        struct evpl_timer           timer;
+        struct chimera_smb_request *park_next;
+        uint8_t                     signing_key[16];
+        uint64_t                    session_id;
+        uint16_t                    dialect;
+        uint16_t                    credit_charge;
+        uint16_t                    credit_request;
+        uint8_t                     signed_session;
+        uint8_t                     armed;
+    } async;
+
     union {
 
         struct {
@@ -489,10 +507,10 @@ struct chimera_smb_request {
             uint32_t                           r_maximal_access;
             /* Deferred-response park (MS-SMB2 3.3.5.9 pending-open): when this open
              * triggered an ack-required lease break, its SUCCESS response is held
-             * until the holder acknowledges.  park_next links it on the tree's
-             * parked_creates list; park_fh identifies the file whose break it
-             * awaits (resumed when that file's caching leases settle). */
-            struct chimera_smb_request        *park_next;
+             * (via the async-interim path; the request links on conn->parked_
+             * requests) until the holder acknowledges.  park_fh identifies the file
+             * whose break it awaits (resumed when that file's caching leases
+             * settle -- chimera_smb_create_resume_parked). */
             uint8_t                            park_fh[CHIMERA_VFS_FH_SIZE];
             uint8_t                            park_fh_len;
             uint64_t                           park_fh_hash;
@@ -872,6 +890,11 @@ struct chimera_smb_conn {
     struct chimera_smb_tree           *last_tree;
     struct chimera_smb_session_handle *session_handles;
     struct chimera_smb_notify_request *parked_notifies;  /* parked CHANGE_NOTIFY requests */
+    /* Requests pending an async-interim (STATUS_PENDING already sent): a create
+     * blocked on a lease break, a blocking lock, etc. (smb_async_interim.c).
+     * SMB2_CANCEL walks this list by AsyncId; conn_free drains it before tearing
+     * down the bind. */
+    struct chimera_smb_request        *parked_requests;
     struct chimera_server_smb_thread  *thread;
     struct evpl_bind                  *bind;
     struct chimera_smb_conn           *prev;
@@ -1192,10 +1215,12 @@ chimera_smb_request_alloc(struct chimera_server_smb_thread *thread)
         request = calloc(1, sizeof(*request));
     }
 
-    request->status   = SMB2_STATUS_SUCCESS;
-    request->flags    = 0;
-    request->async_id = 0;
-    request->tree     = NULL;
+    request->status          = SMB2_STATUS_SUCCESS;
+    request->flags           = 0;
+    request->async_id        = 0;
+    request->tree            = NULL;
+    request->async.armed     = 0;
+    request->async.park_next = NULL;
 
     return request;
 } /* chimera_smb_request_alloc */
@@ -1494,6 +1519,12 @@ void chimera_smb_notify_cancel(
 void chimera_smb_notify_drop(
     struct chimera_smb_notify_request *nr);
 
+/* Defined in smb_async_interim.c -- forward-declared so the inline conn_free
+ * below can drain without including the header (which would create a cycle
+ * through smb_internal.h). */
+void chimera_smb_async_interim_drain(
+    struct chimera_smb_conn *conn);
+
 static inline void
 chimera_smb_conn_free(
     struct chimera_server_smb_thread *thread,
@@ -1508,6 +1539,13 @@ chimera_smb_conn_free(
     while (conn->parked_notifies) {
         chimera_smb_notify_drop(conn->parked_notifies);
     }
+
+    /* Unlink any requests pending an async-interim (their interim is already on
+     * the wire).  They are not freed here -- they remain owned by their
+     * compounds, which tear down through the normal path; a late VFS callback
+     * reaching chimera_smb_complete_request sees async.armed == 0 and skips the
+     * cancel. */
+    chimera_smb_async_interim_drain(conn);
 
     /* Drain any lease-break notifications still queued for this connection and
      * mark it tearing-down so a break_cb racing on another thread won't enqueue
@@ -1635,9 +1673,7 @@ chimera_smb_tree_alloc(struct chimera_server_smb_shared *shared)
         for (int i = 0; i < CHIMERA_SMB_OPEN_FILE_BUCKETS; i++) {
             pthread_mutex_init(&tree->open_files_lock[i], NULL);
         }
-        pthread_mutex_init(&tree->parked_lock, NULL);
     }
-    tree->parked_creates = NULL;
 
     tree->fh_expiration.tv_sec  = 0;
     tree->fh_expiration.tv_nsec = 0;

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -68,6 +68,70 @@
                          __LINE__, \
                          __VA_ARGS__)
 
+/*
+ * Canonical mapping between the SMB caching-grant encodings and vfs_state's RWH
+ * lease mode -- one source of truth shared by the create grant path and the
+ * oplock/lease break-notification builder, which previously re-derived these
+ * inline (and could drift).  The SMB2 lease bit layout (R=0x01, H=0x02, W=0x04)
+ * differs from vfs_state's CHIMERA_VFS_LEASE_MODE_{R,W,H}, so map field by field.
+ */
+static inline uint8_t
+chimera_smb_vfs_to_lease_bits(uint8_t vfs_mode)
+{
+    uint8_t s = 0;
+
+    if (vfs_mode & CHIMERA_VFS_LEASE_MODE_R) {
+        s |= SMB2_LEASE_READ_CACHING;
+    }
+    if (vfs_mode & CHIMERA_VFS_LEASE_MODE_H) {
+        s |= SMB2_LEASE_HANDLE_CACHING;
+    }
+    if (vfs_mode & CHIMERA_VFS_LEASE_MODE_W) {
+        s |= SMB2_LEASE_WRITE_CACHING;
+    }
+    return s;
+} /* chimera_smb_vfs_to_lease_bits */
+
+static inline uint8_t
+chimera_smb_lease_bits_to_vfs(uint8_t smb_bits)
+{
+    uint8_t v = 0;
+
+    if (smb_bits & SMB2_LEASE_READ_CACHING) {
+        v |= CHIMERA_VFS_LEASE_MODE_R;
+    }
+    if (smb_bits & SMB2_LEASE_HANDLE_CACHING) {
+        v |= CHIMERA_VFS_LEASE_MODE_H;
+    }
+    if (smb_bits & SMB2_LEASE_WRITE_CACHING) {
+        v |= CHIMERA_VFS_LEASE_MODE_W;
+    }
+    return v;
+} /* chimera_smb_lease_bits_to_vfs */
+
+/* Collapse a granted RWH mask to the closest legacy oplock level (used when an
+ * open did not request an RqLs lease).  Legacy oplocks have no separate W/H, so
+ * RWH -> BATCH, RW (no H) -> EXCLUSIVE, R-only -> LEVEL_II, none -> NONE. */
+static inline uint8_t
+chimera_smb_vfs_to_oplock_level(uint8_t vfs_mode)
+{
+    uint8_t rwh = vfs_mode & (CHIMERA_VFS_LEASE_MODE_R |
+                              CHIMERA_VFS_LEASE_MODE_W |
+                              CHIMERA_VFS_LEASE_MODE_H);
+
+    if (rwh == (CHIMERA_VFS_LEASE_MODE_R | CHIMERA_VFS_LEASE_MODE_W |
+                CHIMERA_VFS_LEASE_MODE_H)) {
+        return SMB2_OPLOCK_LEVEL_BATCH;
+    }
+    if (vfs_mode & CHIMERA_VFS_LEASE_MODE_W) {
+        return SMB2_OPLOCK_LEVEL_EXCLUSIVE;
+    }
+    if (vfs_mode & CHIMERA_VFS_LEASE_MODE_R) {
+        return SMB2_OPLOCK_LEVEL_II;
+    }
+    return SMB2_OPLOCK_LEVEL_NONE;
+} /* chimera_smb_vfs_to_oplock_level */
+
 /* Little-endian decoders for SMB2 wire fields. Used by the negotiate-context
  * and CREATE-context parsers; defined here so all SMB protocol code shares one
  * implementation. The SMB2 wire format is little-endian throughout. */

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -1911,6 +1911,55 @@ chimera_smb_open_file_resolve_by_lease_key(
 } /* chimera_smb_open_file_resolve_by_lease_key */
 
 /*
+ * A lease key is bound to exactly one file per client (MS-SMB2 3.3.5.9.8): a
+ * client may not use the same lease key on two different files.  Returns true if
+ * any live open in the session already holds this lease key on a DIFFERENT file
+ * than (fh, fh_len) -- in which case the create must be rejected with
+ * STATUS_INVALID_PARAMETER.  A re-open of the SAME file under the key (coalesce)
+ * is not a conflict.  Scans the session's trees' open_files (lease creates are
+ * rare relative to I/O, so the linear scan is acceptable).
+ */
+static inline bool
+chimera_smb_session_lease_key_conflict(
+    struct chimera_smb_session *session,
+    const uint8_t              *key,
+    const uint8_t              *fh,
+    uint32_t                    fh_len)
+{
+    bool conflict = false;
+    int  t;
+
+    pthread_mutex_lock(&session->lock);
+    for (t = 0; t < session->max_trees && !conflict; t++) {
+        struct chimera_smb_tree      *tree = session->trees[t];
+        struct chimera_smb_open_file *of, *tmp;
+        int                           b;
+
+        if (!tree) {
+            continue;
+        }
+        for (b = 0; b < CHIMERA_SMB_OPEN_FILE_BUCKETS && !conflict; b++) {
+            pthread_mutex_lock(&tree->open_files_lock[b]);
+            HASH_ITER(hh, tree->open_files[b], of, tmp)
+            {
+                if (!(of->flags & CHIMERA_SMB_OPEN_FILE_CLOSED) &&
+                    of->oplock_level == SMB2_OPLOCK_LEVEL_LEASE &&
+                    of->handle &&
+                    memcmp(of->lease_key, key, 16) == 0 &&
+                    (of->handle->fh_len != fh_len ||
+                     memcmp(of->handle->fh, fh, fh_len) != 0)) {
+                    conflict = true;
+                    break;
+                }
+            }
+            pthread_mutex_unlock(&tree->open_files_lock[b]);
+        }
+    }
+    pthread_mutex_unlock(&session->lock);
+    return conflict;
+} /* chimera_smb_session_lease_key_conflict */
+
+/*
  * Caching-grant membership.  A VFS-owned caching grant (chimera_vfs_caching_grant)
  * may be shared by several opens under one (client, lease key); each such open is
  * threaded onto grant->holders so a break callback running on an arbitrary thread

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -369,43 +369,60 @@ struct chimera_smb_request {
                 uint16_t epoch;
                 int      is_v2;
             } rqls;
-            uint64_t                        alsi_alloc_size;
-            uint64_t                        twrp_timestamp;
+            uint64_t                           alsi_alloc_size;
+            uint64_t                           twrp_timestamp;
             /* SMB2_CREATE_APP_INSTANCE_ID / *_VERSION (MS-SMB2 2.2.13.2.13/14).
              * app_instance_id is the 16-byte GUID value; the AppInstanceVersion
              * (VersionHigh/Low) is present only when the version context was
              * also supplied (app_version_present). */
-            uint8_t                         app_instance_id[16];
-            uint64_t                        app_version_high;
-            uint64_t                        app_version_low;
-            uint8_t                         app_version_present;
+            uint8_t                            app_instance_id[16];
+            uint64_t                           app_version_high;
+            uint64_t                           app_version_low;
+            uint8_t                            app_version_present;
             /* Status to return when gen_open_file refuses an open due to a
              * share conflict: defaults to SHARING_VIOLATION, but an
              * app-instance version reject overrides it with FILE_FORCED_CLOSED. */
-            uint32_t                        force_close_status;
+            uint32_t                           force_close_status;
             /* Backing storage for a canonical ACL decoded from a SecD create
              * context (SMB2_CREATE_SD_BUFFER); set_attr.va_acl points here. */
-            uint8_t                         acl_storage[sizeof(struct chimera_acl) +
-                                                        64 * sizeof(struct chimera_ace)];
+            uint8_t                            acl_storage[sizeof(struct chimera_acl) +
+                                                           64 * sizeof(struct chimera_ace)];
             /* SMB3 persistent-handle write-through.  persist_pid != 0 marks this
              * open as a persistent grant (fresh or cold reclaim): the record is
              * persisted atomically with the VFS open via persist_hs, and
              * gen_open_file adopts persist_pid as the file's persistent id. */
-            uint64_t                        persist_pid;
-            struct chimera_vfs_handle_state persist_hs;
-            uint8_t                         persist_key[CHIMERA_SMB_DURABLE_KEY_LEN];
-            uint8_t                         persist_value[CHIMERA_SMB_DURABLE_VALUE_MAX];
-            char                            parent_path[SMB_FILENAME_MAX];
-            char                           *name;
+            uint64_t                           persist_pid;
+            struct chimera_vfs_handle_state    persist_hs;
+            uint8_t                            persist_key[CHIMERA_SMB_DURABLE_KEY_LEN];
+            uint8_t                            persist_value[CHIMERA_SMB_DURABLE_VALUE_MAX];
+            char                               parent_path[SMB_FILENAME_MAX];
+            char                              *name;
             /* Named-stream (ADS) suffix parsed off the final path component.
              * has_stream is set when the create targets "file:stream[:$DATA]";
              * stream_name holds the bare stream name and `name`/name_len are
              * trimmed to the base file.  base_oh is the base file's open handle
              * held across the chained chimera_vfs_open_stream. */
-            uint8_t                         has_stream;
-            uint16_t                        stream_name_len;
-            char                            stream_name[SMB_FILENAME_MAX];
-            struct chimera_vfs_open_handle *base_oh;
+            uint8_t                            has_stream;
+            uint16_t                           stream_name_len;
+            char                               stream_name[SMB_FILENAME_MAX];
+            struct chimera_vfs_open_handle    *base_oh;
+            /* Async share-acquire park (Phase 2 oplock).  A regular-file open
+             * whose share reservation hard-conflicts with a batch-oplock holder
+             * parks here until the holder closes (then granted) or merely acks
+             * (then SHARING_VIOLATION).  gen_finish_cb resumes the open's tail on
+             * a synchronous OR parked grant; the gen_* fields carry the parked
+             * open's state across the wait. */
+            void                               (*gen_finish_cb)(
+                struct chimera_smb_request   *request,
+                struct chimera_smb_open_file *open_file);
+            struct chimera_smb_open_file      *gen_parked_open;
+            struct chimera_vfs_file_state     *gen_parked_fs;
+            struct chimera_vfs_pending_acquire gen_ticket;
+            uint8_t                            gen_held_granted;
+            uint8_t                            gen_parked;
+            uint8_t                            r_is_directory;
+            uint32_t                           r_granted_access;
+            uint32_t                           r_maximal_access;
         } create;
 
         struct  {

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -1862,6 +1862,43 @@ chimera_smb_open_file_resolve_by_lease_key(
     return found;
 } /* chimera_smb_open_file_resolve_by_lease_key */
 
+/*
+ * Caching-grant membership.  A VFS-owned caching grant (chimera_vfs_caching_grant)
+ * may be shared by several opens under one (client, lease key); each such open is
+ * threaded onto grant->holders so a break callback running on an arbitrary thread
+ * can pick a still-connected member to deliver the OPLOCK_BREAK on (and revoke the
+ * lease when no member is live).  The list is guarded by the grant's file->lock.
+ */
+static inline void
+chimera_smb_grant_add_member(
+    struct chimera_vfs_caching_grant *grant,
+    struct chimera_smb_open_file     *open_file)
+{
+    pthread_mutex_lock(&grant->file->lock);
+    open_file->grant_member_next = grant->holders;
+    grant->holders               = open_file;
+    pthread_mutex_unlock(&grant->file->lock);
+} /* chimera_smb_grant_add_member */
+
+static inline void
+chimera_smb_grant_remove_member(
+    struct chimera_vfs_caching_grant *grant,
+    struct chimera_smb_open_file     *open_file)
+{
+    struct chimera_smb_open_file **pp;
+
+    pthread_mutex_lock(&grant->file->lock);
+    for (pp = (struct chimera_smb_open_file **) &grant->holders; *pp;
+         pp = &(*pp)->grant_member_next) {
+        if (*pp == open_file) {
+            *pp = open_file->grant_member_next;
+            break;
+        }
+    }
+    open_file->grant_member_next = NULL;
+    pthread_mutex_unlock(&grant->file->lock);
+} /* chimera_smb_grant_remove_member */
+
 static inline void
 chimera_smb_open_file_release(
     struct chimera_smb_request   *request,

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -1822,6 +1822,46 @@ chimera_smb_open_file_resolve(
     return open_file;
 } /* chimera_smb_open_file_resolve */
 
+/*
+ * Resolve the open_file that owns the caching lease registered under `lease_key`
+ * (an SMB2 RqLs lease).  Unlike file_id, lease keys are not hashed, so this scans
+ * the tree's open_files buckets -- a lease-break ack is rare relative to I/O, so
+ * the linear scan is acceptable; a dedicated lease-key index is a later
+ * optimization.  Multiple opens may share one lease key (coalesced), but only the
+ * one that inserted the lease carries caching_lease_inserted, so match on that.
+ * On success the returned open_file has had its refcnt bumped (release with
+ * chimera_smb_open_file_release).
+ */
+static inline struct chimera_smb_open_file *
+chimera_smb_open_file_resolve_by_lease_key(
+    struct chimera_smb_request *request,
+    const uint8_t              *lease_key)
+{
+    struct chimera_smb_open_file *open_file, *tmp, *found = NULL;
+    struct chimera_smb_tree      *tree = request->tree;
+    int                           b;
+
+    chimera_smb_abort_if(!tree, "tree is NULL");
+
+    for (b = 0; b < CHIMERA_SMB_OPEN_FILE_BUCKETS && !found; b++) {
+        pthread_mutex_lock(&tree->open_files_lock[b]);
+        HASH_ITER(hh, tree->open_files[b], open_file, tmp)
+        {
+            if (!(open_file->flags & CHIMERA_SMB_OPEN_FILE_CLOSED) &&
+                open_file->caching_lease_inserted &&
+                open_file->oplock_level == SMB2_OPLOCK_LEVEL_LEASE &&
+                memcmp(open_file->lease_key, lease_key, 16) == 0) {
+                open_file->refcnt++;
+                found = open_file;
+                break;
+            }
+        }
+        pthread_mutex_unlock(&tree->open_files_lock[b]);
+    }
+
+    return found;
+} /* chimera_smb_open_file_resolve_by_lease_key */
+
 static inline void
 chimera_smb_open_file_release(
     struct chimera_smb_request   *request,

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -1063,6 +1063,7 @@ struct chimera_smb_lease_break_msg {
     uint8_t                             lease_key[16];
     uint8_t                             current_state;
     uint8_t                             new_state;
+    bool                                ack_required;
     uint16_t                            new_epoch;
     uint64_t                            file_id_pid;
     uint64_t                            file_id_vid;

--- a/src/server/smb/smb_proc_cancel.c
+++ b/src/server/smb/smb_proc_cancel.c
@@ -75,6 +75,19 @@ chimera_smb_cancel(struct chimera_smb_request *request)
 
     if (match) {
         chimera_smb_notify_cancel(match);
+    } else if (async) {
+        /* Search requests pending an async-interim (e.g. a CREATE blocked on a
+         * lease break).  The underlying wait is not yet cancellable from
+         * SMB2_CANCEL -- absorb it silently; the request still completes when its
+         * break acks.  A future phase can abort the parked open here. */
+        struct chimera_smb_request *parked;
+
+        for (parked = conn->parked_requests; parked;
+             parked = parked->async.park_next) {
+            if (parked->async_id == target_id) {
+                break;
+            }
+        }
     }
 
     /* CANCEL has no response per MS-SMB2.  Use STATUS_PENDING so the

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -235,6 +235,84 @@ chimera_smb_create_share_park_cb(
     struct chimera_vfs_lease     *conflict,
     void                         *private_data);
 
+/*
+ * Single break-decision point for a conflicting open (MS-FSA open-vs-oplock
+ * ordering), factored out of the two create-path call sites that previously
+ * duplicated the trigger/owner computation verbatim.
+ *
+ *   phase 1 (pre-share-check, trigger H): a batch / handle-caching holder breaks
+ *     BEFORE the share-mode decision, because it may close its deferred handle
+ *     and dissolve the conflict -- so the break fires even when the open is
+ *     ultimately refused with SHARING_VIOLATION (smb2.oplock.batch5).  It retains
+ *     R unless the open truncates.
+ *   phase 2 (post-share-check, trigger W): once the open is granted, a
+ *     conflicting exclusive (W-only) holder breaks to LEVEL_II; a truncating open
+ *     replaces the data and instead invalidates every cached holder to NONE
+ *     (break_on_write).
+ *
+ * The opener is identified by its lease key when it carries an RqLs context (all
+ * of one client's opens of a file share that key, so a re-open by the lease
+ * holder coalesces instead of self-breaking), else by file_id.  It is a no-op on
+ * a pure stat-open (no data/delete/truncate access) and when the only holder is
+ * the opener's own.
+ */
+static inline void
+chimera_smb_create_break_for_open(
+    struct chimera_server_smb_thread *thread,
+    struct chimera_smb_request       *request,
+    struct chimera_smb_open_file     *open_file,
+    struct chimera_vfs_open_handle   *oh,
+    int                               phase)
+{
+    uint32_t                       da        = open_file->desired_access;
+    uint32_t                       disp      = request->create.create_disposition;
+    bool                           truncates =
+        disp == SMB2_FILE_OVERWRITE ||
+        disp == SMB2_FILE_OVERWRITE_IF ||
+        disp == SMB2_FILE_SUPERSEDE;
+    bool                           break_trigger =
+        (da & (SMB2_FILE_READ_DATA | SMB2_FILE_WRITE_DATA |
+               SMB2_FILE_APPEND_DATA | SMB2_FILE_EXECUTE |
+               SMB2_GENERIC_READ | SMB2_GENERIC_WRITE |
+               SMB2_GENERIC_EXECUTE | SMB2_GENERIC_ALL |
+               SMB2_MAXIMUM_ALLOWED | SMB2_DELETE)) ||
+        (request->create.create_options & SMB2_FILE_DELETE_ON_CLOSE) ||
+        truncates;
+    struct chimera_vfs_state      *vfs_state = thread->vfs_thread->vfs->vfs_state;
+    struct chimera_vfs_lease_owner io_owner  = {
+        .protocol   = CHIMERA_VFS_LEASE_PROTO_SMB2,
+        .client_key = request->session_handle->session->session_id,
+        .owner_lo   = open_file->file_id.pid,
+        .owner_hi   = open_file->file_id.vid,
+    };
+
+    if (!break_trigger) {
+        return;
+    }
+
+    /* An RqLs open is owned by its lease key, not its file_id; identify the
+     * opener by the key so break_caching_for_open coalesces a lease this client
+     * already holds under the same key instead of recalling it. */
+    if (request->create.ctx_present_mask & CHIMERA_SMB_CREATE_CTX_RQLS) {
+        memcpy(&io_owner.owner_lo, request->create.rqls.key, 8);
+        memcpy(&io_owner.owner_hi, request->create.rqls.key + 8, 8);
+    }
+
+    if (phase == 1) {
+        chimera_vfs_state_break_caching_for_open(
+            vfs_state, oh->fh, oh->fh_len, oh->fh_hash, &io_owner,
+            CHIMERA_VFS_LEASE_MODE_H,
+            truncates ? 0 : CHIMERA_VFS_LEASE_MODE_R);
+    } else if (truncates) {
+        chimera_vfs_state_break_on_write(vfs_state, oh->fh, oh->fh_len,
+                                         oh->fh_hash, &io_owner);
+    } else {
+        chimera_vfs_state_break_caching_for_open(
+            vfs_state, oh->fh, oh->fh_len, oh->fh_hash, &io_owner,
+            CHIMERA_VFS_LEASE_MODE_W, CHIMERA_VFS_LEASE_MODE_R);
+    }
+} /* chimera_smb_create_break_for_open */
+
 static inline struct chimera_smb_open_file *
 chimera_smb_create_gen_open_file(
     struct chimera_smb_request     *request,
@@ -332,46 +410,7 @@ chimera_smb_create_gen_open_file(
      * otherwise it drops to LEVEL_II.  Pure attribute/EA opens break nothing
      * (stat-open).  No-op on the first open; skips the opener's own lease. */
     if (type == CHIMERA_SMB_OPEN_FILE_TYPE_FILE && tree->share && oh) {
-        uint32_t da        = open_file->desired_access;
-        uint32_t disp      = request->create.create_disposition;
-        bool     truncates =
-            disp == SMB2_FILE_OVERWRITE ||
-            disp == SMB2_FILE_OVERWRITE_IF ||
-            disp == SMB2_FILE_SUPERSEDE;
-        bool     break_trigger =
-            (da & (SMB2_FILE_READ_DATA | SMB2_FILE_WRITE_DATA |
-                   SMB2_FILE_APPEND_DATA | SMB2_FILE_EXECUTE |
-                   SMB2_GENERIC_READ | SMB2_GENERIC_WRITE |
-                   SMB2_GENERIC_EXECUTE | SMB2_GENERIC_ALL |
-                   SMB2_MAXIMUM_ALLOWED | SMB2_DELETE)) ||
-            (request->create.create_options & SMB2_FILE_DELETE_ON_CLOSE) ||
-            truncates;
-
-        if (break_trigger) {
-            struct chimera_vfs_state      *vfs_state = thread->vfs_thread->vfs->vfs_state;
-            struct chimera_vfs_lease_owner io_owner  = {
-                .protocol   = CHIMERA_VFS_LEASE_PROTO_SMB2,
-                .client_key = request->session_handle->session->session_id,
-                .owner_lo   = open_file->file_id.pid,
-                .owner_hi   = open_file->file_id.vid,
-            };
-
-            /* An RqLs open is owned by its lease key, not its file_id, and all of
-             * one client's opens of a file share that key.  Identify this opener
-             * by the lease key so break_caching_for_open recognises an existing
-             * lease held under the same key as the opener's own and coalesces
-             * (no self-break) -- a re-open by the lease holder must not recall
-             * its own lease (the dominant single-client churn source). */
-            if (request->create.ctx_present_mask & CHIMERA_SMB_CREATE_CTX_RQLS) {
-                memcpy(&io_owner.owner_lo, request->create.rqls.key, 8);
-                memcpy(&io_owner.owner_hi, request->create.rqls.key + 8, 8);
-            }
-
-            chimera_vfs_state_break_caching_for_open(vfs_state, oh->fh, oh->fh_len,
-                                                     oh->fh_hash, &io_owner,
-                                                     CHIMERA_VFS_LEASE_MODE_H,
-                                                     truncates ? 0 : CHIMERA_VFS_LEASE_MODE_R);
-        }
+        chimera_smb_create_break_for_open(thread, request, open_file, oh, 1);
     }
 
     /* Check share mode conflicts for regular file opens.
@@ -647,48 +686,7 @@ chimera_smb_create_after_share(
          * whether or not this open requests an oplock of its own (so it covers
          * a plain reader / writer that takes no lease), and is a no-op when
          * there is no conflicting holder or only the opener's own. */
-        {
-            uint32_t da        = open_file->desired_access;
-            uint32_t disp      = request->create.create_disposition;
-            bool     truncates =
-                disp == SMB2_FILE_OVERWRITE ||
-                disp == SMB2_FILE_OVERWRITE_IF ||
-                disp == SMB2_FILE_SUPERSEDE;
-            bool     break_trigger =
-                (da & (SMB2_FILE_READ_DATA | SMB2_FILE_WRITE_DATA |
-                       SMB2_FILE_APPEND_DATA | SMB2_FILE_EXECUTE |
-                       SMB2_GENERIC_READ | SMB2_GENERIC_WRITE |
-                       SMB2_GENERIC_EXECUTE | SMB2_GENERIC_ALL |
-                       SMB2_MAXIMUM_ALLOWED | SMB2_DELETE)) ||
-                (request->create.create_options & SMB2_FILE_DELETE_ON_CLOSE) ||
-                truncates;
-
-            if (break_trigger) {
-                struct chimera_vfs_lease_owner io_owner = {
-                    .protocol   = CHIMERA_VFS_LEASE_PROTO_SMB2,
-                    .client_key = request->session_handle->session->session_id,
-                    .owner_lo   = open_file->file_id.pid,
-                    .owner_hi   = open_file->file_id.vid,
-                };
-
-                /* Identify an RqLs opener by its lease key so it coalesces with
-                 * (does not break) a lease this client already holds under the
-                 * same key (see the phase-1 break above). */
-                if (request->create.ctx_present_mask & CHIMERA_SMB_CREATE_CTX_RQLS) {
-                    memcpy(&io_owner.owner_lo, request->create.rqls.key, 8);
-                    memcpy(&io_owner.owner_hi, request->create.rqls.key + 8, 8);
-                }
-
-                if (truncates) {
-                    chimera_vfs_state_break_on_write(vfs_state, oh->fh, oh->fh_len,
-                                                     oh->fh_hash, &io_owner);
-                } else {
-                    chimera_vfs_state_break_caching_for_open(
-                        vfs_state, oh->fh, oh->fh_len, oh->fh_hash, &io_owner,
-                        CHIMERA_VFS_LEASE_MODE_W, CHIMERA_VFS_LEASE_MODE_R);
-                }
-            }
-        }
+        chimera_smb_create_break_for_open(thread, request, open_file, oh, 2);
 
         if (request->create.ctx_present_mask & CHIMERA_SMB_CREATE_CTX_RQLS) {
             via_rqls = true;

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -534,6 +534,10 @@ chimera_smb_create_gen_open_file(
         bool                           via_rqls = false;
         struct chimera_vfs_lease      *conflict = NULL;
         enum chimera_vfs_lease_result  result;
+        bool                           durable_request =
+            thread->shared->config.persistent_handles &&
+            (request->create.ctx_present_mask &
+             (CHIMERA_SMB_CREATE_CTX_DHNQ | CHIMERA_SMB_CREATE_CTX_DH2Q)) != 0;
 
         /* Phase 2 of the conflicting-open oplock break.  Phase 1 (the batch /
          * handle-caching break that must precede the share-mode check) already

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -3261,7 +3261,15 @@ parse_ctx_rqls(
     request->create.rqls.flags = smb_wire_le32(data + 20);
     if (data_len == 52) {
         request->create.rqls.is_v2 = 1;
-        memcpy(request->create.rqls.parent_key, data + 32, 16);
+        /* The ParentLeaseKey is meaningful only when the client set
+         * SMB2_LEASE_FLAG_PARENT_LEASE_KEY_SET; otherwise the bytes are reserved
+         * and must be ignored (and echoed back as zero -- smb2.lease.
+         * v2_flags_parentkey). */
+        if (request->create.rqls.flags & SMB2_LEASE_FLAG_PARENT_LEASE_KEY_SET) {
+            memcpy(request->create.rqls.parent_key, data + 32, 16);
+        } else {
+            memset(request->create.rqls.parent_key, 0, 16);
+        }
         request->create.rqls.epoch = smb_wire_le16(data + 48);
     } else {
         request->create.rqls.is_v2 = 0;

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -8,6 +8,7 @@
 #include "server/smb/smb_session.h"
 #include "smb_internal.h"
 #include "smb_procs.h"
+#include "smb_async_interim.h"
 #include "smb_string.h"
 #include "common/misc.h"
 #include "vfs/vfs.h"
@@ -1592,10 +1593,12 @@ chimera_smb_create_open_finish(
 
     /* MS-SMB2 3.3.5.9 pending-open: if this open triggered an ack-required lease
      * break on another holder, hold the SUCCESS response until the holder
-     * acknowledges (the break is mid-flight).  Park the request on the tree's
-     * parked_creates list keyed by the file; an inbound OPLOCK_BREAK ack that
-     * settles the file's caching leases resumes it (chimera_smb_create_resume_
-     * parked).  The open_file ref is held across the wait and dropped on resume. */
+     * acknowledges (the break is mid-flight).  Emit an async-interim
+     * STATUS_PENDING now (so the client knows the create is in flight, can cancel
+     * it, and does not time out across the up-to-break-timeout wait); the request
+     * lands on conn->parked_requests, and an inbound OPLOCK_BREAK ack that settles
+     * the file's caching leases resumes it (chimera_smb_create_resume_parked).
+     * The open_file ref is held across the wait and dropped on resume. */
     if (open_file->handle) {
         struct chimera_server_smb_thread *thread    = request->compound->thread;
         struct chimera_vfs_state         *vfs_state =
@@ -1604,16 +1607,10 @@ chimera_smb_create_open_finish(
 
         if (chimera_vfs_state_caching_breaking(vfs_state, oh->fh, oh->fh_len,
                                                oh->fh_hash, open_file->grant)) {
-            struct chimera_smb_tree *tree = request->tree;
-
             memcpy(request->create.park_fh, oh->fh, oh->fh_len);
             request->create.park_fh_len  = oh->fh_len;
             request->create.park_fh_hash = oh->fh_hash;
-
-            pthread_mutex_lock(&tree->parked_lock);
-            request->create.park_next = tree->parked_creates;
-            tree->parked_creates      = request;
-            pthread_mutex_unlock(&tree->parked_lock);
+            chimera_smb_async_interim_begin(request);
             return;
         }
     }
@@ -1622,28 +1619,31 @@ chimera_smb_create_open_finish(
     chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
 } /* chimera_smb_create_open_finish */
 
-/* Resume any CREATE parked on `ack_request`'s tree whose triggered lease break
- * has now settled (no caching lease on the file is mid-break).  Called from the
- * inbound OPLOCK_BREAK ack handler after the lease is acked.  Only resumes parks
- * owned by the current thread (the deferred response's iovecs are thread-local);
- * a park awaiting an ack that arrives on a different channel is left for that
- * channel's ack to drain. */
+/* Resume any CREATE parked on `ack_request`'s connection whose triggered lease
+ * break has now settled (no caching lease on the file is mid-break).  Called from
+ * the inbound OPLOCK_BREAK ack handler after the lease is acked.  The opener's
+ * pending create sits on its own conn's parked_requests; in the single-channel
+ * case that is the same connection the ack arrived on, so the deferred response's
+ * thread-local iovecs are produced on the right thread.  A create awaiting an ack
+ * that arrives on a different channel is drained by that channel's ack. */
 void
 chimera_smb_create_resume_parked(struct chimera_smb_request *ack_request)
 {
     struct chimera_server_smb_thread *thread    = ack_request->compound->thread;
     struct chimera_vfs_state         *vfs_state = thread->vfs_thread->vfs->vfs_state;
-    struct chimera_smb_tree          *tree      = ack_request->tree;
+    struct chimera_smb_conn          *conn      = ack_request->compound->conn;
     struct chimera_smb_request       *req, **pp, *resume = NULL;
 
-    if (!tree) {
+    if (!conn) {
         return;
     }
 
-    pthread_mutex_lock(&tree->parked_lock);
-    pp = &tree->parked_creates;
+    /* Pull settled parked CREATEs off the conn's parked list, then complete them.
+     * Collect first (unlinking + clearing armed) so the completion path does not
+     * re-walk / re-cancel the list we are iterating. */
+    pp = &conn->parked_requests;
     while ((req = *pp)) {
-        if (req->compound->thread == thread &&
+        if (req->smb2_hdr.command == SMB2_CREATE &&
             !chimera_vfs_state_caching_breaking(vfs_state,
                                                 req->create.park_fh,
                                                 req->create.park_fh_len,
@@ -1651,20 +1651,22 @@ chimera_smb_create_resume_parked(struct chimera_smb_request *ack_request)
                                                 req->create.r_open_file
                                                 ? req->create.r_open_file->grant
                                                 : NULL)) {
-            *pp                   = req->create.park_next;
-            req->create.park_next = resume;
-            resume                = req;
+            *pp                  = req->async.park_next;
+            req->async.park_next = resume;
+            req->async.armed     = 0; /* already unlinked; skip re-cancel */
+            resume               = req;
         } else {
-            pp = &req->create.park_next;
+            pp = &req->async.park_next;
         }
     }
-    pthread_mutex_unlock(&tree->parked_lock);
 
     while (resume) {
-        req                   = resume;
-        resume                = req->create.park_next;
-        req->create.park_next = NULL;
+        req                  = resume;
+        resume               = req->async.park_next;
+        req->async.park_next = NULL;
         chimera_smb_open_file_release(req, req->create.r_open_file);
+        /* async_id is still set, so the final reply carries
+         * SMB2_FLAGS_ASYNC_COMMAND matching the interim. */
         chimera_smb_complete_request(req, SMB2_STATUS_SUCCESS);
     }
 } /* chimera_smb_create_resume_parked */

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -280,6 +280,49 @@ chimera_smb_create_gen_open_file(
     open_file->stream_name_len = 0;
     open_file->base_fh_len     = 0;
 
+    /* A *batch* (handle-caching) oplock breaks BEFORE the share-mode check:
+     * the holder may close its deferred handle in response, after which the
+     * sharing conflict disappears.  Fire that break here so it happens even
+     * when this open is ultimately refused with a sharing violation (MS-FSA
+     * drives the break off the access attempt -- smb2.oplock.batch5 expects
+     * the break AND a SHARING_VIOLATION).  An exclusive (W-only) oplock is
+     * different: it breaks only once the open is granted (handled after the
+     * share-mode check), so we do NOT touch W-only holders here.  A truncating
+     * disposition replaces the data, so a batch holder breaks to NONE;
+     * otherwise it drops to LEVEL_II.  Pure attribute/EA opens break nothing
+     * (stat-open).  No-op on the first open; skips the opener's own lease. */
+    if (type == CHIMERA_SMB_OPEN_FILE_TYPE_FILE && tree->share && oh) {
+        uint32_t da   = open_file->desired_access;
+        uint32_t disp = request->create.create_disposition;
+        bool     truncates =
+            disp == SMB2_FILE_OVERWRITE ||
+            disp == SMB2_FILE_OVERWRITE_IF ||
+            disp == SMB2_FILE_SUPERSEDE;
+        bool break_trigger =
+            (da & (SMB2_FILE_READ_DATA | SMB2_FILE_WRITE_DATA |
+                   SMB2_FILE_APPEND_DATA | SMB2_FILE_EXECUTE |
+                   SMB2_GENERIC_READ | SMB2_GENERIC_WRITE |
+                   SMB2_GENERIC_EXECUTE | SMB2_GENERIC_ALL |
+                   SMB2_MAXIMUM_ALLOWED | SMB2_DELETE)) ||
+            (request->create.create_options & SMB2_FILE_DELETE_ON_CLOSE) ||
+            truncates;
+
+        if (break_trigger) {
+            struct chimera_vfs_state      *vfs_state = thread->vfs_thread->vfs->vfs_state;
+            struct chimera_vfs_lease_owner io_owner  = {
+                .protocol   = CHIMERA_VFS_LEASE_PROTO_SMB2,
+                .client_key = request->session_handle->session->session_id,
+                .owner_lo   = open_file->file_id.pid,
+                .owner_hi   = open_file->file_id.vid,
+            };
+
+            chimera_vfs_state_break_caching_for_open(vfs_state, oh->fh, oh->fh_len,
+                                                     oh->fh_hash, &io_owner,
+                                                     CHIMERA_VFS_LEASE_MODE_H,
+                                                     truncates ? 0 : CHIMERA_VFS_LEASE_MODE_R);
+        }
+    }
+
     /* Check share mode conflicts for regular file opens.
      * Attribute-only opens (READ_ATTRIBUTES, SYNCHRONIZE, etc.)
      * bypass share mode enforcement, matching Windows/NTFS behavior.
@@ -625,13 +668,19 @@ chimera_smb_create_gen_open_file(
                                                       &open_file->caching_lease,
                                                       &conflict);
 
-                /* A breakable conflict means another handle already holds a
-                 * caching oplock/lease.  try_insert has kicked off the break
-                 * (downgrading that holder to a shared read / LEVEL_II).  We
-                 * cannot keep an exclusive/write cache, but we can settle for
-                 * a shared read lease, which coexists with the downgraded
-                 * holder — this is how a 2nd open ends up with LEVEL_II. */
-                if (result == CHIMERA_VFS_LEASE_BREAKING) {
+                /* Another handle already holds a caching oplock/lease.  We
+                 * cannot keep an exclusive/write cache, but we can settle for a
+                 * shared read lease, which coexists with the (now downgraded)
+                 * holder -- this is how a 2nd open ends up with LEVEL_II.
+                 *   - BREAKING: try_insert just kicked off the holder's break.
+                 *   - DENIED: the holder was already broken to a shared read by
+                 *     the break-on-open above (its lease is ACKED, no longer
+                 *     IDLE-breakable), so a write cache is refused; a read cache
+                 *     still coexists.
+                 * Either way, retry for read-only caching (LEVEL_II). */
+                if ((result == CHIMERA_VFS_LEASE_BREAKING ||
+                     result == CHIMERA_VFS_LEASE_DENIED) &&
+                    req_vfs != CHIMERA_VFS_LEASE_MODE_R) {
                     req_vfs                               = CHIMERA_VFS_LEASE_MODE_R;
                     open_file->caching_lease.mode.granted = req_vfs;
                     result                                = chimera_vfs_state_try_insert(vfs_state, file_state,
@@ -696,37 +745,34 @@ chimera_smb_create_gen_open_file(
                 open_file->oplock_level = SMB2_OPLOCK_LEVEL_LEASE;
             }
 
-            /* This open requested no caching lease of its own, but it can
-             * still break an oplock another open holds.  A data-modifying or
-             * deleting open breaks every holder all the way to NONE; a plain
-             * (non-modifying) data open downgrades an exclusive/batch holder to
-             * LEVEL_II.  A pure attribute-only open (caching_touches_data ==
-             * false) breaks nothing -- it must leave a stat-open holder's
-             * oplock intact. */
-            bool modifying =
-                (request->create.desired_access &
-                 (SMB2_FILE_WRITE_DATA | SMB2_FILE_APPEND_DATA |
-                  SMB2_GENERIC_WRITE | SMB2_GENERIC_ALL |
-                  SMB2_DELETE | SMB2_MAXIMUM_ALLOWED)) ||
-                (request->create.create_options & SMB2_FILE_DELETE_ON_CLOSE) ||
-                request->create.create_disposition == SMB2_FILE_OVERWRITE ||
-                request->create.create_disposition == SMB2_FILE_OVERWRITE_IF ||
-                request->create.create_disposition == SMB2_FILE_SUPERSEDE;
-
-            if (modifying || caching_touches_data) {
+            /* The open has now been granted (it passed the share-mode check
+             * above).  Break a conflicting *exclusive* (W) holder: unlike a
+             * batch holder (already handled before the share check), an
+             * exclusive oplock breaks only once the conflicting open succeeds.
+             * A truncating open invalidates all cached data (break to NONE);
+             * any other data/delete open downgrades the holder to LEVEL_II.  A
+             * pure attribute/EA open (not caching_touches_data) breaks
+             * nothing.  Skips the opener's own lease (distinct owner). */
+            if (caching_touches_data) {
                 struct chimera_vfs_lease_owner io_owner = {
                     .protocol   = CHIMERA_VFS_LEASE_PROTO_SMB2,
                     .client_key = request->session_handle->session->session_id,
                     .owner_lo   = open_file->file_id.pid,
                     .owner_hi   = open_file->file_id.vid,
                 };
+                bool truncates =
+                    request->create.create_disposition == SMB2_FILE_OVERWRITE ||
+                    request->create.create_disposition == SMB2_FILE_OVERWRITE_IF ||
+                    request->create.create_disposition == SMB2_FILE_SUPERSEDE;
 
-                if (modifying) {
+                if (truncates) {
                     chimera_vfs_state_break_on_write(vfs_state, oh->fh, oh->fh_len,
                                                      oh->fh_hash, &io_owner);
                 } else {
-                    chimera_vfs_state_break_on_open(vfs_state, oh->fh, oh->fh_len,
-                                                    oh->fh_hash, &io_owner);
+                    chimera_vfs_state_break_caching_for_open(
+                        vfs_state, oh->fh, oh->fh_len, oh->fh_hash, &io_owner,
+                        CHIMERA_VFS_LEASE_MODE_W | CHIMERA_VFS_LEASE_MODE_H,
+                        CHIMERA_VFS_LEASE_MODE_R);
                 }
             }
         }

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -371,6 +371,9 @@ chimera_smb_create_gen_open_file(
     open_file->lease_flags        = 0;
     open_file->durable_flags      = 0;
     open_file->durable_timeout_ms = 0;
+    /* No caching grant until the caching block below acquires one (open_file is
+     * reused from a free list without being zeroed). */
+    open_file->grant = NULL;
     memset(open_file->lease_key,        0, sizeof(open_file->lease_key));
     memset(open_file->parent_lease_key, 0, sizeof(open_file->parent_lease_key));
     memset(open_file->create_guid,      0, sizeof(open_file->create_guid));
@@ -775,94 +778,115 @@ chimera_smb_create_after_share(
                                                oh->fh, oh->fh_len,
                                                oh->fh_hash, true);
             if (file_state) {
-                open_file->caching_lease.kind             = CHIMERA_VFS_LEASE_CACHING;
-                open_file->caching_lease.mode.granted     = req_vfs;
-                open_file->caching_lease.owner.protocol   = CHIMERA_VFS_LEASE_PROTO_SMB2;
-                open_file->caching_lease.owner.client_key = request->session_handle->session->session_id;
-                /* For RqLs, owner identity is the lease_key (so multiple
-                 * opens with the same key by the same client coalesce —
-                 * the Samba locking.tdb rule).  For legacy oplocks,
-                 * each open is its own owner (use file_id). */
-                if (via_rqls) {
-                    memcpy(&open_file->caching_lease.owner.owner_lo,
-                           request->create.rqls.key, 8);
-                    memcpy(&open_file->caching_lease.owner.owner_hi,
-                           request->create.rqls.key + 8, 8);
-                    /* Mirror the lease_key onto the open_file for the
-                     * break notification builder. */
-                    memcpy(open_file->lease_key, request->create.rqls.key, 16);
-                    if (request->create.rqls.is_v2) {
-                        memcpy(open_file->parent_lease_key,
-                               request->create.rqls.parent_key, 16);
-                        /* MS-SMB2 3.3.5.9.11: granting (or changing) a lease
-                         * increments its epoch; a freshly granted lease returns
-                         * the client's epoch + 1 (1 for a new lease). */
-                        open_file->lease_epoch = request->create.rqls.epoch + 1;
-                    }
-                } else {
-                    open_file->caching_lease.owner.owner_lo = open_file->file_id.pid;
-                    open_file->caching_lease.owner.owner_hi = open_file->file_id.vid;
-                }
-                /* Wire the break callback so vfs_state can notify the
-                 * client when another acquirer needs this lease. */
-                open_file->caching_lease.owner.break_cb   = chimera_smb_lease_break_cb;
-                open_file->caching_lease.owner.cb_private = open_file;
-                /* Anchor the lease to this open's VFS handle so a setattr issued
-                 * through the same handle (e.g. SetEndOfFile) does not recall
-                 * this lease against itself -- the holder is coherent with its
-                 * own change (chimera_vfs_break_caching_file skip_handle). */
-                open_file->caching_lease.owner.op_handle = oh;
-                open_file->create_conn                   = request->compound->conn;
+                /* The caching lease lives in a VFS-owned grant (refcounted,
+                 * owner-keyed) rather than embedded in the open_file.  In this
+                 * phase each open allocates its own grant (no cross-open
+                 * coalescing yet); the embedded lease's old settle-loop runs
+                 * unchanged on &grant->lease. */
+                struct chimera_vfs_caching_grant *grant = calloc(1, sizeof(*grant));
 
-                result = chimera_vfs_state_try_insert(vfs_state, file_state,
-                                                      &open_file->caching_lease,
-                                                      &conflict);
-
-                /* Settle on the strongest caching lease actually grantable.
-                 * A conflict has two flavors:
-                 *   - BREAKING: try_insert kicked off a holder's break.  The
-                 *     break is optimistic (the holder downgrades to a shared
-                 *     read immediately), so simply retrying the SAME mode now
-                 *     usually succeeds; if it still conflicts we step down.
-                 *   - DENIED: an exclusive/batch grant is refused because
-                 *     another client has the file open (sole-access rule) or a
-                 *     holder is mid-downgrade; step the request down to a shared
-                 *     read (LEVEL_II), which coexists.
-                 * Loop, stepping W|H -> R, until granted or nothing is left to
-                 * try.  Bounded by the W->R step plus a few optimistic-break
-                 * retries. */
-                int settle_guard = 6;
-                while (result != CHIMERA_VFS_LEASE_GRANTED && settle_guard-- > 0) {
-                    if (req_vfs != CHIMERA_VFS_LEASE_MODE_R) {
-                        req_vfs = CHIMERA_VFS_LEASE_MODE_R;
-                    } else if (result != CHIMERA_VFS_LEASE_BREAKING) {
-                        /* Already at R and not merely waiting on an optimistic
-                         * break -- a shared read cache is unobtainable. */
-                        break;
-                    }
-                    open_file->caching_lease.mode.granted = req_vfs;
-                    result                                = chimera_vfs_state_try_insert(vfs_state, file_state,
-                                                                                         &open_file->caching_lease,
-                                                                                         &conflict);
-                }
-
-                if (result == CHIMERA_VFS_LEASE_GRANTED) {
-                    open_file->caching_file_state     = file_state;
-                    open_file->caching_lease_inserted = true;
-                    /* Record granted SMB-side state on the open_file via the
-                     * canonical encoders (smb_internal.h): lease_state holds the
-                     * SMB lease bits the response emitter wants; oplock_level is
-                     * the legacy collapse of the granted RWH for a non-RqLs open. */
-                    open_file->lease_state = chimera_smb_vfs_to_lease_bits(req_vfs);
-                    if (via_rqls) {
-                        open_file->oplock_level = SMB2_OPLOCK_LEVEL_LEASE;
-                    } else {
-                        open_file->oplock_level = chimera_smb_vfs_to_oplock_level(req_vfs);
-                    }
-                } else {
+                if (!grant) {
                     chimera_vfs_state_put(vfs_state, file_state);
                     open_file->lease_state  = 0;
                     open_file->oplock_level = SMB2_OPLOCK_LEVEL_NONE;
+                } else {
+                    grant->file                   = file_state;
+                    grant->refcount               = 1;
+                    grant->epoch                  = 1;
+                    grant->lease.grant            = grant;
+                    grant->lease.kind             = CHIMERA_VFS_LEASE_CACHING;
+                    grant->lease.mode.granted     = req_vfs;
+                    grant->lease.owner.protocol   = CHIMERA_VFS_LEASE_PROTO_SMB2;
+                    grant->lease.owner.client_key = request->session_handle->session->session_id;
+                    /* For RqLs, owner identity is the lease_key (so multiple
+                     * opens with the same key by the same client coalesce —
+                     * the Samba locking.tdb rule).  For legacy oplocks,
+                     * each open is its own owner (use file_id). */
+                    if (via_rqls) {
+                        memcpy(&grant->lease.owner.owner_lo,
+                               request->create.rqls.key, 8);
+                        memcpy(&grant->lease.owner.owner_hi,
+                               request->create.rqls.key + 8, 8);
+                        /* Mirror the lease_key onto the open_file for the
+                         * break notification builder. */
+                        memcpy(open_file->lease_key, request->create.rqls.key, 16);
+                        if (request->create.rqls.is_v2) {
+                            memcpy(open_file->parent_lease_key,
+                                   request->create.rqls.parent_key, 16);
+                            /* MS-SMB2 3.3.5.9.11: granting (or changing) a lease
+                             * increments its epoch; a freshly granted lease returns
+                             * the client's epoch + 1 (1 for a new lease). */
+                            open_file->lease_epoch = request->create.rqls.epoch + 1;
+                        }
+                    } else {
+                        grant->lease.owner.owner_lo = open_file->file_id.pid;
+                        grant->lease.owner.owner_hi = open_file->file_id.vid;
+                    }
+                    /* Wire the break callback so vfs_state can notify the
+                     * client when another acquirer needs this lease. */
+                    grant->lease.owner.break_cb   = chimera_smb_lease_break_cb;
+                    grant->lease.owner.cb_private = open_file;
+                    /* Anchor the lease to this open's VFS handle so a setattr issued
+                     * through the same handle (e.g. SetEndOfFile) does not recall
+                     * this lease against itself -- the holder is coherent with its
+                     * own change (chimera_vfs_break_caching_file skip_handle). */
+                    grant->lease.owner.op_handle = oh;
+                    open_file->create_conn       = request->compound->conn;
+
+                    result = chimera_vfs_state_try_insert(vfs_state, file_state,
+                                                          &grant->lease,
+                                                          &conflict);
+
+                    /* Settle on the strongest caching lease actually grantable.
+                     * A conflict has two flavors:
+                     *   - BREAKING: try_insert kicked off a holder's break.  The
+                     *     break is optimistic (the holder downgrades to a shared
+                     *     read immediately), so simply retrying the SAME mode now
+                     *     usually succeeds; if it still conflicts we step down.
+                     *   - DENIED: an exclusive/batch grant is refused because
+                     *     another client has the file open (sole-access rule) or a
+                     *     holder is mid-downgrade; step the request down to a shared
+                     *     read (LEVEL_II), which coexists.
+                     * Loop, stepping W|H -> R, until granted or nothing is left to
+                     * try.  Bounded by the W->R step plus a few optimistic-break
+                     * retries. */
+                    int settle_guard = 6;
+                    while (result != CHIMERA_VFS_LEASE_GRANTED && settle_guard-- > 0) {
+                        if (req_vfs != CHIMERA_VFS_LEASE_MODE_R) {
+                            req_vfs = CHIMERA_VFS_LEASE_MODE_R;
+                        } else if (result != CHIMERA_VFS_LEASE_BREAKING) {
+                            /* Already at R and not merely waiting on an optimistic
+                             * break -- a shared read cache is unobtainable. */
+                            break;
+                        }
+                        grant->lease.mode.granted = req_vfs;
+                        result                    = chimera_vfs_state_try_insert(vfs_state, file_state,
+                                                                                 &grant->lease,
+                                                                                 &conflict);
+                    }
+
+                    if (result == CHIMERA_VFS_LEASE_GRANTED) {
+                        open_file->grant                  = grant;
+                        open_file->caching_file_state     = file_state;
+                        open_file->caching_lease_inserted = true;
+                        /* Record granted SMB-side state on the open_file via the
+                         * canonical encoders (smb_internal.h): lease_state holds the
+                         * SMB lease bits the response emitter wants; oplock_level is
+                         * the legacy collapse of the granted RWH for a non-RqLs open. */
+                        open_file->lease_state = chimera_smb_vfs_to_lease_bits(req_vfs);
+                        if (via_rqls) {
+                            open_file->oplock_level = SMB2_OPLOCK_LEVEL_LEASE;
+                        } else {
+                            open_file->oplock_level = chimera_smb_vfs_to_oplock_level(req_vfs);
+                        }
+                    } else {
+                        /* try_insert never linked the lease on a non-GRANTED
+                         * result, so the grant just frees. */
+                        free(grant);
+                        chimera_vfs_state_put(vfs_state, file_state);
+                        open_file->lease_state  = 0;
+                        open_file->oplock_level = SMB2_OPLOCK_LEVEL_NONE;
+                    }
                 }
             }
         } else {

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -265,15 +265,22 @@ chimera_smb_create_break_for_open(
     struct chimera_vfs_open_handle   *oh,
     int                               phase)
 {
-    uint32_t                       da        = open_file->desired_access;
-    uint32_t                       disp      = request->create.create_disposition;
-    bool                           truncates =
+    uint32_t da        = open_file->desired_access;
+    uint32_t disp      = request->create.create_disposition;
+    bool     truncates =
         disp == SMB2_FILE_OVERWRITE ||
         disp == SMB2_FILE_OVERWRITE_IF ||
         disp == SMB2_FILE_SUPERSEDE;
-    bool                           break_trigger =
+    /* Access rights that make an open a "real" open (vs a pure stat open) and so
+     * break a conflicting caching holder.  Per MS-FSA / smb2.lease.statopen4:
+     * data read/write/append/execute, EA read/write, DELETE, and WRITE_DAC /
+     * WRITE_OWNER all break; READ_ATTRIBUTES, WRITE_ATTRIBUTES, READ_CONTROL and
+     * SYNCHRONIZE do NOT (they are compatible with a cached handle). */
+    bool break_trigger =
         (da & (SMB2_FILE_READ_DATA | SMB2_FILE_WRITE_DATA |
                SMB2_FILE_APPEND_DATA | SMB2_FILE_EXECUTE |
+               SMB2_FILE_READ_EA | SMB2_FILE_WRITE_EA |
+               SMB2_WRITE_DACL | SMB2_WRITE_OWNER |
                SMB2_GENERIC_READ | SMB2_GENERIC_WRITE |
                SMB2_GENERIC_EXECUTE | SMB2_GENERIC_ALL |
                SMB2_MAXIMUM_ALLOWED | SMB2_DELETE)) ||

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -946,7 +946,11 @@ chimera_smb_create_after_share(
                         chimera_smb_vfs_to_lease_bits(granted_vfs);
                     if (via_rqls) {
                         open_file->oplock_level = SMB2_OPLOCK_LEVEL_LEASE;
-                        if (request->create.rqls.is_v2) {
+                        /* Report the lease's epoch on any open that joins a v2
+                         * lease -- including a v1 request coalescing onto an
+                         * existing v2 lease (the response follows the lease's
+                         * version, set at first grant). */
+                        if (grant->is_v2) {
                             open_file->lease_epoch = grant->epoch;
                         }
                     } else {
@@ -2915,12 +2919,19 @@ build_rqls_response(
     uint32_t                    out_size)
 {
     struct chimera_smb_open_file *of = request->create.r_open_file;
-    bool                          v2 = request->create.rqls.is_v2 != 0;
+    bool                          v2;
     int                           needed;
 
     if (!of) {
         return -1;
     }
+
+    /* The response lease version follows the LEASE's version (set when the lease
+     * was first granted), not this request's: a v1 open that coalesces onto an
+     * existing v2 lease still gets a v2 response, and vice versa (MS-SMB2
+     * 3.3.5.9.11; smb2.lease.v2_epoch2/3).  The grant records is_v2; fall back to
+     * the request only when this open holds no grant (a bare LEASE_NONE). */
+    v2 = of->grant ? of->grant->is_v2 : (request->create.rqls.is_v2 != 0);
 
     needed = v2 ? SMB2_CREATE_REQUEST_LEASE_V2_SIZE
                 : SMB2_CREATE_REQUEST_LEASE_SIZE;

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -307,9 +307,14 @@ chimera_smb_create_break_for_open(
         chimera_vfs_state_break_on_write(vfs_state, oh->fh, oh->fh_len,
                                          oh->fh_hash, &io_owner);
     } else {
+        /* A conflicting open invalidates the (exclusive) write cache of other
+         * holders, but read + handle caching stay shared: break W-holders down to
+         * R|H, not R.  For a legacy oplock R|H still collapses to LEVEL_II (no
+         * separate handle bit), so this only widens what a lease holder keeps. */
         chimera_vfs_state_break_caching_for_open(
             vfs_state, oh->fh, oh->fh_len, oh->fh_hash, &io_owner,
-            CHIMERA_VFS_LEASE_MODE_W, CHIMERA_VFS_LEASE_MODE_R);
+            CHIMERA_VFS_LEASE_MODE_W,
+            CHIMERA_VFS_LEASE_MODE_R | CHIMERA_VFS_LEASE_MODE_H);
     }
 } /* chimera_smb_create_break_for_open */
 
@@ -852,6 +857,12 @@ chimera_smb_create_after_share(
 
                         grant->file     = file_state;
                         grant->refcount = 1;
+                        /* Legacy oplock vs RqLs lease: a legacy oplock's handle is
+                         * broken before the share check, a lease's is not. */
+                        grant->is_oplock = !via_rqls;
+                        /* Only a v2 lease versions its state with an epoch; v1
+                         * leases and legacy oplocks break with epoch 0. */
+                        grant->is_v2 = via_rqls && request->create.rqls.is_v2;
                         /* The grant owns the epoch so coalesced opens and breaks
                          * share one counter; a v2 lease is granted at the client's
                          * epoch + 1 (1 for a brand-new lease, 3.3.5.9.11). */

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -1493,6 +1493,21 @@ chimera_smb_create_open_at_callback(
         }
     }
 
+    /* A lease key may be bound to only one file per client (MS-SMB2 3.3.5.9.8).
+     * If this client already holds the requested lease key on a different file,
+     * reject the open with STATUS_INVALID_PARAMETER (smb2.lease.request /
+     * duplicate_create / duplicate_open).  A re-open of the same file under the
+     * key coalesces and is not a conflict. */
+    if ((request->create.ctx_present_mask & CHIMERA_SMB_CREATE_CTX_RQLS) &&
+        chimera_smb_session_lease_key_conflict(request->session_handle->session,
+                                               request->create.rqls.key,
+                                               oh->fh, oh->fh_len)) {
+        chimera_vfs_release(vfs_thread, oh);
+        chimera_vfs_release(vfs_thread, request->create.parent_handle);
+        chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
+        return;
+    }
+
     /* Named-stream open: the base file is now open; open the stream on it and
      * build the SMB open_file around the stream handle. */
     if (request->create.has_stream) {

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -1638,7 +1638,7 @@ chimera_smb_create_open_finish(
          * STREAM_NAME class for non-directories.  This lets a watcher that
          * requested only FILE_NOTIFY_CHANGE_STREAM_NAME observe the stream
          * appearing (WPTS BVT_SMB2Basic_ChangeNotify_ChangeStreamName). */
-        if (!S_ISDIR(attr->va_mode)) {
+        if (!request->create.r_is_directory) {
             action |= CHIMERA_VFS_NOTIFY_STREAM_NAME;
         }
 

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -592,11 +592,14 @@ chimera_smb_create_gen_open_file(
                 /* Share reservation: owner_lo carries the open's persistent id. */
                 conflict_pid = conflict->owner.owner_lo;
             } else if (conflict->kind == CHIMERA_VFS_LEASE_CACHING &&
-                       conflict->owner.cb_private) {
-                /* Caching lease: owner_lo is the lease key, but cb_private points
-                 * at the owning open_file (set in the lease-grant block). */
+                       conflict->grant &&
+                       ((struct chimera_smb_open_file *) conflict->grant->holders)) {
+                /* Caching lease: owner_lo is the lease key; resolve the owning open
+                 * via the grant's member list (cb_private now points at the grant,
+                 * which may be shared by several opens -- any member identifies the
+                 * parked durable handle to purge). */
                 conflict_pid = ((struct chimera_smb_open_file *)
-                                conflict->owner.cb_private)->file_id.pid;
+                                conflict->grant->holders)->file_id.pid;
             } else {
                 break;
             }
@@ -822,16 +825,26 @@ chimera_smb_create_after_share(
                         grant->lease.owner.owner_lo = open_file->file_id.pid;
                         grant->lease.owner.owner_hi = open_file->file_id.vid;
                     }
-                    /* Wire the break callback so vfs_state can notify the
-                     * client when another acquirer needs this lease. */
+                    /* Wire the break callback so vfs_state can notify the client
+                     * when another acquirer needs this lease.  cb_private is the
+                     * GRANT (not this open): the grant may be shared by, and
+                     * outlive, the open that created it, so the break callback
+                     * resolves a live member from grant->holders rather than
+                     * dereferencing a single open that may already be gone. */
                     grant->lease.owner.break_cb   = chimera_smb_lease_break_cb;
-                    grant->lease.owner.cb_private = open_file;
+                    grant->lease.owner.cb_private = grant;
                     /* Anchor the lease to this open's VFS handle so a setattr issued
                      * through the same handle (e.g. SetEndOfFile) does not recall
                      * this lease against itself -- the holder is coherent with its
                      * own change (chimera_vfs_break_caching_file skip_handle). */
                     grant->lease.owner.op_handle = oh;
                     open_file->create_conn       = request->compound->conn;
+
+                    /* Register this open as a grant member BEFORE the lease becomes
+                     * visible (try_insert links it onto caching_leases): once linked,
+                     * a conflicting acquirer can invoke the break callback, which
+                     * must find a live member or it will revoke the fresh lease. */
+                    chimera_smb_grant_add_member(grant, open_file);
 
                     result = chimera_vfs_state_try_insert(vfs_state, file_state,
                                                           &grant->lease,
@@ -881,7 +894,9 @@ chimera_smb_create_after_share(
                         }
                     } else {
                         /* try_insert never linked the lease on a non-GRANTED
-                         * result, so the grant just frees. */
+                         * result, so the grant just frees -- unregister the member
+                         * first (it was added before the insert attempt). */
+                        chimera_smb_grant_remove_member(grant, open_file);
                         free(grant);
                         chimera_vfs_state_put(vfs_state, file_state);
                         open_file->lease_state  = 0;

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -489,7 +489,6 @@ chimera_smb_create_gen_open_file(
         uint8_t                        req_smb         = 0;
         uint8_t                        req_vfs         = 0;
         bool                           via_rqls        = false;
-        bool                           durable_request = false;
         struct chimera_vfs_lease      *conflict        = NULL;
         enum chimera_vfs_lease_result  result;
 
@@ -516,45 +515,31 @@ chimera_smb_create_gen_open_file(
             } /* switch */
         }
 
-        durable_request = thread->shared->config.persistent_handles &&
-            (request->create.ctx_present_mask &
-             (CHIMERA_SMB_CREATE_CTX_DHNQ |
-              CHIMERA_SMB_CREATE_CTX_DH2Q)) != 0;
-
-        /* SMB lease bits use R=0x01, H=0x02, W=0x04 — different layout
-        * from vfs_state's R/W/H mask, so map field-by-field.  For ordinary
-        * opens we grant only the read-caching (R) bit — a LEVEL_II oplock —
-        * and deliberately withhold write caching (W) and handle caching (H):
+        /* SMB lease bits use R=0x01, H=0x02, W=0x04 — a different layout from
+        * vfs_state's R/W/H mask, so map field-by-field.  We grant the full
+        * requested set: read caching (R → LEVEL_II), write caching
+        * (W → EXCLUSIVE) and handle caching (H → BATCH).  The vfs_state
+        * conflict matrix keeps W single-writer-exclusive and H
+        * single-holder-exclusive, and the SMB layer breaks holders when a
+        * conflicting open / write / byte-range-lock / delete arrives.
         *
-        *   - Handle caching (batch oplock) makes the Linux cifs client keep
-        *     "deferred close" handles cached, which collide with unlink of
-        *     an open file (delete-of-open-file needs delete-pending across
-        *     the cached handle, not yet implemented) — cthon op_unlk failed
-        *     with EBUSY.
-        *   - Write caching lets the client buffer writes it has not flushed
-        *     to the server, which corrupts server-side copy: copy_file_range
-        *     (FSCTL_SRV_COPYCHUNK) reads the source on the server before the
-        *     buffered write lands, copying stale/zero data (fsx READ BAD
-        *     DATA).  Write-through keeps the server authoritative.
-        *
-        * Read caching is the important win and is coherent: a write breaks
-        * other holders' R leases (chimera_vfs_state_break_on_write), and the
-        * VFS attr/data caches keep a single client consistent.  A client that
-        * asked for an exclusive/batch oplock or an RWH lease simply receives
-        * the read-only (LEVEL_II) subset.
-        *
-        * Durable handles are the exception. MS-SMB2 requires a durable grant
-        * to be paired with a batch oplock or a HANDLE-caching lease, and WPTS
-        * verifies the durable response context on that initial CREATE. Only
-        * durable-aware clients take this path, so keep the normal-client
-        * behavior above while allowing the requested W/H bits here. */
+        * The two coherence hazards that previously forced a read-only policy
+        * (W and H withheld) are now handled in the break path rather than by
+        * withholding the cache:
+        *   - delete-of-open-file: unlink / rename / delete-on-close break the
+        *     H (handle-caching) holder so its deferred-close handle is recalled
+        *     before the remove (smb_proc_close.c / set_info / rename) — fixes
+        *     the old cthon op_unlk EBUSY.
+        *   - server-side copy: COPYCHUNK breaks the source's caching lease to
+        *     force a flush before it reads (smb_proc_copychunk.c) — fixes the
+        *     old fsx READ BAD DATA. */
         if (req_smb & SMB2_LEASE_READ_CACHING) {
             req_vfs |= CHIMERA_VFS_LEASE_MODE_R;
         }
-        if (durable_request && (req_smb & SMB2_LEASE_HANDLE_CACHING)) {
+        if (req_smb & SMB2_LEASE_HANDLE_CACHING) {
             req_vfs |= CHIMERA_VFS_LEASE_MODE_H;
         }
-        if (durable_request && (req_smb & SMB2_LEASE_WRITE_CACHING)) {
+        if (req_smb & SMB2_LEASE_WRITE_CACHING) {
             req_vfs |= CHIMERA_VFS_LEASE_MODE_W;
         }
 
@@ -711,17 +696,24 @@ chimera_smb_create_gen_open_file(
                 open_file->oplock_level = SMB2_OPLOCK_LEVEL_LEASE;
             }
 
-            if ((request->create.desired_access &
+            /* This open requested no caching lease of its own, but it can
+             * still break an oplock another open holds.  A data-modifying or
+             * deleting open breaks every holder all the way to NONE; a plain
+             * (non-modifying) data open downgrades an exclusive/batch holder to
+             * LEVEL_II.  A pure attribute-only open (caching_touches_data ==
+             * false) breaks nothing -- it must leave a stat-open holder's
+             * oplock intact. */
+            bool modifying =
+                (request->create.desired_access &
                  (SMB2_FILE_WRITE_DATA | SMB2_FILE_APPEND_DATA |
                   SMB2_GENERIC_WRITE | SMB2_GENERIC_ALL |
                   SMB2_DELETE | SMB2_MAXIMUM_ALLOWED)) ||
                 (request->create.create_options & SMB2_FILE_DELETE_ON_CLOSE) ||
                 request->create.create_disposition == SMB2_FILE_OVERWRITE ||
                 request->create.create_disposition == SMB2_FILE_OVERWRITE_IF ||
-                request->create.create_disposition == SMB2_FILE_SUPERSEDE) {
-                /* This open does not request a caching lease of its own, but
-                 * it modifies or deletes the file, so it must break any
-                 * caching oplock/lease another open holds. */
+                request->create.create_disposition == SMB2_FILE_SUPERSEDE;
+
+            if (modifying || caching_touches_data) {
                 struct chimera_vfs_lease_owner io_owner = {
                     .protocol   = CHIMERA_VFS_LEASE_PROTO_SMB2,
                     .client_key = request->session_handle->session->session_id,
@@ -729,8 +721,13 @@ chimera_smb_create_gen_open_file(
                     .owner_hi   = open_file->file_id.vid,
                 };
 
-                chimera_vfs_state_break_on_write(vfs_state, oh->fh, oh->fh_len,
-                                                 oh->fh_hash, &io_owner);
+                if (modifying) {
+                    chimera_vfs_state_break_on_write(vfs_state, oh->fh, oh->fh_len,
+                                                     oh->fh_hash, &io_owner);
+                } else {
+                    chimera_vfs_state_break_on_open(vfs_state, oh->fh, oh->fh_len,
+                                                    oh->fh_hash, &io_owner);
+                }
             }
         }
     }

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -384,8 +384,7 @@ chimera_smb_create_gen_open_file(
      * legacy per-tree sharemode table is bypassed entirely — its
      * behavior matrix is preserved by chimera_vfs_share_conflict in
      * vfs_state.c. */
-    if (type == CHIMERA_SMB_OPEN_FILE_TYPE_FILE && tree->share &&
-        (open_file->desired_access & SMB2_SHAREMODE_ACCESS_MASK) && oh) {
+    if (type == CHIMERA_SMB_OPEN_FILE_TYPE_FILE && tree->share && oh) {
         struct chimera_vfs_state      *vfs_state = thread->vfs_thread->vfs->vfs_state;
         struct chimera_vfs_file_state *file_state;
         uint32_t                       da = open_file->desired_access;
@@ -439,6 +438,19 @@ chimera_smb_create_gen_open_file(
             request->create.create_disposition == SMB2_FILE_OVERWRITE ||
             request->create.create_disposition == SMB2_FILE_OVERWRITE_IF) {
             granted |= CHIMERA_VFS_LEASE_MODE_W;
+        }
+
+        /* Attribute-only opens (no data/delete access bits, e.g. a
+         * READ_ATTRIBUTES stat-open) hold no share-mode rights and impose no
+         * deny.  Register them anyway as an inert (granted=0, denied=0) SHARE
+         * entry so the layer can answer "is there another opener?" (sole-access
+         * oplock grant), delete-pending, and stat-open classification -- without
+         * changing any conflict outcome (chimera_vfs_share_conflict and the
+         * CACHING sole-access loop both treat a (0,0) entry as absent). */
+        if (!(da & SMB2_SHAREMODE_ACCESS_MASK)) {
+            granted      = 0;
+            denied       = 0;
+            held_granted = 0;
         }
 
         file_state = chimera_vfs_state_get(vfs_state,

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -874,7 +874,17 @@ chimera_smb_create_after_share(
                                                               &grant->lease, &conflict);
                         while (result != CHIMERA_VFS_LEASE_GRANTED &&
                                settle_guard-- > 0) {
-                            if (grant->lease.mode.granted != CHIMERA_VFS_LEASE_MODE_R) {
+                            /* W (write cache) is exclusive across lease keys; a
+                             * conflicting holder forces it off but R+H stay shared.
+                             * Drop only W first (-> R|H), then -- if R|H itself is
+                             * still hard-denied (a cross-client handle conflict) --
+                             * step down to R; give up only when even R is
+                             * unobtainable and we are not merely awaiting a break. */
+                            if (grant->lease.mode.granted & CHIMERA_VFS_LEASE_MODE_W) {
+                                grant->lease.mode.granted &= ~CHIMERA_VFS_LEASE_MODE_W;
+                            } else if (grant->lease.mode.granted !=
+                                       CHIMERA_VFS_LEASE_MODE_R &&
+                                       result == CHIMERA_VFS_LEASE_DENIED) {
                                 grant->lease.mode.granted = CHIMERA_VFS_LEASE_MODE_R;
                             } else if (result != CHIMERA_VFS_LEASE_BREAKING) {
                                 break;

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -776,154 +776,162 @@ chimera_smb_create_after_share(
          * durable handle (MS-SMB2).  The caching_touches_data gate only governs
          * the implicit legacy-oplock path, where an attribute probe must not
          * acquire an oplock. */
-        if (req_vfs != 0 && (caching_touches_data || via_rqls) && backend_copy_safe) {
+        /* A caching lease (oplock / SMB2 lease) lives in a VFS-owned, owner-keyed,
+         * refcounted grant.  Opens by one client under one lease key (RqLs) COALESCE
+         * onto a single grant; legacy oplocks are keyed by file id and so are always
+         * sole members.  We ENTER this block for EVERY RqLs open -- even one that
+         * requests no caching bits -- so a re-open under an existing lease key joins
+         * (and never downgrades) the shared lease (MS-SMB2 3.3.5.9.8: a lease is not
+         * reduced by a subsequent open).  A *fresh* grant is created only when the
+         * open warrants caching (real bits, on a copy-safe backend). */
+        bool want_fresh_caching =
+            (req_vfs != 0 && (caching_touches_data || via_rqls) && backend_copy_safe);
+
+        if (via_rqls || want_fresh_caching) {
             file_state = chimera_vfs_state_get(vfs_state,
                                                oh->fh, oh->fh_len,
                                                oh->fh_hash, true);
             if (file_state) {
-                /* The caching lease lives in a VFS-owned grant (refcounted,
-                 * owner-keyed) rather than embedded in the open_file.  In this
-                 * phase each open allocates its own grant (no cross-open
-                 * coalescing yet); the embedded lease's old settle-loop runs
-                 * unchanged on &grant->lease. */
-                struct chimera_vfs_caching_grant *grant = calloc(1, sizeof(*grant));
+                struct chimera_vfs_caching_grant *grant = NULL;
+                struct chimera_vfs_lease_owner    owner;
+                struct chimera_vfs_lease_mode     want;
 
-                if (!grant) {
-                    chimera_vfs_state_put(vfs_state, file_state);
-                    open_file->lease_state  = 0;
-                    open_file->oplock_level = SMB2_OPLOCK_LEVEL_NONE;
+                memset(&owner, 0, sizeof(owner));
+                owner.protocol   = CHIMERA_VFS_LEASE_PROTO_SMB2;
+                owner.client_key = request->session_handle->session->session_id;
+                /* vfs_state invokes this to notify the client when another acquirer
+                 * needs the lease; the callback resolves the grant from lease->grant
+                 * and picks a live member to deliver the OPLOCK_BREAK on. */
+                owner.break_cb = chimera_smb_lease_break_cb;
+                /* Anchor to THIS open's VFS handle so a setattr through the same
+                 * handle does not recall the lease against itself.  A coalesced
+                 * second open keeps the first open's handle; that per-open self-skip
+                 * is then conservative, not load-bearing. */
+                owner.op_handle = oh;
+                if (via_rqls) {
+                    /* RqLs: owner identity is the lease key, so same-key opens by
+                     * one client coalesce (the Samba locking.tdb rule). */
+                    memcpy(&owner.owner_lo, request->create.rqls.key, 8);
+                    memcpy(&owner.owner_hi, request->create.rqls.key + 8, 8);
+                    /* Mirror the lease_key onto the open_file for the break
+                     * notification builder and the lease-key resolver. */
+                    memcpy(open_file->lease_key, request->create.rqls.key, 16);
+                    if (request->create.rqls.is_v2) {
+                        memcpy(open_file->parent_lease_key,
+                               request->create.rqls.parent_key, 16);
+                    }
                 } else {
-                    grant->file                   = file_state;
-                    grant->refcount               = 1;
-                    grant->epoch                  = 1;
-                    grant->lease.grant            = grant;
-                    grant->lease.kind             = CHIMERA_VFS_LEASE_CACHING;
-                    grant->lease.mode.granted     = req_vfs;
-                    grant->lease.owner.protocol   = CHIMERA_VFS_LEASE_PROTO_SMB2;
-                    grant->lease.owner.client_key = request->session_handle->session->session_id;
-                    /* For RqLs, owner identity is the lease_key (so multiple
-                     * opens with the same key by the same client coalesce —
-                     * the Samba locking.tdb rule).  For legacy oplocks,
-                     * each open is its own owner (use file_id). */
+                    /* Legacy oplock: each open is its own owner (file id). */
+                    owner.owner_lo = open_file->file_id.pid;
+                    owner.owner_hi = open_file->file_id.vid;
+                }
+                open_file->create_conn = request->compound->conn;
+
+                want.granted = req_vfs;
+                want.denied  = 0;
+
+                /* First coalesce onto an existing same-owner grant: refcount + a
+                 * conflict-free in-place upgrade, never a downgrade.  This is what a
+                 * lease re-open does -- including one requesting fewer/no bits, which
+                 * keeps the lease at its current state (3.3.5.9.8). */
+                grant = chimera_vfs_caching_grant_coalesce(file_state, &owner,
+                                                           want, 1 /*upgrade_ok*/);
+                if (grant) {
+                    /* Joined a live grant (it already has member(s)): registering
+                     * this open cannot race a memberless break. */
+                    chimera_smb_grant_add_member(grant, open_file);
+                } else if (want_fresh_caching) {
+                    /* No existing grant: create one and arbitrate against other
+                     * owners, stepping W|H -> R on conflict (the sole-access rule,
+                     * or a holder still mid-downgrade) until a shared read cache is
+                     * grantable.  Reuse the one grant across retries so a kicked-off
+                     * break is not restarted with the wrong needed-mode. */
+                    grant = calloc(1, sizeof(*grant));
+                    if (grant) {
+                        int settle_guard = 6;
+
+                        grant->file     = file_state;
+                        grant->refcount = 1;
+                        /* The grant owns the epoch so coalesced opens and breaks
+                         * share one counter; a v2 lease is granted at the client's
+                         * epoch + 1 (1 for a brand-new lease, 3.3.5.9.11). */
+                        grant->epoch =
+                            (via_rqls && request->create.rqls.is_v2)
+                            ? request->create.rqls.epoch + 1 : 1;
+                        grant->lease.grant            = grant;
+                        grant->lease.kind             = CHIMERA_VFS_LEASE_CACHING;
+                        grant->lease.mode             = want;
+                        grant->lease.owner            = owner;
+                        grant->lease.owner.cb_private = grant;
+
+                        /* Register the member BEFORE the lease becomes visible
+                         * (try_insert links it onto caching_leases): once linked a
+                         * conflicting acquirer can fire the break callback, which
+                         * must find a live member or it revokes the fresh lease. */
+                        chimera_smb_grant_add_member(grant, open_file);
+
+                        result = chimera_vfs_state_try_insert(vfs_state, file_state,
+                                                              &grant->lease, &conflict);
+                        while (result != CHIMERA_VFS_LEASE_GRANTED &&
+                               settle_guard-- > 0) {
+                            if (grant->lease.mode.granted != CHIMERA_VFS_LEASE_MODE_R) {
+                                grant->lease.mode.granted = CHIMERA_VFS_LEASE_MODE_R;
+                            } else if (result != CHIMERA_VFS_LEASE_BREAKING) {
+                                break;
+                            }
+                            result = chimera_vfs_state_try_insert(
+                                vfs_state, file_state, &grant->lease, &conflict);
+                        }
+
+                        if (result == CHIMERA_VFS_LEASE_GRANTED) {
+                            /* Link into the owner index so later same-key opens
+                             * coalesce onto this grant. */
+                            chimera_vfs_caching_grant_link(file_state, grant);
+                        } else {
+                            /* try_insert never linked the lease; drop the member and
+                             * free the grant. */
+                            chimera_smb_grant_remove_member(grant, open_file);
+                            free(grant);
+                            grant = NULL;
+                        }
+                    }
+                }
+
+                if (grant) {
+                    uint8_t granted_vfs = grant->lease.mode.granted;
+
+                    open_file->grant                  = grant;
+                    open_file->caching_file_state     = file_state;
+                    open_file->caching_lease_inserted = true;
+                    /* Report the grant's ACTUAL granted mode: a coalesced open
+                     * inherits the shared lease's current state (an upgrade may have
+                     * widened it; a conflicting peer may have capped it). */
+                    open_file->lease_state =
+                        chimera_smb_vfs_to_lease_bits(granted_vfs);
                     if (via_rqls) {
-                        memcpy(&grant->lease.owner.owner_lo,
-                               request->create.rqls.key, 8);
-                        memcpy(&grant->lease.owner.owner_hi,
-                               request->create.rqls.key + 8, 8);
-                        /* Mirror the lease_key onto the open_file for the
-                         * break notification builder. */
-                        memcpy(open_file->lease_key, request->create.rqls.key, 16);
+                        open_file->oplock_level = SMB2_OPLOCK_LEVEL_LEASE;
                         if (request->create.rqls.is_v2) {
-                            memcpy(open_file->parent_lease_key,
-                                   request->create.rqls.parent_key, 16);
-                            /* MS-SMB2 3.3.5.9.11: granting (or changing) a lease
-                             * increments its epoch; a freshly granted lease returns
-                             * the client's epoch + 1 (1 for a new lease). */
+                            open_file->lease_epoch = grant->epoch;
+                        }
+                    } else {
+                        open_file->oplock_level =
+                            chimera_smb_vfs_to_oplock_level(granted_vfs);
+                    }
+                } else {
+                    /* No caching grant taken.  A bare RqLs lease is still a lease
+                     * (report OPLOCK_LEVEL_LEASE and echo key/epoch in the response);
+                     * a legacy open with no oplock keeps its NONE defaults. */
+                    chimera_vfs_state_put(vfs_state, file_state);
+                    file_state = NULL;
+                    if (via_rqls) {
+                        if (request->create.rqls.is_v2) {
                             open_file->lease_epoch = request->create.rqls.epoch + 1;
                         }
-                    } else {
-                        grant->lease.owner.owner_lo = open_file->file_id.pid;
-                        grant->lease.owner.owner_hi = open_file->file_id.vid;
-                    }
-                    /* Wire the break callback so vfs_state can notify the client
-                     * when another acquirer needs this lease.  cb_private is the
-                     * GRANT (not this open): the grant may be shared by, and
-                     * outlive, the open that created it, so the break callback
-                     * resolves a live member from grant->holders rather than
-                     * dereferencing a single open that may already be gone. */
-                    grant->lease.owner.break_cb   = chimera_smb_lease_break_cb;
-                    grant->lease.owner.cb_private = grant;
-                    /* Anchor the lease to this open's VFS handle so a setattr issued
-                     * through the same handle (e.g. SetEndOfFile) does not recall
-                     * this lease against itself -- the holder is coherent with its
-                     * own change (chimera_vfs_break_caching_file skip_handle). */
-                    grant->lease.owner.op_handle = oh;
-                    open_file->create_conn       = request->compound->conn;
-
-                    /* Register this open as a grant member BEFORE the lease becomes
-                     * visible (try_insert links it onto caching_leases): once linked,
-                     * a conflicting acquirer can invoke the break callback, which
-                     * must find a live member or it will revoke the fresh lease. */
-                    chimera_smb_grant_add_member(grant, open_file);
-
-                    result = chimera_vfs_state_try_insert(vfs_state, file_state,
-                                                          &grant->lease,
-                                                          &conflict);
-
-                    /* Settle on the strongest caching lease actually grantable.
-                     * A conflict has two flavors:
-                     *   - BREAKING: try_insert kicked off a holder's break.  The
-                     *     break is optimistic (the holder downgrades to a shared
-                     *     read immediately), so simply retrying the SAME mode now
-                     *     usually succeeds; if it still conflicts we step down.
-                     *   - DENIED: an exclusive/batch grant is refused because
-                     *     another client has the file open (sole-access rule) or a
-                     *     holder is mid-downgrade; step the request down to a shared
-                     *     read (LEVEL_II), which coexists.
-                     * Loop, stepping W|H -> R, until granted or nothing is left to
-                     * try.  Bounded by the W->R step plus a few optimistic-break
-                     * retries. */
-                    int settle_guard = 6;
-                    while (result != CHIMERA_VFS_LEASE_GRANTED && settle_guard-- > 0) {
-                        if (req_vfs != CHIMERA_VFS_LEASE_MODE_R) {
-                            req_vfs = CHIMERA_VFS_LEASE_MODE_R;
-                        } else if (result != CHIMERA_VFS_LEASE_BREAKING) {
-                            /* Already at R and not merely waiting on an optimistic
-                             * break -- a shared read cache is unobtainable. */
-                            break;
-                        }
-                        grant->lease.mode.granted = req_vfs;
-                        result                    = chimera_vfs_state_try_insert(vfs_state, file_state,
-                                                                                 &grant->lease,
-                                                                                 &conflict);
-                    }
-
-                    if (result == CHIMERA_VFS_LEASE_GRANTED) {
-                        open_file->grant                  = grant;
-                        open_file->caching_file_state     = file_state;
-                        open_file->caching_lease_inserted = true;
-                        /* Record granted SMB-side state on the open_file via the
-                         * canonical encoders (smb_internal.h): lease_state holds the
-                         * SMB lease bits the response emitter wants; oplock_level is
-                         * the legacy collapse of the granted RWH for a non-RqLs open. */
-                        open_file->lease_state = chimera_smb_vfs_to_lease_bits(req_vfs);
-                        if (via_rqls) {
-                            open_file->oplock_level = SMB2_OPLOCK_LEVEL_LEASE;
-                        } else {
-                            open_file->oplock_level = chimera_smb_vfs_to_oplock_level(req_vfs);
-                        }
-                    } else {
-                        /* try_insert never linked the lease on a non-GRANTED
-                         * result, so the grant just frees -- unregister the member
-                         * first (it was added before the insert attempt). */
-                        chimera_smb_grant_remove_member(grant, open_file);
-                        free(grant);
-                        chimera_vfs_state_put(vfs_state, file_state);
                         open_file->lease_state  = 0;
-                        open_file->oplock_level = SMB2_OPLOCK_LEVEL_NONE;
+                        open_file->oplock_level = SMB2_OPLOCK_LEVEL_LEASE;
                     }
                 }
             }
-        } else {
-            if (via_rqls) {
-                /* A lease was requested with no caching bits (LEASE_NONE). It
-                 * is still a lease: report OPLOCK_LEVEL_LEASE and echo the
-                 * lease key / epoch in the response context, but acquire no
-                 * caching lease in vfs_state. */
-                memcpy(open_file->lease_key, request->create.rqls.key, 16);
-                if (request->create.rqls.is_v2) {
-                    memcpy(open_file->parent_lease_key,
-                           request->create.rqls.parent_key, 16);
-                    open_file->lease_epoch = request->create.rqls.epoch + 1;
-                }
-                open_file->lease_state  = 0;
-                open_file->oplock_level = SMB2_OPLOCK_LEVEL_LEASE;
-            }
-
-            /* Any oplock this open needed to break was already broken by the
-             * two-phase break-on-open above (which runs whether or not this
-             * open requests a lease of its own), so there is nothing more to
-             * do for an open that takes no caching lease. */
         }
     }
 

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -292,13 +292,13 @@ chimera_smb_create_gen_open_file(
      * otherwise it drops to LEVEL_II.  Pure attribute/EA opens break nothing
      * (stat-open).  No-op on the first open; skips the opener's own lease. */
     if (type == CHIMERA_SMB_OPEN_FILE_TYPE_FILE && tree->share && oh) {
-        uint32_t da   = open_file->desired_access;
-        uint32_t disp = request->create.create_disposition;
+        uint32_t da        = open_file->desired_access;
+        uint32_t disp      = request->create.create_disposition;
         bool     truncates =
             disp == SMB2_FILE_OVERWRITE ||
             disp == SMB2_FILE_OVERWRITE_IF ||
             disp == SMB2_FILE_SUPERSEDE;
-        bool break_trigger =
+        bool     break_trigger =
             (da & (SMB2_FILE_READ_DATA | SMB2_FILE_WRITE_DATA |
                    SMB2_FILE_APPEND_DATA | SMB2_FILE_EXECUTE |
                    SMB2_GENERIC_READ | SMB2_GENERIC_WRITE |
@@ -529,10 +529,10 @@ chimera_smb_create_gen_open_file(
     if (type == CHIMERA_SMB_OPEN_FILE_TYPE_FILE && oh) {
         struct chimera_vfs_state      *vfs_state = thread->vfs_thread->vfs->vfs_state;
         struct chimera_vfs_file_state *file_state;
-        uint8_t                        req_smb         = 0;
-        uint8_t                        req_vfs         = 0;
-        bool                           via_rqls        = false;
-        struct chimera_vfs_lease      *conflict        = NULL;
+        uint8_t                        req_smb  = 0;
+        uint8_t                        req_vfs  = 0;
+        bool                           via_rqls = false;
+        struct chimera_vfs_lease      *conflict = NULL;
         enum chimera_vfs_lease_result  result;
 
         if (request->create.ctx_present_mask & CHIMERA_SMB_CREATE_CTX_RQLS) {
@@ -559,23 +559,23 @@ chimera_smb_create_gen_open_file(
         }
 
         /* SMB lease bits use R=0x01, H=0x02, W=0x04 — a different layout from
-        * vfs_state's R/W/H mask, so map field-by-field.  We grant the full
-        * requested set: read caching (R → LEVEL_II), write caching
-        * (W → EXCLUSIVE) and handle caching (H → BATCH).  The vfs_state
-        * conflict matrix keeps W single-writer-exclusive and H
-        * single-holder-exclusive, and the SMB layer breaks holders when a
-        * conflicting open / write / byte-range-lock / delete arrives.
-        *
-        * The two coherence hazards that previously forced a read-only policy
-        * (W and H withheld) are now handled in the break path rather than by
-        * withholding the cache:
-        *   - delete-of-open-file: unlink / rename / delete-on-close break the
-        *     H (handle-caching) holder so its deferred-close handle is recalled
-        *     before the remove (smb_proc_close.c / set_info / rename) — fixes
-        *     the old cthon op_unlk EBUSY.
-        *   - server-side copy: COPYCHUNK breaks the source's caching lease to
-        *     force a flush before it reads (smb_proc_copychunk.c) — fixes the
-        *     old fsx READ BAD DATA. */
+         * vfs_state's R/W/H mask, so map field-by-field.  We grant the full
+         * requested set: read caching (R → LEVEL_II), write caching
+         * (W → EXCLUSIVE) and handle caching (H → BATCH).  The vfs_state
+         * conflict matrix keeps W single-writer-exclusive and H
+         * single-holder-exclusive, and the SMB layer breaks holders when a
+         * conflicting open / write / byte-range-lock / delete arrives.
+         *
+         * The two coherence hazards that previously forced a read-only policy
+         * (W and H withheld) are now handled in the break path rather than by
+         * withholding the cache:
+         *   - delete-of-open-file: unlink / rename / delete-on-close break the
+         *     H (handle-caching) holder so its deferred-close handle is recalled
+         *     before the remove (smb_proc_close.c / set_info / rename) — fixes
+         *     the old cthon op_unlk EBUSY.
+         *   - server-side copy: COPYCHUNK breaks the source's caching lease to
+         *     force a flush before it reads (smb_proc_copychunk.c) — fixes the
+         *     old fsx READ BAD DATA. */
         if (req_smb & SMB2_LEASE_READ_CACHING) {
             req_vfs |= CHIMERA_VFS_LEASE_MODE_R;
         }
@@ -668,20 +668,28 @@ chimera_smb_create_gen_open_file(
                                                       &open_file->caching_lease,
                                                       &conflict);
 
-                /* Another handle already holds a caching oplock/lease.  We
-                 * cannot keep an exclusive/write cache, but we can settle for a
-                 * shared read lease, which coexists with the (now downgraded)
-                 * holder -- this is how a 2nd open ends up with LEVEL_II.
-                 *   - BREAKING: try_insert just kicked off the holder's break.
-                 *   - DENIED: the holder was already broken to a shared read by
-                 *     the break-on-open above (its lease is ACKED, no longer
-                 *     IDLE-breakable), so a write cache is refused; a read cache
-                 *     still coexists.
-                 * Either way, retry for read-only caching (LEVEL_II). */
-                if ((result == CHIMERA_VFS_LEASE_BREAKING ||
-                     result == CHIMERA_VFS_LEASE_DENIED) &&
-                    req_vfs != CHIMERA_VFS_LEASE_MODE_R) {
-                    req_vfs                               = CHIMERA_VFS_LEASE_MODE_R;
+                /* Settle on the strongest caching lease actually grantable.
+                 * A conflict has two flavors:
+                 *   - BREAKING: try_insert kicked off a holder's break.  The
+                 *     break is optimistic (the holder downgrades to a shared
+                 *     read immediately), so simply retrying the SAME mode now
+                 *     usually succeeds; if it still conflicts we step down.
+                 *   - DENIED: an exclusive/batch grant is refused because
+                 *     another client has the file open (sole-access rule) or a
+                 *     holder is mid-downgrade; step the request down to a shared
+                 *     read (LEVEL_II), which coexists.
+                 * Loop, stepping W|H -> R, until granted or nothing is left to
+                 * try.  Bounded by the W->R step plus a few optimistic-break
+                 * retries. */
+                int settle_guard = 6;
+                while (result != CHIMERA_VFS_LEASE_GRANTED && settle_guard-- > 0) {
+                    if (req_vfs != CHIMERA_VFS_LEASE_MODE_R) {
+                        req_vfs = CHIMERA_VFS_LEASE_MODE_R;
+                    } else if (result != CHIMERA_VFS_LEASE_BREAKING) {
+                        /* Already at R and not merely waiting on an optimistic
+                         * break -- a shared read cache is unobtainable. */
+                        break;
+                    }
                     open_file->caching_lease.mode.granted = req_vfs;
                     result                                = chimera_vfs_state_try_insert(vfs_state, file_state,
                                                                                          &open_file->caching_lease,
@@ -760,7 +768,7 @@ chimera_smb_create_gen_open_file(
                     .owner_lo   = open_file->file_id.pid,
                     .owner_hi   = open_file->file_id.vid,
                 };
-                bool truncates =
+                bool                           truncates =
                     request->create.create_disposition == SMB2_FILE_OVERWRITE ||
                     request->create.create_disposition == SMB2_FILE_OVERWRITE_IF ||
                     request->create.create_disposition == SMB2_FILE_SUPERSEDE;

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -315,10 +315,14 @@ chimera_smb_create_break_for_open(
         chimera_vfs_state_break_on_write(vfs_state, oh->fh, oh->fh_len,
                                          oh->fh_hash, &io_owner);
     } else {
-        /* A conflicting open invalidates the (exclusive) write cache of other
-         * holders, but read + handle caching stay shared: break W-holders down to
-         * R|H, not R.  For a legacy oplock R|H still collapses to LEVEL_II (no
-         * separate handle bit), so this only widens what a lease holder keeps. */
+        /* A conflicting (non-truncating) open invalidates the (exclusive) write
+         * cache of other holders, but read + handle caching stay shared: break
+         * W-holders down to R|H, not R (MS-SMB2 / smb2.lease.v2_epoch2: a plain
+         * OPEN against an RWH lease yields a single RWH->RH break and the holder
+         * keeps RH).  A holder cascades below RH only when an actual write or a
+         * truncating open follows (chimera_vfs_break_on_write deepens the floor
+         * to NONE; smb2.lease.breaking3).  For a legacy oplock R|H collapses to
+         * LEVEL_II. */
         chimera_vfs_state_break_caching_for_open(
             vfs_state, oh->fh, oh->fh_len, oh->fh_hash, &io_owner,
             CHIMERA_VFS_LEASE_MODE_W,

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -729,15 +729,7 @@ chimera_smb_create_after_share(
          *   - server-side copy: COPYCHUNK breaks the source's caching lease to
          *     force a flush before it reads (smb_proc_copychunk.c) — fixes the
          *     old fsx READ BAD DATA. */
-        if (req_smb & SMB2_LEASE_READ_CACHING) {
-            req_vfs |= CHIMERA_VFS_LEASE_MODE_R;
-        }
-        if (req_smb & SMB2_LEASE_HANDLE_CACHING) {
-            req_vfs |= CHIMERA_VFS_LEASE_MODE_H;
-        }
-        if (req_smb & SMB2_LEASE_WRITE_CACHING) {
-            req_vfs |= CHIMERA_VFS_LEASE_MODE_W;
-        }
+        req_vfs = chimera_smb_lease_bits_to_vfs(req_smb);
 
         /* Oplocks are about data caching: an attribute-only open (no
          * read/write/execute data access) neither acquires nor breaks an
@@ -857,37 +849,15 @@ chimera_smb_create_after_share(
                 if (result == CHIMERA_VFS_LEASE_GRANTED) {
                     open_file->caching_file_state     = file_state;
                     open_file->caching_lease_inserted = true;
-                    /* Record granted SMB-side state on the open_file.
-                     * lease_state stores the SMB lease bits, which is
-                     * what the response context emitter wants. */
-                    open_file->lease_state = 0;
-                    if (req_vfs & CHIMERA_VFS_LEASE_MODE_R) {
-                        open_file->lease_state |= SMB2_LEASE_READ_CACHING;
-                    }
-                    if (req_vfs & CHIMERA_VFS_LEASE_MODE_H) {
-                        open_file->lease_state |= SMB2_LEASE_HANDLE_CACHING;
-                    }
-                    if (req_vfs & CHIMERA_VFS_LEASE_MODE_W) {
-                        open_file->lease_state |= SMB2_LEASE_WRITE_CACHING;
-                    }
+                    /* Record granted SMB-side state on the open_file via the
+                     * canonical encoders (smb_internal.h): lease_state holds the
+                     * SMB lease bits the response emitter wants; oplock_level is
+                     * the legacy collapse of the granted RWH for a non-RqLs open. */
+                    open_file->lease_state = chimera_smb_vfs_to_lease_bits(req_vfs);
                     if (via_rqls) {
                         open_file->oplock_level = SMB2_OPLOCK_LEVEL_LEASE;
                     } else {
-                        /* Translate granted RWH back to legacy oplock
-                         * level.  Without H, the closest legacy match
-                         * is EXCLUSIVE for RW or II for R only. */
-                        if ((req_vfs & (CHIMERA_VFS_LEASE_MODE_R |
-                                        CHIMERA_VFS_LEASE_MODE_W |
-                                        CHIMERA_VFS_LEASE_MODE_H)) ==
-                            (CHIMERA_VFS_LEASE_MODE_R |
-                             CHIMERA_VFS_LEASE_MODE_W |
-                             CHIMERA_VFS_LEASE_MODE_H)) {
-                            open_file->oplock_level = SMB2_OPLOCK_LEVEL_BATCH;
-                        } else if (req_vfs & CHIMERA_VFS_LEASE_MODE_W) {
-                            open_file->oplock_level = SMB2_OPLOCK_LEVEL_EXCLUSIVE;
-                        } else {
-                            open_file->oplock_level = SMB2_OPLOCK_LEVEL_II;
-                        }
+                        open_file->oplock_level = chimera_smb_vfs_to_oplock_level(req_vfs);
                     }
                 } else {
                     chimera_vfs_state_put(vfs_state, file_state);

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -535,6 +535,50 @@ chimera_smb_create_gen_open_file(
         struct chimera_vfs_lease      *conflict = NULL;
         enum chimera_vfs_lease_result  result;
 
+        /* Phase 2 of the conflicting-open oplock break.  Phase 1 (the batch /
+         * handle-caching break that must precede the share-mode check) already
+         * ran before the share reservation above.  Now that this open is
+         * granted, break a conflicting *exclusive* (W-only) holder down to
+         * LEVEL_II; a truncating open replaces the data, so it instead
+         * invalidates every cached holder all the way to NONE.  This fires
+         * whether or not this open requests an oplock of its own (so it covers
+         * a plain reader / writer that takes no lease), and is a no-op when
+         * there is no conflicting holder or only the opener's own. */
+        {
+            uint32_t da        = open_file->desired_access;
+            uint32_t disp      = request->create.create_disposition;
+            bool     truncates =
+                disp == SMB2_FILE_OVERWRITE ||
+                disp == SMB2_FILE_OVERWRITE_IF ||
+                disp == SMB2_FILE_SUPERSEDE;
+            bool     break_trigger =
+                (da & (SMB2_FILE_READ_DATA | SMB2_FILE_WRITE_DATA |
+                       SMB2_FILE_APPEND_DATA | SMB2_FILE_EXECUTE |
+                       SMB2_GENERIC_READ | SMB2_GENERIC_WRITE |
+                       SMB2_GENERIC_EXECUTE | SMB2_GENERIC_ALL |
+                       SMB2_MAXIMUM_ALLOWED | SMB2_DELETE)) ||
+                (request->create.create_options & SMB2_FILE_DELETE_ON_CLOSE) ||
+                truncates;
+
+            if (break_trigger) {
+                struct chimera_vfs_lease_owner io_owner = {
+                    .protocol   = CHIMERA_VFS_LEASE_PROTO_SMB2,
+                    .client_key = request->session_handle->session->session_id,
+                    .owner_lo   = open_file->file_id.pid,
+                    .owner_hi   = open_file->file_id.vid,
+                };
+
+                if (truncates) {
+                    chimera_vfs_state_break_on_write(vfs_state, oh->fh, oh->fh_len,
+                                                     oh->fh_hash, &io_owner);
+                } else {
+                    chimera_vfs_state_break_caching_for_open(
+                        vfs_state, oh->fh, oh->fh_len, oh->fh_hash, &io_owner,
+                        CHIMERA_VFS_LEASE_MODE_W, CHIMERA_VFS_LEASE_MODE_R);
+                }
+            }
+        }
+
         if (request->create.ctx_present_mask & CHIMERA_SMB_CREATE_CTX_RQLS) {
             via_rqls = true;
             req_smb  = (uint8_t) (request->create.rqls.state & 0x07);
@@ -753,36 +797,10 @@ chimera_smb_create_gen_open_file(
                 open_file->oplock_level = SMB2_OPLOCK_LEVEL_LEASE;
             }
 
-            /* The open has now been granted (it passed the share-mode check
-             * above).  Break a conflicting *exclusive* (W) holder: unlike a
-             * batch holder (already handled before the share check), an
-             * exclusive oplock breaks only once the conflicting open succeeds.
-             * A truncating open invalidates all cached data (break to NONE);
-             * any other data/delete open downgrades the holder to LEVEL_II.  A
-             * pure attribute/EA open (not caching_touches_data) breaks
-             * nothing.  Skips the opener's own lease (distinct owner). */
-            if (caching_touches_data) {
-                struct chimera_vfs_lease_owner io_owner = {
-                    .protocol   = CHIMERA_VFS_LEASE_PROTO_SMB2,
-                    .client_key = request->session_handle->session->session_id,
-                    .owner_lo   = open_file->file_id.pid,
-                    .owner_hi   = open_file->file_id.vid,
-                };
-                bool                           truncates =
-                    request->create.create_disposition == SMB2_FILE_OVERWRITE ||
-                    request->create.create_disposition == SMB2_FILE_OVERWRITE_IF ||
-                    request->create.create_disposition == SMB2_FILE_SUPERSEDE;
-
-                if (truncates) {
-                    chimera_vfs_state_break_on_write(vfs_state, oh->fh, oh->fh_len,
-                                                     oh->fh_hash, &io_owner);
-                } else {
-                    chimera_vfs_state_break_caching_for_open(
-                        vfs_state, oh->fh, oh->fh_len, oh->fh_hash, &io_owner,
-                        CHIMERA_VFS_LEASE_MODE_W | CHIMERA_VFS_LEASE_MODE_H,
-                        CHIMERA_VFS_LEASE_MODE_R);
-                }
-            }
+            /* Any oplock this open needed to break was already broken by the
+             * two-phase break-on-open above (which runs whether or not this
+             * open requests a lease of its own), so there is nothing more to
+             * do for an open that takes no caching lease. */
         }
     }
 

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -202,6 +202,39 @@ chimera_smb_app_instance_force_close(
     return true;
 } /* chimera_smb_app_instance_force_close */
 
+/* Finish an open once its share reservation is held (or not required): acquire
+ * the caching (oplock/lease) grant, propagate delete-on-close, grant the durable
+ * handle, and register the open in the tree.  Split out of gen_open_file so the
+ * share acquire can be made asynchronous (parking on a batch-oplock break)
+ * without duplicating this tail.  Always succeeds (the caching grant is
+ * opportunistic); returns open_file. */
+static struct chimera_smb_open_file *
+chimera_smb_create_after_share(
+    struct chimera_smb_request   *request,
+    struct chimera_smb_open_file *open_file);
+
+static void
+chimera_smb_create_open_finish(
+    struct chimera_smb_request   *request,
+    struct chimera_smb_open_file *open_file);
+
+/* Apply the held (post-truncate-downgrade) share grant and mark the reservation
+ * inserted; shared by the synchronous and parked share-acquire paths. */
+static inline void
+chimera_smb_create_finish_share_grant(
+    struct chimera_smb_open_file  *open_file,
+    struct chimera_vfs_file_state *file_state,
+    uint8_t                        held_granted);
+
+/* Resume a parked share acquire once the conflicting batch oplock has been
+ * relinquished (GRANTED -> finish the open) or kept (DENIED -> SHARING_VIOLATION). */
+static void
+chimera_smb_create_share_park_cb(
+    enum chimera_vfs_lease_result result,
+    struct chimera_vfs_lease     *lease,
+    struct chimera_vfs_lease     *conflict,
+    void                         *private_data);
+
 static inline struct chimera_smb_open_file *
 chimera_smb_create_gen_open_file(
     struct chimera_smb_request     *request,
@@ -213,13 +246,13 @@ chimera_smb_create_gen_open_file(
     const char                     *name,
     int                             name_len,
     int                             delete_on_close,
+    int                             is_directory,
     struct chimera_vfs_open_handle *oh)
 {
     struct chimera_smb_compound      *compound = request->compound;
     struct chimera_server_smb_thread *thread   = compound->thread;
     struct chimera_smb_tree          *tree     = request->tree;
     struct chimera_smb_open_file     *open_file;
-    uint64_t                          open_file_bucket;
 
     open_file = chimera_smb_open_file_alloc(thread);
 
@@ -229,13 +262,20 @@ chimera_smb_create_gen_open_file(
         memcpy(open_file->parent_fh, parent_fh, parent_fh_len);
     }
 
-    open_file->parent_fh_len   = parent_fh_len;
-    open_file->file_id.pid     = pid;
-    open_file->file_id.vid     = chimera_rand64();
-    open_file->handle          = oh;
-    open_file->desired_access  = request->create.desired_access;
-    open_file->share_access    = request->create.share_access;
-    open_file->flags           = delete_on_close ? CHIMERA_SMB_OPEN_FILE_FLAG_DELETE_ON_CLOSE : 0;
+    open_file->parent_fh_len  = parent_fh_len;
+    open_file->file_id.pid    = pid;
+    open_file->file_id.vid    = chimera_rand64();
+    open_file->handle         = oh;
+    open_file->desired_access = request->create.desired_access;
+    open_file->share_access   = request->create.share_access;
+    open_file->flags          = delete_on_close ? CHIMERA_SMB_OPEN_FILE_FLAG_DELETE_ON_CLOSE : 0;
+    /* Set the directory flag up front so the caching-lease grant below can skip
+     * directories: a leased directory is recalled on every create/remove of a
+     * child (chimera_vfs_io_recall on the parent), which is a break round-trip
+     * per operation -- so directory opens take no oplock/lease. */
+    if (is_directory) {
+        open_file->flags |= CHIMERA_SMB_OPEN_FILE_FLAG_DIRECTORY;
+    }
     open_file->position        = 0;
     open_file->pipe_transceive = transceive;
     open_file->refcnt          = 2;
@@ -315,6 +355,17 @@ chimera_smb_create_gen_open_file(
                 .owner_lo   = open_file->file_id.pid,
                 .owner_hi   = open_file->file_id.vid,
             };
+
+            /* An RqLs open is owned by its lease key, not its file_id, and all of
+             * one client's opens of a file share that key.  Identify this opener
+             * by the lease key so break_caching_for_open recognises an existing
+             * lease held under the same key as the opener's own and coalesces
+             * (no self-break) -- a re-open by the lease holder must not recall
+             * its own lease (the dominant single-client churn source). */
+            if (request->create.ctx_present_mask & CHIMERA_SMB_CREATE_CTX_RQLS) {
+                memcpy(&io_owner.owner_lo, request->create.rqls.key, 8);
+                memcpy(&io_owner.owner_hi, request->create.rqls.key + 8, 8);
+            }
 
             chimera_vfs_state_break_caching_for_open(vfs_state, oh->fh, oh->fh_len,
                                                      oh->fh_hash, &io_owner,
@@ -409,8 +460,11 @@ chimera_smb_create_gen_open_file(
          * themselves. */
         open_file->share_lease.owner.owner_lo = open_file->file_id.pid;
         open_file->share_lease.owner.owner_hi = open_file->file_id.vid;
-        /* Back-reference to the owning open so a conflicting CREATE that carries a
-         * matching AppInstanceId can locate it for the force-close rule below. */
+        /* Back-reference to the owning open, used two ways: a conflicting CREATE
+         * carrying a matching AppInstanceId can locate it for the force-close rule
+         * below, and the lease layer can match it to this open's caching (batch)
+         * lease so a hard share conflict against a batch-oplock holder parks on the
+         * batch break rather than denying (chimera_vfs_share_batch_escape). */
         open_file->share_lease.owner.cb_private = open_file;
 
         /* If this open also requests a lease, a handle-caching lease already
@@ -501,6 +555,25 @@ chimera_smb_create_gen_open_file(
                                                     &open_file->share_lease, &conflict);
         }
 
+        if (result == CHIMERA_VFS_LEASE_BREAKING &&
+            request->create.gen_finish_cb) {
+            /* A batch (handle-caching) oplock holder is mid-break and may close
+             * its deferred handle, freeing this share conflict.  Park the open:
+             * lease_acquire re-probes and enqueues the ticket, resuming
+             * chimera_smb_create_share_park_cb when the holder closes (GRANTED)
+             * or merely acks while keeping the handle (DENIED -> SHARING_VIOLATION).
+             * The share_lease is not yet inserted, so lease_acquire owns it now. */
+            request->create.gen_parked_open  = open_file;
+            request->create.gen_parked_fs    = file_state;
+            request->create.gen_held_granted = held_granted;
+            request->create.gen_parked       = 1;
+            chimera_vfs_lease_acquire(vfs_state, file_state,
+                                      &open_file->share_lease,
+                                      &request->create.gen_ticket, true,
+                                      chimera_smb_create_share_park_cb, request);
+            return NULL;
+        }
+
         if (result != CHIMERA_VFS_LEASE_GRANTED) {
             chimera_vfs_state_put(vfs_state, file_state);
             open_file->handle = NULL;
@@ -508,17 +581,30 @@ chimera_smb_create_gen_open_file(
             return NULL;
         }
 
-        /* Drop the transient truncate-write grant: the handle holds only the
-         * access it requested, so it must not block a later reader. */
-        if (held_granted != granted) {
-            pthread_mutex_lock(&file_state->lock);
-            open_file->share_lease.mode.granted = held_granted;
-            pthread_mutex_unlock(&file_state->lock);
-        }
-
-        open_file->share_file_state     = file_state;
-        open_file->share_lease_inserted = true;
+        chimera_smb_create_finish_share_grant(open_file, file_state,
+                                              held_granted);
     }
+
+    return chimera_smb_create_after_share(request, open_file);
+} /* chimera_smb_create_gen_open_file */
+
+static struct chimera_smb_open_file *
+chimera_smb_create_after_share(
+    struct chimera_smb_request   *request,
+    struct chimera_smb_open_file *open_file)
+{
+    struct chimera_smb_compound      *compound        = request->compound;
+    struct chimera_server_smb_thread *thread          = compound->thread;
+    struct chimera_smb_tree          *tree            = request->tree;
+    enum chimera_smb_open_file_type   type            = open_file->type;
+    struct chimera_vfs_open_handle   *oh              = open_file->handle;
+    int                               delete_on_close =
+        (open_file->flags & CHIMERA_SMB_OPEN_FILE_FLAG_DELETE_ON_CLOSE) != 0;
+    const void                       *parent_fh     = open_file->parent_fh_len ? open_file->parent_fh : NULL;
+    int                               parent_fh_len = open_file->parent_fh_len;
+    const char                       *name          = open_file->name;
+    int                               name_len      = open_file->name_len;
+    uint64_t                          open_file_bucket;
 
     /* Acquire a CACHING lease (SMB2 lease via RqLs, or legacy oplock
      * via requested_oplock_level).  This is opportunistic — failure to
@@ -526,7 +612,8 @@ chimera_smb_create_gen_open_file(
      * resolved by vfs_state's conflict matrix; without break_cb wired
      * (next task in Stage D), conflicting other-client leases force
      * DENIED here, so we silently end up with no lease. */
-    if (type == CHIMERA_SMB_OPEN_FILE_TYPE_FILE && oh) {
+    if (type == CHIMERA_SMB_OPEN_FILE_TYPE_FILE && oh &&
+        !(open_file->flags & CHIMERA_SMB_OPEN_FILE_FLAG_DIRECTORY)) {
         struct chimera_vfs_state      *vfs_state = thread->vfs_thread->vfs->vfs_state;
         struct chimera_vfs_file_state *file_state;
         uint8_t                        req_smb  = 0;
@@ -571,6 +658,14 @@ chimera_smb_create_gen_open_file(
                     .owner_lo   = open_file->file_id.pid,
                     .owner_hi   = open_file->file_id.vid,
                 };
+
+                /* Identify an RqLs opener by its lease key so it coalesces with
+                 * (does not break) a lease this client already holds under the
+                 * same key (see the phase-1 break above). */
+                if (request->create.ctx_present_mask & CHIMERA_SMB_CREATE_CTX_RQLS) {
+                    memcpy(&io_owner.owner_lo, request->create.rqls.key, 8);
+                    memcpy(&io_owner.owner_hi, request->create.rqls.key + 8, 8);
+                }
 
                 if (truncates) {
                     chimera_vfs_state_break_on_write(vfs_state, oh->fh, oh->fh_len,
@@ -710,7 +805,12 @@ chimera_smb_create_gen_open_file(
                  * client when another acquirer needs this lease. */
                 open_file->caching_lease.owner.break_cb   = chimera_smb_lease_break_cb;
                 open_file->caching_lease.owner.cb_private = open_file;
-                open_file->create_conn                    = request->compound->conn;
+                /* Anchor the lease to this open's VFS handle so a setattr issued
+                 * through the same handle (e.g. SetEndOfFile) does not recall
+                 * this lease against itself -- the holder is coherent with its
+                 * own change (chimera_vfs_break_caching_file skip_handle). */
+                open_file->caching_lease.owner.op_handle = oh;
+                open_file->create_conn                   = request->compound->conn;
 
                 result = chimera_vfs_state_try_insert(vfs_state, file_state,
                                                       &open_file->caching_lease,
@@ -916,11 +1016,8 @@ chimera_smb_create_gen_open_file_normal(
                                                  parent_fh_len,
                                                  name,
                                                  name_len,
-                                                 delete_on_close, oh);
-
-    if (open_file && is_directory) {
-        open_file->flags |= CHIMERA_SMB_OPEN_FILE_FLAG_DIRECTORY;
-    }
+                                                 delete_on_close,
+                                                 is_directory, oh);
 
     return open_file;
 } /* chimera_smb_create_gen_open_file_normal */
@@ -941,6 +1038,7 @@ chimera_smb_create_gen_open_file_pipe(
                                             0,
                                             name,
                                             name_len,
+                                            0,
                                             0,
                                             NULL);
 } /* chimera_smb_create_gen_open_file_pipe */
@@ -964,6 +1062,64 @@ chimera_smb_create_release_parent(struct chimera_smb_request *request)
         request->create.parent_handle = NULL;
     }
 } /* chimera_smb_create_release_parent */
+
+static inline void
+chimera_smb_create_finish_share_grant(
+    struct chimera_smb_open_file  *open_file,
+    struct chimera_vfs_file_state *file_state,
+    uint8_t                        held_granted)
+{
+    /* Drop the transient truncate-write grant: the handle holds only the
+     * access it requested, so it must not block a later reader. */
+    if (held_granted != open_file->share_lease.mode.granted) {
+        pthread_mutex_lock(&file_state->lock);
+        open_file->share_lease.mode.granted = held_granted;
+        pthread_mutex_unlock(&file_state->lock);
+    }
+
+    open_file->share_file_state     = file_state;
+    open_file->share_lease_inserted = true;
+} /* chimera_smb_create_finish_share_grant */
+
+static void
+chimera_smb_create_share_park_cb(
+    enum chimera_vfs_lease_result result,
+    struct chimera_vfs_lease     *lease,
+    struct chimera_vfs_lease     *conflict,
+    void                         *private_data)
+{
+    struct chimera_smb_request       *request    = private_data;
+    struct chimera_server_smb_thread *thread     = request->compound->thread;
+    struct chimera_vfs_thread        *vfs_thread = thread->vfs_thread;
+    struct chimera_vfs_state         *vfs_state  = vfs_thread->vfs->vfs_state;
+    struct chimera_smb_open_file     *open_file  = request->create.gen_parked_open;
+    struct chimera_vfs_file_state    *file_state = request->create.gen_parked_fs;
+
+    (void) lease;
+    (void) conflict;
+
+    request->create.gen_parked = 0;
+
+    if (result == CHIMERA_VFS_LEASE_GRANTED) {
+        /* The batch holder closed; the share reservation is now held. */
+        chimera_smb_create_finish_share_grant(open_file, file_state,
+                                              request->create.gen_held_granted);
+        chimera_smb_create_after_share(request, open_file);
+        request->create.gen_finish_cb(request, open_file);
+        return;
+    }
+
+    /* DENIED: the holder acked its oplock but kept the handle open, so the
+     * share conflict stands. */
+    chimera_vfs_state_put(vfs_state, file_state);
+    if (open_file->handle) {
+        chimera_vfs_release(vfs_thread, open_file->handle);
+        open_file->handle = NULL;
+    }
+    chimera_smb_open_file_free(thread, open_file);
+    chimera_smb_create_release_parent(request);
+    chimera_smb_complete_request(request, SMB2_STATUS_SHARING_VIOLATION);
+} /* chimera_smb_create_share_park_cb */
 
 static inline uint32_t
 chimera_smb_create_granted_access(
@@ -1285,6 +1441,21 @@ chimera_smb_create_open_at_callback(
      * so the reply reports the correct Create Action. */
     request->create.r_created = oh ? oh->r_created : 0;
 
+    /* Compute the attr-derived results up front -- they do not depend on the
+     * share/oplock outcome, and `attr` is not available later if the open parks
+     * on a batch-oplock break (chimera_smb_create_share_park_cb resumes without
+     * it).  chimera_smb_create_open_finish applies them on the synchronous OR
+     * parked grant. */
+    request->create.r_is_directory   = S_ISDIR(attr->va_mode) ? 1 : 0;
+    request->create.r_granted_access = chimera_smb_create_granted_access(request, attr);
+    request->create.r_maximal_access =
+        chimera_vfs_access_check(attr, &request->session_handle->session->cred,
+                                 CHIMERA_ACE_MASK_ALL);
+    chimera_smb_marshal_attrs(attr, &request->create.r_attrs);
+    /* The park-on-batch-break activation (gen_finish_cb) is wired in the
+     * follow-up that adds the cross-thread resume bounce; until then the open
+     * resolves synchronously (a batch-share conflict yields SHARING_VIOLATION). */
+
     open_file = chimera_smb_create_gen_open_file_normal(request,
                                                         request->create.parent_handle->fh,
                                                         request->create.parent_handle->fh_len,
@@ -1294,6 +1465,11 @@ chimera_smb_create_open_at_callback(
                                                         S_ISDIR(attr->va_mode),
                                                         oh);
 
+    if (request->create.gen_parked) {
+        /* Parked on a batch-oplock break; the park cb finishes the open. */
+        return;
+    }
+
     if (!open_file) {
         chimera_smb_create_release_handle(vfs_thread, oh);
         chimera_smb_create_release_parent(request);
@@ -1301,16 +1477,22 @@ chimera_smb_create_open_at_callback(
         return;
     }
 
+    chimera_smb_create_open_finish(request, open_file);
+} /* chimera_smb_create_open_at_callback */
+
+/* Finish a regular-file open: apply the precomputed access masks, emit the
+ * parent-directory create notification, release the parent handle, and complete
+ * the request.  Invoked on a synchronous grant from open_at_callback and on a
+ * parked grant from chimera_smb_create_share_park_cb. */
+static void
+chimera_smb_create_open_finish(
+    struct chimera_smb_request   *request,
+    struct chimera_smb_open_file *open_file)
+{
     request->create.r_open_file = open_file;
 
-    open_file->granted_access = chimera_smb_create_granted_access(request, attr);
-    open_file->maximal_access =
-        chimera_vfs_access_check(attr, &request->session_handle->session->cred,
-                                 CHIMERA_ACE_MASK_ALL);
-
-    chimera_smb_marshal_attrs(
-        attr,
-        &request->create.r_attrs);
+    open_file->granted_access = request->create.r_granted_access;
+    open_file->maximal_access = request->create.r_maximal_access;
 
     /* Emit notification on parent directory for any disposition that can
      * create a new file.  OPEN never creates; CREATE always creates;
@@ -1330,7 +1512,7 @@ chimera_smb_create_open_at_callback(
         request->create.create_disposition == SMB2_FILE_OVERWRITE_IF  ||
         request->create.create_disposition == SMB2_FILE_SUPERSEDE) {
         struct chimera_server_smb_thread *thread = request->compound->thread;
-        uint32_t                          action = S_ISDIR(attr->va_mode) ?
+        uint32_t                          action = request->create.r_is_directory ?
             CHIMERA_VFS_NOTIFY_DIR_ADDED : CHIMERA_VFS_NOTIFY_FILE_ADDED;
 
         /* Creating/opening a (regular) file's data fork introduces its
@@ -1354,7 +1536,7 @@ chimera_smb_create_open_at_callback(
     chimera_smb_create_release_parent(request);
     chimera_smb_open_file_release(request, open_file);
     chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
-} /* chimera_smb_create_open_at_callback */
+} /* chimera_smb_create_open_finish */
 
 /*
  * Map the CREATE DesiredAccess to canonical access-mask bits and evaluate it
@@ -2262,6 +2444,11 @@ chimera_smb_create(struct chimera_smb_request *request)
 
     request->create.has_stream = 0;
     request->create.base_oh    = NULL;
+    /* Only the regular-file open path (open_at_callback) registers a finish
+     * callback and may park on a batch-oplock break; clear it so the mkdir /
+     * stream / pipe paths never inherit a stale callback and park. */
+    request->create.gen_finish_cb = NULL;
+    request->create.gen_parked    = 0;
 
     /* Handle stream-name syntax (file:stream[:$DATA]).  When named streams are
      * disabled (config off, or the backend lacks the capability) the legacy

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -289,7 +289,7 @@ chimera_smb_create_break_for_open(
     struct chimera_vfs_state      *vfs_state = thread->vfs_thread->vfs->vfs_state;
     struct chimera_vfs_lease_owner io_owner  = {
         .protocol   = CHIMERA_VFS_LEASE_PROTO_SMB2,
-        .client_key = request->session_handle->session->session_id,
+        .client_key = request->session_handle->session->client_key,
         .owner_lo   = open_file->file_id.pid,
         .owner_hi   = open_file->file_id.vid,
     };
@@ -521,7 +521,7 @@ chimera_smb_create_gen_open_file(
         open_file->share_lease.mode.granted     = granted;
         open_file->share_lease.mode.denied      = denied;
         open_file->share_lease.owner.protocol   = CHIMERA_VFS_LEASE_PROTO_SMB2;
-        open_file->share_lease.owner.client_key = request->session_handle->session->session_id;
+        open_file->share_lease.owner.client_key = request->session_handle->session->client_key;
         /* The open itself is the owner — different opens, even by the
          * same client, must satisfy share-mode constraints between
          * themselves. */
@@ -811,7 +811,7 @@ chimera_smb_create_after_share(
 
                 memset(&owner, 0, sizeof(owner));
                 owner.protocol   = CHIMERA_VFS_LEASE_PROTO_SMB2;
-                owner.client_key = request->session_handle->session->session_id;
+                owner.client_key = request->session_handle->session->client_key;
                 /* vfs_state invokes this to notify the client when another acquirer
                  * needs the lease; the callback resolves the grant from lease->grant
                  * and picks a live member to deliver the OPLOCK_BREAK on. */

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -1543,6 +1543,38 @@ chimera_smb_create_open_at_callback(
     chimera_smb_create_open_finish(request, open_file);
 } /* chimera_smb_create_open_at_callback */
 
+/* Break-deadline for a CREATE parked on a lease break (MS-SMB2 3.3.5.9 / the
+ * oplock-break timeout): the holder never acknowledged within the deadline, so
+ * forcibly revoke the still-breaking holder(s) and complete the pending open with
+ * its already-acquired lease.  Runs on the open's own conn thread (the timer is
+ * armed on that thread's evpl).  An ack that resumes the open first removes this
+ * timer. */
+static void
+chimera_smb_create_park_deadline_cb(
+    struct evpl       *evpl,
+    struct evpl_timer *timer)
+{
+    struct chimera_smb_request       *request = (struct chimera_smb_request *)
+        ((char *) timer - offsetof(struct chimera_smb_request, async.timer));
+    struct chimera_server_smb_thread *thread    = request->compound->thread;
+    struct chimera_vfs_state         *vfs_state =
+        thread->vfs_thread->vfs->vfs_state;
+    struct chimera_smb_open_file     *open_file = request->create.r_open_file;
+
+    (void) evpl;
+
+    chimera_vfs_state_revoke_breaks(vfs_state, request->create.park_fh,
+                                    request->create.park_fh_len,
+                                    request->create.park_fh_hash,
+                                    open_file ? open_file->grant : NULL);
+
+    chimera_smb_open_file_release(request, open_file);
+    /* complete_request retires the async-interim (unlink from parked_requests +
+     * clear armed); the fired one-shot is already out of the timer heap so its
+     * removal there no-ops.  async_id stays set -> final reply is ASYNC-tagged. */
+    chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
+} /* chimera_smb_create_park_deadline_cb */
+
 /* Finish a regular-file open: apply the precomputed access masks, emit the
  * parent-directory create notification, release the parent handle, and complete
  * the request.  Invoked on a synchronous grant from open_at_callback and on a
@@ -1618,6 +1650,13 @@ chimera_smb_create_open_finish(
             request->create.park_fh_len  = oh->fh_len;
             request->create.park_fh_hash = oh->fh_hash;
             chimera_smb_async_interim_begin(request);
+            /* Arm a deadline: if the holder never acks the break, fire at the
+             * break timeout to revoke it and complete this open anyway (MS-SMB2
+             * break-timeout).  Cancelled when an ack resumes the open first. */
+            evpl_add_oneshot_timer(thread->evpl, &request->async.timer,
+                                   chimera_smb_create_park_deadline_cb,
+                                   (uint64_t) vfs_state->default_break_deadline_ms
+                                   * 1000);
             return;
         }
     }
@@ -1661,7 +1700,10 @@ chimera_smb_create_resume_parked(struct chimera_smb_request *ack_request)
             *pp                  = req->async.park_next;
             req->async.park_next = resume;
             req->async.armed     = 0; /* already unlinked; skip re-cancel */
-            resume               = req;
+            /* Cancel the break-deadline timer so it cannot fire after the open
+             * has been completed here. */
+            evpl_remove_timer(thread->evpl, &req->async.timer);
+            resume = req;
         } else {
             pp = &req->async.park_next;
         }

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -924,6 +924,13 @@ chimera_smb_create_after_share(
                     open_file->grant                  = grant;
                     open_file->caching_file_state     = file_state;
                     open_file->caching_lease_inserted = true;
+                    /* If this open coalesced onto a grant whose lease is currently
+                     * mid-break, the client is told its lease state but with
+                     * BREAK_IN_PROGRESS set (MS-SMB2 3.3.5.9.11: a lease-key re-open
+                     * during a break succeeds and reports the break is underway). */
+                    open_file->lease_flags =
+                        (grant->lease.break_state == CHIMERA_VFS_BREAK_BREAKING)
+                        ? SMB2_LEASE_FLAG_BREAK_IN_PROGRESS : 0;
                     /* Report the grant's ACTUAL granted mode: a coalesced open
                      * inherits the shared lease's current state (an upgrade may have
                      * widened it; a conflicting peer may have capped it). */
@@ -1582,9 +1589,85 @@ chimera_smb_create_open_finish(
     }
 
     chimera_smb_create_release_parent(request);
+
+    /* MS-SMB2 3.3.5.9 pending-open: if this open triggered an ack-required lease
+     * break on another holder, hold the SUCCESS response until the holder
+     * acknowledges (the break is mid-flight).  Park the request on the tree's
+     * parked_creates list keyed by the file; an inbound OPLOCK_BREAK ack that
+     * settles the file's caching leases resumes it (chimera_smb_create_resume_
+     * parked).  The open_file ref is held across the wait and dropped on resume. */
+    if (open_file->handle) {
+        struct chimera_server_smb_thread *thread    = request->compound->thread;
+        struct chimera_vfs_state         *vfs_state =
+            thread->vfs_thread->vfs->vfs_state;
+        struct chimera_vfs_open_handle   *oh = open_file->handle;
+
+        if (chimera_vfs_state_caching_breaking(vfs_state, oh->fh, oh->fh_len,
+                                               oh->fh_hash, open_file->grant)) {
+            struct chimera_smb_tree *tree = request->tree;
+
+            memcpy(request->create.park_fh, oh->fh, oh->fh_len);
+            request->create.park_fh_len  = oh->fh_len;
+            request->create.park_fh_hash = oh->fh_hash;
+
+            pthread_mutex_lock(&tree->parked_lock);
+            request->create.park_next = tree->parked_creates;
+            tree->parked_creates      = request;
+            pthread_mutex_unlock(&tree->parked_lock);
+            return;
+        }
+    }
+
     chimera_smb_open_file_release(request, open_file);
     chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
 } /* chimera_smb_create_open_finish */
+
+/* Resume any CREATE parked on `ack_request`'s tree whose triggered lease break
+ * has now settled (no caching lease on the file is mid-break).  Called from the
+ * inbound OPLOCK_BREAK ack handler after the lease is acked.  Only resumes parks
+ * owned by the current thread (the deferred response's iovecs are thread-local);
+ * a park awaiting an ack that arrives on a different channel is left for that
+ * channel's ack to drain. */
+void
+chimera_smb_create_resume_parked(struct chimera_smb_request *ack_request)
+{
+    struct chimera_server_smb_thread *thread    = ack_request->compound->thread;
+    struct chimera_vfs_state         *vfs_state = thread->vfs_thread->vfs->vfs_state;
+    struct chimera_smb_tree          *tree      = ack_request->tree;
+    struct chimera_smb_request       *req, **pp, *resume = NULL;
+
+    if (!tree) {
+        return;
+    }
+
+    pthread_mutex_lock(&tree->parked_lock);
+    pp = &tree->parked_creates;
+    while ((req = *pp)) {
+        if (req->compound->thread == thread &&
+            !chimera_vfs_state_caching_breaking(vfs_state,
+                                                req->create.park_fh,
+                                                req->create.park_fh_len,
+                                                req->create.park_fh_hash,
+                                                req->create.r_open_file
+                                                ? req->create.r_open_file->grant
+                                                : NULL)) {
+            *pp                   = req->create.park_next;
+            req->create.park_next = resume;
+            resume                = req;
+        } else {
+            pp = &req->create.park_next;
+        }
+    }
+    pthread_mutex_unlock(&tree->parked_lock);
+
+    while (resume) {
+        req                   = resume;
+        resume                = req->create.park_next;
+        req->create.park_next = NULL;
+        chimera_smb_open_file_release(req, req->create.r_open_file);
+        chimera_smb_complete_request(req, SMB2_STATUS_SUCCESS);
+    }
+} /* chimera_smb_create_resume_parked */
 
 /*
  * Map the CREATE DesiredAccess to canonical access-mask bits and evaluate it
@@ -2786,8 +2869,12 @@ build_rqls_response(
     out[17] = 0;
     out[18] = 0;
     out[19] = 0;
-    /* LeaseFlags (4) — reserved at CREATE response time. */
-    out[20] = 0; out[21] = 0; out[22] = 0; out[23] = 0;
+    /* LeaseFlags (4) — BREAK_IN_PROGRESS when this open joined a lease whose
+     * break is still outstanding; otherwise 0. */
+    out[20] = of->lease_flags & 0xff;
+    out[21] = (of->lease_flags >> 8) & 0xff;
+    out[22] = (of->lease_flags >> 16) & 0xff;
+    out[23] = (of->lease_flags >> 24) & 0xff;
     /* LeaseDuration (8) — reserved. */
     memset(out + 24, 0, 8);
     if (v2) {

--- a/src/server/smb/smb_proc_lock.c
+++ b/src/server/smb/smb_proc_lock.c
@@ -60,10 +60,13 @@ chimera_smb_open_file_drain_locks(
         open_file->share_file_state = NULL;
     }
 
-    /* Drop the caching lease (oplock / SMB2 lease) if held. */
-    if (open_file->caching_lease_inserted) {
-        chimera_vfs_lease_release(vfs_state, open_file->caching_file_state,
-                                  &open_file->caching_lease);
+    /* Drop this open's reference on the caching grant (oplock / SMB2 lease).
+     * On the grant's last reference the embedded lease is unlinked and the grant
+     * freed; the per-file state reference (caching_file_state) is balanced
+     * separately below. */
+    if (open_file->grant) {
+        chimera_vfs_caching_grant_release(vfs_state, open_file->grant);
+        open_file->grant                  = NULL;
         open_file->caching_lease_inserted = false;
     }
     if (open_file->caching_file_state) {

--- a/src/server/smb/smb_proc_lock.c
+++ b/src/server/smb/smb_proc_lock.c
@@ -286,7 +286,7 @@ chimera_smb_lock(struct chimera_smb_request *request)
     entry->lease.offset           = request->lock.l_offset;
     entry->lease.length           = want_length;
     entry->lease.owner.protocol   = CHIMERA_VFS_LEASE_PROTO_SMB2;
-    entry->lease.owner.client_key = request->session_handle->session->session_id;
+    entry->lease.owner.client_key = request->session_handle->session->client_key;
     /* The owner identity is the open — different opens (even by the
      * same client) get different owner_lo/owner_hi and lock
      * independently, matching Windows handle-based lock semantics. */

--- a/src/server/smb/smb_proc_lock.c
+++ b/src/server/smb/smb_proc_lock.c
@@ -65,6 +65,10 @@ chimera_smb_open_file_drain_locks(
      * freed; the per-file state reference (caching_file_state) is balanced
      * separately below. */
     if (open_file->grant) {
+        /* Unthread this open from the grant's member list before dropping its
+         * reference: once removed, the break callback will not try to notify a
+         * closing open, and on the grant's last reference the lease is freed. */
+        chimera_smb_grant_remove_member(open_file->grant, open_file);
         chimera_vfs_caching_grant_release(vfs_state, open_file->grant);
         open_file->grant                  = NULL;
         open_file->caching_lease_inserted = false;
@@ -288,11 +292,12 @@ chimera_smb_lock(struct chimera_smb_request *request)
      * independently, matching Windows handle-based lock semantics. */
     entry->lease.owner.owner_lo = open_file->file_id.pid;
     entry->lease.owner.owner_hi = open_file->file_id.vid;
-    /* Point at the owning open so the range-vs-caching conflict check can tell
-     * that a byte-range lock and the same open's caching lease (whose owner
-     * identity is the lease key, not the file id) belong together and must not
-     * break each other. */
-    entry->lease.owner.cb_private = open_file;
+    /* Point at the open's caching grant (NULL if it holds no oplock/lease) so the
+     * range-vs-caching conflict check can tell that a byte-range lock and the same
+     * open's -- or a coalesced peer's -- caching lease (whose owner identity is the
+     * lease key, not the file id) belong to one grant and must not break each
+     * other.  The grant's lease carries the same pointer in cb_private. */
+    entry->lease.owner.cb_private = open_file->grant;
 
     request->lock.entry = entry;
 

--- a/src/server/smb/smb_proc_lock.c
+++ b/src/server/smb/smb_proc_lock.c
@@ -69,7 +69,7 @@ chimera_smb_open_file_drain_locks(
          * reference: once removed, the break callback will not try to notify a
          * closing open, and on the grant's last reference the lease is freed. */
         chimera_smb_grant_remove_member(open_file->grant, open_file);
-        chimera_vfs_caching_grant_release(vfs_state, open_file->grant);
+        chimera_vfs_caching_grant_release(vfs_state, open_file->grant, true /*pump*/);
         open_file->grant                  = NULL;
         open_file->caching_lease_inserted = false;
     }

--- a/src/server/smb/smb_proc_oplock_break.c
+++ b/src/server/smb/smb_proc_oplock_break.c
@@ -166,8 +166,14 @@ chimera_smb_lease_break_cb(
     uint8_t                   needed_mode,
     void                     *private_data)
 {
-    struct chimera_vfs_caching_grant *grant = private_data;
+    /* Resolve the grant from the lease's own back-pointer rather than cb_private:
+     * a fresh grant is linked (and so becomes breakable) before its SMB cb_private
+     * is stamped, but lease->grant is set under the file lock at allocation, so it
+     * is always valid here. */
+    struct chimera_vfs_caching_grant *grant = lease->grant;
     struct chimera_vfs_file_state    *file  = grant->file;
+
+    (void) private_data;
     struct chimera_smb_open_file     *open_file;
     uint8_t                           new_vfs;
 
@@ -210,7 +216,10 @@ chimera_smb_lease_break_cb(
         uint8_t current_smb = chimera_smb_vfs_to_lease_bits(lease->mode.granted);
         uint8_t new_smb     = chimera_smb_vfs_to_lease_bits(new_vfs);
 
-        open_file->lease_epoch++;
+        /* The lease epoch lives on the GRANT so all coalesced opens share one
+         * monotonic counter (MS-SMB2 3.3.5.9.11): bump it once per break. */
+        grant->epoch++;
+        open_file->lease_epoch = grant->epoch;
         open_file->lease_state = new_smb;
 
         /* break_cb may run on the breaker's thread, but the OPLOCK_BREAK
@@ -229,7 +238,7 @@ chimera_smb_lease_break_cb(
                 memcpy(msg->lease_key, open_file->lease_key, 16);
                 msg->current_state    = current_smb;
                 msg->new_state        = new_smb;
-                msg->new_epoch        = open_file->lease_epoch;
+                msg->new_epoch        = grant->epoch;
                 msg->next             = bt->lease_break_ready;
                 bt->lease_break_ready = msg;
                 pthread_mutex_unlock(&bt->lease_break_lock);

--- a/src/server/smb/smb_proc_oplock_break.c
+++ b/src/server/smb/smb_proc_oplock_break.c
@@ -290,15 +290,16 @@ chimera_smb_lease_break_cb(
         open_file->oplock_level = new_level;
     }
 
-    /* Optimistic downgrade: assume the client acks.  The arriving ack
-     * calls chimera_vfs_lease_ack which is idempotent.  Keeping the read
-     * cache lets the conflicting opener settle at LEVEL_II too. */
-    {
-        struct chimera_vfs_lease_mode m;
-        m.granted = new_vfs;
-        m.denied  = 0;
-        chimera_vfs_lease_ack(lease, m);
-    }
+    /* The lease stays BREAKING (awaiting the client's real OPLOCK_BREAK ack or
+     * close); the conflict matrix treats a BREAKING SMB lease as already at its
+     * retained (break_needed_mode) level, so a coexisting acquirer proceeds
+     * immediately without waiting for the ack.  The client's response resolves
+     * the break via chimera_smb_oplock_break -> chimera_vfs_lease_ack, and the
+     * deadline driver revokes it if the client never responds.  (This is the
+     * same real break/wait model NFSv4 delegations use; the previous code acked
+     * optimistically here, which made true wait-for-close semantics
+     * impossible.) */
+    (void) new_vfs;
 } /* chimera_smb_lease_break_cb */
 
 /* Doorbell handler: runs on a connection-owning SMB thread and sends the
@@ -439,17 +440,21 @@ chimera_smb_oplock_break(struct chimera_smb_request *request)
             return;
         }
 
-        /* Apply the oplock level the client chose to keep (it may drop further
-         * than the server's optimistic downgrade -- e.g. straight to NONE). */
+        /* Resolve the outstanding break with the level the client chose to
+         * keep (it may drop further than what we asked -- e.g. straight to
+         * NONE).  The lease is genuinely BREAKING here (we no longer ack
+         * optimistically), so the canonical ack applies the mode, re-arms a
+         * surviving lease, and pumps any parked acquirer. */
         if (open_file->caching_lease_inserted) {
-            uint8_t kept =
-                (request->oplock_break.oplock_level == SMB2_OPLOCK_LEVEL_II)
-                ? CHIMERA_VFS_LEASE_MODE_R : 0;
+            struct chimera_vfs_lease_mode kept = {
+                .granted = (request->oplock_break.oplock_level ==
+                            SMB2_OPLOCK_LEVEL_II) ? CHIMERA_VFS_LEASE_MODE_R : 0,
+                .denied  = 0,
+            };
 
-            chimera_vfs_lease_client_downgrade(vfs_state,
-                                               open_file->caching_file_state,
-                                               &open_file->caching_lease, kept);
+            chimera_vfs_lease_ack(&open_file->caching_lease, kept);
         }
+        (void) vfs_state;
 
         open_file->oplock_level              = request->oplock_break.oplock_level;
         open_file->oplock_break_ack_required = 0;

--- a/src/server/smb/smb_proc_oplock_break.c
+++ b/src/server/smb/smb_proc_oplock_break.c
@@ -154,22 +154,40 @@ chimera_smb_send_oplock_break_legacy(
                EVPL_SEND_FLAG_TAKE_REF);
 } /* chimera_smb_send_oplock_break_legacy */
 
-/* break_cb wired onto every SMB CACHING lease at CREATE time.  The
- * cb_private is the owning open_file. */
+/* break_cb wired onto every SMB CACHING lease at CREATE time.  The cb_private is
+ * the VFS-owned caching grant (chimera_vfs_caching_grant), which may be shared by
+ * several opens under one lease key.  Pick a member whose connection is still
+ * live to carry the OPLOCK_BREAK Notification; the grant outlives any single open,
+ * so the open that created it may already be gone while a coalesced peer keeps the
+ * lease alive. */
 SYMBOL_EXPORT void
 chimera_smb_lease_break_cb(
     struct chimera_vfs_lease *lease,
     uint8_t                   needed_mode,
     void                     *private_data)
 {
-    struct chimera_smb_open_file *open_file = private_data;
-    uint8_t                       new_vfs;
+    struct chimera_vfs_caching_grant *grant = private_data;
+    struct chimera_vfs_file_state    *file  = grant->file;
+    struct chimera_smb_open_file     *open_file;
+    uint8_t                           new_vfs;
 
-    /* If the conn is no longer live, we can't notify the client; the
-     * pragmatic recovery is to forcibly revoke the lease so the pending
-     * acquire (or future acquires) can proceed.  This mirrors the
-     * Linux kernel's F_SETLEASE forcible expiry path. */
-    if (!open_file->create_conn) {
+    /* Select a live member under the grant's file->lock (the holder list is
+     * mutated by add/remove-member under the same lock).  A member is live when
+     * its create_conn is still set and it has not been closed. */
+    pthread_mutex_lock(&file->lock);
+    for (open_file = grant->holders; open_file;
+         open_file = open_file->grant_member_next) {
+        if (!(open_file->flags & CHIMERA_SMB_OPEN_FILE_CLOSED) &&
+            open_file->create_conn) {
+            break;
+        }
+    }
+    pthread_mutex_unlock(&file->lock);
+
+    /* No live member can notify the client; the pragmatic recovery is to forcibly
+     * revoke the lease so the pending acquire (or future acquires) can proceed.
+     * This mirrors the Linux kernel's F_SETLEASE forcible expiry path. */
+    if (!open_file) {
         chimera_vfs_lease_revoke(lease);
         return;
     }

--- a/src/server/smb/smb_proc_oplock_break.c
+++ b/src/server/smb/smb_proc_oplock_break.c
@@ -26,24 +26,9 @@
 
 #define SMB2_OPLOCK_BREAK_FLAG_ACK_REQUIRED 0x01
 
-/* Map vfs_state RWH bits to the SMB2 lease state encoding (different
- * bit positions for H and W). */
-static inline uint8_t
-chimera_smb_vfs_to_lease_bits(uint8_t vfs_mode)
-{
-    uint8_t s = 0;
-
-    if (vfs_mode & CHIMERA_VFS_LEASE_MODE_R) {
-        s |= SMB2_LEASE_READ_CACHING;
-    }
-    if (vfs_mode & CHIMERA_VFS_LEASE_MODE_H) {
-        s |= SMB2_LEASE_HANDLE_CACHING;
-    }
-    if (vfs_mode & CHIMERA_VFS_LEASE_MODE_W) {
-        s |= SMB2_LEASE_WRITE_CACHING;
-    }
-    return s;
-} /* chimera_smb_vfs_to_lease_bits */
+/* chimera_smb_vfs_to_lease_bits / _lease_bits_to_vfs / _vfs_to_oplock_level live
+ * in smb_internal.h -- one canonical SMB<->VFS caching-grant encoding shared with
+ * the create grant path. */
 
 static inline uint8_t
 chimera_smb_lease_to_vfs_bits(uint8_t smb_state)

--- a/src/server/smb/smb_proc_oplock_break.c
+++ b/src/server/smb/smb_proc_oplock_break.c
@@ -30,23 +30,6 @@
  * in smb_internal.h -- one canonical SMB<->VFS caching-grant encoding shared with
  * the create grant path. */
 
-static inline uint8_t
-chimera_smb_lease_to_vfs_bits(uint8_t smb_state)
-{
-    uint8_t m = 0;
-
-    if (smb_state & SMB2_LEASE_READ_CACHING) {
-        m |= CHIMERA_VFS_LEASE_MODE_R;
-    }
-    if (smb_state & SMB2_LEASE_HANDLE_CACHING) {
-        m |= CHIMERA_VFS_LEASE_MODE_H;
-    }
-    if (smb_state & SMB2_LEASE_WRITE_CACHING) {
-        m |= CHIMERA_VFS_LEASE_MODE_W;
-    }
-    return m;
-} /* chimera_smb_lease_to_vfs_bits */
-
 /* Build the 4-byte NetBIOS header + 64-byte SMB2 header for an
  * unsolicited OPLOCK_BREAK Notification.  Returns pointer past the
  * SMB2 header into the body region. */
@@ -405,9 +388,28 @@ chimera_smb_oplock_break(struct chimera_smb_request *request)
     struct chimera_smb_open_file     *open_file;
 
     if (request->oplock_break.is_lease) {
-        /* Lease-break ack: the lease was optimistically downgraded in the
-         * break_cb.  Honoring the client's exact NewLeaseState verbatim is a
-         * future refinement; just emit the response packet. */
+        /* Lease-break ack: resolve the lease by its key and apply the exact
+         * NewLeaseState the client kept (it may drop further than we asked, e.g.
+         * straight to NONE).  The lease is genuinely BREAKING (Phase 1 dropped
+         * optimistic-ack), so chimera_vfs_lease_ack settles it -- re-arming a
+         * surviving lease and pumping any acquirer parked on the break. */
+        open_file = chimera_smb_open_file_resolve_by_lease_key(
+            request, request->oplock_break.lease_key);
+
+        if (open_file) {
+            if (open_file->caching_lease_inserted) {
+                struct chimera_vfs_lease_mode kept = {
+                    .granted = chimera_smb_lease_bits_to_vfs(
+                        request->oplock_break.lease_state),
+                    .denied  = 0,
+                };
+
+                chimera_vfs_lease_ack(&open_file->caching_lease, kept);
+            }
+            open_file->lease_state = request->oplock_break.lease_state;
+            chimera_smb_open_file_release(request, open_file);
+        }
+
         chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
         return;
     }

--- a/src/server/smb/smb_proc_oplock_break.c
+++ b/src/server/smb/smb_proc_oplock_break.c
@@ -259,6 +259,13 @@ chimera_smb_lease_break_cb(
                             ? SMB2_OPLOCK_LEVEL_II
                             : SMB2_OPLOCK_LEVEL_NONE;
 
+        /* Breaking an exclusive/batch oplock expects the client to
+         * acknowledge; breaking a LEVEL_II oplock (to NONE) does not -- a
+         * client ack for that is a protocol error (see the ack handler). */
+        open_file->oplock_break_ack_required =
+            (open_file->oplock_level == SMB2_OPLOCK_LEVEL_EXCLUSIVE ||
+             open_file->oplock_level == SMB2_OPLOCK_LEVEL_BATCH);
+
         {
             struct chimera_smb_conn            *conn = open_file->create_conn;
             struct chimera_server_smb_thread   *bt   = conn->thread;
@@ -407,9 +414,49 @@ chimera_smb_parse_oplock_break(
 SYMBOL_EXPORT void
 chimera_smb_oplock_break(struct chimera_smb_request *request)
 {
-    /* The lease was already optimistically acked inside the break_cb.
-     * Nothing else to do besides letting the dispatcher emit the
-     * reply packet. */
+    struct chimera_server_smb_thread *thread    = request->compound->thread;
+    struct chimera_vfs_state         *vfs_state = thread->vfs_thread->vfs->vfs_state;
+    struct chimera_smb_open_file     *open_file;
+
+    if (request->oplock_break.is_lease) {
+        /* Lease-break ack: the lease was optimistically downgraded in the
+         * break_cb.  Honoring the client's exact NewLeaseState verbatim is a
+         * future refinement; just emit the response packet. */
+        chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
+        return;
+    }
+
+    open_file = chimera_smb_open_file_resolve(request, &request->oplock_break.file_id);
+
+    if (open_file) {
+        if (!open_file->oplock_break_ack_required) {
+            /* No acknowledgment was expected for this break -- e.g. it broke a
+             * LEVEL_II oplock to NONE, which MS-SMB2 says the client must not
+             * acknowledge.  Reply with the protocol error (3.3.5.22.2). */
+            chimera_smb_open_file_release(request, open_file);
+            chimera_smb_complete_request(request,
+                                         SMB2_STATUS_INVALID_OPLOCK_PROTOCOL);
+            return;
+        }
+
+        /* Apply the oplock level the client chose to keep (it may drop further
+         * than the server's optimistic downgrade -- e.g. straight to NONE). */
+        if (open_file->caching_lease_inserted) {
+            uint8_t kept =
+                (request->oplock_break.oplock_level == SMB2_OPLOCK_LEVEL_II)
+                ? CHIMERA_VFS_LEASE_MODE_R : 0;
+
+            chimera_vfs_lease_client_downgrade(vfs_state,
+                                               open_file->caching_file_state,
+                                               &open_file->caching_lease, kept);
+        }
+
+        open_file->oplock_level              = request->oplock_break.oplock_level;
+        open_file->oplock_break_ack_required = 0;
+
+        chimera_smb_open_file_release(request, open_file);
+    }
+
     chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
 } /* chimera_smb_oplock_break */
 

--- a/src/server/smb/smb_proc_oplock_break.c
+++ b/src/server/smb/smb_proc_oplock_break.c
@@ -397,14 +397,14 @@ chimera_smb_oplock_break(struct chimera_smb_request *request)
             request, request->oplock_break.lease_key);
 
         if (open_file) {
-            if (open_file->caching_lease_inserted) {
+            if (open_file->grant) {
                 struct chimera_vfs_lease_mode kept = {
                     .granted = chimera_smb_lease_bits_to_vfs(
                         request->oplock_break.lease_state),
                     .denied  = 0,
                 };
 
-                chimera_vfs_lease_ack(&open_file->caching_lease, kept);
+                chimera_vfs_lease_ack(&open_file->grant->lease, kept);
             }
             open_file->lease_state = request->oplock_break.lease_state;
             chimera_smb_open_file_release(request, open_file);
@@ -432,14 +432,14 @@ chimera_smb_oplock_break(struct chimera_smb_request *request)
          * NONE).  The lease is genuinely BREAKING here (we no longer ack
          * optimistically), so the canonical ack applies the mode, re-arms a
          * surviving lease, and pumps any parked acquirer. */
-        if (open_file->caching_lease_inserted) {
+        if (open_file->grant) {
             struct chimera_vfs_lease_mode kept = {
                 .granted = (request->oplock_break.oplock_level ==
                             SMB2_OPLOCK_LEVEL_II) ? CHIMERA_VFS_LEASE_MODE_R : 0,
                 .denied  = 0,
             };
 
-            chimera_vfs_lease_ack(&open_file->caching_lease, kept);
+            chimera_vfs_lease_ack(&open_file->grant->lease, kept);
         }
         (void) vfs_state;
 

--- a/src/server/smb/smb_proc_oplock_break.c
+++ b/src/server/smb/smb_proc_oplock_break.c
@@ -228,6 +228,15 @@ chimera_smb_lease_break_cb(
         open_file->lease_epoch = grant->is_v2 ? grant->epoch : 0;
         open_file->lease_state = new_smb;
 
+        /* The client must acknowledge only when the break strips write or handle
+         * caching; dropping read caching alone needs no ack.  Record this on the
+         * grant so an open that triggered the break knows whether to park waiting
+         * for an ack (chimera_vfs_state_caching_breaking). */
+        bool ack_req = ((current_smb & ~new_smb) &
+                        (SMB2_LEASE_WRITE_CACHING |
+                         SMB2_LEASE_HANDLE_CACHING)) != 0;
+        grant->break_ack_required = ack_req;
+
         /* break_cb may run on the breaker's thread, but the OPLOCK_BREAK
          * notification must be sent on the holder connection's owning thread
          * because evpl iovec pools and binds are thread-local. */
@@ -242,13 +251,9 @@ chimera_smb_lease_break_cb(
                 msg->conn     = conn;
                 msg->is_lease = true;
                 memcpy(msg->lease_key, open_file->lease_key, 16);
-                msg->current_state = current_smb;
-                msg->new_state     = new_smb;
-                /* The client must acknowledge only when the break strips write or
-                 * handle caching; dropping read caching alone needs no ack. */
-                msg->ack_required =
-                    ((current_smb & ~new_smb) &
-                     (SMB2_LEASE_WRITE_CACHING | SMB2_LEASE_HANDLE_CACHING)) != 0;
+                msg->current_state    = current_smb;
+                msg->new_state        = new_smb;
+                msg->ack_required     = ack_req;
                 msg->new_epoch        = open_file->lease_epoch;
                 msg->next             = bt->lease_break_ready;
                 bt->lease_break_ready = msg;
@@ -271,6 +276,7 @@ chimera_smb_lease_break_cb(
         open_file->oplock_break_ack_required =
             (open_file->oplock_level == SMB2_OPLOCK_LEVEL_EXCLUSIVE ||
              open_file->oplock_level == SMB2_OPLOCK_LEVEL_BATCH);
+        grant->break_ack_required = open_file->oplock_break_ack_required;
 
         {
             struct chimera_smb_conn            *conn = open_file->create_conn;
@@ -448,6 +454,9 @@ chimera_smb_oplock_break(struct chimera_smb_request *request)
             chimera_smb_open_file_release(request, open_file);
         }
 
+        /* The ack settled the lease; resume any CREATE that parked waiting for
+         * this break to complete (MS-SMB2 pending-open). */
+        chimera_smb_create_resume_parked(request);
         chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
         return;
     }
@@ -487,6 +496,8 @@ chimera_smb_oplock_break(struct chimera_smb_request *request)
         chimera_smb_open_file_release(request, open_file);
     }
 
+    /* Resume any CREATE parked waiting for this break to complete. */
+    chimera_smb_create_resume_parked(request);
     chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
 } /* chimera_smb_oplock_break */
 

--- a/src/server/smb/smb_proc_oplock_break.c
+++ b/src/server/smb/smb_proc_oplock_break.c
@@ -68,6 +68,7 @@ chimera_smb_send_oplock_break_lease(
     const uint8_t           *lease_key,
     uint8_t                  current_state, /* SMB lease bits */
     uint8_t                  new_state,     /* SMB lease bits */
+    bool                     ack_required,
     uint16_t                 new_epoch)
 {
     struct evpl_iovec iov;
@@ -89,8 +90,10 @@ chimera_smb_send_oplock_break_lease(
     /* NewEpoch (2) */
     p[2] = new_epoch & 0xff;
     p[3] = (new_epoch >> 8) & 0xff;
-    /* Flags (4) — ACK_REQUIRED so the client must respond */
-    p[4] = SMB2_OPLOCK_BREAK_FLAG_ACK_REQUIRED;
+    /* Flags (4) — ACK_REQUIRED only when the break removes write or handle
+     * caching (the client must flush / close); a break that only drops read
+     * caching (e.g. to NONE) needs no acknowledgment. */
+    p[4] = ack_required ? SMB2_OPLOCK_BREAK_FLAG_ACK_REQUIRED : 0;
     p[5] = 0; p[6] = 0; p[7] = 0;
     /* LeaseKey (16) */
     memcpy(p + 8, lease_key, 16);
@@ -217,9 +220,12 @@ chimera_smb_lease_break_cb(
         uint8_t new_smb     = chimera_smb_vfs_to_lease_bits(new_vfs);
 
         /* The lease epoch lives on the GRANT so all coalesced opens share one
-         * monotonic counter (MS-SMB2 3.3.5.9.11): bump it once per break. */
-        grant->epoch++;
-        open_file->lease_epoch = grant->epoch;
+         * monotonic counter (MS-SMB2 3.3.5.9.11): bump it once per break.  Only a
+         * v2 lease versions its state; a v1 lease breaks with epoch 0. */
+        if (grant->is_v2) {
+            grant->epoch++;
+        }
+        open_file->lease_epoch = grant->is_v2 ? grant->epoch : 0;
         open_file->lease_state = new_smb;
 
         /* break_cb may run on the breaker's thread, but the OPLOCK_BREAK
@@ -236,9 +242,14 @@ chimera_smb_lease_break_cb(
                 msg->conn     = conn;
                 msg->is_lease = true;
                 memcpy(msg->lease_key, open_file->lease_key, 16);
-                msg->current_state    = current_smb;
-                msg->new_state        = new_smb;
-                msg->new_epoch        = grant->epoch;
+                msg->current_state = current_smb;
+                msg->new_state     = new_smb;
+                /* The client must acknowledge only when the break strips write or
+                 * handle caching; dropping read caching alone needs no ack. */
+                msg->ack_required =
+                    ((current_smb & ~new_smb) &
+                     (SMB2_LEASE_WRITE_CACHING | SMB2_LEASE_HANDLE_CACHING)) != 0;
+                msg->new_epoch        = open_file->lease_epoch;
                 msg->next             = bt->lease_break_ready;
                 bt->lease_break_ready = msg;
                 pthread_mutex_unlock(&bt->lease_break_lock);
@@ -325,7 +336,7 @@ chimera_smb_lease_break_doorbell_callback(
         if (msg->is_lease) {
             chimera_smb_send_oplock_break_lease(msg->conn, msg->lease_key,
                                                 msg->current_state, msg->new_state,
-                                                msg->new_epoch);
+                                                msg->ack_required, msg->new_epoch);
         } else {
             chimera_smb_send_oplock_break_legacy(msg->conn,
                                                  msg->file_id_pid,

--- a/src/server/smb/smb_proc_oplock_break.c
+++ b/src/server/smb/smb_proc_oplock_break.c
@@ -191,18 +191,18 @@ chimera_smb_lease_break_cb(
         return;
     }
 
-    /* needed_mode is the *retained* mask the holder may keep:
-     *   - A conflicting OPEN passes a non-zero mask (the new acquirer's
-     *     granted bits); the holder keeps a shared read cache (R) and
-     *     gives up write/handle caching — i.e. it downgrades to LEVEL_II.
-     *   - A WRITE invalidation passes 0; the holder's read cache is now
-     *     stale, so it breaks all the way to NONE.  (See
-     *     chimera_vfs_state_break_on_write.) */
-    if (needed_mode == 0) {
-        new_vfs = 0;
-    } else {
-        new_vfs = lease->mode.granted & CHIMERA_VFS_LEASE_MODE_R;
-    }
+    /* needed_mode is the *retained* mask the holder may keep, intersected with
+     * what it currently holds:
+     *   - A conflicting OPEN passes R: the holder keeps a shared read cache and
+     *     gives up write/handle caching -- it downgrades to LEVEL_II.
+     *   - A WRITE invalidation (and a namespace recall) passes 0: the cache is
+     *     stale / the name is going away, so it breaks all the way to NONE.
+     *   - A FLUSH recall (data setattr) passes R|H: the holder writes back its
+     *     dirty data but keeps its read + handle cache (no full re-lease).
+     * Intersecting with granted means a holder that does not hold a retained bit
+     * simply loses it (e.g. an exclusive W-only oplock flushed with R|H keeps
+     * only R). */
+    new_vfs = lease->mode.granted & needed_mode;
 
     if (open_file->oplock_level == SMB2_OPLOCK_LEVEL_LEASE) {
         /* SMB2 lease (RqLs) — §2.2.23.2 lease-variant notification. */

--- a/src/server/smb/smb_proc_oplock_break.c
+++ b/src/server/smb/smb_proc_oplock_break.c
@@ -442,13 +442,37 @@ chimera_smb_oplock_break(struct chimera_smb_request *request)
 
         if (open_file) {
             if (open_file->grant) {
+                struct chimera_vfs_lease *lease    = &open_file->grant->lease;
+                uint8_t                   kept_vfs = chimera_smb_lease_bits_to_vfs(
+                    request->oplock_break.lease_state);
+
+                /* MS-SMB2 3.3.5.22.2: an ack is valid only while a break is
+                 * outstanding.  A duplicate ack (the lease already settled) is
+                 * STATUS_UNSUCCESSFUL. */
+                if (lease->break_state != CHIMERA_VFS_BREAK_BREAKING) {
+                    chimera_smb_open_file_release(request, open_file);
+                    chimera_smb_complete_request(request, SMB2_STATUS_UNSUCCESSFUL);
+                    return;
+                }
+
+                /* The acknowledged state may only DROP bits the break asked the
+                * holder to give up -- it must be a subset of the retained mask
+                * (break_needed_mode).  An ack that tries to keep a bit being
+                * broken (e.g. acking RWH to a W->RH break) is rejected with
+                * STATUS_REQUEST_NOT_ACCEPTED and the lease is left BREAKING. */
+                if (kept_vfs & ~lease->break_needed_mode) {
+                    chimera_smb_open_file_release(request, open_file);
+                    chimera_smb_complete_request(request,
+                                                 SMB2_STATUS_REQUEST_NOT_ACCEPTED);
+                    return;
+                }
+
                 struct chimera_vfs_lease_mode kept = {
-                    .granted = chimera_smb_lease_bits_to_vfs(
-                        request->oplock_break.lease_state),
+                    .granted = kept_vfs,
                     .denied  = 0,
                 };
 
-                chimera_vfs_lease_ack(&open_file->grant->lease, kept);
+                chimera_vfs_lease_ack(lease, kept);
             }
             open_file->lease_state = request->oplock_break.lease_state;
             chimera_smb_open_file_release(request, open_file);

--- a/src/server/smb/smb_proc_read.c
+++ b/src/server/smb/smb_proc_read.c
@@ -140,7 +140,7 @@ chimera_smb_read(struct chimera_smb_request *request)
 
     struct chimera_vfs_lease_owner io_owner = {
         .protocol   = CHIMERA_VFS_LEASE_PROTO_SMB2,
-        .client_key = request->session_handle->session->session_id,
+        .client_key = request->session_handle->session->client_key,
         .owner_lo   = request->read.open_file->file_id.pid,
         .owner_hi   = request->read.open_file->file_id.vid,
     };

--- a/src/server/smb/smb_proc_session_setup.c
+++ b/src/server/smb/smb_proc_session_setup.c
@@ -220,6 +220,12 @@ chimera_smb_session_setup(struct chimera_smb_request *request)
          * connection must match it. */
         session->supports_notifications = conn->supports_notifications;
 
+        /* Bind the lease owner key to the client (ClientGuid captured at
+         * NEGOTIATE), not the session id, so same-client sessions share a
+         * lease namespace (MS-SMB2 3.3.5.9.8). */
+        session->client_key = chimera_smb_lease_client_key(conn->client_guid,
+                                                           session->session_id);
+
         session_handle = chimera_smb_session_handle_alloc(thread);
 
         session_handle->session_id = session->session_id;

--- a/src/server/smb/smb_proc_write.c
+++ b/src/server/smb/smb_proc_write.c
@@ -228,9 +228,9 @@ chimera_smb_write(struct chimera_smb_request *request)
     struct chimera_vfs_lease_owner io_owner;
     io_owner.protocol   = CHIMERA_VFS_LEASE_PROTO_SMB2;
     io_owner.client_key = request->session_handle->session->session_id;
-    if (request->write.open_file->caching_lease_inserted) {
-        io_owner.owner_lo = request->write.open_file->caching_lease.owner.owner_lo;
-        io_owner.owner_hi = request->write.open_file->caching_lease.owner.owner_hi;
+    if (request->write.open_file->grant) {
+        io_owner.owner_lo = request->write.open_file->grant->lease.owner.owner_lo;
+        io_owner.owner_hi = request->write.open_file->grant->lease.owner.owner_hi;
     } else {
         io_owner.owner_lo = request->write.open_file->file_id.pid;
         io_owner.owner_hi = request->write.open_file->file_id.vid;

--- a/src/server/smb/smb_proc_write.c
+++ b/src/server/smb/smb_proc_write.c
@@ -139,7 +139,7 @@ chimera_smb_rdma_read_callback(
 
         struct chimera_vfs_lease_owner io_owner = {
             .protocol   = CHIMERA_VFS_LEASE_PROTO_SMB2,
-            .client_key = request->session_handle->session->session_id,
+            .client_key = request->session_handle->session->client_key,
             .owner_lo   = request->write.open_file->file_id.pid,
             .owner_hi   = request->write.open_file->file_id.vid,
         };
@@ -227,7 +227,7 @@ chimera_smb_write(struct chimera_smb_request *request)
      * INVALID_NETWORK_RESPONSE on the client. */
     struct chimera_vfs_lease_owner io_owner;
     io_owner.protocol   = CHIMERA_VFS_LEASE_PROTO_SMB2;
-    io_owner.client_key = request->session_handle->session->session_id;
+    io_owner.client_key = request->session_handle->session->client_key;
     if (request->write.open_file->grant) {
         io_owner.owner_lo = request->write.open_file->grant->lease.owner.owner_lo;
         io_owner.owner_hi = request->write.open_file->grant->lease.owner.owner_hi;

--- a/src/server/smb/smb_procs.h
+++ b/src/server/smb/smb_procs.h
@@ -299,6 +299,11 @@ int chimera_smb_parse_oplock_break(
 void chimera_smb_oplock_break(
     struct chimera_smb_request *request);
 
+/* Resume CREATEs parked on the ack's tree whose triggered lease break has now
+ * settled.  Called from the OPLOCK_BREAK ack handler after the lease is acked. */
+void chimera_smb_create_resume_parked(
+    struct chimera_smb_request *ack_request);
+
 void chimera_smb_oplock_break_reply(
     struct evpl_iovec_cursor   *reply_cursor,
     struct chimera_smb_request *request);

--- a/src/server/smb/smb_session.h
+++ b/src/server/smb/smb_session.h
@@ -219,6 +219,15 @@ struct chimera_smb_tree {
 
 struct chimera_smb_session {
     uint64_t                    session_id;
+    /* Stable per-CLIENT identity used as the owner key for CACHING leases,
+     * SHARE reservations and byte-range locks (chimera_vfs_lease_owner.client_key).
+     * Derived from the connection's ClientGuid, NOT the session id, because
+     * MS-SMB2 keys leases by the client (3.3.5.9.8): two sessions of the same
+     * client (same ClientGuid, e.g. a reconnect or a second channel) share one
+     * lease namespace and must coalesce/upgrade rather than conflict.  Falls
+     * back to session_id for guid-less clients (pre-3.0 dialects send a zero
+     * ClientGuid) so distinct legacy clients are not collapsed onto one key. */
+    uint64_t                    client_key;
     uint32_t                    refcnt;
     uint32_t                    flags;
     /* Dialect of the connection this session was established on (MS-SMB2
@@ -253,6 +262,30 @@ struct chimera_smb_session {
 
     struct chimera_vfs_cred     cred;
 };
+
+/* Derive the stable per-client lease owner key from a 16-byte ClientGuid.
+ * FNV-1a over the guid bytes; a guid of all zeros (pre-3.0 clients send none)
+ * falls back to the unique session_id so distinct legacy clients keep distinct
+ * keys rather than colliding on the zero-guid hash.  Never returns 0. */
+static inline uint64_t
+chimera_smb_lease_client_key(
+    const uint8_t *client_guid,
+    uint64_t       session_id)
+{
+    uint64_t h       = 1469598103934665603ULL; /* FNV-1a 64-bit offset basis */
+    int      nonzero = 0;
+
+    for (int i = 0; i < 16; i++) {
+        nonzero |= client_guid[i];
+        h       ^= client_guid[i];
+        h       *= 1099511628211ULL;     /* FNV-1a 64-bit prime */
+    }
+
+    if (!nonzero) {
+        return session_id;
+    }
+    return h ? h : 1;
+} /* chimera_smb_lease_client_key */
 
 static struct chimera_smb_session *
 chimera_smb_session_create()

--- a/src/server/smb/smb_session.h
+++ b/src/server/smb/smb_session.h
@@ -157,6 +157,11 @@ struct chimera_smb_open_file {
     struct chimera_vfs_caching_grant *grant;
     struct chimera_vfs_file_state    *caching_file_state;
     bool                              caching_lease_inserted;
+    /* Intrusive link on grant->holders: every open referencing a shared caching
+     * grant is threaded here so a break callback can pick a live member to notify
+     * (the grant may outlive the open that created it once opens coalesce).
+     * Manipulated under the grant's file->lock. */
+    struct chimera_smb_open_file     *grant_member_next;
     /* Conn on which this open was created — used by the break path to
      * send unsolicited OPLOCK_BREAK Notifications.  Cleared by the
      * disconnect handler before the conn is freed; if NULL when a

--- a/src/server/smb/smb_session.h
+++ b/src/server/smb/smb_session.h
@@ -201,6 +201,13 @@ struct chimera_smb_tree {
     struct chimera_smb_open_file *open_files[CHIMERA_SMB_OPEN_FILE_BUCKETS];
     pthread_mutex_t               open_files_lock[CHIMERA_SMB_OPEN_FILE_BUCKETS];
 
+    /* CREATEs whose final response is deferred because the open triggered an
+     * ack-required lease break on another holder (MS-SMB2 3.3.5.9: the open is
+     * pending until the break completes).  Each is resumed when an inbound
+     * OPLOCK_BREAK ack settles the holder's lease.  Guarded by parked_lock. */
+    struct chimera_smb_request   *parked_creates;
+    pthread_mutex_t               parked_lock;
+
     struct chimera_smb_tree      *prev;
     struct chimera_smb_tree      *next;
 

--- a/src/server/smb/smb_session.h
+++ b/src/server/smb/smb_session.h
@@ -117,6 +117,11 @@ struct chimera_smb_open_file {
     /* Phase-0 plumbing: fields populated by later phases. Zeroed on alloc. */
     uint32_t                         ctx_present_mask;
     uint8_t                          oplock_level;
+    /* Set when an outstanding legacy oplock break to this handle expects an
+     * acknowledgment (it broke an exclusive/batch oplock).  A break from
+     * LEVEL_II to NONE is NOT acknowledged; a client ack for one is a protocol
+     * error (MS-SMB2 -> NT_STATUS_INVALID_OPLOCK_PROTOCOL). */
+    uint8_t                          oplock_break_ack_required;
     uint8_t                          lease_state;
     uint16_t                         lease_epoch;
     uint32_t                         lease_flags;

--- a/src/server/smb/smb_session.h
+++ b/src/server/smb/smb_session.h
@@ -94,84 +94,88 @@ struct chimera_smb_notify_state;
 struct chimera_smb_lock_entry;
 
 struct chimera_smb_open_file {
-    enum chimera_smb_open_file_type  type;
-    enum chimera_smb_pipe_magic      pipe_magic;
-    chimera_smb_pipe_transceive_t    pipe_transceive;
-    struct UT_hash_handle            hh;
-    struct chimera_smb_file_id       file_id;
-    struct chimera_vfs_open_handle  *handle;
-    uint32_t                         desired_access;
+    enum chimera_smb_open_file_type   type;
+    enum chimera_smb_pipe_magic       pipe_magic;
+    chimera_smb_pipe_transceive_t     pipe_transceive;
+    struct UT_hash_handle             hh;
+    struct chimera_smb_file_id        file_id;
+    struct chimera_vfs_open_handle   *handle;
+    uint32_t                          desired_access;
     /* Access mask actually granted on this handle (FileAccessInformation).
      * Resolved from the object ACL at open: equals desired_access for a
      * specific-bits open, or the maximal available set for MAXIMUM_ALLOWED. */
-    uint32_t                         granted_access;
+    uint32_t                          granted_access;
     /* The caller's full effective rights against the object's ACL, regardless
      * of what was requested -- reported in the MxAc create-context response. */
-    uint32_t                         maximal_access;
-    uint32_t                         share_access;
-    uint32_t                         name_len;
-    uint32_t                         flags;
-    uint64_t                         position;
-    uint32_t                         parent_fh_len;
-    uint32_t                         refcnt;
+    uint32_t                          maximal_access;
+    uint32_t                          share_access;
+    uint32_t                          name_len;
+    uint32_t                          flags;
+    uint64_t                          position;
+    uint32_t                          parent_fh_len;
+    uint32_t                          refcnt;
     /* Phase-0 plumbing: fields populated by later phases. Zeroed on alloc. */
-    uint32_t                         ctx_present_mask;
-    uint8_t                          oplock_level;
+    uint32_t                          ctx_present_mask;
+    uint8_t                           oplock_level;
     /* Set when an outstanding legacy oplock break to this handle expects an
      * acknowledgment (it broke an exclusive/batch oplock).  A break from
      * LEVEL_II to NONE is NOT acknowledged; a client ack for one is a protocol
      * error (MS-SMB2 -> NT_STATUS_INVALID_OPLOCK_PROTOCOL). */
-    uint8_t                          oplock_break_ack_required;
-    uint8_t                          lease_state;
-    uint16_t                         lease_epoch;
-    uint32_t                         lease_flags;
-    uint32_t                         durable_flags;
-    uint64_t                         durable_timeout_ms;
-    uint8_t                          lease_key[16];
-    uint8_t                          parent_lease_key[16];
-    uint8_t                          create_guid[16];
+    uint8_t                           oplock_break_ack_required;
+    uint8_t                           lease_state;
+    uint16_t                          lease_epoch;
+    uint32_t                          lease_flags;
+    uint32_t                          durable_flags;
+    uint64_t                          durable_timeout_ms;
+    uint8_t                           lease_key[16];
+    uint8_t                           parent_lease_key[16];
+    uint8_t                           create_guid[16];
     /* SMB2_CREATE_APP_INSTANCE_ID / *_VERSION (MS-SMB2 2.2.13.2.13/14).
      * Recorded when the open carried an AppInstanceId so a later CREATE on a
      * different connection can match it and apply the version-gated
      * force-close rule (3.3.5.9.7 / 3.3.5.9.16). */
-    uint8_t                          app_instance_id[16];
-    uint64_t                         app_version_high;
-    uint64_t                         app_version_low;
-    uint8_t                          app_version_present;
-    struct chimera_smb_open_file    *next;
-    struct chimera_smb_notify_state *notify_state;
+    uint8_t                           app_instance_id[16];
+    uint64_t                          app_version_high;
+    uint64_t                          app_version_low;
+    uint8_t                           app_version_present;
+    struct chimera_smb_open_file     *next;
+    struct chimera_smb_notify_state  *notify_state;
     /* Byte-range locks (SMB2_LOCK) held against this open.  Allocated
      * and linked on each granted lock op; freed on UNLOCK or on close. */
-    struct chimera_smb_lock_entry   *lock_entries;
+    struct chimera_smb_lock_entry    *lock_entries;
     /* SHARE lease (whole-file deny mode reservation) held by this open
      * once CREATE succeeds.  Released at close. */
-    struct chimera_vfs_lease         share_lease;
-    struct chimera_vfs_file_state   *share_file_state;
-    bool                             share_lease_inserted;
-    /* CACHING lease (SMB2 lease / oplock) held by this open.  Released
-     * at close or on OPLOCK_BREAK ack with mode=0. */
-    struct chimera_vfs_lease         caching_lease;
-    struct chimera_vfs_file_state   *caching_file_state;
-    bool                             caching_lease_inserted;
+    struct chimera_vfs_lease          share_lease;
+    struct chimera_vfs_file_state    *share_file_state;
+    bool                              share_lease_inserted;
+    /* CACHING lease (SMB2 lease / oplock) held by this open.  The lease is now a
+     * VFS-owned, owner-keyed, refcounted grant (chimera_vfs_caching_grant) that
+     * may be shared by several opens under one lease key; this open holds one
+     * reference, dropped at close or on OPLOCK_BREAK ack with mode=0.  NULL if
+     * the open holds no caching lease.  caching_file_state holds this open's
+     * reference on the per-file state (balanced separately from the grant ref). */
+    struct chimera_vfs_caching_grant *grant;
+    struct chimera_vfs_file_state    *caching_file_state;
+    bool                              caching_lease_inserted;
     /* Conn on which this open was created — used by the break path to
      * send unsolicited OPLOCK_BREAK Notifications.  Cleared by the
      * disconnect handler before the conn is freed; if NULL when a
      * break is needed, the lease is forcibly revoked instead. */
-    struct chimera_smb_conn         *create_conn;
+    struct chimera_smb_conn          *create_conn;
     /* Tree this open is hashed into (tree->open_files[]).  Lets an
      * AppInstanceId force-close locate and unhash the conflicting open
      * directly from the lease back-reference. */
-    struct chimera_smb_tree         *tree;
-    uint8_t                          parent_fh[CHIMERA_VFS_FH_SIZE];
-    char                             name[SMB_FILENAME_MAX];
-    uint16_t                         pattern[SMB_FILENAME_MAX];
+    struct chimera_smb_tree          *tree;
+    uint8_t                           parent_fh[CHIMERA_VFS_FH_SIZE];
+    char                              name[SMB_FILENAME_MAX];
+    uint16_t                          pattern[SMB_FILENAME_MAX];
     /* Named-stream (ADS) identity, valid when CHIMERA_SMB_OPEN_FILE_FLAG_STREAM
      * is set.  base_fh is the file the stream hangs off (open_file->handle's fh
      * points at the stream itself). */
-    uint16_t                         stream_name_len;
-    char                             stream_name[SMB_FILENAME_MAX];
-    uint16_t                         base_fh_len;
-    uint8_t                          base_fh[CHIMERA_VFS_FH_SIZE];
+    uint16_t                          stream_name_len;
+    char                              stream_name[SMB_FILENAME_MAX];
+    uint16_t                          base_fh_len;
+    uint8_t                           base_fh[CHIMERA_VFS_FH_SIZE];
 };
 
 #define CHIMERA_SMB_OPEN_FILE_BUCKETS     256

--- a/src/server/smb/smb_session.h
+++ b/src/server/smb/smb_session.h
@@ -201,13 +201,6 @@ struct chimera_smb_tree {
     struct chimera_smb_open_file *open_files[CHIMERA_SMB_OPEN_FILE_BUCKETS];
     pthread_mutex_t               open_files_lock[CHIMERA_SMB_OPEN_FILE_BUCKETS];
 
-    /* CREATEs whose final response is deferred because the open triggered an
-     * ack-required lease break on another holder (MS-SMB2 3.3.5.9: the open is
-     * pending until the break completes).  Each is resumed when an inbound
-     * OPLOCK_BREAK ack settles the holder's lease.  Guarded by parked_lock. */
-    struct chimera_smb_request   *parked_creates;
-    pthread_mutex_t               parked_lock;
-
     struct chimera_smb_tree      *prev;
     struct chimera_smb_tree      *next;
 

--- a/src/server/smb/tests/phase0_contexts_test.c
+++ b/src/server/smb/tests/phase0_contexts_test.c
@@ -397,7 +397,7 @@ test_create_rqls_v1_vs_v2(void)
         rqls_v2[i] = (uint8_t) (0xc0 + i);
     }
     put_le32(rqls_v2, 16, 0x07);
-    put_le32(rqls_v2, 20, 0x02);  /* parent_key valid */
+    put_le32(rqls_v2, 20, 0x04);  /* SMB2_LEASE_FLAG_PARENT_LEASE_KEY_SET: parent_key valid */
     for (i = 0; i < 16; i++) {
         rqls_v2[32 + i] = (uint8_t) (0xd0 + i);
     }

--- a/src/vfs/vfs.h
+++ b/src/vfs/vfs.h
@@ -424,6 +424,15 @@ struct chimera_vfs_request {
      * mutation that must recall every caching lease on a target file (regardless
      * of owner) rather than hold an implicit lease. */
     uint8_t                            io_recall_all;
+    /* Set by chimera_vfs_io_recall() for a data-coherence recall (a setattr that
+     * touches data, e.g. SIZE/EOF) as opposed to a namespace recall (remove /
+     * rename / link).  A flush recall downgrades a write-caching (W) holder to
+     * its read+handle cache (forcing the client to flush dirty data without
+     * losing its read cache or oplock), rather than revoking the whole lease to
+     * NONE.  This decouples the load-bearing dirty-cache flush from full
+     * revocation -- the churn source for metadata-heavy single-client workloads
+     * (rewinddir/fsstress) -- while preserving coherence. */
+    uint8_t                            io_recall_flush_only;
     void                               ( *io_next )(
         struct chimera_vfs_request *request);
     struct chimera_vfs_file_state     *io_lease_file;

--- a/src/vfs/vfs_internal.h
+++ b/src/vfs/vfs_internal.h
@@ -178,12 +178,13 @@ chimera_vfs_request_alloc_common(
 
     /* Reset implicit-lease mediation state: requests are pooled and not
      * fully memset on reuse, so a prior op's owner/pin must not leak in. */
-    request->io_owner_valid    = 0;
-    request->io_recall_all     = 0;
-    request->io_next           = NULL;
-    request->io_lease_file     = NULL;
-    request->io_handle         = NULL;
-    request->io_owns_lease_ref = 0;
+    request->io_owner_valid       = 0;
+    request->io_recall_all        = 0;
+    request->io_recall_flush_only = 0;
+    request->io_next              = NULL;
+    request->io_lease_file        = NULL;
+    request->io_handle            = NULL;
+    request->io_owns_lease_ref    = 0;
 
     if (fh && fhlen > 0) {
         memcpy(request->fh, fh, fhlen);

--- a/src/vfs/vfs_lease_types.h
+++ b/src/vfs/vfs_lease_types.h
@@ -184,6 +184,11 @@ struct chimera_vfs_caching_grant {
      * legacy oplock do not version their state, so their break notifications carry
      * epoch 0 and `epoch` is not advanced for them. */
     uint8_t                           is_v2;
+    /* Set while this grant's lease is mid-break and the break requires a client
+     * acknowledgment (write or handle caching was stripped).  A no-ack break (only
+     * read caching dropped, or break to NONE) leaves this clear so an open does not
+     * park waiting for an ack that never comes. */
+    uint8_t                           break_ack_required;
     struct chimera_vfs_caching_grant *grant_next; /* link on file->caching_grants */
     /* Protocol holder list — opaque to the VFS; the protocol server threads its
      * per-open holder objects through here so a break callback can select a LIVE

--- a/src/vfs/vfs_lease_types.h
+++ b/src/vfs/vfs_lease_types.h
@@ -19,6 +19,7 @@
 struct chimera_vfs_lease;
 struct chimera_vfs_file_state;
 struct chimera_vfs_open_handle;
+struct chimera_vfs_caching_grant;
 
 /* -------------------------------------------------------------------- */
 /* Lease vocabulary                                                     */
@@ -118,28 +119,61 @@ enum chimera_vfs_break_state {
 
 struct chimera_vfs_lease {
     enum chimera_vfs_lease_kind kind;
-    struct chimera_vfs_lease_mode  mode;
-    uint64_t                       offset; /* RANGE only; SHARE/CACHING use 0 */
-    uint64_t                       length; /* RANGE only; 0 = to EOF */
-    struct chimera_vfs_lease_owner owner;
-    struct chimera_vfs_file_state *file;
+    struct chimera_vfs_lease_mode     mode;
+    uint64_t                          offset; /* RANGE only; SHARE/CACHING use 0 */
+    uint64_t                          length; /* RANGE only; 0 = to EOF */
+    struct chimera_vfs_lease_owner    owner;
+    struct chimera_vfs_file_state    *file;
 
     enum chimera_vfs_break_state break_state;
-    uint8_t                        break_needed_mode;
-    uint64_t                       break_deadline; /* stopwatch ticks */
+    uint8_t                           break_needed_mode;
+    uint64_t                          break_deadline; /* stopwatch ticks */
 
     /* For a SHARE probe only: a caching (handle) lease held under this same
      * key is the requester's own lease (SMB2 same-client, same lease key) and
      * must NOT be broken when acquiring the share — the opens coalesce.  Set by
      * the SMB server when a lease-bearing open takes its share reservation;
      * left zero (no skip) by every other caller. */
-    uint8_t                        has_break_skip_key;
-    uint64_t                       break_skip_lo;
-    uint64_t                       break_skip_hi;
+    uint8_t                           has_break_skip_key;
+    uint64_t                          break_skip_lo;
+    uint64_t                          break_skip_hi;
+
+    /* For a CACHING lease that is owned by a VFS caching grant (the shared,
+     * owner-keyed, refcounted object that lets N opens under one owner share a
+     * single lease): back-pointer to that grant, so begin_break/ack/revoke can
+     * route through it.  NULL for RANGE/SHARE leases, the implicit lease, and
+     * any CACHING lease not (yet) managed by a grant. */
+    struct chimera_vfs_caching_grant *grant;
 
     /* Intrusive linkage on the appropriate file->{range,share,caching} list. */
-    struct chimera_vfs_lease      *prev;
-    struct chimera_vfs_lease      *next;
+    struct chimera_vfs_lease         *prev;
+    struct chimera_vfs_lease         *next;
+};
+
+/* -------------------------------------------------------------------- */
+/* Caching grant — VFS-owned shared caching lease                       */
+/* -------------------------------------------------------------------- */
+
+/*
+ * A CACHING lease (SMB oplock/lease, NFSv4 delegation) is logically ONE grant
+ * per (file, owner) shared by every open that holds that owner key.  Unlike
+ * RANGE/SHARE leases — which are genuinely per-instance and stay embedded in
+ * the protocol object — a caching grant is allocated and lifetime-managed by
+ * the VFS layer and reference-counted across the opens that share it.  This
+ * generalizes what the NFSv4 server already does by hand for delegations (one
+ * nfs_delegation per (client, FH)) so SMB and NFSv4 share one implementation.
+ *
+ * The grant WRAPS a chimera_vfs_lease: the embedded lease is what the conflict
+ * matrix links onto file->caching_leases and walks, so the matrix/break state
+ * machine are unchanged.  The grant adds owner-keyed lookup, the open refcount,
+ * and the SMB lease epoch.
+ */
+struct chimera_vfs_caching_grant {
+    struct chimera_vfs_lease          lease;      /* kind=CACHING; the matrix node */
+    struct chimera_vfs_file_state    *file;       /* owning file (back-ptr) */
+    uint32_t                          refcount;   /* # of opens referencing this grant */
+    uint32_t                          epoch;      /* SMB lease epoch (3.3.5.9.11) */
+    struct chimera_vfs_caching_grant *grant_next; /* link on file->caching_grants */
 };
 
 /* -------------------------------------------------------------------- */

--- a/src/vfs/vfs_lease_types.h
+++ b/src/vfs/vfs_lease_types.h
@@ -126,7 +126,20 @@ struct chimera_vfs_lease {
     struct chimera_vfs_file_state    *file;
 
     enum chimera_vfs_break_state break_state;
+    /* The level the current outstanding break notification asked the holder to
+     * downgrade to -- ONE caching bit below its granted mode (W, then H, then R
+     * in priority order).  A lease never jumps straight to its floor: each
+     * conflicting open/write drives the holder down a single bit, and the next
+     * step is sent only after the client acks the previous one (MS-SMB2
+     * 3.3.5.9.x cascading break, e.g. RWH -> RH -> R -> NONE). */
     uint8_t                           break_needed_mode;
+    /* The ultimate target of the in-flight cascade: the maximal mode the holder
+     * may keep given every current waiter.  NONE for a writing/truncating open
+     * or a namespace mutation; R for a read-only conflicting open; R|H for a
+     * coexisting caching lease (R and H are shared).  The cascade keeps
+     * break_state == BREAKING and re-fires one bit per ack until granted reaches
+     * this floor, at which point the break completes. */
+    uint8_t                           break_floor;
     uint64_t                          break_deadline; /* stopwatch ticks */
 
     /* For a SHARE probe only: a caching (handle) lease held under this same

--- a/src/vfs/vfs_lease_types.h
+++ b/src/vfs/vfs_lease_types.h
@@ -18,6 +18,7 @@
 
 struct chimera_vfs_lease;
 struct chimera_vfs_file_state;
+struct chimera_vfs_open_handle;
 
 /* -------------------------------------------------------------------- */
 /* Lease vocabulary                                                     */
@@ -98,6 +99,14 @@ struct chimera_vfs_lease_owner {
     chimera_vfs_lease_is_alive_cb_t is_alive_cb;
     chimera_vfs_lease_revoked_cb_t  revoked_cb;
     void                           *cb_private;
+    /* The open handle this lease is anchored to, when the holder is a single
+     * open (SMB oplock/lease).  A metadata mutation (setattr / set-EOF) issued
+     * through this very handle must NOT recall this lease -- the holder is
+     * coherent with its own change -- so chimera_vfs_break_caching_file skips a
+     * lease whose op_handle matches the mutating request's handle.  NULL for
+     * holders not tied to a single handle (e.g. NFSv4 delegations), which are
+     * always recalled. */
+    struct chimera_vfs_open_handle *op_handle;
 };
 
 enum chimera_vfs_break_state {

--- a/src/vfs/vfs_lease_types.h
+++ b/src/vfs/vfs_lease_types.h
@@ -173,6 +173,17 @@ struct chimera_vfs_caching_grant {
     struct chimera_vfs_file_state    *file;       /* owning file (back-ptr) */
     uint32_t                          refcount;   /* # of opens referencing this grant */
     uint32_t                          epoch;      /* SMB lease epoch (3.3.5.9.11) */
+    /* True for a legacy SMB oplock (LEVEL_II/EXCLUSIVE/BATCH), false for an SMB2
+     * RqLs lease.  A legacy batch oplock's handle is broken BEFORE the share-mode
+     * check so the holder can close and dissolve a sharing conflict; an RqLs lease
+     * keeps its handle cache on a conflicting open (only its write cache is
+     * exclusive).  The break-on-open path uses this to handle-break only legacy
+     * oplocks.  Unused by NFSv4 (its grants are delegations, never oplocks). */
+    uint8_t                           is_oplock;
+    /* True for an SMB2.1+ lease v2 (RqLs v2, carries an epoch).  A v1 lease and a
+     * legacy oplock do not version their state, so their break notifications carry
+     * epoch 0 and `epoch` is not advanced for them. */
+    uint8_t                           is_v2;
     struct chimera_vfs_caching_grant *grant_next; /* link on file->caching_grants */
     /* Protocol holder list — opaque to the VFS; the protocol server threads its
      * per-open holder objects through here so a break callback can select a LIVE

--- a/src/vfs/vfs_lease_types.h
+++ b/src/vfs/vfs_lease_types.h
@@ -174,6 +174,13 @@ struct chimera_vfs_caching_grant {
     uint32_t                          refcount;   /* # of opens referencing this grant */
     uint32_t                          epoch;      /* SMB lease epoch (3.3.5.9.11) */
     struct chimera_vfs_caching_grant *grant_next; /* link on file->caching_grants */
+    /* Protocol holder list — opaque to the VFS; the protocol server threads its
+     * per-open holder objects through here so a break callback can select a LIVE
+     * holder to notify (e.g. SMB picks an open whose channel is still connected;
+     * if none is live the lease is revoked).  Manipulated by the protocol under
+     * file->lock.  NFSv4 leaves this NULL (member-set-1; cb_private points at the
+     * delegation directly). */
+    void                             *holders;
 };
 
 /* -------------------------------------------------------------------- */

--- a/src/vfs/vfs_proc_link_at.c
+++ b/src/vfs/vfs_proc_link_at.c
@@ -115,7 +115,8 @@ chimera_vfs_link_at_dispatch(
     /* RFC 7530 §10.4.5: adding a hard link to a delegated file must recall the
      * delegation first.  request->fh is the source file being linked. */
     chimera_vfs_io_recall(request, request->fh, request->fh_len,
-                          request->fh_hash, chimera_vfs_dispatch);
+                          request->fh_hash, 0 /* namespace recall: revoke fully */,
+                          chimera_vfs_dispatch);
 } /* chimera_vfs_link_at_dispatch */
 
 /*

--- a/src/vfs/vfs_proc_remove_at.c
+++ b/src/vfs/vfs_proc_remove_at.c
@@ -155,6 +155,7 @@ chimera_vfs_remove_at_dispatch(
      * it (the caller supplies its FH when known). */
     chimera_vfs_io_recall(request, child_fh, child_fh_len,
                           child_fh_len ? chimera_vfs_hash(child_fh, child_fh_len) : 0,
+                          0 /* namespace recall: revoke fully */,
                           chimera_vfs_dispatch);
 
 } /* chimera_vfs_remove_at_dispatch */

--- a/src/vfs/vfs_proc_rename_at.c
+++ b/src/vfs/vfs_proc_rename_at.c
@@ -108,6 +108,7 @@ chimera_vfs_rename_at_recall_target(struct chimera_vfs_request *request)
                           request->rename_at.target_fh_len ?
                           chimera_vfs_hash(request->rename_at.target_fh,
                                            request->rename_at.target_fh_len) : 0,
+                          0 /* namespace recall: revoke fully */,
                           chimera_vfs_dispatch);
 } /* chimera_vfs_rename_at_recall_target */
 
@@ -134,6 +135,7 @@ chimera_vfs_rename_at_source_lookup_complete(
                               request->rename_at.source_fh_len,
                               chimera_vfs_hash(request->rename_at.source_fh,
                                                request->rename_at.source_fh_len),
+                              0 /* namespace recall: revoke fully */,
                               chimera_vfs_rename_at_recall_target);
     } else {
         /* Source not resolvable (e.g. ENOENT); the backend rename will return

--- a/src/vfs/vfs_proc_setattr.c
+++ b/src/vfs/vfs_proc_setattr.c
@@ -116,9 +116,13 @@ chimera_vfs_setattr_dispatch(
         return;
     }
 
-    request->opcode                          = CHIMERA_VFS_OP_SETATTR;
-    request->complete                        = chimera_vfs_setattr_complete;
-    request->setattr.handle                  = handle;
+    request->opcode         = CHIMERA_VFS_OP_SETATTR;
+    request->complete       = chimera_vfs_setattr_complete;
+    request->setattr.handle = handle;
+    /* Identify the mutating handle so the caching-lease recall below skips a
+     * lease anchored to this same handle (the holder is coherent with its own
+     * setattr -- see chimera_vfs_break_caching_file). */
+    request->io_handle                       = handle;
     request->setattr.set_attr                = set_attr;
     request->setattr.r_pre_attr.va_req_mask  = pre_attr_mask;
     request->setattr.r_pre_attr.va_set_mask  = 0;

--- a/src/vfs/vfs_proc_setattr.c
+++ b/src/vfs/vfs_proc_setattr.c
@@ -131,10 +131,25 @@ chimera_vfs_setattr_dispatch(
     request->proto_callback                  = callback;
     request->proto_private_data              = private_data;
 
-    /* A metadata change invalidates any cached attributes a delegation/oplock
-    * holder has; recall every caching lease on the target before dispatch. */
+    /* Recall flavor depends on whether this setattr changes file *data*:
+     *
+     *   - A SIZE change (truncate/extend) alters the bytes, so a holder's cached
+     *     read data is now stale: recall fully (flush_only = 0 -> break to NONE),
+     *     invalidating the read cache.  Retaining R here returns stale bytes
+     *     (fsx MAPREAD corruption).
+     *   - An attribute-only setattr (mtime/atime/DOS/ACL/owner -- no data change)
+     *     must still flush a write-caching holder's dirty pages, because the
+     *     resulting mtime bump makes other clients revalidate and re-read from
+     *     the backend; but the holder's read cache stays valid (the data did not
+     *     change), so flush_only = 1 keeps R|H.  This is what stops a single
+     *     client's metadata storm (rewinddir/fsstress Create+SetInfo+Close churn)
+     *     from recalling its own lease on every attribute set while preserving
+     *     coherence. */
+    int flush_only = (set_attr->va_set_mask & CHIMERA_VFS_ATTR_SIZE) ? 0 : 1;
+
     chimera_vfs_io_recall(request, request->fh, request->fh_len,
-                          request->fh_hash, chimera_vfs_dispatch);
+                          request->fh_hash, flush_only,
+                          chimera_vfs_dispatch);
 } /* chimera_vfs_setattr_dispatch */
 
 /*

--- a/src/vfs/vfs_state.c
+++ b/src/vfs/vfs_state.c
@@ -1384,6 +1384,47 @@ chimera_vfs_caching_grant_release(
 } /* chimera_vfs_caching_grant_release */
 
 SYMBOL_EXPORT bool
+chimera_vfs_state_caching_breaking(
+    struct chimera_vfs_state               *state,
+    const uint8_t                          *fh,
+    uint8_t                                 fh_len,
+    uint64_t                                fh_hash,
+    const struct chimera_vfs_caching_grant *except)
+{
+    struct chimera_vfs_file_state *file;
+    struct chimera_vfs_lease      *cur;
+    bool                           breaking = false;
+
+    if (!state || fh_len == 0) {
+        return false;
+    }
+
+    file = chimera_vfs_state_get(state, fh, fh_len, fh_hash, false);
+    if (!file) {
+        return false;
+    }
+
+    pthread_mutex_lock(&file->lock);
+    for (cur = file->caching_leases; cur; cur = cur->next) {
+        /* Only an RqLs LEASE break holds the conflicting open pending (MS-SMB2
+         * 3.3.5.9).  A legacy oplock keeps chimera's optimistic post-break
+         * behavior (the open proceeds without waiting), so exclude is_oplock
+         * grants here. */
+        if (cur->break_state == CHIMERA_VFS_BREAK_BREAKING &&
+            cur->grant && cur->grant->break_ack_required &&
+            !cur->grant->is_oplock &&
+            cur->grant != except) {
+            breaking = true;
+            break;
+        }
+    }
+    pthread_mutex_unlock(&file->lock);
+
+    chimera_vfs_state_put(state, file);
+    return breaking;
+} /* chimera_vfs_state_caching_breaking */
+
+SYMBOL_EXPORT bool
 chimera_vfs_lease_acquire_cancel(
     struct chimera_vfs_state           *state,
     struct chimera_vfs_pending_acquire *ticket)

--- a/src/vfs/vfs_state.c
+++ b/src/vfs/vfs_state.c
@@ -1174,6 +1174,61 @@ chimera_vfs_caching_grant_find_locked(
     return NULL;
 } /* chimera_vfs_caching_grant_find_locked */
 
+SYMBOL_EXPORT struct chimera_vfs_caching_grant *
+chimera_vfs_caching_grant_coalesce(
+    struct chimera_vfs_file_state        *file,
+    const struct chimera_vfs_lease_owner *owner,
+    struct chimera_vfs_lease_mode         want,
+    int                                   upgrade_ok)
+{
+    struct chimera_vfs_caching_grant *grant;
+
+    pthread_mutex_lock(&file->lock);
+    grant = chimera_vfs_caching_grant_find_locked(file, owner);
+    if (grant) {
+        grant->refcount++;
+
+        if (upgrade_ok) {
+            uint8_t cur = grant->lease.mode.granted;
+
+            /* MS-SMB2 3.3.5.9.11: a lease is upgraded to the REQUESTED state only
+             * when that state is a (strict) superset of the currently held state;
+             * a request that is not a superset (a downgrade, or a lateral move such
+             * as RH -> RW) leaves the lease unchanged.  This is not a bitwise union:
+             * RH + a request for RW stays RH, it does not become RWH. */
+            if (want.granted != cur &&
+                (want.granted & cur) == cur) {
+                struct chimera_vfs_lease  probe    = grant->lease;
+                struct chimera_vfs_lease *conflict = NULL;
+
+                /* And only if the larger mode is grantable without breaking another
+                 * owner's holder (would_conflict coalesces our own same-owner
+                 * lease).  Never break another lease for an upgrade -- keep the
+                 * current mode otherwise. */
+                probe.mode.granted = want.granted;
+                if (chimera_vfs_state_would_conflict(file, &probe, &conflict) ==
+                    CHIMERA_VFS_LEASE_GRANTED) {
+                    grant->lease.mode.granted = want.granted;
+                    grant->epoch++;
+                }
+            }
+        }
+    }
+    pthread_mutex_unlock(&file->lock);
+    return grant;
+} /* chimera_vfs_caching_grant_coalesce */
+
+SYMBOL_EXPORT void
+chimera_vfs_caching_grant_link(
+    struct chimera_vfs_file_state    *file,
+    struct chimera_vfs_caching_grant *grant)
+{
+    pthread_mutex_lock(&file->lock);
+    grant->grant_next    = file->caching_grants;
+    file->caching_grants = grant;
+    pthread_mutex_unlock(&file->lock);
+} /* chimera_vfs_caching_grant_link */
+
 SYMBOL_EXPORT enum chimera_vfs_lease_result
 chimera_vfs_caching_grant_acquire(
     struct chimera_vfs_state             *state,
@@ -1193,35 +1248,11 @@ chimera_vfs_caching_grant_acquire(
     }
 
     /* Coalesce onto an existing same-owner grant. */
-    pthread_mutex_lock(&file->lock);
-    grant = chimera_vfs_caching_grant_find_locked(file, owner);
+    grant = chimera_vfs_caching_grant_coalesce(file, owner, want, upgrade_ok);
     if (grant) {
-        grant->refcount++;
-
-        if (upgrade_ok) {
-            uint8_t target = grant->lease.mode.granted | want.granted;
-
-            if (target != grant->lease.mode.granted) {
-                struct chimera_vfs_lease  probe    = grant->lease;
-                struct chimera_vfs_lease *conflict = NULL;
-
-                /* Upgrade in place only if the larger mode is grantable without
-                 * breaking another owner's holder (would_conflict coalesces our
-                 * own same-owner lease).  Never break another lease for an
-                 * upgrade -- keep the current mode otherwise (MS-SMB2 3.3.5.9). */
-                probe.mode.granted = target;
-                if (chimera_vfs_state_would_conflict(file, &probe, &conflict) ==
-                    CHIMERA_VFS_LEASE_GRANTED) {
-                    grant->lease.mode.granted = target;
-                    grant->epoch++;
-                }
-            }
-        }
-        pthread_mutex_unlock(&file->lock);
         *grant_out = grant;
         return CHIMERA_VFS_LEASE_GRANTED;
     }
-    pthread_mutex_unlock(&file->lock);
 
     /* No existing grant: allocate one and arbitrate against other owners. */
     grant = calloc(1, sizeof(*grant));

--- a/src/vfs/vfs_state.c
+++ b/src/vfs/vfs_state.c
@@ -17,6 +17,11 @@
  */
 #define CHIMERA_VFS_STATE_DEFAULT_BREAK_DEADLINE_MS 30000
 
+/* Upper bound on caching leases broken / revoked in a single batched pass.  A
+ * file with more concurrent caching holders than this is pathological; any
+ * excess is handled on the next pass. */
+#define CHIMERA_VFS_STATE_MAX_BREAK_BATCH           64
+
 /*
  * Implicit I/O leases held by chimera on behalf of leaseless actors are
  * dropped once they have been idle (no in-flight I/O) for this long.  Keeps
@@ -1383,6 +1388,46 @@ chimera_vfs_caching_grant_release(
     }
 } /* chimera_vfs_caching_grant_release */
 
+SYMBOL_EXPORT void
+chimera_vfs_state_revoke_breaks(
+    struct chimera_vfs_state               *state,
+    const uint8_t                          *fh,
+    uint8_t                                 fh_len,
+    uint64_t                                fh_hash,
+    const struct chimera_vfs_caching_grant *except)
+{
+    struct chimera_vfs_file_state *file;
+    struct chimera_vfs_lease      *to_revoke[CHIMERA_VFS_STATE_MAX_BREAK_BATCH];
+    struct chimera_vfs_lease      *cur;
+    int                            n = 0;
+    int                            i;
+
+    if (!state || fh_len == 0) {
+        return;
+    }
+
+    file = chimera_vfs_state_get(state, fh, fh_len, fh_hash, false);
+    if (!file) {
+        return;
+    }
+
+    pthread_mutex_lock(&file->lock);
+    for (cur = file->caching_leases; cur; cur = cur->next) {
+        if (cur->break_state == CHIMERA_VFS_BREAK_BREAKING &&
+            cur->grant != except &&
+            n < CHIMERA_VFS_STATE_MAX_BREAK_BATCH) {
+            to_revoke[n++] = cur;
+        }
+    }
+    pthread_mutex_unlock(&file->lock);
+
+    for (i = 0; i < n; i++) {
+        chimera_vfs_lease_revoke(to_revoke[i]);
+    }
+
+    chimera_vfs_state_put(state, file);
+} /* chimera_vfs_state_revoke_breaks */
+
 SYMBOL_EXPORT bool
 chimera_vfs_state_caching_breaking(
     struct chimera_vfs_state               *state,
@@ -1785,11 +1830,6 @@ chimera_vfs_state_break_caching(
 /* -------------------------------------------------------------------- */
 /* Break-on-write                                                       */
 /* -------------------------------------------------------------------- */
-
-/* Upper bound on caching leases broken by a single write.  A file with
- * more concurrent caching holders than this is pathological; any excess
- * is left for a subsequent write to break. */
-#define CHIMERA_VFS_STATE_MAX_BREAK_BATCH 64
 
 /* A write invalidates every read-caching (R) lease on the file: those
  * holders can no longer trust their cached data, so each must break down
@@ -2429,6 +2469,39 @@ chimera_vfs_io_lease_release(struct chimera_vfs_request *request)
     }
 } /* chimera_vfs_io_lease_release */
 
+/* Revoke every caching lease on `file` that has been BREAKING past its break
+ * deadline (the holder never acknowledged).  Returns true if any were revoked.
+ * Caller must NOT hold file->lock; revoke takes it internally.  Collect under the
+ * lock, then revoke (which re-locks + pumps), so the list walk is not disturbed
+ * mid-revoke. */
+static bool
+chimera_vfs_state_revoke_expired_breaks(
+    struct chimera_vfs_state      *state,
+    struct chimera_vfs_file_state *file)
+{
+    struct chimera_vfs_lease *expired[CHIMERA_VFS_STATE_MAX_BREAK_BATCH];
+    struct chimera_vfs_lease *cur;
+    int                       n = 0;
+    int                       i;
+
+    (void) state;
+
+    pthread_mutex_lock(&file->lock);
+    for (cur = file->caching_leases; cur; cur = cur->next) {
+        if (cur->break_state == CHIMERA_VFS_BREAK_BREAKING &&
+            chimera_vfs_break_deadline_passed(cur) &&
+            n < CHIMERA_VFS_STATE_MAX_BREAK_BATCH) {
+            expired[n++] = cur;
+        }
+    }
+    pthread_mutex_unlock(&file->lock);
+
+    for (i = 0; i < n; i++) {
+        chimera_vfs_lease_revoke(expired[i]);
+    }
+    return n > 0;
+} /* chimera_vfs_state_revoke_expired_breaks */
+
 SYMBOL_EXPORT void
 chimera_vfs_state_reap_idle(
     struct chimera_vfs_state *state,
@@ -2480,6 +2553,11 @@ chimera_vfs_state_reap_idle(
                 /* finish_drain pumps the wait queue itself. */
                 chimera_vfs_implicit_finish_drain(state, file);
             } else if (has_waiters) {
+                /* A parked I/O / namespace op is waiting on a caching holder to
+                 * break.  If that holder never acknowledged and its break
+                 * deadline has elapsed, forcibly revoke it (MS-SMB2 / NFSv4
+                 * recall timeout) so the waiter can proceed, then re-pump. */
+                chimera_vfs_state_revoke_expired_breaks(state, file);
                 chimera_vfs_state_pump_io(state, file);
             }
 

--- a/src/vfs/vfs_state.c
+++ b/src/vfs/vfs_state.c
@@ -1153,6 +1153,155 @@ chimera_vfs_lease_release(
     chimera_vfs_state_remove(state, file, lease);
 } /* chimera_vfs_lease_release */
 
+/* -------------------------------------------------------------------- */
+/* Caching grant — VFS-owned shared caching lease                       */
+/* -------------------------------------------------------------------- */
+
+/* Find an existing caching grant on `file` matching `owner`.  Caller holds
+ * file->lock. */
+static struct chimera_vfs_caching_grant *
+chimera_vfs_caching_grant_find_locked(
+    struct chimera_vfs_file_state        *file,
+    const struct chimera_vfs_lease_owner *owner)
+{
+    struct chimera_vfs_caching_grant *g;
+
+    for (g = file->caching_grants; g; g = g->grant_next) {
+        if (chimera_vfs_lease_owner_equal(&g->lease.owner, owner)) {
+            return g;
+        }
+    }
+    return NULL;
+} /* chimera_vfs_caching_grant_find_locked */
+
+SYMBOL_EXPORT enum chimera_vfs_lease_result
+chimera_vfs_caching_grant_acquire(
+    struct chimera_vfs_state             *state,
+    struct chimera_vfs_file_state        *file,
+    const struct chimera_vfs_lease_owner *owner,
+    struct chimera_vfs_lease_mode         want,
+    int                                   upgrade_ok,
+    struct chimera_vfs_caching_grant    **grant_out,
+    struct chimera_vfs_lease            **conflict_out)
+{
+    struct chimera_vfs_caching_grant *grant, *existing;
+    enum chimera_vfs_lease_result     result;
+
+    *grant_out = NULL;
+    if (conflict_out) {
+        *conflict_out = NULL;
+    }
+
+    /* Coalesce onto an existing same-owner grant. */
+    pthread_mutex_lock(&file->lock);
+    grant = chimera_vfs_caching_grant_find_locked(file, owner);
+    if (grant) {
+        grant->refcount++;
+
+        if (upgrade_ok) {
+            uint8_t target = grant->lease.mode.granted | want.granted;
+
+            if (target != grant->lease.mode.granted) {
+                struct chimera_vfs_lease  probe    = grant->lease;
+                struct chimera_vfs_lease *conflict = NULL;
+
+                /* Upgrade in place only if the larger mode is grantable without
+                 * breaking another owner's holder (would_conflict coalesces our
+                 * own same-owner lease).  Never break another lease for an
+                 * upgrade -- keep the current mode otherwise (MS-SMB2 3.3.5.9). */
+                probe.mode.granted = target;
+                if (chimera_vfs_state_would_conflict(file, &probe, &conflict) ==
+                    CHIMERA_VFS_LEASE_GRANTED) {
+                    grant->lease.mode.granted = target;
+                    grant->epoch++;
+                }
+            }
+        }
+        pthread_mutex_unlock(&file->lock);
+        *grant_out = grant;
+        return CHIMERA_VFS_LEASE_GRANTED;
+    }
+    pthread_mutex_unlock(&file->lock);
+
+    /* No existing grant: allocate one and arbitrate against other owners. */
+    grant = calloc(1, sizeof(*grant));
+    if (!grant) {
+        return CHIMERA_VFS_LEASE_DENIED;
+    }
+    grant->lease.kind        = CHIMERA_VFS_LEASE_CACHING;
+    grant->lease.mode        = want;
+    grant->lease.owner       = *owner;
+    grant->lease.grant       = grant;
+    grant->lease.break_state = CHIMERA_VFS_BREAK_IDLE;
+    grant->file              = file;
+    grant->refcount          = 1;
+    grant->epoch             = 1;
+
+    result = chimera_vfs_state_try_insert(state, file, &grant->lease, conflict_out);
+    if (result != CHIMERA_VFS_LEASE_GRANTED) {
+        free(grant);
+        return result;
+    }
+
+    /* Link onto the per-file grant index.  Re-check under the lock that no peer
+     * created the same-owner grant while try_insert ran (would_conflict
+     * coalesces same-owner, so two concurrent first-acquires could each insert a
+     * lease for one owner -- collapse onto the one that linked first). */
+    pthread_mutex_lock(&file->lock);
+    existing = chimera_vfs_caching_grant_find_locked(file, owner);
+    if (existing) {
+        existing->refcount++;
+        chimera_vfs_file_state_remove_lease(file, &grant->lease);
+        pthread_mutex_unlock(&file->lock);
+        free(grant);
+        *grant_out = existing;
+        return CHIMERA_VFS_LEASE_GRANTED;
+    }
+    grant->grant_next    = file->caching_grants;
+    file->caching_grants = grant;
+    pthread_mutex_unlock(&file->lock);
+
+    *grant_out = grant;
+    return CHIMERA_VFS_LEASE_GRANTED;
+} /* chimera_vfs_caching_grant_acquire */
+
+SYMBOL_EXPORT void
+chimera_vfs_caching_grant_release(
+    struct chimera_vfs_state         *state,
+    struct chimera_vfs_caching_grant *grant)
+{
+    struct chimera_vfs_file_state     *file = grant->file;
+    struct chimera_vfs_caching_grant **pp;
+    bool                               last;
+
+    pthread_mutex_lock(&file->lock);
+
+    chimera_vfs_abort_if(grant->refcount == 0,
+                         "double release of caching grant");
+    grant->refcount--;
+    last = (grant->refcount == 0);
+
+    if (last) {
+        /* Unlink from the owner index and from the caching_leases list. */
+        for (pp = &file->caching_grants; *pp; pp = &(*pp)->grant_next) {
+            if (*pp == grant) {
+                *pp = grant->grant_next;
+                break;
+            }
+        }
+        chimera_vfs_file_state_remove_lease(file, &grant->lease);
+    }
+
+    pthread_mutex_unlock(&file->lock);
+
+    if (last) {
+        /* Removing the lease may unblock a pending acquire or parked I/O. */
+        chimera_vfs_state_pump_pending(state, file);
+        chimera_vfs_state_pump_io(state, file);
+        free(grant);
+    }
+} /* chimera_vfs_caching_grant_release */
+
 SYMBOL_EXPORT bool
 chimera_vfs_lease_acquire_cancel(
     struct chimera_vfs_state           *state,

--- a/src/vfs/vfs_state.c
+++ b/src/vfs/vfs_state.c
@@ -1367,7 +1367,8 @@ static bool
 chimera_vfs_break_caching_file(
     struct chimera_vfs_state             *state,
     struct chimera_vfs_file_state        *file,
-    const struct chimera_vfs_open_handle *skip_handle)
+    const struct chimera_vfs_open_handle *skip_handle,
+    bool                                  flush_only)
 {
     bool had;
 
@@ -1389,6 +1390,15 @@ chimera_vfs_break_caching_file(
             /* The mutation is issued through this very lease's open handle: the
              * holder is coherent with its own change, so do not recall it. */
             if (skip_handle && cur->owner.op_handle == skip_handle) {
+                continue;
+            }
+            /* Flush recall: only a write-caching (W) holder has dirty data to
+             * flush; a read-only / handle-only holder keeps its cache untouched
+             * (a data setattr does not stale a pure read cache -- the client
+             * revalidates on the resulting mtime/size change).  This is what lets
+             * a same-client metadata storm stop churning: once a holder has
+             * dropped W it is no longer recalled. */
+            if (flush_only && !(cur->mode.granted & CHIMERA_VFS_LEASE_MODE_W)) {
                 continue;
             }
             if (cur->break_state == CHIMERA_VFS_BREAK_IDLE) {
@@ -1416,13 +1426,23 @@ chimera_vfs_break_caching_file(
         pthread_mutex_unlock(&file->lock);
 
         if (to_break) {
-            /* Break to NONE (needed_mode 0), not to the currently-granted
-             * mode: a namespace/metadata mutation invalidates the holder's
-             * cache entirely.  Passing the granted mode would let the SMB
-             * lease break_cb retain its read cache (LEVEL_II) and ack with a
-             * non-zero mode, so this loop would see granted != 0 forever and
-             * the caller would park permanently.  NFSv4 delegations recall
-             * fully regardless of needed_mode, so 0 is correct for them too. */
+            /* Break to NONE (needed_mode 0): the holder writes back dirty data
+             * and drops its cache entirely.  This holds for both recall flavors.
+             *
+             * A flush recall would ideally retain the holder's read cache (break
+             * only W, keep R|H) to spare a metadata-storm client a full re-lease
+             * per op.  But retaining R is only coherent if the changed region of
+             * that read cache is also invalidated, which chimera has no mechanism
+             * for today -- retaining R after a flush serves stale bytes (fsx
+             * MAPREAD corruption).  So a flush still revokes its W holders to
+             * NONE; what flush_only buys is the *filter* above -- read-only /
+             * handle-only holders, which an attribute-only setattr does not
+             * stale, are left untouched rather than needlessly recalled.  Fully
+             * decoupling the flush from the read-cache drop is a follow-up.
+             *
+             * Passing the granted mode would let the SMB break_cb retain a read
+             * cache and ack non-zero, so this loop would see granted != 0 forever
+             * and park permanently.  NFSv4 delegations recall fully regardless. */
             chimera_vfs_lease_begin_break(state, to_break, 0,
                                           CHIMERA_VFS_NFS_DELEG_METAOP_MS);
         } else if (to_revoke) {
@@ -1444,11 +1464,19 @@ chimera_vfs_break_caching_file(
     had = false;
     {
         struct chimera_vfs_lease *cur;
+        /* A flush recall only needs the write cache gone (W flushed); the holder
+         * may keep R|H.  So it blocks only while some holder retains an effective
+         * W -- a notified (BREAKING) SMB holder has effective == its retained
+         * R|H (no W), so the op proceeds at once and the client's flush ack
+         * arrives asynchronously (the client serialises break->writeback->reply
+         * on its own connection, so a later read by it is still coherent).  A
+         * namespace recall blocks while any effective mode remains. */
+        uint8_t                   block_mask = flush_only ? CHIMERA_VFS_LEASE_MODE_W : 0xFF;
         for (cur = file->caching_leases; cur; cur = cur->next) {
             if (skip_handle && cur->owner.op_handle == skip_handle) {
                 continue;
             }
-            if (chimera_vfs_lease_effective_granted(cur) != 0) {
+            if (chimera_vfs_lease_effective_granted(cur) & block_mask) {
                 had = true;
                 break;
             }
@@ -1475,8 +1503,9 @@ chimera_vfs_state_break_caching(
     }
 
     /* No skip handle: this whole-file recall (NFSv4 REMOVE/RENAME) breaks every
-     * caching holder, including the operating client's own delegation. */
-    had = chimera_vfs_break_caching_file(state, file, NULL);
+     * caching holder, including the operating client's own delegation.  It is a
+     * namespace mutation, so revoke fully (flush_only == false). */
+    had = chimera_vfs_break_caching_file(state, file, NULL, false);
 
     chimera_vfs_state_put(state, file);
     return had;
@@ -1868,7 +1897,8 @@ chimera_vfs_io_try(
      * on chimera's behalf.  The periodic maintenance pass re-pumps parked
      * waiters so an unresponsive holder is revoked at its recall deadline. */
     if (request->io_recall_all) {
-        if (chimera_vfs_break_caching_file(state, file, request->io_handle)) {
+        if (chimera_vfs_break_caching_file(state, file, request->io_handle,
+                                           request->io_recall_flush_only)) {
             pthread_mutex_lock(&file->lock);
             chimera_vfs_io_park_locked(file, request);
             request->io_lease_file = file;
@@ -2055,15 +2085,17 @@ chimera_vfs_io_recall(
     const uint8_t              *fh,
     uint8_t                     fh_len,
     uint64_t                    fh_hash,
+    int                         flush_only,
     void (                     *next )(struct chimera_vfs_request *request))
 {
     struct chimera_vfs_state      *state = request->thread->vfs->vfs_state;
     struct chimera_vfs_file_state *file;
 
-    request->io_next           = next;
-    request->io_lease_file     = NULL;
-    request->io_recall_all     = 1;
-    request->io_owns_lease_ref = 1;
+    request->io_next              = next;
+    request->io_lease_file        = NULL;
+    request->io_recall_all        = 1;
+    request->io_recall_flush_only = flush_only ? 1 : 0;
+    request->io_owns_lease_ref    = 1;
 
     /* Fast path: no per-file state means no caching lease to recall. */
     if (!state || fh_len == 0) {

--- a/src/vfs/vfs_state.c
+++ b/src/vfs/vfs_state.c
@@ -1424,29 +1424,40 @@ chimera_vfs_state_break_on_write(
     chimera_vfs_state_put(state, file);
 } /* chimera_vfs_state_break_on_write */
 
-/* Break-on-open: a conflicting open by a *different* owner that is not itself
- * data-modifying downgrades an exclusive (W) or batch (W|H) holder to a shared
- * read cache (LEVEL_II).  We break every other-owner caching lease that holds
- * W or H, retaining only the read bit (needed_mode = R), and leave pure
- * read-cache (LEVEL_II) holders untouched -- multiple readers coexist with a
- * new opener.  This is the SMB break-on-second-open semantic; it is optimistic
- * (the break is queued and the opener proceeds immediately). */
-static void
-chimera_vfs_break_caching_for_open(
+/* Break-on-open: a conflicting open by a *different* owner breaks caching
+ * holders.  `trigger_bits` selects which holders break -- only a lease whose
+ * granted mode intersects `trigger_bits` is affected -- and `retain_mode` is
+ * the mask the holder keeps (R to downgrade an exclusive/batch oplock to
+ * LEVEL_II, 0 to break all the way to NONE).  Holders the opener owns are
+ * skipped.  The break is optimistic from vfs_state's point of view (it is
+ * queued; the opener proceeds), but the SMB layer may choose to wait. */
+SYMBOL_EXPORT void
+chimera_vfs_state_break_caching_for_open(
     struct chimera_vfs_state             *state,
-    struct chimera_vfs_file_state        *file,
-    const struct chimera_vfs_lease_owner *opener)
+    const uint8_t                        *fh,
+    uint8_t                               fh_len,
+    uint64_t                              fh_hash,
+    const struct chimera_vfs_lease_owner *opener,
+    uint8_t                               trigger_bits,
+    uint8_t                               retain_mode)
 {
-    struct chimera_vfs_lease *cur;
-    struct chimera_vfs_lease *to_break[CHIMERA_VFS_STATE_MAX_BREAK_BATCH];
-    int                       n = 0;
-    int                       i;
+    struct chimera_vfs_file_state *file;
+    struct chimera_vfs_lease      *cur;
+    struct chimera_vfs_lease      *to_break[CHIMERA_VFS_STATE_MAX_BREAK_BATCH];
+    int                            n = 0;
+    int                            i;
+
+    file = chimera_vfs_state_get(state, fh, fh_len, fh_hash, false);
+    if (!file) {
+        return;
+    }
 
     pthread_mutex_lock(&file->lock);
 
     for (cur = file->caching_leases; cur; cur = cur->next) {
-        if ((cur->mode.granted & (CHIMERA_VFS_LEASE_MODE_W |
-                                  CHIMERA_VFS_LEASE_MODE_H)) == 0) {
+        /* Only holders that actually hold one of the trigger bits beyond what
+         * they get to retain need to break. */
+        if ((cur->mode.granted & trigger_bits & ~retain_mode) == 0) {
             continue;
         }
         if (chimera_vfs_lease_owner_equal(&cur->owner, opener)) {
@@ -1460,30 +1471,11 @@ chimera_vfs_break_caching_for_open(
     pthread_mutex_unlock(&file->lock);
 
     for (i = 0; i < n; i++) {
-        chimera_vfs_lease_begin_break(state, to_break[i],
-                                      CHIMERA_VFS_LEASE_MODE_R, 0);
+        chimera_vfs_lease_begin_break(state, to_break[i], retain_mode, 0);
     }
-} /* chimera_vfs_break_caching_for_open */
-
-SYMBOL_EXPORT void
-chimera_vfs_state_break_on_open(
-    struct chimera_vfs_state             *state,
-    const uint8_t                        *fh,
-    uint8_t                               fh_len,
-    uint64_t                              fh_hash,
-    const struct chimera_vfs_lease_owner *opener)
-{
-    struct chimera_vfs_file_state *file;
-
-    file = chimera_vfs_state_get(state, fh, fh_len, fh_hash, false);
-    if (!file) {
-        return;
-    }
-
-    chimera_vfs_break_caching_for_open(state, file, opener);
 
     chimera_vfs_state_put(state, file);
-} /* chimera_vfs_state_break_on_open */
+} /* chimera_vfs_state_break_caching_for_open */
 
 /* -------------------------------------------------------------------- */
 /* Implicit I/O lease                                                   */

--- a/src/vfs/vfs_state.c
+++ b/src/vfs/vfs_state.c
@@ -646,7 +646,14 @@ chimera_vfs_state_would_conflict(
                     continue;
                 }
 
-                if (cur->mode.granted & CHIMERA_VFS_LEASE_MODE_H) {
+                /* A handle-caching holder is broken by a conflicting open's share
+                 * reservation ONLY if it is a legacy SMB oplock (batch): the holder
+                 * closes its deferred handle so the open can proceed.  An SMB2 RqLs
+                 * lease shares handle caching across owners and is NOT broken by
+                 * another open -- its (exclusive) write cache is handled by the
+                 * caching-contention path instead. */
+                if ((cur->mode.granted & CHIMERA_VFS_LEASE_MODE_H) &&
+                    cur->grant && cur->grant->is_oplock) {
                     want_break_h = true;
                 }
 
@@ -714,8 +721,24 @@ chimera_vfs_state_would_conflict(
                     continue;
                 }
                 if (chimera_vfs_caching_conflict(cur, probe)) {
+                    /* Breaking a holder only resolves the conflict if the holder
+                     * actually has the exclusive WRITE cache to give up.  For an SMB
+                     * caching holder that holds only read/handle caching (no W), the
+                     * conflict is the ACQUIRER wanting W while a peer caches reads --
+                     * the holder keeps R|H and it is the acquirer that must drop W.
+                     * Report DENIED so the acquirer's settle caps itself to R|H,
+                     * rather than firing a no-op break on the holder (which would
+                     * livelock: would_conflict keeps returning BREAKING).  NFSv4
+                     * delegations are recalled in full regardless, so the W gate
+                     * applies to SMB holders only. */
+                    uint8_t holder_eff = chimera_vfs_lease_effective_granted(cur);
+                    bool smb_no_w      =
+                        cur->owner.protocol == CHIMERA_VFS_LEASE_PROTO_SMB2 &&
+                        !(holder_eff & CHIMERA_VFS_LEASE_MODE_W);
+
                     if (cur->owner.break_cb &&
-                        cur->break_state == CHIMERA_VFS_BREAK_IDLE) {
+                        cur->break_state == CHIMERA_VFS_BREAK_IDLE &&
+                        !smb_no_w) {
                         has_breakable_conflict = true;
                         if (conflict_out && !*conflict_out) {
                             *conflict_out = cur;
@@ -879,6 +902,27 @@ chimera_vfs_file_state_remove_lease(
     lease->file = NULL;
 } /* chimera_vfs_file_state_remove_lease */
 
+/* The mode a conflicting holder is allowed to RETAIN when `acquirer` forces it to
+ * break.  When an SMB caching acquirer (open) contends an SMB caching holder
+ * (oplock / lease), only the WRITE cache is exclusive: the holder gives up W but
+ * keeps read + handle caching, regardless of the acquirer's own requested mode
+ * (a second opener never grants itself W while a peer caches the file).  Every
+ * other break -- NFSv4 delegation recall, a SHARE acquirer invalidating a cache
+ * -- retains the acquirer's mode, the pre-existing behavior. */
+static inline uint8_t
+chimera_vfs_break_retain_for(
+    const struct chimera_vfs_lease *acquirer,
+    const struct chimera_vfs_lease *holder)
+{
+    if (acquirer->kind == CHIMERA_VFS_LEASE_CACHING &&
+        holder->kind == CHIMERA_VFS_LEASE_CACHING &&
+        holder->owner.protocol == CHIMERA_VFS_LEASE_PROTO_SMB2) {
+        return CHIMERA_VFS_LEASE_MODE_R | CHIMERA_VFS_LEASE_MODE_H |
+               CHIMERA_VFS_LEASE_MODE_D;
+    }
+    return acquirer->mode.granted;
+} /* chimera_vfs_break_retain_for */
+
 SYMBOL_EXPORT enum chimera_vfs_lease_result
 chimera_vfs_state_try_insert(
     struct chimera_vfs_state      *state,
@@ -952,7 +996,8 @@ chimera_vfs_state_try_insert(
                     (conflict->owner.protocol == CHIMERA_VFS_LEASE_PROTO_NFSV4)
                     ? CHIMERA_VFS_NFS_DELEG_RECALL_MS : 0;
                 chimera_vfs_lease_begin_break(state, conflict,
-                                              lease->mode.granted, deadline_ms);
+                                              chimera_vfs_break_retain_for(lease, conflict),
+                                              deadline_ms);
                 began_live_break = true;
             } else {
                 /* Surfaced because its recall deadline elapsed -- the holder
@@ -1810,6 +1855,16 @@ chimera_vfs_state_break_caching_for_open(
         if (chimera_vfs_lease_owner_equal(&cur->owner, opener)) {
             continue;
         }
+        /* A pure handle-trigger break (the pre-share-check pass) is a legacy SMB
+         * oplock behavior: a batch oplock's handle is recalled before the share
+         * decision so the holder can close.  An SMB2 RqLs LEASE keeps its handle
+         * cache on a conflicting open (only its write cache is exclusive), so do
+         * not handle-break a lease here -- its write cache is invalidated by the
+         * separate W-trigger pass / caching-contention break instead. */
+        if (trigger_bits == CHIMERA_VFS_LEASE_MODE_H &&
+            cur->grant && !cur->grant->is_oplock) {
+            continue;
+        }
         if (n < CHIMERA_VFS_STATE_MAX_BREAK_BATCH) {
             to_break[n++] = cur;
         }
@@ -1961,7 +2016,8 @@ chimera_vfs_state_drive_breaks(
                 (conflict->owner.protocol == CHIMERA_VFS_LEASE_PROTO_NFSV4)
                 ? CHIMERA_VFS_NFS_DELEG_RECALL_MS : 0;
             chimera_vfs_lease_begin_break(state, conflict,
-                                          probe->mode.granted, deadline_ms);
+                                          chimera_vfs_break_retain_for(probe, conflict),
+                                          deadline_ms);
         } else {
             chimera_vfs_lease_revoke(conflict);
         }

--- a/src/vfs/vfs_state.c
+++ b/src/vfs/vfs_state.c
@@ -567,6 +567,14 @@ chimera_vfs_state_would_conflict(
             struct chimera_vfs_lease *idle_break    = NULL;
             struct chimera_vfs_lease *expired_break = NULL;
 
+            /* An inert (granted=0, denied=0) SHARE entry is an attribute-only
+             * open registered purely for visibility (sole-access / delete-
+             * pending / stat-open queries).  It can neither conflict with nor
+             * break any holder, so grant it with no side effects. */
+            if (probe->mode.granted == 0 && probe->mode.denied == 0) {
+                return CHIMERA_VFS_LEASE_GRANTED;
+            }
+
             for (cur = file->share_resvs; cur; cur = cur->next) {
                 if (chimera_vfs_lease_owner_equal(&cur->owner, &probe->owner)) {
                     continue;
@@ -729,6 +737,13 @@ chimera_vfs_state_would_conflict(
                 for (cur = file->share_resvs; cur; cur = cur->next) {
                     if (cur->owner.client_key == probe->owner.client_key) {
                         continue; /* the requesting client's own open(s) */
+                    }
+                    /* An inert (0,0) attribute-only registration is not a real
+                     * data opener and does not preclude an exclusive oplock --
+                     * matching the prior behavior where stat-opens took no share
+                     * reservation at all. */
+                    if (cur->mode.granted == 0 && cur->mode.denied == 0) {
+                        continue;
                     }
                     if (conflict_out) {
                         *conflict_out = cur;

--- a/src/vfs/vfs_state.c
+++ b/src/vfs/vfs_state.c
@@ -1826,8 +1826,17 @@ chimera_vfs_break_caching_file(
              * (a data setattr does not stale a pure read cache -- the client
              * revalidates on the resulting mtime/size change).  This is what lets
              * a same-client metadata storm stop churning: once a holder has
-             * dropped W it is no longer recalled. */
-            if (flush_only && !(cur->mode.granted & CHIMERA_VFS_LEASE_MODE_W)) {
+             * dropped W it is no longer recalled.
+             *
+             * This filter is an SMB read-cache optimization only.  An NFSv4
+             * delegation is not just a data cache: it guarantees attribute
+             * stability and that no foreign change occurs without a recall (RFC
+             * 7530 10.4), so a metadata-only setattr (e.g. a server-side chmod,
+             * pynfs DELEG20) MUST recall a read delegation held by another party.
+             * The mutating handle's own lease is already spared by skip_handle
+             * above, so this only ever recalls foreign delegations. */
+            if (flush_only && !(cur->mode.granted & CHIMERA_VFS_LEASE_MODE_W) &&
+                cur->owner.protocol != CHIMERA_VFS_LEASE_PROTO_NFSV4) {
                 continue;
             }
             if (cur->break_state == CHIMERA_VFS_BREAK_IDLE) {

--- a/src/vfs/vfs_state.c
+++ b/src/vfs/vfs_state.c
@@ -726,24 +726,17 @@ chimera_vfs_state_would_conflict(
                     continue;
                 }
                 if (chimera_vfs_caching_conflict(cur, probe)) {
-                    /* Breaking a holder only resolves the conflict if the holder
-                     * actually has the exclusive WRITE cache to give up.  For an SMB
-                     * caching holder that holds only read/handle caching (no W), the
-                     * conflict is the ACQUIRER wanting W while a peer caches reads --
-                     * the holder keeps R|H and it is the acquirer that must drop W.
-                     * Report DENIED so the acquirer's settle caps itself to R|H,
-                     * rather than firing a no-op break on the holder (which would
-                     * livelock: would_conflict keeps returning BREAKING).  NFSv4
-                     * delegations are recalled in full regardless, so the W gate
-                     * applies to SMB holders only. */
-                    uint8_t holder_eff = chimera_vfs_lease_effective_granted(cur);
-                    bool smb_no_w      =
-                        cur->owner.protocol == CHIMERA_VFS_LEASE_PROTO_SMB2 &&
-                        !(holder_eff & CHIMERA_VFS_LEASE_MODE_W);
-
+                    /* A conflicting caching holder that can still be recalled (has a
+                     * break callback and is not already mid-break) is broken down to
+                     * the conflict-clearing floor (chimera_vfs_break_retain_for): the
+                     * acquirer parks until it acks.  Because that floor drops exactly
+                     * the contended bits, the break genuinely resolves the conflict
+                     * (no livelock), so a W acquirer recalls a peer's read cache
+                     * rather than capping itself.  A holder with no break path -- or
+                     * one already past IDLE whose effective mode still conflicts -- is
+                     * a hard denial. */
                     if (cur->owner.break_cb &&
-                        cur->break_state == CHIMERA_VFS_BREAK_IDLE &&
-                        !smb_no_w) {
+                        cur->break_state == CHIMERA_VFS_BREAK_IDLE) {
                         has_breakable_conflict = true;
                         if (conflict_out && !*conflict_out) {
                             *conflict_out = cur;
@@ -908,24 +901,43 @@ chimera_vfs_file_state_remove_lease(
 } /* chimera_vfs_file_state_remove_lease */
 
 /* The mode a conflicting holder is allowed to RETAIN when `acquirer` forces it to
- * break.  When an SMB caching acquirer (open) contends an SMB caching holder
- * (oplock / lease), only the WRITE cache is exclusive: the holder gives up W but
- * keeps read + handle caching, regardless of the acquirer's own requested mode
- * (a second opener never grants itself W while a peer caches the file).  Every
- * other break -- NFSv4 delegation recall, a SHARE acquirer invalidating a cache
- * -- retains the acquirer's mode, the pre-existing behavior. */
+* break -- i.e. the break floor handed to begin_break.  The floor must be the
+* holder's granted mode with exactly the bits that CONFLICT with the acquirer
+* cleared (mirroring chimera_vfs_caching_conflict): only then is the floor
+* strictly below `granted`, so the break actually resolves the contention.  A
+* fixed retain (e.g. always keep R|H) livelocks -- the holder keeps the very bit
+* the acquirer needs gone, and would_conflict keeps returning BREAKING -- and a
+* floor of the acquirer's own mode never reduces a same-mode holder at all (an
+* NFSv4 W recall against a W holder would no-op and spin).
+*
+* - acquirer has W (write cache / write open): the holder's cached R and W are
+*   both stale, so it drops R|W and keeps only H/D (handle + delete caching),
+*   which survive a peer's write.
+* - acquirer has R (read cache) but not W: only the holder's exclusive W is
+*   incompatible; it drops W and keeps R|H|D.
+* - acquirer has H (handle cache) from a DIFFERENT client: handle caching is
+*   sole-across-clients, so the holder drops H.
+* Bits the acquirer does not contend (notably D) are always retained, and a
+* same-client H acquirer leaves the holder's H intact (SMB lease keys coexist). */
 static inline uint8_t
 chimera_vfs_break_retain_for(
     const struct chimera_vfs_lease *acquirer,
     const struct chimera_vfs_lease *holder)
 {
-    if (acquirer->kind == CHIMERA_VFS_LEASE_CACHING &&
-        holder->kind == CHIMERA_VFS_LEASE_CACHING &&
-        holder->owner.protocol == CHIMERA_VFS_LEASE_PROTO_SMB2) {
-        return CHIMERA_VFS_LEASE_MODE_R | CHIMERA_VFS_LEASE_MODE_H |
-               CHIMERA_VFS_LEASE_MODE_D;
+    uint8_t a    = acquirer->mode.granted;
+    uint8_t keep = holder->mode.granted;
+
+    if (a & CHIMERA_VFS_LEASE_MODE_W) {
+        keep &= ~(CHIMERA_VFS_LEASE_MODE_R | CHIMERA_VFS_LEASE_MODE_W);
     }
-    return acquirer->mode.granted;
+    if (a & CHIMERA_VFS_LEASE_MODE_R) {
+        keep &= ~CHIMERA_VFS_LEASE_MODE_W;
+    }
+    if ((a & CHIMERA_VFS_LEASE_MODE_H) &&
+        acquirer->owner.client_key != holder->owner.client_key) {
+        keep &= ~CHIMERA_VFS_LEASE_MODE_H;
+    }
+    return keep;
 } /* chimera_vfs_break_retain_for */
 
 SYMBOL_EXPORT enum chimera_vfs_lease_result

--- a/src/vfs/vfs_state.c
+++ b/src/vfs/vfs_state.c
@@ -643,6 +643,27 @@ chimera_vfs_state_would_conflict(
                     }
                 }
             }
+
+            /* An SMB exclusive (W) or batch (W|H) oplock may only be granted to
+             * the SOLE opener of a file: if another client already has it open
+             * (a share reservation with a different client key), the request is
+             * capped to a shared read cache (LEVEL_II).  Signal that by denying
+             * the W/H grant -- the SMB create path retries for R-only, which
+             * coexists.  (Pure attribute-only opens take no share reservation,
+             * so they do not preclude an oplock.) */
+            if (probe->owner.protocol == CHIMERA_VFS_LEASE_PROTO_SMB2 &&
+                (probe->mode.granted & (CHIMERA_VFS_LEASE_MODE_W |
+                                        CHIMERA_VFS_LEASE_MODE_H))) {
+                for (cur = file->share_resvs; cur; cur = cur->next) {
+                    if (cur->owner.client_key == probe->owner.client_key) {
+                        continue; /* the requesting client's own open(s) */
+                    }
+                    if (conflict_out) {
+                        *conflict_out = cur;
+                    }
+                    return CHIMERA_VFS_LEASE_DENIED;
+                }
+            }
             /* An NFSv4 delegation must not be granted when another client
              * already has the file open in a conflicting mode: a read
              * delegation is denied by another client's write open; a write
@@ -1210,6 +1231,43 @@ chimera_vfs_lease_ack(
     }
 } /* chimera_vfs_lease_ack */
 
+/* Apply the lease state a client chose in its OPLOCK_BREAK / lease-break
+ * acknowledgment.  The server optimistically settled the lease at the maximum
+ * the holder could keep (the break's needed_mode); the client may keep less
+ * (e.g. drop straight to NONE), so intersect the granted mode down to its
+ * choice.  A lease that still retains access re-arms (IDLE) so it can break
+ * again later; one reduced to NONE becomes inert (ACKED) until close.  Pumps
+ * waiters in case the further downgrade unblocks them. */
+SYMBOL_EXPORT void
+chimera_vfs_lease_client_downgrade(
+    struct chimera_vfs_state      *state,
+    struct chimera_vfs_file_state *file,
+    struct chimera_vfs_lease      *lease,
+    uint8_t                        kept_mode)
+{
+    bool mutated = false;
+
+    if (!file) {
+        return;
+    }
+
+    pthread_mutex_lock(&file->lock);
+
+    if (lease->mode.granted & ~kept_mode) {
+        lease->mode.granted &= kept_mode;
+        lease->break_state   = lease->mode.granted ? CHIMERA_VFS_BREAK_IDLE
+                                                    : CHIMERA_VFS_BREAK_ACKED;
+        mutated = true;
+    }
+
+    pthread_mutex_unlock(&file->lock);
+
+    if (mutated && state) {
+        chimera_vfs_state_pump_pending(state, file);
+        chimera_vfs_state_pump_io(state, file);
+    }
+} /* chimera_vfs_lease_client_downgrade */
+
 SYMBOL_EXPORT void
 chimera_vfs_lease_revoke(struct chimera_vfs_lease *lease)
 {
@@ -1391,6 +1449,16 @@ chimera_vfs_break_reads_for_write(
         if ((cur->mode.granted & CHIMERA_VFS_LEASE_MODE_W) &&
             chimera_vfs_lease_owner_equal(&cur->owner, writer)) {
             continue;
+        }
+        /* A lease already broken once and settled at LEVEL_II (ACKED, still
+         * holding R) must re-arm so this write can break it again -- this time
+         * to NONE.  (A write is a fresh invalidation event, distinct from the
+         * open that produced the LEVEL_II downgrade, so re-breaking here does
+         * not double-fire within a single open.)  begin_break only acts on an
+         * IDLE lease, so flip it back under the lock. */
+        if (cur->break_state == CHIMERA_VFS_BREAK_ACKED &&
+            cur->owner.break_cb) {
+            cur->break_state = CHIMERA_VFS_BREAK_IDLE;
         }
         if (n < CHIMERA_VFS_STATE_MAX_BREAK_BATCH) {
             to_break[n++] = cur;

--- a/src/vfs/vfs_state.c
+++ b/src/vfs/vfs_state.c
@@ -1929,11 +1929,13 @@ chimera_vfs_state_break_caching(
 
 /* A write invalidates every read-caching (R) lease on the file: those
  * holders can no longer trust their cached data, so each must break down
- * to NONE.  The one exception is the writer's own write-caching (W) lease
- * — an exclusive/batch holder is allowed to write through its own cache
- * without breaking it.  A read-only (LEVEL_II) lease held by the writer
- * itself DOES break (a II oplock caches reads only, so writing through it
- * stales that cache) — this is the SMB2 "self break to none".
+ * to NONE.  The exception is the WRITER'S OWN lease (matched by owner key):
+ * the writing handle is coherent with its own change, so its lease is not
+ * recalled against itself -- whether that lease holds the write cache (an
+ * exclusive/batch holder writing through its own cache) or only read+handle
+ * caching (smb2.lease.complex1: a write by an RH holder breaks the OTHER
+ * client's read lease, never its own RH).  A read cache held by a DIFFERENT
+ * owner of the same client (a second lease key) is still staled and breaks.
  *
  * Breaks are dispatched via begin_break with needed_mode==0, which the
  * SMB break callback interprets as "break to NONE" (the open-conflict
@@ -1957,8 +1959,7 @@ chimera_vfs_break_reads_for_write(
         if ((cur->mode.granted & CHIMERA_VFS_LEASE_MODE_R) == 0) {
             continue;
         }
-        if ((cur->mode.granted & CHIMERA_VFS_LEASE_MODE_W) &&
-            chimera_vfs_lease_owner_equal(&cur->owner, writer)) {
+        if (chimera_vfs_lease_owner_equal(&cur->owner, writer)) {
             continue;
         }
         if (n < CHIMERA_VFS_STATE_MAX_BREAK_BATCH) {

--- a/src/vfs/vfs_state.c
+++ b/src/vfs/vfs_state.c
@@ -1372,7 +1372,8 @@ chimera_vfs_caching_grant_acquire(
 SYMBOL_EXPORT void
 chimera_vfs_caching_grant_release(
     struct chimera_vfs_state         *state,
-    struct chimera_vfs_caching_grant *grant)
+    struct chimera_vfs_caching_grant *grant,
+    bool                              pump)
 {
     struct chimera_vfs_file_state     *file = grant->file;
     struct chimera_vfs_caching_grant **pp;
@@ -1399,9 +1400,13 @@ chimera_vfs_caching_grant_release(
     pthread_mutex_unlock(&file->lock);
 
     if (last) {
-        /* Removing the lease may unblock a pending acquire or parked I/O. */
-        chimera_vfs_state_pump_pending(state, file);
-        chimera_vfs_state_pump_io(state, file);
+        /* Removing the lease may unblock a pending acquire or parked I/O -- but
+         * only pump when a live connection still exists to answer the woken
+         * waiter (skipped at thread shutdown; see chimera_smb_durable_drain_all). */
+        if (pump) {
+            chimera_vfs_state_pump_pending(state, file);
+            chimera_vfs_state_pump_io(state, file);
+        }
         free(grant);
     }
 } /* chimera_vfs_caching_grant_release */

--- a/src/vfs/vfs_state.c
+++ b/src/vfs/vfs_state.c
@@ -424,6 +424,43 @@ chimera_vfs_eval_breakable(
     return false;
 } /* chimera_vfs_eval_breakable */
 
+/* When a hard share-mode conflict comes from an SMB open that also holds a
+ * batch (handle-caching) oplock/lease, that holder may close in response to a
+ * break and so free the share conflict.  MS-FSA breaks such a batch oplock
+ * BEFORE the share-access check: the conflicting open parks until the holder
+ * either closes (then the open is granted) or merely acks while keeping the
+ * handle (then the share conflict stands and the open is denied).  Find that
+ * still-breakable handle-caching lease -- matched to the share holder by their
+ * common owning open (cb_private, set identically on an SMB open's share
+ * reservation and caching lease) -- so a SHARE acquire can park on its break
+ * instead of denying outright.  Returns NULL when the holder has no
+ * still-breakable handle-caching lease, i.e. a genuine hard conflict. */
+static inline struct chimera_vfs_lease *
+chimera_vfs_share_batch_escape(
+    const struct chimera_vfs_file_state *file,
+    const struct chimera_vfs_lease      *share_holder)
+{
+    struct chimera_vfs_lease *cur;
+
+    if (share_holder->owner.protocol != CHIMERA_VFS_LEASE_PROTO_SMB2 ||
+        !share_holder->owner.cb_private) {
+        return NULL;
+    }
+
+    for (cur = file->caching_leases; cur; cur = cur->next) {
+        if (cur->owner.cb_private != share_holder->owner.cb_private ||
+            !cur->owner.break_cb ||
+            !(cur->mode.granted & CHIMERA_VFS_LEASE_MODE_H)) {
+            continue;
+        }
+        if (cur->break_state == CHIMERA_VFS_BREAK_IDLE ||
+            cur->break_state == CHIMERA_VFS_BREAK_BREAKING) {
+            return cur;
+        }
+    }
+    return NULL;
+} /* chimera_vfs_share_batch_escape */
+
 /* A lease whose owning client/session is no longer considered alive (e.g. an
  * NFSv4 client past its lease in courtesy state).  Such a holder retains its
  * lease only "courteously": a conflicting acquire reclaims it on demand rather
@@ -540,13 +577,31 @@ chimera_vfs_state_would_conflict(
                 /* A breakable share holder is chimera's own implicit I/O
                  * lease: recall it so a real client open can take the file.
                  * A non-breakable holder is an ordinary client open and is a
-                 * hard share conflict. */
+                 * hard share conflict -- UNLESS it is an SMB open holding a
+                 * batch (handle-caching) oplock, in which case the holder may
+                 * close on a break and free the conflict, so park on that
+                 * break rather than denying (MS-FSA batch-before-share). */
                 if (chimera_vfs_eval_breakable(cur, &has_breakable_conflict,
                                                &idle_break, &expired_break)) {
-                    if (conflict_out) {
-                        *conflict_out = cur;
+                    struct chimera_vfs_lease *batch =
+                        chimera_vfs_share_batch_escape(file, cur);
+
+                    if (!batch) {
+                        if (conflict_out) {
+                            *conflict_out = cur;
+                        }
+                        return CHIMERA_VFS_LEASE_DENIED;
                     }
-                    return CHIMERA_VFS_LEASE_DENIED;
+
+                    has_breakable_conflict = true;
+                    if (batch->break_state == CHIMERA_VFS_BREAK_IDLE) {
+                        if (!idle_break) {
+                            idle_break = batch;
+                        }
+                    } else if (!expired_break &&
+                               chimera_vfs_break_deadline_passed(batch)) {
+                        expired_break = batch;
+                    }
                 }
             }
             /* A new SHARE acquire may also need to break a caching lease on
@@ -1295,8 +1350,9 @@ chimera_vfs_lease_revoke(struct chimera_vfs_lease *lease)
  * granted mode (the recall is in flight; caller should wait/retry). */
 static bool
 chimera_vfs_break_caching_file(
-    struct chimera_vfs_state      *state,
-    struct chimera_vfs_file_state *file)
+    struct chimera_vfs_state             *state,
+    struct chimera_vfs_file_state        *file,
+    const struct chimera_vfs_open_handle *skip_handle)
 {
     bool had;
 
@@ -1313,6 +1369,11 @@ chimera_vfs_break_caching_file(
         pthread_mutex_lock(&file->lock);
         for (cur = file->caching_leases; cur; cur = cur->next) {
             if (cur->mode.granted == 0 || !cur->owner.break_cb) {
+                continue;
+            }
+            /* The mutation is issued through this very lease's open handle: the
+             * holder is coherent with its own change, so do not recall it. */
+            if (skip_handle && cur->owner.op_handle == skip_handle) {
                 continue;
             }
             if (cur->break_state == CHIMERA_VFS_BREAK_IDLE) {
@@ -1356,13 +1417,23 @@ chimera_vfs_break_caching_file(
         }
     }
 
-    /* Still blocked iff some caching holder retains a granted mode. */
+    /* Still blocked iff some caching holder retains an *effective* granted mode.
+     * A holder mid-break is treated by its effective level: an SMB oplock/lease
+     * that has been notified (BREAKING) is obligated to comply, so it no longer
+     * blocks -- the metadata op proceeds and the client's real ack arrives
+     * asynchronously (this matches the pre-real-break optimistic behaviour and
+     * is what chimera_vfs_lease_effective_granted() encodes).  An NFSv4
+     * delegation keeps its full mode while RECALLING, so it still blocks until
+     * the client returns it or its recall deadline elapses (revoked above). */
     pthread_mutex_lock(&file->lock);
     had = false;
     {
         struct chimera_vfs_lease *cur;
         for (cur = file->caching_leases; cur; cur = cur->next) {
-            if (cur->mode.granted != 0) {
+            if (skip_handle && cur->owner.op_handle == skip_handle) {
+                continue;
+            }
+            if (chimera_vfs_lease_effective_granted(cur) != 0) {
                 had = true;
                 break;
             }
@@ -1388,7 +1459,9 @@ chimera_vfs_state_break_caching(
         return false;
     }
 
-    had = chimera_vfs_break_caching_file(state, file);
+    /* No skip handle: this whole-file recall (NFSv4 REMOVE/RENAME) breaks every
+     * caching holder, including the operating client's own delegation. */
+    had = chimera_vfs_break_caching_file(state, file, NULL);
 
     chimera_vfs_state_put(state, file);
     return had;
@@ -1780,7 +1853,7 @@ chimera_vfs_io_try(
      * on chimera's behalf.  The periodic maintenance pass re-pumps parked
      * waiters so an unresponsive holder is revoked at its recall deadline. */
     if (request->io_recall_all) {
-        if (chimera_vfs_break_caching_file(state, file)) {
+        if (chimera_vfs_break_caching_file(state, file, request->io_handle)) {
             pthread_mutex_lock(&file->lock);
             chimera_vfs_io_park_locked(file, request);
             request->io_lease_file = file;

--- a/src/vfs/vfs_state.c
+++ b/src/vfs/vfs_state.c
@@ -383,9 +383,14 @@ chimera_vfs_caching_conflict(
         return true;
     }
 
-    /* H (handle-cache) is exclusive across owners — only one client may
-     * cache the open handle. */
-    if ((e & CHIMERA_VFS_LEASE_MODE_H) && (p & CHIMERA_VFS_LEASE_MODE_H)) {
+    /* H (handle-cache) is exclusive only ACROSS CLIENTS — a different client
+     * caching the open handle conflicts (a batch oplock is sole-handle), but two
+     * lease keys of the SAME client may each hold handle caching (MS-SMB2 lease
+     * semantics: a client's RH lease is not broken by another RH lease of its own
+     * under a different key -- smb2.lease.break expects two RH leases to coexist).
+     * Write caching above is the only mode exclusive even within one client. */
+    if ((e & CHIMERA_VFS_LEASE_MODE_H) && (p & CHIMERA_VFS_LEASE_MODE_H) &&
+        existing->owner.client_key != probe->owner.client_key) {
         return true;
     }
 

--- a/src/vfs/vfs_state.c
+++ b/src/vfs/vfs_state.c
@@ -1424,6 +1424,67 @@ chimera_vfs_state_break_on_write(
     chimera_vfs_state_put(state, file);
 } /* chimera_vfs_state_break_on_write */
 
+/* Break-on-open: a conflicting open by a *different* owner that is not itself
+ * data-modifying downgrades an exclusive (W) or batch (W|H) holder to a shared
+ * read cache (LEVEL_II).  We break every other-owner caching lease that holds
+ * W or H, retaining only the read bit (needed_mode = R), and leave pure
+ * read-cache (LEVEL_II) holders untouched -- multiple readers coexist with a
+ * new opener.  This is the SMB break-on-second-open semantic; it is optimistic
+ * (the break is queued and the opener proceeds immediately). */
+static void
+chimera_vfs_break_caching_for_open(
+    struct chimera_vfs_state             *state,
+    struct chimera_vfs_file_state        *file,
+    const struct chimera_vfs_lease_owner *opener)
+{
+    struct chimera_vfs_lease *cur;
+    struct chimera_vfs_lease *to_break[CHIMERA_VFS_STATE_MAX_BREAK_BATCH];
+    int                       n = 0;
+    int                       i;
+
+    pthread_mutex_lock(&file->lock);
+
+    for (cur = file->caching_leases; cur; cur = cur->next) {
+        if ((cur->mode.granted & (CHIMERA_VFS_LEASE_MODE_W |
+                                  CHIMERA_VFS_LEASE_MODE_H)) == 0) {
+            continue;
+        }
+        if (chimera_vfs_lease_owner_equal(&cur->owner, opener)) {
+            continue;
+        }
+        if (n < CHIMERA_VFS_STATE_MAX_BREAK_BATCH) {
+            to_break[n++] = cur;
+        }
+    }
+
+    pthread_mutex_unlock(&file->lock);
+
+    for (i = 0; i < n; i++) {
+        chimera_vfs_lease_begin_break(state, to_break[i],
+                                      CHIMERA_VFS_LEASE_MODE_R, 0);
+    }
+} /* chimera_vfs_break_caching_for_open */
+
+SYMBOL_EXPORT void
+chimera_vfs_state_break_on_open(
+    struct chimera_vfs_state             *state,
+    const uint8_t                        *fh,
+    uint8_t                               fh_len,
+    uint64_t                              fh_hash,
+    const struct chimera_vfs_lease_owner *opener)
+{
+    struct chimera_vfs_file_state *file;
+
+    file = chimera_vfs_state_get(state, fh, fh_len, fh_hash, false);
+    if (!file) {
+        return;
+    }
+
+    chimera_vfs_break_caching_for_open(state, file, opener);
+
+    chimera_vfs_state_put(state, file);
+} /* chimera_vfs_state_break_on_open */
+
 /* -------------------------------------------------------------------- */
 /* Implicit I/O lease                                                   */
 /* -------------------------------------------------------------------- */

--- a/src/vfs/vfs_state.c
+++ b/src/vfs/vfs_state.c
@@ -347,12 +347,29 @@ chimera_vfs_share_conflict(
  * owners is a conflict.  W and H are exclusive across clients; R is
  * shareable (multiple clients can each hold an R-lease — that's how
  * SMB2 Level2 oplocks generalize). */
+/* The mode a holder effectively grants for conflict purposes.  While an SMB
+ * oplock/lease is mid-break (notification sent, awaiting the client's ack), the
+ * client is obligated to comply, so the holder is treated as already at its
+ * retained (post-break) level -- this lets a coexisting acquirer (e.g. a 2nd
+ * open settling at LEVEL_II) proceed immediately instead of blocking on the
+ * ack.  NFSv4 delegations keep their full granted mode while RECALLING, so a
+ * conflicting open waits for the DELEGRETURN (or recall-timeout revoke). */
+static inline uint8_t
+chimera_vfs_lease_effective_granted(const struct chimera_vfs_lease *l)
+{
+    if (l->break_state == CHIMERA_VFS_BREAK_BREAKING &&
+        l->owner.protocol == CHIMERA_VFS_LEASE_PROTO_SMB2) {
+        return l->break_needed_mode;
+    }
+    return l->mode.granted;
+} /* chimera_vfs_lease_effective_granted */
+
 static inline bool
 chimera_vfs_caching_conflict(
     const struct chimera_vfs_lease *existing,
     const struct chimera_vfs_lease *probe)
 {
-    uint8_t e = existing->mode.granted;
+    uint8_t e = chimera_vfs_lease_effective_granted(existing);
     uint8_t p = probe->mode.granted;
 
     /* W (write-cache) is exclusive — only one holder may have W on a
@@ -1215,9 +1232,16 @@ chimera_vfs_lease_ack(
     }
 
     if (lease->break_state == CHIMERA_VFS_BREAK_BREAKING) {
-        lease->mode        = resulting;
-        lease->break_state = CHIMERA_VFS_BREAK_ACKED;
-        mutated            = true;
+        lease->mode = resulting;
+        /* A lease that retains some access (e.g. an SMB oplock the client kept
+         * at LEVEL_II) re-arms to IDLE so a later conflicting open / write /
+         * lock can break it again; one reduced to NONE goes inert (ACKED) until
+         * the holder closes.  Re-arming is safe here because this is the
+         * client's real, asynchronous response -- not the old optimistic ack
+         * that fired inside the same operation and could livelock a waiter. */
+        lease->break_state = resulting.granted ? CHIMERA_VFS_BREAK_IDLE
+                                               : CHIMERA_VFS_BREAK_ACKED;
+        mutated = true;
     }
 
     if (file) {
@@ -1230,43 +1254,6 @@ chimera_vfs_lease_ack(
         chimera_vfs_state_pump_io(file->state, file);
     }
 } /* chimera_vfs_lease_ack */
-
-/* Apply the lease state a client chose in its OPLOCK_BREAK / lease-break
- * acknowledgment.  The server optimistically settled the lease at the maximum
- * the holder could keep (the break's needed_mode); the client may keep less
- * (e.g. drop straight to NONE), so intersect the granted mode down to its
- * choice.  A lease that still retains access re-arms (IDLE) so it can break
- * again later; one reduced to NONE becomes inert (ACKED) until close.  Pumps
- * waiters in case the further downgrade unblocks them. */
-SYMBOL_EXPORT void
-chimera_vfs_lease_client_downgrade(
-    struct chimera_vfs_state      *state,
-    struct chimera_vfs_file_state *file,
-    struct chimera_vfs_lease      *lease,
-    uint8_t                        kept_mode)
-{
-    bool mutated = false;
-
-    if (!file) {
-        return;
-    }
-
-    pthread_mutex_lock(&file->lock);
-
-    if (lease->mode.granted & ~kept_mode) {
-        lease->mode.granted &= kept_mode;
-        lease->break_state   = lease->mode.granted ? CHIMERA_VFS_BREAK_IDLE
-                                                    : CHIMERA_VFS_BREAK_ACKED;
-        mutated = true;
-    }
-
-    pthread_mutex_unlock(&file->lock);
-
-    if (mutated && state) {
-        chimera_vfs_state_pump_pending(state, file);
-        chimera_vfs_state_pump_io(state, file);
-    }
-} /* chimera_vfs_lease_client_downgrade */
 
 SYMBOL_EXPORT void
 chimera_vfs_lease_revoke(struct chimera_vfs_lease *lease)
@@ -1449,16 +1436,6 @@ chimera_vfs_break_reads_for_write(
         if ((cur->mode.granted & CHIMERA_VFS_LEASE_MODE_W) &&
             chimera_vfs_lease_owner_equal(&cur->owner, writer)) {
             continue;
-        }
-        /* A lease already broken once and settled at LEVEL_II (ACKED, still
-         * holding R) must re-arm so this write can break it again -- this time
-         * to NONE.  (A write is a fresh invalidation event, distinct from the
-         * open that produced the LEVEL_II downgrade, so re-breaking here does
-         * not double-fire within a single open.)  begin_break only acts on an
-         * IDLE lease, so flip it back under the lock. */
-        if (cur->break_state == CHIMERA_VFS_BREAK_ACKED &&
-            cur->owner.break_cb) {
-            cur->break_state = CHIMERA_VFS_BREAK_IDLE;
         }
         if (n < CHIMERA_VFS_STATE_MAX_BREAK_BATCH) {
             to_break[n++] = cur;

--- a/src/vfs/vfs_state.c
+++ b/src/vfs/vfs_state.c
@@ -1243,7 +1243,13 @@ chimera_vfs_caching_grant_coalesce(
     if (grant) {
         grant->refcount++;
 
-        if (upgrade_ok) {
+        /* A re-open while the lease is mid-break must NOT upgrade it: MS-SMB2
+         * 3.3.5.9.11 has the re-open succeed at the lease's CURRENT (downgrading)
+         * state and report SMB2_LEASE_FLAG_BREAK_IN_PROGRESS instead of granting
+         * back the bits being broken away (smb2.lease.breaking3).  Only an IDLE
+         * lease can be upgraded. */
+        if (upgrade_ok &&
+            grant->lease.break_state == CHIMERA_VFS_BREAK_IDLE) {
             uint8_t cur = grant->lease.mode.granted;
 
             /* MS-SMB2 3.3.5.9.11: a lease is upgraded to the REQUESTED state only
@@ -1559,16 +1565,62 @@ chimera_vfs_state_range_io_conflict(
 /* Break orchestration                                                  */
 /* -------------------------------------------------------------------- */
 
+/* Compute the next single-bit break step: the holder's granted mode with the
+ * ONE highest-priority bit that is still above `floor` removed.  Priority is
+ * W (write cache, flush first) > H (handle cache) > D > R (read cache, the most
+ * shareable, dropped last).  A lease cascades one bit per ack toward its floor
+ * (RWH -> RH -> R -> NONE for floor 0), which is what the MS-SMB2 lease-break
+ * sequence the smbtorture breaking* tests assert requires.  Returns `granted`
+ * unchanged once it is already at or below the floor. */
+/* True for a lease that breaks one caching bit at a time (an SMB2 RqLs lease).
+ * A legacy SMB oplock breaks as one indivisible level, and an NFSv4 delegation
+ * is recalled whole; both jump straight to the floor instead of cascading. */
+static inline bool
+chimera_vfs_lease_cascades(const struct chimera_vfs_lease *lease)
+{
+    return lease->grant != NULL && !lease->grant->is_oplock;
+} /* chimera_vfs_lease_cascades */
+
+static inline uint8_t
+chimera_vfs_lease_break_step(
+    uint8_t granted,
+    uint8_t floor)
+{
+    uint8_t excess = granted & ~floor;
+
+    if (excess & CHIMERA_VFS_LEASE_MODE_W) {
+        return granted & ~CHIMERA_VFS_LEASE_MODE_W;
+    }
+    if (excess & CHIMERA_VFS_LEASE_MODE_H) {
+        return granted & ~CHIMERA_VFS_LEASE_MODE_H;
+    }
+    if (excess & CHIMERA_VFS_LEASE_MODE_D) {
+        return granted & ~CHIMERA_VFS_LEASE_MODE_D;
+    }
+    if (excess & CHIMERA_VFS_LEASE_MODE_R) {
+        return granted & ~CHIMERA_VFS_LEASE_MODE_R;
+    }
+    return granted;
+} /* chimera_vfs_lease_break_step */
+
+/* `floor` is the ultimate target of the break (the maximal mode the holder may
+ * keep given the conflict that triggered it) -- NOT the immediate downgrade.
+ * The first notification asks the holder to drop a single bit toward that floor;
+ * chimera_vfs_lease_ack fires the remaining steps one per ack.  When a break is
+ * already in flight, a new conflict with a lower floor only deepens the target
+ * (the in-flight step still stands and the cascade carries on to the new floor);
+ * it does not re-notify. */
 SYMBOL_EXPORT void
 chimera_vfs_lease_begin_break(
     struct chimera_vfs_state *state,
     struct chimera_vfs_lease *lease,
-    uint8_t                   needed_mode,
+    uint8_t                   floor,
     uint32_t                  deadline_ms)
 {
     struct chimera_vfs_file_state *file = lease->file;
     chimera_vfs_lease_break_cb_t   cb;
     void                          *cb_priv;
+    uint8_t                        step = 0;
     bool                           should_invoke;
 
     if (deadline_ms == 0) {
@@ -1579,12 +1631,28 @@ chimera_vfs_lease_begin_break(
         pthread_mutex_lock(&file->lock);
     }
 
-    should_invoke = (lease->break_state == CHIMERA_VFS_BREAK_IDLE) &&
-        (lease->owner.break_cb != NULL);
+    if (lease->break_state == CHIMERA_VFS_BREAK_BREAKING) {
+        /* Cascade already running: deepen the floor (a writer arriving behind a
+         * reader, an overwrite behind a plain open) so it continues lower, but
+         * leave the outstanding notification alone. */
+        lease->break_floor &= floor;
+        should_invoke       = false;
+    } else {
+        /* Only an SMB2 RqLs lease cascades one bit per ack toward the floor.  A
+         * legacy SMB oplock (one indivisible level: exclusive/batch -> II ->
+         * none) and an NFSv4 delegation (CB_RECALL returns the whole delegation)
+         * both break in a single shot, so they jump straight to the floor. */
+        step = chimera_vfs_lease_cascades(lease)
+            ? chimera_vfs_lease_break_step(lease->mode.granted, floor)
+            : floor;
+        should_invoke = (step != lease->mode.granted) &&
+            (lease->owner.break_cb != NULL);
+    }
 
     if (should_invoke) {
         lease->break_state       = CHIMERA_VFS_BREAK_BREAKING;
-        lease->break_needed_mode = needed_mode;
+        lease->break_floor       = floor;
+        lease->break_needed_mode = step;
         lease->break_deadline    = chimera_vfs_now_ticks() +
             chimera_vfs_ns_to_ticks((uint64_t) deadline_ms * 1000000ULL);
         cb      = lease->owner.break_cb;
@@ -1601,7 +1669,7 @@ chimera_vfs_lease_begin_break(
     /* Invoke the break callback outside the file lock — the protocol
      * server may need to send packets, take other locks, etc. */
     if (cb) {
-        cb(lease, needed_mode, cb_priv);
+        cb(lease, step, cb_priv);
     }
 } /* chimera_vfs_lease_begin_break */
 
@@ -1612,6 +1680,9 @@ chimera_vfs_lease_ack(
 {
     struct chimera_vfs_file_state *file    = lease->file;
     bool                           mutated = false;
+    chimera_vfs_lease_break_cb_t   cb      = NULL;
+    void                          *cb_priv = NULL;
+    uint8_t                        step    = 0;
 
     if (file) {
         pthread_mutex_lock(&file->lock);
@@ -1619,22 +1690,47 @@ chimera_vfs_lease_ack(
 
     if (lease->break_state == CHIMERA_VFS_BREAK_BREAKING) {
         lease->mode = resulting;
-        /* A lease that retains some access (e.g. an SMB oplock the client kept
-         * at LEVEL_II) re-arms to IDLE so a later conflicting open / write /
-         * lock can break it again; one reduced to NONE goes inert (ACKED) until
-         * the holder closes.  Re-arming is safe here because this is the
-         * client's real, asynchronous response -- not the old optimistic ack
-         * that fired inside the same operation and could livelock a waiter. */
-        lease->break_state = resulting.granted ? CHIMERA_VFS_BREAK_IDLE
-                                               : CHIMERA_VFS_BREAK_ACKED;
-        mutated = true;
+
+        /* Cascade: the conflict that started this break may need the holder
+         * lower than the bit it just acked (a plain RW open drives RWH -> RH ->
+         * R -> NONE).  If the acked mode is still above the floor, fire the next
+         * single-bit break immediately and stay BREAKING -- the waiter parked on
+         * this break keeps waiting and a same-key re-open still sees the break in
+         * progress.  Only when the holder reaches the floor does the break
+         * finish: re-arm to IDLE if it kept any mode (a later conflict can break
+         * it again) or go inert (ACKED) at NONE until the holder closes. */
+        step = chimera_vfs_lease_cascades(lease)
+            ? chimera_vfs_lease_break_step(resulting.granted, lease->break_floor)
+            : resulting.granted;
+
+        if (step != resulting.granted && lease->owner.break_cb) {
+            uint32_t deadline_ms = (file && file->state)
+                ? file->state->default_break_deadline_ms
+                : CHIMERA_VFS_STATE_DEFAULT_BREAK_DEADLINE_MS;
+
+            lease->break_needed_mode = step;
+            lease->break_deadline    = chimera_vfs_now_ticks() +
+                chimera_vfs_ns_to_ticks((uint64_t) deadline_ms * 1000000ULL);
+            cb      = lease->owner.break_cb;
+            cb_priv = lease->owner.cb_private;
+        } else {
+            lease->break_state = resulting.granted ? CHIMERA_VFS_BREAK_IDLE
+                                                   : CHIMERA_VFS_BREAK_ACKED;
+            mutated = true;
+        }
     }
 
     if (file) {
         pthread_mutex_unlock(&file->lock);
     }
 
-    /* Acking a break may unblock pending acquires or parked I/O. */
+    /* Fire the next cascade step (outside the lock — the SMB cb sends a packet). */
+    if (cb) {
+        cb(lease, step, cb_priv);
+        return;
+    }
+
+    /* Acking the final step may unblock pending acquires or parked I/O. */
     if (mutated && file && file->state) {
         chimera_vfs_state_pump_pending(file->state, file);
         chimera_vfs_state_pump_io(file->state, file);

--- a/src/vfs/vfs_state.h
+++ b/src/vfs/vfs_state.h
@@ -194,6 +194,33 @@ chimera_vfs_state_remove(
  * `owner` carries the identity 4-tuple AND the break/revoke/alive callbacks +
  * cb_private + op_handle, copied onto the grant's embedded lease.  On GRANTED
  * the caller holds one reference, released via chimera_vfs_caching_grant_release. */
+/* If a same-owner caching grant already exists on `file`, take a reference to it
+ * (coalescing this acquirer onto it) and, when `upgrade_ok` and `want` adds bits,
+ * upgrade it IN PLACE only if the larger mode is grantable without breaking
+ * another owner (MS-SMB2 3.3.5.9 — an upgrade never breaks another lease).
+ * Returns the grant (refcount already bumped) or NULL if no same-owner grant
+ * exists.  Caller must NOT hold file->lock.  Used by protocols that register a
+ * per-open holder on the grant: the caller seeds/links its own holder list, so
+ * splitting coalesce out of acquire lets the caller create the fresh grant and
+ * register its first member under one critical section (no breakable-but-
+ * memberless window). */
+struct chimera_vfs_caching_grant *
+chimera_vfs_caching_grant_coalesce(
+    struct chimera_vfs_file_state        *file,
+    const struct chimera_vfs_lease_owner *owner,
+    struct chimera_vfs_lease_mode         want,
+    int                                   upgrade_ok);
+
+/* Link a freshly-created caching grant (whose embedded lease the caller has
+ * already inserted via chimera_vfs_state_try_insert) into the per-file owner
+ * index so later same-owner acquires coalesce onto it.  Caller must NOT hold
+ * file->lock.  Used by callers that drive the fresh-grant insert themselves
+ * (their own settle loop) rather than through chimera_vfs_caching_grant_acquire. */
+void
+chimera_vfs_caching_grant_link(
+    struct chimera_vfs_file_state    *file,
+    struct chimera_vfs_caching_grant *grant);
+
 enum chimera_vfs_lease_result
 chimera_vfs_caching_grant_acquire(
     struct chimera_vfs_state             *state,

--- a/src/vfs/vfs_state.h
+++ b/src/vfs/vfs_state.h
@@ -232,12 +232,16 @@ chimera_vfs_caching_grant_acquire(
     struct chimera_vfs_lease            **conflict_out);
 
 /* Drop one reference to a caching grant.  On the last reference the embedded
- * lease is unlinked from the file, pending/io waiters are pumped, and the grant
- * is freed.  Caller must NOT hold file->lock. */
+ * lease is unlinked from the file and the grant is freed.  Caller must NOT hold
+ * file->lock.  When `pump` is true (the normal close path) pending/io waiters
+ * are pumped after the lease is removed so a blocked acquirer can proceed; pass
+ * false at thread shutdown, where no live connection remains to answer a pumped
+ * waiter (pumping there would reply on a dead connection). */
 void
 chimera_vfs_caching_grant_release(
     struct chimera_vfs_state         *state,
-    struct chimera_vfs_caching_grant *grant);
+    struct chimera_vfs_caching_grant *grant,
+    bool                              pump);
 
 /* True if any caching lease on the file is mid-break awaiting a client ack (a
  * holder was sent an ack-required OPLOCK_BREAK that has not yet completed),

--- a/src/vfs/vfs_state.h
+++ b/src/vfs/vfs_state.h
@@ -331,13 +331,20 @@ chimera_vfs_state_io_resume(
  * by (fh, fh_hash) — regardless of owner, so even the operating client's own
  * delegation is recalled (RFC 7530 §10.4.5) — then invoke next(request).  The
  * request parks until the recall drains; no lease is held on chimera's behalf.
- * A file with no per-file state proceeds immediately. */
+ * A file with no per-file state proceeds immediately.
+ *
+ * flush_only selects the recall flavor: false = namespace mutation (remove /
+ * rename / link) revokes every caching holder to NONE; true = data-coherence
+ * mutation (a setattr that changes data, e.g. SIZE) downgrades a write-caching
+ * holder to its read+handle cache so the client flushes dirty data but keeps its
+ * read cache and oplock (see request->io_recall_flush_only). */
 void
 chimera_vfs_io_recall(
     struct chimera_vfs_request *request,
     const uint8_t              *fh,
     uint8_t                     fh_len,
     uint64_t                    fh_hash,
+    int                         flush_only,
     void (                     *next )(struct chimera_vfs_request *request));
 
 /* Drop every implicit lease that has been idle (no in-flight I/O) for at

--- a/src/vfs/vfs_state.h
+++ b/src/vfs/vfs_state.h
@@ -265,6 +265,18 @@ chimera_vfs_lease_ack(
     struct chimera_vfs_lease     *lease,
     struct chimera_vfs_lease_mode resulting);
 
+/* Apply the lease state a client selected in its (legacy or lease) oplock-break
+ * acknowledgment.  The server already optimistically settled the lease at the
+ * maximum the holder could keep; the client may keep less.  `kept_mode` is what
+ * the client retains (R for LEVEL_II, 0 for NONE); the lease's granted mode is
+ * intersected down to it and re-armed if anything survives. */
+void
+chimera_vfs_lease_client_downgrade(
+    struct chimera_vfs_state      *state,
+    struct chimera_vfs_file_state *file,
+    struct chimera_vfs_lease      *lease,
+    uint8_t                        kept_mode);
+
 /* Forcibly revoke a lease — called by vfs_state when the break deadline
  * expires, or by the protocol server when it gives up on the client. */
 void

--- a/src/vfs/vfs_state.h
+++ b/src/vfs/vfs_state.h
@@ -79,6 +79,11 @@ struct chimera_vfs_file_state {
      * pending queue without changing public-API signatures. */
     struct chimera_vfs_state           *state;
 
+    /* Phase-3 (SMB delete-pending): set while an open holds delete-on-close on
+     * this file so a subsequent open can be answered with STATUS_DELETE_PENDING
+     * without a break.  Tracked here (additive; no consumer enforces it yet). */
+    uint8_t                             delete_pending;
+
     uint32_t                            refcount;
     struct chimera_vfs_file_state      *bucket_next;
 };

--- a/src/vfs/vfs_state.h
+++ b/src/vfs/vfs_state.h
@@ -254,6 +254,19 @@ chimera_vfs_state_caching_breaking(
     uint64_t                                fh_hash,
     const struct chimera_vfs_caching_grant *except);
 
+/* Forcibly revoke every caching lease on the file that is mid-break, EXCLUDING
+ * the grant `except`.  Used when a parked open's break deadline expires (the
+ * holder never acknowledged): the holder is revoked so the waiting open can
+ * proceed.  `except` (the waiter's own coalesced grant) may be NULL.  Caller must
+ * NOT hold file->lock. */
+void
+chimera_vfs_state_revoke_breaks(
+    struct chimera_vfs_state               *state,
+    const uint8_t                          *fh,
+    uint8_t                                 fh_len,
+    uint64_t                                fh_hash,
+    const struct chimera_vfs_caching_grant *except);
+
 /* -------------------------------------------------------------------- */
 /* Async acquire/release                                                */
 /* -------------------------------------------------------------------- */

--- a/src/vfs/vfs_state.h
+++ b/src/vfs/vfs_state.h
@@ -265,18 +265,6 @@ chimera_vfs_lease_ack(
     struct chimera_vfs_lease     *lease,
     struct chimera_vfs_lease_mode resulting);
 
-/* Apply the lease state a client selected in its (legacy or lease) oplock-break
- * acknowledgment.  The server already optimistically settled the lease at the
- * maximum the holder could keep; the client may keep less.  `kept_mode` is what
- * the client retains (R for LEVEL_II, 0 for NONE); the lease's granted mode is
- * intersected down to it and re-armed if anything survives. */
-void
-chimera_vfs_lease_client_downgrade(
-    struct chimera_vfs_state      *state,
-    struct chimera_vfs_file_state *file,
-    struct chimera_vfs_lease      *lease,
-    uint8_t                        kept_mode);
-
 /* Forcibly revoke a lease — called by vfs_state when the break deadline
  * expires, or by the protocol server when it gives up on the client. */
 void

--- a/src/vfs/vfs_state.h
+++ b/src/vfs/vfs_state.h
@@ -357,3 +357,15 @@ chimera_vfs_state_break_on_write(
     uint8_t                               fh_len,
     uint64_t                              fh_hash,
     const struct chimera_vfs_lease_owner *writer);
+
+/* Break-on-open: downgrade any exclusive (W) or batch (W|H) caching lease held
+ * by a *different* owner on (fh, fh_hash) to a shared read cache (LEVEL_II),
+ * leaving pure read-cache holders untouched.  Drives the SMB2 "second open
+ * breaks the oplock to level II" semantic for a non-modifying opener. */
+void
+chimera_vfs_state_break_on_open(
+    struct chimera_vfs_state             *state,
+    const uint8_t                        *fh,
+    uint8_t                               fh_len,
+    uint64_t                              fh_hash,
+    const struct chimera_vfs_lease_owner *opener);

--- a/src/vfs/vfs_state.h
+++ b/src/vfs/vfs_state.h
@@ -53,6 +53,12 @@ struct chimera_vfs_file_state {
     struct chimera_vfs_lease           *share_resvs;
     struct chimera_vfs_lease           *caching_leases;
 
+    /* Owner-keyed index of VFS-owned caching grants on this file.  Each grant's
+     * embedded lease is linked on caching_leases above (so the conflict matrix
+     * sees it); this index lets an acquire find an existing same-owner grant to
+     * coalesce onto.  One grant per (protocol, client_key, owner_lo, owner_hi). */
+    struct chimera_vfs_caching_grant   *caching_grants;
+
     /* Implicit lease held by chimera itself on behalf of leaseless actors
      * (NFSv3/S3/NFSv4 data I/O).  When active it is linked into share_resvs
      * like any other SHARE; it is kept across operations and dropped only
@@ -167,6 +173,44 @@ chimera_vfs_state_remove(
     struct chimera_vfs_state      *state,
     struct chimera_vfs_file_state *file,
     struct chimera_vfs_lease      *lease);
+
+/* -------------------------------------------------------------------- */
+/* Caching grant — VFS-owned shared caching lease                       */
+/* -------------------------------------------------------------------- */
+
+/* Acquire a reference to the caching grant for (file, owner), creating it if
+ * none exists.  Caller must NOT hold file->lock.
+ *
+ *   - Existing same-owner grant found → coalesce: bump its refcount and, if
+ *     `upgrade_ok` and `want` adds bits, upgrade IN PLACE only if the larger
+ *     mode is grantable without breaking another owner's holder (MS-SMB2
+ *     3.3.5.9: an upgrade never breaks another lease — if it would, the grant
+ *     keeps its current mode).  Always returns GRANTED.
+ *   - No existing grant → allocate one, run the normal conflict/break logic
+ *     against OTHER owners (chimera_vfs_state_try_insert).  Returns GRANTED
+ *     (grant_out set, refcount 1), BREAKING, or DENIED (grant_out NULL,
+ *     conflict_out set).
+ *
+ * `owner` carries the identity 4-tuple AND the break/revoke/alive callbacks +
+ * cb_private + op_handle, copied onto the grant's embedded lease.  On GRANTED
+ * the caller holds one reference, released via chimera_vfs_caching_grant_release. */
+enum chimera_vfs_lease_result
+chimera_vfs_caching_grant_acquire(
+    struct chimera_vfs_state             *state,
+    struct chimera_vfs_file_state        *file,
+    const struct chimera_vfs_lease_owner *owner,
+    struct chimera_vfs_lease_mode         want,
+    int                                   upgrade_ok,
+    struct chimera_vfs_caching_grant    **grant_out,
+    struct chimera_vfs_lease            **conflict_out);
+
+/* Drop one reference to a caching grant.  On the last reference the embedded
+ * lease is unlinked from the file, pending/io waiters are pumped, and the grant
+ * is freed.  Caller must NOT hold file->lock. */
+void
+chimera_vfs_caching_grant_release(
+    struct chimera_vfs_state         *state,
+    struct chimera_vfs_caching_grant *grant);
 
 /* -------------------------------------------------------------------- */
 /* Async acquire/release                                                */

--- a/src/vfs/vfs_state.h
+++ b/src/vfs/vfs_state.h
@@ -239,6 +239,21 @@ chimera_vfs_caching_grant_release(
     struct chimera_vfs_state         *state,
     struct chimera_vfs_caching_grant *grant);
 
+/* True if any caching lease on the file is mid-break awaiting a client ack (a
+ * holder was sent an ack-required OPLOCK_BREAK that has not yet completed),
+ * EXCLUDING the grant `except` (the acquirer's own coalesced grant, which must
+ * not wait for its own break).  Used by the SMB create path to defer an open that
+ * triggered an ack-required break on ANOTHER holder until that holder acks
+ * (MS-SMB2 3.3.5.9: the open is pending until the break completes).  `except` may
+ * be NULL.  Caller must NOT hold file->lock. */
+bool
+chimera_vfs_state_caching_breaking(
+    struct chimera_vfs_state               *state,
+    const uint8_t                          *fh,
+    uint8_t                                 fh_len,
+    uint64_t                                fh_hash,
+    const struct chimera_vfs_caching_grant *except);
+
 /* -------------------------------------------------------------------- */
 /* Async acquire/release                                                */
 /* -------------------------------------------------------------------- */

--- a/src/vfs/vfs_state.h
+++ b/src/vfs/vfs_state.h
@@ -358,14 +358,22 @@ chimera_vfs_state_break_on_write(
     uint64_t                              fh_hash,
     const struct chimera_vfs_lease_owner *writer);
 
-/* Break-on-open: downgrade any exclusive (W) or batch (W|H) caching lease held
- * by a *different* owner on (fh, fh_hash) to a shared read cache (LEVEL_II),
- * leaving pure read-cache holders untouched.  Drives the SMB2 "second open
- * breaks the oplock to level II" semantic for a non-modifying opener. */
+/* Break-on-open: break caching leases held by a *different* owner on
+ * (fh, fh_hash) when a conflicting open arrives.  `trigger_bits` selects which
+ * holders break (only those whose granted mode holds a trigger bit they don't
+ * get to keep); `retain_mode` is what the holder keeps (R downgrades an
+ * exclusive/batch oplock to LEVEL_II, 0 breaks to NONE).  Drives the SMB2
+ * second-open break semantics:
+ *   - batch (H) holders break before the share-mode check (handle caching, the
+ *     holder may close): trigger = H;
+ *   - exclusive (W) holders break only once the open is granted: trigger = W|H.
+ */
 void
-chimera_vfs_state_break_on_open(
+chimera_vfs_state_break_caching_for_open(
     struct chimera_vfs_state             *state,
     const uint8_t                        *fh,
     uint8_t                               fh_len,
     uint64_t                              fh_hash,
-    const struct chimera_vfs_lease_owner *opener);
+    const struct chimera_vfs_lease_owner *opener,
+    uint8_t                               trigger_bits,
+    uint8_t                               retain_mode);


### PR DESCRIPTION
Draft. Builds out real SMB2 oplock and lease support on top of the unified VFS-owned lease layer, to green the smbtorture oplock/lease suites.

## What this does
Reworks SMB caching grants (oplocks + SMB2 leases) into first-class VFS-owned objects with a real break/ack state machine, replacing the earlier optimistic-ack scaffolding.

Highlights, in rough phase order:

**Oplocks**
- Exclusive/batch oplock grant + two-phase break-on-open (batch before the share-check, exclusive after)
- Real break/ack state machine: re-arm, client downgrade, sole-access detection (drops optimistic-ack)
- Attribute-only opens registered in `vfs_state`; create-path break consolidated into one decision point
- One canonical SMB<->VFS caching-grant encoding; caching recall split into namespace-revoke vs flush; apply the client NewLeaseState on a break ack

**SMB2 leases**
- Caching lease lives in a VFS-owned grant; break callback rides the grant, not the open
- Real lease coalescing + MS-SMB2 upgrade semantics
- Break arbitration across lease keys: write cache exclusive, read+handle shared
- Create-park mechanism: defer an open on a triggered lease break (async interim STATUS_PENDING + pending-open)
- Break-deadline-revoke driver (no more parked-forever ops)
- One-file-per-lease-key enforcement (STATUS_INVALID_PARAMETER)
- Lease ownership keyed by ClientGuid (not session id); ParentLeaseKey honored only when its flag is set; lease-response version/epoch follow the lease
- Create break-trigger widened to EA / WRITE_DAC / WRITE_OWNER
- A write never recalls the writer own lease (owner-key match), covering the RH self-break case (smb2.lease.complex1)

## Notes
- Config-gated; targets the smbtorture oplock/lease suites.
- Branch is currently behind main (cut earlier); will rebase onto current main before un-drafting.
