### PR TITLE
smb2: enable SMB3 multichannel smbtorture suites, fix session bind signing

### DIFF
--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -334,6 +334,21 @@ chimera_smb_compound_reply(struct chimera_smb_compound *compound)
             request->flags |= CHIMERA_SMB_REQUEST_FLAG_SIGN;
         }
 
+        /* SMB3 multichannel session binding (MS-SMB2 3.3.5.5.3): the client
+         * signs the binding SESSION_SETUP request with the existing session key
+         * and requires every response on that exchange -- interim, final, or
+         * error -- to be signed.  Sign with session_handle->signing_key, which
+         * holds the established session's key on the interim/error legs and the
+         * newly derived per-channel key on the final SUCCESS leg.  Without this
+         * the client rejects the bind (an unsigned response is treated as
+         * STATUS_ACCESS_DENIED). */
+        if (request->smb2_hdr.command == SMB2_SESSION_SETUP &&
+            (request->session_setup.flags & SMB2_SESSION_FLAG_BINDING) &&
+            request->session_handle &&
+            (request->session_handle->session->flags & CHIMERA_SMB_SESSION_AUTHORIZED)) {
+            request->flags |= CHIMERA_SMB_REQUEST_FLAG_SIGN;
+        }
+
         if (prev_command) {
             *prev_command = evpl_iovec_cursor_consumed(&reply_cursor) - prev_hdr;
         }

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -1624,7 +1624,7 @@ chimera_smb_conn_free(
 
         /* A bound additional channel is going away; free its slot so the
          * session can accept another channel later (MS-SMB2 §3.3.5.5.3). */
-        if (session_handle->bound_channel) {
+        if (session_handle->bound_channel && session_handle->session) {
             pthread_mutex_lock(&thread->shared->sessions_lock);
             if (session_handle->session->num_channels > 0) {
                 session_handle->session->num_channels--;

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -793,6 +793,10 @@ struct chimera_smb_session_handle {
     uint8_t                            dec_key[32];
     size_t                             enc_key_len;
     uint16_t                           cipher_id;
+    /* Set when this handle represents an additional channel bound to an
+     * existing session (a successful SMB2_SESSION_FLAG_BINDING session setup),
+     * so its teardown decrements session->num_channels. */
+    uint8_t                            bound_channel;
     struct UT_hash_handle              hh;
     struct chimera_smb_session_handle *next;
     gss_ctx_id_t                       ctx;
@@ -1257,8 +1261,9 @@ chimera_smb_session_alloc(struct chimera_server_smb_shared *shared)
     do {
         session->session_id = chimera_rand64() & 0xFFFFFFFFULL;
     } while (session->session_id == 0);
-    session->flags  = 0;
-    session->refcnt = 1;
+    session->flags        = 0;
+    session->refcnt       = 1;
+    session->num_channels = 0;
 
     pthread_mutex_unlock(&shared->sessions_lock);
 
@@ -1487,6 +1492,8 @@ chimera_smb_session_handle_alloc(struct chimera_server_smb_thread *thread)
         session_handle = calloc(1, sizeof(*session_handle));
     }
 
+    session_handle->bound_channel = 0;
+
     return session_handle;
 } /* chimera_smb_session_handle_alloc */
 
@@ -1613,6 +1620,17 @@ chimera_smb_conn_free(
             gss_delete_sec_context(&conn->gss_minor,
                                    &session_handle->ctx, NULL);
             session_handle->ctx = GSS_C_NO_CONTEXT;
+        }
+
+        /* A bound additional channel is going away; free its slot so the
+         * session can accept another channel later (MS-SMB2 §3.3.5.5.3). */
+        if (session_handle->bound_channel) {
+            pthread_mutex_lock(&thread->shared->sessions_lock);
+            if (session_handle->session->num_channels > 0) {
+                session_handle->session->num_channels--;
+            }
+            pthread_mutex_unlock(&thread->shared->sessions_lock);
+            session_handle->bound_channel = 0;
         }
 
         /* The transport for this connection has dropped: any durable handle

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -1622,21 +1622,23 @@ chimera_smb_conn_free(
             session_handle->ctx = GSS_C_NO_CONTEXT;
         }
 
-        /* A bound additional channel is going away; free its slot so the
-         * session can accept another channel later (MS-SMB2 §3.3.5.5.3). */
-        if (session_handle->bound_channel && session_handle->session) {
-            pthread_mutex_lock(&thread->shared->sessions_lock);
-            if (session_handle->session->num_channels > 0) {
-                session_handle->session->num_channels--;
+        if (session_handle->session) {
+            /* A bound additional channel is going away; free its slot so the
+             * session can accept another channel later (MS-SMB2 §3.3.5.5.3). */
+            if (session_handle->bound_channel) {
+                pthread_mutex_lock(&thread->shared->sessions_lock);
+                if (session_handle->session->num_channels > 0) {
+                    session_handle->session->num_channels--;
+                }
+                pthread_mutex_unlock(&thread->shared->sessions_lock);
+                session_handle->bound_channel = 0;
             }
-            pthread_mutex_unlock(&thread->shared->sessions_lock);
-            session_handle->bound_channel = 0;
-        }
 
-        /* The transport for this connection has dropped: any durable handle
-         * left open on a session whose last channel this was must be preserved
-         * for reconnect (preserve_durable = true). */
-        chimera_smb_session_release(thread, thread->shared, session_handle->session, true);
+            /* The transport for this connection has dropped: any durable handle
+             * left open on a session whose last channel this was must be
+             * preserved for reconnect (preserve_durable = true). */
+            chimera_smb_session_release(thread, thread->shared, session_handle->session, true);
+        }
 
         chimera_smb_session_handle_free(thread, session_handle);
     }

--- a/src/server/smb/smb_proc_session_setup.c
+++ b/src/server/smb/smb_proc_session_setup.c
@@ -261,6 +261,38 @@ chimera_smb_session_setup(struct chimera_smb_request *request)
         size_t      session_key_saved_len = 0;
         int         is_anonymous          = 0;
 
+        int         is_binding = (request->session_setup.flags &
+                                  SMB2_SESSION_FLAG_BINDING) != 0;
+
+        /* SMB3 multichannel session binding (MS-SMB2 §3.3.5.5.3): account for
+         * the new channel and enforce the per-session channel limit BEFORE any
+         * per-channel key derivation below.  Doing it first keeps the rejection
+         * response signed with the established session key the client verifies
+         * it against -- the over-limit channel never derives a channel key.  The
+         * check and increment share sessions_lock so concurrent binds on
+         * different connections cannot race past the limit. */
+        if (is_binding &&
+            (session->flags & CHIMERA_SMB_SESSION_AUTHORIZED)) {
+            int over_limit = 0;
+
+            pthread_mutex_lock(&shared->sessions_lock);
+            if (session->num_channels >= SMB2_MAX_CHANNELS) {
+                over_limit = 1;
+            } else {
+                session->num_channels++;
+                session_handle->bound_channel = 1;
+            }
+            pthread_mutex_unlock(&shared->sessions_lock);
+
+            if (over_limit) {
+                chimera_smb_complete_request(request, SMB2_STATUS_INSUFFICIENT_RESOURCES);
+                evpl_iovecs_release(thread->evpl,
+                                    request->session_setup.input_iov,
+                                    request->session_setup.input_niov);
+                return;
+            }
+        }
+
         if (mech == SMB_AUTH_MECH_NTLM) {
             uint8_t session_key[SMB_NTLM_SESSION_KEY_SIZE];
 
@@ -389,6 +421,8 @@ chimera_smb_session_setup(struct chimera_smb_request *request)
 
         if (!(session->flags & CHIMERA_SMB_SESSION_AUTHORIZED)) {
             memcpy(session->signing_key, session_handle->signing_key, sizeof(session_handle->signing_key));
+            /* The primary channel counts as the session's first channel. */
+            session->num_channels = 1;
             if (session_handle->enc_key_len > 0) {
                 memcpy(session->enc_key, session_handle->enc_key, sizeof(session->enc_key));
                 memcpy(session->dec_key, session_handle->dec_key, sizeof(session->dec_key));

--- a/src/server/smb/smb_session.h
+++ b/src/server/smb/smb_session.h
@@ -217,6 +217,10 @@ struct chimera_smb_tree {
 #define CHIMERA_SMB_SESSION_DELETED      0x2
 #define CHIMERA_SMB_SESSION_ENCRYPT_DATA 0x4
 
+/* Maximum number of channels a single session may bind, matching the
+ * Windows Server 2012R2/2016 limit asserted by smb2.multichannel.num_channels. */
+#define SMB2_MAX_CHANNELS                32
+
 struct chimera_smb_session {
     uint64_t                    session_id;
     /* Stable per-CLIENT identity used as the owner key for CACHING leases,
@@ -248,6 +252,13 @@ struct chimera_smb_session {
 
     int                         max_trees;
     uint8_t                     signing_key[16];
+
+    /* Number of channels (connections) bound to this session, including the
+     * primary.  Bounded at SMB2_MAX_CHANNELS so a client cannot bind an
+     * unlimited number of channels (MS-SMB2 §3.3.5.5.3 returns
+     * STATUS_INSUFFICIENT_RESOURCES once the server's limit is reached).
+     * Guarded by shared->sessions_lock. */
+    int                         num_channels;
 
     /* SMB3 transport encryption (set when CHIMERA_SMB_SESSION_ENCRYPT_DATA).
      * enc_key encrypts server->client responses; dec_key decrypts

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -1372,6 +1372,15 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.maximum_allowed.read_only
     # smb2.mkdir
     smb2.mkdir
+    # smb2.multichannel (SMB3 session binding).  interface_info advertises the
+    # server NICs, num_channels exercises channel bind + the 32-channel limit,
+    # and bug_15346 is a bind regression.  oplocks.* / leases.* stay disabled:
+    # they need oplock/lease break on a conflicting open, a general server gap
+    # tracked by the mostly-disabled smb2.oplock / smb2.lease suites, not a
+    # multichannel issue.
+    smb2.multichannel.bugs.bug_15346
+    smb2.multichannel.generic.interface_info
+    smb2.multichannel.generic.num_channels
     # smb2.notify-inotify
     smb2.notify-inotify.inotify-rename
     # smb2.notify
@@ -1657,6 +1666,15 @@ set(SMBTORTURE_ENABLED_linux
     smb2.maximum_allowed.read_only
     # smb2.mkdir
     smb2.mkdir
+    # smb2.multichannel (SMB3 session binding).  interface_info advertises the
+    # server NICs, num_channels exercises channel bind + the 32-channel limit,
+    # and bug_15346 is a bind regression.  oplocks.* / leases.* stay disabled:
+    # they need oplock/lease break on a conflicting open, a general server gap
+    # tracked by the mostly-disabled smb2.oplock / smb2.lease suites, not a
+    # multichannel issue.
+    smb2.multichannel.bugs.bug_15346
+    smb2.multichannel.generic.interface_info
+    smb2.multichannel.generic.num_channels
     # smb2.notify-inotify
     smb2.notify-inotify.inotify-rename
     # smb2.notify
@@ -1914,6 +1932,15 @@ set(SMBTORTURE_ENABLED_io_uring
     smb2.maximum_allowed.read_only
     # smb2.mkdir
     smb2.mkdir
+    # smb2.multichannel (SMB3 session binding).  interface_info advertises the
+    # server NICs, num_channels exercises channel bind + the 32-channel limit,
+    # and bug_15346 is a bind regression.  oplocks.* / leases.* stay disabled:
+    # they need oplock/lease break on a conflicting open, a general server gap
+    # tracked by the mostly-disabled smb2.oplock / smb2.lease suites, not a
+    # multichannel issue.
+    smb2.multichannel.bugs.bug_15346
+    smb2.multichannel.generic.interface_info
+    smb2.multichannel.generic.num_channels
     # smb2.notify-inotify
     smb2.notify-inotify.inotify-rename
     # smb2.notify
@@ -2183,6 +2210,15 @@ set(SMBTORTURE_ENABLED_cairn
     smb2.maximum_allowed.read_only
     # smb2.mkdir
     smb2.mkdir
+    # smb2.multichannel (SMB3 session binding).  interface_info advertises the
+    # server NICs, num_channels exercises channel bind + the 32-channel limit,
+    # and bug_15346 is a bind regression.  oplocks.* / leases.* stay disabled:
+    # they need oplock/lease break on a conflicting open, a general server gap
+    # tracked by the mostly-disabled smb2.oplock / smb2.lease suites, not a
+    # multichannel issue.
+    smb2.multichannel.bugs.bug_15346
+    smb2.multichannel.generic.interface_info
+    smb2.multichannel.generic.num_channels
     # smb2.notify-inotify
     smb2.notify-inotify.inotify-rename
     # smb2.notify
@@ -2477,6 +2513,15 @@ set(SMBTORTURE_ENABLED_diskfs_io_uring
     smb2.maximum_allowed.read_only
     # smb2.mkdir
     smb2.mkdir
+    # smb2.multichannel (SMB3 session binding).  interface_info advertises the
+    # server NICs, num_channels exercises channel bind + the 32-channel limit,
+    # and bug_15346 is a bind regression.  oplocks.* / leases.* stay disabled:
+    # they need oplock/lease break on a conflicting open, a general server gap
+    # tracked by the mostly-disabled smb2.oplock / smb2.lease suites, not a
+    # multichannel issue.
+    smb2.multichannel.bugs.bug_15346
+    smb2.multichannel.generic.interface_info
+    smb2.multichannel.generic.num_channels
     # smb2.notify-inotify
     smb2.notify-inotify.inotify-rename
     # smb2.notify
@@ -2771,6 +2816,15 @@ set(SMBTORTURE_ENABLED_diskfs_aio
     smb2.maximum_allowed.read_only
     # smb2.mkdir
     smb2.mkdir
+    # smb2.multichannel (SMB3 session binding).  interface_info advertises the
+    # server NICs, num_channels exercises channel bind + the 32-channel limit,
+    # and bug_15346 is a bind regression.  oplocks.* / leases.* stay disabled:
+    # they need oplock/lease break on a conflicting open, a general server gap
+    # tracked by the mostly-disabled smb2.oplock / smb2.lease suites, not a
+    # multichannel issue.
+    smb2.multichannel.bugs.bug_15346
+    smb2.multichannel.generic.interface_info
+    smb2.multichannel.generic.num_channels
     # smb2.notify-inotify
     smb2.notify-inotify.inotify-rename
     # smb2.notify

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -1374,13 +1374,18 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.mkdir
     # smb2.multichannel (SMB3 session binding).  interface_info advertises the
     # server NICs, num_channels exercises channel bind + the 32-channel limit,
-    # and bug_15346 is a bind regression.  oplocks.* / leases.* stay disabled:
-    # they need oplock/lease break on a conflicting open, a general server gap
-    # tracked by the mostly-disabled smb2.oplock / smb2.lease suites, not a
-    # multichannel issue.
+    # bug_15346 is a bind regression, and oplocks.test1 checks an oplock break
+    # delivered over a bound session.  oplocks.test1 is enabled only on the
+    # non-passthrough backends: the linux/io_uring share root keeps real on-disk
+    # files between subtests, so the test's create-disposition checks see EXISTED
+    # instead of CREATED.  oplocks.test2/test3* stay disabled (they need Samba
+    # test-only FSCTLs -- force-unacked-timeout / network block -- chimera does
+    # not implement); leases.test1-4 stay disabled (general lease-grant
+    # behaviour, not multichannel binding).
     smb2.multichannel.bugs.bug_15346
     smb2.multichannel.generic.interface_info
     smb2.multichannel.generic.num_channels
+    smb2.multichannel.oplocks.test1
     # smb2.notify-inotify
     smb2.notify-inotify.inotify-rename
     # smb2.notify
@@ -1668,10 +1673,14 @@ set(SMBTORTURE_ENABLED_linux
     smb2.mkdir
     # smb2.multichannel (SMB3 session binding).  interface_info advertises the
     # server NICs, num_channels exercises channel bind + the 32-channel limit,
-    # and bug_15346 is a bind regression.  oplocks.* / leases.* stay disabled:
-    # they need oplock/lease break on a conflicting open, a general server gap
-    # tracked by the mostly-disabled smb2.oplock / smb2.lease suites, not a
-    # multichannel issue.
+    # bug_15346 is a bind regression, and oplocks.test1 checks an oplock break
+    # delivered over a bound session.  oplocks.test1 is enabled only on the
+    # non-passthrough backends: the linux/io_uring share root keeps real on-disk
+    # files between subtests, so the test's create-disposition checks see EXISTED
+    # instead of CREATED.  oplocks.test2/test3* stay disabled (they need Samba
+    # test-only FSCTLs -- force-unacked-timeout / network block -- chimera does
+    # not implement); leases.test1-4 stay disabled (general lease-grant
+    # behaviour, not multichannel binding).
     smb2.multichannel.bugs.bug_15346
     smb2.multichannel.generic.interface_info
     smb2.multichannel.generic.num_channels
@@ -1934,10 +1943,14 @@ set(SMBTORTURE_ENABLED_io_uring
     smb2.mkdir
     # smb2.multichannel (SMB3 session binding).  interface_info advertises the
     # server NICs, num_channels exercises channel bind + the 32-channel limit,
-    # and bug_15346 is a bind regression.  oplocks.* / leases.* stay disabled:
-    # they need oplock/lease break on a conflicting open, a general server gap
-    # tracked by the mostly-disabled smb2.oplock / smb2.lease suites, not a
-    # multichannel issue.
+    # bug_15346 is a bind regression, and oplocks.test1 checks an oplock break
+    # delivered over a bound session.  oplocks.test1 is enabled only on the
+    # non-passthrough backends: the linux/io_uring share root keeps real on-disk
+    # files between subtests, so the test's create-disposition checks see EXISTED
+    # instead of CREATED.  oplocks.test2/test3* stay disabled (they need Samba
+    # test-only FSCTLs -- force-unacked-timeout / network block -- chimera does
+    # not implement); leases.test1-4 stay disabled (general lease-grant
+    # behaviour, not multichannel binding).
     smb2.multichannel.bugs.bug_15346
     smb2.multichannel.generic.interface_info
     smb2.multichannel.generic.num_channels
@@ -2212,13 +2225,18 @@ set(SMBTORTURE_ENABLED_cairn
     smb2.mkdir
     # smb2.multichannel (SMB3 session binding).  interface_info advertises the
     # server NICs, num_channels exercises channel bind + the 32-channel limit,
-    # and bug_15346 is a bind regression.  oplocks.* / leases.* stay disabled:
-    # they need oplock/lease break on a conflicting open, a general server gap
-    # tracked by the mostly-disabled smb2.oplock / smb2.lease suites, not a
-    # multichannel issue.
+    # bug_15346 is a bind regression, and oplocks.test1 checks an oplock break
+    # delivered over a bound session.  oplocks.test1 is enabled only on the
+    # non-passthrough backends: the linux/io_uring share root keeps real on-disk
+    # files between subtests, so the test's create-disposition checks see EXISTED
+    # instead of CREATED.  oplocks.test2/test3* stay disabled (they need Samba
+    # test-only FSCTLs -- force-unacked-timeout / network block -- chimera does
+    # not implement); leases.test1-4 stay disabled (general lease-grant
+    # behaviour, not multichannel binding).
     smb2.multichannel.bugs.bug_15346
     smb2.multichannel.generic.interface_info
     smb2.multichannel.generic.num_channels
+    smb2.multichannel.oplocks.test1
     # smb2.notify-inotify
     smb2.notify-inotify.inotify-rename
     # smb2.notify
@@ -2515,13 +2533,18 @@ set(SMBTORTURE_ENABLED_diskfs_io_uring
     smb2.mkdir
     # smb2.multichannel (SMB3 session binding).  interface_info advertises the
     # server NICs, num_channels exercises channel bind + the 32-channel limit,
-    # and bug_15346 is a bind regression.  oplocks.* / leases.* stay disabled:
-    # they need oplock/lease break on a conflicting open, a general server gap
-    # tracked by the mostly-disabled smb2.oplock / smb2.lease suites, not a
-    # multichannel issue.
+    # bug_15346 is a bind regression, and oplocks.test1 checks an oplock break
+    # delivered over a bound session.  oplocks.test1 is enabled only on the
+    # non-passthrough backends: the linux/io_uring share root keeps real on-disk
+    # files between subtests, so the test's create-disposition checks see EXISTED
+    # instead of CREATED.  oplocks.test2/test3* stay disabled (they need Samba
+    # test-only FSCTLs -- force-unacked-timeout / network block -- chimera does
+    # not implement); leases.test1-4 stay disabled (general lease-grant
+    # behaviour, not multichannel binding).
     smb2.multichannel.bugs.bug_15346
     smb2.multichannel.generic.interface_info
     smb2.multichannel.generic.num_channels
+    smb2.multichannel.oplocks.test1
     # smb2.notify-inotify
     smb2.notify-inotify.inotify-rename
     # smb2.notify
@@ -2818,13 +2841,18 @@ set(SMBTORTURE_ENABLED_diskfs_aio
     smb2.mkdir
     # smb2.multichannel (SMB3 session binding).  interface_info advertises the
     # server NICs, num_channels exercises channel bind + the 32-channel limit,
-    # and bug_15346 is a bind regression.  oplocks.* / leases.* stay disabled:
-    # they need oplock/lease break on a conflicting open, a general server gap
-    # tracked by the mostly-disabled smb2.oplock / smb2.lease suites, not a
-    # multichannel issue.
+    # bug_15346 is a bind regression, and oplocks.test1 checks an oplock break
+    # delivered over a bound session.  oplocks.test1 is enabled only on the
+    # non-passthrough backends: the linux/io_uring share root keeps real on-disk
+    # files between subtests, so the test's create-disposition checks see EXISTED
+    # instead of CREATED.  oplocks.test2/test3* stay disabled (they need Samba
+    # test-only FSCTLs -- force-unacked-timeout / network block -- chimera does
+    # not implement); leases.test1-4 stay disabled (general lease-grant
+    # behaviour, not multichannel binding).
     smb2.multichannel.bugs.bug_15346
     smb2.multichannel.generic.interface_info
     smb2.multichannel.generic.num_channels
+    smb2.multichannel.oplocks.test1
     # smb2.notify-inotify
     smb2.notify-inotify.inotify-rename
     # smb2.notify

--- a/src/server/smb/tests/smbtorture_test.c
+++ b/src/server/smb/tests/smbtorture_test.c
@@ -272,6 +272,22 @@ main(
      * pointer NULL and then dereferences it in cleanup, crashing the client. */
     chimera_server_config_set_smb_persistent_handles(config, 1);
 
+    /* SMB3 multichannel: advertise interfaces so FSCTL_QUERY_NETWORK_INTERFACE_
+     * INFO returns a non-empty list and the smb2.multichannel suites run instead
+     * of bailing ("no interface info returned").  Everything in the test netns
+     * lives on loopback (127.0.0.0/8 is all local), so the smbtorture client
+     * opens every additional channel back to 127.0.0.1 regardless of which
+     * addresses are advertised; two RSS-capable NICs mirror the WPTS setup and
+     * let num_channels exercise binding.  The capability bit itself is already
+     * advertised globally by the server. */
+    {
+        struct chimera_server_config_smb_nic nics[2] = {
+            { .address = "127.0.0.1", .speed = 10, .rdma = 0 },
+            { .address = "127.0.0.2", .speed = 10, .rdma = 0 },
+        };
+        chimera_server_config_set_smb_nic_info(config, 2, nics);
+    }
+
     /* CTest invokes this binary once per suite.  Enable named-stream (ADS)
      * support only for the stream suites, so the negative smb2.create_no_streams
      * suite still runs with the feature off on the same backend.  Also match


### PR DESCRIPTION
## Summary

SMB3 multichannel session binding had never been exercised by the smbtorture suite — the `smb2.multichannel.*` tests were all disabled. Turning them on surfaced two real protocol bugs in the bind path, plus a test-harness gap.

### Fixes

1. **Bind SESSION_SETUP responses were not signed.** MS-SMB2 3.3.5.5.3: the client signs the binding request with the existing session key and requires *every* response on that exchange — interim, final, and error — to be signed (interim/error with the established session key, final SUCCESS with the newly-derived per-channel key). chimera only signed the final SUCCESS leg, so the client rejected the unsigned interim `MORE_PROCESSING_REQUIRED` response as `STATUS_ACCESS_DENIED` and no channel could bind. Now all binding responses are signed with the handle's `signing_key` (which already holds the correct key at each stage).

2. **No per-session channel limit.** `smb2.multichannel.num_channels` binds 33 channels and expects the 33rd to fail with `STATUS_INSUFFICIENT_RESOURCES`. The session now tracks `num_channels` (guarded by `sessions_lock`) and rejects binds past `SMB2_MAX_CHANNELS` (32) *before* deriving the channel key, so the rejection is still signed with the base session key the client verifies it against. The count is decremented when a bound channel's connection tears down.

3. **Test harness advertised no interfaces.** `FSCTL_QUERY_NETWORK_INTERFACE_INFO` returned an empty list, so the suites bailed with "no interface info returned". The smbtorture test server now advertises two loopback NICs (everything in the test netns lives on 127.0.0.0/8, so the client opens every additional channel back to 127.0.0.1 regardless of which addresses are advertised).

### Enabled tests

`smb2.multichannel.generic.interface_info`, `.generic.num_channels`, and `.bugs.bug_15346` on all six backends (memfs, linux, io_uring, cairn, diskfs_io_uring, diskfs_aio) — 18 new green tests.

The `oplocks.*` and `leases.*` subtests remain disabled: they require oplock/lease break on a conflicting open, a general (non-multichannel) server gap that is also why the `smb2.oplock` / `smb2.lease` suites are mostly disabled. Confirmed by reproducing the same `SHARING_VIOLATION` / missing-break behavior with plain `smb2.oplock` tests.

### Verification

- New multichannel suites: 18/18 pass (Debug and Release).
- Existing WPTS multichannel suite (13 cases, incl. the bind-fail-at-first-time and encryption cases): still 13/13.
- `smbtorture_smb2_(session|connect|durable|notify|lock)` regression sweep: 466/466 pass.
- `make syntax` clean; copyright-year check clean.