### PR TITLE
smb2: resume cross-connection CREATEs parked on a lease break

### DIFF
--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -190,6 +190,7 @@ chimera_smb_server_init(
     pthread_mutex_init(&shared->sessions_lock, NULL);
     pthread_mutex_init(&shared->shares_lock, NULL);
     pthread_mutex_init(&shared->trees_lock, NULL);
+    pthread_mutex_init(&shared->threads_lock, NULL);
 
     /* Seed the persistent-id allocator with a random, nonzero base so ids do
      * not restart from a fixed value across daemon restarts (a courtesy to the
@@ -250,6 +251,8 @@ chimera_smb_server_destroy(void *data)
     if (shared->srv_cred != GSS_C_NO_CREDENTIAL) {
         gss_release_cred(&min, &shared->srv_cred);
     }
+
+    pthread_mutex_destroy(&shared->threads_lock);
 
     free(shared);
 } /* smb_server_destroy */
@@ -1922,6 +1925,10 @@ chimera_smb_server_accept(
     evpl_bind_get_local_address(bind, conn->local_addr, sizeof(conn->local_addr));
     evpl_bind_get_remote_address(bind, conn->remote_addr, sizeof(conn->remote_addr));
 
+    /* Track this connection on its owning thread's active list so the
+     * lease-break resume doorbell can walk it for parked CREATEs. */
+    DL_APPEND2(thread->active_conns, conn, active_prev, active_next);
+
     *notify_callback   = chimera_smb_server_notify;
     *segment_callback  = chimera_smb_server_segment;
     *conn_private_data = conn;
@@ -1967,6 +1974,18 @@ chimera_smb_server_thread_init(
     chimera_smb_notify_thread_init(thread);
     chimera_smb_lease_break_thread_init(thread);
 
+    /* Resume doorbell: a peer thread settling a lease break rings this so this
+     * thread re-scans its own connections for parked CREATEs to complete. */
+    evpl_add_doorbell(evpl, &thread->lease_resume_doorbell,
+                      chimera_smb_create_resume_doorbell_callback);
+
+    /* Register in the process-global thread list so resume broadcasts reach
+     * this thread. */
+    pthread_mutex_lock(&shared->threads_lock);
+    thread->next_thread = shared->threads;
+    shared->threads     = thread;
+    pthread_mutex_unlock(&shared->threads_lock);
+
     if (shared->config.persistent_handles) {
         evpl_add_timer(evpl, &thread->durable_sweeper,
                        chimera_smb_durable_sweeper_fire,
@@ -1991,6 +2010,19 @@ chimera_smb_server_thread_destroy(void *data)
     struct chimera_smb_conn           *conn;
     struct chimera_smb_compound       *compound;
     struct chimera_smb_session_handle *session_handle;
+    struct chimera_server_smb_thread **tpp;
+
+    /* Unregister from the process-global thread list first so a peer thread's
+     * resume broadcast can no longer ring this thread's (about-to-be-removed)
+     * resume doorbell.  evpl_remove_doorbell below then runs on this thread. */
+    pthread_mutex_lock(&thread->shared->threads_lock);
+    for (tpp = &thread->shared->threads; *tpp; tpp = &(*tpp)->next_thread) {
+        if (*tpp == thread) {
+            *tpp = thread->next_thread;
+            break;
+        }
+    }
+    pthread_mutex_unlock(&thread->shared->threads_lock);
 
     /* Release any durable/persistent handles still parked in the shared
      * registry while this thread's vfs_thread is alive.  Each parked open
@@ -2036,6 +2068,7 @@ chimera_smb_server_thread_destroy(void *data)
     }
 
     evpl_listener_detach(thread->evpl, thread->binding);
+    evpl_remove_doorbell(thread->evpl, &thread->lease_resume_doorbell);
     chimera_smb_notify_thread_destroy(thread);
     chimera_smb_lease_break_thread_destroy(thread);
 

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -899,6 +899,11 @@ struct chimera_smb_conn {
     struct evpl_bind                  *bind;
     struct chimera_smb_conn           *prev;
     struct chimera_smb_conn           *next;
+    /* Active-connection list links (thread->active_conns).  Distinct from
+     * prev/next (the pooled free-list reuse) so an active conn can be walked by
+     * its owning thread without disturbing free-list bookkeeping. */
+    struct chimera_smb_conn           *active_prev;
+    struct chimera_smb_conn           *active_next;
     struct evpl_iovec                  rdma_iov[256];
     char                               local_addr[128];
     char                               remote_addr[128];
@@ -957,35 +962,41 @@ struct chimera_smb_durable_record {
 };
 
 struct chimera_server_smb_shared {
-    struct chimera_smb_config        config;
-    int                              rdma;
-    enum evpl_protocol_id            tcp_protocol;
-    uint8_t                          guid[SMB2_GUID_SIZE];
-    gss_name_t                       svc;
-    gss_cred_id_t                    srv_cred;
-    struct chimera_vfs              *vfs;
-    struct prometheus_metrics       *metrics;
-    struct evpl_endpoint            *endpoint;
-    struct evpl_endpoint            *endpoint_rdma;
-    struct evpl_listener            *listener;
-    struct chimera_smb_session      *sessions;
-    struct chimera_smb_session      *free_sessions;
-    pthread_mutex_t                  sessions_lock;
-    struct chimera_smb_share        *shares;
-    pthread_mutex_t                  shares_lock;
+    struct chimera_smb_config         config;
+    int                               rdma;
+    enum evpl_protocol_id             tcp_protocol;
+    uint8_t                           guid[SMB2_GUID_SIZE];
+    gss_name_t                        svc;
+    gss_cred_id_t                     srv_cred;
+    struct chimera_vfs               *vfs;
+    struct prometheus_metrics        *metrics;
+    struct evpl_endpoint             *endpoint;
+    struct evpl_endpoint             *endpoint_rdma;
+    struct evpl_listener             *listener;
+    struct chimera_smb_session       *sessions;
+    struct chimera_smb_session       *free_sessions;
+    pthread_mutex_t                   sessions_lock;
+    struct chimera_smb_share         *shares;
+    pthread_mutex_t                   shares_lock;
     /* Set when any share has encrypt_data enabled.  Used by SESSION_SETUP to
      * decide whether to derive per-session encryption keys even when the global
      * smb_encryption knob is off (a client may still tree-connect to a
      * per-share-encrypted share). */
-    int                              any_share_encrypt;
-    struct chimera_smb_tree         *free_trees;
-    pthread_mutex_t                  trees_lock;
+    int                               any_share_encrypt;
+    struct chimera_smb_tree          *free_trees;
+    pthread_mutex_t                   trees_lock;
     /* Monotonic, process-global allocator for file persistent ids.  Replaces
      * the old per-tree counter so persistent ids stay unique across tree
      * teardowns — a precondition for durable-handle reconnect lookup. */
-    _Atomic uint64_t                 next_persistent_id;
+    _Atomic uint64_t                  next_persistent_id;
     /* In-memory durable/persistent handle registry (see struct above). */
-    struct chimera_smb_durable_table durable;
+    struct chimera_smb_durable_table  durable;
+    /* Registry of all live SMB threads (chained on thread->next_thread).  Used
+     * to broadcast a lease-break *resume* doorbell to peer threads when an
+     * OPLOCK_BREAK ack settles a lease that a CREATE parked on another thread is
+     * waiting for. */
+    struct chimera_server_smb_thread *threads;
+    pthread_mutex_t                   threads_lock;
 };
 
 /* Forward decl so the inline open_file release paths can call into
@@ -1134,6 +1145,29 @@ struct chimera_server_smb_thread {
     struct evpl_doorbell                lease_break_doorbell;
     struct chimera_smb_lease_break_msg *lease_break_ready;
     pthread_mutex_t                     lease_break_lock;
+
+    /* Lease-break *resume* doorbell: when an inbound OPLOCK_BREAK ack settles a
+     * file's caching lease, CREATEs parked waiting on that break may live on a
+     * different connection owned by a different thread (the two-client lease
+     * break: A's ack arrives on A's thread, B's parked CREATE sits on B's
+     * thread).  The deferred CREATE response's iovecs are thread-local, so the
+     * ack handler cannot complete them; instead it rings every other thread's
+     * resume doorbell, and each thread re-scans its own connections' parked
+     * CREATEs and completes those whose break has now settled
+     * (chimera_vfs_state_caching_breaking() is false).  The re-check makes a
+     * parameterless broadcast safe -- only genuinely-settled creates complete. */
+    struct evpl_doorbell                lease_resume_doorbell;
+
+    /* Active (non-pooled) connections owned by this thread, threaded on
+     * conn->active_prev / conn->active_next.  Lets a thread walk every
+     * connection it owns to find parked CREATEs to resume.  Only touched on the
+     * owning thread (accept / conn_free / resume doorbell all run here), so no
+     * lock is needed. */
+    struct chimera_smb_conn            *active_conns;
+
+    /* Process-global registry link: every SMB thread is chained here under
+    * shared->threads_lock so the resume broadcast can reach every peer. */
+    struct chimera_server_smb_thread   *next_thread;
 
     /* Periodic sweep of the shared durable-handle registry for parked opens
      * whose reconnect grace window has expired.  Each thread sweeps the shared
@@ -1651,6 +1685,10 @@ chimera_smb_conn_free(
 
     // Cleanup GSSAPI context if initialized
     smb_gssapi_cleanup(&conn->gssapi_ctx);
+
+    /* Drop from the owning thread's active-connection list before returning the
+     * conn to the pool (the resume doorbell walks active_conns). */
+    DL_DELETE2(thread->active_conns, conn, active_prev, active_next);
 
     LL_PREPEND(thread->free_conns, conn);
 } /* chimera_smb_conn_free */

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -1688,27 +1688,22 @@ chimera_smb_create_open_finish(
     chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
 } /* chimera_smb_create_open_finish */
 
-/* Resume any CREATE parked on `ack_request`'s connection whose triggered lease
- * break has now settled (no caching lease on the file is mid-break).  Called from
- * the inbound OPLOCK_BREAK ack handler after the lease is acked.  The opener's
- * pending create sits on its own conn's parked_requests; in the single-channel
- * case that is the same connection the ack arrived on, so the deferred response's
- * thread-local iovecs are produced on the right thread.  A create awaiting an ack
- * that arrives on a different channel is drained by that channel's ack. */
-void
-chimera_smb_create_resume_parked(struct chimera_smb_request *ack_request)
+/* Resume the settled parked CREATEs on one connection.  Pull every parked
+ * CREATE whose triggered lease break has now settled (no caching lease on the
+ * file is mid-break) off `conn`'s parked list, then complete them on this
+ * thread.  `conn` must be owned by `thread` so the deferred response's
+ * thread-local iovecs are produced on the right thread.  The
+ * chimera_vfs_state_caching_breaking() re-check is what makes a blind sweep
+ * safe: only genuinely-settled creates complete. */
+static void
+chimera_smb_create_resume_parked_conn(
+    struct chimera_server_smb_thread *thread,
+    struct chimera_vfs_state         *vfs_state,
+    struct chimera_smb_conn          *conn)
 {
-    struct chimera_server_smb_thread *thread    = ack_request->compound->thread;
-    struct chimera_vfs_state         *vfs_state = thread->vfs_thread->vfs->vfs_state;
-    struct chimera_smb_conn          *conn      = ack_request->compound->conn;
-    struct chimera_smb_request       *req, **pp, *resume = NULL;
+    struct chimera_smb_request *req, **pp, *resume = NULL;
 
-    if (!conn) {
-        return;
-    }
-
-    /* Pull settled parked CREATEs off the conn's parked list, then complete them.
-     * Collect first (unlinking + clearing armed) so the completion path does not
+    /* Collect first (unlinking + clearing armed) so the completion path does not
      * re-walk / re-cancel the list we are iterating. */
     pp = &conn->parked_requests;
     while ((req = *pp)) {
@@ -1741,7 +1736,83 @@ chimera_smb_create_resume_parked(struct chimera_smb_request *ack_request)
          * SMB2_FLAGS_ASYNC_COMMAND matching the interim. */
         chimera_smb_complete_request(req, SMB2_STATUS_SUCCESS);
     }
+} /* chimera_smb_create_resume_parked_conn */
+
+/* Resume any CREATE parked on `ack_request`'s OWN connection whose triggered
+ * lease break has now settled.  Called from the inbound OPLOCK_BREAK ack handler
+ * after the lease is acked.  This is the single-client fast path: a client that
+ * breaks its own lease (e.g. a lease upgrade) has its pending create on the same
+ * connection the ack arrived on, so the deferred response's thread-local iovecs
+ * are produced on the right thread.  The two-client case -- where B's CREATE
+ * parked on B's connection/thread triggered the break A just acked on A's
+ * thread -- is handled by chimera_smb_create_resume_parked_broadcast, which
+ * rings every peer thread's resume doorbell so each completes its own parked
+ * CREATEs locally. */
+void
+chimera_smb_create_resume_parked(struct chimera_smb_request *ack_request)
+{
+    struct chimera_server_smb_thread *thread    = ack_request->compound->thread;
+    struct chimera_vfs_state         *vfs_state = thread->vfs_thread->vfs->vfs_state;
+    struct chimera_smb_conn          *conn      = ack_request->compound->conn;
+
+    if (conn) {
+        chimera_smb_create_resume_parked_conn(thread, vfs_state, conn);
+    }
+
+    /* Wake peer threads to resume CREATEs parked on their own connections (the
+     * two-client lease break: the opener's parked CREATE lives on a different
+     * connection/thread than the one this ack arrived on). */
+    chimera_smb_create_resume_parked_broadcast(thread);
 } /* chimera_smb_create_resume_parked */
+
+/* Resume doorbell handler: runs on its owning SMB thread.  An OPLOCK_BREAK ack
+ * settled a lease on some (possibly different) thread; re-scan every connection
+ * this thread owns and complete any parked CREATE whose break has now settled.
+ * The per-CREATE caching_breaking() re-check gates correctness, so this blind
+ * sweep only completes genuinely-settled opens; a CREATE still waiting on an
+ * unsettled break is left parked (its own deadline / a later ack resumes it). */
+SYMBOL_EXPORT void
+chimera_smb_create_resume_doorbell_callback(
+    struct evpl          *evpl,
+    struct evpl_doorbell *doorbell)
+{
+    struct chimera_server_smb_thread *thread;
+    struct chimera_vfs_state         *vfs_state;
+    struct chimera_smb_conn          *conn, *tmp;
+
+    (void) evpl;
+
+    thread = container_of(doorbell, struct chimera_server_smb_thread,
+                          lease_resume_doorbell);
+    vfs_state = thread->vfs_thread->vfs->vfs_state;
+
+    DL_FOREACH_SAFE2(thread->active_conns, conn, tmp, active_next)
+    {
+        chimera_smb_create_resume_parked_conn(thread, vfs_state, conn);
+    }
+} /* chimera_smb_create_resume_doorbell_callback */
+
+/* Ring every PEER SMB thread's resume doorbell so each re-scans its own
+ * connections for parked CREATEs the just-settled lease break unblocked.
+ * `origin` is skipped because the ack handler already swept its own connection
+ * inline; the per-CREATE caching_breaking() re-check would make a re-sweep of
+ * `origin` harmless anyway.  The deferred CREATE responses' iovecs are
+ * thread-local, so each thread must complete its own. */
+void
+chimera_smb_create_resume_parked_broadcast(struct chimera_server_smb_thread *origin)
+{
+    struct chimera_server_smb_shared *shared = origin->shared;
+    struct chimera_server_smb_thread *t;
+
+    pthread_mutex_lock(&shared->threads_lock);
+    for (t = shared->threads; t; t = t->next_thread) {
+        if (t == origin) {
+            continue;
+        }
+        evpl_ring_doorbell(&t->lease_resume_doorbell);
+    }
+    pthread_mutex_unlock(&shared->threads_lock);
+} /* chimera_smb_create_resume_parked_broadcast */
 
 /*
  * Map the CREATE DesiredAccess to canonical access-mask bits and evaluate it

--- a/src/server/smb/smb_procs.h
+++ b/src/server/smb/smb_procs.h
@@ -299,10 +299,22 @@ int chimera_smb_parse_oplock_break(
 void chimera_smb_oplock_break(
     struct chimera_smb_request *request);
 
-/* Resume CREATEs parked on the ack's tree whose triggered lease break has now
- * settled.  Called from the OPLOCK_BREAK ack handler after the lease is acked. */
+/* Resume CREATEs parked whose triggered lease break has now settled.  Called
+ * from the OPLOCK_BREAK ack handler after the lease is acked: sweeps the ack's
+ * own connection, then broadcasts a resume doorbell to peer threads (a CREATE
+ * that triggered the break can be parked on another connection/thread). */
 void chimera_smb_create_resume_parked(
     struct chimera_smb_request *ack_request);
+
+/* Ring every peer SMB thread's resume doorbell so each re-scans its own
+ * connections for parked CREATEs the just-settled lease break unblocked. */
+void chimera_smb_create_resume_parked_broadcast(
+    struct chimera_server_smb_thread *origin);
+
+/* Resume doorbell handler (runs on its owning thread). */
+void chimera_smb_create_resume_doorbell_callback(
+    struct evpl          *evpl,
+    struct evpl_doorbell *doorbell);
 
 void chimera_smb_oplock_break_reply(
     struct evpl_iovec_cursor   *reply_cursor,

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -120,6 +120,8 @@ if(CHIMERA_NETNS_TESTING AND WPTS_DOTNET AND WPTS_SMB2_DLL AND WPTS_ARCH_SUPPORT
         BVT_Compound_UnRelatedRequests
         BVT_CreateClose_CreateAndCloseDirectory
         BVT_CreateClose_CreateAndCloseFile
+        BVT_Leasing_FileLeasingV1
+        BVT_Leasing_FileLeasingV2
         BVT_MultiCredit_OneRequestWithMultiCredit
         BVT_Negotiate_Compatible_2002
         BVT_Negotiate_Compatible_Wildcard
@@ -349,6 +351,7 @@ if(CHIMERA_NETNS_TESTING AND WPTS_DOTNET AND WPTS_SMB2_DLL AND WPTS_ARCH_SUPPORT
     set(WPTS_SMB2_MULTICHANNEL_ALLOWLIST
         BVT_MultipleChannel_NicRedundantOnBoth
         BVT_NetworkInterfaceInfo_QuerySuccessful
+        MultipleChannel_FileLease
         MultipleChannel_LockUnlockOnDiffChannel
         MultipleChannel_LockUnlockOnSameChannel
         MultipleChannel_MultiChannelOnSameNic


### PR DESCRIPTION
## Root cause

An SMB2 file-lease break in the two-client scenario is a two-connection, two-thread interaction:

1. Client A (conn A, thread T_A) holds an RWH SMB2 lease on a file.
2. Client B (conn B, thread T_B != T_A) opens the same file. This conflicts with A's handle-caching lease, so B's CREATE **parks** (async-interim `STATUS_PENDING`) on `conn_B->parked_requests` with a break-deadline timer, and an ack-required lease break is sent to A.
3. A acks the break on **its own** connection / thread T_A.

The ack handler (`chimera_smb_oplock_break` -> `chimera_smb_create_resume_parked`) resumed parked CREATEs by walking only `ack_request->compound->conn->parked_requests` — i.e. the connection the **ack** arrived on (conn A). B's parked CREATE lives on **conn B / thread T_B**, so it was never found and never resumed. It only completed when its break-deadline timer fired (longer than the WPTS client's patience) -> `System.TimeoutException`.

The old code's assumption ("the opener's pending create sits on the same connection the ack arrived on") only holds when a client breaks its **own** lease (e.g. a lease upgrade), not the two-client `BVT_Leasing` case.

## Fix (cross-thread resume)

The deferred CREATE response's iovecs are thread-local, so a parked CREATE must be completed on its own owning thread. This mirrors, in reverse, the existing cross-thread lease-break *notification* machinery (the `lease_break_doorbell`):

- When an ack settles a lease, sweep the ack's **own** connection inline (the single-client self-break / lease-upgrade fast path is preserved), then **broadcast a per-thread resume doorbell** to every peer thread.
- Each peer's resume-doorbell callback re-scans the connections it owns and completes any parked CREATE whose break has now settled.
- Correctness is gated by the per-CREATE `chimera_vfs_state_caching_breaking()` re-check, so the broadcast sweep only completes genuinely-settled opens; a CREATE still waiting on an unsettled break stays parked. The break-deadline timer is cancelled on resume (invariant preserved; safe if both fire).

Supporting bookkeeping:
- Connections are threaded on a per-thread active list (`conn->active_prev/active_next`, maintained in `accept` / `conn_free`) so a thread can walk every connection it owns.
- Every SMB thread is chained in a process-global registry (`shared->threads` under `threads_lock`) so the broadcast can reach all peers. Threads unregister under the lock before their doorbell is removed, so a peer can never ring a torn-down doorbell.

No VFS lease semantics are changed; the change stays within the SMB lease-break / create-park path.

## WPTS cases enabled (3)

| Test | Mode | Result |
| --- | --- | --- |
| `BVT_Leasing_FileLeasingV1` | baseline (memfs) | Passes |
| `BVT_Leasing_FileLeasingV2` | baseline (memfs) | Passes |
| `MultipleChannel_FileLease` | multichannel | Passes |

The two `Leasing_FileLeasingV{1,2}_SameLeaseKey` cases are **not** enabled here: they are blocked on a separate lease-arbitration gap (a same-lease-key conflicting open must break the holder to `SMB2_LEASE_NONE`, not `RH`; the server currently breaks RWH -> RH and the test fails on the `NewLeaseState` assertion before resume matters). That requires a VFS-lease-layer break-target change and is left for a follow-up.

## Regression guard

smbtorture lease/oplock suites stay green across all backends (`oplock.batch10`, `kernel_oplocks8`, `durable_open_disconnect_open_oplock_disconnect` — 11/11 enabled ctest cases pass). The single-client self-break/upgrade path is unaffected.