### PR TITLE
ci: fix reuse-lint by installing reuse[charset-normalizer]

### DIFF
--- a/.github/workflows/reuse-compliance.yml
+++ b/.github/workflows/reuse-compliance.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install reuse tool
       run: |
         pip install --upgrade pip -i http://repository.mdh.quantum.com/repository/pypi-proxy/simple/ --trusted-host repository.mdh.quantum.com
-        pip install reuse -i http://repository.mdh.quantum.com/repository/pypi-proxy/simple/ --trusted-host repository.mdh.quantum.com
+        pip install 'reuse[charset-normalizer]' -i http://repository.mdh.quantum.com/repository/pypi-proxy/simple/ --trusted-host repository.mdh.quantum.com
         
     - name: Run REUSE lint
       run: |


### PR DESCRIPTION
## Problem
`reuse-lint` is failing on **every** open PR (e.g. #686) — not a code/compliance issue. The newly-released **reuse 6.2.0** moved charset detection into an optional dependency, so on Python 3.14 the tool aborts at import:

```
reuse.exceptions.NoEncodingModuleError: No supported module that can detect the
encoding of files could be successfully imported.
- Run `pipx install reuse[charset-normalizer]`...
```

The workflow installs `reuse` unpinned, so it grabbed 6.2.0 and crashes before linting anything.

## Fix
Install `reuse[charset-normalizer]` (exactly what reuse's own error message recommends) so the encoding-detection module is present. One-line change to `.github/workflows/reuse-compliance.yml`.

This unblocks reuse-lint across all PRs.