### PR TITLE
smb2: share (don't break) a lease on a same-lease-key conflicting open

### DIFF
--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -122,6 +122,8 @@ if(CHIMERA_NETNS_TESTING AND WPTS_DOTNET AND WPTS_SMB2_DLL AND WPTS_ARCH_SUPPORT
         BVT_CreateClose_CreateAndCloseFile
         BVT_Leasing_FileLeasingV1
         BVT_Leasing_FileLeasingV2
+        Leasing_FileLeasingV1_SameLeaseKey
+        Leasing_FileLeasingV2_SameLeaseKey
         BVT_MultiCredit_OneRequestWithMultiCredit
         BVT_Negotiate_Compatible_2002
         BVT_Negotiate_Compatible_Wildcard

--- a/src/vfs/vfs_state.c
+++ b/src/vfs/vfs_state.c
@@ -285,6 +285,32 @@ chimera_vfs_lease_owner_equal(
            a->owner_hi == b->owner_hi;
 } /* chimera_vfs_lease_owner_equal */
 
+/* Same-lease-key test for SMB2 caching leases, IGNORING client_key.
+ *
+ * MS-SMB2 identifies a lease by (ClientGuid, LeaseKey); chimera's owner key
+ * encodes ClientGuid in client_key and LeaseKey in owner_lo/owner_hi.  When a
+ * conflicting open or a write presents the SAME LeaseKey as an existing caching
+ * holder, the object store shares the cache rather than breaking it -- so the
+ * holder must be exempted from the break.  Windows applies this on the lease key
+ * alone (two opens with the same lease key, even from different connections with
+ * distinct ClientGuids, do not break one another: WPTS Leasing_FileLeasing*_
+ * SameLeaseKey).  This mirrors the SHARE-acquire side's has_break_skip_key,
+ * which is keyed on the lease key only (see chimera_vfs_state_would_conflict).
+ *
+ * Restricted to SMB2 caching leases on both sides: NFSv4 delegations and the
+ * internal implicit lease never share an SMB lease key, and owner_equal already
+ * covers a holder's own same-client/same-key re-open. */
+static inline bool
+chimera_vfs_lease_smb2_same_key(
+    const struct chimera_vfs_lease_owner *holder,
+    const struct chimera_vfs_lease_owner *opener)
+{
+    return holder->protocol == CHIMERA_VFS_LEASE_PROTO_SMB2 &&
+           opener->protocol == CHIMERA_VFS_LEASE_PROTO_SMB2 &&
+           holder->owner_lo == opener->owner_lo &&
+           holder->owner_hi == opener->owner_hi;
+} /* chimera_vfs_lease_smb2_same_key */
+
 /* Byte-range overlap test for half-open intervals [off, off+len).
  *
  * length==0 is a genuine zero-byte range (SMB2 zero-length lock): [off, off)
@@ -1250,6 +1276,19 @@ chimera_vfs_caching_grant_find_locked(
         if (chimera_vfs_lease_owner_equal(&g->lease.owner, owner)) {
             return g;
         }
+        /* MS-SMB2 same-lease-key: an open that presents the same LeaseKey as an
+         * existing SMB2 RqLs lease grant joins that grant (shares its cache
+         * state), even when it arrives on a different ClientGuid/connection.
+         * Windows keys the underlying oplock by lease key, so two opens with one
+         * lease key share a single lease rather than breaking one another (WPTS
+         * Leasing_FileLeasing{V1,V2}_SameLeaseKey).  Matched here so the second
+         * open is granted the existing state (e.g. RWH) and no break fires.
+         * Restricted to lease grants (!is_oplock): a legacy oplock is keyed by a
+         * per-open file id, never a shareable lease key. */
+        if (!g->is_oplock &&
+            chimera_vfs_lease_smb2_same_key(&g->lease.owner, owner)) {
+            return g;
+        }
     }
     return NULL;
 } /* chimera_vfs_caching_grant_find_locked */
@@ -2001,6 +2040,13 @@ chimera_vfs_break_reads_for_write(
         if (chimera_vfs_lease_owner_equal(&cur->owner, writer)) {
             continue;
         }
+        /* A holder sharing the writer's SMB2 lease key (even under a different
+         * ClientGuid) shares the cache and is coherent with this write: do not
+         * break it (MS-SMB2 same-lease-key; WPTS Leasing_*_SameLeaseKey writes
+         * from both clients without breaking the peer's lease). */
+        if (chimera_vfs_lease_smb2_same_key(&cur->owner, writer)) {
+            continue;
+        }
         if (n < CHIMERA_VFS_STATE_MAX_BREAK_BATCH) {
             to_break[n++] = cur;
         }
@@ -2070,6 +2116,12 @@ chimera_vfs_state_break_caching_for_open(
             continue;
         }
         if (chimera_vfs_lease_owner_equal(&cur->owner, opener)) {
+            continue;
+        }
+        /* Same SMB2 lease key (even from a different ClientGuid): the opens share
+         * one logical lease and the holder is NOT broken (MS-SMB2 same-lease-key
+         * caching; mirrors the SHARE-side has_break_skip_key). */
+        if (chimera_vfs_lease_smb2_same_key(&cur->owner, opener)) {
             continue;
         }
         /* A pure handle-trigger break (the pre-share-check pass) is a legacy SMB


### PR DESCRIPTION
## Root cause

WPTS `Leasing_FileLeasingV1_SameLeaseKey` / `Leasing_FileLeasingV2_SameLeaseKey` open the same file from **two separate connections that present the SAME LeaseKey but distinct ClientGuids** (the WPTS SDK generates a fresh `Guid.NewGuid()` per client), each requesting an RWH lease. The test asserts the peer lease is **neither broken nor downgraded** (`CheckBreakNotification(isNotificationExpected: false)`) and that the second open is granted the existing RWH state.

chimera encodes the SMB2 lease identity `(ClientGuid, LeaseKey)` as `(client_key, owner_lo/owner_hi)` and matched caching holders by the **full** owner tuple. So two opens with one lease key but different ClientGuids were treated as conflicting:

- the second open broke the first holder RWH→RH (ack-required) and **parked waiting for an ack that never arrived** → `STATUS_PENDING` → WPTS `TimeoutException`;
- the second open's own lease was capped to **R** by the caching arbitration.

## MS-SMB2 rule

Windows keys the underlying object-store oplock by **lease key**, so two opens under one lease key form a single shared lease (MS-SMB2 same-lease-key caching, [§3.3.5.9.8](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/24cfce29-5d80-4651-ba5f-a2661c666b41) + the object-store lease-break path). A same-key open shares the cache rather than breaking the peer; a write through a same-key holder is coherent with the peer and does not invalidate it.

## Change

Add `chimera_vfs_lease_smb2_same_key()` (lease-key match ignoring `client_key`, SMB2 leases only) and apply it at three sites in `src/vfs/vfs_state.c`:

1. **caching-grant coalesce** (`chimera_vfs_caching_grant_find_locked`): a same-key open joins the existing RqLs lease grant and inherits its state (RWH), so no new conflicting lease is inserted and no break fires. Restricted to lease grants (`!is_oplock`).
2. **break-on-open** (`chimera_vfs_state_break_caching_for_open`): a holder sharing the opener's lease key is exempt.
3. **break-on-write** (`chimera_vfs_break_reads_for_write`): a holder sharing the writer's lease key is exempt.

This mirrors the SHARE-acquire side's existing `has_break_skip_key`, which is already keyed on the lease key alone. NFSv4 delegations and the implicit I/O lease are unaffected (the helper is SMB2-only and they never share an SMB lease key).

Enables both WPTS cases on memfs.

## Results

- `Leasing_FileLeasingV1_SameLeaseKey` (memfs): **Passed**
- `Leasing_FileLeasingV2_SameLeaseKey` (memfs): **Passed**
- Full WPTS Leasing allowlist (incl. the 3 enabled by #686): no regression
- smbtorture lease/oplock guard: 11/11 pass (all backends)
- smbtorture durable/create/streams/deny: 111/111 pass
- vfs unit tests (state, sync/async delegation, enforce, identity): 10/10 pass

## Base

Based on **#686** (`smb2-lease-break-cross-thread-resume`), which is required to get past the timeout and observe this behavior. **Rebase onto `main` once #686 merges.**