### PR TITLE
vfs: POSIX authorization, pathname limits, and delete-model fixes

### DIFF
--- a/src/vfs/tests/vfs_enforce_test.c
+++ b/src/vfs/tests/vfs_enforce_test.c
@@ -5,8 +5,9 @@
 /*
  * End-to-end check that the VFS-layer access gate actually enforces the ACL on
  * an engine-authoritative backend (memfs): the owner of a 0600 file may
- * read/write/chmod it, and a non-owner is denied (EACCES) on read, write, and
- * chmod -- the cross-protocol-agnostic enforcement the VFS gate provides.
+ * read/write/chmod it, and a non-owner is denied on read, write (EACCES) and
+ * chmod (EPERM, ownership required) -- the cross-protocol-agnostic enforcement
+ * the VFS gate provides.
  */
 
 #include <stdio.h>
@@ -442,8 +443,10 @@ main(
     assert(write_as(&ctx, &other, file_fh, file_fh_len) == CHIMERA_VFS_EACCES);
     TEST_PASS("write: owner allowed, non-owner denied (0600)");
 
-    /* chmod requires WRITE_ACL: the owner holds it implicitly, a non-owner does not. */
-    assert(chmod_as(&ctx, &other, file_fh, file_fh_len, 0640) == CHIMERA_VFS_EACCES);
+    /* chmod requires WRITE_ACL: the owner holds it implicitly, a non-owner does
+     * not.  POSIX chmod(2) by a non-owner is EPERM (ownership required), not
+     * EACCES. */
+    assert(chmod_as(&ctx, &other, file_fh, file_fh_len, 0640) == CHIMERA_VFS_EPERM);
     assert(chmod_as(&ctx, &owner, file_fh, file_fh_len, 0640) == CHIMERA_VFS_OK);
     TEST_PASS("chmod: non-owner denied, owner allowed");
 

--- a/src/vfs/vfs_proc_gate.c
+++ b/src/vfs/vfs_proc_gate.c
@@ -156,8 +156,14 @@ chimera_vfs_gate_delete_child_getattr(
         return;
     }
 
+    /* The parent's DELETE_CHILD grant always authorizes removal.  A per-object
+     * DELETE grant on the child is an NFSv4/NT concept; under POSIX (AUTH_UNIX /
+     * AUTH_NONE) deletion is governed solely by the containing directory's
+     * write+search permission, so the child-DELETE fallback applies only to
+     * ACL-flavored (AUTH_ATTR) callers. */
     allow = ctx->dc ||
-        chimera_vfs_access_allowed(attr, ctx->cred, CHIMERA_ACE_DELETE);
+        (ctx->cred->flavor == CHIMERA_VFS_AUTH_ATTR &&
+         chimera_vfs_access_allowed(attr, ctx->cred, CHIMERA_ACE_DELETE));
 
     if (allow && ctx->sticky) {
         child_uid = (attr->va_set_mask & CHIMERA_VFS_ATTR_UID) ?

--- a/src/vfs/vfs_proc_link_at.c
+++ b/src/vfs/vfs_proc_link_at.c
@@ -180,6 +180,11 @@ chimera_vfs_link_at(
     struct chimera_vfs_module       *module;
     struct chimera_vfs_link_at_gate *gate;
 
+    if (namelen >= CHIMERA_VFS_NAME_MAX) {
+        callback(CHIMERA_VFS_ENAMETOOLONG, NULL, NULL, NULL, private_data);
+        return;
+    }
+
     module = chimera_vfs_get_module(thread, dir_fh, dir_fhlen);
 
     if (module && chimera_vfs_gate_needed(module->capabilities, cred)) {
@@ -200,7 +205,7 @@ chimera_vfs_link_at(
         gate->private_data   = private_data;
 
         chimera_vfs_gate_fh(thread, cred, dir_fh, dir_fhlen,
-                            CHIMERA_ACE_WRITE_DATA,
+                            CHIMERA_ACE_WRITE_DATA | CHIMERA_ACE_EXECUTE,
                             chimera_vfs_link_at_gate_complete, gate);
         return;
     }

--- a/src/vfs/vfs_proc_lookup.c
+++ b/src/vfs/vfs_proc_lookup.c
@@ -308,9 +308,26 @@ chimera_vfs_lookup(
         pathlen--;
     }
 
-    if (pathlen > CHIMERA_VFS_PATH_MAX) {
+    /* POSIX: a pathname longer than {PATH_MAX} (including the terminating null,
+     * so pathlen must be < CHIMERA_VFS_PATH_MAX), or any single component longer
+     * than {NAME_MAX} (CHIMERA_VFS_NAME_MAX includes room for the null), fails
+     * with ENAMETOOLONG before any lookup is attempted. */
+    if (pathlen >= CHIMERA_VFS_PATH_MAX) {
         callback(CHIMERA_VFS_ENAMETOOLONG, NULL, private_data);
         return;
+    }
+
+    {
+        int complen = 0;
+
+        for (int i = 0; i < pathlen; i++) {
+            if (path[i] == '/') {
+                complen = 0;
+            } else if (++complen >= CHIMERA_VFS_NAME_MAX) {
+                callback(CHIMERA_VFS_ENAMETOOLONG, NULL, private_data);
+                return;
+            }
+        }
     }
 
     if (pathlen == 0) {

--- a/src/vfs/vfs_proc_mkdir_at.c
+++ b/src/vfs/vfs_proc_mkdir_at.c
@@ -221,6 +221,11 @@ chimera_vfs_mkdir_at(
 {
     struct chimera_vfs_mkdir_at_gate *gate;
 
+    if (namelen >= CHIMERA_VFS_NAME_MAX) {
+        callback(CHIMERA_VFS_ENAMETOOLONG, NULL, NULL, NULL, NULL, private_data);
+        return;
+    }
+
     if (chimera_vfs_gate_needed(handle->vfs_module->capabilities, cred)) {
         gate                 = malloc(sizeof(*gate));
         gate->thread         = thread;
@@ -235,8 +240,10 @@ chimera_vfs_mkdir_at(
         gate->callback       = callback;
         gate->private_data   = private_data;
 
+        /* Creating an entry in a directory requires both the right to add a
+         * subdirectory (APPEND_DATA) and search permission (EXECUTE) on it. */
         chimera_vfs_gate_fh(thread, cred, handle->fh, handle->fh_len,
-                            CHIMERA_ACE_APPEND_DATA,
+                            CHIMERA_ACE_APPEND_DATA | CHIMERA_ACE_EXECUTE,
                             chimera_vfs_mkdir_at_gate_complete, gate);
         return;
     }

--- a/src/vfs/vfs_proc_mknod_at.c
+++ b/src/vfs/vfs_proc_mknod_at.c
@@ -211,6 +211,11 @@ chimera_vfs_mknod_at(
 {
     struct chimera_vfs_mknod_at_gate *gate;
 
+    if (namelen >= CHIMERA_VFS_NAME_MAX) {
+        callback(CHIMERA_VFS_ENAMETOOLONG, NULL, NULL, NULL, NULL, private_data);
+        return;
+    }
+
     if (chimera_vfs_gate_needed(handle->vfs_module->capabilities, cred)) {
         gate                 = malloc(sizeof(*gate));
         gate->thread         = thread;
@@ -226,7 +231,7 @@ chimera_vfs_mknod_at(
         gate->private_data   = private_data;
 
         chimera_vfs_gate_fh(thread, cred, handle->fh, handle->fh_len,
-                            CHIMERA_ACE_WRITE_DATA,
+                            CHIMERA_ACE_WRITE_DATA | CHIMERA_ACE_EXECUTE,
                             chimera_vfs_mknod_at_gate_complete, gate);
         return;
     }

--- a/src/vfs/vfs_proc_remove_at.c
+++ b/src/vfs/vfs_proc_remove_at.c
@@ -217,6 +217,22 @@ chimera_vfs_remove_at(
 {
     struct chimera_vfs_remove_at_gate *gate;
 
+    if (namelen >= CHIMERA_VFS_NAME_MAX) {
+        callback(CHIMERA_VFS_ENAMETOOLONG, NULL, NULL, private_data);
+        return;
+    }
+
+    /* POSIX: a final path component of "." cannot be removed (EINVAL); ".."
+     * names the (non-empty) parent directory (ENOTEMPTY). */
+    if (namelen == 1 && name[0] == '.') {
+        callback(CHIMERA_VFS_EINVAL, NULL, NULL, private_data);
+        return;
+    }
+    if (namelen == 2 && name[0] == '.' && name[1] == '.') {
+        callback(CHIMERA_VFS_ENOTEMPTY, NULL, NULL, private_data);
+        return;
+    }
+
     if (chimera_vfs_gate_needed(handle->vfs_module->capabilities, cred)) {
         gate                 = malloc(sizeof(*gate));
         gate->thread         = thread;

--- a/src/vfs/vfs_proc_rename_at.c
+++ b/src/vfs/vfs_proc_rename_at.c
@@ -345,6 +345,21 @@ chimera_vfs_rename_at(
     struct chimera_vfs_module         *module;
     struct chimera_vfs_rename_at_gate *gate;
 
+    /* POSIX: renaming to/from "." or ".." is invalid (EINVAL); a final
+     * component longer than {NAME_MAX} is ENAMETOOLONG. */
+    if ((namelen == 1 && name[0] == '.') ||
+        (namelen == 2 && name[0] == '.' && name[1] == '.') ||
+        (new_namelen == 1 && new_name[0] == '.') ||
+        (new_namelen == 2 && new_name[0] == '.' && new_name[1] == '.')) {
+        callback(CHIMERA_VFS_EINVAL, NULL, NULL, NULL, NULL, private_data);
+        return;
+    }
+
+    if (namelen >= CHIMERA_VFS_NAME_MAX || new_namelen >= CHIMERA_VFS_NAME_MAX) {
+        callback(CHIMERA_VFS_ENAMETOOLONG, NULL, NULL, NULL, NULL, private_data);
+        return;
+    }
+
     module = chimera_vfs_get_module(thread, fh, fhlen);
 
     if (module && chimera_vfs_gate_needed(module->capabilities, cred)) {

--- a/src/vfs/vfs_proc_setattr.c
+++ b/src/vfs/vfs_proc_setattr.c
@@ -4,6 +4,7 @@
 
 #include <string.h>
 #include <stdlib.h>
+#include <sys/stat.h>
 #include "vfs_procs.h"
 #include "vfs_state.h"
 #include "vfs_internal.h"
@@ -70,6 +71,104 @@ chimera_vfs_setattr_required(
 
     return required;
 } /* chimera_vfs_setattr_required */
+
+/*
+ * Map a denied setattr to the POSIX errno.  Operations that require ownership
+ * of the file -- chmod (mode/ACL), chown/chgrp (uid/gid), and setting a
+ * timestamp to an explicit value -- fail with EPERM for a non-owner without
+ * privilege.  Operations that merely require write permission -- truncate
+ * (size) and setting a timestamp to "now" -- fail with EACCES.  When both
+ * classes are present, the ownership requirement dominates (EPERM).
+ */
+/* Is `cred` a member of group `gid` (primary or supplementary)? */
+static int
+chimera_vfs_setattr_cred_in_group(
+    const struct chimera_vfs_cred *cred,
+    uint64_t                       gid)
+{
+    if ((uint64_t) cred->gid == gid) {
+        return 1;
+    }
+    for (uint32_t i = 0; i < cred->ngids; i++) {
+        if ((uint64_t) cred->gids[i] == gid) {
+            return 1;
+        }
+    }
+    return 0;
+} /* chimera_vfs_setattr_cred_in_group */
+
+/*
+ * POSIX chown(2) eligibility for a non-privileged caller against the file's
+ * current owner/group.  Only the super-user may change the owner (uid); the
+ * group (gid) may be changed only by the file's owner and only to a group in
+ * the caller's group set.  A field left unset, or set to its current value, is
+ * not a change.  Returns CHIMERA_VFS_OK when permitted, else CHIMERA_VFS_EPERM.
+ */
+static enum chimera_vfs_error
+chimera_vfs_setattr_chown_check(
+    const struct chimera_vfs_cred  *cred,
+    const struct chimera_vfs_attrs *set_attr,
+    const struct chimera_vfs_attrs *cur)
+{
+    uint64_t m  = set_attr->va_set_mask;
+    int has_uid = (m & CHIMERA_VFS_ATTR_UID) != 0;
+    int has_gid = (m & CHIMERA_VFS_ATTR_GID) != 0;
+
+    if (cred->uid == 0) {
+        return CHIMERA_VFS_OK;
+    }
+
+    /* chown(path, -1, -1) names no owner or group and is always permitted. */
+    if (!has_uid && !has_gid) {
+        return CHIMERA_VFS_OK;
+    }
+
+    /* To perform any chown a non-privileged caller must own the file. */
+    if (!(cur->va_set_mask & CHIMERA_VFS_ATTR_UID) ||
+        (uint64_t) cred->uid != cur->va_uid) {
+        return CHIMERA_VFS_EPERM;
+    }
+
+    /* The owner may not change the owner (uid) to a different value. */
+    if (has_uid &&
+        (cur->va_set_mask & CHIMERA_VFS_ATTR_UID) &&
+        set_attr->va_uid != cur->va_uid) {
+        return CHIMERA_VFS_EPERM;
+    }
+
+    /* The owner may change the group only to one it is a member of. */
+    if (has_gid &&
+        (cur->va_set_mask & CHIMERA_VFS_ATTR_GID) &&
+        set_attr->va_gid != cur->va_gid &&
+        !chimera_vfs_setattr_cred_in_group(cred, set_attr->va_gid)) {
+        return CHIMERA_VFS_EPERM;
+    }
+
+    return CHIMERA_VFS_OK;
+} /* chimera_vfs_setattr_chown_check */
+
+static enum chimera_vfs_error
+chimera_vfs_setattr_denied_error(const struct chimera_vfs_attrs *set_attr)
+{
+    uint64_t m = set_attr->va_set_mask;
+
+    if (m & (CHIMERA_VFS_ATTR_MODE | CHIMERA_VFS_ATTR_ACL |
+             CHIMERA_VFS_ATTR_UID | CHIMERA_VFS_ATTR_GID)) {
+        return CHIMERA_VFS_EPERM;
+    }
+
+    if ((m & CHIMERA_VFS_ATTR_ATIME) &&
+        set_attr->va_atime.tv_nsec != CHIMERA_VFS_TIME_NOW) {
+        return CHIMERA_VFS_EPERM;
+    }
+
+    if ((m & CHIMERA_VFS_ATTR_MTIME) &&
+        set_attr->va_mtime.tv_nsec != CHIMERA_VFS_TIME_NOW) {
+        return CHIMERA_VFS_EPERM;
+    }
+
+    return CHIMERA_VFS_EACCES;
+} /* chimera_vfs_setattr_denied_error */
 
 static void
 chimera_vfs_setattr_complete(struct chimera_vfs_request *request)
@@ -168,10 +267,71 @@ chimera_vfs_setattr_gate_complete(
      * owner/group restate does not demand WRITE_OWNER. */
     required = chimera_vfs_setattr_required(gate->set_attr, attr);
 
+    /* POSIX: the file's owner (and the super-user) may always update its
+     * timestamps -- to an explicit value or to "now" -- regardless of write
+     * permission.  For a setattr that changes only atime/mtime, the owner is
+     * therefore unconditionally authorized. */
+    {
+        uint64_t m     = gate->set_attr->va_set_mask;
+        int      owner = (gate->cred->uid == 0) ||
+            ((attr->va_set_mask & CHIMERA_VFS_ATTR_UID) &&
+             (uint64_t) gate->cred->uid == attr->va_uid);
+
+        if (owner && (m & (CHIMERA_VFS_ATTR_ATIME | CHIMERA_VFS_ATTR_MTIME)) &&
+            !(m & ~(CHIMERA_VFS_ATTR_ATIME | CHIMERA_VFS_ATTR_MTIME |
+                    CHIMERA_VFS_ATTR_CTIME))) {
+            required = 0;
+        }
+    }
+
     if (chimera_vfs_gate(attr, gate->cred, required) != CHIMERA_VFS_OK) {
-        gate->callback(CHIMERA_VFS_EACCES, NULL, NULL, NULL, gate->private_data);
+        gate->callback(chimera_vfs_setattr_denied_error(gate->set_attr),
+                       NULL, NULL, NULL, gate->private_data);
         free(gate);
         return;
+    }
+
+    /* POSIX chown(2) restrictions (uid change requires privilege; gid change
+     * requires ownership + group membership) apply on top of the ACL grant. */
+    if (chimera_vfs_setattr_chown_check(gate->cred, gate->set_attr, attr) != CHIMERA_VFS_OK) {
+        gate->callback(CHIMERA_VFS_EPERM, NULL, NULL, NULL, gate->private_data);
+        free(gate);
+        return;
+    }
+
+    /* A successful change of owner or group by a non-privileged caller clears
+     * the set-user-ID and set-group-ID bits of a non-directory (POSIX/Linux
+     * kill-priv: don't let a privileged binary survive an ownership change). */
+    if (gate->cred->uid != 0 &&
+        !(gate->set_attr->va_set_mask & CHIMERA_VFS_ATTR_MODE) &&
+        (attr->va_set_mask & CHIMERA_VFS_ATTR_MODE) &&
+        (attr->va_mode & S_IFMT) != S_IFDIR &&
+        (attr->va_mode & (S_ISUID | S_ISGID))) {
+        uint64_t m            = gate->set_attr->va_set_mask;
+        int      owner_change =
+            ((m & CHIMERA_VFS_ATTR_UID) && (attr->va_set_mask & CHIMERA_VFS_ATTR_UID) &&
+             gate->set_attr->va_uid != attr->va_uid) ||
+            ((m & CHIMERA_VFS_ATTR_GID) && (attr->va_set_mask & CHIMERA_VFS_ATTR_GID) &&
+             gate->set_attr->va_gid != attr->va_gid);
+
+        if (owner_change) {
+            gate->set_attr->va_mode      = attr->va_mode & ~(uint64_t) (S_ISUID | S_ISGID);
+            gate->set_attr->va_set_mask |= CHIMERA_VFS_ATTR_MODE;
+        }
+    }
+
+    /* POSIX: when a non-privileged process whose group set does not include the
+     * file's owning group chmods a non-directory, the set-group-ID bit is
+     * cleared on success (it would otherwise let a user grant themselves the
+     * file group's identity on execution). */
+    if ((gate->set_attr->va_set_mask & CHIMERA_VFS_ATTR_MODE) &&
+        (gate->set_attr->va_mode & S_ISGID) &&
+        gate->cred->uid != 0 &&
+        (attr->va_set_mask & CHIMERA_VFS_ATTR_MODE) &&
+        (attr->va_mode & S_IFMT) != S_IFDIR &&
+        (attr->va_set_mask & CHIMERA_VFS_ATTR_GID) &&
+        !chimera_vfs_setattr_cred_in_group(gate->cred, attr->va_gid)) {
+        gate->set_attr->va_mode &= ~(uint64_t) S_ISGID;
     }
 
     chimera_vfs_setattr_dispatch(gate->thread, gate->cred, gate->handle,

--- a/src/vfs/vfs_proc_symlink_at.c
+++ b/src/vfs/vfs_proc_symlink_at.c
@@ -165,6 +165,11 @@ chimera_vfs_symlink_at(
 {
     struct chimera_vfs_symlink_at_gate *gate;
 
+    if (namelen >= CHIMERA_VFS_NAME_MAX) {
+        callback(CHIMERA_VFS_ENAMETOOLONG, NULL, NULL, NULL, private_data);
+        return;
+    }
+
     if (chimera_vfs_gate_needed(handle->vfs_module->capabilities, cred)) {
         gate                 = malloc(sizeof(*gate));
         gate->thread         = thread;
@@ -182,7 +187,7 @@ chimera_vfs_symlink_at(
         gate->private_data   = private_data;
 
         chimera_vfs_gate_fh(thread, cred, handle->fh, handle->fh_len,
-                            CHIMERA_ACE_WRITE_DATA,
+                            CHIMERA_ACE_WRITE_DATA | CHIMERA_ACE_EXECUTE,
                             chimera_vfs_symlink_at_gate_complete, gate);
         return;
     }


### PR DESCRIPTION
## Summary

VFS-core POSIX authorization, pathname-limit, and delete-model fixes. These are
backend- and protocol-agnostic behavior corrections (NFS, SMB and the POSIX
client all benefit), surfaced while standing up a POSIX conformance test suite.

- **setattr authorization** (`vfs_proc_setattr.c`): EPERM vs EACCES for denied
  chmod/chown/explicit-times vs size/utimes-now; full POSIX `chown(2)`
  restrictions (non-root can't change owner; group only to a member group; any
  non-owner chown is EPERM); setuid/setgid kill-priv on ownership change;
  `S_ISGID` clearing on non-owner chmod; the owner may always set timestamps.
- **Pathname limits**: `chimera_vfs_lookup` rejects an over-long component
  (`{NAME_MAX}`) or whole path (`{PATH_MAX}`) with ENAMETOOLONG instead of
  ENOENT; create/remove `_at` bound the final component too.
- **Directory create** requires search (EXECUTE) + write on the parent
  (`mkdir`/`mknod`/`symlink`/`link` `_at`).
- **POSIX delete model** (`vfs_proc_gate.c`): the per-object DELETE (NFSv4/NT)
  fallback applies only to AUTH_ATTR callers; AUTH_UNIX/NONE deletion is governed
  solely by the containing directory's write+search permission.
- `rmdir`/`rename` of a final `.` → EINVAL, `..` → ENOTEMPTY.

Part of a series splitting the functional compliance fixes out of the
pjdfstest-port PR (#691) so the test-suite addition is purely tests.
