### PR TITLE
s3: honor server.s3_port configuration

### DIFF
--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -557,6 +557,12 @@ main(
         chimera_server_config_set_nfs_port(server_config, int_value);
     }
 
+    json_value = json_object_get(server_params, "s3_port");
+    if (json_is_integer(json_value)) {
+        int_value = json_integer_value(json_value);
+        chimera_server_config_set_s3_port(server_config, int_value);
+    }
+
     /* NFSv4.1 server identity (EXCHANGE_ID server scope).  Set a distinct value
      * on independent servers that do not share state -- e.g. a pNFS data server
      * co-deployed with its MDS -- so v4.1 clients do not coalesce them. */

--- a/src/server/s3/s3.c
+++ b/src/server/s3/s3.c
@@ -773,7 +773,7 @@ s3_server_init(
 
     shared->tcp_protocol = chimera_server_config_get_tcp_stream_protocol(config);
 
-    shared->config->port    = 5000;
+    shared->config->port    = chimera_server_config_get_s3_port(config);
     shared->config->io_size = 128 * 1024;
 
     shared->endpoint = evpl_endpoint_create("0.0.0.0", shared->config->port);

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -48,6 +48,7 @@ struct chimera_server_config {
     int                                   nfs_tcp_rdma_port;
     int                                   nfs_lockmgr_port;
     int                                   nfs_port;
+    int                                   s3_port;
     int                                   nfs_data_server;
     uint64_t                              nfs_server_scope;
     int                                   external_portmap;
@@ -207,6 +208,7 @@ chimera_server_config_init(void)
     /* NFS service port (default 2049); data-server mode binds only the NFSv4
      * service so a pNFS data server can coexist with an MDS on one host. */
     config->nfs_port        = 2049;
+    config->s3_port         = 5000;
     config->nfs_data_server = 0;
 
     /* NFSv4.1 server identity (EXCHANGE_ID eir_server_scope).  Clients treat two
@@ -600,6 +602,20 @@ chimera_server_config_get_nfs_port(const struct chimera_server_config *config)
 {
     return config->nfs_port;
 } /* chimera_server_config_get_nfs_port */
+
+SYMBOL_EXPORT void
+chimera_server_config_set_s3_port(
+    struct chimera_server_config *config,
+    int                           port)
+{
+    config->s3_port = port;
+} /* chimera_server_config_set_s3_port */
+
+SYMBOL_EXPORT int
+chimera_server_config_get_s3_port(const struct chimera_server_config *config)
+{
+    return config->s3_port;
+} /* chimera_server_config_get_s3_port */
 
 SYMBOL_EXPORT void
 chimera_server_config_set_nfs_data_server(

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -288,6 +288,15 @@ chimera_server_config_get_nfs_port(
     const struct chimera_server_config *config);
 
 void
+chimera_server_config_set_s3_port(
+    struct chimera_server_config *config,
+    int                           port);
+
+int
+chimera_server_config_get_s3_port(
+    const struct chimera_server_config *config);
+
+void
 chimera_server_config_set_nfs_data_server(
     struct chimera_server_config *config,
     int                           enable);


### PR DESCRIPTION
The S3 server hardcoded its listen port to 5000 and ignored the `s3_port` value from the config:

```c
shared->config->port = 5000;   /* server.s3_port was never read */
```

So the documented `server.s3_port` knob had no effect (and you couldn't run two S3 servers, or avoid a busy 5000). Add an `s3_port` config field (default 5000) with set/get accessors, parse `server.s3_port` in the daemon, and bind the configured port in S3 server init. No behaviour change when unset.
