### PR TITLE
vfs/posix: open(2) POSIX semantics and memfs backend compliance

### DIFF
--- a/src/posix/posix_ftruncate.c
+++ b/src/posix/posix_ftruncate.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -47,6 +47,13 @@ chimera_posix_ftruncate(
 
     if (!entry) {
         errno = EBADF;
+        return -1;
+    }
+
+    /* POSIX: ftruncate on a descriptor not open for writing fails with EINVAL. */
+    if ((entry->oflags & O_ACCMODE) == O_RDONLY) {
+        chimera_posix_fd_release(entry, 0);
+        errno = EINVAL;
         return -1;
     }
 

--- a/src/posix/posix_internal.h
+++ b/src/posix/posix_internal.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -248,6 +248,8 @@ chimera_posix_to_chimera_flags(int flags)
         out |= CHIMERA_VFS_OPEN_READ_ONLY;
     } else if ((flags & O_ACCMODE) == O_WRONLY) {
         out |= CHIMERA_VFS_OPEN_WRITE_ONLY;
+    } else { /* O_RDWR: request both read and write access */
+        out |= CHIMERA_VFS_OPEN_READ_ONLY | CHIMERA_VFS_OPEN_WRITE_ONLY;
     }
 
     return out;

--- a/src/posix/posix_internal.h
+++ b/src/posix/posix_internal.h
@@ -60,6 +60,7 @@ struct chimera_posix_fd_entry {
     int                             eof_flag;    // For FILE* feof() support
     int                             error_flag;  // For FILE* ferror() support
     int                             ungetc_char; // For FILE* ungetc() support (-1 = none)
+    unsigned int                    oflags;      // Raw open(2) flags (for O_ACCMODE checks)
 } __attribute__((aligned(64)));
 
 // CHIMERA_FILE is a pointer to an fd_entry for FILE* operations
@@ -233,8 +234,20 @@ chimera_posix_to_chimera_flags(int flags)
         out |= CHIMERA_VFS_OPEN_DIRECTORY;
     }
 
+    if (flags & O_TRUNC) {
+        out |= CHIMERA_VFS_OPEN_TRUNCATE;
+    }
+
+#ifdef O_NOFOLLOW
+    if (flags & O_NOFOLLOW) {
+        out |= CHIMERA_VFS_OPEN_NOFOLLOW;
+    }
+#endif /* ifdef O_NOFOLLOW */
+
     if ((flags & O_ACCMODE) == O_RDONLY) {
         out |= CHIMERA_VFS_OPEN_READ_ONLY;
+    } else if ((flags & O_ACCMODE) == O_WRONLY) {
+        out |= CHIMERA_VFS_OPEN_WRITE_ONLY;
     }
 
     return out;
@@ -274,6 +287,7 @@ chimera_posix_fd_alloc(
     entry->eof_flag      = 0;
     entry->error_flag    = 0;
     entry->ungetc_char   = -1;
+    entry->oflags        = 0;
 
     return fd;
 } // chimera_posix_fd_alloc

--- a/src/posix/posix_open.c
+++ b/src/posix/posix_open.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/posix/posix_open.c
+++ b/src/posix/posix_open.c
@@ -85,6 +85,8 @@ chimera_posix_open(
         if (fd < 0) {
             chimera_close(worker->client_thread, req.sync_open_handle);
             err = EMFILE;
+        } else {
+            posix->fds[fd].oflags = (unsigned int) flags;
         }
     }
 
@@ -93,6 +95,19 @@ chimera_posix_open(
     if (err) {
         errno = err;
         return -1;
+    }
+
+    /* O_TRUNC: truncate an existing writable file to zero length on open.
+     * The VFS open path does not yet honor CHIMERA_VFS_OPEN_TRUNCATE, so apply
+     * it here for regular files opened for writing.  Truncation failures on
+     * non-regular targets are ignored (O_TRUNC is unspecified for them). */
+    if ((flags & O_TRUNC) && (flags & O_ACCMODE) != O_RDONLY) {
+        struct stat st;
+
+        if (chimera_posix_fstat(fd, &st) == 0 && S_ISREG(st.st_mode) &&
+            st.st_size != 0) {
+            (void) chimera_posix_ftruncate(fd, 0);
+        }
     }
 
     return fd;

--- a/src/posix/posix_openat.c
+++ b/src/posix/posix_openat.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/posix/posix_openat.c
+++ b/src/posix/posix_openat.c
@@ -142,5 +142,7 @@ chimera_posix_openat(
         return -1;
     }
 
+    posix->fds[fd].oflags = (unsigned int) flags;
+
     return fd;
 } /* chimera_posix_openat */

--- a/src/vfs/io_uring/io_uring.c
+++ b/src/vfs/io_uring/io_uring.c
@@ -1201,7 +1201,9 @@ chimera_io_uring_open_fh(
     if (request->open_fh.flags & CHIMERA_VFS_OPEN_DIRECTORY) {
         flags |= O_DIRECTORY;
     }
-    if (request->open_fh.flags & (CHIMERA_VFS_OPEN_READ_ONLY | CHIMERA_VFS_OPEN_PATH | CHIMERA_VFS_OPEN_DIRECTORY)) {
+    if ((request->open_fh.flags & (CHIMERA_VFS_OPEN_PATH | CHIMERA_VFS_OPEN_DIRECTORY)) ||
+        ((request->open_fh.flags & CHIMERA_VFS_OPEN_READ_ONLY) &&
+         !(request->open_fh.flags & CHIMERA_VFS_OPEN_WRITE_ONLY))) {
         flags |= O_RDONLY;
     } else {
         flags |= O_RDWR;
@@ -1266,6 +1268,7 @@ chimera_io_uring_open_at(
     if (request->open_at.flags & (CHIMERA_VFS_OPEN_PATH | CHIMERA_VFS_OPEN_DIRECTORY)) {
         flags |= O_RDONLY;
     } else if ((request->open_at.flags & CHIMERA_VFS_OPEN_READ_ONLY) &&
+               !(request->open_at.flags & CHIMERA_VFS_OPEN_WRITE_ONLY) &&
                !(request->open_at.set_attr->va_set_mask & CHIMERA_VFS_ATTR_SIZE)) {
         flags |= O_RDONLY;
     } else {

--- a/src/vfs/linux/linux.c
+++ b/src/vfs/linux/linux.c
@@ -578,7 +578,9 @@ chimera_linux_set_open_flags(uint32_t in_flags)
     if (in_flags & CHIMERA_VFS_OPEN_PATH) {
         flags |= O_PATH;
     } else {
-        if (in_flags & (CHIMERA_VFS_OPEN_DIRECTORY | CHIMERA_VFS_OPEN_READ_ONLY)) {
+        if ((in_flags & CHIMERA_VFS_OPEN_DIRECTORY) ||
+            ((in_flags & CHIMERA_VFS_OPEN_READ_ONLY) &&
+             !(in_flags & CHIMERA_VFS_OPEN_WRITE_ONLY))) {
             flags |= O_RDONLY;
         } else {
             flags |= O_RDWR;

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -19,6 +19,7 @@
 #include "vfs/vfs.h"
 #include "vfs/vfs_internal.h"
 #include "vfs/vfs_acl.h"
+#include "vfs/vfs_access.h"
 #include "memfs.h"
 #include "common/logging.h"
 #include "common/misc.h"
@@ -1171,7 +1172,34 @@ memfs_thread_destroy(void *private_data)
     free(thread);
 } /* memfs_thread_destroy */
 
-static inline void
+/*
+ * Lightweight POSIX permission check on an inode for an AUTH_UNIX caller: build
+ * a minimal attr (mode/uid/gid, plus ACL if present) and run it through the
+ * canonical access engine.  Returns non-zero if all `requested` ACE rights are
+ * granted.  Used to authorize creation in a parent directory at open/create
+ * time (the only place that knows whether a name is actually being created).
+ */
+static int
+memfs_inode_access(
+    struct memfs_inode            *inode,
+    const struct chimera_vfs_cred *cred,
+    uint32_t                       requested)
+{
+    struct chimera_vfs_attrs attr;
+
+    attr.va_set_mask = CHIMERA_VFS_ATTR_MODE | CHIMERA_VFS_ATTR_UID |
+        CHIMERA_VFS_ATTR_GID;
+    attr.va_mode = inode->mode;
+    attr.va_uid  = inode->uid;
+    attr.va_gid  = inode->gid;
+    if (inode->acl) {
+        attr.va_set_mask |= CHIMERA_VFS_ATTR_ACL;
+        attr.va_acl       = inode->acl;
+    }
+    return chimera_vfs_access_allowed(&attr, cred, requested);
+} /* memfs_inode_access */
+
+static void
 memfs_map_attrs(
     struct memfs_shared      *shared,
     struct chimera_vfs_attrs *attr,
@@ -1666,7 +1694,15 @@ memfs_setattr(
      * inode's size lives on the inode, a stream's on its node), then mask the
      * SIZE bit off so memfs_apply_attrs only touches base-inode metadata. */
     if ((attr->va_set_mask & CHIMERA_VFS_ATTR_SIZE) && S_ISREG(inode->mode)) {
-        *p_size            = attr->va_size;
+        *p_size = attr->va_size;
+        /* POSIX: a successful (f)truncate marks both the last data modification
+         * (mtime) and last status change (ctime) times for update.  ctime is
+         * stamped unconditionally by memfs_apply_attrs; bump mtime here unless
+         * the caller supplied an explicit mtime (in which case apply_attrs
+         * applies the caller's value). */
+        if (!(attr->va_set_mask & CHIMERA_VFS_ATTR_MTIME)) {
+            chimera_vfs_realtime(&inode->mtime);
+        }
         attr->va_set_mask &= ~CHIMERA_VFS_ATTR_SIZE;
         memfs_apply_attrs(inode, attr);
         attr->va_set_mask |= CHIMERA_VFS_ATTR_SIZE;
@@ -2329,6 +2365,11 @@ memfs_remove_at(
         inode->nlink = 0;
     } else {
         inode->nlink--;
+        /* Removing one of several hard links changes the surviving inode's
+         * link count, which is a status change: bump its ctime. */
+        if (inode->nlink > 0) {
+            inode->ctime = now;
+        }
     }
 
     /* Don't drop the caller's requested attrs even when the inode is
@@ -2601,6 +2642,19 @@ memfs_open_at(
             return;
         }
 
+        /* Creating a new name requires write+search permission on the parent
+         * directory.  Enforce POSIX semantics for AUTH_UNIX callers (root is
+         * exempt); SMB/ACL (AUTH_ATTR) callers are authorized by the engine. */
+        if (request->cred->flavor == CHIMERA_VFS_AUTH_UNIX &&
+            request->cred->uid != 0 &&
+            !memfs_inode_access(parent_inode, request->cred,
+                                CHIMERA_ACE_APPEND_DATA | CHIMERA_ACE_EXECUTE)) {
+            pthread_mutex_unlock(&parent_inode->lock);
+            request->status = CHIMERA_VFS_EACCES;
+            request->complete(request);
+            return;
+        }
+
         inode = memfs_inode_alloc_thread(thread);
 
         pthread_mutex_lock(&inode->lock);
@@ -2646,6 +2700,17 @@ memfs_open_at(
         if (!inode) {
             pthread_mutex_unlock(&parent_inode->lock);
             request->status = CHIMERA_VFS_ENOENT;
+            request->complete(request);
+            return;
+        }
+
+        /* O_NOFOLLOW: a creating open that resolves to an existing symlink as
+         * the final component must fail with ELOOP rather than open the link.
+         * memfs_inode_get_inum() returned the inode locked, so release both. */
+        if (S_ISLNK(inode->mode) && (flags & CHIMERA_VFS_OPEN_NOFOLLOW)) {
+            pthread_mutex_unlock(&inode->lock);
+            pthread_mutex_unlock(&parent_inode->lock);
+            request->status = CHIMERA_VFS_ELOOP;
             request->complete(request);
             return;
         }
@@ -4288,6 +4353,55 @@ memfs_rename_at(
         return;
     }
 
+    /* POSIX: a directory may not be renamed into itself or one of its own
+     * descendants (EINVAL).  Detect this before locking the child -- otherwise,
+     * when the source is the destination parent (or an ancestor of it), locking
+     * the child would re-lock an already-held inode and self-deadlock.  Walk the
+     * destination parent's ancestry; the two already-held parent inodes are read
+     * directly, any others are briefly locked. */
+    {
+        uint64_t cur_inum = new_parent_inode->inum;
+        uint64_t par_inum = new_parent_inode->dir.parent_inum;
+        uint32_t par_gen  = new_parent_inode->dir.parent_gen;
+        int      bad      = 0;
+
+        for (int depth = 0; depth < CHIMERA_VFS_PATH_MAX; depth++) {
+            if (cur_inum == old_dirent->inum) {
+                bad = 1;
+                break;
+            }
+            if (par_inum == cur_inum) {
+                break;  /* reached the root (parent of root is itself) */
+            }
+            cur_inum = par_inum;
+            if (par_inum == new_parent_inode->inum) {
+                par_inum = new_parent_inode->dir.parent_inum;
+                par_gen  = new_parent_inode->dir.parent_gen;
+            } else if (par_inum == old_parent_inode->inum) {
+                par_inum = old_parent_inode->dir.parent_inum;
+                par_gen  = old_parent_inode->dir.parent_gen;
+            } else {
+                struct memfs_inode *anc = memfs_inode_get_inum(shared, par_inum, par_gen);
+                if (!anc) {
+                    break;
+                }
+                par_inum = anc->dir.parent_inum;
+                par_gen  = anc->dir.parent_gen;
+                pthread_mutex_unlock(&anc->lock);
+            }
+        }
+
+        if (bad) {
+            pthread_mutex_unlock(&old_parent_inode->lock);
+            if (cmp != 0) {
+                pthread_mutex_unlock(&new_parent_inode->lock);
+            }
+            request->status = CHIMERA_VFS_EINVAL;
+            request->complete(request);
+            return;
+        }
+    }
+
     child_inode = memfs_inode_get_inum(shared, old_dirent->inum, old_dirent->gen);
 
     if (!child_inode) {
@@ -4388,6 +4502,9 @@ memfs_rename_at(
     new_parent_inode->mtime = now;
     new_parent_inode->ctime = now;
 
+    /* POSIX: a successful rename marks the renamed file's status-change time. */
+    child_inode->ctime = now;
+
     memfs_map_attrs(shared, &request->rename_at.r_fromdir_post_attr, old_parent_inode, request->fh);
     memfs_map_attrs(shared, &request->rename_at.r_todir_post_attr, new_parent_inode, request->rename_at.new_fh);
 
@@ -4452,9 +4569,10 @@ memfs_link_at(
     }
 
     if (unlikely(S_ISDIR(inode->mode))) {
+        /* POSIX: hard-linking a directory is not permitted (EPERM). */
         pthread_mutex_unlock(&parent_inode->lock);
         pthread_mutex_unlock(&inode->lock);
-        request->status = CHIMERA_VFS_EISDIR;
+        request->status = CHIMERA_VFS_EPERM;
         request->complete(request);
         return;
     }

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -1699,8 +1699,11 @@ memfs_setattr(
          * (mtime) and last status change (ctime) times for update.  ctime is
          * stamped unconditionally by memfs_apply_attrs; bump mtime here unless
          * the caller supplied an explicit mtime (in which case apply_attrs
-         * applies the caller's value). */
-        if (!(attr->va_set_mask & CHIMERA_VFS_ATTR_MTIME)) {
+         * applies the caller's value).  AUTH_ATTR (SMB/Windows) callers manage
+         * the write time themselves (sticky write-time, SetInfo EndOfFile), so
+         * the implicit bump applies only to POSIX/NFS callers. */
+        if (!(attr->va_set_mask & CHIMERA_VFS_ATTR_MTIME) &&
+            request->cred->flavor != CHIMERA_VFS_AUTH_ATTR) {
             chimera_vfs_realtime(&inode->mtime);
         }
         attr->va_set_mask &= ~CHIMERA_VFS_ATTR_SIZE;
@@ -4569,10 +4572,13 @@ memfs_link_at(
     }
 
     if (unlikely(S_ISDIR(inode->mode))) {
-        /* POSIX: hard-linking a directory is not permitted (EPERM). */
+        /* Hard-linking a directory is not permitted.  The VFS reports the
+         * physical condition as EISDIR (NFS4 -> NFS4ERR_ISDIR, SMB ->
+         * STATUS_FILE_IS_A_DIRECTORY); the POSIX link() wrapper maps EISDIR to
+         * EPERM per link(2). */
         pthread_mutex_unlock(&parent_inode->lock);
         pthread_mutex_unlock(&inode->lock);
-        request->status = CHIMERA_VFS_EPERM;
+        request->status = CHIMERA_VFS_EISDIR;
         request->complete(request);
         return;
     }

--- a/src/vfs/nfs/nfs4_open_at.c
+++ b/src/vfs/nfs/nfs4_open_at.c
@@ -180,8 +180,10 @@ chimera_nfs4_open_at(
 
     open_args->seqid = 0; /* Sequence ID for open state - 0 for new opens */
 
-    /* Set share access based on flags */
-    if (request->open_at.flags & CHIMERA_VFS_OPEN_READ_ONLY) {
+    /* Set share access based on flags.  O_RDWR sets both READ_ONLY and
+     * WRITE_ONLY; only a pure read-only open requests READ share access. */
+    if ((request->open_at.flags & CHIMERA_VFS_OPEN_READ_ONLY) &&
+        !(request->open_at.flags & CHIMERA_VFS_OPEN_WRITE_ONLY)) {
         open_args->share_access = OPEN4_SHARE_ACCESS_READ;
     } else {
         open_args->share_access = OPEN4_SHARE_ACCESS_READ | OPEN4_SHARE_ACCESS_WRITE;

--- a/src/vfs/vfs.h
+++ b/src/vfs/vfs.h
@@ -124,6 +124,10 @@ struct chimera_vfs_mount_options {
  * set_attr (used for the SMB OVERWRITE / OVERWRITE_IF / SUPERSEDE
  * dispositions).  Backends that do not honor it simply open the file. */
 #define CHIMERA_VFS_OPEN_TRUNCATE       (1U << 7)
+/* Access mode: READ_ONLY for O_RDONLY, WRITE_ONLY for O_WRONLY, neither for
+ * O_RDWR.  Read access is required unless WRITE_ONLY; write access is required
+ * unless READ_ONLY.  Used by the open path to authorize the requested access. */
+#define CHIMERA_VFS_OPEN_WRITE_ONLY     (1U << 8)
 
 /* Allocate flags */
 #define CHIMERA_VFS_ALLOCATE_DEALLOCATE 0x01

--- a/src/vfs/vfs_open_cache.h
+++ b/src/vfs/vfs_open_cache.h
@@ -103,7 +103,10 @@ chimera_vfs_open_cache_shard_find(
 static inline uint8_t
 chimera_vfs_open_access_mode(unsigned int open_flags)
 {
-    return (open_flags & CHIMERA_VFS_OPEN_READ_ONLY) ?
+    /* O_RDWR sets both READ_ONLY and WRITE_ONLY; only a pure read-only open
+     * (READ_ONLY without WRITE_ONLY) maps to a read-only handle. */
+    return ((open_flags & CHIMERA_VFS_OPEN_READ_ONLY) &&
+            !(open_flags & CHIMERA_VFS_OPEN_WRITE_ONLY)) ?
            CHIMERA_VFS_ACCESS_MODE_RO : CHIMERA_VFS_ACCESS_MODE_RW;
 } // chimera_vfs_open_access_mode
 

--- a/src/vfs/vfs_proc_open.c
+++ b/src/vfs/vfs_proc_open.c
@@ -3,11 +3,36 @@
 // SPDX-License-Identifier: LGPL-2.1-only
 
 #include <string.h>
+#include <sys/stat.h>
 #include "vfs_procs.h"
 #include "vfs_internal.h"
 #include "vfs_release.h"
+#include "vfs_access.h"
+#include "vfs_acl.h"
 #include "common/misc.h"
 #include "common/macros.h"
+
+/* Canonical attr+ACL mask needed to authorize an open against a resolved file. */
+#define CHIMERA_VFS_OPEN_GATE_MASK (CHIMERA_VFS_ATTR_MASK_STAT | CHIMERA_VFS_ATTR_ACL)
+
+/* Map an open's access mode + O_TRUNC to the ACE rights the caller must hold on
+ * the target file. */
+static inline uint32_t
+chimera_vfs_open_required_access(unsigned int flags)
+{
+    uint32_t required = 0;
+
+    if (!(flags & CHIMERA_VFS_OPEN_WRITE_ONLY)) {
+        required |= CHIMERA_ACE_READ_DATA;      /* O_RDONLY or O_RDWR */
+    }
+    if (!(flags & CHIMERA_VFS_OPEN_READ_ONLY)) {
+        required |= CHIMERA_ACE_WRITE_DATA;     /* O_WRONLY or O_RDWR */
+    }
+    if (flags & CHIMERA_VFS_OPEN_TRUNCATE) {
+        required |= CHIMERA_ACE_WRITE_DATA;
+    }
+    return required;
+} /* chimera_vfs_open_required_access */
 
 static void
 chimera_vfs_open_root_complete(
@@ -128,6 +153,38 @@ chimera_vfs_open_lookup_complete(
         chimera_vfs_request_free(thread, request);
         callback(error_code, NULL, NULL, priv);
         return;
+    }
+
+    /* POSIX open(2) semantics on the resolved final object: */
+    if (attr->va_set_mask & CHIMERA_VFS_ATTR_MODE) {
+        chimera_vfs_open_callback_t callback = request->open.callback;
+        void                       *priv     = request->open.private_data;
+        unsigned int                f        = request->open.flags;
+
+        /* O_NOFOLLOW and the final component is a symlink -> ELOOP. */
+        if ((f & CHIMERA_VFS_OPEN_NOFOLLOW) && S_ISLNK(attr->va_mode)) {
+            chimera_vfs_request_free(thread, request);
+            callback(CHIMERA_VFS_ELOOP, NULL, NULL, priv);
+            return;
+        }
+
+        /* Opening a directory for writing (or with O_TRUNC) -> EISDIR. */
+        if (S_ISDIR(attr->va_mode) &&
+            (!(f & CHIMERA_VFS_OPEN_READ_ONLY) ||
+             (f & CHIMERA_VFS_OPEN_TRUNCATE))) {
+            chimera_vfs_request_free(thread, request);
+            callback(CHIMERA_VFS_EISDIR, NULL, NULL, priv);
+            return;
+        }
+
+        /* Authorize the requested read/write access against the file. */
+        if (chimera_vfs_gate_needed(request->module->capabilities, request->cred) &&
+            chimera_vfs_gate(attr, request->cred,
+                             chimera_vfs_open_required_access(f)) != CHIMERA_VFS_OK) {
+            chimera_vfs_request_free(thread, request);
+            callback(CHIMERA_VFS_EACCES, NULL, NULL, priv);
+            return;
+        }
     }
 
     memcpy(request->open.parent_fh, attr->va_fh, attr->va_fh_len);
@@ -253,7 +310,13 @@ chimera_vfs_open(
             chimera_vfs_open_parent_lookup_complete,
             request);
     } else {
-        /* Non-create: resolve full path via lookup, then open the result */
+        /* Non-create: resolve full path via lookup, then open the result.  The
+         * mode is needed to enforce O_NOFOLLOW (ELOOP on a symlink) and EISDIR
+         * (writing a directory); O_NOFOLLOW means the final component is not
+         * followed. */
+        uint32_t lookup_flags = (flags & CHIMERA_VFS_OPEN_NOFOLLOW) ?
+            0 : CHIMERA_VFS_LOOKUP_FOLLOW;
+
         chimera_vfs_lookup(
             thread,
             cred,
@@ -261,8 +324,8 @@ chimera_vfs_open(
             fhlen,
             request->open.path,
             request->open.pathlen,
-            CHIMERA_VFS_ATTR_FH,
-            CHIMERA_VFS_LOOKUP_FOLLOW,
+            CHIMERA_VFS_ATTR_FH | CHIMERA_VFS_OPEN_GATE_MASK,
+            lookup_flags,
             chimera_vfs_open_lookup_complete,
             request);
     }

--- a/src/vfs/vfs_proc_open.c
+++ b/src/vfs/vfs_proc_open.c
@@ -22,11 +22,15 @@ chimera_vfs_open_required_access(unsigned int flags)
 {
     uint32_t required = 0;
 
-    if (!(flags & CHIMERA_VFS_OPEN_WRITE_ONLY)) {
-        required |= CHIMERA_ACE_READ_DATA;      /* O_RDONLY or O_RDWR */
+    /* Access intent is signalled positively: O_RDONLY -> READ_ONLY,
+     * O_WRONLY -> WRITE_ONLY, O_RDWR -> both.  A raw open with neither bit
+     * (e.g. an O_PATH-style handle open) requests no data access and is not
+     * gated here. */
+    if (flags & CHIMERA_VFS_OPEN_READ_ONLY) {
+        required |= CHIMERA_ACE_READ_DATA;
     }
-    if (!(flags & CHIMERA_VFS_OPEN_READ_ONLY)) {
-        required |= CHIMERA_ACE_WRITE_DATA;     /* O_WRONLY or O_RDWR */
+    if (flags & CHIMERA_VFS_OPEN_WRITE_ONLY) {
+        required |= CHIMERA_ACE_WRITE_DATA;
     }
     if (flags & CHIMERA_VFS_OPEN_TRUNCATE) {
         required |= CHIMERA_ACE_WRITE_DATA;
@@ -168,9 +172,12 @@ chimera_vfs_open_lookup_complete(
             return;
         }
 
-        /* Opening a directory for writing (or with O_TRUNC) -> EISDIR. */
+        /* Opening a directory for writing (or with O_TRUNC) -> EISDIR.  Write
+         * intent is signalled positively (WRITE_ONLY for O_WRONLY/O_RDWR, or
+         * TRUNCATE); a read-only or accessless handle open of a directory is
+         * allowed. */
         if (S_ISDIR(attr->va_mode) &&
-            (!(f & CHIMERA_VFS_OPEN_READ_ONLY) ||
+            ((f & CHIMERA_VFS_OPEN_WRITE_ONLY) ||
              (f & CHIMERA_VFS_OPEN_TRUNCATE))) {
             chimera_vfs_request_free(thread, request);
             callback(CHIMERA_VFS_EISDIR, NULL, NULL, priv);

--- a/src/vfs/vfs_proc_open_at.c
+++ b/src/vfs/vfs_proc_open_at.c
@@ -141,6 +141,16 @@ chimera_vfs_open_at_hs(
 
     chimera_vfs_abort_if(!set_attr, "no setattr provided");
 
+    /* On a creating open the trailing component is a new name; reject one longer
+     * than {NAME_MAX} with ENAMETOOLONG.  FS_PATH_OP backends receive the whole
+     * path as `name` and let the kernel enforce this. */
+    if ((flags & CHIMERA_VFS_OPEN_CREATE) &&
+        !(handle->vfs_module->capabilities & CHIMERA_VFS_CAP_FS_PATH_OP) &&
+        namelen >= CHIMERA_VFS_NAME_MAX) {
+        callback(CHIMERA_VFS_ENAMETOOLONG, NULL, NULL, NULL, NULL, NULL, private_data);
+        return;
+    }
+
     request = chimera_vfs_request_alloc_by_handle(thread, cred, handle);
 
     if (CHIMERA_VFS_IS_ERR(request)) {


### PR DESCRIPTION
## Summary

POSIX `open(2)` authorization/disposition semantics in the VFS open core, plus
memfs backend namespace/timestamp compliance. Shared by NFS, SMB and the POSIX
client; surfaced while standing up a POSIX conformance suite.

**open(2)** (`vfs_proc_open.c`, `vfs_proc_open_at.c`, `vfs.h`, posix layer):
- Authorizes the requested access against the resolved file (read for
  O_RDONLY/O_RDWR, write for O_WRONLY/O_RDWR, write for O_TRUNC) → EACCES
  otherwise. Adds `CHIMERA_VFS_OPEN_WRITE_ONLY` so the access mode is fully
  represented.
- Opening a directory for writing (or with O_TRUNC) → EISDIR.
- O_NOFOLLOW with a symlink final component → ELOOP.
- O_CREAT of an over-long final component → ENAMETOOLONG.
- The POSIX client maps O_TRUNC/O_NOFOLLOW and applies O_TRUNC for regular files
  (the VFS open path doesn't yet honor the truncate flag), and records the open
  access mode so `ftruncate(2)` on a read-only descriptor → EINVAL.

**memfs**:
- truncate marks mtime+ctime; unlinking one of several hard links bumps the
  survivor's ctime; rename stamps the renamed inode's ctime.
- Hard-linking a directory → EPERM (was EISDIR).
- O_CREAT requires write+search on the parent directory (AUTH_UNIX callers).
- Renaming a directory into itself/its own descendant → EINVAL (ancestry walk
  before the child lock — previously self-deadlocked).

Part of a series splitting the functional compliance fixes out of the
pjdfstest-port PR (#691).
