### PR TITLE
posix/client: per-call credentials, umask, creation mode, and new ops

### DIFF
--- a/src/client/client_clone_range.h
+++ b/src/client/client_clone_range.h
@@ -33,7 +33,7 @@ chimera_dispatch_clone_range(
 {
     chimera_vfs_clone_range(
         thread->vfs_thread,
-        &thread->client->cred,
+        chimera_client_req_cred(request),
         request->clone_range.src_handle,
         request->clone_range.src_offset,
         request->clone_range.dst_handle,

--- a/src/client/client_commit.h
+++ b/src/client/client_commit.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -33,7 +33,7 @@ chimera_dispatch_commit(
 {
     chimera_vfs_commit(
         thread->vfs_thread,
-        &thread->client->cred,
+        chimera_client_req_cred(request),
         request->commit.handle,
         0,  /* offset - sync entire file */
         0,  /* count - sync entire file */

--- a/src/client/client_copy_range.h
+++ b/src/client/client_copy_range.h
@@ -36,7 +36,7 @@ chimera_dispatch_copy_range(
 {
     chimera_vfs_copy_range(
         thread->vfs_thread,
-        &thread->client->cred,
+        chimera_client_req_cred(request),
         request->copy_range.src_handle,
         request->copy_range.src_offset,
         request->copy_range.dst_handle,

--- a/src/client/client_fsetattr.h
+++ b/src/client/client_fsetattr.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -34,7 +34,7 @@ chimera_dispatch_fsetattr(
 {
     chimera_vfs_setattr(
         thread->vfs_thread,
-        &thread->client->cred,
+        chimera_client_req_cred(request),
         request->fsetattr.handle,
         &request->fsetattr.set_attr,
         0,  /* pre_attr_mask */

--- a/src/client/client_fstat.h
+++ b/src/client/client_fstat.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -38,7 +38,7 @@ chimera_dispatch_fstat(
 {
     chimera_vfs_getattr(
         thread->vfs_thread,
-        &thread->client->cred,
+        chimera_client_req_cred(request),
         request->fstat.handle,
         CHIMERA_VFS_ATTR_MASK_STAT,
         chimera_fstat_getattr_complete,

--- a/src/client/client_fstatfs.h
+++ b/src/client/client_fstatfs.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -38,7 +38,7 @@ chimera_dispatch_fstatfs(
 {
     chimera_vfs_getattr(
         thread->vfs_thread,
-        &thread->client->cred,
+        chimera_client_req_cred(request),
         request->fstatfs.handle,
         CHIMERA_VFS_ATTR_MASK_STATFS,
         chimera_fstatfs_getattr_complete,

--- a/src/client/client_internal.h
+++ b/src/client/client_internal.h
@@ -71,6 +71,14 @@ struct chimera_client_request {
 
     int                                heap_allocated;
 
+    /* Per-request credential override.  When has_cred is set, req_cred is used
+     * for VFS authorization instead of the client-global credential.  This lets
+     * a single client issue operations on behalf of different users (e.g. the
+     * POSIX layer switching uid/gid per call).  Default (has_cred == 0) falls
+     * back to thread->client->cred, so existing callers are unaffected. */
+    int                                has_cred;
+    struct chimera_vfs_cred            req_cred;
+
     ssize_t                            sync_result;
     struct chimera_vfs_open_handle    *sync_open_handle;
     struct chimera_stat                sync_stat;
@@ -400,6 +408,17 @@ struct chimera_client_thread {
     struct chimera_vfs_thread     *vfs_thread;
     struct chimera_client_request *free_requests;
 } __attribute__((aligned(64)));
+
+/*
+ * Return the effective credential for a request: the per-request override when
+ * present, otherwise the client-global credential.  All VFS dispatch paths use
+ * this so that a per-call credential transparently overrides the default.
+ */
+static inline const struct chimera_vfs_cred *
+chimera_client_req_cred(const struct chimera_client_request *request)
+{
+    return request->has_cred ? &request->req_cred : &request->thread->client->cred;
+} /* chimera_client_req_cred */
 
 static inline struct chimera_client_request *
 chimera_client_request_alloc(struct chimera_client_thread *thread)

--- a/src/client/client_link.h
+++ b/src/client/client_link.h
@@ -36,7 +36,7 @@ chimera_dispatch_link(
 
     chimera_vfs_link(
         thread->vfs_thread,
-        &thread->client->cred,
+        chimera_client_req_cred(request),
         thread->client->root_fh,
         thread->client->root_fh_len,
         request->link.source_path,

--- a/src/client/client_lock.h
+++ b/src/client/client_lock.h
@@ -42,7 +42,7 @@ chimera_dispatch_lock(
 {
     chimera_vfs_lock(
         thread->vfs_thread,
-        &thread->client->cred,
+        chimera_client_req_cred(request),
         request->lock.handle,
         request->lock.whence,
         request->lock.offset,

--- a/src/client/client_mkdir.c
+++ b/src/client/client_mkdir.c
@@ -30,6 +30,9 @@ chimera_mkdir(
 
     request->mkdir.name_offset = slash ? slash - path : -1;
 
+    request->mkdir.set_attr.va_req_mask = 0;
+    request->mkdir.set_attr.va_set_mask = 0;
+
     memcpy(request->mkdir.path, path, path_len);
 
     chimera_dispatch_mkdir(thread, request);

--- a/src/client/client_mkdir.h
+++ b/src/client/client_mkdir.h
@@ -35,12 +35,10 @@ chimera_dispatch_mkdir(
         return;
     }
 
-    request->mkdir.set_attr.va_req_mask = 0;
-    request->mkdir.set_attr.va_set_mask = 0;
-
+    /* set_attr (creation mode) is initialized by the caller. */
     chimera_vfs_mkdir(
         thread->vfs_thread,
-        &thread->client->cred,
+        chimera_client_req_cred(request),
         thread->client->root_fh,
         thread->client->root_fh_len,
         request->mkdir.path,
@@ -82,7 +80,7 @@ chimera_dispatch_mkdir_at(
 {
     chimera_vfs_mkdir_at(
         thread->vfs_thread,
-        &thread->client->cred,
+        chimera_client_req_cred(request),
         parent_handle,
         request->mkdir.path,
         request->mkdir.path_len,

--- a/src/client/client_mknod.h
+++ b/src/client/client_mknod.h
@@ -36,7 +36,7 @@ chimera_dispatch_mknod(
 
     chimera_vfs_mknod(
         thread->vfs_thread,
-        &thread->client->cred,
+        chimera_client_req_cred(request),
         thread->client->root_fh,
         thread->client->root_fh_len,
         request->mknod.path,

--- a/src/client/client_open.c
+++ b/src/client/client_open.c
@@ -23,6 +23,9 @@ chimera_open(
     request->open.flags        = flags;
     request->open.path_len     = path_len;
 
+    request->open.set_attr.va_req_mask = 0;
+    request->open.set_attr.va_set_mask = 0;
+
     memcpy(request->open.path, path, path_len);
 
     chimera_dispatch_open(thread, request);

--- a/src/client/client_open.h
+++ b/src/client/client_open.h
@@ -28,12 +28,10 @@ chimera_dispatch_open(
     struct chimera_client_thread  *thread,
     struct chimera_client_request *request)
 {
-    request->open.set_attr.va_req_mask = 0;
-    request->open.set_attr.va_set_mask = 0;
-
+    /* set_attr (creation mode) is initialized by the caller. */
     chimera_vfs_open(
         thread->vfs_thread,
-        &thread->client->cred,
+        chimera_client_req_cred(request),
         thread->client->root_fh,
         thread->client->root_fh_len,
         request->open.path,
@@ -75,12 +73,10 @@ chimera_dispatch_open_at(
     struct chimera_vfs_open_handle *parent_handle,
     struct chimera_client_request  *request)
 {
-    request->open.set_attr.va_req_mask = 0;
-    request->open.set_attr.va_set_mask = 0;
-
+    /* set_attr (creation mode) is initialized by the caller. */
     chimera_vfs_open_at(
         thread->vfs_thread,
-        &thread->client->cred,
+        chimera_client_req_cred(request),
         parent_handle,
         request->open.path,
         request->open.path_len,

--- a/src/client/client_read.h
+++ b/src/client/client_read.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -36,7 +36,7 @@ chimera_dispatch_read(
     struct chimera_client_request *request)
 {
     chimera_vfs_read(thread->vfs_thread,
-                     &thread->client->cred,
+                     chimera_client_req_cred(request),
                      request->read.handle,
                      request->read.offset,
                      request->read.length,

--- a/src/client/client_read_into.h
+++ b/src/client/client_read_into.h
@@ -38,7 +38,7 @@ chimera_dispatch_read_into(
     struct chimera_client_request *request)
 {
     chimera_vfs_read_into(thread->vfs_thread,
-                          &thread->client->cred,
+                          chimera_client_req_cred(request),
                           request->read_into.handle,
                           request->read_into.offset,
                           request->read_into.length,

--- a/src/client/client_readdir.h
+++ b/src/client/client_readdir.h
@@ -56,7 +56,7 @@ chimera_dispatch_readdir(
     struct chimera_client_request *request)
 {
     chimera_vfs_readdir(thread->vfs_thread,
-                        &thread->client->cred,
+                        chimera_client_req_cred(request),
                         request->readdir.handle,
                         0,  // attr_mask for entries
                         0,  // dir_attr_mask

--- a/src/client/client_readlink.h
+++ b/src/client/client_readlink.h
@@ -58,7 +58,7 @@ chimera_readlink_open_complete(
 
     chimera_vfs_readlink(
         request->thread->vfs_thread,
-        &request->thread->client->cred,
+        chimera_client_req_cred(request),
         oh,
         request->readlink.target,
         request->readlink.target_maxlength,
@@ -91,7 +91,7 @@ chimera_readlink_lookup_complete(
 
     chimera_vfs_open_fh(
         request->thread->vfs_thread,
-        &request->thread->client->cred,
+        chimera_client_req_cred(request),
         request->fh,
         request->fh_len,
         CHIMERA_VFS_OPEN_PATH | CHIMERA_VFS_OPEN_INFERRED,
@@ -108,7 +108,7 @@ chimera_dispatch_readlink(
     /* Do not follow the final symlink - we want to read its target */
     chimera_vfs_lookup(
         thread->vfs_thread,
-        &thread->client->cred,
+        chimera_client_req_cred(request),
         thread->client->root_fh,
         thread->client->root_fh_len,
         request->readlink.path,

--- a/src/client/client_remove.h
+++ b/src/client/client_remove.h
@@ -35,7 +35,7 @@ chimera_dispatch_remove(
 
     chimera_vfs_remove(
         thread->vfs_thread,
-        &thread->client->cred,
+        chimera_client_req_cred(request),
         thread->client->root_fh,
         thread->client->root_fh_len,
         request->remove.path,
@@ -95,7 +95,7 @@ chimera_remove_at_lookup_complete(
     /* Now call remove with the child FH */
     chimera_vfs_remove_at(
         thread->vfs_thread,
-        &thread->client->cred,
+        chimera_client_req_cred(request),
         request->remove.parent_handle,
         request->remove.path,
         request->remove.path_len,
@@ -121,7 +121,7 @@ chimera_dispatch_remove_at(
      * not the target it points to. */
     chimera_vfs_lookup_at(
         thread->vfs_thread,
-        &thread->client->cred,
+        chimera_client_req_cred(request),
         parent_handle,
         request->remove.path,
         request->remove.path_len,

--- a/src/client/client_rename.h
+++ b/src/client/client_rename.h
@@ -35,7 +35,7 @@ chimera_dispatch_rename(
 
     chimera_vfs_rename(
         thread->vfs_thread,
-        &thread->client->cred,
+        chimera_client_req_cred(request),
         thread->client->root_fh,
         thread->client->root_fh_len,
         request->rename.source_path,

--- a/src/client/client_setattr.h
+++ b/src/client/client_setattr.h
@@ -57,7 +57,7 @@ chimera_setattr_open_complete(
 
     chimera_vfs_setattr(
         request->thread->vfs_thread,
-        &request->thread->client->cred,
+        chimera_client_req_cred(request),
         oh,
         &request->setattr.set_attr,
         0,  /* pre_attr_mask */
@@ -100,7 +100,7 @@ chimera_setattr_lookup_complete(
 
     chimera_vfs_open_fh(
         request->thread->vfs_thread,
-        &request->thread->client->cred,
+        chimera_client_req_cred(request),
         request->fh,
         request->fh_len,
         open_flags,
@@ -115,7 +115,7 @@ chimera_dispatch_setattr(
 {
     chimera_vfs_lookup(
         thread->vfs_thread,
-        &thread->client->cred,
+        chimera_client_req_cred(request),
         thread->client->root_fh,
         thread->client->root_fh_len,
         request->setattr.path,
@@ -125,6 +125,26 @@ chimera_dispatch_setattr(
         chimera_setattr_lookup_complete,
         request);
 } /* chimera_dispatch_setattr */
+
+/* Variant that does NOT follow a final symlink (for lchown(2) and friends): the
+ * attributes are applied to the symlink itself, not its target. */
+static inline void
+chimera_dispatch_lsetattr(
+    struct chimera_client_thread  *thread,
+    struct chimera_client_request *request)
+{
+    chimera_vfs_lookup(
+        thread->vfs_thread,
+        chimera_client_req_cred(request),
+        thread->client->root_fh,
+        thread->client->root_fh_len,
+        request->setattr.path,
+        request->setattr.path_len,
+        CHIMERA_VFS_ATTR_FH,
+        0,  /* no CHIMERA_VFS_LOOKUP_FOLLOW */
+        chimera_setattr_lookup_complete,
+        request);
+} /* chimera_dispatch_lsetattr */
 
 /* Completion callback for setattr_at operations - doesn't release parent handle */
 static void
@@ -157,7 +177,7 @@ chimera_dispatch_setattr_at(
 {
     chimera_vfs_setattr(
         thread->vfs_thread,
-        &thread->client->cred,
+        chimera_client_req_cred(request),
         parent_handle,
         &request->setattr.set_attr,
         0,  /* pre_attr_mask */

--- a/src/client/client_stat.h
+++ b/src/client/client_stat.h
@@ -86,7 +86,7 @@ chimera_stat_open_complete(
 
     chimera_vfs_getattr(
         request->thread->vfs_thread,
-        &request->thread->client->cred,
+        chimera_client_req_cred(request),
         oh,
         CHIMERA_VFS_ATTR_MASK_STAT,
         chimera_stat_getattr_complete,
@@ -117,7 +117,7 @@ chimera_stat_lookup_complete(
 
     chimera_vfs_open_fh(
         request->thread->vfs_thread,
-        &request->thread->client->cred,
+        chimera_client_req_cred(request),
         request->fh,
         request->fh_len,
         CHIMERA_VFS_OPEN_PATH | CHIMERA_VFS_OPEN_INFERRED,
@@ -133,7 +133,7 @@ chimera_dispatch_stat(
 {
     chimera_vfs_lookup(
         thread->vfs_thread,
-        &thread->client->cred,
+        chimera_client_req_cred(request),
         thread->client->root_fh,
         thread->client->root_fh_len,
         request->stat.path,

--- a/src/client/client_statfs.h
+++ b/src/client/client_statfs.h
@@ -87,7 +87,7 @@ chimera_statfs_open_complete(
 
     chimera_vfs_getattr(
         request->thread->vfs_thread,
-        &request->thread->client->cred,
+        chimera_client_req_cred(request),
         oh,
         CHIMERA_VFS_ATTR_MASK_STATFS,
         chimera_statfs_getattr_complete,
@@ -118,7 +118,7 @@ chimera_statfs_lookup_complete(
 
     chimera_vfs_open_fh(
         request->thread->vfs_thread,
-        &request->thread->client->cred,
+        chimera_client_req_cred(request),
         request->fh,
         request->fh_len,
         CHIMERA_VFS_OPEN_PATH | CHIMERA_VFS_OPEN_INFERRED,
@@ -134,7 +134,7 @@ chimera_dispatch_statfs(
 {
     chimera_vfs_lookup(
         thread->vfs_thread,
-        &thread->client->cred,
+        chimera_client_req_cred(request),
         thread->client->root_fh,
         thread->client->root_fh_len,
         request->statfs.path,

--- a/src/client/client_symlink.h
+++ b/src/client/client_symlink.h
@@ -39,7 +39,7 @@ chimera_dispatch_symlink(
 
     chimera_vfs_symlink(
         thread->vfs_thread,
-        &thread->client->cred,
+        chimera_client_req_cred(request),
         thread->client->root_fh,
         thread->client->root_fh_len,
         request->symlink.path,

--- a/src/client/client_write.h
+++ b/src/client/client_write.h
@@ -120,7 +120,7 @@ chimera_dispatch_write(
     }
 
     chimera_vfs_write(thread->vfs_thread,
-                      &thread->client->cred,
+                      chimera_client_req_cred(request),
                       request->write.handle,
                       request->write.offset,
                       request->write.length,
@@ -183,7 +183,7 @@ chimera_dispatch_writev(
     }
 
     chimera_vfs_write(thread->vfs_thread,
-                      &thread->client->cred,
+                      chimera_client_req_cred(request),
                       request->writev.handle,
                       request->writev.offset,
                       request->writev.length,
@@ -203,7 +203,7 @@ chimera_dispatch_writerv(
     struct chimera_client_request *request)
 {
     chimera_vfs_write(thread->vfs_thread,
-                      &thread->client->cred,
+                      chimera_client_req_cred(request),
                       request->writerv.handle,
                       request->writerv.offset,
                       request->writerv.length,

--- a/src/posix/CMakeLists.txt
+++ b/src/posix/CMakeLists.txt
@@ -60,6 +60,8 @@ add_library(chimera_posix SHARED
             posix_lchown.c
             posix_fchown.c
             posix_fchownat.c
+            posix_utimensat.c
+            posix_pathconf.c
             posix_truncate.c
             posix_ftruncate.c
             posix_fcntl.c

--- a/src/posix/posix.c
+++ b/src/posix/posix.c
@@ -8,7 +8,39 @@
 #include "evpl/evpl.h"
 #include "vfs/vfs.h"
 
-struct chimera_posix_client *chimera_posix_global;
+struct chimera_posix_client     *chimera_posix_global;
+
+__thread int                     chimera_posix_tls_has_cred;
+__thread struct chimera_vfs_cred chimera_posix_tls_cred;
+__thread int                     chimera_posix_tls_has_umask;
+__thread mode_t                  chimera_posix_tls_umask;
+
+SYMBOL_EXPORT void
+chimera_posix_set_cred(const struct chimera_vfs_cred *cred)
+{
+    if (cred) {
+        chimera_posix_tls_cred     = *cred;
+        chimera_posix_tls_has_cred = 1;
+    } else {
+        chimera_posix_tls_has_cred = 0;
+    }
+} /* chimera_posix_set_cred */
+
+SYMBOL_EXPORT void
+chimera_posix_clear_cred(void)
+{
+    chimera_posix_tls_has_cred = 0;
+} /* chimera_posix_clear_cred */
+
+SYMBOL_EXPORT mode_t
+chimera_posix_umask(mode_t mask)
+{
+    mode_t prev = chimera_posix_tls_has_umask ? chimera_posix_tls_umask : 0;
+
+    chimera_posix_tls_umask     = mask & 0777;
+    chimera_posix_tls_has_umask = 1;
+    return prev;
+} /* chimera_posix_umask */
 
 void *
 chimera_posix_worker_init(

--- a/src/posix/posix.h
+++ b/src/posix/posix.h
@@ -37,6 +37,24 @@ void
 chimera_posix_shutdown(
     void);
 
+/* Override the effective credential used for subsequent operations on the
+ * calling thread.  Pass NULL to clear the override and fall back to the
+ * client-global credential.  The credential is copied. */
+void
+chimera_posix_set_cred(
+    const struct chimera_vfs_cred *cred);
+
+void
+chimera_posix_clear_cred(
+    void);
+
+/* Set the calling thread's file-mode creation mask (mirrors umask(2)); returns
+ * the previous mask.  Applied to mode in the create paths (open O_CREAT, mkdir,
+ * mknod, ...).  Until first set, no umask is applied. */
+mode_t
+chimera_posix_umask(
+    mode_t mask);
+
 int
 chimera_posix_mount(
     const char *mount_path,
@@ -526,6 +544,30 @@ chimera_posix_fchownat(
     uid_t       owner,
     gid_t       group,
     int         flags);
+
+// Timestamp functions
+int
+chimera_posix_utimensat(
+    int                   dirfd,
+    const char           *pathname,
+    const struct timespec times[2],
+    int                   flags);
+
+int
+chimera_posix_futimens(
+    int                   fd,
+    const struct timespec times[2]);
+
+// Configurable pathname limits (pathconf(3)/fpathconf(3))
+long
+chimera_posix_pathconf(
+    const char *path,
+    int         name);
+
+long
+chimera_posix_fpathconf(
+    int fd,
+    int name);
 
 // Truncate functions
 int

--- a/src/posix/posix_chmod.c
+++ b/src/posix/posix_chmod.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -38,9 +38,12 @@ chimera_posix_chmod(
     struct chimera_posix_completion comp;
     int                             path_len;
 
-    chimera_posix_completion_init(&comp, &req);
+    path_len = chimera_posix_check_path(path);
+    if (path_len < 0) {
+        return -1;
+    }
 
-    path_len = strlen(path);
+    chimera_posix_completion_init(&comp, &req);
 
     req.opcode               = CHIMERA_CLIENT_OP_SETATTR;
     req.setattr.callback     = chimera_posix_chmod_callback;

--- a/src/posix/posix_chown.c
+++ b/src/posix/posix_chown.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -39,9 +39,12 @@ chimera_posix_chown(
     struct chimera_posix_completion comp;
     int                             path_len;
 
-    chimera_posix_completion_init(&comp, &req);
+    path_len = chimera_posix_check_path(path);
+    if (path_len < 0) {
+        return -1;
+    }
 
-    path_len = strlen(path);
+    chimera_posix_completion_init(&comp, &req);
 
     req.opcode               = CHIMERA_CLIENT_OP_SETATTR;
     req.setattr.callback     = chimera_posix_chown_callback;

--- a/src/posix/posix_fchmodat.c
+++ b/src/posix/posix_fchmodat.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -71,7 +71,7 @@ chimera_posix_fchmodat_open_complete(
 
     chimera_vfs_setattr(
         request->thread->vfs_thread,
-        &request->thread->client->cred,
+        chimera_client_req_cred(request),
         oh,
         &ctx->set_attr,
         0,  /* pre_attr_mask */
@@ -94,7 +94,7 @@ chimera_posix_fchmodat_at_exec(
     /* Open the target file relative to the parent directory */
     chimera_vfs_open_at(
         thread->vfs_thread,
-        &thread->client->cred,
+        chimera_client_req_cred(request),
         request->setattr.parent_handle,
         request->setattr.path,
         request->setattr.path_len,

--- a/src/posix/posix_fchownat.c
+++ b/src/posix/posix_fchownat.c
@@ -75,7 +75,7 @@ chimera_posix_fchownat_open_complete(
 
     chimera_vfs_setattr(
         request->thread->vfs_thread,
-        &request->thread->client->cred,
+        chimera_client_req_cred(request),
         oh,
         &ctx->set_attr,
         0,  /* pre_attr_mask */
@@ -96,7 +96,7 @@ chimera_posix_fchownat_at_exec(
     /* Open the target file relative to the parent directory */
     chimera_vfs_open_at(
         thread->vfs_thread,
-        &thread->client->cred,
+        chimera_client_req_cred(request),
         request->setattr.parent_handle,
         request->setattr.path,
         request->setattr.path_len,

--- a/src/posix/posix_internal.h
+++ b/src/posix/posix_internal.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -91,6 +91,33 @@ struct chimera_posix_client {
 
 extern struct chimera_posix_client *chimera_posix_global;
 
+/*
+ * Per-thread effective credential and umask overrides.
+ *
+ * The POSIX client is initialized with one client-global credential, but POSIX
+ * semantics (and conformance suites such as pjdfstest) require switching the
+ * effective uid/gid/groups per operation to exercise permission checks.  These
+ * thread-locals let a caller temporarily override the credential and umask for
+ * subsequent calls on the same thread; when unset, operations fall back to the
+ * client-global credential and apply no umask (matching prior behavior).
+ */
+extern __thread int                     chimera_posix_tls_has_cred;
+extern __thread struct chimera_vfs_cred chimera_posix_tls_cred;
+extern __thread int                     chimera_posix_tls_has_umask;
+extern __thread mode_t                  chimera_posix_tls_umask;
+
+static FORCE_INLINE const struct chimera_vfs_cred *
+chimera_posix_effective_cred(void)
+{
+    return chimera_posix_tls_has_cred ? &chimera_posix_tls_cred : NULL;
+} // chimera_posix_effective_cred
+
+static FORCE_INLINE mode_t
+chimera_posix_effective_umask(void)
+{
+    return chimera_posix_tls_has_umask ? chimera_posix_tls_umask : 0;
+} // chimera_posix_effective_umask
+
 static FORCE_INLINE struct chimera_posix_client *
 chimera_posix_get_global(void)
 {
@@ -131,6 +158,20 @@ chimera_posix_completion_init(
     comp->done    = 0;
 
     req->heap_allocated = 0;
+
+    /* Capture the calling thread's effective credential override (if any) into
+     * the request, so the worker thread authorizes this operation as the
+     * intended user rather than the client-global credential. */
+    {
+        const struct chimera_vfs_cred *eff = chimera_posix_effective_cred();
+
+        if (eff) {
+            req->req_cred = *eff;
+            req->has_cred = 1;
+        } else {
+            req->has_cred = 0;
+        }
+    }
 } // chimera_posix_completion_init
 
 static FORCE_INLINE void
@@ -239,6 +280,45 @@ chimera_posix_to_chimera_flags(int flags)
 
     return out;
 } // chimera_posix_to_chimera_flags
+
+/* Initialize a create-path set_attr to request the given creation mode, with
+ * the calling thread's umask applied to the permission bits.  umask is masked
+ * to 0777, so file-type and special bits in `mode` (e.g. for mknod) survive. */
+static FORCE_INLINE void
+chimera_posix_set_create_mode(
+    struct chimera_vfs_attrs *sa,
+    mode_t                    mode)
+{
+    sa->va_req_mask = 0;
+    sa->va_set_mask = CHIMERA_VFS_ATTR_MODE;
+    sa->va_mode     = mode & ~chimera_posix_effective_umask();
+} // chimera_posix_set_create_mode
+
+/* Initialize a create-path set_attr that carries no explicit mode (backend
+ * default applies). */
+static FORCE_INLINE void
+chimera_posix_no_create_mode(struct chimera_vfs_attrs *sa)
+{
+    sa->va_req_mask = 0;
+    sa->va_set_mask = 0;
+} // chimera_posix_no_create_mode
+
+/* Validate a caller-supplied pathname length before it is copied into a fixed
+ * CHIMERA_VFS_PATH_MAX request buffer.  Returns the length on success; on a path
+ * that would not fit (>= CHIMERA_VFS_PATH_MAX including the terminating null)
+ * sets errno=ENAMETOOLONG and returns -1.  This both yields the POSIX errno and
+ * prevents a buffer overflow of the request path field. */
+static FORCE_INLINE int
+chimera_posix_check_path(const char *path)
+{
+    size_t len = strlen(path);
+
+    if (len >= CHIMERA_VFS_PATH_MAX) {
+        errno = ENAMETOOLONG;
+        return -1;
+    }
+    return (int) len;
+} /* chimera_posix_check_path */
 
 static FORCE_INLINE int
 chimera_posix_fd_alloc(

--- a/src/posix/posix_lchown.c
+++ b/src/posix/posix_lchown.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -24,7 +24,7 @@ chimera_posix_lchown_exec(
     struct chimera_client_thread  *thread,
     struct chimera_client_request *request)
 {
-    chimera_dispatch_setattr(thread, request);
+    chimera_dispatch_lsetattr(thread, request);
 } /* chimera_posix_lchown_exec */
 
 SYMBOL_EXPORT int
@@ -39,9 +39,12 @@ chimera_posix_lchown(
     struct chimera_posix_completion comp;
     int                             path_len;
 
-    chimera_posix_completion_init(&comp, &req);
+    path_len = chimera_posix_check_path(path);
+    if (path_len < 0) {
+        return -1;
+    }
 
-    path_len = strlen(path);
+    chimera_posix_completion_init(&comp, &req);
 
     req.opcode               = CHIMERA_CLIENT_OP_SETATTR;
     req.setattr.callback     = chimera_posix_lchown_callback;

--- a/src/posix/posix_link.c
+++ b/src/posix/posix_link.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -41,12 +41,16 @@ chimera_posix_link(
     int                             source_path_len;
     int                             dest_path_len;
 
+    source_path_len = chimera_posix_check_path(oldpath);
+    dest_path_len   = chimera_posix_check_path(newpath);
+    if (source_path_len < 0 || dest_path_len < 0) {
+        return -1;
+    }
+
     chimera_posix_completion_init(&comp, &req);
 
-    source_path_len = strlen(oldpath);
-    dest_path_len   = strlen(newpath);
-    source_slash    = rindex(oldpath, '/');
-    dest_slash      = rindex(newpath, '/');
+    source_slash = rindex(oldpath, '/');
+    dest_slash   = rindex(newpath, '/');
 
     req.opcode                 = CHIMERA_CLIENT_OP_LINK;
     req.link.callback          = chimera_posix_link_callback;

--- a/src/posix/posix_link.c
+++ b/src/posix/posix_link.c
@@ -76,7 +76,9 @@ chimera_posix_link(
     chimera_posix_completion_destroy(&comp);
 
     if (err) {
-        errno = err;
+        /* POSIX link(2) reports a directory source as EPERM; the VFS surfaces
+         * the physical condition as EISDIR (for NFS4/SMB protocol fidelity). */
+        errno = (err == EISDIR) ? EPERM : err;
         return -1;
     }
 

--- a/src/posix/posix_linkat.c
+++ b/src/posix/posix_linkat.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -105,7 +105,9 @@ chimera_posix_linkat(
     chimera_posix_completion_destroy(&comp);
 
     if (err) {
-        errno = err;
+        /* POSIX link(2) reports a directory source as EPERM; the VFS surfaces
+         * the physical condition as EISDIR (for NFS4/SMB protocol fidelity). */
+        errno = (err == EISDIR) ? EPERM : err;
         return -1;
     }
 

--- a/src/posix/posix_mkdir.c
+++ b/src/posix/posix_mkdir.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -32,8 +32,6 @@ chimera_posix_mkdir(
     const char *path,
     mode_t      mode)
 {
-    (void) mode;
-
     struct chimera_posix_client    *posix  = chimera_posix_get_global();
     struct chimera_posix_worker    *worker = chimera_posix_choose_worker(posix);
     struct chimera_client_request   req;
@@ -41,10 +39,14 @@ chimera_posix_mkdir(
     const char                     *slash;
     int                             path_len;
 
+    path_len = chimera_posix_check_path(path);
+    if (path_len < 0) {
+        return -1;
+    }
+
     chimera_posix_completion_init(&comp, &req);
 
-    path_len = strlen(path);
-    slash    = rindex(path, '/');
+    slash = rindex(path, '/');
 
     req.opcode             = CHIMERA_CLIENT_OP_MKDIR;
     req.mkdir.callback     = chimera_posix_mkdir_callback;
@@ -57,6 +59,8 @@ chimera_posix_mkdir(
     }
 
     req.mkdir.name_offset = slash ? slash - path : -1;
+
+    chimera_posix_set_create_mode(&req.mkdir.set_attr, mode);
 
     memcpy(req.mkdir.path, path, path_len);
 

--- a/src/posix/posix_mkdirat.c
+++ b/src/posix/posix_mkdirat.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -98,9 +98,7 @@ chimera_posix_mkdirat(
     req.mkdir.callback     = chimera_posix_mkdirat_callback;
     req.mkdir.private_data = &comp;
 
-    req.mkdir.set_attr.va_req_mask = 0;
-    req.mkdir.set_attr.va_set_mask = CHIMERA_VFS_ATTR_MODE;
-    req.mkdir.set_attr.va_mode     = mode;
+    chimera_posix_set_create_mode(&req.mkdir.set_attr, mode);
 
     chimera_posix_worker_enqueue(worker, &req, chimera_posix_mkdirat_exec);
 

--- a/src/posix/posix_mknod.c
+++ b/src/posix/posix_mknod.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -40,10 +40,13 @@ chimera_posix_mknod(
     const char                     *slash;
     int                             path_len;
 
-    chimera_posix_completion_init(&comp, &req);
+    path_len = chimera_posix_check_path(path);
+    if (path_len < 0) {
+        return -1;
+    }
 
-    path_len = strlen(path);
-    slash    = rindex(path, '/');
+    chimera_posix_completion_init(&comp, &req);
+    slash = rindex(path, '/');
 
     req.opcode             = CHIMERA_CLIENT_OP_MKNOD;
     req.mknod.callback     = chimera_posix_mknod_callback;
@@ -61,7 +64,7 @@ chimera_posix_mknod(
 
     req.mknod.set_attr.va_req_mask = 0;
     req.mknod.set_attr.va_set_mask = CHIMERA_VFS_ATTR_MODE | CHIMERA_VFS_ATTR_RDEV;
-    req.mknod.set_attr.va_mode     = mode;
+    req.mknod.set_attr.va_mode     = mode & ~chimera_posix_effective_umask();
     req.mknod.set_attr.va_rdev     = dev;
 
     chimera_posix_worker_enqueue(worker, &req, chimera_posix_mknod_exec);

--- a/src/posix/posix_open.c
+++ b/src/posix/posix_open.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -53,12 +53,14 @@ chimera_posix_open(
         va_end(ap);
     }
 
-    (void) mode;
+    path_len = chimera_posix_check_path(path);
+    if (path_len < 0) {
+        return -1;
+    }
 
     chimera_posix_completion_init(&comp, &req);
 
-    path_len = strlen(path);
-    slash    = rindex(path, '/');
+    slash = rindex(path, '/');
 
     req.opcode            = CHIMERA_CLIENT_OP_OPEN;
     req.open.callback     = chimera_posix_open_callback;
@@ -72,6 +74,12 @@ chimera_posix_open(
     }
 
     req.open.name_offset = slash ? slash - path : -1;
+
+    if (flags & O_CREAT) {
+        chimera_posix_set_create_mode(&req.open.set_attr, mode);
+    } else {
+        chimera_posix_no_create_mode(&req.open.set_attr);
+    }
 
     memcpy(req.open.path, path, path_len);
 

--- a/src/posix/posix_openat.c
+++ b/src/posix/posix_openat.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -65,8 +65,6 @@ chimera_posix_openat(
         va_end(ap);
     }
 
-    (void) mode;
-
     chimera_posix_completion_init(&comp, &req);
 
     // Handle AT_FDCWD case
@@ -118,6 +116,12 @@ chimera_posix_openat(
     req.open.callback     = chimera_posix_openat_callback;
     req.open.private_data = &comp;
     req.open.flags        = chimera_posix_to_chimera_flags(flags);
+
+    if (flags & O_CREAT) {
+        chimera_posix_set_create_mode(&req.open.set_attr, mode);
+    } else {
+        chimera_posix_no_create_mode(&req.open.set_attr);
+    }
 
     chimera_posix_worker_enqueue(worker, &req, chimera_posix_openat_exec);
 

--- a/src/posix/posix_pathconf.c
+++ b/src/posix/posix_pathconf.c
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include <errno.h>
+#include <unistd.h>
+#include <limits.h>
+
+#include "posix_internal.h"
+
+/*
+ * pathconf(3)/fpathconf(3) for the Chimera POSIX client.
+ *
+ * The VFS does not expose per-file configurable limits, so these return the
+ * filesystem-wide constants the Chimera VFS enforces.  CHIMERA_VFS_PATH_MAX is
+ * the wire/path buffer limit shared by every backend; NAME_MAX mirrors the
+ * common POSIX value.  Callers (e.g. conformance suites) use these to size
+ * maximal names/paths for ENAMETOOLONG testing.
+ */
+
+#ifndef CHIMERA_POSIX_NAME_MAX
+#define CHIMERA_POSIX_NAME_MAX 255
+#endif /* ifndef CHIMERA_POSIX_NAME_MAX */
+
+#ifndef CHIMERA_POSIX_LINK_MAX
+#define CHIMERA_POSIX_LINK_MAX 32767
+#endif /* ifndef CHIMERA_POSIX_LINK_MAX */
+
+static long
+chimera_posix_pathconf_value(int name)
+{
+    switch (name) {
+        case _PC_NAME_MAX:
+            return CHIMERA_POSIX_NAME_MAX;
+        case _PC_PATH_MAX:
+            return CHIMERA_VFS_PATH_MAX;
+        case _PC_LINK_MAX:
+            return CHIMERA_POSIX_LINK_MAX;
+#ifdef _PC_SYMLINK_MAX
+        case _PC_SYMLINK_MAX:
+            return CHIMERA_VFS_PATH_MAX;
+#endif /* ifdef _PC_SYMLINK_MAX */
+        case _PC_NO_TRUNC:
+            return 1;
+        case _PC_CHOWN_RESTRICTED:
+            return 1;
+        default:
+            errno = EINVAL;
+            return -1;
+    } /* switch */
+} /* chimera_posix_pathconf_value */
+
+SYMBOL_EXPORT long
+chimera_posix_pathconf(
+    const char *path,
+    int         name)
+{
+    (void) path;
+    return chimera_posix_pathconf_value(name);
+} /* chimera_posix_pathconf */
+
+SYMBOL_EXPORT long
+chimera_posix_fpathconf(
+    int fd,
+    int name)
+{
+    (void) fd;
+    return chimera_posix_pathconf_value(name);
+} /* chimera_posix_fpathconf */

--- a/src/posix/posix_rename.c
+++ b/src/posix/posix_rename.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -41,12 +41,16 @@ chimera_posix_rename(
     int                             source_path_len;
     int                             dest_path_len;
 
+    source_path_len = chimera_posix_check_path(oldpath);
+    dest_path_len   = chimera_posix_check_path(newpath);
+    if (source_path_len < 0 || dest_path_len < 0) {
+        return -1;
+    }
+
     chimera_posix_completion_init(&comp, &req);
 
-    source_path_len = strlen(oldpath);
-    dest_path_len   = strlen(newpath);
-    source_slash    = rindex(oldpath, '/');
-    dest_slash      = rindex(newpath, '/');
+    source_slash = rindex(oldpath, '/');
+    dest_slash   = rindex(newpath, '/');
 
     req.opcode                   = CHIMERA_CLIENT_OP_RENAME;
     req.rename.callback          = chimera_posix_rename_callback;

--- a/src/posix/posix_rmdir.c
+++ b/src/posix/posix_rmdir.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -37,10 +37,14 @@ chimera_posix_rmdir(const char *path)
     const char                     *slash;
     int                             path_len;
 
+    path_len = chimera_posix_check_path(path);
+    if (path_len < 0) {
+        return -1;
+    }
+
     chimera_posix_completion_init(&comp, &req);
 
-    path_len = strlen(path);
-    slash    = rindex(path, '/');
+    slash = rindex(path, '/');
 
     req.opcode              = CHIMERA_CLIENT_OP_REMOVE;
     req.remove.callback     = chimera_posix_rmdir_callback;

--- a/src/posix/posix_symlink.c
+++ b/src/posix/posix_symlink.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -40,9 +40,18 @@ chimera_posix_symlink(
     int                             path_len;
     int                             target_len;
 
+    path_len = chimera_posix_check_path(path);
+    if (path_len < 0) {
+        return -1;
+    }
+
+    if (strlen(target) >= CHIMERA_VFS_PATH_MAX) {
+        errno = ENAMETOOLONG;
+        return -1;
+    }
+
     chimera_posix_completion_init(&comp, &req);
 
-    path_len   = strlen(path);
     target_len = strlen(target);
     slash      = rindex(path, '/');
 

--- a/src/posix/posix_truncate.c
+++ b/src/posix/posix_truncate.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -43,9 +43,12 @@ chimera_posix_truncate(
         return -1;
     }
 
-    chimera_posix_completion_init(&comp, &req);
+    path_len = chimera_posix_check_path(path);
+    if (path_len < 0) {
+        return -1;
+    }
 
-    path_len = strlen(path);
+    chimera_posix_completion_init(&comp, &req);
 
     req.opcode               = CHIMERA_CLIENT_OP_SETATTR;
     req.setattr.callback     = chimera_posix_truncate_callback;

--- a/src/posix/posix_unlink.c
+++ b/src/posix/posix_unlink.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -37,10 +37,14 @@ chimera_posix_unlink(const char *path)
     const char                     *slash;
     int                             path_len;
 
+    path_len = chimera_posix_check_path(path);
+    if (path_len < 0) {
+        return -1;
+    }
+
     chimera_posix_completion_init(&comp, &req);
 
-    path_len = strlen(path);
-    slash    = rindex(path, '/');
+    slash = rindex(path, '/');
 
     req.opcode              = CHIMERA_CLIENT_OP_REMOVE;
     req.remove.callback     = chimera_posix_remove_callback;

--- a/src/posix/posix_utimensat.c
+++ b/src/posix/posix_utimensat.c
@@ -1,0 +1,324 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include <errno.h>
+#include <string.h>
+#include <sys/stat.h>
+
+#include "posix_internal.h"
+#include "../client/client_setattr.h"
+#include "../client/client_fsetattr.h"
+
+#ifndef AT_FDCWD
+#define AT_FDCWD            -100
+#endif /* ifndef AT_FDCWD */
+
+#ifndef AT_SYMLINK_NOFOLLOW
+#define AT_SYMLINK_NOFOLLOW 0x100
+#endif /* ifndef AT_SYMLINK_NOFOLLOW */
+
+/*
+ * Translate a POSIX utimensat(2) `times[2]` array into a VFS set_attr.  The
+ * atime/mtime mask bits are always set so that the backend applies consistent
+ * ctime semantics; per-field UTIME_NOW / UTIME_OMIT are conveyed through the
+ * CHIMERA_VFS_TIME_NOW / CHIMERA_VFS_TIME_OMIT tv_nsec sentinels that backends
+ * already honor (see vfs_attrs.h).  A NULL `times` means "set both to now".
+ */
+static void
+chimera_posix_fill_utimes(
+    struct chimera_vfs_attrs *sa,
+    const struct timespec     times[2])
+{
+    sa->va_req_mask = 0;
+    sa->va_set_mask = CHIMERA_VFS_ATTR_ATIME | CHIMERA_VFS_ATTR_MTIME;
+
+    if (times == NULL) {
+        sa->va_atime.tv_sec  = 0;
+        sa->va_atime.tv_nsec = CHIMERA_VFS_TIME_NOW;
+        sa->va_mtime.tv_sec  = 0;
+        sa->va_mtime.tv_nsec = CHIMERA_VFS_TIME_NOW;
+        return;
+    }
+
+    if (times[0].tv_nsec == UTIME_NOW) {
+        sa->va_atime.tv_sec  = 0;
+        sa->va_atime.tv_nsec = CHIMERA_VFS_TIME_NOW;
+    } else if (times[0].tv_nsec == UTIME_OMIT) {
+        sa->va_atime.tv_sec  = 0;
+        sa->va_atime.tv_nsec = CHIMERA_VFS_TIME_OMIT;
+    } else {
+        sa->va_atime = times[0];
+    }
+
+    if (times[1].tv_nsec == UTIME_NOW) {
+        sa->va_mtime.tv_sec  = 0;
+        sa->va_mtime.tv_nsec = CHIMERA_VFS_TIME_NOW;
+    } else if (times[1].tv_nsec == UTIME_OMIT) {
+        sa->va_mtime.tv_sec  = 0;
+        sa->va_mtime.tv_nsec = CHIMERA_VFS_TIME_OMIT;
+    } else {
+        sa->va_mtime = times[1];
+    }
+} /* chimera_posix_fill_utimes */
+
+/* ---- futimens(fd, times) : fsetattr on the open handle ---- */
+
+static void
+chimera_posix_futimens_callback(
+    struct chimera_client_thread *thread,
+    enum chimera_vfs_error        status,
+    void                         *private_data)
+{
+    struct chimera_posix_completion *comp = private_data;
+
+    chimera_posix_complete(comp, status);
+} /* chimera_posix_futimens_callback */
+
+static void
+chimera_posix_futimens_exec(
+    struct chimera_client_thread  *thread,
+    struct chimera_client_request *request)
+{
+    chimera_dispatch_fsetattr(thread, request);
+} /* chimera_posix_futimens_exec */
+
+SYMBOL_EXPORT int
+chimera_posix_futimens(
+    int                   fd,
+    const struct timespec times[2])
+{
+    struct chimera_posix_client    *posix  = chimera_posix_get_global();
+    struct chimera_posix_worker    *worker = chimera_posix_choose_worker(posix);
+    struct chimera_posix_fd_entry  *entry;
+    struct chimera_client_request   req;
+    struct chimera_posix_completion comp;
+
+    entry = chimera_posix_fd_acquire(posix, fd, 0);
+
+    if (!entry) {
+        errno = EBADF;
+        return -1;
+    }
+
+    chimera_posix_completion_init(&comp, &req);
+
+    req.opcode                = CHIMERA_CLIENT_OP_FSETATTR;
+    req.fsetattr.handle       = entry->handle;
+    req.fsetattr.callback     = chimera_posix_futimens_callback;
+    req.fsetattr.private_data = &comp;
+
+    chimera_posix_fill_utimes(&req.fsetattr.set_attr, times);
+
+    chimera_posix_worker_enqueue(worker, &req, chimera_posix_futimens_exec);
+
+    int err = chimera_posix_wait(&comp);
+
+    chimera_posix_fd_release(entry, 0);
+
+    chimera_posix_completion_destroy(&comp);
+
+    if (err) {
+        errno = err;
+        return -1;
+    }
+
+    return 0;
+} /* chimera_posix_futimens */
+
+/* ---- utimensat(dirfd, path, times, flags) ---- */
+
+struct chimera_posix_utimensat_ctx {
+    struct chimera_posix_completion comp;
+    struct chimera_vfs_open_handle *file_handle;
+    struct chimera_vfs_attrs        set_attr;
+    struct chimera_vfs_attrs        open_attr;   /* scratch for open_at; must
+                                                  * outlive the async open */
+};
+
+static void
+chimera_posix_utimensat_callback(
+    struct chimera_client_thread *thread,
+    enum chimera_vfs_error        status,
+    void                         *private_data)
+{
+    struct chimera_posix_completion *comp = private_data;
+
+    chimera_posix_complete(comp, status);
+} /* chimera_posix_utimensat_callback */
+
+static void
+chimera_posix_utimensat_setattr_complete(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *pre_attr,
+    struct chimera_vfs_attrs *set_attr,
+    struct chimera_vfs_attrs *post_attr,
+    void                     *private_data)
+{
+    struct chimera_posix_utimensat_ctx *ctx = private_data;
+
+    chimera_vfs_release(ctx->comp.request->thread->vfs_thread, ctx->file_handle);
+    chimera_posix_complete(&ctx->comp, error_code);
+} /* chimera_posix_utimensat_setattr_complete */
+
+static void
+chimera_posix_utimensat_open_complete(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *oh,
+    struct chimera_vfs_attrs       *set_attr,
+    struct chimera_vfs_attrs       *attr,
+    struct chimera_vfs_attrs       *dir_pre_attr,
+    struct chimera_vfs_attrs       *dir_post_attr,
+    void                           *private_data)
+{
+    struct chimera_posix_utimensat_ctx *ctx     = private_data;
+    struct chimera_client_request      *request = ctx->comp.request;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        chimera_posix_complete(&ctx->comp, error_code);
+        return;
+    }
+
+    ctx->file_handle = oh;
+
+    chimera_vfs_setattr(
+        request->thread->vfs_thread,
+        chimera_client_req_cred(request),
+        oh,
+        &ctx->set_attr,
+        0,  /* pre_attr_mask */
+        0,  /* post_attr_mask */
+        chimera_posix_utimensat_setattr_complete,
+        ctx);
+} /* chimera_posix_utimensat_open_complete */
+
+static void
+chimera_posix_utimensat_at_exec(
+    struct chimera_client_thread  *thread,
+    struct chimera_client_request *request)
+{
+    struct chimera_posix_utimensat_ctx *ctx = request->setattr.private_data;
+    unsigned int                        open_flags;
+
+    ctx->open_attr.va_req_mask = 0;
+    ctx->open_attr.va_set_mask = 0;
+
+    open_flags = CHIMERA_VFS_OPEN_PATH | CHIMERA_VFS_OPEN_INFERRED;
+
+    chimera_vfs_open_at(
+        thread->vfs_thread,
+        chimera_client_req_cred(request),
+        request->setattr.parent_handle,
+        request->setattr.path,
+        request->setattr.path_len,
+        open_flags,
+        &ctx->open_attr,
+        CHIMERA_VFS_ATTR_FH,
+        0,
+        0,
+        chimera_posix_utimensat_open_complete,
+        ctx);
+} /* chimera_posix_utimensat_at_exec */
+
+static void
+chimera_posix_utimensat_exec(
+    struct chimera_client_thread  *thread,
+    struct chimera_client_request *request)
+{
+    chimera_dispatch_setattr(thread, request);
+} /* chimera_posix_utimensat_exec */
+
+SYMBOL_EXPORT int
+chimera_posix_utimensat(
+    int                   dirfd,
+    const char           *pathname,
+    const struct timespec times[2],
+    int                   flags)
+{
+    struct chimera_posix_client       *posix  = chimera_posix_get_global();
+    struct chimera_posix_worker       *worker = chimera_posix_choose_worker(posix);
+    struct chimera_client_request      req;
+    struct chimera_posix_utimensat_ctx ctx;
+    struct chimera_posix_fd_entry     *dir_entry = NULL;
+    int                                path_len;
+    const char                        *slash;
+    int                                err;
+
+    /* AT_SYMLINK_NOFOLLOW on the final component is not yet distinguished from
+     * follow in the open path; non-symlink targets (the common case) behave
+     * identically. */
+    (void) flags;
+
+    chimera_posix_completion_init(&ctx.comp, &req);
+
+    if (dirfd == AT_FDCWD) {
+        if (pathname[0] == '/') {
+            path_len = strlen(pathname);
+            memcpy(req.setattr.path, pathname, path_len);
+        } else {
+            req.setattr.path[0] = '/';
+            path_len            = strlen(pathname);
+            memcpy(req.setattr.path + 1, pathname, path_len);
+            path_len++;
+        }
+
+        req.setattr.path[path_len] = '\0';
+        slash                      = rindex(req.setattr.path, '/');
+
+        req.setattr.parent_handle = NULL;
+        req.setattr.path_len      = path_len;
+        req.setattr.parent_len    = slash ? slash - req.setattr.path : path_len;
+
+        while (slash && *slash == '/') {
+            slash++;
+        }
+
+        req.setattr.name_offset = slash ? slash - req.setattr.path : -1;
+
+        req.opcode               = CHIMERA_CLIENT_OP_SETATTR;
+        req.setattr.callback     = chimera_posix_utimensat_callback;
+        req.setattr.private_data = &ctx.comp;
+
+        chimera_posix_fill_utimes(&req.setattr.set_attr, times);
+
+        chimera_posix_worker_enqueue(worker, &req, chimera_posix_utimensat_exec);
+    } else {
+        dir_entry = chimera_posix_fd_acquire(posix, dirfd, 0);
+        if (!dir_entry) {
+            errno = EBADF;
+            chimera_posix_completion_destroy(&ctx.comp);
+            return -1;
+        }
+
+        path_len = strlen(pathname);
+        memcpy(req.setattr.path, pathname, path_len);
+
+        req.setattr.parent_handle = dir_entry->handle;
+        req.setattr.path_len      = path_len;
+        req.setattr.parent_len    = 0;
+        req.setattr.name_offset   = 0;
+
+        req.opcode               = CHIMERA_CLIENT_OP_SETATTR;
+        req.setattr.callback     = chimera_posix_utimensat_callback;
+        req.setattr.private_data = &ctx;
+
+        chimera_posix_fill_utimes(&ctx.set_attr, times);
+
+        chimera_posix_worker_enqueue(worker, &req, chimera_posix_utimensat_at_exec);
+    }
+
+    err = chimera_posix_wait(&ctx.comp);
+
+    if (dir_entry) {
+        chimera_posix_fd_release(dir_entry, 0);
+    }
+
+    chimera_posix_completion_destroy(&ctx.comp);
+
+    if (err) {
+        errno = err;
+        return -1;
+    }
+
+    return 0;
+} /* chimera_posix_utimensat */


### PR DESCRIPTION
## Summary

Enabling work for the POSIX client layer (and the underlying async client API),
factored out so the POSIX conformance suite that drives it lands as purely
tests. No behavior change for existing callers when the new overrides are unset.

- **Per-call credential override (client API)**: `chimera_client_request` carries
  an optional credential and every dispatch routes through
  `chimera_client_req_cred()` (falling back to the client-global credential). The
  POSIX layer exposes a thread-local effective credential
  (`chimera_posix_set_cred`/`clear_cred`) captured into each request, so one
  client can authorize operations as different users without re-initializing.
- **umask**: thread-local `chimera_posix_umask`, applied to the create paths.
- **Honor creation mode**: `open(O_CREAT)`/`mkdir`/`mkdirat`/`mknod` previously
  dropped the caller's mode; they now pass it (umask-adjusted) to the backend.
- **New ops**: `utimensat`/`futimens` (ATIME/MTIME via TIME_NOW/TIME_OMIT) and
  `pathconf`/`fpathconf`.
- **lchown** no longer follows symlinks (no-follow setattr dispatch).
- **Pathname-length guards** (`chimera_posix_check_path`) on path entry points →
  ENAMETOOLONG instead of overflow.

Part of a series splitting the functional fixes out of the pjdfstest-port
PR (#691). Pairs with the VFS-core (#694) and open/memfs (#696) PRs.
