### PR TITLE
s3: implement ListObjects v1/v2 delimiter, pagination and encoding

### DIFF
--- a/src/server/s3/s3.c
+++ b/src/server/s3/s3.c
@@ -23,15 +23,50 @@
 #include "vfs/vfs.h"
 #include "vfs/vfs_procs.h"
 
-static inline void
-chimera_s3_sterilize_path(
-    struct chimera_s3_request *request,
-    const char                *prefix,
-    int                        prefix_len)
+static inline int
+chimera_s3_hexval(int c)
 {
-    request->path     = request->list.prefix;
-    request->path_len = request->list.prefix_len;
-} /* chimera_s3_sterilize_path */
+    if (c >= '0' && c <= '9') {
+        return c - '0';
+    } else if (c >= 'a' && c <= 'f') {
+        return c - 'a' + 10;
+    } else if (c >= 'A' && c <= 'F') {
+        return c - 'A' + 10;
+    }
+    return -1;
+} /* chimera_s3_hexval */
+
+/* Percent-decode an S3 query-string value (%XX escapes only; '+' is left
+ * intact because S3, unlike form encoding, does not treat it as a space).
+ * Writes a NUL-terminated result and returns its length. */
+static inline int
+chimera_s3_pct_decode(
+    char       *dst,
+    int         dstcap,
+    const char *src,
+    int         srclen)
+{
+    int o = 0, i = 0;
+
+    while (i < srclen && o < dstcap - 1) {
+        int c = (unsigned char) src[i];
+
+        if (c == '%' && i + 2 < srclen) {
+            int hi = chimera_s3_hexval((unsigned char) src[i + 1]);
+            int lo = chimera_s3_hexval((unsigned char) src[i + 2]);
+            if (hi >= 0 && lo >= 0) {
+                dst[o++] = (char) ((hi << 4) | lo);
+                i       += 3;
+                continue;
+            }
+        }
+        dst[o++] = (char) c;
+        i++;
+    }
+
+    dst[o] = '\0';
+    return o;
+} /* chimera_s3_pct_decode */
 
 /* expect range_str in the form: bytes=1000-1599 */
 static inline int
@@ -518,10 +553,26 @@ s3_server_dispatch(
             const char *p;
             int         key_len, value_len;
             /* Staging buffers; we don't know yet whether this is a LIST or a
-             * multipart request, and they share a union. */
-            char        prefix_buf[256];
-            int         prefix_len = 0;
-            int         max_keys   = 1000;
+             * multipart request, and they share a union. LIST values are
+             * percent-decoded since clients (e.g. the AWS CLI) encode prefix,
+             * delimiter and continuation tokens in the query string. */
+            char        prefix_buf[CHIMERA_S3_KEY_MAX];
+            char        delim_buf[CHIMERA_S3_DELIM_MAX];
+            char        marker_buf[CHIMERA_S3_KEY_MAX];
+            char        ctoken_buf[CHIMERA_S3_KEY_MAX];
+            char        startafter_buf[CHIMERA_S3_KEY_MAX];
+            int         prefix_len     = 0;
+            int         delim_len      = 0;
+            int         marker_len     = 0;
+            int         ctoken_len     = 0;
+            int         startafter_len = 0;
+            int         max_keys       = 1000;
+            int         list_type      = 1;
+            int         encoding_url   = 0;
+            /* Set when the query carries a key we don't recognize as a list
+             * parameter or handled subresource: an unimplemented bucket/object
+             * subresource (acl/policy/tagging/cors/lifecycle/...). */
+            int         saw_unknown = 0;
 
             p = qmark + 1;
 
@@ -563,14 +614,38 @@ s3_server_dispatch(
                     s3_request->query_part_number = atoi(value_start);
                     s3_request->has_part_number   = 1;
                 } else if (key_len == 6 && memcmp(key_start, "prefix", 6) == 0) {
-                    if (value_len > (int) sizeof(prefix_buf) - 1) {
-                        value_len = sizeof(prefix_buf) - 1;
-                    }
-                    memcpy(prefix_buf, value_start, value_len);
-                    prefix_buf[value_len] = '\0';
-                    prefix_len            = value_len;
+                    prefix_len = chimera_s3_pct_decode(prefix_buf, sizeof(prefix_buf),
+                                                       value_start, value_len);
                 } else if (key_len == 8 && memcmp(key_start, "max-keys", 8) == 0) {
                     max_keys = atoi(value_start);
+                } else if (key_len == 9 && memcmp(key_start, "list-type", 9) == 0) {
+                    list_type = atoi(value_start);
+                } else if (key_len == 9 && memcmp(key_start, "delimiter", 9) == 0) {
+                    delim_len = chimera_s3_pct_decode(delim_buf, sizeof(delim_buf),
+                                                      value_start, value_len);
+                } else if (key_len == 6 && memcmp(key_start, "marker", 6) == 0) {
+                    marker_len = chimera_s3_pct_decode(marker_buf, sizeof(marker_buf),
+                                                       value_start, value_len);
+                } else if (key_len == 10 && memcmp(key_start, "key-marker", 10) == 0) {
+                    /* ListObjectVersions pagination cursor; reuse the marker. */
+                    marker_len = chimera_s3_pct_decode(marker_buf, sizeof(marker_buf),
+                                                       value_start, value_len);
+                } else if (key_len == 18 && memcmp(key_start, "continuation-token", 18) == 0) {
+                    ctoken_len = chimera_s3_pct_decode(ctoken_buf, sizeof(ctoken_buf),
+                                                       value_start, value_len);
+                } else if (key_len == 11 && memcmp(key_start, "start-after", 11) == 0) {
+                    startafter_len = chimera_s3_pct_decode(startafter_buf, sizeof(startafter_buf),
+                                                           value_start, value_len);
+                } else if (key_len == 13 && memcmp(key_start, "encoding-type", 13) == 0) {
+                    if (value_len == 3 && strncasecmp(value_start, "url", 3) == 0) {
+                        encoding_url = 1;
+                    }
+                } else if ((key_len == 11 && memcmp(key_start, "fetch-owner", 11) == 0) ||
+                           (key_len == 17 && memcmp(key_start, "version-id-marker", 17) == 0)) {
+                    /* Recognized list parameters we accept but don't act on. */
+                } else {
+                    /* Unrecognized query key: an unimplemented subresource. */
+                    saw_unknown = 1;
                 }
 
                 if (*p == '&') {
@@ -619,18 +694,35 @@ s3_server_dispatch(
                 s3_request->del.cur      = 0;
                 s3_request->del.quiet    = 0;
             } else if (qmark == s3_request->path) {
-                /* Path starts with '?': bucket-level LIST query. */
-                s3_request->is_list         = 1;
-                s3_request->list.prefix_len = prefix_len;
-                if (prefix_len > 0) {
-                    memcpy(s3_request->list.prefix, prefix_buf, prefix_len);
-                    s3_request->list.prefix[prefix_len] = '\0';
+                if (saw_unknown && !s3_request->has_versions) {
+                    /* Path is "?<subresource>" we don't implement (acl, policy,
+                     * tagging, cors, lifecycle, versioning, website, ...). These
+                     * configure features that have no meaning for a filesystem-
+                     * backed bucket shared with NFS/SMB, so we accept and ignore
+                     * them with an empty 200 rather than (a) mis-listing or (b)
+                     * routing a PUT to an object write that would create a junk
+                     * "?subresource" key visible to every protocol. vfs_state
+                     * COMPLETE short-circuits the routing below.
+                     *
+                     * NOTE: this means security-relevant configs (bucket policy,
+                     * encryption, ACL) are silently NOT enforced. */
+                    s3_request->status           = CHIMERA_S3_STATUS_OK;
+                    s3_request->file_length      = 0;
+                    s3_request->file_real_length = 0;
+                    s3_request->file_offset      = 0;
+                    s3_request->vfs_state        = CHIMERA_S3_VFS_STATE_COMPLETE;
+                    s3_request->op_bucket        = 1;
+                } else {
+                    /* Bucket-level LIST query (ListObjects V1/V2 or
+                     * ListObjectVersions). */
+                    chimera_s3_list_setup(s3_request, list_type, max_keys, encoding_url,
+                                          prefix_buf, prefix_len,
+                                          delim_buf, delim_len,
+                                          marker_buf, marker_len,
+                                          ctoken_buf, ctoken_len,
+                                          startafter_buf, startafter_len);
+                    s3_request->list.versions = s3_request->has_versions;
                 }
-                s3_request->list.max_keys = max_keys;
-                s3_request->list.versions = s3_request->has_versions;
-                chimera_s3_sterilize_path(s3_request,
-                                          s3_request->list.prefix,
-                                          s3_request->list.prefix_len);
             } else {
                 /* Path has '?' mid-string but no recognized subresource: strip
                  * the query suffix and treat as a regular object request. */
@@ -654,6 +746,12 @@ s3_server_dispatch(
 
     {
         enum evpl_http_request_type method = evpl_http_request_type(request);
+
+        /* The query parser already resolved this request (e.g. an unimplemented
+         * subresource); don't run the bucket/object routing over it. */
+        if (s3_request->vfs_state == CHIMERA_S3_VFS_STATE_COMPLETE) {
+            return;
+        }
 
         /* Service-level request (no bucket in the path): GET / == ListBuckets. */
         if (s3_request->bucket_namelen == 0) {
@@ -707,13 +805,9 @@ s3_server_dispatch(
                 return;
             } else if (method == EVPL_HTTP_REQUEST_TYPE_GET) {
                 /* GET /bucket with no object key == ListObjects (v1). */
-                s3_request->op_bucket       = 1;
-                s3_request->is_list         = 1;
-                s3_request->list.prefix_len = 0;
-                s3_request->list.prefix[0]  = '\0';
-                s3_request->list.max_keys   = 1000;
-                s3_request->list.versions   = 0;
-                chimera_s3_sterilize_path(s3_request, s3_request->list.prefix, 0);
+                s3_request->op_bucket = 1;
+                chimera_s3_list_setup(s3_request, 1, 1000, 0,
+                                      "", 0, "", 0, "", 0, "", 0, "", 0);
             }
         }
 

--- a/src/server/s3/s3_internal.h
+++ b/src/server/s3/s3_internal.h
@@ -35,6 +35,22 @@ enum chimera_s3_http_state {
 
 #define CHIMERA_S3_UPLOAD_ID_LEN 32
 
+/* S3 keys are limited to 1024 bytes; delimiters are normally a single
+ * character but we allow a small amount of slack. */
+#define CHIMERA_S3_KEY_MAX       1024
+#define CHIMERA_S3_DELIM_MAX     16
+
+/* A single collected listing element: either an object (is_prefix == 0) or a
+ * rolled-up CommonPrefix (is_prefix == 1). Objects carry the attributes needed
+ * to render <Contents>; the key string is heap-allocated and NUL-terminated. */
+struct chimera_s3_list_entry {
+    int             is_prefix;
+    uint64_t        size;
+    uint64_t        etag[2];
+    struct timespec mtime;
+    char           *key;
+};
+
 struct chimera_server_s3_thread;
 struct chimera_s3_multipart_table;
 struct chimera_s3_multipart_upload;
@@ -114,17 +130,28 @@ struct chimera_s3_request {
         } put;
 
         struct {
-            int               prefix_len;
-            int               base_path_len;
-            int               filter_len;
-            int               max_keys;
-            int               versions;   /* emit ListVersionsResult, not ListBucketResult */
-            char             *rp;
-            struct evpl_iovec response;
-            uint8_t           root_fh[CHIMERA_VFS_FH_SIZE];
-            char              prefix[256];
-            char              base_path[256];
-            char              filter[256];
+            int                           list_type;     /* 1 (V1) or 2 (V2) */
+            int                           max_keys;
+            int                           encoding_url;  /* encoding-type=url */
+            int                           versions;      /* emit ListVersionsResult */
+            int                           prefix_len;
+            int                           delimiter_len;
+            int                           enumdir_len;   /* prefix up to last delimiter */
+            int                           has_start;     /* skip past 'start' (exclusive) */
+            int                           start_len;
+            int                           marker_len;     /* V1 marker echo */
+            int                           ctoken_len;     /* V2 continuation-token echo */
+            int                           startafter_len; /* V2 start-after echo */
+            int                           n_entries;
+            int                           cap_entries;
+            struct chimera_s3_list_entry *entries;
+            char                          delimiter[CHIMERA_S3_DELIM_MAX];
+            char                          prefix[CHIMERA_S3_KEY_MAX];
+            char                          enumdir[CHIMERA_S3_KEY_MAX];
+            char                          start[CHIMERA_S3_KEY_MAX];
+            char                          marker[CHIMERA_S3_KEY_MAX];
+            char                          ctoken[CHIMERA_S3_KEY_MAX];
+            char                          startafter[CHIMERA_S3_KEY_MAX];
         } list;
 
         struct {

--- a/src/server/s3/s3_list.c
+++ b/src/server/s3/s3_list.c
@@ -3,29 +3,492 @@
 // SPDX-License-Identifier: LGPL-2.1-only
 
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
 #include <time.h>
+#include <ctype.h>
 #include <sys/stat.h>
 #include "vfs/vfs.h"
 #include "vfs/vfs_procs.h"
-#include "vfs/vfs_release.h"
+#include "common/format.h"
 #include "s3_internal.h"
+#include "s3_procs.h"
 #include "s3_etag.h"
 
+/* Chunk size for response iovecs. The listing is rendered into a chain of
+ * fixed chunks so a large (but max-keys bounded) page never overruns a single
+ * buffer the way the old fixed 1 MiB scratch did. */
+#define CHIMERA_S3_OUT_CHUNK (256 * 1024)
 
-static inline void
-chimera_s3_list_append(
-    char      **p,
-    const char *fmt,
+/*
+ * S3 object listing (ListObjects V1 + ListObjectsV2 + ListObjectVersions).
+ *
+ * The VFS `find` walks the bucket subtree depth-first, invoking our filter to
+ * decide descent and our callback for every entry. We collect the matching
+ * objects and rolled-up CommonPrefixes into an in-memory array, sort it
+ * lexicographically (S3 mandates sorted keys), apply the requested page window
+ * (marker / continuation-token / start-after + max-keys), and render the V1 or
+ * V2 response shape. There is no server-side cursor: each page re-walks and
+ * re-sorts, then slices past the caller's token. This is O(n) per page but
+ * correct and stateless.
+ *
+ * chimera has no object versioning: every object is its own single, latest,
+ * "null" version. ListObjectVersions therefore reuses the same collection/sort/
+ * page machinery and only differs in the rendered XML (ListVersionsResult with
+ * <Version> elements and KeyMarker pagination).
+ */
+
+/* ---------------------------------------------------------------------------
+* Chunked output builder
+* ------------------------------------------------------------------------- */
+
+struct chimera_s3_out {
+    struct evpl      *evpl;
+    struct evpl_iovec iov[CHIMERA_S3_IOV_MAX];
+    int               niov;
+    char             *base;  /* start of current chunk */
+    char             *cur;   /* write cursor within current chunk */
+    int               cap;   /* usable bytes in current chunk */
+};
+
+static void
+chimera_s3_out_init(
+    struct chimera_s3_out *o,
+    struct evpl           *evpl)
+{
+    o->evpl = evpl;
+    o->niov = 0;
+    o->base = NULL;
+    o->cur  = NULL;
+    o->cap  = 0;
+} /* chimera_s3_out_init */
+
+static void
+chimera_s3_out_flush(struct chimera_s3_out *o)
+{
+    if (o->base) {
+        evpl_iovec_set_length(&o->iov[o->niov], o->cur - o->base);
+        o->niov++;
+        o->base = NULL;
+    }
+} /* chimera_s3_out_flush */
+
+/* Ensure the current chunk has room for `need` bytes, opening a new one if
+ * not. `need` for a single append never exceeds the temp buffer in
+ * chimera_s3_out_append, which is comfortably below CHIMERA_S3_OUT_CHUNK. */
+static void
+chimera_s3_out_reserve(
+    struct chimera_s3_out *o,
+    int                    need)
+{
+    int sz;
+
+    if (o->base && (o->cur - o->base) + need <= o->cap) {
+        return;
+    }
+
+    chimera_s3_out_flush(o);
+
+    chimera_s3_abort_if(o->niov >= CHIMERA_S3_IOV_MAX,
+                        "s3 list response exceeds %d iovecs", CHIMERA_S3_IOV_MAX);
+
+    sz = need > CHIMERA_S3_OUT_CHUNK ? need : CHIMERA_S3_OUT_CHUNK;
+
+    evpl_iovec_alloc(o->evpl, sz, 0, 1, 0, &o->iov[o->niov]);
+
+    o->base = evpl_iovec_data(&o->iov[o->niov]);
+    o->cur  = o->base;
+    o->cap  = evpl_iovec_length(&o->iov[o->niov]);
+} /* chimera_s3_out_reserve */
+
+static void
+chimera_s3_out_append(
+    struct chimera_s3_out *o,
+    const char            *fmt,
     ...)
 {
+    /* Worst case for one append is a single XML element wrapping one escaped
+     * key (each byte may expand to "&quot;"/"&apos;" = 6 chars) plus fixed
+     * markup, so size for the escaped key expansion plus slack. */
+    char    tmp[CHIMERA_S3_KEY_MAX * 6 + 1024];
     va_list ap;
+    int     n;
 
     va_start(ap, fmt);
-    *p += vsprintf(*p, fmt, ap);
+    n = vsnprintf(tmp, sizeof(tmp), fmt, ap);
     va_end(ap);
-} /* chimera_s3_list_append */
 
+    if (n <= 0) {
+        return;
+    }
+    if (n >= (int) sizeof(tmp)) {
+        n = sizeof(tmp) - 1;
+    }
 
+    chimera_s3_out_reserve(o, n);
+
+    memcpy(o->cur, tmp, n);
+    o->cur += n;
+} /* chimera_s3_out_append */
+
+/* ---------------------------------------------------------------------------
+* String encoding for response values
+* ------------------------------------------------------------------------- */
+
+static inline int
+chimera_s3_url_unreserved(int c)
+{
+    return isalnum(c) || c == '-' || c == '_' || c == '.' || c == '~';
+} /* chimera_s3_url_unreserved */
+
+/* Encode a value for emission inside an XML element. When the client asked for
+ * encoding-type=url we percent-encode (which is also XML-safe); otherwise we
+ * XML-escape the metacharacters. Returns the NUL-terminated length. */
+static int
+chimera_s3_encode(
+    struct chimera_s3_request *request,
+    char                      *dst,
+    int                        cap,
+    const char                *s,
+    int                        slen)
+{
+    static const char hex[] = "0123456789ABCDEF";
+    int               o     = 0;
+    int               i;
+
+    if (request->list.encoding_url) {
+        for (i = 0; i < slen && o < cap - 4; i++) {
+            unsigned char c = (unsigned char) s[i];
+            if (chimera_s3_url_unreserved(c)) {
+                dst[o++] = (char) c;
+            } else {
+                dst[o++] = '%';
+                dst[o++] = hex[c >> 4];
+                dst[o++] = hex[c & 0xf];
+            }
+        }
+    } else {
+        for (i = 0; i < slen && o < cap - 7; i++) {
+            char c = s[i];
+            switch (c) {
+                case '&':
+                    memcpy(dst + o, "&amp;", 5); o += 5; break;
+                case '<':
+                    memcpy(dst + o, "&lt;", 4); o += 4; break;
+                case '>':
+                    memcpy(dst + o, "&gt;", 4); o += 4; break;
+                case '"':
+                    memcpy(dst + o, "&quot;", 6); o += 6; break;
+                case '\'':
+                    memcpy(dst + o, "&apos;", 6); o += 6; break;
+                default:
+                    dst[o++] = c; break;
+            } /* switch */
+        }
+    }
+
+    dst[o] = '\0';
+    return o;
+} /* chimera_s3_encode */
+
+/* ---------------------------------------------------------------------------
+* Opaque continuation tokens
+*
+* ListObjectsV2 continuation tokens are opaque to the client, which echoes
+* them back verbatim. We encode the last key of a page as base64url (no
+* padding) so the token survives both XML emission and query-string
+* round-tripping regardless of encoding-type, then decode it to recover the
+* resume key.
+* ------------------------------------------------------------------------- */
+
+static const char chimera_s3_b64url[] =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+
+static int
+chimera_s3_b64url_encode(
+    char                *dst,
+    int                  cap,
+    const unsigned char *src,
+    int                  slen)
+{
+    int o = 0, i = 0;
+
+    while (i < slen && o + 4 < cap) {
+        uint32_t v = src[i] << 16;
+        int      n = 1;
+
+        if (i + 1 < slen) {
+            v |= src[i + 1] << 8;
+            n++;
+        }
+        if (i + 2 < slen) {
+            v |= src[i + 2];
+            n++;
+        }
+
+        dst[o++] = chimera_s3_b64url[(v >> 18) & 0x3f];
+        dst[o++] = chimera_s3_b64url[(v >> 12) & 0x3f];
+        if (n >= 2) {
+            dst[o++] = chimera_s3_b64url[(v >> 6) & 0x3f];
+        }
+        if (n >= 3) {
+            dst[o++] = chimera_s3_b64url[v & 0x3f];
+        }
+        i += 3;
+    }
+
+    dst[o] = '\0';
+    return o;
+} /* chimera_s3_b64url_encode */
+
+static int
+chimera_s3_b64url_val(int c)
+{
+    if (c >= 'A' && c <= 'Z') {
+        return c - 'A';
+    }
+    if (c >= 'a' && c <= 'z') {
+        return c - 'a' + 26;
+    }
+    if (c >= '0' && c <= '9') {
+        return c - '0' + 52;
+    }
+    if (c == '-') {
+        return 62;
+    }
+    if (c == '_') {
+        return 63;
+    }
+    return -1;
+} /* chimera_s3_b64url_val */
+
+static int
+chimera_s3_b64url_decode(
+    unsigned char *dst,
+    int            cap,
+    const char    *src,
+    int            slen)
+{
+    uint32_t v    = 0;
+    int      bits = 0;
+    int      o    = 0;
+    int      i;
+
+    for (i = 0; i < slen; i++) {
+        int d = chimera_s3_b64url_val((unsigned char) src[i]);
+        if (d < 0) {
+            continue;
+        }
+        v     = (v << 6) | d;
+        bits += 6;
+        if (bits >= 8) {
+            bits -= 8;
+            if (o < cap) {
+                dst[o++] = (unsigned char) ((v >> bits) & 0xff);
+            }
+        }
+    }
+
+    return o;
+} /* chimera_s3_b64url_decode */
+
+/* ---------------------------------------------------------------------------
+* Query-parameter setup
+* ------------------------------------------------------------------------- */
+
+void
+chimera_s3_list_setup(
+    struct chimera_s3_request *request,
+    int                        list_type,
+    int                        max_keys,
+    int                        encoding_url,
+    const char                *prefix,
+    int                        prefix_len,
+    const char                *delimiter,
+    int                        delimiter_len,
+    const char                *marker,
+    int                        marker_len,
+    const char                *ctoken,
+    int                        ctoken_len,
+    const char                *startafter,
+    int                        startafter_len)
+{
+    const char *slash;
+    const char *sk  = NULL;
+    int         skl = 0;
+
+    request->is_list           = 1;
+    request->list.entries      = NULL;
+    request->list.n_entries    = 0;
+    request->list.cap_entries  = 0;
+    request->list.list_type    = (list_type == 2) ? 2 : 1;
+    request->list.encoding_url = encoding_url;
+    /* versions is set by the dispatcher after setup; default off. */
+    request->list.versions = 0;
+
+    if (max_keys < 0) {
+        max_keys = 1000;
+    }
+    if (max_keys > 1000) {
+        /* S3 returns at most 1000 keys per page regardless of the request. */
+        max_keys = 1000;
+    }
+    request->list.max_keys = max_keys;
+
+    if (prefix_len > CHIMERA_S3_KEY_MAX - 1) {
+        prefix_len = CHIMERA_S3_KEY_MAX - 1;
+    }
+    memcpy(request->list.prefix, prefix, prefix_len);
+    request->list.prefix[prefix_len] = '\0';
+    request->list.prefix_len         = prefix_len;
+
+    if (delimiter_len > CHIMERA_S3_DELIM_MAX - 1) {
+        delimiter_len = CHIMERA_S3_DELIM_MAX - 1;
+    }
+    memcpy(request->list.delimiter, delimiter, delimiter_len);
+    request->list.delimiter[delimiter_len] = '\0';
+    request->list.delimiter_len            = delimiter_len;
+
+    /* For the common '/' delimiter we can prune the VFS walk to the directory
+     * containing the prefix and never descend below it. enumdir is the prefix
+     * truncated at its last '/' (the directory whose children we enumerate). */
+    request->list.enumdir[0]  = '\0';
+    request->list.enumdir_len = 0;
+    if (delimiter_len == 1 && delimiter[0] == '/') {
+        slash = rindex(request->list.prefix, '/');
+        if (slash) {
+            int el = slash - request->list.prefix;
+            memcpy(request->list.enumdir, request->list.prefix, el);
+            request->list.enumdir[el] = '\0';
+            request->list.enumdir_len = el;
+        }
+    }
+
+    if (marker_len > CHIMERA_S3_KEY_MAX - 1) {
+        marker_len = CHIMERA_S3_KEY_MAX - 1;
+    }
+    memcpy(request->list.marker, marker, marker_len);
+    request->list.marker[marker_len] = '\0';
+    request->list.marker_len         = marker_len;
+
+    if (ctoken_len > CHIMERA_S3_KEY_MAX - 1) {
+        ctoken_len = CHIMERA_S3_KEY_MAX - 1;
+    }
+    memcpy(request->list.ctoken, ctoken, ctoken_len);
+    request->list.ctoken[ctoken_len] = '\0';
+    request->list.ctoken_len         = ctoken_len;
+
+    if (startafter_len > CHIMERA_S3_KEY_MAX - 1) {
+        startafter_len = CHIMERA_S3_KEY_MAX - 1;
+    }
+    memcpy(request->list.startafter, startafter, startafter_len);
+    request->list.startafter[startafter_len] = '\0';
+    request->list.startafter_len             = startafter_len;
+
+    /* Effective pagination start (exclusive). V2: continuation-token (an opaque
+     * base64url blob) wins over start-after; V1 uses marker. start-after and
+     * marker are real keys supplied by the caller. */
+    request->list.has_start = 0;
+    request->list.start_len = 0;
+    request->list.start[0]  = '\0';
+
+    if (request->list.list_type == 2 && ctoken_len > 0) {
+        int dl = chimera_s3_b64url_decode((unsigned char *) request->list.start,
+                                          CHIMERA_S3_KEY_MAX - 1,
+                                          request->list.ctoken, ctoken_len);
+        request->list.start[dl] = '\0';
+        request->list.start_len = dl;
+        request->list.has_start = 1;
+    } else {
+        if (request->list.list_type == 2) {
+            if (startafter_len > 0) {
+                sk  = request->list.startafter;
+                skl = startafter_len;
+            }
+        } else if (marker_len > 0) {
+            sk  = request->list.marker;
+            skl = marker_len;
+        }
+
+        if (sk) {
+            memcpy(request->list.start, sk, skl);
+            request->list.start[skl] = '\0';
+            request->list.start_len  = skl;
+            request->list.has_start  = 1;
+        }
+    }
+} /* chimera_s3_list_setup */
+
+/* ---------------------------------------------------------------------------
+* Entry collection
+* ------------------------------------------------------------------------- */
+
+static struct chimera_s3_list_entry *
+chimera_s3_list_new_entry(struct chimera_s3_request *request)
+{
+    if (request->list.n_entries == request->list.cap_entries) {
+        int newcap = request->list.cap_entries ? request->list.cap_entries * 2 : 64;
+        request->list.entries = realloc(request->list.entries,
+                                        newcap * sizeof(*request->list.entries));
+        request->list.cap_entries = newcap;
+    }
+    return &request->list.entries[request->list.n_entries++];
+} /* chimera_s3_list_new_entry */
+
+static void
+chimera_s3_list_add_object(
+    struct chimera_s3_request      *request,
+    const char                     *key,
+    int                             keylen,
+    const struct chimera_vfs_attrs *attr)
+{
+    struct chimera_s3_list_entry *e = chimera_s3_list_new_entry(request);
+
+    e->is_prefix = 0;
+    e->key       = strndup(key, keylen);
+    e->size      = attr->va_size;
+    e->mtime     = attr->va_mtime;
+    chimera_s3_compute_etag(e->etag, attr);
+} /* chimera_s3_list_add_object */
+
+static void
+chimera_s3_list_add_prefix(
+    struct chimera_s3_request *request,
+    const char                *key,
+    int                        keylen)
+{
+    struct chimera_s3_list_entry *e = chimera_s3_list_new_entry(request);
+
+    e->is_prefix = 1;
+    e->key       = strndup(key, keylen);
+    e->size      = 0;
+    e->etag[0]   = 0;
+    e->etag[1]   = 0;
+    memset(&e->mtime, 0, sizeof(e->mtime));
+} /* chimera_s3_list_add_prefix */
+
+/* Strip the single leading '/' that vfs_find prepends to every path so all
+ * comparisons run against the bucket-relative S3 key. */
+static inline const char *
+chimera_s3_list_key(
+    const char *path,
+    int         pathlen,
+    int        *keylen)
+{
+    if (pathlen > 0 && path[0] == '/') {
+        *keylen = pathlen - 1;
+        return path + 1;
+    }
+    *keylen = pathlen;
+    return path;
+} /* chimera_s3_list_key */
+
+/* ---------------------------------------------------------------------------
+* VFS find filter (descent control) and callback (collection)
+* ------------------------------------------------------------------------- */
+
+/* Returns non-zero to PRUNE (do not descend into this directory). */
 static int
 chimera_s3_list_filter(
     const char                     *path,
@@ -34,17 +497,32 @@ chimera_s3_list_filter(
     void                           *private_data)
 {
     struct chimera_s3_request *request = private_data;
-    int                        match, len = pathlen;
+    int                        klen;
+    const char                *k = chimera_s3_list_key(path, pathlen, &klen);
 
-    if (request->list.filter_len < len) {
-        len = request->list.filter_len;
+    if (request->list.delimiter_len == 1 && request->list.delimiter[0] == '/') {
+        /* Folder-style: only descend ancestors-or-equal of enumdir so we read
+        * exactly one level and roll subdirectories up into CommonPrefixes. */
+        const char *e  = request->list.enumdir;
+        int         el = request->list.enumdir_len;
+
+        if (el >= klen && memcmp(e, k, klen) == 0 &&
+            (el == klen || e[klen] == '/')) {
+            return 0;
+        }
+        return 1;
+    } else {
+        /* Flat or arbitrary-delimiter: descend any directory that is on the
+         * path to the prefix or wholly inside the prefix subtree. */
+        const char *p  = request->list.prefix;
+        int         pl = request->list.prefix_len;
+
+        if (klen >= pl) {
+            return memcmp(k, p, pl) == 0 ? 0 : 1;
+        }
+        return (memcmp(k, p, klen) == 0 && p[klen] == '/') ? 0 : 1;
     }
-
-    match = strncmp(path, request->list.filter, len);
-
-    return match != 0;
 } /* chimera_s3_list_filter */
-
 
 static int
 chimera_s3_list_find_callback(
@@ -54,67 +532,93 @@ chimera_s3_list_find_callback(
     void                           *private_data)
 {
     struct chimera_s3_request *request = private_data;
-    int                        match, len = pathlen;
-    char                       date[64], etag[64];
+    int                        klen;
+    const char                *k = chimera_s3_list_key(path, pathlen, &klen);
+    int                        isdir;
+    int                        pl = request->list.prefix_len;
+    const char                *p  = request->list.prefix;
+    int                        dl = request->list.delimiter_len;
 
     chimera_s3_abort_if((attr->va_set_mask & (CHIMERA_VFS_ATTR_FH | CHIMERA_VFS_ATTR_MASK_STAT)) !=
                         (CHIMERA_VFS_ATTR_FH | CHIMERA_VFS_ATTR_MASK_STAT),
-                        "find return missing expected attributes");
+                        "find returned without expected attributes");
 
-    if ((attr->va_mode & S_IFMT) == S_IFDIR) {
+    isdir = (attr->va_mode & S_IFMT) == S_IFDIR;
+
+    if (dl == 0) {
+        /* Flat listing: every file under the prefix is an object. */
+        if (isdir || klen < pl || memcmp(k, p, pl) != 0) {
+            return 0;
+        }
+        chimera_s3_list_add_object(request, k, klen, attr);
         return 0;
     }
 
-    if (request->list.filter_len < len) {
-        len = request->list.filter_len;
-    }
-
-    match = strncmp(path, request->list.filter, len);
-
-    if (match != 0) {
+    if (isdir) {
+        /* Only '/' subdirectories collapse to CommonPrefixes here; other
+         * delimiters are resolved over file keys below, so directories are
+         * pure traversal. */
+        if (!(dl == 1 && request->list.delimiter[0] == '/')) {
+            return 0;
+        }
+        /* The subdirectory itself is the CommonPrefix "<key>/". A directory
+         * shorter than the prefix (e.g. the enumdir we descended through) is
+         * traversal only, not a result. */
+        if (klen < pl || memcmp(k, p, pl) != 0) {
+            return 0;
+        }
+        {
+            char cp[CHIMERA_S3_KEY_MAX + 2];
+            int  n = klen < CHIMERA_S3_KEY_MAX ? klen : CHIMERA_S3_KEY_MAX;
+            memcpy(cp, k, n);
+            cp[n]     = '/';
+            cp[n + 1] = '\0';
+            chimera_s3_list_add_prefix(request, cp, n + 1);
+        }
         return 0;
-    }
-
-    chimera_s3_format_date(date, sizeof(date), &attr->va_mtime);
-
-    chimera_s3_etag_hex(etag, sizeof(etag), attr);
-
-    /* chimera_vfs_find roots every walked path with '/' (it joins an empty
-     * prefix with "/name"); S3 object keys must NOT carry a leading slash, or
-     * clients delete/address the wrong key. Strip it from the find-relative
-     * portion before emitting. */
-    while (pathlen > 0 && path[0] == '/') {
-        path++;
-        pathlen--;
-    }
-
-    /* ListObjectVersions (?versions) wraps each object in <Version> with a
-     * synthetic "null" version id; chimera does not implement S3 versioning, so
-     * every object is its own single, latest, null version. Plain ListObjects
-     * uses <Contents>. */
-    chimera_s3_list_append(&request->list.rp,
-                           request->list.versions ? " <Version>\n" : " <Contents>\n");
-
-    if (request->list.base_path_len) {
-        chimera_s3_list_append(&request->list.rp, "  <Key>%.*s/%.*s</Key>\n",
-                               request->list.base_path_len, request->list.base_path,
-                               pathlen, path);
     } else {
-        chimera_s3_list_append(&request->list.rp, "  <Key>%.*s</Key>\n", pathlen, path);
-    }
-    if (request->list.versions) {
-        chimera_s3_list_append(&request->list.rp, "  <VersionId>null</VersionId>\n");
-        chimera_s3_list_append(&request->list.rp, "  <IsLatest>true</IsLatest>\n");
-    }
-    chimera_s3_list_append(&request->list.rp, "  <LastModified>%s</LastModified>\n", date);
-    chimera_s3_list_append(&request->list.rp, "  <ETag>%s</ETag>\n", etag);
-    chimera_s3_list_append(&request->list.rp, "  <Size>%lu</Size>\n", attr->va_size);
-    chimera_s3_list_append(&request->list.rp, "  <StorageClass>STANDARD</StorageClass>\n");
-    chimera_s3_list_append(&request->list.rp,
-                           request->list.versions ? " </Version>\n" : " </Contents>\n");
+        /* File key: roll up at the first delimiter past the prefix, else it is
+         * an object directly under the prefix. */
+        const char *rest;
+        int         restlen, i, idx = -1;
 
-    return 0;
+        if (klen < pl || memcmp(k, p, pl) != 0) {
+            return 0;
+        }
+
+        rest    = k + pl;
+        restlen = klen - pl;
+
+        for (i = 0; i + dl <= restlen; i++) {
+            if (memcmp(rest + i, request->list.delimiter, dl) == 0) {
+                idx = i;
+                break;
+            }
+        }
+
+        if (idx >= 0) {
+            chimera_s3_list_add_prefix(request, k, pl + idx + dl);
+        } else {
+            chimera_s3_list_add_object(request, k, klen, attr);
+        }
+        return 0;
+    }
 } /* chimera_s3_list_find_callback */
+
+/* ---------------------------------------------------------------------------
+* Sort, page, render
+* ------------------------------------------------------------------------- */
+
+static int
+chimera_s3_list_cmp(
+    const void *a,
+    const void *b)
+{
+    const struct chimera_s3_list_entry *ea = a;
+    const struct chimera_s3_list_entry *eb = b;
+
+    return strcmp(ea->key, eb->key);
+} /* chimera_s3_list_cmp */
 
 static void
 chimera_s3_list_find_complete(
@@ -124,55 +628,236 @@ chimera_s3_list_find_complete(
     struct chimera_s3_request       *request = private_data;
     struct chimera_server_s3_thread *thread  = request->thread;
     struct evpl                     *evpl    = thread->evpl;
-    struct evpl_iovec                prefix_iov, suffix_iov;
-    char                            *prefix, *suffix;
+    struct chimera_s3_list_entry    *ents    = request->list.entries;
+    struct chimera_s3_out            out;
+    int                              n = request->list.n_entries;
+    int                              w, r, i;
+    int                              start_idx, emit, key_count;
+    int                              truncated;
+    int                              versions = request->list.versions;
+    char                             enc[CHIMERA_S3_KEY_MAX * 6 + 8];
+    const char                      *next = NULL;
+    uint64_t                         total;
 
-    evpl_iovec_alloc(evpl, 4096, 0, 1, 0, &prefix_iov);
-    evpl_iovec_alloc(evpl, 4096, 0, 1, 0, &suffix_iov);
-
-    prefix = evpl_iovec_data(&prefix_iov);
-    suffix = evpl_iovec_data(&suffix_iov);
-
-    chimera_s3_list_append(&prefix, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
-
-    if (request->list.versions) {
-        chimera_s3_list_append(&prefix,
-                               "<ListVersionsResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\n");
-        chimera_s3_list_append(&prefix, " <Name>%.*s</Name>\n", request->bucket_namelen, request->bucket_name);
-        chimera_s3_list_append(&prefix, " <Prefix>%.*s</Prefix>\n", request->list.prefix_len, request->list.prefix);
-        chimera_s3_list_append(&prefix, " <KeyMarker></KeyMarker>\n");
-        chimera_s3_list_append(&prefix, " <VersionIdMarker></VersionIdMarker>\n");
-        chimera_s3_list_append(&prefix, " <MaxKeys>%d</MaxKeys>\n", request->list.max_keys);
-        chimera_s3_list_append(&prefix, " <IsTruncated>false</IsTruncated>\n");
-    } else {
-        chimera_s3_list_append(&prefix,
-                               "<ListBucketResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\n");
-        chimera_s3_list_append(&prefix, " <Name>%.*s</Name>\n", request->bucket_namelen, request->bucket_name);
-        chimera_s3_list_append(&prefix, " <Prefix>%.*s</Prefix>\n", request->list.prefix_len, request->list.prefix);
-        //chimera_s3_list_append(&prefix, " <Marker></Marker>\n");
-        chimera_s3_list_append(&prefix, " <MaxKeys>%d</MaxKeys>\n", request->list.max_keys);
-        //chimera_s3_list_append(&prefix, " <Delimiter>/</Delimiter>\n");
-        chimera_s3_list_append(&prefix, " <IsTruncated>false</IsTruncated>\n");
+    /* S3 returns keys in lexicographic order; the VFS walk does not. */
+    if (n > 0) {
+        qsort(ents, n, sizeof(*ents), chimera_s3_list_cmp);
     }
 
-    chimera_s3_list_append(&suffix, request->list.versions ?
-                           "</ListVersionsResult>\n" : "</ListBucketResult>\n");
+    /* Collapse duplicate CommonPrefixes (an arbitrary-delimiter walk rolls
+     * many file keys into the same prefix). Duplicates are adjacent post-sort. */
+    w = 0;
+    for (r = 0; r < n; r++) {
+        if (w > 0 && ents[w - 1].is_prefix && ents[r].is_prefix &&
+            strcmp(ents[w - 1].key, ents[r].key) == 0) {
+            free(ents[r].key);
+            continue;
+        }
+        ents[w++] = ents[r];
+    }
+    n = w;
 
-    evpl_iovec_set_length(&prefix_iov, prefix - (char *) evpl_iovec_data(&prefix_iov));
-    evpl_iovec_set_length(&suffix_iov, suffix - (char *) evpl_iovec_data(&suffix_iov));
-    evpl_iovec_set_length(&request->list.response, request->list.rp - (char *) evpl_iovec_data(&request->list.response))
-    ;
+    /* Page window: skip everything at or before the caller's start key. */
+    start_idx = 0;
+    if (request->list.has_start) {
+        while (start_idx < n &&
+               strcmp(ents[start_idx].key, request->list.start) <= 0) {
+            start_idx++;
+        }
+    }
 
-    evpl_http_request_add_datav(request->http_request, &prefix_iov, 1);
-    evpl_http_request_add_datav(request->http_request, &request->list.response, 1);
-    evpl_http_request_add_datav(request->http_request, &suffix_iov, 1);
+    emit      = n - start_idx;
+    truncated = 0;
+    if (request->list.max_keys == 0) {
+        /* Degenerate request: S3 returns an empty page that is NOT truncated. */
+        emit = 0;
+    } else if (emit > request->list.max_keys) {
+        emit      = request->list.max_keys;
+        truncated = 1;
+    }
+    key_count = emit;
 
-    request->file_length = evpl_iovec_length(&prefix_iov) +
-        evpl_iovec_length(&request->list.response) +
-        evpl_iovec_length(&suffix_iov);
+    if (truncated) {
+        if (emit > 0) {
+            next = ents[start_idx + emit - 1].key;
+        } else {
+            next = request->list.start;
+        }
+    }
 
-    request->file_real_length = request->file_length;
+    /* ---- header ---- */
+    chimera_s3_out_init(&out, evpl);
+
+    chimera_s3_out_append(&out, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+
+    if (versions) {
+        chimera_s3_out_append(&out,
+                              "<ListVersionsResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\n");
+
+        chimera_s3_encode(request, enc, sizeof(enc), request->bucket_name, request->bucket_namelen);
+        chimera_s3_out_append(&out, " <Name>%s</Name>\n", enc);
+
+        chimera_s3_encode(request, enc, sizeof(enc), request->list.prefix, request->list.prefix_len);
+        chimera_s3_out_append(&out, " <Prefix>%s</Prefix>\n", enc);
+
+        chimera_s3_encode(request, enc, sizeof(enc), request->list.marker, request->list.marker_len);
+        chimera_s3_out_append(&out, " <KeyMarker>%s</KeyMarker>\n", enc);
+        chimera_s3_out_append(&out, " <VersionIdMarker></VersionIdMarker>\n");
+        if (next) {
+            chimera_s3_encode(request, enc, sizeof(enc), next, strlen(next));
+            chimera_s3_out_append(&out, " <NextKeyMarker>%s</NextKeyMarker>\n", enc);
+            chimera_s3_out_append(&out, " <NextVersionIdMarker>null</NextVersionIdMarker>\n");
+        }
+        chimera_s3_out_append(&out, " <MaxKeys>%d</MaxKeys>\n", request->list.max_keys);
+        if (request->list.delimiter_len) {
+            chimera_s3_encode(request, enc, sizeof(enc),
+                              request->list.delimiter, request->list.delimiter_len);
+            chimera_s3_out_append(&out, " <Delimiter>%s</Delimiter>\n", enc);
+        }
+        chimera_s3_out_append(&out, " <IsTruncated>%s</IsTruncated>\n",
+                              truncated ? "true" : "false");
+        if (request->list.encoding_url) {
+            chimera_s3_out_append(&out, " <EncodingType>url</EncodingType>\n");
+        }
+    } else {
+        chimera_s3_out_append(&out,
+                              "<ListBucketResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\n");
+
+        chimera_s3_encode(request, enc, sizeof(enc), request->bucket_name, request->bucket_namelen);
+        chimera_s3_out_append(&out, " <Name>%s</Name>\n", enc);
+
+        chimera_s3_encode(request, enc, sizeof(enc), request->list.prefix, request->list.prefix_len);
+        chimera_s3_out_append(&out, " <Prefix>%s</Prefix>\n", enc);
+
+        if (request->list.list_type == 2) {
+            chimera_s3_out_append(&out, " <KeyCount>%d</KeyCount>\n", key_count);
+            chimera_s3_out_append(&out, " <MaxKeys>%d</MaxKeys>\n", request->list.max_keys);
+            if (request->list.delimiter_len) {
+                chimera_s3_encode(request, enc, sizeof(enc),
+                                  request->list.delimiter, request->list.delimiter_len);
+                chimera_s3_out_append(&out, " <Delimiter>%s</Delimiter>\n", enc);
+            }
+            chimera_s3_out_append(&out, " <IsTruncated>%s</IsTruncated>\n",
+                                  truncated ? "true" : "false");
+            /* V2 always echoes the (possibly empty) ContinuationToken. */
+            chimera_s3_encode(request, enc, sizeof(enc),
+                              request->list.ctoken, request->list.ctoken_len);
+            chimera_s3_out_append(&out, " <ContinuationToken>%s</ContinuationToken>\n", enc);
+            if (next) {
+                /* base64url is unreserved, so it needs no XML/URL escaping. */
+                chimera_s3_b64url_encode(enc, sizeof(enc),
+                                         (const unsigned char *) next, strlen(next));
+                chimera_s3_out_append(&out, " <NextContinuationToken>%s</NextContinuationToken>\n", enc);
+            }
+            if (request->list.startafter_len) {
+                chimera_s3_encode(request, enc, sizeof(enc),
+                                  request->list.startafter, request->list.startafter_len);
+                chimera_s3_out_append(&out, " <StartAfter>%s</StartAfter>\n", enc);
+            }
+        } else {
+            chimera_s3_encode(request, enc, sizeof(enc),
+                              request->list.marker, request->list.marker_len);
+            chimera_s3_out_append(&out, " <Marker>%s</Marker>\n", enc);
+            if (next) {
+                chimera_s3_encode(request, enc, sizeof(enc), next, strlen(next));
+                chimera_s3_out_append(&out, " <NextMarker>%s</NextMarker>\n", enc);
+            }
+            chimera_s3_out_append(&out, " <MaxKeys>%d</MaxKeys>\n", request->list.max_keys);
+            if (request->list.delimiter_len) {
+                chimera_s3_encode(request, enc, sizeof(enc),
+                                  request->list.delimiter, request->list.delimiter_len);
+                chimera_s3_out_append(&out, " <Delimiter>%s</Delimiter>\n", enc);
+            }
+            chimera_s3_out_append(&out, " <IsTruncated>%s</IsTruncated>\n",
+                                  truncated ? "true" : "false");
+        }
+
+        if (request->list.encoding_url) {
+            chimera_s3_out_append(&out, " <EncodingType>url</EncodingType>\n");
+        }
+    }
+
+    /* ---- objects, then common prefixes (each already sorted) ---- */
+    for (i = start_idx; i < start_idx + emit; i++) {
+        struct chimera_s3_list_entry *e = &ents[i];
+        char                          date[64], etag[64];
+        char                         *hp = etag;
+
+        if (e->is_prefix) {
+            continue;
+        }
+
+        chimera_s3_format_date(date, sizeof(date), &e->mtime);
+
+        *hp++ = '"';
+        hp   += format_hex(hp, sizeof(etag) - 2, e->etag, sizeof(e->etag));
+        *hp++ = '"';
+        *hp   = '\0';
+
+        chimera_s3_encode(request, enc, sizeof(enc), e->key, strlen(e->key));
+
+        if (versions) {
+            chimera_s3_out_append(&out, " <Version>\n");
+            chimera_s3_out_append(&out, "  <Key>%s</Key>\n", enc);
+            chimera_s3_out_append(&out, "  <VersionId>null</VersionId>\n");
+            chimera_s3_out_append(&out, "  <IsLatest>true</IsLatest>\n");
+            chimera_s3_out_append(&out, "  <LastModified>%s</LastModified>\n", date);
+            chimera_s3_out_append(&out, "  <ETag>%s</ETag>\n", etag);
+            chimera_s3_out_append(&out, "  <Size>%lu</Size>\n", e->size);
+            chimera_s3_out_append(&out, "  <StorageClass>STANDARD</StorageClass>\n");
+            chimera_s3_out_append(&out, " </Version>\n");
+        } else {
+            chimera_s3_out_append(&out, " <Contents>\n");
+            chimera_s3_out_append(&out, "  <Key>%s</Key>\n", enc);
+            chimera_s3_out_append(&out, "  <LastModified>%s</LastModified>\n", date);
+            chimera_s3_out_append(&out, "  <ETag>%s</ETag>\n", etag);
+            chimera_s3_out_append(&out, "  <Size>%lu</Size>\n", e->size);
+            chimera_s3_out_append(&out, "  <StorageClass>STANDARD</StorageClass>\n");
+            chimera_s3_out_append(&out, " </Contents>\n");
+        }
+    }
+
+    for (i = start_idx; i < start_idx + emit; i++) {
+        struct chimera_s3_list_entry *e = &ents[i];
+
+        if (!e->is_prefix) {
+            continue;
+        }
+
+        chimera_s3_encode(request, enc, sizeof(enc), e->key, strlen(e->key));
+
+        chimera_s3_out_append(&out, " <CommonPrefixes>\n");
+        chimera_s3_out_append(&out, "  <Prefix>%s</Prefix>\n", enc);
+        chimera_s3_out_append(&out, " </CommonPrefixes>\n");
+    }
+
+    chimera_s3_out_append(&out, versions ?
+                          "</ListVersionsResult>\n" : "</ListBucketResult>\n");
+
+    chimera_s3_out_flush(&out);
+
+    /* ---- ship it ---- */
+    total = 0;
+    for (i = 0; i < out.niov; i++) {
+        total += evpl_iovec_length(&out.iov[i]);
+    }
+
+    if (out.niov > 0) {
+        evpl_http_request_add_datav(request->http_request, out.iov, out.niov);
+    }
+
+    request->file_length      = total;
+    request->file_real_length = total;
     request->file_offset      = 0;
+
+    /* ---- release collected entries ---- */
+    for (i = 0; i < n; i++) {
+        free(ents[i].key);
+    }
+    free(ents);
+    request->list.entries     = NULL;
+    request->list.n_entries   = 0;
+    request->list.cap_entries = 0;
 
     request->vfs_state = CHIMERA_S3_VFS_STATE_COMPLETE;
 
@@ -181,105 +866,18 @@ chimera_s3_list_find_complete(
     }
 } /* chimera_s3_list_find_complete */
 
-static void
-chimera_s3_list_lookup_path_callback(
-    enum chimera_vfs_error    error_code,
-    struct chimera_vfs_attrs *attr,
-    void                     *private_data)
-{
-    struct chimera_s3_request       *request = private_data;
-    struct chimera_server_s3_thread *thread  = request->thread;
-    const char                      *slash;
-    const void                      *root_fh;
-    int                              root_fh_len;
-
-    if (error_code || !S_ISDIR(attr->va_mode)) {
-        /* The path prefix was not a valid path, so take the largest
-         * prefix of it that must be a valid path and start the find from there */
-
-        slash = rindex(request->path, '/');
-
-        if (slash) {
-            request->list.base_path_len = slash - request->path;
-            memcpy(request->list.base_path, request->path, request->list.base_path_len);
-
-            request->list.filter_len = request->path_len - request->list.base_path_len;
-            memcpy(request->list.filter, request->path + request->list.base_path_len, request->list.filter_len);
-        } else {
-            request->list.base_path_len = 0;
-            request->list.filter_len    = request->path_len;
-            memcpy(request->list.filter, request->path, request->list.filter_len);
-        }
-
-
-        root_fh     = request->bucket_fh;
-        root_fh_len = request->bucket_fhlen;
-    } else {
-        /* Path prefix turned out to be a valid path, we can start from there */
-        memcpy(request->list.root_fh, attr->va_fh, attr->va_fh_len);
-        root_fh     = request->list.root_fh;
-        root_fh_len = attr->va_fh_len;
-
-        request->list.base_path_len = request->path_len;
-        memcpy(request->list.base_path, request->path, request->list.base_path_len);
-
-        request->list.filter_len = 0;
-    }
-
-    chimera_vfs_find(thread->vfs, &thread->shared->cred,
-                     root_fh,
-                     root_fh_len,
-                     CHIMERA_VFS_ATTR_FH | CHIMERA_VFS_ATTR_MASK_STAT,
-                     chimera_s3_list_filter,
-                     chimera_s3_list_find_callback,
-                     chimera_s3_list_find_complete,
-                     request);
-
-} /* chimera_s3_list_lookup_path_callback */
-
 void
 chimera_s3_list(
     struct evpl                     *evpl,
     struct chimera_server_s3_thread *thread,
     struct chimera_s3_request       *request)
 {
-    while (*request->path == '/') {
-        request->path++;
-        request->path_len--;
-    }
-
-    evpl_iovec_alloc(evpl, 1024 * 1024, 0, 1, 0, &request->list.response);
-
-    request->list.rp = evpl_iovec_data(&request->list.response);
-
-    if (request->path_len == 0) {
-
-        request->list.base_path_len = 0;
-        request->list.filter_len    = 0;
-
-        chimera_vfs_find(thread->vfs, &thread->shared->cred,
-                         request->bucket_fh,
-                         request->bucket_fhlen,
-                         CHIMERA_VFS_ATTR_FH | CHIMERA_VFS_ATTR_MASK_STAT,
-                         chimera_s3_list_filter,
-                         chimera_s3_list_find_callback,
-                         chimera_s3_list_find_complete,
-                         request);
-    } else {
-
-        /* If we are lucky, the path prefix is a valid path and we can start
-         * the find from that location */
-
-        chimera_vfs_lookup(
-            thread->vfs,
-            &thread->shared->cred,
-            request->bucket_fh,
-            request->bucket_fhlen,
-            request->path,
-            request->path_len,
-            CHIMERA_VFS_ATTR_FH | CHIMERA_VFS_ATTR_MASK_STAT,
-            CHIMERA_VFS_LOOKUP_FOLLOW,
-            chimera_s3_list_lookup_path_callback,
-            request);
-    }
+    chimera_vfs_find(thread->vfs, &thread->shared->cred,
+                     request->bucket_fh,
+                     request->bucket_fhlen,
+                     CHIMERA_VFS_ATTR_FH | CHIMERA_VFS_ATTR_MASK_STAT,
+                     chimera_s3_list_filter,
+                     chimera_s3_list_find_callback,
+                     chimera_s3_list_find_complete,
+                     request);
 } /* chimera_s3_list */

--- a/src/server/s3/s3_procs.h
+++ b/src/server/s3/s3_procs.h
@@ -53,6 +53,26 @@ chimera_s3_list(
     struct chimera_server_s3_thread *thread,
     struct chimera_s3_request       *request);
 
+/* Populate request->list from parsed query parameters (decoded, NUL-free).
+ * Derives the effective pagination start key and the directory boundary used
+ * to prune the VFS walk for '/'-delimited (folder-style) listings. */
+void
+chimera_s3_list_setup(
+    struct chimera_s3_request *request,
+    int                        list_type,
+    int                        max_keys,
+    int                        encoding_url,
+    const char                *prefix,
+    int                        prefix_len,
+    const char                *delimiter,
+    int                        delimiter_len,
+    const char                *marker,
+    int                        marker_len,
+    const char                *ctoken,
+    int                        ctoken_len,
+    const char                *startafter,
+    int                        startafter_len);
+
 void
 chimera_s3_delete_objects(
     struct evpl                     *evpl,


### PR DESCRIPTION
**Stacked on #699 (bucket lifecycle).** Base will become `main` once #699 merges.

Replaces the flat, readdir-order object listing with a full implementation that maps S3 listing onto the filesystem directory tree:

- **delimiter** with `CommonPrefixes` rollup (folder-style for `/`, arbitrary delimiters resolved over keys), lexicographically sorted
- **pagination**: `max-keys` + `IsTruncated`; V1 `marker`/`NextMarker`; V2 `continuation-token`/`NextContinuationToken` (opaque base64url) + `start-after`; `KeyCount`
- **`encoding-type=url`**; chunked response output
- `ListObjectVersions` reuses the same collect/sort/page machinery

The dispatcher percent-decodes list query values and recognizes `list-type`, `delimiter`, `marker`, `key-marker`, `continuation-token`, `start-after`, `encoding-type`, `fetch-owner`. Pagination is stateless (each page re-walks + re-sorts the matched subtree, then slices past the token — O(n) per page, fine for the in-memory-first stage).

Edge behaviours: `MaxKeys=0` → empty, non-truncated page; V2 always echoes `ContinuationToken` so an empty token round-trips.

**Bucket sub-resources** we don't implement (acl/policy/lifecycle/encryption/cors/…) are **accepted-and-ignored with an empty 200**, rather than mis-listed or routed to an object write that would create a junk `?subresource` key visible to NFS/SMB. ⚠️ This means security-relevant configs (bucket policy, encryption, ACL) are accepted but **not enforced** — calling it out for explicit review; happy to switch specific ones (e.g. encryption) to an error instead.

Against ceph/s3-tests this takes the listing category from 16→66 passing; verified delimiter/CommonPrefixes/KeyCount and max-keys pagination by hand.
