### PR TITLE
s3: fix SigV4 CanonicalURI double-encoding for special-char object keys

### DIFF
--- a/src/server/s3/s3_auth.c
+++ b/src/server/s3/s3_auth.c
@@ -637,37 +637,6 @@ parse_auth_header_v4(
 } /* parse_auth_header_v4 */
 
 /*
- * URL-encode a string for canonical request
- */
-static void
-url_encode(
-    const char *str,
-    char       *out,
-    int         out_max)
-{
-    const char *hex = "0123456789ABCDEF";
-    int         j   = 0;
-
-    for (int i = 0; str[i] && j < out_max - 3; i++) {
-        unsigned char c = str[i];
-        if ((c >= 'A' && c <= 'Z') ||
-            (c >= 'a' && c <= 'z') ||
-            (c >= '0' && c <= '9') ||
-            c == '-' || c == '_' || c == '.' || c == '~') {
-            out[j++] = c;
-        } else if (c == '/') {
-            /* Don't encode path separators for URI path */
-            out[j++] = c;
-        } else {
-            out[j++] = '%';
-            out[j++] = hex[(c >> 4) & 0xF];
-            out[j++] = hex[c & 0xF];
-        }
-    }
-    out[j] = '\0';
-} /* url_encode */
-
-/*
  * Compare function for qsort to sort query parameters
  */
 static int
@@ -752,7 +721,6 @@ build_canonical_request_v4(
     const char *method;
     const char *uri;
     int         uri_len;
-    char        encoded_uri[2048];
     char        payload_hash[65];
     int         offset = 0;
 
@@ -779,7 +747,23 @@ build_canonical_request_v4(
 
     offset += snprintf(canonical_request + offset, max_len - offset, "%s\n", method);
 
-    /* Canonical URI (URL-encoded path) */
+    /*
+     * Canonical URI.
+     *
+     * Per AWS SigV4, CanonicalURI is the URI-encoded request path: each path
+     * segment is RFC 3986 encoded (unreserved A-Z a-z 0-9 - _ . ~ kept
+     * literally, every other byte as %XX with UPPERCASE hex) while the '/'
+     * segment separators are left literal. For S3 the path is encoded exactly
+     * once (S3 does not double-encode the way most other services do).
+     *
+     * The client signs using that encoded path, and evpl_http_request_url()
+     * returns the request-target verbatim from the wire -- i.e. already in the
+     * exact percent-encoded form the client signed. We must therefore use it
+     * as-is. Running url_encode() over it would re-encode the '%' of each
+     * existing escape (e.g. "%20" -> "%2520"), producing a CanonicalURI that
+     * never matches the client's and rejecting every key with a space, '+',
+     * '%', or non-ASCII byte. So copy the path through unchanged.
+     */
     uri = evpl_http_request_url(request, &uri_len);
 
     /* Find query string separator */
@@ -791,16 +775,8 @@ build_canonical_request_v4(
         path_len = uri_len;
     }
 
-    /* Copy and encode just the path */
-    char        path[1024];
-    if (path_len >= (int) sizeof(path)) {
-        path_len = sizeof(path) - 1;
-    }
-    strncpy(path, uri, path_len);
-    path[path_len] = '\0';
-
-    url_encode(path, encoded_uri, sizeof(encoded_uri));
-    offset += snprintf(canonical_request + offset, max_len - offset, "%s\n", encoded_uri);
+    offset += snprintf(canonical_request + offset, max_len - offset, "%.*s\n",
+                       path_len, uri);
 
     /* Canonical Query String - must be sorted alphabetically */
     if (query) {


### PR DESCRIPTION
## Problem

Object keys containing spaces, `+`, `%`, or non-ASCII bytes failed every
request with HTTP 403 `SignatureDoesNotMatch`. This blocked a broad set of
put/get/copy/list operations against keys such as `foo+1/bar`, `quux ab/thud`,
`asdf+b`, and unicode keys.

## Root cause

The AWS SigV4 canonical-request builder (`build_canonical_request_v4` in
`src/server/s3/s3_auth.c`) ran `url_encode()` over the request path before
emitting it as the CanonicalURI.

But `evpl_http_request_url()` returns the request-target **verbatim from the
wire**, which is already in the exact percent-encoded form the client signed.
Re-encoding it percent-encoded the `%` of every existing escape:

- `%20` (space) -> `%2520`
- `%2B` (`+`)   -> `%252B`
- `%25` (`%`)   -> `%2525`

So the server's CanonicalURI never matched the client's whenever the key
contained one of those bytes, and the signature comparison failed.

Per AWS SigV4, S3 encodes the path **exactly once** (it does not double-encode
the way some other services do). The client has already performed that single
encoding, and it arrives intact on the wire.

## Fix

Emit the wire path unchanged as the CanonicalURI and drop the now-unused
`url_encode()` helper. A comment documents the encoding rule.

## Validation

Direct boto3 repro (path-style, `s3v4`) against a pre-registered bucket,
before vs. after:

| Key | Before | After |
| --- | --- | --- |
| `a b+c/d%e`     | 403 SignatureDoesNotMatch | 200 PUT+GET |
| `foo+1/bar`     | 403 | 200 |
| `quux ab/thud`  | 403 | 200 |
| `asdf+b`        | 403 | 200 |
| unicode key     | 403 | 200 |

CanonicalURI for key `a b+c/d%e`:
- before: `/reprobucket/a%2520b%252Bc/d%2525e` (double-encoded -> mismatch)
- after:  `/reprobucket/a%20b%2Bc/d%25e` (matches the client)

Regression: the `s3_test.py` suites
`put`/`get`/`head`/`list`/`delete`/`delete_objects`/`copy`/`multipart`/`streaming`
all stay green on memfs (normal, non-special keys).

## Scope note

The ceph/s3-tests `*_encoding_basic` / `unicode_metadata` / `copy_object`
cases additionally exercise the `CreateBucket` API in their fixtures, which
chimera's S3 server does not implement (buckets must be pre-registered via
config/REST), so those fixtures fail at setup independently of this signature
bug. That bucket-lifecycle gap is pre-existing and out of scope here; the
signature/path fix is validated directly against pre-registered buckets.
