### PR TITLE
smb2: implement FSCTL_LMR_REQUEST_RESILIENCY (request resiliency)

### DIFF
--- a/src/server/smb/smb2.h
+++ b/src/server/smb/smb2.h
@@ -1018,6 +1018,12 @@ typedef uint8_t smb2_guid[SMB2_GUID_SIZE];
 #define SMB2_FSCTL_SRV_COPYCHUNK_WRITE              0x001480F2
 #define SMB2_FSCTL_CREATE_OR_GET_OBJECT_ID          0x000900C0
 #define SMB2_FSCTL_SRV_ENUMERATE_SNAPSHOTS          0x00144064
+#define SMB2_FSCTL_LMR_REQUEST_RESILIENCY           0x001401D4
+
+/* Server policy for FSCTL_LMR_REQUEST_RESILIENCY: a Timeout of 0 selects the
+ * default; any larger request is capped at the maximum (MS-SMB2 3.3.5.15.9). */
+#define CHIMERA_SMB_RESILIENCY_DEFAULT_TIMEOUT_MS   120000U
+#define CHIMERA_SMB_RESILIENCY_MAX_TIMEOUT_MS       300000U
 
 #define SMB2_IO_REPARSE_TAG_NFS                     0x80000014
 #define SMB2_IO_REPARSE_TAG_SYMLINK                 0xA000000C

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -679,6 +679,9 @@ struct chimera_smb_request {
              * FILE_OBJECTID_BUFFER, type 1): ObjectId(16) + BirthVolumeId(16)
              * + BirthObjectId(16) + DomainId(16) = 64 bytes. */
             uint8_t                         oid_buffer[64];
+            /* FSCTL_LMR_REQUEST_RESILIENCY (NETWORK_RESILIENCY_REQUEST,
+             * MS-SMB2 2.2.31.3): requested resiliency Timeout in milliseconds. */
+            uint32_t                        rr_timeout_ms;
         } ioctl;
         struct {
             uint8_t                         info_type;

--- a/src/server/smb/smb_proc_ioctl.c
+++ b/src/server/smb/smb_proc_ioctl.c
@@ -213,6 +213,41 @@ chimera_smb_ioctl(struct chimera_smb_request *request)
             chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
             break;
 
+        case SMB2_FSCTL_LMR_REQUEST_RESILIENCY:
+            /* MS-SMB2 3.3.5.15.9: grant handle resiliency on the open.  The
+             * requested Timeout (ms) is capped at a server maximum; a Timeout of
+             * 0 selects the server default.  Resiliency only applies to a
+             * disk-file open — a request against a pipe is invalid. */
+            open_file = chimera_smb_open_file_resolve(request, &request->ioctl.file_id);
+
+            if (unlikely(!open_file)) {
+                chimera_smb_complete_request(request, SMB2_STATUS_FILE_CLOSED);
+                return;
+            }
+
+            if (open_file->type != CHIMERA_SMB_OPEN_FILE_TYPE_FILE) {
+                chimera_smb_open_file_release(request, open_file);
+                chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
+                return;
+            }
+
+            {
+                uint64_t timeout_ms = request->ioctl.rr_timeout_ms;
+
+                if (timeout_ms == 0) {
+                    timeout_ms = CHIMERA_SMB_RESILIENCY_DEFAULT_TIMEOUT_MS;
+                } else if (timeout_ms > CHIMERA_SMB_RESILIENCY_MAX_TIMEOUT_MS) {
+                    timeout_ms = CHIMERA_SMB_RESILIENCY_MAX_TIMEOUT_MS;
+                }
+
+                open_file->resilient            = true;
+                open_file->resilient_timeout_ms = timeout_ms;
+            }
+
+            chimera_smb_open_file_release(request, open_file);
+            chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
+            break;
+
         case SMB2_FSCTL_SRV_ENUMERATE_SNAPSHOTS:
             /* MS-SMB2 3.3.5.15.1 / MS-FSCC 2.3.20: enumerate the previous
              * versions (VSS snapshots) of the open.  We don't expose
@@ -702,6 +737,18 @@ chimera_smb_parse_ioctl(
                 }
                 break;
             }
+            case SMB2_FSCTL_LMR_REQUEST_RESILIENCY:
+                /* NETWORK_RESILIENCY_REQUEST (MS-SMB2 2.2.31.3): Timeout(4) +
+                 * Reserved(4). */
+                if (request->ioctl.input_count < 8) {
+                    chimera_smb_error("LMR_REQUEST_RESILIENCY input too small (%u < 8)",
+                                      request->ioctl.input_count);
+                    request->status = SMB2_STATUS_INVALID_PARAMETER;
+                    return -1;
+                }
+                evpl_iovec_cursor_get_uint32(request_cursor, &request->ioctl.rr_timeout_ms);
+                evpl_iovec_cursor_skip(request_cursor, 4); /* Reserved */
+                break;
             default:
                 /* Other IOCTLs don't need input parsing yet */
                 chimera_smb_info("Received IOCTL request with unhandled ctl_code 0x%08x, skipping input parsing",

--- a/src/server/smb/smb_session.h
+++ b/src/server/smb/smb_session.h
@@ -127,6 +127,12 @@ struct chimera_smb_open_file {
     uint32_t                          lease_flags;
     uint32_t                          durable_flags;
     uint64_t                          durable_timeout_ms;
+    /* FSCTL_LMR_REQUEST_RESILIENCY (MS-SMB2 2.2.31.3 / 3.3.5.15.9): set once a
+     * client has been granted handle resiliency on this open.  resilient_timeout_ms
+     * is the (server-capped) duration the open survives a network disconnect for
+     * reclaim-by-reconnect. */
+    bool                              resilient;
+    uint64_t                          resilient_timeout_ms;
     uint8_t                           lease_key[16];
     uint8_t                           parent_lease_key[16];
     uint8_t                           create_guid[16];

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -224,7 +224,9 @@ if(CHIMERA_NETNS_TESTING AND WPTS_DOTNET AND WPTS_SMB2_DLL AND WPTS_ARCH_SUPPORT
     # against the current server.  Left out: *_WithDifferentDurableOwner /
     # BVT_PersistentHandles (need a second user account / scale-out config the
     # harness doesn't provide — they report Inconclusive/NotExecuted), and the
-    # Replay IoCtl/Lock cases (replay-eligibility not yet cleared on those ops).
+    # Replay Lock cases (replay-eligibility not yet cleared on that op).  The
+    # Replay IoCtl cases use FSCTL_LMR_REQUEST_RESILIENCY as their vehicle and
+    # are applicable now that the server grants request-resiliency.
     set(WPTS_SMB2_PERSISTENT_ALLOWLIST
         BVT_DurableHandleV1_Reconnect_WithBatchOplock
         BVT_DurableHandleV1_Reconnect_WithLeaseV1
@@ -252,12 +254,14 @@ if(CHIMERA_NETNS_TESTING AND WPTS_DOTNET AND WPTS_SMB2_DLL AND WPTS_ARCH_SUPPORT
         DurableHandleV2_WithLeaseV2_WithoutHandleCaching
         PersistentHandle_ReOpenFromDiffClient
         Replay_NonPersistentHandle_Flush_ReplayEligibleCleared
+        Replay_NonPersistentHandle_IoCtl_ReplayEligibleCleared
         Replay_NonPersistentHandle_QueryInfo_ReplayEligibleCleared
         Replay_NonPersistentHandle_Read_ReplayEligibleCleared
         Replay_NonPersistentHandle_SetInfo_ReplayEligibleCleared
         Replay_NonPersistentHandle_Write_ReplayEligibleCleared
         Replay_PersistentHandle_ChangeNotify_ReplayEligibleCleared
         Replay_PersistentHandle_Flush_ReplayEligibleCleared
+        Replay_PersistentHandle_IoCtl_ReplayEligibleCleared
         Replay_PersistentHandle_QueryDirectory_ReplayEligibleCleared
         Replay_PersistentHandle_QueryInfo_ReplayEligibleCleared
         Replay_PersistentHandle_Read_ReplayEligibleCleared


### PR DESCRIPTION
## Root cause

chimera's SMB2 ioctl dispatch (`src/server/smb/smb_proc_ioctl.c`) had no case for **`FSCTL_LMR_REQUEST_RESILIENCY`** (ctl_code `0x001401D4`), so the request fell through to `STATUS_NOT_SUPPORTED`. The MS-SMB2 `Replay_*_IoCtl_ReplayEligibleCleared` WPTS cases use this FSCTL as their replay vehicle, so the WPTS SDK threw `Unexpected status STATUS_NOT_SUPPORTED for IOCTL` at test setup — before any replay logic ran. (Confirmed via the daemon log: `Received IOCTL request with unhandled ctl_code 0x001401d4`.) The header replay / ChannelSequence handling these tests assert was already correct (the analogous `*_Lock`/`*_Read`/etc. cases pass); the only gap was the missing FSCTL.

## What's implemented (MS-SMB2 2.2.31.3 / 3.3.5.15.9)

- `SMB2_FSCTL_LMR_REQUEST_RESILIENCY 0x001401D4` define + server timeout policy constants.
- Parse the 8-byte `NETWORK_RESILIENCY_REQUEST` (`Timeout` ms + `Reserved`).
- Dispatch case: resolve the open, reject a request on a non-file (pipe) handle with `STATUS_INVALID_PARAMETER`, record the resilient grant + a server-capped timeout on the open (`Timeout == 0` selects the default; over-max is clamped), and return `STATUS_SUCCESS` with empty output.
- Record the grant on the open: new `resilient` flag + `resilient_timeout_ms` on `struct chimera_smb_open_file` (not just a blind SUCCESS).

The Replay tests exercise replay-eligibility on the **same** connection and only needed the FSCTL to succeed — no disconnect/reconnect, so the durable-park machinery was not required here.

## WPTS cases enabled (persistent allowlist)

- `Replay_NonPersistentHandle_IoCtl_ReplayEligibleCleared`
- `Replay_PersistentHandle_IoCtl_ReplayEligibleCleared`

Both pass via the real ctest path. The full persistent allowlist (39 cases) stays 100% green, and smbtorture durable/create/lease/oplock/lock stays green.

## Follow-up

Full resilient-handle support — disconnect survival via the durable-park path, reconnect reclaim, and the scavenger timer (the six Resilient-Handle BVT cases) — is a scoped follow-up. Those cases were verified to **not** hang or crash the daemon with this change (they remain Failed; the daemon stayed up across the full 10-minute scavenger-timer run).