### PR TITLE
s3: validate max-keys and emit Owner on ListObjectsV2 fetch-owner

### DIFF
--- a/src/server/s3/s3.c
+++ b/src/server/s3/s3.c
@@ -569,6 +569,8 @@ s3_server_dispatch(
             int         max_keys       = 1000;
             int         list_type      = 1;
             int         encoding_url   = 0;
+            int         fetch_owner    = 0;
+            int         bad_max_keys   = 0;
             /* Set when the query carries a key we don't recognize as a list
              * parameter or handled subresource: an unimplemented bucket/object
              * subresource (acl/policy/tagging/cors/lifecycle/...). */
@@ -617,7 +619,20 @@ s3_server_dispatch(
                     prefix_len = chimera_s3_pct_decode(prefix_buf, sizeof(prefix_buf),
                                                        value_start, value_len);
                 } else if (key_len == 8 && memcmp(key_start, "max-keys", 8) == 0) {
-                    max_keys = atoi(value_start);
+                    /* max-keys must be a non-negative integer; a non-numeric or
+                     * empty value is an InvalidArgument (400), not a silent 0. */
+                    int mk_valid = (value_len > 0);
+                    for (int mi = 0; mi < value_len; mi++) {
+                        if (value_start[mi] < '0' || value_start[mi] > '9') {
+                            mk_valid = 0;
+                            break;
+                        }
+                    }
+                    if (mk_valid) {
+                        max_keys = atoi(value_start);
+                    } else {
+                        bad_max_keys = 1;
+                    }
                 } else if (key_len == 9 && memcmp(key_start, "list-type", 9) == 0) {
                     list_type = atoi(value_start);
                 } else if (key_len == 9 && memcmp(key_start, "delimiter", 9) == 0) {
@@ -640,9 +655,12 @@ s3_server_dispatch(
                     if (value_len == 3 && strncasecmp(value_start, "url", 3) == 0) {
                         encoding_url = 1;
                     }
-                } else if ((key_len == 11 && memcmp(key_start, "fetch-owner", 11) == 0) ||
-                           (key_len == 17 && memcmp(key_start, "version-id-marker", 17) == 0)) {
-                    /* Recognized list parameters we accept but don't act on. */
+                } else if (key_len == 11 && memcmp(key_start, "fetch-owner", 11) == 0) {
+                    /* V2: emit <Owner> in each <Contents> when true. */
+                    fetch_owner = (value_len == 4 &&
+                                   strncasecmp(value_start, "true", 4) == 0);
+                } else if (key_len == 17 && memcmp(key_start, "version-id-marker", 17) == 0) {
+                    /* Recognized list parameter we accept but don't act on. */
                 } else {
                     /* Unrecognized query key: an unimplemented subresource. */
                     saw_unknown = 1;
@@ -712,6 +730,14 @@ s3_server_dispatch(
                     s3_request->file_offset      = 0;
                     s3_request->vfs_state        = CHIMERA_S3_VFS_STATE_COMPLETE;
                     s3_request->op_bucket        = 1;
+                } else if (bad_max_keys) {
+                    /* A non-numeric/empty max-keys is an InvalidArgument (400). */
+                    s3_request->status           = CHIMERA_S3_STATUS_BAD_REQUEST;
+                    s3_request->file_length      = 0;
+                    s3_request->file_real_length = 0;
+                    s3_request->file_offset      = 0;
+                    s3_request->vfs_state        = CHIMERA_S3_VFS_STATE_COMPLETE;
+                    s3_request->op_bucket        = 1;
                 } else {
                     /* Bucket-level LIST query (ListObjects V1/V2 or
                      * ListObjectVersions). */
@@ -721,7 +747,8 @@ s3_server_dispatch(
                                           marker_buf, marker_len,
                                           ctoken_buf, ctoken_len,
                                           startafter_buf, startafter_len);
-                    s3_request->list.versions = s3_request->has_versions;
+                    s3_request->list.versions    = s3_request->has_versions;
+                    s3_request->list.fetch_owner = fetch_owner;
                 }
             } else {
                 /* Path has '?' mid-string but no recognized subresource: strip

--- a/src/server/s3/s3_internal.h
+++ b/src/server/s3/s3_internal.h
@@ -142,6 +142,7 @@ struct chimera_s3_request {
             int                           marker_len;     /* V1 marker echo */
             int                           ctoken_len;     /* V2 continuation-token echo */
             int                           startafter_len; /* V2 start-after echo */
+            int                           fetch_owner;    /* V2 fetch-owner=true */
             int                           n_entries;
             int                           cap_entries;
             struct chimera_s3_list_entry *entries;

--- a/src/server/s3/s3_list.c
+++ b/src/server/s3/s3_list.c
@@ -324,8 +324,10 @@ chimera_s3_list_setup(
     request->list.cap_entries  = 0;
     request->list.list_type    = (list_type == 2) ? 2 : 1;
     request->list.encoding_url = encoding_url;
-    /* versions is set by the dispatcher after setup; default off. */
-    request->list.versions = 0;
+    /* versions and fetch_owner are set by the dispatcher after setup;
+     * default off. */
+    request->list.versions    = 0;
+    request->list.fetch_owner = 0;
 
     if (max_keys < 0) {
         max_keys = 1000;
@@ -813,6 +815,13 @@ chimera_s3_list_find_complete(
             chimera_s3_out_append(&out, "  <ETag>%s</ETag>\n", etag);
             chimera_s3_out_append(&out, "  <Size>%lu</Size>\n", e->size);
             chimera_s3_out_append(&out, "  <StorageClass>STANDARD</StorageClass>\n");
+            if (request->list.fetch_owner) {
+                /* V2 fetch-owner=true: same canonical owner as ListBuckets/ACL. */
+                chimera_s3_out_append(&out, "  <Owner>\n");
+                chimera_s3_out_append(&out, "   <ID>chimera</ID>\n");
+                chimera_s3_out_append(&out, "   <DisplayName>chimera</DisplayName>\n");
+                chimera_s3_out_append(&out, "  </Owner>\n");
+            }
             chimera_s3_out_append(&out, " </Contents>\n");
         }
     }


### PR DESCRIPTION
Finishes the ListObjects edge cases on the S3 server.

## Changes

1. **Validate `max-keys`** — a non-numeric or empty `max-keys` value (e.g. `max-keys=blah`) previously passed through `atoi()` and silently became `0`. The dispatch query parser now validates the value is a non-negative integer and short-circuits to a `400 InvalidArgument` (`CHIMERA_S3_STATUS_BAD_REQUEST`) otherwise.

2. **V2 `fetch-owner`** — `fetch-owner=true` on a ListObjectsV2 request was recognized but ignored. Each `<Contents>` entry now includes an `<Owner>` element (with `<ID>` and `<DisplayName>`) using the same canonical `chimera` owner that ListBuckets/ACL emit. The flag was appended to the list request struct and threaded through the dispatcher (mirroring `versions`).

3. **Delimiter with special characters** — investigated the arbitrary-delimiter rollup path. The existing logic (descend the whole prefix subtree, then roll up file keys at the first delimiter substring past the prefix) already handles non-`/` delimiters correctly; the `_dot` and `_alt` ceph tests confirm this. No change needed.

## Test results (ceph/s3-tests, `-k "delimiter or maxkeys or fetchowner"`, isolated per-test)

- `test_bucket_list_maxkeys_invalid`: FAIL -> PASS
- `test_bucket_listv2_fetchowner_notempty`: FAIL -> PASS
- `test_bucket_listv2_fetchowner_defaultempty` / `_empty`: PASS (unchanged)
- No listing regressions: same 35 pass / 8 pre-existing fails as the base branch.

The remaining delimiter failures (`whitespace`, `percentage`, `not_skip_special`, `*_basic`) are **pre-existing** and fail identically on the base branch — they fail at `PutObject` with `SignatureDoesNotMatch` on keys containing spaces / `%` / `#`, an auth-canonicalization issue outside the listing path.

`s3_test.py` regression suite (memfs): all of put/get/head/list/delete/delete_objects/copy/multipart/streaming pass.
