### PR TITLE
smb2: ChannelSequence tracking + DH2Q create_guid replay

### DIFF
--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -1090,6 +1090,12 @@ chimera_smb_server_handle_smb2(
 
         left -= sizeof(request->smb2_hdr);
 
+        /* Capture the per-request ChannelSequence (low 16 bits of the field the
+         * header struct calls "status" on a request) and the replay flag for
+         * MS-SMB2 §3.3.5.2.10 stale-write detection and create-context replay. */
+        request->channel_sequence = (uint16_t) (request->smb2_hdr.status & 0xFFFF);
+        request->is_replay        = (request->smb2_hdr.flags & SMB2_FLAGS_REPLAY_OPERATION) ? 1 : 0;
+
         signature_cursor = *request_cursor;
 
         /* We only need to validate that we are using SMB2 at this point */

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -296,6 +296,13 @@ struct chimera_smb_request {
         struct smb1_header smb1_hdr;
         struct smb2_header smb2_hdr;
     };
+    /* MS-SMB2 §3.2.4.1.5 / §3.3.5.2.10: on a request the 4 bytes the header
+     * struct calls "status" are ChannelSequence(2)+Reserved(2); captured here
+     * (the reply emits the separate request->status field, so reading them off
+     * smb2_hdr.status never corrupts the response Status).  is_replay mirrors
+     * the SMB2_FLAGS_REPLAY_OPERATION header flag. */
+    uint16_t                           channel_sequence;
+    uint8_t                            is_replay;
     struct chimera_smb_session_handle *session_handle;
     struct chimera_smb_tree           *tree;
     struct chimera_smb_compound       *compound;
@@ -424,6 +431,12 @@ struct chimera_smb_request {
             * DesiredAccess / CreateOptions / etc. fields entirely, so the
             * getattr-reply callback must not re-run the ACL access check. */
             uint8_t                         reconnect;
+            /* Set by the DH2Q create_guid replay path (MS-SMB2 §3.3.5.9.7): this
+             * CREATE re-presents an already-completed create, so the reply must
+             * echo the ORIGINAL handle's create_action (stored on the open) and,
+             * for an oplock (non-lease) handle, the REQUESTED oplock level rather
+             * than the granted one. */
+            uint8_t                         replay;
             /* CREATE contexts the client sent (CHIMERA_SMB_CREATE_CTX_* bits).
              * Phase-0 stubs set the bit and capture a minimum set of fields needed
              * by the response emit; Phase 1/3 will populate the rest. */
@@ -1936,6 +1949,42 @@ chimera_smb_open_file_resolve(
 
     return open_file;
 } /* chimera_smb_open_file_resolve */
+
+/*
+ * MS-SMB2 §3.3.5.2.10 "Verifying the Channel Sequence Number".  Compare the
+ * request's ChannelSequence against the highest seen on this Open.  Returns true
+ * when the op must be rejected as stale (only mutating ops -- WRITE/SET_INFO/
+ * IOCTL -- reject; READ tolerates a stale sequence).  An equal-or-ahead sequence
+ * advances the Open's tracked value; a behind sequence (delta in [0x8000,0xFFFF]
+ * mod 0x10000) is stale.  The first op on a not-yet-seeded Open just seeds it
+ * (opens are normally seeded from the CREATE's sequence at grant time).
+ */
+static inline bool
+chimera_smb_channel_sequence_stale(
+    struct chimera_smb_open_file *open_file,
+    uint16_t                      req_cs,
+    int                           mutating)
+{
+    uint16_t delta;
+
+    if (!open_file->channel_sequence_valid) {
+        open_file->channel_sequence       = req_cs;
+        open_file->channel_sequence_valid = 1;
+        return false;
+    }
+
+    delta = (uint16_t) (req_cs - open_file->channel_sequence);
+
+    if (delta >= 0x8000) {
+        /* Stale (behind).  Mutating ops are rejected; reads proceed without
+         * advancing the tracked sequence. */
+        return mutating ? true : false;
+    }
+
+    /* Equal or ahead: this becomes the new high-water sequence. */
+    open_file->channel_sequence = req_cs;
+    return false;
+} /* chimera_smb_channel_sequence_stale */
 
 /*
  * Resolve the open_file that owns the caching lease registered under `lease_key`

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -374,6 +374,11 @@ chimera_smb_create_gen_open_file(
     open_file->position        = 0;
     open_file->pipe_transceive = transceive;
     open_file->refcnt          = 2;
+    /* Seed MS-SMB2 §3.3.5.2.10 channel-sequence tracking from the CREATE's
+     * sequence so the first mutating op is compared against the right baseline
+     * (the open_file pool is reused without zeroing). */
+    open_file->channel_sequence       = request->channel_sequence;
+    open_file->channel_sequence_valid = 1;
     /* Identify the owning conn/tree up front so an AppInstanceId force-close can
      * locate this open from the share-lease back-reference even when no caching
      * lease (which also sets create_conn) is granted. */
@@ -2582,6 +2587,9 @@ chimera_smb_durable_reconnect(struct chimera_smb_request *request)
     open_file->create_conn = request->compound->conn;
     open_file->file_id.vid = chimera_rand64();
     open_file->refcnt      = 2;
+    /* Reseed the channel-sequence baseline from the reconnecting CREATE. */
+    open_file->channel_sequence       = request->channel_sequence;
+    open_file->channel_sequence_valid = 1;
 
     bucket = open_file->file_id.vid & CHIMERA_SMB_OPEN_FILE_BUCKET_MASK;
     pthread_mutex_lock(&tree->open_files_lock[bucket]);
@@ -2713,6 +2721,88 @@ chimera_smb_path_begins_with_dotdot(
            (len >= 3 && path[0] == '.' && path[1] == '.' && path[2] == '/');
 } /* chimera_smb_path_begins_with_dotdot */
 
+/*
+ * MS-SMB2 §3.3.5.9.7/.10: a CREATE that carries a DurableHandleRequestV2 (DH2Q)
+ * create_guid matching a still-live open from the same client is a *replay* of
+ * the original create -- the server returns the existing open instead of opening
+ * a second handle (or returning a sharing violation).  This is distinct from a
+ * DH2C/DHnC reconnect (which targets a *parked* handle by persistent id).
+ *
+ * Returns 1 if the request was handled here (replay matched, or rejected with
+ * ACCESS_DENIED on a type/key mismatch) -- the caller must return.  Returns 0 if
+ * no live open carries this create_guid, so the caller proceeds with a fresh
+ * create.
+ */
+static int
+chimera_smb_create_guid_replay(struct chimera_smb_request *request)
+{
+    struct chimera_smb_tree          *tree = request->tree;
+    struct chimera_smb_open_file     *of, *tmp, *match = NULL;
+    struct chimera_server_smb_thread *thread = request->compound->thread;
+    int                               b;
+    bool                              req_is_lease, open_is_lease;
+
+    for (b = 0; b < CHIMERA_SMB_OPEN_FILE_BUCKETS && !match; b++) {
+        pthread_mutex_lock(&tree->open_files_lock[b]);
+        HASH_ITER(hh, tree->open_files[b], of, tmp)
+        {
+            if ((of->ctx_present_mask & CHIMERA_SMB_CREATE_CTX_DH2Q) &&
+                !(of->flags & (CHIMERA_SMB_OPEN_FILE_CLOSED |
+                               CHIMERA_SMB_OPEN_FILE_PARKED)) &&
+                memcmp(of->create_guid, request->create.dh2q.create_guid, 16) == 0) {
+                of->refcnt++;   /* held for this request; getattr cb releases it */
+                match = of;
+                break;
+            }
+        }
+        pthread_mutex_unlock(&tree->open_files_lock[b]);
+    }
+
+    if (!match) {
+        return 0;
+    }
+
+    /* A replay that asks for a different handle type (oplock vs lease), or a
+     * lease with a different key than the live open holds, is rejected with
+     * ACCESS_DENIED (MS-SMB2 dhv2 oplock_lease / lease_oplock / lease3). */
+    req_is_lease  = (request->create.ctx_present_mask & CHIMERA_SMB_CREATE_CTX_RQLS) != 0;
+    open_is_lease = (match->oplock_level == SMB2_OPLOCK_LEVEL_LEASE);
+
+    if (req_is_lease != open_is_lease ||
+        (req_is_lease &&
+         memcmp(match->lease_key, request->create.rqls.key, 16) != 0)) {
+        chimera_smb_open_file_release(request, match);
+        chimera_smb_complete_request(request, SMB2_STATUS_ACCESS_DENIED);
+        return 1;
+    }
+
+    /* A coalesced lease may have been upgraded by a sibling open since this
+     * handle was first granted; report the grant's CURRENT granted mode rather
+     * than this open's possibly-stale cached copy (MS-SMB2 replay-dhv2-lease1/2,
+     * which upgrade RH->RWH then replay the original RH create). */
+    if (open_is_lease && match->grant) {
+        match->lease_state =
+            chimera_smb_vfs_to_lease_bits(match->grant->lease.mode.granted);
+    }
+
+    /* Replay: return the existing open via the reconnect reply path.  reconnect=1
+     * skips the ACL re-check; replay=1 makes the reply echo the original
+     * create_action and (for an oplock handle) the requested oplock level.  The
+     * create_disposition is left as the request's own so it is not consulted. */
+    request->create.r_open_file      = match;
+    request->create.reconnect        = 1;
+    request->create.replay           = 1;
+    request->compound->saved_file_id = match->file_id;
+
+    chimera_vfs_getattr(thread->vfs_thread,
+                        &request->session_handle->session->cred,
+                        match->handle,
+                        CHIMERA_VFS_ATTR_MASK_STAT,
+                        chimera_smb_create_open_getattr_callback,
+                        request);
+    return 1;
+} /* chimera_smb_create_guid_replay */
+
 void
 chimera_smb_create(struct chimera_smb_request *request)
 {
@@ -2818,6 +2908,7 @@ chimera_smb_create(struct chimera_smb_request *request)
      * reclaim) or chimera_smb_create_persist_prepare for a fresh grant. */
     request->create.persist_pid = 0;
     request->create.reconnect   = 0;
+    request->create.replay      = 0;
     /* Default share-conflict status; an AppInstanceId version reject overrides
      * it with STATUS_FILE_FORCED_CLOSED inside gen_open_file. */
     request->create.force_close_status = SMB2_STATUS_SHARING_VIOLATION;
@@ -2858,6 +2949,16 @@ chimera_smb_create(struct chimera_smb_request *request)
          * ignores all create fields, so it runs before the DOC access check. */
         if (is_durable_reconnect) {
             chimera_smb_durable_reconnect(request);
+            return;
+        }
+
+        /* MS-SMB2 3.3.5.9.7: a DH2Q create whose create_guid matches a live
+         * open is a replay of the original create -- return the existing handle
+         * rather than opening a second one.  Runs before the field validations
+         * below since a replay re-presents the original (already-validated)
+         * request. */
+        if ((request->create.ctx_present_mask & CHIMERA_SMB_CREATE_CTX_DH2Q) &&
+            chimera_smb_create_guid_replay(request)) {
             return;
         }
 
@@ -3057,6 +3158,17 @@ build_dh2q_response(
         return -1;
     }
 
+    /* On an oplock (non-lease) create_guid replay, a durable response is emitted
+     * only if the REQUESTED oplock could itself have been granted a durable
+     * handle (batch); a replay asking for a lesser oplock gets no durable
+     * response at all (MS-SMB2 replay-dhv2-oplock2 expects durable_open_v2=false,
+     * timeout=0, no blobs). */
+    if (request->create.replay &&
+        of->oplock_level != SMB2_OPLOCK_LEVEL_LEASE &&
+        request->create.requested_oplock_level != SMB2_OPLOCK_LEVEL_BATCH) {
+        return -1;
+    }
+
     timeout = (uint32_t) of->durable_timeout_ms;
     flags   = (of->durable_flags & CHIMERA_SMB_DURABLE_PERSISTENT) ?
         SMB2_DHANDLE_FLAG_PERSISTENT : 0;
@@ -3177,11 +3289,21 @@ chimera_smb_create_reply(
     evpl_iovec_cursor_append_uint16(reply_cursor, SMB2_CREATE_REPLY_SIZE);
 
     /* Oplock level — granted at CREATE time and stored on the open_file
-     * by the CACHING acquire above; defaults to NONE if no lease. */
-    evpl_iovec_cursor_append_uint8(reply_cursor,
-                                   request->create.r_open_file
-                                   ? request->create.r_open_file->oplock_level
-                                   : SMB2_OPLOCK_LEVEL_NONE);
+     * by the CACHING acquire above; defaults to NONE if no lease.  On a DH2Q
+     * create_guid replay of an oplock (non-lease) handle the response echoes the
+     * REQUESTED oplock level, not the granted one (MS-SMB2 replay-dhv2-oplock2);
+     * a lease handle always reports its current (shared, possibly upgraded)
+     * state, so it is exempt. */
+    uint8_t reply_oplock_level = SMB2_OPLOCK_LEVEL_NONE;
+    if (request->create.r_open_file) {
+        if (request->create.replay &&
+            request->create.r_open_file->oplock_level != SMB2_OPLOCK_LEVEL_LEASE) {
+            reply_oplock_level = request->create.requested_oplock_level;
+        } else {
+            reply_oplock_level = request->create.r_open_file->oplock_level;
+        }
+    }
+    evpl_iovec_cursor_append_uint8(reply_cursor, reply_oplock_level);
 
     /* Flags */
     evpl_iovec_cursor_append_uint8(reply_cursor, 0);
@@ -3191,6 +3313,13 @@ chimera_smb_create_reply(
      * file already existed — the VFS open reports that via handle->r_created. */
     uint32_t create_action;
     bool     created = request->create.r_created;
+
+    if (request->create.replay && request->create.r_open_file) {
+        /* A replay re-presents the original create; report the action recorded
+         * when the handle was first opened (MS-SMB2 replay-dhv2-*). */
+        create_action = request->create.r_open_file->create_action;
+        goto have_create_action;
+    }
 
     switch (request->create.create_disposition) {
         case SMB2_FILE_CREATE:
@@ -3216,6 +3345,14 @@ chimera_smb_create_reply(
             create_action = SMB2_CREATE_ACTION_OPENED;
             break;
     } /* switch */
+
+    /* Record the action on a fresh open so a later DH2Q create_guid replay can
+     * report it verbatim (a replay branches above and does not re-record). */
+    if (request->create.r_open_file) {
+        request->create.r_open_file->create_action = create_action;
+    }
+
+ have_create_action:
 
     evpl_iovec_cursor_append_uint32(reply_cursor, create_action);
 

--- a/src/server/smb/smb_proc_ioctl.c
+++ b/src/server/smb/smb_proc_ioctl.c
@@ -183,6 +183,15 @@ chimera_smb_ioctl(struct chimera_smb_request *request)
                 return;
             }
 
+            /* MS-SMB2 §3.3.5.2.10: IOCTL is in the channel-sequence-checked set;
+             * a stale sequence is rejected with FILE_NOT_AVAILABLE. */
+            if (chimera_smb_channel_sequence_stale(open_file,
+                                                   request->channel_sequence, 1)) {
+                chimera_smb_open_file_release(request, open_file);
+                chimera_smb_complete_request(request, SMB2_STATUS_FILE_NOT_AVAILABLE);
+                return;
+            }
+
             if (request->ioctl.max_output_response < 64) {
                 chimera_smb_open_file_release(request, open_file);
                 chimera_smb_complete_request(request, SMB2_STATUS_BUFFER_TOO_SMALL);

--- a/src/server/smb/smb_proc_read.c
+++ b/src/server/smb/smb_proc_read.c
@@ -138,6 +138,12 @@ chimera_smb_read(struct chimera_smb_request *request)
         return;
     }
 
+    /* MS-SMB2 §3.3.5.2.10: a READ is never rejected for a stale ChannelSequence,
+     * but it still advances the Open's tracked sequence (the third argument 0
+     * marks this as a non-mutating op). */
+    chimera_smb_channel_sequence_stale(request->read.open_file,
+                                       request->channel_sequence, 0);
+
     struct chimera_vfs_lease_owner io_owner = {
         .protocol   = CHIMERA_VFS_LEASE_PROTO_SMB2,
         .client_key = request->session_handle->session->client_key,

--- a/src/server/smb/smb_proc_set_info.c
+++ b/src/server/smb/smb_proc_set_info.c
@@ -221,6 +221,15 @@ chimera_smb_set_info(struct chimera_smb_request *request)
         return;
     }
 
+    /* MS-SMB2 §3.3.5.2.10: SET_INFO is a mutating op; reject a stale
+     * ChannelSequence with FILE_NOT_AVAILABLE. */
+    if (chimera_smb_channel_sequence_stale(request->set_info.open_file,
+                                           request->channel_sequence, 1)) {
+        chimera_smb_open_file_release(request, request->set_info.open_file);
+        chimera_smb_complete_request(request, SMB2_STATUS_FILE_NOT_AVAILABLE);
+        return;
+    }
+
     switch (request->set_info.info_type) {
         case SMB2_INFO_FILE:
             switch (request->set_info.info_class) {

--- a/src/server/smb/smb_proc_write.c
+++ b/src/server/smb/smb_proc_write.c
@@ -217,6 +217,17 @@ chimera_smb_write(struct chimera_smb_request *request)
         return;
     }
 
+    /* MS-SMB2 §3.3.5.2.10: a WRITE carrying a stale ChannelSequence (the client
+     * has since failed over to a higher sequence) must be rejected with
+     * FILE_NOT_AVAILABLE so a delayed retry cannot clobber newer data. */
+    if (chimera_smb_channel_sequence_stale(request->write.open_file,
+                                           request->channel_sequence, 1)) {
+        evpl_iovecs_release(evpl, request->write.iov, request->write.niov);
+        chimera_smb_open_file_release(request, request->write.open_file);
+        chimera_smb_complete_request(request, SMB2_STATUS_FILE_NOT_AVAILABLE);
+        return;
+    }
+
     /* When the open holds a caching lease, use the lease's owner identity for
      * the write so chimera_vfs_break_reads_for_write self-exempts (mode.granted
      * & MODE_W AND owner_equal): the holder is writing through its own granted

--- a/src/server/smb/smb_session.h
+++ b/src/server/smb/smb_session.h
@@ -114,6 +114,16 @@ struct chimera_smb_open_file {
     uint64_t                          position;
     uint32_t                          parent_fh_len;
     uint32_t                          refcnt;
+    /* MS-SMB2 §3.3.5.2.10 channel-sequence tracking.  channel_sequence holds
+     * the highest ChannelSequence observed on this Open; a mutating op
+     * (WRITE/SET_INFO/IOCTL) carrying a stale sequence -- behind by
+     * [0x8000..0xFFFF] mod 0x10000 -- is rejected with FILE_NOT_AVAILABLE.
+     * READ never rejects but advances the value.  _valid gates the first op. */
+    uint16_t                          channel_sequence;
+    uint8_t                           channel_sequence_valid;
+    /* The CREATE Action reported when this handle was first opened
+     * (CREATED/OPENED/...); replayed verbatim on a DH2Q create_guid replay. */
+    uint32_t                          create_action;
     /* Phase-0 plumbing: fields populated by later phases. Zeroed on alloc. */
     uint32_t                          ctx_present_mask;
     uint8_t                           oplock_level;

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -1443,7 +1443,14 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.rename.simple_modtime
     smb2.rename.simple_nodelete
     # smb2.replay
+    smb2.replay.channel-sequence
     smb2.replay.replay-commands
+    smb2.replay.replay-dhv2-lease-oplock
+    smb2.replay.replay-dhv2-lease1
+    smb2.replay.replay-dhv2-lease2
+    smb2.replay.replay-dhv2-lease3
+    smb2.replay.replay-dhv2-oplock-lease
+    smb2.replay.replay-dhv2-oplock1
     smb2.replay.replay-regular
     smb2.replay.replay5
     smb2.replay.replay7
@@ -1749,6 +1756,7 @@ set(SMBTORTURE_ENABLED_linux
     smb2.rename.simple_modtime
     smb2.rename.simple_nodelete
     # smb2.replay
+    smb2.replay.channel-sequence
     smb2.replay.replay-commands
     smb2.replay.replay5
     smb2.replay.replay7
@@ -2029,6 +2037,7 @@ set(SMBTORTURE_ENABLED_io_uring
     smb2.rename.simple_modtime
     smb2.rename.simple_nodelete
     # smb2.replay
+    smb2.replay.channel-sequence
     smb2.replay.replay-commands
     smb2.replay.replay5
     smb2.replay.replay7
@@ -2322,7 +2331,14 @@ set(SMBTORTURE_ENABLED_cairn
     smb2.rename.simple_modtime
     smb2.rename.simple_nodelete
     # smb2.replay
+    smb2.replay.channel-sequence
     smb2.replay.replay-commands
+    smb2.replay.replay-dhv2-lease-oplock
+    smb2.replay.replay-dhv2-lease1
+    smb2.replay.replay-dhv2-lease2
+    smb2.replay.replay-dhv2-lease3
+    smb2.replay.replay-dhv2-oplock-lease
+    smb2.replay.replay-dhv2-oplock1
     smb2.replay.replay-regular
     smb2.replay.replay5
     smb2.replay.replay7
@@ -2640,7 +2656,14 @@ set(SMBTORTURE_ENABLED_diskfs_io_uring
     smb2.rename.simple_modtime
     smb2.rename.simple_nodelete
     # smb2.replay
+    smb2.replay.channel-sequence
     smb2.replay.replay-commands
+    smb2.replay.replay-dhv2-lease-oplock
+    smb2.replay.replay-dhv2-lease1
+    smb2.replay.replay-dhv2-lease2
+    smb2.replay.replay-dhv2-lease3
+    smb2.replay.replay-dhv2-oplock-lease
+    smb2.replay.replay-dhv2-oplock1
     smb2.replay.replay-regular
     smb2.replay.replay5
     smb2.replay.replay7
@@ -2958,7 +2981,14 @@ set(SMBTORTURE_ENABLED_diskfs_aio
     smb2.rename.simple_modtime
     smb2.rename.simple_nodelete
     # smb2.replay
+    smb2.replay.channel-sequence
     smb2.replay.replay-commands
+    smb2.replay.replay-dhv2-lease-oplock
+    smb2.replay.replay-dhv2-lease1
+    smb2.replay.replay-dhv2-lease2
+    smb2.replay.replay-dhv2-lease3
+    smb2.replay.replay-dhv2-oplock-lease
+    smb2.replay.replay-dhv2-oplock1
     smb2.replay.replay-regular
     smb2.replay.replay5
     smb2.replay.replay7


### PR DESCRIPTION
## Summary

Implements the single-channel core of the SMB2 `replay` suite, which was almost entirely unimplemented on `main` — the `SMB2_FLAGS_REPLAY_OPERATION` flag was defined but never read, and there was no `ChannelSequence` state at all. This is **Phase 1** of a phased effort to pass the persistent-handle / replay test cluster.

### What's implemented

1. **Header capture** — the per-request `ChannelSequence` (low 16 bits of the request header's `status` field; the reply emits the separate `request->status`, so this is free to read on requests) and the `REPLAY_OPERATION` flag.

2. **Per-Open ChannelSequence** (MS-SMB2 §3.3.5.2.10) — a mutating op (WRITE / SET_INFO / IOCTL) carrying a stale sequence (behind by `[0x8000..0xFFFF]` mod `0x10000`) is rejected with `STATUS_FILE_NOT_AVAILABLE`; READ never rejects but advances the tracked value. Seeded from the CREATE's sequence at grant and re-seeded on durable reconnect.

3. **DH2Q `create_guid` replay** (MS-SMB2 §3.3.5.9.7) — a CREATE whose `create_guid` matches a live open is a replay of the original create: return the existing handle rather than opening a second one. The reply echoes the original `create_action` and (for an oplock handle) the *requested* oplock level, while a lease handle reports its current (possibly upgraded) state. An oplock-vs-lease type mismatch or a lease-key mismatch is rejected with `ACCESS_DENIED`; a non-DH2Q create never dedupes (so `replay-regular` keeps returning the normal collision/sharing-violation).

### Tests

Greens the following `smb2.replay` cases (added to the per-backend allowlists):

- `channel-sequence`, `replay-commands`, `replay-regular` — all backends
- `replay-dhv2-oplock1`, `replay-dhv2-lease1/2/3`, `replay-dhv2-oplock-lease`, `replay-dhv2-lease-oplock` — memfs / cairn / diskfs (durable handles are unsupported on the linux/io_uring passthrough backends, matching the existing `replay-regular` exclusion there)

No regressions: the create / oplock / lease / durable-open / durable-v2-open / read / write suites are unchanged when run per-subtest (oplock 18-fail, lease 22-fail, durable-open 5-fail, durable-v2 8-fail baselines all hold).

### Deferred to later phases

- `replay-dhv2-oplock2/3` — need a batch-oplock break to fire on a *share*-conflicting open (caching-break arbitration, a later durable phase).
- `replay3/4` and the `dhv2-pending*` multichannel matrix — need multichannel binding + pending-create parking.
- `replay5/6`, `durable-reconnect-replay*` — need a continuously-available test share + a global `create_guid`→`DUPLICATE_OBJECTID` registry check.