### PR TITLE
s3: fix response desync on keep-alive connections (double-respond + stale PUT ETag)

### DIFF
--- a/src/server/s3/s3.c
+++ b/src/server/s3/s3.c
@@ -107,6 +107,19 @@ s3_server_respond(
     char              date_ts[64];
     time_t            now = time(NULL);
 
+    /* The response headers/status are emitted exactly once. Several paths can
+     * race to call this for the same request: for synchronous VFS backends
+     * (e.g. memfs) the VFS completion callback runs inline, so both it and the
+     * HTTP RECEIVE_COMPLETE notification observe the request ready to send.
+     * Responding twice duplicates the response headers and desyncs the
+     * connection, so dispatch the status line + headers only on the first
+     * call. (GET streams its body via later WANT_DATA notifications, which is
+     * why we cannot key this off vfs_state.) */
+    if (request->responded) {
+        return;
+    }
+    request->responded = 1;
+
     strftime(date_ts, sizeof(date_ts), "%a, %d %b %Y %H:%M:%S GMT", gmtime(&now));
 
     evpl_http_request_add_header(request->http_request, "Date", date_ts);
@@ -391,6 +404,7 @@ s3_server_dispatch(
     s3_request->has_part_number    = 0;
     s3_request->op_bucket          = 0;
     s3_request->chunked            = 0;
+    s3_request->responded          = 0;
     s3_request->query_upload_idlen = 0;
     s3_request->query_part_number  = 0;
     s3_request->http_request       = request;

--- a/src/server/s3/s3_internal.h
+++ b/src/server/s3/s3_internal.h
@@ -82,6 +82,10 @@ struct chimera_s3_request {
      * drain any request body instead of treating it as object data. */
     int                              op_bucket;
     int                              chunked;
+    /* Set once the response status/headers have been dispatched, so the
+     * several paths that can observe a request ready to send only emit it
+     * once (see s3_server_respond). */
+    int                              responded;
     int                              query_upload_idlen;
     int                              query_part_number;
     char                             query_upload_id[CHIMERA_S3_UPLOAD_ID_LEN + 1];

--- a/src/server/s3/s3_put.c
+++ b/src/server/s3/s3_put.c
@@ -10,6 +10,35 @@
 #include "s3_internal.h"
 #include "s3_etag.h"
 
+static void
+chimera_s3_put_getattr_callback(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *attr,
+    void                     *private_data)
+{
+    struct chimera_s3_request       *request = private_data;
+    struct chimera_server_s3_thread *thread  = request->thread;
+    struct evpl                     *evpl    = thread->evpl;
+    const uint64_t                   need    = CHIMERA_VFS_ATTR_FH |
+        CHIMERA_VFS_ATTR_SIZE | CHIMERA_VFS_ATTR_MTIME;
+
+    /* Attach the object ETag computed from the *final* attributes (post-write
+     * size + mtime + fh) so the value matches what a subsequent HEAD/GET will
+     * return. Computing it earlier (e.g. at create time, when the object is
+     * still empty) yields a different hash and desyncs client ETag checks. */
+    if (!error_code && (attr->va_set_mask & need) == need) {
+        chimera_s3_attach_etag(request->http_request, attr);
+    }
+
+    chimera_vfs_release(thread->vfs, request->file_handle);
+
+    request->vfs_state = CHIMERA_S3_VFS_STATE_SEND;
+
+    if (request->http_state == CHIMERA_S3_HTTP_STATE_RECVED) {
+        s3_server_respond(evpl, request);
+    }
+} /* chimera_s3_put_getattr_callback */
+
 static inline void
 chimera_s3_put_finish_common(
     enum chimera_vfs_error error_code,
@@ -20,17 +49,26 @@ chimera_s3_put_finish_common(
     struct evpl                     *evpl    = thread->evpl;
 
     chimera_vfs_release(thread->vfs, request->dir_handle);
-    chimera_vfs_release(thread->vfs, request->file_handle);
 
     if (error_code) {
         request->status = CHIMERA_S3_STATUS_INTERNAL_ERROR;
+        chimera_vfs_release(thread->vfs, request->file_handle);
+        request->vfs_state = CHIMERA_S3_VFS_STATE_SEND;
+        if (request->http_state == CHIMERA_S3_HTTP_STATE_RECVED) {
+            s3_server_respond(evpl, request);
+        }
+        return;
     }
 
-    request->vfs_state = CHIMERA_S3_VFS_STATE_SEND;
-
-    if (request->http_state == CHIMERA_S3_HTTP_STATE_RECVED) {
-        s3_server_respond(evpl, request);
-    }
+    /* Fetch the object's final attributes to build the response ETag, then
+     * release the file handle and respond from the getattr callback. */
+    chimera_vfs_getattr(thread->vfs,
+                        &thread->shared->cred,
+                        request->file_handle,
+                        CHIMERA_VFS_ATTR_FH | CHIMERA_VFS_ATTR_SIZE |
+                        CHIMERA_VFS_ATTR_MTIME,
+                        chimera_s3_put_getattr_callback,
+                        request);
 } /* chimera_s3_put_finish_common */
 
 static void
@@ -260,11 +298,12 @@ chimera_s3_put_create_unlinked_callback(
     request->file_handle = oh;
     request->vfs_state   = CHIMERA_S3_VFS_STATE_RECV;
 
-    chimera_s3_attach_etag(request->http_request, attr);
+    /* The response ETag is attached after the body is written, from the
+     * object's final attributes (see chimera_s3_put_getattr_callback). */
 
     chimera_s3_put_recv(evpl, request);
 
-} /* chimera_s3_put_create_callback */
+} /* chimera_s3_put_create_unlinked_callback */
 
 static void
 chimera_s3_put_create_callback(
@@ -290,7 +329,8 @@ chimera_s3_put_create_callback(
     request->file_handle = oh;
     request->vfs_state   = CHIMERA_S3_VFS_STATE_RECV;
 
-    chimera_s3_attach_etag(request->http_request, attr);
+    /* The response ETag is attached after the body is written, from the
+     * object's final attributes (see chimera_s3_put_getattr_callback). */
 
     chimera_s3_put_recv(evpl, request);
 


### PR DESCRIPTION
## Problem

S3 responses could desync on reused (keep-alive) connections: a request could observe another request's response or a stale ETag. This is the root cause of the intermittent multipart `InvalidPart` flake and why the ceph `s3-tests` harness had to spawn one daemon per test. Separately, an `Expect: 100-continue` request followed by a reuse of the same connection (`test_100_continue_error_retry`) would hang the client.

## Root cause

Two distinct bugs, both in the chimera S3 server (`src/server/s3/`):

1. **Double response on synchronous VFS backends.** `s3_server_respond()` was reachable twice for a single request. For a PUT, the VFS write/link completion callback (`chimera_s3_put_finish_common`) responds inline, and so does the HTTP `RECEIVE_COMPLETE` notification once the body is in. On a synchronous backend (memfs) the VFS callback runs inline, so **both** paths observe the request ready to send and each appends the full set of response headers and dispatches a status line. The result is a response with **duplicated headers** and a `Content-Length` that no longer frames the body — desyncing every subsequent request on the connection and hanging strict HTTP clients (boto3/urllib3 reports `MissingHeaderBodySeparatorDefect`).

2. **PUT response ETag computed from the pre-write (empty) object.** The PUT ETag was attached in the create / create-unlinked callback, *before* the body was written, so it hashed `(size=0, create-mtime, fh)`. A later HEAD/GET hashes the final `(size=N, write-mtime, fh)` and so returns a **different ETag for every object**, breaking client ETag checks on a reused connection.

## Fix

1. Guard `s3_server_respond()` with a per-request `responded` flag so the status line + headers are emitted exactly once. (GET still streams its body via later `WANT_DATA` notifications, which is why this can't be keyed off `vfs_state`.)
2. Defer the PUT ETag to after the body is written: `getattr` the object's final attributes and attach the ETag from those, matching exactly what HEAD/GET compute.

The interim `100 Continue` handshake was **already** handled correctly by the libevpl HTTP layer (it emits `100 Continue` before reading the body when the client sends `Expect: 100-continue`), so **no libevpl change is required**.

## Before / after (memfs, single long-lived daemon, no per-test restart)

| Check | Before | After |
| --- | --- | --- |
| boto3 keep-alive put/head loop, 200 ops, one pooled socket | 200/200 ETag mismatches | **0/200** |
| ceph/s3-tests curated allowlist (198 cases) on one daemon, x3 | flaky, needed 1 daemon/test | **198/198, stable across 3 runs** |
| `test_100_continue_error_retry` (Expect + connection reuse) | hangs | **passes** |
| chimera `s3_test.py` put/get/head/list/delete/delete_objects/copy/multipart/streaming | pass | **pass** (no regression) |

Debug/ASan build is clean; no daemon crashes under the full load.

> Note on `test_100_continue` (the strict 403-then-100 case): the second leg requires an anonymous-access / bucket-ACL model (allow anonymous PUT after `put_bucket_acl public-read-write`) that chimera's filesystem-backed S3 does not implement, so that specific case is out of scope here. The allowlisted `test_100_continue_error_retry` — which exercises the 100-continue handshake plus connection reuse — passes.
