### PR TITLE
smb2: run AppInstanceId failover before the phase-1 oplock break

### DIFF
--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -418,6 +418,51 @@ chimera_smb_create_gen_open_file(
     open_file->stream_name_len = 0;
     open_file->base_fh_len     = 0;
 
+    /* MS-SMB2 3.3.5.9.16: an AppInstanceId failover replaces a prior open held
+     * under the same AppInstanceId on another connection.  It must run BEFORE the
+     * phase-1 batch break below, because the failover force-closes that prior
+     * open SILENTLY -- if the break fired first the doomed open would receive a
+     * real OPLOCK_BREAK (smb2.durable-v2-open app-instance expects break count 0).
+     * Decision > 0 force-closes the prior open and lets this CREATE proceed;
+     * decision < 0 rejects this CREATE with FILE_FORCED_CLOSED. */
+    if (type == CHIMERA_SMB_OPEN_FILE_TYPE_FILE && tree->share && oh &&
+        (request->create.ctx_present_mask & CHIMERA_SMB_CREATE_CTX_APP)) {
+        struct chimera_vfs_state      *vfs_state  = thread->vfs_thread->vfs->vfs_state;
+        struct chimera_vfs_file_state *file_state =
+            chimera_vfs_state_get(vfs_state, oh->fh, oh->fh_len, oh->fh_hash, true);
+
+        if (file_state) {
+            struct chimera_smb_open_file *match    = NULL;
+            int                           decision = 0;
+
+            pthread_mutex_lock(&file_state->lock);
+            for (struct chimera_vfs_lease *l = file_state->share_resvs;
+                 l; l = l->next) {
+                struct chimera_smb_open_file *of =
+                    (struct chimera_smb_open_file *) l->owner.cb_private;
+                int                           d = chimera_smb_app_instance_decision(request, of);
+                if (d != 0) {
+                    match    = of;
+                    decision = d;
+                    break;
+                }
+            }
+            pthread_mutex_unlock(&file_state->lock);
+
+            chimera_vfs_state_put(vfs_state, file_state);
+
+            if (decision < 0) {
+                /* Reject: leave the existing open intact. */
+                open_file->handle = NULL;
+                chimera_smb_open_file_free(thread, open_file);
+                request->create.force_close_status = SMB2_STATUS_FILE_FORCED_CLOSED;
+                return NULL;
+            } else if (decision > 0) {
+                chimera_smb_app_instance_force_close(thread, match);
+            }
+        }
+    }
+
     /* A *batch* (handle-caching) oplock breaks BEFORE the share-mode check:
      * the holder may close its deferred handle in response, after which the
      * sharing conflict disappears.  Fire that break here so it happens even
@@ -551,44 +596,9 @@ chimera_smb_create_gen_open_file(
             open_file->share_lease.has_break_skip_key = 0;
         }
 
-        /* AppInstanceId failover (MS-SMB2 3.3.5.9.7 / 3.3.5.9.16).  Processed
-         * before the share check (the spec-pure ordering): scan the file's
-         * existing SHARE reservations for an open carrying the same
-         * AppInstanceId on a different connection and apply the
-         * AppInstanceVersion rule.  This must run even when the new open would
-         * not otherwise conflict (e.g. fully-shared opens), since the rule may
-         * still mandate a force-close or a STATUS_FILE_FORCED_CLOSED reject.
-         * The matching open is collected under file->lock; the force-close /
-         * reject is then performed outside it to keep the lock ordering. */
-        if (request->create.ctx_present_mask & CHIMERA_SMB_CREATE_CTX_APP) {
-            struct chimera_smb_open_file *match    = NULL;
-            int                           decision = 0;
-
-            pthread_mutex_lock(&file_state->lock);
-            for (struct chimera_vfs_lease *l = file_state->share_resvs;
-                 l; l = l->next) {
-                struct chimera_smb_open_file *of =
-                    (struct chimera_smb_open_file *) l->owner.cb_private;
-                int                           d = chimera_smb_app_instance_decision(request, of);
-                if (d != 0) {
-                    match    = of;
-                    decision = d;
-                    break;
-                }
-            }
-            pthread_mutex_unlock(&file_state->lock);
-
-            if (decision < 0) {
-                /* Reject: leave the existing open intact. */
-                chimera_vfs_state_put(vfs_state, file_state);
-                open_file->handle = NULL;
-                chimera_smb_open_file_free(thread, open_file);
-                request->create.force_close_status = SMB2_STATUS_FILE_FORCED_CLOSED;
-                return NULL;
-            } else if (decision > 0) {
-                chimera_smb_app_instance_force_close(thread, match);
-            }
-        }
+        /* AppInstanceId failover (MS-SMB2 3.3.5.9.7 / 3.3.5.9.16) was already
+         * resolved before the phase-1 break above (so the displaced open is
+         * force-closed silently); nothing to do here. */
 
         result = chimera_vfs_state_try_insert(vfs_state, file_state,
                                               &open_file->share_lease, &conflict);

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -1293,6 +1293,7 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.durable-v2-delay.durable_v2_reconnect_delay
     smb2.durable-v2-delay.durable_v2_reconnect_delay_msec
     # smb2.durable-v2-open
+    smb2.durable-v2-open.app-instance
     # smb2.durable-v2-regressions
     smb2.durable-v2-regressions.durable_v2_reconnect_bug15624
     # smb2.fileid
@@ -2185,6 +2186,7 @@ set(SMBTORTURE_ENABLED_cairn
     smb2.durable-v2-delay.durable_v2_reconnect_delay
     smb2.durable-v2-delay.durable_v2_reconnect_delay_msec
     # smb2.durable-v2-open
+    smb2.durable-v2-open.app-instance
     # smb2.durable-v2-regressions
     smb2.durable-v2-regressions.durable_v2_reconnect_bug15624
     # smb2.fileid
@@ -2503,6 +2505,7 @@ set(SMBTORTURE_ENABLED_diskfs_io_uring
     smb2.durable-v2-delay.durable_v2_reconnect_delay
     smb2.durable-v2-delay.durable_v2_reconnect_delay_msec
     # smb2.durable-v2-open
+    smb2.durable-v2-open.app-instance
     # smb2.durable-v2-regressions
     smb2.durable-v2-regressions.durable_v2_reconnect_bug15624
     # smb2.fileid
@@ -2821,6 +2824,7 @@ set(SMBTORTURE_ENABLED_diskfs_aio
     smb2.durable-v2-delay.durable_v2_reconnect_delay
     smb2.durable-v2-delay.durable_v2_reconnect_delay_msec
     # smb2.durable-v2-open
+    smb2.durable-v2-open.app-instance
     # smb2.durable-v2-regressions
     smb2.durable-v2-regressions.durable_v2_reconnect_bug15624
     # smb2.fileid


### PR DESCRIPTION
## Summary

An AppInstanceId failover (MS-SMB2 §3.3.5.9.16) replaces a prior open held under the same AppInstanceId on another connection, and the displaced open must be force-closed **silently**. The decision was made inside the share-mode block, which runs **after** the phase-1 batch-oplock break — so the doomed prior open received a real `OPLOCK_BREAK` before being force-closed (`smb2.durable-v2-open.app-instance` asserts a break count of 0).

This moves the AppInstanceId scan/decision **ahead of the phase-1 break** in `chimera_smb_create_gen_open_file`, with its own `file_state` get/put:
- `decision > 0` → force-close the prior open, then this CREATE proceeds (breaking nothing).
- `decision < 0` → reject this CREATE with `FILE_FORCED_CLOSED`.

The now-redundant in-block copy is removed. The decision logic itself is unchanged.

### Tests
- Greens `smb2.durable-v2-open.app-instance` on memfs / cairn / diskfs (durable handles are unsupported on the linux/io_uring passthrough backends).
- **No regressions:** `smb2.create` (8-fail baseline) unchanged; `smb2.durable-v2-open` per-subtest unchanged except the now-passing app-instance; all **7 WPTS AppInstanceVersion** cases (Greater / Lower-High / Lower-Low / Same / cross-dialect / NoVersion-negative) still pass — covering both the force-close and reject decision paths.

### Context (phased durable/replay effort)
This is Phase 2 of the persistent-handle work (follows #711). The other durable "quick wins" originally scoped here turned out not to be quick and were deferred:
- **delete-on-close across disconnect** (`delete_on_close1`) needs the parked-handle *purge* on a share-conflicting create to fire and honor delete-on-close — the same batch-break-on-share-conflict gap that blocks `replay-dhv2-oplock2/3`. A non-preservable shortcut greened it but regressed `delete_on_close2` (which reclaims the same delete-pending durable handle via durable reopen, so it must stay preserved). Deferred to the Phase 3 caching-break rework.
- **alloc-size** (`AlSi`) needs allocation-without-EOF (`KEEP_SIZE`) tracking added to memfs/cairn/diskfs — a separate follow-up.