### PR TITLE
smb2: harden request parsing against malformed/malicious input

### DIFF
--- a/src/common/evpl_iovec_cursor.h
+++ b/src/common/evpl_iovec_cursor.h
@@ -6,6 +6,7 @@
 
 #include <string.h>
 #include <stdlib.h>
+#include <limits.h>
 
 #include "evpl/evpl.h"
 
@@ -14,6 +15,12 @@ struct evpl_iovec_cursor {
     int                offset;
     int                consumed;
     int                niov;
+    /* Soft upper bound (in bytes, measured against `consumed`) on how far the
+     * checked `_try_*` readers below may advance.  INT_MAX means "unbounded",
+     * which is the behaviour every non-SMB caller relies on.  The SMB ingest
+     * path clamps this to the current message's window so a malformed request
+     * cannot read into the next compound element or off the received segment. */
+    int                limit;
 };
 
 
@@ -27,7 +34,30 @@ evpl_iovec_cursor_init(
     cursor->niov     = niov;
     cursor->consumed = 0;
     cursor->offset   = 0;
+    cursor->limit    = INT_MAX;
 } /* evpl_iovec_cursor_init */
+
+/*
+ * Clamp the checked readers to at most `length` bytes beyond the current
+ * `consumed` position.  Used by the SMB request parser to fence each compound
+ * element to its own [start,end) window.
+ */
+static inline void
+evpl_iovec_cursor_set_limit(
+    struct evpl_iovec_cursor *cursor,
+    int                       length)
+{
+    cursor->limit = cursor->consumed + length;
+} /* evpl_iovec_cursor_set_limit */
+
+/* Bytes still readable within the current limit (never negative). */
+static inline int
+evpl_iovec_cursor_remaining(struct evpl_iovec_cursor *cursor)
+{
+    int rem = cursor->limit - cursor->consumed;
+
+    return rem > 0 ? rem : 0;
+} /* evpl_iovec_cursor_remaining */
 
 
 static inline int
@@ -210,6 +240,100 @@ evpl_iovec_cursor_get_uint64(
     evpl_iovec_cursor_skip(cursor, (8 - (cursor->consumed & 7)) & 7);
     evpl_iovec_cursor_copy(cursor, value, sizeof(uint64_t));
 } /* evpl_iovec_cursor_get_uint64 */
+
+/*
+ * Checked variants of copy/skip/get_uintN for parsing untrusted (client) data.
+ *
+ * Unlike the helpers above -- which abort() the whole (threaded) process on a
+ * short read -- these return -1 when the requested bytes would exceed either the
+ * available iovec data or the active limit, so the caller can reject the request
+ * cleanly.  On failure the caller abandons the request, so any partial cursor
+ * advancement is harmless.  The limit defaults to INT_MAX, so a cursor that never
+ * calls set_limit behaves like an ordinary bounds-by-data read.
+ */
+static inline int
+evpl_iovec_cursor_try_copy(
+    struct evpl_iovec_cursor *cursor,
+    void                     *out,
+    int                       length)
+{
+    if (length < 0 || evpl_iovec_cursor_remaining(cursor) < length) {
+        return -1;
+    }
+    return evpl_iovec_cursor_get_blob(cursor, out, length);
+} /* evpl_iovec_cursor_try_copy */
+
+static inline int
+evpl_iovec_cursor_try_skip(
+    struct evpl_iovec_cursor *cursor,
+    int                       length)
+{
+    if (length < 0 || evpl_iovec_cursor_remaining(cursor) < length) {
+        return -1;
+    }
+
+    while (length && cursor->niov) {
+        int chunk = cursor->iov->length - cursor->offset;
+
+        if (length < chunk) {
+            chunk = length;
+        }
+
+        length -= chunk;
+
+        cursor->offset   += chunk;
+        cursor->consumed += chunk;
+
+        if (cursor->offset == cursor->iov->length) {
+            cursor->iov++;
+            cursor->niov--;
+            cursor->offset = 0;
+        }
+    }
+
+    return length ? -1 : 0;
+} /* evpl_iovec_cursor_try_skip */
+
+static inline int
+evpl_iovec_cursor_try_get_uint8(
+    struct evpl_iovec_cursor *cursor,
+    uint8_t                  *value)
+{
+    return evpl_iovec_cursor_try_copy(cursor, value, sizeof(uint8_t));
+} /* evpl_iovec_cursor_try_get_uint8 */
+
+static inline int
+evpl_iovec_cursor_try_get_uint16(
+    struct evpl_iovec_cursor *cursor,
+    uint16_t                 *value)
+{
+    if (evpl_iovec_cursor_try_skip(cursor, (2 - (cursor->consumed & 1)) & 1)) {
+        return -1;
+    }
+    return evpl_iovec_cursor_try_copy(cursor, value, sizeof(uint16_t));
+} /* evpl_iovec_cursor_try_get_uint16 */
+
+static inline int
+evpl_iovec_cursor_try_get_uint32(
+    struct evpl_iovec_cursor *cursor,
+    uint32_t                 *value)
+{
+    if (evpl_iovec_cursor_try_skip(cursor, (4 - (cursor->consumed & 3)) & 3)) {
+        return -1;
+    }
+    return evpl_iovec_cursor_try_copy(cursor, value, sizeof(uint32_t));
+} /* evpl_iovec_cursor_try_get_uint32 */
+
+static inline int
+evpl_iovec_cursor_try_get_uint64(
+    struct evpl_iovec_cursor *cursor,
+    uint64_t                 *value)
+{
+    if (evpl_iovec_cursor_try_skip(cursor, (8 - (cursor->consumed & 7)) & 7)) {
+        return -1;
+    }
+    return evpl_iovec_cursor_try_copy(cursor, value, sizeof(uint64_t));
+} /* evpl_iovec_cursor_try_get_uint64 */
 
 static inline void
 evpl_iovec_cursor_append_uint8(

--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -1095,7 +1095,25 @@ chimera_smb_server_handle_smb2(
             return;
         }
 
+        /* The compound request array is fixed-size; a chain that would overflow
+         * it is hostile.  Every loop iteration appends exactly one request, so
+         * checking here guards all of the requests[num_requests++] sites below. */
+        if (unlikely(compound->num_requests >= CHIMERA_SMB_COMPOUND_MAX_REQUESTS)) {
+            chimera_smb_error(
+                "SMB2 compound exceeds %d chained requests; closing connection",
+                CHIMERA_SMB_COMPOUND_MAX_REQUESTS);
+            chimera_smb_compound_free(thread, compound);
+            evpl_close(evpl, conn->bind);
+            return;
+        }
+
         evpl_iovec_cursor_reset_consumed(request_cursor);
+
+        /* Fence the cursor's checked readers to this element's bytes.  `left`
+         * still counts from this element's header start (the -= below has not
+         * run yet), so this caps reads at the end of the received compound; once
+         * NextCommand is validated we tighten it to this element's own window. */
+        evpl_iovec_cursor_set_limit(request_cursor, left);
 
         request = chimera_smb_request_alloc(thread);
 
@@ -1131,6 +1149,34 @@ chimera_smb_server_handle_smb2(
         evpl_iovec_cursor_copy(request_cursor,
                                &request->request_struct_size,
                                sizeof(request->request_struct_size));
+
+        /* Validate the compound chain link before anything trusts it -- the
+         * per-element cursor window, the signing payload length, and the skip to
+         * the next element all derive from NextCommand.  When present it must be
+         * 8-byte aligned (MS-SMB2 2.2.1.2), point past this header, and stay
+         * within the bytes actually received (`left` + the header we consumed).
+         * A bogus value is rejected cleanly and terminates the chain rather than
+         * driving an out-of-bounds skip. */
+        if (request->smb2_hdr.next_command != 0) {
+            uint32_t nc = request->smb2_hdr.next_command;
+
+            if (unlikely(nc < sizeof(request->smb2_hdr) ||
+                         (nc & 7) != 0 ||
+                         nc > (uint32_t) left + sizeof(request->smb2_hdr))) {
+                chimera_smb_error("Received SMB2 compound with invalid NextCommand %u", nc);
+                request->smb2_hdr.next_command               = 0;
+                request->status                              = SMB2_STATUS_INVALID_PARAMETER;
+                request->flags                              |= CHIMERA_SMB_REQUEST_FLAG_PARSE_FAILED;
+                compound->requests[compound->num_requests++] = request;
+                goto next_compound_request;
+            }
+
+            /* Tighten the window to exactly this element: limit becomes the
+             * absolute NextCommand offset (set_limit is relative to the current
+             * consumed position). */
+            evpl_iovec_cursor_set_limit(request_cursor,
+                                        nc - evpl_iovec_cursor_consumed(request_cursor));
+        }
 
         /* Compound related requests inherit session/tree from previous request */
         if (request->smb2_hdr.flags & SMB2_FLAGS_RELATED_OPERATIONS) {
@@ -1389,8 +1435,19 @@ chimera_smb_server_handle_smb2(
         more_requests = request->smb2_hdr.next_command != 0;
 
         if (more_requests) {
-            evpl_iovec_cursor_skip(request_cursor,
-                                   request->smb2_hdr.next_command - evpl_iovec_cursor_consumed(request_cursor));
+            /* A per-command parser may have tightened the cursor limit to fence a
+             * sub-buffer (SET_INFO / IOCTL), which would otherwise make the skip
+             * to the next compound header spuriously fail.  NextCommand was
+             * validated above (aligned, forward, within the received data), so
+             * restore the element boundary as the limit before skipping to it. */
+            evpl_iovec_cursor_set_limit(request_cursor,
+                                        request->smb2_hdr.next_command -
+                                        evpl_iovec_cursor_consumed(request_cursor));
+            if (unlikely(smb_cursor_seek_to(request_cursor, request->smb2_hdr.next_command) != 0)) {
+                chimera_smb_error("SMB2 compound NextCommand skip out of range; closing connection");
+                evpl_close(evpl, conn->bind);
+                return;
+            }
         }
 
         left -= evpl_iovec_cursor_consumed(request_cursor) - sizeof(request->smb2_hdr);

--- a/src/server/smb/smb_attr.h
+++ b/src/server/smb/smb_attr.h
@@ -462,57 +462,80 @@ chimera_smb_unmarshal_end_of_file_info(
     attr->va_set_mask |= CHIMERA_VFS_ATTR_SIZE;
 } // chimera_smb_unmarshal_end_of_file_info
 
-static inline void
+/* The parse_*_info helpers below read a client-supplied SET_INFO buffer.  They
+ * use the bounds-checked cursor readers and return -1 (without aborting) when
+ * the buffer is shorter than the information class requires, so the caller can
+ * answer STATUS_INFO_LENGTH_MISMATCH instead of crashing the server. */
+static inline int
 chimera_smb_parse_basic_info(
     struct evpl_iovec_cursor *cursor,
     struct chimera_smb_attrs *attrs)
 {
-    evpl_iovec_cursor_get_uint64(cursor, &attrs->smb_crttime);
-    evpl_iovec_cursor_get_uint64(cursor, &attrs->smb_atime);
-    evpl_iovec_cursor_get_uint64(cursor, &attrs->smb_mtime);
-    evpl_iovec_cursor_get_uint64(cursor, &attrs->smb_ctime);
-    evpl_iovec_cursor_get_uint32(cursor, &attrs->smb_attributes);
+    int rc = 0;
+
+    rc |= evpl_iovec_cursor_try_get_uint64(cursor, &attrs->smb_crttime);
+    rc |= evpl_iovec_cursor_try_get_uint64(cursor, &attrs->smb_atime);
+    rc |= evpl_iovec_cursor_try_get_uint64(cursor, &attrs->smb_mtime);
+    rc |= evpl_iovec_cursor_try_get_uint64(cursor, &attrs->smb_ctime);
+    rc |= evpl_iovec_cursor_try_get_uint32(cursor, &attrs->smb_attributes);
+
+    if (rc) {
+        return -1;
+    }
 
     attrs->smb_attr_mask |= SMB_ATTR_CRTTIME | SMB_ATTR_ATIME | SMB_ATTR_MTIME | SMB_ATTR_CTIME | SMB_ATTR_ATTRIBUTES;
+    return 0;
 } /* chimera_smb_parse_basic_info */
 
-static inline void
+static inline int
 chimera_smb_parse_disposition_info(
     struct evpl_iovec_cursor *cursor,
     struct chimera_smb_attrs *attrs)
 {
-    evpl_iovec_cursor_get_uint8(cursor, &attrs->smb_disposition);
+    if (evpl_iovec_cursor_try_get_uint8(cursor, &attrs->smb_disposition)) {
+        return -1;
+    }
     attrs->smb_attr_mask |= SMB_ATTR_DISPOSITION;
+    return 0;
 } /* chimera_smb_parse_disposition_info */
 
-static inline void
+static inline int
 chimera_smb_parse_disposition_info_ex(
     struct evpl_iovec_cursor *cursor,
     struct chimera_smb_attrs *attrs)
 {
     uint32_t flags;
 
-    evpl_iovec_cursor_get_uint32(cursor, &flags);
+    if (evpl_iovec_cursor_try_get_uint32(cursor, &flags)) {
+        return -1;
+    }
     attrs->smb_disposition = (flags & 0x01) ? 1 : 0;
     attrs->smb_attr_mask  |= SMB_ATTR_DISPOSITION;
+    return 0;
 } /* chimera_smb_parse_disposition_info_ex */
 
-static inline void
+static inline int
 chimera_smb_parse_position_info(
     struct evpl_iovec_cursor *cursor,
     struct chimera_smb_attrs *attrs)
 {
-    evpl_iovec_cursor_get_uint64(cursor, &attrs->smb_position);
+    if (evpl_iovec_cursor_try_get_uint64(cursor, &attrs->smb_position)) {
+        return -1;
+    }
     attrs->smb_attr_mask |= SMB_ATTR_POSITION;
+    return 0;
 } /* chimera_smb_parse_position_info */
 
-static inline void
+static inline int
 chimera_smb_parse_end_of_file_info(
     struct evpl_iovec_cursor *cursor,
     struct chimera_smb_attrs *attrs)
 {
-    evpl_iovec_cursor_get_uint64(cursor, &attrs->smb_size);
+    if (evpl_iovec_cursor_try_get_uint64(cursor, &attrs->smb_size)) {
+        return -1;
+    }
     attrs->smb_attr_mask |= SMB_ATTR_SIZE;
+    return 0;
 } /* chimera_smb_parse_end_of_file_info */
 
 

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -823,6 +823,44 @@ struct chimera_smb_compound {
     struct chimera_smb_request        *requests[CHIMERA_SMB_COMPOUND_MAX_REQUESTS];
 };
 
+/*
+ * Reject a request whose body is malformed.  Rather than tearing down the
+ * transport, mark it PARSE_FAILED with an SMB2 status; the dispatcher then
+ * completes it -- in order within the compound -- as an error reply (see
+ * CHIMERA_SMB_REQUEST_FLAG_PARSE_FAILED).  Returns 0 so the compound parse loop
+ * keeps walking the remaining (independently framed) elements.
+ */
+static inline int
+chimera_smb_parse_reject(
+    struct chimera_smb_request *request,
+    uint32_t                    status)
+{
+    request->status = status;
+    request->flags |= CHIMERA_SMB_REQUEST_FLAG_PARSE_FAILED;
+    return 0;
+} /* chimera_smb_parse_reject */
+
+/*
+ * Advance the cursor to a client-supplied absolute offset (measured, like all
+ * SMB2 *Offset fields, from the start of this request's SMB2 header, which is
+ * where the per-element cursor's `consumed` is rebased to 0).  Rejects offsets
+ * that point backward (into already-parsed bytes) or beyond the message window.
+ * Returns 0 on success, -1 if the offset is out of range.
+ */
+static inline int
+smb_cursor_seek_to(
+    struct evpl_iovec_cursor *cursor,
+    uint32_t                  target_offset)
+{
+    int consumed = evpl_iovec_cursor_consumed(cursor);
+
+    if (target_offset < (uint32_t) consumed) {
+        return -1;
+    }
+
+    return evpl_iovec_cursor_try_skip(cursor, (int) (target_offset - (uint32_t) consumed));
+} /* smb_cursor_seek_to */
+
 struct chimera_smb_session_handle {
     uint64_t                           session_id;
     struct chimera_smb_session        *session;

--- a/src/server/smb/smb_proc_change_notify.c
+++ b/src/server/smb/smb_proc_change_notify.c
@@ -22,11 +22,18 @@ chimera_smb_parse_change_notify(
     uint32_t completion_filter;
 
     /* StructureSize (2 bytes) already consumed by the framework */
-    evpl_iovec_cursor_get_uint16(request_cursor, &flags);
-    evpl_iovec_cursor_get_uint32(request_cursor, &output_buffer_length);
-    evpl_iovec_cursor_get_uint64(request_cursor, &file_id_pid);
-    evpl_iovec_cursor_get_uint64(request_cursor, &file_id_vid);
-    evpl_iovec_cursor_get_uint32(request_cursor, &completion_filter);
+    int      prc = 0;
+
+    prc |= evpl_iovec_cursor_try_get_uint16(request_cursor, &flags);
+    prc |= evpl_iovec_cursor_try_get_uint32(request_cursor, &output_buffer_length);
+    prc |= evpl_iovec_cursor_try_get_uint64(request_cursor, &file_id_pid);
+    prc |= evpl_iovec_cursor_try_get_uint64(request_cursor, &file_id_vid);
+    prc |= evpl_iovec_cursor_try_get_uint32(request_cursor, &completion_filter);
+
+    if (unlikely(prc)) {
+        chimera_smb_error("Received SMB2 CHANGE_NOTIFY request truncated in fixed body");
+        return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
+    }
 
     request->change_notify.flags                = flags;
     request->change_notify.output_buffer_length = output_buffer_length;

--- a/src/server/smb/smb_proc_close.c
+++ b/src/server/smb/smb_proc_close.c
@@ -352,10 +352,15 @@ chimera_smb_parse_close(
         return -1;
     }
 
-    evpl_iovec_cursor_get_uint16(request_cursor, &request->close.flags);
-    evpl_iovec_cursor_get_uint64(request_cursor, &request->close.file_id.pid);
-    evpl_iovec_cursor_get_uint64(request_cursor, &request->close.file_id.vid);
+    int prc = 0;
+    prc |= evpl_iovec_cursor_try_get_uint16(request_cursor, &request->close.flags);
+    prc |= evpl_iovec_cursor_try_get_uint64(request_cursor, &request->close.file_id.pid);
+    prc |= evpl_iovec_cursor_try_get_uint64(request_cursor, &request->close.file_id.vid);
 
+    if (unlikely(prc)) {
+        chimera_smb_error("Received SMB2 CLOSE request truncated in fixed body");
+        return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
+    }
 
     return 0;
 } /* chimera_smb_parse_close */

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -3747,7 +3747,12 @@ chimera_smb_parse_create_contexts(
         data_off = smb_wire_le16(buf + pos + 10);
         data_len = smb_wire_le32(buf + pos + 12);
 
-        if ((uint32_t) name_off + name_len > buf_len - pos) {
+        /* avail > 0 (loop condition) and >= 16 (header check above).  All bounds
+         * tests are written as subtractions against avail so a hostile 32-bit
+         * length/offset cannot wrap an addition past the check. */
+        uint32_t avail = buf_len - pos;
+
+        if (name_off > avail || name_len > avail - name_off) {
             chimera_smb_error("CREATE-context name out of bounds (pos=%u, name_off=%u, name_len=%u)",
                               pos, name_off, name_len);
             request->status = SMB2_STATUS_INVALID_PARAMETER;
@@ -3755,7 +3760,7 @@ chimera_smb_parse_create_contexts(
         }
 
         if (data_len > 0) {
-            if (data_off == 0 || (uint32_t) data_off + data_len > buf_len - pos) {
+            if (data_off == 0 || data_off > avail || data_len > avail - data_off) {
                 chimera_smb_error("CREATE-context data out of bounds (pos=%u, data_off=%u, data_len=%u)",
                                   pos, data_off, data_len);
                 request->status = SMB2_STATUS_INVALID_PARAMETER;
@@ -3801,7 +3806,7 @@ chimera_smb_parse_create_contexts(
             break;
         }
 
-        if (next < 16 || (next & 0x7) != 0 || pos + next > buf_len) {
+        if (next < 16 || (next & 0x7) != 0 || next > avail) {
             chimera_smb_error("CREATE-context Next field invalid (pos=%u, next=%u, buf_len=%u)",
                               pos, next, buf_len);
             request->status = SMB2_STATUS_INVALID_PARAMETER;
@@ -3867,20 +3872,26 @@ chimera_smb_parse_create(
      * aligning cursor would otherwise swallow RequestedOplockLevel as padding
      * before the uint32 ImpersonationLevel read, leaving oplock level always 0. */
     uint8_t security_flags;
-    evpl_iovec_cursor_get_uint8(request_cursor, &security_flags);
-    evpl_iovec_cursor_get_uint8(request_cursor, &request->create.requested_oplock_level);
-    evpl_iovec_cursor_get_uint32(request_cursor, &request->create.impersonation_level);
-    evpl_iovec_cursor_get_uint64(request_cursor, &request->create.flags);
-    evpl_iovec_cursor_skip(request_cursor, 8);
-    evpl_iovec_cursor_get_uint32(request_cursor, &request->create.desired_access);
-    evpl_iovec_cursor_get_uint32(request_cursor, &request->create.file_attributes);
-    evpl_iovec_cursor_get_uint32(request_cursor, &request->create.share_access);
-    evpl_iovec_cursor_get_uint32(request_cursor, &request->create.create_disposition);
-    evpl_iovec_cursor_get_uint32(request_cursor, &request->create.create_options);
-    evpl_iovec_cursor_get_uint16(request_cursor, &name_offset);
-    evpl_iovec_cursor_get_uint16(request_cursor, &request->create.name_len);
-    evpl_iovec_cursor_get_uint32(request_cursor, &blob_offset);
-    evpl_iovec_cursor_get_uint32(request_cursor, &blob_length);
+    int     prc = 0;
+    prc |= evpl_iovec_cursor_try_get_uint8(request_cursor, &security_flags);
+    prc |= evpl_iovec_cursor_try_get_uint8(request_cursor, &request->create.requested_oplock_level);
+    prc |= evpl_iovec_cursor_try_get_uint32(request_cursor, &request->create.impersonation_level);
+    prc |= evpl_iovec_cursor_try_get_uint64(request_cursor, &request->create.flags);
+    prc |= evpl_iovec_cursor_try_skip(request_cursor, 8);
+    prc |= evpl_iovec_cursor_try_get_uint32(request_cursor, &request->create.desired_access);
+    prc |= evpl_iovec_cursor_try_get_uint32(request_cursor, &request->create.file_attributes);
+    prc |= evpl_iovec_cursor_try_get_uint32(request_cursor, &request->create.share_access);
+    prc |= evpl_iovec_cursor_try_get_uint32(request_cursor, &request->create.create_disposition);
+    prc |= evpl_iovec_cursor_try_get_uint32(request_cursor, &request->create.create_options);
+    prc |= evpl_iovec_cursor_try_get_uint16(request_cursor, &name_offset);
+    prc |= evpl_iovec_cursor_try_get_uint16(request_cursor, &request->create.name_len);
+    prc |= evpl_iovec_cursor_try_get_uint32(request_cursor, &blob_offset);
+    prc |= evpl_iovec_cursor_try_get_uint32(request_cursor, &blob_length);
+
+    if (unlikely(prc)) {
+        chimera_smb_error("Received SMB2 CREATE request truncated in fixed body");
+        return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
+    }
 
     /* ImpersonationLevel is advisory and Windows servers do not validate it
      * (a durable reconnect, for one, fills it with a don't-care sentinel) — so
@@ -3893,7 +3904,10 @@ chimera_smb_parse_create(
         return -1;
     }
 
-    evpl_iovec_cursor_copy(request_cursor, name16, request->create.name_len);
+    if (unlikely(evpl_iovec_cursor_try_copy(request_cursor, name16, request->create.name_len) != 0)) {
+        chimera_smb_error("Received SMB2 CREATE request with name running past message");
+        return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
+    }
 
     name_size = chimera_smb_utf16le_to_utf8(&request->compound->thread->iconv_ctx,
                                             name16,
@@ -3962,12 +3976,18 @@ chimera_smb_parse_create(
     }
 
     if (blob_offset > 0 && blob_length > 0 && blob_length <= 1024) {
-        uint8_t  ctx_buf[1024];
-        uint32_t skip = blob_offset - evpl_iovec_cursor_consumed(request_cursor);
+        uint8_t ctx_buf[1024];
 
-        evpl_iovec_cursor_skip(request_cursor, skip);
+        /* Seek to the client-declared create-context offset (validated to be
+         * forward and within this request's window) and pull the blob with the
+         * bounds-checked reader; a malformed offset/length rejects cleanly
+         * rather than driving an out-of-bounds skip or read. */
+        if (unlikely(smb_cursor_seek_to(request_cursor, blob_offset) != 0)) {
+            chimera_smb_error("CREATE create-context offset %u out of range", blob_offset);
+            return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
+        }
 
-        if (evpl_iovec_cursor_get_blob(request_cursor, ctx_buf, blob_length) == 0) {
+        if (evpl_iovec_cursor_try_copy(request_cursor, ctx_buf, blob_length) == 0) {
             if (chimera_smb_parse_create_contexts(ctx_buf, blob_length, request) < 0) {
                 return -1;
             }

--- a/src/server/smb/smb_proc_echo.c
+++ b/src/server/smb/smb_proc_echo.c
@@ -20,7 +20,10 @@ chimera_smb_parse_echo(
 
     // Echo request has only struct size (2 bytes) and reserved (2 bytes)
     // Skip the reserved field
-    evpl_iovec_cursor_skip(request_cursor, 2);
+    if (unlikely(evpl_iovec_cursor_try_skip(request_cursor, 2) != 0)) {
+        chimera_smb_error("Received SMB2 ECHO request truncated in fixed body");
+        return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
+    }
 
     return 0;
 } /* chimera_smb_parse_echo */

--- a/src/server/smb/smb_proc_flush.c
+++ b/src/server/smb/smb_proc_flush.c
@@ -69,8 +69,11 @@ chimera_smb_parse_flush(
         return -1;
     }
 
-    evpl_iovec_cursor_get_uint64(request_cursor, &request->flush.file_id.pid);
-    evpl_iovec_cursor_get_uint64(request_cursor, &request->flush.file_id.vid);
+    if (unlikely(evpl_iovec_cursor_try_get_uint64(request_cursor, &request->flush.file_id.pid) ||
+                 evpl_iovec_cursor_try_get_uint64(request_cursor, &request->flush.file_id.vid))) {
+        chimera_smb_error("Received SMB2 FLUSH request truncated in fixed body");
+        return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
+    }
 
     return 0;
 } /* chimera_smb_parse_ioctl */

--- a/src/server/smb/smb_proc_ioctl.c
+++ b/src/server/smb/smb_proc_ioctl.c
@@ -458,25 +458,39 @@ chimera_smb_parse_ioctl(
     }
 
 
-    evpl_iovec_cursor_get_uint32(request_cursor, &request->ioctl.ctl_code);
-    evpl_iovec_cursor_get_uint64(request_cursor, &request->ioctl.file_id.pid);
-    evpl_iovec_cursor_get_uint64(request_cursor, &request->ioctl.file_id.vid);
-    evpl_iovec_cursor_get_uint32(request_cursor, &request->ioctl.input_offset);
-    evpl_iovec_cursor_get_uint32(request_cursor, &request->ioctl.input_count);
-    evpl_iovec_cursor_get_uint32(request_cursor, &request->ioctl.max_input_response);
-    evpl_iovec_cursor_get_uint32(request_cursor, &request->ioctl.output_offset);
-    evpl_iovec_cursor_get_uint32(request_cursor, &request->ioctl.output_count);
-    evpl_iovec_cursor_get_uint32(request_cursor, &request->ioctl.max_output_response);
-    evpl_iovec_cursor_get_uint32(request_cursor, &request->ioctl.flags);
+    int prc = 0;
+    prc |= evpl_iovec_cursor_try_get_uint32(request_cursor, &request->ioctl.ctl_code);
+    prc |= evpl_iovec_cursor_try_get_uint64(request_cursor, &request->ioctl.file_id.pid);
+    prc |= evpl_iovec_cursor_try_get_uint64(request_cursor, &request->ioctl.file_id.vid);
+    prc |= evpl_iovec_cursor_try_get_uint32(request_cursor, &request->ioctl.input_offset);
+    prc |= evpl_iovec_cursor_try_get_uint32(request_cursor, &request->ioctl.input_count);
+    prc |= evpl_iovec_cursor_try_get_uint32(request_cursor, &request->ioctl.max_input_response);
+    prc |= evpl_iovec_cursor_try_get_uint32(request_cursor, &request->ioctl.output_offset);
+    prc |= evpl_iovec_cursor_try_get_uint32(request_cursor, &request->ioctl.output_count);
+    prc |= evpl_iovec_cursor_try_get_uint32(request_cursor, &request->ioctl.max_output_response);
+    prc |= evpl_iovec_cursor_try_get_uint32(request_cursor, &request->ioctl.flags);
+
+    if (unlikely(prc)) {
+        chimera_smb_error("Received SMB2 IOCTL request truncated in fixed body");
+        return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
+    }
 
     /* SET_SPARSE with no input buffer means SetSparse = TRUE. */
     request->ioctl.sp_set_sparse = 1;
 
     /* Parse IOCTL-specific input data if present */
     if (request->ioctl.input_count > 0) {
-        /* Skip to the input data offset */
-        evpl_iovec_cursor_skip(request_cursor,
-                               request->ioctl.input_offset - evpl_iovec_cursor_consumed(request_cursor));
+        /* Seek to the client-declared input offset and fence the cursor to
+         * exactly input_count bytes.  Every reader below is then bounded by the
+         * declared input buffer: a field-length field that claims more than the
+         * buffer holds (a classic IOCTL abuse) rejects cleanly via the checked
+         * readers instead of reading out of bounds or aborting. */
+        if (unlikely(smb_cursor_seek_to(request_cursor, request->ioctl.input_offset) != 0 ||
+                     request->ioctl.input_count > (uint32_t) evpl_iovec_cursor_remaining(request_cursor))) {
+            chimera_smb_error("Received SMB2 IOCTL with input buffer out of range");
+            return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
+        }
+        evpl_iovec_cursor_set_limit(request_cursor, request->ioctl.input_count);
 
         switch (request->ioctl.ctl_code) {
             case SMB2_FSCTL_DFS_GET_REFERRALS:
@@ -565,7 +579,11 @@ chimera_smb_parse_ioctl(
                                 uint16_t                          utf16_buf[CHIMERA_VFS_PATH_MAX];
                                 struct chimera_server_smb_thread *thread = request->compound->thread;
 
-                                evpl_iovec_cursor_copy(request_cursor, utf16_buf, utf16_data_len);
+                                if (unlikely(evpl_iovec_cursor_try_copy(request_cursor, utf16_buf,
+                                                                        utf16_data_len) != 0)) {
+                                    chimera_smb_error("SET_REPARSE_POINT LNK: target runs past input buffer");
+                                    return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
+                                }
 
                                 utf8_len = chimera_smb_utf16le_to_utf8(
                                     &thread->iconv_ctx,
@@ -600,8 +618,13 @@ chimera_smb_parse_ioctl(
                                 request->status = SMB2_STATUS_INVALID_PARAMETER;
                                 return -1;
                             }
-                            evpl_iovec_cursor_get_uint32(request_cursor, &request->ioctl.rp_device_major);
-                            evpl_iovec_cursor_get_uint32(request_cursor, &request->ioctl.rp_device_minor);
+                            if (unlikely(evpl_iovec_cursor_try_get_uint32(request_cursor,
+                                                                          &request->ioctl.rp_device_major) ||
+                                         evpl_iovec_cursor_try_get_uint32(request_cursor,
+                                                                          &request->ioctl.rp_device_minor))) {
+                                chimera_smb_error("SET_REPARSE_POINT CHR/BLK: device numbers past input buffer");
+                                return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
+                            }
                             break;
                         case SMB2_NFS_SPECFILE_FIFO:
                         case SMB2_NFS_SPECFILE_SOCK:
@@ -627,11 +650,17 @@ chimera_smb_parse_ioctl(
                         return -1;
                     }
 
-                    evpl_iovec_cursor_get_uint16(request_cursor, &sub_name_offset);
-                    evpl_iovec_cursor_get_uint16(request_cursor, &sub_name_length);
-                    evpl_iovec_cursor_get_uint16(request_cursor, &print_name_offset);
-                    evpl_iovec_cursor_get_uint16(request_cursor, &print_name_length);
-                    evpl_iovec_cursor_get_uint32(request_cursor, &symlink_flags);
+                    int src = 0;
+                    src |= evpl_iovec_cursor_try_get_uint16(request_cursor, &sub_name_offset);
+                    src |= evpl_iovec_cursor_try_get_uint16(request_cursor, &sub_name_length);
+                    src |= evpl_iovec_cursor_try_get_uint16(request_cursor, &print_name_offset);
+                    src |= evpl_iovec_cursor_try_get_uint16(request_cursor, &print_name_length);
+                    src |= evpl_iovec_cursor_try_get_uint32(request_cursor, &symlink_flags);
+
+                    if (unlikely(src)) {
+                        chimera_smb_error("SET_REPARSE_POINT SYMLINK: header past input buffer");
+                        return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
+                    }
 
                     if (sub_name_length == 0 ||
                         sub_name_length > (CHIMERA_VFS_PATH_MAX - 1) * 2) {
@@ -643,14 +672,21 @@ chimera_smb_parse_ioctl(
 
                     /* Skip to SubstituteName within PathBuffer */
                     if (sub_name_offset > 0) {
-                        evpl_iovec_cursor_skip(request_cursor, sub_name_offset);
+                        if (unlikely(evpl_iovec_cursor_try_skip(request_cursor, sub_name_offset) != 0)) {
+                            chimera_smb_error("SET_REPARSE_POINT SYMLINK: name offset past input buffer");
+                            return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
+                        }
                     }
 
                     {
                         uint16_t                          utf16_buf[CHIMERA_VFS_PATH_MAX];
                         struct chimera_server_smb_thread *thread = request->compound->thread;
 
-                        evpl_iovec_cursor_copy(request_cursor, utf16_buf, sub_name_length);
+                        if (unlikely(evpl_iovec_cursor_try_copy(request_cursor, utf16_buf,
+                                                                sub_name_length) != 0)) {
+                            chimera_smb_error("SET_REPARSE_POINT SYMLINK: name runs past input buffer");
+                            return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
+                        }
 
                         utf8_len = chimera_smb_utf16le_to_utf8(
                             &thread->iconv_ctx,

--- a/src/server/smb/smb_proc_lock.c
+++ b/src/server/smb/smb_proc_lock.c
@@ -125,8 +125,8 @@ chimera_smb_parse_lock(
     struct evpl_iovec_cursor   *request_cursor,
     struct chimera_smb_request *request)
 {
-    uint16_t reserved_lock_seq_lo;
-    uint32_t reserved_lock_seq_hi;
+    uint16_t reserved_lock_seq_lo = 0;
+    uint16_t reserved_lock_seq_hi = 0;
     uint32_t reserved;
 
     if (unlikely(request->request_struct_size != SMB2_LOCK_REQUEST_SIZE)) {
@@ -137,22 +137,32 @@ chimera_smb_parse_lock(
         return -1;
     }
 
-    evpl_iovec_cursor_get_uint16(request_cursor, &request->lock.lock_count);
+    int prc = 0;
+    prc |= evpl_iovec_cursor_try_get_uint16(request_cursor, &request->lock.lock_count);
     /* LockSequenceNumber is 4 bits + LockSequenceIndex 28 bits = 32 bits.
      * We don't replay-detect by sequence in Stage B; just store. */
-    evpl_iovec_cursor_get_uint16(request_cursor, &reserved_lock_seq_lo);
-    evpl_iovec_cursor_get_uint16(request_cursor, (uint16_t *) &reserved_lock_seq_hi);
+    prc |= evpl_iovec_cursor_try_get_uint16(request_cursor, &reserved_lock_seq_lo);
+    prc |= evpl_iovec_cursor_try_get_uint16(request_cursor, &reserved_lock_seq_hi);
+    prc |= evpl_iovec_cursor_try_get_uint64(request_cursor, &request->lock.file_id.pid);
+    prc |= evpl_iovec_cursor_try_get_uint64(request_cursor, &request->lock.file_id.vid);
+
+    if (unlikely(prc)) {
+        chimera_smb_error("Received SMB2 LOCK request truncated in fixed body");
+        return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
+    }
+
+    /* Combine the LockSequence halves only once every field parsed cleanly, so a
+     * short read can never feed an uninitialized value into the shift/or. */
     request->lock.lock_sequence = ((uint32_t) reserved_lock_seq_lo) |
         (((uint32_t) reserved_lock_seq_hi) << 16);
-    evpl_iovec_cursor_get_uint64(request_cursor, &request->lock.file_id.pid);
-    evpl_iovec_cursor_get_uint64(request_cursor, &request->lock.file_id.vid);
 
     /* Read the lock elements (24 bytes each: Offset, Length, Flags, Reserved).
      * A zero-lock request (which smbtorture sends to probe rejection) carries
      * no element; an over-long LockCount is flagged so the handler can reply
      * INVALID_PARAMETER rather than tearing the connection down with a -1.  The
      * first element is mirrored into l_offset/l_length/l_flags for the common
-     * single-lock path. */
+     * single-lock path.  The elements are pulled with the bounds-checked reader
+     * so a LockCount that runs past the received bytes rejects cleanly. */
     request->lock.l_offset      = 0;
     request->lock.l_length      = 0;
     request->lock.l_flags       = 0;
@@ -161,14 +171,20 @@ chimera_smb_parse_lock(
     if (request->lock.lock_count >= 1 &&
         request->lock.lock_count <= CHIMERA_SMB_LOCK_MAX_ELEMENTS) {
         for (uint16_t i = 0; i < request->lock.lock_count; i++) {
-            evpl_iovec_cursor_get_uint64(request_cursor,
-                                         &request->lock.elements[i].offset);
-            evpl_iovec_cursor_get_uint64(request_cursor,
-                                         &request->lock.elements[i].length);
-            evpl_iovec_cursor_get_uint32(request_cursor,
-                                         &request->lock.elements[i].flags);
-            evpl_iovec_cursor_get_uint32(request_cursor, &reserved);
+            prc |= evpl_iovec_cursor_try_get_uint64(request_cursor,
+                                                    &request->lock.elements[i].offset);
+            prc |= evpl_iovec_cursor_try_get_uint64(request_cursor,
+                                                    &request->lock.elements[i].length);
+            prc |= evpl_iovec_cursor_try_get_uint32(request_cursor,
+                                                    &request->lock.elements[i].flags);
+            prc |= evpl_iovec_cursor_try_get_uint32(request_cursor, &reserved);
         }
+
+        if (unlikely(prc)) {
+            chimera_smb_error("Received SMB2 LOCK elements past message");
+            return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
+        }
+
         request->lock.l_offset = request->lock.elements[0].offset;
         request->lock.l_length = request->lock.elements[0].length;
         request->lock.l_flags  = request->lock.elements[0].flags;

--- a/src/server/smb/smb_proc_negotiate.c
+++ b/src/server/smb/smb_proc_negotiate.c
@@ -1014,18 +1014,22 @@ chimera_smb_parse_negotiate(
         request->status = SMB2_STATUS_INVALID_PARAMETER;
         return -1;
     }
-    evpl_iovec_cursor_get_uint16(request_cursor, &request->negotiate.dialect_count);
-    {
-        uint16_t security_mode_wire;
-        evpl_iovec_cursor_get_uint16(request_cursor, &security_mode_wire);
-        request->negotiate.security_mode = (uint8_t) security_mode_wire;
+    int      prc = 0;
+    uint16_t security_mode_wire;
+    prc |= evpl_iovec_cursor_try_get_uint16(request_cursor, &request->negotiate.dialect_count);
+    prc |= evpl_iovec_cursor_try_get_uint16(request_cursor, &security_mode_wire);
+    prc |= evpl_iovec_cursor_try_skip(request_cursor, 2); /* Reserved */
+    prc |= evpl_iovec_cursor_try_get_uint32(request_cursor, &request->negotiate.capabilities);
+    prc |= evpl_iovec_cursor_try_copy(request_cursor, request->negotiate.client_guid, 16);
+    prc |= evpl_iovec_cursor_try_get_uint32(request_cursor, &request->negotiate.negotiate_context_offset);
+    prc |= evpl_iovec_cursor_try_get_uint16(request_cursor, &request->negotiate.negotiate_context_count);
+    prc |= evpl_iovec_cursor_try_skip(request_cursor, 2); /* Reserved2 */
+
+    if (unlikely(prc)) {
+        chimera_smb_error("Received SMB2 NEGOTIATE request truncated in fixed body");
+        return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
     }
-    evpl_iovec_cursor_skip(request_cursor, 2); /* Reserved */
-    evpl_iovec_cursor_get_uint32(request_cursor, &request->negotiate.capabilities);
-    evpl_iovec_cursor_copy(request_cursor, request->negotiate.client_guid, 16);
-    evpl_iovec_cursor_get_uint32(request_cursor, &request->negotiate.negotiate_context_offset);
-    evpl_iovec_cursor_get_uint16(request_cursor, &request->negotiate.negotiate_context_count);
-    evpl_iovec_cursor_skip(request_cursor, 2); /* Reserved2 */
+    request->negotiate.security_mode = (uint8_t) security_mode_wire;
 
     if (request->negotiate.dialect_count > SMB2_MAX_DIALECTS) {
         chimera_smb_error("Received SMB2 NEGOTIATE request with invalid dialect count (%u max %u)",
@@ -1036,36 +1040,40 @@ chimera_smb_parse_negotiate(
     }
 
     for (i = 0; i < request->negotiate.dialect_count; i++) {
-        evpl_iovec_cursor_get_uint16(request_cursor, &request->negotiate.dialects[i]);
+        prc |= evpl_iovec_cursor_try_get_uint16(request_cursor, &request->negotiate.dialects[i]);
+    }
+
+    if (unlikely(prc)) {
+        chimera_smb_error("Received SMB2 NEGOTIATE dialect array past message");
+        return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
     }
 
     request->negotiate.ctx_present_mask = 0;
 
     if (request->negotiate.negotiate_context_count) {
-        /* Reject a context list that starts before the bytes we've already
-         * consumed — without this, the uint32 subtraction below wraps and
-         * evpl_iovec_cursor_skip burns through the rest of the cursor. */
-        if (request->negotiate.negotiate_context_offset <
-            (uint32_t) evpl_iovec_cursor_consumed(request_cursor)) {
-            chimera_smb_error("Negotiate context offset %u precedes consumed bytes %d",
-                              request->negotiate.negotiate_context_offset,
-                              evpl_iovec_cursor_consumed(request_cursor));
-            request->status = SMB2_STATUS_INVALID_PARAMETER;
-            return -1;
+        /* Seek to the context list (validated forward and within the message);
+         * smb_cursor_seek_to subsumes the old precedes-consumed underflow guard. */
+        if (unlikely(smb_cursor_seek_to(request_cursor,
+                                        request->negotiate.negotiate_context_offset) != 0)) {
+            chimera_smb_error("Negotiate context offset %u out of range",
+                              request->negotiate.negotiate_context_offset);
+            return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
         }
-
-        evpl_iovec_cursor_skip(request_cursor,
-                               request->negotiate.negotiate_context_offset -
-                               evpl_iovec_cursor_consumed(request_cursor));
 
         for (i = 0; i < request->negotiate.negotiate_context_count; i++) {
             uint16_t type, length;
             uint8_t  data[512];
+            int      crc = 0;
 
-            evpl_iovec_cursor_align64(request_cursor);
-            evpl_iovec_cursor_get_uint16(request_cursor, &type);
-            evpl_iovec_cursor_get_uint16(request_cursor, &length);
-            evpl_iovec_cursor_skip(request_cursor, 4);  /* Reserved */
+            crc |= evpl_iovec_cursor_try_skip(request_cursor, (8 - (request_cursor->consumed & 7)) & 7);
+            crc |= evpl_iovec_cursor_try_get_uint16(request_cursor, &type);
+            crc |= evpl_iovec_cursor_try_get_uint16(request_cursor, &length);
+            crc |= evpl_iovec_cursor_try_skip(request_cursor, 4);  /* Reserved */
+
+            if (unlikely(crc)) {
+                chimera_smb_error("Negotiate context header truncated");
+                return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
+            }
 
             if (length > sizeof(data)) {
                 chimera_smb_error("Negotiate context length %u exceeds parser cap %zu",
@@ -1075,7 +1083,7 @@ chimera_smb_parse_negotiate(
             }
 
             if (length > 0) {
-                if (evpl_iovec_cursor_get_blob(request_cursor, data, length) != 0) {
+                if (evpl_iovec_cursor_try_copy(request_cursor, data, length) != 0) {
                     chimera_smb_error("Negotiate context body truncated (type=0x%04x len=%u)",
                                       type, length);
                     request->status = SMB2_STATUS_INVALID_PARAMETER;

--- a/src/server/smb/smb_proc_oplock_break.c
+++ b/src/server/smb/smb_proc_oplock_break.c
@@ -409,32 +409,46 @@ chimera_smb_parse_oplock_break(
     struct evpl_iovec_cursor   *request_cursor,
     struct chimera_smb_request *request)
 {
-    uint16_t reserved;
-    uint32_t reserved32;
+    /* Initialized so a short read cannot feed an uninitialized value into the
+     * lease_state computation below (which runs before the aggregate prc check). */
+    uint16_t reserved   = 0;
+    uint32_t reserved32 = 0;
+
+    int      prc = 0;
 
     if (request->request_struct_size == SMB2_OPLOCK_BREAK_ACK_LEASE_SIZE) {
         request->oplock_break.is_lease = true;
-        evpl_iovec_cursor_get_uint16(request_cursor, &reserved);
-        evpl_iovec_cursor_get_uint32(request_cursor, &request->oplock_break.lease_flags);
-        evpl_iovec_cursor_copy(request_cursor, request->oplock_break.lease_key, 16);
-        evpl_iovec_cursor_get_uint32(request_cursor, &reserved32);
+        prc                           |= evpl_iovec_cursor_try_get_uint16(request_cursor, &reserved);
+        prc                           |= evpl_iovec_cursor_try_get_uint32(request_cursor, &request->oplock_break.
+                                                                          lease_flags);
+        prc |= evpl_iovec_cursor_try_copy(request_cursor, request->oplock_break.lease_key,
+                                          16);
+        prc                              |= evpl_iovec_cursor_try_get_uint32(request_cursor, &reserved32);
         request->oplock_break.lease_state = (uint8_t) (reserved32 & 0xff);
         /* LeaseDuration (8 bytes, reserved) sits at a 4-aligned offset; the
          * aligning get_uint64 would skip to the next 8-boundary and overrun the
          * 36-byte request.  It is unused, so just advance past it. */
-        evpl_iovec_cursor_skip(request_cursor, 8);
+        prc |= evpl_iovec_cursor_try_skip(request_cursor, 8);
     } else if (request->request_struct_size == SMB2_OPLOCK_BREAK_ACK_LEGACY_SIZE) {
         request->oplock_break.is_lease = false;
-        evpl_iovec_cursor_get_uint8(request_cursor, &request->oplock_break.oplock_level);
-        evpl_iovec_cursor_get_uint8(request_cursor, (uint8_t *) &reserved);
-        evpl_iovec_cursor_get_uint32(request_cursor, &reserved32);
-        evpl_iovec_cursor_get_uint64(request_cursor, &request->oplock_break.file_id.pid);
-        evpl_iovec_cursor_get_uint64(request_cursor, &request->oplock_break.file_id.vid);
+        prc                           |= evpl_iovec_cursor_try_get_uint8(request_cursor, &request->oplock_break.
+                                                                         oplock_level);
+        prc |= evpl_iovec_cursor_try_get_uint8(request_cursor, (uint8_t *) &reserved);
+        prc |= evpl_iovec_cursor_try_get_uint32(request_cursor, &reserved32);
+        prc |= evpl_iovec_cursor_try_get_uint64(request_cursor, &request->oplock_break.file_id
+                                                .pid);
+        prc |= evpl_iovec_cursor_try_get_uint64(request_cursor, &request->oplock_break.file_id
+                                                .vid);
     } else {
         chimera_smb_error("SMB2 OPLOCK_BREAK ack with unexpected struct size %u",
                           request->request_struct_size);
         request->status = SMB2_STATUS_INVALID_PARAMETER;
         return -1;
+    }
+
+    if (unlikely(prc)) {
+        chimera_smb_error("Received SMB2 OPLOCK_BREAK ack truncated in body");
+        return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
     }
 
     return 0;

--- a/src/server/smb/smb_proc_query_directory.c
+++ b/src/server/smb/smb_proc_query_directory.c
@@ -429,14 +429,20 @@ chimera_smb_parse_query_directory(
         return -1;
     }
 
-    evpl_iovec_cursor_get_uint8(request_cursor, &request->query_directory.info_class);
-    evpl_iovec_cursor_get_uint8(request_cursor, &request->query_directory.flags);
-    evpl_iovec_cursor_get_uint32(request_cursor, &request->query_directory.file_index);
-    evpl_iovec_cursor_get_uint64(request_cursor, &request->query_directory.file_id.pid);
-    evpl_iovec_cursor_get_uint64(request_cursor, &request->query_directory.file_id.vid);
-    evpl_iovec_cursor_get_uint16(request_cursor, &name_offset);
-    evpl_iovec_cursor_get_uint16(request_cursor, &request->query_directory.pattern_length);
-    evpl_iovec_cursor_get_uint32(request_cursor, &request->query_directory.max_output_length);
+    int prc = 0;
+    prc |= evpl_iovec_cursor_try_get_uint8(request_cursor, &request->query_directory.info_class);
+    prc |= evpl_iovec_cursor_try_get_uint8(request_cursor, &request->query_directory.flags);
+    prc |= evpl_iovec_cursor_try_get_uint32(request_cursor, &request->query_directory.file_index);
+    prc |= evpl_iovec_cursor_try_get_uint64(request_cursor, &request->query_directory.file_id.pid);
+    prc |= evpl_iovec_cursor_try_get_uint64(request_cursor, &request->query_directory.file_id.vid);
+    prc |= evpl_iovec_cursor_try_get_uint16(request_cursor, &name_offset);
+    prc |= evpl_iovec_cursor_try_get_uint16(request_cursor, &request->query_directory.pattern_length);
+    prc |= evpl_iovec_cursor_try_get_uint32(request_cursor, &request->query_directory.max_output_length);
+
+    if (unlikely(prc)) {
+        chimera_smb_error("Received SMB2 QUERY_DIRECTORY request truncated in fixed body");
+        return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
+    }
 
     request->query_directory.output_length    = 0;
     request->query_directory.eof              = 1;
@@ -449,7 +455,16 @@ chimera_smb_parse_query_directory(
         return -1;
     }
 
-    evpl_iovec_cursor_copy(request_cursor, pattern16, request->query_directory.pattern_length);
+    /* Honor the client-declared FileName offset (previously read but ignored)
+     * and pull the pattern with the bounds-checked reader. */
+    if (request->query_directory.pattern_length > 0) {
+        if (unlikely(smb_cursor_seek_to(request_cursor, name_offset) != 0 ||
+                     evpl_iovec_cursor_try_copy(request_cursor, pattern16,
+                                                request->query_directory.pattern_length) != 0)) {
+            chimera_smb_error("Received SMB2 QUERY_DIRECTORY with search pattern out of range");
+            return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
+        }
+    }
     name_size = chimera_smb_utf16le_to_utf8(&request->compound->thread->iconv_ctx,
                                             pattern16,
                                             request->query_directory.pattern_length,

--- a/src/server/smb/smb_proc_query_info.c
+++ b/src/server/smb/smb_proc_query_info.c
@@ -545,15 +545,21 @@ chimera_smb_parse_query_info(
         return -1;
     }
 
-    evpl_iovec_cursor_get_uint8(request_cursor, &request->query_info.info_type);
-    evpl_iovec_cursor_get_uint8(request_cursor, &request->query_info.info_class);
-    evpl_iovec_cursor_get_uint32(request_cursor, &max_response_size);
-    evpl_iovec_cursor_get_uint16(request_cursor, &input_offset);
-    evpl_iovec_cursor_get_uint32(request_cursor, &input_size);
-    evpl_iovec_cursor_get_uint32(request_cursor, &request->query_info.addl_info);
-    evpl_iovec_cursor_get_uint32(request_cursor, &request->query_info.flags);
-    evpl_iovec_cursor_get_uint64(request_cursor, &request->query_info.file_id.pid);
-    evpl_iovec_cursor_get_uint64(request_cursor, &request->query_info.file_id.vid);
+    int prc = 0;
+    prc |= evpl_iovec_cursor_try_get_uint8(request_cursor, &request->query_info.info_type);
+    prc |= evpl_iovec_cursor_try_get_uint8(request_cursor, &request->query_info.info_class);
+    prc |= evpl_iovec_cursor_try_get_uint32(request_cursor, &max_response_size);
+    prc |= evpl_iovec_cursor_try_get_uint16(request_cursor, &input_offset);
+    prc |= evpl_iovec_cursor_try_get_uint32(request_cursor, &input_size);
+    prc |= evpl_iovec_cursor_try_get_uint32(request_cursor, &request->query_info.addl_info);
+    prc |= evpl_iovec_cursor_try_get_uint32(request_cursor, &request->query_info.flags);
+    prc |= evpl_iovec_cursor_try_get_uint64(request_cursor, &request->query_info.file_id.pid);
+    prc |= evpl_iovec_cursor_try_get_uint64(request_cursor, &request->query_info.file_id.vid);
+
+    if (unlikely(prc)) {
+        chimera_smb_error("Received SMB2 QUERY_INFO request truncated in fixed body");
+        return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
+    }
 
     return 0;
 } /* chimera_smb_parse_query_info */

--- a/src/server/smb/smb_proc_read.c
+++ b/src/server/smb/smb_proc_read.c
@@ -200,20 +200,30 @@ chimera_smb_parse_read(
      * below realigns to a 4-byte boundary, so a single byte read here would
      * capture Padding and silently skip the Flags field (which carries
      * SMB2_READFLAG_REQUEST_COMPRESSED). */
-    evpl_iovec_cursor_get_uint8(request_cursor, &padding);
-    evpl_iovec_cursor_get_uint8(request_cursor, &request->read.flags);
-    evpl_iovec_cursor_get_uint32(request_cursor, &request->read.length);
-    evpl_iovec_cursor_get_uint64(request_cursor, &request->read.offset);
-    evpl_iovec_cursor_get_uint64(request_cursor, &request->read.file_id.pid);
-    evpl_iovec_cursor_get_uint64(request_cursor, &request->read.file_id.vid);
-    evpl_iovec_cursor_get_uint32(request_cursor, &request->read.minimum);
-    evpl_iovec_cursor_get_uint32(request_cursor, &request->read.channel);
-    evpl_iovec_cursor_get_uint32(request_cursor, &request->read.remaining);
-    evpl_iovec_cursor_get_uint16(request_cursor, &blob_offset);
-    evpl_iovec_cursor_get_uint16(request_cursor, &blob_length);
+    int      prc = 0;
+
+    prc |= evpl_iovec_cursor_try_get_uint8(request_cursor, &padding);
+    prc |= evpl_iovec_cursor_try_get_uint8(request_cursor, &request->read.flags);
+    prc |= evpl_iovec_cursor_try_get_uint32(request_cursor, &request->read.length);
+    prc |= evpl_iovec_cursor_try_get_uint64(request_cursor, &request->read.offset);
+    prc |= evpl_iovec_cursor_try_get_uint64(request_cursor, &request->read.file_id.pid);
+    prc |= evpl_iovec_cursor_try_get_uint64(request_cursor, &request->read.file_id.vid);
+    prc |= evpl_iovec_cursor_try_get_uint32(request_cursor, &request->read.minimum);
+    prc |= evpl_iovec_cursor_try_get_uint32(request_cursor, &request->read.channel);
+    prc |= evpl_iovec_cursor_try_get_uint32(request_cursor, &request->read.remaining);
+    prc |= evpl_iovec_cursor_try_get_uint16(request_cursor, &blob_offset);
+    prc |= evpl_iovec_cursor_try_get_uint16(request_cursor, &blob_length);
+
+    if (unlikely(prc)) {
+        chimera_smb_error("Received SMB2 READ request truncated in fixed body");
+        return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
+    }
 
     if (request->read.channel == SMB2_CHANNEL_RDMA_V1) {
-        evpl_iovec_cursor_skip(request_cursor, blob_offset - evpl_iovec_cursor_consumed(request_cursor));
+        if (unlikely(smb_cursor_seek_to(request_cursor, blob_offset) != 0)) {
+            chimera_smb_error("Received SMB2 READ with RDMA channel offset out of range");
+            return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
+        }
 
         request->read.num_rdma_elements = blob_length >> 4;
 
@@ -224,9 +234,14 @@ chimera_smb_parse_read(
         }
 
         for (i = 0; i < request->read.num_rdma_elements; i++) {
-            evpl_iovec_cursor_get_uint64(request_cursor, &request->read.rdma_elements[i].offset);
-            evpl_iovec_cursor_get_uint32(request_cursor, &request->read.rdma_elements[i].token);
-            evpl_iovec_cursor_get_uint32(request_cursor, &request->read.rdma_elements[i].length);
+            prc |= evpl_iovec_cursor_try_get_uint64(request_cursor, &request->read.rdma_elements[i].offset);
+            prc |= evpl_iovec_cursor_try_get_uint32(request_cursor, &request->read.rdma_elements[i].token);
+            prc |= evpl_iovec_cursor_try_get_uint32(request_cursor, &request->read.rdma_elements[i].length);
+        }
+
+        if (unlikely(prc)) {
+            chimera_smb_error("Received SMB2 READ with RDMA descriptor list past message");
+            return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
         }
     }
 

--- a/src/server/smb/smb_proc_session_setup.c
+++ b/src/server/smb/smb_proc_session_setup.c
@@ -553,17 +553,30 @@ chimera_smb_parse_session_setup(
         return -1;
     }
 
-    evpl_iovec_cursor_get_uint8(request_cursor, &request->session_setup.flags);
-    evpl_iovec_cursor_get_uint8(request_cursor, &request->session_setup.security_mode);
-    evpl_iovec_cursor_get_uint32(request_cursor, &request->session_setup.capabilities);
-    evpl_iovec_cursor_get_uint32(request_cursor, &request->session_setup.channel);
-    evpl_iovec_cursor_get_uint16(request_cursor, &request->session_setup.blob_offset);
-    evpl_iovec_cursor_get_uint16(request_cursor, &request->session_setup.blob_length);
-    evpl_iovec_cursor_get_uint64(request_cursor, &request->session_setup.prev_session_id);
+    int prc = 0;
+    prc |= evpl_iovec_cursor_try_get_uint8(request_cursor, &request->session_setup.flags);
+    prc |= evpl_iovec_cursor_try_get_uint8(request_cursor, &request->session_setup.security_mode);
+    prc |= evpl_iovec_cursor_try_get_uint32(request_cursor, &request->session_setup.capabilities);
+    prc |= evpl_iovec_cursor_try_get_uint32(request_cursor, &request->session_setup.channel);
+    prc |= evpl_iovec_cursor_try_get_uint16(request_cursor, &request->session_setup.blob_offset);
+    prc |= evpl_iovec_cursor_try_get_uint16(request_cursor, &request->session_setup.blob_length);
+    prc |= evpl_iovec_cursor_try_get_uint64(request_cursor, &request->session_setup.prev_session_id);
 
-    evpl_iovec_cursor_skip(request_cursor,
-                           request->session_setup.blob_offset - evpl_iovec_cursor_consumed(request_cursor));
+    if (unlikely(prc)) {
+        chimera_smb_error("Received SMB2 SESSION_SETUP request truncated in fixed body");
+        return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
+    }
 
+    /* The security buffer sits at a client-declared offset and must fit within
+     * this request's window; reject a bogus offset/length rather than seeking or
+     * moving out of bounds. */
+    if (request->session_setup.blob_length > 0) {
+        if (unlikely(smb_cursor_seek_to(request_cursor, request->session_setup.blob_offset) != 0 ||
+                     request->session_setup.blob_length > (uint32_t) evpl_iovec_cursor_remaining(request_cursor))) {
+            chimera_smb_error("Received SMB2 SESSION_SETUP with security buffer out of range");
+            return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
+        }
+    }
 
     request->session_setup.input_niov = evpl_iovec_cursor_move(request_cursor,
                                                                request->session_setup.input_iov,

--- a/src/server/smb/smb_proc_set_info.c
+++ b/src/server/smb/smb_proc_set_info.c
@@ -405,16 +405,29 @@ chimera_smb_parse_set_info(
         return -1;
     }
 
-    evpl_iovec_cursor_get_uint8(request_cursor, &request->set_info.info_type);
-    evpl_iovec_cursor_get_uint8(request_cursor, &request->set_info.info_class);
-    evpl_iovec_cursor_get_uint32(request_cursor, &request->set_info.buffer_length);
-    evpl_iovec_cursor_get_uint16(request_cursor, &request->set_info.buffer_offset);
-    evpl_iovec_cursor_get_uint32(request_cursor, &request->set_info.addl_info);
-    evpl_iovec_cursor_get_uint64(request_cursor, &request->set_info.file_id.pid);
-    evpl_iovec_cursor_get_uint64(request_cursor, &request->set_info.file_id.vid);
+    int prc = 0;
+    prc |= evpl_iovec_cursor_try_get_uint8(request_cursor, &request->set_info.info_type);
+    prc |= evpl_iovec_cursor_try_get_uint8(request_cursor, &request->set_info.info_class);
+    prc |= evpl_iovec_cursor_try_get_uint32(request_cursor, &request->set_info.buffer_length);
+    prc |= evpl_iovec_cursor_try_get_uint16(request_cursor, &request->set_info.buffer_offset);
+    prc |= evpl_iovec_cursor_try_get_uint32(request_cursor, &request->set_info.addl_info);
+    prc |= evpl_iovec_cursor_try_get_uint64(request_cursor, &request->set_info.file_id.pid);
+    prc |= evpl_iovec_cursor_try_get_uint64(request_cursor, &request->set_info.file_id.vid);
 
-    evpl_iovec_cursor_skip(request_cursor,
-                           request->set_info.buffer_offset - evpl_iovec_cursor_consumed(request_cursor));
+    if (unlikely(prc)) {
+        chimera_smb_error("Received SMB2 SET_INFO request truncated in fixed body");
+        return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
+    }
+
+    /* Seek to the client-declared input buffer and fence the cursor to exactly
+     * buffer_length bytes, so the per-info-class sub-parsers below can read only
+     * within the declared buffer (and reject cleanly if it is too short). */
+    if (unlikely(smb_cursor_seek_to(request_cursor, request->set_info.buffer_offset) != 0 ||
+                 request->set_info.buffer_length > (uint32_t) evpl_iovec_cursor_remaining(request_cursor))) {
+        chimera_smb_error("Received SMB2 SET_INFO with input buffer out of range");
+        return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
+    }
+    evpl_iovec_cursor_set_limit(request_cursor, request->set_info.buffer_length);
 
     request->set_info.attrs.smb_attr_mask = 0;
 
@@ -422,17 +435,17 @@ chimera_smb_parse_set_info(
         case SMB2_INFO_FILE:
             switch (request->set_info.info_class) {
                 case SMB2_FILE_BASIC_INFO:
-                    chimera_smb_parse_basic_info(request_cursor, &request->set_info.attrs);
+                    rc = chimera_smb_parse_basic_info(request_cursor, &request->set_info.attrs);
                     break;
                 case SMB2_FILE_DISPOSITION_INFO:
-                    chimera_smb_parse_disposition_info(request_cursor, &request->set_info.attrs);
+                    rc = chimera_smb_parse_disposition_info(request_cursor, &request->set_info.attrs);
                     break;
                 case SMB2_FILE_DISPOSITION_INFO_EX:
-                    chimera_smb_parse_disposition_info_ex(request_cursor, &request->set_info.attrs);
+                    rc = chimera_smb_parse_disposition_info_ex(request_cursor, &request->set_info.attrs);
                     break;
                 case SMB2_FILE_ENDOFFILE_INFO:
                 case SMB2_FILE_ALLOCATION_INFO:
-                    chimera_smb_parse_end_of_file_info(
+                    rc = chimera_smb_parse_end_of_file_info(
                         request_cursor,
                         &request->set_info.attrs);
                     break;
@@ -444,7 +457,7 @@ chimera_smb_parse_set_info(
                     /* EAs not supported, accept and ignore */
                     break;
                 case SMB2_FILE_POSITION_INFO:
-                    chimera_smb_parse_position_info(request_cursor, &request->set_info.attrs);
+                    rc = chimera_smb_parse_position_info(request_cursor, &request->set_info.attrs);
                     break;
 
                 default:
@@ -457,8 +470,10 @@ chimera_smb_parse_set_info(
             break;
         case SMB2_INFO_SECURITY:
             if (request->set_info.buffer_length <= sizeof(request->set_info.sec_buf)) {
-                evpl_iovec_cursor_copy(request_cursor, request->set_info.sec_buf,
-                                       request->set_info.buffer_length);
+                if (unlikely(evpl_iovec_cursor_try_copy(request_cursor, request->set_info.sec_buf,
+                                                        request->set_info.buffer_length) != 0)) {
+                    return chimera_smb_parse_reject(request, SMB2_STATUS_INFO_LENGTH_MISMATCH);
+                }
                 request->set_info.sec_buf_len = request->set_info.buffer_length;
             } else {
                 chimera_smb_error("parse_set_info: security descriptor too large (%u bytes)",
@@ -473,5 +488,13 @@ chimera_smb_parse_set_info(
             rc              = -1;
             break;
     } /* switch */
+
+    /* A sub-parser that ran off the end of the declared buffer returns -1
+     * without setting a status; answer that cleanly as a length mismatch rather
+     * than letting the dispatcher tear down the connection. */
+    if (rc != 0 && request->status == SMB2_STATUS_SUCCESS) {
+        return chimera_smb_parse_reject(request, SMB2_STATUS_INFO_LENGTH_MISMATCH);
+    }
+
     return rc;
 } /* chimera_smb_parse_set_info */

--- a/src/server/smb/smb_proc_set_info_rename.c
+++ b/src/server/smb/smb_proc_set_info_rename.c
@@ -407,16 +407,24 @@ chimera_smb_parse_rename_info(
     /* Initialize the new_parent_handle to NULL */
     rename_info->new_parent_handle = NULL;
 
-    evpl_iovec_cursor_get_uint8(cursor, &rename_info->replace_if_exist);
-    evpl_iovec_cursor_skip(cursor, 7); /* Reserved */
-    evpl_iovec_cursor_get_uint64(cursor, &root_dir);
+    int                             prc = 0;
+    prc |= evpl_iovec_cursor_try_get_uint8(cursor, &rename_info->replace_if_exist);
+    prc |= evpl_iovec_cursor_try_skip(cursor, 7); /* Reserved */
+    prc |= evpl_iovec_cursor_try_get_uint64(cursor, &root_dir);
+    prc |= evpl_iovec_cursor_try_get_uint32(cursor, &name_len);
+
+    if (unlikely(prc)) {
+        chimera_smb_error("SET_INFO RENAME_INFO request truncated in fixed body");
+        request->status = SMB2_STATUS_INFO_LENGTH_MISMATCH;
+        return -1;
+    }
+
     if (root_dir != 0) {
         // Non-zero root directory not supported
         chimera_smb_error("SET_INFO RENAME_INFO with non-zero root directory not supported");
         request->status = SMB2_STATUS_INVALID_PARAMETER;
         return -1;
     }
-    evpl_iovec_cursor_get_uint32(cursor, &name_len);
     if (name_len > sizeof(name16)) {
         chimera_smb_error("SET_INFO RENAME_INFO request: UTF-16 name too long (%u bytes)",
                           name_len);
@@ -424,7 +432,11 @@ chimera_smb_parse_rename_info(
         return -1;
     }
 
-    evpl_iovec_cursor_copy(cursor, (uint8_t *) name16, name_len);
+    if (unlikely(evpl_iovec_cursor_try_copy(cursor, (uint8_t *) name16, name_len) != 0)) {
+        chimera_smb_error("SET_INFO RENAME_INFO name runs past the input buffer");
+        request->status = SMB2_STATUS_INFO_LENGTH_MISMATCH;
+        return -1;
+    }
     /* Convert UTF-16LE name to UTF-8 */
     rename_info->new_parent_len = chimera_smb_utf16le_to_utf8(&request->compound->thread->iconv_ctx,
                                                               name16,

--- a/src/server/smb/smb_proc_tree_connect.c
+++ b/src/server/smb/smb_proc_tree_connect.c
@@ -168,19 +168,37 @@ chimera_smb_parse_tree_connect(
         return -1;
     }
 
-    evpl_iovec_cursor_get_uint16(request_cursor, &request->tree_connect.flags);
-    evpl_iovec_cursor_get_uint16(request_cursor, &request->tree_connect.path_offset);
-    evpl_iovec_cursor_get_uint16(request_cursor, &request->tree_connect.path_length);
+    int prc = 0;
+    prc |= evpl_iovec_cursor_try_get_uint16(request_cursor, &request->tree_connect.flags);
+    prc |= evpl_iovec_cursor_try_get_uint16(request_cursor, &request->tree_connect.path_offset);
+    prc |= evpl_iovec_cursor_try_get_uint16(request_cursor, &request->tree_connect.path_length);
 
-    if (unlikely(request->tree_connect.path_length > CHIMERA_VFS_PATH_MAX)) {
-        chimera_smb_error("Received SMB2 TREE_CONNECT request with invalid path length (%u max %u)",
+    if (unlikely(prc)) {
+        chimera_smb_error("Received SMB2 TREE_CONNECT request truncated in fixed body");
+        return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
+    }
+
+    /* Bound against the UTF-16 staging buffer (path16), NOT CHIMERA_VFS_PATH_MAX:
+     * path16 holds SMB_FILENAME_MAX uint16 units, so a PathLength above its byte
+     * size would overflow this stack buffer. */
+    if (unlikely(request->tree_connect.path_length > sizeof(path16))) {
+        chimera_smb_error("Received SMB2 TREE_CONNECT request with invalid path length (%u max %zu)",
                           request->tree_connect.path_length,
-                          CHIMERA_VFS_PATH_MAX);
+                          sizeof(path16));
         request->status = SMB2_STATUS_INVALID_PARAMETER;
         return -1;
     }
 
-    evpl_iovec_cursor_copy(request_cursor, path16, request->tree_connect.path_length);
+    /* Honor the client-declared PathOffset (previously read but ignored) and
+     * pull the path with the bounds-checked reader. */
+    if (request->tree_connect.path_length > 0) {
+        if (unlikely(smb_cursor_seek_to(request_cursor, request->tree_connect.path_offset) != 0 ||
+                     evpl_iovec_cursor_try_copy(request_cursor, path16,
+                                                request->tree_connect.path_length) != 0)) {
+            chimera_smb_error("Received SMB2 TREE_CONNECT with path out of range");
+            return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
+        }
+    }
 
     name_size = chimera_smb_utf16le_to_utf8(&request->compound->thread->iconv_ctx,
                                             path16,

--- a/src/server/smb/smb_proc_write.c
+++ b/src/server/smb/smb_proc_write.c
@@ -318,20 +318,30 @@ chimera_smb_parse_write(
     uint32_t     total_length;
     int          i;
 
-    evpl_iovec_cursor_get_uint16(request_cursor, &data_offset);
-    evpl_iovec_cursor_get_uint32(request_cursor, &request->write.length);
-    evpl_iovec_cursor_get_uint64(request_cursor, &request->write.offset);
-    evpl_iovec_cursor_get_uint64(request_cursor, &request->write.file_id.pid);
-    evpl_iovec_cursor_get_uint64(request_cursor, &request->write.file_id.vid);
-    evpl_iovec_cursor_get_uint32(request_cursor, &request->write.channel);
-    evpl_iovec_cursor_get_uint32(request_cursor, &request->write.remaining);
-    evpl_iovec_cursor_get_uint16(request_cursor, &blob_offset);
-    evpl_iovec_cursor_get_uint16(request_cursor, &blob_length);
-    evpl_iovec_cursor_get_uint32(request_cursor, &request->write.flags);
+    int          prc = 0;
+
+    prc |= evpl_iovec_cursor_try_get_uint16(request_cursor, &data_offset);
+    prc |= evpl_iovec_cursor_try_get_uint32(request_cursor, &request->write.length);
+    prc |= evpl_iovec_cursor_try_get_uint64(request_cursor, &request->write.offset);
+    prc |= evpl_iovec_cursor_try_get_uint64(request_cursor, &request->write.file_id.pid);
+    prc |= evpl_iovec_cursor_try_get_uint64(request_cursor, &request->write.file_id.vid);
+    prc |= evpl_iovec_cursor_try_get_uint32(request_cursor, &request->write.channel);
+    prc |= evpl_iovec_cursor_try_get_uint32(request_cursor, &request->write.remaining);
+    prc |= evpl_iovec_cursor_try_get_uint16(request_cursor, &blob_offset);
+    prc |= evpl_iovec_cursor_try_get_uint16(request_cursor, &blob_length);
+    prc |= evpl_iovec_cursor_try_get_uint32(request_cursor, &request->write.flags);
+
+    if (unlikely(prc)) {
+        chimera_smb_error("Received SMB2 WRITE request truncated in fixed body");
+        return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
+    }
 
     if (request->write.channel == SMB2_CHANNEL_RDMA_V1) {
 
-        evpl_iovec_cursor_skip(request_cursor, blob_offset - evpl_iovec_cursor_consumed(request_cursor));
+        if (unlikely(smb_cursor_seek_to(request_cursor, blob_offset) != 0)) {
+            chimera_smb_error("Received SMB2 WRITE with RDMA channel offset out of range");
+            return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
+        }
 
         request->write.num_rdma_elements = blob_length >> 4;
 
@@ -344,10 +354,15 @@ chimera_smb_parse_write(
         total_length = 0;
 
         for (i = 0; i < request->write.num_rdma_elements; i++) {
-            evpl_iovec_cursor_get_uint64(request_cursor, &request->write.rdma_elements[i].offset);
-            evpl_iovec_cursor_get_uint32(request_cursor, &request->write.rdma_elements[i].token);
-            evpl_iovec_cursor_get_uint32(request_cursor, &request->write.rdma_elements[i].length);
+            prc          |= evpl_iovec_cursor_try_get_uint64(request_cursor, &request->write.rdma_elements[i].offset);
+            prc          |= evpl_iovec_cursor_try_get_uint32(request_cursor, &request->write.rdma_elements[i].token);
+            prc          |= evpl_iovec_cursor_try_get_uint32(request_cursor, &request->write.rdma_elements[i].length);
             total_length += request->write.rdma_elements[i].length;
+        }
+
+        if (unlikely(prc)) {
+            chimera_smb_error("Received SMB2 WRITE with RDMA descriptor list past message");
+            return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
         }
 
         if (unlikely(total_length != request->write.remaining)) {
@@ -361,6 +376,16 @@ chimera_smb_parse_write(
         request->write.niov = evpl_iovec_alloc(evpl, request->write.length, 4096, 1, 0, request->write.iov);
 
     } else {
+        /* The payload sits at the client-declared DataOffset and must fit inside
+         * this request's window; otherwise the move would pull bytes from the
+         * next compound element or off the end of the received data. */
+        if (request->write.length > 0) {
+            if (unlikely(smb_cursor_seek_to(request_cursor, data_offset) != 0 ||
+                         request->write.length > (uint32_t) evpl_iovec_cursor_remaining(request_cursor))) {
+                chimera_smb_error("Received SMB2 WRITE with data offset/length out of range");
+                return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
+            }
+        }
         request->write.niov = evpl_iovec_cursor_move(request_cursor, request->write.iov, 256, request->write.length, 1);
     }
 

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -55,6 +55,15 @@ target_include_directories(phase0_contexts_test PRIVATE ${CMAKE_SOURCE_DIR}/src)
 add_test(NAME chimera/server/smb/phase0_contexts_test
     COMMAND ${CMAKE_CURRENT_BINARY_DIR}/phase0_contexts_test)
 
+# SMB2 request-parse hardening: checked cursor primitives, safe seek, and
+# CREATE-context bounds arithmetic against malformed/adversarial input.
+add_executable(smb_harden_test smb_harden_test.c)
+target_link_libraries(smb_harden_test chimera_server chimera_smb)
+target_include_directories(smb_harden_test PRIVATE ${CMAKE_SOURCE_DIR}/src)
+
+add_test(NAME chimera/server/smb/harden_test
+    COMMAND ${CMAKE_CURRENT_BINARY_DIR}/smb_harden_test)
+
 # SMB3 transport-compression codec unit test (pure MS-XCA Plain LZ77)
 add_executable(smb_compress_test smb_compress_test.c)
 target_link_libraries(smb_compress_test chimera_server chimera_smb)

--- a/src/server/smb/tests/smb_harden_test.c
+++ b/src/server/smb/tests/smb_harden_test.c
@@ -1,0 +1,307 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * Hardening unit tests for the SMB2 request parse path.
+ *
+ * These exercise the bounds-checked cursor primitives, the safe-seek helper,
+ * and the CREATE-context bounds arithmetic with malformed/adversarial input.
+ * The whole point is that none of these inputs may abort() or read out of
+ * bounds -- a malformed request must be rejected cleanly.  Run under the Debug
+ * (AddressSanitizer) build so an over-read is a hard failure, not a silent pass.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+
+#include "common/evpl_iovec_cursor.h"
+#include "server/smb/smb_internal.h"
+#include "server/smb/smb_procs.h"
+
+static int passed = 0;
+static int failed = 0;
+
+#define TEST_PASS(name)   do { fprintf(stderr, "  PASS: %s\n", name); passed++; } while (0)
+#define TEST_FAIL(name)   do { fprintf(stderr, "  FAIL: %s\n", name); failed++; } while (0)
+#define CHECK(cond, name) do { if (cond) { TEST_PASS(name); } else { TEST_FAIL(name); } } while (0)
+
+static void
+put_le32(
+    uint8_t *buf,
+    uint32_t off,
+    uint32_t v)
+{
+    buf[off]     = v & 0xff;
+    buf[off + 1] = (v >> 8) & 0xff;
+    buf[off + 2] = (v >> 16) & 0xff;
+    buf[off + 3] = (v >> 24) & 0xff;
+} /* put_le32 */
+
+static void
+put_le16(
+    uint8_t *buf,
+    uint32_t off,
+    uint16_t v)
+{
+    buf[off]     = v & 0xff;
+    buf[off + 1] = (v >> 8) & 0xff;
+} /* put_le16 */
+
+/* Build a cursor over a single contiguous buffer (ref unused by the readers). */
+static void
+cursor_over(
+    struct evpl_iovec_cursor *cursor,
+    struct evpl_iovec        *iov,
+    void                     *buf,
+    int                       len)
+{
+    iov->data   = buf;
+    iov->length = len;
+    iov->pad    = 0;
+    iov->ref    = NULL;
+    evpl_iovec_cursor_init(cursor, iov, 1);
+} /* cursor_over */
+
+/* ------------------------------------------------------------------ *
+*  Checked cursor primitives                                         *
+* ------------------------------------------------------------------ */
+
+static void
+test_try_readers_within_data(void)
+{
+    uint8_t                  buf[16];
+    struct evpl_iovec        iov;
+    struct evpl_iovec_cursor cur;
+    uint32_t                 v32;
+    uint16_t                 v16;
+    int                      rc;
+
+    for (int i = 0; i < 16; i++) {
+        buf[i] = (uint8_t) i;
+    }
+
+    cursor_over(&cur, &iov, buf, sizeof(buf));
+
+    rc  = evpl_iovec_cursor_try_get_uint16(&cur, &v16);
+    rc |= evpl_iovec_cursor_try_get_uint16(&cur, &v16); /* realign pad */
+    rc |= evpl_iovec_cursor_try_get_uint32(&cur, &v32);
+    CHECK(rc == 0, "checked readers succeed within data");
+} /* test_try_readers_within_data */
+
+static void
+test_try_copy_past_end_rejected(void)
+{
+    uint8_t                  buf[8] = { 0 };
+    uint8_t                  out[32];
+    struct evpl_iovec        iov;
+    struct evpl_iovec_cursor cur;
+
+    cursor_over(&cur, &iov, buf, sizeof(buf));
+
+    /* Ask for 32 bytes from an 8-byte buffer: must return -1, never abort. */
+    CHECK(evpl_iovec_cursor_try_copy(&cur, out, 32) == -1,
+          "try_copy past end of data returns -1 (no abort)");
+} /* test_try_copy_past_end_rejected */
+
+static void
+test_limit_fences_reads(void)
+{
+    uint8_t                  buf[64] = { 0 };
+    uint8_t                  out[16];
+    struct evpl_iovec        iov;
+    struct evpl_iovec_cursor cur;
+
+    cursor_over(&cur, &iov, buf, sizeof(buf));
+
+    /* Plenty of data (64 bytes) but fence the window to 8. */
+    evpl_iovec_cursor_set_limit(&cur, 8);
+
+    CHECK(evpl_iovec_cursor_remaining(&cur) == 8, "remaining reflects the limit");
+    CHECK(evpl_iovec_cursor_try_copy(&cur, out, 8) == 0,
+          "read up to the limit succeeds");
+    CHECK(evpl_iovec_cursor_remaining(&cur) == 0, "remaining hits zero at limit");
+    CHECK(evpl_iovec_cursor_try_get_uint8(&cur, out) == -1,
+          "read past the limit (but within data) is rejected");
+} /* test_limit_fences_reads */
+
+static void
+test_unbounded_default(void)
+{
+    uint8_t                  buf[8] = { 0 };
+    uint8_t                  out[8];
+    struct evpl_iovec        iov;
+    struct evpl_iovec_cursor cur;
+
+    cursor_over(&cur, &iov, buf, sizeof(buf));
+
+    /* Without set_limit the limit is INT_MAX, so remaining is bounded only by
+     * data; a full-buffer read must still succeed. */
+    CHECK(evpl_iovec_cursor_remaining(&cur) > (int) sizeof(buf),
+          "default limit is effectively unbounded");
+    CHECK(evpl_iovec_cursor_try_copy(&cur, out, 8) == 0,
+          "default-limit read bounded only by data");
+} /* test_unbounded_default */
+
+/* ------------------------------------------------------------------ *
+*  smb_cursor_seek_to                                                *
+* ------------------------------------------------------------------ */
+
+static void
+test_seek_to(void)
+{
+    uint8_t                  buf[64] = { 0 };
+    struct evpl_iovec        iov;
+    struct evpl_iovec_cursor cur;
+    uint32_t                 v32;
+
+    cursor_over(&cur, &iov, buf, sizeof(buf));
+    evpl_iovec_cursor_set_limit(&cur, 64);
+
+    /* Consume 8 bytes so consumed == 8. */
+    evpl_iovec_cursor_try_get_uint32(&cur, &v32);
+    evpl_iovec_cursor_try_get_uint32(&cur, &v32);
+
+    CHECK(smb_cursor_seek_to(&cur, 4) == -1,
+          "seek backward (offset < consumed) rejected");
+    CHECK(smb_cursor_seek_to(&cur, 32) == 0,
+          "seek forward within window accepted");
+    CHECK(smb_cursor_seek_to(&cur, 4096) == -1,
+          "seek past the window rejected (no abort)");
+} /* test_seek_to */
+
+/*
+ * Regression: a compound element whose parser fences a sub-buffer (SET_INFO /
+ * IOCTL call set_limit on the shared cursor) must not leave that smaller limit
+ * in place for the compound loop's skip to the next element.  This reproduces
+ * the cursor interaction that closed connections on the Linux kernel client's
+ * CREATE+SET_INFO+CLOSE compounds: with next_command=128, a SET_INFO sub-window
+ * of buffer_length=16 clobbers the element limit, and the skip to offset 128
+ * would fail unless the element boundary is restored first.
+ */
+static void
+test_compound_subwindow_then_skip(void)
+{
+    uint8_t                  buf[256] = { 0 };
+    struct evpl_iovec        iov;
+    struct evpl_iovec_cursor cur;
+    uint8_t                  sink[16];
+
+    cursor_over(&cur, &iov, buf, sizeof(buf));
+
+    /* Element window = NextCommand (128). */
+    evpl_iovec_cursor_set_limit(&cur, 128);
+
+    /* Parse a fixed body (consume 96), then a SET_INFO-style sub-buffer at
+     * offset 96 fenced to 16 bytes, fully consumed. */
+    CHECK(evpl_iovec_cursor_try_skip(&cur, 96) == 0, "consume fixed body");
+    evpl_iovec_cursor_set_limit(&cur, 16);           /* clobbers element limit */
+    CHECK(evpl_iovec_cursor_try_copy(&cur, sink, 16) == 0, "read sub-buffer");
+
+    /* Without restoring the element limit the skip to NextCommand=128 is
+     * rejected (remaining() is now 0).  Restore it, then the skip must succeed. */
+    CHECK(smb_cursor_seek_to(&cur, 128) == -1,
+          "skip is (correctly) blocked while the sub-window limit is in place");
+    evpl_iovec_cursor_set_limit(&cur, 128 - evpl_iovec_cursor_consumed(&cur));
+    CHECK(smb_cursor_seek_to(&cur, 128) == 0,
+          "skip to next compound element succeeds after restoring element limit");
+} /* test_compound_subwindow_then_skip */
+
+/* ------------------------------------------------------------------ *
+*  CREATE-context bounds arithmetic                                  *
+* ------------------------------------------------------------------ */
+
+/* A DataLength near UINT32_MAX must not wrap the bounds check (data_off +
+ * data_len) and let an out-of-bounds data pointer through. */
+static void
+test_create_ctx_datalen_uint32_overflow(void)
+{
+    struct chimera_smb_request req;
+    uint8_t                    buf[64] = { 0 };
+
+    memset(&req, 0, sizeof(req));
+
+    put_le32(buf, 0, 0);            /* Next = 0 (last)           */
+    put_le16(buf, 4, 16);           /* NameOffset                */
+    put_le16(buf, 6, 4);            /* NameLength                */
+    put_le16(buf, 10, 24);          /* DataOffset                */
+    put_le32(buf, 12, 0xFFFFFFFF);  /* DataLength: wraps if added */
+    memcpy(buf + 16, "DH2Q", 4);
+
+    CHECK(chimera_smb_parse_create_contexts(buf, sizeof(buf), &req) < 0 &&
+          req.status == SMB2_STATUS_INVALID_PARAMETER,
+          "CREATE ctx: UINT32-overflow DataLength rejected (no OOB)");
+} /* test_create_ctx_datalen_uint32_overflow */
+
+/* A Next field near UINT32_MAX must not wrap (pos + next) and loop forever or
+ * skip the bounds check. */
+static void
+test_create_ctx_next_uint32_overflow(void)
+{
+    struct chimera_smb_request req;
+    uint8_t                    buf[64] = { 0 };
+
+    memset(&req, 0, sizeof(req));
+
+    put_le32(buf, 0, 0xFFFFFFF8);  /* Next: 8-aligned but wraps pos+next */
+    put_le16(buf, 4, 16);
+    put_le16(buf, 6, 4);
+    put_le16(buf, 10, 0);
+    put_le32(buf, 12, 0);
+    memcpy(buf + 16, "MxAc", 4);
+
+    CHECK(chimera_smb_parse_create_contexts(buf, sizeof(buf), &req) < 0 &&
+          req.status == SMB2_STATUS_INVALID_PARAMETER,
+          "CREATE ctx: UINT32-overflow Next rejected (no wrap)");
+} /* test_create_ctx_next_uint32_overflow */
+
+/* NameOffset/NameLength that run past the entry must be rejected. */
+static void
+test_create_ctx_name_overflow(void)
+{
+    struct chimera_smb_request req;
+    uint8_t                    buf[32] = { 0 };
+
+    memset(&req, 0, sizeof(req));
+
+    put_le32(buf, 0, 0);
+    put_le16(buf, 4, 16);           /* NameOffset 16 */
+    put_le16(buf, 6, 0xFFFF);       /* NameLength huge */
+    put_le16(buf, 10, 0);
+    put_le32(buf, 12, 0);
+
+    CHECK(chimera_smb_parse_create_contexts(buf, sizeof(buf), &req) < 0 &&
+          req.status == SMB2_STATUS_INVALID_PARAMETER,
+          "CREATE ctx: oversized NameLength rejected");
+} /* test_create_ctx_name_overflow */
+
+int
+main(
+    int   argc,
+    char *argv[])
+{
+    (void) argc;
+    (void) argv;
+
+    chimera_log_init();
+
+    fprintf(stderr, "=== SMB parse hardening: checked cursor primitives ===\n");
+    test_try_readers_within_data();
+    test_try_copy_past_end_rejected();
+    test_limit_fences_reads();
+    test_unbounded_default();
+
+    fprintf(stderr, "=== SMB parse hardening: smb_cursor_seek_to ===\n");
+    test_seek_to();
+    test_compound_subwindow_then_skip();
+
+    fprintf(stderr, "=== SMB parse hardening: CREATE-context bounds ===\n");
+    test_create_ctx_datalen_uint32_overflow();
+    test_create_ctx_next_uint32_overflow();
+    test_create_ctx_name_overflow();
+
+    fprintf(stderr, "\nTotal: %d passed, %d failed\n", passed, failed);
+    return failed == 0 ? 0 : 1;
+} /* main */


### PR DESCRIPTION
## Problem

The SMB2 server walks an `evpl_iovec_cursor` over the received bytes and pulls fields directly into request structs, trusting client-supplied lengths and offsets. The failure mode is the worst possible one for a **threaded** server: the cursor primitives `abort()` the whole process on a short read. A single malformed request could crash the entire daemon (all connections) or read out of bounds.

Three classes of defect:

1. **`abort()` on underrun = remote DoS.** Every `evpl_iovec_cursor_copy/skip/get_uintN` aborts when the requested bytes aren't present. Anything past the 64-byte header + StructureSize was unguarded.
2. **Cursor bounded by the whole TCP segment, not the SMB2 message.** A parser could silently read into the *next* compound element (desync / info-leak) and only abort at the very end.
3. **Unchecked client-controlled offset/length arithmetic** — `skip(client_offset - consumed)` wrapping to a huge unsigned skip (CREATE/WRITE/READ/SESSION_SETUP/SET_INFO/IOCTL), an unbounded `requests[num_requests++]` (65+ chained requests overflowed the fixed 64-slot array), and an unvalidated `NextCommand`. Plus two **real OOB bugs**: a uint32 add-overflow in the create-context bounds check (`data_off + data_len`), and a **stack buffer overflow in TREE_CONNECT** (`PathLength` bounded by `CHIMERA_VFS_PATH_MAX`=4096 but copied into a 510-byte stack buffer).

## Approach

Bound the cursor to the current message once at the framing layer, then a read past the end is just a cheap comparison that returns an error — no per-field length math sprinkled across 20 parsers. The shared abort()ing primitives are left untouched (reply construction relies on them over server-owned buffers); new checked variants are added for the client-data path only, so there is zero blast radius outside SMB ingest.

- **`evpl_iovec_cursor.h`** — add a per-message `limit` (defaults to `INT_MAX`, so every existing NFS/reply caller is unchanged), `set_limit`/`remaining`, and non-aborting `try_copy`/`try_skip`/`try_get_uintN` that return `-1` instead of crashing.
- **`smb.c` compound loop** — bound `num_requests`, validate `NextCommand` (8-byte aligned, forward, in-bounds), fence each element's cursor window, fix the signing `payload_length`, and make the skip-to-next-element checked.
- **`smb_internal.h`** — `chimera_smb_parse_reject()` (defer an in-order error reply, honoring `soft_fail_bad_req`) and `smb_cursor_seek_to()` (validated forward seek) replacing the wrapping `skip(offset - consumed)` idiom.
- **Every per-command parser** converted to the checked readers; IOCTL and SET_INFO fence the cursor to the declared input buffer.
- **Fix the two OOB bugs**: create-context bounds rewritten in subtraction form; TREE_CONNECT `PathLength` bounded against the actual staging buffer.
- **`smb_harden_test`** — new unit test covering the checked primitives, safe seek, and the create-context overflow cases (ASan-clean).

The hot path adds only an integer compare per field — no allocation, no second pass over the payload.

## Verification

- Debug (ASan) and Release both build clean with `-Werror`; `make syntax-check` passes.
- New `smb_harden_test` (14 cases) passes under ASan.
- **93 smbtorture suites pass, 0 failures** on memfs — create, read/write, lock, ioctl (copy_chunk / sparse / dup_extents / validate_negotiate), and `compound_related*` / `compound_find_related` (the NextCommand chaining), plus `smbclient_ntlm` — confirming real protocol traffic is unaffected.

## Follow-up (out of scope)

The TRANSFORM/decrypt and compression-decode paths deserve a separate decompressed-size-bounds audit.