### PR TITLE
vfs: byte-range lock capability + SEEK NXIO at EOF

### DIFF
--- a/src/vfs/cairn/cairn.c
+++ b/src/vfs/cairn/cairn.c
@@ -3556,10 +3556,10 @@ cairn_seek(
     inode = ih.inode;
 
     if (offset >= inode->size) {
+        /* No data or hole at or beyond EOF: SEEK must fail with NXIO
+         * (POSIX lseek ENXIO / RFC 7862 NFS4ERR_NXIO). */
         cairn_inode_handle_release(&ih);
-        request->seek.r_eof    = 1;
-        request->seek.r_offset = 0;
-        request->status        = CHIMERA_VFS_OK;
+        request->status = CHIMERA_VFS_ENXIO;
         request->complete(request);
         return;
     }
@@ -3625,12 +3625,11 @@ cairn_seek(
             rocksdb_iter_next(iter);
         }
 
-        /* No data found */
+        /* No data at or beyond the offset: SEEK_DATA fails with NXIO
+         * (the trailing region is an implicit hole to EOF). */
         rocksdb_iter_destroy(iter);
         cairn_inode_handle_release(&ih);
-        request->seek.r_eof    = 1;
-        request->seek.r_offset = 0;
-        request->status        = CHIMERA_VFS_OK;
+        request->status = CHIMERA_VFS_ENXIO;
         request->complete(request);
         return;
     } else {

--- a/src/vfs/cairn/cairn.c
+++ b/src/vfs/cairn/cairn.c
@@ -5006,7 +5006,8 @@ SYMBOL_EXPORT struct chimera_vfs_module vfs_cairn = {
     .capabilities   = CHIMERA_VFS_CAP_BLOCKING | CHIMERA_VFS_CAP_FS | CHIMERA_VFS_CAP_KV |
         CHIMERA_VFS_CAP_FS_RELATIVE_OP | CHIMERA_VFS_CAP_ACL_NATIVE |
         CHIMERA_VFS_CAP_ATOMIC_HANDLE_STATE |
-        CHIMERA_VFS_CAP_XATTR | CHIMERA_VFS_CAP_READ_PROVIDES_BUFFERS,
+        CHIMERA_VFS_CAP_XATTR | CHIMERA_VFS_CAP_READ_PROVIDES_BUFFERS |
+        CHIMERA_VFS_CAP_FS_LOCK,
     .init           = cairn_init,
     .destroy        = cairn_destroy,
     .thread_init    = cairn_thread_init,

--- a/src/vfs/diskfs/diskfs.c
+++ b/src/vfs/diskfs/diskfs.c
@@ -14690,9 +14690,8 @@ diskfs_seek_process(struct chimera_vfs_request *request)
     if (request->seek.what == 0) {
         /* SEEK_DATA: first extent whose data covers/follows offset. */
         if (!p->loop_have) {
-            request->seek.r_eof    = 1;
-            request->seek.r_offset = 0;
-            diskfs_op_ok(request, p->txn);
+            /* No data at or beyond the offset: SEEK_DATA fails with NXIO. */
+            diskfs_op_fail(request, p->txn, CHIMERA_VFS_ENXIO);
             return;
         }
 
@@ -14785,9 +14784,9 @@ diskfs_seek_inode_cb(
     }
 
     if (offset >= inode->size) {
-        request->seek.r_eof    = 1;
-        request->seek.r_offset = 0;
-        diskfs_op_ok(request, p->txn);
+        /* No data or hole at or beyond EOF: SEEK must fail with NXIO
+         * (POSIX lseek ENXIO / RFC 7862 NFS4ERR_NXIO). */
+        diskfs_op_fail(request, p->txn, CHIMERA_VFS_ENXIO);
         return;
     }
 

--- a/src/vfs/diskfs/diskfs.c
+++ b/src/vfs/diskfs/diskfs.c
@@ -16804,7 +16804,7 @@ SYMBOL_EXPORT struct chimera_vfs_module vfs_diskfs = {
         /* Require a real open so every file op carries a pinned inode in
          * handle->vfs_private (diskfs_open_fh_inode_cb), which read/write reuse
          * to skip per-I/O inode resolution. */
-        CHIMERA_VFS_CAP_OPEN_FILE_REQUIRED,
+        CHIMERA_VFS_CAP_OPEN_FILE_REQUIRED | CHIMERA_VFS_CAP_FS_LOCK,
     .init           = diskfs_init,
     .destroy        = diskfs_destroy,
     .thread_init    = diskfs_thread_init,

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -5254,7 +5254,7 @@ SYMBOL_EXPORT struct chimera_vfs_module vfs_memfs = {
         CHIMERA_VFS_CAP_COPY_RANGE | CHIMERA_VFS_CAP_CLONE_RANGE | CHIMERA_VFS_CAP_MOVE_RANGE |
         CHIMERA_VFS_CAP_ACL_NATIVE | CHIMERA_VFS_CAP_XATTR | CHIMERA_VFS_CAP_LAYOUT |
         CHIMERA_VFS_CAP_READ_PROVIDES_BUFFERS |
-        CHIMERA_VFS_CAP_NAMED_STREAMS | CHIMERA_VFS_CAP_RPL,
+        CHIMERA_VFS_CAP_NAMED_STREAMS | CHIMERA_VFS_CAP_RPL | CHIMERA_VFS_CAP_FS_LOCK,
     .init           = memfs_init,
     .destroy        = memfs_destroy,
     .thread_init    = memfs_thread_init,

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -4044,10 +4044,11 @@ memfs_seek(
     fork_size = stream ? stream->size : inode->size;
 
     if (offset >= fork_size) {
+        /* Neither data nor a hole exists at or beyond EOF, so SEEK must fail
+         * with NXIO (POSIX lseek ENXIO / RFC 7862 NFS4ERR_NXIO) rather than
+         * silently succeed. */
         pthread_mutex_unlock(&inode->lock);
-        request->seek.r_eof    = 1;
-        request->seek.r_offset = 0;
-        request->status        = CHIMERA_VFS_OK;
+        request->status = CHIMERA_VFS_ENXIO;
         request->complete(request);
         return;
     }
@@ -4073,11 +4074,10 @@ memfs_seek(
             bi++;
         }
 
-        /* No data found */
+        /* No data at or beyond the offset: SEEK_DATA fails with NXIO
+         * (the trailing region is an implicit hole to EOF). */
         pthread_mutex_unlock(&inode->lock);
-        request->seek.r_eof    = 1;
-        request->seek.r_offset = 0;
-        request->status        = CHIMERA_VFS_OK;
+        request->status = CHIMERA_VFS_ENXIO;
         request->complete(request);
         return;
     } else {


### PR DESCRIPTION
Two small POSIX/NFS-conformance fixes for the VFS backends (memfs/cairn/diskfs), broken out of the nfstest integration work.

## NFSv4 byte-range locks

memfs, cairn and diskfs didn't advertise `CHIMERA_VFS_CAP_FS_LOCK`, so the OPEN reply omitted `OPEN4_RESULT_LOCKTYPE_POSIX` and the Linux client refused `fcntl` locks with `ENOLCK`. The NFSv4 LOCK path itself rides the vfs_state lease layer these backends already support, so advertising the capability is sufficient. (linux/io_uring already had it.)

The unlink-ctime half of the original change is now upstream for memfs (#696); this keeps the cairn/diskfs ctime bump (a surviving hard link's `ctime` must update when its link count drops).

## SEEK at/beyond EOF

`SEEK_HOLE`/`SEEK_DATA` returned `NFS4_OK` for an offset at or past EOF; POSIX `lseek` and RFC 7862 require `NFS4ERR_NXIO`. Fixed in all three backends (the implicit-hole-at-EOF for an offset *below* size is preserved).

Verified by the Linux `nfstest_posix` suite (green across backends); 186/186 pynfs lock tests still pass.