### PR TITLE
diskfs: space accounting — large ALLOCATE, AG-derived statfs, per-open reservation, reclaim

### DIFF
--- a/src/vfs/diskfs/diskfs.c
+++ b/src/vfs/diskfs/diskfs.c
@@ -519,6 +519,13 @@ struct diskfs_inode {
     int                         mtime_dirty;
     uint64_t                    mtime_dirty_since;  /* monotonic tick of first dirty */
 
+    /* Per-open-file data-space reservation (RAM only, not persisted): a write
+     * over-reserves SM_RESERVATION_MIN and retains the tail here for this file's
+     * next write so its blocks lay out sequentially; the tail is returned to the
+     * space map when the last open handle closes (diskfs_inode_return_reservation).
+     * Mutated only under the inode write lock the data path already holds. */
+    struct sm_thread_cache      space_resv;
+
     /* This inode's 4 KiB metadata home block in the block cache; pinned
      * while the inode is dirty in a transaction.  NULL until first claimed.
      * Directory entries, extents and the symlink target all live as keyed
@@ -1065,8 +1072,8 @@ struct diskfs_thread {
     struct evpl_iovec            pad;
     int                          thread_id;
     struct slab_allocator       *allocator;
-    struct sm_thread_cache       space_cache;      /* metadata (LOCAL devices) */
-    struct sm_thread_cache       data_space_cache; /* block-mode file data (REMOTE devices) */
+    struct sm_thread_cache       space_cache;      /* metadata (LOCAL devices); file
+                                                    * data uses per-inode space_resv */
     struct diskfs_txn           *txn_free_list;
     struct diskfs_inode_waiter  *waiter_free_list;
     struct diskfs_iq_channel    *iq_channel;
@@ -3793,7 +3800,8 @@ diskfs_bt_alloc_node(
      * never journals -- hence no_suspend and the rc != 0 abort. */
     DISKFS_SM_JNL(jnl, thread, txn, diskfs_sm_no_suspend, NULL);
     rc = space_map_alloc(shared->space_map, &thread->space_cache, &jnl,
-                         SM_DEV_LOCAL, DISKFS_BLOCK_SIZE, &device_id, &device_offset);
+                         SM_DEV_LOCAL, DISKFS_BLOCK_SIZE, SM_RESERVATION_MIN,
+                         &device_id, &device_offset);
     chimera_diskfs_abort_if(rc != 0, "b+tree node allocation failed (ENOSPC)");
 
     blk = diskfs_block_claim(thread, device_id, device_offset, 1);
@@ -4572,60 +4580,6 @@ diskfs_bt_collapse_root(
     }
 } /* diskfs_bt_collapse_root */
 
-/*
- * Reclaim space owned by a deleted inode (nlink just hit 0, not open).
- *
- * The free count for one inode is bounded only by its tree size, but every
- * free must ride a single transaction's redo -- an arbitrarily large inode
- * would overflow the journal / block-I/O queue.  So we reclaim inline only the
- * BOUNDED case: an inode whose entire tree fits in the embedded root (no child
- * node blocks).  That covers small files (data extents in the root, <=~100) and
- * empty/small directories.  The inode home block is not returned to the
- * allocator yet: inode structs stay cached after unlink and generation reuse is
- * not persisted for newly allocated inodes, so reusing an inum can collide with
- * the cache and stale file handles.
- *
- * TODO(incremental-drain): a large inode (interior embedded root) still leaks
- * its child node blocks and their data extents here.  Draining those needs a
- * scheme that walks the tree across multiple bounded transactions (an orphan
- * list of deleted-but-not-fully-reclaimed inodes, drained in the background).
- * Also, a file unlinked while still open frees nothing here (deferred to close,
- * which has no write txn) -- another known leak.
- */
-static void
-diskfs_bt_free_tree(
-    struct diskfs_thread *thread,
-    struct diskfs_txn    *txn,
-    struct diskfs_inode  *inode)
-{
-    void                      *buf;
-    struct diskfs_bt_node_hdr *h;
-
-    diskfs_txn_pin_inode_block(thread, txn, inode, 0);
-    buf = inode->block->iov.data;
-    h   = diskfs_bt_hdr(buf, DISKFS_BT_ROOT_BASE);
-
-    if (h->level == 0 && S_ISREG(inode->mode)) {
-        /* Small file: data extents are recorded in the embedded root, mixed
-         * with non-space records such as xattrs. */
-        struct diskfs_bt_lslot *s = diskfs_bt_lslots(buf, DISKFS_BT_ROOT_BASE);
-        int                     i;
-
-        for (i = 0; i < h->nitems; i++) {
-            struct diskfs_extent_rec *e =
-                (struct diskfs_extent_rec *) ((char *) buf + DISKFS_BT_ROOT_BASE + s[i].off);
-
-            if (s[i].key.type != DISKFS_REC_EXTENT) {
-                continue;
-            }
-            diskfs_txn_free_space(thread, txn, e->device_id, e->device_offset,
-                                  SM_ALIGN_UP(e->length));
-        }
-    }
-
-    /* Leave the inode home block pinned + logged with the nlink=0 dinode. */
-} /* diskfs_bt_free_tree */
-
 /* Forward declarations for helpers defined later in the file. */
 static struct diskfs_txn * diskfs_txn_begin(
     struct diskfs_thread *thread,
@@ -4645,6 +4599,10 @@ static void diskfs_thread_free_space(
     uint32_t              device_id,
     uint64_t              device_offset,
     uint64_t              length);
+static void diskfs_inode_return_reservation(
+    struct diskfs_thread *thread,
+    struct diskfs_txn    *txn,
+    struct diskfs_inode  *inode);
 static int diskfs_bt_remove_async(
     struct diskfs_bt_op        *op,
     struct diskfs_thread       *thread,
@@ -4918,14 +4876,16 @@ diskfs_drain_final_cb(
 } /* diskfs_drain_final_cb */
 
 /* The durable orphan entry is removed; finish retiring the inode in the same
- * transaction and commit.  The inode home block is intentionally leaked for now;
- * see diskfs_bt_free_tree. */
+* transaction and commit.  The inode home block is intentionally leaked for now
+* (inode structs stay cached after unlink and generation reuse is not persisted,
+* so reusing an inum could collide with the cache and stale file handles). */
 static void
 diskfs_drain_after_unrecord(void *priv)
 {
     struct diskfs_drain *d = priv;
 
     diskfs_txn_pin_inode_block(d->thread, d->txn, d->inode, 0);
+    diskfs_inode_return_reservation(d->thread, d->txn, d->inode);
     diskfs_inode_free(d->thread, d->inode);
     diskfs_txn_commit(d->txn, diskfs_drain_final_cb, d);
 } /* diskfs_drain_after_unrecord */
@@ -5305,7 +5265,8 @@ diskfs_bt_run(struct diskfs_bt_op *op)
             DISKFS_SM_JNL(jnl, thread, op->txn, diskfs_bt_op_resume_cb, op);
             int rrc = space_map_reserve(thread->shared->space_map,
                                         &thread->space_cache, &jnl, SM_DEV_LOCAL,
-                                        (uint64_t) (DISKFS_BT_MAX_DEPTH + 2) * DISKFS_BLOCK_SIZE);
+                                        (uint64_t) (DISKFS_BT_MAX_DEPTH + 2) * DISKFS_BLOCK_SIZE,
+                                        SM_RESERVATION_MIN);
 
             if (rrc == SM_AGAIN) {
                 return;     /* parked; resumes back into this phase */
@@ -6326,6 +6287,12 @@ diskfs_inode_cache_recycle_locked(
             continue;                                  /* not durable yet; skip */
         }
 
+        /* An idle inode (no open handle) has already returned its data-space
+         * reservation at its last close; catch a leak before the struct goes. */
+        chimera_diskfs_abort_if(inode->space_resv.valid,
+                                "evicting inode %lu with a live space reservation",
+                                inode->inum);
+
         diskfs_inode_lru_unlink(shard, inode);
         rb_tree_remove(&shard->inodes, &inode->node);
         shard->ninodes--;
@@ -6519,7 +6486,8 @@ diskfs_inode_alloc_async(
 
     DISKFS_SM_JNL(jnl, thread, txn, diskfs_inode_alloc_resume, actx);
     rc = space_map_alloc(shared->space_map, &thread->space_cache, &jnl,
-                         SM_DEV_LOCAL, SM_BLOCK_SIZE, &device_id, &device_offset);
+                         SM_DEV_LOCAL, SM_BLOCK_SIZE, SM_RESERVATION_MIN,
+                         &device_id, &device_offset);
     if (rc == SM_AGAIN) {
         return;     /* parked; diskfs_inode_alloc_resume re-runs (owns actx) */
     }
@@ -6588,6 +6556,12 @@ diskfs_inode_free(
      * inode's b+tree blocks, which are leaked for now (no space reclaim
      * yet); the device ranges backing file extents are returned to the
      * space map by truncate/deallocate before this point. */
+
+    /* The per-open-file data reservation must already have been returned at the
+     * last close (or this retire's caller) -- catch a leak. */
+    chimera_diskfs_abort_if(inode->space_resv.valid,
+                            "inode %lu freed with a live space reservation",
+                            inode->inum);
 
     inode->gen++;
     inode->refcnt = 0;
@@ -6672,32 +6646,40 @@ diskfs_kv_entry_release(
     free(entry);
 } /* diskfs_kv_entry_release */
 
+/*
+ * Allocate file-data backing for `inode` from its own per-open-file reservation
+ * (inode->space_resv) rather than a shared per-thread cache, so a file's blocks
+ * lay out sequentially and the unused tail is returned when the file is closed
+ * (not stranded per-thread).  `floor` is the over-reserve minimum: writes pass
+ * SM_RESERVATION_MIN (reserve 1 MiB or the write, whichever is larger, and keep
+ * the rest for the next write); fallocate passes 0 (exact, no retained tail).
+ * Must be called with the inode write-locked (the data path holds it).  Returns
+ * SM_AGAIN on a journal-block miss (caller's resume re-drives), ENOSPC, or 0.
+ */
 static inline int
-diskfs_thread_alloc_space(
+diskfs_inode_alloc_space(
     struct diskfs_thread *thread,
     struct diskfs_txn *txn,
+    struct diskfs_inode *inode,
     int64_t desired_size,
+    uint64_t floor,
     uint64_t *r_device_id,
     uint64_t *r_device_offset,
     void ( *resume )(struct diskfs_thread *, void *),
     void *resume_arg)
 {
-    uint32_t                dev_id;
-    int                     rc;
-    struct space_map       *sm = thread->shared->space_map;
+    uint32_t          dev_id;
+    int               rc;
+    struct space_map *sm = thread->shared->space_map;
 
-    /* File data goes to REMOTE (pNFS data) devices when this is a block-mode
-     * filesystem, and to LOCAL devices otherwise; each class draws from its own
-     * per-thread reservation cache so a local metadata reservation and a remote
-     * data reservation never collide. */
-    int                     remote = space_map_has_remote(sm);
-    uint32_t                role   = remote ? SM_DEV_REMOTE : SM_DEV_LOCAL;
-    struct sm_thread_cache *cache  = remote ? &thread->data_space_cache :
-        &thread->space_cache;
+    /* File data goes to REMOTE (pNFS data) devices in block mode, LOCAL
+     * otherwise; metadata keeps its own per-thread reservation, so the two
+     * classes never collide. */
+    uint32_t          role = space_map_has_remote(sm) ? SM_DEV_REMOTE : SM_DEV_LOCAL;
 
     DISKFS_SM_JNL(jnl, thread, txn, resume, resume_arg);
-    rc = space_map_alloc(sm, cache, &jnl, role,
-                         (uint64_t) desired_size, &dev_id, r_device_offset);
+    rc = space_map_alloc(sm, &inode->space_resv, &jnl, role,
+                         (uint64_t) desired_size, floor, &dev_id, r_device_offset);
 
     if (rc == SM_AGAIN) {
         return SM_AGAIN;        /* parked; caller's resume re-drives */
@@ -6708,7 +6690,7 @@ diskfs_thread_alloc_space(
 
     *r_device_id = dev_id;
     return 0;
-} /* diskfs_thread_alloc_space */
+} /* diskfs_inode_alloc_space */
 
 static inline void
 diskfs_thread_free_space(
@@ -6723,6 +6705,33 @@ diskfs_thread_free_space(
      * in memory while its redo is discarded). */
     diskfs_txn_free_space(thread, txn, device_id, device_offset, length);
 } /* diskfs_thread_free_space */
+
+/*
+ * Return this file's unused data-space reservation tail to the space map when
+ * its last open handle closes (or it is otherwise torn down with a live txn).
+ * Uses the pending-free path (journaled at pre-commit, applied on commit), so it
+ * never has to suspend inside the caller, and clears the reservation so it is
+ * returned exactly once.  Must run under the inode write lock.
+ */
+static inline void
+diskfs_inode_return_reservation(
+    struct diskfs_thread *thread,
+    struct diskfs_txn    *txn,
+    struct diskfs_inode  *inode)
+{
+    struct sm_thread_cache *resv = &inode->space_resv;
+
+    if (!resv->valid || resv->length == 0) {
+        resv->valid  = 0;
+        resv->length = 0;
+        return;
+    }
+
+    diskfs_thread_free_space(thread, txn, resv->device_id, resv->offset,
+                             resv->length);
+    resv->valid  = 0;
+    resv->length = 0;
+} /* diskfs_inode_return_reservation */
 
 /* ------------------------------------------------------------------ */
 /* Transaction plumbing                                                */
@@ -9533,13 +9542,27 @@ diskfs_mtime_flush_drop_pin(
     struct diskfs_inode  *inode)
 {
     struct diskfs_inode_shard *shard = diskfs_inode_shard(thread->shared, inode->inum);
+    int                        retire;
+    uint64_t                   inum;
+    uint32_t                   gen;
 
     pthread_mutex_lock(&shard->lock);
     --inode->refcnt;
-    if (diskfs_inode_idle(inode) && !inode->on_lru) {
+    /* If this drops the last reference to an inode that was unlinked while held
+     * open (its durable orphan record already written), it is now reclaimable. */
+    retire = (inode->refcnt == 0 && inode->nlink == 0);
+    inum   = inode->inum;
+    gen    = inode->gen;
+    if (!retire && diskfs_inode_idle(inode) && !inode->on_lru) {
         diskfs_inode_lru_push_tail(shard, inode);
     }
     pthread_mutex_unlock(&shard->lock);
+
+    /* Enqueue the async drain outside the shard lock (it begins a txn and
+     * acquires inodes, taking shard locks). */
+    if (retire) {
+        diskfs_drain_enqueue(thread, inum, gen);
+    }
 } /* diskfs_mtime_flush_drop_pin */
 
 struct diskfs_mtime_flush {
@@ -9762,10 +9785,10 @@ diskfs_thread_destroy(void *private_data)
         evpl_block_close_queue(thread->evpl, thread->queue[i]);
     }
 
-    /* No txn at thread teardown; the unused reservation tail returns to the
-     * in-memory free set and is captured by the condense at clean unmount. */
+    /* No txn at thread teardown; the unused metadata reservation tail returns to
+     * the in-memory free set and is captured by the condense at clean unmount.
+     * (File-data reservations live on the inode and are returned on close.) */
     space_map_thread_cache_return(shared->space_map, NULL, &thread->space_cache);
-    space_map_thread_cache_return(shared->space_map, NULL, &thread->data_space_cache);
 
     /* Unregister the intent-log channel.  Caller must have quiesced all
      * in-flight VFS ops on this thread first. */
@@ -11204,7 +11227,13 @@ diskfs_remove_orphan_done(void *priv)
     struct diskfs_request_private *p       = request->plugin_data;
     struct diskfs_inode           *inode   = p->inode_stash[1];
 
-    diskfs_drain_enqueue(p->thread, inode->inum, inode->gen);
+    /* Reclaim now only if nothing else holds the inode open; otherwise the last
+     * close (or deferred-mtime pin drop) will enqueue the drain when refcnt
+     * reaches 0.  The durable orphan record (just written) covers a crash in the
+     * meantime. */
+    if (inode->refcnt == 0) {
+        diskfs_drain_enqueue(p->thread, inode->inum, inode->gen);
+    }
     diskfs_remove_at_finish(request);
 } /* diskfs_remove_orphan_done */
 
@@ -11259,29 +11288,20 @@ diskfs_remove_at_removed_cb(
 
     if (inode->nlink == 0) {
         --inode->refcnt;
-        if (inode->refcnt == 0) {
-            struct diskfs_bt_node_hdr *rh;
 
-            diskfs_txn_pin_inode_block(thread, p->txn, inode, 0);
-            rh = diskfs_bt_hdr(inode->block->iov.data, DISKFS_BT_ROOT_BASE);
-
-            if (rh->level == 0) {
-                /* Small inode (whole tree in the embedded root): reclaim inline. */
-                diskfs_bt_free_tree(thread, p->txn, inode);
-                diskfs_inode_free(thread, inode);
-            } else {
-                /* Large inode: record it on the durable orphan list -- atomic
-                 * with this unlink txn (the orphan inode is acquired last, a
-                 * leaf in the lock order, so no deadlock).  The continuation
-                 * enqueues it for the in-session drainer + finishes; a crash
-                 * before this txn commits leaves neither the unlink nor the
-                 * orphan record, and after it the mount scan can resume. */
-                diskfs_orphan_op_start(thread, p->txn, inode->inum, inode->gen,
-                                       0 /* insert */, diskfs_remove_orphan_done,
-                                       request);
-                return;
-            }
-        }
+        /* Record the durable orphan entry now, atomic with persisting nlink=0,
+         * regardless of whether the inode is still held open: a crash before the
+         * space is reclaimed is recovered by the next mount's orphan scan.  The
+         * actual reclaim (freeing data extents + b+tree nodes, then retiring the
+         * inode) is deferred to the async drain -- never done in this delete hot
+         * path -- and is enqueued from the continuation once the inode is
+         * unreferenced (refcnt 0): now if it is already closed, otherwise at the
+         * final close (diskfs_close_inode_cb / the deferred-mtime pin drop).  The
+         * orphan inode (inum 3) is acquired last, a leaf in the lock order. */
+        diskfs_orphan_op_start(thread, p->txn, inode->inum, inode->gen,
+                               0 /* insert */, diskfs_remove_orphan_done,
+                               request);
+        return;
     }
 
     diskfs_remove_at_finish(request);
@@ -12087,8 +12107,25 @@ diskfs_close_inode_cb(
     }
 
     --inode->refcnt;
+
+    /* Return this file's unused data-space reservation tail on close.  Done
+     * unconditionally (not just at refcnt 0, which is the delete-on-close case):
+     * a normal close drops the inode back to its idle cache reference, where it
+     * would otherwise strand the reservation until eviction.  A file held open
+     * by another handle simply re-reserves on its next write (the inode write
+     * lock, held here, serializes that against this close). */
+    diskfs_inode_return_reservation(p->thread, p->txn, inode);
+
     if (inode->refcnt == 0) {
-        diskfs_inode_free(p->thread, inode);
+        if (inode->nlink == 0) {
+            /* Delete-on-close: the file was unlinked while open (its durable
+             * orphan record was written then), and this was the last reference.
+             * Reclaim its space via the async drain, which frees the extents and
+             * retires the inode -- not inline in this close path. */
+            diskfs_drain_enqueue(p->thread, inode->inum, inode->gen);
+        } else {
+            diskfs_inode_free(p->thread, inode);
+        }
     }
 
     diskfs_op_ok(request, p->txn);
@@ -13684,10 +13721,11 @@ diskfs_write_redirect_alloc(struct chimera_vfs_request *request)
     uint64_t                       dev_id, dev_off;
     int                            rc;
 
-    rc = diskfs_thread_alloc_space(thread, p->txn,
-                                   (int64_t) p->rmw_aligned_length,
-                                   &dev_id, &dev_off,
-                                   diskfs_write_alloc_resume, request);
+    rc = diskfs_inode_alloc_space(thread, p->txn, p->inode_stash[0],
+                                  (int64_t) p->rmw_aligned_length,
+                                  SM_RESERVATION_MIN,
+                                  &dev_id, &dev_off,
+                                  diskfs_write_alloc_resume, request);
     if (rc == SM_AGAIN) {
         return;     /* parked; diskfs_write_alloc_resume re-runs */
     }
@@ -14139,7 +14177,14 @@ diskfs_dealloc_process(struct chimera_vfs_request *request)
             diskfs_dealloc_modify_advance_cb(op, op->result, request);
         }
     } else if (es < hole_start && ee > hole_end) {
-        /* Spans the hole: insert tail at hole_end first. */
+        /* Spans the hole: free the punched-out middle [hole_start, hole_end) of
+         * this extent's backing, then insert tail at hole_end.  The raw range is
+         * passed (not block-rounded): space_map_free frees only whole blocks
+         * strictly contained, so a sub-block hole edge shared with a kept piece
+         * is never freed. */
+        diskfs_thread_free_space(thread, p->txn, p->ext_iter.device_id,
+                                 p->ext_iter.device_offset + (hole_start - es),
+                                 hole_end - hole_start);
         op = diskfs_bt_op_alloc(thread);
         if (diskfs_ext_insert_async(op, thread, p->txn, p->inode_stash[0], hole_end,
                                     ee - hole_end, p->ext_iter.device_id,
@@ -14149,14 +14194,22 @@ diskfs_dealloc_process(struct chimera_vfs_request *request)
             diskfs_dealloc_spans_after_cb(op, op->result, request);
         }
     } else if (es < hole_start) {
-        /* Overlaps the hole start: remove, then reinsert the head. */
+        /* Overlaps the hole start: free the punched tail [hole_start, ee) of this
+         * extent's backing, then remove + reinsert the kept head [es, hole_start). */
+        diskfs_thread_free_space(thread, p->txn, p->ext_iter.device_id,
+                                 p->ext_iter.device_offset + (hole_start - es),
+                                 ee - hole_start);
         op = diskfs_bt_op_alloc(thread);
         if (diskfs_ext_remove_async(op, thread, p->txn, p->inode_stash[0], es,
                                     diskfs_dealloc_ostart_removed_cb, request)) {
             diskfs_dealloc_ostart_removed_cb(op, op->result, request);
         }
     } else {
-        /* Overlaps the hole end: remove, then reinsert the tail at hole_end. */
+        /* Overlaps the hole end: free the punched head [es, hole_end) of this
+         * extent's backing, then remove + reinsert the kept tail at hole_end. */
+        diskfs_thread_free_space(thread, p->txn, p->ext_iter.device_id,
+                                 p->ext_iter.device_offset,
+                                 hole_end - es);
         op = diskfs_bt_op_alloc(thread);
         if (diskfs_ext_remove_async(op, thread, p->txn, p->inode_stash[0], es,
                                     diskfs_dealloc_oend_removed_cb, request)) {
@@ -14248,9 +14301,10 @@ diskfs_allocate_do_alloc(struct chimera_vfs_request *request)
         chunk = p->alloc_cap;
     }
 
-    rc = diskfs_thread_alloc_space(thread, p->txn, (int64_t) chunk,
-                                   &dev_id, &dev_off,
-                                   diskfs_allocate_alloc_resume, request);
+    rc = diskfs_inode_alloc_space(thread, p->txn, p->inode_stash[0],
+                                  (int64_t) chunk, 0 /* exact, no retained tail */,
+                                  &dev_id, &dev_off,
+                                  diskfs_allocate_alloc_resume, request);
     if (rc == SM_AGAIN) {
         return;     /* parked; resume re-drives diskfs_allocate_do_alloc */
     }
@@ -16214,9 +16268,11 @@ diskfs_get_layout_do_alloc(
     uint64_t                       dev_id, dev_off;
     int                            rc;
 
-    rc = diskfs_thread_alloc_space(thread, p->txn, (int64_t) p->rmw_aligned_length,
-                                   &dev_id, &dev_off,
-                                   diskfs_get_layout_do_alloc, request);
+    rc = diskfs_inode_alloc_space(thread, p->txn, p->inode_stash[0],
+                                  (int64_t) p->rmw_aligned_length,
+                                  0 /* exact, no retained tail */,
+                                  &dev_id, &dev_off,
+                                  diskfs_get_layout_do_alloc, request);
     if (rc == SM_AGAIN) {
         return;     /* parked; re-driven into this function */
     }

--- a/src/vfs/diskfs/diskfs.c
+++ b/src/vfs/diskfs/diskfs.c
@@ -163,6 +163,7 @@ struct diskfs_request_private {
     uint64_t                    loop_left;
     uint64_t                    loop_pos;
     int                         loop_have;
+    uint64_t                    alloc_cap;   /* ALLOCATE: adaptive per-chunk cap */
 
     struct evpl_iovec           iov[66];
 
@@ -10080,10 +10081,16 @@ diskfs_map_attrs(
     }
 
     if (attr->va_req_mask & CHIMERA_VFS_ATTR_MASK_STATFS) {
-        attr->va_set_mask      |= CHIMERA_VFS_ATTR_MASK_STATFS;
-        attr->va_fs_space_total = space_map_total_capacity(shared->space_map);
-        attr->va_fs_space_used  = space_map_used_bytes(shared->space_map);
-        attr->va_fs_space_free  = attr->va_fs_space_total - attr->va_fs_space_used;
+        attr->va_set_mask |= CHIMERA_VFS_ATTR_MASK_STATFS;
+        /* Free/used are derived from the space map's live per-AG free counts
+         * (cold path) rather than a running counter the alloc/free fast path
+         * would have to maintain. */
+        attr->va_fs_space_total = space_map_usable_capacity(shared->space_map);
+        attr->va_fs_space_free  = space_map_free_bytes(shared->space_map);
+        if (attr->va_fs_space_free > attr->va_fs_space_total) {
+            attr->va_fs_space_free = attr->va_fs_space_total;
+        }
+        attr->va_fs_space_used  = attr->va_fs_space_total - attr->va_fs_space_free;
         attr->va_fs_space_avail = attr->va_fs_space_free;
         attr->va_fs_files_total = CHIMERA_VFS_SYNTHETIC_FS_INODES;
         attr->va_fs_files_avail = CHIMERA_VFS_SYNTHETIC_FS_INODES;
@@ -14237,8 +14244,8 @@ diskfs_allocate_do_alloc(struct chimera_vfs_request *request)
     int                            rc;
 
     chunk = p->loop_left - off;
-    if (chunk > DISKFS_ALLOCATE_MAX_EXTENT) {
-        chunk = DISKFS_ALLOCATE_MAX_EXTENT;
+    if (chunk > p->alloc_cap) {
+        chunk = p->alloc_cap;
     }
 
     rc = diskfs_thread_alloc_space(thread, p->txn, (int64_t) chunk,
@@ -14248,9 +14255,22 @@ diskfs_allocate_do_alloc(struct chimera_vfs_request *request)
         return;     /* parked; resume re-drives diskfs_allocate_do_alloc */
     }
     if (rc) {
+        /* No single allocation group has `chunk` contiguous free space, but the
+         * filesystem as a whole may: a space map reservation is per-AG and
+         * all-or-nothing (and failure is a cheap in-memory check, no journal).
+         * Halve the cap and retry so a large fallocate spreads across AGs;
+         * only a request that can't place even one block is truly ENOSPC. */
+        if (chunk > SM_BLOCK_SIZE) {
+            p->alloc_cap = chunk >> 1;
+            diskfs_allocate_do_alloc(request);
+            return;
+        }
         diskfs_op_fail(request, p->txn, CHIMERA_VFS_ENOSPC);
         return;
     }
+
+    /* Success: re-probe a large chunk for the next allocation. */
+    p->alloc_cap = DISKFS_ALLOCATE_MAX_EXTENT;
 
     /* Advance before recording: diskfs_ext_put may complete inline and run
      * diskfs_allocate_next, which reads loop_off.  Record the reserved chunk
@@ -14399,6 +14419,7 @@ diskfs_allocate_inode_cb(
         p->loop_off = request->allocate.offset & ~4095ULL;
         p->loop_pos = (request->allocate.offset + request->allocate.length +
                        4095ULL) & ~4095ULL;
+        p->alloc_cap = DISKFS_ALLOCATE_MAX_EXTENT;
         diskfs_allocate_reserve_step(request);
         return;
     }

--- a/src/vfs/diskfs/space_map.c
+++ b/src/vfs/diskfs/space_map.c
@@ -576,7 +576,8 @@ space_map_reserve(
     struct sm_thread_cache  *cache,
     const struct sm_journal *jnl,
     uint32_t                 role,
-    uint64_t                 min_bytes)
+    uint64_t                 min_bytes,
+    uint64_t                 floor)
 {
     uint64_t need = SM_ALIGN_UP(min_bytes);
     uint64_t want;
@@ -600,7 +601,7 @@ space_map_reserve(
         }
     }
 
-    want = need > SM_RESERVATION_MIN ? need : SM_RESERVATION_MIN;
+    want = need > floor ? need : floor;
 
     /* A reservation can't cross an AG boundary, so cap at the AG size; a
      * caller needing more than SM_AG_SIZE contiguous cannot be satisfied. */
@@ -642,6 +643,7 @@ space_map_alloc(
     const struct sm_journal *jnl,
     uint32_t                 role,
     uint64_t                 size,
+    uint64_t                 floor,
     uint32_t                *r_device_id,
     uint64_t                *r_device_offset)
 {
@@ -653,7 +655,7 @@ space_map_alloc(
     /* Ensure the cache covers `need` (refilling -- journals, may SM_AGAIN),
      * then dole from it.  Callers that have front-loaded the reservation via
      * space_map_reserve hit the fast path here with no journaling. */
-    rc = space_map_reserve(sm, cache, jnl, role, need);
+    rc = space_map_reserve(sm, cache, jnl, role, need, floor);
     if (rc != 0) {
         return rc;     /* SM_AGAIN or -1 (ENOSPC) */
     }

--- a/src/vfs/diskfs/space_map.c
+++ b/src/vfs/diskfs/space_map.c
@@ -400,8 +400,7 @@ space_map_create(
 
                 data_off = base;
                 if (a == 0 && dev->sig_len) {
-                    data_off        = base + SM_ALIGN_UP(dev->sig_offset + dev->sig_len);
-                    sm->used_bytes += data_off - base;
+                    data_off = base + SM_ALIGN_UP(dev->sig_offset + dev->sig_len);
                 }
                 data_end = base + span;
                 sm_ag_init(ag, d, a, base, span, log_device_id, log_offset,
@@ -422,8 +421,7 @@ space_map_create(
                     sm->remote_log_size;
                 uint64_t post_log = 3 * SM_BLOCK_SIZE;
 
-                log_offset      = base + pre_log;
-                sm->used_bytes += pre_log + post_log;
+                log_offset = base + pre_log;
 
                 data_off = log_offset + SM_AG_LOG_SIZE + post_log;
                 sm_abort_if(pre_log + SM_AG_LOG_SIZE + post_log > span,
@@ -437,10 +435,19 @@ space_map_create(
                             span, SM_AG_LOG_SIZE);
             }
 
-            sm->used_bytes += SM_AG_LOG_SIZE;
-            data_end        = base + span;
+            data_end = base + span;
             sm_ag_init(ag, d, a, base, span, log_device_id, log_offset,
                        data_off, data_end > data_off ? data_end - data_off : 0);
+        }
+    }
+
+    /* Usable (allocatable) capacity is the live free total at format time, when
+     * every AG holds its full data range and nothing is allocated yet.  Metadata
+     * regions (logs, superblock, signatures) are already excluded from each AG's
+     * data range, so they never count toward usable space. */
+    for (d = 0; d < num_devices; d++) {
+        for (a = 0; a < sm->devices[d].num_ags; a++) {
+            sm->usable_capacity += sm->devices[d].ags[a].free_bytes;
         }
     }
 
@@ -555,7 +562,6 @@ sm_pick_and_alloc(
             if (rc == 0) {
                 *r_device_id     = dev_id;
                 *r_device_offset = offset;
-                __atomic_fetch_add(&sm->used_bytes, want, __ATOMIC_RELAXED);
                 return 0;
             }
         }
@@ -781,8 +787,6 @@ space_map_free_apply(
     pthread_mutex_lock(&ag->lock);
     sm_ag_free_locked(ag, offset, aligned);
     pthread_mutex_unlock(&ag->lock);
-
-    __atomic_fetch_sub(&sm->used_bytes, aligned, __ATOMIC_RELAXED);
 } /* space_map_free_apply */
 
 /*
@@ -1180,13 +1184,36 @@ space_map_persist(
     return 0;
 } /* space_map_persist */
 
+uint64_t
+space_map_free_bytes(struct space_map *sm)
+{
+    uint64_t free = 0;
+    uint32_t d, a;
+
+    /* Cold path (statfs): sum each AG's live free count.  Space held in a
+     * thread's reservation cache (carved out of an AG but not yet handed to a
+     * file) reads as not-free here, so the report is conservative -- never an
+     * overestimate of what can still be allocated. */
+    for (d = 0; d < sm->num_devices; d++) {
+        struct sm_device *dev = &sm->devices[d];
+
+        for (a = 0; a < dev->num_ags; a++) {
+            struct sm_ag *ag = &dev->ags[a];
+
+            pthread_mutex_lock(&ag->lock);
+            free += ag->free_bytes;
+            pthread_mutex_unlock(&ag->lock);
+        }
+    }
+    return free;
+} /* space_map_free_bytes */
+
 int
 space_map_load(
     struct space_map   *sm,
     const struct sm_io *io)
 {
     uint32_t d, a;
-    uint64_t free_total = 0;
 
     for (d = 0; d < sm->num_devices; d++) {
         struct sm_device *dev = &sm->devices[d];
@@ -1227,13 +1254,10 @@ space_map_load(
             pthread_mutex_lock(&ag->lock);
             sm_ag_reconstruct(ag, buf);
             ag->log_slot = (uint32_t) best;
-            free_total  += ag->free_bytes;
             pthread_mutex_unlock(&ag->lock);
             free(buf);
         }
     }
 
-    sm->used_bytes = sm->total_capacity > free_total ?
-        sm->total_capacity - free_total : 0;
     return 0;
 } /* space_map_load */

--- a/src/vfs/diskfs/space_map.h
+++ b/src/vfs/diskfs/space_map.h
@@ -309,8 +309,14 @@ struct space_map {
     struct sm_device *devices;
     uint32_t          num_devices;
     uint32_t          device_rotor;
-    uint64_t          total_capacity;
-    uint64_t          used_bytes;     /* atomic accounting for statfs */
+    uint64_t          total_capacity;  /* raw sum of device sizes */
+    uint64_t          usable_capacity; /* allocatable total (sum of AG data
+                                        * ranges, metadata excluded); constant
+                                        * after create.  Free/used for statfs are
+                                        * derived on demand from the AGs' live
+                                        * free counts -- see space_map_free_bytes
+                                        * -- so the alloc/free hot path keeps no
+                                        * running counter. */
     pthread_mutex_t   lock;           /* protects rotors and journaled writes */
 
     /* Relocated remote-AG-log region on device 0 (block mode); zero if no
@@ -458,10 +464,18 @@ space_map_total_capacity(const struct space_map *sm)
 } // space_map_total_capacity
 
 static inline uint64_t
-space_map_used_bytes(const struct space_map *sm)
+space_map_usable_capacity(const struct space_map *sm)
 {
-    return __atomic_load_n(&sm->used_bytes, __ATOMIC_RELAXED);
-} // space_map_used_bytes
+    return sm->usable_capacity;
+} // space_map_usable_capacity
+
+/* Live free byte count, summed from the allocation groups (cold path -- statfs
+ * only).  Computed on demand so the alloc/free fast path maintains no counter.
+ * Space held in a thread's reservation cache (carved from an AG but not yet
+ * handed to a file) reads as not-free, so the report is conservative. */
+uint64_t
+space_map_free_bytes(
+    struct space_map *sm);
 
 static inline uint64_t
 sm_inum_make(

--- a/src/vfs/diskfs/space_map.h
+++ b/src/vfs/diskfs/space_map.h
@@ -354,11 +354,14 @@ space_map_destroy(
 #define SM_AGAIN 1
 
 /*
- * Ensure the thread's reservation cache holds at least min_bytes of contiguous
- * space, refilling (journals + may SM_AGAIN) if short.  Hands out nothing;
- * callers use it to front-load the journaling/suspension of a metadata op
- * before a non-suspendable section (e.g. a b+tree modify) so the subsequent
- * allocs are pure cache draws.  0 = covered, -1 = ENOSPC, SM_AGAIN = parked.
+ * Ensure the cache holds at least min_bytes of contiguous space, refilling
+ * (journals + may SM_AGAIN) if short.  Hands out nothing; callers use it to
+ * front-load the journaling/suspension of a metadata op before a non-suspendable
+ * section (e.g. a b+tree modify) so the subsequent allocs are pure cache draws.
+ * `floor` is the minimum reservation to grab when refilling (the over-reserve
+ * amount that batches future small allocs); pass SM_RESERVATION_MIN for the
+ * batched behaviour or 0 for an exact reservation (no retained tail).
+ * 0 = covered, -1 = ENOSPC, SM_AGAIN = parked.
  */
 int
 space_map_reserve(
@@ -366,11 +369,13 @@ space_map_reserve(
     struct sm_thread_cache  *cache,
     const struct sm_journal *jnl,
     uint32_t                 role,
-    uint64_t                 min_bytes);
+    uint64_t                 min_bytes,
+    uint64_t                 floor);
 
 /* `role` (SM_DEV_LOCAL/SM_DEV_REMOTE) restricts the allocation to devices of
  * that class: block mode places metadata on LOCAL and data on REMOTE devices.
- * With no remote devices everything is LOCAL (today's single-pool behavior). */
+ * With no remote devices everything is LOCAL (today's single-pool behavior).
+ * `floor` is the over-reserve minimum (see space_map_reserve). */
 int
 space_map_alloc(
     struct space_map        *sm,
@@ -378,6 +383,7 @@ space_map_alloc(
     const struct sm_journal *jnl,
     uint32_t                 role,
     uint64_t                 size,
+    uint64_t                 floor,
     uint32_t                *r_device_id,
     uint64_t                *r_device_offset);
 


### PR DESCRIPTION
diskfs space-accounting correctness, broken out of the nfstest integration work. Two commits.

## Large ALLOCATE across AGs + AG-derived statfs

- **Large fallocate**: a space-map reservation is contiguous within one allocation group, so a `fallocate` larger than any single AG's free extent failed `ENOSPC` even when the filesystem had room across AGs. The ALLOCATE path now adaptively shrinks its per-extent request on a (cheap, in-memory) reservation failure and retries, spreading a large fallocate across AGs.
- **statfs from live AG free**: free/used were tracked by a `sm->used_bytes` counter the alloc/free fast paths had to maintain (an atomic per reservation). Replaced — usable capacity is computed once at format (the AGs' data ranges, metadata excluded) and free is summed on demand from the AGs' live free counts on the cold statfs path. No per-op counter, and no drift to accumulate.

## Per-open-file reservation + reclaim

- **Per-open-file data reservation**: file data was reserved through a per-thread cache that held an over-reservation tail across operations, interleaving concurrently-written files and stranding space one thread couldn't reclaim from another. Reserve per inode instead — a write grabs `max(1 MiB, write)` and keeps the tail on the inode for that file's next write (sequential layout), returned to the space map when the last open handle closes. `space_map_reserve/alloc` gain a `floor` (writes pass `SM_RESERVATION_MIN`, fallocate exact); metadata keeps its own per-thread reservation.
- **Delete-on-close reclaim**: the NFS client defers CLOSE, so a file is typically unlinked while still open. Reclaim was gated on the inode reaching refcnt 0 *synchronously at unlink*, which a still-open inode never does — so neither the durable orphan record nor the extent free happened and the space leaked permanently. Now the orphan record is written at unlink whenever `nlink` hits 0 (crash-recoverable via the mount scan), and the async drain that frees the extents/nodes and retires the inode is enqueued when the last reference drops (final close, deferred-mtime pin drop, or unlink of an already-closed file).
- **DEALLOCATE partial-extent free**: punching part of an extent trimmed the record but leaked the punched device range (only fully-contained extents were freed), so a write into a just-deallocated region failed `ENOSPC` on a full filesystem. The punched sub-range is now freed in the overlap-start/end/spans cases.

Verified by the Linux nfstest_alloc suite (616/616 on diskfs io_uring + libaio) and nfstest_posix (461/461 on diskfs); no regression.