### PR TITLE
vfs: share TIME_NOW/TIME_OMIT resolution across native backends

### DIFF
--- a/src/vfs/cairn/cairn.c
+++ b/src/vfs/cairn/cairn.c
@@ -1770,29 +1770,17 @@ cairn_apply_attrs(
 
     if (set_mask & CHIMERA_VFS_ATTR_ATIME) {
         attr->va_set_mask |= CHIMERA_VFS_ATTR_ATIME;
-        if (attr->va_atime.tv_nsec == CHIMERA_VFS_TIME_NOW) {
-            inode->atime = now;
-        } else if (attr->va_atime.tv_nsec != CHIMERA_VFS_TIME_OMIT) {
-            inode->atime = attr->va_atime;
-        }
+        chimera_vfs_resolve_set_time(&attr->va_atime, &now, &inode->atime);
     }
 
     if (set_mask & CHIMERA_VFS_ATTR_MTIME) {
         attr->va_set_mask |= CHIMERA_VFS_ATTR_MTIME;
-        if (attr->va_mtime.tv_nsec == CHIMERA_VFS_TIME_NOW) {
-            inode->mtime = now;
-        } else if (attr->va_mtime.tv_nsec != CHIMERA_VFS_TIME_OMIT) {
-            inode->mtime = attr->va_mtime;
-        }
+        chimera_vfs_resolve_set_time(&attr->va_mtime, &now, &inode->mtime);
     }
 
     if (set_mask & CHIMERA_VFS_ATTR_BTIME) {
         attr->va_set_mask |= CHIMERA_VFS_ATTR_BTIME;
-        if (attr->va_btime.tv_nsec == CHIMERA_VFS_TIME_NOW) {
-            inode->btime = now;
-        } else if (attr->va_btime.tv_nsec != CHIMERA_VFS_TIME_OMIT) {
-            inode->btime = attr->va_btime;
-        }
+        chimera_vfs_resolve_set_time(&attr->va_btime, &now, &inode->btime);
     }
 
     if (set_mask & CHIMERA_VFS_ATTR_DOS_ATTRIBUTES) {
@@ -1805,11 +1793,7 @@ cairn_apply_attrs(
      * implicit metadata change.  See memfs_apply_attrs() for the rationale. */
     if (set_mask & CHIMERA_VFS_ATTR_CTIME) {
         attr->va_set_mask |= CHIMERA_VFS_ATTR_CTIME;
-        if (attr->va_ctime.tv_nsec == CHIMERA_VFS_TIME_NOW) {
-            inode->ctime = now;
-        } else if (attr->va_ctime.tv_nsec != CHIMERA_VFS_TIME_OMIT) {
-            inode->ctime = attr->va_ctime;
-        }
+        chimera_vfs_resolve_set_time(&attr->va_ctime, &now, &inode->ctime);
     } else {
         inode->ctime = now;
     }

--- a/src/vfs/diskfs/diskfs.c
+++ b/src/vfs/diskfs/diskfs.c
@@ -10249,35 +10249,29 @@ diskfs_apply_attrs(
     }
 
     if (set_mask & CHIMERA_VFS_ATTR_ATIME) {
+        struct timespec t;
         attr->va_set_mask |= CHIMERA_VFS_ATTR_ATIME;
-        if (attr->va_atime.tv_nsec == CHIMERA_VFS_TIME_NOW) {
-            inode->atime_sec  = now.tv_sec;
-            inode->atime_nsec = now.tv_nsec;
-        } else if (attr->va_atime.tv_nsec != CHIMERA_VFS_TIME_OMIT) {
-            inode->atime_sec  = attr->va_atime.tv_sec;
-            inode->atime_nsec = attr->va_atime.tv_nsec;
+        if (chimera_vfs_resolve_set_time(&attr->va_atime, &now, &t)) {
+            inode->atime_sec  = t.tv_sec;
+            inode->atime_nsec = t.tv_nsec;
         }
     }
 
     if (set_mask & CHIMERA_VFS_ATTR_MTIME) {
+        struct timespec t;
         attr->va_set_mask |= CHIMERA_VFS_ATTR_MTIME;
-        if (attr->va_mtime.tv_nsec == CHIMERA_VFS_TIME_NOW) {
-            inode->mtime_sec  = now.tv_sec;
-            inode->mtime_nsec = now.tv_nsec;
-        } else if (attr->va_mtime.tv_nsec != CHIMERA_VFS_TIME_OMIT) {
-            inode->mtime_sec  = attr->va_mtime.tv_sec;
-            inode->mtime_nsec = attr->va_mtime.tv_nsec;
+        if (chimera_vfs_resolve_set_time(&attr->va_mtime, &now, &t)) {
+            inode->mtime_sec  = t.tv_sec;
+            inode->mtime_nsec = t.tv_nsec;
         }
     }
 
     if (set_mask & CHIMERA_VFS_ATTR_BTIME) {
+        struct timespec t;
         attr->va_set_mask |= CHIMERA_VFS_ATTR_BTIME;
-        if (attr->va_btime.tv_nsec == CHIMERA_VFS_TIME_NOW) {
-            inode->btime_sec  = now.tv_sec;
-            inode->btime_nsec = now.tv_nsec;
-        } else if (attr->va_btime.tv_nsec != CHIMERA_VFS_TIME_OMIT) {
-            inode->btime_sec  = attr->va_btime.tv_sec;
-            inode->btime_nsec = attr->va_btime.tv_nsec;
+        if (chimera_vfs_resolve_set_time(&attr->va_btime, &now, &t)) {
+            inode->btime_sec  = t.tv_sec;
+            inode->btime_nsec = t.tv_nsec;
         }
     }
 
@@ -10290,13 +10284,11 @@ diskfs_apply_attrs(
      * SetInfo) or preserve it on TIME_OMIT; otherwise stamp it with now for the
      * implicit metadata change.  See memfs_apply_attrs() for the rationale. */
     if (set_mask & CHIMERA_VFS_ATTR_CTIME) {
+        struct timespec t;
         attr->va_set_mask |= CHIMERA_VFS_ATTR_CTIME;
-        if (attr->va_ctime.tv_nsec == CHIMERA_VFS_TIME_NOW) {
-            inode->ctime_sec  = now.tv_sec;
-            inode->ctime_nsec = now.tv_nsec;
-        } else if (attr->va_ctime.tv_nsec != CHIMERA_VFS_TIME_OMIT) {
-            inode->ctime_sec  = attr->va_ctime.tv_sec;
-            inode->ctime_nsec = attr->va_ctime.tv_nsec;
+        if (chimera_vfs_resolve_set_time(&attr->va_ctime, &now, &t)) {
+            inode->ctime_sec  = t.tv_sec;
+            inode->ctime_nsec = t.tv_nsec;
         }
     } else {
         inode->ctime_sec  = now.tv_sec;

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -1318,20 +1318,12 @@ memfs_apply_attrs(
 
     if (set_mask & CHIMERA_VFS_ATTR_ATIME) {
         attr->va_set_mask |= CHIMERA_VFS_ATTR_ATIME;
-        if (attr->va_atime.tv_nsec == CHIMERA_VFS_TIME_NOW) {
-            inode->atime = now;
-        } else if (attr->va_atime.tv_nsec != CHIMERA_VFS_TIME_OMIT) {
-            inode->atime = attr->va_atime;
-        }
+        chimera_vfs_resolve_set_time(&attr->va_atime, &now, &inode->atime);
     }
 
     if (set_mask & CHIMERA_VFS_ATTR_MTIME) {
         attr->va_set_mask |= CHIMERA_VFS_ATTR_MTIME;
-        if (attr->va_mtime.tv_nsec == CHIMERA_VFS_TIME_NOW) {
-            inode->mtime = now;
-        } else if (attr->va_mtime.tv_nsec != CHIMERA_VFS_TIME_OMIT) {
-            inode->mtime = attr->va_mtime;
-        }
+        chimera_vfs_resolve_set_time(&attr->va_mtime, &now, &inode->mtime);
     }
 
     /* ACL coherence.  An explicit ACL set replaces storage and re-derives mode;
@@ -1359,11 +1351,7 @@ memfs_apply_attrs(
 
     if (set_mask & CHIMERA_VFS_ATTR_BTIME) {
         attr->va_set_mask |= CHIMERA_VFS_ATTR_BTIME;
-        if (attr->va_btime.tv_nsec == CHIMERA_VFS_TIME_NOW) {
-            inode->btime = now;
-        } else if (attr->va_btime.tv_nsec != CHIMERA_VFS_TIME_OMIT) {
-            inode->btime = attr->va_btime;
-        }
+        chimera_vfs_resolve_set_time(&attr->va_btime, &now, &inode->btime);
     }
 
     /* Opaque pNFS layout state: persist the NFS server's blob verbatim. */
@@ -1388,11 +1376,7 @@ memfs_apply_attrs(
      * all (NFS chmod/chown, etc.), stamp it with `now`. */
     if (set_mask & CHIMERA_VFS_ATTR_CTIME) {
         attr->va_set_mask |= CHIMERA_VFS_ATTR_CTIME;
-        if (attr->va_ctime.tv_nsec == CHIMERA_VFS_TIME_NOW) {
-            inode->ctime = now;
-        } else if (attr->va_ctime.tv_nsec != CHIMERA_VFS_TIME_OMIT) {
-            inode->ctime = attr->va_ctime;
-        }
+        chimera_vfs_resolve_set_time(&attr->va_ctime, &now, &inode->ctime);
     } else {
         inode->ctime = now;
     }

--- a/src/vfs/vfs_attrs.h
+++ b/src/vfs/vfs_attrs.h
@@ -98,6 +98,34 @@ struct chimera_acl;
  * a value of TIME_OMIT means the backend should leave that timestamp alone. */
 #define CHIMERA_VFS_TIME_OMIT           ((1l << 30) - 4l)
 
+/*
+ * Resolve a settable timestamp against the TIME_NOW / TIME_OMIT sentinels that
+ * the SMB and NFS layers carry in a settable atime/mtime/btime/ctime field.
+ * Writes the resolved value to *out and returns 1 when the field should be
+ * stored (TIME_NOW -> the pre-sampled `now`, any concrete value -> itself), or
+ * returns 0 without touching *out when the caller asked to preserve the
+ * existing value (TIME_OMIT).  Leaving *out untouched on the 0 return lets a
+ * caller pass a pointer to the stored field directly and have TIME_OMIT be a
+ * no-op.  This is the single source of truth for that three-way decision; the
+ * native-storage backends (memfs/cairn/diskfs) all route through it.
+ */
+static inline int
+chimera_vfs_resolve_set_time(
+    const struct timespec *in,
+    const struct timespec *now,
+    struct timespec       *out)
+{
+    if (in->tv_nsec == CHIMERA_VFS_TIME_NOW) {
+        *out = *now;
+        return 1;
+    } else if (in->tv_nsec != CHIMERA_VFS_TIME_OMIT) {
+        *out = *in;
+        return 1;
+    }
+
+    return 0;
+} /* chimera_vfs_resolve_set_time */
+
 struct chimera_vfs_attrs {
     uint64_t            va_req_mask;
     uint64_t            va_set_mask;


### PR DESCRIPTION
## Summary

`memfs`, `cairn`, and `diskfs` each open-coded the same three-way decision for a settable `atime`/`mtime`/`btime`/`ctime` field in their `*_apply_attrs`:

- `TIME_NOW` → stamp the pre-sampled `now`
- `TIME_OMIT` → preserve the stored value
- any concrete value → store it

That is the contract behind the `CHIMERA_VFS_TIME_NOW`/`CHIMERA_VFS_TIME_OMIT` sentinels (SMB `SetInfo(FileBasicInformation)` round-trip / suppress, NFS `utimensat`-style `now`), and it lived in **12 hand-written copies** (4 fields × 3 backends) that had to stay in lockstep.

This hoists the decision into a single `chimera_vfs_resolve_set_time()` in `vfs_attrs.h`, right next to the sentinel definitions it interprets, and routes all three backends through it.

## Mechanics

- **memfs / cairn** store `struct timespec`, so they pass the inode field straight through as the output. `TIME_OMIT` is a no-op because the helper leaves `*out` untouched on a preserve.
- **diskfs** keeps its split `sec`/`nsec` on-disk layout and writes back only when the helper reports a change (return value `1`).
- The POSIX "stamp `ctime` on any *other* metadata change" fallback is unchanged and still lives in each `apply_attrs` (it is not a sentinel decision).

No behavior change: for every input the resolved value and the `va_set_mask` echo are identical to before. This is purely the removal of duplicated sentinel logic into one source of truth, so a future fix to the `NOW`/`OMIT` semantics lands in one place instead of three.

## Verification

Green on memfs/cairn/diskfs under ASan (Debug):
- `smb2.timestamps` — 70 tests (the SMB SetInfo round-trip + OMIT path)
- pynfs `setattr` (`SATT*`) — 184 tests
- posix `chmod`/`fchmod`/`fchmodat`/`truncate`/`ftruncate` — 140 tests (ctime/mtime assertions)

## Note

While doing this I confirmed a prior suspicion that the three backends had drifted on the `ctime` block was **not** accurate — all three already handle `ctime` (including the `else`-stamp fallback) identically. So this PR is a clean dedup with no latent-bug fix bundled in.

`linux`/`io_uring` are intentionally untouched: they translate the sentinels to the kernel's `UTIME_NOW`/`UTIME_OMIT` rather than resolving them to a concrete value, which is a different operation.