### PR TITLE
smb2: courtesy-hold disconnected durable handles (keep compatible, purge conflicting)

### DIFF
--- a/src/server/smb/smb_durable.c
+++ b/src/server/smb/smb_durable.c
@@ -162,6 +162,93 @@ chimera_smb_durable_forget(
     }
 } /* chimera_smb_durable_forget */
 
+/* Fire-and-forget context for a delete-on-close unlink issued while a parked
+ * durable open is torn down.  Unlike the CLOSE path there is no request to
+ * complete, so the doc_info is copied here and freed in the final callback. */
+struct chimera_smb_durable_doc {
+    struct chimera_vfs_thread      *vfs_thread;
+    struct chimera_vfs_doc_info     doc_info;
+    struct chimera_vfs_open_handle *parent_handle;
+};
+
+static void
+chimera_smb_durable_doc_remove_cb(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *pre_attr,
+    struct chimera_vfs_attrs *post_attr,
+    void                     *private_data)
+{
+    struct chimera_smb_durable_doc *ctx = private_data;
+
+    if (error_code) {
+        chimera_smb_debug("durable delete-on-close: remove_at failed for '%.*s' (error %d)",
+                          ctx->doc_info.name_len, ctx->doc_info.name, error_code);
+    }
+    chimera_vfs_release(ctx->vfs_thread, ctx->parent_handle);
+    chimera_vfs_close(ctx->vfs_thread, ctx->doc_info.close_module,
+                      ctx->doc_info.close_private, ctx->doc_info.close_hash, NULL, NULL);
+    free(ctx);
+} /* chimera_smb_durable_doc_remove_cb */
+
+static void
+chimera_smb_durable_doc_open_parent_cb(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *oh,
+    void                           *private_data)
+{
+    struct chimera_smb_durable_doc *ctx = private_data;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        chimera_smb_debug("durable delete-on-close: open parent failed for '%.*s' (error %d)",
+                          ctx->doc_info.name_len, ctx->doc_info.name, error_code);
+        chimera_vfs_close(ctx->vfs_thread, ctx->doc_info.close_module,
+                          ctx->doc_info.close_private, ctx->doc_info.close_hash, NULL, NULL);
+        free(ctx);
+        return;
+    }
+    ctx->parent_handle = oh;
+    chimera_vfs_remove_at(ctx->vfs_thread, &ctx->doc_info.cred, oh,
+                          ctx->doc_info.name, ctx->doc_info.name_len, NULL, 0, 0, 0,
+                          chimera_smb_durable_doc_remove_cb, ctx);
+} /* chimera_smb_durable_doc_open_parent_cb */
+
+/*
+ * Release a parked durable open's VFS handle honoring delete-on-close: if the
+ * handle was delete-pending (a DELETE_ON_CLOSE durable handle whose last close
+ * is this teardown), the file is unlinked asynchronously (no request needed).
+ * Requires a live event-loop pump, so it must NOT be used on the shutdown drain.
+ */
+static void
+chimera_smb_durable_release_handle(
+    struct chimera_server_smb_thread *thread,
+    struct chimera_smb_open_file     *open_file)
+{
+    struct chimera_smb_durable_doc *ctx;
+    struct chimera_vfs_doc_info     doc_info;
+    int                             need_doc;
+
+    if (!open_file->handle) {
+        return;
+    }
+
+    need_doc          = chimera_vfs_release_doc(thread->vfs_thread, open_file->handle, &doc_info);
+    open_file->handle = NULL;
+
+    if (!need_doc || doc_info.parent_fh_len == 0) {
+        return;
+    }
+
+    ctx                = malloc(sizeof(*ctx));
+    ctx->vfs_thread    = thread->vfs_thread;
+    ctx->doc_info      = doc_info;
+    ctx->parent_handle = NULL;
+
+    chimera_vfs_open_fh(thread->vfs_thread, &ctx->doc_info.cred,
+                        ctx->doc_info.parent_fh, ctx->doc_info.parent_fh_len,
+                        CHIMERA_VFS_OPEN_INFERRED | CHIMERA_VFS_OPEN_PATH,
+                        chimera_smb_durable_doc_open_parent_cb, ctx);
+} /* chimera_smb_durable_release_handle */
+
 /* Purge a parked (disconnected) *durable* open by persistent id when a new,
  * conflicting open arrives: MS-SMB2 has the disconnected handle yield.  Tears
  * down its leases / share reservation / byte-range locks and VFS handle (the
@@ -196,10 +283,7 @@ chimera_smb_durable_purge_parked(
     }
 
     chimera_smb_open_file_drain_locks(thread, open_file);
-    if (open_file->handle) {
-        chimera_vfs_release(thread->vfs_thread, open_file->handle);
-        open_file->handle = NULL;
-    }
+    chimera_smb_durable_release_handle(thread, open_file);
     chimera_smb_open_file_free(thread, open_file);
     return true;
 } /* chimera_smb_durable_purge_parked */
@@ -228,6 +312,19 @@ chimera_smb_durable_park(
         }
     }
     pthread_mutex_unlock(&shared->durable.lock);
+
+    /* Mark the caching grant's lease AND the share reservation parked so the
+     * vfs_state conflict matrix treats this disconnected holder as
+     * courtesy-held: a compatible new open coexists (keep) and a write-cache
+     * holder is evicted by the caching-acquire path (purge).  The share-resv
+     * flag stops the sole-opener rule from capping a new opener's lease to R on
+     * account of a disconnected holder.  Cleared on reconnect. */
+    if (open_file->grant) {
+        open_file->grant->lease.parked = 1;
+    }
+    if (open_file->share_lease_inserted) {
+        open_file->share_lease.parked = 1;
+    }
 } /* chimera_smb_durable_park */
 
 SYMBOL_EXPORT struct chimera_smb_open_file *
@@ -361,10 +458,9 @@ chimera_smb_durable_sweep(struct chimera_server_smb_thread *thread)
                           open_file->file_id.pid, open_file->name_len, open_file->name);
 
         chimera_smb_open_file_drain_locks(thread, open_file);
-        if (open_file->handle) {
-            chimera_vfs_release(thread->vfs_thread, open_file->handle);
-            open_file->handle = NULL;
-        }
+        /* Grace-timer reap honors delete-on-close (a DELETE_ON_CLOSE durable
+         * handle whose last close is this expiry unlinks the file). */
+        chimera_smb_durable_release_handle(thread, open_file);
         chimera_smb_open_file_free(thread, open_file);
 
         free(entry);

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -243,6 +243,53 @@ chimera_smb_create_share_park_cb(
     void                         *private_data);
 
 /*
+ * Before a conflicting open breaks a caching holder, evict any *parked*
+ * (disconnected durable) holder that still holds a write cache on this file: a
+ * doomed break would only mark its lease BREAKING (the parked handle has no
+ * connection to ack it), masking the conflict so the new open silently caps its
+ * own grant -- and the orphaned handle leaks until its grace timer.  MS-SMB2 has
+ * the disconnected handle yield to a conflicting open, so purge it instead.  A
+ * parked holder with no write cache is courtesy-held and left to coexist
+ * (keep-disconnected-rh-*).  pids are collected under file->lock, then purged
+ * after it is dropped (purge takes the registry lock and tears down VFS state).
+ */
+static void
+chimera_smb_create_purge_parked_writers(
+    struct chimera_server_smb_thread *thread,
+    const uint8_t                    *fh,
+    uint8_t                           fh_len,
+    uint64_t                          fh_hash)
+{
+    struct chimera_vfs_state      *vfs_state = thread->vfs_thread->vfs->vfs_state;
+    struct chimera_vfs_file_state *file_state;
+    struct chimera_vfs_lease      *lease;
+    uint64_t                       pids[16];
+    int                            npids = 0, i;
+
+    file_state = chimera_vfs_state_get(vfs_state, fh, fh_len, fh_hash, false);
+    if (!file_state) {
+        return;
+    }
+
+    pthread_mutex_lock(&file_state->lock);
+    for (lease = file_state->caching_leases; lease && npids < 16; lease = lease->next) {
+        if (lease->parked &&
+            (lease->mode.granted & CHIMERA_VFS_LEASE_MODE_W) &&
+            lease->grant && lease->grant->holders) {
+            pids[npids++] =
+                ((struct chimera_smb_open_file *) lease->grant->holders)->file_id.pid;
+        }
+    }
+    pthread_mutex_unlock(&file_state->lock);
+
+    chimera_vfs_state_put(vfs_state, file_state);
+
+    for (i = 0; i < npids; i++) {
+        chimera_smb_durable_purge_parked(thread, pids[i]);
+    }
+} /* chimera_smb_create_purge_parked_writers */
+
+/*
  * Single break-decision point for a conflicting open (MS-FSA open-vs-oplock
  * ordering), factored out of the two create-path call sites that previously
  * duplicated the trigger/owner computation verbatim.
@@ -314,6 +361,8 @@ chimera_smb_create_break_for_open(
     }
 
     if (phase == 1) {
+        /* Evict parked write-cache holders before the (otherwise doomed) break. */
+        chimera_smb_create_purge_parked_writers(thread, oh->fh, oh->fh_len, oh->fh_hash);
         chimera_vfs_state_break_caching_for_open(
             vfs_state, oh->fh, oh->fh_len, oh->fh_hash, &io_owner,
             CHIMERA_VFS_LEASE_MODE_H,
@@ -578,7 +627,12 @@ chimera_smb_create_gen_open_file(
             return NULL;
         }
 
-        open_file->share_lease.kind             = CHIMERA_VFS_LEASE_SHARE;
+        open_file->share_lease.kind = CHIMERA_VFS_LEASE_SHARE;
+        /* Explicitly clear the parked flag: the open_file pool is reused without
+         * zeroing, so a recycled slot could otherwise carry a stale parked=1 from
+         * a previously-disconnected durable handle and make this live opener
+         * invisible to the sole-opener / conflict rules. */
+        open_file->share_lease.parked           = 0;
         open_file->share_lease.mode.granted     = granted;
         open_file->share_lease.mode.denied      = denied;
         open_file->share_lease.owner.protocol   = CHIMERA_VFS_LEASE_PROTO_SMB2;
@@ -2715,6 +2769,13 @@ chimera_smb_durable_reconnect(struct chimera_smb_request *request)
     /* Reseed the channel-sequence baseline from the reconnecting CREATE. */
     open_file->channel_sequence       = request->channel_sequence;
     open_file->channel_sequence_valid = 1;
+    /* No longer a courtesy-held disconnected holder. */
+    if (open_file->grant) {
+        open_file->grant->lease.parked = 0;
+    }
+    if (open_file->share_lease_inserted) {
+        open_file->share_lease.parked = 0;
+    }
 
     bucket = open_file->file_id.vid & CHIMERA_SMB_OPEN_FILE_BUCKET_MASK;
     pthread_mutex_lock(&tree->open_files_lock[bucket]);

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -1293,11 +1293,18 @@ set(SMBTORTURE_ENABLED_memfs
     # smb2.durable-open-disconnect
     smb2.durable-open-disconnect.open-oplock-disconnect
     # smb2.durable-open
+    smb2.durable-open.lease
+    smb2.durable-open.oplock
+    smb2.durable-open.open2-oplock
     # smb2.durable-v2-delay
     smb2.durable-v2-delay.durable_v2_reconnect_delay
     smb2.durable-v2-delay.durable_v2_reconnect_delay_msec
     # smb2.durable-v2-open
     smb2.durable-v2-open.app-instance
+    smb2.durable-v2-open.keep-disconnected-rh-with-rh-open
+    smb2.durable-v2-open.keep-disconnected-rh-with-rwh-open
+    smb2.durable-v2-open.purge-disconnected-rwh-with-rh-open
+    smb2.durable-v2-open.purge-disconnected-rwh-with-rwh-open
     # smb2.durable-v2-regressions
     smb2.durable-v2-regressions.durable_v2_reconnect_bug15624
     # smb2.fileid
@@ -2195,11 +2202,18 @@ set(SMBTORTURE_ENABLED_cairn
     # smb2.durable-open-disconnect
     smb2.durable-open-disconnect.open-oplock-disconnect
     # smb2.durable-open
+    smb2.durable-open.lease
+    smb2.durable-open.oplock
+    smb2.durable-open.open2-oplock
     # smb2.durable-v2-delay
     smb2.durable-v2-delay.durable_v2_reconnect_delay
     smb2.durable-v2-delay.durable_v2_reconnect_delay_msec
     # smb2.durable-v2-open
     smb2.durable-v2-open.app-instance
+    smb2.durable-v2-open.keep-disconnected-rh-with-rh-open
+    smb2.durable-v2-open.keep-disconnected-rh-with-rwh-open
+    smb2.durable-v2-open.purge-disconnected-rwh-with-rh-open
+    smb2.durable-v2-open.purge-disconnected-rwh-with-rwh-open
     # smb2.durable-v2-regressions
     smb2.durable-v2-regressions.durable_v2_reconnect_bug15624
     # smb2.fileid
@@ -2526,6 +2540,10 @@ set(SMBTORTURE_ENABLED_diskfs_io_uring
     smb2.durable-v2-delay.durable_v2_reconnect_delay_msec
     # smb2.durable-v2-open
     smb2.durable-v2-open.app-instance
+    smb2.durable-v2-open.keep-disconnected-rh-with-rh-open
+    smb2.durable-v2-open.keep-disconnected-rh-with-rwh-open
+    smb2.durable-v2-open.purge-disconnected-rwh-with-rh-open
+    smb2.durable-v2-open.purge-disconnected-rwh-with-rwh-open
     # smb2.durable-v2-regressions
     smb2.durable-v2-regressions.durable_v2_reconnect_bug15624
     # smb2.fileid
@@ -2852,6 +2870,10 @@ set(SMBTORTURE_ENABLED_diskfs_aio
     smb2.durable-v2-delay.durable_v2_reconnect_delay_msec
     # smb2.durable-v2-open
     smb2.durable-v2-open.app-instance
+    smb2.durable-v2-open.keep-disconnected-rh-with-rh-open
+    smb2.durable-v2-open.keep-disconnected-rh-with-rwh-open
+    smb2.durable-v2-open.purge-disconnected-rwh-with-rh-open
+    smb2.durable-v2-open.purge-disconnected-rwh-with-rwh-open
     # smb2.durable-v2-regressions
     smb2.durable-v2-regressions.durable_v2_reconnect_bug15624
     # smb2.fileid

--- a/src/vfs/vfs_lease_types.h
+++ b/src/vfs/vfs_lease_types.h
@@ -157,6 +157,15 @@ struct chimera_vfs_lease {
     uint64_t                          break_skip_lo;
     uint64_t                          break_skip_hi;
 
+    /* Set by the SMB server when this caching lease's owning open is PARKED as a
+     * disconnected durable handle (MS-SMB2 "courtesy-held" open).  A parked
+     * holder with no write cache is treated as non-conflicting for the
+     * cross-client handle-cache rule so a compatible new open can coexist (the
+     * keep-disconnected case); a parked holder that still holds a write cache is
+     * evicted (purged) by the SMB caching-acquire path instead.  Cleared on
+     * reconnect. */
+    uint8_t                           parked;
+
     /* For a CACHING lease that is owned by a VFS caching grant (the shared,
      * owner-keyed, refcounted object that lets N opens under one owner share a
      * single lease): back-pointer to that grant, so begin_break/ack/revoke can

--- a/src/vfs/vfs_state.c
+++ b/src/vfs/vfs_state.c
@@ -434,7 +434,13 @@ chimera_vfs_caching_conflict(
      * under a different key -- smb2.lease.break expects two RH leases to coexist).
      * Write caching above is the only mode exclusive even within one client. */
     if ((e & CHIMERA_VFS_LEASE_MODE_H) && (p & CHIMERA_VFS_LEASE_MODE_H) &&
-        existing->owner.client_key != probe->owner.client_key) {
+        existing->owner.client_key != probe->owner.client_key &&
+        !existing->parked) {
+        /* A *parked* (disconnected durable) holder with no write cache is
+        * courtesy-held: MS-SMB2 lets a compatible new open from another client
+        * coexist with it (keep-disconnected-rh-*), so it does not conflict on
+        * the handle-cache rule.  (A parked holder that still holds W trips the
+        * W rule above and is evicted by the SMB caching-acquire path.) */
         return true;
     }
 
@@ -808,6 +814,14 @@ chimera_vfs_state_would_conflict(
                      * matching the prior behavior where stat-opens took no share
                      * reservation at all. */
                     if (cur->mode.granted == 0 && cur->mode.denied == 0) {
+                        continue;
+                    }
+                    /* A parked (disconnected durable) holder is courtesy-held: it
+                     * does not cap a new opener's lease.  If it genuinely conflicts
+                     * (a write cache) the caching-vs-caching path above already
+                     * forced a break/deny; otherwise the new open coexists with it
+                     * (keep-disconnected-rh-*). */
+                    if (cur->parked) {
                         continue;
                     }
                     if (conflict_out) {


### PR DESCRIPTION
## Summary

A disconnected durable handle is **courtesy-held** (MS-SMB2 §3.3.5.9.7): a *compatible* new open coexists with it, while a *conflicting* new open evicts it. Chimera did neither cleanly — the parked handle's caching lease was treated like a live one, so:
- a **compatible** RH reopen was capped to read-only (no durable grant returned), and
- a **conflicting** open fired a *doomed* oplock break that the disconnected handle could never ack — masking the conflict (the new open silently capped its own grant) and leaking the orphaned handle until its grace timer.

This adds a `parked` flag on the caching/share lease (set when a durable open parks, cleared on reconnect) and teaches the conflict path to honor the courtesy-hold:

- **keep:** a parked holder with **no write cache** is non-conflicting for the cross-client handle-cache rule and does not cap a new opener via the sole-opener rule — a compatible RH reopen coexists and keeps its own durable grant (`vfs_state.c`).
- **purge:** before a conflicting open's (otherwise doomed) phase-1 break, evict any parked **write-cache** holder on the file — the disconnected handle yields by eviction (`chimera_smb_create_purge_parked_writers`). The purge **honors delete-on-close**, unlinking a delete-pending file as its last close.

The parked flag is explicitly cleared when a recycled `open_file` takes a fresh share reservation (the pool is not zeroed), so a live opener is never mistaken for a courtesy-held one.

### Tests greened
- `smb2.durable-open.{oplock,lease,open2-oplock}` — memfs/cairn (timing-sensitive on the slower diskfs backend, so not enabled there)
- `smb2.durable-v2-open.{keep-disconnected-rh-with-rh-open, keep-disconnected-rh-with-rwh-open, purge-disconnected-rwh-with-rh-open, purge-disconnected-rwh-with-rwh-open}` — memfs/cairn/diskfs

### No regressions
- The **full `smb2.lease` and `smb2.oplock` suites have a byte-identical per-subtest failure set vs main** (stash/rebuild/diff) — the changes are inert unless a parked durable holder is present.
- `vfs_state` unit tests **74/74**, **scan-build clean** (Debug + Release), `delete_on_close2` not regressed.

### Deferred to a Phase 3b follow-up
These each need a distinct additional mechanism beyond the parked courtesy-hold:
- `durable-open.delete_on_close1` — the *purging* create must observe the file already deleted, but the delete-on-close unlink is async (races the create's open). Needs a synchronous unlink-during-create.
- `durable-v2-open.purge-disconnected-rh-with-{write,rename}` — a parked **RH** (no-W) holder evicted by a conflicting **write/rename**, which live on the write/rename paths (not the create caching-acquire).
- `durable-v2-open.nonstat-and-lease` — W-sole-access that strips W but **keeps H** for a same-client non-coalesced other-opener.
- `smb2.replay.replay-dhv2-oplock2/3` — also need the create_guid replay from #711.