### PR TITLE
test-infra: cut KVM and pynfs per-test overhead

### DIFF
--- a/kvm/CMakeLists.txt
+++ b/kvm/CMakeLists.txt
@@ -16,14 +16,19 @@ get_filename_component(BUILD_ROOT ${CMAKE_BINARY_DIR} DIRECTORY)
 set(KVM_IMAGE_REGISTRY "ghcr.io/chimera-nas/kvm-test-base" CACHE STRING
     "OCI registry base that hosts the prebuilt KVM guest images.")
 # Pinned version of the prebuilt images to consume; bump to adopt a newer
-# kvm-test-base release.
-set(KVM_IMAGE_VERSION "v1.0.0" CACHE STRING
+# kvm-test-base release.  v1.1.0 drops the 22.04 generic variant (see the
+# KVM_IMAGES note below); v1.0.0 still has all four for older checkouts.
+set(KVM_IMAGE_VERSION "v1.1.0" CACHE STRING
     "Version tag of the KVM guest images to consume.")
 
+# Note: the 22.04 generic (non-HWE) kernel does not build the virtio block
+# driver in -- it can only mount the root disk from its initrd.  Every other
+# kernel here has virtio built in, so the wrappers boot with no initrd (saving
+# ~0.9s/test, see kvm_*_test_wrapper.sh).  Rather than special-case an initrd
+# for one image, 22.04 is covered by its HWE kernel only.
 set(KVM_IMAGES
     ubuntu2404
     ubuntu2404_hwe
-    ubuntu2204
     ubuntu2204_hwe
 )
 

--- a/kvm/kvm_nfs_test_wrapper.sh
+++ b/kvm/kvm_nfs_test_wrapper.sh
@@ -68,9 +68,9 @@ cleanup() {
     if [ -n "$CHIMERA_PID" ]; then
         kill "$CHIMERA_PID" 2>/dev/null || true
         # Give chimera up to 3 seconds to shut down cleanly
-        for i in $(seq 1 30); do
+        for i in $(seq 1 150); do
             kill -0 "$CHIMERA_PID" 2>/dev/null || break
-            sleep 0.1
+            sleep 0.02
         done
         # Force kill if still alive
         if kill -0 "$CHIMERA_PID" 2>/dev/null; then
@@ -191,7 +191,7 @@ ip netns exec "${NETNS_NAME}" "$CHIMERA_BINARY" -c "$CONFIG_FILE" &
 CHIMERA_PID=$!
 
 # Wait for NFS port to be ready
-for i in $(seq 1 30); do
+for i in $(seq 1 150); do
     if ip netns exec "${NETNS_NAME}" bash -c "echo > /dev/tcp/10.0.0.1/2049" 2>/dev/null; then
         break
     fi
@@ -199,7 +199,7 @@ for i in $(seq 1 30); do
         echo "chimera daemon exited prematurely"
         exit 1
     fi
-    sleep 0.1
+    sleep 0.02
 done
 
 # Build the test command to run inside the VM

--- a/kvm/kvm_nfs_test_wrapper.sh
+++ b/kvm/kvm_nfs_test_wrapper.sh
@@ -134,6 +134,9 @@ generate_config() {
 
     cat > "$CONFIG_FILE" << EOF
 {
+    "common": {
+        "rcu_reclaim_threads": 4
+    },
     "server": {
         "threads": 4,
         "delegation_threads": 4,

--- a/kvm/kvm_nfs_test_wrapper.sh
+++ b/kvm/kvm_nfs_test_wrapper.sh
@@ -223,7 +223,7 @@ ip netns exec "${NETNS_NAME}" "$QEMU_BIN" \
     -serial stdio \
     -nographic \
     -no-reboot \
-    -append "root=/dev/vda rw console=${QEMU_CONSOLE} net.ifnames=0 biosdevname=0 quiet panic=-1 test_cmd=\"${TEST_CMD}\" init=/init.sh" \
+    -append "root=/dev/vda rw console=${QEMU_CONSOLE} net.ifnames=0 biosdevname=0 quiet mitigations=off tsc=reliable panic=-1 test_cmd=\"${TEST_CMD}\" init=/init.sh" \
     2>/dev/null | tee "$LOG_FILE"
 
 # Check if chimera is still alive after QEMU exits

--- a/kvm/kvm_nfs_test_wrapper.sh
+++ b/kvm/kvm_nfs_test_wrapper.sh
@@ -22,7 +22,11 @@ if [ "$ARCH" = "aarch64" ]; then
     QEMU_CONSOLE="ttyAMA0"
 else
     QEMU_BIN="qemu-system-x86_64"
-    QEMU_MACHINE="-machine q35,usb=off"
+    # microvm machine: skips legacy PCI/ACPI device probing for a faster boot
+    # (~0.1s/test).  pcie=on keeps a PCIe bus so the existing virtio-pci and
+    # virtio-scsi-pci devices attach unchanged; rtc/pit on so the guest kernel
+    # uses normal timers (without them it falls back to slow calibration paths).
+    QEMU_MACHINE="-M microvm,acpi=on,rtc=on,pit=on,pcie=on"
     QEMU_CONSOLE="ttyS0"
 fi
 

--- a/kvm/kvm_nfs_test_wrapper.sh
+++ b/kvm/kvm_nfs_test_wrapper.sh
@@ -33,13 +33,12 @@ BACKEND=$1; shift
 NFS_VERSION=$1; shift
 TEST_CMD_ARG="$*"
 
-# Use initrd if present alongside vmlinuz
-INITRD="$(dirname "$VMLINUZ")/initrd"
-if [ -f "$INITRD" ]; then
-    QEMU_INITRD="-initrd $INITRD"
-else
-    QEMU_INITRD=""
-fi
+# Boot with no initrd: every kernel in the KVM image matrix builds the virtio
+# block/net drivers in, so the kernel mounts the virtio root disk directly.
+# Skipping the ~63MB initrd unpack saves ~0.9s/test.  (See kvm/CMakeLists.txt:
+# the 22.04 generic kernel, which needs an initrd, was dropped from the matrix
+# in favor of its HWE kernel for exactly this reason.)
+QEMU_INITRD=""
 
 NETNS_NAME="kvm_nfs_$$_$(date +%s%N)"
 TAP_NAME="tap_$$"

--- a/kvm/kvm_pnfs_block_test_wrapper.sh
+++ b/kvm/kvm_pnfs_block_test_wrapper.sh
@@ -34,7 +34,11 @@ if [ "$ARCH" = "aarch64" ]; then
     QEMU_CONSOLE="ttyAMA0"
 else
     QEMU_BIN="qemu-system-x86_64"
-    QEMU_MACHINE="-machine q35,usb=off"
+    # microvm machine: skips legacy PCI/ACPI device probing for a faster boot
+    # (~0.1s/test).  pcie=on keeps a PCIe bus so the existing virtio-pci and
+    # virtio-scsi-pci devices attach unchanged; rtc/pit on so the guest kernel
+    # uses normal timers (without them it falls back to slow calibration paths).
+    QEMU_MACHINE="-M microvm,acpi=on,rtc=on,pit=on,pcie=on"
     QEMU_CONSOLE="ttyS0"
 fi
 

--- a/kvm/kvm_pnfs_block_test_wrapper.sh
+++ b/kvm/kvm_pnfs_block_test_wrapper.sh
@@ -44,12 +44,12 @@ CHIMERA_BINARY=$1; shift
 BACKEND=$1; shift
 TEST_CMD_ARG="$*"
 
-INITRD="$(dirname "$VMLINUZ")/initrd"
-if [ -f "$INITRD" ]; then
-    QEMU_INITRD="-initrd $INITRD"
-else
-    QEMU_INITRD=""
-fi
+# Boot with no initrd: every kernel in the KVM image matrix builds the virtio
+# block/net drivers in, so the kernel mounts the virtio root disk directly.
+# Skipping the ~63MB initrd unpack saves ~0.9s/test.  (See kvm/CMakeLists.txt:
+# the 22.04 generic kernel, which needs an initrd, was dropped from the matrix
+# in favor of its HWE kernel for exactly this reason.)
+QEMU_INITRD=""
 
 NETNS_NAME="kvm_pnfsblk_$$_$(date +%s%N)"
 TAP_NAME="tapb_$$"

--- a/kvm/kvm_pnfs_block_test_wrapper.sh
+++ b/kvm/kvm_pnfs_block_test_wrapper.sh
@@ -192,7 +192,7 @@ ip netns exec "${NETNS_NAME}" "$QEMU_BIN" \
     -serial stdio \
     -nographic \
     -no-reboot \
-    -append "root=/dev/vda rw console=${QEMU_CONSOLE} net.ifnames=0 biosdevname=0 quiet panic=-1 test_cmd=\"${TEST_CMD}\" init=/init.sh" \
+    -append "root=/dev/vda rw console=${QEMU_CONSOLE} net.ifnames=0 biosdevname=0 quiet mitigations=off tsc=reliable panic=-1 test_cmd=\"${TEST_CMD}\" init=/init.sh" \
     2>/dev/null | tee "$LOG_FILE"
 
 if ! kill -0 "$MDS_PID" 2>/dev/null; then

--- a/kvm/kvm_pnfs_block_test_wrapper.sh
+++ b/kvm/kvm_pnfs_block_test_wrapper.sh
@@ -79,9 +79,9 @@ SIG_HEX=$(printf '%s' "$SIG_MAGIC" | od -An -v -tx1 | tr -d ' \n')
 cleanup() {
     if [ -n "$MDS_PID" ]; then
         kill "$MDS_PID" 2>/dev/null || true
-        for i in $(seq 1 30); do
+        for i in $(seq 1 150); do
             kill -0 "$MDS_PID" 2>/dev/null || break
-            sleep 0.1
+            sleep 0.02
         done
         kill -9 "$MDS_PID" 2>/dev/null || true
         wait "$MDS_PID" 2>/dev/null || true
@@ -140,7 +140,7 @@ EOF
 
 wait_for_port() {
     local ip="$1" port="$2" pid="$3"
-    for i in $(seq 1 50); do
+    for i in $(seq 1 250); do
         if ip netns exec "${NETNS_NAME}" bash -c "echo > /dev/tcp/${ip}/${port}" 2>/dev/null; then
             return 0
         fi
@@ -148,7 +148,7 @@ wait_for_port() {
             echo "chimera daemon (pid $pid) exited prematurely" >&2
             return 1
         fi
-        sleep 0.1
+        sleep 0.02
     done
     echo "timed out waiting for ${ip}:${port}" >&2
     return 1

--- a/kvm/kvm_pnfs_block_test_wrapper.sh
+++ b/kvm/kvm_pnfs_block_test_wrapper.sh
@@ -106,6 +106,9 @@ generate_mds_config() {
 
     cat > "$MDS_CONFIG" << EOF
 {
+    "common": {
+        "rcu_reclaim_threads": 4
+    },
     "server": {
         "threads": 4,
         "external_portmap": false,

--- a/kvm/kvm_pnfs_proxy_test_wrapper.sh
+++ b/kvm/kvm_pnfs_proxy_test_wrapper.sh
@@ -39,7 +39,11 @@ if [ "$ARCH" = "aarch64" ]; then
     QEMU_CONSOLE="ttyAMA0"
 else
     QEMU_BIN="qemu-system-x86_64"
-    QEMU_MACHINE="-machine q35,usb=off"
+    # microvm machine: skips legacy PCI/ACPI device probing for a faster boot
+    # (~0.1s/test).  pcie=on keeps a PCIe bus so the existing virtio-pci and
+    # virtio-scsi-pci devices attach unchanged; rtc/pit on so the guest kernel
+    # uses normal timers (without them it falls back to slow calibration paths).
+    QEMU_MACHINE="-M microvm,acpi=on,rtc=on,pit=on,pcie=on"
     QEMU_CONSOLE="ttyS0"
 fi
 
@@ -49,12 +53,12 @@ CHIMERA_BINARY=$1; shift
 BACKEND=$1; shift
 TEST_CMD_ARG="$*"
 
-INITRD="$(dirname "$VMLINUZ")/initrd"
-if [ -f "$INITRD" ]; then
-    QEMU_INITRD="-initrd $INITRD"
-else
-    QEMU_INITRD=""
-fi
+# Boot with no initrd: every kernel in the KVM image matrix builds the virtio
+# block/net drivers in, so the kernel mounts the virtio root disk directly.
+# Skipping the ~63MB initrd unpack saves ~0.9s/test.  (See kvm/CMakeLists.txt:
+# the 22.04 generic kernel, which needs an initrd, was dropped from the matrix
+# in favor of its HWE kernel for exactly this reason.)
+QEMU_INITRD=""
 
 BE_NS="kvm_pnfsproxy_be_$$_$(date +%s%N)"
 FE_NS="kvm_pnfsproxy_fe_$$_$(date +%s%N)"
@@ -86,9 +90,9 @@ cleanup() {
     for pid in "$PROXY_PID" "$MDS_PID" "$DS_PID"; do
         if [ -n "$pid" ]; then
             kill "$pid" 2>/dev/null || true
-            for i in $(seq 1 30); do
+            for i in $(seq 1 150); do
                 kill -0 "$pid" 2>/dev/null || break
-                sleep 0.1
+                sleep 0.02
             done
             kill -9 "$pid" 2>/dev/null || true
             wait "$pid" 2>/dev/null || true
@@ -114,6 +118,9 @@ trap cleanup EXIT
 generate_ds_config() {
     cat > "$DS_CONFIG" << EOF
 {
+    "common": {
+        "rcu_reclaim_threads": 4
+    },
     "server": {
         "threads": 2,
         "nfs_port": ${DS_PORT},
@@ -154,6 +161,9 @@ generate_mds_config() {
 
     cat > "$MDS_CONFIG" << EOF
 {
+    "common": {
+        "rcu_reclaim_threads": 4
+    },
     "server": {
         "threads": 4,
         "external_portmap": false,
@@ -180,6 +190,9 @@ EOF
 generate_proxy_config() {
     cat > "$PROXY_CONFIG" << EOF
 {
+    "common": {
+        "rcu_reclaim_threads": 4
+    },
     "server": {
         "threads": 4,
         "nfs_port": ${PROXY_PORT},
@@ -196,7 +209,7 @@ EOF
 
 wait_for_port() {
     local ns="$1" ip="$2" port="$3" pid="$4"
-    for i in $(seq 1 50); do
+    for i in $(seq 1 250); do
         if ip netns exec "${ns}" bash -c "echo > /dev/tcp/${ip}/${port}" 2>/dev/null; then
             return 0
         fi
@@ -204,7 +217,7 @@ wait_for_port() {
             echo "chimera daemon (pid $pid) exited prematurely" >&2
             return 1
         fi
-        sleep 0.1
+        sleep 0.02
     done
     echo "timed out waiting for ${ip}:${port}" >&2
     return 1
@@ -285,7 +298,7 @@ ip netns exec "${FE_NS}" "$QEMU_BIN" \
     -serial stdio \
     -nographic \
     -no-reboot \
-    -append "root=/dev/vda rw console=${QEMU_CONSOLE} net.ifnames=0 biosdevname=0 quiet panic=-1 test_cmd=\"${TEST_CMD}\" init=/init.sh" \
+    -append "root=/dev/vda rw console=${QEMU_CONSOLE} net.ifnames=0 biosdevname=0 quiet mitigations=off tsc=reliable panic=-1 test_cmd=\"${TEST_CMD}\" init=/init.sh" \
     2>/dev/null | tee "$LOG_FILE"
 
 for pid in "$PROXY_PID" "$MDS_PID" "$DS_PID"; do

--- a/kvm/kvm_pnfs_scsi_test_wrapper.sh
+++ b/kvm/kvm_pnfs_scsi_test_wrapper.sh
@@ -64,12 +64,12 @@ CHIMERA_BINARY=$1; shift
 BACKEND=$1; shift
 TEST_CMD_ARG="$*"
 
-INITRD="$(dirname "$VMLINUZ")/initrd"
-if [ -f "$INITRD" ]; then
-    QEMU_INITRD="-initrd $INITRD"
-else
-    QEMU_INITRD=""
-fi
+# Boot with no initrd: every kernel in the KVM image matrix builds the virtio
+# block/net drivers in, so the kernel mounts the virtio root disk directly.
+# Skipping the ~63MB initrd unpack saves ~0.9s/test.  (See kvm/CMakeLists.txt:
+# the 22.04 generic kernel, which needs an initrd, was dropped from the matrix
+# in favor of its HWE kernel for exactly this reason.)
+QEMU_INITRD=""
 
 NETNS_NAME="kvm_pnfsscsi_$$_$(date +%s%N)"
 TAP_NAME="taps_$$"

--- a/kvm/kvm_pnfs_scsi_test_wrapper.sh
+++ b/kvm/kvm_pnfs_scsi_test_wrapper.sh
@@ -98,9 +98,9 @@ WWN="5000c500deadbeef"
 cleanup() {
     if [ -n "$MDS_PID" ]; then
         kill "$MDS_PID" 2>/dev/null || true
-        for i in $(seq 1 30); do
+        for i in $(seq 1 150); do
             kill -0 "$MDS_PID" 2>/dev/null || break
-            sleep 0.1
+            sleep 0.02
         done
         kill -9 "$MDS_PID" 2>/dev/null || true
         wait "$MDS_PID" 2>/dev/null || true
@@ -161,7 +161,7 @@ EOF
 
 wait_for_port() {
     local ip="$1" port="$2" pid="$3"
-    for i in $(seq 1 50); do
+    for i in $(seq 1 250); do
         if ip netns exec "${NETNS_NAME}" bash -c "echo > /dev/tcp/${ip}/${port}" 2>/dev/null; then
             return 0
         fi
@@ -169,7 +169,7 @@ wait_for_port() {
             echo "chimera daemon (pid $pid) exited prematurely" >&2
             return 1
         fi
-        sleep 0.1
+        sleep 0.02
     done
     echo "timed out waiting for ${ip}:${port}" >&2
     return 1

--- a/kvm/kvm_pnfs_scsi_test_wrapper.sh
+++ b/kvm/kvm_pnfs_scsi_test_wrapper.sh
@@ -211,7 +211,7 @@ ip netns exec "${NETNS_NAME}" "$QEMU_BIN" \
     -serial stdio \
     -nographic \
     -no-reboot \
-    -append "root=/dev/vda rw console=${QEMU_CONSOLE} net.ifnames=0 biosdevname=0 quiet panic=-1 test_cmd=\"${TEST_CMD}\" init=/init.sh" \
+    -append "root=/dev/vda rw console=${QEMU_CONSOLE} net.ifnames=0 biosdevname=0 quiet mitigations=off tsc=reliable panic=-1 test_cmd=\"${TEST_CMD}\" init=/init.sh" \
     2>/dev/null | tee "$LOG_FILE"
 
 if ! kill -0 "$MDS_PID" 2>/dev/null; then

--- a/kvm/kvm_pnfs_scsi_test_wrapper.sh
+++ b/kvm/kvm_pnfs_scsi_test_wrapper.sh
@@ -54,7 +54,11 @@ if [ "$ARCH" = "aarch64" ]; then
     QEMU_CONSOLE="ttyAMA0"
 else
     QEMU_BIN="qemu-system-x86_64"
-    QEMU_MACHINE="-machine q35,usb=off"
+    # microvm machine: skips legacy PCI/ACPI device probing for a faster boot
+    # (~0.1s/test).  pcie=on keeps a PCIe bus so the existing virtio-pci and
+    # virtio-scsi-pci devices attach unchanged; rtc/pit on so the guest kernel
+    # uses normal timers (without them it falls back to slow calibration paths).
+    QEMU_MACHINE="-M microvm,acpi=on,rtc=on,pit=on,pcie=on"
     QEMU_CONSOLE="ttyS0"
 fi
 

--- a/kvm/kvm_pnfs_scsi_test_wrapper.sh
+++ b/kvm/kvm_pnfs_scsi_test_wrapper.sh
@@ -126,6 +126,9 @@ generate_mds_config() {
 
     cat > "$MDS_CONFIG" << EOF
 {
+    "common": {
+        "rcu_reclaim_threads": 4
+    },
     "server": {
         "threads": 4,
         "external_portmap": false,

--- a/kvm/kvm_pnfs_test_wrapper.sh
+++ b/kvm/kvm_pnfs_test_wrapper.sh
@@ -35,7 +35,11 @@ if [ "$ARCH" = "aarch64" ]; then
     QEMU_CONSOLE="ttyAMA0"
 else
     QEMU_BIN="qemu-system-x86_64"
-    QEMU_MACHINE="-machine q35,usb=off"
+    # microvm machine: skips legacy PCI/ACPI device probing for a faster boot
+    # (~0.1s/test).  pcie=on keeps a PCIe bus so the existing virtio-pci and
+    # virtio-scsi-pci devices attach unchanged; rtc/pit on so the guest kernel
+    # uses normal timers (without them it falls back to slow calibration paths).
+    QEMU_MACHINE="-M microvm,acpi=on,rtc=on,pit=on,pcie=on"
     QEMU_CONSOLE="ttyS0"
 fi
 

--- a/kvm/kvm_pnfs_test_wrapper.sh
+++ b/kvm/kvm_pnfs_test_wrapper.sh
@@ -79,12 +79,12 @@ case "$TOPOLOGY" in
     *) echo "topology must be split or combined, got ${TOPOLOGY}" >&2; exit 1 ;;
 esac
 
-INITRD="$(dirname "$VMLINUZ")/initrd"
-if [ -f "$INITRD" ]; then
-    QEMU_INITRD="-initrd $INITRD"
-else
-    QEMU_INITRD=""
-fi
+# Boot with no initrd: every kernel in the KVM image matrix builds the virtio
+# block/net drivers in, so the kernel mounts the virtio root disk directly.
+# Skipping the ~63MB initrd unpack saves ~0.9s/test.  (See kvm/CMakeLists.txt:
+# the 22.04 generic kernel, which needs an initrd, was dropped from the matrix
+# in favor of its HWE kernel for exactly this reason.)
+QEMU_INITRD=""
 
 NETNS_NAME="kvm_pnfs_$$_$(date +%s%N)"
 TAP_NAME="tap_$$"

--- a/kvm/kvm_pnfs_test_wrapper.sh
+++ b/kvm/kvm_pnfs_test_wrapper.sh
@@ -120,9 +120,9 @@ cleanup() {
     for pid in "$MDS_PID" "$DS_PID"; do
         if [ -n "$pid" ]; then
             kill "$pid" 2>/dev/null || true
-            for i in $(seq 1 30); do
+            for i in $(seq 1 150); do
                 kill -0 "$pid" 2>/dev/null || break
-                sleep 0.1
+                sleep 0.02
             done
             kill -9 "$pid" 2>/dev/null || true
             wait "$pid" 2>/dev/null || true
@@ -281,7 +281,7 @@ EOF
 
 wait_for_port() {
     local ip="$1" port="$2" pid="$3"
-    for i in $(seq 1 50); do
+    for i in $(seq 1 250); do
         if ip netns exec "${NETNS_NAME}" bash -c "echo > /dev/tcp/${ip}/${port}" 2>/dev/null; then
             return 0
         fi
@@ -289,7 +289,7 @@ wait_for_port() {
             echo "chimera daemon (pid $pid) exited prematurely" >&2
             return 1
         fi
-        sleep 0.1
+        sleep 0.02
     done
     echo "timed out waiting for ${ip}:${port}" >&2
     return 1

--- a/kvm/kvm_pnfs_test_wrapper.sh
+++ b/kvm/kvm_pnfs_test_wrapper.sh
@@ -348,7 +348,7 @@ ip netns exec "${NETNS_NAME}" "$QEMU_BIN" \
     -serial stdio \
     -nographic \
     -no-reboot \
-    -append "root=/dev/vda rw console=${QEMU_CONSOLE} net.ifnames=0 biosdevname=0 quiet panic=-1 test_cmd=\"${TEST_CMD}\" init=/init.sh" \
+    -append "root=/dev/vda rw console=${QEMU_CONSOLE} net.ifnames=0 biosdevname=0 quiet mitigations=off tsc=reliable panic=-1 test_cmd=\"${TEST_CMD}\" init=/init.sh" \
     2>/dev/null | tee "$LOG_FILE"
 
 for pid in "$MDS_PID" "$DS_PID"; do

--- a/kvm/kvm_pnfs_test_wrapper.sh
+++ b/kvm/kvm_pnfs_test_wrapper.sh
@@ -153,6 +153,9 @@ trap cleanup EXIT
 generate_ds_config() {
     cat > "$DS_CONFIG" << EOF
 {
+    "common": {
+        "rcu_reclaim_threads": 4
+    },
     "server": {
         "threads": 2,
         "nfs_port": ${DS_PORT},
@@ -198,6 +201,9 @@ generate_mds_config() {
 
     cat > "$MDS_CONFIG" << EOF
 {
+    "common": {
+        "rcu_reclaim_threads": 4
+    },
     "server": {
         "threads": 4,
         "external_portmap": false,
@@ -247,6 +253,9 @@ generate_combined_config() {
 
     cat > "$MDS_CONFIG" << EOF
 {
+    "common": {
+        "rcu_reclaim_threads": 4
+    },
     "server": {
         "threads": 4,
         "external_portmap": false,

--- a/kvm/kvm_smb_test_wrapper.sh
+++ b/kvm/kvm_smb_test_wrapper.sh
@@ -179,7 +179,7 @@ ip netns exec "${NETNS_NAME}" env \
 CHIMERA_PID=$!
 
 # Wait for SMB port to be ready
-for i in $(seq 1 30); do
+for i in $(seq 1 150); do
     if ip netns exec "${NETNS_NAME}" bash -c "echo > /dev/tcp/10.0.0.1/445" 2>/dev/null; then
         break
     fi
@@ -187,7 +187,7 @@ for i in $(seq 1 30); do
         echo "chimera daemon exited prematurely"
         exit 1
     fi
-    sleep 0.1
+    sleep 0.02
 done
 
 # Build the test command to run inside the VM

--- a/kvm/kvm_smb_test_wrapper.sh
+++ b/kvm/kvm_smb_test_wrapper.sh
@@ -22,7 +22,11 @@ if [ "$ARCH" = "aarch64" ]; then
     QEMU_CONSOLE="ttyAMA0"
 else
     QEMU_BIN="qemu-system-x86_64"
-    QEMU_MACHINE="-machine q35,usb=off"
+    # microvm machine: skips legacy PCI/ACPI device probing for a faster boot
+    # (~0.1s/test).  pcie=on keeps a PCIe bus so the existing virtio-pci and
+    # virtio-scsi-pci devices attach unchanged; rtc/pit on so the guest kernel
+    # uses normal timers (without them it falls back to slow calibration paths).
+    QEMU_MACHINE="-M microvm,acpi=on,rtc=on,pit=on,pcie=on"
     QEMU_CONSOLE="ttyS0"
 fi
 

--- a/kvm/kvm_smb_test_wrapper.sh
+++ b/kvm/kvm_smb_test_wrapper.sh
@@ -202,7 +202,7 @@ ip netns exec "${NETNS_NAME}" "$QEMU_BIN" \
     -serial file:"$LOG_FILE" \
     -nographic \
     -no-reboot \
-    -append "root=/dev/vda rw console=${QEMU_CONSOLE} net.ifnames=0 biosdevname=0 quiet panic=-1 test_cmd=\"${TEST_CMD}\" init=/init.sh"
+    -append "root=/dev/vda rw console=${QEMU_CONSOLE} net.ifnames=0 biosdevname=0 quiet mitigations=off tsc=reliable panic=-1 test_cmd=\"${TEST_CMD}\" init=/init.sh"
 
 cat "$LOG_FILE"
 

--- a/kvm/kvm_smb_test_wrapper.sh
+++ b/kvm/kvm_smb_test_wrapper.sh
@@ -32,13 +32,12 @@ CHIMERA_BINARY=$1; shift
 BACKEND=$1; shift
 TEST_CMD_ARG="$*"
 
-# Use initrd if present alongside vmlinuz
-INITRD="$(dirname "$VMLINUZ")/initrd"
-if [ -f "$INITRD" ]; then
-    QEMU_INITRD="-initrd $INITRD"
-else
-    QEMU_INITRD=""
-fi
+# Boot with no initrd: every kernel in the KVM image matrix builds the virtio
+# block/net drivers in, so the kernel mounts the virtio root disk directly.
+# Skipping the ~63MB initrd unpack saves ~0.9s/test.  (See kvm/CMakeLists.txt:
+# the 22.04 generic kernel, which needs an initrd, was dropped from the matrix
+# in favor of its HWE kernel for exactly this reason.)
+QEMU_INITRD=""
 
 NETNS_NAME="kvm_smb_$$_$(date +%s%N)"
 TAP_NAME="tap_$$"

--- a/kvm/kvm_smb_test_wrapper.sh
+++ b/kvm/kvm_smb_test_wrapper.sh
@@ -113,6 +113,9 @@ generate_config() {
 
     cat > "$CONFIG_FILE" << EOF
 {
+    "common": {
+        "rcu_reclaim_threads": 4
+    },
     "server": {
         "threads": 4,
         "delegation_threads": 4,

--- a/kvm/kvm_test_wrapper.sh
+++ b/kvm/kvm_test_wrapper.sh
@@ -21,7 +21,11 @@ if [ "$ARCH" = "aarch64" ]; then
     QEMU_CONSOLE="ttyAMA0"
 else
     QEMU_BIN="qemu-system-x86_64"
-    QEMU_MACHINE="-machine q35,usb=off"
+    # microvm machine: skips legacy PCI/ACPI device probing for a faster boot
+    # (~0.1s/test).  pcie=on keeps a PCIe bus so the existing virtio-pci and
+    # virtio-scsi-pci devices attach unchanged; rtc/pit on so the guest kernel
+    # uses normal timers (without them it falls back to slow calibration paths).
+    QEMU_MACHINE="-M microvm,acpi=on,rtc=on,pit=on,pcie=on"
     QEMU_CONSOLE="ttyS0"
 fi
 

--- a/kvm/kvm_test_wrapper.sh
+++ b/kvm/kvm_test_wrapper.sh
@@ -72,7 +72,7 @@ ip netns exec "${NETNS_NAME}" "$QEMU_BIN" \
     -serial file:"$LOG_FILE" \
     -nographic \
     -no-reboot \
-    -append "root=/dev/vda rw console=${QEMU_CONSOLE} net.ifnames=0 biosdevname=0 panic=-1 test_cmd=\"${TEST_CMD}\" init=/init.sh"
+    -append "root=/dev/vda rw console=${QEMU_CONSOLE} net.ifnames=0 biosdevname=0 mitigations=off tsc=reliable panic=-1 test_cmd=\"${TEST_CMD}\" init=/init.sh"
 
 cat "$LOG_FILE"
 

--- a/kvm/kvm_test_wrapper.sh
+++ b/kvm/kvm_test_wrapper.sh
@@ -29,13 +29,12 @@ VMLINUZ=$1; shift
 ROOTFS=$1; shift
 TEST_CMD="$*"
 
-# Use initrd if present alongside vmlinuz
-INITRD="$(dirname "$VMLINUZ")/initrd"
-if [ -f "$INITRD" ]; then
-    QEMU_INITRD="-initrd $INITRD"
-else
-    QEMU_INITRD=""
-fi
+# Boot with no initrd: every kernel in the KVM image matrix builds the virtio
+# block/net drivers in, so the kernel mounts the virtio root disk directly.
+# Skipping the ~63MB initrd unpack saves ~0.9s/test.  (See kvm/CMakeLists.txt:
+# the 22.04 generic kernel, which needs an initrd, was dropped from the matrix
+# in favor of its HWE kernel for exactly this reason.)
+QEMU_INITRD=""
 
 NETNS_NAME="kvm_test_$$_$(date +%s%N)"
 TAP_NAME="tap_$$"

--- a/scripts/pynfs_pnfs_test_wrapper.sh
+++ b/scripts/pynfs_pnfs_test_wrapper.sh
@@ -52,7 +52,7 @@ cleanup() {
     for pid in "$MDS_PID" "$DS_PID"; do
         if [ -n "$pid" ]; then
             kill "$pid" 2>/dev/null || true
-            for i in $(seq 1 30); do kill -0 "$pid" 2>/dev/null || break; sleep 0.1; done
+            for i in $(seq 1 150); do kill -0 "$pid" 2>/dev/null || break; sleep 0.02; done
             kill -9 "$pid" 2>/dev/null || true
             wait "$pid" 2>/dev/null || true
         fi
@@ -66,6 +66,7 @@ trap cleanup EXIT
 
 cat > "$DS_CONFIG" << EOF
 {
+    "common": { "rcu_reclaim_threads": 4 },
     "server": { "threads": 2, "nfs_port": ${DS_PORT}, "data_server": true,
                 "nfs4_lease_time": ${PYNFS_NFS4_LEASE_TIME},
                 "nfs4_grace_time": ${PYNFS_NFS4_GRACE_TIME},
@@ -77,6 +78,7 @@ EOF
 
 cat > "$MDS_CONFIG" << EOF
 {
+    "common": { "rcu_reclaim_threads": 4 },
     "server": {
         "threads": 4, "external_portmap": false,
         "nfs4_lease_time": ${PYNFS_NFS4_LEASE_TIME},
@@ -100,13 +102,13 @@ EOF
 # mount + backing-root resolution complete) closes that window.
 wait_for_ready() {
     local port="$1" pid="$2" log="$3"
-    for i in $(seq 1 100); do
+    for i in $(seq 1 500); do
         if grep -q "Server is ready." "$log" 2>/dev/null &&
            ip netns exec "${NETNS_NAME}" bash -c "echo > /dev/tcp/127.0.0.1/${port}" 2>/dev/null; then
             return 0
         fi
         kill -0 "$pid" 2>/dev/null || { echo "chimera (pid $pid) exited early" >&2; return 1; }
-        sleep 0.1
+        sleep 0.02
     done
     echo "timed out waiting for 127.0.0.1:${port} to become ready" >&2; return 1
 }

--- a/scripts/pynfs_test_wrapper.sh
+++ b/scripts/pynfs_test_wrapper.sh
@@ -49,9 +49,9 @@ cleanup() {
             CHIMERA_DIED_DURING_TEST=1
         fi
         kill "$CHIMERA_PID" 2>/dev/null || true
-        for i in $(seq 1 30); do
+        for i in $(seq 1 150); do
             kill -0 "$CHIMERA_PID" 2>/dev/null || break
-            sleep 0.1
+            sleep 0.02
         done
         if kill -0 "$CHIMERA_PID" 2>/dev/null; then
             echo "=== Chimera shutdown hung, force killing ==="
@@ -144,6 +144,9 @@ generate_config() {
 
     cat > "$CONFIG_FILE" << EOF
 {
+    "common": {
+        "rcu_reclaim_threads": 4
+    },
     "server": {
         "threads": 4,
         "delegation_threads": 4,
@@ -193,7 +196,7 @@ CHIMERA_PID=$!
 # has finished its own readiness path; starting pynfs in that window produces
 # connection-refused initialization failures.
 READY=0
-for i in $(seq 1 100); do
+for i in $(seq 1 500); do
     if grep -q "Server is ready." "$CHIMERA_LOG" &&
        ip netns exec "${NETNS_NAME}" bash -c "echo > /dev/tcp/127.0.0.1/2049" 2>/dev/null &&
        { [ "$DELEG_ENABLE" != "true" ] ||
@@ -205,7 +208,7 @@ for i in $(seq 1 100); do
         echo "chimera daemon exited prematurely"
         exit 1
     fi
-    sleep 0.1
+    sleep 0.02
 done
 
 if [ "$READY" != "1" ]; then

--- a/src/client/client.c
+++ b/src/client/client.c
@@ -32,6 +32,7 @@ chimera_client_config_init(void)
     config->async_delegation         = 0;
     config->async_delegation_threads = 8;
     config->cache_ttl                = 60;
+    config->rcu_reclaim_threads      = 0; /* 0 = one call_rcu worker per CPU */
     config->max_fds                  = 1024;
 
     strncpy(config->modules[0].module_name, "root", sizeof(config->modules[0].module_name));
@@ -179,6 +180,7 @@ chimera_client_init(
                                    config->num_modules,
                                    config->kv_module,
                                    config->cache_ttl,
+                                   config->rcu_reclaim_threads,
                                    metrics);
 
     /* Propagate the common TCP flavor so VFS client modules (e.g. nfs)
@@ -310,6 +312,16 @@ chimera_client_init_json(
                                              deleg.sync_delegation_threads,
                                              deleg.async_delegation,
                                              deleg.async_delegation_threads);
+    }
+
+    /* RCU reclaim worker count is a VFS-level setting shared with the server;
+     * its canonical home is the "common" section. */
+    {
+        int rcu_threads = chimera_common_rcu_reclaim_threads(root);
+
+        if (rcu_threads >= 0) {
+            config->rcu_reclaim_threads = rcu_threads;
+        }
     }
 
     client = chimera_client_init(config, cred, metrics);

--- a/src/client/client_internal.h
+++ b/src/client/client_internal.h
@@ -388,6 +388,7 @@ struct chimera_client_config {
     int                           async_delegation;
     int                           async_delegation_threads;
     int                           cache_ttl;
+    int                           rcu_reclaim_threads;
     int                           max_fds;
     enum chimera_tcp_flavor       tcp_flavor;
     char                          kv_module[64];

--- a/src/client/client_internal.h
+++ b/src/client/client_internal.h
@@ -394,7 +394,13 @@ struct chimera_client_config {
     char                          kv_module[64];
     struct chimera_vfs_module_cfg modules[CHIMERA_CLIENT_MAX_MODULES];
     int                           num_modules;
-} __attribute__((aligned(64)));
+};
+/* No __attribute__((aligned(64))) here: this is a cold, singly-allocated config
+ * blob (cache-line alignment buys nothing), and over-aligning it is unsafe given
+ * it is calloc'd -- calloc only guarantees 16-byte alignment, but with alignof
+ * 64 the optimizer is free to initialize the struct with 32-byte *aligned* AVX
+ * stores (vmovdqa), which GP-fault when the allocation lands 16- but not
+ * 32-byte aligned (Release-only; -O0 Debug uses scalar stores and survives). */
 
 struct chimera_client {
     const struct chimera_client_config *config;

--- a/src/common/common_config.h
+++ b/src/common/common_config.h
@@ -272,3 +272,34 @@ chimera_common_metrics_file(json_t *root)
 
     return NULL;
 } /* chimera_common_metrics_file */
+
+/*
+ * Number of liburcu call_rcu reclaim worker threads, from the shared "common"
+ * section's "rcu_reclaim_threads" key.  This is a VFS-level setting (the workers
+ * reclaim retired entries from the VFS fungible caches), so it is honored
+ * identically by the server and the client.  Returns the configured value
+ * (0 == one worker per CPU, the default reclaim parallelism; a positive value
+ * caps the count) or -1 when the section or key is absent, meaning "unset" so
+ * the caller leaves its own default in place.  `root` may be NULL.
+ */
+static inline int
+chimera_common_rcu_reclaim_threads(json_t *root)
+{
+    json_t *common, *val;
+
+    if (!root) {
+        return -1;
+    }
+
+    common = json_object_get(root, "common");
+    if (!json_is_object(common)) {
+        return -1;
+    }
+
+    val = json_object_get(common, "rcu_reclaim_threads");
+    if (json_is_integer(val)) {
+        return (int) json_integer_value(val);
+    }
+
+    return -1;
+} /* chimera_common_rcu_reclaim_threads */

--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -403,6 +403,16 @@ main(
         }
     }
 
+    /* RCU reclaim worker count is also a VFS-level setting shared with the
+     * client; its canonical home is the "common" section. */
+    {
+        int rcu_threads = chimera_common_rcu_reclaim_threads(config);
+
+        if (rcu_threads >= 0) {
+            chimera_server_config_set_rcu_reclaim_threads(server_config, rcu_threads);
+        }
+    }
+
     json_value = json_object_get(server_params, "smb_persistent_handles");
     if (json_is_boolean(json_value)) {
         chimera_server_config_set_smb_persistent_handles(server_config, json_is_true(json_value));

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -61,6 +61,7 @@ struct chimera_server_config {
     int                                   async_delegation;
     int                                   async_delegation_threads;
     int                                   cache_ttl;
+    int                                   rcu_reclaim_threads;
     int                                   nfs4_session_slots;
     int                                   nfs4_delegations;
     uint32_t                              nfs4_lease_time_s;
@@ -222,6 +223,14 @@ chimera_server_config_init(void)
     config->nfs_server_scope = 42;
 
     config->cache_ttl = 60;
+
+    /* Number of liburcu call_rcu reclaim worker threads.  0 (the default) means
+     * one worker per CPU (create_all_cpu_call_rcu_data) to keep RCU reclaim up
+     * with per-request cache churn under heavy load.  On a many-core host that
+     * spawns hundreds of threads, which is wasteful for short-lived or
+     * lightly-loaded instances (memory, and process-teardown cost); set a small
+     * positive value (e.g. the CI test daemons) to cap the worker count. */
+    config->rcu_reclaim_threads = 0;
 
     /* Default NFSv4.1 fore-channel session slots (server cap on the number
      * of concurrent SEQUENCE requests a client may have outstanding per
@@ -463,6 +472,14 @@ chimera_server_config_get_cache_ttl(const struct chimera_server_config *config)
 {
     return config->cache_ttl;
 } /* chimera_server_config_get_cache_ttl */
+
+SYMBOL_EXPORT void
+chimera_server_config_set_rcu_reclaim_threads(
+    struct chimera_server_config *config,
+    int                           threads)
+{
+    config->rcu_reclaim_threads = threads;
+} /* chimera_server_config_set_rcu_reclaim_threads */
 
 SYMBOL_EXPORT void
 chimera_server_config_set_nfs4_session_slots(
@@ -1629,6 +1646,7 @@ chimera_server_init(
                                    config->num_modules,
                                    config->kv_module,
                                    config->cache_ttl,
+                                   config->rcu_reclaim_threads,
                                    metrics);
 
     /* Propagate the common TCP flavor so VFS client modules (e.g. nfs)

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -147,6 +147,11 @@ chimera_server_config_get_cache_ttl(
     const struct chimera_server_config *config);
 
 void
+chimera_server_config_set_rcu_reclaim_threads(
+    struct chimera_server_config *config,
+    int                           threads);
+
+void
 chimera_server_config_set_nfs4_session_slots(
     struct chimera_server_config *config,
     int                           slots);

--- a/src/vfs/tests/vfs_async_delegation_test.c
+++ b/src/vfs/tests/vfs_async_delegation_test.c
@@ -278,6 +278,7 @@ run_phase(
         1,
         "",
         60,
+        0,                  /* num_rcu_reclaim_threads: 0 = one per CPU */
         metrics);
     assert(ctx.vfs != NULL);
 

--- a/src/vfs/tests/vfs_enforce_test.c
+++ b/src/vfs/tests/vfs_enforce_test.c
@@ -386,7 +386,7 @@ main(
     ctx.evpl = evpl_create(NULL);
     assert(ctx.evpl != NULL);
 
-    ctx.vfs = chimera_vfs_init(0, 0, module_cfgs, 2, "memkv", 60, metrics);
+    ctx.vfs = chimera_vfs_init(0, 0, module_cfgs, 2, "memkv", 60, 0, metrics);
     assert(ctx.vfs != NULL);
 
     ctx.vfs_thread = chimera_vfs_thread_init(ctx.evpl, ctx.vfs);

--- a/src/vfs/tests/vfs_identity_test.c
+++ b/src/vfs/tests/vfs_identity_test.c
@@ -74,7 +74,7 @@ main(
     evpl = evpl_create(NULL);
     assert(evpl != NULL);
 
-    vfs = chimera_vfs_init(0, 0, module_cfgs, 2, "memkv", 60, metrics);
+    vfs = chimera_vfs_init(0, 0, module_cfgs, 2, "memkv", 60, 0, metrics);
     assert(vfs != NULL);
 
     thread = chimera_vfs_thread_init(evpl, vfs);

--- a/src/vfs/tests/vfs_kv_test.c
+++ b/src/vfs/tests/vfs_kv_test.c
@@ -377,6 +377,7 @@ run_suite(
         1,              /* num_modules */
         kv_name,        /* kv_module_name */
         60,             /* cache_ttl */
+        0,              /* num_rcu_reclaim_threads: 0 = one per CPU */
         metrics);
     assert(ctx.vfs != NULL);
 

--- a/src/vfs/tests/vfs_sync_delegation_test.c
+++ b/src/vfs/tests/vfs_sync_delegation_test.c
@@ -288,6 +288,7 @@ run_phase(
         1,
         "cairn",
         60,
+        0,                 /* num_rcu_reclaim_threads: 0 = one per CPU */
         metrics);
     assert(ctx.vfs != NULL);
 

--- a/src/vfs/vfs.c
+++ b/src/vfs/vfs.c
@@ -408,6 +408,62 @@ chimera_vfs_spawn_delegation_pool(
     return pool;
 } /* chimera_vfs_spawn_delegation_pool */
 
+/*
+ * Bring up the liburcu call_rcu reclaim workers.
+ *
+ * nworkers <= 0 (or >= the CPU count) requests one worker per CPU via liburcu's
+ * create_all_cpu_call_rcu_data() -- maximum reclaim parallelism, but hundreds of
+ * threads on a many-core host.  A smaller positive nworkers creates exactly that
+ * many workers and round-robins every CPU onto them, capping thread/memory
+ * overhead (and teardown cost) for short-lived or lightly-loaded instances.
+ * Best-effort throughout: any failure leaves liburcu's single default worker in
+ * place, which is correct, just slower to reclaim.
+ */
+static void
+chimera_vfs_create_call_rcu_workers(int nworkers)
+{
+    long                   ncpu = sysconf(_SC_NPROCESSORS_CONF);
+    struct call_rcu_data **workers;
+
+    if (nworkers <= 0 || (ncpu > 0 && nworkers >= ncpu)) {
+        if (create_all_cpu_call_rcu_data(0) != 0) {
+            chimera_vfs_error("Failed to create per-CPU call_rcu workers; "
+                              "falling back to the default RCU reclaim thread");
+        }
+        return;
+    }
+
+    if (ncpu <= 0) {
+        /* Unknown CPU count -- nothing to map workers onto; keep the default. */
+        return;
+    }
+
+    workers = calloc(nworkers, sizeof(*workers));
+    if (!workers) {
+        return;
+    }
+
+    for (int i = 0; i < nworkers; i++) {
+        workers[i] = create_call_rcu_data(0, -1);
+        if (!workers[i]) {
+            chimera_vfs_error("Failed to create call_rcu worker %d/%d; "
+                              "falling back to the default RCU reclaim thread", i, nworkers);
+            /* Tear down the ones we did create and bail to the default worker. */
+            for (int j = 0; j < i; j++) {
+                call_rcu_data_free(workers[j]);
+            }
+            free(workers);
+            return;
+        }
+    }
+
+    for (long cpu = 0; cpu < ncpu; cpu++) {
+        set_cpu_call_rcu_data(cpu, workers[cpu % nworkers]);
+    }
+
+    free(workers);
+} /* chimera_vfs_create_call_rcu_workers */
+
 SYMBOL_EXPORT struct chimera_vfs *
 chimera_vfs_init(
     int                                  num_sync_delegation_threads,
@@ -416,6 +472,7 @@ chimera_vfs_init(
     int                                  num_modules,
     const char                          *kv_module_name,
     int                                  cache_ttl,
+    int                                  num_rcu_reclaim_threads,
     struct prometheus_metrics           *metrics)
 {
     struct chimera_vfs        *vfs;
@@ -427,15 +484,14 @@ chimera_vfs_init(
     /* Bring up the process-wide TSC clock before any cache/timestamp use. */
     chimera_vfs_clock_init();
 
-    /* Scale RCU reclaim across CPUs: spawn one call_rcu worker per CPU so the
-     * fungible-cache retire callbacks (attr/name/rpl) keep up with per-request
-     * churn.  Without this liburcu uses a single default worker for the whole
-     * process.  Best-effort -- on failure call_rcu falls back to that default
-     * worker. */
-    if (create_all_cpu_call_rcu_data(0) != 0) {
-        chimera_vfs_error("Failed to create per-CPU call_rcu workers; "
-                          "falling back to the default RCU reclaim thread");
-    }
+    /* Scale RCU reclaim so the fungible-cache retire callbacks (attr/name/rpl)
+     * keep up with per-request churn; without dedicated workers liburcu uses a
+     * single default worker for the whole process.  num_rcu_reclaim_threads <= 0
+     * means one worker per CPU (the default); a positive value caps the worker
+     * count, which bounds thread/memory overhead and process-teardown cost on
+     * many-core hosts (e.g. short-lived CI test daemons).  Best-effort -- on
+     * failure call_rcu falls back to the default worker. */
+    chimera_vfs_create_call_rcu_workers(num_rcu_reclaim_threads);
 
     vfs = calloc(1, sizeof(*vfs));
 
@@ -633,6 +689,138 @@ chimera_vfs_module_capabilities(
     return module ? module->capabilities : 0;
 } /* chimera_vfs_module_capabilities */
 
+/* Upper bound on the helper threads used to tear the per-CPU call_rcu workers
+ * down in parallel (see chimera_vfs_free_all_cpu_call_rcu_data_parallel). */
+#define CHIMERA_RCU_TEARDOWN_MAX_THREADS 64
+
+struct chimera_rcu_teardown_ctx {
+    pthread_t              thread;
+    struct call_rcu_data **crdps;
+    int                    count;
+    int                    started;
+};
+
+static void *
+chimera_vfs_rcu_teardown_worker(void *arg)
+{
+    struct chimera_rcu_teardown_ctx *ctx = arg;
+
+    for (int i = 0; i < ctx->count; i++) {
+        call_rcu_data_free(ctx->crdps[i]);
+    }
+    return NULL;
+} /* chimera_vfs_rcu_teardown_worker */
+
+/*
+ * Tear down the per-CPU call_rcu workers created by create_all_cpu_call_rcu_data().
+ *
+ * liburcu's free_all_cpu_call_rcu_data() joins the workers one at a time, and
+ * each worker can take up to its ~10ms idle poll interval to notice the stop
+ * request.  On a many-core host that serial join dominates process shutdown
+ * (~4s with several hundred workers on a 384-core box), which in turn is paid
+ * on every short-lived test daemon.
+ *
+ * The joins are mutually independent, so we replicate liburcu's teardown but
+ * fan the call_rcu_data_free() calls out across a bounded thread pool.  The
+ * per-worker poll latencies then overlap instead of summing, collapsing the
+ * teardown to tens of milliseconds while keeping shutdown clean (no SIGKILL),
+ * so AddressSanitizer leak/UAF checks still run on a graceful exit.
+ */
+static void
+chimera_vfs_free_all_cpu_call_rcu_data_parallel(void)
+{
+    long                             ncpu = sysconf(_SC_NPROCESSORS_CONF);
+    struct call_rcu_data            *defaultcrdp;
+    struct call_rcu_data           **crdps;
+    struct chimera_rcu_teardown_ctx *ctx;
+    int                              n = 0, nthreads, per, idx;
+
+    if (ncpu <= 0) {
+        free_all_cpu_call_rcu_data();
+        return;
+    }
+
+    defaultcrdp = get_default_call_rcu_data();
+    crdps       = calloc(ncpu, sizeof(*crdps));
+
+    if (!crdps) {
+        free_all_cpu_call_rcu_data();
+        return;
+    }
+
+    /* Detach each per-CPU worker from the registry (cheap, no join) and collect
+     * the unique crdps to free.  Skip the shared default worker -- liburcu owns
+     * its lifetime and call_rcu_data_free() refuses to free it anyway. */
+    for (long cpu = 0; cpu < ncpu; cpu++) {
+        struct call_rcu_data *crdp = get_cpu_call_rcu_data(cpu);
+        int                   dup  = 0;
+
+        if (crdp == NULL || crdp == defaultcrdp) {
+            continue;
+        }
+
+        set_cpu_call_rcu_data(cpu, NULL);
+
+        for (int i = 0; i < n; i++) {
+            if (crdps[i] == crdp) {
+                dup = 1;
+                break;
+            }
+        }
+
+        if (!dup) {
+            crdps[n++] = crdp;
+        }
+    }
+
+    if (n == 0) {
+        free(crdps);
+        return;
+    }
+
+    /* Wait for any in-flight call_rcu() that read an old per-CPU pointer to
+     * become quiescent before freeing the workers -- mirrors the synchronize_rcu()
+     * inside liburcu's own free_all_cpu_call_rcu_data(). */
+    synchronize_rcu();
+
+    nthreads = n < CHIMERA_RCU_TEARDOWN_MAX_THREADS ? n : CHIMERA_RCU_TEARDOWN_MAX_THREADS;
+    ctx      = calloc(nthreads, sizeof(*ctx));
+
+    if (!ctx) {
+        /* Fall back to a serial free of everything we detached. */
+        for (int i = 0; i < n; i++) {
+            call_rcu_data_free(crdps[i]);
+        }
+        free(crdps);
+        return;
+    }
+
+    per = (n + nthreads - 1) / nthreads;
+    idx = 0;
+
+    for (int t = 0; t < nthreads && idx < n; t++) {
+        ctx[t].crdps = &crdps[idx];
+        ctx[t].count = (idx + per <= n) ? per : (n - idx);
+        idx         += ctx[t].count;
+
+        if (pthread_create(&ctx[t].thread, NULL, chimera_vfs_rcu_teardown_worker, &ctx[t]) == 0) {
+            ctx[t].started = 1;
+        } else {
+            /* Spawn failed -- free this chunk inline so nothing leaks. */
+            chimera_vfs_rcu_teardown_worker(&ctx[t]);
+        }
+    }
+
+    for (int t = 0; t < nthreads; t++) {
+        if (ctx[t].started) {
+            pthread_join(ctx[t].thread, NULL);
+        }
+    }
+
+    free(ctx);
+    free(crdps);
+} /* chimera_vfs_free_all_cpu_call_rcu_data_parallel */
+
 SYMBOL_EXPORT void
 chimera_vfs_destroy(struct chimera_vfs *vfs)
 {
@@ -715,8 +903,10 @@ chimera_vfs_destroy(struct chimera_vfs *vfs)
     chimera_vfs_open_cache_destroy(vfs->vfs_open_file_cache);
 
     /* All RCU caches are destroyed above and each drained via rcu_barrier(), so
-     * no callbacks remain; tear down the per-CPU call_rcu workers. */
-    free_all_cpu_call_rcu_data();
+     * no callbacks remain; tear down the per-CPU call_rcu workers.  Use the
+     * parallel teardown -- liburcu's free_all_cpu_call_rcu_data() joins them
+     * serially, which dominates shutdown on many-core hosts. */
+    chimera_vfs_free_all_cpu_call_rcu_data_parallel();
 
     if (vfs->metrics.op_latency) {
         for (int i = 0; i < CHIMERA_VFS_OP_NUM; i++) {

--- a/src/vfs/vfs.h
+++ b/src/vfs/vfs.h
@@ -1466,6 +1466,7 @@ chimera_vfs_init(
     int                                  num_modules,
     const char                          *kv_module_name,
     int                                  cache_ttl,
+    int                                  num_rcu_reclaim_threads,
     struct prometheus_metrics           *metrics);
 
 void


### PR DESCRIPTION
The KVM and pynfs ctest suites run thousands of tests, each spinning up a chimera daemon (and, for KVM, a QEMU VM) to run one small case. Each carried several seconds of *fixed infrastructure* cost, multiplied across the whole suite. This series brings KVM tests from ~5s/~6s (NFS/SMB) to ~1s and pynfs tests from ~3.5s to ~0.5s, without changing what the tests exercise.

### The shared root cause: chimera shutdown

The dominant cost in both suites wasn't the VM or the Python harness — it was the daemon taking ~4s to exit. `chimera_vfs_destroy` tears down the per-CPU liburcu `call_rcu` reclaim workers via `free_all_cpu_call_rcu_data()`, which joins them one at a time, and each idle worker takes up to its ~10ms poll to acknowledge stop. On a 384-core host that's ~384 × ~10ms ≈ 4s, paid by every short-lived test daemon (the wrappers' grace loops just waited it out and SIGKILLed at their 3s timeout).

`vfs: parallelize call_rcu worker teardown + configurable reclaim count` fixes this for **every** daemon invocation:
- Replace the serial teardown with a parallel one: detach all per-CPU crdps, one `synchronize_rcu()` (as liburcu does), then fan `call_rcu_data_free()` across a bounded thread pool so the poll latencies overlap. **4.2s → ~0.2s, graceful exit preserved** (ASan still runs at shutdown).
- Add a `rcu_reclaim_threads` knob in the shared `common` config section (read by both server and client — both build the VFS). `0`/absent = one worker per CPU (unchanged default); a positive value caps the count. The KVM and pynfs wrappers set `4` (413 → ~33 threads).

### KVM-specific wins

- **`kvm: boot tests with no initrd; drop 22.04 generic image`** — every kernel in the image matrix builds the virtio drivers in, so QEMU mounts the virtio root disk directly and the ~63MB initrd unpack is pure overhead. The 22.04 *generic* kernel (virtio_blk is a module there) is dropped from the matrix; 22.04 is still covered by its HWE kernel. ~0.9s/test.
- **`kvm: disable CPU mitigations + trust TSC in test guests`** — throwaway VMs in an isolated netns running trusted code; `mitigations=off tsc=reliable` cuts boot (~0.12s) and workload time (an nfs3 fsstress run dropped ~20%).
- **`kvm: boot test VMs on the microvm machine type`** — `-M microvm,acpi=on,rtc=on,pit=on,pcie=on` (x86 only; aarch64 keeps `virt`). microvm omits the legacy PC device complement so the kernel probes far less. `pcie=on` keeps a PCIe bus so the existing virtio-blk/virtio-net-pci/virtio-scsi-pci devices attach unchanged (pNFS block/scsi still get a real `/dev/sda`); `rtc/pit=on` give normal timers (without them it boots *slower*); `acpi=on` keeps sysrq power-off working. ~0.1s/test.

### Polling (both suites)

- **`kvm: poll chimera readiness/shutdown at finer granularity`** / **`pynfs: apply the same per-test infra speedups`** — chimera reaches "ready" ~50ms after exec and now exits in ~0.12s, but the wrappers polled readiness and shutdown every 0.1s, rounding both waits up. Poll every 0.02s instead (loop bounds scaled 5× so the 3s/5s safety timeouts are unchanged). The pynfs commit also sets `common.rcu_reclaim_threads=4`.

### Validation
Verified through the real wrappers on every image and test type — KVM NFS (memfs/linux/io_uring/diskfs), SMB, pNFS file (split/combined) and pNFS block (confirmed "using block device sda"), incl. fsstress/fsx under load; pynfs across memfs/linux/diskfs, nfs4.0/1/2, and flex. The RCU teardown change is ASan-clean on a Debug build (graceful shutdown, no leaks/UAF), and the affected `vfs/*` unit tests pass.
---

**Rebased** onto current `main` (the KVM image-build move to `chimera-nas/kvm-test-base`). Adjustments folded in:
- `kvm/CMakeLists.txt`: the `ubuntu2204` drop now applies to the new fetch-based `KVM_IMAGES` list, and `KVM_IMAGE_VERSION` is pinned to **`v1.1.0`**.
- The 22.04-generic drop's image-side half is **chimera-nas/kvm-test-base#1** (drops the variant, bumps `VERSION` to `v1.1.0`, leaving the immutable `v1.0.0` images intact for current `main`). **That must merge + publish first** — this PR's KVM jobs pull `v1.1.0` and will stay red until those tags exist.
- The new `kvm_pnfs_proxy_test_wrapper.sh` (added on `main` after this branch) gets the same boot speedups.

Only the non-HWE `ubuntu2204` (generic) is dropped; `ubuntu2204_hwe` is retained.
