### PR TITLE
Add CTest labels to enable independent test group selection

### DIFF
--- a/pynfs/CMakeLists.txt
+++ b/pynfs/CMakeLists.txt
@@ -220,8 +220,12 @@ function(pynfs_add_code_test flag code backend minor)
         list(APPEND test_env "PYNFS_FORCE_DELEG=1")
     endif()
 
+    # Label each test along every dimension encoded in its name so the suite
+    # can be sharded independently: the whole suite (pynfs), the category/flag
+    # (pynfs_rename, pynfs_courteous, ...), the VFS backend (memfs, linux, ...),
+    # and the NFSv4 minor version (nfs4.0, nfs4.1, nfs4.2).
     set_tests_properties(${name} PROPERTIES
-        LABELS pynfs
+        LABELS "pynfs;pynfs_${flag};${backend};nfs4.${minor}"
         ENVIRONMENT "${test_env}")
 endfunction()
 
@@ -247,6 +251,6 @@ foreach(code ${PYNFS_FLEX_CODES})
     add_test(NAME ${name}
         COMMAND bash ${PNFS_WRAPPER} ${CHIMERA_BINARY} ${PYNFS_DIR} ${code})
     set_tests_properties(${name} PROPERTIES
-        LABELS pynfs
+        LABELS "pynfs;pynfs_flex;memfs;nfs4.1"
         ENVIRONMENT "PYTHONUNBUFFERED=1;PYNFS_RUNDEPS=1")
 endforeach()

--- a/src/client/tests/CMakeLists.txt
+++ b/src/client/tests/CMakeLists.txt
@@ -99,3 +99,21 @@ endif()
 generate_backend_tests(cairn CAIRN_ENABLED)
 generate_backend_tests(linux "")
 generate_backend_tests(io_uring CHIMERA_VFS_IO_URING)
+
+# Tag every test registered above with the 'client' label so the suite can be
+# run independently via `ctest -L client`, and with the VFS backend encoded in
+# its name (longest-name-first so diskfs_io_uring beats the io_uring substring)
+# so an entire backend can be run across every suite via e.g. `ctest -L linux`.
+# Tests with no backend in their name keep only the suite label.
+get_property(_client_tests DIRECTORY PROPERTY TESTS)
+if(_client_tests)
+    set_property(TEST ${_client_tests} APPEND PROPERTY LABELS client)
+    foreach(_t IN LISTS _client_tests)
+        foreach(_be diskfs_io_uring diskfs_aio io_uring memfs linux cairn)
+            if(_t MATCHES "_${_be}($|_)")
+                set_property(TEST ${_t} APPEND PROPERTY LABELS ${_be})
+                break()
+            endif()
+        endforeach()
+    endforeach()
+endif()

--- a/src/posix/tests/CMakeLists.txt
+++ b/src/posix/tests/CMakeLists.txt
@@ -946,3 +946,26 @@ foreach(prog test_fcntl test_lockf)
     add_posix_nfs3_test_myuser(${test_name}     ${prog} linux)
     add_posix_nfs3rdma_test_myuser(${test_name} ${prog} linux)
 endforeach()
+
+# Tag every test registered above with the 'posix' label so the whole suite can
+# be run independently via `ctest -L posix`.  Collected from the directory TESTS
+# property rather than per-add_test so new tests are covered automatically.
+#
+# Additionally tag each test with the VFS backend encoded in its name so an
+# entire backend can be run across every suite via e.g. `ctest -L linux`.  The
+# backend list is checked longest-name-first so diskfs_io_uring wins over the
+# io_uring substring; the boundary "($|_)" keeps the match to a whole token and
+# still catches a trailing "_myuser".  Tests with no backend in their name keep
+# only the suite label.
+get_property(_posix_tests DIRECTORY PROPERTY TESTS)
+if(_posix_tests)
+    set_property(TEST ${_posix_tests} APPEND PROPERTY LABELS posix)
+    foreach(_t IN LISTS _posix_tests)
+        foreach(_be diskfs_io_uring diskfs_aio io_uring memfs linux cairn)
+            if(_t MATCHES "_${_be}($|_)")
+                set_property(TEST ${_t} APPEND PROPERTY LABELS ${_be})
+                break()
+            endif()
+        endforeach()
+    endforeach()
+endif()

--- a/src/server/nfs/tests/CMakeLists.txt
+++ b/src/server/nfs/tests/CMakeLists.txt
@@ -64,3 +64,10 @@ target_include_directories(test_access_xattr PRIVATE
     ${NFS_COMMON_INCLUDE_DIR})
 add_dependencies(test_access_xattr chimera_nfs_common)
 add_test(NAME chimera/server/nfs/access_xattr COMMAND test_access_xattr)
+
+# Tag every test registered above with the 'nfs' label so these NFS server unit
+# tests can be run independently via `ctest -L nfs`.
+get_property(_nfs_tests DIRECTORY PROPERTY TESTS)
+if(_nfs_tests)
+    set_property(TEST ${_nfs_tests} APPEND PROPERTY LABELS nfs)
+endif()

--- a/src/vfs/tests/CMakeLists.txt
+++ b/src/vfs/tests/CMakeLists.txt
@@ -47,3 +47,10 @@ add_test(chimera/vfs/idmap_test vfs_idmap_test)
 add_executable(vfs_identity_test vfs_identity_test.c)
 target_link_libraries(vfs_identity_test chimera_vfs chimera_vfs_memfs evpl urcu-qsbr)
 add_test(chimera/vfs/identity_test vfs_identity_test)
+
+# Tag every test registered above with the 'vfs' label so the suite can be run
+# independently via `ctest -L vfs`.
+get_property(_vfs_tests DIRECTORY PROPERTY TESTS)
+if(_vfs_tests)
+    set_property(TEST ${_vfs_tests} APPEND PROPERTY LABELS vfs)
+endif()


### PR DESCRIPTION
The chimera ctest suite registers ~10k+ tests with no labels on the posix, client, vfs, and server/nfs groups, so there was no clean way to run a subset. This adds labels along the dimensions already encoded in the test names:

  - Suite labels: posix, client, vfs, nfs (pynfs/smb already had them). Applied via the directory TESTS property so future tests inherit the label automatically.
  - Backend labels on posix/client/pynfs tests (memfs, linux, cairn, io_uring, diskfs_aio, diskfs_io_uring), matched longest-name-first so diskfs_io_uring wins over the io_uring substring.
  - pynfs gains per-category (pynfs_<flag>) and NFSv4 minor-version (nfs4.0/4.1/4.2) labels in addition to its existing pynfs label.

This lets a whole backend be exercised across every suite with e.g. `ctest -L linux`, a single suite with `ctest -L posix`, or one pynfs category with `ctest -L pynfs_rename`. No tests are added, removed, or changed -- labels only.