### PR TITLE
smb/tests: consolidate WPTS into one run per config (~84% faster)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -418,7 +418,7 @@ jobs:
             -w /build \
             ${{ matrix.image_tag_prefix }}:${{ github.sha }}-${{ matrix.arch }} \
             bash -euxc '
-              cmake -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DREQUIRE_NETNS_TESTS=ON -DKVM_IMAGE_REGISTRY=${{ env.KVM_IMAGE_REGISTRY }} -DPYNFS_JUNIT_DIR=/workspace/ctest-results/pynfs-junit ${{ matrix.cmake_extra }} /workspace
+              cmake -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DREQUIRE_NETNS_TESTS=ON -DKVM_IMAGE_REGISTRY=${{ env.KVM_IMAGE_REGISTRY }} -DPYNFS_JUNIT_DIR=/workspace/ctest-results/pynfs-junit -DWPTS_JUNIT_DIR=/workspace/ctest-results/wpts-junit ${{ matrix.cmake_extra }} /workspace
               ninja
               mkdir -p /workspace/ctest-results
               start=$(date +%s)

--- a/scripts/ci_test_report.py
+++ b/scripts/ci_test_report.py
@@ -57,25 +57,41 @@ def run_label(dirname):
     return " · ".join(parts)
 
 
+# Consolidated CTest entries that run many cases in one process: a single
+# CTest test, but each writes a per-case JUnit under <subdir>/<suite>.xml so a
+# failure can be expanded to the specific cases (suite = last path component).
+CONSOLIDATED = [
+    ("chimera/pynfs/combined_", "pynfs-junit"),
+    ("chimera/server/smb/wpts/", "wpts-junit"),
+]
+
+
+def expand_failures(run_dir, name):
+    """If a failed CTest entry is a consolidated run, return its failed cases;
+    otherwise None (caller names the entry itself)."""
+    for prefix, subdir in CONSOLIDATED:
+        if name.startswith(prefix):
+            suite = name.split("/")[-1]
+            pj = os.path.join(run_dir, subdir, suite + ".xml")
+            return [n for n, f, _ in testcases(pj) if f]
+    return None
+
+
 def collect(run_dir):
     """Return a summary dict for one run directory."""
     results_xml = os.path.join(run_dir, "results.xml")
-    pynfs_dir = os.path.join(run_dir, "pynfs-junit")
 
     passed = failed = 0
     sum_time = 0.0
-    failures = []  # list of named failures (codes, not the pynfs rollup)
+    failures = []  # list of named failures (specific cases, not the rollup)
     have_results = os.path.exists(results_xml)
 
     for name, is_fail, t in testcases(results_xml):
         sum_time += t
-        # Expand a failed combined pynfs CTest entry to its specific codes.
-        if is_fail and name.startswith("chimera/pynfs/combined_"):
-            suite = name.split("/")[-1]  # combined_<backend>_nfs4.<minor>
-            pj = os.path.join(pynfs_dir, suite + ".xml")
-            codes = [n for n, f, _ in testcases(pj) if f]
-            if codes:
-                failures.extend(f"{name}  →  {c}" for c in codes)
+        cases = expand_failures(run_dir, name) if is_fail else None
+        if cases is not None:
+            if cases:
+                failures.extend(f"{name}  →  {c}" for c in cases)
             else:
                 failures.append(name)
             failed += 1

--- a/scripts/trx_to_junit.py
+++ b/scripts/trx_to_junit.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+#
+# SPDX-License-Identifier: Unlicense
+"""Convert a VSTest TRX result file to JUnit XML (one <testcase> per case).
+
+Usage: trx_to_junit.py <input.trx> <output-junit.xml>
+
+The WPTS suites run under `dotnet vstest`, which writes a TRX (Visual Studio
+TeamTest XML).  ctest --output-junit only sees the consolidated run as a single
+test, so -- exactly like the pynfs per-code JUnit -- we emit a per-case JUnit so
+the CI report keeps WPTS per-case visibility.
+"""
+import sys
+import xml.etree.ElementTree as ET
+
+
+def localname(tag):
+    return tag.rsplit("}", 1)[-1]
+
+
+def esc(s):
+    return ((s or "")
+            .replace("&", "&amp;").replace("<", "&lt;")
+            .replace(">", "&gt;").replace('"', "&quot;"))
+
+
+def duration_secs(d):
+    # TRX duration looks like "00:00:01.2340000"
+    if not d:
+        return 0.0
+    try:
+        h, m, s = d.split(":")
+        return int(h) * 3600 + int(m) * 60 + float(s)
+    except Exception:
+        return 0.0
+
+
+def main():
+    trx, out = sys.argv[1], sys.argv[2]
+    root = ET.parse(trx).getroot()
+
+    cases = []
+    fails = skips = 0
+    for el in root.iter():
+        if localname(el.tag) != "UnitTestResult":
+            continue
+        name = el.get("testName") or "?"
+        outcome = el.get("outcome") or ""
+        dur = duration_secs(el.get("duration"))
+        msg = ""
+        for e in el.iter():
+            if localname(e.tag) == "Message" and e.text:
+                msg = e.text.strip()
+                break
+        cases.append((name, outcome, dur, msg))
+        if outcome == "Failed":
+            fails += 1
+        elif outcome != "Passed":
+            skips += 1
+
+    lines = [f'<testsuite name="wpts" tests="{len(cases)}" '
+             f'failures="{fails}" errors="0" skipped="{skips}">']
+    for name, outcome, dur, msg in cases:
+        attr = f'name="{esc(name)}" classname="wpts" time="{dur:.3f}"'
+        if outcome == "Failed":
+            lines.append(f'  <testcase {attr}>'
+                         f'<failure message="{esc(msg)}"></failure></testcase>')
+        elif outcome == "Passed":
+            lines.append(f'  <testcase {attr}/>')
+        else:
+            lines.append(f'  <testcase {attr}><skipped/></testcase>')
+    lines.append("</testsuite>")
+    with open(out, "w") as f:
+        f.write("\n".join(lines) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/wpts_smb_test_wrapper.sh
+++ b/scripts/wpts_smb_test_wrapper.sh
@@ -325,6 +325,16 @@ echo "=== vstest exit code: ${VSTEST_RC} ==="
 # after the session dir is cleaned up.
 cp -f "$CHIMERA_LOG" "${RESULT_DIR}/chimera_stderr.log" 2>/dev/null || true
 
+# When the harness asks (WPTS_JUNIT_FILE, set for the consolidated runs whose
+# per-case detail CTest's --output-junit cannot see), convert vstest's TRX to a
+# per-case JUnit for the CI report -- the WPTS analogue of pynfs's --xml.
+if [ -n "${WPTS_JUNIT_FILE:-}" ] && [ -f "${RESULT_DIR}/SMB2TestResult.trx" ]; then
+    mkdir -p "$(dirname "$WPTS_JUNIT_FILE")"
+    python3 "${SCRIPT_DIR}/trx_to_junit.py" \
+        "${RESULT_DIR}/SMB2TestResult.trx" "${WPTS_JUNIT_FILE}" \
+        || echo "=== trx_to_junit conversion failed (non-fatal) ==="
+fi
+
 # A daemon that died during the run is a finding in its own right: fail the
 # test even if vstest itself reported success.
 if ! kill -0 "$CHIMERA_PID" 2>/dev/null; then

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -104,6 +104,52 @@ if(CHIMERA_NETNS_TESTING AND WPTS_DOTNET AND WPTS_SMB2_DLL AND WPTS_ARCH_SUPPORT
     get_filename_component(WPTS_BIN_DIR "${WPTS_SMB2_DLL}" DIRECTORY)
     set(CHIMERA_DAEMON $<TARGET_FILE:chimera>)
 
+    set(WPTS_JUNIT_DIR ${CMAKE_BINARY_DIR}/wpts-junit
+        CACHE PATH "Directory for per-case WPTS JUnit XML output.")
+
+    # Run a whole WPTS allowlist in ONE consolidated CTest entry -- one daemon +
+    # netns + dotnet/vstest invocation -- instead of one per case.  The ~5s fixed
+    # tax per invocation (daemon/netns/dotnet+vstest startup) dwarfs the ~0.5s of
+    # actual work per case, so consolidating collapses the suite (~90% of the
+    # wall clock, ~196 netns -> ~7).  vstest takes the whole allowlist as a single
+    # "Name=A|Name=B|..." filter, and the wrapper converts vstest's TRX to a
+    # per-case JUnit (WPTS_JUNIT_FILE) so the CI report keeps per-case visibility,
+    # exactly like the pynfs combined runs.  Trailing args are extra VAR=value
+    # environment entries (the per-config CHIMERA_SMB_* feature flags).
+    function(wpts_add_combined suffix labels allowlist_var)
+        set(filter "")
+        foreach(tc ${${allowlist_var}})
+            if(filter)
+                string(APPEND filter "|Name=${tc}")
+            else()
+                set(filter "Name=${tc}")
+            endif()
+        endforeach()
+        if(NOT filter)
+            return()
+        endif()
+
+        set(name chimera/server/smb/wpts/${suffix})
+        add_test(NAME ${name}
+            COMMAND ${CMAKE_SOURCE_DIR}/scripts/wpts_smb_test_wrapper.sh
+                    ${CHIMERA_DAEMON} memfs "${filter}")
+
+        set(env "WPTS_BIN_DIR=${WPTS_BIN_DIR}" "DOTNET=${WPTS_DOTNET}"
+                "WPTS_JUNIT_FILE=${WPTS_JUNIT_DIR}/${suffix}.xml")
+        if(ARGN)
+            list(APPEND env ${ARGN})
+        endif()
+
+        # The wrapper stages a per-config ptfconfig into the shared WPTS Bin dir,
+        # so the configs still can't run concurrently -- keep them serialized
+        # (only ~7 entries now, not ~196).
+        set_tests_properties(${name} PROPERTIES
+            LABELS "${labels}"
+            TIMEOUT 600
+            RESOURCE_LOCK wpts_smb_bin
+            ENVIRONMENT "${env}")
+    endfunction()
+
     # Allowlist: MS-SMB2 cases confirmed green across repeated runs against the
     # current SMB2 server (memfs backend). Grow this as features land. Tests
     # that only pass with an unmerged server fix (e.g. the QUERY_DIRECTORY
@@ -200,18 +246,7 @@ if(CHIMERA_NETNS_TESTING AND WPTS_DOTNET AND WPTS_SMB2_DLL AND WPTS_ARCH_SUPPORT
         ValidateNegotiateInfo_Negative_SMB311
         )
 
-    foreach(tc ${WPTS_SMB2_ALLOWLIST})
-        add_test(NAME chimera/server/smb/wpts/memfs/${tc}
-            COMMAND ${CMAKE_SOURCE_DIR}/scripts/wpts_smb_test_wrapper.sh
-                    ${CHIMERA_DAEMON} memfs "Name=${tc}")
-        # The wrapper stages our ptfconfig into the shared WPTS Bin dir, so
-        # serialize WPTS tests against each other to avoid a write race.
-        set_tests_properties(chimera/server/smb/wpts/memfs/${tc} PROPERTIES
-            LABELS "smb;wpts"
-            TIMEOUT 180
-            RESOURCE_LOCK wpts_smb_bin
-            ENVIRONMENT "WPTS_BIN_DIR=${WPTS_BIN_DIR};DOTNET=${WPTS_DOTNET}")
-    endforeach()
+    wpts_add_combined(memfs "smb;wpts" WPTS_SMB2_ALLOWLIST)
 
     # SMB3 durable / persistent handle cases plus the Replay (channel-sequence)
     # suite.  These need the daemon run with smb_persistent_handles enabled (the
@@ -268,16 +303,7 @@ if(CHIMERA_NETNS_TESTING AND WPTS_DOTNET AND WPTS_SMB2_DLL AND WPTS_ARCH_SUPPORT
         Replay_PersistentHandle_SetInfo_ReplayEligibleCleared
         Replay_PersistentHandle_Write_ReplayEligibleCleared)
 
-    foreach(tc ${WPTS_SMB2_PERSISTENT_ALLOWLIST})
-        add_test(NAME chimera/server/smb/wpts/memfs_persistent/${tc}
-            COMMAND ${CMAKE_SOURCE_DIR}/scripts/wpts_smb_test_wrapper.sh
-                    ${CHIMERA_DAEMON} memfs "Name=${tc}")
-        set_tests_properties(chimera/server/smb/wpts/memfs_persistent/${tc} PROPERTIES
-            LABELS "smb;wpts;persistent"
-            TIMEOUT 180
-            RESOURCE_LOCK wpts_smb_bin
-            ENVIRONMENT "WPTS_BIN_DIR=${WPTS_BIN_DIR};DOTNET=${WPTS_DOTNET};CHIMERA_SMB_PERSISTENT=1")
-    endforeach()
+    wpts_add_combined(memfs_persistent "smb;wpts;persistent" WPTS_SMB2_PERSISTENT_ALLOWLIST "CHIMERA_SMB_PERSISTENT=1")
 
     # SMB3 transport-compression cases.  These need the daemon run with
     # smb_compression enabled (the wrapper sets it from CHIMERA_SMB_COMPRESSION,
@@ -325,16 +351,7 @@ if(CHIMERA_NETNS_TESTING AND WPTS_DOTNET AND WPTS_SMB2_DLL AND WPTS_ARCH_SUPPORT
         SMB2Compression_LZ77_LargeFile
         TreeMgmt_SMB311_COMPRESS_DATA)
 
-    foreach(tc ${WPTS_SMB2_COMPRESSION_ALLOWLIST})
-        add_test(NAME chimera/server/smb/wpts/memfs_compression/${tc}
-            COMMAND ${CMAKE_SOURCE_DIR}/scripts/wpts_smb_test_wrapper.sh
-                    ${CHIMERA_DAEMON} memfs "Name=${tc}")
-        set_tests_properties(chimera/server/smb/wpts/memfs_compression/${tc} PROPERTIES
-            LABELS "smb;wpts;compression"
-            TIMEOUT 180
-            RESOURCE_LOCK wpts_smb_bin
-            ENVIRONMENT "WPTS_BIN_DIR=${WPTS_BIN_DIR};DOTNET=${WPTS_DOTNET};CHIMERA_SMB_COMPRESSION=1")
-    endforeach()
+    wpts_add_combined(memfs_compression "smb;wpts;compression" WPTS_SMB2_COMPRESSION_ALLOWLIST "CHIMERA_SMB_COMPRESSION=1")
 
     # SMB3 multichannel cases.  The wrapper runs the daemon with a second NIC
     # address (so FSCTL_QUERY_NETWORK_INTERFACE_INFO advertises an alternative
@@ -371,16 +388,7 @@ if(CHIMERA_NETNS_TESTING AND WPTS_DOTNET AND WPTS_SMB2_DLL AND WPTS_ARCH_SUPPORT
         NetworkInterfaceInfo_Query_ReturnsIPv4IPv6
         )
 
-    foreach(tc ${WPTS_SMB2_MULTICHANNEL_ALLOWLIST})
-        add_test(NAME chimera/server/smb/wpts/memfs_multichannel/${tc}
-            COMMAND ${CMAKE_SOURCE_DIR}/scripts/wpts_smb_test_wrapper.sh
-                    ${CHIMERA_DAEMON} memfs "Name=${tc}")
-        set_tests_properties(chimera/server/smb/wpts/memfs_multichannel/${tc} PROPERTIES
-            LABELS "smb;wpts;multichannel"
-            TIMEOUT 180
-            RESOURCE_LOCK wpts_smb_bin
-            ENVIRONMENT "WPTS_BIN_DIR=${WPTS_BIN_DIR};DOTNET=${WPTS_DOTNET};CHIMERA_SMB_MULTICHANNEL=1")
-    endforeach()
+    wpts_add_combined(memfs_multichannel "smb;wpts;multichannel" WPTS_SMB2_MULTICHANNEL_ALLOWLIST "CHIMERA_SMB_MULTICHANNEL=1")
 
     # SMB3 transport-encryption cases.  These need the daemon run with
     # smb_encryption enabled (the wrapper sets it from CHIMERA_SMB_ENCRYPTION,
@@ -404,16 +412,7 @@ if(CHIMERA_NETNS_TESTING AND WPTS_DOTNET AND WPTS_SMB2_DLL AND WPTS_ARCH_SUPPORT
         Compound_Encrypt_UnrelatedRequests
         Signing_VerifySignatureWhenEncrypted)
 
-    foreach(tc ${WPTS_SMB2_ENCRYPTION_ALLOWLIST})
-        add_test(NAME chimera/server/smb/wpts/memfs_encryption/${tc}
-            COMMAND ${CMAKE_SOURCE_DIR}/scripts/wpts_smb_test_wrapper.sh
-                    ${CHIMERA_DAEMON} memfs "Name=${tc}")
-        set_tests_properties(chimera/server/smb/wpts/memfs_encryption/${tc} PROPERTIES
-            LABELS "smb;wpts;encryption"
-            TIMEOUT 180
-            RESOURCE_LOCK wpts_smb_bin
-            ENVIRONMENT "WPTS_BIN_DIR=${WPTS_BIN_DIR};DOTNET=${WPTS_DOTNET};CHIMERA_SMB_ENCRYPTION=1")
-    endforeach()
+    wpts_add_combined(memfs_encryption "smb;wpts;encryption" WPTS_SMB2_ENCRYPTION_ALLOWLIST "CHIMERA_SMB_ENCRYPTION=1")
 
     # Compression + encryption combined cases (compress-then-encrypt, MS-SMB2
     # §3.1.4.4).  The wrapper enables both smb_compression and smb_encryption so a
@@ -426,16 +425,7 @@ if(CHIMERA_NETNS_TESTING AND WPTS_DOTNET AND WPTS_SMB2_DLL AND WPTS_ARCH_SUPPORT
         BVT_SMB2Compression_Chained_PatternV1_Encrypted
         Negotiate_SMB311_WithEncryptionAndCompressionContextsWithoutIntegrityContext)
 
-    foreach(tc ${WPTS_SMB2_COMPRESSION_ENCRYPTION_ALLOWLIST})
-        add_test(NAME chimera/server/smb/wpts/memfs_compression_encryption/${tc}
-            COMMAND ${CMAKE_SOURCE_DIR}/scripts/wpts_smb_test_wrapper.sh
-                    ${CHIMERA_DAEMON} memfs "Name=${tc}")
-        set_tests_properties(chimera/server/smb/wpts/memfs_compression_encryption/${tc} PROPERTIES
-            LABELS "smb;wpts;compression;encryption"
-            TIMEOUT 180
-            RESOURCE_LOCK wpts_smb_bin
-            ENVIRONMENT "WPTS_BIN_DIR=${WPTS_BIN_DIR};DOTNET=${WPTS_DOTNET};CHIMERA_SMB_COMPRESSION=1;CHIMERA_SMB_ENCRYPTION=1")
-    endforeach()
+    wpts_add_combined(memfs_compression_encryption "smb;wpts;compression;encryption" WPTS_SMB2_COMPRESSION_ENCRYPTION_ALLOWLIST "CHIMERA_SMB_COMPRESSION=1" "CHIMERA_SMB_ENCRYPTION=1")
 
     # Multichannel + encryption combined case: encryption is session-scoped, so
     # the keys derived on the first channel cover every bound channel.  The
@@ -445,16 +435,7 @@ if(CHIMERA_NETNS_TESTING AND WPTS_DOTNET AND WPTS_SMB2_DLL AND WPTS_ARCH_SUPPORT
     set(WPTS_SMB2_MULTICHANNEL_ENCRYPTION_ALLOWLIST
         MultipleChannel_EncryptionOnBothChannels)
 
-    foreach(tc ${WPTS_SMB2_MULTICHANNEL_ENCRYPTION_ALLOWLIST})
-        add_test(NAME chimera/server/smb/wpts/memfs_multichannel_encryption/${tc}
-            COMMAND ${CMAKE_SOURCE_DIR}/scripts/wpts_smb_test_wrapper.sh
-                    ${CHIMERA_DAEMON} memfs "Name=${tc}")
-        set_tests_properties(chimera/server/smb/wpts/memfs_multichannel_encryption/${tc} PROPERTIES
-            LABELS "smb;wpts;multichannel;encryption"
-            TIMEOUT 180
-            RESOURCE_LOCK wpts_smb_bin
-            ENVIRONMENT "WPTS_BIN_DIR=${WPTS_BIN_DIR};DOTNET=${WPTS_DOTNET};CHIMERA_SMB_MULTICHANNEL=1;CHIMERA_SMB_ENCRYPTION=1")
-    endforeach()
+    wpts_add_combined(memfs_multichannel_encryption "smb;wpts;multichannel;encryption" WPTS_SMB2_MULTICHANNEL_ENCRYPTION_ALLOWLIST "CHIMERA_SMB_MULTICHANNEL=1" "CHIMERA_SMB_ENCRYPTION=1")
 
     message(STATUS "WPTS MS-SMB2 tests: enabled (${WPTS_BIN_DIR}, ${WPTS_DOTNET})")
 elseif(CHIMERA_NETNS_TESTING AND WPTS_DOTNET AND WPTS_SMB2_DLL AND NOT WPTS_ARCH_SUPPORTED)


### PR DESCRIPTION
Layered on top of #727 (targets `ctest-junit-report`; will retarget to `main` once that merges).

## What
Each WPTS case was its own CTest entry — ~196 entries, each spawning a daemon + netns + a fresh `dotnet vstest` process, all serialized on a shared ptfconfig. The **~5s fixed tax per invocation** (daemon/netns/dotnet+vstest startup) dwarfs the **~0.5s** of actual per-case work.

This runs each config's whole allowlist in **one** vstest invocation against one daemon (vstest takes the allowlist as a single `Name=A|Name=B|...` filter):

- **196 CTest entries → 7** (one per `CHIMERA_SMB_*` config), ~196 netns → 7.

## Measured (local, memfs backend)
| | before | after |
|---|---|---|
| memfs config (88 cases) | ~435s | **44.9s** |
| full WPTS suite (196 cases) | ~980s | **159s (~84%)** |

All 196 cases still green.

## Visibility preserved
`ctest --output-junit` only sees the consolidated entry as one test, so the wrapper converts vstest's TRX to a **per-case JUnit** (new `scripts/trx_to_junit.py`) when `WPTS_JUNIT_FILE` is set — the WPTS analogue of pynfs's `--xml`. `ci_test_report.py` now expands a failed consolidated WPTS entry to its specific failed cases, and CI collects `wpts-junit/` alongside `pynfs-junit/`.

## Trade-off
A daemon crash mid-run loses that config's remaining cases (the TRX still captures what ran, and the daemon-died check fails the entry) — acceptable for independent conformance cases given the ~6× speedup.