### PR TITLE
build: make KVM testing a tri-state KVM_TESTING flag (default AUTO)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -293,35 +293,39 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # devcontainer (amd64 + arm64)
+          # devcontainer. KVM is required ON for amd64, where the suites
+          # actually run, so a regression in availability fails the build
+          # rather than silently skipping. The devcontainer ships only x86
+          # qemu (qemu-system-x86), so KVM acceleration is unavailable on
+          # arm64 -- the suites never ran there, so keep them explicitly OFF.
           - platform: linux/amd64
             runner: arc-amd64
             arch: amd64
             build_type: Release
             image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-dev
             image_name: devcontainer
-            cmake_extra: ""
+            cmake_extra: "-DKVM_TESTING=ON"
           - platform: linux/amd64
             runner: arc-amd64
             arch: amd64
             build_type: Debug
             image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-dev
             image_name: devcontainer
-            cmake_extra: ""
+            cmake_extra: "-DKVM_TESTING=ON"
           - platform: linux/arm64
             runner: arc-arm64
             arch: arm64
             build_type: Release
             image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-dev
             image_name: devcontainer
-            cmake_extra: ""
+            cmake_extra: "-DKVM_TESTING=OFF"
           - platform: linux/arm64
             runner: arc-arm64
             arch: arm64
             build_type: Debug
             image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-dev
             image_name: devcontainer
-            cmake_extra: ""
+            cmake_extra: "-DKVM_TESTING=OFF"
           # ubuntu 26 (amd64 only on PR; arm64 runs in nightly)
           - platform: linux/amd64
             runner: arc-amd64
@@ -329,14 +333,14 @@ jobs:
             build_type: Release
             image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu26
             image_name: ubuntu26
-            cmake_extra: ""
+            cmake_extra: "-DKVM_TESTING=OFF"
           - platform: linux/amd64
             runner: arc-amd64
             arch: amd64
             build_type: Debug
             image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu26
             image_name: ubuntu26
-            cmake_extra: ""
+            cmake_extra: "-DKVM_TESTING=OFF"
           # ubuntu 24 (amd64 only on PR; arm64 runs in nightly)
           - platform: linux/amd64
             runner: arc-amd64
@@ -344,14 +348,14 @@ jobs:
             build_type: Release
             image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu24
             image_name: ubuntu24
-            cmake_extra: ""
+            cmake_extra: "-DKVM_TESTING=OFF"
           - platform: linux/amd64
             runner: arc-amd64
             arch: amd64
             build_type: Debug
             image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu24
             image_name: ubuntu24
-            cmake_extra: ""
+            cmake_extra: "-DKVM_TESTING=OFF"
           # ubuntu 22 (amd64 only on PR; arm64 runs in nightly)
           - platform: linux/amd64
             runner: arc-amd64
@@ -359,14 +363,14 @@ jobs:
             build_type: Release
             image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu22
             image_name: ubuntu22
-            cmake_extra: "-DIO_URING_ENABLED=OFF"
+            cmake_extra: "-DIO_URING_ENABLED=OFF -DKVM_TESTING=OFF"
           - platform: linux/amd64
             runner: arc-amd64
             arch: amd64
             build_type: Debug
             image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu22
             image_name: ubuntu22
-            cmake_extra: "-DIO_URING_ENABLED=OFF"
+            cmake_extra: "-DIO_URING_ENABLED=OFF -DKVM_TESTING=OFF"
           # rocky 9 (io_uring disabled: kernel 5.14 + ASAN causes timeouts, see #197)
           - platform: linux/amd64
             runner: arc-amd64
@@ -374,14 +378,14 @@ jobs:
             build_type: Release
             image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-rocky9
             image_name: rocky9
-            cmake_extra: "-DIO_URING_ENABLED=OFF"
+            cmake_extra: "-DIO_URING_ENABLED=OFF -DKVM_TESTING=OFF"
           - platform: linux/amd64
             runner: arc-amd64
             arch: amd64
             build_type: Debug
             image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-rocky9
             image_name: rocky9
-            cmake_extra: "-DIO_URING_ENABLED=OFF"
+            cmake_extra: "-DIO_URING_ENABLED=OFF -DKVM_TESTING=OFF"
           # rocky 10 (amd64 only on PR; arm64 runs in nightly)
           - platform: linux/amd64
             runner: arc-amd64
@@ -389,14 +393,14 @@ jobs:
             build_type: Release
             image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-rocky10
             image_name: rocky10
-            cmake_extra: ""
+            cmake_extra: "-DKVM_TESTING=OFF"
           - platform: linux/amd64
             runner: arc-amd64
             arch: amd64
             build_type: Debug
             image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-rocky10
             image_name: rocky10
-            cmake_extra: ""
+            cmake_extra: "-DKVM_TESTING=OFF"
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -295,64 +295,69 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # devcontainer
+          # devcontainer. KVM is required ON for amd64, where the suites
+          # actually run, so a regression in availability fails the build
+          # rather than silently skipping. The devcontainer ships only x86
+          # qemu (qemu-system-x86), so KVM acceleration is unavailable on
+          # arm64 -- the suites never ran there, so keep them explicitly OFF.
           - platform: linux/amd64
             runner: arc-amd64
             arch: amd64
             build_type: Release
             image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-dev
             image_name: devcontainer
-            cmake_extra: ""
+            cmake_extra: "-DKVM_TESTING=ON"
           - platform: linux/amd64
             runner: arc-amd64
             arch: amd64
             build_type: Debug
             image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-dev
             image_name: devcontainer
-            cmake_extra: ""
+            cmake_extra: "-DKVM_TESTING=ON"
           - platform: linux/arm64
             runner: arc-arm64
             arch: arm64
             build_type: Release
             image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-dev
             image_name: devcontainer
-            cmake_extra: ""
+            cmake_extra: "-DKVM_TESTING=OFF"
           - platform: linux/arm64
             runner: arc-arm64
             arch: arm64
             build_type: Debug
             image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-dev
             image_name: devcontainer
-            cmake_extra: ""
-          # ubuntu 26
+            cmake_extra: "-DKVM_TESTING=OFF"
+          # ubuntu 26 (no KVM here; disable explicitly so a missing /dev/kvm
+          # does not get silently auto-detected)
           - platform: linux/amd64
             runner: arc-amd64
             arch: amd64
             build_type: Release
             image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu26
             image_name: ubuntu26
-            cmake_extra: ""
+            cmake_extra: "-DKVM_TESTING=OFF"
           - platform: linux/amd64
             runner: arc-amd64
             arch: amd64
             build_type: Debug
             image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu26
             image_name: ubuntu26
-            cmake_extra: ""
+            cmake_extra: "-DKVM_TESTING=OFF"
           - platform: linux/arm64
             runner: arc-arm64
             arch: arm64
             build_type: Release
             image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu26
             image_name: ubuntu26
-            cmake_extra: ""
+            cmake_extra: "-DKVM_TESTING=OFF"
           - platform: linux/arm64
             runner: arc-arm64
             arch: arm64
             build_type: Debug
             image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu26
             image_name: ubuntu26
-            cmake_extra: ""
+            cmake_extra: "-DKVM_TESTING=OFF"
           # ubuntu 24
           - platform: linux/amd64
             runner: arc-amd64
@@ -360,28 +365,28 @@ jobs:
             build_type: Release
             image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu24
             image_name: ubuntu24
-            cmake_extra: ""
+            cmake_extra: "-DKVM_TESTING=OFF"
           - platform: linux/amd64
             runner: arc-amd64
             arch: amd64
             build_type: Debug
             image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu24
             image_name: ubuntu24
-            cmake_extra: ""
+            cmake_extra: "-DKVM_TESTING=OFF"
           - platform: linux/arm64
             runner: arc-arm64
             arch: arm64
             build_type: Release
             image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu24
             image_name: ubuntu24
-            cmake_extra: ""
+            cmake_extra: "-DKVM_TESTING=OFF"
           - platform: linux/arm64
             runner: arc-arm64
             arch: arm64
             build_type: Debug
             image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu24
             image_name: ubuntu24
-            cmake_extra: ""
+            cmake_extra: "-DKVM_TESTING=OFF"
           # ubuntu 22
           - platform: linux/amd64
             runner: arc-amd64
@@ -389,28 +394,28 @@ jobs:
             build_type: Release
             image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu22
             image_name: ubuntu22
-            cmake_extra: "-DIO_URING_ENABLED=OFF"
+            cmake_extra: "-DIO_URING_ENABLED=OFF -DKVM_TESTING=OFF"
           - platform: linux/amd64
             runner: arc-amd64
             arch: amd64
             build_type: Debug
             image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu22
             image_name: ubuntu22
-            cmake_extra: "-DIO_URING_ENABLED=OFF"
+            cmake_extra: "-DIO_URING_ENABLED=OFF -DKVM_TESTING=OFF"
           - platform: linux/arm64
             runner: arc-arm64
             arch: arm64
             build_type: Release
             image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu22
             image_name: ubuntu22
-            cmake_extra: "-DIO_URING_ENABLED=OFF"
+            cmake_extra: "-DIO_URING_ENABLED=OFF -DKVM_TESTING=OFF"
           - platform: linux/arm64
             runner: arc-arm64
             arch: arm64
             build_type: Debug
             image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu22
             image_name: ubuntu22
-            cmake_extra: "-DIO_URING_ENABLED=OFF"
+            cmake_extra: "-DIO_URING_ENABLED=OFF -DKVM_TESTING=OFF"
           # rocky 9 (io_uring disabled: kernel 5.14 + ASAN causes timeouts, see #197)
           - platform: linux/amd64
             runner: arc-amd64
@@ -418,28 +423,28 @@ jobs:
             build_type: Release
             image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-rocky9
             image_name: rocky9
-            cmake_extra: "-DIO_URING_ENABLED=OFF"
+            cmake_extra: "-DIO_URING_ENABLED=OFF -DKVM_TESTING=OFF"
           - platform: linux/amd64
             runner: arc-amd64
             arch: amd64
             build_type: Debug
             image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-rocky9
             image_name: rocky9
-            cmake_extra: "-DIO_URING_ENABLED=OFF"
+            cmake_extra: "-DIO_URING_ENABLED=OFF -DKVM_TESTING=OFF"
           - platform: linux/arm64
             runner: arc-arm64
             arch: arm64
             build_type: Release
             image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-rocky9
             image_name: rocky9
-            cmake_extra: "-DIO_URING_ENABLED=OFF"
+            cmake_extra: "-DIO_URING_ENABLED=OFF -DKVM_TESTING=OFF"
           - platform: linux/arm64
             runner: arc-arm64
             arch: arm64
             build_type: Debug
             image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-rocky9
             image_name: rocky9
-            cmake_extra: "-DIO_URING_ENABLED=OFF"
+            cmake_extra: "-DIO_URING_ENABLED=OFF -DKVM_TESTING=OFF"
           # rocky 10
           - platform: linux/amd64
             runner: arc-amd64
@@ -447,28 +452,28 @@ jobs:
             build_type: Release
             image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-rocky10
             image_name: rocky10
-            cmake_extra: ""
+            cmake_extra: "-DKVM_TESTING=OFF"
           - platform: linux/amd64
             runner: arc-amd64
             arch: amd64
             build_type: Debug
             image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-rocky10
             image_name: rocky10
-            cmake_extra: ""
+            cmake_extra: "-DKVM_TESTING=OFF"
           - platform: linux/arm64
             runner: arc-arm64
             arch: arm64
             build_type: Release
             image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-rocky10
             image_name: rocky10
-            cmake_extra: ""
+            cmake_extra: "-DKVM_TESTING=OFF"
           - platform: linux/arm64
             runner: arc-arm64
             arch: arm64
             build_type: Debug
             image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-rocky10
             image_name: rocky10
-            cmake_extra: ""
+            cmake_extra: "-DKVM_TESTING=OFF"
 
     steps:
       - name: Checkout repository

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,48 +155,76 @@ else()
     message(STATUS "CAIRN disabled")
 endif()
 
-# KVM testing detection
+# KVM testing.
 #
-# Guest images are pulled (not built) from chimera-nas/kvm-test-base as OCI
-# artifacts, so KVM testing needs `oras` to fetch them plus QEMU and /dev/kvm
-# to run them. Docker is no longer required at build time.
-find_program(ORAS_EXECUTABLE oras)
+# The KVM-based suites (cthon/xfstests/pnfs) boot a real guest kernel via
+# QEMU/KVM. Guest images are pulled (not built) from chimera-nas/kvm-test-base
+# as OCI artifacts, so running them needs `oras` to fetch the images, an
+# arch-appropriate qemu, /dev/kvm, and root.
+#
+# KVM_TESTING is tri-state:
+#   AUTO (default) - enable iff KVM is available and we are root, else skip
+#   ON             - require KVM testing; hard fail if it is not available
+#   OFF            - never register the KVM suites
+#
+# CI sets ON for the devcontainer image (where KVM must work, so a regression
+# in availability fails loudly) and OFF for the other images (which lack the
+# prerequisites and should not probe). When the flag is not supplied at all the
+# AUTO default makes normal users pick up KVM testing whenever their machine can
+# actually run it.
+set(KVM_TESTING "AUTO" CACHE STRING "KVM test suites: AUTO (enable iff available), ON (require), or OFF")
+set_property(CACHE KVM_TESTING PROPERTY STRINGS AUTO ON OFF)
+string(TOUPPER "${KVM_TESTING}" KVM_TESTING)
 
-# Find architecture-appropriate QEMU binary
-execute_process(COMMAND uname -m OUTPUT_VARIABLE HOST_ARCH OUTPUT_STRIP_TRAILING_WHITESPACE)
-if(HOST_ARCH STREQUAL "aarch64")
-    find_program(QEMU_EXECUTABLE qemu-system-aarch64)
+if(KVM_TESTING STREQUAL "OFF")
+    message(STATUS "KVM testing disabled (KVM_TESTING=OFF)")
 else()
-    find_program(QEMU_EXECUTABLE qemu-system-x86_64)
-endif()
+    # Probe the prerequisites and collect any that are missing.
+    find_program(ORAS_EXECUTABLE oras)
 
-set(KVM_TESTING_AVAILABLE FALSE)
-
-if(ORAS_EXECUTABLE AND QEMU_EXECUTABLE)
-    if(EXISTS "/dev/kvm")
-        set(KVM_AVAILABLE TRUE)
+    execute_process(COMMAND uname -m OUTPUT_VARIABLE HOST_ARCH OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if(HOST_ARCH STREQUAL "aarch64")
+        find_program(QEMU_EXECUTABLE qemu-system-aarch64)
     else()
-        set(KVM_AVAILABLE FALSE)
-        message(STATUS "KVM testing: /dev/kvm not found")
+        find_program(QEMU_EXECUTABLE qemu-system-x86_64)
     endif()
 
-    if(KVM_AVAILABLE)
-        set(KVM_TESTING_AVAILABLE TRUE)
-    endif()
-else()
+    execute_process(COMMAND id -u OUTPUT_VARIABLE HOST_UID OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+    set(KVM_TESTING_AVAILABLE TRUE)
+    set(KVM_UNAVAILABLE_REASON "")
+
     if(NOT ORAS_EXECUTABLE)
-        message(STATUS "KVM testing: oras not found")
+        set(KVM_TESTING_AVAILABLE FALSE)
+        string(APPEND KVM_UNAVAILABLE_REASON " oras not found;")
     endif()
-    if(NOT QEMU_EXECUTABLE)
-        message(STATUS "KVM testing: QEMU not found for ${HOST_ARCH}")
-    endif()
-endif()
 
-if(KVM_TESTING_AVAILABLE)
-    message(STATUS "KVM testing enabled")
-    add_subdirectory(kvm)
-else()
-    message(STATUS "KVM testing disabled")
+    if(NOT QEMU_EXECUTABLE)
+        set(KVM_TESTING_AVAILABLE FALSE)
+        string(APPEND KVM_UNAVAILABLE_REASON " qemu not found for ${HOST_ARCH};")
+    endif()
+
+    if(NOT EXISTS "/dev/kvm")
+        set(KVM_TESTING_AVAILABLE FALSE)
+        string(APPEND KVM_UNAVAILABLE_REASON " /dev/kvm not found;")
+    endif()
+
+    if(NOT HOST_UID EQUAL 0)
+        set(KVM_TESTING_AVAILABLE FALSE)
+        string(APPEND KVM_UNAVAILABLE_REASON " not running as root;")
+    endif()
+
+    if(KVM_TESTING_AVAILABLE)
+        message(STATUS "KVM testing enabled")
+        add_subdirectory(kvm)
+    elseif(KVM_TESTING STREQUAL "ON")
+        message(FATAL_ERROR
+            "KVM_TESTING=ON but KVM testing is not available:${KVM_UNAVAILABLE_REASON} "
+            "Provide the missing prerequisites or re-run with -DKVM_TESTING=AUTO/OFF.")
+    else()
+        message(STATUS "KVM testing disabled (KVM_TESTING=AUTO;${KVM_UNAVAILABLE_REASON}). "
+            "Pass -DKVM_TESTING=ON to make missing prerequisites fatal.")
+    endif()
 endif()
 
 # Network namespace testing detection.


### PR DESCRIPTION
## Summary

Inverts the KVM test gating so that KVM-based suites (cthon/xfstests/pnfs) are enabled by default for normal users when their machine can actually run them, while CI keeps tight, explicit control.

Previously the KVM suites were gated purely on silent auto-detection of docker + `/dev/kvm`. This replaces that with a tri-state `KVM_TESTING` cache variable:

- **AUTO** (default) — enable iff KVM is available **and we are root**, else skip
- **ON** — require KVM testing; hard fail (`FATAL_ERROR`, listing what's missing) if it is not available
- **OFF** — never register the KVM suites

AUTO now also checks for root (`id -u`) in addition to a functional docker, an arch-appropriate qemu, and `/dev/kvm`, so an ordinary developer with a working setup picks the suites up automatically.

## CI changes

The old default is inverted explicitly in `build-test.yml` and `nightly.yml`:

- **devcontainer** test jobs pass `-DKVM_TESTING=ON` — a regression in KVM availability now fails loudly rather than silently dropping coverage.
- every **non-devcontainer** test job passes `-DKVM_TESTING=OFF` so it does not probe for absent prerequisites (folded into the existing `-DIO_URING_ENABLED=OFF` where present).
- build-only **static-analysis** jobs are intentionally left at AUTO — they don't start `dockerd`, so forcing ON would falsely fail; AUTO cleanly skips.

## Verification

- Exercised the tri-state logic as standalone `cmake -P` scripts: AUTO/OFF/default/lowercase-`on` all behave correctly; `ON` with a missing prerequisite exits non-zero with the listed reason; AUTO with the same gap skips gracefully.
- Both workflow YAMLs parse.