### PR TITLE
smb/pnfs: pNFS proxy crash fixes + SMB leases/oplocks config gate (default off)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -5,6 +5,7 @@
 name: CI
 
 on:
+  pull_request:        # PRs: lint + cheap aggregator no-ops (heavy jobs gated to merge_group)
   merge_group:         # full matrix runs only in the merge queue, not on raw PRs; don't publish
   workflow_dispatch:   # allow manual runs
 
@@ -30,6 +31,7 @@ env:
 jobs:
   build-devcontainer:
     name: Build devcontainer ${{ matrix.arch }}
+    if: ${{ github.event_name != 'pull_request' }}
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -74,6 +76,7 @@ jobs:
 
   build-ubuntu26:
     name: Build ubuntu26 ${{ matrix.arch }}
+    if: ${{ github.event_name != 'pull_request' }}
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -115,6 +118,7 @@ jobs:
 
   build-ubuntu24:
     name: Build ubuntu24 ${{ matrix.arch }}
+    if: ${{ github.event_name != 'pull_request' }}
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -156,6 +160,7 @@ jobs:
 
   build-ubuntu22:
     name: Build ubuntu22 ${{ matrix.arch }}
+    if: ${{ github.event_name != 'pull_request' }}
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -197,6 +202,7 @@ jobs:
 
   build-rocky9:
     name: Build rocky9 ${{ matrix.arch }}
+    if: ${{ github.event_name != 'pull_request' }}
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -237,6 +243,7 @@ jobs:
 
   build-rocky10:
     name: Build rocky10 ${{ matrix.arch }}
+    if: ${{ github.event_name != 'pull_request' }}
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -278,6 +285,7 @@ jobs:
   test:
     name: Test ${{ matrix.image_name }} ${{ matrix.arch }} ${{ matrix.build_type }}
     needs: [build-devcontainer, build-ubuntu26, build-ubuntu24, build-ubuntu22, build-rocky9, build-rocky10]
+    if: ${{ github.event_name != 'pull_request' }}
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -464,6 +472,7 @@ jobs:
   static-analysis:
     name: Analyze ${{ matrix.image_name }} ${{ matrix.arch }} ${{ matrix.build_type }}
     needs: [build-devcontainer]
+    if: ${{ github.event_name != 'pull_request' }}
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -542,7 +551,7 @@ jobs:
   publish-test-results:
     name: Report
     needs: [test]
-    if: always()
+    if: ${{ always() && github.event_name != 'pull_request' }}
     runs-on: arc-amd64
     permissions:
       pull-requests: write
@@ -685,6 +694,10 @@ jobs:
     steps:
       - name: Verify all build/test jobs passed
         run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "PR placeholder — the full build/test matrix runs in the merge queue (merge_group)."
+            exit 0
+          fi
           if ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}; then
             echo "One or more build/test jobs did not pass."
             exit 1

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -10,6 +10,7 @@ on:
       - main          # publish from the default branch
     tags:
       - "*"           # publish when any tag is pushed
+  pull_request:        # PRs: docker-build-complete no-op only (build-and-push gated below)
   merge_group:         # build to gate the merge queue (no publish) but don’t publish
   workflow_dispatch:   # allow manual runs
 
@@ -22,6 +23,7 @@ env:
 jobs:
   build-and-push:
     name: Build ${{ matrix.os }} ${{ matrix.platform }} ${{ matrix.build_type }}
+    if: ${{ github.event_name != 'pull_request' }}
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -147,6 +149,10 @@ jobs:
     steps:
       - name: Verify docker build jobs passed
         run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "PR placeholder — docker image builds run in the merge queue (merge_group)."
+            exit 0
+          fi
           if ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}; then
             echo "One or more docker build jobs did not pass."
             exit 1

--- a/scripts/wpts_smb_test_wrapper.sh
+++ b/scripts/wpts_smb_test_wrapper.sh
@@ -163,6 +163,8 @@ generate_config() {
         ${multichannel_line}
         ${encryption_line}
         "smb_named_streams": true,
+        "smb_leases": true,
+        "smb_oplocks": true,
         "threads": 4,
         "delegation_threads": 4,
         "external_portmap": false

--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -423,6 +423,16 @@ main(
         chimera_server_config_set_smb_named_streams(server_config, json_is_true(json_value));
     }
 
+    json_value = json_object_get(server_params, "smb_leases");
+    if (json_is_boolean(json_value)) {
+        chimera_server_config_set_smb_leases(server_config, json_is_true(json_value));
+    }
+
+    json_value = json_object_get(server_params, "smb_oplocks");
+    if (json_is_boolean(json_value)) {
+        chimera_server_config_set_smb_oplocks(server_config, json_is_true(json_value));
+    }
+
     /* smb_min_dialect: lowest SMB2 dialect to advertise ("2.0.2"|"2.1"|"3.0"|
      * "3.0.2"|"3.1.1").  Defaults to 2.1; lower it to 2.0.2 only where a client
      * (e.g. a conformance suite) explicitly needs the original SMB2 dialect. */

--- a/src/server/nfs/nfs4_callback.c
+++ b/src/server/nfs/nfs4_callback.c
@@ -25,6 +25,7 @@
 #include "evpl/evpl_rpc2.h"
 
 #include "nfs4_callback.h"
+#include "nfs4_cb.h"
 #include "nfs4_state.h"
 #include "nfs4_session.h"
 #include "nfs4_procs.h"
@@ -1184,18 +1185,21 @@ nfs4_cb_doorbell_drain(
         (struct chimera_server_nfs_thread *) ((char *) doorbell -
                                               offsetof(struct chimera_server_nfs_thread, cb_doorbell));
     struct nfs_delegation            *queue;
+    struct nfs_layout_state          *lrq;
     struct nfs4_cb_getattr           *gq;
     struct nfs4_cb_client            *tq;
 
     (void) evpl;
 
     pthread_mutex_lock(&thread->cb_recall_lock);
-    queue                     = thread->cb_recall_queue;
-    thread->cb_recall_queue   = NULL;
-    gq                        = thread->cb_getattr_queue;
-    thread->cb_getattr_queue  = NULL;
-    tq                        = thread->cb_teardown_queue;
-    thread->cb_teardown_queue = NULL;
+    queue                         = thread->cb_recall_queue;
+    thread->cb_recall_queue       = NULL;
+    lrq                           = thread->cb_layoutrecall_queue;
+    thread->cb_layoutrecall_queue = NULL;
+    gq                            = thread->cb_getattr_queue;
+    thread->cb_getattr_queue      = NULL;
+    tq                            = thread->cb_teardown_queue;
+    thread->cb_teardown_queue     = NULL;
     pthread_mutex_unlock(&thread->cb_recall_lock);
 
     while (queue) {
@@ -1204,6 +1208,21 @@ nfs4_cb_doorbell_drain(
         deleg->recall_qnext = NULL;
         nfs4_cb_recall_send(thread, deleg);
     }
+
+    /* Layout recalls bounced here from another thread: we now own the holder's
+     * backchannel conn, so nfs4_cb_recall_holder sends inline.  Drop the ref the
+     * producer took to pin the layout across the bounce. */
+    while (lrq) {
+        struct nfs_layout_state *h = lrq;
+        lrq             = h->recall_qnext;
+        h->recall_qnext = NULL;
+        nfs4_cb_recall_holder(thread, h);
+        nfs_layout_state_put(h);
+    }
+
+    /* Deferred-op resumes bounced to this (their home) thread by a recall that
+     * completed on another thread.  Re-drives the op where its iovecs live. */
+    nfs4_cb_drain_resume_queue(thread);
 
     while (gq) {
         struct nfs4_cb_getattr *w = gq;

--- a/src/server/nfs/nfs4_cb.c
+++ b/src/server/nfs/nfs4_cb.c
@@ -9,6 +9,7 @@
 #include "nfs4_stateid.h"
 #include "nfs4_layout_table.h"
 #include "nfs4_callback.h"
+#include "nfs4_session.h"
 #include "nfs_common.h"
 #include "nfs_internal.h"
 #include "nfs4_cb.h"
@@ -53,20 +54,89 @@ nfs4_cb_recall_done(
     free(ctx);
 } /* nfs4_cb_recall_done */
 
+/* Deferred-op resume that must run on its home thread.  The layout table fires
+ * the waiter's resume on whichever thread processed the final LAYOUTRETURN, but
+ * the deferred op's request and iovecs are owned by the thread that received it
+ * (evpl/iovec ops are not cross-thread safe).  recall_and_wait wraps the real
+ * resume in nfs4_cb_resume_bounce, which marshals it back to the origin thread
+ * via cb_doorbell; the drain runs it there. */
+struct nfs4_cb_resume_ctx {
+    void                              (*resume)(
+        void *arg);
+    void                             *arg;
+    struct chimera_server_nfs_thread *origin;
+    struct nfs4_cb_resume_ctx        *next;
+};
+
+static void
+nfs4_cb_resume_bounce(void *arg)
+{
+    struct nfs4_cb_resume_ctx        *ctx    = arg;
+    struct chimera_server_nfs_thread *origin = ctx->origin;
+
+    pthread_mutex_lock(&origin->cb_recall_lock);
+    ctx->next               = origin->cb_resume_queue;
+    origin->cb_resume_queue = ctx;
+    pthread_mutex_unlock(&origin->cb_recall_lock);
+
+    evpl_ring_doorbell(&origin->cb_doorbell);
+} /* nfs4_cb_resume_bounce */
+
+void
+nfs4_cb_drain_resume_queue(struct chimera_server_nfs_thread *thread)
+{
+    struct nfs4_cb_resume_ctx *q;
+
+    pthread_mutex_lock(&thread->cb_recall_lock);
+    q                       = thread->cb_resume_queue;
+    thread->cb_resume_queue = NULL;
+    pthread_mutex_unlock(&thread->cb_recall_lock);
+
+    while (q) {
+        struct nfs4_cb_resume_ctx *ctx = q;
+        q = ctx->next;
+        ctx->resume(ctx->arg);
+        free(ctx);
+    }
+} /* nfs4_cb_drain_resume_queue */
+
 /*
  * Recall `holder` from the client that holds it, over that client's shared
  * callback channel.  A client with no usable channel cannot be asked to return
  * the layout, so it is revoked locally (which deregisters it and lets the
  * recall make progress).  `holder` is pinned by the caller.
  */
-static void
+void
 nfs4_cb_recall_holder(
     struct chimera_server_nfs_thread *thread,
     struct nfs_layout_state          *holder)
 {
-    struct nfs_client         *client = holder->client;
-    struct nfs4_cb_recall_ctx *ctx;
-    struct stateid4            recall_stateid;
+    struct nfs_client                *client   = holder->client;
+    struct nfs4_cb_client            *chan     = client->cb_path.cb_client;
+    struct chimera_server_nfs_thread *cb_owner =
+        (chan && chan->session) ? chan->session->nfs4_session_backchannel_owner : NULL;
+    struct nfs4_cb_recall_ctx        *ctx;
+    struct stateid4                   recall_stateid;
+
+    /* The CB_LAYOUTRECALL rides the session's backchannel conn, owned by one
+     * thread's evpl (evpl sends are not cross-thread safe).  When a conflicting
+     * op recalls from a different thread, bounce to that conn's owner -- mirrors
+     * the delegation CB_RECALL path (nfs4_cb_recall_enqueue): pin the layout
+     * with a ref, queue it, ring the owner's cb_doorbell.  The drain re-enters
+     * this function on the owner thread (where the test below is false) and
+     * sends inline.  Note: the bounce target is the *backchannel conn's* owner
+     * (tracked on the session, repointed by CREATE_SESSION/BIND_CONN), NOT
+     * chan->owner_thread, which is fixed at channel-open and drifts from the
+     * conn.  If there is no backchannel the send below fails -> revoke. */
+    if (cb_owner && thread != cb_owner) {
+        nfs_layout_state_get(holder);
+        pthread_mutex_lock(&cb_owner->cb_recall_lock);
+        holder->recall_qnext            = cb_owner->cb_layoutrecall_queue;
+        cb_owner->cb_layoutrecall_queue = holder;
+        pthread_mutex_unlock(&cb_owner->cb_recall_lock);
+        evpl_ring_doorbell(&cb_owner->cb_doorbell);
+        return;
+    }
 
     nfs4_stateid_encode(&recall_stateid, holder->seqid, NFS4_STATEID_TYPE_LAYOUT,
                         holder->shard, holder->slot_idx, holder->generation,
@@ -96,19 +166,30 @@ chimera_nfs4_cb_recall_and_wait(
     void                             *resume_arg)
 {
     struct nfs_layout_recall_waiter *waiter;
+    struct nfs4_cb_resume_ctx       *rctx;
     struct nfs_layout_state         *holders[NFS4_CB_MAX_HOLDERS];
     int                              n, i;
 
+    /* The waiter's resume fires on whichever thread processes the final
+     * LAYOUTRETURN, not this one; wrap it so it bounces back to this (the
+     * deferred op's home) thread, where the op's request/iovecs are owned. */
+    rctx         = calloc(1, sizeof(*rctx));
+    rctx->resume = resume;
+    rctx->arg    = resume_arg;
+    rctx->origin = thread;
+
     waiter         = calloc(1, sizeof(*waiter));
-    waiter->resume = resume;
-    waiter->arg    = resume_arg;
+    waiter->resume = nfs4_cb_resume_bounce;
+    waiter->arg    = rctx;
 
     n = nfs_layout_table_recall_prepare(&thread->shared->nfs4_layout_table,
                                         fh, (uint16_t) fhlen, waiter,
                                         holders, NFS4_CB_MAX_HOLDERS);
 
     if (n == 0) {
-        /* No layouts held for this file: nothing to recall, proceed now. */
+        /* No layouts held for this file: nothing to recall, proceed now (we are
+         * already on the deferred op's home thread). */
+        free(rctx);
         free(waiter);
         resume(resume_arg);
         return;

--- a/src/server/nfs/nfs4_cb.h
+++ b/src/server/nfs/nfs4_cb.h
@@ -28,3 +28,26 @@ chimera_nfs4_cb_recall_and_wait(
     uint32_t                          fhlen,
     void (                           *resume )(void *arg),
     void                             *resume_arg);
+
+/*
+ * Recall the layout `holder` from its client.  The CB_LAYOUTRECALL rides the
+ * client's backchannel connection, which is owned by a single thread's evpl
+ * (evpl sends are not cross-thread safe).  When called off that owner thread,
+ * this self-bounces: it pins `holder` with a ref, queues it on the owner's
+ * cb_layoutrecall_queue, and rings cb_doorbell -- the doorbell drain re-enters
+ * this function on the owner thread and sends inline.  `holder` is pinned by
+ * the caller across the call.
+ */
+struct nfs_layout_state;
+void
+nfs4_cb_recall_holder(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_layout_state          *holder);
+
+/*
+ * Run deferred-operation resumes that were bounced to `thread` (their home
+ * thread) by nfs4_cb_resume_bounce.  Called from the cb_doorbell drain.
+ */
+void
+nfs4_cb_drain_resume_queue(
+    struct chimera_server_nfs_thread *thread);

--- a/src/server/nfs/nfs4_proc_bind_conn_to_session.c
+++ b/src/server/nfs/nfs4_proc_bind_conn_to_session.c
@@ -88,6 +88,9 @@ chimera_nfs4_bind_conn_to_session(
          * delegation recall that was stuck with no live backchannel (RFC 8881
          * §20.4.1; the same path CREATE_SESSION uses for DSESS9003). */
         session->nfs4_session_backchannel_conn = req->conn;
+        /* This compound runs on req->conn's owner thread; record it so
+         * cross-thread callbacks marshal their send to the new owner. */
+        session->nfs4_session_backchannel_owner = thread;
         nfs4_cb_resend_recalls_on_rebind(thread, session->client_unified, req);
     }
 

--- a/src/server/nfs/nfs4_proc_create_session.c
+++ b/src/server/nfs/nfs4_proc_create_session.c
@@ -194,6 +194,9 @@ chimera_nfs4_create_session(
     if (args->csa_flags & CREATE_SESSION4_FLAG_CONN_BACK_CHAN) {
         session->nfs4_session_cb_program       = args->csa_cb_program;
         session->nfs4_session_backchannel_conn = conn;
+        /* This compound runs on conn's owner thread; record it so cross-thread
+         * callbacks (CB_RECALL / CB_LAYOUTRECALL) marshal their send here. */
+        session->nfs4_session_backchannel_owner = thread;
 
         nfs4_client_set_cb_path(&shared->nfs4_shared_clients,
                                 args->csa_clientid,

--- a/src/server/nfs/nfs4_session.h
+++ b/src/server/nfs/nfs4_session.h
@@ -177,30 +177,30 @@ struct nfs4_exchange_id_result {
 
 struct nfs4_session {
     /* magic MUST be the first member -- see NFS4_SESSION_MAGIC comment. */
-    uint32_t                 magic;
+    uint32_t                          magic;
     /* Cached pointer to the owning client's unified state hierarchy.  Set
      * at session creation; cleared at table teardown (when the unified
      * client is destroyed).  Borrowed reference: lifetime matches the
      * nfs4_client this session belongs to. */
-    struct nfs_client       *client_unified;
-    _Atomic uint32_t         refcount;
-    _Atomic bool             destroyed;
-    uint8_t                  nfs4_session_id[NFS4_SESSIONID_SIZE];
-    uint64_t                 nfs4_session_clientid;
-    uint32_t                 nfs4_session_implicit;
-    struct nfs4_client      *nfs4_session_client;
-    struct channel_attrs4    nfs4_session_fore_attrs;
-    struct channel_attrs4    nfs4_session_back_attrs;
-    uint32_t                 nfs4_session_fore_attrs_rdma_ird;
-    uint32_t                 nfs4_session_back_attrs_rdma_ird;
+    struct nfs_client                *client_unified;
+    _Atomic uint32_t                  refcount;
+    _Atomic bool                      destroyed;
+    uint8_t                           nfs4_session_id[NFS4_SESSIONID_SIZE];
+    uint64_t                          nfs4_session_clientid;
+    uint32_t                          nfs4_session_implicit;
+    struct nfs4_client               *nfs4_session_client;
+    struct channel_attrs4             nfs4_session_fore_attrs;
+    struct channel_attrs4             nfs4_session_back_attrs;
+    uint32_t                          nfs4_session_fore_attrs_rdma_ird;
+    uint32_t                          nfs4_session_back_attrs_rdma_ird;
     /* NFS4.1 SEQUENCE replay cache (per-session slot table).  Distinct
      * mechanism from the 4.0 per-owner replay in nfs_open_owner.replay /
      * nfs_lock_owner.replay -- the two coexist by minor version.  Implicit
      * sessions (4.0 SETCLIENTID path) leave replay_max_slots = 0. */
-    uint32_t                 replay_max_slots;
-    uint32_t                 replay_maxresp_cached;
-    _Atomic size_t           replay_bytes_in_use;
-    struct nfs4_replay_slot *replay_slots;
+    uint32_t                          replay_max_slots;
+    uint32_t                          replay_maxresp_cached;
+    _Atomic size_t                    replay_bytes_in_use;
+    struct nfs4_replay_slot          *replay_slots;
     /* NFSv4.1 backchannel for delegation recalls (RFC 8881 §2.10.3.1).
      * Set at CREATE_SESSION when CREATE_SESSION4_FLAG_CONN_BACK_CHAN is
      * requested: cb_program is the client's callback program number and
@@ -208,9 +208,14 @@ struct nfs4_session {
      * which doubles as the server->client callback transport.  The conn is
      * a borrowed pointer kept live by the session<->conn binding; it is
      * cleared by nfs4_session_unbind_conn on disconnect. */
-    uint32_t                 nfs4_session_cb_program;
-    struct evpl_rpc2_conn   *nfs4_session_backchannel_conn;
-    struct UT_hash_handle    nfs4_session_hh;
+    uint32_t                          nfs4_session_cb_program;
+    struct evpl_rpc2_conn            *nfs4_session_backchannel_conn;
+    /* The thread that owns nfs4_session_backchannel_conn's evpl (set whenever
+     * the backchannel conn is (re)assigned, on that conn's own handler thread).
+     * Callbacks must be sent from this thread -- evpl sends are not cross-thread
+     * safe -- so cross-thread recalls marshal to it (nfs4_cb_recall_holder). */
+    struct chimera_server_nfs_thread *nfs4_session_backchannel_owner;
+    struct UT_hash_handle             nfs4_session_hh;
 };
 
 struct nfs4_client_table {

--- a/src/server/nfs/nfs4_state.h
+++ b/src/server/nfs/nfs4_state.h
@@ -458,6 +458,10 @@ struct nfs_layout_state {
 
     UT_hash_handle           hh;        /* by fh in client->layouts_by_fh */
 
+    /* Link on an owner thread's cb_layoutrecall_queue while a CB_LAYOUTRECALL
+     * is being marshalled cross-thread (see nfs4_cb_recall_holder). */
+    struct nfs_layout_state *recall_qnext;
+
     _Atomic uint32_t         refcount;
     _Atomic uint8_t          destroyed;
 };

--- a/src/server/nfs/nfs_common.h
+++ b/src/server/nfs/nfs_common.h
@@ -308,6 +308,14 @@ struct chimera_server_nfs_thread {
     struct evpl_doorbell              cb_doorbell;
     pthread_mutex_t                   cb_recall_lock;
     struct nfs_delegation            *cb_recall_queue; /* via deleg->recall_qnext */
+    /* Cross-thread pNFS CB_LAYOUTRECALL marshalling (same rationale as
+     * cb_recall_queue, but for layout holders).  Via layout->recall_qnext. */
+    struct nfs_layout_state          *cb_layoutrecall_queue;
+    /* Deferred-op resumes bounced back to their home thread: a layout recall
+     * completes (LAYOUTRETURN) on the backchannel owner thread, but the deferred
+     * op's request/iovecs are owned by the thread that received it.  See
+     * nfs4_cb_resume_bounce / nfs4_cb_drain_resume_queue in nfs4_cb.c. */
+    struct nfs4_cb_resume_ctx        *cb_resume_queue;
     /* Cross-thread CB_GETATTR work (request to the deleg holder's thread, and
      * the response back to the requester's thread).  Protected by
      * cb_recall_lock and drained by cb_doorbell.  See nfs4_callback.c. */

--- a/src/server/nfs/tests/CMakeLists.txt
+++ b/src/server/nfs/tests/CMakeLists.txt
@@ -26,7 +26,8 @@ add_executable(test_replay_slot
     ${CMAKE_CURRENT_SOURCE_DIR}/../nfs4_layout_table.c
     ${CMAKE_CURRENT_SOURCE_DIR}/../nfs4_lease.c
     ${CMAKE_CURRENT_SOURCE_DIR}/../nfs4_recovery.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/../nfs4_callback.c)
+    ${CMAKE_CURRENT_SOURCE_DIR}/../nfs4_callback.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/../nfs4_cb.c)
 target_include_directories(test_replay_slot PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/..
     ${CMAKE_SOURCE_DIR}/src

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -79,6 +79,8 @@ struct chimera_server_config {
     int                                   smb_signing_required;
     int                                   smb_encryption;
     int                                   smb_compression;
+    int                                   smb_leases;
+    int                                   smb_oplocks;
     int                                   smb_notify_disabled;
     int                                   smb_acl_inherited_canonicalize;
     int                                   smb_num_nic_info;
@@ -179,6 +181,14 @@ chimera_server_config_init(void)
     /* SMB3 transport compression is off by default; the "smb_compression" flag
      * enables (1) advertising/using it. */
     config->smb_compression = 0;
+
+    /* SMB2 leases (RqLs) and legacy SMB oplocks are off by default: the server
+     * grants neither, so clients run uncached (every op hits the server) and no
+     * lease/oplock break can stall a conflicting open.  Opt in via the
+     * "smb_leases" / "smb_oplocks" config flags; the smbtorture and WPTS test
+     * harnesses enable them to exercise the leasing/oplock suites. */
+    config->smb_leases  = 0;
+    config->smb_oplocks = 0;
 
     /* CHANGE_NOTIFY is enabled by default; the "smb_notify_disabled" flag makes
      * the server reject CHANGE_NOTIFY with STATUS_NOT_IMPLEMENTED. */
@@ -397,6 +407,34 @@ chimera_server_config_get_smb_compression(const struct chimera_server_config *co
 {
     return config->smb_compression;
 } /* chimera_server_config_get_smb_compression */
+
+SYMBOL_EXPORT void
+chimera_server_config_set_smb_leases(
+    struct chimera_server_config *config,
+    int                           enabled)
+{
+    config->smb_leases = enabled;
+} /* chimera_server_config_set_smb_leases */
+
+SYMBOL_EXPORT int
+chimera_server_config_get_smb_leases(const struct chimera_server_config *config)
+{
+    return config->smb_leases;
+} /* chimera_server_config_get_smb_leases */
+
+SYMBOL_EXPORT void
+chimera_server_config_set_smb_oplocks(
+    struct chimera_server_config *config,
+    int                           enabled)
+{
+    config->smb_oplocks = enabled;
+} /* chimera_server_config_set_smb_oplocks */
+
+SYMBOL_EXPORT int
+chimera_server_config_get_smb_oplocks(const struct chimera_server_config *config)
+{
+    return config->smb_oplocks;
+} /* chimera_server_config_get_smb_oplocks */
 
 SYMBOL_EXPORT void
 chimera_server_config_set_smb_notify_disabled(

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -120,6 +120,24 @@ chimera_server_config_get_smb_compression(
     const struct chimera_server_config *config);
 
 void
+chimera_server_config_set_smb_leases(
+    struct chimera_server_config *config,
+    int                           enabled);
+
+int
+chimera_server_config_get_smb_leases(
+    const struct chimera_server_config *config);
+
+void
+chimera_server_config_set_smb_oplocks(
+    struct chimera_server_config *config,
+    int                           enabled);
+
+int
+chimera_server_config_get_smb_oplocks(
+    const struct chimera_server_config *config);
+
+void
 chimera_server_config_set_smb_notify_disabled(
     struct chimera_server_config *config,
     int                           disabled);

--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -151,6 +151,8 @@ chimera_smb_server_init(
     shared->config.signing_required           = chimera_server_config_get_smb_signing_required(config);
     shared->config.encryption                 = chimera_server_config_get_smb_encryption(config);
     shared->config.compression                = chimera_server_config_get_smb_compression(config);
+    shared->config.leases                     = chimera_server_config_get_smb_leases(config);
+    shared->config.oplocks                    = chimera_server_config_get_smb_oplocks(config);
     shared->config.notify_disabled            = chimera_server_config_get_smb_notify_disabled(config);
     shared->config.acl_inherited_canonicalize = chimera_server_config_get_smb_acl_inherited_canonicalize(config);
 

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -193,6 +193,11 @@ struct chimera_smb_config {
     /* SMB3 transport compression: 0 = off (no compression advertised),
      * 1 = enabled (offered, used when the client opts in). */
     int                            compression;
+    /* SMB2 leases (RqLs) and legacy SMB oplocks: 0 = the server grants none
+     * (clients run uncached, so no caching break can stall a conflicting open),
+     * 1 = grant on request.  Both default off; opt in via smb_leases/smb_oplocks. */
+    int                            leases;
+    int                            oplocks;
     /* When set, CHANGE_NOTIFY is disabled for the server's shares: the
      * handler returns STATUS_NOT_IMPLEMENTED immediately instead of arming
      * a watch (the "change notify = no" share behaviour Windows exposes;

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -729,8 +729,15 @@ chimera_smb_create_after_share(
 
         if (request->create.ctx_present_mask & CHIMERA_SMB_CREATE_CTX_RQLS) {
             via_rqls = true;
-            req_smb  = (uint8_t) (request->create.rqls.state & 0x07);
-        } else {
+            /* SMB2 leases are opt-in (smb_leases).  When disabled, grant no
+             * caching bits: via_rqls stays set so the open still reports a lease
+             * with state NONE (the existing bare-RqLs path), but nothing is
+             * cached, so no lease break can ever stall a conflicting open. */
+            req_smb = thread->shared->config.leases
+                ? (uint8_t) (request->create.rqls.state & 0x07) : 0;
+        } else if (thread->shared->config.oplocks) {
+            /* Legacy SMB oplocks are opt-in (smb_oplocks); when disabled no
+             * oplock is granted (req_smb stays 0 -> reply OPLOCK_LEVEL_NONE). */
             switch (request->create.requested_oplock_level) {
                 case SMB2_OPLOCK_LEVEL_II:
                     req_smb = SMB2_LEASE_READ_CACHING;

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -304,6 +304,7 @@ chimera_smb_create_break_for_open(
     if (request->create.ctx_present_mask & CHIMERA_SMB_CREATE_CTX_RQLS) {
         memcpy(&io_owner.owner_lo, request->create.rqls.key, 8);
         memcpy(&io_owner.owner_hi, request->create.rqls.key + 8, 8);
+        io_owner.is_lease = 1;
     }
 
     if (phase == 1) {

--- a/src/server/smb/smb_proc_oplock_break.c
+++ b/src/server/smb/smb_proc_oplock_break.c
@@ -302,6 +302,22 @@ chimera_smb_lease_break_cb(
         open_file->oplock_level = new_level;
     }
 
+    /* A break that needs no client ack (it stripped only read caching, e.g. the
+     * R->NONE tail of an RWH->RH->R->NONE cascade) will never be resolved by an
+     * inbound OPLOCK_BREAK ack, so the ack-driven resume of parked CREATEs
+     * (chimera_smb_create_resume_parked, only called from the ack handler) never
+     * fires for it.  But the lease is now at its retained level, so
+     * chimera_vfs_state_caching_breaking() returns false and any CREATE parked on
+     * this file is resumable.  Ring the resume doorbell on this thread AND every
+     * peer (the broadcast skips its origin) so each re-sweeps and completes its
+     * parked CREATEs instead of stalling to the break deadline (cthon special
+     * hang). */
+    if (!grant->break_ack_required) {
+        struct chimera_server_smb_thread *rt = open_file->create_conn->thread;
+        evpl_ring_doorbell(&rt->lease_resume_doorbell);
+        chimera_smb_create_resume_parked_broadcast(rt);
+    }
+
     /* The lease stays BREAKING (awaiting the client's real OPLOCK_BREAK ack or
      * close); the conflict matrix treats a BREAKING SMB lease as already at its
      * retained (break_needed_mode) level, so a coexisting acquirer proceeds

--- a/src/server/smb/tests/smbtorture_test.c
+++ b/src/server/smb/tests/smbtorture_test.c
@@ -272,6 +272,14 @@ main(
      * pointer NULL and then dereferences it in cleanup, crashing the client. */
     chimera_server_config_set_smb_persistent_handles(config, 1);
 
+    /* SMB2 leases and legacy oplocks are off by default in the server; enable
+     * both here so the leasing/oplock smbtorture suites (smb2.lease*,
+     * smb2.oplock*, plus durable/multichannel cases that ride a lease) exercise
+     * the caching grant + break path.  Suites that request neither are
+     * unaffected by the grant being available. */
+    chimera_server_config_set_smb_leases(config, 1);
+    chimera_server_config_set_smb_oplocks(config, 1);
+
     /* SMB3 multichannel: advertise interfaces so FSCTL_QUERY_NETWORK_INTERFACE_
      * INFO returns a non-empty list and the smb2.multichannel suites run instead
      * of bailing ("no interface info returned").  Everything in the test netns

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -2602,10 +2602,15 @@ memfs_open_at(
             return;
         }
 
-        /* O_NOFOLLOW: a creating open that resolves to an existing symlink as
-         * the final component must fail with ELOOP rather than open the link.
+        /* A symlink as the final component under O_NOFOLLOW: a *data* open
+         * (POSIX open(O_NOFOLLOW)) must fail with ELOOP, but an O_PATH-style
+         * open (SMB FILE_OPEN_REPARSE_POINT, i.e. O_PATH|O_NOFOLLOW) wants a
+         * handle to the link itself so the caller can read its attributes /
+         * security descriptor / reparse data -- so fall through and open the
+         * symlink inode in that case (mirrors the linux backend's O_PATH retry).
          * memfs_inode_get_inum() returned the inode locked, so release both. */
-        if (S_ISLNK(inode->mode) && (flags & CHIMERA_VFS_OPEN_NOFOLLOW)) {
+        if (S_ISLNK(inode->mode) && (flags & CHIMERA_VFS_OPEN_NOFOLLOW) &&
+            !(flags & CHIMERA_VFS_OPEN_PATH)) {
             pthread_mutex_unlock(&inode->lock);
             pthread_mutex_unlock(&parent_inode->lock);
             request->status = CHIMERA_VFS_ELOOP;

--- a/src/vfs/nfs/nfs4_pnfs.c
+++ b/src/vfs/nfs/nfs4_pnfs.c
@@ -1302,9 +1302,22 @@ chimera_nfs4_pnfs_ds_write(
     args.offset         = request->write.offset;
     args.count          = request->write.length;
     args.stable         = request->write.sync;
-    args.data.iov       = request->write.iov;
-    args.data.niov      = request->write.niov;
-    args.data.length    = request->write.length;
+    /* The DS WRITE3 marshaller MOVES (consumes + frees) the payload iovecs into
+     * the outgoing RPC message.  Our payload is BORROWED from the NFS server
+     * layer -- request->write.iov aliases the WRITE4 args, which
+     * chimera_nfs4_write_complete releases on our completion -- so hand the
+     * marshaller CLONES (each takes its own buffer ref, dropped when the DS RPC
+     * message is released) and leave the borrowed originals intact.  Passing the
+     * originals lets the marshaller free them out from under that server-side
+     * release -> heap-use-after-free in evpl_iovecs_release. */
+    struct evpl_iovec *ds_iov = malloc((size_t) request->write.niov *
+                                       sizeof(*ds_iov));
+    for (int i = 0; i < request->write.niov; i++) {
+        evpl_iovec_clone(&ds_iov[i], &request->write.iov[i]);
+    }
+    args.data.iov    = ds_iov;
+    args.data.niov   = request->write.niov;
+    args.data.length = request->write.length;
 
     chimera_nfs_init_rpc2_cred(&rpc2_cred, request->cred,
                                request->thread->vfs->machine_name,
@@ -1313,6 +1326,9 @@ chimera_nfs4_pnfs_ds_write(
     shared->nfs_v3.send_call_NFSPROC3_WRITE(
         &shared->nfs_v3.rpc2, thread->evpl, ds_thread->nfs_conn, &rpc2_cred,
         &args, 1, 0, NULL, 0, 0, chimera_nfs4_pnfs_ds_write_callback, request);
+
+    /* The marshaller moved (and invalidated) the clones; free only the array. */
+    free(ds_iov);
     return 1;
 } /* chimera_nfs4_pnfs_ds_write */
 

--- a/src/vfs/vfs_lease_types.h
+++ b/src/vfs/vfs_lease_types.h
@@ -96,6 +96,12 @@ struct chimera_vfs_lease_owner {
     uint64_t                        client_key;
     uint64_t                        owner_lo;
     uint64_t                        owner_hi;
+    /* True when this actor holds/requests an SMB2 RqLs lease (owner_lo/hi carry
+     * the 16-byte LeaseKey).  False for a plain open (owner_lo/hi carry the
+     * file_id) and for non-SMB actors.  Lets a same-client *non-lease* open skip
+     * recalling that client's own caching lease in break_caching_for_open, while
+     * a 2nd LeaseKey from the same client still breaks (MS-SMB2 SameLeaseKey). */
+    uint8_t                         is_lease;
     chimera_vfs_lease_break_cb_t    break_cb;
     chimera_vfs_lease_is_alive_cb_t is_alive_cb;
     chimera_vfs_lease_revoked_cb_t  revoked_cb;

--- a/src/vfs/vfs_state.c
+++ b/src/vfs/vfs_state.c
@@ -2124,6 +2124,25 @@ chimera_vfs_state_break_caching_for_open(
         if (chimera_vfs_lease_smb2_same_key(&cur->owner, opener)) {
             continue;
         }
+        /* A *non-lease* open by the SAME client must not recall that client's own
+         * RqLs lease.  The opening client is internally coherent with its own
+         * (non-data) open, so a server-driven break here is spurious -- and the
+         * Linux SMB client cannot ack a break for a lease its new plain handle
+         * does not own, so the break goes unacked, the lease is stuck BREAKING,
+         * and every such open then stalls the full break-deadline (cthon special
+         * hang).  Coherence on an actual write is preserved by the untouched
+         * chimera_vfs_break_on_write path -- so this suppresses ONLY the open
+         * break, never the write break (the over-broad earlier suppression of the
+         * write break served stale reads and was reverted).  A *lease* opener with
+         * a different key (2nd LeaseKey, same client) still breaks here, as
+         * MS-SMB2 Leasing_*_SameLeaseKey / smb2.lease.complex1 require. */
+        if (opener->protocol == CHIMERA_VFS_LEASE_PROTO_SMB2 &&
+            cur->owner.protocol == CHIMERA_VFS_LEASE_PROTO_SMB2 &&
+            !opener->is_lease &&
+            opener->client_key == cur->owner.client_key &&
+            cur->grant && !cur->grant->is_oplock) {
+            continue;
+        }
         /* A pure handle-trigger break (the pre-share-check pass) is a legacy SMB
          * oplock behavior: a batch oplock's handle is recalled before the share
          * decision so the holder can close.  An SMB2 RqLs LEASE keeps its handle


### PR DESCRIPTION
Three fixes surfaced bringing the KVM SMB/pNFS suites green under the new merge queue.

## SMB lease over-break + memfs symlink reparse (commit 1)
- **memfs**: open a symlink final component under `O_PATH|NOFOLLOW` (SMB `FILE_OPEN_REPARSE_POINT`) instead of returning `ELOOP`, so the client can read the link's security descriptor (fixes cthon `basic` on memfs).
- **vfs_state**: don't break a client's own RqLs caching lease for that same client's *non-lease* open (an `is_lease` actor flag distinguishes a second LeaseKey, which still breaks). The write/SET_INFO break path is untouched, so data coherence holds (fsx clean).
- **smb**: resume a CREATE parked on a no-ack (R→NONE) lease-break tail instead of stalling to the break deadline.

## pNFS proxy: write UAF + cross-thread layout recall/resume (commit 2)
The NFSv4.1 pNFS proxy crashed (ASan) on every forwarded write and every layout recall, so `kvm/pnfs/proxy_*` timed out:
- **ds_write**: the proxy handed the guest's WRITE4 payload iovecs to the DS WRITE3 marshaller, which MOVEs (frees) them, double-freeing the buffers the NFS server layer releases on completion. Clone the borrowed iovecs for the DS call.
- **CB_LAYOUTRECALL**: was sent inline on the calling thread, but the session backchannel conn is owned by another thread (evpl sends aren't cross-thread safe). Track the backchannel conn's owner on the session and marshal the recall there via `cb_doorbell`, mirroring delegation recall.
- **deferred-op resume**: after the layout returns, the deferred op resumed on the LAYOUTRETURN thread, not its home thread, faulting on its iovecs. Bounce the resume back to the originating thread.

## SMB leases/oplocks config gate, default off (commit 3)
SMB2 leases (RqLs) and legacy oplocks are now opt-in (`smb_leases` / `smb_oplocks`), off by default, mirroring `nfs4_delegations`. With them off the server grants no client-side caching, so a lease/oplock break can never stall a conflicting open — this resolves the cthon `special_*` hang on every backend (the non-lease open that used to self-break a just-granted lease no longer has a lease to break). The smbtorture harness and WPTS wrapper enable both so the `smb2.lease*` / `smb2.oplock*` + durable/oplock-break suites still exercise the grant + break path.

Validated on KVM (cthon basic/general/special + fsx pass on memfs/linux/io_uring/diskfs/cairn with leases off) and netns (1739 smbtorture + WPTS + SMB unit tests green with the opt-in; pynfs delegation clean).