### PR TITLE
smb2: fix flaky CHANGE_NOTIFY timeout when watched dir is deleted before arm

### DIFF
--- a/src/server/smb/smb_proc_change_notify.c
+++ b/src/server/smb/smb_proc_change_notify.c
@@ -144,6 +144,25 @@ chimera_smb_change_notify(struct chimera_smb_request *request)
 
     nevents = chimera_vfs_notify_drain(state->watch, events, 16, &overflowed);
 
+    /* The watched directory may already have been removed (rmdir / delete-
+     * on-close from another handle or connection) before this CHANGE_NOTIFY
+     * was armed.  chimera_vfs_notify_emit_delete records that on the watch
+     * via the deleted flag and fires the callback, but if that callback ran
+     * before we installed state->pending (a cross-connection race —
+     * smb2.notify.rmdir3/4 send the CHANGE_NOTIFY and the rmdir without
+     * waiting for the interim reply) the wakeup is lost and the request
+     * would park forever, never completing.  Check the flag here under
+     * state->lock — atomic against the callback, exactly as the async
+     * send_response path does — and complete immediately with
+     * STATUS_DELETE_PENDING.  DELETE takes precedence over any buffered
+     * events, matching MS-SMB2 3.3.4.4 and the send_response classification. */
+    if (chimera_vfs_notify_watch_take_deleted(state->watch)) {
+        pthread_mutex_unlock(&state->lock);
+        chimera_smb_open_file_release(request, open_file);
+        chimera_smb_complete_request(request, SMB2_STATUS_DELETE_PENDING);
+        return;
+    }
+
     /* Re-filter drained events against this request's filter — the
      * watch's mask may have been broader when these were enqueued
      * (see same logic in the async send_response path).  Done under


### PR DESCRIPTION
## Summary

Fixes the intermittent CI timeout in `smbtorture_smb2_notify_memfs`:

```
Test #1499: chimera/server/smb/smbtorture_smb2_notify_memfs ...***Timeout 600.11 sec
```

The hang is in **`smb2.notify.rmdir3` / `rmdir4`** — the only notify subtests that delete a watched directory from a *second connection*. They send `CHANGE_NOTIFY` asynchronously and then rmdir/delete-on-close the dir from another tree **without waiting for the interim `STATUS_PENDING`** (samba `source4/torture/smb2/notify.c`), expecting `STATUS_DELETE_PENDING`.

## Root cause

When a watched directory is removed, `chimera_vfs_notify_emit_delete` sets `watch->deleted = 1` and fires the watch callback. The async delivery path (`chimera_smb_notify_do_send_response`) consults that flag via `chimera_vfs_notify_watch_take_deleted()` — **but the arm path (`chimera_smb_change_notify`) never did.**

So in the window after the watch is created but before the arm installs `state->pending`, the deletion callback (running on the second connection's thread) observes `pending == NULL` and no-ops. The arm then parks the request without checking `deleted`, so the parked `CHANGE_NOTIFY` never completes → the client blocks → 600s timeout. The outcome depends on scheduling between the two connections' threads, which is why it only fails under load. Single-connection `rmdir1/2` are immune because both operations serialize on one thread.

This matches the failure log exactly: server alive, no crash, two connections established and never disconnected.

## Fix

After the drain and under `state->lock`, check `watch->deleted` and complete with `STATUS_DELETE_PENDING`, mirroring what `do_send_response` already does. The lock order (`state->lock → watch->lock`) matches the adjacent `notify_drain` call, so there is no inversion.

## Verification

Reproduced deterministically by widening the race with a temporary `usleep(100000)` before the park:

- fix disabled + widener: `rmdir3` and `rmdir4` both **time out** (reproduces the hang)
- fix enabled + widener: both pass in **0.5s**

With scaffolding removed, all `smb2.notify.*_memfs` subtests pass (the ~72s `mask` test is the legitimately-slow run that appears as the long gap in the CI log, not a hang), and `rmdir3/4` ran 20× under parallel load with no failures. `uncrustify` made no changes.