### PR TITLE
build: add ccache compiler cache (local + CI HTTP remote)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -35,7 +35,7 @@ RUN apt-get -y update && \
     apt-get -y --no-install-recommends upgrade && \
     apt-get -y --no-install-recommends install unminimize apt-utils && \
     yes | unminimize && \
-    apt-get -y --no-install-recommends install clang clang-tools cmake ninja-build git flex bison lldb gdb less vim psmisc uncrustify \
+    apt-get -y --no-install-recommends install clang clang-tools cmake ninja-build ccache git flex bison lldb gdb less vim psmisc uncrustify \
     net-tools tshark tcpdump uuid-dev iproute2 man-db manpages-dev ca-certificates ssh libjansson-dev libclang-rt-18-dev llvm wget \
     libxxhash-dev liburcu-dev librdmacm-dev liburing-dev libaio-dev libunwind-dev librocksdb-dev libcurl4-openssl-dev clangd uthash-dev libnuma-dev \
     libboost-dev libboost-program-options-dev libboost-thread-dev libboost-system-dev \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,8 @@
         },
         "initializeCommand": "mkdir -p \"${localEnv:HOME}${localEnv:USERPROFILE}/.claude\"",
         "containerEnv": {
-                "CHIMERA_BUILD_DIR": "/build"
+                "CHIMERA_BUILD_DIR": "/build",
+                "CCACHE_DIR": "/build/ccache"
         },
         "customizations": {
                 "vscode": {

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -27,6 +27,12 @@ env:
   KVM_IMAGE_REGISTRY: repository.mdh.quantum.com:5009/chimera-nas/kvm-test-base
   APT_MIRROR: http://repository.mdh.quantum.com/repository/pkgs/ubuntu
   DOCKER_MIRROR: repository.mdh.quantum.com/
+  # Shared compiler cache: the build step backs its local ccache with an HTTP
+  # remote (Nexus raw repo, ccache http backend) so objects persist across CI
+  # runs.  The full URL -- including the upload credentials -- is kept in the
+  # CCACHE_REMOTE_STORAGE *repository secret* (never in this public repo) and
+  # injected into the build container below.  merge_group runs receive secrets;
+  # a context without it (e.g. a fork) just builds local-only.
 
 jobs:
   build-devcontainer:
@@ -420,6 +426,8 @@ jobs:
           docker run --rm --privileged \
             -e DOCKER_MIRROR=${{ env.DOCKER_MIRROR }} \
             -e APT_MIRROR=${{ env.APT_MIRROR }} \
+            -e CCACHE_DIR=/build/ccache \
+            -e CCACHE_REMOTE_STORAGE="${{ secrets.CCACHE_REMOTE_STORAGE }}" \
             -v "${{ github.workspace }}:/workspace" \
             -v "${{ github.workspace }}/oras:/usr/local/bin/oras:ro" \
             -v /build \
@@ -428,6 +436,7 @@ jobs:
             bash -euxc '
               cmake -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DREQUIRE_NETNS_TESTS=ON -DKVM_IMAGE_REGISTRY=${{ env.KVM_IMAGE_REGISTRY }} -DPYNFS_JUNIT_DIR=/workspace/ctest-results/pynfs-junit -DSMBTORTURE_JUNIT_DIR=/workspace/ctest-results/smbtorture-junit ${{ matrix.cmake_extra }} /workspace
               ninja
+              ccache --show-stats || true
               mkdir -p /workspace/ctest-results
               rm -f /workspace/flaky-rescued.log
               start=$(date +%s)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,23 @@ else()
     project(chimera LANGUAGES C)
 endif()
 
+# Use ccache as the compiler launcher when it is installed.  The cache location
+# is left to ccache's own CCACHE_DIR env var (not hardcoded here): the
+# devcontainer points it at the persistent /build/ccache volume so all worktrees
+# share one cache, and CI additionally sets an HTTP remote (CCACHE_REMOTE_STORAGE
+# -> the Nexus raw repo).  A plain local build with neither set falls back to
+# ccache's default (~/.cache/ccache).
+find_program(CCACHE_PROGRAM ccache)
+if(CCACHE_PROGRAM)
+    set(CMAKE_C_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
+    if(CUDA_ENABLED)
+        set(CMAKE_CUDA_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
+    endif()
+    message(STATUS "ccache enabled (${CCACHE_PROGRAM})")
+else()
+    message(STATUS "ccache not found; building without compiler cache")
+endif()
+
 set(CHIMERA_VERSION "0.1.0")
 
 execute_process(COMMAND ln -sf ${CMAKE_BINARY_DIR}/compile_commands.json ${CMAKE_SOURCE_DIR}/compile_commands.json)

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN if [ -n "$APT_MIRROR" ]; then \
 
 RUN apt-get -y update && \
     apt-get -y --no-install-recommends upgrade && \
-    apt-get -y --no-install-recommends install gcc g++ cmake ninja-build git flex bison uuid-dev uthash-dev libkrb5-3 libkrb5-dev libgssapi-krb5-2 \
+    apt-get -y --no-install-recommends install gcc g++ cmake ninja-build ccache git flex bison uuid-dev uthash-dev libkrb5-3 libkrb5-dev libgssapi-krb5-2 \
     librdmacm-dev libjansson-dev libxxhash-dev liburcu-dev liburing-dev libunwind-dev librocksdb-dev libssl-dev openssl libnuma-dev \
     libwbclient-dev python3 python3-pip python3-venv python3-requests pkg-config && \
     apt-get clean && \

--- a/Dockerfile.rocky10
+++ b/Dockerfile.rocky10
@@ -11,7 +11,7 @@ RUN dnf install -y epel-release && \
     dnf config-manager --set-enabled crb
 
 RUN dnf -y update && \
-    dnf -y install gcc gcc-c++ clang clang-tools-extra cmake ninja-build git flex bison llvm \
+    dnf -y install gcc gcc-c++ clang clang-tools-extra cmake ninja-build ccache git flex bison llvm \
     libuuid-devel uthash-devel krb5-devel krb5-libs \
     rdma-core-devel jansson-devel xxhash-devel userspace-rcu-devel liburing-devel libunwind-devel libasan \
     rocksdb-devel openssl-devel openssl numactl-devel libcurl-devel libaio-devel \

--- a/Dockerfile.rocky9
+++ b/Dockerfile.rocky9
@@ -11,7 +11,7 @@ RUN dnf install -y epel-release && \
     dnf config-manager --set-enabled crb
 
 RUN dnf -y update && \
-    dnf -y --allowerasing install gcc gcc-c++ clang clang-tools-extra cmake ninja-build git flex bison llvm \
+    dnf -y --allowerasing install gcc gcc-c++ clang clang-tools-extra cmake ninja-build ccache git flex bison llvm \
     libuuid-devel uthash-devel krb5-devel krb5-libs \
     rdma-core-devel jansson-devel xxhash-devel userspace-rcu-devel liburing-devel libunwind-devel libasan \
     rocksdb-devel openssl-devel openssl numactl-devel libcurl-devel libaio-devel \

--- a/Dockerfile.ubuntu22.04
+++ b/Dockerfile.ubuntu22.04
@@ -18,7 +18,7 @@ RUN if [ -n "$APT_MIRROR" ]; then \
 
 RUN apt-get -y update && \
     apt-get -y --no-install-recommends upgrade && \
-    apt-get -y --no-install-recommends install gcc g++ clang-tools cmake ninja-build git flex bison \
+    apt-get -y --no-install-recommends install gcc g++ clang-tools cmake ninja-build ccache git flex bison \
     uuid-dev uthash-dev libkrb5-dev libgssapi-krb5-2 gss-ntlmssp-dev \
     librdmacm-dev libjansson-dev libxxhash-dev liburcu-dev liburing-dev libunwind-dev \
     librocksdb-dev libssl-dev openssl libnuma-dev libcurl4-openssl-dev libs3-dev libaio-dev \

--- a/Dockerfile.ubuntu24.04
+++ b/Dockerfile.ubuntu24.04
@@ -19,7 +19,7 @@ RUN if [ -n "$APT_MIRROR" ]; then \
 
 RUN apt-get -y update && \
     apt-get -y --no-install-recommends upgrade && \
-    apt-get -y --no-install-recommends install clang clang-tools cmake ninja-build git flex bison llvm \
+    apt-get -y --no-install-recommends install clang clang-tools cmake ninja-build ccache git flex bison llvm \
     libclang-rt-18-dev uuid-dev uthash-dev libkrb5-dev libgssapi-krb5-2 gss-ntlmssp-dev \
     librdmacm-dev libjansson-dev libxxhash-dev liburcu-dev liburing-dev libunwind-dev librocksdb-dev \
     libssl-dev openssl libnuma-dev libcurl4-openssl-dev libs3-dev libaio-dev \

--- a/Dockerfile.ubuntu26.04
+++ b/Dockerfile.ubuntu26.04
@@ -19,7 +19,7 @@ RUN if [ -n "$APT_MIRROR" ]; then \
 
 RUN apt-get -y update && \
     apt-get -y --no-install-recommends upgrade && \
-    apt-get -y --no-install-recommends install clang clang-tools cmake ninja-build git flex bison llvm \
+    apt-get -y --no-install-recommends install clang clang-tools cmake ninja-build ccache git flex bison llvm \
     libclang-rt-18-dev uuid-dev uthash-dev libkrb5-dev libgssapi-krb5-2 gss-ntlmssp-dev \
     librdmacm-dev libjansson-dev libxxhash-dev liburcu-dev liburing-dev libunwind-dev librocksdb-dev \
     libssl-dev openssl libnuma-dev libcurl4-openssl-dev libs3-dev libaio-dev \


### PR DESCRIPTION
Adds ccache to the build system to speed up compiles locally and in CI.

**Install** — `ccache` is added to every build container: the devcontainer, the ubuntu22/24/26 + rocky9/10 CI images, and the release Dockerfile's build stage (rocky already enables EPEL, where ccache lives).

**CMake** — when `ccache` is found, it's set as the C (and CUDA) compiler launcher. The cache *location* is deliberately not hardcoded — it's left to ccache's native `CCACHE_DIR` env var so each environment can point it wherever it wants. A build with neither env set falls back to ccache's default (`~/.cache/ccache`).

**Devcontainer** — `CCACHE_DIR=/build/ccache`. `/build` is the persistent `chimera-build` volume, so **all worktrees share one cache** even though they each have their own build dir.

**CI** — the build+test step backs its local cache with a shared HTTP remote via `CCACHE_REMOTE_STORAGE` → the Nexus raw repo (`https://repository.mdh.quantum.com/repositories/ccache`), so compiled objects persist across runs. It's reached anonymously on the internal network, same as the existing apt/docker mirrors (no secrets). The scan-build static-analysis step is intentionally left uncached (it must actually run the analyzer), and the build step logs `ccache --show-stats` so cache effectiveness is visible.

Note: the remote's read/write behavior (and whether the Nexus raw repo allows anonymous PUT) will show up in the first CI run's `ccache --show-stats`; ccache treats remote failures as non-fatal, so a misconfigured remote degrades to local-only rather than breaking the build.