### PR TITLE
smb2: fix CHANGE_NOTIFY hang when watched dir is deleted before the watch is armed

### DIFF
--- a/src/vfs/vfs_notify.c
+++ b/src/vfs/vfs_notify.c
@@ -658,6 +658,22 @@ chimera_vfs_notify_watch_create(
     bucket  = &notify->buckets[bi];
 
     pthread_mutex_lock(&bucket->lock);
+    /* If this object was removed in the brief window before this watch was
+     * created (emit_delete ran first and found no watch to flag), inherit
+     * that deletion now so the first drain reports STATUS_DELETE_PENDING
+     * rather than parking forever.  The watch is not yet linked, so setting
+     * deleted without watch->lock is safe — no other thread can see it. */
+    for (int t = 0; t < CHIMERA_VFS_NOTIFY_TOMBSTONE_COUNT; t++) {
+        struct chimera_vfs_notify_tombstone *ts = &bucket->tombstones[t];
+
+        if (ts->stamp &&
+            ts->fh_len == dir_fh_len &&
+            memcmp(ts->fh, dir_fh, dir_fh_len) == 0 &&
+            chimera_vfs_elapsed_ns(ts->stamp) < CHIMERA_VFS_NOTIFY_TOMBSTONE_NS) {
+            watch->deleted = 1;
+            break;
+        }
+    }
     watch->next     = bucket->watches;
     bucket->watches = watch;
     pthread_mutex_unlock(&bucket->lock);
@@ -1223,6 +1239,23 @@ chimera_vfs_notify_emit_delete(
                 watch->callback(watch, watch->private_data);
             }
         }
+    }
+
+    /* Record a tombstone for this FH unconditionally — even when no watch
+     * currently matches.  A CHANGE_NOTIFY racing this delete may arm its
+     * watch a moment from now (the deleting client need not wait for the
+     * watcher's interim reply); watch_create consults these tombstones so
+     * that late-armed watch is born already-deleted instead of parking on
+     * an object that will never emit another event. */
+    {
+        struct chimera_vfs_notify_tombstone *ts =
+            &bucket->tombstones[bucket->tombstone_next];
+
+        memcpy(ts->fh, fh, fh_len);
+        ts->fh_len             = fh_len;
+        ts->stamp              = chimera_vfs_now_ticks();
+        bucket->tombstone_next =
+            (bucket->tombstone_next + 1) % CHIMERA_VFS_NOTIFY_TOMBSTONE_COUNT;
     }
 
     pthread_mutex_unlock(&bucket->lock);

--- a/src/vfs/vfs_notify.h
+++ b/src/vfs/vfs_notify.h
@@ -80,10 +80,29 @@ struct chimera_vfs_notify_watch {
     struct chimera_vfs_notify_watch *subtree_next;
 };
 
+/* Tombstone of a just-removed object's FH.  Recorded by emit_delete so a
+ * CHANGE_NOTIFY whose watch is armed *after* the delete already fired — a
+ * cross-connection race where the deleting client does not wait for the
+ * watcher's interim reply (smb2.notify.rmdir3/4) — still learns the object
+ * is gone instead of parking on a watch that will never see another event.
+ * Bounded ring per bucket; entries are honoured only within
+ * CHIMERA_VFS_NOTIFY_TOMBSTONE_NS of the deletion so a later FH reuse cannot
+ * spuriously report DELETE_PENDING. */
+#define CHIMERA_VFS_NOTIFY_TOMBSTONE_COUNT 16
+#define CHIMERA_VFS_NOTIFY_TOMBSTONE_NS    2000000000ULL /* 2 seconds */
+
+struct chimera_vfs_notify_tombstone {
+    uint8_t  fh[CHIMERA_VFS_FH_SIZE];
+    uint16_t fh_len;
+    uint64_t stamp;             /* chimera_vfs_now_ticks() at deletion; 0 = empty */
+};
+
 /* Bucket in the sharded exact-watch hash table */
 struct chimera_vfs_notify_bucket {
-    struct chimera_vfs_notify_watch *watches;
-    pthread_mutex_t                  lock;
+    struct chimera_vfs_notify_watch    *watches;
+    struct chimera_vfs_notify_tombstone tombstones[CHIMERA_VFS_NOTIFY_TOMBSTONE_COUNT];
+    int                                 tombstone_next; /* ring write index */
+    pthread_mutex_t                     lock;
 };
 
 /* Per-mount subtree watch registry */


### PR DESCRIPTION
Follow-up to #736, which fixed only part of the `smb2.notify.rmdir3`/`rmdir4` cross-connection flake. The suite still timed out under merge_group `-j` load (run 27288603463, on a commit that already contained #736).

## Root cause

#736 handled `emit_delete` arriving *after* the watch existed but before the request parked. A second window remained: **`emit_delete` can fire before the watch is created at all.**

In `rmdir3`/`rmdir4` the deleting connection (tree2) races the watcher’s arm (tree1) with no ordering between them. If the delete wins:

1. `chimera_vfs_notify_emit_delete` walks the bucket, finds **no matching watch**, and sets no flag.
2. The arm handler then calls `watch_create` on an already-deleted directory, drains nothing, sees `deleted == 0`, and **parks the CHANGE_NOTIFY forever** — no further event will ever fire on a removed object.

A gdb dump of a reproduced hang shows every thread idle in the event loop (none in a mutex), confirming a **lost wakeup**, not a deadlock.

## Fix

Record a short-lived per-bucket **tombstone** of every removed FH in `emit_delete`, unconditionally — even when no watch currently matches. `watch_create` consults the bucket’s tombstones and, if this FH was removed within the window, is born with `deleted = 1`, so the existing `take_deleted` check in the arm path completes the request with `STATUS_DELETE_PENDING` instead of parking.

Both `emit_delete` and `watch_create` serialize on `bucket->lock`, so the signal is preserved regardless of which side wins the race. The ring is bounded (16 entries/bucket) and entries are honoured only within 2s of deletion (via the existing TSC clock), so a later reuse of the same FH cannot spuriously report `DELETE_PENDING`.

## Verification

- Deterministic widener (`usleep` before `watch_create`) hangs without this change, passes with it.
- 720 parallel natural-timing runs of `smb2.notify.rmdir3`/`rmdir4` on memfs: **0 hangs** (vs ~6 before the fix).
- Full `smb2.notify` suite passes on **memfs, cairn, and linux**.