### PR TITLE
Fix silent init hang when pthread_create fails under load (lockf_linux flake)

### DIFF
--- a/src/common/logging.c
+++ b/src/common/logging.c
@@ -23,6 +23,7 @@
 
 #include "common/macros.h"
 #include "common/logging.h"
+#include "common/pthread_util.h"
 #include "common/snprintf.h"
 
 #define SECS_PER_HOUR (60 * 60)
@@ -158,9 +159,17 @@ chimera_log_thread(void *arg)
         usleep(1000);
     }
 
+    /* Clear the pointers under the lock so a straggling chimera_vlog()
+     * after the flush sees NULL and bails instead of writing into freed
+     * memory. */
+    pthread_mutex_lock(&ChimeraLogBufLock);
     for (i = 0; i < 2; ++i) {
         free(ChimeraLogBuffers[i]);
+        ChimeraLogBuffers[i] = NULL;
     }
+    ChimeraLogBuf    = NULL;
+    ChimeraLogBufPtr = NULL;
+    pthread_mutex_unlock(&ChimeraLogBufLock);
 
     if (ChimeraLogFile) {
         fclose(ChimeraLogFile);
@@ -216,10 +225,16 @@ chimera_log_atfork_child(void)
      * safe in both cases.  Also clear ChimeraLogRun so the inherited atexit
      * handler does not attempt to pthread_join() the parent's (now-invalid)
      * thread handle.  Any log data buffered by the parent at fork time is
-     * discarded in the child.
+     * discarded in the child (the parent's own copy still gets flushed by
+     * the parent's log thread).
      */
     pthread_mutex_init(&ChimeraLogBufLock, NULL);
     ChimeraLogRun = 0;
+
+    if (ChimeraLogBuf) {
+        ChimeraLogBufPtr = ChimeraLogBuf;
+        ChimeraLogBuf[0] = '\0';
+    }
 } /* chimera_log_atfork_child */
 
 static void
@@ -252,7 +267,19 @@ chimera_log_thread_init(void)
 
     pthread_atfork(chimera_log_atfork_prepare, chimera_log_atfork_parent,
                    chimera_log_atfork_child);
-    pthread_create(&ChimeraLogThread, NULL, chimera_log_thread, NULL);
+
+    int rc = chimera_pthread_create(&ChimeraLogThread, NULL,
+                                    chimera_log_thread, NULL);
+
+    if (rc != 0) {
+        /* Without a flusher thread nothing ever drains the log buffer, so
+         * later log calls would stall once it fills.  Report directly to
+         * stderr (the logging system is the thing that failed) and abort. */
+        fprintf(stderr, "chimera_log_init: pthread_create failed: %s\n",
+                strerror(rc));
+        abort();
+    }
+
     atexit(chimera_log_thread_exit);
 
 } /* chimera_log_thread_init */
@@ -302,7 +329,25 @@ chimera_vlog(
 
     pthread_mutex_lock(&ChimeraLogBufLock);
 
+    if (!ChimeraLogBuf) {
+        /* Buffers already torn down by chimera_log_flush(). */
+        pthread_mutex_unlock(&ChimeraLogBufLock);
+        return;
+    }
+
     while ((ChimeraLogBufPtr + 4096) > (ChimeraLogBuf + CHIMERA_LOG_BUF_SIZE)) {
+        if (!ChimeraLogRun) {
+            /* No flusher thread is alive to drain the buffer (e.g. in a
+             * fork()ed child, where the parent's log thread does not
+             * survive), so waiting would spin forever: drain it inline. */
+            FILE *out = ChimeraLogFile ? ChimeraLogFile : stdout;
+
+            fprintf(out, "%s", ChimeraLogBuf);
+            fflush(out);
+            ChimeraLogBufPtr = ChimeraLogBuf;
+            ChimeraLogBuf[0] = '\0';
+            break;
+        }
         pthread_mutex_unlock(&ChimeraLogBufLock);
         usleep(1);
         pthread_mutex_lock(&ChimeraLogBufLock);

--- a/src/common/pthread_util.h
+++ b/src/common/pthread_util.h
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#pragma once
+
+#include <errno.h>
+#include <pthread.h>
+#include <unistd.h>
+
+/*
+ * pthread_create with bounded retry on EAGAIN.
+ *
+ * EAGAIN from pthread_create is almost always transient resource pressure
+ * (RLIMIT_NPROC, cgroup pids/memory limits, kernel threads-max) during load
+ * spikes.  Retry briefly to ride out the spike, then hand the error back so
+ * the caller can fail loudly; callers must never ignore the result, since a
+ * missing thread typically turns into a silent hang on a work queue that
+ * nothing will ever service, plus a later pthread_join on a garbage handle.
+ *
+ * Returns 0 on success or the final pthread_create error code.
+ */
+static inline int
+chimera_pthread_create(
+    pthread_t            *thread,
+    const pthread_attr_t *attr,
+    void *(*start_routine )(void *),
+    void                 *arg)
+{
+    useconds_t delay = 1000;
+    int        attempt;
+    int        rc;
+
+    for (attempt = 0; ; attempt++) {
+        rc = pthread_create(thread, attr, start_routine, arg);
+
+        if (rc != EAGAIN || attempt >= 100) {
+            return rc;
+        }
+
+        usleep(delay);
+
+        if (delay < 100000) {
+            delay *= 2;
+        }
+    }
+} /* chimera_pthread_create */

--- a/src/vfs/vfs_identity.c
+++ b/src/vfs/vfs_identity.c
@@ -26,6 +26,7 @@
 #include "vfs_user_cache.h"
 #include "vfs_identity.h"
 #include "common/macros.h"
+#include "common/pthread_util.h"
 
 struct chimera_vfs_identity_handler_entry {
     chimera_vfs_identity_handler               handler;
@@ -313,8 +314,14 @@ chimera_vfs_identity_create(
                                      NULL);
 
     for (i = 0; i < num_workers; i++) {
-        pthread_create(&identity->workers[i], NULL,
-                       chimera_vfs_identity_worker, identity);
+        int rc = chimera_pthread_create(&identity->workers[i], NULL,
+                                        chimera_vfs_identity_worker, identity);
+
+        /* A missing worker would leave queued identity jobs that nothing
+         * services and destroy() joining a garbage pthread_t. */
+        chimera_vfs_abort_if(rc,
+                             "chimera_vfs_identity_create: pthread_create failed: %s",
+                             strerror(rc));
     }
 
     return identity;


### PR DESCRIPTION
## Summary

Root-causes and fixes the rare `chimera/posix/lockf_linux` CI flake (300s timeout in merge_group run 27288603463, clean 1.1s pass on rerun).

**Root cause:** `pthread_create` returning `EAGAIN` under transient thread/pid/memory pressure was ignored at several mandatory-thread creation sites. The forked test child hit one during `chimera_posix_init_json` and parked forever in `evpl_thread_create`'s ready-wait — silently, since nothing reports the failure:

```
#3  pthread_cond_wait
#4  evpl_thread_create                 (while (!ready) cond_wait — thread never created)
#5  chimera_vfs_spawn_delegation_pool  (count=64)
#6  chimera_vfs_init
#7  chimera_client_init
#9  chimera_posix_init_json
#10 child_main                         test_lockf.c:57
```

Reproduced deterministically with an LD_PRELOAD shim that fails the first `pthread_create` issued from `evpl_thread_create` in the forked child: exact CI signature — child alive with zero output, parent blocked in `recv_sig` after `cross-proc parent F_TLOCK: PASS`, timeout; passes once the failure is transient and retried. The timing fits: the flake hit as the last test (2517/2517) of a full `-j` ASan suite, peak thread/pid pressure on the runner; each test process spawns ~80 threads plus per-CPU urcu threads.

## Changes

- **`ext/libevpl` bump** to pick up chimera-nas/libevpl#100: `evpl_thread_create` and the allocator prealloc loop retry transient `EAGAIN` with bounded backoff (~10s) and abort loudly on failure instead of waiting forever; also fixes a NULL `EvplFlush` crash in `evpl_fatal`/`evpl_abort`.
- **`src/common/pthread_util.h` (new):** `chimera_pthread_create()` — same bounded-EAGAIN-retry wrapper for chimera-side callers.
- **`src/vfs/vfs_identity.c`:** check worker creation; a missing identity worker left queued jobs that nothing services and `destroy()` joining a garbage `pthread_t`.
- **`src/common/logging.c`:**
  - check log-flusher creation (a missing flusher means the buffer never drains and `chimera_vlog` stalls once it fills);
  - fix a latent silent hang: `chimera_vlog` spun forever in its buffer-full wait when no flusher is alive — the state every `fork()`ed child is in (the parent's log thread does not survive fork). A child logging more than the 1MB buffer wedged with no output; now the buffer is drained inline;
  - the flusher freed the log buffers at exit but left the globals dangling, so a `chimera_vlog` after `chimera_log_flush()` wrote freed memory — clear the pointers under the lock and bail out;
  - the atfork child handler now actually discards the parent's buffered bytes, as its comment already claimed.

## Validation

- Shim failing one `pthread_create` with `EAGAIN` (transient): hung 300s before, **passes** now.
- Shim failing persistently: aborts in ~10s with `evpl_thread_create: pthread_create failed: Resource temporarily unavailable` instead of hanging silently.
- vlog spin: gdb-forcing the forked child's log buffer to within 4KB of full at init previously spun forever; now drains inline and the test completes.
- `lockf|fcntl` ctest across all backends: 14/14; `chimera/vfs` + `chimera/client`: 204/204 (Debug/ASan).