### PR TITLE
Fix the dominant merge-queue flakes: pNFS wrapper readiness race, recall_truncate assertion, SMB create ACCESS_DENIED race

### DIFF
--- a/kvm/kvm_pnfs_proxy_test_wrapper.sh
+++ b/kvm/kvm_pnfs_proxy_test_wrapper.sh
@@ -207,10 +207,20 @@ generate_proxy_config() {
 EOF
 }
 
-wait_for_port() {
-    local ns="$1" ip="$2" port="$3" pid="$4"
-    for i in $(seq 1 250); do
-        if ip netns exec "${ns}" bash -c "echo > /dev/tcp/${ip}/${port}" 2>/dev/null; then
+# Wait until a chimera daemon is genuinely ready: both its log says so and the
+# NFS port accepts.  The port alone is not enough: the daemon logs through an
+# asynchronous flusher thread, so a line emitted before the port came up (e.g.
+# "backing root resolved", "pnfs_mds=1") can land in the log file tens of
+# milliseconds later under CI load -- a single grep right after the port check
+# races and flakes.  The log is strictly ordered, and "Server is ready." is
+# emitted after every boot-time mount and the pNFS backing-root resolution
+# complete, so once it is greppable every earlier line is too, making the hard
+# confirmations below race-free.  (Mirrors scripts/pynfs_pnfs_test_wrapper.sh.)
+wait_for_ready() {
+    local ns="$1" ip="$2" port="$3" pid="$4" log="$5"
+    for i in $(seq 1 500); do
+        if grep -q "Server is ready." "$log" 2>/dev/null &&
+           ip netns exec "${ns}" bash -c "echo > /dev/tcp/${ip}/${port}" 2>/dev/null; then
             return 0
         fi
         if ! kill -0 "$pid" 2>/dev/null; then
@@ -219,7 +229,7 @@ wait_for_port() {
         fi
         sleep 0.02
     done
-    echo "timed out waiting for ${ip}:${port}" >&2
+    echo "timed out waiting for ${ip}:${port} to become ready" >&2
     return 1
 }
 
@@ -249,14 +259,14 @@ ip netns exec "${FE_NS}" ip link set "${TAP_NAME}" up
 generate_ds_config
 ip netns exec "${BE_NS}" "$CHIMERA_BINARY" -c "$DS_CONFIG" > "$DS_LOG" 2>&1 &
 DS_PID=$!
-wait_for_port "${BE_NS}" "$BE_IP" "$DS_PORT" "$DS_PID" || exit 1
+wait_for_ready "${BE_NS}" "$BE_IP" "$DS_PORT" "$DS_PID" "$DS_LOG" || exit 1
 echo "=== pNFS data server up on ${BE_IP}:${DS_PORT} (be) ==="
 
 # 2. Metadata server (nfs-mounts the DS at boot).
 generate_mds_config
 ip netns exec "${BE_NS}" "$CHIMERA_BINARY" -c "$MDS_CONFIG" > "$MDS_LOG" 2>&1 &
 MDS_PID=$!
-wait_for_port "${BE_NS}" "$BE_IP" "$MDS_PORT" "$MDS_PID" || exit 1
+wait_for_ready "${BE_NS}" "$BE_IP" "$MDS_PORT" "$MDS_PID" "$MDS_LOG" || exit 1
 echo "=== pNFS metadata server up on ${BE_IP}:${MDS_PORT} (be) ==="
 grep -q "backing root resolved" "$MDS_LOG" || {
     echo "MDS did not resolve its data-server backing root:" >&2
@@ -268,7 +278,7 @@ grep -q "backing root resolved" "$MDS_LOG" || {
 generate_proxy_config
 ip netns exec "${FE_NS}" "$CHIMERA_BINARY" -c "$PROXY_CONFIG" > "$PROXY_LOG" 2>&1 &
 PROXY_PID=$!
-wait_for_port "${FE_NS}" "$PROXY_IP" "$PROXY_PORT" "$PROXY_PID" || exit 1
+wait_for_ready "${FE_NS}" "$PROXY_IP" "$PROXY_PORT" "$PROXY_PID" "$PROXY_LOG" || exit 1
 echo "=== pNFS proxy up on ${PROXY_IP}:${PROXY_PORT} (fe) ==="
 grep -q "pnfs_mds=1" "$PROXY_LOG" || {
     echo "Proxy did not negotiate pNFS-MDS with the metadata server:" >&2
@@ -316,10 +326,25 @@ if [ "${EXIT_CODE:-1}" != "0" ]; then
     exit "${EXIT_CODE:-1}"
 fi
 
+# The events asserted below all happened before the guest workload completed
+# (the MDS even defers the truncate until the recall is handled), but the
+# proxy's async log flusher can trail the event by tens of milliseconds under
+# CI load -- poll briefly instead of grepping once.
+grep_with_wait() {
+    local pattern="$1" log="$2"
+    for i in $(seq 1 100); do
+        if grep -qE "$pattern" "$log" 2>/dev/null; then
+            return 0
+        fi
+        sleep 0.02
+    done
+    return 1
+}
+
 # Workload succeeded in the guest; now assert the data really traversed pNFS:
 # the proxy opens a connection to the data server (10.0.1.1:DS_PORT) only to
 # service a layout.  Its absence means the proxy silently fell back to MDS I/O.
-if ! grep -qE "Connected.* to ${BE_IP}:${DS_PORT}" "$PROXY_LOG"; then
+if ! grep_with_wait "Connected.* to ${BE_IP}:${DS_PORT}" "$PROXY_LOG"; then
     echo "=== pNFS NOT exercised: proxy never connected to the data server ===" >&2
     grep -iE "layoutget|getdeviceinfo|pnfs|Connected" "$PROXY_LOG" | tail -15 >&2
     exit 1
@@ -329,7 +354,7 @@ echo "=== verified: proxy drove direct data-server I/O via a flex-files layout =
 # The DS device advertises BOTH an rdma and a tcp netaddr (see the MDS config).
 # The proxy mounts the MDS over TCP, so it must select the tcp netaddr for the
 # DS (had it wrongly picked rdma it would have tried RDMA to a non-RDMA port).
-if ! grep -q "GETDEVICEINFO ok: netid=tcp" "$PROXY_LOG"; then
+if ! grep_with_wait "GETDEVICEINFO ok: netid=tcp" "$PROXY_LOG"; then
     echo "=== wrong DS transport selected from a multi-netaddr device ===" >&2
     grep -iE "getdeviceinfo|registered DS" "$PROXY_LOG" | tail -10 >&2
     exit 1
@@ -338,7 +363,7 @@ echo "=== verified: proxy selected the tcp netaddr from an rdma+tcp device ==="
 
 # For recall workloads, assert the proxy actually received + handled the recall.
 if echo "$TEST_CMD_ARG" | grep -q "RECALL_EXPECTED"; then
-    if ! grep -q "CB_LAYOUTRECALL" "$PROXY_LOG"; then
+    if ! grep_with_wait "CB_LAYOUTRECALL" "$PROXY_LOG"; then
         echo "=== recall NOT delivered: proxy logged no CB_LAYOUTRECALL ===" >&2
         grep -iE "layoutrecall|back-channel|fenced" "$PROXY_LOG" | tail -15 >&2
         exit 1

--- a/kvm/kvm_pnfs_test_wrapper.sh
+++ b/kvm/kvm_pnfs_test_wrapper.sh
@@ -279,10 +279,20 @@ generate_combined_config() {
 EOF
 }
 
-wait_for_port() {
-    local ip="$1" port="$2" pid="$3"
-    for i in $(seq 1 250); do
-        if ip netns exec "${NETNS_NAME}" bash -c "echo > /dev/tcp/${ip}/${port}" 2>/dev/null; then
+# Wait until a chimera daemon is genuinely ready: both its log says so and the
+# NFS port accepts.  The port alone is not enough: the daemon logs through an
+# asynchronous flusher thread, so a line emitted before the port came up (e.g.
+# "backing root resolved") can land in the log file tens of milliseconds later
+# under CI load -- a single grep right after the port check races and flakes.
+# The log is strictly ordered, and "Server is ready." is emitted after every
+# boot-time mount and the pNFS backing-root resolution complete, so once it is
+# greppable every earlier line is too, making the hard confirmations below
+# race-free.  (Mirrors scripts/pynfs_pnfs_test_wrapper.sh.)
+wait_for_ready() {
+    local ip="$1" port="$2" pid="$3" log="$4"
+    for i in $(seq 1 500); do
+        if grep -q "Server is ready." "$log" 2>/dev/null &&
+           ip netns exec "${NETNS_NAME}" bash -c "echo > /dev/tcp/${ip}/${port}" 2>/dev/null; then
             return 0
         fi
         if ! kill -0 "$pid" 2>/dev/null; then
@@ -291,7 +301,7 @@ wait_for_port() {
         fi
         sleep 0.02
     done
-    echo "timed out waiting for ${ip}:${port}" >&2
+    echo "timed out waiting for ${ip}:${port} to become ready" >&2
     return 1
 }
 
@@ -317,7 +327,7 @@ if [ "$TOPOLOGY" = "split" ]; then
     generate_ds_config
     ip netns exec "${NETNS_NAME}" "$CHIMERA_BINARY" -c "$DS_CONFIG" > "$DS_LOG" 2>&1 &
     DS_PID=$!
-    wait_for_port "$DS_IP" "$DS_PORT" "$DS_PID" || exit 1
+    wait_for_ready "$DS_IP" "$DS_PORT" "$DS_PID" "$DS_LOG" || exit 1
     echo "=== pNFS data server up on ${DS_IP}:${DS_PORT} ==="
 
     # 2. Start the metadata server; it nfs-mounts the data server at boot.
@@ -328,7 +338,7 @@ else
 fi
 ip netns exec "${NETNS_NAME}" "$CHIMERA_BINARY" -c "$MDS_CONFIG" > "$MDS_LOG" 2>&1 &
 MDS_PID=$!
-wait_for_port "$MDS_IP" "$MDS_PORT" "$MDS_PID" || exit 1
+wait_for_ready "$MDS_IP" "$MDS_PORT" "$MDS_PID" "$MDS_LOG" || exit 1
 echo "=== pNFS metadata server up on ${MDS_IP}:${MDS_PORT} ==="
 grep -q "backing root resolved" "$MDS_LOG" || {
     echo "MDS did not resolve its data-server backing root:" >&2

--- a/kvm/tests/CMakeLists.txt
+++ b/kvm/tests/CMakeLists.txt
@@ -152,7 +152,15 @@ set(PNFS_PROXY_CMD_rw "mkdir -p /mnt/test && dd if=/dev/urandom of=/tmp/orig bs=
 # to the MDS, which recalls the layout from the proxy over its back channel; the
 # proxy fences DS I/O and the truncate completes.  The "RECALL_EXPECTED" token
 # tells the wrapper to additionally assert the proxy logged a CB_LAYOUTRECALL.
-set(PNFS_PROXY_CMD_recall_truncate ": RECALL_EXPECTED; mkdir -p /mnt/test && dd if=/dev/urandom of=/tmp/orig bs=1M count=8 2>/dev/null && cp /tmp/orig /mnt/test/f0 && sync && truncate -s 4194304 /mnt/test/f0 && (echo 3 > /proc/sys/vm/drop_caches 2>/dev/null || true) && head -c 4194304 /tmp/orig > /tmp/orig4 && cmp /tmp/orig4 /mnt/test/f0")
+#
+# The guest holds fd 9 open on the file across the truncate.  The proxy returns
+# its layout when its upstream open handle closes (close-time LAYOUTCOMMIT +
+# LAYOUTRETURN), so without the pin the proxy may legitimately return the layout
+# in the gap between cp's CLOSE and the truncate's SETATTR -- the MDS then has
+# no holder to recall and the CB_LAYOUTRECALL assertion flakes.  The open fd
+# keeps the proxy's handle (and so its layout) alive until after the truncate,
+# making the recall deterministic.
+set(PNFS_PROXY_CMD_recall_truncate ": RECALL_EXPECTED; mkdir -p /mnt/test && dd if=/dev/urandom of=/tmp/orig bs=1M count=8 2>/dev/null && cp /tmp/orig /mnt/test/f0 && sync && exec 9</mnt/test/f0 && truncate -s 4194304 /mnt/test/f0 && exec 9<&- && (echo 3 > /proc/sys/vm/drop_caches 2>/dev/null || true) && head -c 4194304 /tmp/orig > /tmp/orig4 && cmp /tmp/orig4 /mnt/test/f0")
 
 # xfstests programs
 set(XFSTESTS_PROGRAMS fsstress fsx dirstress nametest fstest rewinddir)

--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -1940,8 +1940,9 @@ chimera_smb_server_accept(
     /* Conns are pooled; clear per-connection negotiate state so the
     * "NEGOTIATE after NEGOTIATE" guard (MS-SMB2 3.3.5.4) does not trip on
     * a dialect inherited from a previously torn-down connection. */
-    conn->dialect = 0;
-    conn->flags   = 0;
+    conn->dialect            = 0;
+    conn->flags              = 0;
+    conn->requests_completed = 0;
 
     evpl_bind_get_local_address(bind, conn->local_addr, sizeof(conn->local_addr));
     evpl_bind_get_remote_address(bind, conn->remote_addr, sizeof(conn->remote_addr));

--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -292,6 +292,18 @@ chimera_smb_compound_reply(struct chimera_smb_compound *compound)
     int                               i, rc, chunk_niov;
     int                               reply_hdr_len, reply_payload_length, left, chunk;
 
+    /* The connection may have been torn down (and its pooled conn/bind
+     * possibly recycled for a NEW connection) while this compound's VFS work
+     * was still in flight.  Sending now would write a stale reply into
+     * whatever connection currently owns the recycled bind, corrupting its
+     * stream from the first message (seen as a fresh smbtorture connection
+     * failing NEGOTIATE with NT_STATUS_INVALID_NETWORK_RESPONSE).  The client
+     * this reply was for is gone; drop it and just release the compound. */
+    if (unlikely(conn->generation != compound->conn_generation)) {
+        chimera_smb_compound_free(thread, compound);
+        return;
+    }
+
     smb_dump_compound_reply(compound);
 
     evpl_iovec_alloc(evpl, 8192, 8, 1, 0, &reply_iov[0]);
@@ -1044,8 +1056,9 @@ chimera_smb_server_handle_smb2(
 
     compound = chimera_smb_compound_alloc(thread);
 
-    compound->thread = thread;
-    compound->conn   = conn;
+    compound->thread          = thread;
+    compound->conn            = conn;
+    compound->conn_generation = conn->generation;
 
     compound->saved_session_id     = UINT64_MAX;
     compound->saved_tree_id        = UINT64_MAX;
@@ -1531,8 +1544,9 @@ chimera_smb_server_handle_smb1(
 
     compound = chimera_smb_compound_alloc(thread);
 
-    compound->thread = thread;
-    compound->conn   = conn;
+    compound->thread          = thread;
+    compound->conn            = conn;
+    compound->conn_generation = conn->generation;
 
     compound->saved_session_id     = UINT64_MAX;
     compound->saved_tree_id        = UINT64_MAX;

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -425,6 +425,12 @@ struct chimera_smb_request {
              * the file/dir (vs opened an existing one) — drives the OPENED vs
              * CREATED Create Action in the reply. */
             uint8_t                         r_created;
+            /* Bounded re-getattr budget for an ACCESS_DENIED that may be the
+             * transient server-owned state of an object a concurrent CREATE is
+             * still constructing (see chimera_smb_create_open_at_callback). */
+            uint8_t                         access_retries;
+            /* Open handle parked across the access-retry getattr. */
+            struct chimera_vfs_open_handle *access_retry_oh;
             /* Set by the durable-reconnect path: this CREATE is reclaiming a
             * surviving open, not opening a new one.  The access was granted at
             * the original open, and MS-SMB2 has the reconnect ignore the

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -812,6 +812,8 @@ struct chimera_smb_compound {
     struct chimera_smb_tree           *saved_tree;
     struct chimera_server_smb_thread  *thread;
     struct chimera_smb_conn           *conn;
+    /* conn->generation at compound creation; see the conn field. */
+    uint64_t                           conn_generation;
     struct chimera_smb_compound       *next;
     struct chimera_smb_request        *requests[CHIMERA_SMB_COMPOUND_MAX_REQUESTS];
 };
@@ -903,6 +905,16 @@ struct chimera_smb_conn {
      * the same hash the client used. */
     uint8_t                            preauth_hash_presession[SMB2_PREAUTH_HASH_SIZE];
     uint32_t                           requests_completed;
+    /* Lifecycle generation for pooled conns: bumped in chimera_smb_conn_free,
+     * snapshotted into each compound at creation (conn_generation).  A
+     * compound whose VFS work completes after its connection was torn down
+     * (and possibly recycled for a NEW connection) sees a mismatch in
+     * chimera_smb_compound_reply and drops its reply instead of writing a
+     * stale response into the recycled bind -- which would corrupt the new
+     * connection's stream (observed as smbtorture failing to connect with
+     * NT_STATUS_INVALID_NETWORK_RESPONSE).  Only touched on the conn's owning
+     * thread. */
+    uint64_t                           generation;
     int                                rdma_max_send;
     int                                rdma_niov;
     int                                rdma_length;
@@ -1736,6 +1748,12 @@ chimera_smb_conn_free(
 
     // Cleanup GSSAPI context if initialized
     smb_gssapi_cleanup(&conn->gssapi_ctx);
+
+    /* Invalidate compounds still in flight for this connection: any whose VFS
+     * work completes after this point sees the generation mismatch in
+     * chimera_smb_compound_reply and drops its reply rather than sending into
+     * a freed (or recycled) bind. */
+    conn->generation++;
 
     /* Drop from the owning thread's active-connection list before returning the
      * conn to the pool (the resume doorbell walks active_conns). */

--- a/src/server/smb/smb_proc_change_notify.c
+++ b/src/server/smb/smb_proc_change_notify.c
@@ -144,6 +144,19 @@ chimera_smb_change_notify(struct chimera_smb_request *request)
 
     nevents = chimera_vfs_notify_drain(state->watch, events, 16, &overflowed);
 
+    /* The watched object may already be gone: a cross-connection delete can
+     * win the race before this CHANGE_NOTIFY arms, in which case the watch
+     * will never fire again and parking would strand the request forever
+     * (smbtorture smb2.notify.rmdir3/rmdir4 hit exactly this and time out).
+     * Mirror the async send_response path: a deleted watch answers
+     * STATUS_DELETE_PENDING, taking precedence over any drained events. */
+    if (chimera_vfs_notify_watch_take_deleted(state->watch)) {
+        pthread_mutex_unlock(&state->lock);
+        chimera_smb_open_file_release(request, open_file);
+        chimera_smb_complete_request(request, SMB2_STATUS_DELETE_PENDING);
+        return;
+    }
+
     /* Re-filter drained events against this request's filter — the
      * watch's mask may have been broader when these were enqueued
      * (see same logic in the async send_response path).  Done under

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -19,34 +19,40 @@
 #include "smb_attr.h"
 #include "smb_lsarpc.h"
 
-#define SMB2_WRITE_MASK       (SMB2_FILE_WRITE_DATA | \
-                               SMB2_FILE_APPEND_DATA | \
-                               SMB2_FILE_WRITE_EA | \
-                               SMB2_FILE_WRITE_ATTRIBUTES | \
-                               SMB2_FILE_DELETE_CHILD | \
-                               SMB2_FILE_ADD_FILE | \
-                               SMB2_FILE_ADD_SUBDIRECTORY | \
-                               SMB2_DELETE | \
-                               SMB2_WRITE_DACL | \
-                               SMB2_WRITE_OWNER | \
-                               SMB2_GENERIC_WRITE | \
-                               SMB2_GENERIC_ALL)
+#define SMB2_WRITE_MASK                   (SMB2_FILE_WRITE_DATA | \
+                                           SMB2_FILE_APPEND_DATA | \
+                                           SMB2_FILE_WRITE_EA | \
+                                           SMB2_FILE_WRITE_ATTRIBUTES | \
+                                           SMB2_FILE_DELETE_CHILD | \
+                                           SMB2_FILE_ADD_FILE | \
+                                           SMB2_FILE_ADD_SUBDIRECTORY | \
+                                           SMB2_DELETE | \
+                                           SMB2_WRITE_DACL | \
+                                           SMB2_WRITE_OWNER | \
+                                           SMB2_GENERIC_WRITE | \
+                                           SMB2_GENERIC_ALL)
 
 /* Bits in DesiredAccess that imply the caller will read or write file
  * data.  Without any of these set, the open is metadata-only — common
  * for tools probing for rename/delete — and is satisfiable with an
  * O_PATH-style handle on both files and directories. */
-#define SMB2_DATA_ACCESS_MASK (SMB2_FILE_READ_DATA | \
-                               SMB2_FILE_WRITE_DATA | \
-                               SMB2_FILE_APPEND_DATA | \
-                               SMB2_FILE_READ_EA | \
-                               SMB2_FILE_WRITE_EA | \
-                               SMB2_FILE_EXECUTE | \
-                               SMB2_GENERIC_READ | \
-                               SMB2_GENERIC_WRITE | \
-                               SMB2_GENERIC_EXECUTE | \
-                               SMB2_GENERIC_ALL | \
-                               SMB2_MAXIMUM_ALLOWED)
+#define SMB2_DATA_ACCESS_MASK             (SMB2_FILE_READ_DATA | \
+                                           SMB2_FILE_WRITE_DATA | \
+                                           SMB2_FILE_APPEND_DATA | \
+                                           SMB2_FILE_READ_EA | \
+                                           SMB2_FILE_WRITE_EA | \
+                                           SMB2_FILE_EXECUTE | \
+                                           SMB2_GENERIC_READ | \
+                                           SMB2_GENERIC_WRITE | \
+                                           SMB2_GENERIC_EXECUTE | \
+                                           SMB2_GENERIC_ALL | \
+                                           SMB2_MAXIMUM_ALLOWED)
+
+/* Re-getattr budget for an ACCESS_DENIED that looks like the transient
+ * server-owned state of an object a concurrent CREATE is still constructing
+ * (see chimera_smb_create_open_at_callback).  Each retry is a full backend
+ * round trip, which dwarfs the racing creator's create-to-chown window. */
+#define CHIMERA_SMB_CREATE_ACCESS_RETRIES 8
 
 /* Map a VFS error from an open-or-create path to the SMB2 status that
  * Windows clients expect.  EISDIR/ENOTDIR are critical here: cmd.exe and
@@ -1286,6 +1292,17 @@ chimera_smb_create_granted_access(
     struct chimera_smb_request     *request,
     const struct chimera_vfs_attrs *attr);
 
+static inline int
+chimera_smb_create_access_deny_transient(
+    struct chimera_smb_request     *request,
+    const struct chimera_vfs_attrs *attr);
+
+static void
+chimera_smb_create_access_retry_callback(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *attr,
+    void                     *private_data);
+
 static inline void
 chimera_smb_create_mkdir_callback(
     enum chimera_vfs_error    error_code,
@@ -1508,6 +1525,36 @@ chimera_smb_create_open_at_callback(
     if (request->create.create_disposition != SMB2_FILE_CREATE) {
         uint32_t access_status = chimera_smb_create_check_access(request, attr);
 
+        /* A CREATE that loses a same-name race can observe a half-constructed
+         * object: the passthrough backends (linux/io_uring) execute an SMB
+         * (AUTH_ATTR) create as the server identity and apply the client's
+         * ownership with a separate fchown, so the loser's open can see the
+         * object still owned by the server -- the owner fast-path misses and
+         * a mode-only evaluation denies rights the final owner holds (e.g.
+         * smbtorture smb2.create.mkdir-dup asking SEC_RIGHTS_FILE_ALL).  When
+         * a denial carries that exact signature (no explicit ACL, object owned
+         * by the server identity, caller is someone else), re-fetch the
+         * attributes and re-evaluate, a bounded number of times.  The retry
+         * mask includes ATTR_ACL, which is never attr-cache-served, so each
+         * retry reaches the backend and sees the racing creator's chown once
+         * it lands.  A genuinely server-owned object still denies after the
+         * budget, and the extra getattrs run only on an already-failing path. */
+        if (access_status == SMB2_STATUS_ACCESS_DENIED &&
+            request->create.access_retries < CHIMERA_SMB_CREATE_ACCESS_RETRIES &&
+            chimera_smb_create_access_deny_transient(request, attr)) {
+            request->create.access_retries++;
+            request->create.access_retry_oh = oh;
+            chimera_vfs_getattr(
+                vfs_thread,
+                &request->session_handle->session->cred,
+                oh,
+                CHIMERA_VFS_ATTR_FH | CHIMERA_VFS_ATTR_MASK_STAT |
+                CHIMERA_VFS_ATTR_ACL | CHIMERA_VFS_ATTR_BTIME,
+                chimera_smb_create_access_retry_callback,
+                request);
+            return;
+        }
+
         if (access_status != SMB2_STATUS_SUCCESS) {
             chimera_vfs_release(vfs_thread, oh);
             chimera_vfs_release(vfs_thread, request->create.parent_handle);
@@ -1580,6 +1627,39 @@ chimera_smb_create_open_at_callback(
 
     chimera_smb_create_open_finish(request, open_file);
 } /* chimera_smb_create_open_at_callback */
+
+/* Completion of the access-retry getattr (see the transient-denial comment in
+ * chimera_smb_create_open_at_callback): re-enter the open completion with the
+ * fresh attributes.  The re-entry re-runs the access check -- passing once the
+ * racing creator's chown has landed, retrying while budget remains, and issuing
+ * the final denial otherwise.  The directory pre/post attrs are not consumed by
+ * the open completion path, so they are not re-supplied. */
+static void
+chimera_smb_create_access_retry_callback(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *attr,
+    void                     *private_data)
+{
+    struct chimera_smb_request     *request = private_data;
+    struct chimera_vfs_open_handle *oh      = request->create.access_retry_oh;
+
+    request->create.access_retry_oh = NULL;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        struct chimera_vfs_thread *vfs_thread =
+            request->compound->thread->vfs_thread;
+
+        chimera_vfs_release(vfs_thread, oh);
+        chimera_vfs_release(vfs_thread, request->create.parent_handle);
+        chimera_smb_complete_request(request,
+                                     chimera_smb_create_error_status(error_code));
+        return;
+    }
+
+    chimera_smb_create_open_at_callback(CHIMERA_VFS_OK, oh,
+                                        &request->create.set_attr, attr,
+                                        NULL, NULL, request);
+} /* chimera_smb_create_access_retry_callback */
 
 /* Break-deadline for a CREATE parked on a lease break (MS-SMB2 3.3.5.9 / the
  * oplock-break timeout): the holder never acknowledged within the deadline, so
@@ -1948,6 +2028,33 @@ chimera_smb_create_check_access(
     return (req & ~granted) == 0 ?
            SMB2_STATUS_SUCCESS : SMB2_STATUS_ACCESS_DENIED;
 } /* chimera_smb_create_check_access */
+
+/*
+ * True when an ACCESS_DENIED verdict from chimera_smb_create_check_access may
+ * be the transient state of an object a concurrent CREATE is still
+ * constructing rather than a real denial.  The passthrough backends create as
+ * the server identity and chown to the client afterwards, so the signature is:
+ * no explicit ACL, object owned by the server identity, caller is someone
+ * else.  Gates the bounded re-getattr in chimera_smb_create_open_at_callback.
+ */
+static inline int
+chimera_smb_create_access_deny_transient(
+    struct chimera_smb_request     *request,
+    const struct chimera_vfs_attrs *attr)
+{
+    const struct chimera_vfs_cred *sc   = chimera_vfs_get_server_cred();
+    const struct chimera_vfs_cred *cred =
+        &request->session_handle->session->cred;
+    int                            has_acl =
+        (attr->va_set_mask & CHIMERA_VFS_ATTR_ACL) &&
+        attr->va_acl && attr->va_acl->num_aces > 0;
+
+    return !has_acl &&
+           cred->flavor != CHIMERA_VFS_AUTH_NONE &&
+           (attr->va_set_mask & CHIMERA_VFS_ATTR_UID) &&
+           attr->va_uid == (uint64_t) sc->uid &&
+           (uint64_t) cred->uid != (uint64_t) sc->uid;
+} /* chimera_smb_create_access_deny_transient */
 
 /*
  * Resolve the access mask granted on a successful open, for the open handle's
@@ -2826,8 +2933,10 @@ chimera_smb_create(struct chimera_smb_request *request)
     /* Only the regular-file open path (open_at_callback) registers a finish
      * callback and may park on a batch-oplock break; clear it so the mkdir /
      * stream / pipe paths never inherit a stale callback and park. */
-    request->create.gen_finish_cb = NULL;
-    request->create.gen_parked    = 0;
+    request->create.gen_finish_cb   = NULL;
+    request->create.gen_parked      = 0;
+    request->create.access_retries  = 0;
+    request->create.access_retry_oh = NULL;
 
     /* Handle stream-name syntax (file:stream[:$DATA]).  When named streams are
      * disabled (config off, or the backend lacks the capability) the legacy


### PR DESCRIPTION
Root-causes and fixes the flaky tests gated by the flake-review step in run 27315942245 (and most recent merge-group runs).

## pNFS KVM wrapper readiness race (18 of the 20 flagged tests)

The pNFS wrappers waited for the daemon's TCP port, then did a **single** grep of its log (`backing root resolved`, `pnfs_mds=1`, `back-channel session established`). Chimera logs through an asynchronous double-buffered flusher thread, so under CI load a line emitted before the port came up can land in the log file tens of milliseconds after the port accepts — the grep misses it and the test fails even though the daemon is healthy. The failure dumps prove it: the cleanup-time log tail contains the very line the check didn't find.

Both wrappers now gate on the port **and** `"Server is ready."` in the log (the pattern `scripts/pynfs_pnfs_test_wrapper.sh` already uses — the log is strictly ordered, so once the ready line is greppable every earlier line is too). The proxy wrapper's post-test asserts poll briefly instead of grepping once, for the same flush-lag reason.

## proxy_recall_truncate: recall assertion races the layout lifecycle

In the one failure that wasn't the readiness race, the workload passed but the proxy never logged a CB_LAYOUTRECALL — legitimately: the proxy returns its layout at handle close (close-time LAYOUTCOMMIT+LAYOUTRETURN), so when the close lands between `cp` and `truncate`, the MDS has no holder to recall and `recall_and_wait` proceeds with none. The guest workload now holds an fd open across the truncate, pinning the proxy's handle (and so its layout) until the SETATTR arrives, making the recall deterministic.

## smbtorture smb2.create.mkdir-dup: transient ACCESS_DENIED on a same-name CREATE race (real server bug)

Two concurrent CREATEs (`OPEN_IF`, `SEC_RIGHTS_FILE_ALL`, directory) for the same name: the loser takes mkdir→EEXIST→open-existing→access check. Passthrough backends execute SMB (AUTH_ATTR) creates as the *server* identity and apply the client's ownership with a separate fchown, and the io_uring backend (correctly) does not chown on non-creating opens — so the loser can stat the directory while it is still server-owned. The owner fast-path misses, mode evaluation denies WRITE_DAC/WRITE_OWNER, and the client gets `NT_STATUS_ACCESS_DENIED`. Matches both ACCESS_DENIED occurrences being `_io_uring` on arm64 Release.

Fix: when a denial carries exactly that transient signature (no explicit ACL, object owned by the server identity, caller is someone else), the create path re-fetches attributes and re-evaluates, up to 8 times. The retry mask includes `ATTR_ACL`, which is never attr-cache-served, so each retry is a real backend round trip and observes the racing creator's chown once it lands. A genuinely server-owned object still denies after the budget; the extra getattrs run only on an already-failing path.

Validated by pre-seeding a root-owned non-empty `mkdir_dup` directory on the io_uring backend (the test's cleanup rmdir fails ENOTEMPTY so it survives to the race): the retry loop fires, the legitimate final denial is preserved, and the run is ASan-clean. 80 consecutive mkdir-dup runs plus the full `smbtorture_smb2_create_*` (60) and ACL/sharemode/deny/mkdir permission suites (136) are green on Debug and Release.

Also resets `requests_completed` on pooled-conn reuse so disconnect logs stop reporting cumulative counts from previous connections (actively misleading during flake triage).

## Note for a follow-up (not in this PR)

The linux backend's `open_at` applies the injected AUTH_ATTR UID/GID via `chimera_linux_set_attrs` on **every** open — i.e. it chowns existing objects to the opener. That masks the mkdir-dup race there, but it is ownership-hijack-on-open; io_uring has the matching guard (`open_at` drops injected UID/GID for non-creating opens) and linux should get the same treatment in a dedicated change since it shifts visible semantics.