### PR TITLE
smb: drop stale compound replies into torn-down/recycled connections

### DIFF
--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -294,6 +294,18 @@ chimera_smb_compound_reply(struct chimera_smb_compound *compound)
     int                               i, rc, chunk_niov;
     int                               reply_hdr_len, reply_payload_length, left, chunk;
 
+    /* The connection may have been torn down (and its pooled conn/bind
+     * possibly recycled for a NEW connection) while this compound's VFS work
+     * was still in flight.  Sending now would write a stale reply into
+     * whatever connection currently owns the recycled bind, corrupting its
+     * stream from the first message (seen as a fresh smbtorture connection
+     * failing NEGOTIATE with NT_STATUS_INVALID_NETWORK_RESPONSE).  The client
+     * this reply was for is gone; drop it and just release the compound. */
+    if (unlikely(conn->generation != compound->conn_generation)) {
+        chimera_smb_compound_free(thread, compound);
+        return;
+    }
+
     smb_dump_compound_reply(compound);
 
     evpl_iovec_alloc(evpl, 8192, 8, 1, 0, &reply_iov[0]);
@@ -1046,8 +1058,9 @@ chimera_smb_server_handle_smb2(
 
     compound = chimera_smb_compound_alloc(thread);
 
-    compound->thread = thread;
-    compound->conn   = conn;
+    compound->thread          = thread;
+    compound->conn            = conn;
+    compound->conn_generation = conn->generation;
 
     compound->saved_session_id     = UINT64_MAX;
     compound->saved_tree_id        = UINT64_MAX;
@@ -1533,8 +1546,9 @@ chimera_smb_server_handle_smb1(
 
     compound = chimera_smb_compound_alloc(thread);
 
-    compound->thread = thread;
-    compound->conn   = conn;
+    compound->thread          = thread;
+    compound->conn            = conn;
+    compound->conn_generation = conn->generation;
 
     compound->saved_session_id     = UINT64_MAX;
     compound->saved_tree_id        = UINT64_MAX;

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -811,6 +811,8 @@ struct chimera_smb_compound {
     struct chimera_smb_tree           *saved_tree;
     struct chimera_server_smb_thread  *thread;
     struct chimera_smb_conn           *conn;
+    /* conn->generation at compound creation; see the conn field. */
+    uint64_t                           conn_generation;
     struct chimera_smb_compound       *next;
     struct chimera_smb_request        *requests[CHIMERA_SMB_COMPOUND_MAX_REQUESTS];
 };
@@ -902,6 +904,16 @@ struct chimera_smb_conn {
      * the same hash the client used. */
     uint8_t                            preauth_hash_presession[SMB2_PREAUTH_HASH_SIZE];
     uint32_t                           requests_completed;
+    /* Lifecycle generation for pooled conns: bumped in chimera_smb_conn_free,
+     * snapshotted into each compound at creation (conn_generation).  A
+     * compound whose VFS work completes after its connection was torn down
+     * (and possibly recycled for a NEW connection) sees a mismatch in
+     * chimera_smb_compound_reply and drops its reply instead of writing a
+     * stale response into the recycled bind -- which would corrupt the new
+     * connection's stream (observed as smbtorture failing to connect with
+     * NT_STATUS_INVALID_NETWORK_RESPONSE).  Only touched on the conn's owning
+     * thread. */
+    uint64_t                           generation;
     int                                rdma_max_send;
     int                                rdma_niov;
     int                                rdma_length;
@@ -1735,6 +1747,12 @@ chimera_smb_conn_free(
 
     // Cleanup GSSAPI context if initialized
     smb_gssapi_cleanup(&conn->gssapi_ctx);
+
+    /* Invalidate compounds still in flight for this connection: any whose VFS
+     * work completes after this point sees the generation mismatch in
+     * chimera_smb_compound_reply and drops its reply rather than sending into
+     * a freed (or recycled) bind. */
+    conn->generation++;
 
     /* Drop from the owning thread's active-connection list before returning the
      * conn to the pool (the resume doorbell walks active_conns). */


### PR DESCRIPTION
Root-causes the recurring merge-queue flake where smbtorture smb2.create fails to even connect with `NT_STATUS_INVALID_NETWORK_RESPONSE` (2 occurrences, arm64 Release, linux and cairn backends — backend-independent).

`chimera_smb_compound_reply` sent unconditionally to `compound->conn->bind`. When a connection drops with requests still in flight (smbtorture's bench-path-contention does exactly this), a late VFS completion sent its reply into a freed bind — or one already recycled for a **new** connection, corrupting that connection's stream from its first message. Both occurrences carry the same fingerprint: the failing fresh connection had recycled the bench connection's pooled conn struct, handled exactly one message (the NEGOTIATE), and the client rejected the response as malformed.

Fix: each pooled conn gets a lifecycle `generation`, bumped in `chimera_smb_conn_free` and snapshotted into the compound at creation; `compound_reply` drops the reply (releasing the compound normally) on mismatch — the client it was for is gone. Conns are pooled and only returned to the OS at thread shutdown, and bump/check both run on the conn's owning thread, so the comparison needs no atomics.

(An earlier revision of this PR also carried a CHANGE_NOTIFY deleted-watch fix; main landed the equivalent in 0512243a / e39499e2 while it was in flight, so this PR is now the generation guard alone, rebased onto main.)

Full smbtorture battery green on Debug/ASan with the guard in place.