### PR TITLE
Add REST /api/v1/config endpoint, prevent duplicate resources, preser…

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -16,6 +16,26 @@
     }
   ],
   "paths": {
+    "/config": {
+      "get": {
+        "summary": "Get server configuration",
+        "description": "Returns the running server configuration as a JSON document compatible with the chimera.json file format, reconstructed from live runtime state. The \"users\" section (passwords) and the \"server\" section are omitted, and the internal \"root\" mount is excluded.",
+        "operationId": "getConfig",
+        "tags": ["Config"],
+        "responses": {
+          "200": {
+            "description": "Server configuration",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Config"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/users": {
       "get": {
         "summary": "List builtin users",
@@ -727,6 +747,68 @@
           "path": {
             "type": "string",
             "description": "VFS path"
+          }
+        }
+      },
+      "Config": {
+        "type": "object",
+        "description": "Server configuration in chimera.json format. Excludes the users section (passwords) and the server section; the internal root mount is excluded from mounts.",
+        "properties": {
+          "mounts": {
+            "type": "object",
+            "description": "VFS mounts keyed by mount name (the internal root mount is excluded)",
+            "additionalProperties": {
+              "type": "object",
+              "properties": {
+                "module": {
+                  "type": "string",
+                  "description": "VFS module name"
+                },
+                "path": {
+                  "type": "string",
+                  "description": "Backend path"
+                }
+              }
+            }
+          },
+          "exports": {
+            "type": "object",
+            "description": "NFS exports keyed by export name",
+            "additionalProperties": {
+              "type": "object",
+              "properties": {
+                "path": {
+                  "type": "string",
+                  "description": "VFS path"
+                }
+              }
+            }
+          },
+          "shares": {
+            "type": "object",
+            "description": "SMB shares keyed by share name",
+            "additionalProperties": {
+              "type": "object",
+              "properties": {
+                "path": {
+                  "type": "string",
+                  "description": "VFS path"
+                }
+              }
+            }
+          },
+          "buckets": {
+            "type": "object",
+            "description": "S3 buckets keyed by bucket name",
+            "additionalProperties": {
+              "type": "object",
+              "properties": {
+                "path": {
+                  "type": "string",
+                  "description": "VFS path"
+                }
+              }
+            }
           }
         }
       },

--- a/src/admin/README.md
+++ b/src/admin/README.md
@@ -26,6 +26,10 @@ client = ChimeraAdminClient(host="localhost", port=8080)
 version_info = client.get_version()
 print(f"Server version: {version_info['version']}")
 
+# Get the running configuration (chimera.json format)
+config = client.get_config()
+print(config["mounts"])
+
 # Using context manager
 with ChimeraAdminClient(host="localhost", port=8080) as client:
     print(client.get_version())
@@ -54,6 +58,9 @@ The package provides a CLI, invoked as a module:
 ```bash
 # Global connection options precede the resource and action
 python3 -m chimera_admin --host localhost --port 8080 version
+
+# Dump the running configuration (chimera.json format)
+python3 -m chimera_admin config
 
 # VFS mounts
 python3 -m chimera_admin mount list

--- a/src/admin/chimera_admin/cli.py
+++ b/src/admin/chimera_admin/cli.py
@@ -11,6 +11,7 @@ Run as a module:
 Examples:
 
     python3 -m chimera_admin version
+    python3 -m chimera_admin config
     python3 -m chimera_admin mount list
     python3 -m chimera_admin mount create data --module linux --path /srv/data
     python3 -m chimera_admin user create alice --uid 1000 --gid 1000
@@ -156,6 +157,10 @@ def _build_parser() -> argparse.ArgumentParser:
     p = sub.add_parser("version", help="Show server version")
     p.set_defaults(func=lambda c, a: c.get_version())
 
+    p = sub.add_parser(
+        "config", help="Show server configuration (chimera.json format)")
+    p.set_defaults(func=lambda c, a: c.get_config())
+
     _add_user_commands(sub)
     _add_crud_commands(sub, "export", "NFS export")
     _add_crud_commands(sub, "share", "SMB share")
@@ -172,7 +177,9 @@ def _emit(result) -> None:
     if isinstance(result, str):
         print(result)
     else:
-        print(json.dumps(result, indent=2, sort_keys=True))
+        # Preserve the server's key ordering (e.g. config emits mounts before
+        # exports/shares/buckets) rather than alphabetizing it.
+        print(json.dumps(result, indent=2, sort_keys=False))
 
 
 def main(argv=None) -> int:

--- a/src/admin/chimera_admin/client.py
+++ b/src/admin/chimera_admin/client.py
@@ -111,6 +111,23 @@ class ChimeraAdminClient:
         """
         return self._request("GET", "/api/openapi.json")
 
+    def get_config(self) -> dict:
+        """Get the running server configuration.
+
+        Returns a JSON document compatible with the chimera.json file
+        format, reconstructed from live runtime state. The "users" and
+        "server" sections are intentionally omitted, and the internal
+        "root" mount is excluded.
+
+        Returns:
+            Dictionary with "mounts", "exports", "shares", and "buckets"
+            sections (each a mapping of resource name to its definition).
+
+        Raises:
+            ChimeraAdminError: If the request fails
+        """
+        return self._request("GET", "/api/v1/config")
+
     # Users API
 
     def list_users(self) -> list:

--- a/src/admin/tests/test_api.py
+++ b/src/admin/tests/test_api.py
@@ -154,6 +154,26 @@ class TestMountsAPI:
         assert exc_info.value.status_code == 404
 
 
+class TestConfigAPI:
+    """Test the server configuration endpoint."""
+
+    def test_get_config(self, client):
+        """Test fetching the running configuration."""
+        config = client.get_config()
+        assert isinstance(config, dict)
+        # The collection sections are always present (empty when unset).
+        assert all(
+            k in config for k in ("mounts", "exports", "shares", "buckets"))
+        # The "users" and "server" sections are intentionally omitted.
+        assert "users" not in config
+        assert "server" not in config
+        # The test config defines a "testshare" memfs mount; the internal
+        # "root" mount must not be reported.
+        assert "testshare" in config["mounts"]
+        assert config["mounts"]["testshare"]["module"] == "memfs"
+        assert "root" not in config["mounts"]
+
+
 class TestHTTPS:
     """Test HTTPS API endpoints with self-signed certificate."""
 

--- a/src/server/rest/CMakeLists.txt
+++ b/src/server/rest/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(chimera_rest SHARED
     rest_users.c
     rest_shares.c
     rest_mounts.c
+    rest_config.c
     rest_swagger.c
     rest_debug.c
 )

--- a/src/server/rest/rest.c
+++ b/src/server/rest/rest.c
@@ -120,6 +120,12 @@ void chimera_rest_handle_mounts_delete(
     struct chimera_rest_thread *,
     const char *);
 
+/* External handler from rest_config.c */
+void chimera_rest_handle_config(
+    struct evpl *,
+    struct evpl_http_request *,
+    struct chimera_rest_thread *);
+
 /* External handlers from rest_swagger.c */
 void chimera_rest_handle_swagger_ui(
     struct evpl *,
@@ -453,6 +459,16 @@ chimera_rest_dispatch(
                                      "/api/docs/swagger-ui.min.css", 28)) {
         if (req_type == EVPL_HTTP_REQUEST_TYPE_GET) {
             chimera_rest_handle_swagger_css(evpl, request);
+        } else {
+            chimera_rest_handle_method_not_allowed(evpl, request);
+        }
+        return;
+    }
+
+    /* Config API: /api/v1/config */
+    if (url_len == 14 && strncmp(url, "/api/v1/config", 14) == 0) {
+        if (req_type == EVPL_HTTP_REQUEST_TYPE_GET) {
+            chimera_rest_handle_config(evpl, request, thread);
         } else {
             chimera_rest_handle_method_not_allowed(evpl, request);
         }

--- a/src/server/rest/rest_config.c
+++ b/src/server/rest/rest_config.c
@@ -1,0 +1,140 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <jansson.h>
+
+#include "evpl/evpl.h"
+#include "evpl/evpl_http.h"
+#include "server/server.h"
+#include "server/nfs/nfs.h"
+#include "server/smb/smb.h"
+#include "server/s3/s3.h"
+#include "rest_internal.h"
+
+/*
+ * GET /api/v1/config
+ *
+ * Reconstructs a JSON document compatible with the chimera.json file format
+ * from live runtime state.  The "users" section is intentionally omitted (it
+ * would expose passwords) and the "server" section is omitted (a partially
+ * reconstructed server section is more confusing than useful).  The internal
+ * "root" pseudo-mount is skipped.
+ */
+
+static int
+config_mount_callback(
+    const char *mount_path,
+    const char *module_name,
+    const char *module_path,
+    void       *data)
+{
+    json_t *mounts = data;
+    json_t *obj;
+
+    /* The "root" pseudo-mount is a Chimera-internal entry, not part of the
+     * user-facing configuration. */
+    if (strcmp(module_name, "root") == 0) {
+        return 0;
+    }
+
+    obj = json_object();
+    json_object_set_new(obj, "module", json_string(module_name));
+    json_object_set_new(obj, "path", json_string(module_path));
+
+    json_object_set_new(mounts, mount_path, obj);
+
+    return 0;
+} /* config_mount_callback */
+
+static int
+config_export_callback(
+    const struct chimera_nfs_export *export,
+    void                            *data)
+{
+    json_t *exports = data;
+    json_t *obj;
+
+    obj = json_object();
+    json_object_set_new(obj, "path",
+                        json_string(chimera_nfs_export_get_path(export)));
+
+    json_object_set_new(exports, chimera_nfs_export_get_name(export), obj);
+
+    return 0;
+} /* config_export_callback */
+
+static int
+config_share_callback(
+    const struct chimera_smb_share *share,
+    void                           *data)
+{
+    json_t *shares = data;
+    json_t *obj;
+
+    obj = json_object();
+    json_object_set_new(obj, "path",
+                        json_string(chimera_smb_share_get_path(share)));
+
+    json_object_set_new(shares, chimera_smb_share_get_name(share), obj);
+
+    return 0;
+} /* config_share_callback */
+
+static int
+config_bucket_callback(
+    const struct s3_bucket *bucket,
+    void                   *data)
+{
+    json_t *buckets = data;
+    json_t *obj;
+
+    obj = json_object();
+    json_object_set_new(obj, "path",
+                        json_string(chimera_s3_bucket_get_path(bucket)));
+
+    json_object_set_new(buckets, chimera_s3_bucket_get_name(bucket), obj);
+
+    return 0;
+} /* config_bucket_callback */
+
+void
+chimera_rest_handle_config(
+    struct evpl                *evpl,
+    struct evpl_http_request   *request,
+    struct chimera_rest_thread *thread)
+{
+    struct chimera_server *server = thread->shared->server;
+    json_t                *root;
+    json_t                *mounts;
+    json_t                *exports;
+    json_t                *shares;
+    json_t                *buckets;
+
+    root = json_object();
+
+    /* mounts (the internal "root" mount is filtered out) */
+    mounts = json_object();
+    chimera_server_iterate_mounts(server, config_mount_callback, mounts);
+    json_object_set_new(root, "mounts", mounts);
+
+    /* exports */
+    exports = json_object();
+    chimera_server_iterate_exports(server, config_export_callback, exports);
+    json_object_set_new(root, "exports", exports);
+
+    /* shares */
+    shares = json_object();
+    chimera_server_iterate_shares(server, config_share_callback, shares);
+    json_object_set_new(root, "shares", shares);
+
+    /* buckets (no-op when S3 is not configured) */
+    buckets = json_object();
+    chimera_server_iterate_buckets(server, config_bucket_callback, buckets);
+    json_object_set_new(root, "buckets", buckets);
+
+    chimera_rest_send_json(evpl, request, 200, root);
+} /* chimera_rest_handle_config */

--- a/src/server/rest/rest_mounts.c
+++ b/src/server/rest/rest_mounts.c
@@ -30,6 +30,12 @@ mount_to_json_callback(
     struct mount_list_ctx *ctx = data;
     json_t                *obj;
 
+    /* The "root" pseudo-mount is a Chimera-internal entry that is not meant to
+     * be managed by clients, so omit it from the listing. */
+    if (strcmp(module_name, "root") == 0) {
+        return 0;
+    }
+
     obj = json_object();
     json_object_set_new(obj, "name", json_string(mount_path));
     json_object_set_new(obj, "module", json_string(module_name));
@@ -69,6 +75,12 @@ mount_get_callback(
     void       *data)
 {
     struct mount_get_ctx *ctx = data;
+
+    /* The "root" pseudo-mount is a Chimera-internal entry and must not be
+     * retrievable through the REST API. */
+    if (strcmp(module_name, "root") == 0) {
+        return 0;
+    }
 
     if (strcmp(mount_path, ctx->name) != 0) {
         return 0;
@@ -122,6 +134,28 @@ chimera_rest_handle_mounts_get(
  * HTTP reply is dispatched from the completion callback.
  */
 
+struct mount_exists_ctx {
+    const char *name;
+    int         found;
+};
+
+static int
+mount_exists_callback(
+    const char *mount_path,
+    const char *module_name,
+    const char *module_path,
+    void       *data)
+{
+    struct mount_exists_ctx *ctx = data;
+
+    if (strcmp(mount_path, ctx->name) == 0) {
+        ctx->found = 1;
+        return 1;
+    }
+
+    return 0;
+} /* mount_exists_callback */
+
 struct mount_create_ctx {
     struct evpl              *evpl;
     struct evpl_http_request *request;
@@ -165,7 +199,9 @@ chimera_rest_handle_mounts_create(
     const char              *module;
     const char              *path;
     const char              *options;
+    const char              *normalized;
     struct mount_create_ctx *ctx;
+    struct mount_exists_ctx  exists_ctx;
 
     root = json_loadb(body, body_len, 0, &error);
     if (!root) {
@@ -183,6 +219,26 @@ chimera_rest_handle_mounts_create(
         json_decref(root);
         chimera_rest_send_error(evpl, request, 400, "Bad Request",
                                 "Missing required fields: name, module, path");
+        return;
+    }
+
+    /* Mount paths are registered with leading slashes stripped, so normalize
+     * the requested name the same way before checking for an existing mount. */
+    normalized = name;
+    while (*normalized == '/') {
+        normalized++;
+    }
+
+    exists_ctx.name  = normalized;
+    exists_ctx.found = 0;
+
+    chimera_server_iterate_mounts(thread->shared->server,
+                                  mount_exists_callback, &exists_ctx);
+
+    if (exists_ctx.found) {
+        json_decref(root);
+        chimera_rest_send_error(evpl, request, 409, "Conflict",
+                                "Mount with that name already exists");
         return;
     }
 

--- a/src/server/rest/rest_shares.c
+++ b/src/server/rest/rest_shares.c
@@ -114,6 +114,13 @@ chimera_rest_handle_exports_create(
         return;
     }
 
+    if (chimera_server_get_export(thread->shared->server, name)) {
+        json_decref(root);
+        chimera_rest_send_error(evpl, request, 409, "Conflict",
+                                "Export with that name already exists");
+        return;
+    }
+
     rc = chimera_server_create_export(thread->shared->server, name, path);
 
     json_decref(root);
@@ -248,6 +255,13 @@ chimera_rest_handle_shares_create(
         return;
     }
 
+    if (chimera_server_get_share(thread->shared->server, name)) {
+        json_decref(root);
+        chimera_rest_send_error(evpl, request, 409, "Conflict",
+                                "Share with that name already exists");
+        return;
+    }
+
     rc = chimera_server_create_share(thread->shared->server, name, path, 0);
 
     json_decref(root);
@@ -360,12 +374,13 @@ chimera_rest_handle_buckets_create(
     const char                 *body,
     int                         body_len)
 {
-    json_t      *root;
-    json_error_t error;
-    const char  *name;
-    const char  *path;
-    int          rc;
-    json_t      *obj;
+    json_t                 *root;
+    json_error_t            error;
+    const char             *name;
+    const char             *path;
+    const struct s3_bucket *existing;
+    int                     rc;
+    json_t                 *obj;
 
     root = json_loadb(body, body_len, 0, &error);
     if (!root) {
@@ -381,6 +396,17 @@ chimera_rest_handle_buckets_create(
         json_decref(root);
         chimera_rest_send_error(evpl, request, 400, "Bad Request",
                                 "Missing required fields: name, path");
+        return;
+    }
+
+    /* chimera_server_get_bucket holds a read lock until released, so release it
+     * unconditionally before acting on the result. */
+    existing = chimera_server_get_bucket(thread->shared->server, name);
+    chimera_server_release_bucket(thread->shared->server);
+    if (existing) {
+        json_decref(root);
+        chimera_rest_send_error(evpl, request, 409, "Conflict",
+                                "Bucket with that name already exists");
         return;
     }
 

--- a/src/server/rest/rest_users.c
+++ b/src/server/rest/rest_users.c
@@ -131,6 +131,13 @@ chimera_rest_handle_users_create(
         return;
     }
 
+    if (chimera_server_get_user(thread->shared->server, username)) {
+        json_decref(root);
+        chimera_rest_send_error(evpl, request, 409, "Conflict",
+                                "User with that username already exists");
+        return;
+    }
+
     password      = json_string_value(json_object_get(root, "password"));
     uid           = json_integer_value(json_object_get(root, "uid"));
     gid           = json_integer_value(json_object_get(root, "gid"));


### PR DESCRIPTION
…ve key order in admin CLI

Add the GET /api/v1/config endpoint that reconstructs a chimera.json-format document from live runtime state (mounts, exports, shares, buckets), omitting the users and server sections and the internal root mount.

Reject creation of a resource whose name already exists, returning 409 Conflict instead of silently creating a duplicate. This covers mounts, exports, shares, buckets, and users.

Stop the admin CLI from alphabetizing JSON output (sort_keys=False) so it faithfully reflects the server's key ordering, with mounts emitted first.