### PR TITLE
diskfs: quiesce in-flight intent-log commits before thread teardown

### DIFF
--- a/src/vfs/diskfs/diskfs.c
+++ b/src/vfs/diskfs/diskfs.c
@@ -9800,9 +9800,21 @@ diskfs_thread_destroy(void *private_data)
      * an elbencho-teardown ASan UAF in diskfs_block_unpin).
      * commits_inflight counts every commit from submission (or SQ-full park)
      * until its CQE is reaped, which is strictly after the IL's last touch
-     * of the txn and the channel, so zero here means quiescent. */
+     * of the txn and the channel, so zero here means quiescent.
+     *
+     * Drain the CQ directly rather than pumping the event loop: the IL posts
+     * commit CQEs WITHOUT ringing the cq_doorbell (it relies on the pinned
+     * worker reaping via the per-iteration poll), and evpl_continue stops
+     * running polls once its poll-iteration budget expires without activity
+     * and parks in the OS wait -- with no doorbell ever coming, that is a
+     * deadlock (seen as mass diskfs test timeouts in CI, where loaded
+     * runners reach teardown with a commit still in flight).  drain_cq also
+     * resubmits commits parked on the SQ-full FIFO, so parked entries make
+     * progress too. */
     while (thread->commits_inflight > 0) {
-        evpl_continue(thread->evpl);
+        if (diskfs_iq_drain_cq(thread->iq_channel) == 0) {
+            usleep(100);
+        }
     }
 
     evpl_iovec_release(thread->evpl, &thread->zero);
@@ -9831,12 +9843,12 @@ diskfs_thread_destroy(void *private_data)
         __atomic_store_n(&shared->intent_log.reg_dirty, 1, __ATOMIC_SEQ_CST);
         evpl_ring_doorbell(&shared->intent_log.wake_doorbell);
 
-        /* Pump the event loop rather than raw-spinning: should anything still
-         * be in flight on this channel despite the commits_inflight drain
-         * above, this keeps the CQ draining instead of deadlocking against a
-         * full ring. */
+        /* Spin (not evpl_continue: with nothing left in flight there is no
+         * event to wake the loop, and the IL acks via a plain store with no
+         * doorbell).  The commits_inflight drain above guarantees the channel
+         * is quiescent, so the IL acks on its next registration sweep. */
         while (!__atomic_load_n(&ch->unregister_done, __ATOMIC_ACQUIRE)) {
-            evpl_continue(thread->evpl);
+            usleep(100);
         }
 
         evpl_remove_poll(thread->evpl, thread->cq_poll);

--- a/src/vfs/diskfs/diskfs.c
+++ b/src/vfs/diskfs/diskfs.c
@@ -7712,6 +7712,21 @@ diskfs_il_service_registrations(struct diskfs_intent_log *il)
 
         if (__atomic_load_n(&ch->unregister_requested, __ATOMIC_ACQUIRE)) {
             uint32_t last = il->num_channels - 1;
+
+            /* The worker frees the channel (and soon its thread struct) the
+             * moment unregister_done is set, and retired txns dereference
+             * their submitting thread -- acking with anything still in
+             * flight would be a use-after-free.  The worker guarantees
+             * quiescence (commits_inflight drained to zero) before
+             * requesting unregistration; make a violation loud instead of
+             * corrupting memory. */
+            chimera_diskfs_abort_if(
+                ch->cq_inflight != 0 ||
+                __atomic_load_n(&ch->sq.tail, __ATOMIC_ACQUIRE) !=
+                __atomic_load_n(&ch->sq.head, __ATOMIC_RELAXED),
+                "intent-log channel unregistered with work in flight "
+                "(cq_inflight=%u)", ch->cq_inflight);
+
             if (i != last) {
                 il->channels[i] = il->channels[last];
             }
@@ -9773,6 +9788,23 @@ diskfs_thread_destroy(void *private_data)
         chimera_diskfs_debug("diskfs_thread_destroy: drain complete");
     }
 
+    /* Wait for every commit this thread handed to the intent log to become
+     * durable and be reaped from the CQ.  The IL's retire path walks each
+     * txn's pinned blocks and dereferences txn->thread
+     * (diskfs_txn_unpin_blocks -> diskfs_block_unpin -> thread->shared), so
+     * tearing this thread down with a commit still in flight is a
+     * use-after-free on both the thread struct and the iq channel.  The
+     * drains above do not cover it: with unsafe_async a VFS request
+     * completes before its commit is durable, so the caller can legitimately
+     * reach thread teardown with redo writes still queued at the IL (seen as
+     * an elbencho-teardown ASan UAF in diskfs_block_unpin).
+     * commits_inflight counts every commit from submission (or SQ-full park)
+     * until its CQE is reaped, which is strictly after the IL's last touch
+     * of the txn and the channel, so zero here means quiescent. */
+    while (thread->commits_inflight > 0) {
+        evpl_continue(thread->evpl);
+    }
+
     evpl_iovec_release(thread->evpl, &thread->zero);
     evpl_iovec_release(thread->evpl, &thread->pad);
 
@@ -9799,8 +9831,12 @@ diskfs_thread_destroy(void *private_data)
         __atomic_store_n(&shared->intent_log.reg_dirty, 1, __ATOMIC_SEQ_CST);
         evpl_ring_doorbell(&shared->intent_log.wake_doorbell);
 
+        /* Pump the event loop rather than raw-spinning: should anything still
+         * be in flight on this channel despite the commits_inflight drain
+         * above, this keeps the CQ draining instead of deadlocking against a
+         * full ring. */
         while (!__atomic_load_n(&ch->unregister_done, __ATOMIC_ACQUIRE)) {
-            /* spin */
+            evpl_continue(thread->evpl);
         }
 
         evpl_remove_poll(thread->evpl, thread->cq_poll);


### PR DESCRIPTION
Fixes the elbencho `diskfs_verify` CI flake (SIGSEGV at exit in Release; ASan heap-use-after-free in Debug, 2 occurrences).

`diskfs_thread_destroy` drained mtime flushes, background inode drains, and pending block I/O — but nothing covered commits already handed to the intent log whose redo writes were still in flight. The IL's retire path walks each txn's pinned blocks and dereferences `txn->thread` (`diskfs_txn_unpin_blocks` → `diskfs_block_unpin` → `thread->shared`), and posts the CQE into the channel the worker frees at unregister. A teardown racing a late redo write is therefore a use-after-free on both the thread struct and the iq channel. With `unsafe_async` a VFS request completes before its commit is durable, so a caller can legitimately reach thread teardown in exactly that state — which is how elbencho's per-worker client shutdown hit it:

```
READ of size 8 ... in diskfs_block_unpin diskfs.c:2578
  diskfs_txn_unpin_blocks ← diskfs_redo_write_cb ← evpl_block_complete   (IL thread)
freed by diskfs_thread_destroy ← chimera_vfs_thread_destroy ← elb_chimera_worker_destroy
```

Fix:
- **Drain on `commits_inflight` before teardown.** It counts every commit from submission (or SQ-full park) until its CQE is reaped — strictly after the IL's last touch of the txn and the channel — so zero means the channel is quiescent. (The IL consumes an SQ entry and reserves its CQ slot in one step, so `SQ empty && cq_inflight == 0` has no in-between window.)
- The unregister wait pumps the event loop instead of raw-spinning, keeping the CQ draining if anything is ever still in flight there.
- The IL's unregister pass now **aborts loudly** if asked to drop a channel with work in flight, so any future gap in the quiesce protocol becomes a deterministic assert instead of heap corruption.

elbencho diskfs tests looped 20× green under ASan; full posix diskfs battery (664) and smbtorture diskfs suites (110) green.