### PR TITLE
posix/tests: child watchdog for the post-fork hang family; close a log-flusher fork window

### DIFF
--- a/src/common/logging.c
+++ b/src/common/logging.c
@@ -132,6 +132,14 @@ SYMBOL_EXPORT int  ChimeraLogLevel    = CHIMERA_LOG_INFO;
 FILE              *ChimeraLogFile     = NULL; /* NULL => write to stdout */
 int                ChimeraLogDisabled = 0;
 pthread_mutex_t    ChimeraLogBufLock  = PTHREAD_MUTEX_INITIALIZER;
+/* Held by the flusher across its stdio write and by the atfork prepare
+ * handler: without it, fork() can land while the flusher is inside
+ * fprintf/fflush holding the C library's stream lock, and the child inherits
+ * that lock permanently taken -- its first write to the same stream (e.g.
+ * chimera_vlog's inline drain once the buffer fills with no flusher alive)
+ * deadlocks.  ChimeraLogBufLock alone cannot prevent this because the flusher
+ * deliberately prints outside it. */
+pthread_mutex_t    ChimeraLogFlushLock = PTHREAD_MUTEX_INITIALIZER;
 pthread_t          ChimeraLogThread;
 pthread_once_t     ChimeraLogOnce = PTHREAD_ONCE_INIT;
 
@@ -146,6 +154,9 @@ chimera_log_thread(void *arg)
 
         if (ChimeraLogBufPtr > ChimeraLogBuf) {
 
+            /* FlushLock before BufLock; the atfork prepare handler takes them
+             * in the same order. */
+            pthread_mutex_lock(&ChimeraLogFlushLock);
             pthread_mutex_lock(&ChimeraLogBufLock);
             tmp              = ChimeraLogBuf;
             ChimeraLogIndex  = !ChimeraLogIndex;
@@ -155,6 +166,7 @@ chimera_log_thread(void *arg)
 
             fprintf(out, "%s", tmp);
             fflush(out);
+            pthread_mutex_unlock(&ChimeraLogFlushLock);
         }
         usleep(1000);
     }
@@ -206,6 +218,10 @@ chimera_log_flush_signal(int signum)
 static void
 chimera_log_atfork_prepare(void)
 {
+    /* FlushLock first (same order as the flusher): holding it across fork()
+     * guarantees the flusher is not mid-fprintf/fflush, so the child cannot
+     * inherit the C library's stream lock in a taken state. */
+    pthread_mutex_lock(&ChimeraLogFlushLock);
     pthread_mutex_lock(&ChimeraLogBufLock);
 } /* chimera_log_atfork_prepare */
 
@@ -213,6 +229,7 @@ static void
 chimera_log_atfork_parent(void)
 {
     pthread_mutex_unlock(&ChimeraLogBufLock);
+    pthread_mutex_unlock(&ChimeraLogFlushLock);
 } /* chimera_log_atfork_parent */
 
 static void
@@ -229,6 +246,7 @@ chimera_log_atfork_child(void)
      * the parent's log thread).
      */
     pthread_mutex_init(&ChimeraLogBufLock, NULL);
+    pthread_mutex_init(&ChimeraLogFlushLock, NULL);
     ChimeraLogRun = 0;
 
     if (ChimeraLogBuf) {

--- a/src/posix/tests/cthon_lock_tlock.c
+++ b/src/posix/tests/cthon_lock_tlock.c
@@ -622,6 +622,9 @@ main(
     if ((childpid = fork()) == 0) {
         who = CHILD;
         signal(SIGINT, childsig);
+        /* Fail fast with a stack if this child wedges (the recurring
+         * lock-family post-fork hang); fires well before the ctest timeout. */
+        posix_test_child_watchdog(240);
     } else {
         who = PARENT;
         signal(SIGINT, parentsig);

--- a/src/posix/tests/posix_test_common.h
+++ b/src/posix/tests/posix_test_common.h
@@ -11,12 +11,91 @@
 #include <unistd.h>
 #include <sys/stat.h>
 #include <errno.h>
+#include <signal.h>
+#include <dirent.h>
+#include <execinfo.h>
 #include <jansson.h>
 #include "posix/posix.h"
 #include "server/server.h"
 #include "common/logging.h"
 #include "common/test_users.h"
 #include "prometheus-c.h"
+
+/*
+ * Self-dumping watchdog for the forked child of a cross-process test.
+ *
+ * The lock-family tests (lockf, fcntl, cthon tlock) fork a child that runs
+ * its own chimera_posix init/mount/open.  A rare, so-far-unreproduced CI
+ * flake strands that child before it signals the parent, and the test dies
+ * as a silent 300s ctest Timeout with no stack -- four tests have hit it
+ * (lockf_linux, lockf_io_uring, fcntl_io_uring, cthon_lock_tlock_linux).
+ *
+ * Arm SIGALRM in the child well below the ctest timeout.  On fire, dump
+ * every thread's kernel sleep location (procfs wchan -- localizes a hang to
+ * its blocking syscall even for threads this handler cannot backtrace) plus
+ * the signaled thread's userspace backtrace, then abort().  The SIGABRT
+ * unblocks the parent's waitpid, so the test fails fast WITH diagnostics
+ * instead of timing out silently.  The handler knowingly calls
+ * async-signal-unsafe functions: the process is wedged and about to abort,
+ * so a lost dump costs nothing over the status quo.
+ */
+static void
+posix_test_child_watchdog_fire(int sig)
+{
+    void *frames[64];
+    int   nframes;
+    DIR  *taskdir;
+
+    (void) sig;
+
+    dprintf(STDERR_FILENO,
+            "child-watchdog: pid %d stuck; dumping thread states\n",
+            (int) getpid());
+
+    taskdir = opendir("/proc/self/task");
+    if (taskdir) {
+        struct dirent *de;
+
+        while ((de = readdir(taskdir)) != NULL) {
+            char    path[280], wchan[128];
+            int     wfd;
+            ssize_t m = 0;
+
+            if (de->d_name[0] == '.') {
+                continue;
+            }
+            snprintf(path, sizeof(path), "/proc/self/task/%s/wchan",
+                     de->d_name);
+            wfd = open(path, O_RDONLY);
+            if (wfd >= 0) {
+                m = read(wfd, wchan, sizeof(wchan) - 1);
+                close(wfd);
+            }
+            wchan[m > 0 ? m : 0] = '\0';
+            dprintf(STDERR_FILENO, "child-watchdog: tid %s wchan %s\n",
+                    de->d_name, wchan);
+        }
+        closedir(taskdir);
+    }
+
+    dprintf(STDERR_FILENO, "child-watchdog: signaled thread backtrace:\n");
+    nframes = backtrace(frames, 64);
+    backtrace_symbols_fd(frames, nframes, STDERR_FILENO);
+
+    signal(SIGABRT, SIG_DFL);
+    abort();
+} /* posix_test_child_watchdog_fire */
+
+static inline void
+posix_test_child_watchdog(unsigned int seconds)
+{
+    struct sigaction sa;
+
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_handler = posix_test_child_watchdog_fire;
+    sigaction(SIGALRM, &sa, NULL);
+    alarm(seconds);
+} /* posix_test_child_watchdog */
 
 struct posix_test_env {
     struct chimera_posix_client *posix;

--- a/src/posix/tests/test_fcntl.c
+++ b/src/posix/tests/test_fcntl.c
@@ -58,6 +58,10 @@ child_main(
     close(p2c[1]);
     close(c2p[0]);
 
+    /* Fail fast with a stack if this child wedges (the recurring lock-family
+     * post-fork hang); fires well before the 300s ctest timeout. */
+    posix_test_child_watchdog(240);
+
     fprintf(stderr, "child: Testing chimera_posix_fcntl()...\n");
     env->posix = chimera_posix_init_json(posix_json_path, cred, env->metrics);
 
@@ -66,6 +70,8 @@ child_main(
         return 1;
     }
 
+    fprintf(stderr, "child: init done\n");
+
     /* Wait for parent to create + lock the file. optional start NFS server */
     recv_sig(p2c[0]);
 
@@ -73,6 +79,8 @@ child_main(
         fprintf(stderr, "child: mount failed: %s\n", strerror(errno));
         return 1;
     }
+
+    fprintf(stderr, "child: mount done\n");
 
     fd = chimera_posix_open(TEST_FILE, O_RDWR, 0);
 

--- a/src/posix/tests/test_lockf.c
+++ b/src/posix/tests/test_lockf.c
@@ -54,12 +54,18 @@ child_main(
     close(p2c[1]);
     close(c2p[0]);
 
+    /* Fail fast with a stack if this child wedges (the recurring lock-family
+     * post-fork hang); fires well before the 300s ctest timeout. */
+    posix_test_child_watchdog(240);
+
     env->posix = chimera_posix_init_json(posix_json_path, cred, env->metrics);
 
     if (!env->posix) {
         fprintf(stderr, "child: chimera init failed\n");
         return 1;
     }
+
+    fprintf(stderr, "child: init done\n");
 
     /* Wait for parent to create + lock the file. optional start NFS server */
     recv_sig(p2c[0]);
@@ -68,6 +74,8 @@ child_main(
         fprintf(stderr, "child: mount failed: %s\n", strerror(errno));
         return 1;
     }
+
+    fprintf(stderr, "child: mount done\n");
 
     fd = chimera_posix_open(TEST_FILE, O_RDWR, 0);
 


### PR DESCRIPTION
Targets the recurring cross-process-lock-test flake: **four tests now share it** (`lockf_linux`, `lockf_io_uring`, `fcntl_io_uring`, `cthon_lock_tlock_linux`) — the forked child wedges somewhere in its own `chimera_posix` init/mount/open and the test dies as a silent 300s ctest Timeout. It has never reproduced locally (~30 min of looping in this session either).

**1. Self-dumping child watchdog.** The forked child arms SIGALRM at 240s; on fire it dumps every thread's kernel sleep location (procfs `wchan` — localizes a hang to its blocking syscall even for threads the handler can't backtrace) plus the signaled thread's userspace backtrace, then `abort()`s — so the parent's `waitpid` unblocks and the test fails fast **with diagnostics** instead of timing out silently. Children also print init/mount breadcrumbs to localize the hung phase. The next CI occurrence will tell us exactly where the child is stuck.

**2. The one concrete fork hazard the audit found.** These tests fork before starting chimera threads — but the **log flusher thread** already exists pre-fork, and it prints with `fprintf`/`fflush` *outside* `ChimeraLogBufLock`. The atfork prepare handler takes only that lock, so a fork can land while the flusher is mid-write — the child then inherits the C library's stream lock permanently taken, and deadlocks on its first write to the same stream (`chimera_vlog`'s inline no-flusher drain hits exactly that once the child's 1MB buffer fills, which a DEBUG-level init does quickly). Fix: a `ChimeraLogFlushLock` held by the flusher across its stdio write, taken first (consistent order) by the atfork prepare handler, re-initialized in the child.

I can't prove (2) is THE hang — the window needs pre-fork log traffic, which these tests generate little of — but it's a real load-dependent fork bug regardless, and (1) will conclusively identify any residual cause.

Lock-family tests looped 15× green; broader posix battery green.