### PR TITLE
nfs4/vfs: make wedged-request stalls visible in the server log

### DIFF
--- a/src/server/nfs/nfs4_session.c
+++ b/src/server/nfs/nfs4_session.c
@@ -1329,9 +1329,11 @@ nfs4_replay_slot_acquire(
                     memory_order_acq_rel, memory_order_acquire)) {
                 continue;  /* lost the race; re-read and re-evaluate */
             }
-            req->replay_slot    = slot;
-            req->replay_slot_id = slotid;
-            req->replay_action  = NFS4_REPLAY_ACTION_NEW;
+            req->replay_slot        = slot;
+            req->replay_slot_id     = slotid;
+            req->replay_action      = NFS4_REPLAY_ACTION_NEW;
+            slot->in_progress_since = nfs4_slot_now();
+            slot->last_stuck_report = 0;
             if (cachethis) {
                 nfs4_replay_arm_capture(req);
             }
@@ -1356,9 +1358,11 @@ nfs4_replay_slot_acquire(
                     atomic_fetch_sub_explicit(&session->replay_bytes_in_use,
                                               freed_bytes, memory_order_relaxed);
                 }
-                req->replay_slot    = slot;
-                req->replay_slot_id = slotid;
-                req->replay_action  = NFS4_REPLAY_ACTION_NEW;
+                req->replay_slot        = slot;
+                req->replay_slot_id     = slotid;
+                req->replay_action      = NFS4_REPLAY_ACTION_NEW;
+                slot->in_progress_since = nfs4_slot_now();
+                slot->last_stuck_report = 0;
                 if (cachethis) {
                     nfs4_replay_arm_capture(req);
                 }
@@ -1384,6 +1388,27 @@ nfs4_replay_slot_acquire(
              * produce a reply yet.  Both paths return errors. */
             if (seqid == cseq) {
                 status = NFS4ERR_RETRY_UNCACHED_REP;
+                /* A retry landing on a slot that has been IN_PROGRESS for many
+                 * seconds means the original compound is wedged server-side;
+                 * the client will retry RETRY_UNCACHED_REP silently forever
+                 * (observed as fsstress writeback hanging in CI with 14k
+                 * errored WRITE RPCs and nothing in the server log).  Make the
+                 * wedge visible, rate-limited per slot. */
+                {
+                    time_t now = nfs4_slot_now();
+
+                    if (slot->in_progress_since &&
+                        now - slot->in_progress_since >= 5 &&
+                        now - slot->last_stuck_report >= 10) {
+                        slot->last_stuck_report = now;
+                        chimera_nfs_error(
+                            "nfs4 session slot %u seqid %u stuck IN_PROGRESS "
+                            "for %ld sec; replying RETRY_UNCACHED_REP "
+                            "(original compound has not completed)",
+                            slotid, seqid,
+                            (long) (now - slot->in_progress_since));
+                    }
+                }
             } else {
                 status = NFS4ERR_SEQ_MISORDERED;
             }

--- a/src/server/nfs/nfs4_session.h
+++ b/src/server/nfs/nfs4_session.h
@@ -6,6 +6,7 @@
 
 #include <stdatomic.h>
 #include <stdbool.h>
+#include <time.h>
 #include <uthash.h>
 
 #include "nfs4_xdr.h"
@@ -56,10 +57,28 @@ struct nfs4_replay_slot {
     _Atomic uint64_t state_word;       /* (seqid << NFS4_SLOT_SEQID_SHIFT) | state */
     uint32_t         cached_len;       /* bytes in cached_buf (CACHED only) */
     void            *cached_buf;       /* RPC reply (header+body); malloc'd */
+    /* Diagnostics for a wedged compound: when the slot entered IN_PROGRESS
+     * and when a stuck-slot report was last logged for it.  Written only by
+     * the CAS winner / the retry path observing it, both monotonic-seconds;
+     * plain (non-atomic) is fine for a rate-limited log. */
+    time_t           in_progress_since;
+    time_t           last_stuck_report;
 };
 
 #define NFS4_SLOT_STATE_MASK  0x3u
 #define NFS4_SLOT_SEQID_SHIFT 2
+
+/* Coarse monotonic seconds for the slot-stuck diagnostics; off every hot
+ * comparison except the IN_PROGRESS transitions and the already-failing
+ * retry path. */
+static inline time_t
+nfs4_slot_now(void)
+{
+    struct timespec ts;
+
+    clock_gettime(CLOCK_MONOTONIC_COARSE, &ts);
+    return ts.tv_sec;
+} /* nfs4_slot_now */
 
 static inline uint64_t
 nfs4_slot_word(

--- a/src/vfs/vfs.c
+++ b/src/vfs/vfs.c
@@ -977,7 +977,24 @@ chimera_vfs_watchdog(struct chimera_vfs_thread *thread)
     elapsed = prometheus_stopwatch_elapsed_ns(&request->start_time);
 
     if (elapsed > 10000000000UL) {
-        chimera_vfs_debug("oldest request has been active for %lu ns", elapsed);
+        /* A request alive this long is wedged, and at the default (info) log
+         * level a debug-only report is invisible -- a CI hang then yields no
+         * server-side evidence at all (a stuck WRITE wedged an NFS4.1 session
+         * slot for 290s with an empty log).  Identify the request at error
+         * level; rate-limit to one report per thread per ~30s so a long wedge
+         * does not flood. */
+        struct timespec ts;
+
+        clock_gettime(CLOCK_MONOTONIC_COARSE, &ts);
+
+        if (ts.tv_sec - thread->watchdog_last_report >= 30) {
+            thread->watchdog_last_report = ts.tv_sec;
+            chimera_vfs_error(
+                "request %p op %s active for %lu sec (oldest on this thread)",
+                (void *) request,
+                chimera_vfs_op_name(request->opcode),
+                elapsed / 1000000000UL);
+        }
         chimera_vfs_dump_request(request);
     }
 

--- a/src/vfs/vfs.h
+++ b/src/vfs/vfs.h
@@ -1445,6 +1445,8 @@ struct chimera_vfs_thread {
      * pump runs on whatever thread released/broke a lease, but a request's
      * dispatch+reply must run on the thread that owns its connection iovecs). */
     struct chimera_vfs_request          *pending_io_resume;
+    /* Monotonic seconds of the last watchdog stuck-request report. */
+    time_t                               watchdog_last_report;
     struct evpl_doorbell                 doorbell;
     pthread_mutex_t                      lock;
     uint64_t                             anon_fh_key;


### PR DESCRIPTION
Follow-up to the new `kvm/xfstests/fsstress_linux_nfs4.1/4.2` timeout flake (2 legs of one merge-queue run, rescued on rerun).

What the evidence shows: fsstress wedged in `close() → nfs_wb_all → folio_wait_writeback`; mountstats recorded **14,466 of 14,486 WRITE RPCs returning errors** the client retried silently — no retransmits, no state-manager recovery. That pattern is `NFS4ERR_RETRY_UNCACHED_REP`: the original WRITE compound never completed server-side, its session slot stayed IN_PROGRESS, and every client retransmit of the same slot/seqid got the retry status, forever. The wedge survived ~290s. The server log contained **nothing** — the VFS watchdog that tracks the oldest active request reports only at debug level, and the slot machine returns the retry status silently.

Ruled out so far: the write path takes no implicit-lease parking (NFS4 writes carry an owner and proceed immediately), there is no DELAY producer in the write path, and the silent-retry behavior excludes stateid/session recovery errors. What's left (a lost dispatch/completion somewhere between the slot machine and the backend) is not findable from current CI logs, and the flake has not reproduced locally.

This PR makes the next occurrence pin the wedge precisely, with two rate-limited error-level reports:

- **Session slot machine**: each slot is stamped when it enters IN_PROGRESS; a retransmit landing on a slot stuck ≥5s reports the slot/seqid and age (≤1 report per 10s per slot).
- **VFS watchdog**: the oldest active request is reported at error level with its opcode and age once it passes 10s (≤1 per 30s per thread) — previously debug-gated and invisible at the default log level.

Together they answer "which opcode is wedged, how old is it, and which slot is it holding" from any future CI log. pynfs session suites (408) and posix nfs4 battery (498) green.