### PR TITLE
ci: clean up PR check list — split required-check placeholders into pr-checks.yml

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -5,8 +5,11 @@
 name: CI
 
 on:
-  pull_request:        # PRs: lint + cheap aggregator no-ops (heavy jobs gated to merge_group)
-  merge_group:         # full matrix runs only in the merge queue, not on raw PRs; don't publish
+  # The full build/test matrix runs ONLY in the merge queue, never on raw PRs
+  # (PR-time required-check placeholders live in pr-checks.yml).  The job-level
+  # `if: github.event_name != 'pull_request'` guards below are now redundant but
+  # left in place as a harmless backstop.
+  merge_group:
   workflow_dispatch:   # allow manual runs
 
 # The full cross-OS, cross-arch test and static-analysis matrix runs nightly

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -10,7 +10,8 @@ on:
       - main          # publish from the default branch
     tags:
       - "*"           # publish when any tag is pushed
-  pull_request:        # PRs: docker-build-complete no-op only (build-and-push gated below)
+  # No pull_request trigger: the PR-time "Docker build complete" placeholder
+  # lives in pr-checks.yml, so PRs don't show a skipped docker-build job.
   merge_group:         # build to gate the merge queue (no publish) but don’t publish
   workflow_dispatch:   # allow manual runs
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+#
+# SPDX-License-Identifier: Unlicense
+
+name: PR checks
+
+# The heavy build/test matrix (build-test.yml) and docker image builds
+# (docker-build.yml) run ONLY in the merge queue (merge_group), not on pull
+# requests -- so a PR's check list isn't cluttered with a wall of skipped
+# matrix jobs.  But the branch-protection ruleset still requires the
+# "CI complete", "Flake review gate" and "Docker build complete" checks on a PR
+# before it can be added to the queue.  This workflow satisfies them with
+# instant no-op placeholders; the real checks of the same names run in the queue
+# (where the actual matrix / image builds / flake review happen).
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  ci-complete:
+    name: CI complete
+    runs-on: arc-amd64
+    steps:
+      - name: PR placeholder
+        run: echo "PR placeholder -- the full build/test matrix runs in the merge queue (merge_group)."
+
+  flake-gate:
+    name: Flake review gate
+    runs-on: arc-amd64
+    # No environment here: flaky-test review only applies to the real test run,
+    # which happens in the merge queue.  Keeping this a plain no-op means a PR
+    # never sits waiting on a manual approval just to be queued.
+    steps:
+      - name: PR placeholder
+        run: echo "PR placeholder -- flaky-test review happens in the merge queue (merge_group)."
+
+  docker-build-complete:
+    name: Docker build complete
+    runs-on: arc-amd64
+    steps:
+      - name: PR placeholder
+        run: echo "PR placeholder -- docker image builds run in the merge queue (merge_group)."


### PR DESCRIPTION
**Problem:** `build-test.yml` and `docker-build.yml` ran on `pull_request` but gated their heavy jobs with `if: github.event_name != 'pull_request'`. GitHub lists conditionally-excluded jobs as **skipped**, so a PR's check list was a wall of skipped matrix / image-build jobs — noisy and confusing.

**Change (Option B — split workflows):**
- Drop the `pull_request` trigger from `build-test.yml` and `docker-build.yml`. They now run only on `merge_group` (+ `push`/`workflow_dispatch`), so none of their jobs appear on a PR run.
- Add `pr-checks.yml` (on `pull_request`) that emits the three required aggregator checks — **CI complete**, **Flake review gate**, **Docker build complete** — as instant no-op placeholders, so a PR can still satisfy the `protect-main` ruleset and be queued.

**Result:** a PR's check list is just the checks that actually run — `reuse-lint`, `uncrustify`, and the three placeholders — instead of ~20 skipped jobs. The real matrix / image builds / flake review run in the merge queue under the **same check names** (so the ruleset is satisfied on both events; each event produces exactly one check of each name).

Bonus fix: the PR-side **Flake review gate** placeholder carries **no environment**, so a clean PR is never left waiting on a manual flake-review approval just to be added to the queue (which was happening with the old in-workflow placeholder).

The now-redundant `!= pull_request` guards on the heavy jobs are left in place as a harmless backstop rather than churning every job.