### PR TITLE
diskfs: full async space reclaim (orphan shards, gen epoch, home-block reuse) + runtime AG-log condensation

### DIFF
--- a/src/posix/tests/CMakeLists.txt
+++ b/src/posix/tests/CMakeLists.txt
@@ -119,6 +119,20 @@ if(CHIMERA_NETNS_TESTING)
     endif()
 endif()
 
+# diskfs-only space-reclaim + AG-log condensation test (statfs convergence
+# over delete churn, unlink-while-open, reclaim backlog across remount)
+add_posix_testprog(test_diskfs_reclaim)
+if(CHIMERA_NETNS_TESTING)
+    if(IO_URING_ENABLED)
+        add_posix_test(diskfs_reclaim_diskfs_io_uring test_diskfs_reclaim diskfs_io_uring)
+        set_tests_properties(chimera/posix/diskfs_reclaim_diskfs_io_uring PROPERTIES TIMEOUT 600)
+    endif()
+    if(HAVE_LIBAIO)
+        add_posix_test(diskfs_reclaim_diskfs_aio test_diskfs_reclaim diskfs_aio)
+        set_tests_properties(chimera/posix/diskfs_reclaim_diskfs_aio PROPERTIES TIMEOUT 600)
+    endif()
+endif()
+
 # ============================================================================
 # NFS3 Backend Tests
 # These tests run the POSIX tests through the Chimera NFS client,

--- a/src/posix/tests/test_diskfs_reclaim.c
+++ b/src/posix/tests/test_diskfs_reclaim.c
@@ -1,0 +1,280 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * diskfs space-reclaim + AG-log condensation test.
+ *
+ * Verifies that deleted-inode space actually returns to the filesystem:
+ * create+write+delete cycles must converge back to the baseline free space
+ * (data extents, b+tree nodes, AND the 4 KiB inode home blocks -- nothing may
+ * bleed), unlink-while-open must hold the space until the last close and
+ * reclaim it afterwards, and a reclaim backlog must survive a cold remount
+ * (DISKFS_DRAIN_DISABLE suppresses the in-session drain so the next mount's
+ * orphan scan does the work).  DISKFS_AG_CONDENSE_DELTAS lowers the AG-log
+ * condensation trigger so the churn above exercises runtime condensation
+ * (park -> snapshot -> slot flip -> resume) many times over.
+ */
+
+#include <sys/vfs.h>
+
+#include "posix_test_common.h"
+
+#define RECLAIM_CYCLES \
+        (getenv("RECLAIM_CYCLES") ? atoi(getenv("RECLAIM_CYCLES")) : 1500)
+#define RECLAIM_FILE_BYTES (256 * 1024)
+
+/* Free-space convergence slack: steady-state metadata that legitimately
+ * stays allocated (directory tree nodes, AG-log churn) is far below this. */
+#define RECLAIM_SLACK      (8ULL << 20)
+
+static uint64_t
+free_bytes(struct posix_test_env *env)
+{
+    struct statfs sf;
+
+    if (chimera_posix_statfs("/test", &sf) != 0) {
+        fprintf(stderr, "statfs failed: %s\n", strerror(errno));
+        posix_test_fail(env);
+    }
+    return (uint64_t) sf.f_bfree * (uint64_t) sf.f_bsize;
+} /* free_bytes */
+
+/* Reclaim is asynchronous: poll until free space is within slack of the
+ * baseline (or time out). */
+static void
+expect_convergence(
+    struct posix_test_env *env,
+    uint64_t               baseline,
+    const char            *phase)
+{
+    uint64_t now_free = 0;
+    int      i;
+
+    for (i = 0; i < 600; i++) {
+        now_free = free_bytes(env);
+        if (now_free + RECLAIM_SLACK >= baseline) {
+            fprintf(stderr, "%s: converged (baseline=%lu free=%lu)\n",
+                    phase, baseline, now_free);
+            return;
+        }
+        usleep(100000);
+    }
+
+    fprintf(stderr, "%s: space did not converge: baseline=%lu free=%lu "
+            "(leaked ~%lu bytes)\n",
+            phase, baseline, now_free, baseline - now_free);
+    posix_test_fail(env);
+} /* expect_convergence */
+
+static void
+write_file(
+    struct posix_test_env *env,
+    const char            *path,
+    int                    keep_open,
+    int                   *r_fd)
+{
+    static char buf[64 * 1024];
+    int         fd, i, rc;
+
+    fd = chimera_posix_open(path, O_CREAT | O_RDWR, 0644);
+    if (fd < 0) {
+        fprintf(stderr, "create %s failed: %s\n", path, strerror(errno));
+        posix_test_fail(env);
+    }
+
+    memset(buf, 0xa5, sizeof(buf));
+    for (i = 0; i < (int) (RECLAIM_FILE_BYTES / sizeof(buf)); i++) {
+        rc = (int) chimera_posix_write(fd, buf, sizeof(buf));
+        if (rc != (int) sizeof(buf)) {
+            fprintf(stderr, "write %s failed: %s\n", path, strerror(errno));
+            posix_test_fail(env);
+        }
+    }
+
+    if (keep_open) {
+        *r_fd = fd;
+    } else {
+        chimera_posix_close(fd);
+    }
+} /* write_file */
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    struct posix_test_env env;
+    char                  path[128];
+    uint64_t              baseline;
+    int                   fd = -1, rc, i;
+
+    /* Exercise AG-log runtime condensation continuously: condense every 64
+     * deltas instead of at the 4 MiB slot high-water. */
+    setenv("DISKFS_AG_CONDENSE_DELTAS", "64", 1);
+
+    posix_test_init(&env, argv, argc);
+    ChimeraLogLevel = CHIMERA_LOG_INFO;
+
+    if (!posix_test_is_diskfs(env.backend)) {
+        fprintf(stderr, "diskfs-only test, nothing to do for %s\n", env.backend);
+        posix_test_success(&env);
+        return 0;
+    }
+
+    rc = posix_test_mount(&env);
+    if (rc != 0) {
+        fprintf(stderr, "Failed to mount test module: %s\n", strerror(errno));
+        posix_test_fail(&env);
+    }
+
+    rc = chimera_posix_mkdir("/test/d", 0755);
+    if (rc != 0) {
+        fprintf(stderr, "mkdir failed: %s\n", strerror(errno));
+        posix_test_fail(&env);
+    }
+
+    /* Warm-up: every client worker that ever allocates retains up to 1 MiB
+     * of space-map reservation as working capital (by design, not a leak).
+     * Touch them all with a round of churn BEFORE taking the baseline, so
+     * the convergence checks below measure true bleed. */
+    fprintf(stderr, "warm-up...\n");
+    for (i = 0; i < 200; i++) {
+        snprintf(path, sizeof(path), "/test/d/w%04d", i % 32);
+        write_file(&env, path, 0, NULL);
+        if (chimera_posix_unlink(path) != 0) {
+            fprintf(stderr, "unlink %s failed: %s\n", path, strerror(errno));
+            posix_test_fail(&env);
+        }
+    }
+    /* Let the warm-up's reclaim settle so the baseline is steady. */
+    sleep(3);
+
+    baseline = free_bytes(&env);
+    fprintf(stderr, "baseline free: %lu bytes\n", baseline);
+
+    /* Phase 1: create+write+delete churn must not bleed space.  This also
+     * recycles inums (home blocks return to the allocator), so stale-handle
+     * safety rides on the generation epoch throughout. */
+    fprintf(stderr, "phase 1: %d create/write/delete cycles...\n",
+            RECLAIM_CYCLES);
+    for (i = 0; i < RECLAIM_CYCLES; i++) {
+        snprintf(path, sizeof(path), "/test/d/f%04d", i % 32);
+        write_file(&env, path, 0, NULL);
+        if (chimera_posix_unlink(path) != 0) {
+            fprintf(stderr, "unlink %s failed: %s\n", path, strerror(errno));
+            posix_test_fail(&env);
+        }
+    }
+    expect_convergence(&env, baseline, "phase 1 (churn)");
+
+    /* Phase 2: unlink-while-open defers reclaim to the final close.  The
+     * open handle must keep the (now nameless) file fully readable -- if the
+     * extents were reclaimed early this read returns wrong data or fails --
+     * and the close must then hand it to the reclaim workers. */
+    fprintf(stderr, "phase 2: unlink-while-open...\n");
+    write_file(&env, "/test/d/held", 1, &fd);
+    if (chimera_posix_unlink("/test/d/held") != 0) {
+        fprintf(stderr, "unlink held failed: %s\n", strerror(errno));
+        posix_test_fail(&env);
+    }
+    {
+        static char rbuf[64 * 1024];
+        int         k, r;
+
+        for (k = 0; k < (int) (RECLAIM_FILE_BYTES / sizeof(rbuf)); k++) {
+            r = (int) chimera_posix_pread(fd, rbuf, sizeof(rbuf),
+                                          (off_t) k * (off_t) sizeof(rbuf));
+            if (r != (int) sizeof(rbuf) ||
+                memchr(rbuf, 0, sizeof(rbuf)) != NULL) {
+                fprintf(stderr, "phase 2: unlinked-but-open file unreadable "
+                        "at %d (r=%d)\n", k, r);
+                posix_test_fail(&env);
+            }
+        }
+    }
+    chimera_posix_close(fd);
+    expect_convergence(&env, baseline, "phase 2 (close reclaim)");
+
+    /* Phase 3: a reclaim backlog survives a cold remount.  Suppress the
+     * in-session drain entirely; the deletes only leave durable orphan
+     * records, and the next mount's scan must reclaim everything. */
+    fprintf(stderr, "phase 3: backlog across cold remount...\n");
+    setenv("DISKFS_DRAIN_DISABLE", "1", 1);
+    for (i = 0; i < 64; i++) {
+        snprintf(path, sizeof(path), "/test/d/b%04d", i);
+        write_file(&env, path, 0, NULL);
+        if (chimera_posix_unlink(path) != 0) {
+            fprintf(stderr, "unlink %s failed: %s\n", path, strerror(errno));
+            posix_test_fail(&env);
+        }
+    }
+    unsetenv("DISKFS_DRAIN_DISABLE");
+
+    rc = posix_test_umount();
+    if (rc != 0) {
+        fprintf(stderr, "umount failed: %s\n", strerror(errno));
+        posix_test_fail(&env);
+    }
+
+    chimera_posix_shutdown();
+
+    {
+        char                       diskfs_cfg[4096];
+        char                       posix_json_path[300];
+        json_t                    *root, *config, *vfs, *vfs_entry;
+        struct prometheus_metrics *metrics2;
+
+        posix_test_diskfs_reuse_devices = 1;
+        posix_test_configure_diskfs(env.session_dir,
+                                    posix_test_diskfs_device_type(env.backend),
+                                    diskfs_cfg, sizeof(diskfs_cfg));
+
+        root      = json_object();
+        config    = json_object();
+        vfs       = json_object();
+        vfs_entry = json_object();
+        json_object_set_new(vfs_entry, "path", json_string("/build/test/diskfs"));
+        json_object_set_new(vfs_entry, "config", json_string(diskfs_cfg));
+        json_object_set_new(vfs, "diskfs", vfs_entry);
+        json_object_set_new(config, "vfs", vfs);
+        json_object_set_new(root, "config", config);
+        chimera_test_write_users_json(root);
+
+        snprintf(posix_json_path, sizeof(posix_json_path),
+                 "%s/posix_remount.json", env.session_dir);
+        json_dump_file(root, posix_json_path, 0);
+        json_decref(root);
+
+        metrics2  = prometheus_metrics_create(NULL, NULL, 0);
+        env.posix = chimera_posix_init_json(posix_json_path, &env.cred, metrics2);
+        if (!env.posix) {
+            fprintf(stderr, "Failed to re-initialize POSIX client\n");
+            posix_test_fail(&env);
+        }
+        prometheus_metrics_destroy(env.metrics);
+        env.metrics = metrics2;
+    }
+
+    rc = posix_test_mount(&env);
+    if (rc != 0) {
+        fprintf(stderr, "Failed to re-mount: %s\n", strerror(errno));
+        posix_test_fail(&env);
+    }
+
+    expect_convergence(&env, baseline, "phase 3 (remount re-drain)");
+
+    if (chimera_posix_rmdir("/test/d") != 0) {
+        fprintf(stderr, "rmdir failed: %s\n", strerror(errno));
+        posix_test_fail(&env);
+    }
+
+    rc = posix_test_umount();
+    if (rc != 0) {
+        fprintf(stderr, "umount failed: %s\n", strerror(errno));
+        posix_test_fail(&env);
+    }
+
+    posix_test_success(&env);
+    return 0;
+} /* main */

--- a/src/vfs/diskfs/diskfs.c
+++ b/src/vfs/diskfs/diskfs.c
@@ -1096,6 +1096,10 @@ struct diskfs_shared {
     uint64_t                   fsid;
     struct space_map          *space_map;
     struct diskfs_intent_log   intent_log;
+    /* Dedicated reclaim workers: deleted-inode burn-down (and other background
+     * maintenance) runs here, off the request workers' hot path. */
+    struct diskfs_reclaim     *reclaim;
+    uint32_t                   reclaim_threads;    /* config knob (0 = default) */
     struct diskfs_metrics      metrics;
     pthread_mutex_t            lock;
 };
@@ -5094,6 +5098,192 @@ diskfs_drain_step(struct diskfs_drain *d)
 } /* diskfs_drain_step */
 
 /* ------------------------------------------------------------------ */
+/* Reclaim worker pool: dedicated threads for background space reclaim */
+/*                                                                      */
+/* Deleted-inode burn-down (and other background maintenance) runs on   */
+/* its own small pool of evpl threads, each owning a full diskfs thread */
+/* context (block queues, b+tree ops, an intent-log channel), so the    */
+/* incremental drains never compete for the request workers' loops.     */
+/* Jobs are submitted cross-thread onto a per-worker FIFO + doorbell    */
+/* and handed to the worker's existing drain machinery.                 */
+/* ------------------------------------------------------------------ */
+
+#define DISKFS_RECLAIM_THREADS_DEFAULT 2
+
+/* Defined with the module thread hooks below. */
+static void * diskfs_thread_init(
+    struct evpl *evpl,
+    void        *private_data);
+static void diskfs_thread_destroy(
+    void *private_data);
+
+struct diskfs_reclaim_job {
+    uint64_t                   inum;
+    uint32_t                   gen;
+    struct diskfs_reclaim_job *next;
+};
+
+struct diskfs_reclaim_worker {
+    struct diskfs_shared      *shared;
+    struct diskfs_thread      *ctx;        /* this worker's diskfs thread context */
+    struct evpl_thread        *thread;
+    struct evpl_doorbell       doorbell;
+    pthread_mutex_t            lock;
+    struct diskfs_reclaim_job *head;
+    struct diskfs_reclaim_job *tail;
+    int                        ready;      /* atomic: context constructed */
+};
+
+struct diskfs_reclaim {
+    struct diskfs_reclaim_worker *workers;
+    uint32_t                      nworkers;
+    uint32_t                      rr;      /* atomic round-robin submit cursor */
+};
+
+/* Pop every queued job and hand it to this worker's drain machinery. */
+static void
+diskfs_reclaim_doorbell_cb(
+    struct evpl          *evpl,
+    struct evpl_doorbell *doorbell)
+{
+    struct diskfs_reclaim_worker *w = container_of(doorbell,
+                                                   struct diskfs_reclaim_worker,
+                                                   doorbell);
+    struct diskfs_reclaim_job    *jobs, *j;
+
+    (void) evpl;
+
+    pthread_mutex_lock(&w->lock);
+    jobs    = w->head;
+    w->head = NULL;
+    w->tail = NULL;
+    pthread_mutex_unlock(&w->lock);
+
+    while (jobs) {
+        j    = jobs;
+        jobs = j->next;
+        diskfs_drain_enqueue(w->ctx, j->inum, j->gen);
+        free(j);
+    }
+} /* diskfs_reclaim_doorbell_cb */
+
+/*
+ * Queue a deleted (nlink==0, refcnt==0) inode for background reclaim on the
+ * worker pool, round-robin.  Safe from any thread.  The durable orphan record
+ * already exists (inserted by the unlink/create txn), so a crash before the
+ * drain finishes is recovered by the next mount's orphan scan.
+ */
+static void
+diskfs_reclaim_submit(
+    struct diskfs_shared *shared,
+    uint64_t              inum,
+    uint32_t              gen)
+{
+    struct diskfs_reclaim        *r = shared->reclaim;
+    struct diskfs_reclaim_worker *w;
+    struct diskfs_reclaim_job    *j;
+    uint32_t                      idx;
+
+    idx = __atomic_fetch_add(&r->rr, 1, __ATOMIC_RELAXED) % r->nworkers;
+    w   = &r->workers[idx];
+
+    j       = malloc(sizeof(*j));
+    j->inum = inum;
+    j->gen  = gen;
+    j->next = NULL;
+
+    pthread_mutex_lock(&w->lock);
+    if (w->tail) {
+        w->tail->next = j;
+    } else {
+        w->head = j;
+    }
+    w->tail = j;
+    pthread_mutex_unlock(&w->lock);
+
+    evpl_ring_doorbell(&w->doorbell);
+} /* diskfs_reclaim_submit */
+
+static void *
+diskfs_reclaim_thread_init(
+    struct evpl *evpl,
+    void        *private_data)
+{
+    struct diskfs_reclaim_worker *w = private_data;
+
+    w->ctx = diskfs_thread_init(evpl, w->shared);
+    evpl_add_doorbell(evpl, &w->doorbell, diskfs_reclaim_doorbell_cb);
+    __atomic_store_n(&w->ready, 1, __ATOMIC_RELEASE);
+    return w;
+} /* diskfs_reclaim_thread_init */
+
+static void
+diskfs_reclaim_thread_shutdown(
+    struct evpl *evpl,
+    void        *private_data)
+{
+    struct diskfs_reclaim_worker *w = private_data;
+    struct diskfs_reclaim_job    *j;
+
+    /* Feed any still-queued jobs to the drain machinery first;
+     * diskfs_thread_destroy pumps until every drain completes, so unmount
+     * finishes the reclaim backlog rather than re-scanning it next mount. */
+    diskfs_reclaim_doorbell_cb(evpl, &w->doorbell);
+
+    evpl_remove_doorbell(evpl, &w->doorbell);
+    diskfs_thread_destroy(w->ctx);
+
+    /* Anything submitted after the doorbell drain is recovered by the next
+     * mount's orphan scan (the records are durable). */
+    while ((j = w->head)) {
+        w->head = j->next;
+        free(j);
+    }
+    pthread_mutex_destroy(&w->lock);
+} /* diskfs_reclaim_thread_shutdown */
+
+static void
+diskfs_reclaim_create(struct diskfs_shared *shared)
+{
+    struct diskfs_reclaim *r = calloc(1, sizeof(*r));
+    uint32_t               i;
+
+    r->nworkers = shared->reclaim_threads ? shared->reclaim_threads
+                                          : DISKFS_RECLAIM_THREADS_DEFAULT;
+    r->workers  = calloc(r->nworkers, sizeof(*r->workers));
+
+    for (i = 0; i < r->nworkers; i++) {
+        struct diskfs_reclaim_worker *w = &r->workers[i];
+
+        w->shared = shared;
+        pthread_mutex_init(&w->lock, NULL);
+        w->thread = evpl_thread_create(NULL, diskfs_reclaim_thread_init,
+                                       diskfs_reclaim_thread_shutdown, w);
+        while (!__atomic_load_n(&w->ready, __ATOMIC_ACQUIRE)) {
+            /* spin briefly; context construction is fast */
+        }
+    }
+    shared->reclaim = r;
+} /* diskfs_reclaim_create */
+
+static void
+diskfs_reclaim_destroy(struct diskfs_shared *shared)
+{
+    struct diskfs_reclaim *r = shared->reclaim;
+    uint32_t               i;
+
+    if (!r) {
+        return;
+    }
+    for (i = 0; i < r->nworkers; i++) {
+        evpl_thread_destroy(r->workers[i].thread);
+    }
+    free(r->workers);
+    free(r);
+    shared->reclaim = NULL;
+} /* diskfs_reclaim_destroy */
+
+/* ------------------------------------------------------------------ */
 /* Mount-time orphan recovery: re-enqueue inodes left on the durable    */
 /* orphan list by a crash mid-drain (draining is idempotent).           */
 /* ------------------------------------------------------------------ */
@@ -5205,7 +5395,7 @@ diskfs_orphan_scan(struct diskfs_thread *thread)
         /* Reload the orphaned (nlink==0) inode into cache, then enqueue it;
          * the drainer resumes its (possibly partially-drained) tree. */
         diskfs_inode_load_sync(thread, io, arr[i].inum, arr[i].gen, 1 /* allow_orphan */);
-        diskfs_drain_enqueue(thread, arr[i].inum, arr[i].gen);
+        diskfs_reclaim_submit(thread->shared, arr[i].inum, arr[i].gen);
     }
     free(arr);
     diskfs_mount_io_close(io);
@@ -8897,6 +9087,8 @@ diskfs_init(
     }
     shared->inode_cache_inodes = (uint32_t) json_integer_value(
         json_object_get(cfg, "inode_cache_inodes"));
+    shared->reclaim_threads = (uint32_t) json_integer_value(
+        json_object_get(cfg, "reclaim_threads"));
 
     json_decref(cfg);
 
@@ -9117,6 +9309,10 @@ diskfs_init(
         /* spin briefly */
     }
 
+    /* Reclaim workers last: their thread contexts register intent-log
+     * channels, so the commit thread must already be up. */
+    diskfs_reclaim_create(shared);
+
     return shared;
 } /* diskfs_init */
 
@@ -9279,6 +9475,10 @@ diskfs_destroy(void *private_data)
 {
     struct diskfs_shared *shared = private_data;
     int                   i;
+
+    /* Reclaim workers first: their shutdown finishes the queued drains, which
+     * need the inode cache and the intent-log threads still alive. */
+    diskfs_reclaim_destroy(shared);
 
     for (i = 0; i < DISKFS_INODE_CACHE_SHARDS; i++) {
         rb_tree_destroy(&shared->inode_cache->shards[i].inodes,
@@ -9534,10 +9734,10 @@ diskfs_mtime_flush_drop_pin(
     }
     pthread_mutex_unlock(&shard->lock);
 
-    /* Enqueue the async drain outside the shard lock (it begins a txn and
-     * acquires inodes, taking shard locks). */
+    /* Submit the async drain outside the shard lock (the drain begins a txn
+     * and acquires inodes, taking shard locks). */
     if (retire) {
-        diskfs_drain_enqueue(thread, inum, gen);
+        diskfs_reclaim_submit(thread->shared, inum, gen);
     }
 } /* diskfs_mtime_flush_drop_pin */
 
@@ -11415,11 +11615,11 @@ diskfs_remove_orphan_done(void *priv)
     struct diskfs_inode           *inode   = p->inode_stash[1];
 
     /* Reclaim now only if nothing else holds the inode open; otherwise the last
-     * close (or deferred-mtime pin drop) will enqueue the drain when refcnt
-     * reaches 0.  The durable orphan record (just written) covers a crash in the
-     * meantime. */
+     * close (or deferred-mtime pin drop) hands it to the reclaim workers when
+     * refcnt reaches 0.  The durable orphan record (just written) covers a
+     * crash in the meantime. */
     if (inode->refcnt == 0) {
-        diskfs_drain_enqueue(p->thread, inode->inum, inode->gen);
+        diskfs_reclaim_submit(p->thread->shared, inode->inum, inode->gen);
     }
     diskfs_remove_at_finish(request);
 } /* diskfs_remove_orphan_done */
@@ -12397,9 +12597,9 @@ diskfs_close_inode_cb(
         if (inode->nlink == 0) {
             /* Delete-on-close: the file was unlinked while open (its durable
              * orphan record was written then), and this was the last reference.
-             * Reclaim its space via the async drain, which frees the extents and
-             * retires the inode -- not inline in this close path. */
-            diskfs_drain_enqueue(p->thread, inode->inum, inode->gen);
+             * Reclaim its space on the reclaim workers, which free the extents
+             * and retire the inode -- not inline in this close path. */
+            diskfs_reclaim_submit(p->thread->shared, inode->inum, inode->gen);
         } else {
             diskfs_inode_free(p->thread, inode);
         }

--- a/src/vfs/diskfs/diskfs.c
+++ b/src/vfs/diskfs/diskfs.c
@@ -52,13 +52,23 @@
  * reclaim).  The orphan inode is a directory whose b+tree keys are orphan
  * inums; the drainer empties it. */
 #define DISKFS_ROOT_INUM          2
-#define DISKFS_ORPHAN_INUM        3
+/* Sharded orphan-list inodes: deleted-but-not-yet-reclaimed inodes are
+ * recorded as DISKFS_REC_ORPHAN keys spread across these (by deleted inum),
+ * so concurrent unlinks don't serialize on a single inode's write lock
+ * (inode locks are held until the txn is durable).  Created at format,
+ * permanent.  Count is baked into the on-disk bootstrap layout. */
+#define DISKFS_ORPHAN_INUM_BASE   3
+#define DISKFS_ORPHAN_SHARDS      SM_BOOTSTRAP_ORPHAN_SLOTS
 #define DISKFS_ORPHAN_GEN         1   /* permanent: created at format, never deleted */
 
+#define DISKFS_ORPHAN_SHARD_INUM(inum) \
+        (DISKFS_ORPHAN_INUM_BASE + ((inum) % DISKFS_ORPHAN_SHARDS))
+
 /* Max inodes a single transaction can hold locked at once.  rename needs
- * 4 (two parents, child, replaced target); others (e.g. readdir) touch
- * many but only 2 at a time and release as they go. */
-#define DISKFS_TXN_MAX_INODES     4
+ * 5 (two parents, child, replaced target, plus the orphan-list shard when
+ * the replace deletes the target); others (e.g. readdir) touch many but
+ * only 2 at a time and release as they go. */
+#define DISKFS_TXN_MAX_INODES     5
 
 /* Diskfs RMW writes assemble:
  *   prefix (valid + zero) + request write iovecs +
@@ -4856,8 +4866,9 @@ diskfs_orphan_op_start(
     o->done   = done;
     o->priv   = priv;
 
-    diskfs_inode_acquire(thread, txn, DISKFS_ORPHAN_INUM, DISKFS_ORPHAN_GEN,
-                         DISKFS_INODE_LOCK_WRITE, diskfs_orphan_op_acquired_cb, o);
+    diskfs_inode_acquire(thread, txn, DISKFS_ORPHAN_SHARD_INUM(inum),
+                         DISKFS_ORPHAN_GEN, DISKFS_INODE_LOCK_WRITE,
+                         diskfs_orphan_op_acquired_cb, o);
 } /* diskfs_orphan_op_start */
 
 /* ------------------------------------------------------------------ */
@@ -5015,9 +5026,9 @@ diskfs_drain_final_cb(
 } /* diskfs_drain_final_cb */
 
 /* The durable orphan entry is removed; finish retiring the inode in the same
-* transaction and commit.  The inode home block is intentionally leaked for now
-* (inode structs stay cached after unlink and generation reuse is not persisted,
-* so reusing an inum could collide with the cache and stale file handles). */
+ * transaction and commit.  The inode home block is intentionally leaked for
+ * now: generation reuse is not persisted for newly allocated inodes, so
+ * reusing an inum could resolve a stale file handle to the new file. */
 static void
 diskfs_drain_after_unrecord(void *priv)
 {
@@ -5137,7 +5148,8 @@ struct diskfs_reclaim_worker {
 struct diskfs_reclaim {
     struct diskfs_reclaim_worker *workers;
     uint32_t                      nworkers;
-    uint32_t                      rr;      /* atomic round-robin submit cursor */
+    uint32_t                      rr;       /* atomic round-robin submit cursor */
+    int                           shutdown; /* atomic: pool tearing down */
 };
 
 /* Pop every queued job and hand it to this worker's drain machinery. */
@@ -5183,6 +5195,13 @@ diskfs_reclaim_submit(
     struct diskfs_reclaim_worker *w;
     struct diskfs_reclaim_job    *j;
     uint32_t                      idx;
+
+    /* Pool tearing down (a worker's own shutdown flush can drop a last
+     * reference): skip -- the durable orphan record makes the next mount's
+     * scan pick the inode up. */
+    if (__atomic_load_n(&r->shutdown, __ATOMIC_ACQUIRE)) {
+        return;
+    }
 
     idx = __atomic_fetch_add(&r->rr, 1, __ATOMIC_RELAXED) % r->nworkers;
     w   = &r->workers[idx];
@@ -5275,6 +5294,7 @@ diskfs_reclaim_destroy(struct diskfs_shared *shared)
     if (!r) {
         return;
     }
+    __atomic_store_n(&r->shutdown, 1, __ATOMIC_RELEASE);
     for (i = 0; i < r->nworkers; i++) {
         evpl_thread_destroy(r->workers[i].thread);
     }
@@ -5282,6 +5302,112 @@ diskfs_reclaim_destroy(struct diskfs_shared *shared)
     free(r);
     shared->reclaim = NULL;
 } /* diskfs_reclaim_destroy */
+
+/* ------------------------------------------------------------------ */
+/* nlink -> 0 transition: durable orphan record + deferred reclaim     */
+/* ------------------------------------------------------------------ */
+
+struct diskfs_inode_orphaned_ctx {
+    struct diskfs_thread *thread;
+    struct diskfs_inode  *inode;
+    void                  (*done)(
+        void *priv);
+    void                 *priv;
+};
+
+static void
+diskfs_inode_orphaned_recorded_cb(void *priv)
+{
+    struct diskfs_inode_orphaned_ctx c = *(struct diskfs_inode_orphaned_ctx *) priv;
+    struct diskfs_inode_shard       *shard =
+        diskfs_inode_shard(c.thread->shared, c.inode->inum);
+    int                              reclaim;
+
+    free(priv);
+
+    /* Last reference already gone (no open handles, no deferred-mtime pin):
+     * hand the inode to the reclaim workers now.  Their drain parks on the
+     * inode's write lock, which this txn holds until it is durable, so the
+     * burn-down can't start before the orphan record (and the nlink=0 dinode)
+     * are recoverable.  Otherwise the final ref drop (close / pin release)
+     * submits it.  (A duplicate submit from a racing ref drop is benign: the
+     * second drain finds the bumped generation and skips.) */
+    pthread_mutex_lock(&shard->lock);
+    reclaim = (c.inode->refcnt == 0);
+    pthread_mutex_unlock(&shard->lock);
+
+    if (reclaim) {
+        diskfs_reclaim_submit(c.thread->shared, c.inode->inum, c.inode->gen);
+    }
+
+    c.done(c.priv);
+} /* diskfs_inode_orphaned_recorded_cb */
+
+/*
+ * Call when `inode`'s nlink just dropped to 0 inside `txn` (which holds its
+ * write lock): drop the namespace's base reference, record the inode on the
+ * durable orphan list (the record rides this txn's redo, so a crash at any
+ * later point is recovered by the next mount's orphan scan), and queue it for
+ * background reclaim once nothing references it.  `done(priv)` fires when the
+ * record is in place; the caller continues (attr mapping, commit) from there.
+ *
+ * Invariant: an inode holds a base reference iff nlink > 0, so refcnt of a
+ * deleted inode counts only open handles + transient pins, and exactly one
+ * ref-drop site observes zero.
+ */
+static void
+diskfs_inode_orphaned(
+    struct diskfs_thread *thread,
+    struct diskfs_txn    *txn,
+    struct diskfs_inode  *inode,
+    void (               *done )(void *priv),
+    void                 *priv)
+{
+    struct diskfs_inode_orphaned_ctx *c = malloc(sizeof(*c));
+    struct diskfs_inode_shard        *shard =
+        diskfs_inode_shard(thread->shared, inode->inum);
+
+    /* Shard-locked like every other ref drop, so it can't race a concurrent
+     * deferred-mtime pin release. */
+    pthread_mutex_lock(&shard->lock);
+    --inode->refcnt;
+    pthread_mutex_unlock(&shard->lock);
+
+    c->thread = thread;
+    c->inode  = inode;
+    c->done   = done;
+    c->priv   = priv;
+
+    diskfs_orphan_op_start(thread, txn, inode->inum, inode->gen, 0 /* insert */,
+                           diskfs_inode_orphaned_recorded_cb, c);
+} /* diskfs_inode_orphaned */
+
+/* A non-namespace reference (open handle, deferred-mtime pin, commit pin)
+ * was dropped; if it was the last one on a deleted inode, reclaim it.  The
+ * decrement runs under the inode's shard lock so it can't race the deferred-
+ * mtime pin release (which holds no inode lock); a live inode that became
+ * idle joins the recycle LRU as before. */
+static void
+diskfs_inode_ref_drop(
+    struct diskfs_thread *thread,
+    struct diskfs_inode  *inode)
+{
+    struct diskfs_inode_shard *shard = diskfs_inode_shard(thread->shared,
+                                                          inode->inum);
+    int reclaim;
+
+    pthread_mutex_lock(&shard->lock);
+    --inode->refcnt;
+    reclaim = (inode->refcnt == 0 && inode->nlink == 0);
+    if (diskfs_inode_idle(inode) && !inode->on_lru) {
+        diskfs_inode_lru_push_tail(shard, inode);
+    }
+    pthread_mutex_unlock(&shard->lock);
+
+    if (reclaim) {
+        diskfs_reclaim_submit(thread->shared, inode->inum, inode->gen);
+    }
+} /* diskfs_inode_ref_drop */
 
 /* ------------------------------------------------------------------ */
 /* Mount-time orphan recovery: re-enqueue inodes left on the durable    */
@@ -5375,19 +5501,23 @@ diskfs_orphan_scan(struct diskfs_thread *thread)
      * it resident, so this is a cheap cache hit. */
     diskfs_inode_load_sync(thread, io, shared->root_inum, shared->root_gen, 0);
 
-    /* Load the orphan-list inode (nlink 1) and read its tree from its home
-     * block, collecting every recorded orphan inum + gen. */
-    odir = diskfs_inode_load_sync(thread, io, DISKFS_ORPHAN_INUM, DISKFS_ORPHAN_GEN, 0);
-    if (!odir) {
-        diskfs_mount_io_close(io);
-        return;     /* not yet created (no orphans possible) */
-    }
-
-    off  = sm_inum_to_device_offset(shared->space_map, DISKFS_ORPHAN_INUM, &dev);
+    /* Load each orphan-list shard inode (nlink 1) and read its tree from its
+     * home block, collecting every recorded orphan inum + gen. */
     obuf = malloc(DISKFS_BLOCK_SIZE);
     arr  = malloc(cap * sizeof(*arr));
-    if (diskfs_mount_io_read(io, dev, obuf, DISKFS_BLOCK_SIZE, off) == 0) {
-        diskfs_orphan_scan_node(thread, io, obuf, DISKFS_BT_ROOT_BASE, &arr, &n, &cap);
+    for (i = 0; i < DISKFS_ORPHAN_SHARDS; i++) {
+        uint64_t oinum = DISKFS_ORPHAN_INUM_BASE + i;
+
+        odir = diskfs_inode_load_sync(thread, io, oinum, DISKFS_ORPHAN_GEN, 0);
+        if (!odir) {
+            continue;     /* not yet created (no orphans possible) */
+        }
+
+        off = sm_inum_to_device_offset(shared->space_map, oinum, &dev);
+        if (diskfs_mount_io_read(io, dev, obuf, DISKFS_BLOCK_SIZE, off) == 0) {
+            diskfs_orphan_scan_node(thread, io, obuf, DISKFS_BT_ROOT_BASE,
+                                    &arr, &n, &cap);
+        }
     }
     free(obuf);
 
@@ -9397,15 +9527,17 @@ diskfs_bootstrap(struct diskfs_thread *thread)
     diskfs_block_unpin(thread, inode->block, DISKFS_BLOCK_CLEAN);
     inode->block = NULL;
 
-    /* Statically-reserved orphan-list inode (inum 3): an empty directory whose
-     * b+tree keys are the inums of deleted-but-not-fully-reclaimed inodes.
-     * Created at format alongside root (persists; loaded from disk on remount);
-     * the incremental drainer scans it on mount and empties it. */
-    {
+    /* Statically-reserved orphan-list shard inodes (inums 3..): empty
+     * directories whose b+tree keys are the inums of deleted-but-not-fully-
+     * reclaimed inodes, sharded by deleted inum.  Created at format alongside
+     * root (persist; loaded from disk on remount); the reclaim workers scan
+     * them on mount and empty them. */
+    for (int s = 0; s < DISKFS_ORPHAN_SHARDS; s++) {
+        uint64_t             oinum = DISKFS_ORPHAN_INUM_BASE + s;
         uint32_t             odev;
         uint64_t             ooff = sm_inum_to_device_offset(shared->space_map,
-                                                             DISKFS_ORPHAN_INUM, &odev);
-        struct diskfs_inode *oin = diskfs_inode_struct_new(DISKFS_ORPHAN_INUM);
+                                                             oinum, &odev);
+        struct diskfs_inode *oin = diskfs_inode_struct_new(oinum);
 
         oin->size           = 4096;
         oin->space_used     = 4096;
@@ -9420,7 +9552,7 @@ diskfs_bootstrap(struct diskfs_thread *thread)
         oin->btime_sec      = now.tv_sec;
         oin->btime_nsec     = now.tv_nsec;
         oin->dos_attributes = 0;
-        oin->parent_inum    = DISKFS_ORPHAN_INUM;
+        oin->parent_inum    = oinum;
         oin->parent_gen     = oin->gen;
 
         diskfs_inode_cache_insert(shared, oin);
@@ -9717,28 +9849,9 @@ diskfs_mtime_flush_drop_pin(
     struct diskfs_thread *thread,
     struct diskfs_inode  *inode)
 {
-    struct diskfs_inode_shard *shard = diskfs_inode_shard(thread->shared, inode->inum);
-    int                        retire;
-    uint64_t                   inum;
-    uint32_t                   gen;
-
-    pthread_mutex_lock(&shard->lock);
-    --inode->refcnt;
-    /* If this drops the last reference to an inode that was unlinked while held
-     * open (its durable orphan record already written), it is now reclaimable. */
-    retire = (inode->refcnt == 0 && inode->nlink == 0);
-    inum   = inode->inum;
-    gen    = inode->gen;
-    if (!retire && diskfs_inode_idle(inode) && !inode->on_lru) {
-        diskfs_inode_lru_push_tail(shard, inode);
-    }
-    pthread_mutex_unlock(&shard->lock);
-
-    /* Submit the async drain outside the shard lock (the drain begins a txn
-     * and acquires inodes, taking shard locks). */
-    if (retire) {
-        diskfs_reclaim_submit(thread->shared, inum, gen);
-    }
+    /* May be the last reference to an inode unlinked while its deferred
+     * mtime was still queued: ref_drop hands it to the reclaim workers. */
+    diskfs_inode_ref_drop(thread, inode);
 } /* diskfs_mtime_flush_drop_pin */
 
 struct diskfs_mtime_flush {
@@ -11605,23 +11718,12 @@ diskfs_remove_at_finish(struct chimera_vfs_request *request)
     diskfs_op_ok(request, p->txn);
 } /* diskfs_remove_at_finish */
 
-/* Continuation after a large deleted inode is recorded on the durable orphan
- * list: enqueue it for the in-session drainer and finish the request. */
+/* The deleted inode is recorded on the durable orphan list (and queued for
+ * reclaim when unreferenced): finish the request. */
 static void
 diskfs_remove_orphan_done(void *priv)
 {
-    struct chimera_vfs_request    *request = priv;
-    struct diskfs_request_private *p       = request->plugin_data;
-    struct diskfs_inode           *inode   = p->inode_stash[1];
-
-    /* Reclaim now only if nothing else holds the inode open; otherwise the last
-     * close (or deferred-mtime pin drop) hands it to the reclaim workers when
-     * refcnt reaches 0.  The durable orphan record (just written) covers a
-     * crash in the meantime. */
-    if (inode->refcnt == 0) {
-        diskfs_reclaim_submit(p->thread->shared, inode->inum, inode->gen);
-    }
-    diskfs_remove_at_finish(request);
+    diskfs_remove_at_finish(priv);
 } /* diskfs_remove_orphan_done */
 
 static void
@@ -11680,20 +11782,15 @@ diskfs_remove_at_removed_cb(
     diskfs_map_attrs(thread, &request->remove_at.r_removed_attr, inode);
 
     if (inode->nlink == 0) {
-        --inode->refcnt;
-
-        /* Record the durable orphan entry now, atomic with persisting nlink=0,
-         * regardless of whether the inode is still held open: a crash before the
-         * space is reclaimed is recovered by the next mount's orphan scan.  The
-         * actual reclaim (freeing data extents + b+tree nodes, then retiring the
-         * inode) is deferred to the async drain -- never done in this delete hot
-         * path -- and is enqueued from the continuation once the inode is
-         * unreferenced (refcnt 0): now if it is already closed, otherwise at the
-         * final close (diskfs_close_inode_cb / the deferred-mtime pin drop).  The
-         * orphan inode (inum 3) is acquired last, a leaf in the lock order. */
-        diskfs_orphan_op_start(thread, p->txn, inode->inum, inode->gen,
-                               0 /* insert */, diskfs_remove_orphan_done,
-                               request);
+        /* Record the deleted inode on the durable orphan list -- atomic with
+         * this unlink txn (the orphan shard is acquired last, a leaf in the
+         * lock order, so no deadlock) -- and hand it to the reclaim workers
+         * once nothing references it.  All space reclaim (extents + b+tree
+         * burn-down) happens there, off this hot path; a crash before this
+         * txn commits leaves neither the unlink nor the orphan record, and
+         * after it the mount scan resumes the drain. */
+        diskfs_inode_orphaned(thread, p->txn, inode,
+                              diskfs_remove_orphan_done, request);
         return;
     }
 
@@ -12183,6 +12280,14 @@ diskfs_open_fh_inode_cb(
         return;
     }
 
+    /* A deleted, unreferenced inode is dead (queued for or under background
+     * reclaim); a stale handle must not resurrect it mid-burn-down.  One that
+     * still has open handles (deleted-while-open / anonymous) stays openable. */
+    if (unlikely(inode->nlink == 0 && inode->refcnt == 0)) {
+        diskfs_op_fail(request, p->txn, CHIMERA_VFS_ENOENT);
+        return;
+    }
+
     inode->refcnt++;
 
     request->open_fh.r_vfs_private = (uint64_t) inode;
@@ -12507,6 +12612,15 @@ diskfs_open_at(
 
 
 static void
+diskfs_create_unlinked_orphaned_cb(void *priv)
+{
+    struct chimera_vfs_request    *request = priv;
+    struct diskfs_request_private *p       = request->plugin_data;
+
+    diskfs_op_ok(request, p->txn);
+} /* diskfs_create_unlinked_orphaned_cb */
+
+static void
 diskfs_create_unlinked_alloc_cb(
     struct diskfs_inode *inode,
     int                  status,
@@ -12528,7 +12642,7 @@ diskfs_create_unlinked_alloc_cb(
     inode->space_used     = 0;
     inode->uid            = request->cred->uid;
     inode->gid            = request->cred->gid;
-    inode->nlink          = 0;
+    inode->nlink          = 0;     /* anonymous; orphan-recorded below */
     inode->mode           = S_IFREG | 0644;
     inode->atime_sec      = now.tv_sec;
     inode->atime_nsec     = now.tv_nsec;
@@ -12542,12 +12656,17 @@ diskfs_create_unlinked_alloc_cb(
 
     diskfs_apply_attrs(inode, request->create_unlinked.set_attr);
 
-    inode->refcnt++;
+    inode->refcnt++;     /* the open handle */
     request->create_unlinked.r_vfs_private = (uint64_t) inode;
 
     diskfs_map_attrs(thread, &request->create_unlinked.r_attr, inode);
 
-    diskfs_op_ok(request, p->txn);
+    /* Anonymous from birth (nlink==0 => no namespace base reference): record
+     * it on the durable orphan list in the creating txn, so a crash while it
+     * is open reclaims it at the next mount, and the final handle close hands
+     * it to the reclaim workers.  A later link_at removes the record. */
+    diskfs_inode_orphaned(thread, p->txn, inode,
+                          diskfs_create_unlinked_orphaned_cb, request);
 } /* diskfs_create_unlinked_alloc_cb */
 
 static void
@@ -12583,8 +12702,6 @@ diskfs_close_inode_cb(
         return;
     }
 
-    --inode->refcnt;
-
     /* Return this file's unused data-space reservation tail on close.  Done
      * unconditionally (not just at refcnt 0, which is the delete-on-close case):
      * a normal close drops the inode back to its idle cache reference, where it
@@ -12593,17 +12710,10 @@ diskfs_close_inode_cb(
      * lock, held here, serializes that against this close). */
     diskfs_inode_return_reservation(p->thread, p->txn, inode);
 
-    if (inode->refcnt == 0) {
-        if (inode->nlink == 0) {
-            /* Delete-on-close: the file was unlinked while open (its durable
-             * orphan record was written then), and this was the last reference.
-             * Reclaim its space on the reclaim workers, which free the extents
-             * and retire the inode -- not inline in this close path. */
-            diskfs_reclaim_submit(p->thread->shared, inode->inum, inode->gen);
-        } else {
-            diskfs_inode_free(p->thread, inode);
-        }
-    }
+    /* Drop the handle's reference; the last drop on a deleted inode hands it
+     * to the reclaim workers (their drain parks on the inode's write lock,
+     * which this txn holds until durable). */
+    diskfs_inode_ref_drop(p->thread, inode);
 
     diskfs_op_ok(request, p->txn);
 } /* diskfs_close_inode_cb */
@@ -15605,6 +15715,14 @@ diskfs_rename_at_perform_insert(struct chimera_vfs_request *request)
     }
 } /* diskfs_rename_at_perform_insert */
 
+/* The replaced target's orphan record is in place: continue with the new
+ * dirent insert. */
+static void
+diskfs_rename_at_replaced_orphaned_cb(void *priv)
+{
+    diskfs_rename_at_perform_insert(priv);
+} /* diskfs_rename_at_replaced_orphaned_cb */
+
 static void
 diskfs_rename_at_perform_removed_cb(
     struct diskfs_bt_op *bop,
@@ -15619,9 +15737,19 @@ diskfs_rename_at_perform_removed_cb(
     diskfs_bt_op_free(p->thread, bop);
 
     if (result == 1) {
-        existing_inode->nlink--;
         if (S_ISDIR(existing_inode->mode)) {
+            /* A replaced directory must be empty (validated above); like
+             * remove_at, the delete zeroes its self+parent link count. */
+            existing_inode->nlink = 0;
             np->nlink--;
+        } else {
+            existing_inode->nlink--;
+        }
+        if (existing_inode->nlink == 0) {
+            diskfs_inode_orphaned(p->thread, p->txn, existing_inode,
+                                  diskfs_rename_at_replaced_orphaned_cb,
+                                  request);
+            return;
         }
     }
 
@@ -15897,6 +16025,17 @@ diskfs_link_at_inserted_cb(
     diskfs_op_ok(request, p->txn);
 } /* diskfs_link_at_inserted_cb */
 
+static void diskfs_link_at_finish(
+    struct chimera_vfs_request *request);
+
+/* Linking an anonymous (created-unlinked) inode into the namespace: its
+ * orphan record is removed in the same txn; continue with the link. */
+static void
+diskfs_link_at_unorphaned_cb(void *priv)
+{
+    diskfs_link_at_finish(priv);
+} /* diskfs_link_at_unorphaned_cb */
+
 static void
 diskfs_link_at_finish(struct chimera_vfs_request *request)
 {
@@ -15907,6 +16046,19 @@ diskfs_link_at_finish(struct chimera_vfs_request *request)
     uint64_t                       hash   = request->link_at.name_hash;
     struct diskfs_bt_op           *op;
     struct timespec                now;
+
+    /* An nlink==0 source is an anonymous inode (create_unlinked) entering the
+     * namespace: it re-takes the namespace's base reference and leaves the
+     * durable orphan list before the link proceeds.  (A deleted-and-
+     * unreferenced source was already rejected at fetch time.) */
+    if (inode->nlink == 0 && !p->op_scratch) {
+        p->op_scratch = 1;     /* unorphan once; this re-enters */
+        inode->refcnt++;
+        diskfs_orphan_op_start(thread, p->txn, inode->inum, inode->gen,
+                               1 /* remove */, diskfs_link_at_unorphaned_cb,
+                               request);
+        return;
+    }
 
     clock_gettime(CLOCK_REALTIME, &now);
 
@@ -15930,6 +16082,13 @@ diskfs_link_at_finish(struct chimera_vfs_request *request)
     }
 } /* diskfs_link_at_finish */
 
+/* The replaced target's orphan record is in place: continue with the link. */
+static void
+diskfs_link_at_replaced_orphaned_cb(void *priv)
+{
+    diskfs_link_at_finish(priv);
+} /* diskfs_link_at_replaced_orphaned_cb */
+
 static void
 diskfs_link_at_existing_cb(
     struct diskfs_inode *existing_inode,
@@ -15945,6 +16104,12 @@ diskfs_link_at_existing_cb(
         existing_inode->nlink--;
         diskfs_map_attrs(p->thread, &request->link_at.r_replaced_attr,
                          existing_inode);
+        if (existing_inode->nlink == 0) {
+            diskfs_inode_orphaned(p->thread, p->txn, existing_inode,
+                                  diskfs_link_at_replaced_orphaned_cb,
+                                  request);
+            return;
+        }
     }
 
     diskfs_link_at_finish(request);
@@ -16023,6 +16188,15 @@ diskfs_link_at_inode_cb(
         return;
     }
 
+    /* A deleted, unreferenced inode is dead -- it is queued for (or already
+     * under) background reclaim, so it must not re-enter the namespace.  An
+     * nlink==0 inode with open handles is a live anonymous file
+     * (create_unlinked) and may be linked. */
+    if (unlikely(inode->nlink == 0 && inode->refcnt == 0)) {
+        diskfs_op_fail(request, p->txn, CHIMERA_VFS_ENOENT);
+        return;
+    }
+
     p->inode_stash[1] = inode;
 
     op = diskfs_bt_op_alloc(thread);
@@ -16073,8 +16247,9 @@ diskfs_link_at(
     (void) shared;
     (void) private_data;
 
-    p->thread = thread;
-    p->txn    = diskfs_txn_begin(thread, DISKFS_TXN_WRITE);
+    p->thread     = thread;
+    p->txn        = diskfs_txn_begin(thread, DISKFS_TXN_WRITE);
+    p->op_scratch = 0;     /* anonymous-source unorphan latch (link_at_finish) */
 
     diskfs_inode_get_fh_async(thread, p->txn,
                               request->link_at.dir_fh,
@@ -17241,7 +17416,10 @@ diskfs_commit_acquired_cb(
     pthread_mutex_lock(&shard->lock);
     if (inode->mtime_dirty) {
         diskfs_inode_mtime_unlink_locked(shard, inode);
-        --inode->refcnt;     /* drop the dirty-pin; the txn write lock holds it */
+        /* Drop the dirty-pin; the txn write lock holds the inode.  Never the
+         * final reference: the COMMIT's own open handle still holds one, so
+         * no reclaim check is needed here. */
+        --inode->refcnt;
         pthread_mutex_unlock(&shard->lock);
         diskfs_txn_pin_inode_block(thread, cp->txn, inode, 0);
     } else {

--- a/src/vfs/diskfs/diskfs.c
+++ b/src/vfs/diskfs/diskfs.c
@@ -1082,34 +1082,34 @@ struct diskfs_intent_log {
 };
 
 struct diskfs_shared {
-    struct diskfs_device      *devices;
-    char                     **device_paths;     /* for unmount-time persistence */
-    int                        num_devices;
-    struct diskfs_inode_cache *inode_cache;
-    struct diskfs_block_cache *block_cache;
-    struct diskfs_kv_shard    *kv_shards;
-    int                        num_kv_shards;
-    int                        num_active_threads;
-    uint8_t                    root_fh[CHIMERA_VFS_FH_SIZE];
-    uint32_t                   root_fhlen;
-    int                        orphans_scanned;    /* mount-time orphan recovery done */
-    uint64_t                   root_inum;          /* for the clean-unmount superblock */
-    uint32_t                   root_gen;
-    int                        unsafe_async;       /* config opt-in: submit block writes without FUA/sync (no crash safety) */
-    int                        noatime;            /* config opt-in: never update atime on read (default: relatime) */
-    uint64_t                   mtime_defer_us;     /* coalesce non-FILE_SYNC in-place mtime updates: flush each dirty inode at most once per this many us (0 = disabled, log every write); default 1s */
-    int                        mounted;            /* 1 = remounted existing FS (enables inode read-back) */
-    uint32_t                   block_cache_blocks; /* total resident block-buffer cap (0 = default) */
-    uint32_t                   inode_cache_inodes; /* total resident inode cap (0 = default) */
-    int                        block_layout;       /* config opt-in: advertise pNFS block layouts */
-    int                        scsi_layout;        /* config opt-in: advertise pNFS SCSI layouts  */
-    uint64_t                   fsid;
-    struct space_map          *space_map;
-    struct diskfs_intent_log   intent_log;
+    struct diskfs_device       *devices;
+    char                      **device_paths;    /* for unmount-time persistence */
+    int                         num_devices;
+    struct diskfs_inode_cache  *inode_cache;
+    struct diskfs_block_cache  *block_cache;
+    struct diskfs_kv_shard     *kv_shards;
+    int                         num_kv_shards;
+    int                         num_active_threads;
+    uint8_t                     root_fh[CHIMERA_VFS_FH_SIZE];
+    uint32_t                    root_fhlen;
+    int                         orphans_scanned;   /* mount-time orphan recovery done */
+    uint64_t                    root_inum;         /* for the clean-unmount superblock */
+    uint32_t                    root_gen;
+    int                         unsafe_async;      /* config opt-in: submit block writes without FUA/sync (no crash safety) */
+    int                         noatime;           /* config opt-in: never update atime on read (default: relatime) */
+    uint64_t                    mtime_defer_us;    /* coalesce non-FILE_SYNC in-place mtime updates: flush each dirty inode at most once per this many us (0 = disabled, log every write); default 1s */
+    int                         mounted;           /* 1 = remounted existing FS (enables inode read-back) */
+    uint32_t                    block_cache_blocks; /* total resident block-buffer cap (0 = default) */
+    uint32_t                    inode_cache_inodes; /* total resident inode cap (0 = default) */
+    int                         block_layout;      /* config opt-in: advertise pNFS block layouts */
+    int                         scsi_layout;       /* config opt-in: advertise pNFS SCSI layouts  */
+    uint64_t                    fsid;
+    struct space_map           *space_map;
+    struct diskfs_intent_log    intent_log;
     /* Dedicated reclaim workers: deleted-inode burn-down (and other background
      * maintenance) runs here, off the request workers' hot path. */
-    struct diskfs_reclaim     *reclaim;
-    uint32_t                   reclaim_threads;    /* config knob (0 = default) */
+    struct diskfs_reclaim      *reclaim;
+    uint32_t                    reclaim_threads;   /* config knob (0 = default) */
     /* Inode-generation epoch: every generation is drawn from this global
      * monotonic counter; gen_floor is the durably-persisted bound
      * (reserve-ahead) that no issued generation may reach.  A reused inode
@@ -1122,6 +1122,9 @@ struct diskfs_shared {
     int                         gen_extend_inflight; /* atomic */
     pthread_mutex_t             gen_lock;            /* guards gen_wait */
     struct diskfs_block_waiter *gen_wait;
+    /* Per-(device, AG) park lists for journaling operations stalled behind a
+     * runtime AG-log condensation; drained when the condense commits. */
+    struct diskfs_ag_wait     **agw;                 /* [device][ag] */
     struct diskfs_metrics       metrics;
     pthread_mutex_t             lock;
 };
@@ -2976,9 +2979,25 @@ diskfs_sm_claim_block(
     return blk->iov.data;
 } /* diskfs_sm_claim_block */
 
-#define DISKFS_SM_JNL(name, thr, t, res, a)                                  \
-        struct diskfs_sm_jnl name ## _ctx = { (thr), (t), (res), (a) };      \
-        struct sm_journal    name         = { diskfs_sm_claim_block, &name ## _ctx }
+/* AG-log condensation bridge (defined with the reclaim pool): schedule the
+ * background condense, and park journaling continuations behind it. */
+static void diskfs_sm_ag_condense(
+    void    *user,
+    uint32_t device_id,
+    uint32_t ag_index);
+static void diskfs_sm_ag_park(
+    void    *user,
+    uint32_t device_id,
+    uint32_t ag_index);
+
+#define DISKFS_SM_JNL(name, thr, t, res, a)                                   \
+        struct diskfs_sm_jnl name ## _ctx = { (thr), (t), (res), (a) };       \
+        struct sm_journal    name         = {                                 \
+            .claim_block = diskfs_sm_claim_block,                             \
+            .ag_condense = diskfs_sm_ag_condense,                             \
+            .ag_park     = diskfs_sm_ag_park,                                 \
+            .user        = &name ## _ctx                                      \
+        }
 
 /* A journaling context for a site that has guaranteed its log blocks are
  * resident (e.g. a pre-reserved b+tree modify): a claim must never park, so a
@@ -5172,10 +5191,24 @@ static void * diskfs_thread_init(
 static void diskfs_thread_destroy(
     void *private_data);
 
+enum diskfs_reclaim_job_type {
+    DISKFS_RECLAIM_JOB_DRAIN = 0,   /* burn down a deleted inode */
+    DISKFS_RECLAIM_JOB_CONDENSE,    /* condense an AG's allocation log */
+};
+
 struct diskfs_reclaim_job {
-    uint64_t                   inum;
-    uint32_t                   gen;
+    enum diskfs_reclaim_job_type type;
+    uint64_t                   inum;         /* DRAIN */
+    uint32_t                   gen;          /* DRAIN */
+    uint32_t                   device_id;    /* CONDENSE */
+    uint32_t                   ag_index;     /* CONDENSE */
     struct diskfs_reclaim_job *next;
+};
+
+/* Journaling continuations parked behind one AG's condensation. */
+struct diskfs_ag_wait {
+    pthread_mutex_t             lock;
+    struct diskfs_block_waiter *head;
 };
 
 struct diskfs_reclaim_worker {
@@ -5186,6 +5219,7 @@ struct diskfs_reclaim_worker {
     pthread_mutex_t            lock;
     struct diskfs_reclaim_job *head;
     struct diskfs_reclaim_job *tail;
+    int                        condenses;  /* condense jobs in flight here */
     int                        ready;      /* atomic: context constructed */
 };
 
@@ -5195,6 +5229,11 @@ struct diskfs_reclaim {
     uint32_t                      rr;       /* atomic round-robin submit cursor */
     int                           shutdown; /* atomic: pool tearing down */
 };
+
+static void diskfs_condense_start(
+    struct diskfs_reclaim_worker *w,
+    uint32_t                      device_id,
+    uint32_t                      ag_index);
 
 /* Pop every queued job and hand it to this worker's drain machinery. */
 static void
@@ -5218,7 +5257,11 @@ diskfs_reclaim_doorbell_cb(
     while (jobs) {
         j    = jobs;
         jobs = j->next;
-        diskfs_drain_enqueue(w->ctx, j->inum, j->gen);
+        if (j->type == DISKFS_RECLAIM_JOB_CONDENSE) {
+            diskfs_condense_start(w, j->device_id, j->ag_index);
+        } else {
+            diskfs_drain_enqueue(w->ctx, j->inum, j->gen);
+        }
         free(j);
     }
 } /* diskfs_reclaim_doorbell_cb */
@@ -5230,30 +5273,25 @@ diskfs_reclaim_doorbell_cb(
  * drain finishes is recovered by the next mount's orphan scan.
  */
 static void
-diskfs_reclaim_submit(
-    struct diskfs_shared *shared,
-    uint64_t              inum,
-    uint32_t              gen)
+diskfs_reclaim_submit_job(
+    struct diskfs_shared      *shared,
+    struct diskfs_reclaim_job *j)
 {
     struct diskfs_reclaim        *r = shared->reclaim;
     struct diskfs_reclaim_worker *w;
-    struct diskfs_reclaim_job    *j;
     uint32_t                      idx;
 
     /* Pool tearing down (a worker's own shutdown flush can drop a last
-     * reference): skip -- the durable orphan record makes the next mount's
-     * scan pick the inode up. */
+    * reference): skip -- the durable orphan record makes the next mount's
+    * scan pick the inode up.  (Condense jobs cannot arrive here during
+    * teardown: every journaling request completed before it began.) */
     if (__atomic_load_n(&r->shutdown, __ATOMIC_ACQUIRE)) {
+        free(j);
         return;
     }
 
     idx = __atomic_fetch_add(&r->rr, 1, __ATOMIC_RELAXED) % r->nworkers;
     w   = &r->workers[idx];
-
-    j       = malloc(sizeof(*j));
-    j->inum = inum;
-    j->gen  = gen;
-    j->next = NULL;
 
     pthread_mutex_lock(&w->lock);
     if (w->tail) {
@@ -5265,6 +5303,20 @@ diskfs_reclaim_submit(
     pthread_mutex_unlock(&w->lock);
 
     evpl_ring_doorbell(&w->doorbell);
+} /* diskfs_reclaim_submit_job */
+
+static void
+diskfs_reclaim_submit(
+    struct diskfs_shared *shared,
+    uint64_t              inum,
+    uint32_t              gen)
+{
+    struct diskfs_reclaim_job *j = calloc(1, sizeof(*j));
+
+    j->type = DISKFS_RECLAIM_JOB_DRAIN;
+    j->inum = inum;
+    j->gen  = gen;
+    diskfs_reclaim_submit_job(shared, j);
 } /* diskfs_reclaim_submit */
 
 static void *
@@ -5293,6 +5345,12 @@ diskfs_reclaim_thread_shutdown(
      * finishes the reclaim backlog rather than re-scanning it next mount. */
     diskfs_reclaim_doorbell_cb(evpl, &w->doorbell);
 
+    /* Finish in-flight AG-log condensations (their parked journaling ops
+     * belong to requests that cannot complete until the flip). */
+    while (w->condenses > 0) {
+        evpl_continue(evpl);
+    }
+
     evpl_remove_doorbell(evpl, &w->doorbell);
     diskfs_thread_destroy(w->ctx);
 
@@ -5313,7 +5371,7 @@ diskfs_reclaim_create(struct diskfs_shared *shared)
 
     r->nworkers = shared->reclaim_threads ? shared->reclaim_threads
                                           : DISKFS_RECLAIM_THREADS_DEFAULT;
-    r->workers  = calloc(r->nworkers, sizeof(*r->workers));
+    r->workers = calloc(r->nworkers, sizeof(*r->workers));
 
     for (i = 0; i < r->nworkers; i++) {
         struct diskfs_reclaim_worker *w = &r->workers[i];
@@ -5346,6 +5404,176 @@ diskfs_reclaim_destroy(struct diskfs_shared *shared)
     free(r);
     shared->reclaim = NULL;
 } /* diskfs_reclaim_destroy */
+
+/* ------------------------------------------------------------------ */
+/* AG-log runtime condensation                                         */
+/*                                                                      */
+/* When an AG's active log slot nears full, the space map parks every   */
+/* journaling operation for that AG (diskfs_sm_ag_park) and schedules a */
+/* condense job here (diskfs_sm_ag_condense).  The job snapshots the    */
+/* AG's free set into the inactive slot -- body blocks first, header    */
+/* block last, all FUA, so a crash at any point leaves the old slot     */
+/* authoritative -- commits the flip, and re-drives the parked ops into */
+/* the fresh slot.                                                      */
+/* ------------------------------------------------------------------ */
+
+struct diskfs_condense {
+    struct diskfs_reclaim_worker *worker;
+    uint32_t                      device_id;
+    uint32_t                      ag_index;
+    struct evpl_iovec             hdr;       /* slot block 0 */
+    struct evpl_iovec             body;      /* remaining payload blocks */
+    uint64_t                      slot_off;
+    uint64_t                      body_len;
+    uint8_t                      *scratch;   /* SM_AG_LOG_SLOT_SIZE image */
+};
+
+static void
+diskfs_condense_finish(
+    struct evpl *evpl,
+    int          status,
+    void        *private_data)
+{
+    struct diskfs_condense       *c      = private_data;
+    struct diskfs_reclaim_worker *w      = c->worker;
+    struct diskfs_shared         *shared = w->shared;
+    struct diskfs_ag_wait        *agw    = &shared->agw[c->device_id][c->ag_index];
+    struct diskfs_block_waiter   *waiters, *wt;
+    uint32_t                      base_count;
+
+    chimera_diskfs_abort_if(status != 0,
+                            "AG-log condense header write failed: %d", status);
+
+    base_count = ((struct sm_ag_log_header *) c->scratch)->base_count;
+    space_map_condense_commit(shared->space_map, c->device_id, c->ag_index,
+                              base_count);
+
+    chimera_diskfs_info("AG %u/%u log condensed (%u free extents)",
+                        c->device_id, c->ag_index, base_count);
+
+    /* Re-drive everything parked behind the condensation. */
+    pthread_mutex_lock(&agw->lock);
+    waiters   = agw->head;
+    agw->head = NULL;
+    pthread_mutex_unlock(&agw->lock);
+
+    while (waiters) {
+        wt      = waiters;
+        waiters = wt->next;
+        diskfs_block_waiter_dispatch(w->ctx, wt);
+    }
+
+    evpl_iovec_release(evpl, &c->hdr);
+    if (c->body_len) {
+        evpl_iovec_release(evpl, &c->body);
+    }
+    free(c->scratch);
+    w->condenses--;
+    free(c);
+} /* diskfs_condense_finish */
+
+/* Body blocks durable: write the header block (slot becomes valid). */
+static void
+diskfs_condense_body_done(
+    struct evpl *evpl,
+    int          status,
+    void        *private_data)
+{
+    struct diskfs_condense       *c = private_data;
+    struct diskfs_reclaim_worker *w = c->worker;
+
+    chimera_diskfs_abort_if(status != 0,
+                            "AG-log condense body write failed: %d", status);
+
+    memcpy(c->hdr.data, c->scratch, DISKFS_BLOCK_SIZE);
+    evpl_block_write(evpl, w->ctx->queue[c->device_id], &c->hdr, 1,
+                     c->slot_off, 1 /* FUA */, diskfs_condense_finish, c);
+} /* diskfs_condense_body_done */
+
+static void
+diskfs_condense_try(struct diskfs_condense *c)
+{
+    struct diskfs_reclaim_worker *w      = c->worker;
+    struct diskfs_shared         *shared = w->shared;
+    struct evpl                  *evpl   = w->ctx->evpl;
+    uint64_t                      payload, aligned;
+
+    space_map_condense_prepare(shared->space_map, c->device_id,
+                               c->ag_index, c->scratch,
+                               &c->slot_off, &payload);
+
+    aligned = (payload + DISKFS_BLOCK_SIZE - 1) & ~((uint64_t) DISKFS_BLOCK_SIZE - 1);
+    memset(c->scratch + payload, 0, aligned - payload);
+    c->body_len = aligned - DISKFS_BLOCK_SIZE;
+
+    /* Header block (written last) makes the slot valid; everything after it
+     * goes first. */
+    evpl_iovec_alloc(evpl, DISKFS_BLOCK_SIZE, DISKFS_BLOCK_SIZE, 1, 0, &c->hdr);
+
+    if (c->body_len) {
+        evpl_iovec_alloc(evpl, c->body_len, DISKFS_BLOCK_SIZE, 1, 0, &c->body);
+        memcpy(c->body.data, c->scratch + DISKFS_BLOCK_SIZE, c->body_len);
+        evpl_block_write(evpl, w->ctx->queue[c->device_id], &c->body, 1,
+                         c->slot_off + DISKFS_BLOCK_SIZE, 1 /* FUA */,
+                         diskfs_condense_body_done, c);
+    } else {
+        diskfs_condense_body_done(evpl, 0, c);
+    }
+} /* diskfs_condense_try */
+
+static void
+diskfs_condense_start(
+    struct diskfs_reclaim_worker *w,
+    uint32_t                      device_id,
+    uint32_t                      ag_index)
+{
+    struct diskfs_condense *c = calloc(1, sizeof(*c));
+
+    c->worker    = w;
+    c->device_id = device_id;
+    c->ag_index  = ag_index;
+    c->scratch   = malloc(SM_AG_LOG_SLOT_SIZE);
+    w->condenses++;
+
+    diskfs_condense_try(c);
+} /* diskfs_condense_start */
+
+/* sm_journal bridge (called under the AG lock; see space_map.h). */
+static void
+diskfs_sm_ag_condense(
+    void    *user,
+    uint32_t device_id,
+    uint32_t ag_index)
+{
+    struct diskfs_sm_jnl      *c = user;
+    struct diskfs_reclaim_job *j = calloc(1, sizeof(*j));
+
+    j->type      = DISKFS_RECLAIM_JOB_CONDENSE;
+    j->device_id = device_id;
+    j->ag_index  = ag_index;
+    diskfs_reclaim_submit_job(c->thread->shared, j);
+} /* diskfs_sm_ag_condense */
+
+static void
+diskfs_sm_ag_park(
+    void    *user,
+    uint32_t device_id,
+    uint32_t ag_index)
+{
+    struct diskfs_sm_jnl       *c      = user;
+    struct diskfs_shared       *shared = c->thread->shared;
+    struct diskfs_ag_wait      *agw    = &shared->agw[device_id][ag_index];
+    struct diskfs_block_waiter *w      = diskfs_block_waiter_alloc(c->thread);
+
+    w->thread = c->thread;
+    w->resume = c->resume;
+    w->arg    = c->resume_arg;
+
+    pthread_mutex_lock(&agw->lock);
+    w->next   = agw->head;
+    agw->head = w;
+    pthread_mutex_unlock(&agw->lock);
+} /* diskfs_sm_ag_park */
 
 /* ------------------------------------------------------------------ */
 /* Inode-generation epoch                                              */
@@ -5398,8 +5626,8 @@ diskfs_gen_extend_complete(
 } /* diskfs_gen_extend_complete */
 
 /* Persist a new generation floor (current counter + reserve).  The write
- * always carries FUA regardless of unsafe_async: re-issuing a generation
- * after a crash would let stale file handles resolve to reused inodes. */
+* always carries FUA regardless of unsafe_async: re-issuing a generation
+* after a crash would let stale file handles resolve to reused inodes. */
 static void
 diskfs_gen_extend(struct diskfs_thread *thread)
 {
@@ -5438,9 +5666,9 @@ diskfs_gen_extend(struct diskfs_thread *thread)
 static int
 diskfs_gen_alloc(
     struct diskfs_thread *thread,
-    uint32_t             *r_gen,
+    uint32_t *r_gen,
     void ( *resume )(struct diskfs_thread *, void *),
-    void                 *arg)
+    void *arg)
 {
     struct diskfs_shared *shared = thread->shared;
     uint64_t              g      = __atomic_fetch_add(&shared->gen_next, 1,
@@ -5498,7 +5726,7 @@ struct diskfs_inode_orphaned_ctx {
 static void
 diskfs_inode_orphaned_recorded_cb(void *priv)
 {
-    struct diskfs_inode_orphaned_ctx c = *(struct diskfs_inode_orphaned_ctx *) priv;
+    struct diskfs_inode_orphaned_ctx c     = *(struct diskfs_inode_orphaned_ctx *) priv;
     struct diskfs_inode_shard       *shard =
         diskfs_inode_shard(c.thread->shared, c.inode->inum);
     int                              reclaim;
@@ -5543,7 +5771,7 @@ diskfs_inode_orphaned(
     void (               *done )(void *priv),
     void                 *priv)
 {
-    struct diskfs_inode_orphaned_ctx *c = malloc(sizeof(*c));
+    struct diskfs_inode_orphaned_ctx *c     = malloc(sizeof(*c));
     struct diskfs_inode_shard        *shard =
         diskfs_inode_shard(thread->shared, inode->inum);
 
@@ -5574,7 +5802,7 @@ diskfs_inode_ref_drop(
 {
     struct diskfs_inode_shard *shard = diskfs_inode_shard(thread->shared,
                                                           inode->inum);
-    int reclaim;
+    int                        reclaim;
 
     pthread_mutex_lock(&shard->lock);
     --inode->refcnt;
@@ -6948,7 +7176,7 @@ diskfs_inode_alloc_async(
     actx->private_data = private_data;
 
     /* Draw the generation before the space draw so a (rare) park on the
-     * generation floor can re-drive without having allocated a block. */
+    * generation floor can re-drive without having allocated a block. */
     if (diskfs_gen_alloc(thread, &gen, diskfs_inode_alloc_resume,
                          actx) == SM_AGAIN) {
         return;     /* parked; diskfs_inode_alloc_resume re-runs (owns actx) */
@@ -6967,8 +7195,8 @@ diskfs_inode_alloc_async(
         return;
     }
 
-    inum  = sm_inum_from_device_offset(shared->space_map, device_id, device_offset);
-    inode = diskfs_inode_struct_new(inum);
+    inum       = sm_inum_from_device_offset(shared->space_map, device_id, device_offset);
+    inode      = diskfs_inode_struct_new(inum);
     inode->gen = gen;
 
     /* New dirty inode: write-locked by this (write) txn from birth. */
@@ -9542,7 +9770,7 @@ diskfs_init(
          * floor (>= every generation ever issued); a fresh format starts
          * above the format-created inodes' generation (1).  The dirty
          * superblock write below persists the extended floor. */
-        shared->gen_next  = (mode != 0 && sb.gen_floor > DISKFS_GEN_FIRST)
+        shared->gen_next = (mode != 0 && sb.gen_floor > DISKFS_GEN_FIRST)
             ? sb.gen_floor : DISKFS_GEN_FIRST;
         shared->gen_floor = shared->gen_next + DISKFS_GEN_RESERVE;
 
@@ -9672,6 +9900,18 @@ diskfs_init(
                                                         &shared->intent_log);
     while (!__atomic_load_n(&shared->intent_log.push_ready, __ATOMIC_ACQUIRE)) {
         /* spin briefly */
+    }
+
+    /* Per-(device, AG) park lists for journaling stalled behind an AG-log
+     * condensation. */
+    shared->agw = calloc(shared->num_devices, sizeof(*shared->agw));
+    for (int d = 0; d < shared->num_devices; d++) {
+        uint32_t nags = shared->space_map->devices[d].num_ags;
+
+        shared->agw[d] = calloc(nags, sizeof(**shared->agw));
+        for (uint32_t a = 0; a < nags; a++) {
+            pthread_mutex_init(&shared->agw[d][a].lock, NULL);
+        }
     }
 
     /* Reclaim workers last: their thread contexts register intent-log
@@ -9909,6 +10149,18 @@ diskfs_destroy(void *private_data)
     }
 
     diskfs_block_cache_destroy(shared);
+
+    if (shared->agw) {
+        for (i = 0; i < shared->num_devices; i++) {
+            uint32_t nags = shared->space_map->devices[i].num_ags;
+
+            for (uint32_t a = 0; a < nags; a++) {
+                pthread_mutex_destroy(&shared->agw[i][a].lock);
+            }
+            free(shared->agw[i]);
+        }
+        free(shared->agw);
+    }
 
     space_map_destroy(shared->space_map);
 
@@ -15978,7 +16230,7 @@ diskfs_rename_at_perform_removed_cb(
     if (result == 1) {
         if (S_ISDIR(existing_inode->mode)) {
             /* A replaced directory must be empty (validated above); like
-             * remove_at, the delete zeroes its self+parent link count. */
+            * remove_at, the delete zeroes its self+parent link count. */
             existing_inode->nlink = 0;
             np->nlink--;
         } else {

--- a/src/vfs/diskfs/diskfs.c
+++ b/src/vfs/diskfs/diskfs.c
@@ -1110,8 +1110,20 @@ struct diskfs_shared {
      * maintenance) runs here, off the request workers' hot path. */
     struct diskfs_reclaim     *reclaim;
     uint32_t                   reclaim_threads;    /* config knob (0 = default) */
-    struct diskfs_metrics      metrics;
-    pthread_mutex_t            lock;
+    /* Inode-generation epoch: every generation is drawn from this global
+     * monotonic counter; gen_floor is the durably-persisted bound
+     * (reserve-ahead) that no issued generation may reach.  A reused inode
+     * block therefore always gets a generation greater than any file handle
+     * this filesystem ever issued, so a stale handle can never resolve to
+     * the new file.  gen_wait parks allocations that catch up to the floor
+     * while an extension write is in flight (effectively never). */
+    uint64_t                    gen_next;            /* atomic */
+    uint64_t                    gen_floor;           /* atomic; durable bound */
+    int                         gen_extend_inflight; /* atomic */
+    pthread_mutex_t             gen_lock;            /* guards gen_wait */
+    struct diskfs_block_waiter *gen_wait;
+    struct diskfs_metrics       metrics;
+    pthread_mutex_t             lock;
 };
 
 struct diskfs_thread {
@@ -2423,6 +2435,10 @@ static void diskfs_acl_serial_install(
     struct diskfs_inode *inode,
     const uint8_t       *serial,
     int                  len);
+
+/* Defined with the inode-cache helpers; frees a struct + record mirrors. */
+static inline void diskfs_inode_struct_free(
+    struct diskfs_inode *inode);
 
 static struct diskfs_inode *
 diskfs_inode_load_sync(
@@ -5020,23 +5036,51 @@ diskfs_drain_final_cb(
     int                status,
     void              *priv)
 {
+    struct diskfs_drain       *d      = priv;
+    struct diskfs_shared      *shared = d->thread->shared;
+    struct diskfs_inode_shard *shard  = diskfs_inode_shard(shared, d->inum);
+    struct diskfs_inode       *inode;
+
     (void) txn;
     (void) status;
-    diskfs_drain_complete(priv);
+
+    /* The retire txn is durable and its locks are released; drop the dead
+     * struct from the cache so it neither accumulates nor lingers to collide
+     * with a reallocation of the inum.  Straggling lookups by the old (or
+     * any) generation fault from disk and get ENOENT from the tombstone /
+     * inum check there. */
+    pthread_mutex_lock(&shard->lock);
+    rb_tree_query_exact(&shard->inodes, d->inum, inum, inode);
+    if (inode && inode->nlink == 0 && inode->refcnt == 0 &&
+        !inode->writer && !inode->readers && !inode->wait_head) {
+        diskfs_inode_lru_unlink(shard, inode);
+        rb_tree_remove(&shard->inodes, &inode->node);
+        shard->ninodes--;
+        diskfs_inode_struct_free(inode);
+    }
+    pthread_mutex_unlock(&shard->lock);
+
+    diskfs_drain_complete(d);
 } /* diskfs_drain_final_cb */
 
 /* The durable orphan entry is removed; finish retiring the inode in the same
- * transaction and commit.  The inode home block is intentionally leaked for
- * now: generation reuse is not persisted for newly allocated inodes, so
- * reusing an inum could resolve a stale file handle to the new file. */
+ * transaction and commit: the dinode is logged one last time (gen bumped,
+ * nlink 0 -- a tombstone for any straggling pre-reuse fault) and the 4 KiB
+ * home block itself is returned to the space map.  Generation reuse is safe:
+ * generations are drawn from the global epoch counter, so whatever this inum
+ * becomes next carries a generation no file handle has ever seen. */
 static void
 diskfs_drain_after_unrecord(void *priv)
 {
     struct diskfs_drain *d = priv;
+    uint32_t             dev;
+    uint64_t             off = sm_inum_to_device_offset(d->thread->shared->space_map,
+                                                        d->inum, &dev);
 
     diskfs_txn_pin_inode_block(d->thread, d->txn, d->inode, 0);
     diskfs_inode_return_reservation(d->thread, d->txn, d->inode);
     diskfs_inode_free(d->thread, d->inode);
+    diskfs_txn_free_space(d->thread, d->txn, dev, off, DISKFS_BLOCK_SIZE);
     diskfs_txn_commit(d->txn, diskfs_drain_final_cb, d);
 } /* diskfs_drain_after_unrecord */
 
@@ -5302,6 +5346,142 @@ diskfs_reclaim_destroy(struct diskfs_shared *shared)
     free(r);
     shared->reclaim = NULL;
 } /* diskfs_reclaim_destroy */
+
+/* ------------------------------------------------------------------ */
+/* Inode-generation epoch                                              */
+/* ------------------------------------------------------------------ */
+
+/* Reserve-ahead window persisted into the superblock's gen_floor: a crash
+ * restarts the counter at the last durable floor, which is always at or
+ * above every generation actually issued. */
+#define DISKFS_GEN_RESERVE (1u << 20)
+#define DISKFS_GEN_FIRST   2   /* 0 invalid; 1 = format-created inodes */
+
+struct diskfs_gen_extend {
+    struct diskfs_thread *thread;
+    struct evpl_iovec     iov;
+    uint64_t              new_floor;
+};
+
+static void
+diskfs_gen_extend_complete(
+    struct evpl *evpl,
+    int          status,
+    void        *private_data)
+{
+    struct diskfs_gen_extend   *ge     = private_data;
+    struct diskfs_thread       *thread = ge->thread;
+    struct diskfs_shared       *shared = thread->shared;
+    struct diskfs_block_waiter *waiters, *w;
+
+    chimera_diskfs_abort_if(status != 0,
+                            "generation-floor superblock write failed: %d",
+                            status);
+
+    __atomic_store_n(&shared->gen_floor, ge->new_floor, __ATOMIC_RELEASE);
+    __atomic_store_n(&shared->gen_extend_inflight, 0, __ATOMIC_RELEASE);
+
+    evpl_iovec_release(evpl, &ge->iov);
+    free(ge);
+
+    /* Resume any allocations that caught up to the old floor. */
+    pthread_mutex_lock(&shared->gen_lock);
+    waiters          = shared->gen_wait;
+    shared->gen_wait = NULL;
+    pthread_mutex_unlock(&shared->gen_lock);
+
+    while (waiters) {
+        w       = waiters;
+        waiters = w->next;
+        diskfs_block_waiter_dispatch(thread, w);
+    }
+} /* diskfs_gen_extend_complete */
+
+/* Persist a new generation floor (current counter + reserve).  The write
+ * always carries FUA regardless of unsafe_async: re-issuing a generation
+ * after a crash would let stale file handles resolve to reused inodes. */
+static void
+diskfs_gen_extend(struct diskfs_thread *thread)
+{
+    struct diskfs_shared     *shared = thread->shared;
+    struct diskfs_gen_extend *ge;
+    int                       expect = 0;
+
+    if (!__atomic_compare_exchange_n(&shared->gen_extend_inflight, &expect, 1,
+                                     0, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE)) {
+        return;     /* one extension in flight at a time */
+    }
+
+    ge            = malloc(sizeof(*ge));
+    ge->thread    = thread;
+    ge->new_floor = __atomic_load_n(&shared->gen_next, __ATOMIC_RELAXED) +
+        DISKFS_GEN_RESERVE;
+
+    evpl_iovec_alloc(thread->evpl, SM_SUPERBLOCK_SIZE, SM_SUPERBLOCK_SIZE, 1,
+                     0, &ge->iov);
+    space_map_fill_superblock(shared->space_map, ge->iov.data, shared->fsid,
+                              0 /* dirty */, shared->root_inum,
+                              shared->root_gen, 0, ge->new_floor);
+
+    evpl_block_write(thread->evpl, thread->queue[0], &ge->iov, 1,
+                     SM_SUPERBLOCK_OFFSET, 1 /* sync */,
+                     diskfs_gen_extend_complete, ge);
+} /* diskfs_gen_extend */
+
+/*
+ * Draw the next inode generation.  Returns 0 with *r_gen set, or SM_AGAIN
+ * after parking resume(thread, arg) for the (effectively never taken) case
+ * where the counter caught up to the durable floor before an extension
+ * landed.  The extension is kicked at half-reserve so allocations normally
+ * never block on it.
+ */
+static int
+diskfs_gen_alloc(
+    struct diskfs_thread *thread,
+    uint32_t             *r_gen,
+    void ( *resume )(struct diskfs_thread *, void *),
+    void                 *arg)
+{
+    struct diskfs_shared *shared = thread->shared;
+    uint64_t              g      = __atomic_fetch_add(&shared->gen_next, 1,
+                                                      __ATOMIC_RELAXED);
+    uint64_t              floor;
+
+    chimera_diskfs_abort_if(g >= UINT32_MAX,
+                            "inode generation space exhausted");
+
+    floor = __atomic_load_n(&shared->gen_floor, __ATOMIC_ACQUIRE);
+
+    if (g + DISKFS_GEN_RESERVE / 2 >= floor) {
+        diskfs_gen_extend(thread);
+        if (g >= floor) {
+            /* The slot is past the durable bound: park until the extension
+             * lands (the drawn value is simply wasted; the retry draws a
+             * fresh one). */
+            struct diskfs_block_waiter *w = diskfs_block_waiter_alloc(thread);
+
+            w->thread = thread;
+            w->resume = resume;
+            w->arg    = arg;
+
+            pthread_mutex_lock(&shared->gen_lock);
+            /* The extension may have landed while we took the lock. */
+            if (__atomic_load_n(&shared->gen_floor, __ATOMIC_ACQUIRE) > g) {
+                pthread_mutex_unlock(&shared->gen_lock);
+                diskfs_block_waiter_free(thread, w);
+                *r_gen = (uint32_t) g;
+                return 0;
+            }
+            w->next          = shared->gen_wait;
+            shared->gen_wait = w;
+            pthread_mutex_unlock(&shared->gen_lock);
+            return SM_AGAIN;
+        }
+    }
+
+    *r_gen = (uint32_t) g;
+    return 0;
+} /* diskfs_gen_alloc */
 
 /* ------------------------------------------------------------------ */
 /* nlink -> 0 transition: durable orphan record + deferred reclaim     */
@@ -6475,8 +6655,29 @@ diskfs_inode_cache_insert(
     struct diskfs_inode  *inode)
 {
     struct diskfs_inode_shard *shard = diskfs_inode_shard(shared, inode->inum);
+    struct diskfs_inode       *stale;
 
     pthread_mutex_lock(&shard->lock);
+
+    /* A reallocated inum can collide with the previous life's retired struct
+     * (kept cached through its background drain).  By the time the space map
+     * re-issued the home block, the drain fully retired it -- dead, unlocked,
+     * unreferenced -- so it can be replaced; any straggling lookup by the old
+     * generation gets ENOENT from the new struct's gen check. */
+    rb_tree_query_exact(&shard->inodes, inode->inum, inum, stale);
+    if (stale) {
+        chimera_diskfs_abort_if(stale->nlink != 0 || stale->refcnt != 0 ||
+                                stale->writer || stale->readers ||
+                                stale->wait_head,
+                                "inum %lu reallocated while previous life "
+                                "is still live", inode->inum);
+        diskfs_inode_lru_unlink(shard, stale);
+        diskfs_inode_mtime_unlink_locked(shard, stale);
+        rb_tree_remove(&shard->inodes, &stale->node);
+        shard->ninodes--;
+        diskfs_inode_struct_free(stale);
+    }
+
     diskfs_inode_cache_recycle_locked(shared, shard);
     rb_tree_insert(&shard->inodes, inum, inode);
     shard->ninodes++;
@@ -6735,6 +6936,7 @@ diskfs_inode_alloc_async(
     struct diskfs_inode_alloc_ctx *actx;
     uint32_t                       device_id;
     uint64_t                       device_offset, inum;
+    uint32_t                       gen;
     int                            rc;
 
     /* The reservation refill journals and may park on a cold log block; carry
@@ -6744,6 +6946,13 @@ diskfs_inode_alloc_async(
     actx->txn          = txn;
     actx->cb           = cb;
     actx->private_data = private_data;
+
+    /* Draw the generation before the space draw so a (rare) park on the
+     * generation floor can re-drive without having allocated a block. */
+    if (diskfs_gen_alloc(thread, &gen, diskfs_inode_alloc_resume,
+                         actx) == SM_AGAIN) {
+        return;     /* parked; diskfs_inode_alloc_resume re-runs (owns actx) */
+    }
 
     DISKFS_SM_JNL(jnl, thread, txn, diskfs_inode_alloc_resume, actx);
     rc = space_map_alloc(shared->space_map, &thread->space_cache, &jnl,
@@ -6760,6 +6969,7 @@ diskfs_inode_alloc_async(
 
     inum  = sm_inum_from_device_offset(shared->space_map, device_id, device_offset);
     inode = diskfs_inode_struct_new(inum);
+    inode->gen = gen;
 
     /* New dirty inode: write-locked by this (write) txn from birth. */
     inode->writer = 1;
@@ -9224,6 +9434,7 @@ diskfs_init(
 
 
     pthread_mutex_init(&shared->lock, NULL);
+    pthread_mutex_init(&shared->gen_lock, NULL);
     diskfs_metrics_init(shared, metrics);
 
     /* Decide mkfs vs clean-mount vs crash-recovery from the superblock, just as
@@ -9312,6 +9523,14 @@ diskfs_init(
 
         shared->mounted = (mode != 0);
 
+        /* Seed the generation epoch: a remount continues from the durable
+         * floor (>= every generation ever issued); a fresh format starts
+         * above the format-created inodes' generation (1).  The dirty
+         * superblock write below persists the extended floor. */
+        shared->gen_next  = (mode != 0 && sb.gen_floor > DISKFS_GEN_FIRST)
+            ? sb.gen_floor : DISKFS_GEN_FIRST;
+        shared->gen_floor = shared->gen_next + DISKFS_GEN_RESERVE;
+
         if (mode != 0) {
             uint8_t              fsid_buf[CHIMERA_VFS_FSID_SIZE] = { 0 };
             uint64_t             rinum                           = sb.root_inum ? sb.root_inum : 2;
@@ -9368,7 +9587,8 @@ diskfs_init(
                                         shared->fsid, 0,
                                         mode != 0 ? shared->root_inum : 0,
                                         mode != 0 ? shared->root_gen : 0,
-                                        mode != 0 ? sb.log_seq : 0);
+                                        mode != 0 ? sb.log_seq : 0,
+                                        shared->gen_floor);
         chimera_diskfs_abort_if(rc != 0, "Failed to write superblock");
 
         /* mkfs: write an initial condensed AG-log base so each slot has a valid
@@ -9652,10 +9872,14 @@ diskfs_destroy(void *private_data)
         if (space_map_persist(shared->space_map, &smio) != 0) {
             chimera_diskfs_error("space-map persist at unmount failed");
         } else if (shared->root_fhlen != 0) {
+            /* Clean unmount: persist the exact next generation (no reserve
+             * needed -- nothing was issued past gen_next). */
             int rc = space_map_write_superblock(shared->space_map, &smio,
                                                 shared->fsid, SM_SB_CLEAN,
                                                 shared->root_inum, shared->root_gen,
-                                                shared->intent_log.log_seq);
+                                                shared->intent_log.log_seq,
+                                                __atomic_load_n(&shared->gen_next,
+                                                                __ATOMIC_ACQUIRE));
             if (rc != 0) {
                 chimera_diskfs_error("clean-superblock write at unmount failed");
             }

--- a/src/vfs/diskfs/diskfs.c
+++ b/src/vfs/diskfs/diskfs.c
@@ -8657,13 +8657,28 @@ diskfs_txn_commit_finish(
      * and the inode locks are still held -- so the redo record captures this
      * txn's committed image, immune to a later COW, and the intent-log thread
      * never has to touch the live block->iov.  The refs are moved into the
-     * record by diskfs_il_write_redo. */
+     * record by diskfs_il_write_redo.
+     *
+     * Each clone runs under the block's shard lock: a shared block (an
+     * AG-log block pinned dirty by several journaling txns) goes LOGGED as
+     * soon as the FIRST txn's record is durable, at which point a concurrent
+     * claim COW-forks it -- replacing block->iov under that same lock --
+     * while a later txn is still snapshotting.  The COW copies the buffer,
+     * so whichever side of the swap the clone sees carries this txn's
+     * bytes. */
     {
         struct diskfs_txn_block *tb;
         uint64_t                 blocks = 0;
 
         for (tb = txn->blocks; tb; tb = tb->next) {
+            struct diskfs_block_shard *bshard =
+                diskfs_block_shard(thread->shared->block_cache,
+                                   tb->block->device_id,
+                                   tb->block->device_offset);
+
+            pthread_mutex_lock(&bshard->lock);
             evpl_iovec_clone(&tb->snap, &tb->block->iov);
+            pthread_mutex_unlock(&bshard->lock);
             blocks++;
         }
         diskfs_metric_counter_inc(thread->metrics.txn[0]);

--- a/src/vfs/diskfs/space_map.c
+++ b/src/vfs/diskfs/space_map.c
@@ -31,6 +31,24 @@
 #define SM_PERSIST_BATCH_OPS   128U
 #define SM_PERSIST_BATCH_BYTES (16ULL << 20)
 
+/* Test knob: trigger runtime AG-log condensation after this many deltas
+ * instead of at the slot's byte high-water (0 = disabled).  Read lazily so a
+ * test can set the variable before mount. */
+static uint32_t
+sm_condense_test_deltas_get(void)
+{
+    static int      init;
+    static uint32_t val;
+
+    if (!init) {
+        const char *e = getenv("DISKFS_AG_CONDENSE_DELTAS");
+
+        val  = e ? (uint32_t) strtoul(e, NULL, 10) : 0;
+        init = 1;
+    }
+    return val;
+} /* sm_condense_test_deltas_get */
+
 /*
  * Append one allocation/free delta to the AG's active log slot, journaled
  * through the current transaction (via jnl) so it rides the main redo log and
@@ -40,9 +58,10 @@
  * 4 KiB-aligned, 128-per-block units (no block-spanning); the delta count
  * lives in the slot header (block 0).
  *
- * Runtime condensation (recycling a full delta region into a fresh base) is
- * not yet implemented; the 4 MiB region holds ~128K deltas per AG between
- * clean unmounts, which re-condense.  Overflow aborts (TODO).
+ * When the active slot's delta region hits its high-water mark, journaling
+ * parks and a background condensation rewrites the inactive slot with a
+ * fresh base and flips (space_map_condense_prepare/commit); clean unmounts
+ * also re-condense every AG.
  */
 /*
  * The two AG-log blocks an upcoming delta touches, claimed (and pinned into the
@@ -80,6 +99,12 @@ sm_ag_journal_claim(
         return 0;
     }
 
+    /* Already condensing: park behind it. */
+    if (ag->condensing) {
+        jnl->ag_park(jnl->user, ag->device_id, ag->ag_index);
+        return SM_AGAIN;
+    }
+
     slot_base  = ag->log_offset + (uint64_t) ag->log_slot * SM_AG_LOG_SLOT_SIZE;
     region_off = (sizeof(struct sm_ag_log_header) +
                   (uint64_t) ag->log_base_count * sizeof(struct sm_ag_log_ext) +
@@ -87,8 +112,25 @@ sm_ag_journal_claim(
     slot->idx = ag->log_delta_count;
 
     delta_byte = region_off + (uint64_t) slot->idx * sizeof(struct sm_ag_log_delta);
+
+    /* High-water: hand the slot to a background condensation (writes the
+     * current free set as a fresh base into the inactive slot and flips) and
+     * park this operation behind it.  The margin below the hard limit
+     * absorbs nothing -- claims park immediately -- it is simply headroom so
+     * the abort is unreachable short of a condensation bug.  The test knob
+     * (DISKFS_AG_CONDENSE_DELTAS) triggers after a small fixed delta count
+     * so tests can exercise the condensation path without journaling ~100K
+     * deltas per AG. */
+    if (delta_byte + SM_AG_LOG_CONDENSE_MARGIN > SM_AG_LOG_SLOT_SIZE ||
+        (sm_condense_test_deltas_get() && slot->idx >= sm_condense_test_deltas_get())) {
+        ag->condensing = 1;
+        jnl->ag_condense(jnl->user, ag->device_id, ag->ag_index);
+        jnl->ag_park(jnl->user, ag->device_id, ag->ag_index);
+        return SM_AGAIN;
+    }
+
     sm_abort_if(delta_byte + sizeof(struct sm_ag_log_delta) > SM_AG_LOG_SLOT_SIZE,
-                "AG %u/%u delta region full (%u deltas) -- condensation TODO",
+                "AG %u/%u delta region full (%u deltas) despite condensation",
                 ag->device_id, ag->ag_index, slot->idx);
 
     blk_off        = slot_base + (delta_byte & ~((uint64_t) SM_BLOCK_SIZE - 1));
@@ -191,6 +233,7 @@ sm_ag_init(
     ag->log_generation  = 0;
     ag->log_base_count  = 0;
     ag->log_delta_count = 0;
+    ag->condensing      = 0;
 
     pthread_mutex_init(&ag->lock, NULL);
     rb_tree_init(&ag->free_by_offset);
@@ -966,6 +1009,78 @@ sm_ag_mark_used_locked(
     ag->free_bytes -= length;
     free(e);
 } /* sm_ag_mark_used_locked */
+
+static uint64_t sm_ag_condense_into(
+    struct sm_ag *ag,
+    uint8_t      *slot,
+    uint64_t      generation);
+
+/*
+ * Runtime condensation, phase 1: snapshot the AG's free set as a condensed
+ * base image (header at buf[0]) for the INACTIVE slot.  Called by the
+ * background condenser once jnl->ag_condense fired; all journaling into this
+ * AG is parked, so the set is mutated only by free-applies of durable
+ * transactions, and any snapshot is crash-safe: allocations are reflected
+ * eagerly (a lost one merely leaks) and frees only once durable (so the base
+ * never frees a block a committed file still references).  One bounded,
+ * self-healing crash window exists: a FREE delta journaled into the old slot
+ * whose txn becomes durable after the flip lives only in the dead slot, so a
+ * crash before the next condensation/clean unmount leaks that range (the
+ * next snapshot re-captures it from memory).  buf must hold
+ * SM_AG_LOG_SLOT_SIZE bytes.
+ *
+ * The caller must write the image to *r_slot_offset with the HEADER BLOCK
+ * (first 4 KiB) LAST and FUA: the inactive slot stays invalid (stale, lower
+ * generation) until the header lands, so a crash at any point leaves the old
+ * slot authoritative.  Then call space_map_condense_commit.
+ */
+int
+space_map_condense_prepare(
+    struct space_map *sm,
+    uint32_t          device_id,
+    uint32_t          ag_index,
+    void             *buf,
+    uint64_t         *r_slot_offset,
+    uint64_t         *r_payload)
+{
+    struct sm_ag *ag = &sm->devices[device_id].ags[ag_index];
+    uint64_t      payload;
+
+    pthread_mutex_lock(&ag->lock);
+    sm_abort_if(!ag->condensing, "condense_prepare on a non-condensing AG");
+
+    payload = sm_ag_condense_into(ag, (uint8_t *) buf, ag->log_generation + 1);
+
+    *r_slot_offset = ag->log_offset +
+        (uint64_t) (1 - ag->log_slot) * SM_AG_LOG_SLOT_SIZE;
+    *r_payload = payload;
+    pthread_mutex_unlock(&ag->lock);
+    return 0;
+} /* space_map_condense_prepare */
+
+/*
+ * Runtime condensation, phase 2: the new base image is durable in the
+ * inactive slot (header written last) -- flip to it and clear the gate.  The
+ * caller then re-drives every operation it parked for this AG.
+ */
+void
+space_map_condense_commit(
+    struct space_map *sm,
+    uint32_t          device_id,
+    uint32_t          ag_index,
+    uint32_t          base_count)
+{
+    struct sm_ag *ag = &sm->devices[device_id].ags[ag_index];
+
+    pthread_mutex_lock(&ag->lock);
+    sm_abort_if(!ag->condensing, "condense_commit on a non-condensing AG");
+    ag->log_slot        = 1 - ag->log_slot;
+    ag->log_generation += 1;
+    ag->log_base_count  = base_count;
+    ag->log_delta_count = 0;
+    ag->condensing      = 0;
+    pthread_mutex_unlock(&ag->lock);
+} /* space_map_condense_commit */
 
 /* Serialize the AG's current free set into `slot` as a condensed base (no
  * deltas) at `generation`.  Caller holds ag->lock.  Returns bytes written. */

--- a/src/vfs/diskfs/space_map.c
+++ b/src/vfs/diskfs/space_map.c
@@ -835,20 +835,20 @@ space_map_thread_cache_return(
     return 0;
 } /* space_map_thread_cache_return */
 
-int
-space_map_write_superblock(
-    struct space_map   *sm,
-    const struct sm_io *io,
-    uint64_t            fsid,
-    uint64_t            flags,
-    uint64_t            root_inum,
-    uint32_t            root_gen,
-    uint64_t            log_seq)
+void
+space_map_fill_superblock(
+    struct space_map *sm,
+    void             *buf,
+    uint64_t          fsid,
+    uint64_t          flags,
+    uint64_t          root_inum,
+    uint32_t          root_gen,
+    uint64_t          log_seq,
+    uint64_t          gen_floor)
 {
-    uint8_t               buf[SM_SUPERBLOCK_SIZE];
     struct sm_superblock *sb = (struct sm_superblock *) buf;
 
-    memset(buf, 0, sizeof(buf));
+    memset(buf, 0, SM_SUPERBLOCK_SIZE);
 
     sb->magic              = SM_SUPERBLOCK_MAGIC;
     sb->version            = SM_FORMAT_VERSION;
@@ -868,8 +868,26 @@ space_map_write_superblock(
     sb->remote_log_device  = SM_INTENT_LOG_DEVICE;
     sb->remote_log_offset  = sm->remote_log_offset;
     sb->remote_log_size    = sm->remote_log_size;
+    sb->gen_floor          = gen_floor;
     sb->crc32              = 0;
-    sb->crc32              = sm_crc32(buf, sizeof(buf));
+    sb->crc32              = sm_crc32(buf, SM_SUPERBLOCK_SIZE);
+} /* space_map_fill_superblock */
+
+int
+space_map_write_superblock(
+    struct space_map   *sm,
+    const struct sm_io *io,
+    uint64_t            fsid,
+    uint64_t            flags,
+    uint64_t            root_inum,
+    uint32_t            root_gen,
+    uint64_t            log_seq,
+    uint64_t            gen_floor)
+{
+    uint8_t buf[SM_SUPERBLOCK_SIZE];
+
+    space_map_fill_superblock(sm, buf, fsid, flags, root_inum, root_gen,
+                              log_seq, gen_floor);
 
     if (io->write(io->user, 0, buf, sizeof(buf), SM_SUPERBLOCK_OFFSET) != 0) {
         return -1;

--- a/src/vfs/diskfs/space_map.c
+++ b/src/vfs/diskfs/space_map.c
@@ -415,11 +415,12 @@ space_map_create(
             if (d == SM_INTENT_LOG_DEVICE && a == 0) {
                 /* AG 0 of device 0 also hosts the superblock, the intent log
                  * and the relocated remote-AG-log region, all *before* this
-                 * AG's own log.  Then 3 bootstrap inode blocks after the log
-                 * (block_idx 1=AG header, 2=root inode, 3=orphan list). */
+                 * AG's own log.  Then the bootstrap inode blocks after the log
+                 * (block_idx 1=reserved, 2=root inode, 3..=orphan-list
+                 * shards). */
                 uint64_t pre_log = SM_SUPERBLOCK_SIZE + SM_INTENT_LOG_SIZE +
                     sm->remote_log_size;
-                uint64_t post_log = 3 * SM_BLOCK_SIZE;
+                uint64_t post_log = (2 + SM_BOOTSTRAP_ORPHAN_SLOTS) * SM_BLOCK_SIZE;
 
                 log_offset = base + pre_log;
 

--- a/src/vfs/diskfs/space_map.h
+++ b/src/vfs/diskfs/space_map.h
@@ -23,18 +23,18 @@
  * intent log will replace; this is where on-disk durability hooks in.
  */
 
-#define SM_BLOCK_SHIFT       12
-#define SM_BLOCK_SIZE        (1ULL << SM_BLOCK_SHIFT)
-#define SM_BLOCK_MASK        (SM_BLOCK_SIZE - 1)
+#define SM_BLOCK_SHIFT            12
+#define SM_BLOCK_SIZE             (1ULL << SM_BLOCK_SHIFT)
+#define SM_BLOCK_MASK             (SM_BLOCK_SIZE - 1)
 
-#define SM_AG_SIZE_LOG2      30                             /* 1 GiB */
-#define SM_AG_SIZE           (1ULL << SM_AG_SIZE_LOG2)
-#define SM_AG_OFFSET_MASK    (SM_AG_SIZE - 1)
+#define SM_AG_SIZE_LOG2           30                        /* 1 GiB */
+#define SM_AG_SIZE                (1ULL << SM_AG_SIZE_LOG2)
+#define SM_AG_OFFSET_MASK         (SM_AG_SIZE - 1)
 
-#define SM_SUPERBLOCK_OFFSET 0
-#define SM_SUPERBLOCK_SIZE   4096
-#define SM_SUPERBLOCK_MAGIC  0x4D5346534B534944ULL          /* "DISKSFSM" */
-#define SM_FORMAT_VERSION    2
+#define SM_SUPERBLOCK_OFFSET      0
+#define SM_SUPERBLOCK_SIZE        4096
+#define SM_SUPERBLOCK_MAGIC       0x4D5346534B534944ULL     /* "DISKSFSM" */
+#define SM_FORMAT_VERSION         2
 
 /*
  * Bootstrap inode blocks carved after AG 0's log on device 0 at format time:
@@ -45,7 +45,7 @@
  */
 #define SM_BOOTSTRAP_ORPHAN_SLOTS 16
 
-#define SM_RESERVATION_MIN   (1ULL << 20)                   /* 1 MiB */
+#define SM_RESERVATION_MIN        (1ULL << 20)              /* 1 MiB */
 
 #define SM_ALIGN_UP(x) (((x) + SM_BLOCK_MASK) & ~SM_BLOCK_MASK)
 
@@ -62,16 +62,16 @@
  * 0 we reserve block_idx == 1 at format time so the very first allocation
  * lands at block_idx == 2 (= inum 2 = the root inode).
  */
-#define SM_INUM_INDEX_BITS   32
-#define SM_INUM_AG_BITS      24
-#define SM_INUM_DISK_BITS    8
+#define SM_INUM_INDEX_BITS        32
+#define SM_INUM_AG_BITS           24
+#define SM_INUM_DISK_BITS         8
 
-#define SM_INUM_INDEX_MASK   ((1ULL << SM_INUM_INDEX_BITS) - 1)
-#define SM_INUM_AG_MASK      ((1ULL << SM_INUM_AG_BITS)    - 1)
-#define SM_INUM_DISK_MASK    ((1ULL << SM_INUM_DISK_BITS)  - 1)
+#define SM_INUM_INDEX_MASK        ((1ULL << SM_INUM_INDEX_BITS) - 1)
+#define SM_INUM_AG_MASK           ((1ULL << SM_INUM_AG_BITS)    - 1)
+#define SM_INUM_DISK_MASK         ((1ULL << SM_INUM_DISK_BITS)  - 1)
 
-#define SM_INUM_AG_SHIFT     SM_INUM_INDEX_BITS
-#define SM_INUM_DISK_SHIFT   (SM_INUM_INDEX_BITS + SM_INUM_AG_BITS)
+#define SM_INUM_AG_SHIFT          SM_INUM_INDEX_BITS
+#define SM_INUM_DISK_SHIFT        (SM_INUM_INDEX_BITS + SM_INUM_AG_BITS)
 
 /*
  * Each AG carves a fixed prefix off the front of its data range for its
@@ -80,9 +80,14 @@
  * fragmentation of a 1 GiB AG with 4 KiB blocks (~2 MiB per snapshot) with
  * comfortable headroom.
  */
-#define SM_AG_LOG_SLOT_SIZE  (4ULL << 20)  /* 4 MiB */
-#define SM_AG_LOG_SLOT_COUNT 2
-#define SM_AG_LOG_SIZE       (SM_AG_LOG_SLOT_SIZE * SM_AG_LOG_SLOT_COUNT)
+#define SM_AG_LOG_SLOT_SIZE       (4ULL << 20) /* 4 MiB */
+#define SM_AG_LOG_SLOT_COUNT      2
+#define SM_AG_LOG_SIZE            (SM_AG_LOG_SLOT_SIZE * SM_AG_LOG_SLOT_COUNT)
+
+/* Free headroom (bytes) left in a slot's delta region when runtime
+ * condensation is triggered; new journaling parks behind the condense, so
+ * this is margin against the hard-full abort, not a budget that fills. */
+#define SM_AG_LOG_CONDENSE_MARGIN (64ULL << 10)
 
 /*
  * On-disk per-AG allocation log.  Each slot begins with this header, followed
@@ -96,10 +101,10 @@
  * no separate checksum -- a torn condensation simply leaves the older slot
  * live.
  */
-#define SM_AG_LOG_MAGIC      0x474F4C47414B5344ULL     /* "DSKAGLOG" */
+#define SM_AG_LOG_MAGIC           0x474F4C47414B5344ULL /* "DSKAGLOG" */
 
-#define SM_AG_LOG_OP_ALLOC   0u /* [offset,len) was handed out: remove from free */
-#define SM_AG_LOG_OP_FREE    1u /* [offset,len) was returned:   add to free */
+#define SM_AG_LOG_OP_ALLOC        0u /* [offset,len) was handed out: remove from free */
+#define SM_AG_LOG_OP_FREE         1u /* [offset,len) was returned:   add to free */
 
 struct sm_ag_log_header {
     uint64_t magic;
@@ -138,6 +143,20 @@ struct sm_journal {
         uint32_t device_id,
         uint64_t device_offset,
         int      is_new);
+    /* The AG's active log slot hit its high-water mark: schedule a runtime
+     * condensation (background; see space_map_condense_prepare/commit).
+     * Called once per condensation cycle, under the AG lock. */
+    void  (*ag_condense)(
+        void    *user,
+        uint32_t device_id,
+        uint32_t ag_index);
+    /* The AG is condensing: park the current operation's continuation; it is
+     * re-driven when the condensation commits.  Called under the AG lock
+     * (park on a caller-side list; do not call back into the space map). */
+    void  (*ag_park)(
+        void    *user,
+        uint32_t device_id,
+        uint32_t ag_index);
     void *user;
 };
 
@@ -305,6 +324,11 @@ struct sm_ag {
     uint64_t        log_generation;  /* generation of the active slot */
     uint32_t        log_base_count;  /* condensed base extents in the active slot */
     uint32_t        log_delta_count; /* deltas appended since the last condense */
+
+    /* Runtime condensation gate (protected by lock): while set, every
+     * journaling operation parks (jnl->ag_park) until the background
+     * condense commits the inactive slot and flips. */
+    int             condensing;
 };
 
 struct sm_device {
@@ -471,6 +495,27 @@ space_map_write_superblock(
     uint32_t            root_gen,
     uint64_t            log_seq,
     uint64_t            gen_floor);
+
+/* Runtime AG-log condensation (see the implementation for the full
+ * protocol): prepare snapshots the free set as a new base image for the
+ * inactive slot; after the caller writes the image (header block last, FUA),
+ * commit flips the slot and re-opens journaling.  base_count comes from the
+ * image header. */
+int
+space_map_condense_prepare(
+    struct space_map *sm,
+    uint32_t          device_id,
+    uint32_t          ag_index,
+    void             *buf,
+    uint64_t         *r_slot_offset,
+    uint64_t         *r_payload);
+
+void
+space_map_condense_commit(
+    struct space_map *sm,
+    uint32_t          device_id,
+    uint32_t          ag_index,
+    uint32_t          base_count);
 
 /* Read + validate the superblock from device 0; 0 on success (fills *out),
  * -1 if absent/corrupt/wrong-version (caller should mkfs). */

--- a/src/vfs/diskfs/space_map.h
+++ b/src/vfs/diskfs/space_map.h
@@ -440,6 +440,23 @@ space_map_thread_cache_return(
     struct sm_thread_cache  *cache);
 
 /*
+ * Format a complete superblock image (including CRC) into buf, which must be
+ * SM_SUPERBLOCK_SIZE bytes.  Used by space_map_write_superblock and by the
+ * runtime generation-floor extension, which writes the block through a live
+ * worker's block queue instead of the mount-time bridge.
+ */
+void
+space_map_fill_superblock(
+    struct space_map *sm,
+    void             *buf,
+    uint64_t          fsid,
+    uint64_t          flags,
+    uint64_t          root_inum,
+    uint32_t          root_gen,
+    uint64_t          log_seq,
+    uint64_t          gen_floor);
+
+/*
  * Write a stub superblock to offset 0 of device 0 through the mount-time
  * I/O bridge (async evpl_block, pumped to completion + flushed).  Done at
  * format/unmount time before worker threads exist.
@@ -452,7 +469,8 @@ space_map_write_superblock(
     uint64_t            flags,
     uint64_t            root_inum,
     uint32_t            root_gen,
-    uint64_t            log_seq);
+    uint64_t            log_seq,
+    uint64_t            gen_floor);
 
 /* Read + validate the superblock from device 0; 0 on success (fills *out),
  * -1 if absent/corrupt/wrong-version (caller should mkfs). */

--- a/src/vfs/diskfs/space_map.h
+++ b/src/vfs/diskfs/space_map.h
@@ -34,7 +34,16 @@
 #define SM_SUPERBLOCK_OFFSET 0
 #define SM_SUPERBLOCK_SIZE   4096
 #define SM_SUPERBLOCK_MAGIC  0x4D5346534B534944ULL          /* "DISKSFSM" */
-#define SM_FORMAT_VERSION    1
+#define SM_FORMAT_VERSION    2
+
+/*
+ * Bootstrap inode blocks carved after AG 0's log on device 0 at format time:
+ * block_idx 1 is reserved (inum 1 invalid by convention), 2 is the root
+ * inode, and the next SM_BOOTSTRAP_ORPHAN_SLOTS blocks (inums 3..) are the
+ * sharded orphan-list inodes (diskfs spreads deleted-inode records across
+ * them so unlinks don't serialize on one inode's write lock).
+ */
+#define SM_BOOTSTRAP_ORPHAN_SLOTS 16
 
 #define SM_RESERVATION_MIN   (1ULL << 20)                   /* 1 MiB */
 
@@ -209,6 +218,12 @@ struct sm_superblock {
     uint32_t remote_log_device;     /* device holding relocated logs (== 0) */
     uint64_t remote_log_offset;     /* region base on remote_log_device */
     uint64_t remote_log_size;       /* total region bytes */
+    /* Inode-generation floor: every generation ever issued by this filesystem
+     * is below this value, persisted with reserve-ahead so a crash can never
+     * re-issue a generation (which would let a stale file handle resolve to a
+     * reused inode block).  diskfs owns the semantics; see the gen allocator
+     * there. */
+    uint64_t gen_floor;
     /* Remainder of the 4 KiB block is implicit zero padding. */
 };
 


### PR DESCRIPTION
**Stacked on #751** — the first 4 commits here belong to that PR; review the last 7 (`8954fc17..a82df377`).

This removes the two remaining structural blockers from the scale-readiness audit: deletes that leak space (4 KiB home block per inode, everything for unlink-while-open, everything for rename/link-replace) and the AG-log "delta region full — condensation TODO" abort. Deletes now reclaim everything they allocated, asynchronously off the hot path, and the allocation log condenses online.

### diskfs: dedicated reclaim worker threads
A small pool (config `reclaim_threads`, default 2) of evpl threads, each owning a full diskfs thread context (block queues, b+tree ops, its own intent-log channel). Deleted-inode burn-down runs here instead of on the request workers; unmount finishes the queued backlog.

### diskfs: reclaim all deleted-inode space asynchronously off the hot path
Every nlink→0 transition (unlink, rmdir, rename-replace, link-replace, create_unlinked at birth) records the inode on the durable orphan list in the same txn and does no inline reclaim; the burn-down (data extents + incremental b+tree destruction in bounded batches) happens on the reclaim workers once the last reference drops — at the unlink itself, or at the final close, which fixes the unlink-while-open leak (those files previously freed nothing, ever). The orphan list is sharded across 16 format-created inodes because inode locks are held to txn-durability — a single orphan inode would serialize every unlink at commit latency. Also fixed along the way: rename-replace left a replaced directory at nlink=1 (never reclaimable), and both rename- and link-replace leaked the replaced target entirely; dead (deleted + unreferenced) inodes are now unopenable by stale handle and unlinkable into the namespace.

### diskfs: generation epoch + inode home-block reclaim
Generations come from a global monotonic counter whose bound is superblock-persisted with 2^20 reserve-ahead (extension writes are always FUA; clean unmount stores the exact next value). Any inum reuse therefore gets a generation no file handle has ever seen, which makes it safe for the final drain txn to return the 4 KiB home block to the space map — closing the deliberate leak that previously substituted for stale-handle safety. Retired structs leave the inode cache (they used to accumulate forever), with a defensive replace at re-allocation.

### diskfs: runtime AG-log condensation
At the slot high-water mark the space map parks journaling for that AG and a reclaim worker writes the in-memory free set as a fresh base into the inactive slot — body blocks first, header last, all FUA, so a torn condensation leaves the old slot authoritative — then flips and re-drives the parked ops. No quiesce is needed for crash safety (allocs are reflected eagerly, frees only once durable); the design notes document the one bounded, self-healing leak-on-crash window. An earlier wait-for-pending-frees design is documented as a deadlock and avoided.

### Three pre-existing bugs found and fixed while validating
- **`diskfs: deliver b+tree op completion after a reserve-only journal park`** — an insert whose reservation parked on a cold AG-log block but whose descent was then fully resident completed into `done` with no caller left: callback never fired, request dropped, txn write locks held forever. Deterministic FS-wide wedge on the first metadata write after a remount.
- **`diskfs: snapshot txn blocks under the block shard lock`** — commit-time block snapshots raced the LOGGED→COW fork on shared AG-log blocks (ASan UAF under churn).
- The reserve-park fix also explains rare unlink-phase hangs previously seen under eviction stress.

### test: diskfs space-reclaim + AG-log condensation coverage
`posix_test_diskfs_reclaim` asserts statfs convergence over 1500 create/write/delete cycles (extents + tree nodes + home blocks all return, inums recycling under the gen epoch), read-back of an unlinked-but-open file with reclaim at final close, and a `DISKFS_DRAIN_DISABLE` backlog reclaimed across a cold remount — with `DISKFS_AG_CONDENSE_DELTAS=64` so each run exercises dozens of runtime condensations. A warm-up round precedes the baseline because per-worker space-map reservations (≤1 MiB each) are working capital, not leaks.

On-disk format bumps to version 2 (sharded orphan inodes in the bootstrap layout, superblock gen_floor); v1 images report "superblock missing or invalid; specify initialize to format".

Validation: full Debug (ASan) and Release diskfs matrices green (732/732 each, including the eviction and new reclaim tests), scan-build clean, reuse-lint clean.