### PR TITLE
smb2: resolve the disconnect-vs-conflicting-open race on durable handles

### DIFF
--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -1870,6 +1870,25 @@ chimera_smb_server_notify(
             chimera_smb_info("Disconnected %s SMB connection from %s to %s, handled %lu requests",
                              conn->protocol == EVPL_DATAGRAM_RDMACM_RC ? "RDMA" : "TCP",
                              conn->remote_addr, conn->local_addr, conn->requests_completed);
+            /* Test hook: delay disconnect processing to deterministically widen
+             * the window between a client's TCP close and the server-side
+             * teardown that parks its durable handles.  A request racing into
+             * that window on another connection exercises the
+             * disconnect-vs-conflicting-open paths (close-not-park, yielded
+             * reclaim, parked-CREATE re-arbitration) that otherwise only a
+             * loaded CI machine hits.  Inert unless the environment variable is
+             * set; used by the smbtorture durable-open ctest entries. */
+            {
+                static int delay_ms = -1;
+
+                if (delay_ms < 0) {
+                    const char *d = getenv("CHIMERA_SMB_TEST_DISCONNECT_DELAY_MS");
+                    delay_ms = d ? atoi(d) : 0;
+                }
+                if (delay_ms > 0) {
+                    usleep(delay_ms * 1000);
+                }
+            }
             chimera_smb_conn_free(thread, conn);
             break;
         case EVPL_NOTIFY_RECV_MSG:

--- a/src/server/smb/smb_async_interim.c
+++ b/src/server/smb/smb_async_interim.c
@@ -181,5 +181,18 @@ chimera_smb_async_interim_drain(struct chimera_smb_conn *conn)
         request->async.park_next = NULL;
         request->async.armed     = 0;
         evpl_remove_timer(thread->evpl, &request->async.timer);
+
+        /* A parked CREATE holds an open_file reference (taken when it deferred
+        * on the lease/oplock break it triggered) that only its resume path
+        * would drop -- and with the deadline timer cancelled above, no resume
+        * will ever come.  Drop it here or the reference pins the open past
+        * its tree's teardown and the open's VFS handle leaks, wedging the
+        * VFS close-thread drain at shutdown.  Clear r_open_file so a late
+        * completion of the orphaned request cannot touch the released open. */
+        if (request->smb2_hdr.command == SMB2_CREATE &&
+            request->create.r_open_file) {
+            chimera_smb_open_file_release(request, request->create.r_open_file);
+            request->create.r_open_file = NULL;
+        }
     }
 } /* chimera_smb_async_interim_drain */

--- a/src/server/smb/smb_durable.c
+++ b/src/server/smb/smb_durable.c
@@ -362,6 +362,14 @@ chimera_smb_durable_claim(
         /* The handle is still live on another (multi-)channel — a second
          * reconnect cannot steal it. */
         *status = SMB2_STATUS_OBJECT_NAME_NOT_FOUND;
+    } else if (entry->open_file &&
+               (entry->open_file->flags & CHIMERA_SMB_OPEN_FILE_YIELDED)) {
+        /* While disconnected, this open's write-caching oplock/lease was
+         * forcibly revoked to admit a conflicting open — it yielded (MS-SMB2
+         * 3.3.4.6/3.3.4.7 close a disconnected open whose batch oplock /
+         * write-caching lease breaks), so the reconnect must not find it.
+         * The grace-timer sweep reaps the carcass. */
+        *status = SMB2_STATUS_OBJECT_NAME_NOT_FOUND;
     } else if (create_guid && memcmp(entry->create_guid, create_guid, 16) != 0) {
         *status = SMB2_STATUS_OBJECT_NAME_NOT_FOUND;
     } else if ((had_lease || entry->persistent) && client_guid &&

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -1058,6 +1058,14 @@ chimera_smb_open_file_drain_locks(
     struct chimera_server_smb_thread *thread,
     struct chimera_smb_open_file     *open_file);
 
+/* Ring every peer SMB thread's lease-resume doorbell so each re-sweeps its
+ * connections for parked CREATEs an event on this thread unblocked (defined in
+ * smb_proc_create.c; also declared in smb_procs.h, which this header cannot
+ * include). */
+void
+chimera_smb_create_resume_parked_broadcast(
+    struct chimera_server_smb_thread *origin);
+
 /* Durable/persistent handle registry (smb_durable.c). */
 void
 chimera_smb_durable_table_init(
@@ -1458,6 +1466,26 @@ chimera_smb_durable_open_preservable(const struct chimera_smb_open_file *open_fi
     return true;
 } /* chimera_smb_durable_open_preservable */
 
+/* MS-SMB2 3.3.7.1 (connection loss): only an open whose oplock/lease is Held
+ * survives as a disconnected durable handle.  One mid-break can never deliver
+ * the ack its breaker is waiting on (the connection is gone), so preserving it
+ * would wedge the conflicting CREATE behind the full break deadline and leave
+ * a reclaimable handle that should have yielded -- close it instead.  An
+ * already-revoked grant likewise holds nothing worth preserving.
+ *
+ * break_state is read without the grant's file lock: the teardown path holds
+ * the tree bucket lock here and the bucket -> vfs_state order forbids nesting
+ * the other way around, so a break that begins concurrently may be missed.
+ * That race is benign: the break callback then finds no live member
+ * (create_conn was cleared under this bucket lock first), revokes the lease,
+ * and marks the open YIELDED, which a later reconnect refuses. */
+static inline bool
+chimera_smb_durable_open_break_in_flight(const struct chimera_smb_open_file *open_file)
+{
+    return open_file->grant &&
+           open_file->grant->lease.break_state != CHIMERA_VFS_BREAK_IDLE;
+} /* chimera_smb_durable_open_break_in_flight */
+
 /* Park every durable/persistent open held by `session` for reconnect, leaving
  * the rest of the session in place.  Used when a PreviousSessionId reconnect
  * closes this session out from under its still-live connection (MS-SMB2
@@ -1490,7 +1518,11 @@ chimera_smb_session_park_durables(
             {
                 if (!open_file->durable_flags ||
                     (open_file->flags & CHIMERA_SMB_OPEN_FILE_PARKED) ||
-                    !chimera_smb_durable_open_preservable(open_file)) {
+                    !chimera_smb_durable_open_preservable(open_file) ||
+                    /* Mid-break opens are not preserved (MS-SMB2 3.3.7.1);
+                     * leave them in the tree for the old connection's own
+                     * teardown to close on its thread. */
+                    chimera_smb_durable_open_break_in_flight(open_file)) {
                     continue;
                 }
                 HASH_DELETE(hh, tree->open_files[b], open_file);
@@ -1805,6 +1837,7 @@ chimera_smb_tree_free(
     struct chimera_smb_open_file    *open_file, *tmp;
     struct chimera_smb_notify_state *gc_states = NULL;
     struct chimera_smb_notify_state *nstate;
+    bool                             closed_breaking = false;
     int                              i;
 
     for (i = 0; i < CHIMERA_SMB_OPEN_FILE_BUCKETS; i++) {
@@ -1833,12 +1866,27 @@ chimera_smb_tree_free(
              * returns OBJECT_NAME_NOT_FOUND. */
             if (open_file->durable_flags && preserve_durable &&
                 chimera_smb_durable_open_preservable(open_file)) {
-                open_file->flags      |= CHIMERA_SMB_OPEN_FILE_PARKED;
+                /* Clear create_conn BEFORE deciding park-vs-close: a break
+                 * that begins after this point finds no live member, revokes
+                 * the lease and marks the open YIELDED (so a reconnect is
+                 * refused); one that began before is seen by the
+                 * break_in_flight check below and the open is closed instead
+                 * of parked (MS-SMB2 3.3.7.1) -- between them, an unackable
+                 * break can no longer wedge a conflicting CREATE behind the
+                 * full break deadline. */
                 open_file->create_conn = NULL;
-                /* park acquires the registry lock under this bucket lock —
-                 * the bucket -> registry order is observed everywhere. */
-                chimera_smb_durable_park(shared, open_file);
-                continue;
+                if (!chimera_smb_durable_open_break_in_flight(open_file)) {
+                    open_file->flags |= CHIMERA_SMB_OPEN_FILE_PARKED;
+                    /* park acquires the registry lock under this bucket lock —
+                     * the bucket -> registry order is observed everywhere. */
+                    chimera_smb_durable_park(shared, open_file);
+                    continue;
+                }
+                /* Mid-break at disconnect: fall through to the normal close,
+                 * which releases the grant (resolving the break) and forgets
+                 * the registry entry.  Wake the parked-CREATE sweeps once the
+                 * bucket walk finishes. */
+                closed_breaking = true;
             }
 
             /* Detach any CHANGE_NOTIFY watch/parked request from this open and
@@ -1897,6 +1945,15 @@ chimera_smb_tree_free(
         nstate    = gc_states;
         gc_states = nstate->gc_next;
         chimera_smb_notify_close(shared->vfs->vfs_notify, nstate);
+    }
+
+    /* Closing a mid-break durable open above resolved its (unackable) break;
+     * CREATEs parked on that break wait for a doorbell, not the VFS pump, so
+     * wake this thread's sweep and every peer's (the conflicting CREATE
+     * usually lives on another connection's thread). */
+    if (closed_breaking) {
+        evpl_ring_doorbell(&thread->lease_resume_doorbell);
+        chimera_smb_create_resume_parked_broadcast(thread);
     }
 
     pthread_mutex_lock(&shared->trees_lock);

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -242,6 +242,76 @@ chimera_smb_create_share_park_cb(
     struct chimera_vfs_lease     *conflict,
     void                         *private_data);
 
+static void
+chimera_smb_create_resume_rearbitrate(
+    struct chimera_smb_request *request);
+
+/* Durable / persistent handle grant decision (MS-SMB2 3.3.5.9.10/.11/.12): a
+ * durable handle is granted only when the open holds a batch oplock or a
+ * HANDLE-caching lease; a persistent handle on a continuous-availability share
+ * is exempt.  Reads oplock_level / lease_state off the open_file, so it can be
+ * re-run by the parked-CREATE resume path after a deferred caching upgrade
+ * makes the open durable-eligible. */
+static void
+chimera_smb_create_grant_durable(
+    struct chimera_smb_request   *request,
+    struct chimera_smb_open_file *open_file)
+{
+    struct chimera_server_smb_thread *thread = request->compound->thread;
+    struct chimera_smb_tree          *tree   = request->tree;
+    uint32_t                          ctx    = request->create.ctx_present_mask;
+    bool                              has_caching;
+
+    if (!thread->shared->config.persistent_handles) {
+        return;
+    }
+
+    has_caching = (open_file->oplock_level == SMB2_OPLOCK_LEVEL_BATCH) ||
+        (open_file->lease_state & SMB2_LEASE_HANDLE_CACHING);
+
+    if (ctx & CHIMERA_SMB_CREATE_CTX_DH2Q) {
+        bool persistent = (request->create.dh2q.flags & SMB2_DHANDLE_FLAG_PERSISTENT) &&
+            tree->share->continuous_availability;
+
+        if (has_caching || persistent) {
+            open_file->durable_flags = CHIMERA_SMB_DURABLE_V2;
+            memcpy(open_file->create_guid, request->create.dh2q.create_guid, 16);
+            if (persistent) {
+                open_file->durable_flags |= CHIMERA_SMB_DURABLE_PERSISTENT;
+            }
+            if (request->create.dh2q.timeout_ms == 0) {
+                open_file->durable_timeout_ms = CHIMERA_SMB_DURABLE_TIMEOUT_DEFAULT_MS;
+            } else if (request->create.dh2q.timeout_ms > CHIMERA_SMB_DURABLE_TIMEOUT_MAX_MS) {
+                open_file->durable_timeout_ms = CHIMERA_SMB_DURABLE_TIMEOUT_MAX_MS;
+            } else {
+                open_file->durable_timeout_ms = request->create.dh2q.timeout_ms;
+            }
+        }
+    } else if ((ctx & CHIMERA_SMB_CREATE_CTX_DHNQ) && has_caching) {
+        /* Durable v1: no timeout or create-guid on the wire. */
+        open_file->durable_flags      = CHIMERA_SMB_DURABLE_V1;
+        open_file->durable_timeout_ms = CHIMERA_SMB_DURABLE_TIMEOUT_DEFAULT_MS;
+    }
+} /* chimera_smb_create_grant_durable */
+
+/* Register a freshly durable-granted open in the shared registry so it
+ * survives a disconnect and can be reclaimed on reconnect.  Must be called
+ * without the tree bucket lock held (bucket -> registry order, smb_durable.c). */
+static void
+chimera_smb_create_register_durable(
+    struct chimera_smb_request   *request,
+    struct chimera_smb_open_file *open_file)
+{
+    if (request->create.persist_pid != 0) {
+        open_file->flags |= CHIMERA_SMB_OPEN_FILE_PERSISTED;
+    }
+    chimera_smb_durable_register(request->compound->thread->shared, open_file,
+                                 request->session_handle->session->session_id,
+                                 request->compound->conn->client_guid,
+                                 open_file->name, open_file->name_len,
+                                 request->create.persist_pid != 0);
+} /* chimera_smb_create_register_durable */
+
 /*
  * Before a conflicting open breaks a caching holder, evict any *parked*
  * (disconnected durable) holder that still holds a write cache on this file: a
@@ -1076,40 +1146,8 @@ chimera_smb_create_after_share(
      * includes HANDLE caching — otherwise a survived handle could not be safely
      * reclaimed.  oplock_level / lease_state were set by the caching-lease block
      * above. */
-    if (type == CHIMERA_SMB_OPEN_FILE_TYPE_FILE && tree->share &&
-        thread->shared->config.persistent_handles) {
-        uint32_t ctx = request->create.ctx_present_mask;
-        /* A durable handle requires a batch oplock or a HANDLE-caching lease
-         * (MS-SMB2 3.3.5.9.10/9.11).  A *persistent* handle (DH2Q + PERSISTENT
-         * on a continuous-availability share, 3.3.5.9.12) is exempt — the CA
-         * share provides the durability guarantee, so it is granted with no
-         * oplock/lease. */
-        bool     has_caching = (open_file->oplock_level == SMB2_OPLOCK_LEVEL_BATCH) ||
-            (open_file->lease_state & SMB2_LEASE_HANDLE_CACHING);
-
-        if (ctx & CHIMERA_SMB_CREATE_CTX_DH2Q) {
-            bool persistent = (request->create.dh2q.flags & SMB2_DHANDLE_FLAG_PERSISTENT) &&
-                tree->share->continuous_availability;
-
-            if (has_caching || persistent) {
-                open_file->durable_flags = CHIMERA_SMB_DURABLE_V2;
-                memcpy(open_file->create_guid, request->create.dh2q.create_guid, 16);
-                if (persistent) {
-                    open_file->durable_flags |= CHIMERA_SMB_DURABLE_PERSISTENT;
-                }
-                if (request->create.dh2q.timeout_ms == 0) {
-                    open_file->durable_timeout_ms = CHIMERA_SMB_DURABLE_TIMEOUT_DEFAULT_MS;
-                } else if (request->create.dh2q.timeout_ms > CHIMERA_SMB_DURABLE_TIMEOUT_MAX_MS) {
-                    open_file->durable_timeout_ms = CHIMERA_SMB_DURABLE_TIMEOUT_MAX_MS;
-                } else {
-                    open_file->durable_timeout_ms = request->create.dh2q.timeout_ms;
-                }
-            }
-        } else if ((ctx & CHIMERA_SMB_CREATE_CTX_DHNQ) && has_caching) {
-            /* Durable v1: no timeout or create-guid on the wire. */
-            open_file->durable_flags      = CHIMERA_SMB_DURABLE_V1;
-            open_file->durable_timeout_ms = CHIMERA_SMB_DURABLE_TIMEOUT_DEFAULT_MS;
-        }
+    if (type == CHIMERA_SMB_OPEN_FILE_TYPE_FILE && tree->share) {
+        chimera_smb_create_grant_durable(request, open_file);
     }
 
     open_file_bucket = open_file->file_id.vid & CHIMERA_SMB_OPEN_FILE_BUCKET_MASK;
@@ -1124,14 +1162,7 @@ chimera_smb_create_after_share(
      * disconnect and can be reclaimed on reconnect.  Done outside the bucket
      * lock to keep the bucket -> registry lock order (see smb_durable.c). */
     if (open_file->durable_flags) {
-        if (request->create.persist_pid != 0) {
-            open_file->flags |= CHIMERA_SMB_OPEN_FILE_PERSISTED;
-        }
-        chimera_smb_durable_register(thread->shared, open_file,
-                                     request->session_handle->session->session_id,
-                                     request->compound->conn->client_guid,
-                                     open_file->name, open_file->name_len,
-                                     request->create.persist_pid != 0);
+        chimera_smb_create_register_durable(request, open_file);
     }
 
     compound->saved_file_id = open_file->file_id;
@@ -1748,6 +1779,10 @@ chimera_smb_create_park_deadline_cb(
                                     request->create.park_fh_hash,
                                     open_file ? open_file->grant : NULL);
 
+    /* The holder never acked and has now been revoked; lift the capped
+     * lease/durable decision if nothing else conflicts. */
+    chimera_smb_create_resume_rearbitrate(request);
+
     chimera_smb_open_file_release(request, open_file);
     /* complete_request retires the async-interim (unlink from parked_requests +
      * clear armed); the fired one-shot is already out of the timer heap so its
@@ -1845,6 +1880,91 @@ chimera_smb_create_open_finish(
     chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
 } /* chimera_smb_create_open_finish */
 
+/* Re-arbitrate a parked CREATE's caching grant as its break wait resolves.
+ *
+ * The open's oplock/lease -- and the durable grant that hinges on holding
+ * batch / HANDLE caching -- were decided while the conflicting holder was
+ * still mid-break, capping them below what the client requested.  If that
+ * holder has since gone away entirely (a disconnected durable handle closed
+ * by its connection teardown, purged on conflict, or force-revoked), the
+ * deferred reply can carry the full grant -- which is what Windows returns,
+ * and what smb2.durable-open.{lease,oplock} assert when the second client's
+ * open races the first client's TCP disconnect.  A holder that instead acked
+ * its break and kept the handle still conflicts, so the upgrade probe refuses
+ * and the capped decision stands (the live-holder outcome is unchanged).
+ *
+ * Runs on the request's owning thread, immediately before the deferred
+ * completion marshals the reply from the open_file. */
+static void
+chimera_smb_create_resume_rearbitrate(struct chimera_smb_request *request)
+{
+    struct chimera_server_smb_thread *thread    = request->compound->thread;
+    struct chimera_smb_open_file     *open_file = request->create.r_open_file;
+    uint8_t                           req_smb   = 0;
+    uint8_t                           want_vfs;
+    bool                              via_rqls;
+
+    if (!open_file || !open_file->grant || !open_file->caching_file_state) {
+        return;
+    }
+
+    /* Recompute the requested caching bits exactly as the original acquire
+     * did (chimera_smb_create_after_share). */
+    via_rqls = (request->create.ctx_present_mask & CHIMERA_SMB_CREATE_CTX_RQLS) != 0;
+    if (via_rqls) {
+        req_smb = thread->shared->config.leases
+            ? (uint8_t) (request->create.rqls.state & 0x07) : 0;
+    } else if (thread->shared->config.oplocks) {
+        switch (request->create.requested_oplock_level) {
+            case SMB2_OPLOCK_LEVEL_II:
+                req_smb = SMB2_LEASE_READ_CACHING;
+                break;
+            case SMB2_OPLOCK_LEVEL_EXCLUSIVE:
+                req_smb = SMB2_LEASE_READ_CACHING |
+                    SMB2_LEASE_WRITE_CACHING;
+                break;
+            case SMB2_OPLOCK_LEVEL_BATCH:
+                req_smb = SMB2_LEASE_READ_CACHING |
+                    SMB2_LEASE_WRITE_CACHING |
+                    SMB2_LEASE_HANDLE_CACHING;
+                break;
+            default:
+                break;
+        } /* switch */
+    }
+
+    want_vfs = chimera_smb_lease_bits_to_vfs(req_smb);
+    if (want_vfs == 0) {
+        return;
+    }
+
+    if (chimera_vfs_caching_grant_try_upgrade(open_file->caching_file_state,
+                                              open_file->grant,
+                                              want_vfs) != want_vfs) {
+        /* Still capped by a surviving holder (or the grant is shared / mid-
+         * break): the original decision stands. */
+        return;
+    }
+
+    if (via_rqls) {
+        open_file->lease_state = chimera_smb_vfs_to_lease_bits(want_vfs);
+    } else {
+        open_file->oplock_level = chimera_smb_vfs_to_oplock_level(want_vfs);
+    }
+
+    /* The upgrade may have made the open durable-eligible (batch / HANDLE
+     * caching); grant and register it now so the deferred reply carries the
+     * durable context and a disconnect can park it. */
+    if (!open_file->durable_flags && open_file->handle &&
+        open_file->type == CHIMERA_SMB_OPEN_FILE_TYPE_FILE &&
+        request->tree && request->tree->share) {
+        chimera_smb_create_grant_durable(request, open_file);
+        if (open_file->durable_flags) {
+            chimera_smb_create_register_durable(request, open_file);
+        }
+    }
+} /* chimera_smb_create_resume_rearbitrate */
+
 /* Resume the settled parked CREATEs on one connection.  Pull every parked
  * CREATE whose triggered lease break has now settled (no caching lease on the
  * file is mid-break) off `conn`'s parked list, then complete them on this
@@ -1888,6 +2008,10 @@ chimera_smb_create_resume_parked_conn(
         req                  = resume;
         resume               = req->async.park_next;
         req->async.park_next = NULL;
+        /* The break this CREATE waited on has settled; if the conflicting
+         * holder vanished outright, lift the capped lease/durable decision
+         * before the deferred reply is marshaled. */
+        chimera_smb_create_resume_rearbitrate(req);
         chimera_smb_open_file_release(req, req->create.r_open_file);
         /* async_id is still set, so the final reply carries
          * SMB2_FLAGS_ASYNC_COMMAND matching the interim. */

--- a/src/server/smb/smb_proc_oplock_break.c
+++ b/src/server/smb/smb_proc_oplock_break.c
@@ -191,6 +191,25 @@ chimera_smb_lease_break_cb(
             break;
         }
     }
+    if (!open_file && (lease->mode.granted & CHIMERA_VFS_LEASE_MODE_W)) {
+        /* Breaking a WRITE-caching holder none of whose opens can be notified:
+         * the disconnected durable handle yields to the conflicting acquirer
+         * (MS-SMB2 3.3.4.6/3.3.4.7 close a disconnected open whose batch
+         * oplock / write-caching lease breaks).  The purge-on-conflict path
+         * (chimera_smb_create_purge_parked_writers) evicts such a holder when
+         * it is already parked; when this break races the disconnect teardown
+         * instead, mark the members yielded so a durable reconnect is refused
+         * (the grace-timer sweep reaps the carcass).  A holder with no write
+         * cache (a parked RH lease) is courtesy-held: its lease is still
+         * revoked below, but the handle stays reclaimable
+         * (keep-disconnected-rh-*). */
+        struct chimera_smb_open_file *member;
+
+        for (member = grant->holders; member;
+             member = member->grant_member_next) {
+            member->flags |= CHIMERA_SMB_OPEN_FILE_YIELDED;
+        }
+    }
     pthread_mutex_unlock(&file->lock);
 
     /* No live member can notify the client; the pragmatic recovery is to forcibly

--- a/src/server/smb/smb_session.h
+++ b/src/server/smb/smb_session.h
@@ -44,6 +44,15 @@ struct chimera_smb_file_id {
  * stream handle; stream_name + base_fh identify the stream for enumeration and
  * delete-on-close (which removes only the stream, not the base file). */
 #define CHIMERA_SMB_OPEN_FILE_FLAG_STREAM          0x00000040
+/* While this open sat disconnected (parked durable), its write-caching
+ * oplock/lease was forcibly revoked to admit a conflicting open: the
+ * disconnected handle has yielded (MS-SMB2 3.3.4.6/3.3.4.7 close a
+ * disconnected open whose batch oplock / write-caching lease breaks).  Had the
+ * conflicting open found it already parked it would have been purged outright
+ * (chimera_smb_create_purge_parked_writers); when the revoke wins that race
+ * instead, this flag makes a later durable reconnect fail with
+ * OBJECT_NAME_NOT_FOUND and leaves the carcass to the grace-timer sweep. */
+#define CHIMERA_SMB_OPEN_FILE_YIELDED              0x00000080
 
 /* Bits identifying which CREATE contexts a client supplied on the open. Mirrored
  * from request->create.ctx_present_mask into the open file so later phases

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -3225,6 +3225,26 @@ endmacro()
 find_program(SMBTORTURE_EXECUTABLE smbtorture)
 
 if(CHIMERA_NETNS_TESTING AND SMBTORTURE_EXECUTABLE)
+    # Deterministic regression coverage for the disconnect-vs-conflicting-open
+    # race on durable handles: CHIMERA_SMB_TEST_DISCONNECT_DELAY_MS holds the
+    # server-side disconnect teardown so the second client's CREATE always
+    # lands while the first client's durable handle is still live -- the
+    # interleaving a loaded CI runner only hits occasionally.  Exercises the
+    # close-not-park (MS-SMB2 3.3.7.1), yielded-reclaim, and parked-CREATE
+    # re-arbitration paths.
+    foreach(_sub smb2.durable-open.lease smb2.durable-open.oplock)
+        string(REGEX REPLACE "[^A-Za-z0-9]" "_" _sid "${_sub}")
+        set(_name chimera/server/smb/smbtorture_${_sid}_disconnect_race_memfs)
+        add_test(NAME ${_name}
+            COMMAND ${CMAKE_SOURCE_DIR}/scripts/netns_test_wrapper.sh
+                    ${SMBTORTURE_CMD} -b memfs ${_sub})
+        set_tests_properties(${_name} PROPERTIES
+            ENVIRONMENT "${SMBTORTURE_LSAN};CHIMERA_SMB_TEST_DISCONNECT_DELAY_MS=50"
+            SKIP_RETURN_CODE 77
+            TIMEOUT 300
+            RESOURCE_LOCK smb_durable_oplock_family)
+    endforeach()
+
     add_smbtorture_backend_tests(memfs)
     add_smbtorture_backend_tests(linux)
     add_smbtorture_backend_tests(diskfs_io_uring)

--- a/src/vfs/vfs_state.c
+++ b/src/vfs/vfs_state.c
@@ -1357,6 +1357,56 @@ chimera_vfs_caching_grant_coalesce(
     return grant;
 } /* chimera_vfs_caching_grant_coalesce */
 
+SYMBOL_EXPORT uint8_t
+chimera_vfs_caching_grant_try_upgrade(
+    struct chimera_vfs_file_state    *file,
+    struct chimera_vfs_caching_grant *grant,
+    uint8_t                           want_granted)
+{
+    uint8_t granted;
+
+    pthread_mutex_lock(&file->lock);
+
+    granted = grant->lease.mode.granted;
+
+    /* Same admission rules as the coalesce-path upgrade -- IDLE lease, strict
+     * superset, grantable without breaking another owner -- plus two stricter
+     * gates befitting a rescue path:
+     *
+     *   - refcount 1: the capped mode was never reported to the client (the
+     *     open is still deferred), so a sole-member upgrade owes no epoch bump
+     *     or notification.  A shared grant's state HAS been reported to
+     *     coalesced peers, so it is left as is.
+     *
+     *   - sole caching lease on the file: the cap is lifted only when the
+     *     holder that imposed it is GONE (closed by its disconnect teardown,
+     *     purged, or revoked-and-released), not merely downgraded.  The
+     *     conflict matrix scores a surviving mid-cascade holder at its
+     *     retained mode, which would let a deferred RWH request leapfrog a
+     *     live holder that acked down to RH and legitimately keeps it
+     *     (smb2.lease.v2_complex2 expects the deferred open to settle at RH). */
+    if (grant->refcount == 1 &&
+        grant->lease.break_state == CHIMERA_VFS_BREAK_IDLE &&
+        want_granted != granted &&
+        (want_granted & granted) == granted &&
+        file->caching_leases == &grant->lease &&
+        grant->lease.next == NULL) {
+        struct chimera_vfs_lease  probe    = grant->lease;
+        struct chimera_vfs_lease *conflict = NULL;
+
+        probe.mode.granted = want_granted;
+        if (chimera_vfs_state_would_conflict(file, &probe, &conflict) ==
+            CHIMERA_VFS_LEASE_GRANTED) {
+            grant->lease.mode.granted = want_granted;
+            granted                   = want_granted;
+        }
+    }
+
+    pthread_mutex_unlock(&file->lock);
+
+    return granted;
+} /* chimera_vfs_caching_grant_try_upgrade */
+
 SYMBOL_EXPORT void
 chimera_vfs_caching_grant_link(
     struct chimera_vfs_file_state    *file,
@@ -1540,13 +1590,16 @@ chimera_vfs_state_caching_breaking(
 
     pthread_mutex_lock(&file->lock);
     for (cur = file->caching_leases; cur; cur = cur->next) {
-        /* Only an RqLs LEASE break holds the conflicting open pending (MS-SMB2
-         * 3.3.5.9).  A legacy oplock keeps chimera's optimistic post-break
-         * behavior (the open proceeds without waiting), so exclude is_oplock
-         * grants here. */
+        /* An ack-required break -- an RqLs LEASE break (MS-SMB2 3.3.5.9) or a
+         * legacy batch/exclusive oplock break (3.3.4.6) -- holds the
+         * conflicting open pending until the holder acks, closes, or the
+         * break deadline revokes it.  Holding the oplock case too is what
+         * lets a CREATE that races the holder's disconnect re-arbitrate its
+         * capped grant when the teardown resolves the break, instead of
+         * baking LEVEL_II/no-durable into a reply that left too early
+         * (smb2.durable-open.oplock vs a mid-teardown holder). */
         if (cur->break_state == CHIMERA_VFS_BREAK_BREAKING &&
             cur->grant && cur->grant->break_ack_required &&
-            !cur->grant->is_oplock &&
             cur->grant != except) {
             breaking = true;
             break;

--- a/src/vfs/vfs_state.h
+++ b/src/vfs/vfs_state.h
@@ -211,6 +211,22 @@ chimera_vfs_caching_grant_coalesce(
     struct chimera_vfs_lease_mode         want,
     int                                   upgrade_ok);
 
+/* Attempt a conflict-free in-place upgrade of `grant` to `want_granted`, for a
+ * DEFERRED open whose grant was capped by a holder that has since gone away (a
+ * CREATE parked on the ack-required break it triggered re-arbitrates here when
+ * the break resolves).  The upgrade is applied only when the grant is this
+ * deferred open's alone (refcount 1 — its capped state was never reported to
+ * the client, so no epoch bump or peer notification is owed), its lease is
+ * IDLE, `want_granted` is a strict superset of the current mode, and the larger
+ * mode is grantable without breaking any other owner's holder.  Returns the
+ * grant's resulting granted mode (upgraded or unchanged).  Caller must NOT
+ * hold file->lock. */
+uint8_t
+chimera_vfs_caching_grant_try_upgrade(
+    struct chimera_vfs_file_state    *file,
+    struct chimera_vfs_caching_grant *grant,
+    uint8_t                           want_granted);
+
 /* Link a freshly-created caching grant (whose embedded lease the caller has
  * already inserted via chimera_vfs_state_try_insert) into the per-file owner
  * index so later same-owner acquires coalesce onto it.  Caller must NOT hold


### PR DESCRIPTION
## Root cause

`smbtorture_smb2_durable_open_{lease,oplock}_memfs` flaked on the arm64 Release smbtorture shard (PR #753's run) with two opposite-looking signatures:

- `durable_open.c:2256: io2.out.durable_open was 0, expected 1` (lease)
- `durable_open.c:2173: status was NT_STATUS_OK, expected NT_STATUS_OBJECT_NAME_NOT_FOUND` (oplock reclaim)

Both come from one race in the courtesy-hold work (4d4ee9a2, which also enabled these suites for memfs — hence the flake appearing now). The keep/purge logic keys off the disconnected holder being **parked**, but parking happens during server-side disconnect teardown. When the second client's CREATE lands between the first client's TCP close and that teardown (a window a loaded runner stretches to milliseconds), the conflict path fires a break the disconnected holder can never ack. Depending on which side wins each sub-race, the new open bakes a capped (LEVEL_II / no-durable) grant into its reply, and/or the parked handle survives with a force-revoked lease and wrongly reclaims.

Reproduced deterministically with a new inert-unless-set test hook (`CHIMERA_SMB_TEST_DISCONNECT_DELAY_MS`) that holds disconnect processing: both tests fail every time at 5/50/200ms on unpatched main, and pass at every delay with this fix.

## Fix (three legs)

1. **Close, don't park, mid-break opens at disconnect** (MS-SMB2 3.3.7.1: only a *Held* oplock/lease survives connection loss). The close releases the grant, resolving the unackable break, and rings the parked-CREATE resume sweeps so the waiting open completes in teardown latency instead of the 30s break deadline. `create_conn` is cleared before the park-vs-close decision so a break racing the teardown is caught by one side or the other.
2. **Refuse reclaim of yielded handles**: a disconnected write-cache holder whose lease gets force-revoked by the no-live-member break path is marked `YIELDED` — it would have been purged had the conflict found it parked (3.3.4.6/3.3.4.7), so reclaim returns `OBJECT_NAME_NOT_FOUND` and the grace-timer sweep reaps it. Parked RH holders remain courtesy-held (`keep-disconnected-rh-*` unaffected).
3. **Re-arbitrate on resume**: a CREATE parked on the break it triggered re-probes its capped lease/oplock (and the durable grant that hinges on batch/HANDLE caching) when the wait resolves. The upgrade only applies when the grant is the file's sole caching lease with no conflicts — i.e. the holder is *gone*, not merely downgraded — so a live holder that acks down to RH still caps the open exactly as before (`smb2.lease.v2_complex2` guards this). Legacy batch/exclusive breaks now hold the conflicting CREATE pending the ack like lease breaks (3.3.4.6), which is what gives the resume path its chance.

## Pre-existing bug found and fixed along the way

A CREATE parked on a break holds an open_file reference dropped only by its resume path. If its connection died first, the conn-teardown drain unlinked it without dropping the reference — leaking the open's VFS handle and wedging the VFS close-thread drain at shutdown. **Upstream main's full `smb2.lease` run hangs at shutdown today because of this**; with the drain fix it exits cleanly.

## Validation

- New ctest entries `smbtorture_smb2_durable_open_{lease,oplock}_disconnect_race_memfs` pin the race at 50ms delay (fail-every-time before, pass after); plain runs verified at 0/5/50/200ms.
- Full-suite comparison vs upstream/main on memfs: `smb2.durable-open` improves by exactly `durable-open.oplock` (it fails even unloaded on main); `smb2.durable-v2-open` failure set identical; `smb2.lease` delta consists only of `initial_delete_disconnect`, `lease-epoch`, `rename_dir_openfile`, which fail 3/3 standalone on the upstream/main build too (suite-order masks them there).
- Pre-existing and out of scope: the full `smb2.oplock` suite aborts around batch25 (`compound_advance: complete_requests=1 num_requests=0`) identically on upstream/main; the three standalone-failing lease tests above.
- `vfs/state_test` passes; full ctest `smb` group (196 tests incl. WPTS) green under Debug/ASan; `make syntax` clean.