### PR TITLE
vfs: metadata ops must wait for a recalled NFSv4 delegation, not just W flush

### DIFF
--- a/src/vfs/vfs_state.c
+++ b/src/vfs/vfs_state.c
@@ -2030,10 +2030,24 @@ chimera_vfs_break_caching_file(
          * namespace recall blocks while any effective mode remains. */
         uint8_t                   block_mask = flush_only ? CHIMERA_VFS_LEASE_MODE_W : 0xFF;
         for (cur = file->caching_leases; cur; cur = cur->next) {
+            uint8_t mask = block_mask;
+
             if (skip_handle && cur->owner.op_handle == skip_handle) {
                 continue;
             }
-            if (chimera_vfs_lease_effective_granted(cur) & block_mask) {
+            /* The W-only flush mask is an SMB read-cache optimization, exactly
+             * like the recall-selection filter above.  An NFSv4 delegation
+             * guarantees attribute stability (RFC 7530 §10.4): a metadata-only
+             * mutation that recalled it must also WAIT for it to be returned
+             * (or revoked at the recall deadline), not just for write caches
+             * to flush.  Without this, a server-side chmod against a foreign
+             * read delegation completes before the client has even seen the
+             * CB_RECALL, and pynfs DELEG20 -- which checks for the recall the
+             * instant the chmod returns -- flakes under load. */
+            if (cur->owner.protocol == CHIMERA_VFS_LEASE_PROTO_NFSV4) {
+                mask = 0xFF;
+            }
+            if (chimera_vfs_lease_effective_granted(cur) & mask) {
                 had = true;
                 break;
             }


### PR DESCRIPTION
Root-causes the `DELEG20_diskfs_aio_nfs4.0` flake from the flake-gate report on run 27367178600 (#733).

## Root cause

`chimera_vfs_break_caching_file`'s two halves disagree about NFSv4 delegations on the flush-only (attribute-only setattr) path. The recall-selection loop correctly exempts NFSv4 from the W-holder filter (its comment even cites DELEG20: a delegation guarantees attribute stability per RFC 7530 §10.4, so a metadata-only mutation must recall even a foreign read delegation). But the blocking decision below masks with `W` only — a read delegation's effective mode is `R`, so the mutation proceeded the instant the CB_RECALL was *initiated*, never waiting for the return.

DELEG20 (`testServerChmod`) does a server-side chmod through the REST debug-fsop endpoint and checks its CB_RECALL counter the moment the chmod returns — pynfs has no wait of its own (its callback server increments the counter before it even sends DELEGRETURN, so the test's contract is simply that the server-side op completes after the recall round-trip). The in-process recall normally beats the curl/HTTP response path easily, which is why this almost always passes; arm64 Debug/ASan at `ctest -j 32` occasionally inverts the race. It also explains why only DELEG20 of the DELEG16–20 serverhelper family flakes: unlink/rename/link are namespace recalls (`flush_only=0`, full-mode mask, already blocking); chmod is the only attr-only setattr.

## Fix

Give the blocking loop the same NFSv4 exemption the selection loop already has: a delegation blocks the mutation on its full effective mode regardless of recall flavor, so the op parks until DELEGRETURN (the existing 5s metaop recall deadline revokes an unresponsive holder, and the pump on lease release/revoke resumes the parked op). SMB holders keep the W-only flush semantics unchanged — the exemption is protocol-gated, so the metadata-storm optimization this mask exists for is untouched.

## Validation

- `vfs/state_test` passes.
- All 156 `pynfs/delegations` tests pass across the full backend matrix; the flaking configuration (diskfs_aio nfs4.0) passes 25/25, and DELEG20 there looped 20× clean.
- The 48-test smbtorture durable set was run as cross-protocol sanity: the one failure observed was `smb2.durable-open.oplock` reproducing its known disconnect race on unpatched main under `-j 8` (the other two flakes in the same gate report; fixed by #755), unrelated to this change.