### PR TITLE
smb/tests: enable 336 newly-passing smbtorture cells

### DIFF
--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -1234,8 +1234,15 @@ set(SMBTORTURE_ENABLED_memfs
     # smb2.async_dosmode
     smb2.async_dosmode
     # smb2.bench
+    smb2.bench.echo
+    smb2.bench.path-contention-shared
+    smb2.bench.read
+    smb2.bench.session-setup
     # smb2.change_notify_disabled
     smb2.change_notify_disabled.notfiy_disabled
+    # smb2.charset
+    "smb2.charset.Testing composite character (a umlaut)"
+    "smb2.charset.Testing naked diacritical (umlaut)"
     # smb2.check-sharemode
     smb2.check-sharemode
     # smb2.compound
@@ -1251,6 +1258,10 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.compound.related6
     smb2.compound.related9
     smb2.compound.unrelated1
+    # smb2.compound_async
+    smb2.compound_async.create_lease_break_async
+    smb2.compound_async.rename_last
+    smb2.compound_async.rename_middle
     # smb2.compound_find
     smb2.compound_find.compound_find_close
     smb2.compound_find.compound_find_related
@@ -1277,6 +1288,7 @@ set(SMBTORTURE_ENABLED_memfs
     # smb2.delete-on-close-perms
     smb2.delete-on-close-perms.BUG14427
     smb2.delete-on-close-perms.CREATE
+    "smb2.delete-on-close-perms.CREATE Existing"
     smb2.delete-on-close-perms.CREATE_IF
     smb2.delete-on-close-perms.FIND_and_set_DOC
     smb2.delete-on-close-perms.OVERWRITE_IF
@@ -1293,18 +1305,63 @@ set(SMBTORTURE_ENABLED_memfs
     # smb2.durable-open-disconnect
     smb2.durable-open-disconnect.open-oplock-disconnect
     # smb2.durable-open
+    smb2.durable-open.delete_on_close2
+    smb2.durable-open.file-position
     smb2.durable-open.lease
-    smb2.durable-open.oplock
+    smb2.durable-open.lock-lease
+    smb2.durable-open.lock-noW-lease
+    smb2.durable-open.lock-oplock
+    smb2.durable-open.open-lease
+    smb2.durable-open.open-oplock
     smb2.durable-open.open2-oplock
+    smb2.durable-open.oplock
+    smb2.durable-open.read-only
+    smb2.durable-open.reopen1
+    smb2.durable-open.reopen1a
+    smb2.durable-open.reopen1a-lease
+    smb2.durable-open.reopen2
+    smb2.durable-open.reopen2-lease
+    smb2.durable-open.reopen2-lease-v2
+    smb2.durable-open.reopen2a
+    smb2.durable-open.reopen3
+    smb2.durable-open.reopen4
+    smb2.durable-open.reopen5
+    smb2.durable-open.reopen6
+    smb2.durable-open.stat-open
     # smb2.durable-v2-delay
     smb2.durable-v2-delay.durable_v2_reconnect_delay
     smb2.durable-v2-delay.durable_v2_reconnect_delay_msec
     # smb2.durable-v2-open
     smb2.durable-v2-open.app-instance
+    smb2.durable-v2-open.create-blob
+    smb2.durable-v2-open.durable-v2-setinfo
     smb2.durable-v2-open.keep-disconnected-rh-with-rh-open
     smb2.durable-v2-open.keep-disconnected-rh-with-rwh-open
+    smb2.durable-v2-open.keep-disconnected-rh-with-stat-open
+    smb2.durable-v2-open.keep-disconnected-rwh-with-stat-open
+    smb2.durable-v2-open.lock-lease
+    smb2.durable-v2-open.lock-noW-lease
+    smb2.durable-v2-open.lock-oplock
+    smb2.durable-v2-open.open-lease
+    smb2.durable-v2-open.open-oplock
+    smb2.durable-v2-open.persistent-open-lease
+    smb2.durable-v2-open.persistent-open-oplock
+    smb2.durable-v2-open.purge-disconnected-rh-with-share-none-open
     smb2.durable-v2-open.purge-disconnected-rwh-with-rh-open
     smb2.durable-v2-open.purge-disconnected-rwh-with-rwh-open
+    smb2.durable-v2-open.reconnect-twice
+    smb2.durable-v2-open.reopen1
+    smb2.durable-v2-open.reopen1a
+    smb2.durable-v2-open.reopen1a-lease
+    smb2.durable-v2-open.reopen2
+    smb2.durable-v2-open.reopen2-lease
+    smb2.durable-v2-open.reopen2-lease-v2
+    smb2.durable-v2-open.reopen2b
+    smb2.durable-v2-open.reopen2c
+    smb2.durable-v2-open.stat-and-lease
+    smb2.durable-v2-open.statRH-and-lease
+    smb2.durable-v2-open.two-different-lease
+    smb2.durable-v2-open.two-same-lease
     # smb2.durable-v2-regressions
     smb2.durable-v2-regressions.durable_v2_reconnect_bug15624
     # smb2.fileid
@@ -1349,6 +1406,7 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.ioctl.dup_extents_src_is_dest
     smb2.ioctl.dup_extents_src_is_dest_overlap
     smb2.ioctl.dup_extents_src_lock
+    smb2.ioctl.network_interface_info
     smb2.ioctl.req_resume_key
     smb2.ioctl.req_two_resume_keys
     smb2.ioctl.shadow_copy
@@ -1371,27 +1429,46 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.ioctl.sparse_set_nobuf
     smb2.ioctl.sparse_set_oversize
     # smb2.kernel-oplocks
+    smb2.kernel-oplocks.kernel_oplocks1
+    smb2.kernel-oplocks.kernel_oplocks3
     smb2.kernel-oplocks.kernel_oplocks8
+    # smb2.lease
+    smb2.lease.duplicate_create
+    smb2.lease.duplicate_open
+    smb2.lease.multibreak
+    smb2.lease.rename_wait
+    smb2.lease.statopen
+    smb2.lease.statopen2
+    smb2.lease.statopen3
+    smb2.lease.upgrade
+    smb2.lease.upgrade2
+    smb2.lease.upgrade3
+    smb2.lease.v1_bug15148
+    smb2.lease.v2_bug15148
+    smb2.lease.v2_complex2
+    smb2.lease.v2_epoch1
+    smb2.lease.v2_flags_breaking
+    smb2.lease.v2_flags_parentkey
     # smb2.lock
     smb2.lock.auto-unlock
-    smb2.lock.errorcode
-    smb2.lock.lock
-    smb2.lock.multiple-unlock
-    smb2.lock.overlap
-    smb2.lock.range
-    smb2.lock.stacking
-    smb2.lock.valid-request
-    smb2.lock.zerobytelength
-    smb2.lock.zerobyteread
     smb2.lock.contend
     smb2.lock.context
     smb2.lock.ctdb-delrec-deadlock
+    smb2.lock.errorcode
+    smb2.lock.lock
+    smb2.lock.multiple-unlock
     smb2.lock.open-brlock-deadlock
+    smb2.lock.overlap
+    smb2.lock.range
     smb2.lock.rw-exclusive
     smb2.lock.rw-none
     smb2.lock.rw-shared
+    smb2.lock.stacking
     smb2.lock.truncate
     smb2.lock.unlock
+    smb2.lock.valid-request
+    smb2.lock.zerobytelength
+    smb2.lock.zerobyteread
     # smb2.maxfid
     smb2.maxfid
     # smb2.maximum_allowed
@@ -1399,16 +1476,7 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.maximum_allowed.read_only
     # smb2.mkdir
     smb2.mkdir
-    # smb2.multichannel (SMB3 session binding).  interface_info advertises the
-    # server NICs, num_channels exercises channel bind + the 32-channel limit,
-    # bug_15346 is a bind regression, and oplocks.test1 checks an oplock break
-    # delivered over a bound session.  oplocks.test1 is enabled only on the
-    # non-passthrough backends: the linux/io_uring share root keeps real on-disk
-    # files between subtests, so the test's create-disposition checks see EXISTED
-    # instead of CREATED.  oplocks.test2/test3* stay disabled (they need Samba
-    # test-only FSCTLs -- force-unacked-timeout / network block -- chimera does
-    # not implement); leases.test1-4 stay disabled (general lease-grant
-    # behaviour, not multichannel binding).
+    # smb2.multichannel
     smb2.multichannel.bugs.bug_15346
     smb2.multichannel.generic.interface_info
     smb2.multichannel.generic.num_channels
@@ -1438,6 +1506,29 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.openattr
     # smb2.oplock
     smb2.oplock.batch10
+    smb2.oplock.batch11
+    smb2.oplock.batch12
+    smb2.oplock.batch13
+    smb2.oplock.batch14
+    smb2.oplock.batch15
+    smb2.oplock.batch16
+    smb2.oplock.batch2
+    smb2.oplock.batch21
+    smb2.oplock.batch23
+    smb2.oplock.batch24
+    smb2.oplock.batch25
+    smb2.oplock.batch4
+    smb2.oplock.batch5
+    smb2.oplock.batch8
+    smb2.oplock.brl2
+    smb2.oplock.exclusive1
+    smb2.oplock.exclusive2
+    smb2.oplock.exclusive3
+    smb2.oplock.exclusive4
+    smb2.oplock.exclusive5
+    smb2.oplock.exclusive9
+    smb2.oplock.levelii501
+    smb2.oplock.levelii502
     # smb2.read
     smb2.read.access
     smb2.read.bug14607
@@ -1519,6 +1610,8 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.session.expire2e
     smb2.session.expire2s
     smb2.session.expire_disconnect
+    smb2.session.reauth6
+    smb2.session.reconnect2
     smb2.session.signing-aes-128-cmac
     smb2.session.signing-aes-128-gmac
     smb2.session.signing-hmac-sha-256
@@ -1569,8 +1662,15 @@ set(SMBTORTURE_ENABLED_memfs
 
 set(SMBTORTURE_ENABLED_linux
     # smb2.bench
+    smb2.bench.echo
+    smb2.bench.path-contention-shared
+    smb2.bench.read
+    smb2.bench.session-setup
     # smb2.change_notify_disabled
     smb2.change_notify_disabled.notfiy_disabled
+    # smb2.charset
+    "smb2.charset.Testing composite character (a umlaut)"
+    "smb2.charset.Testing naked diacritical (umlaut)"
     # smb2.check-sharemode
     smb2.check-sharemode
     # smb2.compound
@@ -1586,6 +1686,10 @@ set(SMBTORTURE_ENABLED_linux
     smb2.compound.related6
     smb2.compound.related9
     smb2.compound.unrelated1
+    # smb2.compound_async
+    smb2.compound_async.create_lease_break_async
+    smb2.compound_async.rename_last
+    smb2.compound_async.rename_middle
     # smb2.compound_find
     smb2.compound_find.compound_find_close
     smb2.compound_find.compound_find_related
@@ -1609,6 +1713,7 @@ set(SMBTORTURE_ENABLED_linux
     smb2.credits.skipped_mid
     # smb2.delete-on-close-perms
     smb2.delete-on-close-perms.CREATE
+    "smb2.delete-on-close-perms.CREATE Existing"
     smb2.delete-on-close-perms.CREATE_IF
     smb2.delete-on-close-perms.FIND_and_set_DOC
     smb2.delete-on-close-perms.OVERWRITE_IF
@@ -1622,10 +1727,12 @@ set(SMBTORTURE_ENABLED_linux
     smb2.dir.fixed
     smb2.dir.sorted
     # smb2.durable-open
+    smb2.durable-open.reopen6
     # smb2.durable-v2-delay
     smb2.durable-v2-delay.durable_v2_reconnect_delay
     smb2.durable-v2-delay.durable_v2_reconnect_delay_msec
     # smb2.durable-v2-open
+    smb2.durable-v2-open.reconnect-twice
     # smb2.durable-v2-regressions
     smb2.durable-v2-regressions.durable_v2_reconnect_bug15624
     # smb2.fileid
@@ -1668,6 +1775,7 @@ set(SMBTORTURE_ENABLED_linux
     smb2.ioctl.dup_extents_src_is_dest
     smb2.ioctl.dup_extents_src_is_dest_overlap
     smb2.ioctl.dup_extents_src_lock
+    smb2.ioctl.network_interface_info
     smb2.ioctl.req_resume_key
     smb2.ioctl.req_two_resume_keys
     smb2.ioctl.shadow_copy
@@ -1689,42 +1797,39 @@ set(SMBTORTURE_ENABLED_linux
     smb2.ioctl.sparse_qar_truncated
     smb2.ioctl.sparse_set_nobuf
     smb2.ioctl.sparse_set_oversize
+    # smb2.kernel-oplocks
+    smb2.kernel-oplocks.kernel_oplocks1
+    smb2.kernel-oplocks.kernel_oplocks3
+    # smb2.lease
+    smb2.lease.statopen2
+    smb2.lease.statopen3
     # smb2.lock
     smb2.lock.auto-unlock
-    smb2.lock.errorcode
-    smb2.lock.lock
-    smb2.lock.multiple-unlock
-    smb2.lock.overlap
-    smb2.lock.range
-    smb2.lock.stacking
-    smb2.lock.valid-request
-    smb2.lock.zerobytelength
-    smb2.lock.zerobyteread
     smb2.lock.contend
     smb2.lock.context
     smb2.lock.ctdb-delrec-deadlock
+    smb2.lock.errorcode
+    smb2.lock.lock
+    smb2.lock.multiple-unlock
     smb2.lock.open-brlock-deadlock
+    smb2.lock.overlap
+    smb2.lock.range
     smb2.lock.rw-exclusive
     smb2.lock.rw-none
     smb2.lock.rw-shared
+    smb2.lock.stacking
     smb2.lock.truncate
     smb2.lock.unlock
+    smb2.lock.valid-request
+    smb2.lock.zerobytelength
+    smb2.lock.zerobyteread
     # smb2.maxfid
     smb2.maxfid
     # smb2.maximum_allowed
     smb2.maximum_allowed.read_only
     # smb2.mkdir
     smb2.mkdir
-    # smb2.multichannel (SMB3 session binding).  interface_info advertises the
-    # server NICs, num_channels exercises channel bind + the 32-channel limit,
-    # bug_15346 is a bind regression, and oplocks.test1 checks an oplock break
-    # delivered over a bound session.  oplocks.test1 is enabled only on the
-    # non-passthrough backends: the linux/io_uring share root keeps real on-disk
-    # files between subtests, so the test's create-disposition checks see EXISTED
-    # instead of CREATED.  oplocks.test2/test3* stay disabled (they need Samba
-    # test-only FSCTLs -- force-unacked-timeout / network block -- chimera does
-    # not implement); leases.test1-4 stay disabled (general lease-grant
-    # behaviour, not multichannel binding).
+    # smb2.multichannel
     smb2.multichannel.bugs.bug_15346
     smb2.multichannel.generic.interface_info
     smb2.multichannel.generic.num_channels
@@ -1751,6 +1856,29 @@ set(SMBTORTURE_ENABLED_linux
     smb2.notify.tdis1
     # smb2.oplock
     smb2.oplock.batch10
+    smb2.oplock.batch11
+    smb2.oplock.batch12
+    smb2.oplock.batch13
+    smb2.oplock.batch14
+    smb2.oplock.batch15
+    smb2.oplock.batch16
+    smb2.oplock.batch2
+    smb2.oplock.batch21
+    smb2.oplock.batch23
+    smb2.oplock.batch24
+    smb2.oplock.batch25
+    smb2.oplock.batch4
+    smb2.oplock.batch5
+    smb2.oplock.batch8
+    smb2.oplock.brl2
+    smb2.oplock.exclusive1
+    smb2.oplock.exclusive2
+    smb2.oplock.exclusive3
+    smb2.oplock.exclusive4
+    smb2.oplock.exclusive5
+    smb2.oplock.exclusive9
+    smb2.oplock.levelii501
+    smb2.oplock.levelii502
     # smb2.read
     smb2.read.access
     smb2.read.bug14607
@@ -1849,8 +1977,15 @@ set(SMBTORTURE_ENABLED_linux
 
 set(SMBTORTURE_ENABLED_io_uring
     # smb2.bench
+    smb2.bench.echo
+    smb2.bench.path-contention-shared
+    smb2.bench.read
+    smb2.bench.session-setup
     # smb2.change_notify_disabled
     smb2.change_notify_disabled.notfiy_disabled
+    # smb2.charset
+    "smb2.charset.Testing composite character (a umlaut)"
+    "smb2.charset.Testing naked diacritical (umlaut)"
     # smb2.check-sharemode
     smb2.check-sharemode
     # smb2.compound
@@ -1866,6 +2001,10 @@ set(SMBTORTURE_ENABLED_io_uring
     smb2.compound.related6
     smb2.compound.related9
     smb2.compound.unrelated1
+    # smb2.compound_async
+    smb2.compound_async.create_lease_break_async
+    smb2.compound_async.rename_last
+    smb2.compound_async.rename_middle
     # smb2.compound_find
     smb2.compound_find.compound_find_close
     smb2.compound_find.compound_find_related
@@ -1889,6 +2028,7 @@ set(SMBTORTURE_ENABLED_io_uring
     smb2.credits.skipped_mid
     # smb2.delete-on-close-perms
     smb2.delete-on-close-perms.CREATE
+    "smb2.delete-on-close-perms.CREATE Existing"
     smb2.delete-on-close-perms.CREATE_IF
     smb2.delete-on-close-perms.FIND_and_set_DOC
     smb2.delete-on-close-perms.OVERWRITE_IF
@@ -1903,10 +2043,12 @@ set(SMBTORTURE_ENABLED_io_uring
     smb2.dir.many
     smb2.dir.sorted
     # smb2.durable-open
+    smb2.durable-open.reopen6
     # smb2.durable-v2-delay
     smb2.durable-v2-delay.durable_v2_reconnect_delay
     smb2.durable-v2-delay.durable_v2_reconnect_delay_msec
     # smb2.durable-v2-open
+    smb2.durable-v2-open.reconnect-twice
     # smb2.durable-v2-regressions
     smb2.durable-v2-regressions.durable_v2_reconnect_bug15624
     # smb2.fileid
@@ -1949,6 +2091,7 @@ set(SMBTORTURE_ENABLED_io_uring
     smb2.ioctl.dup_extents_src_is_dest
     smb2.ioctl.dup_extents_src_is_dest_overlap
     smb2.ioctl.dup_extents_src_lock
+    smb2.ioctl.network_interface_info
     smb2.ioctl.req_resume_key
     smb2.ioctl.req_two_resume_keys
     smb2.ioctl.shadow_copy
@@ -1970,42 +2113,39 @@ set(SMBTORTURE_ENABLED_io_uring
     smb2.ioctl.sparse_qar_truncated
     smb2.ioctl.sparse_set_nobuf
     smb2.ioctl.sparse_set_oversize
+    # smb2.kernel-oplocks
+    smb2.kernel-oplocks.kernel_oplocks1
+    smb2.kernel-oplocks.kernel_oplocks3
+    # smb2.lease
+    smb2.lease.statopen2
+    smb2.lease.statopen3
     # smb2.lock
     smb2.lock.auto-unlock
-    smb2.lock.errorcode
-    smb2.lock.lock
-    smb2.lock.multiple-unlock
-    smb2.lock.overlap
-    smb2.lock.range
-    smb2.lock.stacking
-    smb2.lock.valid-request
-    smb2.lock.zerobytelength
-    smb2.lock.zerobyteread
     smb2.lock.contend
     smb2.lock.context
     smb2.lock.ctdb-delrec-deadlock
+    smb2.lock.errorcode
+    smb2.lock.lock
+    smb2.lock.multiple-unlock
     smb2.lock.open-brlock-deadlock
+    smb2.lock.overlap
+    smb2.lock.range
     smb2.lock.rw-exclusive
     smb2.lock.rw-none
     smb2.lock.rw-shared
+    smb2.lock.stacking
     smb2.lock.truncate
     smb2.lock.unlock
+    smb2.lock.valid-request
+    smb2.lock.zerobytelength
+    smb2.lock.zerobyteread
     # smb2.maxfid
     smb2.maxfid
     # smb2.maximum_allowed
     smb2.maximum_allowed.read_only
     # smb2.mkdir
     smb2.mkdir
-    # smb2.multichannel (SMB3 session binding).  interface_info advertises the
-    # server NICs, num_channels exercises channel bind + the 32-channel limit,
-    # bug_15346 is a bind regression, and oplocks.test1 checks an oplock break
-    # delivered over a bound session.  oplocks.test1 is enabled only on the
-    # non-passthrough backends: the linux/io_uring share root keeps real on-disk
-    # files between subtests, so the test's create-disposition checks see EXISTED
-    # instead of CREATED.  oplocks.test2/test3* stay disabled (they need Samba
-    # test-only FSCTLs -- force-unacked-timeout / network block -- chimera does
-    # not implement); leases.test1-4 stay disabled (general lease-grant
-    # behaviour, not multichannel binding).
+    # smb2.multichannel
     smb2.multichannel.bugs.bug_15346
     smb2.multichannel.generic.interface_info
     smb2.multichannel.generic.num_channels
@@ -2032,6 +2172,28 @@ set(SMBTORTURE_ENABLED_io_uring
     smb2.notify.tdis1
     # smb2.oplock
     smb2.oplock.batch10
+    smb2.oplock.batch11
+    smb2.oplock.batch12
+    smb2.oplock.batch13
+    smb2.oplock.batch14
+    smb2.oplock.batch15
+    smb2.oplock.batch16
+    smb2.oplock.batch2
+    smb2.oplock.batch21
+    smb2.oplock.batch23
+    smb2.oplock.batch24
+    smb2.oplock.batch25
+    smb2.oplock.batch4
+    smb2.oplock.batch5
+    smb2.oplock.batch8
+    smb2.oplock.brl2
+    smb2.oplock.exclusive1
+    smb2.oplock.exclusive2
+    smb2.oplock.exclusive3
+    smb2.oplock.exclusive4
+    smb2.oplock.exclusive5
+    smb2.oplock.levelii501
+    smb2.oplock.levelii502
     # smb2.read
     smb2.read.access
     smb2.read.bug14607
@@ -2147,8 +2309,15 @@ set(SMBTORTURE_ENABLED_cairn
     # smb2.async_dosmode
     smb2.async_dosmode
     # smb2.bench
+    smb2.bench.echo
+    smb2.bench.path-contention-shared
+    smb2.bench.read
+    smb2.bench.session-setup
     # smb2.change_notify_disabled
     smb2.change_notify_disabled.notfiy_disabled
+    # smb2.charset
+    "smb2.charset.Testing composite character (a umlaut)"
+    "smb2.charset.Testing naked diacritical (umlaut)"
     # smb2.check-sharemode
     smb2.check-sharemode
     # smb2.compound
@@ -2188,6 +2357,7 @@ set(SMBTORTURE_ENABLED_cairn
     # smb2.delete-on-close-perms
     smb2.delete-on-close-perms.BUG14427
     smb2.delete-on-close-perms.CREATE
+    "smb2.delete-on-close-perms.CREATE Existing"
     smb2.delete-on-close-perms.CREATE_IF
     smb2.delete-on-close-perms.FIND_and_set_DOC
     smb2.delete-on-close-perms.OVERWRITE_IF
@@ -2202,18 +2372,62 @@ set(SMBTORTURE_ENABLED_cairn
     # smb2.durable-open-disconnect
     smb2.durable-open-disconnect.open-oplock-disconnect
     # smb2.durable-open
+    smb2.durable-open.delete_on_close2
+    smb2.durable-open.file-position
     smb2.durable-open.lease
-    smb2.durable-open.oplock
+    smb2.durable-open.lock-lease
+    smb2.durable-open.lock-noW-lease
+    smb2.durable-open.lock-oplock
+    smb2.durable-open.open-lease
+    smb2.durable-open.open-oplock
     smb2.durable-open.open2-oplock
+    smb2.durable-open.oplock
+    smb2.durable-open.read-only
+    smb2.durable-open.reopen1
+    smb2.durable-open.reopen1a
+    smb2.durable-open.reopen1a-lease
+    smb2.durable-open.reopen2
+    smb2.durable-open.reopen2-lease
+    smb2.durable-open.reopen2-lease-v2
+    smb2.durable-open.reopen2a
+    smb2.durable-open.reopen3
+    smb2.durable-open.reopen4
+    smb2.durable-open.reopen5
+    smb2.durable-open.reopen6
+    smb2.durable-open.stat-open
     # smb2.durable-v2-delay
     smb2.durable-v2-delay.durable_v2_reconnect_delay
     smb2.durable-v2-delay.durable_v2_reconnect_delay_msec
     # smb2.durable-v2-open
     smb2.durable-v2-open.app-instance
+    smb2.durable-v2-open.create-blob
+    smb2.durable-v2-open.durable-v2-setinfo
     smb2.durable-v2-open.keep-disconnected-rh-with-rh-open
     smb2.durable-v2-open.keep-disconnected-rh-with-rwh-open
+    smb2.durable-v2-open.keep-disconnected-rh-with-stat-open
+    smb2.durable-v2-open.keep-disconnected-rwh-with-stat-open
+    smb2.durable-v2-open.lock-lease
+    smb2.durable-v2-open.lock-noW-lease
+    smb2.durable-v2-open.lock-oplock
+    smb2.durable-v2-open.open-lease
+    smb2.durable-v2-open.open-oplock
+    smb2.durable-v2-open.persistent-open-lease
+    smb2.durable-v2-open.persistent-open-oplock
+    smb2.durable-v2-open.purge-disconnected-rh-with-share-none-open
     smb2.durable-v2-open.purge-disconnected-rwh-with-rh-open
     smb2.durable-v2-open.purge-disconnected-rwh-with-rwh-open
+    smb2.durable-v2-open.reconnect-twice
+    smb2.durable-v2-open.reopen1
+    smb2.durable-v2-open.reopen1a
+    smb2.durable-v2-open.reopen1a-lease
+    smb2.durable-v2-open.reopen2
+    smb2.durable-v2-open.reopen2-lease
+    smb2.durable-v2-open.reopen2-lease-v2
+    smb2.durable-v2-open.reopen2b
+    smb2.durable-v2-open.reopen2c
+    smb2.durable-v2-open.stat-and-lease
+    smb2.durable-v2-open.two-different-lease
+    smb2.durable-v2-open.two-same-lease
     # smb2.durable-v2-regressions
     smb2.durable-v2-regressions.durable_v2_reconnect_bug15624
     # smb2.fileid
@@ -2248,6 +2462,7 @@ set(SMBTORTURE_ENABLED_cairn
     smb2.ioctl.dup_extents_src_is_dest
     smb2.ioctl.dup_extents_src_is_dest_overlap
     smb2.ioctl.dup_extents_src_lock
+    smb2.ioctl.network_interface_info
     smb2.ioctl.req_resume_key
     smb2.ioctl.req_two_resume_keys
     smb2.ioctl.shadow_copy
@@ -2273,40 +2488,32 @@ set(SMBTORTURE_ENABLED_cairn
     smb2.kernel-oplocks.kernel_oplocks8
     # smb2.lock
     smb2.lock.auto-unlock
-    smb2.lock.errorcode
-    smb2.lock.lock
-    smb2.lock.multiple-unlock
-    smb2.lock.overlap
-    smb2.lock.range
-    smb2.lock.stacking
-    smb2.lock.valid-request
-    smb2.lock.zerobytelength
-    smb2.lock.zerobyteread
     smb2.lock.contend
     smb2.lock.context
     smb2.lock.ctdb-delrec-deadlock
+    smb2.lock.errorcode
+    smb2.lock.lock
+    smb2.lock.multiple-unlock
     smb2.lock.open-brlock-deadlock
+    smb2.lock.overlap
+    smb2.lock.range
     smb2.lock.rw-exclusive
     smb2.lock.rw-none
     smb2.lock.rw-shared
+    smb2.lock.stacking
     smb2.lock.truncate
     smb2.lock.unlock
+    smb2.lock.valid-request
+    smb2.lock.zerobytelength
+    smb2.lock.zerobyteread
     # smb2.maxfid
+    smb2.maxfid
     # smb2.maximum_allowed
     smb2.maximum_allowed.maximum_allowed
     smb2.maximum_allowed.read_only
     # smb2.mkdir
     smb2.mkdir
-    # smb2.multichannel (SMB3 session binding).  interface_info advertises the
-    # server NICs, num_channels exercises channel bind + the 32-channel limit,
-    # bug_15346 is a bind regression, and oplocks.test1 checks an oplock break
-    # delivered over a bound session.  oplocks.test1 is enabled only on the
-    # non-passthrough backends: the linux/io_uring share root keeps real on-disk
-    # files between subtests, so the test's create-disposition checks see EXISTED
-    # instead of CREATED.  oplocks.test2/test3* stay disabled (they need Samba
-    # test-only FSCTLs -- force-unacked-timeout / network block -- chimera does
-    # not implement); leases.test1-4 stay disabled (general lease-grant
-    # behaviour, not multichannel binding).
+    # smb2.multichannel
     smb2.multichannel.bugs.bug_15346
     smb2.multichannel.generic.interface_info
     smb2.multichannel.generic.num_channels
@@ -2476,8 +2683,15 @@ set(SMBTORTURE_ENABLED_diskfs_io_uring
     # smb2.async_dosmode
     smb2.async_dosmode
     # smb2.bench
+    smb2.bench.echo
+    smb2.bench.path-contention-shared
+    smb2.bench.read
+    smb2.bench.session-setup
     # smb2.change_notify_disabled
     smb2.change_notify_disabled.notfiy_disabled
+    # smb2.charset
+    "smb2.charset.Testing composite character (a umlaut)"
+    "smb2.charset.Testing naked diacritical (umlaut)"
     # smb2.check-sharemode
     smb2.check-sharemode
     # smb2.compound
@@ -2519,6 +2733,7 @@ set(SMBTORTURE_ENABLED_diskfs_io_uring
     # smb2.delete-on-close-perms
     smb2.delete-on-close-perms.BUG14427
     smb2.delete-on-close-perms.CREATE
+    "smb2.delete-on-close-perms.CREATE Existing"
     smb2.delete-on-close-perms.CREATE_IF
     smb2.delete-on-close-perms.FIND_and_set_DOC
     smb2.delete-on-close-perms.OVERWRITE_IF
@@ -2535,15 +2750,59 @@ set(SMBTORTURE_ENABLED_diskfs_io_uring
     # smb2.durable-open-disconnect
     smb2.durable-open-disconnect.open-oplock-disconnect
     # smb2.durable-open
+    smb2.durable-open.delete_on_close2
+    smb2.durable-open.file-position
+    smb2.durable-open.lock-lease
+    smb2.durable-open.lock-noW-lease
+    smb2.durable-open.lock-oplock
+    smb2.durable-open.open-lease
+    smb2.durable-open.open-oplock
+    smb2.durable-open.read-only
+    smb2.durable-open.reopen1
+    smb2.durable-open.reopen1a
+    smb2.durable-open.reopen1a-lease
+    smb2.durable-open.reopen2
+    smb2.durable-open.reopen2-lease
+    smb2.durable-open.reopen2-lease-v2
+    smb2.durable-open.reopen2a
+    smb2.durable-open.reopen3
+    smb2.durable-open.reopen4
+    smb2.durable-open.reopen5
+    smb2.durable-open.reopen6
+    smb2.durable-open.stat-open
     # smb2.durable-v2-delay
     smb2.durable-v2-delay.durable_v2_reconnect_delay
     smb2.durable-v2-delay.durable_v2_reconnect_delay_msec
     # smb2.durable-v2-open
     smb2.durable-v2-open.app-instance
+    smb2.durable-v2-open.create-blob
+    smb2.durable-v2-open.durable-v2-setinfo
     smb2.durable-v2-open.keep-disconnected-rh-with-rh-open
     smb2.durable-v2-open.keep-disconnected-rh-with-rwh-open
+    smb2.durable-v2-open.keep-disconnected-rh-with-stat-open
+    smb2.durable-v2-open.keep-disconnected-rwh-with-stat-open
+    smb2.durable-v2-open.lock-lease
+    smb2.durable-v2-open.lock-noW-lease
+    smb2.durable-v2-open.lock-oplock
+    smb2.durable-v2-open.open-lease
+    smb2.durable-v2-open.open-oplock
+    smb2.durable-v2-open.persistent-open-lease
+    smb2.durable-v2-open.persistent-open-oplock
+    smb2.durable-v2-open.purge-disconnected-rh-with-share-none-open
     smb2.durable-v2-open.purge-disconnected-rwh-with-rh-open
     smb2.durable-v2-open.purge-disconnected-rwh-with-rwh-open
+    smb2.durable-v2-open.reconnect-twice
+    smb2.durable-v2-open.reopen1
+    smb2.durable-v2-open.reopen1a
+    smb2.durable-v2-open.reopen1a-lease
+    smb2.durable-v2-open.reopen2
+    smb2.durable-v2-open.reopen2-lease
+    smb2.durable-v2-open.reopen2-lease-v2
+    smb2.durable-v2-open.reopen2b
+    smb2.durable-v2-open.reopen2c
+    smb2.durable-v2-open.stat-and-lease
+    smb2.durable-v2-open.two-different-lease
+    smb2.durable-v2-open.two-same-lease
     # smb2.durable-v2-regressions
     smb2.durable-v2-regressions.durable_v2_reconnect_bug15624
     # smb2.fileid
@@ -2578,6 +2837,7 @@ set(SMBTORTURE_ENABLED_diskfs_io_uring
     smb2.ioctl.dup_extents_src_is_dest
     smb2.ioctl.dup_extents_src_is_dest_overlap
     smb2.ioctl.dup_extents_src_lock
+    smb2.ioctl.network_interface_info
     smb2.ioctl.req_resume_key
     smb2.ioctl.req_two_resume_keys
     smb2.ioctl.shadow_copy
@@ -2603,40 +2863,32 @@ set(SMBTORTURE_ENABLED_diskfs_io_uring
     smb2.kernel-oplocks.kernel_oplocks8
     # smb2.lock
     smb2.lock.auto-unlock
-    smb2.lock.errorcode
-    smb2.lock.lock
-    smb2.lock.multiple-unlock
-    smb2.lock.overlap
-    smb2.lock.range
-    smb2.lock.stacking
-    smb2.lock.valid-request
-    smb2.lock.zerobytelength
-    smb2.lock.zerobyteread
     smb2.lock.contend
     smb2.lock.context
     smb2.lock.ctdb-delrec-deadlock
+    smb2.lock.errorcode
+    smb2.lock.lock
+    smb2.lock.multiple-unlock
     smb2.lock.open-brlock-deadlock
+    smb2.lock.overlap
+    smb2.lock.range
     smb2.lock.rw-exclusive
     smb2.lock.rw-none
     smb2.lock.rw-shared
+    smb2.lock.stacking
     smb2.lock.truncate
     smb2.lock.unlock
+    smb2.lock.valid-request
+    smb2.lock.zerobytelength
+    smb2.lock.zerobyteread
     # smb2.maxfid
+    smb2.maxfid
     # smb2.maximum_allowed
     smb2.maximum_allowed.maximum_allowed
     smb2.maximum_allowed.read_only
     # smb2.mkdir
     smb2.mkdir
-    # smb2.multichannel (SMB3 session binding).  interface_info advertises the
-    # server NICs, num_channels exercises channel bind + the 32-channel limit,
-    # bug_15346 is a bind regression, and oplocks.test1 checks an oplock break
-    # delivered over a bound session.  oplocks.test1 is enabled only on the
-    # non-passthrough backends: the linux/io_uring share root keeps real on-disk
-    # files between subtests, so the test's create-disposition checks see EXISTED
-    # instead of CREATED.  oplocks.test2/test3* stay disabled (they need Samba
-    # test-only FSCTLs -- force-unacked-timeout / network block -- chimera does
-    # not implement); leases.test1-4 stay disabled (general lease-grant
-    # behaviour, not multichannel binding).
+    # smb2.multichannel
     smb2.multichannel.bugs.bug_15346
     smb2.multichannel.generic.interface_info
     smb2.multichannel.generic.num_channels
@@ -2806,8 +3058,15 @@ set(SMBTORTURE_ENABLED_diskfs_aio
     # smb2.async_dosmode
     smb2.async_dosmode
     # smb2.bench
+    smb2.bench.echo
+    smb2.bench.path-contention-shared
+    smb2.bench.read
+    smb2.bench.session-setup
     # smb2.change_notify_disabled
     smb2.change_notify_disabled.notfiy_disabled
+    # smb2.charset
+    "smb2.charset.Testing composite character (a umlaut)"
+    "smb2.charset.Testing naked diacritical (umlaut)"
     # smb2.check-sharemode
     smb2.check-sharemode
     # smb2.compound
@@ -2849,6 +3108,7 @@ set(SMBTORTURE_ENABLED_diskfs_aio
     # smb2.delete-on-close-perms
     smb2.delete-on-close-perms.BUG14427
     smb2.delete-on-close-perms.CREATE
+    "smb2.delete-on-close-perms.CREATE Existing"
     smb2.delete-on-close-perms.CREATE_IF
     smb2.delete-on-close-perms.FIND_and_set_DOC
     smb2.delete-on-close-perms.OVERWRITE_IF
@@ -2865,15 +3125,59 @@ set(SMBTORTURE_ENABLED_diskfs_aio
     # smb2.durable-open-disconnect
     smb2.durable-open-disconnect.open-oplock-disconnect
     # smb2.durable-open
+    smb2.durable-open.delete_on_close2
+    smb2.durable-open.file-position
+    smb2.durable-open.lock-lease
+    smb2.durable-open.lock-noW-lease
+    smb2.durable-open.lock-oplock
+    smb2.durable-open.open-lease
+    smb2.durable-open.open-oplock
+    smb2.durable-open.read-only
+    smb2.durable-open.reopen1
+    smb2.durable-open.reopen1a
+    smb2.durable-open.reopen1a-lease
+    smb2.durable-open.reopen2
+    smb2.durable-open.reopen2-lease
+    smb2.durable-open.reopen2-lease-v2
+    smb2.durable-open.reopen2a
+    smb2.durable-open.reopen3
+    smb2.durable-open.reopen4
+    smb2.durable-open.reopen5
+    smb2.durable-open.reopen6
+    smb2.durable-open.stat-open
     # smb2.durable-v2-delay
     smb2.durable-v2-delay.durable_v2_reconnect_delay
     smb2.durable-v2-delay.durable_v2_reconnect_delay_msec
     # smb2.durable-v2-open
     smb2.durable-v2-open.app-instance
+    smb2.durable-v2-open.create-blob
+    smb2.durable-v2-open.durable-v2-setinfo
     smb2.durable-v2-open.keep-disconnected-rh-with-rh-open
     smb2.durable-v2-open.keep-disconnected-rh-with-rwh-open
+    smb2.durable-v2-open.keep-disconnected-rh-with-stat-open
+    smb2.durable-v2-open.keep-disconnected-rwh-with-stat-open
+    smb2.durable-v2-open.lock-lease
+    smb2.durable-v2-open.lock-noW-lease
+    smb2.durable-v2-open.lock-oplock
+    smb2.durable-v2-open.open-lease
+    smb2.durable-v2-open.open-oplock
+    smb2.durable-v2-open.persistent-open-lease
+    smb2.durable-v2-open.persistent-open-oplock
+    smb2.durable-v2-open.purge-disconnected-rh-with-share-none-open
     smb2.durable-v2-open.purge-disconnected-rwh-with-rh-open
     smb2.durable-v2-open.purge-disconnected-rwh-with-rwh-open
+    smb2.durable-v2-open.reconnect-twice
+    smb2.durable-v2-open.reopen1
+    smb2.durable-v2-open.reopen1a
+    smb2.durable-v2-open.reopen1a-lease
+    smb2.durable-v2-open.reopen2
+    smb2.durable-v2-open.reopen2-lease
+    smb2.durable-v2-open.reopen2-lease-v2
+    smb2.durable-v2-open.reopen2b
+    smb2.durable-v2-open.reopen2c
+    smb2.durable-v2-open.stat-and-lease
+    smb2.durable-v2-open.two-different-lease
+    smb2.durable-v2-open.two-same-lease
     # smb2.durable-v2-regressions
     smb2.durable-v2-regressions.durable_v2_reconnect_bug15624
     # smb2.fileid
@@ -2908,6 +3212,7 @@ set(SMBTORTURE_ENABLED_diskfs_aio
     smb2.ioctl.dup_extents_src_is_dest
     smb2.ioctl.dup_extents_src_is_dest_overlap
     smb2.ioctl.dup_extents_src_lock
+    smb2.ioctl.network_interface_info
     smb2.ioctl.req_resume_key
     smb2.ioctl.req_two_resume_keys
     smb2.ioctl.shadow_copy
@@ -2933,40 +3238,30 @@ set(SMBTORTURE_ENABLED_diskfs_aio
     smb2.kernel-oplocks.kernel_oplocks8
     # smb2.lock
     smb2.lock.auto-unlock
-    smb2.lock.errorcode
-    smb2.lock.lock
-    smb2.lock.multiple-unlock
-    smb2.lock.overlap
-    smb2.lock.range
-    smb2.lock.stacking
-    smb2.lock.valid-request
-    smb2.lock.zerobytelength
-    smb2.lock.zerobyteread
     smb2.lock.contend
     smb2.lock.context
     smb2.lock.ctdb-delrec-deadlock
+    smb2.lock.errorcode
+    smb2.lock.lock
+    smb2.lock.multiple-unlock
     smb2.lock.open-brlock-deadlock
+    smb2.lock.overlap
+    smb2.lock.range
     smb2.lock.rw-exclusive
     smb2.lock.rw-none
     smb2.lock.rw-shared
+    smb2.lock.stacking
     smb2.lock.truncate
     smb2.lock.unlock
-    # smb2.maxfid
+    smb2.lock.valid-request
+    smb2.lock.zerobytelength
+    smb2.lock.zerobyteread
     # smb2.maximum_allowed
     smb2.maximum_allowed.maximum_allowed
     smb2.maximum_allowed.read_only
     # smb2.mkdir
     smb2.mkdir
-    # smb2.multichannel (SMB3 session binding).  interface_info advertises the
-    # server NICs, num_channels exercises channel bind + the 32-channel limit,
-    # bug_15346 is a bind regression, and oplocks.test1 checks an oplock break
-    # delivered over a bound session.  oplocks.test1 is enabled only on the
-    # non-passthrough backends: the linux/io_uring share root keeps real on-disk
-    # files between subtests, so the test's create-disposition checks see EXISTED
-    # instead of CREATED.  oplocks.test2/test3* stay disabled (they need Samba
-    # test-only FSCTLs -- force-unacked-timeout / network block -- chimera does
-    # not implement); leases.test1-4 stay disabled (general lease-grant
-    # behaviour, not multichannel binding).
+    # smb2.multichannel
     smb2.multichannel.bugs.bug_15346
     smb2.multichannel.generic.interface_info
     smb2.multichannel.generic.num_channels


### PR DESCRIPTION
## Summary

A full-catalog smbtorture matrix run (all 655 `smb2.*` subtests × 6 backends, ignoring the allowlists) at current main found **zero regressions** — every allowlisted test still passes — plus 336 (subtest, backend) cells that now pass but were never enabled. These are mostly `oplock.batch*/exclusive*`, `durable-open.reopen*`, `lease.statopen/upgrade/v2_*`, `bench` and `charset` cells that started passing with the recent lease over-break, durable-handle and compound work.

Allowlists were regenerated with `tools/smbtorture/regen.py` from the verified results. The change is strictly additive per backend:

| backend | before | after |
|---|---|---|
| memfs | 290 | 389 |
| linux | 227 | 267 |
| io_uring | 228 | 267 |
| cairn | 270 | 323 |
| diskfs_io_uring | 271 | 324 |
| diskfs_aio | 271 | 323 |

## Flake screening

Every newly-enabled cell was re-run 3× against this base (the set includes the timing-fragile oplock/lease/durable families). 338/340 candidate cells passed 3/3; the one flaky subtest, `smb2.durable-open.open2-lease` (intermittent `SHARING_VIOLATION` on reconnect), is left disabled on all backends.

The 22 durable-disconnect cells enabled on main after the matrix base (courtesy-hold work) were re-verified 3× at this base as well — all pass and remain enabled.