### PR TITLE
ci: three-phase pipeline — Build images, Compile code, then Test + Analyze

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -30,6 +30,12 @@ env:
   KVM_IMAGE_REGISTRY: repository.mdh.quantum.com:5009/chimera-nas/kvm-test-base
   APT_MIRROR: http://repository.mdh.quantum.com/repository/pkgs/ubuntu
   DOCKER_MIRROR: repository.mdh.quantum.com/
+  # Local Nexus raw repository for transient intra-run artifacts (the build
+  # tree handed from build-dev to the test-dev shards).  Keeps that traffic
+  # inside the self-hosted runner infra instead of GitHub's Azure-blob artifact
+  # storage; objects age out server-side, so jobs never delete.  Credentials
+  # come from the NEXUS_SCRATCH_USER / NEXUS_SCRATCH_PASSWORD secrets.
+  NEXUS_SCRATCH_URL: http://repository.mdh.quantum.com/repository/scratch
   # Shared compiler cache: the build step backs its local ccache with an HTTP
   # remote (Nexus raw repo, ccache http backend) so objects persist across CI
   # runs.  The full URL -- including the upload credentials -- is kept in the
@@ -571,7 +577,7 @@ jobs:
           fi
 
   # Devcontainer build half: build the tree once per (arch, build_type) and
-  # publish it as an artifact for the test-dev shards to consume.  KVM guest
+  # publish it to the local Nexus scratch repo for the test-dev shards.  KVM guest
   # images are NOT fetched here (KVM_FETCH_IMAGES=OFF, amd64 only) -- the kvm-*
   # test shards fetch them on demand.  KVM is x86-only in the devcontainer, so
   # arm64 builds with KVM off.
@@ -625,12 +631,23 @@ jobs:
               # already excluded).
               tar -C /build --exclude=./ccache -czf /workspace/build-dev.tar.gz .'
 
-      - name: Upload build tree
-        uses: actions/upload-artifact@v6
-        with:
-          name: build-dev-${{ matrix.arch }}-${{ matrix.build_type }}
-          path: build-dev.tar.gz
-          retention-days: 1
+      # The build tree stays inside the self-hosted runner infra: push it to the
+      # local Nexus scratch repository rather than GitHub's artifact storage
+      # (whose Azure-blob upload leaves the network and has produced transient
+      # DNS failures that evict merge-queue runs).  run_id alone names the
+      # object -- unique per run, and shared across job re-run attempts so a
+      # re-run test shard still finds the original build (matching the old
+      # download-artifact semantics).  scratch ages objects out automatically,
+      # so nothing is deleted here.
+      - name: Upload build tree to Nexus scratch
+        env:
+          NEXUS_USER: ${{ secrets.NEXUS_SCRATCH_USER }}
+          NEXUS_PASSWORD: ${{ secrets.NEXUS_SCRATCH_PASSWORD }}
+        run: |
+          curl -sfS --retry 5 --retry-all-errors --retry-delay 5 \
+            -u "${NEXUS_USER}:${NEXUS_PASSWORD}" \
+            -T build-dev.tar.gz \
+            "${{ env.NEXUS_SCRATCH_URL }}/chimera/build-dev-${{ github.run_id }}-${{ matrix.arch }}-${{ matrix.build_type }}.tar.gz"
 
   # Barrier: every devcontainer build-time job (build + static analysis) must
   # finish before any test-dev shard starts.  Default needs-success semantics
@@ -684,10 +701,15 @@ jobs:
             | tar -xz -C "${{ github.workspace }}" oras
           chmod +x "${{ github.workspace }}/oras"
 
-      - name: Download build tree
-        uses: actions/download-artifact@v6
-        with:
-          name: build-dev-${{ matrix.arch }}-${{ matrix.build_type }}
+      - name: Download build tree from Nexus scratch
+        env:
+          NEXUS_USER: ${{ secrets.NEXUS_SCRATCH_USER }}
+          NEXUS_PASSWORD: ${{ secrets.NEXUS_SCRATCH_PASSWORD }}
+        run: |
+          curl -sfS --retry 5 --retry-all-errors --retry-delay 5 \
+            -u "${NEXUS_USER}:${NEXUS_PASSWORD}" \
+            -o build-dev.tar.gz \
+            "${{ env.NEXUS_SCRATCH_URL }}/chimera/build-dev-${{ github.run_id }}-${{ matrix.arch }}-${{ matrix.build_type }}.tar.gz"
 
       - name: Unpack, fetch images if needed, and run the category
         run: |

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -17,6 +17,16 @@ on:
 #   - all OS images built for amd64 (devcontainer also for arm64)
 #   - tests on all OS images amd64; arm64 only on devcontainer
 #   - static analysis only on devcontainer
+#
+# The run is three phases, fanned out as wide as possible within each, and
+# the job display names follow the phase ("Build X" = container image,
+# "Compile X" = the source tree, "Test X" / "Analyze X" = phase 3) so the CI
+# details view reads unambiguously:
+#   1. Build    container images       (build-devcontainer, build-<os>)
+#   2. Compile  the source tree        (build-dev, build-os), build trees
+#               pushed to the local Nexus scratch repo
+#   3. Test     tests + static analysis (test, test-dev, static-analysis),
+#               all in parallel behind the Compiles-complete barrier
 
 env:
   DEV_IMAGE_TAG_PREFIX: repository.mdh.quantum.com:5004/cache/chimera-dev
@@ -297,8 +307,14 @@ jobs:
           build-args: |
             DOCKER_MIRROR=${{ env.DOCKER_MIRROR }}
 
-  test:
-    name: Test ${{ matrix.image_name }} ${{ matrix.arch }} ${{ matrix.build_type }}
+  # Distro build half (phase 2): compile the tree once per (image, build_type)
+  # and publish it to the local Nexus scratch repo for the matching `test` job
+  # to consume -- the same build/test split the devcontainer uses (build-dev /
+  # test-dev below).  Phase 3 (all test jobs + static analysis, in parallel)
+  # starts only once every phase-2 compile has finished (the build-complete
+  # barrier).
+  build-os:
+    name: Compile ${{ matrix.image_name }} ${{ matrix.arch }} ${{ matrix.build_type }}
     needs: [build-devcontainer, build-ubuntu26, build-ubuntu24, build-ubuntu22, build-rocky9, build-rocky10]
     if: ${{ github.event_name != 'pull_request' }}
     runs-on: ${{ matrix.runner }}
@@ -310,7 +326,7 @@ jobs:
         include:
           # NOTE: the devcontainer is built and tested by the dedicated
           # build-dev / test-dev jobs below (build once, then shard the tests by
-          # category); it is no longer part of this combined build+test matrix.
+          # category); it is no longer part of this distro matrix.
           # ubuntu 26 (amd64 only on PR; arm64 runs in nightly)
           - platform: linux/amd64
             runner: arc-amd64
@@ -404,7 +420,7 @@ jobs:
             | tar -xz -C "${{ github.workspace }}" oras
           chmod +x "${{ github.workspace }}/oras"
 
-      - name: Configure, build, and test inside the container
+      - name: Configure and build inside the container
         run: |
           docker run --rm --privileged \
             -e DOCKER_MIRROR=${{ env.DOCKER_MIRROR }} \
@@ -420,6 +436,69 @@ jobs:
               cmake -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DREQUIRE_NETNS_TESTS=ON -DKVM_IMAGE_REGISTRY=${{ env.KVM_IMAGE_REGISTRY }} -DPYNFS_JUNIT_DIR=/workspace/ctest-results/pynfs-junit -DSMBTORTURE_JUNIT_DIR=/workspace/ctest-results/smbtorture-junit ${{ matrix.cmake_extra }} /workspace
               ninja
               ccache --show-stats || true
+              tar -C /build --exclude=./ccache -czf /workspace/build-os.tar.gz .'
+
+      - name: Upload build tree to Nexus scratch
+        env:
+          NEXUS_USER: ${{ secrets.NEXUS_SCRATCH_USER }}
+          NEXUS_PASSWORD: ${{ secrets.NEXUS_SCRATCH_PASSWORD }}
+        run: |
+          curl -sfS --retry 5 --retry-all-errors --retry-delay 5 \
+            -u "${NEXUS_USER}:${NEXUS_PASSWORD}" \
+            -T build-os.tar.gz \
+            "${{ env.NEXUS_SCRATCH_URL }}/chimera/build-${{ matrix.image_name }}-${{ github.run_id }}-${{ matrix.arch }}-${{ matrix.build_type }}.tar.gz"
+
+  # Distro test half (phase 3): pull the build tree from Nexus scratch and run
+  # this image's full ctest suite.  Gated on the build-complete barrier, so all
+  # test jobs (distro + devcontainer shards) and static analysis start together
+  # once every compile has finished.
+  test:
+    name: Test ${{ matrix.image_name }} ${{ matrix.arch }} ${{ matrix.build_type }}
+    needs: [build-complete]
+    if: ${{ github.event_name != 'pull_request' }}
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [amd64]
+        build_type: [Release, Debug]
+        image_name: [ubuntu26, ubuntu24, ubuntu22, rocky9, rocky10]
+        include:
+          - { arch: amd64, runner: arc-amd64 }
+          - { image_name: ubuntu26, image_tag_prefix: "repository.mdh.quantum.com:5004/cache/chimera-ubuntu26" }
+          - { image_name: ubuntu24, image_tag_prefix: "repository.mdh.quantum.com:5004/cache/chimera-ubuntu24" }
+          - { image_name: ubuntu22, image_tag_prefix: "repository.mdh.quantum.com:5004/cache/chimera-ubuntu22" }
+          - { image_name: rocky9,   image_tag_prefix: "repository.mdh.quantum.com:5004/cache/chimera-rocky9" }
+          - { image_name: rocky10,  image_tag_prefix: "repository.mdh.quantum.com:5004/cache/chimera-rocky10" }
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+
+      - name: Download build tree from Nexus scratch
+        env:
+          NEXUS_USER: ${{ secrets.NEXUS_SCRATCH_USER }}
+          NEXUS_PASSWORD: ${{ secrets.NEXUS_SCRATCH_PASSWORD }}
+        run: |
+          curl -sfS --retry 5 --retry-all-errors --retry-delay 5 \
+            -u "${NEXUS_USER}:${NEXUS_PASSWORD}" \
+            -o build-os.tar.gz \
+            "${{ env.NEXUS_SCRATCH_URL }}/chimera/build-${{ matrix.image_name }}-${{ github.run_id }}-${{ matrix.arch }}-${{ matrix.build_type }}.tar.gz"
+
+      - name: Unpack and test inside the container
+        run: |
+          docker run --rm --privileged \
+            -e DOCKER_MIRROR=${{ env.DOCKER_MIRROR }} \
+            -e APT_MIRROR=${{ env.APT_MIRROR }} \
+            -v "${{ github.workspace }}:/workspace" \
+            -v /build \
+            -w /build \
+            ${{ matrix.image_tag_prefix }}:${{ github.sha }}-${{ matrix.arch }} \
+            bash -euxc '
+              tar -C /build -xzf /workspace/build-os.tar.gz
               mkdir -p /workspace/ctest-results
               rm -f /workspace/flaky-rescued.log
               start=$(date +%s)
@@ -461,9 +540,15 @@ jobs:
           path: flaky-rescued.log
           retention-days: 14
 
+  # Phase 3 alongside the test jobs: scan-build does its own instrumented
+  # compile (it cannot reuse the Nexus build tree), but it is gated on the
+  # build-complete barrier so the analysis fleet spins up together with the
+  # tests instead of competing with the phase-2 compiles -- and so a
+  # scan-build finding never blocks tests from starting (it still gates
+  # ci-complete).
   static-analysis:
     name: Analyze ${{ matrix.image_name }} ${{ matrix.arch }} ${{ matrix.build_type }}
-    needs: [build-devcontainer]
+    needs: [build-complete]
     if: ${{ github.event_name != 'pull_request' }}
     runs-on: ${{ matrix.runner }}
     permissions:
@@ -582,7 +667,7 @@ jobs:
   # test shards fetch them on demand.  KVM is x86-only in the devcontainer, so
   # arm64 builds with KVM off.
   build-dev:
-    name: Build devcontainer ${{ matrix.arch }} ${{ matrix.build_type }}
+    name: Compile devcontainer ${{ matrix.arch }} ${{ matrix.build_type }}
     needs: [build-devcontainer]
     if: ${{ github.event_name != 'pull_request' }}
     runs-on: ${{ matrix.runner }}
@@ -649,19 +734,20 @@ jobs:
             -T build-dev.tar.gz \
             "${{ env.NEXUS_SCRATCH_URL }}/chimera/build-dev-${{ github.run_id }}-${{ matrix.arch }}-${{ matrix.build_type }}.tar.gz"
 
-  # Barrier: every devcontainer build-time job (build + static analysis) must
-  # finish before any test-dev shard starts.  Default needs-success semantics
-  # mean a failed build skips this, which in turn skips all test shards.
-  build-dev-complete:
-    name: Devcontainer build complete
-    needs: [build-dev, static-analysis]
+  # Phase-2 -> phase-3 barrier: every compile (devcontainer + distro) must
+  # finish before any test job or the static analysis starts.  Default
+  # needs-success semantics mean a failed build skips this, which in turn
+  # skips phase 3 entirely.
+  build-complete:
+    name: Compiles complete
+    needs: [build-dev, build-os]
     if: ${{ github.event_name != 'pull_request' }}
     runs-on: arc-amd64
     permissions:
       contents: read
     steps:
       - name: Builds done
-        run: echo "All devcontainer build-time jobs passed; releasing test shards."
+        run: echo "All compile jobs passed; releasing test + analysis jobs."
 
   # Devcontainer test half: one shard per category, each consuming the build
   # artifact.  netns categories run on both arches; the kvm-* categories run on
@@ -669,7 +755,7 @@ jobs:
   # demand before running.
   test-dev:
     name: Test devcontainer ${{ matrix.arch }} ${{ matrix.build_type }} ${{ matrix.category }}
-    needs: [build-dev-complete]
+    needs: [build-complete]
     if: ${{ github.event_name != 'pull_request' }}
     runs-on: ${{ matrix.runner }}
     permissions:
@@ -688,6 +774,9 @@ jobs:
           - { arch: arm64, category: kvm-cthon }
           - { arch: arm64, category: kvm-xfsprogs }
           - { arch: arm64, category: kvm-pnfs }
+          # WPTS (Microsoft Protocol Test Suite) is not supported on arm64 —
+          # the shard would only skip every test, so don't run it at all.
+          - { arch: arm64, category: wpts }
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -878,6 +967,7 @@ jobs:
       - build-ubuntu22
       - build-rocky9
       - build-rocky10
+      - build-os
       - test
       - build-dev
       - test-dev


### PR DESCRIPTION
**Stacked on #760** (this branch contains its commit; merge #760 first and this PR reduces to the restructure commit).

Restructures the merge-queue workflow into three explicit phases, each fanned out as wide as possible, with **job display names following the phase** so the CI details view reads unambiguously — previously both the container builds and the compiles were named "Build X" and were hard to tell apart:

1. **Build** — container images: `Build devcontainer amd64`, `Build ubuntu26 amd64`, … (unchanged jobs).
2. **Compile** — the source tree: `Compile devcontainer <arch> <type>` (was build-dev's "Build devcontainer …") plus the new `Compile <image> <arch> <type>` (`build-os`). The distro jobs previously configured + built + tested in a single container run; they now get the same build/test split the devcontainer has. Each compile pushes its build tree to the local Nexus scratch repo (`build-<image>-<run_id>-<arch>-<build_type>.tar.gz`, same mechanism as #760).
3. **Test** — `Test <image> …` (distro, now unpack + ctest only), `Test devcontainer … <category>` shards, and `Analyze …` (static analysis), all in parallel behind a single **"Compiles complete"** barrier (`needs: [build-dev, build-os]`).

Notable effects:

- **Static analysis no longer delays any test.** It moves out of the old `build-dev-complete` barrier into phase 3 — it still gates `CI complete`, but tests start the moment the compiles finish, and scan-build's instrumented compile no longer competes with phase-2 builds for runners.
- **Distro test retries don't recompile.** A flaky distro test job re-run now costs an unpack + ctest, not a full build; ccache traffic disappears from the test phase entirely.
- **arm64 wpts shard removed** via matrix exclude: WPTS isn't supported on arm64, so the shard only ever skipped every test.

Mechanical notes: `build-os` keeps the exact cmake invocations (incl. per-image `cmake_extra`) and the oras fetch from the old combined job; the `test` matrix is the same 10 (image × build_type) combos expressed compactly; JUnit/flaky-marker uploads move with the test half so `publish-test-results`, `collect-flakes`, and the flake-gate are untouched (they key off artifact names, not job names). Branch-protection placeholders (`CI complete`, `Flake review gate`, `Docker build complete`) are unaffected by the renames. `ci-complete` additionally requires `build-os`. Job-graph wiring validated (no dangling `needs`, no cycles).