### PR TITLE
smb: defer no-session parse failure to fix compound accounting abort

### DIFF
--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -1337,10 +1337,22 @@ chimera_smb_server_handle_smb2(
                      (request->smb2_hdr.command != SMB2_NEGOTIATE &&
                       request->smb2_hdr.command != SMB2_SESSION_SETUP &&
                       request->smb2_hdr.command != SMB2_ECHO))) {
-            chimera_smb_error("Received SMB2 message with invalid command and no session");
-            chimera_smb_complete_request(request, SMB2_STATUS_NO_SUCH_LOGON_SESSION);
-            chimera_smb_request_free(thread, request);
-            return;
+            /* A session-requiring command whose header carries SessionId 0 --
+             * e.g. smbtorture's sessionless FSCTL_SMBTORTURE transport-block
+             * IOCTL (smb2.replay.dhv2-pending3*, smb2.oplock.batch22b,
+             * smb2.multichannel.*).  Per MS-SMB2 3.3.5.2.9 this is answered
+             * with USER_SESSION_DELETED.  Defer the failure exactly like the
+             * invalid-session-id case above: the request was not yet added to
+             * the compound, so completing it inline would advance
+             * complete_requests against a compound that does not contain it
+             * (tripping the compound_advance accounting abort) and, mid-chain,
+             * would complete requests out of order. */
+            chimera_smb_error("Received session-requiring SMB2 command %u with no session",
+                              request->smb2_hdr.command);
+            request->status                              = SMB2_STATUS_USER_SESSION_DELETED;
+            request->flags                              |= CHIMERA_SMB_REQUEST_FLAG_PARSE_FAILED;
+            compound->requests[compound->num_requests++] = request;
+            goto next_compound_request;
         }
 
         if (request->session_handle &&

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -2759,11 +2759,14 @@ set(SMBTORTURE_ENABLED_diskfs_io_uring
     # smb2.durable-open
     smb2.durable-open.delete_on_close2
     smb2.durable-open.file-position
+    smb2.durable-open.lease
     smb2.durable-open.lock-lease
     smb2.durable-open.lock-noW-lease
     smb2.durable-open.lock-oplock
     smb2.durable-open.open-lease
     smb2.durable-open.open-oplock
+    smb2.durable-open.open2-oplock
+    smb2.durable-open.oplock
     smb2.durable-open.read-only
     smb2.durable-open.reopen1
     smb2.durable-open.reopen1a


### PR DESCRIPTION
## Root cause

A full smbtorture matrix run found 62 cells (all backends) where the server aborts with:

```
fatal: "compound_advance: complete_requests = 1 num_requests = 0" at src/server/smb/smb.c:845
```

The trigger is smbtorture's sessionless `FSCTL_SMBTORTURE_FORCE_UNACKED_TIMEOUT` IOCTL (sent with no session and no tcon, SessionId 0) which `smb2.replay.dhv2-pending3*`, `smb2.oplock.batch22b` and the `smb2.multichannel` block-transport tests use to simulate a blocked transport.

In `chimera_smb_server_handle_smb2()`, the "session-requiring command with no session" branch called `chimera_smb_complete_request()` inline from the parse loop, **before the request had been added to `compound->requests[]`**. That advanced `complete_requests` to 1 against `num_requests == 0` and tripped the accounting abort in `chimera_smb_compound_advance()`. Mid-chain, the inline completion would also have replied to compounded requests out of order, and the early `return` leaked any previously parsed requests in the compound.

## Fix

Handle it exactly like the adjacent invalid-session-id and deleted-session cases already do: mark the request `PARSE_FAILED` with `STATUS_USER_SESSION_DELETED` (MS-SMB2 3.3.5.2.9, matching what smbd replies), append it to the compound, and let the dispatcher complete it in chain order.

## Verification (Debug/ASan, memfs + diskfs_io_uring + cairn, 3x each)

Tests that stopped crashing (server no longer aborts in 189/189 runs):
- `smb2.replay.dhv2-pending3{l,n,o}-vs-{lease,oplock}-{sane,windows}` (12 tests)
- `smb2.oplock.batch22b`
- `smb2.multichannel.oplocks.test2`
- plus `smb2.replay.durable-reconnect-replay1/2/3`, `smb2.replay.replay-twice-durable`, `smb2.durable-open.{oplock,lease,open2-oplock}` re-verified crash-free

The block-transport tests still fail *functionally* with a clean error: they require the Samba-private `FSCTL_SMBTORTURE` server hook (or iptables) to actually block the transport, which chimera does not implement. The server now answers `USER_SESSION_DELETED` and keeps serving instead of aborting.

Regression: all currently-enabled `smb2.compound*`, `smb2.durable-open*`, `smb2.durable-v2-open*`, `smb2.replay`, `smb2.oplock` subtests on memfs and diskfs_io_uring — 68/68 pass, zero new failures.

## Newly enabled

`smb2.durable-open.lease`, `smb2.durable-open.oplock`, `smb2.durable-open.open2-oplock` on **diskfs_io_uring** (already enabled on memfs/cairn): they failed in the matrix run but now pass deterministically — 6/6 runs each under ASan.