### PR TITLE
smb2: don't abort on probeable info classes

### DIFF
--- a/src/server/smb/smb_attr.h
+++ b/src/server/smb/smb_attr.h
@@ -337,6 +337,15 @@ chimera_smb_marshal_attribute_tag_info(
 
     chimera_smb_marshal_basic_attrs(attr, smb_attr);
 
+    /* marshal_basic_attrs only sets a reparse tag for special files; a
+     * regular file or directory is simply not a reparse point, so report
+     * ReparseTag 0 (MS-FSCC 2.4.6) rather than leaving the attribute unset
+     * and tripping the required-attribute assert at append time. */
+    if (!(smb_attr->smb_attr_mask & SMB_ATTR_REPARSE_TAG)) {
+        smb_attr->smb_reparse_tag = 0;
+        smb_attr->smb_attr_mask  |= SMB_ATTR_REPARSE_TAG;
+    }
+
     /* Clear the timestamp masks since we're not including them */
     smb_attr->smb_attr_mask &= ~(SMB_ATTR_CRTTIME | SMB_ATTR_ATIME |
                                  SMB_ATTR_MTIME | SMB_ATTR_CTIME);

--- a/src/server/smb/smb_proc_query_directory.c
+++ b/src/server/smb/smb_proc_query_directory.c
@@ -324,6 +324,24 @@ chimera_smb_query_directory(struct chimera_smb_request *request)
     struct chimera_server_smb_thread *thread = request->compound->thread;
     struct evpl                      *evpl   = thread->evpl;
 
+    /* Validate the client-supplied information class up front.  The readdir
+     * entry marshaller only understands the classes below; anything else
+     * (e.g. smbtorture smb2.scan.find probing all 255 values) must be
+     * answered with STATUS_INVALID_INFO_CLASS, not crash the server when the
+     * first entry is emitted. */
+    switch (request->query_directory.info_class) {
+        case SMB2_FILE_DIRECTORY_INFORMATION:
+        case SMB2_FILE_FULL_DIRECTORY_INFORMATION:
+        case SMB2_FILE_BOTH_DIRECTORY_INFORMATION:
+        case SMB2_FILE_NAMES_INFORMATION:
+        case SMB2_FILE_ID_BOTH_DIRECTORY_INFORMATION:
+        case SMB2_FILE_ID_FULL_DIRECTORY_INFORMATION:
+            break;
+        default:
+            chimera_smb_complete_request(request, SMB2_STATUS_INVALID_INFO_CLASS);
+            return;
+    } /* switch */
+
     request->query_directory.open_file = chimera_smb_open_file_resolve(request, &request->query_directory.file_id);
 
     if (unlikely(!request->query_directory.open_file)) {

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -1570,6 +1570,9 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.rw.rw1
     smb2.rw.rw2
     # smb2.scan
+    smb2.scan.find
+    smb2.scan.getinfo
+    smb2.scan.scan
     smb2.scan.setinfo
     # smb2.secleak
     smb2.secleak
@@ -1912,6 +1915,9 @@ set(SMBTORTURE_ENABLED_linux
     smb2.rw.invalid
     smb2.rw.rw1
     smb2.rw.rw2
+    # smb2.scan
+    smb2.scan.find
+    smb2.scan.scan
     # smb2.secleak
     smb2.secleak
     # smb2.session-id
@@ -2582,6 +2588,9 @@ set(SMBTORTURE_ENABLED_cairn
     smb2.rw.rw1
     smb2.rw.rw2
     # smb2.scan
+    smb2.scan.find
+    smb2.scan.getinfo
+    smb2.scan.scan
     smb2.scan.setinfo
     # smb2.secleak
     smb2.secleak
@@ -2957,6 +2966,9 @@ set(SMBTORTURE_ENABLED_diskfs_io_uring
     smb2.rw.rw1
     smb2.rw.rw2
     # smb2.scan
+    smb2.scan.find
+    smb2.scan.getinfo
+    smb2.scan.scan
     smb2.scan.setinfo
     # smb2.secleak
     smb2.secleak


### PR DESCRIPTION
## Problem

The Samba smbtorture `smb2.scan.*` suite — a client that simply probes the server with every info class / opcode — aborts the chimera server. A malicious (or merely buggy) client can kill the whole daemon, all connections, with one request. Two signatures remain on current main (re-verified empirically on plain `upstream/main` after #715 merged):

1. **`smb2.scan.find`** — fatal `"Unsupported info class N"` at `smb_proc_query_directory.c:165` → SIGABRT. QUERY_DIRECTORY parses fine for any FileInformationClass; the unsupported class is only noticed inside the per-entry readdir marshaller, which `chimera_smb_abort()`s when the first entry is emitted.

2. **`smb2.scan.getinfo`** — fatal `"Missing required attribute tag attributes: mask=40, required=1040"` at `smb_attr.h:632` → SIGABRT. QUERY_INFO `FileAttributeTagInformation` against **any non-reparse-point file or directory** dies: `marshal_basic_attrs` only sets `SMB_ATTR_REPARSE_TAG` for special files (symlink/chr/blk/fifo/sock), so the required-attribute assert in `append_attribute_tag_info` fires at reply-marshalling time.

Both are reachable through perfectly well-formed requests, so the #715 parse hardening does not (and should not) catch them.

A third signature this PR originally fixed — READ/WRITE/CHANGE_NOTIFY pulling their fixed body off the cursor without validating StructureSize, SIGABRT on `smb2.scan.scan`'s 2-byte zero bodies — is now **fully subsumed by #715**, which converted every command parser to bounds-checked `try_*` cursor readers that fail the request with `STATUS_INVALID_PARAMETER`. Verified: `smb2.scan.scan` passes on plain `upstream/main`. The StructureSize checks have been dropped from this PR; it now only enables the test.

## Fix

- `chimera_smb_query_directory()` validates the client's info class at dispatch and answers `STATUS_INVALID_INFO_CLASS` for anything the entry marshaller doesn't implement (the smbtorture scan accepts `INVALID_INFO_CLASS` / `INVALID_PARAMETER` / `NOT_SUPPORTED`). The marshaller's abort stays as a genuine internal invariant.
- `chimera_smb_marshal_attribute_tag_info()` reports `ReparseTag 0` for a non-reparse file (MS-FSCC 2.4.6) instead of leaving the attribute unset and tripping the assert.

Also swept the remaining `vlog_fatal` / `chimera_smb_abort` / `abort()` sites in `src/server/smb/`: the rest are server-side invariants (reply construction over server-owned buffers, refcounts, teardown, crypto-context init) not reachable from client-controlled input, and are left as asserts.

## Verification (Debug/ASan, rebased on current main)

`smb2.scan.find`, `smb2.scan.getinfo`, `smb2.scan.scan`, `smb2.scan.setinfo` run 2x each on memfs, cairn, diskfs_io_uring, plus find/scan 2x on linux — **no server abort in any run**:

| backend | find | getinfo | scan | setinfo |
|---|---|---|---|---|
| memfs | 2/2 PASS | 2/2 PASS | 2/2 PASS | 2/2 PASS |
| cairn | 2/2 PASS | 2/2 PASS | 2/2 PASS | 2/2 PASS |
| diskfs_io_uring | 2/2 PASS | 2/2 PASS | 2/2 PASS | 2/2 PASS |
| linux | 2/2 PASS | FAIL* | 2/2 PASS | FAIL* |

\* pre-existing passthrough issue: `torture_setup_complex_file` fails with `INTERNAL_ERROR` during *test setup* (before any scanning); the server never aborts.

Every passing (test, backend) is added to that backend's `SMBTORTURE_ENABLED_*` allowlist on top of the regenerated lists from #759 (`scan.setinfo` was already enabled on memfs/cairn/diskfs_io_uring/diskfs_aio).

Regression smoke on memfs: consolidated `smbtorture_smb2_dir_memfs` + `smbtorture_smb2_notify_memfs` + `smbtorture_smb2_rw_memfs` ctest cells (the same cells main runs green in CI) — 3/3 PASS, zero new failures vs plain `upstream/main`.
