### PR TITLE
smb2: grant oplocks/leases on all backends

### DIFF
--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -841,10 +841,6 @@ chimera_smb_create_after_share(
         bool                           via_rqls = false;
         struct chimera_vfs_lease      *conflict = NULL;
         enum chimera_vfs_lease_result  result;
-        bool                           durable_request =
-            thread->shared->config.persistent_handles &&
-            (request->create.ctx_present_mask &
-             (CHIMERA_SMB_CREATE_CTX_DHNQ | CHIMERA_SMB_CREATE_CTX_DH2Q)) != 0;
 
         /* Phase 2 of the conflicting-open oplock break.  Phase 1 (the batch /
          * handle-caching break that must precede the share-mode check) already
@@ -920,26 +916,6 @@ chimera_smb_create_after_share(
             request->create.create_disposition == SMB2_FILE_OVERWRITE_IF ||
             request->create.create_disposition == SMB2_FILE_SUPERSEDE;
 
-        /* Only advertise a read-caching oplock on backends that can serve a
-         * server-side copy (FSCTL_SRV_COPYCHUNK -> chimera_vfs_copy_range).
-         * Under a read cache the client offloads copy_file_range to the
-         * server; if the backend can't do server-side copy the client falls
-         * back to a cache-mediated copy that reads stale data (fsx READ BAD
-         * DATA on diskfs/cairn).  Where copy_range is unavailable we leave the
-         * file uncached (write-through), which is correct.
-         *
-         * Durable-aware opens are the exception: MS-SMB2 3.3.5.9 requires a
-         * durable grant to be paired with a batch oplock or HANDLE-caching
-         * lease, and durable-aware clients (WPTS, smbtorture durable suites)
-         * verify that response context on the initial CREATE.  Without a
-         * caching grant the durable request is silently dropped and the suite
-         * fails before it even disconnects.  Durable-aware Windows clients do
-         * not stream copy_file_range through a durable handle, so opting in
-         * for those opens does not re-introduce the fsx hazard. */
-        bool backend_copy_safe =
-            (oh->vfs_module->capabilities & CHIMERA_VFS_CAP_COPY_RANGE) != 0 ||
-            durable_request;
-
         /* An explicitly requested SMB2 lease (RqLs) is acquired even for an
          * attribute-only ("stat") open: a handle/read-caching lease is about the
          * handle, not data access, and such an open is still eligible for a
@@ -953,9 +929,15 @@ chimera_smb_create_after_share(
          * requests no caching bits -- so a re-open under an existing lease key joins
          * (and never downgrades) the shared lease (MS-SMB2 3.3.5.9.8: a lease is not
          * reduced by a subsequent open).  A *fresh* grant is created only when the
-         * open warrants caching (real bits, on a copy-safe backend). */
+         * open warrants caching (real bits).  The grant is backend-independent:
+         * coherence does not rely on the backend serving FSCTL_SRV_COPYCHUNK
+         * (CAP_COPY_RANGE).  A client whose COPYCHUNK is answered NOT_SUPPORTED
+         * falls back to plain READ/WRITE, and those paths (like every other
+         * conflicting open / lock / delete) break conflicting caching holders
+         * via vfs_state before touching data, so the old "uncached unless
+         * copy-capable" rule from the pre-break era is no longer needed. */
         bool want_fresh_caching =
-            (req_vfs != 0 && (caching_touches_data || via_rqls) && backend_copy_safe);
+            (req_vfs != 0 && (caching_touches_data || via_rqls));
 
         if (via_rqls || want_fresh_caching) {
             file_state = chimera_vfs_state_get(vfs_state,

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -2351,6 +2351,10 @@ set(SMBTORTURE_ENABLED_cairn
     smb2.compound.related6
     smb2.compound.related9
     smb2.compound.unrelated1
+    # smb2.compound_async
+    smb2.compound_async.create_lease_break_async
+    smb2.compound_async.rename_last
+    smb2.compound_async.rename_middle
     # smb2.compound_find
     smb2.compound_find.compound_find_close
     smb2.compound_find.compound_find_related
@@ -2444,6 +2448,7 @@ set(SMBTORTURE_ENABLED_cairn
     smb2.durable-v2-open.reopen2b
     smb2.durable-v2-open.reopen2c
     smb2.durable-v2-open.stat-and-lease
+    smb2.durable-v2-open.statRH-and-lease
     smb2.durable-v2-open.two-different-lease
     smb2.durable-v2-open.two-same-lease
     # smb2.durable-v2-regressions
@@ -2503,7 +2508,25 @@ set(SMBTORTURE_ENABLED_cairn
     smb2.ioctl.sparse_set_nobuf
     smb2.ioctl.sparse_set_oversize
     # smb2.kernel-oplocks
+    smb2.kernel-oplocks.kernel_oplocks1
+    smb2.kernel-oplocks.kernel_oplocks3
     smb2.kernel-oplocks.kernel_oplocks8
+    # smb2.lease
+    smb2.lease.duplicate_create
+    smb2.lease.duplicate_open
+    smb2.lease.multibreak
+    smb2.lease.rename_wait
+    smb2.lease.statopen2
+    smb2.lease.statopen3
+    smb2.lease.upgrade
+    smb2.lease.upgrade2
+    smb2.lease.upgrade3
+    smb2.lease.v1_bug15148
+    smb2.lease.v2_bug15148
+    smb2.lease.v2_complex2
+    smb2.lease.v2_epoch1
+    smb2.lease.v2_flags_breaking
+    smb2.lease.v2_flags_parentkey
     # smb2.lock
     smb2.lock.auto-unlock
     smb2.lock.contend
@@ -2559,6 +2582,31 @@ set(SMBTORTURE_ENABLED_cairn
     smb2.notify.tdis1
     # smb2.openattr
     smb2.openattr
+    # smb2.oplock
+    smb2.oplock.batch10
+    smb2.oplock.batch11
+    smb2.oplock.batch12
+    smb2.oplock.batch13
+    smb2.oplock.batch14
+    smb2.oplock.batch15
+    smb2.oplock.batch16
+    smb2.oplock.batch2
+    smb2.oplock.batch21
+    smb2.oplock.batch23
+    smb2.oplock.batch24
+    smb2.oplock.batch25
+    smb2.oplock.batch4
+    smb2.oplock.batch5
+    smb2.oplock.batch8
+    smb2.oplock.brl2
+    smb2.oplock.exclusive1
+    smb2.oplock.exclusive2
+    smb2.oplock.exclusive3
+    smb2.oplock.exclusive4
+    smb2.oplock.exclusive5
+    smb2.oplock.exclusive9
+    smb2.oplock.levelii501
+    smb2.oplock.levelii502
     # smb2.read
     smb2.read.access
     smb2.read.bug14607
@@ -2640,6 +2688,7 @@ set(SMBTORTURE_ENABLED_cairn
     smb2.session.expire2e
     smb2.session.expire2s
     smb2.session.expire_disconnect
+    smb2.session.reauth6
     smb2.session.signing-aes-128-cmac
     smb2.session.signing-aes-128-gmac
     smb2.session.signing-hmac-sha-256
@@ -2725,6 +2774,10 @@ set(SMBTORTURE_ENABLED_diskfs_io_uring
     smb2.compound.related6
     smb2.compound.related9
     smb2.compound.unrelated1
+    # smb2.compound_async
+    smb2.compound_async.create_lease_break_async
+    smb2.compound_async.rename_last
+    smb2.compound_async.rename_middle
     # smb2.compound_find
     smb2.compound_find.compound_find_close
     smb2.compound_find.compound_find_related
@@ -2822,6 +2875,7 @@ set(SMBTORTURE_ENABLED_diskfs_io_uring
     smb2.durable-v2-open.reopen2b
     smb2.durable-v2-open.reopen2c
     smb2.durable-v2-open.stat-and-lease
+    smb2.durable-v2-open.statRH-and-lease
     smb2.durable-v2-open.two-different-lease
     smb2.durable-v2-open.two-same-lease
     # smb2.durable-v2-regressions
@@ -2881,7 +2935,25 @@ set(SMBTORTURE_ENABLED_diskfs_io_uring
     smb2.ioctl.sparse_set_nobuf
     smb2.ioctl.sparse_set_oversize
     # smb2.kernel-oplocks
+    smb2.kernel-oplocks.kernel_oplocks1
+    smb2.kernel-oplocks.kernel_oplocks3
     smb2.kernel-oplocks.kernel_oplocks8
+    # smb2.lease
+    smb2.lease.duplicate_create
+    smb2.lease.duplicate_open
+    smb2.lease.multibreak
+    smb2.lease.rename_wait
+    smb2.lease.statopen2
+    smb2.lease.statopen3
+    smb2.lease.upgrade
+    smb2.lease.upgrade2
+    smb2.lease.upgrade3
+    smb2.lease.v1_bug15148
+    smb2.lease.v2_bug15148
+    smb2.lease.v2_complex2
+    smb2.lease.v2_epoch1
+    smb2.lease.v2_flags_breaking
+    smb2.lease.v2_flags_parentkey
     # smb2.lock
     smb2.lock.auto-unlock
     smb2.lock.contend
@@ -2937,6 +3009,31 @@ set(SMBTORTURE_ENABLED_diskfs_io_uring
     smb2.notify.tdis1
     # smb2.openattr
     smb2.openattr
+    # smb2.oplock
+    smb2.oplock.batch10
+    smb2.oplock.batch11
+    smb2.oplock.batch12
+    smb2.oplock.batch13
+    smb2.oplock.batch14
+    smb2.oplock.batch15
+    smb2.oplock.batch16
+    smb2.oplock.batch2
+    smb2.oplock.batch21
+    smb2.oplock.batch23
+    smb2.oplock.batch24
+    smb2.oplock.batch25
+    smb2.oplock.batch4
+    smb2.oplock.batch5
+    smb2.oplock.batch8
+    smb2.oplock.brl2
+    smb2.oplock.exclusive1
+    smb2.oplock.exclusive2
+    smb2.oplock.exclusive3
+    smb2.oplock.exclusive4
+    smb2.oplock.exclusive5
+    smb2.oplock.exclusive9
+    smb2.oplock.levelii501
+    smb2.oplock.levelii502
     # smb2.read
     smb2.read.access
     smb2.read.bug14607
@@ -3020,6 +3117,7 @@ set(SMBTORTURE_ENABLED_diskfs_io_uring
     smb2.session.expire2s
     smb2.session.expire_disconnect
     smb2.session.ntlmssp_bug14932
+    smb2.session.reauth6
     smb2.session.signing-aes-128-cmac
     smb2.session.signing-aes-128-gmac
     smb2.session.signing-hmac-sha-256
@@ -3105,6 +3203,10 @@ set(SMBTORTURE_ENABLED_diskfs_aio
     smb2.compound.related6
     smb2.compound.related9
     smb2.compound.unrelated1
+    # smb2.compound_async
+    smb2.compound_async.create_lease_break_async
+    smb2.compound_async.rename_last
+    smb2.compound_async.rename_middle
     # smb2.compound_find
     smb2.compound_find.compound_find_close
     smb2.compound_find.compound_find_related
@@ -3199,6 +3301,7 @@ set(SMBTORTURE_ENABLED_diskfs_aio
     smb2.durable-v2-open.reopen2b
     smb2.durable-v2-open.reopen2c
     smb2.durable-v2-open.stat-and-lease
+    smb2.durable-v2-open.statRH-and-lease
     smb2.durable-v2-open.two-different-lease
     smb2.durable-v2-open.two-same-lease
     # smb2.durable-v2-regressions
@@ -3258,7 +3361,25 @@ set(SMBTORTURE_ENABLED_diskfs_aio
     smb2.ioctl.sparse_set_nobuf
     smb2.ioctl.sparse_set_oversize
     # smb2.kernel-oplocks
+    smb2.kernel-oplocks.kernel_oplocks1
+    smb2.kernel-oplocks.kernel_oplocks3
     smb2.kernel-oplocks.kernel_oplocks8
+    # smb2.lease
+    smb2.lease.duplicate_create
+    smb2.lease.duplicate_open
+    smb2.lease.multibreak
+    smb2.lease.rename_wait
+    smb2.lease.statopen2
+    smb2.lease.statopen3
+    smb2.lease.upgrade
+    smb2.lease.upgrade2
+    smb2.lease.upgrade3
+    smb2.lease.v1_bug15148
+    smb2.lease.v2_bug15148
+    smb2.lease.v2_complex2
+    smb2.lease.v2_epoch1
+    smb2.lease.v2_flags_breaking
+    smb2.lease.v2_flags_parentkey
     # smb2.lock
     smb2.lock.auto-unlock
     smb2.lock.contend
@@ -3312,6 +3433,31 @@ set(SMBTORTURE_ENABLED_diskfs_aio
     smb2.notify.tdis1
     # smb2.openattr
     smb2.openattr
+    # smb2.oplock
+    smb2.oplock.batch10
+    smb2.oplock.batch11
+    smb2.oplock.batch12
+    smb2.oplock.batch13
+    smb2.oplock.batch14
+    smb2.oplock.batch15
+    smb2.oplock.batch16
+    smb2.oplock.batch2
+    smb2.oplock.batch21
+    smb2.oplock.batch23
+    smb2.oplock.batch24
+    smb2.oplock.batch25
+    smb2.oplock.batch4
+    smb2.oplock.batch5
+    smb2.oplock.batch8
+    smb2.oplock.brl2
+    smb2.oplock.exclusive1
+    smb2.oplock.exclusive2
+    smb2.oplock.exclusive3
+    smb2.oplock.exclusive4
+    smb2.oplock.exclusive5
+    smb2.oplock.exclusive9
+    smb2.oplock.levelii501
+    smb2.oplock.levelii502
     # smb2.read
     smb2.read.access
     smb2.read.bug14607
@@ -3393,6 +3539,7 @@ set(SMBTORTURE_ENABLED_diskfs_aio
     smb2.session.expire2e
     smb2.session.expire2s
     smb2.session.expire_disconnect
+    smb2.session.reauth6
     smb2.session.signing-aes-128-cmac
     smb2.session.signing-aes-128-gmac
     smb2.session.signing-hmac-sha-256


### PR DESCRIPTION
A full smbtorture matrix run had ~38 lease/oplock subtests passing on memfs but failing on cairn/diskfs_io_uring/diskfs_aio with no lease/oplock granted at all (lease_state 0x0 / oplock_level NONE).

## Root cause

The CREATE path gated every fresh caching grant on `CHIMERA_VFS_CAP_COPY_RANGE` (`backend_copy_safe`, from the original oplock enablement #325): only backends able to serve FSCTL_SRV_COPYCHUNK could hand out read-caching oplocks, so a cifs client could never fall back from COPYCHUNK to a cache-mediated copy reading stale data. cairn/diskfs declare no such cap, so legacy-oplock opens never entered the grant block and RqLs opens got state NONE.

The rule predates the unified lease/break machinery: every conflicting open/read/write/lock/delete now breaks conflicting caching holders through vfs_state (range_io_conflict in the READ/WRITE paths, the phase-1/2 create breaks, copychunk/unlink/rename breaks), so the NOT_SUPPORTED -> plain-READ/WRITE fallback is coherent and the gate is vestigial -- its `durable_request` exemption was already granting (and breaking) leases on these backends. Drop it; a fresh caching grant depends only on the requested bits and the data-access/disposition rule.

## Relation to #767

Granting durable handles on these backends also exposed a pre-existing durable-reconnect-vs-disconnect-teardown race (the DH2C/DHnC CREATE could be processed on the new connection's thread before the old connection's teardown parked the handle). An earlier revision of this PR carried a defer-based fix for that race; it has been dropped: the race was fixed independently on the reclaim side by #767 (retry the claim on a 20 ms timer behind a STATUS_PENDING interim), and this change is rebased on and re-verified on top of that fix -- `CHIMERA_SMB_TEST_DISCONNECT_DELAY_MS=50` with smb2.durable-v2-open.statRH-and-lease / smb2.durable-open.lease / smb2.durable-open.oplock passes repeatedly on memfs and diskfs_aio, so the new grants and the retry-based reclaim compose cleanly.

## Enabled tests

Enables 46 subtests each on cairn / diskfs_io_uring / diskfs_aio (138 allowlist entries): smb2.oplock batch/exclusive/levelii/brl2, smb2.lease statopen / upgrade / multibreak / duplicate / v2_*, smb2.compound_async, smb2.kernel-oplocks 1+3, smb2.durable-v2-open.statRH-and-lease, smb2.session.reauth6.

Verification on top of #767 (Debug/ASan): smb2.lease.statopen2, smb2.oplock.batch2, smb2.oplock.exclusive1, smb2.kernel-oplocks.kernel_oplocks1, smb2.durable-v2-open.statRH-and-lease 2x each on cairn, diskfs_io_uring and diskfs_aio -- all pass; disconnect-race set at 50 ms 2x each on memfs and diskfs_aio -- all pass; memfs lease/oplock spot-check -- no regressions.
