### PR TITLE
nfs/client: bounds-check upstream file handle before re-encoding (V-001)

### DIFF
--- a/src/nfs_common/CMakeLists.txt
+++ b/src/nfs_common/CMakeLists.txt
@@ -84,3 +84,5 @@ install(TARGETS chimera_nfs_common DESTINATION lib)
 
 # Ensure xdrzcc is built before these libraries
 add_dependencies(chimera_nfs_common xdrzcc)
+
+add_subdirectory(tests)

--- a/src/nfs_common/nfs3_attr.h
+++ b/src/nfs_common/nfs3_attr.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -291,7 +291,25 @@ chimera_nfs3_unmarshall_attrs(
     attr->va_set_mask |= CHIMERA_NFS3_ATTR_MASK | CHIMERA_VFS_ATTR_FSID | CHIMERA_VFS_ATTR_ATOMIC;
 } /* chimera_nfs3_unmarshall_attrs */
 
-static inline void
+/*
+ * Re-encode an upstream NFSv3 file handle into a chimera proxy handle:
+ * [server_index][remote_fh_data] prefixed with the parent's mount id.
+ *
+ * fh->data is server-supplied (this is the NFS *client* module parsing a
+ * backend server's reply) and bounded only by the wire frame, NOT by the
+ * NFS3_FHSIZE the schema declares -- the generated XDR decoder does not enforce
+ * the `<NFS3_FHSIZE>` bound.  The local `fragment` buffer holds the 1-byte
+ * server index plus the handle data, so the handle must be small enough that
+ * 1 + fh->data.len fits in CHIMERA_VFS_FH_SIZE (which also keeps the subsequent
+ * encode into the larger attr->va_fh in bounds).  An oversized handle -- a
+ * malformed/malicious server, or simply a backend whose handles are larger than
+ * chimera can represent -- is rejected rather than overflowing the stack buffer.
+ *
+ * Returns 0 on success (ATTR_FH set), -1 if the handle does not fit (ATTR_FH
+ * left unset; the caller fails the operation with EOVERFLOW, or omits the
+ * handle for an optional readdir entry).
+ */
+static inline int
 chimera_nfs3_unmarshall_fh(
     const struct nfs_fh3     *fh,
     int                       server_index,
@@ -301,6 +319,11 @@ chimera_nfs3_unmarshall_fh(
     uint8_t fragment[CHIMERA_VFS_FH_SIZE];
     int     fragment_len;
 
+    /* 1 (server_index) + data must fit the fragment buffer. */
+    if (fh->data.len > CHIMERA_VFS_FH_SIZE - 1) {
+        return -1;
+    }
+
     /* Build fh_fragment: [server_index][remote_fh_data] */
     fragment[0] = server_index;
     memcpy(fragment + 1, fh->data.data, fh->data.len);
@@ -308,6 +331,7 @@ chimera_nfs3_unmarshall_fh(
 
     attr->va_set_mask |= CHIMERA_VFS_ATTR_FH;
     attr->va_fh_len    = chimera_vfs_encode_fh_parent(parent_fh, fragment, fragment_len, attr->va_fh);
+    return 0;
 } /* chimera_nfs3_unmarshall_fh */
 
 

--- a/src/nfs_common/tests/CMakeLists.txt
+++ b/src/nfs_common/tests/CMakeLists.txt
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+#
+# SPDX-License-Identifier: LGPL-2.1-only
+
+add_executable(nfs3_fh_test nfs3_fh_test.c)
+# Header-only logic (chimera_nfs3_unmarshall_fh + chimera_vfs_encode_fh_parent
+# are static inline), but it needs the generated nfs3_xdr.h for struct nfs_fh3.
+target_include_directories(nfs3_fh_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/..
+    ${CMAKE_CURRENT_BINARY_DIR}/..)
+add_dependencies(nfs3_fh_test chimera_nfs_common)
+add_test(chimera/nfs_common/fh_test nfs3_fh_test)

--- a/src/nfs_common/tests/nfs3_fh_test.c
+++ b/src/nfs_common/tests/nfs3_fh_test.c
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * Regression test for chimera_nfs3_unmarshall_fh (nfs3_attr.h).
+ *
+ * The proxy NFSv3 client re-encodes a backend server's file handle into a
+ * chimera handle.  The server-supplied length is NOT bounded by the generated
+ * XDR decoder, so an oversized handle must be rejected rather than overflowing
+ * the fixed-size fragment / va_fh buffers (the V-001 report).  This pins:
+ *   - data.len within capacity  -> returns 0, ATTR_FH set, bytes copied intact
+ *   - data.len at the boundary  -> the largest accepted len is FH_SIZE-1
+ *   - data.len over capacity    -> returns -1, ATTR_FH NOT set, no write past
+ *                                  the destination (verified with a canary)
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#undef NDEBUG
+#include <assert.h>
+
+#include "nfs3_attr.h"
+
+/* attrs wrapped in a canary-guarded struct: chimera_nfs3_unmarshall_fh writes
+ * into attr.va_fh (the largest sink in the encode chain), so a guard page of
+ * known bytes immediately after the attrs catches any over-write. */
+struct guarded_attrs {
+    struct chimera_vfs_attrs attr;
+    uint8_t                  canary[64];
+};
+
+static void
+reset_guard(struct guarded_attrs *g)
+{
+    memset(g, 0, sizeof(*g));
+    memset(g->canary, 0xAB, sizeof(g->canary));
+} /* reset_guard */
+
+static void
+check_canary(const struct guarded_attrs *g)
+{
+    for (size_t i = 0; i < sizeof(g->canary); i++) {
+        assert(g->canary[i] == 0xAB && "destination buffer overflow");
+    }
+} /* check_canary */
+
+int
+main(void)
+{
+    /* A valid parent handle: 16-byte mount id is all encode_fh_parent reads. */
+    uint8_t        parent_fh[CHIMERA_VFS_FH_SIZE + 16];
+
+    memset(parent_fh, 0x11, sizeof(parent_fh));
+
+    /* Backing store for the server-supplied handle data, larger than any
+    * length we test so data.data is always valid memory to copy from. */
+    static uint8_t fh_data[1024];
+
+    memset(fh_data, 0x55, sizeof(fh_data));
+
+    const uint32_t max_ok = CHIMERA_VFS_FH_SIZE - 1; /* largest accepted len */
+
+    /*
+     * (len, expect_ok) cases spanning over / boundary / valid:
+     *   1024        far oversized -- would smash the stack fragment
+     *   256         oversized
+     *   max_ok + 1  one byte over the boundary
+     *   max_ok      exactly the largest that fits
+     *   32          comfortably valid
+     *   1           minimal
+     *   0           empty handle
+     */
+    /* *INDENT-OFF* */ /* uncrustify oscillates on aligned struct-init tables */
+    struct {
+        uint32_t len;
+        int      expect_ok;
+    } cases[] = {
+        { 1024,       0 },
+        { 256,        0 },
+        { max_ok + 1, 0 },
+        { max_ok,     1 },
+        { 32,         1 },
+        { 1,          1 },
+        { 0,          1 },
+    };
+    /* *INDENT-ON* */
+    int ncases = (int) (sizeof(cases) / sizeof(cases[0]));
+
+    for (int i = 0; i < ncases; i++) {
+        struct guarded_attrs g;
+        struct nfs_fh3       fh;
+        int                  rc;
+
+        reset_guard(&g);
+
+        fh.data.len  = cases[i].len;
+        fh.data.data = fh_data;
+
+        rc = chimera_nfs3_unmarshall_fh(&fh, 7 /*server_index*/, parent_fh, &g.attr);
+
+        /* No path may ever write past the destination. */
+        check_canary(&g);
+
+        if (cases[i].expect_ok) {
+            assert(rc == 0);
+            /* ATTR_FH must be set and the encoded length consistent with
+             * mount_id(16) + server_index(1) + data.len. */
+            assert(g.attr.va_set_mask & CHIMERA_VFS_ATTR_FH);
+            assert(g.attr.va_fh_len == 16 + 1 + cases[i].len);
+            /* server_index then the handle bytes land after the mount id. */
+            assert(g.attr.va_fh[16] == 7);
+            for (uint32_t b = 0; b < cases[i].len; b++) {
+                assert(g.attr.va_fh[16 + 1 + b] == 0x55);
+            }
+        } else {
+            assert(rc == -1);
+            /* Rejected: the FH attribute must be left unset so the caller
+             * fails the op (or omits the readdir entry's handle). */
+            assert(!(g.attr.va_set_mask & CHIMERA_VFS_ATTR_FH));
+        }
+
+        printf("len=%-5u expect_ok=%d rc=%d OK\n",
+               cases[i].len, cases[i].expect_ok, rc);
+    }
+
+    printf("nfs3_fh_test: all cases passed\n");
+    return 0;
+} /* main */

--- a/src/vfs/nfs/nfs3_lookup_at.c
+++ b/src/vfs/nfs/nfs3_lookup_at.c
@@ -38,7 +38,12 @@ chimera_nfs3_lookup_callback(
         return;
     }
 
-    chimera_nfs3_unmarshall_fh(&res->resok.object, ctx->server->index, request->fh, &request->lookup_at.r_attr);
+    if (chimera_nfs3_unmarshall_fh(&res->resok.object, ctx->server->index, request->fh, &request->lookup_at.r_attr) != 0
+        ) {
+        request->status = CHIMERA_VFS_EOVERFLOW;
+        request->complete(request);
+        return;
+    }
 
     if (res->resok.obj_attributes.attributes_follow) {
         chimera_nfs3_unmarshall_attrs(&res->resok.obj_attributes.attributes, &request->lookup_at.r_attr);

--- a/src/vfs/nfs/nfs3_mkdir_at.c
+++ b/src/vfs/nfs/nfs3_mkdir_at.c
@@ -38,7 +38,12 @@ chimera_nfs3_mkdir_callback(
         return;
     }
 
-    chimera_nfs3_unmarshall_fh(&res->resok.obj.handle, ctx->server->index, request->fh, &request->mkdir_at.r_attr);
+    if (chimera_nfs3_unmarshall_fh(&res->resok.obj.handle, ctx->server->index, request->fh, &request->mkdir_at.r_attr)
+        != 0) {
+        request->status = CHIMERA_VFS_EOVERFLOW;
+        request->complete(request);
+        return;
+    }
 
     if (res->resok.obj_attributes.attributes_follow) {
         chimera_nfs3_unmarshall_attrs(&res->resok.obj_attributes.attributes, &request->mkdir_at.r_attr);

--- a/src/vfs/nfs/nfs3_mknod_at.c
+++ b/src/vfs/nfs/nfs3_mknod_at.c
@@ -38,7 +38,12 @@ chimera_nfs3_mknod_callback(
         return;
     }
 
-    chimera_nfs3_unmarshall_fh(&res->resok.obj.handle, ctx->server->index, request->fh, &request->mknod_at.r_attr);
+    if (chimera_nfs3_unmarshall_fh(&res->resok.obj.handle, ctx->server->index, request->fh, &request->mknod_at.r_attr)
+        != 0) {
+        request->status = CHIMERA_VFS_EOVERFLOW;
+        request->complete(request);
+        return;
+    }
 
     if (res->resok.obj_attributes.attributes_follow) {
         chimera_nfs3_unmarshall_attrs(&res->resok.obj_attributes.attributes, &request->mknod_at.r_attr);

--- a/src/vfs/nfs/nfs3_open_at.c
+++ b/src/vfs/nfs/nfs3_open_at.c
@@ -51,7 +51,12 @@ chimera_nfs3_open_at_lookup_callback(
         chimera_nfs3_unmarshall_attrs(&res->resok.dir_attributes.attributes, &request->open_at.r_dir_post_attr);
     }
 
-    chimera_nfs3_unmarshall_fh(&res->resok.object, ctx->server->index, request->fh, &request->open_at.r_attr);
+    if (chimera_nfs3_unmarshall_fh(&res->resok.object, ctx->server->index, request->fh, &request->open_at.r_attr) != 0)
+    {
+        request->status = CHIMERA_VFS_EOVERFLOW;
+        request->complete(request);
+        return;
+    }
 
     /* Allocate open state for dirty tracking and silly rename support.
      * Skip for inferred opens (use synthetic handles which don't call close).
@@ -109,7 +114,12 @@ chimera_nfs3_open_at_create_callback(
         chimera_nfs3_unmarshall_attrs(&res->resok.obj_attributes.attributes, &request->open_at.r_attr);
     }
 
-    chimera_nfs3_unmarshall_fh(&res->resok.obj.handle, ctx->server->index, request->fh, &request->open_at.r_attr);
+    if (chimera_nfs3_unmarshall_fh(&res->resok.obj.handle, ctx->server->index, request->fh, &request->open_at.r_attr) !=
+        0) {
+        request->status = CHIMERA_VFS_EOVERFLOW;
+        request->complete(request);
+        return;
+    }
 
     chimera_nfs3_get_wcc_data(&request->open_at.r_dir_pre_attr, &request->open_at.r_dir_post_attr, &res->resok.dir_wcc);
 

--- a/src/vfs/nfs/nfs3_readdir.c
+++ b/src/vfs/nfs/nfs3_readdir.c
@@ -58,7 +58,11 @@ chimera_nfs3_readdir_callback(
         attrs.va_set_mask = 0;
 
         if (entry->name_handle.handle_follows) {
-            chimera_nfs3_unmarshall_fh(&entry->name_handle.handle, ctx->server->index, request->fh, &attrs);
+            /* An entry whose upstream handle is too large to re-encode is
+             * emitted without a handle (ATTR_FH left unset) rather than
+             * aborting the whole listing -- the same as an entry the server
+             * sent with handle_follows == false. */
+            (void) chimera_nfs3_unmarshall_fh(&entry->name_handle.handle, ctx->server->index, request->fh, &attrs);
         }
 
         if (entry->name_attributes.attributes_follow) {

--- a/src/vfs/nfs/nfs3_symlink_at.c
+++ b/src/vfs/nfs/nfs3_symlink_at.c
@@ -42,8 +42,12 @@ chimera_nfs3_symlink_callback(
                               dir_wcc);
 
     if (res->resok.obj.handle_follows) {
-        chimera_nfs3_unmarshall_fh(&res->resok.obj.handle, ctx->server->index, request->fh, &request->symlink_at.r_attr)
-        ;
+        if (chimera_nfs3_unmarshall_fh(&res->resok.obj.handle, ctx->server->index, request->fh,
+                                       &request->symlink_at.r_attr) != 0) {
+            request->status = CHIMERA_VFS_EOVERFLOW;
+            request->complete(request);
+            return;
+        }
     }
 
     if (res->resok.obj_attributes.attributes_follow) {


### PR DESCRIPTION
## Summary

Properly fixes the `nfs3_attr.h` file-handle overflow reported in #726 (V-001), with a real regression test, and corrects the threat model / handling that PR's auto-generated fix got wrong.

## The bug

`chimera_nfs3_unmarshall_fh` re-encodes a backend NFSv3 server's file handle into a chimera proxy handle:

```c
uint8_t fragment[CHIMERA_VFS_FH_SIZE];          /* 48 bytes */
fragment[0] = server_index;
memcpy(fragment + 1, fh->data.data, fh->data.len);   /* unchecked */
```

`fh->data` comes from an **upstream NFS server's reply** (this is the NFS *client*/proxy module — every caller is in `src/vfs/nfs/`). Its length is **not** bounded by the generated XDR decoder: `__unmarshall_opaque_vector`/`_contig` take the `<NFS3_FHSIZE>` bound as a parameter and never compare it against the wire length. So `fh->data.len` is whatever the server sent, and anything `≥ 48` overruns the stack buffer (and the subsequent encode into `attr->va_fh`).

## What #726 got wrong

- **Threat model is backwards.** It claims "an attacker crafts a malicious NFS *request*… RCE." This code never parses client requests — it parses *server responses*. The attacker is a compromised/hostile backend server or a MITM on the proxy↔backend link. Real OOB write, but not unauthenticated-client RCE.
- **Silent drop.** Its fix `return`s on overflow, leaving the result-handle callers (lookup/open/mkdir/…) to report a *successful* operation with no file handle — a latent correctness bug.
- **Placeholder test.** The included test asserts a tautology, never calls the function, and uses a bogus `#include "src/..."` path.

## This fix

- Reject a handle that doesn't fit (`1 + data.len > CHIMERA_VFS_FH_SIZE`) instead of copying it; the function returns `-1` and leaves `ATTR_FH` unset.
- The five result-handle callers (lookup, open create+lookup, mkdir, mknod, symlink) fail the op with `EOVERFLOW`; **readdir** omits just that entry's handle (same as the server sending `handle_follows == false`) rather than aborting the whole listing.
- Adds `src/nfs_common/tests/nfs3_fh_test.c` — a canary-guarded unit test over oversized / boundary / valid lengths. Verified it **aborts on the pre-fix code** (canary clobbered) and passes with the guard.

## Scope note

The deeper root cause — the XDR generator ignoring its declared `<N>` bound — is worth fixing for defense-in-depth across every bounded opaque/string in the NFS protocols, but it does **not** by itself close this site: `CHIMERA_VFS_FH_SIZE (48) < NFS3_FHSIZE (64)`, so even a protocol-legal 64-byte handle overflows the 48-byte destination and the caller-side check is required regardless. I'd track the xdrzcc hardening separately.

Closes #726.