### PR TITLE
smb2: session re-authentication and multichannel binding

### DIFF
--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -339,28 +339,24 @@ chimera_smb_compound_reply(struct chimera_smb_compound *compound)
             request->flags |= CHIMERA_SMB_REQUEST_FLAG_SIGN;
         }
 
-        /* The final SESSION_SETUP response that establishes an authenticated
-         * session MUST be signed once a signing key exists, even when signing
-         * is only enabled (not required). SMB 3.x clients verify this response
-         * to confirm the server holds the session key; for SMB 3.1.1 it also
-         * binds the preauth-integrity hash. */
+        /* Every SESSION_SETUP response that involves an AUTHORIZED session is
+         * signed once a signing key exists, even when signing is only enabled
+         * (not required):
+         *   - the final response that establishes the session — SMB 3.x
+         *     clients verify it to confirm the server holds the session key,
+         *     and for 3.1.1 it binds the preauth-integrity hash;
+         *   - every leg of a channel bind (MS-SMB2 3.3.5.5.3): the client
+         *     signs the binding request with the existing session key and
+         *     requires interim, error and final responses signed —
+         *     session_handle->signing_key holds the session key on
+         *     interim/error legs and the newly derived per-channel key on the
+         *     final SUCCESS leg (an unsigned response is treated as
+         *     STATUS_ACCESS_DENIED);
+         *   - every leg of a re-authentication on a live session, which the
+         *     client likewise verifies with the unchanged session key.
+         * An initial authentication's interim legs are excluded because the
+         * session is only authorized once its final leg succeeds. */
         if (request->smb2_hdr.command == SMB2_SESSION_SETUP &&
-            request->status == SMB2_STATUS_SUCCESS &&
-            request->session_handle &&
-            (request->session_handle->session->flags & CHIMERA_SMB_SESSION_AUTHORIZED)) {
-            request->flags |= CHIMERA_SMB_REQUEST_FLAG_SIGN;
-        }
-
-        /* SMB3 multichannel session binding (MS-SMB2 3.3.5.5.3): the client
-         * signs the binding SESSION_SETUP request with the existing session key
-         * and requires every response on that exchange -- interim, final, or
-         * error -- to be signed.  Sign with session_handle->signing_key, which
-         * holds the established session's key on the interim/error legs and the
-         * newly derived per-channel key on the final SUCCESS leg.  Without this
-         * the client rejects the bind (an unsigned response is treated as
-         * STATUS_ACCESS_DENIED). */
-        if (request->smb2_hdr.command == SMB2_SESSION_SETUP &&
-            (request->session_setup.flags & SMB2_SESSION_FLAG_BINDING) &&
             request->session_handle &&
             (request->session_handle->session->flags & CHIMERA_SMB_SESSION_AUTHORIZED)) {
             request->flags |= CHIMERA_SMB_REQUEST_FLAG_SIGN;
@@ -523,6 +519,16 @@ chimera_smb_compound_reply(struct chimera_smb_compound *compound)
     if (compound->num_requests > 0 &&
         (compound->requests[0]->smb2_hdr.command == SMB2_NEGOTIATE ||
          compound->requests[0]->smb2_hdr.command == SMB2_SESSION_SETUP)) {
+
+        /* Track whether a multi-leg SESSION_SETUP exchange is in flight: the
+         * next SESSION_SETUP that arrives with this clear starts a NEW
+         * authentication exchange and restarts the preauth-integrity hash from
+         * the post-NEGOTIATE baseline (see the request-fold path).  Only an
+         * interim MORE_PROCESSING_REQUIRED leg leaves the exchange open. */
+        if (compound->requests[0]->smb2_hdr.command == SMB2_SESSION_SETUP) {
+            conn->session_setup_in_progress =
+                (compound->requests[0]->status == SMB2_STATUS_MORE_PROCESSING_REQUIRED);
+        }
 
         /* A SESSION_SETUP that completes with a hard error contributes nothing
          * to the preauth-integrity hash: the client folds a SESSION_SETUP
@@ -1193,7 +1199,20 @@ chimera_smb_server_handle_smb2(
                     request->session_handle = session_handle;
                 } else {
 
-                    session = chimera_smb_session_lookup(thread->shared, request->smb2_hdr.session_id);
+                    /* Only a SESSION_SETUP (a channel bind, or a re-auth /
+                     * reconnect probe the handler answers per MS-SMB2) may
+                     * adopt a session from the GLOBAL table onto this
+                     * connection: the attached handle carries the session's
+                     * signing key so the exchange's responses can be signed
+                     * (Samba bug 14512).  Any other command referencing a
+                     * session with no channel on this connection is answered
+                     * USER_SESSION_DELETED without taking a session reference
+                     * — a parasitic reference here would keep a dying
+                     * session's opens alive after its real channels are gone
+                     * (smb2.session.bind2). */
+                    session = request->smb2_hdr.command == SMB2_SESSION_SETUP ?
+                        chimera_smb_session_lookup(thread->shared, request->smb2_hdr.session_id) :
+                        NULL;
 
                     if (session) {
                         session_handle = chimera_smb_session_handle_alloc(thread);
@@ -1246,6 +1265,23 @@ chimera_smb_server_handle_smb2(
         if (unlikely(request->session_handle &&
                      (request->session_handle->session->flags &
                       CHIMERA_SMB_SESSION_DELETED))) {
+            request->session_handle                      = NULL;
+            request->status                              = SMB2_STATUS_USER_SESSION_DELETED;
+            request->flags                              |= CHIMERA_SMB_REQUEST_FLAG_PARSE_FAILED;
+            compound->requests[compound->num_requests++] = request;
+            goto next_compound_request;
+        }
+
+        /* A session that exists globally but has no channel on THIS connection
+         * (the handle was attached by the global-session lookup above, e.g.
+         * for a channel bind in progress or one that failed) may only be
+         * referenced by SESSION_SETUP.  Any other command through such a
+         * handle is answered STATUS_USER_SESSION_DELETED without touching the
+         * session (MS-SMB2 3.3.5.2.9; Samba bug 14512 / smbtorture
+         * smb2.session.bind_invalid_auth's "unlink on invalid channel"). */
+        if (unlikely(request->session_handle &&
+                     !request->session_handle->is_channel &&
+                     request->smb2_hdr.command != SMB2_SESSION_SETUP)) {
             request->session_handle                      = NULL;
             request->status                              = SMB2_STATUS_USER_SESSION_DELETED;
             request->flags                              |= CHIMERA_SMB_REQUEST_FLAG_PARSE_FAILED;
@@ -1465,19 +1501,24 @@ chimera_smb_server_handle_smb2(
      * handler derives the signing key over a hash that includes this request.
      * Maintained unconditionally for these commands; only consumed at 3.1.1.
      *
-     * A SESSION_SETUP whose header SessionId is 0 starts a brand-new
-     * authentication (the first leg of a new session, including a re-auth
-     * after LOGOFF on the same connection).  Per MS-SMB2 3.3.5.5.3 that
-     * session's preauth hash restarts from the post-NEGOTIATE baseline, not
-     * from whatever earlier sessions accumulated -- otherwise the signing key
-     * is derived over the wrong hash and the client rejects the session. */
+     * A SESSION_SETUP that is not a continuation leg of an in-flight exchange
+     * starts a brand-new authentication: the first leg of a new session
+     * (header SessionId 0, including a re-auth after LOGOFF on the same
+     * connection), and equally the first leg of a channel bind or of a
+     * re-authentication, which carry the EXISTING session's id.  Per MS-SMB2
+     * 3.3.5.5.3 that exchange's preauth hash restarts from the post-NEGOTIATE
+     * baseline, not from whatever earlier exchanges accumulated -- otherwise
+     * the signing key is derived over the wrong hash and the client rejects
+     * the session (a bound channel's signing key would chain over the
+     * connection's previous session setups, which the client never folds). */
     if (compound->num_requests > 0 &&
         (compound->requests[0]->smb2_hdr.command == SMB2_NEGOTIATE ||
          compound->requests[0]->smb2_hdr.command == SMB2_SESSION_SETUP)) {
         uint8_t *msg = malloc(length);
         if (msg) {
             if (compound->requests[0]->smb2_hdr.command == SMB2_SESSION_SETUP &&
-                compound->requests[0]->smb2_hdr.session_id == 0) {
+                (compound->requests[0]->smb2_hdr.session_id == 0 ||
+                 !conn->session_setup_in_progress)) {
                 memcpy(conn->preauth_hash, conn->negotiate_preauth_hash,
                        sizeof(conn->preauth_hash));
             }
@@ -2027,8 +2068,9 @@ chimera_smb_server_accept(
     /* SMB 3.1.1 preauth-integrity hash starts at zero for each connection. */
     memset(conn->preauth_hash, 0, sizeof(conn->preauth_hash));
     memset(conn->negotiate_preauth_hash, 0, sizeof(conn->negotiate_preauth_hash));
-    conn->rdma_niov   = 0;
-    conn->rdma_length = 0;
+    conn->session_setup_in_progress = 0;
+    conn->rdma_niov                 = 0;
+    conn->rdma_length               = 0;
     /* Conns are pooled; clear per-connection negotiate state so the
     * "NEGOTIATE after NEGOTIATE" guard (MS-SMB2 3.3.5.4) does not trip on
     * a dialect inherited from a previously torn-down connection. */

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -873,6 +873,15 @@ struct chimera_smb_session_handle {
      * existing session (a successful SMB2_SESSION_FLAG_BINDING session setup),
      * so its teardown decrements session->num_channels. */
     uint8_t                            bound_channel;
+    /* Set when this connection legitimately owns a channel of the session:
+     * either the session was established (or re-authenticated) on this
+     * connection, or a SMB2_SESSION_FLAG_BINDING session setup completed here.
+     * A handle attached by the dispatcher's global-session lookup (so a
+     * binding SESSION_SETUP can be resolved and its responses signed with the
+     * session key) starts at 0; any non-SESSION_SETUP request arriving through
+     * such a handle is answered STATUS_USER_SESSION_DELETED (MS-SMB2
+     * 3.3.5.2.9, Samba bug 14512). */
+    uint8_t                            is_channel;
     struct UT_hash_handle              hh;
     struct chimera_smb_session_handle *next;
     gss_ctx_id_t                       ctx;
@@ -947,6 +956,14 @@ struct chimera_smb_conn {
      * to this snapshot so the next, successful leg derives its signing key over
      * the same hash the client used. */
     uint8_t                            preauth_hash_presession[SMB2_PREAUTH_HASH_SIZE];
+    /* Set while a multi-leg SESSION_SETUP exchange is in flight on this
+     * connection (the previous SESSION_SETUP response was
+     * STATUS_MORE_PROCESSING_REQUIRED).  A SESSION_SETUP arriving with this
+     * clear starts a NEW authentication exchange, so its preauth-integrity
+     * hash restarts from the post-NEGOTIATE baseline even when the header
+     * carries a non-zero SessionId — a channel-binding or re-authentication
+     * first leg does (MS-SMB2 3.3.5.5.3). */
+    uint8_t                            session_setup_in_progress;
     uint32_t                           requests_completed;
     /* Lifecycle generation for pooled conns: bumped in chimera_smb_conn_free,
      * snapshotted into each compound at creation (conn_generation).  A
@@ -1645,6 +1662,7 @@ chimera_smb_session_handle_alloc(struct chimera_server_smb_thread *thread)
     }
 
     session_handle->bound_channel = 0;
+    session_handle->is_channel    = 0;
 
     return session_handle;
 } /* chimera_smb_session_handle_alloc */

--- a/src/server/smb/smb_ntlm.c
+++ b/src/server/smb/smb_ntlm.c
@@ -699,6 +699,51 @@ validate_local_user(
 } /* validate_local_user */
 
 // Validate AUTHENTICATE message
+/* Validate the structure of an NTLMv2 response: 16-byte NTProofStr followed by
+ * an NTLMv2_CLIENT_CHALLENGE — RespType(1)=1, HiRespType(1)=1, Reserved1(2),
+ * Reserved2(4), TimeStamp(8), ChallengeFromClient(8), Reserved3(4), then an
+ * AvPair list that must terminate with MsvAvEOL (id 0, len 0) inside the
+ * buffer.  Trailing bytes after MsvAvEOL (clients commonly pad 4 zero bytes)
+ * are tolerated.  Returns 0 when well-formed, -1 otherwise. */
+static int
+validate_ntlmv2_response_format(
+    const uint8_t *nt_response,
+    size_t         nt_response_len)
+{
+    const uint8_t *temp;
+    size_t         temp_len, off;
+
+    if (nt_response_len < 16 + 28 + 4) {
+        return -1;
+    }
+
+    temp     = nt_response + 16;
+    temp_len = nt_response_len - 16;
+
+    if (temp[0] != 1 || temp[1] != 1) {
+        return -1;
+    }
+
+    off = 28; /* start of AvPairs */
+
+    while (off + 4 <= temp_len) {
+        uint16_t av_id  = temp[off] | (temp[off + 1] << 8);
+        uint16_t av_len = temp[off + 2] | (temp[off + 3] << 8);
+
+        if (av_id == 0 && av_len == 0) {
+            return 0; /* MsvAvEOL */
+        }
+
+        if (off + 4 + (size_t) av_len > temp_len) {
+            return -1;
+        }
+
+        off += 4 + av_len;
+    }
+
+    return -1;
+} /* validate_ntlmv2_response_format */
+
 static int
 validate_authenticate(
     struct smb_ntlm_ctx                  *ctx,
@@ -758,7 +803,7 @@ validate_authenticate(
     memcpy(&nt_response_len, buf + 20, 2);
     memcpy(&nt_response_offset, buf + 24, 4);
 
-    if (nt_response_len < 24 || nt_response_offset + nt_response_len > buf_len) {
+    if (nt_response_offset + nt_response_len > buf_len) {
         smb_ntlm_error("NTLM: Invalid NT response field");
         goto cleanup;
     }
@@ -784,6 +829,44 @@ validate_authenticate(
             enc_session_key     = buf + eskey_offset;
             enc_session_key_len = eskey_len;
         }
+    }
+
+    /* Anonymous (null-session) AUTHENTICATE (MS-NLMP 3.2.5.1.2): the
+    * NTLMSSP_NEGOTIATE_ANONYMOUS flag is set and the NtChallengeResponse is
+    * empty (the LmChallengeResponse is a single zero byte or empty).  No
+    * password proof to validate and no usable session key; the SMB layer
+    * decides whether an anonymous logon is acceptable in context. */
+    if ((negotiate_flags & NTLMSSP_NEGOTIATE_ANONYMOUS) && nt_response_len == 0) {
+        ctx->username[0] = '\0';
+        ctx->domain[0]   = '\0';
+        ctx->sid[0]      = '\0';
+        ctx->uid         = 65534;
+        ctx->gid         = 65534;
+        ctx->ngids       = 0;
+        memset(ctx->session_key, 0, sizeof(ctx->session_key));
+        ctx->authenticated = 1;
+        ctx->is_anonymous  = 1;
+        smb_ntlm_info("NTLM: Anonymous logon");
+        result = 0;
+        goto cleanup;
+    }
+
+    if (nt_response_len < 24) {
+        smb_ntlm_error("NTLM: Invalid NT response field");
+        goto cleanup;
+    }
+
+    /* An NTLMv2 response (anything longer than the 24-byte NTLMv1 proof) must
+     * be structurally valid: NTProofStr(16) followed by an NTLMv2_CLIENT_
+     * CHALLENGE whose RespType/HiRespType are 1 and whose AvPair list
+     * terminates with MsvAvEOL inside the buffer (MS-NLMP 2.2.2.7/2.2.2.8).
+     * A malformed blob is a protocol error answered with
+     * STATUS_INVALID_PARAMETER, not a failed logon (Samba bug 14932). */
+    if (nt_response_len > 24 &&
+        validate_ntlmv2_response_format(nt_response, nt_response_len) < 0) {
+        smb_ntlm_error("NTLM: Malformed NTLMv2 response");
+        result = SMB_NTLM_STATUS_BAD_TOKEN;
+        goto cleanup;
     }
 
     // First, try to look up user in local VFS cache
@@ -896,6 +979,10 @@ smb_ntlm_process(
     switch (msg_type) {
         case NTLM_NEGOTIATE_MESSAGE:
             smb_ntlm_debug("NTLM: Processing NEGOTIATE message");
+            /* A NEGOTIATE starts a fresh handshake; clear any state a previous
+             * exchange on this connection left behind (a re-authentication
+             * reuses the connection's context after a completed logon). */
+            smb_ntlm_ctx_init(ctx);
             if (generate_challenge(ctx, &ntlm_output, &ntlm_output_len) < 0) {
                 return -1;
             }
@@ -921,7 +1008,7 @@ smb_ntlm_process(
             }
             rc = validate_authenticate(ctx, vfs, auth_config, ntlm_input, ntlm_input_len);
             if (rc < 0) {
-                return -1;
+                return rc;
             }
 
             // Generate SPNEGO accept-complete response if input was wrapped

--- a/src/server/smb/smb_ntlm.h
+++ b/src/server/smb/smb_ntlm.h
@@ -12,6 +12,11 @@
 #define SMB_NTLM_HASH_SIZE                         16
 #define SMB_NTLM_SID_MAX_LEN                       80
 
+/* smb_ntlm_process() result for a structurally malformed authentication token
+ * (e.g. an NTLMv2_RESPONSE whose AvPairs cannot be parsed): the SMB layer
+ * answers STATUS_INVALID_PARAMETER instead of STATUS_LOGON_FAILURE. */
+#define SMB_NTLM_STATUS_BAD_TOKEN                  (-2)
+
 // NTLM message types
 #define NTLM_NEGOTIATE_MESSAGE                     0x00000001
 #define NTLM_CHALLENGE_MESSAGE                     0x00000002
@@ -44,6 +49,7 @@ struct smb_ntlm_ctx {
     uint32_t negotiate_flags;
     int      have_challenge;
     int      authenticated;
+    int      is_anonymous;       // AUTHENTICATE was an anonymous (null-session) logon
     int      is_winbind_user;    // True if authenticated via winbind (AD user)
     char     username[256];
     char     domain[256];

--- a/src/server/smb/smb_proc_session_setup.c
+++ b/src/server/smb/smb_proc_session_setup.c
@@ -154,6 +154,20 @@ chimera_smb_session_setup(struct chimera_smb_request *request)
 
         if (!(request->smb2_hdr.flags & SMB2_FLAGS_SIGNED)) {
             reject = 1;
+        } else if ((bind_session->flags & CHIMERA_SMB_SESSION_AUTHORIZED) &&
+                   bind_session->dialect != conn->dialect) {
+            /* MS-SMB2 3.3.5.5: the binding connection's dialect MUST equal the
+             * dialect of the connection the session was established on
+             * (smb2.session.bind_negative_smb3to3* binds a 3.0.2 session from
+             * a 3.1.1 connection and expects STATUS_INVALID_PARAMETER). */
+            reject = 1;
+        } else if ((bind_session->flags & CHIMERA_SMB_SESSION_AUTHORIZED) &&
+                   conn->negotiated.cipher_id != bind_session->conn_cipher_id) {
+            /* MS-SMB2 3.3.5.5: likewise the negotiated cipher must match the
+             * establishing connection's (smb2.session.bind_negative_
+             * smb3encGtoC* negotiates AES-128-GCM on the first connection and
+             * AES-128-CCM on the binding one). */
+            reject = 1;
         } else if (conn->dialect == SMB2_DIALECT_3_1_1 &&
                    bind_session->supports_notifications !=
                    conn->supports_notifications) {
@@ -167,6 +181,35 @@ chimera_smb_session_setup(struct chimera_smb_request *request)
             return;
         }
     }
+
+    /* A non-binding SESSION_SETUP that names an established session which has
+     * no channel on THIS connection is invalid: re-authentication is only
+     * possible over a connection the session is bound to.  The session itself
+     * is left untouched and the request answered STATUS_USER_SESSION_DELETED
+     * (MS-SMB2 3.3.5.5; Samba bug 14512 — the response is signed with the
+     * session's key by the reply path since the handle remains attached). */
+    if (!(request->session_setup.flags & SMB2_SESSION_FLAG_BINDING) &&
+        request->session_handle &&
+        (request->session_handle->session->flags & CHIMERA_SMB_SESSION_AUTHORIZED) &&
+        !request->session_handle->is_channel) {
+        chimera_smb_complete_request(request, SMB2_STATUS_USER_SESSION_DELETED);
+        evpl_iovecs_release(thread->evpl, request->session_setup.input_iov,
+                            request->session_setup.input_niov);
+        return;
+    }
+
+    int is_binding = (request->session_setup.flags &
+                      SMB2_SESSION_FLAG_BINDING) != 0;
+
+    /* Re-authentication: a non-binding SESSION_SETUP over an established
+     * channel of a live session (MS-SMB2 3.3.5.5.2).  The session, its open
+     * handles and trees, and crucially its keys are all preserved — the server
+     * MUST NOT change Session.SessionKey or the signing/encryption keys on
+     * re-authentication; only the security context is refreshed. */
+    int is_reauth = !is_binding &&
+        request->session_handle &&
+        (request->session_handle->session->flags & CHIMERA_SMB_SESSION_AUTHORIZED) &&
+        request->session_handle->is_channel;
 
     // Detect authentication mechanism
     mech = smb_auth_detect_mechanism(input, input_len);
@@ -200,6 +243,26 @@ chimera_smb_session_setup(struct chimera_smb_request *request)
             bad_token = 1;
             break;
     } /* switch */
+
+    /* A structurally malformed authentication token (e.g. an NTLMv2_RESPONSE
+     * whose client-challenge AvPairs cannot be parsed) is reported as
+     * SMB_NTLM_STATUS_BAD_TOKEN and answered STATUS_INVALID_PARAMETER, not
+     * STATUS_LOGON_FAILURE (Samba bug 14932). */
+    if (rc == SMB_NTLM_STATUS_BAD_TOKEN) {
+        rc        = -1;
+        bad_token = 1;
+    }
+
+    /* Anonymous NTLM authentication is accepted only as a re-authentication of
+     * an established session (smb2.session.reauth2-5 re-authenticate a user
+     * session as anonymous and back; the session keeps its keys and open
+     * handles while the security context switches).  An initial anonymous
+     * session or an anonymous channel bind is refused. */
+    if (rc == 0 && mech == SMB_AUTH_MECH_NTLM &&
+        conn->ntlm_ctx.is_anonymous && !is_reauth) {
+        chimera_smb_error("Anonymous authentication rejected (only re-authentication of an established session)");
+        rc = -1;
+    }
 
     /* Allocate the session (and its SessionId) on the first leg, whether the
      * exchange completes now or needs another round trip. The server MUST
@@ -259,10 +322,8 @@ chimera_smb_session_setup(struct chimera_smb_request *request)
          * encrypted. */
         uint8_t     session_key_saved[32];
         size_t      session_key_saved_len = 0;
-        int         is_anonymous          = 0;
-
-        int         is_binding = (request->session_setup.flags &
-                                  SMB2_SESSION_FLAG_BINDING) != 0;
+        int         is_anonymous          = (mech == SMB_AUTH_MECH_NTLM &&
+                                             conn->ntlm_ctx.is_anonymous);
 
         /* SMB3 multichannel session binding (MS-SMB2 §3.3.5.5.3): account for
          * the new channel and enforce the per-session channel limit BEFORE any
@@ -274,6 +335,21 @@ chimera_smb_session_setup(struct chimera_smb_request *request)
         if (is_binding &&
             (session->flags & CHIMERA_SMB_SESSION_AUTHORIZED)) {
             int over_limit = 0;
+
+            /* MS-SMB2 3.3.5.5.3: the binding user MUST be the user the session
+            * was established by; a successful authentication as a DIFFERENT
+            * principal is rejected with STATUS_ACCESS_DENIED and the session
+            * (and its channels) survive (smb2.session.bind_different_user). */
+            if (mech == SMB_AUTH_MECH_NTLM &&
+                smb_ntlm_get_uid(&conn->ntlm_ctx) != session->cred.uid) {
+                chimera_smb_error("Channel bind rejected: user mismatch (uid %u != session uid %u)",
+                                  smb_ntlm_get_uid(&conn->ntlm_ctx), session->cred.uid);
+                chimera_smb_complete_request(request, SMB2_STATUS_ACCESS_DENIED);
+                evpl_iovecs_release(thread->evpl,
+                                    request->session_setup.input_iov,
+                                    request->session_setup.input_niov);
+                return;
+            }
 
             pthread_mutex_lock(&shared->sessions_lock);
             if (session->num_channels >= SMB2_MAX_CHANNELS) {
@@ -296,7 +372,13 @@ chimera_smb_session_setup(struct chimera_smb_request *request)
         if (mech == SMB_AUTH_MECH_NTLM) {
             uint8_t session_key[SMB_NTLM_SESSION_KEY_SIZE];
 
-            if (smb_ntlm_get_session_key(&conn->ntlm_ctx, session_key, sizeof(session_key)) == 0) {
+            /* Re-authentication MUST NOT change the session's keys (MS-SMB2
+             * 3.3.5.5.2): the client keeps signing with the original session
+             * key, so skip key derivation entirely on a re-auth leg.  A
+             * channel bind derives this CHANNEL's signing key from the new
+             * exchange's session key and this connection's preauth hash. */
+            if (!is_reauth &&
+                smb_ntlm_get_session_key(&conn->ntlm_ctx, session_key, sizeof(session_key)) == 0) {
                 chimera_smb_derive_signing_key(conn->dialect,
                                                session_handle->signing_key,
                                                session_key,
@@ -331,7 +413,8 @@ chimera_smb_session_setup(struct chimera_smb_request *request)
         } else if (mech == SMB_AUTH_MECH_KERBEROS) {
             uint8_t session_key[SMB_GSSAPI_SESSION_KEY_SIZE];
 
-            if (smb_gssapi_get_session_key(&conn->gssapi_ctx, session_key, sizeof(session_key)) == 0) {
+            if (!is_reauth &&
+                smb_gssapi_get_session_key(&conn->gssapi_ctx, session_key, sizeof(session_key)) == 0) {
                 chimera_smb_derive_signing_key(conn->dialect,
                                                session_handle->signing_key,
                                                session_key,
@@ -403,7 +486,7 @@ chimera_smb_session_setup(struct chimera_smb_request *request)
             conn->negotiated.cipher_id != 0 &&
             conn->dialect >= SMB2_DIALECT_3_0 &&
             session_key_saved_len > 0 &&
-            !is_anonymous) {
+            !is_anonymous && !is_reauth && !is_binding) {
             size_t klen = 0;
 
             if (chimera_smb_derive_encryption_keys(
@@ -423,6 +506,13 @@ chimera_smb_session_setup(struct chimera_smb_request *request)
             memcpy(session->signing_key, session_handle->signing_key, sizeof(session_handle->signing_key));
             /* The primary channel counts as the session's first channel. */
             session->num_channels = 1;
+            /* Record the establishing connection's signing algorithm and
+             * negotiated cipher: SESSION_SETUP responses verified against
+             * Session.SigningKey must be signed with this algorithm even when
+             * they go out on a binding connection that negotiated another, and
+             * a binding connection's cipher must match this one. */
+            session->sign_alg       = conn->negotiated.signing_alg;
+            session->conn_cipher_id = conn->negotiated.cipher_id;
             if (session_handle->enc_key_len > 0) {
                 memcpy(session->enc_key, session_handle->enc_key, sizeof(session->enc_key));
                 memcpy(session->dec_key, session_handle->dec_key, sizeof(session->dec_key));
@@ -436,13 +526,19 @@ chimera_smb_session_setup(struct chimera_smb_request *request)
             chimera_smb_session_authorize(shared, session);
         }
 
+        /* This connection now legitimately owns a channel of the session:
+         * the establishing/binding/re-authenticated SESSION_SETUP succeeded. */
+        session_handle->is_channel = 1;
+
         /* If the client named a previous session (reconnect on a fresh
          * transport), close it now that this one is established.  MS-SMB2
          * 3.3.5.5.1: when the previous session was negotiated at a different
          * dialect than this connection, the reconnect is rejected -- close the
          * just-created session and fail with STATUS_USER_SESSION_DELETED
-         * (smb2.session ReconnectWithDifferentDialect). */
-        if (request->session_setup.prev_session_id &&
+         * (smb2.session ReconnectWithDifferentDialect).  PreviousSessionId is
+         * ignored on a binding SESSION_SETUP (MS-SMB2 3.3.5.5.3). */
+        if (!is_binding &&
+            request->session_setup.prev_session_id &&
             chimera_smb_session_invalidate_previous(thread, shared,
                                                     request->session_setup.prev_session_id,
                                                     session, conn->dialect)) {
@@ -471,9 +567,6 @@ chimera_smb_session_setup(struct chimera_smb_request *request)
          * existing session down — the established channel(s) survive.  Only a
          * failed initial auth (never-authorized session) or a failed non-binding
          * REAUTH invalidates the session. */
-        int is_binding = (request->session_setup.flags &
-                          SMB2_SESSION_FLAG_BINDING) != 0;
-
         if (request->session_handle &&
             !((request->session_handle->session->flags &
                CHIMERA_SMB_SESSION_AUTHORIZED) && is_binding)) {
@@ -493,8 +586,27 @@ chimera_smb_session_setup(struct chimera_smb_request *request)
              *     (smb2.notify.invalid-reauth) and makes the SessionId
              *     invalid for subsequent requests.  A failed auth holds no
              *     preservable durable opens, so nothing to preserve. */
+            struct chimera_smb_session *failed_session = request->session_handle->session;
+
+            /* A failed REAUTH invalidates the whole session, not just this
+             * connection's handle: remove it from the global table and mark it
+             * DELETED so requests arriving on OTHER channels (and later
+             * global lookups) are answered USER_SESSION_DELETED while the
+             * session lingers until every referencing connection drops
+             * (smb2.session.bind_invalid_auth re-auths a bound session with
+             * invalid credentials and expects both channels dead).  Clearing
+             * AUTHORIZED keeps the refcnt-driven release below from HASH_DELing
+             * a second time. */
+            pthread_mutex_lock(&shared->sessions_lock);
+            if (failed_session->flags & CHIMERA_SMB_SESSION_AUTHORIZED) {
+                failed_session->flags |= CHIMERA_SMB_SESSION_DELETED;
+                failed_session->flags &= ~CHIMERA_SMB_SESSION_AUTHORIZED;
+                HASH_DEL(shared->sessions, failed_session);
+            }
+            pthread_mutex_unlock(&shared->sessions_lock);
+
             HASH_DEL(conn->session_handles, request->session_handle);
-            chimera_smb_session_release(thread, shared, request->session_handle->session, false);
+            chimera_smb_session_release(thread, shared, failed_session, false);
             chimera_smb_session_handle_free(thread, request->session_handle);
             request->session_handle   = NULL;
             conn->last_session_handle = NULL;

--- a/src/server/smb/smb_session.h
+++ b/src/server/smb/smb_session.h
@@ -268,6 +268,20 @@ struct chimera_smb_session {
      * authorized the session.  A later binding SESSION_SETUP on a connection
      * whose SupportsNotifications differs is rejected (3.1.1 only). */
     uint8_t                     supports_notifications;
+    /* Signing algorithm (SMB2_SIGNING_*) negotiated on the connection the
+     * session was established on.  A SESSION_SETUP response the client
+     * verifies against Session.SigningKey (binding interim/error legs and
+     * other non-final session-setup responses) must be signed with the
+     * SESSION's dialect+algorithm, not the receiving connection's: the
+     * client's session signing-key object carries the algorithm of the
+     * establishing connection (smbtorture smb2.session.bind_negative_smb3to2*,
+     * Samba bug 14512). */
+    uint16_t                    sign_alg;
+    /* Cipher (SMB2_ENCRYPTION_*) negotiated on the establishing connection,
+     * recorded whether or not encryption is active.  A binding connection
+     * whose negotiated cipher differs is rejected with
+     * STATUS_INVALID_PARAMETER (MS-SMB2 3.3.5.5). */
+    uint16_t                    conn_cipher_id;
     struct UT_hash_handle       hh;
     struct chimera_smb_session *prev;
     struct chimera_smb_session *next;

--- a/src/server/smb/smb_signing.c
+++ b/src/server/smb/smb_signing.c
@@ -455,16 +455,17 @@ chimera_smb_request_gmac_aes_128(
  * SMB 3.1.1 negotiated signing algorithm (GMAC / CMAC / HMAC-SHA256) for 3.1.1.
  */
 static int
-chimera_smb_compute_signature(
+chimera_smb_compute_signature_alg(
     struct chimera_smb_signing_ctx *ctx,
-    struct chimera_smb_conn        *conn,
+    uint16_t                        dialect,
+    uint16_t                        signing_alg,
     struct smb2_header             *hdr,
     struct evpl_iovec_cursor       *cursor,
     int                             length,
     const uint8_t                  *key,
     uint8_t                        *out_sig16)
 {
-    switch (conn->dialect) {
+    switch (dialect) {
         case SMB2_DIALECT_2_0_2:
         case SMB2_DIALECT_2_1:
             return chimera_smb_request_hmac_sha256(ctx, hdr, cursor, length, key, 16, out_sig16);
@@ -472,7 +473,7 @@ chimera_smb_compute_signature(
         case SMB2_DIALECT_3_0_2:
             return chimera_smb_request_cmac_aes_128_cbc(ctx, hdr, cursor, length, key, 16, out_sig16);
         case SMB2_DIALECT_3_1_1:
-            switch (conn->negotiated.signing_alg) {
+            switch (signing_alg) {
                 case SMB2_SIGNING_AES_GMAC:
                     return chimera_smb_request_gmac_aes_128(ctx, hdr, cursor, length, key, 16, out_sig16);
                 case SMB2_SIGNING_HMAC_SHA256:
@@ -483,6 +484,21 @@ chimera_smb_compute_signature(
         default:
             return -1;
     } /* switch */
+} /* chimera_smb_compute_signature_alg */
+
+static int
+chimera_smb_compute_signature(
+    struct chimera_smb_signing_ctx *ctx,
+    struct chimera_smb_conn        *conn,
+    struct smb2_header             *hdr,
+    struct evpl_iovec_cursor       *cursor,
+    int                             length,
+    const uint8_t                  *key,
+    uint8_t                        *out_sig16)
+{
+    return chimera_smb_compute_signature_alg(ctx, conn->dialect,
+                                             conn->negotiated.signing_alg,
+                                             hdr, cursor, length, key, out_sig16);
 } /* chimera_smb_compute_signature */
 
 int
@@ -596,10 +612,34 @@ chimera_smb_sign_compound(
              * mishandles channel/session setup and can crash it). */
             hdr->flags |= SMB2_FLAGS_SIGNED;
 
-            rc = chimera_smb_compute_signature(ctx, conn, hdr, &cursor,
-                                               payload_length,
-                                               session_handle->signing_key,
-                                               signature);
+            /* A SESSION_SETUP response other than a final SUCCESS (interim
+             * MORE_PROCESSING legs and errors such as a rejected channel bind)
+             * is verified by the client against its Session.SigningKey object,
+             * which carries the dialect/algorithm of the connection the
+             * session was ESTABLISHED on — not this connection's.  Sign those
+             * with the session's algorithm (Samba bug 14512; smbtorture
+             * smb2.session.bind_negative_smb3to2* receives the bind rejection
+             * on a 2.10 connection but verifies it with the 3.x session's
+             * AES-CMAC).  A final SUCCESS response is verified with the
+             * just-derived per-channel key, whose client-side object uses this
+             * connection's algorithm. */
+            if (request->smb2_hdr.command == SMB2_SESSION_SETUP &&
+                request->status != SMB2_STATUS_SUCCESS &&
+                session_handle->session &&
+                (session_handle->session->flags & CHIMERA_SMB_SESSION_AUTHORIZED)) {
+                rc = chimera_smb_compute_signature_alg(ctx,
+                                                       session_handle->session->dialect,
+                                                       session_handle->session->sign_alg,
+                                                       hdr, &cursor,
+                                                       payload_length,
+                                                       session_handle->signing_key,
+                                                       signature);
+            } else {
+                rc = chimera_smb_compute_signature(ctx, conn, hdr, &cursor,
+                                                   payload_length,
+                                                   session_handle->signing_key,
+                                                   signature);
+            }
 
             if (unlikely(rc != 0)) {
                 chimera_smb_error("Failed to calculate signature for dialect %x", conn->dialect);

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -1578,7 +1578,10 @@ set(SMBTORTURE_ENABLED_memfs
     # smb2.session-require-signing
     smb2.session-require-signing.bug15397
     # smb2.session
+    smb2.session.bind1
+    smb2.session.bind2
     smb2.session.bind_different_user
+    smb2.session.bind_invalid_auth
     smb2.session.bind_negative_smb3signC30toGd
     smb2.session.bind_negative_smb3signC30toGs
     smb2.session.bind_negative_smb3signCtoGd
@@ -1607,6 +1610,10 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.session.bind_negative_smb3sneGtoHs
     smb2.session.bind_negative_smb3sneHtoGd
     smb2.session.bind_negative_smb3sneHtoGs
+    smb2.session.bind_negative_smb3to2d
+    smb2.session.bind_negative_smb3to2s
+    smb2.session.bind_negative_smb3to3d
+    smb2.session.bind_negative_smb3to3s
     smb2.session.encryption-aes-128-ccm
     smb2.session.encryption-aes-128-gcm
     smb2.session.encryption-aes-256-ccm
@@ -1617,6 +1624,10 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.session.expire2e
     smb2.session.expire2s
     smb2.session.expire_disconnect
+    smb2.session.ntlmssp_bug14932
+    smb2.session.reauth1
+    smb2.session.reauth2
+    smb2.session.reauth3
     smb2.session.reauth6
     smb2.session.reconnect2
     smb2.session.signing-aes-128-cmac
@@ -2965,6 +2976,7 @@ set(SMBTORTURE_ENABLED_diskfs_io_uring
     # smb2.session-require-signing
     smb2.session-require-signing.bug15397
     # smb2.session
+    smb2.session.bind2
     smb2.session.bind_different_user
     smb2.session.bind_negative_smb3signC30toGd
     smb2.session.bind_negative_smb3signC30toGs
@@ -3004,6 +3016,7 @@ set(SMBTORTURE_ENABLED_diskfs_io_uring
     smb2.session.expire2e
     smb2.session.expire2s
     smb2.session.expire_disconnect
+    smb2.session.ntlmssp_bug14932
     smb2.session.signing-aes-128-cmac
     smb2.session.signing-aes-128-gmac
     smb2.session.signing-hmac-sha-256

--- a/src/server/smb/tests/smbtorture_test.c
+++ b/src/server/smb/tests/smbtorture_test.c
@@ -502,6 +502,17 @@ main(
         }
     }
 
+    /* The bind_negative_smb3enc* cases connect with encryption REQUIRED on the
+     * client credentials, so the server must actually support SMB3 transport
+     * encryption for the connection to come up at all.  Enable it only for
+     * those cases — every other suite runs with the default (off). */
+    for (i = 0; i < num_tests; i++) {
+        if (strstr(tests[i], "bind_negative_smb3enc") != NULL) {
+            chimera_server_config_set_smb_encryption(config, 1);
+            break;
+        }
+    }
+
     /* Initialize server */
     env.server = chimera_server_init(config, env.metrics);
     if (!env.server) {


### PR DESCRIPTION
## What's implemented

**Re-authentication (MS-SMB2 3.3.5.5.2)**
- A non-binding SESSION_SETUP on an established channel is processed as a re-auth: the security context is refreshed, but the session's signing/encryption keys are never re-derived (the client keeps signing with the original session key) and open handles/trees are preserved.
- Anonymous NTLM (null session) is accepted only as a re-auth of an established session (`reauth2`/`reauth3` switch user → anonymous → user).
- A failed re-auth invalidates the whole session (removed from the global table, marked DELETED) so requests on its *other* channels get `USER_SESSION_DELETED` while the session lingers until every referencing connection drops.
- The per-connection NTLM context is reset when a NEGOTIATE token arrives, so a re-auth handshake starts clean.
- A structurally malformed NTLMv2_RESPONSE (unparseable AvPairs) is answered `STATUS_INVALID_PARAMETER` instead of `LOGON_FAILURE` (Samba bug 14932).

**Multichannel binding (MS-SMB2 3.3.5.5.3)**
- Root cause of the failing positive binds: the binding exchange's preauth-integrity hash must restart from the connection's post-NEGOTIATE baseline, but the server chained it over the connection's earlier session-setup exchanges (which the client never folds), so the derived channel signing key never matched. A `session_setup_in_progress` flag now distinguishes a continuation leg from the first leg of a new exchange, and the hash restarts on the latter.
- Bind validation: binding connection's dialect and negotiated cipher must equal the establishing connection's (`STATUS_INVALID_PARAMETER`), and the binding principal must be the session's user (`STATUS_ACCESS_DENIED`).
- SESSION_SETUP responses the client verifies against `Session.SigningKey` (binding interim/error legs, non-final responses on an authorized session) are signed with the **session's** dialect/algorithm, not the receiving connection's — e.g. the bind rejection sent on a 2.10 connection is AES-CMAC-signed when the session lives on a 3.x connection (Samba bug 14512).
- Sessions are only usable over connections holding a channel of them: the dispatcher's global-session lookup is restricted to SESSION_SETUP; any other command referencing a session with no channel on the connection gets `USER_SESSION_DELETED` without taking a session reference (a parasitic reference kept a dying session's opens alive after its real channels were gone — `bind2`).
- `PreviousSessionId` is ignored on a binding setup.
- The smbtorture driver enables `smb_encryption` for the `bind_negative_smb3enc*` cases, whose client credentials require encryption end-to-end.

## Tests enabled

memfs: `smb2.session.bind1`, `bind2`, `bind_invalid_auth`, `bind_negative_smb3to2d/s`, `bind_negative_smb3to3d/s`, `ntlmssp_bug14932`, `reauth1`, `reauth2`, `reauth3` (11).
diskfs_io_uring: `smb2.session.bind2`, `ntlmssp_bug14932` (2).

Each verified 3x green under Debug/ASan, both standalone and in the consolidated suite grouping ctest uses; all previously-enabled smb2.session / session-id / session-require-signing / multichannel subtests plus a notify/credits/durable/tcon smoke remain green on both backends.

## Deliberately left out

- `bind_negative_smb202/210d/210s/2to3d/2to3s`: blocked client-side — the harness's global `client smb3 signing algorithms=aes-128-cmac` option makes smbtorture refuse to negotiate SMB2.0x/2.1 connections, so these tests never reach the server.
- `bind_negative_smb3encGtoCd/s`: the cipher-mismatch rejection is implemented and passes locally with the driver's per-case encryption enable, but in CI the whole smb2.session suite shares one server instance and force-enabling encryption there would change conditions for every other subtest, so they stay off the allowlist.
- `reauth4`: after re-authenticating to anonymous, a SET_INFO(secdesc) through a handle opened by the original user must succeed (handle-based access); chimera's VFS re-checks the *current* session credential per op, so the anonymous context is denied by the backend. Needs handle-credential semantics in the VFS — separate work.
- `reauth5`: known-fail in Samba's own selftest ("some special anonymous checks").
- `reconnect1`: requires purging a disconnected session's batch-oplock open when a conflicting CREATE arrives — part of the known durable-handle keep/purge rework.
- `anon-signing*/anon-encryption*`: require accepting *initial* anonymous sessions; only anonymous re-auth is implemented here.
- diskfs_io_uring (and cairn/diskfs_aio) reauth/bind cases beyond the two enabled: blocked by the pre-existing backend oplock-grant bug (batch oplock not granted, `oplock_level was 0 expected 9`), tracked separately.