### PR TITLE
smb2: retry a durable reconnect that races the previous connection's teardown

### DIFF
--- a/src/server/smb/smb_durable.c
+++ b/src/server/smb/smb_durable.c
@@ -338,13 +338,15 @@ chimera_smb_durable_claim(
     bool                              has_lease_ctx,
     const uint8_t                    *lease_key,
     bool                             *r_cold,
+    bool                             *r_retry,
     uint32_t                         *status)
 {
     struct chimera_smb_durable_entry *entry;
     struct chimera_smb_open_file     *open_file = NULL;
     bool                              had_lease;
 
-    *r_cold = false;
+    *r_cold  = false;
+    *r_retry = false;
 
     pthread_mutex_lock(&shared->durable.lock);
 
@@ -359,9 +361,17 @@ chimera_smb_durable_claim(
     if (!entry) {
         *status = SMB2_STATUS_OBJECT_NAME_NOT_FOUND;
     } else if (!entry->parked) {
-        /* The handle is still live on another (multi-)channel — a second
-         * reconnect cannot steal it. */
-        *status = SMB2_STATUS_OBJECT_NAME_NOT_FOUND;
+        /* The handle is flagged live -- either genuinely still open on another
+         * channel (a second reconnect must not steal it), OR its previous
+         * connection has dropped but that disconnect has not been processed yet
+         * (a cross-connection race: the reconnect's CREATE reached this thread
+         * before the old connection's teardown parked the handle).  We cannot
+         * tell the two apart here, so ask the caller to retry briefly: once the
+         * disconnect is processed the entry becomes parked and the retry
+         * reclaims it; a genuinely-live handle never parks and the retry budget
+         * lapses into OBJECT_NAME_NOT_FOUND. */
+        *r_retry = true;
+        *status  = SMB2_STATUS_OBJECT_NAME_NOT_FOUND;
     } else if (entry->open_file &&
                (entry->open_file->flags & CHIMERA_SMB_OPEN_FILE_YIELDED)) {
         /* While disconnected, this open's write-caching oplock/lease was

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -538,6 +538,12 @@ struct chimera_smb_request {
             uint8_t                            park_fh[CHIMERA_VFS_FH_SIZE];
             uint8_t                            park_fh_len;
             uint64_t                           park_fh_hash;
+            /* Durable-reconnect retry: a reclaim that finds its handle still
+             * flagged live (the previous connection's disconnect has not yet
+             * been processed -- a cross-connection race) re-arms a short timer
+             * and re-attempts the claim until the handle is parked or this
+             * many attempts elapse. */
+            uint16_t                           reconnect_retries;
         } create;
 
         struct  {
@@ -1139,6 +1145,7 @@ chimera_smb_durable_claim(
     bool                              has_lease_ctx,
     const uint8_t                    *lease_key,
     bool                             *r_cold,
+    bool                             *r_retry,
     uint32_t                         *status);
 void
 chimera_smb_durable_sweep(

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -2810,43 +2810,39 @@ chimera_smb_revalidate_tree(
 
 } /* chimera_smb_revalidate_tree */
 
-/* Durable-handle reconnect (DH2C / DHnC).  Reclaims a parked open that
- * survived its previous connection and re-homes it into the reconnecting
- * tree, then replies as a normal OPEN of the surviving file. */
-static void
-chimera_smb_durable_reconnect(struct chimera_smb_request *request)
+/* A durable reconnect can reach this server thread before the previous
+ * connection's disconnect has been processed (the two connections live on
+ * independent event loops, so there is no ordering between the new CREATE and
+ * the old TCP teardown).  In that window the surviving open is still flagged
+ * live and the claim is refused -- spuriously, because the legitimate owner IS
+ * reconnecting.  So a refused-because-not-parked claim is retried on a short
+ * timer until the disconnect is processed (the handle parks and the retry
+ * reclaims it) or this budget elapses (a genuinely-live handle never parks).
+ * ~3s comfortably covers the teardown latency even on a loaded ASan runner,
+ * while bounding the wait for the rare genuinely-conflicting reconnect. */
+#define CHIMERA_SMB_DURABLE_RECONNECT_INTERVAL_US 20000  /* 20 ms */
+#define CHIMERA_SMB_DURABLE_RECONNECT_MAX_RETRIES 150    /* ~3 s total */
+
+/* One durable-reclaim attempt.  Returns true if the request has been completed
+ * or handed off (cold reopen / success reply / terminal failure); false if the
+ * handle is still racing its previous connection's disconnect and the caller
+ * should retry. */
+static bool
+chimera_smb_durable_reconnect_attempt(struct chimera_smb_request *request)
 {
     struct chimera_server_smb_thread *thread = request->compound->thread;
     struct chimera_server_smb_shared *shared = thread->shared;
     struct chimera_smb_tree          *tree   = request->tree;
     struct chimera_smb_open_file     *open_file;
     const uint8_t                    *create_guid = NULL;
+    const uint8_t                    *lease_key   = NULL;
     uint64_t                          persistent_id;
-    uint32_t                          status    = SMB2_STATUS_OBJECT_NAME_NOT_FOUND;
-    uint32_t                          ctx       = request->create.ctx_present_mask;
-    const uint8_t                    *lease_key = NULL;
+    uint32_t                          status = SMB2_STATUS_OBJECT_NAME_NOT_FOUND;
+    uint32_t                          ctx    = request->create.ctx_present_mask;
     bool                              has_lease_ctx;
-    bool                              cold = false;
+    bool                              cold  = false;
+    bool                              retry = false;
     int                               bucket;
-
-    /* Reject malformed reconnect-context combinations:
-     *   - DH2C (3.3.5.9.12) must stand alone: combining it with ANY other
-     *     durable context (DHnQ, DH2Q, or DHnC) is INVALID_PARAMETER.
-     *   - DHnC (3.3.5.9.7) may carry a v1 durable *request* (DHnQ) -- the request
-     *     is simply ignored -- but combining it with a v2 context (DH2Q or DH2C)
-     *     is INVALID_PARAMETER.
-     * So a lone DHnC, a lone DH2C, or DHnC+DHnQ are all valid reconnects. */
-    if ((ctx & CHIMERA_SMB_CREATE_CTX_DH2C) &&
-        (ctx & (CHIMERA_SMB_CREATE_CTX_DHNQ | CHIMERA_SMB_CREATE_CTX_DH2Q |
-                CHIMERA_SMB_CREATE_CTX_DHNC))) {
-        chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
-        return;
-    }
-    if ((ctx & CHIMERA_SMB_CREATE_CTX_DHNC) &&
-        (ctx & (CHIMERA_SMB_CREATE_CTX_DH2Q | CHIMERA_SMB_CREATE_CTX_DH2C))) {
-        chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
-        return;
-    }
 
     if (ctx & CHIMERA_SMB_CREATE_CTX_DH2C) {
         persistent_id = request->create.dh2c.persistent;
@@ -2864,7 +2860,7 @@ chimera_smb_durable_reconnect(struct chimera_smb_request *request)
                                           request->compound->conn->client_guid,
                                           request->create.name, request->create.name_len,
                                           has_lease_ctx, lease_key,
-                                          &cold, &status);
+                                          &cold, &retry, &status);
 
     if (cold) {
         /* Recovered-after-restart persistent handle: there is no live open to
@@ -2874,12 +2870,15 @@ chimera_smb_durable_reconnect(struct chimera_smb_request *request)
          * backend record is refreshed atomically. */
         request->create.persist_pid = persistent_id;
         chimera_smb_create_process(request);
-        return;
+        return true;
     }
 
     if (!open_file) {
+        if (retry) {
+            return false;
+        }
         chimera_smb_complete_request(request, status);
-        return;
+        return true;
     }
 
     /* Re-home the surviving open into the reconnecting tree.  The persistent
@@ -2919,6 +2918,75 @@ chimera_smb_durable_reconnect(struct chimera_smb_request *request)
                         CHIMERA_VFS_ATTR_MASK_STAT,
                         chimera_smb_create_open_getattr_callback,
                         request);
+    return true;
+} /* chimera_smb_durable_reconnect_attempt */
+
+/* Retry timer for a reclaim that raced its previous connection's disconnect.
+ * Re-attempts; on continued racing it re-arms until the budget lapses, then
+ * answers OBJECT_NAME_NOT_FOUND.  Runs on the reconnecting request's own
+ * thread (the timer is armed on that thread's evpl). */
+static void
+chimera_smb_durable_reconnect_retry_cb(
+    struct evpl       *evpl,
+    struct evpl_timer *timer)
+{
+    struct chimera_smb_request *request = (struct chimera_smb_request *)
+        ((char *) timer - offsetof(struct chimera_smb_request, async.timer));
+
+    if (chimera_smb_durable_reconnect_attempt(request)) {
+        return;
+    }
+
+    if (--request->create.reconnect_retries == 0) {
+        chimera_smb_complete_request(request, SMB2_STATUS_OBJECT_NAME_NOT_FOUND);
+        return;
+    }
+
+    evpl_add_oneshot_timer(evpl, &request->async.timer,
+                           chimera_smb_durable_reconnect_retry_cb,
+                           CHIMERA_SMB_DURABLE_RECONNECT_INTERVAL_US);
+} /* chimera_smb_durable_reconnect_retry_cb */
+
+/* Durable-handle reconnect (DH2C / DHnC).  Reclaims a parked open that
+ * survived its previous connection and re-homes it into the reconnecting
+ * tree, then replies as a normal OPEN of the surviving file. */
+static void
+chimera_smb_durable_reconnect(struct chimera_smb_request *request)
+{
+    struct chimera_server_smb_thread *thread = request->compound->thread;
+    uint32_t                          ctx    = request->create.ctx_present_mask;
+
+    /* Reject malformed reconnect-context combinations:
+     *   - DH2C (3.3.5.9.12) must stand alone: combining it with ANY other
+     *     durable context (DHnQ, DH2Q, or DHnC) is INVALID_PARAMETER.
+     *   - DHnC (3.3.5.9.7) may carry a v1 durable *request* (DHnQ) -- the request
+     *     is simply ignored -- but combining it with a v2 context (DH2Q or DH2C)
+     *     is INVALID_PARAMETER.
+     * So a lone DHnC, a lone DH2C, or DHnC+DHnQ are all valid reconnects. */
+    if ((ctx & CHIMERA_SMB_CREATE_CTX_DH2C) &&
+        (ctx & (CHIMERA_SMB_CREATE_CTX_DHNQ | CHIMERA_SMB_CREATE_CTX_DH2Q |
+                CHIMERA_SMB_CREATE_CTX_DHNC))) {
+        chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
+        return;
+    }
+    if ((ctx & CHIMERA_SMB_CREATE_CTX_DHNC) &&
+        (ctx & (CHIMERA_SMB_CREATE_CTX_DH2Q | CHIMERA_SMB_CREATE_CTX_DH2C))) {
+        chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
+        return;
+    }
+
+    if (chimera_smb_durable_reconnect_attempt(request)) {
+        return;
+    }
+
+    /* The handle is racing its previous connection's disconnect: tell the
+     * client the create is pending (so it does not time out or cancel), then
+     * retry on a short timer until the disconnect is processed. */
+    request->create.reconnect_retries = CHIMERA_SMB_DURABLE_RECONNECT_MAX_RETRIES;
+    chimera_smb_async_interim_begin(request);
+    evpl_add_oneshot_timer(thread->evpl, &request->async.timer,
+                           chimera_smb_durable_reconnect_retry_cb,
+                           CHIMERA_SMB_DURABLE_RECONNECT_INTERVAL_US);
 } /* chimera_smb_durable_reconnect */
 
 /* Parse an SMB stream-name suffix out of the final path component

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -3529,14 +3529,17 @@ endmacro()
 find_program(SMBTORTURE_EXECUTABLE smbtorture)
 
 if(CHIMERA_NETNS_TESTING AND SMBTORTURE_EXECUTABLE)
-    # Deterministic regression coverage for the disconnect-vs-conflicting-open
-    # race on durable handles: CHIMERA_SMB_TEST_DISCONNECT_DELAY_MS holds the
-    # server-side disconnect teardown so the second client's CREATE always
-    # lands while the first client's durable handle is still live -- the
-    # interleaving a loaded CI runner only hits occasionally.  Exercises the
-    # close-not-park (MS-SMB2 3.3.7.1), yielded-reclaim, and parked-CREATE
-    # re-arbitration paths.
-    foreach(_sub smb2.durable-open.lease smb2.durable-open.oplock)
+    # Deterministic regression coverage for the disconnect-vs-reconnect races
+    # on durable handles: CHIMERA_SMB_TEST_DISCONNECT_DELAY_MS holds the
+    # server-side disconnect teardown so the reconnecting client's CREATE always
+    # lands while the first connection's handle teardown is still in flight --
+    # the interleaving a loaded CI runner only hits occasionally.  Exercises:
+    #   - .lease / .oplock: a conflicting open vs the disconnect (close-not-park
+    #     MS-SMB2 3.3.7.1, yielded-reclaim, parked-CREATE re-arbitration).
+    #   - .reopen2b: the same client's durable reconnect racing the teardown
+    #     parking (eager park-on-disconnect; otherwise OBJECT_NAME_NOT_FOUND).
+    foreach(_sub smb2.durable-open.lease smb2.durable-open.oplock
+                 smb2.durable-v2-open.reopen2b)
         string(REGEX REPLACE "[^A-Za-z0-9]" "_" _sid "${_sub}")
         set(_name chimera/server/smb/smbtorture_${_sid}_disconnect_race_memfs)
         add_test(NAME ${_name}

--- a/src/server/smb/tests/phase0_contexts_test.c
+++ b/src/server/smb/tests/phase0_contexts_test.c
@@ -946,6 +946,7 @@ test_durable_register_park_claim(void)
     uint8_t                           lkey[16];
     uint32_t                          status;
     bool                              cold;
+    bool                              retry;
     int                               i;
 
     chimera_smb_durable_table_init(&shared->durable);
@@ -965,7 +966,8 @@ test_durable_register_park_claim(void)
     chimera_smb_durable_register(shared, &of, 42, cguid, "foo.txt", 7, false);
 
     /* Before park: live, not reclaimable. */
-    claimed = chimera_smb_durable_claim(shared, 0xABCDEF, guid, cguid, "foo.txt", 7, false, NULL, &cold, &status);
+    claimed = chimera_smb_durable_claim(shared, 0xABCDEF, guid, cguid, "foo.txt", 7, false, NULL, &cold, &retry, &status
+                                        );
     if (claimed != NULL || status != SMB2_STATUS_OBJECT_NAME_NOT_FOUND) {
         TEST_FAIL("durable: live (unparked) handle is not reclaimable");
     } else {
@@ -976,7 +978,8 @@ test_durable_register_park_claim(void)
 
     /* Wrong create-guid is rejected. */
     guid[0] = 0xFF;
-    claimed = chimera_smb_durable_claim(shared, 0xABCDEF, guid, cguid, "foo.txt", 7, false, NULL, &cold, &status);
+    claimed = chimera_smb_durable_claim(shared, 0xABCDEF, guid, cguid, "foo.txt", 7, false, NULL, &cold, &retry, &status
+                                        );
     guid[0] = 0x10;
     if (claimed != NULL || status != SMB2_STATUS_OBJECT_NAME_NOT_FOUND) {
         TEST_FAIL("durable: create-guid mismatch rejected");
@@ -987,7 +990,8 @@ test_durable_register_park_claim(void)
     /* An oplock-only (no-lease) durable handle is not bound to the ClientGuid:
      * a reconnect from a different ClientGuid reclaims it (MS-SMB2 3.3.5.9.7
      * binds the GUID check to leased opens).  of.oplock_level is 0 here. */
-    claimed = chimera_smb_durable_claim(shared, 0xABCDEF, guid, other, "foo.txt", 7, false, NULL, &cold, &status);
+    claimed = chimera_smb_durable_claim(shared, 0xABCDEF, guid, other, "foo.txt", 7, false, NULL, &cold, &retry, &status
+                                        );
     if (claimed == &of && status == SMB2_STATUS_SUCCESS) {
         TEST_PASS("durable: oplock reconnect ignores client-guid");
     } else {
@@ -1000,7 +1004,8 @@ test_durable_register_park_claim(void)
     /* A *leased* handle IS bound to the ClientGuid: a mismatch is rejected. */
     of.oplock_level = SMB2_OPLOCK_LEVEL_LEASE;
     memcpy(of.lease_key, lkey, 16);
-    claimed = chimera_smb_durable_claim(shared, 0xABCDEF, guid, other, "foo.txt", 7, true, lkey, &cold, &status);
+    claimed = chimera_smb_durable_claim(shared, 0xABCDEF, guid, other, "foo.txt", 7, true, lkey, &cold, &retry, &status)
+    ;
     if (claimed != NULL || status != SMB2_STATUS_OBJECT_NAME_NOT_FOUND) {
         TEST_FAIL("durable: leased reconnect rejects client-guid mismatch");
     } else {
@@ -1008,7 +1013,8 @@ test_durable_register_park_claim(void)
     }
 
     /* Matching reconnect (correct ClientGuid + lease key) reclaims the open. */
-    claimed = chimera_smb_durable_claim(shared, 0xABCDEF, guid, cguid, "foo.txt", 7, true, lkey, &cold, &status);
+    claimed = chimera_smb_durable_claim(shared, 0xABCDEF, guid, cguid, "foo.txt", 7, true, lkey, &cold, &retry, &status)
+    ;
     if (claimed == &of && status == SMB2_STATUS_SUCCESS) {
         TEST_PASS("durable: matching reconnect reclaims the open");
     } else {
@@ -1017,7 +1023,8 @@ test_durable_register_park_claim(void)
     of.oplock_level = 0;
 
     /* A second reconnect must fail — the handle is now live again. */
-    claimed = chimera_smb_durable_claim(shared, 0xABCDEF, guid, cguid, "foo.txt", 7, false, NULL, &cold, &status);
+    claimed = chimera_smb_durable_claim(shared, 0xABCDEF, guid, cguid, "foo.txt", 7, false, NULL, &cold, &retry, &status
+                                        );
     if (claimed != NULL || status != SMB2_STATUS_OBJECT_NAME_NOT_FOUND) {
         TEST_FAIL("durable: double-reconnect rejected");
     } else {
@@ -1027,7 +1034,8 @@ test_durable_register_park_claim(void)
     /* After forget, the persistent id is unknown. */
     chimera_smb_durable_forget(shared, 0xABCDEF);
     chimera_smb_durable_park(shared, &of);  /* no entry -> no-op */
-    claimed = chimera_smb_durable_claim(shared, 0xABCDEF, guid, cguid, "foo.txt", 7, false, NULL, &cold, &status);
+    claimed = chimera_smb_durable_claim(shared, 0xABCDEF, guid, cguid, "foo.txt", 7, false, NULL, &cold, &retry, &status
+                                        );
     if (claimed != NULL || status != SMB2_STATUS_OBJECT_NAME_NOT_FOUND) {
         TEST_FAIL("durable: forgotten handle not found");
     } else {
@@ -1039,7 +1047,7 @@ test_durable_register_park_claim(void)
     of.durable_flags = CHIMERA_SMB_DURABLE_V1;
     chimera_smb_durable_register(shared, &of, 7, cguid, "bar", 3, false);
     chimera_smb_durable_park(shared, &of);
-    claimed = chimera_smb_durable_claim(shared, 0x999, NULL, cguid, "bar", 3, false, NULL, &cold, &status);
+    claimed = chimera_smb_durable_claim(shared, 0x999, NULL, cguid, "bar", 3, false, NULL, &cold, &retry, &status);
     if (claimed == &of && status == SMB2_STATUS_SUCCESS) {
         TEST_PASS("durable: v1 (no-guid) reconnect reclaims the open");
     } else {
@@ -1116,6 +1124,7 @@ test_durable_cold_recover_claim(void)
     uint8_t                           other[16];
     uint32_t                          status;
     bool                              cold;
+    bool                              retry;
     int                               i;
 
     chimera_smb_durable_table_init(&shared->durable);
@@ -1144,14 +1153,14 @@ test_durable_cold_recover_claim(void)
 
     /* Claim of a cold entry returns NULL + SUCCESS + cold=true (caller must
      * re-open the file) and consumes the entry. */
-    claimed = chimera_smb_durable_claim(shared, 0x5000, guid, cguid, "abc", 3, false, NULL, &cold, &status);
+    claimed = chimera_smb_durable_claim(shared, 0x5000, guid, cguid, "abc", 3, false, NULL, &cold, &retry, &status);
     if (claimed == NULL && cold && status == SMB2_STATUS_SUCCESS) {
         TEST_PASS("durable cold: reclaim signals cold re-open");
     } else {
         TEST_FAIL("durable cold: reclaim signals cold re-open");
     }
 
-    claimed = chimera_smb_durable_claim(shared, 0x5000, guid, cguid, "abc", 3, false, NULL, &cold, &status);
+    claimed = chimera_smb_durable_claim(shared, 0x5000, guid, cguid, "abc", 3, false, NULL, &cold, &retry, &status);
     if (claimed == NULL && !cold && status == SMB2_STATUS_OBJECT_NAME_NOT_FOUND) {
         TEST_PASS("durable cold: entry consumed after reclaim");
     } else {
@@ -1161,7 +1170,7 @@ test_durable_cold_recover_claim(void)
     /* Wrong client reclaiming a cold entry is denied. */
     rec.persistent_id = 0x5001;
     chimera_smb_durable_recover_entry(shared, &rec);
-    claimed = chimera_smb_durable_claim(shared, 0x5001, guid, other, "abc", 3, false, NULL, &cold, &status);
+    claimed = chimera_smb_durable_claim(shared, 0x5001, guid, other, "abc", 3, false, NULL, &cold, &retry, &status);
     if (claimed == NULL && !cold && status == SMB2_STATUS_OBJECT_NAME_NOT_FOUND) {
         TEST_PASS("durable cold: wrong client -> OBJECT_NAME_NOT_FOUND");
     } else {


### PR DESCRIPTION
Root-causes and fixes the `smb2.durable-v2-open.reopen2b` flake from the flake-gate reports (seen on `diskfs_aio` and `io_uring`, `durable_open.c:1165` — `status was OBJECT_NAME_NOT_FOUND, expected OK`).

## Root cause

The test opens a durable-v2 batch handle, drops the connection, reconnects, and reclaims the handle — and the reclaim is refused.

The reconnect comes in on a **fresh connection with its own event loop**, while the previous connection's disconnect hasn't been processed yet. There's no ordering between the new CREATE and the old TCP teardown. `chimera_smb_durable_claim` finds the surviving open still flagged live (`entry->parked == false` — parking only happens deep in the old connection's `conn_free → session_release → tree_free`) and refuses with `OBJECT_NAME_NOT_FOUND`, the same refusal that stops a second client stealing a genuinely-live handle.

I reproduced it deterministically with the `CHIMERA_SMB_TEST_DISCONNECT_DELAY_MS` hook (holds the teardown) and instrumented the order: the reclaim's `!parked` refusal fires **before** the old connection's disconnect handler even runs. The slower `diskfs_aio`/`io_uring` teardown widens the window naturally; under Debug/ASan it fails every time. **No parking-side change can win this** — the disconnect event hasn't been delivered when the reclaim runs (I tried an eager-park-on-disconnect approach first; it can't help because the disconnect handler itself hasn't started).

## Fix

On the reclaim side: `chimera_smb_durable_claim` now flags a "not parked" refusal as **retryable**, and `chimera_smb_durable_reconnect` re-attempts on a 20 ms timer (budget ~3 s), emitting a `STATUS_PENDING` interim so the client doesn't time out. Once the disconnect is processed the handle parks and the retry reclaims it.

- A handle that is **genuinely still live** never parks → the budget lapses into `OBJECT_NAME_NOT_FOUND`, exactly as before (just delayed) — the multichannel-steal protection is preserved.
- Any **other** refusal (no entry, create_guid / lease-key / client_guid mismatch, yielded) stays terminal and is answered immediately. So `reopen2b`'s wrong-GUID v2 leg still fails fast the moment the handle parks — the retry only spins while the entry exists but isn't parked.

## Validation

- New ctest pin `smbtorture_smb2_durable_v2_open_reopen2b_disconnect_race_memfs` (the existing delay-pinned regression set, at 50 ms): fails every time without this change, passes with it. Also verified at 0/50/200/500 ms on Release and Debug/ASan.
- Full durable matrix **232/232** across all backends; `smb2.lease`/`smb2.oplock` **91/91**; the #755 disconnect-race pins still green. Debug/ASan durable sweep clean (no sanitizer reports).

Branches off current `main` (includes #755). Companion to the DELEG20 fix (#756) and the disconnect-race fix (#755) — same family of disconnect-vs-reconnect races, different leg.