### PR TITLE
pynfs: raise courteous suite timeout to 180s to fix COUR7 flake recurrence

### DIFF
--- a/pynfs/CMakeLists.txt
+++ b/pynfs/CMakeLists.txt
@@ -114,14 +114,20 @@ set(PYNFS_LEASE_OVERRIDE_deleg DELEG8)
 # PYNFS_LEASE_OVERRIDE_SECONDS_<flag> overrides the shared default above.
 #
 # The flake is load-correlated -- a heavy ctest -j run is exactly when the 1000
-# client setup is slowest, pushing total runtime toward the 60s default wrapper
-# timeout (pynfs_test_wrapper.sh) just as the longer sleeps already cost more.
-# Raise the courteous wrapper timeout (PYNFS_TIMEOUT_<flag>, plumbed below) to
-# absorb that variance; 90s leaves ample headroom (COUR1's lease*2 = 40s sleep
-# plus even a badly inflated setup) while still flagging a genuine hang.
+# client setup is slowest, pushing total runtime toward the wrapper timeout just
+# as the longer sleeps already cost more.  COUR7's budget is:
+#   setup (1000 clients) + sleep(lease+10 = 30s) + conflicting open
+# The 90s ceiling that appeared sufficient when the fix was written (with ~8-10s
+# setup observed then) proved too tight after the devcontainer test job was split
+# into per-category shards: all pynfs tests now run concurrently in one shard,
+# and the heavier intra-shard parallelism pushes the setup past 60s under CI
+# load, hitting the 90s wall.  The whole family fails in lockstep -- the
+# classic all-backends-at-once load-induced timeout signature.  Raise to 180s,
+# matching the headroom already given to the other load-sensitive pynfs suites
+# (delegations, destroy_session, readdir).
 set(PYNFS_LEASE_OVERRIDE_courteous COUR1 COUR2 COUR3 COUR4 COUR5 COUR6 COUR7)
 set(PYNFS_LEASE_OVERRIDE_SECONDS_courteous 20)
-set(PYNFS_TIMEOUT_courteous 90)
+set(PYNFS_TIMEOUT_courteous 180)
 
 # Per-code delegation-enable override.  The wrapper enables NFSv4 protocol
 # delegations only for the deleg/delegations suites, so the other suites


### PR DESCRIPTION
## Root cause

COUR7 (`testExpiringManyClients`) has been flaking again in CI since 2026-06-12 (issue #733), recurring after the original fix in PR #526 (ea8db284, merged 2026-05-25).

PR #526 correctly diagnosed the mechanism: COUR7 creates 1000 clients back-to-back, and under CI load the 1000-client setup phase can exceed the wrapper's wall-clock budget (90s - 30s sleep = 60s for setup).  The fix raised the lease to 20s and the timeout to 90s, which held for ~18 days.

The recurrence is explained by subsequent CI restructuring: the devcontainer test jobs were split into per-category shards (ci-phase-split).  The pynfs shard now runs the **entire pynfs matrix concurrently** — all 12 COUR7 instances (6 backends × nfs4.1 + nfs4.2) compete for CPU alongside all other pynfs tests simultaneously, rather than being spread across multiple test jobs.  Under this heavier intra-shard parallelism, the 1000-client setup takes materially longer than the ~8-10s observed when the 90s ceiling was chosen, exhausting the setup budget.

The lockstep failure pattern (all 6 backends fail in the same CI run, then pass on `--rerun-failed`) is the classic load-induced timeout signature: all backends start simultaneously under the same load conditions, all hit the same ceiling, and all pass when retried without competing tests.

## The fix

Raise `PYNFS_TIMEOUT_courteous` from 90s to 180s, matching the headroom already given to the other load-sensitive pynfs suites (`delegations`/`destroy_session`/`readdir`, all 180s).

The lease (20s) remains unchanged.  An individual `EXCHANGE_ID` → `CREATE_SESSION` handshake gap exceeding 20s is impossible on loopback regardless of load (pynfs sends `CREATE_SESSION` immediately after receiving the `EXCHANGE_ID` response, and both are processed by chimera in microseconds).  The `NFS4ERR_STALE_CLIENTID` path that PR #516 fixed is not in play; the failure mode here is purely wall-clock timeout.

## Relationship to #516

PR #516 fixed a real server bug (lease not renewed on `EXCHANGE_ID`/`CREATE_SESSION`).  That fix held — the server is correct.  The ongoing flakes are test-harness timing, not a server regression.

Recurrence after #526 / COUR7 in issue #733.