### PR TITLE
client: cap default rcu_reclaim_threads at 4 to avoid thread exhaustion on many-core hosts

### DIFF
--- a/src/client/client.c
+++ b/src/client/client.c
@@ -32,7 +32,7 @@ chimera_client_config_init(void)
     config->async_delegation         = 0;
     config->async_delegation_threads = 8;
     config->cache_ttl                = 60;
-    config->rcu_reclaim_threads      = 0; /* 0 = one call_rcu worker per CPU */
+    config->rcu_reclaim_threads      = 4; /* 4 = cap RCU reclaim workers to avoid thread exhaustion on many-core hosts */
     config->max_fds                  = 1024;
 
     strncpy(config->modules[0].module_name, "root", sizeof(config->modules[0].module_name));


### PR DESCRIPTION
## Root cause

`rcu_reclaim_threads = 0` means "one `call_rcu` worker per CPU" (via `create_all_cpu_call_rcu_data`).  On the 384-vCPU CI runners this creates **384 RCU worker threads** per chimera client instance.  With `-j 32` parallel tests, each test forking a parent+child process that both call `chimera_posix_init_json` independently:

```
32 tests × 2 processes × ~465 threads/process ≈ 29,760 threads
```

Under this load `pthread_create` can transiently return `EAGAIN` (thread limit temporarily exhausted).  `evpl_thread_create` did **not** check this return value, leaving `evpl_thread->ready == 0` and the caller blocked in `pthread_cond_wait` forever — manifesting as a 240-second watchdog hang in `posix/fcntl_io_uring`, `posix/fcntl_nfs3_io_uring`, and `posix/cthon/cthon_lock_tlock_io_uring` on rocky10-amd64-Debug.

The watchdog added in commit 3114959c confirmed the symptom: child main thread stuck in `futex_wait_queue` (i.e. `pthread_cond_wait`) with all 80+ worker threads also in `futex_wait_queue` — meaning no worker ever signaled ready.

## Fix

Cap the default `rcu_reclaim_threads` at **4** instead of 0-per-CPU.  Four RCU workers are sufficient for reclaim throughput.  The existing `common.rcu_reclaim_threads` JSON knob lets operators tune upward for write-heavy workloads.

## Companion fix (pending libevpl PR)

A defense-in-depth fix to `evpl_thread_create` — retry `pthread_create` on EAGAIN with exponential back-off (1 ms → 100 ms cap, up to 100 attempts) before aborting — is being submitted to `chimera-nas/libevpl` separately.  That fix converts a silent forever-hang into a bounded retry + fast abort with a diagnostic message.