### PR TITLE
smb/tests: per-session WPTS shadow Bin dir, drop the RESOURCE_LOCK

### DIFF
--- a/scripts/wpts_smb_test_wrapper.sh
+++ b/scripts/wpts_smb_test_wrapper.sh
@@ -92,6 +92,9 @@ cleanup() {
     done
     timeout 2s ip netns delete "${NETNS_NAME}" 2>/dev/null || true
     rm -rf "$SESSION_DIR"
+    # The Bin-dir shadow may live outside SESSION_DIR (on the Bin dir's own
+    # filesystem, so it can be hardlinked); clean it up explicitly.
+    [ -n "${WPTS_STAGE_DIR:-}" ] && rm -rf "$WPTS_STAGE_DIR"
 }
 trap cleanup EXIT
 
@@ -243,17 +246,55 @@ if [ "$ready" != "1" ]; then
     exit 1
 fi
 
-# Stage our pinned ptfconfig fixtures into the WPTS Bin dir. WPTS auto-loads
-# the *.deployment.ptfconfig files sitting next to the test DLL.
-cp -f "${WPTS_PTFCONFIG_DIR}/CommonTestSuite.deployment.ptfconfig" \
-      "${WPTS_PTFCONFIG_DIR}/MS-SMB2_ServerTestSuite.deployment.ptfconfig" \
-      "${WPTS_BIN_DIR}/"
+# Stage a per-session shadow of the WPTS Bin dir.  PTF auto-loads the
+# *.deployment.ptfconfig files sitting next to the test DLL and also writes its
+# logs there, so running the suite straight out of the shared Bin dir would
+# force every WPTS test to serialize on it.  Each session instead gets its own
+# materialised copy of the Bin dir and runs vstest out of that.
+#
+# It must be a *real* directory of files, NOT a symlink farm: .NET resolves a
+# symlinked assembly back to its real path, so PTF would look for the
+# ptfconfig next to the original DLL (in the shared Bin dir) and the per-config
+# overrides would never take effect.  Hardlinks (and copies) have no such
+# resolution, so the staged DLL's real path is the shadow and PTF reads our
+# staged ptfconfig.  Hardlinking is near-free but only works within a single
+# filesystem, so the shadow is created on the Bin dir's own filesystem when a
+# writable same-device location exists, falling back to a full copy otherwise.
+WPTS_BIN_ABS=$(cd "${WPTS_BIN_DIR}" && pwd)
+_bin_dev=$(stat -c %d "${WPTS_BIN_ABS}")
+_shadow_parent="${SESSION_DIR}"
+for _cand in "${WPTS_SHADOW_ROOT:-}" "$(dirname "${WPTS_BIN_ABS}")" "${TMPDIR:-/tmp}" /var/tmp; do
+    [ -n "${_cand}" ] && [ -d "${_cand}" ] && [ -w "${_cand}" ] || continue
+    if [ "$(stat -c %d "${_cand}" 2>/dev/null)" = "${_bin_dev}" ]; then
+        _shadow_parent="${_cand}"
+        break
+    fi
+done
+WPTS_STAGE_DIR=$(mktemp -d "${_shadow_parent}/wpts_bin_XXXXXX")
+if [ "$(stat -c %d "${WPTS_STAGE_DIR}")" = "${_bin_dev}" ]; then
+    cp -al "${WPTS_BIN_ABS}/." "${WPTS_STAGE_DIR}/"
+else
+    cp -a "${WPTS_BIN_ABS}/." "${WPTS_STAGE_DIR}/"
+fi
+
+# Swap in our per-config ptfconfig fixtures as PRIVATE copies.  rm first: in
+# the hardlink case the staged file still shares the shared Bin dir's inode, so
+# editing it in place would corrupt the original.  Likewise drop any PTF/vstest
+# scratch outputs carried over from the source so each session writes its own
+# (the '.\TestLog' dir name is a literal backslash on Linux).
+rm -f "${WPTS_STAGE_DIR}/CommonTestSuite.deployment.ptfconfig" \
+      "${WPTS_STAGE_DIR}/MS-SMB2_ServerTestSuite.deployment.ptfconfig" \
+      "${WPTS_STAGE_DIR}/PTFApplicationLog.txt"
+rm -rf "${WPTS_STAGE_DIR}/TestResults" "${WPTS_STAGE_DIR}/.\\TestLog"
+cp "${WPTS_PTFCONFIG_DIR}/CommonTestSuite.deployment.ptfconfig" \
+   "${WPTS_PTFCONFIG_DIR}/MS-SMB2_ServerTestSuite.deployment.ptfconfig" \
+   "${WPTS_STAGE_DIR}/"
 
 # When persistent handles are enabled, advertise the matching capability +
 # CA-share to the test driver so the DurableHandleV2 / PersistentHandle cases
 # become applicable (otherwise they are Inconclusive/skipped).
 if [ "${CHIMERA_SMB_PERSISTENT:-0}" = "1" ]; then
-    staged="${WPTS_BIN_DIR}/CommonTestSuite.deployment.ptfconfig"
+    staged="${WPTS_STAGE_DIR}/CommonTestSuite.deployment.ptfconfig"
     sed -i \
         -e 's#<Property name="IsPersistentHandlesSupported" value="false"/>#<Property name="IsPersistentHandlesSupported" value="true"/>#' \
         -e 's#<Property name="CAShareName" value=""/>#<Property name="CAShareName" value="FileShare"/>#' \
@@ -265,7 +306,7 @@ fi
 # a compressed share so the SMB2Compression cases become applicable. Chimera
 # implements Plain LZ77 and the chained Pattern_V1 run-length payload.
 if [ "${CHIMERA_SMB_COMPRESSION:-0}" = "1" ]; then
-    staged="${WPTS_BIN_DIR}/CommonTestSuite.deployment.ptfconfig"
+    staged="${WPTS_STAGE_DIR}/CommonTestSuite.deployment.ptfconfig"
     sed -i \
         -e 's#<Property name="CompressedFileShare" value=""/>#<Property name="CompressedFileShare" value="SMBBasic"/>#' \
         -e 's#<Property name="IsChainedCompressionSupported" value="false"/>#<Property name="IsChainedCompressionSupported" value="true"/>#' \
@@ -278,8 +319,8 @@ fi
 # applicable (they assert serverIps.Count > 1 and the IsMultiChannelCapable
 # capability; otherwise they are Inconclusive/skipped).
 if [ "${CHIMERA_SMB_MULTICHANNEL:-0}" = "1" ]; then
-    staged_common="${WPTS_BIN_DIR}/CommonTestSuite.deployment.ptfconfig"
-    staged_smb2="${WPTS_BIN_DIR}/MS-SMB2_ServerTestSuite.deployment.ptfconfig"
+    staged_common="${WPTS_STAGE_DIR}/CommonTestSuite.deployment.ptfconfig"
+    staged_smb2="${WPTS_STAGE_DIR}/MS-SMB2_ServerTestSuite.deployment.ptfconfig"
     sed -i \
         -e 's#<Property name="IsMultiChannelCapable" value="false"/>#<Property name="IsMultiChannelCapable" value="true"/>#' \
         -e "s#<Property name=\"ClientNic2IPAddress\" value=\"\"/>#<Property name=\"ClientNic2IPAddress\" value=\"${SUT_IP2}\"/>#" \
@@ -298,7 +339,7 @@ fi
 # know the cipher set to validate the echoed Connection.CipherId
 # (BVT_Negotiate_SMB311).
 if [ "${CHIMERA_SMB_ENCRYPTION:-0}" = "1" ]; then
-    staged="${WPTS_BIN_DIR}/CommonTestSuite.deployment.ptfconfig"
+    staged="${WPTS_STAGE_DIR}/CommonTestSuite.deployment.ptfconfig"
     sed -i \
         -e 's#<Property name="IsEncryptionSupported" value="false"/>#<Property name="IsEncryptionSupported" value="true"/>#' \
         -e 's#<Property name="IsGlobalEncryptDataEnabled" value="false"/>#<Property name="IsGlobalEncryptDataEnabled" value="true"/>#' \
@@ -332,7 +373,7 @@ ip netns exec "${NETNS_NAME}" env \
     DOTNET_NOLOGO=1 \
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1 \
     HOME="${SESSION_DIR}" \
-    "$DOTNET" vstest "${WPTS_BIN_DIR}/MS-SMB2_ServerTestSuite.dll" \
+    "$DOTNET" vstest "${WPTS_STAGE_DIR}/MS-SMB2_ServerTestSuite.dll" \
         "${FILTER_ARGS[@]}" \
         --logger:"trx;LogFileName=SMB2TestResult.trx" \
         --ResultsDirectory:"${RESULT_DIR}"

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -213,9 +213,9 @@ if(CHIMERA_NETNS_TESTING AND WPTS_DOTNET AND WPTS_SMB2_DLL AND WPTS_ARCH_SUPPORT
     # single chimera server, rather than one ctest (one daemon + .NET host
     # bringup) per case -- the bringup dominated, so batching is ~10x faster.
     # vstest --Tests takes a comma-separated name list (CMake lists are
-    # ';'-separated, so swap the separator).  The group ctests still share the
-    # WPTS Bin dir for ptfconfig staging, so RESOURCE_LOCK serializes them
-    # against each other.
+    # ';'-separated, so swap the separator).  The wrapper stages a per-session
+    # shadow of the WPTS Bin dir (symlink farm + private ptfconfig copies), so
+    # the group ctests share no mutable state and may run concurrently.
     string(REPLACE ";" "," _wpts_tests "${WPTS_SMB2_ALLOWLIST}")
     add_test(NAME chimera/server/smb/wpts/memfs
         COMMAND ${CMAKE_SOURCE_DIR}/scripts/wpts_smb_test_wrapper.sh
@@ -223,7 +223,6 @@ if(CHIMERA_NETNS_TESTING AND WPTS_DOTNET AND WPTS_SMB2_DLL AND WPTS_ARCH_SUPPORT
     set_tests_properties(chimera/server/smb/wpts/memfs PROPERTIES
         LABELS "smb;wpts"
         TIMEOUT 900
-        RESOURCE_LOCK wpts_smb_bin
         ENVIRONMENT "WPTS_BIN_DIR=${WPTS_BIN_DIR};DOTNET=${WPTS_DOTNET}")
 
     # SMB3 durable / persistent handle cases plus the Replay (channel-sequence)
@@ -288,7 +287,6 @@ if(CHIMERA_NETNS_TESTING AND WPTS_DOTNET AND WPTS_SMB2_DLL AND WPTS_ARCH_SUPPORT
     set_tests_properties(chimera/server/smb/wpts/memfs_persistent PROPERTIES
         LABELS "smb;wpts;persistent"
         TIMEOUT 900
-        RESOURCE_LOCK wpts_smb_bin
         ENVIRONMENT "WPTS_BIN_DIR=${WPTS_BIN_DIR};DOTNET=${WPTS_DOTNET};CHIMERA_SMB_PERSISTENT=1")
 
     # SMB3 transport-compression cases.  These need the daemon run with
@@ -344,7 +342,6 @@ if(CHIMERA_NETNS_TESTING AND WPTS_DOTNET AND WPTS_SMB2_DLL AND WPTS_ARCH_SUPPORT
     set_tests_properties(chimera/server/smb/wpts/memfs_compression PROPERTIES
         LABELS "smb;wpts;compression"
         TIMEOUT 900
-        RESOURCE_LOCK wpts_smb_bin
         ENVIRONMENT "WPTS_BIN_DIR=${WPTS_BIN_DIR};DOTNET=${WPTS_DOTNET};CHIMERA_SMB_COMPRESSION=1")
 
     # SMB3 multichannel cases.  The wrapper runs the daemon with a second NIC
@@ -389,7 +386,6 @@ if(CHIMERA_NETNS_TESTING AND WPTS_DOTNET AND WPTS_SMB2_DLL AND WPTS_ARCH_SUPPORT
     set_tests_properties(chimera/server/smb/wpts/memfs_multichannel PROPERTIES
         LABELS "smb;wpts;multichannel"
         TIMEOUT 900
-        RESOURCE_LOCK wpts_smb_bin
         ENVIRONMENT "WPTS_BIN_DIR=${WPTS_BIN_DIR};DOTNET=${WPTS_DOTNET};CHIMERA_SMB_MULTICHANNEL=1")
 
     # SMB3 transport-encryption cases.  These need the daemon run with
@@ -421,7 +417,6 @@ if(CHIMERA_NETNS_TESTING AND WPTS_DOTNET AND WPTS_SMB2_DLL AND WPTS_ARCH_SUPPORT
     set_tests_properties(chimera/server/smb/wpts/memfs_encryption PROPERTIES
         LABELS "smb;wpts;encryption"
         TIMEOUT 900
-        RESOURCE_LOCK wpts_smb_bin
         ENVIRONMENT "WPTS_BIN_DIR=${WPTS_BIN_DIR};DOTNET=${WPTS_DOTNET};CHIMERA_SMB_ENCRYPTION=1")
 
     # Compression + encryption combined cases (compress-then-encrypt, MS-SMB2
@@ -442,7 +437,6 @@ if(CHIMERA_NETNS_TESTING AND WPTS_DOTNET AND WPTS_SMB2_DLL AND WPTS_ARCH_SUPPORT
     set_tests_properties(chimera/server/smb/wpts/memfs_compression_encryption PROPERTIES
         LABELS "smb;wpts;compression;encryption"
         TIMEOUT 900
-        RESOURCE_LOCK wpts_smb_bin
         ENVIRONMENT "WPTS_BIN_DIR=${WPTS_BIN_DIR};DOTNET=${WPTS_DOTNET};CHIMERA_SMB_COMPRESSION=1;CHIMERA_SMB_ENCRYPTION=1")
 
     # Multichannel + encryption combined case: encryption is session-scoped, so
@@ -460,7 +454,6 @@ if(CHIMERA_NETNS_TESTING AND WPTS_DOTNET AND WPTS_SMB2_DLL AND WPTS_ARCH_SUPPORT
     set_tests_properties(chimera/server/smb/wpts/memfs_multichannel_encryption PROPERTIES
         LABELS "smb;wpts;multichannel;encryption"
         TIMEOUT 900
-        RESOURCE_LOCK wpts_smb_bin
         ENVIRONMENT "WPTS_BIN_DIR=${WPTS_BIN_DIR};DOTNET=${WPTS_DOTNET};CHIMERA_SMB_MULTICHANNEL=1;CHIMERA_SMB_ENCRYPTION=1")
 
     message(STATUS "WPTS MS-SMB2 tests: enabled (${WPTS_BIN_DIR}, ${WPTS_DOTNET})")


### PR DESCRIPTION
The WPTS config-group ctests serialized on a `RESOURCE_LOCK` because the
wrapper staged each config's ptfconfig into the shared WPTS Bin dir (PTF
auto-loads the `*.deployment.ptfconfig` next to the test DLL and writes its
logs there too).

This gives each session its own **materialised shadow** of the Bin dir and
runs vstest out of that. It is deliberately a real directory of files, **not
a symlink farm**: .NET resolves a symlinked assembly back to its real path,
so PTF would discover the ptfconfig next to the *original* DLL in the shared
Bin dir and the per-config overrides would silently not apply — the suite
connects to the stock `SutIPAddress` (192.168.1.11) and times out. (This is
exactly how the first version of this PR failed in the merge queue.)

The shadow is **hardlinked** (near-free) when a writable location on the Bin
dir's own filesystem exists, falling back to a full copy otherwise. The two
mutable ptfconfig fixtures are swapped in as private copies (removed first, so
the hardlink case cannot write through into the shared Bin dir), and PTF /
vstest scratch outputs carried over from the source are dropped so each
session writes its own.

With no shared mutable state the `RESOURCE_LOCK` is removed from all seven
config-group entries.

Verified locally:
- pointed the wrapper at a throwaway Bin with the **stock** 192.168.1.11 IPs
  and confirmed the suite still reaches the daemon on 10.0.0.1 — i.e. PTF reads
  the shadow's ptfconfig, the failure mode the symlink version hit is gone;
- two consecutive `-j7` parallel runs of all seven config-groups green
  (~390s serial → ~93s), shared Bin dir ptfconfig mtimes untouched, no leftover
  shadow dirs.