### PR TITLE
posix: port pjdfstest conformance suite + raise POSIX compliance

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -765,7 +765,7 @@ jobs:
       matrix:
         arch: [amd64, arm64]
         build_type: [Release, Debug]
-        category: [pynfs, smbtorture, wpts, posix-client, s3, client, unit, kvm-cthon, kvm-xfsprogs, kvm-pnfs]
+        category: [pynfs, smbtorture, wpts, posix-client, pjdfstest, s3, client, unit, kvm-cthon, kvm-xfsprogs, kvm-pnfs]
         include:
           - { arch: amd64, runner: arc-amd64 }
           - { arch: arm64, runner: arc-arm64 }
@@ -820,9 +820,10 @@ jobs:
                 smbtorture)   SEL="-L smbtorture" ;;
                 wpts)         SEL="-L wpts" ;;
                 posix-client) SEL="-L posix" ;;
+                pjdfstest)    SEL="-L pjdfstest" ;;
                 s3)           SEL="-L s3" ;;
                 client)       SEL="-L client" ;;
-                unit)         SEL="-LE pynfs|smbtorture|wpts|posix|s3|client|kvm" ;;
+                unit)         SEL="-LE pynfs|smbtorture|wpts|posix|pjdfstest|s3|client|kvm" ;;
                 kvm-cthon)    SEL="-L kvm -R /cthon/";    NEED_KVM=1 ;;
                 kvm-xfsprogs) SEL="-L kvm -R /xfstests/"; NEED_KVM=1 ;;
                 kvm-pnfs)     SEL="-L pnfs";              NEED_KVM=1 ;;

--- a/LICENSES/BSD-2-Clause.txt
+++ b/LICENSES/BSD-2-Clause.txt
@@ -1,0 +1,9 @@
+Copyright (c) <year> <owner> 
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/src/posix/tests/CMakeLists.txt
+++ b/src/posix/tests/CMakeLists.txt
@@ -975,6 +975,172 @@ foreach(prog test_fcntl test_lockf)
     add_posix_nfs3rdma_test_myuser(${test_name} ${prog} linux)
 endforeach()
 
+# pjdfstest POSIX conformance ports (one program per upstream .t file).
+# Each lives under pjd/<category>/NN.c and shares pjd_common.h.  Registered on
+# memfs first; widen the backend list per category as it greens.
+# ============================================================================
+set(PJD_TESTS
+    open/00
+    open/01
+    open/02
+    open/03
+    open/04
+    open/05
+    open/06
+    open/07
+    open/08
+    open/12
+    open/13
+    open/16
+    open/22
+    open/26
+    chmod/00
+    chmod/01
+    chmod/02
+    chmod/03
+    chmod/04
+    chmod/05
+    chmod/06
+    chmod/07
+    chown/00
+    chown/01
+    chown/02
+    chown/03
+    chown/04
+    chown/05
+    chown/06
+    chown/07
+    truncate/00
+    truncate/01
+    truncate/02
+    truncate/03
+    truncate/04
+    truncate/05
+    truncate/06
+    truncate/07
+    truncate/09
+    truncate/13
+    ftruncate/00
+    ftruncate/13
+    mkdir/00
+    mkdir/01
+    mkdir/02
+    mkdir/03
+    mkdir/04
+    mkdir/05
+    mkdir/06
+    mkdir/07
+    mkdir/10
+    rmdir/00
+    rmdir/01
+    rmdir/02
+    rmdir/03
+    rmdir/04
+    rmdir/05
+    rmdir/06
+    rmdir/07
+    rmdir/08
+    rmdir/11
+    rmdir/12
+    mkfifo/00
+    mkfifo/01
+    mkfifo/02
+    mkfifo/03
+    mkfifo/04
+    mkfifo/05
+    mkfifo/06
+    mkfifo/07
+    mkfifo/09
+    mknod/00
+    mknod/01
+    mknod/02
+    mknod/03
+    mknod/04
+    mknod/05
+    mknod/06
+    mknod/07
+    mknod/08
+    mknod/11
+    symlink/00
+    symlink/01
+    symlink/02
+    symlink/03
+    symlink/04
+    symlink/05
+    symlink/06
+    symlink/07
+    symlink/08
+    unlink/00
+    unlink/01
+    unlink/02
+    unlink/03
+    unlink/04
+    unlink/05
+    unlink/06
+    unlink/07
+    unlink/08
+    unlink/11
+    unlink/14
+    link/00
+    link/01
+    link/02
+    link/03
+    link/04
+    link/06
+    link/07
+    link/08
+    link/09
+    link/10
+    link/11
+    rename/00
+    rename/01
+    rename/02
+    rename/03
+    rename/04
+    rename/05
+    rename/11
+    rename/12
+    rename/13
+    rename/14
+    rename/18
+    rename/19
+    rename/20
+    rename/22
+    utimensat/00
+    utimensat/01
+    utimensat/02
+    utimensat/04
+    utimensat/08
+    utimensat/06
+    utimensat/07
+    utimensat/09
+)
+
+macro(add_pjd_testprog path)
+    string(REPLACE "/" "_" _pjd_flat ${path})
+    add_executable(posix_pjd_${_pjd_flat} pjd/${path}.c)
+    target_link_libraries(posix_pjd_${_pjd_flat} chimera_posix chimera_client chimera_server jansson)
+    set_target_properties(posix_pjd_${_pjd_flat} PROPERTIES
+        TEST_FILE "${CMAKE_CURRENT_SOURCE_DIR}/pjd/${path}.c")
+endmacro()
+
+macro(add_pjd_test path backend)
+    if(CHIMERA_NETNS_TESTING)
+        string(REPLACE "/" "_" _pjd_flat ${path})
+        add_test(NAME chimera/posix/pjd/${path}/${backend}
+            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_pjd_${_pjd_flat} -b ${backend})
+        get_target_property(_pjd_tf posix_pjd_${_pjd_flat} TEST_FILE)
+        set_tests_properties(chimera/posix/pjd/${path}/${backend} PROPERTIES
+            ENVIRONMENT "TEST_FILE=${_pjd_tf}"
+            SKIP_RETURN_CODE 77)
+    endif()
+endmacro()
+
+foreach(t ${PJD_TESTS})
+    add_pjd_testprog(${t})
+    add_pjd_test(${t} memfs)
+endforeach()
+
 # Tag every test registered above with the 'posix' label so the whole suite can
 # be run independently via `ctest -L posix`.  Collected from the directory TESTS
 # property rather than per-add_test so new tests are covered automatically.

--- a/src/posix/tests/CMakeLists.txt
+++ b/src/posix/tests/CMakeLists.txt
@@ -1139,10 +1139,15 @@ macro(add_pjd_test path backend)
     endif()
 endmacro()
 
+# Backends the pjd suite is green on are registered here.  memfs and cairn pass
+# 134/134; diskfs/passthrough/NFS are widened by follow-up PRs as they green.
 set(_pjd_test_names "")
 foreach(t ${PJD_TESTS})
     add_pjd_testprog(${t})
     add_pjd_test(${t} memfs)
+    if(CAIRN_ENABLED)
+        add_pjd_test(${t} cairn)
+    endif()
 endforeach()
 
 # Tag the non-pjd tests with the 'posix' label so that suite can be run

--- a/src/posix/tests/CMakeLists.txt
+++ b/src/posix/tests/CMakeLists.txt
@@ -1133,17 +1133,23 @@ macro(add_pjd_test path backend)
         set_tests_properties(chimera/posix/pjd/${path}/${backend} PROPERTIES
             ENVIRONMENT "TEST_FILE=${_pjd_tf}"
             SKIP_RETURN_CODE 77)
+        # Track pjd tests so they can be labelled as their own CI shard
+        # (LABELS pjdfstest) and kept out of the broader 'posix' label.
+        list(APPEND _pjd_test_names chimera/posix/pjd/${path}/${backend})
     endif()
 endmacro()
 
+set(_pjd_test_names "")
 foreach(t ${PJD_TESTS})
     add_pjd_testprog(${t})
     add_pjd_test(${t} memfs)
 endforeach()
 
-# Tag every test registered above with the 'posix' label so the whole suite can
-# be run independently via `ctest -L posix`.  Collected from the directory TESTS
-# property rather than per-add_test so new tests are covered automatically.
+# Tag the non-pjd tests with the 'posix' label so that suite can be run
+# independently via `ctest -L posix`.  The pjdfstest ports are tagged separately
+# with 'pjdfstest' so they run as their own CI shard (alongside pynfs, s3, etc.)
+# instead of riding along in the broad posix-client shard.  Both are collected
+# from the directory TESTS property so new tests are covered automatically.
 #
 # Additionally tag each test with the VFS backend encoded in its name so an
 # entire backend can be run across every suite via e.g. `ctest -L linux`.  The
@@ -1153,8 +1159,12 @@ endforeach()
 # only the suite label.
 get_property(_posix_tests DIRECTORY PROPERTY TESTS)
 if(_posix_tests)
-    set_property(TEST ${_posix_tests} APPEND PROPERTY LABELS posix)
     foreach(_t IN LISTS _posix_tests)
+        if(_t IN_LIST _pjd_test_names)
+            set_property(TEST ${_t} APPEND PROPERTY LABELS pjdfstest)
+        else()
+            set_property(TEST ${_t} APPEND PROPERTY LABELS posix)
+        endif()
         foreach(_be diskfs_io_uring diskfs_aio io_uring memfs linux cairn)
             if(_t MATCHES "_${_be}($|_)")
                 set_property(TEST ${_t} APPEND PROPERTY LABELS ${_be})

--- a/src/posix/tests/pjd/chmod/00.c
+++ b/src/posix/tests/pjd/chmod/00.c
@@ -1,0 +1,121 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/chmod/00.t:
+* "chmod changes permission" - across every file type, chmod following a
+* symlink, ctime updates on success / no update on failure, and S_ISGID
+* clearing when a non-owner chmods a file whose group it does not match.
+* (lchmod is FreeBSD-only and omitted.) */
+
+#include "../../pjd_common.h"
+
+static const enum pjd_ftype types[] = {
+    PJD_FT_REGULAR, PJD_FT_DIR,    PJD_FT_FIFO,
+    PJD_FT_BLOCK,   PJD_FT_CHAR,   PJD_FT_SOCKET,
+    PJD_FT_SYMLINK,
+};
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+
+    char *n0 = pjd_namegen();
+    char *n1 = pjd_namegen();
+    char *n2 = pjd_namegen();
+
+    EXPECT(0, pjd_mkdir(n2, 0755));
+    pjd_cd(n2);
+
+    for (unsigned i = 0; i < sizeof(types) / sizeof(types[0]); i++) {
+        enum pjd_ftype t = types[i];
+
+        if (t != PJD_FT_SYMLINK) {
+            EXPECT(0, pjd_create_file(t, n0));
+            EXPECT(0, pjd_chmod(n0, 0111));
+            EXPECT_EQ(0111, pjd_stat_mode(n0));
+
+            /* chmod through a symlink affects the target, not the link. */
+            EXPECT(0, pjd_symlink(n0, n1));
+            int linkmode = pjd_lstat_mode(n1);
+            EXPECT(0, pjd_chmod(n1, 0222));
+            EXPECT_EQ(0222, pjd_stat_mode(n1));
+            EXPECT_EQ(0222, pjd_stat_mode(n0));
+            EXPECT_EQ(linkmode, pjd_lstat_mode(n1));
+            EXPECT(0, pjd_unlink(n1));
+
+            EXPECT(0, pjd_remove_file(t, n0));
+        }
+    }
+
+    /* Successful chmod updates ctime. */
+    for (unsigned i = 0; i < sizeof(types) / sizeof(types[0]); i++) {
+        enum pjd_ftype  t = types[i];
+        struct timespec c1, c2;
+
+        if (t == PJD_FT_SYMLINK) {
+            continue;
+        }
+
+        EXPECT(0, pjd_create_file(t, n0));
+        pjd_lstat_ctime(n0, &c1);
+        pjd_settle();
+        EXPECT(0, pjd_chmod(n0, 0111));
+        pjd_lstat_ctime(n0, &c2);
+        PJD_CHECK(pjd_timespec_lt(&c1, &c2), "ctime advanced after chmod (type %d)", t);
+        EXPECT(0, pjd_remove_file(t, n0));
+    }
+
+    /* Unsuccessful chmod (EPERM as non-owner) does not update ctime. */
+    for (unsigned i = 0; i < sizeof(types) / sizeof(types[0]); i++) {
+        enum pjd_ftype  t = types[i];
+        struct timespec c1, c2;
+
+        if (t == PJD_FT_SYMLINK) {
+            continue;
+        }
+
+        EXPECT(0, pjd_create_file(t, n0));
+        pjd_lstat_ctime(n0, &c1);
+        pjd_settle();
+        pjd_set_user(65534, 65534);
+        EXPECT(EPERM, pjd_chmod(n0, 0111));
+        pjd_set_root();
+        pjd_lstat_ctime(n0, &c2);
+        PJD_CHECK(c1.tv_sec == c2.tv_sec && c1.tv_nsec == c2.tv_nsec,
+                  "ctime unchanged after failed chmod (type %d)", t);
+        EXPECT(0, pjd_remove_file(t, n0));
+    }
+
+    /* POSIX: when a non-privileged process whose effective gid does not match
+     * the file's gid (and the file is a regular file) chmods it, S_ISGID is
+     * cleared on success. */
+    EXPECT(0, pjd_create(n0, 0755));
+    EXPECT(0, pjd_chown(n0, 65534, 65534));
+
+    pjd_set_user(65534, 65534);
+    EXPECT(0, pjd_chmod(n0, 02755));
+    pjd_set_root();
+    EXPECT_EQ(02755, pjd_stat_mode(n0));
+
+    pjd_set_user(65534, 65534);
+    EXPECT(0, pjd_chmod(n0, 0755));
+    pjd_set_root();
+    EXPECT_EQ(0755, pjd_stat_mode(n0));
+
+    /* gid 65533 != file gid 65534 -> Linux clears S_ISGID and succeeds. */
+    pjd_set_user(65534, 65533);
+    EXPECT(0, pjd_chmod(n0, 02755));
+    pjd_set_root();
+    EXPECT_EQ(0755, pjd_stat_mode(n0));
+
+    EXPECT(0, pjd_unlink(n0));
+
+    pjd_cd("..");
+    EXPECT(0, pjd_rmdir(n2));
+
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/chmod/00.c
+++ b/src/posix/tests/pjd/chmod/00.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/chmod/00.t:
 * "chmod changes permission" - across every file type, chmod following a

--- a/src/posix/tests/pjd/chmod/01.c
+++ b/src/posix/tests/pjd/chmod/01.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/chmod/01.t:
  * chmod returns ENOTDIR if a component of the path prefix is not a directory. */

--- a/src/posix/tests/pjd/chmod/01.c
+++ b/src/posix/tests/pjd/chmod/01.c
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/chmod/01.t:
+ * chmod returns ENOTDIR if a component of the path prefix is not a directory. */
+
+#include "../../pjd_common.h"
+
+static const enum pjd_ftype types[] = {
+    PJD_FT_REGULAR, PJD_FT_FIFO, PJD_FT_BLOCK, PJD_FT_CHAR, PJD_FT_SOCKET,
+};
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+
+    char *n0 = pjd_namegen();
+    char *n1 = pjd_namegen();
+    char  sub[256];
+
+    EXPECT(0, pjd_mkdir(n0, 0755));
+
+    for (unsigned i = 0; i < sizeof(types) / sizeof(types[0]); i++) {
+        snprintf(sub, sizeof(sub), "%s/%s", n0, n1);
+        EXPECT(0, pjd_create_file(types[i], sub));
+
+        char deeper[512];
+        snprintf(deeper, sizeof(deeper), "%s/%s/test", n0, n1);
+        EXPECT(ENOTDIR, pjd_chmod(deeper, 0644));
+
+        EXPECT(0, pjd_unlink(sub));
+    }
+
+    EXPECT(0, pjd_rmdir(n0));
+
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/chmod/02.c
+++ b/src/posix/tests/pjd/chmod/02.c
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/chmod/02.t:
+ * chmod returns ENAMETOOLONG if a pathname component exceeds {NAME_MAX}. */
+
+#include "../../pjd_common.h"
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+
+    char *nx = pjd_namegen_max();
+    char  nxx[512];
+
+    snprintf(nxx, sizeof(nxx), "%sx", nx);
+
+    EXPECT(0, pjd_create(nx, 0644));
+    EXPECT(0, pjd_chmod(nx, 0620));
+    EXPECT_EQ(0620, pjd_stat_mode(nx));
+    EXPECT(0, pjd_unlink(nx));
+    EXPECT(ENAMETOOLONG, pjd_chmod(nxx, 0620));
+
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/chmod/02.c
+++ b/src/posix/tests/pjd/chmod/02.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/chmod/02.t:
  * chmod returns ENAMETOOLONG if a pathname component exceeds {NAME_MAX}. */

--- a/src/posix/tests/pjd/chmod/03.c
+++ b/src/posix/tests/pjd/chmod/03.c
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/chmod/03.t:
+ * chmod returns ENAMETOOLONG if an entire pathname exceeds {PATH_MAX}.
+ * (Cleanup of the deep tree is unnecessary: the per-test backend is torn down
+ * at teardown.) */
+
+#include "../../pjd_common.h"
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+
+    char *nx = pjd_dirgen_max();
+    char  nxx[8192];
+
+    snprintf(nxx, sizeof(nxx), "%sx", nx);
+
+    pjd_mkdir_p(nx);
+
+    EXPECT(0, pjd_create(nx, 0644));
+    EXPECT(0, pjd_chmod(nx, 0642));
+    EXPECT_EQ(0642, pjd_stat_mode(nx));
+    EXPECT(0, pjd_unlink(nx));
+    EXPECT(ENAMETOOLONG, pjd_chmod(nxx, 0642));
+
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/chmod/03.c
+++ b/src/posix/tests/pjd/chmod/03.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/chmod/03.t:
  * chmod returns ENAMETOOLONG if an entire pathname exceeds {PATH_MAX}.

--- a/src/posix/tests/pjd/chmod/04.c
+++ b/src/posix/tests/pjd/chmod/04.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/chmod/04.t:
  * chmod returns ENOENT if the named file does not exist (including a chmod

--- a/src/posix/tests/pjd/chmod/04.c
+++ b/src/posix/tests/pjd/chmod/04.c
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/chmod/04.t:
+ * chmod returns ENOENT if the named file does not exist (including a chmod
+ * through a dangling symlink). */
+
+#include "../../pjd_common.h"
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+
+    char *n0 = pjd_namegen();
+    char *n1 = pjd_namegen();
+    char *n2 = pjd_namegen();
+    char  p1[256], p1t[512];
+
+    EXPECT(0, pjd_mkdir(n0, 0755));
+
+    snprintf(p1,  sizeof(p1),  "%s/%s", n0, n1);
+    snprintf(p1t, sizeof(p1t), "%s/%s/test", n0, n1);
+
+    EXPECT(ENOENT, pjd_chmod(p1t, 0644));
+    EXPECT(ENOENT, pjd_chmod(p1, 0644));
+
+    /* chmod follows the (dangling) symlink -> ENOENT. */
+    EXPECT(0, pjd_symlink(n2, p1));
+    EXPECT(ENOENT, pjd_chmod(p1, 0644));
+    EXPECT(0, pjd_unlink(p1));
+
+    EXPECT(0, pjd_rmdir(n0));
+
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/chmod/05.c
+++ b/src/posix/tests/pjd/chmod/05.c
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/chmod/05.t:
+ * chmod returns EACCES when search permission is denied for a component of the
+ * path prefix. */
+
+#include "../../pjd_common.h"
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+
+    char *n0 = pjd_namegen();
+    char *n1 = pjd_namegen();
+    char *n2 = pjd_namegen();
+    char  n1n2[256];
+
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    pjd_cd(n0);
+
+    EXPECT(0, pjd_mkdir(n1, 0755));
+    EXPECT(0, pjd_chown(n1, 65534, 65534));
+
+    snprintf(n1n2, sizeof(n1n2), "%s/%s", n1, n2);
+
+    pjd_set_user(65534, 65534);
+    EXPECT(0, pjd_create(n1n2, 0644));
+    EXPECT(0, pjd_chmod(n1n2, 0642));
+    EXPECT_EQ(0642, pjd_stat_mode(n1n2));
+    pjd_set_root();
+
+    /* Remove search permission on n1; non-owner can no longer traverse it. */
+    EXPECT(0, pjd_chmod(n1, 0644));
+    pjd_set_user(65534, 65534);
+    EXPECT(EACCES, pjd_chmod(n1n2, 0620));
+    pjd_set_root();
+
+    EXPECT(0, pjd_chmod(n1, 0755));
+    pjd_set_user(65534, 65534);
+    EXPECT(0, pjd_chmod(n1n2, 0420));
+    EXPECT_EQ(0420, pjd_stat_mode(n1n2));
+    EXPECT(0, pjd_unlink(n1n2));
+    pjd_set_root();
+
+    EXPECT(0, pjd_rmdir(n1));
+    pjd_cd("..");
+    EXPECT(0, pjd_rmdir(n0));
+
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/chmod/05.c
+++ b/src/posix/tests/pjd/chmod/05.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/chmod/05.t:
  * chmod returns EACCES when search permission is denied for a component of the

--- a/src/posix/tests/pjd/chmod/06.c
+++ b/src/posix/tests/pjd/chmod/06.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/chmod/06.t:
  * chmod returns ELOOP if too many symbolic links were encountered in

--- a/src/posix/tests/pjd/chmod/06.c
+++ b/src/posix/tests/pjd/chmod/06.c
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/chmod/06.t:
+ * chmod returns ELOOP if too many symbolic links were encountered in
+ * translating the pathname. */
+
+#include "../../pjd_common.h"
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+
+    char *n0 = pjd_namegen();
+    char *n1 = pjd_namegen();
+    char  n0t[256], n1t[256];
+
+    /* Two symlinks pointing at each other form a loop. */
+    EXPECT(0, pjd_symlink(n0, n1));
+    EXPECT(0, pjd_symlink(n1, n0));
+
+    EXPECT(ELOOP, pjd_chmod(n0, 0644));
+    EXPECT(ELOOP, pjd_chmod(n1, 0644));
+
+    snprintf(n0t, sizeof(n0t), "%s/test", n0);
+    snprintf(n1t, sizeof(n1t), "%s/test", n1);
+    EXPECT(ELOOP, pjd_chmod(n0t, 0644));
+    EXPECT(ELOOP, pjd_chmod(n1t, 0644));
+
+    EXPECT(0, pjd_unlink(n0));
+    EXPECT(0, pjd_unlink(n1));
+
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/chmod/07.c
+++ b/src/posix/tests/pjd/chmod/07.c
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/chmod/07.t:
+ * chmod returns EPERM if the effective user ID is neither the file owner nor
+ * the super-user (also via a symlink to the target). */
+
+#include "../../pjd_common.h"
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+
+    char *n0 = pjd_namegen();
+    char *n1 = pjd_namegen();
+    char *n2 = pjd_namegen();
+    char *n3 = pjd_namegen();
+    char  n1n2[256], n1n3[256];
+
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    pjd_cd(n0);
+
+    EXPECT(0, pjd_mkdir(n1, 0755));
+    EXPECT(0, pjd_chown(n1, 65534, 65534));
+
+    snprintf(n1n2, sizeof(n1n2), "%s/%s", n1, n2);
+    snprintf(n1n3, sizeof(n1n3), "%s/%s", n1, n3);
+
+    /* Owner (65534) may chmod; a different unprivileged user may not. */
+    pjd_set_user(65534, 65534);
+    EXPECT(0, pjd_create(n1n2, 0644));
+    EXPECT(0, pjd_chmod(n1n2, 0642));
+    pjd_set_root();
+    EXPECT_EQ(0642, pjd_stat_mode(n1n2));
+
+    pjd_set_user(65533, 65533);
+    EXPECT(EPERM, pjd_chmod(n1n2, 0641));
+    pjd_set_root();
+    EXPECT_EQ(0642, pjd_stat_mode(n1n2));
+
+    /* After chown to root, the former owner can no longer chmod. */
+    EXPECT(0, pjd_chown(n1n2, 0, 0));
+    pjd_set_user(65534, 65534);
+    EXPECT(EPERM, pjd_chmod(n1n2, 0641));
+    pjd_set_root();
+    EXPECT_EQ(0642, pjd_stat_mode(n1n2));
+    EXPECT(0, pjd_unlink(n1n2));
+
+    /* Same, but chmod via a symlink to the target. */
+    pjd_set_user(65534, 65534);
+    EXPECT(0, pjd_create(n1n2, 0644));
+    EXPECT(0, pjd_symlink(n2, n1n3));
+    EXPECT(0, pjd_chmod(n1n3, 0642));
+    pjd_set_root();
+    EXPECT_EQ(0642, pjd_stat_mode(n1n2));
+    EXPECT_EQ(65534, pjd_lstat_uid(n1n2));
+
+    pjd_set_user(65533, 65533);
+    EXPECT(EPERM, pjd_chmod(n1n3, 0641));
+    pjd_set_root();
+    EXPECT_EQ(0642, pjd_stat_mode(n1n2));
+
+    EXPECT(0, pjd_chown(n1n3, 0, 0));
+    pjd_set_user(65534, 65534);
+    EXPECT(EPERM, pjd_chmod(n1n3, 0641));
+    pjd_set_root();
+    EXPECT_EQ(0642, pjd_stat_mode(n1n2));
+    EXPECT_EQ(0, pjd_lstat_uid(n1n2));
+
+    EXPECT(0, pjd_unlink(n1n2));
+    EXPECT(0, pjd_unlink(n1n3));
+
+    EXPECT(0, pjd_rmdir(n1));
+    pjd_cd("..");
+    EXPECT(0, pjd_rmdir(n0));
+
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/chmod/07.c
+++ b/src/posix/tests/pjd/chmod/07.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/chmod/07.t:
  * chmod returns EPERM if the effective user ID is neither the file owner nor

--- a/src/posix/tests/pjd/chown/00.c
+++ b/src/posix/tests/pjd/chown/00.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/chown/00.t: "chown changes ownership".
  * Covers: super-user ownership changes (incl. via symlink and lchown);

--- a/src/posix/tests/pjd/chown/00.c
+++ b/src/posix/tests/pjd/chown/00.c
@@ -1,0 +1,225 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/chown/00.t: "chown changes ownership".
+ * Covers: super-user ownership changes (incl. via symlink and lchown);
+ * non-super-user group changes (owner + group membership); chown(-1,-1) as a
+ * permitted no-op; clearing of set-uid/set-gid on ownership change; and ctime
+ * updates.  Where Linux differs from POSIX/BSD (e.g. it does not clear SUID/SGID
+ * on a directory, and updates ctime on a -1/-1 chown), the corresponding upstream
+ * assertions are TODO; those are relaxed here. */
+
+#include "../../pjd_common.h"
+
+static const enum pjd_ftype types[] = {
+    PJD_FT_REGULAR, PJD_FT_DIR,    PJD_FT_FIFO,
+    PJD_FT_BLOCK,   PJD_FT_CHAR,   PJD_FT_SOCKET,  PJD_FT_SYMLINK,
+};
+
+static void
+check_uidgid(
+    const char *name,
+    long        uid,
+    long        gid)
+{
+    EXPECT_EQ(uid, pjd_lstat_uid(name));
+    EXPECT_EQ(gid, pjd_lstat_gid(name));
+} /* check_uidgid */
+
+/* Follow symlinks: stat-based uid/gid. */
+static void
+check_uidgid_follow(
+    const char *name,
+    long        uid,
+    long        gid)
+{
+    struct stat st;
+
+    if (pjd_stat(name, &st) != 0) {
+        PJD_CHECK(0, "stat %s for uid/gid", name);
+        return;
+    }
+    EXPECT_EQ(uid, (long) st.st_uid);
+    EXPECT_EQ(gid, (long) st.st_gid);
+} /* check_uidgid_follow */
+
+/* Mode is either of two acceptable values (e.g. 06555 not-cleared or 0555
+ * cleared), via stat (follow). */
+static void
+check_mode_either(
+    const char *name,
+    int         a,
+    int         b)
+{
+    int m = pjd_stat_mode(name);
+
+    PJD_CHECK(m == a || m == b, "mode %04o in {%04o,%04o} for %s", m, a, b, name);
+} /* check_mode_either */
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+
+    char          *n0 = pjd_namegen();
+    char          *n1 = pjd_namegen();
+    char          *n2 = pjd_namegen();
+    const uint32_t g31 = 65531, g32 = 65532;
+
+    EXPECT(0, pjd_mkdir(n2, 0755));
+    pjd_cd(n2);
+
+    /* --- super-user can always modify ownership --- */
+    for (unsigned i = 0; i < sizeof(types) / sizeof(types[0]); i++) {
+        enum pjd_ftype t = types[i];
+
+        if (t != PJD_FT_SYMLINK) {
+            EXPECT(0, pjd_create_file(t, n0));
+            EXPECT(0, pjd_chown(n0, 123, 456));
+            check_uidgid(n0, 123, 456);
+            EXPECT(0, pjd_chown(n0, 0, 0));
+            check_uidgid(n0, 0, 0);
+
+            EXPECT(0, pjd_symlink(n0, n1));
+            long luid = pjd_lstat_uid(n1), lgid = pjd_lstat_gid(n1);
+            EXPECT(0, pjd_chown(n1, 123, 456));
+            check_uidgid_follow(n1, 123, 456);
+            check_uidgid_follow(n0, 123, 456);
+            check_uidgid(n1, luid, lgid);   /* symlink itself unchanged */
+            EXPECT(0, pjd_unlink(n1));
+
+            EXPECT(0, pjd_remove_file(t, n0));
+        }
+
+        EXPECT(0, pjd_create_file(t, n0));
+        EXPECT(0, pjd_lchown(n0, 123, 456));
+        check_uidgid(n0, 123, 456);
+        EXPECT(0, pjd_remove_file(t, n0));
+    }
+
+    /* --- non-super-user may change group if owner and member of the group --- */
+    for (unsigned i = 0; i < sizeof(types) / sizeof(types[0]); i++) {
+        enum pjd_ftype t = types[i];
+
+        if (t != PJD_FT_SYMLINK) {
+            EXPECT(0, pjd_create_file(t, n0));
+            EXPECT(0, pjd_chown(n0, 65534, 65533));
+            check_uidgid(n0, 65534, 65533);
+
+            pjd_set_user_groups(65534, g32, 1, &g31);
+            EXPECT(0, pjd_chown(n0, (uid_t) -1, 65532));
+            check_uidgid(n0, 65534, 65532);
+            EXPECT(0, pjd_chown(n0, 65534, 65531));
+            check_uidgid(n0, 65534, 65531);
+            pjd_set_root();
+
+            EXPECT(0, pjd_remove_file(t, n0));
+        }
+
+        EXPECT(0, pjd_create_file(t, n0));
+        EXPECT(0, pjd_lchown(n0, 65534, 65533));
+        check_uidgid(n0, 65534, 65533);
+        pjd_set_user_groups(65534, g32, 1, &g31);
+        EXPECT(0, pjd_lchown(n0, (uid_t) -1, 65532));
+        check_uidgid(n0, 65534, 65532);
+        EXPECT(0, pjd_lchown(n0, 65534, 65531));
+        check_uidgid(n0, 65534, 65531);
+        pjd_set_root();
+        EXPECT(0, pjd_remove_file(t, n0));
+    }
+
+    /* --- chown(-1,-1) succeeds even for a non-owner --- */
+    for (unsigned i = 0; i < sizeof(types) / sizeof(types[0]); i++) {
+        enum pjd_ftype t = types[i];
+
+        if (t != PJD_FT_SYMLINK) {
+            EXPECT(0, pjd_create_file(t, n0));
+            pjd_set_user(65534, 65534);
+            EXPECT(0, pjd_chown(n0, (uid_t) -1, (gid_t) -1));
+            pjd_set_root();
+            check_uidgid_follow(n0, 0, 0);
+            EXPECT(0, pjd_remove_file(t, n0));
+        }
+
+        EXPECT(0, pjd_create_file(t, n0));
+        pjd_set_user(65534, 65534);
+        EXPECT(0, pjd_lchown(n0, (uid_t) -1, (gid_t) -1));
+        pjd_set_root();
+        check_uidgid(n0, 0, 0);
+        EXPECT(0, pjd_remove_file(t, n0));
+    }
+
+    /* --- super-user chown may clear set-uid/set-gid (either accepted) --- */
+    for (unsigned i = 0; i < sizeof(types) / sizeof(types[0]); i++) {
+        enum pjd_ftype t = types[i];
+
+        if (t == PJD_FT_SYMLINK) {
+            continue;
+        }
+        EXPECT(0, pjd_create_file(t, n0));
+        EXPECT(0, pjd_chown(n0, 65534, 65533));
+        EXPECT(0, pjd_chmod(n0, 06555));
+        EXPECT_EQ(06555, pjd_stat_mode(n0));
+        EXPECT(0, pjd_chown(n0, 65532, 65531));
+        check_mode_either(n0, 06555, 0555);
+        EXPECT(0, pjd_remove_file(t, n0));
+    }
+
+    /* --- non-super-user chown clears set-uid/set-gid (required on files;
+     *     Linux does not clear on directories, so accept either there) --- */
+    for (unsigned i = 0; i < sizeof(types) / sizeof(types[0]); i++) {
+        enum pjd_ftype t = types[i];
+
+        if (t == PJD_FT_SYMLINK) {
+            continue;
+        }
+        EXPECT(0, pjd_create_file(t, n0));
+        EXPECT(0, pjd_chown(n0, 65534, 65533));
+        EXPECT(0, pjd_chmod(n0, 06555));
+        EXPECT_EQ(06555, pjd_stat_mode(n0));
+
+        pjd_set_user_groups(65534, 65533, 1, &g32);
+        EXPECT(0, pjd_chown(n0, 65534, 65532));
+        pjd_set_root();
+        if (t == PJD_FT_DIR) {
+            check_mode_either(n0, 06555, 0555);
+        } else {
+            EXPECT_EQ(0555, pjd_stat_mode(n0));
+        }
+        EXPECT(0, pjd_remove_file(t, n0));
+    }
+
+    /* --- successful chown updates ctime; failed chown does not --- */
+    for (unsigned i = 0; i < sizeof(types) / sizeof(types[0]); i++) {
+        enum pjd_ftype  t = types[i];
+        struct timespec c1, c2;
+
+        EXPECT(0, pjd_create_file(t, n0));
+        pjd_lstat_ctime(n0, &c1);
+        pjd_settle();
+        EXPECT(0, pjd_lchown(n0, 65534, 65533));
+        check_uidgid(n0, 65534, 65533);
+        pjd_lstat_ctime(n0, &c2);
+        PJD_CHECK(pjd_timespec_lt(&c1, &c2), "ctime advanced after chown (type %d)", t);
+
+        /* Failed chown (EPERM) must not change ctime. */
+        pjd_lstat_ctime(n0, &c1);
+        pjd_settle();
+        pjd_set_user(65532, 65532);
+        EXPECT(EPERM, pjd_lchown(n0, 65532, 65532));
+        pjd_set_root();
+        pjd_lstat_ctime(n0, &c2);
+        PJD_CHECK(c1.tv_sec == c2.tv_sec && c1.tv_nsec == c2.tv_nsec,
+                  "ctime unchanged after failed chown (type %d)", t);
+
+        EXPECT(0, pjd_remove_file(t, n0));
+    }
+
+    pjd_cd("..");
+    EXPECT(0, pjd_rmdir(n2));
+
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/chown/01.c
+++ b/src/posix/tests/pjd/chown/01.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/chown/01.t:
  * chown returns ENOTDIR if a component of the path prefix is not a directory. */

--- a/src/posix/tests/pjd/chown/01.c
+++ b/src/posix/tests/pjd/chown/01.c
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/chown/01.t:
+ * chown returns ENOTDIR if a component of the path prefix is not a directory. */
+
+#include "../../pjd_common.h"
+
+static const enum pjd_ftype types[] = {
+    PJD_FT_REGULAR, PJD_FT_FIFO, PJD_FT_BLOCK, PJD_FT_CHAR, PJD_FT_SOCKET,
+};
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+
+    char *n0 = pjd_namegen();
+    char *n1 = pjd_namegen();
+    char  sub[256], deeper[512];
+
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    for (unsigned i = 0; i < sizeof(types) / sizeof(types[0]); i++) {
+        snprintf(sub, sizeof(sub), "%s/%s", n0, n1);
+        EXPECT(0, pjd_create_file(types[i], sub));
+        snprintf(deeper, sizeof(deeper), "%s/%s/test", n0, n1);
+        EXPECT(ENOTDIR, pjd_chown(deeper, 65534, 65534));
+        EXPECT(0, pjd_unlink(sub));
+    }
+    EXPECT(0, pjd_rmdir(n0));
+
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/chown/02.c
+++ b/src/posix/tests/pjd/chown/02.c
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/chown/02.t:
+ * chown returns ENAMETOOLONG if a pathname component exceeds {NAME_MAX}. */
+
+#include "../../pjd_common.h"
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+
+    char *nx = pjd_namegen_max();
+    char  nxx[512];
+
+    snprintf(nxx, sizeof(nxx), "%sx", nx);
+
+    EXPECT(0, pjd_create(nx, 0644));
+    EXPECT(0, pjd_chown(nx, 65534, 65534));
+    EXPECT_EQ(65534, pjd_lstat_uid(nx));
+    EXPECT(0, pjd_unlink(nx));
+    EXPECT(ENAMETOOLONG, pjd_chown(nxx, 65534, 65534));
+
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/chown/02.c
+++ b/src/posix/tests/pjd/chown/02.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/chown/02.t:
  * chown returns ENAMETOOLONG if a pathname component exceeds {NAME_MAX}. */

--- a/src/posix/tests/pjd/chown/03.c
+++ b/src/posix/tests/pjd/chown/03.c
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/chown/03.t:
+ * chown returns ENAMETOOLONG if an entire pathname exceeds {PATH_MAX}. */
+
+#include "../../pjd_common.h"
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+
+    char *nx = pjd_dirgen_max();
+    char  nxx[8192];
+
+    snprintf(nxx, sizeof(nxx), "%sx", nx);
+    pjd_mkdir_p(nx);
+
+    EXPECT(0, pjd_create(nx, 0644));
+    EXPECT(0, pjd_chown(nx, 65534, 65534));
+    EXPECT_EQ(65534, pjd_lstat_uid(nx));
+    EXPECT(0, pjd_unlink(nx));
+    EXPECT(ENAMETOOLONG, pjd_chown(nxx, 65534, 65534));
+
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/chown/03.c
+++ b/src/posix/tests/pjd/chown/03.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/chown/03.t:
  * chown returns ENAMETOOLONG if an entire pathname exceeds {PATH_MAX}. */

--- a/src/posix/tests/pjd/chown/04.c
+++ b/src/posix/tests/pjd/chown/04.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/chown/04.t:
  * chown returns ENOENT if the named file does not exist. */

--- a/src/posix/tests/pjd/chown/04.c
+++ b/src/posix/tests/pjd/chown/04.c
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/chown/04.t:
+ * chown returns ENOENT if the named file does not exist. */
+
+#include "../../pjd_common.h"
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+
+    char *n0 = pjd_namegen();
+    char *n1 = pjd_namegen();
+    char *n2 = pjd_namegen();
+    char  p1[256], p1t[512];
+
+    EXPECT(0, pjd_mkdir(n0, 0755));
+
+    snprintf(p1,  sizeof(p1),  "%s/%s", n0, n1);
+    snprintf(p1t, sizeof(p1t), "%s/%s/test", n0, n1);
+
+    EXPECT(ENOENT, pjd_chown(p1t, 65534, 65534));
+    EXPECT(ENOENT, pjd_chown(p1, 65534, 65534));
+
+    /* chown follows the (dangling) symlink -> ENOENT. */
+    EXPECT(0, pjd_symlink(n2, p1));
+    EXPECT(ENOENT, pjd_chown(p1, 65534, 65534));
+    EXPECT(0, pjd_unlink(p1));
+
+    EXPECT(0, pjd_rmdir(n0));
+
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/chown/05.c
+++ b/src/posix/tests/pjd/chown/05.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/chown/05.t:
  * chown returns EACCES when search permission is denied for a component of the

--- a/src/posix/tests/pjd/chown/05.c
+++ b/src/posix/tests/pjd/chown/05.c
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/chown/05.t:
+ * chown returns EACCES when search permission is denied for a component of the
+ * path prefix. */
+
+#include "../../pjd_common.h"
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+
+    char *n0 = pjd_namegen();
+    char *n1 = pjd_namegen();
+    char *n2 = pjd_namegen();
+    char  n1n2[256];
+
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    pjd_cd(n0);
+
+    EXPECT(0, pjd_mkdir(n1, 0755));
+    EXPECT(0, pjd_chown(n1, 65534, 65534));
+
+    snprintf(n1n2, sizeof(n1n2), "%s/%s", n1, n2);
+
+    pjd_set_user(65534, 65534);
+    EXPECT(0, pjd_create(n1n2, 0644));
+    EXPECT(0, pjd_chown(n1n2, 65534, 65534));
+    pjd_set_root();
+
+    /* Remove search permission on n1; non-owner can no longer traverse it. */
+    EXPECT(0, pjd_chmod(n1, 0644));
+    pjd_set_user(65534, 65534);
+    EXPECT(EACCES, pjd_chown(n1n2, 65534, 65534));
+    pjd_set_root();
+
+    EXPECT(0, pjd_chmod(n1, 0755));
+    pjd_set_user(65534, 65534);
+    EXPECT(0, pjd_chown(n1n2, 65534, 65534));
+    EXPECT(0, pjd_unlink(n1n2));
+    pjd_set_root();
+
+    EXPECT(0, pjd_rmdir(n1));
+    pjd_cd("..");
+    EXPECT(0, pjd_rmdir(n0));
+
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/chown/06.c
+++ b/src/posix/tests/pjd/chown/06.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/chown/06.t:
  * chown returns ELOOP if too many symbolic links were encountered in

--- a/src/posix/tests/pjd/chown/06.c
+++ b/src/posix/tests/pjd/chown/06.c
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/chown/06.t:
+ * chown returns ELOOP if too many symbolic links were encountered in
+ * translating the pathname. */
+
+#include "../../pjd_common.h"
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+
+    char *n0 = pjd_namegen();
+    char *n1 = pjd_namegen();
+    char  n0t[256], n1t[256];
+
+    EXPECT(0, pjd_symlink(n0, n1));
+    EXPECT(0, pjd_symlink(n1, n0));
+
+    EXPECT(ELOOP, pjd_chown(n0, 65534, 65534));
+    EXPECT(ELOOP, pjd_chown(n1, 65534, 65534));
+
+    snprintf(n0t, sizeof(n0t), "%s/test", n0);
+    snprintf(n1t, sizeof(n1t), "%s/test", n1);
+    EXPECT(ELOOP, pjd_chown(n0t, 65534, 65534));
+    EXPECT(ELOOP, pjd_chown(n1t, 65534, 65534));
+
+    EXPECT(0, pjd_unlink(n0));
+    EXPECT(0, pjd_unlink(n1));
+
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/chown/07.c
+++ b/src/posix/tests/pjd/chown/07.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/chown/07.t:
  * chown returns EPERM if the effective user is not the super-user and either is

--- a/src/posix/tests/pjd/chown/07.c
+++ b/src/posix/tests/pjd/chown/07.c
@@ -1,0 +1,93 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/chown/07.t:
+ * chown returns EPERM if the effective user is not the super-user and either is
+ * not the file owner, or attempts to change the owner (uid) or to a group it
+ * does not belong to. */
+
+#include "../../pjd_common.h"
+
+static const enum pjd_ftype types[] = {
+    PJD_FT_REGULAR, PJD_FT_DIR,    PJD_FT_FIFO,
+    PJD_FT_BLOCK,   PJD_FT_CHAR,   PJD_FT_SOCKET,  PJD_FT_SYMLINK,
+};
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+
+    char *n0 = pjd_namegen();
+    char *n1 = pjd_namegen();
+    char *n2 = pjd_namegen();
+    char *n3 = pjd_namegen();
+    char  n1n2[256], n1n3[256];
+
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    pjd_cd(n0);
+    EXPECT(0, pjd_mkdir(n1, 0755));
+    EXPECT(0, pjd_chown(n1, 65534, 65534));
+
+    snprintf(n1n2, sizeof(n1n2), "%s/%s", n1, n2);
+    snprintf(n1n3, sizeof(n1n3), "%s/%s", n1, n3);
+
+    for (unsigned i = 0; i < sizeof(types) / sizeof(types[0]); i++) {
+        enum pjd_ftype t = types[i];
+
+        if (t != PJD_FT_SYMLINK) {
+            EXPECT(0, pjd_create_file_owned(t, n1n2, 65534, 65534));
+
+            pjd_set_user(65534, 65534);
+            EXPECT(EPERM, pjd_chown(n1n2, 65533, 65533));
+            pjd_set_root();
+            pjd_set_user(65533, 65533);
+            EXPECT(EPERM, pjd_chown(n1n2, 65534, 65534));
+            EXPECT(EPERM, pjd_chown(n1n2, 65533, 65533));
+            pjd_set_root();
+            pjd_set_user(65534, 65534);
+            EXPECT(EPERM, pjd_chown(n1n2, (uid_t) -1, 65533));
+            pjd_set_root();
+
+            /* chown through a symlink to the target. */
+            pjd_set_user(65534, 65534);
+            EXPECT(0, pjd_symlink(n2, n1n3));
+            pjd_set_root();
+            pjd_set_user(65534, 65534);
+            EXPECT(EPERM, pjd_chown(n1n3, 65533, 65533));
+            pjd_set_root();
+            pjd_set_user(65533, 65533);
+            EXPECT(EPERM, pjd_chown(n1n3, 65534, 65534));
+            EXPECT(EPERM, pjd_chown(n1n3, 65533, 65533));
+            pjd_set_root();
+            pjd_set_user(65534, 65534);
+            EXPECT(EPERM, pjd_chown(n1n3, (uid_t) -1, 65533));
+            pjd_set_root();
+            EXPECT(0, pjd_unlink(n1n3));
+
+            EXPECT(0, pjd_remove_file(t, n1n2));
+        }
+
+        EXPECT(0, pjd_create_file_owned(t, n1n2, 65534, 65534));
+        pjd_set_user(65534, 65534);
+        EXPECT(EPERM, pjd_lchown(n1n2, 65533, 65533));
+        pjd_set_root();
+        pjd_set_user(65533, 65533);
+        EXPECT(EPERM, pjd_lchown(n1n2, 65534, 65534));
+        EXPECT(EPERM, pjd_lchown(n1n2, 65533, 65533));
+        pjd_set_root();
+        pjd_set_user(65534, 65534);
+        EXPECT(EPERM, pjd_lchown(n1n2, (uid_t) -1, 65533));
+        pjd_set_root();
+        EXPECT(0, pjd_remove_file(t, n1n2));
+    }
+
+    EXPECT(0, pjd_rmdir(n1));
+    pjd_cd("..");
+    EXPECT(0, pjd_rmdir(n0));
+
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/ftruncate/00.c
+++ b/src/posix/tests/pjd/ftruncate/00.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/ftruncate/00.t:
  * ftruncate decreases/increases file size on a writable descriptor, updates

--- a/src/posix/tests/pjd/ftruncate/00.c
+++ b/src/posix/tests/pjd/ftruncate/00.c
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/ftruncate/00.t:
+ * ftruncate decreases/increases file size on a writable descriptor, updates
+ * ctime, fails with EINVAL on a read-only descriptor, and is governed by the
+ * descriptor's access mode rather than the file's mode bits.
+ *
+ * (ftruncate/01-12,14 in pjdfstest are byte-for-byte copies of the path-based
+ * truncate tests and are covered by the truncate category.) */
+
+#include "../../pjd_common.h"
+
+/* open `name` with flags, ftruncate to len, return ftruncate's errno-or-0. */
+static int
+open_ftruncate(
+    const char *name,
+    int         flags,
+    off_t       len)
+{
+    int fd = pjd_open(name, flags, 0644);
+    int rc;
+
+    if (fd < 0) {
+        return errno ? errno : EBADF;
+    }
+    rc = chimera_posix_ftruncate(fd, len);
+    int e = (rc < 0) ? errno : 0;
+    chimera_posix_close(fd);
+    return e;
+} /* open_ftruncate */
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+
+    char           *n0 = pjd_namegen();
+    char           *n1 = pjd_namegen();
+    struct timespec c1, c2;
+
+    EXPECT(0, pjd_mkdir(n1, 0755));
+    pjd_cd(n1);
+
+    EXPECT(0, pjd_create(n0, 0644));
+    EXPECT_EQ(0, open_ftruncate(n0, O_RDWR, 1234567));
+    EXPECT_EQ(1234567, pjd_stat_size(n0));
+    EXPECT_EQ(0, open_ftruncate(n0, O_WRONLY, 567));
+    EXPECT_EQ(567, pjd_stat_size(n0));
+    EXPECT(0, pjd_unlink(n0));
+
+    /* Successful ftruncate updates ctime. */
+    EXPECT(0, pjd_create(n0, 0644));
+    pjd_stat_ctime(n0, &c1);
+    pjd_settle();
+    EXPECT_EQ(0, open_ftruncate(n0, O_RDWR, 123));
+    pjd_stat_ctime(n0, &c2);
+    PJD_CHECK(pjd_timespec_lt(&c1, &c2), "ctime advanced after ftruncate");
+    EXPECT(0, pjd_unlink(n0));
+
+    /* ftruncate on a read-only descriptor fails with EINVAL and leaves ctime. */
+    EXPECT(0, pjd_create(n0, 0644));
+    pjd_stat_ctime(n0, &c1);
+    pjd_settle();
+    pjd_set_user(65534, 65534);
+    EXPECT_EQ(EINVAL, open_ftruncate(n0, O_RDONLY, 123));
+    pjd_set_root();
+    pjd_stat_ctime(n0, &c2);
+    PJD_CHECK(c1.tv_sec == c2.tv_sec && c1.tv_nsec == c2.tv_nsec,
+              "ctime unchanged after failed ftruncate");
+    EXPECT(0, pjd_unlink(n0));
+
+    /* The file mode does not affect ftruncate -- only the descriptor's access
+     * mode does.  A freshly created mode-0 file opened O_RDWR can be ftruncated,
+     * by its owner and by an unprivileged creator alike. */
+    EXPECT_EQ(0, open_ftruncate(n0, O_CREAT | O_RDWR, 0));
+    EXPECT(0, pjd_unlink(n0));
+
+    EXPECT(0, pjd_chmod(".", 0777));
+    pjd_set_user(65534, 65534);
+    EXPECT_EQ(0, open_ftruncate(n0, O_CREAT | O_RDWR, 0));
+    EXPECT(0, pjd_unlink(n0));
+    pjd_set_root();
+
+    pjd_cd("..");
+    EXPECT(0, pjd_rmdir(n1));
+
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/ftruncate/13.c
+++ b/src/posix/tests/pjd/ftruncate/13.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/ftruncate/13.t:
  * ftruncate returns EINVAL if the length argument was less than 0. */

--- a/src/posix/tests/pjd/ftruncate/13.c
+++ b/src/posix/tests/pjd/ftruncate/13.c
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/ftruncate/13.t:
+ * ftruncate returns EINVAL if the length argument was less than 0. */
+
+#include "../../pjd_common.h"
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+
+    char *n0 = pjd_namegen();
+    int   fd;
+
+    EXPECT(0, pjd_create(n0, 0644));
+
+    fd = pjd_open(n0, O_RDWR, 0644);
+    PJD_CHECK(fd >= 0, "open n0 O_RDWR");
+    EXPECT(EINVAL, chimera_posix_ftruncate(fd, -1));
+    if (fd >= 0) {
+        chimera_posix_close(fd);
+    }
+
+    fd = pjd_open(n0, O_WRONLY, 0644);
+    PJD_CHECK(fd >= 0, "open n0 O_WRONLY");
+    EXPECT(EINVAL, chimera_posix_ftruncate(fd, -999999));
+    if (fd >= 0) {
+        chimera_posix_close(fd);
+    }
+
+    EXPECT(0, pjd_unlink(n0));
+
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/link/00.c
+++ b/src/posix/tests/pjd/link/00.c
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/link/00.t:
+ * link creates hard links - link count tracks across names, metadata is shared
+ * by all links, and removing names decrements the count until the inode is gone. */
+
+#include "../../pjd_common.h"
+
+static const enum pjd_ftype types[] = {
+    PJD_FT_REGULAR, PJD_FT_FIFO, PJD_FT_BLOCK, PJD_FT_CHAR, PJD_FT_SOCKET,
+};
+
+static mode_t
+type_fmt(enum pjd_ftype t)
+{
+    switch (t) {
+        case PJD_FT_REGULAR: return S_IFREG;
+        case PJD_FT_FIFO:    return S_IFIFO;
+        case PJD_FT_BLOCK:   return S_IFBLK;
+        case PJD_FT_CHAR:    return S_IFCHR;
+        case PJD_FT_SOCKET:  return S_IFSOCK;
+        default:             return 0;
+    } /* switch */
+} /* type_fmt */
+
+static void
+check(
+    const char *name,
+    mode_t      fmt,
+    int         mode,
+    long        nlink,
+    long        uid,
+    long        gid)
+{
+    struct stat st;
+
+    if (pjd_lstat(name, &st) != 0) {
+        PJD_CHECK(0, "lstat %s", name);
+        return;
+    }
+    PJD_CHECK((st.st_mode & S_IFMT) == fmt, "%s type", name);
+    if (mode >= 0) {
+        EXPECT_EQ(mode, st.st_mode & 07777);
+    }
+    EXPECT_EQ(nlink, (long) st.st_nlink);
+    if (uid >= 0) {
+        EXPECT_EQ(uid, (long) st.st_uid);
+    }
+    if (gid >= 0) {
+        EXPECT_EQ(gid, (long) st.st_gid);
+    }
+} /* check */
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+
+    char *n0 = pjd_namegen();
+    char *n1 = pjd_namegen();
+    char *n2 = pjd_namegen();
+    char *n3 = pjd_namegen();
+
+    EXPECT(0, pjd_mkdir(n3, 0755));
+    pjd_cd(n3);
+
+    for (unsigned i = 0; i < sizeof(types) / sizeof(types[0]); i++) {
+        mode_t fmt = type_fmt(types[i]);
+
+        EXPECT(0, pjd_create_file(types[i], n0));
+        check(n0, fmt, -1, 1, -1, -1);
+
+        EXPECT(0, pjd_link(n0, n1));
+        check(n0, fmt, -1, 2, -1, -1);
+        check(n1, fmt, -1, 2, -1, -1);
+
+        EXPECT(0, pjd_link(n1, n2));
+        check(n0, fmt, -1, 3, -1, -1);
+        check(n2, fmt, -1, 3, -1, -1);
+
+        /* Metadata is shared across all links. */
+        EXPECT(0, pjd_chmod(n1, 0201));
+        EXPECT(0, pjd_chown(n1, 65534, 65533));
+        check(n0, fmt, 0201, 3, 65534, 65533);
+        check(n1, fmt, 0201, 3, 65534, 65533);
+        check(n2, fmt, 0201, 3, 65534, 65533);
+
+        EXPECT(0, pjd_unlink(n0));
+        check(n1, fmt, 0201, 2, 65534, 65533);
+        check(n2, fmt, 0201, 2, 65534, 65533);
+
+        EXPECT(0, pjd_unlink(n2));
+        check(n1, fmt, 0201, 1, 65534, 65533);
+
+        EXPECT(0, pjd_unlink(n1));
+    }
+
+    pjd_cd("..");
+    EXPECT(0, pjd_rmdir(n3));
+
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/link/00.c
+++ b/src/posix/tests/pjd/link/00.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/link/00.t:
  * link creates hard links - link count tracks across names, metadata is shared

--- a/src/posix/tests/pjd/link/01.c
+++ b/src/posix/tests/pjd/link/01.c
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/link/01.t: ENOTDIR if a component of either path prefix is not a directory. */
+#include "../../pjd_common.h"
+static const enum pjd_ftype types[] = { PJD_FT_REGULAR, PJD_FT_FIFO, PJD_FT_BLOCK, PJD_FT_CHAR, PJD_FT_SOCKET };
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen(), *n1 = pjd_namegen();
+    char  sub[256], P[512];
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    for (unsigned i = 0; i < sizeof(types) / sizeof(types[0]); i++) {
+        snprintf(sub, sizeof(sub), "%s/%s", n0, n1);
+        EXPECT(0, pjd_create_file(types[i], sub));
+        snprintf(P, sizeof(P), "%s/%s/test", n0, n1);
+        /* dest prefix is a non-directory */
+        EXPECT(ENOTDIR, pjd_link(sub, P));
+        /* source prefix is a non-directory */
+        EXPECT(ENOTDIR, pjd_link(P, sub));
+        EXPECT(0, pjd_unlink(sub));
+    }
+    EXPECT(0, pjd_rmdir(n0));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/link/01.c
+++ b/src/posix/tests/pjd/link/01.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/link/01.t: ENOTDIR if a component of either path prefix is not a directory. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/link/02.c
+++ b/src/posix/tests/pjd/link/02.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/link/02.t: ENAMETOOLONG if a component of either pathname exceeds {NAME_MAX}. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/link/02.c
+++ b/src/posix/tests/pjd/link/02.c
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/link/02.t: ENAMETOOLONG if a component of either pathname exceeds {NAME_MAX}. */
+#include "../../pjd_common.h"
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen();
+    char *nx = pjd_namegen_max();
+    char  P[512];
+    snprintf(P, sizeof(P), "%sx", nx);
+    EXPECT(0, pjd_create(n0, 0644));
+    EXPECT(ENAMETOOLONG, pjd_link(n0, P));
+    EXPECT(ENAMETOOLONG, pjd_link(P, n0));
+    EXPECT(0, pjd_unlink(n0));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/link/03.c
+++ b/src/posix/tests/pjd/link/03.c
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/link/03.t: ENAMETOOLONG if an entire pathname exceeds {PATH_MAX}. */
+#include "../../pjd_common.h"
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen();
+    char *nx = pjd_dirgen_max();
+    char  P[8192];
+    snprintf(P, sizeof(P), "%sx", nx);
+    pjd_mkdir_p(nx);
+    EXPECT(0, pjd_create(n0, 0644));
+    EXPECT(ENAMETOOLONG, pjd_link(n0, P));
+    EXPECT(ENAMETOOLONG, pjd_link(P, n0));
+    EXPECT(0, pjd_unlink(n0));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/link/03.c
+++ b/src/posix/tests/pjd/link/03.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/link/03.t: ENAMETOOLONG if an entire pathname exceeds {PATH_MAX}. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/link/04.c
+++ b/src/posix/tests/pjd/link/04.c
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/link/04.t: ENOENT if a component of either path prefix does not exist. */
+#include "../../pjd_common.h"
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen(), *n1 = pjd_namegen(), *n2 = pjd_namegen();
+    char  src[256], P[512];
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    snprintf(src, sizeof(src), "%s/%s", n0, n1);
+    EXPECT(0, pjd_create(src, 0644));
+    snprintf(P, sizeof(P), "%s/%s/test", n0, n2);
+    EXPECT(ENOENT, pjd_link(src, P));
+    EXPECT(ENOENT, pjd_link(P, src));
+    EXPECT(0, pjd_unlink(src));
+    EXPECT(0, pjd_rmdir(n0));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/link/04.c
+++ b/src/posix/tests/pjd/link/04.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/link/04.t: ENOENT if a component of either path prefix does not exist. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/link/06.c
+++ b/src/posix/tests/pjd/link/06.c
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/link/06.t:
+ * link returns EACCES when a component of either path prefix denies search. */
+
+#include "../../pjd_common.h"
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+
+    char *n0 = pjd_namegen();
+    char *n1 = pjd_namegen();
+    char *n2 = pjd_namegen();
+    char *n3 = pjd_namegen();
+    char  src[256], dst[256];
+
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    pjd_cd(n0);
+
+    EXPECT(0, pjd_mkdir(n1, 0755));
+    EXPECT(0, pjd_chown(n1, 65534, 65534));
+
+    snprintf(src, sizeof(src), "%s/%s", n1, n2);
+    snprintf(dst, sizeof(dst), "%s/%s", n1, n3);
+
+    pjd_set_user(65534, 65534);
+    EXPECT(0, pjd_create(src, 0644));
+    EXPECT(0, pjd_link(src, dst));
+    EXPECT(0, pjd_unlink(dst));
+    pjd_set_root();
+
+    /* No search permission on n1 -> EACCES for both source and dest prefix. */
+    EXPECT(0, pjd_chmod(n1, 0644));
+    pjd_set_user(65534, 65534);
+    EXPECT(EACCES, pjd_link(src, dst));
+    pjd_set_root();
+
+    EXPECT(0, pjd_chmod(n1, 0755));
+    pjd_set_user(65534, 65534);
+    EXPECT(0, pjd_link(src, dst));
+    EXPECT(0, pjd_unlink(dst));
+    EXPECT(0, pjd_unlink(src));
+    pjd_set_root();
+
+    EXPECT(0, pjd_rmdir(n1));
+    pjd_cd("..");
+    EXPECT(0, pjd_rmdir(n0));
+
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/link/06.c
+++ b/src/posix/tests/pjd/link/06.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/link/06.t:
  * link returns EACCES when a component of either path prefix denies search. */

--- a/src/posix/tests/pjd/link/07.c
+++ b/src/posix/tests/pjd/link/07.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/link/07.t:
  * link returns EACCES when the requested link requires writing in a directory

--- a/src/posix/tests/pjd/link/07.c
+++ b/src/posix/tests/pjd/link/07.c
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/link/07.t:
+ * link returns EACCES when the requested link requires writing in a directory
+ * that denies write permission. */
+
+#include "../../pjd_common.h"
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+
+    char *n0 = pjd_namegen();
+    char *n1 = pjd_namegen();
+    char *n2 = pjd_namegen();
+    char *n3 = pjd_namegen();
+    char  src[256], dst[256];
+
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    pjd_cd(n0);
+
+    EXPECT(0, pjd_mkdir(n1, 0755));
+    EXPECT(0, pjd_chown(n1, 65534, 65534));
+
+    snprintf(src, sizeof(src), "%s/%s", n1, n2);
+    snprintf(dst, sizeof(dst), "%s/%s", n1, n3);
+
+    pjd_set_user(65534, 65534);
+    EXPECT(0, pjd_create(src, 0644));
+    EXPECT(0, pjd_link(src, dst));
+    EXPECT(0, pjd_unlink(dst));
+    pjd_set_root();
+
+    /* No write permission on n1 -> EACCES creating the new link. */
+    EXPECT(0, pjd_chmod(n1, 0555));
+    pjd_set_user(65534, 65534);
+    EXPECT(EACCES, pjd_link(src, dst));
+    pjd_set_root();
+
+    EXPECT(0, pjd_chmod(n1, 0755));
+    pjd_set_user(65534, 65534);
+    EXPECT(0, pjd_link(src, dst));
+    EXPECT(0, pjd_unlink(dst));
+    EXPECT(0, pjd_unlink(src));
+    pjd_set_root();
+
+    EXPECT(0, pjd_rmdir(n1));
+    pjd_cd("..");
+    EXPECT(0, pjd_rmdir(n0));
+
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/link/08.c
+++ b/src/posix/tests/pjd/link/08.c
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/link/08.t: ELOOP on a symlink loop in either pathname. */
+#include "../../pjd_common.h"
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen(), *n1 = pjd_namegen(), *n2 = pjd_namegen();
+    char  P0[256], P1[256];
+
+    EXPECT(0, pjd_symlink(n0, n1));
+    EXPECT(0, pjd_symlink(n1, n0));
+
+    snprintf(P0, sizeof(P0), "%s/test", n0);
+    snprintf(P1, sizeof(P1), "%s/test", n1);
+
+    /* Loop on the source side. */
+    EXPECT(ELOOP, pjd_link(P0, n2));
+    EXPECT(ELOOP, pjd_link(P1, n2));
+
+    /* Loop on the destination side (with a real, resolvable source). */
+    EXPECT(0, pjd_create(n2, 0644));
+    EXPECT(ELOOP, pjd_link(n2, P0));
+    EXPECT(ELOOP, pjd_link(n2, P1));
+
+    EXPECT(0, pjd_unlink(n0));
+    EXPECT(0, pjd_unlink(n1));
+    EXPECT(0, pjd_unlink(n2));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/link/08.c
+++ b/src/posix/tests/pjd/link/08.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/link/08.t: ELOOP on a symlink loop in either pathname. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/link/09.c
+++ b/src/posix/tests/pjd/link/09.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/link/09.t: ENOENT if the source file does not exist. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/link/09.c
+++ b/src/posix/tests/pjd/link/09.c
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/link/09.t: ENOENT if the source file does not exist. */
+#include "../../pjd_common.h"
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen(), *n1 = pjd_namegen();
+    EXPECT(ENOENT, pjd_link(n0, n1));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/link/10.c
+++ b/src/posix/tests/pjd/link/10.c
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/link/10.t: EEXIST if the destination already exists (any type). */
+#include "../../pjd_common.h"
+static const enum pjd_ftype types[] = { PJD_FT_REGULAR, PJD_FT_DIR, PJD_FT_FIFO, PJD_FT_BLOCK, PJD_FT_CHAR,
+                                        PJD_FT_SOCKET,  PJD_FT_SYMLINK };
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen(), *n1 = pjd_namegen();
+    EXPECT(0, pjd_create(n0, 0644));
+    for (unsigned i = 0; i < sizeof(types) / sizeof(types[0]); i++) {
+        EXPECT(0, pjd_create_file(types[i], n1));
+        EXPECT(EEXIST, pjd_link(n0, n1));
+        EXPECT(0, pjd_remove_file(types[i], n1));
+    }
+    EXPECT(0, pjd_unlink(n0));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/link/10.c
+++ b/src/posix/tests/pjd/link/10.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/link/10.t: EEXIST if the destination already exists (any type). */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/link/11.c
+++ b/src/posix/tests/pjd/link/11.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/link/11.t: EPERM if the source file is a directory. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/link/11.c
+++ b/src/posix/tests/pjd/link/11.c
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/link/11.t: EPERM if the source file is a directory. */
+#include "../../pjd_common.h"
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen(), *n1 = pjd_namegen(), *n2 = pjd_namegen();
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    EXPECT(EPERM, pjd_link(n0, n1));
+    EXPECT(0, pjd_rmdir(n0));
+
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    EXPECT(0, pjd_chown(n0, 65534, 65534));
+    pjd_cd(n0);
+    pjd_set_user(65534, 65534);
+    EXPECT(0, pjd_mkdir(n1, 0755));
+    EXPECT(EPERM, pjd_link(n1, n2));
+    EXPECT(0, pjd_rmdir(n1));
+    pjd_set_root();
+    pjd_cd("..");
+    EXPECT(0, pjd_rmdir(n0));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/mkdir/00.c
+++ b/src/posix/tests/pjd/mkdir/00.c
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/mkdir/00.t:
+ * mkdir creates directories - mode/umask application, uid/gid inheritance, and
+ * new-dir / parent-dir timestamp updates. */
+
+#include "../../pjd_common.h"
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+
+    char           *n0 = pjd_namegen();
+    char           *n1 = pjd_namegen();
+    struct timespec t0, t1;
+
+    EXPECT(0, pjd_mkdir(n1, 0755));
+    pjd_cd(n1);
+
+    /* mode honored, with umask applied. */
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    EXPECT_EQ(S_IFDIR, pjd_lstat_type(n0));
+    EXPECT_EQ(0755, pjd_lstat_mode(n0));
+    EXPECT(0, pjd_rmdir(n0));
+
+    EXPECT(0, pjd_mkdir(n0, 0151));
+    EXPECT_EQ(0151, pjd_lstat_mode(n0));
+    EXPECT(0, pjd_rmdir(n0));
+
+    chimera_posix_umask(0077);
+    EXPECT(0, pjd_mkdir(n0, 0151));
+    chimera_posix_umask(0);
+    EXPECT_EQ(0100, pjd_lstat_mode(n0));
+    EXPECT(0, pjd_rmdir(n0));
+
+    chimera_posix_umask(0070);
+    EXPECT(0, pjd_mkdir(n0, 0345));
+    chimera_posix_umask(0);
+    EXPECT_EQ(0305, pjd_lstat_mode(n0));
+    EXPECT(0, pjd_rmdir(n0));
+
+    chimera_posix_umask(0501);
+    EXPECT(0, pjd_mkdir(n0, 0345));
+    chimera_posix_umask(0);
+    EXPECT_EQ(0244, pjd_lstat_mode(n0));
+    EXPECT(0, pjd_rmdir(n0));
+
+    /* New dir's uid = effective uid; gid = parent gid or effective gid. */
+    EXPECT(0, pjd_chown(".", 65534, 65534));
+
+    pjd_set_user(65534, 65534);
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    pjd_set_root();
+    EXPECT_EQ(65534, pjd_lstat_uid(n0));
+    EXPECT_EQ(65534, pjd_lstat_gid(n0));
+    EXPECT(0, pjd_rmdir(n0));
+
+    pjd_set_user(65534, 65533);
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    pjd_set_root();
+    EXPECT_EQ(65534, pjd_lstat_uid(n0));
+    {
+        long g = pjd_lstat_gid(n0);
+        PJD_CHECK(g == 65533 || g == 65534, "new dir gid %ld in {65533,65534}", g);
+    }
+    EXPECT(0, pjd_rmdir(n0));
+
+    EXPECT(0, pjd_chmod(".", 0777));
+    pjd_set_user(65533, 65532);
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    pjd_set_root();
+    EXPECT_EQ(65533, pjd_lstat_uid(n0));
+    {
+        long g = pjd_lstat_gid(n0);
+        PJD_CHECK(g == 65532 || g == 65534, "new dir gid %ld in {65532,65534}", g);
+    }
+    EXPECT(0, pjd_rmdir(n0));
+
+    /* mkdir updates the parent's mtime/ctime and the new dir's timestamps. */
+    EXPECT(0, pjd_chown(".", 0, 0));
+    pjd_stat_ctime(".", &t0);
+    pjd_settle();
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    pjd_stat_mtime(".", &t1);
+    PJD_CHECK(pjd_timespec_lt(&t0, &t1), "parent mtime advanced on mkdir");
+    pjd_stat_ctime(".", &t1);
+    PJD_CHECK(pjd_timespec_lt(&t0, &t1), "parent ctime advanced on mkdir");
+    pjd_stat_mtime(n0, &t1);
+    PJD_CHECK(pjd_timespec_lt(&t0, &t1), "new dir mtime set");
+    EXPECT(0, pjd_rmdir(n0));
+
+    pjd_cd("..");
+    EXPECT(0, pjd_rmdir(n1));
+
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/mkdir/00.c
+++ b/src/posix/tests/pjd/mkdir/00.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/mkdir/00.t:
  * mkdir creates directories - mode/umask application, uid/gid inheritance, and

--- a/src/posix/tests/pjd/mkdir/01.c
+++ b/src/posix/tests/pjd/mkdir/01.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/mkdir/01.t: ENOTDIR if a path-prefix component is not a directory. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/mkdir/01.c
+++ b/src/posix/tests/pjd/mkdir/01.c
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/mkdir/01.t: ENOTDIR if a path-prefix component is not a directory. */
+#include "../../pjd_common.h"
+static const enum pjd_ftype types[] = { PJD_FT_REGULAR, PJD_FT_FIFO, PJD_FT_BLOCK, PJD_FT_CHAR, PJD_FT_SOCKET };
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen(), *n1 = pjd_namegen();
+    char  sub[256], deeper[512];
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    for (unsigned i = 0; i < sizeof(types) / sizeof(types[0]); i++) {
+        snprintf(sub, sizeof(sub), "%s/%s", n0, n1);
+        EXPECT(0, pjd_create_file(types[i], sub));
+        snprintf(deeper, sizeof(deeper), "%s/%s/test", n0, n1);
+        EXPECT(ENOTDIR, pjd_mkdir(deeper, 0755));
+        EXPECT(0, pjd_unlink(sub));
+    }
+    EXPECT(0, pjd_rmdir(n0));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/mkdir/02.c
+++ b/src/posix/tests/pjd/mkdir/02.c
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/mkdir/02.t: ENAMETOOLONG if a component exceeds {NAME_MAX}. */
+#include "../../pjd_common.h"
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *nx = pjd_namegen_max();
+    char  nxx[512];
+    snprintf(nxx, sizeof(nxx), "%sx", nx);
+    EXPECT(0, pjd_mkdir(nx, 0755));
+    EXPECT_EQ(S_IFDIR, pjd_lstat_type(nx));
+    EXPECT(0, pjd_rmdir(nx));
+    EXPECT(ENAMETOOLONG, pjd_mkdir(nxx, 0755));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/mkdir/02.c
+++ b/src/posix/tests/pjd/mkdir/02.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/mkdir/02.t: ENAMETOOLONG if a component exceeds {NAME_MAX}. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/mkdir/03.c
+++ b/src/posix/tests/pjd/mkdir/03.c
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/mkdir/03.t: ENAMETOOLONG if the whole path exceeds {PATH_MAX}. */
+#include "../../pjd_common.h"
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *nx = pjd_dirgen_max();
+    char  nxx[8192];
+    snprintf(nxx, sizeof(nxx), "%sx", nx);
+    pjd_mkdir_p(nx);
+    EXPECT(0, pjd_mkdir(nx, 0755));
+    EXPECT_EQ(S_IFDIR, pjd_lstat_type(nx));
+    EXPECT(0, pjd_rmdir(nx));
+    EXPECT(ENAMETOOLONG, pjd_mkdir(nxx, 0755));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/mkdir/03.c
+++ b/src/posix/tests/pjd/mkdir/03.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/mkdir/03.t: ENAMETOOLONG if the whole path exceeds {PATH_MAX}. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/mkdir/04.c
+++ b/src/posix/tests/pjd/mkdir/04.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/mkdir/04.t: ENOENT if a path-prefix component does not exist. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/mkdir/04.c
+++ b/src/posix/tests/pjd/mkdir/04.c
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/mkdir/04.t: ENOENT if a path-prefix component does not exist. */
+#include "../../pjd_common.h"
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen(), *n1 = pjd_namegen();
+    char  p[256];
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    snprintf(p, sizeof(p), "%s/%s/test", n0, n1);
+    EXPECT(ENOENT, pjd_mkdir(p, 0755));
+    EXPECT(0, pjd_rmdir(n0));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/mkdir/05.c
+++ b/src/posix/tests/pjd/mkdir/05.c
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/mkdir/05.t:
+ * mkdir returns EACCES when search permission is denied for a component of the
+ * path prefix. */
+
+#include "../../pjd_common.h"
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+
+    char *n0 = pjd_namegen();
+    char *n1 = pjd_namegen();
+    char *n2 = pjd_namegen();
+    char  n1n2[256];
+
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    pjd_cd(n0);
+
+    EXPECT(0, pjd_mkdir(n1, 0755));
+    EXPECT(0, pjd_chown(n1, 65534, 65534));
+
+    snprintf(n1n2, sizeof(n1n2), "%s/%s", n1, n2);
+
+    pjd_set_user(65534, 65534);
+    EXPECT(0, pjd_mkdir(n1n2, 0755));
+    EXPECT(0, pjd_rmdir(n1n2));
+    pjd_set_root();
+
+    /* No search permission on n1 -> EACCES. */
+    EXPECT(0, pjd_chmod(n1, 0644));
+    pjd_set_user(65534, 65534);
+    EXPECT(EACCES, pjd_mkdir(n1n2, 0755));
+    pjd_set_root();
+
+    EXPECT(0, pjd_chmod(n1, 0755));
+    pjd_set_user(65534, 65534);
+    EXPECT(0, pjd_mkdir(n1n2, 0755));
+    EXPECT(0, pjd_rmdir(n1n2));
+    pjd_set_root();
+
+    EXPECT(0, pjd_rmdir(n1));
+    pjd_cd("..");
+    EXPECT(0, pjd_rmdir(n0));
+
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/mkdir/05.c
+++ b/src/posix/tests/pjd/mkdir/05.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/mkdir/05.t:
  * mkdir returns EACCES when search permission is denied for a component of the

--- a/src/posix/tests/pjd/mkdir/06.c
+++ b/src/posix/tests/pjd/mkdir/06.c
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/mkdir/06.t:
+ * mkdir returns EACCES when write permission is denied on the parent directory
+ * of the directory to be created. */
+
+#include "../../pjd_common.h"
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+
+    char *n0 = pjd_namegen();
+    char *n1 = pjd_namegen();
+    char *n2 = pjd_namegen();
+    char  n1n2[256];
+
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    pjd_cd(n0);
+
+    EXPECT(0, pjd_mkdir(n1, 0755));
+    EXPECT(0, pjd_chown(n1, 65534, 65534));
+
+    snprintf(n1n2, sizeof(n1n2), "%s/%s", n1, n2);
+
+    pjd_set_user(65534, 65534);
+    EXPECT(0, pjd_mkdir(n1n2, 0755));
+    EXPECT(0, pjd_rmdir(n1n2));
+    pjd_set_root();
+
+    /* Parent n1 read+execute only (no write) -> EACCES. */
+    EXPECT(0, pjd_chmod(n1, 0555));
+    pjd_set_user(65534, 65534);
+    EXPECT(EACCES, pjd_mkdir(n1n2, 0755));
+    pjd_set_root();
+
+    EXPECT(0, pjd_chmod(n1, 0755));
+    pjd_set_user(65534, 65534);
+    EXPECT(0, pjd_mkdir(n1n2, 0755));
+    EXPECT(0, pjd_rmdir(n1n2));
+    pjd_set_root();
+
+    EXPECT(0, pjd_rmdir(n1));
+    pjd_cd("..");
+    EXPECT(0, pjd_rmdir(n0));
+
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/mkdir/06.c
+++ b/src/posix/tests/pjd/mkdir/06.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/mkdir/06.t:
  * mkdir returns EACCES when write permission is denied on the parent directory

--- a/src/posix/tests/pjd/mkdir/07.c
+++ b/src/posix/tests/pjd/mkdir/07.c
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/mkdir/07.t: ELOOP on a symlink loop in the pathname. */
+#include "../../pjd_common.h"
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen(), *n1 = pjd_namegen();
+    char  n0t[256], n1t[256];
+    EXPECT(0, pjd_symlink(n0, n1));
+    EXPECT(0, pjd_symlink(n1, n0));
+    snprintf(n0t, sizeof(n0t), "%s/test", n0);
+    snprintf(n1t, sizeof(n1t), "%s/test", n1);
+    EXPECT(ELOOP, pjd_mkdir(n0t, 0755));
+    EXPECT(ELOOP, pjd_mkdir(n1t, 0755));
+    EXPECT(0, pjd_unlink(n0));
+    EXPECT(0, pjd_unlink(n1));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/mkdir/07.c
+++ b/src/posix/tests/pjd/mkdir/07.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/mkdir/07.t: ELOOP on a symlink loop in the pathname. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/mkdir/10.c
+++ b/src/posix/tests/pjd/mkdir/10.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/mkdir/10.t: EEXIST if the named file exists (any type). */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/mkdir/10.c
+++ b/src/posix/tests/pjd/mkdir/10.c
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/mkdir/10.t: EEXIST if the named file exists (any type). */
+#include "../../pjd_common.h"
+static const enum pjd_ftype types[] = { PJD_FT_REGULAR, PJD_FT_DIR, PJD_FT_FIFO, PJD_FT_BLOCK, PJD_FT_CHAR,
+                                        PJD_FT_SOCKET,  PJD_FT_SYMLINK };
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen();
+    for (unsigned i = 0; i < sizeof(types) / sizeof(types[0]); i++) {
+        EXPECT(0, pjd_create_file(types[i], n0));
+        EXPECT(EEXIST, pjd_mkdir(n0, 0755));
+        EXPECT(0, pjd_remove_file(types[i], n0));
+    }
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/mkfifo/00.c
+++ b/src/posix/tests/pjd/mkfifo/00.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/mkfifo/00.t: creates FIFO files - mode/umask, uid/gid
  * inheritance, and new-node / parent-dir timestamp updates. */

--- a/src/posix/tests/pjd/mkfifo/00.c
+++ b/src/posix/tests/pjd/mkfifo/00.c
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/mkfifo/00.t: creates FIFO files - mode/umask, uid/gid
+ * inheritance, and new-node / parent-dir timestamp updates. */
+#include "../../pjd_common.h"
+static int mkf(
+    const char *n,
+    mode_t      m){ return pjd_mkfifo(n, m); }
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char           *n0 = pjd_namegen(), *n1 = pjd_namegen();
+    struct timespec t0, t1;
+    EXPECT(0, pjd_mkdir(n1, 0755));
+    pjd_cd(n1);
+
+    EXPECT(0, mkf(n0, 0755));
+    EXPECT_EQ(S_IFIFO, pjd_lstat_type(n0));
+    EXPECT_EQ(0755, pjd_lstat_mode(n0));
+    EXPECT(0, pjd_unlink(n0));
+    EXPECT(0, mkf(n0, 0151));
+    EXPECT_EQ(0151, pjd_lstat_mode(n0));
+    EXPECT(0, pjd_unlink(n0));
+    chimera_posix_umask(0077); EXPECT(0, mkf(n0, 0151)); chimera_posix_umask(0);
+    EXPECT_EQ(0100, pjd_lstat_mode(n0));
+    EXPECT(0, pjd_unlink(n0));
+    chimera_posix_umask(0070); EXPECT(0, mkf(n0, 0345)); chimera_posix_umask(0);
+    EXPECT_EQ(0305, pjd_lstat_mode(n0));
+    EXPECT(0, pjd_unlink(n0));
+    chimera_posix_umask(0501); EXPECT(0, mkf(n0, 0345)); chimera_posix_umask(0);
+    EXPECT_EQ(0244, pjd_lstat_mode(n0));
+    EXPECT(0, pjd_unlink(n0));
+
+    EXPECT(0, pjd_chown(".", 65534, 65534));
+    pjd_set_user(65534, 65534); EXPECT(0, mkf(n0, 0755)); pjd_set_root();
+    EXPECT_EQ(65534, pjd_lstat_uid(n0));
+    EXPECT_EQ(65534, pjd_lstat_gid(n0));
+    EXPECT(0, pjd_unlink(n0));
+    pjd_set_user(65534, 65533); EXPECT(0, mkf(n0, 0755)); pjd_set_root();
+    EXPECT_EQ(65534, pjd_lstat_uid(n0));
+    { long g = pjd_lstat_gid(n0); PJD_CHECK(g == 65533 || g == 65534, "gid %ld", g); }
+    EXPECT(0, pjd_unlink(n0));
+
+    EXPECT(0, pjd_chown(".", 0, 0));
+    pjd_stat_ctime(".", &t0);
+    pjd_settle();
+    EXPECT(0, mkf(n0, 0755));
+    pjd_stat_mtime(".", &t1); PJD_CHECK(pjd_timespec_lt(&t0, &t1), "parent mtime");
+    pjd_stat_ctime(".", &t1); PJD_CHECK(pjd_timespec_lt(&t0, &t1), "parent ctime");
+    pjd_stat_mtime(n0, &t1);  PJD_CHECK(pjd_timespec_lt(&t0, &t1), "node mtime");
+    EXPECT(0, pjd_unlink(n0));
+
+    pjd_cd("..");
+    EXPECT(0, pjd_rmdir(n1));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/mkfifo/01.c
+++ b/src/posix/tests/pjd/mkfifo/01.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/mkfifo/01.t: ENOTDIR if a path-prefix component is not a directory. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/mkfifo/01.c
+++ b/src/posix/tests/pjd/mkfifo/01.c
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/mkfifo/01.t: ENOTDIR if a path-prefix component is not a directory. */
+#include "../../pjd_common.h"
+static const enum pjd_ftype types[] = { PJD_FT_REGULAR, PJD_FT_FIFO, PJD_FT_BLOCK, PJD_FT_CHAR, PJD_FT_SOCKET };
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen(), *n1 = pjd_namegen();
+    char  sub[256], P[512];
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    for (unsigned i = 0; i < sizeof(types) / sizeof(types[0]); i++) {
+        snprintf(sub, sizeof(sub), "%s/%s", n0, n1);
+        EXPECT(0, pjd_create_file(types[i], sub));
+        snprintf(P, sizeof(P), "%s/%s/test", n0, n1);
+        EXPECT(ENOTDIR, pjd_mkfifo(P, 0644));
+        EXPECT(0, pjd_unlink(sub));
+    }
+    EXPECT(0, pjd_rmdir(n0));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/mkfifo/02.c
+++ b/src/posix/tests/pjd/mkfifo/02.c
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/mkfifo/02.t: ENAMETOOLONG if a component exceeds {NAME_MAX}. */
+#include "../../pjd_common.h"
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *nx = pjd_namegen_max();
+    char  P[512];
+    snprintf(P, sizeof(P), "%sx", nx);
+    EXPECT(ENAMETOOLONG, pjd_mkfifo(P, 0644));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/mkfifo/02.c
+++ b/src/posix/tests/pjd/mkfifo/02.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/mkfifo/02.t: ENAMETOOLONG if a component exceeds {NAME_MAX}. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/mkfifo/03.c
+++ b/src/posix/tests/pjd/mkfifo/03.c
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/mkfifo/03.t: ENAMETOOLONG if the whole path exceeds {PATH_MAX}. */
+#include "../../pjd_common.h"
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *nx = pjd_dirgen_max();
+    char  P[8192];
+    snprintf(P, sizeof(P), "%sx", nx);
+    pjd_mkdir_p(nx);
+    EXPECT(ENAMETOOLONG, pjd_mkfifo(P, 0644));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/mkfifo/03.c
+++ b/src/posix/tests/pjd/mkfifo/03.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/mkfifo/03.t: ENAMETOOLONG if the whole path exceeds {PATH_MAX}. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/mkfifo/04.c
+++ b/src/posix/tests/pjd/mkfifo/04.c
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/mkfifo/04.t: ENOENT if a path-prefix component does not exist. */
+#include "../../pjd_common.h"
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen(), *n1 = pjd_namegen();
+    char  P[512];
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    snprintf(P, sizeof(P), "%s/%s/test", n0, n1);
+    EXPECT(ENOENT, pjd_mkfifo(P, 0644));
+    EXPECT(0, pjd_rmdir(n0));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/mkfifo/04.c
+++ b/src/posix/tests/pjd/mkfifo/04.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/mkfifo/04.t: ENOENT if a path-prefix component does not exist. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/mkfifo/05.c
+++ b/src/posix/tests/pjd/mkfifo/05.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/mkfifo/05.t: EACCES when search permission is denied for a path-prefix component. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/mkfifo/05.c
+++ b/src/posix/tests/pjd/mkfifo/05.c
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/mkfifo/05.t: EACCES when search permission is denied for a path-prefix component. */
+#include "../../pjd_common.h"
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen(), *n1 = pjd_namegen(), *n2 = pjd_namegen();
+    char  P[256];
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    pjd_cd(n0);
+    EXPECT(0, pjd_mkdir(n1, 0755));
+    EXPECT(0, pjd_chown(n1, 65534, 65534));
+    snprintf(P, sizeof(P), "%s/%s", n1, n2);
+    pjd_set_user(65534, 65534);
+    EXPECT(0, pjd_mkfifo(P, 0644));
+    EXPECT(0, pjd_unlink(P));
+    pjd_set_root();
+    EXPECT(0, pjd_chmod(n1, 0644));
+    pjd_set_user(65534, 65534);
+    EXPECT(EACCES, pjd_mkfifo(P, 0644));
+    pjd_set_root();
+    EXPECT(0, pjd_chmod(n1, 0755));
+    EXPECT(0, pjd_rmdir(n1));
+    pjd_cd("..");
+    EXPECT(0, pjd_rmdir(n0));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/mkfifo/06.c
+++ b/src/posix/tests/pjd/mkfifo/06.c
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/mkfifo/06.t: EACCES when write permission is denied on the parent directory. */
+#include "../../pjd_common.h"
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen(), *n1 = pjd_namegen(), *n2 = pjd_namegen();
+    char  P[256];
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    pjd_cd(n0);
+    EXPECT(0, pjd_mkdir(n1, 0755));
+    EXPECT(0, pjd_chown(n1, 65534, 65534));
+    snprintf(P, sizeof(P), "%s/%s", n1, n2);
+    pjd_set_user(65534, 65534);
+    EXPECT(0, pjd_mkfifo(P, 0644));
+    EXPECT(0, pjd_unlink(P));
+    pjd_set_root();
+    EXPECT(0, pjd_chmod(n1, 0555));
+    pjd_set_user(65534, 65534);
+    EXPECT(EACCES, pjd_mkfifo(P, 0644));
+    pjd_set_root();
+    EXPECT(0, pjd_chmod(n1, 0755));
+    EXPECT(0, pjd_rmdir(n1));
+    pjd_cd("..");
+    EXPECT(0, pjd_rmdir(n0));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/mkfifo/06.c
+++ b/src/posix/tests/pjd/mkfifo/06.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/mkfifo/06.t: EACCES when write permission is denied on the parent directory. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/mkfifo/07.c
+++ b/src/posix/tests/pjd/mkfifo/07.c
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/mkfifo/07.t: ELOOP on a symlink loop in the pathname. */
+#include "../../pjd_common.h"
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen(), *n1 = pjd_namegen();
+    char  P[256];
+    EXPECT(0, pjd_symlink(n0, n1));
+    EXPECT(0, pjd_symlink(n1, n0));
+    snprintf(P, sizeof(P), "%s/test", n0);
+    EXPECT(ELOOP, pjd_mkfifo(P, 0644));
+    snprintf(P, sizeof(P), "%s/test", n1);
+    EXPECT(ELOOP, pjd_mkfifo(P, 0644));
+    EXPECT(0, pjd_unlink(n0));
+    EXPECT(0, pjd_unlink(n1));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/mkfifo/07.c
+++ b/src/posix/tests/pjd/mkfifo/07.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/mkfifo/07.t: ELOOP on a symlink loop in the pathname. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/mkfifo/09.c
+++ b/src/posix/tests/pjd/mkfifo/09.c
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/mkfifo/09.t: EEXIST if the named file exists (any type). */
+#include "../../pjd_common.h"
+static const enum pjd_ftype types[] = { PJD_FT_REGULAR, PJD_FT_DIR, PJD_FT_FIFO, PJD_FT_BLOCK, PJD_FT_CHAR,
+                                        PJD_FT_SOCKET,  PJD_FT_SYMLINK };
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen();
+    char  P[256];
+    snprintf(P, sizeof(P), "%s", n0);
+    for (unsigned i = 0; i < sizeof(types) / sizeof(types[0]); i++) {
+        EXPECT(0, pjd_create_file(types[i], n0));
+        EXPECT(EEXIST, pjd_mkfifo(P, 0644));
+        EXPECT(0, pjd_remove_file(types[i], n0));
+    }
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/mkfifo/09.c
+++ b/src/posix/tests/pjd/mkfifo/09.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/mkfifo/09.t: EEXIST if the named file exists (any type). */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/mknod/00.c
+++ b/src/posix/tests/pjd/mknod/00.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/mknod/00.t: creates FIFO files - mode/umask, uid/gid
  * inheritance, and new-node / parent-dir timestamp updates. */

--- a/src/posix/tests/pjd/mknod/00.c
+++ b/src/posix/tests/pjd/mknod/00.c
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/mknod/00.t: creates FIFO files - mode/umask, uid/gid
+ * inheritance, and new-node / parent-dir timestamp updates. */
+#include "../../pjd_common.h"
+static int mkf(
+    const char *n,
+    mode_t      m){ return pjd_mknod_fifo(n, m); }
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char           *n0 = pjd_namegen(), *n1 = pjd_namegen();
+    struct timespec t0, t1;
+    EXPECT(0, pjd_mkdir(n1, 0755));
+    pjd_cd(n1);
+
+    EXPECT(0, mkf(n0, 0755));
+    EXPECT_EQ(S_IFIFO, pjd_lstat_type(n0));
+    EXPECT_EQ(0755, pjd_lstat_mode(n0));
+    EXPECT(0, pjd_unlink(n0));
+    EXPECT(0, mkf(n0, 0151));
+    EXPECT_EQ(0151, pjd_lstat_mode(n0));
+    EXPECT(0, pjd_unlink(n0));
+    chimera_posix_umask(0077); EXPECT(0, mkf(n0, 0151)); chimera_posix_umask(0);
+    EXPECT_EQ(0100, pjd_lstat_mode(n0));
+    EXPECT(0, pjd_unlink(n0));
+    chimera_posix_umask(0070); EXPECT(0, mkf(n0, 0345)); chimera_posix_umask(0);
+    EXPECT_EQ(0305, pjd_lstat_mode(n0));
+    EXPECT(0, pjd_unlink(n0));
+    chimera_posix_umask(0501); EXPECT(0, mkf(n0, 0345)); chimera_posix_umask(0);
+    EXPECT_EQ(0244, pjd_lstat_mode(n0));
+    EXPECT(0, pjd_unlink(n0));
+
+    EXPECT(0, pjd_chown(".", 65534, 65534));
+    pjd_set_user(65534, 65534); EXPECT(0, mkf(n0, 0755)); pjd_set_root();
+    EXPECT_EQ(65534, pjd_lstat_uid(n0));
+    EXPECT_EQ(65534, pjd_lstat_gid(n0));
+    EXPECT(0, pjd_unlink(n0));
+    pjd_set_user(65534, 65533); EXPECT(0, mkf(n0, 0755)); pjd_set_root();
+    EXPECT_EQ(65534, pjd_lstat_uid(n0));
+    { long g = pjd_lstat_gid(n0); PJD_CHECK(g == 65533 || g == 65534, "gid %ld", g); }
+    EXPECT(0, pjd_unlink(n0));
+
+    EXPECT(0, pjd_chown(".", 0, 0));
+    pjd_stat_ctime(".", &t0);
+    pjd_settle();
+    EXPECT(0, mkf(n0, 0755));
+    pjd_stat_mtime(".", &t1); PJD_CHECK(pjd_timespec_lt(&t0, &t1), "parent mtime");
+    pjd_stat_ctime(".", &t1); PJD_CHECK(pjd_timespec_lt(&t0, &t1), "parent ctime");
+    pjd_stat_mtime(n0, &t1);  PJD_CHECK(pjd_timespec_lt(&t0, &t1), "node mtime");
+    EXPECT(0, pjd_unlink(n0));
+
+    pjd_cd("..");
+    EXPECT(0, pjd_rmdir(n1));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/mknod/01.c
+++ b/src/posix/tests/pjd/mknod/01.c
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/mknod/01.t: ENOTDIR if a path-prefix component is not a directory. */
+#include "../../pjd_common.h"
+static const enum pjd_ftype types[] = { PJD_FT_REGULAR, PJD_FT_FIFO, PJD_FT_BLOCK, PJD_FT_CHAR, PJD_FT_SOCKET };
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen(), *n1 = pjd_namegen();
+    char  sub[256], P[512];
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    for (unsigned i = 0; i < sizeof(types) / sizeof(types[0]); i++) {
+        snprintf(sub, sizeof(sub), "%s/%s", n0, n1);
+        EXPECT(0, pjd_create_file(types[i], sub));
+        snprintf(P, sizeof(P), "%s/%s/test", n0, n1);
+        EXPECT(ENOTDIR, pjd_mknod(P, S_IFIFO | 0644, 0));
+        EXPECT(0, pjd_unlink(sub));
+    }
+    EXPECT(0, pjd_rmdir(n0));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/mknod/01.c
+++ b/src/posix/tests/pjd/mknod/01.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/mknod/01.t: ENOTDIR if a path-prefix component is not a directory. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/mknod/02.c
+++ b/src/posix/tests/pjd/mknod/02.c
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/mknod/02.t: ENAMETOOLONG if a component exceeds {NAME_MAX}. */
+#include "../../pjd_common.h"
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *nx = pjd_namegen_max();
+    char  P[512];
+    snprintf(P, sizeof(P), "%sx", nx);
+    EXPECT(ENAMETOOLONG, pjd_mknod(P, S_IFIFO | 0644, 0));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/mknod/02.c
+++ b/src/posix/tests/pjd/mknod/02.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/mknod/02.t: ENAMETOOLONG if a component exceeds {NAME_MAX}. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/mknod/03.c
+++ b/src/posix/tests/pjd/mknod/03.c
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/mknod/03.t: ENAMETOOLONG if the whole path exceeds {PATH_MAX}. */
+#include "../../pjd_common.h"
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *nx = pjd_dirgen_max();
+    char  P[8192];
+    snprintf(P, sizeof(P), "%sx", nx);
+    pjd_mkdir_p(nx);
+    EXPECT(ENAMETOOLONG, pjd_mknod(P, S_IFIFO | 0644, 0));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/mknod/03.c
+++ b/src/posix/tests/pjd/mknod/03.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/mknod/03.t: ENAMETOOLONG if the whole path exceeds {PATH_MAX}. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/mknod/04.c
+++ b/src/posix/tests/pjd/mknod/04.c
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/mknod/04.t: ENOENT if a path-prefix component does not exist. */
+#include "../../pjd_common.h"
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen(), *n1 = pjd_namegen();
+    char  P[512];
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    snprintf(P, sizeof(P), "%s/%s/test", n0, n1);
+    EXPECT(ENOENT, pjd_mknod(P, S_IFIFO | 0644, 0));
+    EXPECT(0, pjd_rmdir(n0));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/mknod/04.c
+++ b/src/posix/tests/pjd/mknod/04.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/mknod/04.t: ENOENT if a path-prefix component does not exist. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/mknod/05.c
+++ b/src/posix/tests/pjd/mknod/05.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/mknod/05.t: EACCES when search permission is denied for a path-prefix component. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/mknod/05.c
+++ b/src/posix/tests/pjd/mknod/05.c
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/mknod/05.t: EACCES when search permission is denied for a path-prefix component. */
+#include "../../pjd_common.h"
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen(), *n1 = pjd_namegen(), *n2 = pjd_namegen();
+    char  P[256];
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    pjd_cd(n0);
+    EXPECT(0, pjd_mkdir(n1, 0755));
+    EXPECT(0, pjd_chown(n1, 65534, 65534));
+    snprintf(P, sizeof(P), "%s/%s", n1, n2);
+    pjd_set_user(65534, 65534);
+    EXPECT(0, pjd_mknod(P, S_IFIFO | 0644, 0));
+    EXPECT(0, pjd_unlink(P));
+    pjd_set_root();
+    EXPECT(0, pjd_chmod(n1, 0644));
+    pjd_set_user(65534, 65534);
+    EXPECT(EACCES, pjd_mknod(P, S_IFIFO | 0644, 0));
+    pjd_set_root();
+    EXPECT(0, pjd_chmod(n1, 0755));
+    EXPECT(0, pjd_rmdir(n1));
+    pjd_cd("..");
+    EXPECT(0, pjd_rmdir(n0));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/mknod/06.c
+++ b/src/posix/tests/pjd/mknod/06.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/mknod/06.t: EACCES when write permission is denied on the parent directory. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/mknod/06.c
+++ b/src/posix/tests/pjd/mknod/06.c
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/mknod/06.t: EACCES when write permission is denied on the parent directory. */
+#include "../../pjd_common.h"
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen(), *n1 = pjd_namegen(), *n2 = pjd_namegen();
+    char  P[256];
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    pjd_cd(n0);
+    EXPECT(0, pjd_mkdir(n1, 0755));
+    EXPECT(0, pjd_chown(n1, 65534, 65534));
+    snprintf(P, sizeof(P), "%s/%s", n1, n2);
+    pjd_set_user(65534, 65534);
+    EXPECT(0, pjd_mknod(P, S_IFIFO | 0644, 0));
+    EXPECT(0, pjd_unlink(P));
+    pjd_set_root();
+    EXPECT(0, pjd_chmod(n1, 0555));
+    pjd_set_user(65534, 65534);
+    EXPECT(EACCES, pjd_mknod(P, S_IFIFO | 0644, 0));
+    pjd_set_root();
+    EXPECT(0, pjd_chmod(n1, 0755));
+    EXPECT(0, pjd_rmdir(n1));
+    pjd_cd("..");
+    EXPECT(0, pjd_rmdir(n0));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/mknod/07.c
+++ b/src/posix/tests/pjd/mknod/07.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/mknod/07.t: ELOOP on a symlink loop in the pathname. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/mknod/07.c
+++ b/src/posix/tests/pjd/mknod/07.c
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/mknod/07.t: ELOOP on a symlink loop in the pathname. */
+#include "../../pjd_common.h"
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen(), *n1 = pjd_namegen();
+    char  P[256];
+    EXPECT(0, pjd_symlink(n0, n1));
+    EXPECT(0, pjd_symlink(n1, n0));
+    snprintf(P, sizeof(P), "%s/test", n0);
+    EXPECT(ELOOP, pjd_mknod(P, S_IFIFO | 0644, 0));
+    snprintf(P, sizeof(P), "%s/test", n1);
+    EXPECT(ELOOP, pjd_mknod(P, S_IFIFO | 0644, 0));
+    EXPECT(0, pjd_unlink(n0));
+    EXPECT(0, pjd_unlink(n1));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/mknod/08.c
+++ b/src/posix/tests/pjd/mknod/08.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/mknod/08.t: EEXIST if the named file exists (any type). */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/mknod/08.c
+++ b/src/posix/tests/pjd/mknod/08.c
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/mknod/08.t: EEXIST if the named file exists (any type). */
+#include "../../pjd_common.h"
+static const enum pjd_ftype types[] = { PJD_FT_REGULAR, PJD_FT_DIR, PJD_FT_FIFO, PJD_FT_BLOCK, PJD_FT_CHAR,
+                                        PJD_FT_SOCKET,  PJD_FT_SYMLINK };
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen();
+    char  P[256];
+    snprintf(P, sizeof(P), "%s", n0);
+    for (unsigned i = 0; i < sizeof(types) / sizeof(types[0]); i++) {
+        EXPECT(0, pjd_create_file(types[i], n0));
+        EXPECT(EEXIST, pjd_mknod(P, S_IFIFO | 0644, 0));
+        EXPECT(0, pjd_remove_file(types[i], n0));
+    }
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/mknod/11.c
+++ b/src/posix/tests/pjd/mknod/11.c
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/mknod/11.t:
+ * mknod creates character and block device files with the requested major/minor
+ * numbers, returns EEXIST on a second create, and updates node/parent times. */
+
+#include "../../pjd_common.h"
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+
+    char *n0 = pjd_namegen();
+    char *n1 = pjd_namegen();
+
+    EXPECT(0, pjd_mkdir(n1, 0755));
+    pjd_cd(n1);
+
+    struct {
+        mode_t fmt;
+        mode_t type_bits;
+    } kinds[] = { { S_IFCHR, S_IFCHR }, { S_IFBLK, S_IFBLK } };
+
+    for (int k = 0; k < 2; k++) {
+        struct timespec t0, t1;
+
+        EXPECT(0, pjd_mknod(n0, kinds[k].fmt | 0755, makedev(1, 2)));
+        EXPECT_EQ(kinds[k].type_bits, pjd_lstat_type(n0));
+        EXPECT_EQ(0755, pjd_lstat_mode(n0));
+        EXPECT_EQ(1, pjd_lstat_major(n0));
+        EXPECT_EQ(2, pjd_lstat_minor(n0));
+        EXPECT(EEXIST, pjd_mknod(n0, kinds[k].fmt | 0777, makedev(3, 4)));
+        EXPECT(0, pjd_unlink(n0));
+
+        /* Timestamps: node + parent updated on successful mknod. */
+        EXPECT(0, pjd_chown(".", 0, 0));
+        pjd_stat_ctime(".", &t0);
+        pjd_settle();
+        EXPECT(0, pjd_mknod(n0, kinds[k].fmt | 0755, makedev(1, 2)));
+        pjd_stat_mtime(".", &t1);
+        PJD_CHECK(pjd_timespec_lt(&t0, &t1), "parent mtime advanced (kind %d)", k);
+        pjd_stat_ctime(".", &t1);
+        PJD_CHECK(pjd_timespec_lt(&t0, &t1), "parent ctime advanced (kind %d)", k);
+        pjd_stat_mtime(n0, &t1);
+        PJD_CHECK(pjd_timespec_lt(&t0, &t1), "node mtime set (kind %d)", k);
+        EXPECT(0, pjd_unlink(n0));
+    }
+
+    pjd_cd("..");
+    EXPECT(0, pjd_rmdir(n1));
+
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/mknod/11.c
+++ b/src/posix/tests/pjd/mknod/11.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/mknod/11.t:
  * mknod creates character and block device files with the requested major/minor

--- a/src/posix/tests/pjd/open/00.c
+++ b/src/posix/tests/pjd/open/00.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/open/00.t:
  * "open opens (and eventually creates) a file" - mode/umask application, uid/gid

--- a/src/posix/tests/pjd/open/00.c
+++ b/src/posix/tests/pjd/open/00.c
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/open/00.t:
+ * "open opens (and eventually creates) a file" - mode/umask application, uid/gid
+ * inheritance of a newly created file, and parent/child timestamp updates. */
+
+#include "../../pjd_common.h"
+
+static void
+expect_open_create(
+    const char *name,
+    int         flags,
+    mode_t      mode)
+{
+    int fd = pjd_open(name, flags, mode);
+
+    pjd_record(fd >= 0, __FILE__, __LINE__, "open(%s) -> %d", name, fd);
+    if (fd >= 0) {
+        chimera_posix_close(fd);
+    }
+} /* expect_open_create */
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    struct timespec t0, t1;
+
+    pjd_begin(argc, argv);
+
+    char           *n0 = pjd_namegen();
+    char           *n1 = pjd_namegen();
+
+    EXPECT(0, pjd_mkdir(n1, 0755));
+    pjd_cd(n1);
+
+    /* O_CREAT applies the mode (umask 0 by default). */
+    expect_open_create(n0, O_CREAT | O_WRONLY, 0755);
+    EXPECT_EQ(S_IFREG, pjd_lstat_type(n0));
+    EXPECT_EQ(0755, pjd_lstat_mode(n0));
+    EXPECT(0, pjd_unlink(n0));
+
+    expect_open_create(n0, O_CREAT | O_WRONLY, 0151);
+    EXPECT_EQ(0151, pjd_lstat_mode(n0));
+    EXPECT(0, pjd_unlink(n0));
+
+    /* umask applied: 0151 & ~077 = 0100. */
+    chimera_posix_umask(0077);
+    expect_open_create(n0, O_CREAT | O_WRONLY, 0151);
+    chimera_posix_umask(0);
+    EXPECT_EQ(0100, pjd_lstat_mode(n0));
+    EXPECT(0, pjd_unlink(n0));
+
+    /* 0345 & ~070 = 0305. */
+    chimera_posix_umask(0070);
+    expect_open_create(n0, O_CREAT | O_WRONLY, 0345);
+    chimera_posix_umask(0);
+    EXPECT_EQ(0305, pjd_lstat_mode(n0));
+    EXPECT(0, pjd_unlink(n0));
+
+    /* 0345 & ~0501 = 0244. */
+    chimera_posix_umask(0501);
+    expect_open_create(n0, O_CREAT | O_WRONLY, 0345);
+    chimera_posix_umask(0);
+    EXPECT_EQ(0244, pjd_lstat_mode(n0));
+    EXPECT(0, pjd_unlink(n0));
+
+    /* New file's uid = effective uid; gid = parent gid or effective gid. */
+    EXPECT(0, pjd_chown(".", 65534, 65534));
+
+    pjd_set_user(65534, 65534);
+    expect_open_create(n0, O_CREAT | O_WRONLY, 0644);
+    pjd_set_root();
+    EXPECT_EQ(65534, pjd_lstat_uid(n0));
+    EXPECT_EQ(65534, pjd_lstat_gid(n0));
+    EXPECT(0, pjd_unlink(n0));
+
+    pjd_set_user(65534, 65533);
+    expect_open_create(n0, O_CREAT | O_WRONLY, 0644);
+    pjd_set_root();
+    EXPECT_EQ(65534, pjd_lstat_uid(n0));
+    {
+        long g = pjd_lstat_gid(n0);
+        PJD_CHECK(g == 65533 || g == 65534, "new file gid %ld in {65533,65534}", g);
+    }
+    EXPECT(0, pjd_unlink(n0));
+
+    EXPECT(0, pjd_chmod(".", 0777));
+    pjd_set_user(65533, 65532);
+    expect_open_create(n0, O_CREAT | O_WRONLY, 0644);
+    pjd_set_root();
+    EXPECT_EQ(65533, pjd_lstat_uid(n0));
+    {
+        long g = pjd_lstat_gid(n0);
+        PJD_CHECK(g == 65532 || g == 65534, "new file gid %ld in {65532,65534}", g);
+    }
+    EXPECT(0, pjd_unlink(n0));
+
+    /* Creating a new file updates the parent directory's mtime and ctime. */
+    EXPECT(0, pjd_chown(".", 0, 0));
+    pjd_stat_ctime(".", &t0);
+    pjd_settle();
+    expect_open_create(n0, O_CREAT | O_WRONLY, 0644);
+    pjd_stat_mtime(".", &t1);
+    PJD_CHECK(pjd_timespec_lt(&t0, &t1), "parent mtime advanced on create");
+    pjd_stat_ctime(".", &t1);
+    PJD_CHECK(pjd_timespec_lt(&t0, &t1), "parent ctime advanced on create");
+    EXPECT(0, pjd_unlink(n0));
+
+    /* Opening an existing file does NOT update the parent's mtime/ctime. */
+    EXPECT(0, pjd_create(n0, 0644));
+    {
+        struct timespec dm, dc, m, c;
+        pjd_stat_mtime(".", &dm);
+        pjd_stat_ctime(".", &dc);
+        pjd_settle();
+        expect_open_create(n0, O_CREAT | O_RDONLY, 0644);
+        pjd_stat_mtime(".", &m);
+        pjd_stat_ctime(".", &c);
+        PJD_CHECK(dm.tv_sec == m.tv_sec && dm.tv_nsec == m.tv_nsec,
+                  "parent mtime unchanged opening existing");
+        PJD_CHECK(dc.tv_sec == c.tv_sec && dc.tv_nsec == c.tv_nsec,
+                  "parent ctime unchanged opening existing");
+    }
+    EXPECT(0, pjd_unlink(n0));
+
+    /* O_TRUNC on an existing file updates its mtime/ctime and zeroes size. */
+    {
+        int             fd = pjd_open(n0, O_CREAT | O_WRONLY, 0644);
+        PJD_CHECK(fd >= 0, "create n0 for trunc test");
+        if (fd >= 0) {
+            chimera_posix_write(fd, "test\n", 5);
+            chimera_posix_close(fd);
+        }
+        EXPECT_EQ(5, pjd_stat_size(n0));
+
+        struct timespec m1, c1, m2, c2;
+        pjd_stat_mtime(n0, &m1);
+        pjd_stat_ctime(n0, &c1);
+        pjd_settle();
+        expect_open_create(n0, O_WRONLY | O_TRUNC, 0644);
+        pjd_stat_mtime(n0, &m2);
+        pjd_stat_ctime(n0, &c2);
+        PJD_CHECK(pjd_timespec_lt(&m1, &m2), "mtime advanced on O_TRUNC");
+        PJD_CHECK(pjd_timespec_lt(&c1, &c2), "ctime advanced on O_TRUNC");
+        EXPECT_EQ(0, pjd_stat_size(n0));
+        EXPECT(0, pjd_unlink(n0));
+    }
+
+    pjd_cd("..");
+    EXPECT(0, pjd_rmdir(n1));
+
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/open/01.c
+++ b/src/posix/tests/pjd/open/01.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/open/01.t: ENOTDIR if a path-prefix component is not a directory. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/open/01.c
+++ b/src/posix/tests/pjd/open/01.c
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/open/01.t: ENOTDIR if a path-prefix component is not a directory. */
+#include "../../pjd_common.h"
+static const enum pjd_ftype types[] = { PJD_FT_REGULAR, PJD_FT_FIFO, PJD_FT_BLOCK, PJD_FT_CHAR, PJD_FT_SOCKET };
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen(), *n1 = pjd_namegen();
+    char  sub[256], P[512];
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    for (unsigned i = 0; i < sizeof(types) / sizeof(types[0]); i++) {
+        snprintf(sub, sizeof(sub), "%s/%s", n0, n1);
+        EXPECT(0, pjd_create_file(types[i], sub));
+        snprintf(P, sizeof(P), "%s/%s/test", n0, n1);
+        EXPECT_EQ(ENOTDIR, pjd_open_e(P, O_RDONLY, 0));
+        EXPECT(0, pjd_unlink(sub));
+    }
+    EXPECT(0, pjd_rmdir(n0));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/open/02.c
+++ b/src/posix/tests/pjd/open/02.c
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/open/02.t: ENAMETOOLONG if a component exceeds {NAME_MAX}. */
+#include "../../pjd_common.h"
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *nx = pjd_namegen_max();
+    char  P[512];
+    snprintf(P, sizeof(P), "%sx", nx);
+    EXPECT_EQ(0, pjd_open_e(nx, O_CREAT | O_RDONLY, 0644));
+    EXPECT(0, pjd_unlink(nx));
+    EXPECT_EQ(ENAMETOOLONG, pjd_open_e(P, O_CREAT | O_RDONLY, 0644));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/open/02.c
+++ b/src/posix/tests/pjd/open/02.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/open/02.t: ENAMETOOLONG if a component exceeds {NAME_MAX}. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/open/03.c
+++ b/src/posix/tests/pjd/open/03.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/open/03.t: ENAMETOOLONG if the whole path exceeds {PATH_MAX}. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/open/03.c
+++ b/src/posix/tests/pjd/open/03.c
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/open/03.t: ENAMETOOLONG if the whole path exceeds {PATH_MAX}. */
+#include "../../pjd_common.h"
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *nx = pjd_dirgen_max();
+    char  P[8192];
+    snprintf(P, sizeof(P), "%sx", nx);
+    pjd_mkdir_p(nx);
+    EXPECT_EQ(0, pjd_open_e(nx, O_CREAT | O_RDONLY, 0644));
+    EXPECT(0, pjd_unlink(nx));
+    EXPECT_EQ(ENAMETOOLONG, pjd_open_e(P, O_CREAT | O_RDONLY, 0644));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/open/04.c
+++ b/src/posix/tests/pjd/open/04.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/open/04.t: ENOENT if a required path component does not exist. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/open/04.c
+++ b/src/posix/tests/pjd/open/04.c
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/open/04.t: ENOENT if a required path component does not exist. */
+#include "../../pjd_common.h"
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen(), *n1 = pjd_namegen();
+    char  P[512];
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    snprintf(P, sizeof(P), "%s/%s/test", n0, n1);
+    EXPECT_EQ(ENOENT, pjd_open_e(P, O_RDONLY, 0));
+    EXPECT_EQ(ENOENT, pjd_open_e(P, O_RDONLY | O_CREAT, 0644));
+    /* Plain open of a missing file (no O_CREAT) is ENOENT. */
+    snprintf(P, sizeof(P), "%s/%s", n0, n1);
+    EXPECT_EQ(ENOENT, pjd_open_e(P, O_RDONLY, 0));
+    EXPECT(0, pjd_rmdir(n0));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/open/05.c
+++ b/src/posix/tests/pjd/open/05.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/open/05.t: EACCES when search permission is denied for a path-prefix component. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/open/05.c
+++ b/src/posix/tests/pjd/open/05.c
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/open/05.t: EACCES when search permission is denied for a path-prefix component. */
+#include "../../pjd_common.h"
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen(), *n1 = pjd_namegen(), *n2 = pjd_namegen();
+    char  P[256];
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    pjd_cd(n0);
+    EXPECT(0, pjd_mkdir(n1, 0755));
+    EXPECT(0, pjd_chown(n1, 65534, 65534));
+    snprintf(P, sizeof(P), "%s/%s", n1, n2);
+    pjd_set_user(65534, 65534);
+    EXPECT_EQ(0, pjd_open_e(P, O_RDONLY | O_CREAT, 0644));
+    pjd_set_root();
+    EXPECT(0, pjd_chmod(n1, 0644));
+    pjd_set_user(65534, 65534);
+    EXPECT_EQ(EACCES, pjd_open_e(P, O_RDONLY, 0));
+    pjd_set_root();
+    EXPECT(0, pjd_chmod(n1, 0755));
+    EXPECT(0, pjd_unlink(P));
+    EXPECT(0, pjd_rmdir(n1));
+    pjd_cd("..");
+    EXPECT(0, pjd_rmdir(n0));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/open/06.c
+++ b/src/posix/tests/pjd/open/06.c
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/open/06.t:
+ * open returns EACCES when the requested access (read and/or write) is not
+ * granted by the file's mode for the calling credential.  (The FIFO section,
+ * which involves O_NONBLOCK/ENXIO open semantics, is omitted; the regular-file
+ * and directory permission matrices are covered.) */
+
+#include "../../pjd_common.h"
+
+struct row {
+    int mode;
+    int uid;
+    int gid;
+    int rd;   /* expected errno for O_RDONLY (0 = success) */
+    int wr;   /* O_WRONLY */
+    int rw;   /* O_RDWR   */
+};
+
+/* File owned 65534:65534; each row exercises one permission class.
+ * *INDENT-OFF* */
+static const struct row file_rows[] = {
+    { 0600, 65534, 65534, 0, 0, 0 },
+    { 0060, 65533, 65534, 0, 0, 0 },
+    { 0006, 65533, 65533, 0, 0, 0 },
+    { 0477, 65534, 65534, 0, EACCES, EACCES },
+    { 0747, 65533, 65534, 0, EACCES, EACCES },
+    { 0774, 65533, 65533, 0, EACCES, EACCES },
+    { 0277, 65534, 65534, EACCES, 0, EACCES },
+    { 0727, 65533, 65534, EACCES, 0, EACCES },
+    { 0772, 65533, 65533, EACCES, 0, EACCES },
+    { 0177, 65534, 65534, EACCES, EACCES, EACCES },
+    { 0717, 65533, 65534, EACCES, EACCES, EACCES },
+    { 0771, 65533, 65533, EACCES, EACCES, EACCES },
+    { 0077, 65534, 65534, EACCES, EACCES, EACCES },
+    { 0707, 65533, 65534, EACCES, EACCES, EACCES },
+    { 0770, 65533, 65533, EACCES, EACCES, EACCES },
+};
+
+/* Directory open (O_RDONLY) needs read permission on the directory. */
+static const struct row dir_rows[] = {
+    { 0600, 65534, 65534, 0, 0, 0 },
+    { 0060, 65533, 65534, 0, 0, 0 },
+    { 0006, 65533, 65533, 0, 0, 0 },
+    { 0477, 65534, 65534, 0, 0, 0 },
+    { 0747, 65533, 65534, 0, 0, 0 },
+    { 0774, 65533, 65533, 0, 0, 0 },
+    { 0277, 65534, 65534, EACCES, 0, 0 },
+    { 0727, 65533, 65534, EACCES, 0, 0 },
+    { 0772, 65533, 65533, EACCES, 0, 0 },
+    { 0177, 65534, 65534, EACCES, 0, 0 },
+    { 0717, 65533, 65534, EACCES, 0, 0 },
+    { 0771, 65533, 65533, EACCES, 0, 0 },
+    { 0077, 65534, 65534, EACCES, 0, 0 },
+    { 0707, 65533, 65534, EACCES, 0, 0 },
+    { 0770, 65533, 65533, EACCES, 0, 0 },
+};
+/* *INDENT-ON* */
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+
+    char *n0 = pjd_namegen();
+    char *n1 = pjd_namegen();
+
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    EXPECT(0, pjd_chown(n0, 65534, 65534));
+    pjd_cd(n0);
+
+    /* Regular file. */
+    pjd_set_user(65534, 65534);
+    EXPECT(0, pjd_create(n1, 0644));
+    pjd_set_root();
+
+    for (unsigned i = 0; i < sizeof(file_rows) / sizeof(file_rows[0]); i++) {
+        const struct row *r = &file_rows[i];
+        pjd_set_user(65534, 65534);
+        EXPECT(0, pjd_chmod(n1, r->mode));
+        pjd_set_root();
+        pjd_set_user(r->uid, r->gid);
+        EXPECT_EQ(r->rd, pjd_open_e(n1, O_RDONLY, 0));
+        EXPECT_EQ(r->wr, pjd_open_e(n1, O_WRONLY, 0));
+        EXPECT_EQ(r->rw, pjd_open_e(n1, O_RDWR, 0));
+        pjd_set_root();
+    }
+    pjd_set_user(65534, 65534);
+    EXPECT(0, pjd_unlink(n1));
+    pjd_set_root();
+
+    /* Directory. */
+    pjd_set_user(65534, 65534);
+    EXPECT(0, pjd_mkdir(n1, 0755));
+    pjd_set_root();
+
+    for (unsigned i = 0; i < sizeof(dir_rows) / sizeof(dir_rows[0]); i++) {
+        const struct row *r = &dir_rows[i];
+        pjd_set_user(65534, 65534);
+        EXPECT(0, pjd_chmod(n1, r->mode));
+        pjd_set_root();
+        pjd_set_user(r->uid, r->gid);
+        EXPECT_EQ(r->rd, pjd_open_e(n1, O_RDONLY, 0));
+        pjd_set_root();
+    }
+    pjd_set_user(65534, 65534);
+    EXPECT(0, pjd_rmdir(n1));
+    pjd_set_root();
+
+    pjd_cd("..");
+    EXPECT(0, pjd_rmdir(n0));
+
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/open/06.c
+++ b/src/posix/tests/pjd/open/06.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/open/06.t:
  * open returns EACCES when the requested access (read and/or write) is not

--- a/src/posix/tests/pjd/open/07.c
+++ b/src/posix/tests/pjd/open/07.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/open/07.t: O_TRUNC requires write permission (EACCES otherwise). */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/open/07.c
+++ b/src/posix/tests/pjd/open/07.c
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/open/07.t: O_TRUNC requires write permission (EACCES otherwise). */
+#include "../../pjd_common.h"
+struct row { int mode; int uid; int gid; };
+static const struct row rows[] = {
+    { 0477, 65534, 65534 }, { 0747, 65533, 65534 }, { 0774, 65533, 65533 },
+    { 0177, 65534, 65534 }, { 0717, 65533, 65534 }, { 0771, 65533, 65533 },
+    { 0077, 65534, 65534 }, { 0707, 65533, 65534 }, { 0770, 65533, 65533 },
+};
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen(), *n1 = pjd_namegen();
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    EXPECT(0, pjd_chown(n0, 65534, 65534));
+    pjd_cd(n0);
+    pjd_set_user(65534, 65534);
+    EXPECT(0, pjd_create(n1, 0644));
+    /* Owner can write then read back one byte. */
+    {
+        int         fd = pjd_open(n1, O_WRONLY, 0);
+        PJD_CHECK(fd >= 0, "open n1 O_WRONLY");
+        chimera_posix_write(fd, "x", 1);
+        struct stat stbuf;
+        chimera_posix_fstat(fd, &stbuf);
+        EXPECT_EQ(1, (long) stbuf.st_size);
+        chimera_posix_close(fd);
+    }
+    pjd_set_root();
+    for (unsigned i = 0; i < sizeof(rows) / sizeof(rows[0]); i++) {
+        pjd_set_user(65534, 65534);
+        EXPECT(0, pjd_chmod(n1, rows[i].mode));
+        pjd_set_root();
+        pjd_set_user(rows[i].uid, rows[i].gid);
+        EXPECT_EQ(EACCES, pjd_open_e(n1, O_RDONLY | O_TRUNC, 0));
+        pjd_set_root();
+    }
+    pjd_set_user(65534, 65534);
+    EXPECT(0, pjd_unlink(n1));
+    pjd_set_root();
+    pjd_cd("..");
+    EXPECT(0, pjd_rmdir(n0));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/open/08.c
+++ b/src/posix/tests/pjd/open/08.c
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/open/08.t: O_CREAT in a directory the caller cannot write -> EACCES. */
+#include "../../pjd_common.h"
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen(), *n1 = pjd_namegen();
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    pjd_cd(n0);
+    /* cwd n0 is owned by root, mode 0755: an unprivileged caller cannot create. */
+    pjd_set_user(65534, 65534);
+    EXPECT_EQ(EACCES, pjd_open_e(n1, O_RDONLY | O_CREAT, 0644));
+    pjd_set_root();
+    pjd_cd("..");
+    EXPECT(0, pjd_rmdir(n0));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/open/08.c
+++ b/src/posix/tests/pjd/open/08.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/open/08.t: O_CREAT in a directory the caller cannot write -> EACCES. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/open/12.c
+++ b/src/posix/tests/pjd/open/12.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/open/12.t: ELOOP on a symlink loop in the pathname. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/open/12.c
+++ b/src/posix/tests/pjd/open/12.c
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/open/12.t: ELOOP on a symlink loop in the pathname. */
+#include "../../pjd_common.h"
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen(), *n1 = pjd_namegen();
+    char  P[256];
+    EXPECT(0, pjd_symlink(n0, n1));
+    EXPECT(0, pjd_symlink(n1, n0));
+    EXPECT_EQ(ELOOP, pjd_open_e(n0, O_RDONLY, 0));
+    EXPECT_EQ(ELOOP, pjd_open_e(n1, O_RDONLY, 0));
+    snprintf(P, sizeof(P), "%s/test", n0);
+    EXPECT_EQ(ELOOP, pjd_open_e(P, O_RDONLY, 0));
+    snprintf(P, sizeof(P), "%s/test", n1);
+    EXPECT_EQ(ELOOP, pjd_open_e(P, O_RDONLY, 0));
+    EXPECT(0, pjd_unlink(n0));
+    EXPECT(0, pjd_unlink(n1));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/open/13.c
+++ b/src/posix/tests/pjd/open/13.c
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/open/13.t: EISDIR when opening a directory for writing. */
+#include "../../pjd_common.h"
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen();
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    EXPECT_EQ(0, pjd_open_e(n0, O_RDONLY, 0));
+    EXPECT_EQ(EISDIR, pjd_open_e(n0, O_WRONLY, 0));
+    EXPECT_EQ(EISDIR, pjd_open_e(n0, O_RDWR, 0));
+    EXPECT_EQ(EISDIR, pjd_open_e(n0, O_RDONLY | O_TRUNC, 0));
+    EXPECT_EQ(EISDIR, pjd_open_e(n0, O_WRONLY | O_TRUNC, 0));
+    EXPECT_EQ(EISDIR, pjd_open_e(n0, O_RDWR | O_TRUNC, 0));
+    EXPECT(0, pjd_rmdir(n0));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/open/13.c
+++ b/src/posix/tests/pjd/open/13.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/open/13.t: EISDIR when opening a directory for writing. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/open/16.c
+++ b/src/posix/tests/pjd/open/16.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/open/16.t: O_NOFOLLOW on a symlink target yields ELOOP (Linux). */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/open/16.c
+++ b/src/posix/tests/pjd/open/16.c
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/open/16.t: O_NOFOLLOW on a symlink target yields ELOOP (Linux). */
+#include "../../pjd_common.h"
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen(), *n1 = pjd_namegen();
+    EXPECT(0, pjd_symlink(n0, n1));
+    EXPECT_EQ(ELOOP, pjd_open_e(n1, O_RDONLY | O_CREAT | O_NOFOLLOW, 0644));
+    EXPECT_EQ(ELOOP, pjd_open_e(n1, O_RDONLY | O_NOFOLLOW, 0));
+    EXPECT_EQ(ELOOP, pjd_open_e(n1, O_WRONLY | O_NOFOLLOW, 0));
+    EXPECT_EQ(ELOOP, pjd_open_e(n1, O_RDWR | O_NOFOLLOW, 0));
+    EXPECT(0, pjd_unlink(n1));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/open/22.c
+++ b/src/posix/tests/pjd/open/22.c
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/open/22.t: EEXIST with O_CREAT|O_EXCL on an existing file (any type). */
+#include "../../pjd_common.h"
+static const enum pjd_ftype types[] = { PJD_FT_REGULAR, PJD_FT_DIR, PJD_FT_FIFO, PJD_FT_BLOCK, PJD_FT_CHAR,
+                                        PJD_FT_SOCKET,  PJD_FT_SYMLINK };
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen();
+    for (unsigned i = 0; i < sizeof(types) / sizeof(types[0]); i++) {
+        EXPECT(0, pjd_create_file(types[i], n0));
+        EXPECT_EQ(EEXIST, pjd_open_e(n0, O_CREAT | O_EXCL, 0644));
+        EXPECT(0, pjd_remove_file(types[i], n0));
+    }
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/open/22.c
+++ b/src/posix/tests/pjd/open/22.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/open/22.t: EEXIST with O_CREAT|O_EXCL on an existing file (any type). */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/open/26.c
+++ b/src/posix/tests/pjd/open/26.c
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/open/26.t: O_CREAT can create files with 0000 mode,
+ * openable by the creator for read/write. */
+#include "../../pjd_common.h"
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen();
+    EXPECT_EQ(0, pjd_open_e(n0, O_CREAT | O_WRONLY, 0000));
+    EXPECT_EQ(S_IFREG, pjd_lstat_type(n0));
+    EXPECT_EQ(0, pjd_lstat_mode(n0));
+    EXPECT(0, pjd_unlink(n0));
+    EXPECT_EQ(0, pjd_open_e(n0, O_CREAT | O_RDWR, 0000));
+    EXPECT_EQ(0, pjd_lstat_mode(n0));
+    EXPECT(0, pjd_unlink(n0));
+    EXPECT_EQ(0, pjd_open_e(n0, O_CREAT | O_RDONLY, 0000));
+    EXPECT_EQ(0, pjd_lstat_mode(n0));
+    EXPECT(0, pjd_unlink(n0));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/open/26.c
+++ b/src/posix/tests/pjd/open/26.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/open/26.t: O_CREAT can create files with 0000 mode,
  * openable by the creator for read/write. */

--- a/src/posix/tests/pjd/rename/00.c
+++ b/src/posix/tests/pjd/rename/00.c
@@ -1,0 +1,94 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/rename/00.t:
+ * rename changes a file's name while preserving its inode, mode and link count;
+ * renaming one of several links and renaming directories both behave correctly. */
+
+#include "../../pjd_common.h"
+
+static const enum pjd_ftype types[] = {
+    PJD_FT_REGULAR, PJD_FT_FIFO, PJD_FT_BLOCK, PJD_FT_CHAR, PJD_FT_SOCKET,
+};
+
+static void
+check(
+    const char *name,
+    int         mode,
+    long        inode,
+    long        nlink)
+{
+    struct stat st;
+
+    if (pjd_lstat(name, &st) != 0) {
+        PJD_CHECK(0, "lstat %s", name);
+        return;
+    }
+    if (mode >= 0) {
+        EXPECT_EQ(mode, st.st_mode & 07777);
+    }
+    if (inode >= 0) {
+        EXPECT_EQ(inode, (long) st.st_ino);
+    }
+    EXPECT_EQ(nlink, (long) st.st_nlink);
+} /* check */
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+
+    char *n0 = pjd_namegen();
+    char *n1 = pjd_namegen();
+    char *n2 = pjd_namegen();
+    char *n3 = pjd_namegen();
+
+    EXPECT(0, pjd_mkdir(n3, 0755));
+    pjd_cd(n3);
+
+    for (unsigned i = 0; i < sizeof(types) / sizeof(types[0]); i++) {
+        struct stat junk;
+
+        EXPECT(0, pjd_create_file(types[i], n0));
+        EXPECT(0, pjd_chmod(n0, 0644));
+        long        inode = pjd_lstat_inode(n0);
+        check(n0, 0644, inode, 1);
+
+        EXPECT(0, pjd_rename(n0, n1));
+        EXPECT(ENOENT, pjd_lstat(n0, &junk));
+        check(n1, 0644, inode, 1);
+
+        EXPECT(0, pjd_link(n1, n0));
+        check(n0, 0644, inode, 2);
+        check(n1, 0644, inode, 2);
+
+        EXPECT(0, pjd_rename(n1, n2));
+        check(n0, 0644, inode, 2);
+        EXPECT(ENOENT, pjd_lstat(n1, &junk));
+        check(n2, 0644, inode, 2);
+
+        EXPECT(0, pjd_unlink(n0));
+        EXPECT(0, pjd_unlink(n2));
+    }
+
+    /* Directory rename preserves the inode. */
+    {
+        struct stat junk;
+        EXPECT(0, pjd_mkdir(n0, 0755));
+        EXPECT_EQ(S_IFDIR, pjd_lstat_type(n0));
+        long        inode = pjd_lstat_inode(n0);
+        EXPECT(0, pjd_rename(n0, n1));
+        EXPECT(ENOENT, pjd_lstat(n0, &junk));
+        EXPECT_EQ(S_IFDIR, pjd_lstat_type(n1));
+        EXPECT_EQ(inode, pjd_lstat_inode(n1));
+        EXPECT(0, pjd_rmdir(n1));
+    }
+
+    pjd_cd("..");
+    EXPECT(0, pjd_rmdir(n3));
+
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/rename/00.c
+++ b/src/posix/tests/pjd/rename/00.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/rename/00.t:
  * rename changes a file's name while preserving its inode, mode and link count;

--- a/src/posix/tests/pjd/rename/01.c
+++ b/src/posix/tests/pjd/rename/01.c
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/rename/01.t: ENAMETOOLONG if a component of either pathname exceeds {NAME_MAX}. */
+#include "../../pjd_common.h"
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen();
+    char *nx = pjd_namegen_max();
+    char  P[512];
+    snprintf(P, sizeof(P), "%sx", nx);
+    EXPECT(0, pjd_create(n0, 0644));
+    EXPECT(0, pjd_rename(n0, nx));
+    EXPECT(0, pjd_rename(nx, n0));
+    EXPECT(ENAMETOOLONG, pjd_rename(n0, P));
+    EXPECT(ENAMETOOLONG, pjd_rename(P, n0));
+    EXPECT(0, pjd_unlink(n0));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/rename/01.c
+++ b/src/posix/tests/pjd/rename/01.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/rename/01.t: ENAMETOOLONG if a component of either pathname exceeds {NAME_MAX}. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/rename/02.c
+++ b/src/posix/tests/pjd/rename/02.c
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/rename/02.t: ENAMETOOLONG if an entire pathname exceeds {PATH_MAX}. */
+#include "../../pjd_common.h"
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen();
+    char *nx = pjd_dirgen_max();
+    char  P[8192];
+    snprintf(P, sizeof(P), "%sx", nx);
+    pjd_mkdir_p(nx);
+    EXPECT(0, pjd_create(n0, 0644));
+    EXPECT(ENAMETOOLONG, pjd_rename(n0, P));
+    EXPECT(ENAMETOOLONG, pjd_rename(P, n0));
+    EXPECT(0, pjd_unlink(n0));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/rename/02.c
+++ b/src/posix/tests/pjd/rename/02.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/rename/02.t: ENAMETOOLONG if an entire pathname exceeds {PATH_MAX}. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/rename/03.c
+++ b/src/posix/tests/pjd/rename/03.c
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/rename/03.t: ENOENT if a component of the 'from' path does not exist. */
+#include "../../pjd_common.h"
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen(), *n1 = pjd_namegen(), *n2 = pjd_namegen();
+    char  from[256], to[256];
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    pjd_cd(n0);
+    snprintf(from, sizeof(from), "%s/test", n1);   /* n1 doesn't exist */
+    EXPECT(ENOENT, pjd_rename(from, n2));
+    EXPECT(ENOENT, pjd_rename(n1, n2));            /* plain missing source */
+    (void) to;
+    pjd_cd("..");
+    EXPECT(0, pjd_rmdir(n0));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/rename/03.c
+++ b/src/posix/tests/pjd/rename/03.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/rename/03.t: ENOENT if a component of the 'from' path does not exist. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/rename/04.c
+++ b/src/posix/tests/pjd/rename/04.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/rename/04.t: EACCES when a component of either path prefix denies search. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/rename/04.c
+++ b/src/posix/tests/pjd/rename/04.c
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/rename/04.t: EACCES when a component of either path prefix denies search. */
+#include "../../pjd_common.h"
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen(), *n1 = pjd_namegen(), *n2 = pjd_namegen(), *n3 = pjd_namegen();
+    char  src[256], dst[256];
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    pjd_cd(n0);
+    EXPECT(0, pjd_mkdir(n1, 0755));
+    EXPECT(0, pjd_chown(n1, 65534, 65534));
+    snprintf(src, sizeof(src), "%s/%s", n1, n2);
+    snprintf(dst, sizeof(dst), "%s/%s", n1, n3);
+    pjd_set_user(65534, 65534);
+    EXPECT(0, pjd_create(src, 0644));
+    EXPECT(0, pjd_rename(src, dst));
+    EXPECT(0, pjd_rename(dst, src));
+    pjd_set_root();
+    EXPECT(0, pjd_chmod(n1, 0644));   /* no search */
+    pjd_set_user(65534, 65534);
+    EXPECT(EACCES, pjd_rename(src, dst));
+    pjd_set_root();
+    EXPECT(0, pjd_chmod(n1, 0755));
+    pjd_set_user(65534, 65534);
+    EXPECT(0, pjd_unlink(src));
+    pjd_set_root();
+    EXPECT(0, pjd_rmdir(n1));
+    pjd_cd("..");
+    EXPECT(0, pjd_rmdir(n0));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/rename/05.c
+++ b/src/posix/tests/pjd/rename/05.c
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/rename/05.t: EACCES when the rename requires writing in a directory that denies write. */
+#include "../../pjd_common.h"
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen(), *n1 = pjd_namegen(), *n2 = pjd_namegen(), *n3 = pjd_namegen();
+    char  src[256], dst[256];
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    pjd_cd(n0);
+    EXPECT(0, pjd_mkdir(n1, 0755));
+    EXPECT(0, pjd_chown(n1, 65534, 65534));
+    snprintf(src, sizeof(src), "%s/%s", n1, n2);
+    snprintf(dst, sizeof(dst), "%s/%s", n1, n3);
+    pjd_set_user(65534, 65534);
+    EXPECT(0, pjd_create(src, 0644));
+    EXPECT(0, pjd_rename(src, dst));
+    EXPECT(0, pjd_rename(dst, src));
+    pjd_set_root();
+    EXPECT(0, pjd_chmod(n1, 0555));   /* no write */
+    pjd_set_user(65534, 65534);
+    EXPECT(EACCES, pjd_rename(src, dst));
+    pjd_set_root();
+    EXPECT(0, pjd_chmod(n1, 0755));
+    pjd_set_user(65534, 65534);
+    EXPECT(0, pjd_unlink(src));
+    pjd_set_root();
+    EXPECT(0, pjd_rmdir(n1));
+    pjd_cd("..");
+    EXPECT(0, pjd_rmdir(n0));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/rename/05.c
+++ b/src/posix/tests/pjd/rename/05.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/rename/05.t: EACCES when the rename requires writing in a directory that denies write. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/rename/11.c
+++ b/src/posix/tests/pjd/rename/11.c
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/rename/11.t: ELOOP on a symlink loop in either pathname. */
+#include "../../pjd_common.h"
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen(), *n1 = pjd_namegen();
+    char  P0[256], P1[256];
+    EXPECT(0, pjd_symlink(n0, n1));
+    EXPECT(0, pjd_symlink(n1, n0));
+    snprintf(P0, sizeof(P0), "%s/test", n0);
+    snprintf(P1, sizeof(P1), "%s/test", n1);
+    EXPECT(ELOOP, pjd_rename(P0, n0));
+    EXPECT(ELOOP, pjd_rename(P1, n0));
+    EXPECT(ELOOP, pjd_rename(n0, P0));
+    EXPECT(ELOOP, pjd_rename(n0, P1));
+    EXPECT(0, pjd_unlink(n0));
+    EXPECT(0, pjd_unlink(n1));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/rename/11.c
+++ b/src/posix/tests/pjd/rename/11.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/rename/11.t: ELOOP on a symlink loop in either pathname. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/rename/12.c
+++ b/src/posix/tests/pjd/rename/12.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/rename/12.t: ENOTDIR if a component of either path prefix is not a directory. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/rename/12.c
+++ b/src/posix/tests/pjd/rename/12.c
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/rename/12.t: ENOTDIR if a component of either path prefix is not a directory. */
+#include "../../pjd_common.h"
+static const enum pjd_ftype types[] = { PJD_FT_REGULAR, PJD_FT_FIFO, PJD_FT_BLOCK, PJD_FT_CHAR, PJD_FT_SOCKET };
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen(), *n1 = pjd_namegen(), *n2 = pjd_namegen();
+    char  src[256], P[512];
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    pjd_cd(n0);
+    EXPECT(0, pjd_mkdir(n1, 0755));
+    snprintf(src, sizeof(src), "%s/%s", n1, n2);
+    for (unsigned i = 0; i < sizeof(types) / sizeof(types[0]); i++) {
+        EXPECT(0, pjd_create_file(types[i], src));
+        snprintf(P, sizeof(P), "%s/%s/test", n1, n2);
+        EXPECT(ENOTDIR, pjd_rename(P, n2));   /* from prefix is a non-dir */
+        EXPECT(ENOTDIR, pjd_rename(n1, P));   /* to prefix is a non-dir */
+        EXPECT(0, pjd_unlink(src));
+    }
+    EXPECT(0, pjd_rmdir(n1));
+    pjd_cd("..");
+    EXPECT(0, pjd_rmdir(n0));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/rename/13.c
+++ b/src/posix/tests/pjd/rename/13.c
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/rename/13.t: ENOTDIR when 'from' is a directory but 'to' is an existing non-directory. */
+#include "../../pjd_common.h"
+static const enum pjd_ftype types[] = { PJD_FT_REGULAR, PJD_FT_FIFO, PJD_FT_BLOCK, PJD_FT_CHAR, PJD_FT_SOCKET,
+                                        PJD_FT_SYMLINK };
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen(), *n1 = pjd_namegen();
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    for (unsigned i = 0; i < sizeof(types) / sizeof(types[0]); i++) {
+        EXPECT(0, pjd_create_file(types[i], n1));
+        EXPECT(ENOTDIR, pjd_rename(n0, n1));
+        EXPECT_EQ(S_IFDIR, pjd_lstat_type(n0));
+        EXPECT(0, pjd_unlink(n1));
+    }
+    EXPECT(0, pjd_rmdir(n0));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/rename/13.c
+++ b/src/posix/tests/pjd/rename/13.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/rename/13.t: ENOTDIR when 'from' is a directory but 'to' is an existing non-directory. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/rename/14.c
+++ b/src/posix/tests/pjd/rename/14.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/rename/14.t: EISDIR when 'to' is a directory but 'from' is an existing non-directory. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/rename/14.c
+++ b/src/posix/tests/pjd/rename/14.c
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/rename/14.t: EISDIR when 'to' is a directory but 'from' is an existing non-directory. */
+#include "../../pjd_common.h"
+static const enum pjd_ftype types[] = { PJD_FT_REGULAR, PJD_FT_FIFO, PJD_FT_BLOCK, PJD_FT_CHAR, PJD_FT_SOCKET,
+                                        PJD_FT_SYMLINK };
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen(), *n1 = pjd_namegen();
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    for (unsigned i = 0; i < sizeof(types) / sizeof(types[0]); i++) {
+        EXPECT(0, pjd_create_file(types[i], n1));
+        EXPECT(EISDIR, pjd_rename(n1, n0));
+        EXPECT_EQ(S_IFDIR, pjd_lstat_type(n0));
+        EXPECT(0, pjd_unlink(n1));
+    }
+    EXPECT(0, pjd_rmdir(n0));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/rename/18.c
+++ b/src/posix/tests/pjd/rename/18.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/rename/18.t: EINVAL when 'from' is an ancestor of 'to'. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/rename/18.c
+++ b/src/posix/tests/pjd/rename/18.c
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/rename/18.t: EINVAL when 'from' is an ancestor of 'to'. */
+#include "../../pjd_common.h"
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen(), *n1 = pjd_namegen(), *n2 = pjd_namegen();
+    char  a[256], b[512];
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    snprintf(a, sizeof(a), "%s/%s", n0, n1);
+    EXPECT(0, pjd_mkdir(a, 0755));
+    EXPECT(EINVAL, pjd_rename(n0, a));
+    snprintf(b, sizeof(b), "%s/%s/%s", n0, n1, n2);
+    EXPECT(EINVAL, pjd_rename(n0, b));
+    EXPECT(0, pjd_rmdir(a));
+    EXPECT(0, pjd_rmdir(n0));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/rename/19.c
+++ b/src/posix/tests/pjd/rename/19.c
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/rename/19.t: EINVAL/EBUSY when renaming '.' or '..'. */
+#include "../../pjd_common.h"
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen(), *n1 = pjd_namegen(), *n2 = pjd_namegen();
+    char  dot[300], dotdot[300], a[256];
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    snprintf(a, sizeof(a), "%s/%s", n0, n1);
+    EXPECT(0, pjd_mkdir(a, 0755));
+    snprintf(dot, sizeof(dot), "%s/.", a);
+    snprintf(dotdot, sizeof(dotdot), "%s/..", a);
+    int   rc = pjd_rename(dot, n2); int e = (rc < 0) ? errno : 0;
+    PJD_CHECK(e == EINVAL || e == EBUSY, "rename '.' -> %s", strerror(e));
+    rc = pjd_rename(dotdot, n2); e = (rc < 0) ? errno : 0;
+    PJD_CHECK(e == EINVAL || e == EBUSY, "rename '..' -> %s", strerror(e));
+    EXPECT(0, pjd_rmdir(a));
+    EXPECT(0, pjd_rmdir(n0));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/rename/19.c
+++ b/src/posix/tests/pjd/rename/19.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/rename/19.t: EINVAL/EBUSY when renaming '.' or '..'. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/rename/20.c
+++ b/src/posix/tests/pjd/rename/20.c
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/rename/20.t: EEXIST or ENOTEMPTY if 'to' is a non-empty directory. */
+#include "../../pjd_common.h"
+static const enum pjd_ftype types[] = { PJD_FT_REGULAR, PJD_FT_DIR, PJD_FT_FIFO, PJD_FT_BLOCK, PJD_FT_CHAR,
+                                        PJD_FT_SOCKET,  PJD_FT_SYMLINK };
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen(), *n1 = pjd_namegen(), *n2 = pjd_namegen();
+    char  n1n2[256];
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    EXPECT(0, pjd_mkdir(n1, 0755));
+    snprintf(n1n2, sizeof(n1n2), "%s/%s", n1, n2);
+    for (unsigned i = 0; i < sizeof(types) / sizeof(types[0]); i++) {
+        EXPECT(0, pjd_create_file(types[i], n1n2));
+        int rc = pjd_rename(n0, n1); int e = (rc < 0) ? errno : 0;
+        PJD_CHECK(e == EEXIST || e == ENOTEMPTY, "rename to non-empty -> %s", strerror(e));
+        EXPECT(0, pjd_remove_file(types[i], n1n2));
+    }
+    EXPECT(0, pjd_rmdir(n1));
+    EXPECT(0, pjd_rmdir(n0));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/rename/20.c
+++ b/src/posix/tests/pjd/rename/20.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/rename/20.t: EEXIST or ENOTEMPTY if 'to' is a non-empty directory. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/rename/22.c
+++ b/src/posix/tests/pjd/rename/22.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/rename/22.t: rename updates the file's ctime. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/rename/22.c
+++ b/src/posix/tests/pjd/rename/22.c
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/rename/22.t: rename updates the file's ctime. */
+#include "../../pjd_common.h"
+static const enum pjd_ftype types[] = { PJD_FT_REGULAR, PJD_FT_DIR, PJD_FT_FIFO, PJD_FT_BLOCK, PJD_FT_CHAR,
+                                        PJD_FT_SOCKET };
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen(), *n1 = pjd_namegen();
+    for (unsigned i = 0; i < sizeof(types) / sizeof(types[0]); i++) {
+        struct timespec c1, c2;
+        EXPECT(0, pjd_create_file(types[i], n0));
+        pjd_lstat_ctime(n0, &c1);
+        pjd_settle();
+        EXPECT(0, pjd_rename(n0, n1));
+        pjd_lstat_ctime(n1, &c2);
+        PJD_CHECK(pjd_timespec_lt(&c1, &c2), "ctime advanced after rename (type %d)", types[i]);
+        EXPECT(0, pjd_remove_file(types[i], n1));
+    }
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/rmdir/00.c
+++ b/src/posix/tests/pjd/rmdir/00.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/rmdir/00.t: rmdir removes directories and updates
  * the parent directory's mtime/ctime. */

--- a/src/posix/tests/pjd/rmdir/00.c
+++ b/src/posix/tests/pjd/rmdir/00.c
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/rmdir/00.t: rmdir removes directories and updates
+ * the parent directory's mtime/ctime. */
+#include "../../pjd_common.h"
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char           *n0 = pjd_namegen(), *n1 = pjd_namegen();
+    char            n0n1[256];
+    struct timespec t0, t1;
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    EXPECT_EQ(S_IFDIR, pjd_lstat_type(n0));
+    EXPECT(0, pjd_rmdir(n0));
+    EXPECT_EQ(0, pjd_lstat_type(n0));   /* gone */
+
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    snprintf(n0n1, sizeof(n0n1), "%s/%s", n0, n1);
+    EXPECT(0, pjd_mkdir(n0n1, 0755));
+    pjd_stat_ctime(n0, &t0);
+    pjd_settle();
+    EXPECT(0, pjd_rmdir(n0n1));
+    pjd_stat_mtime(n0, &t1);
+    PJD_CHECK(pjd_timespec_lt(&t0, &t1), "parent mtime advanced on rmdir");
+    pjd_stat_ctime(n0, &t1);
+    PJD_CHECK(pjd_timespec_lt(&t0, &t1), "parent ctime advanced on rmdir");
+    EXPECT(0, pjd_rmdir(n0));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/rmdir/01.c
+++ b/src/posix/tests/pjd/rmdir/01.c
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/rmdir/01.t: ENOTDIR if a path component is not a directory. */
+#include "../../pjd_common.h"
+static const enum pjd_ftype types[] = { PJD_FT_REGULAR, PJD_FT_FIFO, PJD_FT_BLOCK, PJD_FT_CHAR, PJD_FT_SOCKET };
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen(), *n1 = pjd_namegen();
+    char  sub[256], deeper[512];
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    for (unsigned i = 0; i < sizeof(types) / sizeof(types[0]); i++) {
+        snprintf(sub, sizeof(sub), "%s/%s", n0, n1);
+        EXPECT(0, pjd_create_file(types[i], sub));
+        snprintf(deeper, sizeof(deeper), "%s/%s/test", n0, n1);
+        EXPECT(ENOTDIR, pjd_rmdir(deeper));
+        EXPECT(0, pjd_unlink(sub));
+    }
+    EXPECT(0, pjd_rmdir(n0));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/rmdir/01.c
+++ b/src/posix/tests/pjd/rmdir/01.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/rmdir/01.t: ENOTDIR if a path component is not a directory. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/rmdir/02.c
+++ b/src/posix/tests/pjd/rmdir/02.c
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/rmdir/02.t: ENAMETOOLONG if a component exceeds {NAME_MAX}. */
+#include "../../pjd_common.h"
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *nx = pjd_namegen_max();
+    char  nxx[512];
+    snprintf(nxx, sizeof(nxx), "%sx", nx);
+    EXPECT(0, pjd_mkdir(nx, 0755));
+    EXPECT(0, pjd_rmdir(nx));
+    EXPECT(ENAMETOOLONG, pjd_rmdir(nxx));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/rmdir/02.c
+++ b/src/posix/tests/pjd/rmdir/02.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/rmdir/02.t: ENAMETOOLONG if a component exceeds {NAME_MAX}. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/rmdir/03.c
+++ b/src/posix/tests/pjd/rmdir/03.c
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/rmdir/03.t: ENAMETOOLONG if the whole path exceeds {PATH_MAX}. */
+#include "../../pjd_common.h"
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *nx = pjd_dirgen_max();
+    char  nxx[8192];
+    snprintf(nxx, sizeof(nxx), "%sx", nx);
+    pjd_mkdir_p(nx);
+    EXPECT(0, pjd_mkdir(nx, 0755));
+    EXPECT(0, pjd_rmdir(nx));
+    EXPECT(ENAMETOOLONG, pjd_rmdir(nxx));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/rmdir/03.c
+++ b/src/posix/tests/pjd/rmdir/03.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/rmdir/03.t: ENAMETOOLONG if the whole path exceeds {PATH_MAX}. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/rmdir/04.c
+++ b/src/posix/tests/pjd/rmdir/04.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/rmdir/04.t: ENOENT if the named directory does not exist. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/rmdir/04.c
+++ b/src/posix/tests/pjd/rmdir/04.c
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/rmdir/04.t: ENOENT if the named directory does not exist. */
+#include "../../pjd_common.h"
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen(), *n1 = pjd_namegen();
+    char  p[256];
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    snprintf(p, sizeof(p), "%s/%s", n0, n1);
+    EXPECT(ENOENT, pjd_rmdir(p));
+    EXPECT(0, pjd_rmdir(n0));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/rmdir/05.c
+++ b/src/posix/tests/pjd/rmdir/05.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/rmdir/05.t: ELOOP on a symlink loop in the pathname. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/rmdir/05.c
+++ b/src/posix/tests/pjd/rmdir/05.c
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/rmdir/05.t: ELOOP on a symlink loop in the pathname. */
+#include "../../pjd_common.h"
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen(), *n1 = pjd_namegen();
+    char  n0t[256], n1t[256];
+    EXPECT(0, pjd_symlink(n0, n1));
+    EXPECT(0, pjd_symlink(n1, n0));
+    snprintf(n0t, sizeof(n0t), "%s/test", n0);
+    snprintf(n1t, sizeof(n1t), "%s/test", n1);
+    EXPECT(ELOOP, pjd_rmdir(n0t));
+    EXPECT(ELOOP, pjd_rmdir(n1t));
+    EXPECT(0, pjd_unlink(n0));
+    EXPECT(0, pjd_unlink(n1));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/rmdir/06.c
+++ b/src/posix/tests/pjd/rmdir/06.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/rmdir/06.t: EEXIST or ENOTEMPTY if the directory is not empty. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/rmdir/06.c
+++ b/src/posix/tests/pjd/rmdir/06.c
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/rmdir/06.t: EEXIST or ENOTEMPTY if the directory is not empty. */
+#include "../../pjd_common.h"
+static const enum pjd_ftype types[] = { PJD_FT_REGULAR, PJD_FT_DIR, PJD_FT_FIFO, PJD_FT_BLOCK, PJD_FT_CHAR,
+                                        PJD_FT_SOCKET,  PJD_FT_SYMLINK };
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen(), *n1 = pjd_namegen();
+    char  n0n1[256];
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    snprintf(n0n1, sizeof(n0n1), "%s/%s", n0, n1);
+    for (unsigned i = 0; i < sizeof(types) / sizeof(types[0]); i++) {
+        EXPECT(0, pjd_create_file(types[i], n0n1));
+        int rc = pjd_rmdir(n0);
+        int e  = (rc < 0) ? errno : 0;
+        PJD_CHECK(e == EEXIST || e == ENOTEMPTY, "rmdir non-empty -> %s (want EEXIST/ENOTEMPTY)", strerror(e));
+        EXPECT(0, pjd_remove_file(types[i], n0n1));
+    }
+    EXPECT(0, pjd_rmdir(n0));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/rmdir/07.c
+++ b/src/posix/tests/pjd/rmdir/07.c
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/rmdir/07.t:
+ * rmdir returns EACCES when search permission is denied for a component of the
+ * path prefix. */
+
+#include "../../pjd_common.h"
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+
+    char *n0 = pjd_namegen();
+    char *n1 = pjd_namegen();
+    char *n2 = pjd_namegen();
+    char  n1n2[256];
+
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    pjd_cd(n0);
+
+    EXPECT(0, pjd_mkdir(n1, 0755));
+    EXPECT(0, pjd_chown(n1, 65534, 65534));
+
+    snprintf(n1n2, sizeof(n1n2), "%s/%s", n1, n2);
+
+    pjd_set_user(65534, 65534);
+    EXPECT(0, pjd_mkdir(n1n2, 0755));
+    pjd_set_root();
+
+    EXPECT(0, pjd_chmod(n1, 0644));   /* no search permission */
+    pjd_set_user(65534, 65534);
+    EXPECT(EACCES, pjd_rmdir(n1n2));
+    pjd_set_root();
+
+    EXPECT(0, pjd_chmod(n1, 0755));
+    pjd_set_user(65534, 65534);
+    EXPECT(0, pjd_rmdir(n1n2));
+    pjd_set_root();
+
+    EXPECT(0, pjd_rmdir(n1));
+    pjd_cd("..");
+    EXPECT(0, pjd_rmdir(n0));
+
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/rmdir/07.c
+++ b/src/posix/tests/pjd/rmdir/07.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/rmdir/07.t:
  * rmdir returns EACCES when search permission is denied for a component of the

--- a/src/posix/tests/pjd/rmdir/08.c
+++ b/src/posix/tests/pjd/rmdir/08.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/rmdir/08.t:
  * rmdir returns EACCES when write permission is denied on the directory

--- a/src/posix/tests/pjd/rmdir/08.c
+++ b/src/posix/tests/pjd/rmdir/08.c
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/rmdir/08.t:
+ * rmdir returns EACCES when write permission is denied on the directory
+ * containing the directory to be removed. */
+
+#include "../../pjd_common.h"
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+
+    char *n0 = pjd_namegen();
+    char *n1 = pjd_namegen();
+    char *n2 = pjd_namegen();
+    char  n1n2[256];
+
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    pjd_cd(n0);
+
+    EXPECT(0, pjd_mkdir(n1, 0755));
+    EXPECT(0, pjd_chown(n1, 65534, 65534));
+
+    snprintf(n1n2, sizeof(n1n2), "%s/%s", n1, n2);
+
+    pjd_set_user(65534, 65534);
+    EXPECT(0, pjd_mkdir(n1n2, 0755));
+    pjd_set_root();
+
+    EXPECT(0, pjd_chmod(n1, 0555));   /* no write permission */
+    pjd_set_user(65534, 65534);
+    EXPECT(EACCES, pjd_rmdir(n1n2));
+    pjd_set_root();
+
+    EXPECT(0, pjd_chmod(n1, 0755));
+    pjd_set_user(65534, 65534);
+    EXPECT(0, pjd_rmdir(n1n2));
+    pjd_set_root();
+
+    EXPECT(0, pjd_rmdir(n1));
+    pjd_cd("..");
+    EXPECT(0, pjd_rmdir(n0));
+
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/rmdir/11.c
+++ b/src/posix/tests/pjd/rmdir/11.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/rmdir/11.t:
  * rmdir returns EACCES or EPERM if the containing directory is sticky and the

--- a/src/posix/tests/pjd/rmdir/11.c
+++ b/src/posix/tests/pjd/rmdir/11.c
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/rmdir/11.t:
+ * rmdir returns EACCES or EPERM if the containing directory is sticky and the
+ * caller owns neither the containing directory nor the directory to remove. */
+
+#include "../../pjd_common.h"
+
+static void
+expect_acces_or_eperm(const char *path)
+{
+    int rc = pjd_rmdir(path);
+    int e  = (rc < 0) ? errno : 0;
+
+    PJD_CHECK(e == EACCES || e == EPERM,
+              "sticky rmdir %s -> %s (want EACCES/EPERM)", path, strerror(e));
+} /* expect_acces_or_eperm */
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+
+    char *n0 = pjd_namegen();
+    char *n1 = pjd_namegen();
+    char *n2 = pjd_namegen();
+    char  n0n1[256];
+
+    EXPECT(0, pjd_mkdir(n2, 0755));
+    pjd_cd(n2);
+
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    EXPECT(0, pjd_chown(n0, 65534, 65534));
+    EXPECT(0, pjd_chmod(n0, 01777));   /* sticky */
+
+    snprintf(n0n1, sizeof(n0n1), "%s/%s", n0, n1);
+
+    /* Caller owns both the sticky dir and the dir to remove -> allowed. */
+    pjd_set_user(65534, 65534);
+    EXPECT(0, pjd_mkdir(n0n1, 0755));
+    EXPECT(0, pjd_rmdir(n0n1));
+    pjd_set_root();
+
+    /* Caller owns the dir to remove but not the sticky dir -> allowed. */
+    for (int k = 0; k < 2; k++) {
+        int id = k == 0 ? 0 : 65533;
+        EXPECT(0, pjd_chown(n0, id, id));
+        EXPECT(0, pjd_create_file_owned(PJD_FT_DIR, n0n1, 65534, 65534));
+        pjd_set_user(65534, 65534);
+        EXPECT(0, pjd_rmdir(n0n1));
+        pjd_set_root();
+    }
+
+    /* Caller owns the sticky dir but not the dir to remove -> allowed. */
+    EXPECT(0, pjd_chown(n0, 65534, 65534));
+    for (int k = 0; k < 2; k++) {
+        int id = k == 0 ? 0 : 65533;
+        EXPECT(0, pjd_create_file_owned(PJD_FT_DIR, n0n1, id, id));
+        pjd_set_user(65534, 65534);
+        EXPECT(0, pjd_rmdir(n0n1));
+        pjd_set_root();
+    }
+
+    /* Caller owns neither -> EACCES/EPERM. */
+    for (int k = 0; k < 2; k++) {
+        int id = k == 0 ? 0 : 65533;
+        EXPECT(0, pjd_chown(n0, id, id));
+        EXPECT(0, pjd_create_file_owned(PJD_FT_DIR, n0n1, id, id));
+        pjd_set_user(65534, 65534);
+        expect_acces_or_eperm(n0n1);
+        pjd_set_root();
+        EXPECT(0, pjd_rmdir(n0n1));
+    }
+
+    EXPECT(0, pjd_rmdir(n0));
+    pjd_cd("..");
+    EXPECT(0, pjd_rmdir(n2));
+
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/rmdir/12.c
+++ b/src/posix/tests/pjd/rmdir/12.c
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/rmdir/12.t:
+ * rmdir returns EINVAL if the last path component is '.', and EEXIST/ENOTEMPTY
+ * if it is '..'. */
+
+#include "../../pjd_common.h"
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+
+    char *n0 = pjd_namegen();
+    char *n1 = pjd_namegen();
+    char  n0n1[256], dot[300], dotdot[300];
+
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    snprintf(n0n1, sizeof(n0n1), "%s/%s", n0, n1);
+    EXPECT(0, pjd_mkdir(n0n1, 0755));
+
+    snprintf(dot, sizeof(dot), "%s/.", n0n1);
+    EXPECT(EINVAL, pjd_rmdir(dot));
+
+    snprintf(dotdot, sizeof(dotdot), "%s/..", n0n1);
+    {
+        int rc = pjd_rmdir(dotdot);
+        int e  = (rc < 0) ? errno : 0;
+        PJD_CHECK(e == ENOTEMPTY || e == EEXIST,
+                  "rmdir '..' -> %s (want ENOTEMPTY/EEXIST)", strerror(e));
+    }
+
+    EXPECT(0, pjd_rmdir(n0n1));
+    EXPECT(0, pjd_rmdir(n0));
+
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/rmdir/12.c
+++ b/src/posix/tests/pjd/rmdir/12.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/rmdir/12.t:
  * rmdir returns EINVAL if the last path component is '.', and EEXIST/ENOTEMPTY

--- a/src/posix/tests/pjd/symlink/00.c
+++ b/src/posix/tests/pjd/symlink/00.c
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/symlink/00.t:
+ * symlink creates symbolic links; lstat sees the link, stat follows to the
+ * target, and the parent directory's mtime/ctime are updated. */
+
+#include "../../pjd_common.h"
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+
+    char           *n0 = pjd_namegen();
+    char           *n1 = pjd_namegen();
+    char            n0n1[256];
+    struct timespec t0, t1;
+    struct stat     st;
+
+    EXPECT(0, pjd_create(n0, 0644));
+    EXPECT_EQ(S_IFREG, pjd_lstat_type(n0));
+    EXPECT_EQ(0644, pjd_lstat_mode(n0));
+
+    EXPECT(0, pjd_symlink(n0, n1));
+    EXPECT_EQ(S_IFLNK, pjd_lstat_type(n1));
+    EXPECT_EQ(S_IFREG, pjd_stat_type(n1));      /* follows to the regular file */
+    EXPECT_EQ(0644, pjd_stat_mode(n1));
+
+    EXPECT(0, pjd_unlink(n0));
+    EXPECT(ENOENT, pjd_stat(n1, &st));          /* dangling now */
+    EXPECT(0, pjd_unlink(n1));
+
+    /* symlink updates the parent directory's mtime/ctime. */
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    snprintf(n0n1, sizeof(n0n1), "%s/%s", n0, n1);
+    pjd_stat_ctime(n0, &t0);
+    pjd_settle();
+    EXPECT(0, pjd_symlink("test", n0n1));
+    pjd_stat_mtime(n0, &t1);
+    PJD_CHECK(pjd_timespec_lt(&t0, &t1), "parent mtime advanced on symlink");
+    pjd_stat_ctime(n0, &t1);
+    PJD_CHECK(pjd_timespec_lt(&t0, &t1), "parent ctime advanced on symlink");
+    EXPECT(0, pjd_unlink(n0n1));
+    EXPECT(0, pjd_rmdir(n0));
+
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/symlink/00.c
+++ b/src/posix/tests/pjd/symlink/00.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/symlink/00.t:
  * symlink creates symbolic links; lstat sees the link, stat follows to the

--- a/src/posix/tests/pjd/symlink/01.c
+++ b/src/posix/tests/pjd/symlink/01.c
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/symlink/01.t: ENOTDIR if a name2 path-prefix component is not a directory. */
+#include "../../pjd_common.h"
+static const enum pjd_ftype types[] = { PJD_FT_REGULAR, PJD_FT_FIFO, PJD_FT_BLOCK, PJD_FT_CHAR, PJD_FT_SOCKET };
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen(), *n1 = pjd_namegen();
+    char  sub[256], P[512];
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    for (unsigned i = 0; i < sizeof(types) / sizeof(types[0]); i++) {
+        snprintf(sub, sizeof(sub), "%s/%s", n0, n1);
+        EXPECT(0, pjd_create_file(types[i], sub));
+        snprintf(P, sizeof(P), "%s/%s/test", n0, n1);
+        EXPECT(ENOTDIR, pjd_symlink("test", P));
+        EXPECT(0, pjd_unlink(sub));
+    }
+    EXPECT(0, pjd_rmdir(n0));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/symlink/01.c
+++ b/src/posix/tests/pjd/symlink/01.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/symlink/01.t: ENOTDIR if a name2 path-prefix component is not a directory. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/symlink/02.c
+++ b/src/posix/tests/pjd/symlink/02.c
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/symlink/02.t: ENAMETOOLONG if a name2 component exceeds {NAME_MAX}. */
+#include "../../pjd_common.h"
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *nx = pjd_namegen_max();
+    char  P[512];
+    snprintf(P, sizeof(P), "%sx", nx);
+    EXPECT(ENAMETOOLONG, pjd_symlink("test", P));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/symlink/02.c
+++ b/src/posix/tests/pjd/symlink/02.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/symlink/02.t: ENAMETOOLONG if a name2 component exceeds {NAME_MAX}. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/symlink/03.c
+++ b/src/posix/tests/pjd/symlink/03.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/symlink/03.t: ENAMETOOLONG if the whole name2 path, or
  * the symlink target (name1), exceeds {PATH_MAX}. */

--- a/src/posix/tests/pjd/symlink/03.c
+++ b/src/posix/tests/pjd/symlink/03.c
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/symlink/03.t: ENAMETOOLONG if the whole name2 path, or
+ * the symlink target (name1), exceeds {PATH_MAX}. */
+#include "../../pjd_common.h"
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *nx = pjd_dirgen_max();
+    char  P[8192];
+    snprintf(P, sizeof(P), "%sx", nx);
+    pjd_mkdir_p(nx);
+    EXPECT(ENAMETOOLONG, pjd_symlink("test", P));
+    /* Over-long symlink target (used verbatim, so it must itself exceed
+     * {PATH_MAX} regardless of the harness cwd). */
+    char *target = pjd_namegen_len((size_t) CHIMERA_VFS_PATH_MAX + 16);
+    char *ln     = pjd_namegen();
+    EXPECT(ENAMETOOLONG, pjd_symlink(target, ln));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/symlink/04.c
+++ b/src/posix/tests/pjd/symlink/04.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/symlink/04.t: ENOENT if a name2 path-prefix component does not exist. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/symlink/04.c
+++ b/src/posix/tests/pjd/symlink/04.c
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/symlink/04.t: ENOENT if a name2 path-prefix component does not exist. */
+#include "../../pjd_common.h"
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen(), *n1 = pjd_namegen();
+    char  P[512];
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    snprintf(P, sizeof(P), "%s/%s/test", n0, n1);
+    EXPECT(ENOENT, pjd_symlink("test", P));
+    EXPECT(0, pjd_rmdir(n0));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/symlink/05.c
+++ b/src/posix/tests/pjd/symlink/05.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/symlink/05.t: EACCES when search permission is denied for a name2 prefix component. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/symlink/05.c
+++ b/src/posix/tests/pjd/symlink/05.c
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/symlink/05.t: EACCES when search permission is denied for a name2 prefix component. */
+#include "../../pjd_common.h"
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen(), *n1 = pjd_namegen(), *n2 = pjd_namegen();
+    char  P[256];
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    pjd_cd(n0);
+    EXPECT(0, pjd_mkdir(n1, 0755));
+    EXPECT(0, pjd_chown(n1, 65534, 65534));
+    snprintf(P, sizeof(P), "%s/%s", n1, n2);
+    pjd_set_user(65534, 65534);
+    EXPECT(0, pjd_symlink("test", P));
+    EXPECT(0, pjd_unlink(P));
+    pjd_set_root();
+    EXPECT(0, pjd_chmod(n1, 0644));
+    pjd_set_user(65534, 65534);
+    EXPECT(EACCES, pjd_symlink("test", P));
+    pjd_set_root();
+    EXPECT(0, pjd_chmod(n1, 0755));
+    EXPECT(0, pjd_rmdir(n1));
+    pjd_cd("..");
+    EXPECT(0, pjd_rmdir(n0));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/symlink/06.c
+++ b/src/posix/tests/pjd/symlink/06.c
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/symlink/06.t: EACCES when write permission is denied on the name2 parent directory. */
+#include "../../pjd_common.h"
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen(), *n1 = pjd_namegen(), *n2 = pjd_namegen();
+    char  P[256];
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    pjd_cd(n0);
+    EXPECT(0, pjd_mkdir(n1, 0755));
+    EXPECT(0, pjd_chown(n1, 65534, 65534));
+    snprintf(P, sizeof(P), "%s/%s", n1, n2);
+    pjd_set_user(65534, 65534);
+    EXPECT(0, pjd_symlink("test", P));
+    EXPECT(0, pjd_unlink(P));
+    pjd_set_root();
+    EXPECT(0, pjd_chmod(n1, 0555));
+    pjd_set_user(65534, 65534);
+    EXPECT(EACCES, pjd_symlink("test", P));
+    pjd_set_root();
+    EXPECT(0, pjd_chmod(n1, 0755));
+    EXPECT(0, pjd_rmdir(n1));
+    pjd_cd("..");
+    EXPECT(0, pjd_rmdir(n0));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/symlink/06.c
+++ b/src/posix/tests/pjd/symlink/06.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/symlink/06.t: EACCES when write permission is denied on the name2 parent directory. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/symlink/07.c
+++ b/src/posix/tests/pjd/symlink/07.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/symlink/07.t: ELOOP on a symlink loop in the name2 pathname. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/symlink/07.c
+++ b/src/posix/tests/pjd/symlink/07.c
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/symlink/07.t: ELOOP on a symlink loop in the name2 pathname. */
+#include "../../pjd_common.h"
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen(), *n1 = pjd_namegen();
+    char  P[256];
+    EXPECT(0, pjd_symlink(n0, n1));
+    EXPECT(0, pjd_symlink(n1, n0));
+    snprintf(P, sizeof(P), "%s/test", n0);
+    EXPECT(ELOOP, pjd_symlink("test", P));
+    snprintf(P, sizeof(P), "%s/test", n1);
+    EXPECT(ELOOP, pjd_symlink("test", P));
+    EXPECT(0, pjd_unlink(n0));
+    EXPECT(0, pjd_unlink(n1));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/symlink/08.c
+++ b/src/posix/tests/pjd/symlink/08.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/symlink/08.t: EEXIST if name2 already exists (any type). */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/symlink/08.c
+++ b/src/posix/tests/pjd/symlink/08.c
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/symlink/08.t: EEXIST if name2 already exists (any type). */
+#include "../../pjd_common.h"
+static const enum pjd_ftype types[] = { PJD_FT_REGULAR, PJD_FT_DIR, PJD_FT_FIFO, PJD_FT_BLOCK, PJD_FT_CHAR,
+                                        PJD_FT_SOCKET,  PJD_FT_SYMLINK };
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen();
+    char  P[256];
+    snprintf(P, sizeof(P), "%s", n0);
+    for (unsigned i = 0; i < sizeof(types) / sizeof(types[0]); i++) {
+        EXPECT(0, pjd_create_file(types[i], n0));
+        EXPECT(EEXIST, pjd_symlink("test", P));
+        EXPECT(0, pjd_remove_file(types[i], n0));
+    }
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/truncate/00.c
+++ b/src/posix/tests/pjd/truncate/00.c
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/truncate/00.t:
+ * truncate decreases/increases file size and updates ctime on success (but not
+ * on a failed, permission-denied truncate). */
+
+#include "../../pjd_common.h"
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+
+    char           *n0 = pjd_namegen();
+    char           *n1 = pjd_namegen();
+    struct timespec c1, c2;
+
+    EXPECT(0, pjd_mkdir(n1, 0755));
+    pjd_cd(n1);
+
+    EXPECT(0, pjd_create(n0, 0644));
+    EXPECT(0, pjd_truncate(n0, 1234567));
+    EXPECT_EQ(1234567, pjd_stat_size(n0));
+    EXPECT(0, pjd_truncate(n0, 567));
+    EXPECT_EQ(567, pjd_stat_size(n0));
+    EXPECT(0, pjd_unlink(n0));
+
+    /* Grow from data, then shrink. */
+    {
+        int fd = pjd_open(n0, O_CREAT | O_WRONLY, 0644);
+        PJD_CHECK(fd >= 0, "create n0 with data");
+        if (fd >= 0) {
+            char buf[12345];
+            memset(buf, 'a', sizeof(buf));
+            chimera_posix_write(fd, buf, sizeof(buf));
+            chimera_posix_close(fd);
+        }
+    }
+    EXPECT(0, pjd_truncate(n0, 23456));
+    EXPECT_EQ(23456, pjd_stat_size(n0));
+    EXPECT(0, pjd_truncate(n0, 1));
+    EXPECT_EQ(1, pjd_stat_size(n0));
+    EXPECT(0, pjd_unlink(n0));
+
+    /* Successful truncate updates ctime. */
+    EXPECT(0, pjd_create(n0, 0644));
+    pjd_stat_ctime(n0, &c1);
+    pjd_settle();
+    EXPECT(0, pjd_truncate(n0, 123));
+    pjd_stat_ctime(n0, &c2);
+    PJD_CHECK(pjd_timespec_lt(&c1, &c2), "ctime advanced after truncate");
+    EXPECT(0, pjd_unlink(n0));
+
+    /* Unsuccessful truncate does not update ctime. */
+    EXPECT(0, pjd_create(n0, 0644));
+    pjd_stat_ctime(n0, &c1);
+    pjd_settle();
+    pjd_set_user(65534, 65534);
+    EXPECT(EACCES, pjd_truncate(n0, 123));
+    pjd_set_root();
+    pjd_stat_ctime(n0, &c2);
+    PJD_CHECK(c1.tv_sec == c2.tv_sec && c1.tv_nsec == c2.tv_nsec,
+              "ctime unchanged after failed truncate");
+    EXPECT(0, pjd_unlink(n0));
+
+    pjd_cd("..");
+    EXPECT(0, pjd_rmdir(n1));
+
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/truncate/00.c
+++ b/src/posix/tests/pjd/truncate/00.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/truncate/00.t:
  * truncate decreases/increases file size and updates ctime on success (but not

--- a/src/posix/tests/pjd/truncate/01.c
+++ b/src/posix/tests/pjd/truncate/01.c
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/truncate/01.t:
+ * truncate returns ENOTDIR if a component of the path prefix is not a directory. */
+
+#include "../../pjd_common.h"
+
+static const enum pjd_ftype types[] = {
+    PJD_FT_REGULAR, PJD_FT_FIFO, PJD_FT_BLOCK, PJD_FT_CHAR, PJD_FT_SOCKET,
+};
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen();
+    char *n1 = pjd_namegen();
+    char  sub[256], deeper[512];
+
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    for (unsigned i = 0; i < sizeof(types) / sizeof(types[0]); i++) {
+        snprintf(sub, sizeof(sub), "%s/%s", n0, n1);
+        EXPECT(0, pjd_create_file(types[i], sub));
+        snprintf(deeper, sizeof(deeper), "%s/%s/test", n0, n1);
+        EXPECT(ENOTDIR, pjd_truncate(deeper, 123));
+        EXPECT(0, pjd_unlink(sub));
+    }
+    EXPECT(0, pjd_rmdir(n0));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/truncate/01.c
+++ b/src/posix/tests/pjd/truncate/01.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/truncate/01.t:
  * truncate returns ENOTDIR if a component of the path prefix is not a directory. */

--- a/src/posix/tests/pjd/truncate/02.c
+++ b/src/posix/tests/pjd/truncate/02.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/truncate/02.t:
  * truncate returns ENAMETOOLONG if a pathname component exceeds {NAME_MAX}. */

--- a/src/posix/tests/pjd/truncate/02.c
+++ b/src/posix/tests/pjd/truncate/02.c
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/truncate/02.t:
+ * truncate returns ENAMETOOLONG if a pathname component exceeds {NAME_MAX}. */
+
+#include "../../pjd_common.h"
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *nx = pjd_namegen_max();
+    char  nxx[512];
+
+    snprintf(nxx, sizeof(nxx), "%sx", nx);
+    EXPECT(0, pjd_create(nx, 0644));
+    EXPECT(0, pjd_truncate(nx, 123));
+    EXPECT_EQ(123, pjd_stat_size(nx));
+    EXPECT(0, pjd_unlink(nx));
+    EXPECT(ENAMETOOLONG, pjd_truncate(nxx, 123));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/truncate/03.c
+++ b/src/posix/tests/pjd/truncate/03.c
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/truncate/03.t:
+ * truncate returns ENAMETOOLONG if an entire pathname exceeds {PATH_MAX}. */
+
+#include "../../pjd_common.h"
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *nx = pjd_dirgen_max();
+    char  nxx[8192];
+
+    snprintf(nxx, sizeof(nxx), "%sx", nx);
+    pjd_mkdir_p(nx);
+    EXPECT(0, pjd_create(nx, 0644));
+    EXPECT(0, pjd_truncate(nx, 123));
+    EXPECT_EQ(123, pjd_stat_size(nx));
+    EXPECT(0, pjd_unlink(nx));
+    EXPECT(ENAMETOOLONG, pjd_truncate(nxx, 123));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/truncate/03.c
+++ b/src/posix/tests/pjd/truncate/03.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/truncate/03.t:
  * truncate returns ENAMETOOLONG if an entire pathname exceeds {PATH_MAX}. */

--- a/src/posix/tests/pjd/truncate/04.c
+++ b/src/posix/tests/pjd/truncate/04.c
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/truncate/04.t:
+ * truncate returns ENOENT if the named file does not exist. */
+
+#include "../../pjd_common.h"
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen();
+    char *n1 = pjd_namegen();
+    char  p[256];
+
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    snprintf(p, sizeof(p), "%s/%s", n0, n1);
+    EXPECT(ENOENT, pjd_truncate(p, 123));
+    EXPECT(0, pjd_rmdir(n0));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/truncate/04.c
+++ b/src/posix/tests/pjd/truncate/04.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/truncate/04.t:
  * truncate returns ENOENT if the named file does not exist. */

--- a/src/posix/tests/pjd/truncate/05.c
+++ b/src/posix/tests/pjd/truncate/05.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/truncate/05.t:
  * truncate returns EACCES when search permission is denied for a component of

--- a/src/posix/tests/pjd/truncate/05.c
+++ b/src/posix/tests/pjd/truncate/05.c
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/truncate/05.t:
+ * truncate returns EACCES when search permission is denied for a component of
+ * the path prefix. */
+
+#include "../../pjd_common.h"
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+
+    char *n0 = pjd_namegen();
+    char *n1 = pjd_namegen();
+    char *n2 = pjd_namegen();
+    char  n1n2[256];
+
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    pjd_cd(n0);
+
+    EXPECT(0, pjd_mkdir(n1, 0755));
+    EXPECT(0, pjd_chown(n1, 65534, 65534));
+
+    snprintf(n1n2, sizeof(n1n2), "%s/%s", n1, n2);
+
+    pjd_set_user(65534, 65534);
+    EXPECT(0, pjd_create(n1n2, 0644));
+    EXPECT(0, pjd_truncate(n1n2, 123));
+    pjd_set_root();
+
+    EXPECT(0, pjd_chmod(n1, 0644));
+    pjd_set_user(65534, 65534);
+    EXPECT(EACCES, pjd_truncate(n1n2, 123));
+    pjd_set_root();
+
+    EXPECT(0, pjd_chmod(n1, 0755));
+    pjd_set_user(65534, 65534);
+    EXPECT(0, pjd_truncate(n1n2, 123));
+    EXPECT(0, pjd_unlink(n1n2));
+    pjd_set_root();
+
+    EXPECT(0, pjd_rmdir(n1));
+    pjd_cd("..");
+    EXPECT(0, pjd_rmdir(n0));
+
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/truncate/06.c
+++ b/src/posix/tests/pjd/truncate/06.c
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/truncate/06.t:
+ * truncate returns EACCES if the named file is not writable by the user. */
+
+#include "../../pjd_common.h"
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+
+    char *n0 = pjd_namegen();
+    char *n1 = pjd_namegen();
+
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    pjd_cd(n0);
+
+    EXPECT(0, pjd_create(n1, 0644));
+
+    /* Not the owner, no write bit for others -> EACCES. */
+    pjd_set_user(65534, 65534);
+    EXPECT(EACCES, pjd_truncate(n1, 123));
+    pjd_set_root();
+
+    /* Owner, but file mode 0444 (no write) -> EACCES. */
+    EXPECT(0, pjd_chown(n1, 65534, 65534));
+    EXPECT(0, pjd_chmod(n1, 0444));
+    pjd_set_user(65534, 65534);
+    EXPECT(EACCES, pjd_truncate(n1, 123));
+    pjd_set_root();
+
+    EXPECT(0, pjd_unlink(n1));
+    pjd_cd("..");
+    EXPECT(0, pjd_rmdir(n0));
+
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/truncate/06.c
+++ b/src/posix/tests/pjd/truncate/06.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/truncate/06.t:
  * truncate returns EACCES if the named file is not writable by the user. */

--- a/src/posix/tests/pjd/truncate/07.c
+++ b/src/posix/tests/pjd/truncate/07.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/truncate/07.t:
  * truncate returns ELOOP if too many symbolic links were encountered. */

--- a/src/posix/tests/pjd/truncate/07.c
+++ b/src/posix/tests/pjd/truncate/07.c
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/truncate/07.t:
+ * truncate returns ELOOP if too many symbolic links were encountered. */
+
+#include "../../pjd_common.h"
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen();
+    char *n1 = pjd_namegen();
+    char  n0t[256], n1t[256];
+
+    EXPECT(0, pjd_symlink(n0, n1));
+    EXPECT(0, pjd_symlink(n1, n0));
+    EXPECT(ELOOP, pjd_truncate(n0, 123));
+    EXPECT(ELOOP, pjd_truncate(n1, 123));
+    snprintf(n0t, sizeof(n0t), "%s/test", n0);
+    snprintf(n1t, sizeof(n1t), "%s/test", n1);
+    EXPECT(ELOOP, pjd_truncate(n0t, 123));
+    EXPECT(ELOOP, pjd_truncate(n1t, 123));
+    EXPECT(0, pjd_unlink(n0));
+    EXPECT(0, pjd_unlink(n1));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/truncate/09.c
+++ b/src/posix/tests/pjd/truncate/09.c
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/truncate/09.t:
+ * truncate returns EISDIR if the named file is a directory. */
+
+#include "../../pjd_common.h"
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen();
+
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    EXPECT(EISDIR, pjd_truncate(n0, 123));
+    EXPECT(0, pjd_rmdir(n0));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/truncate/09.c
+++ b/src/posix/tests/pjd/truncate/09.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/truncate/09.t:
  * truncate returns EISDIR if the named file is a directory. */

--- a/src/posix/tests/pjd/truncate/13.c
+++ b/src/posix/tests/pjd/truncate/13.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/truncate/13.t:
  * truncate returns EINVAL if the length argument was less than 0. */

--- a/src/posix/tests/pjd/truncate/13.c
+++ b/src/posix/tests/pjd/truncate/13.c
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/truncate/13.t:
+ * truncate returns EINVAL if the length argument was less than 0. */
+
+#include "../../pjd_common.h"
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen();
+
+    EXPECT(0, pjd_create(n0, 0644));
+    EXPECT(EINVAL, pjd_truncate(n0, -1));
+    EXPECT(EINVAL, pjd_truncate(n0, -999999));
+    EXPECT(0, pjd_unlink(n0));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/unlink/00.c
+++ b/src/posix/tests/pjd/unlink/00.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/unlink/00.t:
  * unlink removes files of every (non-directory) type; a successful unlink that

--- a/src/posix/tests/pjd/unlink/00.c
+++ b/src/posix/tests/pjd/unlink/00.c
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/unlink/00.t:
+ * unlink removes files of every (non-directory) type; a successful unlink that
+ * leaves another link updates the surviving link's ctime and the containing
+ * directory's mtime/ctime; a permission-denied unlink does not. */
+
+#include "../../pjd_common.h"
+
+static const enum pjd_ftype types[] = {
+    PJD_FT_REGULAR, PJD_FT_FIFO,      PJD_FT_BLOCK,
+    PJD_FT_CHAR,    PJD_FT_SOCKET,    PJD_FT_SYMLINK,
+};
+
+/* Types that support hard links (not symlinks/dirs). */
+static const enum pjd_ftype link_types[] = {
+    PJD_FT_REGULAR, PJD_FT_FIFO, PJD_FT_BLOCK, PJD_FT_CHAR, PJD_FT_SOCKET,
+};
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+
+    char *n0 = pjd_namegen();
+    char *n1 = pjd_namegen();
+    char *n2 = pjd_namegen();
+    char  st;
+
+    EXPECT(0, pjd_mkdir(n2, 0755));
+    pjd_cd(n2);
+
+    /* Each type can be created and unlinked. */
+    for (unsigned i = 0; i < sizeof(types) / sizeof(types[0]); i++) {
+        struct stat junk;
+        EXPECT(0, pjd_create_file(types[i], n0));
+        EXPECT(0, pjd_unlink(n0));
+        EXPECT(ENOENT, pjd_lstat(n0, &junk));
+    }
+    (void) st;
+
+    /* A successful unlink of one link updates the survivor's ctime. */
+    for (unsigned i = 0; i < sizeof(link_types) / sizeof(link_types[0]); i++) {
+        struct timespec c1, c2;
+        EXPECT(0, pjd_create_file(link_types[i], n0));
+        EXPECT(0, pjd_link(n0, n1));
+        pjd_lstat_ctime(n0, &c1);
+        pjd_settle();
+        EXPECT(0, pjd_unlink(n1));
+        pjd_lstat_ctime(n0, &c2);
+        PJD_CHECK(pjd_timespec_lt(&c1, &c2), "survivor ctime advanced (type %d)", link_types[i]);
+        EXPECT(0, pjd_unlink(n0));
+    }
+
+    /* A permission-denied unlink (no write on the parent) leaves ctime alone. */
+    for (unsigned i = 0; i < sizeof(types) / sizeof(types[0]); i++) {
+        struct timespec c1, c2;
+        if (types[i] == PJD_FT_SYMLINK) {
+            continue;
+        }
+        EXPECT(0, pjd_create_file(types[i], n0));
+        pjd_lstat_ctime(n0, &c1);
+        pjd_settle();
+        pjd_set_user(65534, 65534);
+        EXPECT(EACCES, pjd_unlink(n0));
+        pjd_set_root();
+        pjd_lstat_ctime(n0, &c2);
+        PJD_CHECK(c1.tv_sec == c2.tv_sec && c1.tv_nsec == c2.tv_nsec,
+                  "ctime unchanged after failed unlink (type %d)", types[i]);
+        EXPECT(0, pjd_unlink(n0));
+    }
+
+    /* Unlinking an entry updates the containing directory's mtime/ctime. */
+    for (unsigned i = 0; i < sizeof(types) / sizeof(types[0]); i++) {
+        struct timespec t0, t1;
+        char            n0n1[256];
+        EXPECT(0, pjd_mkdir(n0, 0755));
+        snprintf(n0n1, sizeof(n0n1), "%s/%s", n0, n1);
+        EXPECT(0, pjd_create_file(types[i], n0n1));
+        pjd_stat_ctime(n0, &t0);
+        pjd_settle();
+        EXPECT(0, pjd_unlink(n0n1));
+        pjd_stat_mtime(n0, &t1);
+        PJD_CHECK(pjd_timespec_lt(&t0, &t1), "parent mtime advanced (type %d)", types[i]);
+        pjd_stat_ctime(n0, &t1);
+        PJD_CHECK(pjd_timespec_lt(&t0, &t1), "parent ctime advanced (type %d)", types[i]);
+        EXPECT(0, pjd_rmdir(n0));
+    }
+
+    pjd_cd("..");
+    EXPECT(0, pjd_rmdir(n2));
+
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/unlink/01.c
+++ b/src/posix/tests/pjd/unlink/01.c
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/unlink/01.t: ENOTDIR if a path-prefix component is not a directory. */
+#include "../../pjd_common.h"
+static const enum pjd_ftype types[] = { PJD_FT_REGULAR, PJD_FT_FIFO, PJD_FT_BLOCK, PJD_FT_CHAR, PJD_FT_SOCKET };
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen(), *n1 = pjd_namegen();
+    char  sub[256], P[512];
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    for (unsigned i = 0; i < sizeof(types) / sizeof(types[0]); i++) {
+        snprintf(sub, sizeof(sub), "%s/%s", n0, n1);
+        EXPECT(0, pjd_create_file(types[i], sub));
+        snprintf(P, sizeof(P), "%s/%s/test", n0, n1);
+        EXPECT(ENOTDIR, pjd_unlink(P));
+        EXPECT(0, pjd_unlink(sub));
+    }
+    EXPECT(0, pjd_rmdir(n0));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/unlink/01.c
+++ b/src/posix/tests/pjd/unlink/01.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/unlink/01.t: ENOTDIR if a path-prefix component is not a directory. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/unlink/02.c
+++ b/src/posix/tests/pjd/unlink/02.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/unlink/02.t: ENAMETOOLONG if a component exceeds {NAME_MAX}. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/unlink/02.c
+++ b/src/posix/tests/pjd/unlink/02.c
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/unlink/02.t: ENAMETOOLONG if a component exceeds {NAME_MAX}. */
+#include "../../pjd_common.h"
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *nx = pjd_namegen_max();
+    char  P[512];
+    snprintf(P, sizeof(P), "%sx", nx);
+    EXPECT(0, pjd_create(nx, 0644));
+    EXPECT(0, pjd_unlink(nx));
+    EXPECT(ENAMETOOLONG, pjd_unlink(P));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/unlink/03.c
+++ b/src/posix/tests/pjd/unlink/03.c
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/unlink/03.t: ENAMETOOLONG if the whole path exceeds {PATH_MAX}. */
+#include "../../pjd_common.h"
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *nx = pjd_dirgen_max();
+    char  P[8192];
+    snprintf(P, sizeof(P), "%sx", nx);
+    pjd_mkdir_p(nx);
+    EXPECT(0, pjd_create(nx, 0644));
+    EXPECT(0, pjd_unlink(nx));
+    EXPECT(ENAMETOOLONG, pjd_unlink(P));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/unlink/03.c
+++ b/src/posix/tests/pjd/unlink/03.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/unlink/03.t: ENAMETOOLONG if the whole path exceeds {PATH_MAX}. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/unlink/04.c
+++ b/src/posix/tests/pjd/unlink/04.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/unlink/04.t: ENOENT if the named file does not exist. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/unlink/04.c
+++ b/src/posix/tests/pjd/unlink/04.c
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/unlink/04.t: ENOENT if the named file does not exist. */
+#include "../../pjd_common.h"
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen(), *n1 = pjd_namegen();
+    char  P[256];
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    snprintf(P, sizeof(P), "%s/%s", n0, n1);
+    EXPECT(ENOENT, pjd_unlink(P));
+    EXPECT(0, pjd_rmdir(n0));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/unlink/05.c
+++ b/src/posix/tests/pjd/unlink/05.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/unlink/05.t: EACCES when search permission is denied for a path-prefix component. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/unlink/05.c
+++ b/src/posix/tests/pjd/unlink/05.c
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/unlink/05.t: EACCES when search permission is denied for a path-prefix component. */
+#include "../../pjd_common.h"
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen(), *n1 = pjd_namegen(), *n2 = pjd_namegen();
+    char  P[256];
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    pjd_cd(n0);
+    EXPECT(0, pjd_mkdir(n1, 0755));
+    EXPECT(0, pjd_chown(n1, 65534, 65534));
+    snprintf(P, sizeof(P), "%s/%s", n1, n2);
+    pjd_set_user(65534, 65534);
+    EXPECT(0, pjd_create(P, 0644));
+    pjd_set_root();
+    EXPECT(0, pjd_chmod(n1, 0644));
+    pjd_set_user(65534, 65534);
+    EXPECT(EACCES, pjd_unlink(P));
+    pjd_set_root();
+    EXPECT(0, pjd_chmod(n1, 0755));
+    pjd_set_user(65534, 65534);
+    EXPECT(0, pjd_unlink(P));
+    pjd_set_root();
+    EXPECT(0, pjd_rmdir(n1));
+    pjd_cd("..");
+    EXPECT(0, pjd_rmdir(n0));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/unlink/06.c
+++ b/src/posix/tests/pjd/unlink/06.c
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/unlink/06.t: EACCES when write permission is denied on the containing directory. */
+#include "../../pjd_common.h"
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen(), *n1 = pjd_namegen(), *n2 = pjd_namegen();
+    char  P[256];
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    pjd_cd(n0);
+    EXPECT(0, pjd_mkdir(n1, 0755));
+    EXPECT(0, pjd_chown(n1, 65534, 65534));
+    snprintf(P, sizeof(P), "%s/%s", n1, n2);
+    pjd_set_user(65534, 65534);
+    EXPECT(0, pjd_create(P, 0644));
+    pjd_set_root();
+    EXPECT(0, pjd_chmod(n1, 0555));
+    pjd_set_user(65534, 65534);
+    EXPECT(EACCES, pjd_unlink(P));
+    pjd_set_root();
+    EXPECT(0, pjd_chmod(n1, 0755));
+    pjd_set_user(65534, 65534);
+    EXPECT(0, pjd_unlink(P));
+    pjd_set_root();
+    EXPECT(0, pjd_rmdir(n1));
+    pjd_cd("..");
+    EXPECT(0, pjd_rmdir(n0));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/unlink/06.c
+++ b/src/posix/tests/pjd/unlink/06.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/unlink/06.t: EACCES when write permission is denied on the containing directory. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/unlink/07.c
+++ b/src/posix/tests/pjd/unlink/07.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/unlink/07.t: ELOOP on a symlink loop in the pathname. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/unlink/07.c
+++ b/src/posix/tests/pjd/unlink/07.c
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/unlink/07.t: ELOOP on a symlink loop in the pathname. */
+#include "../../pjd_common.h"
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen(), *n1 = pjd_namegen();
+    char  P[256];
+    EXPECT(0, pjd_symlink(n0, n1));
+    EXPECT(0, pjd_symlink(n1, n0));
+    snprintf(P, sizeof(P), "%s/test", n0);
+    EXPECT(ELOOP, pjd_unlink(P));
+    snprintf(P, sizeof(P), "%s/test", n1);
+    EXPECT(ELOOP, pjd_unlink(P));
+    EXPECT(0, pjd_unlink(n0));
+    EXPECT(0, pjd_unlink(n1));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/unlink/08.c
+++ b/src/posix/tests/pjd/unlink/08.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/unlink/08.t: unlink of a directory.  POSIX permits
  * EPERM; Linux returns EISDIR; some systems allow it (0).  Accept any. */

--- a/src/posix/tests/pjd/unlink/08.c
+++ b/src/posix/tests/pjd/unlink/08.c
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/unlink/08.t: unlink of a directory.  POSIX permits
+ * EPERM; Linux returns EISDIR; some systems allow it (0).  Accept any. */
+#include "../../pjd_common.h"
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen();
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    int   rc = pjd_unlink(n0);
+    int   e  = (rc < 0) ? errno : 0;
+    PJD_CHECK(e == 0 || e == EPERM || e == EISDIR, "unlink dir -> %s", strerror(e));
+    int   rc2 = pjd_rmdir(n0);
+    int   e2  = (rc2 < 0) ? errno : 0;
+    PJD_CHECK(e2 == 0 || e2 == ENOENT, "rmdir dir -> %s", strerror(e2));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/unlink/11.c
+++ b/src/posix/tests/pjd/unlink/11.c
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/unlink/11.t:
+ * unlink returns EACCES or EPERM if the containing directory is sticky and the
+ * caller owns neither the directory nor the file to be removed. */
+
+#include "../../pjd_common.h"
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+
+    char *n0 = pjd_namegen();
+    char *n1 = pjd_namegen();
+    char *n2 = pjd_namegen();
+    char  n0n1[256];
+
+    EXPECT(0, pjd_mkdir(n2, 0755));
+    pjd_cd(n2);
+
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    EXPECT(0, pjd_chown(n0, 65534, 65534));
+    EXPECT(0, pjd_chmod(n0, 01777));   /* sticky */
+
+    snprintf(n0n1, sizeof(n0n1), "%s/%s", n0, n1);
+
+    /* Caller owns both the sticky dir and the file -> allowed. */
+    pjd_set_user(65534, 65534);
+    EXPECT(0, pjd_create(n0n1, 0644));
+    EXPECT(0, pjd_unlink(n0n1));
+    pjd_set_root();
+
+    /* Caller owns the file but not the sticky dir -> allowed. */
+    for (int k = 0; k < 2; k++) {
+        int id = k == 0 ? 0 : 65533;
+        EXPECT(0, pjd_chown(n0, id, id));
+        EXPECT(0, pjd_create_file_owned(PJD_FT_REGULAR, n0n1, 65534, 65534));
+        pjd_set_user(65534, 65534);
+        EXPECT(0, pjd_unlink(n0n1));
+        pjd_set_root();
+    }
+
+    /* Caller owns the sticky dir but not the file -> allowed. */
+    EXPECT(0, pjd_chown(n0, 65534, 65534));
+    for (int k = 0; k < 2; k++) {
+        int id = k == 0 ? 0 : 65533;
+        EXPECT(0, pjd_create_file_owned(PJD_FT_REGULAR, n0n1, id, id));
+        pjd_set_user(65534, 65534);
+        EXPECT(0, pjd_unlink(n0n1));
+        pjd_set_root();
+    }
+
+    /* Caller owns neither -> EACCES/EPERM. */
+    for (int k = 0; k < 2; k++) {
+        int id = k == 0 ? 0 : 65533;
+        EXPECT(0, pjd_chown(n0, id, id));
+        EXPECT(0, pjd_create_file_owned(PJD_FT_REGULAR, n0n1, id, id));
+        pjd_set_user(65534, 65534);
+        int rc = pjd_unlink(n0n1);
+        int e  = (rc < 0) ? errno : 0;
+        PJD_CHECK(e == EACCES || e == EPERM, "sticky unlink -> %s", strerror(e));
+        pjd_set_root();
+        EXPECT(0, pjd_unlink(n0n1));
+    }
+
+    EXPECT(0, pjd_rmdir(n0));
+    pjd_cd("..");
+    EXPECT(0, pjd_rmdir(n2));
+
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/unlink/11.c
+++ b/src/posix/tests/pjd/unlink/11.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/unlink/11.t:
  * unlink returns EACCES or EPERM if the containing directory is sticky and the

--- a/src/posix/tests/pjd/unlink/14.c
+++ b/src/posix/tests/pjd/unlink/14.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/unlink/14.t: an open file is not freed by unlink;
  * stat/I/O via the open descriptor keep working and nlink drops to 0. */

--- a/src/posix/tests/pjd/unlink/14.c
+++ b/src/posix/tests/pjd/unlink/14.c
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/unlink/14.t: an open file is not freed by unlink;
+ * stat/I/O via the open descriptor keep working and nlink drops to 0. */
+#include "../../pjd_common.h"
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen(), *n2 = pjd_namegen();
+    EXPECT(0, pjd_mkdir(n2, 0755));
+    pjd_cd(n2);
+
+    /* nlink of an open-but-unlinked file is 0. */
+    EXPECT(0, pjd_create(n0, 0644));
+    {
+        int         fd = pjd_open(n0, O_RDONLY, 0644);
+        PJD_CHECK(fd >= 0, "open n0");
+        EXPECT(0, pjd_unlink(n0));
+        struct stat stbuf;
+        EXPECT(0, chimera_posix_fstat(fd, &stbuf));
+        EXPECT_EQ(0, (long) stbuf.st_nlink);
+        chimera_posix_close(fd);
+    }
+
+    /* I/O to an open-but-unlinked file still works. */
+    EXPECT(0, pjd_create(n0, 0644));
+    {
+        int     fd = pjd_open(n0, O_RDWR, 0644);
+        char    buf[16];
+        PJD_CHECK(fd >= 0, "open n0 rdwr");
+        chimera_posix_write(fd, "Hello,_World!", 13);
+        EXPECT(0, pjd_unlink(n0));
+        ssize_t r = chimera_posix_pread(fd, buf, 13, 0);
+        PJD_CHECK(r == 13 && memcmp(buf, "Hello,_World!", 13) == 0,
+                  "pread after unlink returns data (%zd)", r);
+        chimera_posix_close(fd);
+    }
+
+    pjd_cd("..");
+    EXPECT(0, pjd_rmdir(n2));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/utimensat/00.c
+++ b/src/posix/tests/pjd/utimensat/00.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/utimensat/00.t: utimensat sets atime/mtime to the
  * given explicit values on any type of file. */

--- a/src/posix/tests/pjd/utimensat/00.c
+++ b/src/posix/tests/pjd/utimensat/00.c
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/utimensat/00.t: utimensat sets atime/mtime to the
+ * given explicit values on any type of file. */
+#include "../../pjd_common.h"
+#include <sys/stat.h>
+static const enum pjd_ftype types[] = { PJD_FT_REGULAR, PJD_FT_DIR, PJD_FT_FIFO, PJD_FT_BLOCK, PJD_FT_CHAR,
+                                        PJD_FT_SOCKET };
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char        *n0 = pjd_namegen(), *n1 = pjd_namegen();
+    const time_t DATE1 = 1900000000, DATE2 = 1950000000;
+    EXPECT(0, pjd_mkdir(n1, 0755));
+    pjd_cd(n1);
+    for (unsigned i = 0; i < sizeof(types) / sizeof(types[0]); i++) {
+        EXPECT(0, pjd_create_file(types[i], n0));
+        EXPECT(0, pjd_utimensat(n0, DATE1, 0, DATE2, 0, 0));
+        EXPECT_EQ(DATE1, pjd_lstat_atime(n0));
+        EXPECT_EQ(DATE2, pjd_lstat_mtime_sec(n0));
+        EXPECT(0, pjd_remove_file(types[i], n0));
+    }
+    pjd_cd("..");
+    EXPECT(0, pjd_rmdir(n1));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/utimensat/01.c
+++ b/src/posix/tests/pjd/utimensat/01.c
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/utimensat/01.t: UTIME_NOW sets timestamps to ~now. */
+#include "../../pjd_common.h"
+#include <sys/stat.h>
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen(), *n1 = pjd_namegen();
+    EXPECT(0, pjd_mkdir(n1, 0755));
+    pjd_cd(n1);
+    EXPECT(0, pjd_create(n0, 0644));
+    EXPECT(0, pjd_utimensat(n0, 0, 0, 0, 0, 0));   /* baseline epoch */
+    EXPECT(0, pjd_utimensat(n0, 0, UTIME_NOW, 0, UTIME_NOW, 0));
+    long  now = (long) time(NULL);
+    PJD_CHECK(pjd_lstat_atime(n0) > now - 300 && pjd_lstat_atime(n0) <= now + 5, "atime ~ now");
+    PJD_CHECK(pjd_lstat_mtime_sec(n0) > now - 300 && pjd_lstat_mtime_sec(n0) <= now + 5, "mtime ~ now");
+    EXPECT(0, pjd_unlink(n0));
+    pjd_cd("..");
+    EXPECT(0, pjd_rmdir(n1));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/utimensat/01.c
+++ b/src/posix/tests/pjd/utimensat/01.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/utimensat/01.t: UTIME_NOW sets timestamps to ~now. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/utimensat/02.c
+++ b/src/posix/tests/pjd/utimensat/02.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/utimensat/02.t: UTIME_OMIT leaves that timestamp unchanged. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/utimensat/02.c
+++ b/src/posix/tests/pjd/utimensat/02.c
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/utimensat/02.t: UTIME_OMIT leaves that timestamp unchanged. */
+#include "../../pjd_common.h"
+#include <sys/stat.h>
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char        *n0 = pjd_namegen(), *n1 = pjd_namegen();
+    const time_t DATE1 = 1900000000, DATE2 = 1950000000, DATE3 = 1920000000;
+    EXPECT(0, pjd_mkdir(n1, 0755));
+    pjd_cd(n1);
+    EXPECT(0, pjd_create(n0, 0644));
+    EXPECT(0, pjd_utimensat(n0, DATE1, 0, DATE2, 0, 0));
+    /* Omit atime, change mtime. */
+    EXPECT(0, pjd_utimensat(n0, 0, UTIME_OMIT, DATE3, 0, 0));
+    EXPECT_EQ(DATE1, pjd_lstat_atime(n0));
+    EXPECT_EQ(DATE3, pjd_lstat_mtime_sec(n0));
+    /* Omit mtime, change atime. */
+    EXPECT(0, pjd_utimensat(n0, DATE2, 0, 0, UTIME_OMIT, 0));
+    EXPECT_EQ(DATE2, pjd_lstat_atime(n0));
+    EXPECT_EQ(DATE3, pjd_lstat_mtime_sec(n0));
+    EXPECT(0, pjd_unlink(n0));
+    pjd_cd("..");
+    EXPECT(0, pjd_rmdir(n1));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/utimensat/04.c
+++ b/src/posix/tests/pjd/utimensat/04.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/utimensat/04.t: atime and mtime can be set independently. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/utimensat/04.c
+++ b/src/posix/tests/pjd/utimensat/04.c
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/utimensat/04.t: atime and mtime can be set independently. */
+#include "../../pjd_common.h"
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen(), *n1 = pjd_namegen();
+    EXPECT(0, pjd_mkdir(n1, 0755));
+    pjd_cd(n1);
+    EXPECT(0, pjd_create(n0, 0644));
+    EXPECT(0, pjd_utimensat(n0, 1950000000, 0, 1900000000, 0, 0));   /* atime > mtime */
+    EXPECT_EQ(1950000000, pjd_lstat_atime(n0));
+    EXPECT_EQ(1900000000, pjd_lstat_mtime_sec(n0));
+    EXPECT(0, pjd_utimensat(n0, 1900000000, 0, 1950000000, 0, 0));   /* mtime > atime */
+    EXPECT_EQ(1900000000, pjd_lstat_atime(n0));
+    EXPECT_EQ(1950000000, pjd_lstat_mtime_sec(n0));
+    EXPECT(0, pjd_unlink(n0));
+    pjd_cd("..");
+    EXPECT(0, pjd_rmdir(n1));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/utimensat/06.c
+++ b/src/posix/tests/pjd/utimensat/06.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/utimensat/06.t: UTIME_NOW works for the owner, the
  * super-user, or anyone with write permission; otherwise EACCES. */

--- a/src/posix/tests/pjd/utimensat/06.c
+++ b/src/posix/tests/pjd/utimensat/06.c
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/utimensat/06.t: UTIME_NOW works for the owner, the
+ * super-user, or anyone with write permission; otherwise EACCES. */
+#include "../../pjd_common.h"
+#include <sys/stat.h>
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *n0 = pjd_namegen(), *n1 = pjd_namegen();
+    EXPECT(0, pjd_mkdir(n1, 0755));
+    pjd_cd(n1);
+    EXPECT(0, pjd_create(n0, 0644));   /* owned root */
+
+    /* Non-owner without write -> EACCES. */
+    pjd_set_user(65534, 65534);
+    EXPECT_EQ(EACCES, pjd_utimensat(n0, 0, UTIME_NOW, 0, UTIME_NOW, 0) < 0 ? errno : 0);
+    pjd_set_root();
+
+    /* Owner (even read-only mode) can touch. */
+    EXPECT(0, pjd_chown(n0, 65534, 65534));
+    EXPECT(0, pjd_chmod(n0, 0444));
+    pjd_set_user(65534, 65534);
+    EXPECT(0, pjd_utimensat(n0, 0, UTIME_NOW, 0, UTIME_NOW, 0));
+    pjd_set_root();
+
+    /* Super-user can touch. */
+    EXPECT(0, pjd_utimensat(n0, 0, UTIME_OMIT, 0, UTIME_OMIT, 0));
+
+    /* Non-owner with write permission can touch. */
+    EXPECT(0, pjd_chown(n0, 0, 0));
+    EXPECT(0, pjd_chmod(n0, 0666));
+    pjd_set_user(65534, 65534);
+    EXPECT(0, pjd_utimensat(n0, 0, UTIME_NOW, 0, UTIME_NOW, 0));
+    pjd_set_root();
+
+    EXPECT(0, pjd_unlink(n0));
+    pjd_cd("..");
+    EXPECT(0, pjd_rmdir(n1));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/utimensat/07.c
+++ b/src/posix/tests/pjd/utimensat/07.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/utimensat/07.t: setting explicit timestamps requires
  * ownership (or super-user); a non-owner gets EPERM even with write permission. */

--- a/src/posix/tests/pjd/utimensat/07.c
+++ b/src/posix/tests/pjd/utimensat/07.c
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/utimensat/07.t: setting explicit timestamps requires
+ * ownership (or super-user); a non-owner gets EPERM even with write permission. */
+#include "../../pjd_common.h"
+#include <sys/stat.h>
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char        *n0 = pjd_namegen(), *n1 = pjd_namegen();
+    const time_t D1 = 1900000000, D2 = 1950000000;
+    EXPECT(0, pjd_mkdir(n1, 0755));
+    pjd_cd(n1);
+    EXPECT(0, pjd_create(n0, 0644));   /* owned root */
+
+    /* Non-owner cannot set explicit times. */
+    pjd_set_user(65534, 65534);
+    EXPECT_EQ(EPERM, pjd_utimensat(n0, 0, UTIME_OMIT, D2, 0, 0) < 0 ? errno : 0);
+    EXPECT_EQ(EPERM, pjd_utimensat(n0, D1, 0, 0, UTIME_OMIT, 0) < 0 ? errno : 0);
+    EXPECT_EQ(EPERM, pjd_utimensat(n0, D1, 0, D2, 0, 0) < 0 ? errno : 0);
+    pjd_set_root();
+
+    /* Non-owner with write still cannot set explicit times. */
+    EXPECT(0, pjd_chmod(n0, 0666));
+    pjd_set_user(65534, 65534);
+    EXPECT_EQ(EPERM, pjd_utimensat(n0, D1, 0, D2, 0, 0) < 0 ? errno : 0);
+    pjd_set_root();
+
+    /* Owner can. */
+    EXPECT(0, pjd_chown(n0, 65534, 65534));
+    EXPECT(0, pjd_chmod(n0, 0444));
+    pjd_set_user(65534, 65534);
+    EXPECT(0, pjd_utimensat(n0, D1, 0, D2, 0, 0));
+    pjd_set_root();
+
+    /* Super-user can. */
+    EXPECT(0, pjd_chown(n0, 0, 0));
+    EXPECT(0, pjd_utimensat(n0, D1, 0, D2, 0, 0));
+
+    EXPECT(0, pjd_unlink(n0));
+    pjd_cd("..");
+    EXPECT(0, pjd_rmdir(n1));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/utimensat/08.c
+++ b/src/posix/tests/pjd/utimensat/08.c
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/utimensat/08.t: sub-second precision. */
+#include "../../pjd_common.h"
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char           *n0 = pjd_namegen(), *n1 = pjd_namegen();
+    struct timespec a, m;
+    EXPECT(0, pjd_mkdir(n1, 0755));
+    pjd_cd(n1);
+    EXPECT(0, pjd_create(n0, 0644));
+    EXPECT(0, pjd_utimensat(n0, 1900000000, 123456789, 1950000000, 987654321, 0));
+    EXPECT(0, pjd_lstat_times(n0, &a, &m));
+    EXPECT_EQ(1900000000, (long) a.tv_sec);
+    EXPECT_EQ(123456789, (long) a.tv_nsec);
+    EXPECT_EQ(1950000000, (long) m.tv_sec);
+    EXPECT_EQ(987654321, (long) m.tv_nsec);
+    EXPECT(0, pjd_unlink(n0));
+    pjd_cd("..");
+    EXPECT(0, pjd_rmdir(n1));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/utimensat/08.c
+++ b/src/posix/tests/pjd/utimensat/08.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/utimensat/08.t: sub-second precision. */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/utimensat/09.c
+++ b/src/posix/tests/pjd/utimensat/09.c
@@ -1,6 +1,13 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
 
 /* Ported from pjdfstest tests/utimensat/09.t: y2038-compliant (timestamps past 2038). */
 #include "../../pjd_common.h"

--- a/src/posix/tests/pjd/utimensat/09.c
+++ b/src/posix/tests/pjd/utimensat/09.c
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ported from pjdfstest tests/utimensat/09.t: y2038-compliant (timestamps past 2038). */
+#include "../../pjd_common.h"
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char        *n0 = pjd_namegen(), *n1 = pjd_namegen();
+    const time_t BIG = 2200000000L;   /* ~2039-09-13 */
+    EXPECT(0, pjd_mkdir(n1, 0755));
+    pjd_cd(n1);
+    EXPECT(0, pjd_create(n0, 0644));
+    EXPECT(0, pjd_utimensat(n0, BIG, 0, BIG + 100, 0, 0));
+    EXPECT_EQ(BIG, pjd_lstat_atime(n0));
+    EXPECT_EQ(BIG + 100, pjd_lstat_mtime_sec(n0));
+    EXPECT(0, pjd_unlink(n0));
+    pjd_cd("..");
+    EXPECT(0, pjd_rmdir(n1));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd_common.h
+++ b/src/posix/tests/pjd_common.h
@@ -1,0 +1,930 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * pjd_common.h - C harness for the pjdfstest POSIX conformance suite ported to
+ * the Chimera POSIX client.  This is a C analog of pjdfstest's tests/misc.sh:
+ * it provides TAP-style assertions, a harness-level working directory, per-call
+ * credential / umask switching (mapping pjdfstest's -u/-g/-U flags), file
+ * creation of every POSIX type, name generators, and stat-field accessors.
+ *
+ * Each ported .t becomes a standalone program:
+ *
+ *     #include "pjd_common.h"
+ *     int main(int argc, char **argv) {
+ *         pjd_begin(argc, argv);
+ *         ... ported test body using EXPECT()/pjd_* helpers ...
+ *         return pjd_end();
+ *     }
+ *
+ * A test "passes" iff every assertion passed (pjd_end() exits non-zero
+ * otherwise, failing the ctest case).
+ */
+
+#pragma once
+
+#include <stdarg.h>
+#include <limits.h>
+#include <sys/sysmacros.h>
+#include "posix_test_common.h"
+
+/* ---- lifecycle / global state ------------------------------------------- */
+
+/* Harness-side path buffer.  Larger than CHIMERA_VFS_PATH_MAX so that an
+ * intentionally over-long pathname survives resolution intact and the POSIX
+ * layer (not snprintf truncation) is what reports ENAMETOOLONG. */
+#define PJD_PATHBUF         8192
+
+static struct posix_test_env pjd_env;
+static int                   pjd_ntest;
+static int                   pjd_nfail;
+static char                  pjd_cwd[PJD_PATHBUF];
+
+/* Generated names are tracked here and freed in pjd_end() so the suite stays
+ * clean under AddressSanitizer (the Debug build enables ASan). */
+#define PJD_MAX_NAMES       4096
+static char                 *pjd_name_registry[PJD_MAX_NAMES];
+static int                   pjd_name_count;
+
+#ifndef AT_FDCWD
+#define AT_FDCWD            -100
+#endif /* ifndef AT_FDCWD */
+#ifndef AT_SYMLINK_NOFOLLOW
+#define AT_SYMLINK_NOFOLLOW 0x100
+#endif /* ifndef AT_SYMLINK_NOFOLLOW */
+
+static inline void
+pjd_begin(
+    int    argc,
+    char **argv)
+{
+    posix_test_init(&pjd_env, argv, argc);
+
+    if (posix_test_mount(&pjd_env) != 0) {
+        fprintf(stderr, "pjd: failed to mount test backend: %s\n", strerror(errno));
+        posix_test_fail(&pjd_env);
+    }
+
+    snprintf(pjd_cwd, sizeof(pjd_cwd), "/test");
+    pjd_ntest = 0;
+    pjd_nfail = 0;
+} /* pjd_begin */
+
+static inline void
+pjd_free_names(void)
+{
+    for (int i = 0; i < pjd_name_count; i++) {
+        free(pjd_name_registry[i]);
+        pjd_name_registry[i] = NULL;
+    }
+    pjd_name_count = 0;
+} /* pjd_free_names */
+
+static inline int
+pjd_end(void)
+{
+    /* Restore root credential before teardown so cleanup is unrestricted. */
+    chimera_posix_clear_cred();
+
+    posix_test_umount();
+
+    fprintf(stderr, "# %d assertions, %d failures\n", pjd_ntest, pjd_nfail);
+
+    pjd_free_names();
+
+    if (pjd_nfail) {
+        posix_test_fail(&pjd_env);   /* noreturn, exit(EXIT_FAILURE) */
+    }
+
+    posix_test_success(&pjd_env);
+    return 0;
+} /* pjd_end */
+
+/* ---- assertions --------------------------------------------------------- */
+
+static inline int
+pjd_record(
+    int         ok,
+    const char *file,
+    int         line,
+    const char *fmt,
+    ...)
+{
+    va_list ap;
+
+    pjd_ntest++;
+    if (!ok) {
+        pjd_nfail++;
+    }
+
+    fprintf(stderr, "%s %d - ", ok ? "ok" : "not ok", pjd_ntest);
+    va_start(ap, fmt);
+    vfprintf(stderr, fmt, ap);
+    va_end(ap);
+    if (!ok) {
+        fprintf(stderr, "   [%s:%d]", file, line);
+    }
+    fprintf(stderr, "\n");
+    return ok;
+} /* pjd_record */
+
+/* Expect a syscall-style call: success when rc >= 0, else errno is captured.
+ * `experr` of 0 means "expect success"; otherwise expect rc < 0 && errno == experr.
+ * Mirrors pjdfstest `expect <errno|0> <op> ...`. */
+static inline void
+pjd_expect_call(
+    int         experr,
+    long        rc,
+    int         call_errno,
+    const char *expr,
+    const char *file,
+    int         line)
+{
+    int got = (rc < 0) ? call_errno : 0;
+
+    pjd_record(got == experr, file, line,
+               "%s -> %s (want %s)", expr,
+               got ? strerror(got) : "0",
+               experr ? strerror(experr) : "0");
+} /* pjd_expect_call */
+
+/* EXPECT(experr, call): run `call`, then compare its outcome to experr.
+ * errno is read immediately after the call. */
+#define EXPECT(experr, call)                                              \
+        do {                                                              \
+            errno = 0;                                                    \
+            long _pjd_rc = (long) (call);                                 \
+            int  _pjd_en = errno;                                         \
+            pjd_expect_call((experr), _pjd_rc, _pjd_en, #call,            \
+                            __FILE__, __LINE__);                          \
+        } while (0)
+
+/* Compare two integral values (e.g. stat field == expected). */
+#define EXPECT_EQ(want, got)                                              \
+        pjd_record((long) (want) == (long) (got), __FILE__, __LINE__,     \
+                   "%s == %s (%ld vs %ld)", #want, #got,                  \
+                   (long) (want), (long) (got))
+
+/* Generic boolean assertion with a message. */
+#define PJD_CHECK(cond, ...) pjd_record((cond) ? 1 : 0, __FILE__, __LINE__, __VA_ARGS__)
+
+/* ---- credential / umask switching --------------------------------------- */
+
+static inline void
+pjd_set_user(
+    uid_t uid,
+    gid_t gid)
+{
+    struct chimera_vfs_cred cred;
+
+    chimera_vfs_cred_init_unix(&cred, uid, gid, 0, NULL);
+    chimera_posix_set_cred(&cred);
+} /* pjd_set_user */
+
+static inline void
+pjd_set_user_groups(
+    uid_t           uid,
+    gid_t           gid,
+    int             ngids,
+    const uint32_t *gids)
+{
+    struct chimera_vfs_cred cred;
+
+    chimera_vfs_cred_init_unix(&cred, uid, gid, ngids, gids);
+    chimera_posix_set_cred(&cred);
+} /* pjd_set_user_groups */
+
+static inline void
+pjd_set_root(void)
+{
+    chimera_posix_clear_cred();
+} /* pjd_set_root */
+
+/* ---- working directory & path resolution -------------------------------- */
+
+/* Resolve a (relative) name against the harness cwd into `out`.  Absolute
+ * names are taken relative to the mount root. */
+static inline const char *
+pjd_resolve(
+    const char *name,
+    char       *out,
+    size_t      outlen)
+{
+    /* Build base[+sep]+name into out with explicit bounds.  snprintf("%s/%s")
+     * trips -Werror=format-truncation at -O3 because the operands can each be
+     * the full buffer size; a bounded copy is both warning-free and correct. */
+    const char *base = (name[0] == '/') ? "/test" : pjd_cwd;
+    const char *sep  = (name[0] == '/') ? "" : "/"; /* absolute name keeps its '/' */
+    size_t      blen = strlen(base);
+    size_t      slen = strlen(sep);
+    size_t      nlen = strlen(name);
+    size_t      pos  = 0;
+
+    if (outlen == 0) {
+        return out;
+    }
+    if (blen > outlen - 1) {
+        blen = outlen - 1;
+    }
+    memcpy(out, base, blen);
+    pos = blen;
+    if (pos + slen < outlen) {
+        memcpy(out + pos, sep, slen);
+        pos += slen;
+    }
+    if (pos < outlen - 1) {
+        size_t cp = nlen;
+        if (cp > outlen - 1 - pos) {
+            cp = outlen - 1 - pos;
+        }
+        memcpy(out + pos, name, cp);
+        pos += cp;
+    }
+    out[pos] = '\0';
+    return out;
+} /* pjd_resolve */
+
+/* Change the harness working directory (no real chdir; resolves names). */
+static inline void
+pjd_cd(const char *name)
+{
+    char tmp[PJD_PATHBUF];
+
+    if (strcmp(name, "..") == 0) {
+        char *slash = strrchr(pjd_cwd, '/');
+        if (slash && slash != pjd_cwd) {
+            *slash = '\0';
+        }
+        return;
+    }
+    pjd_resolve(name, tmp, sizeof(tmp));
+    snprintf(pjd_cwd, sizeof(pjd_cwd), "%s", tmp);
+} /* pjd_cd */
+
+/* ---- name generators ---------------------------------------------------- */
+
+static unsigned int pjd_name_ctr;
+
+static inline char *
+pjd_track_name(char *b)
+{
+#ifdef __clang_analyzer__
+    /* The static analyzer does not model the harness name registry (every
+     * tracked name is freed in pjd_end()).  Make the allocation unconditionally
+     * escape into the registry so scan-build does not report a false
+     * unix.Malloc leak on the "registry full" branch below. */
+    pjd_name_registry[0] = b;
+    return b;
+#else  /* ifdef __clang_analyzer__ */
+    if (pjd_name_count < PJD_MAX_NAMES) {
+        pjd_name_registry[pjd_name_count++] = b;
+    }
+    return b;
+#endif /* ifdef __clang_analyzer__ */
+} /* pjd_track_name */
+
+/* Unique name. */
+static inline char *
+pjd_namegen(void)
+{
+    char *b = malloc(64);
+
+    snprintf(b, 64, "pjd_%d_%u", (int) getpid(), pjd_name_ctr++);
+    return pjd_track_name(b);
+} /* pjd_namegen */
+
+/* Name of exactly `len` bytes (for ENAMETOOLONG tests). */
+static inline char *
+pjd_namegen_len(size_t len)
+{
+    char *b = malloc(len + 1);
+
+    memset(b, 'a', len);
+    b[len] = '\0';
+    return pjd_track_name(b);
+} /* pjd_namegen_len */
+
+/* A single name component exactly {NAME_MAX} bytes long. */
+static inline char *
+pjd_namegen_max(void)
+{
+    long name_max = chimera_posix_pathconf(".", _PC_NAME_MAX);
+
+    return pjd_namegen_len((size_t) name_max);
+} /* pjd_namegen_max */
+
+/* A relative path whose total length is {PATH_MAX}-1 bytes, built from
+ * {NAME_MAX}/2-byte components (mirrors misc.sh dirgen_max).  The parent
+ * directories do not exist yet; use pjd_mkdir_p() to create them. */
+static inline char *
+pjd_dirgen_max(void)
+{
+    long   name_max = chimera_posix_pathconf(".", _PC_NAME_MAX);
+    long   comp     = name_max / 2;
+    /* The harness resolves names to "<cwd>/<name>"; size the name so the
+     * resolved pathname totals {PATH_MAX}-1 bytes (the longest legal path). */
+    long   prefix   = (long) strlen(pjd_cwd) + 1;
+    long   path_max = chimera_posix_pathconf(".", _PC_PATH_MAX) - 1 - prefix;
+    char  *b        = malloc(path_max + 2);
+    size_t len      = 0;
+
+    while ((long) len < path_max) {
+        for (long i = 0; i < comp && (long) len < path_max; i++) {
+            b[len++] = 'a';
+        }
+        if ((long) len < path_max) {
+            b[len++] = '/';
+        }
+    }
+    b[path_max] = '\0';
+    /* Ensure the final byte is not a trailing slash. */
+    if (b[path_max - 1] == '/') {
+        b[path_max - 1] = 'x';
+    }
+    return pjd_track_name(b);
+} /* pjd_dirgen_max */
+
+/* ---- path-resolving operation wrappers ---------------------------------- */
+/* These mirror the pjdfstest operations; each resolves its path argument(s)
+ * against the harness cwd, so test bodies read like the shell originals. */
+
+static inline int
+pjd_mkdir(
+    const char *name,
+    mode_t      mode)
+{
+    char p[PJD_PATHBUF];
+
+    return chimera_posix_mkdir(pjd_resolve(name, p, sizeof(p)), mode);
+} /* pjd_mkdir */
+
+static inline int
+pjd_rmdir(const char *name)
+{
+    char p[PJD_PATHBUF];
+
+    return chimera_posix_rmdir(pjd_resolve(name, p, sizeof(p)));
+} /* pjd_rmdir */
+
+/* Recursively create every parent directory of `relpath` (like mkdir -p of the
+ * dirname).  Components are created mode 0755; existing ones are tolerated. */
+static inline void
+pjd_mkdir_p(const char *relpath)
+{
+    char   work[8192];
+    size_t i;
+
+    snprintf(work, sizeof(work), "%s", relpath);
+
+    for (i = 1; work[i]; i++) {
+        if (work[i] == '/') {
+            work[i] = '\0';
+            (void) pjd_mkdir(work, 0755);
+            work[i] = '/';
+        }
+    }
+} /* pjd_mkdir_p */
+
+/* create: exclusive create + close, returning 0/-1 (pjdfstest `create`). */
+static inline int
+pjd_create(
+    const char *name,
+    mode_t      mode)
+{
+    char p[PJD_PATHBUF];
+    int  fd = chimera_posix_open(pjd_resolve(name, p, sizeof(p)),
+                                 O_CREAT | O_EXCL | O_WRONLY, mode);
+
+    if (fd < 0) {
+        return -1;
+    }
+    chimera_posix_close(fd);
+    return 0;
+} /* pjd_create */
+
+static inline int
+pjd_open(
+    const char *name,
+    int         flags,
+    mode_t      mode)
+{
+    char p[PJD_PATHBUF];
+
+    return chimera_posix_open(pjd_resolve(name, p, sizeof(p)), flags, mode);
+} /* pjd_open */
+
+/* open `name`; return 0 on success (closing the fd), else the errno. */
+static inline int
+pjd_open_e(
+    const char *name,
+    int         flags,
+    mode_t      mode)
+{
+    int fd = pjd_open(name, flags, mode);
+
+    if (fd < 0) {
+        return errno ? errno : -1;
+    }
+    chimera_posix_close(fd);
+    return 0;
+} /* pjd_open_e */
+
+static inline int
+pjd_unlink(const char *name)
+{
+    char p[PJD_PATHBUF];
+
+    return chimera_posix_unlink(pjd_resolve(name, p, sizeof(p)));
+} /* pjd_unlink */
+
+static inline int
+pjd_chmod(
+    const char *name,
+    mode_t      mode)
+{
+    char p[PJD_PATHBUF];
+
+    return chimera_posix_chmod(pjd_resolve(name, p, sizeof(p)), mode);
+} /* pjd_chmod */
+
+static inline int
+pjd_chown(
+    const char *name,
+    uid_t       uid,
+    gid_t       gid)
+{
+    char p[PJD_PATHBUF];
+
+    return chimera_posix_chown(pjd_resolve(name, p, sizeof(p)), uid, gid);
+} /* pjd_chown */
+
+static inline int
+pjd_lchown(
+    const char *name,
+    uid_t       uid,
+    gid_t       gid)
+{
+    char p[PJD_PATHBUF];
+
+    return chimera_posix_lchown(pjd_resolve(name, p, sizeof(p)), uid, gid);
+} /* pjd_lchown */
+
+static inline int
+pjd_symlink(
+    const char *target,
+    const char *name)
+{
+    char p[PJD_PATHBUF];
+
+    /* target is stored verbatim (not resolved); only the link path is. */
+    return chimera_posix_symlink(target, pjd_resolve(name, p, sizeof(p)));
+} /* pjd_symlink */
+
+static inline int
+pjd_link(
+    const char *oldname,
+    const char *newname)
+{
+    char op[PJD_PATHBUF], np[PJD_PATHBUF];
+
+    return chimera_posix_link(pjd_resolve(oldname, op, sizeof(op)),
+                              pjd_resolve(newname, np, sizeof(np)));
+} /* pjd_link */
+
+static inline int
+pjd_rename(
+    const char *oldname,
+    const char *newname)
+{
+    char op[PJD_PATHBUF], np[PJD_PATHBUF];
+
+    return chimera_posix_rename(pjd_resolve(oldname, op, sizeof(op)),
+                                pjd_resolve(newname, np, sizeof(np)));
+} /* pjd_rename */
+
+static inline int
+pjd_mknod(
+    const char *name,
+    mode_t      mode,
+    dev_t       dev)
+{
+    char p[PJD_PATHBUF];
+
+    return chimera_posix_mknod(pjd_resolve(name, p, sizeof(p)), mode, dev);
+} /* pjd_mknod */
+
+static inline int
+pjd_mkfifo(
+    const char *name,
+    mode_t      mode)
+{
+    return pjd_mknod(name, S_IFIFO | mode, 0);
+} /* pjd_mkfifo */
+
+/* mknod(2) creating a FIFO (the substantive mknod/00 path). */
+static inline int
+pjd_mknod_fifo(
+    const char *name,
+    mode_t      mode)
+{
+    return pjd_mknod(name, S_IFIFO | mode, 0);
+} /* pjd_mknod_fifo */
+
+static inline int
+pjd_truncate(
+    const char *name,
+    off_t       length)
+{
+    char p[PJD_PATHBUF];
+
+    return chimera_posix_truncate(pjd_resolve(name, p, sizeof(p)), length);
+} /* pjd_truncate */
+
+/* ---- stat-field accessors ----------------------------------------------- */
+
+/* File-type constant for a name (follows symlinks); returns the S_IFMT bits,
+ * or 0 on error. */
+static inline mode_t
+pjd_stat_type(const char *name)
+{
+    char        p[PJD_PATHBUF];
+    struct stat st;
+
+    if (chimera_posix_stat(pjd_resolve(name, p, sizeof(p)), &st) != 0) {
+        return 0;
+    }
+    return st.st_mode & S_IFMT;
+} /* pjd_stat_type */
+
+static inline mode_t
+pjd_lstat_type(const char *name)
+{
+    char        p[PJD_PATHBUF];
+    struct stat st;
+
+    if (chimera_posix_lstat(pjd_resolve(name, p, sizeof(p)), &st) != 0) {
+        return 0;
+    }
+    return st.st_mode & S_IFMT;
+} /* pjd_lstat_type */
+
+/* Permission/special bits (mode & 07777), following symlinks; -1 on error. */
+static inline int
+pjd_stat_mode(const char *name)
+{
+    char        p[PJD_PATHBUF];
+    struct stat st;
+
+    if (chimera_posix_stat(pjd_resolve(name, p, sizeof(p)), &st) != 0) {
+        return -1;
+    }
+    return st.st_mode & 07777;
+} /* pjd_stat_mode */
+
+static inline int
+pjd_lstat_mode(const char *name)
+{
+    char        p[PJD_PATHBUF];
+    struct stat st;
+
+    if (chimera_posix_lstat(pjd_resolve(name, p, sizeof(p)), &st) != 0) {
+        return -1;
+    }
+    return st.st_mode & 07777;
+} /* pjd_lstat_mode */
+
+/* Full lstat/stat into caller's struct; returns 0/-1 (errno set). */
+static inline int
+pjd_lstat(
+    const char  *name,
+    struct stat *st)
+{
+    char p[PJD_PATHBUF];
+
+    return chimera_posix_lstat(pjd_resolve(name, p, sizeof(p)), st);
+} /* pjd_lstat */
+
+static inline int
+pjd_stat(
+    const char  *name,
+    struct stat *st)
+{
+    char p[PJD_PATHBUF];
+
+    return chimera_posix_stat(pjd_resolve(name, p, sizeof(p)), st);
+} /* pjd_stat */
+
+static inline long
+pjd_stat_nlink(const char *name)
+{
+    char        p[PJD_PATHBUF];
+    struct stat st;
+
+    if (chimera_posix_stat(pjd_resolve(name, p, sizeof(p)), &st) != 0) {
+        return -1;
+    }
+    return (long) st.st_nlink;
+} /* pjd_stat_nlink */
+
+/* ctime/mtime as full timespec; used by "syscall updates ctime/mtime" checks.
+ * Returns 0 on success, -1 on error. */
+static inline int
+pjd_lstat_ctime(
+    const char      *name,
+    struct timespec *ts)
+{
+    char        p[PJD_PATHBUF];
+    struct stat st;
+
+    if (chimera_posix_lstat(pjd_resolve(name, p, sizeof(p)), &st) != 0) {
+        return -1;
+    }
+    *ts = st.st_ctim;
+    return 0;
+} /* pjd_lstat_ctime */
+
+static inline int
+pjd_lstat_mtime(
+    const char      *name,
+    struct timespec *ts)
+{
+    char        p[PJD_PATHBUF];
+    struct stat st;
+
+    if (chimera_posix_lstat(pjd_resolve(name, p, sizeof(p)), &st) != 0) {
+        return -1;
+    }
+    *ts = st.st_mtim;
+    return 0;
+} /* pjd_lstat_mtime */
+
+static inline long
+pjd_lstat_inode(const char *name)
+{
+    char        p[PJD_PATHBUF];
+    struct stat st;
+
+    if (chimera_posix_lstat(pjd_resolve(name, p, sizeof(p)), &st) != 0) {
+        return -1;
+    }
+    return (long) st.st_ino;
+} /* pjd_lstat_inode */
+
+static inline long
+pjd_lstat_major(const char *name)
+{
+    char        p[PJD_PATHBUF];
+    struct stat st;
+
+    if (chimera_posix_lstat(pjd_resolve(name, p, sizeof(p)), &st) != 0) {
+        return -1;
+    }
+    return (long) major(st.st_rdev);
+} /* pjd_lstat_major */
+
+static inline long
+pjd_lstat_minor(const char *name)
+{
+    char        p[PJD_PATHBUF];
+    struct stat st;
+
+    if (chimera_posix_lstat(pjd_resolve(name, p, sizeof(p)), &st) != 0) {
+        return -1;
+    }
+    return (long) minor(st.st_rdev);
+} /* pjd_lstat_minor */
+
+static inline long
+pjd_lstat_uid(const char *name)
+{
+    char        p[PJD_PATHBUF];
+    struct stat st;
+
+    if (chimera_posix_lstat(pjd_resolve(name, p, sizeof(p)), &st) != 0) {
+        return -1;
+    }
+    return (long) st.st_uid;
+} /* pjd_lstat_uid */
+
+static inline long
+pjd_lstat_gid(const char *name)
+{
+    char        p[PJD_PATHBUF];
+    struct stat st;
+
+    if (chimera_posix_lstat(pjd_resolve(name, p, sizeof(p)), &st) != 0) {
+        return -1;
+    }
+    return (long) st.st_gid;
+} /* pjd_lstat_gid */
+
+static inline long
+pjd_stat_size(const char *name)
+{
+    char        p[PJD_PATHBUF];
+    struct stat st;
+
+    if (chimera_posix_stat(pjd_resolve(name, p, sizeof(p)), &st) != 0) {
+        return -1;
+    }
+    return (long) st.st_size;
+} /* pjd_stat_size */
+
+/* stat (follow) ctime/mtime; 0 on success, -1 on error. */
+static inline int
+pjd_stat_ctime(
+    const char      *name,
+    struct timespec *ts)
+{
+    char        p[PJD_PATHBUF];
+    struct stat st;
+
+    if (chimera_posix_stat(pjd_resolve(name, p, sizeof(p)), &st) != 0) {
+        return -1;
+    }
+    *ts = st.st_ctim;
+    return 0;
+} /* pjd_stat_ctime */
+
+static inline int
+pjd_stat_mtime(
+    const char      *name,
+    struct timespec *ts)
+{
+    char        p[PJD_PATHBUF];
+    struct stat st;
+
+    if (chimera_posix_stat(pjd_resolve(name, p, sizeof(p)), &st) != 0) {
+        return -1;
+    }
+    *ts = st.st_mtim;
+    return 0;
+} /* pjd_stat_mtime */
+
+/* Brief delay so a subsequent metadata change yields a strictly greater
+ * timestamp.  The shell suite sleeps 1s (second-resolution stat); Chimera
+ * exposes nanosecond timestamps, so a short sleep suffices on fine-grained
+ * backends. */
+static inline void
+pjd_settle(void)
+{
+    struct timespec ts = { 0, 20 * 1000 * 1000 };  /* 20ms */
+
+    nanosleep(&ts, NULL);
+} /* pjd_settle */
+
+/* atime/mtime seconds via lstat (no-follow); -1 on error. */
+static inline long
+pjd_lstat_atime(const char *name)
+{
+    char        p[PJD_PATHBUF];
+    struct stat st;
+
+    if (chimera_posix_lstat(pjd_resolve(name, p, sizeof(p)), &st) != 0) {
+        return -1;
+    }
+    return (long) st.st_atim.tv_sec;
+} /* pjd_lstat_atime */
+
+static inline long
+pjd_lstat_mtime_sec(const char *name)
+{
+    char        p[PJD_PATHBUF];
+    struct stat st;
+
+    if (chimera_posix_lstat(pjd_resolve(name, p, sizeof(p)), &st) != 0) {
+        return -1;
+    }
+    return (long) st.st_mtim.tv_sec;
+} /* pjd_lstat_mtime_sec */
+
+/* Full atime/mtime timespec via lstat; 0 on success. */
+static inline int
+pjd_lstat_times(
+    const char      *name,
+    struct timespec *atime,
+    struct timespec *mtime)
+{
+    char        p[PJD_PATHBUF];
+    struct stat st;
+
+    if (chimera_posix_lstat(pjd_resolve(name, p, sizeof(p)), &st) != 0) {
+        return -1;
+    }
+    *atime = st.st_atim;
+    *mtime = st.st_mtim;
+    return 0;
+} /* pjd_lstat_times */
+
+/* utimensat against a real directory descriptor opened on the harness cwd
+ * (mirrors pjdfstest's `open . O_RDONLY : utimensat 0 <name> ...`).  `name` is
+ * resolved relative to that descriptor, so it is passed verbatim. */
+static inline int
+pjd_utimensat(
+    const char *name,
+    time_t      a_sec,
+    long        a_nsec,
+    time_t      m_sec,
+    long        m_nsec,
+    int         flags)
+{
+    struct timespec ts[2];
+    int             dirfd = chimera_posix_open(pjd_cwd, O_RDONLY, 0);
+    int             rc, e;
+
+    if (dirfd < 0) {
+        return -1;
+    }
+    ts[0].tv_sec  = a_sec;
+    ts[0].tv_nsec = a_nsec;
+    ts[1].tv_sec  = m_sec;
+    ts[1].tv_nsec = m_nsec;
+
+    rc = chimera_posix_utimensat(dirfd, name, ts, flags);
+    e  = (rc < 0) ? errno : 0;
+    chimera_posix_close(dirfd);
+    errno = e;
+    return rc;
+} /* pjd_utimensat */
+
+static inline int
+pjd_timespec_lt(
+    const struct timespec *a,
+    const struct timespec *b)
+{
+    if (a->tv_sec != b->tv_sec) {
+        return a->tv_sec < b->tv_sec;
+    }
+    return a->tv_nsec < b->tv_nsec;
+} /* pjd_timespec_lt */
+
+/* ---- create_file: all POSIX types (mirrors misc.sh create_file) --------- */
+
+enum pjd_ftype {
+    PJD_FT_NONE,
+    PJD_FT_REGULAR,
+    PJD_FT_DIR,
+    PJD_FT_FIFO,
+    PJD_FT_BLOCK,
+    PJD_FT_CHAR,
+    PJD_FT_SOCKET,
+    PJD_FT_SYMLINK,
+};
+
+/* Create a file of the given type at `name`.  Returns 0 on success, -1 on
+ * error (errno set), mirroring the misc.sh helper's per-type create.  Default
+ * modes follow pjdfstest (regular/block/char/socket 0644, dir 0755). */
+static inline int
+pjd_create_file(
+    enum pjd_ftype type,
+    const char    *name)
+{
+    switch (type) {
+        case PJD_FT_NONE:
+            return 0;
+        case PJD_FT_REGULAR:
+            return pjd_create(name, 0644);
+        case PJD_FT_DIR:
+            return pjd_mkdir(name, 0755);
+        case PJD_FT_FIFO:
+            return pjd_mkfifo(name, 0644);
+        case PJD_FT_BLOCK:
+            return pjd_mknod(name, S_IFBLK | 0644, makedev(1, 2));
+        case PJD_FT_CHAR:
+            return pjd_mknod(name, S_IFCHR | 0644, makedev(1, 2));
+        case PJD_FT_SOCKET:
+            return pjd_mknod(name, S_IFSOCK | 0644, 0);
+        case PJD_FT_SYMLINK:
+            return pjd_symlink("test", name);
+    } /* switch */
+    return -1;
+} /* pjd_create_file */
+
+/* Create a file of the given type owned by uid:gid (created as the current
+ * credential, then lchown'd -- mirrors misc.sh create_file <type> <name> <uid>
+ * <gid>).  Returns 0 on success, -1 on the first failing step. */
+static inline int
+pjd_create_file_owned(
+    enum pjd_ftype type,
+    const char    *name,
+    uid_t          uid,
+    gid_t          gid)
+{
+    if (pjd_create_file(type, name) != 0) {
+        return -1;
+    }
+    return pjd_lchown(name, uid, gid);
+} /* pjd_create_file_owned */
+
+/* Remove a file of the given type (dir -> rmdir, else unlink). */
+static inline int
+pjd_remove_file(
+    enum pjd_ftype type,
+    const char    *name)
+{
+    if (type == PJD_FT_DIR) {
+        return pjd_rmdir(name);
+    }
+    return pjd_unlink(name);
+} /* pjd_remove_file */


### PR DESCRIPTION
> Supersedes #691 (rebased onto current main + wired in as its own CI test shard). Same change set, re-based from the fork branch.

## Summary

Ports the **pjdfstest** POSIX filesystem conformance suite into the Chimera POSIX
client test suite (`src/posix/tests/pjd/<category>/NN.c`, one C program per
upstream `.t`), and raises the POSIX compliance of the client/VFS layers those
tests exercise. Per the design, fixes were made **below the POSIX wrapper** —
in the shared `src/client` and `src/vfs` layers — wherever the behavior is
shared, so NFS and SMB benefit too.

**134 ctest cases** across 14 categories, all green on `memfs`, with no
regressions in the existing POSIX suite (332 memfs cases) or the
`memfs`/`cairn`/`linux`/`nfs` namespace/rename suites.

## Enabling infrastructure

- **Per-call credentials in the client API.** Added `has_cred`/`req_cred` to
  `chimera_client_request` plus a `chimera_client_req_cred()` accessor, routing
  every VFS dispatch through it. The POSIX layer exposes a thread-local override
  (`chimera_posix_set_cred`/`clear_cred`) captured into each request, so a single
  client can act as different users per call — required for the permission tests.
- **umask** support (`chimera_posix_umask`) and a fix for create paths that were
  discarding the requested mode entirely (`open`/`mkdir` did `(void) mode;`).
- New ops: `utimensat`/`futimens` (setattr ATIME/MTIME via the `TIME_NOW`/
  `TIME_OMIT` sentinels) and `pathconf`/`fpathconf`.
- `src/posix/tests/pjd_common.h` — a C analog of pjdfstest's `misc.sh`: TAP
  assertions, a harness working directory, per-call cred/umask switching, file
  creation of every type, name/path generators and stat-field accessors.

## Compliance fixes (shared client/VFS)

- **open** now authorizes the requested access (read for `O_RDONLY`/`O_RDWR`,
  write for `O_WRONLY`/`O_RDWR`, write for `O_TRUNC`); added
  `CHIMERA_VFS_OPEN_WRITE_ONLY` so the access mode is fully represented.
- `O_TRUNC` was unimplemented; opening a directory for writing now returns
  EISDIR; `O_NOFOLLOW` on a symlink returns ELOOP; `O_CREAT` enforces NAME_MAX
  and parent write+search.
- `ENAMETOOLONG` for over-long components/paths (was falling through to ENOENT).
- setattr returns **EPERM vs EACCES** correctly (chmod/chown/explicit-times vs
  size/utimes-now); POSIX **chown** restrictions (non-root can't change uid, gid
  only to a group it belongs to); **setuid/setgid kill-priv** on ownership
  change; **S_ISGID** clearing on non-owner chmod; the owner may always set
  timestamps regardless of write permission.
- Creating/removing an entry requires **search (EXECUTE) + write** on the
  directory; POSIX **delete model** (the NFSv4 per-object DELETE fallback applies
  only to ACL-flavored callers); sticky-bit deletes; `rmdir`/`rename` of
  `.`/`..` → EINVAL/ENOTEMPTY; hard-linking a directory → EPERM; `lchown` no
  longer follows symlinks.
- Timestamp semantics: truncate/chmod/chown/rename bump ctime (and mtime where
  required); unlink of a hard link bumps the surviving inode's ctime.

### Crash/deadlock fixes uncovered by the suite

- `O_NOFOLLOW` create path in memfs left an inode lock held (deadlock).
- `rename` of a directory into its own descendant self-deadlocked; now an
  ancestry walk returns EINVAL before taking the child lock.
- `utimensat`'s directory-relative path used a stack-local attr after scope and
  didn't request the FH (backend abort "no fh returned").
- `ftruncate` on a read-only descriptor now returns EINVAL.

## Scope / deferred

Out of scope for this PR (documented inline): FreeBSD-only rows
(chflags, `st_birthtime`), EROFS/EFAULT/EXDEV/ETXTBSY/ENOSPC/>2GB cases, the
`granular` NFSv4-ACL category, and two single sub-tests (`utimensat/05`
per-component symlink-follow in the dirfd path; `chmod/12` write-clears-SUID).
Tests are registered on `memfs` first; widening to cairn/diskfs/linux/io_uring/
nfs is a follow-up using the existing `generate_posix_backend_tests` machinery.
