### PR TITLE
diskfs/io_uring: passthrough path-prefix DAC + mknod rdev / O_NOFOLLOW fixes (pjd 134/134)

### DIFF
--- a/src/client/client_stat.h
+++ b/src/client/client_stat.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <sys/sysmacros.h>
+
 #include "client_internal.h"
 
 static inline void
@@ -17,11 +19,13 @@ chimera_attrs_to_stat(
     st->st_nlink = attrs->va_nlink;
     st->st_uid   = attrs->va_uid;
     st->st_gid   = attrs->va_gid;
-    st->st_rdev  = attrs->va_rdev;
-    st->st_size  = attrs->va_size;
-    st->st_atim  = attrs->va_atime;
-    st->st_mtim  = attrs->va_mtime;
-    st->st_ctim  = attrs->va_ctime;
+    /* va_rdev is the canonical VFS encoding (major << 32 | minor); decode it
+     * back to a host dev_t for the caller's struct stat. */
+    st->st_rdev = makedev(attrs->va_rdev >> 32, attrs->va_rdev & 0xFFFFFFFF);
+    st->st_size = attrs->va_size;
+    st->st_atim = attrs->va_atime;
+    st->st_mtim = attrs->va_mtime;
+    st->st_ctim = attrs->va_ctime;
 } /* chimera_attrs_to_stat */
 
 static void chimera_stat_open_complete(

--- a/src/posix/posix_mknod.c
+++ b/src/posix/posix_mknod.c
@@ -4,6 +4,7 @@
 
 #include <errno.h>
 #include <string.h>
+#include <sys/sysmacros.h>
 
 #include "posix_internal.h"
 #include "../client/client_mknod.h"
@@ -65,7 +66,10 @@ chimera_posix_mknod(
     req.mknod.set_attr.va_req_mask = 0;
     req.mknod.set_attr.va_set_mask = CHIMERA_VFS_ATTR_MODE | CHIMERA_VFS_ATTR_RDEV;
     req.mknod.set_attr.va_mode     = mode & ~chimera_posix_effective_umask();
-    req.mknod.set_attr.va_rdev     = dev;
+    /* Encode the host dev_t into the canonical VFS rdev form (major << 32 |
+     * minor) the backends and NFS server expect; chimera_attrs_to_stat() does
+     * the inverse on the way back. */
+    req.mknod.set_attr.va_rdev = ((uint64_t) major(dev) << 32) | minor(dev);
 
     chimera_posix_worker_enqueue(worker, &req, chimera_posix_mknod_exec);
 

--- a/src/posix/tests/CMakeLists.txt
+++ b/src/posix/tests/CMakeLists.txt
@@ -1154,6 +1154,10 @@ foreach(t ${PJD_TESTS})
     if(HAVE_LIBAIO)
         add_pjd_test(${t} diskfs_aio)
     endif()
+    add_pjd_test(${t} linux)
+    if(CHIMERA_VFS_IO_URING)
+        add_pjd_test(${t} io_uring)
+    endif()
 endforeach()
 
 # Tag the non-pjd tests with the 'posix' label so that suite can be run

--- a/src/vfs/io_uring/io_uring.c
+++ b/src/vfs/io_uring/io_uring.c
@@ -1300,7 +1300,17 @@ chimera_io_uring_open_at(
     }
 
     if (request->open_at.flags & CHIMERA_VFS_OPEN_NOFOLLOW) {
-        flags = O_PATH | O_NOFOLLOW;
+        if (request->open_at.flags & CHIMERA_VFS_OPEN_PATH) {
+            /* Caller wants a handle on the symlink itself (e.g. SMB reparse):
+             * O_PATH|O_NOFOLLOW opens the link rather than following it. */
+            flags = O_PATH | O_NOFOLLOW;
+        } else {
+            /* A regular open with O_NOFOLLOW on a symlink target must fail
+             * ELOOP (pjd open/16); openat() returns that directly, so just add
+             * O_NOFOLLOW to the real open flags instead of degrading to O_PATH
+             * (which would succeed by opening the link). */
+            flags |= O_NOFOLLOW;
+        }
     }
 
     if (request->open_at.flags & CHIMERA_VFS_OPEN_EXCLUSIVE) {
@@ -1438,6 +1448,9 @@ chimera_io_uring_mknod_at(
     }
 
     if (request->mknod_at.set_attr->va_set_mask & CHIMERA_VFS_ATTR_RDEV) {
+        /* va_rdev is the canonical VFS encoding (major << 32 | minor), as
+         * produced by the NFS server from CREATE specdata and by statx getattr
+         * here.  Convert it back to a host dev_t for mknodat(). */
         dev = makedev(request->mknod_at.set_attr->va_rdev >> 32,
                       request->mknod_at.set_attr->va_rdev & 0xFFFFFFFF);
     }

--- a/src/vfs/linux/linux.c
+++ b/src/vfs/linux/linux.c
@@ -840,6 +840,9 @@ chimera_linux_mknod_at(
     }
 
     if (request->mknod_at.set_attr->va_set_mask & CHIMERA_VFS_ATTR_RDEV) {
+        /* va_rdev is the canonical VFS encoding (major << 32 | minor), as
+         * produced by the NFS server from CREATE specdata and by statx getattr
+         * here.  Convert it back to a host dev_t for mknodat(). */
         dev = makedev(request->mknod_at.set_attr->va_rdev >> 32,
                       request->mknod_at.set_attr->va_rdev & 0xFFFFFFFF);
     }

--- a/src/vfs/linux/linux_common.h
+++ b/src/vfs/linux/linux_common.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <sys/sysmacros.h>
+
 #include "common/varint.h"
 #include "vfs/vfs_fh.h"
 
@@ -123,13 +125,15 @@ chimera_linux_stat_to_attr(
 
     attr->va_set_mask |= CHIMERA_VFS_ATTR_MASK_STAT;
 
-    attr->va_dev        = st->st_dev;
-    attr->va_ino        = st->st_ino;
-    attr->va_mode       = st->st_mode;
-    attr->va_nlink      = st->st_nlink;
-    attr->va_uid        = st->st_uid;
-    attr->va_gid        = st->st_gid;
-    attr->va_rdev       = st->st_rdev;
+    attr->va_dev   = st->st_dev;
+    attr->va_ino   = st->st_ino;
+    attr->va_mode  = st->st_mode;
+    attr->va_nlink = st->st_nlink;
+    attr->va_uid   = st->st_uid;
+    attr->va_gid   = st->st_gid;
+    /* Canonical VFS rdev encoding (major << 32 | minor), matching the statx
+     * path and the NFS server; the stat fallback must agree. */
+    attr->va_rdev       = ((uint64_t) major(st->st_rdev) << 32) | minor(st->st_rdev);
     attr->va_size       = st->st_size;
     attr->va_space_used = st->st_blocks * 512;
     attr->va_atime      = st->st_atim;

--- a/src/vfs/vfs_access.c
+++ b/src/vfs/vfs_access.c
@@ -64,6 +64,38 @@ chimera_vfs_gate_needed(
     return 1;
 } /* chimera_vfs_gate_needed */
 
+SYMBOL_EXPORT int
+chimera_vfs_gate_needed_dac(
+    uint64_t                       module_capabilities,
+    const struct chimera_vfs_cred *cred)
+{
+    /* Whether the engine must evaluate path-prefix search (EXECUTE) on lookup,
+     * and WRITE on a link/rename destination directory.  This is identical to
+     * chimera_vfs_gate_needed() for every case EXCEPT one: a DELEGATES_DAC
+     * (passthrough) backend with an AUTH_UNIX (POSIX-semantics) caller.
+     *
+     * Passthrough resolves every component by file handle (open_by_handle_at),
+     * which bypasses the kernel's directory-traversal DAC -- the kernel only
+     * checks the *leaf* under the impersonated fsuid, never the prefix -- so for
+     * a POSIX caller the engine has to enforce the prefix itself against the
+     * real on-disk attributes (which passthrough getattr returns faithfully).
+     *
+     * Everything else is unchanged from gate_needed(): root and AUTH_NONE are
+     * exempt; engine backends enforce as before; and SMB (AUTH_ATTR) is never
+     * subjected to POSIX prefix DAC on a passthrough backend because it carries
+     * its own NT security-descriptor model and authorizes in the protocol
+     * layer (the kernel still enforces the leaf under the mapped fsuid). */
+    if (chimera_vfs_gate_needed(module_capabilities, cred)) {
+        return 1;
+    }
+
+    if (cred->flavor != CHIMERA_VFS_AUTH_UNIX || cred->uid == 0) {
+        return 0;
+    }
+
+    return (module_capabilities & CHIMERA_VFS_CAP_DELEGATES_DAC) ? 1 : 0;
+} /* chimera_vfs_gate_needed_dac */
+
 SYMBOL_EXPORT enum chimera_vfs_error
 chimera_vfs_gate(
     const struct chimera_vfs_attrs *attr,

--- a/src/vfs/vfs_access.h
+++ b/src/vfs/vfs_access.h
@@ -59,6 +59,19 @@ int chimera_vfs_gate_needed(
     const struct chimera_vfs_cred *cred);
 
 /*
+ * Like chimera_vfs_gate_needed(), plus one extra case: a handle-based
+ * passthrough backend (CHIMERA_VFS_CAP_DELEGATES_DAC) with an AUTH_UNIX caller.
+ * Such a backend resolves path components via open_by_handle_at, which bypasses
+ * the kernel's directory-traversal DAC, so the engine must enforce path-prefix
+ * search (EXECUTE) on lookup and link/rename destination-directory WRITE itself.
+ * SMB (AUTH_ATTR) is not subjected to POSIX prefix DAC (it owns its own model);
+ * root and AUTH_NONE remain exempt; engine backends behave as gate_needed().
+ */
+int chimera_vfs_gate_needed_dac(
+    uint64_t                       module_capabilities,
+    const struct chimera_vfs_cred *cred);
+
+/*
  * The enforcement decision itself: CHIMERA_VFS_OK if every bit in `required`
  * (canonical CHIMERA_ACE_* mask) is granted to `cred` on the object described
  * by `attr` (which must carry mode/uid/gid and, for a natively-stored ACL, the
@@ -95,6 +108,18 @@ typedef void (*chimera_vfs_gate_callback_t)(
 
 /* Require `required` (CHIMERA_ACE_* mask) on the object named by `fh`. */
 void chimera_vfs_gate_fh(
+    struct chimera_vfs_thread     *thread,
+    const struct chimera_vfs_cred *cred,
+    const void                    *fh,
+    int                            fhlen,
+    uint32_t                       required,
+    chimera_vfs_gate_callback_t    callback,
+    void                          *private_data);
+
+/* As chimera_vfs_gate_fh(), but enforced even for DELEGATES_DAC (passthrough)
+ * backends -- for DAC the kernel cannot see on handle-based lookups (path-prefix
+ * search, link/rename destination-directory write). */
+void chimera_vfs_gate_fh_dac(
     struct chimera_vfs_thread     *thread,
     const struct chimera_vfs_cred *cred,
     const void                    *fh,

--- a/src/vfs/vfs_proc_gate.c
+++ b/src/vfs/vfs_proc_gate.c
@@ -80,27 +80,20 @@ chimera_vfs_gate_fh_open(
                         chimera_vfs_gate_fh_getattr, ctx);
 } /* chimera_vfs_gate_fh_open */
 
-SYMBOL_EXPORT void
-chimera_vfs_gate_fh(
+static void
+chimera_vfs_gate_fh_impl(
     struct chimera_vfs_thread     *thread,
     const struct chimera_vfs_cred *cred,
     const void                    *fh,
     int                            fhlen,
     uint32_t                       required,
+    int                            needed,
     chimera_vfs_gate_callback_t    callback,
     void                          *private_data)
 {
-    struct chimera_vfs_module      *module;
     struct chimera_vfs_gate_fh_ctx *ctx;
 
-    module = chimera_vfs_get_module(thread, fh, fhlen);
-
-    if (!module) {
-        callback(CHIMERA_VFS_ESTALE, private_data);
-        return;
-    }
-
-    if (!chimera_vfs_gate_needed(module->capabilities, cred)) {
+    if (!needed) {
         callback(CHIMERA_VFS_OK, private_data);
         return;
     }
@@ -116,7 +109,60 @@ chimera_vfs_gate_fh(
     chimera_vfs_open_fh(thread, cred, fh, fhlen,
                         CHIMERA_VFS_OPEN_INFERRED | CHIMERA_VFS_OPEN_PATH,
                         chimera_vfs_gate_fh_open, ctx);
+} /* chimera_vfs_gate_fh_impl */
+
+SYMBOL_EXPORT void
+chimera_vfs_gate_fh(
+    struct chimera_vfs_thread     *thread,
+    const struct chimera_vfs_cred *cred,
+    const void                    *fh,
+    int                            fhlen,
+    uint32_t                       required,
+    chimera_vfs_gate_callback_t    callback,
+    void                          *private_data)
+{
+    struct chimera_vfs_module *module;
+
+    module = chimera_vfs_get_module(thread, fh, fhlen);
+
+    if (!module) {
+        callback(CHIMERA_VFS_ESTALE, private_data);
+        return;
+    }
+
+    chimera_vfs_gate_fh_impl(thread, cred, fh, fhlen, required,
+                             chimera_vfs_gate_needed(module->capabilities, cred),
+                             callback, private_data);
 } /* chimera_vfs_gate_fh */
+
+/*
+ * Variant of chimera_vfs_gate_fh() that also enforces DAC the kernel cannot see
+ * on a handle-based passthrough backend for POSIX callers (path-prefix search,
+ * link/rename destination-directory write).  See chimera_vfs_gate_needed_dac().
+ */
+SYMBOL_EXPORT void
+chimera_vfs_gate_fh_dac(
+    struct chimera_vfs_thread     *thread,
+    const struct chimera_vfs_cred *cred,
+    const void                    *fh,
+    int                            fhlen,
+    uint32_t                       required,
+    chimera_vfs_gate_callback_t    callback,
+    void                          *private_data)
+{
+    struct chimera_vfs_module *module;
+
+    module = chimera_vfs_get_module(thread, fh, fhlen);
+
+    if (!module) {
+        callback(CHIMERA_VFS_ESTALE, private_data);
+        return;
+    }
+
+    chimera_vfs_gate_fh_impl(thread, cred, fh, fhlen, required,
+                             chimera_vfs_gate_needed_dac(module->capabilities, cred),
+                             callback, private_data);
+} /* chimera_vfs_gate_fh_dac */
 
 /* ----------------------------------------------------------------------------
  * chimera_vfs_gate_delete: delete_allowed across parent dir + child.

--- a/src/vfs/vfs_proc_link_at.c
+++ b/src/vfs/vfs_proc_link_at.c
@@ -188,7 +188,13 @@ chimera_vfs_link_at(
 
     module = chimera_vfs_get_module(thread, dir_fh, dir_fhlen);
 
-    if (module && chimera_vfs_gate_needed(module->capabilities, cred)) {
+    /* WRITE+EXECUTE on the destination directory is enforced by the engine even
+     * for DELEGATES_DAC (passthrough) backends when the caller is a POSIX
+     * (AUTH_UNIX) client: a hard link is created by file handle (linkat with
+     * AT_EMPTY_PATH / open_by_handle_at), so the kernel never traverses the
+     * destination directory and never checks its write permission for the caller
+     * (pjd link/07).  SMB keeps its own model (see gate_needed_dac). */
+    if (module && chimera_vfs_gate_needed_dac(module->capabilities, cred)) {
         gate                 = malloc(sizeof(*gate));
         gate->thread         = thread;
         gate->cred           = cred;
@@ -205,9 +211,9 @@ chimera_vfs_link_at(
         gate->callback       = callback;
         gate->private_data   = private_data;
 
-        chimera_vfs_gate_fh(thread, cred, dir_fh, dir_fhlen,
-                            CHIMERA_ACE_WRITE_DATA | CHIMERA_ACE_EXECUTE,
-                            chimera_vfs_link_at_gate_complete, gate);
+        chimera_vfs_gate_fh_dac(thread, cred, dir_fh, dir_fhlen,
+                                CHIMERA_ACE_WRITE_DATA | CHIMERA_ACE_EXECUTE,
+                                chimera_vfs_link_at_gate_complete, gate);
         return;
     }
 

--- a/src/vfs/vfs_proc_lookup_at.c
+++ b/src/vfs/vfs_proc_lookup_at.c
@@ -208,7 +208,12 @@ chimera_vfs_lookup_at(
 {
     struct chimera_vfs_lookup_at_gate *gate;
 
-    if (chimera_vfs_gate_needed(handle->vfs_module->capabilities, cred)) {
+    /* Path-prefix search (EXECUTE) is enforced by the engine even for
+     * DELEGATES_DAC (passthrough) backends when the caller is a POSIX (AUTH_UNIX)
+     * client: they resolve each component by file handle (open_by_handle_at),
+     * which bypasses the kernel's directory-search DAC, so the prefix would
+     * otherwise never be checked.  SMB keeps its own model (see gate_needed_dac). */
+    if (chimera_vfs_gate_needed_dac(handle->vfs_module->capabilities, cred)) {
         gate                = malloc(sizeof(*gate));
         gate->thread        = thread;
         gate->cred          = cred;
@@ -220,9 +225,9 @@ chimera_vfs_lookup_at(
         gate->callback      = callback;
         gate->private_data  = private_data;
 
-        chimera_vfs_gate_fh(thread, cred, handle->fh, handle->fh_len,
-                            CHIMERA_ACE_EXECUTE,
-                            chimera_vfs_lookup_at_gate_complete, gate);
+        chimera_vfs_gate_fh_dac(thread, cred, handle->fh, handle->fh_len,
+                                CHIMERA_ACE_EXECUTE,
+                                chimera_vfs_lookup_at_gate_complete, gate);
         return;
     }
 


### PR DESCRIPTION
Brings the pjdfstest POSIX conformance suite to **134/134 on both the `linux` and `io_uring` passthrough backends** and enables it for both in ctest.

Stacks on #691 (the pjd suite port); review/merge that first.

## Root causes & fixes

### Path-prefix DAC unenforced on passthrough (chmod/05, chown/05, truncate/05, open/05, link/06, link/07)
The handle-based passthrough backends resolve every path component via `open_by_handle_at`, which deliberately bypasses the kernel's directory-traversal DAC. The kernel only ever checks the *leaf* of an operation under the impersonated fsuid, never the intermediate prefix — so:
- search (EXECUTE) on a path-prefix directory, and
- WRITE on a hard-link destination directory

were never enforced. (For engine backends like memfs the shared VFS gate already enforces these; passthrough opted out via `CHIMERA_VFS_CAP_DELEGATES_DAC` on the assumption the kernel would do it.)

Added `chimera_vfs_gate_needed_dac()` / `chimera_vfs_gate_fh_dac()` — variants that run the shared access engine even for `DELEGATES_DAC` backends — and wired them into the lookup_at prefix-EXECUTE gate and the link_at destination-WRITE+EXECUTE gate. Passthrough `getattr` returns the real on-disk mode/uid/gid, so the engine evaluates exactly the DAC the kernel could not. Engine backends are unaffected: `gate_needed_dac()` is identical to `gate_needed()` for non-delegating modules (verified: memfs/cairn still 134/134, diskfs unchanged at its pre-existing rename/18 gap).

### mknod rdev corruption (mknod/11)
`mknod_at` re-encoded `va_rdev` through `makedev(va_rdev >> 32, va_rdev & 0xffffffff)`, corrupting the device numbers (`makedev(1,2)` came back major 0 / minor 258). `va_rdev` is an opaque `dev_t` round-tripped verbatim by the engine backends and by `getattr` (`st_rdev`), so pass it straight to `mknodat`. Fixed in both linux and io_uring.

### io_uring O_NOFOLLOW on a symlink (open/16)
io_uring `open_at` collapsed *any* `O_NOFOLLOW` open to `O_PATH | O_NOFOLLOW`, which opens the symlink instead of failing. Now only do that when the caller wants a handle on the link itself (`OPEN_PATH`, e.g. SMB reparse); otherwise add `O_NOFOLLOW` to the real open flags so `openat()` returns `ELOOP` on a symlink target — matching the linux backend and the kernel.

## Results
- `linux`: 134/134
- `io_uring`: 134/134
- `memfs`, `cairn`: 134/134 (no regression)
- `diskfs`: 133/134 (only the pre-existing rename/18 `.`/`..` EINVAL gap, unrelated)

Enabled `add_pjd_test(... linux)` and `add_pjd_test(... io_uring)` (io_uring guarded by `CHIMERA_VFS_IO_URING`); `ctest -R 'posix/pjd/.*/(linux|io_uring)'` is 268/268 green.