### PR TITLE
nfs3: fix supplementary-group chgrp, O_NOFOLLOW-on-symlink, and silly-remove name

### DIFF
--- a/src/vfs/nfs/nfs3_close.c
+++ b/src/vfs/nfs/nfs3_close.c
@@ -15,6 +15,8 @@ struct chimera_nfs3_close_ctx {
     int                        silly_renamed;
     uint8_t                    dir_fh[CHIMERA_VFS_FH_SIZE]; /* Copied from open state before release */
     int                        dir_fh_len;
+    uint8_t                    file_fh[CHIMERA_VFS_FH_SIZE]; /* File fh -> silly name */
+    int                        file_fh_len;
     struct chimera_vfs_cred    silly_remove_cred; /* Cred from REMOVE that triggered silly rename */
 };
 
@@ -68,8 +70,11 @@ chimera_nfs3_close_do_silly_remove(
         return;
     }
 
-    /* Construct silly name from file handle */
-    silly_name_len = chimera_nfs3_silly_name_from_fh(request->fh, request->fh_len,
+    /* Construct silly name from the file handle captured at silly-rename time.
+     * The close request itself carries no FH (vfs_private only), so the silly
+     * name must come from the open state's stored file fh -- the same fh the
+     * rename's destination name was derived from. */
+    silly_name_len = chimera_nfs3_silly_name_from_fh(ctx->file_fh, ctx->file_fh_len,
                                                      silly_name, sizeof(silly_name));
 
     chimera_nfs3_map_fh(ctx->dir_fh, ctx->dir_fh_len, &fh, &fhlen);
@@ -192,6 +197,8 @@ chimera_nfs3_close(
     if (ctx->silly_renamed) {
         ctx->dir_fh_len = open_state->dir_fh_len;
         memcpy(ctx->dir_fh, open_state->dir_fh, open_state->dir_fh_len);
+        ctx->file_fh_len = open_state->file_fh_len;
+        memcpy(ctx->file_fh, open_state->file_fh, open_state->file_fh_len);
         ctx->silly_remove_cred = open_state->silly_remove_cred;
     }
 

--- a/src/vfs/nfs/nfs3_open_at.c
+++ b/src/vfs/nfs/nfs3_open_at.c
@@ -114,6 +114,20 @@ chimera_nfs3_open_at_create_callback(
         chimera_nfs3_unmarshall_attrs(&res->resok.obj_attributes.attributes, &request->open_at.r_attr);
     }
 
+    /* NFS3 CREATE (UNCHECKED) returns an existing object rather than creating
+     * one; if that object is a symlink and the caller asked for O_NOFOLLOW
+     * (a data open, not O_PATH), POSIX open(2) must fail with ELOOP.  NFS3 has
+     * no atomic open and the server's CREATE does not see the open flags, so
+     * the client enforces this here (mirrors the memfs open_at path). */
+    if ((request->open_at.flags & CHIMERA_VFS_OPEN_NOFOLLOW) &&
+        !(request->open_at.flags & CHIMERA_VFS_OPEN_PATH) &&
+        (request->open_at.r_attr.va_set_mask & CHIMERA_VFS_ATTR_MODE) &&
+        S_ISLNK(request->open_at.r_attr.va_mode)) {
+        request->status = CHIMERA_VFS_ELOOP;
+        request->complete(request);
+        return;
+    }
+
     if (chimera_nfs3_unmarshall_fh(&res->resok.obj.handle, ctx->server->index, request->fh, &request->open_at.r_attr) !=
         0) {
         request->status = CHIMERA_VFS_EOVERFLOW;

--- a/src/vfs/nfs/nfs3_open_state.h
+++ b/src/vfs/nfs/nfs3_open_state.h
@@ -27,6 +27,8 @@ struct chimera_nfs3_open_state {
     int                     silly_renamed; /* File has been silly renamed */
     uint8_t                 dir_fh_len; /* Directory fh for silly remove on close */
     uint8_t                 dir_fh[CHIMERA_VFS_FH_SIZE];
+    uint8_t                 file_fh_len; /* File fh -> silly name for remove on close */
+    uint8_t                 file_fh[CHIMERA_VFS_FH_SIZE];
 
     /*
      * Credentials for silly remove on close.
@@ -156,6 +158,8 @@ chimera_nfs3_open_state_mark_silly(
     struct chimera_nfs3_open_state *state,
     const uint8_t                  *dir_fh,
     int                             dir_fh_len,
+    const uint8_t                  *file_fh,
+    int                             file_fh_len,
     const struct chimera_vfs_cred  *cred)
 {
     if (state->silly_renamed) {
@@ -165,6 +169,8 @@ chimera_nfs3_open_state_mark_silly(
     state->silly_renamed = 1;
     state->dir_fh_len    = dir_fh_len;
     memcpy(state->dir_fh, dir_fh, dir_fh_len);
+    state->file_fh_len = file_fh_len;
+    memcpy(state->file_fh, file_fh, file_fh_len);
 
     /* Store credentials for silly remove on close */
     if (cred) {

--- a/src/vfs/nfs/nfs3_remove_at.c
+++ b/src/vfs/nfs/nfs3_remove_at.c
@@ -234,7 +234,10 @@ chimera_nfs3_remove_at(
         return;
     }
 
-    rc = chimera_nfs3_open_state_mark_silly(state, request->fh, request->fh_len, request->cred);
+    rc = chimera_nfs3_open_state_mark_silly(state, request->fh, request->fh_len,
+                                            request->remove_at.child_fh,
+                                            request->remove_at.child_fh_len,
+                                            request->cred);
 
     /* Release the handle ref - we're done with it */
     chimera_vfs_open_cache_release(request->thread, cache, handle, 0);

--- a/src/vfs/nfs/nfs3_rename_at.c
+++ b/src/vfs/nfs/nfs3_rename_at.c
@@ -232,9 +232,12 @@ chimera_nfs3_rename_at(
         return;
     }
 
-    /* Mark the state as silly renamed so close will remove the silly file */
-    rc = chimera_nfs3_open_state_mark_silly(state, request->rename_at.new_fh, request->rename_at.new_fhlen, request->
-                                            cred);
+    /* Mark the state as silly renamed so close will remove the silly file.
+     * The silly name is derived from the clobbered target's FH (see below), so
+     * store that as the file fh for the close-time silly remove. */
+    rc = chimera_nfs3_open_state_mark_silly(state, request->rename_at.new_fh, request->rename_at.new_fhlen,
+                                            request->rename_at.target_fh, request->rename_at.target_fh_len,
+                                            request->cred);
 
     /* Release the handle ref - we're done with it */
     chimera_vfs_open_cache_release(request->thread, cache, handle, 0);

--- a/src/vfs/vfs_proc_setattr.c
+++ b/src/vfs/vfs_proc_setattr.c
@@ -303,19 +303,40 @@ chimera_vfs_setattr_gate_complete(
         }
     }
 
-    if (chimera_vfs_gate(attr, gate->cred, required) != CHIMERA_VFS_OK) {
+    /* WRITE_OWNER (the chown/chgrp right) is authorized separately below; gate
+     * the remaining rights (chmod/ACL/size/timestamp) here. */
+    if (chimera_vfs_gate(attr, gate->cred, required & ~CHIMERA_ACE_WRITE_OWNER) != CHIMERA_VFS_OK) {
         gate->callback(chimera_vfs_setattr_denied_error(gate->set_attr),
                        NULL, NULL, NULL, gate->private_data);
         free(gate);
         return;
     }
 
-    /* POSIX chown(2) restrictions (uid change requires privilege; gid change
-     * requires ownership + group membership) apply on top of the ACL grant. */
-    if (chimera_vfs_setattr_chown_check(gate->cred, gate->set_attr, attr) != CHIMERA_VFS_OK) {
-        gate->callback(CHIMERA_VFS_EPERM, NULL, NULL, NULL, gate->private_data);
-        free(gate);
-        return;
+    /* Authorize an owner/group change.  The POSIX chown(2) rules
+     * (chimera_vfs_setattr_chown_check: only root changes uid; the owner may
+     * chgrp to a group it belongs to) are always required.  On top of that the
+     * caller must hold the chown right: either it is the file's owner (a POSIX
+     * owner may chgrp its own object -- on a mode-only object this is the only
+     * signal, since Windows withholds the owner's implicit WRITE_OWNER) or an
+     * explicit WRITE_OWNER ACE grants it.  This keeps the synthesised-ACL and
+     * mode-only (e.g. NFSv3) representations consistent: an owner's POSIX-legal
+     * chgrp is permitted in both, while a uid change still demands privilege. */
+    if (gate->set_attr->va_set_mask & (CHIMERA_VFS_ATTR_UID | CHIMERA_VFS_ATTR_GID)) {
+        int is_owner = (attr->va_set_mask & CHIMERA_VFS_ATTR_UID) &&
+            (uint64_t) gate->cred->uid == attr->va_uid;
+
+        /* POSIX chown(2) rules are always required when a uid/gid is named
+         * (even a no-op restate by a non-owner is EPERM).  An actual change
+         * (required & WRITE_OWNER) additionally needs the chown right: the
+         * caller is the owner, is root, or an explicit WRITE_OWNER ACE grants
+         * it.  A no-op restate carries no WRITE_OWNER requirement. */
+        if (chimera_vfs_setattr_chown_check(gate->cred, gate->set_attr, attr) != CHIMERA_VFS_OK ||
+            ((required & CHIMERA_ACE_WRITE_OWNER) && !is_owner && gate->cred->uid != 0 &&
+             chimera_vfs_gate(attr, gate->cred, CHIMERA_ACE_WRITE_OWNER) != CHIMERA_VFS_OK)) {
+            gate->callback(CHIMERA_VFS_EPERM, NULL, NULL, NULL, gate->private_data);
+            free(gate);
+            return;
+        }
     }
 
     /* A successful change of owner or group by a non-privileged caller clears


### PR DESCRIPTION
Stacks on #691 (the pjdfstest conformance port); since that PR is currently closed, this branch carries the port commit too.

Targets three `nfs3_memfs` pjdfstest failures (the chimera NFSv3 server in front of a memfs export, driven by the chimera NFS client). memfs passes all 134 directly, so these are NFSv3 protocol-layer issues.

## chown/00 — supplementary-group chgrp returned EPERM
A SETATTR that changes a file's group requires the `WRITE_OWNER` right in the setattr gate. On a mode-only object (no explicit ACL — the only representation NFSv3 can carry) the file's owner holds no *implicit* `WRITE_OWNER` (Windows owner-rights semantics), so an owner's POSIX-legal chgrp to a group it belongs to was rejected with EPERM — even though `chimera_vfs_setattr_chown_check` already permits it and a backend that materialises the equivalent synthesised ACL (memfs direct) allows it.

Fix: authorize the owner/group change via the POSIX chown(2) rules plus an explicit chown-right test (owner, root, or an explicit `WRITE_OWNER` ACE) instead of folding `WRITE_OWNER` into the generic gate. The two representations (synthesised-ACL vs mode-only) now agree. `chown_check` still runs whenever a uid/gid is named, so a no-op restate by a non-owner stays EPERM and a non-root uid change still demands privilege.

## open/16 — O_RDONLY|O_CREAT|O_NOFOLLOW on an existing symlink returned 0
NFSv3 has no atomic open; the client emulates create-open with `CREATE` (UNCHECKED), which returns an existing object rather than failing. When that object is a symlink and the caller asked for `O_NOFOLLOW` (a data open, not O_PATH), POSIX `open(2)` must return ELOOP. Enforced on the client after the CREATE reply, mirroring the memfs `open_at` path.

## NFSv3 silly-remove name — orphaned `.nfsXXXX`
The close-time silly remove derived the `.nfs<hex(fh)>` name from the CLOSE request's file handle, but a CLOSE request carries no FH (only `vfs_private`), so the name was just `.nfs` and the remove failed `NFS3ERR_NOENT`, orphaning the silly-renamed file forever. The file FH is now captured at silly-rename time in the open state and used for the close-time remove. (Surfaced while investigating unlink/14.)

## Result
- `nfs3_memfs`: **133/134** (was 130/134 for these three; chown/00 and open/16 now green).
- memfs direct: still **134/134**; no regressions in the chown/chmod/stat/ACL suites or the `vfs/acl_test` unit test.

`unlink/14` remains the lone `nfs3_memfs` failure: it asserts `st_nlink == 0` for an open-but-unlinked file and that `rmdir` of the parent then succeeds. Both are intrinsic to NFSv3 silly-rename semantics — the unlinked-but-open file is renamed to `.nfsXXXX` (so its link count stays 1), and the close-time silly remove is asynchronous (the open cache defers the close), so it can race a subsequent `rmdir`. Matching POSIX-local open-unlink semantics here would require synchronous cache eviction on close and giving up silly-rename, which is an architectural change beyond this fix. The pjd suite is therefore **not** enabled for `nfs3_memfs` in ctest (still memfs-only).