### PR TITLE
Add an SMB2 client (path-only VFS backend)

### DIFF
--- a/src/client/tests/CMakeLists.txt
+++ b/src/client/tests/CMakeLists.txt
@@ -57,6 +57,7 @@ set(CLIENT_TEST_PROGRAMS
     test_stat
     test_fstat
     test_ftruncate
+    test_io
 )
 
 # Create test programs
@@ -99,6 +100,32 @@ endif()
 generate_backend_tests(cairn CAIRN_ENABLED)
 generate_backend_tests(linux "")
 generate_backend_tests(io_uring CHIMERA_VFS_IO_URING)
+
+# SMB client tests: drive the vfs_smb client against an in-process SMB server
+# (backed by memfs) over loopback.  Limited to the file operations implemented
+# so far, and to the root user -- the memfs share root's ACL denies an
+# unprivileged user's create, so myuser variants fail server-side authorization
+# (not a client defect).  The "-s" flag selects SMB mode in client_test_common.h.
+macro(add_client_smb_test prog)
+    string(REGEX REPLACE "^test_" "" _smb_name ${prog})
+    if(CHIMERA_NETNS_TESTING)
+        add_test(NAME chimera/client/${_smb_name}_smb_memfs_root
+            COMMAND ${CMAKE_SOURCE_DIR}/scripts/netns_test_wrapper.sh
+                    ${CMAKE_CURRENT_BINARY_DIR}/${prog} -s -b memfs -U root)
+        get_target_property(_smb_test_file ${prog} TEST_FILE)
+        set_tests_properties(chimera/client/${_smb_name}_smb_memfs_root PROPERTIES
+            ENVIRONMENT "TEST_FILE=${_smb_test_file}")
+    endif()
+endmacro()
+
+# NOTE: test_symlink / test_readlink are intentionally NOT in the SMB set yet.
+# Symlink *creation* works over SMB, but reading a symlink back (open with
+# FILE_OPEN_REPARSE_POINT, then FSCTL_GET_REPARSE_POINT) currently returns
+# ObjectNameNotFound against the server's reparse-open path -- an alpha gap to
+# fix in the SMB client's own iteration.  They still run on the FH backends.
+foreach(prog test_stat test_fstat test_ftruncate test_remove test_rename test_io)
+    add_client_smb_test(${prog})
+endforeach()
 
 # Tag every test registered above with the 'client' label so the suite can be
 # run independently via `ctest -L client`, and with the VFS backend encoded in

--- a/src/client/tests/client_test_common.h
+++ b/src/client/tests/client_test_common.h
@@ -30,6 +30,8 @@ struct test_env {
     const char                   *backend;
     int                           use_nfs;
     int                           nfsvers;
+    int                           use_smb;
+    char                          user_spec[64];
     struct chimera_vfs_cred       cred;          // Credential used to initialize the client
 };
 
@@ -48,6 +50,8 @@ client_test_init(
 
     env->use_nfs = 0;
     env->nfsvers = 0;
+    env->use_smb = 0;
+    snprintf(env->user_spec, sizeof(env->user_spec), "root");
 
     env->server_metrics = prometheus_metrics_create(NULL, NULL, 0);
 
@@ -63,7 +67,7 @@ client_test_init(
                                CHIMERA_TEST_USER_ROOT_GID,
                                0, NULL);
 
-    while ((opt = getopt(argc, argv, "b:v:U:")) != -1) {
+    while ((opt = getopt(argc, argv, "b:v:U:s")) != -1) {
         switch (opt) {
             case 'b':
                 backend = optarg;
@@ -73,7 +77,11 @@ client_test_init(
                 env->use_nfs = 1;
                 env->nfsvers = nfsvers;
                 break;
+            case 's':
+                env->use_smb = 1;
+                break;
             case 'U':
+                snprintf(env->user_spec, sizeof(env->user_spec), "%s", optarg);
                 if (!chimera_test_parse_user(optarg, &env->cred)) {
                     fprintf(stderr, "Unknown user spec '%s'. "
                             "Use: root, johndoe, myuser, or uid:gid\n", optarg);
@@ -108,7 +116,7 @@ client_test_init(
         fprintf(stderr, "to set session_dir uid/gid: %s\n", strerror(errno));
         exit(EXIT_FAILURE);
     }
-    if (env->use_nfs) {
+    if (env->use_nfs || env->use_smb) {
         server_config = chimera_server_config_init();
 
         if (strcmp(backend, "diskfs_io_uring") == 0 ||
@@ -199,11 +207,18 @@ client_test_init(
         }
 
         // Create NFSv3 server export entry
-        chimera_server_create_export(env->server, "/share", "/share");
+        if (env->use_nfs) {
+            chimera_server_create_export(env->server, "/share", "/share");
+        }
 
         chimera_server_start(env->server);
 
         chimera_test_add_server_users(env->server);
+
+        // Create the SMB share (must follow start + user setup)
+        if (env->use_smb) {
+            chimera_server_create_share(env->server, "share", "share", 0);
+        }
     } else {
         env->server = NULL;
     }
@@ -219,7 +234,18 @@ client_test_init(
         client_json_root   = json_object();
         client_json_config = json_object();
 
-        if (!env->use_nfs) {
+        /* SMB mode: register the (built-in) smb client VFS module so the client
+         * can mount "smb"; the backend is served remotely over SMB. */
+        if (env->use_smb) {
+            json_t *vfs       = json_object();
+            json_t *vfs_entry = json_object();
+            json_object_set_new(vfs_entry, "path", json_string(""));
+            json_object_set_new(vfs_entry, "config", json_string(""));
+            json_object_set_new(vfs, "smb", vfs_entry);
+            json_object_set_new(client_json_config, "vfs", vfs);
+        }
+
+        if (!env->use_nfs && !env->use_smb) {
             if (strcmp(backend, "diskfs_io_uring") == 0 ||
                 strcmp(backend, "diskfs_aio") == 0) {
                 char        diskfs_cfg[4096];
@@ -361,7 +387,21 @@ client_test_mount(
     chimera_mount_callback_t callback,
     void                    *private_data)
 {
-    if (env->use_nfs) {
+    if (env->use_smb) {
+        char        smb_opts[256];
+        const char *smbpasswd;
+
+        /* The test users registered by chimera_test_add_server_users carry the
+         * SMB passwords below; map the -U user spec to its password. */
+        if (strcmp(env->user_spec, "myuser") == 0) {
+            smbpasswd = CHIMERA_TEST_USER_MYUSER_SMBPASSWD;
+        } else {
+            smbpasswd = CHIMERA_TEST_USER_SMBPASSWD;
+        }
+
+        snprintf(smb_opts, sizeof(smb_opts), "user=%s,password=%s", env->user_spec, smbpasswd);
+        chimera_mount(env->client_thread, mount_path, "smb", "127.0.0.1:share", smb_opts, callback, private_data);
+    } else if (env->use_nfs) {
         char nfs_path[256];
         snprintf(nfs_path, sizeof(nfs_path), "127.0.0.1:/share");
         chimera_mount(env->client_thread, mount_path, "nfs", nfs_path, NULL, callback, private_data);

--- a/src/client/tests/test_io.c
+++ b/src/client/tests/test_io.c
@@ -1,0 +1,300 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * Exercises the SMB client data path + deep paths under a path-only mount:
+ * mkdir a nested directory, create + write a file two levels deep, read it back
+ * and verify the bytes, then readdir the parent and assert the entry shows up.
+ */
+
+#include <string.h>
+#include <stdlib.h>
+#include "client_test_common.h"
+
+struct simple_ctx {
+    int                             done;
+    enum chimera_vfs_error          status;
+    struct chimera_vfs_open_handle *handle;
+    struct evpl                    *evpl;
+    uint32_t                        rlen;
+    char                            rbuf[4096];
+    char                           *rdyn;     /* large-IO landing buffer (optional) */
+    uint32_t                        rdyn_max;
+};
+
+static void
+mount_cb(
+    struct chimera_client_thread *client,
+    enum chimera_vfs_error        status,
+    void                         *private_data)
+{
+    struct simple_ctx *ctx = private_data;
+
+    ctx->status = status;
+    ctx->done   = 1;
+} /* mount_cb */
+
+static void
+open_cb(
+    struct chimera_client_thread   *client,
+    enum chimera_vfs_error          status,
+    struct chimera_vfs_open_handle *oh,
+    void                           *private_data)
+{
+    struct simple_ctx *ctx = private_data;
+
+    ctx->status = status;
+    ctx->handle = oh;
+    ctx->done   = 1;
+} /* open_cb */
+
+static void
+mkdir_cb(
+    struct chimera_client_thread *client,
+    enum chimera_vfs_error        status,
+    void                         *private_data)
+{
+    struct simple_ctx *ctx = private_data;
+
+    ctx->status = status;
+    ctx->done   = 1;
+} /* mkdir_cb */
+
+static void
+write_cb(
+    struct chimera_client_thread *client,
+    enum chimera_vfs_error        status,
+    void                         *private_data)
+{
+    struct simple_ctx *ctx = private_data;
+
+    ctx->status = status;
+    ctx->done   = 1;
+} /* write_cb */
+
+static void
+read_cb(
+    struct chimera_client_thread *client,
+    enum chimera_vfs_error        status,
+    struct evpl_iovec            *iov,
+    int                           niov,
+    void                         *private_data)
+{
+    struct simple_ctx *ctx = private_data;
+    char              *dst = ctx->rdyn ? ctx->rdyn : ctx->rbuf;
+    uint32_t           cap = ctx->rdyn ? ctx->rdyn_max : (uint32_t) sizeof(ctx->rbuf);
+    uint32_t           off = 0;
+    int                i;
+
+    ctx->status = status;
+    ctx->rlen   = 0;
+
+    for (i = 0; i < niov; i++) {
+        if (status == CHIMERA_VFS_OK) {
+            uint32_t len = iov[i].length;
+
+            if (off + len > cap) {
+                len = cap - off;
+            }
+            memcpy(dst + off, iov[i].data, len);
+            off += len;
+        }
+        evpl_iovec_release(ctx->evpl, &iov[i]);
+    }
+    ctx->rlen = off;
+    ctx->done = 1;
+} /* read_cb */
+
+struct readdir_ctx {
+    int done;
+    enum chimera_vfs_error status;
+    int found_b;
+    int count;
+};
+
+static int
+readdir_entry_cb(
+    struct chimera_client_thread *thread,
+    const struct chimera_dirent  *dirent,
+    void                         *private_data)
+{
+    struct readdir_ctx *ctx = private_data;
+
+    ctx->count++;
+    if (dirent->namelen == 1 && dirent->name[0] == 'b') {
+        ctx->found_b = 1;
+    }
+    return 0;
+} /* readdir_entry_cb */
+
+static void
+readdir_complete_cb(
+    struct chimera_client_thread *thread,
+    enum chimera_vfs_error        status,
+    uint64_t                      cookie,
+    int                           eof,
+    void                         *private_data)
+{
+    struct readdir_ctx *ctx = private_data;
+
+    ctx->status = status;
+    ctx->done   = 1;
+} /* readdir_complete_cb */
+
+#define RUN(ctx)       do { (ctx).done = 0; } while (0)
+#define WAIT(env, ctx) do { while (!(ctx).done) { evpl_continue((env).evpl); } } while (0)
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    struct test_env    env;
+    struct simple_ctx  c;
+    struct readdir_ctx rc;
+    const char        *payload = "the quick brown fox jumps over the lazy dog";
+    uint32_t           plen    = (uint32_t) strlen(payload);
+
+    client_test_init(&env, argv, argc);
+
+    memset(&c, 0, sizeof(c));
+    c.evpl = env.evpl;
+
+    RUN(c);
+    client_test_mount(&env, "/test", mount_cb, &c);
+    WAIT(env, c);
+    if (c.status != 0) {
+        fprintf(stderr, "mount failed: %d\n", c.status);
+        client_test_fail(&env);
+    }
+
+    /* Deep paths under a path-only mount: mkdir /test/a then /test/a/b. */
+    RUN(c);
+    chimera_mkdir(env.client_thread, "/test/a", 7, mkdir_cb, &c);
+    WAIT(env, c);
+    if (c.status != 0) {
+        fprintf(stderr, "mkdir /test/a failed: %d\n", c.status);
+        client_test_fail(&env);
+    }
+
+    RUN(c);
+    chimera_mkdir(env.client_thread, "/test/a/b", 9, mkdir_cb, &c);
+    WAIT(env, c);
+    if (c.status != 0) {
+        fprintf(stderr, "mkdir /test/a/b (deep) failed: %d\n", c.status);
+        client_test_fail(&env);
+    }
+
+    /* Create a file two levels deep, write, read back, verify. */
+    RUN(c);
+    chimera_open(env.client_thread, "/test/a/b/file", 14, CHIMERA_VFS_OPEN_CREATE,
+                 open_cb, &c);
+    WAIT(env, c);
+    if (c.status != 0 || !c.handle) {
+        fprintf(stderr, "create deep file failed: %d\n", c.status);
+        client_test_fail(&env);
+    }
+
+    struct chimera_vfs_open_handle *fh = c.handle;
+
+    RUN(c);
+    chimera_write(env.client_thread, fh, 0, plen, payload, write_cb, &c);
+    WAIT(env, c);
+    if (c.status != 0) {
+        fprintf(stderr, "write failed: %d\n", c.status);
+        client_test_fail(&env);
+    }
+
+    RUN(c);
+    chimera_read(env.client_thread, fh, 0, plen, read_cb, &c);
+    WAIT(env, c);
+    if (c.status != 0 || c.rlen != plen || memcmp(c.rbuf, payload, plen) != 0) {
+        fprintf(stderr, "read-back mismatch: status %d len %u/%u\n",
+                c.status, c.rlen, plen);
+        client_test_fail(&env);
+    }
+    fprintf(stderr, "deep-path write/read round-trip verified (%u bytes)\n", plen);
+
+    chimera_close(env.client_thread, fh);
+
+    /* Large IO: exercise read/write chunking (well above the 64 KiB write PDU
+     * and not a chunk multiple, so the last chunk is partial). */
+    {
+        uint32_t big = 300000;
+        char    *src = malloc(big);
+        char    *dst = malloc(big);
+        uint32_t k;
+
+        for (k = 0; k < big; k++) {
+            src[k] = (char) ((k * 2654435761u) >> 24);
+        }
+
+        RUN(c);
+        chimera_open(env.client_thread, "/test/a/b/big", 13, CHIMERA_VFS_OPEN_CREATE,
+                     open_cb, &c);
+        WAIT(env, c);
+        if (c.status != 0 || !c.handle) {
+            fprintf(stderr, "create big file failed: %d\n", c.status);
+            client_test_fail(&env);
+        }
+        fh = c.handle;
+
+        RUN(c);
+        chimera_write(env.client_thread, fh, 0, big, src, write_cb, &c);
+        WAIT(env, c);
+        if (c.status != 0) {
+            fprintf(stderr, "big write failed: %d\n", c.status);
+            client_test_fail(&env);
+        }
+
+        RUN(c);
+        c.rdyn     = dst;
+        c.rdyn_max = big;
+        chimera_read(env.client_thread, fh, 0, big, read_cb, &c);
+        WAIT(env, c);
+        c.rdyn = NULL;
+        if (c.status != 0 || c.rlen != big || memcmp(dst, src, big) != 0) {
+            fprintf(stderr, "big read-back mismatch: status %d len %u/%u\n",
+                    c.status, c.rlen, big);
+            client_test_fail(&env);
+        }
+        fprintf(stderr, "large-IO chunked write/read round-trip verified (%u bytes)\n", big);
+
+        chimera_close(env.client_thread, fh);
+        free(src);
+        free(dst);
+    }
+
+    /* readdir /test/a should list "b". */
+    RUN(c);
+    chimera_open(env.client_thread, "/test/a", 7, CHIMERA_VFS_OPEN_DIRECTORY,
+                 open_cb, &c);
+    WAIT(env, c);
+    if (c.status != 0 || !c.handle) {
+        fprintf(stderr, "open dir /test/a failed: %d\n", c.status);
+        client_test_fail(&env);
+    }
+
+    memset(&rc, 0, sizeof(rc));
+    chimera_readdir(env.client_thread, c.handle, 0,
+                    readdir_entry_cb, readdir_complete_cb, &rc);
+    while (!rc.done) {
+        evpl_continue(env.evpl);
+    }
+    chimera_close(env.client_thread, c.handle);
+
+    if (rc.status != 0 || !rc.found_b) {
+        fprintf(stderr, "readdir of /test/a failed: status %d count %d found_b %d\n",
+                rc.status, rc.count, rc.found_b);
+        client_test_fail(&env);
+    }
+    fprintf(stderr, "readdir verified (%d entries, found 'b')\n", rc.count);
+
+    RUN(c);
+    chimera_umount(env.client_thread, "/test", mount_cb, &c);
+    WAIT(env, c);
+
+    client_test_success(&env);
+    return 0;
+} /* main */

--- a/src/vfs/CMakeLists.txt
+++ b/src/vfs/CMakeLists.txt
@@ -52,6 +52,7 @@ add_subdirectory(memfs)
 add_subdirectory(memkv)
 add_subdirectory(linux)
 add_subdirectory(nfs)
+add_subdirectory(smb)
 
 if (CHIMERA_VFS_IO_URING)
     add_subdirectory(io_uring)
@@ -77,7 +78,7 @@ endif()
 
 target_link_libraries(chimera_vfs
     chimera_vfs_root chimera_vfs_memfs chimera_vfs_memkv chimera_vfs_linux chimera_vfs_diskfs
-    chimera_vfs_nfs
+    chimera_vfs_nfs chimera_vfs_smb
     chimera_common prometheus-c xxhash dl urcu-qsbr)
 
 if (CHIMERA_VFS_IO_URING)

--- a/src/vfs/smb/CMakeLists.txt
+++ b/src/vfs/smb/CMakeLists.txt
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+#
+# SPDX-License-Identifier: LGPL-2.1-only
+
+add_library(chimera_vfs_smb SHARED
+    smb.c
+    smb_mount.c
+    smb_umount.c
+    smb_ops.c
+    smb_io.c
+    smb_namespace.c
+    smb_ntlm.c
+)
+
+target_link_libraries(chimera_vfs_smb chimera_common evpl crypto)
+
+install(TARGETS chimera_vfs_smb DESTINATION lib)
+
+if (NOT DISABLE_TESTS)
+    add_subdirectory(tests)
+endif()

--- a/src/vfs/smb/smb.c
+++ b/src/vfs/smb/smb.c
@@ -1,0 +1,1060 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <pthread.h>
+
+#include <openssl/evp.h>
+#include <openssl/core_names.h>
+#include <openssl/params.h>
+#include <openssl/kdf.h>
+
+#include "smb.h"
+#include "smb_internal.h"
+#include "common/macros.h"
+#include "common/tcp_flavor.h"
+#include "evpl/evpl.h"
+
+static const uint8_t SMB2_PROTOCOL_ID[4] = { 0xFE, 'S', 'M', 'B' };
+
+/* ---- SMB3 signing primitives ------------------------------------------- *
+ *
+ * These mirror the server's src/server/smb/smb_signing.c exactly so the two
+ * sides compute identical MACs.  The client signs a single CONTIGUOUS SMB2
+ * message in place (one iovec from pdu_begin) and verifies a single contiguous
+ * received message, so we operate on a flat (hdr, body) buffer rather than the
+ * server's compound/iovec-cursor machinery.  Same KDF, same fields zeroed.
+ */
+
+void
+chimera_smb_client_preauth_extend(
+    uint8_t    *hash,
+    const void *msg,
+    uint32_t    msg_len)
+{
+    EVP_MD_CTX  *md      = EVP_MD_CTX_new();
+    unsigned int out_len = 0;
+
+    chimera_smbclient_abort_if(!md, "EVP_MD_CTX_new failed");
+
+    if (EVP_DigestInit_ex(md, EVP_sha512(), NULL) != 1 ||
+        EVP_DigestUpdate(md, hash, SMB2_PREAUTH_HASH_SIZE) != 1 ||
+        EVP_DigestUpdate(md, msg, msg_len) != 1 ||
+        EVP_DigestFinal_ex(md, hash, &out_len) != 1) {
+        chimera_smbclient_fatal("SHA-512 preauth hash update failed");
+    }
+    EVP_MD_CTX_free(md);
+} /* chimera_smb_client_preauth_extend */
+
+/* SP800-108 counter-mode KDF with HMAC-SHA256 (OpenSSL KBKDF).  Identical to
+ * the server's kdf_counter_hmac_sha256_ossl3: USE_L + USE_SEPARATOR on, label
+ * passed as SALT, context as INFO. */
+static int
+chimera_smb_client_kbkdf(
+    const uint8_t *key,
+    size_t         key_len,
+    const void    *label,
+    size_t         label_len,
+    const uint8_t *context,
+    size_t         ctx_len,
+    uint8_t       *out,
+    size_t         out_len)
+{
+    EVP_KDF     *kdf = EVP_KDF_fetch(NULL, "KBKDF", NULL);
+    EVP_KDF_CTX *kctx;
+    OSSL_PARAM   params[10];
+    size_t       n       = 0;
+    int          use_l   = 1;
+    int          use_sep = 1;
+    int          ok      = 0;
+
+    if (!kdf) {
+        return -1;
+    }
+    kctx = EVP_KDF_CTX_new(kdf);
+    EVP_KDF_free(kdf);
+    if (!kctx) {
+        return -1;
+    }
+
+    params[n++] = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_MODE, (char *) "counter", 0);
+    params[n++] = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_MAC, (char *) "HMAC", 0);
+    params[n++] = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_DIGEST, (char *) "SHA256", 0);
+    params[n++] = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_KEY, (void *) key, key_len);
+    if (label && label_len) {
+        params[n++] = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_SALT, (void *) label, label_len);
+    }
+    if (context && ctx_len) {
+        params[n++] = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_INFO, (void *) context, ctx_len);
+    }
+    params[n++] = OSSL_PARAM_construct_int(OSSL_KDF_PARAM_KBKDF_USE_L, &use_l);
+    params[n++] = OSSL_PARAM_construct_int(OSSL_KDF_PARAM_KBKDF_USE_SEPARATOR, &use_sep);
+    params[n++] = OSSL_PARAM_construct_end();
+
+    if (EVP_KDF_derive(kctx, out, out_len, params) == 1) {
+        ok = 1;
+    }
+    EVP_KDF_CTX_free(kctx);
+    return ok ? 0 : -1;
+} /* chimera_smb_client_kbkdf */
+
+int
+chimera_smb_client_derive_signing_key(
+    uint16_t       dialect,
+    const uint8_t *session_key,
+    size_t         session_key_len,
+    const uint8_t *preauth_hash,
+    uint8_t       *out_key16)
+{
+    static const char label30[]  = "SMB2AESCMAC";   /* include NUL per spec */
+    static const char ctx30[]    = "SmbSign";       /* include NUL per spec */
+    static const char label311[] = "SMBSigningKey"; /* include NUL per spec */
+
+    switch (dialect) {
+        case SMB2_DIALECT_2_0_2:
+        case SMB2_DIALECT_2_1:
+            /* 2.x signs with the raw session key (HMAC-SHA256); no KDF. */
+            if (session_key_len < 16) {
+                return -1;
+            }
+            memcpy(out_key16, session_key, 16);
+            return 0;
+        case SMB2_DIALECT_3_0:
+        case SMB2_DIALECT_3_0_2:
+            return chimera_smb_client_kbkdf(session_key, session_key_len,
+                                            label30, sizeof(label30),
+                                            (const uint8_t *) ctx30, sizeof(ctx30),
+                                            out_key16, 16);
+        case SMB2_DIALECT_3_1_1:
+            if (!preauth_hash) {
+                return -1;
+            }
+            return chimera_smb_client_kbkdf(session_key, session_key_len,
+                                            label311, sizeof(label311),
+                                            preauth_hash, SMB2_PREAUTH_HASH_SIZE,
+                                            out_key16, 16);
+        default:
+            return -1;
+    } /* switch */
+} /* chimera_smb_client_derive_signing_key */
+
+/* HMAC-SHA256 (2.x / 3.1.1-HMAC) over hdr||body, first 16 bytes -> out_sig16. */
+static int
+chimera_smb_client_hmac_sha256(
+    const struct smb2_header *hdr,
+    const uint8_t            *body,
+    int                       body_len,
+    const uint8_t            *key,
+    uint8_t                  *out_sig16)
+{
+    EVP_MAC      *mac;
+    EVP_MAC_CTX  *mctx;
+    OSSL_PARAM    params[] = {
+        OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_DIGEST, (char *) "SHA256", 0),
+        OSSL_PARAM_construct_end()
+    };
+    unsigned char macbuf[32];
+    size_t        maclen = 0;
+    int           rc     = -1;
+
+    mac = EVP_MAC_fetch(NULL, "HMAC", NULL);
+    if (!mac) {
+        return -1;
+    }
+    mctx = EVP_MAC_CTX_new(mac);
+    EVP_MAC_free(mac);
+    if (!mctx) {
+        return -1;
+    }
+    if (EVP_MAC_init(mctx, key, 16, params) == 1 &&
+        EVP_MAC_update(mctx, (const uint8_t *) hdr, sizeof(*hdr)) == 1 &&
+        (body_len == 0 || EVP_MAC_update(mctx, body, body_len) == 1) &&
+        EVP_MAC_final(mctx, macbuf, &maclen, sizeof(macbuf)) == 1 &&
+        maclen >= 16) {
+        memcpy(out_sig16, macbuf, 16);
+        rc = 0;
+    }
+    EVP_MAC_CTX_free(mctx);
+    return rc;
+} /* chimera_smb_client_hmac_sha256 */
+
+/* AES-128-CMAC (3.0 / 3.0.2 / 3.1.1-CMAC) over hdr||body -> out_sig16. */
+static int
+chimera_smb_client_cmac_aes128(
+    const struct smb2_header *hdr,
+    const uint8_t            *body,
+    int                       body_len,
+    const uint8_t            *key,
+    uint8_t                  *out_sig16)
+{
+    EVP_MAC     *mac;
+    EVP_MAC_CTX *mctx;
+    OSSL_PARAM   params[] = {
+        OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_CIPHER, (char *) "AES-128-CBC", 0),
+        OSSL_PARAM_construct_end()
+    };
+    size_t       maclen = 0;
+    int          rc     = -1;
+
+    mac = EVP_MAC_fetch(NULL, "CMAC", NULL);
+    if (!mac) {
+        return -1;
+    }
+    mctx = EVP_MAC_CTX_new(mac);
+    EVP_MAC_free(mac);
+    if (!mctx) {
+        return -1;
+    }
+    if (EVP_MAC_init(mctx, key, 16, params) == 1 &&
+        EVP_MAC_update(mctx, (const uint8_t *) hdr, sizeof(*hdr)) == 1 &&
+        (body_len == 0 || EVP_MAC_update(mctx, body, body_len) == 1) &&
+        EVP_MAC_final(mctx, out_sig16, &maclen, 16) == 1 &&
+        maclen == 16) {
+        rc = 0;
+    }
+    EVP_MAC_CTX_free(mctx);
+    return rc;
+} /* chimera_smb_client_cmac_aes128 */
+
+/* AES-128-GMAC (3.1.1-GMAC) over hdr||body -> out_sig16 (MS-SMB2 §3.1.4.1).
+ * The 12-byte IV is MessageId(8) || flags-derived(4): SERVER_TO_REDIR (+ASYNC
+ * for CANCEL).  AAD = full 64-byte header (signature zeroed) followed by body;
+ * the 16-byte GCM tag is the signature.  Mirrors the server exactly. */
+static int
+chimera_smb_client_gmac_aes128(
+    const struct smb2_header *hdr,
+    const uint8_t            *body,
+    int                       body_len,
+    const uint8_t            *key,
+    uint8_t                  *out_sig16)
+{
+    EVP_CIPHER     *gcm;
+    EVP_CIPHER_CTX *c;
+    uint8_t         iv[12];
+    uint32_t        high_bits;
+    int             outl;
+    int             rc = -1;
+
+    high_bits = hdr->flags & SMB2_FLAGS_SERVER_TO_REDIR;
+    if (hdr->command == SMB2_CANCEL) {
+        high_bits |= SMB2_FLAGS_ASYNC_COMMAND;
+    }
+
+    memset(iv, 0, sizeof(iv));
+    memcpy(iv, &hdr->message_id, 8);
+    iv[8]  = (uint8_t) (high_bits & 0xff);
+    iv[9]  = (uint8_t) ((high_bits >> 8) & 0xff);
+    iv[10] = (uint8_t) ((high_bits >> 16) & 0xff);
+    iv[11] = (uint8_t) ((high_bits >> 24) & 0xff);
+
+    gcm = EVP_CIPHER_fetch(NULL, "AES-128-GCM", NULL);
+    if (!gcm) {
+        return -1;
+    }
+    c = EVP_CIPHER_CTX_new();
+    if (!c) {
+        EVP_CIPHER_free(gcm);
+        return -1;
+    }
+    if (EVP_EncryptInit_ex(c, gcm, NULL, NULL, NULL) == 1 &&
+        EVP_CIPHER_CTX_ctrl(c, EVP_CTRL_GCM_SET_IVLEN, sizeof(iv), NULL) == 1 &&
+        EVP_EncryptInit_ex(c, NULL, NULL, key, iv) == 1 &&
+        EVP_EncryptUpdate(c, NULL, &outl, (const uint8_t *) hdr, sizeof(*hdr)) == 1 &&
+        (body_len == 0 || EVP_EncryptUpdate(c, NULL, &outl, body, body_len) == 1) &&
+        EVP_EncryptFinal_ex(c, NULL, &outl) == 1 &&
+        EVP_CIPHER_CTX_ctrl(c, EVP_CTRL_GCM_GET_TAG, 16, out_sig16) == 1) {
+        rc = 0;
+    }
+    EVP_CIPHER_CTX_free(c);
+    EVP_CIPHER_free(gcm);
+    return rc;
+} /* chimera_smb_client_gmac_aes128 */
+
+/* Dispatch to the negotiated algorithm.  `dialect`/`signing_alg` come from the
+ * shared session (server struct).  Computes over hdr (signature must already be
+ * zeroed by the caller) plus body. */
+static int
+chimera_smb_client_compute_signature(
+    uint16_t                  dialect,
+    uint16_t                  signing_alg,
+    const struct smb2_header *hdr,
+    const uint8_t            *body,
+    int                       body_len,
+    const uint8_t            *key,
+    uint8_t                  *out_sig16)
+{
+    switch (dialect) {
+        case SMB2_DIALECT_2_0_2:
+        case SMB2_DIALECT_2_1:
+            return chimera_smb_client_hmac_sha256(hdr, body, body_len, key, out_sig16);
+        case SMB2_DIALECT_3_0:
+        case SMB2_DIALECT_3_0_2:
+            return chimera_smb_client_cmac_aes128(hdr, body, body_len, key, out_sig16);
+        case SMB2_DIALECT_3_1_1:
+            switch (signing_alg) {
+                case SMB2_SIGNING_AES_GMAC:
+                    return chimera_smb_client_gmac_aes128(hdr, body, body_len, key, out_sig16);
+                case SMB2_SIGNING_HMAC_SHA256:
+                    return chimera_smb_client_hmac_sha256(hdr, body, body_len, key, out_sig16);
+                default: /* SMB2_SIGNING_AES_CMAC */
+                    return chimera_smb_client_cmac_aes128(hdr, body, body_len, key, out_sig16);
+            } /* switch */
+        default:
+            return -1;
+    } /* switch */
+} /* chimera_smb_client_compute_signature */
+
+/* Sign a contiguous SMB2 message in place: set SMB2_FLAGS_SIGNED, zero the
+ * signature field, compute the MAC over the message, write it back. */
+static int
+chimera_smb_client_sign_inplace(
+    uint16_t            dialect,
+    uint16_t            signing_alg,
+    const uint8_t      *key,
+    struct smb2_header *hdr,
+    int                 smb2_len)
+{
+    uint8_t signature[16];
+    int     body_len = smb2_len - (int) sizeof(*hdr);
+    int     rc;
+
+    if (body_len < 0) {
+        return -1;
+    }
+    hdr->flags |= SMB2_FLAGS_SIGNED;
+    memset(hdr->signature, 0, sizeof(hdr->signature));
+
+    rc = chimera_smb_client_compute_signature(dialect, signing_alg, hdr,
+                                              (const uint8_t *) (hdr + 1), body_len,
+                                              key, signature);
+    if (rc != 0) {
+        return rc;
+    }
+    memcpy(hdr->signature, signature, sizeof(signature));
+    return 0;
+} /* chimera_smb_client_sign_inplace */
+
+/* Verify a contiguous received SMB2 message.  `hdr` points at a private copy of
+ * the 64-byte header (so we can zero its signature without touching the wire
+ * buffer); `body` is the message body.  Returns 0 if the signature matches. */
+static int
+chimera_smb_client_verify(
+    uint16_t            dialect,
+    uint16_t            signing_alg,
+    const uint8_t      *key,
+    struct smb2_header *hdr,
+    const uint8_t      *body,
+    int                 body_len)
+{
+    uint8_t received[16];
+    uint8_t calculated[16];
+    int     rc;
+
+    memcpy(received, hdr->signature, sizeof(received));
+    memset(hdr->signature, 0, sizeof(hdr->signature));
+
+    rc = chimera_smb_client_compute_signature(dialect, signing_alg, hdr,
+                                              body, body_len, key, calculated);
+    if (rc != 0) {
+        return rc;
+    }
+    return memcmp(received, calculated, sizeof(received)) == 0 ? 0 : -1;
+} /* chimera_smb_client_verify */
+
+/* ---- module lifecycle -------------------------------------------------- */
+
+static void *
+chimera_smb_client_init(
+    const char                *cfgdata,
+    struct prometheus_metrics *metrics)
+{
+    struct chimera_smb_client_shared *shared = calloc(1, sizeof(*shared));
+
+    (void) cfgdata;
+    (void) metrics;
+
+    pthread_mutex_init(&shared->lock, NULL);
+
+    shared->max_servers  = CHIMERA_SMB_CLIENT_MAX_SERVERS;
+    shared->servers      = calloc(shared->max_servers, sizeof(*shared->servers));
+    shared->tcp_protocol = EVPL_STREAM_SOCKET_TCP;
+
+    return shared;
+} /* chimera_smb_client_init */
+
+static void
+chimera_smb_client_destroy(void *private_data)
+{
+    struct chimera_smb_client_shared *shared = private_data;
+    int                               i;
+
+    for (i = 0; i < shared->max_servers; i++) {
+        if (shared->servers[i]) {
+            if (shared->servers[i]->endpoint) {
+                evpl_endpoint_close(shared->servers[i]->endpoint);
+            }
+            free(shared->servers[i]);
+        }
+    }
+
+    pthread_mutex_destroy(&shared->lock);
+    free(shared->servers);
+    free(shared);
+} /* chimera_smb_client_destroy */
+
+static void *
+chimera_smb_client_thread_init(
+    struct evpl *evpl,
+    void        *private_data)
+{
+    struct chimera_smb_client_shared *shared = private_data;
+    struct chimera_smb_client_thread *thread = calloc(1, sizeof(*thread));
+
+    thread->evpl      = evpl;
+    thread->shared    = shared;
+    thread->max_conns = shared->max_servers;
+    thread->conns     = calloc(thread->max_conns, sizeof(*thread->conns));
+
+    return thread;
+} /* chimera_smb_client_thread_init */
+
+static void
+chimera_smb_client_thread_destroy(void *private_data)
+{
+    struct chimera_smb_client_thread *thread = private_data;
+    struct chimera_smb_client_conn   *conn;
+
+    /* Detach every connection from this thread and close any still-open binds.
+     * The conns are NOT freed here: their DISCONNECTED notify (which frees them)
+     * is delivered later by evpl_destroy, after this thread struct is gone -- so
+     * we null conn->thread to keep that notify from dereferencing freed state. */
+    for (conn = thread->conns_list; conn; conn = conn->list_next) {
+        conn->thread = NULL;
+        if (conn->bind && !conn->closing) {
+            conn->closing = 1;
+            evpl_close(thread->evpl, conn->bind);
+        }
+    }
+
+    free(thread->conns);
+    free(thread);
+} /* chimera_smb_client_thread_destroy */
+
+/* ---- transport --------------------------------------------------------- */
+
+void
+chimera_smb_client_pdu_begin(
+    struct chimera_smb_client_conn *conn,
+    uint16_t                        command,
+    struct evpl_iovec              *iov,
+    struct evpl_iovec_cursor       *cursor,
+    struct smb2_header            **hdr)
+{
+    struct smb2_header *h;
+
+    evpl_iovec_alloc(conn->evpl, 65536, 8, 1, 0, iov);
+
+    evpl_iovec_cursor_init(cursor, iov, 1);
+
+    /* Reserve the NetBIOS framing prefix, then make the SMB2 header the origin
+     * for the consumed-relative field alignment (matches the server). */
+    evpl_iovec_cursor_skip(cursor, sizeof(struct smb_client_netbios_header));
+    evpl_iovec_cursor_reset_consumed(cursor);
+
+    h = evpl_iovec_cursor_data(cursor);
+    evpl_iovec_cursor_skip(cursor, sizeof(struct smb2_header));
+
+    memset(h, 0, sizeof(*h));
+    memcpy(h->protocol_id, SMB2_PROTOCOL_ID, 4);
+    h->struct_size             = 64;
+    h->credit_charge           = 1;
+    h->status                  = 0;
+    h->command                 = command;
+    h->credit_request_response = 256;
+    h->flags                   = 0;
+    h->next_command            = 0;
+    h->message_id              = conn->next_message_id++;
+    h->sync.process_id         = 0;
+    h->sync.tree_id            = conn->server->tree_id;
+    h->session_id              = conn->server->session_id;
+
+    *hdr = h;
+} /* chimera_smb_client_pdu_begin */
+
+/* Sign (if the session has signing on), frame with the NetBIOS length, and send
+ * a finished SMB2 PDU.  Shared by pdu_finish and server-initiated replies (the
+ * OPLOCK_BREAK ack) that send without registering a pending reply. */
+static void
+chimera_smb_client_sign_frame_send(
+    struct chimera_smb_client_conn *conn,
+    struct evpl_iovec              *iov,
+    int                             smb2_len)
+{
+    struct smb_client_netbios_header *netbios = evpl_iovec_data(iov);
+    struct smb2_header               *hdr     = (struct smb2_header *) (netbios + 1);
+    int                               total   = smb2_len + (int) sizeof(*netbios);
+
+    /* Sign the outgoing PDU once a signing key exists for the session (3.x with
+     * signing on).  NEGOTIATE and SESSION_SETUP are never signed: they run
+     * before the key is derived.  The 2.x unsigned path leaves signing_active
+     * clear and skips this entirely. */
+    if (conn->server->signing_active &&
+        hdr->command != SMB2_NEGOTIATE &&
+        hdr->command != SMB2_SESSION_SETUP) {
+        if (chimera_smb_client_sign_inplace(conn->server->dialect,
+                                            conn->server->signing_alg,
+                                            conn->server->signing_key,
+                                            hdr, smb2_len) != 0) {
+            chimera_smbclient_error("Failed to sign outgoing SMB2 PDU (command %u)", hdr->command);
+        }
+    }
+
+    netbios->word = __builtin_bswap32((uint32_t) smb2_len);
+
+    evpl_iovec_set_length(iov, total);
+
+    evpl_sendv(conn->evpl, conn->bind, iov, 1, total, EVPL_SEND_FLAG_TAKE_REF);
+} /* chimera_smb_client_sign_frame_send */
+
+void
+chimera_smb_client_pdu_finish(
+    struct chimera_smb_client_conn *conn,
+    struct evpl_iovec              *iov,
+    struct evpl_iovec_cursor       *cursor,
+    struct chimera_vfs_request     *request,
+    chimera_smb_client_reply_cb     reply_cb,
+    void                           *reply_arg)
+{
+    struct smb_client_netbios_header  *netbios = evpl_iovec_data(iov);
+    struct smb2_header                *hdr     = (struct smb2_header *) (netbios + 1);
+    struct chimera_smb_client_pending *pending;
+    int                                smb2_len = evpl_iovec_cursor_consumed(cursor);
+
+    pending             = calloc(1, sizeof(*pending));
+    pending->message_id = hdr->message_id;
+    pending->cb         = reply_cb;
+    pending->arg        = reply_arg;
+    pending->request    = request;
+    pending->next       = conn->pending;
+    conn->pending       = pending;
+
+    chimera_smb_client_sign_frame_send(conn, iov, smb2_len);
+} /* chimera_smb_client_pdu_finish */
+
+/* Server-initiated SMB2 OPLOCK_BREAK (lease-break notification): acknowledge it
+ * so the server can complete the conflicting open.  The client holds no client-
+ * side cache yet, so it simply concedes to the server's proposed NewLeaseState.
+ * (When the break does not require an ack, nothing is sent.) */
+static void
+chimera_smb_client_handle_oplock_break(
+    struct chimera_smb_client_conn *conn,
+    struct evpl_iovec_cursor       *body)
+{
+    struct evpl_iovec        iov;
+    struct evpl_iovec_cursor cursor;
+    struct smb2_header      *hdr;
+    uint16_t                 struct_size, new_epoch;
+    uint32_t                 flags, current_state, new_state;
+    uint8_t                  lease_key[16];
+    /* MS-SMB2 2.2.23.2 Flags bit (not exported in a shared header). */
+    const uint32_t           ACK_REQUIRED = 0x01;
+
+    evpl_iovec_cursor_get_uint16(body, &struct_size);
+
+    /* Only lease-variant breaks are expected (the client requests leases, not
+     * legacy oplocks); ignore anything else. */
+    if (struct_size != SMB2_OPLOCK_BREAK_NOTIFY_LEASE_SIZE) {
+        return;
+    }
+
+    evpl_iovec_cursor_get_uint16(body, &new_epoch);
+    evpl_iovec_cursor_get_uint32(body, &flags);
+    evpl_iovec_cursor_copy(body, lease_key, 16);
+    evpl_iovec_cursor_get_uint32(body, &current_state);
+    evpl_iovec_cursor_get_uint32(body, &new_state);
+
+    (void) new_epoch;
+    (void) current_state;
+
+    if (!(flags & ACK_REQUIRED)) {
+        return;
+    }
+
+    /* Lease-break ACK (MS-SMB2 2.2.24.2): StructureSize(36), Reserved(2),
+     * Flags(4), LeaseKey(16), LeaseState(4), LeaseDuration(8). */
+    chimera_smb_client_pdu_begin(conn, SMB2_OPLOCK_BREAK, &iov, &cursor, &hdr);
+
+    evpl_iovec_cursor_append_uint16(&cursor, SMB2_OPLOCK_BREAK_ACK_LEASE_SIZE);
+    evpl_iovec_cursor_append_uint16(&cursor, 0);             /* Reserved */
+    evpl_iovec_cursor_append_uint32(&cursor, 0);             /* Flags */
+    evpl_iovec_cursor_append_blob(&cursor, lease_key, 16);
+    evpl_iovec_cursor_append_uint32(&cursor, new_state);     /* concede to NewLeaseState */
+    evpl_iovec_cursor_append_uint64(&cursor, 0);             /* LeaseDuration */
+
+    chimera_smb_client_sign_frame_send(conn, &iov, evpl_iovec_cursor_consumed(&cursor));
+} /* chimera_smb_client_handle_oplock_break */
+
+static struct chimera_smb_client_pending *
+chimera_smb_client_pending_take(
+    struct chimera_smb_client_conn *conn,
+    uint64_t                        message_id)
+{
+    struct chimera_smb_client_pending **pp = &conn->pending;
+    struct chimera_smb_client_pending  *p;
+
+    while ((p = *pp)) {
+        if (p->message_id == message_id) {
+            *pp = p->next;
+            return p;
+        }
+        pp = &p->next;
+    }
+    return NULL;
+} /* chimera_smb_client_pending_take */
+
+static void
+chimera_smb_client_handle_recv(
+    struct chimera_smb_client_conn *conn,
+    struct evpl_iovec              *iov,
+    int                             niov,
+    int                             length)
+{
+    struct evpl_iovec_cursor           cursor;
+    struct smb_client_netbios_header   netbios;
+    struct smb2_header                 hdr;
+    struct chimera_smb_client_pending *pending;
+    int                                body_len;
+
+    if (length < (int) (sizeof(netbios) + sizeof(hdr))) {
+        chimera_smbclient_error("Received SMB2 reply too short (%d bytes)", length);
+        return;
+    }
+
+    evpl_iovec_cursor_init(&cursor, iov, niov);
+    evpl_iovec_cursor_copy(&cursor, &netbios, sizeof(netbios));
+
+    evpl_iovec_cursor_reset_consumed(&cursor);
+    evpl_iovec_cursor_copy(&cursor, &hdr, sizeof(hdr));
+
+    if (memcmp(hdr.protocol_id, SMB2_PROTOCOL_ID, 4) != 0) {
+        chimera_smbclient_error("Received reply with invalid SMB2 protocol id");
+        return;
+    }
+
+    body_len = length - (int) sizeof(netbios) - (int) sizeof(hdr);
+
+    /* Verify the signature on a signed reply once the session has a signing key.
+     * NEGOTIATE/SESSION_SETUP replies are exempt (the final SESSION_SETUP reply
+     * is signed by the server before the client commits the key; mirrors the
+     * server's verify-skip for these commands).  The cursor is currently
+     * positioned at the body start (consumed == sizeof(hdr)); copy the body out
+     * to a contiguous buffer for the MAC, then leave a fresh cursor for the cb. */
+    if (conn->server->signing_active &&
+        (hdr.flags & SMB2_FLAGS_SIGNED) &&
+        hdr.command != SMB2_NEGOTIATE &&
+        hdr.command != SMB2_SESSION_SETUP) {
+        uint8_t *body = NULL;
+        int      vrc;
+
+        if (body_len > 0) {
+            struct evpl_iovec_cursor body_cursor = cursor;
+            body = malloc(body_len);
+            if (!body) {
+                chimera_smbclient_error("Out of memory verifying SMB2 signature");
+                return;
+            }
+            evpl_iovec_cursor_copy(&body_cursor, body, body_len);
+        }
+
+        vrc = chimera_smb_client_verify(conn->server->dialect,
+                                        conn->server->signing_alg,
+                                        conn->server->signing_key,
+                                        &hdr, body, body_len);
+        free(body);
+
+        if (vrc != 0) {
+            chimera_smbclient_error("Received SMB2 reply with invalid signature "
+                                    "(command %u, message_id %lu)", hdr.command, hdr.message_id);
+            chimera_smb_client_conn_fail(conn, CHIMERA_VFS_EIO);
+            return;
+        }
+    }
+
+    /* A server-initiated OPLOCK_BREAK (lease break) is not a reply to any
+     * request -- handle it directly rather than matching a pending message_id. */
+    if (hdr.command == SMB2_OPLOCK_BREAK) {
+        chimera_smb_client_handle_oplock_break(conn, &cursor);
+        return;
+    }
+
+    pending = chimera_smb_client_pending_take(conn, hdr.message_id);
+    if (!pending) {
+        chimera_smbclient_error("Received SMB2 reply for unknown message_id %lu (command %u)",
+                                hdr.message_id, hdr.command);
+        return;
+    }
+
+    pending->cb(conn, hdr.status, &hdr, &cursor, body_len, pending->arg);
+
+    free(pending);
+} /* chimera_smb_client_handle_recv */
+
+/* Error-complete every request associated with a connection (in-flight,
+ * deferred, and the in-progress mount).  Does not close or free the conn. */
+static void
+chimera_smb_client_conn_drain(
+    struct chimera_smb_client_conn *conn,
+    enum chimera_vfs_error          status)
+{
+    struct chimera_smb_client_pending  *pending;
+    struct chimera_smb_client_deferred *deferred;
+
+    while ((pending = conn->pending)) {
+        conn->pending = pending->next;
+        if (pending->request) {
+            pending->request->status = status;
+            pending->request->complete(pending->request);
+        }
+        free(pending);
+    }
+
+    while ((deferred = conn->deferred)) {
+        conn->deferred            = deferred->next;
+        deferred->request->status = status;
+        deferred->request->complete(deferred->request);
+        free(deferred);
+    }
+
+    if (conn->mount_request) {
+        struct chimera_vfs_request *request = conn->mount_request;
+        conn->mount_request = NULL;
+        request->status     = status;
+        request->complete(request);
+    }
+} /* chimera_smb_client_conn_drain */
+
+void
+chimera_smb_client_conn_fail(
+    struct chimera_smb_client_conn *conn,
+    enum chimera_vfs_error          status)
+{
+    if (conn->state == CHIMERA_SMB_CONN_FAILED) {
+        return;
+    }
+    conn->state = CHIMERA_SMB_CONN_FAILED;
+
+    chimera_smb_client_conn_drain(conn, status);
+
+    if (conn->bind && !conn->closing) {
+        conn->closing = 1;
+        evpl_close(conn->evpl, conn->bind);
+    }
+} /* chimera_smb_client_conn_fail */
+
+void
+chimera_smb_client_conn_ready(struct chimera_smb_client_conn *conn)
+{
+    struct chimera_smb_client_deferred *deferred;
+
+    conn->state = CHIMERA_SMB_CONN_READY;
+
+    while ((deferred = conn->deferred)) {
+        conn->deferred = deferred->next;
+        deferred->start(conn, deferred->request);
+        free(deferred);
+    }
+} /* chimera_smb_client_conn_ready */
+
+static void
+chimera_smb_client_notify(
+    struct evpl        *evpl,
+    struct evpl_bind   *bind,
+    struct evpl_notify *notify,
+    void               *private_data)
+{
+    struct chimera_smb_client_conn *conn = private_data;
+    int                             i;
+
+    switch (notify->notify_type) {
+        case EVPL_NOTIFY_CONNECTED:
+            chimera_smb_client_conn_on_connected(conn);
+            break;
+        case EVPL_NOTIFY_DISCONNECTED:
+            /* The bind is being destroyed; error-complete anything still
+             * outstanding (no further close), then unlink and free the conn. */
+            conn->bind = NULL;
+            chimera_smb_client_conn_drain(conn, CHIMERA_VFS_EIO);
+
+            if (conn->thread) {
+                struct chimera_smb_client_thread *thread = conn->thread;
+                struct chimera_smb_client_conn  **pp     = &thread->conns_list;
+
+                while (*pp && *pp != conn) {
+                    pp = &(*pp)->list_next;
+                }
+                if (*pp) {
+                    *pp = conn->list_next;
+                }
+                if (thread->conns[conn->server->index] == conn) {
+                    thread->conns[conn->server->index] = NULL;
+                }
+            }
+
+            free(conn);
+            break;
+        case EVPL_NOTIFY_RECV_MSG:
+            chimera_smb_client_handle_recv(conn,
+                                           notify->recv_msg.iovec,
+                                           notify->recv_msg.niov,
+                                           notify->recv_msg.length);
+
+            for (i = 0; i < (int) notify->recv_msg.niov; i++) {
+                evpl_iovec_release(evpl, &notify->recv_msg.iovec[i]);
+            }
+            break;
+        case EVPL_NOTIFY_SENT:
+            break;
+    } /* switch */
+} /* chimera_smb_client_notify */
+
+static int
+chimera_smb_client_segment(
+    struct evpl      *evpl,
+    struct evpl_bind *bind,
+    void             *private_data)
+{
+    uint32_t hdr;
+    int      len;
+
+    (void) private_data;
+
+    len = evpl_peek(evpl, bind, &hdr, 4);
+    if (len < 4) {
+        return -1;
+    }
+
+    hdr  = __builtin_bswap32(hdr);
+    hdr &= 0x00ffffff;
+
+    return 4 + hdr;
+} /* chimera_smb_client_segment */
+
+struct evpl_bind *
+chimera_smb_client_connect(
+    struct chimera_smb_client_conn *conn,
+    struct evpl_endpoint           *endpoint)
+{
+    return evpl_connect(conn->evpl,
+                        conn->thread->shared->tcp_protocol,
+                        NULL,
+                        endpoint,
+                        chimera_smb_client_notify,
+                        chimera_smb_client_segment,
+                        conn);
+} /* chimera_smb_client_connect */
+
+/* ---- per-thread connection management ---------------------------------- */
+
+struct chimera_smb_client_conn *
+chimera_smb_client_get_conn(
+    struct chimera_smb_client_thread *thread,
+    struct chimera_smb_client_server *server)
+{
+    struct chimera_smb_client_conn *conn = thread->conns[server->index];
+
+    if (conn) {
+        return conn;
+    }
+
+    conn         = calloc(1, sizeof(*conn));
+    conn->thread = thread;
+    conn->evpl   = thread->evpl;
+    conn->server = server;
+    conn->state  = CHIMERA_SMB_CONN_NEW;
+
+    conn->list_next    = thread->conns_list;
+    thread->conns_list = conn;
+
+    thread->conns[server->index] = conn;
+
+    return conn;
+} /* chimera_smb_client_get_conn */
+
+void
+chimera_smb_client_ensure_ready(
+    struct chimera_smb_client_conn *conn,
+    struct chimera_vfs_request     *request,
+    chimera_smb_client_start_fn     start)
+{
+    struct chimera_smb_client_deferred *deferred;
+
+    if (conn->state == CHIMERA_SMB_CONN_READY) {
+        start(conn, request);
+        return;
+    }
+
+    if (conn->state == CHIMERA_SMB_CONN_FAILED) {
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+
+    /* NEW or CONNECTING: defer the op until the handshake completes. */
+    deferred          = calloc(1, sizeof(*deferred));
+    deferred->request = request;
+    deferred->start   = start;
+    deferred->next    = conn->deferred;
+    conn->deferred    = deferred;
+
+    if (conn->state == CHIMERA_SMB_CONN_NEW) {
+        conn->state = CHIMERA_SMB_CONN_CONNECTING;
+        conn->bind  = chimera_smb_client_connect(conn, conn->server->endpoint);
+    }
+} /* chimera_smb_client_ensure_ready */
+
+/* ---- dispatch ---------------------------------------------------------- */
+
+static void
+chimera_smb_client_dispatch(
+    struct chimera_vfs_request *request,
+    void                       *private_data)
+{
+    struct chimera_smb_client_thread *thread = private_data;
+    struct chimera_smb_client_shared *shared = thread->shared;
+    struct chimera_smb_client_server *server;
+    struct chimera_smb_client_conn   *conn;
+    chimera_smb_client_start_fn       start;
+    int                               server_index;
+
+    switch (request->opcode) {
+        case CHIMERA_VFS_OP_MOUNT:
+            chimera_smb_client_mount(thread, request);
+            return;
+        case CHIMERA_VFS_OP_UMOUNT:
+            chimera_smb_client_umount(thread, request);
+            return;
+        case CHIMERA_VFS_OP_CLOSE:
+        {
+            struct chimera_smb_client_open *open_state =
+                (struct chimera_smb_client_open *) request->close.vfs_private;
+
+            if (!open_state) {
+                request->status = CHIMERA_VFS_OK;
+                request->complete(request);
+                return;
+            }
+
+            server_index = open_state->server_index;
+            server       = (server_index >= 0 && server_index < shared->max_servers)
+                     ? shared->servers[server_index] : NULL;
+            conn = server ? thread->conns[server_index] : NULL;
+
+            /* Only send a real CLOSE when a live session connection exists.  If
+             * the session is gone (post-umount / disconnect), the server already
+             * released the handle via LOGOFF, so just drop local state -- do not
+             * reconnect solely to close. */
+            if (server && server->session_ready && conn &&
+                conn->state == CHIMERA_SMB_CONN_READY) {
+                chimera_smb_client_close(conn, request);
+            } else {
+                free(open_state);
+                request->status = CHIMERA_VFS_OK;
+                request->complete(request);
+            }
+            return;
+        }
+        case CHIMERA_VFS_OP_GETATTR:
+            server_index = chimera_smb_fh_server_index(request->fh);
+            start        = chimera_smb_client_getattr;
+            break;
+        case CHIMERA_VFS_OP_LOOKUP_AT:
+            server_index = chimera_smb_fh_server_index(request->fh);
+            start        = chimera_smb_client_lookup_at;
+            break;
+        case CHIMERA_VFS_OP_OPEN_AT:
+            server_index = chimera_smb_fh_server_index(request->fh);
+            start        = chimera_smb_client_open_at;
+            break;
+        case CHIMERA_VFS_OP_OPEN_FH:
+            server_index = chimera_smb_fh_server_index(request->fh);
+            start        = chimera_smb_client_open_fh;
+            break;
+        case CHIMERA_VFS_OP_MKDIR_AT:
+            server_index = chimera_smb_fh_server_index(request->fh);
+            start        = chimera_smb_client_mkdir_at;
+            break;
+        case CHIMERA_VFS_OP_REMOVE_AT:
+            server_index = chimera_smb_fh_server_index(request->fh);
+            start        = chimera_smb_client_remove_at;
+            break;
+        case CHIMERA_VFS_OP_SETATTR:
+            server_index = chimera_smb_fh_server_index(request->fh);
+            start        = chimera_smb_client_setattr;
+            break;
+        case CHIMERA_VFS_OP_COMMIT:
+            server_index = chimera_smb_fh_server_index(request->fh);
+            start        = chimera_smb_client_commit;
+            break;
+        case CHIMERA_VFS_OP_READ:
+            server_index = chimera_smb_fh_server_index(request->fh);
+            start        = chimera_smb_client_read;
+            break;
+        case CHIMERA_VFS_OP_WRITE:
+            server_index = chimera_smb_fh_server_index(request->fh);
+            start        = chimera_smb_client_write;
+            break;
+        case CHIMERA_VFS_OP_READDIR:
+            server_index = chimera_smb_fh_server_index(request->fh);
+            start        = chimera_smb_client_readdir;
+            break;
+        case CHIMERA_VFS_OP_RENAME_AT:
+            server_index = chimera_smb_fh_server_index(request->fh);
+            start        = chimera_smb_client_rename_at;
+            break;
+        case CHIMERA_VFS_OP_SYMLINK_AT:
+            server_index = chimera_smb_fh_server_index(request->fh);
+            start        = chimera_smb_client_symlink_at;
+            break;
+        case CHIMERA_VFS_OP_MKNOD_AT:
+            server_index = chimera_smb_fh_server_index(request->fh);
+            start        = chimera_smb_client_mknod_at;
+            break;
+        case CHIMERA_VFS_OP_READLINK:
+            server_index = chimera_smb_fh_server_index(request->fh);
+            start        = chimera_smb_client_readlink;
+            break;
+        default:
+            request->status = CHIMERA_VFS_ENOTSUP;
+            request->complete(request);
+            return;
+    } /* switch */
+
+    if (server_index < 0 || server_index >= shared->max_servers ||
+        !shared->servers[server_index]) {
+        request->status = CHIMERA_VFS_ESTALE;
+        request->complete(request);
+        return;
+    }
+
+    server = shared->servers[server_index];
+    conn   = chimera_smb_client_get_conn(thread, server);
+
+    chimera_smb_client_ensure_ready(conn, request, start);
+} /* chimera_smb_client_dispatch */
+
+SYMBOL_EXPORT struct chimera_vfs_module vfs_smb = {
+    .name     = "smb",
+    .fh_magic = CHIMERA_VFS_FH_MAGIC_SMB,
+    /* Path-only backend: full mount-relative paths, opaque per-open handle
+     * tokens, no FH-relative ops (no CAP_FS_RELATIVE_OP). */
+    .capabilities   = CHIMERA_VFS_CAP_FS | CHIMERA_VFS_CAP_FS_PATH_OP |
+        CHIMERA_VFS_CAP_OPEN_FILE_REQUIRED,
+    .init           = chimera_smb_client_init,
+    .destroy        = chimera_smb_client_destroy,
+    .thread_init    = chimera_smb_client_thread_init,
+    .thread_destroy = chimera_smb_client_thread_destroy,
+    .dispatch       = chimera_smb_client_dispatch,
+};

--- a/src/vfs/smb/smb.h
+++ b/src/vfs/smb/smb.h
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#pragma once
+
+#include "vfs/vfs.h"
+
+/* SMB2 client VFS module.  Proxies VFS operations to a remote SMB2 server,
+ * mirroring the NFS client (src/vfs/nfs).  This first increment supports only
+ * MOUNT (connect + NEGOTIATE + SESSION_SETUP + TREE_CONNECT) and UMOUNT
+ * (TREE_DISCONNECT + LOGOFF + disconnect); file operations are layered on
+ * incrementally. */
+extern struct chimera_vfs_module vfs_smb;

--- a/src/vfs/smb/smb_internal.h
+++ b/src/vfs/smb/smb_internal.h
@@ -1,0 +1,701 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#pragma once
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <pthread.h>
+#include <sys/stat.h>
+
+#include "vfs/vfs.h"
+#include "vfs/vfs_fh.h"
+#include "vfs/vfs_error.h"
+#include "vfs/vfs_attrs.h"
+#include "evpl/evpl.h"
+#include "common/logging.h"
+#include "common/evpl_iovec_cursor.h"
+#include "server/smb/smb2.h"
+#include "smb_ntlm.h"
+
+#define chimera_smbclient_debug(...) chimera_debug("smbclient", __FILE__, __LINE__, __VA_ARGS__)
+#define chimera_smbclient_info(...)  chimera_info("smbclient", __FILE__, __LINE__, __VA_ARGS__)
+#define chimera_smbclient_error(...) chimera_error("smbclient", __FILE__, __LINE__, __VA_ARGS__)
+#define chimera_smbclient_fatal(...) chimera_fatal("smbclient", __FILE__, __LINE__, __VA_ARGS__)
+
+#define chimera_smbclient_abort_if(cond, ...) \
+        chimera_abort_if(cond, "smbclient", __FILE__, __LINE__, __VA_ARGS__)
+
+/* SMB2 default port for this client. */
+#define CHIMERA_SMB_CLIENT_PORT             445
+#define CHIMERA_SMB_CLIENT_DEFAULT_DOMAIN   "WORKGROUP"
+#define CHIMERA_SMB_CLIENT_MAX_SERVERS      64
+
+/* Dialects advertised in NEGOTIATE, ascending.  The chimera server selects the
+ * highest dialect the client offers, so this list determines what we end up
+ * speaking (2.1 unsigned through 3.1.1 with preauth-integrity + signing). */
+#define CHIMERA_SMB_CLIENT_DIALECTS \
+        { SMB2_DIALECT_2_1, SMB2_DIALECT_3_0, SMB2_DIALECT_3_0_2, SMB2_DIALECT_3_1_1 }
+#define CHIMERA_SMB_CLIENT_NUM_DIALECTS     4
+
+/* Client GUID is fixed-zero (single-instance); 3.1.1 preauth salt length. */
+#define CHIMERA_SMB_CLIENT_PREAUTH_SALT_LEN 32
+
+/* The SMB client is a PATH-ONLY VFS backend (no persistent file handles).  File
+ * handles come in exactly two shapes:
+ *
+ *   mount root:  [ mount_id (16) ][ server_index (1) ]                = 17 bytes
+ *   open token:  [ mount_id (16) ][ server_index (1) ][ FileId (16) ] = 33 bytes
+ *
+ * The mount root is the ONLY re-openable fh (open_fh on it CREATEs the share
+ * root).  An open-token fh is an opaque per-open identity built at open time
+ * from the SMB FileId; it is used only for open-cache keying and routing, never
+ * to re-derive a path, and open_fh of one returns ESTALE.  All metadata is
+ * addressed by full mount-relative paths carried in request->X.name. */
+#define CHIMERA_SMB_FH_SERVER_OFFSET        CHIMERA_VFS_MOUNT_ID_SIZE
+#define CHIMERA_SMB_ROOT_FH_LEN             (CHIMERA_VFS_MOUNT_ID_SIZE + 1)
+#define CHIMERA_SMB_OPEN_FH_LEN             (CHIMERA_VFS_MOUNT_ID_SIZE + 1 + 16)
+/* Longest mount-relative path the client will encode in a single SMB request. */
+#define CHIMERA_SMB_PATH_MAX                1024
+
+/* ---- little-endian wire helpers ---------------------------------------- */
+
+static inline uint16_t
+smb_wire_le16(const uint8_t *p)
+{
+    return (uint16_t) p[0] | ((uint16_t) p[1] << 8);
+} /* smb_wire_le16 */
+
+static inline uint32_t
+smb_wire_le32(const uint8_t *p)
+{
+    return (uint32_t) p[0] | ((uint32_t) p[1] << 8) |
+           ((uint32_t) p[2] << 16) | ((uint32_t) p[3] << 24);
+} /* smb_wire_le32 */
+
+static inline uint64_t
+smb_wire_le64(const uint8_t *p)
+{
+    return (uint64_t) smb_wire_le32(p) | ((uint64_t) smb_wire_le32(p + 4) << 32);
+} /* smb_wire_le64 */
+
+static inline void
+smb_wire_set_le16(
+    uint8_t *p,
+    uint16_t v)
+{
+    p[0] = (uint8_t) (v & 0xff);
+    p[1] = (uint8_t) ((v >> 8) & 0xff);
+} /* smb_wire_set_le16 */
+
+static inline void
+smb_wire_set_le32(
+    uint8_t *p,
+    uint32_t v)
+{
+    p[0] = (uint8_t) (v & 0xff);
+    p[1] = (uint8_t) ((v >> 8) & 0xff);
+    p[2] = (uint8_t) ((v >> 16) & 0xff);
+    p[3] = (uint8_t) ((v >> 24) & 0xff);
+} /* smb_wire_set_le32 */
+
+static inline void
+smb_wire_set_le64(
+    uint8_t *p,
+    uint64_t v)
+{
+    smb_wire_set_le32(p, (uint32_t) (v & 0xffffffffULL));
+    smb_wire_set_le32(p + 4, (uint32_t) (v >> 32));
+} /* smb_wire_set_le64 */
+
+/* NetBIOS-over-TCP framing prefix (4 bytes: zero + 24-bit big-endian length). */
+struct smb_client_netbios_header {
+    uint32_t word;
+} __attribute__((packed));
+
+/* ---- module state ------------------------------------------------------ */
+
+struct chimera_smb_client_conn;
+struct chimera_smb_client_thread;
+
+/* A 16-byte SMB2 file handle (persistent + volatile id), returned by CREATE and
+ * echoed in every subsequent op on that open.  Valid on any connection bound to
+ * the same session, which is what lets per-thread connections share opens. */
+struct chimera_smb_client_file_id {
+    uint64_t pid;
+    uint64_t vid;
+};
+
+/* Per-server registration (global), holding the shared SMB session established
+ * once at MOUNT.  Every per-thread connection to this server reuses session_id /
+ * tree_id, so a file opened on one thread's connection is usable from another. */
+struct chimera_smb_client_server {
+    int                   index;
+    int                   in_use;
+    char                  hostname[256];
+    char                  share[256];
+    char                  user[256];
+    char                  domain[256];
+    char                  password[256];
+    uint16_t              port;
+
+    struct evpl_endpoint *endpoint;
+
+    /* Shared session state, written once by the mount handshake. */
+    uint16_t              dialect;
+    uint16_t              security_mode;
+    uint64_t              session_id;
+    uint32_t              tree_id;
+    int                   session_ready;
+
+    /* Server-advertised maxima from NEGOTIATE; reads/writes are chunked to these
+     * (0 until captured -- callers fall back to the safe per-PDU defaults). */
+    uint32_t              max_transact;
+    uint32_t              max_read;
+    uint32_t              max_write;
+
+    /* Signing state, derived once at SESSION_SETUP on the mount connection and
+    * shared by every per-thread connection to this server (the signing key is
+    * per-SESSION).  signing_active is set only when the negotiated dialect is
+    * 3.x AND a signing key has been derived; the unsigned 2.x path leaves it 0.
+    *
+    *   signing_alg: for 3.1.1, the SMB2_SIGNING_* algorithm the server selected
+    *   (GMAC/CMAC/HMAC-SHA256); unused for 3.0/3.0.2 (always AES-128-CMAC). */
+    int                   signing_active;
+    uint16_t              signing_alg;
+    uint8_t               signing_key[16];
+};
+
+struct chimera_smb_client_shared {
+    pthread_mutex_t                    lock;
+    struct chimera_smb_client_server **servers;
+    int                                max_servers;
+    enum evpl_protocol_id tcp_protocol;
+};
+
+/* Per-open state stored in the VFS open handle's vfs_private; carries the SMB
+ * FileId so any thread's connection can address the open. */
+struct chimera_smb_client_open {
+    struct chimera_smb_client_file_id file_id;
+    uint8_t                           server_index;
+    uint8_t                           is_directory;
+};
+
+/* A network-open-information block (CREATE/CLOSE/QUERY_INFO embed it). */
+struct smb_open_info {
+    uint64_t crttime, atime, mtime, ctime;
+    uint64_t alloc_size, end_of_file;
+    uint32_t file_attributes;
+};
+
+/* Parsed SMB2 CREATE response: FileId + create action + embedded attrs. */
+struct smb_create_result {
+    struct chimera_smb_client_file_id file_id;
+    uint32_t                          create_action;
+    struct smb_open_info              info;
+};
+
+/* Transient per-op state kept in request->plugin_data across a CREATE -> ... ->
+* CLOSE chain (ops that open a path transiently: lookup/mkdir/remove/rename). */
+struct chimera_smb_op_state {
+    struct chimera_smb_client_file_id file_id;
+};
+
+/* The continuation invoked when the reply for a specific message_id arrives.
+* `body` is positioned at the SMB2 body (consumed == sizeof(smb2_header)). */
+typedef void (*chimera_smb_client_reply_cb)(
+    struct chimera_smb_client_conn *conn,
+    uint32_t                        status,
+    const struct smb2_header       *hdr,
+    struct evpl_iovec_cursor       *body,
+    int                             body_len,
+    void                           *arg);
+
+/* The entry point that issues an op once its connection is READY. */
+typedef void (*chimera_smb_client_start_fn)(
+    struct chimera_smb_client_conn *conn,
+    struct chimera_vfs_request     *request);
+
+/* One in-flight request awaiting its reply (keyed by message_id).  `request` is
+ * the VFS request whose op chain this PDU belongs to, so a connection drop can
+ * error-complete it. */
+struct chimera_smb_client_pending {
+    uint64_t                           message_id;
+    chimera_smb_client_reply_cb        cb;
+    void                              *arg;
+    struct chimera_vfs_request        *request;
+    struct chimera_smb_client_pending *next;
+};
+
+/* One op deferred until the connection finishes connect + NEGOTIATE. */
+struct chimera_smb_client_deferred {
+    struct chimera_vfs_request         *request;
+    chimera_smb_client_start_fn         start;
+    struct chimera_smb_client_deferred *next;
+};
+
+enum chimera_smb_client_conn_state {
+    CHIMERA_SMB_CONN_NEW = 0,
+    CHIMERA_SMB_CONN_CONNECTING,
+    CHIMERA_SMB_CONN_READY,
+    CHIMERA_SMB_CONN_FAILED,
+};
+
+struct chimera_smb_client_conn {
+    struct chimera_smb_client_thread   *thread;
+    struct evpl                        *evpl;
+    struct evpl_bind                   *bind;
+    struct chimera_smb_client_server   *server;
+
+    enum chimera_smb_client_conn_state  state;
+    int                                 closing;   /* evpl_close already issued  */
+
+    uint64_t                            next_message_id;
+
+    struct chimera_smb_client_pending  *pending;   /* in-flight, by message_id  */
+    struct chimera_smb_client_deferred *deferred;  /* queued until READY        */
+
+    /* All connections a thread owns are linked here so thread teardown can
+     * detach every one (the DISCONNECTED notify that frees a conn is deferred to
+     * evpl_destroy, after the thread struct is gone). */
+    struct chimera_smb_client_conn     *list_next;
+
+    /* NTLM state + mount request, used only by the connection that establishes
+     * the shared session (the MOUNT connection). */
+    struct smb_ntlm_client              ntlm;
+    struct chimera_vfs_request         *mount_request;
+
+    /* 3.1.1 preauth-integrity hash, maintained ONLY on the mount connection
+     * while it runs NEGOTIATE -> SESSION_SETUP.  Folded over the raw SMB2
+     * messages (header+body, no NetBIOS framing, no trailing pad), mirroring the
+     * server's conn->preauth_hash.  Carries the dialect/signing_alg the mount
+     * conn negotiated until they are committed to the shared server struct. */
+    uint8_t                             preauth_hash[SMB2_PREAUTH_HASH_SIZE];
+    uint16_t                            negotiated_dialect;
+    uint16_t                            negotiated_signing_alg;
+};
+
+struct chimera_smb_client_thread {
+    struct evpl                      *evpl;
+    struct chimera_smb_client_shared *shared;
+    struct chimera_smb_client_conn  **conns;       /* routing table, by server index */
+    struct chimera_smb_client_conn   *conns_list;  /* every conn this thread owns */
+    int                               max_conns;
+};
+
+/* ---- status mapping ---------------------------------------------------- */
+
+static inline enum chimera_vfs_error
+chimera_smb_status_to_errno(uint32_t status)
+{
+    switch (status) {
+        case SMB2_STATUS_SUCCESS:
+            return CHIMERA_VFS_OK;
+        case SMB2_STATUS_END_OF_FILE:
+            return CHIMERA_VFS_OK;          /* short read at EOF, handled by caller */
+
+        /* ---- not found ---- */
+        case SMB2_STATUS_OBJECT_NAME_NOT_FOUND:
+        case SMB2_STATUS_OBJECT_PATH_NOT_FOUND:
+        case SMB2_STATUS_NO_SUCH_FILE:
+        case SMB2_STATUS_NOT_FOUND:
+        case SMB2_STATUS_BAD_NETWORK_NAME:
+        case SMB2_STATUS_BAD_NETWORK_PATH:
+        case SMB2_STATUS_DELETE_PENDING:    /* name is going away -> treat as gone */
+            return CHIMERA_VFS_ENOENT;
+
+        /* ---- permission / access ---- */
+        case SMB2_STATUS_ACCESS_DENIED:
+        case SMB2_STATUS_NETWORK_ACCESS_DENIED:
+        case SMB2_STATUS_LOGON_FAILURE:
+        case SMB2_STATUS_ACCOUNT_DISABLED:
+        case SMB2_STATUS_ACCOUNT_LOCKED_OUT:
+        case SMB2_STATUS_WRONG_PASSWORD:
+            return CHIMERA_VFS_EACCES;
+        case SMB2_STATUS_PRIVILEGE_NOT_HELD:
+        case SMB2_STATUS_CANNOT_DELETE:
+            return CHIMERA_VFS_EPERM;
+        case SMB2_STATUS_MEDIA_WRITE_PROTECTED:
+            return CHIMERA_VFS_EROFS;
+
+        /* ---- existence / type ---- */
+        case SMB2_STATUS_OBJECT_NAME_COLLISION:
+            return CHIMERA_VFS_EEXIST;
+        case SMB2_STATUS_NOT_A_DIRECTORY:
+            return CHIMERA_VFS_ENOTDIR;
+        case SMB2_STATUS_FILE_IS_A_DIRECTORY:
+            return CHIMERA_VFS_EISDIR;
+        case SMB2_STATUS_DIRECTORY_NOT_EMPTY:
+            return CHIMERA_VFS_ENOTEMPTY;
+        case SMB2_STATUS_NOT_SAME_DEVICE:
+            return CHIMERA_VFS_EXDEV;
+        case SMB2_STATUS_TOO_MANY_LINKS:
+            return CHIMERA_VFS_EMLINK;
+        case SMB2_STATUS_STOPPED_ON_SYMLINK:
+            return CHIMERA_VFS_ELOOP;
+        case SMB2_STATUS_NOT_A_REPARSE_POINT:
+            return CHIMERA_VFS_EINVAL;      /* readlink of a non-symlink */
+
+        /* ---- arguments ---- */
+        case SMB2_STATUS_INVALID_PARAMETER:
+        case SMB2_STATUS_INVALID_INFO_CLASS:
+        case SMB2_STATUS_INFO_LENGTH_MISMATCH:
+        case SMB2_STATUS_INVALID_DEVICE_REQUEST:
+            return CHIMERA_VFS_EINVAL;
+        case SMB2_STATUS_NAME_TOO_LONG:
+            return CHIMERA_VFS_ENAMETOOLONG;
+        case SMB2_STATUS_BUFFER_TOO_SMALL:
+        case SMB2_STATUS_BUFFER_OVERFLOW:
+            return CHIMERA_VFS_ERANGE;
+
+        /* ---- space / quota ---- */
+        case SMB2_STATUS_DISK_FULL:
+        case SMB2_STATUS_ALLOTTED_SPACE_EXCEEDED:
+            return CHIMERA_VFS_ENOSPC;
+        case SMB2_STATUS_QUOTA_EXCEEDED:
+            return CHIMERA_VFS_EDQUOT;
+
+        /* ---- sharing / locking (transient) ---- */
+        case SMB2_STATUS_SHARING_VIOLATION:
+        case SMB2_STATUS_FILE_LOCK_CONFLICT:
+        case SMB2_STATUS_LOCK_NOT_GRANTED:
+            return CHIMERA_VFS_EAGAIN;
+
+        /* ---- handle / file ---- */
+        case SMB2_STATUS_INVALID_HANDLE:
+        case SMB2_STATUS_SMB_BAD_FID:
+        case SMB2_STATUS_FILE_CLOSED:
+            return CHIMERA_VFS_EBADF;
+        case SMB2_STATUS_TOO_MANY_OPENED_FILES:
+            return CHIMERA_VFS_EMFILE;
+
+        /* ---- EA / xattr ---- */
+        case SMB2_STATUS_EAS_NOT_SUPPORTED:
+            return CHIMERA_VFS_ENOTSUP;
+        case SMB2_STATUS_NO_EAS_ON_FILE:
+        case SMB2_STATUS_NONEXISTENT_EA_ENTRY:
+            return CHIMERA_VFS_ENODATA;
+
+        /* ---- unsupported ---- */
+        case SMB2_STATUS_NOT_SUPPORTED:
+        case SMB2_STATUS_NOT_IMPLEMENTED:
+            return CHIMERA_VFS_ENOTSUP;
+
+        /* ---- session / connection gone -> stale (handles must be reopened) ---- */
+        case SMB2_STATUS_NETWORK_NAME_DELETED:
+        case SMB2_STATUS_USER_SESSION_DELETED:
+        case SMB2_STATUS_CONNECTION_DISCONNECTED:
+        case SMB2_STATUS_CONNECTION_RESET:
+        case SMB2_STATUS_VIRTUAL_CIRCUIT_CLOSED:
+            return CHIMERA_VFS_ESTALE;
+
+        default:
+            return CHIMERA_VFS_EIO;
+    } /* switch */
+} /* chimera_smb_status_to_errno */
+
+/* ---- attribute mapping ------------------------------------------------- */
+
+/* POSIX timespec -> Windows FILETIME (100ns ticks since 1601-01-01).  A zero
+ * timespec maps to 0, which SET_INFO FileBasicInformation reads as "don't
+ * change", matching the convention the client uses for unset time fields. */
+static inline uint64_t
+smb_timespec_to_filetime(const struct timespec *ts)
+{
+    if (ts->tv_sec == 0 && ts->tv_nsec == 0) {
+        return 0;
+    }
+    return (uint64_t) ts->tv_sec * 10000000ULL +
+           (uint64_t) ts->tv_nsec / 100 + 116444736000000000ULL;
+} /* smb_timespec_to_filetime */
+
+/* Windows FILETIME (100ns ticks since 1601-01-01) -> POSIX timespec. */
+static inline void
+smb_filetime_to_timespec(
+    uint64_t         filetime,
+    struct timespec *ts)
+{
+    if (filetime == 0 || filetime == (uint64_t) -1) {
+        ts->tv_sec  = 0;
+        ts->tv_nsec = 0;
+        return;
+    }
+    uint64_t unix100 = filetime - 116444736000000000ULL;
+    ts->tv_sec  = (time_t) (unix100 / 10000000ULL);
+    ts->tv_nsec = (long) ((unix100 % 10000000ULL) * 100);
+} /* smb_filetime_to_timespec */
+
+/* Fill a chimera_vfs_attrs from the SMB FileNetworkOpenInformation fields
+* (times + sizes + dos attributes), which CREATE/CLOSE responses embed. */
+static inline void
+smb_fill_attrs_from_network_open(
+    struct chimera_vfs_attrs *attr,
+    uint64_t                  crttime,
+    uint64_t                  atime,
+    uint64_t                  mtime,
+    uint64_t                  ctime,
+    uint64_t                  alloc_size,
+    uint64_t                  end_of_file,
+    uint32_t                  file_attributes)
+{
+    int is_dir = (file_attributes & SMB2_FILE_ATTRIBUTE_DIRECTORY) != 0;
+
+    /* SMB has no POSIX mode; synthesize type + a default permission. */
+    attr->va_mode       = (is_dir ? (S_IFDIR | 0755) : (S_IFREG | 0644));
+    attr->va_nlink      = 1;
+    attr->va_size       = end_of_file;
+    attr->va_space_used = alloc_size;
+
+    smb_filetime_to_timespec(atime, &attr->va_atime);
+    smb_filetime_to_timespec(mtime, &attr->va_mtime);
+    smb_filetime_to_timespec(ctime, &attr->va_ctime);
+    smb_filetime_to_timespec(crttime, &attr->va_btime);
+
+    attr->va_set_mask |= CHIMERA_VFS_ATTR_MODE | CHIMERA_VFS_ATTR_NLINK |
+        CHIMERA_VFS_ATTR_SIZE | CHIMERA_VFS_ATTR_SPACE_USED |
+        CHIMERA_VFS_ATTR_ATIME | CHIMERA_VFS_ATTR_MTIME |
+        CHIMERA_VFS_ATTR_CTIME | CHIMERA_VFS_ATTR_BTIME;
+} /* smb_fill_attrs_from_network_open */
+
+/* ---- file-handle helpers ----------------------------------------------- */
+
+static inline int
+chimera_smb_fh_server_index(const uint8_t *fh)
+{
+    return fh[CHIMERA_SMB_FH_SERVER_OFFSET];
+} /* chimera_smb_fh_server_index */
+
+/* The mount-root fh is the only re-openable one. */
+static inline int
+chimera_smb_fh_is_root(int fh_len)
+{
+    return fh_len == CHIMERA_SMB_ROOT_FH_LEN;
+} /* chimera_smb_fh_is_root */
+
+/* Build the opaque open-token fh [mount_id][server_index][FileId] from the
+ * (root) fh that carries the mount_id + server_index.  Returns its length. */
+static inline int
+chimera_smb_encode_open_fh(
+    const uint8_t                           *root_fh,
+    const struct chimera_smb_client_file_id *file_id,
+    uint8_t                                 *out_fh)
+{
+    uint8_t fragment[1 + sizeof(*file_id)];
+
+    fragment[0] = (uint8_t) chimera_smb_fh_server_index(root_fh);
+    memcpy(fragment + 1, file_id, sizeof(*file_id));
+
+    return chimera_vfs_encode_fh_parent(root_fh, fragment, sizeof(fragment), out_fh);
+} /* chimera_smb_encode_open_fh */
+
+/* ---- transport (smb.c) ------------------------------------------------- */
+
+void chimera_smb_client_pdu_begin(
+    struct chimera_smb_client_conn *conn,
+    uint16_t                        command,
+    struct evpl_iovec              *iov,
+    struct evpl_iovec_cursor       *cursor,
+    struct smb2_header            **hdr);
+
+void chimera_smb_client_pdu_finish(
+    struct chimera_smb_client_conn *conn,
+    struct evpl_iovec              *iov,
+    struct evpl_iovec_cursor       *cursor,
+    struct chimera_vfs_request     *request,
+    chimera_smb_client_reply_cb     reply_cb,
+    void                           *reply_arg);
+
+struct evpl_bind * chimera_smb_client_connect(
+    struct chimera_smb_client_conn *conn,
+    struct evpl_endpoint           *endpoint);
+
+/* ---- SMB3 signing / preauth (smb.c) ------------------------------------ */
+
+/* Extend an SMB 3.1.1 preauth-integrity hash in place: hash = SHA512(hash||msg).
+ * `msg` is a raw SMB2 message (header+body), `msg_len` its byte length. */
+void chimera_smb_client_preauth_extend(
+    uint8_t    *hash,
+    const void *msg,
+    uint32_t    msg_len);
+
+/* Derive the per-session 16-byte signing key from the NTLM session key via the
+ * SMB3 SP800-108 KDF.  `dialect` selects the label/context (and, for 3.1.1, the
+ * preauth_hash binding); returns 0 on success.  Mirrors the server's
+ * chimera_smb_derive_signing_key. */
+int chimera_smb_client_derive_signing_key(
+    uint16_t       dialect,
+    const uint8_t *session_key,
+    size_t         session_key_len,
+    const uint8_t *preauth_hash,
+    uint8_t       *out_key16);
+
+/* Transition a connection to READY and run any deferred ops (called from the
+ * mount handshake or a secondary connection's NEGOTIATE completion). */
+void chimera_smb_client_conn_ready(
+    struct chimera_smb_client_conn *conn);
+
+/* Fail a connection: error-complete every in-flight and deferred request, then
+ * close it (its DISCONNECTED notify frees it). */
+void chimera_smb_client_conn_fail(
+    struct chimera_smb_client_conn *conn,
+    enum chimera_vfs_error          status);
+
+/* Get (lazily create) this thread's connection to `server`. */
+struct chimera_smb_client_conn * chimera_smb_client_get_conn(
+    struct chimera_smb_client_thread *thread,
+    struct chimera_smb_client_server *server);
+
+/* Run `start` once `conn` is READY (connected + negotiated + session live),
+ * deferring `request` if establishment is still in flight. */
+void chimera_smb_client_ensure_ready(
+    struct chimera_smb_client_conn *conn,
+    struct chimera_vfs_request     *request,
+    chimera_smb_client_start_fn     start);
+
+/* ---- mount / umount (smb_mount.c) -------------------------------------- */
+
+void chimera_smb_client_mount(
+    struct chimera_smb_client_thread *thread,
+    struct chimera_vfs_request       *request);
+
+void chimera_smb_client_umount(
+    struct chimera_smb_client_thread *thread,
+    struct chimera_vfs_request       *request);
+
+/* Drive the NEGOTIATE -> (SESSION_SETUP -> TREE_CONNECT for the mount conn) ->
+ * READY handshake once TCP connects (smb_mount.c). */
+void chimera_smb_client_conn_on_connected(
+    struct chimera_smb_client_conn *conn);
+
+/* ---- file operations (smb_ops.c) --------------------------------------- */
+
+void chimera_smb_client_getattr(
+    struct chimera_smb_client_conn *conn,
+    struct chimera_vfs_request     *request);
+void chimera_smb_client_lookup_at(
+    struct chimera_smb_client_conn *conn,
+    struct chimera_vfs_request     *request);
+void chimera_smb_client_open_at(
+    struct chimera_smb_client_conn *conn,
+    struct chimera_vfs_request     *request);
+void chimera_smb_client_open_fh(
+    struct chimera_smb_client_conn *conn,
+    struct chimera_vfs_request     *request);
+void chimera_smb_client_close(
+    struct chimera_smb_client_conn *conn,
+    struct chimera_vfs_request     *request);
+void chimera_smb_client_mkdir_at(
+    struct chimera_smb_client_conn *conn,
+    struct chimera_vfs_request     *request);
+void chimera_smb_client_remove_at(
+    struct chimera_smb_client_conn *conn,
+    struct chimera_vfs_request     *request);
+void chimera_smb_client_setattr(
+    struct chimera_smb_client_conn *conn,
+    struct chimera_vfs_request     *request);
+void chimera_smb_client_commit(
+    struct chimera_smb_client_conn *conn,
+    struct chimera_vfs_request     *request);
+void chimera_smb_client_read(
+    struct chimera_smb_client_conn *conn,
+    struct chimera_vfs_request     *request);
+void chimera_smb_client_write(
+    struct chimera_smb_client_conn *conn,
+    struct chimera_vfs_request     *request);
+void chimera_smb_client_read(
+    struct chimera_smb_client_conn *conn,
+    struct chimera_vfs_request     *request);
+void chimera_smb_client_write(
+    struct chimera_smb_client_conn *conn,
+    struct chimera_vfs_request     *request);
+void chimera_smb_client_readdir(
+    struct chimera_smb_client_conn *conn,
+    struct chimera_vfs_request     *request);
+void chimera_smb_client_rename_at(
+    struct chimera_smb_client_conn *conn,
+    struct chimera_vfs_request     *request);
+void chimera_smb_client_symlink_at(
+    struct chimera_smb_client_conn *conn,
+    struct chimera_vfs_request     *request);
+void chimera_smb_client_mknod_at(
+    struct chimera_smb_client_conn *conn,
+    struct chimera_vfs_request     *request);
+void chimera_smb_client_readlink(
+    struct chimera_smb_client_conn *conn,
+    struct chimera_vfs_request     *request);
+
+/* ---- shared op helpers (smb_ops.c) ------------------------------------- */
+
+/* Encode a mount-relative path as UTF-16LE (with '/'->'\\'); returns byte len. */
+size_t smb_utf16le_encode(
+    const char *s,
+    int         len,
+    uint8_t    *out);
+
+/* Parse a FileNetworkOpenInformation block from `body` at the cursor. */
+void smb_parse_open_info(
+    struct evpl_iovec_cursor *body,
+    struct smb_open_info     *r);
+
+/* Parse an SMB2 CREATE response body (after the SMB2 header). */
+void smb_parse_create_reply(
+    struct evpl_iovec_cursor *body,
+    struct smb_create_result *r);
+
+/* Fill `attr` from SMB attrs; stamps cred as owner + a stable inode number. */
+void smb_apply_attrs(
+    const struct chimera_vfs_request *request,
+    struct chimera_vfs_attrs         *attr,
+    const struct smb_open_info       *info,
+    uint64_t                          ino);
+
+/* Send an SMB2 CREATE on `path` (full mount-relative path; "" for the root). */
+void smb_send_create(
+    struct chimera_smb_client_conn *conn,
+    struct chimera_vfs_request     *request,
+    const char                     *path,
+    int                             path_len,
+    uint32_t                        desired_access,
+    uint32_t                        share_access,
+    uint32_t                        disposition,
+    uint32_t                        options,
+    chimera_smb_client_reply_cb     reply_cb);
+
+/* Same, but carrying a pre-built create-context blob after the name. */
+void smb_send_create_ex(
+    struct chimera_smb_client_conn *conn,
+    struct chimera_vfs_request     *request,
+    const char                     *path,
+    int                             path_len,
+    uint32_t                        desired_access,
+    uint32_t                        share_access,
+    uint32_t                        disposition,
+    uint32_t                        options,
+    const uint8_t                  *ctx,
+    uint32_t                        ctx_len,
+    chimera_smb_client_reply_cb     reply_cb);
+
+/* An RqLs (lease request v1) create context is 56 bytes: header(16) + "RqLs"(4)
+ * + pad(4) + data(32). */
+#define CHIMERA_SMB_LEASE_CTX_SIZE 56
+
+uint32_t smb_build_lease_ctx(
+    uint8_t       *buf,
+    const uint8_t *lease_key,
+    uint32_t       lease_state);
+
+/* Send an SMB2 CLOSE for `file_id`. */
+void smb_send_close(
+    struct chimera_smb_client_conn          *conn,
+    struct chimera_vfs_request              *request,
+    const struct chimera_smb_client_file_id *file_id,
+    chimera_smb_client_reply_cb              reply_cb);
+
+/* Recover the per-open state (FileId + server) from a VFS open handle. */
+static inline struct chimera_smb_client_open *
+smb_handle_open_state(struct chimera_vfs_open_handle *handle)
+{
+    return handle ? (struct chimera_smb_client_open *) handle->vfs_private : NULL;
+} /* smb_handle_open_state */

--- a/src/vfs/smb/smb_io.c
+++ b/src/vfs/smb/smb_io.c
@@ -1,0 +1,697 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <xxhash.h>
+
+#include "smb_internal.h"
+#include "vfs/vfs_attrs.h"
+#include "evpl/evpl.h"
+
+/*
+ * SMB2 data-path operations for the path-only SMB client: READ, WRITE, and
+ * directory enumeration (QUERY_DIRECTORY).  All three operate on an already-open
+ * VFS handle whose vfs_private carries the SMB FileId (smb_handle_open_state).
+ */
+
+/* SMB2 READ request StructureSize (MS-SMB2 2.2.19): 48 fixed + 1 variable.  The
+ * sibling WRITE/QUERY_DIRECTORY sizes are exposed by smb2.h, but the READ
+ * request size is only defined as a reply size there, so define it locally. */
+#ifndef SMB2_READ_REQUEST_SIZE
+#define SMB2_READ_REQUEST_SIZE      49
+#endif /* ifndef SMB2_READ_REQUEST_SIZE */
+
+/* SMB2 READ/WRITE are chunked to the server-negotiated maxima (and bounded so a
+ * WRITE always fits one send PDU).  Per-transfer progress lives in plugin_data. */
+#define CHIMERA_SMB_WRITE_CHUNK_MAX 65280u      /* leaves room for the 64 KiB PDU */
+#define CHIMERA_SMB_READ_CHUNK_MAX  (1u << 20)  /* bound a single READ response   */
+
+struct smb_io_chunk {
+    uint64_t base_offset;   /* file offset of transfer byte 0                 */
+    uint32_t total;         /* total bytes to transfer                        */
+    uint32_t done;          /* bytes transferred so far                       */
+    uint32_t chunk_max;     /* per-request cap                                */
+    uint32_t last_req;      /* bytes asked for in the in-flight request       */
+};
+
+static inline uint32_t
+smb_write_chunk_cap(const struct chimera_smb_client_server *server)
+{
+    uint32_t cap = CHIMERA_SMB_WRITE_CHUNK_MAX;
+
+    if (server->max_write && server->max_write < cap) {
+        cap = server->max_write;
+    }
+    return cap;
+} /* smb_write_chunk_cap */
+
+static inline uint32_t
+smb_read_chunk_cap(const struct chimera_smb_client_server *server)
+{
+    uint32_t cap = CHIMERA_SMB_READ_CHUNK_MAX;
+
+    if (server->max_read && server->max_read < cap) {
+        cap = server->max_read;
+    }
+    return cap;
+} /* smb_read_chunk_cap */
+
+/* ---- read (SMB2 READ) -------------------------------------------------- */
+
+/* Scatter `length` bytes from the reply `body` cursor into the VFS-core read
+ * iovecs, starting at byte offset `skip` into the iovec array. */
+static void
+smb_scatter_into_iovecs(
+    struct evpl_iovec_cursor *body,
+    struct evpl_iovec        *iov,
+    int                       niov,
+    uint32_t                  skip,
+    uint32_t                  length)
+{
+    int      i;
+    uint32_t left = length;
+
+    for (i = 0; i < niov && left > 0; i++) {
+        uint32_t avail = iov[i].length;
+        uint32_t off;
+        uint32_t chunk;
+
+        if (skip >= avail) {
+            skip -= avail;
+            continue;
+        }
+        off  = skip;
+        skip = 0;
+
+        chunk = avail - off;
+        if (chunk > left) {
+            chunk = left;
+        }
+
+        evpl_iovec_cursor_get_blob(body, (char *) iov[i].data + off, chunk);
+        left -= chunk;
+    }
+} /* smb_scatter_into_iovecs */
+
+static void chimera_smb_read_send_chunk(
+    struct chimera_smb_client_conn *conn,
+    struct chimera_vfs_request     *request);
+
+static void
+chimera_smb_read_finish(struct chimera_vfs_request *request)
+{
+    struct smb_io_chunk *st     = (struct smb_io_chunk *) request->plugin_data;
+    uint32_t             prefix = request->read.aligned_prefix;
+    uint32_t             avail  = (st->done > prefix) ? (st->done - prefix) : 0;
+    uint32_t             want   = request->read.length;
+
+    request->read.r_length = (avail < want) ? avail : want;
+    request->read.r_eof    = (request->read.r_length < want) ? 1 : 0;
+    request->status        = CHIMERA_VFS_OK;
+    request->complete(request);
+} /* chimera_smb_read_finish */
+
+static void
+chimera_smb_read_reply(
+    struct chimera_smb_client_conn *conn,
+    uint32_t                        status,
+    const struct smb2_header       *hdr,
+    struct evpl_iovec_cursor       *body,
+    int                             body_len,
+    void                           *arg)
+{
+    struct chimera_vfs_request *request = arg;
+    struct smb_io_chunk        *st      = (struct smb_io_chunk *) request->plugin_data;
+    uint16_t                    structsize;
+    uint8_t                     data_offset, reserved;
+    uint32_t                    data_length, data_remaining, reserved2;
+    int                         consumed;
+
+    (void) hdr;
+    (void) body_len;
+
+    /* STATUS_END_OF_FILE maps to OK but signals a zero-length short read. */
+    request->status = chimera_smb_status_to_errno(status);
+
+    if (request->status != CHIMERA_VFS_OK) {
+        request->complete(request);
+        return;
+    }
+
+    if (status == SMB2_STATUS_END_OF_FILE) {
+        chimera_smb_read_finish(request);
+        return;
+    }
+
+    /* MS-SMB2 2.2.20 READ response: StructureSize(2), DataOffset(1),
+     * Reserved(1), DataLength(4), DataRemaining(4), Reserved2(4), Buffer. */
+    evpl_iovec_cursor_get_uint16(body, &structsize);
+    evpl_iovec_cursor_get_uint8(body, &data_offset);
+    evpl_iovec_cursor_get_uint8(body, &reserved);
+    evpl_iovec_cursor_get_uint32(body, &data_length);
+    evpl_iovec_cursor_get_uint32(body, &data_remaining);
+    evpl_iovec_cursor_get_uint32(body, &reserved2);
+
+    (void) structsize;
+    (void) reserved;
+    (void) data_remaining;
+    (void) reserved2;
+
+    /* DataOffset is header-relative, as is the cursor's consumed count. */
+    consumed = evpl_iovec_cursor_consumed(body);
+    if ((int) data_offset > consumed) {
+        evpl_iovec_cursor_skip(body, (int) data_offset - consumed);
+    }
+
+    if (data_length > 0) {
+        smb_scatter_into_iovecs(body, request->read.iov,
+                                request->read.buffers_provided,
+                                st->done, data_length);
+        st->done += data_length;
+    }
+
+    /* A short read (fewer bytes than asked) is EOF; otherwise keep going until
+     * the whole aligned range is read. */
+    if (data_length < st->last_req || st->done >= st->total) {
+        chimera_smb_read_finish(request);
+        return;
+    }
+
+    chimera_smb_read_send_chunk(conn, request);
+} /* chimera_smb_read_reply */
+
+static void
+chimera_smb_read_send_chunk(
+    struct chimera_smb_client_conn *conn,
+    struct chimera_vfs_request     *request)
+{
+    struct chimera_smb_client_open *open_state = smb_handle_open_state(request->read.handle);
+    struct smb_io_chunk            *st         = (struct smb_io_chunk *) request->plugin_data;
+    struct evpl_iovec               iov;
+    struct evpl_iovec_cursor        cursor;
+    struct smb2_header             *hdr;
+    uint32_t                        len = st->total - st->done;
+
+    if (len > st->chunk_max) {
+        len = st->chunk_max;
+    }
+    st->last_req = len;
+
+    chimera_smb_client_pdu_begin(conn, SMB2_READ, &iov, &cursor, &hdr);
+
+    evpl_iovec_cursor_append_uint16(&cursor, SMB2_READ_REQUEST_SIZE);
+    evpl_iovec_cursor_append_uint8(&cursor, 0);              /* Padding */
+    evpl_iovec_cursor_append_uint8(&cursor, 0);              /* Flags */
+    evpl_iovec_cursor_append_uint32(&cursor, len);           /* Length */
+    evpl_iovec_cursor_append_uint64(&cursor, st->base_offset + st->done);
+    evpl_iovec_cursor_append_uint64(&cursor, open_state->file_id.pid);
+    evpl_iovec_cursor_append_uint64(&cursor, open_state->file_id.vid);
+    evpl_iovec_cursor_append_uint32(&cursor, 0);             /* MinimumCount */
+    evpl_iovec_cursor_append_uint32(&cursor, 0);             /* Channel */
+    evpl_iovec_cursor_append_uint32(&cursor, 0);             /* RemainingBytes */
+    evpl_iovec_cursor_append_uint16(&cursor, 0);             /* ReadChannelInfoOffset */
+    evpl_iovec_cursor_append_uint16(&cursor, 0);             /* ReadChannelInfoLength */
+    evpl_iovec_cursor_append_uint8(&cursor, 0);              /* Buffer (1 byte min) */
+
+    chimera_smb_client_pdu_finish(conn, &iov, &cursor, request,
+                                  chimera_smb_read_reply, request);
+} /* chimera_smb_read_send_chunk */
+
+void
+chimera_smb_client_read(
+    struct chimera_smb_client_conn *conn,
+    struct chimera_vfs_request     *request)
+{
+    struct chimera_smb_client_open *open_state = smb_handle_open_state(request->read.handle);
+    struct smb_io_chunk            *st         = (struct smb_io_chunk *) request->plugin_data;
+    uint64_t                        aligned_offset;
+
+    if (!open_state) {
+        request->status = CHIMERA_VFS_EINVAL;
+        request->complete(request);
+        return;
+    }
+
+    if (request->read.length == 0) {
+        request->read.r_length = 0;
+        request->read.r_eof    = 0;
+        request->status        = CHIMERA_VFS_OK;
+        request->complete(request);
+        return;
+    }
+
+    /* The VFS core (no CAP_READ_PROVIDES_BUFFERS) pre-allocated read.iov padded
+     * to a 4 KiB boundary on both sides; read the whole aligned range so the
+     * data lands at iovec byte 0, where the core's finalize step expects it. */
+    aligned_offset  = request->read.offset - request->read.aligned_prefix;
+    st->base_offset = aligned_offset;
+    st->total       = (uint32_t) (((request->read.offset + request->read.length + 4095ULL) & ~4095ULL)
+                                  - aligned_offset);
+    st->done      = 0;
+    st->chunk_max = smb_read_chunk_cap(conn->server);
+
+    chimera_smb_read_send_chunk(conn, request);
+} /* chimera_smb_client_read */
+
+/* ---- write (SMB2 WRITE) ------------------------------------------------ */
+
+/* Append [skip, skip+length) bytes from the caller's write iovecs to `cursor`. */
+static void
+smb_gather_from_iovecs(
+    struct evpl_iovec_cursor *cursor,
+    const struct evpl_iovec  *iov,
+    int                       niov,
+    uint32_t                  skip,
+    uint32_t                  length)
+{
+    int      i;
+    uint32_t left = length;
+
+    for (i = 0; i < niov && left > 0; i++) {
+        uint32_t avail = iov[i].length;
+        uint32_t off;
+        uint32_t chunk;
+
+        if (skip >= avail) {
+            skip -= avail;
+            continue;
+        }
+        off  = skip;
+        skip = 0;
+
+        chunk = avail - off;
+        if (chunk > left) {
+            chunk = left;
+        }
+
+        evpl_iovec_cursor_append_blob_unaligned(cursor,
+                                                (char *) iov[i].data + off, chunk);
+        left -= chunk;
+    }
+} /* smb_gather_from_iovecs */
+
+static void chimera_smb_write_send_chunk(
+    struct chimera_smb_client_conn *conn,
+    struct chimera_vfs_request     *request);
+
+static void
+chimera_smb_write_reply(
+    struct chimera_smb_client_conn *conn,
+    uint32_t                        status,
+    const struct smb2_header       *hdr,
+    struct evpl_iovec_cursor       *body,
+    int                             body_len,
+    void                           *arg)
+{
+    struct chimera_vfs_request *request = arg;
+    struct smb_io_chunk        *st      = (struct smb_io_chunk *) request->plugin_data;
+    uint16_t                    structsize, channel_offset, channel_length;
+    uint32_t                    count, remaining;
+
+    (void) hdr;
+    (void) body_len;
+
+    request->status = chimera_smb_status_to_errno(status);
+
+    if (request->status != CHIMERA_VFS_OK) {
+        request->complete(request);
+        return;
+    }
+
+    /* MS-SMB2 2.2.22 WRITE response: StructureSize(2), Reserved(2), Count(4),
+     * Remaining(4), WriteChannelInfoOffset(2), WriteChannelInfoLength(2). */
+    evpl_iovec_cursor_get_uint16(body, &structsize);
+    evpl_iovec_cursor_get_uint16(body, &channel_offset); /* Reserved (2) */
+    evpl_iovec_cursor_get_uint32(body, &count);
+    evpl_iovec_cursor_get_uint32(body, &remaining);
+    evpl_iovec_cursor_get_uint16(body, &channel_offset);
+    evpl_iovec_cursor_get_uint16(body, &channel_length);
+
+    (void) structsize;
+    (void) remaining;
+    (void) channel_offset;
+    (void) channel_length;
+
+    st->done += count;
+
+    /* A short write (server accepted fewer bytes than asked) ends the transfer;
+     * otherwise continue until the whole buffer is written. */
+    if (count < st->last_req || st->done >= st->total) {
+        request->write.r_length = st->done;
+        request->write.r_sync   = request->write.sync ? 1 : 0;
+        request->complete(request);
+        return;
+    }
+
+    chimera_smb_write_send_chunk(conn, request);
+} /* chimera_smb_write_reply */
+
+static void
+chimera_smb_write_send_chunk(
+    struct chimera_smb_client_conn *conn,
+    struct chimera_vfs_request     *request)
+{
+    struct chimera_smb_client_open *open_state = smb_handle_open_state(request->write.handle);
+    struct smb_io_chunk            *st         = (struct smb_io_chunk *) request->plugin_data;
+    struct evpl_iovec               iov;
+    struct evpl_iovec_cursor        cursor;
+    struct smb2_header             *hdr;
+    uint32_t                        flags = request->write.sync ? SMB2_WRITEFLAG_WRITE_THROUGH : 0;
+    uint32_t                        len   = st->total - st->done;
+
+    if (len > st->chunk_max) {
+        len = st->chunk_max;
+    }
+    st->last_req = len;
+
+    /* MS-SMB2 2.2.21 WRITE request: fixed part is 48 bytes -> data begins at
+     * header(64) + 48 = 112. */
+    chimera_smb_client_pdu_begin(conn, SMB2_WRITE, &iov, &cursor, &hdr);
+
+    evpl_iovec_cursor_append_uint16(&cursor, SMB2_WRITE_REQUEST_SIZE);
+    evpl_iovec_cursor_append_uint16(&cursor, sizeof(struct smb2_header) + 48); /* DataOffset */
+    evpl_iovec_cursor_append_uint32(&cursor, len);
+    evpl_iovec_cursor_append_uint64(&cursor, request->write.offset + st->done);
+    evpl_iovec_cursor_append_uint64(&cursor, open_state->file_id.pid);
+    evpl_iovec_cursor_append_uint64(&cursor, open_state->file_id.vid);
+    evpl_iovec_cursor_append_uint32(&cursor, 0);             /* Channel */
+    evpl_iovec_cursor_append_uint32(&cursor, 0);             /* RemainingBytes */
+    evpl_iovec_cursor_append_uint16(&cursor, 0);             /* WriteChannelInfoOffset */
+    evpl_iovec_cursor_append_uint16(&cursor, 0);             /* WriteChannelInfoLength */
+    evpl_iovec_cursor_append_uint32(&cursor, flags);
+
+    smb_gather_from_iovecs(&cursor, request->write.iov, request->write.niov,
+                           st->done, len);
+
+    chimera_smb_client_pdu_finish(conn, &iov, &cursor, request,
+                                  chimera_smb_write_reply, request);
+} /* chimera_smb_write_send_chunk */
+
+void
+chimera_smb_client_write(
+    struct chimera_smb_client_conn *conn,
+    struct chimera_vfs_request     *request)
+{
+    struct chimera_smb_client_open *open_state = smb_handle_open_state(request->write.handle);
+    struct smb_io_chunk            *st         = (struct smb_io_chunk *) request->plugin_data;
+
+    if (!open_state) {
+        request->status = CHIMERA_VFS_EINVAL;
+        request->complete(request);
+        return;
+    }
+
+    if (request->write.length == 0) {
+        request->write.r_length = 0;
+        request->write.r_sync   = request->write.sync ? 1 : 0;
+        request->status         = CHIMERA_VFS_OK;
+        request->complete(request);
+        return;
+    }
+
+    st->base_offset = request->write.offset;
+    st->total       = request->write.length;
+    st->done        = 0;
+    st->chunk_max   = smb_write_chunk_cap(conn->server);
+
+    chimera_smb_write_send_chunk(conn, request);
+} /* chimera_smb_client_write */
+
+/* ---- readdir (SMB2 QUERY_DIRECTORY) ------------------------------------ */
+
+/* QUERY_DIRECTORY uses FileFullDirectoryInformation (0x02): a clean layout with
+ * no short-name region.  Per-entry fixed fields (after NextEntryOffset):
+ *   FileIndex(4), CreationTime(8), LastAccessTime(8), LastWriteTime(8),
+ *   ChangeTime(8), EndOfFile(8), AllocationSize(8), FileAttributes(4),
+ *   FileNameLength(4), EaSize(4), then FileName (UTF-16LE). */
+#define SMB_DIRINFO_FULL          SMB2_FILE_FULL_DIRECTORY_INFORMATION
+
+/* Output buffer the client advertises per QUERY_DIRECTORY round. */
+#define SMB_READDIR_OUTPUT_LENGTH 65536
+
+/* Per-readdir state kept in request->plugin_data across the QUERY_DIRECTORY
+ * loop (one VFS readdir call may span several QUERY_DIRECTORY round-trips). */
+struct smb_readdir_ctx {
+    struct chimera_smb_client_open *open_state;
+    uint64_t                        next_cookie; /* monotonic emit index */
+    int                             first;       /* send SMB2_RESTART_SCANS once */
+    int                             full;        /* emit callback asked us to stop */
+};
+
+static void chimera_smb_readdir_query(
+    struct chimera_smb_client_conn *conn,
+    struct chimera_vfs_request     *request);
+
+/* Decode UTF-16LE (ASCII subset) into a UTF-8 buffer.  The client encodes paths
+ * with smb_utf16le_encode (ASCII-only), so a symmetric ASCII decode is adequate
+ * for the names this client round-trips.  TODO: full UTF-16 -> UTF-8. */
+static int
+smb_utf16le_decode_ascii(
+    const uint8_t *in,
+    int            in_bytes,
+    char          *out,
+    int            out_max)
+{
+    int i, n = in_bytes / 2;
+
+    if (n >= out_max) {
+        n = out_max - 1;
+    }
+
+    for (i = 0; i < n; i++) {
+        out[i] = (char) in[i * 2];
+    }
+    out[n] = '\0';
+    return n;
+} /* smb_utf16le_decode_ascii */
+
+static void
+chimera_smb_readdir_reply(
+    struct chimera_smb_client_conn *conn,
+    uint32_t                        status,
+    const struct smb2_header       *hdr,
+    struct evpl_iovec_cursor       *body,
+    int                             body_len,
+    void                           *arg)
+{
+    struct chimera_vfs_request *request = arg;
+    struct smb_readdir_ctx     *ctx     = request->plugin_data;
+    uint16_t                    structsize, out_offset;
+    uint32_t                    out_length;
+    int                         consumed, base, off;
+    uint8_t                    *buf;
+
+    (void) hdr;
+    (void) body_len;
+
+    /* STATUS_NO_MORE_FILES terminates a normal enumeration. */
+    if (status == SMB2_STATUS_NO_MORE_FILES) {
+        request->readdir.r_eof    = 1;
+        request->readdir.r_cookie = ctx->next_cookie;
+        request->status           = CHIMERA_VFS_OK;
+        request->complete(request);
+        return;
+    }
+
+    request->status = chimera_smb_status_to_errno(status);
+    if (request->status != CHIMERA_VFS_OK) {
+        request->complete(request);
+        return;
+    }
+
+    /* MS-SMB2 2.2.34 QUERY_DIRECTORY response: StructureSize(2),
+     * OutputBufferOffset(2), OutputBufferLength(4), then the buffer.  Offset is
+     * relative to the SMB2 header start (cursor consumed is header-relative). */
+    evpl_iovec_cursor_get_uint16(body, &structsize);
+    evpl_iovec_cursor_get_uint16(body, &out_offset);
+    evpl_iovec_cursor_get_uint32(body, &out_length);
+    (void) structsize;
+
+    consumed = evpl_iovec_cursor_consumed(body);
+    if ((int) out_offset > consumed) {
+        evpl_iovec_cursor_skip(body, (int) out_offset - consumed);
+    }
+
+    /* Pull the whole entry buffer into a contiguous scratch so we can walk it by
+     * NextEntryOffset.  out_length is bounded by SMB_READDIR_OUTPUT_LENGTH. */
+    if (out_length == 0) {
+        request->readdir.r_eof    = 1;
+        request->readdir.r_cookie = ctx->next_cookie;
+        request->status           = CHIMERA_VFS_OK;
+        request->complete(request);
+        return;
+    }
+
+    buf = malloc(out_length);
+    if (evpl_iovec_cursor_get_blob(body, buf, out_length) < 0) {
+        free(buf);
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+
+    off  = 0;
+    base = 0;
+    while (off + 4 <= (int) out_length) {
+        uint32_t                 next_offset, file_attributes, name_length;
+        uint64_t                 crttime, atime, mtime, ctime, end_of_file, alloc_size;
+        const uint8_t           *e = buf + off;
+        char                     name[CHIMERA_SMB_PATH_MAX];
+        int                      namelen;
+        struct chimera_vfs_attrs attrs;
+        int                      rc;
+
+        next_offset = smb_wire_le32(e + 0);
+        /* FileIndex at e+4 (unused) */
+        crttime         = smb_wire_le64(e + 8);
+        atime           = smb_wire_le64(e + 16);
+        mtime           = smb_wire_le64(e + 24);
+        ctime           = smb_wire_le64(e + 32);
+        end_of_file     = smb_wire_le64(e + 40);
+        alloc_size      = smb_wire_le64(e + 48);
+        file_attributes = smb_wire_le32(e + 56);
+        name_length     = smb_wire_le32(e + 60);
+        /* EaSize at e+64 (4 bytes, unused); name begins at e+68. */
+
+        if ((int) (68 + name_length) > (int) out_length - off) {
+            break;
+        }
+
+        namelen = smb_utf16le_decode_ascii(e + 68, (int) name_length,
+                                           name, sizeof(name));
+
+        /* Skip "." and ".." -- the VFS readdir layer does not expect them (it
+         * requested EMIT_DOT only at the server's discretion; vfs_nfs/readdir
+         * consumers filter them, so drop them here). */
+        if (!((namelen == 1 && name[0] == '.') ||
+              (namelen == 2 && name[0] == '.' && name[1] == '.'))) {
+
+            attrs.va_req_mask = request->readdir.attr_mask;
+            attrs.va_set_mask = 0;
+
+            smb_fill_attrs_from_network_open(&attrs, crttime, atime,
+                                             mtime, ctime,
+                                             alloc_size, end_of_file,
+                                             file_attributes);
+
+            attrs.va_ino       = XXH3_64bits(name, namelen) | 1;
+            attrs.va_set_mask |= CHIMERA_VFS_ATTR_INUM;
+
+            ctx->next_cookie++;
+
+            rc = request->readdir.callback(attrs.va_ino,
+                                           ctx->next_cookie,
+                                           name, namelen,
+                                           &attrs,
+                                           request->proto_private_data);
+
+            request->readdir.r_cookie = ctx->next_cookie;
+
+            if (rc) {
+                /* The emit buffer is full: stop, leaving more entries on the
+                 * server.  Report not-EOF; the caller re-issues with the
+                 * resume cookie (we keep the server-side scan position by NOT
+                 * sending RESTART_SCANS on the follow-up). */
+                ctx->full = 1;
+                break;
+            }
+        }
+
+        base++;
+
+        if (next_offset == 0) {
+            break;          /* last entry in this buffer */
+        }
+        off += (int) next_offset;
+    }
+
+    (void) base;
+
+    free(buf);
+
+    if (ctx->full) {
+        request->readdir.r_eof = 0;
+        request->status        = CHIMERA_VFS_OK;
+        request->complete(request);
+        return;
+    }
+
+    /* This buffer is drained; ask the server for the next batch (continuing the
+     * open's scan position -- no RESTART_SCANS). */
+    chimera_smb_readdir_query(conn, request);
+} /* chimera_smb_readdir_reply */
+
+static void
+chimera_smb_readdir_query(
+    struct chimera_smb_client_conn *conn,
+    struct chimera_vfs_request     *request)
+{
+    struct smb_readdir_ctx  *ctx = request->plugin_data;
+    struct evpl_iovec        iov;
+    struct evpl_iovec_cursor cursor;
+    struct smb2_header      *hdr;
+    uint8_t                  flags;
+    uint8_t                  pattern16[2];
+
+    /* On the first round of a readdir starting at cookie 0, restart the scan to
+     * the top of the directory; otherwise continue from the open's position. */
+    flags      = ctx->first ? SMB2_RESTART_SCANS : 0;
+    ctx->first = 0;
+
+    /* MS-SMB2 2.2.33 QUERY_DIRECTORY request: StructureSize(2),
+     * FileInformationClass(1), Flags(1), FileIndex(4), FileId(16),
+     * FileNameOffset(2), FileNameLength(2), OutputBufferLength(4), then the
+     * search pattern (UTF-16LE).  We always pass "*". */
+    chimera_smb_client_pdu_begin(conn, SMB2_QUERY_DIRECTORY, &iov, &cursor, &hdr);
+
+    pattern16[0] = (uint8_t) '*';
+    pattern16[1] = 0;
+
+    evpl_iovec_cursor_append_uint16(&cursor, SMB2_QUERY_DIRECTORY_REQUEST_SIZE);
+    evpl_iovec_cursor_append_uint8(&cursor, SMB_DIRINFO_FULL);
+    evpl_iovec_cursor_append_uint8(&cursor, flags);
+    evpl_iovec_cursor_append_uint32(&cursor, 0);             /* FileIndex */
+    evpl_iovec_cursor_append_uint64(&cursor, ctx->open_state->file_id.pid);
+    evpl_iovec_cursor_append_uint64(&cursor, ctx->open_state->file_id.vid);
+    evpl_iovec_cursor_append_uint16(&cursor, sizeof(struct smb2_header) + 32); /* FileNameOffset */
+    evpl_iovec_cursor_append_uint16(&cursor, sizeof(pattern16)); /* FileNameLength */
+    evpl_iovec_cursor_append_uint32(&cursor, SMB_READDIR_OUTPUT_LENGTH);
+    evpl_iovec_cursor_append_blob(&cursor, pattern16, sizeof(pattern16));
+
+    chimera_smb_client_pdu_finish(conn, &iov, &cursor, request,
+                                  chimera_smb_readdir_reply, request);
+} /* chimera_smb_readdir_query */
+
+void
+chimera_smb_client_readdir(
+    struct chimera_smb_client_conn *conn,
+    struct chimera_vfs_request     *request)
+{
+    struct chimera_smb_client_open *open_state = smb_handle_open_state(request->readdir.handle);
+    struct smb_readdir_ctx         *ctx;
+
+    if (!open_state) {
+        request->status = CHIMERA_VFS_EINVAL;
+        request->complete(request);
+        return;
+    }
+
+    ctx              = request->plugin_data;
+    ctx->open_state  = open_state;
+    ctx->next_cookie = request->readdir.cookie;
+    /* Restart the server-side scan only when the caller resumes from the start
+     * (cookie 0).  A non-zero resume cookie continues the open's existing
+     * position.  TODO: the SMB server-side scan position is per-open and is not
+     * a stable cursor across separate VFS readdir calls; a precise mid-stream
+     * resume would need to re-skip to request->readdir.cookie entries. */
+    ctx->first = (request->readdir.cookie == 0);
+    ctx->full  = 0;
+
+    request->readdir.r_eof    = 0;
+    request->readdir.r_cookie = request->readdir.cookie;
+
+    chimera_smb_readdir_query(conn, request);
+} /* chimera_smb_client_readdir */

--- a/src/vfs/smb/smb_mount.c
+++ b/src/vfs/smb/smb_mount.c
@@ -1,0 +1,698 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <xxhash.h>
+
+#include "smb_internal.h"
+#include "smb.h"
+#include "common/tcp_flavor.h"
+#include "vfs/vfs_attrs.h"
+#include "evpl/evpl.h"
+
+/* Fold one raw SMB2 message (header+body, no NetBIOS framing, no trailing pad)
+ * into the mount connection's 3.1.1 preauth-integrity hash.  Maintained
+ * UNCONDITIONALLY across every NEGOTIATE / SESSION_SETUP message during the
+ * handshake: we always advertise 3.1.1 and do not know whether the server will
+ * select it until the NEGOTIATE reply, so the running hash must already include
+ * the NEGOTIATE request.  The hash is only CONSUMED (for key derivation) when
+ * the negotiated dialect is 3.1.1; for any other dialect it is simply unused.
+ * Mirrors the server's conn->preauth_hash bookkeeping. */
+static void
+chimera_smb_client_preauth_fold(
+    struct chimera_smb_client_conn *conn,
+    const struct smb2_header       *hdr,
+    int                             smb2_len)
+{
+    chimera_smb_client_preauth_extend(conn->preauth_hash, hdr, (uint32_t) smb2_len);
+} /* chimera_smb_client_preauth_fold */
+
+/* Extract the contiguous SMB2 message (header + body, no NetBIOS prefix) and
+ * its length from a freshly-built request iovec, for preauth folding. */
+static struct smb2_header *
+chimera_smb_client_msg_from_iov(
+    struct evpl_iovec        *iov,
+    struct evpl_iovec_cursor *cursor,
+    int                      *out_len)
+{
+    struct smb_client_netbios_header *netbios = evpl_iovec_data(iov);
+
+    *out_len = evpl_iovec_cursor_consumed(cursor);
+    return (struct smb2_header *) (netbios + 1);
+} /* chimera_smb_client_msg_from_iov */
+
+/* Fold a received reply (header copy + body cursor) into the preauth hash by
+ * reconstructing its contiguous SMB2 message.  `body` is positioned at the body
+ * start; it is NOT advanced (a private snapshot is used). */
+static void
+chimera_smb_client_preauth_fold_reply(
+    struct chimera_smb_client_conn *conn,
+    const struct smb2_header       *hdr,
+    struct evpl_iovec_cursor       *body,
+    int                             body_len)
+{
+    uint8_t *msg = malloc(sizeof(*hdr) + body_len);
+
+    if (!msg) {
+        return;
+    }
+    memcpy(msg, hdr, sizeof(*hdr));
+    if (body_len > 0) {
+        struct evpl_iovec_cursor c = *body;
+        evpl_iovec_cursor_copy(&c, msg + sizeof(*hdr), body_len);
+    }
+    chimera_smb_client_preauth_fold(conn, (struct smb2_header *) msg,
+                                    (int) sizeof(*hdr) + body_len);
+    free(msg);
+} /* chimera_smb_client_preauth_fold_reply */
+
+/* ---- helpers ----------------------------------------------------------- */
+
+static const char *
+chimera_smb_client_get_option(
+    const struct chimera_vfs_mount_options *options,
+    const char                             *key)
+{
+    int i;
+
+    for (i = 0; i < options->num_options; i++) {
+        if (strcmp(options->options[i].key, key) == 0) {
+            return options->options[i].value;
+        }
+    }
+    return NULL;
+} /* chimera_smb_client_get_option */
+
+static struct chimera_smb_client_server *
+chimera_smb_client_server_alloc(struct chimera_smb_client_shared *shared)
+{
+    struct chimera_smb_client_server *server = NULL;
+    int                               i;
+
+    pthread_mutex_lock(&shared->lock);
+
+    for (i = 0; i < shared->max_servers; i++) {
+        if (!shared->servers[i]) {
+            server             = calloc(1, sizeof(*server));
+            server->index      = i;
+            server->in_use     = 1;
+            shared->servers[i] = server;
+            break;
+        }
+    }
+
+    pthread_mutex_unlock(&shared->lock);
+
+    return server;
+} /* chimera_smb_client_server_alloc */
+
+/* ---- TREE_CONNECT (final mount leg) ------------------------------------ */
+
+static void
+chimera_smb_client_tree_connect_reply(
+    struct chimera_smb_client_conn *conn,
+    uint32_t                        status,
+    const struct smb2_header       *hdr,
+    struct evpl_iovec_cursor       *body,
+    int                             body_len,
+    void                           *arg)
+{
+    struct chimera_vfs_request       *request = conn->mount_request;
+    struct chimera_smb_client_server *server  = conn->server;
+    uint8_t                           fragment[1];
+    XXH128_hash_t                     fsid_hash;
+    char                              fsid_input[600];
+    int                               fsid_len;
+    uint8_t                           fsid[CHIMERA_VFS_FSID_SIZE];
+
+    (void) body;
+    (void) body_len;
+    (void) arg;
+
+    if (status != SMB2_STATUS_SUCCESS) {
+        chimera_smbclient_error("TREE_CONNECT failed: status 0x%08x", status);
+        chimera_smb_client_conn_fail(conn, chimera_smb_status_to_errno(status));
+        return;
+    }
+
+    server->tree_id       = hdr->sync.tree_id;
+    server->session_ready = 1;
+
+    /* Mount root FH: fsid = hash(host/share), fragment = [server_index][""]. */
+    fragment[0] = (uint8_t) server->index;
+
+    fsid_len = snprintf(fsid_input, sizeof(fsid_input), "%s/%s",
+                        server->hostname, server->share);
+    fsid_hash = XXH3_128bits(fsid_input, fsid_len);
+    memcpy(fsid, &fsid_hash, CHIMERA_VFS_FSID_SIZE);
+
+    request->mount.r_attr.va_set_mask = CHIMERA_VFS_ATTR_FH;
+    request->mount.r_attr.va_fh_len   = chimera_vfs_encode_fh_mount(
+        fsid, fragment, 1, request->mount.r_attr.va_fh);
+
+    request->mount.r_mount_private = server;
+
+    chimera_smbclient_info("SMB mount established: //%s/%s (dialect 0x%04x, session 0x%lx, tree %u)",
+                           server->hostname, server->share, server->dialect,
+                           server->session_id, server->tree_id);
+
+    conn->mount_request = NULL;
+    request->status     = CHIMERA_VFS_OK;
+    request->complete(request);
+
+    chimera_smb_client_conn_ready(conn);
+} /* chimera_smb_client_tree_connect_reply */
+
+static void
+chimera_smb_client_tree_connect_send(struct chimera_smb_client_conn *conn)
+{
+    struct chimera_smb_client_server *server = conn->server;
+    struct evpl_iovec                 iov;
+    struct evpl_iovec_cursor          cursor;
+    struct smb2_header               *hdr;
+    uint8_t                           unc16[1200];
+    char                              unc[600];
+    size_t                            unc_len, i, n16;
+
+    snprintf(unc, sizeof(unc), "\\\\%s\\%s", server->hostname, server->share);
+    unc_len = strlen(unc);
+
+    n16 = 0;
+    for (i = 0; i < unc_len; i++) {
+        unc16[n16++] = (uint8_t) unc[i];
+        unc16[n16++] = 0;
+    }
+
+    chimera_smb_client_pdu_begin(conn, SMB2_TREE_CONNECT, &iov, &cursor, &hdr);
+
+    evpl_iovec_cursor_append_uint16(&cursor, SMB2_TREE_CONNECT_REQUEST_SIZE);
+    evpl_iovec_cursor_append_uint16(&cursor, 0);
+    evpl_iovec_cursor_append_uint16(&cursor, sizeof(struct smb2_header) + 8);
+    evpl_iovec_cursor_append_uint16(&cursor, (uint16_t) n16);
+    evpl_iovec_cursor_append_blob(&cursor, unc16, n16);
+
+    chimera_smb_client_pdu_finish(conn, &iov, &cursor, conn->mount_request,
+                                  chimera_smb_client_tree_connect_reply, NULL);
+} /* chimera_smb_client_tree_connect_send */
+
+/* ---- SESSION_SETUP ----------------------------------------------------- */
+
+static void
+chimera_smb_client_session_setup_send(
+    struct chimera_smb_client_conn *conn,
+    const uint8_t                  *token,
+    size_t                          token_len,
+    chimera_smb_client_reply_cb     reply_cb)
+{
+    struct evpl_iovec        iov;
+    struct evpl_iovec_cursor cursor;
+    struct smb2_header      *hdr;
+    int                      msg_len;
+
+    chimera_smb_client_pdu_begin(conn, SMB2_SESSION_SETUP, &iov, &cursor, &hdr);
+
+    evpl_iovec_cursor_append_uint16(&cursor, SMB2_SESSION_SETUP_REQUEST_SIZE);
+    evpl_iovec_cursor_append_uint8(&cursor, 0);
+    evpl_iovec_cursor_append_uint8(&cursor, SMB2_SIGNING_ENABLED);
+    evpl_iovec_cursor_append_uint32(&cursor, 0);
+    evpl_iovec_cursor_append_uint32(&cursor, 0);
+    evpl_iovec_cursor_append_uint16(&cursor, sizeof(struct smb2_header) + 24);
+    evpl_iovec_cursor_append_uint16(&cursor, (uint16_t) token_len);
+    evpl_iovec_cursor_append_uint64(&cursor, 0);
+    evpl_iovec_cursor_append_blob(&cursor, (void *) token, token_len);
+
+    /* Fold the raw SESSION_SETUP request into the preauth hash before send.
+     * The 3.1.1 signing key is derived over the hash through the final
+     * (AUTHENTICATE) request, so both legs must be folded here. */
+    (void) chimera_smb_client_msg_from_iov(&iov, &cursor, &msg_len);
+    chimera_smb_client_preauth_fold(conn, hdr, msg_len);
+
+    chimera_smb_client_pdu_finish(conn, &iov, &cursor, conn->mount_request,
+                                  reply_cb, NULL);
+} /* chimera_smb_client_session_setup_send */
+
+static void
+chimera_smb_client_session_setup_done(
+    struct chimera_smb_client_conn *conn,
+    uint32_t                        status,
+    const struct smb2_header       *hdr,
+    struct evpl_iovec_cursor       *body,
+    int                             body_len,
+    void                           *arg)
+{
+    struct chimera_smb_client_server *server = conn->server;
+
+    (void) hdr;
+    (void) body;
+    (void) body_len;
+    (void) arg;
+
+    if (status != SMB2_STATUS_SUCCESS) {
+        chimera_smbclient_error("SESSION_SETUP (authenticate) failed: status 0x%08x", status);
+        chimera_smb_client_conn_fail(conn, chimera_smb_status_to_errno(status));
+        return;
+    }
+
+    /* The session is now authenticated.  Derive the per-session signing key and,
+     * for a 3.x session with signing on, activate signing on the shared server
+     * struct so every (mount + per-thread) connection signs/verifies with it.
+     *
+     * The key is derived over the same inputs the server used while processing
+     * the final AUTHENTICATE request: the NTLM session key, and (for 3.1.1) the
+     * preauth-integrity hash accumulated through that request.  We deliberately
+     * do NOT fold the SUCCESS reply first — the server derives before signing
+     * that reply, so deriving here keeps both sides identical.  2.1 is left
+     * unsigned (signing_active stays clear), preserving the working 2.1 path. */
+    if (server->dialect >= SMB2_DIALECT_3_0 && conn->ntlm.have_session_key) {
+        if (chimera_smb_client_derive_signing_key(
+                server->dialect,
+                conn->ntlm.session_key, sizeof(conn->ntlm.session_key),
+                conn->negotiated_dialect == SMB2_DIALECT_3_1_1 ? conn->preauth_hash : NULL,
+                server->signing_key) != 0) {
+            chimera_smbclient_error("Failed to derive SMB3 signing key (dialect 0x%04x)",
+                                    server->dialect);
+            chimera_smb_client_conn_fail(conn, CHIMERA_VFS_EIO);
+            return;
+        }
+        server->signing_alg    = conn->negotiated_signing_alg;
+        server->signing_active = 1;
+    }
+
+    chimera_smb_client_tree_connect_send(conn);
+} /* chimera_smb_client_session_setup_done */
+
+static void
+chimera_smb_client_session_setup_challenge(
+    struct chimera_smb_client_conn *conn,
+    uint32_t                        status,
+    const struct smb2_header       *hdr,
+    struct evpl_iovec_cursor       *body,
+    int                             body_len,
+    void                           *arg)
+{
+    uint16_t                 structsize, session_flags, blob_offset, blob_length;
+    uint8_t                  challenge[2048];
+    uint8_t                  authenticate[2048];
+    size_t                   auth_len;
+    int                      consumed;
+    struct evpl_iovec_cursor fold_cursor;
+
+    (void) arg;
+
+    if (status != SMB2_STATUS_MORE_PROCESSING_REQUIRED &&
+        status != SMB2_STATUS_SUCCESS) {
+        chimera_smbclient_error("SESSION_SETUP (negotiate) failed: status 0x%08x", status);
+        chimera_smb_client_conn_fail(conn, chimera_smb_status_to_errno(status));
+        return;
+    }
+
+    conn->server->session_id = hdr->session_id;
+
+    /* Fold the raw challenge reply into the preauth hash before continuing.
+    * Snapshot the body cursor first since the parsing below consumes it. */
+    fold_cursor = *body;
+    chimera_smb_client_preauth_fold_reply(conn, hdr, &fold_cursor, body_len);
+
+    evpl_iovec_cursor_get_uint16(body, &structsize);
+    evpl_iovec_cursor_get_uint16(body, &session_flags);
+    evpl_iovec_cursor_get_uint16(body, &blob_offset);
+    evpl_iovec_cursor_get_uint16(body, &blob_length);
+
+    (void) structsize;
+    (void) session_flags;
+
+    if (blob_length == 0 || blob_length > sizeof(challenge)) {
+        chimera_smbclient_error("SESSION_SETUP response has invalid security buffer (%u bytes)", blob_length);
+        chimera_smb_client_conn_fail(conn, CHIMERA_VFS_EINVAL);
+        return;
+    }
+
+    consumed = evpl_iovec_cursor_consumed(body);
+    if (blob_offset < consumed ||
+        blob_offset - consumed + blob_length > body_len + (int) sizeof(struct smb2_header)) {
+        chimera_smbclient_error("SESSION_SETUP security buffer out of range");
+        chimera_smb_client_conn_fail(conn, CHIMERA_VFS_EINVAL);
+        return;
+    }
+    evpl_iovec_cursor_skip(body, blob_offset - consumed);
+    evpl_iovec_cursor_copy(body, challenge, blob_length);
+
+    if (smb_ntlm_client_parse_challenge(&conn->ntlm, challenge, blob_length) < 0) {
+        chimera_smbclient_error("Failed to parse NTLM CHALLENGE");
+        chimera_smb_client_conn_fail(conn, CHIMERA_VFS_EACCES);
+        return;
+    }
+
+    if (smb_ntlm_client_build_authenticate(&conn->ntlm, authenticate,
+                                           sizeof(authenticate), &auth_len) < 0) {
+        chimera_smbclient_error("Failed to build NTLM AUTHENTICATE");
+        chimera_smb_client_conn_fail(conn, CHIMERA_VFS_EACCES);
+        return;
+    }
+
+    chimera_smb_client_session_setup_send(conn, authenticate, auth_len,
+                                          chimera_smb_client_session_setup_done);
+} /* chimera_smb_client_session_setup_challenge */
+
+/* ---- NEGOTIATE --------------------------------------------------------- */
+
+/* Parse the 3.1.1 negotiate-context list out of a NEGOTIATE reply to learn the
+ * server's selected signing algorithm (and confirm it echoed a preauth-integrity
+ * context).  `ctx_off` is the absolute NegotiateContextOffset from the SMB2
+ * header; `body` is positioned at the body start (consumed == sizeof header).
+ * Returns 0 on success.  Defaults signing_alg to AES-CMAC (the 3.1.1 default)
+ * when the server does not echo a SIGNING_CAPABILITIES context. */
+static int
+chimera_smb_client_parse_neg_contexts(
+    struct chimera_smb_client_conn *conn,
+    struct evpl_iovec_cursor       *body,
+    uint32_t                        ctx_off,
+    uint16_t                        ctx_count,
+    int                             body_len)
+{
+    uint16_t i;
+    int      consumed;
+    int      have_preauth = 0;
+
+    /* The whole SMB2 message (header + body) is what body_len covers from the
+     * body start; ctx_off is from the header, so the byte we must reach in the
+     * body is ctx_off - sizeof(header). */
+    consumed = evpl_iovec_cursor_consumed(body); /* == sizeof(smb2_header) */
+    if ((int) ctx_off < consumed) {
+        return -1;
+    }
+    evpl_iovec_cursor_skip(body, (int) ctx_off - consumed);
+
+    for (i = 0; i < ctx_count; i++) {
+        uint16_t type, len;
+        uint8_t  data[256];
+
+        /* Each context is 8-byte aligned from the header; align the cursor (it
+         * is consumed-relative to the header). */
+        evpl_iovec_cursor_skip(body, (8 - (body->consumed & 7)) & 7);
+        evpl_iovec_cursor_get_uint16(body, &type);
+        evpl_iovec_cursor_get_uint16(body, &len);
+        evpl_iovec_cursor_skip(body, 4); /* Reserved */
+
+        if (len > sizeof(data)) {
+            return -1;
+        }
+        if (len) {
+            evpl_iovec_cursor_copy(body, data, len);
+        }
+
+        switch (type) {
+            case SMB2_PREAUTH_INTEGRITY_CAPABILITIES:
+                /* HashAlgorithmCount(2), SaltLength(2), HashAlgorithms[...]. */
+                if (len >= 6 && smb_wire_le16(data + 4) == SMB2_PREAUTH_HASH_SHA_512) {
+                    have_preauth = 1;
+                }
+                break;
+            case SMB2_SIGNING_CAPABILITIES:
+                /* SigningAlgorithmCount(2), SigningAlgorithms[0]. */
+                if (len >= 4) {
+                    conn->negotiated_signing_alg = smb_wire_le16(data + 2);
+                }
+                break;
+            default:
+                break;
+        } /* switch */
+    }
+
+    (void) body_len;
+
+    if (!have_preauth) {
+        chimera_smbclient_error("SMB 3.1.1 NEGOTIATE reply without SHA-512 preauth context");
+        return -1;
+    }
+    return 0;
+} /* chimera_smb_client_parse_neg_contexts */
+
+static void
+chimera_smb_client_negotiate_reply(
+    struct chimera_smb_client_conn *conn,
+    uint32_t                        status,
+    const struct smb2_header       *hdr,
+    struct evpl_iovec_cursor       *body,
+    int                             body_len,
+    void                           *arg)
+{
+    uint16_t                 structsize, security_mode, dialect, ctx_count;
+    uint32_t                 ctx_off;
+    uint8_t                  negotiate[64];
+    int                      neg_len;
+    struct evpl_iovec_cursor ctx_cursor;
+
+    (void) arg;
+
+    if (status != SMB2_STATUS_SUCCESS) {
+        chimera_smbclient_error("NEGOTIATE failed: status 0x%08x", status);
+        chimera_smb_client_conn_fail(conn, chimera_smb_status_to_errno(status));
+        return;
+    }
+
+    /* Snapshot the body cursor for context parsing before we consume the fixed
+     * NEGOTIATE-reply fields. */
+    ctx_cursor = *body;
+
+    /* NEGOTIATE reply fixed fields: StructSize(2), SecurityMode(2), Dialect(2),
+     * NegotiateContextCount(2), ServerGuid(16), Capabilities(4),
+     * MaxTransact(4), MaxRead(4), MaxWrite(4), SystemTime(8), StartTime(8),
+     * SecurityBufferOffset(2), SecurityBufferLength(2),
+     * NegotiateContextOffset(4). */
+    evpl_iovec_cursor_get_uint16(body, &structsize);
+    evpl_iovec_cursor_get_uint16(body, &security_mode);
+    evpl_iovec_cursor_get_uint16(body, &dialect);
+    evpl_iovec_cursor_get_uint16(body, &ctx_count);
+    evpl_iovec_cursor_skip(body, 16);            /* ServerGuid */
+    evpl_iovec_cursor_skip(body, 4);             /* Capabilities */
+    evpl_iovec_cursor_get_uint32(body, &conn->server->max_transact);
+    evpl_iovec_cursor_get_uint32(body, &conn->server->max_read);
+    evpl_iovec_cursor_get_uint32(body, &conn->server->max_write);
+    evpl_iovec_cursor_skip(body, 8 + 8);         /* SystemTime + ServerStartTime */
+    evpl_iovec_cursor_skip(body, 2 + 2);         /* SecurityBufferOffset + Length */
+    evpl_iovec_cursor_get_uint32(body, &ctx_off);
+
+    (void) structsize;
+
+    conn->server->security_mode = security_mode;
+    conn->server->dialect       = dialect;
+    conn->negotiated_dialect    = dialect;
+
+    /* Fold the raw NEGOTIATE reply into the preauth hash (header + body, no
+     * trailing pad), reconstructing the contiguous message from the body
+     * snapshot taken before the fixed fields were consumed. */
+    chimera_smb_client_preauth_fold_reply(conn, hdr, &ctx_cursor, body_len);
+
+    if (dialect == SMB2_DIALECT_3_1_1) {
+        if (chimera_smb_client_parse_neg_contexts(conn, &ctx_cursor, ctx_off,
+                                                  ctx_count, body_len) != 0) {
+            chimera_smb_client_conn_fail(conn, CHIMERA_VFS_ENOTSUP);
+            return;
+        }
+    } else if (dialect != SMB2_DIALECT_2_1 && dialect != SMB2_DIALECT_3_0 &&
+               dialect != SMB2_DIALECT_3_0_2) {
+        chimera_smbclient_error("Server selected unsupported dialect 0x%04x", dialect);
+        chimera_smb_client_conn_fail(conn, CHIMERA_VFS_ENOTSUP);
+        return;
+    }
+
+    /* A secondary connection (the session already exists) is READY once it has
+    * negotiated; it reuses the shared session_id/tree_id AND signing state
+    * (signing key is per-session, already derived on the mount connection). */
+    if (!conn->mount_request) {
+        chimera_smb_client_conn_ready(conn);
+        return;
+    }
+
+    /* The mount connection continues into authentication. */
+    neg_len = smb_ntlm_client_build_negotiate(negotiate, sizeof(negotiate));
+    if (neg_len < 0) {
+        chimera_smb_client_conn_fail(conn, CHIMERA_VFS_EFAULT);
+        return;
+    }
+
+    chimera_smb_client_session_setup_send(conn, negotiate, neg_len,
+                                          chimera_smb_client_session_setup_challenge);
+} /* chimera_smb_client_negotiate_reply */
+
+/* Append a single SMB2 NEGOTIATE-request context (ContextType, DataLength,
+ * Reserved(4), Data), 8-byte aligned from the start of the SMB2 header.  The
+ * cursor is consumed-relative to the SMB2 header (pdu_begin reset it there), so
+ * evpl_iovec_cursor_zero to the next 8-byte boundary aligns correctly. */
+static void
+chimera_smb_client_append_neg_context(
+    struct evpl_iovec_cursor *cursor,
+    uint16_t                  type,
+    const uint8_t            *data,
+    uint16_t                  data_len)
+{
+    evpl_iovec_cursor_zero(cursor, (8 - (cursor->consumed & 7)) & 7);
+    evpl_iovec_cursor_append_uint16(cursor, type);
+    evpl_iovec_cursor_append_uint16(cursor, data_len);
+    evpl_iovec_cursor_append_uint32(cursor, 0); /* Reserved */
+    if (data_len) {
+        evpl_iovec_cursor_append_blob(cursor, (void *) data, data_len);
+    }
+} /* chimera_smb_client_append_neg_context */
+
+void
+chimera_smb_client_conn_on_connected(struct chimera_smb_client_conn *conn)
+{
+    static const uint16_t    dialects[CHIMERA_SMB_CLIENT_NUM_DIALECTS] =
+        CHIMERA_SMB_CLIENT_DIALECTS;
+    struct evpl_iovec        iov;
+    struct evpl_iovec_cursor cursor;
+    struct smb2_header      *hdr;
+    uint8_t                  client_guid[SMB2_GUID_SIZE];
+    uint8_t                  preauth_ctx[4 + 2 + CHIMERA_SMB_CLIENT_PREAUTH_SALT_LEN];
+    uint8_t                  signing_ctx[2 + 2 * 2];
+    int                      ctx_offset_pos, ctx_count_pos;
+    int                      ctx_offset, msg_len;
+    int                      i;
+
+    memset(client_guid, 0, sizeof(client_guid));
+
+    chimera_smb_client_pdu_begin(conn, SMB2_NEGOTIATE, &iov, &cursor, &hdr);
+
+    /* Fresh handshake: reset the preauth-integrity hash for this connection. */
+    memset(conn->preauth_hash, 0, sizeof(conn->preauth_hash));
+    conn->negotiated_dialect     = 0;
+    conn->negotiated_signing_alg = SMB2_SIGNING_AES_CMAC; /* 3.1.1 default */
+
+    evpl_iovec_cursor_append_uint16(&cursor, SMB2_NEGOTIATE_REQUEST_SIZE);
+    evpl_iovec_cursor_append_uint16(&cursor, CHIMERA_SMB_CLIENT_NUM_DIALECTS);
+    evpl_iovec_cursor_append_uint16(&cursor, SMB2_SIGNING_ENABLED);
+    evpl_iovec_cursor_append_uint16(&cursor, 0); /* Reserved */
+    evpl_iovec_cursor_append_uint32(&cursor, 0); /* Capabilities */
+    evpl_iovec_cursor_append_blob(&cursor, client_guid, SMB2_GUID_SIZE);
+    /* NegotiateContextOffset(4) + NegotiateContextCount(2) + Reserved2(2).
+     * Backpatched below once the dialects + contexts are laid out. */
+    ctx_offset_pos = cursor.consumed;
+    evpl_iovec_cursor_append_uint32(&cursor, 0);
+    ctx_count_pos = cursor.consumed;
+    evpl_iovec_cursor_append_uint16(&cursor, 0);
+    evpl_iovec_cursor_append_uint16(&cursor, 0); /* Reserved2 */
+
+    for (i = 0; i < CHIMERA_SMB_CLIENT_NUM_DIALECTS; i++) {
+        evpl_iovec_cursor_append_uint16(&cursor, dialects[i]);
+    }
+
+    /* 3.1.1 negotiate contexts.  Offset is 8-byte aligned from the SMB2 header;
+     * the cursor is consumed-relative to that header. */
+    evpl_iovec_cursor_zero(&cursor, (8 - (cursor.consumed & 7)) & 7);
+    ctx_offset = cursor.consumed;
+
+    /* SMB2_PREAUTH_INTEGRITY_CAPABILITIES: HashAlgorithmCount(2)=1,
+    * SaltLength(2), HashAlgorithms[1]=SHA-512, Salt(SaltLength). */
+    smb_wire_set_le16(preauth_ctx + 0, 1);
+    smb_wire_set_le16(preauth_ctx + 2, CHIMERA_SMB_CLIENT_PREAUTH_SALT_LEN);
+    smb_wire_set_le16(preauth_ctx + 4, SMB2_PREAUTH_HASH_SHA_512);
+    memset(preauth_ctx + 6, 0, CHIMERA_SMB_CLIENT_PREAUTH_SALT_LEN); /* salt value is arbitrary */
+    chimera_smb_client_append_neg_context(&cursor, SMB2_PREAUTH_INTEGRITY_CAPABILITIES,
+                                          preauth_ctx, sizeof(preauth_ctx));
+
+    /* SMB2_SIGNING_CAPABILITIES: SigningAlgorithmCount(2)=2,
+     * SigningAlgorithms = { AES-GMAC, AES-CMAC } (client preference order). */
+    smb_wire_set_le16(signing_ctx + 0, 2);
+    smb_wire_set_le16(signing_ctx + 2, SMB2_SIGNING_AES_GMAC);
+    smb_wire_set_le16(signing_ctx + 4, SMB2_SIGNING_AES_CMAC);
+    chimera_smb_client_append_neg_context(&cursor, SMB2_SIGNING_CAPABILITIES,
+                                          signing_ctx, sizeof(signing_ctx));
+
+    /* Backpatch NegotiateContextOffset (absolute from SMB2 header) and Count. */
+    {
+        struct smb_client_netbios_header *netbios = evpl_iovec_data(&iov);
+        uint8_t                          *smb2    = (uint8_t *) (netbios + 1);
+        smb_wire_set_le32(smb2 + ctx_offset_pos, (uint32_t) ctx_offset);
+        smb_wire_set_le16(smb2 + ctx_count_pos, 2);
+    }
+
+    /* Fold the raw NEGOTIATE request into the preauth hash before send. */
+    (void) chimera_smb_client_msg_from_iov(&iov, &cursor, &msg_len);
+    chimera_smb_client_preauth_fold(conn, hdr, msg_len);
+
+    chimera_smb_client_pdu_finish(conn, &iov, &cursor, conn->mount_request,
+                                  chimera_smb_client_negotiate_reply, NULL);
+} /* chimera_smb_client_conn_on_connected */
+
+/* ---- MOUNT entry point ------------------------------------------------- */
+
+void
+chimera_smb_client_mount(
+    struct chimera_smb_client_thread *thread,
+    struct chimera_vfs_request       *request)
+{
+    struct chimera_smb_client_shared *shared = thread->shared;
+    struct chimera_smb_client_server *server;
+    struct chimera_smb_client_conn   *conn;
+    const char                       *user, *password, *domain, *port_opt;
+    char                              host[256];
+    char                              share[256];
+    const char                       *colon;
+    int                               host_len;
+    uint16_t                          port;
+
+    shared->tcp_protocol = chimera_tcp_flavor_to_protocol(request->thread->vfs->tcp_flavor);
+
+    colon = memchr(request->mount.path, ':', request->mount.pathlen);
+    if (!colon) {
+        chimera_smbclient_error("SMB mount path '%s' is not host:share", request->mount.path);
+        request->status = CHIMERA_VFS_EINVAL;
+        request->complete(request);
+        return;
+    }
+
+    host_len = (int) (colon - request->mount.path);
+    if (host_len <= 0 || host_len >= (int) sizeof(host)) {
+        request->status = CHIMERA_VFS_EINVAL;
+        request->complete(request);
+        return;
+    }
+    memcpy(host, request->mount.path, host_len);
+    host[host_len] = '\0';
+    snprintf(share, sizeof(share), "%s", colon + 1);
+
+    user     = chimera_smb_client_get_option(&request->mount.options, "user");
+    password = chimera_smb_client_get_option(&request->mount.options, "password");
+    domain   = chimera_smb_client_get_option(&request->mount.options, "domain");
+    port_opt = chimera_smb_client_get_option(&request->mount.options, "port");
+
+    if (!user || !password) {
+        chimera_smbclient_error("SMB mount requires user= and password= options");
+        request->status = CHIMERA_VFS_EINVAL;
+        request->complete(request);
+        return;
+    }
+
+    port = port_opt ? (uint16_t) atoi(port_opt) : CHIMERA_SMB_CLIENT_PORT;
+
+    server = chimera_smb_client_server_alloc(shared);
+    if (!server) {
+        chimera_smbclient_error("SMB client server table full");
+        request->status = CHIMERA_VFS_ENOSPC;
+        request->complete(request);
+        return;
+    }
+
+    snprintf(server->hostname, sizeof(server->hostname), "%s", host);
+    snprintf(server->share, sizeof(server->share), "%s", share);
+    snprintf(server->user, sizeof(server->user), "%s", user);
+    snprintf(server->domain, sizeof(server->domain), "%s",
+             domain ? domain : CHIMERA_SMB_CLIENT_DEFAULT_DOMAIN);
+    snprintf(server->password, sizeof(server->password), "%s", password);
+    server->port     = port;
+    server->endpoint = evpl_endpoint_create(server->hostname, server->port);
+
+    conn = chimera_smb_client_get_conn(thread, server);
+
+    conn->mount_request = request;
+    conn->state         = CHIMERA_SMB_CONN_CONNECTING;
+
+    smb_ntlm_client_init(&conn->ntlm, server->user, server->domain, server->password);
+
+    conn->bind = chimera_smb_client_connect(conn, server->endpoint);
+} /* chimera_smb_client_mount */

--- a/src/vfs/smb/smb_namespace.c
+++ b/src/vfs/smb/smb_namespace.c
@@ -1,0 +1,515 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <xxhash.h>
+
+#include "smb_internal.h"
+#include "vfs/vfs_attrs.h"
+#include "evpl/evpl.h"
+
+/*
+ * SMB2 namespace operations for the path-only SMB client: rename, symlink, and
+ * mknod.  Each addresses files by the full mount-relative path carried in
+ * request->X.name (and request->rename_at.new_name for rename) and drives a
+ * transient SMB2 CREATE -> SET_INFO/IOCTL -> CLOSE chain, reusing the shared
+ * helpers in smb_internal.h (smb_send_create / smb_send_close /
+ * smb_parse_create_reply / smb_apply_attrs / struct chimera_smb_op_state).
+ */
+
+/* SMB2 IOCTL request fixed-field size (StructureSize value, MS-SMB2 2.2.31).
+ * Defined locally because smb2.h carries it for the SET_REPARSE wire format. */
+#ifndef SMB2_IOCTL_REQUEST_SIZE
+#define SMB2_IOCTL_REQUEST_SIZE 57
+#endif /* ifndef SMB2_IOCTL_REQUEST_SIZE */
+
+/* IOCTL Flags bit: this is an FSCTL (MS-SMB2 2.2.31 SMB2_0_IOCTL_IS_FSCTL).
+ * Not defined in smb2.h (the server ignores the field), so define it here. */
+#define SMB2_0_IOCTL_IS_FSCTL   0x00000001
+
+/* ---- rename_at (SET_INFO FileRenameInformation) ------------------------ */
+
+/*
+ * rename_at chain: CREATE the source path (DELETE | READ_ATTRIBUTES) -> SET_INFO
+ * FileRenameInformation with the destination path -> CLOSE.  The transient
+ * source FileId is carried in request->plugin_data (struct chimera_smb_op_state)
+ * across the three legs.
+ */
+
+static void
+chimera_smb_rename_close_reply(
+    struct chimera_smb_client_conn *conn,
+    uint32_t                        status,
+    const struct smb2_header       *hdr,
+    struct evpl_iovec_cursor       *body,
+    int                             body_len,
+    void                           *arg)
+{
+    struct chimera_vfs_request *request = arg;
+
+    (void) conn;
+    (void) hdr;
+    (void) body;
+    (void) body_len;
+    (void) status;
+
+    /* The rename status was already recorded by the SET_INFO reply; the CLOSE
+     * is best-effort cleanup of the transient open. */
+    request->complete(request);
+} /* chimera_smb_rename_close_reply */
+
+static void
+chimera_smb_rename_set_info_reply(
+    struct chimera_smb_client_conn *conn,
+    uint32_t                        status,
+    const struct smb2_header       *hdr,
+    struct evpl_iovec_cursor       *body,
+    int                             body_len,
+    void                           *arg)
+{
+    struct chimera_vfs_request  *request = arg;
+    struct chimera_smb_op_state *state   = request->plugin_data;
+
+    (void) hdr;
+    (void) body;
+    (void) body_len;
+
+    request->status = chimera_smb_status_to_errno(status);
+
+    /* Always CLOSE the transient source open, even if the rename failed. */
+    smb_send_close(conn, request, &state->file_id, chimera_smb_rename_close_reply);
+} /* chimera_smb_rename_set_info_reply */
+
+static void
+chimera_smb_rename_create_reply(
+    struct chimera_smb_client_conn *conn,
+    uint32_t                        status,
+    const struct smb2_header       *hdr,
+    struct evpl_iovec_cursor       *body,
+    int                             body_len,
+    void                           *arg)
+{
+    struct chimera_vfs_request  *request = arg;
+    struct chimera_smb_op_state *state   = request->plugin_data;
+    struct smb_create_result     r;
+    struct evpl_iovec            iov;
+    struct evpl_iovec_cursor     cursor;
+    struct smb2_header          *shdr;
+    uint8_t                      name16[2 * CHIMERA_SMB_PATH_MAX];
+    size_t                       name16_len;
+    int                          buffer_offset;
+    uint32_t                     buffer_length;
+
+    (void) hdr;
+    (void) body_len;
+
+    if (status != SMB2_STATUS_SUCCESS) {
+        request->status = chimera_smb_status_to_errno(status);
+        request->complete(request);
+        return;
+    }
+
+    smb_parse_create_reply(body, &r);
+    state->file_id = r.file_id;
+
+    if (request->rename_at.new_namelen > CHIMERA_SMB_PATH_MAX) {
+        request->status = CHIMERA_VFS_ENAMETOOLONG;
+        /* Close the transient source open before bailing. */
+        smb_send_close(conn, request, &state->file_id, chimera_smb_rename_close_reply);
+        return;
+    }
+
+    /* FileRenameInformation.FileName is the share-relative destination path in
+    * UTF-16LE with '\\' separators (smb_utf16le_encode does the '/'->'\\'). */
+    name16_len = smb_utf16le_encode(request->rename_at.new_name,
+                                    request->rename_at.new_namelen, name16);
+
+    /* FileRenameInformation buffer: ReplaceIfExists(1) + Reserved(7) +
+     * RootDirectory(8) + FileNameLength(4) = 20 fixed, then FileName(UTF-16LE). */
+    buffer_length = (uint32_t) (20 + name16_len);
+
+    /* SET_INFO, FILE / FileRenameInformation, on the open source FileId. */
+    chimera_smb_client_pdu_begin(conn, SMB2_SET_INFO, &iov, &cursor, &shdr);
+
+    /* The buffer immediately follows the SET_INFO fixed fields.  The fixed part
+     * the server reads is StructureSize(2) + InfoType(1) + InfoClass(1) +
+     * BufferLength(4) + BufferOffset(2) + Reserved(2) + AdditionalInformation(4)
+     * + FileId(16) = 32 bytes, so the buffer starts at SMB2 header + 32. */
+    buffer_offset = sizeof(struct smb2_header) + 32;
+
+    evpl_iovec_cursor_append_uint16(&cursor, SMB2_SET_INFO_REQUEST_SIZE);
+    evpl_iovec_cursor_append_uint8(&cursor, SMB2_INFO_FILE);
+    evpl_iovec_cursor_append_uint8(&cursor, SMB2_FILE_RENAME_INFO);
+    evpl_iovec_cursor_append_uint32(&cursor, buffer_length);          /* BufferLength */
+    evpl_iovec_cursor_append_uint16(&cursor, (uint16_t) buffer_offset); /* BufferOffset */
+    evpl_iovec_cursor_append_uint16(&cursor, 0);                      /* Reserved */
+    evpl_iovec_cursor_append_uint32(&cursor, 0);                      /* AdditionalInformation */
+    evpl_iovec_cursor_append_uint64(&cursor, state->file_id.pid);
+    evpl_iovec_cursor_append_uint64(&cursor, state->file_id.vid);
+
+    /* FILE_RENAME_INFORMATION_TYPE_2 body. */
+    evpl_iovec_cursor_append_uint8(&cursor, 1);                       /* ReplaceIfExists */
+    evpl_iovec_cursor_append_uint8(&cursor, 0);                       /* Reserved[0..6] */
+    evpl_iovec_cursor_append_uint16(&cursor, 0);
+    evpl_iovec_cursor_append_uint32(&cursor, 0);
+    evpl_iovec_cursor_append_uint64(&cursor, 0);                      /* RootDirectory */
+    evpl_iovec_cursor_append_uint32(&cursor, (uint32_t) name16_len);  /* FileNameLength */
+    if (name16_len > 0) {
+        evpl_iovec_cursor_append_blob(&cursor, name16, name16_len);
+    }
+
+    chimera_smb_client_pdu_finish(conn, &iov, &cursor, request,
+                                  chimera_smb_rename_set_info_reply, request);
+} /* chimera_smb_rename_create_reply */
+
+void
+chimera_smb_client_rename_at(
+    struct chimera_smb_client_conn *conn,
+    struct chimera_vfs_request     *request)
+{
+    /* Open the source by its full mount-relative path with DELETE (required to
+     * rename) + READ_ATTRIBUTES.  Cross-mount renames are already rejected by
+     * the VFS layer (EXDEV), so both paths are within this one share. */
+    smb_send_create(conn, request,
+                    request->rename_at.name, request->rename_at.namelen,
+                    SMB2_DELETE | SMB2_FILE_READ_ATTRIBUTES,
+                    SMB2_FILE_SHARE_READ | SMB2_FILE_SHARE_WRITE | SMB2_FILE_SHARE_DELETE,
+                    SMB2_FILE_OPEN, 0,
+                    chimera_smb_rename_create_reply);
+} /* chimera_smb_client_rename_at */
+
+/* ---- symlink_at (reparse point) ---------------------------------------- */
+
+/*
+ * symlink_at chain: CREATE a new file at the link path -> IOCTL
+ * FSCTL_SET_REPARSE_POINT with an NFS LNK reparse buffer carrying the target ->
+ * CLOSE.  The chimera SMB server's SET_REPARSE handler (smb_proc_reparse.c)
+ * removes the just-created placeholder and replaces it with a real symlink via
+ * chimera_vfs_symlink_at, so the placeholder's create attrs are irrelevant.
+ */
+
+static void
+chimera_smb_symlink_close_reply(
+    struct chimera_smb_client_conn *conn,
+    uint32_t                        status,
+    const struct smb2_header       *hdr,
+    struct evpl_iovec_cursor       *body,
+    int                             body_len,
+    void                           *arg)
+{
+    struct chimera_vfs_request *request = arg;
+
+    (void) conn;
+    (void) hdr;
+    (void) body;
+    (void) body_len;
+    (void) status;
+
+    /* The symlink status was recorded by the IOCTL reply; CLOSE is cleanup. */
+    request->complete(request);
+} /* chimera_smb_symlink_close_reply */
+
+static void
+chimera_smb_symlink_ioctl_reply(
+    struct chimera_smb_client_conn *conn,
+    uint32_t                        status,
+    const struct smb2_header       *hdr,
+    struct evpl_iovec_cursor       *body,
+    int                             body_len,
+    void                           *arg)
+{
+    struct chimera_vfs_request  *request = arg;
+    struct chimera_smb_op_state *state   = request->plugin_data;
+
+    (void) hdr;
+    (void) body;
+    (void) body_len;
+
+    request->status = chimera_smb_status_to_errno(status);
+
+    smb_send_close(conn, request, &state->file_id, chimera_smb_symlink_close_reply);
+} /* chimera_smb_symlink_ioctl_reply */
+
+static void
+chimera_smb_symlink_create_reply(
+    struct chimera_smb_client_conn *conn,
+    uint32_t                        status,
+    const struct smb2_header       *hdr,
+    struct evpl_iovec_cursor       *body,
+    int                             body_len,
+    void                           *arg)
+{
+    struct chimera_vfs_request  *request = arg;
+    struct chimera_smb_op_state *state   = request->plugin_data;
+    struct smb_create_result     r;
+    struct evpl_iovec            iov;
+    struct evpl_iovec_cursor     cursor;
+    struct smb2_header          *shdr;
+    uint8_t                      target16[2 * CHIMERA_SMB_PATH_MAX];
+    size_t                       target16_len;
+    int                          input_offset;
+    uint32_t                     input_count;
+    uint16_t                     reparse_data_len;
+
+    (void) hdr;
+    (void) body_len;
+
+    if (status != SMB2_STATUS_SUCCESS) {
+        request->status = chimera_smb_status_to_errno(status);
+        request->complete(request);
+        return;
+    }
+
+    smb_parse_create_reply(body, &r);
+    state->file_id = r.file_id;
+
+    if (request->symlink_at.targetlen > CHIMERA_SMB_PATH_MAX) {
+        request->status = CHIMERA_VFS_ENAMETOOLONG;
+        smb_send_close(conn, request, &state->file_id, chimera_smb_symlink_close_reply);
+        return;
+    }
+
+    /* The reparse target is UTF-16LE with '\\' separators (the server flips
+     * '\\'->'/' on parse), reusing smb_utf16le_encode's '/'->'\\' convention. */
+    target16_len = smb_utf16le_encode(request->symlink_at.target,
+                                      request->symlink_at.targetlen, target16);
+
+    /* NFS reparse data buffer (matches smb_proc_reparse.c parse for TAG_NFS):
+     *   ReparseTag(4) + ReparseDataLength(2) + Reserved(2) +
+     *   InodeType(8 = NFS_SPECFILE_LNK) + Target(UTF-16LE).
+     * ReparseDataLength covers InodeType(8) + the UTF-16LE target. */
+    reparse_data_len = (uint16_t) (8 + target16_len);
+    input_count      = (uint32_t) (8 + reparse_data_len);
+
+    chimera_smb_client_pdu_begin(conn, SMB2_IOCTL, &iov, &cursor, &shdr);
+
+    /* The input buffer follows the IOCTL fixed fields: StructureSize(2) +
+     * CtlCode(4) + FileId(16) + InputOffset(4) + InputCount(4) +
+     * MaxInputResponse(4) + OutputOffset(4) + OutputCount(4) +
+     * MaxOutputResponse(4) + Flags(4) + Reserved2(4).  The self-aligning uint32
+     * append for CtlCode (right after the 2-byte StructureSize) inserts the
+     * 2-byte pad that is the spec's Reserved field, so the fixed part is 56
+     * bytes and the input starts at SMB2 header + 56. */
+    input_offset = sizeof(struct smb2_header) + 56;
+
+    evpl_iovec_cursor_append_uint16(&cursor, SMB2_IOCTL_REQUEST_SIZE);
+    evpl_iovec_cursor_append_uint32(&cursor, SMB2_FSCTL_SET_REPARSE_POINT);
+    evpl_iovec_cursor_append_uint64(&cursor, state->file_id.pid);
+    evpl_iovec_cursor_append_uint64(&cursor, state->file_id.vid);
+    evpl_iovec_cursor_append_uint32(&cursor, (uint32_t) input_offset); /* InputOffset */
+    evpl_iovec_cursor_append_uint32(&cursor, input_count);             /* InputCount */
+    evpl_iovec_cursor_append_uint32(&cursor, 0);                       /* MaxInputResponse */
+    evpl_iovec_cursor_append_uint32(&cursor, 0);                       /* OutputOffset */
+    evpl_iovec_cursor_append_uint32(&cursor, 0);                       /* OutputCount */
+    evpl_iovec_cursor_append_uint32(&cursor, 0);                       /* MaxOutputResponse */
+    evpl_iovec_cursor_append_uint32(&cursor, SMB2_0_IOCTL_IS_FSCTL);   /* Flags */
+    evpl_iovec_cursor_append_uint32(&cursor, 0);                       /* Reserved2 */
+
+    /* REPARSE_DATA_BUFFER (NFS) input. */
+    evpl_iovec_cursor_append_uint32(&cursor, SMB2_IO_REPARSE_TAG_NFS);
+    evpl_iovec_cursor_append_uint16(&cursor, reparse_data_len);
+    evpl_iovec_cursor_append_uint16(&cursor, 0);                       /* Reserved */
+    evpl_iovec_cursor_append_uint64(&cursor, SMB2_NFS_SPECFILE_LNK);   /* InodeType */
+    if (target16_len > 0) {
+        evpl_iovec_cursor_append_blob(&cursor, target16, target16_len);
+    }
+
+    chimera_smb_client_pdu_finish(conn, &iov, &cursor, request,
+                                  chimera_smb_symlink_ioctl_reply, request);
+} /* chimera_smb_symlink_create_reply */
+
+void
+chimera_smb_client_symlink_at(
+    struct chimera_smb_client_conn *conn,
+    struct chimera_vfs_request     *request)
+{
+    /* CREATE a new placeholder at the link path (FILE_CREATE fails if it already
+     * exists, matching symlink_at's EEXIST semantics).  The server's
+     * SET_REPARSE handler then removes the placeholder and lays down the real
+     * symlink, so we only need DELETE + WRITE access on the placeholder. */
+    smb_send_create(conn, request,
+                    request->symlink_at.name, request->symlink_at.namelen,
+                    SMB2_DELETE | SMB2_FILE_WRITE_DATA | SMB2_FILE_WRITE_ATTRIBUTES |
+                    SMB2_FILE_READ_ATTRIBUTES,
+                    SMB2_FILE_SHARE_READ | SMB2_FILE_SHARE_WRITE | SMB2_FILE_SHARE_DELETE,
+                    SMB2_FILE_CREATE, SMB2_FILE_NON_DIRECTORY_FILE,
+                    chimera_smb_symlink_create_reply);
+} /* chimera_smb_client_symlink_at */
+
+/* ---- readlink (FSCTL_GET_REPARSE_POINT) -------------------------------- */
+
+/*
+ * readlink operates on an open handle.  The client genericization opens the
+ * target with CHIMERA_VFS_OPEN_NOFOLLOW, which the SMB open_at maps to
+ * FILE_OPEN_REPARSE_POINT, so the handle's FileId refers to the symlink itself.
+ * We then issue FSCTL_GET_REPARSE_POINT and decode the NFS LNK reparse buffer
+ * the server returns (mirrors chimera_smb_get_reparse_readlink_cb).
+ */
+
+static void
+chimera_smb_readlink_reply(
+    struct chimera_smb_client_conn *conn,
+    uint32_t                        status,
+    const struct smb2_header       *hdr,
+    struct evpl_iovec_cursor       *body,
+    int                             body_len,
+    void                           *arg)
+{
+    struct chimera_vfs_request *request = arg;
+    uint16_t                    structsize, reparse_data_len, rsvd16;
+    uint32_t                    ctlcode, input_offset, input_count;
+    uint32_t                    output_offset, output_count, flags, rsvd32;
+    uint32_t                    reparse_tag;
+    uint64_t                    fid_pid, fid_vid, inode_type;
+    int                         consumed, target16_len, i, out;
+    char                       *out_buf = request->readlink.r_target;
+    uint32_t                    maxlen  = request->readlink.target_maxlength;
+    uint8_t                     target16[2 * CHIMERA_SMB_PATH_MAX];
+
+    (void) hdr;
+    (void) body_len;
+
+    if (status != SMB2_STATUS_SUCCESS) {
+        request->status = chimera_smb_status_to_errno(status);
+        request->complete(request);
+        return;
+    }
+
+    /* IOCTL response (the chimera server's field order: StructureSize then
+     * CtlCode directly, no leading Reserved -- matches the request convention). */
+    evpl_iovec_cursor_get_uint16(body, &structsize);
+    evpl_iovec_cursor_get_uint32(body, &ctlcode);
+    evpl_iovec_cursor_get_uint64(body, &fid_pid);
+    evpl_iovec_cursor_get_uint64(body, &fid_vid);
+    evpl_iovec_cursor_get_uint32(body, &input_offset);
+    evpl_iovec_cursor_get_uint32(body, &input_count);
+    evpl_iovec_cursor_get_uint32(body, &output_offset);
+    evpl_iovec_cursor_get_uint32(body, &output_count);
+    evpl_iovec_cursor_get_uint32(body, &flags);
+    evpl_iovec_cursor_get_uint32(body, &rsvd32);
+
+    (void) structsize;
+    (void) ctlcode;
+    (void) fid_pid;
+    (void) fid_vid;
+    (void) input_offset;
+    (void) input_count;
+    (void) flags;
+    (void) rsvd32;
+
+    /* OutputOffset is header-relative, as is the cursor's consumed count. */
+    consumed = evpl_iovec_cursor_consumed(body);
+    if ((int) output_offset > consumed) {
+        evpl_iovec_cursor_skip(body, (int) output_offset - consumed);
+    }
+
+    /* REPARSE_DATA_BUFFER: ReparseTag(4) + ReparseDataLength(2) + Reserved(2) +
+     * InodeType(8) + UTF-16LE target. */
+    if (output_count < 16) {
+        request->status = CHIMERA_VFS_EINVAL;
+        request->complete(request);
+        return;
+    }
+
+    evpl_iovec_cursor_get_uint32(body, &reparse_tag);
+    evpl_iovec_cursor_get_uint16(body, &reparse_data_len);
+    evpl_iovec_cursor_get_uint16(body, &rsvd16);
+    evpl_iovec_cursor_get_uint64(body, &inode_type);
+
+    (void) rsvd16;
+
+    /* readlink of a non-symlink is EINVAL (POSIX). */
+    if (reparse_tag != SMB2_IO_REPARSE_TAG_NFS ||
+        inode_type != SMB2_NFS_SPECFILE_LNK || reparse_data_len < 8) {
+        request->status = CHIMERA_VFS_EINVAL;
+        request->complete(request);
+        return;
+    }
+
+    target16_len = reparse_data_len - 8;     /* UTF-16LE target bytes */
+    if (target16_len > (int) sizeof(target16)) {
+        target16_len = sizeof(target16);
+    }
+
+    /* A truncated reply (claims reparse_data_len bytes but the cursor is short)
+     * would leave target16 partly uninitialized -- treat it as a bad reply. */
+    if (evpl_iovec_cursor_get_blob(body, target16, target16_len) < 0) {
+        request->status = CHIMERA_VFS_EINVAL;
+        request->complete(request);
+        return;
+    }
+
+    /* Decode UTF-16LE (ASCII subset) into r_target, flipping '\\' back to '/'
+     * (symmetric with smb_utf16le_encode). */
+    out = 0;
+    for (i = 0; i + 1 < target16_len && (uint32_t) out < maxlen; i += 2) {
+        char c = (char) target16[i];
+        out_buf[out++] = (c == '\\') ? '/' : c;
+    }
+
+    request->readlink.r_target_length = out;
+    request->status                   = CHIMERA_VFS_OK;
+    request->complete(request);
+} /* chimera_smb_readlink_reply */
+
+void
+chimera_smb_client_readlink(
+    struct chimera_smb_client_conn *conn,
+    struct chimera_vfs_request     *request)
+{
+    struct chimera_smb_client_open *open_state = smb_handle_open_state(request->readlink.handle);
+    struct evpl_iovec               iov;
+    struct evpl_iovec_cursor        cursor;
+    struct smb2_header             *hdr;
+    int                             input_offset;
+
+    if (!open_state) {
+        request->status = CHIMERA_VFS_EINVAL;
+        request->complete(request);
+        return;
+    }
+
+    chimera_smb_client_pdu_begin(conn, SMB2_IOCTL, &iov, &cursor, &hdr);
+
+    /* No input buffer; the server reads InputCount(0) bytes at InputOffset.
+     * Fixed part is 56 bytes (see chimera_smb_client_symlink_at). */
+    input_offset = sizeof(struct smb2_header) + 56;
+
+    evpl_iovec_cursor_append_uint16(&cursor, SMB2_IOCTL_REQUEST_SIZE);
+    evpl_iovec_cursor_append_uint32(&cursor, SMB2_FSCTL_GET_REPARSE_POINT);
+    evpl_iovec_cursor_append_uint64(&cursor, open_state->file_id.pid);
+    evpl_iovec_cursor_append_uint64(&cursor, open_state->file_id.vid);
+    evpl_iovec_cursor_append_uint32(&cursor, (uint32_t) input_offset);       /* InputOffset */
+    evpl_iovec_cursor_append_uint32(&cursor, 0);                             /* InputCount */
+    evpl_iovec_cursor_append_uint32(&cursor, 0);                             /* MaxInputResponse */
+    evpl_iovec_cursor_append_uint32(&cursor, 0);                             /* OutputOffset */
+    evpl_iovec_cursor_append_uint32(&cursor, 0);                             /* OutputCount */
+    evpl_iovec_cursor_append_uint32(&cursor, 16 + 2 * CHIMERA_SMB_PATH_MAX); /* MaxOutputResponse */
+    evpl_iovec_cursor_append_uint32(&cursor, SMB2_0_IOCTL_IS_FSCTL);         /* Flags */
+    evpl_iovec_cursor_append_uint32(&cursor, 0);                             /* Reserved2 */
+
+    chimera_smb_client_pdu_finish(conn, &iov, &cursor, request,
+                                  chimera_smb_readlink_reply, request);
+} /* chimera_smb_client_readlink */
+
+/* ---- mknod_at ---------------------------------------------------------- */
+
+void
+chimera_smb_client_mknod_at(
+    struct chimera_smb_client_conn *conn,
+    struct chimera_vfs_request     *request)
+{
+    /* SMB2 has no general mknod path.  Device/FIFO/socket nodes can in
+     * principle be created via the same FSCTL_SET_REPARSE_POINT NFS mechanism
+     * used for symlinks (the chimera server supports the CHR/BLK/FIFO/SOCK NFS
+     * specfile types), but the VFS mknod_at request carries no encoding for the
+     * node type beyond va_mode/va_rdev in set_attr, and there is no test or
+     * caller exercising it through this backend.  Report ENOTSUP cleanly rather
+     * than guess at a mapping. */
+    (void) conn;
+    request->status = CHIMERA_VFS_ENOTSUP;
+    request->complete(request);
+} /* chimera_smb_client_mknod_at */

--- a/src/vfs/smb/smb_ntlm.c
+++ b/src/vfs/smb/smb_ntlm.c
@@ -1,0 +1,358 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+#include <time.h>
+#include <openssl/evp.h>
+#include <openssl/hmac.h>
+#include <openssl/rand.h>
+#include <openssl/provider.h>
+
+#include "smb_ntlm.h"
+#include "smb_internal.h"
+
+/* NTLMSSP message types. */
+#define NTLM_NEGOTIATE_MESSAGE                     0x00000001
+#define NTLM_CHALLENGE_MESSAGE                     0x00000002
+#define NTLM_AUTHENTICATE_MESSAGE                  0x00000003
+
+/* NTLMSSP negotiate flags (subset). */
+#define NTLMSSP_NEGOTIATE_128                      0x20000000
+#define NTLMSSP_NEGOTIATE_TARGET_INFO              0x00800000
+#define NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY 0x00080000
+#define NTLMSSP_NEGOTIATE_NTLM                     0x00000200
+#define NTLMSSP_REQUEST_TARGET                     0x00000004
+#define NTLMSSP_NEGOTIATE_UNICODE                  0x00000001
+
+/* OpenSSL 3.0 requires the legacy provider for MD4 (the NT hash). */
+static OSSL_PROVIDER *smb_ntlm_legacy_provider;
+static OSSL_PROVIDER *smb_ntlm_default_provider;
+static int            smb_ntlm_providers_loaded;
+
+static void
+smb_ntlm_ensure_legacy_provider(void)
+{
+    if (smb_ntlm_providers_loaded) {
+        return;
+    }
+    smb_ntlm_legacy_provider  = OSSL_PROVIDER_load(NULL, "legacy");
+    smb_ntlm_default_provider = OSSL_PROVIDER_load(NULL, "default");
+    smb_ntlm_providers_loaded = 1;
+} /* smb_ntlm_ensure_legacy_provider */
+
+/* Convert an ASCII/UTF-8 string to UTF-16LE.  Writes 2*len bytes to out (which
+ * must be large enough) and returns the byte count. */
+static size_t
+smb_ntlm_utf16le(
+    const char *in,
+    uint8_t    *out)
+{
+    size_t len = in ? strlen(in) : 0;
+    size_t i;
+
+    for (i = 0; i < len; i++) {
+        out[i * 2]     = (uint8_t) in[i];
+        out[i * 2 + 1] = 0;
+    }
+    return len * 2;
+} /* smb_ntlm_utf16le */
+
+/* NT hash = MD4(UTF16LE(password)). */
+static int
+smb_ntlm_nt_hash(
+    const char *password,
+    uint8_t     nt_hash[16])
+{
+    uint8_t       utf16[512];
+    size_t        utf16_len;
+    EVP_MD_CTX   *ctx;
+    const EVP_MD *md4;
+    unsigned int  hash_len;
+    int           rc = -1;
+
+    smb_ntlm_ensure_legacy_provider();
+
+    utf16_len = smb_ntlm_utf16le(password, utf16);
+
+    ctx = EVP_MD_CTX_new();
+    if (!ctx) {
+        return -1;
+    }
+
+    md4 = EVP_md4();
+    if (md4 &&
+        EVP_DigestInit_ex(ctx, md4, NULL) == 1 &&
+        EVP_DigestUpdate(ctx, utf16, utf16_len) == 1 &&
+        EVP_DigestFinal_ex(ctx, nt_hash, &hash_len) == 1) {
+        rc = 0;
+    }
+
+    EVP_MD_CTX_free(ctx);
+    return rc;
+} /* smb_ntlm_nt_hash */
+
+/* ntlmv2_hash = HMAC-MD5(NT_hash, UTF16LE(UPPER(user)) || UTF16LE(domain)). */
+static int
+smb_ntlm_v2_hash(
+    const char *user,
+    const char *password,
+    const char *domain,
+    uint8_t     ntlmv2_hash[16])
+{
+    uint8_t      nt_hash[16];
+    char         user_upper[256];
+    uint8_t      concat[1024];
+    size_t       user_len, concat_len;
+    unsigned int hmac_len;
+    size_t       i;
+
+    if (smb_ntlm_nt_hash(password, nt_hash) < 0) {
+        return -1;
+    }
+
+    user_len = strlen(user);
+    if (user_len >= sizeof(user_upper)) {
+        return -1;
+    }
+    for (i = 0; i < user_len; i++) {
+        user_upper[i] = (char) toupper((unsigned char) user[i]);
+    }
+    user_upper[user_len] = '\0';
+
+    concat_len  = smb_ntlm_utf16le(user_upper, concat);
+    concat_len += smb_ntlm_utf16le(domain, concat + concat_len);
+
+    if (!HMAC(EVP_md5(), nt_hash, 16, concat, concat_len, ntlmv2_hash, &hmac_len)) {
+        return -1;
+    }
+    return 0;
+} /* smb_ntlm_v2_hash */
+
+void
+smb_ntlm_client_init(
+    struct smb_ntlm_client *c,
+    const char             *user,
+    const char             *domain,
+    const char             *password)
+{
+    memset(c, 0, sizeof(*c));
+    snprintf(c->user, sizeof(c->user), "%s", user ? user : "");
+    snprintf(c->domain, sizeof(c->domain), "%s", domain ? domain : "");
+    snprintf(c->password, sizeof(c->password), "%s", password ? password : "");
+} /* smb_ntlm_client_init */
+
+int
+smb_ntlm_client_build_negotiate(
+    uint8_t *out,
+    size_t   out_max)
+{
+    uint32_t flags;
+
+    /* Fixed 32-byte NTLMSSP_NEGOTIATE: signature(8) + type(4) + flags(4) +
+     * DomainNameFields(8, empty) + WorkstationFields(8, empty).  The chimera
+     * server ignores these fields on the first leg (it generates its own
+     * CHALLENGE), so a minimal message is sufficient. */
+    if (out_max < 32) {
+        return -1;
+    }
+
+    memset(out, 0, 32);
+    memcpy(out, "NTLMSSP\0", 8);
+    smb_wire_set_le32(out + 8, NTLM_NEGOTIATE_MESSAGE);
+
+    flags = NTLMSSP_NEGOTIATE_UNICODE | NTLMSSP_REQUEST_TARGET |
+        NTLMSSP_NEGOTIATE_NTLM | NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY |
+        NTLMSSP_NEGOTIATE_TARGET_INFO | NTLMSSP_NEGOTIATE_128;
+    smb_wire_set_le32(out + 12, flags);
+
+    return 32;
+} /* smb_ntlm_client_build_negotiate */
+
+int
+smb_ntlm_client_parse_challenge(
+    struct smb_ntlm_client *c,
+    const uint8_t          *buf,
+    size_t                  len)
+{
+    uint32_t msg_type;
+    uint16_t ti_len;
+    uint32_t ti_offset;
+
+    /* Fixed CHALLENGE header is 48 bytes; target-info fields live at 40/44. */
+    if (len < 48 || memcmp(buf, "NTLMSSP\0", 8) != 0) {
+        return -1;
+    }
+
+    msg_type = smb_wire_le32(buf + 8);
+    if (msg_type != NTLM_CHALLENGE_MESSAGE) {
+        return -1;
+    }
+
+    memcpy(c->server_challenge, buf + 24, SMB_NTLM_CLIENT_CHALLENGE_SIZE);
+
+    ti_len    = smb_wire_le16(buf + 40);
+    ti_offset = smb_wire_le32(buf + 44);
+
+    c->target_info_len = 0;
+    if (ti_len > 0) {
+        if (ti_len > SMB_NTLM_CLIENT_TARGET_INFO_MAX ||
+            (size_t) ti_offset + ti_len > len) {
+            return -1;
+        }
+        memcpy(c->target_info, buf + ti_offset, ti_len);
+        c->target_info_len = ti_len;
+    }
+
+    return 0;
+} /* smb_ntlm_client_parse_challenge */
+
+int
+smb_ntlm_client_build_authenticate(
+    struct smb_ntlm_client *c,
+    uint8_t                *out,
+    size_t                  out_max,
+    size_t                 *out_len)
+{
+    uint8_t      ntlmv2_hash[16];
+    uint8_t      client_blob[64 + SMB_NTLM_CLIENT_TARGET_INFO_MAX];
+    size_t       blob_len;
+    uint8_t      nt_proof[16];
+    uint8_t     *hmac_input;
+    size_t       hmac_input_len;
+    unsigned int hmac_len;
+    uint64_t     filetime;
+    uint32_t     flags;
+
+    uint8_t      dom16[512], user16[512];
+    size_t       dom16_len, user16_len;
+
+    size_t       domain_off, user_off, ws_off, lm_off, nt_off;
+    size_t       nt_response_len;
+    size_t       pos;
+
+    if (smb_ntlm_v2_hash(c->user, c->password, c->domain, ntlmv2_hash) < 0) {
+        return -1;
+    }
+
+    /* Build the NTLMv2 client blob: RespType(1)=1, HiRespType(1)=1,
+     * Reserved(6), Timestamp(8, FILETIME), ClientChallenge(8), Reserved(4),
+     * TargetInfo(var), Reserved(4).  The exact contents are irrelevant to the
+     * server beyond being echoed into the HMAC -- it recomputes NTProofStr over
+     * the same bytes. */
+    filetime = ((uint64_t) time(NULL) + 11644473600ULL) * 10000000ULL;
+
+    blob_len                = 0;
+    client_blob[blob_len++] = 0x01;            /* RespType   */
+    client_blob[blob_len++] = 0x01;            /* HiRespType */
+    memset(client_blob + blob_len, 0, 6);      /* Reserved   */
+    blob_len += 6;
+    smb_wire_set_le64(client_blob + blob_len, filetime);
+    blob_len += 8;
+    if (RAND_bytes(client_blob + blob_len, 8) != 1) {
+        return -1;
+    }
+    blob_len += 8;
+    memset(client_blob + blob_len, 0, 4);      /* Reserved */
+    blob_len += 4;
+    memcpy(client_blob + blob_len, c->target_info, c->target_info_len);
+    blob_len += c->target_info_len;
+    memset(client_blob + blob_len, 0, 4);      /* Reserved (trailing) */
+    blob_len += 4;
+
+    /* NTProofStr = HMAC-MD5(ntlmv2_hash, server_challenge || client_blob). */
+    hmac_input_len = SMB_NTLM_CLIENT_CHALLENGE_SIZE + blob_len;
+    hmac_input     = malloc(hmac_input_len);
+    if (!hmac_input) {
+        return -1;
+    }
+    memcpy(hmac_input, c->server_challenge, SMB_NTLM_CLIENT_CHALLENGE_SIZE);
+    memcpy(hmac_input + SMB_NTLM_CLIENT_CHALLENGE_SIZE, client_blob, blob_len);
+
+    if (!HMAC(EVP_md5(), ntlmv2_hash, 16, hmac_input, hmac_input_len, nt_proof, &hmac_len)) {
+        free(hmac_input);
+        return -1;
+    }
+    free(hmac_input);
+
+    /* Session base key (== SMB2 session key; no key exchange negotiated) =
+     * HMAC-MD5(ntlmv2_hash, NTProofStr). */
+    if (!HMAC(EVP_md5(), ntlmv2_hash, 16, nt_proof, 16, c->session_key, &hmac_len)) {
+        return -1;
+    }
+    c->have_session_key = 1;
+
+    /* NtChallengeResponse = NTProofStr(16) || client_blob. */
+    nt_response_len = 16 + blob_len;
+
+    dom16_len  = smb_ntlm_utf16le(c->domain, dom16);
+    user16_len = smb_ntlm_utf16le(c->user, user16);
+
+    /* Lay out the AUTHENTICATE message.  Fixed header is 64 bytes (offsets the
+     * server reads in validate_authenticate), followed by the payload. */
+    domain_off = 64;
+    user_off   = domain_off + dom16_len;
+    ws_off     = user_off + user16_len;
+    lm_off     = ws_off;                       /* zero-length workstation */
+    nt_off     = lm_off + 24;                  /* 24-byte LM response slot */
+
+    if (out_max < nt_off + nt_response_len) {
+        return -1;
+    }
+
+    memset(out, 0, nt_off + nt_response_len);
+    memcpy(out, "NTLMSSP\0", 8);
+    smb_wire_set_le32(out + 8, NTLM_AUTHENTICATE_MESSAGE);
+
+    /* LmChallengeResponse fields (offset 12): 24 zero bytes. */
+    smb_wire_set_le16(out + 12, 24);
+    smb_wire_set_le16(out + 14, 24);
+    smb_wire_set_le32(out + 16, (uint32_t) lm_off);
+
+    /* NtChallengeResponse fields (offset 20). */
+    smb_wire_set_le16(out + 20, (uint16_t) nt_response_len);
+    smb_wire_set_le16(out + 22, (uint16_t) nt_response_len);
+    smb_wire_set_le32(out + 24, (uint32_t) nt_off);
+
+    /* DomainName fields (offset 28). */
+    smb_wire_set_le16(out + 28, (uint16_t) dom16_len);
+    smb_wire_set_le16(out + 30, (uint16_t) dom16_len);
+    smb_wire_set_le32(out + 32, (uint32_t) domain_off);
+
+    /* UserName fields (offset 36). */
+    smb_wire_set_le16(out + 36, (uint16_t) user16_len);
+    smb_wire_set_le16(out + 38, (uint16_t) user16_len);
+    smb_wire_set_le32(out + 40, (uint32_t) user_off);
+
+    /* Workstation fields (offset 44): empty. */
+    smb_wire_set_le16(out + 44, 0);
+    smb_wire_set_le16(out + 46, 0);
+    smb_wire_set_le32(out + 48, (uint32_t) ws_off);
+
+    /* EncryptedRandomSessionKey fields (offset 52): absent. */
+    smb_wire_set_le16(out + 52, 0);
+    smb_wire_set_le16(out + 54, 0);
+    smb_wire_set_le32(out + 56, (uint32_t) nt_off + nt_response_len);
+
+    /* NegotiateFlags (offset 60).  KEY_EXCH deliberately omitted. */
+    flags = NTLMSSP_NEGOTIATE_UNICODE | NTLMSSP_REQUEST_TARGET |
+        NTLMSSP_NEGOTIATE_NTLM | NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY |
+        NTLMSSP_NEGOTIATE_TARGET_INFO | NTLMSSP_NEGOTIATE_128;
+    smb_wire_set_le32(out + 60, flags);
+
+    /* Payload. */
+    pos = domain_off;
+    memcpy(out + pos, dom16, dom16_len);
+    pos = user_off;
+    memcpy(out + pos, user16, user16_len);
+    /* workstation: empty */
+    memset(out + lm_off, 0, 24);               /* LM response */
+    memcpy(out + nt_off, nt_proof, 16);        /* NTProofStr */
+    memcpy(out + nt_off + 16, client_blob, blob_len);
+
+    *out_len = nt_off + nt_response_len;
+    return 0;
+} /* smb_ntlm_client_build_authenticate */

--- a/src/vfs/smb/smb_ntlm.h
+++ b/src/vfs/smb/smb_ntlm.h
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#pragma once
+
+#include <stdint.h>
+#include <stddef.h>
+
+/*
+ * Client-side NTLMSSP (NTLMv2) for the SMB2 client.  This is the mirror image
+ * of the server's src/server/smb/smb_ntlm.c: the client BUILDS the NEGOTIATE
+ * and AUTHENTICATE messages and PARSES the CHALLENGE.  Only raw NTLMSSP tokens
+ * are produced/consumed (no SPNEGO wrapper) -- the chimera SMB server accepts
+ * bare NTLMSSP and replies in kind.
+ *
+ * Crypto (OpenSSL): NT hash = MD4(UTF16LE(password)); ntlmv2_hash =
+ * HMAC-MD5(NT, UTF16LE(UPPER(user)) || UTF16LE(domain)); NTProofStr =
+ * HMAC-MD5(ntlmv2_hash, server_challenge || client_blob); the session base key
+ * (== SMB2 session key, no key exchange) = HMAC-MD5(ntlmv2_hash, NTProofStr).
+ */
+
+#define SMB_NTLM_CLIENT_CHALLENGE_SIZE   8
+#define SMB_NTLM_CLIENT_SESSION_KEY_SIZE 16
+#define SMB_NTLM_CLIENT_TARGET_INFO_MAX  1024
+
+struct smb_ntlm_client {
+    char    user[256];
+    char    domain[256];
+    char    password[256];
+
+    /* Captured from the server's CHALLENGE message. */
+    uint8_t server_challenge[SMB_NTLM_CLIENT_CHALLENGE_SIZE];
+    uint8_t target_info[SMB_NTLM_CLIENT_TARGET_INFO_MAX];
+    size_t  target_info_len;
+
+    /* Derived during build_authenticate; the SMB2 session key. */
+    uint8_t session_key[SMB_NTLM_CLIENT_SESSION_KEY_SIZE];
+    int     have_session_key;
+};
+
+void smb_ntlm_client_init(
+    struct smb_ntlm_client *c,
+    const char             *user,
+    const char             *domain,
+    const char             *password);
+
+/* Build a minimal NTLMSSP_NEGOTIATE token into out (capacity out_max).
+ * Returns the token length, or -1 on overflow. */
+int smb_ntlm_client_build_negotiate(
+    uint8_t *out,
+    size_t   out_max);
+
+/* Parse an NTLMSSP_CHALLENGE token (the server's interim SESSION_SETUP blob),
+ * capturing the server challenge and target-info AV_PAIR list.  Returns 0 on
+ * success, -1 on a malformed token. */
+int smb_ntlm_client_parse_challenge(
+    struct smb_ntlm_client *c,
+    const uint8_t          *buf,
+    size_t                  len);
+
+/* Build an NTLMSSP_AUTHENTICATE token into out (capacity out_max) and derive
+ * c->session_key.  Must be called after parse_challenge.  Returns 0 on success
+ * (with *out_len set), -1 on error. */
+int smb_ntlm_client_build_authenticate(
+    struct smb_ntlm_client *c,
+    uint8_t                *out,
+    size_t                  out_max,
+    size_t                 *out_len);

--- a/src/vfs/smb/smb_ops.c
+++ b/src/vfs/smb/smb_ops.c
@@ -1,0 +1,1033 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <xxhash.h>
+
+#include "smb_internal.h"
+#include "vfs/vfs_attrs.h"
+#include "evpl/evpl.h"
+#include "common/misc.h"
+
+/*
+ * File operations for the SMB2 client -- a PATH-ONLY VFS backend.
+ *
+ * Metadata ops (lookup/mkdir/remove/open) address files by the full
+ * mount-relative path carried in request->X.name and do a transient SMB2 CREATE
+ * on that path.  An open file's VFS handle carries an opaque token fh
+ * [mount_id][server_index][FileId]; ops on an open handle
+ * (read/write/getattr/setattr/commit/close) recover the server + FileId from the
+ * handle's vfs_private (struct chimera_smb_client_open), never from a path.
+ */
+
+/* Shared op helpers (smb_send_create/close, parse, attrs, op-state struct, the
+* network-open-info / create-result structs, and smb_handle_open_state) are
+* declared in smb_internal.h so smb_io.c and smb_namespace.c can reuse them. */
+
+/* ---- small helpers ----------------------------------------------------- */
+
+size_t
+smb_utf16le_encode(
+    const char *s,
+    int         len,
+    uint8_t    *out)
+{
+    int i;
+
+    for (i = 0; i < len; i++) {
+        /* SMB path separators are backslashes. */
+        uint8_t c = (uint8_t) (s[i] == '/' ? '\\' : s[i]);
+        out[i * 2]     = c;
+        out[i * 2 + 1] = 0;
+    }
+    return (size_t) len * 2;
+} /* smb_utf16le_encode */
+
+void
+smb_parse_open_info(
+    struct evpl_iovec_cursor *body,
+    struct smb_open_info     *r)
+{
+    uint32_t reserved;
+
+    evpl_iovec_cursor_get_uint64(body, &r->crttime);
+    evpl_iovec_cursor_get_uint64(body, &r->atime);
+    evpl_iovec_cursor_get_uint64(body, &r->mtime);
+    evpl_iovec_cursor_get_uint64(body, &r->ctime);
+    evpl_iovec_cursor_get_uint64(body, &r->alloc_size);
+    evpl_iovec_cursor_get_uint64(body, &r->end_of_file);
+    evpl_iovec_cursor_get_uint32(body, &r->file_attributes);
+    evpl_iovec_cursor_get_uint32(body, &reserved);
+} /* smb_parse_open_info */
+
+void
+smb_parse_create_reply(
+    struct evpl_iovec_cursor *body,
+    struct smb_create_result *r)
+{
+    uint16_t structsize;
+    uint8_t  oplock, flags;
+
+    evpl_iovec_cursor_get_uint16(body, &structsize);
+    evpl_iovec_cursor_get_uint8(body, &oplock);
+    evpl_iovec_cursor_get_uint8(body, &flags);
+    evpl_iovec_cursor_get_uint32(body, &r->create_action);
+    smb_parse_open_info(body, &r->info);
+    evpl_iovec_cursor_get_uint64(body, &r->file_id.pid);
+    evpl_iovec_cursor_get_uint64(body, &r->file_id.vid);
+
+    (void) structsize;
+    (void) oplock;
+    (void) flags;
+} /* smb_parse_create_reply */
+
+/* Map SMB attrs into a chimera_vfs_attrs.  SMB exposes no POSIX owner; report
+ * the requesting credential as the owner (correct for a caller inspecting files
+ * it created), and a caller-supplied stable inode number. */
+void
+smb_apply_attrs(
+    const struct chimera_vfs_request *request,
+    struct chimera_vfs_attrs         *attr,
+    const struct smb_open_info       *info,
+    uint64_t                          ino)
+{
+    smb_fill_attrs_from_network_open(attr, info->crttime, info->atime,
+                                     info->mtime, info->ctime, info->alloc_size,
+                                     info->end_of_file, info->file_attributes);
+
+    attr->va_ino       = ino | 1;
+    attr->va_set_mask |= CHIMERA_VFS_ATTR_INUM;
+
+    if (request->cred) {
+        attr->va_uid       = request->cred->uid;
+        attr->va_gid       = request->cred->gid;
+        attr->va_set_mask |= CHIMERA_VFS_ATTR_UID | CHIMERA_VFS_ATTR_GID;
+    }
+} /* smb_apply_attrs */
+
+/* Send an SMB2 CREATE on `path`, optionally carrying `ctx` create contexts (a
+ * pre-built, already-chained context blob) after the name. */
+void
+smb_send_create_ex(
+    struct chimera_smb_client_conn *conn,
+    struct chimera_vfs_request     *request,
+    const char                     *path,
+    int                             path_len,
+    uint32_t                        desired_access,
+    uint32_t                        share_access,
+    uint32_t                        disposition,
+    uint32_t                        options,
+    const uint8_t                  *ctx,
+    uint32_t                        ctx_len,
+    chimera_smb_client_reply_cb     reply_cb)
+{
+    struct evpl_iovec        iov;
+    struct evpl_iovec_cursor cursor;
+    struct smb2_header      *hdr;
+    uint8_t                  name16[2 * CHIMERA_SMB_PATH_MAX];
+    size_t                   name16_len;
+    uint32_t                 name_end, ctx_off = 0, pad = 0;
+
+    if (path_len > CHIMERA_SMB_PATH_MAX) {
+        request->status = CHIMERA_VFS_ENAMETOOLONG;
+        request->complete(request);
+        return;
+    }
+
+    name16_len = smb_utf16le_encode(path, path_len, name16);
+
+    /* Offsets are relative to the SMB2 header start: NameOffset = header(64) +
+     * fixed body(56).  Create contexts (if any) follow the name, 8-byte aligned. */
+    if (ctx_len > 0) {
+        name_end = sizeof(struct smb2_header) + 56 + (uint32_t) name16_len;
+        ctx_off  = (name_end + 7) & ~7u;
+        pad      = ctx_off - name_end;
+    }
+
+    chimera_smb_client_pdu_begin(conn, SMB2_CREATE, &iov, &cursor, &hdr);
+
+    evpl_iovec_cursor_append_uint16(&cursor, SMB2_CREATE_REQUEST_SIZE);
+    evpl_iovec_cursor_append_uint8(&cursor, 0);                             /* SecurityFlags */
+    evpl_iovec_cursor_append_uint8(&cursor, ctx_len ? SMB2_OPLOCK_LEVEL_LEASE : 0); /* RequestedOplockLevel */
+    evpl_iovec_cursor_append_uint32(&cursor, SMB2_IMPERSONATION_IMPERSONATION);
+    evpl_iovec_cursor_append_uint64(&cursor, 0);                            /* SmbCreateFlags */
+    evpl_iovec_cursor_append_uint64(&cursor, 0);                            /* Reserved */
+    evpl_iovec_cursor_append_uint32(&cursor, desired_access);
+    evpl_iovec_cursor_append_uint32(&cursor, 0);                            /* FileAttributes */
+    evpl_iovec_cursor_append_uint32(&cursor, share_access);
+    evpl_iovec_cursor_append_uint32(&cursor, disposition);
+    evpl_iovec_cursor_append_uint32(&cursor, options);
+    evpl_iovec_cursor_append_uint16(&cursor, sizeof(struct smb2_header) + 56); /* NameOffset */
+    evpl_iovec_cursor_append_uint16(&cursor, (uint16_t) name16_len);        /* NameLength */
+    evpl_iovec_cursor_append_uint32(&cursor, ctx_off);                      /* CreateContextsOffset */
+    evpl_iovec_cursor_append_uint32(&cursor, ctx_len);                      /* CreateContextsLength */
+    if (name16_len > 0) {
+        evpl_iovec_cursor_append_blob(&cursor, name16, name16_len);
+    }
+
+    if (ctx_len > 0) {
+        /* Unaligned: append_blob would re-align the cursor and shift these past
+         * the CreateContextsOffset we declared above (the name already left the
+         * cursor at name_end). */
+        static uint8_t zero[8] = { 0 };
+        if (pad > 0) {
+            evpl_iovec_cursor_append_blob_unaligned(&cursor, zero, pad);
+        }
+        evpl_iovec_cursor_append_blob_unaligned(&cursor, (uint8_t *) ctx, ctx_len);
+    }
+
+    chimera_smb_client_pdu_finish(conn, &iov, &cursor, request, reply_cb, request);
+} /* smb_send_create_ex */
+
+/* Send an SMB2 CREATE on `path` (full mount-relative path; "" for the root). */
+void
+smb_send_create(
+    struct chimera_smb_client_conn *conn,
+    struct chimera_vfs_request     *request,
+    const char                     *path,
+    int                             path_len,
+    uint32_t                        desired_access,
+    uint32_t                        share_access,
+    uint32_t                        disposition,
+    uint32_t                        options,
+    chimera_smb_client_reply_cb     reply_cb)
+{
+    smb_send_create_ex(conn, request, path, path_len, desired_access,
+                       share_access, disposition, options, NULL, 0, reply_cb);
+} /* smb_send_create */
+
+/* Build an RqLs (lease request v1) create context into `buf` (>= 56 bytes);
+ * returns its length.  Header(16) + name "RqLs"(4) + pad(4) + data(32). */
+uint32_t
+smb_build_lease_ctx(
+    uint8_t       *buf,
+    const uint8_t *lease_key,
+    uint32_t       lease_state)
+{
+    memset(buf, 0, CHIMERA_SMB_LEASE_CTX_SIZE);
+
+    /* Context header. */
+    smb_wire_set_le16(buf + 4, 16);      /* NameOffset (from context start) */
+    smb_wire_set_le16(buf + 6, 4);       /* NameLength */
+    smb_wire_set_le16(buf + 10, 24);     /* DataOffset */
+    smb_wire_set_le32(buf + 12, 32);     /* DataLength (RqLs v1) */
+    memcpy(buf + 16, "RqLs", 4);
+
+    /* RqLs v1 data: LeaseKey(16), LeaseState(4), LeaseFlags(4), Duration(8). */
+    memcpy(buf + 24, lease_key, 16);
+    smb_wire_set_le32(buf + 40, lease_state);
+
+    return CHIMERA_SMB_LEASE_CTX_SIZE;
+} /* smb_build_lease_ctx */
+
+void
+smb_send_close(
+    struct chimera_smb_client_conn          *conn,
+    struct chimera_vfs_request              *request,
+    const struct chimera_smb_client_file_id *file_id,
+    chimera_smb_client_reply_cb              reply_cb)
+{
+    struct evpl_iovec        iov;
+    struct evpl_iovec_cursor cursor;
+    struct smb2_header      *hdr;
+
+    chimera_smb_client_pdu_begin(conn, SMB2_CLOSE, &iov, &cursor, &hdr);
+
+    evpl_iovec_cursor_append_uint16(&cursor, SMB2_CLOSE_REQUEST_SIZE);
+    evpl_iovec_cursor_append_uint16(&cursor, 0);             /* Flags */
+    evpl_iovec_cursor_append_uint32(&cursor, 0);             /* Reserved */
+    evpl_iovec_cursor_append_uint64(&cursor, file_id->pid);
+    evpl_iovec_cursor_append_uint64(&cursor, file_id->vid);
+
+    chimera_smb_client_pdu_finish(conn, &iov, &cursor, request, reply_cb, request);
+} /* smb_send_close */
+
+/* ---- CLOSE (VFS op) ---------------------------------------------------- */
+
+static void
+chimera_smb_close_reply(
+    struct chimera_smb_client_conn *conn,
+    uint32_t                        status,
+    const struct smb2_header       *hdr,
+    struct evpl_iovec_cursor       *body,
+    int                             body_len,
+    void                           *arg)
+{
+    struct chimera_vfs_request *request = arg;
+
+    (void) conn;
+    (void) hdr;
+    (void) body;
+    (void) body_len;
+
+    request->status = chimera_smb_status_to_errno(status);
+    request->complete(request);
+} /* chimera_smb_close_reply */
+
+void
+chimera_smb_client_close(
+    struct chimera_smb_client_conn *conn,
+    struct chimera_vfs_request     *request)
+{
+    struct chimera_smb_client_open   *open_state =
+        (struct chimera_smb_client_open *) request->close.vfs_private;
+    struct chimera_smb_client_file_id file_id = open_state->file_id;
+
+    free(open_state);
+
+    smb_send_close(conn, request, &file_id, chimera_smb_close_reply);
+} /* chimera_smb_client_close */
+
+/* ---- getattr (handle-based QUERY_INFO) --------------------------------- */
+
+#define CHIMERA_SMB_STATFS_ATTRS \
+        (CHIMERA_VFS_ATTR_SPACE_TOTAL | CHIMERA_VFS_ATTR_SPACE_FREE | \
+         CHIMERA_VFS_ATTR_SPACE_AVAIL)
+
+/* statfs is funnelled through getattr (the client opens a handle and requests
+ * the SPACE_* attrs); answer it with QUERY_INFO FILESYSTEM /
+ * FileFsFullSizeInformation instead of the per-file network-open info. */
+static void
+chimera_smb_statfs_reply(
+    struct chimera_smb_client_conn *conn,
+    uint32_t                        status,
+    const struct smb2_header       *hdr,
+    struct evpl_iovec_cursor       *body,
+    int                             body_len,
+    void                           *arg)
+{
+    struct chimera_vfs_request *request = arg;
+    uint16_t                    structsize, out_offset;
+    uint32_t                    out_length, sectors_per_unit, bytes_per_sector;
+    uint64_t                    total_units, caller_avail_units, actual_avail_units;
+    uint64_t                    bytes_per_unit;
+    int                         consumed;
+
+    (void) hdr;
+    (void) body_len;
+
+    if (status != SMB2_STATUS_SUCCESS) {
+        request->status = chimera_smb_status_to_errno(status);
+        request->complete(request);
+        return;
+    }
+
+    evpl_iovec_cursor_get_uint16(body, &structsize);
+    evpl_iovec_cursor_get_uint16(body, &out_offset);
+    evpl_iovec_cursor_get_uint32(body, &out_length);
+
+    consumed = evpl_iovec_cursor_consumed(body);
+    if (out_offset > consumed) {
+        evpl_iovec_cursor_skip(body, out_offset - consumed);
+    }
+
+    /* FileFsFullSizeInformation (MS-FSCC 2.5.4): TotalAllocationUnits(8),
+     * CallerAvailableAllocationUnits(8), ActualAvailableAllocationUnits(8),
+     * SectorsPerAllocationUnit(4), BytesPerSector(4). */
+    evpl_iovec_cursor_get_uint64(body, &total_units);
+    evpl_iovec_cursor_get_uint64(body, &caller_avail_units);
+    evpl_iovec_cursor_get_uint64(body, &actual_avail_units);
+    evpl_iovec_cursor_get_uint32(body, &sectors_per_unit);
+    evpl_iovec_cursor_get_uint32(body, &bytes_per_sector);
+
+    (void) structsize;
+    (void) out_length;
+
+    bytes_per_unit = (uint64_t) sectors_per_unit * bytes_per_sector;
+
+    request->getattr.r_attr.va_fs_space_total = total_units * bytes_per_unit;
+    request->getattr.r_attr.va_fs_space_avail = caller_avail_units * bytes_per_unit;
+    request->getattr.r_attr.va_fs_space_free  = actual_avail_units * bytes_per_unit;
+    request->getattr.r_attr.va_set_mask      |= CHIMERA_SMB_STATFS_ATTRS;
+
+    request->status = CHIMERA_VFS_OK;
+    request->complete(request);
+} /* chimera_smb_statfs_reply */
+
+static void
+chimera_smb_client_statfs(
+    struct chimera_smb_client_conn *conn,
+    struct chimera_vfs_request     *request,
+    struct chimera_smb_client_open *open_state)
+{
+    struct evpl_iovec        iov;
+    struct evpl_iovec_cursor cursor;
+    struct smb2_header      *hdr;
+
+    /* QUERY_INFO, FILESYSTEM / FileFsFullSizeInformation, on the open FileId. */
+    chimera_smb_client_pdu_begin(conn, SMB2_QUERY_INFO, &iov, &cursor, &hdr);
+
+    evpl_iovec_cursor_append_uint16(&cursor, SMB2_QUERY_INFO_REQUEST_SIZE);
+    evpl_iovec_cursor_append_uint8(&cursor, SMB2_INFO_FILESYSTEM);
+    evpl_iovec_cursor_append_uint8(&cursor, SMB2_FILE_FS_FULL_SIZE_INFO);
+    evpl_iovec_cursor_append_uint32(&cursor, 32);            /* OutputBufferLength */
+    evpl_iovec_cursor_append_uint16(&cursor, 0);             /* InputBufferOffset */
+    evpl_iovec_cursor_append_uint16(&cursor, 0);             /* Reserved */
+    evpl_iovec_cursor_append_uint32(&cursor, 0);             /* InputBufferLength */
+    evpl_iovec_cursor_append_uint32(&cursor, 0);             /* AdditionalInformation */
+    evpl_iovec_cursor_append_uint32(&cursor, 0);             /* Flags */
+    evpl_iovec_cursor_append_uint64(&cursor, open_state->file_id.pid);
+    evpl_iovec_cursor_append_uint64(&cursor, open_state->file_id.vid);
+
+    chimera_smb_client_pdu_finish(conn, &iov, &cursor, request,
+                                  chimera_smb_statfs_reply, request);
+} /* chimera_smb_client_statfs */
+
+static void
+chimera_smb_getattr_reply(
+    struct chimera_smb_client_conn *conn,
+    uint32_t                        status,
+    const struct smb2_header       *hdr,
+    struct evpl_iovec_cursor       *body,
+    int                             body_len,
+    void                           *arg)
+{
+    struct chimera_vfs_request     *request    = arg;
+    struct chimera_smb_client_open *open_state = smb_handle_open_state(request->getattr.handle);
+    struct smb_open_info            info;
+    uint16_t                        structsize, out_offset;
+    uint32_t                        out_length;
+    int                             consumed;
+
+    (void) conn;
+    (void) hdr;
+    (void) body_len;
+
+    if (status != SMB2_STATUS_SUCCESS) {
+        request->status = chimera_smb_status_to_errno(status);
+        request->complete(request);
+        return;
+    }
+
+    evpl_iovec_cursor_get_uint16(body, &structsize);
+    evpl_iovec_cursor_get_uint16(body, &out_offset);
+    evpl_iovec_cursor_get_uint32(body, &out_length);
+
+    consumed = evpl_iovec_cursor_consumed(body);
+    if (out_offset > consumed) {
+        evpl_iovec_cursor_skip(body, out_offset - consumed);
+    }
+
+    smb_parse_open_info(body, &info);
+
+    smb_apply_attrs(request, &request->getattr.r_attr, &info,
+                    open_state->file_id.pid);
+
+    request->status = CHIMERA_VFS_OK;
+    request->complete(request);
+} /* chimera_smb_getattr_reply */
+
+void
+chimera_smb_client_getattr(
+    struct chimera_smb_client_conn *conn,
+    struct chimera_vfs_request     *request)
+{
+    struct chimera_smb_client_open *open_state = smb_handle_open_state(request->getattr.handle);
+    struct evpl_iovec               iov;
+    struct evpl_iovec_cursor        cursor;
+    struct smb2_header             *hdr;
+
+    if (!open_state) {
+        request->status = CHIMERA_VFS_EINVAL;
+        request->complete(request);
+        return;
+    }
+
+    /* A statfs request (SPACE_* attrs) goes to the filesystem-info query. */
+    if (request->getattr.r_attr.va_req_mask & CHIMERA_SMB_STATFS_ATTRS) {
+        chimera_smb_client_statfs(conn, request, open_state);
+        return;
+    }
+
+    /* SMB2 QUERY_INFO, FILE / FileNetworkOpenInformation, on the open FileId. */
+    chimera_smb_client_pdu_begin(conn, SMB2_QUERY_INFO, &iov, &cursor, &hdr);
+
+    evpl_iovec_cursor_append_uint16(&cursor, SMB2_QUERY_INFO_REQUEST_SIZE);
+    evpl_iovec_cursor_append_uint8(&cursor, SMB2_INFO_FILE);
+    evpl_iovec_cursor_append_uint8(&cursor, SMB2_FILE_NETWORK_OPEN_INFO);
+    evpl_iovec_cursor_append_uint32(&cursor, SMB2_FILE_NETWORK_OPEN_INFO_SIZE); /* OutputBufferLength */
+    evpl_iovec_cursor_append_uint16(&cursor, 0);             /* InputBufferOffset */
+    evpl_iovec_cursor_append_uint16(&cursor, 0);             /* Reserved */
+    evpl_iovec_cursor_append_uint32(&cursor, 0);             /* InputBufferLength */
+    evpl_iovec_cursor_append_uint32(&cursor, 0);             /* AdditionalInformation */
+    evpl_iovec_cursor_append_uint32(&cursor, 0);             /* Flags */
+    evpl_iovec_cursor_append_uint64(&cursor, open_state->file_id.pid);
+    evpl_iovec_cursor_append_uint64(&cursor, open_state->file_id.vid);
+
+    chimera_smb_client_pdu_finish(conn, &iov, &cursor, request,
+                                  chimera_smb_getattr_reply, request);
+} /* chimera_smb_client_getattr */
+
+/* ---- lookup_at (full path, transient open) ----------------------------- */
+
+static void
+chimera_smb_lookup_close_reply(
+    struct chimera_smb_client_conn *conn,
+    uint32_t                        status,
+    const struct smb2_header       *hdr,
+    struct evpl_iovec_cursor       *body,
+    int                             body_len,
+    void                           *arg)
+{
+    struct chimera_vfs_request *request = arg;
+
+    (void) conn;
+    (void) hdr;
+    (void) body;
+    (void) body_len;
+    (void) status;
+
+    request->complete(request);
+} /* chimera_smb_lookup_close_reply */
+
+static void
+chimera_smb_lookup_create_reply(
+    struct chimera_smb_client_conn *conn,
+    uint32_t                        status,
+    const struct smb2_header       *hdr,
+    struct evpl_iovec_cursor       *body,
+    int                             body_len,
+    void                           *arg)
+{
+    struct chimera_vfs_request  *request = arg;
+    struct chimera_smb_op_state *state   = request->plugin_data;
+    struct smb_create_result     r;
+
+    (void) hdr;
+    (void) body_len;
+
+    if (status != SMB2_STATUS_SUCCESS) {
+        request->status = chimera_smb_status_to_errno(status);
+        request->complete(request);
+        return;
+    }
+
+    smb_parse_create_reply(body, &r);
+
+    /* Path-only: return attrs but NO child fh (va_fh stays unset). */
+    smb_apply_attrs(request, &request->lookup_at.r_attr, &r.info,
+                    XXH3_64bits(request->lookup_at.component,
+                                request->lookup_at.component_len));
+
+    request->status = CHIMERA_VFS_OK;
+    state->file_id  = r.file_id;
+
+    smb_send_close(conn, request, &state->file_id, chimera_smb_lookup_close_reply);
+} /* chimera_smb_lookup_create_reply */
+
+void
+chimera_smb_client_lookup_at(
+    struct chimera_smb_client_conn *conn,
+    struct chimera_vfs_request     *request)
+{
+    smb_send_create(conn, request,
+                    request->lookup_at.component, request->lookup_at.component_len,
+                    SMB2_FILE_READ_ATTRIBUTES,
+                    SMB2_FILE_SHARE_READ | SMB2_FILE_SHARE_WRITE | SMB2_FILE_SHARE_DELETE,
+                    SMB2_FILE_OPEN, 0,
+                    chimera_smb_lookup_create_reply);
+} /* chimera_smb_client_lookup_at */
+
+/* ---- open_at / open_fh (persistent open) ------------------------------- */
+
+static void
+chimera_smb_open_at_reply(
+    struct chimera_smb_client_conn *conn,
+    uint32_t                        status,
+    const struct smb2_header       *hdr,
+    struct evpl_iovec_cursor       *body,
+    int                             body_len,
+    void                           *arg)
+{
+    struct chimera_vfs_request     *request = arg;
+    struct chimera_smb_client_open *open_state;
+    struct smb_create_result        r;
+
+    (void) hdr;
+    (void) body_len;
+
+    if (status != SMB2_STATUS_SUCCESS) {
+        request->status = chimera_smb_status_to_errno(status);
+        request->complete(request);
+        return;
+    }
+
+    smb_parse_create_reply(body, &r);
+
+    open_state               = calloc(1, sizeof(*open_state));
+    open_state->file_id      = r.file_id;
+    open_state->server_index = (uint8_t) conn->server->index;
+    open_state->is_directory = (r.info.file_attributes & SMB2_FILE_ATTRIBUTE_DIRECTORY) != 0;
+
+    smb_apply_attrs(request, &request->open_at.r_attr, &r.info,
+                    XXH3_64bits(request->open_at.name, request->open_at.namelen));
+
+    /* The handle's identity is the opaque open token built from the FileId. */
+    request->open_at.r_attr.va_fh_len = chimera_smb_encode_open_fh(
+        request->fh, &r.file_id, request->open_at.r_attr.va_fh);
+    request->open_at.r_attr.va_set_mask |= CHIMERA_VFS_ATTR_FH;
+
+    request->open_at.r_vfs_private = (uint64_t) (uintptr_t) open_state;
+    request->open_at.r_created     = (r.create_action == SMB2_CREATE_ACTION_CREATED);
+
+    request->status = CHIMERA_VFS_OK;
+    request->complete(request);
+} /* chimera_smb_open_at_reply */
+
+void
+chimera_smb_client_open_at(
+    struct chimera_smb_client_conn *conn,
+    struct chimera_vfs_request     *request)
+{
+    uint32_t       disposition;
+    uint32_t       desired_access;
+    uint32_t       options = SMB2_FILE_NON_DIRECTORY_FILE;
+    uint8_t        lease_ctx[CHIMERA_SMB_LEASE_CTX_SIZE];
+    uint8_t        lease_key[16];
+    const uint8_t *ctx     = NULL;
+    uint32_t       ctx_len = 0;
+
+    if (request->open_at.flags & CHIMERA_VFS_OPEN_CREATE) {
+        disposition = (request->open_at.flags & CHIMERA_VFS_OPEN_EXCLUSIVE)
+                      ? SMB2_FILE_CREATE : SMB2_FILE_OPEN_IF;
+    } else {
+        disposition = SMB2_FILE_OPEN;
+    }
+
+    /*
+     * NOFOLLOW: open the symlink (reparse point) itself rather than following
+     * it to its target, so callers like readlink see the link node.
+     */
+    if (request->open_at.flags & CHIMERA_VFS_OPEN_NOFOLLOW) {
+        options |= SMB2_FILE_OPEN_REPARSE_POINT;
+    }
+
+    desired_access = SMB2_FILE_READ_DATA | SMB2_FILE_WRITE_DATA |
+        SMB2_FILE_READ_ATTRIBUTES | SMB2_FILE_WRITE_ATTRIBUTES | SMB2_DELETE;
+
+    /* Request a read+handle-caching lease on file opens.  HANDLE caching is the
+     * prerequisite the server requires before it will grant a durable handle
+     * (the next increment), and the client acks any later break.  Directory
+     * opens skip it. */
+    if (!(request->open_at.flags & CHIMERA_VFS_OPEN_DIRECTORY)) {
+        uint64_t *k = (uint64_t *) lease_key;
+
+        k[0]    = chimera_rand64();
+        k[1]    = chimera_rand64();
+        ctx_len = smb_build_lease_ctx(lease_ctx, lease_key,
+                                      SMB2_LEASE_READ_CACHING | SMB2_LEASE_HANDLE_CACHING);
+        ctx = lease_ctx;
+    }
+
+    smb_send_create_ex(conn, request,
+                       request->open_at.name, request->open_at.namelen,
+                       desired_access,
+                       SMB2_FILE_SHARE_READ | SMB2_FILE_SHARE_WRITE | SMB2_FILE_SHARE_DELETE,
+                       disposition, options, ctx, ctx_len,
+                       chimera_smb_open_at_reply);
+} /* chimera_smb_client_open_at */
+
+static void
+chimera_smb_open_fh_reply(
+    struct chimera_smb_client_conn *conn,
+    uint32_t                        status,
+    const struct smb2_header       *hdr,
+    struct evpl_iovec_cursor       *body,
+    int                             body_len,
+    void                           *arg)
+{
+    struct chimera_vfs_request     *request = arg;
+    struct chimera_smb_client_open *open_state;
+    struct smb_create_result        r;
+
+    (void) hdr;
+    (void) body_len;
+
+    if (status != SMB2_STATUS_SUCCESS) {
+        request->status = chimera_smb_status_to_errno(status);
+        request->complete(request);
+        return;
+    }
+
+    smb_parse_create_reply(body, &r);
+
+    open_state               = calloc(1, sizeof(*open_state));
+    open_state->file_id      = r.file_id;
+    open_state->server_index = (uint8_t) conn->server->index;
+    open_state->is_directory = (r.info.file_attributes & SMB2_FILE_ATTRIBUTE_DIRECTORY) != 0;
+
+    request->open_fh.r_vfs_private = (uint64_t) (uintptr_t) open_state;
+
+    request->status = CHIMERA_VFS_OK;
+    request->complete(request);
+} /* chimera_smb_open_fh_reply */
+
+void
+chimera_smb_client_open_fh(
+    struct chimera_smb_client_conn *conn,
+    struct chimera_vfs_request     *request)
+{
+    uint32_t options;
+
+    /* Only the mount root is re-openable by fh; an opaque open token cannot be
+     * re-derived to a path (path-only contract) -- reject with ESTALE. */
+    if (!chimera_smb_fh_is_root(request->fh_len)) {
+        request->status = CHIMERA_VFS_ESTALE;
+        request->complete(request);
+        return;
+    }
+
+    options = (request->open_fh.flags & CHIMERA_VFS_OPEN_DIRECTORY)
+              ? SMB2_FILE_DIRECTORY_FILE : 0;
+
+    /* CREATE the share root (empty path). */
+    smb_send_create(conn, request, "", 0,
+                    SMB2_FILE_READ_DATA | SMB2_FILE_READ_ATTRIBUTES |
+                    SMB2_FILE_LIST_DIRECTORY,
+                    SMB2_FILE_SHARE_READ | SMB2_FILE_SHARE_WRITE | SMB2_FILE_SHARE_DELETE,
+                    SMB2_FILE_OPEN, options,
+                    chimera_smb_open_fh_reply);
+} /* chimera_smb_client_open_fh */
+
+/* ---- mkdir_at (full path, transient open) ------------------------------ */
+
+static void
+chimera_smb_mkdir_close_reply(
+    struct chimera_smb_client_conn *conn,
+    uint32_t                        status,
+    const struct smb2_header       *hdr,
+    struct evpl_iovec_cursor       *body,
+    int                             body_len,
+    void                           *arg)
+{
+    struct chimera_vfs_request *request = arg;
+
+    (void) conn;
+    (void) hdr;
+    (void) body;
+    (void) body_len;
+    (void) status;
+
+    request->complete(request);
+} /* chimera_smb_mkdir_close_reply */
+
+static void
+chimera_smb_mkdir_create_reply(
+    struct chimera_smb_client_conn *conn,
+    uint32_t                        status,
+    const struct smb2_header       *hdr,
+    struct evpl_iovec_cursor       *body,
+    int                             body_len,
+    void                           *arg)
+{
+    struct chimera_vfs_request  *request = arg;
+    struct chimera_smb_op_state *state   = request->plugin_data;
+    struct smb_create_result     r;
+
+    (void) hdr;
+    (void) body_len;
+
+    if (status != SMB2_STATUS_SUCCESS) {
+        request->status = chimera_smb_status_to_errno(status);
+        request->complete(request);
+        return;
+    }
+
+    smb_parse_create_reply(body, &r);
+
+    /* Transient open of a directory: return attrs, no persistent fh. */
+    smb_apply_attrs(request, &request->mkdir_at.r_attr, &r.info,
+                    XXH3_64bits(request->mkdir_at.name, request->mkdir_at.name_len));
+
+    request->status = CHIMERA_VFS_OK;
+    state->file_id  = r.file_id;
+
+    smb_send_close(conn, request, &state->file_id, chimera_smb_mkdir_close_reply);
+} /* chimera_smb_mkdir_create_reply */
+
+void
+chimera_smb_client_mkdir_at(
+    struct chimera_smb_client_conn *conn,
+    struct chimera_vfs_request     *request)
+{
+    smb_send_create(conn, request,
+                    request->mkdir_at.name, request->mkdir_at.name_len,
+                    SMB2_FILE_READ_ATTRIBUTES,
+                    SMB2_FILE_SHARE_READ | SMB2_FILE_SHARE_WRITE | SMB2_FILE_SHARE_DELETE,
+                    SMB2_FILE_CREATE, SMB2_FILE_DIRECTORY_FILE,
+                    chimera_smb_mkdir_create_reply);
+} /* chimera_smb_client_mkdir_at */
+
+/* ---- remove_at (full path, delete-on-close) ---------------------------- */
+
+static void
+chimera_smb_remove_close_reply(
+    struct chimera_smb_client_conn *conn,
+    uint32_t                        status,
+    const struct smb2_header       *hdr,
+    struct evpl_iovec_cursor       *body,
+    int                             body_len,
+    void                           *arg)
+{
+    struct chimera_vfs_request *request = arg;
+
+    (void) conn;
+    (void) hdr;
+    (void) body;
+    (void) body_len;
+
+    request->status = chimera_smb_status_to_errno(status);
+    request->complete(request);
+} /* chimera_smb_remove_close_reply */
+
+static void
+chimera_smb_remove_create_reply(
+    struct chimera_smb_client_conn *conn,
+    uint32_t                        status,
+    const struct smb2_header       *hdr,
+    struct evpl_iovec_cursor       *body,
+    int                             body_len,
+    void                           *arg)
+{
+    struct chimera_vfs_request  *request = arg;
+    struct chimera_smb_op_state *state   = request->plugin_data;
+    struct smb_create_result     r;
+
+    (void) hdr;
+    (void) body_len;
+
+    if (status != SMB2_STATUS_SUCCESS) {
+        request->status = chimera_smb_status_to_errno(status);
+        request->complete(request);
+        return;
+    }
+
+    smb_parse_create_reply(body, &r);
+    state->file_id = r.file_id;
+
+    /* FILE_DELETE_ON_CLOSE was set on the open, so CLOSE removes the file. */
+    smb_send_close(conn, request, &state->file_id, chimera_smb_remove_close_reply);
+} /* chimera_smb_remove_create_reply */
+
+void
+chimera_smb_client_remove_at(
+    struct chimera_smb_client_conn *conn,
+    struct chimera_vfs_request     *request)
+{
+    smb_send_create(conn, request,
+                    request->remove_at.name, request->remove_at.namelen,
+                    SMB2_DELETE | SMB2_FILE_READ_ATTRIBUTES,
+                    SMB2_FILE_SHARE_READ | SMB2_FILE_SHARE_WRITE | SMB2_FILE_SHARE_DELETE,
+                    SMB2_FILE_OPEN, SMB2_FILE_DELETE_ON_CLOSE,
+                    chimera_smb_remove_create_reply);
+} /* chimera_smb_client_remove_at */
+
+/* ---- setattr (SET_INFO on the open handle) ----------------------------- */
+
+#define CHIMERA_SMB_SETATTR_TIMES \
+        (CHIMERA_VFS_ATTR_ATIME | CHIMERA_VFS_ATTR_MTIME | \
+         CHIMERA_VFS_ATTR_CTIME | CHIMERA_VFS_ATTR_BTIME)
+
+/* Final SET_INFO reply (size-only, times-only, or the times leg of size+times). */
+static void
+chimera_smb_setattr_reply(
+    struct chimera_smb_client_conn *conn,
+    uint32_t                        status,
+    const struct smb2_header       *hdr,
+    struct evpl_iovec_cursor       *body,
+    int                             body_len,
+    void                           *arg)
+{
+    struct chimera_vfs_request *request = arg;
+
+    (void) conn;
+    (void) hdr;
+    (void) body;
+    (void) body_len;
+
+    request->status = chimera_smb_status_to_errno(status);
+    request->complete(request);
+} /* chimera_smb_setattr_reply */
+
+/* SET_INFO FileBasicInformation: set the requested timestamps (a zero FILETIME
+ * means "leave unchanged"; FileAttributes 0 likewise). */
+static void
+chimera_smb_setattr_send_basic(
+    struct chimera_smb_client_conn *conn,
+    struct chimera_vfs_request     *request)
+{
+    struct chimera_smb_client_open *open_state = smb_handle_open_state(request->setattr.handle);
+    struct chimera_vfs_attrs       *set_attr   = request->setattr.set_attr;
+    struct evpl_iovec               iov;
+    struct evpl_iovec_cursor        cursor;
+    struct smb2_header             *hdr;
+    uint64_t                        crttime, atime, mtime, ctime;
+
+    crttime = (set_attr->va_set_mask & CHIMERA_VFS_ATTR_BTIME) ?
+        smb_timespec_to_filetime(&set_attr->va_btime) : 0;
+    atime = (set_attr->va_set_mask & CHIMERA_VFS_ATTR_ATIME) ?
+        smb_timespec_to_filetime(&set_attr->va_atime) : 0;
+    mtime = (set_attr->va_set_mask & CHIMERA_VFS_ATTR_MTIME) ?
+        smb_timespec_to_filetime(&set_attr->va_mtime) : 0;
+    ctime = (set_attr->va_set_mask & CHIMERA_VFS_ATTR_CTIME) ?
+        smb_timespec_to_filetime(&set_attr->va_ctime) : 0;
+
+    chimera_smb_client_pdu_begin(conn, SMB2_SET_INFO, &iov, &cursor, &hdr);
+
+    evpl_iovec_cursor_append_uint16(&cursor, SMB2_SET_INFO_REQUEST_SIZE);
+    evpl_iovec_cursor_append_uint8(&cursor, SMB2_INFO_FILE);
+    evpl_iovec_cursor_append_uint8(&cursor, SMB2_FILE_BASIC_INFO);
+    evpl_iovec_cursor_append_uint32(&cursor, 40);                            /* BufferLength */
+    evpl_iovec_cursor_append_uint16(&cursor, sizeof(struct smb2_header) + 32); /* BufferOffset */
+    evpl_iovec_cursor_append_uint16(&cursor, 0);                             /* Reserved */
+    evpl_iovec_cursor_append_uint32(&cursor, 0);                             /* AdditionalInformation */
+    evpl_iovec_cursor_append_uint64(&cursor, open_state->file_id.pid);
+    evpl_iovec_cursor_append_uint64(&cursor, open_state->file_id.vid);
+    /* FILE_BASIC_INFORMATION: Creation/LastAccess/LastWrite/ChangeTime + attrs. */
+    evpl_iovec_cursor_append_uint64(&cursor, crttime);
+    evpl_iovec_cursor_append_uint64(&cursor, atime);
+    evpl_iovec_cursor_append_uint64(&cursor, mtime);
+    evpl_iovec_cursor_append_uint64(&cursor, ctime);
+    evpl_iovec_cursor_append_uint32(&cursor, 0);                             /* FileAttributes (no change) */
+    evpl_iovec_cursor_append_uint32(&cursor, 0);                             /* Reserved */
+
+    chimera_smb_client_pdu_finish(conn, &iov, &cursor, request,
+                                  chimera_smb_setattr_reply, request);
+} /* chimera_smb_setattr_send_basic */
+
+/* After the size leg: chain the times leg if any timestamps were also set. */
+static void
+chimera_smb_setattr_size_reply(
+    struct chimera_smb_client_conn *conn,
+    uint32_t                        status,
+    const struct smb2_header       *hdr,
+    struct evpl_iovec_cursor       *body,
+    int                             body_len,
+    void                           *arg)
+{
+    struct chimera_vfs_request *request = arg;
+
+    (void) hdr;
+    (void) body;
+    (void) body_len;
+
+    if (status != SMB2_STATUS_SUCCESS) {
+        request->status = chimera_smb_status_to_errno(status);
+        request->complete(request);
+        return;
+    }
+
+    if (request->setattr.set_attr->va_set_mask & CHIMERA_SMB_SETATTR_TIMES) {
+        chimera_smb_setattr_send_basic(conn, request);
+        return;
+    }
+
+    request->status = CHIMERA_VFS_OK;
+    request->complete(request);
+} /* chimera_smb_setattr_size_reply */
+
+void
+chimera_smb_client_setattr(
+    struct chimera_smb_client_conn *conn,
+    struct chimera_vfs_request     *request)
+{
+    struct chimera_smb_client_open *open_state = smb_handle_open_state(request->setattr.handle);
+    struct chimera_vfs_attrs       *set_attr   = request->setattr.set_attr;
+    struct evpl_iovec               iov;
+    struct evpl_iovec_cursor        cursor;
+    struct smb2_header             *hdr;
+
+    if (!open_state) {
+        request->status = CHIMERA_VFS_ENOTSUP;
+        request->complete(request);
+        return;
+    }
+
+    /* SMB can set size (FileEndOfFileInformation) and timestamps (FileBasic-
+     * Information).  POSIX mode/owner have no SMB2 equivalent against this
+     * server, so those bits are accepted but not applied. */
+    if (set_attr->va_set_mask & CHIMERA_VFS_ATTR_SIZE) {
+        /* Set size first, then chain the times leg from its reply. */
+        chimera_smb_client_pdu_begin(conn, SMB2_SET_INFO, &iov, &cursor, &hdr);
+
+        evpl_iovec_cursor_append_uint16(&cursor, SMB2_SET_INFO_REQUEST_SIZE);
+        evpl_iovec_cursor_append_uint8(&cursor, SMB2_INFO_FILE);
+        evpl_iovec_cursor_append_uint8(&cursor, SMB2_FILE_ENDOFFILE_INFO);
+        evpl_iovec_cursor_append_uint32(&cursor, 8);                             /* BufferLength */
+        evpl_iovec_cursor_append_uint16(&cursor, sizeof(struct smb2_header) + 32); /* BufferOffset */
+        evpl_iovec_cursor_append_uint16(&cursor, 0);                             /* Reserved */
+        evpl_iovec_cursor_append_uint32(&cursor, 0);                             /* AdditionalInformation */
+        evpl_iovec_cursor_append_uint64(&cursor, open_state->file_id.pid);
+        evpl_iovec_cursor_append_uint64(&cursor, open_state->file_id.vid);
+        evpl_iovec_cursor_append_uint64(&cursor, set_attr->va_size);
+
+        chimera_smb_client_pdu_finish(conn, &iov, &cursor, request,
+                                      chimera_smb_setattr_size_reply, request);
+        return;
+    }
+
+    if (set_attr->va_set_mask & CHIMERA_SMB_SETATTR_TIMES) {
+        chimera_smb_setattr_send_basic(conn, request);
+        return;
+    }
+
+    /* Nothing SMB can apply (e.g. mode/owner only) -- accept as a no-op. */
+    request->status = CHIMERA_VFS_OK;
+    request->complete(request);
+} /* chimera_smb_client_setattr */
+
+/* ---- commit (FLUSH) ---------------------------------------------------- */
+
+static void
+chimera_smb_commit_reply(
+    struct chimera_smb_client_conn *conn,
+    uint32_t                        status,
+    const struct smb2_header       *hdr,
+    struct evpl_iovec_cursor       *body,
+    int                             body_len,
+    void                           *arg)
+{
+    struct chimera_vfs_request *request = arg;
+
+    (void) conn;
+    (void) hdr;
+    (void) body;
+    (void) body_len;
+
+    request->status = chimera_smb_status_to_errno(status);
+    request->complete(request);
+} /* chimera_smb_commit_reply */
+
+void
+chimera_smb_client_commit(
+    struct chimera_smb_client_conn *conn,
+    struct chimera_vfs_request     *request)
+{
+    struct chimera_smb_client_open *open_state = smb_handle_open_state(request->commit.handle);
+    struct evpl_iovec               iov;
+    struct evpl_iovec_cursor        cursor;
+    struct smb2_header             *hdr;
+
+    if (!open_state) {
+        request->status = CHIMERA_VFS_OK;
+        request->complete(request);
+        return;
+    }
+
+    chimera_smb_client_pdu_begin(conn, SMB2_FLUSH, &iov, &cursor, &hdr);
+
+    evpl_iovec_cursor_append_uint16(&cursor, SMB2_FLUSH_REQUEST_SIZE);
+    evpl_iovec_cursor_append_uint16(&cursor, 0);             /* Reserved1 */
+    evpl_iovec_cursor_append_uint32(&cursor, 0);             /* Reserved2 */
+    evpl_iovec_cursor_append_uint64(&cursor, open_state->file_id.pid);
+    evpl_iovec_cursor_append_uint64(&cursor, open_state->file_id.vid);
+
+    chimera_smb_client_pdu_finish(conn, &iov, &cursor, request,
+                                  chimera_smb_commit_reply, request);
+} /* chimera_smb_client_commit */
+
+/* read / write / readdir live in smb_io.c; rename/symlink/mknod in
+ * smb_namespace.c -- they reuse the shared helpers declared in smb_internal.h. */

--- a/src/vfs/smb/smb_umount.c
+++ b/src/vfs/smb/smb_umount.c
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "smb_internal.h"
+#include "evpl/evpl.h"
+
+/* UMOUNT tears the shared session down gracefully on the calling thread's
+ * connection: TREE_DISCONNECT -> LOGOFF -> close.  Best-effort: a server-side
+ * error on either leg still completes the umount successfully.  The server
+ * registration is retained (freed at module destroy) so other threads' cached
+ * connections never dereference freed state. */
+
+static void
+chimera_smb_client_umount_finish(
+    struct chimera_smb_client_conn *conn,
+    struct chimera_vfs_request     *request)
+{
+    conn->server->session_ready = 0;
+
+    /* Detach before closing so the DISCONNECTED notify does not re-find this
+     * connection in the thread's table. */
+    if (conn->thread->conns[conn->server->index] == conn) {
+        conn->thread->conns[conn->server->index] = NULL;
+    }
+
+    request->status = CHIMERA_VFS_OK;
+    request->complete(request);
+
+    conn->closing = 1;
+    evpl_close(conn->evpl, conn->bind);
+} /* chimera_smb_client_umount_finish */
+
+static void
+chimera_smb_client_logoff_reply(
+    struct chimera_smb_client_conn *conn,
+    uint32_t                        status,
+    const struct smb2_header       *hdr,
+    struct evpl_iovec_cursor       *body,
+    int                             body_len,
+    void                           *arg)
+{
+    struct chimera_vfs_request *request = arg;
+
+    (void) hdr;
+    (void) body;
+    (void) body_len;
+
+    if (status != SMB2_STATUS_SUCCESS) {
+        chimera_smbclient_info("LOGOFF returned status 0x%08x (ignored)", status);
+    }
+
+    chimera_smb_client_umount_finish(conn, request);
+} /* chimera_smb_client_logoff_reply */
+
+static void
+chimera_smb_client_logoff_send(
+    struct chimera_smb_client_conn *conn,
+    struct chimera_vfs_request     *request)
+{
+    struct evpl_iovec        iov;
+    struct evpl_iovec_cursor cursor;
+    struct smb2_header      *hdr;
+
+    chimera_smb_client_pdu_begin(conn, SMB2_LOGOFF, &iov, &cursor, &hdr);
+
+    evpl_iovec_cursor_append_uint16(&cursor, SMB2_LOGOFF_REQUEST_SIZE);
+    evpl_iovec_cursor_append_uint16(&cursor, 0);
+
+    chimera_smb_client_pdu_finish(conn, &iov, &cursor, request,
+                                  chimera_smb_client_logoff_reply, request);
+} /* chimera_smb_client_logoff_send */
+
+static void
+chimera_smb_client_tree_disconnect_reply(
+    struct chimera_smb_client_conn *conn,
+    uint32_t                        status,
+    const struct smb2_header       *hdr,
+    struct evpl_iovec_cursor       *body,
+    int                             body_len,
+    void                           *arg)
+{
+    struct chimera_vfs_request *request = arg;
+
+    (void) hdr;
+    (void) body;
+    (void) body_len;
+
+    if (status != SMB2_STATUS_SUCCESS) {
+        chimera_smbclient_info("TREE_DISCONNECT returned status 0x%08x (ignored)", status);
+    }
+
+    chimera_smb_client_logoff_send(conn, request);
+} /* chimera_smb_client_tree_disconnect_reply */
+
+void
+chimera_smb_client_umount(
+    struct chimera_smb_client_thread *thread,
+    struct chimera_vfs_request       *request)
+{
+    struct chimera_smb_client_server *server = request->umount.mount_private;
+    struct chimera_smb_client_conn   *conn;
+    struct evpl_iovec                 iov;
+    struct evpl_iovec_cursor          cursor;
+    struct smb2_header               *hdr;
+
+    if (!server) {
+        request->status = CHIMERA_VFS_OK;
+        request->complete(request);
+        return;
+    }
+
+    conn = thread->conns[server->index];
+
+    if (!conn || conn->state != CHIMERA_SMB_CONN_READY) {
+        /* No live connection to this server on this thread; nothing to send. */
+        request->status = CHIMERA_VFS_OK;
+        request->complete(request);
+        return;
+    }
+
+    chimera_smb_client_pdu_begin(conn, SMB2_TREE_DISCONNECT, &iov, &cursor, &hdr);
+
+    evpl_iovec_cursor_append_uint16(&cursor, SMB2_TREE_DISCONNECT_REQUEST_SIZE);
+    evpl_iovec_cursor_append_uint16(&cursor, 0);
+
+    chimera_smb_client_pdu_finish(conn, &iov, &cursor, request,
+                                  chimera_smb_client_tree_disconnect_reply, request);
+} /* chimera_smb_client_umount */

--- a/src/vfs/smb/tests/CMakeLists.txt
+++ b/src/vfs/smb/tests/CMakeLists.txt
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+#
+# SPDX-License-Identifier: LGPL-2.1-only
+
+# SMB2 client mount/umount smoke test.  Stands up an in-process SMB server over
+# a memfs share and drives the vfs_smb client through a full session
+# establish + teardown over loopback TCP.  Like the smbclient auth test it
+# binds the privileged SMB port, so it runs under the netns wrapper.
+add_executable(smb_mount_test smb_mount_test.c)
+target_link_libraries(smb_mount_test chimera_server chimera_metrics jansson)
+target_include_directories(smb_mount_test PRIVATE ${CMAKE_SOURCE_DIR}/src)
+
+if(CHIMERA_NETNS_TESTING)
+    add_test(NAME chimera/vfs/smb/mount
+        COMMAND ${CMAKE_SOURCE_DIR}/scripts/netns_test_wrapper.sh
+                ${CMAKE_CURRENT_BINARY_DIR}/smb_mount_test)
+endif()

--- a/src/vfs/smb/tests/smb_mount_test.c
+++ b/src/vfs/smb/tests/smb_mount_test.c
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * SMB2 client mount smoke test.
+ *
+ * Starts an in-process Chimera SMB *server* exporting a memfs share, then
+ * drives the SMB2 *client* VFS module (vfs_smb) to MOUNT the share -- which
+ * runs the full NEGOTIATE -> SESSION_SETUP (NTLMv2) -> TREE_CONNECT handshake
+ * over a loopback TCP connection -- and then UMOUNT it (TREE_DISCONNECT ->
+ * LOGOFF -> disconnect).  A successful mount proves the session was
+ * established and torn down end to end.
+ *
+ * MOUNT and UMOUNT are driven on a single client evpl thread so the SMB
+ * connection (which lives on that thread's evpl) stays valid across both.
+ */
+
+#include "common/logging.h"
+#include "prometheus-c.h"
+#include "server/server.h"
+#include "common/test_users.h"
+#include "vfs/vfs.h"
+#include "vfs/vfs_procs.h"
+#include "evpl/evpl.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+struct op_ctx {
+    int done;
+    enum chimera_vfs_error status;
+};
+
+static void
+mount_callback(
+    struct chimera_vfs_thread *thread,
+    enum chimera_vfs_error     status,
+    void                      *private_data)
+{
+    struct op_ctx *ctx = private_data;
+
+    (void) thread;
+    ctx->status = status;
+    ctx->done   = 1;
+} /* mount_callback */
+
+static void
+umount_callback(
+    struct chimera_vfs_thread *thread,
+    enum chimera_vfs_error     status,
+    void                      *private_data)
+{
+    struct op_ctx *ctx = private_data;
+
+    (void) thread;
+    ctx->status = status;
+    ctx->done   = 1;
+} /* umount_callback */
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    struct chimera_server        *server;
+    struct chimera_server_config *config;
+    struct prometheus_metrics    *metrics;
+    struct chimera_vfs           *vfs;
+    struct chimera_vfs_thread    *thread;
+    struct evpl                  *evpl;
+    struct op_ctx                 ctx;
+    int                           rc;
+
+    (void) argc;
+    (void) argv;
+
+    ChimeraLogLevel = CHIMERA_LOG_INFO;
+    evpl_set_log_fn(chimera_vlog, chimera_log_flush);
+
+    metrics = prometheus_metrics_create(NULL, NULL, 0);
+
+    config = chimera_server_config_init();
+    /* Register the SMB2 client VFS module (statically linked into chimera_vfs;
+     * empty path => resolve the vfs_smb symbol, do not dlopen). */
+    chimera_server_config_add_module(config, "smb", NULL, "");
+
+    server = chimera_server_init(config, metrics);
+    if (!server) {
+        fprintf(stderr, "Failed to initialize server\n");
+        return EXIT_FAILURE;
+    }
+
+    /* Export a memfs share over SMB. */
+    if (chimera_server_mount(server, "share", "memfs", "/", NULL) != 0) {
+        fprintf(stderr, "Failed to mount memfs share\n");
+        return EXIT_FAILURE;
+    }
+
+    chimera_server_start(server);
+    chimera_test_add_server_users(server);
+    chimera_server_create_share(server, "share", "share", 0);
+
+    /* Let the server's listener come up. */
+    usleep(200000);
+
+    /* ---- client side: mount the share through vfs_smb ---- */
+    vfs    = chimera_server_get_vfs(server);
+    evpl   = evpl_create(NULL);
+    thread = chimera_vfs_thread_init(evpl, vfs);
+
+    ctx.done = 0;
+    chimera_vfs_mount(thread, NULL,
+                      "smbclient",                 /* local mount name */
+                      "smb",                       /* module */
+                      "127.0.0.1:share",           /* host:share */
+                      "user=myuser,password=mypassword,domain=WORKGROUP",
+                      mount_callback, &ctx);
+
+    while (!ctx.done) {
+        evpl_continue(evpl);
+    }
+
+    if (ctx.status != CHIMERA_VFS_OK) {
+        fprintf(stderr, "SMB mount failed: vfs error %d\n", ctx.status);
+        rc = EXIT_FAILURE;
+        goto out;
+    }
+
+    fprintf(stderr, "SMB mount established; tearing down\n");
+
+    ctx.done = 0;
+    chimera_vfs_umount(thread, NULL, "smbclient", umount_callback, &ctx);
+
+    while (!ctx.done) {
+        evpl_continue(evpl);
+    }
+
+    if (ctx.status != CHIMERA_VFS_OK) {
+        fprintf(stderr, "SMB umount failed: vfs error %d\n", ctx.status);
+        rc = EXIT_FAILURE;
+        goto out;
+    }
+
+    fprintf(stderr, "SMB mount/umount smoke test PASSED\n");
+    rc = EXIT_SUCCESS;
+
+ out:
+    chimera_vfs_thread_destroy(thread);
+    evpl_destroy(evpl);
+    chimera_server_destroy(server);
+    prometheus_metrics_destroy(metrics);
+
+    return rc;
+} /* main */


### PR DESCRIPTION
> **Stacked on #804** (`vfs: path-only backend capability`) — that PR carries the shared VFS/client changes this client depends on, so **merge #804 first**. Until it lands, this PR's diff includes those foundation commits; once #804 merges into `main`, the diff here narrows to just the SMB client (`src/vfs/smb`, its tests, and build wiring).

---

## Overview

Adds an **SMB2 client** to chimera as a VFS backend module (`src/vfs/smb`,
`vfs_smb`), mirroring the NFS client (`src/vfs/nfs`) — a backend that proxies
VFS operations to a remote SMB server. Along the way it introduces a general
**path-only VFS backend capability** so a backend that has no persistent file
handles (like SMB) is a first-class citizen.

Draft: the session + a useful set of file operations work end-to-end and are
tested; several operations are still stubbed (see *Not yet done*).

## What's here (three increments)

**1. Session establish/teardown.** `vfs_smb` mounts a share by opening a TCP
connection and running `NEGOTIATE → SESSION_SETUP (NTLMv2) → TREE_CONNECT`;
umount runs `TREE_DISCONNECT → LOGOFF → disconnect`. Unlike the NFS client
(which rides `evpl_rpc2`/XDR), SMB2 has its own framing, so the module uses a
bare evpl stream connection and frames SMB2 PDUs itself, mirroring the SMB
*server* in `src/server/smb`. Raw NTLMSSP (no SPNEGO), dialect 2.1, signing not
required.

**2. File operations + per-thread connections.** Each evpl thread lazily opens
its own TCP connection that shares a single SMB session (a `FileId` opened on
one connection is usable from any connection bound to the session). Multi-
outstanding reply demux keyed by `message_id`, plus a deferred-op queue until a
connection finishes connecting. Operations: open/close, getattr, lookup, mkdir,
remove, setattr (truncate), commit.

**3. Path-only VFS capability.** SMB has no persistent file handle, so the
client originally fabricated a path-encoded handle. This increment makes
path-relative operation a first-class capability: a module advertising
`CAP_FS_PATH_OP` and not `CAP_FS_RELATIVE_OP` is **path-only**. For such a mount,
an open file's VFS handle carries an **opaque per-open token**
(`[mount_id][server_index][SMB FileId]`) — never re-derived to a path, not
re-openable; metadata is addressed by full mount-relative paths; only the mount
root is re-openable via `open_fh`. This mirrors the Linux cifs client (FileId in
the open file, paths for metadata, no persistent inode handle). The VFS path
walk hands the whole remaining path to a path-only mount in one lookup instead
of walking component by component, and `client stat` now uses the lookup's
attributes directly (a simplification for all backends).

## Notable design points

- VFS request routing is by `mount_id` (mount table), not an `fh_magic` first
  byte, so the opaque token routes correctly.
- A path-only success returns `va_fh_len == 0`, which the VFS name cache treats
  as a *negative* entry — the child name/attr cache inserts are guarded so a
  successful op doesn't poison the cache.
- Accepted limitation (same as Linux not re-exporting cifs over NFS): a
  path-only mount can't be re-exported by a handle-based consumer; `open_fh` of
  a child token returns `ESTALE` rather than crashing.

## Testing

The SMB client is exercised through the existing client test harness
(`client_test_common.h` gains a `-s` SMB mode that stands up an in-process SMB
server over a memfs share). `stat`, `fstat`, `ftruncate`, and `remove` pass over
the SMB client (root, memfs), AddressSanitizer-clean, and are wired into ctest;
a connect/teardown smoke test (`src/vfs/smb/tests/smb_mount_test.c`) also passes.
FH-relative backends (memfs direct) are unaffected.

## Not yet done (follow-ups)

- `read`/`write`/`readdir` (SMB2 READ/WRITE/QUERY_DIRECTORY) and
  `symlink`/`mknod`/`rename` backend ops are stubbed/`ENOTSUP`.
- Client `setattr`/`readlink`/`statfs` still resolve via `lookup → open_fh`
  (would need the path-only treatment); plus an `OPEN_NOFOLLOW` flag for
  lstat/readlink.
- Deep paths *under* a path-only mount (the create/remove parent resolution
  needs to rebase onto the mount root with the in-mount sub-path); current tests
  use single-level paths.
- SMB 3.x dialects, signing/encryption, SPNEGO/Kerberos, multichannel.
