### PR TITLE
vfs/kv: end-inclusivity flag and ordered results for KV search

### DIFF
--- a/src/server/smb/smb_durable.c
+++ b/src/server/smb/smb_durable.c
@@ -730,7 +730,7 @@ chimera_smb_durable_recover_share(
     chimera_vfs_search_keys_at(thread->vfs_thread, NULL, fh, fh_len,
                                CHIMERA_SMB_DURABLE_KEY_PREFIX,
                                CHIMERA_SMB_DURABLE_KEY_PREFIX_LEN,
-                               NULL, 0,
+                               NULL, 0, 0,
                                chimera_smb_durable_recover_cb,
                                chimera_smb_durable_recover_complete,
                                ctx);

--- a/src/vfs/cairn/cairn.c
+++ b/src/vfs/cairn/cairn.c
@@ -4451,6 +4451,7 @@ cairn_search_keys(
     size_t                             key_len, value_len;
     int                                rc;
     chimera_vfs_search_keys_callback_t callback = request->search_keys.callback;
+    uint32_t                           flags    = request->search_keys.flags;
 
     if (request->search_keys.start_key_len > CAIRN_KV_KEY_MAX ||
         request->search_keys.end_key_len > CAIRN_KV_KEY_MAX) {
@@ -4488,11 +4489,20 @@ cairn_search_keys(
             break;
         }
 
-        /* Check if key is past end key (if end key specified) */
+        /* Check if key is past end key (if end key specified).  With
+         * END_EXCLUSIVE, a key byte-equal to end_kv_key is itself past the
+         * range and stops the scan. */
         if (request->search_keys.end_key_len > 0) {
-            if (key_len > end_kv_key_len ||
-                (key_len == end_kv_key_len &&
-                 memcmp(key, end_kv_key, end_kv_key_len) > 0)) {
+            int past = 0;
+
+            if (key_len > end_kv_key_len) {
+                past = 1;
+            } else if (key_len == end_kv_key_len) {
+                int c = memcmp(key, end_kv_key, end_kv_key_len);
+                past = (flags & CHIMERA_VFS_SEARCH_KEYS_END_EXCLUSIVE) ? (c >= 0) : (c > 0);
+            }
+
+            if (past) {
                 break;
             }
         }

--- a/src/vfs/diskfs/diskfs_attr.c
+++ b/src/vfs/diskfs/diskfs_attr.c
@@ -116,7 +116,8 @@ diskfs_kv_key_in_range(
     const void *start_key,
     uint32_t    start_key_len,
     const void *end_key,
-    uint32_t    end_key_len);
+    uint32_t    end_key_len,
+    uint32_t    flags);
 
 static inline int
 diskfs_xattr_rec_matches(
@@ -1295,7 +1296,8 @@ diskfs_kv_key_in_range(
     const void *start_key,
     uint32_t    start_key_len,
     const void *end_key,
-    uint32_t    end_key_len)
+    uint32_t    end_key_len,
+    uint32_t    flags)
 {
     int cmp;
 
@@ -1315,11 +1317,41 @@ diskfs_kv_key_in_range(
         if (cmp > 0 || (cmp == 0 && key_len > end_key_len)) {
             return 0; /* key > end_key */
         }
+        if ((flags & CHIMERA_VFS_SEARCH_KEYS_END_EXCLUSIVE) &&
+            cmp == 0 && key_len == end_key_len) {
+            return 0; /* key == end_key, end is exclusive */
+        }
     }
 
-    return 1; /* key is in range [start_key, end_key] */
+    return 1; /* key is in range */
 } /* diskfs_kv_key_in_range */
 
+
+/* One matched key/value, copied out from under the shard lock so the search
+ * can sort across shards and invoke the callback without holding any lock. */
+struct diskfs_search_item {
+    void    *key;
+    uint32_t key_len;
+    void    *value;
+    uint32_t value_len;
+};
+
+static int
+diskfs_search_item_cmp(
+    const void *a,
+    const void *b)
+{
+    const struct diskfs_search_item *ia  = a;
+    const struct diskfs_search_item *ib  = b;
+    uint32_t                         min = ia->key_len < ib->key_len ? ia->key_len : ib->key_len;
+    int                              cmp = memcmp(ia->key, ib->key, min);
+
+    if (cmp) {
+        return cmp;
+    }
+    /* Shorter key (a byte-prefix of the other) sorts first. */
+    return (ia->key_len > ib->key_len) - (ia->key_len < ib->key_len);
+} /* diskfs_search_item_cmp */
 
 void
 diskfs_search_keys(
@@ -1329,9 +1361,11 @@ diskfs_search_keys(
     void                       *private_data)
 {
     struct diskfs_request_private     *p = request->plugin_data;
-    int                                i, rc;
+    int                                i;
+    size_t                             n = 0, cap = 0, k;
     struct diskfs_kv_shard            *shard;
     struct diskfs_kv_entry            *entry;
+    struct diskfs_search_item         *items = NULL, *grown;
     chimera_vfs_search_keys_callback_t callback = request->search_keys.callback;
 
     (void) private_data;
@@ -1339,6 +1373,10 @@ diskfs_search_keys(
     p->thread = thread;
     p->txn    = diskfs_txn_begin(thread, DISKFS_TXN_READ);
 
+    /* Entries are stored hash-ordered (sharded by hash), so collect every
+     * in-range match across all shards, then sort by key to return results in
+     * the backend's natural (lexicographic) key order.  Keys and values are
+     * copied so the callback runs without any shard lock held. */
     for (i = 0; i < shared->num_kv_shards; i++) {
         shard = &shared->kv_shards[i];
 
@@ -1352,16 +1390,38 @@ diskfs_search_keys(
                                        request->search_keys.start_key,
                                        request->search_keys.start_key_len,
                                        request->search_keys.end_key,
-                                       request->search_keys.end_key_len)) {
-                rc = callback(entry->key, entry->key_len,
-                              entry->value, entry->value_len,
-                              request->proto_private_data);
+                                       request->search_keys.end_key_len,
+                                       request->search_keys.flags)) {
+                struct diskfs_search_item *item;
 
-                if (rc) {
-                    pthread_mutex_unlock(&shard->lock);
-                    diskfs_op_ok(request, p->txn);
-                    return;
+                if (n == cap) {
+                    cap   = cap ? cap * 2 : 16;
+                    grown = realloc(items, cap * sizeof(*items));
+                    if (!grown) {
+                        pthread_mutex_unlock(&shard->lock);
+                        goto enomem;
+                    }
+                    items = grown;
                 }
+
+                item            = &items[n];
+                item->key_len   = entry->key_len;
+                item->value_len = entry->value_len;
+                item->key       = malloc(entry->key_len);
+                item->value     = entry->value_len ? malloc(entry->value_len) : NULL;
+
+                if (!item->key || (entry->value_len && !item->value)) {
+                    free(item->key);
+                    free(item->value);
+                    pthread_mutex_unlock(&shard->lock);
+                    goto enomem;
+                }
+
+                memcpy(item->key, entry->key, entry->key_len);
+                if (entry->value_len) {
+                    memcpy(item->value, entry->value, entry->value_len);
+                }
+                n++;
             }
 
             entry = rb_tree_next(&shard->entries, entry);
@@ -1370,7 +1430,35 @@ diskfs_search_keys(
         pthread_mutex_unlock(&shard->lock);
     }
 
+    if (n > 1) {
+        qsort(items, n, sizeof(*items), diskfs_search_item_cmp);
+    }
+
+    for (k = 0; k < n; k++) {
+        if (callback(items[k].key, items[k].key_len,
+                     items[k].value, items[k].value_len,
+                     request->proto_private_data)) {
+            break; /* caller aborted the search */
+        }
+    }
+
+    for (k = 0; k < n; k++) {
+        free(items[k].key);
+        free(items[k].value);
+    }
+    free(items);
+
     diskfs_op_ok(request, p->txn);
+    return;
+
+ enomem:
+    for (k = 0; k < n; k++) {
+        free(items[k].key);
+        free(items[k].value);
+    }
+    free(items);
+
+    diskfs_op_fail(request, p->txn, CHIMERA_VFS_EIO);
 } /* diskfs_search_keys */
 
 

--- a/src/vfs/memkv/memkv.c
+++ b/src/vfs/memkv/memkv.c
@@ -319,7 +319,8 @@ memkv_key_in_range(
     const void *start_key,
     uint32_t    start_key_len,
     const void *end_key,
-    uint32_t    end_key_len)
+    uint32_t    end_key_len,
+    uint32_t    flags)
 {
     int cmp;
 
@@ -339,10 +340,41 @@ memkv_key_in_range(
         if (cmp > 0 || (cmp == 0 && key_len > end_key_len)) {
             return 0; /* key > end_key */
         }
+        if ((flags & CHIMERA_VFS_SEARCH_KEYS_END_EXCLUSIVE) &&
+            cmp == 0 && key_len == end_key_len) {
+            return 0; /* key == end_key, end is exclusive */
+        }
     }
 
-    return 1; /* key is in range [start_key, end_key] */
+    return 1; /* key is in range */
 } /* memkv_key_in_range */
+
+/* One matched key/value, copied out from under the shard lock so the search
+ * can sort across shards and invoke the callback without holding any lock (the
+ * callback is caller-supplied and may re-enter the backend). */
+struct memkv_search_item {
+    void    *key;
+    uint32_t key_len;
+    void    *value;
+    uint32_t value_len;
+};
+
+static int
+memkv_search_item_cmp(
+    const void *a,
+    const void *b)
+{
+    const struct memkv_search_item *ia  = a;
+    const struct memkv_search_item *ib  = b;
+    uint32_t                        min = ia->key_len < ib->key_len ? ia->key_len : ib->key_len;
+    int                             cmp = memcmp(ia->key, ib->key, min);
+
+    if (cmp) {
+        return cmp;
+    }
+    /* Shorter key (a byte-prefix of the other) sorts first. */
+    return (ia->key_len > ib->key_len) - (ia->key_len < ib->key_len);
+} /* memkv_search_item_cmp */
 
 static void
 memkv_search_keys(
@@ -350,15 +382,20 @@ memkv_search_keys(
     struct memkv_shared        *shared,
     struct chimera_vfs_request *request)
 {
-    int                                i, rc;
+    int                                i;
+    size_t                             n = 0, cap = 0, k;
     struct memkv_shard                *shard;
     struct memkv_entry                *entry;
+    struct memkv_search_item          *items = NULL, *grown;
     chimera_vfs_search_keys_callback_t callback = request->search_keys.callback;
+    enum chimera_vfs_error             status   = CHIMERA_VFS_OK;
 
     (void) thread;
 
-    /* Iterate over all shards (entries are hash-ordered, not key-ordered, so a
-     * full scan with an in-range filter is required). */
+    /* Entries are stored hash-ordered (sharded by hash), so collect every
+     * in-range match across all shards, then sort by key to return results in
+     * the backend's natural (lexicographic) key order.  Keys and values are
+     * copied so the callback runs without any shard lock held. */
     for (i = 0; i < shared->num_shards; i++) {
         shard = &shared->shards[i];
 
@@ -372,20 +409,40 @@ memkv_search_keys(
                                    request->search_keys.start_key,
                                    request->search_keys.start_key_len,
                                    request->search_keys.end_key,
-                                   request->search_keys.end_key_len)) {
-                rc = callback(entry->key,
-                              entry->key_len,
-                              entry->value,
-                              entry->value_len,
-                              request->proto_private_data);
+                                   request->search_keys.end_key_len,
+                                   request->search_keys.flags)) {
+                struct memkv_search_item *item;
 
-                if (rc) {
-                    /* Caller wants to abort search */
-                    pthread_mutex_unlock(&shard->lock);
-                    request->status = CHIMERA_VFS_OK;
-                    request->complete(request);
-                    return;
+                if (n == cap) {
+                    cap   = cap ? cap * 2 : 16;
+                    grown = realloc(items, cap * sizeof(*items));
+                    if (!grown) {
+                        pthread_mutex_unlock(&shard->lock);
+                        status = CHIMERA_VFS_EIO;
+                        goto out;
+                    }
+                    items = grown;
                 }
+
+                item            = &items[n];
+                item->key_len   = entry->key_len;
+                item->value_len = entry->value_len;
+                item->key       = malloc(entry->key_len);
+                item->value     = entry->value_len ? malloc(entry->value_len) : NULL;
+
+                if (!item->key || (entry->value_len && !item->value)) {
+                    free(item->key);
+                    free(item->value);
+                    pthread_mutex_unlock(&shard->lock);
+                    status = CHIMERA_VFS_EIO;
+                    goto out;
+                }
+
+                memcpy(item->key, entry->key, entry->key_len);
+                if (entry->value_len) {
+                    memcpy(item->value, entry->value, entry->value_len);
+                }
+                n++;
             }
 
             entry = rb_tree_next(&shard->entries, entry);
@@ -394,7 +451,26 @@ memkv_search_keys(
         pthread_mutex_unlock(&shard->lock);
     }
 
-    request->status = CHIMERA_VFS_OK;
+    if (n > 1) {
+        qsort(items, n, sizeof(*items), memkv_search_item_cmp);
+    }
+
+    for (k = 0; k < n; k++) {
+        if (callback(items[k].key, items[k].key_len,
+                     items[k].value, items[k].value_len,
+                     request->proto_private_data)) {
+            break; /* caller aborted the search */
+        }
+    }
+
+ out:
+    for (k = 0; k < n; k++) {
+        free(items[k].key);
+        free(items[k].value);
+    }
+    free(items);
+
+    request->status = status;
     request->complete(request);
 } /* memkv_search_keys */
 

--- a/src/vfs/sqlite/sqlite.c
+++ b/src/vfs/sqlite/sqlite.c
@@ -282,6 +282,7 @@ sqlite_search_keys(
     uint32_t                           start_len = request->search_keys.start_key_len;
     const void                        *end       = request->search_keys.end_key;
     uint32_t                           end_len   = request->search_keys.end_key_len;
+    uint32_t                           flags     = request->search_keys.flags;
     sqlite3_stmt                      *stmt      = NULL;
     const char                        *sql;
     int                                bind_idx = 1;
@@ -289,15 +290,28 @@ sqlite_search_keys(
 
     /* BLOB comparison in sqlite is bytewise (memcmp with the shorter blob
      * ordering first), matching the range semantics used by the other KV
-     * backends.  Both bounds are inclusive. */
-    if (start_len && end_len) {
-        sql = "SELECT key,value FROM kv WHERE key>=? AND key<=? ORDER BY key";
-    } else if (start_len) {
-        sql = "SELECT key,value FROM kv WHERE key>=? ORDER BY key";
-    } else if (end_len) {
-        sql = "SELECT key,value FROM kv WHERE key<=? ORDER BY key";
+     * backends.  The start bound is inclusive; the end bound is inclusive
+     * unless END_EXCLUSIVE is set. */
+    if (flags & CHIMERA_VFS_SEARCH_KEYS_END_EXCLUSIVE) {
+        if (start_len && end_len) {
+            sql = "SELECT key,value FROM kv WHERE key>=? AND key<? ORDER BY key";
+        } else if (start_len) {
+            sql = "SELECT key,value FROM kv WHERE key>=? ORDER BY key";
+        } else if (end_len) {
+            sql = "SELECT key,value FROM kv WHERE key<? ORDER BY key";
+        } else {
+            sql = "SELECT key,value FROM kv ORDER BY key";
+        }
     } else {
-        sql = "SELECT key,value FROM kv ORDER BY key";
+        if (start_len && end_len) {
+            sql = "SELECT key,value FROM kv WHERE key>=? AND key<=? ORDER BY key";
+        } else if (start_len) {
+            sql = "SELECT key,value FROM kv WHERE key>=? ORDER BY key";
+        } else if (end_len) {
+            sql = "SELECT key,value FROM kv WHERE key<=? ORDER BY key";
+        } else {
+            sql = "SELECT key,value FROM kv ORDER BY key";
+        }
     }
 
     rc = sqlite3_prepare_v2(thread->db, sql, -1, &stmt, NULL);

--- a/src/vfs/tests/vfs_async_delegation_test.c
+++ b/src/vfs/tests/vfs_async_delegation_test.c
@@ -146,6 +146,7 @@ search_for_single_key(
         strlen(key),
         end_key,
         strlen(end_key),
+        0,
         search_keys_callback,
         search_keys_complete,
         ctx);

--- a/src/vfs/tests/vfs_kv_test.c
+++ b/src/vfs/tests/vfs_kv_test.c
@@ -19,10 +19,12 @@
 
 struct test_ctx {
     int                        done;
-    enum chimera_vfs_error status;
+    enum chimera_vfs_error     status;
     const void                *value;
     uint32_t                   value_len;
     int                        search_count;
+    char                       search_keys[16][64];
+    uint32_t                   search_key_lens[16];
     struct chimera_vfs        *vfs;
     struct chimera_vfs_thread *vfs_thread;
     struct evpl               *evpl;
@@ -75,6 +77,10 @@ search_keys_callback(
 {
     struct test_ctx *ctx = private_data;
 
+    if (ctx->search_count < 16 && key_len < sizeof(ctx->search_keys[0])) {
+        memcpy(ctx->search_keys[ctx->search_count], key, key_len);
+        ctx->search_key_lens[ctx->search_count] = key_len;
+    }
     ctx->search_count++;
     return 0; /* continue searching */
 } /* search_keys_callback */
@@ -242,7 +248,7 @@ test_search_keys(struct test_ctx *ctx)
         assert(ctx->status == CHIMERA_VFS_OK);
     }
 
-    /* Search for all keys in range */
+    /* Search the whole range; results must come back in sorted key order. */
     ctx->search_count = 0;
     chimera_vfs_search_keys(
         ctx->vfs_thread,
@@ -250,6 +256,7 @@ test_search_keys(struct test_ctx *ctx)
         strlen("search_aaa"),
         "search_zzz",
         strlen("search_zzz"),
+        0,
         search_keys_callback,
         search_keys_complete,
         ctx);
@@ -257,6 +264,47 @@ test_search_keys(struct test_ctx *ctx)
     wait_for_completion(ctx);
     assert(ctx->status == CHIMERA_VFS_OK);
     assert(ctx->search_count == num_keys);
+
+    for (int i = 0; i < num_keys; i++) {
+        assert(ctx->search_key_lens[i] == strlen(keys[i]));
+        assert(memcmp(ctx->search_keys[i], keys[i], ctx->search_key_lens[i]) == 0);
+    }
+
+    /* Inclusive end: a range ending exactly on "search_ccc" returns it. */
+    ctx->search_count = 0;
+    chimera_vfs_search_keys(
+        ctx->vfs_thread,
+        "search_aaa",
+        strlen("search_aaa"),
+        "search_ccc",
+        strlen("search_ccc"),
+        0,
+        search_keys_callback,
+        search_keys_complete,
+        ctx);
+
+    wait_for_completion(ctx);
+    assert(ctx->status == CHIMERA_VFS_OK);
+    assert(ctx->search_count == 3); /* aaa, bbb, ccc */
+
+    /* Exclusive end: the same range drops the key equal to the end bound. */
+    ctx->search_count = 0;
+    chimera_vfs_search_keys(
+        ctx->vfs_thread,
+        "search_aaa",
+        strlen("search_aaa"),
+        "search_ccc",
+        strlen("search_ccc"),
+        CHIMERA_VFS_SEARCH_KEYS_END_EXCLUSIVE,
+        search_keys_callback,
+        search_keys_complete,
+        ctx);
+
+    wait_for_completion(ctx);
+    assert(ctx->status == CHIMERA_VFS_OK);
+    assert(ctx->search_count == 2); /* aaa, bbb */
+    assert(ctx->search_key_lens[1] == strlen("search_bbb"));
+    assert(memcmp(ctx->search_keys[1], "search_bbb", strlen("search_bbb")) == 0);
 
     /* Cleanup */
     for (int i = 0; i < num_keys; i++) {

--- a/src/vfs/tests/vfs_sync_delegation_test.c
+++ b/src/vfs/tests/vfs_sync_delegation_test.c
@@ -144,6 +144,7 @@ search_for_single_key(
         strlen(key),
         key,
         strlen(key),
+        0,
         search_keys_callback,
         search_keys_complete,
         ctx);

--- a/src/vfs/vfs.h
+++ b/src/vfs/vfs.h
@@ -327,6 +327,15 @@ typedef void (*chimera_vfs_delete_key_callback_t)(
     enum chimera_vfs_error error_code,
     void                  *private_data);
 
+/* Flags for chimera_vfs_search_keys / chimera_vfs_search_keys_at.
+ *
+ * By default the range searched is [start_key, end_key] (both bounds
+ * inclusive).  END_EXCLUSIVE makes the end bound exclusive, i.e. the range
+ * becomes [start_key, end_key); a key byte-equal to end_key is not returned.
+ * The flag has no effect when no end key is supplied (the range is then
+ * open-ended). */
+#define CHIMERA_VFS_SEARCH_KEYS_END_EXCLUSIVE 0x00000001U
+
 /* Returns non-zero to abort the search */
 typedef int (*chimera_vfs_search_keys_callback_t)(
     const void *key,
@@ -877,6 +886,7 @@ struct chimera_vfs_request {
             uint32_t                           start_key_len;
             const void                        *end_key;
             uint32_t                           end_key_len;
+            uint32_t                           flags;
             chimera_vfs_search_keys_callback_t callback;
         } search_keys;
 

--- a/src/vfs/vfs_proc_search_keys.c
+++ b/src/vfs/vfs_proc_search_keys.c
@@ -27,6 +27,7 @@ chimera_vfs_search_keys(
     uint32_t                           start_key_len,
     const void                        *end_key,
     uint32_t                           end_key_len,
+    uint32_t                           flags,
     chimera_vfs_search_keys_callback_t callback,
     chimera_vfs_search_keys_complete_t complete,
     void                              *private_data)
@@ -46,6 +47,7 @@ chimera_vfs_search_keys(
     request->search_keys.start_key_len = start_key_len;
     request->search_keys.end_key       = end_key;
     request->search_keys.end_key_len   = end_key_len;
+    request->search_keys.flags         = flags;
     request->search_keys.callback      = callback;
     request->proto_callback            = complete;
     request->proto_private_data        = private_data;
@@ -107,6 +109,7 @@ chimera_vfs_search_keys_at(
     uint32_t                           start_key_len,
     const void                        *end_key,
     uint32_t                           end_key_len,
+    uint32_t                           flags,
     chimera_vfs_search_keys_callback_t callback,
     chimera_vfs_search_keys_complete_t complete,
     void                              *private_data)
@@ -164,10 +167,14 @@ chimera_vfs_search_keys_at(
             memcpy(p + 1, end_key, end_key_len);
             request->search_keys.end_key     = p;
             request->search_keys.end_key_len = end_key_len + 1;
+            request->search_keys.flags       = flags;
         } else {
             p[0]                             = (uint8_t) (route.ns + 1);
             request->search_keys.end_key     = p;
             request->search_keys.end_key_len = 1;
+            /* ns+1 is a strict namespace boundary: exclude it so a key that
+             * happens to equal the single boundary byte never leaks out. */
+            request->search_keys.flags = CHIMERA_VFS_SEARCH_KEYS_END_EXCLUSIVE;
         }
 
         request->search_keys.callback = chimera_vfs_kv_ns_search_cb;
@@ -186,6 +193,7 @@ chimera_vfs_search_keys_at(
         request->search_keys.start_key_len = start_key_len;
         request->search_keys.end_key       = end_key_len ? scratch + start_key_len : NULL;
         request->search_keys.end_key_len   = end_key_len;
+        request->search_keys.flags         = flags;
         request->search_keys.callback      = callback;
         request->proto_callback            = complete;
         request->proto_private_data        = private_data;

--- a/src/vfs/vfs_procs.h
+++ b/src/vfs/vfs_procs.h
@@ -735,6 +735,7 @@ chimera_vfs_search_keys(
     uint32_t                           start_key_len,
     const void                        *end_key,
     uint32_t                           end_key_len,
+    uint32_t                           flags,
     chimera_vfs_search_keys_callback_t callback,
     chimera_vfs_search_keys_complete_t complete,
     void                              *private_data);
@@ -749,6 +750,7 @@ chimera_vfs_search_keys_at(
     uint32_t                           start_key_len,
     const void                        *end_key,
     uint32_t                           end_key_len,
+    uint32_t                           flags,
     chimera_vfs_search_keys_callback_t callback,
     chimera_vfs_search_keys_complete_t complete,
     void                              *private_data);


### PR DESCRIPTION
## Summary

Extends the VFS KV search API (`chimera_vfs_search_keys` / `_at`) with a `flags` argument and guarantees key-ordered results across all KV backends.

Previously the search scanned a `[start_key, end_key]` range with the end bound **hard-coded inclusive**, and two backends (memkv, diskfs) returned matches in *hash order* rather than key order.

## Changes

- **`flags` argument** added to the public API and request struct, with `CHIMERA_VFS_SEARCH_KEYS_END_EXCLUSIVE` (vfs.h). When set, the end bound becomes exclusive (`[start, end)`); the default (flag clear) stays **inclusive**, so every existing caller is unchanged.
- **Backends honor the flag:**
  - `sqlite` — `key<?` vs `key<=?`
  - `cairn` — stops the iterator when a key byte-equals the end bound
  - `memkv` / `diskfs` — extended the in-range predicate
- **Key-ordered results everywhere.** sqlite (`ORDER BY key`) and cairn (RocksDB iterator) were already sorted. memkv and diskfs store entries in hash-keyed rb-trees, so they now collect in-range matches across shards, copy key/value out from under the shard lock, `qsort` lexicographically (shorter prefix sorts first — matches sqlite's blob collation), then invoke the callback with no lock held (safe for re-entrant callbacks). diskfs returns `EIO` via its txn-fail path on the rare alloc failure.
- **Fallback path** (`_at` to the default KV): propagates the caller's flags for a bounded end, and forces the synthesized `ns+1` namespace-boundary upper bound to exclusive so a key equal to that single boundary byte cannot leak across namespaces.
- All call sites updated (`smb_durable.c`, both VFS delegation unit tests).

## Notes

- `vfs_kv_test` now asserts sorted output and inclusive-vs-exclusive end semantics; passes on memkv + sqlite, including under ASan (no leaks/UAF in the new collect+sort path).
- cairn/diskfs search paths get integration coverage through the SMB durable-recovery suites (flags=0, unbounded); their exclusive-flag branch mirrors the directly-tested memkv/sqlite logic. The kv unit-test harness only wires the built-in modules (memkv, sqlite), so cairn (dlopen plugin) and diskfs (needs a block device) aren't directly unit-tested for the exclusive branch.