### PR TITLE
posix/tests: relicense pjd_common.h under BSD-2-Clause

### DIFF
--- a/src/posix/tests/pjd_common.h
+++ b/src/posix/tests/pjd_common.h
@@ -1,6 +1,12 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
 // SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
-// SPDX-License-Identifier: LGPL-2.1-only
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  This harness is a
+// C analog of pjdfstest's tests/misc.sh, run against the Chimera POSIX client,
+// and is distributed under pjdfstest's original 2-clause BSD license.
 
 /*
  * pjd_common.h - C harness for the pjdfstest POSIX conformance suite ported to


### PR DESCRIPTION
The pjdfstest ports were relicensed to BSD-2-Clause in #776, but `pjd_common.h` was missed — it sits one level up from the `pjd/` directory, so the directory-scoped `git add` didn't catch it, and it stayed `LGPL-2.1-only`. (`reuse lint` passed because LGPL is also a valid identifier, so it wasn't caught.)

Like the ports it registers, `pjd_common.h` is a derivative work of pjdfstest (a C analog of `tests/misc.sh`). This relicenses it to **BSD-2-Clause** to match, retaining the upstream `(c) 2006-2012 Pawel Jakub Dawidek` copyright alongside the Chimera-NAS copyright and citing the derivation in the header.

`reuse lint` clean.