### PR TITLE
smb2: stream name validation and case-insensitive stream lookup

### DIFF
--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -3228,12 +3228,35 @@ chimera_smb_create(struct chimera_smb_request *request)
             return;
         }
 
+        /* A wildcard/invalid character in the BASE file name of a stream path
+         * is rejected with OBJECT_NAME_INVALID (smb2.streams.names "stream*").
+         * Wildcards are permitted in the stream name itself ("?Stream*"), so
+         * this only screens the base component, not the stream suffix. */
+        for (uint16_t bi = 0; bi < base_len; bi++) {
+            char bc = request->create.name[bi];
+            if (bc == '*' || bc == '?' || bc == '<' || bc == '>' ||
+                bc == '|' || bc == '"') {
+                chimera_smb_complete_request(request,
+                                             SMB2_STATUS_OBJECT_NAME_INVALID);
+                return;
+            }
+        }
+
         /* Trim the final component to the base file; the stream (if any) is
          * opened after the base file via chimera_vfs_open_stream. */
         request->create.name_len       = base_len;
         request->create.name[base_len] = '\0';
 
         if (has_stream) {
+            /* A named stream is never a directory; a CREATE that names a stream
+             * and also requests FILE_DIRECTORY_FILE is invalid
+             * (smb2.streams.dir expects NOT_A_DIRECTORY). */
+            if (request->create.create_options & SMB2_FILE_DIRECTORY_FILE) {
+                chimera_smb_complete_request(request,
+                                             SMB2_STATUS_NOT_A_DIRECTORY);
+                return;
+            }
+
             request->create.has_stream      = 1;
             request->create.stream_name_len = sname_len;
             memcpy(request->create.stream_name, sname, sname_len);
@@ -4183,7 +4206,24 @@ chimera_smb_parse_create(
         return -1;
     }
 
-    slash = rindex(request->create.parent_path, '\\');
+    /* Split the final path component off at the last backslash.  A named-stream
+     * suffix (everything from the first ':' onward) is part of the final
+     * component and may itself contain backslashes (e.g. an invalid stream name
+     * "Stream\"); those must not be treated as path separators, or the parent
+     * lookup would fail with OBJECT_PATH_NOT_FOUND instead of the stream-name
+     * validation returning OBJECT_NAME_INVALID (smb2.streams.names2).  So limit
+     * the backslash search to the base portion before the first ':'. */
+    {
+        char *colon = memchr(request->create.parent_path, ':',
+                             request->create.parent_path_len);
+        if (colon) {
+            *colon = '\0';
+            slash  = rindex(request->create.parent_path, '\\');
+            *colon = ':';
+        } else {
+            slash = rindex(request->create.parent_path, '\\');
+        }
+    }
 
     if (slash) {
         *slash                          = '\0';

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -1646,6 +1646,8 @@ set(SMBTORTURE_ENABLED_memfs
     # smb2.streams
     smb2.streams.basefile-rename-with-open-stream
     smb2.streams.create-disposition
+    smb2.streams.names
+    smb2.streams.names2
     smb2.streams.rename
     smb2.streams.sharemodes
     smb2.streams.zero-byte

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -7,6 +7,7 @@
 #include <stdlib.h>
 #include <pthread.h>
 #include <string.h>
+#include <strings.h>
 #include <time.h>
 #include <unistd.h>
 #include <sys/stat.h>
@@ -296,9 +297,12 @@ memfs_stream_find_by_name(
 {
     struct memfs_named_stream *stream;
 
+    /* Named-stream lookup is case-insensitive, matching Windows semantics even
+     * on a volume that reports FILE_CASE_SENSITIVE_SEARCH (smb2.streams.names3
+     * opens "StreamName" via "streamname"/"STREAMNAME"). */
     for (stream = inode->streams; stream; stream = stream->next) {
         if (stream->name_len == name_len &&
-            memcmp(stream->name, name, name_len) == 0) {
+            strncasecmp(stream->name, name, name_len) == 0) {
             return stream;
         }
     }


### PR DESCRIPTION
Improves SMB2 named-streams (ADS) conformance on memfs, fixing three `smb2.streams` smbtorture subtests centered on stream-name validation and lookup.

## Fixed (verified 3/3 green on memfs under Debug/ASan)

- **`smb2.streams.names`** — A wildcard/invalid char (`* ? < > | "`) in the **base** file name of a stream path is now rejected with `OBJECT_NAME_INVALID` (`dir\stream*:?Stream*:$DATA`). Wildcards remain legal in the **stream** name itself (`?Stream*` opens fine), so only the base component is screened.
- **`smb2.streams.names2`** — The CREATE handler split the wire name on the *last* backslash, so a backslash inside the stream suffix (an invalid stream name like `Stream\`) was mistaken for a path separator and the parent lookup failed with `OBJECT_PATH_NOT_FOUND` instead of the stream-name validation returning `OBJECT_NAME_INVALID`. The backslash search is now limited to the base component before the first `:`.
- Partial enabler for **`smb2.streams.dir`** — A CREATE that names a stream and also requests `FILE_DIRECTORY_FILE` is now rejected with `NOT_A_DIRECTORY` (a named stream is never a directory). This clears the first check of `dir` but the test as a whole stays deferred (see below).
- memfs named-stream lookup is now case-insensitive (`strncasecmp`), matching Windows stream-name semantics — a partial enabler for `names3`.

Both `smb2.streams.names` and `smb2.streams.names2` are added to `SMBTORTURE_ENABLED_memfs`.

## Deliberately deferred (each needs a structural change, not a focused stream fix)

- **`names3`** — needs case-insensitive **base-path** resolution in memfs (the test uppercases the whole path `TESTSTREAMS\STREAM_NAMES3.TXT`, which is a filesystem-wide casefold concern, not stream-specific). The stream-lookup half is fixed here.
- **`dir`** — needs `::$DATA`-on-directory (directory data-fork) semantics returning `NOT_A_DIRECTORY` / `FILE_IS_A_DIRECTORY` ahead of share-mode checks. The stream+DIRECTORY check is fixed; the remaining cases are not.
- **`delete`, `rename2`, `sharemodes`** — need cross-handle share-mode reservations spanning a stream open and its base file (a stream opened without `FILE_SHARE_DELETE` must block unlink/delete-access of the base file). Share reservations are per-file-handle via the VFS lease layer; making a stream handle reserve against the base file's identity is a structural change.
- **`attributes1`** — stream attribute/permission (`ACCESS_DENIED`) enforcement.
- **`attributes2`** — base-file DOS attribute + btime metadata persistence across write/reopen.
- **`io`** — stream enumeration/IO (`check_stream("Second Stream:*")`).

## Tests

Enabled `smb2.streams.names`, `smb2.streams.names2` (memfs). Regression: all currently-enabled `smb2.create`, `smb2.create_no_streams`, `smb2.delete-on-close-perms`, and `smb2.streams` memfs subtests pass with zero new failures.
