### PR TITLE
smb2: validate CREATE input and report directory size as zero

### DIFF
--- a/src/server/smb/smb2.h
+++ b/src/server/smb/smb2.h
@@ -953,6 +953,21 @@ typedef uint8_t smb2_guid[SMB2_GUID_SIZE];
 #define SMB2_FILE_OPEN_NO_RECALL                    0x00400000
 #define SMB2_FILE_OPEN_FOR_FREE_SPACE_QUERY         0x00800000
 
+/* CreateOptions validation (MS-SMB2 2.2.13 / MS-FSA, matched against Windows;
+ * see smb2.create.gentest).  Bits 24-31 are undefined and rejected with
+ * STATUS_INVALID_PARAMETER; FILE_CREATE_TREE_CONNECTION (0x80, never sent by a
+ * client), FILE_OPEN_BY_FILE_ID and FILE_RESERVE_OPFILTER are defined but
+ * unsupported and rejected with STATUS_NOT_SUPPORTED. */
+#define SMB2_CREATE_OPTIONS_INVALID_MASK            0xff000000
+#define SMB2_CREATE_OPTIONS_UNSUPPORTED_MASK \
+        (0x00000080 | SMB2_FILE_OPEN_BY_FILE_ID | SMB2_FILE_RESERVE_OPFILTER)
+
+/* File attribute validation for CREATE (MS-FSCC 2.6; smb2.create.gentest).  The
+ * settable/valid attribute bits a CREATE may carry; any bit outside this set
+ * (e.g. FILE_ATTRIBUTE_VOLUME 0x08, FILE_ATTRIBUTE_DEVICE 0x40) is rejected with
+ * STATUS_INVALID_PARAMETER. */
+#define SMB2_CREATE_FILE_ATTR_VALID_MASK            0x00007fb7
+
 /* Create Action */
 #define SMB2_CREATE_ACTION_SUPERSEDED               0x00000000
 #define SMB2_CREATE_ACTION_OPENED                   0x00000001

--- a/src/server/smb/smb_attr.h
+++ b/src/server/smb/smb_attr.h
@@ -183,11 +183,20 @@ chimera_smb_marshal_standard_attrs(
     const struct chimera_vfs_attrs *attr,
     struct chimera_smb_attrs       *smb_attr)
 {
-    /* File size */
-    smb_attr->smb_alloc_size = attr->va_space_used;
+    /* File size.  A directory carries no data stream, so Windows reports both
+     * EndOfFile and AllocationSize as 0 for it -- in the CREATE response, the
+     * FileAllInformation/FileStandardInformation query, and directory listings
+     * alike (smb2.create.open expects out.size == 0 for a freshly-created dir).
+     * Backends store a non-zero internal directory size (e.g. memfs 4096), so
+     * normalize it here at the SMB boundary. */
+    if ((attr->va_mode & S_IFMT) == S_IFDIR) {
+        smb_attr->smb_alloc_size = 0;
+        smb_attr->smb_size       = 0;
+    } else {
+        smb_attr->smb_alloc_size = attr->va_space_used;
+        smb_attr->smb_size       = attr->va_size;
+    }
     smb_attr->smb_attr_mask |= SMB_ATTR_ALLOC_SIZE;
-
-    smb_attr->smb_size       = attr->va_size;
     smb_attr->smb_attr_mask |= SMB_ATTR_SIZE;
 
     /* Number of links */
@@ -221,8 +230,9 @@ chimera_smb_marshal_compression_attrs(
     const struct chimera_vfs_attrs *attr,
     struct chimera_smb_attrs       *smb_attr)
 {
-    /* File size for the compression info */
-    smb_attr->smb_size       = attr->va_size;
+    /* File size for the compression info (0 for a directory, as above). */
+    smb_attr->smb_size = ((attr->va_mode & S_IFMT) == S_IFDIR) ?
+        0 : attr->va_size;
     smb_attr->smb_attr_mask |= SMB_ATTR_SIZE;
 
     /* Compression (not tracked in VFS) */

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -3345,6 +3345,38 @@ chimera_smb_create(struct chimera_smb_request *request)
             return;
         }
 
+        /* MS-SMB2 2.2.13 / MS-FSA CreateOptions validation (smb2.create.gentest).
+        * An undefined high CreateOptions bit is STATUS_INVALID_PARAMETER; a
+        * defined-but-unsupported one (TREE_CONNECTION / OPEN_BY_FILE_ID /
+        * RESERVE_OPFILTER) is STATUS_NOT_SUPPORTED.  INVALID takes precedence. */
+        if (request->create.create_options & SMB2_CREATE_OPTIONS_INVALID_MASK) {
+            chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
+            return;
+        }
+        if (request->create.create_options & SMB2_CREATE_OPTIONS_UNSUPPORTED_MASK) {
+            chimera_smb_complete_request(request, SMB2_STATUS_NOT_SUPPORTED);
+            return;
+        }
+
+        /* MS-FSCC 2.6 FileAttributes validation (smb2.create.gentest).  Any bit
+        * outside the settable/valid set -- e.g. FILE_ATTRIBUTE_VOLUME (0x08) or
+        * FILE_ATTRIBUTE_DEVICE (0x40) -- is rejected with INVALID_PARAMETER. */
+        if (request->create.file_attributes & ~SMB2_CREATE_FILE_ATTR_VALID_MASK) {
+            chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
+            return;
+        }
+
+        /* MS-SMB2 2.2.13: ImpersonationLevel must be one of the four defined
+         * SECURITY_IMPERSONATION_LEVEL values (0..3); anything else is
+         * STATUS_BAD_IMPERSONATION_LEVEL (smb2.create.impersonation).  A durable
+         * reconnect carries a don't-care sentinel and was already dispatched
+         * above, so this only applies to a fresh open. */
+        if (request->create.impersonation_level > SMB2_IMPERSONATION_DELEGATE) {
+            chimera_smb_complete_request(request,
+                                         SMB2_STATUS_BAD_IMPERSONATION_LEVEL);
+            return;
+        }
+
         /* MS-SMB2 3.3.5.9: if FILE_DELETE_ON_CLOSE is set in CreateOptions,
          * the create must also request DELETE access (DELETE, GENERIC_ALL, or
          * MAXIMUM_ALLOWED, which resolves to a superset). Otherwise fail with
@@ -4149,9 +4181,10 @@ chimera_smb_parse_create(
         return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
     }
 
-    /* ImpersonationLevel is advisory and Windows servers do not validate it
-     * (a durable reconnect, for one, fills it with a don't-care sentinel) — so
-     * accept any value rather than returning STATUS_BAD_IMPERSONATION_LEVEL. */
+    /* ImpersonationLevel is range-validated (0..3 -> else
+     * STATUS_BAD_IMPERSONATION_LEVEL) in the dispatcher chimera_smb_create, after
+     * the durable-reconnect short-circuit (a reconnect carries a don't-care
+     * sentinel and must not be validated). */
 
     if (request->create.name_len >= SMB_FILENAME_MAX) {
         chimera_smb_error("Create request: UTF-16 name too long (%u bytes)",

--- a/src/server/smb/smb_proc_set_info.c
+++ b/src/server/smb/smb_proc_set_info.c
@@ -235,6 +235,20 @@ chimera_smb_set_info(struct chimera_smb_request *request)
             switch (request->set_info.info_class) {
                 case SMB2_FILE_BASIC_INFO:
 
+                    /* FILE_ATTRIBUTE_TEMPORARY is meaningful only for a data
+                     * stream; a directory has none, so setting it on a directory
+                     * is STATUS_INVALID_PARAMETER (MS-FSCC 2.6 / smb2.create
+                     * dosattr_tmp_dir). */
+                    if ((request->set_info.open_file->flags &
+                         CHIMERA_SMB_OPEN_FILE_FLAG_DIRECTORY) &&
+                        (request->set_info.attrs.smb_attributes &
+                         SMB2_FILE_ATTRIBUTE_TEMPORARY)) {
+                        chimera_smb_open_file_release(request, request->set_info.open_file);
+                        chimera_smb_complete_request(request,
+                                                     SMB2_STATUS_INVALID_PARAMETER);
+                        break;
+                    }
+
                     chimera_smb_unmarshal_basic_info(&request->set_info.attrs, &request->set_info.vfs_attrs);
 
                     /* An explicit (non-sentinel) write-time set hands control of

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -1282,9 +1282,12 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.create.brlocked
     smb2.create.delete
     smb2.create.dir-alloc-size
+    smb2.create.dosattr_tmp_dir
+    smb2.create.impersonation
     smb2.create.leading-slash
     smb2.create.mkdir-dup
     smb2.create.multi
+    smb2.create.open
     smb2.create.path-length
     # smb2.create_no_streams
     smb2.create_no_streams.no_stream
@@ -1722,6 +1725,8 @@ set(SMBTORTURE_ENABLED_linux
     smb2.create.brlocked
     smb2.create.delete
     smb2.create.dir-alloc-size
+    smb2.create.dosattr_tmp_dir
+    smb2.create.impersonation
     smb2.create.leading-slash
     smb2.create.mkdir-dup
     smb2.create.multi
@@ -2040,6 +2045,8 @@ set(SMBTORTURE_ENABLED_io_uring
     smb2.create.brlocked
     smb2.create.delete
     smb2.create.dir-alloc-size
+    smb2.create.dosattr_tmp_dir
+    smb2.create.impersonation
     smb2.create.leading-slash
     smb2.create.mkdir-dup
     smb2.create.multi
@@ -2368,9 +2375,12 @@ set(SMBTORTURE_ENABLED_cairn
     smb2.create.brlocked
     smb2.create.delete
     smb2.create.dir-alloc-size
+    smb2.create.dosattr_tmp_dir
+    smb2.create.impersonation
     smb2.create.leading-slash
     smb2.create.mkdir-dup
     smb2.create.multi
+    smb2.create.open
     smb2.create.path-length
     # smb2.create_no_streams
     smb2.create_no_streams.no_stream
@@ -2747,9 +2757,12 @@ set(SMBTORTURE_ENABLED_diskfs_io_uring
     smb2.create.brlocked
     smb2.create.delete
     smb2.create.dir-alloc-size
+    smb2.create.dosattr_tmp_dir
+    smb2.create.impersonation
     smb2.create.leading-slash
     smb2.create.mkdir-dup
     smb2.create.multi
+    smb2.create.open
     smb2.create.path-length
     # smb2.create_no_streams
     smb2.create_no_streams.no_stream
@@ -3130,9 +3143,12 @@ set(SMBTORTURE_ENABLED_diskfs_aio
     smb2.create.brlocked
     smb2.create.delete
     smb2.create.dir-alloc-size
+    smb2.create.dosattr_tmp_dir
+    smb2.create.impersonation
     smb2.create.leading-slash
     smb2.create.mkdir-dup
     smb2.create.multi
+    smb2.create.open
     smb2.create.path-length
     # smb2.create_no_streams
     smb2.create_no_streams.no_stream


### PR DESCRIPTION
## Summary

Improves SMB2 CREATE conformance by tightening field validation and fixing
directory size reporting to match Windows, greening three `smb2.create`
smbtorture subtests (previously failing on all backends).

## Fixed

- **smb2.create.impersonation** — `ImpersonationLevel` is now range-validated:
  any value outside the four defined `SECURITY_IMPERSONATION_LEVEL` values
  (0..3) is rejected with `STATUS_BAD_IMPERSONATION_LEVEL`. Validated in the
  dispatcher after the durable-reconnect short-circuit (a reconnect carries a
  don't-care sentinel that must not be validated).
- **smb2.create.dosattr_tmp_dir** — setting `FILE_ATTRIBUTE_TEMPORARY` via
  SetInfo `FileBasicInformation` on a directory (which has no data stream) now
  returns `STATUS_INVALID_PARAMETER`.
- **smb2.create.open** — a directory carries no data stream, so EndOfFile and
  AllocationSize are now reported as 0 at the SMB attribute boundary (CREATE
  response, FileAll/FileStandard queries, listings) instead of leaking a
  backend's internal directory size (e.g. memfs 4096).

In addition, CREATE now performs the MS-SMB2 / MS-FSCC field validation that
`smb2.create.gentest` exercises (undefined high `CreateOptions` ->
`INVALID_PARAMETER`; `TREE_CONNECTION`/`OPEN_BY_FILE_ID`/`RESERVE_OPFILTER` ->
`NOT_SUPPORTED`; invalid `FileAttributes` such as `VOLUME`/`DEVICE` ->
`INVALID_PARAMETER`). These are correct on their own but do not green
`gentest`, which is deferred (see below).

## Tests enabled (allowlist)

- `smb2.create.impersonation`, `smb2.create.dosattr_tmp_dir` — added to all six
  backend blocks (memfs, linux, io_uring, cairn, diskfs_io_uring, diskfs_aio).
- `smb2.create.open` — added to memfs, cairn, diskfs_io_uring, diskfs_aio. Not
  added to linux/io_uring: it remains blocked there by a pre-existing
  `smb2_create_complex_file` -> `STATUS_INTERNAL_ERROR` limitation in the
  passthrough backends (identical failure on upstream/main, unrelated to this
  change).

Each enabled subtest verified green 3x on memfs and across the relevant
backends; full `smb2.create` aggregate ctest green on all six backends; smb2.acls
and smb2.scan (getinfo/setinfo) smoke green on memfs (no DACL/attr ripple).

## Deferred (with reasons)

- **smb2.create.gentest** — beyond the field validation here, full pass requires
  comprehensive ACL-based desired-access enforcement (the per-bit
  `access_mask` denial loop) ordered *before* the attribute validation, which is
  significant access-enforcement work in the unified-ACL domain.
- **smb2.create.mkdir-visible** — requires honoring an inheritable
  ACCESS_DENIED ACE for `SEC_DIR_ADD_FILE` on the parent directory at create
  time (parent-dir add-file/add-subdirectory access enforcement + inheritance);
  an ACL-enforcement feature out of scope for these focused validation fixes.
- **smb2.create.nulldacl** — requires the SD/ACL storage model to distinguish a
  present-but-NULL DACL (allow-all) from no-DACL and round-trip it through
  SetInfo/GetInfo; a deeper change to the ACL/VFS model.
- **smb2.create.blob** — the ALSI create context requested allocation size is
  parsed but not honored; reporting it correctly needs backends to model a
  reserved-but-unwritten allocation hint distinct from EOF/space_used, which
  none currently do.
- **smb2.create.quota-fake-file** — the `$Extend\$Quota` fake-file path is an
  NTFS-special construct out of scope for this stack.
