### PR TITLE
smb2: fix related-compound error propagation, handle inheritance, and notify interims

### DIFF
--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -887,6 +887,29 @@ chimera_smb_compound_advance(struct chimera_smb_compound *compound)
             chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
             return;
         }
+
+        /* MS-SMB2 3.3.5.2.7.2: a related request inherits the FileId of the
+         * preceding request (FileId 0xFFFF.../0xFFFF...).  When that preceding
+         * request was a CREATE that failed, no Open was established, so the
+         * inherited handle is unavailable.  In that case the server fails the
+         * related request with the *preceding request's* error status rather
+         * than the generic STATUS_FILE_CLOSED an unresolved handle would yield
+         * (Windows/Samba: related4/related7 inherit ACCESS_DENIED, related8
+         * inherits OBJECT_NAME_NOT_FOUND).  Detect "no Open established" via the
+         * saved FileId still being UINT64_MAX: a successful CREATE anywhere in
+         * the chain populates it, so a later failing op (e.g. a read-only
+         * handle's WRITE in related6) leaves the handle resolvable and does NOT
+         * poison the rest of the chain. */
+        if (unlikely(compound->complete_requests > 0 &&
+                     compound->saved_file_id.pid == UINT64_MAX)) {
+            struct chimera_smb_request *prev =
+                compound->requests[compound->complete_requests - 1];
+
+            if (chimera_smb_is_error_status(prev->status)) {
+                chimera_smb_complete_request(request, prev->status);
+                return;
+            }
+        }
     } else {
         /* An unrelated request breaks the related chain: clear the saved
          * context so a following related request cannot inherit stale session,

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -2067,20 +2067,18 @@ chimera_smb_open_file_resolve(
      * related compound (MS-SMB2 3.3.5.2.7.2).  For an unrelated request it is
      * just an invalid handle and must resolve to FILE_CLOSED, not the prior
      * request's file. */
-    if (unlikely(file_id->pid == UINT64_MAX)) {
+    if (unlikely(file_id->pid == UINT64_MAX || file_id->vid == UINT64_MAX)) {
         if (!(request->smb2_hdr.flags & SMB2_FLAGS_RELATED_OPERATIONS) ||
-            request->compound->saved_file_id.pid == UINT64_MAX) {
-            return NULL;
-        }
-        file_id->pid = request->compound->saved_file_id.pid;
-    }
-
-    if (unlikely(file_id->vid == UINT64_MAX)) {
-        if (!(request->smb2_hdr.flags & SMB2_FLAGS_RELATED_OPERATIONS) ||
+            request->compound->saved_file_id.pid == UINT64_MAX ||
             request->compound->saved_file_id.vid == UINT64_MAX) {
             return NULL;
         }
-        file_id->vid = request->compound->saved_file_id.vid;
+        /* A related request inherits the WHOLE saved FileId, not field-by-field:
+         * Windows/Samba ignore the per-field bytes once the request is related
+         * (some clients leave one half as a literal 0, e.g. the placeholder
+         * { UINT64_MAX, 0 } compound_async.getinfo_middle sends), so a literal
+         * value in the other half must not be HASH_FINDed as-is. */
+        *file_id = request->compound->saved_file_id;
     }
 
     open_file_bucket = file_id->vid & CHIMERA_SMB_OPEN_FILE_BUCKET_MASK;
@@ -2098,6 +2096,17 @@ chimera_smb_open_file_resolve(
     }
 
     pthread_mutex_unlock(&tree->open_files_lock[open_file_bucket]);
+
+    /* Record the FileId this op resolved so a subsequent compound-related
+     * request can inherit it (FileId 0xFFFF.../0xFFFF...).  Only CREATE used to
+     * seed saved_file_id, which left a related op chained behind a non-CREATE
+     * lead (e.g. FLUSH+related CLOSE, or GETINFO in the middle of a chain)
+     * unable to find the handle and failing FILE_CLOSED
+     * (compound_async.flush_close / flush_flush / getinfo_middle).  Any op that
+     * successfully resolved a concrete handle is a valid inheritance source. */
+    if (likely(open_file)) {
+        request->compound->saved_file_id = *file_id;
+    }
 
     return open_file;
 } /* chimera_smb_open_file_resolve */
@@ -2359,20 +2368,14 @@ chimera_smb_open_file_close(
     /* Only a related compound request inherits the previous request's FileId
      * from a UINT64_MAX placeholder; for an unrelated request it is an invalid
      * handle and must report FILE_CLOSED (MS-SMB2 3.3.5.2.7.2). */
-    if (unlikely(file_id->pid == UINT64_MAX)) {
+    if (unlikely(file_id->pid == UINT64_MAX || file_id->vid == UINT64_MAX)) {
         if (!(request->smb2_hdr.flags & SMB2_FLAGS_RELATED_OPERATIONS) ||
-            request->compound->saved_file_id.pid == UINT64_MAX) {
-            return NULL;
-        }
-        file_id->pid = request->compound->saved_file_id.pid;
-    }
-
-    if (unlikely(file_id->vid == UINT64_MAX)) {
-        if (!(request->smb2_hdr.flags & SMB2_FLAGS_RELATED_OPERATIONS) ||
+            request->compound->saved_file_id.pid == UINT64_MAX ||
             request->compound->saved_file_id.vid == UINT64_MAX) {
             return NULL;
         }
-        file_id->vid = request->compound->saved_file_id.vid;
+        /* Inherit the whole saved FileId (see chimera_smb_open_file_resolve). */
+        *file_id = request->compound->saved_file_id;
     }
 
     open_file_bucket = file_id->vid & CHIMERA_SMB_OPEN_FILE_BUCKET_MASK;

--- a/src/server/smb/smb_proc_change_notify.c
+++ b/src/server/smb/smb_proc_change_notify.c
@@ -234,23 +234,29 @@ chimera_smb_change_notify(struct chimera_smb_request *request)
 
     /* No events — about to park the request.
      *
-     * Reject parking when this CHANGE_NOTIFY is inside a multi-command
-     * compound.  Async completion would force the compound reply
-     * builder to skip this slot (status STATUS_PENDING is dropped from
-     * the compound), and clients that match compound slots positionally
-     * may misparse the remaining replies.  Windows itself appears to
-     * cope (it matches by message_id), but the safe + portable answer
-     * is "don't allow it" — Windows never compounds CHANGE_NOTIFY with
-     * anything else in practice anyway.  The client can retry the
-     * CHANGE_NOTIFY as a standalone request.
+     * A CHANGE_NOTIFY that would go asynchronous inside a multi-command
+     * compound is governed by MS-SMB2 <159>/<162> (the Win7 compound
+     * behaviour the smb2.compound.interim* tests pin):
      *
-     * Synchronous completion (events were already pending) is fine —
-     * that slot's reply lands in the compound normally and we never
-     * reach this check. */
-    if (request->compound->num_requests > 1) {
+     *   - If it is NOT the last request in the compound, the server fails
+     *     it with STATUS_INTERNAL_ERROR (the other, synchronous, requests
+     *     in the compound still succeed) -- interim2.
+     *
+     *   - If it IS the last request, the server is allowed to split it off
+     *     and let it go async: the interim STATUS_PENDING is sent as a
+     *     standalone async message (just as for a non-compounded notify)
+     *     and this slot is dropped from the compound reply.  The parked
+     *     request can then be cancelled (interim1) or completed later
+     *     (interim3).
+     *
+     * Synchronous completion (events were already pending) is fine for any
+     * position -- that slot's reply lands in the compound normally and we
+     * never reach this check. */
+    if (request->compound->num_requests > 1 &&
+        request != request->compound->requests[request->compound->num_requests - 1]) {
         pthread_mutex_unlock(&state->lock);
         chimera_smb_open_file_release(request, open_file);
-        chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
+        chimera_smb_complete_request(request, SMB2_STATUS_INTERNAL_ERROR);
         return;
     }
 

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -1254,6 +1254,9 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.check-sharemode
     # smb2.compound
     smb2.compound.create-write-close
+    smb2.compound.interim1
+    smb2.compound.interim2
+    smb2.compound.interim3
     smb2.compound.invalid1
     smb2.compound.invalid2
     smb2.compound.invalid3
@@ -1261,12 +1264,18 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.compound.related1
     smb2.compound.related2
     smb2.compound.related3
+    smb2.compound.related4
     smb2.compound.related5
     smb2.compound.related6
+    smb2.compound.related7
+    smb2.compound.related8
     smb2.compound.related9
     smb2.compound.unrelated1
     # smb2.compound_async
     smb2.compound_async.create_lease_break_async
+    smb2.compound_async.flush_close
+    smb2.compound_async.flush_flush
+    smb2.compound_async.getinfo_middle
     smb2.compound_async.rename_last
     smb2.compound_async.rename_middle
     # smb2.compound_find
@@ -2784,6 +2793,9 @@ set(SMBTORTURE_ENABLED_diskfs_io_uring
     smb2.check-sharemode
     # smb2.compound
     smb2.compound.create-write-close
+    smb2.compound.interim1
+    smb2.compound.interim2
+    smb2.compound.interim3
     smb2.compound.invalid1
     smb2.compound.invalid2
     smb2.compound.invalid3
@@ -2791,12 +2803,18 @@ set(SMBTORTURE_ENABLED_diskfs_io_uring
     smb2.compound.related1
     smb2.compound.related2
     smb2.compound.related3
+    smb2.compound.related4
     smb2.compound.related5
     smb2.compound.related6
+    smb2.compound.related7
+    smb2.compound.related8
     smb2.compound.related9
     smb2.compound.unrelated1
     # smb2.compound_async
     smb2.compound_async.create_lease_break_async
+    smb2.compound_async.flush_close
+    smb2.compound_async.flush_flush
+    smb2.compound_async.getinfo_middle
     smb2.compound_async.rename_last
     smb2.compound_async.rename_middle
     # smb2.compound_find


### PR DESCRIPTION
smb2: fix related-compound error propagation, handle inheritance, and notify interims

Three independent SMB2 compound conformance fixes (smb2.compound +
smb2.compound_async, failing on all backends), verified on memfs and
diskfs_io_uring.

1. Related-compound error propagation (related4/related7/related8).
   When the lead CREATE of a related compound fails, no Open is
   established, so subsequent related ops (which inherit FileId
   0xFFFF.../0xFFFF...) cannot resolve a handle.  We returned the generic
   STATUS_FILE_CLOSED; MS-SMB2 3.3.5.2.7.2 (and Windows/Samba) instead
   fail them with the *preceding* op's error status (ACCESS_DENIED for
   related4/7, OBJECT_NAME_NOT_FOUND for related8).  chimera_smb_compound_
   advance now short-circuits a related request with the previous status
   when no Open was established (saved FileId still UINT64_MAX) -- a later
   failing op behind a successful CREATE (related6's read-only WRITE) keeps
   the handle resolvable and does NOT poison the chain.

2. Handle inheritance from non-CREATE leads + whole-FileId inheritance
   (compound_async.flush_close / flush_flush / getinfo_middle).
   saved_file_id was only seeded by CREATE, so a related op chained behind
   a FLUSH (FLUSH+related CLOSE) or a GETINFO in the middle of a chain
   could not find the handle and failed FILE_CLOSED.  chimera_smb_open_
   file_resolve now records any successfully resolved concrete FileId as an
   inheritance source.  Related requests also inherit the WHOLE saved
   FileId rather than field-by-field, matching Windows/Samba which ignore
   the per-field bytes once a request is related (getinfo_middle sends the
   placeholder { UINT64_MAX, 0 }).

3. CHANGE_NOTIFY interim (STATUS_PENDING) inside a compound
   (interim1/interim2/interim3).  A parking CHANGE_NOTIFY in a multi-op
   compound was rejected outright with INVALID_PARAMETER.  Per MS-SMB2
   <159>/<162> (the Win7 behaviour the interim* tests pin): a notify that
   is NOT the last request fails with INTERNAL_ERROR (the other,
   synchronous, requests still succeed); a notify that IS the last request
   is split off and allowed to go async (interim sent standalone, slot
   dropped from the compound reply), so it can be cancelled or completed
   later.

Deferred:
- compound.compound-padding, compound.compound-break: both depend on
  named-stream (ADS) support, which is config/CAP-gated and disabled on
  the test backends -- the stream CREATE / FileStreamInformation GETINFO
  return OBJECT_NAME_INVALID / NOT_IMPLEMENTED before the compound paths
  under test are reached.  Not a compound bug.
- compound_async.read_read, compound_async.write_write: require the server
  to emit an interim STATUS_PENDING for the last READ/WRITE of a compound
  even when it can complete synchronously, purely so the client can mark it
  cancellable.  chimera deliberately drives interims off block decisions,
  never off latency/position (smb_async_interim.h); forcing one here adds a
  wasted round-trip to common compound patterns (e.g. CREATE+READ).
- compound_async.getinfo_middle on diskfs_io_uring, and
  compound_async.rename_*_non_compound_no_async: pre-existing diskfs/lease
  grant gaps (RWH/RH lease not granted to a second opener), unrelated to
  compound handling; getinfo_middle is enabled on memfs where it is green.

Tests enabled (3/3 on memfs; 3/3 on diskfs_io_uring except getinfo_middle):
  smb2.compound.related4/related7/related8/interim1/interim2/interim3
  smb2.compound_async.flush_close/flush_flush
  smb2.compound_async.getinfo_middle (memfs only)
