### PR TITLE
smb: drain VFS thread after protocol teardown to avoid post-free doorbell ring

### DIFF
--- a/src/server/server.c
+++ b/src/server/server.c
@@ -1630,6 +1630,18 @@ chimera_server_thread_shutdown(
 
     chimera_rest_thread_destroy(thread->rest_thread);
 
+    /* Protocol thread_destroy can issue fresh VFS operations (e.g. the SMB
+     * durable/persistent handle drain releases parked opens, NFS releases
+     * state).  For a CAP_BLOCKING backend like cairn those are posted to a
+     * shared delegation thread and completed asynchronously back to *this*
+     * vfs_thread's doorbell.  Drain again so every such late request lands
+     * before we free the vfs_thread below -- otherwise the delegation thread
+     * rings (and writes to) an already-closed doorbell and dereferences the
+     * freed thread, aborting the server.  The delegation pool is still alive
+     * here; it is not torn down until chimera_vfs_destroy, after every protocol
+     * thread has joined. */
+    chimera_vfs_thread_drain(thread->vfs_thread);
+
     evpl_remove_timer(evpl, &thread->watchdog);
     chimera_vfs_thread_destroy(thread->vfs_thread);
     free(thread);


### PR DESCRIPTION
## Summary

A full smbtorture matrix run found exactly one remaining server abort across all 3930 cells: the **cairn** backend `SIGABRT`s on `smb2.lease.timeout-disconnect` with

```
fatal "failed to write to doorbell fd 115: len=-1 errno=9 (Bad file descriptor)" at ext/libevpl/src/core/doorbell.c:86
```

This was a cross-thread doorbell write to a doorbell whose eventfd had already been closed during shutdown teardown. Under Debug/ASan the same race surfaces deterministically as a heap-use-after-free in `chimera_vfs_complete_delegate` (a delegation thread's `cairn_thread_commit` dereferencing a freed `chimera_vfs_thread`).

## Root cause

At server shutdown, `chimera_server_thread_shutdown` drained the per-thread `vfs_thread`, then destroyed the protocol threads, then freed the `vfs_thread`. But a protocol's `thread_destroy` *itself* issues fresh VFS operations — the SMB durable/persistent handle drain (`chimera_smb_durable_drain_all`) releases parked opens; NFS releases state — which the single up-front drain could not have waited for.

For a `CAP_BLOCKING` backend like cairn, those late operations are posted to a shared sync-delegation thread and completed asynchronously back to the originating `vfs_thread` via `chimera_vfs_complete_delegate`, which appends the request and rings that thread's doorbell. Because the `vfs_thread` was freed (and its doorbell eventfd closed) immediately after `thread_destroy`, the delegation thread's later `cairn_thread_commit` dereferenced the freed thread and wrote to the closed doorbell fd — the UAF (ASan) / `EBADF` doorbell abort (production).

memfs does not hit this because its ops run inline on the originating thread rather than on a delegation thread, so the teardown/doorbell interleaving differs — this is why it was cairn-specific.

## Fix

Drain the `vfs_thread` a second time, after protocol `thread_destroy` and before `chimera_vfs_thread_destroy`, so every late delegated request lands first. The delegation pool is still alive at this point; it is not torn down until `chimera_vfs_destroy`, after all protocol threads have joined. The fix is in chimera (the misuse), not in libevpl's doorbell API.

## Verification (Debug/ASan)

- `smb2.lease.timeout-disconnect` on cairn: 15/15 clean runs at `CHIMERA_SMB_TEST_DISCONNECT_DELAY_MS` = 0 / 50 / 100 (was an abort every run before). No ASan report, no doorbell abort, graceful shutdown.
- Full lease/durable/disconnect-race smbtorture suite across all backends (cairn, memfs, diskfs_aio, diskfs_io_uring/io_uring): **275/275 pass**, no aborts, no regressions vs upstream/main.
- Broader cairn durable/lease/replay/notify/oplock + disconnect-race smoke: **74/74 pass**.

## Allowlist

No allowlist change. `smb2.lease.timeout-disconnect` (and `smb2.lease.timeout`) still **fail functionally** after the fix — the server no longer aborts, but the lease-break-on-timeout behavior the test expects is a separate, unimplemented functional gap. The crash fix is the deliverable here; these tests remain disabled until that behavior lands. Every test that the crash fix unblocks was already enabled and continues to pass.
