### PR TITLE
nfs3: NFSACL sideband protocol (prog 100227) + POSIX.1e ACL translation [draft]

### DIFF
--- a/src/admin/tests/test_e2e_nfs_acl.py
+++ b/src/admin/tests/test_e2e_nfs_acl.py
@@ -1,0 +1,193 @@
+# SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""End-to-end NFSv3 POSIX ACL round-trip test (the NFSACL sideband protocol).
+
+Drives the full pipeline against a live daemon: mount a memfs backend, expose it
+as an NFS export, kernel-mount it over NFSv3, and verify that POSIX.1e ACLs set
+and read with setfacl/getfacl round-trip through the unofficial NFSACL sideband
+protocol (RPC program 100227).  The Linux kernel NFSv3 client auto-negotiates
+NFSACL when the server registers program 100227, which chimera advertises via
+portmap and multiplexes on the NFS port.
+
+memfs stores the canonical (NFSv4/NT) ACL natively, so a named-user entry must
+survive the canonical<->POSIX.1e translation in both directions.
+
+Management operations go through the Python SDK client; the data path uses the
+system mount/setfacl/getfacl binaries.
+"""
+
+import os
+import shutil
+import subprocess
+import tempfile
+
+import pytest
+from chimera_admin import ChimeraAdminError
+
+MOUNT = "aclmount"
+# Export name doubles as the NFS pseudo-path clients mount.
+EXPORT = "/acl1"
+EXPORT_VFS_PATH = "/aclmount"
+
+# Needs root to mount NFS, plus the NFS client and acl tooling.  Skip cleanly
+# elsewhere rather than fail.
+pytestmark = [
+    pytest.mark.skipif(
+        os.geteuid() != 0, reason="kernel NFS mount needs root"
+    ),
+    pytest.mark.skipif(
+        shutil.which("mount") is None, reason="mount(8) not installed"
+    ),
+    pytest.mark.skipif(
+        shutil.which("setfacl") is None or shutil.which("getfacl") is None,
+        reason="acl tools (setfacl/getfacl) not installed",
+    ),
+]
+
+
+def _run(cmd, timeout=30):
+    """Run a command, capturing output."""
+    return subprocess.run(
+        cmd, capture_output=True, text=True, timeout=timeout
+    )
+
+
+class TestNfsAclRoundTrip:
+    """Exercise mount -> export -> NFSv3 mount -> POSIX ACL round-trip."""
+
+    def test_named_user_acl_round_trip(self, client, chimera_server):
+        """A named-user ACL set over NFSv3 round-trips via the NFSACL sideband."""
+        host, _ = chimera_server
+
+        created = {"mount": False, "export": False}
+        mountpoint = tempfile.mkdtemp(prefix="chimera_nfs_acl_")
+        mounted = False
+        try:
+            # memfs mount in the VFS namespace, exposed as an NFS export.
+            client.create_mount(MOUNT, module="memfs", path="/")
+            created["mount"] = True
+            client.create_export(EXPORT, EXPORT_VFS_PATH)
+            created["export"] = True
+
+            # Kernel-mount over NFSv3 (NFSACL is negotiated automatically).
+            result = _run(
+                [
+                    "mount",
+                    "-t",
+                    "nfs",
+                    "-o",
+                    "vers=3,port=2049,mountport=20048,"
+                    "mountproto=tcp,proto=tcp,nolock",
+                    f"{host}:{EXPORT}",
+                    mountpoint,
+                ]
+            )
+            assert result.returncode == 0, (
+                f"NFSv3 mount failed (rc={result.returncode})\n"
+                f"stderr:\n{result.stderr}"
+            )
+            mounted = True
+
+            testfile = os.path.join(mountpoint, "file1")
+            result = _run(["touch", testfile])
+            assert result.returncode == 0, f"touch failed: {result.stderr}"
+
+            # Grant a named user r-x via the NFSACL SETACL path.
+            result = _run(["setfacl", "-m", "u:1005:r-x", testfile])
+            assert result.returncode == 0, f"setfacl failed: {result.stderr}"
+
+            # Read it back (numeric ids for a stable assertion) -- the named
+            # entry must survive the canonical<->POSIX translation.
+            result = _run(["getfacl", "-n", testfile])
+            assert result.returncode == 0, f"getfacl failed: {result.stderr}"
+            assert "user:1005:r-x" in result.stdout, result.stdout
+            # POSIX requires a mask once a named entry exists.
+            assert "mask::" in result.stdout, result.stdout
+
+            # Remove the named entry.
+            result = _run(["setfacl", "-x", "u:1005", testfile])
+            assert result.returncode == 0, f"setfacl -x failed: {result.stderr}"
+
+            result = _run(["getfacl", "-n", testfile])
+            assert result.returncode == 0, f"getfacl failed: {result.stderr}"
+            assert "user:1005:" not in result.stdout, result.stdout
+        finally:
+            # Best-effort cleanup so a mid-test failure does not leak the mount
+            # or the resources in the session daemon shared with other modules.
+            if mounted:
+                _run(["umount", mountpoint])
+            try:
+                os.rmdir(mountpoint)
+            except OSError:
+                pass
+            if created["export"]:
+                try:
+                    client.delete_export(EXPORT)
+                except ChimeraAdminError:
+                    pass
+            if created["mount"]:
+                try:
+                    client.delete_mount(MOUNT)
+                except ChimeraAdminError:
+                    pass
+
+    def test_default_acl_inheritance(self, client, chimera_server):
+        """A default ACL set on a directory is inherited by a new child."""
+        host, _ = chimera_server
+
+        created = {"mount": False, "export": False}
+        mountpoint = tempfile.mkdtemp(prefix="chimera_nfs_dacl_")
+        mounted = False
+        try:
+            client.create_mount(MOUNT, module="memfs", path="/")
+            created["mount"] = True
+            client.create_export(EXPORT, EXPORT_VFS_PATH)
+            created["export"] = True
+
+            result = _run(
+                [
+                    "mount",
+                    "-t",
+                    "nfs",
+                    "-o",
+                    "vers=3,port=2049,mountport=20048,"
+                    "mountproto=tcp,proto=tcp,nolock",
+                    f"{host}:{EXPORT}",
+                    mountpoint,
+                ]
+            )
+            assert result.returncode == 0, (
+                f"NFSv3 mount failed (rc={result.returncode})\n"
+                f"stderr:\n{result.stderr}"
+            )
+            mounted = True
+
+            testdir = os.path.join(mountpoint, "dir1")
+            os.mkdir(testdir)
+
+            # Set a default ACL granting a named user rwx on future children.
+            result = _run(["setfacl", "-d", "-m", "u:1006:rwx", testdir])
+            assert result.returncode == 0, f"setfacl -d failed: {result.stderr}"
+
+            result = _run(["getfacl", "-n", testdir])
+            assert result.returncode == 0, f"getfacl failed: {result.stderr}"
+            assert "default:user:1006:rwx" in result.stdout, result.stdout
+        finally:
+            if mounted:
+                _run(["umount", mountpoint])
+            try:
+                os.rmdir(mountpoint)
+            except OSError:
+                pass
+            if created["export"]:
+                try:
+                    client.delete_export(EXPORT)
+                except ChimeraAdminError:
+                    pass
+            if created["mount"]:
+                try:
+                    client.delete_mount(MOUNT)
+                except ChimeraAdminError:
+                    pass

--- a/src/nfs_common/CMakeLists.txt
+++ b/src/nfs_common/CMakeLists.txt
@@ -23,6 +23,10 @@ set(NLM4_XDR_X ${CMAKE_CURRENT_SOURCE_DIR}/nlm4.x)
 set(NLM4_XDR_C ${CMAKE_CURRENT_BINARY_DIR}/nlm4_xdr.c)
 set(NLM4_XDR_H ${CMAKE_CURRENT_BINARY_DIR}/nlm4_xdr.h)
 
+set(NFSACL_XDR_X ${CMAKE_CURRENT_SOURCE_DIR}/nfsacl.x)
+set(NFSACL_XDR_C ${CMAKE_CURRENT_BINARY_DIR}/nfsacl_xdr.c)
+set(NFSACL_XDR_H ${CMAKE_CURRENT_BINARY_DIR}/nfsacl_xdr.h)
+
 add_custom_command(
     OUTPUT ${NFS3_XDR_C} ${NFS3_XDR_H}
     COMMAND ${XDRZCC} -r ${NFS3_XDR_X} ${NFS3_XDR_C} ${NFS3_XDR_H}
@@ -58,13 +62,20 @@ add_custom_command(
     COMMENT "Compiling ${NLM4_XDR_X}"
 )
 
+add_custom_command(
+    OUTPUT ${NFSACL_XDR_C} ${NFSACL_XDR_H}
+    COMMAND ${XDRZCC} -r ${NFSACL_XDR_X} ${NFSACL_XDR_C} ${NFSACL_XDR_H}
+    DEPENDS ${NFSACL_XDR_X} ${XDRZCC}
+    COMMENT "Compiling ${NFSACL_XDR_X}"
+)
+
 set(NFS_COMMON_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR} PARENT_SCOPE)
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 # Suppress warnings for the generated source files
 set_source_files_properties(
-    ${NFS3_XDR_C} ${NFS4_XDR_C} ${NFS_MOUNT_XDR_C} ${PORTMAP_XDR_C} ${NLM4_XDR_C} PROPERTIES COMPILE_OPTIONS "-Wno-unused;-Wno-switch;-Wno-format-truncation"
+    ${NFS3_XDR_C} ${NFS4_XDR_C} ${NFS_MOUNT_XDR_C} ${PORTMAP_XDR_C} ${NLM4_XDR_C} ${NFSACL_XDR_C} PROPERTIES COMPILE_OPTIONS "-Wno-unused;-Wno-switch;-Wno-format-truncation"
 )
 
 add_definitions(-fvisibility=default)
@@ -76,7 +87,8 @@ add_library(chimera_nfs_common  SHARED
             ${NFS4_XDR_C} ${NFS4_XDR_H}
             ${NFS_MOUNT_XDR_C} ${NFS_MOUNT_XDR_H}
             ${PORTMAP_XDR_C} ${PORTMAP_XDR_H}
-            ${NLM4_XDR_C} ${NLM4_XDR_H})
+            ${NLM4_XDR_C} ${NLM4_XDR_H}
+            ${NFSACL_XDR_C} ${NFSACL_XDR_H})
 
 target_link_libraries(chimera_nfs_common chimera_common evpl evpl_rpc2)
 

--- a/src/nfs_common/nfsacl.x
+++ b/src/nfs_common/nfsacl.x
@@ -1,0 +1,151 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * NFSACL: the unofficial NFSv3 ACL sideband protocol (RPC program 100227,
+ * version 3) originated by Sun for Solaris and implemented by the Linux kernel
+ * for interop.  It carries POSIX.1e draft ACLs (access + default) so that
+ * getfacl/setfacl/ls work over NFSv3.  Never standardised in an RFC.
+ *
+ * xdrzcc compiles each .x independently and emits a self-contained header, so
+ * the few NFSv3 types this program reuses (file handle, post-op attrs, status)
+ * are redeclared here with an "nacl_" prefix to avoid colliding with the
+ * identically-named declarations in nfs3_xdr.h -- both headers are co-included
+ * by the server's nfs_common.h.  Layouts are byte-identical to nfs3.x; keep
+ * them in sync.  (nfs4.x coexists with nfs3.x the same way, via unique names.)
+ */
+
+const NFSACL_FHSIZE = 64;
+
+enum nacl_nfsstat3 {
+ NACL_NFS3_OK             = 0,
+ NACL_NFS3ERR_PERM        = 1,
+ NACL_NFS3ERR_NOENT       = 2,
+ NACL_NFS3ERR_IO          = 5,
+ NACL_NFS3ERR_ACCES       = 13,
+ NACL_NFS3ERR_INVAL       = 22,
+ NACL_NFS3ERR_NOTSUPP     = 10004,
+ NACL_NFS3ERR_SERVERFAULT = 10006
+};
+
+enum nacl_ftype3 {
+ NACL_NF3REG  = 1,
+ NACL_NF3DIR  = 2,
+ NACL_NF3BLK  = 3,
+ NACL_NF3CHR  = 4,
+ NACL_NF3LNK  = 5,
+ NACL_NF3SOCK = 6,
+ NACL_NF3FIFO = 7
+};
+
+struct nacl_specdata3 {
+ unsigned int specdata1;
+ unsigned int specdata2;
+};
+
+struct nfsacl_fh3 {
+ opaque data<NFSACL_FHSIZE>;
+};
+
+struct nacl_nfstime3 {
+ unsigned int seconds;
+ unsigned int nseconds;
+};
+
+struct nacl_fattr3 {
+ nacl_ftype3    type;
+ unsigned int   mode;
+ unsigned int   nlink;
+ unsigned int   uid;
+ unsigned int   gid;
+ uint64_t       size;
+ uint64_t       used;
+ nacl_specdata3 rdev;
+ uint64_t       fsid;
+ uint64_t       fileid;
+ nacl_nfstime3  atime;
+ nacl_nfstime3  mtime;
+ nacl_nfstime3  ctime;
+};
+
+union nacl_post_op_attr switch (bool attributes_follow) {
+ case TRUE:
+  nacl_fattr3 attributes;
+ case FALSE:
+  void;
+};
+
+/*
+ * One POSIX.1e ACL entry on the wire: three uint32 words (tag, id, perm),
+ * matching Linux fs/nfs_common/nfsacl.c (xdr_nfsace_encode).  For default-ACL
+ * entries the tag word additionally carries the NFS_ACL_DEFAULT (0x1000) flag.
+ */
+struct nfsacl_entry {
+ unsigned int tag;
+ unsigned int id;
+ unsigned int perm;
+};
+
+/*
+ * The access and default ACLs are each a count-prefixed array.  Real clients
+ * (Linux, Solaris) always request entries (NFS_ACL|NFS_ACLCNT together), so the
+ * leading count equals the array length, which is exactly what an xdrzcc
+ * var-array encodes.  The pure count-only query (NFS_ACLCNT without NFS_ACL) is
+ * not separately supported -- chimera always returns entries when either bit is
+ * set and echoes the satisfied mask.
+ */
+struct GETACL3args {
+ nfsacl_fh3   fh;
+ unsigned int mask;
+};
+
+/*
+ * Each ACL is encoded as Linux fs/nfs_common/nfsacl.c does: an explicit entry
+ * count word, followed by an XDR counted array (which carries its own length
+ * prefix).  The decoder requires the two counts to match (they differ only in
+ * the count-only NFS_ACLCNT query, which real clients never issue without
+ * NFS_ACL).  Hence the explicit *_count field in front of each <> array.
+ */
+struct GETACL3resok {
+ nacl_post_op_attr attr;
+ unsigned int      mask;
+ unsigned int      acl_access_count;
+ nfsacl_entry      acl_access<>;
+ unsigned int      acl_default_count;
+ nfsacl_entry      acl_default<>;
+};
+
+union GETACL3res switch (nacl_nfsstat3 status) {
+ case NACL_NFS3_OK:
+  GETACL3resok resok;
+ default:
+  nacl_post_op_attr attr;
+};
+
+struct SETACL3args {
+ nfsacl_fh3   fh;
+ unsigned int mask;
+ unsigned int acl_access_count;
+ nfsacl_entry acl_access<>;
+ unsigned int acl_default_count;
+ nfsacl_entry acl_default<>;
+};
+
+struct SETACL3resok {
+ nacl_post_op_attr attr;
+};
+
+union SETACL3res switch (nacl_nfsstat3 status) {
+ case NACL_NFS3_OK:
+  SETACL3resok resok;
+ default:
+  void;
+};
+
+program NFSACL {
+ version NFSACL_V3 {
+  void          NFSACLPROC3_NULL(void)             = 0;
+  GETACL3res    NFSACLPROC3_GETACL(GETACL3args)    = 1;
+  SETACL3res    NFSACLPROC3_SETACL(SETACL3args)    = 2;
+ } = 3;
+} = 100227;

--- a/src/server/nfs/CMakeLists.txt
+++ b/src/server/nfs/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(chimera_nfs SHARED nfs.c nfs4_session.c nfs4_state.c nfs4_lease.c nf
             nfs3_proc_create.c nfs3_proc_mkdir.c nfs3_proc_remove.c nfs3_proc_mknod.c nfs3_proc_symlink.c
             nfs3_proc_rmdir.c nfs3_proc_rename.c nfs3_proc_readdir.c nfs3_proc_readdirplus.c
             nfs3_proc_link.c nfs3_proc_commit.c nfs3_proc_fsinfo.c nfs3_proc_pathconf.c nfs3_proc_fsstat.c
+            nfs3_proc_getacl.c nfs3_proc_setacl.c
 
 
             nfs4_proc_getfh.c nfs4_proc_access.c nfs4_proc_putrootfh.c nfs4_proc_putfh.c

--- a/src/server/nfs/nfs.c
+++ b/src/server/nfs/nfs.c
@@ -98,7 +98,7 @@ nfs_server_init(
 {
     struct chimera_server_nfs_shared *shared;
     struct timespec                   now;
-    struct evpl_rpc2_program         *programs[3];
+    struct evpl_rpc2_program         *programs[4];
     int                               nfs_rdma;
     const char                       *nfs_rdma_hostname;
     int                               nfs_rdma_port;
@@ -156,6 +156,7 @@ nfs_server_init(
     NFS_V4_init(&shared->nfs_v4);
     NFS_V4_CB_init(&shared->nfs_v4_cb);
     NLM_V4_init(&shared->nlm_v4);
+    NFSACL_V3_init(&shared->nfsacl_v3);
 
     shared->metrics      = metrics;
     shared->op_histogram = prometheus_metrics_create_histogram_time(metrics, "chimera_nfs_op_latency_nanoseconds",
@@ -222,6 +223,7 @@ nfs_server_init(
     chimera_nfs_init_metrics(shared, &shared->nfs_v4.rpc2);
     chimera_nfs_init_metrics(shared, &shared->nfs_v4_cb.rpc2);
     chimera_nfs_init_metrics(shared, &shared->nlm_v4.rpc2);
+    chimera_nfs_init_metrics(shared, &shared->nfsacl_v3.rpc2);
 
     shared->mount_v3.recv_call_MOUNTPROC3_NULL    = chimera_nfs_mount_null;
     shared->mount_v3.recv_call_MOUNTPROC3_MNT     = chimera_nfs_mount_mnt;
@@ -252,6 +254,10 @@ nfs_server_init(
     shared->nfs_v3.recv_call_NFSPROC3_FSINFO      = chimera_nfs3_fsinfo;
     shared->nfs_v3.recv_call_NFSPROC3_PATHCONF    = chimera_nfs3_pathconf;
     shared->nfs_v3.recv_call_NFSPROC3_COMMIT      = chimera_nfs3_commit;
+
+    shared->nfsacl_v3.recv_call_NFSACLPROC3_NULL   = chimera_nfs3_acl_null;
+    shared->nfsacl_v3.recv_call_NFSACLPROC3_GETACL = chimera_nfs3_getacl;
+    shared->nfsacl_v3.recv_call_NFSACLPROC3_SETACL = chimera_nfs3_setacl;
 
     shared->nfs_v4.recv_call_NFSPROC4_NULL     = chimera_nfs4_null;
     shared->nfs_v4.recv_call_NFSPROC4_COMPOUND = chimera_nfs4_compound;
@@ -358,8 +364,10 @@ nfs_server_init(
     programs[0] = &shared->nfs_v3.rpc2;
     programs[1] = &shared->nfs_v4.rpc2;
     programs[2] = &shared->nfs_v4_cb.rpc2;
+    /* NFSACL (prog 100227) is multiplexed onto the same endpoint as NFS. */
+    programs[3] = &shared->nfsacl_v3.rpc2;
 
-    shared->nfs_server = evpl_rpc2_server_init(programs, 3);
+    shared->nfs_server = evpl_rpc2_server_init(programs, 4);
 
     if (!data_server) {
         chimera_nfs_debug("Initializing NFS lock manager server on port %d", nfs_lockmgr_port);
@@ -547,6 +555,7 @@ nfs_server_destroy(void *data)
     free(shared->nfs_v4.rpc2.metrics);
     free(shared->nfs_v4_cb.rpc2.metrics);
     free(shared->nlm_v4.rpc2.metrics);
+    free(shared->nfsacl_v3.rpc2.metrics);
 
     while (shared->exports) {
         export = shared->exports;

--- a/src/server/nfs/nfs3_acl.h
+++ b/src/server/nfs/nfs3_acl.h
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#pragma once
+
+#include <sys/stat.h>
+
+#include "nfs_common.h"
+#include "vfs/vfs_attrs.h"
+
+/*
+ * Marshal a chimera_vfs_attrs into the NFSACL program's private nacl_post_op_attr
+ * (a byte-identical clone of nfs3's post_op_attr -- see nfsacl.x for why the
+ * type is prefixed).  Mirrors chimera_nfs3_set_post_op_attr: attributes follow
+ * only when the full NFSv3 stat set is present.
+ */
+static inline void
+chimera_nfs3_acl_set_post_op_attr(
+    struct nacl_post_op_attr       *poa,
+    const struct chimera_vfs_attrs *attr)
+{
+    struct nacl_fattr3 *f;
+
+    if (!attr ||
+        (attr->va_set_mask & CHIMERA_NFS3_ATTR_MASK) != CHIMERA_NFS3_ATTR_MASK) {
+        poa->attributes_follow = 0;
+        return;
+    }
+
+    poa->attributes_follow = 1;
+    f                      = &poa->attributes;
+
+    switch (attr->va_mode & S_IFMT) {
+        case S_IFDIR:  f->type = NACL_NF3DIR;  break;
+        case S_IFBLK:  f->type = NACL_NF3BLK;  break;
+        case S_IFCHR:  f->type = NACL_NF3CHR;  break;
+        case S_IFLNK:  f->type = NACL_NF3LNK;  break;
+        case S_IFSOCK: f->type = NACL_NF3SOCK; break;
+        case S_IFIFO:  f->type = NACL_NF3FIFO; break;
+        default:       f->type = NACL_NF3REG;  break;
+    } /* switch */
+
+    f->mode           = attr->va_mode & ~S_IFMT;
+    f->nlink          = attr->va_nlink;
+    f->uid            = attr->va_uid;
+    f->gid            = attr->va_gid;
+    f->size           = attr->va_size;
+    f->used           = attr->va_space_used;
+    f->rdev.specdata1 = (attr->va_rdev >> 32) & 0xFFFFFFFF;
+    f->rdev.specdata2 = attr->va_rdev & 0xFFFFFFFF;
+    f->fsid           = attr->va_fsid;
+    f->fileid         = attr->va_ino;
+    f->atime.seconds  = attr->va_atime.tv_sec;
+    f->atime.nseconds = attr->va_atime.tv_nsec;
+    f->mtime.seconds  = attr->va_mtime.tv_sec;
+    f->mtime.nseconds = attr->va_mtime.tv_nsec;
+    f->ctime.seconds  = attr->va_ctime.tv_sec;
+    f->ctime.nseconds = attr->va_ctime.tv_nsec;
+} /* chimera_nfs3_acl_set_post_op_attr */

--- a/src/server/nfs/nfs3_proc_getacl.c
+++ b/src/server/nfs/nfs3_proc_getacl.c
@@ -1,0 +1,209 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include <sys/stat.h>
+
+#include "nfs3_procs.h"
+#include "nfs_common/nfs3_status.h"
+#include "nfs_common/nfs3_attr.h"
+#include "vfs/vfs_procs.h"
+#include "vfs/vfs_release.h"
+#include "vfs/vfs_acl.h"
+#include "vfs/vfs_acl_posix.h"
+#include "nfs3_acl.h"
+
+void
+chimera_nfs3_acl_null(
+    struct evpl               *evpl,
+    struct evpl_rpc2_conn     *conn,
+    struct evpl_rpc2_cred     *cred,
+    struct evpl_rpc2_encoding *encoding,
+    void                      *private_data)
+{
+    struct chimera_server_nfs_thread *thread = private_data;
+    struct chimera_server_nfs_shared *shared = thread->shared;
+    int                               rc;
+
+    rc = shared->nfsacl_v3.send_reply_NFSACLPROC3_NULL(evpl, NULL, encoding);
+    chimera_nfs_abort_if(rc, "Failed to send RPC2 reply");
+} /* chimera_nfs3_acl_null */
+
+static void
+chimera_nfs3_getacl_complete(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *attr,
+    void                     *private_data)
+{
+    struct nfs_request               *req    = private_data;
+    struct chimera_server_nfs_thread *thread = req->thread;
+    struct chimera_server_nfs_shared *shared = thread->shared;
+    struct evpl                      *evpl   = thread->evpl;
+    struct GETACL3args               *args   = req->args_getacl;
+    struct GETACL3res                 res;
+    int                               rc;
+
+    res.status = (nacl_nfsstat3) chimera_vfs_error_to_nfsstat3(error_code);
+
+    if (res.status != NACL_NFS3_OK) {
+        res.attr.attributes_follow = 0;
+        goto out;
+    }
+
+    {
+        /* Synthesise a canonical ACL from mode if the backend returned none
+         * (it normally will -- memfs/cairn store it, linux derives it). */
+        uint8_t                         synth_buf[sizeof(struct chimera_acl) +
+                                                  5 * sizeof(struct chimera_ace)];
+        struct chimera_acl             *synth = (struct chimera_acl *) synth_buf;
+        const struct chimera_acl       *acl;
+        int                             is_dir;
+        unsigned                        cap;
+        struct chimera_posix_acl_entry *pa, *pd;
+        struct nfsacl_entry            *wa, *wd;
+        uint32_t                        aclcnt = 0, dfaclcnt = 0;
+        uint32_t                        want_access, want_default;
+
+        if (attr->va_set_mask & CHIMERA_VFS_ATTR_ACL && attr->va_acl) {
+            acl = attr->va_acl;
+        } else {
+            chimera_acl_from_mode(attr->va_mode, synth, 5);
+            acl = synth;
+        }
+
+        is_dir       = S_ISDIR(attr->va_mode);
+        want_access  = args->mask & (CHIMERA_NFS_ACL | CHIMERA_NFS_ACLCNT);
+        want_default = args->mask & (CHIMERA_NFS_DFACL | CHIMERA_NFS_DFACLCNT);
+
+        cap = acl->num_aces + 8;
+
+        pa = xdr_dbuf_alloc_space(cap * sizeof(*pa), req->encoding->dbuf);
+        pd = xdr_dbuf_alloc_space(cap * sizeof(*pd), req->encoding->dbuf);
+        wa = xdr_dbuf_alloc_space(cap * sizeof(*wa), req->encoding->dbuf);
+        wd = xdr_dbuf_alloc_space(cap * sizeof(*wd), req->encoding->dbuf);
+        chimera_nfs_abort_if(!pa || !pd || !wa || !wd,
+                             "Failed to allocate ACL space");
+
+        rc = chimera_acl_to_posix(acl, attr->va_uid, attr->va_gid, is_dir,
+                                  pa, cap, &aclcnt, pd, cap, &dfaclcnt);
+        if (rc < 0) {
+            res.status                 = NACL_NFS3ERR_SERVERFAULT;
+            res.attr.attributes_follow = 0;
+            goto out;
+        }
+
+        chimera_nfs3_acl_set_post_op_attr(&res.resok.attr, attr);
+        /* The reply mask must echo every requested bit the server honours: the
+        * Linux client rejects the reply with EINVAL if (req.mask & res.mask)
+        * != req.mask.  We support all four, so reflect them and emit the
+        * matching (possibly empty) array -- a directory with no default ACL
+        * still answers an NFS_DFACL request with a zero-length default ACL. */
+        res.resok.mask = 0;
+
+        if (want_access) {
+            for (uint32_t i = 0; i < aclcnt; i++) {
+                wa[i].tag  = pa[i].e_tag;
+                wa[i].id   = pa[i].e_id;
+                wa[i].perm = pa[i].e_perm;
+            }
+            res.resok.acl_access_count = aclcnt;
+            res.resok.num_acl_access   = aclcnt;
+            res.resok.acl_access       = aclcnt ? wa : NULL;
+            res.resok.mask            |= args->mask &
+                (CHIMERA_NFS_ACL | CHIMERA_NFS_ACLCNT);
+        } else {
+            res.resok.acl_access_count = 0;
+            res.resok.num_acl_access   = 0;
+            res.resok.acl_access       = NULL;
+        }
+
+        /* Echo the requested default bits even when the directory has no
+         * default ACL (the client rejects the reply with EINVAL unless
+         * res.mask covers req.mask); a directory with no default ACL answers
+         * with a zero-length default array, exactly as Linux nfsd does. */
+        if (want_default && is_dir) {
+            for (uint32_t i = 0; i < dfaclcnt; i++) {
+                /* Default-ACL entries carry the NFS_ACL_DEFAULT flag in the
+                 * wire tag (Linux fs/nfs_common/nfsacl.c). */
+                wd[i].tag  = pd[i].e_tag | CHIMERA_NFS_ACL_DEFAULT;
+                wd[i].id   = pd[i].e_id;
+                wd[i].perm = pd[i].e_perm;
+            }
+            res.resok.acl_default_count = dfaclcnt;
+            res.resok.num_acl_default   = dfaclcnt;
+            res.resok.acl_default       = dfaclcnt ? wd : NULL;
+            res.resok.mask             |= args->mask &
+                (CHIMERA_NFS_DFACL | CHIMERA_NFS_DFACLCNT);
+        } else {
+            res.resok.acl_default_count = 0;
+            res.resok.num_acl_default   = 0;
+            res.resok.acl_default       = NULL;
+        }
+    }
+
+ out:
+    chimera_vfs_release(thread->vfs_thread, req->handle);
+
+
+    rc = shared->nfsacl_v3.send_reply_NFSACLPROC3_GETACL(evpl, NULL, &res,
+                                                         req->encoding);
+    chimera_nfs_abort_if(rc, "Failed to send RPC2 reply");
+
+    nfs_request_free(thread, req);
+} /* chimera_nfs3_getacl_complete */
+
+static void
+chimera_nfs3_getacl_open_callback(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *handle,
+    void                           *private_data)
+{
+    struct nfs_request               *req    = private_data;
+    struct chimera_server_nfs_thread *thread = req->thread;
+    struct chimera_server_nfs_shared *shared = thread->shared;
+    struct evpl                      *evpl   = thread->evpl;
+    struct GETACL3res                 res;
+    int                               rc;
+
+    if (error_code == CHIMERA_VFS_OK) {
+        req->handle = handle;
+
+        chimera_vfs_getattr(thread->vfs_thread, &req->cred, handle,
+                            CHIMERA_NFS3_ATTR_MASK | CHIMERA_VFS_ATTR_ACL,
+                            chimera_nfs3_getacl_complete, req);
+    } else {
+        res.status                 = (nacl_nfsstat3) chimera_vfs_error_to_nfsstat3(error_code);
+        res.attr.attributes_follow = 0;
+        rc                         = shared->nfsacl_v3.send_reply_NFSACLPROC3_GETACL(
+            evpl, NULL, &res, req->encoding);
+        chimera_nfs_abort_if(rc, "Failed to send RPC2 reply");
+        nfs_request_free(thread, req);
+    }
+} /* chimera_nfs3_getacl_open_callback */
+
+void
+chimera_nfs3_getacl(
+    struct evpl               *evpl,
+    struct evpl_rpc2_conn     *conn,
+    struct evpl_rpc2_cred     *cred,
+    struct GETACL3args        *args,
+    struct evpl_rpc2_encoding *encoding,
+    void                      *private_data)
+{
+    struct chimera_server_nfs_thread *thread = private_data;
+    struct nfs_request               *req;
+
+    req = nfs_request_alloc(thread, conn, encoding);
+
+    chimera_nfs_map_cred(&req->cred, cred);
+
+
+    req->args_getacl = args;
+
+    chimera_vfs_open_fh(thread->vfs_thread, &req->cred,
+                        args->fh.data.data,
+                        args->fh.data.len,
+                        CHIMERA_VFS_OPEN_INFERRED | CHIMERA_VFS_OPEN_PATH,
+                        chimera_nfs3_getacl_open_callback,
+                        req);
+} /* chimera_nfs3_getacl */

--- a/src/server/nfs/nfs3_proc_setacl.c
+++ b/src/server/nfs/nfs3_proc_setacl.c
@@ -1,0 +1,158 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "nfs3_procs.h"
+#include "nfs_common/nfs3_status.h"
+#include "nfs_common/nfs3_attr.h"
+#include "vfs/vfs_procs.h"
+#include "vfs/vfs_release.h"
+#include "vfs/vfs_acl.h"
+#include "vfs/vfs_acl_posix.h"
+#include "nfs3_acl.h"
+
+static void
+chimera_nfs3_setacl_complete(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *pre_attr,
+    struct chimera_vfs_attrs *set_attr,
+    struct chimera_vfs_attrs *post_attr,
+    void                     *private_data)
+{
+    struct nfs_request               *req    = private_data;
+    struct chimera_server_nfs_thread *thread = req->thread;
+    struct chimera_server_nfs_shared *shared = thread->shared;
+    struct evpl                      *evpl   = thread->evpl;
+    struct SETACL3res                 res;
+    int                               rc;
+
+    res.status = (nacl_nfsstat3) chimera_vfs_error_to_nfsstat3(error_code);
+
+    if (res.status == NACL_NFS3_OK) {
+        chimera_nfs3_acl_set_post_op_attr(&res.resok.attr, post_attr);
+    }
+
+    rc = shared->nfsacl_v3.send_reply_NFSACLPROC3_SETACL(evpl, NULL, &res,
+                                                         req->encoding);
+    chimera_nfs_abort_if(rc, "Failed to send RPC2 reply");
+
+    chimera_vfs_release(thread->vfs_thread, req->handle);
+
+    nfs_request_free(thread, req);
+} /* chimera_nfs3_setacl_complete */
+
+static void
+chimera_nfs3_setacl_open_callback(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *handle,
+    void                           *private_data)
+{
+    struct nfs_request               *req    = private_data;
+    struct chimera_server_nfs_thread *thread = req->thread;
+    struct chimera_server_nfs_shared *shared = thread->shared;
+    struct evpl                      *evpl   = thread->evpl;
+    struct SETACL3args               *args   = req->args_setacl;
+    struct SETACL3res                 res;
+    struct chimera_vfs_attrs         *attr;
+    struct chimera_acl               *acl;
+    struct chimera_posix_acl_entry   *pa, *pd;
+    int                               rc;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        res.status = (nacl_nfsstat3) chimera_vfs_error_to_nfsstat3(error_code);
+        rc         = shared->nfsacl_v3.send_reply_NFSACLPROC3_SETACL(
+            evpl, NULL, &res, req->encoding);
+        chimera_nfs_abort_if(rc, "Failed to send RPC2 reply");
+        nfs_request_free(thread, req);
+        return;
+    }
+
+    req->handle = handle;
+
+
+    /* Reject oversized ACLs before allocating / translating. */
+    if (args->num_acl_access > CHIMERA_NFSACL_MAXENTRIES ||
+        args->num_acl_default > CHIMERA_NFSACL_MAXENTRIES) {
+        res.status = NACL_NFS3ERR_INVAL;
+        rc         = shared->nfsacl_v3.send_reply_NFSACLPROC3_SETACL(
+            evpl, NULL, &res, req->encoding);
+        chimera_nfs_abort_if(rc, "Failed to send RPC2 reply");
+        chimera_vfs_release(thread->vfs_thread, req->handle);
+        nfs_request_free(thread, req);
+        return;
+    }
+
+    /* Translate the wire (tag,id,perm) entries into the protocol-neutral POSIX
+     * entry struct the translation layer consumes. */
+    pa = xdr_dbuf_alloc_space((args->num_acl_access + 1) * sizeof(*pa),
+                              req->encoding->dbuf);
+    pd = xdr_dbuf_alloc_space((args->num_acl_default + 1) * sizeof(*pd),
+                              req->encoding->dbuf);
+    acl = xdr_dbuf_alloc_space(chimera_acl_size(CHIMERA_ACL_MAX_ACES),
+                               req->encoding->dbuf);
+    chimera_nfs_abort_if(!pa || !pd || !acl, "Failed to allocate ACL space");
+
+    for (uint32_t i = 0; i < args->num_acl_access; i++) {
+        pa[i].e_tag  = args->acl_access[i].tag & ~CHIMERA_NFS_ACL_DEFAULT;
+        pa[i].e_id   = args->acl_access[i].id;
+        pa[i].e_perm = args->acl_access[i].perm;
+    }
+    for (uint32_t i = 0; i < args->num_acl_default; i++) {
+        pd[i].e_tag  = args->acl_default[i].tag & ~CHIMERA_NFS_ACL_DEFAULT;
+        pd[i].e_id   = args->acl_default[i].id;
+        pd[i].e_perm = args->acl_default[i].perm;
+    }
+
+    rc = chimera_acl_from_posix(pa, args->num_acl_access,
+                                pd, args->num_acl_default,
+                                acl, CHIMERA_ACL_MAX_ACES);
+    if (rc < 0) {
+        res.status = NACL_NFS3ERR_INVAL;
+        rc         = shared->nfsacl_v3.send_reply_NFSACLPROC3_SETACL(
+            evpl, NULL, &res, req->encoding);
+        chimera_nfs_abort_if(rc, "Failed to send RPC2 reply");
+        chimera_vfs_release(thread->vfs_thread, req->handle);
+        nfs_request_free(thread, req);
+        return;
+    }
+
+    attr = xdr_dbuf_alloc_space(sizeof(*attr), req->encoding->dbuf);
+    chimera_nfs_abort_if(attr == NULL, "Failed to allocate space");
+
+    /* Set ATTR_ACL alone: memfs/cairn store the canonical ACL (and re-derive
+     * mode from it); the linux backend, which only persists mode, projects the
+     * ACL down to mode itself (vfs_acl.h -- documented lossy).  Adding ATTR_MODE
+     * here would suppress that projection. */
+    attr->va_set_mask = CHIMERA_VFS_ATTR_ACL;
+    attr->va_acl      = acl;
+
+    chimera_vfs_setattr(thread->vfs_thread, &req->cred, req->handle,
+                        attr, 0, CHIMERA_NFS3_ATTR_MASK,
+                        chimera_nfs3_setacl_complete, req);
+} /* chimera_nfs3_setacl_open_callback */
+
+void
+chimera_nfs3_setacl(
+    struct evpl               *evpl,
+    struct evpl_rpc2_conn     *conn,
+    struct evpl_rpc2_cred     *cred,
+    struct SETACL3args        *args,
+    struct evpl_rpc2_encoding *encoding,
+    void                      *private_data)
+{
+    struct chimera_server_nfs_thread *thread = private_data;
+    struct nfs_request               *req;
+
+    req = nfs_request_alloc(thread, conn, encoding);
+
+    chimera_nfs_map_cred(&req->cred, cred);
+
+    req->args_setacl = args;
+
+    chimera_vfs_open_fh(thread->vfs_thread, &req->cred,
+                        args->fh.data.data,
+                        args->fh.data.len,
+                        CHIMERA_VFS_OPEN_INFERRED | CHIMERA_VFS_OPEN_PATH,
+                        chimera_nfs3_setacl_open_callback,
+                        req);
+} /* chimera_nfs3_setacl */

--- a/src/server/nfs/nfs3_procs.h
+++ b/src/server/nfs/nfs3_procs.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -185,5 +185,29 @@ void chimera_nfs3_secinfo_no_name(
     struct evpl               *evpl,
     struct evpl_rpc2_conn     *conn,
     struct evpl_rpc2_cred     *cred,
+    struct evpl_rpc2_encoding *encoding,
+    void                      *private_data);
+
+/* NFSACL sideband protocol (RPC program 100227, version 3). */
+void chimera_nfs3_acl_null(
+    struct evpl               *evpl,
+    struct evpl_rpc2_conn     *conn,
+    struct evpl_rpc2_cred     *cred,
+    struct evpl_rpc2_encoding *encoding,
+    void                      *private_data);
+
+void chimera_nfs3_getacl(
+    struct evpl               *evpl,
+    struct evpl_rpc2_conn     *conn,
+    struct evpl_rpc2_cred     *cred,
+    struct GETACL3args        *args,
+    struct evpl_rpc2_encoding *encoding,
+    void                      *private_data);
+
+void chimera_nfs3_setacl(
+    struct evpl               *evpl,
+    struct evpl_rpc2_conn     *conn,
+    struct evpl_rpc2_cred     *cred,
+    struct SETACL3args        *args,
     struct evpl_rpc2_encoding *encoding,
     void                      *private_data);

--- a/src/server/nfs/nfs_common.h
+++ b/src/server/nfs/nfs_common.h
@@ -13,6 +13,7 @@
 #include "nfs3_xdr.h"
 #include "nfs4_xdr.h"
 #include "nlm4_xdr.h"
+#include "nfsacl_xdr.h"
 #include "nfs4_session.h"
 #include "nfs4_state.h"
 #include "nfs4_layout_table.h"
@@ -153,6 +154,8 @@ struct nfs_request {
         struct READLINK3args    *args_readlink;
         struct MKNOD3args       *args_mknod;
         struct WRITE4args       *args_write4;
+        struct GETACL3args      *args_getacl;
+        struct SETACL3args      *args_setacl;
     };
     struct COMPOUND4args *args_compound;
     union {
@@ -240,6 +243,7 @@ struct chimera_server_nfs_shared {
     struct NFS_V4                       nfs_v4;
     struct NFS_V4_CB                    nfs_v4_cb;
     struct NLM_V4                       nlm_v4;
+    struct NFSACL_V3                    nfsacl_v3;
     struct nlm_state                    nlm_state;
 
     struct chimera_nfs_export          *exports;

--- a/src/server/nfs/nfs_portmap.c
+++ b/src/server/nfs/nfs_portmap.c
@@ -32,9 +32,11 @@ static struct portmap_service portmap_services[num_portmap_services_MAX] = {
     { 100003, 4, 6, 2049  },
     /* Mount - program 100005 */
     { 100005, 3, 6, 20048 },
+    /* NFSACL sideband - program 100227 (multiplexed on the NFS port) */
+    { 100227, 3, 6, 2049  },
 };
 
-static int                    num_portmap_services = 6;
+static int                    num_portmap_services = 7;
 
 /*
  * Convert local address from "ip:port" format to universal address format.

--- a/src/vfs/CMakeLists.txt
+++ b/src/vfs/CMakeLists.txt
@@ -14,7 +14,7 @@
 add_compile_definitions(_LGPL_SOURCE)
 
 add_library(chimera_vfs SHARED vfs.c vfs_lsan.c
-            vfs_acl.c vfs_acl_serialize.c vfs_access.c vfs_idmap.c vfs_identity.c
+            vfs_acl.c vfs_acl_posix.c vfs_acl_serialize.c vfs_access.c vfs_idmap.c vfs_identity.c
             vfs_proc_mount.c vfs_proc_umount.c
             vfs_proc_mkdir_at.c vfs_proc_mknod_at.c vfs_proc_close.c vfs_proc_open_fh.c
             vfs_proc_readdir.c vfs_proc_getattr.c vfs_proc_lookup_at.c

--- a/src/vfs/nfs/CMakeLists.txt
+++ b/src/vfs/nfs/CMakeLists.txt
@@ -11,6 +11,8 @@ add_library(chimera_vfs_nfs SHARED
     nfs3_close.c
     nfs3_commit.c
     nfs3_getattr.c
+    nfs3_getacl.c
+    nfs3_setacl.c
     nfs3_mount.c
     nfs3_umount.c
     nfs3_link_at.c

--- a/src/vfs/nfs/nfs.c
+++ b/src/vfs/nfs/nfs.c
@@ -108,6 +108,7 @@ chimera_nfs_init(
      * by the control connection (nfs4_cb.c). */
     shared->nfs_v4_cb.recv_call_CB_COMPOUND = chimera_nfs4_cb_compound;
     NLM_V4_init(&shared->nlm_v4);
+    NFSACL_V3_init(&shared->nfsacl_v3);
 
     return shared;
 } /* chimera_nfs_init */

--- a/src/vfs/nfs/nfs3_getacl.c
+++ b/src/vfs/nfs/nfs3_getacl.c
@@ -1,0 +1,137 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include <sys/stat.h>
+
+#include "nfs_internal.h"
+#include "nfs_common/nfs3_status.h"
+#include "nfs_common/nfs3_attr.h"
+#include "vfs/vfs_acl.h"
+#include "vfs/vfs_acl_posix.h"
+
+/*
+ * Populate request->getattr.r_attr.va_acl by deriving it from the just-fetched
+ * mode bits (the fallback when the upstream does not speak NFSACL or returns an
+ * error for GETACL).  Always sets ATTR_ACL and completes OK.
+ */
+static void
+chimera_nfs3_acl_fallback_from_mode(struct chimera_vfs_request *request)
+{
+    struct chimera_nfs3_acl_ctx *ctx = request->plugin_data;
+    struct chimera_acl          *acl = (struct chimera_acl *) ctx->acl_buf;
+    int                          n;
+
+    n = chimera_acl_from_mode(request->getattr.r_attr.va_mode, acl,
+                              CHIMERA_NFS3_CLIENT_ACL_MAX);
+    if (n >= 0) {
+        request->getattr.r_attr.va_acl       = acl;
+        request->getattr.r_attr.va_set_mask |= CHIMERA_VFS_ATTR_ACL;
+    }
+
+    request->status = CHIMERA_VFS_OK;
+    request->complete(request);
+} /* chimera_nfs3_acl_fallback_from_mode */
+
+static void
+chimera_nfs3_getacl_callback(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    struct GETACL3res           *res,
+    int                          status,
+    void                        *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct chimera_nfs3_acl_ctx   *ctx     = request->plugin_data;
+    struct chimera_acl            *acl     = (struct chimera_acl *) ctx->acl_buf;
+    struct chimera_posix_acl_entry pa[CHIMERA_NFS3_CLIENT_ACL_MAX];
+    struct chimera_posix_acl_entry pd[CHIMERA_NFS3_CLIENT_ACL_MAX];
+    uint32_t                       na, nd;
+    int                            n;
+
+    /* An RPC-level failure means the upstream does not export NFSACL on this
+     * connection (PROG_UNAVAIL/PROG_MISMATCH) or the call was dropped.  Mark the
+     * server so we stop probing and fall back to mode-derived ACLs. */
+    if (unlikely(status)) {
+        ctx->server_thread->server->nfsacl_unsupported = 1;
+        chimera_nfs3_acl_fallback_from_mode(request);
+        return;
+    }
+
+    /* A protocol error for GETACL (e.g. the export has ACLs disabled) is not
+     * fatal to the getattr -- fall back to deriving the ACL from mode. */
+    if (res->status != NACL_NFS3_OK) {
+        chimera_nfs3_acl_fallback_from_mode(request);
+        return;
+    }
+
+    na = res->resok.num_acl_access;
+    nd = res->resok.num_acl_default;
+
+    if (na > CHIMERA_NFS3_CLIENT_ACL_MAX || nd > CHIMERA_NFS3_CLIENT_ACL_MAX) {
+        /* Larger than we translate for a proxied ACL; degrade to mode. */
+        chimera_nfs3_acl_fallback_from_mode(request);
+        return;
+    }
+
+    for (uint32_t i = 0; i < na; i++) {
+        pa[i].e_tag  = res->resok.acl_access[i].tag & ~CHIMERA_NFS_ACL_DEFAULT;
+        pa[i].e_id   = res->resok.acl_access[i].id;
+        pa[i].e_perm = res->resok.acl_access[i].perm;
+    }
+    for (uint32_t i = 0; i < nd; i++) {
+        pd[i].e_tag  = res->resok.acl_default[i].tag & ~CHIMERA_NFS_ACL_DEFAULT;
+        pd[i].e_id   = res->resok.acl_default[i].id;
+        pd[i].e_perm = res->resok.acl_default[i].perm;
+    }
+
+    n = chimera_acl_from_posix(pa, na, pd, nd, acl,
+                               CHIMERA_NFS3_CLIENT_ACL_MAX);
+    if (n < 0) {
+        chimera_nfs3_acl_fallback_from_mode(request);
+        return;
+    }
+
+    request->getattr.r_attr.va_acl       = acl;
+    request->getattr.r_attr.va_set_mask |= CHIMERA_VFS_ATTR_ACL;
+
+    request->status = CHIMERA_VFS_OK;
+    request->complete(request);
+} /* chimera_nfs3_getacl_callback */
+
+void
+chimera_nfs3_acl_fetch(struct chimera_vfs_request *request)
+{
+    struct chimera_nfs3_acl_ctx             *ctx           = request->plugin_data;
+    struct chimera_nfs_thread               *thread        = ctx->thread;
+    struct chimera_nfs_shared               *shared        = ctx->shared;
+    struct chimera_nfs_client_server_thread *server_thread = ctx->server_thread;
+    struct GETACL3args                       args;
+    struct evpl_rpc2_cred                    rpc2_cred;
+    uint8_t                                 *fh;
+    int                                      fhlen;
+
+    /* Upstream already known not to support NFSACL: derive from mode. */
+    if (server_thread->server->nfsacl_unsupported) {
+        chimera_nfs3_acl_fallback_from_mode(request);
+        return;
+    }
+
+    chimera_nfs3_map_fh(request->fh, request->fh_len, &fh, &fhlen);
+
+    args.fh.data.data = fh;
+    args.fh.data.len  = fhlen;
+    args.mask         = CHIMERA_NFS_ACL | CHIMERA_NFS_ACLCNT;
+    if (S_ISDIR(request->getattr.r_attr.va_mode)) {
+        args.mask |= CHIMERA_NFS_DFACL | CHIMERA_NFS_DFACLCNT;
+    }
+
+    chimera_nfs_init_rpc2_cred(&rpc2_cred, request->cred,
+                               request->thread->vfs->machine_name,
+                               request->thread->vfs->machine_name_len);
+
+    shared->nfsacl_v3.send_call_NFSACLPROC3_GETACL(
+        &shared->nfsacl_v3.rpc2, thread->evpl, server_thread->nfs_conn,
+        &rpc2_cred, &args, 0, 0, NULL, 0, 0,
+        chimera_nfs3_getacl_callback, request);
+} /* chimera_nfs3_acl_fetch */

--- a/src/vfs/nfs/nfs3_getattr.c
+++ b/src/vfs/nfs/nfs3_getattr.c
@@ -30,6 +30,15 @@ chimera_nfs3_getattr_callback(
 
     chimera_nfs3_unmarshall_attrs(&res->resok.obj_attributes, &request->getattr.r_attr);
 
+    /* If the caller wants the ACL attribute, chain an NFSACL GETACL (multiplexed
+     * on the same connection) before completing.  chimera_nfs3_acl_fetch always
+     * completes the request, falling back to a mode-derived ACL when the upstream
+     * does not speak NFSACL; without it vfs_nfs would silently drop ATTR_ACL. */
+    if (request->getattr.r_attr.va_req_mask & CHIMERA_VFS_ATTR_ACL) {
+        chimera_nfs3_acl_fetch(request);
+        return;
+    }
+
     request->status = CHIMERA_VFS_OK;
     request->complete(request);
 } /* chimera_nfs3_getattr_callback */
@@ -52,6 +61,16 @@ chimera_nfs3_getattr(
         request->status = CHIMERA_VFS_ESTALE;
         request->complete(request);
         return;
+    }
+
+    /* Stash the dispatch context so the completion callback can chain a GETACL
+     * (see chimera_nfs3_acl_fetch) if the caller requested the ACL attribute. */
+    if (request->getattr.r_attr.va_req_mask & CHIMERA_VFS_ATTR_ACL) {
+        struct chimera_nfs3_acl_ctx *ctx = request->plugin_data;
+
+        ctx->thread        = thread;
+        ctx->shared        = shared;
+        ctx->server_thread = server_thread;
     }
 
     chimera_nfs3_map_fh(request->fh, request->fh_len, &fh, &fhlen);

--- a/src/vfs/nfs/nfs3_setacl.c
+++ b/src/vfs/nfs/nfs3_setacl.c
@@ -1,0 +1,123 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include <sys/stat.h>
+
+#include "nfs_internal.h"
+#include "nfs_common/nfs3_status.h"
+#include "vfs/vfs_acl.h"
+#include "vfs/vfs_acl_posix.h"
+
+static void
+chimera_nfs3_setacl_callback(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    struct SETACL3res           *res,
+    int                          status,
+    void                        *private_data)
+{
+    struct chimera_vfs_request  *request = private_data;
+    struct chimera_nfs3_acl_ctx *ctx     = request->plugin_data;
+
+    /* RPC-level failure: upstream does not speak NFSACL.  The non-ACL attrs were
+     * already applied by the preceding SETATTR, so report success (the ACL store
+     * is best-effort over a POSIX-ACL proxy -- documented lossy). */
+    if (unlikely(status)) {
+        ctx->server_thread->server->nfsacl_unsupported = 1;
+        request->status                                = CHIMERA_VFS_OK;
+        request->complete(request);
+        return;
+    }
+
+    /* A protocol error (e.g. EACCES) is meaningful for an explicit ACL set --
+     * surface it. */
+    if (res->status != NACL_NFS3_OK) {
+        request->status = nfs3_client_status_to_chimera_vfs_error(res->status);
+        request->complete(request);
+        return;
+    }
+
+    request->status = CHIMERA_VFS_OK;
+    request->complete(request);
+} /* chimera_nfs3_setacl_callback */
+
+void
+chimera_nfs3_acl_store(struct chimera_vfs_request *request)
+{
+    struct chimera_nfs3_acl_ctx             *ctx           = request->plugin_data;
+    struct chimera_nfs_thread               *thread        = ctx->thread;
+    struct chimera_nfs_shared               *shared        = ctx->shared;
+    struct chimera_nfs_client_server_thread *server_thread = ctx->server_thread;
+    const struct chimera_vfs_attrs          *set_attr      = request->setattr.set_attr;
+    struct SETACL3args                       args;
+    struct evpl_rpc2_cred                    rpc2_cred;
+    struct chimera_posix_acl_entry           pa[CHIMERA_NFS3_CLIENT_ACL_MAX];
+    struct chimera_posix_acl_entry           pd[CHIMERA_NFS3_CLIENT_ACL_MAX];
+    struct nfsacl_entry                      wa[CHIMERA_NFS3_CLIENT_ACL_MAX];
+    struct nfsacl_entry                      wd[CHIMERA_NFS3_CLIENT_ACL_MAX];
+    uint32_t                                 aclcnt = 0, dfaclcnt = 0;
+    uint32_t                                 owner_uid, owner_gid;
+    uint8_t                                 *fh;
+    int                                      fhlen;
+    int                                      rc;
+
+    /* Upstream known not to support NFSACL: the ACL cannot be carried.  The
+     * preceding SETATTR already applied any mode/owner; report success. */
+    if (server_thread->server->nfsacl_unsupported || !set_attr->va_acl) {
+        request->status = CHIMERA_VFS_OK;
+        request->complete(request);
+        return;
+    }
+
+    owner_uid = (set_attr->va_set_mask & CHIMERA_VFS_ATTR_UID) ? set_attr->va_uid : 0;
+    owner_gid = (set_attr->va_set_mask & CHIMERA_VFS_ATTR_GID) ? set_attr->va_gid : 0;
+
+    /* A directory ACL may carry inheritable (default) entries; permit their
+     * emission (a non-directory simply has none). */
+    rc = chimera_acl_to_posix(set_attr->va_acl, owner_uid, owner_gid, 1,
+                              pa, CHIMERA_NFS3_CLIENT_ACL_MAX, &aclcnt,
+                              pd, CHIMERA_NFS3_CLIENT_ACL_MAX, &dfaclcnt);
+    if (rc < 0) {
+        /* Too large to translate; leave the upstream ACL as the SETATTR-derived
+         * mode set it (best-effort). */
+        request->status = CHIMERA_VFS_OK;
+        request->complete(request);
+        return;
+    }
+
+    for (uint32_t i = 0; i < aclcnt; i++) {
+        wa[i].tag  = pa[i].e_tag;
+        wa[i].id   = pa[i].e_id;
+        wa[i].perm = pa[i].e_perm;
+    }
+    for (uint32_t i = 0; i < dfaclcnt; i++) {
+        wd[i].tag  = pd[i].e_tag | CHIMERA_NFS_ACL_DEFAULT;
+        wd[i].id   = pd[i].e_id;
+        wd[i].perm = pd[i].e_perm;
+    }
+
+    chimera_nfs3_map_fh(request->fh, request->fh_len, &fh, &fhlen);
+
+    args.fh.data.data      = fh;
+    args.fh.data.len       = fhlen;
+    args.mask              = CHIMERA_NFS_ACL | CHIMERA_NFS_ACLCNT;
+    args.acl_access_count  = aclcnt;
+    args.num_acl_access    = aclcnt;
+    args.acl_access        = wa;
+    args.acl_default_count = dfaclcnt;
+    args.num_acl_default   = dfaclcnt;
+    args.acl_default       = wd;
+    if (dfaclcnt) {
+        args.mask |= CHIMERA_NFS_DFACL | CHIMERA_NFS_DFACLCNT;
+    }
+
+    chimera_nfs_init_rpc2_cred(&rpc2_cred, request->cred,
+                               request->thread->vfs->machine_name,
+                               request->thread->vfs->machine_name_len);
+
+    shared->nfsacl_v3.send_call_NFSACLPROC3_SETACL(
+        &shared->nfsacl_v3.rpc2, thread->evpl, server_thread->nfs_conn,
+        &rpc2_cred, &args, 0, 0, NULL, 0, 0,
+        chimera_nfs3_setacl_callback, request);
+} /* chimera_nfs3_acl_store */

--- a/src/vfs/nfs/nfs3_setattr.c
+++ b/src/vfs/nfs/nfs3_setattr.c
@@ -33,6 +33,14 @@ chimera_nfs3_setattr_callback(
 
     chimera_nfs3_get_wcc_data(&request->setattr.r_pre_attr, &request->setattr.r_post_attr, &res->resok.obj_wcc);
 
+    /* The base SETATTR carried mode/owner/size/times only (sattr3 has no ACL
+     * field).  If the caller also set an ACL, chain an NFSACL SETACL on the same
+     * connection; chimera_nfs3_acl_store always completes the request. */
+    if (request->setattr.set_attr->va_set_mask & CHIMERA_VFS_ATTR_ACL) {
+        chimera_nfs3_acl_store(request);
+        return;
+    }
+
     request->status = CHIMERA_VFS_OK;
     request->complete(request);
 } /* chimera_nfs3_setattr_callback */
@@ -55,6 +63,16 @@ chimera_nfs3_setattr(
         request->status = CHIMERA_VFS_ESTALE;
         request->complete(request);
         return;
+    }
+
+    /* Stash the dispatch context so the completion callback can chain a SETACL
+     * (see chimera_nfs3_acl_store) when the caller set the ACL attribute. */
+    if (request->setattr.set_attr->va_set_mask & CHIMERA_VFS_ATTR_ACL) {
+        struct chimera_nfs3_acl_ctx *ctx = request->plugin_data;
+
+        ctx->thread        = thread;
+        ctx->shared        = shared;
+        ctx->server_thread = server_thread;
     }
 
     chimera_nfs3_map_fh(request->fh, request->fh_len, &fh, &fhlen);

--- a/src/vfs/nfs/nfs_internal.h
+++ b/src/vfs/nfs/nfs_internal.h
@@ -13,6 +13,7 @@
 #include <utlist.h>
 #include "vfs/vfs.h"
 #include "vfs/vfs_pnfs.h"
+#include "vfs/vfs_acl.h"
 #include "evpl/evpl.h"
 #include "portmap_xdr.h"
 #include "nfs_mount_xdr.h"
@@ -23,6 +24,7 @@
 #include "vfs/vfs_fh.h"
 #include "evpl/evpl_rpc2.h"
 #include "nlm4_xdr.h"
+#include "nfsacl_xdr.h"
 
 /* Byte order conversion macros */
 static inline uint32_t
@@ -201,6 +203,12 @@ struct chimera_nfs_client_server {
     uint16_t                            nfs_port;
     uint16_t                            nlm_port;
 
+    /* NFSACL (prog 100227) capability for this upstream.  0 = not yet probed
+     * (optimistically try); 1 = confirmed unsupported (fall back to deriving
+     * ACLs from mode).  Multiplexed on the NFS connection, so no separate port
+     * or portmap lookup is needed. */
+    int                                 nfsacl_unsupported;
+
     struct chimera_vfs_request         *pending_mounts;
 
     char                                hostname[256];
@@ -295,6 +303,7 @@ struct chimera_nfs_shared {
     struct NFS_V4                       nfs_v4;
     struct NFS_V4_CB                    nfs_v4_cb;
     struct NLM_V4                       nlm_v4;
+    struct NFSACL_V3                    nfsacl_v3;
 
     /* Back-channel control thread (nfs4_cb.c).  A single dedicated evpl thread
      * owns a persistent connection per server (server->cb_conn) on which it runs
@@ -799,6 +808,35 @@ void chimera_nfs4_cb_establish_session(
 void chimera_nfs4_mount_resume_after_session(
     struct chimera_nfs_client_server_thread *server_thread,
     struct chimera_vfs_request              *request);
+
+/*
+ * NFSACL (prog 100227) client helpers.  ACL fetch/store is multiplexed onto the
+ * existing nfs_conn.  The getattr fast path stashes the dispatch context in
+ * request->plugin_data so its completion callback can chain a GETACL when the
+ * caller asked for the ACL attribute; the SETATTR path chains a SETACL.  Bounds
+ * the translated canonical ACL to a sane size for a proxied POSIX ACL.
+ */
+#define CHIMERA_NFS3_CLIENT_ACL_MAX 256
+
+struct chimera_nfs3_acl_ctx {
+    struct chimera_nfs_thread               *thread;
+    struct chimera_nfs_shared               *shared;
+    struct chimera_nfs_client_server_thread *server_thread;
+    /* Storage for the translated canonical ACL (header + flexible aces[]). */
+    uint8_t                                  acl_buf[sizeof(struct chimera_acl) +
+                                                     CHIMERA_NFS3_CLIENT_ACL_MAX *
+                                                     sizeof(struct chimera_ace)];
+};
+
+/* Chain a GETACL after a successful GETATTR (ctx in request->plugin_data).
+ * Always completes the request (translating, or falling back to mode). */
+void chimera_nfs3_acl_fetch(
+    struct chimera_vfs_request *request);
+
+/* Chain a SETACL after a successful SETATTR when the caller set ATTR_ACL
+ * (ctx in request->plugin_data).  Always completes the request. */
+void chimera_nfs3_acl_store(
+    struct chimera_vfs_request *request);
 
 void chimera_nfs3_dispatch(
     struct chimera_nfs_thread *,

--- a/src/vfs/tests/CMakeLists.txt
+++ b/src/vfs/tests/CMakeLists.txt
@@ -40,6 +40,10 @@ add_executable(vfs_enforce_test vfs_enforce_test.c)
 target_link_libraries(vfs_enforce_test chimera_vfs chimera_vfs_memfs evpl)
 add_test(chimera/vfs/enforce_test vfs_enforce_test)
 
+add_executable(vfs_acl_posix_test vfs_acl_posix_test.c)
+target_link_libraries(vfs_acl_posix_test chimera_vfs)
+add_test(chimera/vfs/acl_posix_test vfs_acl_posix_test)
+
 add_executable(vfs_idmap_test vfs_idmap_test.c)
 target_link_libraries(vfs_idmap_test chimera_vfs)
 add_test(chimera/vfs/idmap_test vfs_idmap_test)

--- a/src/vfs/tests/vfs_acl_posix_test.c
+++ b/src/vfs/tests/vfs_acl_posix_test.c
@@ -1,0 +1,269 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#undef NDEBUG
+#include <assert.h>
+
+#include "vfs/vfs_acl.h"
+#include "vfs/vfs_acl_posix.h"
+
+#define TEST_PASS(name) fprintf(stderr, "  PASS: %s\n", name)
+
+#define ACL_BUF(name, n)                                              \
+        uint8_t name ## _storage[sizeof(struct chimera_acl) +         \
+                                 (n) * sizeof(struct chimera_ace)];   \
+        struct chimera_acl *name = (struct chimera_acl *) name ## _storage
+
+#define MAXE 64
+
+/*
+ * The keystone property: mode -> canonical -> POSIX.1e -> canonical must project
+ * back to the same 9-bit mode for every one of the 512 permission patterns.
+ * This exercises the deny-aware special-who projection in both directions and
+ * the mask folding, and proves a SETACL of a GETACL'd mode-only object is
+ * idempotent.
+ */
+static void
+test_mode_roundtrip_through_posix(void)
+{
+    for (uint32_t mode = 0; mode <= 0777; mode++) {
+        ACL_BUF(c1, MAXE);
+        ACL_BUF(c2, MAXE);
+        struct chimera_posix_acl_entry pa[MAXE], pd[MAXE];
+        uint32_t                       na = 0, nd = 0;
+        int                            n;
+
+        n = chimera_acl_from_mode(mode, c1, MAXE);
+        assert(n >= 3);
+
+        n = chimera_acl_to_posix(c1, 1000, 2000, 0, pa, MAXE, &na,
+                                 pd, MAXE, &nd);
+        assert(n == 0);
+        /* A mode-only ACL has no named entries, so no mask is emitted:
+         * USER_OBJ, GROUP_OBJ, OTHER -- exactly three. */
+        assert(na == 3);
+        assert(nd == 0);
+
+        n = chimera_acl_from_posix(pa, na, pd, nd, c2, MAXE);
+        assert(n >= 3);
+
+        assert(chimera_acl_to_mode(c2) == mode);
+    }
+    TEST_PASS("mode -> canonical -> POSIX -> canonical -> mode for all 0..0777");
+} /* test_mode_roundtrip_through_posix */
+
+/* Locate a POSIX entry of a given tag (ignoring the DEFAULT wire flag). */
+static const struct chimera_posix_acl_entry *
+find_entry(
+    const struct chimera_posix_acl_entry *e,
+    uint32_t                              n,
+    uint16_t                              tag,
+    uint32_t                              id,
+    int                                   match_id)
+{
+    for (uint32_t i = 0; i < n; i++) {
+        if ((e[i].e_tag & ~CHIMERA_NFS_ACL_DEFAULT) == tag &&
+            (!match_id || e[i].e_id == id)) {
+            return &e[i];
+        }
+    }
+    return NULL;
+} /* find_entry */
+
+/*
+ * A named user with explicit perms must survive canonical -> POSIX, appear in
+ * the mask, and come back as a USER-principal ALLOW ACE.
+ */
+static void
+test_named_user_preserved(void)
+{
+    ACL_BUF(c1, MAXE);
+    ACL_BUF(c2, MAXE);
+    struct chimera_posix_acl_entry        pa[MAXE], pd[MAXE];
+    uint32_t                              na = 0, nd = 0;
+    const struct chimera_posix_acl_entry *e;
+    int                                   n, found;
+
+    /* 0640 base + a named user 1005 granted r-x. */
+    n = chimera_acl_from_mode(0640, c1, MAXE);
+    assert(n >= 3);
+    c1->aces[n].type        = CHIMERA_ACE_ALLOWED;
+    c1->aces[n].flags       = 0;
+    c1->aces[n].access_mask = CHIMERA_ACE_PERM_R | CHIMERA_ACE_PERM_X;
+    c1->aces[n].who.type    = CHIMERA_PRINCIPAL_USER;
+    c1->aces[n].who.special = 0;
+    c1->aces[n].who.id      = 1005;
+    n++;
+    c1->num_aces = n;
+
+    n = chimera_acl_to_posix(c1, 1000, 2000, 0, pa, MAXE, &na, pd, MAXE, &nd);
+    assert(n == 0);
+
+    e = find_entry(pa, na, CHIMERA_POSIX_ACL_USER, 1005, 1);
+    assert(e != NULL);
+    assert(e->e_perm == (CHIMERA_POSIX_ACL_READ | CHIMERA_POSIX_ACL_EXECUTE));
+
+    /* The mask must include the named user's permissions (r-x). */
+    e = find_entry(pa, na, CHIMERA_POSIX_ACL_MASK, 0, 0);
+    assert(e != NULL);
+    assert((e->e_perm & (CHIMERA_POSIX_ACL_READ | CHIMERA_POSIX_ACL_EXECUTE)) ==
+           (CHIMERA_POSIX_ACL_READ | CHIMERA_POSIX_ACL_EXECUTE));
+
+    /* Round-trips back to a USER-principal ALLOW ACE with READ_DATA|EXECUTE. */
+    n = chimera_acl_from_posix(pa, na, pd, nd, c2, MAXE);
+    assert(n >= 3);
+    found = 0;
+    for (int i = 0; i < c2->num_aces; i++) {
+        if (c2->aces[i].who.type == CHIMERA_PRINCIPAL_USER &&
+            c2->aces[i].who.id == 1005) {
+            assert(c2->aces[i].type == CHIMERA_ACE_ALLOWED);
+            assert(c2->aces[i].access_mask & CHIMERA_ACE_READ_DATA);
+            assert(c2->aces[i].access_mask & CHIMERA_ACE_EXECUTE);
+            assert(!(c2->aces[i].access_mask & CHIMERA_ACE_WRITE_DATA));
+            found = 1;
+        }
+    }
+    assert(found);
+    TEST_PASS("named user preserved through canonical<->POSIX");
+} /* test_named_user_preserved */
+
+/*
+ * The POSIX mask must clamp a named group's effective permissions when the
+ * group is fed back into the canonical model.
+ */
+static void
+test_mask_clamps_group(void)
+{
+    ACL_BUF(c, MAXE);
+    struct chimera_posix_acl_entry pa[8];
+    uint32_t                       n;
+    int                            rc, found;
+
+    /* user::rwx, group::rwx (named 2001), mask::r--, other::--- :
+    * the group's effective perms are clamped to r by the mask. */
+    pa[0] = (struct chimera_posix_acl_entry) { CHIMERA_POSIX_ACL_USER_OBJ, 0x7, 1000 };
+    pa[1] = (struct chimera_posix_acl_entry) { CHIMERA_POSIX_ACL_GROUP_OBJ, 0x7, 2000 };
+    pa[2] = (struct chimera_posix_acl_entry) { CHIMERA_POSIX_ACL_GROUP, 0x7, 2001 };
+    pa[3] = (struct chimera_posix_acl_entry) { CHIMERA_POSIX_ACL_MASK, CHIMERA_POSIX_ACL_READ, 0 };
+    pa[4] = (struct chimera_posix_acl_entry) { CHIMERA_POSIX_ACL_OTHER, 0, 0 };
+    n     = 5;
+
+    rc = chimera_acl_from_posix(pa, n, NULL, 0, c, MAXE);
+    assert(rc >= 3);
+
+    found = 0;
+    for (int i = 0; i < c->num_aces; i++) {
+        if (c->aces[i].who.type == CHIMERA_PRINCIPAL_GROUP &&
+            c->aces[i].who.id == 2001) {
+            /* masked to read only: no write/execute granted. */
+            assert(c->aces[i].access_mask & CHIMERA_ACE_READ_DATA);
+            assert(!(c->aces[i].access_mask & CHIMERA_ACE_WRITE_DATA));
+            assert(!(c->aces[i].access_mask & CHIMERA_ACE_EXECUTE));
+            found = 1;
+        }
+    }
+    assert(found);
+    TEST_PASS("POSIX mask clamps named-group effective perms");
+} /* test_mask_clamps_group */
+
+/*
+ * A POSIX default ACL must map to inheritable canonical templates and project
+ * back to an equivalent default ACL.
+ */
+static void
+test_default_acl_roundtrip(void)
+{
+    ACL_BUF(c, MAXE);
+    struct chimera_posix_acl_entry        pa[4], pd_in[4], pa_out[MAXE], pd_out[MAXE];
+    uint32_t                              na = 0, nd = 0;
+    const struct chimera_posix_acl_entry *e;
+    int                                   rc, inheritable = 0;
+
+    /* Minimal access ACL + a default ACL granting rwx/r-x/r--. */
+    pa[0] = (struct chimera_posix_acl_entry) { CHIMERA_POSIX_ACL_USER_OBJ, 0x7, 1000 };
+    pa[1] = (struct chimera_posix_acl_entry) { CHIMERA_POSIX_ACL_GROUP_OBJ, 0x5, 2000 };
+    pa[2] = (struct chimera_posix_acl_entry) { CHIMERA_POSIX_ACL_OTHER, 0x4, 0 };
+
+    pd_in[0] = (struct chimera_posix_acl_entry) { CHIMERA_POSIX_ACL_USER_OBJ, 0x7, 1000 };
+    pd_in[1] = (struct chimera_posix_acl_entry) { CHIMERA_POSIX_ACL_GROUP_OBJ, 0x5, 2000 };
+    pd_in[2] = (struct chimera_posix_acl_entry) { CHIMERA_POSIX_ACL_OTHER, 0x4, 0 };
+
+    rc = chimera_acl_from_posix(pa, 3, pd_in, 3, c, MAXE);
+    assert(rc >= 3);
+
+    /* The canonical ACL must carry inheritable INHERIT_ONLY templates. */
+    for (int i = 0; i < c->num_aces; i++) {
+        if (c->aces[i].flags & CHIMERA_ACE_FLAG_INHERIT_ONLY) {
+            assert(c->aces[i].flags & CHIMERA_ACE_FLAG_FILE_INHERIT);
+            assert(c->aces[i].flags & CHIMERA_ACE_FLAG_DIR_INHERIT);
+            inheritable++;
+        }
+    }
+    assert(inheritable >= 3);
+
+    /* Project back as a directory: a default ACL must reappear. */
+    rc = chimera_acl_to_posix(c, 1000, 2000, 1, pa_out, MAXE, &na,
+                              pd_out, MAXE, &nd);
+    assert(rc == 0);
+    assert(nd >= 3);
+
+    e = find_entry(pd_out, nd, CHIMERA_POSIX_ACL_USER_OBJ, 0, 0);
+    assert(e && e->e_perm == 0x7);
+    e = find_entry(pd_out, nd, CHIMERA_POSIX_ACL_GROUP_OBJ, 0, 0);
+    assert(e && e->e_perm == 0x5);
+    e = find_entry(pd_out, nd, CHIMERA_POSIX_ACL_OTHER, 0, 0);
+    assert(e && e->e_perm == 0x4);
+
+    /* A non-directory projection must emit no default entries. */
+    na = nd = 0;
+    rc = chimera_acl_to_posix(c, 1000, 2000, 0, pa_out, MAXE, &na,
+                              pd_out, MAXE, &nd);
+    assert(rc == 0);
+    assert(nd == 0);
+
+    TEST_PASS("POSIX default ACL <-> inheritable canonical templates");
+} /* test_default_acl_roundtrip */
+
+/*
+ * USER_OBJ/GROUP_OBJ must carry the owner uid/gid in e_id (as Linux/Solaris
+ * encode them); MASK and OTHER carry 0.
+ */
+static void
+test_owner_ids_in_entries(void)
+{
+    ACL_BUF(c, MAXE);
+    struct chimera_posix_acl_entry        pa[MAXE], pd[MAXE];
+    uint32_t                              na = 0, nd = 0;
+    const struct chimera_posix_acl_entry *e;
+
+    chimera_acl_from_mode(0644, c, MAXE);
+    chimera_acl_to_posix(c, 4242, 5252, 0, pa, MAXE, &na, pd, MAXE, &nd);
+
+    e = find_entry(pa, na, CHIMERA_POSIX_ACL_USER_OBJ, 4242, 1);
+    assert(e != NULL);
+    e = find_entry(pa, na, CHIMERA_POSIX_ACL_GROUP_OBJ, 5252, 1);
+    assert(e != NULL);
+    e = find_entry(pa, na, CHIMERA_POSIX_ACL_OTHER, 0, 1);
+    assert(e != NULL);
+    TEST_PASS("owner/group ids encoded in USER_OBJ/GROUP_OBJ e_id");
+} /* test_owner_ids_in_entries */
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    fprintf(stderr, "vfs_acl_posix_test:\n");
+    test_mode_roundtrip_through_posix();
+    test_named_user_preserved();
+    test_mask_clamps_group();
+    test_default_acl_roundtrip();
+    test_owner_ids_in_entries();
+    fprintf(stderr, "All POSIX.1e ACL translation tests passed.\n");
+    return 0;
+} /* main */

--- a/src/vfs/vfs_acl_posix.c
+++ b/src/vfs/vfs_acl_posix.c
@@ -1,0 +1,399 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "vfs_acl_posix.h"
+#include "vfs_acl.h"
+#include "common/macros.h"
+
+/* Baseline / owner-extra bit sets, kept bit-identical to chimera_acl_from_mode
+ * (vfs_acl.c) so a mode-derived ACL round-trips and a named/default ALLOW ACE
+ * synthesised here grants the same metadata rights the special-who ACEs do. */
+#define ACE_BASELINE      (CHIMERA_ACE_READ_ATTRIBUTES | CHIMERA_ACE_READ_ACL)
+#define ACE_OWNER_EXTRA   (CHIMERA_ACE_WRITE_ATTRIBUTES | CHIMERA_ACE_WRITE_ACL | \
+                           CHIMERA_ACE_WRITE_OWNER | CHIMERA_ACE_READ_ACL)
+
+/* Inheritance flags carried by every default-ACL template ACE. */
+#define ACE_DEFAULT_FLAGS (CHIMERA_ACE_FLAG_INHERIT_ONLY | \
+                           CHIMERA_ACE_FLAG_FILE_INHERIT | \
+                           CHIMERA_ACE_FLAG_DIR_INHERIT)
+
+/* Expand POSIX rwx (3 bits) into a canonical access mask. */
+static inline uint32_t
+posix_perm_to_mask(uint16_t perm)
+{
+    uint32_t mask = 0;
+
+    if (perm & CHIMERA_POSIX_ACL_READ) {
+        mask |= CHIMERA_ACE_PERM_R;
+    }
+    if (perm & CHIMERA_POSIX_ACL_WRITE) {
+        mask |= CHIMERA_ACE_PERM_W;
+    }
+    if (perm & CHIMERA_POSIX_ACL_EXECUTE) {
+        mask |= CHIMERA_ACE_PERM_X;
+    }
+    return mask;
+} /* posix_perm_to_mask */
+
+/* Collapse a canonical access mask down to POSIX rwx (3 bits).  Mirrors the
+ * data-bit test used by chimera_acl_to_mode; metadata bits do not leak in. */
+static inline uint16_t
+mask_to_posix_perm(uint32_t mask)
+{
+    uint16_t perm = 0;
+
+    if (mask & CHIMERA_ACE_READ_DATA) {
+        perm |= CHIMERA_POSIX_ACL_READ;
+    }
+    if (mask & CHIMERA_ACE_WRITE_DATA) {
+        perm |= CHIMERA_POSIX_ACL_WRITE;
+    }
+    if (mask & CHIMERA_ACE_EXECUTE) {
+        perm |= CHIMERA_POSIX_ACL_EXECUTE;
+    }
+    return perm;
+} /* mask_to_posix_perm */
+
+/* True for an ACE that bears on the object itself (effective, not a pure
+ * inheritance template) and contributes to access. */
+static inline int
+ace_is_effective_allow(const struct chimera_ace *ace)
+{
+    return ace->type == CHIMERA_ACE_ALLOWED &&
+           !(ace->flags & CHIMERA_ACE_FLAG_INHERIT_ONLY);
+} /* ace_is_effective_allow */
+
+/* True for an inheritable ALLOW ACE (a default-ACL template entry). */
+static inline int
+ace_is_inheritable_allow(const struct chimera_ace *ace)
+{
+    return ace->type == CHIMERA_ACE_ALLOWED &&
+           (ace->flags & (CHIMERA_ACE_FLAG_FILE_INHERIT |
+                          CHIMERA_ACE_FLAG_DIR_INHERIT));
+} /* ace_is_inheritable_allow */
+
+SYMBOL_EXPORT int
+chimera_acl_to_posix(
+    const struct chimera_acl       *acl,
+    uint32_t                        owner_uid,
+    uint32_t                        owner_gid,
+    int                             is_dir,
+    struct chimera_posix_acl_entry *access,
+    unsigned                        access_max,
+    uint32_t                       *aclcnt,
+    struct chimera_posix_acl_entry *deflt,
+    unsigned                        deflt_max,
+    uint32_t                       *dfaclcnt)
+{
+    unsigned n     = 0;
+    unsigned named = 0;
+    uint32_t mode;
+    uint16_t group_class;
+
+#define EMIT(arr, max, idx, tag, perm, id) \
+        do { \
+            if ((idx) >= (max)) { return -1; } \
+            (arr)[idx].e_tag  = (tag); \
+            (arr)[idx].e_perm = (perm); \
+            (arr)[idx].e_id   = (id); \
+            (idx)++; \
+        } while (0)
+
+    /* ---- Access ACL ----------------------------------------------------- */
+    /* OWNER@/GROUP@/EVERYONE@ classes via the same deny-aware projection the
+     * mode path uses, so a mode-only ACL renders the canonical three entries. */
+    mode        = chimera_acl_to_mode(acl);
+    group_class = (mode >> 3) & 7; /* seed the mask with the group-obj perms */
+
+    EMIT(access, access_max, n, CHIMERA_POSIX_ACL_USER_OBJ,
+         (mode >> 6) & 7, owner_uid);
+
+    /* Named users: each USER-principal effective ALLOW ACE. */
+    if (acl) {
+        for (unsigned i = 0; i < acl->num_aces; i++) {
+            const struct chimera_ace *ace = &acl->aces[i];
+
+            if (!ace_is_effective_allow(ace) ||
+                ace->who.type != CHIMERA_PRINCIPAL_USER) {
+                continue;
+            }
+            EMIT(access, access_max, n, CHIMERA_POSIX_ACL_USER,
+                 mask_to_posix_perm(ace->access_mask), ace->who.id);
+            named++;
+        }
+    }
+
+    EMIT(access, access_max, n, CHIMERA_POSIX_ACL_GROUP_OBJ,
+         (mode >> 3) & 7, owner_gid);
+
+    /* Named groups. */
+    if (acl) {
+        for (unsigned i = 0; i < acl->num_aces; i++) {
+            const struct chimera_ace *ace = &acl->aces[i];
+            uint16_t                  perm;
+
+            if (!ace_is_effective_allow(ace) ||
+                ace->who.type != CHIMERA_PRINCIPAL_GROUP) {
+                continue;
+            }
+            perm         = mask_to_posix_perm(ace->access_mask);
+            group_class |= perm;
+            EMIT(access, access_max, n, CHIMERA_POSIX_ACL_GROUP, perm,
+                 ace->who.id);
+            named++;
+        }
+        /* Fold named-user perms into the mask (group class = everything but
+         * USER_OBJ and OTHER). */
+        for (unsigned i = 0; i < acl->num_aces; i++) {
+            const struct chimera_ace *ace = &acl->aces[i];
+
+            if (ace_is_effective_allow(ace) &&
+                ace->who.type == CHIMERA_PRINCIPAL_USER) {
+                group_class |= mask_to_posix_perm(ace->access_mask);
+            }
+        }
+    }
+
+    /* POSIX has (and the Linux client accepts) a mask entry only when named
+     * USER/GROUP entries exist; a minimal three-entry ACL must omit it (a lone
+     * mask makes the decoded POSIX ACL invalid on the client). */
+    if (named) {
+        EMIT(access, access_max, n, CHIMERA_POSIX_ACL_MASK, group_class, 0);
+    }
+    EMIT(access, access_max, n, CHIMERA_POSIX_ACL_OTHER, mode & 7, 0);
+
+    *aclcnt = n;
+
+    /* ---- Default ACL (directories only) --------------------------------- */
+    *dfaclcnt = 0;
+    if (is_dir && acl && deflt && deflt_max) {
+        unsigned dn       = 0;
+        unsigned dnamed   = 0;
+        int      have_def = 0;
+        uint16_t duo = 0, dgo = 0, dot = 0, dgroup_class = 0;
+
+        for (unsigned i = 0; i < acl->num_aces; i++) {
+            const struct chimera_ace *ace = &acl->aces[i];
+            uint16_t                  perm;
+
+            if (!ace_is_inheritable_allow(ace)) {
+                continue;
+            }
+            have_def = 1;
+            perm     = mask_to_posix_perm(ace->access_mask);
+
+            if (ace->who.type == CHIMERA_PRINCIPAL_SPECIAL) {
+                switch (ace->who.special) {
+                    case CHIMERA_WHO_CREATOR_OWNER:
+                    case CHIMERA_WHO_OWNER:
+                        duo = perm;
+                        break;
+                    case CHIMERA_WHO_CREATOR_GROUP:
+                    case CHIMERA_WHO_GROUP:
+                        dgo           = perm;
+                        dgroup_class |= perm;
+                        break;
+                    case CHIMERA_WHO_EVERYONE:
+                        dot = perm;
+                        break;
+                    default:
+                        break;
+                } /* switch */
+            } else {
+                dgroup_class |= perm;
+                dnamed++;
+            }
+        }
+
+        if (have_def) {
+            EMIT(deflt, deflt_max, dn, CHIMERA_POSIX_ACL_USER_OBJ, duo,
+                 owner_uid);
+
+            for (unsigned i = 0; i < acl->num_aces; i++) {
+                const struct chimera_ace *ace = &acl->aces[i];
+
+                if (ace_is_inheritable_allow(ace) &&
+                    ace->who.type == CHIMERA_PRINCIPAL_USER) {
+                    EMIT(deflt, deflt_max, dn, CHIMERA_POSIX_ACL_USER,
+                         mask_to_posix_perm(ace->access_mask), ace->who.id);
+                }
+            }
+
+            EMIT(deflt, deflt_max, dn, CHIMERA_POSIX_ACL_GROUP_OBJ, dgo,
+                 owner_gid);
+
+            for (unsigned i = 0; i < acl->num_aces; i++) {
+                const struct chimera_ace *ace = &acl->aces[i];
+
+                if (ace_is_inheritable_allow(ace) &&
+                    ace->who.type == CHIMERA_PRINCIPAL_GROUP) {
+                    EMIT(deflt, deflt_max, dn, CHIMERA_POSIX_ACL_GROUP,
+                         mask_to_posix_perm(ace->access_mask), ace->who.id);
+                }
+            }
+
+            if (dnamed) {
+                EMIT(deflt, deflt_max, dn, CHIMERA_POSIX_ACL_MASK,
+                     dgroup_class, 0);
+            }
+            EMIT(deflt, deflt_max, dn, CHIMERA_POSIX_ACL_OTHER, dot, 0);
+
+            *dfaclcnt = dn;
+        }
+    }
+#undef EMIT
+
+    return 0;
+} /* chimera_acl_to_posix */
+
+/* Parse the three base classes + mask out of a POSIX entry list. */
+static void
+posix_parse_base(
+    const struct chimera_posix_acl_entry *entries,
+    uint32_t                              count,
+    uint16_t                             *user_obj,
+    uint16_t                             *group_obj,
+    uint16_t                             *other,
+    uint16_t                             *mask,
+    int                                  *has_mask)
+{
+    *user_obj = *group_obj = *other = 0;
+    *mask     = 0x7;
+    *has_mask = 0;
+
+    for (uint32_t i = 0; i < count; i++) {
+        uint16_t tag  = entries[i].e_tag & ~CHIMERA_NFS_ACL_DEFAULT;
+        uint16_t perm = entries[i].e_perm & 0x7;
+
+        switch (tag) {
+            case CHIMERA_POSIX_ACL_USER_OBJ:
+                *user_obj = perm;
+                break;
+            case CHIMERA_POSIX_ACL_GROUP_OBJ:
+                *group_obj = perm;
+                break;
+            case CHIMERA_POSIX_ACL_OTHER:
+                *other = perm;
+                break;
+            case CHIMERA_POSIX_ACL_MASK:
+                *mask     = perm;
+                *has_mask = 1;
+                break;
+            default:
+                break;
+        } /* switch */
+    }
+} /* posix_parse_base */
+
+SYMBOL_EXPORT int
+chimera_acl_from_posix(
+    const struct chimera_posix_acl_entry *access,
+    uint32_t                              aclcnt,
+    const struct chimera_posix_acl_entry *deflt,
+    uint32_t                              dfaclcnt,
+    struct chimera_acl                   *out,
+    unsigned                              max_aces)
+{
+    uint16_t uo, go, ot, mask;
+    int      has_mask;
+    uint16_t eff_go;
+    uint32_t mode;
+    int      n;
+
+    posix_parse_base(access, aclcnt, &uo, &go, &ot, &mask, &has_mask);
+
+    /* The group-obj effective permission is the stored group-obj intersected
+     * with the mask (POSIX effective-perm semantics). */
+    eff_go = has_mask ? (go & mask) : go;
+    mode   = ((uint32_t) uo << 6) | ((uint32_t) eff_go << 3) | ot;
+
+    /* Special-who block, bit-identical to the mode path (idempotent round
+     * trip with chimera_acl_from_mode). */
+    n = chimera_acl_from_mode(mode, out, max_aces);
+    if (n < 0) {
+        return -1;
+    }
+
+#define APPEND(t, m, fl, ptype, pspecial, pid) \
+        do { \
+            if ((unsigned) n >= max_aces) { return -1; } \
+            out->aces[n].type        = (t); \
+            out->aces[n].flags       = (fl); \
+            out->aces[n].access_mask = (m); \
+            out->aces[n].who.type    = (ptype); \
+            out->aces[n].who.special = (pspecial); \
+            out->aces[n].who.id      = (pid); \
+            n++; \
+        } while (0)
+
+    /* Named access entries become ALLOW ACEs (perms masked).  DENY is not
+     * representable in POSIX, so there is nothing to drop here. */
+    for (uint32_t i = 0; i < aclcnt; i++) {
+        uint16_t tag  = access[i].e_tag & ~CHIMERA_NFS_ACL_DEFAULT;
+        uint16_t perm = access[i].e_perm & 0x7;
+
+        if (has_mask) {
+            perm &= mask;
+        }
+        if (tag == CHIMERA_POSIX_ACL_USER) {
+            APPEND(CHIMERA_ACE_ALLOWED,
+                   posix_perm_to_mask(perm) | ACE_BASELINE, 0,
+                   CHIMERA_PRINCIPAL_USER, 0, access[i].e_id);
+        } else if (tag == CHIMERA_POSIX_ACL_GROUP) {
+            APPEND(CHIMERA_ACE_ALLOWED,
+                   posix_perm_to_mask(perm) | ACE_BASELINE,
+                   CHIMERA_ACE_FLAG_IDENTIFIER_GROUP,
+                   CHIMERA_PRINCIPAL_GROUP, 0, access[i].e_id);
+        }
+    }
+
+    /* Default entries become INHERIT_ONLY templates carrying the placeholder
+    * CREATOR_OWNER/CREATOR_GROUP so a child resolves its own owner/group. */
+    if (dfaclcnt) {
+        uint16_t duo, dgo, dot, dmask;
+        int      has_dmask;
+        uint16_t deff_go;
+
+        posix_parse_base(deflt, dfaclcnt, &duo, &dgo, &dot, &dmask, &has_dmask);
+        deff_go = has_dmask ? (dgo & dmask) : dgo;
+
+        APPEND(CHIMERA_ACE_ALLOWED,
+               posix_perm_to_mask(duo) | ACE_BASELINE | ACE_OWNER_EXTRA,
+               ACE_DEFAULT_FLAGS, CHIMERA_PRINCIPAL_SPECIAL,
+               CHIMERA_WHO_CREATOR_OWNER, 0);
+        APPEND(CHIMERA_ACE_ALLOWED,
+               posix_perm_to_mask(deff_go) | ACE_BASELINE,
+               ACE_DEFAULT_FLAGS, CHIMERA_PRINCIPAL_SPECIAL,
+               CHIMERA_WHO_CREATOR_GROUP, 0);
+        APPEND(CHIMERA_ACE_ALLOWED,
+               posix_perm_to_mask(dot) | ACE_BASELINE,
+               ACE_DEFAULT_FLAGS, CHIMERA_PRINCIPAL_SPECIAL,
+               CHIMERA_WHO_EVERYONE, 0);
+
+        for (uint32_t i = 0; i < dfaclcnt; i++) {
+            uint16_t tag  = deflt[i].e_tag & ~CHIMERA_NFS_ACL_DEFAULT;
+            uint16_t perm = deflt[i].e_perm & 0x7;
+
+            if (has_dmask) {
+                perm &= dmask;
+            }
+            if (tag == CHIMERA_POSIX_ACL_USER) {
+                APPEND(CHIMERA_ACE_ALLOWED,
+                       posix_perm_to_mask(perm) | ACE_BASELINE,
+                       ACE_DEFAULT_FLAGS, CHIMERA_PRINCIPAL_USER, 0,
+                       deflt[i].e_id);
+            } else if (tag == CHIMERA_POSIX_ACL_GROUP) {
+                APPEND(CHIMERA_ACE_ALLOWED,
+                       posix_perm_to_mask(perm) | ACE_BASELINE,
+                       ACE_DEFAULT_FLAGS | CHIMERA_ACE_FLAG_IDENTIFIER_GROUP,
+                       CHIMERA_PRINCIPAL_GROUP, 0, deflt[i].e_id);
+            }
+        }
+    }
+#undef APPEND
+
+    out->num_aces   = n;
+    out->ctrl_flags = 0;
+    return n;
+} /* chimera_acl_from_posix */

--- a/src/vfs/vfs_acl_posix.h
+++ b/src/vfs/vfs_acl_posix.h
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#pragma once
+
+/*
+ * POSIX.1e draft ACL <-> canonical (NFSv4/NT) ACL translation.
+ *
+ * This is the bridge for the unofficial NFSv3 ACL sideband protocol (NFSACL,
+ * RPC program 100227), which carries Solaris/Linux POSIX.1e ACLs.  Chimera's
+ * single canonical model is the NFSv4/NT ACL (see vfs_acl.h); POSIX.1e is a
+ * deliberately LOSSY projection of it, never a peer:
+ *
+ *   - canonical -> POSIX (chimera_acl_to_posix): the OWNER@/GROUP@/EVERYONE@
+ *     classes are projected with the same deny-aware logic chimera_acl_to_mode
+ *     uses (so a mode-derived ACL round-trips exactly); named USER/GROUP ALLOW
+ *     ACEs become POSIX named entries; a synthetic ACL_MASK is computed as the
+ *     union of the group-class permissions.  Named DENY ACEs cannot be
+ *     represented in POSIX and are DROPPED.
+ *
+ *   - POSIX -> canonical (chimera_acl_from_posix): the three base classes are
+ *     rebuilt via chimera_acl_from_mode (bit-identical to the mode path, so a
+ *     SETACL of a previously GETACL'd ACL is idempotent); the ACL_MASK is folded
+ *     into the group-class effective permissions (POSIX effective-perm
+ *     semantics) since the canonical engine has no mask concept; named entries
+ *     become ALLOW ACEs; default entries become INHERIT_ONLY templates.
+ *
+ * Strict POSIX owner->user->group->mask->other precedence (which would require
+ * synthesising per-named DENY ACEs) is intentionally out of scope; named
+ * entries are emitted as ALLOW only.  See the comments in vfs_acl_posix.c.
+ */
+
+#include <stdint.h>
+
+struct chimera_acl;
+
+/* ---- POSIX.1e ACL entry tags (uapi/linux/posix_acl.h) ------------------- */
+#define CHIMERA_POSIX_ACL_USER_OBJ  0x0001
+#define CHIMERA_POSIX_ACL_USER      0x0002
+#define CHIMERA_POSIX_ACL_GROUP_OBJ 0x0004
+#define CHIMERA_POSIX_ACL_GROUP     0x0008
+#define CHIMERA_POSIX_ACL_MASK      0x0010
+#define CHIMERA_POSIX_ACL_OTHER     0x0020
+
+/* ---- POSIX.1e permission bits (== the S_IRWXO rwx bit values) ----------- */
+#define CHIMERA_POSIX_ACL_READ      0x04
+#define CHIMERA_POSIX_ACL_WRITE     0x02
+#define CHIMERA_POSIX_ACL_EXECUTE   0x01
+
+/* ---- NFSACL (prog 100227) protocol constants ---------------------------- */
+/* getacl/setacl mode flags (which ACL components the request/reply carries). */
+#define CHIMERA_NFS_ACL             0x0001 /* access ACL entries           */
+#define CHIMERA_NFS_ACLCNT          0x0002 /* access ACL entry count       */
+#define CHIMERA_NFS_DFACL           0x0004 /* default ACL entries          */
+#define CHIMERA_NFS_DFACLCNT        0x0008 /* default ACL entry count      */
+
+/* OR'd into the wire e_tag of every default-ACL entry (stripped on decode). */
+#define CHIMERA_NFS_ACL_DEFAULT     0x1000
+
+/* Protocol cap on entries in one ACL (matches CHIMERA_ACL_MAX_ACES). */
+#define CHIMERA_NFSACL_MAXENTRIES   1024
+
+/* One POSIX.1e ACL entry as it travels on the NFSACL wire: (tag, id, perm). */
+struct chimera_posix_acl_entry {
+    uint16_t e_tag;  /* CHIMERA_POSIX_ACL_* (without the DEFAULT wire flag)  */
+    uint16_t e_perm; /* CHIMERA_POSIX_ACL_READ|WRITE|EXECUTE                 */
+    uint32_t e_id;   /* uid for USER, gid for GROUP, owner for *_OBJ, else 0 */
+};
+
+/*
+ * Project a canonical ACL down to POSIX.1e access (and, for directories,
+ * default) entries.  `owner_uid`/`owner_gid` fill the e_id of the USER_OBJ /
+ * GROUP_OBJ entries (informational, as Linux/Solaris encode them).  Writes up
+ * to `access_max` / `deflt_max` entries and sets `*aclcnt` / `*dfaclcnt`.
+ * `deflt`/`dfaclcnt` are only populated when `is_dir`.  Returns 0 on success,
+ * -1 if an output array is too small.
+ */
+int chimera_acl_to_posix(
+    const struct chimera_acl       *acl,
+    uint32_t                        owner_uid,
+    uint32_t                        owner_gid,
+    int                             is_dir,
+    struct chimera_posix_acl_entry *access,
+    unsigned                        access_max,
+    uint32_t                       *aclcnt,
+    struct chimera_posix_acl_entry *deflt,
+    unsigned                        deflt_max,
+    uint32_t                       *dfaclcnt);
+
+/*
+ * Build a canonical ACL from POSIX.1e access + default entries.  The ACL_MASK
+ * is folded into the group-class effective permissions; default entries become
+ * INHERIT_ONLY|FILE_INHERIT|DIR_INHERIT templates.  Writes into `out` (caller
+ * provides storage for `max_aces` ACEs); returns the ACE count, or -1 on
+ * overflow / malformed input.
+ */
+int chimera_acl_from_posix(
+    const struct chimera_posix_acl_entry *access,
+    uint32_t                              aclcnt,
+    const struct chimera_posix_acl_entry *deflt,
+    uint32_t                              dfaclcnt,
+    struct chimera_acl                   *out,
+    unsigned                              max_aces);


### PR DESCRIPTION
## Summary

Adds the unofficial **NFSv3 ACL sideband protocol** (NFSACL, RPC program **100227 v3** — Sun/Solaris, supported by the Linux kernel for interop) to chimera, on **both the NFS server and the vfs_nfs client**, bridged to chimera's canonical NFSv4/NT ACL model through a new POSIX.1e translation layer.

The Linux kernel NFSv3 client auto-negotiates NFSACL when the server registers program 100227 (advertised via portmap, multiplexed on the NFS port), so `getfacl`/`setfacl`/`ls` work over NFSv3 against a chimera export.

## What's here

- **Translation layer** — `src/vfs/vfs_acl_posix.{c,h}`: `chimera_acl_to_posix` / `chimera_acl_from_posix`. Reuses the existing deny-aware `chimera_acl_to_mode`/`from_mode` for OWNER@/GROUP@/EVERYONE@ (mode round-trips bit-exact); named USER/GROUP map to ALLOW ACEs; default ACLs become `INHERIT_ONLY|FILE_INHERIT|DIR_INHERIT` templates.
- **XDR** — `src/nfs_common/nfsacl.x` (program 100227 v3), types prefixed `nacl_` to coexist with `nfs3_xdr.h`.
- **Server** — `nfs3_proc_getacl.c` / `nfs3_proc_setacl.c` + registration in `nfs.c`, `nfs_common.h`, `nfs_portmap.c`.
- **Client (vfs_nfs)** — `nfs3_getacl.c` / `nfs3_setacl.c` chained off getattr/setattr, with a per-server capability flag that falls back to mode-synthesis when the upstream doesn't speak NFSACL.

### POSIX.1e fidelity (by design)
POSIX.1e is a **documented-lossy** projection of the canonical NFSv4/NT model: named **DENY** ACEs are dropped, and the POSIX `mask::` is recomputed as the union of group-class perms (chimera stores effective perms; it has no mask concept).

## Verification

- **End-to-end against the real Linux kernel NFSv3 client** (`mount -t nfs vers=3`): `getfacl`, `setfacl -m u:1005:r-x` named-user round-trip (correct `mask::`), and `setfacl -d` default-ACL inheritance into a freshly created child.
- Unit test `vfs_acl_posix_test.c` (all-512-modes round-trip + named/mask/default).
- e2e `src/admin/tests/test_e2e_nfs_acl.py` (root + `acl` pkg; runs in CI).
- Debug + Release clean; `vfs` ctest 11/11; `make syntax` / reuse-lint / copyright / clang-analyze clean.

Three wire-format details were required for the kernel to accept replies: a **double count per ACL** (`xdr_decode_array2` length prefix *plus* an explicit `entries` word — they must match), the **reply mask must cover the request** (empty default ACL still echoes `NFS_DFACL` with a zero-length array), and **no lone `ACL_MASK`**.

## Gaps / parked for follow-up

> Draft — parking this here; the items below are deliberately deferred, not oversights.

1. **Strict POSIX precedence not synthesized.** Named entries are emitted ALLOW-only; no per-named DENY to enforce exact `owner→user→group→mask→other` precedence (a named user can be over-granted by a following GROUP@/EVERYONE@ ALLOW).
2. **Named DENY is a one-way loss** — a named DENY set via NFSv4/SMB is invisible over NFSACL and erased by a later SETACL.
3. **Mask is always recomputed**, so a client-set mask broader than any group-class entry isn't preserved (effective perms are).
4. **Client side is the speculative half.** Works, but adds a round-trip on ACL-bearing getattrs, bounds translated ACLs to `CHIMERA_NFS3_CLIENT_ACL_MAX` (256) before degrading to mode-synthesis, and uses optimistic-then-sticky capability probing with no re-probe.
5. **NFSACL v2 (NFSv2) not implemented** — v3 only.
6. **Count-only query** (`NFS_ACLCNT` without `NFS_ACL`) isn't separately supported; we always return entries when either bit is set (real clients always set both).
7. **`make check` not fully run in-sandbox**: KVM matrix and full `build_clang` (scan-build) pending; `clang --analyze` on the new TUs was clean. Wants a full CI pass before un-drafting.
8. **Default-ACL inheritance corner cases** (NO_PROPAGATE, mode-masking interactions) deserve more coverage.
