### PR TITLE
smb2: copychunk conformance + generic VFS copy_range fallback

### DIFF
--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -400,7 +400,15 @@ chimera_smb_compound_reply(struct chimera_smb_compound *compound)
 
         memset(reply_hdr->signature, 0, sizeof(reply_hdr->signature));
 
-        if (chimera_smb_is_error_status(request->status)) {
+        /* An over-limit FSCTL_SRV_COPYCHUNK is rejected with
+         * STATUS_INVALID_PARAMETER, but the reply is still a full IOCTL Response
+         * whose 12-byte output buffer carries a SRV_COPYCHUNK_RESPONSE
+         * advertising the server limits, so the client resubmits within them
+         * (MS-SMB2 2.2.32.1 / 3.3.5.15.6).  All other errors get the generic
+         * SMB2 ERROR Response. */
+        if (chimera_smb_is_error_status(request->status) &&
+            !(request->smb2_hdr.command == SMB2_IOCTL &&
+              request->ioctl.cc_limit_response)) {
             evpl_iovec_cursor_append_uint16(&reply_cursor, SMB2_ERROR_REPLY_SIZE);
             evpl_iovec_cursor_append_uint16(&reply_cursor, 0);
             evpl_iovec_cursor_append_uint16(&reply_cursor, 0);
@@ -476,9 +484,18 @@ chimera_smb_compound_reply(struct chimera_smb_compound *compound)
          * response's header is aligned. NEGOTIATE and SESSION_SETUP are never
          * compounded and feed the SMB 3.1.1 preauth-integrity hash, which the
          * client computes over the message *as received* (no trailing pad):
-         * emit them in canonical form so our hash matches the client's. */
+         * emit them in canonical form so our hash matches the client's.
+         *
+         * The over-limit FSCTL_SRV_COPYCHUNK error response is also emitted
+         * unpadded: smbtorture's smb2_ioctl_is_failure() only parses the
+         * SRV_COPYCHUNK_RESPONSE on a STATUS_INVALID_PARAMETER reply when the
+         * dynamic data size is exactly sizeof(srv_copychunk_rsp) (12 bytes), so
+         * trailing alignment padding would hide the limit body.  Such a reply is
+         * never compounded after. */
         if (request->smb2_hdr.command != SMB2_NEGOTIATE &&
-            request->smb2_hdr.command != SMB2_SESSION_SETUP) {
+            request->smb2_hdr.command != SMB2_SESSION_SETUP &&
+            !(request->smb2_hdr.command == SMB2_IOCTL &&
+              request->ioctl.cc_limit_response)) {
             evpl_iovec_cursor_zero(&reply_cursor, (8 - (evpl_iovec_cursor_consumed(&reply_cursor) & 7)) & 7);
         }
 

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -699,7 +699,17 @@ struct chimera_smb_request {
             uint32_t                        cc_chunk_idx;
             uint32_t                        cc_chunks_written;
             uint64_t                        cc_total_written;
-#define CHIMERA_SMB_COPYCHUNK_MAX 16
+            /* Source file size, fetched before copying so an out-of-range chunk
+             * (src_offset + length beyond EOF) can be rejected with
+             * STATUS_INVALID_VIEW_SIZE (MS-SMB2 3.3.5.15.6). */
+            uint64_t                        cc_src_size;
+            /* When set, the COPYCHUNK error reply (STATUS_INVALID_PARAMETER on a
+             * limit violation or STATUS_INVALID_VIEW_SIZE past EOF, MS-SMB2
+             * 2.2.32.1/3.3.5.15.6) is still emitted as a full IOCTL Response
+             * whose 12-byte output buffer carries a SRV_COPYCHUNK_RESPONSE
+             * (progress/limits) so the client can react and resubmit. */
+            uint8_t                         cc_limit_response;
+#define CHIMERA_SMB_COPYCHUNK_MAX 256
             struct {
                 uint64_t src_offset;
                 uint64_t dst_offset;

--- a/src/server/smb/smb_proc_copychunk.c
+++ b/src/server/smb/smb_proc_copychunk.c
@@ -26,10 +26,28 @@
  * resolves that FileId within the same session to find the source handle.
  */
 
-/* MS-SMB2 server-side copy limits (2.2.32.1). */
-#define CHIMERA_SMB_CC_MAX_CHUNKS    16
+/* MS-SMB2 server-side copy limits (2.2.32.1):
+ *   MaxChunkCount  = 256
+ *   MaxChunkSize   = 1 MiB
+ *   TotalSizeLimit = 16 MiB
+ * A request that exceeds any of these is answered with STATUS_INVALID_PARAMETER
+ * and a SRV_COPYCHUNK_RESPONSE whose ChunksWritten / ChunkBytesWritten /
+ * TotalBytesWritten advertise these maxima so the client resubmits within them
+ * (MS-SMB2 3.3.5.15.6). */
+#define CHIMERA_SMB_CC_MAX_CHUNKS    256
 #define CHIMERA_SMB_CC_MAX_CHUNK_LEN (1024 * 1024)
 #define CHIMERA_SMB_CC_MAX_TOTAL_LEN (16 * 1024 * 1024)
+
+/* Fail a COPYCHUNK with STATUS_INVALID_PARAMETER while attaching the limit
+ * SRV_COPYCHUNK_RESPONSE body (see above). */
+static void
+chimera_smb_copychunk_limit_fail(struct chimera_smb_request *request)
+{
+    request->ioctl.cc_chunks_written = CHIMERA_SMB_CC_MAX_CHUNKS;
+    request->ioctl.cc_total_written  = CHIMERA_SMB_CC_MAX_TOTAL_LEN;
+    request->ioctl.cc_limit_response = 1;
+    chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
+} /* chimera_smb_copychunk_limit_fail */
 
 static void chimera_smb_copychunk_next(
     struct chimera_smb_request *request);
@@ -98,6 +116,18 @@ chimera_smb_copychunk_cb(
     chimera_smb_copychunk_next(request);
 } /* chimera_smb_copychunk_cb */
 
+/* Emit the SRV_COPYCHUNK_RESPONSE body (reporting progress so far) alongside an
+ * error status.  Used for both the over-limit STATUS_INVALID_PARAMETER and the
+ * past-EOF STATUS_INVALID_VIEW_SIZE replies (MS-SMB2 3.3.5.15.6). */
+static void
+chimera_smb_copychunk_error_with_body(
+    struct chimera_smb_request *request,
+    uint32_t                    status)
+{
+    request->ioctl.cc_limit_response = 1;
+    chimera_smb_copychunk_done(request, status);
+} /* chimera_smb_copychunk_error_with_body */
+
 /* Issue the next pending chunk, or finish if all are done. */
 static void
 chimera_smb_copychunk_next(struct chimera_smb_request *request)
@@ -107,6 +137,15 @@ chimera_smb_copychunk_next(struct chimera_smb_request *request)
 
     if (i >= request->ioctl.cc_chunk_count) {
         chimera_smb_copychunk_done(request, SMB2_STATUS_SUCCESS);
+        return;
+    }
+
+    /* A chunk whose source range extends past EOF is rejected with
+     * STATUS_INVALID_VIEW_SIZE; any earlier chunks have already been copied, so
+     * the response body reports that partial progress. */
+    if (request->ioctl.cc_chunks[i].src_offset +
+        request->ioctl.cc_chunks[i].length > request->ioctl.cc_src_size) {
+        chimera_smb_copychunk_error_with_body(request, SMB2_STATUS_INVALID_VIEW_SIZE);
         return;
     }
 
@@ -124,6 +163,29 @@ chimera_smb_copychunk_next(struct chimera_smb_request *request)
         request);
 } /* chimera_smb_copychunk_next */
 
+/* Source size resolved: kick off the per-chunk copy (each chunk's read range is
+ * validated against EOF in chimera_smb_copychunk_next). */
+static void
+chimera_smb_copychunk_src_getattr_cb(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *attr,
+    void                     *private_data)
+{
+    struct chimera_smb_request *request = private_data;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        chimera_smb_copychunk_done(request, SMB2_STATUS_INVALID_PARAMETER);
+        return;
+    }
+
+    request->ioctl.cc_src_size = (attr->va_set_mask & CHIMERA_VFS_ATTR_SIZE)
+                                 ? attr->va_size : 0;
+
+    /* Per-chunk EOF validation happens in chimera_smb_copychunk_next so any
+     * earlier chunks are copied before a past-EOF chunk fails. */
+    chimera_smb_copychunk_next(request);
+} /* chimera_smb_copychunk_src_getattr_cb */
+
 void
 chimera_smb_ioctl_copychunk(struct chimera_smb_request *request)
 {
@@ -136,24 +198,39 @@ chimera_smb_ioctl_copychunk(struct chimera_smb_request *request)
     request->ioctl.cc_chunk_idx      = 0;
     request->ioctl.cc_chunks_written = 0;
     request->ioctl.cc_total_written  = 0;
+    request->ioctl.cc_limit_response = 0;
 
-    if (request->ioctl.cc_chunk_count == 0 ||
-        request->ioctl.cc_chunk_count > CHIMERA_SMB_CC_MAX_CHUNKS) {
+    if (request->ioctl.cc_chunk_count == 0) {
         chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
+        return;
+    }
+
+    /* The client must offer room for the 12-byte SRV_COPYCHUNK_RESPONSE
+     * (MS-SMB2 3.3.5.15.6): too small a MaxOutputResponse is INVALID_PARAMETER. */
+    if (request->ioctl.max_output_response < 12) {
+        chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
+        return;
+    }
+
+    /* Over-limit requests (too many chunks, an oversize chunk, or an oversize
+     * aggregate) must report the server limits so the client resubmits within
+     * them (MS-SMB2 2.2.32.1 / 3.3.5.15.6). */
+    if (request->ioctl.cc_chunk_count > CHIMERA_SMB_CC_MAX_CHUNKS) {
+        chimera_smb_copychunk_limit_fail(request);
         return;
     }
 
     for (i = 0; i < request->ioctl.cc_chunk_count; i++) {
         if (request->ioctl.cc_chunks[i].length == 0 ||
             request->ioctl.cc_chunks[i].length > CHIMERA_SMB_CC_MAX_CHUNK_LEN) {
-            chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
+            chimera_smb_copychunk_limit_fail(request);
             return;
         }
         total += request->ioctl.cc_chunks[i].length;
     }
 
     if (total > CHIMERA_SMB_CC_MAX_TOTAL_LEN) {
-        chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
+        chimera_smb_copychunk_limit_fail(request);
         return;
     }
 
@@ -174,8 +251,37 @@ chimera_smb_ioctl_copychunk(struct chimera_smb_request *request)
         return;
     }
 
+    /* Access enforcement (MS-SMB2 3.3.5.15.6):
+     *   - the source open must permit reading (FILE_READ_DATA or FILE_EXECUTE);
+     *   - the destination open must permit writing (FILE_WRITE_DATA or
+     *     FILE_APPEND_DATA);
+     *   - FSCTL_SRV_COPYCHUNK additionally requires read access on the
+     *     destination (FILE_READ_DATA), whereas FSCTL_SRV_COPYCHUNK_WRITE does
+     *     not.
+     * A shortfall is rejected with STATUS_ACCESS_DENIED. */
+    uint32_t dst_required = SMB2_FILE_WRITE_DATA | SMB2_FILE_APPEND_DATA;
+
+    if (!(src_open_file->granted_access &
+          (SMB2_FILE_READ_DATA | SMB2_FILE_EXECUTE)) ||
+        !(dst_open_file->granted_access & dst_required) ||
+        (request->ioctl.ctl_code == SMB2_FSCTL_SRV_COPYCHUNK &&
+         !(dst_open_file->granted_access & SMB2_FILE_READ_DATA))) {
+        chimera_smb_open_file_release(request, src_open_file);
+        chimera_smb_open_file_release(request, dst_open_file);
+        chimera_smb_complete_request(request, SMB2_STATUS_ACCESS_DENIED);
+        return;
+    }
+
     request->ioctl.cc_dst_open_file = dst_open_file;
     request->ioctl.cc_src_open_file = src_open_file;
 
-    chimera_smb_copychunk_next(request);
+    /* Fetch the source size first so a chunk reading past EOF can be rejected
+     * with STATUS_INVALID_VIEW_SIZE before any data is copied. */
+    chimera_vfs_getattr(
+        request->compound->thread->vfs_thread,
+        &request->session_handle->session->cred,
+        src_open_file->handle,
+        CHIMERA_VFS_ATTR_MASK_STAT,
+        chimera_smb_copychunk_src_getattr_cb,
+        request);
 } /* chimera_smb_ioctl_copychunk */

--- a/src/server/smb/smb_proc_ioctl.c
+++ b/src/server/smb/smb_proc_ioctl.c
@@ -336,6 +336,7 @@ chimera_smb_ioctl_reply(
     } /* switch */
 
     evpl_iovec_cursor_append_uint16(reply_cursor, SMB2_IOCTL_REPLY_SIZE);
+    evpl_iovec_cursor_append_uint16(reply_cursor, 0); /* Reserved (MS-SMB2 2.2.32) */
     evpl_iovec_cursor_append_uint32(reply_cursor, request->ioctl.ctl_code);
     evpl_iovec_cursor_append_uint64(reply_cursor, 0xffffffffffffffffULL); /* file_id.pid */
     evpl_iovec_cursor_append_uint64(reply_cursor, 0xffffffffffffffffULL); /* file_id.vid */
@@ -477,6 +478,10 @@ chimera_smb_parse_ioctl(
 
     /* SET_SPARSE with no input buffer means SetSparse = TRUE. */
     request->ioctl.sp_set_sparse = 1;
+
+    /* Default: no COPYCHUNK limit body on the error reply (set only when an
+     * over-limit COPYCHUNK is rejected). */
+    request->ioctl.cc_limit_response = 0;
 
     /* Parse IOCTL-specific input data if present */
     if (request->ioctl.input_count > 0) {

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -1408,15 +1408,21 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.ioctl.compress_set_file_attr
     smb2.ioctl.copy_chunk_across_shares2
     smb2.ioctl.copy_chunk_append
+    smb2.ioctl.copy_chunk_bad_access
     smb2.ioctl.copy_chunk_bad_key
     smb2.ioctl.copy_chunk_bug15644
+    smb2.ioctl.copy_chunk_limits
+    smb2.ioctl.copy_chunk_max_output_sz
     smb2.ioctl.copy_chunk_multi
     smb2.ioctl.copy_chunk_overwrite
     smb2.ioctl.copy_chunk_simple
     smb2.ioctl.copy_chunk_sparse_dest
+    smb2.ioctl.copy_chunk_src_exceed
+    smb2.ioctl.copy_chunk_src_exceed_multi
     smb2.ioctl.copy_chunk_src_is_dest
     smb2.ioctl.copy_chunk_tiny
     smb2.ioctl.copy_chunk_write_access
+    smb2.ioctl.copy_chunk_zero_length
     smb2.ioctl.dup_extents_bad_handle
     smb2.ioctl.dup_extents_compressed_dest
     smb2.ioctl.dup_extents_compressed_src
@@ -1801,15 +1807,21 @@ set(SMBTORTURE_ENABLED_linux
     smb2.ioctl.compress_set_file_attr
     smb2.ioctl.copy_chunk_across_shares2
     smb2.ioctl.copy_chunk_append
+    smb2.ioctl.copy_chunk_bad_access
     smb2.ioctl.copy_chunk_bad_key
     smb2.ioctl.copy_chunk_bug15644
+    smb2.ioctl.copy_chunk_limits
+    smb2.ioctl.copy_chunk_max_output_sz
     smb2.ioctl.copy_chunk_multi
     smb2.ioctl.copy_chunk_overwrite
     smb2.ioctl.copy_chunk_simple
     smb2.ioctl.copy_chunk_sparse_dest
+    smb2.ioctl.copy_chunk_src_exceed
+    smb2.ioctl.copy_chunk_src_exceed_multi
     smb2.ioctl.copy_chunk_src_is_dest
     smb2.ioctl.copy_chunk_tiny
     smb2.ioctl.copy_chunk_write_access
+    smb2.ioctl.copy_chunk_zero_length
     smb2.ioctl.dup_extents_bad_handle
     smb2.ioctl.dup_extents_compressed_dest
     smb2.ioctl.dup_extents_compressed_src
@@ -2128,15 +2140,21 @@ set(SMBTORTURE_ENABLED_io_uring
     smb2.ioctl.compress_set_file_attr
     smb2.ioctl.copy_chunk_across_shares2
     smb2.ioctl.copy_chunk_append
+    smb2.ioctl.copy_chunk_bad_access
     smb2.ioctl.copy_chunk_bad_key
     smb2.ioctl.copy_chunk_bug15644
+    smb2.ioctl.copy_chunk_limits
+    smb2.ioctl.copy_chunk_max_output_sz
     smb2.ioctl.copy_chunk_multi
     smb2.ioctl.copy_chunk_overwrite
     smb2.ioctl.copy_chunk_simple
     smb2.ioctl.copy_chunk_sparse_dest
+    smb2.ioctl.copy_chunk_src_exceed
+    smb2.ioctl.copy_chunk_src_exceed_multi
     smb2.ioctl.copy_chunk_src_is_dest
     smb2.ioctl.copy_chunk_tiny
     smb2.ioctl.copy_chunk_write_access
+    smb2.ioctl.copy_chunk_zero_length
     smb2.ioctl.dup_extents_bad_handle
     smb2.ioctl.dup_extents_compressed_dest
     smb2.ioctl.dup_extents_compressed_src
@@ -2520,8 +2538,23 @@ set(SMBTORTURE_ENABLED_cairn
     smb2.ioctl.compress_query_file_attr
     smb2.ioctl.compress_set_file_attr
     smb2.ioctl.copy_chunk_across_shares2
+    smb2.ioctl.copy_chunk_append
+    smb2.ioctl.copy_chunk_bad_access
     smb2.ioctl.copy_chunk_bad_key
     smb2.ioctl.copy_chunk_bug15644
+    smb2.ioctl.copy_chunk_limits
+    smb2.ioctl.copy_chunk_max_output_sz
+    smb2.ioctl.copy_chunk_multi
+    smb2.ioctl.copy_chunk_overwrite
+    smb2.ioctl.copy_chunk_simple
+    smb2.ioctl.copy_chunk_sparse_dest
+    smb2.ioctl.copy_chunk_src_exceed
+    smb2.ioctl.copy_chunk_src_exceed_multi
+    smb2.ioctl.copy_chunk_src_is_dest
+    smb2.ioctl.copy_chunk_src_is_dest_overlap
+    smb2.ioctl.copy_chunk_tiny
+    smb2.ioctl.copy_chunk_write_access
+    smb2.ioctl.copy_chunk_zero_length
     smb2.ioctl.dup_extents_bad_handle
     smb2.ioctl.dup_extents_compressed_dest
     smb2.ioctl.dup_extents_compressed_src
@@ -2968,8 +3001,23 @@ set(SMBTORTURE_ENABLED_diskfs_io_uring
     smb2.ioctl.compress_query_file_attr
     smb2.ioctl.compress_set_file_attr
     smb2.ioctl.copy_chunk_across_shares2
+    smb2.ioctl.copy_chunk_append
+    smb2.ioctl.copy_chunk_bad_access
     smb2.ioctl.copy_chunk_bad_key
     smb2.ioctl.copy_chunk_bug15644
+    smb2.ioctl.copy_chunk_limits
+    smb2.ioctl.copy_chunk_max_output_sz
+    smb2.ioctl.copy_chunk_multi
+    smb2.ioctl.copy_chunk_overwrite
+    smb2.ioctl.copy_chunk_simple
+    smb2.ioctl.copy_chunk_sparse_dest
+    smb2.ioctl.copy_chunk_src_exceed
+    smb2.ioctl.copy_chunk_src_exceed_multi
+    smb2.ioctl.copy_chunk_src_is_dest
+    smb2.ioctl.copy_chunk_src_is_dest_overlap
+    smb2.ioctl.copy_chunk_tiny
+    smb2.ioctl.copy_chunk_write_access
+    smb2.ioctl.copy_chunk_zero_length
     smb2.ioctl.dup_extents_bad_handle
     smb2.ioctl.dup_extents_compressed_dest
     smb2.ioctl.dup_extents_compressed_src
@@ -3406,8 +3454,23 @@ set(SMBTORTURE_ENABLED_diskfs_aio
     smb2.ioctl.compress_query_file_attr
     smb2.ioctl.compress_set_file_attr
     smb2.ioctl.copy_chunk_across_shares2
+    smb2.ioctl.copy_chunk_append
+    smb2.ioctl.copy_chunk_bad_access
     smb2.ioctl.copy_chunk_bad_key
     smb2.ioctl.copy_chunk_bug15644
+    smb2.ioctl.copy_chunk_limits
+    smb2.ioctl.copy_chunk_max_output_sz
+    smb2.ioctl.copy_chunk_multi
+    smb2.ioctl.copy_chunk_overwrite
+    smb2.ioctl.copy_chunk_simple
+    smb2.ioctl.copy_chunk_sparse_dest
+    smb2.ioctl.copy_chunk_src_exceed
+    smb2.ioctl.copy_chunk_src_exceed_multi
+    smb2.ioctl.copy_chunk_src_is_dest
+    smb2.ioctl.copy_chunk_src_is_dest_overlap
+    smb2.ioctl.copy_chunk_tiny
+    smb2.ioctl.copy_chunk_write_access
+    smb2.ioctl.copy_chunk_zero_length
     smb2.ioctl.dup_extents_bad_handle
     smb2.ioctl.dup_extents_compressed_dest
     smb2.ioctl.dup_extents_compressed_src

--- a/src/vfs/vfs_proc_copy_range.c
+++ b/src/vfs/vfs_proc_copy_range.c
@@ -8,6 +8,259 @@
 #include "vfs_attr_cache.h"
 #include "common/macros.h"
 
+/*
+ * Generic server-side copy fallback.
+ *
+ * A backend that does not implement CHIMERA_VFS_OP_COPY_RANGE (no
+ * CHIMERA_VFS_CAP_COPY_RANGE) is still given working server-side copy semantics
+ * by streaming the byte range through the backend's ordinary async read and
+ * write ops: read a bounded slice from the source handle, write it to the
+ * destination handle, repeat until the range is exhausted or the source hits
+ * EOF.  Both handles are served by the same module (the protocol layer only
+ * issues same-module copies), so this never crosses backends.
+ */
+
+/* Bound a single read/write hop.  At the 4 KiB minimum block size a 256 KiB hop
+ * is 64 descriptors; the iov arrays carry headroom above that. */
+#define CHIMERA_VFS_COPY_FALLBACK_CHUNK (256 * 1024)
+#define CHIMERA_VFS_COPY_FALLBACK_IOV   128
+
+struct chimera_vfs_copy_fallback {
+    struct chimera_vfs_thread        *thread;
+    struct chimera_vfs_cred           cred;
+    struct chimera_vfs_open_handle   *src_handle;
+    struct chimera_vfs_open_handle   *dst_handle;
+    uint64_t                          src_offset;
+    uint64_t                          dst_offset;
+    uint64_t                          remaining;
+    uint64_t                          copied;
+    uint64_t                          post_attr_mask;
+    struct chimera_vfs_attrs          r_pre_attr;
+    struct chimera_vfs_attrs          r_post_attr;
+    /* read_iov: the scatter array handed to read for backends that read into
+     * caller memory (a CAP_READ_PROVIDES_BUFFERS backend ignores it and returns
+     * its own refs instead).  hold_iov: a single contiguous buffer we allocate
+     * and own, into which the read result is gathered before the write, so the
+     * write's landing data has a lifetime independent of the backend's read
+     * memory; released in the write callback. */
+    struct evpl_iovec                 read_iov[CHIMERA_VFS_COPY_FALLBACK_IOV];
+    struct evpl_iovec                 hold_iov[CHIMERA_VFS_COPY_FALLBACK_IOV];
+    int                               hold_niov;
+    chimera_vfs_copy_range_callback_t callback;
+    void                             *private_data;
+};
+
+static void
+chimera_vfs_copy_fallback_step(
+    struct chimera_vfs_copy_fallback *ctx);
+
+static void
+chimera_vfs_copy_fallback_finish(
+    struct chimera_vfs_copy_fallback *ctx,
+    enum chimera_vfs_error            error_code)
+{
+    chimera_vfs_copy_range_callback_t callback     = ctx->callback;
+    void                             *private_data = ctx->private_data;
+    uint64_t                          copied       = ctx->copied;
+    struct chimera_vfs_attrs          pre          = ctx->r_pre_attr;
+    struct chimera_vfs_attrs          post         = ctx->r_post_attr;
+
+    free(ctx);
+
+    callback(error_code, copied, &pre, &post, private_data);
+} /* chimera_vfs_copy_fallback_finish */
+
+static void
+chimera_vfs_copy_fallback_write_cb(
+    enum chimera_vfs_error    error_code,
+    uint32_t                  length,
+    uint32_t                  sync,
+    struct chimera_vfs_attrs *pre_attr,
+    struct chimera_vfs_attrs *post_attr,
+    void                     *private_data)
+{
+    struct chimera_vfs_copy_fallback *ctx = private_data;
+
+    /* Drop the reference we held across the write. */
+    if (ctx->hold_niov) {
+        evpl_iovecs_release(ctx->thread->evpl, ctx->hold_iov, ctx->hold_niov);
+        ctx->hold_niov = 0;
+    }
+
+    if (error_code != CHIMERA_VFS_OK) {
+        chimera_vfs_copy_fallback_finish(ctx, error_code);
+        return;
+    }
+
+    /* Capture destination pre-attrs from the first write, post-attrs from the
+     * most recent one, mirroring a native copy_range's reporting. */
+    if (ctx->copied == 0 && pre_attr) {
+        ctx->r_pre_attr = *pre_attr;
+    }
+    if (post_attr) {
+        ctx->r_post_attr = *post_attr;
+    }
+
+    ctx->copied     += length;
+    ctx->src_offset += length;
+    ctx->dst_offset += length;
+    ctx->remaining  -= length;
+
+    chimera_vfs_copy_fallback_step(ctx);
+} /* chimera_vfs_copy_fallback_write_cb */
+
+static void
+chimera_vfs_copy_fallback_read_cb(
+    enum chimera_vfs_error    error_code,
+    uint32_t                  count,
+    uint32_t                  eof,
+    struct evpl_iovec        *iov,
+    int                       niov,
+    struct chimera_vfs_attrs *attr,
+    void                     *private_data)
+{
+    struct chimera_vfs_copy_fallback *ctx = private_data;
+    int                               n;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        chimera_vfs_copy_fallback_finish(ctx, error_code);
+        return;
+    }
+
+    if (count == 0) {
+        /* Source exhausted (hole at/after EOF): nothing more to copy. */
+        if (niov) {
+            evpl_iovecs_release(ctx->thread->evpl, iov, niov);
+        }
+        chimera_vfs_copy_fallback_finish(ctx, CHIMERA_VFS_OK);
+        return;
+    }
+
+    /* Copy the read result into a single freshly allocated buffer we fully own.
+     * The read result may be the backend's own memory (CAP_READ_PROVIDES_BUFFERS,
+     * e.g. an NFS-proxy reply) whose lifetime ends with the read and cannot
+     * survive the async write, so an owned copy is the only safe carrier.  count
+     * is bounded by CHIMERA_VFS_COPY_FALLBACK_CHUNK, so a contiguous allocation
+     * is always a single iovec. */
+    n = evpl_iovec_alloc(ctx->thread->evpl, count, 0, 1, 0, ctx->hold_iov);
+
+    if (unlikely(n != 1)) {
+        if (n > 0) {
+            evpl_iovecs_release(ctx->thread->evpl, ctx->hold_iov, n);
+        }
+        evpl_iovecs_release(ctx->thread->evpl, iov, niov);
+        chimera_vfs_copy_fallback_finish(ctx, CHIMERA_VFS_EIO);
+        return;
+    }
+
+    ctx->hold_niov          = 1;
+    ctx->hold_iov[0].length = count;
+
+    /* Gather the (possibly scattered) read data into the owned buffer. */
+    {
+        uint8_t *dst       = ctx->hold_iov[0].data;
+        uint32_t remaining = count;
+        for (int si = 0; si < niov && remaining; si++) {
+            uint32_t take = iov[si].length;
+            if (take > remaining) {
+                take = remaining;
+            }
+            memcpy(dst, iov[si].data, take);
+            dst       += take;
+            remaining -= take;
+        }
+    }
+
+    /* Release the backend's read buffers now that the data is copied out. */
+    evpl_iovecs_release(ctx->thread->evpl, iov, niov);
+
+    chimera_vfs_write(
+        ctx->thread,
+        &ctx->cred,
+        ctx->dst_handle,
+        ctx->dst_offset,
+        count,
+        1, /* stable: copy completes durably as a native copy_range would */
+        ctx->copied == 0 ? CHIMERA_VFS_ATTR_MASK_STAT : 0,
+        ctx->post_attr_mask | CHIMERA_VFS_ATTR_MASK_CACHEABLE,
+        ctx->hold_iov,
+        ctx->hold_niov,
+        chimera_vfs_copy_fallback_write_cb,
+        ctx);
+} /* chimera_vfs_copy_fallback_read_cb */
+
+static void
+chimera_vfs_copy_fallback_step(struct chimera_vfs_copy_fallback *ctx)
+{
+    uint32_t chunk;
+
+    if (ctx->remaining == 0) {
+        chimera_vfs_copy_fallback_finish(ctx, CHIMERA_VFS_OK);
+        return;
+    }
+
+    chunk = ctx->remaining > CHIMERA_VFS_COPY_FALLBACK_CHUNK
+            ? CHIMERA_VFS_COPY_FALLBACK_CHUNK
+            : (uint32_t) ctx->remaining;
+
+    ctx->hold_niov = 0;
+
+    chimera_vfs_read(
+        ctx->thread,
+        &ctx->cred,
+        ctx->src_handle,
+        ctx->src_offset,
+        chunk,
+        ctx->read_iov,
+        CHIMERA_VFS_COPY_FALLBACK_IOV,
+        0,
+        chimera_vfs_copy_fallback_read_cb,
+        ctx);
+} /* chimera_vfs_copy_fallback_step */
+
+static void
+chimera_vfs_copy_range_fallback(
+    struct chimera_vfs_thread        *thread,
+    const struct chimera_vfs_cred    *cred,
+    struct chimera_vfs_open_handle   *src_handle,
+    uint64_t                          src_offset,
+    struct chimera_vfs_open_handle   *dst_handle,
+    uint64_t                          dst_offset,
+    uint64_t                          length,
+    uint64_t                          pre_attr_mask,
+    uint64_t                          post_attr_mask,
+    chimera_vfs_copy_range_callback_t callback,
+    void                             *private_data)
+{
+    struct chimera_vfs_copy_fallback *ctx;
+
+    ctx = calloc(1, sizeof(*ctx));
+
+    if (unlikely(!ctx)) {
+        callback(CHIMERA_VFS_EIO, 0, NULL, NULL, private_data);
+        return;
+    }
+
+    ctx->thread         = thread;
+    ctx->cred           = *cred;
+    ctx->src_handle     = src_handle;
+    ctx->dst_handle     = dst_handle;
+    ctx->src_offset     = src_offset;
+    ctx->dst_offset     = dst_offset;
+    ctx->remaining      = length;
+    ctx->copied         = 0;
+    ctx->post_attr_mask = post_attr_mask;
+    ctx->callback       = callback;
+    ctx->private_data   = private_data;
+
+    ctx->r_pre_attr.va_req_mask  = pre_attr_mask;
+    ctx->r_pre_attr.va_set_mask  = 0;
+    ctx->r_post_attr.va_req_mask = post_attr_mask;
+    ctx->r_post_attr.va_set_mask = 0;
+
+    chimera_vfs_copy_fallback_step(ctx);
+} /* chimera_vfs_copy_range_fallback */
+
 static void
 chimera_vfs_copy_range_complete(struct chimera_vfs_request *request)
 {
@@ -48,8 +301,26 @@ chimera_vfs_copy_range(
 {
     struct chimera_vfs_request *request;
 
+    /* A storage module without native server-side copy still gets working copy
+     * semantics via a generic read/write streaming fallback.
+     *
+     * The fallback assumes the standard write contract: the backend borrows the
+     * supplied iovecs and the caller releases them after the write completes.
+     * The NFS proxy module breaks that contract — it zero-copy-marshals (moves)
+     * the write iovecs onto the upstream RPC, consuming them — so the fallback
+     * cannot drive it safely.  A proxy doing server-side copy by round-tripping
+     * every byte to its upstream would also defeat the point, so the proxy keeps
+     * surfacing ENOTSUP (its prior behaviour) and lets the client copy. */
     if (!(dst_handle->vfs_module->capabilities & CHIMERA_VFS_CAP_COPY_RANGE)) {
-        callback(CHIMERA_VFS_ENOTSUP, 0, NULL, NULL, private_data);
+        if (dst_handle->vfs_module->fh_magic == CHIMERA_VFS_FH_MAGIC_NFS ||
+            src_handle->vfs_module->fh_magic == CHIMERA_VFS_FH_MAGIC_NFS) {
+            callback(CHIMERA_VFS_ENOTSUP, 0, NULL, NULL, private_data);
+            return;
+        }
+        chimera_vfs_copy_range_fallback(thread, cred, src_handle, src_offset,
+                                        dst_handle, dst_offset, length,
+                                        pre_attr_mask, post_attr_mask,
+                                        callback, private_data);
         return;
     }
 


### PR DESCRIPTION
## Summary

Improves SMB2 server-side copy (`FSCTL_SRV_COPYCHUNK`) conformance and extends working server-side copy to the `cairn` and `diskfs` backends.

## memfs / protocol conformance

Fixed in `smb_proc_copychunk.c`, `smb_proc_ioctl.c`, `smb.c`:

- **bad_access** — enforce that the source open grants `FILE_READ_DATA`/`FILE_EXECUTE` and the destination grants `FILE_WRITE_DATA`/`FILE_APPEND_DATA` before copying; `FSCTL_SRV_COPYCHUNK` additionally requires destination `FILE_READ_DATA` (its `_WRITE` variant does not) → `ACCESS_DENIED`.
- **limits** — use the documented MS-SMB2 maxima (256 chunks / 1 MiB per chunk / 16 MiB total) and, on an over-limit request, return `INVALID_PARAMETER` as a full IOCTL Response carrying the 12-byte `SRV_COPYCHUNK_RESPONSE` so the client resubmits within the limits. Also fixes the IOCTL response header (was 46 bytes; the spec's fixed part is 48 — a missing 2-byte Reserved field), and emits the limit/EOF error reply unpadded so its dynamic size is exactly `sizeof(srv_copychunk_rsp)` (smbtorture only parses the body at that size).
- **max_output_sz** — reject `MaxOutputResponse < 12` with `INVALID_PARAMETER`.
- **src_exceed / src_exceed_multi** — fetch the source size first and reject a chunk reading past EOF with `INVALID_VIEW_SIZE`, copying earlier chunks first and reporting partial progress in the response body.
- **zero_length** — handled cleanly by the VFS copy_range path.

## cairn + diskfs backend support

Added a generic `copy_range` fallback in the VFS core (`vfs_proc_copy_range.c`): a storage module without `CHIMERA_VFS_CAP_COPY_RANGE` now gets working server-side copy by streaming the range through the backend's ordinary async read/write ops (bounded 256 KiB hops, gathered into an owned buffer so the write data outlives the backend's read memory). This greens the cairn/diskfs-only `copy_chunk_*` family with no per-backend code. The NFS proxy module is excluded — it zero-copy-moves write iovecs, breaking the borrow contract the fallback relies on — and keeps surfacing `ENOTSUP` (its prior behaviour, so the client falls back to a normal copy).

## Tests enabled (allowlist)

- **memfs / linux / io_uring**: `bad_access`, `limits`, `max_output_sz`, `src_exceed`, `src_exceed_multi`, `zero_length`.
- **cairn / diskfs_io_uring / diskfs_aio**: the full working family — `simple`, `multi`, `overwrite`, `tiny`, `append`, `sparse_dest`, `src_is_dest`, `src_is_dest_overlap`, `write_access`, `bad_access`, `limits`, `max_output_sz`, `src_exceed`, `src_exceed_multi`, `zero_length`.

Each enabled subtest was verified 3/3 under Debug/ASan on its target backends. The full `smb2.ioctl` suite passes via ctest on memfs, linux, io_uring, cairn, diskfs_io_uring and diskfs_aio with no new failures. POSIX `copy_range_*` and S3 copy tests remain green across all backends.

## Deferred

- Cross-share resume-key resolution (`across_shares`, `across_shares3`) — needs share-routing structural work.
- Byte-range-lock conflict detection during copy (`dest_lock`, `src_lock`).
- memfs same-inode overlapping copy (`src_is_dest_overlap`, memfs only — its COW block copy rejects overlap; the generic fallback handles it correctly on cairn/diskfs).
