### PR TITLE
kvm: integrate the Linux Test Project (LTP) suite

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -765,7 +765,7 @@ jobs:
       matrix:
         arch: [amd64, arm64]
         build_type: [Release, Debug]
-        category: [pynfs, smbtorture, wpts, posix-client, pjdfstest, s3, ceph-s3, client, unit, kvm-cthon, kvm-xfsprogs, kvm-pnfs, kvm-nfstest]
+        category: [pynfs, smbtorture, wpts, posix-client, pjdfstest, s3, ceph-s3, client, unit, kvm-cthon, kvm-xfsprogs, kvm-pnfs, kvm-nfstest, kvm-ltp]
         include:
           - { arch: amd64, runner: arc-amd64 }
           - { arch: arm64, runner: arc-arm64 }
@@ -775,6 +775,7 @@ jobs:
           - { arch: arm64, category: kvm-xfsprogs }
           - { arch: arm64, category: kvm-pnfs }
           - { arch: arm64, category: kvm-nfstest }
+          - { arch: arm64, category: kvm-ltp }
           # WPTS (Microsoft Protocol Test Suite) is not supported on arm64 —
           # the shard would only skip every test, so don't run it at all.
           - { arch: arm64, category: wpts }
@@ -830,6 +831,7 @@ jobs:
                 kvm-xfsprogs) SEL="-L kvm -R /xfstests/"; NEED_KVM=1 ;;
                 kvm-pnfs)     SEL="-L pnfs";              NEED_KVM=1 ;;
                 kvm-nfstest)  SEL="-L kvm -R /nfstest/";  NEED_KVM=1 ;;
+                kvm-ltp)      SEL="-L kvm -R /ltp/";      NEED_KVM=1 ;;
               esac
               if [ -n "$NEED_KVM" ]; then
                 ninja kvm_ubuntu2404_image kvm_ubuntu2404_hwe_image kvm_ubuntu2204_hwe_image

--- a/kvm/CMakeLists.txt
+++ b/kvm/CMakeLists.txt
@@ -16,10 +16,12 @@ get_filename_component(BUILD_ROOT ${CMAKE_BINARY_DIR} DIRECTORY)
 set(KVM_IMAGE_REGISTRY "ghcr.io/chimera-nas/kvm-test-base" CACHE STRING
     "OCI registry base that hosts the prebuilt KVM guest images.")
 # Pinned version of the prebuilt images to consume; bump to adopt a newer
-# kvm-test-base release.  v1.2.0 adds the Linux nfstest suite (used by the
-# nfstest tests in tests/CMakeLists.txt); v1.1.0 dropped the 22.04 generic
-# variant; v1.0.0 still has all four for older checkouts.
-set(KVM_IMAGE_VERSION "v1.2.0" CACHE STRING
+# kvm-test-base release.  v1.5.0 pares LTP to the non-duplicative slice and adds
+# the curated chimera_nfs42 runtest + an ltp-run.sh JSON-fallback; v1.4.0 added
+# the ubuntu2604 variant; v1.3.0 added the Linux Test Project (LTP) tree under
+# /opt/ltp{,-skip}; v1.2.0 added the Linux nfstest suite; v1.1.0 dropped the 22.04
+# generic variant (see the KVM_IMAGES note below); v1.0.0 still has all four.
+set(KVM_IMAGE_VERSION "v1.5.0" CACHE STRING
     "Version tag of the KVM guest images to consume.")
 
 # Note: the 22.04 generic (non-HWE) kernel does not build the virtio block

--- a/kvm/tests/CMakeLists.txt
+++ b/kvm/tests/CMakeLists.txt
@@ -184,6 +184,34 @@ set(XFSTESTS_CMD_nametest  "mkdir -p /mnt/test && cd /mnt/test && /opt/xfstests/
 set(XFSTESTS_CMD_fstest    "mkdir -p /mnt/test && /opt/xfstests/src/fstest -p /mnt/test -n 1 -f 2 -l 5 -s 65536")
 set(XFSTESTS_CMD_rewinddir "mkdir -p /mnt/test && /opt/xfstests/src/rewinddir-test /mnt/test")
 
+# Linux Test Project (LTP) scenario groups, run against the server-mounted share.
+# Matrix entries are "<group>|<space-separated NFS versions>"; <group> names a
+# runtest file shipped in the guest's /opt/ltp/runtest (>= kvm-test-base v1.5.0).
+# Each group has a companion /opt/ltp-skip/<group>.skip allowlist baked into the
+# image listing the cases that fail/break for reasons intrinsic to NFS, so any
+# remaining failure is a genuine server regression.
+#
+# Pared to the LTP coverage our other suites do NOT provide (an audit found the
+# bulk of LTP's fs/syscalls coverage duplicates pjdfstest, xfstests and cthon, or
+# isn't filesystem-related at all):
+#   dio             -- O_DIRECT / uncached I/O (our xfstests fsx runs buffered)
+#   fcntl-locktests -- POSIX byte-range locking via the real kernel client
+#   chimera_nfs42   -- NFSv4.2-only server ops (fallocate -> ALLOCATE/DEALLOCATE,
+#                      copy_file_range -> COPY/CLONE, statx); a curated runtest
+#                      generated in the guest image
+# All are fast, so they run on every backend in both Debug and Release.
+set(LTP_MATRIX
+    "dio|3 4.2"
+    "fcntl-locktests|3 4.0 4.1 4.2"
+    "chimera_nfs42|4.2"
+)
+
+# The guest's /opt/ltp-run.sh drives the group through kirk (the LTP runner) with
+# its skip file and turns the JSON report into a pass/fail exit code -- kirk's own
+# exit status ignores test failures, so the verdict is its stats.failed/broken.
+# The "<grp>" token is substituted per matrix entry below.
+set(LTP_CMD_TEMPLATE "/opt/ltp-run.sh <grp>")
+
 foreach(image_spec ${KVM_IMAGES})
     string(REPLACE "|" ";" image_parts "${image_spec}")
     list(GET image_parts 0 IMAGE_NAME)
@@ -377,6 +405,43 @@ foreach(image_spec ${KVM_IMAGES})
                         set_tests_properties(chimera/kvm/${IMAGE_NAME}/nfstest/${prog}_${backend}_nfs${nfsver}
                             PROPERTIES TIMEOUT 900)
                     endif()
+                endforeach()
+            endforeach()
+        endforeach()
+    endif()
+
+    # Linux Test Project (LTP) -- ubuntu2404 only.  Reuses the plain NFS wrapper:
+    # LTP runs against the pre-mounted share at /mnt exactly like cthon/xfstests,
+    # so it needs no dedicated wrapper.  See LTP_MATRIX above for the pared-down
+    # group selection (the non-duplicative slice).
+    if(IMAGE_NAME STREQUAL "ubuntu2404")
+        set(LTP_BACKENDS ${KVM_BACKENDS})
+        if(CAIRN_ENABLED)
+            list(APPEND LTP_BACKENDS cairn)
+        endif()
+        foreach(entry ${LTP_MATRIX})
+            string(REPLACE "|" ";" parts "${entry}")
+            list(GET parts 0 grp)
+            list(GET parts 1 vers_str)
+            string(REPLACE " " ";" vers "${vers_str}")
+            string(REPLACE "<grp>" "${grp}" ltp_cmd "${LTP_CMD_TEMPLATE}")
+            foreach(nfsver ${vers})
+                foreach(backend ${LTP_BACKENDS})
+                    # chimera_nfs42 exercises NFSv4.2 server allocation/copy ops;
+                    # run it on memfs + the diskfs backends (chimera's own
+                    # allocation paths) rather than the passthrough/cairn backends.
+                    if(grp STREQUAL "chimera_nfs42" AND
+                       NOT (backend STREQUAL "memfs" OR backend MATCHES "diskfs"))
+                        continue()
+                    endif()
+                    add_test(NAME chimera/kvm/${IMAGE_NAME}/ltp/${grp}_${backend}_nfs${nfsver}
+                        COMMAND bash ${NFS_WRAPPER}
+                                ${IMAGE_DIR}/vmlinuz ${IMAGE_DIR}/rootfs.qcow2
+                                ${CHIMERA_BINARY} ${backend} ${nfsver}
+                                "${ltp_cmd}")
+                    set_tests_properties(chimera/kvm/${IMAGE_NAME}/ltp/${grp}_${backend}_nfs${nfsver}
+                        PROPERTIES LABELS "kvm;${IMAGE_NAME}" PROCESSORS 2
+                                   TIMEOUT 600)
                 endforeach()
             endforeach()
         endforeach()


### PR DESCRIPTION
Wires the Linux Test Project (LTP) into the KVM ctest harness, run over NFS from the Linux guest like cthon/xfstests/nfstest.

### Approach
LTP runs against a server-mounted directory, so it reuses the existing `kvm_nfs_test_wrapper.sh` (which pre-mounts the share at `/mnt`) — no dedicated wrapper needed. The guest's `/opt/ltp-run.sh <group>` (shipped in the image) drives the group through **kirk** (LTP's runner; the old `runltp` was removed upstream) and turns its JSON report into a pass/fail exit code, since kirk's own exit status ignores test failures. A per-group skip file in the image is the allowlist for failures intrinsic to NFS.

### Matrix (102 tests, ubuntu2404 only — LTP is the heaviest suite)
- `fs`, `dio`, `fcntl-locktests`, `fs_perms_simple` × {3, 4.0, 4.1, 4.2} × all backends
- `syscalls` × {3, 4.2} × memfs + diskfs only (bounds CI wall-clock)
- Per-test `TIMEOUT` (1200s; 3600s for syscalls) overrides ctest's global `--timeout`.
- New `kvm-ltp` CI shard (`-L kvm -R /ltp/`, amd64-only).

### Depends on
The guest image **v1.3.0** (LTP + kirk + skip files): chimera-nas/kvm-test-base#3. This branch pins `KVM_IMAGE_VERSION=v1.3.0`, so the `kvm-ltp` shard can only pass once that image is published.

### Validation
Built v1.3.0 locally and ran over NFS (memfs, NFSv4.2): `fs_perms_simple` 18/18 · `fcntl-locktests` 1/1 · `dio` 106/106 · `fs` green with `fs_fill` allowlisted (needs an LTP scratch block device — meaningless over NFS). `syscalls` skip-seeding is in progress and will land as a follow-up to the image PR.