### PR TITLE
smb2: durable create_guid replay + pending-conflict FILE_NOT_AVAILABLE

### DIFF
--- a/src/server/smb/smb_durable.c
+++ b/src/server/smb/smb_durable.c
@@ -431,6 +431,97 @@ chimera_smb_durable_claim(
     return open_file;
 } /* chimera_smb_durable_claim */
 
+/*
+ * DH2Q create_guid replay lookup (MS-SMB2 3.3.5.9.10).
+ *
+ * A CREATE that carries a DurableHandleRequestV2 (DH2Q) plus the
+ * SMB2_FLAGS_REPLAY_OPERATION header flag is a replay of the original durable
+ * create whose reply the client lost.  The durable identity is the create_guid
+ * (unlike a DH2C/DHnC reconnect, which is keyed by persistent id), so we scan
+ * the (small) registry for a matching entry and classify the outcome:
+ *
+ *   CHIMERA_SMB_GUID_REPLAY_RECLAIM  - a *parked* (disconnected) durable open of
+ *       the same client matches: warm-reclaim it (clear parked) and return the
+ *       surviving open via *r_open_file for the caller to re-home, reporting the
+ *       ORIGINAL create_action.  (durable-reconnect-replay1, replay-twice-durable)
+ *
+ *   CHIMERA_SMB_GUID_REPLAY_DUPLICATE - a *live* durable open with this
+ *       create_guid exists on a DIFFERENT connection of the same client: the
+ *       replay collides with the still-open original and is rejected with
+ *       STATUS_DUPLICATE_OBJECTID.  (durable-reconnect-replay2)
+ *
+ *   CHIMERA_SMB_GUID_REPLAY_NONE     - no registry entry carries this guid (or
+ *       the only live match is the requesting connection's own open, handled by
+ *       the live open_files scan): the caller proceeds with a fresh create.
+ */
+SYMBOL_EXPORT enum chimera_smb_guid_replay_result
+chimera_smb_durable_claim_by_guid(
+    struct chimera_server_smb_shared *shared,
+    const uint8_t                    *create_guid,
+    const uint8_t                    *client_guid,
+    const struct chimera_smb_conn    *req_conn,
+    int                               is_replay,
+    struct chimera_smb_open_file    **r_open_file)
+{
+    struct chimera_smb_durable_entry   *entry, *tmp;
+    enum chimera_smb_guid_replay_result result = CHIMERA_SMB_GUID_REPLAY_NONE;
+
+    *r_open_file = NULL;
+
+    pthread_mutex_lock(&shared->durable.lock);
+
+    HASH_ITER(hh, shared->durable.by_pid, entry, tmp)
+    {
+        if (entry->cold || !entry->open_file) {
+            continue;
+        }
+        if (memcmp(entry->create_guid, create_guid, 16) != 0) {
+            continue;
+        }
+        if (client_guid &&
+            memcmp(entry->client_guid, client_guid, 16) != 0) {
+            continue;
+        }
+
+        if (entry->parked) {
+            if (entry->open_file->flags & CHIMERA_SMB_OPEN_FILE_YIELDED) {
+                /* The disconnected open's caching state was revoked to admit a
+                 * conflicting open; it is no longer reclaimable. */
+                continue;
+            }
+            if (!is_replay) {
+                /* A non-replay create whose create_guid matches a still-durable
+                 * (parked) open of this client collides with it. */
+                result = CHIMERA_SMB_GUID_REPLAY_DUPLICATE;
+                break;
+            }
+            entry->parked = false;
+            *r_open_file  = entry->open_file;
+            result        = CHIMERA_SMB_GUID_REPLAY_RECLAIM;
+            break;
+        }
+
+        /* Live durable open with this create_guid (the caller's live open_files
+         * scan already returned any replay-eligible same-tree open).
+         *   - A different connection's open: any create here collides
+         *     (DUPLICATE_OBJECTID): durable-reconnect-replay2.
+         *   - This connection's own open reached here only because it is NOT
+         *     replay-eligible (a non-replay op has used it) or the create is not
+         *     a replay.  A non-replay create collides (DUPLICATE_OBJECTID,
+         *     replay6 @5310); an ineligible replay is "ignored" and falls
+         *     through to a fresh open (replay-twice-durable, replay6 @5288). */
+        if (entry->open_file->create_conn != req_conn || !is_replay) {
+            result = CHIMERA_SMB_GUID_REPLAY_DUPLICATE;
+            break;
+        }
+        /* else: ineligible replay on our own live open -> NONE (fresh open). */
+    }
+
+    pthread_mutex_unlock(&shared->durable.lock);
+
+    return result;
+} /* chimera_smb_durable_claim_by_guid */
+
 void
 chimera_smb_durable_sweep(struct chimera_server_smb_thread *thread)
 {

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -1169,6 +1169,22 @@ chimera_smb_durable_claim(
     bool                             *r_cold,
     bool                             *r_retry,
     uint32_t                         *status);
+
+/* Classification of a DH2Q create_guid replay against the durable registry. */
+enum chimera_smb_guid_replay_result {
+    CHIMERA_SMB_GUID_REPLAY_NONE = 0,  /* no match -- proceed with a fresh create */
+    CHIMERA_SMB_GUID_REPLAY_RECLAIM,   /* parked open reclaimed -> *r_open_file */
+    CHIMERA_SMB_GUID_REPLAY_DUPLICATE, /* live open on another conn -> DUPLICATE_OBJECTID */
+};
+
+enum chimera_smb_guid_replay_result
+chimera_smb_durable_claim_by_guid(
+    struct chimera_server_smb_shared *shared,
+    const uint8_t                    *create_guid,
+    const uint8_t                    *client_guid,
+    const struct chimera_smb_conn    *req_conn,
+    int                               is_replay,
+    struct chimera_smb_open_file    **r_open_file);
 void
 chimera_smb_durable_sweep(
     struct chimera_server_smb_thread *thread);
@@ -2095,6 +2111,13 @@ chimera_smb_open_file_resolve(
     if (likely(open_file)) {
         if (likely(!(open_file->flags & CHIMERA_SMB_OPEN_FILE_CLOSED))) {
             open_file->refcnt++;
+            /* A non-replay request operating on a durable open ends its
+             * replay-eligibility window (MS-SMB2 3.3.5.9.10): a later replayed
+             * create that matches this handle is then treated as a normal open
+             * (smb2.replay.replay-twice-durable). */
+            if (!request->is_replay) {
+                open_file->flags &= ~CHIMERA_SMB_OPEN_FILE_REPLAY_ELIGIBLE;
+            }
         } else {
             open_file = NULL;
         }

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -276,9 +276,19 @@ chimera_smb_create_grant_durable(
         bool persistent = (request->create.dh2q.flags & SMB2_DHANDLE_FLAG_PERSISTENT) &&
             tree->share->continuous_availability;
 
+        /* Record the DH2Q create_guid and mark the open replay-eligible even
+         * when no durable handle is granted (e.g. the request took no
+         * batch/HANDLE-caching lease).  The replay machinery (MS-SMB2 3.3.5.9.10)
+         * keys on the create_guid the client supplied and on IsReplayEligible,
+         * not on whether a durable grant was made -- so a replayed create can be
+         * matched against a still-pending or still-eligible non-durable open
+         * (smb2.replay.dhv2-pending*-vs-* with a NONE oplock).  Eligibility is
+         * cleared by the first non-replay op on the handle. */
+        memcpy(open_file->create_guid, request->create.dh2q.create_guid, 16);
+        open_file->flags |= CHIMERA_SMB_OPEN_FILE_REPLAY_ELIGIBLE;
+
         if (has_caching || persistent) {
             open_file->durable_flags = CHIMERA_SMB_DURABLE_V2;
-            memcpy(open_file->create_guid, request->create.dh2q.create_guid, 16);
             if (persistent) {
                 open_file->durable_flags |= CHIMERA_SMB_DURABLE_PERSISTENT;
             }
@@ -1768,6 +1778,10 @@ chimera_smb_create_park_deadline_cb(
      * lease/durable decision if nothing else conflicts. */
     chimera_smb_create_resume_rearbitrate(request);
 
+    if (open_file) {
+        open_file->flags &= ~CHIMERA_SMB_OPEN_FILE_CREATE_PENDING;
+    }
+
     chimera_smb_open_file_release(request, open_file);
     /* complete_request retires the async-interim (unlink from parked_requests +
      * clear armed); the fired one-shot is already out of the timer heap so its
@@ -1849,6 +1863,15 @@ chimera_smb_create_open_finish(
             memcpy(request->create.park_fh, oh->fh, oh->fh_len);
             request->create.park_fh_len  = oh->fh_len;
             request->create.park_fh_hash = oh->fh_hash;
+            /* The CREATE is now pending on a break ack; mark the handle so a
+             * concurrent replayed DH2Q create with this create_guid is answered
+             * FILE_NOT_AVAILABLE instead of parking too (MS-SMB2 3.3.5.9.10,
+             * smb2.replay.dhv2-pending*).  Keyed on the DH2Q create_guid the
+             * client supplied -- recorded on the open even without a durable
+             * grant (so the NONE-oplock pending variants match too). */
+            if (request->create.ctx_present_mask & CHIMERA_SMB_CREATE_CTX_DH2Q) {
+                open_file->flags |= CHIMERA_SMB_OPEN_FILE_CREATE_PENDING;
+            }
             chimera_smb_async_interim_begin(request);
             /* Arm a deadline: if the holder never acks the break, fire at the
              * break timeout to revoke it and complete this open anyway (MS-SMB2
@@ -1997,6 +2020,10 @@ chimera_smb_create_resume_parked_conn(
          * holder vanished outright, lift the capped lease/durable decision
          * before the deferred reply is marshaled. */
         chimera_smb_create_resume_rearbitrate(req);
+        if (req->create.r_open_file) {
+            req->create.r_open_file->flags &=
+                ~CHIMERA_SMB_OPEN_FILE_CREATE_PENDING;
+        }
         chimera_smb_open_file_release(req, req->create.r_open_file);
         /* async_id is still set, so the final reply carries
          * SMB2_FLAGS_ASYNC_COMMAND matching the interim. */
@@ -2808,6 +2835,65 @@ chimera_smb_revalidate_tree(
 #define CHIMERA_SMB_DURABLE_RECONNECT_INTERVAL_US 20000  /* 20 ms */
 #define CHIMERA_SMB_DURABLE_RECONNECT_MAX_RETRIES 150    /* ~3 s total */
 
+/* Re-home a reclaimed (formerly parked) durable open into the reconnecting
+ * tree and emit the open reply via the create getattr callback.  Shared by the
+ * DH2C/DHnC reconnect path and the DH2Q create_guid replay-reclaim path.  When
+ * replay != 0 the reply echoes the ORIGINAL create_action (CREATED) instead of
+ * OPENED -- the replay re-presents the create that established the handle. */
+static void
+chimera_smb_durable_rehome(
+    struct chimera_smb_request   *request,
+    struct chimera_smb_open_file *open_file,
+    int                           replay)
+{
+    struct chimera_server_smb_thread *thread = request->compound->thread;
+    struct chimera_smb_tree          *tree   = request->tree;
+    int                               bucket;
+
+    /* The persistent id is unchanged; the volatile id is reissued (spec
+     * permits this).  The registry reference becomes the new tree reference; we
+     * add one more for this in-flight request, which the getattr callback
+     * releases below. */
+    open_file->flags &= ~CHIMERA_SMB_OPEN_FILE_PARKED;
+    /* A reclaimed durable open becomes replay-eligible again (MS-SMB2
+     * 3.3.5.9.10): a replayed create matching it reports the original
+     * create_action until the next non-replay op uses the handle. */
+    open_file->flags      |= CHIMERA_SMB_OPEN_FILE_REPLAY_ELIGIBLE;
+    open_file->create_conn = request->compound->conn;
+    open_file->file_id.vid = chimera_rand64();
+    open_file->refcnt      = 2;
+    /* Reseed the channel-sequence baseline from the reconnecting CREATE. */
+    open_file->channel_sequence       = request->channel_sequence;
+    open_file->channel_sequence_valid = 1;
+    /* No longer a courtesy-held disconnected holder. */
+    if (open_file->grant) {
+        open_file->grant->lease.parked = 0;
+    }
+    if (open_file->share_lease_inserted) {
+        open_file->share_lease.parked = 0;
+    }
+
+    bucket = open_file->file_id.vid & CHIMERA_SMB_OPEN_FILE_BUCKET_MASK;
+    pthread_mutex_lock(&tree->open_files_lock[bucket]);
+    HASH_ADD(hh, tree->open_files[bucket], file_id, sizeof(open_file->file_id), open_file);
+    pthread_mutex_unlock(&tree->open_files_lock[bucket]);
+
+    request->create.r_open_file        = open_file;
+    request->create.create_disposition = SMB2_FILE_OPEN; /* reply default OPENED */
+    request->create.reconnect          = 1; /* skip ACL re-check on the reply path */
+    request->create.replay             = replay; /* echo original create_action */
+    request->compound->saved_file_id   = open_file->file_id;
+
+    /* Refresh the network-open-info from the surviving handle, then reply.
+     * Reuses the normal create getattr callback (releases the request ref). */
+    chimera_vfs_getattr(thread->vfs_thread,
+                        &request->session_handle->session->cred,
+                        open_file->handle,
+                        CHIMERA_VFS_ATTR_MASK_STAT,
+                        chimera_smb_create_open_getattr_callback,
+                        request);
+} /* chimera_smb_durable_rehome */
+
 /* One durable-reclaim attempt.  Returns true if the request has been completed
  * or handed off (cold reopen / success reply / terminal failure); false if the
  * handle is still racing its previous connection's disconnect and the caller
@@ -2817,7 +2903,6 @@ chimera_smb_durable_reconnect_attempt(struct chimera_smb_request *request)
 {
     struct chimera_server_smb_thread *thread = request->compound->thread;
     struct chimera_server_smb_shared *shared = thread->shared;
-    struct chimera_smb_tree          *tree   = request->tree;
     struct chimera_smb_open_file     *open_file;
     const uint8_t                    *create_guid = NULL;
     const uint8_t                    *lease_key   = NULL;
@@ -2827,7 +2912,6 @@ chimera_smb_durable_reconnect_attempt(struct chimera_smb_request *request)
     bool                              has_lease_ctx;
     bool                              cold  = false;
     bool                              retry = false;
-    int                               bucket;
 
     if (ctx & CHIMERA_SMB_CREATE_CTX_DH2C) {
         persistent_id = request->create.dh2c.persistent;
@@ -2866,43 +2950,11 @@ chimera_smb_durable_reconnect_attempt(struct chimera_smb_request *request)
         return true;
     }
 
-    /* Re-home the surviving open into the reconnecting tree.  The persistent
-     * id is unchanged; the volatile id is reissued (spec permits this).  The
-     * registry reference becomes the new tree reference; we add one more for
-     * this in-flight request, which the getattr callback releases below. */
-    open_file->flags      &= ~CHIMERA_SMB_OPEN_FILE_PARKED;
-    open_file->create_conn = request->compound->conn;
-    open_file->file_id.vid = chimera_rand64();
-    open_file->refcnt      = 2;
-    /* Reseed the channel-sequence baseline from the reconnecting CREATE. */
-    open_file->channel_sequence       = request->channel_sequence;
-    open_file->channel_sequence_valid = 1;
-    /* No longer a courtesy-held disconnected holder. */
-    if (open_file->grant) {
-        open_file->grant->lease.parked = 0;
-    }
-    if (open_file->share_lease_inserted) {
-        open_file->share_lease.parked = 0;
-    }
-
-    bucket = open_file->file_id.vid & CHIMERA_SMB_OPEN_FILE_BUCKET_MASK;
-    pthread_mutex_lock(&tree->open_files_lock[bucket]);
-    HASH_ADD(hh, tree->open_files[bucket], file_id, sizeof(open_file->file_id), open_file);
-    pthread_mutex_unlock(&tree->open_files_lock[bucket]);
-
-    request->create.r_open_file        = open_file;
-    request->create.create_disposition = SMB2_FILE_OPEN; /* reply emits OPENED */
-    request->create.reconnect          = 1; /* skip ACL re-check on the reply path */
-    request->compound->saved_file_id   = open_file->file_id;
-
-    /* Refresh the network-open-info from the surviving handle, then reply.
-     * Reuses the normal create getattr callback (releases the request ref). */
-    chimera_vfs_getattr(thread->vfs_thread,
-                        &request->session_handle->session->cred,
-                        open_file->handle,
-                        CHIMERA_VFS_ATTR_MASK_STAT,
-                        chimera_smb_create_open_getattr_callback,
-                        request);
+    /* Re-home the surviving open into the reconnecting tree.  A pure DH2C/DHnC
+     * reconnect reports OPENED; if the reconnect ALSO carries the replay flag
+     * (the client lost the original create's reply), report the original
+     * create_action instead. */
+    chimera_smb_durable_rehome(request, open_file, request->is_replay);
     return true;
 } /* chimera_smb_durable_reconnect_attempt */
 
@@ -3104,14 +3156,38 @@ chimera_smb_create_guid_replay(struct chimera_smb_request *request)
     struct chimera_server_smb_thread *thread = request->compound->thread;
     int                               b;
     bool                              req_is_lease, open_is_lease;
+    bool                              pending_match = false;
 
-    for (b = 0; b < CHIMERA_SMB_OPEN_FILE_BUCKETS && !match; b++) {
+    for (b = 0; b < CHIMERA_SMB_OPEN_FILE_BUCKETS && !match && !pending_match; b++) {
         pthread_mutex_lock(&tree->open_files_lock[b]);
         HASH_ITER(hh, tree->open_files[b], of, tmp)
         {
+            /* A replayed durable create whose create_guid matches an open whose
+             * own CREATE is still pending on a break ack must be answered
+             * FILE_NOT_AVAILABLE (MS-SMB2 3.3.5.9.10): the original create has
+             * not completed, so we neither return its (not-yet-final) handle nor
+             * park a second time.  The pending open's ctx_present_mask is not yet
+             * populated (set on reply), so match on the durable create_guid that
+             * grant_durable already stored.  smb2.replay.dhv2-pending*. */
+            if (request->is_replay &&
+                (of->flags & CHIMERA_SMB_OPEN_FILE_CREATE_PENDING) &&
+                memcmp(of->create_guid, request->create.dh2q.create_guid, 16) == 0) {
+                pending_match = true;
+                break;
+            }
+
             if ((of->ctx_present_mask & CHIMERA_SMB_CREATE_CTX_DH2Q) &&
                 !(of->flags & (CHIMERA_SMB_OPEN_FILE_CLOSED |
                                CHIMERA_SMB_OPEN_FILE_PARKED)) &&
+                /* Only a replayed create returns the existing live open, and only
+                 * while it remains replay-eligible.  A non-replay create with a
+                 * matching create_guid, or a replay after a non-replay op cleared
+                 * eligibility, is NOT returned here (MS-SMB2 3.3.5.9.10): it falls
+                 * to the registry classification below (DUPLICATE_OBJECTID for a
+                 * non-replay collision, or a fresh open for an ineligible replay).
+                 * smb2.replay.replay-twice-durable, replay6. */
+                request->is_replay &&
+                (of->flags & CHIMERA_SMB_OPEN_FILE_REPLAY_ELIGIBLE) &&
                 memcmp(of->create_guid, request->create.dh2q.create_guid, 16) == 0) {
                 of->refcnt++;   /* held for this request; getattr cb releases it */
                 match = of;
@@ -3121,7 +3197,43 @@ chimera_smb_create_guid_replay(struct chimera_smb_request *request)
         pthread_mutex_unlock(&tree->open_files_lock[b]);
     }
 
+    if (pending_match) {
+        chimera_smb_complete_request(request, SMB2_STATUS_FILE_NOT_AVAILABLE);
+        return 1;
+    }
+
     if (!match) {
+        /* No live open in this tree returned the existing handle.  Consult the
+         * durable registry to classify the create_guid against ALL of this
+         * client's durable opens (parked or live on any connection), per
+         * MS-SMB2 3.3.5.9.10.  This covers: a replay reclaiming a parked open
+         * (durable-reconnect-replay1, replay-twice-durable); a collision with a
+         * still-live durable open -> DUPLICATE_OBJECTID (durable-reconnect-replay2,
+         * replay6); and an ineligible replay that falls through to a fresh open
+         * (replay-twice-durable, replay6). */
+        if (request->compound->thread->shared->config.persistent_handles) {
+            struct chimera_smb_open_file       *parked = NULL;
+            enum chimera_smb_guid_replay_result gr     =
+                chimera_smb_durable_claim_by_guid(
+                    request->compound->thread->shared,
+                    request->create.dh2q.create_guid,
+                    request->compound->conn->client_guid,
+                    request->compound->conn,
+                    request->is_replay,
+                    &parked);
+
+            switch (gr) {
+                case CHIMERA_SMB_GUID_REPLAY_RECLAIM:
+                    chimera_smb_durable_rehome(request, parked, /* replay */ 1);
+                    return 1;
+                case CHIMERA_SMB_GUID_REPLAY_DUPLICATE:
+                    chimera_smb_complete_request(request,
+                                                 SMB2_STATUS_DUPLICATE_OBJECTID);
+                    return 1;
+                case CHIMERA_SMB_GUID_REPLAY_NONE:
+                    break;
+            } /* switch */
+        }
         return 0;
     }
 

--- a/src/server/smb/smb_session.h
+++ b/src/server/smb/smb_session.h
@@ -53,6 +53,21 @@ struct chimera_smb_file_id {
  * instead, this flag makes a later durable reconnect fail with
  * OBJECT_NAME_NOT_FOUND and leaves the carcass to the grace-timer sweep. */
 #define CHIMERA_SMB_OPEN_FILE_YIELDED              0x00000080
+/* This durable open is still eligible to be returned by a DH2Q create_guid
+ * replay (MS-SMB2 3.3.5.9.10 Open.IsReplayEligible).  Set when the durable open
+ * is granted or reclaimed; cleared the first time a non-replay request operates
+ * on the handle.  Once cleared, a replayed create that matches the live open is
+ * "ignored" and handled as a normal open (reports EXISTED, not the original
+ * CREATED): smb2.replay.replay-twice-durable. */
+#define CHIMERA_SMB_OPEN_FILE_REPLAY_ELIGIBLE      0x00000100
+/* This open's CREATE is still in flight: it parked waiting for a conflicting
+ * holder to acknowledge a lease/oplock break (MS-SMB2 3.3.5.9 pending open).
+ * The handle is already in the tree (so its durable create_guid is visible) but
+ * the open has not completed.  A replayed durable create whose create_guid
+ * matches a still-pending open must be answered STATUS_FILE_NOT_AVAILABLE
+ * rather than parking a second time and timing out (MS-SMB2 3.3.5.9.10):
+ * smb2.replay.dhv2-pending*. Cleared on resume / break-deadline. */
+#define CHIMERA_SMB_OPEN_FILE_CREATE_PENDING       0x00000200
 
 /* Bits identifying which CREATE contexts a client supplied on the open. Mirrored
  * from request->create.ctx_present_mask into the open file so later phases

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -1572,6 +1572,15 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.rename.simple_nodelete
     # smb2.replay
     smb2.replay.channel-sequence
+    smb2.replay.dhv2-pending1l-vs-lease-sane
+    smb2.replay.dhv2-pending1l-vs-oplock-sane
+    smb2.replay.dhv2-pending1n-vs-lease-sane
+    smb2.replay.dhv2-pending1n-vs-oplock-sane
+    smb2.replay.dhv2-pending1o-vs-lease-sane
+    smb2.replay.dhv2-pending1o-vs-oplock-sane
+    smb2.replay.durable-reconnect-replay1
+    smb2.replay.durable-reconnect-replay2
+    smb2.replay.durable-reconnect-replay3
     smb2.replay.replay-commands
     smb2.replay.replay-dhv2-lease-oplock
     smb2.replay.replay-dhv2-lease1
@@ -1580,7 +1589,9 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.replay.replay-dhv2-oplock-lease
     smb2.replay.replay-dhv2-oplock1
     smb2.replay.replay-regular
+    smb2.replay.replay-twice-durable
     smb2.replay.replay5
+    smb2.replay.replay6
     smb2.replay.replay7
     # smb2.rw
     smb2.rw.append
@@ -3124,6 +3135,15 @@ set(SMBTORTURE_ENABLED_diskfs_io_uring
     smb2.rename.simple_nodelete
     # smb2.replay
     smb2.replay.channel-sequence
+    smb2.replay.dhv2-pending1l-vs-lease-sane
+    smb2.replay.dhv2-pending1l-vs-oplock-sane
+    smb2.replay.dhv2-pending1n-vs-lease-sane
+    smb2.replay.dhv2-pending1n-vs-oplock-sane
+    smb2.replay.dhv2-pending1o-vs-lease-sane
+    smb2.replay.dhv2-pending1o-vs-oplock-sane
+    smb2.replay.durable-reconnect-replay1
+    smb2.replay.durable-reconnect-replay2
+    smb2.replay.durable-reconnect-replay3
     smb2.replay.replay-commands
     smb2.replay.replay-dhv2-lease-oplock
     smb2.replay.replay-dhv2-lease1
@@ -3132,7 +3152,9 @@ set(SMBTORTURE_ENABLED_diskfs_io_uring
     smb2.replay.replay-dhv2-oplock-lease
     smb2.replay.replay-dhv2-oplock1
     smb2.replay.replay-regular
+    smb2.replay.replay-twice-durable
     smb2.replay.replay5
+    smb2.replay.replay6
     smb2.replay.replay7
     # smb2.rw
     smb2.rw.append


### PR DESCRIPTION
## What this implements

The SMB2 `smb2.replay` durable-handle replay-detection state machine
(MS-SMB2 3.3.5.9.10), so a replayed CREATE (carrying
`SMB2_FLAGS_REPLAY_OPERATION`) is reconciled against the original durable
create instead of being re-executed as a fresh open.

### Mechanism

A DH2Q `create_guid` is now classified against this client's durable opens:

- **Parked-open reclaim** — a replay whose `create_guid` matches a *parked*
  (disconnected) durable open reclaims and re-homes it, reporting the
  **original** create_action (CREATED), not OPENED. Re-home is factored into a
  shared `chimera_smb_durable_rehome()` helper used by both the DH2C/DHnC
  reconnect path and the replay-reclaim path.
- **Live eligible match** — a replay matching a still-replay-eligible live open
  returns the existing handle (the prior live-open scan, now gated on the new
  `Open.IsReplayEligible` bit).
- **DUPLICATE_OBJECTID** — a `create_guid` colliding with a still-live durable
  open on another connection, or any **non-replay** create colliding with a live
  durable open, is rejected `STATUS_DUPLICATE_OBJECTID`.
- **Ignored replay** — a replay whose matching open is no longer replay-eligible
  (a non-replay op has since used the handle) falls through to a normal open
  (EXISTED).

`Open.IsReplayEligible` is modeled as `CHIMERA_SMB_OPEN_FILE_REPLAY_ELIGIBLE`:
set when a DH2Q open is granted or reclaimed, cleared the first time a
non-replay request resolves the handle.

### Pending-conflict status

A replayed durable create whose `create_guid` matches an open whose own CREATE
is still parked on a lease/oplock break ack now returns
`STATUS_FILE_NOT_AVAILABLE` immediately (`CHIMERA_SMB_OPEN_FILE_CREATE_PENDING`)
instead of parking a second time and timing out (`IO_TIMEOUT`). The DH2Q
`create_guid` is recorded on the open even without a durable grant so the
NONE-oplock pending variants match.

## Tests enabled (memfs + diskfs_io_uring)

Verified 3x green on both backends, zero regressions across the enabled
`smb2.replay` / `smb2.durable-open` / `smb2.durable-v2-open` / `smb2.lease` /
`smb2.oplock` suites and the durable disconnect-race ctests
(`CHIMERA_SMB_TEST_DISCONNECT_DELAY_MS`):

- `smb2.replay.dhv2-pending1{l,n,o}-vs-{lease,oplock}-sane` (6)
- `smb2.replay.durable-reconnect-replay{1,2,3}` (3)
- `smb2.replay.replay-twice-durable`
- `smb2.replay.replay6`

## What remains (follow-up)

- **`*-windows` pending variants** — parameterized to expect the *opposite*
  status (`ACCESS_DENIED`) to the `-sane` variants; only one of each pair can
  pass on a given server, and chimera follows the Samba/`-sane` behavior, so the
  `-windows` cases cannot pass without behaving like Windows.
- **`dhv2-pending2`/`dhv2-pending3`** — multichannel session-level replay (replay
  arrives on a different channel of the same session after the original channel
  disconnects); needs session-scoped pending-create tracking and cross-channel
  create replay.
- **`*-vs-violation` and `replay-dhv2-oplock2/3`** — depend on a separate,
  pre-existing gap: a share-access-conflicting open not triggering the holder's
  oplock/lease break (`break_info.count` stays 0). Orthogonal to replay.
