### PR TITLE
nfs4 client: fix OPEN access evaluation (owner/group attrs) and O_NOFOLLOW symlink ELOOP

### DIFF
--- a/src/vfs/nfs/nfs4_lookup_at.c
+++ b/src/vfs/nfs/nfs4_lookup_at.c
@@ -212,10 +212,14 @@ chimera_nfs4_lookup_at(
         args.num_argarray = 5;
     }
 
-    /* GETATTR for the resolved object */
+    /* GETATTR for the resolved object.  OWNER/OWNER_GROUP are required so the
+     * client-side open access gate (chimera_vfs_open_lookup_complete) can
+     * evaluate ownership; without them the gate sees uid/gid 0 and mis-decides
+     * owner/group access (pjdfstest open/06). */
     argarray[getattr_idx].argop = OP_GETATTR;
     attr_request[0]             = (1 << FATTR4_TYPE) | (1 << FATTR4_SIZE) | (1 << FATTR4_FILEID);
     attr_request[1]             = (1 << (FATTR4_MODE - 32)) | (1 << (FATTR4_NUMLINKS - 32)) |
+        (1 << (FATTR4_OWNER - 32)) | (1 << (FATTR4_OWNER_GROUP - 32)) |
         (1 << (FATTR4_TIME_ACCESS - 32)) | (1 << (FATTR4_TIME_MODIFY - 32));
     argarray[getattr_idx].opgetattr.attr_request     = attr_request;
     argarray[getattr_idx].opgetattr.num_attr_request = 2;

--- a/src/vfs/nfs/nfs4_open_at.c
+++ b/src/vfs/nfs/nfs4_open_at.c
@@ -36,7 +36,22 @@ chimera_nfs4_open_at_callback(
     }
 
     if (res->status != NFS4_OK) {
-        request->status = chimera_nfs4_status_to_errno(res->status);
+        /* OPEN of a symlink as the final component: the server rejects it with
+         * NFS4ERR_SYMLINK (there is no atomic O_NOFOLLOW on the wire, so the
+         * server cannot distinguish a data open of the link from a follow).
+         * When the caller asked for a *data* open with O_NOFOLLOW (not an
+         * O_PATH-style open of the link itself), POSIX open(2) must report ELOOP
+         * rather than the default EINVAL mapping (pjdfstest open/16).  This
+         * mirrors the NFS3 client open path.  A failing OPEN sets the whole
+         * COMPOUND's status to the op's error, so this must be handled here
+         * (before the generic mapping) rather than at the per-op check below. */
+        if (res->status == NFS4ERR_SYMLINK &&
+            (request->open_at.flags & CHIMERA_VFS_OPEN_NOFOLLOW) &&
+            !(request->open_at.flags & CHIMERA_VFS_OPEN_PATH)) {
+            request->status = CHIMERA_VFS_ELOOP;
+        } else {
+            request->status = chimera_nfs4_status_to_errno(res->status);
+        }
         request->complete(request);
         return;
     }


### PR DESCRIPTION
## Summary

Fixes the NFSv4 OPEN / access-evaluation failures in the pjdfstest suite on the `nfs4_memfs` backend. These were NFSv4 client-layer protocol bugs (memfs-direct and `nfs3_memfs` already pass these tests).

### Root causes

1. **open/06, open/07 — wrong owner/group access decision.** The chimera NFSv4 *client* enforces POSIX open access in its path resolver (`chimera_vfs_open_lookup_complete` → `chimera_vfs_gate`), which authorizes the requested read/write (and O_TRUNC's write requirement) against the resolved file's attributes. The client's LOOKUP `GETATTR` requested `FATTR4_MODE` but **not** `FATTR4_OWNER` / `FATTR4_OWNER_GROUP`, so the access engine evaluated ownership against uid/gid `0`. This inverted the decision for owner- and group-class access (e.g. owner opening a `0600` file got EACCES; an "other" user opening a file whose owner-only bits denied access got success). NFS3 was unaffected because fattr3 always carries uid/gid.

   Fix: request `FATTR4_OWNER` and `FATTR4_OWNER_GROUP` in the client lookup `GETATTR`. The unmarshaller already decoded both in attribute order.

2. **open/16 — O_NOFOLLOW on a symlink returned EINVAL instead of ELOOP.** An OPEN whose final component is a symlink is rejected by the server with `NFS4ERR_SYMLINK`, which the generic client status mapping converted to EINVAL. POSIX `open(2)` with `O_NOFOLLOW` on a symlink (a data open, not an `O_PATH` open of the link itself) must return ELOOP.

   Fix: in the OPEN callback, map `NFS4ERR_SYMLINK` to ELOOP when the caller requested `O_NOFOLLOW` without `O_PATH`. Handled at the COMPOUND-status branch because a failing OPEN propagates its error to the whole compound. Mirrors the existing NFS3 client behavior.

### Results (`-b nfs4_memfs`)

| test | before | after |
|------|--------|-------|
| open/06 | 22 failing subtests | 0 |
| open/07 | 7 failing subtests | 0 |
| open/16 | 1 failing subtest | 0 |

No regressions on `-b memfs` or `-b nfs3_memfs` (open/06, open/07, open/16 still clean).

### Registration

`nfs4_memfs` registration is **not** enabled: the full nfs4_memfs pjd sweep is 85/134 with the open/access set now fixed. The remaining 49 failures are the attribute/timestamp/rdev set owned by a separate parallel PR — predominantly `mknod`/`mkfifo` special-file creation returning `Operation not supported` (and the lstat/unlink/link/rmdir cascades from those), plus ctime-advance and mknod rdev assertions (chmod/chown/mkdir/rename/truncate/utimensat/mknod_11, etc.). None are OPEN/access bugs. Registration should be enabled once both PRs land.

### Scope

Touches only the NFSv4 client OPEN/access path (`src/vfs/nfs/nfs4_lookup_at.c`, `src/vfs/nfs/nfs4_open_at.c`). No changes to NFS4 getattr/setattr time or rawdev encoding.