### PR TITLE
smb2: encrypt async interim / change-notify responses on encrypting sessions

### DIFF
--- a/src/server/smb/smb_async_interim.c
+++ b/src/server/smb/smb_async_interim.c
@@ -96,17 +96,11 @@ chimera_smb_async_interim_send(struct chimera_smb_request *request)
     nb       = __builtin_bswap32((uint32_t) smb2_len);
     memcpy(buf, &nb, 4);
 
-    if (request->async.signed_session) {
-        chimera_smb_sign_message(conn->thread->signing_ctx,
-                                 request->async.dialect,
-                                 conn->negotiated.signing_alg,
-                                 request->async.signing_key,
-                                 buf + 4,
-                                 smb2_len);
-    }
-
+    /* Sign or, on an encrypting session, wrap in a TRANSFORM header -- an
+     * interim STATUS_PENDING is a response like any other and must be secured
+     * the same way (MS-SMB2 §3.3.4.1.4).  This consumes iov. */
     iov.length = CHIMERA_SMB_ASYNC_INTERIM_LEN;
-    evpl_sendv(evpl, conn->bind, &iov, 1, iov.length, EVPL_SEND_FLAG_TAKE_REF);
+    chimera_smb_secure_send(conn, &iov, smb2_len, &request->async.secure);
 } /* chimera_smb_async_interim_send */
 
 void
@@ -123,21 +117,13 @@ chimera_smb_async_interim_begin(struct chimera_smb_request *request)
     request->async.armed          = 1;
     request->async.credit_charge  = request->smb2_hdr.credit_charge;
     request->async.credit_request = request->smb2_hdr.credit_request_response;
-    request->async.dialect        = conn->dialect;
     request->async.session_id     = request->smb2_hdr.session_id;
 
-    /* Sign the interim iff the original request was signed (same rule as the
-     * change-notify path); an unsigned async reply on a signed session is
-     * rejected by Windows clients. */
-    if ((request->smb2_hdr.flags & SMB2_FLAGS_SIGNED) &&
-        request->session_handle) {
-        request->async.signed_session = 1;
-        memcpy(request->async.signing_key,
-               request->session_handle->signing_key,
-               sizeof(request->async.signing_key));
-    } else {
-        request->async.signed_session = 0;
-    }
+    /* Snapshot signing/encryption state so both the interim and the eventual
+     * final response are secured the way the synchronous path would secure
+     * them (sign if signed; wrap in a TRANSFORM header if the session
+     * encrypts). */
+    chimera_smb_secure_send_snapshot(request, &request->async.secure);
 
     /* AsyncId = the original MessageId (Samba's convention; the client
      * correlates and cancels by it). */

--- a/src/server/smb/smb_encrypt.c
+++ b/src/server/smb/smb_encrypt.c
@@ -4,6 +4,7 @@
 
 #include <string.h>
 #include <stdlib.h>
+#include <stdatomic.h>
 #include <openssl/evp.h>
 
 #include "smb_encrypt.h"
@@ -274,6 +275,100 @@ chimera_smb_encrypt_compound(
     evpl_iovec_release(evpl, out_iov);
     return -1;
 } /* chimera_smb_encrypt_compound */
+
+void
+chimera_smb_secure_send_snapshot(
+    struct chimera_smb_request     *request,
+    struct chimera_smb_secure_send *snap)
+{
+    struct chimera_smb_session *session = request->session_handle
+        ? request->session_handle->session : NULL;
+    struct chimera_smb_tree    *tree = request->tree;
+
+    memset(snap, 0, sizeof(*snap));
+
+    /* Encryption supersedes signing: when the session encrypts (global
+     * EncryptData, a per-share encrypted tree, or the request itself arrived
+     * inside a TRANSFORM) every response including this async one MUST be
+     * encrypted (MS-SMB2 §3.3.4.1.4) rather than signed. */
+    if (session && session->enc_key_len > 0 &&
+        (request->compound->received_encrypted ||
+         (session->flags & CHIMERA_SMB_SESSION_ENCRYPT_DATA) ||
+         (tree && tree->share && tree->share->encrypt_data))) {
+        snap->encrypt     = 1;
+        snap->cipher_id   = session->cipher_id;
+        snap->enc_key_len = session->enc_key_len;
+        snap->session_id  = session->session_id;
+        snap->enc_session = session;
+        memcpy(snap->enc_key, session->enc_key, session->enc_key_len);
+        return;
+    }
+
+    /* Otherwise sign iff the originating request was signed (an unsigned async
+     * reply on a signed session is rejected by Windows clients). */
+    if ((request->smb2_hdr.flags & SMB2_FLAGS_SIGNED) && request->session_handle) {
+        snap->sign = 1;
+        memcpy(snap->signing_key, request->session_handle->signing_key,
+               sizeof(snap->signing_key));
+    }
+} /* chimera_smb_secure_send_snapshot */
+
+void
+chimera_smb_secure_send(
+    struct chimera_smb_conn              *conn,
+    struct evpl_iovec                    *iov,
+    int                                   smb2_len,
+    const struct chimera_smb_secure_send *snap)
+{
+    struct chimera_server_smb_thread *thread = conn->thread;
+    struct evpl                      *evpl   = thread->evpl;
+
+    if (snap->encrypt) {
+        struct evpl_iovec      enc_iov;
+        struct netbios_header *nb;
+        uint64_t               nonce;
+        int                    enc_total;
+
+        /* Strictly-monotonic per-session nonce -- never reuse a nonce for a key
+         * (GCM nonce reuse is catastrophic), shared across the session's
+         * channels, same source the synchronous reply path uses. */
+        nonce = atomic_fetch_add(&snap->enc_session->enc_nonce_counter, 1);
+
+        if (chimera_smb_encrypt_compound(thread->encrypt_ctx, evpl,
+                                         snap->cipher_id, snap->enc_key,
+                                         snap->enc_key_len, nonce,
+                                         snap->session_id, iov, 1, smb2_len,
+                                         (int) sizeof(struct netbios_header),
+                                         &enc_iov) != 0) {
+            evpl_iovec_release(evpl, iov);
+            evpl_close(evpl, conn->bind);
+            return;
+        }
+
+        evpl_iovec_release(evpl, iov);
+
+        /* The NetBIOS framing length excludes itself: TRANSFORM header + ct. */
+        enc_total = (int) sizeof(struct smb2_transform_header) + smb2_len;
+        nb        = evpl_iovec_data(&enc_iov);
+        nb->word  = __builtin_bswap32((uint32_t) enc_total);
+
+        evpl_sendv(evpl, conn->bind, &enc_iov, 1,
+                   (int) sizeof(struct netbios_header) + enc_total,
+                   EVPL_SEND_FLAG_TAKE_REF);
+        return;
+    }
+
+    if (snap->sign) {
+        chimera_smb_sign_message(thread->signing_ctx, conn->dialect,
+                                 conn->negotiated.signing_alg, snap->signing_key,
+                                 (uint8_t *) evpl_iovec_data(iov) +
+                                 sizeof(struct netbios_header), smb2_len);
+    }
+
+    evpl_sendv(evpl, conn->bind, iov, 1,
+               (int) sizeof(struct netbios_header) + smb2_len,
+               EVPL_SEND_FLAG_TAKE_REF);
+} /* chimera_smb_secure_send */
 
 int
 chimera_smb_decrypt_message(

--- a/src/server/smb/smb_encrypt.h
+++ b/src/server/smb/smb_encrypt.h
@@ -4,10 +4,65 @@
 
 #pragma once
 
+#include <stdint.h>
+#include <stddef.h>
+
 struct evpl;
 struct evpl_iovec;
 struct evpl_iovec_cursor;
 struct chimera_smb_encrypt_ctx;
+struct chimera_smb_conn;
+struct chimera_smb_request;
+struct chimera_smb_session;
+
+/*
+ * Snapshot of the signing/encryption state a request needs to finalize a
+ * STANDALONE async response (an interim STATUS_PENDING, or a change-notify
+ * delivery) on the wire after the originating request/compound is gone.
+ *
+ * Encryption supersedes signing (MS-SMB2 §3.1.4.3): on a session that encrypts,
+ * EVERY response -- including async interims -- must be wrapped in a TRANSFORM
+ * header (§3.3.4.1.4), not signed.  When the session only signs, the standalone
+ * message is signed in place instead.
+ */
+struct chimera_smb_secure_send {
+    uint8_t                     encrypt;        /* wrap in a TRANSFORM header */
+    uint8_t                     sign;           /* sign in place (when !encrypt) */
+    uint16_t                    cipher_id;
+    size_t                      enc_key_len;
+    uint64_t                    session_id;
+    uint8_t                     enc_key[32];
+    uint8_t                     signing_key[16];
+    /* Owns the strictly-monotonic per-session AEAD nonce counter.  The session
+     * outlives every parked request on its connection (teardown drains parked
+     * requests without sending), so this pointer is valid at send time. */
+    struct chimera_smb_session *enc_session;
+};
+
+/*
+ * Capture `request`'s signing/encryption state into `snap` so a later
+ * standalone async response can be secured the same way the synchronous reply
+ * path would have secured it.
+ */
+void
+chimera_smb_secure_send_snapshot(
+    struct chimera_smb_request     *request,
+    struct chimera_smb_secure_send *snap);
+
+/*
+ * Finalize and send a standalone SMB2 message built outside the compound reply
+ * path.  `iov` holds [4-byte NetBIOS framing][SMB2 message] plaintext and is
+ * consumed (sent with TAKE_REF, or released on error).  smb2_len is the SMB2
+ * message length (excluding the NetBIOS framing); iov.length must be at least
+ * 4 + smb2_len.  Encrypts (per `snap->encrypt`) or signs (per `snap->sign`)
+ * before sending; on an encryption failure the connection is closed.
+ */
+void
+chimera_smb_secure_send(
+    struct chimera_smb_conn              *conn,
+    struct evpl_iovec                    *iov,
+    int                                   smb2_len,
+    const struct chimera_smb_secure_send *snap);
 
 /*
  * SMB3 transport encryption (MS-SMB2 §3.1.4.3 / §3.3.4.1.4).  Mirrors the

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -19,6 +19,7 @@
 #include "common/macros.h"
 #include "common/misc.h"
 #include "smb2.h"
+#include "smb_encrypt.h"
 #include "smb1.h"
 #include "smb_attr.h"
 #include "smb_session.h"
@@ -320,15 +321,15 @@ struct chimera_smb_request {
      * window.  The timer field is reserved for a future block deadline driver
      * (begin does not arm it today; cancel/drain remove it as a safe no-op). */
     struct {
-        struct evpl_timer           timer;
-        struct chimera_smb_request *park_next;
-        uint8_t                     signing_key[16];
-        uint64_t                    session_id;
-        uint16_t                    dialect;
-        uint16_t                    credit_charge;
-        uint16_t                    credit_request;
-        uint8_t                     signed_session;
-        uint8_t                     armed;
+        struct evpl_timer              timer;
+        struct chimera_smb_request    *park_next;
+        /* Signing/encryption snapshot so the interim (and the eventual final
+         * response) can be secured after the originating request is parked. */
+        struct chimera_smb_secure_send secure;
+        uint64_t                       session_id;
+        uint16_t                       credit_charge;
+        uint16_t                       credit_request;
+        uint8_t                        armed;
     } async;
 
     union {

--- a/src/server/smb/smb_notify.c
+++ b/src/server/smb/smb_notify.c
@@ -335,18 +335,11 @@ chimera_smb_notify_send_interim(struct chimera_smb_notify_request *nr)
     smb2_len = (int) (p - buf - 4);
     chimera_smb_notify_set_netbios_len(buf, smb2_len);
 
-    if (nr->signed_session) {
-        chimera_smb_sign_message(nr->thread->signing_ctx,
-                                 nr->conn->dialect,
-                                 nr->conn->negotiated.signing_alg,
-                                 nr->signing_key,
-                                 buf + 4,
-                                 smb2_len);
-    }
-
+    /* Sign, or wrap in a TRANSFORM header on an encrypting session (the interim
+     * is a response and must be secured the same way -- MS-SMB2 §3.3.4.1.4).
+     * Consumes iov. */
     iov.length = (int) (p - buf);
-    evpl_sendv(nr->thread->evpl, nr->conn->bind, &iov, 1, iov.length,
-               EVPL_SEND_FLAG_TAKE_REF);
+    chimera_smb_secure_send(nr->conn, &iov, smb2_len, &nr->secure);
 } /* chimera_smb_notify_send_interim */
 
 /* ----------------------------------------------------------------
@@ -639,18 +632,11 @@ chimera_smb_notify_do_send_response(
 
     chimera_smb_notify_set_netbios_len(buf, smb2_len);
 
-    if (nr->signed_session) {
-        chimera_smb_sign_message(nr->thread->signing_ctx,
-                                 nr->conn->dialect,
-                                 nr->conn->negotiated.signing_alg,
-                                 nr->signing_key,
-                                 buf + 4,
-                                 smb2_len);
-    }
-
+    /* Sign, or wrap in a TRANSFORM header on an encrypting session (every
+     * change-notify delivery is a response and must be secured -- MS-SMB2
+     * §3.3.4.1.4).  Consumes iov. */
     iov.length = (int) (p - buf);
-    evpl_sendv(nr->thread->evpl, nr->conn->bind, &iov, 1, iov.length,
-               EVPL_SEND_FLAG_TAKE_REF);
+    chimera_smb_secure_send(nr->conn, &iov, smb2_len, &nr->secure);
 
     chimera_smb_notify_unlink(nr);
     chimera_smb_notify_request_free(nr);
@@ -771,18 +757,10 @@ chimera_smb_notify_cancel(struct chimera_smb_notify_request *nr)
     smb2_len = (int) (p - buf - 4);
     chimera_smb_notify_set_netbios_len(buf, smb2_len);
 
-    if (nr->signed_session) {
-        chimera_smb_sign_message(nr->thread->signing_ctx,
-                                 nr->conn->dialect,
-                                 nr->conn->negotiated.signing_alg,
-                                 nr->signing_key,
-                                 buf + 4,
-                                 smb2_len);
-    }
-
+    /* Sign, or wrap in a TRANSFORM header on an encrypting session.  Consumes
+     * iov. */
     iov.length = (int) (p - buf);
-    evpl_sendv(nr->thread->evpl, nr->conn->bind, &iov, 1, iov.length,
-               EVPL_SEND_FLAG_TAKE_REF);
+    chimera_smb_secure_send(nr->conn, &iov, smb2_len, &nr->secure);
 
     chimera_smb_notify_request_free(nr);
 } /* chimera_smb_notify_cancel */

--- a/src/server/smb/smb_notify.h
+++ b/src/server/smb/smb_notify.h
@@ -7,6 +7,7 @@
 #include <stdint.h>
 #include <pthread.h>
 #include "vfs/vfs_notify.h"
+#include "smb_encrypt.h"
 
 struct chimera_smb_request;
 struct chimera_smb_conn;
@@ -45,10 +46,10 @@ struct chimera_smb_notify_request {
     uint32_t                           completion_filter;
     uint16_t                           flags;
     int                                watch_tree;
-    /* Signing state captured at park time so async responses can be
-    * properly signed even after the originating request is gone. */
-    int                                signed_session;
-    uint8_t                            signing_key[16];
+    /* Signing/encryption state captured at park time so async responses can be
+     * properly secured (signed, or wrapped in a TRANSFORM header on an
+     * encrypting session) even after the originating request is gone. */
+    struct chimera_smb_secure_send     secure;
     /* Set under state->lock when callback has queued this nr to
      * thread->notify_ready.  Cleared by send_response or by close
      * when reaping the request from the ready queue. */

--- a/src/server/smb/smb_proc_change_notify.c
+++ b/src/server/smb/smb_proc_change_notify.c
@@ -284,17 +284,12 @@ chimera_smb_change_notify(struct chimera_smb_request *request)
     nr->completion_filter    = request->change_notify.completion_filter;
     nr->watch_tree           = request->change_notify.watch_tree;
 
-    /* Capture signing state so the deferred async responses can be
-     * signed.  An unsigned async reply on a signed session is rejected
-     * by Windows clients with SEC_E_INCOMPLETE_MESSAGE, breaking the
-     * watcher. */
-    if ((request->smb2_hdr.flags & SMB2_FLAGS_SIGNED) &&
-        request->session_handle) {
-        nr->signed_session = 1;
-        memcpy(nr->signing_key, request->session_handle->signing_key, 16);
-    } else {
-        nr->signed_session = 0;
-    }
+    /* Capture signing/encryption state so the deferred async responses can be
+     * secured.  An unsigned async reply on a signed session is rejected by
+     * Windows clients with SEC_E_INCOMPLETE_MESSAGE, and on an encrypting
+     * session every response must be wrapped in a TRANSFORM header -- either
+     * way breaks the watcher if we send it in the clear. */
+    chimera_smb_secure_send_snapshot(request, &nr->secure);
 
     state->pending = nr;
     pthread_mutex_unlock(&state->lock);

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -413,7 +413,33 @@ if(CHIMERA_NETNS_TESTING AND WPTS_DOTNET AND WPTS_SMB2_DLL AND WPTS_ARCH_SUPPORT
         BVT_TreeMgmt_SMB311_Disconnect_NoSignedNoEncryptedTreeConnect
         Compound_Encrypt_RelatedRequests
         Compound_Encrypt_UnrelatedRequests
-        Signing_VerifySignatureWhenEncrypted)
+        Signing_VerifySignatureWhenEncrypted
+        # Interim STATUS_PENDING emitters (oplock/lease break, change notify).
+        # On an encrypting session the async interim and the change-notify
+        # delivery must themselves be wrapped in a TRANSFORM header (MS-SMB2
+        # §3.3.4.1.4); these failed with "the packet should be encrypted" until
+        # the standalone async send paths learned to encrypt.
+        BVT_OpLockBreak
+        BVT_Leasing_FileLeasingV1
+        BVT_Leasing_FileLeasingV2
+        Leasing_FileLeasingV1_SameLeaseKey
+        Leasing_FileLeasingV2_SameLeaseKey
+        BVT_SMB2Basic_CancelRegisteredChangeNotify
+        BVT_SMB2Basic_ChangeNotify_ChangeAttributes
+        BVT_SMB2Basic_ChangeNotify_ChangeCreation
+        BVT_SMB2Basic_ChangeNotify_ChangeDirName
+        BVT_SMB2Basic_ChangeNotify_ChangeEa
+        BVT_SMB2Basic_ChangeNotify_ChangeFileName
+        BVT_SMB2Basic_ChangeNotify_ChangeLastAccess
+        BVT_SMB2Basic_ChangeNotify_ChangeLastWrite
+        BVT_SMB2Basic_ChangeNotify_ChangeSecurity
+        BVT_SMB2Basic_ChangeNotify_ChangeSize
+        BVT_SMB2Basic_ChangeNotify_ChangeStreamName
+        BVT_SMB2Basic_ChangeNotify_ChangeStreamSize
+        BVT_SMB2Basic_ChangeNotify_ChangeStreamWrite
+        BVT_SMB2Basic_ChangeNotify_ServerReceiveSmb2Close
+        BVT_SMB2Basic_ChangeNotify_NonDirectoryFile
+        BVT_SMB2Basic_ChangeNotify_NoFileListDirectoryInGrantedAccess)
 
     string(REPLACE ";" "," _wpts_tests "${WPTS_SMB2_ENCRYPTION_ALLOWLIST}")
     add_test(NAME chimera/server/smb/wpts/memfs_encryption


### PR DESCRIPTION
## Problem

On an SMB3 session that encrypts (global `EncryptData`, a per-share encrypted
tree, or a request that arrived inside a TRANSFORM), MS-SMB2 §3.3.4.1.4 requires
**every** response to be wrapped in a TRANSFORM header. But the standalone async
responses the compound reply path never sees were only ever *signed* and sent in
the clear:

- the interim `STATUS_PENDING` emitted when a handler blocks (oplock/lease break
  ack, blocking lock, change notify), and
- the change-notify delivery / cancel responses.

So on an encrypting session the WPTS client rejected them with *"the packet
should be encrypted for session"* and tore the connection down — failing every
operation that pends (change notify, oplock/lease break, blocking lock).

## Fix

Factor the per-request signing/encryption decision into a small snapshot
(`chimera_smb_secure_send`, captured when the request is parked) and a shared
finalizer (`chimera_smb_secure_send()`) that signs the message in place or, when
the session encrypts, wraps it in a TRANSFORM header using the session's
monotonic nonce counter — exactly how the synchronous reply path secures a
normal response (encryption supersedes signing). The async-interim
infrastructure and all three change-notify send paths (interim, delivery,
cancel) now use it.

## Tests

Enables 21 change-notify / oplock-break / lease-break cases in the encryption
config allowlist (previously failing *"should be encrypted"*). Verified:

- all interim emitters pass in the encryption config, both isolated and as a
  consolidated batch (0 `"should be encrypted"` failures, was 9+);
- the signed / plaintext paths (base, multichannel configs) are unchanged — no
  regression;
- all 7 WPTS config-groups green; Debug/ASan and `scan-build` clean.

Note: the encryption config still has a **separate, pre-existing** failure
cluster — a server-side TRANSFORM *decrypt* cascade (`tag verification failed`)
that only manifests in the full unfiltered suite (~120 occurrences, present
before this change) and is unrelated to interim encryption. Out of scope here.
