### PR TITLE
smb: SRVSVC browse + LSARPC QueryInfoPolicy2 opcodes

### DIFF
--- a/scripts/smb_rpcclient_test.sh
+++ b/scripts/smb_rpcclient_test.sh
@@ -94,4 +94,22 @@ else
     echo "FAIL: unexpected NetShareEnumAll response"; rc=1
 fi
 
+echo "=== rpcclient netsharegetinfo share 1 (SRVSVC NetShareGetInfo, opnum 16) ==="
+OUT="$(timeout 20 $RPCCLIENT -U 'myuser%mypassword' 127.0.0.1 -c 'netsharegetinfo share 1' 2>&1)"
+echo "$OUT"
+if echo "$OUT" | grep -qi "netname: *share"; then
+    echo "PASS: SRVSVC NetShareGetInfo returned the share's level-1 info"
+else
+    echo "FAIL: unexpected NetShareGetInfo response"; rc=1
+fi
+
+echo "=== rpcclient srvinfo (SRVSVC NetSrvGetInfo level 101, opnum 21) ==="
+OUT="$(timeout 20 $RPCCLIENT -U 'myuser%mypassword' 127.0.0.1 -c 'srvinfo' 2>&1)"
+echo "$OUT"
+if echo "$OUT" | grep -qi "platform_id" && echo "$OUT" | grep -qi "chimera"; then
+    echo "PASS: SRVSVC NetSrvGetInfo returned the server's level-101 info"
+else
+    echo "FAIL: unexpected NetSrvGetInfo response"; rc=1
+fi
+
 exit $rc

--- a/src/server/smb/idl/lsarpc.idl
+++ b/src/server/smb/idl/lsarpc.idl
@@ -152,6 +152,14 @@ interface lsarpc {
         [in]      uint16              level,
         [in, out] uint32              count);
 
+    /* opnum 46 -- LsarQueryInformationPolicy2.  Identical signature and arms to
+     * QueryInfoPolicy (opnum 7); Windows clients call this variant first and
+     * fall back to opnum 7 only on a fault. */
+    [opnum(46)] uint32 lsa_QueryInfoPolicy2(
+        [in]  policy_handle         *handle,
+        [in]  uint16                 level,
+        [out] lsa_PolicyInformation **info);
+
     /* opnum 44 -- LsarOpenPolicy2.  ObjectAttributes (an LSAPR_OBJECT_ATTRIBUTES
      * the server ignores) is intentionally not modelled; the input is consumed
      * best-effort and does not affect the response. */

--- a/src/server/smb/idl/srvsvc.idl
+++ b/src/server/smb/idl/srvsvc.idl
@@ -28,4 +28,41 @@ interface srvsvc {
         [in] uint32                              max_buffer,
         [out] uint32                             total_entries,
         [in, out, unique] uint32                *resume_handle);
+
+    /* ---- NetShareGetInfo (MS-SRVS 3.1.4.10) ----
+     * The [out] InfoStruct is a non-encapsulated union switched on the [in]
+     * level; modelled as a struct whose leading uint32 is the union switch
+     * value followed by the (unique-pointer) arm.  Only level 1 is filled. */
+    typedef struct {
+        uint32                level;     /* union switch value (echoes the requested level) */
+        srvsvc_NetShareInfo1 *info1;
+    } srvsvc_NetShareGetInfoCtr;
+
+    [opnum(16)] uint32 srvsvc_NetShareGetInfo(
+        [in, unique, string] wchar_t            *server_unc,
+        [in, string]         wchar_t            *netname,
+        [in]  uint32                             level,
+        [out] srvsvc_NetShareGetInfoCtr         *info);
+
+    /* ---- NetServerGetInfo (MS-SRVS 3.1.4.17) ----
+     * SERVER_INFO_101 carried through the same union-as-struct shape; only
+     * level 101 is filled. */
+    typedef struct {
+        uint32            platform_id;
+        [string] wchar_t *name;
+        uint32            version_major;
+        uint32            version_minor;
+        uint32            type;
+        [string] wchar_t *comment;
+    } srvsvc_NetSrvInfo101;
+
+    typedef struct {
+        uint32                level;     /* union switch value (echoes the requested level) */
+        srvsvc_NetSrvInfo101 *info101;
+    } srvsvc_NetSrvInfoCtr;
+
+    [opnum(21)] uint32 srvsvc_NetSrvGetInfo(
+        [in, unique, string] wchar_t            *server_unc,
+        [in]  uint32                             level,
+        [out] srvsvc_NetSrvInfoCtr              *info);
 }

--- a/src/server/smb/smb_lsarpc.c
+++ b/src/server/smb/smb_lsarpc.c
@@ -30,6 +30,7 @@ static const dce_if_uuid_t LSA_INTERFACE = {
 #define LSA_SID_NAME_UNKNOWN       8
 #define LSA_OP_OPENPOLICY2         44
 #define LSA_OP_GETUSERNAME         45
+#define LSA_OP_QUERYINFOPOLICY2    46
 
 /* Bytes of DCE/RPC framing (common + response header) the framing layer writes
 * before the stub, so the generated marshaller's buffer cap stays in bounds. */
@@ -200,9 +201,13 @@ chimera_smb_lsarpc_impl(
             o->status         = 0;
             break;
         }
-        case LSA_OP_QUERYINFOPOLICY: {
-            struct lsa_QueryInfoPolicy_out      *o  = out;
+        case LSA_OP_QUERYINFOPOLICY:
+        case LSA_OP_QUERYINFOPOLICY2: {
+            /* QueryInfoPolicy (7) and QueryInfoPolicy2 (46) share an identical
+            * request/response shape; the generated _in/_out structs are
+            * layout-identical, so the level and info/status fields line up. */
             const struct lsa_QueryInfoPolicy_in *qi = in;
+            struct lsa_QueryInfoPolicy_out      *o  = out;
             /* Levels 3 (PrimaryDomain) and 5 (AccountDomain) both return the
              * server's workgroup name and machine SID. */
             static const char                   *domain = "WORKGROUP";

--- a/src/server/smb/smb_srvsvc.c
+++ b/src/server/smb/smb_srvsvc.c
@@ -15,12 +15,25 @@ static const dce_if_uuid_t SRV_INTERFACE = {
     .if_vers_minor = 0,
 };
 
-#define SRV_OP_NETSHAREENUMALL 15
+#define SRV_OP_NETSHAREENUMALL     15
+#define SRV_OP_NETSHAREGETINFO     16
+#define SRV_OP_NETSRVGETINFO       21
 
-#define SRV_STYPE_DISKTREE     0x00000000
-#define SRV_STYPE_IPC_HIDDEN   0x80000003
+#define SRV_STYPE_DISKTREE         0x00000000
+#define SRV_STYPE_IPC_HIDDEN       0x80000003
 
-#define SRV_RPC_STUB_MAX       (65535 - (int) (sizeof(dce_common_t) + sizeof(dce_co_response_t)))
+/* MS-DTYP / lmerr.h: returned in the WERROR status when an operation cannot be
+ * satisfied. */
+#define SRV_WERR_OK                0x00000000
+#define SRV_WERR_UNKNOWN_LEVEL     0x0000007C
+#define SRV_WERR_NETNAME_NOT_FOUND 0x00000906
+
+/* MS-SRVS SV_PLATFORM_ID_NT and a plausible NT-class server type bitmask
+ * (workstation + server + Unix). rpcclient just echoes these fields. */
+#define SRV_PLATFORM_ID_NT         500
+#define SRV_TYPE_DEFAULT           0x00001003
+
+#define SRV_RPC_STUB_MAX           (65535 - (int) (sizeof(dce_common_t) + sizeof(dce_co_response_t)))
 
 static char *
 chimera_smb_srvsvc_dbuf_strdup(
@@ -82,6 +95,80 @@ chimera_smb_srvsvc_impl(
             o->total_entries  = i;
             o->resume_handle  = 0;
             o->status         = 0;   /* WERR_OK */
+            break;
+        }
+        case SRV_OP_NETSHAREGETINFO: {
+            const struct srvsvc_NetShareGetInfo_in *in_g = in;
+            struct srvsvc_NetShareGetInfo_out      *o    = out;
+            struct srvsvc_NetShareInfo1            *info;
+            struct chimera_smb_share               *cur;
+            const char                             *netname = in_g->netname;
+            int                                     found   = 0;
+
+            /* Echo the requested level as the union switch value regardless of
+             * outcome so the client decodes the arm it expects. */
+            o->info.level = in_g->level;
+            o->info.info1 = NULL;
+
+            if (in_g->level != 1) {
+                o->status = SRV_WERR_UNKNOWN_LEVEL;
+                break;
+            }
+
+            info = ndr_dbuf_alloc(dbuf, sizeof(*info));
+
+            if (netname && strcasecmp(netname, "IPC$") == 0) {
+                info->name    = chimera_smb_srvsvc_dbuf_strdup(dbuf, "IPC$");
+                info->type    = SRV_STYPE_IPC_HIDDEN;
+                info->comment = "Remote IPC";
+                found         = 1;
+            } else if (netname) {
+                pthread_mutex_lock(&shared->shares_lock);
+                LL_FOREACH(shared->shares, cur)
+                {
+                    if (strcasecmp(cur->name, netname) == 0) {
+                        info->name    = chimera_smb_srvsvc_dbuf_strdup(dbuf, cur->name);
+                        info->type    = SRV_STYPE_DISKTREE;
+                        info->comment = "";
+                        found         = 1;
+                        break;
+                    }
+                }
+                pthread_mutex_unlock(&shared->shares_lock);
+            }
+
+            if (found) {
+                o->info.info1 = info;
+                o->status     = SRV_WERR_OK;
+            } else {
+                o->status = SRV_WERR_NETNAME_NOT_FOUND;
+            }
+            break;
+        }
+        case SRV_OP_NETSRVGETINFO: {
+            const struct srvsvc_NetSrvGetInfo_in *in_s = in;
+            struct srvsvc_NetSrvGetInfo_out      *o    = out;
+            struct srvsvc_NetSrvInfo101          *info;
+
+            o->info.level   = in_s->level;
+            o->info.info101 = NULL;
+
+            if (in_s->level != 101) {
+                o->status = SRV_WERR_UNKNOWN_LEVEL;
+                break;
+            }
+
+            info = ndr_dbuf_alloc(dbuf, sizeof(*info));
+
+            info->platform_id   = SRV_PLATFORM_ID_NT;
+            info->name          = chimera_smb_srvsvc_dbuf_strdup(dbuf, shared->config.identity);
+            info->version_major = 6;
+            info->version_minor = 1;
+            info->type          = SRV_TYPE_DEFAULT;
+            info->comment       = "Chimera NAS";
+
+            o->info.info101 = info;
+            o->status       = SRV_WERR_OK;
             break;
         }
         default:


### PR DESCRIPTION
Builds on #792 (ndrzcc-generated DCE/RPC). Stacked on that branch — until #792 merges this PR's diff also shows its three commits; the only new commit here is the last one (`smb: add SRVSVC browse + LSARPC QueryInfoPolicy2 opcodes`).

Closes the remaining "browse + ACL" gaps toward standalone-Samba parity, all on the generated marshalling path:

- **LSARPC `LsarQueryInformationPolicy2` (opnum 46)** — identical request/response shape to `QueryInfoPolicy` (7). Windows clients call the v2 variant first and only fall back to opnum 7 on a fault, so implementing it removes a wasted fault round-trip on every Security-tab open. The generated v1/v2 `_in`/`_out` structs are layout-identical, so the business logic is shared.

- **SRVSVC `NetShareGetInfo` (opnum 16)** — level-1 info for a single share, backing the per-share Properties dialog. The `[out]` union is modelled as a struct whose leading `uint32` is the switch value followed by the unique-pointer arm; only level 1 is filled, other levels return `WERR_UNKNOWN_LEVEL`, unknown shares `WERR_NETNAME_NOT_FOUND`.

- **SRVSVC `NetServerGetInfo` (opnum 21)** — level-101 server info (platform id, name from `config.identity`, version, type, comment), queried during the Explorer browse handshake.

The `netname` input on `NetShareGetInfo` is a top-level `[ref]` string (no referent id) — the codegen already handles this; the new IDL is the first consumer of that path.

## Verification

- `lsarpc` golden unit test (byte-identical legacy compare) — pass.
- Samba `rpcclient` smoke test extended with `netsharegetinfo share 1` and `srvinfo`; all seven checks pass end-to-end against a live in-process server, under both Release and Debug/ASan.

```
netname: share
        remark:
        chimera        Wk Sv NT             Chimera NAS
        platform_id     :       500
        os version      :       6.1
        server type     :       0x1003
```

KVM/WPTS matrix steps can't run in the dev sandbox, so CI is the first signal there.