### PR TITLE
nfs3: add an optional duplicate-request cache (DRC) persisted to the KV store

### DIFF
--- a/kvm/kvm_nfs3_drc_reboot_test_wrapper.sh
+++ b/kvm/kvm_nfs3_drc_reboot_test_wrapper.sh
@@ -1,0 +1,232 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+#
+# SPDX-License-Identifier: Unlicense
+
+# Usage: kvm_nfs3_drc_reboot_test_wrapper.sh <vmlinuz> <rootfs.qcow2> <chimera_binary>
+#
+# Cross-reboot persistence test for the NFSv3 duplicate-request cache (DRC).
+# Exercises the reply-cache persistence end to end across a real chimera server
+# restart, backed by a persistent cairn store (initialize=true on first boot,
+# false on restart) with server.kv_module=cairn and server.nfs3_drc=true:
+#
+#   1. Start chimera A; a guest mounts NFSv3 and runs a batch of non-idempotent
+#      ops (mkdir/create/rename/remove) under /mnt.  Each captured reply is
+#      written through to the cairn KV store keyed by {client,xid,proc,cksum}.
+#      The guest does NOT unmount (a crash, not a graceful teardown).
+#   2. Stop chimera A and restart it (chimera B) against the same cairn store
+#      with initialize=false, so the FS data and the DRC reply records survive.
+#   3. chimera B warms the DRC from stable storage at thread-init; its log is
+#      checked for the cold-start reload marker (>=1 reply record reloaded)
+#      emitted by nfs3_drc_reload_complete.  A second guest then mounts and
+#      confirms the FS is still usable.
+#
+# Passing proves: NFSv3 reply records are written to stable storage and
+# reloaded into the in-memory cache on restart -- the cross-reboot replay tier
+# the in-memory-only DRC lacks.
+
+set -u
+
+ARCH=$(uname -m)
+if [ "$ARCH" = "aarch64" ]; then
+    QEMU_BIN="qemu-system-aarch64"
+    QEMU_MACHINE="-machine virt"
+    QEMU_CONSOLE="ttyAMA0"
+else
+    QEMU_BIN="qemu-system-x86_64"
+    QEMU_MACHINE="-M microvm,acpi=on,rtc=on,pit=on,pcie=on"
+    QEMU_CONSOLE="ttyS0"
+fi
+
+VMLINUZ=$1; shift
+ROOTFS=$1; shift
+CHIMERA_BINARY=$1; shift
+
+NETNS_NAME="kvm_nfs3drc_$$_$(date +%s%N)"
+TAP_NAME="tap3_$$"
+BUILD_DIR=$(dirname "$(dirname "$CHIMERA_BINARY")")
+SESSION_DIR=$(mktemp -d "${BUILD_DIR}/kvm_nfs3drc_session_XXXXXX")
+CAIRN_DIR="${SESSION_DIR}/cairn"
+CONFIG_FILE="${SESSION_DIR}/chimera.json"
+CHIMERA_LOG="${SESSION_DIR}/chimera.log"
+CHIMERA_PID=""
+mkdir -p "$CAIRN_DIR"
+
+cleanup() {
+    if [ -n "$CHIMERA_PID" ]; then
+        kill "$CHIMERA_PID" 2>/dev/null || true
+        for i in $(seq 1 150); do
+            kill -0 "$CHIMERA_PID" 2>/dev/null || break
+            sleep 0.02
+        done
+        kill -9 "$CHIMERA_PID" 2>/dev/null || true
+        wait "$CHIMERA_PID" 2>/dev/null || true
+    fi
+    ip netns delete "${NETNS_NAME}" 2>/dev/null || true
+    rm -rf "$SESSION_DIR"
+}
+trap cleanup EXIT
+
+# Generate the chimera config.  $1 = initialize flag (true/false).
+generate_config() {
+    local init="$1"
+    cat > "$CONFIG_FILE" << EOF
+{
+    "common": {
+        "rcu_reclaim_threads": 4
+    },
+    "server": {
+        "threads": 4,
+        "delegation_threads": 4,
+        "kv_module": "cairn",
+        "nfs3_drc": true,
+        "vfs": {
+            "cairn": {
+                "config": {"initialize":${init},"path":"$CAIRN_DIR"}
+            }
+        },
+        "external_portmap": false
+    },
+    "mounts": {
+        "share": {
+            "module": "cairn",
+            "path": "/"
+        }
+    },
+    "exports": {
+        "/share": {
+            "path": "/share"
+        }
+    }
+}
+EOF
+}
+
+BOOT_N=0
+start_chimera() {
+    BOOT_N=$((BOOT_N + 1))
+    CHIMERA_LOG="${SESSION_DIR}/chimera_${BOOT_N}.log"
+    ip netns exec "${NETNS_NAME}" "$CHIMERA_BINARY" -c "$CONFIG_FILE" \
+        > "$CHIMERA_LOG" 2>&1 &
+    CHIMERA_PID=$!
+    for i in $(seq 1 200); do
+        if ip netns exec "${NETNS_NAME}" bash -c "echo > /dev/tcp/10.0.0.1/2049" 2>/dev/null; then
+            return 0
+        fi
+        if ! kill -0 "$CHIMERA_PID" 2>/dev/null; then
+            echo "chimera daemon exited prematurely"
+            cat "$CHIMERA_LOG"
+            return 1
+        fi
+        sleep 0.02
+    done
+    echo "chimera NFS port never came up"
+    return 1
+}
+
+stop_chimera() {
+    kill "$CHIMERA_PID" 2>/dev/null || true
+    for i in $(seq 1 200); do
+        kill -0 "$CHIMERA_PID" 2>/dev/null || break
+        sleep 0.02
+    done
+    kill -9 "$CHIMERA_PID" 2>/dev/null || true
+    wait "$CHIMERA_PID" 2>/dev/null || true
+    CHIMERA_PID=""
+}
+
+# Boot a guest that runs $1 (mounted NFSv3 at /mnt).  $2 = log label.  Emits the
+# parsed guest exit code.
+run_guest() {
+    local guest_cmd="$1"
+    local label="$2"
+    local log="${SESSION_DIR}/guest_${label}.log"
+    local mount_opts="vers=3,tcp,nconnect=16,nolock"
+    local full="mount -t nfs -o ${mount_opts} 10.0.0.1:/share /mnt && ${guest_cmd}"
+
+    ip netns exec "${NETNS_NAME}" "$QEMU_BIN" \
+        -enable-kvm -smp 4 -m 1G -cpu host \
+        -kernel "$VMLINUZ" \
+        $QEMU_MACHINE \
+        -nodefaults \
+        -drive file="$ROOTFS",if=virtio,format=qcow2,snapshot=on \
+        -netdev tap,id=net0,ifname="${TAP_NAME}",script=no,downscript=no \
+        -device virtio-net-pci,netdev=net0,romfile="" \
+        -serial stdio \
+        -nographic \
+        -no-reboot \
+        -append "root=/dev/vda rw console=${QEMU_CONSOLE} net.ifnames=0 biosdevname=0 quiet mitigations=off tsc=reliable panic=-1 test_cmd=\"${full}\" init=/init.sh" \
+        > "$log" 2>/dev/null
+
+    grep -oaP 'CHIMERA_KVM_EXIT_CODE=\K[0-9]+' "$log" | tail -1
+}
+
+# --- network namespace + TAP ---
+ulimit -l unlimited
+ip netns add "${NETNS_NAME}"
+ip netns exec "${NETNS_NAME}" ip link set lo up
+ip netns exec "${NETNS_NAME}" ip tuntap add dev "${TAP_NAME}" mode tap
+ip netns exec "${NETNS_NAME}" ip addr add 10.0.0.1/24 dev "${TAP_NAME}"
+ip netns exec "${NETNS_NAME}" ip link set "${TAP_NAME}" up
+
+# --- boot 1: drive non-idempotent ops so reply records get persisted ---
+generate_config "true"
+start_chimera || exit 1
+GUEST_OPS="mkdir -p /mnt/d1 /mnt/d2 && \
+echo hi > /mnt/d1/f && \
+mv /mnt/d1/f /mnt/d1/g && \
+rmdir /mnt/d2 && \
+sync && ls -l /mnt/d1"
+RC1=$(run_guest "${GUEST_OPS}" boot1)
+echo "=== boot 1 guest exit: ${RC1:-<none>} ==="
+if [ "${RC1:-1}" != "0" ]; then
+    echo "FAIL: pre-reboot guest did not succeed"
+    cat "$CHIMERA_LOG"
+    exit 1
+fi
+# Let the fire-and-forget DRC KV writes + cairn commit settle before the crash.
+sleep 2
+stop_chimera
+
+# --- restart: same cairn store, initialize=false ---
+generate_config "false"
+start_chimera || exit 1
+
+# chimera B warms the DRC at thread-init; give the async scan a moment, then a
+# guest mount confirms the FS is still serviceable.
+RC2=$(run_guest "ls -l /mnt/d1 && cat /mnt/d1/g" boot2)
+echo "=== boot 2 guest exit: ${RC2:-<none>} ==="
+
+# --- assertions ---
+FAIL=0
+
+if [ "${RC2:-1}" != "0" ]; then
+    echo "FAIL: post-reboot guest could not use the filesystem"
+    FAIL=1
+fi
+
+if grep -q "NFSv3 DRC: cold-start load complete:" "$CHIMERA_LOG"; then
+    RELOADED=$(grep -oP 'NFSv3 DRC: cold-start load complete: \K[0-9]+' "$CHIMERA_LOG" | tail -1)
+    echo "=== chimera B reloaded ${RELOADED} NFSv3 reply record(s) ==="
+    if [ "${RELOADED:-0}" -lt 1 ]; then
+        echo "FAIL: no NFSv3 reply records were reloaded after restart"
+        FAIL=1
+    fi
+else
+    echo "FAIL: chimera B did not log an NFSv3 DRC cold-start load"
+    FAIL=1
+fi
+
+if grep -qi "non-persistent" "$CHIMERA_LOG"; then
+    echo "FAIL: KV backend reported non-persistent (expected cairn)"
+    FAIL=1
+fi
+
+if [ "$FAIL" != "0" ]; then
+    echo "=== chimera log ==="
+    cat "$CHIMERA_LOG"
+    exit 1
+fi
+
+echo "PASS: NFSv3 DRC cross-reboot persistence (reply records reloaded)"
+exit 0

--- a/kvm/tests/CMakeLists.txt
+++ b/kvm/tests/CMakeLists.txt
@@ -5,6 +5,7 @@
 set(CHIMERA_BINARY ${CMAKE_BINARY_DIR}/src/daemon/chimera)
 set(NFS_WRAPPER ${CMAKE_SOURCE_DIR}/kvm/kvm_nfs_test_wrapper.sh)
 set(NFS_REBOOT_WRAPPER ${CMAKE_SOURCE_DIR}/kvm/kvm_nfs_reboot_test_wrapper.sh)
+set(NFS3_DRC_REBOOT_WRAPPER ${CMAKE_SOURCE_DIR}/kvm/kvm_nfs3_drc_reboot_test_wrapper.sh)
 set(SMB_WRAPPER ${CMAKE_SOURCE_DIR}/kvm/kvm_smb_test_wrapper.sh)
 set(PNFS_WRAPPER ${CMAKE_SOURCE_DIR}/kvm/kvm_pnfs_test_wrapper.sh)
 set(PNFS_BLOCK_WRAPPER ${CMAKE_SOURCE_DIR}/kvm/kvm_pnfs_block_test_wrapper.sh)
@@ -194,6 +195,15 @@ foreach(image_spec ${KVM_IMAGES})
                     ${IMAGE_DIR}/vmlinuz ${IMAGE_DIR}/rootfs.qcow2
                     ${CHIMERA_BINARY} 4.1)
         set_tests_properties(chimera/kvm/${IMAGE_NAME}/reboot/recovery_cairn_nfs4.1
+            PROPERTIES LABELS "kvm;${IMAGE_NAME}" PROCESSORS 2)
+
+        # NFSv3 DRC cross-reboot persistence: drive non-idempotent ops, restart
+        # against the same cairn store, verify the reply records reload.
+        add_test(NAME chimera/kvm/${IMAGE_NAME}/reboot/drc_cairn_nfs3
+            COMMAND bash ${NFS3_DRC_REBOOT_WRAPPER}
+                    ${IMAGE_DIR}/vmlinuz ${IMAGE_DIR}/rootfs.qcow2
+                    ${CHIMERA_BINARY})
+        set_tests_properties(chimera/kvm/${IMAGE_NAME}/reboot/drc_cairn_nfs3
             PROPERTIES LABELS "kvm;${IMAGE_NAME}" PROCESSORS 2)
     endif()
 

--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -510,6 +510,11 @@ main(
         chimera_server_config_set_nfs4_drc(server_config, json_is_true(json_value));
     }
 
+    json_value = json_object_get(server_params, "nfs3_drc");
+    if (json_is_boolean(json_value)) {
+        chimera_server_config_set_nfs3_drc(server_config, json_is_true(json_value));
+    }
+
     json_value = json_object_get(server_params, "nfs4_lease_time");
     if (json_is_integer(json_value)) {
         int_value = json_integer_value(json_value);

--- a/src/server/nfs/CMakeLists.txt
+++ b/src/server/nfs/CMakeLists.txt
@@ -5,7 +5,7 @@
 include_directories(${NFS_COMMON_INCLUDE_DIR})
 
 # Create libraries for NFSv3 and NFSv4
-add_library(chimera_nfs SHARED nfs.c nfs4_session.c nfs4_state.c nfs4_lease.c nfs4_recovery.c nfs4_drc.c nfs4_callback.c nfs_mount.c nfs_portmap.c nfs3_dump.c nfs4_dump.c
+add_library(chimera_nfs SHARED nfs.c nfs4_session.c nfs4_state.c nfs4_lease.c nfs4_recovery.c nfs4_drc.c nfs3_drc.c nfs_drc_reply.c nfs4_callback.c nfs_mount.c nfs_portmap.c nfs3_dump.c nfs4_dump.c
             nfs_external_portmap.c nfs_nlm.c nfs_nlm_state.c
             nfs3_proc_null.c nfs3_proc_getattr.c nfs3_proc_setattr.c nfs3_proc_lookup.c 
             nfs3_proc_access.c nfs3_proc_readlink.c nfs3_proc_read.c nfs3_proc_write.c

--- a/src/server/nfs/nfs.c
+++ b/src/server/nfs/nfs.c
@@ -285,6 +285,13 @@ nfs_server_init(
     nfs_state_table_init(&shared->nfs4_state_table);
     nfs_layout_table_init(&shared->nfs4_layout_table);
     nfs4_v40_drc_init(&shared->v40_drc);
+    nfs3_drc_init(&shared->nfs3_drc);
+    /* The NFSv3 duplicate-request cache wraps the NFS_V3 call dispatcher; only
+     * install the wrapper when enabled so a disabled server keeps the direct
+     * (zero-overhead) path. */
+    if (chimera_server_config_get_nfs3_drc(config)) {
+        nfs3_drc_install(shared);
+    }
     pthread_mutex_init(&shared->nfs4_pnfs_devcache.lock, NULL);
     shared->nfs4_pnfs_devcache.count = 0;
 
@@ -569,6 +576,7 @@ nfs_server_destroy(void *data)
 
     nlm_state_destroy(&shared->nlm_state);
     nfs4_v40_drc_destroy(&shared->v40_drc);
+    nfs3_drc_destroy(&shared->nfs3_drc);
 
     free(shared);
 } /* nfs_server_destroy */

--- a/src/server/nfs/nfs3_drc.c
+++ b/src/server/nfs/nfs3_drc.c
@@ -1,0 +1,628 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include <stdatomic.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "nfs3_drc.h"
+#include "nfs_common.h"
+#include "nfs_internal.h"
+#include "nfs_kv_keys.h"
+#include "nfs_drc_reply.h"
+#include "nfs4_lease.h"
+#include "vfs/vfs.h"
+#include "vfs/vfs_procs.h"
+#include "evpl/evpl.h"
+#include "evpl/evpl_rpc2.h"
+#include "evpl/evpl_rpc2_program.h"
+
+#define NFS3_DRC_VALUE_MAGIC 0x33435244u /* "DRC3" */
+
+/* Most evictions remove a single similarly-sized entry; this caps how many
+ * evicted keys one insert reports back for KV cleanup (any beyond it leak in
+ * the KV store until the next cold-start reload re-bounds it). */
+#define NFS3_DRC_EVICT_MAX   32
+
+/* Standard NFSv3 procedure numbers (the generated dispatcher keys on these). */
+enum {
+    NFS3PROC_SETATTR = 2,
+    NFS3PROC_CREATE  = 8,
+    NFS3PROC_MKDIR   = 9,
+    NFS3PROC_SYMLINK = 10,
+    NFS3PROC_MKNOD   = 11,
+    NFS3PROC_REMOVE  = 12,
+    NFS3PROC_RMDIR   = 13,
+    NFS3PROC_RENAME  = 14,
+    NFS3PROC_LINK    = 15,
+};
+
+/* ------------------------------------------------------------------ *
+*  request identity                                                  *
+* ------------------------------------------------------------------ */
+
+int
+nfs3_drc_proc_cacheable(uint32_t proc)
+{
+    switch (proc) {
+        case NFS3PROC_SETATTR:
+        case NFS3PROC_CREATE:
+        case NFS3PROC_MKDIR:
+        case NFS3PROC_SYMLINK:
+        case NFS3PROC_MKNOD:
+        case NFS3PROC_REMOVE:
+        case NFS3PROC_RMDIR:
+        case NFS3PROC_RENAME:
+        case NFS3PROC_LINK:
+            return 1;
+        default:
+            /* Idempotent ops (READ/WRITE/GETATTR/LOOKUP/COMMIT/...) are safe to
+             * re-execute on a retransmit, so they bypass the cache. */
+            return 0;
+    } /* switch */
+} /* nfs3_drc_proc_cacheable */
+
+#define NFS3_DRC_FNV_OFFSET 1469598103934665603ULL
+#define NFS3_DRC_FNV_PRIME  1099511628211ULL
+
+static inline uint64_t
+nfs3_drc_fnv_accum(
+    uint64_t       h,
+    const uint8_t *p,
+    uint32_t       len)
+{
+    uint32_t i;
+
+    for (i = 0; i < len; i++) {
+        h ^= p[i];
+        h *= NFS3_DRC_FNV_PRIME;
+    }
+    return h;
+} /* nfs3_drc_fnv_accum */
+
+uint64_t
+nfs3_drc_checksum(
+    const void *data,
+    uint32_t    len)
+{
+    return nfs3_drc_fnv_accum(NFS3_DRC_FNV_OFFSET, data, len);
+} /* nfs3_drc_checksum */
+
+static uint64_t
+nfs3_drc_checksum_iov(
+    const xdr_iovec *iov,
+    int              niov)
+{
+    uint64_t h = NFS3_DRC_FNV_OFFSET;
+    int      i;
+
+    for (i = 0; i < niov; i++) {
+        h = nfs3_drc_fnv_accum(h, xdr_iovec_data(&iov[i]), xdr_iovec_len(&iov[i]));
+    }
+    return h;
+} /* nfs3_drc_checksum_iov */
+
+/* Source IP with the ephemeral port stripped (stable across the reconnect a
+ * retransmit rides in on).  Returns the address length written into out. */
+static uint8_t
+nfs3_drc_client_addr(
+    struct evpl_rpc2_conn *conn,
+    uint8_t               *out)
+{
+    char   str[80];
+    char  *p;
+    size_t n;
+
+    evpl_rpc2_conn_get_remote_address(conn, str, sizeof(str));
+
+    if (str[0] == '[') {
+        /* "[ipv6]:port" -> the bytes between the brackets. */
+        p = strchr(str, ']');
+        n = p ? (size_t) (p - (str + 1)) : strlen(str);
+        memmove(str, str + 1, n);
+    } else {
+        /* "ipv4:port" -> strip the trailing ":port". */
+        p = strrchr(str, ':');
+        n = p ? (size_t) (p - str) : strlen(str);
+    }
+
+    if (n > NFS3_DRC_ADDR_MAX) {
+        n = NFS3_DRC_ADDR_MAX;
+    }
+    memcpy(out, str, n);
+    return (uint8_t) n;
+} /* nfs3_drc_client_addr */
+
+/* ------------------------------------------------------------------ *
+*  reply value (de)serialization                                     *
+* ------------------------------------------------------------------ */
+
+/* Value layout (LE): magic(4) ts(8) len(4) reply[len]. */
+uint32_t
+nfs3_drc_value_serialize(
+    uint8_t    *buf,
+    uint32_t    buf_size,
+    uint64_t    ts,
+    const void *body,
+    uint32_t    body_len)
+{
+    uint32_t p = 0;
+
+    if (buf_size < NFS3_DRC_VALUE_HDR_LEN + body_len) {
+        return 0;
+    }
+    nfs_kv_put_le32(buf, &p, NFS3_DRC_VALUE_MAGIC);
+    nfs_kv_put_le64(buf, &p, ts);
+    nfs_kv_put_le32(buf, &p, body_len);
+    memcpy(buf + p, body, body_len);
+    return p + body_len;
+} /* nfs3_drc_value_serialize */
+
+int
+nfs3_drc_value_parse(
+    const uint8_t  *buf,
+    uint32_t        len,
+    uint64_t       *out_ts,
+    const uint8_t **out_body,
+    uint32_t       *out_body_len)
+{
+    uint32_t body_len;
+
+    if (len < NFS3_DRC_VALUE_HDR_LEN ||
+        nfs_kv_le32(buf) != NFS3_DRC_VALUE_MAGIC) {
+        return -1;
+    }
+    *out_ts  = nfs_kv_le64(buf + 4);
+    body_len = nfs_kv_le32(buf + 12);
+    if (NFS3_DRC_VALUE_HDR_LEN + body_len > len) {
+        return -1;
+    }
+    *out_body     = buf + NFS3_DRC_VALUE_HDR_LEN;
+    *out_body_len = body_len;
+    return 0;
+} /* nfs3_drc_value_parse */
+
+/* ------------------------------------------------------------------ *
+*  in-memory cache                                                   *
+* ------------------------------------------------------------------ */
+
+/* Caller holds drc->lock.  Returns the number of evicted entries whose keys
+ * were copied into evicted[] (for the caller to drop from the KV store). */
+static int
+nfs3_drc_cache_insert_locked(
+    struct nfs3_drc              *drc,
+    const struct nfs3_drc_keybuf *key,
+    const void                   *body,
+    uint32_t                      body_len,
+    uint64_t                      ts,
+    struct nfs3_drc_keybuf       *evicted,
+    int                           max_evicted)
+{
+    struct nfs3_drc_entry *e;
+    int                    nev = 0;
+
+    HASH_FIND(hh, drc->table, key, sizeof(*key), e);
+    if (e) {
+        /* Last-writer-wins refresh of an existing identity. */
+        drc->bytes -= e->len;
+        free(e->buf);
+        e->buf = malloc(body_len);
+        memcpy(e->buf, body, body_len);
+        e->len      = body_len;
+        e->ts       = ts;
+        drc->bytes += body_len;
+        return 0;
+    }
+
+    /* FIFO eviction: drc->table is the oldest-inserted entry. */
+    while (drc->bytes + body_len > NFS3_DRC_MAX_BYTES && drc->table) {
+        struct nfs3_drc_entry *old = drc->table;
+
+        if (evicted && nev < max_evicted) {
+            evicted[nev++] = old->key;
+        }
+        HASH_DELETE(hh, drc->table, old);
+        drc->bytes -= old->len;
+        free(old->buf);
+        free(old);
+    }
+
+    e      = calloc(1, sizeof(*e));
+    e->key = *key;
+    e->buf = malloc(body_len);
+    memcpy(e->buf, body, body_len);
+    e->len = body_len;
+    e->ts  = ts;
+    HASH_ADD(hh, drc->table, key, sizeof(e->key), e);
+    drc->bytes += body_len;
+
+    return nev;
+} /* nfs3_drc_cache_insert_locked */
+
+void
+nfs3_drc_cache_insert(
+    struct nfs3_drc              *drc,
+    const struct nfs3_drc_keybuf *key,
+    const void                   *body,
+    uint32_t                      body_len,
+    uint64_t                      ts)
+{
+    pthread_mutex_lock(&drc->lock);
+    nfs3_drc_cache_insert_locked(drc, key, body, body_len, ts, NULL, 0);
+    pthread_mutex_unlock(&drc->lock);
+} /* nfs3_drc_cache_insert */
+
+int
+nfs3_drc_cache_lookup(
+    struct nfs3_drc              *drc,
+    const struct nfs3_drc_keybuf *key,
+    uint8_t                     **out_buf,
+    uint32_t                     *out_len)
+{
+    struct nfs3_drc_entry *e;
+    uint8_t               *buf = NULL;
+    uint32_t               len = 0;
+
+    pthread_mutex_lock(&drc->lock);
+    HASH_FIND(hh, drc->table, key, sizeof(*key), e);
+    if (e) {
+        len = e->len;
+        buf = malloc(len);
+        memcpy(buf, e->buf, len);
+    }
+    pthread_mutex_unlock(&drc->lock);
+
+    if (!buf) {
+        return 0;
+    }
+    *out_buf = buf;
+    *out_len = len;
+    return 1;
+} /* nfs3_drc_cache_lookup */
+
+/* ------------------------------------------------------------------ *
+*  KV write-through                                                  *
+* ------------------------------------------------------------------ */
+
+struct nfs3_drc_kv_ctx {
+    uint8_t  key[CHIMERA_KV_NFS3_REPLY_KEY_MAX];
+    uint32_t key_len;
+    uint8_t *value;
+    uint32_t value_len;
+};
+
+static void
+nfs3_drc_kv_done(
+    enum chimera_vfs_error error_code,
+    void                  *private_data)
+{
+    struct nfs3_drc_kv_ctx *ctx = private_data;
+
+    (void) error_code;
+    free(ctx->value);
+    free(ctx);
+} /* nfs3_drc_kv_done */
+
+static void
+nfs3_drc_kv_put(
+    struct chimera_vfs_thread    *vfs_thread,
+    const struct nfs3_drc_keybuf *key,
+    const void                   *body,
+    uint32_t                      body_len,
+    uint64_t                      ts)
+{
+    struct nfs3_drc_kv_ctx *ctx = malloc(sizeof(*ctx));
+
+    ctx->key_len = nfs_kv_nfs3_reply_key(ctx->key, key->addr, key->addr_len,
+                                         key->proc, key->xid, key->cksum);
+    ctx->value     = malloc(NFS3_DRC_VALUE_HDR_LEN + body_len);
+    ctx->value_len = nfs3_drc_value_serialize(ctx->value,
+                                              NFS3_DRC_VALUE_HDR_LEN + body_len,
+                                              ts, body, body_len);
+
+    chimera_vfs_put_key(vfs_thread, ctx->key, ctx->key_len,
+                        ctx->value, ctx->value_len, nfs3_drc_kv_done, ctx);
+} /* nfs3_drc_kv_put */
+
+static void
+nfs3_drc_kv_delete(
+    struct chimera_vfs_thread    *vfs_thread,
+    const struct nfs3_drc_keybuf *key)
+{
+    struct nfs3_drc_kv_ctx *ctx = malloc(sizeof(*ctx));
+
+    ctx->value     = NULL;
+    ctx->value_len = 0;
+    ctx->key_len   = nfs_kv_nfs3_reply_key(ctx->key, key->addr, key->addr_len,
+                                           key->proc, key->xid, key->cksum);
+
+    chimera_vfs_delete_key(vfs_thread, ctx->key, ctx->key_len,
+                           nfs3_drc_kv_done, ctx);
+} /* nfs3_drc_kv_delete */
+
+/* ------------------------------------------------------------------ *
+*  reply capture (fires from inside send_reply)                      *
+* ------------------------------------------------------------------ */
+
+struct nfs3_drc_capture_ctx {
+    struct chimera_server_nfs_thread *thread;
+    struct nfs3_drc_keybuf            key;
+};
+
+static void
+nfs3_drc_capture_reply(
+    const struct evpl_iovec *iov,
+    int                      niov,
+    int                      total_length,
+    void                    *private_data)
+{
+    struct nfs3_drc_capture_ctx      *ctx    = private_data;
+    struct chimera_server_nfs_thread *thread = ctx->thread;
+    struct nfs3_drc                  *drc    = &thread->shared->nfs3_drc;
+    struct nfs3_drc_keybuf            evicted[NFS3_DRC_EVICT_MAX];
+    uint8_t                          *buf;
+    size_t                            offset = 0;
+    uint64_t                          ts;
+    int                               i, nev;
+
+    if (total_length <= 0 || (uint32_t) total_length > NFS3_DRC_MAX_REPLY_SIZE) {
+        return;
+    }
+
+    buf = malloc(total_length);
+    for (i = 0; i < niov; i++) {
+        memcpy(buf + offset, iov[i].data, iov[i].length);
+        offset += iov[i].length;
+    }
+
+    ts = nfs_lease_now_ns();
+
+    pthread_mutex_lock(&drc->lock);
+    nev = nfs3_drc_cache_insert_locked(drc, &ctx->key, buf, total_length, ts,
+                                       evicted, NFS3_DRC_EVICT_MAX);
+    pthread_mutex_unlock(&drc->lock);
+
+    if (!drc->persistence_disabled) {
+        nfs3_drc_kv_put(thread->vfs_thread, &ctx->key, buf, total_length, ts);
+        for (i = 0; i < nev; i++) {
+            nfs3_drc_kv_delete(thread->vfs_thread, &evicted[i]);
+        }
+    }
+
+    free(buf);
+} /* nfs3_drc_capture_reply */
+
+/* ------------------------------------------------------------------ *
+*  cold-start reload                                                 *
+* ------------------------------------------------------------------ */
+
+struct nfs3_drc_reload_ctx {
+    struct chimera_server_nfs_thread *thread;
+    uint32_t                          loaded;
+    uint8_t                           start[CHIMERA_KV_HDR_LEN];
+};
+
+static int
+nfs3_drc_reload_scan_cb(
+    const void *key,
+    uint32_t    key_len,
+    const void *value,
+    uint32_t    value_len,
+    void       *private_data)
+{
+    struct nfs3_drc_reload_ctx       *ctx    = private_data;
+    struct chimera_server_nfs_thread *thread = ctx->thread;
+    struct nfs3_drc                  *drc    = &thread->shared->nfs3_drc;
+    const uint8_t                    *k      = key;
+    struct nfs3_drc_keybuf            kb;
+    const uint8_t                    *body;
+    uint64_t                          ts;
+    uint32_t                          p, body_len;
+    uint8_t                           addr_len;
+
+    if (key_len < CHIMERA_KV_HDR_LEN + 1 ||
+        memcmp(k, ctx->start, CHIMERA_KV_HDR_LEN) != 0) {
+        return 1;  /* left the NFSv3 reply band */
+    }
+
+    addr_len = k[CHIMERA_KV_HDR_LEN];
+    p        = CHIMERA_KV_HDR_LEN + 1;
+    if (addr_len > NFS3_DRC_ADDR_MAX || p + addr_len + 16 > key_len) {
+        return 0;  /* skip a malformed key */
+    }
+
+    memset(&kb, 0, sizeof(kb));
+    memcpy(kb.addr, k + p, addr_len);
+    kb.addr_len = addr_len;
+    p          += addr_len;
+    kb.proc     = nfs_kv_le32(k + p); p += 4;
+    kb.xid      = nfs_kv_le32(k + p); p += 4;
+    kb.cksum    = nfs_kv_le64(k + p);
+
+    if (nfs3_drc_value_parse(value, value_len, &ts, &body, &body_len) != 0) {
+        return 0;  /* skip a corrupt value */
+    }
+
+    /* In-memory only here -- deleting KV entries mid-scan could disturb the
+     * backend's iteration, and KV size is already bounded by the previous
+     * uptime's evict-on-insert. */
+    nfs3_drc_cache_insert(drc, &kb, body, body_len, ts);
+    ctx->loaded++;
+    return 0;
+} /* nfs3_drc_reload_scan_cb */
+
+static void
+nfs3_drc_reload_complete(
+    enum chimera_vfs_error error_code,
+    void                  *private_data)
+{
+    struct nfs3_drc_reload_ctx       *ctx    = private_data;
+    struct chimera_server_nfs_thread *thread = ctx->thread;
+
+    (void) error_code;
+
+    atomic_store(&thread->shared->nfs3_drc.load_state, NFS3_DRC_LOAD_READY);
+    chimera_nfs_info("NFSv3 DRC: cold-start load complete: %u reply record(s) "
+                     "reloaded", ctx->loaded);
+    free(ctx);
+} /* nfs3_drc_reload_complete */
+
+static void
+nfs3_drc_reload(struct chimera_server_nfs_thread *thread)
+{
+    struct nfs3_drc_reload_ctx *ctx = malloc(sizeof(*ctx));
+
+    ctx->thread = thread;
+    ctx->loaded = 0;
+    nfs_kv_type_prefix(ctx->start, CHIMERA_KV_TYPE_NFS3_REPLY);
+
+    /* No end key + flags 0: key-ordered results, the callback stops when the
+     * 3-byte type header changes. */
+    chimera_vfs_search_keys(thread->vfs_thread,
+                            ctx->start, CHIMERA_KV_HDR_LEN,
+                            NULL, 0, 0,
+                            nfs3_drc_reload_scan_cb,
+                            nfs3_drc_reload_complete, ctx);
+} /* nfs3_drc_reload */
+
+/* One-shot cold-start reload.  Idempotent (atomic IDLE->RUNNING CAS); no-op
+ * unless the cache is installed and the backend is persistent.  Called eagerly
+ * from each worker's thread-init so the cache is warm before clients retransmit
+ * across a restart, with the dispatch path as a fallback trigger. */
+void
+nfs3_drc_reload_kickoff(struct chimera_server_nfs_thread *thread)
+{
+    struct nfs3_drc *drc      = &thread->shared->nfs3_drc;
+    int              expected = NFS3_DRC_LOAD_IDLE;
+
+    if (!drc->orig_dispatch || drc->persistence_disabled) {
+        return;  /* DRC disabled or non-persistent: nothing to reload */
+    }
+
+    if (atomic_compare_exchange_strong(&drc->load_state, &expected,
+                                       NFS3_DRC_LOAD_RUNNING)) {
+        nfs3_drc_reload(thread);
+    }
+} /* nfs3_drc_reload_kickoff */
+
+/* ------------------------------------------------------------------ *
+*  dispatch wrapper                                                  *
+* ------------------------------------------------------------------ */
+
+static int
+nfs3_drc_dispatch(
+    struct evpl               *evpl,
+    struct evpl_rpc2_conn     *conn,
+    struct evpl_rpc2_encoding *encoding,
+    uint32_t                   proc,
+    void                      *program_data,
+    struct evpl_rpc2_cred     *cred,
+    xdr_iovec                 *iov,
+    int                        niov,
+    int                        length,
+    void                      *private_data)
+{
+    struct chimera_server_nfs_thread *thread = private_data;
+    struct nfs3_drc                  *drc    = &thread->shared->nfs3_drc;
+    struct nfs3_drc_capture_ctx      *cctx;
+    struct nfs3_drc_keybuf            key;
+    uint8_t                          *cached;
+    uint32_t                          cached_len;
+
+    /* Warm the cache from stable storage on the first request of any kind (a
+     * live vfs_thread is required, which only requests have).  Idempotent.
+     * Lookups serve misses while the reload is in flight -- a miss just
+     * re-executes, the pre-feature behavior. */
+    nfs3_drc_reload_kickoff(thread);
+
+    /* The cached reply is the TCP on-wire form; RDMA framing differs, so leave
+    * RDMA requests (and idempotent procs) to the real dispatcher untouched. */
+    if (conn->rdma || !nfs3_drc_proc_cacheable(proc)) {
+        return drc->orig_dispatch(evpl, conn, encoding, proc, program_data,
+                                  cred, iov, niov, length, private_data);
+    }
+
+    memset(&key, 0, sizeof(key));
+    key.addr_len = nfs3_drc_client_addr(conn, key.addr);
+    key.proc     = proc;
+    key.xid      = encoding->xid;
+    key.cksum    = nfs3_drc_checksum_iov(iov, niov);
+
+    if (nfs3_drc_cache_lookup(drc, &key, &cached, &cached_len)) {
+        int rc = nfs_drc_send_cached_reply(thread, encoding, cached, cached_len);
+
+        free(cached);
+        if (rc == 0) {
+            return 0;  /* retransmit replayed from cache */
+        }
+        /* Unparseable cached reply (should not happen for a TCP MSG_ACCEPTED
+         * reply): fall through and re-execute. */
+    }
+
+    /* Miss: arm the reply-capture hook, then run the real handler. */
+    cctx = xdr_dbuf_alloc_space(sizeof(*cctx), encoding->dbuf);
+    if (cctx) {
+        cctx->thread                    = thread;
+        cctx->key                       = key;
+        encoding->reply_capture_cb      = nfs3_drc_capture_reply;
+        encoding->reply_capture_private = cctx;
+    }
+
+    return drc->orig_dispatch(evpl, conn, encoding, proc, program_data,
+                              cred, iov, niov, length, private_data);
+} /* nfs3_drc_dispatch */
+
+/* ------------------------------------------------------------------ *
+*  lifecycle                                                         *
+* ------------------------------------------------------------------ */
+
+void
+nfs3_drc_init(struct nfs3_drc *drc)
+{
+    pthread_mutex_init(&drc->lock, NULL);
+    drc->table                = NULL;
+    drc->bytes                = 0;
+    drc->persistence_disabled = 0;
+    drc->orig_dispatch        = NULL;
+    atomic_store(&drc->load_state, NFS3_DRC_LOAD_IDLE);
+} /* nfs3_drc_init */
+
+void
+nfs3_drc_destroy(struct nfs3_drc *drc)
+{
+    /* The uthash delete-during-iteration idiom (tmp holds the next entry before
+     * the body runs, so freeing e is safe) trips scan-build's use-after-free
+     * checker; guard it the same way the other NFS hash-table teardowns do. */
+#ifndef __clang_analyzer__
+    struct nfs3_drc_entry *e, *tmp;
+
+    HASH_ITER(hh, drc->table, e, tmp)
+    {
+        HASH_DELETE(hh, drc->table, e);
+        free(e->buf);
+        free(e);
+    }
+#endif /* ifndef __clang_analyzer__ */
+    pthread_mutex_destroy(&drc->lock);
+} /* nfs3_drc_destroy */
+
+void
+nfs3_drc_install(struct chimera_server_nfs_shared *shared)
+{
+    struct nfs3_drc *drc    = &shared->nfs3_drc;
+    const char      *kvname = (shared->vfs && shared->vfs->kv_module) ?
+        shared->vfs->kv_module->name : "";
+
+    drc->persistence_disabled = (strcmp(kvname, "memkv") == 0);
+
+    if (drc->persistence_disabled) {
+        chimera_nfs_info(
+            "NFSv3 DRC: KV backend '%s' is non-persistent; the duplicate-"
+            "request cache will not survive a server restart", kvname);
+    }
+
+    /* Wrap the generated NFS_V3 call dispatcher. */
+    drc->orig_dispatch                     = shared->nfs_v3.rpc2.recv_call_dispatch;
+    shared->nfs_v3.rpc2.recv_call_dispatch = nfs3_drc_dispatch;
+} /* nfs3_drc_install */

--- a/src/server/nfs/nfs3_drc.h
+++ b/src/server/nfs/nfs3_drc.h
@@ -1,0 +1,170 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#pragma once
+
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdint.h>
+
+#include <uthash.h>
+
+/* nfs3_xdr.h defines xdr_iovec (used in orig_dispatch below) and then pulls in
+ * evpl_rpc2_program.h, which uses it. */
+#include "nfs3_xdr.h"
+
+struct chimera_server_nfs_thread;
+struct chimera_server_nfs_shared;
+struct evpl;
+struct evpl_rpc2_conn;
+struct evpl_rpc2_encoding;
+struct evpl_rpc2_cred;
+
+/*
+ * NFSv3 duplicate-request cache (DRC), gated by server.nfs3_drc (default off).
+ *
+ * NFSv3 has no sessions or client ids, so -- following the classic server DRC
+ * pattern -- a request is identified by {client address, xid, procedure,
+ * request checksum}.  The address has its ephemeral port stripped so it stays
+ * stable across the reconnect a retransmit rides in on; the checksum guards
+ * against a reused xid mapping to a different call (a hit then means the same
+ * client re-presenting a byte-identical request).
+ *
+ * Only non-idempotent procedures are cached (CREATE/MKDIR/REMOVE/RENAME/...);
+ * re-executing an idempotent op is harmless, so those bypass the cache.
+ *
+ * The cache is installed as a wrapper around the generated NFS_V3 call
+ * dispatcher (see nfs3_drc_install): on a hit it replays the cached reply and
+ * skips execution; on a miss it arms the rpc2 reply-capture hook and forwards
+ * to the real dispatcher.  When kv_module is persistent the captured reply is
+ * also written through to the KV store keyed by the same identity, and a
+ * cold-start scan repopulates the in-memory cache, so a retransmit that arrives
+ * after a server restart still replays instead of re-executing.
+ */
+
+/* Longest client address string a key embeds (see CHIMERA_KV_NFS3_ADDR_MAX). */
+#define NFS3_DRC_ADDR_MAX       48u
+
+/* Per-entry reply cap and total in-memory (and therefore on-KV) byte budget. */
+#define NFS3_DRC_MAX_REPLY_SIZE (64u * 1024u)
+#define NFS3_DRC_MAX_BYTES      (4u * 1024u * 1024u)
+
+/* Fixed-layout identity used as the uthash key.  memset to zero before filling
+ * so the trailing pad and any unused addr bytes hash deterministically. */
+struct nfs3_drc_keybuf {
+    uint8_t  addr[NFS3_DRC_ADDR_MAX];
+    uint8_t  addr_len;
+    uint8_t  pad[3];
+    uint32_t proc;
+    uint32_t xid;
+    uint64_t cksum;
+};
+
+struct nfs3_drc_entry {
+    struct nfs3_drc_keybuf key;
+    uint8_t               *buf;     /* cached procedure-result body */
+    uint32_t               len;
+    uint64_t               ts;      /* capture time (monotonic ticks), diag */
+    UT_hash_handle         hh;
+};
+
+enum nfs3_drc_load_state {
+    NFS3_DRC_LOAD_IDLE = 0,
+    NFS3_DRC_LOAD_RUNNING,
+    NFS3_DRC_LOAD_READY,
+};
+
+struct nfs3_drc {
+    pthread_mutex_t        lock;
+    struct nfs3_drc_entry *table;            /* uthash, FIFO eviction order */
+    uint64_t               bytes;
+    int                    persistence_disabled;
+    _Atomic int            load_state;
+    /* The generated NFS_V3 dispatcher we wrap; NULL until installed. */
+    int                    (*orig_dispatch)(
+        struct evpl               *evpl,
+        struct evpl_rpc2_conn     *conn,
+        struct evpl_rpc2_encoding *encoding,
+        uint32_t                   proc,
+        void                      *program_data,
+        struct evpl_rpc2_cred     *cred,
+        xdr_iovec                 *iov,
+        int                        niov,
+        int                        length,
+        void                      *private_data);
+};
+
+/* Wrap the NFS_V3 program's call dispatcher with the DRC (call once at server
+ * init, after NFS_V3_init, only when nfs3_drc is enabled). */
+void
+nfs3_drc_install(
+    struct chimera_server_nfs_shared *shared);
+
+/* One-shot cold-start reload of persisted reply records into the in-memory
+ * cache.  Idempotent; no-op when the cache is disabled or the backend is
+ * non-persistent.  Call from per-thread init (a live vfs_thread is required). */
+void
+nfs3_drc_reload_kickoff(
+    struct chimera_server_nfs_thread *thread);
+
+/* Initialize / tear down the in-memory cache. */
+void
+nfs3_drc_init(
+    struct nfs3_drc *drc);
+
+void
+nfs3_drc_destroy(
+    struct nfs3_drc *drc);
+
+/* ----------------------------------------------------------------------- *
+*  Exposed for unit tests (test_nfs_persist).                             *
+* ----------------------------------------------------------------------- */
+
+/* 64-bit FNV-1a over a request body -- the key's checksum field. */
+uint64_t
+nfs3_drc_checksum(
+    const void *data,
+    uint32_t    len);
+
+/* Is this NFSv3 procedure number non-idempotent (and therefore cached)? */
+int
+nfs3_drc_proc_cacheable(
+    uint32_t proc);
+
+/* Reply value layout: magic(4) ts(8) len(4) body[len].  serialize returns
+ * bytes written (0 on overflow); parse points data at the in-buffer body. */
+#define NFS3_DRC_VALUE_HDR_LEN 16u
+
+uint32_t
+nfs3_drc_value_serialize(
+    uint8_t    *buf,
+    uint32_t    buf_size,
+    uint64_t    ts,
+    const void *body,
+    uint32_t    body_len);
+
+int
+nfs3_drc_value_parse(
+    const uint8_t  *buf,
+    uint32_t        len,
+    uint64_t       *out_ts,
+    const uint8_t **out_body,
+    uint32_t       *out_body_len);
+
+/* In-memory cache primitives (lock taken internally). */
+void
+nfs3_drc_cache_insert(
+    struct nfs3_drc              *drc,
+    const struct nfs3_drc_keybuf *key,
+    const void                   *body,
+    uint32_t                      body_len,
+    uint64_t                      ts);
+
+/* Returns 1 and fills out_buf (malloc'd, caller frees) + out_len on a hit. */
+int
+nfs3_drc_cache_lookup(
+    struct nfs3_drc              *drc,
+    const struct nfs3_drc_keybuf *key,
+    uint8_t                     **out_buf,
+    uint32_t                     *out_len);

--- a/src/server/nfs/nfs4_proc_compound.c
+++ b/src/server/nfs/nfs4_proc_compound.c
@@ -11,115 +11,17 @@
 #include "evpl/evpl_bind.h"
 #include "nfs4_dump.h"
 #include "nfs4_op_matrix.h"
-
-static uint32_t
-nfs4_replay_be32(const uint8_t *p)
-{
-    return ((uint32_t) p[0] << 24) |
-           ((uint32_t) p[1] << 16) |
-           ((uint32_t) p[2] << 8) |
-           (uint32_t) p[3];
-} /* nfs4_replay_be32 */
-
-static bool
-nfs4_replay_cached_body_offset(
-    const uint8_t *buf,
-    uint32_t       len,
-    uint32_t      *offset)
-{
-    uint32_t v, verf_len, pad;
-    uint32_t pos = 4; /* TCP record marker */
-
-    if (len < 28) {
-        return false;
-    }
-
-    v = nfs4_replay_be32(buf);
-    if ((v & 0x80000000u) == 0 || (v & 0x7fffffffu) + 4 != len) {
-        return false;
-    }
-
-    pos += 4; /* xid */
-
-    v = nfs4_replay_be32(buf + pos); /* mtype */
-    if (v != 1) { /* REPLY */
-        return false;
-    }
-    pos += 4;
-
-    v = nfs4_replay_be32(buf + pos); /* reply stat */
-    if (v != 0) { /* MSG_ACCEPTED */
-        return false;
-    }
-    pos += 4;
-
-    pos     += 4; /* verifier flavor */
-    verf_len = nfs4_replay_be32(buf + pos);
-    pos     += 4;
-
-    pad = (4 - (verf_len & 3)) & 3;
-    if (pos + verf_len + pad + 4 > len) {
-        return false;
-    }
-    pos += verf_len + pad;
-
-    v = nfs4_replay_be32(buf + pos); /* accept stat */
-    if (v != 0) { /* SUCCESS */
-        return false;
-    }
-    pos += 4;
-
-    *offset = pos;
-    return true;
-} /* nfs4_replay_cached_body_offset */
-
-static int
-nfs4_send_cached_reply_buf(
-    struct chimera_server_nfs_thread *thread,
-    struct nfs_request               *req,
-    const uint8_t                    *cached,
-    uint32_t                          cached_len)
-{
-    uint32_t           body_offset, body_len, reserve;
-    struct evpl_iovec *msg_iov;
-    int                niov;
-
-    if (!nfs4_replay_cached_body_offset(cached, cached_len, &body_offset)) {
-        return -1;
-    }
-
-    body_len = cached_len - body_offset;
-    reserve  = req->encoding->program->reserve;
-
-    msg_iov = xdr_dbuf_alloc_space(sizeof(*msg_iov), req->encoding->dbuf);
-    if (!msg_iov) {
-        return -1;
-    }
-
-    niov = evpl_iovec_alloc(thread->evpl, body_len + reserve, 8, 1, 0, msg_iov);
-    if (niov != 1) {
-        return -1;
-    }
-
-    memcpy((uint8_t *) msg_iov->data + reserve, cached + body_offset, body_len);
-
-    return evpl_rpc2_send_reply_dispatch(thread->evpl,
-                                         req->encoding,
-                                         NULL,
-                                         msg_iov,
-                                         1,
-                                         body_len + reserve);
-} /* nfs4_send_cached_reply_buf */
+#include "nfs_drc_reply.h"
 
 static int
 nfs4_send_cached_reply(
     struct chimera_server_nfs_thread *thread,
     struct nfs_request               *req)
 {
-    return nfs4_send_cached_reply_buf(thread,
-                                      req,
-                                      req->replay_slot->cached_buf,
-                                      req->replay_slot->cached_len);
+    return nfs_drc_send_cached_reply(thread,
+                                     req->encoding,
+                                     req->replay_slot->cached_buf,
+                                     req->replay_slot->cached_len);
 } /* nfs4_send_cached_reply */
 
 static void
@@ -688,7 +590,8 @@ chimera_nfs4_compound(
                                 &cached_buf,
                                 &cached_len)) {
             nfs4_release_write_args(thread, args);
-            rc = nfs4_send_cached_reply_buf(thread, req, cached_buf, cached_len);
+            rc = nfs_drc_send_cached_reply(thread, req->encoding, cached_buf,
+                                           cached_len);
             free(cached_buf);
             chimera_nfs_abort_if(rc, "Failed to send cached RPC2 reply");
             nfs_request_free(thread, req);

--- a/src/server/nfs/nfs_common.h
+++ b/src/server/nfs/nfs_common.h
@@ -17,6 +17,7 @@
 #include "nfs4_state.h"
 #include "nfs4_layout_table.h"
 #include "nfs4_recovery.h"
+#include "nfs3_drc.h"
 #include "nfs_nlm_state.h"
 
 struct chimera_server_nfs_thread;
@@ -279,6 +280,7 @@ struct chimera_server_nfs_shared {
     struct prometheus_metrics          *metrics;
     struct nfs4_replay_metrics          replay_metrics;
     struct nfs4_v40_drc                 v40_drc;
+    struct nfs3_drc                     nfs3_drc;
 };
 
 /* Forward decl for the per-thread lease sweeper (defined in nfs4_lease.h). */

--- a/src/server/nfs/nfs_drc_reply.c
+++ b/src/server/nfs/nfs_drc_reply.c
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include <string.h>
+
+#include "nfs_drc_reply.h"
+#include "nfs_common.h"
+#include "evpl/evpl.h"
+#include "evpl/evpl_rpc2.h"
+#include "evpl/evpl_rpc2_program.h"
+
+static uint32_t
+nfs_drc_be32(const uint8_t *p)
+{
+    return ((uint32_t) p[0] << 24) |
+           ((uint32_t) p[1] << 16) |
+           ((uint32_t) p[2] << 8) |
+           (uint32_t) p[3];
+} /* nfs_drc_be32 */
+
+bool
+nfs_drc_reply_body_offset(
+    const uint8_t *buf,
+    uint32_t       len,
+    uint32_t      *offset)
+{
+    uint32_t v, verf_len, pad;
+    uint32_t pos = 4; /* TCP record marker */
+
+    if (len < 28) {
+        return false;
+    }
+
+    v = nfs_drc_be32(buf);
+    if ((v & 0x80000000u) == 0 || (v & 0x7fffffffu) + 4 != len) {
+        return false;
+    }
+
+    pos += 4; /* xid */
+
+    v = nfs_drc_be32(buf + pos); /* mtype */
+    if (v != 1) { /* REPLY */
+        return false;
+    }
+    pos += 4;
+
+    v = nfs_drc_be32(buf + pos); /* reply stat */
+    if (v != 0) { /* MSG_ACCEPTED */
+        return false;
+    }
+    pos += 4;
+
+    pos     += 4; /* verifier flavor */
+    verf_len = nfs_drc_be32(buf + pos);
+    pos     += 4;
+
+    pad = (4 - (verf_len & 3)) & 3;
+    if (pos + verf_len + pad + 4 > len) {
+        return false;
+    }
+    pos += verf_len + pad;
+
+    v = nfs_drc_be32(buf + pos); /* accept stat */
+    if (v != 0) { /* SUCCESS */
+        return false;
+    }
+    pos += 4;
+
+    *offset = pos;
+    return true;
+} /* nfs_drc_reply_body_offset */
+
+int
+nfs_drc_send_cached_reply(
+    struct chimera_server_nfs_thread *thread,
+    struct evpl_rpc2_encoding        *encoding,
+    const uint8_t                    *cached,
+    uint32_t                          cached_len)
+{
+    uint32_t           body_offset, body_len, reserve;
+    struct evpl_iovec *msg_iov;
+    int                niov;
+
+    if (!nfs_drc_reply_body_offset(cached, cached_len, &body_offset)) {
+        return -1;
+    }
+
+    body_len = cached_len - body_offset;
+    reserve  = encoding->program->reserve;
+
+    msg_iov = xdr_dbuf_alloc_space(sizeof(*msg_iov), encoding->dbuf);
+    if (!msg_iov) {
+        return -1;
+    }
+
+    niov = evpl_iovec_alloc(thread->evpl, body_len + reserve, 8, 1, 0, msg_iov);
+    if (niov != 1) {
+        return -1;
+    }
+
+    memcpy((uint8_t *) msg_iov->data + reserve, cached + body_offset, body_len);
+
+    return evpl_rpc2_send_reply_dispatch(thread->evpl,
+                                         encoding,
+                                         NULL,
+                                         msg_iov,
+                                         1,
+                                         body_len + reserve);
+} /* nfs_drc_send_cached_reply */

--- a/src/server/nfs/nfs_drc_reply.h
+++ b/src/server/nfs/nfs_drc_reply.h
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+struct chimera_server_nfs_thread;
+struct evpl_rpc2_encoding;
+
+/*
+ * Shared helpers for the NFSv3/NFSv4 duplicate-request caches.
+ *
+ * A captured reply (from the rpc2 reply_capture_cb) is the full on-wire TCP
+ * reply: [record-mark(4)][RPC reply header][procedure result body].  Both DRCs
+ * cache only the procedure-result body and re-emit it through the rpc2 reply
+ * path on replay, so the RPC header (xid, verifier) and transport framing are
+ * regenerated for the current connection -- which may differ from the one the
+ * reply was first captured on (a different transport, or, after a restart, a
+ * brand-new connection entirely).
+ */
+
+/* Parse a captured on-wire reply and yield the offset of the procedure-result
+ * body within it.  Returns false unless the buffer is a well-formed
+ * MSG_ACCEPTED / SUCCESS reply (the only kind worth replaying). */
+bool
+nfs_drc_reply_body_offset(
+    const uint8_t *buf,
+    uint32_t       len,
+    uint32_t      *offset);
+
+/* Strip the cached reply down to its procedure-result body and send it as the
+ * reply for `encoding`'s request.  Returns 0 on success. */
+int
+nfs_drc_send_cached_reply(
+    struct chimera_server_nfs_thread *thread,
+    struct evpl_rpc2_encoding        *encoding,
+    const uint8_t                    *cached,
+    uint32_t                          cached_len);

--- a/src/server/nfs/nfs_kv_keys.h
+++ b/src/server/nfs/nfs_kv_keys.h
@@ -38,11 +38,16 @@ enum chimera_kv_record_type {
     CHIMERA_KV_TYPE_NFS4_EPOCH    = 0x02, /* singleton server boot-epoch marker */
     CHIMERA_KV_TYPE_NFS4_SESSION  = 0x03, /* session metadata (nfs4_drc only)   */
     CHIMERA_KV_TYPE_NFS4_REPLY    = 0x04, /* reply-cache slot entry (nfs4_drc)  */
-    /* 0x05 .. 0xFE reserved for future global record types */
+    CHIMERA_KV_TYPE_NFS3_REPLY    = 0x05, /* NFSv3 DRC reply entry (nfs3_drc)   */
+    /* 0x06 .. 0xFE reserved for future global record types */
 };
 
+/* Longest normalized client address string an NFSv3 DRC key embeds (IPv6
+ * literal, no port -- comfortably inside INET6_ADDRSTRLEN). */
+#define CHIMERA_KV_NFS3_ADDR_MAX 48u
+
 /* Largest key any NFS record type produces: header + a full client owner. */
-#define CHIMERA_KV_NFS_KEY_MAX (CHIMERA_KV_HDR_LEN + NFS4_OPAQUE_LIMIT)
+#define CHIMERA_KV_NFS_KEY_MAX   (CHIMERA_KV_HDR_LEN + NFS4_OPAQUE_LIMIT)
 
 /* ----------------------------------------------------------------------- *
 *  Little-endian value (de)serialization helpers                          *
@@ -167,3 +172,31 @@ nfs_kv_reply_key(
 #define CHIMERA_KV_REPLY_KEY_LEN \
         (CHIMERA_KV_HDR_LEN + NFS4_SESSIONID_SIZE + 4 + 4)
 #define CHIMERA_KV_SESSION_KEY_LEN (CHIMERA_KV_HDR_LEN + NFS4_SESSIONID_SIZE)
+
+/* NFSv3 DRC key = header + addr_len(1) + client addr bytes + proc(LE32) +
+ * xid(LE32) + checksum(LE64).  The client address is the request's source IP
+ * with the ephemeral port stripped, so it stays stable across the reconnect a
+ * retransmit rides in on.  proc + xid + checksum disambiguate a reused xid:
+ * a hit means the same client re-presenting an identical call. */
+static inline uint32_t
+nfs_kv_nfs3_reply_key(
+    uint8_t       *buf,
+    const uint8_t *addr,
+    uint8_t        addr_len,
+    uint32_t       proc,
+    uint32_t       xid,
+    uint64_t       cksum)
+{
+    uint32_t p = nfs_kv_hdr(buf, CHIMERA_KV_TYPE_NFS3_REPLY);
+
+    buf[p++] = addr_len;
+    memcpy(buf + p, addr, addr_len);
+    p += addr_len;
+    nfs_kv_put_le32(buf, &p, proc);
+    nfs_kv_put_le32(buf, &p, xid);
+    nfs_kv_put_le64(buf, &p, cksum);
+    return p;
+} /* nfs_kv_nfs3_reply_key */
+
+#define CHIMERA_KV_NFS3_REPLY_KEY_MAX \
+        (CHIMERA_KV_HDR_LEN + 1 + CHIMERA_KV_NFS3_ADDR_MAX + 4 + 4 + 8)

--- a/src/server/nfs/tests/CMakeLists.txt
+++ b/src/server/nfs/tests/CMakeLists.txt
@@ -47,6 +47,8 @@ add_executable(test_nfs_persist
     ${CMAKE_CURRENT_SOURCE_DIR}/../nfs4_lease.c
     ${CMAKE_CURRENT_SOURCE_DIR}/../nfs4_recovery.c
     ${CMAKE_CURRENT_SOURCE_DIR}/../nfs4_drc.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/../nfs3_drc.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/../nfs_drc_reply.c
     ${CMAKE_CURRENT_SOURCE_DIR}/../nfs4_callback.c
     ${CMAKE_CURRENT_SOURCE_DIR}/../nfs4_cb.c)
 target_include_directories(test_nfs_persist PRIVATE

--- a/src/server/nfs/tests/test_nfs_persist.c
+++ b/src/server/nfs/tests/test_nfs_persist.c
@@ -24,6 +24,7 @@
 #include "nfs4_session.h"
 #include "nfs4_recovery.h"
 #include "nfs4_drc.h"
+#include "nfs3_drc.h"
 #include "nfs4_state.h"
 #include "nfs_kv_keys.h"
 
@@ -327,6 +328,229 @@ test_cross_reboot_replay(void)
     printf("ok: cross_reboot_replay\n");
 } /* test_cross_reboot_replay */
 
+/* ------------------------------------------------------------------ *
+*  NFSv3 DRC                                                          *
+* ------------------------------------------------------------------ */
+
+/* Build the keybuf the dispatch path would for a given client/xid/proc/body. */
+static struct nfs3_drc_keybuf
+nfs3_make_key(
+    const char*addr,
+    uint32_t   proc,
+    uint32_t   xid,
+    const void*body,
+    uint32_t   body_len)
+{
+    struct nfs3_drc_keybuf k;
+
+    memset(&k,0,sizeof(k));
+    k.addr_len = (uint8_t) strlen(addr);
+    memcpy(k.addr,addr,k.addr_len);
+    k.proc  = proc;
+    k.xid   = xid;
+    k.cksum = nfs3_drc_checksum(body,body_len);
+    return k;
+} /* nfs3_make_key */
+
+static void
+test_nfs3_key_encoding(void)
+{
+    struct nfs3_drc_keybuf k = nfs3_make_key("10.1.2.3",9,0x11223344,
+                                             "abc",3);
+    uint8_t                buf[CHIMERA_KV_NFS3_REPLY_KEY_MAX];
+    uint32_t               klen,p;
+
+    klen = nfs_kv_nfs3_reply_key(buf,k.addr,k.addr_len,k.proc,k.xid,
+                                 k.cksum);
+
+    /* header */
+    CHECK(buf[0] == CHIMERA_KV_MAGIC);
+    CHECK(buf[1] == CHIMERA_KV_VERSION);
+    CHECK(buf[2] == CHIMERA_KV_TYPE_NFS3_REPLY);
+    /* addr_len + addr */
+    p = CHIMERA_KV_HDR_LEN;
+    CHECK(buf[p] == k.addr_len);
+    p++;
+    CHECK(memcmp(buf + p,"10.1.2.3",8) == 0);
+    p += k.addr_len;
+    /* proc, xid (LE32), cksum (LE64) */
+    CHECK(nfs_kv_le32(buf + p) == 9); p          += 4;
+    CHECK(nfs_kv_le32(buf + p) == 0x11223344); p += 4;
+    CHECK(nfs_kv_le64(buf + p) == k.cksum); p    += 8;
+    CHECK(klen == p);
+    CHECK(klen <= CHIMERA_KV_NFS3_REPLY_KEY_MAX);
+
+    printf("ok: nfs3_key_encoding\n");
+} /* test_nfs3_key_encoding */
+
+static void
+test_nfs3_checksum_and_cacheable(void)
+{
+    /* Deterministic + sensitive to content. */
+    CHECK(nfs3_drc_checksum("hello",5) == nfs3_drc_checksum("hello",5));
+    CHECK(nfs3_drc_checksum("hello",5) != nfs3_drc_checksum("hellp",5));
+    CHECK(nfs3_drc_checksum("hello",5) != nfs3_drc_checksum("hell",4));
+
+    /* Non-idempotent ops are cached; idempotent ones bypass. */
+    CHECK(nfs3_drc_proc_cacheable(9));   /* MKDIR   */
+    CHECK(nfs3_drc_proc_cacheable(8));   /* CREATE  */
+    CHECK(nfs3_drc_proc_cacheable(12));  /* REMOVE  */
+    CHECK(nfs3_drc_proc_cacheable(14));  /* RENAME  */
+    CHECK(nfs3_drc_proc_cacheable(2));   /* SETATTR */
+    CHECK(!nfs3_drc_proc_cacheable(0));  /* NULL    */
+    CHECK(!nfs3_drc_proc_cacheable(1));  /* GETATTR */
+    CHECK(!nfs3_drc_proc_cacheable(6));  /* READ    */
+    CHECK(!nfs3_drc_proc_cacheable(7));  /* WRITE   */
+    CHECK(!nfs3_drc_proc_cacheable(21)); /* COMMIT  */
+
+    printf("ok: nfs3_checksum_and_cacheable\n");
+} /* test_nfs3_checksum_and_cacheable */
+
+static void
+test_nfs3_value_roundtrip(void)
+{
+    const uint8_t body[] = { 0xDE,0xAD,0xBE,0xEF,0x01,0x02 };
+    uint8_t       buf[NFS3_DRC_VALUE_HDR_LEN + sizeof(body)];
+    uint64_t      ts_in = 0x0123456789ABCDEFull,ts_out;
+    const uint8_t*out_body;
+    uint32_t      n,out_len;
+
+    n = nfs3_drc_value_serialize(buf,sizeof(buf),ts_in,body,sizeof(body));
+    CHECK(n == sizeof(buf));
+
+    CHECK(nfs3_drc_value_parse(buf,n,&ts_out,&out_body,&out_len) == 0);
+    CHECK(ts_out == ts_in);
+    CHECK(out_len == sizeof(body));
+    CHECK(memcmp(out_body,body,sizeof(body)) == 0);
+
+    /* A truncated / wrong-magic buffer is rejected, not trusted. */
+    CHECK(nfs3_drc_value_parse(buf,NFS3_DRC_VALUE_HDR_LEN - 1,&ts_out,
+                               &out_body,&out_len) != 0);
+    buf[0] ^= 0xFF;
+    CHECK(nfs3_drc_value_parse(buf,n,&ts_out,&out_body,&out_len) != 0);
+
+    printf("ok: nfs3_value_roundtrip\n");
+} /* test_nfs3_value_roundtrip */
+
+static void
+test_nfs3_cache_lookup(void)
+{
+    struct nfs3_drc        drc;
+    struct nfs3_drc_keybuf k1 = nfs3_make_key("192.168.0.9",9,7001,
+                                              "mkdir-args-A",12);
+    struct nfs3_drc_keybuf k2 = nfs3_make_key("192.168.0.9",9,7002,
+                                              "mkdir-args-B",12);
+    const uint8_t          reply[] = "REPLY-BYTES-FOR-K1";
+    uint8_t               *out;
+    uint32_t               out_len;
+
+    nfs3_drc_init(&drc);
+
+    /* Miss on an empty cache. */
+    CHECK(nfs3_drc_cache_lookup(&drc,&k1,&out,&out_len) == 0);
+
+    nfs3_drc_cache_insert(&drc,&k1,reply,sizeof(reply),1);
+
+    /* Hit returns the exact bytes. */
+    CHECK(nfs3_drc_cache_lookup(&drc,&k1,&out,&out_len) == 1);
+    CHECK(out_len == sizeof(reply));
+    CHECK(memcmp(out,reply,sizeof(reply)) == 0);
+    free(out);
+
+    /* A different xid (same client/proc) is a distinct identity -> miss. */
+    CHECK(nfs3_drc_cache_lookup(&drc,&k2,&out,&out_len) == 0);
+
+    /* Re-insert under the same key replaces last-writer-wins. */
+    nfs3_drc_cache_insert(&drc,&k1,"NEW",3,2);
+    CHECK(nfs3_drc_cache_lookup(&drc,&k1,&out,&out_len) == 1);
+    CHECK(out_len == 3 && memcmp(out,"NEW",3) == 0);
+    free(out);
+
+    nfs3_drc_destroy(&drc);
+    printf("ok: nfs3_cache_lookup\n");
+} /* test_nfs3_cache_lookup */
+
+/*
+ * The decisive NFSv3 check: persist a reply exactly as the capture path does
+ * (KV key + value bytes), "reboot" into a fresh cache, parse those bytes back
+ * the way the cold-start scan does, and confirm the retransmit's identity hits
+ * and replays the original reply.
+ */
+static void
+test_nfs3_cross_reboot(void)
+{
+    const char            *addr = "172.16.5.20";
+    const uint32_t         proc = 9 /* MKDIR */,xid = 0xCAFEBABE;
+    const uint8_t          args[]   = "dirfh+name+attrs";
+    const uint8_t          reply[]  = "cached MKDIR3res success body";
+    struct nfs3_drc_keybuf k_before = nfs3_make_key(addr,proc,xid,
+                                                    args,sizeof(args));
+
+    /* --- before reboot: serialize the KV key + value --- */
+    uint8_t                kvkey[CHIMERA_KV_NFS3_REPLY_KEY_MAX];
+    uint32_t               kvkey_len = nfs_kv_nfs3_reply_key(kvkey,k_before.addr,
+                                                             k_before.addr_len,k_before.proc,
+                                                             k_before.xid,k_before.cksum);
+    uint8_t                kvval[NFS3_DRC_VALUE_HDR_LEN + sizeof(reply)];
+    uint32_t               kvval_len = nfs3_drc_value_serialize(kvval,sizeof(kvval),
+                                                                0xABCDull,reply,
+                                                                sizeof(reply));
+
+    CHECK(kvval_len == sizeof(kvval));
+
+    /* --- reboot: a fresh, empty cache --- */
+    struct nfs3_drc        drc;
+
+    nfs3_drc_init(&drc);
+
+    /* --- reload: parse the persisted key back into a keybuf (mirrors
+     * nfs3_drc_reload_scan_cb), parse the value, and insert. --- */
+    struct nfs3_drc_keybuf k_after;
+    const uint8_t         *body;
+    uint64_t               ts;
+    uint32_t               body_len,p;
+    uint8_t                addr_len;
+
+    CHECK(memcmp(kvkey,(uint8_t[]) { CHIMERA_KV_MAGIC,CHIMERA_KV_VERSION,
+                                     CHIMERA_KV_TYPE_NFS3_REPLY },3) == 0);
+    addr_len = kvkey[CHIMERA_KV_HDR_LEN];
+    p        = CHIMERA_KV_HDR_LEN + 1;
+    CHECK(addr_len <= NFS3_DRC_ADDR_MAX);
+    CHECK(p + addr_len + 16 <= kvkey_len);
+
+    memset(&k_after,0,sizeof(k_after));
+    memcpy(k_after.addr,kvkey + p,addr_len);
+    k_after.addr_len = addr_len;
+    p               += addr_len;
+    k_after.proc     = nfs_kv_le32(kvkey + p); p += 4;
+    k_after.xid      = nfs_kv_le32(kvkey + p); p += 4;
+    k_after.cksum    = nfs_kv_le64(kvkey + p);
+
+    CHECK(nfs3_drc_value_parse(kvval,kvval_len,&ts,&body,&body_len) == 0);
+    nfs3_drc_cache_insert(&drc,&k_after,body,body_len,ts);
+
+    /* --- retransmit after reboot: the client re-presents an identical call.
+     * The independently-recomputed key must hit and return the cached reply. */
+    struct nfs3_drc_keybuf k_retransmit = nfs3_make_key(addr,proc,xid,
+                                                        args,sizeof(args));
+    uint8_t               *out;
+    uint32_t               out_len;
+
+    CHECK(nfs3_drc_cache_lookup(&drc,&k_retransmit,&out,&out_len) == 1);
+    CHECK(out_len == sizeof(reply));
+    CHECK(memcmp(out,reply,sizeof(reply)) == 0);
+    free(out);
+
+    /* A retransmit whose body differs (xid reuse for a new call) must NOT hit
+     * the stale entry -- the checksum disambiguates it. */
+    struct nfs3_drc_keybuf k_other = nfs3_make_key(addr,proc,xid,
+                                                   "different-args",14);
+    CHECK(nfs3_drc_cache_lookup(&drc,&k_other,&out,&out_len) == 0);
+
+    nfs3_drc_destroy(&drc);
+    printf("ok: nfs3_cross_reboot\n");
+} /* test_nfs3_cross_reboot */
+
 int
 main(void)
 {
@@ -340,6 +564,12 @@ main(void)
     test_session_record_roundtrip();
     test_reply_record_roundtrip();
     test_cross_reboot_replay();
+
+    test_nfs3_key_encoding();
+    test_nfs3_checksum_and_cacheable();
+    test_nfs3_value_roundtrip();
+    test_nfs3_cache_lookup();
+    test_nfs3_cross_reboot();
 
     printf("PASS: all nfs persistence tests\n");
     return 0;

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -65,6 +65,7 @@ struct chimera_server_config {
     int                                   nfs4_session_slots;
     int                                   nfs4_delegations;
     int                                   nfs4_drc;
+    int                                   nfs3_drc;
     uint32_t                              nfs4_lease_time_s;
     uint32_t                              nfs4_grace_time_s;
     uint32_t                              nfs4_courtesy_time_s;
@@ -264,7 +265,14 @@ chimera_server_config_init(void)
      * retransmit of a non-idempotent op replays its cached reply across a
      * server restart.  Recovery-record persistence is independent and always
      * on. */
-    config->nfs4_drc             = 0;
+    config->nfs4_drc = 0;
+    /* NFSv3 duplicate-request cache.  Default off.  When enabled, the reply of
+     * a non-idempotent NFSv3 op is captured and (if kv_module is persistent)
+     * written through to the KV store keyed by {client, xid, proc, checksum},
+     * so a retransmit after a server restart replays the cached reply instead
+     * of re-executing.  There is no session and no on-wire advertisement -- the
+     * cache is transparent to the client. */
+    config->nfs3_drc             = 0;
     config->nfs4_lease_time_s    = NFS4_LEASE_TIME_DEFAULT_S;
     config->nfs4_grace_time_s    = NFS4_GRACE_TIME_DEFAULT_S;
     config->nfs4_courtesy_time_s = NFS4_COURTESY_TIME_DEFAULT_S;
@@ -569,6 +577,20 @@ chimera_server_config_get_nfs4_drc(const struct chimera_server_config *config)
 {
     return config->nfs4_drc;
 } /* chimera_server_config_get_nfs4_drc */
+
+SYMBOL_EXPORT void
+chimera_server_config_set_nfs3_drc(
+    struct chimera_server_config *config,
+    int                           enable)
+{
+    config->nfs3_drc = enable;
+} /* chimera_server_config_set_nfs3_drc */
+
+SYMBOL_EXPORT int
+chimera_server_config_get_nfs3_drc(const struct chimera_server_config *config)
+{
+    return config->nfs3_drc;
+} /* chimera_server_config_get_nfs3_drc */
 
 SYMBOL_EXPORT void
 chimera_server_config_set_nfs4_lease_time(

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -197,6 +197,15 @@ chimera_server_config_get_nfs4_drc(
     const struct chimera_server_config *config);
 
 void
+chimera_server_config_set_nfs3_drc(
+    struct chimera_server_config *config,
+    int                           enable);
+
+int
+chimera_server_config_get_nfs3_drc(
+    const struct chimera_server_config *config);
+
+void
 chimera_server_config_set_nfs4_lease_time(
     struct chimera_server_config *config,
     uint32_t                      seconds);


### PR DESCRIPTION
## Summary

Adds an optional **NFSv3 duplicate-request cache (DRC)**, gated by a new `server.nfs3_drc` option (default **off**). It is the sessionless counterpart to the NFSv4 reply cache: it identifies a request the classic NFSv3 way — `{client address (port stripped), xid, procedure, request checksum}` — so a retransmit of a non-idempotent operation replays its cached reply instead of re-executing it (avoiding a spurious `EEXIST`/`ENOENT`), **including across a server restart** when `kv_module` is persistent.

## How it works

- **Transparent dispatcher wrap.** Rather than touching every proc handler, the cache wraps the generated `NFS_V3` call dispatcher (`recv_call_dispatch`), installed only when `nfs3_drc` is enabled. On a **hit** it replays the cached reply and returns; on a **miss** it arms the rpc2 `reply_capture_cb` (the same hook the NFSv4 DRC uses) and forwards to the real handler.
- **Only non-idempotent procs are cached** (`SETATTR`/`CREATE`/`MKDIR`/`SYMLINK`/`MKNOD`/`REMOVE`/`RMDIR`/`RENAME`/`LINK`); idempotent ops and RDMA connections bypass it untouched.
- **Checksum-keyed for correctness.** A 64-bit FNV-1a checksum of the request body is folded into the key, so a reused xid that maps to a *different* call cannot false-hit. This also makes a persisted entry's replay provably correct without needing a TTL.
- **Persistence.** On a persistent backend each captured reply is written through to the KV store under a new `CHIMERA_KV_TYPE_NFS3_REPLY` key band and reloaded into the in-memory cache on the first request after a restart. On `memkv` (non-persistent) it logs a warning and acts as an in-memory-only cache for the server's uptime.
- **Shared reply plumbing.** The RPC reply body-offset/replay logic is extracted from the NFSv4 compound path into a new shared `nfs_drc_reply` unit, so both DRCs cache only the procedure-result body and re-frame it for the current connection (−111 lines of duplication in `nfs4_proc_compound.c`).

## Testing

- **Unit** (`test_nfs_persist`): key encoding, checksum + cacheable-proc selection, value (de)serialization round-trip, in-memory cache lookup/replace, and a full cross-reboot `persist → reload → replay` path including checksum disambiguation of a reused xid.
- **KVM end-to-end** (new `chimera/kvm/<image>/reboot/drc_cairn_nfs3`): drives `mkdir`/`create`/`rename`/`rmdir` over NFSv3 against a cairn-backed server with `nfs3_drc` on, restarts chimera against the same store, and asserts the reply records reload (5 reloaded).
- Validated under Release and Debug/AddressSanitizer (clean); the NFSv4 reboot test and NFSv3 cthon basics remain green (the shared-helper refactor is verified against the existing NFSv4 DRC).
