### PR TITLE
smb2: lease-break state machine — epoch/flags settle, grant self-cap, drop same-client suppression (12 subtests)

### DIFF
--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -1041,6 +1041,21 @@ chimera_smb_create_after_share(
                          * must find a live member or it revokes the fresh lease. */
                         chimera_smb_grant_add_member(grant, open_file);
 
+                        /* MS-SMB2 3.3.5.9: granting a lease never breaks another
+                         * lease.  A fresh RqLs lease whose requested mode collides
+                         * with another key's holder (e.g. RHW behind a peer's R)
+                         * must CAP ITSELF to the grantable subset (-> RH) rather
+                         * than recall the peer; otherwise try_insert would fire a
+                         * spurious break (smb2.lease.break's "no break + no change"
+                         * re-open check, nobreakself).  Legacy oplocks keep the
+                         * break-the-peer behavior (exclusive/batch arbitration), so
+                         * cap only the lease path. */
+                        if (via_rqls) {
+                            grant->lease.mode.granted =
+                                chimera_vfs_caching_grant_cap_mode(file_state,
+                                                                   &grant->lease);
+                        }
+
                         result = chimera_vfs_state_try_insert(vfs_state, file_state,
                                                               &grant->lease, &conflict);
                         while (result != CHIMERA_VFS_LEASE_GRANTED &&
@@ -1319,6 +1334,22 @@ chimera_smb_create_mkdir_open_callback(
     if (error_code != CHIMERA_VFS_OK) {
         chimera_smb_create_release_parent(request);
         chimera_smb_complete_request(request, SMB2_STATUS_OBJECT_NAME_NOT_FOUND);
+        return;
+    }
+
+    /* A lease key is bound to exactly one file per client (MS-SMB2 3.3.5.9.8).
+     * The file-create path enforces this in chimera_smb_create_open_finish, but
+     * the directory (mkdir) path completes here without passing through it, so a
+     * client opening a directory under a lease key already held on another file
+     * would slip past the check (smb2.lease.request opens fname2 as a directory
+     * under LEASE1 and expects STATUS_INVALID_PARAMETER). */
+    if ((request->create.ctx_present_mask & CHIMERA_SMB_CREATE_CTX_RQLS) &&
+        chimera_smb_session_lease_key_conflict(request->session_handle->session,
+                                               request->create.rqls.key,
+                                               oh->fh, oh->fh_len)) {
+        chimera_smb_create_release_handle(vfs_thread, oh);
+        chimera_smb_create_release_parent(request);
+        chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
         return;
     }
 

--- a/src/server/smb/smb_proc_oplock_break.c
+++ b/src/server/smb/smb_proc_oplock_break.c
@@ -349,16 +349,28 @@ chimera_smb_lease_break_cb(
     }
 
     /* A break that needs no client ack (it stripped only read caching, e.g. the
-     * R->NONE tail of an RWH->RH->R->NONE cascade) will never be resolved by an
-     * inbound OPLOCK_BREAK ack, so the ack-driven resume of parked CREATEs
-     * (chimera_smb_create_resume_parked, only called from the ack handler) never
-     * fires for it.  But the lease is now at its retained level, so
-     * chimera_vfs_state_caching_breaking() returns false and any CREATE parked on
-     * this file is resumable.  Ring the resume doorbell on this thread AND every
-     * peer (the broadcast skips its origin) so each re-sweeps and completes its
-     * parked CREATEs instead of stalling to the break deadline (cthon special
-     * hang).  Use the snapshotted conn_thread — same reason as above. */
+     * R->NONE tail of an RWH->RH->R->NONE cascade, or a same-key reader broken
+     * by a peer's write) will never be resolved by an inbound OPLOCK_BREAK ack.
+     * Settle the lease NOW to its retained mode so it leaves the BREAKING state:
+     *   - it must return to IDLE at its new level so a *later* conflicting op can
+     *     break it again (smb2.lease.nobreakself writes twice through one handle,
+     *     each expecting a fresh break of the other lease; begin_break is a no-op
+     *     on a lease still stuck BREAKING), and
+     *   - a same-key re-open must NOT report SMB2_LEASE_FLAG_BREAK_IN_PROGRESS
+     *     once the (un-acked) downgrade has settled (smb2.lease.break's third
+     *     open checks lease_flags == 0).
+     * chimera_vfs_lease_ack with the retained mode is the canonical settle: it
+     * re-arms a surviving lease to IDLE (or goes inert ACKED at NONE) and pumps
+     * any acquirer parked on the break.  An ack-required break instead waits for
+     * the client's real OPLOCK_BREAK ack (handled in chimera_smb_oplock_break). */
     if (!grant->break_ack_required) {
+        struct chimera_vfs_lease_mode settled = {
+            .granted = new_vfs,
+            .denied  = 0,
+        };
+
+        chimera_vfs_lease_ack(lease, settled);
+
         evpl_ring_doorbell(&conn_thread->lease_resume_doorbell);
         chimera_smb_create_resume_parked_broadcast(conn_thread);
     }

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -1491,6 +1491,11 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.kernel-oplocks.kernel_oplocks8
     # smb2.lease
     smb2.lease.break
+    smb2.lease.breaking1
+    smb2.lease.breaking2
+    smb2.lease.breaking3
+    smb2.lease.breaking5
+    smb2.lease.breaking6
     smb2.lease.complex1
     smb2.lease.duplicate_create
     smb2.lease.duplicate_open
@@ -1500,13 +1505,17 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.lease.statopen
     smb2.lease.statopen2
     smb2.lease.statopen3
+    smb2.lease.statopen4
     smb2.lease.upgrade
     smb2.lease.upgrade2
     smb2.lease.upgrade3
     smb2.lease.v1_bug15148
     smb2.lease.v2_bug15148
+    smb2.lease.v2_complex1
     smb2.lease.v2_complex2
     smb2.lease.v2_epoch1
+    smb2.lease.v2_epoch2
+    smb2.lease.v2_epoch3
     smb2.lease.v2_flags_breaking
     smb2.lease.v2_flags_parentkey
     # smb2.lock
@@ -3101,6 +3110,11 @@ set(SMBTORTURE_ENABLED_diskfs_io_uring
     smb2.kernel-oplocks.kernel_oplocks8
     # smb2.lease
     smb2.lease.break
+    smb2.lease.breaking1
+    smb2.lease.breaking2
+    smb2.lease.breaking3
+    smb2.lease.breaking5
+    smb2.lease.breaking6
     smb2.lease.complex1
     smb2.lease.duplicate_create
     smb2.lease.duplicate_open
@@ -3109,13 +3123,17 @@ set(SMBTORTURE_ENABLED_diskfs_io_uring
     smb2.lease.rename_wait
     smb2.lease.statopen2
     smb2.lease.statopen3
+    smb2.lease.statopen4
     smb2.lease.upgrade
     smb2.lease.upgrade2
     smb2.lease.upgrade3
     smb2.lease.v1_bug15148
     smb2.lease.v2_bug15148
+    smb2.lease.v2_complex1
     smb2.lease.v2_complex2
     smb2.lease.v2_epoch1
+    smb2.lease.v2_epoch2
+    smb2.lease.v2_epoch3
     smb2.lease.v2_flags_breaking
     smb2.lease.v2_flags_parentkey
     # smb2.lock

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -1490,9 +1490,12 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.kernel-oplocks.kernel_oplocks3
     smb2.kernel-oplocks.kernel_oplocks8
     # smb2.lease
+    smb2.lease.break
+    smb2.lease.complex1
     smb2.lease.duplicate_create
     smb2.lease.duplicate_open
     smb2.lease.multibreak
+    smb2.lease.nobreakself
     smb2.lease.rename_wait
     smb2.lease.statopen
     smb2.lease.statopen2
@@ -3097,9 +3100,12 @@ set(SMBTORTURE_ENABLED_diskfs_io_uring
     smb2.kernel-oplocks.kernel_oplocks3
     smb2.kernel-oplocks.kernel_oplocks8
     # smb2.lease
+    smb2.lease.break
+    smb2.lease.complex1
     smb2.lease.duplicate_create
     smb2.lease.duplicate_open
     smb2.lease.multibreak
+    smb2.lease.nobreakself
     smb2.lease.rename_wait
     smb2.lease.statopen2
     smb2.lease.statopen3

--- a/src/vfs/vfs_state.c
+++ b/src/vfs/vfs_state.c
@@ -1324,10 +1324,15 @@ chimera_vfs_caching_grant_coalesce(
         /* A re-open while the lease is mid-break must NOT upgrade it: MS-SMB2
          * 3.3.5.9.11 has the re-open succeed at the lease's CURRENT (downgrading)
          * state and report SMB2_LEASE_FLAG_BREAK_IN_PROGRESS instead of granting
-         * back the bits being broken away (smb2.lease.breaking3).  Only an IDLE
-         * lease can be upgraded. */
+         * back the bits being broken away (smb2.lease.breaking3).  An IDLE lease
+         * upgrades freely; an ACKED lease is one whose break has fully SETTLED at
+         * NONE (a no-ack read-cache loss, e.g. a peer's write broke our R) -- its
+         * break is complete, so a re-open re-arms it back to a live mode (re-arm
+         * to IDLE below).  smb2.lease.nobreakself writes through a second handle
+         * to break a lease to NONE, then re-opens the same key expecting R again. */
         if (upgrade_ok &&
-            grant->lease.break_state == CHIMERA_VFS_BREAK_IDLE) {
+            (grant->lease.break_state == CHIMERA_VFS_BREAK_IDLE ||
+             grant->lease.break_state == CHIMERA_VFS_BREAK_ACKED)) {
             uint8_t cur = grant->lease.mode.granted;
 
             /* MS-SMB2 3.3.5.9.11: a lease is upgraded to the REQUESTED state only
@@ -1348,6 +1353,9 @@ chimera_vfs_caching_grant_coalesce(
                 if (chimera_vfs_state_would_conflict(file, &probe, &conflict) ==
                     CHIMERA_VFS_LEASE_GRANTED) {
                     grant->lease.mode.granted = want.granted;
+                    /* Re-arming a settled (ACKED-at-NONE) lease puts it back to
+                     * IDLE so a later conflict can break it again. */
+                    grant->lease.break_state = CHIMERA_VFS_BREAK_IDLE;
                     grant->epoch++;
                 }
             }
@@ -1406,6 +1414,49 @@ chimera_vfs_caching_grant_try_upgrade(
 
     return granted;
 } /* chimera_vfs_caching_grant_try_upgrade */
+
+/* Cap a fresh lease's requested mode to the largest subset grantable WITHOUT
+* breaking another owner's holder.  MS-SMB2 3.3.5.9: granting a lease never
+* recalls another lease -- a write-caching request that collides with another
+* key's read cache simply yields the write bit (RWH -> RH), it does not break
+* the peer.  `lease` carries the candidate mode and owner; the returned mode is
+* stepped down W then H (R is the floor) until would_conflict reports GRANTED
+* (which coalesces this owner's own lease, so a same-owner re-open never caps
+* itself).  Caller must NOT hold file->lock.  Used by the SMB create path to
+* pick the grantable lease level up front, so the subsequent try_insert never
+* fires a spurious break against a peer that should simply have capped us. */
+SYMBOL_EXPORT uint8_t
+chimera_vfs_caching_grant_cap_mode(
+    struct chimera_vfs_file_state  *file,
+    const struct chimera_vfs_lease *lease)
+{
+    struct chimera_vfs_lease  probe    = *lease;
+    struct chimera_vfs_lease *conflict = NULL;
+    uint8_t                   mode     = lease->mode.granted;
+
+    pthread_mutex_lock(&file->lock);
+    for ( ; ;) {
+        probe.mode.granted = mode;
+        if (chimera_vfs_state_would_conflict(file, &probe, &conflict) ==
+            CHIMERA_VFS_LEASE_GRANTED) {
+            break;
+        }
+        /* Step down toward the read floor: drop the exclusive write cache first,
+         * then handle caching.  Once at R with a remaining conflict there is
+         * nothing left to yield -- return R and let try_insert resolve it (a
+         * genuine cross-client read/handle conflict that a cap cannot dissolve). */
+        if (mode & CHIMERA_VFS_LEASE_MODE_W) {
+            mode &= ~CHIMERA_VFS_LEASE_MODE_W;
+        } else if (mode & CHIMERA_VFS_LEASE_MODE_H) {
+            mode &= ~CHIMERA_VFS_LEASE_MODE_H;
+        } else {
+            break;
+        }
+    }
+    pthread_mutex_unlock(&file->lock);
+
+    return mode;
+} /* chimera_vfs_caching_grant_cap_mode */
 
 SYMBOL_EXPORT void
 chimera_vfs_caching_grant_link(
@@ -1746,12 +1797,20 @@ chimera_vfs_lease_break_step(
  * already in flight, a new conflict with a lower floor only deepens the target
  * (the in-flight step still stands and the cascade carries on to the new floor);
  * it does not re-notify. */
-SYMBOL_EXPORT void
-chimera_vfs_lease_begin_break(
+/* `one_shot` forces the break straight to the floor in a single notification
+ * instead of cascading one caching bit per ack.  A conflicting OPEN negotiates
+ * the holder down step by step (the breaking* deferred-ack staircase), but a
+ * WRITE or a namespace mutation (unlink/rename/data-setattr) invalidates the
+ * whole stale cache at once, so the holder is told to drop everything above the
+ * floor in one break (MS-SMB2: a write breaks RH straight to NONE with a single
+ * ACK_REQUIRED notification — smb2.lease.complex1, nobreakself). */
+static void
+chimera_vfs_lease_begin_break_ex(
     struct chimera_vfs_state *state,
     struct chimera_vfs_lease *lease,
     uint8_t                   floor,
-    uint32_t                  deadline_ms)
+    uint32_t                  deadline_ms,
+    bool                      one_shot)
 {
     struct chimera_vfs_file_state *file = lease->file;
     chimera_vfs_lease_break_cb_t   cb;
@@ -1774,11 +1833,12 @@ chimera_vfs_lease_begin_break(
         lease->break_floor &= floor;
         should_invoke       = false;
     } else {
-        /* Only an SMB2 RqLs lease cascades one bit per ack toward the floor.  A
-         * legacy SMB oplock (one indivisible level: exclusive/batch -> II ->
-         * none) and an NFSv4 delegation (CB_RECALL returns the whole delegation)
-         * both break in a single shot, so they jump straight to the floor. */
-        step = chimera_vfs_lease_cascades(lease)
+        /* Only an SMB2 RqLs lease cascades one bit per ack toward the floor, and
+         * only for a step-wise break (a conflicting open).  A one-shot break (a
+         * write / namespace invalidation), a legacy SMB oplock (one indivisible
+         * level: exclusive/batch -> II -> none) and an NFSv4 delegation (CB_RECALL
+         * returns the whole delegation) all break in a single shot to the floor. */
+        step = (chimera_vfs_lease_cascades(lease) && !one_shot)
             ? chimera_vfs_lease_break_step(lease->mode.granted, floor)
             : floor;
         should_invoke = (step != lease->mode.granted) &&
@@ -1807,6 +1867,16 @@ chimera_vfs_lease_begin_break(
     if (cb) {
         cb(lease, step, cb_priv);
     }
+} /* chimera_vfs_lease_begin_break_ex */
+
+SYMBOL_EXPORT void
+chimera_vfs_lease_begin_break(
+    struct chimera_vfs_state *state,
+    struct chimera_vfs_lease *lease,
+    uint8_t                   floor,
+    uint32_t                  deadline_ms)
+{
+    chimera_vfs_lease_begin_break_ex(state, lease, floor, deadline_ms, false);
 } /* chimera_vfs_lease_begin_break */
 
 SYMBOL_EXPORT void
@@ -1999,7 +2069,16 @@ chimera_vfs_break_caching_file(
              *
              * Passing the granted mode would let the SMB break_cb retain a read
              * cache and ack non-zero, so this loop would see granted != 0 forever
-             * and park permanently.  NFSv4 delegations recall fully regardless. */
+             * and park permanently.  NFSv4 delegations recall fully regardless.
+             *
+             * Cascading (not one-shot): a namespace recall fans out across the
+             * distinct retain levels its callers need -- a RENAME breaks an RH
+             * holder only down to R (drop handle caching, keep the read cache,
+             * since the data is unchanged: smb2.compound_async.rename_last), while
+             * an UNLINK / data-setattr breaks all the way to NONE.  The cascade
+             * single-steps RH->R first; if the caller's floor is NONE the ack
+             * then carries R->NONE.  (A one-shot here would force rename to NONE
+             * and regress rename_last.) */
             chimera_vfs_lease_begin_break(state, to_break, 0,
                                           CHIMERA_VFS_NFS_DELEG_METAOP_MS);
         } else if (to_revoke) {
@@ -2136,7 +2215,11 @@ chimera_vfs_break_reads_for_write(
     pthread_mutex_unlock(&file->lock);
 
     for (i = 0; i < n; i++) {
-        chimera_vfs_lease_begin_break(state, to_break[i], 0, 0);
+        /* One-shot: a write invalidates the whole read+handle cache at once, so
+         * an RH holder breaks straight to NONE in a single ACK_REQUIRED
+         * notification rather than cascading RH->R->NONE (smb2.lease.complex1
+         * expects exactly one break; nobreakself). */
+        chimera_vfs_lease_begin_break_ex(state, to_break[i], 0, 0, true);
     }
 } /* chimera_vfs_break_reads_for_write */
 

--- a/src/vfs/vfs_state.c
+++ b/src/vfs/vfs_state.c
@@ -2288,25 +2288,6 @@ chimera_vfs_state_break_caching_for_open(
         if (chimera_vfs_lease_smb2_same_key(&cur->owner, opener)) {
             continue;
         }
-        /* A *non-lease* open by the SAME client must not recall that client's own
-         * RqLs lease.  The opening client is internally coherent with its own
-         * (non-data) open, so a server-driven break here is spurious -- and the
-         * Linux SMB client cannot ack a break for a lease its new plain handle
-         * does not own, so the break goes unacked, the lease is stuck BREAKING,
-         * and every such open then stalls the full break-deadline (cthon special
-         * hang).  Coherence on an actual write is preserved by the untouched
-         * chimera_vfs_break_on_write path -- so this suppresses ONLY the open
-         * break, never the write break (the over-broad earlier suppression of the
-         * write break served stale reads and was reverted).  A *lease* opener with
-         * a different key (2nd LeaseKey, same client) still breaks here, as
-         * MS-SMB2 Leasing_*_SameLeaseKey / smb2.lease.complex1 require. */
-        if (opener->protocol == CHIMERA_VFS_LEASE_PROTO_SMB2 &&
-            cur->owner.protocol == CHIMERA_VFS_LEASE_PROTO_SMB2 &&
-            !opener->is_lease &&
-            opener->client_key == cur->owner.client_key &&
-            cur->grant && !cur->grant->is_oplock) {
-            continue;
-        }
         /* A pure handle-trigger break (the pre-share-check pass) is a legacy SMB
          * oplock behavior: a batch oplock's handle is recalled before the share
          * decision so the holder can close.  An SMB2 RqLs LEASE keeps its handle

--- a/src/vfs/vfs_state.h
+++ b/src/vfs/vfs_state.h
@@ -237,6 +237,15 @@ chimera_vfs_caching_grant_link(
     struct chimera_vfs_file_state    *file,
     struct chimera_vfs_caching_grant *grant);
 
+/* Cap a fresh lease's requested mode to the largest subset grantable WITHOUT
+ * breaking another owner (MS-SMB2 3.3.5.9: granting a lease never recalls
+ * another lease).  Steps the candidate mode down W then H toward the R floor
+ * until it would be granted.  Caller must NOT hold file->lock. */
+uint8_t
+chimera_vfs_caching_grant_cap_mode(
+    struct chimera_vfs_file_state  *file,
+    const struct chimera_vfs_lease *lease);
+
 enum chimera_vfs_lease_result
 chimera_vfs_caching_grant_acquire(
     struct chimera_vfs_state             *state,


### PR DESCRIPTION
## Summary

Lease-break state-machine correctness fixes that take `smb2.lease` from 3 to **12 passing subtests** (enabled on memfs and diskfs_io_uring), in two parts.

### Part 1 — epoch/flags settle + grant self-cap (`break`, `nobreakself`, `complex1`)
Three root causes in the shared VFS lease layer (`src/vfs/vfs_state.c`) and the SMB break path (`src/server/smb/smb_proc_oplock_break.c`):
1. **No-ack break left the lease stuck `BREAKING`.** A read-cache-only break needs no client ack, but the break_cb never settled the lease — so a same-key re-open spuriously reported `LEASE_FLAG_BREAK_IN_PROGRESS` and a later conflicting op couldn't re-break. Fix: self-ack to the retained mode on the no-ack path; re-arm an `ACKED`-at-NONE lease on coalesce.
2. **Spurious break on a fresh lease grant.** A contender requesting RHW behind a peer's R fired a break before capping itself. MS-SMB2 3.3.5.9: a lease grant never recalls another lease. New `chimera_vfs_caching_grant_cap_mode` caps the request (W→H→R) before insertion.
3. **One-shot write break vs. per-bit cascade.** A write breaks RH→NONE in a single `ACK_REQUIRED` notification, not a cascade (the namespace recall stays cascading — rename retains R, unlink goes to NONE).

### Part 2 — drop the same-client non-lease break suppression
Commit `97a3beb5` suppressed recalling a client's own RqLs lease for that same client's *non-lease* SMB2 open, to dodge a cthon hang **when leases were on**: the Linux kernel cifs client left the break unacked → lease stuck `BREAKING` → opens stalled the break deadline.

That suppression is a spec deviation (MS-SMB2 3.3.5.9: a non-lease open isn't on the holder's LeaseKey, so it must recall a conflicting lease — and smbtorture expects the break) and is **no longer load-bearing**: the KVM SMB cthon suite runs **leases off** (`kvm/kvm_smb_test_wrapper.sh` sets neither `smb_leases` nor `smb_oplocks`; both default off), and the suppressed branch only fires for an active lease grant — dead code in that scenario, so the original hang can't recur in CI.

Removing it, combined with Part 1, additionally greens `breaking1/2/3/5/6`, `statopen4`, `v2_complex1`, `v2_epoch2/3` — `breaking2/5` and `v2_complex1` pass only because the deferred-open break handshake now both fires correctly **and** settles.

**Interop caveat:** `smb_leases` is off by default. A real leases-on deployment with the Linux kernel cifs client is the only place the unacked-break hang could resurface — the documented "leave leases off for cthon" tradeoff. The suppression was gated on both opener and owner being SMB2, so **NFSv4 delegations are structurally unaffected**.

### Verification
- All 12 subtests 3× green on memfs and diskfs_io_uring (Debug/ASan).
- All 151 enabled `smb2.{lease,oplock,durable-open,durable-v2-open,replay,compound,compound_async}` subtests pass — **zero regressions**.
- 156 pynfs delegation tests pass (shared lease layer); disconnect-race ctests green; Debug/ASan and Release both clean.
