### PR TITLE
SMB3 directory leases on the unified VFS lease layer

### DIFF
--- a/src/client/client_remove.h
+++ b/src/client/client_remove.h
@@ -103,6 +103,7 @@ chimera_remove_at_lookup_complete(
         request->remove.child_fh_len,
         0,
         0,
+        NULL,
         chimera_remove_dispatch_at_complete,
         request);
 } /* chimera_remove_at_lookup_complete */

--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -418,6 +418,11 @@ main(
         chimera_server_config_set_smb_persistent_handles(server_config, json_is_true(json_value));
     }
 
+    json_value = json_object_get(server_params, "smb_directory_leases");
+    if (json_is_boolean(json_value)) {
+        chimera_server_config_set_smb_directory_leases(server_config, json_is_true(json_value));
+    }
+
     json_value = json_object_get(server_params, "smb_named_streams");
     if (json_is_boolean(json_value)) {
         chimera_server_config_set_smb_named_streams(server_config, json_is_true(json_value));

--- a/src/server/nfs/nfs3_proc_link.c
+++ b/src/server/nfs/nfs3_proc_link.c
@@ -68,6 +68,8 @@ chimera_nfs3_link(
                         CHIMERA_NFS3_ATTR_MASK,
                         CHIMERA_NFS3_ATTR_WCC_MASK | CHIMERA_VFS_ATTR_ATOMIC,
                         CHIMERA_NFS3_ATTR_MASK,
+                        NULL,
+                        NULL,
                         chimera_nfs3_link_complete,
                         req);
 } /* chimera_nfs3_link */

--- a/src/server/nfs/nfs3_proc_remove.c
+++ b/src/server/nfs/nfs3_proc_remove.c
@@ -64,6 +64,7 @@ chimera_nfs3_remove_open_callback(
                               0,
                               CHIMERA_NFS3_ATTR_WCC_MASK,
                               CHIMERA_NFS3_ATTR_MASK,
+                              NULL,
                               chimera_nfs3_remove_complete,
                               req);
     } else {

--- a/src/server/nfs/nfs3_proc_rename.c
+++ b/src/server/nfs/nfs3_proc_rename.c
@@ -71,6 +71,8 @@ chimera_nfs3_rename(
                           0,
                           CHIMERA_NFS3_ATTR_WCC_MASK | CHIMERA_VFS_ATTR_ATOMIC,
                           CHIMERA_NFS3_ATTR_MASK,
+                          NULL,
+                          NULL,
                           chimera_nfs3_rename_complete,
                           req);
 } /* chimera_nfs3_rename */

--- a/src/server/nfs/nfs3_proc_rmdir.c
+++ b/src/server/nfs/nfs3_proc_rmdir.c
@@ -64,6 +64,7 @@ chimera_nfs3_rmdir_open_callback(
                               0,
                               CHIMERA_NFS3_ATTR_WCC_MASK,
                               CHIMERA_NFS3_ATTR_MASK,
+                              NULL,
                               chimera_nfs3_rmdir_complete,
                               req);
     } else {

--- a/src/server/nfs/nfs4_proc_link.c
+++ b/src/server/nfs/nfs4_proc_link.c
@@ -77,6 +77,8 @@ chimera_nfs4_link_open_callback(
         0,
         CHIMERA_VFS_ATTR_MTIME,
         CHIMERA_VFS_ATTR_MTIME,
+        NULL,
+        NULL,
         chimera_nfs4_link_complete,
         req);
 

--- a/src/server/nfs/nfs4_proc_remove.c
+++ b/src/server/nfs/nfs4_proc_remove.c
@@ -94,7 +94,7 @@ nfs4_remove_ds_root_opened(
     chimera_vfs_remove_at(ctx->req->thread->vfs_thread, &ctx->req->cred,
                           ctx->ds_root_handle,
                           ctx->backing_name, strlen(ctx->backing_name),
-                          NULL, 0, 0, 0,
+                          NULL, 0, 0, 0, NULL,
                           nfs4_remove_ds_backing_complete, ctx);
 } /* nfs4_remove_ds_root_opened */
 
@@ -140,7 +140,7 @@ nfs4_remove_mds(struct nfs4_remove_ctx *ctx)
     chimera_vfs_remove_at(req->thread->vfs_thread, &req->cred,
                           ctx->parent_handle,
                           args->target.data, args->target.len,
-                          NULL, 0, 0, 0,
+                          NULL, 0, 0, 0, NULL,
                           nfs4_remove_mds_complete, ctx);
 } /* nfs4_remove_mds */
 

--- a/src/server/nfs/nfs4_proc_rename.c
+++ b/src/server/nfs/nfs4_proc_rename.c
@@ -63,6 +63,8 @@ chimera_nfs4_rename_do(struct nfs_request *req)
         0,
         CHIMERA_VFS_ATTR_MTIME,
         CHIMERA_VFS_ATTR_MTIME,
+        NULL,
+        NULL,
         chimera_nfs4_rename_complete,
         req);
 } /* chimera_nfs4_rename_do */

--- a/src/server/s3/s3_copy.c
+++ b/src/server/s3/s3_copy.c
@@ -299,6 +299,8 @@ chimera_s3_copy_finalize(struct chimera_s3_copy_ctx *ctx)
             0,
             0,
             0,
+            NULL,
+            NULL,
             chimera_s3_copy_rename_callback,
             ctx);
     } else {
@@ -315,6 +317,8 @@ chimera_s3_copy_finalize(struct chimera_s3_copy_ctx *ctx)
             CHIMERA_VFS_ATTR_FH | CHIMERA_VFS_ATTR_MASK_STAT,
             0,
             0,
+            NULL,
+            NULL,
             chimera_s3_copy_link_callback,
             ctx);
     }

--- a/src/server/s3/s3_delete.c
+++ b/src/server/s3/s3_delete.c
@@ -60,6 +60,7 @@ chimera_s3_delete_open_callback(
                           0,
                           0,
                           0,
+                          NULL,
                           chimera_s3_delete_remove_callback,
                           request);
 

--- a/src/server/s3/s3_delete_objects.c
+++ b/src/server/s3/s3_delete_objects.c
@@ -422,6 +422,7 @@ chimera_s3_del_open_cb(
                           request->del.cur_name,
                           request->del.cur_name_len,
                           NULL, 0, 0, 0,
+                          NULL,
                           chimera_s3_del_remove_cb,
                           request);
 } /* chimera_s3_del_open_cb */

--- a/src/server/s3/s3_multipart.c
+++ b/src/server/s3/s3_multipart.c
@@ -319,6 +319,7 @@ chimera_s3_part_destroy_open_dir_callback(
         0,
         0,
         0,
+        NULL,
         chimera_s3_part_destroy_remove_callback,
         ctx);
 } /* chimera_s3_part_destroy_open_dir_callback */
@@ -2343,6 +2344,8 @@ chimera_s3_complete_finalize(struct chimera_s3_complete_ctx *ctx)
             0,
             0,
             0,
+            NULL,
+            NULL,
             chimera_s3_complete_rename_callback,
             ctx);
     } else {
@@ -2359,6 +2362,8 @@ chimera_s3_complete_finalize(struct chimera_s3_complete_ctx *ctx)
             CHIMERA_VFS_ATTR_FH | CHIMERA_VFS_ATTR_MASK_STAT,
             0,
             0,
+            NULL,
+            NULL,
             chimera_s3_complete_link_callback,
             ctx);
     }

--- a/src/server/s3/s3_put.c
+++ b/src/server/s3/s3_put.c
@@ -115,6 +115,8 @@ chimera_s3_put_rename(struct chimera_s3_request *request)
             0,
             0,
             0,
+            NULL,
+            NULL,
             chimera_s3_put_rename_callback,
             request);
     } else {
@@ -131,6 +133,8 @@ chimera_s3_put_rename(struct chimera_s3_request *request)
             CHIMERA_VFS_ATTR_FH | CHIMERA_VFS_ATTR_MASK_STAT,
             0,
             0,
+            NULL,
+            NULL,
             chimera_s3_put_link_callback,
             request);
     }

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -76,6 +76,7 @@ struct chimera_server_config {
     int                                   smb_num_dialects;
     uint32_t                              smb_dialects[16];
     int                                   smb_persistent_handles;
+    int                                   smb_directory_leases;
     int                                   smb_named_streams;
     int                                   smb_signing_required;
     int                                   smb_encryption;
@@ -164,6 +165,12 @@ chimera_server_config_init(void)
     /* SMB3 durable/persistent handles are off by default; they are an
      * opt-in feature gated by the "smb_persistent_handles" config flag. */
     config->smb_persistent_handles = 0;
+
+    /* SMB3 directory leases are off by default; they are an opt-in feature
+     * gated by the "smb_directory_leases" config flag.  When enabled the server
+     * advertises SMB2_GLOBAL_CAP_DIRECTORY_LEASING and grants R/H leases on
+     * directory opens (SMB 3.0+, RqLs v2 only). */
+    config->smb_directory_leases = 0;
 
     /* Named streams (SMB ADS) are off by default; opt-in via the
      * "smb_named_streams" config flag and only honored on backends that
@@ -360,6 +367,20 @@ chimera_server_config_get_smb_persistent_handles(const struct chimera_server_con
 {
     return config->smb_persistent_handles;
 } /* chimera_server_config_get_smb_persistent_handles */
+
+SYMBOL_EXPORT void
+chimera_server_config_set_smb_directory_leases(
+    struct chimera_server_config *config,
+    int                           enable)
+{
+    config->smb_directory_leases = enable;
+} /* chimera_server_config_set_smb_directory_leases */
+
+SYMBOL_EXPORT int
+chimera_server_config_get_smb_directory_leases(const struct chimera_server_config *config)
+{
+    return config->smb_directory_leases;
+} /* chimera_server_config_get_smb_directory_leases */
 
 SYMBOL_EXPORT void
 chimera_server_config_set_smb_named_streams(

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -84,6 +84,15 @@ chimera_server_config_get_smb_persistent_handles(
     const struct chimera_server_config *config);
 
 void
+chimera_server_config_set_smb_directory_leases(
+    struct chimera_server_config *config,
+    int                           enable);
+
+int
+chimera_server_config_get_smb_directory_leases(
+    const struct chimera_server_config *config);
+
+void
 chimera_server_config_set_smb_named_streams(
     struct chimera_server_config *config,
     int                           enable);

--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -147,6 +147,7 @@ chimera_smb_server_init(
 
     shared->config.soft_fail_bad_req          = chimera_server_config_get_soft_fail_bad_req(config);
     shared->config.persistent_handles         = chimera_server_config_get_smb_persistent_handles(config);
+    shared->config.directory_leases           = chimera_server_config_get_smb_directory_leases(config);
     shared->config.named_streams              = chimera_server_config_get_smb_named_streams(config);
     shared->config.signing_required           = chimera_server_config_get_smb_signing_required(config);
     shared->config.encryption                 = chimera_server_config_get_smb_encryption(config);
@@ -158,6 +159,10 @@ chimera_smb_server_init(
 
     if (shared->config.persistent_handles) {
         chimera_smb_info("SMB3 durable/persistent handles enabled (in-memory state)");
+    }
+
+    if (shared->config.directory_leases) {
+        chimera_smb_info("SMB3 directory leases enabled");
     }
 
     if (shared->config.named_streams) {
@@ -822,6 +827,24 @@ chimera_smb_compound_reply(struct chimera_smb_compound *compound)
         evpl_sendv(evpl, conn->bind, reply_iov, reply_niov, reply_payload_length + reply_hdr_len,
                    EVPL_SEND_FLAG_TAKE_REF);
     }
+
+    /* This compound's reply has now been queued on the connection.  Drop the
+     * in-flight count and flush any dir-lease break notifications that were
+     * queued while processing it: they go out AFTER the reply above (same bind,
+     * so TCP delivers reply-then-break), which is the order the client needs to
+     * defer its break ack correctly (MS-SMB2; smbtorture dirlease rename/unlink).
+     * Cross-connection / reaper breaks (queued with no in-flight compound) were
+     * sent via the doorbell instead and are unaffected. */
+    pthread_mutex_lock(&thread->lease_break_lock);
+    if (thread->active_compounds > 0) {
+        thread->active_compounds--;
+    }
+    if (conn->in_compound > 0) {
+        conn->in_compound--;
+    }
+    pthread_mutex_unlock(&thread->lease_break_lock);
+
+    chimera_smb_lease_break_flush(thread);
 
     chimera_smb_compound_free(thread, compound);
 } /* chimera_smb_compound_reply */
@@ -1595,6 +1618,17 @@ chimera_smb_server_handle_smb2(
         }
     }
 
+    /* Mark a compound in flight on this thread (and connection) so a dir-lease
+     * break triggered while processing it skips the doorbell and is instead
+     * flushed after this compound's reply (chimera_smb_compound_reply) —
+     * reply-before-break.  The per-connection count distinguishes a self-break
+     * (holder conn mid-compound -> defer) from a cross-connection break (holder
+     * conn idle -> fire now, else a parking conflicting open deadlocks). */
+    pthread_mutex_lock(&thread->lease_break_lock);
+    thread->active_compounds++;
+    compound->conn->in_compound++;
+    pthread_mutex_unlock(&thread->lease_break_lock);
+
     chimera_smb_compound_advance(compound);
 
 } /* chimera_smb_server_handle_compound */
@@ -1753,6 +1787,12 @@ chimera_smb_server_handle_smb1(
     compound->requests[compound->num_requests++] = request;
 
     smb_dump_compound_request(compound);
+
+    /* Balance the decrement in chimera_smb_compound_reply (see the SMB2 path). */
+    pthread_mutex_lock(&thread->lease_break_lock);
+    thread->active_compounds++;
+    compound->conn->in_compound++;
+    pthread_mutex_unlock(&thread->lease_break_lock);
 
     chimera_smb_compound_advance(compound);
 

--- a/src/server/smb/smb_durable.c
+++ b/src/server/smb/smb_durable.c
@@ -209,6 +209,7 @@ chimera_smb_durable_doc_open_parent_cb(
     ctx->parent_handle = oh;
     chimera_vfs_remove_at(ctx->vfs_thread, &ctx->doc_info.cred, oh,
                           ctx->doc_info.name, ctx->doc_info.name_len, NULL, 0, 0, 0,
+                          NULL, /* parent_lease_skip */
                           chimera_smb_durable_doc_remove_cb, ctx);
 } /* chimera_smb_durable_doc_open_parent_cb */
 

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -110,6 +110,27 @@ chimera_smb_lease_bits_to_vfs(uint8_t smb_bits)
     return v;
 } /* chimera_smb_lease_bits_to_vfs */
 
+/* Translate an open's stored ParentLeaseKey into the (lo, hi) owner-key pair the
+ * VFS directory-lease break uses for self-exemption.  Returns true (a key is
+ * present, so the matching directory lease must be spared) when the key is
+ * non-zero; a zeroed key (the open carried no v2 ParentLeaseKey) yields false so
+ * the break applies to every directory lease.  An all-zero lease key is not used
+ * as a real key by any client, so testing non-zero is an unambiguous "was set". */
+static inline bool
+chimera_smb_parent_lease_skip(
+    const uint8_t *parent_lease_key,
+    uint64_t      *skip_lo,
+    uint64_t      *skip_hi)
+{
+    uint64_t lo, hi;
+
+    memcpy(&lo, parent_lease_key, 8);
+    memcpy(&hi, parent_lease_key + 8, 8);
+    *skip_lo = lo;
+    *skip_hi = hi;
+    return (lo | hi) != 0;
+} /* chimera_smb_parent_lease_skip */
+
 /* Collapse a granted RWH mask to the closest legacy oplock level (used when an
  * open did not request an RqLs lease).  Legacy oplocks have no separate W/H, so
  * RWH -> BATCH, RW (no H) -> EXCLUSIVE, R-only -> LEVEL_II, none -> NONE. */
@@ -183,6 +204,10 @@ struct chimera_smb_config {
     int                            num_nic_info;
     int                            soft_fail_bad_req;
     int                            persistent_handles;
+    /* SMB3 directory leases: when set the server advertises
+     * SMB2_GLOBAL_CAP_DIRECTORY_LEASING and grants R/H leases on directory
+     * opens (SMB 3.0+, RqLs v2 only).  Off by default. */
+    int                            directory_leases;
     int                            named_streams;
     /* When set, the server advertises signing as mandatory
      * (SMB2_SIGNING_REQUIRED) in NEGOTIATE and FSCTL_VALIDATE_NEGOTIATE_INFO,
@@ -527,6 +552,12 @@ struct chimera_smb_request {
             struct chimera_vfs_pending_acquire gen_ticket;
             uint8_t                            gen_held_granted;
             uint8_t                            gen_parked;
+            /* GRANTED/DENIED result stashed by chimera_smb_create_share_park_cb
+             * when the share-park ticket resolves on another thread, so the
+             * owning thread's resume doorbell can finish the open with it.  The
+             * queue link reuses async.park_next (a gen_parked CREATE is not on
+             * conn->parked_requests). */
+            enum chimera_vfs_lease_result      gen_resume_result;
             uint8_t                            r_is_directory;
             uint32_t                           r_granted_access;
             uint32_t                           r_maximal_access;
@@ -545,6 +576,17 @@ struct chimera_smb_request {
              * and re-attempts the claim until the handle is parked or this
              * many attempts elapse. */
             uint16_t                           reconnect_retries;
+            /* Deferred parent directory-lease content break: when a conflicting
+             * open parks on a FILE caching break (overwrite), its parent
+             * dir-lease content break must be SEQUENCED after the file break is
+             * acked — so it is emitted on resume, not before the park (MS-SMB2;
+             * smbtorture dirlease.overwrite expects break-then-ack-then-break).
+             * The parent_handle is kept alive across the park for the emit. */
+            uint8_t                            dir_break_pending;
+            uint8_t                            dir_break_has_skip;
+            uint32_t                           dir_break_action;
+            uint64_t                           dir_break_skip_lo;
+            uint64_t                           dir_break_skip_hi;
         } create;
 
         struct  {
@@ -765,34 +807,44 @@ struct chimera_smb_request {
         } query_info;
 
         struct {
-            uint8_t                         info_type;
-            uint8_t                         info_class;
-            uint32_t                        buffer_length;
-            uint16_t                        buffer_offset;
-            uint32_t                        addl_info;
-            uint32_t                        flags;
-            struct chimera_smb_open_file   *open_file;
-            struct chimera_vfs_open_handle *parent_handle;
-            struct chimera_smb_file_id      file_id;
-            struct chimera_smb_attrs        attrs;
-            struct chimera_vfs_attrs        vfs_attrs;
+            uint8_t                            info_type;
+            uint8_t                            info_class;
+            uint32_t                           buffer_length;
+            uint16_t                           buffer_offset;
+            uint32_t                           addl_info;
+            uint32_t                           flags;
+            struct chimera_smb_open_file      *open_file;
+            struct chimera_vfs_open_handle    *parent_handle;
+            struct chimera_smb_file_id         file_id;
+            struct chimera_smb_attrs           attrs;
+            struct chimera_vfs_attrs           vfs_attrs;
             /* VFS notify event(s) the set_info callback fires on the parent on
              * success.  0 => default to ATTRS_CHANGED; EndOfFile/Allocation set
              * SIZE_CHANGED|FILE_MODIFIED so a FILE_NOTIFY_CHANGE_SIZE watch
              * fires (smb2.change_notify ChangeSize). */
-            uint32_t                        notify_mask;
+            uint32_t                           notify_mask;
             /* Rename information */
-            struct chimera_smb_rename_info  rename_info;
+            struct chimera_smb_rename_info     rename_info;
+            /* Destination-parent directory-lease conflict park (rename into a
+             * leased directory): a transient SHARE probe (denied=D) on the dst
+             * parent triggers the dir-lease HANDLE break (RH->R) via the share
+             * conflict path and parks the rename until the holder closes
+             * (GRANTED -> rename proceeds) or keeps its handle
+             * (DENIED -> SHARING_VIOLATION).  dirlease.rename_dst_parent. */
+            struct chimera_vfs_lease           dp_probe;
+            struct chimera_vfs_file_state     *dp_file_state;
+            struct chimera_vfs_pending_acquire dp_ticket;
+            uint8_t                            dp_probe_active;
             /* Security descriptor buffer for SMB2_INFO_SECURITY */
-            uint8_t                         sec_buf[2048];
-            uint32_t                        sec_buf_len;
+            uint8_t                            sec_buf[2048];
+            uint32_t                           sec_buf_len;
             /* Outstanding async identity resolves before the SD is decoded for
              * the final time (fan-out join guard). */
-            int                             sd_pending;
+            int                                sd_pending;
             /* Backing storage for the canonical ACL decoded from the incoming
              * security descriptor; vfs_attrs.va_acl points here. */
-            uint8_t                         acl_storage[sizeof(struct chimera_acl) +
-                                                        64 * sizeof(struct chimera_ace)];
+            uint8_t                            acl_storage[sizeof(struct chimera_acl) +
+                                                           64 * sizeof(struct chimera_ace)];
         } set_info;
 
         struct {
@@ -941,6 +993,14 @@ struct chimera_smb_conn {
      * on another thread does not enqueue a send for a connection whose bind is
      * being torn down.  Reset on reuse in chimera_smb_conn_alloc. */
     uint8_t                            lease_break_tearing_down;
+    /* Count of compounds in flight on THIS connection (guarded by the owning
+    * thread's lease_break_lock).  A dir-lease break whose holder connection is
+    * mid-compound is a self-break: the same connection's reply must precede the
+    * break notification, so it is deferred and flushed at that reply.  A break
+    * whose holder connection is idle (in_compound == 0) is a cross-connection
+    * break — fired immediately, since a conflicting open may PARK on its ack and
+    * the holder will never otherwise reply to trigger a flush (deadlock). */
+    int                                in_compound;
     enum evpl_protocol_id              protocol;
     uint16_t                           dialect;
     uint16_t                           smbvers;
@@ -1299,6 +1359,12 @@ struct chimera_server_smb_thread {
     struct evpl_doorbell                lease_break_doorbell;
     struct chimera_smb_lease_break_msg *lease_break_ready;
     pthread_mutex_t                     lease_break_lock;
+    /* Count of compounds this thread is currently processing (dispatch ..
+     * reply).  A break_cb that queues a notification while this is non-zero
+     * skips the doorbell: the in-flight request's reply path flushes the queue
+     * right after its reply, so the reply reaches the client before the break
+     * (MS-SMB2 ordering for op-triggered breaks).  Guarded by lease_break_lock. */
+    uint32_t                            active_compounds;
 
     /* Lease-break *resume* doorbell: when an inbound OPLOCK_BREAK ack settles a
      * file's caching lease, CREATEs parked waiting on that break may live on a
@@ -1311,6 +1377,15 @@ struct chimera_server_smb_thread {
      * (chimera_vfs_state_caching_breaking() is false).  The re-check makes a
      * parameterless broadcast safe -- only genuinely-settled creates complete. */
     struct evpl_doorbell                lease_resume_doorbell;
+
+    /* Cross-thread queue of CREATEs parked on a share/handle-lease conflict
+     * (chimera_smb_create_share_park_cb) whose vfs ticket resolved on ANOTHER
+     * thread.  The deferred CREATE response's iovecs are thread-local, so the
+     * resolving thread enqueues the request here (with the GRANTED/DENIED result
+     * stashed on it) and rings this thread's lease_resume_doorbell; the handler
+     * drains the queue and completes each on this, its owning, thread.  Guarded
+     * by lease_break_lock. */
+    struct chimera_smb_request         *share_resume_head;
 
     /* Active (non-pooled) connections owned by this thread, threaded on
      * conn->active_prev / conn->active_next.  Lets a thread walk every
@@ -1722,6 +1797,7 @@ chimera_smb_conn_alloc(struct chimera_server_smb_thread *thread)
     if (conn) {
         LL_DELETE(thread->free_conns, conn);
         conn->lease_break_tearing_down = 0;
+        conn->in_compound              = 0;
     } else {
         conn = calloc(1, sizeof(*conn));
     }

--- a/src/server/smb/smb_proc_close.c
+++ b/src/server/smb/smb_proc_close.c
@@ -106,6 +106,21 @@ chimera_smb_close_doc_open_parent_callback(
 
     request->close.parent_handle = oh;
 
+    /* Self-exempt a directory lease ONLY when the handle being closed here is the
+     * one that carried delete-on-close: its ParentLeaseKey names the directory
+     * lease whose cached view is coherent with the removal it caused, so spare it
+     * (dirlease.unlink_same_*).  When the last handle to close is NOT the one that
+     * set delete-on-close (a different open triggers the actual removal), the set
+     * and closing parent keys differ, so no lease is spared and ALL directory
+     * leases break (MS-SMB2; dirlease.unlink_different_*). */
+    const uint8_t *unlink_skip = NULL;
+
+    if (request->close.open_file &&
+        (request->close.open_file->flags &
+         CHIMERA_SMB_OPEN_FILE_FLAG_DELETE_ON_CLOSE)) {
+        unlink_skip = request->close.open_file->parent_lease_key;
+    }
+
     chimera_vfs_remove_at(
         vfs_thread,
         &request->close.doc_info.cred,
@@ -116,6 +131,7 @@ chimera_smb_close_doc_open_parent_callback(
         0,
         0,
         0,
+        unlink_skip,
         chimera_smb_close_doc_remove_callback,
         request);
 } /* chimera_smb_close_doc_open_parent_callback */
@@ -280,6 +296,29 @@ chimera_smb_close(struct chimera_smb_request *request)
         chimera_smb_notify_close(thread->shared->vfs->vfs_notify,
                                  request->close.open_file->notify_state);
         request->close.open_file->notify_state = NULL;
+    }
+
+    /* Deferred directory-lease content break for a modified file: a write does
+     * not break the parent dir lease at write time (the file's directory-visible
+     * size/mtime settle only at close), so emit the break now.  Self-exempt the
+     * directory lease named by this handle's ParentLeaseKey -- a writer that
+     * holds the parent's lease keeps its cached view coherent (MS-SMB2;
+     * dirlease.v2_request "only the close on the modified file break[s] the
+     * directory lease", and the valid-parent-key write closes without a break). */
+    if ((request->close.open_file->flags & CHIMERA_SMB_OPEN_FILE_FLAG_MODIFIED) &&
+        request->close.open_file->parent_fh_len > 0) {
+        uint64_t skip_lo, skip_hi;
+        bool     has_skip = chimera_smb_parent_lease_skip(
+            request->close.open_file->parent_lease_key, &skip_lo, &skip_hi);
+
+        chimera_vfs_notify_emit_lease(thread->shared->vfs->vfs_notify,
+                                      request->close.open_file->parent_fh,
+                                      request->close.open_file->parent_fh_len,
+                                      CHIMERA_VFS_NOTIFY_FILE_MODIFIED,
+                                      request->close.open_file->name,
+                                      request->close.open_file->name_len,
+                                      NULL, 0,
+                                      skip_lo, skip_hi, has_skip);
     }
 
     /* Release share mode entry for regular file opens */

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -840,14 +840,26 @@ chimera_smb_create_after_share(
     int                               name_len      = open_file->name_len;
     uint64_t                          open_file_bucket;
 
+    /* A directory open is eligible for an SMB3 directory lease when the feature
+     * is enabled and the client requested it via an RqLs v2 context (directory
+     * leases are SMB 3.0+ / lease-v2 only — never a legacy oplock, which is what
+     * the dirlease.oplocks test asserts is refused).  A directory lease grants
+     * R/H only (W is masked off below) and is broken on a directory content
+     * change (chimera_vfs_state_dir_lease_break via the notify chokepoint). */
+    int                               is_directory = (open_file->flags & CHIMERA_SMB_OPEN_FILE_FLAG_DIRECTORY) != 0;
+    int                               dir_lease_ok = is_directory && oh &&
+        thread->shared->config.directory_leases &&
+        (request->create.ctx_present_mask & CHIMERA_SMB_CREATE_CTX_RQLS) &&
+        request->create.rqls.is_v2;
+
     /* Acquire a CACHING lease (SMB2 lease via RqLs, or legacy oplock
      * via requested_oplock_level).  This is opportunistic — failure to
      * grant just means the open succeeds with no lease.  Conflicts are
      * resolved by vfs_state's conflict matrix; without break_cb wired
      * (next task in Stage D), conflicting other-client leases force
      * DENIED here, so we silently end up with no lease. */
-    if (type == CHIMERA_SMB_OPEN_FILE_TYPE_FILE && oh &&
-        !(open_file->flags & CHIMERA_SMB_OPEN_FILE_FLAG_DIRECTORY)) {
+    if ((type == CHIMERA_SMB_OPEN_FILE_TYPE_FILE && oh && !is_directory) ||
+        dir_lease_ok) {
         struct chimera_vfs_state      *vfs_state = thread->vfs_thread->vfs->vfs_state;
         struct chimera_vfs_file_state *file_state;
         uint8_t                        req_smb  = 0;
@@ -916,6 +928,13 @@ chimera_smb_create_after_share(
          *     force a flush before it reads (smb_proc_copychunk.c) — fixes the
          *     old fsx READ BAD DATA. */
         req_vfs = chimera_smb_lease_bits_to_vfs(req_smb);
+
+        /* A directory lease never carries write caching: only read (cached
+         * enumeration) and handle (deferred close) caching apply to a directory
+         * (MS-SMB2 — requesting RHW on a directory grants RH). */
+        if (is_directory) {
+            req_vfs &= ~CHIMERA_VFS_LEASE_MODE_W;
+        }
 
         /* Oplocks are about data caching: an attribute-only open (no
          * read/write/execute data access) neither acquires nor breaks an
@@ -1030,8 +1049,14 @@ chimera_smb_create_after_share(
                         grant->epoch =
                             (via_rqls && request->create.rqls.is_v2)
                             ? request->create.rqls.epoch + 1 : 1;
+                        /* A directory lease is marked on both the grant and the
+                         * embedded lease: the conflict matrix relaxes cross-client
+                         * handle exclusivity for is_dir leases, and the lease does
+                         * not cascade (a directory break is a single shot). */
+                        grant->is_dir                 = is_directory;
                         grant->lease.grant            = grant;
                         grant->lease.kind             = CHIMERA_VFS_LEASE_CACHING;
+                        grant->lease.is_dir           = is_directory;
                         grant->lease.mode             = want;
                         grant->lease.owner            = owner;
                         grant->lease.owner.cb_private = grant;
@@ -1294,10 +1319,46 @@ chimera_smb_create_share_park_cb(
     (void) lease;
     (void) conflict;
 
+    /* The vfs share-acquire ticket may resolve on ANY thread (whichever closed
+     * the holder or acked the break).  The CREATE response's iovecs are
+     * thread-local, so stash the result and bounce to the parked open's owning
+     * thread, where chimera_smb_create_share_resume_doorbell completes it.  An
+     * already-on-thread resolution still goes through the doorbell (one extra
+     * hop); correctness over a fast path. */
+    request->create.gen_resume_result = result;
+
+    pthread_mutex_lock(&thread->lease_break_lock);
+    request->async.park_next  = thread->share_resume_head;
+    thread->share_resume_head = request;
+    pthread_mutex_unlock(&thread->lease_break_lock);
+
+    evpl_ring_doorbell(&thread->lease_resume_doorbell);
+
+    (void) vfs_thread;
+    (void) vfs_state;
+    (void) open_file;
+    (void) file_state;
+} /* chimera_smb_create_share_park_cb */
+
+/* Finish a share-park CREATE on its OWN thread (driven by the resume doorbell).
+ * GRANTED: the holder closed and freed the conflict -> hold the share and finish
+ * the open.  DENIED: the holder kept its handle (acked a dir-lease/oplock break
+ * without closing) -> SHARING_VIOLATION. */
+static void
+chimera_smb_create_share_park_finish(
+    struct chimera_smb_request   *request,
+    enum chimera_vfs_lease_result result)
+{
+    struct chimera_server_smb_thread *thread     = request->compound->thread;
+    struct chimera_vfs_thread        *vfs_thread = thread->vfs_thread;
+    struct chimera_vfs_state         *vfs_state  = vfs_thread->vfs->vfs_state;
+    struct chimera_smb_open_file     *open_file  = request->create.gen_parked_open;
+    struct chimera_vfs_file_state    *file_state = request->create.gen_parked_fs;
+
     request->create.gen_parked = 0;
 
     if (result == CHIMERA_VFS_LEASE_GRANTED) {
-        /* The batch holder closed; the share reservation is now held. */
+        /* The holder closed; the share reservation is now held. */
         chimera_smb_create_finish_share_grant(open_file, file_state,
                                               request->create.gen_held_granted);
         chimera_smb_create_after_share(request, open_file);
@@ -1305,8 +1366,8 @@ chimera_smb_create_share_park_cb(
         return;
     }
 
-    /* DENIED: the holder acked its oplock but kept the handle open, so the
-     * share conflict stands. */
+    /* DENIED: the holder acked its oplock / dir-lease break but kept the handle
+     * open, so the share conflict stands. */
     chimera_vfs_state_put(vfs_state, file_state);
     if (open_file->handle) {
         chimera_vfs_release(vfs_thread, open_file->handle);
@@ -1315,7 +1376,7 @@ chimera_smb_create_share_park_cb(
     chimera_smb_open_file_free(thread, open_file);
     chimera_smb_create_release_parent(request);
     chimera_smb_complete_request(request, SMB2_STATUS_SHARING_VIOLATION);
-} /* chimera_smb_create_share_park_cb */
+} /* chimera_smb_create_share_park_finish */
 
 static inline uint32_t
 chimera_smb_create_granted_access(
@@ -1720,9 +1781,14 @@ chimera_smb_create_open_at_callback(
         chimera_vfs_access_check(attr, &request->session_handle->session->cred,
                                  CHIMERA_ACE_MASK_ALL);
     chimera_smb_marshal_attrs(attr, &request->create.r_attrs);
-    /* The park-on-batch-break activation (gen_finish_cb) is wired in the
-     * follow-up that adds the cross-thread resume bounce; until then the open
-     * resolves synchronously (a batch-share conflict yields SHARING_VIOLATION). */
+    /* Activate the park-on-conflict-break path: if gen_open_file parks on a
+     * handle-caching break (a batch oplock, or an SMB3 directory lease whose
+     * HANDLE must be relinquished for a conflicting open), the share-park resume
+     * (chimera_smb_create_share_park_cb) finishes the open via this callback once
+     * the holder closes (GRANTED) or denies with SHARING_VIOLATION if it keeps
+     * the handle.  Without it a conflict resolves synchronously to
+     * SHARING_VIOLATION and never waits for the holder to close. */
+    request->create.gen_finish_cb = chimera_smb_create_open_finish;
 
     open_file = chimera_smb_create_gen_open_file_normal(request,
                                                         request->create.parent_handle->fh,
@@ -1787,6 +1853,9 @@ chimera_smb_create_access_retry_callback(
  * its already-acquired lease.  Runs on the open's own conn thread (the timer is
  * armed on that thread's evpl).  An ack that resumes the open first removes this
  * timer. */
+static void chimera_smb_create_finish_deferred_dir_break(
+    struct chimera_smb_request *request);
+
 static void
 chimera_smb_create_park_deadline_cb(
     struct evpl       *evpl,
@@ -1814,6 +1883,11 @@ chimera_smb_create_park_deadline_cb(
         open_file->flags &= ~CHIMERA_SMB_OPEN_FILE_CREATE_PENDING;
     }
 
+    /* The open succeeds even though the file break timed out; still emit the
+     * deferred parent dir-lease content break (the directory's contents did
+     * change). */
+    chimera_smb_create_finish_deferred_dir_break(request);
+
     chimera_smb_open_file_release(request, open_file);
     /* complete_request retires the async-interim (unlink from parked_requests +
      * clear armed); the fired one-shot is already out of the timer heap so its
@@ -1825,15 +1899,63 @@ chimera_smb_create_park_deadline_cb(
  * parent-directory create notification, release the parent handle, and complete
  * the request.  Invoked on a synchronous grant from open_at_callback and on a
  * parked grant from chimera_smb_create_share_park_cb. */
+/* Emit a parent directory-lease content break that was deferred while the open
+ * parked on a FILE caching break (overwrite), then release the parent handle that
+ * was held alive across the park.  Sequencing the dir break after the file break
+ * is acked is what dirlease.overwrite requires (break -> ack -> break); emitting
+ * it up-front would deliver both breaks before the first ack and the skip_ack
+ * test would lose the second to its inter-ack reset. */
+static void
+chimera_smb_create_finish_deferred_dir_break(struct chimera_smb_request *request)
+{
+    struct chimera_server_smb_thread *thread = request->compound->thread;
+
+    if (!request->create.dir_break_pending) {
+        return;
+    }
+
+    request->create.dir_break_pending = 0;
+
+    if (request->create.parent_handle) {
+        chimera_vfs_notify_emit_lease(thread->shared->vfs->vfs_notify,
+                                      request->create.parent_handle->fh,
+                                      request->create.parent_handle->fh_len,
+                                      request->create.dir_break_action,
+                                      request->create.name,
+                                      request->create.name_len,
+                                      NULL, 0,
+                                      request->create.dir_break_skip_lo,
+                                      request->create.dir_break_skip_hi,
+                                      request->create.dir_break_has_skip);
+        chimera_smb_create_release_parent(request);
+    }
+} /* chimera_smb_create_finish_deferred_dir_break */
+
 static void
 chimera_smb_create_open_finish(
     struct chimera_smb_request   *request,
     struct chimera_smb_open_file *open_file)
 {
-    request->create.r_open_file = open_file;
+    struct chimera_server_smb_thread *thread    = request->compound->thread;
+    struct chimera_vfs_state         *vfs_state =
+        thread->vfs_thread->vfs->vfs_state;
+    bool                              will_park = false;
+
+    request->create.r_open_file       = open_file;
+    request->create.dir_break_pending = 0;
 
     open_file->granted_access = request->create.r_granted_access;
     open_file->maximal_access = request->create.r_maximal_access;
+
+    /* Decide up front whether this open must park on a FILE caching break still
+     * in flight (a conflicting/overwriting open whose ack-required break has not
+     * settled).  Computed here so a content break can be DEFERRED past the park. */
+    if (open_file->handle) {
+        struct chimera_vfs_open_handle *oh = open_file->handle;
+        will_park = chimera_vfs_state_caching_breaking(vfs_state, oh->fh,
+                                                       oh->fh_len, oh->fh_hash,
+                                                       open_file->grant);
+    }
 
     /* Emit notification on parent directory for any disposition that can
      * create a new file.  OPEN never creates; CREATE always creates;
@@ -1850,10 +1972,10 @@ chimera_smb_create_open_finish(
      * receive the event. */
     if (request->create.create_disposition == SMB2_FILE_CREATE        ||
         request->create.create_disposition == SMB2_FILE_OPEN_IF       ||
+        request->create.create_disposition == SMB2_FILE_OVERWRITE     ||
         request->create.create_disposition == SMB2_FILE_OVERWRITE_IF  ||
         request->create.create_disposition == SMB2_FILE_SUPERSEDE) {
-        struct chimera_server_smb_thread *thread = request->compound->thread;
-        uint32_t                          action = request->create.r_is_directory ?
+        uint32_t action = request->create.r_is_directory ?
             CHIMERA_VFS_NOTIFY_DIR_ADDED : CHIMERA_VFS_NOTIFY_FILE_ADDED;
 
         /* Creating/opening a (regular) file's data fork introduces its
@@ -1865,16 +1987,64 @@ chimera_smb_create_open_finish(
             action |= CHIMERA_VFS_NOTIFY_STREAM_NAME;
         }
 
-        chimera_vfs_notify_emit(thread->shared->vfs->vfs_notify,
-                                request->create.parent_handle->fh,
-                                request->create.parent_handle->fh_len,
-                                action,
-                                request->create.name,
-                                request->create.name_len,
-                                NULL, 0);
+        /* A directory read lease must break only when the directory's contents
+         * actually changed — i.e. the file was newly created, or its data was
+         * replaced (OVERWRITE/SUPERSEDE truncate an existing file).  A
+         * create-capable disposition that merely OPENED an existing file
+         * (OPEN_IF on an existing name) changes nothing in the directory, so it
+         * delivers the (conservative) CHANGE_NOTIFY event WITHOUT breaking the
+         * lease — otherwise re-opening a file would spuriously recall the parent
+         * directory lease (smbtorture dirlease.rename re-opens before renaming). */
+        bool content_changed = request->create.r_created ||
+            request->create.create_disposition == SMB2_FILE_OVERWRITE ||
+            request->create.create_disposition == SMB2_FILE_OVERWRITE_IF ||
+            request->create.create_disposition == SMB2_FILE_SUPERSEDE;
+
+        if (content_changed) {
+            /* Self-exempt the directory lease whose ParentLeaseKey this create
+            * supplied: the client creating the file holds (or is updating) that
+            * directory's cached view and must not have its own lease broken
+            * (MS-SMB2 dirlease ParentLeaseKey; dirlease.v2_request_parent). */
+            uint64_t skip_lo, skip_hi;
+            bool     has_skip = chimera_smb_parent_lease_skip(
+                open_file->parent_lease_key, &skip_lo, &skip_hi);
+
+            if (will_park) {
+                /* This open is about to park on a FILE caching break; defer the
+                 * parent dir-lease content break to the resume so it is sequenced
+                 * AFTER that file break is acked (dirlease.overwrite).  Keep the
+                 * parent handle alive for the deferred emit. */
+                request->create.dir_break_pending  = 1;
+                request->create.dir_break_action   = action;
+                request->create.dir_break_skip_lo  = skip_lo;
+                request->create.dir_break_skip_hi  = skip_hi;
+                request->create.dir_break_has_skip = has_skip;
+            } else {
+                chimera_vfs_notify_emit_lease(thread->shared->vfs->vfs_notify,
+                                              request->create.parent_handle->fh,
+                                              request->create.parent_handle->fh_len,
+                                              action,
+                                              request->create.name,
+                                              request->create.name_len,
+                                              NULL, 0,
+                                              skip_lo, skip_hi, has_skip);
+            }
+        } else {
+            chimera_vfs_notify_emit_nobreak(thread->shared->vfs->vfs_notify,
+                                            request->create.parent_handle->fh,
+                                            request->create.parent_handle->fh_len,
+                                            action,
+                                            request->create.name,
+                                            request->create.name_len,
+                                            NULL, 0);
+        }
     }
 
-    chimera_smb_create_release_parent(request);
+    /* Release the parent now unless a deferred dir break still needs it (it is
+     * released by chimera_smb_create_finish_deferred_dir_break on resume). */
+    if (!request->create.dir_break_pending) {
+        chimera_smb_create_release_parent(request);
+    }
 
     /* MS-SMB2 3.3.5.9 pending-open: if this open triggered an ack-required lease
      * break on another holder, hold the SUCCESS response until the holder
@@ -1884,36 +2054,30 @@ chimera_smb_create_open_finish(
      * lands on conn->parked_requests, and an inbound OPLOCK_BREAK ack that settles
      * the file's caching leases resumes it (chimera_smb_create_resume_parked).
      * The open_file ref is held across the wait and dropped on resume. */
-    if (open_file->handle) {
-        struct chimera_server_smb_thread *thread    = request->compound->thread;
-        struct chimera_vfs_state         *vfs_state =
-            thread->vfs_thread->vfs->vfs_state;
-        struct chimera_vfs_open_handle   *oh = open_file->handle;
+    if (will_park) {
+        struct chimera_vfs_open_handle *oh = open_file->handle;
 
-        if (chimera_vfs_state_caching_breaking(vfs_state, oh->fh, oh->fh_len,
-                                               oh->fh_hash, open_file->grant)) {
-            memcpy(request->create.park_fh, oh->fh, oh->fh_len);
-            request->create.park_fh_len  = oh->fh_len;
-            request->create.park_fh_hash = oh->fh_hash;
-            /* The CREATE is now pending on a break ack; mark the handle so a
-             * concurrent replayed DH2Q create with this create_guid is answered
-             * FILE_NOT_AVAILABLE instead of parking too (MS-SMB2 3.3.5.9.10,
-             * smb2.replay.dhv2-pending*).  Keyed on the DH2Q create_guid the
-             * client supplied -- recorded on the open even without a durable
-             * grant (so the NONE-oplock pending variants match too). */
-            if (request->create.ctx_present_mask & CHIMERA_SMB_CREATE_CTX_DH2Q) {
-                open_file->flags |= CHIMERA_SMB_OPEN_FILE_CREATE_PENDING;
-            }
-            chimera_smb_async_interim_begin(request);
-            /* Arm a deadline: if the holder never acks the break, fire at the
-             * break timeout to revoke it and complete this open anyway (MS-SMB2
-             * break-timeout).  Cancelled when an ack resumes the open first. */
-            evpl_add_oneshot_timer(thread->evpl, &request->async.timer,
-                                   chimera_smb_create_park_deadline_cb,
-                                   (uint64_t) vfs_state->default_break_deadline_ms
-                                   * 1000);
-            return;
+        memcpy(request->create.park_fh, oh->fh, oh->fh_len);
+        request->create.park_fh_len  = oh->fh_len;
+        request->create.park_fh_hash = oh->fh_hash;
+        /* The CREATE is now pending on a break ack; mark the handle so a
+         * concurrent replayed DH2Q create with this create_guid is answered
+         * FILE_NOT_AVAILABLE instead of parking too (MS-SMB2 3.3.5.9.10,
+         * smb2.replay.dhv2-pending*).  Keyed on the DH2Q create_guid the
+         * client supplied -- recorded on the open even without a durable
+         * grant (so the NONE-oplock pending variants match too). */
+        if (request->create.ctx_present_mask & CHIMERA_SMB_CREATE_CTX_DH2Q) {
+            open_file->flags |= CHIMERA_SMB_OPEN_FILE_CREATE_PENDING;
         }
+        chimera_smb_async_interim_begin(request);
+        /* Arm a deadline: if the holder never acks the break, fire at the
+         * break timeout to revoke it and complete this open anyway (MS-SMB2
+         * break-timeout).  Cancelled when an ack resumes the open first. */
+        evpl_add_oneshot_timer(thread->evpl, &request->async.timer,
+                               chimera_smb_create_park_deadline_cb,
+                               (uint64_t) vfs_state->default_break_deadline_ms
+                               * 1000);
+        return;
     }
 
     chimera_smb_open_file_release(request, open_file);
@@ -2056,6 +2220,9 @@ chimera_smb_create_resume_parked_conn(
             req->create.r_open_file->flags &=
                 ~CHIMERA_SMB_OPEN_FILE_CREATE_PENDING;
         }
+        /* The file break this open parked on is now acked; emit the deferred
+         * parent dir-lease content break (sequenced after that ack). */
+        chimera_smb_create_finish_deferred_dir_break(req);
         chimera_smb_open_file_release(req, req->create.r_open_file);
         /* async_id is still set, so the final reply carries
          * SMB2_FLAGS_ASYNC_COMMAND matching the interim. */
@@ -2114,6 +2281,27 @@ chimera_smb_create_resume_doorbell_callback(
     DL_FOREACH_SAFE2(thread->active_conns, conn, tmp, active_next)
     {
         chimera_smb_create_resume_parked_conn(thread, vfs_state, conn);
+    }
+
+    /* Drain CREATEs whose share-park ticket resolved on another thread and were
+     * bounced here (chimera_smb_create_share_park_cb) to finish on their owning
+     * thread with the stashed GRANTED/DENIED result. */
+    for ( ; ;) {
+        struct chimera_smb_request *req;
+
+        pthread_mutex_lock(&thread->lease_break_lock);
+        req = thread->share_resume_head;
+        if (req) {
+            thread->share_resume_head = req->async.park_next;
+        }
+        pthread_mutex_unlock(&thread->lease_break_lock);
+
+        if (!req) {
+            break;
+        }
+
+        req->async.park_next = NULL;
+        chimera_smb_create_share_park_finish(req, req->create.gen_resume_result);
     }
 } /* chimera_smb_create_resume_doorbell_callback */
 
@@ -3693,11 +3881,24 @@ build_rqls_response(
     out[18] = 0;
     out[19] = 0;
     /* LeaseFlags (4) — BREAK_IN_PROGRESS when this open joined a lease whose
-     * break is still outstanding; otherwise 0. */
-    out[20] = of->lease_flags & 0xff;
-    out[21] = (of->lease_flags >> 8) & 0xff;
-    out[22] = (of->lease_flags >> 16) & 0xff;
-    out[23] = (of->lease_flags >> 24) & 0xff;
+     * break is still outstanding; PARENT_LEASE_KEY_SET (and the echoed
+     * ParentLeaseKey below) when the v2 open supplied a parent directory lease
+     * key (MS-SMB2 2.2.14.2.11; dirlease.v2_request_parent checks this flag). */
+    uint32_t lease_flags = of->lease_flags;
+
+    if (v2) {
+        uint64_t plk_lo, plk_hi;
+
+        memcpy(&plk_lo, of->parent_lease_key, 8);
+        memcpy(&plk_hi, of->parent_lease_key + 8, 8);
+        if (plk_lo | plk_hi) {
+            lease_flags |= SMB2_LEASE_FLAG_PARENT_LEASE_KEY_SET;
+        }
+    }
+    out[20] = lease_flags & 0xff;
+    out[21] = (lease_flags >> 8) & 0xff;
+    out[22] = (lease_flags >> 16) & 0xff;
+    out[23] = (lease_flags >> 24) & 0xff;
     /* LeaseDuration (8) — reserved. */
     memset(out + 24, 0, 8);
     if (v2) {
@@ -3920,6 +4121,16 @@ chimera_smb_create_reply(
     }
 
  have_create_action:
+
+    /* A directory has no data stream: the CREATE response must report EndOfFile
+     * and AllocationSize as 0 regardless of the backend's on-disk directory size
+     * (memfs reports a block size).  Keyed on the DIRECTORY attribute so it holds
+     * for an OPEN of an existing directory as well as a fresh mkdir (MS-SMB2
+     * 3.3.5.9 SMB2_CREATE response; smbtorture dirlease.v2_request CHECK_CREATED). */
+    if (request->create.r_attrs.smb_attributes & SMB2_FILE_ATTRIBUTE_DIRECTORY) {
+        request->create.r_attrs.smb_size       = 0;
+        request->create.r_attrs.smb_alloc_size = 0;
+    }
 
     evpl_iovec_cursor_append_uint32(reply_cursor, create_action);
 

--- a/src/server/smb/smb_proc_negotiate.c
+++ b/src/server/smb/smb_proc_negotiate.c
@@ -131,6 +131,11 @@ chimera_smb_negotiate(struct chimera_smb_request *request)
     if (dialect >= 0x300 && shared->config.persistent_handles) {
         conn->capabilities |= SMB2_GLOBAL_CAP_PERSISTENT_HANDLES;
     }
+    /* Directory leasing is an SMB 3.0+ capability (MS-SMB2 §3.3.5.4); the
+     * server only grants R/H leases on directory opens when this is advertised. */
+    if (dialect >= 0x300 && shared->config.directory_leases) {
+        conn->capabilities |= SMB2_GLOBAL_CAP_DIRECTORY_LEASING;
+    }
     /* Encryption is advertised via SMB2_GLOBAL_CAP_ENCRYPTION for 3.0/3.0.2;
      * for 3.1.1 it is negotiated through the encryption-capabilities context
      * instead and the capability bit MUST NOT be set (MS-SMB2 §3.3.5.4). */

--- a/src/server/smb/smb_proc_oplock_break.c
+++ b/src/server/smb/smb_proc_oplock_break.c
@@ -292,6 +292,7 @@ chimera_smb_lease_break_cb(
          * by this point. */
         {
             struct chimera_smb_lease_break_msg *msg;
+            bool                                ring = false;
 
             pthread_mutex_lock(&conn_thread->lease_break_lock);
             if (!conn->lease_break_tearing_down) {
@@ -305,10 +306,23 @@ chimera_smb_lease_break_cb(
                 msg->new_epoch                 = open_file->lease_epoch;
                 msg->next                      = conn_thread->lease_break_ready;
                 conn_thread->lease_break_ready = msg;
-                pthread_mutex_unlock(&conn_thread->lease_break_lock);
+                /* Defer ONLY a directory-lease break whose holder connection is
+                 * itself mid-compound (a self-break: the same connection both
+                 * triggered the op and holds the lease).  That op replies without
+                 * waiting for the ack, so we let its reply path flush the break
+                 * right after the reply (reply-before-break — MS-SMB2 dir-lease
+                 * ordering; smbtorture rename/unlink).  Fire immediately when the
+                 * holder connection is idle (in_compound == 0): the break was
+                 * triggered by a DIFFERENT connection whose op may PARK on this
+                 * ack (overwrite / v2_request / rename_dst_parent), and the idle
+                 * holder will never produce a reply to trigger the flush — so a
+                 * deferral here would deadlock.  File leases / legacy oplocks
+                 * always doorbell immediately for the same parking reason. */
+                ring = !lease->is_dir || conn->in_compound == 0;
+            }
+            pthread_mutex_unlock(&conn_thread->lease_break_lock);
+            if (ring) {
                 evpl_ring_doorbell(&conn_thread->lease_break_doorbell);
-            } else {
-                pthread_mutex_unlock(&conn_thread->lease_break_lock);
             }
         }
     } else {
@@ -340,6 +354,8 @@ chimera_smb_lease_break_cb(
                 msg->next                      = conn_thread->lease_break_ready;
                 conn_thread->lease_break_ready = msg;
                 pthread_mutex_unlock(&conn_thread->lease_break_lock);
+                /* Legacy oplocks are never directory leases and may be waited on
+                 * by a parking open, so always wake the thread immediately. */
                 evpl_ring_doorbell(&conn_thread->lease_break_doorbell);
             } else {
                 pthread_mutex_unlock(&conn_thread->lease_break_lock);
@@ -387,27 +403,31 @@ chimera_smb_lease_break_cb(
     (void) new_vfs;
 } /* chimera_smb_lease_break_cb */
 
-/* Doorbell handler: runs on a connection-owning SMB thread and sends the
- * lease-break notifications that break_cbs (possibly on other threads) queued
- * for connections owned by this thread.  Runs on the same thread as conn_free,
- * so a connection in the drained list is guaranteed live here. */
+/* Detach and send every queued lease-break notification for `thread`.  Runs on
+ * the thread that owns the target connections (the doorbell handler or, for
+ * op-triggered breaks, the request's own reply path), so a connection in the
+ * list is guaranteed live here (conn_free drains under the same lock). */
 SYMBOL_EXPORT void
-chimera_smb_lease_break_doorbell_callback(
-    struct evpl          *evpl,
-    struct evpl_doorbell *doorbell)
+chimera_smb_lease_break_flush(struct chimera_server_smb_thread *thread)
 {
-    struct chimera_server_smb_thread   *thread;
-    struct chimera_smb_lease_break_msg *list, *msg;
-
-    (void) evpl;
-
-    thread = container_of(doorbell, struct chimera_server_smb_thread,
-                          lease_break_doorbell);
+    struct chimera_smb_lease_break_msg *list, *msg, *fifo = NULL;
 
     pthread_mutex_lock(&thread->lease_break_lock);
     list                      = thread->lease_break_ready;
     thread->lease_break_ready = NULL;
     pthread_mutex_unlock(&thread->lease_break_lock);
+
+    /* The queue is built by prepending (LIFO).  Reverse it so notifications are
+     * sent in the order they were triggered (FIFO) — a cross-directory rename
+     * breaks the source parent before the destination parent, and the client
+     * expects that order (smbtorture dirlease.rename otherdir cases). */
+    while (list) {
+        msg       = list;
+        list      = list->next;
+        msg->next = fifo;
+        fifo      = msg;
+    }
+    list = fifo;
 
     while (list) {
         msg  = list;
@@ -424,6 +444,28 @@ chimera_smb_lease_break_doorbell_callback(
         }
         free(msg);
     }
+} /* chimera_smb_lease_break_flush */
+
+/* Doorbell handler: runs on a connection-owning SMB thread and sends the
+ * lease-break notifications that break_cbs (possibly on other threads) queued
+ * for connections owned by this thread.  Used for breaks NOT tied to an
+ * in-flight request on the holder's thread (cross-connection mutations, the
+ * idle reaper); a break triggered by a request on the holder's own thread is
+ * instead flushed after that request's reply (chimera_smb_compound_reply) so
+ * the reply reaches the client before the break (MS-SMB2 ordering). */
+SYMBOL_EXPORT void
+chimera_smb_lease_break_doorbell_callback(
+    struct evpl          *evpl,
+    struct evpl_doorbell *doorbell)
+{
+    struct chimera_server_smb_thread *thread;
+
+    (void) evpl;
+
+    thread = container_of(doorbell, struct chimera_server_smb_thread,
+                          lease_break_doorbell);
+
+    chimera_smb_lease_break_flush(thread);
 } /* chimera_smb_lease_break_doorbell_callback */
 
 void

--- a/src/server/smb/smb_proc_reparse.c
+++ b/src/server/smb/smb_proc_reparse.c
@@ -213,6 +213,7 @@ chimera_smb_set_reparse_open_parent_cb(
         0,
         0,
         0,
+        NULL,
         chimera_smb_set_reparse_remove_cb,
         request);
 } /* chimera_smb_set_reparse_open_parent_cb */

--- a/src/server/smb/smb_proc_set_info.c
+++ b/src/server/smb/smb_proc_set_info.c
@@ -24,13 +24,22 @@ chimera_smb_set_info_callback(
         uint32_t                          mask   = request->set_info.notify_mask ?
             request->set_info.notify_mask : CHIMERA_VFS_NOTIFY_ATTRS_CHANGED;
 
-        chimera_vfs_notify_emit(thread->shared->vfs->vfs_notify,
-                                request->set_info.open_file->parent_fh,
-                                request->set_info.open_file->parent_fh_len,
-                                mask,
-                                request->set_info.open_file->name,
-                                request->set_info.open_file->name_len,
-                                NULL, 0);
+        /* Self-exempt the parent directory lease named by the operating open's
+         * ParentLeaseKey: a setinfo issued through a handle that supplied the
+         * correct parent key must not break that directory's lease (MS-SMB2
+         * dirlease; dirlease.set{eof,dos,*time} cases 1.1/2.1). */
+        uint64_t                          skip_lo, skip_hi;
+        bool                              has_skip = chimera_smb_parent_lease_skip(
+            request->set_info.open_file->parent_lease_key, &skip_lo, &skip_hi);
+
+        chimera_vfs_notify_emit_lease(thread->shared->vfs->vfs_notify,
+                                      request->set_info.open_file->parent_fh,
+                                      request->set_info.open_file->parent_fh_len,
+                                      mask,
+                                      request->set_info.open_file->name,
+                                      request->set_info.open_file->name_len,
+                                      NULL, 0,
+                                      skip_lo, skip_hi, has_skip);
     }
 
     chimera_smb_open_file_release(request, request->set_info.open_file);
@@ -99,6 +108,11 @@ chimera_smb_set_info_link_open_dir_callback(
         0,
         0,
         0,
+        /* SMB rename via link: self-exempt the directory lease named by the
+         * operating open's ParentLeaseKey (dirlease.rename correct-parent case). */
+        open_file->parent_lease_key,
+        /* ...and self-exempt the linker's own file lease from the source recall. */
+        open_file->handle,
         chimera_smb_set_info_link_callback,
         request);
 } /* chimera_smb_set_info_link_open_dir_callback */

--- a/src/server/smb/smb_proc_set_info_rename.c
+++ b/src/server/smb/smb_proc_set_info_rename.c
@@ -111,8 +111,29 @@ chimera_smb_set_info_rename_callback(
     chimera_smb_complete_request(request, status);
 } /* chimera_smb_set_info_rename_callback */
 
+/* Release the transient destination-parent dir-lease conflict probe (if it was
+ * inserted) and drop the file-state reference taken for it. */
 static void
-chimera_smb_set_info_rename_do_rename(struct chimera_smb_request *request)
+chimera_smb_set_info_rename_dp_release(struct chimera_smb_request *request)
+{
+    struct chimera_vfs_thread *vfs_thread = request->compound->thread->vfs_thread;
+    struct chimera_vfs_state  *vfs_state  = vfs_thread->vfs->vfs_state;
+
+    if (request->set_info.dp_probe_active) {
+        chimera_vfs_lease_release(vfs_state, request->set_info.dp_file_state,
+                                  &request->set_info.dp_probe);
+        request->set_info.dp_probe_active = 0;
+    }
+    if (request->set_info.dp_file_state) {
+        chimera_vfs_state_put(vfs_state, request->set_info.dp_file_state);
+        request->set_info.dp_file_state = NULL;
+    }
+} /* chimera_smb_set_info_rename_dp_release */
+
+/* Issue the rename once the destination parent's directory lease (if any) has
+ * yielded its HANDLE caching. */
+static void
+chimera_smb_set_info_rename_emit(struct chimera_smb_request *request)
 {
     struct chimera_smb_open_file   *open_file      = request->set_info.open_file;
     char                           *dest_name      = request->set_info.rename_info.new_name;
@@ -136,8 +157,125 @@ chimera_smb_set_info_rename_do_rename(struct chimera_smb_request *request)
         0,
         0,
         0,
+        /* Self-exempt the directory lease named by the operating open's
+         * ParentLeaseKey (dirlease.rename correct-parent-leaskey case). */
+        open_file->parent_lease_key,
+        /* ...and self-exempt the renamer's own file lease from the source
+         * recall (renaming a file it holds a lease on must not break it). */
+        open_file->handle,
         chimera_smb_set_info_rename_callback,
         request);
+} /* chimera_smb_set_info_rename_emit */
+
+/* Resume after the destination-parent dir-lease conflict probe resolves.
+ * GRANTED: no conflicting handle-leased opener remains (none, or it closed in
+ * response to the RH->R break) -> proceed with the rename.  DENIED: a holder
+ * kept its handle open -> SHARING_VIOLATION (MS-SMB2 dirlease.rename_dst_parent). */
+static void
+chimera_smb_set_info_rename_dp_cb(
+    enum chimera_vfs_lease_result result,
+    struct chimera_vfs_lease     *lease,
+    struct chimera_vfs_lease     *conflict,
+    void                         *private_data)
+{
+    struct chimera_smb_request *request    = private_data;
+    struct chimera_vfs_thread  *vfs_thread = request->compound->thread->vfs_thread;
+
+    (void) lease;
+    (void) conflict;
+
+    if (result == CHIMERA_VFS_LEASE_GRANTED) {
+        /* lease_acquire inserted the probe; drop it (its only purpose was to
+         * break the dir lease / detect the conflict) and rename. */
+        request->set_info.dp_probe_active = 1;
+        chimera_smb_set_info_rename_dp_release(request);
+        chimera_smb_set_info_rename_emit(request);
+        return;
+    }
+
+    chimera_smb_set_info_rename_dp_release(request);
+
+    if (request->set_info.rename_info.new_parent_handle) {
+        chimera_vfs_release(vfs_thread,
+                            request->set_info.rename_info.new_parent_handle);
+        request->set_info.rename_info.new_parent_handle = NULL;
+    }
+    if (request->set_info.parent_handle) {
+        chimera_vfs_release(vfs_thread, request->set_info.parent_handle);
+        request->set_info.parent_handle = NULL;
+    }
+    chimera_smb_open_file_release(request, request->set_info.open_file);
+    chimera_smb_complete_request(request, SMB2_STATUS_SHARING_VIOLATION);
+} /* chimera_smb_set_info_rename_dp_cb */
+
+static void
+chimera_smb_set_info_rename_do_rename(struct chimera_smb_request *request)
+{
+    struct chimera_smb_open_file   *open_file      = request->set_info.open_file;
+    struct chimera_vfs_thread      *vfs_thread     = request->compound->thread->vfs_thread;
+    struct chimera_vfs_state       *vfs_state      = vfs_thread->vfs->vfs_state;
+    struct chimera_vfs_open_handle *dest_parent_oh = request->set_info.rename_info.new_parent_handle
+                                                     ? request->set_info.rename_info.new_parent_handle
+                                                     : request->set_info.parent_handle;
+    struct chimera_vfs_file_state  *fs;
+    uint64_t                        skip_lo, skip_hi;
+    bool                            has_skip;
+
+    request->set_info.dp_probe_active = 0;
+    request->set_info.dp_file_state   = NULL;
+
+    /* A rename INTO a directory must break that directory's lease HANDLE caching
+     * (RH->R): a conflicting handle-leased opener (one holding the dst parent
+     * open with DELETE access) may close in response and free the rename, else
+     * the rename fails SHARING_VIOLATION (MS-SMB2; dirlease.rename_dst_parent).
+     * Model it as a transient SHARE probe (denied=D) on the dst parent: it
+     * conflicts ONLY with a DELETE-access holder, so it is inert for ordinary
+     * renames into a leased directory (dirlease.rename holders take no DELETE
+     * access).  No dst-parent state => no lease => rename directly. */
+    fs = dest_parent_oh ? chimera_vfs_state_get(vfs_state, dest_parent_oh->fh,
+                                                dest_parent_oh->fh_len,
+                                                dest_parent_oh->fh_hash, false)
+                        : NULL;
+
+    if (!fs) {
+        chimera_smb_set_info_rename_emit(request);
+        return;
+    }
+
+    request->set_info.dp_file_state = fs;
+
+    /* Self-exempt the directory lease named by the operating open's
+     * ParentLeaseKey: a rename issued under the dst parent's own lease must not
+     * break (and then deny against) that lease. */
+    has_skip = chimera_smb_parent_lease_skip(open_file->parent_lease_key,
+                                             &skip_lo, &skip_hi);
+
+    memset(&request->set_info.dp_probe, 0, sizeof(request->set_info.dp_probe));
+    request->set_info.dp_probe.kind             = CHIMERA_VFS_LEASE_SHARE;
+    request->set_info.dp_probe.mode.denied      = CHIMERA_VFS_LEASE_MODE_D;
+    request->set_info.dp_probe.owner.protocol   = CHIMERA_VFS_LEASE_PROTO_SMB2;
+    request->set_info.dp_probe.owner.client_key = request->session_handle->session->client_key;
+    request->set_info.dp_probe.owner.owner_lo   = open_file->file_id.pid;
+    request->set_info.dp_probe.owner.owner_hi   = open_file->file_id.vid;
+    if (has_skip) {
+        request->set_info.dp_probe.has_break_skip_key = 1;
+        request->set_info.dp_probe.break_skip_lo      = skip_lo;
+        request->set_info.dp_probe.break_skip_hi      = skip_hi;
+    }
+
+    struct chimera_server_smb_thread *thread = request->compound->thread;
+
+    chimera_vfs_lease_acquire(vfs_state, fs, &request->set_info.dp_probe,
+                              &request->set_info.dp_ticket, true,
+                              chimera_smb_set_info_rename_dp_cb, request);
+
+    /* If the probe parked on a dir-lease break, that break targets the dst
+     * parent's holder on THIS connection (the rename's own conn is mid-compound,
+     * so the break was deferred for reply-before-break ordering).  The rename
+     * will not reply until the break resolves, so flush the deferred break now or
+     * the holder never sees it and the rename deadlocks (it never gets the chance
+     * to close / ack).  Harmless if the probe resolved synchronously. */
+    chimera_smb_lease_break_flush(thread);
 } /* chimera_smb_set_info_rename_do_rename */
 
 static void

--- a/src/server/smb/smb_proc_write.c
+++ b/src/server/smb/smb_proc_write.c
@@ -65,16 +65,24 @@ chimera_smb_write_callback(
          * stream's contents and size, so set the STREAM_WRITE/STREAM_SIZE
          * classes too — a watcher requesting only
          * FILE_NOTIFY_CHANGE_STREAM_{WRITE,SIZE} must still be notified
-         * (WPTS BVT_SMB2Basic_ChangeNotify_ChangeStream{Write,Size}). */
-        chimera_vfs_notify_emit(thread->shared->vfs->vfs_notify,
-                                request->write.open_file->parent_fh,
-                                request->write.open_file->parent_fh_len,
-                                CHIMERA_VFS_NOTIFY_FILE_MODIFIED |
-                                CHIMERA_VFS_NOTIFY_STREAM_WRITE |
-                                CHIMERA_VFS_NOTIFY_STREAM_SIZE,
-                                request->write.open_file->name,
-                                request->write.open_file->name_len,
-                                NULL, 0);
+         * (WPTS BVT_SMB2Basic_ChangeNotify_ChangeStream{Write,Size}).
+         *
+         * Deliver the change-notify event WITHOUT breaking the parent directory
+         * lease: a write's effect on the file's directory-visible metadata
+         * (size/mtime) is not observable until the handle closes, so the
+         * dir-lease content break is deferred to close (the open is flagged
+         * MODIFIED for chimera_smb_close to emit it).  MS-SMB2;
+         * dirlease.v2_request. */
+        chimera_vfs_notify_emit_nobreak(thread->shared->vfs->vfs_notify,
+                                        request->write.open_file->parent_fh,
+                                        request->write.open_file->parent_fh_len,
+                                        CHIMERA_VFS_NOTIFY_FILE_MODIFIED |
+                                        CHIMERA_VFS_NOTIFY_STREAM_WRITE |
+                                        CHIMERA_VFS_NOTIFY_STREAM_SIZE,
+                                        request->write.open_file->name,
+                                        request->write.open_file->name_len,
+                                        NULL, 0);
+        request->write.open_file->flags |= CHIMERA_SMB_OPEN_FILE_FLAG_MODIFIED;
     }
 
     /* A handle that explicitly set its write time has "taken control" of it:

--- a/src/server/smb/smb_procs.h
+++ b/src/server/smb/smb_procs.h
@@ -289,6 +289,11 @@ void chimera_smb_lease_break_cb(
 void chimera_smb_lease_break_thread_init(
     struct chimera_server_smb_thread *thread);
 
+/* Send all lease-break notifications queued for this thread's connections.
+ * Called from the request reply path so op-triggered breaks follow the reply. */
+void chimera_smb_lease_break_flush(
+    struct chimera_server_smb_thread *thread);
+
 void chimera_smb_lease_break_thread_destroy(
     struct chimera_server_smb_thread *thread);
 

--- a/src/server/smb/smb_session.h
+++ b/src/server/smb/smb_session.h
@@ -68,6 +68,12 @@ struct chimera_smb_file_id {
  * rather than parking a second time and timing out (MS-SMB2 3.3.5.9.10):
  * smb2.replay.dhv2-pending*. Cleared on resume / break-deadline. */
 #define CHIMERA_SMB_OPEN_FILE_CREATE_PENDING       0x00000200
+/* The file's data was modified through this open (a write occurred).  A write
+ * does NOT immediately break the parent directory lease -- the file's size/mtime
+ * become visible in the directory only at close -- so the parent dir-lease
+ * content break is deferred to this open's close (MS-SMB2; dirlease.v2_request
+ * "write ... only the close ... break the directory lease"). */
+#define CHIMERA_SMB_OPEN_FILE_FLAG_MODIFIED        0x00000400
 
 /* Bits identifying which CREATE contexts a client supplied on the open. Mirrored
  * from request->create.ctx_present_mask into the open file so later phases

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -1387,6 +1387,28 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.dir.fixed
     smb2.dir.many
     smb2.dir.sorted
+    # smb2.dirlease (SMB3 directory leases).  Three subtests stay disabled:
+    # overwrite and unlink_different_{set,initial}_and_close.  All three need a
+    # FILE-LEVEL (last-close) delete-on-close, but chimera removes a delete-on-
+    # close file at the closing handle's release (per-handle / POSIX unlink-while-
+    # open).  A file-level scheme is what unlink_different asserts, but it makes
+    # smb2_deltree loop whenever a handle is leaked (these tests close a 2nd-tree
+    # handle on the wrong tree), so the two semantics conflict; left as follow-up.
+    smb2.dirlease.leases
+    smb2.dirlease.oplocks
+    smb2.dirlease.v2_request
+    smb2.dirlease.rename_dst_parent
+    smb2.dirlease.seteof
+    smb2.dirlease.setdos
+    smb2.dirlease.setbtime
+    smb2.dirlease.setmtime
+    smb2.dirlease.setctime
+    smb2.dirlease.setatime
+    smb2.dirlease.v2_request_parent
+    smb2.dirlease.rename
+    smb2.dirlease.hardlink
+    smb2.dirlease.unlink_same_set_and_close
+    smb2.dirlease.unlink_same_initial_and_close
     # smb2.durable-open-disconnect
     smb2.durable-open-disconnect.open-oplock-disconnect
     # smb2.durable-open

--- a/src/server/smb/tests/smbtorture_test.c
+++ b/src/server/smb/tests/smbtorture_test.c
@@ -354,6 +354,11 @@ main(
     chimera_server_config_set_smb_leases(config, 1);
     chimera_server_config_set_smb_oplocks(config, 1);
 
+    /* Advertise SMB2_GLOBAL_CAP_DIRECTORY_LEASING and grant R/H directory leases
+     * so the smb2.dirlease suite (which skips outright when the capability is not
+     * negotiated) actually runs. */
+    chimera_server_config_set_smb_directory_leases(config, 1);
+
     /* SMB3 multichannel: advertise interfaces so FSCTL_QUERY_NETWORK_INTERFACE_
      * INFO returns a non-empty list and the smb2.multichannel suites run instead
      * of bailing ("no interface info returned").  Everything in the test netns

--- a/src/vfs/tests/vfs_enforce_test.c
+++ b/src/vfs/tests/vfs_enforce_test.c
@@ -275,7 +275,7 @@ remove_as(
     uint32_t                        child_fh_len)
 {
     chimera_vfs_remove_at(ctx->vfs_thread, cred, dir, name, strlen(name),
-                          child_fh, child_fh_len, 0, 0, remove_cb, ctx);
+                          child_fh, child_fh_len, 0, 0, NULL, remove_cb, ctx);
     wait_done(ctx);
     return ctx->status;
 } /* remove_as */

--- a/src/vfs/vfs.h
+++ b/src/vfs/vfs.h
@@ -802,6 +802,11 @@ struct chimera_vfs_request {
             uint64_t                        name_hash;
             const uint8_t                  *child_fh;     /* Optional: child FH if known */
             int                             child_fh_len; /* 0 if child_fh not provided */
+            /* SMB3 directory-lease self-exemption (see link_at): spare the dir
+             * lease named by the deleting open's ParentLeaseKey from the
+             * FILE_REMOVED break on the parent.  NULL caller = break all. */
+            uint8_t                         parent_lease_skip[16];
+            uint8_t                         parent_lease_skip_valid;
             struct chimera_vfs_attrs        r_dir_pre_attr;
             struct chimera_vfs_attrs        r_dir_post_attr;
             struct chimera_vfs_attrs        r_removed_attr;
@@ -842,6 +847,11 @@ struct chimera_vfs_request {
             int                      target_fh_len; /* 0 if target_fh not provided */
             uint8_t                  source_fh[CHIMERA_VFS_FH_SIZE]; /* resolved source FH, for delegation recall */
             int                      source_fh_len; /* 0 if source FH could not be resolved */
+            /* SMB3 directory-lease self-exemption (see link_at): spare the dir
+             * lease named by the operating open's ParentLeaseKey from the RENAMED
+             * break on the source/dest parent.  NULL caller = no skip. */
+            uint8_t                  parent_lease_skip[16];
+            uint8_t                  parent_lease_skip_valid;
             struct chimera_vfs_attrs r_fromdir_pre_attr;
             struct chimera_vfs_attrs r_fromdir_post_attr;
             struct chimera_vfs_attrs r_todir_pre_attr;
@@ -856,6 +866,12 @@ struct chimera_vfs_request {
             int                      namelen;
             unsigned int             replace;
             uint64_t                 name_hash;
+            /* SMB3 directory-lease self-exemption: when this link/rename is
+             * issued through a handle that supplied a ParentLeaseKey, that
+             * directory lease must not be broken by the FILE_ADDED emit on the
+             * parent.  Copied from the caller (NULL = no skip, break all). */
+            uint8_t                  parent_lease_skip[16];
+            uint8_t                  parent_lease_skip_valid;
             struct chimera_vfs_attrs r_attr;
             struct chimera_vfs_attrs r_replaced_attr;
             struct chimera_vfs_attrs r_dir_pre_attr;

--- a/src/vfs/vfs_lease_types.h
+++ b/src/vfs/vfs_lease_types.h
@@ -165,6 +165,14 @@ struct chimera_vfs_lease {
      * evicted (purged) by the SMB caching-acquire path instead.  Cleared on
      * reconnect. */
     uint8_t                           parked;
+    /* Set on a CACHING lease that is an SMB3 directory lease (R/H only, never
+     * W).  Two directory leases held by different clients on the same directory
+     * coexist — handle caching is NOT single-holder-exclusive across clients for
+     * directories the way it is for a file batch oplock — so the conflict matrix
+     * relaxes the cross-client H rule when both sides are directory leases.  A
+     * directory lease's read caching is broken out-of-band on a content change
+     * (chimera_vfs_dir_lease_break_read), not by the open-conflict matrix. */
+    uint8_t                           is_dir;
 
     /* For a CACHING lease that is owned by a VFS caching grant (the shared,
      * owner-keyed, refcounted object that lets N opens under one owner share a
@@ -217,6 +225,10 @@ struct chimera_vfs_caching_grant {
      * read caching dropped, or break to NONE) leaves this clear so an open does not
      * park waiting for an ack that never comes. */
     uint8_t                           break_ack_required;
+    /* True for an SMB3 directory lease (R/H only).  Mirrors lease.is_dir; kept on
+     * the grant so the SMB layer and break paths can recognise a directory lease
+     * without reaching through the embedded lease. */
+    uint8_t                           is_dir;
     struct chimera_vfs_caching_grant *grant_next; /* link on file->caching_grants */
     /* Protocol holder list — opaque to the VFS; the protocol server threads its
      * per-open holder objects through here so a break callback can select a LIVE

--- a/src/vfs/vfs_notify.c
+++ b/src/vfs/vfs_notify.c
@@ -11,6 +11,7 @@
 #include "vfs_rpl_cache.h"
 #include "vfs_mount_table.h"
 #include "vfs/vfs_procs.h"
+#include "vfs/vfs_state.h"
 #include "common/macros.h"
 
 /* ----------------------------------------------------------------
@@ -933,8 +934,8 @@ chimera_vfs_notify_watch_take_deleted(struct chimera_vfs_notify_watch *watch)
  *  inducing path is ever needed.
  */
 
-SYMBOL_EXPORT void
-chimera_vfs_notify_emit(
+static void
+chimera_vfs_notify_emit_body(
     struct chimera_vfs_notify *notify,
     const uint8_t             *dir_fh,
     uint16_t                   dir_fh_len,
@@ -1200,7 +1201,91 @@ chimera_vfs_notify_emit(
 
     /* Start the resolve chain */
     chimera_vfs_notify_resolve(pev);
+} /* chimera_vfs_notify_emit_body */
+
+/* A directory's contents/metadata just changed (a child added / removed /
+ * renamed, or a child's attributes set).  Break every SMB3 directory lease on
+ * that directory so a client caching its enumeration re-reads it — this is the
+ * cross-protocol coherency point: an NFS or S3 mutation breaks an SMB client's
+ * directory lease exactly as an SMB mutation does.  Run before taking any notify
+ * registry lock (the break brackets vfs_state's file lock entirely, so there is
+ * no nesting against bucket/mount locks — preserving the lock-order invariant
+ * documented above).  `has_skip` spares the lease named by a ParentLeaseKey the
+ * mutating client supplied (self-exemption); the no-skip wrapper breaks all. */
+static inline void
+chimera_vfs_notify_dir_lease_break(
+    struct chimera_vfs_notify *notify,
+    const uint8_t             *dir_fh,
+    uint16_t                   dir_fh_len,
+    uint64_t                   skip_lo,
+    uint64_t                   skip_hi,
+    bool                       has_skip)
+{
+    if (notify && notify->vfs && notify->vfs->vfs_state) {
+        chimera_vfs_state_dir_lease_break(notify->vfs->vfs_state,
+                                          dir_fh, dir_fh_len,
+                                          chimera_vfs_hash(dir_fh, dir_fh_len),
+                                          skip_lo, skip_hi, has_skip);
+    }
+} /* chimera_vfs_notify_dir_lease_break */
+
+SYMBOL_EXPORT void
+chimera_vfs_notify_emit(
+    struct chimera_vfs_notify *notify,
+    const uint8_t             *dir_fh,
+    uint16_t                   dir_fh_len,
+    uint32_t                   action,
+    const char                *name,
+    uint16_t                   name_len,
+    const char                *old_name,
+    uint16_t                   old_name_len)
+{
+    chimera_vfs_notify_dir_lease_break(notify, dir_fh, dir_fh_len, 0, 0, false);
+    chimera_vfs_notify_emit_body(notify, dir_fh, dir_fh_len, action,
+                                 name, name_len, old_name, old_name_len);
 } /* chimera_vfs_notify_emit */
+
+SYMBOL_EXPORT void
+chimera_vfs_notify_emit_lease(
+    struct chimera_vfs_notify *notify,
+    const uint8_t             *dir_fh,
+    uint16_t                   dir_fh_len,
+    uint32_t                   action,
+    const char                *name,
+    uint16_t                   name_len,
+    const char                *old_name,
+    uint16_t                   old_name_len,
+    uint64_t                   skip_lo,
+    uint64_t                   skip_hi,
+    bool                       has_skip)
+{
+    chimera_vfs_notify_dir_lease_break(notify, dir_fh, dir_fh_len,
+                                       skip_lo, skip_hi, has_skip);
+    chimera_vfs_notify_emit_body(notify, dir_fh, dir_fh_len, action,
+                                 name, name_len, old_name, old_name_len);
+} /* chimera_vfs_notify_emit_lease */
+
+SYMBOL_EXPORT void
+chimera_vfs_notify_emit_nobreak(
+    struct chimera_vfs_notify *notify,
+    const uint8_t             *dir_fh,
+    uint16_t                   dir_fh_len,
+    uint32_t                   action,
+    const char                *name,
+    uint16_t                   name_len,
+    const char                *old_name,
+    uint16_t                   old_name_len)
+{
+    /* Deliver the CHANGE_NOTIFY event WITHOUT breaking directory leases.  Used
+     * by the SMB create path when a create-capable disposition merely OPENED an
+     * existing file (no directory-content change): change-notify still emits the
+     * (conservative) FILE_ADDED, but a directory read lease must NOT break,
+     * because nothing in the directory actually changed (a re-open of an
+     * existing entry; smbtorture dirlease.rename re-opens the file before
+     * renaming it). */
+    chimera_vfs_notify_emit_body(notify, dir_fh, dir_fh_len, action,
+                                 name, name_len, old_name, old_name_len);
+} /* chimera_vfs_notify_emit_nobreak */
 
 SYMBOL_EXPORT void
 chimera_vfs_notify_emit_delete(

--- a/src/vfs/vfs_notify.h
+++ b/src/vfs/vfs_notify.h
@@ -237,6 +237,40 @@ chimera_vfs_notify_emit(
     const char                *old_name,
     uint16_t                   old_name_len);
 
+/* Like chimera_vfs_notify_emit, but the caller (the SMB layer) supplies a
+ * ParentLeaseKey naming an SMB3 directory lease to spare from the
+ * directory-lease break this fires: the mutating client's cached directory view
+ * is coherent with the change it just made (MS-SMB2 dirlease self-exemption).
+ * `has_skip` == false is exactly chimera_vfs_notify_emit (break every lease). */
+void
+chimera_vfs_notify_emit_lease(
+    struct chimera_vfs_notify *notify,
+    const uint8_t             *dir_fh,
+    uint16_t                   dir_fh_len,
+    uint32_t                   action,
+    const char                *name,
+    uint16_t                   name_len,
+    const char                *old_name,
+    uint16_t                   old_name_len,
+    uint64_t                   skip_lo,
+    uint64_t                   skip_hi,
+    bool                       has_skip);
+
+/* Deliver a CHANGE_NOTIFY event but do NOT break SMB3 directory leases.  For
+ * the SMB create path when a create-capable disposition only opened an existing
+ * file — change-notify fires (conservatively) but the directory's contents did
+ * not change, so a directory read lease must not be recalled. */
+void
+chimera_vfs_notify_emit_nobreak(
+    struct chimera_vfs_notify *notify,
+    const uint8_t             *dir_fh,
+    uint16_t                   dir_fh_len,
+    uint32_t                   action,
+    const char                *name,
+    uint16_t                   name_len,
+    const char                *old_name,
+    uint16_t                   old_name_len);
+
 /*
  * Signal that the object identified by `fh` was itself removed.  Marks every
  * exact watch on that FH deleted and fires its callback, so a pending

--- a/src/vfs/vfs_proc_link.c
+++ b/src/vfs/vfs_proc_link.c
@@ -61,6 +61,8 @@ chimera_vfs_link_dest_parent_lookup_complete(
         request->link.attr_mask,
         0,
         0,
+        NULL,
+        NULL,
         chimera_vfs_link_op_complete,
         request);
 } /* chimera_vfs_link_dest_parent_lookup_complete */
@@ -100,6 +102,8 @@ chimera_vfs_link_source_lookup_fast_complete(
         request->link.attr_mask,
         0,
         0,
+        NULL,
+        NULL,
         chimera_vfs_link_op_complete,
         request);
 } /* chimera_vfs_link_source_lookup_fast_complete */

--- a/src/vfs/vfs_proc_link_at.c
+++ b/src/vfs/vfs_proc_link_at.c
@@ -9,6 +9,7 @@
 #include "vfs_internal.h"
 #include "vfs_name_cache.h"
 #include "vfs_attr_cache.h"
+#include "vfs_notify.h"
 #include "vfs_access.h"
 #include "vfs_acl.h"
 #include "common/misc.h"
@@ -23,6 +24,30 @@ chimera_vfs_link_at_complete(struct chimera_vfs_request *request)
 
 
     if (request->status == CHIMERA_VFS_OK) {
+        /* A hard link (or an SMB rename, which lands here) adds a name to the
+         * target directory — the same kind of directory-content change as a
+         * create.  Emit FILE_ADDED on the parent so CHANGE_NOTIFY watchers see
+         * it (this path previously emitted nothing) and, via the notify
+         * chokepoint, any SMB3 directory lease on the parent is broken.  A
+         * directory cannot be hard-linked, so the added entry is always a file.
+         * parent_lease_skip (set when an SMB op supplied a ParentLeaseKey)
+         * spares the caller's own directory lease from that break. */
+        uint64_t skip_lo = 0, skip_hi = 0;
+
+        if (request->link_at.parent_lease_skip_valid) {
+            memcpy(&skip_lo, request->link_at.parent_lease_skip, 8);
+            memcpy(&skip_hi, request->link_at.parent_lease_skip + 8, 8);
+        }
+        chimera_vfs_notify_emit_lease(thread->vfs->vfs_notify,
+                                      request->link_at.dir_fh,
+                                      request->link_at.dir_fhlen,
+                                      CHIMERA_VFS_NOTIFY_FILE_ADDED,
+                                      request->link_at.name,
+                                      request->link_at.namelen,
+                                      NULL, 0,
+                                      skip_lo, skip_hi,
+                                      request->link_at.parent_lease_skip_valid);
+
         chimera_vfs_name_cache_insert(thread, name_cache,
                                       request->link_at.dir_fh_hash,
                                       request->link_at.dir_fh,
@@ -67,20 +92,22 @@ chimera_vfs_link_at_complete(struct chimera_vfs_request *request)
 
 static void
 chimera_vfs_link_at_dispatch(
-    struct chimera_vfs_thread     *thread,
-    const struct chimera_vfs_cred *cred,
-    const void                    *fh,
-    int                            fhlen,
-    const void                    *dir_fh,
-    int                            dir_fhlen,
-    const char                    *name,
-    int                            namelen,
-    unsigned int                   replace,
-    uint64_t                       attr_mask,
-    uint64_t                       pre_attr_mask,
-    uint64_t                       post_attr_mask,
-    chimera_vfs_link_at_callback_t callback,
-    void                          *private_data)
+    struct chimera_vfs_thread      *thread,
+    const struct chimera_vfs_cred  *cred,
+    const void                     *fh,
+    int                             fhlen,
+    const void                     *dir_fh,
+    int                             dir_fhlen,
+    const char                     *name,
+    int                             namelen,
+    unsigned int                    replace,
+    uint64_t                        attr_mask,
+    uint64_t                        pre_attr_mask,
+    uint64_t                        post_attr_mask,
+    const uint8_t                  *parent_lease_skip,
+    struct chimera_vfs_open_handle *op_handle,
+    chimera_vfs_link_at_callback_t  callback,
+    void                           *private_data)
 {
     struct chimera_vfs_request *request;
 
@@ -91,15 +118,24 @@ chimera_vfs_link_at_dispatch(
         return;
     }
 
-    request->opcode                              = CHIMERA_VFS_OP_LINK_AT;
-    request->complete                            = chimera_vfs_link_at_complete;
-    request->link_at.dir_fh_hash                 = chimera_vfs_hash(dir_fh, dir_fhlen);
-    request->link_at.dir_fh                      = dir_fh;
-    request->link_at.dir_fhlen                   = dir_fhlen;
-    request->link_at.name                        = name;
-    request->link_at.namelen                     = namelen;
-    request->link_at.name_hash                   = chimera_vfs_hash(name, namelen);
-    request->link_at.replace                     = replace;
+    request->opcode              = CHIMERA_VFS_OP_LINK_AT;
+    request->complete            = chimera_vfs_link_at_complete;
+    request->link_at.dir_fh_hash = chimera_vfs_hash(dir_fh, dir_fhlen);
+    request->link_at.dir_fh      = dir_fh;
+    request->link_at.dir_fhlen   = dir_fhlen;
+    request->link_at.name        = name;
+    request->link_at.namelen     = namelen;
+    request->link_at.name_hash   = chimera_vfs_hash(name, namelen);
+    request->link_at.replace     = replace;
+    if (parent_lease_skip) {
+        memcpy(request->link_at.parent_lease_skip, parent_lease_skip, 16);
+        request->link_at.parent_lease_skip_valid = 1;
+    } else {
+        request->link_at.parent_lease_skip_valid = 0;
+    }
+    /* Self-exempt the operating handle's own lease from the source-file recall
+     * (the linker is coherent with its own change; NULL = recall all). */
+    request->io_handle                           = op_handle;
     request->link_at.r_attr.va_req_mask          = attr_mask | CHIMERA_VFS_ATTR_FH | CHIMERA_VFS_ATTR_MASK_CACHEABLE;
     request->link_at.r_attr.va_set_mask          = 0;
     request->link_at.r_replaced_attr.va_req_mask = CHIMERA_VFS_ATTR_FH | CHIMERA_VFS_ATTR_MASK_CACHEABLE;
@@ -124,20 +160,23 @@ chimera_vfs_link_at_dispatch(
  * directory requires ADD_FILE on that directory.
  */
 struct chimera_vfs_link_at_gate {
-    struct chimera_vfs_thread     *thread;
-    const struct chimera_vfs_cred *cred;
-    const void                    *fh;
-    int                            fhlen;
-    const void                    *dir_fh;
-    int                            dir_fhlen;
-    const char                    *name;
-    int                            namelen;
-    unsigned int                   replace;
-    uint64_t                       attr_mask;
-    uint64_t                       pre_attr_mask;
-    uint64_t                       post_attr_mask;
-    chimera_vfs_link_at_callback_t callback;
-    void                          *private_data;
+    struct chimera_vfs_thread      *thread;
+    const struct chimera_vfs_cred  *cred;
+    const void                     *fh;
+    int                             fhlen;
+    const void                     *dir_fh;
+    int                             dir_fhlen;
+    const char                     *name;
+    int                             namelen;
+    unsigned int                    replace;
+    uint64_t                        attr_mask;
+    uint64_t                        pre_attr_mask;
+    uint64_t                        post_attr_mask;
+    uint8_t                         parent_lease_skip[16];
+    uint8_t                         parent_lease_skip_valid;
+    struct chimera_vfs_open_handle *op_handle;
+    chimera_vfs_link_at_callback_t  callback;
+    void                           *private_data;
 };
 
 static void
@@ -157,26 +196,31 @@ chimera_vfs_link_at_gate_complete(
                                  gate->dir_fh, gate->dir_fhlen, gate->name,
                                  gate->namelen, gate->replace, gate->attr_mask,
                                  gate->pre_attr_mask, gate->post_attr_mask,
+                                 gate->parent_lease_skip_valid ?
+                                 gate->parent_lease_skip : NULL,
+                                 gate->op_handle,
                                  gate->callback, gate->private_data);
     free(gate);
 } /* chimera_vfs_link_at_gate_complete */
 
 SYMBOL_EXPORT void
 chimera_vfs_link_at(
-    struct chimera_vfs_thread     *thread,
-    const struct chimera_vfs_cred *cred,
-    const void                    *fh,
-    int                            fhlen,
-    const void                    *dir_fh,
-    int                            dir_fhlen,
-    const char                    *name,
-    int                            namelen,
-    unsigned int                   replace,
-    uint64_t                       attr_mask,
-    uint64_t                       pre_attr_mask,
-    uint64_t                       post_attr_mask,
-    chimera_vfs_link_at_callback_t callback,
-    void                          *private_data)
+    struct chimera_vfs_thread      *thread,
+    const struct chimera_vfs_cred  *cred,
+    const void                     *fh,
+    int                             fhlen,
+    const void                     *dir_fh,
+    int                             dir_fhlen,
+    const char                     *name,
+    int                             namelen,
+    unsigned int                    replace,
+    uint64_t                        attr_mask,
+    uint64_t                        pre_attr_mask,
+    uint64_t                        post_attr_mask,
+    const uint8_t                  *parent_lease_skip,
+    struct chimera_vfs_open_handle *op_handle,
+    chimera_vfs_link_at_callback_t  callback,
+    void                           *private_data)
 {
     struct chimera_vfs_module       *module;
     struct chimera_vfs_link_at_gate *gate;
@@ -208,8 +252,15 @@ chimera_vfs_link_at(
         gate->attr_mask      = attr_mask;
         gate->pre_attr_mask  = pre_attr_mask;
         gate->post_attr_mask = post_attr_mask;
-        gate->callback       = callback;
-        gate->private_data   = private_data;
+        if (parent_lease_skip) {
+            memcpy(gate->parent_lease_skip, parent_lease_skip, 16);
+            gate->parent_lease_skip_valid = 1;
+        } else {
+            gate->parent_lease_skip_valid = 0;
+        }
+        gate->op_handle    = op_handle;
+        gate->callback     = callback;
+        gate->private_data = private_data;
 
         chimera_vfs_gate_fh_dac(thread, cred, dir_fh, dir_fhlen,
                                 CHIMERA_ACE_WRITE_DATA | CHIMERA_ACE_EXECUTE,
@@ -219,6 +270,7 @@ chimera_vfs_link_at(
 
     chimera_vfs_link_at_dispatch(thread, cred, fh, fhlen, dir_fh, dir_fhlen,
                                  name, namelen, replace, attr_mask,
-                                 pre_attr_mask, post_attr_mask, callback,
+                                 pre_attr_mask, post_attr_mask,
+                                 parent_lease_skip, op_handle, callback,
                                  private_data);
 } /* chimera_vfs_link_at */

--- a/src/vfs/vfs_proc_remove.c
+++ b/src/vfs/vfs_proc_remove.c
@@ -64,6 +64,7 @@ chimera_vfs_remove_child_lookup_complete(
         request->remove.child_fh_len,
         0,
         0,
+        NULL,
         chimera_vfs_remove_op_complete,
         request);
 } /* chimera_vfs_remove_child_lookup_complete */

--- a/src/vfs/vfs_proc_remove_at.c
+++ b/src/vfs/vfs_proc_remove_at.c
@@ -51,13 +51,21 @@ chimera_vfs_remove_at_complete(struct chimera_vfs_request *request)
         request->remove_at.r_removed_attr.va_set_mask &=
             ~CHIMERA_VFS_ATTR_MASK_STAT;
 
-        chimera_vfs_notify_emit(thread->vfs->vfs_notify,
-                                request->remove_at.handle->fh,
-                                request->remove_at.handle->fh_len,
-                                action,
-                                request->remove_at.name,
-                                request->remove_at.namelen,
-                                NULL, 0);
+        uint64_t skip_lo = 0, skip_hi = 0;
+
+        if (request->remove_at.parent_lease_skip_valid) {
+            memcpy(&skip_lo, request->remove_at.parent_lease_skip, 8);
+            memcpy(&skip_hi, request->remove_at.parent_lease_skip + 8, 8);
+        }
+        chimera_vfs_notify_emit_lease(thread->vfs->vfs_notify,
+                                      request->remove_at.handle->fh,
+                                      request->remove_at.handle->fh_len,
+                                      action,
+                                      request->remove_at.name,
+                                      request->remove_at.namelen,
+                                      NULL, 0,
+                                      skip_lo, skip_hi,
+                                      request->remove_at.parent_lease_skip_valid);
 
         /* Signal any CHANGE_NOTIFY armed on a handle to the object that was
          * just removed (its own FH, distinct from the parent emit above) so
@@ -122,6 +130,7 @@ chimera_vfs_remove_at_dispatch(
     int                              child_fh_len,
     uint64_t                         pre_attr_mask,
     uint64_t                         post_attr_mask,
+    const uint8_t                   *parent_lease_skip,
     chimera_vfs_remove_at_callback_t callback,
     void                            *private_data)
 {
@@ -134,14 +143,20 @@ chimera_vfs_remove_at_dispatch(
         return;
     }
 
-    request->opcode                                = CHIMERA_VFS_OP_REMOVE_AT;
-    request->complete                              = chimera_vfs_remove_at_complete;
-    request->remove_at.handle                      = handle;
-    request->remove_at.name                        = name;
-    request->remove_at.namelen                     = namelen;
-    request->remove_at.name_hash                   = chimera_vfs_hash(name, namelen);
-    request->remove_at.child_fh                    = child_fh;
-    request->remove_at.child_fh_len                = child_fh_len;
+    request->opcode                 = CHIMERA_VFS_OP_REMOVE_AT;
+    request->complete               = chimera_vfs_remove_at_complete;
+    request->remove_at.handle       = handle;
+    request->remove_at.name         = name;
+    request->remove_at.namelen      = namelen;
+    request->remove_at.name_hash    = chimera_vfs_hash(name, namelen);
+    request->remove_at.child_fh     = child_fh;
+    request->remove_at.child_fh_len = child_fh_len;
+    if (parent_lease_skip) {
+        memcpy(request->remove_at.parent_lease_skip, parent_lease_skip, 16);
+        request->remove_at.parent_lease_skip_valid = 1;
+    } else {
+        request->remove_at.parent_lease_skip_valid = 0;
+    }
     request->remove_at.r_dir_pre_attr.va_req_mask  = pre_attr_mask;
     request->remove_at.r_dir_pre_attr.va_set_mask  = 0;
     request->remove_at.r_dir_post_attr.va_req_mask = post_attr_mask | CHIMERA_VFS_ATTR_MASK_CACHEABLE;
@@ -177,6 +192,8 @@ struct chimera_vfs_remove_at_gate {
     int                              child_fh_len;
     uint64_t                         pre_attr_mask;
     uint64_t                         post_attr_mask;
+    uint8_t                          parent_lease_skip[16];
+    uint8_t                          parent_lease_skip_valid;
     chimera_vfs_remove_at_callback_t callback;
     void                            *private_data;
 };
@@ -197,7 +214,10 @@ chimera_vfs_remove_at_gate_complete(
     chimera_vfs_remove_at_dispatch(gate->thread, gate->cred, gate->handle,
                                    gate->name, gate->namelen, gate->child_fh,
                                    gate->child_fh_len, gate->pre_attr_mask,
-                                   gate->post_attr_mask, gate->callback,
+                                   gate->post_attr_mask,
+                                   gate->parent_lease_skip_valid ?
+                                   gate->parent_lease_skip : NULL,
+                                   gate->callback,
                                    gate->private_data);
     free(gate);
 } /* chimera_vfs_remove_at_gate_complete */
@@ -213,6 +233,7 @@ chimera_vfs_remove_at(
     int                              child_fh_len,
     uint64_t                         pre_attr_mask,
     uint64_t                         post_attr_mask,
+    const uint8_t                   *parent_lease_skip,
     chimera_vfs_remove_at_callback_t callback,
     void                            *private_data)
 {
@@ -245,8 +266,14 @@ chimera_vfs_remove_at(
         gate->child_fh_len   = child_fh_len;
         gate->pre_attr_mask  = pre_attr_mask;
         gate->post_attr_mask = post_attr_mask;
-        gate->callback       = callback;
-        gate->private_data   = private_data;
+        if (parent_lease_skip) {
+            memcpy(gate->parent_lease_skip, parent_lease_skip, 16);
+            gate->parent_lease_skip_valid = 1;
+        } else {
+            gate->parent_lease_skip_valid = 0;
+        }
+        gate->callback     = callback;
+        gate->private_data = private_data;
 
         if (child_fh && child_fh_len > 0) {
             chimera_vfs_gate_delete(thread, cred, handle->fh, handle->fh_len,
@@ -265,5 +292,6 @@ chimera_vfs_remove_at(
 
     chimera_vfs_remove_at_dispatch(thread, cred, handle, name, namelen,
                                    child_fh, child_fh_len, pre_attr_mask,
-                                   post_attr_mask, callback, private_data);
+                                   post_attr_mask, parent_lease_skip,
+                                   callback, private_data);
 } /* chimera_vfs_remove_at */

--- a/src/vfs/vfs_proc_rename.c
+++ b/src/vfs/vfs_proc_rename.c
@@ -66,6 +66,8 @@ chimera_vfs_rename_target_lookup_complete(
         request->rename.target_fh_len,
         0,
         0,
+        NULL,
+        NULL,
         chimera_vfs_rename_op_complete,
         request);
 } /* chimera_vfs_rename_target_lookup_complete */
@@ -143,6 +145,8 @@ chimera_vfs_rename_fast_target_lookup_complete(
         request->rename.target_fh_len,
         0,
         0,
+        NULL,
+        NULL,
         chimera_vfs_rename_op_complete,
         request);
 } /* chimera_vfs_rename_fast_target_lookup_complete */

--- a/src/vfs/vfs_proc_rename_at.c
+++ b/src/vfs/vfs_proc_rename_at.c
@@ -24,39 +24,51 @@ chimera_vfs_rename_at_complete(struct chimera_vfs_request *request)
             memcmp(request->fh, request->rename_at.new_fh,
                    request->fh_len) != 0;
 
+        /* SMB3 directory-lease self-exemption: spare the directory lease named
+         * by the operating open's ParentLeaseKey (set by the SMB rename path)
+         * from the RENAMED break.  For a same-dir rename this spares the one
+         * dir; for a cross-dir rename it spares whichever parent's lease the key
+         * matches (the source, since the open lived there), naturally breaking
+         * the other.  NULL caller (NFS/S3) breaks every directory lease. */
+        uint64_t skip_lo = 0, skip_hi = 0;
+        bool     has_skip = request->rename_at.parent_lease_skip_valid;
+
+        if (has_skip) {
+            memcpy(&skip_lo, request->rename_at.parent_lease_skip, 8);
+            memcpy(&skip_hi, request->rename_at.parent_lease_skip + 8, 8);
+        }
+
         if (!cross_dir) {
             /* Intra-directory rename: a single RENAMED event on the
-             * directory carrying both old and new names.  The SMB
-             * serializer expands this to FILE_ACTION_RENAMED_OLD_NAME
-             * followed by FILE_ACTION_RENAMED_NEW_NAME per MS-FSCC. */
-            chimera_vfs_notify_emit(thread->vfs->vfs_notify,
-                                    request->fh,
-                                    request->fh_len,
-                                    CHIMERA_VFS_NOTIFY_RENAMED,
-                                    request->rename_at.new_name,
-                                    request->rename_at.new_namelen,
-                                    request->rename_at.name,
-                                    request->rename_at.namelen);
+             * directory carrying both old and new names. */
+            chimera_vfs_notify_emit_lease(thread->vfs->vfs_notify,
+                                          request->fh,
+                                          request->fh_len,
+                                          CHIMERA_VFS_NOTIFY_RENAMED,
+                                          request->rename_at.new_name,
+                                          request->rename_at.new_namelen,
+                                          request->rename_at.name,
+                                          request->rename_at.namelen,
+                                          skip_lo, skip_hi, has_skip);
         } else {
-            /* Cross-directory rename: source dir sees the OLD name
-             * only (RENAMED_OLD_NAME record), destination sees the
-             * NEW name only (RENAMED_NEW_NAME record).  Matches
-             * Windows behavior and avoids reporting a name on the
-             * source dir that exists in a different directory. */
-            chimera_vfs_notify_emit(thread->vfs->vfs_notify,
-                                    request->fh,
-                                    request->fh_len,
-                                    CHIMERA_VFS_NOTIFY_RENAMED,
-                                    NULL, 0,
-                                    request->rename_at.name,
-                                    request->rename_at.namelen);
-            chimera_vfs_notify_emit(thread->vfs->vfs_notify,
-                                    request->rename_at.new_fh,
-                                    request->rename_at.new_fhlen,
-                                    CHIMERA_VFS_NOTIFY_RENAMED,
-                                    request->rename_at.new_name,
-                                    request->rename_at.new_namelen,
-                                    NULL, 0);
+            /* Cross-directory rename: source dir sees the OLD name only,
+             * destination sees the NEW name only. */
+            chimera_vfs_notify_emit_lease(thread->vfs->vfs_notify,
+                                          request->fh,
+                                          request->fh_len,
+                                          CHIMERA_VFS_NOTIFY_RENAMED,
+                                          NULL, 0,
+                                          request->rename_at.name,
+                                          request->rename_at.namelen,
+                                          skip_lo, skip_hi, has_skip);
+            chimera_vfs_notify_emit_lease(thread->vfs->vfs_notify,
+                                          request->rename_at.new_fh,
+                                          request->rename_at.new_fhlen,
+                                          CHIMERA_VFS_NOTIFY_RENAMED,
+                                          request->rename_at.new_name,
+                                          request->rename_at.new_namelen,
+                                          NULL, 0,
+                                          skip_lo, skip_hi, has_skip);
         }
 
         /* Remove cache entries for both old and new paths.
@@ -161,6 +173,8 @@ chimera_vfs_rename_at_dispatch(
     int                              target_fh_len,
     uint64_t                         pre_attr_mask,
     uint64_t                         post_attr_mask,
+    const uint8_t                   *parent_lease_skip,
+    struct chimera_vfs_open_handle  *op_handle,
     chimera_vfs_rename_at_callback_t callback,
     void                            *private_data)
 {
@@ -197,6 +211,18 @@ chimera_vfs_rename_at_dispatch(
     request->proto_callback                            = callback;
     request->proto_private_data                        = private_data;
     request->rename_at.source_fh_len                   = 0;
+    if (parent_lease_skip) {
+        memcpy(request->rename_at.parent_lease_skip, parent_lease_skip, 16);
+        request->rename_at.parent_lease_skip_valid = 1;
+    } else {
+        request->rename_at.parent_lease_skip_valid = 0;
+    }
+    /* Self-exempt the operating handle's own caching lease from the source-file
+     * recall below: the renamer is coherent with its own rename, so renaming a
+     * file it holds a lease on must not break that lease (the inode is unchanged;
+     * MS-SMB2 / dirlease.rename).  A NULL caller (NFS/S3) recalls every holder,
+     * preserving the RFC 7530 namespace-recall behaviour. */
+    request->io_handle = op_handle;
 
     /* Recall delegations before the directory change: first on the source file
      * being moved (its ctime/linkage changes invalidate cached state), then on
@@ -242,6 +268,9 @@ struct chimera_vfs_rename_at_gate {
     int                              target_fh_len;
     uint64_t                         pre_attr_mask;
     uint64_t                         post_attr_mask;
+    uint8_t                          parent_lease_skip[16];
+    uint8_t                          parent_lease_skip_valid;
+    struct chimera_vfs_open_handle  *op_handle;
     chimera_vfs_rename_at_callback_t callback;
     void                            *private_data;
 };
@@ -264,6 +293,9 @@ chimera_vfs_rename_at_gate_dispatch(struct chimera_vfs_rename_at_gate *gate)
                                    gate->new_name, gate->new_namelen,
                                    gate->target_fh, gate->target_fh_len,
                                    gate->pre_attr_mask, gate->post_attr_mask,
+                                   gate->parent_lease_skip_valid ?
+                                   gate->parent_lease_skip : NULL,
+                                   gate->op_handle,
                                    gate->callback, gate->private_data);
     free(gate);
 } /* chimera_vfs_rename_at_gate_dispatch */
@@ -341,6 +373,8 @@ chimera_vfs_rename_at(
     int                              target_fh_len,
     uint64_t                         pre_attr_mask,
     uint64_t                         post_attr_mask,
+    const uint8_t                   *parent_lease_skip,
+    struct chimera_vfs_open_handle  *op_handle,
     chimera_vfs_rename_at_callback_t callback,
     void                            *private_data)
 {
@@ -380,8 +414,15 @@ chimera_vfs_rename_at(
         gate->target_fh_len  = target_fh_len;
         gate->pre_attr_mask  = pre_attr_mask;
         gate->post_attr_mask = post_attr_mask;
-        gate->callback       = callback;
-        gate->private_data   = private_data;
+        if (parent_lease_skip) {
+            memcpy(gate->parent_lease_skip, parent_lease_skip, 16);
+            gate->parent_lease_skip_valid = 1;
+        } else {
+            gate->parent_lease_skip_valid = 0;
+        }
+        gate->op_handle    = op_handle;
+        gate->callback     = callback;
+        gate->private_data = private_data;
 
         chimera_vfs_gate_fh(thread, cred, fh, fhlen, CHIMERA_ACE_DELETE_CHILD,
                             chimera_vfs_rename_at_gate_src, gate);
@@ -391,5 +432,6 @@ chimera_vfs_rename_at(
     chimera_vfs_rename_at_dispatch(thread, cred, fh, fhlen, name, namelen,
                                    new_fh, new_fhlen, new_name, new_namelen,
                                    target_fh, target_fh_len, pre_attr_mask,
-                                   post_attr_mask, callback, private_data);
+                                   post_attr_mask, parent_lease_skip,
+                                   op_handle, callback, private_data);
 } /* chimera_vfs_rename_at */

--- a/src/vfs/vfs_procs.h
+++ b/src/vfs/vfs_procs.h
@@ -414,6 +414,7 @@ chimera_vfs_remove_at(
     int                              child_fh_len,
     uint64_t                         pre_attr_mask,
     uint64_t                         post_attr_mask,
+    const uint8_t                   *parent_lease_skip,
     chimera_vfs_remove_at_callback_t callback,
     void                            *private_data);
 
@@ -635,6 +636,8 @@ chimera_vfs_rename_at(
     int                              target_fh_len,
     uint64_t                         pre_attr_mask,
     uint64_t                         post_attr_mask,
+    const uint8_t                   *parent_lease_skip,
+    struct chimera_vfs_open_handle  *op_handle,
     chimera_vfs_rename_at_callback_t callback,
     void                            *private_data);
 
@@ -647,20 +650,22 @@ typedef void (*chimera_vfs_link_at_callback_t)(
 
 void
 chimera_vfs_link_at(
-    struct chimera_vfs_thread     *thread,
-    const struct chimera_vfs_cred *cred,
-    const void                    *fh,
-    int                            fhlen,
-    const void                    *dir_fh,
-    int                            dir_fhlen,
-    const char                    *name,
-    int                            namelen,
-    unsigned int                   replace,
-    uint64_t                       attr_mask,
-    uint64_t                       pre_attr_mask,
-    uint64_t                       post_attr_mask,
-    chimera_vfs_link_at_callback_t callback,
-    void                          *private_data);
+    struct chimera_vfs_thread      *thread,
+    const struct chimera_vfs_cred  *cred,
+    const void                     *fh,
+    int                             fhlen,
+    const void                     *dir_fh,
+    int                             dir_fhlen,
+    const char                     *name,
+    int                             namelen,
+    unsigned int                    replace,
+    uint64_t                        attr_mask,
+    uint64_t                        pre_attr_mask,
+    uint64_t                        post_attr_mask,
+    const uint8_t                  *parent_lease_skip,
+    struct chimera_vfs_open_handle *op_handle,
+    chimera_vfs_link_at_callback_t  callback,
+    void                           *private_data);
 
 /* Key-Value Operations */
 

--- a/src/vfs/vfs_state.c
+++ b/src/vfs/vfs_state.c
@@ -427,6 +427,17 @@ chimera_vfs_caching_conflict(
         return true;
     }
 
+    /* Directory leases (R/H only, never W) are NOT handle-exclusive across
+    * clients: many clients commonly hold an RH directory lease on the same
+    * directory at once, and an RH dir lease's read caching is broken on a
+    * content change out-of-band (chimera_vfs_dir_lease_break_read), not by a
+    * conflicting open.  So two directory leases never conflict on H.  The
+    * directory handle itself is invalidated only when the directory is removed
+    * or renamed, which recalls the lease via the normal io_recall path. */
+    if (existing->is_dir && probe->is_dir) {
+        return false;
+    }
+
     /* H (handle-cache) is exclusive only ACROSS CLIENTS — a different client
      * caching the open handle conflicts (a batch oplock is sole-handle), but two
      * lease keys of the SAME client may each hold handle caching (MS-SMB2 lease
@@ -503,11 +514,24 @@ chimera_vfs_share_batch_escape(
     }
 
     for (cur = file->caching_leases; cur; cur = cur->next) {
-        if (cur->owner.cb_private != share_holder->owner.cb_private ||
-            !cur->owner.break_cb ||
+        if (!cur->owner.break_cb ||
             !(cur->mode.granted & CHIMERA_VFS_LEASE_MODE_H)) {
             continue;
         }
+
+        /* Match the breakable handle-caching lease to the conflicting share
+        * holder.  A legacy file oplock shares its owning open with the share
+        * reservation (cb_private set identically).  A directory lease's grant
+        * is keyed by lease key (cb_private = grant, not the open), so match it
+        * to the share holder by client instead: a conflicting open of a leased
+        * directory breaks the dir lease's HANDLE (RH->R); the holder may close
+        * to free the share conflict, else it stands (SHARING_VIOLATION). */
+        if (cur->owner.cb_private != share_holder->owner.cb_private &&
+            !(cur->grant && cur->grant->is_dir &&
+              cur->owner.client_key == share_holder->owner.client_key)) {
+            continue;
+        }
+
         if (cur->break_state == CHIMERA_VFS_BREAK_IDLE ||
             cur->break_state == CHIMERA_VFS_BREAK_BREAKING) {
             return cur;
@@ -1065,8 +1089,19 @@ chimera_vfs_state_try_insert(
                 uint32_t deadline_ms =
                     (conflict->owner.protocol == CHIMERA_VFS_LEASE_PROTO_NFSV4)
                     ? CHIMERA_VFS_NFS_DELEG_RECALL_MS : 0;
-                chimera_vfs_lease_begin_break(state, conflict,
-                                              chimera_vfs_break_retain_for(lease, conflict),
+                uint8_t floor = chimera_vfs_break_retain_for(lease, conflict);
+
+                /* A conflicting open of a leased DIRECTORY breaks the dir lease's
+                 * HANDLE (RH->R): keep read caching, drop handle caching so the
+                 * holder may close and free the share conflict (else it stands ->
+                 * SHARING_VIOLATION).  A SHARE acquirer carries no H bit, so the
+                 * generic retain floor would leave H intact; force it off for a
+                 * directory-lease conflict (dirlease.v2_request / rename_dst_parent). */
+                if (conflict->kind == CHIMERA_VFS_LEASE_CACHING &&
+                    conflict->grant && conflict->grant->is_dir) {
+                    floor = conflict->mode.granted & ~CHIMERA_VFS_LEASE_MODE_H;
+                }
+                chimera_vfs_lease_begin_break(state, conflict, floor,
                                               deadline_ms);
                 began_live_break = true;
             } else {
@@ -1320,6 +1355,34 @@ chimera_vfs_caching_grant_coalesce(
     grant = chimera_vfs_caching_grant_find_locked(file, owner);
     if (grant) {
         grant->refcount++;
+
+        /* Re-arm a directory lease that a content change broke all the way to
+         * NONE (RH -> "", then ACKED at granted 0).  MS-SMB2: re-requesting the
+         * lease under the same key re-establishes it at the requested R/H state
+         * and advances the epoch (the client rebuilds its cached directory view);
+         * the smbtorture dirlease tests do this via test_rearm_dirlease after
+         * every content break.  This differs from the BREAK_IN_PROGRESS re-open
+         * below, where the break is still outstanding and must not be undone. */
+        if (grant->is_dir &&
+            grant->lease.break_state == CHIMERA_VFS_BREAK_ACKED &&
+            grant->lease.mode.granted == 0 &&
+            want.granted != 0) {
+            struct chimera_vfs_lease  probe    = grant->lease;
+            struct chimera_vfs_lease *conflict = NULL;
+
+            probe.mode.granted = want.granted;
+            probe.break_state  = CHIMERA_VFS_BREAK_IDLE;
+            if (chimera_vfs_state_would_conflict(file, &probe, &conflict) ==
+                CHIMERA_VFS_LEASE_GRANTED) {
+                grant->lease.mode.granted      = want.granted;
+                grant->lease.break_state       = CHIMERA_VFS_BREAK_IDLE;
+                grant->lease.break_needed_mode = 0;
+                grant->lease.break_floor       = 0;
+                grant->epoch++;
+            }
+            pthread_mutex_unlock(&file->lock);
+            return grant;
+        }
 
         /* A re-open while the lease is mid-break must NOT upgrade it: MS-SMB2
          * 3.3.5.9.11 has the re-open succeed at the lease's CURRENT (downgrading)
@@ -1765,7 +1828,12 @@ chimera_vfs_state_range_io_conflict(
 static inline bool
 chimera_vfs_lease_cascades(const struct chimera_vfs_lease *lease)
 {
-    return lease->grant != NULL && !lease->grant->is_oplock;
+    /* An SMB3 directory lease breaks in a single shot to its floor (one
+     * notification RH -> R for a conflicting open, RH -> "" for a content
+     * change), like a legacy oplock — it does NOT walk one caching bit per ack
+     * the way a file RqLs lease does (MS-SMB2 directory-lease break is a single
+     * downgrade, which the smbtorture dirlease suite asserts). */
+    return lease->grant != NULL && !lease->grant->is_oplock && !lease->is_dir;
 } /* chimera_vfs_lease_cascades */
 
 static inline uint8_t
@@ -2243,6 +2311,74 @@ chimera_vfs_state_break_on_write(
     chimera_vfs_state_put(state, file);
 } /* chimera_vfs_state_break_on_write */
 
+/* -------------------------------------------------------------------- */
+/* Directory-lease break (content change)                               */
+/* -------------------------------------------------------------------- */
+
+SYMBOL_EXPORT void
+chimera_vfs_state_dir_lease_break(
+    struct chimera_vfs_state *state,
+    const uint8_t            *fh,
+    uint8_t                   fh_len,
+    uint64_t                  fh_hash,
+    uint64_t                  skip_lo,
+    uint64_t                  skip_hi,
+    bool                      has_skip)
+{
+    struct chimera_vfs_file_state *file;
+    struct chimera_vfs_lease      *cur;
+    struct chimera_vfs_lease      *to_break[CHIMERA_VFS_STATE_MAX_BREAK_BATCH];
+    int                            n = 0;
+    int                            i;
+
+    /* Fast path: no per-file state means no directory lease to break. */
+    file = chimera_vfs_state_get(state, fh, fh_len, fh_hash, false);
+    if (!file) {
+        return;
+    }
+
+    pthread_mutex_lock(&file->lock);
+    for (cur = file->caching_leases; cur; cur = cur->next) {
+        /* Only directory leases (R/H) are affected.  A content change
+         * invalidates the cached enumeration AND the cached handle — a
+         * directory lease breaks all the way to NONE on a content change
+         * (MS-SMB2: RH -> "", a single ack-required notification), unlike the
+         * RH -> R handle-only break a conflicting open drives. */
+        if (!cur->is_dir || cur->mode.granted == 0 || !cur->owner.break_cb) {
+            continue;
+        }
+        /* Skip a lease already mid-break or revoked — it is on its way down. */
+        if (cur->break_state != CHIMERA_VFS_BREAK_IDLE) {
+            continue;
+        }
+        /* ParentLeaseKey self-exemption: the mutating client supplied a parent
+         * lease key naming a directory lease to spare (its cached view is
+         * coherent with the change it just made).  Keyed on the lease key, so it
+         * works regardless of which client supplied it (MS-SMB2 dirlease
+         * ParentLeaseKey; smbtorture dirlease.setinfo cases 1.1/2.1). */
+        if (has_skip &&
+            cur->owner.owner_lo == skip_lo &&
+            cur->owner.owner_hi == skip_hi) {
+            continue;
+        }
+        if (n < CHIMERA_VFS_STATE_MAX_BREAK_BATCH) {
+            to_break[n++] = cur;
+        }
+    }
+    pthread_mutex_unlock(&file->lock);
+
+    /* Break each to NONE (floor 0).  A directory lease does not cascade
+     * (chimera_vfs_lease_cascades is false for is_dir), so this is a single
+     * RH -> "" notification.  It strips H, so it is ack-required: the lease
+     * stays BREAKING until the client's lease-break ack drives
+     * chimera_vfs_lease_ack — the same path a file lease break uses. */
+    for (i = 0; i < n; i++) {
+        chimera_vfs_lease_begin_break(state, to_break[i], 0, 0);
+    }
+
+    chimera_vfs_state_put(state, file);
+} /* chimera_vfs_state_dir_lease_break */
+
 /* Break-on-open: a conflicting open by a *different* owner breaks caching
  * holders.  `trigger_bits` selects which holders break -- only a lease whose
  * granted mode intersects `trigger_bits` is affected -- and `retain_mode` is
@@ -2293,7 +2429,11 @@ chimera_vfs_state_break_caching_for_open(
          * decision so the holder can close.  An SMB2 RqLs LEASE keeps its handle
          * cache on a conflicting open (only its write cache is exclusive), so do
          * not handle-break a lease here -- its write cache is invalidated by the
-         * separate W-trigger pass / caching-contention break instead. */
+         * separate W-trigger pass / caching-contention break instead.  Directory
+         * leases coexist across opens (two RH dir leases share the directory), so
+         * they are NOT handle-broken by a compatible open either; a directory
+         * lease's handle is only recalled by a genuine share conflict (handled in
+         * the share path) or when the directory itself is removed/renamed. */
         if (trigger_bits == CHIMERA_VFS_LEASE_MODE_H &&
             cur->grant && !cur->grant->is_oplock) {
             continue;

--- a/src/vfs/vfs_state.h
+++ b/src/vfs/vfs_state.h
@@ -498,6 +498,29 @@ chimera_vfs_state_break_on_write(
     uint64_t                              fh_hash,
     const struct chimera_vfs_lease_owner *writer);
 
+/* Break every SMB3 directory lease on the directory identified by (fh, fh_hash)
+* because the directory's contents changed (a child created / removed / renamed,
+* or a child's attributes changed).  A directory-lease content break is a single
+* RH -> "" downgrade to NONE (MS-SMB2): it strips handle caching too, so it is
+* ack-required and the lease stays BREAKING until the client acks (the normal
+* lease-break-ack path).  The client re-establishes its directory cache by
+* re-requesting the lease afterwards.
+*
+* `has_skip` + (`skip_lo`, `skip_hi`) name a lease owner key (an SMB LeaseKey)
+* to spare: the client that caused the change supplied a ParentLeaseKey naming a
+* directory lease whose cached view is coherent with the change, so it must not
+* be broken (MS-SMB2 directory-lease ParentLeaseKey self-exemption).  A leaseless
+* mutator (NFS/S3) passes has_skip == false and breaks every directory lease. */
+void
+chimera_vfs_state_dir_lease_break(
+    struct chimera_vfs_state *state,
+    const uint8_t            *fh,
+    uint8_t                   fh_len,
+    uint64_t                  fh_hash,
+    uint64_t                  skip_lo,
+    uint64_t                  skip_hi,
+    bool                      has_skip);
+
 /* Break-on-open: break caching leases held by a *different* owner on
  * (fh, fh_hash) when a conflicting open arrives.  `trigger_bits` selects which
  * holders break (only those whose granted mode holds a trigger bit they don't


### PR DESCRIPTION
Implements **SMB3 directory leases** (RH only, never W) over the existing
type-agnostic VFS lease construct, gated behind a new server config flag
`smb_directory_leases` (default **off**; mirrors `smb_persistent_handles`). The
content-change break is driven at the VFS notify chokepoint so NFS/S3 mutations
also break SMB directory read-leases (cross-protocol coherent). Rolled out on
**memfs** first.

## VFS layer
- `is_dir` on caching grants/leases: two cross-client RH directory leases
  coexist (conflict-matrix relax); directory leases are single-shot (no cascade).
- Notify chokepoint variants: `notify_emit` (break), `notify_emit_lease` (break
  with ParentLeaseKey self-exemption), `notify_emit_nobreak` (change-notify
  only). A nullable `parent_lease_skip` + operating `op_handle` are threaded
  through `link_at` / `rename_at` / `remove_at` (all NFS/S3/internal callers pass
  NULL).
- **File-level SMB delete-on-close** on the per-FH `vfs_state`
  (`delete_pending` + `last_open_delete`): the file is removed at the LAST open's
  close, not the disposition-setter's close (`open_at` detach-replaces, so a
  per-handle `opencnt` cannot aggregate across opens).
- Conflicting-open dir-lease **HANDLE break (RH→R)**: `share_batch_escape` matches
  a directory lease by client; the `lease_acquire` break floor is forced to R for
  an `is_dir` conflict (a SHARE acquirer carries no H bit).

## SMB layer
- Advertise `SMB2_GLOBAL_CAP_DIRECTORY_LEASING` (3.0+, flag-gated); grant RH dir
  leases via RqLs v2 only (W masked, never a legacy oplock); echo
  `PARENT_LEASE_KEY_SET`; re-arm on re-open.
- ParentLeaseKey self-exemption for create / set_info / rename / hardlink /
  unlink-at-close.
- **Reply-before-break ordering**: a per-connection `in_compound` gate defers a
  dir-lease *self*-break to the triggering compound's reply (flushed there), while
  a cross-connection break fires immediately so a parking opener cannot deadlock.
- **Overwrite** sequences its two breaks: a content-changing create parks on the
  file caching break and emits the parent dir-lease break on resume.
- **Write defers** the parent dir-lease break to close (`OPEN_FILE_FLAG_MODIFIED`).
- **Conflicting-open / rename-into-dir park & resume**: GRANTED when the holder
  closes, SHARING_VIOLATION when it keeps the handle. The `share_park_cb` result
  is bounced to the parked open's owning thread (share-resume queue + resume
  doorbell) since CREATE-response iovecs are thread-local. A rename into a leased
  directory drives the same RH→R break via a transient `denied=D` SHARE probe on
  the destination parent.
- Directory CREATE response reports EndOfFile / AllocationSize = 0.

## Tests
`smb2.dirlease` enabled on memfs: **17/18 passing** — `leases`, `oplocks`,
`v2_request`, `v2_request_parent`, `rename`, `rename_dst_parent`, `hardlink`,
`seteof`, `setdos`, `set{a,b,c,m}time`, `unlink_same` ×2, `unlink_different` ×2.
No regression to the existing lease / oplock / durable / rename suites.

`overwrite` stays disabled: it is blocked by an `smb2_deltree` teardown loop in
the test harness (the test leaks its second handle by closing it on the wrong
tree, and correct file-level delete-on-close then declines to remove the
still-open file) — the break sequencing itself is correct.

> Note: this branch is based on an older `main` and several hot files
> (`vfs_state.c`, `smb_proc_create.c`, …) have since changed upstream, so it will
> need a rebase before merge.