### PR TITLE
posix/tests: raise fsx timeout to 600s for contention headroom

### DIFF
--- a/src/posix/tests/CMakeLists.txt
+++ b/src/posix/tests/CMakeLists.txt
@@ -301,9 +301,20 @@ macro(add_fsx_test backend)
             COMMAND ${NETNS_WRAPPER} ${FSX_WRAPPER} -b ${backend} -N ${FSX_NUM_OPS} -l ${FSX_MAX_LEN} -q
             WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
         )
+        # fsx does 10000 randomized ops over RocksDB/diskfs-backed VFS under
+        # ASan.  The slowest variants (cairn, diskfs_io_uring) run ~10-15s on an
+        # idle host but all four cairn variants are scheduled together as the
+        # longest tests in the posix-client shard, which CI runs heavily
+        # oversubscribed (`-j 32` on shared, ephemeral ARC pods).  Under that
+        # contention their wall time scales ~5-8x (measured 14s -> 85-104s at
+        # j64 locally) with no underlying data error -- they complete A-OK, just
+        # slowly.  A flat 300s timeout left too little headroom, so the whole
+        # cairn fsx cluster intermittently tripped the timeout and was rescued
+        # on rerun (issue #733).  Give them the same generous budget as the
+        # other heavy posix tests (diskfs_evict/reclaim use 600-900).
         set_tests_properties(chimera/posix/fsx_${backend} PROPERTIES
             ENVIRONMENT "BUILD_DIR=${CMAKE_BINARY_DIR}"
-            TIMEOUT 300
+            TIMEOUT 600
         )
     endif()
 endmacro()


### PR DESCRIPTION
Fixes the recurring `fsx_*_cairn` flake cluster tracked in #733 (`fsx_nfs3_cairn`, `fsx_nfs3rdma_cairn`, `fsx_nfs4_cairn`, plus the lower-frequency `fsx_*_diskfs_io_uring`).

## Root cause: CI timeout under host contention, not a data bug

Every tracker observation shows **all** of the cairn fsx variants failing **together** in the same `posix-client` shard run, across NFS3, NFS3 RDMA and NFS4 alike, then passing on `--rerun-failed`. That lockstep pattern points at a shared-host condition, not independent per-seed data corruption.

- fsx runs 10000 randomized read/write/truncate ops over a RocksDB-backed (cairn) or diskfs VFS under ASan. On an idle host the slowest variants take ~10-15s.
- The four cairn fsx tests are the longest in the shard, so ctest front-loads them and they run concurrently with each other and the rest of the 2000+ test suite. CI runs the shard heavily oversubscribed (`ctest -j 32` on shared, ephemeral ARC pods).
- Under that contention their wall time scales ~5-8x. Measured locally on the same Debug/ASan build:
  - idle: ~14s
  - full posix suite at `-j 64`: ~41s
  - full posix suite at `-j 64` with the host most loaded: **85-104s**
  
  Every one of those runs still completed `All 10000 operations completed A-OK!`. A flat 300s timeout leaves too little headroom for a contended CI pod, so the cluster intermittently trips the timeout and gets rescued on rerun.

## Why this is not a correctness bug

- **240** heavy concurrent direct runs (120-way parallel, random seeds) plus **three** full posix suites at `-j 64`, all under ASan: zero `READ BAD DATA`, zero short reads/writes, zero `EINVAL`, zero ASan reports.
- Timing is seed-independent (12-14s across seeds idle), and the slow runs always *completed* (not hung), so this is contention, not a pathological input or a livelock.
- The cairn read/write path takes consistent meta-before-data snapshots on the reader and commits data-before-meta on the writer, so same-file ops (fsx is single-file) never observe a torn size/extent view. This is distinct from the known NFS4-only `write: Invalid argument` (EINVAL) signature, which is NFS4-only across *all* backends; the cairn cluster spans NFS3+RDMA+NFS4 and fails in lockstep.

## Change

Raise the posix fsx test timeout from 300s to 600s, matching the budget the other heavy posix tests already use (`diskfs_evict`/`diskfs_reclaim` use 600-900). This is the repo's established remedy for contention-bound timeouts (cf. "pynfs: extend readdir suite timeout").

Refs #733