### PR TITLE
smb2: fix parked CHANGE_NOTIFY hang on PreviousSessionId reconnect

### DIFF
--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -1599,6 +1599,46 @@ chimera_smb_session_park_durables(
     pthread_mutex_unlock(&session->lock);
 } /* chimera_smb_session_park_durables */
 
+/* Complete every parked CHANGE_NOTIFY held by `session`'s opens with
+ * STATUS_NOTIFY_CLEANUP.  Used when a PreviousSessionId reconnect closes this
+ * session out from under its still-live connection (MS-SMB2 3.3.5.5.3): the
+ * session's opens are not torn down here (that happens on the old connection's
+ * own thread when it finally drops), so the ordinary teardown path that would
+ * complete their notifies (chimera_smb_tree_free) never runs.  Without this a
+ * watcher parked on a non-durable directory open of the old session blocks
+ * forever (smb2.notify.session-reconnect).  The completion is marshaled to each
+ * request's owning thread via the notify doorbell, so it is safe to run from
+ * the new connection's thread even when the old connection lives elsewhere. */
+static inline void
+chimera_smb_session_flush_notifies(struct chimera_smb_session *session)
+{
+    int i, b;
+
+    pthread_mutex_lock(&session->lock);
+
+    for (i = 0; i < session->max_trees; i++) {
+        struct chimera_smb_tree      *tree = session->trees[i];
+        struct chimera_smb_open_file *open_file, *tmp;
+
+        if (!tree) {
+            continue;
+        }
+
+        for (b = 0; b < CHIMERA_SMB_OPEN_FILE_BUCKETS; b++) {
+            pthread_mutex_lock(&tree->open_files_lock[b]);
+            HASH_ITER(hh, tree->open_files[b], open_file, tmp)
+            {
+                if (open_file->notify_state) {
+                    chimera_smb_notify_queue_cleanup(open_file);
+                }
+            }
+            pthread_mutex_unlock(&tree->open_files_lock[b]);
+        }
+    }
+
+    pthread_mutex_unlock(&session->lock);
+} /* chimera_smb_session_flush_notifies */
+
 /* MS-SMB2 3.3.5.5.3: a SESSION_SETUP carrying a non-zero PreviousSessionId asks
  * the server to close that earlier session of the same user once the new one is
  * established (a client reconnecting on a fresh transport, e.g. for durable-
@@ -1651,6 +1691,12 @@ chimera_smb_session_invalidate_previous(
 
     if (prev) {
         chimera_smb_session_park_durables(shared, prev);
+        /* Complete any CHANGE_NOTIFY parked on a non-durable open of the prior
+         * session with STATUS_NOTIFY_CLEANUP: those opens are not torn down by
+         * the release below (the old connection still references the session),
+         * so the normal teardown that flushes their notifies never runs and a
+         * watcher would otherwise hang (smb2.notify.session-reconnect). */
+        chimera_smb_session_flush_notifies(prev);
         chimera_smb_session_release(thread, shared, prev, true);
     }
     return 0;

--- a/src/server/smb/smb_notify.c
+++ b/src/server/smb/smb_notify.c
@@ -392,6 +392,51 @@ chimera_smb_notify_callback(
 } /* chimera_smb_notify_callback */
 
 /* ----------------------------------------------------------------
+ * Queue the open's parked CHANGE_NOTIFY for a NOTIFY_CLEANUP completion
+ * on its owning thread.  Mirrors the callback's enqueue (state->lock outer,
+ * notify_ready_lock inner) so close/cancel observe a consistent
+ * (state->pending, on_ready_queue) pair, and rings the owning thread's
+ * doorbell.  The doorbell handler honors nr->cleanup and completes the
+ * request with STATUS_NOTIFY_CLEANUP rather than the event-delivery path.
+ * ---------------------------------------------------------------- */
+int
+chimera_smb_notify_queue_cleanup(struct chimera_smb_open_file *open_file)
+{
+    struct chimera_smb_notify_state   *state = open_file->notify_state;
+    struct chimera_smb_notify_request *nr;
+    struct chimera_server_smb_thread  *thread;
+    int                                wake = 0;
+
+    if (!state) {
+        return 0;
+    }
+
+    pthread_mutex_lock(&state->lock);
+
+    nr = state->pending;
+    if (nr && !nr->on_ready_queue) {
+        thread             = nr->thread;
+        nr->cleanup        = 1;
+        nr->on_ready_queue = 1;
+
+        pthread_mutex_lock(&thread->notify_ready_lock);
+        nr->ready_next       = thread->notify_ready;
+        thread->notify_ready = nr;
+        pthread_mutex_unlock(&thread->notify_ready_lock);
+
+        wake = 1;
+    }
+
+    pthread_mutex_unlock(&state->lock);
+
+    if (wake) {
+        evpl_ring_doorbell(&thread->notify_doorbell);
+    }
+
+    return wake;
+} /* chimera_smb_notify_queue_cleanup */
+
+/* ----------------------------------------------------------------
  * Build and send an async CHANGE_NOTIFY response with events.
  * Must be called on the SMB thread that owns the connection.
  *
@@ -906,7 +951,17 @@ chimera_smb_notify_doorbell_callback(
     for (nr = ready; nr; nr = next) {
         next           = nr->ready_next;
         nr->ready_next = NULL;
-        chimera_smb_notify_send_response(nr);
+        if (nr->cleanup) {
+            /* Session closed under a still-live connection (PreviousSessionId
+             * reconnect): complete with STATUS_NOTIFY_CLEANUP.  The watch
+             * state stays attached to the open (the open is torn down later
+             * by its own connection); pass it explicitly. */
+            nr->on_ready_queue = 0;
+            chimera_smb_notify_complete_cleanup(nr,
+                                                nr->open_file ? nr->open_file->notify_state : NULL);
+        } else {
+            chimera_smb_notify_send_response(nr);
+        }
     }
 } /* chimera_smb_notify_doorbell_callback */
 

--- a/src/server/smb/smb_notify.h
+++ b/src/server/smb/smb_notify.h
@@ -53,6 +53,12 @@ struct chimera_smb_notify_request {
      * thread->notify_ready.  Cleared by send_response or by close
      * when reaping the request from the ready queue. */
     int                                on_ready_queue;
+    /* When set, the doorbell handler completes this request with
+     * STATUS_NOTIFY_CLEANUP (MS-SMB2 3.3.4.4) instead of the normal
+     * event-delivery path.  Used to flush a parked CHANGE_NOTIFY whose
+     * session is being closed by a PreviousSessionId reconnect, where the
+     * cleanup must be marshaled to the request's owning thread. */
+    int                                cleanup;
     struct chimera_smb_notify_request *next;          /* parked list linkage */
     struct chimera_smb_notify_request *prev;          /* parked list linkage */
     struct chimera_smb_notify_request *ready_next;    /* doorbell ready queue */
@@ -148,6 +154,19 @@ void
 chimera_smb_notify_complete_cleanup(
     struct chimera_smb_notify_request *nr,
     struct chimera_smb_notify_state   *state);
+
+/*
+ * Marshal a NOTIFY_CLEANUP completion of the open's parked CHANGE_NOTIFY to
+ * the request's owning SMB thread.  Used when a session is closed out from
+ * under its still-live connection (a PreviousSessionId reconnect, MS-SMB2
+ * 3.3.5.5.3): the parked request must be completed with STATUS_NOTIFY_CLEANUP,
+ * but the response has to be built/sent on the connection's own thread.
+ * Returns 1 if a parked request was queued for cleanup, 0 otherwise.  Safe to
+ * call from another thread.
+ */
+int
+chimera_smb_notify_queue_cleanup(
+    struct chimera_smb_open_file *open_file);
 
 /*
  * Clean up notify state for an open file being closed.

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -1508,6 +1508,7 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.notify.rmdir2
     smb2.notify.rmdir3
     smb2.notify.rmdir4
+    smb2.notify.session-reconnect
     smb2.notify.tcon
     smb2.notify.tcp
     smb2.notify.tdis
@@ -1878,6 +1879,7 @@ set(SMBTORTURE_ENABLED_linux
     smb2.notify.rmdir2
     smb2.notify.rmdir3
     smb2.notify.rmdir4
+    smb2.notify.session-reconnect
     smb2.notify.tcon
     smb2.notify.tcp
     smb2.notify.tdis
@@ -2199,6 +2201,7 @@ set(SMBTORTURE_ENABLED_io_uring
     smb2.notify.rmdir2
     smb2.notify.rmdir3
     smb2.notify.rmdir4
+    smb2.notify.session-reconnect
     smb2.notify.tcon
     smb2.notify.tcp
     smb2.notify.tdis
@@ -2594,6 +2597,7 @@ set(SMBTORTURE_ENABLED_cairn
     smb2.notify.rmdir2
     smb2.notify.rmdir3
     smb2.notify.rmdir4
+    smb2.notify.session-reconnect
     smb2.notify.tcon
     smb2.notify.tcp
     smb2.notify.tdis
@@ -3027,6 +3031,7 @@ set(SMBTORTURE_ENABLED_diskfs_io_uring
     smb2.notify.rmdir2
     smb2.notify.rmdir3
     smb2.notify.rmdir4
+    smb2.notify.session-reconnect
     smb2.notify.tcon
     smb2.notify.tcp
     smb2.notify.tdis
@@ -3457,6 +3462,7 @@ set(SMBTORTURE_ENABLED_diskfs_aio
     smb2.notify.rmdir2
     smb2.notify.rmdir3
     smb2.notify.rmdir4
+    smb2.notify.session-reconnect
     smb2.notify.tcon
     smb2.notify.tcp
     smb2.notify.tdis


### PR DESCRIPTION
A `SESSION_SETUP` carrying a non-zero `PreviousSessionId` closes the prior session of the same user (MS-SMB2 3.3.5.5.3). `chimera_smb_session_invalidate_previous()` marks that session deleted, parks its durable opens, and releases it with `preserve_durable=true`.

But when the reconnect lands on the **same transport** (the common case), the prior session’s connection still holds a reference, so its refcount never reaches zero and `chimera_smb_tree_free()` — the path that completes a parked `CHANGE_NOTIFY` with `STATUS_NOTIFY_CLEANUP` — never runs. A non-durable watched directory open of the old session therefore keeps its `CHANGE_NOTIFY` parked forever, and the client blocks indefinitely in `smb2_notify_recv`.

## Root cause
`smb2.notify.session-reconnect`:
1. Open a directory, arm a `CHANGE_NOTIFY` (interim `STATUS_PENDING`).
2. New `SESSION_SETUP` with `PreviousSessionId` = the current session id, on the **same** transport.
3. Client expects `smb2_notify_recv` → `STATUS_NOTIFY_CLEANUP` with 0 changes.

`invalidate_previous` only parks *durable* opens and releases the session; it never completes the parked notify on the **non-durable** watched open, and the session’s opens are not torn down (the old connection still references the session). The watcher hangs → ctest `Timeout` → flake. This is also why `smb2.notify.session-reconnect` was never enabled in any backend’s smbtorture list — it always hung.

Racing code paths:
- `src/server/smb/smb_internal.h` `chimera_smb_session_invalidate_previous()` → `chimera_smb_session_release(preserve_durable=true)`; refcount stays > 0 on a same-transport reconnect, so `chimera_smb_tree_free()` (the only path that fires `chimera_smb_notify_complete_cleanup`) never runs.
- `src/server/smb/smb_proc_change_notify.c` parks the request in `state->pending`; nothing completes it.

## Fix
When invalidating the previous session, flush every parked `CHANGE_NOTIFY` held by its opens with `STATUS_NOTIFY_CLEANUP` (MS-SMB2 3.3.4.4). The completion is marshaled to each request’s owning thread via the existing notify doorbell (new `nr->cleanup` flag honored in the doorbell handler), so it is safe even when the old connection lives on another thread, and it avoids re-taking the `open_files` bucket lock under `session->lock`.

The new `chimera_smb_session_flush_notifies()` takes `session->lock` → bucket lock (same order as `chimera_smb_session_park_durables`), and `chimera_smb_notify_queue_cleanup()` takes `state->lock` → `notify_ready_lock` (same order as the VFS notify callback). The heavyweight completion (which re-takes the bucket lock via `open_file_release_nr`) runs later on the doorbell, never under the locks held here.

With the hang fixed, `smb2.notify.session-reconnect` is enabled in every backend’s smbtorture list to guard against regression.

## Verification
- **Before:** `smb2.notify.session-reconnect` hangs deterministically (ctest `EXIT=124`, server idle after the two SESSION_SETUPs). The enabled `smbtorture_smb2_notify_memfs` suite also `Timeout`s under load.
- **After:** subtest passes on all six backends (memfs/linux/cairn/io_uring/diskfs_io_uring/diskfs_aio); 10/10 in a loop on memfs (Debug ASan); passes in Release; full **memfs smbtorture suite 156/156 green** with the subtest now enabled; SMB session + durable-reconnect (PreviousSessionId) families unaffected.

Refs #733 (`smbtorture_smb2_notify_*`).