### PR TITLE
smb: DCE/RPC over SMB2 WRITE/READ named-pipe transport + smbtorture RPC gates

### DIFF
--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -1389,6 +1389,14 @@ chimera_smb_open_file_free(
     struct chimera_server_smb_thread *thread,
     struct chimera_smb_open_file     *open_file)
 {
+    /* Release any undrained ncacn_np pipe response and reset the stash so a
+     * reused open_file (the free list does not zero) starts clean. */
+    if (open_file->rpc_resp) {
+        free(open_file->rpc_resp);
+        open_file->rpc_resp = NULL;
+    }
+    open_file->rpc_resp_len = 0;
+    open_file->rpc_resp_off = 0;
     LL_PREPEND(thread->free_open_files, open_file);
 } /* chimera_smb_open_file_free */
 

--- a/src/server/smb/smb_lsarpc.c
+++ b/src/server/smb/smb_lsarpc.c
@@ -254,13 +254,24 @@ chimera_smb_lsarpc_impl(
 
                 names[i].sid_index = 0xffffffff;
                 names[i].sid_type  = LSA_SID_NAME_UNKNOWN;
-                chimera_smb_set_ustr(&names[i].name, "");
 
                 if (!sid) {
+                    chimera_smb_set_ustr(&names[i].name, "");
                     continue;
                 }
 
                 chimera_smb_sid_to_string(sid, sidstr, sizeof(sidstr));
+
+                /* Default for an unmapped SID: echo it back in string form as
+                 * the name (MS-LSAT returns untranslated SIDs as their string
+                 * form, type Unknown).  Copy into the arena -- set_ustr stores
+                 * the pointer and sidstr is loop-local. */
+                {
+                    size_t sl = strlen(sidstr) + 1;
+                    char  *ns = ndr_dbuf_alloc(dbuf, sl);
+                    memcpy(ns, sidstr, sl);
+                    chimera_smb_set_ustr(&names[i].name, ns);
+                }
 
                 u = chimera_vfs_user_cache_lookup_by_sid(cache, sidstr);
                 if (!u) {

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -3475,6 +3475,15 @@ chimera_smb_create(struct chimera_smb_request *request)
         request->create.r_attrs.smb_attributes = 0x80;
         request->create.r_attrs.smb_attr_mask  = SMB_ATTR_MASK_NETWORK_OPEN;
 
+        /* Drop the create-time reference (gen_open_file sets refcnt=2: one for
+         * the tree's open_files hash, one held by the originating request).  The
+         * file path drops it in chimera_smb_create_finish; the pipe path
+         * completes inline, so release it here.  Without this the open stays at
+         * refcnt 1 after the single decrement in the disconnect/tree teardown
+         * sweep and is never freed -- a leak per pipe open that smbtorture's RPC
+         * suites (which disconnect without an explicit CLOSE) expose. */
+        chimera_smb_open_file_release(request, open_file);
+
         chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
 
     } else {

--- a/src/server/smb/smb_proc_read.c
+++ b/src/server/smb/smb_proc_read.c
@@ -89,6 +89,48 @@ chimera_smb_read_callback(
     chimera_smb_complete_request(private_data, SMB2_STATUS_SUCCESS);
 } /* chimera_smb_read_callback */
 
+/*
+ * DCE/RPC over a named pipe (ncacn_np), SMB2 READ leg: drain the response PDU a
+ * prior SMB2 WRITE stashed via chimera_smb_pipe_write.  Serves up to the
+ * requested length, advancing an offset so a client may read the response in
+ * several chunks; the stash is freed once fully drained.
+ */
+static void
+chimera_smb_pipe_read(struct chimera_smb_request *request)
+{
+    struct chimera_server_smb_thread *thread    = request->compound->thread;
+    struct evpl                      *evpl      = thread->evpl;
+    struct chimera_smb_open_file     *open_file = request->read.open_file;
+    uint32_t                          avail, n;
+
+    avail = open_file->rpc_resp_len - open_file->rpc_resp_off;
+    n     = request->read.length < avail ? request->read.length : avail;
+
+    if (n == 0) {
+        request->read.niov     = 0;
+        request->read.r_length = 0;
+        chimera_smb_open_file_release(request, open_file);
+        chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
+        return;
+    }
+
+    request->read.niov = evpl_iovec_alloc(evpl, n, 8, 1, 0, request->read.iov);
+    memcpy(request->read.iov[0].data,
+           open_file->rpc_resp + open_file->rpc_resp_off, n);
+    request->read.r_length   = n;
+    open_file->rpc_resp_off += n;
+
+    if (open_file->rpc_resp_off >= open_file->rpc_resp_len) {
+        free(open_file->rpc_resp);
+        open_file->rpc_resp     = NULL;
+        open_file->rpc_resp_len = 0;
+        open_file->rpc_resp_off = 0;
+    }
+
+    chimera_smb_open_file_release(request, open_file);
+    chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
+} /* chimera_smb_pipe_read */
+
 void
 chimera_smb_read(struct chimera_smb_request *request)
 {
@@ -98,6 +140,13 @@ chimera_smb_read(struct chimera_smb_request *request)
 
     if (unlikely(!request->read.open_file)) {
         chimera_smb_complete_request(request, SMB2_STATUS_FILE_CLOSED);
+        return;
+    }
+
+    /* Named-pipe FIDs carry no VFS handle; serve RPC reads from the stashed
+     * ncacn_np response before any handle-backed file logic. */
+    if (request->read.open_file->type == CHIMERA_SMB_OPEN_FILE_TYPE_PIPE) {
+        chimera_smb_pipe_read(request);
         return;
     }
 

--- a/src/server/smb/smb_proc_write.c
+++ b/src/server/smb/smb_proc_write.c
@@ -164,6 +164,54 @@ chimera_smb_rdma_read_callback(
 
 
 
+/*
+ * DCE/RPC over a named pipe (ncacn_np), SMB2 WRITE leg: feed the written request
+ * PDU through the pipe's transceive handler and stash the response for the
+ * client's following SMB2 READ(s) to drain.  This is the WRITE/READ transport
+ * Windows and smbtorture use, distinct from the single-shot
+ * FSCTL_PIPE_TRANSCEIVE IOCTL transport.  A request PDU is assumed to arrive in
+ * one WRITE (true for the small LSARPC/SRVSVC calls in scope).
+ */
+static void
+chimera_smb_pipe_write(struct chimera_smb_request *request)
+{
+    struct chimera_server_smb_thread *thread    = request->compound->thread;
+    struct evpl                      *evpl      = thread->evpl;
+    struct chimera_smb_open_file     *open_file = request->write.open_file;
+    struct evpl_iovec                 output_iov;
+    int                               status;
+
+    evpl_iovec_alloc(evpl, 65535, 8, 1, 0, &output_iov);
+
+    status = open_file->pipe_transceive(request, request->write.iov,
+                                        request->write.niov, &output_iov);
+
+    evpl_iovecs_release(evpl, request->write.iov, request->write.niov);
+
+    if (unlikely(status != 0)) {
+        evpl_iovec_release(evpl, &output_iov);
+        chimera_smb_open_file_release(request, open_file);
+        chimera_smb_complete_request(request, SMB2_STATUS_INTERNAL_ERROR);
+        return;
+    }
+
+    /* Replace any still-undrained prior response, then copy the new PDU into a
+     * stable heap buffer (the evpl iovec is thread-local and released now). */
+    if (open_file->rpc_resp) {
+        free(open_file->rpc_resp);
+    }
+    open_file->rpc_resp_len = output_iov.length;
+    open_file->rpc_resp_off = 0;
+    open_file->rpc_resp     = malloc(output_iov.length ? output_iov.length : 1);
+    memcpy(open_file->rpc_resp, output_iov.data, output_iov.length);
+
+    evpl_iovec_release(evpl, &output_iov);
+    chimera_smb_open_file_release(request, open_file);
+
+    /* chimera_smb_write_reply reports request->write.length bytes accepted. */
+    chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
+} /* chimera_smb_pipe_write */
+
 void
 chimera_smb_write(struct chimera_smb_request *request)
 {
@@ -181,6 +229,13 @@ chimera_smb_write(struct chimera_smb_request *request)
          * chimera_smb_write_callback is being skipped. */
         evpl_iovecs_release(evpl, request->write.iov, request->write.niov);
         chimera_smb_complete_request(request, SMB2_STATUS_FILE_CLOSED);
+        return;
+    }
+
+    /* Named-pipe FIDs carry no VFS handle; route RPC writes to the ncacn_np
+     * transport before any handle-backed file logic. */
+    if (request->write.open_file->type == CHIMERA_SMB_OPEN_FILE_TYPE_PIPE) {
+        chimera_smb_pipe_write(request);
         return;
     }
 

--- a/src/server/smb/smb_session.h
+++ b/src/server/smb/smb_session.h
@@ -122,6 +122,13 @@ struct chimera_smb_open_file {
     enum chimera_smb_open_file_type   type;
     enum chimera_smb_pipe_magic       pipe_magic;
     chimera_smb_pipe_transceive_t     pipe_transceive;
+    /* DCE/RPC-over-named-pipe (ncacn_np) transport via SMB2 WRITE/READ: a WRITE
+     * runs the request PDU through pipe_transceive and stashes the response PDU
+     * here for one or more following READs to drain.  NULL when no response is
+     * pending.  (The IOCTL FSCTL_PIPE_TRANSCEIVE transport does not use this.) */
+    uint8_t                          *rpc_resp;
+    uint32_t                          rpc_resp_len;
+    uint32_t                          rpc_resp_off;
     struct UT_hash_handle             hh;
     struct chimera_smb_file_id        file_id;
     struct chimera_vfs_open_handle   *handle;

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -520,19 +520,46 @@ set_tests_properties(chimera/server/smb/rpcclient_lsa PROPERTIES
     LABELS "smb"
     TIMEOUT 120)
 
-# smbtorture DCE/RPC conformance suites for LSARPC.  Wired here but DISABLED:
-# each exercises a domain feature beyond a standalone file server's scope --
-# rpc.handles.lsarpc asserts DCE/RPC context-handle association tracking
-# (cross-connection RPC_SS_CONTEXT_MISMATCH), and rpc.lsalookup bails with
-# "no trusts" because it looks names up in trusted domains.  The actual LSARPC
-# functionality (bind, OpenPolicy/2, Close, QueryInfoPolicy, EnumTrustDom,
-# GetUserName) is validated by rpcclient_lsa above.  Drop DISABLED on a suite
-# once the server grows the feature it needs.
-set(SMBTORTURE_RPC_SUITES
+# smbtorture DCE/RPC conformance suites that pass against the standalone
+# file-server stack -- enabled as real gates (run against the in-process server
+# over the named-pipe transport, no domain controller required).
+#   rpc.lsa.lookupsids : LookupSids of a SID set; untranslated SIDs come back in
+#                        string form (MS-LSAT), local unix-user SIDs resolve via
+#                        the idmap.
+#   rpc.srvsvc...NetShareEnumAll : the level-1 share enumeration that backs
+#                        Explorer browsing, exercised over the SMB2 WRITE/READ
+#                        ncacn_np transport (named subtest; pinned Samba image).
+set(SMBTORTURE_RPC_SUITES_ENABLED
+    rpc.lsa.lookupsids
+    "rpc.srvsvc.srvsvc (admin access).NetShareEnumAll")
+
+foreach(SUITE ${SMBTORTURE_RPC_SUITES_ENABLED})
+    string(REGEX REPLACE "[^A-Za-z0-9]" "_" SUITE_ID ${SUITE})
+    set(TEST_NAME chimera/server/smb/smbtorture_${SUITE_ID}_memfs)
+    add_test(NAME ${TEST_NAME}
+        COMMAND ${CMAKE_SOURCE_DIR}/scripts/netns_test_wrapper.sh
+                ${SMBTORTURE_CMD} -b memfs ${SUITE})
+    set_tests_properties(${TEST_NAME} PROPERTIES
+        ENVIRONMENT "${SMBTORTURE_LSAN}"
+        SKIP_RETURN_CODE 77
+        LABELS "smbtorture_rpc"
+        TIMEOUT 300)
+endforeach()
+
+# smbtorture DCE/RPC conformance suites wired but DISABLED: each needs a server
+# feature we don't have yet (but that is in NAS scope -- drop DISABLED once the
+# feature lands).
+#   rpc.lsa.lookupnames : needs well-known name resolution (Everyone, SYSTEM,
+#                         BUILTIN\Administrators, ...) AND a Close that returns
+#                         RPC_SS_CONTEXT_MISMATCH (real context-handle tracking).
+#   rpc.handles.lsarpc  : DCE/RPC context-handle association across connections.
+#   rpc.lsalookup       : looks names up in trusted domains ("no trusts").
+set(SMBTORTURE_RPC_SUITES_DISABLED
+    rpc.lsa.lookupnames
     rpc.handles.lsarpc
     rpc.lsalookup)
 
-foreach(SUITE ${SMBTORTURE_RPC_SUITES})
+foreach(SUITE ${SMBTORTURE_RPC_SUITES_DISABLED})
     string(REGEX REPLACE "[^A-Za-z0-9]" "_" SUITE_ID ${SUITE})
     set(TEST_NAME chimera/server/smb/smbtorture_${SUITE_ID}_memfs)
     add_test(NAME ${TEST_NAME}


### PR DESCRIPTION
Found by pointing Samba's **smbtorture** `rpc.*` conformance suites at the in-process SMB server (no Windows / no DC needed — all Linux-side). Independent of #798.

## The crash (headline)
The LSARPC/SRVSVC named pipes only handled DCE/RPC via the single-shot `FSCTL_PIPE_TRANSCEIVE` IOCTL. Windows clients — and smbtorture's `rpc.srvsvc` binding — instead drive ncacn_np as an **SMB2 WRITE** of the request PDU followed by an **SMB2 READ** of the response. `chimera_smb_write`/`chimera_smb_read` had no pipe branch and dereferenced `open_file->handle->fh`, which is `NULL` for a pipe FID → a **remotely triggerable NULL-deref crash** on any write to an RPC pipe.

This PR adds the transport: a WRITE runs the request through the pipe's existing transceive handler and stashes the response PDU on the open; the following READ(s) drain it. Reuses all the existing `dce_rpc()` marshalling; the pipe branch is a cheap tag check, so file I/O is untouched.

## Pipe-open refcount leak (exposed by the above)
CREATE seeds `refcnt=2` (tree-hash ref + the originating request's ref). The file path drops the request ref in `chimera_smb_create_finish`, but the pipe CREATE branch completed inline without it — so **every pipe open leaked**, surviving the single decrement in the disconnect/tree-teardown sweep. Drop the create reference in the pipe branch (+ free any undrained response in `chimera_smb_open_file_free`). Previously masked because no smbtorture RPC suite could run to ASan-completion.

## LookupSids conformance
MS-LSAT returns an untranslated SID as its **string form** (type Unknown), not an empty name. We returned `""`; `rpc.lsa.lookupsids` asserts the string form. Fixed.

## New conformance gates (ctest, `smbtorture_rpc` label)
- `rpc.lsa.lookupsids` — **enabled, passing**
- `rpc.srvsvc … NetShareEnumAll` — **enabled, passing** (exercises the new WRITE/READ transport end-to-end)
- `rpc.lsa.lookupnames`, `rpc.handles.lsarpc`, `rpc.lsalookup` — wired but **DISABLED**, each annotated with the NAS-scope feature it still needs (well-known SID resolution + context-handle `CONTEXT_MISMATCH`; trusted-domain lookup).

## Verification
- `rpc.lsa.lookupsids` + `rpc.srvsvc NetShareEnumAll` gates pass via ctest; `rpc.srvsvc` runs crash-free and **ASan-clean** (0 leaks) — 3 subtests pass, the rest fail only on unimplemented ops / anonymous access / unimplemented info levels (not defects).
- rpcclient smoke test, lsarpc golden test, and a slice of `smb2.rw`/`smb2.lock` (12 tests) all green — file I/O unaffected.
- Built + tested under Release and Debug/ASan.