### PR TITLE
smb: LSARPC context-handle lifecycle + well-known name resolution

### DIFF
--- a/src/server/smb/smb_dcerpc.h
+++ b/src/server/smb/smb_dcerpc.h
@@ -13,6 +13,11 @@
 #define DCE_RPC_PTYPE_PING               0x01     /* keepalive/probe (rare over SMB) */
 #define DCE_RPC_PTYPE_RESPONSE           0x02     /* normal call response */
 #define DCE_RPC_PTYPE_FAULT              0x03     /* call failed; carries nca_s_* status */
+
+/* Handler negative-return sentinels selecting the DCE/RPC fault status emitted
+ * by dce_rpc().  Any negative other than CONTEXT_MISMATCH yields the default
+ * nca_s_op_rng_error (e.g. an unknown opnum returning -1). */
+#define DCE_RC_FAULT_CONTEXT_MISMATCH    (-2)
 #define DCE_RPC_PTYPE_WORKING            0x04     /* server is processing (progress hint) */
 #define DCE_RPC_PTYPE_NOCALL             0x05     /* server didn’t match the call (legacy) */
 #define DCE_RPC_PTYPE_REJECT             0x06     /* association/call rejected */
@@ -332,18 +337,24 @@ dce_rpc(
             rc = handler(request_call.opnum, &input_cursor, outputp, private_data);
 
             if (unlikely(rc < 0)) {
-                /* Unknown or failed opnum: reply with a DCE/RPC fault rather
-                 * than dropping the connection, so the client receives a clean
-                 * nca_s_op_rng_error and the association stays usable.  The
-                 * response header already written (alloc_hint/p_cont_id/
-                 * cancel_count/reserved) matches the fault PDU's leading
-                 * fields; append the 32-bit status and a reserved word. */
+                /* A failed call replies with a DCE/RPC fault rather than dropping
+                 * the connection, so the client receives a clean nca_s_* status
+                 * and the association stays usable.  The handler selects the
+                 * fault via its negative return: DCE_RC_FAULT_CONTEXT_MISMATCH
+                 * (a bad/foreign context handle) maps to
+                 * nca_s_fault_context_mismatch; anything else (e.g. an unknown
+                 * opnum) to nca_s_op_rng_error.  The response header already
+                 * written (alloc_hint/p_cont_id/cancel_count/reserved) matches
+                 * the fault PDU's leading fields; append the status + a reserved
+                 * word. */
                 uint32_t *faultp = outputp;
 
                 reply_common->ptype = DCE_RPC_PTYPE_FAULT;
-                faultp[0]           = 0x1C010002; /* nca_s_op_rng_error */
-                faultp[1]           = 0;          /* reserved / pad */
-                outputp            += 2 * sizeof(uint32_t);
+                faultp[0]           = (rc == DCE_RC_FAULT_CONTEXT_MISMATCH)
+                                      ? 0x1C00001A  /* nca_s_fault_context_mismatch */
+                                      : 0x1C010002; /* nca_s_op_rng_error */
+                faultp[1] = 0;                    /* reserved / pad */
+                outputp  += 2 * sizeof(uint32_t);
 
                 reply_call->alloc_hint = 0;
                 reply_common->frag_len = (uint16_t) ((char *) outputp - (char *) reply_common);

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -977,6 +977,8 @@ struct chimera_smb_session_handle {
 
 struct chimera_smb_notify_request;
 
+#define CHIMERA_SMB_RPC_MAX_HANDLES                 16
+
 struct chimera_smb_conn {
     OM_uint32                          gss_major;
     OM_uint32                          gss_minor;
@@ -988,6 +990,15 @@ struct chimera_smb_conn {
     uint8_t                           *ntlm_output;
     size_t                             ntlm_output_len;
     unsigned int                       flags;
+    /* DCE/RPC context (policy) handles currently open on this connection: each
+     * 16-byte slot holds an issued handle's id, an all-zero slot is free.  An op
+     * presented a handle not in this set -- issued on another connection,
+     * already closed, or never issued -- faults with
+     * nca_s_fault_context_mismatch.  Scoping the set to the connection is what
+     * makes a cross-connection use and a double-close fail (MS-LSAD,
+     * smbtorture rpc.handles).  16 slots is far more than the one or two policy
+     * handles a client holds at once. */
+    uint8_t                            rpc_handles[CHIMERA_SMB_RPC_MAX_HANDLES][16];
     /* Set under the owning thread's lease_break_lock while conn_free drains
      * this connection's queued lease-break notifications, so a break_cb racing
      * on another thread does not enqueue a send for a connection whose bind is
@@ -1855,6 +1866,10 @@ chimera_smb_conn_alloc(struct chimera_server_smb_thread *thread)
     } else {
         conn = calloc(1, sizeof(*conn));
     }
+
+    /* No RPC context handles open yet; clear the set since the connection pool
+    * does not zero on reuse (a stale slot would validate a foreign handle). */
+    memset(conn->rpc_handles, 0, sizeof(conn->rpc_handles));
 
     return conn;
 } /* chimera_smb_conn_alloc */

--- a/src/server/smb/smb_lsarpc.c
+++ b/src/server/smb/smb_lsarpc.c
@@ -16,25 +16,29 @@ static const dce_if_uuid_t LSA_INTERFACE = {
     .if_vers_minor = 0,
 };
 
-#define LSA_OP_CLOSE               0
-#define LSA_OP_OPENPOLICY          6
-#define LSA_OP_QUERYINFOPOLICY     7
-#define LSA_OP_ENUMTRUSTDOM        13
-#define LSA_OP_LOOKUPNAMES         14
-#define LSA_OP_LOOKUPSIDS          15
+#define LSA_OP_CLOSE                      0
+#define LSA_OP_OPENPOLICY                 6
+#define LSA_OP_QUERYINFOPOLICY            7
+#define LSA_OP_ENUMTRUSTDOM               13
+#define LSA_OP_LOOKUPNAMES                14
+#define LSA_OP_LOOKUPSIDS                 15
 
-#define LSA_STATUS_NO_MORE_ENTRIES 0x8000001A
-#define LSA_STATUS_SOME_NOT_MAPPED 0x00000107
-#define LSA_STATUS_NONE_MAPPED     0xC0000073
-#define LSA_SID_NAME_USER          1
-#define LSA_SID_NAME_UNKNOWN       8
-#define LSA_OP_OPENPOLICY2         44
-#define LSA_OP_GETUSERNAME         45
-#define LSA_OP_QUERYINFOPOLICY2    46
+#define LSA_STATUS_NO_MORE_ENTRIES        0x8000001A
+#define LSA_STATUS_SOME_NOT_MAPPED        0x00000107
+#define LSA_STATUS_NONE_MAPPED            0xC0000073
+#define LSA_STATUS_INSUFFICIENT_RESOURCES 0xC000009A
+#define LSA_SID_NAME_USER                 1
+#define LSA_SID_NAME_DOMAIN               3
+#define LSA_SID_NAME_ALIAS                4
+#define LSA_SID_NAME_WKN_GROUP            5
+#define LSA_SID_NAME_UNKNOWN              8
+#define LSA_OP_OPENPOLICY2                44
+#define LSA_OP_GETUSERNAME                45
+#define LSA_OP_QUERYINFOPOLICY2           46
 
 /* Bytes of DCE/RPC framing (common + response header) the framing layer writes
 * before the stub, so the generated marshaller's buffer cap stays in bounds. */
-#define LSA_RPC_STUB_MAX           (65535 - (int) (sizeof(dce_common_t) + sizeof(dce_co_response_t)))
+#define LSA_RPC_STUB_MAX                  (65535 - (int) (sizeof(dce_common_t) + sizeof(dce_co_response_t)))
 
 /*
  * Business logic for the ndrzcc-generated operations: fill the generated _out
@@ -142,8 +146,63 @@ chimera_smb_domain_name(const struct ndr_sid *domsid)
             return "Unix Group";
         }
     }
+    /* Well-known authorities (MS-DTYP 2.4.2.4). */
+    if (domsid->identifier_authority[5] == 1) {
+        return "";                 /* World authority (Everyone) */
+    }
+    if (domsid->identifier_authority[5] == 5) {
+        if (domsid->sub_authority_count >= 1 && domsid->sub_authority[0] == 32) {
+            return "BUILTIN";
+        }
+        return "NT AUTHORITY";     /* S-1-5-* well-knowns */
+    }
     return "WORKGROUP";
 } /* chimera_smb_domain_name */
+
+/* Well-known names the ACL editor / smbtorture LookupNames resolves on a
+ * standalone server (MS-DTYP 2.4.2.4 / MS-LSAT).  Matched case-insensitively in
+ * both the bare and DOMAIN\name forms. */
+struct chimera_smb_wellknown_name {
+    const char *name;
+    const char *sid;
+    uint32_t    type;
+};
+
+static const struct chimera_smb_wellknown_name chimera_smb_wellknown_names[] = {
+    { "Everyone",                          "S-1-1-0",                             LSA_SID_NAME_WKN_GROUP      },
+    { "SYSTEM",                            "S-1-5-18",                            LSA_SID_NAME_WKN_GROUP      },
+    { "NT AUTHORITY\\SYSTEM",              "S-1-5-18",                            LSA_SID_NAME_WKN_GROUP      },
+    { "NT AUTHORITY\\ANONYMOUS LOGON",     "S-1-5-7",                             LSA_SID_NAME_WKN_GROUP      },
+    { "NT AUTHORITY\\Authenticated Users", "S-1-5-11",                            LSA_SID_NAME_WKN_GROUP      },
+    { "BUILTIN\\Administrators",           "S-1-5-32-544",                        LSA_SID_NAME_ALIAS          },
+    { "BUILTIN\\Users",                    "S-1-5-32-545",                        LSA_SID_NAME_ALIAS          },
+    { "BUILTIN",                           "S-1-5-32",                            LSA_SID_NAME_DOMAIN         },
+    { "BUILTIN\\",                         "S-1-5-32",                            LSA_SID_NAME_DOMAIN         },
+};
+
+/* Resolve a name to a SID string + lsa_SidType; returns 1 if well-known. */
+static int
+chimera_smb_lookup_wellknown_name(
+    const char *name,
+    char       *sidbuf,
+    size_t      buflen,
+    uint32_t   *type)
+{
+    unsigned int i;
+
+    if (!name) {
+        return 0;
+    }
+    for (i = 0; i < sizeof(chimera_smb_wellknown_names) /
+         sizeof(chimera_smb_wellknown_names[0]); i++) {
+        if (strcasecmp(name, chimera_smb_wellknown_names[i].name) == 0) {
+            snprintf(sidbuf, buflen, "%s", chimera_smb_wellknown_names[i].sid);
+            *type = chimera_smb_wellknown_names[i].type;
+            return 1;
+        }
+    }
+    return 0;
+} /* chimera_smb_lookup_wellknown_name */
 
 /* Point an rpc_unicode_string (lsa_String) at a UTF-8 string; byte counts are
  * length==size==chars*2 (the buffer body is emitted no-NUL by ndr_push_wstring,
@@ -158,13 +217,99 @@ chimera_smb_set_ustr(
     s->buffer = (char *) utf8;
 } /* chimera_smb_set_ustr */
 
-static void
+/* A 16-byte handle id occupies a slot when any byte is non-zero. */
+static int
+chimera_smb_handle_id_set(const uint8_t uuid[16])
+{
+    for (int i = 0; i < 16; i++) {
+        if (uuid[i]) {
+            return 1;
+        }
+    }
+    return 0;
+} /* chimera_smb_handle_id_set */
+
+/* Issue a policy handle into a free slot of this connection's open-handle set.
+ * Returns 0 with h filled, or -1 if the set is full. */
+static int
+chimera_smb_lsarpc_handle_open(
+    struct chimera_smb_conn *conn,
+    struct policy_handle    *h)
+{
+    for (int i = 0; i < CHIMERA_SMB_RPC_MAX_HANDLES; i++) {
+        uint64_t a, b;
+
+        if (chimera_smb_handle_id_set(conn->rpc_handles[i])) {
+            continue;
+        }
+        a = chimera_rand64();
+        b = chimera_rand64();
+        memcpy(conn->rpc_handles[i], &a, 8);
+        memcpy(conn->rpc_handles[i] + 8, &b, 8);
+        conn->rpc_handles[i][0] |= 1;   /* never all-zero, so the slot reads busy */
+
+        h->handle_type = 0;
+        memcpy(h->uuid, conn->rpc_handles[i], 16);
+        return 0;
+    }
+    return -1;
+} /* chimera_smb_lsarpc_handle_open */
+
+/* Slot index of a handle open on this connection, or -1 (foreign, closed, or
+ * zeroed -- the cases that must fault with nca_s_fault_context_mismatch). */
+static int
+chimera_smb_lsarpc_handle_slot(
+    struct chimera_smb_conn    *conn,
+    const struct policy_handle *h)
+{
+    if (!chimera_smb_handle_id_set(h->uuid)) {
+        return -1;
+    }
+    for (int i = 0; i < CHIMERA_SMB_RPC_MAX_HANDLES; i++) {
+        if (memcmp(conn->rpc_handles[i], h->uuid, 16) == 0) {
+            return i;
+        }
+    }
+    return -1;
+} /* chimera_smb_lsarpc_handle_slot */
+
+static int
+chimera_smb_lsarpc_handle_valid(
+    struct chimera_smb_conn    *conn,
+    const struct policy_handle *h)
+{
+    return chimera_smb_lsarpc_handle_slot(conn, h) >= 0;
+} /* chimera_smb_lsarpc_handle_valid */
+
+/* Close (free) a handle's slot.  Returns 1 if it was open, 0 otherwise. */
+static int
+chimera_smb_lsarpc_handle_close(
+    struct chimera_smb_conn    *conn,
+    const struct policy_handle *h)
+{
+    int slot = chimera_smb_lsarpc_handle_slot(conn, h);
+
+    if (slot < 0) {
+        return 0;
+    }
+    memset(conn->rpc_handles[slot], 0, 16);
+    return 1;
+} /* chimera_smb_lsarpc_handle_close */
+
+/*
+ * Business logic for the generated operations.  Returns 0 on success (the _out
+ * struct is filled for marshalling) or DCE_RC_FAULT_CONTEXT_MISMATCH when an op
+ * is presented a handle this connection did not issue -- the dispatcher then
+ * emits a DCE/RPC fault instead of a response.
+ */
+static int
 chimera_smb_lsarpc_impl(
-    int                 opnum,
-    const void         *in,
-    void               *out,
-    struct ndr_dbuf    *dbuf,
-    struct chimera_vfs *vfs)
+    int                      opnum,
+    const void              *in,
+    void                    *out,
+    struct ndr_dbuf         *dbuf,
+    struct chimera_vfs      *vfs,
+    struct chimera_smb_conn *conn)
 {
     (void) in;
     (void) vfs;
@@ -172,16 +317,22 @@ chimera_smb_lsarpc_impl(
     switch (opnum) {
         case LSA_OP_OPENPOLICY2: {
             struct lsa_OpenPolicy2_out *o = out;
-            o->handle.handle_type = 0;
-            memset(o->handle.uuid, 0xaa, sizeof(o->handle.uuid));
-            o->status = 0;
+            if (chimera_smb_lsarpc_handle_open(conn, &o->handle) != 0) {
+                memset(&o->handle, 0, sizeof(o->handle));
+                o->status = LSA_STATUS_INSUFFICIENT_RESOURCES;
+            } else {
+                o->status = 0;
+            }
             break;
         }
         case LSA_OP_OPENPOLICY: {
             struct lsa_OpenPolicy_out *o = out;
-            o->handle.handle_type = 0;
-            memset(o->handle.uuid, 0xaa, sizeof(o->handle.uuid));
-            o->status = 0;
+            if (chimera_smb_lsarpc_handle_open(conn, &o->handle) != 0) {
+                memset(&o->handle, 0, sizeof(o->handle));
+                o->status = LSA_STATUS_INSUFFICIENT_RESOURCES;
+            } else {
+                o->status = 0;
+            }
             break;
         }
         case LSA_OP_GETUSERNAME: {
@@ -208,6 +359,10 @@ chimera_smb_lsarpc_impl(
             * layout-identical, so the level and info/status fields line up. */
             const struct lsa_QueryInfoPolicy_in *qi = in;
             struct lsa_QueryInfoPolicy_out      *o  = out;
+
+            if (!chimera_smb_lsarpc_handle_valid(conn, &qi->handle)) {
+                return DCE_RC_FAULT_CONTEXT_MISMATCH;
+            }
             /* Levels 3 (PrimaryDomain) and 5 (AccountDomain) both return the
              * server's workgroup name and machine SID. */
             static const char                   *domain = "WORKGROUP";
@@ -225,7 +380,12 @@ chimera_smb_lsarpc_impl(
             break;
         }
         case LSA_OP_ENUMTRUSTDOM: {
-            struct lsa_EnumTrustDom_out *o = out;
+            const struct lsa_EnumTrustDom_in *li = in;
+            struct lsa_EnumTrustDom_out      *o  = out;
+
+            if (!chimera_smb_lsarpc_handle_valid(conn, &li->handle)) {
+                return DCE_RC_FAULT_CONTEXT_MISMATCH;
+            }
             /* No trusted domains on a standalone server. */
             o->resume_handle   = 0;
             o->domains.count   = 0;
@@ -242,6 +402,10 @@ chimera_smb_lsarpc_impl(
             struct lsa_TranslatedName      *names;
             struct lsa_DomainInfo          *domains;
             struct lsa_RefDomainList       *rdl;
+
+            if (!chimera_smb_lsarpc_handle_valid(conn, &li->handle)) {
+                return DCE_RC_FAULT_CONTEXT_MISMATCH;
+            }
 
             names   = ndr_dbuf_alloc(dbuf, (n ? n : 1) * sizeof(*names));
             domains = ndr_dbuf_alloc(dbuf, (n ? n : 1) * sizeof(*domains));
@@ -334,58 +498,92 @@ chimera_smb_lsarpc_impl(
             struct lsa_DomainInfo           *domains;
             struct lsa_RefDomainList        *rdl;
 
+            if (!chimera_smb_lsarpc_handle_valid(conn, &li->handle)) {
+                return DCE_RC_FAULT_CONTEXT_MISMATCH;
+            }
+
             sids    = ndr_dbuf_alloc(dbuf, (nn ? nn : 1) * sizeof(*sids));
             domains = ndr_dbuf_alloc(dbuf, (nn ? nn : 1) * sizeof(*domains));
             rdl     = ndr_dbuf_alloc(dbuf, sizeof(*rdl));
 
             for (i = 0; i < nn; i++) {
-                const char                    *name = li->names[i].buffer;
-                const struct chimera_vfs_user *u;
+                const char    *name = li->names[i].buffer;
+                char           sidstr[CHIMERA_IDMAP_SID_MAX];
+                uint32_t       type = LSA_SID_NAME_UNKNOWN;
+                int            resolved;
+                struct ndr_sid full, dom;
+                int            didx = -1;
+                uint32_t       d, rid;
 
                 sids[i].sid_type  = LSA_SID_NAME_UNKNOWN;
                 sids[i].rid       = 0;
                 sids[i].sid_index = 0xffffffff;
 
-                u = name ? chimera_vfs_user_cache_lookup_by_name(cache, name) : NULL;
-                if (u) {
-                    char           sidstr[CHIMERA_IDMAP_SID_MAX];
-                    struct ndr_sid full, dom;
-                    int            didx = -1;
-                    uint32_t       d, rid;
+                if (!name || name[0] == '\0') {
+                    /* An empty/NULL name resolves to the server's own primary
+                     * (account) domain (MS-LSAT): its machine SID, type Domain. */
+                    struct ndr_sid m;
+                    chimera_smb_lsarpc_machine_sid(&m);
+                    chimera_smb_sid_to_string(&m, sidstr, sizeof(sidstr));
+                    type     = LSA_SID_NAME_DOMAIN;
+                    resolved = 1;
+                } else {
+                    /* Well-known names (Everyone, SYSTEM, BUILTIN\*, ...) first,
+                     * then the local-account idmap (a unix user -> S-1-22-1-<uid>
+                     * or its configured SID). */
+                    resolved = chimera_smb_lookup_wellknown_name(name, sidstr,
+                                                                 sizeof(sidstr), &type);
+                    if (!resolved) {
+                        const struct chimera_vfs_user *u =
+                            chimera_vfs_user_cache_lookup_by_name(cache, name);
+                        if (u) {
+                            if (u->sid[0]) {
+                                snprintf(sidstr, sizeof(sidstr), "%s", u->sid);
+                            } else {
+                                snprintf(sidstr, sizeof(sidstr), "S-1-22-1-%u", u->uid);
+                            }
+                            type     = LSA_SID_NAME_USER;
+                            resolved = 1;
+                        }
+                    }
+                }
 
-                    if (u->sid[0]) {
-                        snprintf(sidstr, sizeof(sidstr), "%s", u->sid);
-                    } else {
-                        snprintf(sidstr, sizeof(sidstr), "S-1-22-1-%u", u->uid);
-                    }
-                    if (chimera_smb_string_to_sid(sidstr, &full) != 0 ||
-                        full.sub_authority_count == 0) {
-                        continue;
-                    }
+                if (!resolved ||
+                    chimera_smb_string_to_sid(sidstr, &full) != 0 ||
+                    full.sub_authority_count == 0) {
+                    continue;
+                }
+
+                if (type == LSA_SID_NAME_DOMAIN) {
+                    /* A domain name resolves to the domain SID itself, with no
+                     * RID (0xffffffff) referencing the whole domain. */
+                    dom = full;
+                    rid = 0xffffffff;
+                } else {
                     rid = full.sub_authority[full.sub_authority_count - 1];
                     dom = full;            /* domain SID = SID minus the RID */
                     dom.sub_authority_count--;
-
-                    for (d = 0; d < ndom; d++) {
-                        if (chimera_smb_sid_equal(domains[d].sid, &dom)) {
-                            didx = (int) d;
-                            break;
-                        }
-                    }
-                    if (didx < 0) {
-                        struct ndr_sid *ds = ndr_dbuf_alloc(dbuf, sizeof(*ds));
-                        *ds               = dom;
-                        domains[ndom].sid = ds;
-                        chimera_smb_set_ustr(&domains[ndom].name,
-                                             chimera_smb_domain_name(&dom));
-                        didx = (int) ndom++;
-                    }
-
-                    sids[i].sid_type  = LSA_SID_NAME_USER;
-                    sids[i].rid       = rid;
-                    sids[i].sid_index = (uint32_t) didx;
-                    mapped++;
                 }
+
+                for (d = 0; d < ndom; d++) {
+                    if (chimera_smb_sid_equal(domains[d].sid, &dom)) {
+                        didx = (int) d;
+                        break;
+                    }
+                }
+                if (didx < 0) {
+                    struct ndr_sid *ds = ndr_dbuf_alloc(dbuf, sizeof(*ds));
+                    *ds               = dom;
+                    domains[ndom].sid = ds;
+                    chimera_smb_set_ustr(&domains[ndom].name,
+                                         chimera_smb_domain_name(&dom));
+                    didx = (int) ndom++;
+                }
+
+                sids[i].sid_type  = type;
+                sids[i].rid       = rid;
+                sids[i].sid_index = (uint32_t) didx;
+                mapped++;
             }
 
             rdl->count    = ndom;
@@ -401,15 +599,24 @@ chimera_smb_lsarpc_impl(
             break;
         }
         case LSA_OP_CLOSE: {
-            struct lsa_Close_out *o = out;
+            const struct lsa_Close_in *li = in;
+            struct lsa_Close_out      *o  = out;
+
+            if (!chimera_smb_lsarpc_handle_close(conn, &li->handle)) {
+                return DCE_RC_FAULT_CONTEXT_MISMATCH;
+            }
+            /* Per MS-LSAD a successful Close returns a zeroed handle; closing an
+             * already-closed (or foreign) handle faults above. */
             o->handle.handle_type = 0;
-            memset(o->handle.uuid, 0xaa, sizeof(o->handle.uuid));
+            memset(o->handle.uuid, 0, sizeof(o->handle.uuid));
             o->status = 0;
             break;
         }
         default:
             break;
     } /* switch */
+
+    return 0;
 } /* chimera_smb_lsarpc_impl */
 
 /*
@@ -424,12 +631,13 @@ chimera_smb_lsarpc_ndr_dispatch(
     void                       *output,
     struct chimera_smb_request *request)
 {
-    struct ndr_cursor   c;
-    struct ndr_writer   w;
-    struct ndr_dbuf     dbuf;
-    struct chimera_vfs *vfs = request->compound->thread->shared->vfs;
-    void               *in, *out;
-    int                 n;
+    struct ndr_cursor        c;
+    struct ndr_writer        w;
+    struct ndr_dbuf          dbuf;
+    struct chimera_vfs      *vfs  = request->compound->thread->shared->vfs;
+    struct chimera_smb_conn *conn = request->compound->conn;
+    void                    *in, *out;
+    int                      n;
 
     ndr_cursor_init(&c, evpl_iovec_cursor_data(cursor),
                     cursor->iov->length - cursor->offset);
@@ -441,7 +649,14 @@ chimera_smb_lsarpc_ndr_dispatch(
     out = ndr_dbuf_alloc(&dbuf, op->out_size);
 
     op->pull_in(&c, in, &dbuf);
-    chimera_smb_lsarpc_impl(op->opnum, in, out, &dbuf, vfs);
+    n = chimera_smb_lsarpc_impl(op->opnum, in, out, &dbuf, vfs, conn);
+
+    /* A context-handle fault skips marshalling: dce_rpc emits a fault PDU from
+     * the negative return. */
+    if (n < 0) {
+        ndr_dbuf_destroy(&dbuf);
+        return n;
+    }
 
     ndr_writer_init(&w, output, LSA_RPC_STUB_MAX);
     n = op->push_out(&w, out);

--- a/src/server/smb/smb_lsarpc.c
+++ b/src/server/smb/smb_lsarpc.c
@@ -169,15 +169,24 @@ struct chimera_smb_wellknown_name {
 };
 
 static const struct chimera_smb_wellknown_name chimera_smb_wellknown_names[] = {
-    { "Everyone",                          "S-1-1-0",                             LSA_SID_NAME_WKN_GROUP      },
-    { "SYSTEM",                            "S-1-5-18",                            LSA_SID_NAME_WKN_GROUP      },
-    { "NT AUTHORITY\\SYSTEM",              "S-1-5-18",                            LSA_SID_NAME_WKN_GROUP      },
-    { "NT AUTHORITY\\ANONYMOUS LOGON",     "S-1-5-7",                             LSA_SID_NAME_WKN_GROUP      },
-    { "NT AUTHORITY\\Authenticated Users", "S-1-5-11",                            LSA_SID_NAME_WKN_GROUP      },
-    { "BUILTIN\\Administrators",           "S-1-5-32-544",                        LSA_SID_NAME_ALIAS          },
-    { "BUILTIN\\Users",                    "S-1-5-32-545",                        LSA_SID_NAME_ALIAS          },
-    { "BUILTIN",                           "S-1-5-32",                            LSA_SID_NAME_DOMAIN         },
-    { "BUILTIN\\",                         "S-1-5-32",                            LSA_SID_NAME_DOMAIN         },
+    { "Everyone",                          "S-1-1-0",                             LSA_SID_NAME_WKN_GROUP
+    },
+    { "SYSTEM",                            "S-1-5-18",                            LSA_SID_NAME_WKN_GROUP
+    },
+    { "NT AUTHORITY\\SYSTEM",              "S-1-5-18",                            LSA_SID_NAME_WKN_GROUP
+    },
+    { "NT AUTHORITY\\ANONYMOUS LOGON",     "S-1-5-7",                             LSA_SID_NAME_WKN_GROUP
+    },
+    { "NT AUTHORITY\\Authenticated Users", "S-1-5-11",                            LSA_SID_NAME_WKN_GROUP
+    },
+    { "BUILTIN\\Administrators",           "S-1-5-32-544",                        LSA_SID_NAME_ALIAS
+    },
+    { "BUILTIN\\Users",                    "S-1-5-32-545",                        LSA_SID_NAME_ALIAS
+    },
+    { "BUILTIN",                           "S-1-5-32",                            LSA_SID_NAME_DOMAIN
+    },
+    { "BUILTIN\\",                         "S-1-5-32",                            LSA_SID_NAME_DOMAIN
+    },
 };
 
 /* Resolve a name to a SID string + lsa_SidType; returns 1 if well-known. */

--- a/src/server/smb/smb_lsarpc.c
+++ b/src/server/smb/smb_lsarpc.c
@@ -46,9 +46,10 @@ static const dce_if_uuid_t LSA_INTERFACE = {
  * handler returned (a fixed opaque policy handle, STATUS_SUCCESS); inputs are
  * not consulted, matching prior behaviour.
  */
-/* Fill a zero-initialised SID with the server's fixed machine SID
- * S-1-5-21-1111-2222-3333.  The caller provides storage from the dbuf arena,
- * which ndr_dbuf_alloc has already zeroed. */
+/* Fill a SID with the server's fixed machine SID S-1-5-21-1111-2222-3333.  The
+ * caller must provide zeroed storage (a dbuf allocation, or a `= { 0 }`
+ * initialiser) so the unset identifier-authority and sub-authority bytes are
+ * defined. */
 static void
 chimera_smb_lsarpc_machine_sid(struct ndr_sid *sid)
 {
@@ -531,7 +532,7 @@ chimera_smb_lsarpc_impl(
                 if (!name || name[0] == '\0') {
                     /* An empty/NULL name resolves to the server's own primary
                      * (account) domain (MS-LSAT): its machine SID, type Domain. */
-                    struct ndr_sid m;
+                    struct ndr_sid m = { 0 };
                     chimera_smb_lsarpc_machine_sid(&m);
                     chimera_smb_sid_to_string(&m, sidstr, sizeof(sidstr));
                     type     = LSA_SID_NAME_DOMAIN;

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -529,8 +529,12 @@ set_tests_properties(chimera/server/smb/rpcclient_lsa PROPERTIES
 #   rpc.srvsvc...NetShareEnumAll : the level-1 share enumeration that backs
 #                        Explorer browsing, exercised over the SMB2 WRITE/READ
 #                        ncacn_np transport (named subtest; pinned Samba image).
+#   rpc.handles.lsarpc : DCE/RPC context (policy) handle association -- a handle
+#                        opened on one connection, used on another, must fault
+#                        with CONTEXT_MISMATCH, and a closed handle must too.
 set(SMBTORTURE_RPC_SUITES_ENABLED
     rpc.lsa.lookupsids
+    rpc.handles.lsarpc
     "rpc.srvsvc.srvsvc (admin access).NetShareEnumAll")
 
 foreach(SUITE ${SMBTORTURE_RPC_SUITES_ENABLED})
@@ -549,14 +553,13 @@ endforeach()
 # smbtorture DCE/RPC conformance suites wired but DISABLED: each needs a server
 # feature we don't have yet (but that is in NAS scope -- drop DISABLED once the
 # feature lands).
-#   rpc.lsa.lookupnames : needs well-known name resolution (Everyone, SYSTEM,
-#                         BUILTIN\Administrators, ...) AND a Close that returns
-#                         RPC_SS_CONTEXT_MISMATCH (real context-handle tracking).
-#   rpc.handles.lsarpc  : DCE/RPC context-handle association across connections.
+#   rpc.lsa.lookupnames : well-known names (Everyone, SYSTEM, BUILTIN\*, ...) and
+#                         the NULL-name/handle cases now resolve via LookupNames
+#                         (opnum 14); the suite additionally probes LookupNames2
+#                         (58) and LookupNames3 (68), still unimplemented.
 #   rpc.lsalookup       : looks names up in trusted domains ("no trusts").
 set(SMBTORTURE_RPC_SUITES_DISABLED
     rpc.lsa.lookupnames
-    rpc.handles.lsarpc
     rpc.lsalookup)
 
 foreach(SUITE ${SMBTORTURE_RPC_SUITES_DISABLED})


### PR DESCRIPTION
**Tier 1**, layered on #807 (the pipe-transport PR). Until #807 merges this PR's diff also shows its commits; the new commits here are the last two (`smb: LSARPC context-handle lifecycle…` and `test: enable the rpc.handles.lsarpc conformance gate`).

Lights up another Windows-free smbtorture gate — `rpc.handles.lsarpc` — and most of `rpc.lsa.lookupnames`.

## Context-handle lifecycle (the DCE-protocol piece)
Policy handles were fixed dummy bytes (`memset 0xaa`) and never validated, so the server couldn't distinguish a live handle from a foreign or already-closed one. Now each connection tracks its open handles in a small fixed per-connection set:
- `OpenPolicy`/`OpenPolicy2` issue a random id into a free slot.
- Every handle-taking op (`QueryInfoPolicy[2]`, `EnumTrustedDomains`, `LookupNames`, `LookupSids`, `Close`) validates the presented handle against that set.
- `Close` frees the slot and returns a zeroed handle.

A handle from another connection, an already-closed handle, or a zeroed handle isn't in the set → the op faults with **`nca_s_fault_context_mismatch`**. `dce_rpc()` maps a handler's `DCE_RC_FAULT_CONTEXT_MISMATCH` return to that status (everything else still faults `nca_s_op_rng_error`). Scoping the set to the connection is exactly what makes a cross-connection use and a double-close fail, as MS-LSAD requires — which is what `rpc.handles.lsarpc` checks.

## Well-known name resolution
`LookupNames` now resolves the standard identities the ACL editor asks for — Everyone (S-1-1-0), SYSTEM (S-1-5-18), `NT AUTHORITY\{ANONYMOUS LOGON,Authenticated Users}`, `BUILTIN\Administrators`, the BUILTIN domain, … — ahead of the local-account idmap, and maps an empty/NULL name to the server's own primary domain. Domain-type names resolve to the domain SID itself (RID `0xffffffff`); others split into domain + RID.

## Gates
- **`rpc.handles.lsarpc` → enabled, passing** (new).
- `rpc.lsa.lookupsids`, `rpc.srvsvc NetShareEnumAll` → still passing (no regression).
- `rpc.lsa.lookupnames` → all its LookupNames(14) cases (well-known + NULL + handle) now pass; stays **disabled** only because the suite additionally probes `LookupNames2`(58)/`LookupNames3`(68), which are unimplemented. Clean follow-up.

## Verification
All four enabled RPC gates pass via ctest; ASan-clean (0 leaks); rpcclient smoke + lsarpc golden green. Built under Release and Debug/ASan.