### PR TITLE
nfs: add NSM/statd (program 100024) to drive NLM lock recovery

### DIFF
--- a/src/nfs_common/CMakeLists.txt
+++ b/src/nfs_common/CMakeLists.txt
@@ -23,6 +23,10 @@ set(NLM4_XDR_X ${CMAKE_CURRENT_SOURCE_DIR}/nlm4.x)
 set(NLM4_XDR_C ${CMAKE_CURRENT_BINARY_DIR}/nlm4_xdr.c)
 set(NLM4_XDR_H ${CMAKE_CURRENT_BINARY_DIR}/nlm4_xdr.h)
 
+set(SM_INTER_XDR_X ${CMAKE_CURRENT_SOURCE_DIR}/sm_inter.x)
+set(SM_INTER_XDR_C ${CMAKE_CURRENT_BINARY_DIR}/sm_inter_xdr.c)
+set(SM_INTER_XDR_H ${CMAKE_CURRENT_BINARY_DIR}/sm_inter_xdr.h)
+
 add_custom_command(
     OUTPUT ${NFS3_XDR_C} ${NFS3_XDR_H}
     COMMAND ${XDRZCC} -r ${NFS3_XDR_X} ${NFS3_XDR_C} ${NFS3_XDR_H}
@@ -58,13 +62,20 @@ add_custom_command(
     COMMENT "Compiling ${NLM4_XDR_X}"
 )
 
+add_custom_command(
+    OUTPUT ${SM_INTER_XDR_C} ${SM_INTER_XDR_H}
+    COMMAND ${XDRZCC} -r ${SM_INTER_XDR_X} ${SM_INTER_XDR_C} ${SM_INTER_XDR_H}
+    DEPENDS ${SM_INTER_XDR_X} ${XDRZCC}
+    COMMENT "Compiling ${SM_INTER_XDR_X}"
+)
+
 set(NFS_COMMON_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR} PARENT_SCOPE)
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 # Suppress warnings for the generated source files
 set_source_files_properties(
-    ${NFS3_XDR_C} ${NFS4_XDR_C} ${NFS_MOUNT_XDR_C} ${PORTMAP_XDR_C} ${NLM4_XDR_C} PROPERTIES COMPILE_OPTIONS "-Wno-unused;-Wno-switch;-Wno-format-truncation"
+    ${NFS3_XDR_C} ${NFS4_XDR_C} ${NFS_MOUNT_XDR_C} ${PORTMAP_XDR_C} ${NLM4_XDR_C} ${SM_INTER_XDR_C} PROPERTIES COMPILE_OPTIONS "-Wno-unused;-Wno-switch;-Wno-format-truncation"
 )
 
 add_definitions(-fvisibility=default)
@@ -76,7 +87,8 @@ add_library(chimera_nfs_common  SHARED
             ${NFS4_XDR_C} ${NFS4_XDR_H}
             ${NFS_MOUNT_XDR_C} ${NFS_MOUNT_XDR_H}
             ${PORTMAP_XDR_C} ${PORTMAP_XDR_H}
-            ${NLM4_XDR_C} ${NLM4_XDR_H})
+            ${NLM4_XDR_C} ${NLM4_XDR_H}
+            ${SM_INTER_XDR_C} ${SM_INTER_XDR_H})
 
 target_link_libraries(chimera_nfs_common chimera_common evpl evpl_rpc2)
 

--- a/src/nfs_common/sm_inter.x
+++ b/src/nfs_common/sm_inter.x
@@ -1,0 +1,67 @@
+
+/*
+ * SPDX-FileCopyrightText: 2026 'IETF Trust and the persons identified
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/* NSM (Network Status Monitor) protocol -- RFC 1813 Appendix / the de-facto
+ * "sm_inter" interface implemented by rpc.statd.  This is the reboot-monitor
+ * service that drives NLM (program 100021) lock recovery: peers' statd send us
+ * SM_NOTIFY when they reboot so we drop their stale locks, and on our own
+ * reboot we send SM_NOTIFY to every host we were monitoring so they reclaim. */
+
+const SM_MAXSTRLEN = 1024;  /* Maximum bytes in a monitored-host name */
+const SM_PRIV_SIZE = 16;    /* Opaque cookie handed back to the monitorer */
+
+enum res {
+    STAT_SUCC = 0,          /* NSM agrees to monitor */
+    STAT_FAIL = 1           /* NSM cannot monitor     */
+};
+
+struct sm_name {
+    string mon_name<SM_MAXSTRLEN>;
+};
+
+struct my_id {
+    string my_name<SM_MAXSTRLEN>; /* hostname of the monitorer (the local NLM) */
+    int    my_prog;               /* RPC program to call back on a status change */
+    int    my_vers;
+    int    my_proc;
+};
+
+struct mon_id {
+    string mon_name<SM_MAXSTRLEN>; /* hostname of the monitored peer */
+    my_id  id;
+};
+
+struct mon {
+    mon_id id;
+    opaque priv[SM_PRIV_SIZE];     /* opaque cookie returned in the callback */
+};
+
+struct sm_stat_res {
+    res res_stat;
+    int state;                     /* NSM state number of this host */
+};
+
+struct sm_stat {
+    int state;
+};
+
+/* SM_NOTIFY argument: "host <mon_name> has restarted with state <state>". */
+struct stat_chge {
+    string mon_name<SM_MAXSTRLEN>;
+    int    state;
+};
+
+program SM_INTER {
+    version SM_INTER_V1 {
+        void         SM_NULL(void)             = 0;
+        sm_stat_res  SM_STAT(sm_name)          = 1;
+        sm_stat_res  SM_MON(mon)               = 2;
+        sm_stat      SM_UNMON(mon_id)          = 3;
+        sm_stat      SM_UNMON_ALL(my_id)       = 4;
+        void         SM_SIMU_CRASH(void)       = 5;
+        void         SM_NOTIFY(stat_chge)      = 6;
+    } = 1;
+} = 100024;

--- a/src/server/nfs/CMakeLists.txt
+++ b/src/server/nfs/CMakeLists.txt
@@ -6,7 +6,7 @@ include_directories(${NFS_COMMON_INCLUDE_DIR})
 
 # Create libraries for NFSv3 and NFSv4
 add_library(chimera_nfs SHARED nfs.c nfs4_session.c nfs4_state.c nfs4_lease.c nfs4_recovery.c nfs4_drc.c nfs3_drc.c nfs_drc_reply.c nfs4_callback.c nfs_mount.c nfs_portmap.c nfs3_dump.c nfs4_dump.c
-            nfs_external_portmap.c nfs_nlm.c nfs_nlm_state.c
+            nfs_external_portmap.c nfs_nlm.c nfs_nlm_state.c nfs_nsm.c nfs_nsm_state.c
             nfs3_proc_null.c nfs3_proc_getattr.c nfs3_proc_setattr.c nfs3_proc_lookup.c 
             nfs3_proc_access.c nfs3_proc_readlink.c nfs3_proc_read.c nfs3_proc_write.c
             nfs3_proc_create.c nfs3_proc_mkdir.c nfs3_proc_remove.c nfs3_proc_mknod.c nfs3_proc_symlink.c

--- a/src/server/nfs/nfs.c
+++ b/src/server/nfs/nfs.c
@@ -20,6 +20,7 @@
 #include "nfs4_lease.h"
 #include "nfs4_callback.h"
 #include "nfs_nlm.h"
+#include "nfs_nsm.h"
 #include "prometheus-c.h"
 #include "nfs_external_portmap.h"
 
@@ -104,6 +105,7 @@ nfs_server_init(
     int                               nfs_rdma_port;
     int                               nfs_tcp_rdma_port;
     int                               nfs_lockmgr_port;
+    int                               nfs_nsm_port;
     int                               nfs_port;
     int                               data_server;
     int                               external_portmap;
@@ -116,11 +118,13 @@ nfs_server_init(
     nfs_rdma_port     = chimera_server_config_get_nfs_rdma_port(config);
     nfs_tcp_rdma_port = chimera_server_config_get_nfs_tcp_rdma_port(config);
     nfs_lockmgr_port  = chimera_server_config_get_nfs_lockmgr_port(config);
+    nfs_nsm_port      = chimera_server_config_get_nfs_nsm_port(config);
     external_portmap  = chimera_server_config_get_external_portmap(config);
     portmap_hostname  = chimera_server_config_get_portmap_hostname(config);
     chimera_nfs_debug("NFS RDMA: %s", nfs_rdma ? "enabled" : "disabled");
     chimera_nfs_debug("NFS TCP-RDMA: %s (port %d)", nfs_tcp_rdma_port > 0 ? "enabled" : "disabled", nfs_tcp_rdma_port);
     chimera_nfs_debug("NFS Lock Manager port: %d", nfs_lockmgr_port);
+    chimera_nfs_debug("NSM/statd port: %d", nfs_nsm_port);
     chimera_nfs_debug("External Portmap: %s", external_portmap ? "enabled" : "disabled");
 
     clock_gettime(CLOCK_REALTIME, &now);
@@ -156,6 +160,7 @@ nfs_server_init(
     NFS_V4_init(&shared->nfs_v4);
     NFS_V4_CB_init(&shared->nfs_v4_cb);
     NLM_V4_init(&shared->nlm_v4);
+    SM_INTER_V1_init(&shared->nsm_v1);
 
     shared->metrics      = metrics;
     shared->op_histogram = prometheus_metrics_create_histogram_time(metrics, "chimera_nfs_op_latency_nanoseconds",
@@ -281,6 +286,14 @@ nfs_server_init(
     shared->nlm_v4.recv_call_NLMPROC4_NM_LOCK     = chimera_nfs_nlm4_nm_lock;
     shared->nlm_v4.recv_call_NLMPROC4_FREE_ALL    = chimera_nfs_nlm4_free_all;
 
+    shared->nsm_v1.recv_call_SM_NULL       = chimera_nfs_sm_null;
+    shared->nsm_v1.recv_call_SM_STAT       = chimera_nfs_sm_stat;
+    shared->nsm_v1.recv_call_SM_MON        = chimera_nfs_sm_mon;
+    shared->nsm_v1.recv_call_SM_UNMON      = chimera_nfs_sm_unmon;
+    shared->nsm_v1.recv_call_SM_UNMON_ALL  = chimera_nfs_sm_unmon_all;
+    shared->nsm_v1.recv_call_SM_SIMU_CRASH = chimera_nfs_sm_simu_crash;
+    shared->nsm_v1.recv_call_SM_NOTIFY     = chimera_nfs_sm_notify;
+
     nfs4_client_table_init(&shared->nfs4_shared_clients);
     nfs_state_table_init(&shared->nfs4_state_table);
     nfs_layout_table_init(&shared->nfs4_layout_table);
@@ -317,6 +330,8 @@ nfs_server_init(
     nlm_state_init(&shared->nlm_state,
                    chimera_server_config_get_state_dir(config));
 
+    nsm_state_init(&shared->nsm_state, shared->vfs);
+
     shared->nfs_endpoint = evpl_endpoint_create("0.0.0.0", nfs_port);
 
     /* A pNFS data server only needs the NFSv4 service (clients reach it by
@@ -328,6 +343,8 @@ nfs_server_init(
         shared->mount_server     = NULL;
         shared->nlm_endpoint     = NULL;
         shared->nlm_server       = NULL;
+        shared->nsm_endpoint     = NULL;
+        shared->nsm_server       = NULL;
         shared->portmap_endpoint = NULL;
         shared->portmap_server   = NULL;
     }
@@ -357,6 +374,7 @@ nfs_server_init(
             programs[2]              = &shared->portmap_v4.rpc2;
             shared->portmap_server   = evpl_rpc2_server_init(programs, 3);
             portmap_set_nlm_port(nfs_lockmgr_port);
+            portmap_set_nsm_port(nfs_nsm_port);
         }
 
         chimera_nfs_debug("Initializing NFS mountd server");
@@ -376,10 +394,24 @@ nfs_server_init(
         shared->nlm_endpoint = evpl_endpoint_create("0.0.0.0", nfs_lockmgr_port);
         programs[0]          = &shared->nlm_v4.rpc2;
         shared->nlm_server   = evpl_rpc2_server_init(programs, 1);
+
+        chimera_nfs_debug("Initializing NSM/statd server on port %d", nfs_nsm_port);
+        shared->nsm_endpoint = evpl_endpoint_create("0.0.0.0", nfs_nsm_port);
+        programs[0]          = &shared->nsm_v1.rpc2;
+        shared->nsm_server   = evpl_rpc2_server_init(programs, 1);
     }
 
     nlm_state_load(&shared->nlm_state);
-    if (shared->nlm_state.in_grace) {
+
+    /* Enter the NLM post-restart grace window so clients can reclaim the locks
+     * they held before this server (re)started.  Only meaningful when state is
+     * persistent: on a non-persistent KV backend the NSM monitor list is lost
+     * across a restart, so there is nothing to reclaim and no notifies are sent
+     * -- skip grace to avoid pointlessly blocking fresh locks for 90s.  Phase 2
+     * holds this window open until the cold-start monitor scan completes and
+     * ends it early when the scan finds no monitors. */
+    if (!data_server && !shared->nsm_state.persistence_disabled) {
+        nlm_state_begin_grace(&shared->nlm_state);
         chimera_nfs_info("NLM entering %d-second grace period for lock reclaim",
                          NLM_GRACE_PERIOD_SECS);
     }
@@ -413,6 +445,9 @@ nfs_server_start(void *arg)
     if (shared->nlm_server) {
         evpl_rpc2_server_start(shared->nlm_server, EVPL_STREAM_SOCKET_TCP, shared->nlm_endpoint);
     }
+    if (shared->nsm_server) {
+        evpl_rpc2_server_start(shared->nsm_server, EVPL_STREAM_SOCKET_TCP, shared->nsm_endpoint);
+    }
 
     /* A data server registers no portmap services (it skips the auxiliary
      * protocols entirely). */
@@ -420,7 +455,8 @@ nfs_server_start(void *arg)
         if (shared->portmap_server) {
             evpl_rpc2_server_start(shared->portmap_server, EVPL_STREAM_SOCKET_TCP, shared->portmap_endpoint);
         } else {
-            register_nfs_rpc_services(chimera_server_config_get_nfs_lockmgr_port(shared->config));
+            register_nfs_rpc_services(chimera_server_config_get_nfs_lockmgr_port(shared->config),
+                                      chimera_server_config_get_nfs_nsm_port(shared->config));
         }
     }
 
@@ -438,10 +474,14 @@ nfs_server_stop(void *arg)
     if (shared->nlm_server) {
         evpl_rpc2_server_stop(shared->nlm_server);
     }
+    if (shared->nsm_server) {
+        evpl_rpc2_server_stop(shared->nsm_server);
+    }
     if (shared->portmap_server) {
         evpl_rpc2_server_stop(shared->portmap_server);
     } else {
-        unregister_nfs_rpc_services(chimera_server_config_get_nfs_lockmgr_port(shared->config));
+        unregister_nfs_rpc_services(chimera_server_config_get_nfs_lockmgr_port(shared->config),
+                                    chimera_server_config_get_nfs_nsm_port(shared->config));
     }
 
 } /* nfs_server_stop */
@@ -486,6 +526,9 @@ nfs_server_destroy(void *data)
     evpl_rpc2_server_destroy(shared->nfs_server);
     if (shared->nlm_server) {
         evpl_rpc2_server_destroy(shared->nlm_server);
+    }
+    if (shared->nsm_server) {
+        evpl_rpc2_server_destroy(shared->nsm_server);
     }
 
     if (shared->portmap_server) {
@@ -557,6 +600,7 @@ nfs_server_destroy(void *data)
     free(shared->nfs_v4.rpc2.metrics);
     free(shared->nfs_v4_cb.rpc2.metrics);
     free(shared->nlm_v4.rpc2.metrics);
+    free(shared->nsm_v1.rpc2.metrics);
 
     while (shared->exports) {
         export = shared->exports;
@@ -575,6 +619,13 @@ nfs_server_destroy(void *data)
     }
 
     nlm_state_destroy(&shared->nlm_state);
+    /* Join the reboot-notify worker (idle once its notifies completed) before
+     * tearing down NSM state. */
+    if (shared->nsm_state.notify_thread) {
+        evpl_thread_destroy(shared->nsm_state.notify_thread);
+        shared->nsm_state.notify_thread = NULL;
+    }
+    nsm_state_destroy(&shared->nsm_state);
     nfs4_v40_drc_destroy(&shared->v40_drc);
     nfs3_drc_destroy(&shared->nfs3_drc);
 
@@ -643,6 +694,8 @@ chimera_nfs_server_notify(
                 if (release_locks) {
                     nlm_state_remove_client_file(&shared->nlm_state,
                                                  nlm_cli->hostname);
+                    /* No locks remain for this host -- stop monitoring it. */
+                    nsm_unmonitor(thread, nlm_cli->hostname);
                 }
             } else if (magic == NFS4_SESSION_MAGIC) {
                 nfs4_session_unbind_conn(conn);
@@ -680,6 +733,9 @@ nfs_server_thread_init(
     if (shared->nlm_server) {
         evpl_rpc2_server_attach(thread->rpc2_thread, shared->nlm_server, thread);
     }
+    if (shared->nsm_server) {
+        evpl_rpc2_server_attach(thread->rpc2_thread, shared->nsm_server, thread);
+    }
     if (shared->portmap_server) {
         evpl_rpc2_server_attach(thread->rpc2_thread, shared->portmap_server, thread);
     }
@@ -692,6 +748,14 @@ nfs_server_thread_init(
 
     /* Delegation callback recall doorbell + queue. */
     nfs4_cb_thread_init(thread);
+
+    /* Run-once cold-start: reload the persisted NSM state + monitor list and
+     * notify monitored hosts that we restarted (so they reclaim during the NLM
+     * grace window).  Idempotent across threads; no-op on a non-persistent
+     * backend or when NSM is not running (data-server mode). */
+    if (shared->nsm_server) {
+        chimera_nfs_nsm_kickoff(thread);
+    }
 
     return thread;
 } /* nfs_server_thread_init */
@@ -716,6 +780,9 @@ nfs_server_thread_destroy(void *data)
     evpl_rpc2_server_detach(thread->rpc2_thread, thread->shared->nfs_server);
     if (thread->shared->nlm_server) {
         evpl_rpc2_server_detach(thread->rpc2_thread, thread->shared->nlm_server);
+    }
+    if (thread->shared->nsm_server) {
+        evpl_rpc2_server_detach(thread->rpc2_thread, thread->shared->nsm_server);
     }
     if (thread->shared->portmap_server) {
         evpl_rpc2_server_detach(thread->rpc2_thread, thread->shared->portmap_server);

--- a/src/server/nfs/nfs_common.h
+++ b/src/server/nfs/nfs_common.h
@@ -19,6 +19,8 @@
 #include "nfs4_recovery.h"
 #include "nfs3_drc.h"
 #include "nfs_nlm_state.h"
+#include "nfs_nsm_state.h"
+#include "sm_inter_xdr.h"
 
 struct chimera_server_nfs_thread;
 
@@ -242,6 +244,8 @@ struct chimera_server_nfs_shared {
     struct NFS_V4_CB                    nfs_v4_cb;
     struct NLM_V4                       nlm_v4;
     struct nlm_state                    nlm_state;
+    struct SM_INTER_V1                  nsm_v1;
+    struct nsm_state                    nsm_state;
 
     struct chimera_nfs_export          *exports;
     pthread_mutex_t                     exports_lock;
@@ -255,12 +259,14 @@ struct chimera_server_nfs_shared {
     struct evpl_endpoint               *portmap_endpoint;
     struct evpl_endpoint               *nfs_rdma_endpoint;
     struct evpl_endpoint               *nlm_endpoint;
+    struct evpl_endpoint               *nsm_endpoint;
 
     struct evpl_rpc2_server            *portmap_server;
     struct evpl_rpc2_server            *mount_server;
     struct evpl_rpc2_server            *nfs_server;
     struct evpl_rpc2_server            *nfs_rdma_server;
     struct evpl_rpc2_server            *nlm_server;
+    struct evpl_rpc2_server            *nsm_server;
 
     uint64_t                            nfs_verifier;
 

--- a/src/server/nfs/nfs_external_portmap.c
+++ b/src/server/nfs/nfs_external_portmap.c
@@ -191,7 +191,9 @@ unregister_service(
 } /* unregister_service */
 
 void
-register_nfs_rpc_services(int lockmgr_port)
+register_nfs_rpc_services(
+    int lockmgr_port,
+    int nsm_port)
 {
     struct portmap_reg_ctx ctx;
 
@@ -206,6 +208,10 @@ register_nfs_rpc_services(int lockmgr_port)
 
     if (lockmgr_port > 0) {
         register_service(&ctx, NFS_NLM_PROGRAM, 4, lockmgr_port, "NLM v4 over TCP");
+    }
+
+    if (nsm_port > 0) {
+        register_service(&ctx, NFS_NSM_PROGRAM, 1, nsm_port, "NSM/statd v1 over TCP");
     }
 
     /* Wait for all registrations to complete */
@@ -223,7 +229,9 @@ register_nfs_rpc_services(int lockmgr_port)
 } /* register_nfs_rpc_services */
 
 void
-unregister_nfs_rpc_services(int lockmgr_port)
+unregister_nfs_rpc_services(
+    int lockmgr_port,
+    int nsm_port)
 {
     struct portmap_reg_ctx ctx;
 
@@ -238,6 +246,10 @@ unregister_nfs_rpc_services(int lockmgr_port)
 
     if (lockmgr_port > 0) {
         unregister_service(&ctx, NFS_NLM_PROGRAM, 4, "NLM v4 over TCP");
+    }
+
+    if (nsm_port > 0) {
+        unregister_service(&ctx, NFS_NSM_PROGRAM, 1, "NSM/statd v1 over TCP");
     }
 
     /* Wait for all unregistrations to complete */

--- a/src/server/nfs/nfs_external_portmap.h
+++ b/src/server/nfs/nfs_external_portmap.h
@@ -10,9 +10,12 @@
 #define NFS_RPC_PROGRAM   100003
 #define NFS_MOUNT_PROGRAM 100005
 #define NFS_NLM_PROGRAM   100021
+#define NFS_NSM_PROGRAM   100024
 
 void register_nfs_rpc_services(
-    int lockmgr_port);
+    int lockmgr_port,
+    int nsm_port);
 
 void unregister_nfs_rpc_services(
-    int lockmgr_port);
+    int lockmgr_port,
+    int nsm_port);

--- a/src/server/nfs/nfs_kv_keys.h
+++ b/src/server/nfs/nfs_kv_keys.h
@@ -39,7 +39,9 @@ enum chimera_kv_record_type {
     CHIMERA_KV_TYPE_NFS4_SESSION  = 0x03, /* session metadata (nfs4_drc only)   */
     CHIMERA_KV_TYPE_NFS4_REPLY    = 0x04, /* reply-cache slot entry (nfs4_drc)  */
     CHIMERA_KV_TYPE_NFS3_REPLY    = 0x05, /* NFSv3 DRC reply entry (nfs3_drc)   */
-    /* 0x06 .. 0xFE reserved for future global record types */
+    CHIMERA_KV_TYPE_NSM_STATE     = 0x06, /* singleton NSM/statd state number   */
+    CHIMERA_KV_TYPE_NSM_MONITOR   = 0x07, /* per-host NSM monitor (nfs_nsm)     */
+    /* 0x08 .. 0xFE reserved for future global record types */
 };
 
 /* Longest normalized client address string an NFSv3 DRC key embeds (IPv6
@@ -200,3 +202,32 @@ nfs_kv_nfs3_reply_key(
 
 #define CHIMERA_KV_NFS3_REPLY_KEY_MAX \
         (CHIMERA_KV_HDR_LEN + 1 + CHIMERA_KV_NFS3_ADDR_MAX + 4 + 4 + 8)
+
+/* NSM singleton state-number key = header + a fixed 0x00 sub-id (mirrors the
+ * NFSv4 epoch key).  Value = magic(LE32) + version(LE32) + state(LE32). */
+static inline uint32_t
+nfs_kv_nsm_state_key(uint8_t *buf)
+{
+    uint32_t p = nfs_kv_hdr(buf, CHIMERA_KV_TYPE_NSM_STATE);
+
+    buf[p] = 0x00;
+    return p + 1;
+} /* nfs_kv_nsm_state_key */
+
+#define CHIMERA_KV_NSM_STATE_KEY_LEN (CHIMERA_KV_HDR_LEN + 1)
+
+/* NSM monitor key = header + host name bytes (the NLM caller_name / mon_name,
+ * the same stable identity a peer's statd presents in SM_NOTIFY).  Value =
+ * magic(LE32) + flags(LE32) + addr_len(1) + addr[addr_len] (the peer IP, no
+ * port -- how we reach its statd on our reboot). */
+static inline uint32_t
+nfs_kv_nsm_monitor_key(
+    uint8_t       *buf,
+    const uint8_t *host,
+    uint32_t       host_len)
+{
+    uint32_t p = nfs_kv_hdr(buf, CHIMERA_KV_TYPE_NSM_MONITOR);
+
+    memcpy(buf + p, host, host_len);
+    return p + host_len;
+} /* nfs_kv_nsm_monitor_key */

--- a/src/server/nfs/nfs_nlm.c
+++ b/src/server/nfs/nfs_nlm.c
@@ -11,9 +11,37 @@
 #include "nfs_internal.h"
 #include "nfs_nlm.h"
 #include "nfs_nlm_state.h"
+#include "nfs_nsm.h"
 #include "vfs/vfs_procs.h"
 #include "vfs/vfs_release.h"
 #include "vfs/vfs_state.h"
+
+/* Peer IP of an NLM connection with the ephemeral port stripped, written as a
+ * C-string into out (size bytes).  Handles both "ipv4:port" and "[ipv6]:port".
+ * Used to record where a lock-holder's statd can be reached (NSM monitor). */
+static void
+nlm_conn_peer_addr(
+    struct evpl_rpc2_conn *conn,
+    char                  *out,
+    int                    size)
+{
+    char  *p;
+    size_t n;
+
+    evpl_rpc2_conn_get_remote_address(conn, out, size);
+
+    if (out[0] == '[') {
+        p = strchr(out, ']');
+        n = p ? (size_t) (p - (out + 1)) : strlen(out);
+        memmove(out, out + 1, n);
+        out[n] = '\0';
+    } else {
+        p = strrchr(out, ':');
+        if (p) {
+            *p = '\0';
+        }
+    }
+} /* nlm_conn_peer_addr */
 
 /* Convert NLM length (UINT64_MAX == to-EOF) to POSIX length (0 == to-EOF) */
 #define NLM_TO_POSIX_LEN(l)     ((l) == UINT64_MAX ? 0 : (l))
@@ -251,6 +279,15 @@ chimera_nfs_nlm4_lock_acquire_cb(
         entry->lease_inserted = true;
         pthread_mutex_unlock(&shared->nlm_state.mutex);
         res.stat = NLM4_GRANTED;
+
+        /* Monitor the lock holder so we can SM_NOTIFY it to reclaim if we
+        * reboot.  NM_LOCK is explicitly non-monitored, so it opts out. */
+        if (!ctx->nm_lock) {
+            char addr[80];
+
+            nlm_conn_peer_addr(ctx->conn, addr, sizeof(addr));
+            nsm_monitor(thread, ctx->client->hostname, addr);
+        }
     } else {
         /* DENIED or wait=false-with-BREAKING: drop the entry. */
         pthread_mutex_lock(&shared->nlm_state.mutex);
@@ -1306,6 +1343,8 @@ chimera_nfs_nlm4_free_all(
     /* Remove on-disk state outside the mutex to avoid blocking I/O under lock */
     if (client) {
         nlm_state_remove_client_file(&shared->nlm_state, safe_hostname);
+        /* All of this client's locks are gone; stop monitoring it for reboot. */
+        nsm_unmonitor(thread, safe_hostname);
     }
 
     rc = shared->nlm_v4.send_reply_NLMPROC4_FREE_ALL(evpl, NULL, encoding);

--- a/src/server/nfs/nfs_nlm_state.h
+++ b/src/server/nfs/nfs_nlm_state.h
@@ -128,6 +128,28 @@ nlm_state_in_grace(struct nlm_state *state)
 } /* nlm_state_in_grace */
 
 /*
+ * Open the post-restart grace window: only reclaim locks are accepted until it
+ * lazily expires (nlm_state_in_grace) NLM_GRACE_PERIOD_SECS from now.  Called
+ * from single-threaded server init, or otherwise with state->mutex held.
+ */
+static inline void
+nlm_state_begin_grace(struct nlm_state *state)
+{
+    state->in_grace  = 1;
+    state->grace_end = time(NULL) + NLM_GRACE_PERIOD_SECS;
+} /* nlm_state_begin_grace */
+
+/*
+ * Close the grace window early (nothing left to reclaim).  Called from
+ * single-threaded server init, or otherwise with state->mutex held.
+ */
+static inline void
+nlm_state_end_grace(struct nlm_state *state)
+{
+    state->in_grace = 0;
+} /* nlm_state_end_grace */
+
+/*
  * Allocate and zero a new lock entry.
  */
 static inline struct nlm_lock_entry *

--- a/src/server/nfs/nfs_nsm.c
+++ b/src/server/nfs/nfs_nsm.c
@@ -1,0 +1,740 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include <string.h>
+#include <stdlib.h>
+#include <stdatomic.h>
+#include <pthread.h>
+#include <time.h>
+
+#include "nfs_common.h"
+#include "nfs_internal.h"
+#include "nfs_nsm.h"
+#include "nfs_nsm_state.h"
+#include "nfs_nlm_state.h"
+#include "nfs_kv_keys.h"
+#include "portmap_xdr.h"
+#include "vfs/vfs_procs.h"
+#include "evpl/evpl.h"
+#include "evpl/evpl_rpc2.h"
+
+/* ------------------------------------------------------------------ *
+*  KV persistence (fire-and-forget, heap ctx freed in the callback)   *
+* ------------------------------------------------------------------ */
+
+struct nsm_kv_ctx {
+    uint8_t  key[CHIMERA_KV_HDR_LEN + SM_MAXSTRLEN];
+    uint32_t key_len;
+    uint8_t  value[NSM_MON_VALUE_MAX > NSM_STATE_VALUE_LEN ?
+                   NSM_MON_VALUE_MAX : NSM_STATE_VALUE_LEN];
+    uint32_t value_len;
+};
+
+static void
+nsm_kv_done(
+    enum chimera_vfs_error error_code,
+    void                  *private_data)
+{
+    (void) error_code;
+    free(private_data);
+} /* nsm_kv_done */
+
+static void
+nsm_state_persist(
+    struct chimera_vfs_thread *vfs_thread,
+    uint32_t                   state_number)
+{
+    struct nsm_kv_ctx *ctx = malloc(sizeof(*ctx));
+
+    ctx->key_len   = nfs_kv_nsm_state_key(ctx->key);
+    ctx->value_len = nsm_state_value_serialize(ctx->value, sizeof(ctx->value),
+                                               state_number);
+    chimera_vfs_put_key(vfs_thread, ctx->key, ctx->key_len,
+                        ctx->value, ctx->value_len, nsm_kv_done, ctx);
+} /* nsm_state_persist */
+
+void
+nsm_monitor(
+    struct chimera_server_nfs_thread *thread,
+    const char                       *host,
+    const char                       *peer_addr)
+{
+    struct nsm_state  *nsm = &thread->shared->nsm_state;
+    struct nsm_kv_ctx *ctx;
+    size_t             host_len;
+    int                changed;
+
+    pthread_mutex_lock(&nsm->mutex);
+    changed = nsm_monitor_set(nsm, host, peer_addr);
+    pthread_mutex_unlock(&nsm->mutex);
+
+    /* Only persist on first sight or an address change, so a lock-heavy client
+     * does not hammer the KV store. */
+    if (!changed || nsm->persistence_disabled) {
+        return;
+    }
+
+    host_len = strnlen(host, SM_MAXSTRLEN);
+
+    ctx          = malloc(sizeof(*ctx));
+    ctx->key_len = nfs_kv_nsm_monitor_key(ctx->key, (const uint8_t *) host,
+                                          host_len);
+    ctx->value_len = nsm_monitor_value_serialize(ctx->value, sizeof(ctx->value),
+                                                 peer_addr);
+    chimera_vfs_put_key(thread->vfs_thread, ctx->key, ctx->key_len,
+                        ctx->value, ctx->value_len, nsm_kv_done, ctx);
+} /* nsm_monitor */
+
+void
+nsm_unmonitor(
+    struct chimera_server_nfs_thread *thread,
+    const char                       *host)
+{
+    struct nsm_state  *nsm = &thread->shared->nsm_state;
+    struct nsm_kv_ctx *ctx;
+    size_t             host_len;
+    int                removed;
+
+    pthread_mutex_lock(&nsm->mutex);
+    removed = nsm_monitor_remove(nsm, host);
+    pthread_mutex_unlock(&nsm->mutex);
+
+    if (!removed || nsm->persistence_disabled) {
+        return;
+    }
+
+    host_len     = strnlen(host, SM_MAXSTRLEN);
+    ctx          = malloc(sizeof(*ctx));
+    ctx->key_len = nfs_kv_nsm_monitor_key(ctx->key, (const uint8_t *) host,
+                                          host_len);
+    chimera_vfs_delete_key(thread->vfs_thread, ctx->key, ctx->key_len,
+                           nsm_kv_done, ctx);
+} /* nsm_unmonitor */
+
+/* ------------------------------------------------------------------ *
+*  reboot-notify client (runs on a dedicated short-lived evpl thread) *
+* ------------------------------------------------------------------ */
+
+#define NSM_NOTIFY_TIMEOUT_SECS 5
+
+struct nsm_notify_job {
+    struct nsm_notify_target *targets;
+    uint32_t                  count;
+    uint32_t                  state;
+    char                      my_name[SM_MAXSTRLEN + 1];
+};
+
+struct nsm_getport_result {
+    unsigned int port;
+    int          done;
+};
+
+static void
+nsm_getport_cb(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    unsigned int                 port,
+    int                          status,
+    void                        *private_data)
+{
+    struct nsm_getport_result *g = private_data;
+
+    g->port = (status == 0) ? port : 0;
+    g->done = 1;
+} /* nsm_getport_cb */
+
+static void
+nsm_notify_reply_cb(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    int                          status,
+    void                        *private_data)
+{
+    int *done = private_data;
+
+    (void) status;
+    *done = 1;
+} /* nsm_notify_reply_cb */
+
+/* Pump the dedicated evpl until *flag is set or the timeout elapses, so an
+ * unreachable host cannot wedge the notify loop forever. */
+static void
+nsm_pump_until(
+    struct evpl *evpl,
+    const int   *flag)
+{
+    time_t deadline = time(NULL) + NSM_NOTIFY_TIMEOUT_SECS;
+
+    while (!*flag && time(NULL) < deadline) {
+        evpl_continue(evpl);
+    }
+} /* nsm_pump_until */
+
+static void
+nsm_notify_one(
+    struct evpl                    *evpl,
+    struct evpl_rpc2_thread        *rpc2_thread,
+    struct PORTMAP_V2              *pm,
+    struct SM_INTER_V1             *sm,
+    const struct nsm_notify_target *t,
+    const char                     *my_name,
+    uint32_t                        state)
+{
+    struct evpl_endpoint     *ep;
+    struct evpl_rpc2_conn    *conn;
+    struct mapping            mapping;
+    struct nsm_getport_result g = { 0 };
+    struct stat_chge          arg;
+    int                       done = 0;
+
+    /* Resolve the peer's statd port via its portmapper. */
+    ep   = evpl_endpoint_create(t->addr, 111);
+    conn = evpl_rpc2_client_connect(rpc2_thread, EVPL_STREAM_SOCKET_TCP, ep,
+                                    NULL, 0, NULL);
+    if (!conn) {
+        evpl_endpoint_close(ep);
+        chimera_nfs_info("NSM notify: cannot reach portmap at %s", t->addr);
+        return;
+    }
+
+    mapping.prog = 100024;
+    mapping.vers = 1;
+    mapping.prot = 6;
+    mapping.port = 0;
+    pm->send_call_PMAPPROC_GETPORT(&pm->rpc2, evpl, conn, NULL, &mapping,
+                                   0, 0, NULL, 0, 0, nsm_getport_cb, &g);
+    nsm_pump_until(evpl, &g.done);
+    evpl_rpc2_client_disconnect(rpc2_thread, conn);
+    evpl_endpoint_close(ep);
+
+    if (!g.done || g.port == 0) {
+        chimera_nfs_info("NSM notify: host '%s' (%s) has no statd registered; "
+                         "skipping", t->host, t->addr);
+        return;
+    }
+
+    /* Tell the peer's statd that we (mon_name) restarted with `state`. */
+    ep   = evpl_endpoint_create(t->addr, g.port);
+    conn = evpl_rpc2_client_connect(rpc2_thread, EVPL_STREAM_SOCKET_TCP, ep,
+                                    NULL, 0, NULL);
+    if (!conn) {
+        evpl_endpoint_close(ep);
+        return;
+    }
+
+    arg.mon_name.str = (char *) my_name;
+    arg.mon_name.len = strlen(my_name);
+    arg.state        = (int) state;
+    sm->send_call_SM_NOTIFY(&sm->rpc2, evpl, conn, NULL, &arg,
+                            0, 0, NULL, 0, 0, nsm_notify_reply_cb, &done);
+    nsm_pump_until(evpl, &done);
+    evpl_rpc2_client_disconnect(rpc2_thread, conn);
+    evpl_endpoint_close(ep);
+
+    chimera_nfs_info("NSM notify: told host '%s' (%s:%u) we restarted (state %u)",
+                     t->host, t->addr, g.port, state);
+} /* nsm_notify_one */
+
+static void *
+nsm_notify_thread_init(
+    struct evpl *evpl,
+    void        *private_data)
+{
+    struct nsm_notify_job    *job = private_data;
+    struct evpl_rpc2_thread  *rpc2_thread;
+    struct PORTMAP_V2         pm;
+    struct SM_INTER_V1        sm;
+    struct evpl_rpc2_program *programs[2];
+    uint32_t                  i;
+
+    /* Outbound-only client programs; replies are matched by this rpc2 thread. */
+    PORTMAP_V2_init(&pm);
+    SM_INTER_V1_init(&sm);
+    programs[0] = &pm.rpc2;
+    programs[1] = &sm.rpc2;
+    rpc2_thread = evpl_rpc2_thread_init(evpl, programs, 2, NULL, NULL);
+
+    chimera_nfs_info("NSM: notifying %u monitored host(s) of restart (state %u)",
+                     job->count, job->state);
+
+    /* All work is synchronous (each call self-pumps the dedicated evpl), so it
+     * completes here before the framework's own idle loop starts. */
+    for (i = 0; i < job->count; i++) {
+        nsm_notify_one(evpl, rpc2_thread, &pm, &sm, &job->targets[i],
+                       job->my_name, job->state);
+    }
+
+    evpl_rpc2_thread_destroy(rpc2_thread);
+    return job;
+} /* nsm_notify_thread_init */
+
+static void
+nsm_notify_thread_shutdown(
+    struct evpl *evpl,
+    void        *private_data)
+{
+    struct nsm_notify_job *job = private_data;
+
+    (void) evpl;
+    free(job->targets);
+    free(job);
+} /* nsm_notify_thread_shutdown */
+
+/* Snapshot the monitor list and, if non-empty, spawn the reboot-notify worker.
+ * A previously-spawned (idle, work-already-done) worker is reaped first. */
+static void
+nsm_spawn_notify(
+    struct chimera_server_nfs_thread *thread,
+    uint32_t                          state)
+{
+    struct nsm_state         *nsm = &thread->shared->nsm_state;
+    struct nsm_notify_job    *job;
+    struct nsm_notify_target *targets;
+    uint32_t                  count;
+    struct evpl_thread       *old;
+
+    pthread_mutex_lock(&nsm->mutex);
+    count = nsm_monitors_snapshot(nsm, &targets);
+    pthread_mutex_unlock(&nsm->mutex);
+
+    if (count == 0) {
+        return;
+    }
+
+    job          = malloc(sizeof(*job));
+    job->targets = targets;
+    job->count   = count;
+    job->state   = state;
+    snprintf(job->my_name, sizeof(job->my_name), "%s", nsm->my_name);
+
+    pthread_mutex_lock(&nsm->mutex);
+    old                = nsm->notify_thread;
+    nsm->notify_thread = evpl_thread_create(NULL, nsm_notify_thread_init,
+                                            nsm_notify_thread_shutdown, job);
+    pthread_mutex_unlock(&nsm->mutex);
+
+    if (old) {
+        evpl_thread_destroy(old);
+    }
+} /* nsm_spawn_notify */
+
+/* ------------------------------------------------------------------ *
+*  cold-start load (state bump + monitor reload) -> reboot notify     *
+* ------------------------------------------------------------------ */
+
+struct nsm_load_ctx {
+    struct chimera_server_nfs_thread *thread;
+    uint32_t                          state;
+    /* Keys handed to the async KV layer must outlive the call -- keep them in
+     * this heap ctx, not on the stack. */
+    uint8_t                           skey[CHIMERA_KV_NSM_STATE_KEY_LEN];
+    uint8_t                           start[CHIMERA_KV_HDR_LEN];
+};
+
+static int
+nsm_monitor_scan_cb(
+    const void *key,
+    uint32_t    key_len,
+    const void *value,
+    uint32_t    value_len,
+    void       *private_data)
+{
+    struct nsm_load_ctx *ctx = private_data;
+    struct nsm_state    *nsm = &ctx->thread->shared->nsm_state;
+    const uint8_t       *k   = key;
+    char                 host[SM_MAXSTRLEN + 1];
+    char                 addr[CHIMERA_NSM_ADDR_MAX];
+    uint32_t             host_len;
+
+    /* Keys arrive in order; stop once we leave the monitor type band. */
+    if (key_len < CHIMERA_KV_HDR_LEN ||
+        memcmp(k, ctx->start, CHIMERA_KV_HDR_LEN) != 0) {
+        return 1;
+    }
+
+    host_len = key_len - CHIMERA_KV_HDR_LEN;
+    if (host_len == 0 || host_len > SM_MAXSTRLEN) {
+        return 0;  /* skip a malformed key */
+    }
+    memcpy(host, k + CHIMERA_KV_HDR_LEN, host_len);
+    host[host_len] = '\0';
+
+    if (nsm_monitor_value_parse(value, value_len, addr, sizeof(addr)) != 0) {
+        return 0;  /* skip a corrupt value */
+    }
+
+    pthread_mutex_lock(&nsm->mutex);
+    nsm_monitor_set(nsm, host, addr);
+    pthread_mutex_unlock(&nsm->mutex);
+    return 0;
+} /* nsm_monitor_scan_cb */
+
+static void
+nsm_monitor_scan_complete(
+    enum chimera_vfs_error error_code,
+    void                  *private_data)
+{
+    struct nsm_load_ctx              *ctx    = private_data;
+    struct chimera_server_nfs_thread *thread = ctx->thread;
+    struct nsm_state                 *nsm    = &thread->shared->nsm_state;
+    uint32_t                          count;
+
+    (void) error_code;
+
+    pthread_mutex_lock(&nsm->mutex);
+    count = HASH_COUNT(nsm->monitors);
+    pthread_mutex_unlock(&nsm->mutex);
+
+    if (count == 0) {
+        /* Nothing to reclaim -- end the forced grace window early so fresh
+         * locks are accepted immediately (matches the no-clients case). */
+        pthread_mutex_lock(&thread->shared->nlm_state.mutex);
+        nlm_state_end_grace(&thread->shared->nlm_state);
+        pthread_mutex_unlock(&thread->shared->nlm_state.mutex);
+        chimera_nfs_info("NSM cold-start: no monitored hosts; NLM grace ended early");
+    } else {
+        chimera_nfs_info("NSM cold-start: %u monitored host(s); notifying and "
+                         "holding NLM grace", count);
+        nsm_spawn_notify(thread, ctx->state);
+    }
+
+    atomic_store(&nsm->load_state, NSM_LOAD_READY);
+    free(ctx);
+} /* nsm_monitor_scan_complete */
+
+static void
+nsm_state_load_cb(
+    enum chimera_vfs_error error_code,
+    const void            *value,
+    uint32_t               value_len,
+    void                  *private_data)
+{
+    struct nsm_load_ctx              *ctx    = private_data;
+    struct chimera_server_nfs_thread *thread = ctx->thread;
+    struct nsm_state                 *nsm    = &thread->shared->nsm_state;
+    uint32_t                          prev   = 0;
+    uint32_t                          newstate;
+
+    if (error_code == CHIMERA_VFS_OK && value &&
+        nsm_state_value_parse(value, value_len, &prev) == 0) {
+        /* Smallest odd number strictly greater than prev (odd == "we are up"
+         * after a reboot -- the classic NSM state-number convention). */
+        newstate = nsm_next_state(prev);
+    } else {
+        newstate = 1;
+    }
+
+    pthread_mutex_lock(&nsm->mutex);
+    nsm->state_number = newstate;
+    pthread_mutex_unlock(&nsm->mutex);
+    ctx->state = newstate;
+
+    chimera_nfs_info("NSM cold-start: state number %u -> %u", prev, newstate);
+
+    nsm_state_persist(thread->vfs_thread, newstate);
+
+    /* Open-ended scan of the monitor band; nsm_monitor_scan_cb stops when the
+     * 3-byte type header changes (the same pattern recovery/DRC use). */
+    nfs_kv_type_prefix(ctx->start, CHIMERA_KV_TYPE_NSM_MONITOR);
+    chimera_vfs_search_keys(thread->vfs_thread,
+                            ctx->start, CHIMERA_KV_HDR_LEN,
+                            NULL, 0, 0,
+                            nsm_monitor_scan_cb,
+                            nsm_monitor_scan_complete, ctx);
+} /* nsm_state_load_cb */
+
+void
+chimera_nfs_nsm_kickoff(struct chimera_server_nfs_thread *thread)
+{
+    struct nsm_state    *nsm = &thread->shared->nsm_state;
+    struct nsm_load_ctx *ctx;
+    int                  expected = NSM_LOAD_IDLE;
+    uint32_t             klen;
+
+    if (nsm->persistence_disabled) {
+        return;  /* non-persistent: monitor list was lost, nothing to notify */
+    }
+    if (atomic_load(&nsm->load_state) != NSM_LOAD_IDLE) {
+        return;
+    }
+    if (!atomic_compare_exchange_strong(&nsm->load_state, &expected,
+                                        NSM_LOAD_RUNNING)) {
+        return;
+    }
+
+    /* We own the load.  Read the persisted state number first; the rest of the
+     * chain (bump+persist, monitor scan, notify) runs as async callbacks on
+     * this thread's vfs_thread/evpl. */
+    ctx         = malloc(sizeof(*ctx));
+    ctx->thread = thread;
+    ctx->state  = 0;
+    klen        = nfs_kv_nsm_state_key(ctx->skey);
+    chimera_vfs_get_key(thread->vfs_thread, ctx->skey, klen,
+                        nsm_state_load_cb, ctx);
+} /* chimera_nfs_nsm_kickoff */
+
+void
+chimera_nfs_sm_null(
+    struct evpl               *evpl,
+    struct evpl_rpc2_conn     *conn,
+    struct evpl_rpc2_cred     *cred,
+    struct evpl_rpc2_encoding *encoding,
+    void                      *private_data)
+{
+    struct chimera_server_nfs_thread *thread = private_data;
+    struct chimera_server_nfs_shared *shared = thread->shared;
+    int                               rc;
+
+    chimera_nfs_debug("NSM NULL");
+
+    rc = shared->nsm_v1.send_reply_SM_NULL(evpl, NULL, encoding);
+    chimera_nfs_abort_if(rc, "Failed to send NSM NULL reply");
+} /* chimera_nfs_sm_null */
+
+void
+chimera_nfs_sm_stat(
+    struct evpl               *evpl,
+    struct evpl_rpc2_conn     *conn,
+    struct evpl_rpc2_cred     *cred,
+    struct sm_name            *args,
+    struct evpl_rpc2_encoding *encoding,
+    void                      *private_data)
+{
+    struct chimera_server_nfs_thread *thread = private_data;
+    struct chimera_server_nfs_shared *shared = thread->shared;
+    struct sm_stat_res                res;
+    int                               rc;
+
+    /* We do not actively probe peers; report that any host is monitorable. */
+    res.res_stat = STAT_SUCC;
+    res.state    = (int) nsm_state_current(&shared->nsm_state);
+
+    rc = shared->nsm_v1.send_reply_SM_STAT(evpl, NULL, &res, encoding);
+    chimera_nfs_abort_if(rc, "Failed to send NSM STAT reply");
+} /* chimera_nfs_sm_stat */
+
+void
+chimera_nfs_sm_mon(
+    struct evpl               *evpl,
+    struct evpl_rpc2_conn     *conn,
+    struct evpl_rpc2_cred     *cred,
+    struct mon                *args,
+    struct evpl_rpc2_encoding *encoding,
+    void                      *private_data)
+{
+    struct chimera_server_nfs_thread *thread = private_data;
+    struct chimera_server_nfs_shared *shared = thread->shared;
+    struct sm_stat_res                res;
+    int                               rc;
+
+    /* The authoritative monitor list is built from NLM lock grants (Phase 2),
+     * so SM_MON from a peer is accepted but not recorded here. */
+    res.res_stat = STAT_SUCC;
+    res.state    = (int) nsm_state_current(&shared->nsm_state);
+
+    rc = shared->nsm_v1.send_reply_SM_MON(evpl, NULL, &res, encoding);
+    chimera_nfs_abort_if(rc, "Failed to send NSM MON reply");
+} /* chimera_nfs_sm_mon */
+
+void
+chimera_nfs_sm_unmon(
+    struct evpl               *evpl,
+    struct evpl_rpc2_conn     *conn,
+    struct evpl_rpc2_cred     *cred,
+    struct mon_id             *args,
+    struct evpl_rpc2_encoding *encoding,
+    void                      *private_data)
+{
+    struct chimera_server_nfs_thread *thread = private_data;
+    struct chimera_server_nfs_shared *shared = thread->shared;
+    struct sm_stat                    res;
+    int                               rc;
+
+    res.state = (int) nsm_state_current(&shared->nsm_state);
+
+    rc = shared->nsm_v1.send_reply_SM_UNMON(evpl, NULL, &res, encoding);
+    chimera_nfs_abort_if(rc, "Failed to send NSM UNMON reply");
+} /* chimera_nfs_sm_unmon */
+
+void
+chimera_nfs_sm_unmon_all(
+    struct evpl               *evpl,
+    struct evpl_rpc2_conn     *conn,
+    struct evpl_rpc2_cred     *cred,
+    struct my_id              *args,
+    struct evpl_rpc2_encoding *encoding,
+    void                      *private_data)
+{
+    struct chimera_server_nfs_thread *thread = private_data;
+    struct chimera_server_nfs_shared *shared = thread->shared;
+    struct sm_stat                    res;
+    int                               rc;
+
+    res.state = (int) nsm_state_current(&shared->nsm_state);
+
+    rc = shared->nsm_v1.send_reply_SM_UNMON_ALL(evpl, NULL, &res, encoding);
+    chimera_nfs_abort_if(rc, "Failed to send NSM UNMON_ALL reply");
+} /* chimera_nfs_sm_unmon_all */
+
+void
+chimera_nfs_sm_simu_crash(
+    struct evpl               *evpl,
+    struct evpl_rpc2_conn     *conn,
+    struct evpl_rpc2_cred     *cred,
+    struct evpl_rpc2_encoding *encoding,
+    void                      *private_data)
+{
+    struct chimera_server_nfs_thread *thread = private_data;
+    struct chimera_server_nfs_shared *shared = thread->shared;
+    struct nsm_state                 *nsm    = &shared->nsm_state;
+    uint32_t                          newstate;
+    int                               rc;
+
+    /* Simulate a crash: bump our state number (keeping it odd), persist it, and
+     * tell every monitored host so they reclaim. */
+    pthread_mutex_lock(&nsm->mutex);
+    nsm->state_number += (nsm->state_number & 1) ? 2 : 1;
+    newstate           = nsm->state_number;
+    pthread_mutex_unlock(&nsm->mutex);
+
+    chimera_nfs_info("NSM SIMU_CRASH: bumped state to %u, notifying monitored hosts",
+                     newstate);
+
+    if (!nsm->persistence_disabled) {
+        nsm_state_persist(thread->vfs_thread, newstate);
+    }
+    nsm_spawn_notify(thread, newstate);
+
+    rc = shared->nsm_v1.send_reply_SM_SIMU_CRASH(evpl, NULL, encoding);
+    chimera_nfs_abort_if(rc, "Failed to send NSM SIMU_CRASH reply");
+} /* chimera_nfs_sm_simu_crash */
+
+/* Strip the ephemeral port from a connection's peer address into a C-string,
+ * matching how nfs_nlm.c records a monitor's reach-address. */
+static void
+nsm_conn_peer_addr(
+    struct evpl_rpc2_conn *conn,
+    char                  *out,
+    int                    size)
+{
+    char  *p;
+    size_t n;
+
+    evpl_rpc2_conn_get_remote_address(conn, out, size);
+
+    if (out[0] == '[') {
+        p = strchr(out, ']');
+        n = p ? (size_t) (p - (out + 1)) : strlen(out);
+        memmove(out, out + 1, n);
+        out[n] = '\0';
+    } else {
+        p = strrchr(out, ':');
+        if (p) {
+            *p = '\0';
+        }
+    }
+} /* nsm_conn_peer_addr */
+
+/* Release every NLM lock held by `host` (the NLMPROC4_FREE_ALL sequence).
+ * Returns 1 if a matching client was found.  Takes nlm_state.mutex internally
+ * and no other lock, so it is safe to call after dropping nsm_state.mutex. */
+static int
+nsm_release_host_locks(
+    struct chimera_server_nfs_thread *thread,
+    const char                       *host)
+{
+    struct chimera_server_nfs_shared *shared = thread->shared;
+    struct nlm_client                *client;
+    struct chimera_vfs_cred           anon_cred;
+    int                               found = 0;
+
+    pthread_mutex_lock(&shared->nlm_state.mutex);
+    HASH_FIND_STR(shared->nlm_state.clients, host, client);
+    if (client) {
+        found = 1;
+        chimera_vfs_cred_init_anonymous(&anon_cred,
+                                        CHIMERA_VFS_ANON_UID,
+                                        CHIMERA_VFS_ANON_GID);
+        nlm_client_release_all_locks(&shared->nlm_state, client,
+                                     thread->vfs_thread,
+                                     thread->vfs->vfs_state,
+                                     &anon_cred);
+    }
+    pthread_mutex_unlock(&shared->nlm_state.mutex);
+    return found;
+} /* nsm_release_host_locks */
+
+#define NSM_NOTIFY_FALLBACK_MAX 32
+
+void
+chimera_nfs_sm_notify(
+    struct evpl               *evpl,
+    struct evpl_rpc2_conn     *conn,
+    struct evpl_rpc2_cred     *cred,
+    struct stat_chge          *args,
+    struct evpl_rpc2_encoding *encoding,
+    void                      *private_data)
+{
+    struct chimera_server_nfs_thread *thread = private_data;
+    struct chimera_server_nfs_shared *shared = thread->shared;
+    char                              host[SM_MAXSTRLEN + 1];
+    size_t                            hn_len;
+    int                               rc;
+
+    /* NUL-terminate the wire name for use as the NLM client hash key.  A peer's
+     * statd sends mon_name == the caller_name it used for its NLM locks, so the
+     * direct lookup mirrors NLMPROC4_FREE_ALL. */
+    hn_len = args->mon_name.len < SM_MAXSTRLEN ? args->mon_name.len : SM_MAXSTRLEN;
+    memcpy(host, args->mon_name.str, hn_len);
+    host[hn_len] = '\0';
+
+    chimera_nfs_info("NSM SM_NOTIFY: host '%s' restarted (state %d); releasing its locks",
+                     host, args->state);
+
+    if (nsm_release_host_locks(thread, host)) {
+        nsm_unmonitor(thread, host);
+    } else {
+        /* Fallback: the peer's statd may present a mon_name that differs from
+         * the caller_name it used for NLM.  Match monitored hosts by the
+         * notify's source IP instead.  Collect matches under nsm_state.mutex,
+         * then release outside it (nsm before nlm lock ordering). */
+        char                src[80];
+        char                matched[NSM_NOTIFY_FALLBACK_MAX][SM_MAXSTRLEN + 1];
+        struct nsm_monitor *mon, *tmp;
+        int                 n = 0, truncated = 0, i;
+
+        nsm_conn_peer_addr(conn, src, sizeof(src));
+
+        pthread_mutex_lock(&shared->nsm_state.mutex);
+        HASH_ITER(hh, shared->nsm_state.monitors, mon, tmp)
+        {
+            if (strcmp(mon->addr, src) != 0) {
+                continue;
+            }
+            if (n < NSM_NOTIFY_FALLBACK_MAX) {
+                snprintf(matched[n++], SM_MAXSTRLEN + 1, "%s", mon->host);
+            } else {
+                truncated = 1;
+            }
+        }
+        pthread_mutex_unlock(&shared->nsm_state.mutex);
+
+        if (truncated) {
+            chimera_nfs_info("NSM SM_NOTIFY: >%d monitored hosts at %s; releasing "
+                             "only the first %d", NSM_NOTIFY_FALLBACK_MAX, src,
+                             NSM_NOTIFY_FALLBACK_MAX);
+        }
+        for (i = 0; i < n; i++) {
+            chimera_nfs_info("NSM SM_NOTIFY: matched host '%s' by source IP %s; "
+                             "releasing its locks", matched[i], src);
+            nsm_release_host_locks(thread, matched[i]);
+            nsm_unmonitor(thread, matched[i]);
+        }
+    }
+
+    /* SM_NOTIFY is a void procedure (no reply body), but the RPC layer still
+     * expects an accepted-reply ack. */
+    rc = shared->nsm_v1.send_reply_SM_NOTIFY(evpl, NULL, encoding);
+    chimera_nfs_abort_if(rc, "Failed to send NSM NOTIFY reply");
+} /* chimera_nfs_sm_notify */

--- a/src/server/nfs/nfs_nsm.h
+++ b/src/server/nfs/nfs_nsm.h
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#pragma once
+
+#include "sm_inter_xdr.h"
+
+struct chimera_server_nfs_thread;
+
+/*
+ * Record `host` (an NLM caller_name) as a monitored peer reachable at
+ * `peer_addr`, persisting it to the KV store when the backend is persistent.
+ * Called from the NLM lock-grant success path; idempotent and cheap (only
+ * writes KV on first sight or an address change).
+ */
+void
+nsm_monitor(
+    struct chimera_server_nfs_thread *thread,
+    const char                       *host,
+    const char                       *peer_addr);
+
+/*
+ * Stop monitoring `host` and drop its persisted record.  Called when all of a
+ * client's NLM locks are released at once (FREE_ALL, last-connection
+ * disconnect, or SM_NOTIFY), so we no longer need to notify it on our reboot.
+ */
+void
+nsm_unmonitor(
+    struct chimera_server_nfs_thread *thread,
+    const char                       *host);
+
+/*
+ * Run-once cold-start load (atomic IDLE->RUNNING CAS), triggered from per-thread
+ * init on a persistent backend: bump+persist the NSM state number, reload the
+ * monitor list, and -- off the server threads -- send SM_NOTIFY to every
+ * monitored host so they reclaim their NLM locks during the grace window.
+ */
+void
+chimera_nfs_nsm_kickoff(
+    struct chimera_server_nfs_thread *thread);
+
+/* NSM / statd (program 100024 v1) RPC handlers.  SM_NOTIFY is the one that
+ * matters: it releases the rebooted peer's NLM locks (the FREE_ALL sequence).
+ * SM_STAT/SM_MON/SM_UNMON/SM_UNMON_ALL are implemented for protocol
+ * completeness; the authoritative monitor list is driven by NLM lock grants
+ * (see nsm_monitor, Phase 2), not by peers calling SM_MON. */
+
+void chimera_nfs_sm_null(
+    struct evpl               *evpl,
+    struct evpl_rpc2_conn     *conn,
+    struct evpl_rpc2_cred     *cred,
+    struct evpl_rpc2_encoding *encoding,
+    void                      *private_data);
+
+void chimera_nfs_sm_stat(
+    struct evpl               *evpl,
+    struct evpl_rpc2_conn     *conn,
+    struct evpl_rpc2_cred     *cred,
+    struct sm_name            *args,
+    struct evpl_rpc2_encoding *encoding,
+    void                      *private_data);
+
+void chimera_nfs_sm_mon(
+    struct evpl               *evpl,
+    struct evpl_rpc2_conn     *conn,
+    struct evpl_rpc2_cred     *cred,
+    struct mon                *args,
+    struct evpl_rpc2_encoding *encoding,
+    void                      *private_data);
+
+void chimera_nfs_sm_unmon(
+    struct evpl               *evpl,
+    struct evpl_rpc2_conn     *conn,
+    struct evpl_rpc2_cred     *cred,
+    struct mon_id             *args,
+    struct evpl_rpc2_encoding *encoding,
+    void                      *private_data);
+
+void chimera_nfs_sm_unmon_all(
+    struct evpl               *evpl,
+    struct evpl_rpc2_conn     *conn,
+    struct evpl_rpc2_cred     *cred,
+    struct my_id              *args,
+    struct evpl_rpc2_encoding *encoding,
+    void                      *private_data);
+
+void chimera_nfs_sm_simu_crash(
+    struct evpl               *evpl,
+    struct evpl_rpc2_conn     *conn,
+    struct evpl_rpc2_cred     *cred,
+    struct evpl_rpc2_encoding *encoding,
+    void                      *private_data);
+
+void chimera_nfs_sm_notify(
+    struct evpl               *evpl,
+    struct evpl_rpc2_conn     *conn,
+    struct evpl_rpc2_cred     *cred,
+    struct stat_chge          *args,
+    struct evpl_rpc2_encoding *encoding,
+    void                      *private_data);

--- a/src/server/nfs/nfs_nsm_state.c
+++ b/src/server/nfs/nfs_nsm_state.c
@@ -1,0 +1,206 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "nfs_nsm_state.h"
+#include "nfs_kv_keys.h"
+#include "nfs_internal.h"
+
+void
+nsm_state_init(
+    struct nsm_state   *state,
+    struct chimera_vfs *vfs)
+{
+    const char *kvname = (vfs && vfs->kv_module) ? vfs->kv_module->name : "";
+
+    pthread_mutex_init(&state->mutex, NULL);
+    state->monitors             = NULL;
+    state->state_number         = 1;  /* odd == up; refined by the cold-start load */
+    state->persistence_disabled = (strcmp(kvname, "memkv") == 0);
+    atomic_store(&state->load_state, NSM_LOAD_IDLE);
+    state->notify_thread = NULL;
+
+    if (gethostname(state->my_name, sizeof(state->my_name)) != 0) {
+        snprintf(state->my_name, sizeof(state->my_name), "localhost");
+    }
+    state->my_name[sizeof(state->my_name) - 1] = '\0';
+
+    chimera_nfs_debug("NSM state init: my_name='%s' persistence=%s",
+                      state->my_name,
+                      state->persistence_disabled ? "disabled" : "enabled");
+} /* nsm_state_init */
+
+void
+nsm_state_destroy(struct nsm_state *state)
+{
+#ifndef __clang_analyzer__
+
+    /* HASH_DEL trips the analyzer's use-after-free checker; guard it the same
+     * way the other NFS hash-table teardowns do. */
+    struct nsm_monitor *mon, *tmp;
+
+    HASH_ITER(hh, state->monitors, mon, tmp)
+    {
+        HASH_DEL(state->monitors, mon);
+        free(mon);
+    }
+
+#endif /* ifndef __clang_analyzer__ */
+
+    pthread_mutex_destroy(&state->mutex);
+} /* nsm_state_destroy */
+
+uint32_t
+nsm_state_current(struct nsm_state *state)
+{
+    uint32_t n;
+
+    pthread_mutex_lock(&state->mutex);
+    n = state->state_number;
+    pthread_mutex_unlock(&state->mutex);
+    return n;
+} /* nsm_state_current */
+
+int
+nsm_monitor_set(
+    struct nsm_state *state,
+    const char       *host,
+    const char       *addr)
+{
+    struct nsm_monitor *mon;
+
+    HASH_FIND_STR(state->monitors, host, mon);
+    if (mon) {
+        if (strncmp(mon->addr, addr, sizeof(mon->addr)) == 0) {
+            return 0;  /* unchanged */
+        }
+        snprintf(mon->addr, sizeof(mon->addr), "%s", addr);
+        return 1;
+    }
+
+    mon = calloc(1, sizeof(*mon));
+    snprintf(mon->host, sizeof(mon->host), "%s", host);
+    snprintf(mon->addr, sizeof(mon->addr), "%s", addr);
+    HASH_ADD_STR(state->monitors, host, mon);
+    return 1;
+} /* nsm_monitor_set */
+
+int
+nsm_monitor_remove(
+    struct nsm_state *state,
+    const char       *host)
+{
+    struct nsm_monitor *mon;
+
+    HASH_FIND_STR(state->monitors, host, mon);
+    if (!mon) {
+        return 0;
+    }
+    HASH_DEL(state->monitors, mon);
+    free(mon);
+    return 1;
+} /* nsm_monitor_remove */
+
+uint32_t
+nsm_monitors_snapshot(
+    struct nsm_state          *state,
+    struct nsm_notify_target **out)
+{
+    struct nsm_monitor       *mon, *tmp;
+    struct nsm_notify_target *arr;
+    uint32_t                  count = HASH_COUNT(state->monitors);
+    uint32_t                  i     = 0;
+
+    *out = NULL;
+    if (count == 0) {
+        return 0;
+    }
+
+    arr = calloc(count, sizeof(*arr));
+    HASH_ITER(hh, state->monitors, mon, tmp)
+    {
+        snprintf(arr[i].host, sizeof(arr[i].host), "%s", mon->host);
+        snprintf(arr[i].addr, sizeof(arr[i].addr), "%s", mon->addr);
+        i++;
+    }
+    *out = arr;
+    return count;
+} /* nsm_monitors_snapshot */
+
+uint32_t
+nsm_state_value_serialize(
+    uint8_t *buf,
+    uint32_t buf_size,
+    uint32_t state_number)
+{
+    uint32_t p = 0;
+
+    if (buf_size < NSM_STATE_VALUE_LEN) {
+        return 0;
+    }
+    nfs_kv_put_le32(buf, &p, NSM_STATE_MAGIC);
+    nfs_kv_put_le32(buf, &p, 0 /* version */);
+    nfs_kv_put_le32(buf, &p, state_number);
+    return p;
+} /* nsm_state_value_serialize */
+
+int
+nsm_state_value_parse(
+    const uint8_t *buf,
+    uint32_t       len,
+    uint32_t      *out_state)
+{
+    if (len < NSM_STATE_VALUE_LEN || nfs_kv_le32(buf) != NSM_STATE_MAGIC) {
+        return -1;
+    }
+    *out_state = nfs_kv_le32(buf + 8);
+    return 0;
+} /* nsm_state_value_parse */
+
+uint32_t
+nsm_monitor_value_serialize(
+    uint8_t    *buf,
+    uint32_t    buf_size,
+    const char *addr)
+{
+    uint32_t p        = 0;
+    size_t   addr_len = strlen(addr);
+
+    if (addr_len > CHIMERA_NSM_ADDR_MAX) {
+        addr_len = CHIMERA_NSM_ADDR_MAX;
+    }
+    if (buf_size < 4 + 4 + 1 + addr_len) {
+        return 0;
+    }
+    nfs_kv_put_le32(buf, &p, NSM_MON_MAGIC);
+    nfs_kv_put_le32(buf, &p, 0 /* flags */);
+    buf[p++] = (uint8_t) addr_len;
+    memcpy(buf + p, addr, addr_len);
+    return p + addr_len;
+} /* nsm_monitor_value_serialize */
+
+int
+nsm_monitor_value_parse(
+    const uint8_t *buf,
+    uint32_t       len,
+    char          *addr_out,
+    size_t         addr_out_size)
+{
+    uint8_t addr_len;
+
+    if (len < 9 || nfs_kv_le32(buf) != NSM_MON_MAGIC) {
+        return -1;
+    }
+    addr_len = buf[8];
+    if (addr_len > CHIMERA_NSM_ADDR_MAX || (uint32_t) 9 + addr_len > len ||
+        addr_len + 1u > addr_out_size) {
+        return -1;
+    }
+    memcpy(addr_out, buf + 9, addr_len);
+    addr_out[addr_len] = '\0';
+    return 0;
+} /* nsm_monitor_value_parse */

--- a/src/server/nfs/nfs_nsm_state.h
+++ b/src/server/nfs/nfs_nsm_state.h
@@ -1,0 +1,154 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#pragma once
+
+#include <stdint.h>
+#include <stdatomic.h>
+#include <pthread.h>
+#include <uthash.h>
+
+#include "sm_inter_xdr.h"
+#include "vfs/vfs.h"
+
+struct evpl_thread;
+
+/* Longest peer-address literal an NSM monitor record stores (IPv6, no port --
+ * comfortably inside INET6_ADDRSTRLEN). */
+#define CHIMERA_NSM_ADDR_MAX 48u
+
+/* One-shot cold-start load state (mirrors the NFSv3 DRC reload machine): only
+ * one server thread loads the persisted state + sends reboot notifies. */
+enum nsm_load_state {
+    NSM_LOAD_IDLE = 0,
+    NSM_LOAD_RUNNING,
+    NSM_LOAD_READY,
+};
+
+/*
+ * One monitored peer.  Keyed by host name -- the same string a client presents
+ * as nlm4_lock.caller_name (and that its statd later sends as SM_NOTIFY
+ * mon_name), so the NSM monitor table and the NLM client table share a key
+ * space.  addr is how we reach that peer's statd on our reboot.
+ *
+ * The table is authoritatively driven by NLM lock grants (Phase 2), not by
+ * peers calling SM_MON: real NFS clients SM_MON their own *local* statd.
+ */
+struct nsm_monitor {
+    char           host[SM_MAXSTRLEN + 1];
+    char           addr[CHIMERA_NSM_ADDR_MAX];
+    UT_hash_handle hh;
+};
+
+/*
+ * Global NSM state shared across all server threads.  The monitor table and
+ * state number are guarded by mutex.  This lock is deliberately disjoint from
+ * nlm_state.mutex: nsm_monitor touches only this struct (+ async KV), while the
+ * SM_NOTIFY handler reads the host string off the wire and takes only
+ * nlm_state.mutex to release locks.  If both are ever needed, take this lock
+ * first and drop it before taking nlm_state.mutex.
+ */
+struct nsm_state {
+    pthread_mutex_t     mutex;
+    struct nsm_monitor *monitors;            /* uthash, keyed by host */
+    uint32_t            state_number;        /* monotonic; odd == "we are up" */
+    int                 persistence_disabled; /* 1 when kv_module is non-persistent */
+    _Atomic int         load_state;          /* enum nsm_load_state */
+    char                my_name[SM_MAXSTRLEN + 1]; /* our identity in SM_NOTIFY */
+    struct evpl_thread *notify_thread;       /* short-lived reboot-notify worker */
+};
+
+/* 4-byte record magics validated before trusting any persisted bytes. */
+#define NSM_STATE_MAGIC     0x4E534D53u /* "NSMS" */
+#define NSM_MON_MAGIC       0x4E534D4Du /* "NSMM" */
+
+/* state value: magic(4) version(4) state(4); monitor value: magic(4) flags(4)
+ * addr_len(1) addr[addr_len]. */
+#define NSM_STATE_VALUE_LEN 12u
+#define NSM_MON_VALUE_MAX   (4u + 4u + 1u + CHIMERA_NSM_ADDR_MAX)
+
+/* A monitored peer copied out of the table for the (off-thread) notify loop. */
+struct nsm_notify_target {
+    char host[SM_MAXSTRLEN + 1];
+    char addr[CHIMERA_NSM_ADDR_MAX];
+};
+
+void
+nsm_state_init(
+    struct nsm_state   *state,
+    struct chimera_vfs *vfs);
+
+void
+nsm_state_destroy(
+    struct nsm_state *state);
+
+/* Read the current NSM state number under the lock. */
+uint32_t
+nsm_state_current(
+    struct nsm_state *state);
+
+/* The next NSM state number after a (re)boot: the smallest odd value strictly
+ * greater than prev.  Odd == "host is up" -- the classic statd convention a
+ * peer uses to detect that we restarted. */
+static inline uint32_t
+nsm_next_state(uint32_t prev)
+{
+    return prev + ((prev & 1) ? 2 : 1);
+} /* nsm_next_state */
+
+/*
+ * Insert or refresh the monitor for `host` with reach-address `addr`.  Caller
+ * MUST hold state->mutex.  Returns 1 when the entry was newly created or its
+ * address changed (so the caller should persist it), 0 when unchanged.
+ */
+int
+nsm_monitor_set(
+    struct nsm_state *state,
+    const char       *host,
+    const char       *addr);
+
+/*
+ * Remove the monitor for `host`.  Caller MUST hold state->mutex.  Returns 1 if
+ * an entry was removed, 0 if none existed.
+ */
+int
+nsm_monitor_remove(
+    struct nsm_state *state,
+    const char       *host);
+
+/*
+ * Snapshot the monitor table into a freshly malloc'd array (caller frees).
+ * Caller MUST hold state->mutex.  Returns the entry count (0 => *out is NULL).
+ */
+uint32_t
+nsm_monitors_snapshot(
+    struct nsm_state          *state,
+    struct nsm_notify_target **out);
+
+/* KV value (de)serialization (little-endian).  serialize returns bytes written
+ * (0 on overflow); parse returns 0 on success, -1 on a bad/short/!magic value. */
+uint32_t
+nsm_state_value_serialize(
+    uint8_t *buf,
+    uint32_t buf_size,
+    uint32_t state_number);
+
+int
+nsm_state_value_parse(
+    const uint8_t *buf,
+    uint32_t       len,
+    uint32_t      *out_state);
+
+uint32_t
+nsm_monitor_value_serialize(
+    uint8_t    *buf,
+    uint32_t    buf_size,
+    const char *addr);
+
+int
+nsm_monitor_value_parse(
+    const uint8_t *buf,
+    uint32_t       len,
+    char          *addr_out,
+    size_t         addr_out_size);

--- a/src/server/nfs/nfs_portmap.c
+++ b/src/server/nfs/nfs_portmap.c
@@ -20,7 +20,7 @@ struct portmap_service {
     uint32_t port;    /* Port number */
 };
 
-#define num_portmap_services_MAX 8
+#define num_portmap_services_MAX 10
 
 static struct portmap_service portmap_services[num_portmap_services_MAX] = {
     /* Portmap/rpcbind - program 100000 */
@@ -187,6 +187,19 @@ portmap_set_nlm_port(uint32_t port)
     }
     portmap_services[num_portmap_services++] = (struct portmap_service) { 100021, 4, 6, port };
 } /* portmap_set_nlm_port */
+
+void
+portmap_set_nsm_port(uint32_t port)
+{
+    if (port == 0) {
+        return;
+    }
+    if (num_portmap_services >= num_portmap_services_MAX) {
+        chimera_nfs_error("portmap_set_nsm_port: no room in portmap_services table");
+        return;
+    }
+    portmap_services[num_portmap_services++] = (struct portmap_service) { 100024, 1, 6, port };
+} /* portmap_set_nsm_port */
 
 void
 chimera_portmap_null_v2(

--- a/src/server/nfs/nfs_portmap.h
+++ b/src/server/nfs/nfs_portmap.h
@@ -11,6 +11,9 @@
 void portmap_set_nlm_port(
     uint32_t port);
 
+void portmap_set_nsm_port(
+    uint32_t port);
+
 void chimera_portmap_null_v2(
     struct evpl               *evpl,
     struct evpl_rpc2_conn     *conn,

--- a/src/server/nfs/tests/CMakeLists.txt
+++ b/src/server/nfs/tests/CMakeLists.txt
@@ -58,6 +58,19 @@ target_include_directories(test_nfs_persist PRIVATE
 target_link_libraries(test_nfs_persist chimera_vfs chimera_common evpl evpl_rpc2 pthread uuid urcu-qsbr urcu-common)
 add_test(NAME chimera/server/nfs/nfs_persist COMMAND test_nfs_persist)
 
+# NSM/statd persistence: KV key/value formats, odd-state bump, monitor table.
+# Compiles nfs_nsm_state.c straight in (its helpers are not SYMBOL_EXPORT'd).
+add_executable(test_nsm_persist
+    test_nsm_persist.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/../nfs_nsm_state.c)
+target_include_directories(test_nsm_persist PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/..
+    ${CMAKE_SOURCE_DIR}/src
+    ${NFS_COMMON_INCLUDE_DIR})
+target_link_libraries(test_nsm_persist chimera_vfs chimera_common evpl evpl_rpc2 pthread uuid urcu-qsbr urcu-common)
+add_dependencies(test_nsm_persist chimera_nfs_common)
+add_test(NAME chimera/server/nfs/nsm_persist COMMAND test_nsm_persist)
+
 add_executable(test_protocol_advertise test_protocol_advertise.c)
 target_include_directories(test_protocol_advertise PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/..

--- a/src/server/nfs/tests/test_nsm_persist.c
+++ b/src/server/nfs/tests/test_nsm_persist.c
@@ -1,0 +1,153 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * NSM/statd persistence + monitor-table unit tests.
+ *
+ * Validates the on-stable-storage key/value formats (nfs_kv_keys.h NSM record
+ * types + nfs_nsm_state.c (de)serializers), the odd-state-number bump
+ * convention, and the in-memory monitor table -- all WITHOUT a live VFS or
+ * event loop.  nfs_nsm_state.c is compiled straight into this test because its
+ * helpers are not SYMBOL_EXPORT'd.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "nfs_nsm_state.h"
+#include "nfs_kv_keys.h"
+
+#define CHECK(cond) do { \
+            if (!(cond)) { \
+                fprintf(stderr, "%s:%d: CHECK failed: %s\n", \
+                        __FILE__, __LINE__, #cond); \
+                abort(); \
+            } \
+} while (0)
+
+static void
+test_state_value_roundtrip(void)
+{
+    uint8_t  buf[NSM_STATE_VALUE_LEN];
+    uint32_t out;
+
+    CHECK(nsm_state_value_serialize(buf, sizeof(buf), 0x01020304u) ==
+          NSM_STATE_VALUE_LEN);
+    CHECK(nsm_state_value_parse(buf, NSM_STATE_VALUE_LEN, &out) == 0);
+    CHECK(out == 0x01020304u);
+
+    /* Overflow guard: too-small buffer writes nothing. */
+    CHECK(nsm_state_value_serialize(buf, NSM_STATE_VALUE_LEN - 1, 7) == 0);
+
+    /* Bad magic + short value are rejected. */
+    buf[0] ^= 0xff;
+    CHECK(nsm_state_value_parse(buf, NSM_STATE_VALUE_LEN, &out) == -1);
+    buf[0] ^= 0xff;
+    CHECK(nsm_state_value_parse(buf, NSM_STATE_VALUE_LEN - 1, &out) == -1);
+} /* test_state_value_roundtrip */
+
+static void
+test_monitor_value_roundtrip(void)
+{
+    uint8_t  buf[NSM_MON_VALUE_MAX];
+    char     addr[CHIMERA_NSM_ADDR_MAX];
+    uint32_t len;
+
+    len = nsm_monitor_value_serialize(buf, sizeof(buf), "192.168.1.50");
+    CHECK(len == 4 + 4 + 1 + 12);
+    CHECK(nsm_monitor_value_parse(buf, len, addr, sizeof(addr)) == 0);
+    CHECK(strcmp(addr, "192.168.1.50") == 0);
+
+    /* IPv6 literal. */
+    len = nsm_monitor_value_serialize(buf, sizeof(buf), "fe80::1");
+    CHECK(nsm_monitor_value_parse(buf, len, addr, sizeof(addr)) == 0);
+    CHECK(strcmp(addr, "fe80::1") == 0);
+
+    /* Bad magic + truncated value are rejected. */
+    len     = nsm_monitor_value_serialize(buf, sizeof(buf), "10.0.0.1");
+    buf[0] ^= 0xff;
+    CHECK(nsm_monitor_value_parse(buf, len, addr, sizeof(addr)) == -1);
+    buf[0] ^= 0xff;
+    CHECK(nsm_monitor_value_parse(buf, len - 1, addr, sizeof(addr)) == -1);
+    CHECK(nsm_monitor_value_parse(buf, 8, addr, sizeof(addr)) == -1);
+} /* test_monitor_value_roundtrip */
+
+static void
+test_keys(void)
+{
+    uint8_t  buf[CHIMERA_KV_HDR_LEN + SM_MAXSTRLEN];
+    uint32_t len;
+
+    /* Every NSM key carries the shared 3-byte band header. */
+    len = nfs_kv_nsm_state_key(buf);
+    CHECK(len == CHIMERA_KV_NSM_STATE_KEY_LEN);
+    CHECK(buf[0] == CHIMERA_KV_MAGIC);
+    CHECK(buf[1] == CHIMERA_KV_VERSION);
+    CHECK(buf[2] == CHIMERA_KV_TYPE_NSM_STATE);
+
+    len = nfs_kv_nsm_monitor_key(buf, (const uint8_t *) "host-a", 6);
+    CHECK(len == CHIMERA_KV_HDR_LEN + 6);
+    CHECK(buf[2] == CHIMERA_KV_TYPE_NSM_MONITOR);
+    CHECK(memcmp(buf + CHIMERA_KV_HDR_LEN, "host-a", 6) == 0);
+
+    /* The two record types occupy distinct, adjacent bands so a search over
+     * [type .. type+1) scans exactly one type. */
+    CHECK(CHIMERA_KV_TYPE_NSM_MONITOR == CHIMERA_KV_TYPE_NSM_STATE + 1);
+} /* test_keys */
+
+static void
+test_state_bump(void)
+{
+    /* Always lands on the smallest odd value strictly greater than prev. */
+    CHECK(nsm_next_state(0) == 1);
+    CHECK(nsm_next_state(1) == 3);
+    CHECK(nsm_next_state(2) == 3);
+    CHECK(nsm_next_state(3) == 5);
+    CHECK(nsm_next_state(100) == 101);
+    CHECK(nsm_next_state(101) == 103);
+} /* test_state_bump */
+
+static void
+test_monitor_table(void)
+{
+    struct nsm_state          st;
+    struct nsm_notify_target *snap;
+    uint32_t                  n;
+
+    nsm_state_init(&st, NULL);
+
+    /* First sight => changed; re-set same addr => unchanged; new addr =>
+     * changed. */
+    CHECK(nsm_monitor_set(&st, "client1", "10.0.0.1") == 1);
+    CHECK(nsm_monitor_set(&st, "client1", "10.0.0.1") == 0);
+    CHECK(nsm_monitor_set(&st, "client1", "10.0.0.2") == 1);
+    CHECK(nsm_monitor_set(&st, "client2", "10.0.0.3") == 1);
+
+    n = nsm_monitors_snapshot(&st, &snap);
+    CHECK(n == 2);
+    CHECK(snap != NULL);
+    free(snap);
+
+    nsm_state_destroy(&st);
+
+    /* Empty table snapshots to nothing. */
+    nsm_state_init(&st, NULL);
+    n = nsm_monitors_snapshot(&st, &snap);
+    CHECK(n == 0);
+    CHECK(snap == NULL);
+    nsm_state_destroy(&st);
+} /* test_monitor_table */
+
+int
+main(void)
+{
+    test_state_value_roundtrip();
+    test_monitor_value_roundtrip();
+    test_keys();
+    test_state_bump();
+    test_monitor_table();
+    printf("test_nsm_persist: all checks passed\n");
+    return 0;
+} /* main */

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -47,6 +47,7 @@ struct chimera_server_config {
     int                                   nfs_rdma_port;
     int                                   nfs_tcp_rdma_port;
     int                                   nfs_lockmgr_port;
+    int                                   nfs_nsm_port;
     int                                   nfs_port;
     int                                   s3_port;
     int                                   nfs_data_server;
@@ -292,6 +293,7 @@ chimera_server_config_init(void)
     strncpy(config->nfs_rdma_hostname, "0.0.0.0", sizeof(config->nfs_rdma_hostname));
     config->nfs_rdma_port    = 20049;
     config->nfs_lockmgr_port = 32803;
+    config->nfs_nsm_port     = 32765;
 
     snprintf(config->state_dir, sizeof(config->state_dir), "%s", CHIMERA_STATE_DIR);
 
@@ -855,6 +857,20 @@ chimera_server_config_get_nfs_lockmgr_port(const struct chimera_server_config *c
 {
     return config->nfs_lockmgr_port;
 } /* chimera_server_config_get_nfs_lockmgr_port */
+
+SYMBOL_EXPORT void
+chimera_server_config_set_nfs_nsm_port(
+    struct chimera_server_config *config,
+    int                           port)
+{
+    config->nfs_nsm_port = port;
+} /* chimera_server_config_set_nfs_nsm_port */
+
+SYMBOL_EXPORT int
+chimera_server_config_get_nfs_nsm_port(const struct chimera_server_config *config)
+{
+    return config->nfs_nsm_port;
+} /* chimera_server_config_get_nfs_nsm_port */
 
 SYMBOL_EXPORT void
 chimera_server_config_set_state_dir(

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -411,6 +411,15 @@ chimera_server_config_get_nfs_lockmgr_port(
     const struct chimera_server_config *config);
 
 void
+chimera_server_config_set_nfs_nsm_port(
+    struct chimera_server_config *config,
+    int                           port);
+
+int
+chimera_server_config_get_nfs_nsm_port(
+    const struct chimera_server_config *config);
+
+void
 chimera_server_config_set_state_dir(
     struct chimera_server_config *config,
     const char                   *dir);


### PR DESCRIPTION
## Context

NLM (the NFSv3 lock manager, program 100021) is fully implemented, but its companion **NSM/statd (program 100024) was entirely absent** — so lock recovery never actually fired:

- `nlm_state_load` discarded all state on restart and never entered the grace window (the grace gate in the LOCK path was dead code).
- Nothing notified clients when the *server* rebooted, so clients never reclaimed → silent lock loss across a restart.
- A *client* reboot only dropped its stale locks on a full TCP disconnect.

This PR adds the NSM service and wires it to NLM so reboot recovery works in both directions. Persisted state goes in the global VFS KV store, reusing the DRC key-namespace convention in `nfs_kv_keys.h`.

NSM runs alongside NLM (configurable `nfs_nsm_port`, default 32765, TCP-only like NLM), registered with the internal and external portmap, and skipped in data-server mode. KV persistence auto-engages only on a persistent `kv_module` (a non-persistent `memkv` server logs a warning and skips grace/notify), mirroring the DRC.

## What's included (three independently-reviewable layers)

**Service + client-reboot cleanup + grace**
- New `sm_inter.x` (XDR), `nfs_nsm.{c,h}`, `nfs_nsm_state.{c,h}`; full init/start/stop/destroy/thread lifecycle, port config, portmap registration.
- `SM_NOTIFY` releases the rebooted peer's NLM locks (the `NLMPROC4_FREE_ALL` sequence).
- The NLM grace window is made real (`nlm_state_begin_grace` / `_end_grace`) and entered at boot on a persistent backend.

**KV persistence + server-reboot notify**
- New global-KV record types `0x06` (NSM state number, singleton) and `0x07` (NSM monitor, per-host) in `nfs_kv_keys.h`.
- `nsm_monitor()` records a lock holder from the NLM grant path (skipping `NM_LOCK`).
- A run-once per-thread cold-start (atomic CAS) bumps the state number to the next odd value, reloads the monitor list, and — on a dedicated short-lived `evpl` thread — sends `SM_NOTIFY` (via portmap `GETPORT`) to every monitored host so they reclaim during the grace window. Grace is held until the scan completes and ended early when no monitors exist.

**Robustness**
- `nsm_unmonitor` on `FREE_ALL` / last-connection disconnect / `SM_NOTIFY`.
- An `SM_NOTIFY` peer-IP fallback for when a client's statd `mon_name` differs from its NLM `caller_name`.
- `SM_SIMU_CRASH` bumps, persists, and notifies.
- `test_nsm_persist` unit test: KV key/value formats, the odd state-number bump, and the in-memory monitor table.

## Notes

- Concurrency: `nsm_state.mutex` is kept disjoint from `nlm_state.mutex` (if both are ever needed, `nsm` is taken first and dropped before `nlm`). All KV writes are fire-and-forget with a heap context freed in the callback.
- Verified: clean Debug + Release builds, NFS-server unit tests pass, and a running daemon advertises `100024 1 tcp 32765 status`, answers `SM_NULL`, and on a cairn (persistent) backend persists and odd-bumps the state number across restarts (0→1→3) with the grace window entering/ending correctly. End-to-end reclaim against a real Linux client is the KVM cairn-reboot validation path (as with the DRC/recovery work).