### PR TITLE
smb: LSARPC LookupNames2/LookupNames3 — rpc.lsa.lookupnames green

### DIFF
--- a/src/server/smb/idl/lsarpc.idl
+++ b/src/server/smb/idl/lsarpc.idl
@@ -167,4 +167,57 @@ interface lsarpc {
         [in, unique, string] wchar_t       *system_name,
         [in]                 uint32         access_mask,
         [out]                policy_handle *handle);
+
+    /* ---- LookupNames2 / LookupNames3 (MS-LSAT EX / EX2 forms) ----
+     * Both add lookup_options + client_revision in-params; modern clients call
+     * v3 (full SIDs) first, then v2, then v1. */
+
+    /* LSAPR_TRANSLATED_SID_EX: v1's TranslatedSid plus a Flags word. */
+    typedef struct {
+        uint32 sid_type;   /* lsa_SidType (Use) */
+        uint32 rid;        /* relative id within the referenced domain */
+        uint32 sid_index;  /* index into the referenced-domain list */
+        uint32 flags;
+    } lsa_TranslatedSidEx;
+
+    typedef struct {
+        uint32                                count;
+        [size_is(count)] lsa_TranslatedSidEx *sids;
+    } lsa_TransSidArrayEx;
+
+    [opnum(58)] uint32 lsa_LookupNames2(
+        [in]      policy_handle             *handle,
+        [in]      uint32                      num_names,
+        [in, size_is(num_names)] rpc_unicode_string *names,
+        [out]     lsa_RefDomainList         **domains,
+        [in, out] lsa_TransSidArrayEx        *sids,
+        [in]      uint16                      level,
+        [in, out] uint32                      count,
+        [in]      uint32                      lookup_options,
+        [in]      uint32                      client_revision);
+
+    /* LSAPR_TRANSLATED_SID_EX2: carries the full account SID per entry instead
+     * of a relative id. */
+    typedef struct {
+        uint32   sid_type;
+        dom_sid *sid;
+        uint32   sid_index;
+        uint32   flags;
+    } lsa_TranslatedSidEx2;
+
+    typedef struct {
+        uint32                                 count;
+        [size_is(count)] lsa_TranslatedSidEx2 *sids;
+    } lsa_TransSidArrayEx2;
+
+    [opnum(68)] uint32 lsa_LookupNames3(
+        [in]      policy_handle             *handle,
+        [in]      uint32                      num_names,
+        [in, size_is(num_names)] rpc_unicode_string *names,
+        [out]     lsa_RefDomainList         **domains,
+        [in, out] lsa_TransSidArrayEx2       *sids,
+        [in]      uint16                      level,
+        [in, out] uint32                      count,
+        [in]      uint32                      lookup_options,
+        [in]      uint32                      client_revision);
 }

--- a/src/server/smb/smb_lsarpc.c
+++ b/src/server/smb/smb_lsarpc.c
@@ -35,6 +35,8 @@ static const dce_if_uuid_t LSA_INTERFACE = {
 #define LSA_OP_OPENPOLICY2                44
 #define LSA_OP_GETUSERNAME                45
 #define LSA_OP_QUERYINFOPOLICY2           46
+#define LSA_OP_LOOKUPNAMES2               58
+#define LSA_OP_LOOKUPNAMES3               68
 
 /* Bytes of DCE/RPC framing (common + response header) the framing layer writes
 * before the stub, so the generated marshaller's buffer cap stays in bounds. */
@@ -213,6 +215,92 @@ chimera_smb_lookup_wellknown_name(
     }
     return 0;
 } /* chimera_smb_lookup_wellknown_name */
+
+/*
+ * Resolve one LookupNames target shared by LookupNames / LookupNames2 /
+ * LookupNames3.  Fills *full (the complete account SID), *type (lsa_SidType)
+ * and *rid (the relative id, or 0xffffffff for a domain), and ensures the
+ * name's domain is present in the referenced-domain list (via domains[] and
+ * *ndom).  Returns the domain index, or -1 if the name does not resolve.
+ */
+static void chimera_smb_set_ustr(
+    struct rpc_unicode_string *s,
+    const char                *utf8);
+
+static int
+chimera_smb_lsarpc_resolve_name(
+    const char                    *name,
+    struct chimera_vfs_user_cache *cache,
+    struct ndr_dbuf               *dbuf,
+    struct lsa_DomainInfo         *domains,
+    uint32_t                      *ndom,
+    struct ndr_sid                *full,
+    uint32_t                      *type,
+    uint32_t                      *rid)
+{
+    char           sidstr[CHIMERA_IDMAP_SID_MAX];
+    uint32_t       t = LSA_SID_NAME_UNKNOWN;
+    int            resolved, didx = -1;
+    struct ndr_sid dom;
+    uint32_t       d;
+
+    if (!name || name[0] == '\0') {
+        /* Empty/NULL name -> the server's own primary (account) domain. */
+        struct ndr_sid m = { 0 };
+        chimera_smb_lsarpc_machine_sid(&m);
+        chimera_smb_sid_to_string(&m, sidstr, sizeof(sidstr));
+        t        = LSA_SID_NAME_DOMAIN;
+        resolved = 1;
+    } else {
+        resolved = chimera_smb_lookup_wellknown_name(name, sidstr,
+                                                     sizeof(sidstr), &t);
+        if (!resolved) {
+            const struct chimera_vfs_user *u =
+                chimera_vfs_user_cache_lookup_by_name(cache, name);
+            if (u) {
+                if (u->sid[0]) {
+                    snprintf(sidstr, sizeof(sidstr), "%s", u->sid);
+                } else {
+                    snprintf(sidstr, sizeof(sidstr), "S-1-22-1-%u", u->uid);
+                }
+                t        = LSA_SID_NAME_USER;
+                resolved = 1;
+            }
+        }
+    }
+
+    if (!resolved ||
+        chimera_smb_string_to_sid(sidstr, full) != 0 ||
+        full->sub_authority_count == 0) {
+        return -1;
+    }
+
+    if (t == LSA_SID_NAME_DOMAIN) {
+        dom  = *full;            /* the SID is the domain; no RID */
+        *rid = 0xffffffff;
+    } else {
+        *rid = full->sub_authority[full->sub_authority_count - 1];
+        dom  = *full;            /* domain SID = SID minus the RID */
+        dom.sub_authority_count--;
+    }
+
+    for (d = 0; d < *ndom; d++) {
+        if (chimera_smb_sid_equal(domains[d].sid, &dom)) {
+            didx = (int) d;
+            break;
+        }
+    }
+    if (didx < 0) {
+        struct ndr_sid *ds = ndr_dbuf_alloc(dbuf, sizeof(*ds));
+        *ds                = dom;
+        domains[*ndom].sid = ds;
+        chimera_smb_set_ustr(&domains[*ndom].name, chimera_smb_domain_name(&dom));
+        didx = (int) (*ndom)++;
+    }
+
+    *type = t;
+    return didx;
+} /* chimera_smb_lsarpc_resolve_name */
 
 /* Point an rpc_unicode_string (lsa_String) at a UTF-8 string; byte counts are
  * length==size==chars*2 (the buffer body is emitted no-NUL by ndr_push_wstring,
@@ -517,81 +605,130 @@ chimera_smb_lsarpc_impl(
             rdl     = ndr_dbuf_alloc(dbuf, sizeof(*rdl));
 
             for (i = 0; i < nn; i++) {
-                const char    *name = li->names[i].buffer;
-                char           sidstr[CHIMERA_IDMAP_SID_MAX];
-                uint32_t       type = LSA_SID_NAME_UNKNOWN;
-                int            resolved;
-                struct ndr_sid full, dom;
-                int            didx = -1;
-                uint32_t       d, rid;
+                struct ndr_sid full;
+                uint32_t       type, rid;
+                int            didx;
 
                 sids[i].sid_type  = LSA_SID_NAME_UNKNOWN;
                 sids[i].rid       = 0;
                 sids[i].sid_index = 0xffffffff;
 
-                if (!name || name[0] == '\0') {
-                    /* An empty/NULL name resolves to the server's own primary
-                     * (account) domain (MS-LSAT): its machine SID, type Domain. */
-                    struct ndr_sid m = { 0 };
-                    chimera_smb_lsarpc_machine_sid(&m);
-                    chimera_smb_sid_to_string(&m, sidstr, sizeof(sidstr));
-                    type     = LSA_SID_NAME_DOMAIN;
-                    resolved = 1;
-                } else {
-                    /* Well-known names (Everyone, SYSTEM, BUILTIN\*, ...) first,
-                     * then the local-account idmap (a unix user -> S-1-22-1-<uid>
-                     * or its configured SID). */
-                    resolved = chimera_smb_lookup_wellknown_name(name, sidstr,
-                                                                 sizeof(sidstr), &type);
-                    if (!resolved) {
-                        const struct chimera_vfs_user *u =
-                            chimera_vfs_user_cache_lookup_by_name(cache, name);
-                        if (u) {
-                            if (u->sid[0]) {
-                                snprintf(sidstr, sizeof(sidstr), "%s", u->sid);
-                            } else {
-                                snprintf(sidstr, sizeof(sidstr), "S-1-22-1-%u", u->uid);
-                            }
-                            type     = LSA_SID_NAME_USER;
-                            resolved = 1;
-                        }
-                    }
-                }
-
-                if (!resolved ||
-                    chimera_smb_string_to_sid(sidstr, &full) != 0 ||
-                    full.sub_authority_count == 0) {
+                didx = chimera_smb_lsarpc_resolve_name(li->names[i].buffer, cache,
+                                                       dbuf, domains, &ndom,
+                                                       &full, &type, &rid);
+                if (didx < 0) {
                     continue;
                 }
-
-                if (type == LSA_SID_NAME_DOMAIN) {
-                    /* A domain name resolves to the domain SID itself, with no
-                     * RID (0xffffffff) referencing the whole domain. */
-                    dom = full;
-                    rid = 0xffffffff;
-                } else {
-                    rid = full.sub_authority[full.sub_authority_count - 1];
-                    dom = full;            /* domain SID = SID minus the RID */
-                    dom.sub_authority_count--;
-                }
-
-                for (d = 0; d < ndom; d++) {
-                    if (chimera_smb_sid_equal(domains[d].sid, &dom)) {
-                        didx = (int) d;
-                        break;
-                    }
-                }
-                if (didx < 0) {
-                    struct ndr_sid *ds = ndr_dbuf_alloc(dbuf, sizeof(*ds));
-                    *ds               = dom;
-                    domains[ndom].sid = ds;
-                    chimera_smb_set_ustr(&domains[ndom].name,
-                                         chimera_smb_domain_name(&dom));
-                    didx = (int) ndom++;
-                }
-
                 sids[i].sid_type  = type;
                 sids[i].rid       = rid;
+                sids[i].sid_index = (uint32_t) didx;
+                mapped++;
+            }
+
+            rdl->count    = ndom;
+            rdl->domains  = ndom ? domains : NULL;
+            rdl->max_size = ndom;
+            o->domains    = rdl;
+            o->sids.count = nn;
+            o->sids.sids  = nn ? sids : NULL;
+            o->count      = mapped;
+            o->status     = (nn == 0 || mapped == nn) ? 0
+                            : (mapped == 0) ? LSA_STATUS_NONE_MAPPED
+                            : LSA_STATUS_SOME_NOT_MAPPED;
+            break;
+        }
+        case LSA_OP_LOOKUPNAMES2: {
+            const struct lsa_LookupNames2_in *li    = in;
+            struct lsa_LookupNames2_out      *o     = out;
+            struct chimera_vfs_user_cache    *cache = vfs->vfs_user_cache;
+            uint32_t                          nn    = li->num_names;
+            uint32_t                          ndom  = 0, mapped = 0, i;
+            struct lsa_TranslatedSidEx       *sids;
+            struct lsa_DomainInfo            *domains;
+            struct lsa_RefDomainList         *rdl;
+
+            if (!chimera_smb_lsarpc_handle_valid(conn, &li->handle)) {
+                return DCE_RC_FAULT_CONTEXT_MISMATCH;
+            }
+
+            sids    = ndr_dbuf_alloc(dbuf, (nn ? nn : 1) * sizeof(*sids));
+            domains = ndr_dbuf_alloc(dbuf, (nn ? nn : 1) * sizeof(*domains));
+            rdl     = ndr_dbuf_alloc(dbuf, sizeof(*rdl));
+
+            for (i = 0; i < nn; i++) {
+                struct ndr_sid full;
+                uint32_t       type, rid;
+                int            didx;
+
+                sids[i].sid_type  = LSA_SID_NAME_UNKNOWN;
+                sids[i].rid       = 0;
+                sids[i].sid_index = 0xffffffff;
+                sids[i].flags     = 0;
+
+                didx = chimera_smb_lsarpc_resolve_name(li->names[i].buffer, cache,
+                                                       dbuf, domains, &ndom,
+                                                       &full, &type, &rid);
+                if (didx < 0) {
+                    continue;
+                }
+                sids[i].sid_type  = type;
+                sids[i].rid       = rid;
+                sids[i].sid_index = (uint32_t) didx;
+                mapped++;
+            }
+
+            rdl->count    = ndom;
+            rdl->domains  = ndom ? domains : NULL;
+            rdl->max_size = ndom;
+            o->domains    = rdl;
+            o->sids.count = nn;
+            o->sids.sids  = nn ? sids : NULL;
+            o->count      = mapped;
+            o->status     = (nn == 0 || mapped == nn) ? 0
+                            : (mapped == 0) ? LSA_STATUS_NONE_MAPPED
+                            : LSA_STATUS_SOME_NOT_MAPPED;
+            break;
+        }
+        case LSA_OP_LOOKUPNAMES3: {
+            const struct lsa_LookupNames3_in *li    = in;
+            struct lsa_LookupNames3_out      *o     = out;
+            struct chimera_vfs_user_cache    *cache = vfs->vfs_user_cache;
+            uint32_t                          nn    = li->num_names;
+            uint32_t                          ndom  = 0, mapped = 0, i;
+            struct lsa_TranslatedSidEx2      *sids;
+            struct lsa_DomainInfo            *domains;
+            struct lsa_RefDomainList         *rdl;
+
+            if (!chimera_smb_lsarpc_handle_valid(conn, &li->handle)) {
+                return DCE_RC_FAULT_CONTEXT_MISMATCH;
+            }
+
+            sids    = ndr_dbuf_alloc(dbuf, (nn ? nn : 1) * sizeof(*sids));
+            domains = ndr_dbuf_alloc(dbuf, (nn ? nn : 1) * sizeof(*domains));
+            rdl     = ndr_dbuf_alloc(dbuf, sizeof(*rdl));
+
+            for (i = 0; i < nn; i++) {
+                struct ndr_sid  full;
+                struct ndr_sid *fs;
+                uint32_t        type, rid;
+                int             didx;
+
+                sids[i].sid_type  = LSA_SID_NAME_UNKNOWN;
+                sids[i].sid       = NULL;
+                sids[i].sid_index = 0xffffffff;
+                sids[i].flags     = 0;
+
+                didx = chimera_smb_lsarpc_resolve_name(li->names[i].buffer, cache,
+                                                       dbuf, domains, &ndom,
+                                                       &full, &type, &rid);
+                if (didx < 0) {
+                    continue;
+                }
+                /* v3 carries the full account SID per entry rather than a RID. */
+                fs                = ndr_dbuf_alloc(dbuf, sizeof(*fs));
+                *fs               = full;
+                sids[i].sid_type  = type;
+                sids[i].sid       = fs;
                 sids[i].sid_index = (uint32_t) didx;
                 mapped++;
             }

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -298,8 +298,12 @@ set_tests_properties(chimera/server/smb/rpcclient_lsa PROPERTIES
 #   rpc.handles.lsarpc : DCE/RPC context (policy) handle association -- a handle
 #                        opened on one connection, used on another, must fault
 #                        with CONTEXT_MISMATCH, and a closed handle must too.
+#   rpc.lsa.lookupnames : name->SID via LookupNames / LookupNames2 / LookupNames3
+#                        (opnums 14/58/68), including well-known names and the
+#                        NULL-name and policy-handle cases.
 set(SMBTORTURE_RPC_SUITES_ENABLED
     rpc.lsa.lookupsids
+    rpc.lsa.lookupnames
     rpc.handles.lsarpc
     "rpc.srvsvc.srvsvc (admin access).NetShareEnumAll")
 
@@ -319,13 +323,8 @@ endforeach()
 # smbtorture DCE/RPC conformance suites wired but DISABLED: each needs a server
 # feature we don't have yet (but that is in NAS scope -- drop DISABLED once the
 # feature lands).
-#   rpc.lsa.lookupnames : well-known names (Everyone, SYSTEM, BUILTIN\*, ...) and
-#                         the NULL-name/handle cases now resolve via LookupNames
-#                         (opnum 14); the suite additionally probes LookupNames2
-#                         (58) and LookupNames3 (68), still unimplemented.
 #   rpc.lsalookup       : looks names up in trusted domains ("no trusts").
 set(SMBTORTURE_RPC_SUITES_DISABLED
-    rpc.lsa.lookupnames
     rpc.lsalookup)
 
 foreach(SUITE ${SMBTORTURE_RPC_SUITES_DISABLED})


### PR DESCRIPTION
Third in the Tier-1 stack, layered on #808 (which is on #807). Until those merge, this PR's diff also shows their commits; the new commits here are the last two.

Completes the `rpc.lsa.lookupnames` conformance gate — the suite probes three name→SID variants and we only had v1.

## What
Modern Windows clients call **LookupNames3** (full SID per entry) first, then **LookupNames2**, then v1. We faulted `PROCNUM_OUT_OF_RANGE` on the v2/v3 probes. This adds both:

- **LookupNames2 (opnum 58)** — `LSAPR_TRANSLATED_SID_EX`: v1's translated SID + a `Flags` word.
- **LookupNames3 (opnum 68)** — `LSAPR_TRANSLATED_SID_EX2`: a full account-SID pointer per entry instead of a RID (a new array-of-structs-with-deferred-SID NDR shape — generated cleanly by ndrzcc).

Both also carry the `lookup_options` + `client_revision` in-params. The name→SID resolution (well-known names, NULL-name → primary domain, local idmap, domain/RID split) is **factored into one helper** shared by all three variants; v3 additionally emits the reconstructed full SID.

## Gate
- **`rpc.lsa.lookupnames` → enabled, passing** (new). The real Samba client decodes our v1/v2/v3 responses — end-to-end validation of the EX2 full-SID shape.
- `rpc.handles.lsarpc`, `rpc.lsa.lookupsids`, `rpc.srvsvc NetShareEnumAll` → still passing.

## Verification
All enabled RPC gates pass via ctest; ASan-clean (0 leaks) across lookupnames/handles/lookupsids; rpcclient smoke + lsarpc golden green. Built Release + Debug/ASan.

After this, the only LSARPC `rpc.*` suite still disabled is `rpc.lsalookup` (trusted-domain lookups — DC territory, out of NAS scope).