### PR TITLE
smb2: extend the async-operation cap to CHANGE_NOTIFY

### DIFF
--- a/src/server/smb/smb_notify.c
+++ b/src/server/smb/smb_notify.c
@@ -85,20 +85,35 @@ chimera_smb_notify_build_header(
     hdr = (struct smb2_header *) buf;
     memset(hdr, 0, sizeof(*hdr));
 
-    hdr->protocol_id[0]          = 0xFE;
-    hdr->protocol_id[1]          = 'S';
-    hdr->protocol_id[2]          = 'M';
-    hdr->protocol_id[3]          = 'B';
-    hdr->struct_size             = 64;
-    hdr->credit_charge           = nr->credit_charge;
-    hdr->status                  = status;
-    hdr->command                 = SMB2_CHANGE_NOTIFY;
-    hdr->credit_request_response = nr->credit_request ? nr->credit_request : 1;
-    hdr->flags                   = SMB2_FLAGS_SERVER_TO_REDIR | SMB2_FLAGS_ASYNC_COMMAND;
-    hdr->next_command            = 0;
-    hdr->message_id              = nr->message_id;
-    hdr->async.async_id          = nr->async_id;
-    hdr->session_id              = nr->session_id;
+    hdr->protocol_id[0] = 0xFE;
+    hdr->protocol_id[1] = 'S';
+    hdr->protocol_id[2] = 'M';
+    hdr->protocol_id[3] = 'B';
+    hdr->struct_size    = 64;
+    hdr->credit_charge  = nr->credit_charge;
+    hdr->status         = status;
+    hdr->command        = SMB2_CHANGE_NOTIFY;
+    /* Grant credits (capped), debiting this request's CreditCharge exactly once
+     * across the interim + final async responses so a client that keeps asking
+     * for more cannot overflow its 16-bit credit window (the fault the
+     * smb2.credits async flood otherwise hits).  The first response to be built
+     * (the interim) consumes the charge; later ones pass 0.  Mirrors the read
+     * path's interim/final handling -- see chimera_smb_grant_credits. */
+    {
+        uint32_t consume = 0;
+
+        if (!nr->credits_charged) {
+            nr->credits_charged = 1;
+            consume             = nr->credit_charge ? nr->credit_charge : 1;
+        }
+        hdr->credit_request_response = chimera_smb_grant_credits(
+            nr->conn, consume, nr->credit_request);
+    }
+    hdr->flags          = SMB2_FLAGS_SERVER_TO_REDIR | SMB2_FLAGS_ASYNC_COMMAND;
+    hdr->next_command   = 0;
+    hdr->message_id     = nr->message_id;
+    hdr->async.async_id = nr->async_id;
+    hdr->session_id     = nr->session_id;
 
     return buf + sizeof(struct smb2_header);
 } /* chimera_smb_notify_build_header */
@@ -114,7 +129,14 @@ chimera_smb_notify_set_netbios_len(
     memcpy(buf, &nb, 4);
 } /* chimera_smb_notify_set_netbios_len */
 
-/* Unlink a parked notify request from the connection's list */
+/* Unlink a parked notify request from the connection's list.
+ *
+ * This is the single chokepoint every un-park/terminal path funnels through
+ * (event delivery, NOTIFY_CLEANUP, SMB2_CANCEL, drop-on-teardown), so it also
+ * releases the request's async-credit slot.  The async_counted guard makes the
+ * conn->async_outstanding decrement happen exactly once: a leaked count would
+ * permanently shrink the connection's async ceiling, a double-decrement would
+ * underflow the unsigned counter and effectively remove the cap. */
 static void
 chimera_smb_notify_unlink(struct chimera_smb_notify_request *nr)
 {
@@ -130,6 +152,13 @@ chimera_smb_notify_unlink(struct chimera_smb_notify_request *nr)
 
     nr->next = NULL;
     nr->prev = NULL;
+
+    if (nr->async_counted) {
+        nr->async_counted = 0;
+        if (nr->conn && nr->conn->async_outstanding) {
+            nr->conn->async_outstanding--;
+        }
+    }
 } /* chimera_smb_notify_unlink */
 
 /* ----------------------------------------------------------------

--- a/src/server/smb/smb_notify.h
+++ b/src/server/smb/smb_notify.h
@@ -60,6 +60,15 @@ struct chimera_smb_notify_request {
      * session is being closed by a PreviousSessionId reconnect, where the
      * cleanup must be marshaled to the request's owning thread. */
     int                                cleanup;
+    /* Set when this parked notify was counted against conn->async_outstanding
+     * (MS-SMB2 3.3.5.2.9 outstanding-async cap).  Guards the decrement in
+     * chimera_smb_notify_unlink so the slot is freed exactly once however the
+     * request un-parks (event delivery, NOTIFY_CLEANUP, CANCEL, teardown). */
+    int                                async_counted;
+    /* Set once the interim STATUS_PENDING has debited this request's
+     * CreditCharge via chimera_smb_grant_credits, so the eventual final
+     * response passes consume=0 and the charge is not counted twice. */
+    int                                credits_charged;
     struct chimera_smb_notify_request *next;          /* parked list linkage */
     struct chimera_smb_notify_request *prev;          /* parked list linkage */
     struct chimera_smb_notify_request *ready_next;    /* doorbell ready queue */

--- a/src/server/smb/smb_proc_change_notify.c
+++ b/src/server/smb/smb_proc_change_notify.c
@@ -261,7 +261,26 @@ chimera_smb_change_notify(struct chimera_smb_request *request)
     }
 
     /* We need to send an interim STATUS_PENDING response and
-     * keep the request alive until events arrive. */
+     * keep the request alive until events arrive.
+     *
+     * MS-SMB2 3.3.5.2.9 caps the simultaneously-outstanding async operations a
+     * connection may hold.  Reuse the per-connection counter and ceiling that
+     * 9c5c7c41 wired into the blocking named-pipe READ path: if parking this
+     * notify would reach the ceiling, reject it with INSUFFICIENT_RESOURCES
+     * instead (the contract smb2.credits.*_notify_max_async_credits asserts). */
+    {
+        struct chimera_smb_conn          *conn   = request->compound->conn;
+        struct chimera_server_smb_shared *shared = thread->shared;
+
+        if (conn->async_outstanding >=
+            (uint32_t) shared->config.smb2_max_async_credits - 1) {
+            pthread_mutex_unlock(&state->lock);
+            chimera_smb_open_file_release(request, open_file);
+            chimera_smb_complete_request(request,
+                                         SMB2_STATUS_INSUFFICIENT_RESOURCES);
+            return;
+        }
+    }
 
     nr = chimera_smb_notify_request_alloc();
 
@@ -309,6 +328,12 @@ chimera_smb_change_notify(struct chimera_smb_request *request)
         nr->next->prev = nr;
     }
     request->compound->conn->parked_notifies = nr;
+
+    /* Count this parked notify against the connection's async-operation
+     * ceiling.  chimera_smb_notify_unlink (the single un-park chokepoint)
+     * decrements it once, guarded by nr->async_counted. */
+    nr->async_counted = 1;
+    request->compound->conn->async_outstanding++;
 
     /* Send the interim STATUS_PENDING response directly as a standalone
      * message with proper NetBIOS framing and async header layout.

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -1102,9 +1102,12 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.create_no_streams.no_stream
     # smb2.credits
     smb2.credits.1conn_ipc_max_async_credits
+    smb2.credits.1conn_notify_max_async_credits
     smb2.credits.2conn_ipc_max_async_credits
+    smb2.credits.2conn_notify_max_async_credits
     smb2.credits.ipc_max_data_zero
     smb2.credits.multichannel_ipc_max_async_credits
+    smb2.credits.multichannel_max_async_credits
     smb2.credits.session_setup_credits_granted
     smb2.credits.single_req_credits_granted
     smb2.credits.skipped_mid
@@ -2976,9 +2979,12 @@ set(SMBTORTURE_ENABLED_diskfs_io_uring
     smb2.create_no_streams.no_stream
     # smb2.credits
     smb2.credits.1conn_ipc_max_async_credits
+    smb2.credits.1conn_notify_max_async_credits
     smb2.credits.2conn_ipc_max_async_credits
+    smb2.credits.2conn_notify_max_async_credits
     smb2.credits.ipc_max_data_zero
     smb2.credits.multichannel_ipc_max_async_credits
+    smb2.credits.multichannel_max_async_credits
     smb2.credits.session_setup_credits_granted
     smb2.credits.single_req_credits_granted
     smb2.credits.skipped_mid


### PR DESCRIPTION
## Summary

This PR's original full implementation of the MS-SMB2 3.3.5.2.9 outstanding-async-operation cap (a per-connection counter + an `INSUFFICIENT_RESOURCES` ceiling + a bounded credit grant) was **superseded by `9c5c7c41` ("smb2: IPC$ named-pipe async-read credits + bounded credit grant")**, which the maintainer landed on `main` while this PR sat in review. That commit added the core mechanism this PR had duplicated:

- `conn->async_outstanding` — the per-connection parked-async counter (reset at conn alloc and teardown drain),
- `shared->config.smb2_max_async_credits` — the config knob (default 512),
- `chimera_smb_grant_credits` — the bounded credit grant (caps the client's running balance at 8192, debiting each `CreditCharge` once across an async request's interim and final),

and wired it into the blocking named-pipe READ path, greening the four `smb2.credits` IPC subtests.

This PR is therefore **reduced** to the one remaining gap: `9c5c7c41` did not wire the cap into the **CHANGE_NOTIFY** async path, so the three notify credit subtests still faulted the connection with `NT_STATUS_INVALID_NETWORK_RESPONSE` (credit-window overflow) instead of returning the expected `STATUS_INSUFFICIENT_RESOURCES`. It now reuses `9c5c7c41`'s infrastructure — **no new counter, config knob, or grant function** — and adds only the notify-path wiring.

## What changed

- **Park check** (`smb_proc_change_notify.c`): before a CHANGE_NOTIFY parks async (sends its `STATUS_PENDING` interim and links onto `conn->parked_notifies`), reject it with `INSUFFICIENT_RESOURCES` if `conn->async_outstanding` has reached `smb2_max_async_credits - 1`; otherwise increment the counter as it parks.
- **Decrement chokepoint** (`smb_notify.c`): `chimera_smb_notify_unlink` is the single point every un-park/terminal path funnels through (event delivery, `NOTIFY_CLEANUP` / PreviousSessionId reconnect, `SMB2_CANCEL`, handle close, tree disconnect, session logoff, connection teardown drain), so it releases the slot there. A per-request `async_counted` flag makes the decrement happen exactly once — a leaked count would shrink the connection's async ceiling, a double decrement would underflow the unsigned counter and remove the cap.
- **Bounded grant** (`smb_notify.c`): the notify interim/final async responses build their own SMB2 header, which previously echoed the client's `CreditRequest` verbatim. They now route through `chimera_smb_grant_credits`, debiting the request's `CreditCharge` exactly once across the interim+final (guarded by a `credits_charged` flag, mirroring the read path).
- **Allowlist**: enable `smb2.credits.{1conn_notify,2conn_notify,multichannel}_max_async_credits` on the `memfs` and `diskfs_io_uring` backends.

## Verification

- The 3 notify credit subtests pass on memfs and diskfs_io_uring (previously 300s timeouts / immediate faults), completing in well under a second.
- The 4 IPC credit subtests from `9c5c7c41` still pass.
- No new failures across the full enabled `smb2.credits`, `smb2.notify`, `smb2.notify-inotify`, `smb2.lock`, `smb2.create`, `smb2.rw`, `smb2.read`, `smb2.compound`, `smb2.session`, `smb2.durable-open` suites and the rpc pipe suites, on memfs + diskfs_io_uring (Debug/ASan).
- Release (`-O3 -Werror`) and `scan-build` both clean ("No bugs found").
