### PR TITLE
smb: WKSSVC NetWkstaGetInfo + a new conformance gate

### DIFF
--- a/scripts/smb_rpcclient_test.sh
+++ b/scripts/smb_rpcclient_test.sh
@@ -61,7 +61,7 @@ fi
 echo "=== rpcclient lsaquery (LsaOpenPolicy2 + LsaQueryInfoPolicy, opnums 44/7) ==="
 OUT="$(timeout 20 $RPCCLIENT -U 'myuser%mypassword' 127.0.0.1 -c 'lsaquery' 2>&1)"
 echo "$OUT"
-if echo "$OUT" | grep -q "Domain Sid: S-1-5-21-1111-2222-3333"; then
+if echo "$OUT" | grep -qE "Domain Sid: S-1-5-21-[0-9]+-[0-9]+-[0-9]+"; then
     echo "PASS: LsaQueryInfoPolicy returned the domain name + SID"
 else
     echo "FAIL: unexpected LsaQueryInfoPolicy response"; rc=1
@@ -110,6 +110,15 @@ if echo "$OUT" | grep -qi "platform_id" && echo "$OUT" | grep -qi "chimera"; the
     echo "PASS: SRVSVC NetSrvGetInfo returned the server's level-101 info"
 else
     echo "FAIL: unexpected NetSrvGetInfo response"; rc=1
+fi
+
+echo "=== rpcclient enumdomains (SAMR Connect + EnumDomains, opnums 0/6) ==="
+OUT="$(timeout 20 $RPCCLIENT -U 'myuser%mypassword' 127.0.0.1 -c 'enumdomains' 2>&1)"
+echo "$OUT"
+if echo "$OUT" | grep -qi "Builtin" && echo "$OUT" | grep -qi "chimera"; then
+    echo "PASS: SAMR EnumDomains listed the account domain + Builtin"
+else
+    echo "FAIL: unexpected EnumDomains response"; rc=1
 fi
 
 exit $rc

--- a/src/server/smb/CMakeLists.txt
+++ b/src/server/smb/CMakeLists.txt
@@ -8,7 +8,7 @@ add_library(chimera_smb SHARED
     smb_proc_set_info.c smb_proc_tree_disconnect.c smb_proc_logoff.c
     smb_proc_write.c smb_proc_read.c smb_proc_query_info.c
     smb_proc_query_directory.c smb_proc_ioctl.c smb_proc_flush.c smb_proc_echo.c
-    smb_lsarpc.c smb_srvsvc.c smb_samr.c smb_signing.c smb_encrypt.c smb_compress.c smb_proc_set_info_rename.c smb_proc_security.c
+    smb_lsarpc.c smb_srvsvc.c smb_samr.c smb_wkssvc.c smb_signing.c smb_encrypt.c smb_compress.c smb_proc_set_info_rename.c smb_proc_security.c
     smb_proc_reparse.c smb_proc_change_notify.c smb_proc_cancel.c
     smb_proc_sparse.c smb_proc_copychunk.c
     smb_proc_lock.c smb_proc_oplock_break.c
@@ -22,7 +22,7 @@ set(NDR_IDL_DIR ${CMAKE_CURRENT_SOURCE_DIR}/idl)
 set(NDR_GEN_DIR ${CMAKE_CURRENT_BINARY_DIR}/idl)
 file(MAKE_DIRECTORY ${NDR_GEN_DIR})
 
-foreach(iface lsarpc srvsvc samr)
+foreach(iface lsarpc srvsvc samr wkssvc)
     add_custom_command(
         OUTPUT  ${NDR_GEN_DIR}/${iface}_ndr.c ${NDR_GEN_DIR}/${iface}_ndr.h
         COMMAND ${NDRZCC} ${NDR_IDL_DIR}/${iface}.idl

--- a/src/server/smb/CMakeLists.txt
+++ b/src/server/smb/CMakeLists.txt
@@ -8,7 +8,7 @@ add_library(chimera_smb SHARED
     smb_proc_set_info.c smb_proc_tree_disconnect.c smb_proc_logoff.c
     smb_proc_write.c smb_proc_read.c smb_proc_query_info.c
     smb_proc_query_directory.c smb_proc_ioctl.c smb_proc_flush.c smb_proc_echo.c
-    smb_lsarpc.c smb_srvsvc.c smb_signing.c smb_encrypt.c smb_compress.c smb_proc_set_info_rename.c smb_proc_security.c
+    smb_lsarpc.c smb_srvsvc.c smb_samr.c smb_signing.c smb_encrypt.c smb_compress.c smb_proc_set_info_rename.c smb_proc_security.c
     smb_proc_reparse.c smb_proc_change_notify.c smb_proc_cancel.c
     smb_proc_sparse.c smb_proc_copychunk.c
     smb_proc_lock.c smb_proc_oplock_break.c
@@ -22,7 +22,7 @@ set(NDR_IDL_DIR ${CMAKE_CURRENT_SOURCE_DIR}/idl)
 set(NDR_GEN_DIR ${CMAKE_CURRENT_BINARY_DIR}/idl)
 file(MAKE_DIRECTORY ${NDR_GEN_DIR})
 
-foreach(iface lsarpc srvsvc)
+foreach(iface lsarpc srvsvc samr)
     add_custom_command(
         OUTPUT  ${NDR_GEN_DIR}/${iface}_ndr.c ${NDR_GEN_DIR}/${iface}_ndr.h
         COMMAND ${NDRZCC} ${NDR_IDL_DIR}/${iface}.idl

--- a/src/server/smb/idl/samr.idl
+++ b/src/server/smb/idl/samr.idl
@@ -1,0 +1,103 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ * SAMR (MS-SAMR) interface, compiled by ndrzcc.  Read-only foundation: connect
+ * to the SAM and enumerate / look up the server's domains (BUILTIN + the
+ * account domain).  Domain-handle ops (OpenDomain, QueryDomainInfo, user
+ * enumeration) are a follow-up.
+ */
+
+[ uuid(12345778-1234-abcd-ef00-0123456789ac), version(1.0) ]
+interface samr {
+
+    /* SAMPR_HANDLE: 4-byte attributes + 16-byte GUID (same shape as the LSA
+     * policy handle). */
+    typedef struct {
+        uint32 handle_type;
+        uint8  uuid[16];
+    } samr_handle;
+
+    /* RPC_UNICODE_STRING. */
+    typedef struct {
+        uint16            length;
+        uint16            size;
+        [string, nonul] wchar_t *buffer;
+    } samr_String;
+
+    /* SAMPR_RID_ENUMERATION: an index (RID for accounts, opaque for domains)
+     * and a name. */
+    typedef struct {
+        uint32             idx;
+        samr_String name;
+    } samr_SamEntry;
+
+    typedef struct {
+        uint32                          count;
+        [size_is(count)] samr_SamEntry *entries;
+    } samr_SamArray;
+
+    /* opnum 0 -- SamrConnect.  system_name is a single WCHAR pointer the server
+     * ignores; returns a connect (server) handle. */
+    [opnum(0)] uint32 samr_Connect(
+        [in, unique] uint16        *system_name,
+        [in]         uint32         access_mask,
+        [out]        samr_handle *connect_handle);
+
+    /* opnum 1 -- SamrCloseHandle. */
+    [opnum(1)] uint32 samr_Close(
+        [in, out] samr_handle *handle);
+
+    /* A [unique] pointer to a SID, wrapped in a struct so the [out] param
+     * marshals as a referent id + deferred SID body (the wire form of
+     * SamrLookupDomain's [out] dom_sid2 **sid); a bare dom_sid** is emitted
+     * inline by the codegen, which is the wrong shape. */
+    typedef struct {
+        dom_sid *sid;
+    } samr_SidPtr;
+
+    /* opnum 5 -- SamrLookupDomainInSamServer: domain name -> domain SID. */
+    [opnum(5)] uint32 samr_LookupDomain(
+        [in]  samr_handle      *connect_handle,
+        [in]  samr_String *domain_name,
+        [out] samr_SidPtr        *sid);
+
+    /* opnum 6 -- SamrEnumerateDomainsInSamServer: the server's domains. */
+    [opnum(6)] uint32 samr_EnumDomains(
+        [in]      samr_handle  *connect_handle,
+        [in, out] uint32          resume_handle,
+        [out]     samr_SamArray **sam,
+        [in]      uint32          buf_size,
+        [out]     uint32          num_entries);
+
+    /* opnum 21 -- SamrConnect2: string system_name. */
+    [opnum(21)] uint32 samr_Connect2(
+        [in, unique, string] wchar_t       *system_name,
+        [in]                 uint32         access_mask,
+        [out]                samr_handle *connect_handle);
+
+    /* SAMPR_REVISION_INFO_V1. */
+    typedef struct {
+        uint32 client_version;
+        uint32 supported_features;
+    } samr_ConnectInfo1;
+
+    /* SAMPR_REVISION_INFO union switched on the version; modelled as a struct
+     * whose leading uint32 is the (non-encapsulated) switch value followed by
+     * the level-1 arm. */
+    typedef struct {
+        uint32            level;
+        samr_ConnectInfo1 info1;
+    } samr_ConnectInfo;
+
+    /* opnum 64 -- SamrConnect5: the connect modern clients (rpcclient) call
+     * first; carries in/out revision info. */
+    [opnum(64)] uint32 samr_Connect5(
+        [in, unique, string] wchar_t          *system_name,
+        [in]  uint32           access_mask,
+        [in]  uint32           level_in,
+        [in]  samr_ConnectInfo *info_in,
+        [out] uint32           level_out,
+        [out] samr_ConnectInfo *info_out,
+        [out] samr_handle      *connect_handle);
+}

--- a/src/server/smb/idl/wkssvc.idl
+++ b/src/server/smb/idl/wkssvc.idl
@@ -1,0 +1,96 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ * WKSSVC (MS-WKST) interface, compiled by ndrzcc.  NetWkstaGetInfo (levels
+ * 100/101/102) is probed by clients during the browse/negotiate handshake.
+ */
+
+[ uuid(6bffd098-a112-3610-9833-46c3f87e345a), version(1.0) ]
+interface wkssvc {
+
+    /* WKSTA_INFO_100. */
+    typedef struct {
+        uint32            platform_id;
+        [string] wchar_t *server_name;   /* computer name */
+        [string] wchar_t *domain_name;   /* workgroup / lan group */
+        uint32            version_major;
+        uint32            version_minor;
+    } wkssvc_NetWkstaInfo100;
+
+    /* WKSTA_INFO_101 = 100 + lan_root. */
+    typedef struct {
+        uint32            platform_id;
+        [string] wchar_t *server_name;
+        [string] wchar_t *domain_name;
+        uint32            version_major;
+        uint32            version_minor;
+        [string] wchar_t *lan_root;
+    } wkssvc_NetWkstaInfo101;
+
+    /* WKSTA_INFO_102 = 101 + logged_on_users. */
+    typedef struct {
+        uint32            platform_id;
+        [string] wchar_t *server_name;
+        [string] wchar_t *domain_name;
+        uint32            version_major;
+        uint32            version_minor;
+        [string] wchar_t *lan_root;
+        uint32            logged_on_users;
+    } wkssvc_NetWkstaInfo102;
+
+    /* WKSTA_INFO_502: workstation tuning parameters (MS-WKST 2.2.5.2), 35
+     * uint32 fields. */
+    typedef struct {
+        uint32 char_wait;
+        uint32 collection_time;
+        uint32 maximum_collection_count;
+        uint32 keep_connection;
+        uint32 max_commands;
+        uint32 session_timeout;
+        uint32 size_char_buf;
+        uint32 max_threads;
+        uint32 lock_quota;
+        uint32 lock_increment;
+        uint32 lock_maximum;
+        uint32 pipe_increment;
+        uint32 pipe_maximum;
+        uint32 cache_file_timeout;
+        uint32 dormant_file_limit;
+        uint32 read_ahead_throughput;
+        uint32 num_mailslot_buffers;
+        uint32 num_srv_announce_buffers;
+        uint32 max_illegal_dgram_events;
+        uint32 dgram_event_reset_freq;
+        uint32 log_election_packets;
+        uint32 use_opportunistic_locking;
+        uint32 use_unlock_behind;
+        uint32 use_close_behind;
+        uint32 buf_named_pipes;
+        uint32 use_lock_read_unlock;
+        uint32 utilize_nt_caching;
+        uint32 use_raw_read;
+        uint32 use_raw_write;
+        uint32 use_write_raw_data;
+        uint32 use_encryption;
+        uint32 buf_files_deny_write;
+        uint32 buf_read_only_files;
+        uint32 force_core_create_mode;
+        uint32 use_512_byte_max_transfer;
+    } wkssvc_NetWkstaInfo502;
+
+    /* The [out] union switched on the requested level (encapsulated: the switch
+     * value is emitted ahead of the selected arm, matching the wire). */
+    union wkssvc_NetWkstaInfo switch(uint32 level) {
+        case 100: wkssvc_NetWkstaInfo100 *info100;
+        case 101: wkssvc_NetWkstaInfo101 *info101;
+        case 102: wkssvc_NetWkstaInfo102 *info102;
+        case 502: wkssvc_NetWkstaInfo502 *info502;
+    };
+
+    /* opnum 0 -- NetrWkstaGetInfo. */
+    [opnum(0)] uint32 wkssvc_NetWkstaGetInfo(
+        [in, unique, string] wchar_t       *server_name,
+        [in]  uint32                        level,
+        [out] wkssvc_NetWkstaInfo          *info);
+}

--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -175,6 +175,35 @@ chimera_smb_server_init(
 
     *(XXH128_hash_t *) shared->guid = XXH3_128bits(shared->config.identity, strlen(shared->config.identity));
 
+    /* Derive the server's account-domain (machine) SID S-1-5-21-X-Y-Z once, from
+     * a stable per-host identity (/etc/machine-id, else hostname), so the SIDs
+     * the LSARPC/SAMR services hand out are unique per server and survive a
+     * restart -- a precondition for any stored NT-form ACL to stay valid.  This
+     * replaces the former fixed S-1-5-21-1111-2222-3333. */
+    {
+        char          hostid[256] = { 0 };
+        FILE         *fp          = fopen("/etc/machine-id", "r");
+        XXH128_hash_t h;
+
+        if (fp) {
+            if (!fgets(hostid, sizeof(hostid), fp)) {
+                hostid[0] = '\0';
+            }
+            fclose(fp);
+        }
+        if (hostid[0] == '\0' && gethostname(hostid, sizeof(hostid)) != 0) {
+            hostid[0] = '\0';
+        }
+        if (hostid[0] == '\0') {
+            snprintf(hostid, sizeof(hostid), "chimera-%lx", (unsigned long) gethostid());
+        }
+
+        h                             = XXH3_128bits(hostid, strlen(hostid));
+        shared->machine_domain_sub[0] = (uint32_t) h.low64 | 1;   /* never zero */
+        shared->machine_domain_sub[1] = (uint32_t) (h.low64 >> 32);
+        shared->machine_domain_sub[2] = (uint32_t) h.high64;
+    }
+
     shared->svc      = GSS_C_NO_NAME;
     shared->srv_cred = GSS_C_NO_CREDENTIAL;
 

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -1279,6 +1279,10 @@ struct chimera_server_smb_shared {
     int                               rdma;
     enum evpl_protocol_id             tcp_protocol;
     uint8_t                           guid[SMB2_GUID_SIZE];
+    /* Account-domain (machine) SID sub-authorities: S-1-5-21-X-Y-Z, derived once
+     * at startup from a stable per-host id (see chimera_smb_server_init).  The
+     * LSARPC/SAMR services issue domain-relative SIDs under this. */
+    uint32_t                          machine_domain_sub[3];
     gss_name_t                        svc;
     gss_cred_id_t                     srv_cred;
     struct chimera_vfs               *vfs;

--- a/src/server/smb/smb_lsarpc.c
+++ b/src/server/smb/smb_lsarpc.c
@@ -48,20 +48,22 @@ static const dce_if_uuid_t LSA_INTERFACE = {
  * handler returned (a fixed opaque policy handle, STATUS_SUCCESS); inputs are
  * not consulted, matching prior behaviour.
  */
-/* Fill a SID with the server's fixed machine SID S-1-5-21-1111-2222-3333.  The
- * caller must provide zeroed storage (a dbuf allocation, or a `= { 0 }`
- * initialiser) so the unset identifier-authority and sub-authority bytes are
- * defined. */
+/* Fill a SID with the server's account-domain (machine) SID S-1-5-21-X-Y-Z,
+ * whose sub-authorities are derived once at startup from a stable per-host id
+ * (shared->machine_domain_sub).  The caller must provide zeroed storage (a dbuf
+ * allocation, or a `= { 0 }` initialiser) so the unset bytes are defined. */
 static void
-chimera_smb_lsarpc_machine_sid(struct ndr_sid *sid)
+chimera_smb_lsarpc_machine_sid(
+    struct ndr_sid                         *sid,
+    const struct chimera_server_smb_shared *shared)
 {
     sid->revision                = 1;
     sid->sub_authority_count     = 4;
     sid->identifier_authority[5] = 5; /* NT authority (big-endian) */
     sid->sub_authority[0]        = 21;
-    sid->sub_authority[1]        = 1111;
-    sid->sub_authority[2]        = 2222;
-    sid->sub_authority[3]        = 3333;
+    sid->sub_authority[1]        = shared->machine_domain_sub[0];
+    sid->sub_authority[2]        = shared->machine_domain_sub[1];
+    sid->sub_authority[3]        = shared->machine_domain_sub[2];
 } /* chimera_smb_lsarpc_machine_sid */
 
 /* Binary RPC_SID <-> "S-1-..." string, bridging the NDR SID to the string form
@@ -229,14 +231,15 @@ static void chimera_smb_set_ustr(
 
 static int
 chimera_smb_lsarpc_resolve_name(
-    const char                    *name,
-    struct chimera_vfs_user_cache *cache,
-    struct ndr_dbuf               *dbuf,
-    struct lsa_DomainInfo         *domains,
-    uint32_t                      *ndom,
-    struct ndr_sid                *full,
-    uint32_t                      *type,
-    uint32_t                      *rid)
+    const char                             *name,
+    struct chimera_vfs_user_cache          *cache,
+    struct ndr_dbuf                        *dbuf,
+    const struct chimera_server_smb_shared *shared,
+    struct lsa_DomainInfo                  *domains,
+    uint32_t                               *ndom,
+    struct ndr_sid                         *full,
+    uint32_t                               *type,
+    uint32_t                               *rid)
 {
     char           sidstr[CHIMERA_IDMAP_SID_MAX];
     uint32_t       t = LSA_SID_NAME_UNKNOWN;
@@ -247,7 +250,7 @@ chimera_smb_lsarpc_resolve_name(
     if (!name || name[0] == '\0') {
         /* Empty/NULL name -> the server's own primary (account) domain. */
         struct ndr_sid m = { 0 };
-        chimera_smb_lsarpc_machine_sid(&m);
+        chimera_smb_lsarpc_machine_sid(&m, shared);
         chimera_smb_sid_to_string(&m, sidstr, sizeof(sidstr));
         t        = LSA_SID_NAME_DOMAIN;
         resolved = 1;
@@ -402,12 +405,13 @@ chimera_smb_lsarpc_handle_close(
  */
 static int
 chimera_smb_lsarpc_impl(
-    int                      opnum,
-    const void              *in,
-    void                    *out,
-    struct ndr_dbuf         *dbuf,
-    struct chimera_vfs      *vfs,
-    struct chimera_smb_conn *conn)
+    int                                     opnum,
+    const void                             *in,
+    void                                   *out,
+    struct ndr_dbuf                        *dbuf,
+    struct chimera_vfs                     *vfs,
+    struct chimera_smb_conn                *conn,
+    const struct chimera_server_smb_shared *shared)
 {
     (void) in;
     (void) vfs;
@@ -471,7 +475,7 @@ chimera_smb_lsarpc_impl(
             pi->name.length = (uint16_t) (strlen(domain) * 2);
             pi->name.size   = (uint16_t) (strlen(domain) * 2);
             pi->name.buffer = (char *) domain;
-            chimera_smb_lsarpc_machine_sid(sid);
+            chimera_smb_lsarpc_machine_sid(sid, shared);
             pi->sid   = sid;
             o->info   = pi;
             o->status = 0;
@@ -614,7 +618,7 @@ chimera_smb_lsarpc_impl(
                 sids[i].sid_index = 0xffffffff;
 
                 didx = chimera_smb_lsarpc_resolve_name(li->names[i].buffer, cache,
-                                                       dbuf, domains, &ndom,
+                                                       dbuf, shared, domains, &ndom,
                                                        &full, &type, &rid);
                 if (didx < 0) {
                     continue;
@@ -666,7 +670,7 @@ chimera_smb_lsarpc_impl(
                 sids[i].flags     = 0;
 
                 didx = chimera_smb_lsarpc_resolve_name(li->names[i].buffer, cache,
-                                                       dbuf, domains, &ndom,
+                                                       dbuf, shared, domains, &ndom,
                                                        &full, &type, &rid);
                 if (didx < 0) {
                     continue;
@@ -719,7 +723,7 @@ chimera_smb_lsarpc_impl(
                 sids[i].flags     = 0;
 
                 didx = chimera_smb_lsarpc_resolve_name(li->names[i].buffer, cache,
-                                                       dbuf, domains, &ndom,
+                                                       dbuf, shared, domains, &ndom,
                                                        &full, &type, &rid);
                 if (didx < 0) {
                     continue;
@@ -778,13 +782,14 @@ chimera_smb_lsarpc_ndr_dispatch(
     void                       *output,
     struct chimera_smb_request *request)
 {
-    struct ndr_cursor        c;
-    struct ndr_writer        w;
-    struct ndr_dbuf          dbuf;
-    struct chimera_vfs      *vfs  = request->compound->thread->shared->vfs;
-    struct chimera_smb_conn *conn = request->compound->conn;
-    void                    *in, *out;
-    int                      n;
+    struct ndr_cursor                 c;
+    struct ndr_writer                 w;
+    struct ndr_dbuf                   dbuf;
+    struct chimera_server_smb_shared *shared = request->compound->thread->shared;
+    struct chimera_vfs               *vfs    = shared->vfs;
+    struct chimera_smb_conn          *conn   = request->compound->conn;
+    void                             *in, *out;
+    int                               n;
 
     ndr_cursor_init(&c, evpl_iovec_cursor_data(cursor),
                     cursor->iov->length - cursor->offset);
@@ -796,7 +801,7 @@ chimera_smb_lsarpc_ndr_dispatch(
     out = ndr_dbuf_alloc(&dbuf, op->out_size);
 
     op->pull_in(&c, in, &dbuf);
-    n = chimera_smb_lsarpc_impl(op->opnum, in, out, &dbuf, vfs, conn);
+    n = chimera_smb_lsarpc_impl(op->opnum, in, out, &dbuf, vfs, conn, shared);
 
     /* A context-handle fault skips marshalling: dce_rpc emits a fault PDU from
      * the negative return. */

--- a/src/server/smb/smb_lsarpc.c
+++ b/src/server/smb/smb_lsarpc.c
@@ -49,9 +49,9 @@ static const dce_if_uuid_t LSA_INTERFACE = {
  * not consulted, matching prior behaviour.
  */
 /* Fill a SID with the server's account-domain (machine) SID S-1-5-21-X-Y-Z,
- * whose sub-authorities are derived once at startup from a stable per-host id
- * (shared->machine_domain_sub).  The caller must provide zeroed storage (a dbuf
- * allocation, or a `= { 0 }` initialiser) so the unset bytes are defined. */
+* whose sub-authorities are derived once at startup from a stable per-host id
+* (shared->machine_domain_sub).  The caller must provide zeroed storage (a dbuf
+* allocation, or a `= { 0 }` initialiser) so the unset bytes are defined. */
 static void
 chimera_smb_lsarpc_machine_sid(
     struct ndr_sid                         *sid,

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -19,6 +19,7 @@
 #include "smb_attr.h"
 #include "smb_lsarpc.h"
 #include "smb_srvsvc.h"
+#include "smb_samr.h"
 
 #define SMB2_WRITE_MASK                            (SMB2_FILE_WRITE_DATA | \
                                                     SMB2_FILE_APPEND_DATA | \
@@ -3776,6 +3777,9 @@ chimera_smb_create(struct chimera_smb_request *request)
         } else if (strcasecmp(request->create.name, "srvsvc") == 0) {
             pipe_magic = CHIMERA_SMB_OPEN_FILE_SRV_RPC;
             transceive = chimera_smb_srvsvc_transceive;
+        } else if (strcasecmp(request->create.name, "samr") == 0) {
+            pipe_magic = CHIMERA_SMB_OPEN_FILE_SAMR_RPC;
+            transceive = chimera_smb_samr_transceive;
         } else {
             chimera_smb_complete_request(request, SMB2_STATUS_OBJECT_NAME_NOT_FOUND);
             return;

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -20,6 +20,7 @@
 #include "smb_lsarpc.h"
 #include "smb_srvsvc.h"
 #include "smb_samr.h"
+#include "smb_wkssvc.h"
 
 #define SMB2_WRITE_MASK                            (SMB2_FILE_WRITE_DATA | \
                                                     SMB2_FILE_APPEND_DATA | \
@@ -3780,6 +3781,9 @@ chimera_smb_create(struct chimera_smb_request *request)
         } else if (strcasecmp(request->create.name, "samr") == 0) {
             pipe_magic = CHIMERA_SMB_OPEN_FILE_SAMR_RPC;
             transceive = chimera_smb_samr_transceive;
+        } else if (strcasecmp(request->create.name, "wkssvc") == 0) {
+            pipe_magic = CHIMERA_SMB_OPEN_FILE_WKSSVC_RPC;
+            transceive = chimera_smb_wkssvc_transceive;
         } else {
             chimera_smb_complete_request(request, SMB2_STATUS_OBJECT_NAME_NOT_FOUND);
             return;

--- a/src/server/smb/smb_samr.c
+++ b/src/server/smb/smb_samr.c
@@ -1,0 +1,334 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "smb_samr.h"
+#include "smb_dcerpc.h"
+#include "samr_ndr.h"
+
+/* SAMR interface 12345778-1234-abcd-ef00-0123456789ac v1.0 (note the trailing
+ * ...ac, vs LSARPC's ...ab). */
+static const dce_if_uuid_t SAMR_INTERFACE = {
+    .if_uuid       = { 0x78, 0x57, 0x34, 0x12, 0x34, 0x12, 0xCD, 0xAB,
+                       0xEF, 0x00, 0x01, 0x23, 0x45, 0x67, 0x89, 0xac },
+    .if_vers_major = 1,
+    .if_vers_minor = 0,
+};
+
+#define SAMR_OP_CONNECT            0
+#define SAMR_OP_CLOSE              1
+#define SAMR_OP_LOOKUPDOMAIN       5
+#define SAMR_OP_ENUMDOMAINS        6
+#define SAMR_OP_CONNECT2           21
+#define SAMR_OP_CONNECT5           64
+
+#define SAMR_STATUS_NO_SUCH_DOMAIN 0xC00000DF
+
+#define SAMR_RPC_STUB_MAX          (65535 - (int) (sizeof(dce_common_t) + sizeof(dce_co_response_t)))
+
+/* ---- per-connection context (policy) handles ----
+ * The same fixed per-connection set the LSARPC service uses (conn->rpc_handles):
+ * a 16-byte all-zero slot is free; a handle not in the set faults
+ * CONTEXT_MISMATCH. */
+static int
+chimera_smb_samr_handle_set(const uint8_t uuid[16])
+{
+    for (int i = 0; i < 16; i++) {
+        if (uuid[i]) {
+            return 1;
+        }
+    }
+    return 0;
+} /* chimera_smb_samr_handle_set */
+
+static int
+chimera_smb_samr_handle_open(
+    struct chimera_smb_conn *conn,
+    struct samr_handle      *h)
+{
+    for (int i = 0; i < CHIMERA_SMB_RPC_MAX_HANDLES; i++) {
+        uint64_t a, b;
+
+        if (chimera_smb_samr_handle_set(conn->rpc_handles[i])) {
+            continue;
+        }
+        a = chimera_rand64();
+        b = chimera_rand64();
+        memcpy(conn->rpc_handles[i], &a, 8);
+        memcpy(conn->rpc_handles[i] + 8, &b, 8);
+        conn->rpc_handles[i][0] |= 1;
+
+        h->handle_type = 0;
+        memcpy(h->uuid, conn->rpc_handles[i], 16);
+        return 0;
+    }
+    return -1;
+} /* chimera_smb_samr_handle_open */
+
+static int
+chimera_smb_samr_handle_slot(
+    struct chimera_smb_conn  *conn,
+    const struct samr_handle *h)
+{
+    if (!chimera_smb_samr_handle_set(h->uuid)) {
+        return -1;
+    }
+    for (int i = 0; i < CHIMERA_SMB_RPC_MAX_HANDLES; i++) {
+        if (memcmp(conn->rpc_handles[i], h->uuid, 16) == 0) {
+            return i;
+        }
+    }
+    return -1;
+} /* chimera_smb_samr_handle_slot */
+
+static int
+chimera_smb_samr_handle_valid(
+    struct chimera_smb_conn  *conn,
+    const struct samr_handle *h)
+{
+    return chimera_smb_samr_handle_slot(conn, h) >= 0;
+} /* chimera_smb_samr_handle_valid */
+
+static int
+chimera_smb_samr_handle_close(
+    struct chimera_smb_conn  *conn,
+    const struct samr_handle *h)
+{
+    int slot = chimera_smb_samr_handle_slot(conn, h);
+
+    if (slot < 0) {
+        return 0;
+    }
+    memset(conn->rpc_handles[slot], 0, 16);
+    return 1;
+} /* chimera_smb_samr_handle_close */
+
+/* ---- helpers ---- */
+static void
+chimera_smb_samr_set_ustr(
+    struct samr_String *s,
+    const char         *utf8)
+{
+    s->length = (uint16_t) (strlen(utf8) * 2);
+    s->size   = (uint16_t) (strlen(utf8) * 2);
+    s->buffer = (char *) utf8;
+} /* chimera_smb_samr_set_ustr */
+
+/* BUILTIN domain SID S-1-5-32. */
+static void
+chimera_smb_samr_builtin_sid(struct ndr_sid *sid)
+{
+    memset(sid, 0, sizeof(*sid));
+    sid->revision                = 1;
+    sid->identifier_authority[5] = 5;
+    sid->sub_authority_count     = 1;
+    sid->sub_authority[0]        = 32;
+} /* chimera_smb_samr_builtin_sid */
+
+/* The server's account-domain (machine) SID S-1-5-21-X-Y-Z. */
+static void
+chimera_smb_samr_account_sid(
+    struct ndr_sid                         *sid,
+    const struct chimera_server_smb_shared *shared)
+{
+    memset(sid, 0, sizeof(*sid));
+    sid->revision                = 1;
+    sid->identifier_authority[5] = 5;
+    sid->sub_authority_count     = 4;
+    sid->sub_authority[0]        = 21;
+    sid->sub_authority[1]        = shared->machine_domain_sub[0];
+    sid->sub_authority[2]        = shared->machine_domain_sub[1];
+    sid->sub_authority[3]        = shared->machine_domain_sub[2];
+} /* chimera_smb_samr_account_sid */
+
+/*
+ * Business logic for the generated SAMR ops.  Read-only foundation: connect,
+ * enumerate the server's two domains (the account domain named after the
+ * server, and BUILTIN), and resolve a domain name to its SID.  Returns 0, or
+ * DCE_RC_FAULT_CONTEXT_MISMATCH when handed a handle this connection did not
+ * issue.
+ */
+static int
+chimera_smb_samr_impl(
+    int                                     opnum,
+    const void                             *in,
+    void                                   *out,
+    struct ndr_dbuf                        *dbuf,
+    struct chimera_smb_conn                *conn,
+    const struct chimera_server_smb_shared *shared)
+{
+    const char *account_domain = shared->config.identity;
+
+    (void) in;
+
+    switch (opnum) {
+        case SAMR_OP_CONNECT: {
+            struct samr_Connect_out *o = out;
+            if (chimera_smb_samr_handle_open(conn, &o->connect_handle) != 0) {
+                memset(&o->connect_handle, 0, sizeof(o->connect_handle));
+                o->status = SAMR_STATUS_NO_SUCH_DOMAIN;
+            } else {
+                o->status = 0;
+            }
+            break;
+        }
+        case SAMR_OP_CONNECT2: {
+            struct samr_Connect2_out *o = out;
+            if (chimera_smb_samr_handle_open(conn, &o->connect_handle) != 0) {
+                memset(&o->connect_handle, 0, sizeof(o->connect_handle));
+                o->status = SAMR_STATUS_NO_SUCH_DOMAIN;
+            } else {
+                o->status = 0;
+            }
+            break;
+        }
+        case SAMR_OP_CONNECT5: {
+            struct samr_Connect5_out *o = out;
+            if (chimera_smb_samr_handle_open(conn, &o->connect_handle) != 0) {
+                memset(&o->connect_handle, 0, sizeof(o->connect_handle));
+                o->status = SAMR_STATUS_NO_SUCH_DOMAIN;
+                break;
+            }
+            /* Echo a level-1 revision info (the version the client negotiated). */
+            o->level_out                         = 1;
+            o->info_out.level                    = 1;
+            o->info_out.info1.client_version     = 1;
+            o->info_out.info1.supported_features = 0;
+            o->status                            = 0;
+            break;
+        }
+        case SAMR_OP_CLOSE: {
+            const struct samr_Close_in *li = in;
+            struct samr_Close_out      *o  = out;
+            if (!chimera_smb_samr_handle_close(conn, &li->handle)) {
+                return DCE_RC_FAULT_CONTEXT_MISMATCH;
+            }
+            o->handle.handle_type = 0;
+            memset(o->handle.uuid, 0, sizeof(o->handle.uuid));
+            o->status = 0;
+            break;
+        }
+        case SAMR_OP_ENUMDOMAINS: {
+            const struct samr_EnumDomains_in *li  = in;
+            struct samr_EnumDomains_out      *o   = out;
+            struct samr_SamArray             *sam = ndr_dbuf_alloc(dbuf, sizeof(*sam));
+            struct samr_SamEntry             *e   = ndr_dbuf_alloc(dbuf, 2 * sizeof(*e));
+
+            if (!chimera_smb_samr_handle_valid(conn, &li->connect_handle)) {
+                return DCE_RC_FAULT_CONTEXT_MISMATCH;
+            }
+
+            e[0].idx = 0;
+            chimera_smb_samr_set_ustr(&e[0].name, account_domain);
+            e[1].idx = 0;
+            chimera_smb_samr_set_ustr(&e[1].name, "Builtin");
+
+            sam->count       = 2;
+            sam->entries     = e;
+            o->sam           = sam;
+            o->num_entries   = 2;
+            o->resume_handle = 0;
+            o->status        = 0;
+            break;
+        }
+        case SAMR_OP_LOOKUPDOMAIN: {
+            const struct samr_LookupDomain_in *li  = in;
+            struct samr_LookupDomain_out      *o   = out;
+            const char                        *dom = li->domain_name.buffer;
+            struct ndr_sid                    *sid;
+
+            if (!chimera_smb_samr_handle_valid(conn, &li->connect_handle)) {
+                return DCE_RC_FAULT_CONTEXT_MISMATCH;
+            }
+
+            o->sid.sid = NULL;
+
+            if (!dom) {
+                o->status = SAMR_STATUS_NO_SUCH_DOMAIN;
+                break;
+            }
+
+            sid = ndr_dbuf_alloc(dbuf, sizeof(*sid));
+            if (strcasecmp(dom, "Builtin") == 0) {
+                chimera_smb_samr_builtin_sid(sid);
+                o->sid.sid = sid;
+                o->status  = 0;
+            } else if (strcasecmp(dom, account_domain) == 0) {
+                chimera_smb_samr_account_sid(sid, shared);
+                o->sid.sid = sid;
+                o->status  = 0;
+            } else {
+                o->status = SAMR_STATUS_NO_SUCH_DOMAIN;
+            }
+            break;
+        }
+        default:
+            break;
+    } /* switch */
+
+    return 0;
+} /* chimera_smb_samr_impl */
+
+static int
+chimera_smb_samr_handler(
+    int                       opnum,
+    struct evpl_iovec_cursor *cursor,
+    void                     *output,
+    void                     *private_data)
+{
+    struct chimera_smb_request       *request = private_data;
+    struct chimera_server_smb_shared *shared  = request->compound->thread->shared;
+    const struct ndr_op_desc         *op;
+    struct ndr_cursor                 c;
+    struct ndr_writer                 w;
+    struct ndr_dbuf                   dbuf;
+    void                             *in, *out;
+    int                               n;
+
+    op = ndr_find_op(samr_op_table, samr_op_count, opnum);
+    if (!op) {
+        return -1;
+    }
+
+    ndr_cursor_init(&c, evpl_iovec_cursor_data(cursor),
+                    cursor->iov->length - cursor->offset);
+    ndr_dbuf_init(&dbuf, 4096);
+
+    in  = ndr_dbuf_alloc(&dbuf, op->in_size);
+    out = ndr_dbuf_alloc(&dbuf, op->out_size);
+
+    op->pull_in(&c, in, &dbuf);
+    n = chimera_smb_samr_impl(op->opnum, in, out, &dbuf,
+                              request->compound->conn, shared);
+
+    if (n < 0) {
+        ndr_dbuf_destroy(&dbuf);
+        return n;
+    }
+
+    ndr_writer_init(&w, output, SAMR_RPC_STUB_MAX);
+    n = op->push_out(&w, out);
+
+    ndr_dbuf_destroy(&dbuf);
+    return n;
+} /* chimera_smb_samr_handler */
+
+int
+chimera_smb_samr_transceive(
+    struct chimera_smb_request *request,
+    struct evpl_iovec          *input_iov,
+    int                         input_niov,
+    struct evpl_iovec          *output_iov)
+{
+    int status;
+
+    status = dce_rpc(&SAMR_INTERFACE, input_iov, input_niov, output_iov,
+                     chimera_smb_samr_handler, request);
+
+    if (status != 0) {
+        chimera_smb_error("SAMR RPC transceive failed");
+        return status;
+    }
+
+    return 0;
+} /* chimera_smb_samr_transceive */

--- a/src/server/smb/smb_samr.h
+++ b/src/server/smb/smb_samr.h
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#pragma once
+
+#include "smb_internal.h"
+
+int
+chimera_smb_samr_transceive(
+    struct chimera_smb_request *request,
+    struct evpl_iovec          *input_iov,
+    int                         input_niov,
+    struct evpl_iovec          *output_iov);

--- a/src/server/smb/smb_session.h
+++ b/src/server/smb/smb_session.h
@@ -111,6 +111,7 @@ enum chimera_smb_open_file_type {
 enum chimera_smb_pipe_magic {
     CHIMERA_SMB_OPEN_FILE_LSA_RPC,
     CHIMERA_SMB_OPEN_FILE_SRV_RPC,
+    CHIMERA_SMB_OPEN_FILE_SAMR_RPC,
 };
 
 struct chimera_smb_request;

--- a/src/server/smb/smb_session.h
+++ b/src/server/smb/smb_session.h
@@ -112,6 +112,7 @@ enum chimera_smb_pipe_magic {
     CHIMERA_SMB_OPEN_FILE_LSA_RPC,
     CHIMERA_SMB_OPEN_FILE_SRV_RPC,
     CHIMERA_SMB_OPEN_FILE_SAMR_RPC,
+    CHIMERA_SMB_OPEN_FILE_WKSSVC_RPC,
 };
 
 struct chimera_smb_request;

--- a/src/server/smb/smb_wkssvc.c
+++ b/src/server/smb/smb_wkssvc.c
@@ -1,0 +1,152 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "smb_wkssvc.h"
+#include "smb_dcerpc.h"
+#include "wkssvc_ndr.h"
+
+/* WKSSVC interface 6bffd098-a112-3610-9833-46c3f87e345a v1.0 (GUID wire form:
+ * first three fields little-endian, last two big-endian). */
+static const dce_if_uuid_t WKS_INTERFACE = {
+    .if_uuid       = { 0x98, 0xd0, 0xff, 0x6b, 0x12, 0xa1, 0x10, 0x36,
+                       0x98, 0x33, 0x46, 0xc3, 0xf8, 0x7e, 0x34, 0x5a },
+    .if_vers_major = 1,
+    .if_vers_minor = 0,
+};
+
+#define WKS_OP_NETWKSTAGETINFO 0
+
+#define WKS_PLATFORM_ID_NT     500
+#define WKS_WERR_UNKNOWN_LEVEL 0x0000007C
+
+#define WKS_RPC_STUB_MAX       (65535 - (int) (sizeof(dce_common_t) + sizeof(dce_co_response_t)))
+
+static void
+chimera_smb_wkssvc_impl(
+    int                               opnum,
+    const void                       *in,
+    void                             *out,
+    struct ndr_dbuf                  *dbuf,
+    struct chimera_server_smb_shared *shared)
+{
+    (void) in;
+
+    switch (opnum) {
+        case WKS_OP_NETWKSTAGETINFO: {
+            const struct wkssvc_NetWkstaGetInfo_in *in_w = in;
+            struct wkssvc_NetWkstaGetInfo_out      *o    = out;
+            char                                   *name = (char *) shared->config.identity;
+
+            o->info.switch_value = in_w->level;
+            memset(&o->info.u, 0, sizeof(o->info.u));
+            o->status = 0;
+
+            switch (in_w->level) {
+                case 100: {
+                    struct wkssvc_NetWkstaInfo100 *i = ndr_dbuf_alloc(dbuf, sizeof(*i));
+                    i->platform_id    = WKS_PLATFORM_ID_NT;
+                    i->server_name    = name;
+                    i->domain_name    = "WORKGROUP";
+                    i->version_major  = 6;
+                    i->version_minor  = 1;
+                    o->info.u.info100 = i;
+                    break;
+                }
+                case 101: {
+                    struct wkssvc_NetWkstaInfo101 *i = ndr_dbuf_alloc(dbuf, sizeof(*i));
+                    i->platform_id    = WKS_PLATFORM_ID_NT;
+                    i->server_name    = name;
+                    i->domain_name    = "WORKGROUP";
+                    i->version_major  = 6;
+                    i->version_minor  = 1;
+                    i->lan_root       = "";
+                    o->info.u.info101 = i;
+                    break;
+                }
+                case 102: {
+                    struct wkssvc_NetWkstaInfo102 *i = ndr_dbuf_alloc(dbuf, sizeof(*i));
+                    i->platform_id     = WKS_PLATFORM_ID_NT;
+                    i->server_name     = name;
+                    i->domain_name     = "WORKGROUP";
+                    i->version_major   = 6;
+                    i->version_minor   = 1;
+                    i->lan_root        = "";
+                    i->logged_on_users = 1;
+                    o->info.u.info102  = i;
+                    break;
+                }
+                case 502: {
+                    /* Tuning parameters; reported as zeros (the arena zeroes the
+                     * allocation), which clients accept. */
+                    o->info.u.info502 = ndr_dbuf_alloc(dbuf, sizeof(struct wkssvc_NetWkstaInfo502));
+                    break;
+                }
+                default:
+                    o->status = WKS_WERR_UNKNOWN_LEVEL;
+                    break;
+            } /* switch level */
+            break;
+        }
+        default:
+            break;
+    } /* switch */
+} /* chimera_smb_wkssvc_impl */
+
+static int
+chimera_smb_wkssvc_handler(
+    int                       opnum,
+    struct evpl_iovec_cursor *cursor,
+    void                     *output,
+    void                     *private_data)
+{
+    struct chimera_smb_request *request = private_data;
+    const struct ndr_op_desc   *op;
+    struct ndr_cursor           c;
+    struct ndr_writer           w;
+    struct ndr_dbuf             dbuf;
+    void                       *in, *out;
+    int                         n;
+
+    op = ndr_find_op(wkssvc_op_table, wkssvc_op_count, opnum);
+    if (!op) {
+        return -1;
+    }
+
+    ndr_cursor_init(&c, evpl_iovec_cursor_data(cursor),
+                    cursor->iov->length - cursor->offset);
+    ndr_dbuf_init(&dbuf, 4096);
+
+    in  = ndr_dbuf_alloc(&dbuf, op->in_size);
+    out = ndr_dbuf_alloc(&dbuf, op->out_size);
+
+    op->pull_in(&c, in, &dbuf);
+    chimera_smb_wkssvc_impl(op->opnum, in, out, &dbuf,
+                            request->compound->thread->shared);
+
+    ndr_writer_init(&w, output, WKS_RPC_STUB_MAX);
+    n = op->push_out(&w, out);
+
+    ndr_dbuf_destroy(&dbuf);
+    return n;
+} /* chimera_smb_wkssvc_handler */
+
+int
+chimera_smb_wkssvc_transceive(
+    struct chimera_smb_request *request,
+    struct evpl_iovec          *input_iov,
+    int                         input_niov,
+    struct evpl_iovec          *output_iov)
+{
+    int status;
+
+    status = dce_rpc(&WKS_INTERFACE, input_iov, input_niov, output_iov,
+                     chimera_smb_wkssvc_handler, request);
+
+    if (status != 0) {
+        chimera_smb_error("WKSSVC RPC transceive failed");
+        return status;
+    }
+
+    return 0;
+} /* chimera_smb_wkssvc_transceive */

--- a/src/server/smb/smb_wkssvc.h
+++ b/src/server/smb/smb_wkssvc.h
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#pragma once
+
+#include "smb_internal.h"
+
+int
+chimera_smb_wkssvc_transceive(
+    struct chimera_smb_request *request,
+    struct evpl_iovec          *input_iov,
+    int                         input_niov,
+    struct evpl_iovec          *output_iov);

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -301,11 +301,14 @@ set_tests_properties(chimera/server/smb/rpcclient_lsa PROPERTIES
 #   rpc.lsa.lookupnames : name->SID via LookupNames / LookupNames2 / LookupNames3
 #                        (opnums 14/58/68), including well-known names and the
 #                        NULL-name and policy-handle cases.
+#   rpc.wkssvc...NetWkstaGetInfo : workstation info levels 100/101/102/502,
+#                        exercising a multi-arm [switch_is] union.
 set(SMBTORTURE_RPC_SUITES_ENABLED
     rpc.lsa.lookupsids
     rpc.lsa.lookupnames
     rpc.handles.lsarpc
-    "rpc.srvsvc.srvsvc (admin access).NetShareEnumAll")
+    "rpc.srvsvc.srvsvc (admin access).NetShareEnumAll"
+    rpc.wkssvc.wkssvc.NetWkstaGetInfo)
 
 foreach(SUITE ${SMBTORTURE_RPC_SUITES_ENABLED})
     string(REGEX REPLACE "[^A-Za-z0-9]" "_" SUITE_ID ${SUITE})


### PR DESCRIPTION
Layered on #812 (the stack: #807 → #808 → #810 → #812 → this). The new commit here is the last one.

Focused on **gated** work — this banks a new Windows-free smbtorture gate, **`rpc.wkssvc.wkssvc.NetWkstaGetInfo`**.

## What
A fourth named-pipe interface, **`\wkssvc`** (MS-WKST), generated by ndrzcc, implementing **NetrWkstaGetInfo** (opnum 0) at levels **100/101/102/502** — the workstation info a client probes during the browse/negotiate handshake.

The `[out]` info is a real **multi-arm `[switch_is]` union** (one arm per level) — the first use of ndrzcc's union codegen (no compiler change needed; it emits the encapsulated discriminant followed by the selected arm). Level 502 is the 35-field tuning struct, reported as zeros (clients accept it).

## Gate
- **`rpc.wkssvc.wkssvc.NetWkstaGetInfo` → enabled, passing** (new) — exercises all four levels, validated by the real Samba client.
- The five existing RPC gates (lookupsids, lookupnames, handles.lsarpc, srvsvc NetShareEnumAll, plus rpcclient_lsa) still pass.

## Why this and not more SAMR
The remaining NAS-relevant smbtorture gates are union-shaped or DC-shaped; this one was reachable because the `[out]` union only needs push (pull is unused for out params). SAMR's suites skip against a samba3-style server, so the SAMR user-enum follow-up has no gate — hence prioritizing this.

## Verification
All RPC gates pass via ctest under Release **and Debug/ASan**; `make syntax` clean. Built clean (the multi-arm union co-links with the other three interfaces).