### PR TITLE
ci: route trivial jobs to the arc-small (no-dind) runner set

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -629,7 +629,7 @@ jobs:
     name: Report
     needs: [test, test-dev]
     if: ${{ always() && github.event_name != 'pull_request' }}
-    runs-on: arc-amd64
+    runs-on: arc-small
     permissions:
       pull-requests: write
       contents: read
@@ -742,7 +742,7 @@ jobs:
     name: Compiles complete
     needs: [build-dev, build-os]
     if: ${{ github.event_name != 'pull_request' }}
-    runs-on: arc-amd64
+    runs-on: arc-small
     permissions:
       contents: read
     steps:
@@ -874,7 +874,7 @@ jobs:
     name: Collect flaky-test markers
     needs: [test, test-dev]
     if: ${{ always() }}
-    runs-on: arc-amd64
+    runs-on: arc-small
     permissions:
       contents: read
       issues: write
@@ -944,7 +944,7 @@ jobs:
     name: Flake review gate
     needs: collect-flakes
     if: ${{ always() }}
-    runs-on: arc-amd64
+    runs-on: arc-small
     permissions:
       contents: read
     environment: ${{ needs.collect-flakes.outputs.flaky == 'true' && 'flake-review' || '' }}
@@ -975,7 +975,7 @@ jobs:
       - test-dev
       - static-analysis
     if: ${{ always() }}
-    runs-on: arc-amd64
+    runs-on: arc-small
     permissions:
       contents: read
     steps:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -144,7 +144,7 @@ jobs:
     name: Docker build complete
     needs: build-and-push
     if: ${{ always() }}
-    runs-on: arc-amd64
+    runs-on: arc-small
     permissions:
       contents: read
     steps:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -21,14 +21,14 @@ permissions:
 jobs:
   ci-complete:
     name: CI complete
-    runs-on: arc-amd64
+    runs-on: arc-small
     steps:
       - name: PR placeholder
         run: echo "PR placeholder -- the full build/test matrix runs in the merge queue (merge_group)."
 
   flake-gate:
     name: Flake review gate
-    runs-on: arc-amd64
+    runs-on: arc-small
     # No environment here: flaky-test review only applies to the real test run,
     # which happens in the merge queue.  Keeping this a plain no-op means a PR
     # never sits waiting on a manual approval just to be queued.
@@ -38,7 +38,7 @@ jobs:
 
   docker-build-complete:
     name: Docker build complete
-    runs-on: arc-amd64
+    runs-on: arc-small
     steps:
       - name: PR placeholder
         run: echo "PR placeholder -- docker image builds run in the merge queue (merge_group)."

--- a/.github/workflows/reuse-compliance.yml
+++ b/.github/workflows/reuse-compliance.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   reuse-lint:
-    runs-on: arc-amd64
+    runs-on: arc-small
     
     steps:
     - name: Checkout repository

--- a/.github/workflows/syntax-check.yml
+++ b/.github/workflows/syntax-check.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   syntax-check:
     name: Check code formatting with uncrustify
-    runs-on: arc-amd64
+    runs-on: arc-small
     
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Move lint/report/gate jobs off the heavy 32-core arc-amd64 pool onto the new lightweight no-DinD arc-small scale set (250m/256Mi req, 2/2Gi limit). These jobs are arch-agnostic and use no Docker:

- reuse-compliance: reuse-lint
- syntax-check: syntax-check
- pr-checks: ci-complete, flake-gate, docker-build-complete
- build-test: publish-test-results, build-complete, collect-flakes, flake-gate, ci-complete
- docker-build: docker-build-complete

merge-manifests stays on arc-amd64 (needs the Docker CLI/daemon). Heavy build/test/static-analysis jobs are unchanged.