### PR TITLE
vfs: stop conflating FSID with statfs values in the attr mask

### DIFF
--- a/src/server/nfs/nfs4_root.c
+++ b/src/server/nfs/nfs4_root.c
@@ -44,7 +44,12 @@ nfs4_root_getattr(
     attr->va_dev   = 0;
     attr->va_rdev  = 0;
 
-    if (attr->va_req_mask & CHIMERA_VFS_ATTR_MASK_STATFS) {
+    if (attr->va_req_mask & CHIMERA_VFS_ATTR_FSID) {
+        attr->va_set_mask |= CHIMERA_VFS_ATTR_FSID;
+        attr->va_fsid      = 0;
+    }
+
+    if (attr->va_req_mask & CHIMERA_VFS_ATTR_MASK_STATFS_VALUES) {
         attr->va_set_mask      |= CHIMERA_VFS_ATTR_MASK_STATFS;
         attr->va_fs_space_total = 0;
         attr->va_fs_space_free  = 0;

--- a/src/vfs/cairn/cairn.c
+++ b/src/vfs/cairn/cairn.c
@@ -1724,7 +1724,7 @@ cairn_map_attrs(
         attr->va_fsid      = shared->fsid;
     }
 
-    if (attr->va_req_mask & CHIMERA_VFS_ATTR_MASK_STATFS) {
+    if (attr->va_req_mask & CHIMERA_VFS_ATTR_MASK_STATFS_VALUES) {
         attr->va_set_mask      |= CHIMERA_VFS_ATTR_MASK_STATFS;
         attr->va_fs_space_avail = CHIMERA_VFS_SYNTHETIC_FS_BYTES;
         attr->va_fs_space_free  = CHIMERA_VFS_SYNTHETIC_FS_BYTES;
@@ -1733,6 +1733,7 @@ cairn_map_attrs(
         attr->va_fs_files_total = CHIMERA_VFS_SYNTHETIC_FS_INODES;
         attr->va_fs_files_free  = CHIMERA_VFS_SYNTHETIC_FS_INODES;
         attr->va_fs_files_avail = CHIMERA_VFS_SYNTHETIC_FS_INODES;
+        attr->va_fsid           = shared->fsid;
     }
 } /* cairn_map_attrs */
 

--- a/src/vfs/diskfs/diskfs_internal.h
+++ b/src/vfs/diskfs/diskfs_internal.h
@@ -4354,7 +4354,7 @@ diskfs_map_attrs(
                                inode->mode);
     }
 
-    if (attr->va_req_mask & CHIMERA_VFS_ATTR_MASK_STATFS) {
+    if (attr->va_req_mask & CHIMERA_VFS_ATTR_MASK_STATFS_VALUES) {
         attr->va_set_mask |= CHIMERA_VFS_ATTR_MASK_STATFS;
         /* Free/used are derived from the space map's live per-AG free counts
          * (cold path) rather than a running counter the alloc/free fast path

--- a/src/vfs/linux/linux_common.h
+++ b/src/vfs/linux/linux_common.h
@@ -139,6 +139,15 @@ chimera_linux_stat_to_attr(
     attr->va_atime      = st->st_atim;
     attr->va_mtime      = st->st_mtim;
     attr->va_ctime      = st->st_ctim;
+
+    /* FSID is part of the statfs set but is also an ordinary per-file
+     * attribute (NFSv3 post-op attrs carry it).  Satisfy it cheaply from the
+     * device id here so an FSID-carrying stat request does not have to make a
+     * cold fstatvfs() call on the hot path. */
+    if (attr->va_req_mask & CHIMERA_VFS_ATTR_FSID) {
+        attr->va_set_mask |= CHIMERA_VFS_ATTR_FSID;
+        attr->va_fsid      = st->st_dev;
+    }
 } /* linux_stat_to_chimera_attr */
 
 static inline void
@@ -164,6 +173,14 @@ chimera_linux_statx_to_attr(
     attr->va_mtime.tv_nsec = stx->stx_mtime.tv_nsec;
     attr->va_ctime.tv_sec  = stx->stx_ctime.tv_sec;
     attr->va_ctime.tv_nsec = stx->stx_ctime.tv_nsec;
+
+    /* See chimera_linux_stat_to_attr: satisfy FSID cheaply from the device id
+     * so an FSID-carrying stat request avoids a cold fstatvfs() on the hot
+     * path. */
+    if (attr->va_req_mask & CHIMERA_VFS_ATTR_FSID) {
+        attr->va_set_mask |= CHIMERA_VFS_ATTR_FSID;
+        attr->va_fsid      = attr->va_dev;
+    }
 } /* io_uring_stat_to_chimera_attr */
 
 static inline void
@@ -172,7 +189,12 @@ chimera_linux_statvfs_to_attr(
     struct statvfs           *stvfs)
 {
 
-    attr->va_set_mask      |= CHIMERA_VFS_ATTR_MASK_STATFS;
+    /* FSID is intentionally NOT taken from statvfs f_fsid here: it is sourced
+     * consistently from the device id in the stat path (see
+     * chimera_linux_stat_to_attr), so that the FSID reported on the hot,
+     * stat-only path matches the FSID reported alongside a full statfs.  This
+     * helper claims only the statfs *value* bits. */
+    attr->va_set_mask      |= CHIMERA_VFS_ATTR_MASK_STATFS_VALUES;
     attr->va_fs_space_total = stvfs->f_blocks * stvfs->f_bsize;
     attr->va_fs_space_free  = stvfs->f_bavail * stvfs->f_bsize;
     attr->va_fs_space_avail = attr->va_fs_space_free;
@@ -181,7 +203,6 @@ chimera_linux_statvfs_to_attr(
     attr->va_fs_files_avail = stvfs->f_ffree;
     attr->va_fs_files_free  = stvfs->f_ffree;
     attr->va_fs_files_total = stvfs->f_files;
-    attr->va_fsid           = stvfs->f_fsid;
 } /* linux_statvfs_to_chimera_attr */
 
 static int
@@ -365,7 +386,7 @@ chimera_linux_map_attrs(
     struct stat    st;
     struct statvfs stvfs;
 
-    if (attr->va_req_mask & CHIMERA_VFS_ATTR_MASK_STAT) {
+    if (attr->va_req_mask & (CHIMERA_VFS_ATTR_MASK_STAT | CHIMERA_VFS_ATTR_FSID)) {
 
         rc = fstat(fd, &st);
 
@@ -376,7 +397,7 @@ chimera_linux_map_attrs(
         chimera_linux_stat_to_attr(attr, &st);
     }
 
-    if (attr->va_req_mask & CHIMERA_VFS_ATTR_MASK_STATFS) {
+    if (attr->va_req_mask & CHIMERA_VFS_ATTR_MASK_STATFS_VALUES) {
         rc = fstatvfs(fd, &stvfs);
 
         if (rc == 0) {
@@ -398,11 +419,11 @@ chimera_linux_map_attrs_statx(
 
     attr->va_set_mask = 0;
 
-    if (attr->va_req_mask & CHIMERA_VFS_ATTR_MASK_STAT) {
+    if (attr->va_req_mask & (CHIMERA_VFS_ATTR_MASK_STAT | CHIMERA_VFS_ATTR_FSID)) {
         chimera_linux_statx_to_attr(attr, stx);
     }
 
-    if (attr->va_req_mask & CHIMERA_VFS_ATTR_MASK_STATFS) {
+    if (attr->va_req_mask & CHIMERA_VFS_ATTR_MASK_STATFS_VALUES) {
         rc = fstatvfs(fd, &stvfs);
 
         if (rc == 0) {
@@ -428,7 +449,7 @@ chimera_linux_map_child_attrs(
 
     attr->va_set_mask = 0;
 
-    if (attr->va_req_mask & CHIMERA_VFS_ATTR_MASK_STAT) {
+    if (attr->va_req_mask & (CHIMERA_VFS_ATTR_MASK_STAT | CHIMERA_VFS_ATTR_FSID)) {
 
         rc = fstatat(dirfd, name, &st, AT_SYMLINK_NOFOLLOW);
 
@@ -451,7 +472,7 @@ chimera_linux_map_child_attrs(
         attr->va_set_mask |= CHIMERA_VFS_ATTR_FH;
     }
 
-    if (attr->va_req_mask & CHIMERA_VFS_ATTR_MASK_STATFS) {
+    if (attr->va_req_mask & CHIMERA_VFS_ATTR_MASK_STATFS_VALUES) {
         rc = fstatvfs(dirfd, &stvfs);
 
         if (rc == 0) {
@@ -476,7 +497,7 @@ chimera_linux_map_child_attrs_statx(
 
     (void) fh_magic; /* No longer used, kept for API compatibility */
 
-    if (attr->va_req_mask & CHIMERA_VFS_ATTR_MASK_STAT) {
+    if (attr->va_req_mask & (CHIMERA_VFS_ATTR_MASK_STAT | CHIMERA_VFS_ATTR_FSID)) {
 
         chimera_linux_statx_to_attr(attr, stx);
     }
@@ -493,7 +514,7 @@ chimera_linux_map_child_attrs_statx(
         attr->va_set_mask |= CHIMERA_VFS_ATTR_FH;
     }
 
-    if (attr->va_req_mask & CHIMERA_VFS_ATTR_MASK_STATFS) {
+    if (attr->va_req_mask & CHIMERA_VFS_ATTR_MASK_STATFS_VALUES) {
         rc = fstatvfs(dirfd, &stvfs);
 
         if (rc == 0) {

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -1335,7 +1335,7 @@ memfs_map_attrs(
         memcpy(attr->va_pnfs, inode->remote->data, inode->remote->len);
     }
 
-    if (attr->va_req_mask & CHIMERA_VFS_ATTR_MASK_STATFS) {
+    if (attr->va_req_mask & CHIMERA_VFS_ATTR_MASK_STATFS_VALUES) {
         attr->va_set_mask      |= CHIMERA_VFS_ATTR_MASK_STATFS;
         attr->va_fs_space_total = shared->fs_size ? shared->fs_size :
             CHIMERA_VFS_SYNTHETIC_FS_BYTES;
@@ -1347,6 +1347,7 @@ memfs_map_attrs(
         attr->va_fs_files_total = CHIMERA_VFS_SYNTHETIC_FS_INODES;
         attr->va_fs_files_free  = CHIMERA_VFS_SYNTHETIC_FS_INODES;
         attr->va_fs_files_avail = CHIMERA_VFS_SYNTHETIC_FS_INODES;
+        attr->va_fsid           = shared->fsid;
     }
 
 } /* memfs_map_attrs */
@@ -1893,7 +1894,12 @@ memfs_mount(
         attr->va_btime     = inode->btime;
     }
 
-    if (attr->va_req_mask & CHIMERA_VFS_ATTR_MASK_STATFS) {
+    if (attr->va_req_mask & CHIMERA_VFS_ATTR_FSID) {
+        attr->va_set_mask |= CHIMERA_VFS_ATTR_FSID;
+        attr->va_fsid      = shared->fsid;
+    }
+
+    if (attr->va_req_mask & CHIMERA_VFS_ATTR_MASK_STATFS_VALUES) {
         attr->va_set_mask      |= CHIMERA_VFS_ATTR_MASK_STATFS;
         attr->va_fs_space_total = shared->fs_size ? shared->fs_size :
             CHIMERA_VFS_SYNTHETIC_FS_BYTES;

--- a/src/vfs/root/vfs_root.c
+++ b/src/vfs/root/vfs_root.c
@@ -146,7 +146,12 @@ chimera_vfs_root_getattr(
     attr->va_dev   = 0;
     attr->va_rdev  = 0;
 
-    if (attr->va_req_mask & CHIMERA_VFS_ATTR_MASK_STATFS) {
+    if (attr->va_req_mask & CHIMERA_VFS_ATTR_FSID) {
+        attr->va_set_mask |= CHIMERA_VFS_ATTR_FSID;
+        attr->va_fsid      = 0;
+    }
+
+    if (attr->va_req_mask & CHIMERA_VFS_ATTR_MASK_STATFS_VALUES) {
         attr->va_set_mask      |= CHIMERA_VFS_ATTR_MASK_STATFS;
         attr->va_fs_space_total = 0;
         attr->va_fs_space_free  = 0;

--- a/src/vfs/tests/CMakeLists.txt
+++ b/src/vfs/tests/CMakeLists.txt
@@ -52,6 +52,10 @@ add_executable(vfs_identity_test vfs_identity_test.c)
 target_link_libraries(vfs_identity_test chimera_vfs chimera_vfs_memfs evpl urcu-qsbr)
 add_test(chimera/vfs/identity_test vfs_identity_test)
 
+add_executable(vfs_statfs_mask_test vfs_statfs_mask_test.c)
+target_link_libraries(vfs_statfs_mask_test chimera_vfs chimera_vfs_memfs chimera_vfs_memkv evpl urcu-qsbr)
+add_test(chimera/vfs/statfs_mask_test vfs_statfs_mask_test)
+
 # Tag every test registered above with the 'vfs' label so the suite can be run
 # independently via `ctest -L vfs`.
 get_property(_vfs_tests DIRECTORY PROPERTY TESTS)

--- a/src/vfs/tests/vfs_statfs_mask_test.c
+++ b/src/vfs/tests/vfs_statfs_mask_test.c
@@ -1,0 +1,257 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * Regression test for the STATFS/FSID attribute-mask conflation.
+ *
+ * FSID is dual-purpose: it is part of the statfs response set, but it is also
+ * an ordinary per-file attribute that ordinary stat-style requests carry (an
+ * NFSv3 post-op attr request includes FSID).  Because FSID used to be the only
+ * thing distinguishing CHIMERA_VFS_ATTR_MASK_STATFS from "a normal attr
+ * request", backends that gated their (cold, lock-heavy) full statfs
+ * computation on `va_req_mask & CHIMERA_VFS_ATTR_MASK_STATFS` ran that
+ * computation on every LOOKUP/CREATE/WRITE reply -- turning a cold path hot.
+ *
+ * The fix introduces CHIMERA_VFS_ATTR_MASK_STATFS_VALUES (the statfs value
+ * fields with FSID excluded) as the gate.  This test pins both halves:
+ *
+ *   1. The mask invariants, so nobody re-conflates FSID into the value gate.
+ *   2. The observable behaviour on an engine-authoritative backend (memfs):
+ *      an NFSv3-style request (stat fields + FSID) yields FSID but does NOT
+ *      populate the statfs value fields, while a full statfs request does.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#undef NDEBUG
+#include <assert.h>
+
+#include "evpl/evpl.h"
+#include "vfs/vfs.h"
+#include "vfs/vfs_procs.h"
+#include "vfs/vfs_release.h"
+#include "vfs/vfs_attrs.h"
+#include "vfs/vfs_cred.h"
+#include "vfs/vfs_error.h"
+#include "common/logging.h"
+#include "prometheus-c.h"
+
+#define TEST_PASS(name) fprintf(stderr, "  PASS: %s\n", name)
+
+/* The six statfs *value* bits, none of which is FSID. */
+#define STATFS_VALUE_BITS ( \
+            CHIMERA_VFS_ATTR_SPACE_AVAIL | \
+            CHIMERA_VFS_ATTR_SPACE_FREE | \
+            CHIMERA_VFS_ATTR_SPACE_TOTAL | \
+            CHIMERA_VFS_ATTR_FILES_TOTAL | \
+            CHIMERA_VFS_ATTR_FILES_FREE | \
+            CHIMERA_VFS_ATTR_FILES_AVAIL)
+
+/* An NFSv3 post-op attr request: the stat set plus FSID (this is exactly the
+ * shape that used to spuriously trip the full-statfs gate). */
+#define NFS3_LIKE_MASK    (CHIMERA_VFS_ATTR_MASK_STAT | CHIMERA_VFS_ATTR_FSID)
+
+/* (1) Compile-time mask invariants. */
+_Static_assert((CHIMERA_VFS_ATTR_MASK_STATFS_VALUES & CHIMERA_VFS_ATTR_FSID) == 0,
+               "MASK_STATFS_VALUES must NOT include FSID");
+_Static_assert((CHIMERA_VFS_ATTR_MASK_STATFS & CHIMERA_VFS_ATTR_FSID) == CHIMERA_VFS_ATTR_FSID,
+               "MASK_STATFS must still include FSID");
+_Static_assert(CHIMERA_VFS_ATTR_MASK_STATFS_VALUES ==
+               (CHIMERA_VFS_ATTR_MASK_STATFS & ~CHIMERA_VFS_ATTR_FSID),
+               "MASK_STATFS_VALUES is MASK_STATFS with FSID cleared");
+_Static_assert(CHIMERA_VFS_ATTR_MASK_STATFS_VALUES == STATFS_VALUE_BITS,
+               "MASK_STATFS_VALUES is exactly the six value bits");
+
+static void
+test_mask_invariants(void)
+{
+    /* The bug: an NFSv3-style request DOES overlap the full statfs mask ... */
+    assert((NFS3_LIKE_MASK & CHIMERA_VFS_ATTR_MASK_STATFS) != 0);
+    /* ... but the fix means it does NOT overlap the value gate, so no backend
+     * will do full statfs work for it. */
+    assert((NFS3_LIKE_MASK & CHIMERA_VFS_ATTR_MASK_STATFS_VALUES) == 0);
+
+    /* A real statfs request (any value bit) trips the value gate. */
+    assert((CHIMERA_VFS_ATTR_MASK_STATFS & CHIMERA_VFS_ATTR_MASK_STATFS_VALUES) != 0);
+
+    TEST_PASS("statfs/fsid mask invariants");
+} /* test_mask_invariants */
+
+struct test_ctx {
+    int                             done;
+    enum chimera_vfs_error          status;
+    struct chimera_vfs_thread      *vfs_thread;
+    struct evpl                    *evpl;
+    uint8_t                         fh[CHIMERA_VFS_FH_SIZE];
+    uint32_t                        fh_len;
+    struct chimera_vfs_open_handle *handle;
+    struct chimera_vfs_attrs        attr;
+};
+
+static void
+wait_done(struct test_ctx *ctx)
+{
+    while (!ctx->done) {
+        evpl_continue(ctx->evpl);
+    }
+    ctx->done = 0;
+} /* wait_done */
+
+static void
+mount_cb(
+    struct chimera_vfs_thread *thread,
+    enum chimera_vfs_error     status,
+    void                      *private_data)
+{
+    struct test_ctx *ctx = private_data;
+
+    ctx->status = status;
+    ctx->done   = 1;
+} /* mount_cb */
+
+static void
+lookup_cb(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *attr,
+    void                     *private_data)
+{
+    struct test_ctx *ctx = private_data;
+
+    ctx->status = error_code;
+    if (error_code == CHIMERA_VFS_OK) {
+        memcpy(ctx->fh, attr->va_fh, attr->va_fh_len);
+        ctx->fh_len = attr->va_fh_len;
+    }
+    ctx->done = 1;
+} /* lookup_cb */
+
+static void
+openfh_cb(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *oh,
+    void                           *private_data)
+{
+    struct test_ctx *ctx = private_data;
+
+    ctx->status = error_code;
+    ctx->handle = oh;
+    ctx->done   = 1;
+} /* openfh_cb */
+
+static void
+getattr_cb(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *attr,
+    void                     *private_data)
+{
+    struct test_ctx *ctx = private_data;
+
+    ctx->status = error_code;
+    if (error_code == CHIMERA_VFS_OK) {
+        ctx->attr = *attr;
+    }
+    ctx->done = 1;
+} /* getattr_cb */
+
+/* getattr `handle` with `mask`, returning the resulting attrs in ctx->attr. */
+static void
+getattr(
+    struct test_ctx               *ctx,
+    const struct chimera_vfs_cred *cred,
+    uint64_t                       mask)
+{
+    memset(&ctx->attr, 0, sizeof(ctx->attr));
+    chimera_vfs_getattr(ctx->vfs_thread, cred, ctx->handle, mask,
+                        getattr_cb, ctx);
+    wait_done(ctx);
+    assert(ctx->status == CHIMERA_VFS_OK);
+} /* getattr */
+
+/* (2) Observable backend behaviour. */
+static void
+test_memfs_behaviour(void)
+{
+    struct test_ctx               ctx = { 0 };
+    struct chimera_vfs           *vfs;
+    struct chimera_vfs_module_cfg module_cfgs[2];
+    struct prometheus_metrics    *metrics;
+    struct chimera_vfs_cred       cred;
+    uint8_t                       root_fh[CHIMERA_VFS_FH_SIZE];
+    uint32_t                      root_fh_len;
+
+    chimera_vfs_cred_init_unix(&cred, 0, 0, 0, NULL);
+
+    metrics = prometheus_metrics_create(NULL, NULL, 0);
+    assert(metrics != NULL);
+
+    memset(module_cfgs, 0, sizeof(module_cfgs));
+    strncpy(module_cfgs[0].module_name, "memfs", sizeof(module_cfgs[0].module_name) - 1);
+    strncpy(module_cfgs[1].module_name, "memkv", sizeof(module_cfgs[1].module_name) - 1);
+
+    ctx.evpl = evpl_create(NULL);
+    assert(ctx.evpl != NULL);
+
+    vfs = chimera_vfs_init(0, 0, module_cfgs, 2, "memkv", 60, 0, metrics);
+    assert(vfs != NULL);
+
+    ctx.vfs_thread = chimera_vfs_thread_init(ctx.evpl, vfs);
+    assert(ctx.vfs_thread != NULL);
+
+    chimera_vfs_mount(ctx.vfs_thread, NULL, "/test", "memfs", "/", NULL,
+                      mount_cb, &ctx);
+    wait_done(&ctx);
+    assert(ctx.status == CHIMERA_VFS_OK);
+
+    /* Resolve the mounted share's root handle. */
+    chimera_vfs_get_root_fh(root_fh, &root_fh_len);
+    chimera_vfs_lookup(ctx.vfs_thread, &cred, root_fh, root_fh_len, "test", 4,
+                       CHIMERA_VFS_ATTR_FH | CHIMERA_VFS_ATTR_MASK_STAT, 0,
+                       lookup_cb, &ctx);
+    wait_done(&ctx);
+    assert(ctx.status == CHIMERA_VFS_OK);
+
+    chimera_vfs_open_fh(ctx.vfs_thread, &cred, ctx.fh, ctx.fh_len,
+                        CHIMERA_VFS_OPEN_INFERRED, openfh_cb, &ctx);
+    wait_done(&ctx);
+    assert(ctx.status == CHIMERA_VFS_OK);
+
+    /* NFSv3-style request: stat set + FSID.  FSID is satisfied, but the statfs
+     * value fields are NOT computed (the hot-path win). */
+    getattr(&ctx, &cred, NFS3_LIKE_MASK);
+    assert(ctx.attr.va_set_mask & CHIMERA_VFS_ATTR_FSID);
+    assert((ctx.attr.va_set_mask & STATFS_VALUE_BITS) == 0);
+    TEST_PASS("NFSv3-style attrs (stat+FSID) populate FSID, not statfs values");
+
+    /* FSID alone: same -- only va_fsid, no full statfs work. */
+    getattr(&ctx, &cred, CHIMERA_VFS_ATTR_FSID);
+    assert(ctx.attr.va_set_mask & CHIMERA_VFS_ATTR_FSID);
+    assert((ctx.attr.va_set_mask & STATFS_VALUE_BITS) == 0);
+    TEST_PASS("FSID alone populates only va_fsid");
+
+    /* A genuine statfs request populates the value fields (and still FSID). */
+    getattr(&ctx, &cred, CHIMERA_VFS_ATTR_MASK_STATFS);
+    assert((ctx.attr.va_set_mask & STATFS_VALUE_BITS) == STATFS_VALUE_BITS);
+    assert(ctx.attr.va_set_mask & CHIMERA_VFS_ATTR_FSID);
+    TEST_PASS("full statfs request populates the statfs value set");
+
+    chimera_vfs_release(ctx.vfs_thread, ctx.handle);
+    chimera_vfs_thread_destroy(ctx.vfs_thread);
+    chimera_vfs_destroy(vfs);
+    evpl_destroy(ctx.evpl);
+    prometheus_metrics_destroy(metrics);
+} /* test_memfs_behaviour */
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    chimera_log_init();
+
+    test_mask_invariants();
+    test_memfs_behaviour();
+
+    fprintf(stderr, "All statfs-mask tests passed\n");
+    return 0;
+} /* main */

--- a/src/vfs/vfs_attrs.h
+++ b/src/vfs/vfs_attrs.h
@@ -8,55 +8,55 @@
 
 struct chimera_acl;
 
-#define CHIMERA_VFS_FH_SIZE             48
+#define CHIMERA_VFS_FH_SIZE                 48
 
-#define CHIMERA_VFS_ATTR_DEV            (1UL << 0)
-#define CHIMERA_VFS_ATTR_INUM           (1UL << 1)
-#define CHIMERA_VFS_ATTR_MODE           (1UL << 2)
-#define CHIMERA_VFS_ATTR_NLINK          (1UL << 3)
-#define CHIMERA_VFS_ATTR_UID            (1UL << 4)
-#define CHIMERA_VFS_ATTR_GID            (1UL << 5)
-#define CHIMERA_VFS_ATTR_RDEV           (1UL << 6)
-#define CHIMERA_VFS_ATTR_SIZE           (1UL << 7)
-#define CHIMERA_VFS_ATTR_ATIME          (1UL << 8)
-#define CHIMERA_VFS_ATTR_MTIME          (1UL << 9)
-#define CHIMERA_VFS_ATTR_CTIME          (1UL << 10)
-#define CHIMERA_VFS_ATTR_SPACE_USED     (1UL << 11)
+#define CHIMERA_VFS_ATTR_DEV                (1UL << 0)
+#define CHIMERA_VFS_ATTR_INUM               (1UL << 1)
+#define CHIMERA_VFS_ATTR_MODE               (1UL << 2)
+#define CHIMERA_VFS_ATTR_NLINK              (1UL << 3)
+#define CHIMERA_VFS_ATTR_UID                (1UL << 4)
+#define CHIMERA_VFS_ATTR_GID                (1UL << 5)
+#define CHIMERA_VFS_ATTR_RDEV               (1UL << 6)
+#define CHIMERA_VFS_ATTR_SIZE               (1UL << 7)
+#define CHIMERA_VFS_ATTR_ATIME              (1UL << 8)
+#define CHIMERA_VFS_ATTR_MTIME              (1UL << 9)
+#define CHIMERA_VFS_ATTR_CTIME              (1UL << 10)
+#define CHIMERA_VFS_ATTR_SPACE_USED         (1UL << 11)
 
-#define CHIMERA_VFS_ATTR_SPACE_AVAIL    (1UL << 12)
-#define CHIMERA_VFS_ATTR_SPACE_FREE     (1UL << 13)
-#define CHIMERA_VFS_ATTR_SPACE_TOTAL    (1UL << 14)
-#define CHIMERA_VFS_ATTR_FILES_TOTAL    (1UL << 15)
-#define CHIMERA_VFS_ATTR_FILES_FREE     (1UL << 16)
-#define CHIMERA_VFS_ATTR_FILES_AVAIL    (1UL << 17)
+#define CHIMERA_VFS_ATTR_SPACE_AVAIL        (1UL << 12)
+#define CHIMERA_VFS_ATTR_SPACE_FREE         (1UL << 13)
+#define CHIMERA_VFS_ATTR_SPACE_TOTAL        (1UL << 14)
+#define CHIMERA_VFS_ATTR_FILES_TOTAL        (1UL << 15)
+#define CHIMERA_VFS_ATTR_FILES_FREE         (1UL << 16)
+#define CHIMERA_VFS_ATTR_FILES_AVAIL        (1UL << 17)
 
-#define CHIMERA_VFS_ATTR_FH             (1UL << 18)
-#define CHIMERA_VFS_ATTR_ATOMIC         (1UL << 19)
-#define CHIMERA_VFS_ATTR_FSID           (1UL << 20)
+#define CHIMERA_VFS_ATTR_FH                 (1UL << 18)
+#define CHIMERA_VFS_ATTR_ATOMIC             (1UL << 19)
+#define CHIMERA_VFS_ATTR_FSID               (1UL << 20)
 
 /* Windows/SMB DOS attribute bits (FILE_ATTRIBUTE_*).  Optional: a backend
  * sets this bit in va_set_mask only if it actually persists the value. */
-#define CHIMERA_VFS_ATTR_DOS_ATTRIBUTES (1UL << 21)
+#define CHIMERA_VFS_ATTR_DOS_ATTRIBUTES     (1UL << 21)
 
 /* Birth/creation time (SMB create time, statx btime).  POSIX has no such
  * concept, so this is optional: a backend sets this bit in va_set_mask only
  * if it actually tracks the value. */
-#define CHIMERA_VFS_ATTR_BTIME          (1UL << 22)
+#define CHIMERA_VFS_ATTR_BTIME              (1UL << 22)
 
 /* Opaque per-file pNFS layout state (va_pnfs/va_pnfs_len).  The contents are
  * defined and interpreted solely by the NFS server (it packs the data-server
  * deviceid + backing file handle); a backend just persists and returns the
  * blob verbatim, which is all it takes to become a pNFS metadata-server
  * backend.  A backend advertises CHIMERA_VFS_CAP_LAYOUT iff it persists it. */
-#define CHIMERA_VFS_ATTR_PNFS_LAYOUT    (1UL << 23)
-#define CHIMERA_VFS_PNFS_LAYOUT_MAX     96
+#define CHIMERA_VFS_ATTR_PNFS_LAYOUT        (1UL << 23)
+#define CHIMERA_VFS_PNFS_LAYOUT_MAX         96
 
 /* Canonical (NFSv4/Windows) ACL, carried via va_acl.  Deliberately excluded
  * from the cacheable mask: the attr cache stays fixed-size and ACLs are fetched
  * fresh, mask-gated, only when a protocol asks for them. */
-#define CHIMERA_VFS_ATTR_ACL            (1UL << 24)
+#define CHIMERA_VFS_ATTR_ACL                (1UL << 24)
 
-#define CHIMERA_VFS_ATTR_MASK_STAT      ( \
+#define CHIMERA_VFS_ATTR_MASK_STAT          ( \
             CHIMERA_VFS_ATTR_DEV | \
             CHIMERA_VFS_ATTR_INUM | \
             CHIMERA_VFS_ATTR_MODE | \
@@ -70,7 +70,7 @@ struct chimera_acl;
             CHIMERA_VFS_ATTR_MTIME | \
             CHIMERA_VFS_ATTR_CTIME)
 
-#define CHIMERA_VFS_ATTR_MASK_STATFS    ( \
+#define CHIMERA_VFS_ATTR_MASK_STATFS        ( \
             CHIMERA_VFS_ATTR_SPACE_AVAIL | \
             CHIMERA_VFS_ATTR_SPACE_FREE | \
             CHIMERA_VFS_ATTR_SPACE_TOTAL | \
@@ -79,16 +79,29 @@ struct chimera_acl;
             CHIMERA_VFS_ATTR_FILES_AVAIL | \
             CHIMERA_VFS_ATTR_FSID)
 
+/* The statfs *value* fields only -- the free/available/total space and file
+ * counts -- with FSID deliberately excluded.  FSID is dual-purpose: it is part
+ * of the statfs response set, but it is also an ordinary per-file attribute
+ * that ordinary stat-style requests carry (e.g. NFSv3 post-op attrs include
+ * FSID).  A backend that uses "do I need to do full statfs work?" as a gate
+ * must test against this mask, NOT against MASK_STATFS: testing MASK_STATFS
+ * makes the gate fire for every FSID-carrying request, turning a cold statfs
+ * path (which may iterate allocation groups / take per-group locks) into a hot
+ * path on every LOOKUP/CREATE/WRITE reply.  FSID alone is satisfied cheaply by
+ * each backend's dedicated FSID handler. */
+#define CHIMERA_VFS_ATTR_MASK_STATFS_VALUES ( \
+            CHIMERA_VFS_ATTR_MASK_STATFS & ~CHIMERA_VFS_ATTR_FSID)
+
 /* Birth time is cacheable and is requested alongside the stat set, but it is
  * deliberately NOT part of MASK_STAT: MASK_STAT is the set every backend is
  * required to supply, and the attr cache's "complete entry" gate and the
  * remove_at hardlink-invalidation both rely on that.  Backends that don't
  * track btime (linux/io_uring/cairn) must still satisfy MASK_STAT. */
-#define CHIMERA_VFS_ATTR_MASK_CACHEABLE ( \
+#define CHIMERA_VFS_ATTR_MASK_CACHEABLE     ( \
             CHIMERA_VFS_ATTR_MASK_STAT | \
             CHIMERA_VFS_ATTR_BTIME)
 
-#define CHIMERA_VFS_TIME_NOW            ((1l << 30) - 3l)
+#define CHIMERA_VFS_TIME_NOW                ((1l << 30) - 3l)
 
 /* Sentinel: "preserve the existing value, don't bump implicitly".  Used by
  * SMB SetInfo(FileBasicInformation) to convey MS-FSCC 2.4.7's "a zero
@@ -96,7 +109,7 @@ struct chimera_acl;
  * the time-attr bit in set_mask (so the implicit ctime bump that would
  * otherwise fire on the co-present DOS-attribute change is suppressed), but
  * a value of TIME_OMIT means the backend should leave that timestamp alone. */
-#define CHIMERA_VFS_TIME_OMIT           ((1l << 30) - 4l)
+#define CHIMERA_VFS_TIME_OMIT               ((1l << 30) - 4l)
 
 /*
  * Resolve a settable timestamp against the TIME_NOW / TIME_OMIT sentinels that

--- a/src/vfs/vfs_internal.h
+++ b/src/vfs/vfs_internal.h
@@ -489,7 +489,7 @@ chimera_vfs_copy_attr(
         dest->va_ctime      = src->va_ctime;
     }
 
-    if (src->va_req_mask & CHIMERA_VFS_ATTR_MASK_STATFS) {
+    if (src->va_req_mask & CHIMERA_VFS_ATTR_MASK_STATFS_VALUES) {
         dest->va_fs_space_avail = src->va_fs_space_avail;
         dest->va_fs_space_free  = src->va_fs_space_free;
         dest->va_fs_space_total = src->va_fs_space_total;


### PR DESCRIPTION
## Summary

`FSID` is dual-purpose: it is part of the statfs response set, but it is also an ordinary per-file attribute that ordinary stat-style requests carry — an NFSv3 post-op attr request (`CHIMERA_NFS3_ATTR_MASK`) includes `FSID`. Because `FSID` was the only bit distinguishing `CHIMERA_VFS_ATTR_MASK_STATFS` from a normal attr request, backends that gated their full (cold, lock-heavy) statfs computation on

```c
attr->va_req_mask & CHIMERA_VFS_ATTR_MASK_STATFS
```

ran that computation on **every** LOOKUP/CREATE/WRITE reply. In `diskfs` that meant `space_map_free_bytes()` — which iterates allocation groups and takes each AG lock — ran on the metadata hot path, turning a cold statfs path hot.

## Fix

Introduce `CHIMERA_VFS_ATTR_MASK_STATFS_VALUES` (the statfs value fields with `FSID` excluded) and use it as the *"do full statfs work?"* gate in every backend and the attr-copy path:

- `FSID` alone is satisfied cheaply by each backend's dedicated `FSID` handler (added where it was missing: memfs fork-attr path, `vfs_root`, `nfs4_root`).
- Full `CHIMERA_VFS_ATTR_MASK_STATFS` still includes `FSID`, so a genuine statfs request gets the complete set.
- For the `linux`/`io_uring` passthrough, `FSID` is now sourced consistently from `st_dev` in the stat path (statvfs `f_fsid` is dropped), so an `FSID`-carrying request avoids a cold `fstatvfs()` on the hot path **and** the `FSID` reported on the stat-only path matches the one reported alongside a full statfs.

Files touched: `vfs_attrs.h`, `vfs_internal.h` (attr copy), `diskfs_internal.h`, `memfs.c`, `cairn.c`, `linux_common.h`, `vfs_root.c`, `nfs4_root.c`.

## Measured impact (diskfs TCP SPEC SWBUILD init)

Reported from the live system that root-caused this:

| milestone | before | after |
|---|---|---|
| 10% init | ~22m11s | ~2m31s |
| 20% init | ~44m32s | ~5m19s |
| 30% init | ~61m18s | ~7m36s |

Before, perf was dominated by `pthread_mutex_lock/unlock` with `space_map_free_bytes` / `diskfs_map_attrs` as top paths. After, the top samples move to the expected event-loop / VFIO polling paths and the statfs accounting and mutex traffic are gone.

## Tests

New `chimera/vfs/statfs_mask_test`: compile-time mask invariants (so nobody re-conflates `FSID` into the value gate) plus an engine-authoritative (memfs) behavioural check that an NFSv3-style `stat+FSID` request yields `FSID` but does **not** populate the statfs value fields, while a full statfs request does.

Locally validated under the ASan Debug build: the `vfs` test label (11/11, including the new test) and the posix `stat`/`fstat`/`lstat` tests across the linux, io_uring, memfs and diskfs backends over local + NFSv3/RDMA (124/124). The full Release `ctest` suite passes (exit 0).
