### PR TITLE
vfs: reject oversized file handles at the routing gate (heap overflow)

### DIFF
--- a/src/vfs/vfs_internal.h
+++ b/src/vfs/vfs_internal.h
@@ -123,7 +123,19 @@ chimera_vfs_get_module(
     struct chimera_vfs_mount  *mount;
     struct chimera_vfs_module *module;
 
-    if (fhlen < CHIMERA_VFS_MOUNT_ID_SIZE) {
+    /*
+     * Reject implausible handle lengths before they reach any sink.  The lower
+     * bound guarantees a mount-id prefix to route on; the upper bound is the
+     * security-critical half: a valid chimera handle never exceeds
+     * CHIMERA_VFS_FH_SIZE, but the NFS3/NFS4 XDR decoders do not enforce the
+     * wire `opaque<>` bound (see nfs3_attr.h), so an oversized handle would
+     * otherwise be memcpy'd into the fixed CHIMERA_VFS_FH_SIZE handle buffers
+     * (e.g. vfs_proc_open_fh.c, vfs_open_cache.h, vfs_state.c) and overflow
+     * them.  This gate is the common chokepoint every fh-routed op funnels
+     * through, so bounding here protects all of them; callers already treat a
+     * NULL module as ESTALE/BADHANDLE.
+     */
+    if (fhlen < CHIMERA_VFS_MOUNT_ID_SIZE || fhlen > CHIMERA_VFS_FH_SIZE) {
         return NULL;
     }
 


### PR DESCRIPTION
## Summary

`chimera_vfs_get_module()` is the common chokepoint every fh-routed VFS operation funnels through, but it only validated the **lower** bound on the handle length (`>= CHIMERA_VFS_MOUNT_ID_SIZE`). The NFS3/NFS4 XDR decoders do not enforce the wire `opaque<>` length bound (see the note in `nfs3_attr.h`), so a client can present a handle longer than `CHIMERA_VFS_FH_SIZE`. That handle is then `memcpy`'d into the fixed `CHIMERA_VFS_FH_SIZE` (48-byte) handle buffers in `vfs_proc_open_fh.c`, `vfs_open_cache.h` and `vfs_state.c` — a heap out-of-bounds write driven by unauthenticated wire input.

## Fix

A valid chimera handle never exceeds `CHIMERA_VFS_FH_SIZE`, so add the upper bound at the gate. Bounding here protects every fh-routed op at one point:
- NFS3 reaches it via `chimera_vfs_open_fh()`,
- NFS4 PUTFH reaches it via `chimera_vfs_fh_is_plausible()`.

Callers already map a NULL module to ESTALE/BADHANDLE, so an oversized handle is now cleanly rejected instead of overflowing. No change for valid handles — pynfs `combined_memfs_nfs4.0/4.1` and the NFS3 client tests pass under the ASan debug build.

Part of a security review of the protocol-facing parsers.
