### PR TITLE
smb2: IPC$ named-pipe async-read credits + bounded credit grant

### DIFF
--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -499,6 +499,11 @@ main(
         chimera_server_config_set_smb_acl_inherited_canonicalize(server_config, json_is_true(json_value));
     }
 
+    json_value = json_object_get(server_params, "smb2_max_async_credits");
+    if (json_is_integer(json_value)) {
+        chimera_server_config_set_smb2_max_async_credits(server_config, json_integer_value(json_value));
+    }
+
     json_value = json_object_get(server_params, "nfs4_session_slots");
     if (json_is_integer(json_value)) {
         int_value = json_integer_value(json_value);

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -86,6 +86,7 @@ struct chimera_server_config {
     int                                   smb_oplocks;
     int                                   smb_notify_disabled;
     int                                   smb_acl_inherited_canonicalize;
+    int                                   smb2_max_async_credits;
     int                                   smb_num_nic_info;
     uint32_t                              anonuid;
     uint32_t                              anongid;
@@ -211,6 +212,10 @@ chimera_server_config_init(void)
      * verbatim (Samba's "= no" mode that the smb2.acls_non_canonical suite
      * exercises). */
     config->smb_acl_inherited_canonicalize = 1;
+
+    /* Per-connection ceiling on outstanding async (STATUS_PENDING) operations.
+     * 512 matches the value smb2.credits.*_ipc_max_async_credits asserts. */
+    config->smb2_max_async_credits = 512;
 
     // SMB auth config defaults - local NTLM only
     config->smb_auth.winbind_enabled    = 0;
@@ -501,6 +506,20 @@ chimera_server_config_get_smb_acl_inherited_canonicalize(const struct chimera_se
 {
     return config->smb_acl_inherited_canonicalize;
 } /* chimera_server_config_get_smb_acl_inherited_canonicalize */
+
+SYMBOL_EXPORT void
+chimera_server_config_set_smb2_max_async_credits(
+    struct chimera_server_config *config,
+    int                           value)
+{
+    config->smb2_max_async_credits = value;
+} /* chimera_server_config_set_smb2_max_async_credits */
+
+SYMBOL_EXPORT int
+chimera_server_config_get_smb2_max_async_credits(const struct chimera_server_config *config)
+{
+    return config->smb2_max_async_credits;
+} /* chimera_server_config_get_smb2_max_async_credits */
 
 SYMBOL_EXPORT void
 chimera_server_config_set_max_open_files(

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -165,6 +165,15 @@ chimera_server_config_get_smb_acl_inherited_canonicalize(
     const struct chimera_server_config *config);
 
 void
+chimera_server_config_set_smb2_max_async_credits(
+    struct chimera_server_config *config,
+    int                           value);
+
+int
+chimera_server_config_get_smb2_max_async_credits(
+    const struct chimera_server_config *config);
+
+void
 chimera_server_config_set_cache_ttl(
     struct chimera_server_config *config,
     int                           ttl);

--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -156,6 +156,7 @@ chimera_smb_server_init(
     shared->config.oplocks                    = chimera_server_config_get_smb_oplocks(config);
     shared->config.notify_disabled            = chimera_server_config_get_smb_notify_disabled(config);
     shared->config.acl_inherited_canonicalize = chimera_server_config_get_smb_acl_inherited_canonicalize(config);
+    shared->config.smb2_max_async_credits     = chimera_server_config_get_smb2_max_async_credits(config);
 
     if (shared->config.persistent_handles) {
         chimera_smb_info("SMB3 durable/persistent handles enabled (in-memory state)");
@@ -393,16 +394,23 @@ chimera_smb_compound_reply(struct chimera_smb_compound *compound)
 
         prev_command = &reply_hdr->next_command;
 
-        reply_hdr->protocol_id[0]          = 0xFE;
-        reply_hdr->protocol_id[1]          = 0x53;
-        reply_hdr->protocol_id[2]          = 0x4D;
-        reply_hdr->protocol_id[3]          = 0x42;
-        reply_hdr->struct_size             = 64;
-        reply_hdr->credit_charge           = request->smb2_hdr.credit_charge;
-        reply_hdr->status                  = request->status;
-        reply_hdr->command                 = request->smb2_hdr.command;
-        reply_hdr->credit_request_response = request->smb2_hdr.credit_request_response ?
-            request->smb2_hdr.credit_request_response : 1;
+        reply_hdr->protocol_id[0] = 0xFE;
+        reply_hdr->protocol_id[1] = 0x53;
+        reply_hdr->protocol_id[2] = 0x4D;
+        reply_hdr->protocol_id[3] = 0x42;
+        reply_hdr->struct_size    = 64;
+        reply_hdr->credit_charge  = request->smb2_hdr.credit_charge;
+        reply_hdr->status         = request->status;
+        reply_hdr->command        = request->smb2_hdr.command;
+        /* Grant credits, capping the client's balance so a flood of
+         * ever-larger CreditRequests cannot overflow its window.  An async
+         * request's CreditCharge was already debited when its interim was sent
+         * (async_id is set), so don't debit it again here. */
+        reply_hdr->credit_request_response = chimera_smb_grant_credits(
+            conn,
+            request->async_id ? 0 :
+            (request->smb2_hdr.credit_charge ? request->smb2_hdr.credit_charge : 1),
+            request->smb2_hdr.credit_request_response);
         reply_hdr->flags        = request->smb2_hdr.flags | SMB2_FLAGS_SERVER_TO_REDIR;
         reply_hdr->next_command = 0;
         reply_hdr->message_id   = request->smb2_hdr.message_id;
@@ -2240,6 +2248,8 @@ chimera_smb_server_accept(
     conn->dialect            = 0;
     conn->flags              = 0;
     conn->requests_completed = 0;
+    conn->async_outstanding  = 0;
+    conn->credits_balance    = 0;
 
     evpl_bind_get_local_address(bind, conn->local_addr, sizeof(conn->local_addr));
     evpl_bind_get_remote_address(bind, conn->remote_addr, sizeof(conn->remote_addr));

--- a/src/server/smb/smb_async_interim.c
+++ b/src/server/smb/smb_async_interim.c
@@ -72,17 +72,22 @@ chimera_smb_async_interim_send(struct chimera_smb_request *request)
     memset(buf, 0, CHIMERA_SMB_ASYNC_INTERIM_LEN);
 
     /* NetBIOS framing length filled in below. */
-    hdr                          = (struct smb2_header *) (buf + 4);
-    hdr->protocol_id[0]          = 0xFE;
-    hdr->protocol_id[1]          = 'S';
-    hdr->protocol_id[2]          = 'M';
-    hdr->protocol_id[3]          = 'B';
-    hdr->struct_size             = 64;
-    hdr->credit_charge           = request->async.credit_charge;
-    hdr->status                  = SMB2_STATUS_PENDING;
-    hdr->command                 = request->smb2_hdr.command;
-    hdr->credit_request_response = request->async.credit_request
-        ? request->async.credit_request : 1;
+    hdr                 = (struct smb2_header *) (buf + 4);
+    hdr->protocol_id[0] = 0xFE;
+    hdr->protocol_id[1] = 'S';
+    hdr->protocol_id[2] = 'M';
+    hdr->protocol_id[3] = 'B';
+    hdr->struct_size    = 64;
+    hdr->credit_charge  = request->async.credit_charge;
+    hdr->status         = SMB2_STATUS_PENDING;
+    hdr->command        = request->smb2_hdr.command;
+    /* Grant credits (capped), debiting this request's CreditCharge once here;
+     * the eventual final response passes consume=0 so the charge is not counted
+     * twice (see chimera_smb_grant_credits / chimera_smb_compound_reply). */
+    hdr->credit_request_response = chimera_smb_grant_credits(
+        conn,
+        request->async.credit_charge ? request->async.credit_charge : 1,
+        request->async.credit_request);
     hdr->flags          = SMB2_FLAGS_SERVER_TO_REDIR | SMB2_FLAGS_ASYNC_COMMAND;
     hdr->message_id     = request->smb2_hdr.message_id;
     hdr->async.async_id = request->async_id;
@@ -181,4 +186,8 @@ chimera_smb_async_interim_drain(struct chimera_smb_conn *conn)
             request->create.r_open_file = NULL;
         }
     }
+
+    /* All parked requests are gone, including any blocking named-pipe READs that
+     * counted against the async ceiling. */
+    conn->async_outstanding = 0;
 } /* chimera_smb_async_interim_drain */

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -233,6 +233,12 @@ struct chimera_smb_config {
      * SET_SECURITY; see chimera_server_config_set_smb_acl_inherited_canonicalize
      * for semantics.  Default 1 (canonical). */
     int                            acl_inherited_canonicalize;
+    /* Per-connection ceiling on simultaneously outstanding async (STATUS_PENDING)
+     * operations.  A blocking named-pipe READ that cannot be served now is made
+     * async until the connection holds (smb2_max_async_credits - 1) of them;
+     * beyond that it is rejected with STATUS_INSUFFICIENT_RESOURCES (the contract
+     * smb2.credits.*_ipc_max_async_credits asserts).  Default 512. */
+    int                            smb2_max_async_credits;
     uint32_t                       capabilities;
     uint32_t                       dialects[16];
     struct chimera_smb_nic_info    nic_info[16];
@@ -355,6 +361,10 @@ struct chimera_smb_request {
         uint16_t                       credit_charge;
         uint16_t                       credit_request;
         uint8_t                        armed;
+        /* Set when this parked request is a blocking named-pipe READ counted
+         * against conn->async_outstanding, so SMB2_CANCEL and teardown drain
+         * decrement that counter when the request leaves the parked list. */
+        uint8_t                        pipe_read;
     } async;
 
     union {
@@ -1112,6 +1122,17 @@ struct chimera_smb_conn {
      * SMB2_CANCEL walks this list by AsyncId; conn_free drains it before tearing
      * down the bind. */
     struct chimera_smb_request        *parked_requests;
+    /* Count of currently-parked async named-pipe READs on this connection.
+     * Capped at (config.smb2_max_async_credits - 1); reaching the cap makes
+     * further blocking pipe reads fail with STATUS_INSUFFICIENT_RESOURCES.
+     * Incremented when a pipe read parks, decremented when it is cancelled or
+     * drained at teardown. */
+    uint32_t                           async_outstanding;
+    /* Server-side estimate of the client's current SMB2 credit balance (granted
+     * minus charged), used to cap how many credits a response grants so a client
+     * that keeps requesting more (e.g. the smb2.credits async flood) cannot
+     * overflow its 16-bit credit window.  See chimera_smb_grant_credits. */
+    uint32_t                           credits_balance;
     struct chimera_server_smb_thread  *thread;
     struct evpl_bind                  *bind;
     struct chimera_smb_conn           *prev;
@@ -1125,6 +1146,47 @@ struct chimera_smb_conn {
     char                               local_addr[128];
     char                               remote_addr[128];
 };
+
+/* Ceiling on the credit balance the server will let a single connection
+ * accumulate.  A response grants the credits the client asked for, but never so
+ * many that the client's balance would exceed this -- otherwise a client that
+ * keeps requesting more (smb2.credits async flood requests 1,2,3,...) would
+ * overflow its 16-bit credit window and fault the connection.  Matches Samba's
+ * default `smb2 max credits`; the credits.c tests require >= 8192 grantable. */
+#define CHIMERA_SMB_MAX_CREDITS 8192
+
+/*
+ * Compute the SMB2 CreditResponse for one response and update the connection's
+ * running estimate of the client's credit balance.
+ *
+ * `consume` is the number of credits the client spent sending the request (its
+ * effective CreditCharge), debited once per request -- callers pass 0 for the
+ * final response of an async request whose interim already accounted the charge.
+ * The grant is the client's CreditRequest, clamped so the balance stays at or
+ * below CHIMERA_SMB_MAX_CREDITS, and never zero while the client holds none (so
+ * the window cannot collapse).  Single-threaded on the conn's SMB thread.
+ */
+static inline uint16_t
+chimera_smb_grant_credits(
+    struct chimera_smb_conn *conn,
+    uint32_t                 consume,
+    uint16_t                 credit_request)
+{
+    uint32_t want = credit_request ? credit_request : 1;
+    uint32_t bal  = conn->credits_balance;
+    uint32_t room, grant;
+
+    bal   = bal > consume ? bal - consume : 0;
+    room  = bal < CHIMERA_SMB_MAX_CREDITS ? CHIMERA_SMB_MAX_CREDITS - bal : 0;
+    grant = want < room ? want : room;
+
+    if (grant == 0 && bal == 0) {
+        grant = 1;
+    }
+
+    conn->credits_balance = bal + grant;
+    return (uint16_t) grant;
+} /* chimera_smb_grant_credits */
 
 /* Default and ceiling for a durable handle's reconnect grace window.  A v2
  * client may request a timeout; we honor it up to the ceiling, falling back to
@@ -1540,6 +1602,7 @@ chimera_smb_request_alloc(struct chimera_server_smb_thread *thread)
     request->async_id        = 0;
     request->tree            = NULL;
     request->async.armed     = 0;
+    request->async.pipe_read = 0;
     request->async.park_next = NULL;
 
     return request;

--- a/src/server/smb/smb_proc_cancel.c
+++ b/src/server/smb/smb_proc_cancel.c
@@ -79,8 +79,9 @@ chimera_smb_cancel(struct chimera_smb_request *request)
         /* Search requests pending an async-interim.  A blocking byte-range LOCK
          * (MS-SMB2 3.3.5.14) parked on a conflicting range is cancellable: cancel
          * its VFS acquire and complete it with STATUS_CANCELLED (smb2.lock.cancel).
-         * A CREATE blocked on a lease break is not (yet) cancellable from here --
-         * absorb that silently; it completes when its break acks. */
+         * A blocking named-pipe READ is likewise cancellable.  A CREATE blocked on
+         * a lease break is not (yet) cancellable from here -- absorb that silently;
+         * it completes when its break acks. */
         struct chimera_smb_request *parked;
 
         for (parked = conn->parked_requests; parked;
@@ -102,7 +103,20 @@ chimera_smb_cancel(struct chimera_smb_request *request)
             if (abort) {
                 chimera_smb_lock_park_finish(abort, SMB2_STATUS_CANCELLED);
             }
+        } else if (parked && parked->async.pipe_read) {
+            /* A blocking named-pipe READ never completes on its own, so a
+             * CANCEL resolves it with STATUS_CANCELLED.  complete_request
+             * unlinks it from the parked list (via async_interim_cancel) and
+             * emits the final READ error response carrying the AsyncId.  Free
+             * its async-credit slot. */
+            if (conn->async_outstanding) {
+                conn->async_outstanding--;
+            }
+            chimera_smb_complete_request(parked, SMB2_STATUS_CANCELLED);
         }
+        /* Other parked requests (e.g. a CREATE blocked on a lease break) are
+         * not yet cancellable from SMB2_CANCEL -- absorb silently; they
+         * complete when their break acks. */
     }
 
     /* CANCEL has no response per MS-SMB2.  Use STATUS_PENDING so the

--- a/src/server/smb/smb_proc_read.c
+++ b/src/server/smb/smb_proc_read.c
@@ -4,6 +4,7 @@
 
 #include "common/evpl_iovec_cursor.h"
 #include "smb_internal.h"
+#include "smb_async_interim.h"
 #include "smb_procs.h"
 #include "smb_session.h"
 #include "vfs/vfs.h"
@@ -94,6 +95,12 @@ chimera_smb_read_callback(
  * prior SMB2 WRITE stashed via chimera_smb_pipe_write.  Serves up to the
  * requested length, advancing an offset so a client may read the response in
  * several chunks; the stash is freed once fully drained.
+ *
+ * A read with no buffered response is a blocking message-mode pipe read: it does
+ * not complete now.  Such reads are made async (STATUS_PENDING) up to a
+ * per-connection ceiling; past it they fail with INSUFFICIENT_RESOURCES.  This
+ * is the contract smb2.credits.*_ipc_max_async_credits asserts (and a parked
+ * read stays parked until the client cancels it or the connection tears down).
  */
 static void
 chimera_smb_pipe_read(struct chimera_smb_request *request)
@@ -107,10 +114,23 @@ chimera_smb_pipe_read(struct chimera_smb_request *request)
     n     = request->read.length < avail ? request->read.length : avail;
 
     if (n == 0) {
-        request->read.niov     = 0;
-        request->read.r_length = 0;
+        struct chimera_smb_conn          *conn   = request->compound->conn;
+        struct chimera_server_smb_shared *shared = thread->shared;
+
+        /* The fid stays open; once parked the request needs nothing from the
+         * open until it is cancelled, so drop our handle reference now. */
         chimera_smb_open_file_release(request, open_file);
-        chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
+
+        if (conn->async_outstanding >=
+            (uint32_t) shared->config.smb2_max_async_credits - 1) {
+            chimera_smb_complete_request(request,
+                                         SMB2_STATUS_INSUFFICIENT_RESOURCES);
+            return;
+        }
+
+        conn->async_outstanding++;
+        request->async.pipe_read = 1;
+        chimera_smb_async_interim_begin(request);
         return;
     }
 

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -1394,6 +1394,10 @@ set(SMBTORTURE_ENABLED_memfs
     # smb2.create_no_streams
     smb2.create_no_streams.no_stream
     # smb2.credits
+    smb2.credits.1conn_ipc_max_async_credits
+    smb2.credits.2conn_ipc_max_async_credits
+    smb2.credits.ipc_max_data_zero
+    smb2.credits.multichannel_ipc_max_async_credits
     smb2.credits.session_setup_credits_granted
     smb2.credits.single_req_credits_granted
     smb2.credits.skipped_mid
@@ -1912,6 +1916,10 @@ set(SMBTORTURE_ENABLED_linux
     # smb2.create_no_streams
     smb2.create_no_streams.no_stream
     # smb2.credits
+    smb2.credits.1conn_ipc_max_async_credits
+    smb2.credits.2conn_ipc_max_async_credits
+    smb2.credits.ipc_max_data_zero
+    smb2.credits.multichannel_ipc_max_async_credits
     smb2.credits.session_setup_credits_granted
     smb2.credits.single_req_credits_granted
     smb2.credits.skipped_mid
@@ -2245,6 +2253,10 @@ set(SMBTORTURE_ENABLED_io_uring
     # smb2.create_no_streams
     smb2.create_no_streams.no_stream
     # smb2.credits
+    smb2.credits.1conn_ipc_max_async_credits
+    smb2.credits.2conn_ipc_max_async_credits
+    smb2.credits.ipc_max_data_zero
+    smb2.credits.multichannel_ipc_max_async_credits
     smb2.credits.session_setup_credits_granted
     smb2.credits.single_req_credits_granted
     smb2.credits.skipped_mid
@@ -2593,6 +2605,10 @@ set(SMBTORTURE_ENABLED_cairn
     # smb2.create_no_streams
     smb2.create_no_streams.no_stream
     # smb2.credits
+    smb2.credits.1conn_ipc_max_async_credits
+    smb2.credits.2conn_ipc_max_async_credits
+    smb2.credits.ipc_max_data_zero
+    smb2.credits.multichannel_ipc_max_async_credits
     smb2.credits.session_setup_credits_granted
     smb2.credits.single_req_credits_granted
     smb2.credits.skipped_mid
@@ -3055,6 +3071,10 @@ set(SMBTORTURE_ENABLED_diskfs_io_uring
     # smb2.create_no_streams
     smb2.create_no_streams.no_stream
     # smb2.credits
+    smb2.credits.1conn_ipc_max_async_credits
+    smb2.credits.2conn_ipc_max_async_credits
+    smb2.credits.ipc_max_data_zero
+    smb2.credits.multichannel_ipc_max_async_credits
     smb2.credits.session_setup_credits_granted
     smb2.credits.single_req_credits_granted
     smb2.credits.skipped_mid
@@ -3550,6 +3570,10 @@ set(SMBTORTURE_ENABLED_diskfs_aio
     # smb2.create_no_streams
     smb2.create_no_streams.no_stream
     # smb2.credits
+    smb2.credits.1conn_ipc_max_async_credits
+    smb2.credits.2conn_ipc_max_async_credits
+    smb2.credits.ipc_max_data_zero
+    smb2.credits.multichannel_ipc_max_async_credits
     smb2.credits.session_setup_credits_granted
     smb2.credits.single_req_credits_granted
     smb2.credits.skipped_mid


### PR DESCRIPTION
**Stacked on #807** (`dce-rpc-pipe-transport`). GitHub can't base a PR on a fork-only branch, so this targets `main`; the commits from #807 appear in the diff until #807 merges, after which only this change remains. Review the last commit (`smb2: IPC$ named-pipe async-read credits + bounded credit grant`) for the new work.

Found by pointing Samba's **smbtorture** `smb2.credits` IPC suite at the in-process SMB server (no Windows / DC needed).

Enables the four `smb2.credits` IPC subtests, which were wired but disabled on every backend:
- `ipc_max_data_zero`
- `1conn_ipc_max_async_credits`
- `2conn_ipc_max_async_credits`
- `multichannel_ipc_max_async_credits`

Each opens `\lsarpc` on IPC$, does a sync BIND (already works since #807), then floods the pipe with async SMB2 READs that have no data to return. The server contract, asserted **per connection**: the first `max_async_credits - 1` (= 511) reads get a `STATUS_PENDING` interim and are parked; the rest are rejected with `STATUS_INSUFFICIENT_RESOURCES`; then all parked reads are cancelled and must return `STATUS_CANCELLED`.

## 1. Blocking named-pipe reads
#807's pipe-read returned an empty `STATUS_SUCCESS` when no `ncacn_np` response was buffered. A no-data pipe read is really a blocking message-mode read, so it now parks as an async interim up to a per-connection ceiling (`conn->async_outstanding < smb2_max_async_credits - 1`), and otherwise fails with `STATUS_INSUFFICIENT_RESOURCES`. `SMB2_CANCEL` completes a matched parked pipe read with `STATUS_CANCELLED` and frees its slot; the teardown drain resets the counter.

New config knob **`smb2_max_async_credits`** (default 512; the test hard-codes 512 in its assertions).

## 2. Bounded credit grant (the real blocker)
The server echoed the client's `CreditRequest` verbatim as `CreditResponse`. This test's client requests an *increasing* number of credits (1, 2, 3, … 514), so the echoed grants accumulated past the client's 16-bit credit window, faulting the connection with `NT_STATUS_INVALID_NETWORK_RESPONSE`. `chimera_smb_grant_credits()` now grants the request but caps the client's running balance at `CHIMERA_SMB_MAX_CREDITS` (8192 — Samba's default; the credits suite needs >= 8192 grantable), debiting each `CreditCharge` exactly once across an async request's interim and final response. Applied to both the synchronous reply path and the async interim.

(`smb_notify.c` still echoes credits — the same latent issue affects the separate *notify* credit variants, which remain out of scope / not enabled.)

## Verification
- All 4 IPC tests pass on all 6 backends (memfs/linux/io_uring/cairn/diskfs_io_uring/diskfs_aio), ASan-clean.
- Full memfs smbtorture sweep: 182/182 pass — the global credit-grant change causes no regressions. The 3 pre-existing `smb2.credits` tests and #807's `rpc.*` gates still pass.
- `syntax-check`, `reuse-lint`, copyright, and scan-build (no bugs found) all clean.
