### PR TITLE
smb2: break a LEVEL_II oplock holder's own read cache on write (batch6)

### DIFF
--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -995,7 +995,11 @@ chimera_smb_create_after_share(
                 owner.op_handle = oh;
                 if (via_rqls) {
                     /* RqLs: owner identity is the lease key, so same-key opens by
-                     * one client coalesce (the Samba locking.tdb rule). */
+                     * one client coalesce (the Samba locking.tdb rule).  Mark the
+                     * grant owner as a lease so the same-lease-key write/open
+                     * coherence exemption (chimera_vfs_lease_smb2_same_key)
+                     * applies to it but never to a legacy oplock. */
+                    owner.is_lease = 1;
                     memcpy(&owner.owner_lo, request->create.rqls.key, 8);
                     memcpy(&owner.owner_hi, request->create.rqls.key + 8, 8);
                     /* Mirror the lease_key onto the open_file for the break

--- a/src/server/smb/smb_proc_write.c
+++ b/src/server/smb/smb_proc_write.c
@@ -300,11 +300,17 @@ chimera_smb_write(struct chimera_smb_request *request)
      * OPLOCK_BREAK notification with the WRITE response and surfaces as
      * INVALID_NETWORK_RESPONSE on the client. */
     struct chimera_vfs_lease_owner io_owner;
+    memset(&io_owner, 0, sizeof(io_owner));
     io_owner.protocol   = CHIMERA_VFS_LEASE_PROTO_SMB2;
     io_owner.client_key = request->session_handle->session->client_key;
     if (request->write.open_file->grant) {
+        /* Carry the grant's own identity -- including is_lease -- so the
+         * write self-exempts only against a genuine RqLs lease key.  A legacy
+         * LEVEL_II oplock (is_lease==0) is NOT same-key-exempt and breaks its
+         * own read cache on write (smb2.oplock.batch6). */
         io_owner.owner_lo = request->write.open_file->grant->lease.owner.owner_lo;
         io_owner.owner_hi = request->write.open_file->grant->lease.owner.owner_hi;
+        io_owner.is_lease = request->write.open_file->grant->lease.owner.is_lease;
     } else {
         io_owner.owner_lo = request->write.open_file->file_id.pid;
         io_owner.owner_hi = request->write.open_file->file_id.vid;

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -1678,6 +1678,7 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.oplock.batch25
     smb2.oplock.batch4
     smb2.oplock.batch5
+    smb2.oplock.batch6
     smb2.oplock.batch8
     smb2.oplock.brl2
     smb2.oplock.exclusive1
@@ -3300,6 +3301,7 @@ set(SMBTORTURE_ENABLED_diskfs_io_uring
     smb2.oplock.batch25
     smb2.oplock.batch4
     smb2.oplock.batch5
+    smb2.oplock.batch6
     smb2.oplock.batch8
     smb2.oplock.brl2
     smb2.oplock.exclusive1

--- a/src/vfs/vfs_state.c
+++ b/src/vfs/vfs_state.c
@@ -305,8 +305,15 @@ chimera_vfs_lease_smb2_same_key(
     const struct chimera_vfs_lease_owner *holder,
     const struct chimera_vfs_lease_owner *opener)
 {
+    /* Both sides must carry a real RqLs LeaseKey (is_lease).  A legacy oplock's
+     * owner_lo/hi is its file_id, not a shared lease key: two oplocks that
+     * happen to share a file_id are simply the same owner (already handled by
+     * owner_equal), and a LEVEL_II oplock holder writing must still break its
+     * own read cache (smb2.oplock.batch6) -- so a legacy oplock never qualifies
+     * for the same-lease-key coherence exemption. */
     return holder->protocol == CHIMERA_VFS_LEASE_PROTO_SMB2 &&
            opener->protocol == CHIMERA_VFS_LEASE_PROTO_SMB2 &&
+           holder->is_lease && opener->is_lease &&
            holder->owner_lo == opener->owner_lo &&
            holder->owner_hi == opener->owner_hi;
 } /* chimera_vfs_lease_smb2_same_key */
@@ -2266,7 +2273,19 @@ chimera_vfs_break_reads_for_write(
             continue;
         }
         if (chimera_vfs_lease_owner_equal(&cur->owner, writer)) {
-            continue;
+            /* The writer's own holder is normally coherent with its own write
+             * and is not broken (smb2.lease.nobreakself / complex1).  The lone
+             * exception is a legacy LEVEL_II oplock (is_oplock, read-cache only,
+             * no W): a LEVEL_II oplock confers no write coherence, so a write --
+             * even by the holder itself -- invalidates the shared read cache and
+             * must break the writer's own LEVEL_II to NONE (smb2.oplock.batch6:
+             * a write by one LEVEL_II holder breaks BOTH LEVEL_II oplocks,
+             * including the writer's).  An exclusive / batch oplock holds W and
+             * is coherent, so it self-exempts like a lease. */
+            if (!(cur->grant && cur->grant->is_oplock) ||
+                (cur->mode.granted & CHIMERA_VFS_LEASE_MODE_W)) {
+                continue;
+            }
         }
         /* A holder sharing the writer's SMB2 lease key (even under a different
          * ClientGuid) shares the cache and is coherent with this write: do not


### PR DESCRIPTION
## Summary

Fixes a missing oplock break-on-conflict case: a write by a **LEVEL_II oplock holder** must break **both** LEVEL_II oplocks on the file, including the writer's own. We were dropping the writer's own break.

`chimera_vfs_break_reads_for_write` unconditionally self-exempts the writing owner. That is correct for an **SMB2 lease** — a lease holding a write cache is coherent with its own write (`smb2.lease.nobreakself`, `smb2.lease.complex1`) — but wrong for a **legacy LEVEL_II oplock**, which is a *read* cache with no write coherence: a write invalidates the shared LEVEL_II read cache for everyone, the writer included.

## MS-SMB2 / MS-FSA mechanism

A LEVEL_II (shared read) oplock provides no write coherence. When any holder writes, every LEVEL_II oplock on the file — including the writer's — is broken to NONE so no stale read cache survives. An *exclusive*/*batch* oplock (or a lease holding W) caches the write and stays coherent, so it self-exempts. `smb2.oplock.batch6` pins this: two LEVEL_II holders, one writes, expects two breaks.

## Changes (break-trigger / break-count only)

- `chimera_vfs_break_reads_for_write` (vfs_state.c): the writer's own holder is still skipped for a lease and for an exclusive/batch oplock (holds W), but a **LEVEL_II oplock** (`is_oplock`, R only, no W) now breaks its own read cache on write.
- `chimera_vfs_lease_smb2_same_key` (vfs_state.c): the same-lease-key coherence exemption now requires a real RqLs LeaseKey (`is_lease`) on **both** sides. A legacy oplock's owner key is its `file_id`, not a shareable lease key, so it never qualifies (owner-equality already covers the genuine same-owner case).
- The caching-grant owner records `is_lease` at acquire time (smb_proc_create.c), and the SMB write owner carries it through and zero-inits the owner struct (smb_proc_write.c).

## Tests enabled

`smb2.oplock.batch6` added to `SMBTORTURE_ENABLED_memfs` and `SMBTORTURE_ENABLED_diskfs_io_uring` (3/3 green on both).

## Verification

- `smb2.oplock.batch6` 3/3 green on memfs and diskfs_io_uring.
- Full enabled `smb2.lease` + `smb2.oplock` suites: zero new failures on both backends (52/52 memfs incl. batch6; 51/51 diskfs).
- Full enabled `smb2.durable-open`, `smb2.durable-v2-open`, `smb2.dirlease`, `smb2.replay`, `smb2.compound_async`: zero new failures on both backends (only the pre-existing env-gated skips `durable-open.reopen6`, `replay.replay5`).
- NFS4 delegations + SMB disconnect-race ctests: 159/159 passed (shared lease layer intact, ASan-clean).
- Release build clean (no `-Wmaybe-uninitialized`).

## Deferred

- **smb2.lease.unlink / smb2.lease.oplock**: blocked on a structural change — two *different clients* must be able to hold `RH` simultaneously (the current conflict matrix treats handle caching as cross-client exclusive). The test's very first assertion needs a second compatible open to be granted `RH` rather than `R`, plus a delete-disposition handle break. Deferred to avoid regressing the batch-oplock sole-handle semantics that rule underpins.
- **smb2.oplock.batch9 / batch9a**: need a batch oplock granted on an attribute-only open *without* breaking or down-capping when a conflicting holder exists. An initial attempt regressed `batch8` / `exclusive4` (a second attribute-only open requesting an oplock must get NONE and must not break the existing holder); the clean fix touches the grant arbitration and is deferred.
- The tcp-transport-block replay harness cases (`dhv2-pending3*`) cannot run in the netns setup regardless.

## Scoping note (parallel agent)

A parallel change is editing the lease **epoch-value** accounting in this same file (`vfs_state.c`). This change is limited to whether the break **fires** and the break **count**, and deliberately does not touch any epoch-increment line, to minimize merge conflict.
