### PR TITLE
smb2: blocking byte-range locks, copy-chunk lock enforcement, LockSequence replay

### DIFF
--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -664,6 +664,25 @@ struct chimera_smb_request {
             }                              elements[CHIMERA_SMB_LOCK_MAX_ELEMENTS];
             bool                           lock_too_many;
             struct chimera_smb_lock_entry *entry;  /* live for the in-flight acquire */
+            /* Blocking-lock (MS-SMB2 3.3.5.14) park state.  Set once a contended
+             * LOCK without FAIL_IMMEDIATELY emits its STATUS_PENDING interim and
+             * parks on the VFS pending-acquire queue.  The grant callback may fire
+             * on ANOTHER thread (whoever released the conflicting range); it stashes
+             * resume_status and enqueues the request on its owning thread's
+             * lock_resume_head via lock_resume_next, then rings the resume doorbell.
+             * The owning thread drains the queue, retires the interim, and completes
+             * with resume_status.  parked stays set from interim until completion so
+             * the close / teardown abort path can find and cancel it. */
+            uint8_t                        parked;
+            uint32_t                       resume_status;
+            struct chimera_smb_request    *lock_resume_next;
+            /* MS-SMB2 3.3.5.14 LockSequence replay bucket for this single-element
+             * request: 1..64 when replay detection is active for the open and the
+             * client supplied a valid bucket, else 0 (no caching).  Captured at
+             * handler entry; the status of a non-replayed op is written back into
+             * open_file->lock_seq_* under this bucket at completion. */
+            uint8_t                        seq_bucket;
+            uint8_t                        seq_index;
         } lock;
 
         struct {
@@ -1195,6 +1214,18 @@ chimera_smb_open_file_drain_locks(
     struct chimera_server_smb_thread *thread,
     struct chimera_smb_open_file     *open_file);
 
+/* Forward decls (defined in smb_proc_lock.c; also in smb_procs.h, which this
+ * header cannot include) so the inline tree-teardown path can abort and complete
+ * a blocking byte-range LOCK parked on an open being torn down. */
+struct chimera_smb_request *
+chimera_smb_lock_abort_parked(
+    struct chimera_server_smb_thread *thread,
+    struct chimera_smb_open_file     *open_file);
+void
+chimera_smb_lock_park_finish(
+    struct chimera_smb_request *request,
+    uint32_t                    status);
+
 /* Ring every peer SMB thread's lease-resume doorbell so each re-sweeps its
  * connections for parked CREATEs an event on this thread unblocked (defined in
  * smb_proc_create.c; also declared in smb_procs.h, which this header cannot
@@ -1386,6 +1417,15 @@ struct chimera_server_smb_thread {
      * drains the queue and completes each on this, its owning, thread.  Guarded
      * by lease_break_lock. */
     struct chimera_smb_request         *share_resume_head;
+
+    /* Cross-thread queue of blocking byte-range LOCKs (MS-SMB2 3.3.5.14) parked
+     * on a conflicting range whose VFS acquire ticket was GRANTED on ANOTHER
+     * thread (whichever released the conflicting lock).  The deferred LOCK
+     * response's iovecs are thread-local, so the granting thread enqueues the
+     * request here and rings this thread's lease_resume_doorbell; the handler
+     * drains the queue and completes each blocking lock on its owning thread.
+     * Guarded by lease_break_lock; link reuses request->async.park_next. */
+    struct chimera_smb_request         *lock_resume_head;
 
     /* Active (non-pooled) connections owned by this thread, threaded on
      * conn->active_prev / conn->active_next.  Lets a thread walk every
@@ -2062,6 +2102,8 @@ chimera_smb_tree_free(
     struct chimera_smb_open_file    *open_file, *tmp;
     struct chimera_smb_notify_state *gc_states = NULL;
     struct chimera_smb_notify_state *nstate;
+    struct chimera_smb_request      *lock_aborts = NULL;
+    struct chimera_smb_request      *labort;
     bool                             closed_breaking = false;
     int                              i;
 
@@ -2073,6 +2115,21 @@ chimera_smb_tree_free(
         {
             chimera_smb_abort_if(open_file->refcnt == 0, "open file refcnt is 0 at tree destruction");
             HASH_DELETE(hh, tree->open_files[i], open_file);
+
+            /* Detach any blocking byte-range LOCK parked on this open (MS-SMB2
+             * smb2.lock.cancel-tdis / cancel-logoff) BEFORE the durable-preserve
+             * decision: a blocking lock cannot survive a disconnect/teardown, so
+             * abort it even when the handle itself is preserved durable.  Defer
+             * its completion until the bucket lock is dropped — finishing it
+             * releases the open_file reference it holds, which re-takes this same
+             * bucket lock.  The parked request keeps refcnt > 0, so the open is not
+             * freed in this loop; the deferred completion below drops that ref.
+             * Aborts are chained on lock.lock_resume_next (the abort cleared it). */
+            labort = chimera_smb_lock_abort_parked(thread, open_file);
+            if (labort) {
+                labort->lock.lock_resume_next = lock_aborts;
+                lock_aborts                   = labort;
+            }
 
             /* A durable/persistent open survives the teardown of its session
              * (connection loss or a graceful LOGOFF, MS-SMB2 3.3.5.6): keep the
@@ -2170,6 +2227,17 @@ chimera_smb_tree_free(
         nstate    = gc_states;
         gc_states = nstate->gc_next;
         chimera_smb_notify_close(shared->vfs->vfs_notify, nstate);
+    }
+
+    /* Complete the blocking LOCKs aborted above with RANGE_NOT_LOCKED, now that
+     * no bucket lock is held (the completion drops the open_file reference, which
+     * re-takes the bucket lock and frees the open). */
+    while (lock_aborts) {
+        labort      = lock_aborts;
+        lock_aborts = labort->lock.lock_resume_next;
+
+        labort->lock.lock_resume_next = NULL;
+        chimera_smb_lock_park_finish(labort, labort->lock.resume_status);
     }
 
     /* Closing a mid-break durable open above resolved its (unackable) break;

--- a/src/server/smb/smb_proc_cancel.c
+++ b/src/server/smb/smb_proc_cancel.c
@@ -76,16 +76,31 @@ chimera_smb_cancel(struct chimera_smb_request *request)
     if (match) {
         chimera_smb_notify_cancel(match);
     } else if (async) {
-        /* Search requests pending an async-interim (e.g. a CREATE blocked on a
-         * lease break).  The underlying wait is not yet cancellable from
-         * SMB2_CANCEL -- absorb it silently; the request still completes when its
-         * break acks.  A future phase can abort the parked open here. */
+        /* Search requests pending an async-interim.  A blocking byte-range LOCK
+         * (MS-SMB2 3.3.5.14) parked on a conflicting range is cancellable: cancel
+         * its VFS acquire and complete it with STATUS_CANCELLED (smb2.lock.cancel).
+         * A CREATE blocked on a lease break is not (yet) cancellable from here --
+         * absorb that silently; it completes when its break acks. */
         struct chimera_smb_request *parked;
 
         for (parked = conn->parked_requests; parked;
              parked = parked->async.park_next) {
             if (parked->async_id == target_id) {
                 break;
+            }
+        }
+
+        if (parked && parked->smb2_hdr.command == SMB2_LOCK &&
+            parked->lock.parked && parked->lock.open_file) {
+            struct chimera_smb_request *abort =
+                chimera_smb_lock_abort_parked(request->compound->thread,
+                                              parked->lock.open_file);
+
+            /* abort_parked clears open_file->parked_lock_req and returns the same
+             * request; complete it with CANCELLED rather than the abort default
+             * (RANGE_NOT_LOCKED). */
+            if (abort) {
+                chimera_smb_lock_park_finish(abort, SMB2_STATUS_CANCELLED);
             }
         }
     }

--- a/src/server/smb/smb_proc_close.c
+++ b/src/server/smb/smb_proc_close.c
@@ -291,6 +291,20 @@ chimera_smb_close(struct chimera_smb_request *request)
         return;
     }
 
+    /* A blocking byte-range LOCK still parked on this handle is aborted by the
+     * close and completed with RANGE_NOT_LOCKED (MS-SMB2; smb2.lock.cancel
+     * "cancel by close").  The open is already unhashed + marked CLOSED above, so
+     * the parked request's deferred grant can no longer land; finishing it here
+     * drops the open_file reference it held. */
+    {
+        struct chimera_smb_request *parked =
+            chimera_smb_lock_abort_parked(thread, request->close.open_file);
+
+        if (parked) {
+            chimera_smb_lock_park_finish(parked, parked->lock.resume_status);
+        }
+    }
+
     /* Clean up any notify watches on this open file */
     if (request->close.open_file->notify_state) {
         chimera_smb_notify_close(thread->shared->vfs->vfs_notify,

--- a/src/server/smb/smb_proc_copychunk.c
+++ b/src/server/smb/smb_proc_copychunk.c
@@ -8,6 +8,7 @@
 #include "smb_session.h"
 #include "vfs/vfs.h"
 #include "vfs/vfs_procs.h"
+#include "vfs/vfs_state.h"
 
 /*
  * Server-side copy: FSCTL_SRV_REQUEST_RESUME_KEY + FSCTL_SRV_COPYCHUNK.
@@ -128,12 +129,33 @@ chimera_smb_copychunk_error_with_body(
     chimera_smb_copychunk_done(request, status);
 } /* chimera_smb_copychunk_error_with_body */
 
+/* Build the byte-range-lock owner identity for an open exactly as the WRITE/READ
+ * paths do, so a copy-chunk's own locks don't conflict with its I/O. */
+static inline void
+chimera_smb_copychunk_io_owner(
+    struct chimera_smb_request     *request,
+    struct chimera_smb_open_file   *open_file,
+    struct chimera_vfs_lease_owner *owner)
+{
+    owner->protocol   = CHIMERA_VFS_LEASE_PROTO_SMB2;
+    owner->client_key = request->session_handle->session->client_key;
+    if (open_file->grant) {
+        owner->owner_lo = open_file->grant->lease.owner.owner_lo;
+        owner->owner_hi = open_file->grant->lease.owner.owner_hi;
+    } else {
+        owner->owner_lo = open_file->file_id.pid;
+        owner->owner_hi = open_file->file_id.vid;
+    }
+} /* chimera_smb_copychunk_io_owner */
+
 /* Issue the next pending chunk, or finish if all are done. */
 static void
 chimera_smb_copychunk_next(struct chimera_smb_request *request)
 {
-    struct chimera_vfs_thread *vfs_thread = request->compound->thread->vfs_thread;
-    uint32_t                   i          = request->ioctl.cc_chunk_idx;
+    struct chimera_vfs_thread     *vfs_thread = request->compound->thread->vfs_thread;
+    struct chimera_vfs_state      *vfs_state  = vfs_thread->vfs->vfs_state;
+    uint32_t                       i          = request->ioctl.cc_chunk_idx;
+    struct chimera_vfs_lease_owner io_owner;
 
     if (i >= request->ioctl.cc_chunk_count) {
         chimera_smb_copychunk_done(request, SMB2_STATUS_SUCCESS);
@@ -146,6 +168,42 @@ chimera_smb_copychunk_next(struct chimera_smb_request *request)
     if (request->ioctl.cc_chunks[i].src_offset +
         request->ioctl.cc_chunks[i].length > request->ioctl.cc_src_size) {
         chimera_smb_copychunk_error_with_body(request, SMB2_STATUS_INVALID_VIEW_SIZE);
+        return;
+    }
+
+    /* MS-SMB2 server-side copy on Windows Server 2012+ moves chunks via regular
+     * read/write, so byte-range locks are enforced: a chunk whose source range is
+     * read-blocked by another owner's lock, or whose destination range is
+     * write-blocked, fails the whole COPYCHUNK with FILE_LOCK_CONFLICT
+     * (smb2.ioctl.copy_chunk_src_lock / copy_chunk_dest_lock).  The response body
+     * reports zero chunks written. */
+    chimera_smb_copychunk_io_owner(request, request->ioctl.cc_src_open_file,
+                                   &io_owner);
+    if (chimera_vfs_state_range_io_conflict(
+            vfs_state,
+            request->ioctl.cc_src_open_file->handle->fh,
+            request->ioctl.cc_src_open_file->handle->fh_len,
+            request->ioctl.cc_src_open_file->handle->fh_hash,
+            request->ioctl.cc_chunks[i].src_offset,
+            request->ioctl.cc_chunks[i].length,
+            false /* read */, &io_owner)) {
+        chimera_smb_copychunk_error_with_body(request,
+                                              SMB2_STATUS_FILE_LOCK_CONFLICT);
+        return;
+    }
+
+    chimera_smb_copychunk_io_owner(request, request->ioctl.cc_dst_open_file,
+                                   &io_owner);
+    if (chimera_vfs_state_range_io_conflict(
+            vfs_state,
+            request->ioctl.cc_dst_open_file->handle->fh,
+            request->ioctl.cc_dst_open_file->handle->fh_len,
+            request->ioctl.cc_dst_open_file->handle->fh_hash,
+            request->ioctl.cc_chunks[i].dst_offset,
+            request->ioctl.cc_chunks[i].length,
+            true /* write */, &io_owner)) {
+        chimera_smb_copychunk_error_with_body(request,
+                                              SMB2_STATUS_FILE_LOCK_CONFLICT);
         return;
     }
 

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -2303,6 +2303,27 @@ chimera_smb_create_resume_doorbell_callback(
         req->async.park_next = NULL;
         chimera_smb_create_share_park_finish(req, req->create.gen_resume_result);
     }
+
+    /* Drain blocking byte-range LOCKs whose VFS acquire ticket resolved on
+     * another thread (chimera_smb_lock_acquire_cb) and were bounced here to
+     * complete on their owning thread with the stashed grant status. */
+    for ( ; ;) {
+        struct chimera_smb_request *req;
+
+        pthread_mutex_lock(&thread->lease_break_lock);
+        req = thread->lock_resume_head;
+        if (req) {
+            thread->lock_resume_head = req->lock.lock_resume_next;
+        }
+        pthread_mutex_unlock(&thread->lease_break_lock);
+
+        if (!req) {
+            break;
+        }
+
+        req->lock.lock_resume_next = NULL;
+        chimera_smb_lock_park_finish(req, req->lock.resume_status);
+    }
 } /* chimera_smb_create_resume_doorbell_callback */
 
 /* Ring every PEER SMB thread's resume doorbell so each re-scans its own

--- a/src/server/smb/smb_proc_lock.c
+++ b/src/server/smb/smb_proc_lock.c
@@ -8,6 +8,8 @@
 #include "smb_internal.h"
 #include "smb_procs.h"
 #include "smb_session.h"
+#include "smb_async_interim.h"
+#include "smb2.h"
 #include "common/misc.h"
 #include "vfs/vfs.h"
 #include "vfs/vfs_procs.h"
@@ -15,6 +17,13 @@
 
 #define SMB2_LOCK_REQUEST_SIZE    48   /* fixed; LockCount==1 in this build */
 #define SMB2_LOCK_REPLY_SIZE      4
+
+/* Sentinel stored in request->lock.resume_status before a (possibly blocking)
+ * single-element acquire: chimera_smb_lock_acquire_cb overwrites it with the
+ * real status if it fires synchronously, so a value still equal to this after
+ * chimera_vfs_lease_acquire returns means the acquire parked on the VFS pending
+ * queue and the callback will fire later. */
+#define CHIMERA_SMB_LOCK_PENDING  0xFFFFFFFFu
 
 /* Per MS-SMB2 §2.2.26.1 */
 #define SMB2_LOCKFLAG_SHARED_LOCK 0x00000001
@@ -25,6 +34,59 @@
 #define SMB2_LOCKFLAG_KIND_MASK   (SMB2_LOCKFLAG_SHARED_LOCK | \
                                    SMB2_LOCKFLAG_EXCLUSIVE   | \
                                    SMB2_LOCKFLAG_UNLOCK)
+
+/* MS-SMB2 3.3.5.14 LockSequence replay detection.  The 32-bit LockSequence is a
+ * 4-bit LockSequenceNumber (the "bucket", valid 1..64) in bits [4..7] and a 4-bit
+ * LockSequenceIndex in bits [0..3]; the rest is reserved.  Replay verification is
+ * performed only for a durable / persistent / resilient handle, or on an SMB 3.x
+ * connection that negotiated multichannel (per the spec and Note <314>). */
+static inline uint8_t
+chimera_smb_lock_seq_bucket(uint32_t lock_sequence)
+{
+    return (uint8_t) ((lock_sequence >> 4) & 0xFF);
+} /* chimera_smb_lock_seq_bucket */
+
+static inline uint8_t
+chimera_smb_lock_seq_index(uint32_t lock_sequence)
+{
+    return (uint8_t) (lock_sequence & 0x0F);
+} /* chimera_smb_lock_seq_index */
+
+/* True when this open performs LockSequence replay verification (MS-SMB2
+ * 3.3.5.14): a durable, persistent, or resilient handle, or any handle on an
+ * SMB 3.x connection that negotiated SMB2_GLOBAL_CAP_MULTI_CHANNEL. */
+static inline bool
+chimera_smb_lock_replay_active(
+    struct chimera_smb_request   *request,
+    struct chimera_smb_open_file *open_file)
+{
+    struct chimera_smb_conn *conn = request->compound->conn;
+
+    if (open_file->durable_flags || open_file->resilient ||
+        (open_file->flags & CHIMERA_SMB_OPEN_FILE_PERSISTED)) {
+        return true;
+    }
+    return conn && conn->dialect >= 0x300 &&
+           (conn->capabilities & SMB2_GLOBAL_CAP_MULTI_CHANNEL);
+} /* chimera_smb_lock_replay_active */
+
+/* Record the outcome `status` of a non-replayed single-element lock op in the
+ * open's per-bucket replay cache.  No-op when the request carried no valid
+ * bucket (replay inactive, or bucket 0 / >64). */
+static inline void
+chimera_smb_lock_seq_record(
+    struct chimera_smb_request   *request,
+    struct chimera_smb_open_file *open_file,
+    uint32_t                      status)
+{
+    uint8_t b = request->lock.seq_bucket;
+
+    if (b >= 1 && b <= 64) {
+        open_file->lock_seq_valid[b - 1]  = 1;
+        open_file->lock_seq_index[b - 1]  = request->lock.seq_index;
+        open_file->lock_seq_status[b - 1] = status;
+    }
+} /* chimera_smb_lock_seq_record */
 
 /* Half-open byte-range overlap, mirroring chimera_vfs_range_overlap: length 0
  * is a genuine zero-byte range and the exclusive end saturates at UINT64_MAX on
@@ -195,6 +257,142 @@ chimera_smb_parse_lock(
     return 0;
 } /* chimera_smb_parse_lock */
 
+/* Map a finished single-element acquire to its SMB2 status and either install or
+ * tear down the lock entry.  Caller owns completing the request afterwards. */
+static uint32_t
+chimera_smb_lock_settle_entry(
+    struct chimera_vfs_state      *vfs_state,
+    struct chimera_smb_request    *request,
+    struct chimera_smb_open_file  *open_file,
+    struct chimera_smb_lock_entry *entry,
+    enum chimera_vfs_lease_result  result)
+{
+    if (result == CHIMERA_VFS_LEASE_GRANTED) {
+        entry->lease_inserted = true;
+        DL_APPEND(open_file->lock_entries, entry);
+        return SMB2_STATUS_SUCCESS;
+    }
+
+    /* Tear the entry down.  Normally the lease was never inserted (a
+     * FAIL_IMMEDIATELY denial or an unbreakable-caching conflict), but a parked
+     * lock that was GRANTED by the VFS and then aborted in the same instant the
+     * grant landed (handle close / teardown racing the conflict release) reaches
+     * here with lease_inserted set — release the inserted lease so it is not
+     * leaked into the VFS range table. */
+    if (entry->lease_inserted) {
+        chimera_vfs_lease_release(vfs_state, entry->file_state, &entry->lease);
+    }
+    chimera_vfs_state_put(vfs_state, entry->file_state);
+    free(entry);
+    request->lock.entry = NULL;
+    /* MS-SMB2 §3.3.5.14 maps a lock denied by an existing range to
+     * STATUS_LOCK_NOT_GRANTED (or _RANGE for SMB2 v.s. SMB1 spec
+     * variants).  Use _NOT_GRANTED — accepted by Windows clients.  A waiting
+     * lock never lands here DENIED (it parks); only a FAIL_IMMEDIATELY acquire
+     * or an unbreakable-caching conflict does. */
+    return SMB2_STATUS_LOCK_NOT_GRANTED;
+} /* chimera_smb_lock_settle_entry */
+
+/* Complete a parked blocking lock on its OWNING thread (driven by the resume
+ * doorbell, the close/teardown abort path, or an SMB2 CANCEL).  `status` is the
+ * stashed grant result, SMB2_STATUS_CANCELLED, or SMB2_STATUS_RANGE_NOT_LOCKED.
+ * Unlinks the open's parked-lock reference, installs or tears down the entry,
+ * and drops the open_file reference the park held. */
+SYMBOL_EXPORT void
+chimera_smb_lock_park_finish(
+    struct chimera_smb_request *request,
+    uint32_t                    status)
+{
+    struct chimera_server_smb_thread *thread    = request->compound->thread;
+    struct chimera_vfs_state         *vfs_state = thread->vfs_thread->vfs->vfs_state;
+    struct chimera_smb_lock_entry    *entry     = request->lock.entry;
+    struct chimera_smb_open_file     *open_file = request->lock.open_file;
+
+    /* open_file is always valid here: a park stores it on request->lock.open_file
+     * and holds a reference that is dropped only by this function, and every
+     * caller (resume doorbell, close/teardown abort, SMB2 CANCEL) reaches a
+     * parked request via that same open_file. */
+    request->lock.parked = 0;
+    if (open_file->parked_lock_req == request) {
+        open_file->parked_lock_req = NULL;
+    }
+
+    if (entry) {
+        entry->pending_req = NULL;
+        if (status == SMB2_STATUS_SUCCESS) {
+            status = chimera_smb_lock_settle_entry(vfs_state, request, open_file,
+                                                   entry, CHIMERA_VFS_LEASE_GRANTED);
+        } else {
+            /* Aborted/cancelled before grant: tear the entry down. */
+            chimera_smb_lock_settle_entry(vfs_state, request, open_file,
+                                          entry, CHIMERA_VFS_LEASE_DENIED);
+        }
+    }
+
+    /* Cache a granted blocking-lock outcome for LockSequence replay (an aborted /
+     * cancelled lock is not a real outcome and is not recorded). */
+    if (status == SMB2_STATUS_SUCCESS) {
+        chimera_smb_lock_seq_record(request, open_file, status);
+    }
+
+    chimera_smb_open_file_release(request, open_file);
+    chimera_smb_complete_request(request, status);
+} /* chimera_smb_lock_park_finish */
+
+SYMBOL_EXPORT struct chimera_smb_request *
+chimera_smb_lock_abort_parked(
+    struct chimera_server_smb_thread *thread,
+    struct chimera_smb_open_file     *open_file)
+{
+    struct chimera_vfs_state      *vfs_state = thread->vfs_thread->vfs->vfs_state;
+    struct chimera_smb_request    *request   = open_file->parked_lock_req;
+    struct chimera_smb_lock_entry *entry;
+
+    if (!request) {
+        return NULL;
+    }
+
+    open_file->parked_lock_req = NULL;
+    entry                      = request->lock.entry;
+
+    /* Try to pull the ticket off the VFS pending-acquire queue.  If it dequeues,
+     * the grant callback will never fire and we own the request outright.  If it
+     * does NOT dequeue, the grant raced in: the callback already fired (on this
+     * or another thread), stashed SUCCESS, and queued the request on this
+     * thread's lock_resume_head.  Both this abort and the resume drain run on the
+     * owning thread, so unlink it from lock_resume_head here and abort it rather
+     * than letting the drain complete it (the open is being torn down). */
+    if (entry && !chimera_vfs_lease_acquire_cancel(vfs_state, &entry->ticket)) {
+        struct chimera_smb_request **pp = &thread->lock_resume_head;
+
+        pthread_mutex_lock(&thread->lease_break_lock);
+        while (*pp) {
+            if (*pp == request) {
+                *pp = request->lock.lock_resume_next;
+                request->lock.lock_resume_next = NULL;
+                break;
+            }
+            pp = &(*pp)->lock.lock_resume_next;
+        }
+        pthread_mutex_unlock(&thread->lease_break_lock);
+
+        /* The ticket did not dequeue because the grant already landed: the VFS
+         * range lease IS inserted in the table even though the SMB-side
+         * lease_inserted flag (set only by the GRANTED settle path) is still
+         * clear.  Mark it so chimera_smb_lock_park_finish's teardown releases the
+         * inserted lease instead of leaking it. */
+        if (entry && request->lock.resume_status == SMB2_STATUS_SUCCESS) {
+            entry->lease_inserted = true;
+        }
+    }
+
+    /* Closing a handle whose blocking lock is still pending completes that lock
+     * with RANGE_NOT_LOCKED (MS-SMB2 / smb2.lock.cancel "cancel by close"; the
+     * tree-disconnect and logoff variants accept RANGE_NOT_LOCKED too). */
+    request->lock.resume_status = SMB2_STATUS_RANGE_NOT_LOCKED;
+    return request;
+} /* chimera_smb_lock_abort_parked */
+
 static void
 chimera_smb_lock_acquire_cb(
     enum chimera_vfs_lease_result result,
@@ -202,33 +400,39 @@ chimera_smb_lock_acquire_cb(
     struct chimera_vfs_lease     *conflict,
     void                         *private_data)
 {
-    struct chimera_smb_lock_entry *entry     = private_data;
-    struct chimera_smb_request    *request   = entry->pending_req;
-    struct chimera_smb_open_file  *open_file = entry->open_file;
-    struct chimera_vfs_state      *vfs_state = request->compound->thread->vfs_thread->vfs->vfs_state;
-    uint32_t                       status;
+    struct chimera_smb_lock_entry    *entry   = private_data;
+    struct chimera_smb_request       *request = entry->pending_req;
+    struct chimera_server_smb_thread *thread  = request->compound->thread;
+    uint32_t                          status;
 
     (void) granted;
     (void) conflict;
 
-    entry->pending_req = NULL;
+    status = (result == CHIMERA_VFS_LEASE_GRANTED)
+        ? SMB2_STATUS_SUCCESS : SMB2_STATUS_LOCK_NOT_GRANTED;
 
-    if (result == CHIMERA_VFS_LEASE_GRANTED) {
-        entry->lease_inserted = true;
-        DL_APPEND(open_file->lock_entries, entry);
-        status = SMB2_STATUS_SUCCESS;
-    } else {
-        chimera_vfs_state_put(vfs_state, entry->file_state);
-        free(entry);
-        request->lock.entry = NULL;
-        /* MS-SMB2 §3.3.5.14 maps a lock denied by an existing range to
-         * STATUS_LOCK_NOT_GRANTED (or _RANGE for SMB2 v.s. SMB1 spec
-         * variants).  Use _NOT_GRANTED — accepted by Windows clients. */
-        status = SMB2_STATUS_LOCK_NOT_GRANTED;
+    if (!request->lock.parked) {
+        /* Synchronous outcome: the acquire has not returned yet.  Stash the
+         * status and let chimera_smb_lock act on it inline (no interim was
+         * emitted), so the common grant/deny path stays a single thread hop. */
+        request->lock.resume_status = status;
+        return;
     }
 
-    chimera_smb_open_file_release(request, open_file);
-    chimera_smb_complete_request(request, status);
+    /* Deferred grant: this lock had parked (interim already sent) and the
+     * conflicting range was just released.  The release — and therefore this
+     * callback — can run on ANY thread (whichever owner unlocked); the LOCK
+     * response's iovecs are thread-local, so stash the result and bounce to the
+     * request's owning thread, which drains lock_resume_head off its resume
+     * doorbell and completes the lock there. */
+    request->lock.resume_status = status;
+
+    pthread_mutex_lock(&thread->lease_break_lock);
+    request->lock.lock_resume_next = thread->lock_resume_head;
+    thread->lock_resume_head       = request;
+    pthread_mutex_unlock(&thread->lease_break_lock);
+
+    evpl_ring_doorbell(&thread->lease_resume_doorbell);
 } /* chimera_smb_lock_acquire_cb */
 
 /* Records a synchronous lease-acquire outcome.  chimera_vfs_lease_acquire fires
@@ -498,6 +702,28 @@ chimera_smb_lock(struct chimera_smb_request *request)
         return;
     }
 
+    /* MS-SMB2 3.3.5.14 LockSequence replay detection (single-element path).
+     * Capture the bucket for an open that performs replay verification, and if it
+     * is a replay of the last op recorded under that bucket (same index), return
+     * the cached status without re-applying the lock — making a retransmit after a
+     * lost reply idempotent. */
+    request->lock.seq_bucket = 0;
+    request->lock.seq_index  = chimera_smb_lock_seq_index(request->lock.lock_sequence);
+    if (chimera_smb_lock_replay_active(request, open_file)) {
+        uint8_t b = chimera_smb_lock_seq_bucket(request->lock.lock_sequence);
+
+        if (b >= 1 && b <= 64) {
+            request->lock.seq_bucket = b;
+            if (open_file->lock_seq_valid[b - 1] &&
+                open_file->lock_seq_index[b - 1] == request->lock.seq_index) {
+                uint32_t cached = open_file->lock_seq_status[b - 1];
+                chimera_smb_open_file_release(request, open_file);
+                chimera_smb_complete_request(request, cached);
+                return;
+            }
+        }
+    }
+
     kind = request->lock.l_flags & SMB2_LOCKFLAG_KIND_MASK;
     if (kind != SMB2_LOCKFLAG_SHARED_LOCK &&
         kind != SMB2_LOCKFLAG_EXCLUSIVE &&
@@ -548,6 +774,8 @@ chimera_smb_lock(struct chimera_smb_request *request)
         }
 
         if (!match) {
+            chimera_smb_lock_seq_record(request, open_file,
+                                        SMB2_STATUS_RANGE_NOT_LOCKED);
             chimera_smb_open_file_release(request, open_file);
             /* No matching range — Windows returns RANGE_NOT_LOCKED. */
             chimera_smb_complete_request(request, SMB2_STATUS_RANGE_NOT_LOCKED);
@@ -563,6 +791,7 @@ chimera_smb_lock(struct chimera_smb_request *request)
         }
         free(match);
 
+        chimera_smb_lock_seq_record(request, open_file, SMB2_STATUS_SUCCESS);
         chimera_smb_open_file_release(request, open_file);
         chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
         return;
@@ -584,6 +813,8 @@ chimera_smb_lock(struct chimera_smb_request *request)
         {
             if (smb_lock_ranges_overlap(held->lease.offset, held->lease.length,
                                         request->lock.l_offset, want_length)) {
+                chimera_smb_lock_seq_record(request, open_file,
+                                            SMB2_STATUS_LOCK_NOT_GRANTED);
                 chimera_smb_open_file_release(request, open_file);
                 chimera_smb_complete_request(request,
                                              SMB2_STATUS_LOCK_NOT_GRANTED);
@@ -633,13 +864,62 @@ chimera_smb_lock(struct chimera_smb_request *request)
      * other.  The grant's lease carries the same pointer in cb_private. */
     entry->lease.owner.cb_private = open_file->grant;
 
-    request->lock.entry = entry;
+    request->lock.entry         = entry;
+    request->lock.resume_status = CHIMERA_SMB_LOCK_PENDING;
 
     wait = !(request->lock.l_flags & SMB2_LOCKFLAG_FAIL_IMM);
+
+    /* A waiting acquire may queue in the VFS and have its grant callback fire
+     * later on ANOTHER thread (whoever releases the conflict).  Arm `parked`
+     * BEFORE the call so the callback always takes the cross-thread bounce path,
+     * even if a concurrent release fires it the instant the ticket queues — this
+     * closes the window where the callback would otherwise mistake a deferred
+     * grant for a synchronous one.  A FAIL_IMMEDIATELY acquire never queues, so
+     * its callback always fires inline; leave it on the synchronous path. */
+    request->lock.parked = wait ? 1 : 0;
 
     chimera_vfs_lease_acquire(vfs_state, entry->file_state,
                               &entry->lease, &entry->ticket, wait,
                               chimera_smb_lock_acquire_cb, entry);
+
+    if (request->lock.parked && request->lock.resume_status == CHIMERA_SMB_LOCK_PENDING) {
+        /* The acquire genuinely queued (a conflicting range held by another
+         * owner, or a breakable caching lease being recalled) and its callback
+         * has not fired.  This is an SMB2 blocking lock (MS-SMB2 3.3.5.14): emit
+         * the STATUS_PENDING interim and record the park on the open so close /
+         * tree-disconnect / logoff / connection teardown can abort it.  On grant
+         * the callback bounces to this thread's resume doorbell; an SMB2 CANCEL
+         * or an abort completes it with CANCELLED / RANGE_NOT_LOCKED. */
+        open_file->parked_lock_req = request;
+        chimera_smb_async_interim_begin(request);
+        return;
+    }
+
+    if (request->lock.parked) {
+        /* Waiting acquire that resolved (granted or unbreakable-caching denial)
+         * before/at return: the callback already stashed the result and queued
+         * the request on this thread's lock_resume_head + rang the doorbell.  No
+         * interim is needed (no real wait occurred); the doorbell drain completes
+         * it.  request->lock.parked stays 1 until the drain. */
+        return;
+    }
+
+    /* FAIL_IMMEDIATELY: a synchronous grant or denial.  Install or tear down the
+     * entry and complete inline.  Clear pending_req BEFORE settle — a DENIED
+     * settle frees the entry, so touching it afterwards would be a UAF. */
+    {
+        uint32_t status;
+
+        entry->pending_req = NULL;
+        status             = chimera_smb_lock_settle_entry(
+            vfs_state, request, open_file, entry,
+            request->lock.resume_status == SMB2_STATUS_SUCCESS
+            ? CHIMERA_VFS_LEASE_GRANTED : CHIMERA_VFS_LEASE_DENIED);
+
+        chimera_smb_lock_seq_record(request, open_file, status);
+        chimera_smb_open_file_release(request, open_file);
+        chimera_smb_complete_request(request, status);
+    }
 } /* chimera_smb_lock */
 
 void

--- a/src/server/smb/smb_procs.h
+++ b/src/server/smb/smb_procs.h
@@ -272,6 +272,24 @@ void chimera_smb_lock_reply(
     struct evpl_iovec_cursor   *reply_cursor,
     struct chimera_smb_request *request);
 
+/* Complete a parked blocking byte-range LOCK on its owning thread with `status`
+ * (the stashed grant result, SMB2_STATUS_CANCELLED, or
+ * SMB2_STATUS_RANGE_NOT_LOCKED).  Cancels the VFS ticket bookkeeping, installs or
+ * tears down the entry, drops the open_file reference the park held, and replies. */
+void chimera_smb_lock_park_finish(
+    struct chimera_smb_request *request,
+    uint32_t                    status);
+
+/* Abort a blocking LOCK parked on `open_file` (handle close, tree disconnect,
+ * logoff, or connection teardown): cancel its VFS acquire and complete it with
+ * SMB2_STATUS_RANGE_NOT_LOCKED.  No-op when no lock is parked.  Must run on the
+ * open's owning thread.  Returns the aborted request (whose open_file reference
+ * the caller's completion drops), or NULL. */
+struct chimera_smb_request *
+chimera_smb_lock_abort_parked(
+    struct chimera_server_smb_thread *thread,
+    struct chimera_smb_open_file     *open_file);
+
 /* Drain (release + free) every byte-range lock entry held by `open_file`.
  * Called at close before the underlying VFS handle is released. */
 void chimera_smb_open_file_drain_locks(

--- a/src/server/smb/smb_session.h
+++ b/src/server/smb/smb_session.h
@@ -197,6 +197,25 @@ struct chimera_smb_open_file {
     /* Byte-range locks (SMB2_LOCK) held against this open.  Allocated
      * and linked on each granted lock op; freed on UNLOCK or on close. */
     struct chimera_smb_lock_entry    *lock_entries;
+    /* A blocking byte-range LOCK (MS-SMB2 3.3.5.14) parked on this open waiting
+     * for a conflicting range to release.  NULL when no lock is pending.  The
+     * parked request holds an open_file reference, so the open is not freed while
+     * a lock waits; close / tree-disconnect / logoff / connection teardown abort
+     * the parked lock (cancel the VFS ticket, complete RANGE_NOT_LOCKED) so the
+     * reference is dropped and the open can be reclaimed. */
+    struct chimera_smb_request       *parked_lock_req;
+    /* MS-SMB2 3.3.5.14 LockSequence replay cache.  A LOCK/UNLOCK carries a
+     * 4-bit LockSequenceNumber (bucket, 1..64 valid) + 4-bit LockSequenceIndex.
+     * For a durable / persistent / resilient / multichannel handle the server
+     * caches, per bucket, the index of the last lock op and its status; a
+     * re-send carrying the same bucket+index is a replay and returns the cached
+     * status without re-applying (so a lost-reply retransmit is idempotent).
+     * lock_seq_valid[b] is 0 until bucket b (1..64) has been used; the slot then
+     * holds the last index and status.  Index 0 is a legal index, so a separate
+     * valid flag is required.  Bucket 0 / >64 are never cached. */
+    uint8_t                           lock_seq_valid[64];
+    uint8_t                           lock_seq_index[64];
+    uint32_t                          lock_seq_status[64];
     /* SHARE lease (whole-file deny mode reservation) held by this open
      * once CREATE succeeds.  Released at close. */
     struct chimera_vfs_lease          share_lease;

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -1526,6 +1526,7 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.ioctl.copy_chunk_bad_access
     smb2.ioctl.copy_chunk_bad_key
     smb2.ioctl.copy_chunk_bug15644
+    smb2.ioctl.copy_chunk_dest_lock
     smb2.ioctl.copy_chunk_limits
     smb2.ioctl.copy_chunk_max_output_sz
     smb2.ioctl.copy_chunk_multi
@@ -1535,6 +1536,7 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.ioctl.copy_chunk_src_exceed
     smb2.ioctl.copy_chunk_src_exceed_multi
     smb2.ioctl.copy_chunk_src_is_dest
+    smb2.ioctl.copy_chunk_src_lock
     smb2.ioctl.copy_chunk_tiny
     smb2.ioctl.copy_chunk_write_access
     smb2.ioctl.copy_chunk_zero_length
@@ -1608,7 +1610,11 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.lease.v2_flags_breaking
     smb2.lease.v2_flags_parentkey
     # smb2.lock
+    smb2.lock.async
     smb2.lock.auto-unlock
+    smb2.lock.cancel
+    smb2.lock.cancel-logoff
+    smb2.lock.cancel-tdis
     smb2.lock.contend
     smb2.lock.context
     smb2.lock.ctdb-delrec-deadlock
@@ -1618,6 +1624,9 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.lock.open-brlock-deadlock
     smb2.lock.overlap
     smb2.lock.range
+    smb2.lock.replay_broken_windows
+    smb2.lock.replay_smb3_specification_durable
+    smb2.lock.replay_smb3_specification_multi
     smb2.lock.rw-exclusive
     smb2.lock.rw-none
     smb2.lock.rw-shared
@@ -3148,6 +3157,7 @@ set(SMBTORTURE_ENABLED_diskfs_io_uring
     smb2.ioctl.copy_chunk_bad_access
     smb2.ioctl.copy_chunk_bad_key
     smb2.ioctl.copy_chunk_bug15644
+    smb2.ioctl.copy_chunk_dest_lock
     smb2.ioctl.copy_chunk_limits
     smb2.ioctl.copy_chunk_max_output_sz
     smb2.ioctl.copy_chunk_multi
@@ -3158,6 +3168,7 @@ set(SMBTORTURE_ENABLED_diskfs_io_uring
     smb2.ioctl.copy_chunk_src_exceed_multi
     smb2.ioctl.copy_chunk_src_is_dest
     smb2.ioctl.copy_chunk_src_is_dest_overlap
+    smb2.ioctl.copy_chunk_src_lock
     smb2.ioctl.copy_chunk_tiny
     smb2.ioctl.copy_chunk_write_access
     smb2.ioctl.copy_chunk_zero_length
@@ -3230,7 +3241,11 @@ set(SMBTORTURE_ENABLED_diskfs_io_uring
     smb2.lease.v2_flags_breaking
     smb2.lease.v2_flags_parentkey
     # smb2.lock
+    smb2.lock.async
     smb2.lock.auto-unlock
+    smb2.lock.cancel
+    smb2.lock.cancel-logoff
+    smb2.lock.cancel-tdis
     smb2.lock.contend
     smb2.lock.context
     smb2.lock.ctdb-delrec-deadlock
@@ -3240,6 +3255,9 @@ set(SMBTORTURE_ENABLED_diskfs_io_uring
     smb2.lock.open-brlock-deadlock
     smb2.lock.overlap
     smb2.lock.range
+    smb2.lock.replay_broken_windows
+    smb2.lock.replay_smb3_specification_durable
+    smb2.lock.replay_smb3_specification_multi
     smb2.lock.rw-exclusive
     smb2.lock.rw-none
     smb2.lock.rw-shared

--- a/src/vfs/vfs_lease_types.h
+++ b/src/vfs/vfs_lease_types.h
@@ -274,6 +274,13 @@ struct chimera_vfs_pending_acquire {
     void                               *private_data;
     struct chimera_vfs_file_state      *file;
     bool                                queued;
+    /* Caller asked to block (wait==true).  A breakable conflict always queues
+     * regardless; this flag additionally keeps a RANGE-lease acquire queued on a
+     * HARD (DENIED) conflict with another owner's byte-range lock — an SMB2
+     * blocking lock (MS-SMB2 3.3.5.14) that must complete only once the
+     * conflicting range is released, not bounce back DENIED.  Without it a
+     * still-DENIED ticket would fire its callback at the next pump. */
+    bool                                wait;
     struct chimera_vfs_pending_acquire *prev;
     struct chimera_vfs_pending_acquire *next;
 };

--- a/src/vfs/vfs_state.c
+++ b/src/vfs/vfs_state.c
@@ -1232,6 +1232,19 @@ chimera_vfs_state_pump_pending(
             continue;
         }
 
+        /* A waiting RANGE-lease ticket still hard-DENIED by another conflicting
+         * range stays parked: the lock that unblocked this pump only freed part
+         * of the contended region (or a different range), so keep blocking until
+         * the specific conflict clears (SMB2 blocking lock; never bounce DENIED
+         * back to a waiter). */
+        if (result == CHIMERA_VFS_LEASE_DENIED && t->wait &&
+            t->lease->kind == CHIMERA_VFS_LEASE_RANGE) {
+            pthread_mutex_lock(&file->lock);
+            chimera_vfs_pending_enqueue_locked(file, t);
+            pthread_mutex_unlock(&file->lock);
+            continue;
+        }
+
         t->cb(result,
               result == CHIMERA_VFS_LEASE_GRANTED ? t->lease : NULL,
               conflict,
@@ -1278,6 +1291,7 @@ chimera_vfs_lease_acquire(
     ticket->private_data = private_data;
     ticket->file         = file;
     ticket->queued       = false;
+    ticket->wait         = wait;
     ticket->prev         = NULL;
     ticket->next         = NULL;
 
@@ -1286,6 +1300,22 @@ chimera_vfs_lease_acquire(
     if (result == CHIMERA_VFS_LEASE_BREAKING && wait) {
         /* Conflict is breakable and caller said to wait.  Queue the
          * ticket; it will fire when the break completes (via pump). */
+        pthread_mutex_lock(&file->lock);
+        chimera_vfs_pending_enqueue_locked(file, ticket);
+        pthread_mutex_unlock(&file->lock);
+        return;
+    }
+
+    /* A RANGE lease (byte-range lock) that is hard-DENIED by another owner's
+     * conflicting lock, when the caller asked to wait, is an SMB2 blocking lock
+     * (MS-SMB2 3.3.5.14): queue it rather than bouncing DENIED.  The ticket fires
+     * GRANTED when the conflicting range is released (chimera_vfs_state_remove ->
+     * pump_pending re-runs try_insert), or the caller cancels it
+     * (chimera_vfs_lease_acquire_cancel) on CANCEL / handle close / teardown.
+     * Restricted to RANGE leases: SHARE/CACHING DENIED is a genuine hard failure
+     * the protocol layer must surface immediately. */
+    if (result == CHIMERA_VFS_LEASE_DENIED && wait &&
+        lease->kind == CHIMERA_VFS_LEASE_RANGE) {
         pthread_mutex_lock(&file->lock);
         chimera_vfs_pending_enqueue_locked(file, ticket);
         pthread_mutex_unlock(&file->lock);


### PR DESCRIPTION
## Summary

Implements blocking (queued) SMB2 byte-range locks per **MS-SMB2 3.3.5.14**.
A contended `SMB2 LOCK` without `SMB2_LOCKFLAG_FAIL_IMMEDIATELY` now blocks: the
server emits an interim `STATUS_PENDING`, parks the request, and completes it
later when the conflicting range is released — or aborts it on cancel / close /
teardown. Previously every contended lock returned `STATUS_LOCK_NOT_GRANTED`
immediately, failing all `smb2.lock.*` blocking subtests.

## How blocked locks park / wake / cancel

**VFS lease layer** (`vfs_state.c`, `vfs_lease_types.h`)
- A byte-range (`RANGE`) conflict between two owners returns `DENIED`, which the
  acquire path fired synchronously even with `wait=true`. Added a `wait` flag to
  the pending-acquire ticket: a `wait`+`DENIED`+`RANGE` acquire now **queues** on
  the file's pending list instead of bouncing. When the conflicting range is
  released, `chimera_vfs_state_remove` -> `pump_pending` re-runs `try_insert`;
  a still-conflicting waiter is re-queued, a now-grantable one fires its callback
  `GRANTED`. The behavior is restricted to `RANGE` leases — `SHARE`/`CACHING`
  `DENIED` remains a synchronous hard failure.

**SMB layer** (`smb_proc_lock.c`)
- **Park**: a single-element waiting `LOCK` that queues in the VFS emits the
  `STATUS_PENDING` interim (`chimera_smb_async_interim_begin`, joining
  `conn->parked_requests`) and records itself on `open_file->parked_lock_req`.
- **Wake**: the grant callback can fire on any thread (whoever released the
  conflict). Like the CREATE share-park path, it stashes the status and bounces
  to the request's owning thread via a new `lock_resume_head` MPSC queue + the
  existing `lease_resume_doorbell`; the owning thread drains it and completes
  with `OK`.
- **Cancel**: an `SMB2 CANCEL` matching the parked AsyncId cancels the VFS ticket
  and completes the lock with `STATUS_CANCELLED`.
- **Abort**: handle close (`smb_proc_close.c`), tree disconnect / logoff /
  connection teardown (`chimera_smb_tree_free`) cancel the VFS ticket and
  complete the parked lock with `STATUS_RANGE_NOT_LOCKED`, dropping the
  open_file reference the park held (deferred past the bucket lock, mirroring the
  CHANGE_NOTIFY teardown). This covers durable-preserved opens too — a blocking
  lock never survives a disconnect.
- `FAIL_IMMEDIATELY` behavior is unchanged (immediate `LOCK_NOT_GRANTED`).

**Copy-chunk lock enforcement** (`smb_proc_copychunk.c`)
- `FSCTL_SRV_COPYCHUNK` now enforces byte-range locks on each chunk's source
  (read) and destination (write) range via `chimera_vfs_state_range_io_conflict`
  — a conflict fails the whole copy with `FILE_LOCK_CONFLICT` and a zero-progress
  response body (Windows Server 2012+ read/write semantics).

**LockSequence replay detection** (`smb_proc_lock.c`, `smb_session.h`)
- The `replay_*` subtests require MS-SMB2 3.3.5.14 lock-sequence verification.
  Added a per-open 64-bucket replay cache keyed by LockSequenceNumber (1..64) +
  LockSequenceIndex; a re-sent lock/unlock with the same bucket+index returns the
  cached status without re-applying. Active for durable / persistent / resilient
  handles, or any handle on an SMB 3.x multichannel connection.

## Tests enabled (memfs + diskfs_io_uring)

`# smb2.lock`: `async`, `cancel`, `cancel-logoff`, `cancel-tdis`,
`replay_broken_windows`, `replay_smb3_specification_durable`,
`replay_smb3_specification_multi`.
`# smb2.ioctl`: `copy_chunk_src_lock`, `copy_chunk_dest_lock`.

## Verification

All 9 enabled subtests pass 3x on **memfs** and **diskfs_io_uring** (Debug/ASan).
Regression: the full enabled `smb2.lock` + `smb2.ioctl` + `smb2.rw` +
`smb2.compound{,_async,_find}` + `smb2.notify{,_inotify}` suites pass 100% on both
backends — zero new failures. Release (GCC `-O3 -Werror`) builds clean.
