### PR TITLE
smb2: advance lease epoch once per break event, not per cascade step

### DIFF
--- a/src/server/smb/smb_proc_oplock_break.c
+++ b/src/server/smb/smb_proc_oplock_break.c
@@ -267,11 +267,13 @@ chimera_smb_lease_break_cb(
         uint8_t new_smb     = chimera_smb_vfs_to_lease_bits(new_vfs);
 
         /* The lease epoch lives on the GRANT so all coalesced opens share one
-         * monotonic counter (MS-SMB2 3.3.5.9.11): bump it once per break.  Only a
-         * v2 lease versions its state; a v1 lease breaks with epoch 0. */
-        if (grant->is_v2) {
-            grant->epoch++;
-        }
+         * monotonic counter (MS-SMB2 3.3.5.9.11).  It is advanced once per break
+         * EVENT by the VFS layer (chimera_vfs_lease_begin_break_ex, on the
+         * IDLE/ACKED -> BREAKING transition) so a multi-notification cascade
+         * (RWH -> RH -> R -> NONE driven by a single conflicting open) keeps one
+         * epoch across all of its steps -- this cb is re-invoked once per step.
+         * Here we only SNAPSHOT the already-advanced epoch.  Only a v2 lease
+         * versions its state; a v1 lease breaks with epoch 0. */
         open_file->lease_epoch = grant->is_v2 ? grant->epoch : 0;
         open_file->lease_state = new_smb;
 

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -1599,6 +1599,7 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.lease.upgrade2
     smb2.lease.upgrade3
     smb2.lease.v1_bug15148
+    smb2.lease.v2_breaking3
     smb2.lease.v2_bug15148
     smb2.lease.v2_complex1
     smb2.lease.v2_complex2
@@ -3221,6 +3222,7 @@ set(SMBTORTURE_ENABLED_diskfs_io_uring
     smb2.lease.upgrade2
     smb2.lease.upgrade3
     smb2.lease.v1_bug15148
+    smb2.lease.v2_breaking3
     smb2.lease.v2_bug15148
     smb2.lease.v2_complex1
     smb2.lease.v2_complex2

--- a/src/vfs/vfs_state.c
+++ b/src/vfs/vfs_state.c
@@ -1921,6 +1921,21 @@ chimera_vfs_lease_begin_break_ex(
             chimera_vfs_ns_to_ticks((uint64_t) deadline_ms * 1000000ULL);
         cb      = lease->owner.break_cb;
         cb_priv = lease->owner.cb_private;
+
+        /* MS-SMB2 2.2.23.2 / 3.3.4.7: a lease-break is ONE logical event that
+         * advances the epoch by exactly one and reports the NEW epoch in the
+         * notification.  Bump the (v2-only) epoch HERE, where a genuinely new
+         * break begins (IDLE/ACKED -> BREAKING) -- NOT in the protocol break
+         * callback, which is also re-invoked once per cascade step out of
+         * chimera_vfs_lease_ack (RWH -> RH -> R -> NONE).  A single conflicting
+         * open's whole cascade is one event and must keep one epoch across all
+         * its notifications (smb2.lease.v2_breaking3); two distinct conflicting
+         * opens are two events and advance the epoch twice (break_twice).  The
+         * callback snapshots grant->epoch, so bumping it once here yields the
+         * correct value for every notification of this break. */
+        if (lease->grant && lease->grant->is_v2) {
+            lease->grant->epoch++;
+        }
     } else {
         cb      = NULL;
         cb_priv = NULL;


### PR DESCRIPTION
## Summary

SMB3 leases (v2) carry an **Epoch** that the server MUST increment by exactly one
on each lease-state change and report the NEW epoch in the LEASE_BREAK notification
([MS-SMB2] 2.2.23.2 / 3.3.4.7). A lease-break is **one logical event** even when the
holder is walked down its caching bits one notification at a time
(`RWH -> RH -> R -> NONE`).

chimera advanced `grant->epoch` inside the SMB break callback
(`chimera_smb_lease_break_cb`). That callback is re-invoked once per cascade step
out of `chimera_vfs_lease_ack`, so a single conflicting open's whole cascade bumped
the epoch on *every* step instead of once for the event. The Samba client syncs its
epoch from the first notification and expects the remaining cascade steps to carry
that same epoch, so it saw the server epoch run ahead by one per extra step.

## Fix

Move the (v2-only) epoch increment into the VFS layer at the genuine new-break
boundary — `chimera_vfs_lease_begin_break_ex`, on the `IDLE/ACKED -> BREAKING`
transition — and have the SMB callback only **snapshot** the already-advanced
`grant->epoch`.

- A single conflicting open's cascade now keeps one epoch across all of its
  notifications.
- Two distinct conflicting opens remain two events and advance the epoch twice.
- Directory-lease breaks (which also route through `begin_break`) keep advancing
  once per break event, unchanged.

## Tests

- `smb2.lease.v2_breaking3` now passes (epoch held constant across the deferred-ack
  `RWH -> RH -> R -> NONE` staircase). Enabled on **memfs** and **diskfs_io_uring**,
  verified 3/3 green on each.
- Full enabled `smb2.lease` / `smb2.dirlease` / `smb2.oplock` / `smb2.durable-open` /
  `smb2.durable-v2-open` suites across all backends (memfs, diskfs_io_uring, cairn,
  io_uring): 473/473 pass — zero regressions.
- NFSv4 delegation pynfs suite (shared lease layer): no regressions (the epoch bump
  is gated to `grant->is_v2`, so delegations are unaffected).

## Scope note (coordination)

This change is limited to the epoch **VALUE** carried in the break notification.
The break-trigger / break-count logic (whether a break fires and how many) is being
fixed concurrently on a separate branch and is left untouched here.

- `smb2.lease.break_twice` and `smb2.lease.v2_rename` also report an epoch mismatch,
  but their *primary* failure is a break-count discrepancy (break_twice's first break
  does not fire; v2_rename fires one break too many) owned by that other change. Their
  epoch values become correct once the count is, given this fix — so they are not
  enabled here.
- `smb2.dirlease.unlink_different_*` epoch-0 reports are a downstream symptom of the
  deferred file-level last-close delete-on-close semantics (the break fires on the
  wrong close, so no notification arrives and the zeroed `lease_break_info` reads
  epoch 0), not an epoch-plumbing miss; left as the existing follow-up.
