### PR TITLE
smb2: establish anonymous (null) sessions

### DIFF
--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -339,8 +339,15 @@ chimera_smb_compound_reply(struct chimera_smb_compound *compound)
             continue;
         }
 
+        /* A null (anonymous) session is never signed even when the connection
+         * negotiated signing-required: it has no verifiable key, so MS-SMB2
+         * 3.3.5.5.3 has the server advertise SMB2_SESSION_FLAG_IS_NULL and the
+         * client drops the signing requirement for it.  Signing its responses
+         * with the zero-derived key would be rejected by a client that forced a
+         * different key (smb2.session.anon-signing2). */
         if ((conn->flags & CHIMERA_SMB_CONN_FLAG_SIGNING_REQUIRED) &&
-            request->session_handle) {
+            request->session_handle &&
+            !(request->session_handle->session->flags & CHIMERA_SMB_SESSION_NULL)) {
             request->flags |= CHIMERA_SMB_REQUEST_FLAG_SIGN;
         }
 
@@ -363,7 +370,14 @@ chimera_smb_compound_reply(struct chimera_smb_compound *compound)
          * session is only authorized once its final leg succeeds. */
         if (request->smb2_hdr.command == SMB2_SESSION_SETUP &&
             request->session_handle &&
-            (request->session_handle->session->flags & CHIMERA_SMB_SESSION_AUTHORIZED)) {
+            (request->session_handle->session->flags & CHIMERA_SMB_SESSION_AUTHORIZED) &&
+            !(request->session_handle->session->flags & CHIMERA_SMB_SESSION_NULL)) {
+            /* A null (anonymous) session has no verifiable key, so its
+             * SESSION_SETUP response is left unsigned (MS-SMB2 3.3.5.5.3): the
+             * client treats SMB2_SESSION_FLAG_IS_NULL as unauthenticated and
+             * does not expect a signature.  Signing it with the zero-derived
+             * key would make a client that forced a different key reject the
+             * response (smb2.session.anon-signing2). */
             request->flags |= CHIMERA_SMB_REQUEST_FLAG_SIGN;
         }
 
@@ -1409,6 +1423,30 @@ chimera_smb_server_handle_smb2(
                                               payload_length);
 
             if (unlikely(rc != 0)) {
+                /* A bad signature on a null (anonymous) session is answered
+                 * STATUS_ACCESS_DENIED rather than fatally tearing the
+                 * connection down: the client signed with a key that does not
+                 * match the null session's zero-derived key (it has no shared
+                 * secret), which MS-SMB2 3.3.5.2.4 treats as an authorization
+                 * failure, not a malformed-frame protocol violation
+                 * (smb2.session.anon-signing2 signs a TREE_CONNECT with a wrong
+                 * key on a null session and expects ACCESS_DENIED with the
+                 * connection still up).  The reply is left unsigned (the null
+                 * session shares no verifiable key): clear the SIGN flag set
+                 * just above.  Compound related operations inherit the lead's
+                 * protection, so only an unrelated signed lead is handled here;
+                 * a bad signature on any real session stays fatal. */
+                if (!(request->smb2_hdr.flags & SMB2_FLAGS_RELATED_OPERATIONS) &&
+                    request->session_handle &&
+                    (request->session_handle->session->flags &
+                     CHIMERA_SMB_SESSION_NULL)) {
+                    request->flags                              &= ~CHIMERA_SMB_REQUEST_FLAG_SIGN;
+                    request->status                              = SMB2_STATUS_ACCESS_DENIED;
+                    request->flags                              |= CHIMERA_SMB_REQUEST_FLAG_PARSE_FAILED;
+                    compound->requests[compound->num_requests++] = request;
+                    goto next_compound_request;
+                }
+
                 chimera_smb_error("Received SMB2 message with invalid signature");
                 chimera_smb_request_free(thread, request);
                 evpl_close(evpl, conn->bind);
@@ -1420,6 +1458,9 @@ chimera_smb_server_handle_smb2(
                    request->smb2_hdr.command != SMB2_NEGOTIATE &&
                    request->smb2_hdr.command != SMB2_SESSION_SETUP &&
                    request->smb2_hdr.command != SMB2_ECHO &&
+                   !(request->session_handle && request->session_handle->session &&
+                     (request->session_handle->session->flags &
+                      CHIMERA_SMB_SESSION_NULL)) &&
                    ((conn->flags & CHIMERA_SMB_CONN_FLAG_SIGNING_REQUIRED) ||
                     (request->session_handle && request->session_handle->session &&
                      (request->session_handle->session->flags &
@@ -1432,7 +1473,12 @@ chimera_smb_server_handle_smb2(
              * protocol violation; tear the connection down.  SESSION_SETUP is
              * exempt (its signing key is only derived while processing it), as
              * are NEGOTIATE and ECHO; compound related operations inherit the
-             * lead request's protection so only the unrelated lead is checked. */
+             * lead request's protection so only the unrelated lead is checked.
+             * A null (anonymous) session is exempt entirely: it has no key, so
+             * MS-SMB2 3.3.5.5.3 never enforces signing or encryption on it even
+             * when the connection negotiated signing-required (the client drops
+             * the requirement for the IS_NULL session — smb2.session.anon-
+             * signing2's second TREE_CONNECT is deliberately unsigned). */
             chimera_smb_error("Unsigned, unencrypted request (cmd %u) on a protected connection; disconnecting",
                               request->smb2_hdr.command);
             chimera_smb_request_free(thread, request);
@@ -1903,6 +1949,22 @@ chimera_smb_server_handle_transform(
         if (session) {
             chimera_smb_session_release(thread, thread->shared, session, true);
         }
+        evpl_close(evpl, conn->bind);
+        return;
+    }
+
+    /* MS-SMB2 constrained connection (smb2.session.anon-encryption1): a
+     * connection that has only ever carried null (anonymous) sessions rejects
+     * encrypted traffic by resetting -- a null session has no real key, so
+     * encrypting to it is not meaningful.  Once a real (non-anonymous) session
+     * has been established on the connection it is no longer constrained, and an
+     * encrypted request on a null session is decrypted normally with its
+     * zero-derived key (anon-encryption2).  A wrong key fails the AEAD tag below
+     * and resets either way (anon-encryption3). */
+    if ((session->flags & CHIMERA_SMB_SESSION_NULL) &&
+        !(conn->flags & CHIMERA_SMB_CONN_FLAG_AUTHENTICATED)) {
+        chimera_smb_error("Encrypted SMB2 message on constrained (anonymous-only) connection; resetting");
+        chimera_smb_session_release(thread, thread->shared, session, true);
         evpl_close(evpl, conn->bind);
         return;
     }

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -963,6 +963,15 @@ struct chimera_smb_session_handle {
 
 #define CHIMERA_SMB_CONN_FLAG_SIGNING_REQUIRED      0x01
 #define CHIMERA_SMB_CONN_FLAG_SMB_DIRECT_NEGOTIATED 0x02
+/* A non-anonymous (real user/guest) session has been established on this
+ * connection, lifting it out of the MS-SMB2 "constrained connection" state.
+ * Until then the connection has only ever carried null (anonymous) sessions and
+ * MUST reject SMB3-encrypted traffic by resetting (smb2.session.anon-
+ * encryption1): a null session holds no key, so an encrypted request on an
+ * exclusively-anonymous connection is invalid.  Once a real session exists, an
+ * (otherwise unenforced) encrypted request on a null session is decrypted with
+ * the null session's zero-derived key like any other (anon-encryption2). */
+#define CHIMERA_SMB_CONN_FLAG_AUTHENTICATED         0x04
 
 /* Bits identifying which negotiate contexts the client sent (and that we
  * accepted on the wire). Phase 0 records this so unit tests can assert

--- a/src/server/smb/smb_proc_session_setup.c
+++ b/src/server/smb/smb_proc_session_setup.c
@@ -253,14 +253,19 @@ chimera_smb_session_setup(struct chimera_smb_request *request)
         bad_token = 1;
     }
 
-    /* Anonymous NTLM authentication is accepted only as a re-authentication of
-     * an established session (smb2.session.reauth2-5 re-authenticate a user
-     * session as anonymous and back; the session keeps its keys and open
-     * handles while the security context switches).  An initial anonymous
-     * session or an anonymous channel bind is refused. */
+    /* Anonymous (null-session) NTLM authentication (MS-SMB2 3.3.5.5.3 /
+     * MS-NLMP 3.2.5.1.2).  An anonymous AUTHENTICATE carries no password proof
+     * and yields no session key; the server establishes a NULL session mapped
+     * to the nobody identity (see ctx->is_anonymous in smb_ntlm.c).  Such a
+     * session is never signed or encrypted.
+     *
+     * Accepted as an initial session and as a re-authentication of an
+     * established session (smb2.session.reauth2-5 switch a user session to
+     * anonymous and back, keeping its keys/handles).  An anonymous CHANNEL BIND
+     * is still refused: a null session has no key to bind a new channel with. */
     if (rc == 0 && mech == SMB_AUTH_MECH_NTLM &&
-        conn->ntlm_ctx.is_anonymous && !is_reauth) {
-        chimera_smb_error("Anonymous authentication rejected (only re-authentication of an established session)");
+        conn->ntlm_ctx.is_anonymous && is_binding) {
+        chimera_smb_error("Anonymous channel bind rejected (a null session has no key)");
         rc = -1;
     }
 
@@ -472,8 +477,7 @@ chimera_smb_session_setup(struct chimera_smb_request *request)
         chimera_vfs_cred_init_attr(&session->cred, uid, gid, ngids, gids);
 
         /* SMB3 transport encryption: derive per-session keys from the raw
-         * session key.  Skipped for anonymous/guest (null) sessions, which have
-         * no usable key and are never encrypted (MS-SMB2 §3.3.5.5.3).
+         * session key.
          *
          * Keys are derived whenever encryption is possible at all -- either the
          * global smb_encryption knob OR any per-share encrypt_data share --
@@ -481,12 +485,19 @@ chimera_smb_session_setup(struct chimera_smb_request *request)
          * when global encryption is off.  The global knob alone decides whether
          * the whole session is marked encrypt-all (CHIMERA_SMB_SESSION_ENCRYPT_
          * DATA); per-share encryption leaves the flag clear and encrypts per
-         * tree (see the reply path in smb.c). */
+         * tree (see the reply path in smb.c).
+         *
+         * A null (anonymous) session derives keys from its all-zero session key
+         * too: a client may still (per smbtorture's anonymous_encryption) wrap a
+         * request in a TRANSFORM, and the server must be able to decrypt it with
+         * the same zero-derived key.  A null session is NEVER marked encrypt-all
+         * though -- it has no secret to protect (MS-SMB2 §3.3.5.5.3) -- so the
+         * server neither requires nor advertises encryption on it. */
         if ((shared->config.encryption || shared->any_share_encrypt) &&
             conn->negotiated.cipher_id != 0 &&
             conn->dialect >= SMB2_DIALECT_3_0 &&
             session_key_saved_len > 0 &&
-            !is_anonymous && !is_reauth && !is_binding) {
+            !is_reauth && !is_binding) {
             size_t klen = 0;
 
             if (chimera_smb_derive_encryption_keys(
@@ -496,9 +507,26 @@ chimera_smb_session_setup(struct chimera_smb_request *request)
                     session_handle->enc_key, session_handle->dec_key, &klen) == 0) {
                 session_handle->enc_key_len = klen;
                 session_handle->cipher_id   = conn->negotiated.cipher_id;
-                if (shared->config.encryption) {
+                if (shared->config.encryption && !is_anonymous) {
                     session->flags |= CHIMERA_SMB_SESSION_ENCRYPT_DATA;
                 }
+            }
+        }
+
+        /* Track whether the established/current security context is anonymous.
+         * A null session has no key, so it is never signed or encrypted and its
+         * SESSION_SETUP response carries SMB2_SESSION_FLAG_IS_NULL.  Re-auth can
+         * flip a session between a real user and anonymous (reauth5), so the
+         * flag follows the current context on every non-binding leg. */
+        if (!is_binding) {
+            if (is_anonymous) {
+                session->flags |= CHIMERA_SMB_SESSION_NULL;
+            } else {
+                session->flags &= ~CHIMERA_SMB_SESSION_NULL;
+                /* A real (non-anonymous) session lifts the connection out of the
+                 * MS-SMB2 constrained-connection state, permitting encrypted
+                 * traffic on its other (including null) sessions thereafter. */
+                conn->flags |= CHIMERA_SMB_CONN_FLAG_AUTHENTICATED;
             }
         }
 
@@ -629,10 +657,17 @@ chimera_smb_session_setup_reply(
     uint16_t                 session_flags          = 0;
 
     /* SessionFlags (MS-SMB2 §2.2.6): advertise per-session encryption so the
-     * client encrypts subsequent requests on this session. */
-    if (request->session_handle &&
-        (request->session_handle->session->flags & CHIMERA_SMB_SESSION_ENCRYPT_DATA)) {
-        session_flags |= SMB2_SESSION_FLAG_ENCRYPT_DATA;
+     * client encrypts subsequent requests on this session.  A null (anonymous)
+     * session instead carries SMB2_SESSION_FLAG_IS_NULL: it has no key, so the
+     * client treats it as unauthenticated (no signing/encryption expected). */
+    if (request->session_handle) {
+        uint32_t sflags = request->session_handle->session->flags;
+
+        if (sflags & CHIMERA_SMB_SESSION_NULL) {
+            session_flags |= SMB2_SESSION_FLAG_IS_NULL;
+        } else if (sflags & CHIMERA_SMB_SESSION_ENCRYPT_DATA) {
+            session_flags |= SMB2_SESSION_FLAG_ENCRYPT_DATA;
+        }
     }
 
     evpl_iovec_cursor_append_uint16(reply_cursor, SMB2_SESSION_SETUP_REPLY_SIZE);

--- a/src/server/smb/smb_session.h
+++ b/src/server/smb/smb_session.h
@@ -270,6 +270,13 @@ struct chimera_smb_tree {
  * requests arriving on that connection are answered STATUS_USER_SESSION_DELETED. */
 #define CHIMERA_SMB_SESSION_DELETED      0x2
 #define CHIMERA_SMB_SESSION_ENCRYPT_DATA 0x4
+/* A null (anonymous) session established by an anonymous NTLMSSP AUTHENTICATE
+ * (MS-SMB2 3.3.5.5.3 / MS-NLMP 3.2.5.1.2).  It has NO session key, so it is
+ * never signed or encrypted: the server derives no signing/encryption keys for
+ * it, advertises SMB2_SESSION_FLAG_IS_NULL in the SESSION_SETUP response, and
+ * answers any signed request on it STATUS_ACCESS_DENIED (without verifying a
+ * key it does not have, and without tearing the connection down). */
+#define CHIMERA_SMB_SESSION_NULL         0x8
 
 /* Maximum number of channels a single session may bind, matching the
  * Windows Server 2012R2/2016 limit asserted by smb2.multichannel.num_channels. */

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -1744,6 +1744,11 @@ set(SMBTORTURE_ENABLED_memfs
     # smb2.session-require-signing
     smb2.session-require-signing.bug15397
     # smb2.session
+    smb2.session.anon-encryption1
+    smb2.session.anon-encryption2
+    smb2.session.anon-encryption3
+    smb2.session.anon-signing1
+    smb2.session.anon-signing2
     smb2.session.bind1
     smb2.session.bind2
     smb2.session.bind_different_user
@@ -3366,6 +3371,11 @@ set(SMBTORTURE_ENABLED_diskfs_io_uring
     # smb2.session-require-signing
     smb2.session-require-signing.bug15397
     # smb2.session
+    smb2.session.anon-encryption1
+    smb2.session.anon-encryption2
+    smb2.session.anon-encryption3
+    smb2.session.anon-signing1
+    smb2.session.anon-signing2
     smb2.session.bind2
     smb2.session.bind_different_user
     smb2.session.bind_negative_smb3signC30toGd
@@ -3924,6 +3934,15 @@ set(SMBTORTURE_ISOLATE_SUITES
     smb2.lease
     smb2.oplock
     smb2.replay
+    # smb2.session needs per-subtest isolation: the anon-encryption* cases make
+    # the test driver enable SMB3 transport encryption for the whole daemon, and
+    # a globally-encrypt-all daemon changes the behaviour other session subtests
+    # depend on (e.g. reconnect2 / bind_invalid_auth encrypt their traffic, then
+    # an encrypted request on a session torn down out from under the connection
+    # is handled differently than the unencrypted form they assert).  Running
+    # each session subtest in its own daemon keeps the encryption knob scoped to
+    # the cases that actually opt into it.
+    smb2.session
 )
 # >>> SMBTORTURE_ISOLATE_END
 

--- a/src/server/smb/tests/smbtorture_test.c
+++ b/src/server/smb/tests/smbtorture_test.c
@@ -514,12 +514,14 @@ main(
         }
     }
 
-    /* The bind_negative_smb3enc* cases connect with encryption REQUIRED on the
-     * client credentials, so the server must actually support SMB3 transport
-     * encryption for the connection to come up at all.  Enable it only for
-     * those cases — every other suite runs with the default (off). */
+    /* The bind_negative_smb3enc* and anon-encryption* cases connect with
+     * encryption REQUIRED on the (user) client credentials, so the server must
+     * actually support SMB3 transport encryption for the connection to come up
+     * at all.  Enable it only for those cases — every other suite runs with the
+     * default (off). */
     for (i = 0; i < num_tests; i++) {
-        if (strstr(tests[i], "bind_negative_smb3enc") != NULL) {
+        if (strstr(tests[i], "bind_negative_smb3enc") != NULL ||
+            strstr(tests[i], "anon-encryption") != NULL) {
             chimera_server_config_set_smb_encryption(config, 1);
             break;
         }


### PR DESCRIPTION
## Anonymous (null-session) SMB2 authentication

chimera previously refused to establish an *initial* anonymous SMB2 session: an
anonymous NTLMSSP AUTHENTICATE (NTLMSSP_NEGOTIATE_ANONYMOUS + empty
NtChallengeResponse) was only accepted as a re-authentication of an already
established session, so a first-time anonymous SESSION_SETUP returned
STATUS_LOGON_FAILURE. This implements anonymous sessions per the MS-SMB2 null
session mechanism (3.3.5.5.3).

### How an anonymous session is established

- An anonymous NTLMSSP AUTHENTICATE now establishes a **null session** instead
  of failing. The principal is the server's nobody identity (uid/gid 65534, as
  already mapped in `smb_ntlm.c`); it is granted no more than a real anonymous
  user. Only an anonymous **channel bind** is still refused — a null session has
  no key to bind a new channel with.
- The session is flagged `CHIMERA_SMB_SESSION_NULL` and its SESSION_SETUP
  response advertises `SMB2_SESSION_FLAG_IS_NULL`, so the client treats it as
  unauthenticated (it drops any signing/encryption requirement for it).

### No-key handling (signing / encryption)

A null session has no usable session key (it is all-zero), so:

- **Signing**: its responses are never signed — even on a signing-required
  connection — because the client does not expect a verifiable signature on an
  IS_NULL session. A request the client *does* sign is verified against the null
  session's zero-derived key; a mismatch is answered STATUS_ACCESS_DENIED
  (MS-SMB2 3.3.5.2.4) rather than fatally resetting the connection, and an
  unsigned request on a null session is never rejected for lack of a signature.
- **Encryption**: a null session is never marked encrypt-all and never has
  encryption required or advertised. It still derives keys from its zero session
  key so an encrypted request (which smbtorture can force) can be decrypted.
  A connection that has only ever carried anonymous sessions is *constrained*:
  encrypted traffic on it resets the connection; once a real (non-anonymous)
  session is established the connection is no longer constrained.

Authenticated-session behaviour is unchanged: real sessions still derive and
require their keys, sign, and encrypt exactly as before.

### Tests

Enabled on memfs and diskfs_io_uring (verified 3/3, ASan): `smb2.session`
`anon-signing1`, `anon-signing2`, `anon-encryption1`, `anon-encryption2`,
`anon-encryption3`.

The `smb2.session` suite is now run per-subtest isolated: the anon-encryption
cases make the test driver enable SMB3 transport encryption for the whole
daemon, and a globally encrypt-all daemon changes behaviour other session
subtests assert on — isolation scopes the encryption knob to the cases that
opt into it.
