### PR TITLE
smb2: courtesy-hold a yielding durable holder's share reservation on disconnect break

### DIFF
--- a/src/server/smb/smb_proc_oplock_break.c
+++ b/src/server/smb/smb_proc_oplock_break.c
@@ -236,6 +236,22 @@ chimera_smb_lease_break_cb(
         for (member = grant->holders; member;
              member = member->grant_member_next) {
             member->flags |= CHIMERA_SMB_OPEN_FILE_YIELDED;
+            /* Courtesy-hold the yielding holder's share reservation too, in the
+             * same file->lock section that revokes its lease (below).  The
+             * holder's connection is already gone but its disconnect teardown
+             * has not yet removed its share reservation; without this a racing
+             * batch/durable opener of the same file would see a surviving
+             * sole-opener and be capped to LEVEL_II with no durable handle, even
+             * though the holder has yielded (smb2.durable-open.oplock: io2 races
+             * io1's TCP disconnect).  The parked flag makes the conflict matrix's
+             * sole-opener check skip this reservation, so the new open takes the
+             * full BATCH + durable grant -- matching the already-parked-holder
+             * outcome of chimera_smb_create_purge_parked_writers.  The teardown
+             * later removes the reservation outright; setting parked early is
+             * idempotent with the park it would otherwise do. */
+            if (member->share_lease_inserted) {
+                member->share_lease.parked = 1;
+            }
         }
     }
     pthread_mutex_unlock(&file->lock);

--- a/src/vfs/vfs_state.c
+++ b/src/vfs/vfs_state.c
@@ -1919,6 +1919,23 @@ chimera_vfs_lease_begin_break_ex(
         lease->break_needed_mode = step;
         lease->break_deadline    = chimera_vfs_now_ticks() +
             chimera_vfs_ns_to_ticks((uint64_t) deadline_ms * 1000000ULL);
+        /* Publish break_ack_required ATOMICALLY with break_state, under file->lock.
+         * A break needs a client acknowledgment when it strips write or handle
+         * caching (the holder must flush / close its deferred handle); a break that
+         * drops only read caching (or goes to NONE) is acked by no client.  The SMB
+         * break callback recomputes the same value, but it runs OUTSIDE this lock,
+         * so a racing reader (chimera_vfs_state_caching_breaking, which decides
+         * whether a conflicting CREATE parks-and-rearbitrates its capped grant) could
+         * observe break_state==BREAKING with a stale break_ack_required and skip the
+         * park -- baking a LEVEL_II / no-durable reply that should have upgraded to
+         * BATCH once the break settled (smb2.durable-open.oplock vs a holder whose
+         * connection is mid-teardown; an arm64 reordering of the two stores).  Set it
+         * here so the pair is always consistent to a file->lock holder. */
+        if (lease->grant) {
+            lease->grant->break_ack_required =
+                ((lease->mode.granted & ~step) &
+                 (CHIMERA_VFS_LEASE_MODE_W | CHIMERA_VFS_LEASE_MODE_H)) != 0;
+        }
         cb      = lease->owner.break_cb;
         cb_priv = lease->owner.cb_private;
     } else {


### PR DESCRIPTION
## Problem

Intermittent CI failure of `smbtorture_smb2_durable_open_oplock` (smbtorture `smb2.durable-open.oplock`), tracked in #733 and seen on the arm64 Release smbtorture runner:

```
source4/torture/smb2/durable_open.c:2158: io2.out.durable_open was 0 (0x0), expected 1 (0x1)
```

The subtest opens a file on tree1 with a **batch oplock + durable handle**, disconnects tree1, then opens the same file on tree2 (also batch + durable) and asserts tree2 is granted **BATCH + a durable handle**. Per MS-SMB2 a durable handle is granted only when the open holds a batch oplock, and a batch oplock is granted only to the **sole opener** of a file.

## Root cause

A teardown-ordering race between tree2's CREATE and tree1's disconnect:

1. tree1's connection drops; `conn_free` clears tree1's `open->create_conn` under the bucket lock, but tree1's **share reservation** and open object are removed later, by the tree teardown.
2. In that window tree2's CREATE fires a batch-oplock break of tree1's lease. With no live member to notify (`create_conn` already NULL), the break callback **force-REVOKES** tree1's caching lease so tree2 can proceed.
3. But tree1's share reservation is still on the file and **un-parked**. The conflict matrix's sole-opener rule (`chimera_vfs_state_would_conflict`) then caps tree2's batch (W|H) request to a shared read cache (LEVEL_II), so tree2 gets no batch oplock and therefore **no durable handle** — `io2.out.durable_open == 0`.

The already-parked-holder path (`chimera_smb_create_purge_parked_writers`) handles this correctly, but only once the holder is parked; the bug is the narrow race where the holder is mid-teardown (lease revoked, share reservation not yet reaped). This is why it reproduces more readily under scheduling jitter on a loaded runner.

## Fix

When the break callback revokes a write-caching holder that has **no live member** (a disconnecting durable handle yielding to the conflicting acquirer, MS-SMB2 3.3.4.6/3.3.4.7), also mark that holder's share reservation `parked` in the same `file->lock` section that revokes its lease. The conflict matrix's sole-opener check already skips a parked reservation, so the racing opener takes the full **BATCH + durable** grant — matching the already-parked-holder outcome. The teardown later removes the reservation outright, so setting `parked` early is idempotent with the park it would otherwise do.

Additionally, publish `caching_grant->break_ack_required` **atomically with `break_state` under `file->lock`** in `chimera_vfs_lease_begin_break_ex`. The flag was written outside the lock by the SMB break callback but read under the lock by `chimera_vfs_state_caching_breaking` (the gate that decides whether a conflicting CREATE parks-and-rearbitrates its capped grant). On a weakly-ordered arch a racing CREATE could observe `break_state==BREAKING` with a stale `break_ack_required` and skip the park — which fits the arm64-only failure signature.

Both changes are under `file->lock` and respect the existing bucket → vfs_state lock order.

## Verification

- **Repro before:** `smb2.durable-open.oplock` failed ~1–3% in a tight disconnect-race loop (Release, `CHIMERA_SMB_TEST_DISCONNECT_DELAY_MS=0`); deterministically reproduced the exact `durable_open.c:2158` assertion.
- **Green after:** 0/750 across memfs / cairn / diskfs_io_uring with randomized disconnect delays; 0/600 on memfs at delay=0.
- **No regressions:** `server/smb` 821/821 (Debug ASan), oplock/lease/durable 470/470 (Release) — including `smb2.lease.v2_complex2`, multichannel, persistent, and WPTS.

Refs #733.