### PR TITLE
kvm/nfstest: disable nfstest_alloc on diskfs pending space-accounting fix

### DIFF
--- a/kvm/tests/CMakeLists.txt
+++ b/kvm/tests/CMakeLists.txt
@@ -302,6 +302,19 @@ foreach(image_spec ${KVM_IMAGES})
                        NOT (backend STREQUAL "memfs" OR backend MATCHES "diskfs"))
                         continue()
                     endif()
+                    # nfstest_alloc is disabled on diskfs pending a space-
+                    # accounting fix (tracking issue #733).  diskfs reports
+                    # statfs free as the sum of the AGs' live free counts, which
+                    # is unstable at the ENOSPC boundary: reservation-cache
+                    # remainders and async deleted-inode reclaim return bytes to
+                    # the free pool concurrently with the test's fill, so a write
+                    # the suite expects to fail with ENOSPC finds the drained-back
+                    # space and succeeds (memfs/cairn/linux account synchronously
+                    # and pass).  Keep memfs coverage; re-enable diskfs once free
+                    # is reported from a stable base (see issue #733).
+                    if(prog STREQUAL "nfstest_alloc" AND backend MATCHES "diskfs")
+                        continue()
+                    endif()
                     # nfstest_posix asserts read() updates st_atime.  The
                     # passthrough backends (linux/io_uring) defer atime to the
                     # host filesystem's mount policy (relatime/noatime), which


### PR DESCRIPTION
## Why

`nfstest_alloc` (NFSv4.2 ALLOCATE/DEALLOCATE) is failing consistently on the **diskfs** backends in the merge queue and blocking forward progress. This temporarily skips only the diskfs variants so the queue is unblocked, while the real fix is designed. **memfs keeps the ENOSPC-boundary coverage**; cairn/linux were never registered for this suite (unbounded host dirs).

## Root cause (already investigated — tracked in #733)

`nfstest_alloc` fills the device to the reported free space and asserts a subsequent write fails with `ENOSPC`. diskfs reports statfs free as `Σ ag->free_bytes` — the per-AG live free counts only — which is **unstable at the ENOSPC boundary**:

- **Reservation caches**: writes over-reserve `SM_RESERVATION_MIN` (1 MiB) into per-inode / per-thread caches; the remainder is returned to the AG free pool on refill (`space_map_thread_cache_return`), so `ag_free` jumps up mid-operation.
- **Async deleted-inode reclaim**: a deleted file's extents return to `ag_free` on a background reclaim worker (`diskfs_drain_after_unrecord`), after the test snapshotted free.

So bytes drain back into the free pool *concurrently with the test's fill*, and the write the suite expects to fail finds that space and succeeds. It's diskfs-only because memfs/cairn/linux account for live data synchronously against a single counter. This is a real diskfs `df`-accuracy bug (visibility/timing, not corruption — no space is leaked).

## Scope

Test-config only (`kvm/tests/CMakeLists.txt`): one `continue()` guard skipping `nfstest_alloc` on `diskfs*`. No server/VFS code touched.

## Follow-up

The proper fix — report free from a stable base and make it obtainable (reserved headroom + a single durable-used counter, with reclaim backpressure) — is being designed and will re-enable the diskfs variants under #733.

Refs #733.