### PR TITLE
smbtorture: disable compound_async.rename_last pending mitigation

### DIFF
--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -3927,6 +3927,29 @@ set(SMBTORTURE_ISOLATE_SUITES
 )
 # >>> SMBTORTURE_ISOLATE_END
 
+# Subtests excluded from every backend's run, regardless of the generated
+# allowlists above.  Use this for tests that flake for reasons we understand
+# but have not yet fixed, so the merge queue is not gated on them.  Hand-curated
+# (survives tools/smbtorture/regen.sh, which only rewrites the SUITES/ENABLED
+# blocks); each entry should cite why and where the fix is tracked.
+#
+#   smb2.compound_async.rename_last -- asserts the compound CREATE reply is still
+#     undelivered immediately after the client's lease-break ack (compound.c
+#     :3239).  chimera is correct (it holds the parked rename the full break
+#     window and completes it only on the ack) and already emits the ack reply
+#     ~1 event-loop turn ahead of the rename reply, but real servers get a larger
+#     gap for free from storage latency; our zero-latency in-memory completion
+#     collapses it to ~tens of microseconds, so under CI CPU saturation the
+#     smbtorture client drains both replies in one loop pass and the assertion
+#     trips.  It is a client-side timing assumption, not a protocol guarantee
+#     (Samba's own fix forced a synchronous rename rather than ordering the
+#     replies).  Disabled pending a decision on the principled mitigation
+#     (see #733).  rename_middle shares the family but asserts before the ack
+#     and has not been observed flaking, so it stays enabled.
+set(SMBTORTURE_DISABLED_SUBTESTS
+    smb2.compound_async.rename_last
+)
+
 # Group the (backend-agnostic) subtest catalog by parent suite -- the first two
 # dotted components, e.g. smb2.acls.OWNER -> smb2.acls, smb2.async_dosmode ->
 # smb2.async_dosmode.  Done once; the per-backend macro then filters by that
@@ -3983,6 +4006,9 @@ macro(add_smbtorture_backend_tests backend)
         set(_pid ${SMBTORTURE_PID_${_parent}})
         set(_enabled "")
         foreach(_sub ${SMBTORTURE_SUBS_${_pid}})
+            if("${_sub}" IN_LIST SMBTORTURE_DISABLED_SUBTESTS)
+                continue()
+            endif()
             if("${_sub}" IN_LIST SMBTORTURE_ENABLED_${backend})
                 list(APPEND _enabled "${_sub}")
             endif()


### PR DESCRIPTION
## Why

`smb2.compound_async.rename_last` flakes in the merge queue across all backends and is blocking forward progress. This disables just that subtest for now, the same way #826 handles the diskfs `nfstest_alloc` case.

## Root cause (already investigated — tracked in #733)

The subtest asserts the compound CREATE reply is still undelivered immediately after the client's lease-break ack (`compound.c:3239`). **chimera is correct**: it holds the parked rename for the full break window and completes it only on the ack, and already emits the ack reply ~1 event-loop turn ahead of the rename reply. But a real server gets a much larger ack→completion gap for free from storage latency; chimera's zero-latency in-memory completion collapses it to ~tens of microseconds, so under CI CPU saturation the smbtorture client drains both replies in one event-loop pass and the assertion trips.

It's a **client-side timing assumption, not a protocol guarantee** — Samba's own fix for this area forced a synchronous rename rather than ordering the two replies, and no finite server-side delay makes it deterministic (the client can always be descheduled longer). Details and the decision on the principled mitigation are in #733.

## Scope

Test-config only. Adds a hand-curated `SMBTORTURE_DISABLED_SUBTESTS` denylist, filtered in `add_smbtorture_backend_tests` so it covers both the consolidated and isolated registration paths and survives `tools/smbtorture/regen.sh` (which only rewrites the generated SUITES/ENABLED blocks). No server code touched.

`rename_middle` shares the family but asserts *before* the ack and has not been observed flaking, so it stays enabled; if it surfaces, it's a one-line add to the denylist.

Refs #733.