### PR TITLE
diskfs: don't speculatively over-reserve space on a near-full device

### DIFF
--- a/src/vfs/diskfs/space_map.c
+++ b/src/vfs/diskfs/space_map.c
@@ -647,6 +647,22 @@ space_map_reserve(
 
     want = need > floor ? need : floor;
 
+    /* Speculative over-reservation (want > need) batches future small writes by
+     * carving out a tail the caller keeps.  That tail is correct accounting --
+     * statfs counts it as used -- but on a near-full device it lets a single
+     * file privately corner the last free blocks: subsequent writes draw the
+     * cached tail on the fast path *without* re-checking the allocator, so they
+     * succeed even when the device truly has no free space (no ENOSPC).  Only
+     * speculate when the filesystem can comfortably afford it -- enough free
+     * that this reservation leaves at least another `want` behind.  Otherwise
+     * reserve exactly `need`, so every block a write consumes is drawn (and
+     * checked) against the live free pool and ENOSPC surfaces correctly.  This
+     * runs on the (already heavyweight, journaling) refill path, not the cache
+     * fast path, so the free-bytes scan is off the hot path. */
+    if (want > need && space_map_free_bytes(sm) < 2 * want) {
+        want = need;
+    }
+
     /* A reservation can't cross an AG boundary, so cap at the AG size; a
      * caller needing more than SM_AG_SIZE contiguous cannot be satisfied. */
     if (want > SM_AG_SIZE) {


### PR DESCRIPTION
## Problem

The merge-queue KVM tests `nfstest_alloc_diskfs_io_uring_nfs4.2` / `…_diskfs_aio_nfs4.2` fail intermittently on the `dealloc06` subtest:

> FAIL: Write within the deallocated region should fail with ENOSPC when no space is left on the device, expecting ENOSPC but it succeeded
> FAIL: WRITE within the deallocated region should fail with NFS4ERR_NOSPC when no space is left on the device

The test fills the device, DEALLOCATEs (hole-punches) a region, then WRITEs back into that region while the device is full — and expects ENOSPC. On diskfs the write succeeds instead. It is diskfs-specific and NFSv4.2-specific, and intermittent.

## Root cause

diskfs file-data and metadata allocations draw from a reservation cache (`inode->space_resv` for data; `thread->space_cache` for b+tree nodes / inode blocks). `space_map_reserve()` over-reserves up to `SM_RESERVATION_MIN` (1 MiB) beyond the immediate need so future small writes batch out of the cache.

That carved-out tail is accounted correctly — `statvfs` counts it as used — but it is handed out on the **fast path** (`space_map_alloc`'s `cache->valid && cache->length >= need` early return) **without consulting the live free pool**.

On a near-full device this lets a single file privately corner the last free blocks: one write over-reserves ~1 MiB, then subsequent writes draw that cached tail and succeed **even when the device truly has zero free space** — so a WRITE that needs new blocks returns success instead of ENOSPC. After the device is filled and a region is DEALLOCATEd, a write back into the (full) device is served from a stale over-reservation rather than failing with NFS4ERR_NOSPC.

Whether the over-reservation survives to the "should fail" write depends on free-extent fragmentation and NFS writeback timing, which is why the failure is intermittent.

I confirmed the mechanism directly with instrumentation: writes were served from a ~1 MiB cached reservation while `space_map_free_bytes()` reported `0` free.

## Fix

In `space_map_reserve()`, only keep the speculative tail (`want > need`) when the filesystem can comfortably afford it — enough free that this reservation still leaves at least another `want` behind. Otherwise reserve exactly `need`, so every block a write consumes is drawn from (and checked against) the live free pool and ENOSPC surfaces correctly even immediately after a DEALLOCATE on a full device.

The extra free-space scan runs only on the heavyweight, journaling refill path — never the cache fast path — so the allocation hot path is unaffected. The existing exact-size fallback is preserved (when `want` is already clamped to `need`, the fallback simply doesn't re-run).

## Testing / verification

**The exact failing test is a KVM test (`chimera/kvm/...`) and could not be run in the sandbox (no `/dev/kvm`).** Instead I verified:

- **Reproduced the logic locally without KVM**: ran the real `nfstest_alloc dealloc06` against a `diskfs` daemon in a network namespace using the host kernel NFS4.2 client, with the same 2×128 MiB device geometry the KVM wrapper uses. All chimera-side `dealloc06` assertions pass with the fix, including *"Write within the deallocated region should fail with ENOSPC"*, across `--free-blocks` 64/256/1024 (varying free headroom). (The only residual failure is nfstest's own "Packet trace file is empty", a loopback/tcpdump-flush artifact of this environment, not a chimera assertion.)
- **Proved the bug mechanism**: instrumentation showed writes succeeding from a ~1 MiB cached reservation while the device reported `0` free bytes.
- **Builds clean** in both Release and Debug.
- **No regression** in the non-KVM diskfs suites: `chimera/client/*diskfs*` (64/64), `chimera/pynfs/combined_diskfs*` (6/6), `chimera/pynfs/{write,create,open,lock,reboot}/*diskfs_io_uring` (30/30), `chimera/posix/fsx*diskfs*` (8/8, incl. fsx_nfs4), `chimera/posix/{truncate,ftruncate,write,open}_diskfs`, and `chimera/server/s3/*diskfs*` (6/6).
- `uncrustify --check` passes on the changed file; SPDX year current.