### PR TITLE
smb2: guard open_file in lock acquire helper against NULL deref

### DIFF
--- a/src/server/smb/smb_proc_lock.c
+++ b/src/server/smb/smb_proc_lock.c
@@ -262,6 +262,15 @@ chimera_smb_lock_take_one(
     struct chimera_smb_lock_entry *entry, *held;
     enum chimera_vfs_lease_result  result = CHIMERA_VFS_LEASE_DENIED;
 
+    /* The only caller (chimera_smb_lock_multi) is reached from chimera_smb_lock
+     * after open_file has been resolved and null-checked, so open_file is an
+     * invariant here.  Make it explicit for the static analyzer (which cannot
+     * carry the upstream check across the two call boundaries): a missing open
+     * fails the acquire, which the caller maps to STATUS_LOCK_NOT_GRANTED. */
+    if (unlikely(!open_file)) {
+        return NULL;
+    }
+
     if (exclusive) {
         DL_FOREACH(open_file->lock_entries, held)
         {


### PR DESCRIPTION
## scan-build finding

The merge-queue **Analyze** job (clang scan-build, run with `--status-bugs` so any finding fails the build) reported:

> src/server/smb/smb_proc_lock.c: warning: Access to field 'lock_entries' results in a dereference of a null pointer (loaded from variable 'open_file') [core.NullDereference]

The deref is the exclusive-lock overlap walk in `chimera_smb_lock_take_one`:

```c
DL_FOREACH(open_file->lock_entries, held)
```

## Root cause: an invariant the analyzer can't see (not a real NULL)

`open_file` is **never** NULL at this point. Tracing the callers:

- `chimera_smb_lock_take_one` (static) has exactly one caller: `chimera_smb_lock_multi` (also static, same TU).
- `chimera_smb_lock_multi` is only reached from `chimera_smb_lock` **after** `chimera_smb_open_file_resolve()` has returned non-NULL — the miss case replies `STATUS_FILE_CLOSED` and returns before the multi-element path.

So `open_file` is guaranteed non-NULL by the caller chain. The analyzer cannot carry that upstream null-check across the two static-function call boundaries, so it explores an infeasible `open_file == NULL` path and flags the `lock_entries` deref. (Note: clang 21 prunes this path locally and does not surface the warning; the devcontainer's clang in CI does.)

## Fix

Make the invariant explicit with an early guard so any analyzer version can prove non-NULL:

```c
if (unlikely(!open_file)) {
    return NULL;
}
```

Returning NULL is the helper's existing "cannot take this lock" signal, which the caller already maps to `STATUS_LOCK_NOT_GRANTED`. So even in the unreachable missing-open case the guard is semantically correct for the SMB LOCK path — it does not just silence the analyzer.

## Verification

- Builds clean Debug + Release (`make build_debug build_release`).
- scan-build over the `smb_proc_lock.c` TU: no `core.NullDereference` (clean before/after with local clang 21; guard removes the infeasible path entirely).
- `ctest -R 'smbtorture_smb2_lock_memfs|durable_open_lock|durable_v2_open_lock'`: 25/25 pass, including the `smb2.lock` conformance suite that drives the multi-element acquire path.
- `uncrustify --check` passes; copyright year current.