### PR TITLE
smb2: take session->lock when clearing create_conn across a session's trees

### DIFF
--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -1934,6 +1934,14 @@ chimera_smb_conn_free(
         if (!s) {
             continue;
         }
+
+        /* Walk the session's trees under session->lock, matching
+         * chimera_smb_session_park_durables / _flush_notifies: a concurrent
+         * chimera_smb_tree_disconnect on another channel clears s->trees[i] and
+         * frees the tree under session->lock, so reading the slot and taking
+         * tree->open_files_lock without it can touch a freed/recycled tree.  The
+         * lock order session->lock -> open_files_lock matches those iterators. */
+        pthread_mutex_lock(&s->lock);
         for (i = 0; i < s->max_trees; i++) {
             struct chimera_smb_tree      *t = s->trees[i];
             struct chimera_smb_open_file *of;
@@ -1954,6 +1962,7 @@ chimera_smb_conn_free(
                 pthread_mutex_unlock(&t->open_files_lock[b]);
             }
         }
+        pthread_mutex_unlock(&s->lock);
     }
 
     HASH_ITER(hh, conn->session_handles, session_handle, tmp)


### PR DESCRIPTION
## Draft — latent multichannel correctness hardening, NOT a verified flake fix

Found while investigating the `wpts/memfs_multichannel*` flakes (#733). It is a real concurrency bug worth fixing on its own merits, but it is **not verified to fix any specific flake** (see below), so it's a draft for review like #811.

## The bug

`chimera_smb_conn_free` walks every tree of each session the connection is bound to (`HASH_ITER` over `conn->session_handles`, then `s->trees[]`) to clear stale `create_conn` pointers on the opens, taking `tree->open_files_lock[b]` per bucket — but **without holding `session->lock`**.

On a multichannel session, a concurrent `chimera_smb_tree_disconnect` on another channel's thread clears `s->trees[tree_id]` and frees the tree **under `session->lock`**. Because `conn_free` reads the slot and locks the tree's `open_files_lock` outside `session->lock`, it can observe a tree mid-free and lock/dereference freed (or recycled) memory.

## The fix

Hold `session->lock` around the walk. The three sibling iterators over `s->trees[]` — `chimera_smb_session_park_durables`, `chimera_smb_session_flush_notifies`, and the would-conflict check — all already do this for exactly this reason. Lock order `session->lock -> open_files_lock` matches those callers, so there's no new inversion risk. One mutex pair, +9 lines.

## Why draft / not a #733 closer

The WPTS multichannel cases (e.g. `MultipleChannel_EncryptionOnBothChannels`) tear the bound channel's tree down and receive the reply **before** the main connection drops, so `s->trees[tree_id]` is already NULL by the time `conn_free` runs — proven unreachable by that ordering via window-widening instrumentation (up to 3s delays in both `tree_disconnect` and `conn_free`). So this hardens the multichannel path against abrupt-disconnect clients but is not demonstrably the cause of the `wpts/memfs*` flakes. Raising it on its correctness merits, for review.

Refs #733.