### PR TITLE
Add OpenTelemetry span tracing (NFS/SMB/S3/VFS)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -336,6 +336,30 @@ add_subdirectory(ext)
 
 include_directories(ext/libevpl/include)
 
+# OpenTelemetry tracing (oteltracing-c, built under libevpl/ext).  The public
+# header is always available (it is header-only no-op when the library is not
+# built).  When the library targets exist (protobuf-c present), wire chimera up
+# to use it; otherwise compile every translation unit with OTEL_TRACING=0 so all
+# embedded spans and span calls strip to nothing with no link dependency.
+include_directories(ext/libevpl/ext/oteltracing-c)
+if(TARGET oteltracing-c)
+    message(STATUS "oteltracing-c found - chimera tracing enabled")
+    add_compile_definitions(CHIMERA_HAVE_OTEL=1)
+    set(CHIMERA_OTEL_LIBS oteltracing-c)
+    if(TARGET oteltracing-sqlite)
+        add_compile_definitions(CHIMERA_HAVE_OTEL_SQLITE=1)
+        list(APPEND CHIMERA_OTEL_LIBS oteltracing-sqlite)
+    endif()
+    if(TARGET evpl_otel)
+        add_compile_definitions(CHIMERA_HAVE_OTEL_GRPC=1)
+        list(APPEND CHIMERA_OTEL_LIBS evpl_otel)
+    endif()
+else()
+    message(STATUS "oteltracing-c not built - chimera tracing disabled")
+    add_compile_definitions(OTEL_TRACING=0)
+    set(CHIMERA_OTEL_LIBS "")
+endif()
+
 # Find libwbclient (optional - for AD/Winbind integration)
 find_package(PkgConfig QUIET)
 if(PKG_CONFIG_FOUND)

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -3,10 +3,10 @@
 # SPDX-License-Identifier: LGPL-2.1-only
 
 add_library(chimera_common SHARED
-    logging.c snprintf.c pthread_create_interpose.c
+    logging.c snprintf.c pthread_create_interpose.c chimera_tracing.c
 )
 
-target_link_libraries(chimera_common unwind pthread dl)
+target_link_libraries(chimera_common unwind pthread dl evpl jansson ${CHIMERA_OTEL_LIBS})
 
 add_subdirectory(tests)
 

--- a/src/common/chimera_tracing.c
+++ b/src/common/chimera_tracing.c
@@ -1,0 +1,235 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "common/chimera_tracing.h"
+#include "common/common_config.h"
+#include "common/macros.h"
+
+/*
+ * oteltracing.h is always on the include path (header-only when the library is
+ * not built: with OTEL_TRACING=0 it provides no-op inlines).  CHIMERA_HAVE_OTEL
+ * is defined by CMake when liboteltracing-c is actually built and linked.
+ */
+#include "oteltracing.h"
+
+#if CHIMERA_HAVE_OTEL_SQLITE
+#include "otel_sqlite.h"
+#endif /* CHIMERA_HAVE_OTEL_SQLITE */
+
+#if CHIMERA_HAVE_OTEL_GRPC
+#include "evpl/evpl.h"
+#include "evpl/evpl_otel.h"
+#endif /* CHIMERA_HAVE_OTEL_GRPC */
+
+#define chimera_tracing_log(fmt, ...) \
+        fprintf(stderr, "chimera tracing: " fmt "\n", ## __VA_ARGS__)
+
+#if CHIMERA_HAVE_OTEL
+
+/* Active once init succeeded; gates thread register/unregister + teardown so we
+ * never touch the tracer when it was never initialized. */
+static int g_tracing_on;
+
+#if CHIMERA_HAVE_OTEL_SQLITE
+static int g_sqlite_open;
+#endif /* CHIMERA_HAVE_OTEL_SQLITE */
+
+#if CHIMERA_HAVE_OTEL_GRPC
+
+/* The OTLP/gRPC exporter is single-threaded: it lives on its own dedicated evpl
+ * thread, which is the sole drain consumer and periodically flushes finished
+ * spans to the collector.  The span producers (core threads) only ever enqueue
+ * into their lock-free rings, so this export I/O never touches a hot path. */
+static struct evpl_thread        *g_grpc_thread;
+static struct evpl_otel_exporter *g_grpc_exporter;
+static struct evpl_timer          g_grpc_timer;
+static char                       g_grpc_host[256];
+static int                        g_grpc_port;
+
+#define OTEL_GRPC_FLUSH_INTERVAL_US 250000   /* 250 ms */
+
+static void
+chimera_tracing_grpc_flush(
+    struct evpl       *evpl,
+    struct evpl_timer *timer)
+{
+    if (g_grpc_exporter) {
+        evpl_otel_exporter_flush(g_grpc_exporter);
+    }
+} /* chimera_tracing_grpc_flush */
+
+static void *
+chimera_tracing_grpc_init(
+    struct evpl *evpl,
+    void        *private_data)
+{
+    g_grpc_exporter = evpl_otel_exporter_create(evpl, g_grpc_host, g_grpc_port);
+    if (!g_grpc_exporter) {
+        chimera_tracing_log("failed to create OTLP/gRPC exporter for %s:%d",
+                            g_grpc_host, g_grpc_port);
+        return NULL;
+    }
+    evpl_add_timer(evpl, &g_grpc_timer, chimera_tracing_grpc_flush,
+                   OTEL_GRPC_FLUSH_INTERVAL_US);
+    return NULL;
+} /* chimera_tracing_grpc_init */
+
+static void
+chimera_tracing_grpc_shutdown(
+    struct evpl *evpl,
+    void        *private_data)
+{
+    if (g_grpc_exporter) {
+        evpl_otel_exporter_flush(g_grpc_exporter);   /* final drain */
+        evpl_remove_timer(evpl, &g_grpc_timer);
+        evpl_otel_exporter_destroy(g_grpc_exporter);
+        g_grpc_exporter = NULL;
+    }
+} /* chimera_tracing_grpc_shutdown */
+
+/* Split "host:port" into g_grpc_host / g_grpc_port.  Returns 0 on success. */
+static int
+chimera_tracing_parse_endpoint(const char *endpoint)
+{
+    const char *colon = strrchr(endpoint, ':');
+    size_t      hlen;
+
+    if (!colon || colon == endpoint) {
+        return -1;
+    }
+    hlen = (size_t) (colon - endpoint);
+    if (hlen >= sizeof(g_grpc_host)) {
+        return -1;
+    }
+    memcpy(g_grpc_host, endpoint, hlen);
+    g_grpc_host[hlen] = '\0';
+    g_grpc_port       = atoi(colon + 1);
+    return g_grpc_port > 0 ? 0 : -1;
+} /* chimera_tracing_parse_endpoint */
+
+#endif /* CHIMERA_HAVE_OTEL_GRPC */
+
+#endif /* CHIMERA_HAVE_OTEL */
+
+SYMBOL_EXPORT int
+chimera_tracing_init(json_t *config)
+{
+    struct chimera_common_tracing tc;
+
+    chimera_common_tracing_config(config, &tc);
+
+    if (!tc.enabled) {
+        return 0;
+    }
+
+#if !CHIMERA_HAVE_OTEL
+    chimera_tracing_log("enabled in config but oteltracing-c was not built; "
+                        "tracing disabled");
+    return 0;
+#else  /* CHIMERA_HAVE_OTEL */
+
+    otel_init("chimera");
+    otel_set_sampler(tc.sample_rate);
+
+    if (tc.grpc_endpoint) {
+#if CHIMERA_HAVE_OTEL_GRPC
+        if (chimera_tracing_parse_endpoint(tc.grpc_endpoint) != 0) {
+            chimera_tracing_log("invalid grpc_endpoint '%s' (want host:port)",
+                                tc.grpc_endpoint);
+            otel_shutdown();
+            return 0;
+        }
+        g_grpc_thread = evpl_thread_create(NULL, chimera_tracing_grpc_init,
+                                           chimera_tracing_grpc_shutdown, NULL);
+        if (!g_grpc_thread) {
+            chimera_tracing_log("failed to start OTLP/gRPC exporter thread");
+            otel_shutdown();
+            return 0;
+        }
+        chimera_tracing_log("OTLP/gRPC export to %s, sample_rate %.4f",
+                            tc.grpc_endpoint, tc.sample_rate);
+#else  /* !CHIMERA_HAVE_OTEL_GRPC */
+        chimera_tracing_log("grpc_endpoint set but evpl_otel was not built; "
+                            "tracing disabled");
+        otel_shutdown();
+        return 0;
+#endif /* CHIMERA_HAVE_OTEL_GRPC */
+    } else if (tc.sqlite_path) {
+#if CHIMERA_HAVE_OTEL_SQLITE
+        if (otel_sqlite_open(tc.sqlite_path, 0) != 0) {
+            chimera_tracing_log("failed to open span store '%s'", tc.sqlite_path);
+            otel_shutdown();
+            return 0;
+        }
+        g_sqlite_open = 1;
+        chimera_tracing_log("SQLite span store '%s', sample_rate %.4f",
+                            tc.sqlite_path, tc.sample_rate);
+#else  /* !CHIMERA_HAVE_OTEL_SQLITE */
+        chimera_tracing_log("sqlite_path set but the SQLite sink was not built; "
+                            "tracing disabled");
+        otel_shutdown();
+        return 0;
+#endif /* CHIMERA_HAVE_OTEL_SQLITE */
+    } else {
+        chimera_tracing_log("enabled but neither sqlite_path nor grpc_endpoint "
+                            "set; tracing disabled");
+        otel_shutdown();
+        return 0;
+    }
+
+    g_tracing_on = 1;
+    return 1;
+#endif /* CHIMERA_HAVE_OTEL */
+} /* chimera_tracing_init */
+
+SYMBOL_EXPORT void
+chimera_tracing_destroy(void)
+{
+#if CHIMERA_HAVE_OTEL
+    if (!g_tracing_on) {
+        return;
+    }
+
+#if CHIMERA_HAVE_OTEL_GRPC
+    if (g_grpc_thread) {
+        evpl_thread_destroy(g_grpc_thread);   /* runs grpc_shutdown: final flush */
+        g_grpc_thread = NULL;
+    }
+#endif /* CHIMERA_HAVE_OTEL_GRPC */
+
+#if CHIMERA_HAVE_OTEL_SQLITE
+    if (g_sqlite_open) {
+        otel_sqlite_close();                  /* stops flusher, final commit */
+        g_sqlite_open = 0;
+    }
+#endif /* CHIMERA_HAVE_OTEL_SQLITE */
+
+    otel_shutdown();
+    g_tracing_on = 0;
+#endif /* CHIMERA_HAVE_OTEL */
+} /* chimera_tracing_destroy */
+
+SYMBOL_EXPORT void
+chimera_tracing_thread_register(void)
+{
+#if CHIMERA_HAVE_OTEL
+    if (g_tracing_on) {
+        otel_thread_register();
+    }
+#endif /* CHIMERA_HAVE_OTEL */
+} /* chimera_tracing_thread_register */
+
+SYMBOL_EXPORT void
+chimera_tracing_thread_unregister(void)
+{
+#if CHIMERA_HAVE_OTEL
+    if (g_tracing_on) {
+        otel_thread_unregister();
+    }
+#endif /* CHIMERA_HAVE_OTEL */
+} /* chimera_tracing_thread_unregister */

--- a/src/common/chimera_tracing.h
+++ b/src/common/chimera_tracing.h
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * chimera_tracing -- process-wide setup for OpenTelemetry span tracing.
+ *
+ * Wraps oteltracing-c (the embeddable span library) and its two exporters: the
+ * optional SQLite local store (oteltracing-sqlite) and the OTLP/gRPC exporter
+ * over libevpl's HTTP/2 client (evpl_otel).  All knobs come from the shared
+ * "common.tracing" config section.  Tracing is off by default; when disabled (or
+ * when the library was not built) every span call elsewhere in the tree compiles
+ * or short-circuits to nothing.
+ *
+ * Lifecycle (daemon):
+ *   chimera_tracing_init(config)         once, after evpl_init(), before threads
+ *   chimera_tracing_thread_register()    on each span-producing (core) thread
+ *   chimera_tracing_thread_unregister()  on each such thread at shutdown
+ *   chimera_tracing_destroy()            once at process exit
+ */
+
+#pragma once
+
+#include <jansson.h>
+
+/*
+ * Parse common.tracing and bring tracing up if enabled.  Returns 1 if tracing is
+ * active afterwards, 0 if disabled or unavailable.  `config` is the parsed
+ * top-level JSON (may be NULL).
+ */
+int chimera_tracing_init(
+    json_t *config);
+
+/* Tear down tracing (flush + close exporters).  Safe if init returned 0. */
+void chimera_tracing_destroy(
+    void);
+
+/* Register/unregister the calling thread as a span producer.  No-ops unless
+ * tracing came up. */
+void chimera_tracing_thread_register(
+    void);
+void chimera_tracing_thread_unregister(
+    void);

--- a/src/common/common_config.h
+++ b/src/common/common_config.h
@@ -369,3 +369,74 @@ chimera_common_name_cache_enabled(json_t *root)
 
     return 1;
 } /* chimera_common_name_cache_enabled */
+
+/*
+ * OpenTelemetry span tracing settings, parsed from the nested "tracing" object
+ * in the shared top-level "common" section.  Tracing is OFF by default.  Exactly
+ * one export destination is used: when grpc_endpoint is set spans go to an OTLP
+ * collector over gRPC, otherwise when sqlite_path is set they go to a local
+ * SQLite store (queryable with the otel-trace CLI).  sample_rate is the head
+ * sampling probability in [0,1], defaulting to 0.001 (0.1%).
+ *
+ *   "common": { "tracing": { "enabled": true,
+ *                            "sqlite_path": "/tmp/chimera-traces.db",
+ *                            "grpc_endpoint": "127.0.0.1:4317",
+ *                            "sample_rate": 0.001 } }
+ *
+ * String pointers are owned by `root` and valid only until json_decref(root).
+ */
+struct chimera_common_tracing {
+    int         enabled;        /* default 0 */
+    const char *sqlite_path;    /* default NULL */
+    const char *grpc_endpoint;  /* default NULL ("host:port") */
+    double      sample_rate;    /* default 0.001 */
+};
+
+static inline void
+chimera_common_tracing_config(
+    json_t                        *root,
+    struct chimera_common_tracing *out)
+{
+    json_t *common, *tracing, *val;
+
+    out->enabled       = 0;
+    out->sqlite_path   = NULL;
+    out->grpc_endpoint = NULL;
+    out->sample_rate   = 0.001;
+
+    if (!root) {
+        return;
+    }
+
+    common = json_object_get(root, "common");
+    if (!json_is_object(common)) {
+        return;
+    }
+
+    tracing = json_object_get(common, "tracing");
+    if (!json_is_object(tracing)) {
+        return;
+    }
+
+    val = json_object_get(tracing, "enabled");
+    if (json_is_boolean(val)) {
+        out->enabled = json_is_true(val);
+    }
+
+    val = json_object_get(tracing, "sqlite_path");
+    if (json_is_string(val)) {
+        out->sqlite_path = json_string_value(val);
+    }
+
+    val = json_object_get(tracing, "grpc_endpoint");
+    if (json_is_string(val)) {
+        out->grpc_endpoint = json_string_value(val);
+    }
+
+    val = json_object_get(tracing, "sample_rate");
+    if (json_is_real(val)) {
+        out->sample_rate = json_real_value(val);
+    } else if (json_is_integer(val)) {
+        out->sample_rate = (double) json_integer_value(val);
+    }
+} /* chimera_common_tracing_config */

--- a/src/daemon/CMakeLists.txt
+++ b/src/daemon/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 add_executable(chimera daemon.c)
 
-target_link_libraries(chimera chimera_server chimera_metrics jansson)
+target_link_libraries(chimera chimera_server chimera_common chimera_metrics jansson ${CHIMERA_OTEL_LIBS})
 
 install(TARGETS chimera DESTINATION sbin)
 install(FILES chimera.json DESTINATION etc)

--- a/src/daemon/chimera.json
+++ b/src/daemon/chimera.json
@@ -4,7 +4,13 @@
 	"sync_delegation": true,
 	"sync_delegation_threads": 1,
 	"async_delegation": false,
-	"async_delegation_threads": 8
+	"async_delegation_threads": 8,
+	"tracing": {
+	    "enabled": false,
+	    "sqlite_path": "/tmp/chimera-traces.db",
+	    "grpc_endpoint": "127.0.0.1:4317",
+	    "sample_rate": 0.001
+	}
     },
     "server": {
 	"threads": 16

--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -26,6 +26,7 @@
 #include "server/server_internal.h"
 #include "common/logging.h"
 #include "common/common_config.h"
+#include "common/chimera_tracing.h"
 #include "metrics/metrics.h"
 #include "daemon.h"
 
@@ -359,6 +360,11 @@ main(
     chimera_apply_common_config(config, evpl_global_config);
 
     evpl_init(evpl_global_config);
+
+    /* Bring up OpenTelemetry span tracing if common.tracing.enabled (off by
+    * default).  Must run after evpl_init (the gRPC exporter spins up an evpl
+    * thread) and before the server's core threads start producing spans. */
+    chimera_tracing_init(config);
 
     signal(SIGINT, signal_handler);
     signal(SIGTERM, signal_handler);
@@ -1388,6 +1394,10 @@ main(
     chimera_server_info("Shutting down server (signal=%d)...", SigInt);
 
     chimera_server_destroy(server);
+
+    /* Flush and close tracing exporters after the server's threads have drained
+     * and unregistered (chimera_server_destroy joined them). */
+    chimera_tracing_destroy();
 
     /* Optionally persist a final metrics scrape (common.metrics_file) before
      * tearing down the registry, so short-lived runs keep their metrics. */

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -9,7 +9,7 @@
 add_compile_definitions(_LGPL_SOURCE)
 
 add_library(chimera_server SHARED server.c)
-target_link_libraries(chimera_server chimera_nfs chimera_s3 chimera_smb chimera_rest chimera_vfs evpl unwind)
+target_link_libraries(chimera_server chimera_nfs chimera_s3 chimera_smb chimera_rest chimera_vfs chimera_common evpl unwind ${CHIMERA_OTEL_LIBS})
 
 install(TARGETS chimera_server DESTINATION lib)
 

--- a/src/server/nfs/CMakeLists.txt
+++ b/src/server/nfs/CMakeLists.txt
@@ -5,7 +5,7 @@
 include_directories(${NFS_COMMON_INCLUDE_DIR})
 
 # Create libraries for NFSv3 and NFSv4
-add_library(chimera_nfs SHARED nfs.c nfs4_session.c nfs4_state.c nfs4_lease.c nfs4_recovery.c nfs4_drc.c nfs3_drc.c nfs4_v40_drc.c nfs_drc_reply.c nfs4_callback.c nfs_mount.c nfs_portmap.c nfs3_dump.c nfs4_dump.c
+add_library(chimera_nfs SHARED nfs.c nfs4_session.c nfs4_state.c nfs4_lease.c nfs4_recovery.c nfs4_drc.c nfs3_drc.c nfs4_v40_drc.c nfs_drc_reply.c nfs4_callback.c nfs_mount.c nfs_portmap.c nfs3_dump.c nfs4_dump.c nfs3_trace.c nfs4_trace.c
             nfs_external_portmap.c nfs_nlm.c nfs_nlm_state.c nfs_nlm_granted.c nfs_nsm.c nfs_nsm_state.c
             nfs3_proc_null.c nfs3_proc_getattr.c nfs3_proc_setattr.c nfs3_proc_lookup.c 
             nfs3_proc_access.c nfs3_proc_readlink.c nfs3_proc_read.c nfs3_proc_write.c

--- a/src/server/nfs/nfs3_proc_access.c
+++ b/src/server/nfs/nfs3_proc_access.c
@@ -10,6 +10,7 @@
 #include "vfs/vfs_acl.h"
 #include "vfs/vfs_access.h"
 #include "nfs3_dump.h"
+#include "nfs3_trace.h"
 
 /* Map the meaningful ACCESS3_* request bits to the canonical ACE mask. */
 static uint32_t
@@ -145,6 +146,7 @@ chimera_nfs3_access(
     chimera_nfs_map_cred_req(req, cred);
 
     nfs3_dump_access(req, args);
+    nfs3_trace_access(req, args);
 
     req->args_access = args;
 

--- a/src/server/nfs/nfs3_proc_commit.c
+++ b/src/server/nfs/nfs3_proc_commit.c
@@ -10,6 +10,7 @@
 #include "vfs/vfs_procs.h"
 #include "vfs/vfs_release.h"
 #include "nfs3_dump.h"
+#include "nfs3_trace.h"
 static void
 chimera_nfs3_commit_complete(
     enum chimera_vfs_error    error_code,
@@ -98,6 +99,7 @@ chimera_nfs3_commit(
     chimera_nfs_map_cred_req(req, cred);
 
     nfs3_dump_commit(req, args);
+    nfs3_trace_commit(req, args);
 
     req->args_commit = args;
 

--- a/src/server/nfs/nfs3_proc_create.c
+++ b/src/server/nfs/nfs3_proc_create.c
@@ -11,6 +11,7 @@
 #include "vfs/vfs_procs.h"
 #include "vfs/vfs_release.h"
 #include "nfs3_dump.h"
+#include "nfs3_trace.h"
 
 static void
 chimera_nfs3_create_reply(
@@ -217,6 +218,7 @@ chimera_nfs3_create(
     chimera_nfs_map_cred_req(req, cred);
 
     nfs3_dump_create(req, args);
+    nfs3_trace_create(req, args);
 
     req->args_create = args;
 

--- a/src/server/nfs/nfs3_proc_fsinfo.c
+++ b/src/server/nfs/nfs3_proc_fsinfo.c
@@ -8,6 +8,7 @@
 #include "vfs/vfs_procs.h"
 #include "vfs/vfs_release.h"
 #include "nfs3_dump.h"
+#include "nfs3_trace.h"
 
 static void
 chimera_nfs3_fsinfo_complete(
@@ -102,6 +103,7 @@ chimera_nfs3_fsinfo(
     chimera_nfs_map_cred_req(req, cred);
 
     nfs3_dump_fsinfo(req, args);
+    nfs3_trace_fsinfo(req, args);
 
     req->args_fsinfo = args;
 

--- a/src/server/nfs/nfs3_proc_fsstat.c
+++ b/src/server/nfs/nfs3_proc_fsstat.c
@@ -8,6 +8,7 @@
 #include "vfs/vfs_procs.h"
 #include "vfs/vfs_release.h"
 #include "nfs3_dump.h"
+#include "nfs3_trace.h"
 static void
 chimera_nfs3_fsstat_complete(
     enum chimera_vfs_error    error_code,
@@ -98,6 +99,7 @@ chimera_nfs3_fsstat(
     chimera_nfs_map_cred_req(req, cred);
 
     nfs3_dump_fsstat(req, args);
+    nfs3_trace_fsstat(req, args);
 
     req->args_fsstat = args;
 

--- a/src/server/nfs/nfs3_proc_getattr.c
+++ b/src/server/nfs/nfs3_proc_getattr.c
@@ -8,6 +8,7 @@
 #include "vfs/vfs_procs.h"
 #include "vfs/vfs_release.h"
 #include "nfs3_dump.h"
+#include "nfs3_trace.h"
 
 static void
 chimera_nfs3_getattr_complete(
@@ -85,6 +86,7 @@ chimera_nfs3_getattr(
     chimera_nfs_map_cred_req(req, cred);
 
     nfs3_dump_getattr(req, args);
+    nfs3_trace_getattr(req, args);
 
     req->args_getattr = args;
 

--- a/src/server/nfs/nfs3_proc_link.c
+++ b/src/server/nfs/nfs3_proc_link.c
@@ -7,6 +7,7 @@
 #include "nfs_common/nfs3_attr.h"
 #include "vfs/vfs_procs.h"
 #include "nfs3_dump.h"
+#include "nfs3_trace.h"
 static void
 chimera_nfs3_link_complete(
     enum chimera_vfs_error    error_code,
@@ -59,6 +60,7 @@ chimera_nfs3_link(
     chimera_nfs_map_cred_req(req, cred);
 
     nfs3_dump_link(req, args);
+    nfs3_trace_link(req, args);
 
     /* Decode the existing-file handle (sets the request export + squash) and
      * the target-directory handle (authenticated into req->saved_fh).  The

--- a/src/server/nfs/nfs3_proc_lookup.c
+++ b/src/server/nfs/nfs3_proc_lookup.c
@@ -9,6 +9,7 @@
 #include "vfs/vfs_procs.h"
 #include "vfs/vfs_release.h"
 #include "nfs3_dump.h"
+#include "nfs3_trace.h"
 static void
 chimera_nfs3_lookup_complete(
     enum chimera_vfs_error    error_code,
@@ -114,6 +115,7 @@ chimera_nfs3_lookup(
     chimera_nfs_map_cred_req(req, cred);
 
     nfs3_dump_lookup(req, args);
+    nfs3_trace_lookup(req, args);
 
     req->args_lookup = args;
 

--- a/src/server/nfs/nfs3_proc_mkdir.c
+++ b/src/server/nfs/nfs3_proc_mkdir.c
@@ -11,6 +11,7 @@
 #include "vfs/vfs.h"
 #include "vfs/vfs_release.h"
 #include "nfs3_dump.h"
+#include "nfs3_trace.h"
 
 static void
 chimera_nfs3_mkdir_complete(
@@ -121,6 +122,7 @@ chimera_nfs3_mkdir(
     chimera_nfs_map_cred_req(req, cred);
 
     nfs3_dump_mkdir(req, args);
+    nfs3_trace_mkdir(req, args);
 
     req->args_mkdir = args;
 

--- a/src/server/nfs/nfs3_proc_mknod.c
+++ b/src/server/nfs/nfs3_proc_mknod.c
@@ -11,6 +11,7 @@
 #include "vfs/vfs.h"
 #include "vfs/vfs_release.h"
 #include "nfs3_dump.h"
+#include "nfs3_trace.h"
 
 static void
 chimera_nfs3_mknod_complete(
@@ -150,6 +151,7 @@ chimera_nfs3_mknod(
     chimera_nfs_map_cred_req(req, cred);
 
     nfs3_dump_mknod(req, args);
+    nfs3_trace_mknod(req, args);
 
     req->args_mknod = args;
 

--- a/src/server/nfs/nfs3_proc_read.c
+++ b/src/server/nfs/nfs3_proc_read.c
@@ -9,6 +9,7 @@
 #include "vfs/vfs_procs.h"
 #include "vfs/vfs_release.h"
 #include "nfs3_dump.h"
+#include "nfs3_trace.h"
 
 static void
 chimera_nfs3_read_complete(
@@ -109,6 +110,7 @@ chimera_nfs3_read(
     chimera_nfs_map_cred_req(req, cred);
 
     nfs3_dump_read(req, args);
+    nfs3_trace_read(req, args);
 
     req->args_read = args;
 

--- a/src/server/nfs/nfs3_proc_readdir.c
+++ b/src/server/nfs/nfs3_proc_readdir.c
@@ -9,6 +9,7 @@
 #include "vfs/vfs_procs.h"
 #include "vfs/vfs_release.h"
 #include "nfs3_dump.h"
+#include "nfs3_trace.h"
 
 static int
 chimera_nfs3_readdir_callback(
@@ -153,6 +154,7 @@ chimera_nfs3_readdir(
     chimera_nfs_map_cred_req(req, cred);
 
     nfs3_dump_readdir(req, args);
+    nfs3_trace_readdir(req, args);
 
     req->args_readdir = args;
 

--- a/src/server/nfs/nfs3_proc_readdirplus.c
+++ b/src/server/nfs/nfs3_proc_readdirplus.c
@@ -9,6 +9,7 @@
 #include "vfs/vfs_procs.h"
 #include "vfs/vfs_release.h"
 #include "nfs3_dump.h"
+#include "nfs3_trace.h"
 static int
 chimera_nfs3_readdirplus_callback(
     uint64_t                        inum,
@@ -183,6 +184,7 @@ chimera_nfs3_readdirplus(
     chimera_nfs_map_cred_req(req, cred);
 
     nfs3_dump_readdirplus(req, args);
+    nfs3_trace_readdirplus(req, args);
 
     req->args_readdirplus = args;
 

--- a/src/server/nfs/nfs3_proc_readlink.c
+++ b/src/server/nfs/nfs3_proc_readlink.c
@@ -8,6 +8,7 @@
 #include "vfs/vfs_procs.h"
 #include "vfs/vfs_release.h"
 #include "nfs3_dump.h"
+#include "nfs3_trace.h"
 
 static void
 chimera_nfs3_readlink_complete(
@@ -105,6 +106,7 @@ chimera_nfs3_readlink(
     chimera_nfs_map_cred_req(req, cred);
 
     nfs3_dump_readlink(req, args);
+    nfs3_trace_readlink(req, args);
     res = &req->res_readlink;
 
     res->resok.data.len = 4096;

--- a/src/server/nfs/nfs3_proc_remove.c
+++ b/src/server/nfs/nfs3_proc_remove.c
@@ -9,6 +9,7 @@
 #include "vfs/vfs_procs.h"
 #include "vfs/vfs_release.h"
 #include "nfs3_dump.h"
+#include "nfs3_trace.h"
 
 /* True when a cross-protocol caching holder (NFSv4 delegation, SMB lease, or
  * SMB oplock) could exist on the shared store.  An NFSv3 REMOVE/RMDIR of an
@@ -162,6 +163,7 @@ chimera_nfs3_remove(
     chimera_nfs_map_cred_req(req, cred);
 
     nfs3_dump_remove(req, args);
+    nfs3_trace_remove(req, args);
 
     req->args_remove = args;
 

--- a/src/server/nfs/nfs3_proc_rename.c
+++ b/src/server/nfs/nfs3_proc_rename.c
@@ -8,6 +8,7 @@
 #include "server/server.h"
 #include "vfs/vfs_procs.h"
 #include "nfs3_dump.h"
+#include "nfs3_trace.h"
 
 /* See chimera_nfs3_remove.c: when a caching protocol is enabled, an NFSv3
  * RENAME that overwrites an existing destination must recall any delegation/
@@ -19,6 +20,7 @@ chimera_nfs3_recall_needed(struct chimera_server_nfs_thread *thread)
            chimera_server_config_get_smb_leases(thread->shared->config) ||
            chimera_server_config_get_smb_oplocks(thread->shared->config);
 } /* chimera_nfs3_recall_needed */
+
 
 static void
 chimera_nfs3_rename_complete(
@@ -132,6 +134,7 @@ chimera_nfs3_rename(
     chimera_nfs_map_cred_req(req, cred);
 
     nfs3_dump_rename(req, args);
+    nfs3_trace_rename(req, args);
 
     /* Decode both directory handles: the source sets the request export (and
      * squash); the destination is authenticated into req->saved_fh.  Both must

--- a/src/server/nfs/nfs3_proc_rmdir.c
+++ b/src/server/nfs/nfs3_proc_rmdir.c
@@ -8,6 +8,7 @@
 #include "server/server.h"
 #include "vfs/vfs_release.h"
 #include "nfs3_dump.h"
+#include "nfs3_trace.h"
 #include "vfs/vfs_procs.h"
 
 /* See chimera_nfs3_remove.c: a directory removed via NFSv3 may be held under an
@@ -151,6 +152,7 @@ chimera_nfs3_rmdir(
     chimera_nfs_map_cred_req(req, cred);
 
     nfs3_dump_rmdir(req, args);
+    nfs3_trace_rmdir(req, args);
 
     req->args_rmdir = args;
 

--- a/src/server/nfs/nfs3_proc_setattr.c
+++ b/src/server/nfs/nfs3_proc_setattr.c
@@ -8,6 +8,7 @@
 #include "vfs/vfs_procs.h"
 #include "vfs/vfs_release.h"
 #include "nfs3_dump.h"
+#include "nfs3_trace.h"
 static void
 chimera_nfs3_setattr_complete(
     enum chimera_vfs_error    error_code,
@@ -155,6 +156,7 @@ chimera_nfs3_setattr(
     chimera_nfs_map_cred_req(req, cred);
 
     nfs3_dump_setattr(req, args);
+    nfs3_trace_setattr(req, args);
 
     req->args_setattr = args;
 

--- a/src/server/nfs/nfs3_proc_symlink.c
+++ b/src/server/nfs/nfs3_proc_symlink.c
@@ -8,6 +8,7 @@
 #include "vfs/vfs_procs.h"
 #include "vfs/vfs_release.h"
 #include "nfs3_dump.h"
+#include "nfs3_trace.h"
 
 static void
 chimera_nfs3_symlink_complete(
@@ -122,6 +123,7 @@ chimera_nfs3_symlink(
     chimera_nfs_map_cred_req(req, cred);
 
     nfs3_dump_symlink(req, args);
+    nfs3_trace_symlink(req, args);
     req->args_symlink = args;
 
     res.status = chimera_nfs3_decode_fh(req, args->where.dir.data.data, args->where.dir.data.len);

--- a/src/server/nfs/nfs3_proc_write.c
+++ b/src/server/nfs/nfs3_proc_write.c
@@ -10,6 +10,7 @@
 #include "vfs/vfs_procs.h"
 #include "vfs/vfs_release.h"
 #include "nfs3_dump.h"
+#include "nfs3_trace.h"
 
 static void
 chimera_nfs3_write_complete(
@@ -124,6 +125,7 @@ chimera_nfs3_write(
     chimera_nfs_map_cred_req(req, cred);
 
     nfs3_dump_write(req, args);
+    nfs3_trace_write(req, args);
 
     req->args_write = args;
 

--- a/src/server/nfs/nfs3_trace.c
+++ b/src/server/nfs/nfs3_trace.c
@@ -10,6 +10,9 @@
  */
 
 #include "nfs3_trace.h"
+
+#if CHIMERA_HAVE_OTEL
+
 #include "common/format.h"
 
 /* NFSv3 file handles are at most NFS3_FHSIZE (64) bytes on the wire. */
@@ -247,3 +250,5 @@ _nfs3_trace_commit(
     otel_span_attr_u64(&req->otel, "nfs.offset", args->offset);
     otel_span_attr_u64(&req->otel, "nfs.count", args->count);
 } /* _nfs3_trace_commit */
+
+#endif /* CHIMERA_HAVE_OTEL */

--- a/src/server/nfs/nfs3_trace.c
+++ b/src/server/nfs/nfs3_trace.c
@@ -1,0 +1,249 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * NFSv3 span tracing (see nfs3_trace.h).  Bodies run only for a recording span.
+ * They set the span name and attach the operation's file handle (hex, same
+ * encoding as the debug dump) plus a few useful attributes.  Field expressions
+ * mirror nfs3_dump.c.
+ */
+
+#include "nfs3_trace.h"
+#include "common/format.h"
+
+/* NFSv3 file handles are at most NFS3_FHSIZE (64) bytes on the wire. */
+#define NFS3_TRACE_FH_HEX (2 * 64 + 1)
+
+static inline void
+nfs3_trace_fh(
+    struct nfs_request *req,
+    const char         *key,
+    const void         *fh,
+    int                 fhlen)
+{
+    char hex[NFS3_TRACE_FH_HEX];
+
+    if (fh && fhlen > 0) {
+        format_hex(hex, sizeof(hex), fh, fhlen);
+        otel_span_attr_str(&req->otel, key, hex);
+    }
+} /* nfs3_trace_fh */
+
+void
+_nfs3_trace_null(struct nfs_request *req)
+{
+    otel_span_set_name(&req->otel, "nfs3.null");
+} /* _nfs3_trace_null */
+
+void
+_nfs3_trace_getattr(
+    struct nfs_request  *req,
+    struct GETATTR3args *args)
+{
+    otel_span_set_name(&req->otel, "nfs3.getattr");
+    nfs3_trace_fh(req, "nfs.fh", args->object.data.data, args->object.data.len);
+} /* _nfs3_trace_getattr */
+
+void
+_nfs3_trace_setattr(
+    struct nfs_request  *req,
+    struct SETATTR3args *args)
+{
+    otel_span_set_name(&req->otel, "nfs3.setattr");
+    nfs3_trace_fh(req, "nfs.fh", args->object.data.data, args->object.data.len);
+} /* _nfs3_trace_setattr */
+
+void
+_nfs3_trace_lookup(
+    struct nfs_request *req,
+    struct LOOKUP3args *args)
+{
+    otel_span_set_name(&req->otel, "nfs3.lookup");
+    nfs3_trace_fh(req, "nfs.dir_fh", args->what.dir.data.data, args->what.dir.data.len);
+    otel_span_attr_strn(&req->otel, "nfs.name", args->what.name.str, args->what.name.len);
+} /* _nfs3_trace_lookup */
+
+void
+_nfs3_trace_access(
+    struct nfs_request *req,
+    struct ACCESS3args *args)
+{
+    otel_span_set_name(&req->otel, "nfs3.access");
+    nfs3_trace_fh(req, "nfs.fh", args->object.data.data, args->object.data.len);
+    otel_span_attr_u64(&req->otel, "nfs.access", args->access);
+} /* _nfs3_trace_access */
+
+void
+_nfs3_trace_readlink(
+    struct nfs_request   *req,
+    struct READLINK3args *args)
+{
+    otel_span_set_name(&req->otel, "nfs3.readlink");
+    nfs3_trace_fh(req, "nfs.fh", args->symlink.data.data, args->symlink.data.len);
+} /* _nfs3_trace_readlink */
+
+void
+_nfs3_trace_read(
+    struct nfs_request *req,
+    struct READ3args   *args)
+{
+    otel_span_set_name(&req->otel, "nfs3.read");
+    nfs3_trace_fh(req, "nfs.fh", args->file.data.data, args->file.data.len);
+    otel_span_attr_u64(&req->otel, "nfs.offset", args->offset);
+    otel_span_attr_u64(&req->otel, "nfs.count", args->count);
+} /* _nfs3_trace_read */
+
+void
+_nfs3_trace_write(
+    struct nfs_request *req,
+    struct WRITE3args  *args)
+{
+    otel_span_set_name(&req->otel, "nfs3.write");
+    nfs3_trace_fh(req, "nfs.fh", args->file.data.data, args->file.data.len);
+    otel_span_attr_u64(&req->otel, "nfs.offset", args->offset);
+    otel_span_attr_u64(&req->otel, "nfs.count", args->count);
+} /* _nfs3_trace_write */
+
+void
+_nfs3_trace_create(
+    struct nfs_request *req,
+    struct CREATE3args *args)
+{
+    otel_span_set_name(&req->otel, "nfs3.create");
+    nfs3_trace_fh(req, "nfs.dir_fh", args->where.dir.data.data, args->where.dir.data.len);
+    otel_span_attr_strn(&req->otel, "nfs.name", args->where.name.str, args->where.name.len);
+} /* _nfs3_trace_create */
+
+void
+_nfs3_trace_mkdir(
+    struct nfs_request *req,
+    struct MKDIR3args  *args)
+{
+    otel_span_set_name(&req->otel, "nfs3.mkdir");
+    nfs3_trace_fh(req, "nfs.dir_fh", args->where.dir.data.data, args->where.dir.data.len);
+    otel_span_attr_strn(&req->otel, "nfs.name", args->where.name.str, args->where.name.len);
+} /* _nfs3_trace_mkdir */
+
+void
+_nfs3_trace_symlink(
+    struct nfs_request  *req,
+    struct SYMLINK3args *args)
+{
+    otel_span_set_name(&req->otel, "nfs3.symlink");
+    nfs3_trace_fh(req, "nfs.dir_fh", args->where.dir.data.data, args->where.dir.data.len);
+    otel_span_attr_strn(&req->otel, "nfs.name", args->where.name.str, args->where.name.len);
+} /* _nfs3_trace_symlink */
+
+void
+_nfs3_trace_mknod(
+    struct nfs_request *req,
+    struct MKNOD3args  *args)
+{
+    otel_span_set_name(&req->otel, "nfs3.mknod");
+    nfs3_trace_fh(req, "nfs.dir_fh", args->where.dir.data.data, args->where.dir.data.len);
+    otel_span_attr_strn(&req->otel, "nfs.name", args->where.name.str, args->where.name.len);
+} /* _nfs3_trace_mknod */
+
+void
+_nfs3_trace_remove(
+    struct nfs_request *req,
+    struct REMOVE3args *args)
+{
+    otel_span_set_name(&req->otel, "nfs3.remove");
+    nfs3_trace_fh(req, "nfs.dir_fh", args->object.dir.data.data, args->object.dir.data.len);
+    otel_span_attr_strn(&req->otel, "nfs.name", args->object.name.str, args->object.name.len);
+} /* _nfs3_trace_remove */
+
+void
+_nfs3_trace_rmdir(
+    struct nfs_request *req,
+    struct RMDIR3args  *args)
+{
+    otel_span_set_name(&req->otel, "nfs3.rmdir");
+    nfs3_trace_fh(req, "nfs.dir_fh", args->object.dir.data.data, args->object.dir.data.len);
+    otel_span_attr_strn(&req->otel, "nfs.name", args->object.name.str, args->object.name.len);
+} /* _nfs3_trace_rmdir */
+
+void
+_nfs3_trace_rename(
+    struct nfs_request *req,
+    struct RENAME3args *args)
+{
+    otel_span_set_name(&req->otel, "nfs3.rename");
+    nfs3_trace_fh(req, "nfs.from_dir_fh", args->from.dir.data.data, args->from.dir.data.len);
+    otel_span_attr_strn(&req->otel, "nfs.from_name", args->from.name.str, args->from.name.len);
+    nfs3_trace_fh(req, "nfs.to_dir_fh", args->to.dir.data.data, args->to.dir.data.len);
+    otel_span_attr_strn(&req->otel, "nfs.to_name", args->to.name.str, args->to.name.len);
+} /* _nfs3_trace_rename */
+
+void
+_nfs3_trace_link(
+    struct nfs_request *req,
+    struct LINK3args   *args)
+{
+    otel_span_set_name(&req->otel, "nfs3.link");
+    nfs3_trace_fh(req, "nfs.fh", args->file.data.data, args->file.data.len);
+    nfs3_trace_fh(req, "nfs.dir_fh", args->link.dir.data.data, args->link.dir.data.len);
+    otel_span_attr_strn(&req->otel, "nfs.name", args->link.name.str, args->link.name.len);
+} /* _nfs3_trace_link */
+
+void
+_nfs3_trace_readdir(
+    struct nfs_request  *req,
+    struct READDIR3args *args)
+{
+    otel_span_set_name(&req->otel, "nfs3.readdir");
+    nfs3_trace_fh(req, "nfs.fh", args->dir.data.data, args->dir.data.len);
+    otel_span_attr_u64(&req->otel, "nfs.cookie", args->cookie);
+    otel_span_attr_u64(&req->otel, "nfs.count", args->count);
+} /* _nfs3_trace_readdir */
+
+void
+_nfs3_trace_readdirplus(
+    struct nfs_request      *req,
+    struct READDIRPLUS3args *args)
+{
+    otel_span_set_name(&req->otel, "nfs3.readdirplus");
+    nfs3_trace_fh(req, "nfs.fh", args->dir.data.data, args->dir.data.len);
+    otel_span_attr_u64(&req->otel, "nfs.cookie", args->cookie);
+    otel_span_attr_u64(&req->otel, "nfs.maxcount", args->maxcount);
+} /* _nfs3_trace_readdirplus */
+
+void
+_nfs3_trace_fsstat(
+    struct nfs_request *req,
+    struct FSSTAT3args *args)
+{
+    otel_span_set_name(&req->otel, "nfs3.fsstat");
+    nfs3_trace_fh(req, "nfs.fh", args->fsroot.data.data, args->fsroot.data.len);
+} /* _nfs3_trace_fsstat */
+
+void
+_nfs3_trace_fsinfo(
+    struct nfs_request *req,
+    struct FSINFO3args *args)
+{
+    otel_span_set_name(&req->otel, "nfs3.fsinfo");
+    nfs3_trace_fh(req, "nfs.fh", args->fsroot.data.data, args->fsroot.data.len);
+} /* _nfs3_trace_fsinfo */
+
+void
+_nfs3_trace_pathconf(
+    struct nfs_request   *req,
+    struct PATHCONF3args *args)
+{
+    otel_span_set_name(&req->otel, "nfs3.pathconf");
+    nfs3_trace_fh(req, "nfs.fh", args->object.data.data, args->object.data.len);
+} /* _nfs3_trace_pathconf */
+
+void
+_nfs3_trace_commit(
+    struct nfs_request *req,
+    struct COMMIT3args *args)
+{
+    otel_span_set_name(&req->otel, "nfs3.commit");
+    nfs3_trace_fh(req, "nfs.fh", args->file.data.data, args->file.data.len);
+    otel_span_attr_u64(&req->otel, "nfs.offset", args->offset);
+    otel_span_attr_u64(&req->otel, "nfs.count", args->count);
+} /* _nfs3_trace_commit */

--- a/src/server/nfs/nfs3_trace.h
+++ b/src/server/nfs/nfs3_trace.h
@@ -15,6 +15,8 @@
 
 #include "nfs_common.h"
 
+#if CHIMERA_HAVE_OTEL
+
 void _nfs3_trace_null(
     struct nfs_request *req);
 void _nfs3_trace_getattr(
@@ -83,6 +85,12 @@ void _nfs3_trace_commit(
 
 #define nfs3_trace_(req, fn, ...) \
         do { if (otel_span_recording(&(req)->otel)) { fn(req, ## __VA_ARGS__); } } while (0)
+
+#else  /* !CHIMERA_HAVE_OTEL : tracing compiled out -- calls vanish entirely */
+
+#define nfs3_trace_(req, fn, ...)         do { } while (0)
+
+#endif /* CHIMERA_HAVE_OTEL */
 
 #define nfs3_trace_null(req)              nfs3_trace_(req, _nfs3_trace_null)
 #define nfs3_trace_getattr(req, args)     nfs3_trace_(req, _nfs3_trace_getattr, args)

--- a/src/server/nfs/nfs3_trace.h
+++ b/src/server/nfs/nfs3_trace.h
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * NFSv3 span tracing, modeled on nfs3_dump.h.  Each handler calls the matching
+ * nfs3_trace_<op>() right next to its nfs3_dump_<op>(); the macro short-circuits
+ * (one inline flag test) unless this request's span is being recorded, so the
+ * per-op span naming + attribute code stays out of the mainline and costs
+ * nothing for unsampled traces.  The _nfs3_trace_<op>() bodies set the span name
+ * ("nfs3.<op>") and attach the file handle (hex) plus op-specific attributes.
+ */
+
+#pragma once
+
+#include "nfs_common.h"
+
+void _nfs3_trace_null(
+    struct nfs_request *req);
+void _nfs3_trace_getattr(
+    struct nfs_request  *req,
+    struct GETATTR3args *args);
+void _nfs3_trace_setattr(
+    struct nfs_request  *req,
+    struct SETATTR3args *args);
+void _nfs3_trace_lookup(
+    struct nfs_request *req,
+    struct LOOKUP3args *args);
+void _nfs3_trace_access(
+    struct nfs_request *req,
+    struct ACCESS3args *args);
+void _nfs3_trace_readlink(
+    struct nfs_request   *req,
+    struct READLINK3args *args);
+void _nfs3_trace_read(
+    struct nfs_request *req,
+    struct READ3args   *args);
+void _nfs3_trace_write(
+    struct nfs_request *req,
+    struct WRITE3args  *args);
+void _nfs3_trace_create(
+    struct nfs_request *req,
+    struct CREATE3args *args);
+void _nfs3_trace_mkdir(
+    struct nfs_request *req,
+    struct MKDIR3args  *args);
+void _nfs3_trace_symlink(
+    struct nfs_request  *req,
+    struct SYMLINK3args *args);
+void _nfs3_trace_mknod(
+    struct nfs_request *req,
+    struct MKNOD3args  *args);
+void _nfs3_trace_remove(
+    struct nfs_request *req,
+    struct REMOVE3args *args);
+void _nfs3_trace_rmdir(
+    struct nfs_request *req,
+    struct RMDIR3args  *args);
+void _nfs3_trace_rename(
+    struct nfs_request *req,
+    struct RENAME3args *args);
+void _nfs3_trace_link(
+    struct nfs_request *req,
+    struct LINK3args   *args);
+void _nfs3_trace_readdir(
+    struct nfs_request  *req,
+    struct READDIR3args *args);
+void _nfs3_trace_readdirplus(
+    struct nfs_request      *req,
+    struct READDIRPLUS3args *args);
+void _nfs3_trace_fsstat(
+    struct nfs_request *req,
+    struct FSSTAT3args *args);
+void _nfs3_trace_fsinfo(
+    struct nfs_request *req,
+    struct FSINFO3args *args);
+void _nfs3_trace_pathconf(
+    struct nfs_request   *req,
+    struct PATHCONF3args *args);
+void _nfs3_trace_commit(
+    struct nfs_request *req,
+    struct COMMIT3args *args);
+
+#define nfs3_trace_(req, fn, ...) \
+        do { if (otel_span_recording(&(req)->otel)) { fn(req, ## __VA_ARGS__); } } while (0)
+
+#define nfs3_trace_null(req)              nfs3_trace_(req, _nfs3_trace_null)
+#define nfs3_trace_getattr(req, args)     nfs3_trace_(req, _nfs3_trace_getattr, args)
+#define nfs3_trace_setattr(req, args)     nfs3_trace_(req, _nfs3_trace_setattr, args)
+#define nfs3_trace_lookup(req, args)      nfs3_trace_(req, _nfs3_trace_lookup, args)
+#define nfs3_trace_access(req, args)      nfs3_trace_(req, _nfs3_trace_access, args)
+#define nfs3_trace_readlink(req, args)    nfs3_trace_(req, _nfs3_trace_readlink, args)
+#define nfs3_trace_read(req, args)        nfs3_trace_(req, _nfs3_trace_read, args)
+#define nfs3_trace_write(req, args)       nfs3_trace_(req, _nfs3_trace_write, args)
+#define nfs3_trace_create(req, args)      nfs3_trace_(req, _nfs3_trace_create, args)
+#define nfs3_trace_mkdir(req, args)       nfs3_trace_(req, _nfs3_trace_mkdir, args)
+#define nfs3_trace_symlink(req, args)     nfs3_trace_(req, _nfs3_trace_symlink, args)
+#define nfs3_trace_mknod(req, args)       nfs3_trace_(req, _nfs3_trace_mknod, args)
+#define nfs3_trace_remove(req, args)      nfs3_trace_(req, _nfs3_trace_remove, args)
+#define nfs3_trace_rmdir(req, args)       nfs3_trace_(req, _nfs3_trace_rmdir, args)
+#define nfs3_trace_rename(req, args)      nfs3_trace_(req, _nfs3_trace_rename, args)
+#define nfs3_trace_link(req, args)        nfs3_trace_(req, _nfs3_trace_link, args)
+#define nfs3_trace_readdir(req, args)     nfs3_trace_(req, _nfs3_trace_readdir, args)
+#define nfs3_trace_readdirplus(req, args) nfs3_trace_(req, _nfs3_trace_readdirplus, args)
+#define nfs3_trace_fsstat(req, args)      nfs3_trace_(req, _nfs3_trace_fsstat, args)
+#define nfs3_trace_fsinfo(req, args)      nfs3_trace_(req, _nfs3_trace_fsinfo, args)
+#define nfs3_trace_pathconf(req, args)    nfs3_trace_(req, _nfs3_trace_pathconf, args)
+#define nfs3_trace_commit(req, args)      nfs3_trace_(req, _nfs3_trace_commit, args)

--- a/src/server/nfs/nfs4_proc_compound.c
+++ b/src/server/nfs/nfs4_proc_compound.c
@@ -94,6 +94,12 @@ chimera_nfs4_compound_process(
 
  again:
 
+    /* Close out the previous operation's span (if any).  Every continuation --
+     * the synchronous goto-again below and the async re-entry from
+     * compound_complete -- lands here with req->index already advanced, so this
+     * ends each op's span exactly once. */
+    nfs4_trace_op_end(req);
+
     /* SEQUENCE replay short-circuit: the SEQUENCE op detected a
      * retransmit on a CACHED slot.  Resend the cached COMPOUND body through
      * the current RPC request so the reply carries the retransmit's XID, then
@@ -155,6 +161,11 @@ chimera_nfs4_compound_process(
     resop = &req->res_compound.resarray[req->index];
 
     resop->resop = argop->argop;
+
+    /* Open a span for this operation (child of the compound span) and re-point
+     * the VFS parent at it so the op's VFS work nests under the op, not the
+     * whole compound. */
+    nfs4_trace_op_begin(req, argop);
 
     thread->active = 1;
 

--- a/src/server/nfs/nfs4_proc_compound.c
+++ b/src/server/nfs/nfs4_proc_compound.c
@@ -10,6 +10,7 @@
 #include "evpl/evpl_rpc2_program.h"
 #include "evpl/evpl_bind.h"
 #include "nfs4_dump.h"
+#include "nfs4_trace.h"
 #include "nfs4_op_matrix.h"
 #include "nfs_drc_reply.h"
 
@@ -435,8 +436,6 @@ chimera_nfs4_compound(
 
     req = nfs_request_alloc(thread, conn, encoding);
 
-    otel_span_set_name(&req->otel, "nfs4.COMPOUND");
-
     chimera_nfs_map_cred_req(req, cred);
     req->export_id = 0;
 
@@ -467,6 +466,7 @@ chimera_nfs4_compound(
     }
 
     nfs4_dump_compound(req, args);
+    nfs4_trace_compound(req, args);
 
     /* The conn caches its bound nfs4_session in private_data.  The conn
      * holds a refcount on it (set up by nfs4_session_bind_conn) so the

--- a/src/server/nfs/nfs4_proc_compound.c
+++ b/src/server/nfs/nfs4_proc_compound.c
@@ -435,6 +435,8 @@ chimera_nfs4_compound(
 
     req = nfs_request_alloc(thread, conn, encoding);
 
+    otel_span_set_name(&req->otel, "nfs4.COMPOUND");
+
     chimera_nfs_map_cred_req(req, cred);
     req->export_id = 0;
 

--- a/src/server/nfs/nfs4_proc_null.c
+++ b/src/server/nfs/nfs4_proc_null.c
@@ -1,9 +1,10 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
 #include "nfs4_procs.h"
 #include "nfs4_dump.h"
+#include "nfs4_trace.h"
 void
 chimera_nfs4_null(
     struct evpl               *evpl,

--- a/src/server/nfs/nfs4_trace.c
+++ b/src/server/nfs/nfs4_trace.c
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * NFSv4 span tracing (see nfs4_trace.h).  Runs only for a recording span.
+ */
+
+#include <string.h>
+#include <stdio.h>
+
+#include "nfs4_trace.h"
+#include "common/format.h"
+
+static const char *
+nfs4_op_name(int op)
+{
+    switch (op) {
+        case OP_ACCESS:              return "ACCESS";
+        case OP_CLOSE:               return "CLOSE";
+        case OP_COMMIT:              return "COMMIT";
+        case OP_CREATE:              return "CREATE";
+        case OP_DELEGPURGE:          return "DELEGPURGE";
+        case OP_DELEGRETURN:         return "DELEGRETURN";
+        case OP_GETATTR:             return "GETATTR";
+        case OP_GETFH:               return "GETFH";
+        case OP_LINK:                return "LINK";
+        case OP_LOCK:                return "LOCK";
+        case OP_LOCKT:               return "LOCKT";
+        case OP_LOCKU:               return "LOCKU";
+        case OP_LOOKUP:              return "LOOKUP";
+        case OP_LOOKUPP:             return "LOOKUPP";
+        case OP_NVERIFY:             return "NVERIFY";
+        case OP_OPEN:                return "OPEN";
+        case OP_OPENATTR:            return "OPENATTR";
+        case OP_OPEN_CONFIRM:        return "OPEN_CONFIRM";
+        case OP_OPEN_DOWNGRADE:      return "OPEN_DOWNGRADE";
+        case OP_PUTFH:               return "PUTFH";
+        case OP_PUTPUBFH:            return "PUTPUBFH";
+        case OP_PUTROOTFH:           return "PUTROOTFH";
+        case OP_READ:                return "READ";
+        case OP_READDIR:             return "READDIR";
+        case OP_READLINK:            return "READLINK";
+        case OP_REMOVE:              return "REMOVE";
+        case OP_RENAME:              return "RENAME";
+        case OP_RENEW:               return "RENEW";
+        case OP_RESTOREFH:           return "RESTOREFH";
+        case OP_SAVEFH:              return "SAVEFH";
+        case OP_SECINFO:             return "SECINFO";
+        case OP_SETATTR:             return "SETATTR";
+        case OP_SETCLIENTID:         return "SETCLIENTID";
+        case OP_SETCLIENTID_CONFIRM: return "SETCLIENTID_CONFIRM";
+        case OP_VERIFY:              return "VERIFY";
+        case OP_WRITE:               return "WRITE";
+        case OP_EXCHANGE_ID:         return "EXCHANGE_ID";
+        case OP_CREATE_SESSION:      return "CREATE_SESSION";
+        case OP_DESTROY_SESSION:     return "DESTROY_SESSION";
+        case OP_SEQUENCE:            return "SEQUENCE";
+        case OP_GETDEVICEINFO:       return "GETDEVICEINFO";
+        case OP_LAYOUTGET:           return "LAYOUTGET";
+        case OP_LAYOUTCOMMIT:        return "LAYOUTCOMMIT";
+        case OP_LAYOUTRETURN:        return "LAYOUTRETURN";
+        case OP_DESTROY_CLIENTID:    return "DESTROY_CLIENTID";
+        case OP_RECLAIM_COMPLETE:    return "RECLAIM_COMPLETE";
+        default:                     return "OP";
+    } /* switch */
+} /* nfs4_op_name */
+
+void
+_nfs4_trace_null(struct nfs_request *req)
+{
+    otel_span_set_name(&req->otel, "nfs4.null");
+} /* _nfs4_trace_null */
+
+void
+_nfs4_trace_compound(
+    struct nfs_request   *req,
+    struct COMPOUND4args *args)
+{
+    char ops[256];
+    int  off = 0;
+    int  i;
+
+    otel_span_set_name(&req->otel, "nfs4.COMPOUND");
+    otel_span_attr_u64(&req->otel, "nfs4.numops", (uint64_t) args->num_argarray);
+
+    /* Join the op names ("PUTFH,GETATTR,...") and attach the first PUTFH FH. */
+    ops[0] = '\0';
+    for (i = 0; i < args->num_argarray; i++) {
+        int op = args->argarray[i].argop;
+
+        if (off < (int) sizeof(ops) - 1) {
+            off += snprintf(ops + off, sizeof(ops) - off, "%s%s",
+                            off ? "," : "", nfs4_op_name(op));
+        }
+
+        if (op == OP_PUTFH) {
+            struct PUTFH4args *pf = &args->argarray[i].opputfh;
+            char               hex[2 * 128 + 1];
+
+            if (pf->object.len > 0) {
+                format_hex(hex, sizeof(hex), pf->object.data, pf->object.len);
+                otel_span_attr_str(&req->otel, "nfs.fh", hex);
+            }
+        }
+    }
+
+    if (off > (int) sizeof(ops) - 1) {
+        off = (int) sizeof(ops) - 1;
+    }
+    otel_span_attr_strn(&req->otel, "nfs4.ops", ops, (size_t) off);
+} /* _nfs4_trace_compound */

--- a/src/server/nfs/nfs4_trace.c
+++ b/src/server/nfs/nfs4_trace.c
@@ -6,10 +6,13 @@
  * NFSv4 span tracing (see nfs4_trace.h).  Runs only for a recording span.
  */
 
+#include "nfs4_trace.h"
+
+#if CHIMERA_HAVE_OTEL
+
 #include <string.h>
 #include <stdio.h>
 
-#include "nfs4_trace.h"
 #include "common/format.h"
 
 static const char *
@@ -170,3 +173,5 @@ _nfs4_trace_compound(
     }
     otel_span_attr_strn(&req->otel, "nfs4.ops", ops, (size_t) off);
 } /* _nfs4_trace_compound */
+
+#endif /* CHIMERA_HAVE_OTEL */

--- a/src/server/nfs/nfs4_trace.c
+++ b/src/server/nfs/nfs4_trace.c
@@ -127,6 +127,43 @@ _nfs4_trace_op_begin(
             otel_span_attr_u64(s, "nfs.offset", argop->opwrite.offset);
             otel_span_attr_u64(s, "nfs.count", argop->opwrite.data.length);
             break;
+        case OP_COMMIT:
+            otel_span_attr_u64(s, "nfs.offset", argop->opcommit.offset);
+            otel_span_attr_u64(s, "nfs.count", argop->opcommit.count);
+            break;
+        case OP_LOOKUP:
+            otel_span_attr_strn(s, "nfs.name", argop->oplookup.objname.data,
+                                argop->oplookup.objname.len);
+            break;
+        case OP_CREATE:
+            otel_span_attr_strn(s, "nfs.name", argop->opcreate.objname.data,
+                                argop->opcreate.objname.len);
+            break;
+        case OP_REMOVE:
+            otel_span_attr_strn(s, "nfs.name", argop->opremove.target.data,
+                                argop->opremove.target.len);
+            break;
+        case OP_LINK:
+            otel_span_attr_strn(s, "nfs.name", argop->oplink.newname.data,
+                                argop->oplink.newname.len);
+            break;
+        case OP_RENAME:
+            otel_span_attr_strn(s, "nfs.name", argop->oprename.oldname.data,
+                                argop->oprename.oldname.len);
+            otel_span_attr_strn(s, "nfs.new_name", argop->oprename.newname.data,
+                                argop->oprename.newname.len);
+            break;
+        case OP_SECINFO:
+            otel_span_attr_strn(s, "nfs.name", argop->opsecinfo.name.data,
+                                argop->opsecinfo.name.len);
+            break;
+        case OP_OPEN:
+            /* The filename is only carried for CLAIM_NULL / CLAIM_FH opens. */
+            if (argop->opopen.claim.file.len > 0) {
+                otel_span_attr_strn(s, "nfs.name", argop->opopen.claim.file.data,
+                                    argop->opopen.claim.file.len);
+            }
+            break;
         default:
             break;
     } /* switch */

--- a/src/server/nfs/nfs4_trace.c
+++ b/src/server/nfs/nfs4_trace.c
@@ -52,16 +52,35 @@ nfs4_op_name(int op)
         case OP_SETCLIENTID_CONFIRM: return "SETCLIENTID_CONFIRM";
         case OP_VERIFY:              return "VERIFY";
         case OP_WRITE:               return "WRITE";
+        case OP_RELEASE_LOCKOWNER:   return "RELEASE_LOCKOWNER";
+        case OP_BACKCHANNEL_CTL:     return "BACKCHANNEL_CTL";
+        case OP_BIND_CONN_TO_SESSION: return "BIND_CONN_TO_SESSION";
         case OP_EXCHANGE_ID:         return "EXCHANGE_ID";
         case OP_CREATE_SESSION:      return "CREATE_SESSION";
         case OP_DESTROY_SESSION:     return "DESTROY_SESSION";
-        case OP_SEQUENCE:            return "SEQUENCE";
+        case OP_FREE_STATEID:        return "FREE_STATEID";
         case OP_GETDEVICEINFO:       return "GETDEVICEINFO";
+        case OP_GETDEVICELIST:       return "GETDEVICELIST";
         case OP_LAYOUTGET:           return "LAYOUTGET";
         case OP_LAYOUTCOMMIT:        return "LAYOUTCOMMIT";
         case OP_LAYOUTRETURN:        return "LAYOUTRETURN";
+        case OP_LAYOUTSTATS:         return "LAYOUTSTATS";
+        case OP_LAYOUTERROR:         return "LAYOUTERROR";
+        case OP_SECINFO_NO_NAME:     return "SECINFO_NO_NAME";
+        case OP_GET_DIR_DELEGATION:  return "GET_DIR_DELEGATION";
+        case OP_WANT_DELEGATION:     return "WANT_DELEGATION";
+        case OP_SEQUENCE:            return "SEQUENCE";
+        case OP_SET_SSV:             return "SET_SSV";
+        case OP_TEST_STATEID:        return "TEST_STATEID";
         case OP_DESTROY_CLIENTID:    return "DESTROY_CLIENTID";
         case OP_RECLAIM_COMPLETE:    return "RECLAIM_COMPLETE";
+        case OP_ALLOCATE:            return "ALLOCATE";
+        case OP_DEALLOCATE:          return "DEALLOCATE";
+        case OP_SEEK:                return "SEEK";
+        case OP_GETXATTR:            return "GETXATTR";
+        case OP_SETXATTR:            return "SETXATTR";
+        case OP_LISTXATTRS:          return "LISTXATTRS";
+        case OP_REMOVEXATTR:         return "REMOVEXATTR";
         default:                     return "OP";
     } /* switch */
 } /* nfs4_op_name */
@@ -71,6 +90,47 @@ _nfs4_trace_null(struct nfs_request *req)
 {
     otel_span_set_name(&req->otel, "nfs4.null");
 } /* _nfs4_trace_null */
+
+/* Begin a span for one operation inside the compound, as a child of the compound
+ * (aggregate) span.  Names it "nfs4.<OP>", attaches a few high-value attributes,
+ * and re-points the VFS parent at this op span so the VFS work it issues nests
+ * under the operation rather than the whole compound. */
+void
+_nfs4_trace_op_begin(
+    struct nfs_request *req,
+    struct nfs_argop4  *argop)
+{
+    struct otel_span *s = &req->op_otel;
+    char              name[32];
+
+    snprintf(name, sizeof(name), "nfs4.%s", nfs4_op_name(argop->argop));
+    otel_span_start_child(s, name, OTEL_SPAN_INTERNAL, &req->otel);
+    otel_span_attr_u64(s, "nfs4.op", (uint64_t) argop->argop);
+
+    switch (argop->argop) {
+        case OP_PUTFH:
+            if (argop->opputfh.object.len > 0) {
+                char hex[2 * 128 + 1];
+                format_hex(hex, sizeof(hex), argop->opputfh.object.data,
+                           argop->opputfh.object.len);
+                otel_span_attr_str(s, "nfs.fh", hex);
+            }
+            break;
+        case OP_READ:
+            otel_span_attr_u64(s, "nfs.offset", argop->opread.offset);
+            otel_span_attr_u64(s, "nfs.count", argop->opread.count);
+            break;
+        case OP_WRITE:
+            otel_span_attr_u64(s, "nfs.offset", argop->opwrite.offset);
+            otel_span_attr_u64(s, "nfs.count", argop->opwrite.data.length);
+            break;
+        default:
+            break;
+    } /* switch */
+
+    req->thread->vfs_thread->otel_parent = s;
+    req->op_span_active                  = 1;
+} /* _nfs4_trace_op_begin */
 
 void
 _nfs4_trace_compound(

--- a/src/server/nfs/nfs4_trace.h
+++ b/src/server/nfs/nfs4_trace.h
@@ -16,6 +16,8 @@
 #include "nfs_common.h"
 #include "nfs4_xdr.h"
 
+#if CHIMERA_HAVE_OTEL
+
 void _nfs4_trace_null(
     struct nfs_request *req);
 void _nfs4_trace_compound(
@@ -40,3 +42,12 @@ void _nfs4_trace_op_begin(
 #define nfs4_trace_op_end(req) \
         do { if ((req)->op_span_active) { \
                  otel_span_end(&(req)->op_otel); (req)->op_span_active = 0; } } while (0)
+
+#else  /* !CHIMERA_HAVE_OTEL : tracing compiled out -- calls vanish entirely */
+
+#define nfs4_trace_null(req)            do { } while (0)
+#define nfs4_trace_compound(req, args)  do { } while (0)
+#define nfs4_trace_op_begin(req, argop) do { } while (0)
+#define nfs4_trace_op_end(req)          do { } while (0)
+
+#endif /* CHIMERA_HAVE_OTEL */

--- a/src/server/nfs/nfs4_trace.h
+++ b/src/server/nfs/nfs4_trace.h
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * NFSv4 span tracing, modeled on nfs4_dump.h.  Called next to nfs4_dump_*; the
+ * macro short-circuits unless the request's span is being recorded.  A COMPOUND
+ * is a single span named "nfs4.COMPOUND" annotated with the op sequence and the
+ * first PUTFH file handle (hex); the individual ops surface as the child VFS
+ * spans they issue.
+ */
+
+#pragma once
+
+#include "nfs_common.h"
+#include "nfs4_xdr.h"
+
+void _nfs4_trace_null(
+    struct nfs_request *req);
+void _nfs4_trace_compound(
+    struct nfs_request   *req,
+    struct COMPOUND4args *args);
+
+#define nfs4_trace_null(req) \
+        do { if (otel_span_recording(&(req)->otel)) { _nfs4_trace_null(req); } } while (0)
+#define nfs4_trace_compound(req, args) \
+        do { if (otel_span_recording(&(req)->otel)) { _nfs4_trace_compound(req, args); } } while (0)

--- a/src/server/nfs/nfs4_trace.h
+++ b/src/server/nfs/nfs4_trace.h
@@ -5,9 +5,10 @@
 /*
  * NFSv4 span tracing, modeled on nfs4_dump.h.  Called next to nfs4_dump_*; the
  * macro short-circuits unless the request's span is being recorded.  A COMPOUND
- * is a single span named "nfs4.COMPOUND" annotated with the op sequence and the
- * first PUTFH file handle (hex); the individual ops surface as the child VFS
- * spans they issue.
+ * is an aggregate span named "nfs4.COMPOUND" annotated with the op sequence and
+ * the first PUTFH file handle (hex).  Each operation inside the compound gets its
+ * own child span ("nfs4.<OP>", via nfs4_trace_op_begin/op_end), and the VFS work
+ * an operation issues nests under that operation's span.
  */
 
 #pragma once
@@ -20,8 +21,22 @@ void _nfs4_trace_null(
 void _nfs4_trace_compound(
     struct nfs_request   *req,
     struct COMPOUND4args *args);
+void _nfs4_trace_op_begin(
+    struct nfs_request *req,
+    struct nfs_argop4  *argop);
 
 #define nfs4_trace_null(req) \
         do { if (otel_span_recording(&(req)->otel)) { _nfs4_trace_null(req); } } while (0)
 #define nfs4_trace_compound(req, args) \
         do { if (otel_span_recording(&(req)->otel)) { _nfs4_trace_compound(req, args); } } while (0)
+
+/* Begin a per-operation span (child of the compound span); see _nfs4_trace_op_begin. */
+#define nfs4_trace_op_begin(req, argop) \
+        do { if (otel_span_recording(&(req)->otel)) { _nfs4_trace_op_begin(req, argop); } } while (0)
+
+/* End the current per-operation span if one is in flight.  Gated on the active
+ * flag (not the recording bit) so it balances op_begin exactly and never
+ * double-ends the reused span slot. */
+#define nfs4_trace_op_end(req) \
+        do { if ((req)->op_span_active) { \
+                 otel_span_end(&(req)->op_otel); (req)->op_span_active = 0; } } while (0)

--- a/src/server/nfs/nfs_common.h
+++ b/src/server/nfs/nfs_common.h
@@ -75,7 +75,9 @@ struct nfs_nfs4_readdir_cursor {
 struct nfs_request {
     struct chimera_server_nfs_thread *thread;
     struct nfs4_session              *session;
-    struct otel_span                  otel;
+    struct otel_span                  otel;        /* compound (aggregate) span */
+    struct otel_span                  op_otel;     /* current op span, child of otel */
+    uint8_t                           op_span_active;
     struct chimera_vfs_cred           cred;
     /* The caller's credential as mapped from the RPC auth, before any export
      * squash.  req->cred is recomputed from this each time a file handle is

--- a/src/server/nfs/nfs_common.h
+++ b/src/server/nfs/nfs_common.h
@@ -10,6 +10,7 @@
 #include "nfs_fh_wrap.h"
 #include "evpl/evpl_rpc2.h"
 #include "portmap_xdr.h"
+#include "vfs/vfs.h"
 #include "vfs/vfs_cred.h"
 #include "nfs_gss.h"
 #include "nfs_mount_xdr.h"
@@ -74,6 +75,7 @@ struct nfs_nfs4_readdir_cursor {
 struct nfs_request {
     struct chimera_server_nfs_thread *thread;
     struct nfs4_session              *session;
+    struct otel_span                  otel;
     struct chimera_vfs_cred           cred;
     /* The caller's credential as mapped from the RPC auth, before any export
      * squash.  req->cred is recomputed from this each time a file handle is
@@ -441,6 +443,12 @@ nfs_request_alloc(
     req->replay_slot_id = 0;
     req->replay_action  = NFS4_REPLAY_ACTION_NONE;
 
+    /* Root span for this NFS request (a single NFSv3 op, or a whole NFSv4
+     * COMPOUND).  Parent the VFS ops it issues under it; propagation in
+     * chimera_vfs_complete keeps the linkage across the request's async ops. */
+    otel_span_start(&req->otel, "nfs", OTEL_SPAN_SERVER);
+    thread->vfs_thread->otel_parent = &req->otel;
+
     thread->active_requests++;
 
     return req;
@@ -451,6 +459,11 @@ nfs_request_free(
     struct chimera_server_nfs_thread *thread,
     struct nfs_request               *req)
 {
+    /* End the request span and drop the trace parent so a later VFS op cannot
+     * attach to this (now recycled) request's span. */
+    otel_span_end(&req->otel);
+    thread->vfs_thread->otel_parent = NULL;
+
     thread->active_requests--;
     LL_PREPEND(thread->free_requests, req);
 } /* nfs_request_free */

--- a/src/server/s3/s3.c
+++ b/src/server/s3/s3.c
@@ -105,6 +105,19 @@ chimera_s3_parse_range(
     return 0;
 } /* chimera_s3_parse_range */
 
+static const char *
+chimera_s3_op_name(enum evpl_http_request_type t)
+{
+    switch (t) {
+        case EVPL_HTTP_REQUEST_TYPE_GET:    return "s3.GET";
+        case EVPL_HTTP_REQUEST_TYPE_HEAD:   return "s3.HEAD";
+        case EVPL_HTTP_REQUEST_TYPE_POST:   return "s3.POST";
+        case EVPL_HTTP_REQUEST_TYPE_PUT:    return "s3.PUT";
+        case EVPL_HTTP_REQUEST_TYPE_DELETE: return "s3.DELETE";
+        default:                            return "s3.request";
+    } /* switch */
+} /* chimera_s3_op_name */
+
 static inline struct chimera_s3_request *
 chimera_s3_request_alloc(struct chimera_server_s3_thread *thread)
 {
@@ -335,6 +348,21 @@ s3_server_notify(
 
             s3_request->elapsed = chimera_get_elapsed_ns(&s3_request->end_time, &s3_request->start_time);
 
+            /* Annotate and end the S3 span (numeric attrs only -- request memory
+             * is freed below, before the span is drained). */
+            otel_span_attr_i64(&s3_request->otel, "s3.status", s3_request->status);
+            if (s3_request->file_length > 0) {
+                otel_span_attr_u64(&s3_request->otel, "s3.offset",
+                                   (uint64_t) s3_request->file_offset);
+                otel_span_attr_u64(&s3_request->otel, "s3.length",
+                                   (uint64_t) s3_request->file_length);
+            }
+            if (s3_request->status != CHIMERA_S3_STATUS_OK) {
+                otel_span_set_status(&s3_request->otel, OTEL_STATUS_ERROR, NULL);
+            }
+            otel_span_end(&s3_request->otel);
+            thread->vfs->otel_parent = NULL;
+
             chimera_s3_dump_response(s3_request);
 
             chimera_s3_tagging_request_cleanup(s3_request);
@@ -479,6 +507,11 @@ s3_server_dispatch(
     s3_request = chimera_s3_request_alloc(thread);
 
     clock_gettime(CLOCK_MONOTONIC, &s3_request->start_time);
+
+    /* Root span for this S3 operation; VFS ops it issues become children. */
+    otel_span_start(&s3_request->otel,
+                    chimera_s3_op_name(evpl_http_request_type(request)),
+                    OTEL_SPAN_SERVER);
 
     s3_request->status             = CHIMERA_S3_STATUS_OK;
     s3_request->vfs_state          = CHIMERA_S3_VFS_STATE_INIT;
@@ -974,6 +1007,10 @@ s3_server_dispatch(
                                       "", 0, "", 0, "", 0, "", 0, "", 0);
             }
         }
+
+        /* Parent the bucket lookup (and, via propagation, every VFS op this
+         * request issues) under the S3 span. */
+        thread->vfs->otel_parent = &s3_request->otel;
 
         chimera_vfs_lookup(thread->vfs,
                            &thread->shared->cred,

--- a/src/server/s3/s3.c
+++ b/src/server/s3/s3.c
@@ -348,9 +348,19 @@ s3_server_notify(
 
             s3_request->elapsed = chimera_get_elapsed_ns(&s3_request->end_time, &s3_request->start_time);
 
-            /* Annotate and end the S3 span (numeric attrs only -- request memory
-             * is freed below, before the span is drained). */
+            /* Annotate and end the S3 span.  Strings are copied into the span's
+             * arena here, so they are safe even though the request is freed
+             * below before the span is drained. */
             otel_span_attr_i64(&s3_request->otel, "s3.status", s3_request->status);
+            if (s3_request->bucket_name && s3_request->bucket_namelen > 0) {
+                otel_span_attr_strn(&s3_request->otel, "s3.bucket",
+                                    s3_request->bucket_name,
+                                    s3_request->bucket_namelen);
+            }
+            if (s3_request->path && s3_request->path_len > 0) {
+                otel_span_attr_strn(&s3_request->otel, "s3.key",
+                                    s3_request->path, s3_request->path_len);
+            }
             if (s3_request->file_length > 0) {
                 otel_span_attr_u64(&s3_request->otel, "s3.offset",
                                    (uint64_t) s3_request->file_offset);

--- a/src/server/s3/s3_internal.h
+++ b/src/server/s3/s3_internal.h
@@ -125,6 +125,7 @@ struct chimera_s3_request {
     struct chimera_vfs_open_handle  *file_handle;
     struct timespec                  start_time;
     struct timespec                  end_time;
+    struct otel_span                 otel;
     struct chimera_s3_request       *prev;
     struct chimera_s3_request       *next;
     struct chimera_vfs_attrs         set_attr;

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -28,6 +28,7 @@
 #include "vfs/vfs_cred.h"
 #include "vfs/vfs_release.h"
 #include "common/macros.h"
+#include "common/chimera_tracing.h"
 #include "server/server.h"
 #include "smb/smb2.h"
 #include "rest/rest.h"
@@ -1337,6 +1338,10 @@ chimera_server_thread_init(
 
     thread->vfs_thread = chimera_vfs_thread_init(evpl, server->vfs);
 
+    /* This core thread produces spans (starts/ends them); register it with the
+     * tracer (no-op unless tracing is active). */
+    chimera_tracing_thread_register();
+
     for (int i = 0; i < server->num_protocols; i++) {
         thread->protocol_private[i] = server->protocols[i]->thread_init(evpl,
                                                                         thread->vfs_thread,
@@ -2314,6 +2319,11 @@ chimera_server_thread_shutdown(
     chimera_vfs_thread_drain(thread->vfs_thread);
 
     evpl_remove_timer(evpl, &thread->watchdog);
+
+    /* Unregister from the tracer (drains this thread's remaining spans) before
+     * tearing down its VFS thread. */
+    chimera_tracing_thread_unregister();
+
     chimera_vfs_thread_destroy(thread->vfs_thread);
     free(thread);
 } /* chimera_server_thread_shutdown */

--- a/src/server/smb/CMakeLists.txt
+++ b/src/server/smb/CMakeLists.txt
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: LGPL-2.1-only
 
 add_library(chimera_smb SHARED
-    smb.c smb_proc_negotiate.c smb_proc_session_setup.c smb_dump.c
+    smb.c smb_proc_negotiate.c smb_proc_session_setup.c smb_dump.c smb_trace.c
     smb_proc_tree_connect.c smb_proc_create.c smb_proc_close.c
     smb_proc_set_info.c smb_proc_tree_disconnect.c smb_proc_logoff.c
     smb_proc_write.c smb_proc_read.c smb_proc_query_info.c

--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -1085,12 +1085,21 @@ chimera_smb_compound_advance(struct chimera_smb_compound *compound)
                          "compound_advance: complete_requests = %u num_requests = %u", compound->complete_requests,
                          compound->num_requests);
 
+    /* Close out the previous request's span; advance re-enters here once per
+     * completed request (via chimera_smb_complete_request), so this ends each
+     * request's span exactly once. */
+    smb_trace_op_end(compound);
+
     if (compound->complete_requests >= compound->num_requests) {
         chimera_smb_compound_reply(compound);
         return;
     }
 
     request = compound->requests[compound->complete_requests];
+
+    /* Open a span for this request (child of the aggregate span) and re-point
+     * the VFS parent at it so the request's VFS work nests under it. */
+    smb_trace_op_begin(compound, request);
 
     if (request->smb2_hdr.flags & SMB2_FLAGS_RELATED_OPERATIONS) {
         /* A related request inherits the session and tree from the preceding

--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -30,6 +30,7 @@
 #include "smb_procs.h"
 #include "smb_notify.h"
 #include "smb_dump.h"
+#include "smb_trace.h"
 #include "smb_signing.h"
 #include "smb_encrypt.h"
 #include "smb_compress.h"
@@ -2000,6 +2001,7 @@ chimera_smb_server_handle_smb2(
     }
 
     smb_dump_compound_request(compound);
+    smb_trace_compound_request(compound);
 
     /* SMB 3.1.1 preauth integrity: fold the raw NEGOTIATE / SESSION_SETUP
      * request into the running hash before dispatch, so the SESSION_SETUP
@@ -2208,6 +2210,7 @@ chimera_smb_server_handle_smb1(
     compound->requests[compound->num_requests++] = request;
 
     smb_dump_compound_request(compound);
+    smb_trace_compound_request(compound);
 
     /* Balance the decrement in chimera_smb_compound_reply (see the SMB2 path). */
     pthread_mutex_lock(&thread->lease_break_lock);

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -1095,7 +1095,9 @@ struct chimera_smb_compound {
     /* conn->generation at compound creation; see the conn field. */
     uint64_t                           conn_generation;
     struct chimera_smb_compound       *next;
-    struct otel_span                   otel;
+    struct otel_span                   otel;        /* compound (aggregate) span */
+    struct otel_span                   op_otel;     /* current request span, child of otel */
+    int                                op_span_active;
     struct chimera_smb_request        *requests[CHIMERA_SMB_COMPOUND_MAX_REQUESTS];
 };
 

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -28,6 +28,7 @@
 #include "smb_gssapi.h"
 #include "smb_sharemode.h"
 #include "smb_notify.h"
+#include "vfs/vfs.h"
 #include "vfs/vfs_acl.h"
 #include "vfs/vfs_idmap.h"
 #include "vfs/vfs_release.h"
@@ -1094,6 +1095,7 @@ struct chimera_smb_compound {
     /* conn->generation at compound creation; see the conn field. */
     uint64_t                           conn_generation;
     struct chimera_smb_compound       *next;
+    struct otel_span                   otel;
     struct chimera_smb_request        *requests[CHIMERA_SMB_COMPOUND_MAX_REQUESTS];
 };
 
@@ -2798,6 +2800,11 @@ chimera_smb_compound_alloc(struct chimera_server_smb_thread *thread)
         compound = calloc(1, sizeof(*compound));
     }
 
+    /* Root span for this SMB2 compound; parent the VFS ops its requests issue
+     * (propagation in chimera_vfs_complete keeps the linkage across async ops). */
+    otel_span_start(&compound->otel, "smb2", OTEL_SPAN_SERVER);
+    thread->vfs_thread->otel_parent = &compound->otel;
+
     return compound;
 } /* chimera_smb_compound_alloc */
 
@@ -2806,6 +2813,9 @@ chimera_smb_compound_free(
     struct chimera_server_smb_thread *thread,
     struct chimera_smb_compound      *compound)
 {
+    otel_span_end(&compound->otel);
+    thread->vfs_thread->otel_parent = NULL;
+
     for (int i = 0; i < compound->num_requests; i++) {
         chimera_smb_request_free(thread, compound->requests[i]);
     }

--- a/src/server/smb/smb_trace.c
+++ b/src/server/smb/smb_trace.c
@@ -6,10 +6,13 @@
  * SMB2 span tracing (see smb_trace.h).  Runs only for a recording span.
  */
 
+#include "smb_trace.h"
+
+#if CHIMERA_HAVE_OTEL
+
 #include <stdio.h>
 #include <string.h>
 
-#include "smb_trace.h"
 #include "common/format.h"
 
 static const char *
@@ -126,3 +129,5 @@ _smb_trace_op_begin(
     compound->thread->vfs_thread->otel_parent = s;
     compound->op_span_active                  = 1;
 } /* _smb_trace_op_begin */
+
+#endif /* CHIMERA_HAVE_OTEL */

--- a/src/server/smb/smb_trace.c
+++ b/src/server/smb/smb_trace.c
@@ -39,36 +39,32 @@ smb_trace_command_name(uint32_t command)
     } /* switch */
 } /* smb_trace_command_name */
 
-/* Encode an SMB FileId (persistent + volatile, 16 bytes) as hex. */
+/* Encode an SMB FileId (persistent + volatile, 16 bytes) as hex onto a span. */
 static void
 smb_trace_file_id(
-    struct chimera_smb_compound      *compound,
+    struct otel_span                 *s,
     const struct chimera_smb_file_id *file_id)
 {
     char hex[2 * sizeof(*file_id) + 1];
 
     format_hex(hex, sizeof(hex), file_id, (int) sizeof(*file_id));
-    otel_span_attr_str(&compound->otel, "smb.file_id", hex);
+    otel_span_attr_str(s, "smb.file_id", hex);
 } /* smb_trace_file_id */
 
 void
 _smb_trace_compound_request(struct chimera_smb_compound *compound)
 {
-    struct chimera_smb_request *r0;
-    char                        name[48];
-    char                        ops[256];
-    int                         off = 0;
-    int                         i;
+    char ops[256];
+    int  off = 0;
+    int  i;
 
     if (compound->num_requests == 0) {
         return;
     }
 
-    r0 = compound->requests[0];
-
-    snprintf(name, sizeof(name), "smb2.%s",
-             smb_trace_command_name(r0->smb2_hdr.command));
-    otel_span_set_name(&compound->otel, name);
+    /* Aggregate span for the whole compound PDU; the individual requests are
+     * its child spans (see _smb_trace_op_begin). */
+    otel_span_set_name(&compound->otel, "smb2.COMPOUND");
     otel_span_attr_u64(&compound->otel, "smb.numreq",
                        (uint64_t) compound->num_requests);
 
@@ -85,29 +81,48 @@ _smb_trace_compound_request(struct chimera_smb_compound *compound)
         off = (int) sizeof(ops) - 1;
     }
     otel_span_attr_strn(&compound->otel, "smb.ops", ops, (size_t) off);
+} /* _smb_trace_compound_request */
 
-    /* Per-command attributes for the leading request. */
-    switch (r0->smb2_hdr.command) {
+/* Begin a span for one request inside the compound, as a child of the aggregate
+ * span.  Names it "smb2.<Command>", attaches the command's key attributes, and
+ * re-points the VFS parent at this span so the request's VFS work nests under it
+ * rather than the whole compound. */
+void
+_smb_trace_op_begin(
+    struct chimera_smb_compound *compound,
+    struct chimera_smb_request  *request)
+{
+    struct otel_span *s = &compound->op_otel;
+    char              name[48];
+
+    snprintf(name, sizeof(name), "smb2.%s",
+             smb_trace_command_name(request->smb2_hdr.command));
+    otel_span_start_child(s, name, OTEL_SPAN_INTERNAL, &compound->otel);
+
+    switch (request->smb2_hdr.command) {
         case SMB2_CREATE:
-            if (r0->create.name && r0->create.name_len > 0) {
-                otel_span_attr_strn(&compound->otel, "smb.name",
-                                    r0->create.name, r0->create.name_len);
+            if (request->create.name && request->create.name_len > 0) {
+                otel_span_attr_strn(s, "smb.name",
+                                    request->create.name, request->create.name_len);
             }
             break;
         case SMB2_READ:
-            otel_span_attr_u64(&compound->otel, "smb.offset", r0->read.offset);
-            otel_span_attr_u64(&compound->otel, "smb.length", r0->read.length);
-            smb_trace_file_id(compound, &r0->read.file_id);
+            otel_span_attr_u64(s, "smb.offset", request->read.offset);
+            otel_span_attr_u64(s, "smb.length", request->read.length);
+            smb_trace_file_id(s, &request->read.file_id);
             break;
         case SMB2_WRITE:
-            otel_span_attr_u64(&compound->otel, "smb.offset", r0->write.offset);
-            otel_span_attr_u64(&compound->otel, "smb.length", r0->write.length);
-            smb_trace_file_id(compound, &r0->write.file_id);
+            otel_span_attr_u64(s, "smb.offset", request->write.offset);
+            otel_span_attr_u64(s, "smb.length", request->write.length);
+            smb_trace_file_id(s, &request->write.file_id);
             break;
         case SMB2_CLOSE:
-            smb_trace_file_id(compound, &r0->close.file_id);
+            smb_trace_file_id(s, &request->close.file_id);
             break;
         default:
             break;
     } /* switch */
-} /* _smb_trace_compound_request */
+
+    compound->thread->vfs_thread->otel_parent = s;
+    compound->op_span_active                  = 1;
+} /* _smb_trace_op_begin */

--- a/src/server/smb/smb_trace.c
+++ b/src/server/smb/smb_trace.c
@@ -108,6 +108,8 @@ _smb_trace_op_begin(
                 otel_span_attr_strn(s, "smb.name",
                                     request->create.name, request->create.name_len);
             }
+            otel_span_attr_u64(s, "smb.desired_access", request->create.desired_access);
+            otel_span_attr_u64(s, "smb.disposition", request->create.create_disposition);
             break;
         case SMB2_READ:
             otel_span_attr_u64(s, "smb.offset", request->read.offset);
@@ -121,6 +123,33 @@ _smb_trace_op_begin(
             break;
         case SMB2_CLOSE:
             smb_trace_file_id(s, &request->close.file_id);
+            break;
+        case SMB2_FLUSH:
+            smb_trace_file_id(s, &request->flush.file_id);
+            break;
+        case SMB2_LOCK:
+            smb_trace_file_id(s, &request->lock.file_id);
+            break;
+        case SMB2_IOCTL:
+            otel_span_attr_u64(s, "smb.ctl_code", request->ioctl.ctl_code);
+            smb_trace_file_id(s, &request->ioctl.file_id);
+            break;
+        case SMB2_QUERY_INFO:
+            otel_span_attr_u64(s, "smb.info_type", request->query_info.info_type);
+            otel_span_attr_u64(s, "smb.info_class", request->query_info.info_class);
+            smb_trace_file_id(s, &request->query_info.file_id);
+            break;
+        case SMB2_SET_INFO:
+            otel_span_attr_u64(s, "smb.info_type", request->set_info.info_type);
+            otel_span_attr_u64(s, "smb.info_class", request->set_info.info_class);
+            smb_trace_file_id(s, &request->set_info.file_id);
+            break;
+        case SMB2_QUERY_DIRECTORY:
+            if (request->query_directory.pattern_length > 0) {
+                otel_span_attr_strn(s, "smb.pattern", request->query_directory.pattern,
+                                    request->query_directory.pattern_length);
+            }
+            smb_trace_file_id(s, &request->query_directory.file_id);
             break;
         default:
             break;

--- a/src/server/smb/smb_trace.c
+++ b/src/server/smb/smb_trace.c
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * SMB2 span tracing (see smb_trace.h).  Runs only for a recording span.
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "smb_trace.h"
+#include "common/format.h"
+
+static const char *
+smb_trace_command_name(uint32_t command)
+{
+    switch (command) {
+        case SMB2_NEGOTIATE:       return "Negotiate";
+        case SMB2_SESSION_SETUP:   return "SessionSetup";
+        case SMB2_LOGOFF:          return "Logoff";
+        case SMB2_TREE_CONNECT:    return "TreeConnect";
+        case SMB2_TREE_DISCONNECT: return "TreeDisconnect";
+        case SMB2_CREATE:          return "Create";
+        case SMB2_CLOSE:           return "Close";
+        case SMB2_FLUSH:           return "Flush";
+        case SMB2_READ:            return "Read";
+        case SMB2_WRITE:           return "Write";
+        case SMB2_LOCK:            return "Lock";
+        case SMB2_IOCTL:           return "Ioctl";
+        case SMB2_CANCEL:          return "Cancel";
+        case SMB2_ECHO:            return "Echo";
+        case SMB2_QUERY_DIRECTORY: return "QueryDirectory";
+        case SMB2_CHANGE_NOTIFY:   return "ChangeNotify";
+        case SMB2_QUERY_INFO:      return "QueryInfo";
+        case SMB2_SET_INFO:        return "SetInfo";
+        case SMB2_OPLOCK_BREAK:    return "OplockBreak";
+        default:                   return "Unknown";
+    } /* switch */
+} /* smb_trace_command_name */
+
+/* Encode an SMB FileId (persistent + volatile, 16 bytes) as hex. */
+static void
+smb_trace_file_id(
+    struct chimera_smb_compound      *compound,
+    const struct chimera_smb_file_id *file_id)
+{
+    char hex[2 * sizeof(*file_id) + 1];
+
+    format_hex(hex, sizeof(hex), file_id, (int) sizeof(*file_id));
+    otel_span_attr_str(&compound->otel, "smb.file_id", hex);
+} /* smb_trace_file_id */
+
+void
+_smb_trace_compound_request(struct chimera_smb_compound *compound)
+{
+    struct chimera_smb_request *r0;
+    char                        name[48];
+    char                        ops[256];
+    int                         off = 0;
+    int                         i;
+
+    if (compound->num_requests == 0) {
+        return;
+    }
+
+    r0 = compound->requests[0];
+
+    snprintf(name, sizeof(name), "smb2.%s",
+             smb_trace_command_name(r0->smb2_hdr.command));
+    otel_span_set_name(&compound->otel, name);
+    otel_span_attr_u64(&compound->otel, "smb.numreq",
+                       (uint64_t) compound->num_requests);
+
+    /* Command sequence, e.g. "Create,QueryInfo,Close". */
+    ops[0] = '\0';
+    for (i = 0; i < compound->num_requests; i++) {
+        if (off < (int) sizeof(ops) - 1) {
+            off += snprintf(ops + off, sizeof(ops) - off, "%s%s",
+                            off ? "," : "",
+                            smb_trace_command_name(compound->requests[i]->smb2_hdr.command));
+        }
+    }
+    if (off > (int) sizeof(ops) - 1) {
+        off = (int) sizeof(ops) - 1;
+    }
+    otel_span_attr_strn(&compound->otel, "smb.ops", ops, (size_t) off);
+
+    /* Per-command attributes for the leading request. */
+    switch (r0->smb2_hdr.command) {
+        case SMB2_CREATE:
+            if (r0->create.name && r0->create.name_len > 0) {
+                otel_span_attr_strn(&compound->otel, "smb.name",
+                                    r0->create.name, r0->create.name_len);
+            }
+            break;
+        case SMB2_READ:
+            otel_span_attr_u64(&compound->otel, "smb.offset", r0->read.offset);
+            otel_span_attr_u64(&compound->otel, "smb.length", r0->read.length);
+            smb_trace_file_id(compound, &r0->read.file_id);
+            break;
+        case SMB2_WRITE:
+            otel_span_attr_u64(&compound->otel, "smb.offset", r0->write.offset);
+            otel_span_attr_u64(&compound->otel, "smb.length", r0->write.length);
+            smb_trace_file_id(compound, &r0->write.file_id);
+            break;
+        case SMB2_CLOSE:
+            smb_trace_file_id(compound, &r0->close.file_id);
+            break;
+        default:
+            break;
+    } /* switch */
+} /* _smb_trace_compound_request */

--- a/src/server/smb/smb_trace.h
+++ b/src/server/smb/smb_trace.h
@@ -16,6 +16,8 @@
 
 #include "smb_internal.h"
 
+#if CHIMERA_HAVE_OTEL
+
 void _smb_trace_compound_request(
     struct chimera_smb_compound *compound);
 void _smb_trace_op_begin(
@@ -38,3 +40,11 @@ void _smb_trace_op_begin(
         do { if ((compound)->op_span_active) { \
                  otel_span_end(&(compound)->op_otel); \
                  (compound)->op_span_active = 0; } } while (0)
+
+#else  /* !CHIMERA_HAVE_OTEL : tracing compiled out -- calls vanish entirely */
+
+#define smb_trace_compound_request(compound)  do { } while (0)
+#define smb_trace_op_begin(compound, request) do { } while (0)
+#define smb_trace_op_end(compound)            do { } while (0)
+
+#endif /* CHIMERA_HAVE_OTEL */

--- a/src/server/smb/smb_trace.h
+++ b/src/server/smb/smb_trace.h
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * SMB2 span tracing, modeled on smb_dump.h.  Called next to
+ * smb_dump_compound_request(); the macro short-circuits unless the compound's
+ * span is being recorded.  Names the compound span after its first command
+ * ("smb2.<Command>"), lists the command sequence, and attaches per-command
+ * attributes (the create path, read/write offset+length, and the SMB FileId in
+ * hex).  The resolved VFS file handles surface on the child VFS spans.
+ */
+
+#pragma once
+
+#include "smb_internal.h"
+
+void _smb_trace_compound_request(
+    struct chimera_smb_compound *compound);
+
+#define smb_trace_compound_request(compound) \
+        do { if (otel_span_recording(&(compound)->otel)) { \
+                 _smb_trace_compound_request(compound); } } while (0)

--- a/src/server/smb/smb_trace.h
+++ b/src/server/smb/smb_trace.h
@@ -4,11 +4,12 @@
 
 /*
  * SMB2 span tracing, modeled on smb_dump.h.  Called next to
- * smb_dump_compound_request(); the macro short-circuits unless the compound's
- * span is being recorded.  Names the compound span after its first command
- * ("smb2.<Command>"), lists the command sequence, and attaches per-command
- * attributes (the create path, read/write offset+length, and the SMB FileId in
- * hex).  The resolved VFS file handles surface on the child VFS spans.
+ * smb_dump_compound_request(); the macros short-circuit unless the compound's
+ * span is being recorded.  The compound PDU is an aggregate span ("smb2.COMPOUND")
+ * listing the command sequence; each request inside it gets its own child span
+ * ("smb2.<Command>", via smb_trace_op_begin/op_end) carrying that command's key
+ * attributes (create path, read/write offset+length, SMB FileId in hex), and the
+ * request's VFS work nests under it.
  */
 
 #pragma once
@@ -17,7 +18,23 @@
 
 void _smb_trace_compound_request(
     struct chimera_smb_compound *compound);
+void _smb_trace_op_begin(
+    struct chimera_smb_compound *compound,
+    struct chimera_smb_request  *request);
 
 #define smb_trace_compound_request(compound) \
         do { if (otel_span_recording(&(compound)->otel)) { \
                  _smb_trace_compound_request(compound); } } while (0)
+
+/* Begin a per-request span (child of the aggregate span); see _smb_trace_op_begin. */
+#define smb_trace_op_begin(compound, request) \
+        do { if (otel_span_recording(&(compound)->otel)) { \
+                 _smb_trace_op_begin(compound, request); } } while (0)
+
+/* End the current per-request span if one is in flight.  Gated on the active
+ * flag (not the recording bit) so it balances op_begin exactly and never
+ * double-ends the reused span slot. */
+#define smb_trace_op_end(compound) \
+        do { if ((compound)->op_span_active) { \
+                 otel_span_end(&(compound)->op_otel); \
+                 (compound)->op_span_active = 0; } } while (0)

--- a/src/vfs/vfs.h
+++ b/src/vfs/vfs.h
@@ -16,6 +16,7 @@
 #include "prometheus-c.h"
 #include "vfs_clock.h"
 #include "common/tcp_flavor.h"
+#include "oteltracing.h"
 
 #define CHIMERA_VFS_PATH_MAX 4096
 #define CHIMERA_VFS_NAME_MAX 256
@@ -424,6 +425,17 @@ struct chimera_vfs_request {
     uint64_t                           wait_arg0;
     uint64_t                           wait_arg1;
     uint64_t                           wait_arg2;
+
+    /* OpenTelemetry span for this VFS op.  Started in chimera_vfs_request_alloc_
+     * common() as a child of thread->otel_parent (the protocol op that issued
+     * it), annotated + ended in chimera_vfs_complete().  Zero-cost when tracing
+     * is disabled; never recorded unless a sampled protocol parent was set. */
+    struct otel_span                   otel;
+    /* The trace parent captured at alloc.  chimera_vfs_complete() re-publishes it
+     * as thread->otel_parent right before the proto completion callback runs, so a
+     * chained sibling VFS op issued from that callback inherits the same protocol
+     * parent without the protocol having to set it again. */
+    struct otel_span                  *otel_parent;
 
     /* Points to one page of memory that the plugin may use as desired */
     void                              *plugin_data;
@@ -1564,6 +1576,12 @@ struct chimera_vfs_thread {
     struct evpl_doorbell                 doorbell;
     pthread_mutex_t                      lock;
     uint64_t                             anon_fh_key;
+
+    /* Trace parent for the next VFS op allocated on this thread: the protocol
+     * span that is issuing it.  Set by the protocol immediately before each
+     * chimera_vfs_* call and consumed (cleared) synchronously at request alloc,
+     * so a forgotten set drops the child span rather than misattributing it. */
+    struct otel_span                    *otel_parent;
 
     struct chimera_vfs_thread_metrics    metrics;
 };

--- a/src/vfs/vfs_dump.c
+++ b/src/vfs/vfs_dump.c
@@ -63,9 +63,12 @@ chimera_vfs_trace_complete(struct chimera_vfs_request *request)
 #if CHIMERA_HAVE_OTEL
     struct otel_span *s = &request->otel;
 
-    s->name = chimera_vfs_op_name(request->opcode);
+    char              fhhex[2 * CHIMERA_VFS_FH_SIZE + 1];
 
-    otel_span_attr_u64(s, "vfs.fh_hash", request->fh_hash);
+    otel_span_set_name(s, chimera_vfs_op_name(request->opcode));
+
+    format_hex(fhhex, sizeof(fhhex), request->fh, request->fh_len);
+    otel_span_attr_str(s, "vfs.fh", fhhex);
     otel_span_attr_i64(s, "vfs.status", request->status);
 
     switch (request->opcode) {

--- a/src/vfs/vfs_dump.c
+++ b/src/vfs/vfs_dump.c
@@ -57,10 +57,10 @@ chimera_vfs_op_name(unsigned int opcode)
 
 } /* chimera_vfs_op_name */
 
-SYMBOL_EXPORT void
-chimera_vfs_trace_complete(struct chimera_vfs_request *request)
-{
 #if CHIMERA_HAVE_OTEL
+SYMBOL_EXPORT void
+_chimera_vfs_trace_complete(struct chimera_vfs_request *request)
+{
     struct otel_span *s = &request->otel;
 
     char              fhhex[2 * CHIMERA_VFS_FH_SIZE + 1];
@@ -107,10 +107,8 @@ chimera_vfs_trace_complete(struct chimera_vfs_request *request)
     }
 
     otel_span_end(s);
-#else  /* !CHIMERA_HAVE_OTEL */
-    (void) request;
+} /* _chimera_vfs_trace_complete */
 #endif /* CHIMERA_HAVE_OTEL */
-} /* chimera_vfs_trace_complete */
 
 void
 __chimera_vfs_dump_request(struct chimera_vfs_request *req)

--- a/src/vfs/vfs_dump.c
+++ b/src/vfs/vfs_dump.c
@@ -10,6 +10,7 @@
 #include "vfs_dump.h"
 #include "vfs.h"
 #include "vfs_internal.h"
+#include "common/macros.h"
 #include "common/format.h"
 #include "vfs_open_cache.h"
 #include "common/snprintf.h"
@@ -55,6 +56,42 @@ chimera_vfs_op_name(unsigned int opcode)
     } /* switch */
 
 } /* chimera_vfs_op_name */
+
+SYMBOL_EXPORT void
+chimera_vfs_trace_complete(struct chimera_vfs_request *request)
+{
+#if CHIMERA_HAVE_OTEL
+    struct otel_span *s = &request->otel;
+
+    s->name = chimera_vfs_op_name(request->opcode);
+
+    otel_span_attr_u64(s, "vfs.fh_hash", request->fh_hash);
+    otel_span_attr_i64(s, "vfs.status", request->status);
+
+    switch (request->opcode) {
+        case CHIMERA_VFS_OP_READ:
+            otel_span_attr_u64(s, "vfs.offset", request->read.offset);
+            otel_span_attr_u64(s, "vfs.length", request->read.length);
+            otel_span_attr_u64(s, "vfs.bytes", request->read.r_length);
+            break;
+        case CHIMERA_VFS_OP_WRITE:
+            otel_span_attr_u64(s, "vfs.offset", request->write.offset);
+            otel_span_attr_u64(s, "vfs.length", request->write.length);
+            otel_span_attr_u64(s, "vfs.bytes", request->write.r_length);
+            break;
+        default:
+            break;
+    } /* switch */
+
+    if (request->status != CHIMERA_VFS_OK) {
+        otel_span_set_status(s, OTEL_STATUS_ERROR, NULL);
+    }
+
+    otel_span_end(s);
+#else  /* !CHIMERA_HAVE_OTEL */
+    (void) request;
+#endif /* CHIMERA_HAVE_OTEL */
+} /* chimera_vfs_trace_complete */
 
 void
 __chimera_vfs_dump_request(struct chimera_vfs_request *req)

--- a/src/vfs/vfs_dump.c
+++ b/src/vfs/vfs_dump.c
@@ -79,6 +79,22 @@ chimera_vfs_trace_complete(struct chimera_vfs_request *request)
             otel_span_attr_u64(s, "vfs.length", request->write.length);
             otel_span_attr_u64(s, "vfs.bytes", request->write.r_length);
             break;
+        case CHIMERA_VFS_OP_LOOKUP_AT:
+            otel_span_attr_strn(s, "vfs.name", request->lookup_at.component,
+                                request->lookup_at.component_len);
+            break;
+        case CHIMERA_VFS_OP_OPEN_AT:
+            otel_span_attr_strn(s, "vfs.name", request->open_at.name,
+                                request->open_at.namelen);
+            break;
+        case CHIMERA_VFS_OP_MKDIR_AT:
+            otel_span_attr_strn(s, "vfs.name", request->mkdir_at.name,
+                                request->mkdir_at.name_len);
+            break;
+        case CHIMERA_VFS_OP_REMOVE_AT:
+            otel_span_attr_strn(s, "vfs.name", request->remove_at.name,
+                                request->remove_at.namelen);
+            break;
         default:
             break;
     } /* switch */

--- a/src/vfs/vfs_dump.c
+++ b/src/vfs/vfs_dump.c
@@ -58,12 +58,81 @@ chimera_vfs_op_name(unsigned int opcode)
 } /* chimera_vfs_op_name */
 
 #if CHIMERA_HAVE_OTEL
+
+/* Hex buffer big enough for any VFS file handle (incl. the +16 slack on va_fh). */
+#define VFS_TRACE_FH_HEX    (2 * (CHIMERA_VFS_FH_SIZE + 16) + 1)
+
+/* Opaque values (xattr value, symlink target) are usually short but may be large;
+* cap what we copy into the span arena.  The full length is recorded alongside. */
+#define VFS_TRACE_VALUE_MAX 64
+
+/* Emit the populated scalar fields of an attrs block as "<prefix>.*" attributes,
+ * gated by va_set_mask (which the backend sets for the fields it actually filled).
+ * Scalars only -- never the ACL or pNFS blob -- so the span arena stays bounded. */
+static void
+vfs_trace_attrs(
+    struct otel_span               *s,
+    const char                     *prefix,
+    const struct chimera_vfs_attrs *a)
+{
+    uint64_t m = a->va_set_mask;
+    char     key[40];
+
+    if (m & CHIMERA_VFS_ATTR_SIZE) {
+        snprintf(key, sizeof(key), "%s.size", prefix);
+        otel_span_attr_u64(s, key, a->va_size);
+    }
+    if (m & CHIMERA_VFS_ATTR_MODE) {
+        snprintf(key, sizeof(key), "%s.mode", prefix);
+        otel_span_attr_u64(s, key, a->va_mode);
+    }
+    if (m & CHIMERA_VFS_ATTR_NLINK) {
+        snprintf(key, sizeof(key), "%s.nlink", prefix);
+        otel_span_attr_u64(s, key, a->va_nlink);
+    }
+    if (m & CHIMERA_VFS_ATTR_UID) {
+        snprintf(key, sizeof(key), "%s.uid", prefix);
+        otel_span_attr_u64(s, key, a->va_uid);
+    }
+    if (m & CHIMERA_VFS_ATTR_GID) {
+        snprintf(key, sizeof(key), "%s.gid", prefix);
+        otel_span_attr_u64(s, key, a->va_gid);
+    }
+    if (m & CHIMERA_VFS_ATTR_INUM) {
+        snprintf(key, sizeof(key), "%s.inum", prefix);
+        otel_span_attr_u64(s, key, a->va_ino);
+    }
+    if (m & CHIMERA_VFS_ATTR_FH) {
+        char hex[VFS_TRACE_FH_HEX];
+        snprintf(key, sizeof(key), "%s.fh", prefix);
+        format_hex(hex, sizeof(hex), a->va_fh, a->va_fh_len);
+        otel_span_attr_str(s, key, hex);
+    }
+} /* vfs_trace_attrs */
+
+/* Emit an opaque value (xattr value, symlink target) truncated to a safe length,
+ * plus its full byte length under `len_key`. */
+static void
+vfs_trace_value(
+    struct otel_span *s,
+    const char       *key,
+    const char       *len_key,
+    const void       *val,
+    uint32_t          len)
+{
+    if (val && len) {
+        otel_span_attr_strn(s, key, val,
+                            len > VFS_TRACE_VALUE_MAX ? VFS_TRACE_VALUE_MAX : len);
+    }
+    otel_span_attr_u64(s, len_key, len);
+} /* vfs_trace_value */
+
 SYMBOL_EXPORT void
 _chimera_vfs_trace_complete(struct chimera_vfs_request *request)
 {
     struct otel_span *s = &request->otel;
 
-    char              fhhex[2 * CHIMERA_VFS_FH_SIZE + 1];
+    char              fhhex[VFS_TRACE_FH_HEX];
 
     otel_span_set_name(s, chimera_vfs_op_name(request->opcode));
 
@@ -71,32 +140,156 @@ _chimera_vfs_trace_complete(struct chimera_vfs_request *request)
     otel_span_attr_str(s, "vfs.fh", fhhex);
     otel_span_attr_i64(s, "vfs.status", request->status);
 
+    /* Per-op request + response (r_*) attributes.  File data (read/write iov) and
+     * directory entries (readdir) are deliberately never attached; opaque values
+     * (xattr/symlink) are truncated. */
     switch (request->opcode) {
+        case CHIMERA_VFS_OP_LOOKUP_AT:
+            otel_span_attr_strn(s, "vfs.name", request->lookup_at.component,
+                                request->lookup_at.component_len);
+            vfs_trace_attrs(s, "vfs", &request->lookup_at.r_attr);
+            break;
+        case CHIMERA_VFS_OP_GETATTR:
+            vfs_trace_attrs(s, "vfs", &request->getattr.r_attr);
+            break;
+        case CHIMERA_VFS_OP_SETATTR:
+            if (request->setattr.set_attr) {
+                otel_span_attr_u64(s, "vfs.set_mask",
+                                   request->setattr.set_attr->va_set_mask);
+            }
+            vfs_trace_attrs(s, "vfs", &request->setattr.r_post_attr);
+            break;
         case CHIMERA_VFS_OP_READ:
             otel_span_attr_u64(s, "vfs.offset", request->read.offset);
             otel_span_attr_u64(s, "vfs.length", request->read.length);
             otel_span_attr_u64(s, "vfs.bytes", request->read.r_length);
+            otel_span_attr_bool(s, "vfs.eof", request->read.r_eof);
             break;
         case CHIMERA_VFS_OP_WRITE:
             otel_span_attr_u64(s, "vfs.offset", request->write.offset);
             otel_span_attr_u64(s, "vfs.length", request->write.length);
             otel_span_attr_u64(s, "vfs.bytes", request->write.r_length);
+            otel_span_attr_u64(s, "vfs.sync", request->write.sync);
             break;
-        case CHIMERA_VFS_OP_LOOKUP_AT:
-            otel_span_attr_strn(s, "vfs.name", request->lookup_at.component,
-                                request->lookup_at.component_len);
+        case CHIMERA_VFS_OP_COMMIT:
+            otel_span_attr_u64(s, "vfs.offset", request->commit.offset);
+            otel_span_attr_u64(s, "vfs.length", request->commit.length);
             break;
         case CHIMERA_VFS_OP_OPEN_AT:
             otel_span_attr_strn(s, "vfs.name", request->open_at.name,
                                 request->open_at.namelen);
+            otel_span_attr_u64(s, "vfs.flags", request->open_at.flags);
+            otel_span_attr_bool(s, "vfs.created", request->open_at.r_created);
+            vfs_trace_attrs(s, "vfs", &request->open_at.r_attr);
+            break;
+        case CHIMERA_VFS_OP_OPEN_FH:
+            otel_span_attr_u64(s, "vfs.flags", request->open_fh.flags);
             break;
         case CHIMERA_VFS_OP_MKDIR_AT:
             otel_span_attr_strn(s, "vfs.name", request->mkdir_at.name,
                                 request->mkdir_at.name_len);
+            vfs_trace_attrs(s, "vfs", &request->mkdir_at.r_attr);
+            break;
+        case CHIMERA_VFS_OP_MKNOD_AT:
+            otel_span_attr_strn(s, "vfs.name", request->mknod_at.name,
+                                request->mknod_at.name_len);
+            vfs_trace_attrs(s, "vfs", &request->mknod_at.r_attr);
+            break;
+        case CHIMERA_VFS_OP_SYMLINK_AT:
+            otel_span_attr_strn(s, "vfs.name", request->symlink_at.name,
+                                request->symlink_at.namelen);
+            vfs_trace_value(s, "vfs.target", "vfs.target_len",
+                            request->symlink_at.target, request->symlink_at.targetlen);
+            vfs_trace_attrs(s, "vfs", &request->symlink_at.r_attr);
             break;
         case CHIMERA_VFS_OP_REMOVE_AT:
             otel_span_attr_strn(s, "vfs.name", request->remove_at.name,
                                 request->remove_at.namelen);
+            break;
+        case CHIMERA_VFS_OP_RENAME_AT:
+            otel_span_attr_strn(s, "vfs.name", request->rename_at.name,
+                                request->rename_at.namelen);
+            otel_span_attr_strn(s, "vfs.new_name", request->rename_at.new_name,
+                                request->rename_at.new_namelen);
+            break;
+        case CHIMERA_VFS_OP_LINK_AT:
+            otel_span_attr_strn(s, "vfs.name", request->link_at.name,
+                                request->link_at.namelen);
+            vfs_trace_attrs(s, "vfs", &request->link_at.r_attr);
+            break;
+        case CHIMERA_VFS_OP_READDIR:
+            otel_span_attr_u64(s, "vfs.cookie", request->readdir.cookie);
+            otel_span_attr_u64(s, "vfs.r_cookie", request->readdir.r_cookie);
+            otel_span_attr_bool(s, "vfs.eof", request->readdir.r_eof);
+            break;
+        case CHIMERA_VFS_OP_READLINK:
+            vfs_trace_value(s, "vfs.target", "vfs.target_len",
+                            request->readlink.r_target,
+                            request->readlink.r_target_length);
+            break;
+        case CHIMERA_VFS_OP_ALLOCATE:
+            otel_span_attr_u64(s, "vfs.offset", request->allocate.offset);
+            otel_span_attr_u64(s, "vfs.length", request->allocate.length);
+            break;
+        case CHIMERA_VFS_OP_SEEK:
+            otel_span_attr_u64(s, "vfs.offset", request->seek.offset);
+            otel_span_attr_u64(s, "vfs.what", request->seek.what);
+            otel_span_attr_u64(s, "vfs.r_offset", request->seek.r_offset);
+            otel_span_attr_bool(s, "vfs.eof", request->seek.r_eof);
+            break;
+        case CHIMERA_VFS_OP_LOCK:
+            otel_span_attr_u64(s, "vfs.offset", request->lock.offset);
+            otel_span_attr_u64(s, "vfs.length", request->lock.length);
+            otel_span_attr_u64(s, "vfs.lock_type", request->lock.lock_type);
+            break;
+        case CHIMERA_VFS_OP_COPY_RANGE:
+            otel_span_attr_u64(s, "vfs.src_offset", request->copy_range.src_offset);
+            otel_span_attr_u64(s, "vfs.dst_offset", request->copy_range.dst_offset);
+            otel_span_attr_u64(s, "vfs.length", request->copy_range.length);
+            otel_span_attr_u64(s, "vfs.bytes", request->copy_range.r_length);
+            break;
+        case CHIMERA_VFS_OP_CLONE_RANGE:
+            otel_span_attr_u64(s, "vfs.src_offset", request->clone_range.src_offset);
+            otel_span_attr_u64(s, "vfs.dst_offset", request->clone_range.dst_offset);
+            otel_span_attr_u64(s, "vfs.length", request->clone_range.length);
+            break;
+        case CHIMERA_VFS_OP_MOVE_RANGE:
+            otel_span_attr_u64(s, "vfs.src_offset", request->move_range.src_offset);
+            otel_span_attr_u64(s, "vfs.dst_offset", request->move_range.dst_offset);
+            otel_span_attr_u64(s, "vfs.length", request->move_range.length);
+            break;
+        case CHIMERA_VFS_OP_GET_XATTR:
+            otel_span_attr_strn(s, "vfs.name", request->get_xattr.name,
+                                request->get_xattr.namelen);
+            vfs_trace_value(s, "vfs.value", "vfs.value_len",
+                            request->get_xattr.value, request->get_xattr.r_value_len);
+            break;
+        case CHIMERA_VFS_OP_SET_XATTR:
+            otel_span_attr_strn(s, "vfs.name", request->set_xattr.name,
+                                request->set_xattr.namelen);
+            vfs_trace_value(s, "vfs.value", "vfs.value_len",
+                            request->set_xattr.value, request->set_xattr.value_len);
+            break;
+        case CHIMERA_VFS_OP_LIST_XATTRS:
+            otel_span_attr_u64(s, "vfs.count", request->list_xattrs.r_count);
+            otel_span_attr_bool(s, "vfs.eof", request->list_xattrs.r_eof);
+            break;
+        case CHIMERA_VFS_OP_REMOVE_XATTR:
+            otel_span_attr_strn(s, "vfs.name", request->remove_xattr.name,
+                                request->remove_xattr.namelen);
+            break;
+        case CHIMERA_VFS_OP_OPEN_STREAM:
+            otel_span_attr_strn(s, "vfs.name", request->open_stream.name,
+                                request->open_stream.namelen);
+            vfs_trace_attrs(s, "vfs", &request->open_stream.r_attr);
+            break;
+        case CHIMERA_VFS_OP_LIST_STREAMS:
+            otel_span_attr_u64(s, "vfs.count", request->list_streams.r_count);
+            otel_span_attr_bool(s, "vfs.eof", request->list_streams.r_eof);
+            break;
+        case CHIMERA_VFS_OP_REMOVE_STREAM:
+            otel_span_attr_strn(s, "vfs.name", request->remove_stream.name,
+                                request->remove_stream.namelen);
             break;
         default:
             break;

--- a/src/vfs/vfs_dump.h
+++ b/src/vfs/vfs_dump.h
@@ -19,10 +19,19 @@ void __chimera_vfs_dump_reply(
     struct chimera_vfs_request *request);
 
 /* Annotate and end the request's OpenTelemetry span (op name, attributes,
- * status).  Only called when the span is recording; out-of-line to keep the
- * inline completion path small.  Compiles to nothing when tracing is disabled. */
-void chimera_vfs_trace_complete(
+ * status).  The macro's recording test is an inline flag check, so unsampled
+ * ops pay nothing and the out-of-line annotation stays off the hot path; when
+ * tracing is compiled out the whole call expands to nothing (no function
+ * reference, no engine call). */
+#if CHIMERA_HAVE_OTEL
+void _chimera_vfs_trace_complete(
     struct chimera_vfs_request *request);
+#define chimera_vfs_trace_complete(request) \
+        do { if (otel_span_recording(&(request)->otel)) { \
+                 _chimera_vfs_trace_complete(request); } } while (0)
+#else // if CHIMERA_HAVE_OTEL
+#define chimera_vfs_trace_complete(request) do { (void) (request); } while (0)
+#endif // if CHIMERA_HAVE_OTEL
 
 #define chimera_vfs_dump_request(request) \
         if (ChimeraLogLevel >= CHIMERA_LOG_DEBUG) { \

--- a/src/vfs/vfs_dump.h
+++ b/src/vfs/vfs_dump.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -16,6 +16,12 @@ chimera_vfs_op_name(
 void __chimera_vfs_dump_request(
     struct chimera_vfs_request *request);
 void __chimera_vfs_dump_reply(
+    struct chimera_vfs_request *request);
+
+/* Annotate and end the request's OpenTelemetry span (op name, attributes,
+ * status).  Only called when the span is recording; out-of-line to keep the
+ * inline completion path small.  Compiles to nothing when tracing is disabled. */
+void chimera_vfs_trace_complete(
     struct chimera_vfs_request *request);
 
 #define chimera_vfs_dump_request(request) \

--- a/src/vfs/vfs_internal.h
+++ b/src/vfs/vfs_internal.h
@@ -269,6 +269,16 @@ chimera_vfs_request_alloc_common(
     request->wait_arg1     = 0;
     request->wait_arg2     = 0;
 
+    /* Start this op's trace span as a child of the protocol span that issued it
+     * (thread->otel_parent, set synchronously just before this call).  Capture
+     * the parent pointer for sibling propagation (see chimera_vfs_complete), then
+     * consume thread->otel_parent so a follow-up op that forgot to set one drops
+     * its span rather than misattributing it.  ~free when not recording. */
+    request->otel_parent = thread->otel_parent;
+    otel_span_start_child(&request->otel, NULL, OTEL_SPAN_INTERNAL,
+                          request->otel_parent);
+    thread->otel_parent = NULL;
+
     thread->num_active_requests++;
     DL_APPEND2(thread->active_requests, request, active_prev, active_next);
 
@@ -396,6 +406,17 @@ chimera_vfs_complete(struct chimera_vfs_request *request)
         prometheus_time_histogram_sample(thread->metrics.op_latency_series[request->opcode],
                                          &request->start_time);
     }
+
+    /* Annotate (op name, attrs, status) and end the trace span.  The recording
+     * test is an inline flag check, so unsampled ops pay nothing here. */
+    if (otel_span_recording(&request->otel)) {
+        chimera_vfs_trace_complete(request);
+    }
+
+    /* Re-publish this op's trace parent so the proto completion callback that
+     * runs next (on this thread) issues any chained sibling VFS op under the same
+     * protocol span.  Consumed (cleared) at that op's alloc. */
+    thread->otel_parent = request->otel_parent;
 
     chimera_vfs_dump_reply(request);
 } /* chimera_vfs_complete */

--- a/src/vfs/vfs_internal.h
+++ b/src/vfs/vfs_internal.h
@@ -407,11 +407,10 @@ chimera_vfs_complete(struct chimera_vfs_request *request)
                                          &request->start_time);
     }
 
-    /* Annotate (op name, attrs, status) and end the trace span.  The recording
-     * test is an inline flag check, so unsampled ops pay nothing here. */
-    if (otel_span_recording(&request->otel)) {
-        chimera_vfs_trace_complete(request);
-    }
+    /* Annotate (op name, attrs, status) and end the trace span.  The macro's
+     * recording test is an inline flag check (unsampled ops pay nothing), and
+     * the whole call compiles out when tracing is disabled. */
+    chimera_vfs_trace_complete(request);
 
     /* Re-publish this op's trace parent so the proto completion callback that
      * runs next (on this thread) issues any chained sibling VFS op under the same


### PR DESCRIPTION
## OpenTelemetry span tracing for NFS / SMB / S3 / VFS

Adds microsecond-grade distributed tracing across the protocol servers and the VFS
layer, emitting OTLP/gRPC to any OpenTelemetry collector or, optionally, to a local
SQLite store that a bundled CLI can query.

### Span library (`oteltracing-c`, via the libevpl submodule)
- Transport-agnostic OTLP/gRPC span library (protobuf-c encoding + gRPC framing),
  exported over libevpl's HTTP/2 client; lock-free per-thread SPSC ring on the hot
  path (no per-span malloc, no locks), drained by the exporter driver.
- Embeddable POD `struct otel_span` (exactly 4 KiB). Everything variable-length —
  name, status, attributes, events and their strings — is sub-allocated from one
  inline arena addressed by offsets, so a span is position-independent and copyable
  by value. No fixed per-kind caps; overflow is dropped and counted.
- Per-event attributes (OTLP `Span.Event.attributes`).
- Compile-time (`OTEL_TRACING=0` → zero-size span, no link) and runtime on/off
  switches; configurable head sampling.
- Optional SQLite sink on a dedicated flusher thread (WAL, batched commits) plus an
  `otel-trace` CLI (list / show / spans / stats / sql). Back-pressure drops spans
  rather than ever blocking producers.

### Chimera integration
- `common.tracing` JSON config (off by default): `enabled`, `sqlite_path` or
  `grpc_endpoint`, and `sample_rate` (default 0.001).
- A `struct otel_span` is embedded in the VFS request and each protocol request;
  the protocol span is the parent and each VFS op it issues is a child, with parent
  context re-published across the async / delegation-thread handoffs.
- Per-op instrumentation follows the `nfs_dump` / `vfs_dump` model: `nfs3_trace`,
  `nfs4_trace` and `smb_trace` modules called beside the existing `*_dump_*` sites,
  each gated by a single `otel_span_recording` check so the setup stays out of the
  mainline. Spans carry per-op names, hex file handles, and operation attributes
  (offsets/lengths, names, status).

Verified end to end against real NFSv3, NFSv4.1 and SMB mounts (parent→child linkage,
hex FHs, attributes) and via the library's OTLP-decode and SQLite round-trip tests.

Draft: depends on the `oteltracing-c` (`main`) and libevpl (`tracing`) submodule
commits this branch points at.
