### PR TITLE
kvm/smb: raise cairn SMB cthon/xfstests timeout to 600s for contention

### DIFF
--- a/kvm/tests/CMakeLists.txt
+++ b/kvm/tests/CMakeLists.txt
@@ -462,8 +462,13 @@ foreach(image_spec ${KVM_IMAGES})
                         ${IMAGE_DIR}/vmlinuz ${IMAGE_DIR}/rootfs.qcow2
                         ${CHIMERA_BINARY} cairn
                         "${SMB_CTHON_CMD_${category}}")
+            # cairn's lock-key contention can push the SMB cthon run past the CI
+            # default `ctest --timeout 300` under parallel load, so it flakes
+            # (fails once, passes on rerun -- tracker #733).  Give it headroom
+            # like the other contention-bound suites (cf. fsx, #805); a test
+            # TIMEOUT property overrides the command-line default.
             set_tests_properties(chimera/kvm/${IMAGE_NAME}/smb/cthon/${category}_cairn
-                PROPERTIES LABELS "kvm;${IMAGE_NAME}" PROCESSORS 2)
+                PROPERTIES LABELS "kvm;${IMAGE_NAME}" PROCESSORS 2 TIMEOUT 600)
         endforeach()
     endif()
 
@@ -487,8 +492,11 @@ foreach(image_spec ${KVM_IMAGES})
                         ${IMAGE_DIR}/vmlinuz ${IMAGE_DIR}/rootfs.qcow2
                         ${CHIMERA_BINARY} cairn
                         "${XFSTESTS_CMD_${prog}}")
+            # Same cairn lock-key contention as the SMB cthon cairn block above:
+            # under load these can exceed the 300s CI default (e.g. the recurring
+            # rewinddir_cairn timeout, #733).  Give them matching headroom.
             set_tests_properties(chimera/kvm/${IMAGE_NAME}/smb/xfstests/${prog}_cairn
-                PROPERTIES LABELS "kvm;${IMAGE_NAME}" PROCESSORS 2)
+                PROPERTIES LABELS "kvm;${IMAGE_NAME}" PROCESSORS 2 TIMEOUT 600)
         endforeach()
     endif()
 


### PR DESCRIPTION
## Why

The cairn KVM SMB tests (`smb/cthon/*_cairn`, `smb/xfstests/*_cairn`) recurringly flake in the merge queue — `rewinddir_cairn` alone is ~6 observations on tracker #733, and the cairn SMB cthon/xfstests family has been timing out for a while.

## Root cause

These tests carry no `TIMEOUT` property, so they inherit the merge queue's `ctest --timeout 300`. cairn's lock-key contention can push them past 300s under the parallel KVM load on the shared CI runners, where they time out → fail the run → pass on `--rerun-failed`. It's a **contention timeout, not a logic bug** (the same backend passes deterministically when not contended).

## Fix

Give the cairn SMB cthon and xfstests tests an explicit `TIMEOUT 600` (a per-test property overrides the CLI default), matching the contention-headroom remedy already used for the posix `fsx` suite (#805) and `nfstest`. Only the cairn variants are bumped, since the contention is cairn-specific (memfs/diskfs/linux SMB variants don't show this timeout). Test-config only; no server code.

Refs #733.