### PR TITLE
smb: fix SMB3.1.1 preauth, long paths, and dir-lease dialect gate (WPTS DirectoryLeasing)

### DIFF
--- a/scripts/wpts_smb_test_wrapper.sh
+++ b/scripts/wpts_smb_test_wrapper.sh
@@ -165,6 +165,14 @@ generate_config() {
         encryption_line='"smb_encryption": "enabled",'
     fi
 
+    # Enable SMB3 directory leases when requested (the DirectoryLeasing WPTS
+    # cases need the feature on; default off keeps the rest of the suite on the
+    # baseline path where directory opens take no lease).
+    local dirlease_line=""
+    if [ "${CHIMERA_SMB_DIRLEASE:-0}" = "1" ]; then
+        dirlease_line='"smb_directory_leases": true,'
+    fi
+
     cat > "$CONFIG_FILE" << EOF
 {
     "server": {
@@ -172,6 +180,7 @@ generate_config() {
         ${compression_line}
         ${multichannel_line}
         ${encryption_line}
+        ${dirlease_line}
         "smb_named_streams": true,
         "smb_leases": true,
         "smb_oplocks": true,
@@ -344,6 +353,16 @@ if [ "${CHIMERA_SMB_ENCRYPTION:-0}" = "1" ]; then
         -e 's#<Property name="IsEncryptionSupported" value="false"/>#<Property name="IsEncryptionSupported" value="true"/>#' \
         -e 's#<Property name="IsGlobalEncryptDataEnabled" value="false"/>#<Property name="IsGlobalEncryptDataEnabled" value="true"/>#' \
         -e 's#<Property name="EncryptedFileShare" value=""/>#<Property name="EncryptedFileShare" value="SMBEncrypted"/>#' \
+        "$staged"
+fi
+
+# When directory leases are enabled, advertise the capability to the driver so
+# the DirectoryLeasing cases become applicable (otherwise they are
+# Inconclusive/skipped).
+if [ "${CHIMERA_SMB_DIRLEASE:-0}" = "1" ]; then
+    staged="${WPTS_STAGE_DIR}/CommonTestSuite.deployment.ptfconfig"
+    sed -i \
+        -e 's#<Property name="IsDirectoryLeasingSupported" value="false"/>#<Property name="IsDirectoryLeasingSupported" value="true"/>#' \
         "$staged"
 fi
 

--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -554,7 +554,16 @@ chimera_smb_compound_reply(struct chimera_smb_compound *compound)
     * SMB2 message is contiguous in reply_iov[0] after the transport header. */
     if (compound->num_requests > 0 &&
         (compound->requests[0]->smb2_hdr.command == SMB2_NEGOTIATE ||
-         compound->requests[0]->smb2_hdr.command == SMB2_SESSION_SETUP)) {
+         compound->requests[0]->smb2_hdr.command == SMB2_SESSION_SETUP) &&
+        /* The SMB1 multi-protocol NEGOTIATE is answered with an SMB2 NEGOTIATE
+         * response carrying the 0x02ff wildcard ("send a real SMB2 NEGOTIATE
+         * next").  That is not a dialect selection and the client does NOT fold
+         * it into Connection.PreauthIntegrityHashValue (MS-SMB2 3.3.5.3.1) — the
+         * preauth hash starts from the subsequent real SMB2 NEGOTIATE.  Folding
+         * it here would diverge from the client and corrupt the 3.1.1 signing
+         * key (every signed request after SESSION_SETUP then fails). */
+        !(compound->requests[0]->smb2_hdr.command == SMB2_NEGOTIATE &&
+          compound->requests[0]->negotiate.r_dialect == 0x02ff)) {
 
         /* Track whether a multi-leg SESSION_SETUP exchange is in flight: the
          * next SESSION_SETUP that arrives with this clear starts a NEW

--- a/src/server/smb/smb2.h
+++ b/src/server/smb/smb2.h
@@ -7,7 +7,14 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
+/* Per-component filename limit (MS-FSA ComponentMaxLength, 255 chars). */
 #define SMB_FILENAME_MAX                              255
+
+/* Full-pathname buffer limit. An SMB2 CREATE/rename name is the whole path
+ * relative to the share root (which may span many components), so it must not
+ * be bounded by the per-component limit. Matches the VFS path ceiling
+ * (CHIMERA_VFS_PATH_MAX / Linux PATH_MAX). */
+#define SMB_PATH_MAX                                  4096
 
 
 #define SMB2_DIALECT_2_0_2                            0x0202

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -527,7 +527,7 @@ struct chimera_smb_request {
             struct chimera_vfs_handle_state    persist_hs;
             uint8_t                            persist_key[CHIMERA_SMB_DURABLE_KEY_LEN];
             uint8_t                            persist_value[CHIMERA_SMB_DURABLE_VALUE_MAX];
-            char                               parent_path[SMB_FILENAME_MAX];
+            char                               parent_path[SMB_PATH_MAX];
             char                              *name;
             /* Named-stream (ADS) suffix parsed off the final path component.
              * has_stream is set when the create targets "file:stream[:$DATA]";

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -847,8 +847,13 @@ chimera_smb_create_after_share(
      * R/H only (W is masked off below) and is broken on a directory content
      * change (chimera_vfs_state_dir_lease_break via the notify chokepoint). */
     int                               is_directory = (open_file->flags & CHIMERA_SMB_OPEN_FILE_FLAG_DIRECTORY) != 0;
+    /* Directory leasing is an SMB 3.0+ feature (MS-SMB2 3.3.5.9.11): the lease-v2
+     * context that carries it is only valid on a 3.x dialect. A v2 RqLs sent over
+     * SMB 2.0.2 / 2.1 must be ignored so the open returns OPLOCK_LEVEL_NONE
+     * (dirlease.Negative_SMB2002 / _SMB21). */
     int                               dir_lease_ok = is_directory && oh &&
         thread->shared->config.directory_leases &&
+        request->compound->conn->dialect >= SMB2_DIALECT_3_0 &&
         (request->create.ctx_present_mask & CHIMERA_SMB_CREATE_CTX_RQLS) &&
         request->create.rqls.is_v2;
 
@@ -4527,7 +4532,7 @@ chimera_smb_parse_create(
 {
     uint16_t name_offset;
     uint32_t blob_offset, blob_length;
-    uint16_t name16[SMB_FILENAME_MAX];
+    uint16_t name16[SMB_PATH_MAX];
     int      name_size;
     char    *slash;
 
@@ -4579,7 +4584,10 @@ chimera_smb_parse_create(
      * the durable-reconnect short-circuit (a reconnect carries a don't-care
      * sentinel and must not be validated). */
 
-    if (request->create.name_len >= SMB_FILENAME_MAX) {
+    /* NameLength is the whole path (relative to the share root), so it is
+     * bounded by the full-path limit, not the per-component one. name16 holds
+     * SMB_PATH_MAX UTF-16 code units (2*SMB_PATH_MAX bytes). */
+    if (request->create.name_len > 2 * SMB_PATH_MAX) {
         chimera_smb_error("Create request: UTF-16 name too long (%u bytes)",
                           request->create.name_len);
         request->status = SMB2_STATUS_NAME_TOO_LONG;

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -502,9 +502,9 @@ if(CHIMERA_NETNS_TESTING AND WPTS_DOTNET AND WPTS_SMB2_DLL AND WPTS_ARCH_SUPPORT
     # Negative_InvalidClientGuid (need a per-client lease table to validate the
     # ack key without a tree-scoped open — the per-tree open lookup also matches
     # a settled FILE lease, so rejecting an unknown key there regresses
-    # smb2.lease.v2_complex2) — all deeper follow-ups; and
-    # AppInstanceId_DirectoryLeasing_NoLeaseInReOpen (NotExecuted — needs
-    # app-instance-id directory support).
+    # smb2.lease.v2_complex2) — all deeper follow-ups.
+    # (AppInstanceId_DirectoryLeasing_NoLeaseInReOpen needs persistent handles +
+    # multichannel advertised too, so it lives in the combined group below.)
     set(WPTS_SMB2_DIRLEASE_ALLOWLIST
         BVT_DirectoryLeasing_ReadWriteHandleCaching
         DirectoryLeasing_BreakHandleCachingByConflictOpen
@@ -529,6 +529,24 @@ if(CHIMERA_NETNS_TESTING AND WPTS_DOTNET AND WPTS_SMB2_DLL AND WPTS_ARCH_SUPPORT
         LABELS "smb;wpts;dirlease"
         TIMEOUT 900
         ENVIRONMENT "WPTS_BIN_DIR=${WPTS_BIN_DIR};DOTNET=${WPTS_DOTNET};CHIMERA_SMB_DIRLEASE=1")
+
+    # AppInstanceId_DirectoryLeasing_NoLeaseInReOpen exercises a client failover:
+    # a new client reopens with the same AppInstanceId (forcing the prior open
+    # closed) and must observe NO carried-over directory lease.  The case asserts
+    # GLOBAL_CAP_PERSISTENT_HANDLES and needs a second client NIC for the
+    # failover, so it only becomes applicable with directory leases AND persistent
+    # handles AND multichannel all advertised — hence its own combined group.
+    set(WPTS_SMB2_DIRLEASE_APPINSTANCE_ALLOWLIST
+        AppInstanceId_DirectoryLeasing_NoLeaseInReOpen)
+
+    string(REPLACE ";" "," _wpts_tests "${WPTS_SMB2_DIRLEASE_APPINSTANCE_ALLOWLIST}")
+    add_test(NAME chimera/server/smb/wpts/memfs_dirlease_appinstance
+        COMMAND ${CMAKE_SOURCE_DIR}/scripts/wpts_smb_test_wrapper.sh
+                ${CHIMERA_DAEMON} memfs "${_wpts_tests}")
+    set_tests_properties(chimera/server/smb/wpts/memfs_dirlease_appinstance PROPERTIES
+        LABELS "smb;wpts;dirlease;persistent;multichannel"
+        TIMEOUT 900
+        ENVIRONMENT "WPTS_BIN_DIR=${WPTS_BIN_DIR};DOTNET=${WPTS_DOTNET};CHIMERA_SMB_DIRLEASE=1;CHIMERA_SMB_PERSISTENT=1;CHIMERA_SMB_MULTICHANNEL=1")
 
     message(STATUS "WPTS MS-SMB2 tests: enabled (${WPTS_BIN_DIR}, ${WPTS_DOTNET})")
 elseif(CHIMERA_NETNS_TESTING AND WPTS_DOTNET AND WPTS_SMB2_DLL AND NOT WPTS_ARCH_SUPPORTED)

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -489,6 +489,47 @@ if(CHIMERA_NETNS_TESTING AND WPTS_DOTNET AND WPTS_SMB2_DLL AND WPTS_ARCH_SUPPORT
         TIMEOUT 900
         ENVIRONMENT "WPTS_BIN_DIR=${WPTS_BIN_DIR};DOTNET=${WPTS_DOTNET};CHIMERA_SMB_MULTICHANNEL=1;CHIMERA_SMB_ENCRYPTION=1")
 
+    # SMB3 directory-leasing cases.  The wrapper runs the daemon with
+    # smb_directory_leases enabled (CHIMERA_SMB_DIRLEASE=1, which also advertises
+    # IsDirectoryLeasingSupported in the ptfconfig so the cases become
+    # applicable).  Allowlist = every DirectoryLeasing case confirmed green: lease
+    # grant (R/RH/RW->R/RWH->RH), the content-change R-break (child add/modify/
+    # delete/rename), the conflict-open H-break, pre-3.0 refusal, and lease-break
+    # lease-break-ack lease-state validation.  Left out:
+    # LeaseBreakOnMultiClients (needs multi-holder H-break fan-out across
+    # sequential break/ack); BreakHandleCachingByParentRenamed (needs dir-rename
+    # denial while a descendant handle is open); Negative_InvalidLeaseKey /
+    # Negative_InvalidClientGuid (need a per-client lease table to validate the
+    # ack key without a tree-scoped open — the per-tree open lookup also matches
+    # a settled FILE lease, so rejecting an unknown key there regresses
+    # smb2.lease.v2_complex2) — all deeper follow-ups; and
+    # AppInstanceId_DirectoryLeasing_NoLeaseInReOpen (NotExecuted — needs
+    # app-instance-id directory support).
+    set(WPTS_SMB2_DIRLEASE_ALLOWLIST
+        BVT_DirectoryLeasing_ReadWriteHandleCaching
+        DirectoryLeasing_BreakHandleCachingByConflictOpen
+        DirectoryLeasing_BreakReadCachingByChildAdded
+        DirectoryLeasing_BreakReadCachingByChildDeleted
+        DirectoryLeasing_BreakReadCachingByChildModified
+        DirectoryLeasing_BreakReadCachingByChildRenamed
+        DirectoryLeasing_Negative_InvalidLeaseStateInLeaseBreakAck
+        DirectoryLeasing_Negative_SMB2002
+        DirectoryLeasing_Negative_SMB21
+        DirectoryLeasing_ReadCaching
+        DirectoryLeasing_ReadHandleCaching
+        DirectoryLeasing_ReadWriteCaching
+        DirectoryLeasing_RWGrantedAsR
+        DirectoryLeasing_RWHGrantedAsRH)
+
+    string(REPLACE ";" "," _wpts_tests "${WPTS_SMB2_DIRLEASE_ALLOWLIST}")
+    add_test(NAME chimera/server/smb/wpts/memfs_dirlease
+        COMMAND ${CMAKE_SOURCE_DIR}/scripts/wpts_smb_test_wrapper.sh
+                ${CHIMERA_DAEMON} memfs "${_wpts_tests}")
+    set_tests_properties(chimera/server/smb/wpts/memfs_dirlease PROPERTIES
+        LABELS "smb;wpts;dirlease"
+        TIMEOUT 900
+        ENVIRONMENT "WPTS_BIN_DIR=${WPTS_BIN_DIR};DOTNET=${WPTS_DOTNET};CHIMERA_SMB_DIRLEASE=1")
+
     message(STATUS "WPTS MS-SMB2 tests: enabled (${WPTS_BIN_DIR}, ${WPTS_DOTNET})")
 elseif(CHIMERA_NETNS_TESTING AND WPTS_DOTNET AND WPTS_SMB2_DLL AND NOT WPTS_ARCH_SUPPORTED)
     message(STATUS "WPTS MS-SMB2 tests: disabled "


### PR DESCRIPTION
Enables the WPTS MS-SMB2 **DirectoryLeasing** suite on memfs and fixes the root causes it surfaces, taking it from **3/19 → 15/19** passing. No regression: memfs `smb2.lease`/`oplock`/`durable` smbtorture suites are 112/112, and the dirlease smbtorture subtests from #803 stay green.

## Fixes

1. **SMB 3.1.1 preauth over the SMB1 multi-protocol negotiate** (`smb.c`) — the SMB1 NEGOTIATE is answered with an SMB2 NEGOTIATE response carrying the `0x02ff` wildcard ("send a real SMB2 NEGOTIATE next"). The client does **not** fold that into `Connection.PreauthIntegrityHashValue` (MS-SMB2 3.3.5.3.1), but chimera did — corrupting the 3.1.1 signing key, so every signed request after `SESSION_SETUP` (first being `TREE_CONNECT`) failed signature on such connections. The WPTS SUT control adapter forces `isSmb1NegotiateEnabled=true`, so it could never connect to mutate a leased directory → no lease break. Fix: skip the preauth fold for a NEGOTIATE response whose `r_dialect == 0x02ff`. Pre-existing, broad bug affecting any client reaching SMB 3.1.1 via the SMB1 multi-protocol negotiate.

2. **CREATE pathname length** (`smb2.h`, `smb_internal.h`, `smb_proc_create.c`) — `SMB_FILENAME_MAX` (255, the per-component limit) was applied as a byte cap on the whole CREATE path, so longer paths returned `NAME_TOO_LONG`. Add `SMB_PATH_MAX` (4096, matching `CHIMERA_VFS_PATH_MAX`) for the full-path buffers and length check; per-component buffers stay 255.

3. **Directory leasing requires SMB 3.0+** (`smb_proc_create.c`) — gate the directory-lease grant on the negotiated dialect, so a v2 RqLs context sent over SMB 2.0.2 / 2.1 is ignored and the open returns `OPLOCK_LEVEL_NONE`.

## Test wiring

`CHIMERA_SMB_DIRLEASE=1` in `wpts_smb_test_wrapper.sh` (enables `smb_directory_leases` and advertises `IsDirectoryLeasingSupported`), plus:
- a `memfs_dirlease` ctest group (14 cases), and
- a `memfs_dirlease_appinstance` combined group running `AppInstanceId_DirectoryLeasing_NoLeaseInReOpen` with directory leases + persistent handles + multichannel all advertised (the case asserts `GLOBAL_CAP_PERSISTENT_HANDLES` and needs a second client NIC for its failover; passes with no server change once applicable).

## Known follow-ups (left out of the allowlist)

- `LeaseBreakOnMultiClients` — needs multi-holder HANDLE-break fan-out across sequential break/ack in the share-conflict acquire path.
- `BreakHandleCachingByParentRenamed` — needs dir-rename denial while a descendant handle is open (`ACCESS_DENIED`) plus the descendant handle-lease break.
- `Negative_InvalidLeaseKey` / `Negative_InvalidClientGuid` — lease-break-ack key validation needs a per-**client** lease-key registry shared across the client's sessions/channels (a client may grant a lease key on one session and ack the break on a sibling session — `smb2.lease.v2_complex2`), so a per-tree-open or per-session check is insufficient.
