### PR TITLE
smb/wpts: isolate vstest .NET named-mutex shm per session (fix NuGet-Migrations flake)

### DIFF
--- a/scripts/wpts_smb_test_wrapper.sh
+++ b/scripts/wpts_smb_test_wrapper.sh
@@ -368,7 +368,22 @@ fi
 # Suppress the .NET first-run experience (telemetry notice + dev-cert
 # generation): it pollutes output and writes to HOME, which may be unset or
 # read-only under ctest/CI.
-ip netns exec "${NETNS_NAME}" env \
+#
+# Run under `setsid` so this vstest gets its own POSIX session id. The .NET
+# runtime backs named mutexes with shared-memory files under a hardcoded
+# /tmp/.dotnet/shm/session<SID>/ directory (the path is NOT relocatable via
+# TMPDIR/HOME -- see dotnet/runtime#49822), scoped by the *session* id. Under
+# `ctest -j N` every wrapper invocation is a child of the same ctest session,
+# so concurrent cold-start vstests collide on the one shared
+# session<SID>/NuGet-Migrations mutex; the loser of the first-run NuGet
+# migration race aborts in ~2s with
+#   System.IO.IOException: ... : 'NuGet-Migrations'
+# before any test body runs, and passes on --rerun-failed. Giving each vstest
+# its own session id (SID == its own pid) gives it a private shm directory, so
+# the mutex can no longer be shared or raced. `setsid -w` keeps us blocking on
+# the child and propagates its exit code.
+setsid -w \
+    ip netns exec "${NETNS_NAME}" env \
     DOTNET_CLI_TELEMETRY_OPTOUT=1 \
     DOTNET_NOLOGO=1 \
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1 \


### PR DESCRIPTION
## Problem

The `chimera/server/smb/wpts/memfs*` test cluster flakes intermittently in CI (~36 observations on #733). The signature is identical across `memfs_compression`, `memfs_compression_encryption`, and `memfs_multichannel_encryption`: the first WPTS test scheduled in a parallel `ctest` burst fails in ~1.7-2s, **before the test body runs**, with

```
System.IO.IOException: The system cannot open the device or file specified. : 'NuGet-Migrations'
```

and then passes on `--rerun-failed`. It is **not** a chimera server bug, codec bug, or lease/timing bug — it is a .NET test-runner startup race.

## Root cause

WPTS runs via `dotnet vstest`. On its first run vstest performs a NuGet settings migration guarded by the .NET **named mutex `NuGet-Migrations`**. The .NET runtime backs named mutexes with shared-memory files in a **hardcoded `/tmp/.dotnet/shm/session<SID>/` directory** — the path is **not** relocatable via `TMPDIR` or `HOME` ([dotnet/runtime#49822](https://github.com/dotnet/runtime/issues/49822)) — and it is scoped by the POSIX **session id**.

Under `ctest -j N`, every wrapper invocation is a child of the same ctest session, so all concurrent cold-start vstests share the one `session<SID>/NuGet-Migrations` mutex and race the first-run migration. The loser aborts with the `IOException` above. The existing per-test `HOME` isolation in `wpts_smb_test_wrapper.sh` does not help, because the mutex shm lives under `/tmp`-style TMPDIR space, not under `HOME`.

## Fix

Run the vstest invocation under **`setsid`** so each gets its own session id (`SID == its own pid`) and therefore a **private** `/tmp/.dotnet/shm/session<SID>/` directory. The `NuGet-Migrations` mutex can no longer be shared or raced. `setsid -w` preserves the blocking wait and propagates the exit code; netns-based cleanup still reaps the child by namespace membership.

> Note: the originally hypothesized per-process `TMPDIR` fix does **not** work here — `strace` and dotnet/runtime#49822 both confirm the named-mutex shm path ignores `TMPDIR`/`HOME` and is hardcoded under `/tmp`, keyed by session id. `setsid` is what actually isolates it.

## Evidence (before / after, via strace of the real `dotnet vstest` invocation)

**Before** (shared ctest session — current `main`), 6 concurrent vstests:
```
6 /tmp/.dotnet/shm/session2744291/NuGet-Migrations   <- all 6 share ONE mutex
```

**After** (`setsid`), 32 concurrent vstests:
```
distinct shm session dirs across 32 setsid'd vstests: 32
any with shared dir (count>1)?:  <none>
NuGet-Migrations IOExceptions: 0
```

Every concurrent vstest gets its own session dir; zero sharing, zero contention.

WPTS tests still run and pass under `setsid` (not skipped): `ctest -R 'wpts' -j 7 --repeat until-fail` stays green, and the non-WPTS `server/smb` suite is unaffected (the wrapper change only touches the vstest launch line).

This single change covers the whole `wpts/memfs*` flake cluster.

Refs #733.
