### PR TITLE
vfs: stop the close thread before delegation threads on teardown (fixes cairn doorbell ring-after-close)

### DIFF
--- a/src/vfs/vfs.c
+++ b/src/vfs/vfs.c
@@ -845,10 +845,20 @@ chimera_vfs_destroy(struct chimera_vfs *vfs)
         vfs->identity = NULL;
     }
 
-    /* Destroy delegation threads before the close thread so that any
-     * in-flight delegated close operations finish and their completion
-     * doorbell rings execute before the close thread's vfs_thread
-     * (and its doorbell) is freed. */
+    /* Stop the close thread before the delegation threads.  The shutdown-drain
+     * handshake above (signaled only when num_pending == 0) already guarantees
+     * every close the close thread dispatched to a delegation thread has
+     * completed and rung back, so no in-flight delegated close remains.  But the
+     * close thread's event loop is still running after that handshake -- its
+     * periodic timer sweep and idle-lease reaper can issue *new* closes, which
+     * for a CHIMERA_VFS_CAP_BLOCKING backend (cairn, diskfs) route through a
+     * delegation thread and ring its doorbell.  If the delegation threads (and
+     * their doorbells) were torn down first, such a late close would ring a
+     * closed doorbell fd -> EBADF fatal abort (a use-after-close of the
+     * doorbell's eventfd).  Quiescing the close thread first closes that window;
+     * its own doorbell/timer-driven completions need no delegation thread. */
+    evpl_thread_destroy(vfs->close_thread.evpl_thread);
+
     for (i = 0; i < vfs->num_sync_delegation_threads; i++) {
         evpl_thread_destroy(vfs->sync_delegation_threads[i].evpl_thread);
     }
@@ -858,8 +868,6 @@ chimera_vfs_destroy(struct chimera_vfs *vfs)
         evpl_thread_destroy(vfs->async_delegation_threads[i].evpl_thread);
     }
     free(vfs->async_delegation_threads);
-
-    evpl_thread_destroy(vfs->close_thread.evpl_thread);
 
     chimera_vfs_mount_table_destroy(vfs->mount_table);
 


### PR DESCRIPTION
## Problem

`chimera/posix/pjd/open/03/cairn` (and other cairn posix tests) intermittently abort during teardown with the fatal libevpl error (tracker #733):

```
level=fatal module=core file="ext/libevpl/src/core/doorbell.c:86"
message="failed to write to doorbell fd <N>: len=-1 errno=9 (Bad file descriptor)"
```

A thread rang an evpl doorbell whose eventfd was already closed (EBADF) -> the write at `doorbell.c:86` failed -> fatal. fails-once / passes-on-rerun, cairn-only.

## Root cause: teardown ordering in `chimera_vfs_destroy`

`chimera_vfs_destroy()` destroyed the sync/async delegation threads (which `evpl_remove_doorbell` -> `close()` their doorbell eventfds) **before** stopping the close thread, while leaving the close thread's event loop running until afterwards.

The shutdown-drain handshake guarantees every close the close thread had *already dispatched* to a delegation thread has completed and rung back (it signals only when `num_pending == 0`), so no in-flight delegated close remains. But the still-running close thread's **periodic timer sweep** and **idle-lease reaper** can issue *new* closes. For a `CHIMERA_VFS_CAP_BLOCKING` backend (cairn, diskfs) a close routes through a delegation thread and rings its doorbell:

```
chimera_vfs_close_thread_wake_timer -> chimera_vfs_close_thread_sweep
  -> chimera_vfs_close -> chimera_vfs_dispatch -> chimera_vfs_post_to_delegation
  -> evpl_ring_doorbell(&delegation_thread->doorbell)  // fd already close()d
  -> write(closed fd) -> EBADF -> fatal (doorbell.c:86)
```

It is **cairn-specific** because non-blocking backends (memfs, linux) run their closes inline on the close thread and never ring a delegation doorbell. cairn/diskfs (RocksDB / block I/O, `CAP_BLOCKING`) always route closes through the delegation pool.

### Crash backtrace (reproduced under ASan, window widened)

The same race as a heap-use-after-free on the delegation-thread struct (the EBADF is the production manifestation when that memory is still mapped):

```
ERROR: AddressSanitizer: heap-use-after-free
READ of size 8 ... thread T234 (the close thread):
  #0 chimera_vfs_post_to_delegation        src/vfs/vfs_internal.h:439
  #1 chimera_vfs_dispatch                  src/vfs/vfs_internal.h:466
  #2 chimera_vfs_close                     src/vfs/vfs_proc_close.c:57
  #3 chimera_vfs_close_thread_sweep        src/vfs/vfs.c:188
  #4 chimera_vfs_close_thread_wake_timer   src/vfs/vfs.c:271
freed by thread T0 (teardown):
  #1 chimera_vfs_destroy                   src/vfs/vfs.c   (free(sync_delegation_threads))
  #2 chimera_destroy                       src/client/client.c:391
  #3 chimera_posix_shutdown                src/posix/posix.c:341
```

## Fix

Quiesce the close thread (`evpl_thread_destroy`) **before** destroying the delegation threads. Once the drain handshake completes, the close thread has no in-flight delegated work; stopping it first means no late timer/reaper close can reach an already-freed/closed delegation doorbell. The close thread's own doorbell/timer-driven completions need no delegation thread.

## Verification

- Reproduced deterministically under ASan by widening the teardown window (300ms gap + forcing the timer to close a leftover handle): crashed every run with the stack above. After the fix the widened-window repro is clean (no UAF, no EBADF).
- `posix/.*cairn` suite: 466/466 pass, Release **and** Debug/ASan.
- `posix/pjd/open/03/cairn` repeat-until-fail: 200x Release, 120x Debug/ASan, clean.
- 720 parallel start/stop runs of the target under CPU load: clean.
- No regression: all 804 `posix/pjd` (all backends) + 1402 local-backend `posix` tests pass (Release).
- Change is chimera-side only; the libevpl submodule is untouched (the lifecycle contract "don't ring a closed doorbell" is correct; chimera was violating it).

Ref #733.