### PR TITLE
smb2: fix durable-open open2-lease disconnect-vs-conflicting-open race (SHARING_VIOLATION)

### DIFF
--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -2139,6 +2139,14 @@ chimera_smb_server_notify(
             chimera_smb_info("Disconnected %s SMB connection from %s to %s, handled %lu requests",
                              conn->protocol == EVPL_DATAGRAM_RDMACM_RC ? "RDMA" : "TCP",
                              conn->remote_addr, conn->local_addr, conn->requests_completed);
+            /* Flag the connection disconnecting up front, before the (possibly
+             * delayed) teardown that parks its durable handles.  A conflicting
+             * CREATE racing in on another connection consults this through the
+             * durable registry: a still-live durable holder whose owning conn is
+             * flagged disconnecting is about to yield, so the CREATE retries
+             * briefly instead of returning SHARING_VIOLATION against a reservation
+             * that has not been parked yet (durable-open.open2-lease). */
+            conn->disconnecting = 1;
             /* Test hook: delay disconnect processing to deterministically widen
              * the window between a client's TCP close and the server-side
              * teardown that parks its durable handles.  A request racing into

--- a/src/server/smb/smb_durable.c
+++ b/src/server/smb/smb_durable.c
@@ -289,6 +289,41 @@ chimera_smb_durable_purge_parked(
     return true;
 } /* chimera_smb_durable_purge_parked */
 
+/* A conflicting CREATE found a still-live (not-yet-parked) durable open by its
+ * persistent id and could not purge it.  Decide whether that holder is merely
+ * racing its own disconnect -- its owning connection has begun teardown but has
+ * not parked the handle yet (the open2-lease / disconnect-vs-conflicting-open
+ * window) -- in which case the conflicting CREATE should retry briefly rather
+ * than deny: MS-SMB2 has the disconnected non-persistent handle yield, and a
+ * short retry lets the park complete so the purge then succeeds.
+ *
+ * Returns true iff a matching non-persistent, non-cold, NOT-yet-parked durable
+ * entry exists whose owning open has lost its connection (create_conn == NULL,
+ * i.e. conn_free already cleared it) OR whose connection is flagged
+ * disconnecting (the teardown is queued but has not run).  A genuinely-live
+ * durable holder on an active connection returns false, so its conflict stands
+ * as a real SHARING_VIOLATION without any retry delay.  Persistent handles do
+ * not yield, so they are excluded. */
+SYMBOL_EXPORT bool
+chimera_smb_durable_conn_disconnecting(
+    struct chimera_server_smb_shared *shared,
+    uint64_t                          persistent_id)
+{
+    struct chimera_smb_durable_entry *entry;
+    bool                              disconnecting = false;
+
+    pthread_mutex_lock(&shared->durable.lock);
+    HASH_FIND(hh, shared->durable.by_pid, &persistent_id, sizeof(persistent_id), entry);
+    if (entry && !entry->parked && !entry->persistent && !entry->cold &&
+        entry->open_file) {
+        struct chimera_smb_conn *cc = entry->open_file->create_conn;
+        disconnecting = (cc == NULL) || cc->disconnecting;
+    }
+    pthread_mutex_unlock(&shared->durable.lock);
+
+    return disconnecting;
+} /* chimera_smb_durable_conn_disconnecting */
+
 SYMBOL_EXPORT void
 chimera_smb_durable_park(
     struct chimera_server_smb_shared *shared,

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -472,6 +472,14 @@ struct chimera_smb_request {
             uint8_t                         access_retries;
             /* Open handle parked across the access-retry getattr. */
             struct chimera_vfs_open_handle *access_retry_oh;
+            /* Bounded retry budget + parked handle for a share conflict against a
+             * durable holder whose owning connection is mid-disconnect: the
+             * holder will yield once its disconnect parks it, so re-attempt the
+             * open completion on a short timer until it does (or the budget
+             * lapses into a real SHARING_VIOLATION).  See
+             * chimera_smb_create_open_at_callback. */
+            uint16_t                        share_conflict_retries;
+            struct chimera_vfs_open_handle *share_conflict_oh;
             /* Set by the durable-reconnect path: this CREATE is reclaiming a
             * surviving open, not opening a new one.  The access was granted at
             * the original open, and MS-SMB2 has the reconnect ignore the
@@ -562,6 +570,12 @@ struct chimera_smb_request {
             struct chimera_vfs_pending_acquire gen_ticket;
             uint8_t                            gen_held_granted;
             uint8_t                            gen_parked;
+            /* Set by chimera_smb_create_gen_open_file_normal when the share
+             * conflict it could not resolve is against a durable holder whose
+             * owning connection is mid-disconnect (it will park+yield shortly).
+             * Tells the open-completion path to retry on a short timer instead of
+             * failing SHARING_VIOLATION.  Cleared per create attempt. */
+            uint8_t                            gen_share_retry;
             /* GRANTED/DENIED result stashed by chimera_smb_create_share_park_cb
              * when the share-park ticket resolves on another thread, so the
              * owning thread's resume doorbell can finish the open with it.  The
@@ -1031,6 +1045,15 @@ struct chimera_smb_conn {
      * on another thread does not enqueue a send for a connection whose bind is
      * being torn down.  Reset on reuse in chimera_smb_conn_alloc. */
     uint8_t                            lease_break_tearing_down;
+    /* Set at the very start of disconnect processing (EVPL_NOTIFY_DISCONNECTED),
+     * BEFORE the heavyweight session/tree teardown that parks this connection's
+     * durable handles.  A conflicting CREATE racing into that window on another
+     * connection (the disconnect-vs-conflicting-open race: the durable holder's
+     * share reservation is still live because its disconnect has not yet parked
+     * it) reads this through the durable registry to tell "this durable's owner
+     * is gone, it will yield -- retry briefly" from "a genuinely-live durable
+     * holder -- real SHARING_VIOLATION".  Cleared on reuse in conn_alloc. */
+    uint8_t                            disconnecting;
     /* Count of compounds in flight on THIS connection (guarded by the owning
     * thread's lease_break_lock).  A dir-lease break whose holder connection is
     * mid-compound is a self-break: the same connection's reply must precede the
@@ -1375,6 +1398,16 @@ chimera_smb_durable_drain_all(
 bool
 chimera_smb_durable_purge_parked(
     struct chimera_server_smb_thread *thread,
+    uint64_t                          persistent_id);
+
+/* True iff a non-persistent durable open with this persistent id exists, is not
+ * yet parked, and its owning connection has begun disconnecting (create_conn
+ * cleared or flagged disconnecting) -- i.e. a conflicting CREATE should retry
+ * briefly for the disconnect to park+yield it rather than deny SHARING_VIOLATION.
+ * False for a genuinely-live durable holder (real conflict) or unknown id. */
+bool
+chimera_smb_durable_conn_disconnecting(
+    struct chimera_server_smb_shared *shared,
     uint64_t                          persistent_id);
 
 /* Scan a share's backend (routed via `fh`) for persisted handle records and
@@ -1963,6 +1996,7 @@ chimera_smb_conn_alloc(struct chimera_server_smb_thread *thread)
     if (conn) {
         LL_DELETE(thread->free_conns, conn);
         conn->lease_break_tearing_down = 0;
+        conn->disconnecting            = 0;
         conn->in_compound              = 0;
     } else {
         conn = calloc(1, sizeof(*conn));

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -20,34 +20,34 @@
 #include "smb_lsarpc.h"
 #include "smb_srvsvc.h"
 
-#define SMB2_WRITE_MASK                   (SMB2_FILE_WRITE_DATA | \
-                                           SMB2_FILE_APPEND_DATA | \
-                                           SMB2_FILE_WRITE_EA | \
-                                           SMB2_FILE_WRITE_ATTRIBUTES | \
-                                           SMB2_FILE_DELETE_CHILD | \
-                                           SMB2_FILE_ADD_FILE | \
-                                           SMB2_FILE_ADD_SUBDIRECTORY | \
-                                           SMB2_DELETE | \
-                                           SMB2_WRITE_DACL | \
-                                           SMB2_WRITE_OWNER | \
-                                           SMB2_GENERIC_WRITE | \
-                                           SMB2_GENERIC_ALL)
+#define SMB2_WRITE_MASK                            (SMB2_FILE_WRITE_DATA | \
+                                                    SMB2_FILE_APPEND_DATA | \
+                                                    SMB2_FILE_WRITE_EA | \
+                                                    SMB2_FILE_WRITE_ATTRIBUTES | \
+                                                    SMB2_FILE_DELETE_CHILD | \
+                                                    SMB2_FILE_ADD_FILE | \
+                                                    SMB2_FILE_ADD_SUBDIRECTORY | \
+                                                    SMB2_DELETE | \
+                                                    SMB2_WRITE_DACL | \
+                                                    SMB2_WRITE_OWNER | \
+                                                    SMB2_GENERIC_WRITE | \
+                                                    SMB2_GENERIC_ALL)
 
 /* Bits in DesiredAccess that imply the caller will read or write file
  * data.  Without any of these set, the open is metadata-only — common
  * for tools probing for rename/delete — and is satisfiable with an
  * O_PATH-style handle on both files and directories. */
-#define SMB2_DATA_ACCESS_MASK             (SMB2_FILE_READ_DATA | \
-                                           SMB2_FILE_WRITE_DATA | \
-                                           SMB2_FILE_APPEND_DATA | \
-                                           SMB2_FILE_READ_EA | \
-                                           SMB2_FILE_WRITE_EA | \
-                                           SMB2_FILE_EXECUTE | \
-                                           SMB2_GENERIC_READ | \
-                                           SMB2_GENERIC_WRITE | \
-                                           SMB2_GENERIC_EXECUTE | \
-                                           SMB2_GENERIC_ALL | \
-                                           SMB2_MAXIMUM_ALLOWED)
+#define SMB2_DATA_ACCESS_MASK                      (SMB2_FILE_READ_DATA | \
+                                                    SMB2_FILE_WRITE_DATA | \
+                                                    SMB2_FILE_APPEND_DATA | \
+                                                    SMB2_FILE_READ_EA | \
+                                                    SMB2_FILE_WRITE_EA | \
+                                                    SMB2_FILE_EXECUTE | \
+                                                    SMB2_GENERIC_READ | \
+                                                    SMB2_GENERIC_WRITE | \
+                                                    SMB2_GENERIC_EXECUTE | \
+                                                    SMB2_GENERIC_ALL | \
+                                                    SMB2_MAXIMUM_ALLOWED)
 
 /* Re-getattr budget for an ACCESS_DENIED that looks like the transient
  * server-owned state of an object a concurrent CREATE is still constructing
@@ -56,7 +56,16 @@
  * 32 retries to accommodate slow arm64 Debug / io_uring builds where the
  * ASan + async overhead can extend the racing creator's chown window well
  * past 8 round trips. */
-#define CHIMERA_SMB_CREATE_ACCESS_RETRIES 32
+#define CHIMERA_SMB_CREATE_ACCESS_RETRIES          32
+
+/* Retry budget + interval for a share conflict against a durable holder whose
+ * owning connection is mid-disconnect (the holder will park + yield shortly).
+ * The window is just the time for the peer connection's disconnect callback to
+ * be scheduled and park the handle, so a short interval with a bounded budget
+ * (~3 s, matching the durable-reconnect retry) covers a loaded CI runner without
+ * delaying a genuinely-live conflict (that path never sets gen_share_retry). */
+#define CHIMERA_SMB_CREATE_SHARE_RETRY_INTERVAL_US 20000  /* 20 ms */
+#define CHIMERA_SMB_CREATE_SHARE_RETRY_MAX         150    /* ~3 s total */
 
 /* Map a VFS error from an open-or-create path to the SMB2 status that
  * Windows clients expect.  EISDIR/ENOTDIR are critical here: cmd.exe and
@@ -782,6 +791,17 @@ chimera_smb_create_gen_open_file(
             }
 
             if (!chimera_smb_durable_purge_parked(thread, conflict_pid)) {
+                /* The durable holder is not parked yet.  If its owning connection
+                 * has begun disconnecting, the park (and the MS-SMB2 yield) is
+                 * imminent but has not landed -- this is the
+                 * disconnect-vs-conflicting-open race (open2-lease).  Flag the
+                 * open to retry on a short timer rather than deny; a genuinely
+                 * live durable holder is not disconnecting, so its conflict
+                 * stands immediately as a real SHARING_VIOLATION. */
+                if (chimera_smb_durable_conn_disconnecting(thread->shared,
+                                                           conflict_pid)) {
+                    request->create.gen_share_retry = 1;
+                }
                 break;
             }
             conflict = NULL;
@@ -1488,6 +1508,11 @@ chimera_smb_create_access_retry_callback(
     struct chimera_vfs_attrs *attr,
     void                     *private_data);
 
+static void
+chimera_smb_create_share_retry_cb(
+    struct evpl       *evpl,
+    struct evpl_timer *timer);
+
 static inline void
 chimera_smb_create_mkdir_callback(
     enum chimera_vfs_error    error_code,
@@ -1794,14 +1819,16 @@ chimera_smb_create_open_at_callback(
      * SHARING_VIOLATION and never waits for the holder to close. */
     request->create.gen_finish_cb = chimera_smb_create_open_finish;
 
-    open_file = chimera_smb_create_gen_open_file_normal(request,
-                                                        request->create.parent_handle->fh,
-                                                        request->create.parent_handle->fh_len,
-                                                        request->create.name,
-                                                        request->create.name_len,
-                                                        request->create.create_options & SMB2_FILE_DELETE_ON_CLOSE,
-                                                        S_ISDIR(attr->va_mode),
-                                                        oh);
+    request->create.gen_share_retry = 0;
+    open_file                       = chimera_smb_create_gen_open_file_normal(request,
+                                                                              request->create.parent_handle->fh,
+                                                                              request->create.parent_handle->fh_len,
+                                                                              request->create.name,
+                                                                              request->create.name_len,
+                                                                              request->create.create_options &
+                                                                              SMB2_FILE_DELETE_ON_CLOSE,
+                                                                              S_ISDIR(attr->va_mode),
+                                                                              oh);
 
     if (request->create.gen_parked) {
         /* Parked on a batch-oplock break; the park cb finishes the open. */
@@ -1809,6 +1836,24 @@ chimera_smb_create_open_at_callback(
     }
 
     if (!open_file) {
+        /* Share conflict against a durable holder whose owning connection is
+         * mid-disconnect: it will park + yield once that disconnect runs, so
+         * re-attempt the open completion on a short timer (holding oh + parent)
+         * rather than failing.  The budget lapses into the original
+         * SHARING_VIOLATION if the holder never yields (e.g. it was actually a
+         * persistent handle or genuinely live -- gen_share_retry would not be
+         * set in that case). */
+        if (request->create.gen_share_retry &&
+            request->create.share_conflict_retries < CHIMERA_SMB_CREATE_SHARE_RETRY_MAX) {
+            request->create.share_conflict_retries++;
+            request->create.share_conflict_oh = oh;
+            evpl_add_oneshot_timer(request->compound->thread->evpl,
+                                   &request->async.timer,
+                                   chimera_smb_create_share_retry_cb,
+                                   CHIMERA_SMB_CREATE_SHARE_RETRY_INTERVAL_US);
+            return;
+        }
+
         chimera_smb_create_release_handle(vfs_thread, oh);
         chimera_smb_create_release_parent(request);
         chimera_smb_complete_request(request, request->create.force_close_status);
@@ -1850,6 +1895,63 @@ chimera_smb_create_access_retry_callback(
                                         &request->create.set_attr, attr,
                                         NULL, NULL, request);
 } /* chimera_smb_create_access_retry_callback */
+
+/* Completion of the share-conflict-retry getattr: the timer fired and re-fetched
+ * the (unchanged) attributes so the open completion can be re-entered with a live
+ * attr pointer, exactly as the access-retry path does.  Re-runs the share
+ * acquire; the conflicting durable holder's disconnect has by now (or on a later
+ * retry) parked + yielded it, so the open is granted.  Shares async.timer with
+ * the access-retry/park machinery -- only one retry path is active at a time. */
+static void
+chimera_smb_create_share_retry_getattr_cb(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *attr,
+    void                     *private_data)
+{
+    struct chimera_smb_request     *request = private_data;
+    struct chimera_vfs_open_handle *oh      = request->create.share_conflict_oh;
+
+    request->create.share_conflict_oh = NULL;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        struct chimera_vfs_thread *vfs_thread =
+            request->compound->thread->vfs_thread;
+
+        chimera_vfs_release(vfs_thread, oh);
+        chimera_vfs_release(vfs_thread, request->create.parent_handle);
+        chimera_smb_complete_request(request,
+                                     chimera_smb_create_error_status(error_code));
+        return;
+    }
+
+    chimera_smb_create_open_at_callback(CHIMERA_VFS_OK, oh,
+                                        &request->create.set_attr, attr,
+                                        NULL, NULL, request);
+} /* chimera_smb_create_share_retry_getattr_cb */
+
+/* Share-conflict retry timer: re-fetch attributes (so the open completion has a
+ * live attr) and re-drive the open.  Runs on the request's own conn thread. */
+static void
+chimera_smb_create_share_retry_cb(
+    struct evpl       *evpl,
+    struct evpl_timer *timer)
+{
+    struct chimera_smb_request     *request = (struct chimera_smb_request *)
+        ((char *) timer - offsetof(struct chimera_smb_request, async.timer));
+    struct chimera_vfs_thread      *vfs_thread =
+        request->compound->thread->vfs_thread;
+    struct chimera_vfs_open_handle *oh = request->create.share_conflict_oh;
+
+    (void) evpl;
+
+    chimera_vfs_getattr(vfs_thread,
+                        &request->session_handle->session->cred,
+                        oh,
+                        CHIMERA_VFS_ATTR_FH | CHIMERA_VFS_ATTR_MASK_STAT |
+                        CHIMERA_VFS_ATTR_ACL | CHIMERA_VFS_ATTR_BTIME,
+                        chimera_smb_create_share_retry_getattr_cb,
+                        request);
+} /* chimera_smb_create_share_retry_cb */
 
 /* Break-deadline for a CREATE parked on a lease break (MS-SMB2 3.3.5.9 / the
  * oplock-break timeout): the holder never acknowledged within the deadline, so
@@ -3536,10 +3638,13 @@ chimera_smb_create(struct chimera_smb_request *request)
     /* Only the regular-file open path (open_at_callback) registers a finish
      * callback and may park on a batch-oplock break; clear it so the mkdir /
      * stream / pipe paths never inherit a stale callback and park. */
-    request->create.gen_finish_cb   = NULL;
-    request->create.gen_parked      = 0;
-    request->create.access_retries  = 0;
-    request->create.access_retry_oh = NULL;
+    request->create.gen_finish_cb          = NULL;
+    request->create.gen_parked             = 0;
+    request->create.gen_share_retry        = 0;
+    request->create.access_retries         = 0;
+    request->create.access_retry_oh        = NULL;
+    request->create.share_conflict_retries = 0;
+    request->create.share_conflict_oh      = NULL;
 
     /* Handle stream-name syntax (file:stream[:$DATA]).  When named streams are
      * disabled (config off, or the backend lacks the capability) the legacy

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -4144,7 +4144,13 @@ if(CHIMERA_NETNS_TESTING AND SMBTORTURE_EXECUTABLE)
     #     MS-SMB2 3.3.7.1, yielded-reclaim, parked-CREATE re-arbitration).
     #   - .reopen2b: the same client's durable reconnect racing the teardown
     #     parking (eager park-on-disconnect; otherwise OBJECT_NAME_NOT_FOUND).
+    #   - .open2-lease: a conflicting open vs a disconnected RH-lease durable
+    #     holder whose share reservation has not parked/yielded yet -- a pure
+    #     SHARE conflict (no breakable handle-cache to park on) that retries
+    #     until the disconnect yields it (otherwise SHARING_VIOLATION).
+    #     open2-oplock exercises the same window through the batch-break path.
     foreach(_sub smb2.durable-open.lease smb2.durable-open.oplock
+                 smb2.durable-open.open2-lease smb2.durable-open.open2-oplock
                  smb2.durable-v2-open.reopen2b)
         string(REGEX REPLACE "[^A-Za-z0-9]" "_" _sid "${_sub}")
         set(_name chimera/server/smb/smbtorture_${_sid}_disconnect_race_memfs)


### PR DESCRIPTION
## Summary

Fixes a load-dependent timing flake in `smb2.durable-open.open2-lease` that surfaced in CI as:

```
source4/torture/smb2/durable_open.c:2630: status was NT_STATUS_SHARING_VIOLATION, expected NT_STATUS_OK
```

This is a **durable-open disconnect-vs-conflicting-open race**, the same family as #767 (reopen2b), #755 (courtesy-hold), and #825 (teardown ordering) — not a regression.

### The race

`test_durable_open_open2_lease`:
1. tree1 opens a file with a durable handle + **RH lease** and `share_access=""` (deny read/write/delete to others).
2. tree1 **disconnects** — its durable handle must park and *yield* to a conflicting open (MS-SMB2: a disconnected non-persistent handle yields).
3. tree2 opens the same file and expects `NT_STATUS_OK` (line 2630).

Under load, tree2's CREATE arrives on its own thread **before tree1's disconnect callback has run** on tree1's thread, so tree1's share reservation is still live and *not yet parked*. The conflicting-open resolution in `chimera_smb_create_gen_open_file_normal` tries `chimera_smb_durable_purge_parked()`, which only purges a **parked** entry — it returns false for the not-yet-parked holder — so the loop falls straight through to `SHARING_VIOLATION`.

Unlike the `.lease`/`.oplock` disconnect-race cases (already handled), `open2-lease` is a **pure SHARE-reservation conflict** with an RH (no-write) lease: there is no breakable handle-cache to park on, so it never reached the existing batch-break park path.

### The fix

Mirror the #767 durable-reconnect retry, but on the **conflicting-open** side:

- Flag the connection `disconnecting` at the very start of `EVPL_NOTIFY_DISCONNECTED`, before the (possibly delayed) teardown that parks its durable handles.
- When a conflicting CREATE hits a share conflict against a non-persistent durable holder it cannot purge, `chimera_smb_durable_conn_disconnecting()` checks whether that holder's owning connection has begun disconnecting (`create_conn == NULL`, or flagged `disconnecting`). If so, the holder is about to park + yield, so the CREATE re-attempts the open completion on a short timer (~3 s budget, 20 ms interval) instead of denying.
- A **genuinely-live** durable holder on an active connection is *not* disconnecting, so its conflict still returns `SHARING_VIOLATION` immediately — no added latency on the legitimate-conflict path.

Relation to the family: #767 retries the *reclaiming* (same-client reconnect) CREATE when the prior handle hasn't parked; this retries the *conflicting* (other-client) CREATE in the same not-yet-parked window. Same root cause (reopen/open racing prior-handle teardown), symmetric fix.

### Deterministic repro + verification

Reproduced 100% with the existing `CHIMERA_SMB_TEST_DISCONNECT_DELAY_MS` knob (added by #755), which holds the disconnect teardown so the conflicting CREATE always lands in the window:

```
CHIMERA_SMB_TEST_DISCONNECT_DELAY_MS=50 smbtorture ... smb2.durable-open.open2-lease
# before: SHARING_VIOLATION (100%)   after: NT_STATUS_OK (100%, delays 50/100/200/500 ms)
```

Added `open2-lease` and `open2-oplock` to the `*_disconnect_race_memfs` regression list in `tests/CMakeLists.txt` as deterministic guards.

The #825 oplock case (`smb2.durable-open.oplock` / `open2-oplock`) and the rest of the durable/lease/oplock cluster stay green (memfs + linux + diskfs + cairn, Release + Debug/ASan).

Ref #733.
