### PR TITLE
smb2: park a conflicting open on a legacy-oplock holder's break (batch3/batch7)

### DIFF
--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -1458,6 +1458,7 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.oplock.batch15
     smb2.oplock.batch16
     smb2.oplock.batch2
+    smb2.oplock.batch3
     smb2.oplock.batch21
     smb2.oplock.batch23
     smb2.oplock.batch24
@@ -1465,6 +1466,7 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.oplock.batch4
     smb2.oplock.batch5
     smb2.oplock.batch6
+    smb2.oplock.batch7
     smb2.oplock.batch8
     smb2.oplock.brl2
     smb2.oplock.exclusive1
@@ -3324,6 +3326,7 @@ set(SMBTORTURE_ENABLED_diskfs_io_uring
     smb2.oplock.batch15
     smb2.oplock.batch16
     smb2.oplock.batch2
+    smb2.oplock.batch3
     smb2.oplock.batch21
     smb2.oplock.batch23
     smb2.oplock.batch24
@@ -3331,6 +3334,7 @@ set(SMBTORTURE_ENABLED_diskfs_io_uring
     smb2.oplock.batch4
     smb2.oplock.batch5
     smb2.oplock.batch6
+    smb2.oplock.batch7
     smb2.oplock.batch8
     smb2.oplock.brl2
     smb2.oplock.exclusive1

--- a/src/vfs/vfs_state.c
+++ b/src/vfs/vfs_state.c
@@ -527,15 +527,30 @@ chimera_vfs_share_batch_escape(
         }
 
         /* Match the breakable handle-caching lease to the conflicting share
-        * holder.  A legacy file oplock shares its owning open with the share
-        * reservation (cb_private set identically).  A directory lease's grant
-        * is keyed by lease key (cb_private = grant, not the open), so match it
-        * to the share holder by client instead: a conflicting open of a leased
-        * directory breaks the dir lease's HANDLE (RH->R); the holder may close
-        * to free the share conflict, else it stands (SHARING_VIOLATION). */
+         * holder.  Three cases, none of which compare cb_private directly: a
+         * legacy oplock's caching-lease cb_private is its grant (smb create
+         * grant->lease.owner.cb_private = grant) while the share reservation's
+         * cb_private is the open_file, so they never match -- but for a legacy
+         * (non-dir) file oplock the open IS the owner, so the caching lease's
+         * (client_key, owner_lo, owner_hi) == the share holder's open file id
+         * (file_id.pid/vid set identically on both). A directory lease's grant
+         * is keyed by lease key, so match it to the share holder by client
+         * instead: a conflicting open of a leased directory breaks the dir
+         * lease's HANDLE (RH->R); the holder may close to free the share
+         * conflict, else it stands (SHARING_VIOLATION). Guard the legacy-oplock
+         * arm with is_oplock so RqLs file leases and dir-lease semantics are
+         * untouched. */
+        bool legacy_oplock_match =
+            cur->grant && cur->grant->is_oplock && !cur->grant->is_dir &&
+            cur->owner.client_key == share_holder->owner.client_key &&
+            cur->owner.owner_lo == share_holder->owner.owner_lo &&
+            cur->owner.owner_hi == share_holder->owner.owner_hi;
+        bool dir_lease_match =
+            cur->grant && cur->grant->is_dir &&
+            cur->owner.client_key == share_holder->owner.client_key;
+
         if (cur->owner.cb_private != share_holder->owner.cb_private &&
-            !(cur->grant && cur->grant->is_dir &&
-              cur->owner.client_key == share_holder->owner.client_key)) {
+            !legacy_oplock_match && !dir_lease_match) {
             continue;
         }
 


### PR DESCRIPTION
## Summary

`smb2.oplock.batch3` and `smb2.oplock.batch7` failed with a synchronous
`SHARING_VIOLATION` where MS-FSA requires the conflicting open to **park** on
the batch-oplock holder's break and only then be granted (the holder closes) or
denied (the holder keeps its handle).

Root cause is in `chimera_vfs_share_batch_escape()` (`src/vfs/vfs_state.c`),
which finds the still-breakable handle-caching lease that a hard share conflict
should park on. It matched the batch-oplock holder's caching lease to the
conflicting share reservation by `cb_private`. But for a **legacy file oplock**
the caching grant sets `grant->lease.owner.cb_private = grant`
(`smb_proc_create.c`), while the share reservation sets
`share_lease.owner.cb_private = open_file` — so the two never compare equal for
a non-directory oplock. The escape returned NULL, the conflict became a hard
`DENIED`, and the (correct, already-complete) parked-CREATE / resume machinery
was bypassed. Only the directory-lease fallback (match by `client_key`) worked.

## Fix

Add an explicit legacy-oplock match arm: a caching grant with `is_oplock`
(and `!is_dir`) matches the share holder when `client_key`, `owner_lo`, and
`owner_hi` are all equal. For a legacy oplock these are identical to the
share holder's open — both carry the open's `file_id.pid` / `file_id.vid` and
the session's `client_key` — so the match is exact. The arm is guarded by
`is_oplock` so RqLs file leases and directory-lease semantics are untouched.

This reuses the existing, proven park/resume path: `batch5` already exercises
the DENIED resume; the only newly reachable behavior is parking for the GRANTED
outcome (`batch3` / `batch7`).

`batch3` and `batch7` are added to `SMBTORTURE_ENABLED_memfs` and
`SMBTORTURE_ENABLED_diskfs_io_uring` under `# smb2.oplock`.

## Verification

- `batch3`, `batch7`, `batch5` pass 3x on **memfs** and **diskfs_io_uring**.
- Full enabled `smb2.oplock`, `smb2.lease`, `smb2.durable-open`,
  `smb2.durable-v2-open`, `smb2.compound_async` suites: zero failures on both
  backends (memfs 119/119, diskfs_io_uring 118/118).
- Durable disconnect-race ctests (`CHIMERA_SMB_TEST_DISCONNECT_DELAY_MS=50`):
  5/5 pass. NFSv4 delegation ctests (memfs): 26/26 pass.
- Release (GCC11 `-Werror`) clean; scan-build reports no bugs; `make syntax`
  clean; copyright-year check clean.
