### PR TITLE
smb2: emit FileAllInformation name as UTF-16LE (batch19/batch20)

### DIFF
--- a/src/server/smb/smb_attr.h
+++ b/src/server/smb/smb_attr.h
@@ -722,12 +722,25 @@ chimera_smb_append_all_info(
     {
         uint16_t *nb;
 
-        evpl_iovec_cursor_append_uint32(cursor, open_file->full_path_len * 2);
-        nb = evpl_iovec_cursor_data(cursor);
-        chimera_smb_utf8_to_utf16le(iconv_ctx,
-                                    open_file->full_path, open_file->full_path_len,
-                                    nb, SMB_PATH_MAX * 2);
-        evpl_iovec_cursor_skip(cursor, open_file->full_path_len * 2);
+        if (open_file->full_path_len == 0) {
+            /* Share root: Windows reports the FileAllInformation name as "\"
+             * (a single backslash).  An empty name yields a 100-byte reply,
+             * one byte below the Linux cifs client's 101-byte FILE_ALL_INFO
+             * struct minimum, so the mount fails ("buffer length 100 smaller
+             * than minimum size 101").  Note FileNormalizedNameInformation
+             * keeps the empty root name (smb2.getinfo.normalized requires it). */
+            evpl_iovec_cursor_append_uint32(cursor, 2);
+            nb    = evpl_iovec_cursor_data(cursor);
+            nb[0] = (uint16_t) '\\';
+            evpl_iovec_cursor_skip(cursor, 2);
+        } else {
+            evpl_iovec_cursor_append_uint32(cursor, open_file->full_path_len * 2);
+            nb = evpl_iovec_cursor_data(cursor);
+            chimera_smb_utf8_to_utf16le(iconv_ctx,
+                                        open_file->full_path, open_file->full_path_len,
+                                        nb, SMB_PATH_MAX * 2);
+            evpl_iovec_cursor_skip(cursor, open_file->full_path_len * 2);
+        }
     }
 
 } /* chimera_smb_append_all_info */

--- a/src/server/smb/smb_attr.h
+++ b/src/server/smb/smb_attr.h
@@ -11,6 +11,7 @@
 #include "common/evpl_iovec_cursor.h"
 
 #include "smb_session.h"
+#include "smb_string.h"
 
 /* Bitmask for tracking which attributes are populated */
 #define SMB_ATTR_SIZE               (1ULL << 0)
@@ -693,6 +694,7 @@ chimera_smb_append_null_network_open_info_null(struct evpl_iovec_cursor *cursor)
 /* Append for FileAllInformation using the other append functions */
 static inline void
 chimera_smb_append_all_info(
+    struct chimera_smb_iconv_ctx   *iconv_ctx,
     struct evpl_iovec_cursor       *cursor,
     struct chimera_smb_open_file   *open_file,
     const struct chimera_smb_attrs *attrs)
@@ -713,11 +715,19 @@ chimera_smb_append_all_info(
     /* Alignemnt */
     evpl_iovec_cursor_append_uint32(cursor, 4095);
 
-    /* Name Info */
-    evpl_iovec_cursor_append_uint32(cursor, open_file->name_len);
+    /* Name Info: FileNameInformation (MS-FSCC 2.1.7).  FileNameLength is the
+     * length in bytes of the UTF-16LE name, followed by the name itself —
+     * the path relative to the share root (backslash separated, no leading
+     * separator), converted to UTF-16LE. */
+    {
+        uint16_t *nb;
 
-    evpl_iovec_cursor_append_blob(cursor, open_file->name, open_file->name_len);
-
-    evpl_iovec_cursor_append_uint32(cursor, 0); /* padding */
+        evpl_iovec_cursor_append_uint32(cursor, open_file->full_path_len * 2);
+        nb = evpl_iovec_cursor_data(cursor);
+        chimera_smb_utf8_to_utf16le(iconv_ctx,
+                                    open_file->full_path, open_file->full_path_len,
+                                    nb, SMB_PATH_MAX * 2);
+        evpl_iovec_cursor_skip(cursor, open_file->full_path_len * 2);
+    }
 
 } /* chimera_smb_append_all_info */

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -578,6 +578,36 @@ chimera_smb_create_gen_open_file(
     open_file->name_len = name_len;
     memcpy(open_file->name, name, open_file->name_len);
 
+    /* Build the canonical full path (relative to the share root, backslash
+     * separated, no leading separator) reported in FileAllInformation /
+     * FileNameInformation.  request->create.parent_path holds the parent
+     * portion forward-slash converted; reassemble it with the leaf using
+     * backslashes.  Bounded by SMB_PATH_MAX (the on-wire path limit). */
+    {
+        uint32_t parent_len = request->create.parent_path_len;
+        uint32_t total;
+
+        if (parent_len + 1 + name_len > SMB_PATH_MAX - 1) {
+            /* Defensive clamp: the wire path is already bounded to SMB_PATH_MAX,
+             * so this cannot legitimately overflow, but never write past the
+             * buffer if a future caller passes a longer composite. */
+            parent_len = 0;
+        }
+
+        if (parent_len > 0) {
+            memcpy(open_file->full_path, request->create.parent_path, parent_len);
+            chimera_smb_slash_forward_to_back(open_file->full_path, parent_len);
+            open_file->full_path[parent_len] = '\\';
+            memcpy(open_file->full_path + parent_len + 1, name, name_len);
+            total = parent_len + 1 + name_len;
+        } else {
+            memcpy(open_file->full_path, name, name_len);
+            total = name_len;
+        }
+        open_file->full_path[total] = '\0';
+        open_file->full_path_len    = total;
+    }
+
     /* Stream identity is set by the named-stream create path; default to none. */
     open_file->stream_name_len = 0;
     open_file->base_fh_len     = 0;

--- a/src/server/smb/smb_proc_query_info.c
+++ b/src/server/smb/smb_proc_query_info.c
@@ -318,8 +318,12 @@ chimera_smb_query_info(struct chimera_smb_request *request)
                     getattr_mask                      = CHIMERA_VFS_ATTR_MASK_STAT;
                     break;
                 case SMB2_FILE_ALL_INFO:
+                    /* FileAllInformation (MS-FSCC 2.4.2): the trailing
+                     * FileNameInformation carries the share-relative path as
+                     * UTF-16LE, so the variable portion is full_path_len*2 bytes
+                     * (no trailing pad). */
                     request->query_info.output_length = SMB2_FILE_ALL_INFO_FIXED_SIZE + request->query_info.open_file->
-                        name_len + 4;
+                        full_path_len * 2;
                     /* The fixed portion ends after the FileNameLength field; a
                      * shorter buffer is INFO_LENGTH_MISMATCH (smbtorture uses
                      * fixed=104 here). */
@@ -329,8 +333,9 @@ chimera_smb_query_info(struct chimera_smb_request *request)
                 case SMB2_FILE_NORMALIZED_NAME_INFO:
                     /* MS-FSCC 2.4.30 FILE_NAME_INFORMATION layout (FileNameLength
                      * + FileName in UTF-16LE).  The normalized name is the open's
-                     * path, which we already hold (as UTF-8) — no backend attrs. */
-                    request->query_info.output_length = 4 + request->query_info.open_file->name_len * 2;
+                     * share-relative path, which we already hold (as UTF-8) — no
+                     * backend attrs. */
+                    request->query_info.output_length = 4 + request->query_info.open_file->full_path_len * 2;
                     request->query_info.min_length    = 4;
                     break;
                 case SMB2_FILE_FULL_EA_INFO:
@@ -501,20 +506,21 @@ chimera_smb_query_info_reply(
                 case SMB2_FILE_NORMALIZED_NAME_INFO:
                 {
                     /* FILE_NAME_INFORMATION: FileNameLength (UTF-16LE bytes)
-                     * followed by the name converted to UTF-16LE. */
+                     * followed by the share-relative path converted to UTF-16LE. */
                     struct chimera_smb_open_file *of = request->query_info.open_file;
                     uint16_t                     *nb;
 
-                    evpl_iovec_cursor_append_uint32(reply_cursor, of->name_len * 2);
+                    evpl_iovec_cursor_append_uint32(reply_cursor, of->full_path_len * 2);
                     nb = evpl_iovec_cursor_data(reply_cursor);
                     chimera_smb_utf8_to_utf16le(&request->compound->thread->iconv_ctx,
-                                                of->name, of->name_len,
-                                                nb, SMB_FILENAME_MAX * 2);
-                    evpl_iovec_cursor_skip(reply_cursor, of->name_len * 2);
+                                                of->full_path, of->full_path_len,
+                                                nb, SMB_PATH_MAX * 2);
+                    evpl_iovec_cursor_skip(reply_cursor, of->full_path_len * 2);
                     break;
                 }
                 case SMB2_FILE_ALL_INFO:
-                    chimera_smb_append_all_info(reply_cursor, request->query_info.open_file, &request->query_info.
+                    chimera_smb_append_all_info(&request->compound->thread->iconv_ctx,
+                                                reply_cursor, request->query_info.open_file, &request->query_info.
                                                 r_attrs);
                     break;
                 case SMB2_FILE_FULL_EA_INFO:

--- a/src/server/smb/smb_proc_query_info.c
+++ b/src/server/smb/smb_proc_query_info.c
@@ -318,12 +318,15 @@ chimera_smb_query_info(struct chimera_smb_request *request)
                     getattr_mask                      = CHIMERA_VFS_ATTR_MASK_STAT;
                     break;
                 case SMB2_FILE_ALL_INFO:
-                    /* FileAllInformation (MS-FSCC 2.4.2): the trailing
-                     * FileNameInformation carries the share-relative path as
-                     * UTF-16LE, so the variable portion is full_path_len*2 bytes
-                     * (no trailing pad). */
-                    request->query_info.output_length = SMB2_FILE_ALL_INFO_FIXED_SIZE + request->query_info.open_file->
-                        full_path_len * 2;
+                    /* FileAllInformation (MS-FSCC 2.4.2): the fixed 100 bytes
+                     * (FileNameLength field included) followed by the
+                     * share-relative path as UTF-16LE (full_path_len*2).  The
+                     * share root has an empty path; Windows reports its name as
+                     * "\" (2 bytes) so the reply clears the Linux cifs client's
+                     * 101-byte FILE_ALL_INFO minimum (see chimera_smb_append_all_info). */
+                    request->query_info.output_length = SMB2_FILE_ALL_INFO_FIXED_SIZE +
+                        (request->query_info.open_file->full_path_len
+                         ? request->query_info.open_file->full_path_len * 2 : 2);
                     /* The fixed portion ends after the FileNameLength field; a
                      * shorter buffer is INFO_LENGTH_MISMATCH (smbtorture uses
                      * fixed=104 here). */

--- a/src/server/smb/smb_session.h
+++ b/src/server/smb/smb_session.h
@@ -248,6 +248,13 @@ struct chimera_smb_open_file {
     struct chimera_smb_tree          *tree;
     uint8_t                           parent_fh[CHIMERA_VFS_FH_SIZE];
     char                              name[SMB_FILENAME_MAX];
+    /* Full path of this open relative to the share root, backslash-separated
+     * with no leading separator (e.g. "dir\\sub\\file.txt").  `name` above is
+     * only the final component (paired with parent_fh for VFS ops); this is the
+     * canonical name reported in FileAllInformation / FileNameInformation
+     * (MS-FSCC 2.1.7 / 2.4.2) and FileNormalizedNameInformation. */
+    char                              full_path[SMB_PATH_MAX];
+    uint32_t                          full_path_len;
     uint16_t                          pattern[SMB_FILENAME_MAX];
     /* Named-stream (ADS) identity, valid when CHIMERA_SMB_OPEN_FILE_FLAG_STREAM
      * is set.  base_fh is the file the stream hangs off (open_file->handle's fh

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -1421,7 +1421,9 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.oplock.batch14
     smb2.oplock.batch15
     smb2.oplock.batch16
+    smb2.oplock.batch19
     smb2.oplock.batch2
+    smb2.oplock.batch20
     smb2.oplock.batch3
     smb2.oplock.batch21
     smb2.oplock.batch23
@@ -3296,7 +3298,9 @@ set(SMBTORTURE_ENABLED_diskfs_io_uring
     smb2.oplock.batch14
     smb2.oplock.batch15
     smb2.oplock.batch16
+    smb2.oplock.batch19
     smb2.oplock.batch2
+    smb2.oplock.batch20
     smb2.oplock.batch3
     smb2.oplock.batch21
     smb2.oplock.batch23


### PR DESCRIPTION
## Problem

`smb2.oplock.batch19` / `batch20` failed because the `FileNameInformation`
field of `FileAllInformation` was emitted incorrectly:

1. **Wrong encoding.** `chimera_smb_append_all_info()` wrote the name as raw
   UTF-8 with a UTF-8 byte length, but MS-FSCC requires the name as **UTF-16LE**
   with `FileNameLength = name_len * 2`. smbtorture decodes it as UTF-16LE and
   saw byte-swapped mojibake. It also appended a stray trailing 4-byte pad that
   is not part of the structure.

2. **Wrong scope.** Only the final path component was emitted. The
   `FileNameInformation` carried in `FileAllInformation` is the path relative to
   the share root (backslash separated), so smbtorture's
   `qfi.all_info2.out.fname` comparison expected `oplock_test\test_batchNN.dat`
   and got just `test_batchNN.dat`.

## Fix

- Store the canonical share-relative path on the open at CREATE time
  (`open_file->full_path`, reassembled from `request->create.parent_path` + the
  leaf with backslash separators, no leading separator). `open_file->name`
  remains the leaf component — it is paired with `parent_fh` for VFS operations
  (close/unlink, write notify, reparse, share-mode hashing, durable records) and
  must not change.
- Emit `full_path` as UTF-16LE (`FileNameLength = full_path_len * 2`) for both
  `FileAllInformation` and `FileNormalizedNameInformation`, mirroring the
  existing `SMB2_FILE_NORMALIZED_NAME_INFO` conversion via
  `chimera_smb_utf8_to_utf16le()`. The `FileAllInformation` `output_length` is
  updated accordingly and the stray trailing pad is dropped.
- The `FileNormalizedNameInformation` path was also leaf-only (a latent bug);
  it now returns the full share-relative name too.

## Tests

Enables `smb2.oplock.batch19` / `batch20` on `memfs` and `diskfs_io_uring`.

Verified green (3x) on both backends; the full
`smb2.oplock` / `smb2.rename` / `smb2.getinfo` / `smb2.create` / `smb2.charset`
/ `smb2.streams` allowlists pass with zero new failures on both backends
(name-encoding change exercised by getinfo/charset/oplock). Release (GCC
`-Werror`) and scan-build are clean; Debug/ASan green.
