### PR TITLE
smb2: carry the breaking holder's handle in a BRL-triggered oplock break (brl1/brl3)

### DIFF
--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -1425,7 +1425,9 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.oplock.batch5
     smb2.oplock.batch6
     smb2.oplock.batch8
+    smb2.oplock.brl1
     smb2.oplock.brl2
+    smb2.oplock.brl3
     smb2.oplock.exclusive1
     smb2.oplock.exclusive2
     smb2.oplock.exclusive3
@@ -3291,7 +3293,9 @@ set(SMBTORTURE_ENABLED_diskfs_io_uring
     smb2.oplock.batch5
     smb2.oplock.batch6
     smb2.oplock.batch8
+    smb2.oplock.brl1
     smb2.oplock.brl2
+    smb2.oplock.brl3
     smb2.oplock.exclusive1
     smb2.oplock.exclusive2
     smb2.oplock.exclusive3

--- a/src/vfs/vfs_state.c
+++ b/src/vfs/vfs_state.c
@@ -567,6 +567,23 @@ chimera_vfs_lease_holder_reclaimable(
            !holder->owner.is_alive_cb(holder, holder->owner.cb_private);
 } /* chimera_vfs_lease_holder_reclaimable */
 
+/* True when `cur` is a pure read (LEVEL_II / read-only) caching lease that a
+ * byte-range lock taken through its own handle must still break to NONE.  A
+ * shared read oplock/lease cannot coexist with a byte-range lock on its stream
+ * (MS-FSA 2.1.5.18), so the range-vs-caching same-owner self-skip does not apply
+ * to it.  A write- or handle-caching holder (batch / exclusive) is exempt: the
+ * owning handle keeps that cache while locking its own file.  Only a breakable,
+ * not-yet-breaking holder qualifies -- one already mid-break needs no re-break. */
+static inline bool
+chimera_vfs_range_breaks_own_read_cache(const struct chimera_vfs_lease *cur)
+{
+    return (cur->mode.granted & CHIMERA_VFS_LEASE_MODE_R) &&
+           !(cur->mode.granted & (CHIMERA_VFS_LEASE_MODE_W |
+                                  CHIMERA_VFS_LEASE_MODE_H)) &&
+           cur->owner.break_cb &&
+           cur->break_state == CHIMERA_VFS_BREAK_IDLE;
+} /* chimera_vfs_range_breaks_own_read_cache */
+
 SYMBOL_EXPORT enum chimera_vfs_lease_result
 chimera_vfs_state_would_conflict(
     const struct chimera_vfs_file_state *file,
@@ -600,16 +617,24 @@ chimera_vfs_state_would_conflict(
              * cache).  This is the "I/O breaks caching" rule applied
              * conservatively to range locks too. */
             for (cur = file->caching_leases; cur; cur = cur->next) {
-                if (chimera_vfs_lease_owner_equal(&cur->owner, &probe->owner)) {
-                    continue;
-                }
-                /* A byte-range lock and a caching lease held by the SAME open do
-                 * not break each other: an SMB open's caching lease is keyed by
-                 * its lease key while its range locks are keyed by the file id,
-                 * so owner_equal does not catch them, but cb_private points at
-                 * the common owning open on both. */
-                if (probe->owner.cb_private &&
-                    cur->owner.cb_private == probe->owner.cb_private) {
+                /* A byte-range lock and a caching lease held by the SAME open
+                 * normally do not break each other (owner_equal, or -- for a
+                 * lease keyed by its lease key rather than the file id -- the
+                 * shared cb_private back-pointer to the common owning open/grant).
+                 *
+                 * The one exception is a pure read (LEVEL_II / read-only) cache:
+                 * a shared oplock cannot coexist with ANY byte-range lock on its
+                 * stream, even one taken through its own handle, so acquiring a
+                 * range lock breaks that read cache to NONE (MS-FSA 2.1.5.18;
+                 * smbtorture smb2.oplock.brl1/brl3, where a 2nd open has already
+                 * downgraded the holder's batch oplock to LEVEL_II).  A write- or
+                 * handle-caching oplock/lease (batch / exclusive) held by the same
+                 * open is still kept -- the handle may lock its own file without
+                 * losing its write cache (smb2.oplock.brl2). */
+                if ((chimera_vfs_lease_owner_equal(&cur->owner, &probe->owner) ||
+                     (probe->owner.cb_private &&
+                      cur->owner.cb_private == probe->owner.cb_private)) &&
+                    !chimera_vfs_range_breaks_own_read_cache(cur)) {
                     continue;
                 }
                 /* A read range lock conflicts with a W cache on another
@@ -1128,6 +1153,25 @@ chimera_vfs_state_try_insert(
         }
 
         if (began_live_break) {
+            /* A RANGE-lock acquirer alone takes the synchronous re-probe: a
+             * no-ack read cache (a LEVEL_II oplock / read lease) breaks to NONE
+             * inside begin_break, so a FAIL_IMMEDIATELY byte-range lock that broke
+             * the same handle's LEVEL_II oplock must still be granted rather than
+             * parked on a break with nothing left to wait for (smb2.oplock.brl1/
+             * brl3).  A *caching* acquirer does NOT take this shortcut: granting a
+             * W cache while a peer's read-cache break is merely initiated (not yet
+             * acked) would open a stale-read window, so it stays BREAKING and waits
+             * for the ack as before (chimera/vfs/state_test "W-vs-R break").  An
+             * ack-required break also leaves the holder conflicting, so the range
+             * path likewise falls through and waits. */
+            if (lease->kind == CHIMERA_VFS_LEASE_RANGE) {
+                pthread_mutex_lock(&file->lock);
+                result = chimera_vfs_state_would_conflict(file, lease, &conflict);
+                pthread_mutex_unlock(&file->lock);
+                if (result == CHIMERA_VFS_LEASE_GRANTED) {
+                    continue;
+                }
+            }
             /* A live holder is mid-break; the caller waits for its ack. */
             return CHIMERA_VFS_LEASE_BREAKING;
         }


### PR DESCRIPTION
## Summary

`smb2.oplock.brl1` and `brl3` exercise the MS-FSA rule that a byte-range lock
cannot coexist with a shared (LEVEL_II) oplock on the same stream — even when
the lock is taken through the very handle that holds the oplock. Both tests:

1. open a file with a **batch** oplock (handle `h1`);
2. take a second open, which downgrades `h1`'s batch oplock to **LEVEL_II**
   (break #1, expected);
3. acquire a `FAIL_IMMEDIATELY` exclusive byte-range lock through `h1`, which
   must break that LEVEL_II oplock to **NONE** (break #2) *and* still grant the
   lock.

Step 3 produced no oplock break, so the client's `break_info.count` stayed `0`
and the handle assertion read back `0x0` instead of `h1.data[0]`.

## Root cause

In `chimera_vfs_state_would_conflict`, the range-vs-caching loop skips a caching
lease held by the same owner / same grant as the probing byte-range lock (the
self-skip that lets a handle keep its own oplock while locking its own file —
`smb2.oplock.brl2`). That skip was unconditional, so a self-BRL never broke the
handle's own oplock. That is correct for a write/handle-caching (batch /
exclusive) oplock, but wrong for a pure-read LEVEL_II oplock, which must break
to NONE on any byte-range lock per MS-FSA 2.1.5.18.

A second issue surfaced once the conflict was no longer skipped: the LEVEL_II ->
NONE break needs no client ack and settles synchronously inside `begin_break`,
yet `chimera_vfs_state_try_insert` still returned `BREAKING` because a break had
been started — denying the `FAIL_IMMEDIATELY` lock that should have been granted.

## Fix

- `chimera_vfs_range_breaks_own_read_cache()`: a same-owner/same-grant caching
  lease that is pure-read (R set, no W/H), breakable and not already breaking is
  *not* skipped by a range-lock probe, so it breaks to NONE. Write/handle-caching
  holders remain exempt (`brl2` still passes — no self-break).
- `chimera_vfs_state_try_insert()`: after a break is begun, re-probe; if the
  break settled synchronously and the conflict is gone, re-run and grant rather
  than spuriously returning `BREAKING`. An ack-required break still leaves the
  holder conflicting, so cross-handle acquirers wait for the client ack exactly
  as before.

## Tests

- `smb2.oplock.brl1` and `brl3` enabled for **memfs** and **diskfs_io_uring**;
  green 3x on both backends.
- Full enabled `smb2.oplock`, `smb2.lease`, `smb2.lock` suites re-run on both
  backends: 81 pass + 4 self-skip = 85/85, zero new failures (incl. `brl2`).

---
**Update:** the post-break synchronous re-probe in `chimera_vfs_state_try_insert` was gated to RANGE-lock acquirers. As first written it also applied to caching acquirers, which regressed `chimera/vfs/state_test` ("W-cache request triggers break") — a W cache must stay BREAKING until a peer's read-cache break is acked, to avoid a stale-read window. Only the byte-range (brl) path takes the synchronous-grant shortcut. Unit suite 120/120; brl1/brl3 (+brl2) 3x green both backends; full oplock/lease/lock allowlist clean; Release + scan-build clean.
