### PR TITLE
smb2: preserve resilient handles across disconnect (FSCTL_LMR_REQUEST_RESILIENCY)

### DIFF
--- a/src/server/smb/smb_durable.c
+++ b/src/server/smb/smb_durable.c
@@ -338,10 +338,17 @@ chimera_smb_durable_park(
     pthread_mutex_lock(&shared->durable.lock);
     HASH_FIND(hh, shared->durable.by_pid, &pid, sizeof(pid), entry);
     if (entry) {
+        /* A resilient open is held for its resiliency timeout; a durable open
+         * for its durable timeout.  When an open is both, keep it for the
+         * longer of the two. */
+        uint64_t timeout_ms = open_file->durable_timeout_ms;
+        if (open_file->resilient && open_file->resilient_timeout_ms > timeout_ms) {
+            timeout_ms = open_file->resilient_timeout_ms;
+        }
         entry->parked            = true;
         entry->deadline          = now;
-        entry->deadline.tv_sec  += open_file->durable_timeout_ms / 1000;
-        entry->deadline.tv_nsec += (open_file->durable_timeout_ms % 1000) * 1000000L;
+        entry->deadline.tv_sec  += timeout_ms / 1000;
+        entry->deadline.tv_nsec += (timeout_ms % 1000) * 1000000L;
         if (entry->deadline.tv_nsec >= 1000000000L) {
             entry->deadline.tv_sec  += 1;
             entry->deadline.tv_nsec -= 1000000000L;

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -1787,6 +1787,14 @@ chimera_smb_session_release(
 static inline bool
 chimera_smb_durable_open_preservable(const struct chimera_smb_open_file *open_file)
 {
+    /* A resilient handle (FSCTL_LMR_REQUEST_RESILIENCY) preserves its byte-range
+     * locks across the disconnect for the resiliency timeout regardless of its
+     * caching state (MS-SMB2 3.3.5.15.9), so it is always preservable -- unlike a
+     * plain durable open, which yields its locks if it has no write-caching
+     * oplock/lease to defend them. */
+    if (open_file->resilient) {
+        return true;
+    }
     if (open_file->lock_entries) {
         bool write_caching =
             (open_file->oplock_level == SMB2_OPLOCK_LEVEL_BATCH) ||
@@ -1849,7 +1857,7 @@ chimera_smb_session_park_durables(
             pthread_mutex_lock(&tree->open_files_lock[b]);
             HASH_ITER(hh, tree->open_files[b], open_file, tmp)
             {
-                if (!open_file->durable_flags ||
+                if ((!open_file->durable_flags && !open_file->resilient) ||
                     (open_file->flags & CHIMERA_SMB_OPEN_FILE_PARKED) ||
                     !chimera_smb_durable_open_preservable(open_file) ||
                     /* Mid-break opens are not preserved (MS-SMB2 3.3.7.1);
@@ -2276,7 +2284,7 @@ chimera_smb_tree_free(
              * the normal close path, which also forgets the registry entry --
              * a later durable reconnect with the stale FileId then correctly
              * returns OBJECT_NAME_NOT_FOUND. */
-            if (open_file->durable_flags && preserve_durable &&
+            if ((open_file->durable_flags || open_file->resilient) && preserve_durable &&
                 chimera_smb_durable_open_preservable(open_file)) {
                 /* Clear create_conn BEFORE deciding park-vs-close: a break
                  * that begins after this point finds no live member, revokes
@@ -2332,7 +2340,7 @@ chimera_smb_tree_free(
                  * tree/session teardown: drop its registry entry so a later
                  * reconnect with the stale FileId is not matched against a
                  * freed open_file. */
-                if (open_file->durable_flags) {
+                if (open_file->durable_flags || open_file->resilient) {
                     chimera_smb_durable_forget(shared, open_file->file_id.pid);
                 }
                 chimera_smb_open_file_drain_locks(thread, open_file);
@@ -2662,7 +2670,7 @@ chimera_smb_open_file_release(
     if (open_file->refcnt == 0) {
         /* Final teardown of a live durable open (e.g. an explicit CLOSE):
          * drop its registry entry before the object is recycled. */
-        if (open_file->durable_flags) {
+        if (open_file->durable_flags || open_file->resilient) {
             chimera_smb_durable_forget(request->compound->thread->shared,
                                        open_file->file_id.pid);
         }
@@ -2703,7 +2711,7 @@ chimera_smb_open_file_release_nr(
     open_file->refcnt--;
 
     if (open_file->refcnt == 0) {
-        if (open_file->durable_flags) {
+        if (open_file->durable_flags || open_file->resilient) {
             chimera_smb_durable_forget(thread->shared, open_file->file_id.pid);
         }
         chimera_smb_open_file_drain_locks(thread, open_file);

--- a/src/server/smb/smb_proc_ioctl.c
+++ b/src/server/smb/smb_proc_ioctl.c
@@ -249,6 +249,20 @@ chimera_smb_ioctl(struct chimera_smb_request *request)
                     timeout_ms = CHIMERA_SMB_RESILIENCY_MAX_TIMEOUT_MS;
                 }
 
+                /* Register the open in the durable registry (as a non-persistent
+                 * entry) on the first resiliency grant so a disconnect parks it
+                 * and a reconnect can reclaim it -- a resilient handle survives a
+                 * network drop for its timeout (MS-SMB2 3.3.5.15.9) using the same
+                 * machinery durable handles use.  A durable open is already
+                 * registered; an already-resilient open must not register twice. */
+                if (!open_file->durable_flags && !open_file->resilient) {
+                    chimera_smb_durable_register(
+                        request->compound->thread->shared, open_file,
+                        request->session_handle->session->session_id,
+                        request->compound->conn->client_guid,
+                        open_file->name, open_file->name_len, false);
+                }
+
                 open_file->resilient            = true;
                 open_file->resilient_timeout_ms = timeout_ms;
             }

--- a/src/server/smb/tests/wpts/wpts_cases.csv
+++ b/src/server/smb/tests/wpts/wpts_cases.csv
@@ -65,10 +65,10 @@ BVT_PersistentHandles,base,skip,0,env
 BVT_Replay_ReplayCreate,multichannel,xfail,0,
 BVT_Replay_WriteWithInvalidChannelSequence,multichannel,xfail,0,
 BVT_Resiliency,base,skip,0,env
-BVT_ResilientHandle_LockSequence,persistent,xfail,0,
+BVT_ResilientHandle_LockSequence,persistent,green,0,
 BVT_ResilientHandle_LockSequence_Lease,persistent,xfail,0,
-BVT_ResilientHandle_Reconnect,persistent,xfail,0,
-BVT_ResilientHandle_Reconnect_Lease,persistent,xfail,0,
+BVT_ResilientHandle_Reconnect,persistent,green,0,
+BVT_ResilientHandle_Reconnect_Lease,persistent,green,0,
 BVT_SMB2Basic_CancelRegisteredChangeNotify,base,green,1,
 BVT_SMB2Basic_ChangeNotify_ChangeAttributes,base,green,1,
 BVT_SMB2Basic_ChangeNotify_ChangeCreation,base,green,1,


### PR DESCRIPTION
## Problem

A handle granted resiliency via `FSCTL_LMR_REQUEST_RESILIENCY` must survive a network disconnect for its timeout and be reclaimable on reconnect (MS-SMB2 3.3.5.15.9) — the same lifecycle a durable handle gets. But the disconnect-survival machinery keyed entirely on `open_file->durable_flags`, while a resilient open carries a **separate `resilient` bool** with `durable_flags == 0`. So every resilient reconnect failed with `STATUS_OBJECT_NAME_NOT_FOUND`:

- the FSCTL never **registered** the open in the durable registry → reconnect's reclaim found nothing;
- both **park** paths (connection teardown + session takeover) skipped it → torn down with the connection;
- the **park deadline** used `durable_timeout_ms` (0) → a parked open expired instantly;
- **`durable_open_preservable()`** dropped a locked open without a write-caching lease;
- **forget-on-close** was `durable_flags`-gated → a resilient registry entry would dangle.

## Fix

Treat `resilient` like a durable flag across that machinery: register on the first resiliency grant (non-persistent entry), park on disconnect, deadline on `resilient_timeout_ms` (the longer of the two when an open is both), exempt resilient opens from the lock-preservation restriction (a resilient handle keeps its locks for the timeout regardless of caching), and forget on close.

## Result

Greens **3 cases**, promoted to the persistent green gate:
- `BVT_ResilientHandle_Reconnect`, `BVT_ResilientHandle_Reconnect_Lease`, `BVT_ResilientHandle_LockSequence`

`ScavengerTimer_Reconnect{Before,After}Timeout` also pass now but stay `xfail` (the 2.5-min timing tests are too slow / timing-sensitive for the consolidated gate). `BVT_ResilientHandle_LockSequence_Lease` (the locks+lease combo) remains a tracked `xfail` follow-up.

## Verification

- Persistent green gate (now 42 cases) passes in the consolidated batch.
- Debug/ASan clean (the registry/forget changes are memory-safe).
- No durable-handle regression (the 39 existing durable greens still pass).
