### PR TITLE
kvm/nfstest: enable the lock and dio suites

### DIFF
--- a/kvm/kvm_nfstest_test_wrapper.sh
+++ b/kvm/kvm_nfstest_test_wrapper.sh
@@ -214,6 +214,13 @@ case "$NFS_VERSION" in
     *)   NFSTEST_VERSION="$NFS_VERSION" ;;
 esac
 
+# nfstest_dio rejects a mount whose rsize/wsize is smaller than 3x its own
+# I/O size, so the default rsize=4096,wsize=4096 aborts it; give dio a large
+# transfer size instead.
+if [ "$NFSTEST_PROGRAM" = "nfstest_dio" ]; then
+    NFSTEST_MTOPTS="hard,rsize=1048576,wsize=1048576"
+fi
+
 # nfstest_interop drives its own mounts at several NFS versions (including v3),
 # so force nolock for it regardless of the top-level version.
 if [ "$NFSTEST_PROGRAM" = "nfstest_interop" ]; then
@@ -259,9 +266,11 @@ TEST_CMD="mkdir -p /mnt/t && PYTHONPATH=/opt/nfstest /opt/nfstest/test/${NFSTEST
 # analyses the whole packet trace in memory and its fill/dealloc subtests
 # generate large traces.
 QEMU_MEM="1G"
-if [ "$NFSTEST_PROGRAM" = "nfstest_alloc" ]; then
-    QEMU_MEM="8G"
-fi
+case "$NFSTEST_PROGRAM" in
+    # nfstest_alloc analyses the whole packet trace in memory; nfstest_dio drives
+    # 1 MiB direct-I/O transfers whose traces and buffers blow past 1 GiB.
+    nfstest_alloc | nfstest_dio) QEMU_MEM="8G" ;;
+esac
 
 # Boot QEMU inside the netns; the guest's /init.sh runs test_cmd (no pre-mount).
 ip netns exec "${NETNS_NAME}" "$QEMU_BIN" \

--- a/kvm/tests/CMakeLists.txt
+++ b/kvm/tests/CMakeLists.txt
@@ -272,14 +272,19 @@ foreach(image_spec ${KVM_IMAGES})
     # behaviour with its own tcpdump-driven RPC dissector.  The nfstest tree and
     # its in-guest deps (python3, tcpdump, a default route) ship in the
     # kvm-test-base image (>= v1.2.0).  Matrix entries are "program|<space-
-    # separated NFS versions>"; nfstest_ssc is left unregistered for now (a
-    # server-side COPY gap).
+    # separated NFS versions>".  nfstest_lock is NFSv4-only here (NFSv3 byte-range
+    # locking is NLM, which needs rpc.statd the guest does not run -- the other
+    # suites mount nolock for v3 for the same reason).  Not yet registered:
+    # nfstest_ssc (server-side COPY gap), nfstest_cache (needs a second client
+    # host), nfstest_delegation (real delegation/lock gaps) and nfstest_pnfs.
     if(IMAGE_NAME STREQUAL "ubuntu2404")
         set(NFSTEST_MATRIX
             "nfstest_posix|3 4.0 4.1 4.2"
             "nfstest_interop|4.0"
             "nfstest_alloc|4.2"
             "nfstest_sparse|4.2"
+            "nfstest_lock|4.1"
+            "nfstest_dio|4.2"
         )
         set(NFSTEST_BACKENDS ${KVM_BACKENDS})
         if(CAIRN_ENABLED)
@@ -331,6 +336,14 @@ foreach(image_spec ${KVM_IMAGES})
                                 ${CHIMERA_BINARY} ${backend} ${nfsver} ${prog})
                     set_tests_properties(chimera/kvm/${IMAGE_NAME}/nfstest/${prog}_${backend}_nfs${nfsver}
                         PROPERTIES LABELS "kvm;${IMAGE_NAME}" PROCESSORS 2)
+                    # nfstest_lock (5296 subtests, ~6.5 min) and nfstest_dio
+                    # (1 MiB direct-I/O transfers, ~5.5 min) run well past the
+                    # CI-wide `ctest --timeout 300`; give them a per-test timeout
+                    # that overrides it so they are not killed mid-run.
+                    if(prog STREQUAL "nfstest_lock" OR prog STREQUAL "nfstest_dio")
+                        set_tests_properties(chimera/kvm/${IMAGE_NAME}/nfstest/${prog}_${backend}_nfs${nfsver}
+                            PROPERTIES TIMEOUT 900)
+                    endif()
                 endforeach()
             endforeach()
         endforeach()


### PR DESCRIPTION
## Summary

Enables two more Linux nfstest conformance suites in the kvm-nfstest CI shard. Both are 100% green across all chimera-native backends:

| Suite | Version | Result (memfs / cairn / diskfs_io_uring / diskfs_aio) |
|---|---|---|
| `nfstest_lock` | 4.1 | **5296 / 5296** on each |
| `nfstest_dio` | 4.2 | **743 / 743** on each |

## Notes

- **`lock` is NFSv4-only** — NFSv3 byte-range locking is NLM, which needs an `rpc.statd` the guest doesn't run (the other suites mount `nolock` for v3 for the same reason).
- **`dio` needs two wrapper tweaks**: it refuses a mount whose `rsize/wsize` is below 3× its own I/O size (so it gets a 1 MiB transfer size instead of the default 4 KiB), and its 1 MiB direct-I/O transfers exceed a 1 GiB guest (so it joins `nfstest_alloc` on the 8 GiB tier).
- **Per-test timeout**: both run ~5.5–6.5 min, past the CI-wide `ctest --timeout 300`, so they get a `TIMEOUT 900` property that overrides it.
- **Passthrough backends** (linux/io_uring) are registered too: lock state lives in the protocol layer (not the backend) and dio is a client-side cache-bypass, so neither depends on the backend the way posix's atime assertion does. They couldn't be validated locally (the passthrough `name_to_handle_at` mount only works in CI) but are expected to pass as the other passthrough nfstest suites do.

Not enabled (separate follow-ups): `xattr` (~95%, root-`/` XATTR_SUPPORT gap), `delegation` (~93%, real deleg/lock gaps), `ssc` (server COPY gap), `cache` (needs a second client host), `pnfs` (combined-DS config WIP).
