### PR TITLE
smb2: cross-client RH leases + recall on namespace delete + delete-on-close on teardown

### DIFF
--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -1339,6 +1339,19 @@ void
 chimera_smb_create_resume_parked_broadcast(
     struct chimera_server_smb_thread *origin);
 
+/* Fire a request-less, fire-and-forget delete-on-close unlink during teardown
+ * (defined in smb_proc_close.c).  The teardown handle-release paths free open
+ * files without a live chimera_smb_request, so the clean-CLOSE DOC machinery
+ * (which threads everything through the request) cannot be reused directly.
+ * This drives the same open-parent -> remove_at -> close-backend sequence off a
+ * self-contained, heap-owned copy of the doc_info returned by
+ * chimera_vfs_release_doc.  Used only for opens teardown is genuinely
+ * discarding (never a preserved/parked durable handle). */
+void
+chimera_smb_teardown_doc_unlink(
+    struct chimera_server_smb_thread  *thread,
+    const struct chimera_vfs_doc_info *doc_info);
+
 /* Durable/persistent handle registry (smb_durable.c). */
 void
 chimera_smb_durable_table_init(
@@ -2337,7 +2350,23 @@ chimera_smb_tree_free(
                 }
                 chimera_smb_open_file_drain_locks(thread, open_file);
                 if (open_file->handle) {
-                    chimera_vfs_release(thread->vfs_thread, open_file->handle);
+                    /* Abrupt teardown (disconnect / LOGOFF / TREE_DISCONNECT)
+                     * of an open this teardown is genuinely DISCARDING: route
+                     * the VFS handle release through the delete-on-close-aware
+                     * path so a DOC-armed file is actually unlinked on the last
+                     * reference, exactly as a clean multi-handle CLOSE does
+                     * (smb2.lease.initial_delete_*).  A preserved/parked durable
+                     * handle never reaches here — it was parked via `continue`
+                     * above with its VFS handle kept intact — so its file is
+                     * never deleted on disconnect.  release_doc behaves like an
+                     * ordinary release (returns 0) when no DOC is armed. */
+                    struct chimera_vfs_doc_info doc_info;
+
+                    if (chimera_vfs_release_doc(thread->vfs_thread,
+                                                open_file->handle,
+                                                &doc_info)) {
+                        chimera_smb_teardown_doc_unlink(thread, &doc_info);
+                    }
                 }
                 chimera_smb_open_file_free(thread, open_file);
             }

--- a/src/server/smb/smb_proc_close.c
+++ b/src/server/smb/smb_proc_close.c
@@ -14,6 +14,39 @@
 static void chimera_smb_close_release(
     struct chimera_smb_request *request);
 
+void
+chimera_smb_break_caching_for_namespace(
+    struct chimera_smb_request   *request,
+    struct chimera_smb_open_file *open_file)
+{
+    struct chimera_vfs_thread      *vfs_thread =
+        request->compound->thread->vfs_thread;
+    struct chimera_vfs_state       *vfs_state = vfs_thread->vfs->vfs_state;
+    struct chimera_vfs_open_handle *oh        = open_file->handle;
+    struct chimera_vfs_lease_owner  owner     = {
+        .protocol   = CHIMERA_VFS_LEASE_PROTO_SMB2,
+        .client_key = request->session_handle->session->client_key,
+        .owner_lo   = open_file->file_id.pid,
+        .owner_hi   = open_file->file_id.vid,
+    };
+
+    if (!oh) {
+        return;
+    }
+
+    /* An RqLs open is owned by its lease key, not its file_id: identify the
+    * operating open by the key so its OWN lease is spared by the recall. */
+    if (open_file->oplock_level == SMB2_OPLOCK_LEVEL_LEASE) {
+        memcpy(&owner.owner_lo, open_file->lease_key, 8);
+        memcpy(&owner.owner_hi, open_file->lease_key + 8, 8);
+        owner.is_lease = 1;
+    }
+
+    chimera_vfs_state_break_caching_for_namespace(
+        vfs_state, oh->fh, oh->fh_len, oh->fh_hash, &owner,
+        CHIMERA_VFS_LEASE_MODE_R);
+} /* chimera_smb_break_caching_for_namespace */
+
 /* Fire-and-forget completion for the persistent-handle record delete. */
 static void
 chimera_smb_close_durable_delete_callback(

--- a/src/server/smb/smb_proc_close.c
+++ b/src/server/smb/smb_proc_close.c
@@ -169,6 +169,140 @@ chimera_smb_close_doc_open_parent_callback(
         request);
 } /* chimera_smb_close_doc_open_parent_callback */
 
+/*
+ * Request-less delete-on-close unlink for the abrupt-teardown path
+ * (connection disconnect / session logoff / tree disconnect).
+ *
+ * The clean-CLOSE DOC path above threads parent_handle, doc_info and the
+ * VFS-module close state through the live chimera_smb_request.  Teardown frees
+ * open files with no request in hand, so this self-contained context carries a
+ * heap-owned copy of the doc_info returned by chimera_vfs_release_doc and runs
+ * the same open-parent -> remove_at -> close-backend sequence as a
+ * fire-and-forget operation on the SMB thread's VFS thread.
+ *
+ * Only invoked for opens teardown is genuinely DISCARDING: a preserved
+ * (courtesy-held / parked) durable handle never reaches release_doc in the
+ * teardown path, so its file is never deleted on disconnect.
+ */
+struct chimera_smb_teardown_doc_ctx {
+    struct chimera_vfs_thread      *vfs_thread;
+    struct chimera_vfs_doc_info     doc_info;
+    struct chimera_vfs_open_handle *parent_handle;
+};
+
+static void
+chimera_smb_teardown_doc_close_backend(struct chimera_smb_teardown_doc_ctx *ctx)
+{
+    chimera_vfs_close(ctx->vfs_thread,
+                      ctx->doc_info.close_module,
+                      ctx->doc_info.close_private,
+                      ctx->doc_info.close_hash,
+                      NULL,
+                      NULL);
+    free(ctx);
+} /* chimera_smb_teardown_doc_close_backend */
+
+static void
+chimera_smb_teardown_doc_remove_callback(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *pre_attr,
+    struct chimera_vfs_attrs *post_attr,
+    void                     *private_data)
+{
+    struct chimera_smb_teardown_doc_ctx *ctx = private_data;
+
+    (void) pre_attr;
+    (void) post_attr;
+
+    if (error_code) {
+        chimera_smb_debug("teardown delete-on-close: remove_at failed for "
+                          "'%.*s' (error %d)",
+                          ctx->doc_info.name_len,
+                          ctx->doc_info.name,
+                          error_code);
+    }
+
+    chimera_vfs_release(ctx->vfs_thread, ctx->parent_handle);
+    chimera_smb_teardown_doc_close_backend(ctx);
+} /* chimera_smb_teardown_doc_remove_callback */
+
+static void
+chimera_smb_teardown_doc_open_parent_callback(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *oh,
+    void                           *private_data)
+{
+    struct chimera_smb_teardown_doc_ctx *ctx = private_data;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        /* Cannot open parent — skip the unlink but still close the backend
+         * handle that release_doc detached from the cache. */
+        chimera_smb_debug("teardown delete-on-close: failed to open parent dir "
+                          "for '%.*s' (error %d)",
+                          ctx->doc_info.name_len,
+                          ctx->doc_info.name,
+                          error_code);
+        chimera_smb_teardown_doc_close_backend(ctx);
+        return;
+    }
+
+    ctx->parent_handle = oh;
+
+    /* No lease self-exemption here: teardown is dropping every handle this
+     * connection/session/tree owned, so all directory leases break.  The child
+     * FH is intentionally not supplied (no cross-client file-lease recall): the
+     * delete-on-close lease-recall semantics are owned by the parallel
+     * smb-lease-crossclient-rh work, and the clean-CLOSE DOC path likewise does
+     * not recall here. */
+    chimera_vfs_remove_at(
+        ctx->vfs_thread,
+        &ctx->doc_info.cred,
+        oh,
+        ctx->doc_info.name,
+        ctx->doc_info.name_len,
+        NULL,
+        0,
+        0,
+        0,
+        NULL,
+        chimera_smb_teardown_doc_remove_callback,
+        ctx);
+} /* chimera_smb_teardown_doc_open_parent_callback */
+
+void
+chimera_smb_teardown_doc_unlink(
+    struct chimera_server_smb_thread  *thread,
+    const struct chimera_vfs_doc_info *doc_info)
+{
+    struct chimera_smb_teardown_doc_ctx *ctx;
+
+    if (doc_info->parent_fh_len == 0) {
+        /* No parent fh recorded — cannot unlink, just close the backend
+         * handle that release_doc detached from the cache. */
+        chimera_vfs_close(thread->vfs_thread,
+                          doc_info->close_module,
+                          doc_info->close_private,
+                          doc_info->close_hash,
+                          NULL,
+                          NULL);
+        return;
+    }
+
+    ctx                = calloc(1, sizeof(*ctx));
+    ctx->vfs_thread    = thread->vfs_thread;
+    ctx->doc_info      = *doc_info;
+    ctx->parent_handle = NULL;
+
+    chimera_vfs_open_fh(
+        ctx->vfs_thread,
+        &ctx->doc_info.cred,
+        ctx->doc_info.parent_fh,
+        ctx->doc_info.parent_fh_len,
+        CHIMERA_VFS_OPEN_INFERRED | CHIMERA_VFS_OPEN_PATH,
+        chimera_smb_teardown_doc_open_parent_callback,
+        ctx);
+} /* chimera_smb_teardown_doc_unlink */
+
 /* Completion of a stream delete-on-close remove_stream. */
 static void
 chimera_smb_close_stream_remove_callback(

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -741,6 +741,14 @@ chimera_smb_create_gen_open_file(
          * lease so a hard share conflict against a batch-oplock holder parks on the
          * batch break rather than denying (chimera_vfs_share_batch_escape). */
         open_file->share_lease.owner.cb_private = open_file;
+        /* Mark whether this open is backed by an SMB2 RqLs lease.  The lease
+         * H-cap (chimera_vfs_state_would_conflict, CACHING/SHARE path) lets two
+         * RqLs-lease opens share handle caching but caps a new lease's H behind a
+         * non-lease open (a legacy oplock or a plain open, which owns the handle
+         * exclusively).  A lease-backed share reservation is reliably visible even
+         * before the (later-linked) caching grant, so the cap can key off it. */
+        open_file->share_lease.owner.is_lease =
+            (request->create.ctx_present_mask & CHIMERA_SMB_CREATE_CTX_RQLS) ? 1 : 0;
 
         /* If this open also requests a lease, a handle-caching lease already
          * held under the same key is its own (a second open under one lease
@@ -1044,6 +1052,30 @@ chimera_smb_create_after_share(
                 want.granted = req_vfs;
                 want.denied  = 0;
 
+                /* A legacy oplock and an SMB2 RqLs lease held by the SAME client on
+                * the SAME file interact per MS-SMB2 3.3.5.9 (smb2.lease.oplock
+                * loop 1), and a legacy oplock request must NEVER recall the
+                * requesting client's own lease:
+                *   - the client holds an H (handle) lease (RH / RHW): the oplock
+                *     is granted NONE (handle caching already owns the handle);
+                *   - the client holds a non-H lease (R / RW): the oplock is capped
+                *     to level-II (R), which coexists with the lease's read cache.
+                * Either way we step the legacy oplock's requested mode DOWN here so
+                * its try_insert never fires a self-break against the client's lease
+                * (the exclusive/batch W bit would otherwise recall the R lease). */
+                if (!via_rqls && want_fresh_caching) {
+                    if (chimera_vfs_client_holds_handle_lease(
+                            file_state, owner.client_key)) {
+                        want_fresh_caching = false;
+                    } else if (chimera_vfs_client_holds_caching_lease(
+                                   file_state, owner.client_key)) {
+                        /* Cap the oplock to a level-II read cache so it coexists
+                         * with the client's own R/RW lease without breaking it. */
+                        req_vfs     &= CHIMERA_VFS_LEASE_MODE_R;
+                        want.granted = req_vfs;
+                    }
+                }
+
                 /* First coalesce onto an existing same-owner grant: refcount + a
                  * conflict-free in-place upgrade, never a downgrade.  This is what a
                  * lease re-open does -- including one requesting fewer/no bits, which
@@ -1204,6 +1236,18 @@ chimera_smb_create_after_share(
                                         parent_fh, parent_fh_len,
                                         name, name_len,
                                         &request->session_handle->session->cred);
+
+        /* An open created with FILE_DELETE_ON_CLOSE is a pending namespace
+         * mutation: recall every OTHER holder's HANDLE cache (RqLs RH -> R) so a
+         * peer that cached the open handle re-validates against the impending
+         * removal (smb2.lease.unlink: open + delete-on-close + close).  The
+         * operating open's own lease is spared.  (The deferred removal itself runs
+         * at last-close through chimera_vfs_remove_at, whose io_recall parks until
+         * the break drains; firing the recall here makes the break visible as soon
+         * as the delete intent is registered.) */
+        if (type == CHIMERA_SMB_OPEN_FILE_TYPE_FILE) {
+            chimera_smb_break_caching_for_namespace(request, open_file);
+        }
     }
 
     /* Durable / persistent handle grant.  MS-SMB2 3.3.5.9: a durable handle is

--- a/src/server/smb/smb_proc_set_info.c
+++ b/src/server/smb/smb_proc_set_info.c
@@ -221,6 +221,25 @@ chimera_smb_set_info_allocation_getattr_callback(
         request);
 } /* chimera_smb_set_info_allocation_getattr_callback */
 
+/* Completion for the delete-on-close caching-lease recall: the recall has
+ * drained (every OTHER holder's handle lease was broken and acknowledged), so the
+ * peer's break is now visible to the client.  Reply to the SetInfo.  Replying
+ * only after the recall drains is what makes the break deterministically precede
+ * the reply (the client checks lease_break_info.count synchronously right after
+ * smb2_setinfo_file -- smb2.lease.unlink). */
+static void
+chimera_smb_set_info_doc_recall_callback(
+    enum chimera_vfs_error error_code,
+    void                  *private_data)
+{
+    struct chimera_smb_request *request = private_data;
+
+    (void) error_code;
+
+    chimera_smb_open_file_release(request, request->set_info.open_file);
+    chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
+} /* chimera_smb_set_info_doc_recall_callback */
+
 void
 chimera_smb_set_info(struct chimera_smb_request *request)
 {
@@ -350,6 +369,22 @@ chimera_smb_set_info(struct chimera_smb_request *request)
                                 request->set_info.open_file->name,
                                 request->set_info.open_file->name_len,
                                 &request->session_handle->session->cred);
+
+                            /* Setting delete-on-close on an open file is a pending
+                             * namespace mutation: recall every OTHER holder's HANDLE
+                             * cache so a peer that cached the open handle re-
+                             * validates against the impending removal (MS-SMB2;
+                             * smb2.lease.unlink).  The operating client's own lease
+                             * is spared.  This PARKS until the recall drains (the
+                             * peer's break is acked), then replies -- so the break
+                             * deterministically precedes the SetInfo reply. */
+                            chimera_vfs_recall_handle_lease(
+                                request->compound->thread->vfs_thread,
+                                &request->session_handle->session->cred,
+                                request->set_info.open_file->handle,
+                                chimera_smb_set_info_doc_recall_callback,
+                                request);
+                            break;
                         }
                     } else {
                         request->set_info.open_file->flags &=

--- a/src/server/smb/smb_procs.h
+++ b/src/server/smb/smb_procs.h
@@ -304,6 +304,15 @@ void chimera_smb_lease_break_cb(
     uint8_t                   needed_mode,
     void                     *private_data);
 
+/* Recall every OTHER holder's HANDLE cache on the file backing `open_file`
+ * because of a pending namespace mutation (delete-on-close / unlink / rename):
+ * an RqLs lease's RH is broken to R, and the operating client's own lease is
+ * spared.  Called from the set-info delete-on-close and the close-time remove
+ * paths (smb2.lease.unlink). */
+void chimera_smb_break_caching_for_namespace(
+    struct chimera_smb_request   *request,
+    struct chimera_smb_open_file *open_file);
+
 void chimera_smb_lease_break_thread_init(
     struct chimera_server_smb_thread *thread);
 

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -1365,6 +1365,9 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.lease.complex1
     smb2.lease.duplicate_create
     smb2.lease.duplicate_open
+    smb2.lease.initial_delete_disconnect
+    smb2.lease.initial_delete_logoff
+    smb2.lease.initial_delete_tdis
     smb2.lease.multibreak
     smb2.lease.nobreakself
     smb2.lease.oplock
@@ -3233,6 +3236,9 @@ set(SMBTORTURE_ENABLED_diskfs_io_uring
     smb2.lease.complex1
     smb2.lease.duplicate_create
     smb2.lease.duplicate_open
+    smb2.lease.initial_delete_disconnect
+    smb2.lease.initial_delete_logoff
+    smb2.lease.initial_delete_tdis
     smb2.lease.multibreak
     smb2.lease.nobreakself
     smb2.lease.oplock

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -1367,11 +1367,13 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.lease.duplicate_open
     smb2.lease.multibreak
     smb2.lease.nobreakself
+    smb2.lease.oplock
     smb2.lease.rename_wait
     smb2.lease.statopen
     smb2.lease.statopen2
     smb2.lease.statopen3
     smb2.lease.statopen4
+    smb2.lease.unlink
     smb2.lease.upgrade
     smb2.lease.upgrade2
     smb2.lease.upgrade3
@@ -3233,11 +3235,13 @@ set(SMBTORTURE_ENABLED_diskfs_io_uring
     smb2.lease.duplicate_open
     smb2.lease.multibreak
     smb2.lease.nobreakself
+    smb2.lease.oplock
     smb2.lease.rename_wait
     smb2.lease.statopen
     smb2.lease.statopen2
     smb2.lease.statopen3
     smb2.lease.statopen4
+    smb2.lease.unlink
     smb2.lease.upgrade
     smb2.lease.upgrade2
     smb2.lease.upgrade3

--- a/src/vfs/CMakeLists.txt
+++ b/src/vfs/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(chimera_vfs SHARED vfs.c vfs_lsan.c
             vfs_proc_remove_at.c vfs_proc_write.c vfs_proc_commit.c
             vfs_proc_open_at.c vfs_proc_symlink_at.c vfs_proc_link_at.c
             vfs_proc_readlink.c vfs_proc_rename_at.c vfs_proc_setattr.c
+            vfs_proc_recall.c
             vfs_proc_gate.c
             vfs_proc_create.c vfs_proc_create_unlinked.c
             vfs_proc_open.c vfs_proc_mkdir.c vfs_proc_remove.c

--- a/src/vfs/vfs.h
+++ b/src/vfs/vfs.h
@@ -446,6 +446,12 @@ struct chimera_vfs_request {
      * revocation -- the churn source for metadata-heavy single-client workloads
      * (rewinddir/fsstress) -- while preserving coherence. */
     uint8_t                            io_recall_flush_only;
+    /* Single-step namespace recall (smb2.lease.unlink delete-on-close): break
+     * each OTHER holder exactly ONCE to io_recall_retain (R) -- not a cascade to
+     * NONE -- and park until those breaks are acked.  io_recall_retain is the
+     * floor handed to begin_break for this flavor. */
+    uint8_t                            io_recall_single;
+    uint8_t                            io_recall_retain;
     void                               ( *io_next )(
         struct chimera_vfs_request *request);
     struct chimera_vfs_file_state     *io_lease_file;

--- a/src/vfs/vfs_internal.h
+++ b/src/vfs/vfs_internal.h
@@ -233,6 +233,8 @@ chimera_vfs_request_alloc_common(
     request->io_owner_valid       = 0;
     request->io_recall_all        = 0;
     request->io_recall_flush_only = 0;
+    request->io_recall_single     = 0;
+    request->io_recall_retain     = 0;
     request->io_next              = NULL;
     request->io_lease_file        = NULL;
     request->io_handle            = NULL;

--- a/src/vfs/vfs_proc_recall.c
+++ b/src/vfs/vfs_proc_recall.c
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include <stdlib.h>
+
+#include "vfs/vfs_procs.h"
+#include "vfs/vfs_state.h"
+#include "vfs/vfs_internal.h"
+#include "common/macros.h"
+
+/* Completion for a stand-alone caching-lease recall (no backend op): the recall
+ * has drained (every conflicting caching holder acked or was revoked), so report
+ * success and free the request. */
+static void
+chimera_vfs_recall_complete(struct chimera_vfs_request *request)
+{
+    chimera_vfs_recall_callback_t callback = request->proto_callback;
+
+    chimera_vfs_complete(request);
+    callback(CHIMERA_VFS_OK, request->proto_private_data);
+    chimera_vfs_request_free(request->thread, request);
+} /* chimera_vfs_recall_complete */
+
+/* Recall every OTHER caching lease on the file backing `handle` (the operating
+ * open's own lease is spared via io_handle) and PARK until the recall drains,
+ * then invoke `callback`.  This is the namespace-mutation recall (an RqLs lease's
+ * handle cache is broken) WITHOUT any backend mutation -- used by the SMB
+ * delete-on-close path so the peer's lease break is acknowledged before the
+ * SetInfo reply is sent (smb2.lease.unlink: the client checks the break count
+ * synchronously right after the SetInfo completes). */
+SYMBOL_EXPORT void
+chimera_vfs_recall_handle_lease(
+    struct chimera_vfs_thread      *thread,
+    const struct chimera_vfs_cred  *cred,
+    struct chimera_vfs_open_handle *handle,
+    chimera_vfs_recall_callback_t   callback,
+    void                           *private_data)
+{
+    struct chimera_vfs_request *request;
+
+    request = chimera_vfs_request_alloc_by_handle(thread, cred, handle);
+
+    if (CHIMERA_VFS_IS_ERR(request)) {
+        callback(CHIMERA_VFS_PTR_ERR(request), private_data);
+        return;
+    }
+
+    request->opcode             = CHIMERA_VFS_OP_GETATTR; /* inert: no dispatch */
+    request->complete           = chimera_vfs_recall_complete;
+    request->io_handle          = handle;
+    request->proto_callback     = callback;
+    request->proto_private_data = private_data;
+
+    /* Single-step recall: break each OTHER holder's handle cache exactly once
+     * (RH -> R), sparing the operating open (io_handle), and park until the
+     * client's break ack arrives. */
+    chimera_vfs_io_recall_single(request, handle->fh, handle->fh_len,
+                                 handle->fh_hash, CHIMERA_VFS_LEASE_MODE_R,
+                                 chimera_vfs_recall_complete);
+} /* chimera_vfs_recall_handle_lease */

--- a/src/vfs/vfs_procs.h
+++ b/src/vfs/vfs_procs.h
@@ -208,6 +208,23 @@ typedef void (*chimera_vfs_getattr_callback_t)(
     struct chimera_vfs_attrs *attr,
     void                     *private_data);
 
+/* Recall every OTHER caching lease on the file backing `handle` (the operating
+ * open's own lease is spared) and PARK until the recall drains, then invoke
+ * `callback`.  A namespace-mutation recall (breaks a peer's handle cache) with no
+ * backend op -- used by the SMB delete-on-close path so the peer's lease break is
+ * acked before the SetInfo reply is sent (smb2.lease.unlink). */
+typedef void (*chimera_vfs_recall_callback_t)(
+    enum chimera_vfs_error error_code,
+    void                  *private_data);
+
+void
+chimera_vfs_recall_handle_lease(
+    struct chimera_vfs_thread      *thread,
+    const struct chimera_vfs_cred  *cred,
+    struct chimera_vfs_open_handle *handle,
+    chimera_vfs_recall_callback_t   callback,
+    void                           *private_data);
+
 void
 chimera_vfs_getattr(
     struct chimera_vfs_thread      *thread,

--- a/src/vfs/vfs_state.c
+++ b/src/vfs/vfs_state.c
@@ -415,6 +415,72 @@ chimera_vfs_lease_effective_granted(const struct chimera_vfs_lease *l)
     return l->mode.granted;
 } /* chimera_vfs_lease_effective_granted */
 
+/* True for an SMB2 RqLs caching lease (file or directory) — as opposed to a
+ * legacy SMB oplock (grant->is_oplock, which is sole-handle) or a non-caching /
+ * NFSv4 lease (grant == NULL).  Two RqLs leases are not handle-exclusive across
+ * clients; a legacy oplock is. */
+static inline bool
+chimera_vfs_lease_is_rqls(const struct chimera_vfs_lease *l)
+{
+    return l->grant != NULL && !l->grant->is_oplock;
+} /* chimera_vfs_lease_is_rqls */
+
+/* True if `client_key` already holds an SMB2 RqLs caching lease WITH handle (H)
+ * caching on `file`.  A handle-caching lease and a legacy oplock are mutually
+ * exclusive for one client on one file (MS-SMB2 3.3.5.9): a client that holds an
+ * H lease cannot also be granted an oplock, and the oplock request must NOT
+ * recall the client's own lease.  The SMB create path calls this to short-
+ * circuit such an oplock request to NONE (smb2.lease.oplock loop 1: hold an
+ * RH/RHW lease, request s/x/b -> NONE, no break).  A lease WITHOUT H (R / RW)
+ * does not preclude a coexisting level-II oplock, so it returns false and the
+ * normal arbitration caps the oplock to level-II.  Takes file->lock. */
+SYMBOL_EXPORT bool
+chimera_vfs_client_holds_handle_lease(
+    struct chimera_vfs_file_state *file,
+    uint64_t                       client_key)
+{
+    const struct chimera_vfs_lease *cur;
+    bool                            held = false;
+
+    pthread_mutex_lock(&file->lock);
+    for (cur = file->caching_leases; cur; cur = cur->next) {
+        if (cur->owner.client_key == client_key &&
+            chimera_vfs_lease_is_rqls(cur) &&
+            (cur->mode.granted & CHIMERA_VFS_LEASE_MODE_H) &&
+            cur->break_state != CHIMERA_VFS_BREAK_REVOKED) {
+            held = true;
+            break;
+        }
+    }
+    pthread_mutex_unlock(&file->lock);
+    return held;
+} /* chimera_vfs_client_holds_handle_lease */
+
+/* True if `client_key` holds ANY live SMB2 RqLs caching lease (with or without
+ * H) on `file`.  The SMB create path uses this to cap a same-client legacy
+ * oplock request to level-II so it coexists with the client's R/RW lease without
+ * recalling it (smb2.lease.oplock loop 1).  Takes file->lock. */
+SYMBOL_EXPORT bool
+chimera_vfs_client_holds_caching_lease(
+    struct chimera_vfs_file_state *file,
+    uint64_t                       client_key)
+{
+    const struct chimera_vfs_lease *cur;
+    bool                            held = false;
+
+    pthread_mutex_lock(&file->lock);
+    for (cur = file->caching_leases; cur; cur = cur->next) {
+        if (cur->owner.client_key == client_key &&
+            chimera_vfs_lease_is_rqls(cur) &&
+            cur->break_state != CHIMERA_VFS_BREAK_REVOKED) {
+            held = true;
+            break;
+        }
+    }
+    pthread_mutex_unlock(&file->lock);
+    return held;
+} /* chimera_vfs_client_holds_caching_lease */
+
 static inline bool
 chimera_vfs_caching_conflict(
     const struct chimera_vfs_lease *existing,
@@ -434,23 +500,27 @@ chimera_vfs_caching_conflict(
         return true;
     }
 
-    /* Directory leases (R/H only, never W) are NOT handle-exclusive across
-    * clients: many clients commonly hold an RH directory lease on the same
-    * directory at once, and an RH dir lease's read caching is broken on a
-    * content change out-of-band (chimera_vfs_dir_lease_break_read), not by a
-    * conflicting open.  So two directory leases never conflict on H.  The
-    * directory handle itself is invalidated only when the directory is removed
-    * or renamed, which recalls the lease via the normal io_recall path. */
-    if (existing->is_dir && probe->is_dir) {
+    /* Two SMB2 RqLs caching leases (file OR directory) are NOT handle-exclusive
+     * across clients: per MS-SMB2 two different clients may each hold an R+H
+     * (read+handle) lease on the same file or directory at once — a read+handle
+     * lease shares the read cache and is recalled by an actual write / namespace
+     * change, not by a peer's mere open (smb2.lease.unlink, smb2.lease.oplock,
+     * and the directory-lease suite all rely on this RH coexistence).  A legacy
+     * SMB oplock is sole-handle, so the cross-client H rule below still fires
+     * when EITHER side is an oplock.  (Same-client RH coexistence — two lease
+     * keys of one client, smb2.lease.break — is also covered here.) */
+    if (chimera_vfs_lease_is_rqls(existing) && chimera_vfs_lease_is_rqls(probe)) {
         return false;
     }
 
-    /* H (handle-cache) is exclusive only ACROSS CLIENTS — a different client
-     * caching the open handle conflicts (a batch oplock is sole-handle), but two
-     * lease keys of the SAME client may each hold handle caching (MS-SMB2 lease
-     * semantics: a client's RH lease is not broken by another RH lease of its own
-     * under a different key -- smb2.lease.break expects two RH leases to coexist).
-     * Write caching above is the only mode exclusive even within one client. */
+    /* H (handle-cache) is exclusive only ACROSS CLIENTS for a sole-handle holder
+     * (a legacy batch oplock; reached here because at least one side is not an
+     * RqLs lease — two RqLs leases already returned no-conflict above).  Both
+     * sides must actually carry the H bit: a peer holding an H-caching oplock and
+     * an H-caching open of another client conflict.  The lease-vs-oplock H cap for
+     * smb2.lease.oplock (a new RH lease behind an s/x/b oplock yields R) is
+     * enforced up front in the SMB create path (the share-reservation is_lease cap
+     * and the same-client holds_handle_lease guard), not here. */
     if ((e & CHIMERA_VFS_LEASE_MODE_H) && (p & CHIMERA_VFS_LEASE_MODE_H) &&
         existing->owner.client_key != probe->owner.client_key &&
         !existing->parked) {
@@ -832,13 +902,38 @@ chimera_vfs_state_would_conflict(
              * capped to a shared read cache (LEVEL_II).  Signal that by denying
              * the W/H grant -- the SMB create path retries for R-only, which
              * coexists.  (Pure attribute-only opens take no share reservation,
-             * so they do not preclude an oplock.) */
+             * so they do not preclude an oplock.)
+             *
+             * The legacy-oplock and the RqLs-lease cases differ:
+             *  - Legacy oplock probe: W|H is sole-access against any OTHER client's
+             *    open (same-client opens coalesce / are this requester's own).
+             *  - RqLs lease probe: the WRITE cache is enforced by the caching-vs-
+             *    caching W rule (not here), so the share path only caps the HANDLE
+             *    bit, and only against a NON-lease open (a legacy oplock or a plain
+             *    open, which owns the handle exclusively -- smb2.lease.oplock: hold
+             *    an s/x/b oplock, request a lease -> R only, even same-client).  Two
+             *    RqLs leases coexist at R+H, whether two lease keys of one client
+             *    (smb2.lease.break) or two clients (smb2.lease.unlink), and a lease
+             *    never caps its own open.  is_lease on the share reservation is
+             *    visible even before the holder's caching grant is linked, so it is
+             *    the reliable discriminator. */
+            bool probe_is_rqls = chimera_vfs_lease_is_rqls(probe);
+            uint8_t sole_mask  = probe_is_rqls
+                ? CHIMERA_VFS_LEASE_MODE_H
+                : (CHIMERA_VFS_LEASE_MODE_W | CHIMERA_VFS_LEASE_MODE_H);
+
             if (probe->owner.protocol == CHIMERA_VFS_LEASE_PROTO_SMB2 &&
-                (probe->mode.granted & (CHIMERA_VFS_LEASE_MODE_W |
-                                        CHIMERA_VFS_LEASE_MODE_H))) {
+                (probe->mode.granted & sole_mask)) {
                 for (cur = file->share_resvs; cur; cur = cur->next) {
                     if (cur->owner.client_key == probe->owner.client_key) {
-                        continue; /* the requesting client's own open(s) */
+                        /* A legacy-oplock probe's own client's opens never cap it.
+                         * An RqLs lease probe is likewise never capped by its own
+                         * open; a same-client second lease key is a lease (is_lease)
+                         * and is skipped by the is_lease rule below, while a
+                         * same-client legacy OPLOCK must still cap the lease's H. */
+                        if (!probe_is_rqls) {
+                            continue;
+                        }
                     }
                     /* An inert (0,0) attribute-only registration is not a real
                      * data opener and does not preclude an exclusive oplock --
@@ -853,6 +948,12 @@ chimera_vfs_state_would_conflict(
                      * forced a break/deny; otherwise the new open coexists with it
                      * (keep-disconnected-rh-*). */
                     if (cur->parked) {
+                        continue;
+                    }
+                    /* An RqLs lease probe (H only here) coexists with any LEASE-
+                     * backed open's handle caching -- including its own open and a
+                     * peer lease.  A non-lease open caps it to R. */
+                    if (probe_is_rqls && cur->owner.is_lease) {
                         continue;
                     }
                     if (conflict_out) {
@@ -1017,7 +1118,14 @@ chimera_vfs_break_retain_for(
     if (a & CHIMERA_VFS_LEASE_MODE_R) {
         keep &= ~CHIMERA_VFS_LEASE_MODE_W;
     }
+    /* The H (handle) bit is sole-across-clients only for a legacy oplock
+     * acquirer: a batch oplock owns the handle cache exclusively, so a peer's H
+     * is stripped.  An SMB2 RqLs lease acquirer is NOT sole-handle -- two clients
+     * may each keep R+H on the same file -- so a lease acquirer leaves the
+     * holder's H intact (smb2.lease.oplock: a second open requesting an oplock,
+     * which arbitrates via this matrix, must not break the RH lease holder). */
     if ((a & CHIMERA_VFS_LEASE_MODE_H) &&
+        !chimera_vfs_lease_is_rqls(acquirer) &&
         acquirer->owner.client_key != holder->owner.client_key) {
         keep &= ~CHIMERA_VFS_LEASE_MODE_H;
     }
@@ -2274,6 +2382,86 @@ chimera_vfs_break_caching_file(
     return had;
 } /* chimera_vfs_break_caching_file */
 
+/* Single-step namespace recall: break every caching holder that still caches a
+ * bit ABOVE `retain` (e.g. an RqLs lease's H beyond a retain of R) exactly ONCE,
+ * down to `retain`, sparing the operating open (`skip_handle`).  Returns true
+ * while any such holder is still BREAKING (the caller parks; the lease ack pumps
+ * the queue, which re-runs this and sees the holder settled at `retain`).  Unlike
+ * chimera_vfs_break_caching_file this does NOT cascade to NONE -- an ACKED holder
+ * sitting at `retain` is left alone, so exactly one RH->R break fires per peer
+ * (smb2.lease.unlink). */
+static bool
+chimera_vfs_break_caching_single(
+    struct chimera_vfs_state             *state,
+    struct chimera_vfs_file_state        *file,
+    const struct chimera_vfs_open_handle *skip_handle,
+    uint8_t                               retain)
+{
+    bool had = false;
+
+    for ( ; ; ) {
+        struct chimera_vfs_lease *cur;
+        struct chimera_vfs_lease *to_break  = NULL;
+        struct chimera_vfs_lease *to_revoke = NULL;
+
+        pthread_mutex_lock(&file->lock);
+        for (cur = file->caching_leases; cur; cur = cur->next) {
+            if (!cur->owner.break_cb) {
+                continue;
+            }
+            if (skip_handle && cur->owner.op_handle == skip_handle) {
+                continue;
+            }
+            /* Only a holder caching a bit above the retain floor needs recall. */
+            if ((cur->mode.granted & ~retain) == 0) {
+                continue;
+            }
+            if (cur->break_state == CHIMERA_VFS_BREAK_IDLE) {
+                to_break = cur;
+                break;
+            }
+            if (cur->break_state == CHIMERA_VFS_BREAK_BREAKING &&
+                chimera_vfs_break_deadline_passed(cur)) {
+                to_revoke = cur;
+                break;
+            }
+        }
+        pthread_mutex_unlock(&file->lock);
+
+        if (to_break) {
+            chimera_vfs_lease_begin_break(state, to_break, retain,
+                                          CHIMERA_VFS_NFS_DELEG_METAOP_MS);
+        } else if (to_revoke) {
+            chimera_vfs_lease_revoke(to_revoke);
+        } else {
+            break;
+        }
+    }
+
+    /* Blocked while any non-spared holder is still BREAKING: unlike a metadata
+     * mutation (which proceeds optimistically once an SMB holder is NOTIFIED), the
+     * delete-on-close caller must WAIT for the client's real break ACK before
+     * replying, so the client sees the break before it inspects the break count
+     * (smb2.lease.unlink).  The lease ack drives break_state BREAKING->ACKED and
+     * pumps this queue. */
+    pthread_mutex_lock(&file->lock);
+    {
+        struct chimera_vfs_lease *cur;
+        for (cur = file->caching_leases; cur; cur = cur->next) {
+            if (skip_handle && cur->owner.op_handle == skip_handle) {
+                continue;
+            }
+            if (cur->break_state == CHIMERA_VFS_BREAK_BREAKING) {
+                had = true;
+                break;
+            }
+        }
+    }
+    pthread_mutex_unlock(&file->lock);
+
+    return had;
+} /* chimera_vfs_break_caching_single */
+
 SYMBOL_EXPORT bool
 chimera_vfs_state_break_caching(
     struct chimera_vfs_state *state,
@@ -2533,6 +2721,65 @@ chimera_vfs_state_break_caching_for_open(
     chimera_vfs_state_put(state, file);
 } /* chimera_vfs_state_break_caching_for_open */
 
+/* Break-on-namespace-change: an unlink / delete-on-close / rename of an OPEN
+ * file is a genuine recall of every other holder's HANDLE cache -- the cached
+ * handle (and any cached directory entry) is no longer valid (MS-SMB2: a
+ * namespace delete breaks a holder's RH lease down to R).  Unlike the
+ * pre-share-check H trigger in break_caching_for_open (which intentionally
+ * leaves an RqLs lease's handle alone), this recall DOES strip an RqLs lease's
+ * H -- it is a real mutation, not a mere conflicting open -- mirroring how a
+ * write recalls a peer's read cache.  Holders are broken down to `retain_mode`
+ * (R, so RH -> R), the requesting client's own lease (matched by `opener`, e.g.
+ * the deleter's still-open handle) is skipped, and same-lease-key holders
+ * coalesce as usual.  Caller must NOT hold file->lock. */
+SYMBOL_EXPORT void
+chimera_vfs_state_break_caching_for_namespace(
+    struct chimera_vfs_state             *state,
+    const uint8_t                        *fh,
+    uint8_t                               fh_len,
+    uint64_t                              fh_hash,
+    const struct chimera_vfs_lease_owner *opener,
+    uint8_t                               retain_mode)
+{
+    struct chimera_vfs_file_state *file;
+    struct chimera_vfs_lease      *cur;
+    struct chimera_vfs_lease      *to_break[CHIMERA_VFS_STATE_MAX_BREAK_BATCH];
+    int                            n = 0;
+    int                            i;
+
+    file = chimera_vfs_state_get(state, fh, fh_len, fh_hash, false);
+    if (!file) {
+        return;
+    }
+
+    pthread_mutex_lock(&file->lock);
+
+    for (cur = file->caching_leases; cur; cur = cur->next) {
+        /* Only a holder that still caches the handle (H beyond what it retains)
+         * needs the namespace recall. */
+        if ((cur->mode.granted & CHIMERA_VFS_LEASE_MODE_H & ~retain_mode) == 0) {
+            continue;
+        }
+        if (opener && chimera_vfs_lease_owner_equal(&cur->owner, opener)) {
+            continue;
+        }
+        if (opener && chimera_vfs_lease_smb2_same_key(&cur->owner, opener)) {
+            continue;
+        }
+        if (n < CHIMERA_VFS_STATE_MAX_BREAK_BATCH) {
+            to_break[n++] = cur;
+        }
+    }
+
+    pthread_mutex_unlock(&file->lock);
+
+    for (i = 0; i < n; i++) {
+        chimera_vfs_lease_begin_break(state, to_break[i], retain_mode, 0);
+    }
+
+    chimera_vfs_state_put(state, file);
+} /* chimera_vfs_state_break_caching_for_namespace */
+
 /* -------------------------------------------------------------------- */
 /* Implicit I/O lease                                                   */
 /* -------------------------------------------------------------------- */
@@ -2791,6 +3038,27 @@ chimera_vfs_io_try(
      * the operating client's own delegation), then proceed.  No lease is held
      * on chimera's behalf.  The periodic maintenance pass re-pumps parked
      * waiters so an unresponsive holder is revoked at its recall deadline. */
+    /* Single-step namespace recall: break each OTHER caching holder exactly ONCE
+     * down to io_recall_retain (drop H, keep R), sparing the operating open
+     * (io_handle), then park until every such break is acked.  Unlike the
+     * recall_all cascade-to-NONE, this fires exactly one RH->R break per peer
+     * (smb2.lease.unlink: a delete-on-close breaks the peer's RH lease to R, and
+     * the client expects a single break notification). */
+    if (request->io_recall_single) {
+        if (chimera_vfs_break_caching_single(state, file, request->io_handle,
+                                             request->io_recall_retain)) {
+            pthread_mutex_lock(&file->lock);
+            chimera_vfs_io_park_locked(file, request);
+            request->io_lease_file = file;
+            pthread_mutex_unlock(&file->lock);
+            return;
+        }
+        request->io_lease_file = NULL;
+        chimera_vfs_state_put(state, file);
+        request->io_next(request);
+        return;
+    }
+
     if (request->io_recall_all) {
         if (chimera_vfs_break_caching_file(state, file, request->io_handle,
                                            request->io_recall_flush_only)) {
@@ -3006,6 +3274,39 @@ chimera_vfs_io_recall(
 
     chimera_vfs_io_try(state, file, request);
 } /* chimera_vfs_io_recall */
+
+SYMBOL_EXPORT void
+chimera_vfs_io_recall_single(
+    struct chimera_vfs_request *request,
+    const uint8_t              *fh,
+    uint8_t                     fh_len,
+    uint64_t                    fh_hash,
+    uint8_t                     retain,
+    void (                     *next )(struct chimera_vfs_request *request))
+{
+    struct chimera_vfs_state      *state = request->thread->vfs->vfs_state;
+    struct chimera_vfs_file_state *file;
+
+    request->io_next           = next;
+    request->io_lease_file     = NULL;
+    request->io_recall_all     = 0;
+    request->io_recall_single  = 1;
+    request->io_recall_retain  = retain;
+    request->io_owns_lease_ref = 1;
+
+    if (!state || fh_len == 0) {
+        next(request);
+        return;
+    }
+
+    file = chimera_vfs_state_get(state, fh, fh_len, fh_hash, false);
+    if (!file) {
+        next(request);
+        return;
+    }
+
+    chimera_vfs_io_try(state, file, request);
+} /* chimera_vfs_io_recall_single */
 
 SYMBOL_EXPORT void
 chimera_vfs_io_lease_release(struct chimera_vfs_request *request)

--- a/src/vfs/vfs_state.h
+++ b/src/vfs/vfs_state.h
@@ -246,6 +246,23 @@ chimera_vfs_caching_grant_cap_mode(
     struct chimera_vfs_file_state  *file,
     const struct chimera_vfs_lease *lease);
 
+/* True if `client_key` already holds an SMB2 RqLs handle-caching (H) lease on
+* `file`.  Used by the SMB create path to deny a legacy oplock request (-> NONE)
+* when the same client already holds an H lease, without recalling its own
+* lease.  A lease without H does not preclude a coexisting level-II oplock. */
+bool
+chimera_vfs_client_holds_handle_lease(
+    struct chimera_vfs_file_state *file,
+    uint64_t                       client_key);
+
+/* True if `client_key` holds ANY live SMB2 RqLs caching lease on `file`.  Used
+ * by the SMB create path to cap a same-client legacy oplock request to level-II
+ * so it coexists with the client's R/RW lease without recalling it. */
+bool
+chimera_vfs_client_holds_caching_lease(
+    struct chimera_vfs_file_state *file,
+    uint64_t                       client_key);
+
 enum chimera_vfs_lease_result
 chimera_vfs_caching_grant_acquire(
     struct chimera_vfs_state             *state,
@@ -475,6 +492,19 @@ chimera_vfs_io_recall(
     int                         flush_only,
     void (                     *next )(struct chimera_vfs_request *request));
 
+/* Single-step namespace recall: break each OTHER caching holder on (fh, fh_hash)
+ * exactly once down to `retain` (sparing request->io_handle) and PARK until the
+ * holder's break is ACKed, then invoke next(request).  Used by the SMB delete-
+ * on-close path (smb2.lease.unlink): one RH->R break per peer, reply after ack. */
+void
+chimera_vfs_io_recall_single(
+    struct chimera_vfs_request *request,
+    const uint8_t              *fh,
+    uint8_t                     fh_len,
+    uint64_t                    fh_hash,
+    uint8_t                     retain,
+    void (                     *next )(struct chimera_vfs_request *request));
+
 /* Drop every implicit lease that has been idle (no in-flight I/O) for at
  * least `idle_ms` milliseconds.  Driven by a periodic reaper. */
 void
@@ -539,4 +569,17 @@ chimera_vfs_state_break_caching_for_open(
     uint64_t                              fh_hash,
     const struct chimera_vfs_lease_owner *opener,
     uint8_t                               trigger_bits,
+    uint8_t                               retain_mode);
+
+/* Break-on-namespace-change: an unlink / delete-on-close / rename of an OPEN
+ * file recalls every OTHER holder's HANDLE cache down to retain_mode (R), strips
+ * an RqLs lease's H (a real mutation, unlike a mere conflicting open), and skips
+ * the requesting client's own lease (matched by opener). */
+void
+chimera_vfs_state_break_caching_for_namespace(
+    struct chimera_vfs_state             *state,
+    const uint8_t                        *fh,
+    uint8_t                               fh_len,
+    uint64_t                              fh_hash,
+    const struct chimera_vfs_lease_owner *opener,
     uint8_t                               retain_mode);


### PR DESCRIPTION
## Summary

Two coupled SMB2 lease/delete-on-close fixes that together green five tests on the lease/teardown frontier (memfs + diskfs_io_uring), with zero regression in the lease/oplock/durable/dirlease/replay suites and the pynfs NFSv4 delegation suite.

### Commit 1 — cross-client RH leases + recall on namespace delete (`lease.unlink`, `lease.oplock`)
The unified VFS lease conflict matrix treated the handle (H) bit as cross-client exclusive, which is correct for a sole-handle legacy oplock but wrong for SMB2 RqLs leases — two different clients may each hold an R+H lease on the same file (MS-SMB2). Three coordinated fixes:
- **Conflict carve-out** generalized: two RqLs caching leases (file or directory) never conflict on H across clients (new `chimera_vfs_lease_is_rqls` helper; subsumes the old directory-lease carve-out). Legacy oplocks stay sole-handle.
- **Cap made `is_lease`-aware**: a new RqLs lease requesting H is not capped to R by a *peer lease* (two RH leases coexist) but still is by a non-lease open. Required marking `owner.is_lease` on the share reservation at CREATE.
- **Lease-vs-oplock**: a legacy oplock requested by a client already holding an RqLs lease no longer recalls that client's own lease.
- **Namespace-delete recall** (new `vfs_proc_recall.c`, `chimera_vfs_io_recall_single`): an unlink / rename / delete-on-close recalls each peer's RH lease exactly once down to R and parks until the client's break is acked, so the SetInfo(FileDispositionInformation) reply deterministically follows the peer's break.

### Commit 2 — delete-on-close on abrupt teardown (`initial_delete_disconnect/logoff/tdis`)
The clean multi-handle CLOSE already deletes DOC files, but abrupt teardown (disconnect / logoff / tree disconnect) funneled through `chimera_smb_tree_free`, which freed handles with a plain release — skipping the DOC check, so a DOC-armed file leaked. Teardown's genuine-discard block now routes through `chimera_vfs_release_doc` + a request-less `chimera_smb_teardown_doc_unlink`. **A preserved durable handle is parked earlier in the loop and never reaches this path — its file is never deleted on disconnect.** The single-step recall from commit 1 fires on the shared remove path, so the teardown delete recalls a peer's lease exactly once.

## Verification
- `lease.unlink`, `lease.oplock`, `initial_delete_disconnect/logoff/tdis`: 3× green on memfs AND diskfs_io_uring.
- Zero regression: full enabled `smb2.{lease,oplock,durable-open,durable-v2-open,dirlease,replay,compound_async,session,delete-on-close-perms}` (185 on memfs) — all pass; durable `keep-disconnected-*` and `CHIMERA_SMB_TEST_DISCONNECT_DELAY_MS` disconnect-race tests stay green (durable handles preserved, files intact).
- pynfs NFSv4 delegation suite: 50/50 (the lease layer is shared; the carve-out keys on `grant && !is_oplock`, which NFSv4 owners never satisfy).
- Release (GCC `-Werror`) clean; scan-build "No bugs found".

`SMBTORTURE_DISABLED_SUBTESTS` untouched.
