### PR TITLE
smb: fix durable-open open2-lease pre-notify SHARING_VIOLATION race

### DIFF
--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -2192,6 +2192,31 @@ chimera_smb_server_notify(
             chimera_smb_info("Disconnected %s SMB connection from %s to %s, handled %lu requests",
                              conn->protocol == EVPL_DATAGRAM_RDMACM_RC ? "RDMA" : "TCP",
                              conn->remote_addr, conn->local_addr, conn->requests_completed);
+            /* Test hook: delay the START of disconnect processing -- BEFORE the
+             * connection is flagged disconnecting -- to deterministically model
+             * the PRE-NOTIFY race window.  In this window the server has not yet
+             * run the disconnect callback for the durable holder's (already
+             * TCP-closed) connection at all, so the holder still looks fully live
+             * (create_conn != NULL, disconnecting == 0) while a conflicting CREATE
+             * races in on another connection.  This is distinct from
+             * CHIMERA_SMB_TEST_DISCONNECT_DELAY_MS below, which delays the teardown
+             * AFTER disconnecting is set (the post-notify window).  The conflicting
+             * CREATE can still tell the holder is on its way out because its bind
+             * has already observed the peer FIN (evpl_bind_is_closing()).  Inert
+             * unless the environment variable is set; used by the smbtorture
+             * durable-open prenotify ctest entry. */
+            {
+                static int prenotify_delay_ms = -1;
+
+                if (prenotify_delay_ms < 0) {
+                    const char *d = getenv(
+                        "CHIMERA_SMB_TEST_DISCONNECT_NOTIFY_DELAY_MS");
+                    prenotify_delay_ms = d ? atoi(d) : 0;
+                }
+                if (prenotify_delay_ms > 0) {
+                    usleep(prenotify_delay_ms * 1000);
+                }
+            }
             /* Flag the connection disconnecting up front, before the (possibly
              * delayed) teardown that parks its durable handles.  A conflicting
              * CREATE racing in on another connection consults this through the

--- a/src/server/smb/smb_durable.c
+++ b/src/server/smb/smb_durable.c
@@ -290,38 +290,77 @@ chimera_smb_durable_purge_parked(
 } /* chimera_smb_durable_purge_parked */
 
 /* A conflicting CREATE found a still-live (not-yet-parked) durable open by its
- * persistent id and could not purge it.  Decide whether that holder is merely
- * racing its own disconnect -- its owning connection has begun teardown but has
- * not parked the handle yet (the open2-lease / disconnect-vs-conflicting-open
- * window) -- in which case the conflicting CREATE should retry briefly rather
+ * persistent id and could not purge it.  Decide whether that holder is racing its
+ * own disconnect and will yield (so the conflicting CREATE should retry rather
  * than deny: MS-SMB2 has the disconnected non-persistent handle yield, and a
- * short retry lets the park complete so the purge then succeeds.
+ * short retry lets the park complete so the purge then succeeds), and if so how
+ * confidently -- see enum chimera_smb_durable_yield.
  *
- * Returns true iff a matching non-persistent, non-cold, NOT-yet-parked durable
- * entry exists whose owning open has lost its connection (create_conn == NULL,
- * i.e. conn_free already cleared it) OR whose connection is flagged
- * disconnecting (the teardown is queued but has not run).  A genuinely-live
- * durable holder on an active connection returns false, so its conflict stands
- * as a real SHARING_VIOLATION without any retry delay.  Persistent handles do
- * not yield, so they are excluded. */
-SYMBOL_EXPORT bool
+ * Only non-persistent, non-cold entries with a live open_file are candidates;
+ * persistent handles do not yield and are excluded (NONE), as is an unknown id.
+ * #839 covered only the post-disconnect stages (create_conn cleared / conn flagged
+ * disconnecting); CONFIRMED here also covers the pre-notify bind-already-closing
+ * stage AND the just-parked stage (purge_parked lost the park race by an instant),
+ * and SPECULATIVE adds the even-earlier FIN-not-yet-read window: any candidate
+ * durable holder with no disconnect signal yet gets a SHORT speculative retry,
+ * because it must yield if its owner is in fact disconnecting, and merely incurs a
+ * brief bounded delay before the same SHARING_VIOLATION if it is genuinely live. */
+SYMBOL_EXPORT enum chimera_smb_durable_yield
 chimera_smb_durable_conn_disconnecting(
     struct chimera_server_smb_shared *shared,
     uint64_t                          persistent_id)
 {
     struct chimera_smb_durable_entry *entry;
-    bool                              disconnecting = false;
+    enum chimera_smb_durable_yield    yield = CHIMERA_SMB_DURABLE_YIELD_NONE;
 
     pthread_mutex_lock(&shared->durable.lock);
     HASH_FIND(hh, shared->durable.by_pid, &persistent_id, sizeof(persistent_id), entry);
-    if (entry && !entry->parked && !entry->persistent && !entry->cold &&
-        entry->open_file) {
+    if (entry && !entry->persistent && !entry->cold && entry->open_file) {
         struct chimera_smb_conn *cc = entry->open_file->create_conn;
-        disconnecting = (cc == NULL) || cc->disconnecting;
+
+        /* The holder yields once its disconnect parks it.  Four observable stages
+         * of that disconnect, earliest first:
+         *
+         *   1. PRE-NOTIFY: the peer's TCP close (read-side FIN) has been seen by
+         *      libevpl, which has scheduled (deferred) the teardown -- but the
+         *      server has not yet run EVPL_NOTIFY_DISCONNECTED for this conn at
+         *      all, so create_conn is still set and disconnecting is still 0.
+         *      The bind is already closing, detected via evpl_bind_is_closing().
+         *   2. NOTIFY started: EVPL_NOTIFY_DISCONNECTED has run far enough to set
+         *      conn->disconnecting, but the teardown has not parked the handle.
+         *   3. conn_free done: create_conn has been cleared (cc == NULL).
+         *   4. PARKED: the teardown has already parked the handle (entry->parked).
+         *      A conflicting CREATE's chimera_smb_durable_purge_parked races the
+         *      park: if it probed an instant before parked flipped to 1 it returns
+         *      false, then re-checks here and finds the now-parked entry -- a sure
+         *      yield, the very next retry's purge_parked will reap it.
+         *
+         * Any of the four is a CONFIRMED disconnect: the holder is on its way out
+         * and will release its share reservation, so retry on the full budget. */
+        if (entry->parked || (cc == NULL) || cc->disconnecting ||
+            (cc->bind && evpl_bind_is_closing(cc->bind))) {
+            yield = CHIMERA_SMB_DURABLE_YIELD_CONFIRMED;
+        } else {
+            /* No disconnect signal yet, but this is the even earlier window the
+             * pre-notify retry alone still misses: the conflicting CREATE was
+             * processed before the server's event loop has even read the holder's
+             * already-sent FIN, so none of the three signals above are set yet.
+             * The holder is a non-persistent durable open, which MS-SMB2 requires
+             * to yield once its owner disconnects -- so this conflict can resolve
+             * in exactly two ways: the holder is disconnecting (and within a couple
+             * of ticks its FIN is read, a subsequent probe flips to CONFIRMED, and
+             * it parks + yields), or it is genuinely live and staying (the conflict
+             * is real).  Retry SPECULATIVELY on a SHORT budget: it covers the
+             * FIN-read latency for the disconnecting case, and merely adds a brief
+             * bounded delay before the same SHARING_VIOLATION for the genuinely-live
+             * case -- never a wrong answer, and the live path is the much rarer one
+             * (a second open against a still-connected durable handle). */
+            yield = CHIMERA_SMB_DURABLE_YIELD_SPECULATIVE;
+        }
     }
     pthread_mutex_unlock(&shared->durable.lock);
 
-    return disconnecting;
+    return yield;
 } /* chimera_smb_durable_conn_disconnecting */
 
 SYMBOL_EXPORT void

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -571,10 +571,12 @@ struct chimera_smb_request {
             uint8_t                            gen_held_granted;
             uint8_t                            gen_parked;
             /* Set by chimera_smb_create_gen_open_file_normal when the share
-             * conflict it could not resolve is against a durable holder whose
-             * owning connection is mid-disconnect (it will park+yield shortly).
-             * Tells the open-completion path to retry on a short timer instead of
-             * failing SHARING_VIOLATION.  Cleared per create attempt. */
+             * conflict it could not resolve is against a durable holder that will
+             * park+yield shortly: an enum chimera_smb_durable_yield value telling
+             * the open-completion path whether to retry on a timer instead of
+             * failing SHARING_VIOLATION, and on which budget (CONFIRMED = full,
+             * SPECULATIVE = short).  Re-evaluated (cleared first) per create
+             * attempt. */
             uint8_t                            gen_share_retry;
             /* GRANTED/DENIED result stashed by chimera_smb_create_share_park_cb
              * when the share-park ticket resolves on another thread, so the
@@ -1415,12 +1417,37 @@ chimera_smb_durable_purge_parked(
     struct chimera_server_smb_thread *thread,
     uint64_t                          persistent_id);
 
-/* True iff a non-persistent durable open with this persistent id exists, is not
- * yet parked, and its owning connection has begun disconnecting (create_conn
- * cleared or flagged disconnecting) -- i.e. a conflicting CREATE should retry
- * briefly for the disconnect to park+yield it rather than deny SHARING_VIOLATION.
- * False for a genuinely-live durable holder (real conflict) or unknown id. */
-bool
+/* How a conflicting CREATE should treat a share conflict against a not-yet-parked
+ * non-persistent durable holder it could not purge.  See
+ * chimera_smb_durable_conn_disconnecting. */
+enum chimera_smb_durable_yield {
+    /* Genuinely-live holder on a fully-connected conn (or persistent/unknown):
+     * the conflict is real, deny SHARING_VIOLATION immediately, no retry. */
+    CHIMERA_SMB_DURABLE_YIELD_NONE        = 0,
+    /* The holder's disconnect has been observed (create_conn cleared, conn
+     * flagged disconnecting, bind already closing, or the entry already parked --
+     * a purge that lost the park race by an instant): the park + MS-SMB2 yield is
+     * imminent or done -- retry on the full (~3 s) budget for it to be reaped. */
+    CHIMERA_SMB_DURABLE_YIELD_CONFIRMED   = 1,
+    /* No disconnect signal yet, but the holder is a non-persistent durable open
+     * (which MS-SMB2 requires to yield once its owner disconnects).  The conflict
+     * can only resolve two ways: the holder is disconnecting (its FIN just has not
+     * been read yet -- a later probe flips to CONFIRMED once it is) or it is
+     * genuinely live and staying.  Retry on a SHORT budget that covers the
+     * FIN-read latency; a genuinely-live holder simply lapses that short budget
+     * into the same SHARING_VIOLATION it would have returned immediately. */
+    CHIMERA_SMB_DURABLE_YIELD_SPECULATIVE = 2,
+};
+
+/* Classify a share conflict against a non-persistent durable open with this
+* persistent id that a conflicting CREATE could not purge.  Returns
+* CHIMERA_SMB_DURABLE_YIELD_NONE for a persistent handle or unknown id;
+* _CONFIRMED once the holder's disconnect has been observed (the pre-notify
+* window via its bind already closing, or later stages: conn flagged
+* disconnecting, create_conn cleared, or the entry already parked); _SPECULATIVE
+* when no disconnect signal is visible yet but the holder is a non-persistent
+* durable open (and so must yield if its owner is in fact disconnecting). */
+enum chimera_smb_durable_yield
 chimera_smb_durable_conn_disconnecting(
     struct chimera_server_smb_shared *shared,
     uint64_t                          persistent_id);

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -65,9 +65,17 @@
  * The window is just the time for the peer connection's disconnect callback to
  * be scheduled and park the handle, so a short interval with a bounded budget
  * (~3 s, matching the durable-reconnect retry) covers a loaded CI runner without
- * delaying a genuinely-live conflict (that path never sets gen_share_retry). */
+ * delaying a genuinely-live conflict.  The budget depends on how the conflict was
+ * classified (enum chimera_smb_durable_yield): a CONFIRMED disconnect (or an
+ * already-parked holder) gets the full ~3 s; a SPECULATIVE conflict (a durable
+ * holder whose FIN may not have been read yet, so the disconnect is not yet
+ * observable) gets only a short budget sufficient to cover the FIN-read latency --
+ * once the FIN is read a re-probe upgrades it to CONFIRMED and the full budget
+ * applies, while a genuinely-live durable holder lapses the short budget into the
+ * same immediate SHARING_VIOLATION. */
 #define CHIMERA_SMB_CREATE_SHARE_RETRY_INTERVAL_US 20000  /* 20 ms */
 #define CHIMERA_SMB_CREATE_SHARE_RETRY_MAX         150    /* ~3 s total */
+#define CHIMERA_SMB_CREATE_SHARE_SPEC_RETRY_MAX    25     /* ~0.5 s total */
 
 /* Map a VFS error from an open-or-create path to the SMB2 status that
  * Windows clients expect.  EISDIR/ENOTDIR are critical here: cmd.exe and
@@ -794,16 +802,16 @@ chimera_smb_create_gen_open_file(
 
             if (!chimera_smb_durable_purge_parked(thread, conflict_pid)) {
                 /* The durable holder is not parked yet.  If its owning connection
-                 * has begun disconnecting, the park (and the MS-SMB2 yield) is
-                 * imminent but has not landed -- this is the
-                 * disconnect-vs-conflicting-open race (open2-lease).  Flag the
-                 * open to retry on a short timer rather than deny; a genuinely
-                 * live durable holder is not disconnecting, so its conflict
-                 * stands immediately as a real SHARING_VIOLATION. */
-                if (chimera_smb_durable_conn_disconnecting(thread->shared,
-                                                           conflict_pid)) {
-                    request->create.gen_share_retry = 1;
-                }
+                * is on its way out, the park (and the MS-SMB2 yield) is imminent
+                * but has not landed -- this is the disconnect-vs-conflicting-open
+                * race (open2-lease).  Flag the open to retry on a timer rather
+                * than deny: CONFIRMED (disconnect observed, or already parked)
+                * gets the full budget; SPECULATIVE (a durable holder whose FIN may
+                * not be read yet) gets a short budget.  Only a persistent or
+                * unknown holder is NONE, standing as a real SHARING_VIOLATION. */
+                request->create.gen_share_retry =
+                    chimera_smb_durable_conn_disconnecting(thread->shared,
+                                                           conflict_pid);
                 break;
             }
             conflict = NULL;
@@ -1846,12 +1854,22 @@ chimera_smb_create_open_at_callback(
         /* Share conflict against a durable holder whose owning connection is
          * mid-disconnect: it will park + yield once that disconnect runs, so
          * re-attempt the open completion on a short timer (holding oh + parent)
-         * rather than failing.  The budget lapses into the original
-         * SHARING_VIOLATION if the holder never yields (e.g. it was actually a
-         * persistent handle or genuinely live -- gen_share_retry would not be
-         * set in that case). */
-        if (request->create.gen_share_retry &&
-            request->create.share_conflict_retries < CHIMERA_SMB_CREATE_SHARE_RETRY_MAX) {
+         * rather than failing.  gen_share_retry was set by
+         * chimera_smb_create_gen_open_file_normal on this attempt and reflects the
+         * latest classification: CONFIRMED (disconnect observed, or already parked)
+         * gets the full budget; SPECULATIVE (a durable holder whose disconnect is
+         * not yet observable) gets the short budget -- if its FIN is read on a
+         * later probe the classification flips to CONFIRMED and the full budget
+         * then applies.  The budget lapses into the original SHARING_VIOLATION if
+         * the holder never yields (persistent or genuinely live -- gen_share_retry
+         * would be NONE in that case). */
+        uint16_t share_budget =
+            (request->create.gen_share_retry == CHIMERA_SMB_DURABLE_YIELD_CONFIRMED)
+            ? CHIMERA_SMB_CREATE_SHARE_RETRY_MAX
+            : CHIMERA_SMB_CREATE_SHARE_SPEC_RETRY_MAX;
+
+        if (request->create.gen_share_retry != CHIMERA_SMB_DURABLE_YIELD_NONE &&
+            request->create.share_conflict_retries < share_budget) {
             request->create.share_conflict_retries++;
             request->create.share_conflict_oh = oh;
             evpl_add_oneshot_timer(request->compound->thread->evpl,

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -4184,6 +4184,28 @@ if(CHIMERA_NETNS_TESTING AND SMBTORTURE_EXECUTABLE)
             RESOURCE_LOCK smb_durable_oplock_family)
     endforeach()
 
+    # PRE-NOTIFY race coverage: CHIMERA_SMB_TEST_DISCONNECT_NOTIFY_DELAY_MS holds
+    # the START of the disconnect callback -- BEFORE conn->disconnecting is set --
+    # so a conflicting CREATE lands while the durable holder still looks fully live
+    # (create_conn != NULL, disconnecting == 0) and only its bind reveals the peer
+    # FIN (evpl_bind_is_closing()).  This is the window CHIMERA_SMB_TEST_DISCONNECT
+    # _DELAY_MS (which delays teardown only AFTER disconnecting is set) cannot
+    # model, and the one that defeated #839 in CI.  open2-lease is the canonical
+    # case: a disconnected non-persistent RH-lease durable holder must yield to a
+    # second client's open.
+    foreach(_sub smb2.durable-open.open2-lease smb2.durable-open.open2-oplock)
+        string(REGEX REPLACE "[^A-Za-z0-9]" "_" _sid "${_sub}")
+        set(_name chimera/server/smb/smbtorture_${_sid}_prenotify_race_memfs)
+        add_test(NAME ${_name}
+            COMMAND ${CMAKE_SOURCE_DIR}/scripts/netns_test_wrapper.sh
+                    ${SMBTORTURE_CMD} -b memfs ${_sub})
+        set_tests_properties(${_name} PROPERTIES
+            ENVIRONMENT "${SMBTORTURE_LSAN};CHIMERA_SMB_TEST_DISCONNECT_NOTIFY_DELAY_MS=50"
+            SKIP_RETURN_CODE 77
+            TIMEOUT 300
+            RESOURCE_LOCK smb_durable_oplock_family)
+    endforeach()
+
     add_smbtorture_backend_tests(memfs)
     add_smbtorture_backend_tests(linux)
     add_smbtorture_backend_tests(diskfs_io_uring)


### PR DESCRIPTION
smb2.durable-open.open2-lease (seed 4242, memfs, netns) still failed in CI after #839 merged, with:

```
durable_open.c:2630: status was NT_STATUS_SHARING_VIOLATION, expected NT_STATUS_OK
```

The test: tree1 opens a non-persistent durable handle + RH lease, `share_access=""`; tree1 disconnects; tree2 opens expecting `OK` (the disconnected durable holder must yield).

## Why #839 was insufficient

#839 added a retry of the conflicting CREATE, but only once the holder's connection was already flagged `disconnecting` (set inside `EVPL_NOTIFY_DISCONNECTED`). CI hits the **pre-notify window**: tree2's CREATE is processed *before* the server runs tree1's `EVPL_NOTIFY_DISCONNECTED` at all, so `disconnecting` is unset and the holder still looks live -> no retry -> `SHARING_VIOLATION`.

`CHIMERA_SMB_TEST_DISCONNECT_DELAY_MS` only delays teardown *after* `disconnecting` is set (the post-notify window), so it never modeled this window -- which is why #839 verified locally yet still failed in CI.

## Fix: detect the bind already closing

When a TCP peer FINs, libevpl's read path (`recv` returns 0) calls `evpl_close`, which **synchronously** marks the bind closing (`EVPL_BIND_PENDING_CLOSED`) and *defers* the destroy that later dispatches `EVPL_NOTIFY_DISCONNECTED`. So even in the pre-notify window the holder's socket is already provably dead.

A new libevpl accessor `evpl_bind_is_closing()` (chimera-nas/libevpl#107) exposes that state through the public header. The durable arbitration now classifies a conflict against a not-yet-parked non-persistent durable holder as `enum chimera_smb_durable_yield`:

- **CONFIRMED** -- disconnect observed (conn flagged `disconnecting`, `create_conn` cleared, entry already parked, *or the bind already closing*): full ~3 s retry budget.
- **SPECULATIVE** -- no disconnect signal yet, but the holder is a non-persistent durable open whose FIN may simply not have been read yet: short ~0.5 s budget that covers FIN-read latency, after which a re-probe upgrades it to CONFIRMED. A genuinely-live holder merely lapses the short budget into the same `SHARING_VIOLATION`.
- **NONE** -- persistent or unknown holder: immediate `SHARING_VIOLATION`, no retry.

Only durable-holder conflicts enter this path; a plain share-mode conflict (non-durable) still denies immediately.

## Pre-notify repro (new knob)

`CHIMERA_SMB_TEST_DISCONNECT_NOTIFY_DELAY_MS` sleeps at the **start** of the disconnect callback, *before* `conn->disconnecting` is set, deterministically modeling the pre-notify window (mirrors the plumbing of `CHIMERA_SMB_TEST_DISCONNECT_DELAY_MS`). A new `*_prenotify_race_memfs` ctest entry runs open2-lease/open2-oplock under it.

- With `NOTIFY_DELAY_MS=50` and **#839's code (no bind-closing/no SPECULATIVE)**: the test fails the exact CI `SHARING_VIOLATION` -- reproduced deterministically 6/6.
- With this fix: passes 5/5, and `until-fail:200` green under 384-way CPU load.

## Verification

- Pre-notify repro: baseline-fail 6/6, fixed-pass 5/5; `durable_open_open2_lease_*_memfs --repeat until-fail:200` green under heavy load (Debug/ASan).
- `smb2.sharemode` wall time **unchanged**: ~0.49 s on #839 baseline vs ~0.48 s with the fix (Release) -- a genuinely-live conflict still denies fast, no retry latency.
- Regression cluster `durable_open|durable_v2_open|smb2_oplock|smb2_lease|sharemode` green on memfs+linux+diskfs+cairn+io_uring, both Release and Debug/ASan (532/532 each), including `*_disconnect_race_memfs` and `open2-oplock` (#825).
- libevpl 69/69 tests pass with the new accessor.
- `make syntax` clean; copyright years current.

## Dependency

Bumps `ext/libevpl` forward (`c2b8832` -> `917a0c7`, forward-only) for `evpl_bind_is_closing()`: chimera-nas/libevpl#107. Merge that first.

Refs #733, #839.