### PR TITLE
smb2: full LOGOFF/TREE_DISCONNECT reply bodies + drop final-response …

### DIFF
--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -360,6 +360,19 @@ chimera_smb_compound_reply(struct chimera_smb_compound *compound)
 
     evpl_iovec_cursor_reset_consumed(&reply_cursor);
 
+    /* Index of the last response that will actually be emitted: trailing
+     * alignment padding is only needed BETWEEN compounded responses (it aligns
+     * the next response's header); the final response goes out at its natural
+     * length.  A padded tail can confuse a client -- samba's client identifies a
+     * COPYCHUNK error-with-data reply by its exact 12-byte output size. */
+    int last_emitted = -1;
+
+    for (i = 0; i < compound->num_requests; i++) {
+        if (compound->requests[i]->status != SMB2_STATUS_PENDING) {
+            last_emitted = i;
+        }
+    }
+
     for (i = 0; i < compound->num_requests; i++) {
         request = compound->requests[i];
 
@@ -537,7 +550,8 @@ chimera_smb_compound_reply(struct chimera_smb_compound *compound)
         preauth_fold_len = evpl_iovec_cursor_consumed(&reply_cursor);
 
         /* Pad each response to an 8-byte boundary so the next compounded
-         * response's header is aligned. NEGOTIATE and SESSION_SETUP are never
+         * response's header is aligned -- but not the final emitted response,
+         * which ends at its natural length. NEGOTIATE and SESSION_SETUP are never
          * compounded and feed the SMB 3.1.1 preauth-integrity hash, which the
          * client computes over the message *as received* (no trailing pad):
          * emit them in canonical form so our hash matches the client's.
@@ -548,7 +562,8 @@ chimera_smb_compound_reply(struct chimera_smb_compound *compound)
          * dynamic data size is exactly sizeof(srv_copychunk_rsp) (12 bytes), so
          * trailing alignment padding would hide the limit body.  Such a reply is
          * never compounded after. */
-        if (request->smb2_hdr.command != SMB2_NEGOTIATE &&
+        if (i != last_emitted &&
+            request->smb2_hdr.command != SMB2_NEGOTIATE &&
             request->smb2_hdr.command != SMB2_SESSION_SETUP &&
             !(request->smb2_hdr.command == SMB2_IOCTL &&
               request->ioctl.cc_limit_response)) {

--- a/src/server/smb/smb_proc_logoff.c
+++ b/src/server/smb/smb_proc_logoff.c
@@ -65,5 +65,6 @@ chimera_smb_logoff_reply(
     struct chimera_smb_request *request)
 {
     evpl_iovec_cursor_append_uint16(reply_cursor, SMB2_LOGOFF_REPLY_SIZE);
+    evpl_iovec_cursor_append_uint16(reply_cursor, 0); /* Reserved */
 } /* chimera_smb_logoff_reply */
 

--- a/src/server/smb/smb_proc_tree_disconnect.c
+++ b/src/server/smb/smb_proc_tree_disconnect.c
@@ -46,6 +46,7 @@ chimera_smb_tree_disconnect_reply(
 {
 
     evpl_iovec_cursor_append_uint16(reply_cursor, SMB2_TREE_DISCONNECT_REPLY_SIZE);
+    evpl_iovec_cursor_append_uint16(reply_cursor, 0); /* Reserved */
 
 } /* chimera_smb_tree_disconnect_reply */
 

--- a/src/server/smb/tests/smbtorture_test.c
+++ b/src/server/smb/tests/smbtorture_test.c
@@ -76,6 +76,13 @@ run_smbtorture(
     const char *converter = getenv("SMBTORTURE_JUNIT_CONVERTER");
     char        capfile[512];
 
+    /* Advertise server-side-copy resume-key support only for the memfs backend,
+     * the one against which the smb2.ioctl.copy_chunk family is verified.  With
+     * resume_key_support=no smbtorture self-skips the whole copy_chunk family, so
+     * memfs needs "yes" to actually exercise the COPYCHUNK conformance path; the
+     * other backends stay "no" until their copy_range coverage is validated. */
+    const char *resume_key = (strcmp(backend, "memfs") == 0) ? "yes" : "no";
+
     /* Size the command buffer to the base options plus every test name: a
      * consolidated suite run passes dozens, which overflowed the old fixed
      * buffer (the truncating snprintf underflowed sizeof()-off and aborted). */
@@ -95,7 +102,7 @@ run_smbtorture(
                    "smbtorture //127.0.0.1/share"
                    " -U myuser%%mypassword"
                    " --option=torture:samba3=yes"
-                   " --option=torture:resume_key_support=no"
+                   " --option=torture:resume_key_support=%s"
                    /* Provide the parameters that several suites abort
                     * without, so the real protocol logic runs instead of
                     * a "missing option" bail-out:
@@ -118,7 +125,8 @@ run_smbtorture(
                     * randomized input deterministic, so a suite that passes
                     * once passes always. */
                    " --seed=4242"
-                   " --fullname");
+                   " --fullname",
+                   resume_key);
 
     /* samba3misc's localposixlock test needs the share's on-disk path so
      * it can take a POSIX lock directly.  Only the passthrough backends


### PR DESCRIPTION
…padding

The LOGOFF and TREE_DISCONNECT reply handlers emitted only the 2-byte StructureSize, two bytes short of their declared 4-byte body (StructureSize + Reserved). The shortfall was masked by the trailing 8-byte alignment padding the compound builder applied to every response, including the last one.

Trailing alignment padding is only needed BETWEEN compounded responses, where it aligns the next response's header; the final response of a compound should go out at its natural length. Stop padding the last emitted response in chimera_smb_compound_reply (tracked via last_emitted), keeping the existing NEGOTIATE/SESSION_SETUP and COPYCHUNK-limit exemptions intact, and emit the Reserved halfword so both replies reach their full declared size. This makes smb2.session.two_logoff exercise the LOGOFF body correctly.

Tests: advertise server-side-copy resume-key support for the memfs backend in the smbtorture harness. With torture:resume_key_support=no the entire smb2.ioctl.copy_chunk family self-skips; memfs is the backend the COPYCHUNK conformance path is verified against, so it now runs the family (the 19 enabled cells pass) while the other backends keep self-skipping until their copy_range coverage is validated.