### PR TITLE
pjdfstest: green nfs3_memfs & nfs4_memfs and register them in CI

### DIFF
--- a/src/posix/tests/CMakeLists.txt
+++ b/src/posix/tests/CMakeLists.txt
@@ -1150,6 +1150,23 @@ macro(add_pjd_test path backend)
     endif()
 endmacro()
 
+# As add_pjd_test, but for NFS backends (nfs3_memfs / nfs4_memfs): each test
+# starts a Chimera NFS server + client in-process, so it needs a longer timeout
+# than the in-process VFS backends.
+macro(add_pjd_nfs_test path backend)
+    if(CHIMERA_NETNS_TESTING)
+        string(REPLACE "/" "_" _pjd_flat ${path})
+        add_test(NAME chimera/posix/pjd/${path}/${backend}
+            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_pjd_${_pjd_flat} -b ${backend})
+        get_target_property(_pjd_tf posix_pjd_${_pjd_flat} TEST_FILE)
+        set_tests_properties(chimera/posix/pjd/${path}/${backend} PROPERTIES
+            ENVIRONMENT "TEST_FILE=${_pjd_tf}"
+            SKIP_RETURN_CODE 77
+            TIMEOUT 120)
+        list(APPEND _pjd_test_names chimera/posix/pjd/${path}/${backend})
+    endif()
+endmacro()
+
 # Backends the pjd suite is green on are registered here.  memfs and cairn pass
 # 134/134; diskfs/passthrough/NFS are widened by follow-up PRs as they green.
 set(_pjd_test_names "")
@@ -1169,6 +1186,9 @@ foreach(t ${PJD_TESTS})
     if(CHIMERA_VFS_IO_URING)
         add_pjd_test(${t} io_uring)
     endif()
+    # NFS backends (Chimera NFS server + client over loopback, memfs export).
+    add_pjd_nfs_test(${t} nfs3_memfs)
+    add_pjd_nfs_test(${t} nfs4_memfs)
 endforeach()
 
 # Tag the non-pjd tests with the 'posix' label so that suite can be run

--- a/src/posix/tests/pjd/unlink/14.c
+++ b/src/posix/tests/pjd/unlink/14.c
@@ -22,7 +22,12 @@ main(
     EXPECT(0, pjd_mkdir(n2, 0755));
     pjd_cd(n2);
 
-    /* nlink of an open-but-unlinked file is 0. */
+    /* nlink of an open-but-unlinked file is 0.
+     *
+     * On NFSv3 the client silly-renames the still-open file to .nfsXXXX rather
+     * than removing it (there is no server-side open-file state), so its link
+     * count stays 1 until close -- the correct NFSv3 behavior, not a local
+     * unlink.  Skip the nlink==0 assertion there but still exercise the path. */
     EXPECT(0, pjd_create(n0, 0644));
     {
         int         fd = pjd_open(n0, O_RDONLY, 0644);
@@ -30,7 +35,9 @@ main(
         EXPECT(0, pjd_unlink(n0));
         struct stat stbuf;
         EXPECT(0, chimera_posix_fstat(fd, &stbuf));
-        EXPECT_EQ(0, (long) stbuf.st_nlink);
+        if (!pjd_backend_is_nfs3()) {
+            EXPECT_EQ(0, (long) stbuf.st_nlink);
+        }
         chimera_posix_close(fd);
     }
 
@@ -49,6 +56,23 @@ main(
     }
 
     pjd_cd("..");
-    EXPECT(0, pjd_rmdir(n2));
+
+    /* On NFSv3 the close above triggers removal of the silly-renamed .nfsXXXX
+     * entry, but the client dispatches it asynchronously (close(2) does not
+     * block on it here), so the directory may not be empty the instant rmdir
+     * runs.  Poll briefly until the silly entry drains.  Local backends remove
+     * the file synchronously and succeed on the first attempt. */
+    if (pjd_backend_is_nfs3()) {
+        int rc = -1;
+        for (int i = 0; i < 100 && rc != 0; i++) {
+            rc = pjd_rmdir(n2);
+            if (rc != 0) {
+                pjd_settle();
+            }
+        }
+        EXPECT_EQ(0, rc);
+    } else {
+        EXPECT(0, pjd_rmdir(n2));
+    }
     return pjd_end();
 } /* main */

--- a/src/posix/tests/pjd_common.h
+++ b/src/posix/tests/pjd_common.h
@@ -780,6 +780,18 @@ pjd_settle(void)
     nanosleep(&ts, NULL);
 } /* pjd_settle */
 
+/* True when running against an NFSv3 backend (nfs3_*).  NFSv3 has no
+ * server-side open-file state, so the client emulates open-unlink with
+ * silly-rename (.nfsXXXX): an open-but-unlinked file keeps link count 1 and
+ * lingers in its directory until close.  Tests that assert local-filesystem
+ * open-unlink semantics (nlink drops to 0 immediately) use this to relax those
+ * specific checks, since silly-rename is the correct NFSv3 behavior. */
+static inline int
+pjd_backend_is_nfs3(void)
+{
+    return pjd_env.backend && strncmp(pjd_env.backend, "nfs3", 4) == 0;
+} /* pjd_backend_is_nfs3 */
+
 /* atime/mtime seconds via lstat (no-follow); -1 on error. */
 static inline long
 pjd_lstat_atime(const char *name)

--- a/src/vfs/nfs/nfs4_open_at.c
+++ b/src/vfs/nfs/nfs4_open_at.c
@@ -28,6 +28,10 @@ chimera_nfs4_open_at_callback(
     struct nfs_resop4               *getattr_res;
     xdr_opaque                      *remote_fh;
     struct chimera_nfs4_open_state  *state;
+    int                              path_open;
+
+    path_open = (request->open_at.flags & CHIMERA_VFS_OPEN_PATH) &&
+        !(request->open_at.flags & CHIMERA_VFS_OPEN_CREATE);
 
     if (unlikely(status)) {
         request->status = CHIMERA_VFS_EFAULT;
@@ -70,14 +74,20 @@ chimera_nfs4_open_at_callback(
         return;
     }
 
-    /* Check OPEN result */
+    /* Check OPEN / LOOKUP result */
     if (res->num_resarray < 3) {
         request->status = CHIMERA_VFS_EIO;
         request->complete(request);
         return;
     }
     open_res = &res->resarray[2];
-    if (open_res->opopen.status != NFS4_OK) {
+    if (path_open) {
+        if (open_res->oplookup.status != NFS4_OK) {
+            request->status = chimera_nfs4_status_to_errno(open_res->oplookup.status);
+            request->complete(request);
+            return;
+        }
+    } else if (open_res->opopen.status != NFS4_OK) {
         request->status = chimera_nfs4_status_to_errno(open_res->opopen.status);
         request->complete(request);
         return;
@@ -110,9 +120,10 @@ chimera_nfs4_open_at_callback(
         }
     }
 
-    /* Allocate and store open state with stateid
-     * Skip for inferred opens (use synthetic handles which don't call close). */
-    if (!(request->open_at.flags & CHIMERA_VFS_OPEN_INFERRED)) {
+    /* Allocate and store open state with stateid.  Skip for inferred opens
+     * (synthetic handles which don't call close) and for path opens (resolved
+     * via LOOKUP, so there is no OPEN stateid). */
+    if (!(request->open_at.flags & CHIMERA_VFS_OPEN_INFERRED) && !path_open) {
         state = chimera_nfs4_open_state_alloc();
 
         if (!state) {
@@ -153,8 +164,16 @@ chimera_nfs4_open_at(
     int                                      fhlen;
     struct chimera_nfs4_open_at_ctx         *ctx;
     struct OPEN4args                        *open_args;
+    int                                      path_open;
 
     ctx = request->plugin_data;
+
+    /* A metadata/path open (OPEN_PATH without O_CREAT) must not issue OP_OPEN:
+     * NFSv4 OPEN only works on regular files (EISDIR on a directory, EINVAL on
+     * a fifo/socket/device), but a path handle is needed for setattr/utimensat
+     * on any file type.  Resolve the leaf with OP_LOOKUP instead. */
+    path_open = (request->open_at.flags & CHIMERA_VFS_OPEN_PATH) &&
+        !(request->open_at.flags & CHIMERA_VFS_OPEN_CREATE);
 
     if (!server_thread) {
         request->status = CHIMERA_VFS_ESTALE;
@@ -190,6 +209,14 @@ chimera_nfs4_open_at(
     argarray[1].argop               = OP_PUTFH;
     argarray[1].opputfh.object.data = fh;
     argarray[1].opputfh.object.len  = fhlen;
+
+    /* Op 2: LOOKUP for a path open, OPEN otherwise. */
+    if (path_open) {
+        argarray[2].argop                 = OP_LOOKUP;
+        argarray[2].oplookup.objname.data = (void *) request->open_at.name;
+        argarray[2].oplookup.objname.len  = request->open_at.namelen;
+        goto emit_getfh;
+    }
 
     /* Op 2: OPEN - open/create the file */
     argarray[2].argop = OP_OPEN;
@@ -250,7 +277,9 @@ chimera_nfs4_open_at(
     open_args->claim.file.data = (void *) request->open_at.name;
     open_args->claim.file.len  = request->open_at.namelen;
 
-    /* Op 3: GETFH - get file handle for opened file */
+ emit_getfh:
+
+    /* Op 3: GETFH - get file handle for the opened/looked-up object */
     argarray[3].argop = OP_GETFH;
 
     /* Op 4: GETATTR - get attributes for opened file */


### PR DESCRIPTION
Brings both NFS backends to **134/134** on the pjdfstest suite and registers them in the `pjdfstest` CTest shard — the suite now runs **8 backends × 134 = 1072 tests** (was 6 × 134).

## nfs4_memfs (utimensat/00, /06, /07)
A path/metadata open (`CHIMERA_VFS_OPEN_PATH`, no `O_CREAT`) was issuing `OP_OPEN`, which only succeeds on regular files. So:
- utimensat on a **directory** → `EISDIR`, on a **fifo/socket/device** → `EINVAL` (utimensat/00);
- a non-owner path-open of a regular file was rejected at OPEN time with `EACCES` before the SETATTR-times permission gate could run (utimensat/06, /07).

`chimera_nfs4_open_at` now resolves a path open with `OP_LOOKUP` instead of `OP_OPEN` (no stateid), mirroring `chimera_nfs4_open_fh`. Real/creating opens still use `OP_OPEN`, so the `O_NOFOLLOW`→`ELOOP` behavior is unchanged. One change fixes all three.

## nfs3_memfs (unlink/14)
An open-but-unlinked file is silly-renamed to `.nfsXXXX` over NFSv3 (no server-side open state), so its link count stays 1 until close and the entry lingers — correct NFSv3 behavior, not a local unlink. The test now relaxes the `nlink==0` assertion on nfs3 backends and polls the final `rmdir` while the asynchronous close-time silly-remove drains. Added `pjd_backend_is_nfs3()` to the harness for this.

## Verification
- Full `pjdfstest` shard: **1072/1072** across all 8 backends.
- Regular posix-over-nfs4 suite: **83/83** (no regression from the client OPEN-path change).
- scan-build, reuse-lint, uncrustify: clean.