### PR TITLE
nfs4/vfs: don't deny a client a lock on its own delegated file

### DIFF
--- a/src/vfs/tests/vfs_state_test.c
+++ b/src/vfs/tests/vfs_state_test.c
@@ -614,6 +614,75 @@ test_range_breaks_caching(void)
     chimera_vfs_state_destroy(state);
 } /* test_range_breaks_caching */
 
+/* Test 11b: an NFSv4 client that holds a caching (delegation) lease may take a
+ * byte-range lock on the same file under a DIFFERENT lock-owner without
+ * conflicting with -- or recalling -- its own delegation (RFC 8881 §10.2: a
+ * delegation is per-client).  A range lock from a DIFFERENT NFSv4 client must
+ * still break the delegation. ------------------------------------------------ */
+static void
+test_nfs4_lock_vs_own_delegation(void)
+{
+    struct chimera_vfs_state      *state;
+    struct chimera_vfs_file_state *file;
+    struct chimera_vfs_lease       deleg, self_lock, other_lock;
+    enum chimera_vfs_lease_result  r;
+    struct chimera_vfs_lease      *conflict;
+    struct break_recorder          rec = { 0 };
+
+    fprintf(stderr, "\ntest_nfs4_lock_vs_own_delegation\n");
+
+    state = chimera_vfs_state_init();
+    file  = get_file(state, 1);
+
+    /* Client 0xA holds a WRITE delegation (caching W-lease).  A delegation is
+    * keyed by the file-handle hash, so its owner_lo differs from any lock. */
+    memset(&deleg, 0, sizeof(deleg));
+    deleg.kind         = CHIMERA_VFS_LEASE_CACHING;
+    deleg.mode.granted = CHIMERA_VFS_LEASE_MODE_W;
+    init_owner(&deleg.owner, CHIMERA_VFS_LEASE_PROTO_NFSV4, 0xA, 0xF11E);
+    deleg.owner.break_cb   = recording_break_cb;
+    deleg.owner.cb_private = &rec;
+
+    r = chimera_vfs_state_try_insert(state, file, &deleg, &conflict);
+    CHECK(r == CHIMERA_VFS_LEASE_GRANTED, "write delegation granted");
+
+    /* The SAME client takes a write byte-range lock under a different
+     * lock-owner -- granted outright, and the delegation is NOT recalled. */
+    memset(&self_lock, 0, sizeof(self_lock));
+    self_lock.kind         = CHIMERA_VFS_LEASE_RANGE;
+    self_lock.mode.granted = CHIMERA_VFS_LEASE_MODE_W;
+    self_lock.offset       = 0;
+    self_lock.length       = 100;
+    init_owner(&self_lock.owner, CHIMERA_VFS_LEASE_PROTO_NFSV4, 0xA, 0x10C0);
+
+    r = chimera_vfs_state_try_insert(state, file, &self_lock, &conflict);
+    CHECK(r == CHIMERA_VFS_LEASE_GRANTED,
+          "same-client lock on own delegated file granted");
+    CHECK(rec.fired == 0, "own delegation not recalled by the client's lock");
+
+    /* Drop the client's own range lock so the next probe is evaluated purely
+     * against the delegation (otherwise range-vs-range would deny it first). */
+    chimera_vfs_state_remove(state, file, &self_lock);
+
+    /* A DIFFERENT client's lock still breaks the delegation. */
+    memset(&other_lock, 0, sizeof(other_lock));
+    other_lock.kind         = CHIMERA_VFS_LEASE_RANGE;
+    other_lock.mode.granted = CHIMERA_VFS_LEASE_MODE_W;
+    other_lock.offset       = 0;
+    other_lock.length       = 100;
+    init_owner(&other_lock.owner, CHIMERA_VFS_LEASE_PROTO_NFSV4, 0xB, 0x20C0);
+
+    r = chimera_vfs_state_try_insert(state, file, &other_lock, &conflict);
+    CHECK(r == CHIMERA_VFS_LEASE_BREAKING,
+          "other-client lock breaks the delegation");
+    CHECK(rec.fired == 1, "delegation recalled for the other client");
+    CHECK(conflict == &deleg, "conflict reports the delegation holder");
+
+    chimera_vfs_state_remove(state, file, &deleg);
+    chimera_vfs_state_put(state, file);
+    chimera_vfs_state_destroy(state);
+} /* test_nfs4_lock_vs_own_delegation */
+
 /* Acquire-callback recorder for the async-API tests. */
 struct acquire_recorder {
     int                       fired;
@@ -993,6 +1062,7 @@ main(
     test_smb_lease_key_coalesces();
     test_caching_break_revoke();
     test_range_breaks_caching();
+    test_nfs4_lock_vs_own_delegation();
     test_async_acquire_immediate();
     test_async_acquire_wait_then_ack();
     test_async_acquire_cancel();

--- a/src/vfs/vfs_state.c
+++ b/src/vfs/vfs_state.c
@@ -702,6 +702,22 @@ chimera_vfs_state_would_conflict(
              * cache).  This is the "I/O breaks caching" rule applied
              * conservatively to range locks too. */
             for (cur = file->caching_leases; cur; cur = cur->next) {
+                /* NFSv4: a delegation is granted per-client (RFC 8881 §10.2),
+                 * so a byte-range lock the client takes on its own delegated
+                 * file -- under any lock-owner, read or write delegation -- does
+                 * not conflict with that delegation and must NOT recall it.  The
+                 * owner_equal / cb_private checks below miss this because a
+                 * delegation lease is keyed by the file-handle hash while a lock
+                 * lease is keyed by its lock-owner, so match on the client
+                 * directly.  (The SMB "read cache breaks on any range lock" rule
+                 * does not apply to NFSv4 delegations, so it is intentionally not
+                 * consulted here.)  Cross-client locks still fall through and
+                 * recall the holder's delegation below. */
+                if (cur->owner.protocol == CHIMERA_VFS_LEASE_PROTO_NFSV4 &&
+                    probe->owner.protocol == CHIMERA_VFS_LEASE_PROTO_NFSV4 &&
+                    cur->owner.client_key == probe->owner.client_key) {
+                    continue;
+                }
                 /* A byte-range lock and a caching lease held by the SAME open
                  * normally do not break each other (owner_equal, or -- for a
                  * lease keyed by its lease key rather than the file id -- the


### PR DESCRIPTION
## Summary

Fixes a real NFSv4 server bug found while investigating `nfstest_delegation`: a client that holds a delegation was **denied a byte-range lock on its own delegated file** (`NFS4ERR_DENIED`).

A delegation is granted per-client (RFC 8881 §10.2) — the client owns the file's cache and may lock it freely; its own lock must neither be denied nor recall the delegation. The lease conflict matrix self-exempts a range lock from a caching lease only when they share an owner (`protocol+client_key+owner_lo+owner_hi`) or a `cb_private` back-pointer. Neither matched here: a delegation lease is keyed by the file-handle hash while a lock lease is keyed by its lock-owner, even though both belong to the same client. This adds a same-NFSv4-client exemption in the RANGE-vs-CACHING conflict path. Cross-client locks still recall the holder's delegation (verified by the unit test).

Covered by a new `vfs_state` unit test (`test_nfs4_lock_vs_own_delegation`); all existing vfs/nfs/smb unit tests still pass. The change is NFSv4-protocol-gated, so SMB oplock/lease paths are untouched.

## On the rest of nfstest_delegation

This fix reduced `nfstest_delegation` from 91 → 78 failures (memfs, NFSv4.1). I did **not** enable the suite, because the remaining failures are not server bugs we can fix in the current harness:

- **Cross-client (~46+):** `CB_RECALL ... from a second client`, conflicting OPEN/RENAME/REMOVE/SETATTR — these need a **second NFS client host** the single-guest KVM harness doesn't have.
- **Client behaviour (~30):** this Ubuntu 24.04 kernel sends server-side `LOCK`s and returns the delegation (`DELEGRETURN`) under a write delegation rather than locking locally — so `LOCK should not be sent when holding a WRITE delegation`, `WRITE delegation should not be recalled after locking`, and `DELEGRETURN should be sent after the close` fail regardless of server behaviour. (The wire trace shows 814 LOCKs + 394 DELEGRETURNs but only ~6 CB_RECALLs.)

Enabling the suite would need a 2-client harness (which would also unlock `nfstest_cache`); that's a separate, larger piece of work. This PR lands the one genuine server-side correctness fix the investigation surfaced.
