### PR TITLE
posix: utimensat follows final symlink by default; enable utimensat/05

### DIFF
--- a/src/posix/posix_utimensat.c
+++ b/src/posix/posix_utimensat.c
@@ -128,24 +128,29 @@ chimera_posix_futimens(
 
 /* ---- utimensat(dirfd, path, times, flags) ---- */
 
+/*
+ * utimensat resolves `pathname` (relative to `dirfd`, or absolute) via the
+ * generic path-walker chimera_vfs_lookup, which follows symlinks in
+ * intermediate components and (when CHIMERA_VFS_LOOKUP_FOLLOW is set) the final
+ * component as well, using each backend's readlink primitive.  This gives
+ * consistent symlink-follow semantics across every VFS backend (memfs, cairn,
+ * diskfs and the NFS3/NFS4 clients).  AT_SYMLINK_NOFOLLOW drops the FOLLOW flag
+ * so the times are applied to the symlink itself.
+ *
+ * Once the target file handle is known we open it (O_PATH) and apply the
+ * setattr, mirroring the lookup -> open_fh -> setattr chain in
+ * client_setattr.h.
+ */
 struct chimera_posix_utimensat_ctx {
     struct chimera_posix_completion comp;
     struct chimera_vfs_open_handle *file_handle;
     struct chimera_vfs_attrs        set_attr;
-    struct chimera_vfs_attrs        open_attr;   /* scratch for open_at; must
-                                                  * outlive the async open */
+    uint32_t                        lookup_flags;   /* CHIMERA_VFS_LOOKUP_FOLLOW or 0 */
+    int                             start_fh_len;
+    uint8_t                         start_fh[CHIMERA_VFS_FH_SIZE + 16];
+    char                            path[CHIMERA_VFS_PATH_MAX];
+    int                             path_len;
 };
-
-static void
-chimera_posix_utimensat_callback(
-    struct chimera_client_thread *thread,
-    enum chimera_vfs_error        status,
-    void                         *private_data)
-{
-    struct chimera_posix_completion *comp = private_data;
-
-    chimera_posix_complete(comp, status);
-} /* chimera_posix_utimensat_callback */
 
 static void
 chimera_posix_utimensat_setattr_complete(
@@ -165,10 +170,6 @@ static void
 chimera_posix_utimensat_open_complete(
     enum chimera_vfs_error          error_code,
     struct chimera_vfs_open_handle *oh,
-    struct chimera_vfs_attrs       *set_attr,
-    struct chimera_vfs_attrs       *attr,
-    struct chimera_vfs_attrs       *dir_pre_attr,
-    struct chimera_vfs_attrs       *dir_post_attr,
     void                           *private_data)
 {
     struct chimera_posix_utimensat_ctx *ctx     = private_data;
@@ -193,39 +194,47 @@ chimera_posix_utimensat_open_complete(
 } /* chimera_posix_utimensat_open_complete */
 
 static void
-chimera_posix_utimensat_at_exec(
-    struct chimera_client_thread  *thread,
-    struct chimera_client_request *request)
+chimera_posix_utimensat_lookup_complete(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *attr,
+    void                     *private_data)
 {
-    struct chimera_posix_utimensat_ctx *ctx = request->setattr.private_data;
-    unsigned int                        open_flags;
+    struct chimera_posix_utimensat_ctx *ctx     = private_data;
+    struct chimera_client_request      *request = ctx->comp.request;
 
-    ctx->open_attr.va_req_mask = 0;
-    ctx->open_attr.va_set_mask = 0;
+    if (error_code != CHIMERA_VFS_OK) {
+        chimera_posix_complete(&ctx->comp, error_code);
+        return;
+    }
 
-    open_flags = CHIMERA_VFS_OPEN_PATH | CHIMERA_VFS_OPEN_INFERRED;
-
-    chimera_vfs_open_at(
-        thread->vfs_thread,
+    chimera_vfs_open_fh(
+        request->thread->vfs_thread,
         chimera_client_req_cred(request),
-        request->setattr.parent_handle,
-        request->setattr.path,
-        request->setattr.path_len,
-        open_flags,
-        &ctx->open_attr,
-        CHIMERA_VFS_ATTR_FH,
-        0,
-        0,
+        attr->va_fh,
+        attr->va_fh_len,
+        CHIMERA_VFS_OPEN_PATH | CHIMERA_VFS_OPEN_INFERRED,
         chimera_posix_utimensat_open_complete,
         ctx);
-} /* chimera_posix_utimensat_at_exec */
+} /* chimera_posix_utimensat_lookup_complete */
 
 static void
 chimera_posix_utimensat_exec(
     struct chimera_client_thread  *thread,
     struct chimera_client_request *request)
 {
-    chimera_dispatch_setattr(thread, request);
+    struct chimera_posix_utimensat_ctx *ctx = request->setattr.private_data;
+
+    chimera_vfs_lookup(
+        thread->vfs_thread,
+        chimera_client_req_cred(request),
+        ctx->start_fh,
+        ctx->start_fh_len,
+        ctx->path,
+        ctx->path_len,
+        CHIMERA_VFS_ATTR_FH,
+        ctx->lookup_flags,
+        chimera_posix_utimensat_lookup_complete,
+        ctx);
 } /* chimera_posix_utimensat_exec */
 
 SYMBOL_EXPORT int
@@ -240,48 +249,23 @@ chimera_posix_utimensat(
     struct chimera_client_request      req;
     struct chimera_posix_utimensat_ctx ctx;
     struct chimera_posix_fd_entry     *dir_entry = NULL;
-    int                                path_len;
-    const char                        *slash;
     int                                err;
-
-    /* AT_SYMLINK_NOFOLLOW on the final component is not yet distinguished from
-     * follow in the open path; non-symlink targets (the common case) behave
-     * identically. */
-    (void) flags;
 
     chimera_posix_completion_init(&ctx.comp, &req);
 
-    if (dirfd == AT_FDCWD) {
-        if (pathname[0] == '/') {
-            path_len = strlen(pathname);
-            memcpy(req.setattr.path, pathname, path_len);
-        } else {
-            req.setattr.path[0] = '/';
-            path_len            = strlen(pathname);
-            memcpy(req.setattr.path + 1, pathname, path_len);
-            path_len++;
-        }
+    ctx.file_handle = NULL;
 
-        req.setattr.path[path_len] = '\0';
-        slash                      = rindex(req.setattr.path, '/');
+    /* By default follow a final symlink and set times on its target; with
+     * AT_SYMLINK_NOFOLLOW operate on the symlink itself. */
+    ctx.lookup_flags = (flags & AT_SYMLINK_NOFOLLOW) ? 0 : CHIMERA_VFS_LOOKUP_FOLLOW;
 
-        req.setattr.parent_handle = NULL;
-        req.setattr.path_len      = path_len;
-        req.setattr.parent_len    = slash ? slash - req.setattr.path : path_len;
+    if (dirfd == AT_FDCWD || pathname[0] == '/') {
+        /* Resolve relative to the namespace root.  chimera_vfs_lookup strips
+         * leading slashes, so an absolute path works as-is. */
+        struct chimera_client *client = worker->client_thread->client;
 
-        while (slash && *slash == '/') {
-            slash++;
-        }
-
-        req.setattr.name_offset = slash ? slash - req.setattr.path : -1;
-
-        req.opcode               = CHIMERA_CLIENT_OP_SETATTR;
-        req.setattr.callback     = chimera_posix_utimensat_callback;
-        req.setattr.private_data = &ctx.comp;
-
-        chimera_posix_fill_utimes(&req.setattr.set_attr, times);
-
-        chimera_posix_worker_enqueue(worker, &req, chimera_posix_utimensat_exec);
+        memcpy(ctx.start_fh, client->root_fh, client->root_fh_len);
+        ctx.start_fh_len = client->root_fh_len;
     } else {
         dir_entry = chimera_posix_fd_acquire(posix, dirfd, 0);
         if (!dir_entry) {
@@ -290,22 +274,29 @@ chimera_posix_utimensat(
             return -1;
         }
 
-        path_len = strlen(pathname);
-        memcpy(req.setattr.path, pathname, path_len);
-
-        req.setattr.parent_handle = dir_entry->handle;
-        req.setattr.path_len      = path_len;
-        req.setattr.parent_len    = 0;
-        req.setattr.name_offset   = 0;
-
-        req.opcode               = CHIMERA_CLIENT_OP_SETATTR;
-        req.setattr.callback     = chimera_posix_utimensat_callback;
-        req.setattr.private_data = &ctx;
-
-        chimera_posix_fill_utimes(&ctx.set_attr, times);
-
-        chimera_posix_worker_enqueue(worker, &req, chimera_posix_utimensat_at_exec);
+        memcpy(ctx.start_fh, dir_entry->handle->fh, dir_entry->handle->fh_len);
+        ctx.start_fh_len = dir_entry->handle->fh_len;
     }
+
+    ctx.path_len = strlen(pathname);
+    if (ctx.path_len >= CHIMERA_VFS_PATH_MAX) {
+        if (dir_entry) {
+            chimera_posix_fd_release(dir_entry, 0);
+        }
+        errno = ENAMETOOLONG;
+        chimera_posix_completion_destroy(&ctx.comp);
+        return -1;
+    }
+    memcpy(ctx.path, pathname, ctx.path_len);
+    ctx.path[ctx.path_len] = '\0';
+
+    chimera_posix_fill_utimes(&ctx.set_attr, times);
+
+    req.opcode               = CHIMERA_CLIENT_OP_SETATTR;
+    req.setattr.callback     = NULL;
+    req.setattr.private_data = &ctx;
+
+    chimera_posix_worker_enqueue(worker, &req, chimera_posix_utimensat_exec);
 
     err = chimera_posix_wait(&ctx.comp);
 

--- a/src/posix/tests/CMakeLists.txt
+++ b/src/posix/tests/CMakeLists.txt
@@ -1121,6 +1121,7 @@ set(PJD_TESTS
     utimensat/01
     utimensat/02
     utimensat/04
+    utimensat/05
     utimensat/08
     utimensat/06
     utimensat/07

--- a/src/posix/tests/pjd/utimensat/05.c
+++ b/src/posix/tests/pjd/utimensat/05.c
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
+
+/* Ported from pjdfstest tests/utimensat/05.t: utimensat follows a final symlink
+ * by default (setting times on the target) and operates on the symlink itself
+ * when AT_SYMLINK_NOFOLLOW is given. */
+#include "../../pjd_common.h"
+#include <sys/stat.h>
+#include <fcntl.h>
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char        *n0 = pjd_namegen(), *n1 = pjd_namegen(), *n2 = pjd_namegen();
+    const time_t DATE1 = 1900000000, DATE2 = 1950000000;
+    const time_t DATE3 = 1960000000, DATE4 = 1970000000;
+    const time_t DATE5 = 1980000000, DATE6 = 1990000000;
+
+    EXPECT(0, pjd_mkdir(n1, 0755));
+    pjd_cd(n1);
+
+    EXPECT(0, pjd_create(n0, 0644));
+    EXPECT(0, pjd_symlink(n0, n2));
+
+    /* Follow disabled by AT_SYMLINK_NOFOLLOW: times applied to the link n2;
+     * the plain (follow) call on the regular file n0 applies to n0 itself. */
+    EXPECT(0, pjd_utimensat(n0, DATE1, 0, DATE2, 0, 0));
+    EXPECT(0, pjd_utimensat(n2, DATE3, 0, DATE4, 0, AT_SYMLINK_NOFOLLOW));
+    EXPECT_EQ(DATE1, pjd_lstat_atime(n0));
+    EXPECT_EQ(DATE2, pjd_lstat_mtime_sec(n0));
+    EXPECT_EQ(DATE3, pjd_lstat_atime(n2));
+    EXPECT_EQ(DATE4, pjd_lstat_mtime_sec(n2));
+
+    /* Default (no flags): follow the symlink n2 and set times on its target n0. */
+    EXPECT(0, pjd_utimensat(n2, DATE5, 0, DATE6, 0, 0));
+    EXPECT_EQ(DATE5, pjd_lstat_atime(n0));
+    EXPECT_EQ(DATE6, pjd_lstat_mtime_sec(n0));
+    /* n2 (the link) must not have been touched by the follow call: its atime
+     * must not be DATE5, and its mtime must still be DATE4. */
+    PJD_CHECK(DATE5 != pjd_lstat_atime(n2), "link atime not set to DATE5");
+    EXPECT_EQ(DATE4, pjd_lstat_mtime_sec(n2));
+
+    EXPECT(0, pjd_unlink(n0));
+    EXPECT(0, pjd_unlink(n2));
+
+    pjd_cd("..");
+    EXPECT(0, pjd_rmdir(n1));
+    return pjd_end();
+} /* main */


### PR DESCRIPTION
`utimensat` resolved its target via an `open_at` that did not follow a final symlink (and ignored `AT_SYMLINK_NOFOLLOW` entirely — the code had `(void) flags;`), so it always set times on the symlink itself rather than its target.

Fix: resolve the path through the generic `chimera_vfs_lookup` walker with `CHIMERA_VFS_LOOKUP_FOLLOW` (dropped when `AT_SYMLINK_NOFOLLOW` is set), then open the resolved handle (O_PATH) and apply the setattr. This gives consistent symlink-follow semantics across every backend (memfs/cairn/diskfs and the NFS3/NFS4 clients) and unifies the AT_FDCWD and dirfd code paths.

Ports utimensat/05 and registers it — **green on all 8 backends**. Re-ran the full utimensat group (00,01,02,04,05,06,07,08,09) on memfs/linux/io_uring/nfs3/nfs4: no regressions. scan-build/reuse/syntax clean.