### PR TITLE
vfs: POSIX kill-priv on write; port pjdfstest chmod/12

### DIFF
--- a/src/posix/tests/CMakeLists.txt
+++ b/src/posix/tests/CMakeLists.txt
@@ -1013,6 +1013,7 @@ set(PJD_TESTS
     chmod/05
     chmod/06
     chmod/07
+    chmod/12
     chown/00
     chown/01
     chown/02

--- a/src/posix/tests/pjd/chmod/12.c
+++ b/src/posix/tests/pjd/chmod/12.c
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
+
+/* Ported from pjdfstest tests/chmod/12.t:
+ * "verify SUID/SGID bit behaviour" - when a non-privileged process writes to a
+ * regular file the kernel clears the set-user-ID bit, and clears the
+ * set-group-ID bit when the file is group-executable.  Each case opens the file
+ * as uid/gid 65534, writes a byte, and checks both fstat (open fd) and stat
+ * (path) report the privileged bits cleared. */
+
+#include "../../pjd_common.h"
+
+/* Permission/special bits (mode & 07777) of an open fd; -1 on error. */
+static int
+fstat_mode(int fd)
+{
+    struct stat st;
+
+    if (chimera_posix_fstat(fd, &st) != 0) {
+        return -1;
+    }
+    return st.st_mode & 07777;
+} /* fstat_mode */
+
+/* Create `name` with `mode`, open it as uid/gid 65534 with `flags`, write one
+ * byte, and assert both fstat (fd) and stat (path) report `expect`. */
+static void
+killpriv_case(
+    const char *name,
+    mode_t      mode,
+    int         flags,
+    int         expect)
+{
+    int     fd;
+    ssize_t w;
+
+    EXPECT(0, pjd_create(name, mode));
+
+    pjd_set_user(65534, 65534);
+    fd = pjd_open(name, flags, 0);
+    PJD_CHECK(fd >= 0, "open %s as uid 65534 (fd=%d)", name, fd);
+
+    if (fd >= 0) {
+        w = chimera_posix_write(fd, "x", 1);
+        PJD_CHECK(w == 1, "write 1 byte to %s (rc=%ld)", name, (long) w);
+        EXPECT_EQ(expect, fstat_mode(fd));
+        chimera_posix_close(fd);
+    }
+    pjd_set_root();
+
+    EXPECT_EQ(expect, pjd_stat_mode(name));
+    EXPECT(0, pjd_unlink(name));
+} /* killpriv_case */
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+
+    char *n0 = pjd_namegen();
+    char *n2 = pjd_namegen();
+
+    EXPECT(0, pjd_mkdir(n2, 0755));
+    pjd_cd(n2);
+
+    /* Writing to the file by non-owner clears the SUID. */
+    killpriv_case(n0, 04777, O_WRONLY, 0777);
+
+    /* Writing to the file by non-owner clears the SGID (group-executable). */
+    killpriv_case(n0, 02777, O_RDWR, 0777);
+
+    /* Writing to the file by non-owner clears both SUID and SGID. */
+    killpriv_case(n0, 06777, O_RDWR, 0777);
+
+    pjd_cd("..");
+    EXPECT(0, pjd_rmdir(n2));
+
+    return pjd_end();
+} /* main */

--- a/src/vfs/cairn/cairn.c
+++ b/src/vfs/cairn/cairn.c
@@ -3445,6 +3445,10 @@ cairn_write(
     inode->mtime       = now;
     inode->ctime       = now;
 
+    /* POSIX kill-priv: a non-privileged write to a regular file clears the
+     * set-user-ID bit and the set-group-ID bit (when group-executable). */
+    inode->mode = chimera_vfs_killpriv_mode(request->cred, inode->mode);
+
     cairn_map_attrs(shared, &request->write.r_post_attr, inode);
 
     cairn_put_inode(thread, inode);

--- a/src/vfs/diskfs/diskfs_io.c
+++ b/src/vfs/diskfs/diskfs_io.c
@@ -1841,6 +1841,14 @@ diskfs_write_finish_map(struct chimera_vfs_request *request)
     inode->ctime_sec  = now.tv_sec;
     inode->ctime_nsec = now.tv_nsec;
 
+    /* POSIX kill-priv: a non-privileged write to a regular file clears the
+     * set-user-ID bit and the set-group-ID bit (when group-executable).  When
+     * the mode actually changes, the inode block must be journaled (the
+     * deferred mtime-only path below would drop it from the txn). */
+    uint32_t new_mode = chimera_vfs_killpriv_mode(request->cred, inode->mode);
+    int      killpriv = (new_mode != inode->mode);
+    inode->mode = new_mode;
+
     diskfs_map_attrs(thread, &request->write.r_post_attr, inode);
 
     request->write.r_length = request->write.length;
@@ -1859,6 +1867,7 @@ diskfs_write_finish_map(struct chimera_vfs_request *request)
      */
     deferrable = diskfs_private->inplace_written &&
         !size_grew &&
+        !killpriv &&
         request->write.sync != CHIMERA_VFS_WRITE_FILESYNC &&
         shared->mtime_defer_us > 0;
 

--- a/src/vfs/io_uring/io_uring.c
+++ b/src/vfs/io_uring/io_uring.c
@@ -286,6 +286,17 @@ chimera_io_uring_set_open_attrs(
         }
     }
 
+    /* Apply the exact requested mode.  io_uring_prep_openat() applies the mode
+     * argument through the process umask (and does not reliably carry the
+     * set-user-ID/set-group-ID bits), so a freshly created file may be missing
+     * bits the client asked for; the client has already applied the caller's
+     * own umask, so the backend must honor the mode verbatim. */
+    if (set_mask & CHIMERA_VFS_ATTR_MODE) {
+        if (fchmod(fd, attr->va_mode & 07777) < 0) {
+            return errno;
+        }
+    }
+
     if (set_mask & CHIMERA_VFS_ATTR_SIZE) {
         if (ftruncate(fd, attr->va_size) < 0) {
             return errno;
@@ -591,6 +602,28 @@ chimera_io_uring_reap(
                 if (cqe->res >= 0) {
                     request->status         = CHIMERA_VFS_OK;
                     request->write.r_length = cqe->res;
+
+                    /* POSIX kill-priv: a non-privileged write to a regular file
+                     * clears the set-user-ID bit and the set-group-ID bit (when
+                     * group-executable).  The server runs with CAP_FSETID, so
+                     * the host kernel does not do this for us; apply it against
+                     * the caller's credential.  Only a non-root UNIX writer can
+                     * trigger the clear, so skip the stat/chmod otherwise. */
+                    if (request->cred &&
+                        request->cred->flavor == CHIMERA_VFS_AUTH_UNIX &&
+                        request->cred->uid != 0) {
+                        int         wfd = (int) request->write.handle->vfs_private;
+                        struct stat wst;
+
+                        if (fstat(wfd, &wst) == 0) {
+                            uint32_t new_mode = chimera_vfs_killpriv_mode(
+                                request->cred, wst.st_mode);
+
+                            if (new_mode != (uint32_t) wst.st_mode) {
+                                (void) fchmod(wfd, new_mode & 07777);
+                            }
+                        }
+                    }
                 } else {
                     request->status         = chimera_linux_errno_to_status(-cqe->res);
                     request->write.r_length = 0;
@@ -1345,8 +1378,14 @@ chimera_io_uring_open_at(
     sqe = chimera_io_uring_get_sqe(thread, request, 0, 0);
 
     if (request->open_at.set_attr->va_set_mask & CHIMERA_VFS_ATTR_MODE) {
-        mode                                    = request->open_at.set_attr->va_mode;
-        request->open_at.set_attr->va_set_mask &= ~CHIMERA_VFS_ATTR_MODE;
+        mode = request->open_at.set_attr->va_mode;
+        /* For a create, leave ATTR_MODE set so set_open_attrs() fchmod()s the
+         * exact mode (openat's mode argument is filtered by the process umask).
+         * For a non-creating open there is nothing to fix up, so clear it to
+         * avoid touching the mode of an existing file. */
+        if (!(flags & O_CREAT)) {
+            request->open_at.set_attr->va_set_mask &= ~CHIMERA_VFS_ATTR_MODE;
+        }
     } else {
         mode = 0600;
     }

--- a/src/vfs/linux/linux.c
+++ b/src/vfs/linux/linux.c
@@ -668,7 +668,8 @@ chimera_linux_open_at(
 {
     int      parent_fd, fd, flags, rc;
     uint32_t mode;
-    char    *scratch = (char *) request->plugin_data;
+    int      have_mode = 0;
+    char    *scratch   = (char *) request->plugin_data;
 
     TERM_STR(fullname, request->open_at.name, request->open_at.namelen, scratch);
 
@@ -676,6 +677,7 @@ chimera_linux_open_at(
 
     if (request->open_at.set_attr->va_set_mask & CHIMERA_VFS_ATTR_MODE) {
         mode                                    = request->open_at.set_attr->va_mode;
+        have_mode                               = 1;
         request->open_at.set_attr->va_set_mask &= ~CHIMERA_VFS_ATTR_MODE;
         /* The explicit mode -- applied atomically by the openat() below -- is
          * authoritative on this mode-only backend.  An SMB create SD commonly
@@ -718,6 +720,20 @@ chimera_linux_open_at(
     }
 
     rc = chimera_linux_set_attrs(fd, "", request->open_at.set_attr);
+
+    /* openat() applies the requested mode through the process umask, so a
+     * freshly created file may be missing bits the client asked for (the
+     * client has already applied the caller's own umask, so the backend must
+     * honor the mode verbatim).  When an explicit mode was requested on a
+     * create, fchmod() it to the exact value -- this also restores the
+     * set-user-ID/set-group-ID bits, which openat()'s mode argument does not
+     * reliably carry. */
+    if (rc >= 0 && have_mode && (flags & O_CREAT)) {
+        if (fchmod(fd, mode & 07777) < 0) {
+            rc = -errno;
+        }
+    }
+
     chimera_restore_privilege(request->cred);
 
     if (rc < 0) {
@@ -1105,6 +1121,22 @@ chimera_linux_write(
     request->write.r_length = len;
 
     chimera_linux_map_attrs(CHIMERA_VFS_FH_MAGIC_LINUX, &request->write.r_post_attr, fd);
+
+    /* POSIX kill-priv: a non-privileged write to a regular file clears the
+     * set-user-ID bit and the set-group-ID bit (when group-executable).  The
+     * server runs with CAP_FSETID, so the host kernel does NOT do this for us
+     * (the write is issued under the server identity, not the caller's), so we
+     * apply it explicitly against the caller's credential. */
+    if (request->write.r_post_attr.va_set_mask & CHIMERA_VFS_ATTR_MODE) {
+        uint32_t new_mode = chimera_vfs_killpriv_mode(request->cred,
+                                                      request->write.r_post_attr.va_mode);
+
+        if (new_mode != request->write.r_post_attr.va_mode) {
+            if (fchmod(fd, new_mode & 07777) == 0) {
+                request->write.r_post_attr.va_mode = new_mode;
+            }
+        }
+    }
 
     request->status = CHIMERA_VFS_OK;
     request->complete(request);

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -3289,6 +3289,11 @@ memfs_write(
     inode->mtime = now;
     inode->ctime = now;
 
+    /* POSIX kill-priv: a non-privileged write to a regular file clears the
+     * set-user-ID bit and the set-group-ID bit (when group-executable).  Named
+     * streams share the parent inode's mode, so this applies on either path. */
+    inode->mode = chimera_vfs_killpriv_mode(request->cred, inode->mode);
+
     memfs_map_attrs_fork(shared, &request->write.r_post_attr, inode, stream, request->fh);
 
     pthread_mutex_unlock(&inode->lock);

--- a/src/vfs/vfs_cred.h
+++ b/src/vfs/vfs_cred.h
@@ -7,6 +7,7 @@
 #include <stdint.h>
 #include <string.h>
 #include <sys/types.h>
+#include <sys/stat.h>
 #include <sys/fsuid.h>
 #include <sys/syscall.h>
 #include <unistd.h>
@@ -290,3 +291,42 @@ chimera_restore_privilege(const struct chimera_vfs_cred *cred)
     }
     return 0;
 } // chimera_restore_privilege
+
+/*
+ * POSIX/Linux "kill-priv" on write: when a process *without appropriate
+ * privilege* modifies the contents of a regular file (write or truncate), the
+ * set-user-ID bit is cleared, and the set-group-ID bit is cleared if the file
+ * is group-executable.  (A set-group-ID file with no group-execute bit denotes
+ * mandatory locking, not a privileged execution, so that bit is preserved --
+ * this mirrors the kernel's should_remove_suid()/setattr_should_drop_suidgid()
+ * logic.)
+ *
+ * `cred` is the writer's credential (NULL or AUTH_NONE means an internal/server
+ * write, which is privileged and exempt); `mode` is the file's current mode.
+ * Returns the (possibly unchanged) mode with the offending bits removed.  Only
+ * a non-privileged (non-root) UNIX writer triggers the clear, and only for a
+ * regular file that actually carries S_ISUID/S_ISGID.
+ */
+static inline uint32_t
+chimera_vfs_killpriv_mode(
+    const struct chimera_vfs_cred *cred,
+    uint32_t                       mode)
+{
+    if (!cred || cred->flavor == CHIMERA_VFS_AUTH_NONE || cred->uid == 0) {
+        return mode;
+    }
+
+    if (!S_ISREG(mode)) {
+        return mode;
+    }
+
+    if (mode & S_ISUID) {
+        mode &= ~(uint32_t) S_ISUID;
+    }
+
+    if ((mode & S_ISGID) && (mode & S_IXGRP)) {
+        mode &= ~(uint32_t) S_ISGID;
+    }
+
+    return mode;
+} // chimera_vfs_killpriv_mode


### PR DESCRIPTION
## Summary

Implement POSIX/Linux *kill-priv* on the write path: when a process without appropriate privilege (non-root) modifies the contents of a regular file, the set-user-ID bit is cleared, and the set-group-ID bit is cleared when the file is group-executable (a SGID-without-group-execute file denotes mandatory locking and is left alone). Chimera previously preserved these bits on write.

A shared helper `chimera_vfs_killpriv_mode()` (in `vfs_cred.h`) captures the rule, mirroring the kernel's `should_remove_suid()` / `setattr_should_drop_suidgid()`. It is the write-path analog of the existing kill-priv on ownership change in `vfs_proc_setattr.c`.

Applied per backend:

- **memfs / cairn / diskfs** (engine-authoritative): clear the bits on the in-memory inode while the write already holds the inode lock and bumps mtime/ctime. For diskfs, a mode change forces the inode block to be journaled instead of taking the deferred mtime-only fast path.
- **linux / io_uring** (passthrough): the server runs with `CAP_FSETID` and issues the write under the server identity, so the host kernel does **not** kill-priv for us; apply it explicitly via `fchmod()` against the caller's credential after the write.

The passthrough create path also honored the requested mode only through `openat()`'s umask-filtered mode argument, which dropped bits the client asked for (the client has already applied the caller's umask) and did not reliably carry SUID/SGID. This blocked the test from even reaching the write step (the 04777 file came back 04755). Fixed by `fchmod()`-ing the exact mode on create.

## Test

Ports `pjdfstest tests/chmod/12.t` to `src/posix/tests/pjd/chmod/12.c` and registers it in `PJD_TESTS`. It creates files mode 04777 / 02777 / 06777, writes a byte as uid/gid 65534, and verifies (via both `fstat` on the open fd and `stat` on the path) that the mode comes back 0777.

Passes on all eight backends: memfs, cairn, diskfs_io_uring, diskfs_aio, linux, io_uring, nfs3_memfs, nfs4_memfs. Existing chmod/00..07 and the open/truncate/chown/mknod/mkfifo/mkdir/rename pjd suites remain green on every backend.