### PR TITLE
vfs: fix cross-directory directory rename ".." and parent link counts

### DIFF
--- a/src/posix/tests/CMakeLists.txt
+++ b/src/posix/tests/CMakeLists.txt
@@ -1117,6 +1117,7 @@ set(PJD_TESTS
     rename/19
     rename/20
     rename/22
+    rename/24
     utimensat/00
     utimensat/01
     utimensat/02

--- a/src/posix/tests/pjd/rename/24.c
+++ b/src/posix/tests/pjd/rename/24.c
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
+
+/* Ported from pjdfstest tests/rename/24.t: rename of a directory updates its
+ * ".." link and both parents' link counts. */
+#include "../../pjd_common.h"
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *sp = pjd_namegen(), *dp = pjd_namegen(), *src = pjd_namegen(), *dst = pjd_namegen();
+    char  sp_src[256], sp_src_dd[256], dp_dst[256], dp_dst_dd[256];
+
+    snprintf(sp_src, sizeof(sp_src), "%s/%s", sp, src);
+    snprintf(sp_src_dd, sizeof(sp_src_dd), "%s/%s/..", sp, src);
+    snprintf(dp_dst, sizeof(dp_dst), "%s/%s", dp, dst);
+    snprintf(dp_dst_dd, sizeof(dp_dst_dd), "%s/%s/..", dp, dst);
+
+    EXPECT(0, pjd_mkdir(sp, 0755));
+    EXPECT(0, pjd_mkdir(dp, 0755));
+    EXPECT(0, pjd_mkdir(sp_src, 0755));
+
+    /* Initial conditions: src_parent has 3 links (., its own .., src/..),
+     * dst_parent has 2 (., ..). */
+    EXPECT_EQ(3, pjd_stat_nlink(sp));
+    EXPECT_EQ(2, pjd_stat_nlink(dp));
+
+    /* src/.. resolves to src_parent. */
+    EXPECT_EQ(pjd_lstat_inode(sp), pjd_lstat_inode(sp_src_dd));
+
+    EXPECT(0, pjd_rename(sp_src, dp_dst));
+
+    /* After the move: src_parent loses a link, dst_parent gains one. */
+    EXPECT_EQ(2, pjd_stat_nlink(sp));
+    EXPECT_EQ(3, pjd_stat_nlink(dp));
+
+    /* dst/.. now resolves to dst_parent. */
+    EXPECT_EQ(pjd_lstat_inode(dp), pjd_lstat_inode(dp_dst_dd));
+
+    EXPECT(0, pjd_rmdir(dp_dst));
+    EXPECT(0, pjd_rmdir(dp));
+    EXPECT(0, pjd_rmdir(sp));
+    return pjd_end();
+} /* main */

--- a/src/vfs/diskfs/diskfs_namespace.c
+++ b/src/vfs/diskfs/diskfs_namespace.c
@@ -2508,9 +2508,14 @@ diskfs_rename_at_perform_final_cb(
 
     clock_gettime(CLOCK_REALTIME, &now);
 
-    if (S_ISDIR(child->mode)) {
+    if (S_ISDIR(child->mode) && np != op) {
+        /* Cross-directory move of a directory: shift the subdirectory backlink
+         * from the source parent to the destination parent, and re-home the
+         * moved directory's ".." (diskfs derives ".." from parent_inum). */
         op->nlink--;
         np->nlink++;
+        child->parent_inum = np->inum;
+        child->parent_gen  = np->gen;
     }
 
     op->mtime_sec  = now.tv_sec;

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -4628,9 +4628,15 @@ memfs_rename_at(
 
     rb_tree_remove(&old_parent_inode->dir.dirents, &old_dirent->node);
 
-    if (S_ISDIR(child_inode->mode)) {
+    if (S_ISDIR(child_inode->mode) && cmp != 0) {
+        /* Cross-directory move of a directory: the source parent loses its
+         * subdirectory backlink and the destination parent gains one.  Also
+         * re-home the moved directory's ".." so it resolves to its new parent
+         * (memfs derives ".." from these stored fields, not a real dirent). */
         old_parent_inode->nlink--;
         new_parent_inode->nlink++;
+        child_inode->dir.parent_inum = new_parent_inode->inum;
+        child_inode->dir.parent_gen  = new_parent_inode->gen;
     }
 
     old_parent_inode->mtime = now;

--- a/src/vfs/vfs_proc_rename_at.c
+++ b/src/vfs/vfs_proc_rename_at.c
@@ -7,6 +7,7 @@
 #include "vfs_state.h"
 #include "vfs_internal.h"
 #include "vfs_name_cache.h"
+#include "vfs_attr_cache.h"
 #include "vfs_notify.h"
 #include "vfs_access.h"
 #include "vfs_acl.h"
@@ -17,6 +18,7 @@ chimera_vfs_rename_at_complete(struct chimera_vfs_request *request)
 {
     struct chimera_vfs_thread       *thread     = request->thread;
     struct chimera_vfs_name_cache   *name_cache = thread->vfs->vfs_name_cache;
+    struct chimera_vfs_attr_cache   *attr_cache = thread->vfs->vfs_attr_cache;
     chimera_vfs_rename_at_callback_t callback   = request->proto_callback;
 
     if (request->status == CHIMERA_VFS_OK) {
@@ -93,6 +95,44 @@ chimera_vfs_rename_at_complete(struct chimera_vfs_request *request)
                                       request->rename_at.new_name_hash,
                                       request->rename_at.new_name,
                                       request->rename_at.new_namelen);
+
+        /* A rename mutates both parent directories' attributes (mtime/ctime,
+         * and on a cross-directory directory move their link counts).  Refresh
+         * the attr cache with the post-rename attributes the backend reported,
+         * or a subsequent getattr/stat would serve a stale nlink/timestamp.
+         * For a same-directory rename both FHs are identical and the second
+         * insert simply re-inserts the same fresh entry. */
+        chimera_vfs_attr_cache_insert(thread, attr_cache,
+                                      request->fh_hash,
+                                      request->fh,
+                                      request->fh_len,
+                                      &request->rename_at.r_fromdir_post_attr);
+
+        chimera_vfs_attr_cache_insert(thread, attr_cache,
+                                      request->rename_at.new_fh_hash,
+                                      request->rename_at.new_fh,
+                                      request->rename_at.new_fhlen,
+                                      &request->rename_at.r_todir_post_attr);
+
+        /* A cross-directory move of a directory re-homes its ".." entry to the
+         * new parent.  The name cache keys ".." under the moved directory's own
+         * FH (unchanged by the rename), so a ".." lookup cached before the move
+         * would still resolve to the old parent.  Drop that entry; the backend
+         * resolves ".." authoritatively from the moved directory on the next
+         * lookup.  source_fh is the moved object's FH resolved during the
+         * delegation-recall pre-step. */
+        if (cross_dir && request->rename_at.source_fh_len > 0) {
+            static const char dotdot[2] = { '.', '.' };
+
+            chimera_vfs_name_cache_remove(name_cache,
+                                          chimera_vfs_hash(request->rename_at.source_fh,
+                                                           request->rename_at.source_fh_len),
+                                          request->rename_at.source_fh,
+                                          request->rename_at.source_fh_len,
+                                          chimera_vfs_hash(dotdot, 2),
+                                          dotdot,
+                                          2);
+        }
     }
 
     chimera_vfs_complete(request);
@@ -202,11 +242,11 @@ chimera_vfs_rename_at_dispatch(
     request->rename_at.target_fh_len                   = target_fh_len;
     request->rename_at.r_fromdir_pre_attr.va_req_mask  = pre_attr_mask;
     request->rename_at.r_fromdir_pre_attr.va_set_mask  = 0;
-    request->rename_at.r_fromdir_post_attr.va_req_mask = post_attr_mask;
+    request->rename_at.r_fromdir_post_attr.va_req_mask = post_attr_mask | CHIMERA_VFS_ATTR_MASK_CACHEABLE;
     request->rename_at.r_fromdir_post_attr.va_set_mask = 0;
     request->rename_at.r_todir_pre_attr.va_req_mask    = pre_attr_mask;
     request->rename_at.r_todir_pre_attr.va_set_mask    = 0;
-    request->rename_at.r_todir_post_attr.va_req_mask   = post_attr_mask;
+    request->rename_at.r_todir_post_attr.va_req_mask   = post_attr_mask | CHIMERA_VFS_ATTR_MASK_CACHEABLE;
     request->rename_at.r_todir_post_attr.va_set_mask   = 0;
     request->proto_callback                            = callback;
     request->proto_private_data                        = private_data;


### PR DESCRIPTION
## Summary

Renaming a directory into a **different** parent must:
1. make the moved directory's `..` resolve to the new parent,
2. decrement the old parent's link count by 1,
3. increment the new parent's link count by 1.

Three distinct defects each broke one or more of these:

- **Backend `..` not re-homed.** `memfs` and `diskfs` synthesize `..` from a parent inum/gen stored on the directory inode (not a real dirent), but rename never updated those fields on a cross-directory move, so `..` kept resolving to the old parent. Now updated on a cross-dir directory move. (`cairn` already did this; `linux`/`io_uring` get it from the host kernel.)

- **Stale parent attrs in the VFS attr cache.** The VFS-core rename completion removed the renamed name's name-cache entries but never refreshed the two parent directories' attr-cache entries, so a subsequent `getattr`/`stat` served the pre-rename `nlink` (and timestamps). The dispatch now requests cacheable post-attrs for both parents and the completion inserts them, matching the existing `mkdir`/`remove` pattern.

- **Stale `..` in the name cache.** `..` is itself name-cached keyed under the moved directory's own FH, which is unchanged by the rename; a `..` lookup cached before the move kept resolving to the old parent. The completion now drops that entry on a cross-directory move (the backend then resolves `..` authoritatively on the next lookup).

## Test

Ports pjdfstest `rename/24.t` ("rename of a directory updates its `..` link") to the `chimera_posix` harness at `src/posix/tests/pjd/rename/24.c` and registers it for all backends. It asserts the initial parent nlinks (sp=3, dp=2), the pre/post `..` resolution, and the post-rename nlinks (sp=2, dp=3).

Passes on all 8 backends (memfs, cairn, diskfs_io_uring, diskfs_aio, linux, io_uring, nfs3_memfs, nfs4_memfs); the full `pjd/rename/*` suite (rename/00..24) is green across backends with no regressions.