### PR TITLE
vfs: pin conflicting caching grant across break + caller use (fixes #733 dirlease flake)

### DIFF
--- a/src/server/nfs/nfs4_proc_open.c
+++ b/src/server/nfs/nfs4_proc_open.c
@@ -81,6 +81,9 @@ chimera_nfs4_open_acquire_share(
 
     result = chimera_vfs_state_try_insert(vfs_state, file_state,
                                           &state->share_lease, &conflict);
+    /* This path does not dereference `conflict`; drop the pin try_insert may hold
+     * on it (no-op for a non-grant conflict). */
+    chimera_vfs_state_conflict_unref(vfs_state, conflict);
     if (result == CHIMERA_VFS_LEASE_BREAKING) {
         /* The conflict is a breakable holder -- an NFSv4 delegation being
          * recalled (try_insert already kicked the break).  Tell the client to
@@ -248,6 +251,9 @@ chimera_nfs4_open_grant_delegation(
 
     result = chimera_vfs_state_try_insert(vfs_state, file_state,
                                           &deleg->lease, &conflict);
+    /* This path does not dereference `conflict`; drop the pin try_insert may hold
+     * on it (no-op for a non-grant conflict). */
+    chimera_vfs_state_conflict_unref(vfs_state, conflict);
     if (result != CHIMERA_VFS_LEASE_GRANTED) {
         /* Contention (another open / lease): just decline to delegate. */
         chimera_vfs_state_put(vfs_state, file_state);

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -852,10 +852,19 @@ chimera_smb_create_gen_open_file(
                                                            conflict_pid);
                 break;
             }
+            /* Drop the pin try_insert holds on this conflict before re-probing:
+             * we are done dereferencing it, and the next try_insert returns a
+             * freshly-pinned conflict. */
+            chimera_vfs_state_conflict_unref(vfs_state, conflict);
             conflict = NULL;
             result   = chimera_vfs_state_try_insert(vfs_state, file_state,
                                                     &open_file->share_lease, &conflict);
         }
+
+        /* Release the pin on whatever conflict the purge loop ended on (the
+         * pointer is no longer dereferenced past this point). */
+        chimera_vfs_state_conflict_unref(vfs_state, conflict);
+        conflict = NULL;
 
         if (result == CHIMERA_VFS_LEASE_BREAKING &&
             request->create.gen_finish_cb) {
@@ -1202,9 +1211,15 @@ chimera_smb_create_after_share(
                             } else if (result != CHIMERA_VFS_LEASE_BREAKING) {
                                 break;
                             }
-                            result = chimera_vfs_state_try_insert(
+                            /* Drop the previous probe's conflict pin before the next
+                             * try_insert overwrites it (this path never derefs it). */
+                            chimera_vfs_state_conflict_unref(vfs_state, conflict);
+                            conflict = NULL;
+                            result   = chimera_vfs_state_try_insert(
                                 vfs_state, file_state, &grant->lease, &conflict);
                         }
+                        chimera_vfs_state_conflict_unref(vfs_state, conflict);
+                        conflict = NULL;
 
                         if (result == CHIMERA_VFS_LEASE_GRANTED) {
                             /* Link into the owner index so later same-key opens

--- a/src/vfs/vfs_state.c
+++ b/src/vfs/vfs_state.c
@@ -1206,6 +1206,19 @@ chimera_vfs_state_try_insert(
     * which may turn a conflict into a grant without the caller waiting. */
     for ( ; ;) {
         bool began_live_break = false;
+        /* When the conflict handed back in *conflict_out is a CACHING grant, we
+         * hold one reference on it across this whole call so it cannot be freed
+         * out from under (a) begin_break's break cb, which dereferences it after
+         * dropping file->lock, and (b) the synchronous caller, which inspects
+         * *conflict_out before its callback returns.  For a CACHING lease the
+         * lease is embedded in its grant, so a close of this holder racing on
+         * another thread would otherwise drop the grant's last reference and free
+         * it (this very `conflict`) mid-deref — the use-after-free that
+         * chimera_smb_lease_break_cb / the SMB create durable-purge loop hit under
+         * load.  The reference is dropped by the caller via
+         * chimera_vfs_state_conflict_unref (no-op for non-grant conflicts), and
+         * by us on the re-probe / revoke / GRANTED paths that supersede it. */
+        struct chimera_vfs_caching_grant *out_pin = NULL;
 
         conflict = NULL;
 
@@ -1220,6 +1233,14 @@ chimera_vfs_state_try_insert(
             }
             return CHIMERA_VFS_LEASE_GRANTED;
         }
+
+        /* Pin the conflict we are about to expose (in *conflict_out), under the
+         * same lock that frees it. */
+        if (conflict && conflict->kind == CHIMERA_VFS_LEASE_CACHING &&
+            conflict->grant) {
+            out_pin = conflict->grant;
+            out_pin->refcount++;
+        }
         pthread_mutex_unlock(&file->lock);
 
         if (conflict_out) {
@@ -1230,10 +1251,15 @@ chimera_vfs_state_try_insert(
             /* A hard conflict against a holder whose owning client has lapsed
              * (courtesy state) is reclaimable: revoke it and re-probe.  Its
              * lease lingers REVOKED until the protocol layer removes it, but
-             * would_conflict skips REVOKED leases, so this terminates. */
+             * would_conflict skips REVOKED leases, so this terminates.  (A DENIED
+             * conflict is a SHARE/RANGE lease — not a grant — so out_pin is NULL
+             * here; the assignment is defensive.) */
             if (conflict &&
                 chimera_vfs_lease_holder_reclaimable(conflict, lease)) {
                 chimera_vfs_lease_revoke(conflict);
+                if (out_pin) {
+                    chimera_vfs_caching_grant_release(state, out_pin, true);
+                }
                 continue;
             }
             return CHIMERA_VFS_LEASE_DENIED;
@@ -1250,6 +1276,20 @@ chimera_vfs_state_try_insert(
         bool revoked_any = false;
 
         while (conflict) {
+            /* Each re-probed conflict (every iteration after the first) is pinned
+             * for the duration of its begin_break cb, then dropped.  The FIRST
+             * conflict is the one in *conflict_out and is held by out_pin instead,
+             * so it survives for the returning caller. */
+            struct chimera_vfs_caching_grant *iter_pin = NULL;
+
+            if (conflict->kind == CHIMERA_VFS_LEASE_CACHING && conflict->grant &&
+                conflict->grant != out_pin) {
+                pthread_mutex_lock(&file->lock);
+                conflict->grant->refcount++;
+                iter_pin = conflict->grant;
+                pthread_mutex_unlock(&file->lock);
+            }
+
             if (chimera_vfs_lease_holder_reclaimable(conflict, lease)) {
                 chimera_vfs_lease_revoke(conflict);
                 revoked_any = true;
@@ -1272,6 +1312,7 @@ chimera_vfs_state_try_insert(
                     conflict->grant && conflict->grant->is_dir) {
                     floor = conflict->mode.granted & ~CHIMERA_VFS_LEASE_MODE_H;
                 }
+
                 chimera_vfs_lease_begin_break(state, conflict, floor,
                                               deadline_ms);
                 began_live_break = true;
@@ -1282,6 +1323,13 @@ chimera_vfs_state_try_insert(
                 chimera_vfs_lease_revoke(conflict);
                 revoked_any = true;
             }
+
+            if (iter_pin) {
+                /* pump=false: still mid-arbitration; we re-probe immediately and
+                 * pumping here would re-enter the state machine. */
+                chimera_vfs_caching_grant_release(state, iter_pin, false);
+            }
+
             conflict = NULL;
             pthread_mutex_lock(&file->lock);
             if (chimera_vfs_state_would_conflict(file, lease, &conflict) !=
@@ -1308,11 +1356,32 @@ chimera_vfs_state_try_insert(
                 result = chimera_vfs_state_would_conflict(file, lease, &conflict);
                 pthread_mutex_unlock(&file->lock);
                 if (result == CHIMERA_VFS_LEASE_GRANTED) {
+                    /* The break already cleared the conflict; this re-probe
+                     * supersedes *conflict_out, so drop the pin we took on it
+                     * before looping to grant on the next pass (otherwise the
+                     * grant refcount leaks past this continue). */
+                    if (out_pin) {
+                        chimera_vfs_caching_grant_release(state, out_pin, true);
+                        out_pin = NULL;
+                        if (conflict_out) {
+                            *conflict_out = NULL;
+                        }
+                    }
                     continue;
                 }
             }
-            /* A live holder is mid-break; the caller waits for its ack. */
+            /* A live holder is mid-break; the caller waits for its ack.  The
+             * out_pin (if any) is transferred to the caller, who releases it via
+             * chimera_vfs_state_conflict_unref after inspecting *conflict_out. */
             return CHIMERA_VFS_LEASE_BREAKING;
+        }
+
+        if (out_pin) {
+            chimera_vfs_caching_grant_release(state, out_pin, true);
+            out_pin = NULL;
+            if (conflict_out) {
+                *conflict_out = NULL;
+            }
         }
 
         if (revoked_any) {
@@ -1326,6 +1395,24 @@ chimera_vfs_state_try_insert(
         return CHIMERA_VFS_LEASE_BREAKING;
     }
 } /* chimera_vfs_state_try_insert */
+
+/* Drop the reference chimera_vfs_state_try_insert() takes on a conflicting
+ * CACHING grant it returns in *conflict_out, keeping the grant alive while the
+ * caller inspects it (MS-SMB2 durable-purge resolution, lock-DENIED reporting).
+ * A no-op for non-grant conflicts (delegations, byte-range, share reservations)
+ * and for a NULL conflict, so every caller that receives a conflict may call it
+ * unconditionally once done with the pointer.  Must run after the caller's last
+ * dereference of `conflict`. */
+SYMBOL_EXPORT void
+chimera_vfs_state_conflict_unref(
+    struct chimera_vfs_state *state,
+    struct chimera_vfs_lease *conflict)
+{
+    if (conflict && conflict->kind == CHIMERA_VFS_LEASE_CACHING &&
+        conflict->grant) {
+        chimera_vfs_caching_grant_release(state, conflict->grant, true);
+    }
+} /* chimera_vfs_state_conflict_unref */
 
 /* -------------------------------------------------------------------- */
 /* Pending-acquire queue                                                */
@@ -1416,6 +1503,7 @@ chimera_vfs_state_pump_pending(
             /* Re-queue and wait for the next ack/revoke.  begin_break
              * has already been invoked on the conflicting holder by
              * try_insert. */
+            chimera_vfs_state_conflict_unref(state, conflict);
             pthread_mutex_lock(&file->lock);
             chimera_vfs_pending_enqueue_locked(file, t);
             pthread_mutex_unlock(&file->lock);
@@ -1429,6 +1517,7 @@ chimera_vfs_state_pump_pending(
          * back to a waiter). */
         if (result == CHIMERA_VFS_LEASE_DENIED && t->wait &&
             t->lease->kind == CHIMERA_VFS_LEASE_RANGE) {
+            chimera_vfs_state_conflict_unref(state, conflict);
             pthread_mutex_lock(&file->lock);
             chimera_vfs_pending_enqueue_locked(file, t);
             pthread_mutex_unlock(&file->lock);
@@ -1439,6 +1528,10 @@ chimera_vfs_state_pump_pending(
               result == CHIMERA_VFS_LEASE_GRANTED ? t->lease : NULL,
               conflict,
               t->private_data);
+
+        /* Done exposing `conflict`; drop the try_insert pin (no-op unless it is a
+         * caching grant). */
+        chimera_vfs_state_conflict_unref(state, conflict);
     }
 } /* chimera_vfs_state_pump_pending */
 
@@ -1490,6 +1583,7 @@ chimera_vfs_lease_acquire(
     if (result == CHIMERA_VFS_LEASE_BREAKING && wait) {
         /* Conflict is breakable and caller said to wait.  Queue the
          * ticket; it will fire when the break completes (via pump). */
+        chimera_vfs_state_conflict_unref(state, conflict);
         pthread_mutex_lock(&file->lock);
         chimera_vfs_pending_enqueue_locked(file, ticket);
         pthread_mutex_unlock(&file->lock);
@@ -1506,6 +1600,7 @@ chimera_vfs_lease_acquire(
      * the protocol layer must surface immediately. */
     if (result == CHIMERA_VFS_LEASE_DENIED && wait &&
         lease->kind == CHIMERA_VFS_LEASE_RANGE) {
+        chimera_vfs_state_conflict_unref(state, conflict);
         pthread_mutex_lock(&file->lock);
         chimera_vfs_pending_enqueue_locked(file, ticket);
         pthread_mutex_unlock(&file->lock);
@@ -1517,6 +1612,10 @@ chimera_vfs_lease_acquire(
        result == CHIMERA_VFS_LEASE_GRANTED ? lease : NULL,
        conflict,
        private_data);
+
+    /* Done exposing `conflict` to the cb; drop the try_insert pin (no-op unless
+     * it is a caching grant). */
+    chimera_vfs_state_conflict_unref(state, conflict);
 } /* chimera_vfs_lease_acquire */
 
 SYMBOL_EXPORT void

--- a/src/vfs/vfs_state.h
+++ b/src/vfs/vfs_state.h
@@ -167,6 +167,16 @@ chimera_vfs_state_try_insert(
     struct chimera_vfs_lease      *lease,
     struct chimera_vfs_lease     **conflict_out);
 
+/* Release the reference chimera_vfs_state_try_insert() (and the async
+ * chimera_vfs_lease_acquire() built on it) holds on a conflicting CACHING grant
+ * returned in *conflict_out, so the grant cannot be freed by a racing close
+ * while the caller inspects the conflict.  A no-op for non-grant / NULL
+ * conflicts; call it exactly once, after the last dereference of `conflict`. */
+void
+chimera_vfs_state_conflict_unref(
+    struct chimera_vfs_state *state,
+    struct chimera_vfs_lease *conflict);
+
 /* Remove a previously-inserted lease.  Caller must NOT hold file->lock. */
 void
 chimera_vfs_state_remove(


### PR DESCRIPTION
## Summary

Roots-causes and fixes the load-dependent flake in `chimera/server/smb/smbtorture_smb2_dirlease_memfs` (tracker #733): a cross-thread **heap use-after-free** on a VFS caching grant.

`chimera_vfs_state_try_insert()` returned a borrowed pointer to a conflicting **CACHING** lease that a concurrent close could free underneath two readers:

- `chimera_vfs_lease_begin_break()` invokes the break callback **outside** `file->lock`; the SMB break cb (`chimera_smb_lease_break_cb`) then dereferences `grant->break_ack_required` / `grant->epoch`, and
- the synchronous caller (the SMB `CREATE` durable-purge loop in `chimera_smb_create_gen_open_file`) dereferences `*conflict_out`.

For a CACHING lease the lease is embedded in its grant (`grant->lease`), so a close of the holder racing on another thread drops the grant's last refcount and frees it (the lease with it) mid-dereference. Under CPU contention this is the crash behind the flaky consolidated `smb2.dirlease` suite: the process aborts with **no clean per-subtest `failure:` marker**, which is exactly why CI saw it fail (longer wall time, e.g. 124s) then pass on rerun (80s) — it was an abort, not an assertion.

### Reproduced (ASan, under heavy CPU load)
```
#0 chimera_smb_lease_break_cb        smb_proc_oplock_break.c:400   (reads freed grant->break_ack_required)
#1 chimera_vfs_lease_begin_break_ex  vfs_state.c
...
freed by another thread:
#1 chimera_vfs_caching_grant_release vfs_state.c   (close path: open_file_drain_locks -> close_release)
```

## Fix

Take a reference on the conflicting grant under the **same `file->lock`** that `chimera_vfs_caching_grant_release()` takes before freeing, hold it across the break cb, and hand it to the caller in `*conflict_out`. A new `chimera_vfs_state_conflict_unref()` drops it (a no-op for non-grant / NULL conflicts) and is called by every consumer once done with the pointer:

- `try_insert`'s own re-probe / revoke / GRANTED paths,
- the async `lease_acquire` / `pump_pending` callback sites,
- the direct SMB `create` durable-purge loops and the NFS `open` callers.

Re-probed conflicts inside the break loop get an equivalent transient pin bracketing their `begin_break`.

## Verification

- **Repro:** 1/12 consolidated `smb2.dirlease` runs crashed (ASan) before the fix; **0 failures across ~50 consolidated runs + repeated single-suite runs** after, all under load average ~800 on a 384-core box.
- `vfs/state_test`, `notify_test`, `async/sync_delegation_test`: pass (the BREAKING-conflict assertions still hold).
- `smb2.lease` / `oplock` / `sharemode` smbtorture matrix (memfs/cairn/linux/io_uring/diskfs): 70/70 pass (Debug/ASan).
- `smb2.dirlease` suites (memfs/cairn/linux/io_uring + WPTS dirlease variants): pass (Release); memfs Debug/ASan `--repeat until-fail:4` green.
- pynfs `open` / `lock` / `delegations` (memfs, 4.0/4.1/4.2): 54/54 pass.

The `durable-open.open2-lease` and `…-disconnect-race` `SHARING_VIOLATION` flakes are **pre-existing and load-induced** — equal pass rates with and without this change (e.g. 6/20 vs 7/20 failures on a box at load ~820), and they stress a separate disconnect-vs-conflicting-open timing path.

Ref #733.