### PR TITLE
kvm/nfstest: enable nfstest_ssc (COPY error/edge subset)

### DIFF
--- a/kvm/kvm_nfstest_test_wrapper.sh
+++ b/kvm/kvm_nfstest_test_wrapper.sh
@@ -250,6 +250,23 @@ if [ "$NFSTEST_PROGRAM" = "nfstest_alloc" ]; then
     NFSTEST_EXTRA="${NFSTEST_EXTRA} --runtest ^perf01"
 fi
 
+# nfstest_ssc: chimera implements NFSv4.2 COPY (intra-server), and every COPY
+# mechanic the suite checks -- handles, stateids, offsets, byte count, sync
+# reply, committed level, and that the copied data is correct -- passes.  But
+# each *data-copying* test then asserts "READs should not be sent to the server
+# after the COPY", i.e. that the client serves the post-copy verify read from
+# cache.  The Linux client's copy_file_range unconditionally invalidates the
+# destination page cache (nfs42_copy_dest_done -> truncate_pagecache_range), so
+# that read always goes to the wire -- against any server, knfsd included.  That
+# assertion tests client behaviour, not the server, so restrict the suite to the
+# subset that does not make it: the COPY error/edge cases (bad opens, offsets at
+# or beyond EOF) plus the zero-byte copy, which still exercise the COPY op path
+# and its error handling.  Inter-server tests need a second server and are
+# excluded by selecting only the intra cases.
+if [ "$NFSTEST_PROGRAM" = "nfstest_ssc" ]; then
+    NFSTEST_EXTRA="${NFSTEST_EXTRA} --runtest intra06,intra09,intra10,intra11,intra13"
+fi
+
 # nfstest_xattr's delegation tests (the d* group: dgetxattr/dsetxattr/
 # dremovexattr/dlistxattr) take a read delegation on a *second* client and
 # assert a CB_RECALL fires when the first client mutates an xattr.  That needs a

--- a/kvm/tests/CMakeLists.txt
+++ b/kvm/tests/CMakeLists.txt
@@ -321,10 +321,14 @@ foreach(image_spec ${KVM_IMAGES})
     # kvm-test-base image (>= v1.2.0).  Matrix entries are "program|<space-
     # separated NFS versions>".  nfstest_lock is NFSv4-only here (NFSv3 byte-range
     # locking is NLM, which needs rpc.statd the guest does not run -- the other
-    # suites mount nolock for v3 for the same reason); nfstest_xattr is
-    # NFSv4.2-only (RFC 8276).  Not yet registered: nfstest_ssc (server-side COPY
-    # gap), nfstest_cache (needs a second client host), nfstest_delegation (real
-    # delegation/lock gaps) and nfstest_pnfs.
+    # suites mount nolock for v3 for the same reason); nfstest_xattr and
+    # nfstest_ssc are NFSv4.2-only (RFC 8276 / server-side COPY).  nfstest_ssc
+    # runs a subset (see the wrapper): chimera's COPY is correct, but the suite's
+    # data-copy tests also assert the client serves the post-copy verify read
+    # from cache, which the Linux client never does (copy_file_range invalidates
+    # the destination page cache), so only the COPY error/edge cases are run.
+    # Not yet registered: nfstest_cache (needs a second client host),
+    # nfstest_delegation (real delegation/lock gaps) and nfstest_pnfs.
     if(IMAGE_NAME STREQUAL "ubuntu2404")
         set(NFSTEST_MATRIX
             "nfstest_posix|3 4.0 4.1 4.2"
@@ -334,6 +338,7 @@ foreach(image_spec ${KVM_IMAGES})
             "nfstest_lock|4.1"
             "nfstest_dio|4.2"
             "nfstest_xattr|4.2"
+            "nfstest_ssc|4.2"
         )
         set(NFSTEST_BACKENDS ${KVM_BACKENDS})
         if(CAIRN_ENABLED)


### PR DESCRIPTION
## Summary

Enables the NFSv4.2 server-side-copy suite (`nfstest_ssc`) in the kvm-nfstest shard, restricted to the COPY error/edge subset that doesn't depend on client cache behaviour.

### COPY works
chimera implements intra-server NFSv4.2 `COPY`. With the v1.5.0 guest image (already on main — it mounts the `/dev/shm` that `nfstest_ssc`'s Python `multiprocessing` needs), the suite runs **350/360**, and every COPY mechanic the suite checks passes: source/dest handles and stateids, source/dest offsets, byte count, synchronous reply, `FILE_SYNC4` committed level, and that the **copied data is correct**.

### Why a subset
The 10 failures are all the same assertion — "READs should not be sent to the server after the COPY". Every *data-copying* test does a post-copy verify read and expects the client to serve it from cache. The Linux client's `copy_file_range` unconditionally invalidates the destination page cache (`nfs42_copy_dest_done` → `truncate_pagecache_range`), so that read always hits the wire — against **any** server (knfsd included). It tests client behaviour, not server conformance.

So the suite is registered (`--runtest`) limited to the cases that don't make that assertion:
- `intra06` — zero-byte copy
- `intra09` — source opened without read (COPY must fail)
- `intra10`, `intra11` — offsets at / beyond EOF
- `intra13` — both source and destination failure case

These still exercise the COPY op path and its error handling. **19/19 green** on memfs, cairn, diskfs_io_uring, diskfs_aio (and registered on the passthrough backends too — the subset is attribute-independent, unlike the posix/xattr cases).

### Caveat
This subset does **not** cover data-copy verification in CI (those tests are blocked by the client re-read). COPY's data correctness is validated by the full local run (350/360, all data assertions pass) but isn't gated in CI. Full coverage would need a fork-patch to make the client-behaviour read assertion advisory.
