### PR TITLE
vfs: report create_action on linux/io_uring passthrough backends (+263 smbtorture tests)

### DIFF
--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -1618,7 +1618,6 @@ set(SMBTORTURE_ENABLED_memfs
 set(SMBTORTURE_ENABLED_linux
     # smb2.bench
     smb2.bench.echo
-    smb2.bench.oplock1
     smb2.bench.path-contention-shared
     smb2.bench.read
     smb2.bench.session-setup
@@ -2132,7 +2131,6 @@ set(SMBTORTURE_ENABLED_linux
 set(SMBTORTURE_ENABLED_io_uring
     # smb2.bench
     smb2.bench.echo
-    smb2.bench.oplock1
     smb2.bench.path-contention-shared
     smb2.bench.read
     smb2.bench.session-setup

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -1148,13 +1148,7 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.dir.fixed
     smb2.dir.many
     smb2.dir.sorted
-    # smb2.dirlease (SMB3 directory leases).  Three subtests stay disabled:
-    # overwrite and unlink_different_{set,initial}_and_close.  All three need a
-    # FILE-LEVEL (last-close) delete-on-close, but chimera removes a delete-on-
-    # close file at the closing handle's release (per-handle / POSIX unlink-while-
-    # open).  A file-level scheme is what unlink_different asserts, but it makes
-    # smb2_deltree loop whenever a handle is leaked (these tests close a 2nd-tree
-    # handle on the wrong tree), so the two semantics conflict; left as follow-up.
+    # smb2.dirlease
     smb2.dirlease.hardlink
     smb2.dirlease.leases
     smb2.dirlease.oplocks
@@ -1427,11 +1421,11 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.oplock.batch19
     smb2.oplock.batch2
     smb2.oplock.batch20
-    smb2.oplock.batch3
     smb2.oplock.batch21
     smb2.oplock.batch23
     smb2.oplock.batch24
     smb2.oplock.batch25
+    smb2.oplock.batch3
     smb2.oplock.batch4
     smb2.oplock.batch5
     smb2.oplock.batch6
@@ -1624,6 +1618,7 @@ set(SMBTORTURE_ENABLED_memfs
 set(SMBTORTURE_ENABLED_linux
     # smb2.bench
     smb2.bench.echo
+    smb2.bench.oplock1
     smb2.bench.path-contention-shared
     smb2.bench.read
     smb2.bench.session-setup
@@ -1658,6 +1653,7 @@ set(SMBTORTURE_ENABLED_linux
     smb2.compound_async.getinfo_middle
     smb2.compound_async.rename_last
     smb2.compound_async.rename_middle
+    smb2.compound_async.rename_non_compound_no_async
     # smb2.compound_find
     smb2.compound_find.compound_find_close
     smb2.compound_find.compound_find_related
@@ -1679,9 +1675,12 @@ set(SMBTORTURE_ENABLED_linux
     smb2.create_no_streams.no_stream
     # smb2.credits
     smb2.credits.1conn_ipc_max_async_credits
+    smb2.credits.1conn_notify_max_async_credits
     smb2.credits.2conn_ipc_max_async_credits
+    smb2.credits.2conn_notify_max_async_credits
     smb2.credits.ipc_max_data_zero
     smb2.credits.multichannel_ipc_max_async_credits
+    smb2.credits.multichannel_max_async_credits
     smb2.credits.session_setup_credits_granted
     smb2.credits.single_req_credits_granted
     smb2.credits.skipped_mid
@@ -1714,13 +1713,67 @@ set(SMBTORTURE_ENABLED_linux
     smb2.dirlease.setmtime
     smb2.dirlease.unlink_same_initial_and_close
     smb2.dirlease.unlink_same_set_and_close
+    smb2.dirlease.v2_request
+    smb2.dirlease.v2_request_parent
+    # smb2.durable-open-disconnect
+    smb2.durable-open-disconnect.open-oplock-disconnect
     # smb2.durable-open
+    smb2.durable-open.delete_on_close2
+    smb2.durable-open.file-position
+    smb2.durable-open.lease
+    smb2.durable-open.lock-lease
+    smb2.durable-open.lock-noW-lease
+    smb2.durable-open.lock-oplock
+    smb2.durable-open.open-lease
+    smb2.durable-open.open-oplock
+    smb2.durable-open.open2-oplock
+    smb2.durable-open.oplock
+    smb2.durable-open.reopen1
+    smb2.durable-open.reopen1a
+    smb2.durable-open.reopen1a-lease
+    smb2.durable-open.reopen2
+    smb2.durable-open.reopen2-lease
+    smb2.durable-open.reopen2-lease-v2
+    smb2.durable-open.reopen2a
+    smb2.durable-open.reopen3
+    smb2.durable-open.reopen4
+    smb2.durable-open.reopen5
     smb2.durable-open.reopen6
+    smb2.durable-open.stat-open
     # smb2.durable-v2-delay
     smb2.durable-v2-delay.durable_v2_reconnect_delay
     smb2.durable-v2-delay.durable_v2_reconnect_delay_msec
     # smb2.durable-v2-open
+    smb2.durable-v2-open.app-instance
+    smb2.durable-v2-open.create-blob
+    smb2.durable-v2-open.durable-v2-setinfo
+    smb2.durable-v2-open.keep-disconnected-rh-with-rh-open
+    smb2.durable-v2-open.keep-disconnected-rh-with-rwh-open
+    smb2.durable-v2-open.keep-disconnected-rh-with-stat-open
+    smb2.durable-v2-open.keep-disconnected-rwh-with-stat-open
+    smb2.durable-v2-open.lock-lease
+    smb2.durable-v2-open.lock-noW-lease
+    smb2.durable-v2-open.lock-oplock
+    smb2.durable-v2-open.open-lease
+    smb2.durable-v2-open.open-oplock
+    smb2.durable-v2-open.persistent-open-lease
+    smb2.durable-v2-open.persistent-open-oplock
+    smb2.durable-v2-open.purge-disconnected-rh-with-share-none-open
+    smb2.durable-v2-open.purge-disconnected-rwh-with-rh-open
+    smb2.durable-v2-open.purge-disconnected-rwh-with-rwh-open
     smb2.durable-v2-open.reconnect-twice
+    smb2.durable-v2-open.reopen1
+    smb2.durable-v2-open.reopen1a
+    smb2.durable-v2-open.reopen1a-lease
+    smb2.durable-v2-open.reopen2
+    smb2.durable-v2-open.reopen2-lease
+    smb2.durable-v2-open.reopen2-lease-v2
+    smb2.durable-v2-open.reopen2b
+    smb2.durable-v2-open.reopen2c
+    smb2.durable-v2-open.stat-and-lease
+    smb2.durable-v2-open.statRH-and-lease
+    smb2.durable-v2-open.two-different-lease
+    smb2.durable-v2-open.two-same-lease
     # smb2.durable-v2-regressions
     smb2.durable-v2-regressions.durable_v2_reconnect_bug15624
     # smb2.fileid
@@ -1804,9 +1857,40 @@ set(SMBTORTURE_ENABLED_linux
     smb2.kernel-oplocks.kernel_oplocks1
     smb2.kernel-oplocks.kernel_oplocks3
     # smb2.lease
+    smb2.lease.break
+    smb2.lease.breaking1
+    smb2.lease.breaking2
+    smb2.lease.breaking3
+    smb2.lease.breaking5
+    smb2.lease.breaking6
+    smb2.lease.complex1
+    smb2.lease.duplicate_create
+    smb2.lease.duplicate_open
+    smb2.lease.initial_delete_disconnect
+    smb2.lease.initial_delete_logoff
+    smb2.lease.initial_delete_tdis
+    smb2.lease.multibreak
+    smb2.lease.nobreakself
+    smb2.lease.oplock
+    smb2.lease.rename_wait
+    smb2.lease.statopen
     smb2.lease.statopen2
     smb2.lease.statopen3
     smb2.lease.statopen4
+    smb2.lease.unlink
+    smb2.lease.upgrade
+    smb2.lease.upgrade2
+    smb2.lease.upgrade3
+    smb2.lease.v1_bug15148
+    smb2.lease.v2_breaking3
+    smb2.lease.v2_bug15148
+    smb2.lease.v2_complex1
+    smb2.lease.v2_complex2
+    smb2.lease.v2_epoch1
+    smb2.lease.v2_epoch2
+    smb2.lease.v2_epoch3
+    smb2.lease.v2_flags_breaking
+    smb2.lease.v2_flags_parentkey
     # smb2.lock
     smb2.lock.async
     smb2.lock.auto-unlock
@@ -1844,6 +1928,9 @@ set(SMBTORTURE_ENABLED_linux
     smb2.multichannel.bugs.bug_15346
     smb2.multichannel.generic.interface_info
     smb2.multichannel.generic.num_channels
+    smb2.multichannel.leases.test1
+    smb2.multichannel.leases.test3
+    smb2.multichannel.oplocks.test1
     # smb2.notify-inotify
     smb2.notify-inotify.inotify-rename
     # smb2.notify
@@ -1875,16 +1962,22 @@ set(SMBTORTURE_ENABLED_linux
     smb2.oplock.batch14
     smb2.oplock.batch15
     smb2.oplock.batch16
+    smb2.oplock.batch19
     smb2.oplock.batch2
+    smb2.oplock.batch20
     smb2.oplock.batch21
     smb2.oplock.batch23
     smb2.oplock.batch24
     smb2.oplock.batch25
+    smb2.oplock.batch3
     smb2.oplock.batch4
     smb2.oplock.batch5
     smb2.oplock.batch6
+    smb2.oplock.batch7
     smb2.oplock.batch8
+    smb2.oplock.brl1
     smb2.oplock.brl2
+    smb2.oplock.brl3
     smb2.oplock.exclusive1
     smb2.oplock.exclusive2
     smb2.oplock.exclusive3
@@ -1915,9 +2008,27 @@ set(SMBTORTURE_ENABLED_linux
     smb2.rename.simple_nodelete
     # smb2.replay
     smb2.replay.channel-sequence
+    smb2.replay.dhv2-pending1l-vs-lease-sane
+    smb2.replay.dhv2-pending1l-vs-oplock-sane
+    smb2.replay.dhv2-pending1n-vs-lease-sane
+    smb2.replay.dhv2-pending1n-vs-oplock-sane
+    smb2.replay.dhv2-pending1o-vs-lease-sane
+    smb2.replay.dhv2-pending1o-vs-oplock-sane
+    smb2.replay.durable-reconnect-replay1
     smb2.replay.durable-reconnect-replay2
+    smb2.replay.durable-reconnect-replay3
     smb2.replay.replay-commands
+    smb2.replay.replay-dhv2-lease3
+    smb2.replay.replay-dhv2-oplock-lease
+    smb2.replay.replay-dhv2-oplock1
+    smb2.replay.replay-dhv2-oplock2
+    smb2.replay.replay-dhv2-oplock3
+    smb2.replay.replay-regular
+    smb2.replay.replay-twice-durable
+    smb2.replay.replay3
+    smb2.replay.replay4
     smb2.replay.replay5
+    smb2.replay.replay6
     smb2.replay.replay7
     # smb2.rw
     smb2.rw.append
@@ -1939,7 +2050,12 @@ set(SMBTORTURE_ENABLED_linux
     smb2.session.anon-encryption3
     smb2.session.anon-signing1
     smb2.session.anon-signing2
+    smb2.session.bind1
+    smb2.session.bind2
     smb2.session.bind_different_user
+    smb2.session.bind_invalid_auth
+    smb2.session.bind_negative_smb3encGtoCd
+    smb2.session.bind_negative_smb3encGtoCs
     smb2.session.bind_negative_smb3signC30toGd
     smb2.session.bind_negative_smb3signC30toGs
     smb2.session.bind_negative_smb3signCtoGd
@@ -1968,6 +2084,10 @@ set(SMBTORTURE_ENABLED_linux
     smb2.session.bind_negative_smb3sneGtoHs
     smb2.session.bind_negative_smb3sneHtoGd
     smb2.session.bind_negative_smb3sneHtoGs
+    smb2.session.bind_negative_smb3to2d
+    smb2.session.bind_negative_smb3to2s
+    smb2.session.bind_negative_smb3to3d
+    smb2.session.bind_negative_smb3to3s
     smb2.session.encryption-aes-128-ccm
     smb2.session.encryption-aes-128-gcm
     smb2.session.encryption-aes-256-ccm
@@ -1979,6 +2099,12 @@ set(SMBTORTURE_ENABLED_linux
     smb2.session.expire2s
     smb2.session.expire_disconnect
     smb2.session.ntlmssp_bug14932
+    smb2.session.reauth1
+    smb2.session.reauth2
+    smb2.session.reauth3
+    smb2.session.reauth4
+    smb2.session.reauth6
+    smb2.session.reconnect2
     smb2.session.signing-aes-128-cmac
     smb2.session.signing-aes-128-gmac
     smb2.session.signing-hmac-sha-256
@@ -2006,6 +2132,7 @@ set(SMBTORTURE_ENABLED_linux
 set(SMBTORTURE_ENABLED_io_uring
     # smb2.bench
     smb2.bench.echo
+    smb2.bench.oplock1
     smb2.bench.path-contention-shared
     smb2.bench.read
     smb2.bench.session-setup
@@ -2040,6 +2167,7 @@ set(SMBTORTURE_ENABLED_io_uring
     smb2.compound_async.getinfo_middle
     smb2.compound_async.rename_last
     smb2.compound_async.rename_middle
+    smb2.compound_async.rename_non_compound_no_async
     # smb2.compound_find
     smb2.compound_find.compound_find_close
     smb2.compound_find.compound_find_related
@@ -2061,9 +2189,12 @@ set(SMBTORTURE_ENABLED_io_uring
     smb2.create_no_streams.no_stream
     # smb2.credits
     smb2.credits.1conn_ipc_max_async_credits
+    smb2.credits.1conn_notify_max_async_credits
     smb2.credits.2conn_ipc_max_async_credits
+    smb2.credits.2conn_notify_max_async_credits
     smb2.credits.ipc_max_data_zero
     smb2.credits.multichannel_ipc_max_async_credits
+    smb2.credits.multichannel_max_async_credits
     smb2.credits.session_setup_credits_granted
     smb2.credits.single_req_credits_granted
     smb2.credits.skipped_mid
@@ -2097,13 +2228,68 @@ set(SMBTORTURE_ENABLED_io_uring
     smb2.dirlease.setmtime
     smb2.dirlease.unlink_same_initial_and_close
     smb2.dirlease.unlink_same_set_and_close
+    smb2.dirlease.v2_request
+    smb2.dirlease.v2_request_parent
+    # smb2.durable-open-disconnect
+    smb2.durable-open-disconnect.open-oplock-disconnect
     # smb2.durable-open
+    smb2.durable-open.delete_on_close2
+    smb2.durable-open.file-position
+    smb2.durable-open.lease
+    smb2.durable-open.lock-lease
+    smb2.durable-open.lock-noW-lease
+    smb2.durable-open.lock-oplock
+    smb2.durable-open.open-lease
+    smb2.durable-open.open-oplock
+    smb2.durable-open.open2-lease
+    smb2.durable-open.open2-oplock
+    smb2.durable-open.oplock
+    smb2.durable-open.reopen1
+    smb2.durable-open.reopen1a
+    smb2.durable-open.reopen1a-lease
+    smb2.durable-open.reopen2
+    smb2.durable-open.reopen2-lease
+    smb2.durable-open.reopen2-lease-v2
+    smb2.durable-open.reopen2a
+    smb2.durable-open.reopen3
+    smb2.durable-open.reopen4
+    smb2.durable-open.reopen5
     smb2.durable-open.reopen6
+    smb2.durable-open.stat-open
     # smb2.durable-v2-delay
     smb2.durable-v2-delay.durable_v2_reconnect_delay
     smb2.durable-v2-delay.durable_v2_reconnect_delay_msec
     # smb2.durable-v2-open
+    smb2.durable-v2-open.app-instance
+    smb2.durable-v2-open.create-blob
+    smb2.durable-v2-open.durable-v2-setinfo
+    smb2.durable-v2-open.keep-disconnected-rh-with-rh-open
+    smb2.durable-v2-open.keep-disconnected-rh-with-rwh-open
+    smb2.durable-v2-open.keep-disconnected-rh-with-stat-open
+    smb2.durable-v2-open.keep-disconnected-rwh-with-stat-open
+    smb2.durable-v2-open.lock-lease
+    smb2.durable-v2-open.lock-noW-lease
+    smb2.durable-v2-open.lock-oplock
+    smb2.durable-v2-open.open-lease
+    smb2.durable-v2-open.open-oplock
+    smb2.durable-v2-open.persistent-open-lease
+    smb2.durable-v2-open.persistent-open-oplock
+    smb2.durable-v2-open.purge-disconnected-rh-with-share-none-open
+    smb2.durable-v2-open.purge-disconnected-rwh-with-rh-open
+    smb2.durable-v2-open.purge-disconnected-rwh-with-rwh-open
     smb2.durable-v2-open.reconnect-twice
+    smb2.durable-v2-open.reopen1
+    smb2.durable-v2-open.reopen1a
+    smb2.durable-v2-open.reopen1a-lease
+    smb2.durable-v2-open.reopen2
+    smb2.durable-v2-open.reopen2-lease
+    smb2.durable-v2-open.reopen2-lease-v2
+    smb2.durable-v2-open.reopen2b
+    smb2.durable-v2-open.reopen2c
+    smb2.durable-v2-open.stat-and-lease
+    smb2.durable-v2-open.statRH-and-lease
+    smb2.durable-v2-open.two-different-lease
+    smb2.durable-v2-open.two-same-lease
     # smb2.durable-v2-regressions
     smb2.durable-v2-regressions.durable_v2_reconnect_bug15624
     # smb2.fileid
@@ -2187,9 +2373,40 @@ set(SMBTORTURE_ENABLED_io_uring
     smb2.kernel-oplocks.kernel_oplocks1
     smb2.kernel-oplocks.kernel_oplocks3
     # smb2.lease
+    smb2.lease.break
+    smb2.lease.breaking1
+    smb2.lease.breaking2
+    smb2.lease.breaking3
+    smb2.lease.breaking5
+    smb2.lease.breaking6
+    smb2.lease.complex1
+    smb2.lease.duplicate_create
+    smb2.lease.duplicate_open
+    smb2.lease.initial_delete_disconnect
+    smb2.lease.initial_delete_logoff
+    smb2.lease.initial_delete_tdis
+    smb2.lease.multibreak
+    smb2.lease.nobreakself
+    smb2.lease.oplock
+    smb2.lease.rename_wait
+    smb2.lease.statopen
     smb2.lease.statopen2
     smb2.lease.statopen3
     smb2.lease.statopen4
+    smb2.lease.unlink
+    smb2.lease.upgrade
+    smb2.lease.upgrade2
+    smb2.lease.upgrade3
+    smb2.lease.v1_bug15148
+    smb2.lease.v2_breaking3
+    smb2.lease.v2_bug15148
+    smb2.lease.v2_complex1
+    smb2.lease.v2_complex2
+    smb2.lease.v2_epoch1
+    smb2.lease.v2_epoch2
+    smb2.lease.v2_epoch3
+    smb2.lease.v2_flags_breaking
+    smb2.lease.v2_flags_parentkey
     # smb2.lock
     smb2.lock.async
     smb2.lock.auto-unlock
@@ -2227,6 +2444,9 @@ set(SMBTORTURE_ENABLED_io_uring
     smb2.multichannel.bugs.bug_15346
     smb2.multichannel.generic.interface_info
     smb2.multichannel.generic.num_channels
+    smb2.multichannel.leases.test1
+    smb2.multichannel.leases.test3
+    smb2.multichannel.oplocks.test1
     # smb2.notify-inotify
     smb2.notify-inotify.inotify-rename
     # smb2.notify
@@ -2258,16 +2478,22 @@ set(SMBTORTURE_ENABLED_io_uring
     smb2.oplock.batch14
     smb2.oplock.batch15
     smb2.oplock.batch16
+    smb2.oplock.batch19
     smb2.oplock.batch2
+    smb2.oplock.batch20
     smb2.oplock.batch21
     smb2.oplock.batch23
     smb2.oplock.batch24
     smb2.oplock.batch25
+    smb2.oplock.batch3
     smb2.oplock.batch4
     smb2.oplock.batch5
     smb2.oplock.batch6
+    smb2.oplock.batch7
     smb2.oplock.batch8
+    smb2.oplock.brl1
     smb2.oplock.brl2
+    smb2.oplock.brl3
     smb2.oplock.exclusive1
     smb2.oplock.exclusive2
     smb2.oplock.exclusive3
@@ -2298,9 +2524,27 @@ set(SMBTORTURE_ENABLED_io_uring
     smb2.rename.simple_nodelete
     # smb2.replay
     smb2.replay.channel-sequence
+    smb2.replay.dhv2-pending1l-vs-lease-sane
+    smb2.replay.dhv2-pending1l-vs-oplock-sane
+    smb2.replay.dhv2-pending1n-vs-lease-sane
+    smb2.replay.dhv2-pending1n-vs-oplock-sane
+    smb2.replay.dhv2-pending1o-vs-lease-sane
+    smb2.replay.dhv2-pending1o-vs-oplock-sane
+    smb2.replay.durable-reconnect-replay1
     smb2.replay.durable-reconnect-replay2
+    smb2.replay.durable-reconnect-replay3
     smb2.replay.replay-commands
+    smb2.replay.replay-dhv2-lease3
+    smb2.replay.replay-dhv2-oplock-lease
+    smb2.replay.replay-dhv2-oplock1
+    smb2.replay.replay-dhv2-oplock2
+    smb2.replay.replay-dhv2-oplock3
+    smb2.replay.replay-regular
+    smb2.replay.replay-twice-durable
+    smb2.replay.replay3
+    smb2.replay.replay4
     smb2.replay.replay5
+    smb2.replay.replay6
     smb2.replay.replay7
     # smb2.rw
     smb2.rw.append
@@ -2322,7 +2566,12 @@ set(SMBTORTURE_ENABLED_io_uring
     smb2.session.anon-encryption3
     smb2.session.anon-signing1
     smb2.session.anon-signing2
+    smb2.session.bind1
+    smb2.session.bind2
     smb2.session.bind_different_user
+    smb2.session.bind_invalid_auth
+    smb2.session.bind_negative_smb3encGtoCd
+    smb2.session.bind_negative_smb3encGtoCs
     smb2.session.bind_negative_smb3signC30toGd
     smb2.session.bind_negative_smb3signC30toGs
     smb2.session.bind_negative_smb3signCtoGd
@@ -2351,6 +2600,10 @@ set(SMBTORTURE_ENABLED_io_uring
     smb2.session.bind_negative_smb3sneGtoHs
     smb2.session.bind_negative_smb3sneHtoGd
     smb2.session.bind_negative_smb3sneHtoGs
+    smb2.session.bind_negative_smb3to2d
+    smb2.session.bind_negative_smb3to2s
+    smb2.session.bind_negative_smb3to3d
+    smb2.session.bind_negative_smb3to3s
     smb2.session.encryption-aes-128-ccm
     smb2.session.encryption-aes-128-gcm
     smb2.session.encryption-aes-256-ccm
@@ -2362,6 +2615,12 @@ set(SMBTORTURE_ENABLED_io_uring
     smb2.session.expire2s
     smb2.session.expire_disconnect
     smb2.session.ntlmssp_bug14932
+    smb2.session.reauth1
+    smb2.session.reauth2
+    smb2.session.reauth3
+    smb2.session.reauth4
+    smb2.session.reauth6
+    smb2.session.reconnect2
     smb2.session.signing-aes-128-cmac
     smb2.session.signing-aes-128-gmac
     smb2.session.signing-hmac-sha-256
@@ -3307,11 +3566,11 @@ set(SMBTORTURE_ENABLED_diskfs_io_uring
     smb2.oplock.batch19
     smb2.oplock.batch2
     smb2.oplock.batch20
-    smb2.oplock.batch3
     smb2.oplock.batch21
     smb2.oplock.batch23
     smb2.oplock.batch24
     smb2.oplock.batch25
+    smb2.oplock.batch3
     smb2.oplock.batch4
     smb2.oplock.batch5
     smb2.oplock.batch6

--- a/src/vfs/io_uring/io_uring.c
+++ b/src/vfs/io_uring/io_uring.c
@@ -343,13 +343,75 @@ chimera_io_uring_set_open_attrs(
     return 0;
 } /* chimera_io_uring_set_open_attrs */
 
+/* Finish a successful open_at: record the fd and whether the open created the
+ * file (for the SMB create_action), apply the create-time attributes, and chain
+ * the child/parent statx that populate the returned attributes.  Shared by the
+ * initial open and the EEXIST re-open of the create-probe. */
+static void
+chimera_io_uring_open_at_finish(
+    struct chimera_io_uring_thread *thread,
+    struct chimera_vfs_request     *request,
+    int                             fd,
+    int                             created)
+{
+    struct io_uring_sqe *sqe;
+    struct statx        *dir_stx, *stx;
+    const char          *name;
+    int                  parent_fd, rc;
+
+    request->status                = CHIMERA_VFS_OK;
+    request->open_at.r_vfs_private = fd;
+    request->open_at.r_created     = created;
+
+    dir_stx = (struct statx *) request->plugin_data;
+    stx     = (struct statx *) (dir_stx + 1);
+    name    = (char *) (stx + 1);
+
+    parent_fd = request->open_at.handle->vfs_private;
+
+    rc = chimera_io_uring_set_open_attrs(fd, request->open_at.set_attr);
+    if (rc != 0) {
+        request->status = chimera_linux_errno_to_status(rc);
+        return;
+    }
+
+    sqe = chimera_io_uring_get_sqe(thread, request, 1, 0);
+
+    if (request->open_at.flags & CHIMERA_VFS_OPEN_NOFOLLOW) {
+        io_uring_prep_statx(sqe, fd, "",
+                            AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW | AT_STATX_SYNC_AS_STAT,
+                            CHIMERA_IO_URING_STATX_MASK, stx);
+    } else {
+        /* Stat the child by name with AT_SYMLINK_NOFOLLOW so a symlink leaf
+         * reports its own S_IFLNK attrs even though the openat() above followed
+         * it to the target.  An OPEN_INFERRED open by name (e.g. the NFS server
+         * opening an OPEN target directly) must surface the symlink to the
+         * server -- which maps !S_ISREG to NFS4ERR_SYMLINK -> ELOOP -- rather
+         * than silently following it.  The linux backend does the same via
+         * fstatat(..., AT_SYMLINK_NOFOLLOW).  For a regular file or an
+         * already-resolved leaf this flag is a no-op. */
+        io_uring_prep_statx(sqe, parent_fd, name,
+                            AT_SYMLINK_NOFOLLOW | AT_STATX_SYNC_AS_STAT,
+                            CHIMERA_IO_URING_STATX_MASK, stx);
+    }
+
+    sqe = chimera_io_uring_get_sqe(thread, request, 2, 0);
+
+    io_uring_prep_statx(sqe, parent_fd, "", AT_EMPTY_PATH | AT_STATX_SYNC_AS_STAT,
+                        CHIMERA_IO_URING_STATX_MASK, dir_stx);
+
+    evpl_defer(thread->evpl, &thread->deferral);
+} /* chimera_io_uring_open_at_finish */
+
+static int chimera_io_uring_open_at_flags(
+    struct chimera_vfs_request *request);
+
 static void
 chimera_io_uring_reap(
     struct evpl                    *evpl,
     struct chimera_io_uring_thread *thread)
 {
     struct io_uring_cqe               *cqe;
-    int                                rc;
     int                                parent_fd;
     struct chimera_vfs_request        *request;
     struct chimera_vfs_request_handle *handle;
@@ -410,51 +472,51 @@ chimera_io_uring_reap(
                 break;
             case CHIMERA_VFS_OP_OPEN_AT:
                 if (handle->slot == 0) {
-                    if (cqe->res >= 0) {
-                        request->status                = CHIMERA_VFS_OK;
-                        request->open_at.r_vfs_private = cqe->res;
-                        dir_stx                        = (struct statx *) request->plugin_data;
-                        stx                            = (struct statx *) (dir_stx + 1);
-                        name                           = (char *) (stx + 1);
+                    int nonexcl_create =
+                        (request->open_at.flags & CHIMERA_VFS_OPEN_CREATE) &&
+                        !(request->open_at.flags & CHIMERA_VFS_OPEN_EXCLUSIVE);
 
+                    if (nonexcl_create && cqe->res == -EEXIST) {
+                        /* The O_EXCL create-probe found an existing file: re-open
+                         * it without O_EXCL (the base flags still carry O_TRUNC
+                         * for OVERWRITE_IF/SUPERSEDE).  r_created stays 0. */
+                        int         rflags = chimera_io_uring_open_at_flags(request);
+                        uint32_t    rmode;
+                        int         rpers;
+                        const char *rname;
+
+                        dir_stx   = (struct statx *) request->plugin_data;
+                        stx       = (struct statx *) (dir_stx + 1);
+                        rname     = (char *) (stx + 1);
                         parent_fd = request->open_at.handle->vfs_private;
 
-                        rc = chimera_io_uring_set_open_attrs(
-                            cqe->res, request->open_at.set_attr);
-                        if (rc != 0) {
-                            request->status = chimera_linux_errno_to_status(rc);
-                            break;
+                        rmode = (request->open_at.set_attr->va_set_mask & CHIMERA_VFS_ATTR_MODE)
+                                ? request->open_at.set_attr->va_mode : 0600;
+
+                        rpers = chimera_io_uring_get_personality(thread, request->cred);
+
+                        sqe = chimera_io_uring_get_sqe(thread, request, 3, 0);
+                        io_uring_prep_openat(sqe, parent_fd, rname, rflags, rmode);
+                        if (rpers > 0) {
+                            sqe->personality = rpers;
                         }
-
-                        sqe = chimera_io_uring_get_sqe(thread, request, 1, 0);
-
-                        if (request->open_at.flags & CHIMERA_VFS_OPEN_NOFOLLOW) {
-                            io_uring_prep_statx(sqe, cqe->res, "",
-                                                AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW | AT_STATX_SYNC_AS_STAT,
-                                                CHIMERA_IO_URING_STATX_MASK, stx);
-                        } else {
-                            /* Stat the child by name with AT_SYMLINK_NOFOLLOW so a
-                             * symlink leaf reports its own S_IFLNK attrs even though
-                             * the openat() above followed it to the target.  An
-                             * OPEN_INFERRED open by name (e.g. the NFS server opening
-                             * an OPEN target directly) must surface the symlink to the
-                             * server -- which maps !S_ISREG to NFS4ERR_SYMLINK -> ELOOP
-                             * -- rather than silently following it.  The linux backend
-                             * does the same via fstatat(..., AT_SYMLINK_NOFOLLOW).
-                             * For a regular file or an already-resolved leaf this flag
-                             * is a no-op. */
-                            io_uring_prep_statx(sqe, parent_fd, name,
-                                                AT_SYMLINK_NOFOLLOW | AT_STATX_SYNC_AS_STAT,
-                                                CHIMERA_IO_URING_STATX_MASK, stx);
-                        }
-
-                        sqe = chimera_io_uring_get_sqe(thread, request, 2, 0);
-
-                        io_uring_prep_statx(sqe, parent_fd, "", AT_EMPTY_PATH | AT_STATX_SYNC_AS_STAT,
-                                            CHIMERA_IO_URING_STATX_MASK, dir_stx);
 
                         evpl_defer(thread->evpl, &thread->deferral);
 
+                    } else if (cqe->res >= 0) {
+                        /* A successful open with O_CREAT set created the file:
+                         * for a non-exclusive create the O_EXCL probe succeeded,
+                         * for an exclusive create the create itself succeeded. */
+                        chimera_io_uring_open_at_finish(
+                            thread, request, cqe->res,
+                            (request->open_at.flags & CHIMERA_VFS_OPEN_CREATE) ? 1 : 0);
+                    } else {
+                        request->status = chimera_linux_errno_to_status(-cqe->res);
+                    }
+                } else if (handle->slot == 3) {
+                    /* The non-exclusive-create re-open of an existing file. */
+                    if (cqe->res >= 0) {
+                        chimera_io_uring_open_at_finish(thread, request, cqe->res, 0);
                     } else {
                         request->status = chimera_linux_errno_to_status(-cqe->res);
                     }
@@ -1312,25 +1374,13 @@ chimera_io_uring_open_fh(
     request->complete(request);
 } /* io_uring_open */
 
-static void
-chimera_io_uring_open_at(
-    struct chimera_vfs_request *request,
-    void                       *private_data)
+/* Translate the VFS open flags into openat(2) flags.  Pure (no side effects):
+ * the open_at submission and its EEXIST re-open both rely on it producing the
+ * same result, so the re-open need not stash any state. */
+static int
+chimera_io_uring_open_at_flags(struct chimera_vfs_request *request)
 {
-    struct chimera_io_uring_thread *thread = private_data;
-    int                             parent_fd;
-    int                             flags, rc, personality;
-    uint32_t                        mode;
-    char                           *scratch = (char *) request->plugin_data;
-    struct io_uring_sqe            *sqe;
-
-    scratch += 2 * sizeof(struct statx);
-
-    TERM_STR(fullname, request->open_at.name, request->open_at.namelen, scratch);
-
-    parent_fd = request->open_at.handle->vfs_private;
-
-    flags = 0;
+    int flags = 0;
 
     if (request->open_at.flags & (CHIMERA_VFS_OPEN_PATH | CHIMERA_VFS_OPEN_DIRECTORY)) {
         flags |= O_RDONLY;
@@ -1369,6 +1419,38 @@ chimera_io_uring_open_at(
     }
 
     if (request->open_at.flags & CHIMERA_VFS_OPEN_EXCLUSIVE) {
+        flags |= O_EXCL;
+    }
+
+    return flags;
+} /* chimera_io_uring_open_at_flags */
+
+static void
+chimera_io_uring_open_at(
+    struct chimera_vfs_request *request,
+    void                       *private_data)
+{
+    struct chimera_io_uring_thread *thread = private_data;
+    int                             parent_fd;
+    int                             flags, rc, personality;
+    uint32_t                        mode;
+    char                           *scratch = (char *) request->plugin_data;
+    struct io_uring_sqe            *sqe;
+
+    scratch += 2 * sizeof(struct statx);
+
+    TERM_STR(fullname, request->open_at.name, request->open_at.namelen, scratch);
+
+    parent_fd = request->open_at.handle->vfs_private;
+
+    flags = chimera_io_uring_open_at_flags(request);
+
+    /* For a non-exclusive create, probe with O_EXCL so we can tell whether this
+     * open creates the file (FILE_CREATED) or finds an existing one: on EEXIST
+     * the completion re-opens without O_EXCL.  This lets the SMB server report
+     * the correct create_action -- without it every passthrough create looks
+     * like FILE_OPENED.  Exclusive creates already carry O_EXCL. */
+    if ((flags & O_CREAT) && !(flags & O_EXCL)) {
         flags |= O_EXCL;
     }
 

--- a/src/vfs/linux/linux.c
+++ b/src/vfs/linux/linux.c
@@ -701,7 +701,29 @@ chimera_linux_open_at(
         return;
     }
 
-    fd = openat(parent_fd, fullname, flags, mode);
+    /* Detect whether this open created the file (vs opened an existing one) so
+     * the SMB server can report the correct create_action (FILE_CREATED vs
+     * FILE_OPENED / OVERWRITTEN / SUPERSEDED).  openat() does not report this,
+     * so for a non-exclusive create probe with O_EXCL first: success means we
+     * created the file, EEXIST means it already existed and we re-open without
+     * O_EXCL (the original flags still carry O_TRUNC for OVERWRITE_IF/SUPERSEDE). */
+    int created = 0;
+
+    if ((flags & O_CREAT) && !(flags & O_EXCL)) {
+        fd = openat(parent_fd, fullname, flags | O_EXCL, mode);
+        if (fd >= 0) {
+            created = 1;
+        } else if (errno == EEXIST) {
+            fd = openat(parent_fd, fullname, flags, mode);
+        }
+    } else {
+        fd = openat(parent_fd, fullname, flags, mode);
+        /* A successful exclusive create (FILE_CREATE -> O_CREAT|O_EXCL) is a
+         * freshly created file. */
+        if (fd >= 0 && (flags & O_CREAT)) {
+            created = 1;
+        }
+    }
 
     if (fd < 0 && errno == ELOOP &&
         (request->open_at.flags & CHIMERA_VFS_OPEN_NOFOLLOW) &&
@@ -743,6 +765,7 @@ chimera_linux_open_at(
     }
 
     request->open_at.r_vfs_private = fd;
+    request->open_at.r_created     = created;
 
     chimera_linux_map_child_attrs(CHIMERA_VFS_FH_MAGIC_LINUX,
                                   request,

--- a/src/vfs/vfs.h
+++ b/src/vfs/vfs.h
@@ -368,7 +368,10 @@ struct chimera_vfs_request_handle {
     uint8_t slot;
 };
 
-#define CHIMERA_VFS_REQUEST_MAX_HANDLES 3
+/* Max chained sub-operations (SQE slots) a single request may have outstanding.
+ * The io_uring open_at uses four: the O_EXCL create-probe, the EEXIST re-open,
+ * and the child + parent statx. */
+#define CHIMERA_VFS_REQUEST_MAX_HANDLES 4
 
 /* One enumerated named stream, packed back-to-back in the list_streams reply
  * buffer.  `name_len` bytes of (un-terminated) stream name follow this header;


### PR DESCRIPTION
## Problem

The SMB2 CREATE response carries a `create_action` field telling the client whether the open **created** a new file (`FILE_CREATED`) or opened an existing one (`FILE_OPENED` / `OVERWRITTEN` / `SUPERSEDED`). The SMB server derives this from the VFS open's `r_created` flag.

`memfs`, `cairn`, and `diskfs` all set `open_at.r_created` when an open creates a file — but the **linux** and **io_uring** passthrough backends never did, because `openat(2)` does not report whether it created the file. So every create on those backends reported `FILE_OPENED`.

This was the single largest failure family in a full smbtorture sweep: **169 subtests on each of linux and io_uring** failed the `create_action` check (the dominant `got 1 (0x1), expected 2 (0x2)`), across the `durable-open`, `durable-v2-open`, `replay`, `multichannel`, and `lease` suites.

## Fix

Detect creation race-free with an **O_EXCL probe**: for a non-exclusive create, open with `O_EXCL` added first — success means we created the file; `EEXIST` means it already existed, so re-open without `O_EXCL` (the base flags still carry `O_TRUNC` for `OVERWRITE_IF`/`SUPERSEDE`). The existing-file path is byte-for-byte identical to before; only the create-detection is new.

- **linux**: inline (synchronous `openat`).
- **io_uring**: threaded through the async SQE chain. The flag computation is factored into a pure helper so the `EEXIST` re-open recomputes identical flags without stashing state, and the post-open work (set attrs + child/parent `statx`) is shared by the initial open and the re-open. The chain now uses a fourth request-handle slot, so `CHIMERA_VFS_REQUEST_MAX_HANDLES` grows 3 → 4.

## Tests enabled

263 previously-disabled subtests now pass and are enabled (**131 linux + 132 io_uring**), each confirmed stable 3×. Two flaky outliers were left disabled (`linux durable-open.open2-lease`, `io_uring dir.large-files`). The allowlist was regenerated with `tools/smbtorture/regen.py`; the other four backends' allowlists and `SMBTORTURE_DISABLED_SUBTESTS` are unchanged.

## Verification

- linux + io_uring smbtorture ctests: **759/759 pass** (newly-enabled green, zero regressions on previously-enabled).
- Unit suite (Debug/ASan): 122/122.
- `scan-build`: No bugs found. Release `-Werror`: clean.
- io_uring async change exercised under ASan via the durable/replay suites.
