### PR TITLE
smb2: copy-offload (ODX OFFLOAD_READ/WRITE + DUPLICATE_EXTENTS_TO_FILE)

### DIFF
--- a/src/server/smb/CMakeLists.txt
+++ b/src/server/smb/CMakeLists.txt
@@ -10,7 +10,7 @@ add_library(chimera_smb SHARED
     smb_proc_query_directory.c smb_proc_ioctl.c smb_proc_flush.c smb_proc_echo.c
     smb_lsarpc.c smb_srvsvc.c smb_samr.c smb_wkssvc.c smb_signing.c smb_encrypt.c smb_compress.c smb_proc_set_info_rename.c smb_proc_security.c
     smb_proc_reparse.c smb_proc_change_notify.c smb_proc_cancel.c
-    smb_proc_sparse.c smb_proc_copychunk.c
+    smb_proc_sparse.c smb_proc_copychunk.c smb_proc_copyoffload.c
     smb_proc_lock.c smb_proc_oplock_break.c
     smb_notify.c smb_async_interim.c smb_sharemode.c smb_ntlm.c smb_durable.c
     smb_wbclient.c smb_auth.c smb_gssapi.c

--- a/src/server/smb/smb2.h
+++ b/src/server/smb/smb2.h
@@ -1041,6 +1041,22 @@ typedef uint8_t smb2_guid[SMB2_GUID_SIZE];
 #define SMB2_FSCTL_CREATE_OR_GET_OBJECT_ID          0x000900C0
 #define SMB2_FSCTL_SRV_ENUMERATE_SNAPSHOTS          0x00144064
 #define SMB2_FSCTL_LMR_REQUEST_RESILIENCY           0x001401D4
+#define SMB2_FSCTL_DUPLICATE_EXTENTS_TO_FILE        0x00098344
+#define SMB2_FSCTL_OFFLOAD_READ                     0x00094264
+#define SMB2_FSCTL_OFFLOAD_WRITE                    0x00098268
+
+/* ODX offload-token sizing (MS-FSCC 2.3.79.1 STORAGE_OFFLOAD_TOKEN):
+ * TokenType(4) + Reserved(2) + TokenIdLength(2) + TokenId(504) = 512 bytes.
+ * We mint a vendor token whose TokenId carries the source identity (see
+ * smb_proc_copyoffload.c).  The OFFLOAD_READ/WRITE output buffers are the
+ * fixed-size structs around it. */
+#define SMB2_OFFLOAD_TOKEN_SIZE                     512
+#define SMB2_OFFLOAD_TOKEN_ID_SIZE                  504
+#define SMB2_FSCTL_OFFLOAD_READ_OUTPUT_SIZE         (16 + SMB2_OFFLOAD_TOKEN_SIZE) /* Size(4)+Flags(4)+TransferLength(8)+Token */
+#define SMB2_FSCTL_OFFLOAD_WRITE_OUTPUT_SIZE        16                             /* Size(4)+Flags(4)+LengthWritten(8) */
+/* Vendor token type for our self-describing token (not a Windows-defined value;
+ * the client treats the token as opaque). */
+#define SMB2_OFFLOAD_TOKEN_TYPE_CHIMERA             0x43484d31U                    /* "CHM1" */
 
 /* Server policy for FSCTL_LMR_REQUEST_RESILIENCY: a Timeout of 0 selects the
  * default; any larger request is capped at the maximum (MS-SMB2 3.3.5.15.9). */

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -810,6 +810,33 @@ struct chimera_smb_request {
             /* FSCTL_LMR_REQUEST_RESILIENCY (NETWORK_RESILIENCY_REQUEST,
              * MS-SMB2 2.2.31.3): requested resiliency Timeout in milliseconds. */
             uint32_t                        rr_timeout_ms;
+            /* FSCTL_DUPLICATE_EXTENTS_TO_FILE (DUPLICATE_EXTENTS_DATA, MS-FSCC
+             * 2.3.8 / MS-SMB2 2.2.31.1.1): SourceFileID(16) is an SMB2 FileId,
+             * SourceFileOffset(8), TargetFileOffset(8), ByteCount(8). */
+            struct chimera_smb_file_id      de_src_file_id;
+            uint64_t                        de_src_offset;
+            uint64_t                        de_dst_offset;
+            uint64_t                        de_length;
+            struct chimera_smb_open_file   *de_src_open_file;
+            struct chimera_smb_open_file   *de_dst_open_file;
+            /* Set once the zero-copy clone has fallen back to copy_range, so the
+             * completion callback doesn't loop the fallback again. */
+            uint8_t                         de_copy_fallback;
+            /* FSCTL_OFFLOAD_READ / FSCTL_OFFLOAD_WRITE (ODX, MS-FSCC 2.3.79-82).
+             * The 512-byte STORAGE_OFFLOAD_TOKEN is self-describing: it encodes
+             * the source open's FileId, the OFFLOAD_READ base offset, and the
+             * valid transfer length, so OFFLOAD_WRITE resolves the source the
+             * same way COPYCHUNK resolves a resume key (no server-side token
+             * table needed). */
+            uint64_t                        od_file_offset;
+            uint64_t                        od_copy_length;
+            uint64_t                        od_transfer_offset;
+            uint64_t                        od_transfer_length;
+            struct chimera_smb_file_id      od_src_file_id;
+            struct chimera_smb_open_file   *od_src_open_file;
+            struct chimera_smb_open_file   *od_dst_open_file;
+            uint8_t                         od_copy_fallback;
+            uint8_t                         od_token[512];
         } ioctl;
         struct {
             uint8_t                         info_type;

--- a/src/server/smb/smb_proc_copyoffload.c
+++ b/src/server/smb/smb_proc_copyoffload.c
@@ -1,0 +1,491 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include <string.h>
+
+#include "smb_internal.h"
+#include "smb_procs.h"
+#include "smb2.h"
+#include "smb_session.h"
+#include "vfs/vfs.h"
+#include "vfs/vfs_procs.h"
+
+/*
+ * Block-level server-side copy beyond COPYCHUNK (smb_proc_copychunk.c):
+ *
+ *   FSCTL_DUPLICATE_EXTENTS_TO_FILE - reflink a source range into a target
+ *     (MS-FSCC 2.3.8 / MS-SMB2 2.2.31.1.1).  The source open is named by a
+ *     16-byte SMB2 FileId inside the request; the FSCTL itself is issued on the
+ *     target handle.  We clone the range via chimera_vfs_clone_range, falling
+ *     back to a byte copy (chimera_vfs_copy_range) on a backend that lacks
+ *     reflink support.
+ *
+ *   FSCTL_OFFLOAD_READ / FSCTL_OFFLOAD_WRITE - the ODX token-copy pair
+ *     (MS-FSCC 2.3.79-82).  OFFLOAD_READ (issued on the source) returns a
+ *     512-byte STORAGE_OFFLOAD_TOKEN representing a source byte range;
+ *     OFFLOAD_WRITE (issued on the target) consumes the token to copy that data
+ *     server-side.  Rather than maintain a server token table, the token is
+ *     self-describing: it carries the source open's FileId plus the read base
+ *     offset and valid length, so OFFLOAD_WRITE resolves the source exactly the
+ *     way COPYCHUNK resolves a resume key.  The source open must still be open
+ *     when OFFLOAD_WRITE arrives (the real lifetime bound), which the ODX flow
+ *     guarantees.
+ */
+
+/* ---- self-describing ODX token (inside the 512-byte STORAGE_OFFLOAD_TOKEN) --
+ * TokenType(4) Reserved(2) TokenIdLength(2) then the TokenId payload:
+ *   FileId.pid(8) FileId.vid(8) base_offset(8) length(8).
+ * The token round-trips through us only (opaque to the client), so a plain
+ * host-order encoding is self-consistent. */
+#define SMB_ODX_TOKEN_ID_LEN 32
+
+static void
+chimera_smb_offload_token_build(
+    uint8_t                          *token,
+    const struct chimera_smb_file_id *fid,
+    uint64_t                          base_offset,
+    uint64_t                          length)
+{
+    uint32_t type  = SMB2_OFFLOAD_TOKEN_TYPE_CHIMERA;
+    uint16_t resv  = 0;
+    uint16_t idlen = SMB_ODX_TOKEN_ID_LEN;
+
+    memset(token, 0, SMB2_OFFLOAD_TOKEN_SIZE);
+    memcpy(token + 0, &type, 4);
+    memcpy(token + 4, &resv, 2);
+    memcpy(token + 6, &idlen, 2);
+    memcpy(token + 8, &fid->pid, 8);
+    memcpy(token + 16, &fid->vid, 8);
+    memcpy(token + 24, &base_offset, 8);
+    memcpy(token + 32, &length, 8);
+} /* chimera_smb_offload_token_build */
+
+static int
+chimera_smb_offload_token_parse(
+    const uint8_t              *token,
+    struct chimera_smb_file_id *fid,
+    uint64_t                   *base_offset,
+    uint64_t                   *length)
+{
+    uint32_t type;
+
+    memcpy(&type, token + 0, 4);
+    if (type != SMB2_OFFLOAD_TOKEN_TYPE_CHIMERA) {
+        return -1;
+    }
+    memcpy(&fid->pid, token + 8, 8);
+    memcpy(&fid->vid, token + 16, 8);
+    memcpy(base_offset, token + 24, 8);
+    memcpy(length, token + 32, 8);
+    return 0;
+} /* chimera_smb_offload_token_parse */
+
+/* ----------------------------- DUPLICATE_EXTENTS ------------------------- */
+
+static void
+chimera_smb_duplicate_extents_done(
+    struct chimera_smb_request *request,
+    uint32_t                    status)
+{
+    if (request->ioctl.de_src_open_file) {
+        chimera_smb_open_file_release(request, request->ioctl.de_src_open_file);
+        request->ioctl.de_src_open_file = NULL;
+    }
+    if (request->ioctl.de_dst_open_file) {
+        chimera_smb_open_file_release(request, request->ioctl.de_dst_open_file);
+        request->ioctl.de_dst_open_file = NULL;
+    }
+    chimera_smb_complete_request(request, status);
+} /* chimera_smb_duplicate_extents_done */
+
+static uint32_t
+chimera_smb_copy_error_status(enum chimera_vfs_error error_code)
+{
+    return (error_code == CHIMERA_VFS_ENOTSUP)
+           ? SMB2_STATUS_NOT_SUPPORTED
+           : SMB2_STATUS_INVALID_PARAMETER;
+} /* chimera_smb_copy_error_status */
+
+static void
+chimera_smb_duplicate_extents_copy_cb(
+    enum chimera_vfs_error    error_code,
+    uint64_t                  length,
+    struct chimera_vfs_attrs *pre_attr,
+    struct chimera_vfs_attrs *post_attr,
+    void                     *private_data)
+{
+    struct chimera_smb_request *request = private_data;
+
+    chimera_smb_duplicate_extents_done(
+        request,
+        (error_code == CHIMERA_VFS_OK)
+        ? SMB2_STATUS_SUCCESS
+        : chimera_smb_copy_error_status(error_code));
+} /* chimera_smb_duplicate_extents_copy_cb */
+
+static void
+chimera_smb_duplicate_extents_clone_cb(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *pre_attr,
+    struct chimera_vfs_attrs *post_attr,
+    void                     *private_data)
+{
+    struct chimera_smb_request *request = private_data;
+
+    if (error_code == CHIMERA_VFS_OK) {
+        chimera_smb_duplicate_extents_done(request, SMB2_STATUS_SUCCESS);
+        return;
+    }
+
+    /* A backend without reflink (or one rejecting this alignment) still copies
+    * the bytes via the generic copy_range path so the data lands correctly. */
+    if (!request->ioctl.de_copy_fallback &&
+        (error_code == CHIMERA_VFS_ENOTSUP || error_code == CHIMERA_VFS_EINVAL)) {
+        request->ioctl.de_copy_fallback = 1;
+        chimera_vfs_copy_range(
+            request->compound->thread->vfs_thread,
+            &request->session_handle->session->cred,
+            request->ioctl.de_src_open_file->handle,
+            request->ioctl.de_src_offset,
+            request->ioctl.de_dst_open_file->handle,
+            request->ioctl.de_dst_offset,
+            request->ioctl.de_length,
+            0, 0,
+            chimera_smb_duplicate_extents_copy_cb,
+            request);
+        return;
+    }
+
+    chimera_smb_duplicate_extents_done(request,
+                                       chimera_smb_copy_error_status(error_code));
+} /* chimera_smb_duplicate_extents_clone_cb */
+
+static void
+chimera_smb_duplicate_extents_getattr_cb(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *attr,
+    void                     *private_data)
+{
+    struct chimera_smb_request *request = private_data;
+    uint64_t                    src_size;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        chimera_smb_duplicate_extents_done(request, SMB2_STATUS_INVALID_PARAMETER);
+        return;
+    }
+
+    src_size = (attr->va_set_mask & CHIMERA_VFS_ATTR_SIZE) ? attr->va_size : 0;
+
+    /* The source range must lie within the source file (MS-FSCC 2.3.8): a range
+     * past EOF cannot be duplicated. */
+    if (request->ioctl.de_src_offset + request->ioctl.de_length > src_size) {
+        chimera_smb_duplicate_extents_done(request, SMB2_STATUS_NOT_SUPPORTED);
+        return;
+    }
+
+    chimera_vfs_clone_range(
+        request->compound->thread->vfs_thread,
+        &request->session_handle->session->cred,
+        request->ioctl.de_src_open_file->handle,
+        request->ioctl.de_src_offset,
+        request->ioctl.de_dst_open_file->handle,
+        request->ioctl.de_dst_offset,
+        request->ioctl.de_length,
+        0, 0,
+        chimera_smb_duplicate_extents_clone_cb,
+        request);
+} /* chimera_smb_duplicate_extents_getattr_cb */
+
+void
+chimera_smb_ioctl_duplicate_extents(struct chimera_smb_request *request)
+{
+    struct chimera_smb_open_file *src_open_file, *dst_open_file;
+
+    request->ioctl.de_src_open_file = NULL;
+    request->ioctl.de_dst_open_file = NULL;
+    request->ioctl.de_copy_fallback = 0;
+
+    /* The FSCTL is issued on the target (destination) handle. */
+    dst_open_file = chimera_smb_open_file_resolve(request, &request->ioctl.file_id);
+    if (unlikely(!dst_open_file)) {
+        chimera_smb_complete_request(request, SMB2_STATUS_FILE_CLOSED);
+        return;
+    }
+
+    /* The source is named by the SMB2 FileId carried in the request. */
+    src_open_file = chimera_smb_open_file_resolve(request, &request->ioctl.de_src_file_id);
+    if (unlikely(!src_open_file)) {
+        chimera_smb_open_file_release(request, dst_open_file);
+        chimera_smb_complete_request(request, SMB2_STATUS_OBJECT_NAME_NOT_FOUND);
+        return;
+    }
+
+    /* Source needs read access, destination needs write access. */
+    if (!(src_open_file->granted_access & (SMB2_FILE_READ_DATA | SMB2_FILE_EXECUTE)) ||
+        !(dst_open_file->granted_access & (SMB2_FILE_WRITE_DATA | SMB2_FILE_APPEND_DATA))) {
+        chimera_smb_open_file_release(request, src_open_file);
+        chimera_smb_open_file_release(request, dst_open_file);
+        chimera_smb_complete_request(request, SMB2_STATUS_ACCESS_DENIED);
+        return;
+    }
+
+    request->ioctl.de_src_open_file = src_open_file;
+    request->ioctl.de_dst_open_file = dst_open_file;
+
+    if (request->ioctl.de_length == 0) {
+        chimera_smb_duplicate_extents_done(request, SMB2_STATUS_SUCCESS);
+        return;
+    }
+
+    /* Validate the source range against EOF before issuing the clone. */
+    chimera_vfs_getattr(
+        request->compound->thread->vfs_thread,
+        &request->session_handle->session->cred,
+        src_open_file->handle,
+        CHIMERA_VFS_ATTR_MASK_STAT,
+        chimera_smb_duplicate_extents_getattr_cb,
+        request);
+} /* chimera_smb_ioctl_duplicate_extents */
+
+/* ------------------------------- OFFLOAD_READ ---------------------------- */
+
+static void
+chimera_smb_offload_read_getattr_cb(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *attr,
+    void                     *private_data)
+{
+    struct chimera_smb_request   *request = private_data;
+    struct chimera_smb_open_file *src     = request->ioctl.od_src_open_file;
+    uint64_t                      src_size, avail, xfer;
+
+    request->ioctl.od_src_open_file = NULL;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        chimera_smb_open_file_release(request, src);
+        chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
+        return;
+    }
+
+    src_size = (attr->va_set_mask & CHIMERA_VFS_ATTR_SIZE) ? attr->va_size : 0;
+
+    if (request->ioctl.od_file_offset >= src_size) {
+        chimera_smb_open_file_release(request, src);
+        chimera_smb_complete_request(request, SMB2_STATUS_END_OF_FILE);
+        return;
+    }
+
+    /* TransferLength is the copy length clamped to what remains in the source
+     * (MS-FSCC 2.3.80). */
+    avail = src_size - request->ioctl.od_file_offset;
+    xfer  = (request->ioctl.od_copy_length < avail)
+            ? request->ioctl.od_copy_length : avail;
+
+    request->ioctl.od_transfer_length = xfer;
+
+    chimera_smb_offload_token_build(request->ioctl.od_token,
+                                    &src->file_id,
+                                    request->ioctl.od_file_offset,
+                                    xfer);
+
+    chimera_smb_open_file_release(request, src);
+    chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
+} /* chimera_smb_offload_read_getattr_cb */
+
+void
+chimera_smb_ioctl_offload_read(struct chimera_smb_request *request)
+{
+    struct chimera_smb_open_file *src_open_file;
+
+    request->ioctl.od_src_open_file = NULL;
+
+    /* OFFLOAD_READ is issued on the source handle. */
+    src_open_file = chimera_smb_open_file_resolve(request, &request->ioctl.file_id);
+    if (unlikely(!src_open_file)) {
+        chimera_smb_complete_request(request, SMB2_STATUS_FILE_CLOSED);
+        return;
+    }
+
+    if (!(src_open_file->granted_access & (SMB2_FILE_READ_DATA | SMB2_FILE_EXECUTE))) {
+        chimera_smb_open_file_release(request, src_open_file);
+        chimera_smb_complete_request(request, SMB2_STATUS_ACCESS_DENIED);
+        return;
+    }
+
+    /* The client must offer room for the 528-byte OFFLOAD_READ_OUTPUT. */
+    if (request->ioctl.max_output_response < SMB2_FSCTL_OFFLOAD_READ_OUTPUT_SIZE) {
+        chimera_smb_open_file_release(request, src_open_file);
+        chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
+        return;
+    }
+
+    request->ioctl.od_src_open_file = src_open_file;
+
+    chimera_vfs_getattr(
+        request->compound->thread->vfs_thread,
+        &request->session_handle->session->cred,
+        src_open_file->handle,
+        CHIMERA_VFS_ATTR_MASK_STAT,
+        chimera_smb_offload_read_getattr_cb,
+        request);
+} /* chimera_smb_ioctl_offload_read */
+
+/* ------------------------------ OFFLOAD_WRITE ---------------------------- */
+
+static void
+chimera_smb_offload_write_done(
+    struct chimera_smb_request *request,
+    uint32_t                    status)
+{
+    if (request->ioctl.od_src_open_file) {
+        chimera_smb_open_file_release(request, request->ioctl.od_src_open_file);
+        request->ioctl.od_src_open_file = NULL;
+    }
+    if (request->ioctl.od_dst_open_file) {
+        chimera_smb_open_file_release(request, request->ioctl.od_dst_open_file);
+        request->ioctl.od_dst_open_file = NULL;
+    }
+    chimera_smb_complete_request(request, status);
+} /* chimera_smb_offload_write_done */
+
+static void
+chimera_smb_offload_write_copy_cb(
+    enum chimera_vfs_error    error_code,
+    uint64_t                  length,
+    struct chimera_vfs_attrs *pre_attr,
+    struct chimera_vfs_attrs *post_attr,
+    void                     *private_data)
+{
+    struct chimera_smb_request *request = private_data;
+
+    chimera_smb_offload_write_done(
+        request,
+        (error_code == CHIMERA_VFS_OK)
+        ? SMB2_STATUS_SUCCESS
+        : chimera_smb_copy_error_status(error_code));
+} /* chimera_smb_offload_write_copy_cb */
+
+static void
+chimera_smb_offload_write_clone_cb(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *pre_attr,
+    struct chimera_vfs_attrs *post_attr,
+    void                     *private_data)
+{
+    struct chimera_smb_request *request = private_data;
+
+    if (error_code == CHIMERA_VFS_OK) {
+        chimera_smb_offload_write_done(request, SMB2_STATUS_SUCCESS);
+        return;
+    }
+
+    if (!request->ioctl.od_copy_fallback &&
+        (error_code == CHIMERA_VFS_ENOTSUP || error_code == CHIMERA_VFS_EINVAL)) {
+        request->ioctl.od_copy_fallback = 1;
+        chimera_vfs_copy_range(
+            request->compound->thread->vfs_thread,
+            &request->session_handle->session->cred,
+            request->ioctl.od_src_open_file->handle,
+            request->ioctl.od_transfer_offset,
+            request->ioctl.od_dst_open_file->handle,
+            request->ioctl.od_file_offset,
+            request->ioctl.od_copy_length,
+            0, 0,
+            chimera_smb_offload_write_copy_cb,
+            request);
+        return;
+    }
+
+    chimera_smb_offload_write_done(request,
+                                   chimera_smb_copy_error_status(error_code));
+} /* chimera_smb_offload_write_clone_cb */
+
+void
+chimera_smb_ioctl_offload_write(struct chimera_smb_request *request)
+{
+    struct chimera_smb_open_file *dst_open_file, *src_open_file;
+    struct chimera_smb_file_id    src_file_id;
+    uint64_t                      base_offset, token_length;
+
+    request->ioctl.od_src_open_file = NULL;
+    request->ioctl.od_dst_open_file = NULL;
+    request->ioctl.od_copy_fallback = 0;
+
+    /* OFFLOAD_WRITE is issued on the destination handle. */
+    dst_open_file = chimera_smb_open_file_resolve(request, &request->ioctl.file_id);
+    if (unlikely(!dst_open_file)) {
+        chimera_smb_complete_request(request, SMB2_STATUS_FILE_CLOSED);
+        return;
+    }
+
+    if (!(dst_open_file->granted_access & (SMB2_FILE_WRITE_DATA | SMB2_FILE_APPEND_DATA))) {
+        chimera_smb_open_file_release(request, dst_open_file);
+        chimera_smb_complete_request(request, SMB2_STATUS_ACCESS_DENIED);
+        return;
+    }
+
+    /* The client must offer room for the 16-byte OFFLOAD_WRITE_OUTPUT. */
+    if (request->ioctl.max_output_response < SMB2_FSCTL_OFFLOAD_WRITE_OUTPUT_SIZE) {
+        chimera_smb_open_file_release(request, dst_open_file);
+        chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
+        return;
+    }
+
+    /* Decode the self-describing token minted by OFFLOAD_READ. */
+    if (chimera_smb_offload_token_parse(request->ioctl.od_token, &src_file_id,
+                                        &base_offset, &token_length) != 0) {
+        chimera_smb_open_file_release(request, dst_open_file);
+        chimera_smb_complete_request(request, SMB2_STATUS_OBJECT_NAME_NOT_FOUND);
+        return;
+    }
+
+    /* The requested slice must lie within the range the token represents. */
+    if (request->ioctl.od_transfer_offset + request->ioctl.od_copy_length > token_length) {
+        chimera_smb_open_file_release(request, dst_open_file);
+        chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
+        return;
+    }
+
+    request->ioctl.od_src_file_id = src_file_id;
+
+    /* Resolve the source open on this tree, exactly like a COPYCHUNK resume
+     * key.  An unknown/closed source maps to OBJECT_NAME_NOT_FOUND. */
+    src_open_file = chimera_smb_open_file_resolve(request, &request->ioctl.od_src_file_id);
+    if (unlikely(!src_open_file)) {
+        chimera_smb_open_file_release(request, dst_open_file);
+        chimera_smb_complete_request(request, SMB2_STATUS_OBJECT_NAME_NOT_FOUND);
+        return;
+    }
+
+    if (!(src_open_file->granted_access & (SMB2_FILE_READ_DATA | SMB2_FILE_EXECUTE))) {
+        chimera_smb_open_file_release(request, src_open_file);
+        chimera_smb_open_file_release(request, dst_open_file);
+        chimera_smb_complete_request(request, SMB2_STATUS_ACCESS_DENIED);
+        return;
+    }
+
+    request->ioctl.od_dst_open_file = dst_open_file;
+    request->ioctl.od_src_open_file = src_open_file;
+
+    if (request->ioctl.od_copy_length == 0) {
+        chimera_smb_offload_write_done(request, SMB2_STATUS_SUCCESS);
+        return;
+    }
+
+    /* Source read position = the token's base offset + the requested transfer
+     * offset within the token range. */
+    request->ioctl.od_transfer_offset += base_offset;
+
+    chimera_vfs_clone_range(
+        request->compound->thread->vfs_thread,
+        &request->session_handle->session->cred,
+        src_open_file->handle,
+        request->ioctl.od_transfer_offset,
+        dst_open_file->handle,
+        request->ioctl.od_file_offset,
+        request->ioctl.od_copy_length,
+        0, 0,
+        chimera_smb_offload_write_clone_cb,
+        request);
+} /* chimera_smb_ioctl_offload_write */

--- a/src/server/smb/smb_proc_ioctl.c
+++ b/src/server/smb/smb_proc_ioctl.c
@@ -169,6 +169,18 @@ chimera_smb_ioctl(struct chimera_smb_request *request)
             chimera_smb_ioctl_copychunk(request);
             break;
 
+        case SMB2_FSCTL_DUPLICATE_EXTENTS_TO_FILE:
+            chimera_smb_ioctl_duplicate_extents(request);
+            break;
+
+        case SMB2_FSCTL_OFFLOAD_READ:
+            chimera_smb_ioctl_offload_read(request);
+            break;
+
+        case SMB2_FSCTL_OFFLOAD_WRITE:
+            chimera_smb_ioctl_offload_write(request);
+            break;
+
         case SMB2_FSCTL_CREATE_OR_GET_OBJECT_ID:
             /* MS-FSCC 2.3.7: returns FILE_OBJECTID_BUFFER (64 bytes).  We
              * don't persist object IDs, but the value is documented as
@@ -341,6 +353,12 @@ chimera_smb_ioctl_reply(
         case SMB2_FSCTL_SRV_COPYCHUNK_WRITE:
             output_length = 12; /* ChunksWritten + ChunkBytesWritten + TotalBytesWritten */
             break;
+        case SMB2_FSCTL_OFFLOAD_READ:
+            output_length = SMB2_FSCTL_OFFLOAD_READ_OUTPUT_SIZE; /* Size+Flags+TransferLength+Token */
+            break;
+        case SMB2_FSCTL_OFFLOAD_WRITE:
+            output_length = SMB2_FSCTL_OFFLOAD_WRITE_OUTPUT_SIZE; /* Size+Flags+LengthWritten */
+            break;
         case SMB2_FSCTL_CREATE_OR_GET_OBJECT_ID:
             output_length = 64; /* FILE_OBJECTID_BUFFER (type 1) */
             break;
@@ -444,6 +462,20 @@ chimera_smb_ioctl_reply(
             evpl_iovec_cursor_append_uint32(reply_cursor, request->ioctl.cc_chunks_written);
             evpl_iovec_cursor_append_uint32(reply_cursor, 0); /* ChunkBytesWritten */
             evpl_iovec_cursor_append_uint32(reply_cursor, (uint32_t) request->ioctl.cc_total_written);
+            break;
+        case SMB2_FSCTL_OFFLOAD_READ:
+            /* FSCTL_OFFLOAD_READ_OUTPUT (MS-FSCC 2.3.80): the self-describing
+             * STORAGE_OFFLOAD_TOKEN was minted into od_token by the handler. */
+            evpl_iovec_cursor_append_uint32(reply_cursor, SMB2_FSCTL_OFFLOAD_READ_OUTPUT_SIZE); /* Size */
+            evpl_iovec_cursor_append_uint32(reply_cursor, 0);                                   /* Flags */
+            evpl_iovec_cursor_append_uint64(reply_cursor, request->ioctl.od_transfer_length);
+            evpl_iovec_cursor_append_blob(reply_cursor, request->ioctl.od_token, SMB2_OFFLOAD_TOKEN_SIZE);
+            break;
+        case SMB2_FSCTL_OFFLOAD_WRITE:
+            /* FSCTL_OFFLOAD_WRITE_OUTPUT (MS-FSCC 2.3.82). */
+            evpl_iovec_cursor_append_uint32(reply_cursor, SMB2_FSCTL_OFFLOAD_WRITE_OUTPUT_SIZE); /* Size */
+            evpl_iovec_cursor_append_uint32(reply_cursor, 0);                                   /* Flags */
+            evpl_iovec_cursor_append_uint64(reply_cursor, request->ioctl.od_copy_length);       /* LengthWritten */
             break;
         case SMB2_FSCTL_CREATE_OR_GET_OBJECT_ID:
             evpl_iovec_cursor_append_blob(reply_cursor, request->ioctl.oid_buffer, 64);
@@ -806,6 +838,46 @@ chimera_smb_parse_ioctl(
                 }
                 break;
             }
+            case SMB2_FSCTL_DUPLICATE_EXTENTS_TO_FILE:
+                /* DUPLICATE_EXTENTS_DATA (MS-FSCC 2.3.8 / MS-SMB2 2.2.31.1.1):
+                 * SourceFileID is a 16-byte SMB2 FileId (pid + vid), then
+                 * SourceFileOffset(8), TargetFileOffset(8), ByteCount(8). */
+                if (request->ioctl.input_count < 40) {
+                    request->status = SMB2_STATUS_INVALID_PARAMETER;
+                    return -1;
+                }
+                evpl_iovec_cursor_get_uint64(request_cursor, &request->ioctl.de_src_file_id.pid);
+                evpl_iovec_cursor_get_uint64(request_cursor, &request->ioctl.de_src_file_id.vid);
+                evpl_iovec_cursor_get_uint64(request_cursor, &request->ioctl.de_src_offset);
+                evpl_iovec_cursor_get_uint64(request_cursor, &request->ioctl.de_dst_offset);
+                evpl_iovec_cursor_get_uint64(request_cursor, &request->ioctl.de_length);
+                break;
+            case SMB2_FSCTL_OFFLOAD_READ:
+                /* FSCTL_OFFLOAD_READ_INPUT (MS-FSCC 2.3.79): Size(4) + Flags(4)
+                 * + TokenTimeToLive(4) + Reserved(4) + FileOffset(8) +
+                 * CopyLength(8). */
+                if (request->ioctl.input_count < 32) {
+                    request->status = SMB2_STATUS_INVALID_PARAMETER;
+                    return -1;
+                }
+                evpl_iovec_cursor_skip(request_cursor, 16); /* Size, Flags, TTL, Reserved */
+                evpl_iovec_cursor_get_uint64(request_cursor, &request->ioctl.od_file_offset);
+                evpl_iovec_cursor_get_uint64(request_cursor, &request->ioctl.od_copy_length);
+                break;
+            case SMB2_FSCTL_OFFLOAD_WRITE:
+                /* FSCTL_OFFLOAD_WRITE_INPUT (MS-FSCC 2.3.81): Size(4) + Flags(4)
+                 * + FileOffset(8) + CopyLength(8) + TransferOffset(8) +
+                 * Token(512). */
+                if (request->ioctl.input_count < 32 + SMB2_OFFLOAD_TOKEN_SIZE) {
+                    request->status = SMB2_STATUS_INVALID_PARAMETER;
+                    return -1;
+                }
+                evpl_iovec_cursor_skip(request_cursor, 8); /* Size, Flags */
+                evpl_iovec_cursor_get_uint64(request_cursor, &request->ioctl.od_file_offset);
+                evpl_iovec_cursor_get_uint64(request_cursor, &request->ioctl.od_copy_length);
+                evpl_iovec_cursor_get_uint64(request_cursor, &request->ioctl.od_transfer_offset);
+                evpl_iovec_cursor_copy(request_cursor, request->ioctl.od_token, SMB2_OFFLOAD_TOKEN_SIZE);
+                break;
             case SMB2_FSCTL_LMR_REQUEST_RESILIENCY:
                 /* NETWORK_RESILIENCY_REQUEST (MS-SMB2 2.2.31.3): Timeout(4) +
                  * Reserved(4). */

--- a/src/server/smb/smb_procs.h
+++ b/src/server/smb/smb_procs.h
@@ -243,6 +243,15 @@ void chimera_smb_ioctl_request_resume_key(
 void chimera_smb_ioctl_copychunk(
     struct chimera_smb_request *request);
 
+void chimera_smb_ioctl_duplicate_extents(
+    struct chimera_smb_request *request);
+
+void chimera_smb_ioctl_offload_read(
+    struct chimera_smb_request *request);
+
+void chimera_smb_ioctl_offload_write(
+    struct chimera_smb_request *request);
+
 int chimera_smb_parse_change_notify(
     struct evpl_iovec_cursor   *request_cursor,
     struct chimera_smb_request *request);

--- a/src/server/smb/tests/wpts/CommonTestSuite.deployment.ptfconfig
+++ b/src/server/smb/tests/wpts/CommonTestSuite.deployment.ptfconfig
@@ -83,9 +83,24 @@
       <Property name="SutSupportedEncryptionAlgorithms" value="ENCRYPTION_AES128_CCM;ENCRYPTION_AES128_GCM;ENCRYPTION_AES256_CCM;ENCRYPTION_AES256_GCM"/>
       <Property name="SupportedCompressionAlgorithms" value=""/>
 
-      <Property name="UnsupportedIoCtlCodes" value="FSCTL_OFFLOAD_READ;FSCTL_OFFLOAD_WRITE;FSCTL_FILE_LEVEL_TRIM"/>
+      <Property name="UnsupportedIoCtlCodes" value="FSCTL_FILE_LEVEL_TRIM"/>
       <Property name="UnsupportedCreateContexts" value=""/>
       <Property name="MaxResiliencyTimeout" value="300000"/>
+    </Group>
+
+    <!-- Copy-offload: the server implements FSCTL_OFFLOAD_READ/WRITE (ODX) and
+         FSCTL_DUPLICATE_EXTENTS_TO_FILE. The MS_FSA_Clarification cases gate on
+         these properties, which SMB2TestConfig reads from the "HVRS" group;
+         VolumnClusterSize must equal the allocation unit the server advertises
+         (8 sectors * 512 = 4096, see smb_attr.h). -->
+    <Group name="HVRS">
+      <Property name="IsOffLoadImplemented" value="true"/>
+      <Property name="IsSetZeroDataImplemented" value="true"/>
+      <Property name="VolumnClusterSize" value="4096"/>
+      <!-- UNC path the MS_FSA_Clarification cases open a verification handle on;
+           SMB2TestConfig.ParseSharePath splits it into ShareServerName + ShareName,
+           so it must be \\<SUT_IP>\<basic share>. -->
+      <Property name="SharePath" value="\\10.0.0.1\SMBBasic"/>
     </Group>
   </Properties>
 </TestSite>

--- a/src/server/smb/tests/wpts/wpts_cases.csv
+++ b/src/server/smb/tests/wpts/wpts_cases.csv
@@ -17,12 +17,12 @@ BVT_AppInstanceVersion_SMB311_LowerAppInstanceVersionLow,base,green,0,
 BVT_AppInstanceVersion_SMB311_SameVersion,base,green,0,
 BVT_Compound_RelatedRequests,base,green,0,
 BVT_Compound_UnRelatedRequests,base,green,0,
-BVT_CopyOffload,base,skip,0,copy-offload
+BVT_CopyOffload,base,green,0,
 BVT_CreateClose_CreateAndCloseDirectory,base,green,0,
 BVT_CreateClose_CreateAndCloseFile,base,green,0,
 BVT_DirectoryLeasing_LeaseBreakOnMultiClients,dirlease,xfail,0,
 BVT_DirectoryLeasing_ReadWriteHandleCaching,dirlease,green,0,
-BVT_DuplicateExtentsToFile,base,skip,0,copy-offload
+BVT_DuplicateExtentsToFile,base,green,0,
 BVT_DurableHandleV1_Reconnect_WithBatchOplock,persistent,green,0,
 BVT_DurableHandleV1_Reconnect_WithLeaseV1,persistent,green,0,
 BVT_DurableHandleV2_Reconnect_WithBatchOplock,persistent,green,0,
@@ -57,7 +57,7 @@ BVT_Negotiate_SMB311_Preauthentication_Encryption_GCM,encryption,green,0,
 BVT_Negotiate_SMB311_RdmaTransformCapabilities_IsSupported,base,skip,0,rdma
 BVT_Negotiate_SigningEnabled,base,green,0,
 BVT_NetworkInterfaceInfo_QuerySuccessful,multichannel,green,0,
-BVT_OffloadReadWrite,base,skip,0,copy-offload
+BVT_OffloadReadWrite,base,green,0,
 BVT_OpLockBreak,base,green,1,
 BVT_OpLockBreak_Lease,base,skip,0,oplock-lease
 BVT_PersistentHandle_Reconnect,persistent,green,0,
@@ -122,7 +122,7 @@ BVT_TreeMgmt_TreeConnectAndDisconnect,base,green,0,
 BVT_ValidateNegotiateInfo,base,green,0,
 Compound_Encrypt_RelatedRequests,encryption,green,0,
 Compound_Encrypt_UnrelatedRequests,encryption,green,0,
-CopyOffload_CopyContentWithinSameFile,base,skip,0,copy-offload
+CopyOffload_CopyContentWithinSameFile,base,green,0,
 CreateClose_CreateAndCloseDirWithDotDir,base,green,0,
 CreateClose_CreateAndCloseDirWithDoubleDotDir,base,green,0,
 CreateClose_CreateAndCloseFileWithDotDir,base,green,0,

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -38,6 +38,15 @@
 #define CHIMERA_MEMFS_BLOCK_SIZE_MAX     (1024 * 1024)
 #define CHIMERA_MEMFS_BLOCK_SIZE_DEFAULT (64 * 1024)
 
+/* clone_range honours alignment to this granularity regardless of the (larger)
+ * internal storage block size: a clone range that fully covers an internal
+ * block is shared copy-on-write (zero-copy), while partial edges are realised
+ * by read-modify-write.  4 KiB matches the allocation unit the SMB server
+ * advertises (smb_attr.h), so SMB clients cloning at cluster granularity (e.g.
+ * FSCTL_DUPLICATE_EXTENTS_TO_FILE, ODX OFFLOAD_WRITE) land on a clean boundary.
+ * Always a power-of-two divisor of every supported block size (>= 4 KiB). */
+#define CHIMERA_MEMFS_CLONE_ALIGN        (4 * 1024)
+
 #define CHIMERA_MEMFS_INODE_LIST_SHIFT   8
 #define CHIMERA_MEMFS_INODE_NUM_LISTS    (1 << CHIMERA_MEMFS_INODE_LIST_SHIFT)
 #define CHIMERA_MEMFS_INODE_LIST_MASK    (CHIMERA_MEMFS_INODE_NUM_LISTS - 1)
@@ -3954,12 +3963,16 @@ memfs_clone_range(
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
+    struct evpl        *evpl        = thread->evpl;
+    const uint32_t      block_size  = shared->block_size;
     const uint32_t      block_shift = shared->block_shift;
     const uint32_t      block_mask  = shared->block_mask;
     struct memfs_inode *src_inode, *dst_inode;
+    struct memfs_block *old_block, *new_block;
     uint64_t            src_offset, dst_offset, length;
     uint64_t            first_block, last_block, bi;
-    uint64_t            src_first_block, n_blocks;
+    uint32_t            block_offset, left, block_len;
+    uint64_t            copied = 0;
     struct timespec     now;
 
     if (request->clone_range.src_handle->vfs_module !=
@@ -3973,12 +3986,13 @@ memfs_clone_range(
     dst_offset = request->clone_range.dst_offset;
     length     = request->clone_range.length;
 
-    /* Block-aligned only: matches memfs_move_range and POSIX FICLONERANGE
-     * semantics on filesystems with reflink support. Sub-block edges would
-     * require copy-on-write and defeat the zero-copy benefit. */
-    if ((src_offset & block_mask) ||
-        (dst_offset & block_mask) ||
-        (length & block_mask)) {
+    /* Honour clone-granularity (4 KiB) alignment rather than the larger internal
+     * block size: whole internal blocks are shared copy-on-write below, partial
+     * edges fall back to read-modify-write.  Sub-cluster offsets/lengths are
+     * still rejected, matching POSIX FICLONERANGE block-alignment semantics. */
+    if ((src_offset & (CHIMERA_MEMFS_CLONE_ALIGN - 1)) ||
+        (dst_offset & (CHIMERA_MEMFS_CLONE_ALIGN - 1)) ||
+        (length & (CHIMERA_MEMFS_CLONE_ALIGN - 1))) {
         request->status = CHIMERA_VFS_EINVAL;
         request->complete(request);
         return;
@@ -4032,10 +4046,10 @@ memfs_clone_range(
     memfs_map_attrs(shared, &request->clone_range.r_pre_attr, dst_inode,
                     request->clone_range.dst_handle->fh);
 
-    first_block     = dst_offset >> block_shift;
-    last_block      = (dst_offset + length - 1) >> block_shift;
-    src_first_block = src_offset >> block_shift;
-    n_blocks        = length >> block_shift;
+    first_block  = dst_offset >> block_shift;
+    block_offset = dst_offset & block_mask;
+    last_block   = (dst_offset + length - 1) >> block_shift;
+    left         = length;
 
     if (memfs_grow_blocks(dst_inode, last_block) != 0) {
         if (src_inode != dst_inode) {
@@ -4051,11 +4065,16 @@ memfs_clone_range(
         dst_inode->file.num_blocks = last_block + 1;
     }
 
-    for (bi = 0; bi < n_blocks; bi++) {
-        uint64_t            si = src_first_block + bi;
-        uint64_t            di = first_block + bi;
+    for (bi = first_block; bi <= last_block; bi++) {
+        uint64_t            cur_src_off = src_offset + copied;
+        uint64_t            si          = cur_src_off >> block_shift;
         struct memfs_block *src_block;
-        struct memfs_block *new_block;
+        int                 whole_block;
+
+        block_len = block_size - block_offset;
+        if (left < block_len) {
+            block_len = left;
+        }
 
         if (src_inode->file.blocks && si < src_inode->file.num_blocks) {
             src_block = src_inode->file.blocks[si];
@@ -4063,21 +4082,31 @@ memfs_clone_range(
             src_block = NULL;
         }
 
-        /* Free anything currently at the destination slot before overwriting */
-        if (dst_inode->file.blocks[di]) {
-            memfs_block_free(thread, dst_inode->file.blocks[di]);
-            dst_inode->file.blocks[di] = NULL;
-        }
+        old_block = dst_inode->file.blocks[bi];
 
-        if (!src_block) {
-            /* Source is a hole - leave destination NULL (reads as zeros) */
+        /* A full-block hole in the source stays sparse at the destination
+         * (reads as zeros) -- preserves sparseness across the clone. */
+        if (!src_block && block_offset == 0 && block_len == block_size) {
+            if (old_block) {
+                memfs_block_free(thread, old_block);
+                dst_inode->file.blocks[bi] = NULL;
+            }
+            copied      += block_len;
+            left        -= block_len;
+            block_offset = 0;
             continue;
         }
 
-        /* Share underlying buffer via iovec refcount; the new memfs_block
-         * has its own iovec descriptors that hold refs into the same
-         * buffers as the source block. Subsequent writes on either side
-         * COW naturally because memfs_write always allocates a new block. */
+        /* Zero-copy fast path: the clone range fully covers this internal
+         * block, the source position is block-aligned, and the source block is
+         * fully backed (not a trailing partial block or a hole).  Share the
+         * source iovecs copy-on-write -- writes on either side allocate a fresh
+         * block, so the sharing is invisible. */
+        whole_block = (block_offset == 0 && block_len == block_size &&
+                       (cur_src_off & block_mask) == 0 &&
+                       cur_src_off + block_size <= src_inode->size &&
+                       src_block != NULL);
+
         new_block = memfs_block_alloc(thread);
 
         if (!new_block) {
@@ -4090,15 +4119,59 @@ memfs_clone_range(
             return;
         }
 
-        new_block->niov = src_block->niov;
-        for (int j = 0; j < src_block->niov; j++) {
-            evpl_iovec_clone_segment(&new_block->iov[j],
-                                     &src_block->iov[j],
-                                     0,
-                                     src_block->iov[j].length);
+        if (whole_block) {
+            new_block->niov = src_block->niov;
+            for (int j = 0; j < src_block->niov; j++) {
+                evpl_iovec_clone_segment(&new_block->iov[j],
+                                         &src_block->iov[j],
+                                         0,
+                                         src_block->iov[j].length);
+            }
+        } else {
+            /* Partial / misaligned edge: read-modify-write.  Allocate backing,
+             * preserve the destination bytes outside [block_offset, +block_len),
+             * then copy the covered range from the source (memfs_copy_from_inode
+             * zero-fills past the source's EOF, matching hole semantics). */
+            new_block->niov = evpl_iovec_alloc(evpl, block_size, 4096,
+                                               CHIMERA_MEMFS_BLOCK_MAX_IOV,
+                                               EVPL_IOVEC_FLAG_SHARED,
+                                               new_block->iov);
+
+            if (block_offset || block_len < block_size) {
+                if (old_block) {
+                    if (block_offset) {
+                        memcpy(new_block->iov[0].data,
+                               old_block->iov[0].data, block_offset);
+                    }
+                    uint32_t tail_off = block_offset + block_len;
+                    if (tail_off < block_size) {
+                        memcpy((uint8_t *) new_block->iov[0].data + tail_off,
+                               (uint8_t *) old_block->iov[0].data + tail_off,
+                               block_size - tail_off);
+                    }
+                } else {
+                    memset(new_block->iov[0].data, 0, block_offset);
+                    uint32_t tail_off = block_offset + block_len;
+                    if (tail_off < block_size) {
+                        memset((uint8_t *) new_block->iov[0].data + tail_off, 0,
+                               block_size - tail_off);
+                    }
+                }
+            }
+
+            memfs_copy_from_inode(shared, src_inode, cur_src_off,
+                                  (uint8_t *) new_block->iov[0].data + block_offset,
+                                  block_len);
         }
 
-        dst_inode->file.blocks[di] = new_block;
+        if (old_block) {
+            memfs_block_free(thread, old_block);
+        }
+        dst_inode->file.blocks[bi] = new_block;
+
+        copied      += block_len;
+        left        -= block_len;
+        block_offset = 0;
     }
 
     if (dst_inode->size < dst_offset + length) {

--- a/src/vfs/tests/CMakeLists.txt
+++ b/src/vfs/tests/CMakeLists.txt
@@ -44,6 +44,10 @@ add_executable(vfs_enforce_test vfs_enforce_test.c)
 target_link_libraries(vfs_enforce_test chimera_vfs chimera_vfs_memfs evpl)
 add_test(chimera/vfs/enforce_test vfs_enforce_test)
 
+add_executable(vfs_clone_range_test vfs_clone_range_test.c)
+target_link_libraries(vfs_clone_range_test chimera_vfs chimera_vfs_memfs evpl)
+add_test(chimera/vfs/clone_range_test vfs_clone_range_test)
+
 add_executable(vfs_idmap_test vfs_idmap_test.c)
 target_link_libraries(vfs_idmap_test chimera_vfs)
 add_test(chimera/vfs/idmap_test vfs_idmap_test)

--- a/src/vfs/tests/vfs_clone_range_test.c
+++ b/src/vfs/tests/vfs_clone_range_test.c
@@ -1,0 +1,432 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * memfs clone_range at 4 KiB (cluster) granularity.  memfs stores files in
+ * larger internal blocks (64 KiB by default), so a clone that fully covers an
+ * internal block is shared copy-on-write while partial / misaligned edges are
+ * realised by read-modify-write.  This exercises both paths end-to-end and
+ * byte-verifies the result, including that destination bytes outside the cloned
+ * range are preserved.  Runs under Debug/ASan, the only coverage the path gets
+ * outside the (Release-only) WPTS copy-offload cases that drive it over SMB.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#undef NDEBUG
+#include <assert.h>
+
+#include "evpl/evpl.h"
+#include "vfs/vfs.h"
+#include "vfs/vfs_procs.h"
+#include "vfs/vfs_release.h"
+#include "vfs/vfs_attrs.h"
+#include "vfs/vfs_cred.h"
+#include "vfs/vfs_error.h"
+#include "common/logging.h"
+#include "prometheus-c.h"
+
+#define TEST_PASS(name) fprintf(stderr, "  PASS: %s\n", name)
+
+#define BLOCK    (64 * 1024)
+#define FILESIZE (96 * 1024)   /* 1.5 internal blocks */
+
+struct test_ctx {
+    int                             done;
+    enum chimera_vfs_error          status;
+    struct chimera_vfs             *vfs;
+    struct chimera_vfs_thread      *vfs_thread;
+    struct evpl                    *evpl;
+    struct chimera_vfs_open_handle *handle;
+    uint8_t                         fh[CHIMERA_VFS_FH_SIZE];
+    uint32_t                        fh_len;
+    const uint8_t                  *expect;     /* read verification */
+    uint32_t                        expect_len;
+    int                             verify_ok;
+};
+
+static void
+wait_done(struct test_ctx *ctx)
+{
+    while (!ctx->done) {
+        evpl_continue(ctx->evpl);
+    }
+    ctx->done = 0;
+} /* wait_done */
+
+static void
+mount_cb(
+    struct chimera_vfs_thread *thread,
+    enum chimera_vfs_error     status,
+    void                      *private_data)
+{
+    struct test_ctx *ctx = private_data;
+
+    ctx->status = status;
+    ctx->done   = 1;
+} /* mount_cb */
+
+static void
+lookup_cb(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *attr,
+    void                     *private_data)
+{
+    struct test_ctx *ctx = private_data;
+
+    ctx->status = error_code;
+    if (error_code == CHIMERA_VFS_OK) {
+        memcpy(ctx->fh, attr->va_fh, attr->va_fh_len);
+        ctx->fh_len = attr->va_fh_len;
+    }
+    ctx->done = 1;
+} /* lookup_cb */
+
+static void
+openfh_cb(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *oh,
+    void                           *private_data)
+{
+    struct test_ctx *ctx = private_data;
+
+    ctx->status = error_code;
+    ctx->handle = oh;
+    ctx->done   = 1;
+} /* openfh_cb */
+
+static void
+openat_cb(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *oh,
+    struct chimera_vfs_attrs       *set_attr,
+    struct chimera_vfs_attrs       *attr,
+    struct chimera_vfs_attrs       *dir_pre,
+    struct chimera_vfs_attrs       *dir_post,
+    void                           *private_data)
+{
+    struct test_ctx *ctx = private_data;
+
+    ctx->status = error_code;
+    ctx->handle = oh;
+    if (error_code == CHIMERA_VFS_OK) {
+        memcpy(ctx->fh, oh->fh, oh->fh_len);
+        ctx->fh_len = oh->fh_len;
+    }
+    ctx->done = 1;
+} /* openat_cb */
+
+static void
+write_cb(
+    enum chimera_vfs_error    error_code,
+    uint32_t                  length,
+    uint32_t                  sync,
+    struct chimera_vfs_attrs *pre_attr,
+    struct chimera_vfs_attrs *post_attr,
+    void                     *private_data)
+{
+    struct test_ctx *ctx = private_data;
+
+    ctx->status = error_code;
+    ctx->done   = 1;
+} /* write_cb */
+
+static void
+read_cb(
+    enum chimera_vfs_error    error_code,
+    uint32_t                  count,
+    uint32_t                  eof,
+    struct evpl_iovec        *iov,
+    int                       niov,
+    struct chimera_vfs_attrs *attr,
+    void                     *private_data)
+{
+    struct test_ctx *ctx = private_data;
+    uint32_t         off = 0;
+
+    ctx->status    = error_code;
+    ctx->verify_ok = 0;
+
+    if (error_code == CHIMERA_VFS_OK) {
+        /* memfs returns one zero-copy iovec per block; gather and compare. */
+        ctx->verify_ok = (count == ctx->expect_len);
+        for (int i = 0; i < niov; i++) {
+            uint32_t n = iov[i].length;
+            if (off + n > ctx->expect_len) {
+                n = ctx->expect_len - off;
+            }
+            if (memcmp(iov[i].data, ctx->expect + off, n) != 0) {
+                ctx->verify_ok = 0;
+            }
+            off += iov[i].length;
+        }
+        /* The read iovecs are caller-owned references; release them. */
+        if (niov) {
+            evpl_iovecs_release(ctx->evpl, iov, niov);
+        }
+    }
+    ctx->done = 1;
+} /* read_cb */
+
+static void
+remove_cb(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *pre_attr,
+    struct chimera_vfs_attrs *post_attr,
+    void                     *private_data)
+{
+    struct test_ctx *ctx = private_data;
+
+    ctx->status = error_code;
+    ctx->done   = 1;
+} /* remove_cb */
+
+static void
+clone_cb(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *pre_attr,
+    struct chimera_vfs_attrs *post_attr,
+    void                     *private_data)
+{
+    struct test_ctx *ctx = private_data;
+
+    ctx->status = error_code;
+    ctx->done   = 1;
+} /* clone_cb */
+
+/* Create `name` under `dir` and return the open handle (kept open).  The
+ * create handle carries the inode in vfs_private, exactly as the SMB create
+ * path delivers to clone_range/copy_range. */
+static struct chimera_vfs_open_handle *
+create_file(
+    struct test_ctx                *ctx,
+    const struct chimera_vfs_cred  *cred,
+    struct chimera_vfs_open_handle *dir,
+    const char                     *name)
+{
+    struct chimera_vfs_attrs sattr;
+
+    memset(&sattr, 0, sizeof(sattr));
+    sattr.va_set_mask = CHIMERA_VFS_ATTR_MODE;
+    sattr.va_mode     = 0644;
+
+    chimera_vfs_open_at(ctx->vfs_thread, cred, dir, name, strlen(name),
+                        CHIMERA_VFS_OPEN_CREATE, &sattr, CHIMERA_VFS_ATTR_FH,
+                        0, 0, openat_cb, ctx);
+    wait_done(ctx);
+    assert(ctx->status == CHIMERA_VFS_OK);
+    return ctx->handle;
+} /* create_file */
+
+static struct chimera_vfs_open_handle *
+open_fh(
+    struct test_ctx               *ctx,
+    const struct chimera_vfs_cred *cred,
+    const uint8_t                 *fh,
+    uint32_t                       fh_len)
+{
+    chimera_vfs_open_fh(ctx->vfs_thread, cred, fh, fh_len,
+                        CHIMERA_VFS_OPEN_INFERRED, openfh_cb, ctx);
+    wait_done(ctx);
+    assert(ctx->status == CHIMERA_VFS_OK);
+    return ctx->handle;
+} /* open_fh */
+
+static void
+write_data(
+    struct test_ctx                *ctx,
+    const struct chimera_vfs_cred  *cred,
+    struct chimera_vfs_open_handle *h,
+    uint64_t                        offset,
+    const uint8_t                  *buf,
+    uint32_t                        len)
+{
+    struct evpl_iovec iov;
+    int               niov;
+
+    niov = evpl_iovec_alloc(ctx->evpl, len, 0, 1, 0, &iov);
+    assert(niov == 1);
+    memcpy(iov.data, buf, len);
+
+    chimera_vfs_write(ctx->vfs_thread, cred, h, offset, len, 1, 0, 0,
+                      &iov, 1, write_cb, ctx);
+    wait_done(ctx);
+    assert(ctx->status == CHIMERA_VFS_OK);
+
+    /* memfs takes its own (SHARED) reference into the block buffers, so drop
+     * the caller's reference on the staged write iovec. */
+    evpl_iovec_release(ctx->evpl, &iov);
+} /* write_data */
+
+#define READ_MAX_IOV 64
+
+static void
+read_verify(
+    struct test_ctx                *ctx,
+    const struct chimera_vfs_cred  *cred,
+    struct chimera_vfs_open_handle *h,
+    uint32_t                        len,
+    const uint8_t                  *expect)
+{
+    /* memfs read fills a caller-provided descriptor array with one zero-copy
+     * iovec per block (so niov must cover every block the range spans). */
+    struct evpl_iovec iov[READ_MAX_IOV];
+
+    ctx->expect     = expect;
+    ctx->expect_len = len;
+
+    chimera_vfs_read(ctx->vfs_thread, cred, h, 0, len, iov, READ_MAX_IOV, 0,
+                     read_cb, ctx);
+    wait_done(ctx);
+    assert(ctx->status == CHIMERA_VFS_OK);
+    assert(ctx->verify_ok);
+} /* read_verify */
+
+static void
+clone(
+    struct test_ctx                *ctx,
+    const struct chimera_vfs_cred  *cred,
+    struct chimera_vfs_open_handle *src,
+    uint64_t                        src_off,
+    struct chimera_vfs_open_handle *dst,
+    uint64_t                        dst_off,
+    uint64_t                        len)
+{
+    chimera_vfs_clone_range(ctx->vfs_thread, cred, src, src_off, dst, dst_off,
+                            len, 0, 0, clone_cb, ctx);
+    wait_done(ctx);
+    assert(ctx->status == CHIMERA_VFS_OK);
+} /* clone */
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    struct test_ctx                 ctx = { 0 };
+    struct chimera_vfs_module_cfg   module_cfgs[2];
+    struct prometheus_metrics      *metrics;
+    struct chimera_vfs_cred         cred;
+    uint8_t                         root_fh[CHIMERA_VFS_FH_SIZE];
+    uint32_t                        root_fh_len;
+    uint8_t                         src_fh[CHIMERA_VFS_FH_SIZE], dst_fh[CHIMERA_VFS_FH_SIZE];
+    uint32_t                        src_fh_len, dst_fh_len;
+    struct chimera_vfs_open_handle *root_handle, *src_h, *dst_h;
+    uint8_t                        *pat_a, *pat_b, *expect;
+
+    chimera_log_init();
+    chimera_vfs_cred_init_unix(&cred, 0, 0, 0, NULL);
+
+    metrics = prometheus_metrics_create(NULL, NULL, 0);
+    assert(metrics != NULL);
+
+    memset(module_cfgs, 0, sizeof(module_cfgs));
+    strncpy(module_cfgs[0].module_name, "memfs", sizeof(module_cfgs[0].module_name) - 1);
+    strncpy(module_cfgs[1].module_name, "memkv", sizeof(module_cfgs[1].module_name) - 1);
+
+    ctx.evpl = evpl_create(NULL);
+    assert(ctx.evpl != NULL);
+
+    ctx.vfs = chimera_vfs_init(0, 0, module_cfgs, 2, "memkv", 60, 0, metrics);
+    assert(ctx.vfs != NULL);
+
+    ctx.vfs_thread = chimera_vfs_thread_init(ctx.evpl, ctx.vfs);
+    assert(ctx.vfs_thread != NULL);
+
+    chimera_vfs_mount(ctx.vfs_thread, NULL, "/test", "memfs", "/", NULL,
+                      mount_cb, &ctx);
+    wait_done(&ctx);
+    assert(ctx.status == CHIMERA_VFS_OK);
+
+    chimera_vfs_get_root_fh(root_fh, &root_fh_len);
+    chimera_vfs_lookup(ctx.vfs_thread, &cred, root_fh, root_fh_len, "test", 4,
+                       CHIMERA_VFS_ATTR_FH | CHIMERA_VFS_ATTR_MASK_STAT, 0,
+                       lookup_cb, &ctx);
+    wait_done(&ctx);
+    assert(ctx.status == CHIMERA_VFS_OK);
+    memcpy(root_fh, ctx.fh, ctx.fh_len);
+    root_fh_len = ctx.fh_len;
+
+    root_handle = open_fh(&ctx, &cred, root_fh, root_fh_len);
+
+    src_h = create_file(&ctx, &cred, root_handle, "src");
+    memcpy(src_fh, ctx.fh, ctx.fh_len);
+    src_fh_len = ctx.fh_len;
+    dst_h      = create_file(&ctx, &cred, root_handle, "dst");
+    memcpy(dst_fh, ctx.fh, ctx.fh_len);
+    dst_fh_len = ctx.fh_len;
+
+    /* Distinct byte patterns so a mis-copied byte is visible. */
+    pat_a  = malloc(FILESIZE);
+    pat_b  = malloc(FILESIZE);
+    expect = malloc(FILESIZE);
+    for (int i = 0; i < FILESIZE; i++) {
+        pat_a[i] = (uint8_t) (i * 7 + 1);
+        pat_b[i] = (uint8_t) (i * 3 + 200);
+    }
+
+    write_data(&ctx, &cred, src_h, 0, pat_a, FILESIZE);
+    write_data(&ctx, &cred, dst_h, 0, pat_b, FILESIZE);
+
+    /* Sanity: write+read roundtrip before any clone. */
+    read_verify(&ctx, &cred, src_h, FILESIZE, pat_a);
+    read_verify(&ctx, &cred, dst_h, FILESIZE, pat_b);
+    TEST_PASS("write/read roundtrip");
+
+    /* 1. Whole-block clone (CoW share fast path): src[0..64K) -> dst[0..64K). */
+    clone(&ctx, &cred, src_h, 0, dst_h, 0, BLOCK);
+    memcpy(expect, pat_a, BLOCK);              /* cloned */
+    memcpy(expect + BLOCK, pat_b + BLOCK, FILESIZE - BLOCK); /* preserved */
+    read_verify(&ctx, &cred, dst_h, FILESIZE, expect);
+    TEST_PASS("whole internal-block clone shares CoW and preserves the tail");
+
+    /* 2. Sub-block, non-zero offset clone (read-modify-write path):
+     *    src[4K..12K) -> dst[68K..76K).  4 KiB aligned, well inside block 1. */
+    clone(&ctx, &cred, src_h, 4 * 1024, dst_h, 68 * 1024, 8 * 1024);
+    memcpy(expect + 68 * 1024, pat_a + 4 * 1024, 8 * 1024); /* cloned slice */
+    read_verify(&ctx, &cred, dst_h, FILESIZE, expect);
+    TEST_PASS("sub-block 4K-aligned clone RMWs and preserves both edges");
+
+    /* 3. Clone straddling the internal-block boundary (partial both sides):
+     *    src[60K..68K) -> dst[60K..68K). */
+    clone(&ctx, &cred, src_h, 60 * 1024, dst_h, 60 * 1024, 8 * 1024);
+    memcpy(expect + 60 * 1024, pat_a + 60 * 1024, 8 * 1024);
+    read_verify(&ctx, &cred, dst_h, FILESIZE, expect);
+    TEST_PASS("clone straddling the internal-block boundary RMWs correctly");
+
+    /* 4. Misaligned offset/length must be rejected (POSIX FICLONERANGE). */
+    chimera_vfs_clone_range(ctx.vfs_thread, &cred, src_h, 100, dst_h, 0, 4096,
+                            0, 0, clone_cb, &ctx);
+    wait_done(&ctx);
+    assert(ctx.status == CHIMERA_VFS_EINVAL);
+    TEST_PASS("sub-cluster (non-4K-aligned) clone is rejected with EINVAL");
+
+    chimera_vfs_release(ctx.vfs_thread, src_h);
+    chimera_vfs_release(ctx.vfs_thread, dst_h);
+
+    /* Unlink the files so their (and the CoW-shared) block buffers are freed
+     * before the module is torn down -- keeps LeakSanitizer quiet. */
+    chimera_vfs_remove_at(ctx.vfs_thread, &cred, root_handle, "src", 3,
+                          src_fh, src_fh_len, 0, 0, NULL, remove_cb, &ctx);
+    wait_done(&ctx);
+    assert(ctx.status == CHIMERA_VFS_OK);
+    chimera_vfs_remove_at(ctx.vfs_thread, &cred, root_handle, "dst", 3,
+                          dst_fh, dst_fh_len, 0, 0, NULL, remove_cb, &ctx);
+    wait_done(&ctx);
+    assert(ctx.status == CHIMERA_VFS_OK);
+    chimera_vfs_release(ctx.vfs_thread, root_handle);
+
+    free(pat_a);
+    free(pat_b);
+    free(expect);
+
+    chimera_vfs_thread_destroy(ctx.vfs_thread);
+    chimera_vfs_destroy(ctx.vfs);
+    evpl_destroy(ctx.evpl);
+    prometheus_metrics_destroy(metrics);
+
+    fprintf(stderr, "All memfs clone_range tests passed!\n");
+    return 0;
+} /* main */


### PR DESCRIPTION
## Problem

The SMB2 CREATE response carries a `create_action` field telling the client whether the open **created** a new file (`FILE_CREATED`) or opened an existing one (`FILE_OPENED` / `OVERWRITTEN` / `SUPERSEDED`). The SMB server derives this from the VFS open's `r_created` flag.

`memfs`, `cairn`, and `diskfs` all set `open_at.r_created` when an open creates a file — but the **linux** and **io_uring** passthrough backends never did, because `openat(2)` does not report whether it created the file. So every create on those backends reported `FILE_OPENED`.

This was the single largest failure family in a full smbtorture sweep: **169 subtests on each of linux and io_uring** failed the `create_action` check (the dominant `got 1 (0x1), expected 2 (0x2)`), across the `durable-open`, `durable-v2-open`, `replay`, `multichannel`, and `lease` suites.

## Fix

Detect creation race-free with an **O_EXCL probe**: for a non-exclusive create, open with `O_EXCL` added first — success means we created the file; `EEXIST` means it already existed, so re-open without `O_EXCL` (the base flags still carry `O_TRUNC` for `OVERWRITE_IF`/`SUPERSEDE`). The existing-file path is byte-for-byte identical to before; only the create-detection is new.

- **linux**: inline (synchronous `openat`).
- **io_uring**: threaded through the async SQE chain. The flag computation is factored into a pure helper so the `EEXIST` re-open recomputes identical flags without stashing state, and the post-open work (set attrs + child/parent `statx`) is shared by the initial open and the re-open. The chain now uses a fourth request-handle slot, so `CHIMERA_VFS_REQUEST_MAX_HANDLES` grows 3 → 4.

## Tests enabled

263 previously-disabled subtests now pass and are enabled (**131 linux + 132 io_uring**), each confirmed stable 3×. Two flaky outliers were left disabled (`linux durable-open.open2-lease`, `io_uring dir.large-files`). The allowlist was regenerated with `tools/smbtorture/regen.py`; the other four backends' allowlists and `SMBTORTURE_DISABLED_SUBTESTS` are unchanged.

## Verification

- linux + io_uring smbtorture ctests: **759/759 pass** (newly-enabled green, zero regressions on previously-enabled).
- Unit suite (Debug/ASan): 122/122.
- `scan-build`: No bugs found. Release `-Werror`: clean.
- io_uring async change exercised under ASan via the durable/replay suites.
