### PR TITLE
io_uring: surface symlink leaf on OPEN_INFERRED; enable pjdfstest NFS over all backends

### DIFF
--- a/src/posix/tests/CMakeLists.txt
+++ b/src/posix/tests/CMakeLists.txt
@@ -1191,9 +1191,30 @@ foreach(t ${PJD_TESTS})
     if(CHIMERA_VFS_IO_URING)
         add_pjd_test(${t} io_uring)
     endif()
-    # NFS backends (Chimera NFS server + client over loopback, memfs export).
+    # NFS backends (Chimera NFS server + client over loopback).  Run pjdfstest
+    # over the NFS server against every VFS backend (gated like the direct-backend
+    # registrations above), not just memfs, to exercise the server<->backend open
+    # path on each store.
     add_pjd_nfs_test(${t} nfs3_memfs)
     add_pjd_nfs_test(${t} nfs4_memfs)
+    if(CAIRN_ENABLED)
+        add_pjd_nfs_test(${t} nfs3_cairn)
+        add_pjd_nfs_test(${t} nfs4_cairn)
+    endif()
+    if(IO_URING_ENABLED)
+        add_pjd_nfs_test(${t} nfs3_diskfs_io_uring)
+        add_pjd_nfs_test(${t} nfs4_diskfs_io_uring)
+    endif()
+    if(HAVE_LIBAIO)
+        add_pjd_nfs_test(${t} nfs3_diskfs_aio)
+        add_pjd_nfs_test(${t} nfs4_diskfs_aio)
+    endif()
+    add_pjd_nfs_test(${t} nfs3_linux)
+    add_pjd_nfs_test(${t} nfs4_linux)
+    if(CHIMERA_VFS_IO_URING)
+        add_pjd_nfs_test(${t} nfs3_io_uring)
+        add_pjd_nfs_test(${t} nfs4_io_uring)
+    endif()
 endforeach()
 
 # Tag the non-pjd tests with the 'posix' label so that suite can be run

--- a/src/vfs/io_uring/io_uring.c
+++ b/src/vfs/io_uring/io_uring.c
@@ -433,7 +433,18 @@ chimera_io_uring_reap(
                                                 AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW | AT_STATX_SYNC_AS_STAT,
                                                 CHIMERA_IO_URING_STATX_MASK, stx);
                         } else {
-                            io_uring_prep_statx(sqe, parent_fd, name, AT_STATX_SYNC_AS_STAT,
+                            /* Stat the child by name with AT_SYMLINK_NOFOLLOW so a
+                             * symlink leaf reports its own S_IFLNK attrs even though
+                             * the openat() above followed it to the target.  An
+                             * OPEN_INFERRED open by name (e.g. the NFS server opening
+                             * an OPEN target directly) must surface the symlink to the
+                             * server -- which maps !S_ISREG to NFS4ERR_SYMLINK -> ELOOP
+                             * -- rather than silently following it.  The linux backend
+                             * does the same via fstatat(..., AT_SYMLINK_NOFOLLOW).
+                             * For a regular file or an already-resolved leaf this flag
+                             * is a no-op. */
+                            io_uring_prep_statx(sqe, parent_fd, name,
+                                                AT_SYMLINK_NOFOLLOW | AT_STATX_SYNC_AS_STAT,
                                                 CHIMERA_IO_URING_STATX_MASK, stx);
                         }
 


### PR DESCRIPTION
## Summary

Two related changes in one PR.

### 1. io_uring backend: surface a symlink leaf on an OPEN_INFERRED open

pjdfstest **open/16** (open an existing symlink with `O_NOFOLLOW` must return **ELOOP**) failed *only* on `nfs3_io_uring` / `nfs4_io_uring`. It already passed on direct `io_uring`, `nfs{3,4}_memfs`, and `nfs{3,4}_linux`.

Root cause: the chimera NFS server opens an OPEN target by name via `chimera_vfs_open_at(..., CHIMERA_VFS_OPEN_INFERRED, ...)` (no `O_NOFOLLOW`) and then decides "target is a symlink" purely from the returned `r_attr` mode (`!S_ISREG` -> `NFS4ERR_SYMLINK`, which the client maps to ELOOP). In the io_uring backend's `open_at` completion, the non-NOFOLLOW path stat'd the child *by name without* `AT_SYMLINK_NOFOLLOW`, so for a symlink leaf it reported the *followed target's* `S_IFREG` attrs. The server therefore saw a regular file, opened the target, and succeeded — the client never got ELOOP.

Fix: add `AT_SYMLINK_NOFOLLOW` to that child statx so the symlink's own `S_IFLNK` attrs are reported to the server, exactly mirroring the linux passthrough backend (`chimera_linux_map_child_attrs` uses `fstatat(..., AT_SYMLINK_NOFOLLOW)`). The `openat()` still follows the link; only the attrs reported back change. For a regular file or an already-resolved leaf the flag is a no-op, so the direct posix open path and regular-file opens are unaffected. The `O_NOFOLLOW` and `O_PATH|O_NOFOLLOW` (SMB reparse) branches are untouched, and `open_fh` already had the matching ESYMLINK probe.

### 2. Enable pjdfstest over NFS for all non-memfs backends

The pjd `foreach` loop registered NFS variants only on memfs. This adds nfs3 and nfs4 registrations over each non-memfs backend — `cairn` (CAIRN_ENABLED), `diskfs_io_uring` (IO_URING_ENABLED), `diskfs_aio` (HAVE_LIBAIO), `linux` (always), `io_uring` (CHIMERA_VFS_IO_URING) — gated to match the rest of the file, using the existing `add_pjd_nfs_test` macro (120s timeout).

### Verification
- open/16: now 0 failures on nfs3_io_uring, nfs4_io_uring, and still on io_uring / nfs{3,4}_memfs / nfs4_linux / linux.
- Full 139-test pjd suite: 139/139 on direct io_uring, nfs3_io_uring, and nfs4_io_uring.
- `ctest -L pjdfstest -R '/nfs[34]_(cairn|diskfs_io_uring|diskfs_aio|linux|io_uring)$' -j8`: **1390/1390 pass** (5 backends × {nfs3,nfs4} × 139).

### CI cost
This adds roughly **8 × 139 ≈ 1112** new pjdfstest cells (cairn/diskfs_io_uring/diskfs_aio/linux/io_uring × nfs3+nfs4, minus the memfs pair already present), flagged for awareness of the added CI runtime.