### PR TITLE
vfs: enforce sticky-bit owner rule on rename; enable rename/09,10

### DIFF
--- a/src/posix/tests/CMakeLists.txt
+++ b/src/posix/tests/CMakeLists.txt
@@ -1111,6 +1111,8 @@ set(PJD_TESTS
     rename/03
     rename/04
     rename/05
+    rename/09
+    rename/10
     rename/11
     rename/12
     rename/13

--- a/src/posix/tests/pjd/rename/09.c
+++ b/src/posix/tests/pjd/rename/09.c
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
+
+/* Ported from pjdfstest tests/rename/09.t: when the directory containing the
+ * 'from' name is marked sticky (S_ISVTX), a non-super-user may rename the entry
+ * only if it owns the sticky directory or the source object; otherwise EACCES
+ * (or EPERM).  This is a representative subset of the upstream type x owner
+ * matrix -- enough to cover every ownership outcome across a few object types. */
+#include "../../pjd_common.h"
+#include <sys/stat.h>
+
+#define U 65534   /* the unprivileged actor */
+#define O 65533   /* some other unprivileged owner */
+
+static char *n0, *n1;   /* sticky source dir, world-writable dest dir */
+
+/* Attempt, as user U, to rename a `type` object owned by file_uid out of the
+ * sticky source dir n0 (owned by dir_uid) into the dest dir n1.  expect_ok
+ * selects success vs an EACCES/EPERM denial. */
+static void
+try_one(
+    enum pjd_ftype type,
+    uid_t          dir_uid,
+    uid_t          file_uid,
+    int            expect_ok)
+{
+    char src[256], dst[256];
+
+    snprintf(src, sizeof(src), "%s/f", n0);
+    snprintf(dst, sizeof(dst), "%s/g", n1);
+
+    EXPECT(0, pjd_chown(n0, dir_uid, dir_uid));
+    EXPECT(0, pjd_create_file_owned(type, src, file_uid, file_uid));
+
+    pjd_set_user(U, U);
+    int e = pjd_rename(src, dst) < 0 ? errno : 0;
+    pjd_set_root();
+
+    if (expect_ok) {
+        PJD_CHECK(e == 0, "rename(dir=%d,file=%d,%d) -> %s (want ok)",
+                  dir_uid, file_uid, type, strerror(e));
+    } else {
+        PJD_CHECK(e == EACCES || e == EPERM,
+                  "rename(dir=%d,file=%d,%d) -> %s (want EACCES/EPERM)",
+                  dir_uid, file_uid, type, strerror(e));
+    }
+
+    /* Clean up whichever location the object ended in (as root). */
+    if (pjd_remove_file(type, src) != 0) {
+        (void) pjd_remove_file(type, dst);
+    }
+} /* try_one */
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *base = pjd_namegen();
+    n0 = pjd_namegen();
+    n1 = pjd_namegen();
+
+    EXPECT(0, pjd_mkdir(base, 0755));
+    pjd_cd(base);
+
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    EXPECT(0, pjd_chmod(n0, 01777));   /* sticky source dir */
+    EXPECT(0, pjd_mkdir(n1, 0777));    /* dest: world-writable, non-sticky */
+
+    /* Owner matrix on a regular file: only "owns neither" is denied. */
+    try_one(PJD_FT_REGULAR, U, U, 1);   /* owns dir and file       */
+    try_one(PJD_FT_REGULAR, U, O, 1);   /* owns the sticky dir     */
+    try_one(PJD_FT_REGULAR, O, U, 1);   /* owns the source object  */
+    try_one(PJD_FT_REGULAR, O, O, 0);   /* owns neither -> denied  */
+
+    /* The deny rule is independent of object type. */
+    try_one(PJD_FT_FIFO, O, O, 0);
+    try_one(PJD_FT_SYMLINK, O, O, 0);
+    try_one(PJD_FT_DIR, O, O, 0);
+    /* ...and an owned object of another type still renames. */
+    try_one(PJD_FT_FIFO, O, U, 1);
+
+    EXPECT(0, pjd_rmdir(n0));
+    EXPECT(0, pjd_rmdir(n1));
+    pjd_cd("..");
+    EXPECT(0, pjd_rmdir(base));
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/rename/10.c
+++ b/src/posix/tests/pjd/rename/10.c
@@ -1,0 +1,94 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
+
+/* Ported from pjdfstest tests/rename/10.t: when the 'to' name exists and the
+ * directory containing it is marked sticky (S_ISVTX), a non-super-user may
+ * replace it by rename only if it owns the sticky directory or the existing
+ * 'to' object; otherwise EACCES (or EPERM).  Representative subset of the
+ * upstream type x owner matrix. */
+#include "../../pjd_common.h"
+#include <sys/stat.h>
+
+#define U 65534   /* the unprivileged actor */
+#define O 65533   /* some other unprivileged owner */
+
+static char *n0, *n1;   /* world-writable source dir, sticky dest dir */
+
+/* As user U, rename a U-owned source object out of n0 over an existing `type`
+ * 'to' object (owned by to_uid) in the sticky dest dir n1 (owned by dir_uid). */
+static void
+try_one(
+    enum pjd_ftype type,
+    uid_t          dir_uid,
+    uid_t          to_uid,
+    int            expect_ok)
+{
+    char src[256], dst[256];
+
+    snprintf(src, sizeof(src), "%s/f", n0);
+    snprintf(dst, sizeof(dst), "%s/g", n1);
+
+    EXPECT(0, pjd_chown(n1, dir_uid, dir_uid));
+    EXPECT(0, pjd_create_file_owned(type, src, U, U));        /* source: owned by U */
+    EXPECT(0, pjd_create_file_owned(type, dst, to_uid, to_uid)); /* existing 'to'   */
+
+    pjd_set_user(U, U);
+    int e = pjd_rename(src, dst) < 0 ? errno : 0;
+    pjd_set_root();
+
+    if (expect_ok) {
+        PJD_CHECK(e == 0, "rename(todir=%d,to=%d,%d) -> %s (want ok)",
+                  dir_uid, to_uid, type, strerror(e));
+    } else {
+        PJD_CHECK(e == EACCES || e == EPERM,
+                  "rename(todir=%d,to=%d,%d) -> %s (want EACCES/EPERM)",
+                  dir_uid, to_uid, type, strerror(e));
+    }
+
+    /* Clean up: on success only the moved object remains at dst; on denial both
+     * src and the original dst remain. */
+    (void) pjd_remove_file(type, src);
+    (void) pjd_remove_file(type, dst);
+} /* try_one */
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+    char *base = pjd_namegen();
+    n0 = pjd_namegen();
+    n1 = pjd_namegen();
+
+    EXPECT(0, pjd_mkdir(base, 0755));
+    pjd_cd(base);
+
+    EXPECT(0, pjd_mkdir(n0, 0777));    /* source: world-writable, non-sticky */
+    EXPECT(0, pjd_mkdir(n1, 0755));
+    EXPECT(0, pjd_chmod(n1, 01777));   /* sticky dest dir */
+
+    /* Owner matrix on a regular 'to': only "owns neither" is denied. */
+    try_one(PJD_FT_REGULAR, U, U, 1);   /* owns dest dir and 'to'   */
+    try_one(PJD_FT_REGULAR, U, O, 1);   /* owns the sticky dest dir */
+    try_one(PJD_FT_REGULAR, O, U, 1);   /* owns the 'to' object     */
+    try_one(PJD_FT_REGULAR, O, O, 0);   /* owns neither -> denied   */
+
+    /* Independent of the 'to' object type. */
+    try_one(PJD_FT_FIFO, O, O, 0);
+    try_one(PJD_FT_SYMLINK, O, O, 0);
+
+    EXPECT(0, pjd_rmdir(n0));
+    EXPECT(0, pjd_rmdir(n1));
+    pjd_cd("..");
+    EXPECT(0, pjd_rmdir(base));
+    return pjd_end();
+} /* main */

--- a/src/vfs/vfs_proc_rename_at.c
+++ b/src/vfs/vfs_proc_rename_at.c
@@ -280,18 +280,19 @@ chimera_vfs_rename_at_dispatch(
 } /* chimera_vfs_rename_at_dispatch */
 
 /*
- * Enforcement pre-step context for rename.  Three chained checks on
+ * Enforcement pre-step context for rename.  Chained checks on
  * engine-authoritative backends:
- *   1. DELETE_CHILD on the source directory (remove the old name).
- *   2. ADD_FILE on the destination directory (create the new name).
- *   3. if an existing name is being replaced, delete_allowed on it.
+ *   1. delete_allowed on the source name (DELETE_CHILD on the source directory
+ *      or DELETE on the source object, plus the POSIX sticky-bit owner rule).
+ *      The source object's FH is resolved up front with a LOOKUP so the sticky
+ *      owner check can run -- a sticky source directory (e.g. /tmp) only lets a
+ *      non-owner rename an entry it owns.
+ *   2. ADD_FILE/WRITE_DATA on the destination directory (create the new name).
+ *   3. if an existing name is being replaced, delete_allowed on it (which also
+ *      applies the sticky-bit rule to the destination directory).
  *
- * Limitation: the VFS rename signature does not carry the source object's FH,
- * so the POSIX sticky-bit owner check on the *source* directory cannot be
- * evaluated here (we authorize source removal by DELETE_CHILD alone).  This
- * only under-enforces world-writable sticky source directories; tracked as a
- * follow-up.  Likewise renaming a subdirectory is authorized via WRITE_DATA
- * rather than distinguishing APPEND_DATA on the destination.
+ * Note: renaming a subdirectory is authorized via WRITE_DATA rather than
+ * distinguishing APPEND_DATA on the destination.
  */
 struct chimera_vfs_rename_at_gate {
     struct chimera_vfs_thread       *thread;
@@ -306,6 +307,8 @@ struct chimera_vfs_rename_at_gate {
     int                              new_namelen;
     const uint8_t                   *target_fh;
     int                              target_fh_len;
+    uint8_t                          src_child_fh[CHIMERA_VFS_FH_SIZE];
+    int                              src_child_fh_len;
     uint64_t                         pre_attr_mask;
     uint64_t                         post_attr_mask;
     uint8_t                          parent_lease_skip[16];
@@ -397,6 +400,40 @@ chimera_vfs_rename_at_gate_src(
                         chimera_vfs_rename_at_gate_dst, gate);
 } /* chimera_vfs_rename_at_gate_src */
 
+/* Source name resolved -> authorize its removal (delete_allowed: DELETE_CHILD
+ * on the source dir or DELETE on the object, plus the sticky-bit owner rule). */
+static void
+chimera_vfs_rename_at_gate_lookup(
+    enum chimera_vfs_error    status,
+    struct chimera_vfs_attrs *attr,
+    void                     *private_data)
+{
+    struct chimera_vfs_rename_at_gate *gate = private_data;
+
+    if (status != CHIMERA_VFS_OK) {
+        chimera_vfs_rename_at_gate_fail(gate, status);
+        return;
+    }
+
+    if ((attr->va_set_mask & CHIMERA_VFS_ATTR_FH) &&
+        attr->va_fh_len > 0 && attr->va_fh_len <= CHIMERA_VFS_FH_SIZE) {
+        memcpy(gate->src_child_fh, attr->va_fh, attr->va_fh_len);
+        gate->src_child_fh_len = attr->va_fh_len;
+
+        chimera_vfs_gate_delete(gate->thread, gate->cred,
+                                gate->fh, gate->fhlen,
+                                gate->src_child_fh, gate->src_child_fh_len,
+                                chimera_vfs_rename_at_gate_src, gate);
+        return;
+    }
+
+    /* No FH resolved: fall back to DELETE_CHILD on the source directory alone
+     * (sticky owner check needs the object's attrs). */
+    chimera_vfs_gate_fh(gate->thread, gate->cred, gate->fh, gate->fhlen,
+                        CHIMERA_ACE_DELETE_CHILD,
+                        chimera_vfs_rename_at_gate_src, gate);
+} /* chimera_vfs_rename_at_gate_lookup */
+
 SYMBOL_EXPORT void
 chimera_vfs_rename_at(
     struct chimera_vfs_thread       *thread,
@@ -460,12 +497,17 @@ chimera_vfs_rename_at(
         } else {
             gate->parent_lease_skip_valid = 0;
         }
-        gate->op_handle    = op_handle;
-        gate->callback     = callback;
-        gate->private_data = private_data;
+        gate->op_handle        = op_handle;
+        gate->callback         = callback;
+        gate->private_data     = private_data;
+        gate->src_child_fh_len = 0;
 
-        chimera_vfs_gate_fh(thread, cred, fh, fhlen, CHIMERA_ACE_DELETE_CHILD,
-                            chimera_vfs_rename_at_gate_src, gate);
+        /* Resolve the source object's FH first so the sticky-bit owner check on
+         * the source directory can be evaluated (no-follow: rename operates on
+         * the name itself). */
+        chimera_vfs_lookup(thread, cred, fh, fhlen, name, namelen,
+                           CHIMERA_VFS_ATTR_FH, 0,
+                           chimera_vfs_rename_at_gate_lookup, gate);
         return;
     }
 


### PR DESCRIPTION
The rename authorization gate (`vfs_proc_rename_at.c`) checked `DELETE_CHILD` on the source directory but **not the POSIX sticky-bit (S_ISVTX) owner rule** — a limitation the code itself documented. So in a world-writable sticky source directory (e.g. `/tmp`), a non-owner could rename an entry it didn't own.

**Fix:** resolve the source object's FH up front with a LOOKUP and authorize source removal via `chimera_vfs_delete_allowed` — the same `DELETE_CHILD`-or-`DELETE` + sticky-owner check already used by unlink/rmdir — instead of a bare `DELETE_CHILD` gate. A sticky source directory now lets a non-super-user rename an entry only when it owns the directory or the source object. The destination sticky rule (replacing an existing `to`) was already covered by the replaced-target `delete_allowed` step. Non-sticky directories are unaffected (the rule only adds a constraint when S_ISVTX is set).

**Tests:** ports `rename/09` (sticky source dir) and `rename/10` (sticky dest dir) as representative subsets of the upstream owner×type matrix, and registers them — **green on all 18 backend combos**.

**Verification:** full pjd suite 2538/2538 and pynfs 1383/1383 (no regressions from the shared rename-gate change). scan-build/reuse/syntax clean.

Note: the gate now does one extra LOOKUP per gated rename to resolve the source FH for the owner check.