### PR TITLE
smb2/tests: iptables transport blocking + enable 80 lease/replay/oplock/multichannel tests

### DIFF
--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -1384,7 +1384,10 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.multichannel.bugs.bug_15346
     smb2.multichannel.generic.interface_info
     smb2.multichannel.generic.num_channels
+    smb2.multichannel.leases.test1
+    smb2.multichannel.leases.test3
     smb2.multichannel.oplocks.test1
+    smb2.multichannel.oplocks.test2
     # smb2.notify-inotify
     smb2.notify-inotify.inotify-rename
     # smb2.notify
@@ -1470,6 +1473,12 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.replay.dhv2-pending1n-vs-oplock-sane
     smb2.replay.dhv2-pending1o-vs-lease-sane
     smb2.replay.dhv2-pending1o-vs-oplock-sane
+    smb2.replay.dhv2-pending3l-vs-lease-sane
+    smb2.replay.dhv2-pending3l-vs-oplock-sane
+    smb2.replay.dhv2-pending3n-vs-lease-sane
+    smb2.replay.dhv2-pending3n-vs-oplock-sane
+    smb2.replay.dhv2-pending3o-vs-lease-sane
+    smb2.replay.dhv2-pending3o-vs-oplock-sane
     smb2.replay.durable-reconnect-replay1
     smb2.replay.durable-reconnect-replay2
     smb2.replay.durable-reconnect-replay3
@@ -1480,6 +1489,8 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.replay.replay-dhv2-lease3
     smb2.replay.replay-dhv2-oplock-lease
     smb2.replay.replay-dhv2-oplock1
+    smb2.replay.replay-dhv2-oplock2
+    smb2.replay.replay-dhv2-oplock3
     smb2.replay.replay-regular
     smb2.replay.replay-twice-durable
     smb2.replay.replay3
@@ -1930,6 +1941,7 @@ set(SMBTORTURE_ENABLED_linux
     smb2.multichannel.leases.test1
     smb2.multichannel.leases.test3
     smb2.multichannel.oplocks.test1
+    smb2.multichannel.oplocks.test2
     # smb2.notify-inotify
     smb2.notify-inotify.inotify-rename
     # smb2.notify
@@ -2013,6 +2025,12 @@ set(SMBTORTURE_ENABLED_linux
     smb2.replay.dhv2-pending1n-vs-oplock-sane
     smb2.replay.dhv2-pending1o-vs-lease-sane
     smb2.replay.dhv2-pending1o-vs-oplock-sane
+    smb2.replay.dhv2-pending3l-vs-lease-sane
+    smb2.replay.dhv2-pending3l-vs-oplock-sane
+    smb2.replay.dhv2-pending3n-vs-lease-sane
+    smb2.replay.dhv2-pending3n-vs-oplock-sane
+    smb2.replay.dhv2-pending3o-vs-lease-sane
+    smb2.replay.dhv2-pending3o-vs-oplock-sane
     smb2.replay.durable-reconnect-replay1
     smb2.replay.durable-reconnect-replay2
     smb2.replay.durable-reconnect-replay3
@@ -2445,6 +2463,7 @@ set(SMBTORTURE_ENABLED_io_uring
     smb2.multichannel.leases.test1
     smb2.multichannel.leases.test3
     smb2.multichannel.oplocks.test1
+    smb2.multichannel.oplocks.test2
     # smb2.notify-inotify
     smb2.notify-inotify.inotify-rename
     # smb2.notify
@@ -2528,6 +2547,12 @@ set(SMBTORTURE_ENABLED_io_uring
     smb2.replay.dhv2-pending1n-vs-oplock-sane
     smb2.replay.dhv2-pending1o-vs-lease-sane
     smb2.replay.dhv2-pending1o-vs-oplock-sane
+    smb2.replay.dhv2-pending3l-vs-lease-sane
+    smb2.replay.dhv2-pending3l-vs-oplock-sane
+    smb2.replay.dhv2-pending3n-vs-lease-sane
+    smb2.replay.dhv2-pending3n-vs-oplock-sane
+    smb2.replay.dhv2-pending3o-vs-lease-sane
+    smb2.replay.dhv2-pending3o-vs-oplock-sane
     smb2.replay.durable-reconnect-replay1
     smb2.replay.durable-reconnect-replay2
     smb2.replay.durable-reconnect-replay3
@@ -2914,13 +2939,18 @@ set(SMBTORTURE_ENABLED_cairn
     smb2.lease.complex1
     smb2.lease.duplicate_create
     smb2.lease.duplicate_open
+    smb2.lease.initial_delete_disconnect
+    smb2.lease.initial_delete_logoff
+    smb2.lease.initial_delete_tdis
     smb2.lease.multibreak
     smb2.lease.nobreakself
+    smb2.lease.oplock
     smb2.lease.rename_wait
     smb2.lease.statopen
     smb2.lease.statopen2
     smb2.lease.statopen3
     smb2.lease.statopen4
+    smb2.lease.unlink
     smb2.lease.upgrade
     smb2.lease.upgrade2
     smb2.lease.upgrade3
@@ -2972,7 +3002,10 @@ set(SMBTORTURE_ENABLED_cairn
     smb2.multichannel.bugs.bug_15346
     smb2.multichannel.generic.interface_info
     smb2.multichannel.generic.num_channels
+    smb2.multichannel.leases.test1
+    smb2.multichannel.leases.test3
     smb2.multichannel.oplocks.test1
+    smb2.multichannel.oplocks.test2
     # smb2.notify-inotify
     smb2.notify-inotify.inotify-rename
     # smb2.notify
@@ -3006,16 +3039,22 @@ set(SMBTORTURE_ENABLED_cairn
     smb2.oplock.batch14
     smb2.oplock.batch15
     smb2.oplock.batch16
+    smb2.oplock.batch19
     smb2.oplock.batch2
+    smb2.oplock.batch20
     smb2.oplock.batch21
     smb2.oplock.batch23
     smb2.oplock.batch24
     smb2.oplock.batch25
+    smb2.oplock.batch3
     smb2.oplock.batch4
     smb2.oplock.batch5
     smb2.oplock.batch6
+    smb2.oplock.batch7
     smb2.oplock.batch8
+    smb2.oplock.brl1
     smb2.oplock.brl2
+    smb2.oplock.brl3
     smb2.oplock.exclusive1
     smb2.oplock.exclusive2
     smb2.oplock.exclusive3
@@ -3052,6 +3091,12 @@ set(SMBTORTURE_ENABLED_cairn
     smb2.replay.dhv2-pending1n-vs-oplock-sane
     smb2.replay.dhv2-pending1o-vs-lease-sane
     smb2.replay.dhv2-pending1o-vs-oplock-sane
+    smb2.replay.dhv2-pending3l-vs-lease-sane
+    smb2.replay.dhv2-pending3l-vs-oplock-sane
+    smb2.replay.dhv2-pending3n-vs-lease-sane
+    smb2.replay.dhv2-pending3n-vs-oplock-sane
+    smb2.replay.dhv2-pending3o-vs-lease-sane
+    smb2.replay.dhv2-pending3o-vs-oplock-sane
     smb2.replay.durable-reconnect-replay1
     smb2.replay.durable-reconnect-replay2
     smb2.replay.durable-reconnect-replay3
@@ -3062,6 +3107,8 @@ set(SMBTORTURE_ENABLED_cairn
     smb2.replay.replay-dhv2-lease3
     smb2.replay.replay-dhv2-oplock-lease
     smb2.replay.replay-dhv2-oplock1
+    smb2.replay.replay-dhv2-oplock2
+    smb2.replay.replay-dhv2-oplock3
     smb2.replay.replay-regular
     smb2.replay.replay-twice-durable
     smb2.replay.replay3
@@ -3527,7 +3574,10 @@ set(SMBTORTURE_ENABLED_diskfs_io_uring
     smb2.multichannel.bugs.bug_15346
     smb2.multichannel.generic.interface_info
     smb2.multichannel.generic.num_channels
+    smb2.multichannel.leases.test1
+    smb2.multichannel.leases.test3
     smb2.multichannel.oplocks.test1
+    smb2.multichannel.oplocks.test2
     # smb2.notify-inotify
     smb2.notify-inotify.inotify-rename
     # smb2.notify
@@ -3613,6 +3663,12 @@ set(SMBTORTURE_ENABLED_diskfs_io_uring
     smb2.replay.dhv2-pending1n-vs-oplock-sane
     smb2.replay.dhv2-pending1o-vs-lease-sane
     smb2.replay.dhv2-pending1o-vs-oplock-sane
+    smb2.replay.dhv2-pending3l-vs-lease-sane
+    smb2.replay.dhv2-pending3l-vs-oplock-sane
+    smb2.replay.dhv2-pending3n-vs-lease-sane
+    smb2.replay.dhv2-pending3n-vs-oplock-sane
+    smb2.replay.dhv2-pending3o-vs-lease-sane
+    smb2.replay.dhv2-pending3o-vs-oplock-sane
     smb2.replay.durable-reconnect-replay1
     smb2.replay.durable-reconnect-replay2
     smb2.replay.durable-reconnect-replay3
@@ -3623,6 +3679,8 @@ set(SMBTORTURE_ENABLED_diskfs_io_uring
     smb2.replay.replay-dhv2-lease3
     smb2.replay.replay-dhv2-oplock-lease
     smb2.replay.replay-dhv2-oplock1
+    smb2.replay.replay-dhv2-oplock2
+    smb2.replay.replay-dhv2-oplock3
     smb2.replay.replay-regular
     smb2.replay.replay-twice-durable
     smb2.replay.replay3
@@ -4022,13 +4080,18 @@ set(SMBTORTURE_ENABLED_diskfs_aio
     smb2.lease.complex1
     smb2.lease.duplicate_create
     smb2.lease.duplicate_open
+    smb2.lease.initial_delete_disconnect
+    smb2.lease.initial_delete_logoff
+    smb2.lease.initial_delete_tdis
     smb2.lease.multibreak
     smb2.lease.nobreakself
+    smb2.lease.oplock
     smb2.lease.rename_wait
     smb2.lease.statopen
     smb2.lease.statopen2
     smb2.lease.statopen3
     smb2.lease.statopen4
+    smb2.lease.unlink
     smb2.lease.upgrade
     smb2.lease.upgrade2
     smb2.lease.upgrade3
@@ -4080,7 +4143,10 @@ set(SMBTORTURE_ENABLED_diskfs_aio
     smb2.multichannel.bugs.bug_15346
     smb2.multichannel.generic.interface_info
     smb2.multichannel.generic.num_channels
+    smb2.multichannel.leases.test1
+    smb2.multichannel.leases.test3
     smb2.multichannel.oplocks.test1
+    smb2.multichannel.oplocks.test2
     # smb2.notify-inotify
     smb2.notify-inotify.inotify-rename
     # smb2.notify
@@ -4114,16 +4180,22 @@ set(SMBTORTURE_ENABLED_diskfs_aio
     smb2.oplock.batch14
     smb2.oplock.batch15
     smb2.oplock.batch16
+    smb2.oplock.batch19
     smb2.oplock.batch2
+    smb2.oplock.batch20
     smb2.oplock.batch21
     smb2.oplock.batch23
     smb2.oplock.batch24
     smb2.oplock.batch25
+    smb2.oplock.batch3
     smb2.oplock.batch4
     smb2.oplock.batch5
     smb2.oplock.batch6
+    smb2.oplock.batch7
     smb2.oplock.batch8
+    smb2.oplock.brl1
     smb2.oplock.brl2
+    smb2.oplock.brl3
     smb2.oplock.exclusive1
     smb2.oplock.exclusive2
     smb2.oplock.exclusive3
@@ -4160,6 +4232,12 @@ set(SMBTORTURE_ENABLED_diskfs_aio
     smb2.replay.dhv2-pending1n-vs-oplock-sane
     smb2.replay.dhv2-pending1o-vs-lease-sane
     smb2.replay.dhv2-pending1o-vs-oplock-sane
+    smb2.replay.dhv2-pending3l-vs-lease-sane
+    smb2.replay.dhv2-pending3l-vs-oplock-sane
+    smb2.replay.dhv2-pending3n-vs-lease-sane
+    smb2.replay.dhv2-pending3n-vs-oplock-sane
+    smb2.replay.dhv2-pending3o-vs-lease-sane
+    smb2.replay.dhv2-pending3o-vs-oplock-sane
     smb2.replay.durable-reconnect-replay1
     smb2.replay.durable-reconnect-replay2
     smb2.replay.durable-reconnect-replay3
@@ -4170,6 +4248,8 @@ set(SMBTORTURE_ENABLED_diskfs_aio
     smb2.replay.replay-dhv2-lease3
     smb2.replay.replay-dhv2-oplock-lease
     smb2.replay.replay-dhv2-oplock1
+    smb2.replay.replay-dhv2-oplock2
+    smb2.replay.replay-dhv2-oplock3
     smb2.replay.replay-regular
     smb2.replay.replay-twice-durable
     smb2.replay.replay3

--- a/src/server/smb/tests/smbtorture_test.c
+++ b/src/server/smb/tests/smbtorture_test.c
@@ -113,6 +113,15 @@ run_smbtorture(
                    " --option=torture:offset=0"
                    " --option=torture:beyond_final_zero=4096"
                    " --option=torture:acl_xattr_name=user.NTACL"
+                   /* Block a client transport with iptables (the default method
+                    * is an FSCTL_SMBTORTURE control op only Samba implements).
+                    * Tests that need to simulate an unresponsive transport
+                    * (smb2.replay.dhv2-pending3*, multichannel, some oplock/lease)
+                    * drop the connection's packets in their own private netns;
+                    * every test runs in a fresh netns the wrapper deletes on
+                    * exit, so the rules cannot leak between tests.  The default
+                    * iptables_command (/usr/sbin/iptables) is correct here. */
+                   " --option=torture:use_iptables=yes"
                    " --option='client smb3 signing algorithms=aes-128-cmac'"
                    /* Fixed randomizer seed: several suites derive inputs from
                     * rand() with boundary hazards -- smb2.replay.channel-


### PR DESCRIPTION
## What

Wire up **iptables-based transport blocking** for the smbtorture harness, and enable the 80 test cells it unblocks (lease / replay / oplock / multichannel), ignoring the Windows-dialect variants that no spec-conforming server can pass.

## Why

Many smbtorture tests simulate an **unresponsive client transport** (a network partition) to exercise lease/oplock break timeouts and durable-handle behavior. smbtorture's *default* block method is an in-band `FSCTL_SMBTORTURE_FORCE_UNACKED_TIMEOUT` that only Samba's `smbd` implements (gated behind `smbd:FSCTL_SMBTORTURE = yes`); against chimera it fails with *"could not block tcp transport"*, so every such test was disabled.

smbtorture also supports `torture:use_iptables=yes`, which drops the connection's packets with `iptables` at the network layer. Our harness already runs each test **as root in its own private network namespace** (`ip netns exec`), so it has `CAP_NET_ADMIN` and a fully isolated iptables table — the rules can't leak between tests (each netns is deleted on exit). Passing the option is all that's needed.

## Changes

- `smbtorture_test.c`: add `--option=torture:use_iptables=yes` to the smbtorture invocation. No-op for tests that don't block; the default `iptables_command` (`/usr/sbin/iptables`) is correct.
- `tests/CMakeLists.txt`: enable **80 newly-passing cells** (regenerated via `tools/smbtorture/regen.py`). Each confirmed **stable 3×**. Purely additive — no test disabled, denylist and catalog untouched.

## Notes

- chimera already implements the underlying server behavior these tests check (unacked break timeout, durable replay) — only the harness plumbing was missing, so no server code changed.
- The `-windows` replay variants stay disabled by design: they expect `ACCESS_DENIED` where chimera (like Samba) returns the spec-sane `FILE_NOT_AVAILABLE`; a server can match one dialect or the other, not both.
- `smb2.lease.breaking4` remains disabled (a genuine hang, unrelated).
- Separately-tracked follow-up: `replay.dhv2-pending2-*-sane` (a zombie `CREATE_PENDING`-on-disconnect bug) and `pending1-vs-violation-sane` (lease-break-count) — real chimera bugs, not iptables-related.
