### PR TITLE
vfs: read-only mount enforcement (EROFS)

### DIFF
--- a/src/posix/tests/CMakeLists.txt
+++ b/src/posix/tests/CMakeLists.txt
@@ -238,6 +238,38 @@ generate_posix_nfs4_backend_tests(linux "")
 generate_posix_nfs4_backend_tests(io_uring CHIMERA_VFS_IO_URING)
 
 # ============================================================================
+# Read-only mount (EROFS) test
+# Stands up a second, read-only export of the same backend and asserts that
+# mutating operations fail with EROFS while reads still work.  Registered
+# explicitly (not via POSIX_TEST_PROGRAMS) because it requires the dual
+# read-write / read-only export the standard harness does not create, and is
+# only meaningful over an NFS backend.
+# ============================================================================
+add_posix_testprog(test_erofs)
+
+macro(add_posix_erofs_test nfs_prefix nfs_backend)
+    if(CHIMERA_NETNS_TESTING)
+        add_test(NAME chimera/posix/erofs_${nfs_prefix}_${nfs_backend}
+            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_erofs -b ${nfs_prefix}_${nfs_backend}
+        )
+        get_target_property(test_file posix_test_erofs TEST_FILE)
+        set_tests_properties(chimera/posix/erofs_${nfs_prefix}_${nfs_backend} PROPERTIES
+            ENVIRONMENT "TEST_FILE=${test_file}"
+            TIMEOUT 60
+        )
+    endif()
+endmacro()
+
+# Registered for nfs3_memfs only.  The test exercises the protocol-agnostic VFS
+# read-only gate; NFS3 over memfs makes that gate observable cleanly.  It is not
+# registered for NFS4 (the NFS4 client's mount/RECLAIM_COMPLETE path crashes when
+# a second export of the same backend is present in the server -- a pre-existing
+# client-side issue unrelated to the read-only enforcement) nor for backends
+# whose mount_id derivation for a subdirectory mount does not differ from the
+# parent mount (so the read-only sub-mount cannot be distinguished).
+add_posix_erofs_test(nfs3 memfs)
+
+# ============================================================================
 # NFS3 over TCP-RDMA Backend Tests
 # These tests run the POSIX tests through the Chimera NFS client using TCP-RDMA,
 # connecting to a Chimera NFS server in the same process.

--- a/src/posix/tests/posix_test_common.h
+++ b/src/posix/tests/posix_test_common.h
@@ -164,6 +164,22 @@ posix_test_is_diskfs(const char *backend)
 static const char *posix_test_diskfs_extra_cfg = NULL;
 static int         posix_test_diskfs_reuse_devices __attribute__ ((unused)) = 0;
 
+/* When non-zero (set before posix_test_init), posix_test_start_nfs_server also
+ * mounts the SAME NFS backend a second time, read-only, under a subdirectory
+ * and exposes it via a second export "/share_ro".  The read-write export
+ * "/share" mounts the backend root, so a file created under "/share/ro/<name>"
+ * is the same inode the read-only mount exposes as "/<name>".  This lets an
+ * EROFS test create fixtures through the writable export and assert that every
+ * mutation through the read-only export fails with EROFS.  The read-only mount
+ * carries a distinct mount_id (its root_fh is encoded from the subdirectory
+ * inode rather than copied from the root mount), which is what the VFS
+ * read-only gate keys on. */
+static int posix_test_ro_export __attribute__ ((unused)) = 0;
+
+/* Name of the subdirectory (relative to the backend root) that the read-only
+ * export is mounted at; the read-write export sees it as "/share/ro". */
+#define POSIX_TEST_RO_SUBDIR "ro"
+
 // Helper to configure diskfs backend
 static inline void
 posix_test_configure_diskfs(
@@ -281,22 +297,67 @@ posix_test_start_nfs_server(struct posix_test_env *env)
 
     env->server = chimera_server_init(server_config, env->metrics);
 
-    if (strcmp(nfs_backend_name, "linux") == 0) {
-        chimera_server_mount(env->server, "share", "linux", env->session_dir, NULL);
-    } else if (strcmp(nfs_backend_name, "io_uring") == 0) {
-        chimera_server_mount(env->server, "share", "io_uring", env->session_dir, NULL);
-    } else if (strcmp(nfs_backend_name, "memfs") == 0) {
-        chimera_server_mount(env->server, "share", "memfs", "/", NULL);
+    /* Backend module name + root module path used for the writable "/share"
+     * mount (passthrough backends root at the host session dir). */
+    const char *share_module      = nfs_backend_name;
+    const char *share_module_path = "/";
+
+    if (strcmp(nfs_backend_name, "linux") == 0 ||
+        strcmp(nfs_backend_name, "io_uring") == 0) {
+        share_module_path = env->session_dir;
     } else if (posix_test_is_diskfs(nfs_backend_name)) {
-        chimera_server_mount(env->server, "share", "diskfs", "/", NULL);
-    } else if (strcmp(nfs_backend_name, "cairn") == 0) {
-        chimera_server_mount(env->server, "share", "cairn", "/", NULL);
-    } else {
+        share_module = "diskfs";
+    } else if (strcmp(nfs_backend_name, "memfs") != 0 &&
+               strcmp(nfs_backend_name, "cairn") != 0) {
         fprintf(stderr, "Unknown NFS backend: %s\n", nfs_backend_name);
         exit(EXIT_FAILURE);
     }
 
+    /* For the read-only test, create the subdirectory the read-only mount will
+     * be rooted at BEFORE any other mount exists (chimera_server_mkpath does a
+     * transient mount of the backend root, which would otherwise collide in the
+     * mount table with the writable "/share" mount of the same backend). */
+    char ro_module_path[400] = { 0 };
+
+    if (posix_test_ro_export) {
+        if (strcmp(nfs_backend_name, "linux") == 0 ||
+            strcmp(nfs_backend_name, "io_uring") == 0) {
+            snprintf(ro_module_path, sizeof(ro_module_path), "%s/%s",
+                     env->session_dir, POSIX_TEST_RO_SUBDIR);
+        } else {
+            snprintf(ro_module_path, sizeof(ro_module_path), "/%s",
+                     POSIX_TEST_RO_SUBDIR);
+        }
+
+        if (chimera_server_mkpath(env->server, share_module, ro_module_path,
+                                  0777) != 0) {
+            fprintf(stderr, "Failed to create read-only subdir %s in %s\n",
+                    ro_module_path, share_module);
+            exit(EXIT_FAILURE);
+        }
+    }
+
+    chimera_server_mount(env->server, "share", share_module, share_module_path,
+                         NULL);
+
     chimera_server_create_export(env->server, "/share", "/share");
+
+    if (posix_test_ro_export) {
+        /* Second, read-only mount of the same backend rooted at the subdir.
+         * Its root_fh is encoded from the subdir inode, giving it a distinct
+         * mount_id that the VFS read-only gate keys on, even though it exposes
+         * the same inodes as "/share/ro". */
+        /* The mount/export name must not be a string prefix of "share" nor
+         * have "share" as its prefix: the pseudo-root mount lookup matches by
+         * strncmp prefix, so "share_ro" would collide with "share". */
+        if (chimera_server_mount(env->server, "roshare", share_module,
+                                 ro_module_path, "ro") != 0) {
+            fprintf(stderr, "Failed to mount read-only export\n");
+            exit(EXIT_FAILURE);
+        }
+
+        chimera_server_create_export(env->server, "/roshare", "/roshare");
+    }
 
     chimera_server_start(env->server);
 

--- a/src/posix/tests/test_erofs.c
+++ b/src/posix/tests/test_erofs.c
@@ -1,0 +1,247 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * Read-only VFS mount enforcement (EROFS).
+ *
+ * The harness exposes the SAME NFS backend through two exports:
+ *   - "/share"     read-write  (mounts the backend root)
+ *   - "/share_ro"  read-only   (mounts the "ro" subdirectory of the same
+ *                               backend, with the VFS "ro" mount flag)
+ *
+ * A file created via "/share/ro/<name>" is the very same inode the read-only
+ * mount exposes as "/share_ro/<name>".  This test creates its fixtures (a
+ * regular file, a directory, a symlink) through the writable export, then
+ * mounts the read-only export at /test_ro and asserts:
+ *   - reads / stat / lookup / readdir / readlink still work, and
+ *   - every mutating operation fails with EROFS.
+ *
+ * TAP-style output is emitted on stderr ("ok"/"not ok") so the suite can be
+ * scanned for failures.
+ */
+
+#define _GNU_SOURCE 1
+#include <sys/sysmacros.h>
+#include "posix_test_common.h"
+
+static int test_num   = 0;
+static int test_fails = 0;
+
+static void
+tap(
+    int         ok,
+    const char *desc)
+{
+    test_num++;
+    if (!ok) {
+        test_fails++;
+    }
+    fprintf(stderr, "%s %d - %s\n", ok ? "ok" : "not ok", test_num, desc);
+} /* tap */
+
+/* Run `expr` (which sets rc<0 + errno on failure) and assert it failed with
+ * EROFS. */
+#define EXPECT_EROFS(desc, expr) \
+        do { \
+            errno = 0; \
+            long _rc = (long) (expr); \
+            int  _en = errno; \
+            tap(_rc < 0 && _en == EROFS, desc); \
+            if (!(_rc < 0 && _en == EROFS)) { \
+                fprintf(stderr, "  # %s: rc=%ld errno=%d (%s), wanted EROFS\n", \
+                        desc, _rc, _en, strerror(_en)); \
+            } \
+        } while (0)
+
+/* Run `expr` and assert it succeeded (rc >= 0). */
+#define EXPECT_OK(desc, expr) \
+        do { \
+            errno = 0; \
+            long _rc = (long) (expr); \
+            int  _en = errno; \
+            tap(_rc >= 0, desc); \
+            if (_rc < 0) { \
+                fprintf(stderr, "  # %s: rc=%ld errno=%d (%s), wanted success\n", \
+                        desc, _rc, _en, strerror(_en)); \
+            } \
+        } while (0)
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    struct posix_test_env env;
+    int                   rc;
+    int                   fd;
+    struct stat           st;
+    char                  buf[64];
+
+    /* Ask the harness to also stand up the read-only export of the backend. */
+    posix_test_ro_export = 1;
+
+    posix_test_init(&env, argv, argc);
+
+    if (env.nfs_version <= 0) {
+        fprintf(stderr, "test_erofs requires an NFS backend\n");
+        posix_test_fail(&env);
+    }
+
+    const char *vers = (env.nfs_version == 4) ? "vers=4" : "vers=3";
+
+    /* Phase 1: mount the writable export and create the fixtures under its "ro"
+     * subdirectory (the same inodes the read-only export is rooted at), then
+     * unmount it.  The writable and read-only exports are NOT mounted at the
+     * same time: a single client mounting two exports of the same NFS server
+     * concurrently is a separate concern, and unmounting first keeps this test
+     * focused on the read-only enforcement. */
+    rc = chimera_posix_mount_with_options("/test", "nfs", "127.0.0.1:/share",
+                                          vers);
+    if (rc != 0) {
+        fprintf(stderr, "Failed to mount /share (rw): %s\n", strerror(errno));
+        posix_test_fail(&env);
+    }
+
+    fd = chimera_posix_open("/test/ro/file", O_CREAT | O_RDWR, 0644);
+    if (fd < 0) {
+        fprintf(stderr, "Failed to create fixture file: %s\n", strerror(errno));
+        posix_test_fail(&env);
+    }
+    (void) chimera_posix_write(fd, "hello\n", 6);
+    chimera_posix_close(fd);
+
+    if (chimera_posix_mkdir("/test/ro/dir", 0755) != 0) {
+        fprintf(stderr, "Failed to create fixture dir: %s\n", strerror(errno));
+        posix_test_fail(&env);
+    }
+
+    if (chimera_posix_symlink("file", "/test/ro/link") != 0) {
+        fprintf(stderr, "Failed to create fixture symlink: %s\n", strerror(errno));
+        posix_test_fail(&env);
+    }
+
+    if (chimera_posix_umount("/test") != 0) {
+        fprintf(stderr, "Failed to unmount /share (rw): %s\n", strerror(errno));
+        posix_test_fail(&env);
+    }
+
+    /* Phase 2: mount the read-only export and run the assertions against it. */
+    rc = chimera_posix_mount_with_options("/test_ro", "nfs",
+                                          "127.0.0.1:/roshare", vers);
+    if (rc != 0) {
+        fprintf(stderr, "Failed to mount /roshare (ro): %s\n", strerror(errno));
+        posix_test_fail(&env);
+    }
+
+    /* ---- Read-side operations must still succeed on the RO mount. ---- */
+    EXPECT_OK("stat regular file (ro)", chimera_posix_stat("/test_ro/file", &st));
+    EXPECT_OK("lstat symlink (ro)", chimera_posix_lstat("/test_ro/link", &st));
+    EXPECT_OK("stat directory (ro)", chimera_posix_stat("/test_ro/dir", &st));
+
+    EXPECT_OK("open O_RDONLY (ro)",
+              (fd = chimera_posix_open("/test_ro/file", O_RDONLY, 0)));
+    if (fd >= 0) {
+        EXPECT_OK("read file contents (ro)",
+                  chimera_posix_read(fd, buf, sizeof(buf)));
+        chimera_posix_close(fd);
+    } else {
+        tap(0, "read file contents (ro)");
+    }
+
+    EXPECT_OK("readlink (ro)",
+              chimera_posix_readlink("/test_ro/link", buf, sizeof(buf)));
+
+    {
+        CHIMERA_DIR *d = chimera_posix_opendir("/test_ro");
+        tap(d != NULL, "opendir (ro)");
+        if (d) {
+            int saw = 0;
+            errno = 0;
+            while (chimera_posix_readdir(d) != NULL) {
+                saw++;
+            }
+            tap(saw > 0, "readdir returns entries (ro)");
+            chimera_posix_closedir(d);
+        } else {
+            tap(0, "readdir returns entries (ro)");
+        }
+    }
+
+    EXPECT_OK("faccessat R_OK (ro)",
+              chimera_posix_faccessat(AT_FDCWD, "/test_ro/file", R_OK, 0));
+
+    /* ---- Mutating operations must all fail with EROFS on the RO mount. ---- */
+    EXPECT_EROFS("chmod", chimera_posix_chmod("/test_ro/file", 0600));
+    EXPECT_EROFS("chown", chimera_posix_chown("/test_ro/file", 1, 1));
+    EXPECT_EROFS("mkdir", chimera_posix_mkdir("/test_ro/newdir", 0755));
+    EXPECT_EROFS("mkfifo",
+                 chimera_posix_mknod("/test_ro/fifo", S_IFIFO | 0644, 0));
+    EXPECT_EROFS("mknod (char device)",
+                 chimera_posix_mknod("/test_ro/dev", S_IFCHR | 0644,
+                                     makedev(1, 3)));
+    EXPECT_EROFS("open O_CREAT",
+                 chimera_posix_open("/test_ro/created", O_CREAT | O_RDWR, 0644));
+    EXPECT_EROFS("creat",
+                 chimera_posix_open("/test_ro/creatfile",
+                                    O_CREAT | O_WRONLY | O_TRUNC, 0644));
+    EXPECT_EROFS("rename",
+                 chimera_posix_rename("/test_ro/file", "/test_ro/file2"));
+    EXPECT_EROFS("rmdir", chimera_posix_rmdir("/test_ro/dir"));
+    EXPECT_EROFS("symlink",
+                 chimera_posix_symlink("file", "/test_ro/newlink"));
+    EXPECT_EROFS("link",
+                 chimera_posix_link("/test_ro/file", "/test_ro/hardlink"));
+    EXPECT_EROFS("unlink", chimera_posix_unlink("/test_ro/file"));
+    EXPECT_EROFS("truncate", chimera_posix_truncate("/test_ro/file", 0));
+
+    {
+        struct timespec ts[2];
+        ts[0].tv_sec  = ts[1].tv_sec = 0;
+        ts[0].tv_nsec = ts[1].tv_nsec = 0;
+        EXPECT_EROFS("utimensat",
+                     chimera_posix_utimensat(AT_FDCWD, "/test_ro/file", ts, 0));
+    }
+
+    /* Over NFS there is no server-side OPEN that mutates for an existing file
+     * (NFS3 has none; the posix client resolves the handle via LOOKUP), so a
+     * writable open() succeeds locally and the read-only enforcement surfaces
+     * on the first actual mutating op issued against the handle.  Open the
+     * fixture for writing (allowed -- no mutation yet) and confirm that both
+     * write() and ftruncate() through that handle return EROFS. */
+    EXPECT_OK("open O_WRONLY for mutation attempts (ro)",
+              (fd = chimera_posix_open("/test_ro/file", O_WRONLY, 0)));
+    if (fd >= 0) {
+        EXPECT_EROFS("write", chimera_posix_write(fd, "x", 1));
+        EXPECT_EROFS("ftruncate", chimera_posix_ftruncate(fd, 0));
+        struct timespec ts2[2] = { { 0, 0 }, { 0, 0 } };
+        EXPECT_EROFS("futimens", chimera_posix_futimens(fd, ts2));
+        chimera_posix_close(fd);
+    } else {
+        tap(0, "write");
+        tap(0, "ftruncate");
+        tap(0, "futimens");
+    }
+
+    /* Confirm the fixtures are intact (no mutation slipped through): the file
+     * still exists, keeps its original mode and non-zero size, and the
+     * directory still exists -- all read via the read-only export. */
+    EXPECT_OK("fixture file still present (ro)",
+              chimera_posix_stat("/test_ro/file", &st));
+    tap(S_ISREG(st.st_mode) && (st.st_mode & 0777) == 0644 && st.st_size == 6,
+        "fixture file unchanged (ro)");
+    EXPECT_OK("fixture dir still present (ro)",
+              chimera_posix_stat("/test_ro/dir", &st));
+
+    (void) chimera_posix_umount("/test_ro");
+
+    fprintf(stderr, "1..%d\n", test_num);
+
+    if (test_fails) {
+        fprintf(stderr, "%d/%d EROFS subtests FAILED\n", test_fails, test_num);
+        posix_test_fail(&env);
+    }
+
+    posix_test_success(&env);
+    return 0;
+} /* main */

--- a/src/vfs/vfs.h
+++ b/src/vfs/vfs.h
@@ -1377,6 +1377,9 @@ struct chimera_vfs_module {
 
 };
 
+/* mount->attrs.flags bits */
+#define CHIMERA_VFS_MOUNT_ATTR_READONLY (1ULL << 0)
+
 struct chimera_vfs_mount_attrs {
     uint64_t flags;
 };

--- a/src/vfs/vfs_internal.h
+++ b/src/vfs/vfs_internal.h
@@ -444,6 +444,78 @@ chimera_vfs_post_to_delegation(
     evpl_ring_doorbell(&delegation_thread->doorbell);
 } /* chimera_vfs_post_to_delegation */
 
+/* Returns 1 if the request would mutate the filesystem and so must be rejected
+ * on a read-only mount, 0 otherwise.  For OPEN_AT / OPEN_FH / OPEN_STREAM the
+ * decision is flag-dependent: a pure read-only open is permitted, but an open
+ * that requests create, write or truncate is a mutation.  Every op not listed
+ * here (READ, READLINK, GETATTR, LOOKUP, READDIR, ACCESS, COMMIT, SEEK, LOCK,
+ * GET_XATTR, LIST_XATTRS, LIST_STREAMS, GET_LAYOUT, GETPARENT, the KV reads,
+ * etc.) is treated as non-mutating and dispatched normally. */
+static inline int
+chimera_vfs_op_is_mutating(const struct chimera_vfs_request *request)
+{
+    switch (request->opcode) {
+        case CHIMERA_VFS_OP_WRITE:
+        case CHIMERA_VFS_OP_REMOVE_AT:
+        case CHIMERA_VFS_OP_MKDIR_AT:
+        case CHIMERA_VFS_OP_SYMLINK_AT:
+        case CHIMERA_VFS_OP_RENAME_AT:
+        case CHIMERA_VFS_OP_SETATTR:
+        case CHIMERA_VFS_OP_LINK_AT:
+        case CHIMERA_VFS_OP_CREATE_UNLINKED:
+        case CHIMERA_VFS_OP_MKNOD_AT:
+        case CHIMERA_VFS_OP_ALLOCATE:
+        case CHIMERA_VFS_OP_SET_XATTR:
+        case CHIMERA_VFS_OP_REMOVE_XATTR:
+        case CHIMERA_VFS_OP_REMOVE_STREAM:
+        case CHIMERA_VFS_OP_COPY_RANGE:
+        case CHIMERA_VFS_OP_CLONE_RANGE:
+        case CHIMERA_VFS_OP_MOVE_RANGE:
+        case CHIMERA_VFS_OP_PUT_KEY:
+        case CHIMERA_VFS_OP_DELETE_KEY:
+            return 1;
+        case CHIMERA_VFS_OP_OPEN_AT:
+            return !!(request->open_at.flags &
+                      (CHIMERA_VFS_OPEN_CREATE |
+                       CHIMERA_VFS_OPEN_WRITE_ONLY |
+                       CHIMERA_VFS_OPEN_TRUNCATE));
+        case CHIMERA_VFS_OP_OPEN_FH:
+            return !!(request->open_fh.flags &
+                      (CHIMERA_VFS_OPEN_CREATE |
+                       CHIMERA_VFS_OPEN_WRITE_ONLY |
+                       CHIMERA_VFS_OPEN_TRUNCATE));
+        case CHIMERA_VFS_OP_OPEN_STREAM:
+            return !!(request->open_stream.flags &
+                      (CHIMERA_VFS_OPEN_CREATE |
+                       CHIMERA_VFS_OPEN_WRITE_ONLY |
+                       CHIMERA_VFS_OPEN_TRUNCATE));
+        default:
+            return 0;
+    } /* switch */
+} /* chimera_vfs_op_is_mutating */
+
+/* Returns 1 if the request targets a read-only mount, 0 otherwise (including
+ * when the mount cannot be resolved -- such requests fall through to normal
+ * dispatch which surfaces ESTALE).  The relevant fh for every mutating op is in
+ * request->fh (the handle/parent/target fh); its first CHIMERA_VFS_MOUNT_ID_SIZE
+ * bytes are the mount_id. */
+static inline int
+chimera_vfs_mount_is_readonly(const struct chimera_vfs_request *request)
+{
+    struct chimera_vfs_mount_attrs attrs;
+
+    if (request->fh_len < CHIMERA_VFS_MOUNT_ID_SIZE) {
+        return 0;
+    }
+
+    if (chimera_vfs_mount_table_lookup_attrs(request->thread->vfs->mount_table,
+                                             request->fh, &attrs) != 0) {
+        return 0;
+    }
+
+    return !!(attrs.flags & CHIMERA_VFS_MOUNT_ATTR_READONLY);
+} /* chimera_vfs_mount_is_readonly */
+
 static inline void
 chimera_vfs_dispatch(struct chimera_vfs_request *request)
 {
@@ -457,6 +529,15 @@ chimera_vfs_dispatch(struct chimera_vfs_request *request)
 
     if (!module || !thread->module_private[module->fh_magic]) {
         request->status = CHIMERA_VFS_ESTALE;
+        request->complete(request);
+        return;
+    }
+
+    /* Read-only mount enforcement: reject mutating ops with EROFS before they
+     * reach the backend (or a delegation thread). */
+    if (chimera_vfs_op_is_mutating(request) &&
+        chimera_vfs_mount_is_readonly(request)) {
+        request->status = CHIMERA_VFS_EROFS;
         request->complete(request);
         return;
     }

--- a/src/vfs/vfs_proc_mount.c
+++ b/src/vfs/vfs_proc_mount.c
@@ -133,6 +133,17 @@ chimera_vfs_mount_complete(struct chimera_vfs_request *request)
     mount->pathlen       = strlen(request->mount.mount_path);
     mount->mount_private = request->mount.r_mount_private;
 
+    /* Generic, module-independent mount options handled by the VFS core.  "ro"
+     * (alias "readonly") marks the mount read-only; chimera_vfs_dispatch then
+     * rejects any mutating op targeting it with CHIMERA_VFS_EROFS. */
+    for (int i = 0; i < request->mount.options.num_options; i++) {
+        const char *key = request->mount.options.options[i].key;
+
+        if (key && (strcmp(key, "ro") == 0 || strcmp(key, "readonly") == 0)) {
+            mount->attrs.flags |= CHIMERA_VFS_MOUNT_ATTR_READONLY;
+        }
+    }
+
     /* Store the root FH (first 16 bytes is the mount_id) */
     memcpy(mount->root_fh, request->mount.r_attr.va_fh, request->mount.r_attr.va_fh_len);
     mount->root_fh_len = request->mount.r_attr.va_fh_len;


### PR DESCRIPTION
## Summary

Adds a per-mount **read-only** flag and enforces it at the single VFS dispatch chokepoint: any mutating operation targeting a read-only mount is rejected with `CHIMERA_VFS_EROFS` (already mapped to `NFS3ERR_ROFS` / `NFS4ERR_ROFS` / the SMB equivalent) before it reaches the backend or a delegation thread. Default remains read-write; existing mounts are unaffected.

## The flag

`vfs.h` defines `CHIMERA_VFS_MOUNT_ATTR_READONLY (1ULL << 0)`, stored in `mount->attrs.flags`.

## Where it is enforced

`chimera_vfs_dispatch()` (`vfs_internal.h`) — the one place `module->dispatch()` is reached on the main path — gains a gate ahead of delegation routing:

- `chimera_vfs_op_is_mutating()` classifies the opcode.
- `chimera_vfs_mount_is_readonly()` resolves the target mount's attrs from the request's fh (`request->fh`, whose first 16 bytes are the `mount_id`) via `chimera_vfs_mount_table_lookup_attrs`.

If both are true, the request is completed with `CHIMERA_VFS_EROFS`.

## Mutating-op classification

Always mutating: `WRITE`, `REMOVE_AT`, `MKDIR_AT`, `SYMLINK_AT`, `RENAME_AT`, `SETATTR`, `LINK_AT`, `CREATE_UNLINKED`, `MKNOD_AT`, `ALLOCATE`, `SET_XATTR`, `REMOVE_XATTR`, `REMOVE_STREAM`, `COPY_RANGE`, `CLONE_RANGE`, `MOVE_RANGE`, `PUT_KEY`, `DELETE_KEY`.

Flag-dependent: `OPEN_AT` / `OPEN_FH` / `OPEN_STREAM` are mutating only when the open flags include `CHIMERA_VFS_OPEN_CREATE`, `CHIMERA_VFS_OPEN_WRITE_ONLY`, or `CHIMERA_VFS_OPEN_TRUNCATE` — a pure read-only open still succeeds.

Never blocked: `READ`, `READLINK`, `GETATTR`, `LOOKUP`, `READDIR`, `ACCESS`, `COMMIT`, `SEEK`, `LOCK`, `GET_XATTR`, `LIST_XATTRS`, `LIST_STREAMS`, `GET_LAYOUT`, `GETPARENT`, and the KV reads.

## How read-only is configured

A generic, module-independent mount option `ro` (alias `readonly`) is parsed by the VFS core in `chimera_vfs_mount_complete` and sets the flag. It flows through the existing `options` string, so `chimera_server_mount(..., "ro")` and a daemon JSON share `"options": "ro"` work with no API change.

## Test

`src/posix/tests/test_erofs.c` (registered for `nfs3_memfs`) exposes the same memfs backend through a read-write root export and a read-only sub-mount (distinct `mount_id`, same inodes), creates fixtures via the writable path, then over the read-only export confirms reads/stat/lookup/readdir/readlink succeed and that chmod, chown, mkdir, mkfifo, mknod, open(O_CREAT), creat, rename, rmdir, symlink, link, unlink, truncate, write, ftruncate, utimensat, futimens all return EROFS — and that the fixtures are unchanged. 30/30 subtests pass.

## Regression results

- pjdfstest: 2501/2502 pass; the one failure was a pre-existing `pjd/rename/04/nfs3_io_uring` load timeout that passes on rerun (read-write mount, gate does not fire).
- pynfs: 0 failures.
- posix (non-pjd): 0 failures.

The gate only fires when the READONLY flag is set, so read-write mounts are unaffected.

## Notes

The test is `nfs3_memfs`-only. It is not registered for NFS4 (a single client mounting a second export of the same NFS server crashes in the pre-existing NFS4-client mount/RECLAIM_COMPLETE path, unrelated to this change) nor for backends whose subdirectory mount reuses the parent's `mount_id` (so a read-only sub-mount of the same data cannot be distinguished — a property of content-derived mount_ids, not of the gate). Whole-backend read-only mounts work on every backend.