### PR TITLE
smb/tests: home multichannel durable-v2 replay cases on multichannel+persistent

### DIFF
--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -133,6 +133,7 @@ if(CHIMERA_NETNS_TESTING AND WPTS_DOTNET AND WPTS_SMB2_DLL AND WPTS_ARCH_SUPPORT
         CACHE PATH "Directory for per-case WPTS JUnit XML output.")
 
     set(_wpts_configs base persistent compression multichannel
+        multichannel_persistent
         encryption compression_encryption multichannel_encryption
         dirlease dirlease_persistent dirlease_appinstance)
     foreach(_c ${_wpts_configs})
@@ -164,6 +165,7 @@ if(CHIMERA_NETNS_TESTING AND WPTS_DOTNET AND WPTS_SMB2_DLL AND WPTS_ARCH_SUPPORT
     set(_wpts_envfrag_persistent              ";CHIMERA_SMB_PERSISTENT=1")
     set(_wpts_envfrag_compression             ";CHIMERA_SMB_COMPRESSION=1")
     set(_wpts_envfrag_multichannel            ";CHIMERA_SMB_MULTICHANNEL=1")
+    set(_wpts_envfrag_multichannel_persistent ";CHIMERA_SMB_MULTICHANNEL=1;CHIMERA_SMB_PERSISTENT=1")
     set(_wpts_envfrag_encryption              ";CHIMERA_SMB_ENCRYPTION=1")
     set(_wpts_envfrag_compression_encryption  ";CHIMERA_SMB_COMPRESSION=1;CHIMERA_SMB_ENCRYPTION=1")
     set(_wpts_envfrag_multichannel_encryption ";CHIMERA_SMB_MULTICHANNEL=1;CHIMERA_SMB_ENCRYPTION=1")
@@ -179,6 +181,7 @@ if(CHIMERA_NETNS_TESTING AND WPTS_DOTNET AND WPTS_SMB2_DLL AND WPTS_ARCH_SUPPORT
     set(_wpts_lbl_persistent              ";persistent")
     set(_wpts_lbl_compression             ";compression")
     set(_wpts_lbl_multichannel            ";multichannel")
+    set(_wpts_lbl_multichannel_persistent ";multichannel;persistent")
     set(_wpts_lbl_encryption              ";encryption")
     set(_wpts_lbl_compression_encryption  ";compression;encryption")
     set(_wpts_lbl_multichannel_encryption ";multichannel;encryption")
@@ -189,6 +192,7 @@ if(CHIMERA_NETNS_TESTING AND WPTS_DOTNET AND WPTS_SMB2_DLL AND WPTS_ARCH_SUPPORT
     set(_wpts_suf_persistent              "_persistent")
     set(_wpts_suf_compression             "_compression")
     set(_wpts_suf_multichannel            "_multichannel")
+    set(_wpts_suf_multichannel_persistent "_multichannel_persistent")
     set(_wpts_suf_encryption              "_encryption")
     set(_wpts_suf_compression_encryption  "_compression_encryption")
     set(_wpts_suf_multichannel_encryption "_multichannel_encryption")

--- a/src/server/smb/tests/wpts/wpts_cases.csv
+++ b/src/server/smb/tests/wpts/wpts_cases.csv
@@ -62,8 +62,8 @@ BVT_OpLockBreak,base,green,1,
 BVT_OpLockBreak_Lease,base,skip,0,oplock-lease
 BVT_PersistentHandle_Reconnect,persistent,green,0,
 BVT_PersistentHandles,base,skip,0,env
-BVT_Replay_ReplayCreate,multichannel,xfail,0,
-BVT_Replay_WriteWithInvalidChannelSequence,multichannel,xfail,0,
+BVT_Replay_ReplayCreate,multichannel_persistent,green,0,
+BVT_Replay_WriteWithInvalidChannelSequence,multichannel_persistent,green,0,
 BVT_Resiliency,base,skip,0,env
 BVT_ResilientHandle_LockSequence,persistent,green,0,
 BVT_ResilientHandle_LockSequence_Lease,persistent,xfail,0,

--- a/tools/wpts/sweep.py
+++ b/tools/wpts/sweep.py
@@ -51,6 +51,7 @@ WRAPPER = os.path.join(REPO, "scripts/wpts_smb_test_wrapper.sh")
 TRX_NS = "{http://microsoft.com/schemas/VisualStudio/TeamTest/2010}"
 
 CONFIGS = ["base", "persistent", "compression", "multichannel",
+           "multichannel_persistent",
            "encryption", "compression_encryption", "multichannel_encryption",
            "dirlease", "dirlease_persistent", "dirlease_appinstance"]
 
@@ -61,6 +62,8 @@ CONFIG_ENV = {
     "persistent":              {"CHIMERA_SMB_PERSISTENT": "1"},
     "compression":             {"CHIMERA_SMB_COMPRESSION": "1"},
     "multichannel":            {"CHIMERA_SMB_MULTICHANNEL": "1"},
+    "multichannel_persistent": {"CHIMERA_SMB_MULTICHANNEL": "1",
+                                "CHIMERA_SMB_PERSISTENT": "1"},
     "encryption":              {"CHIMERA_SMB_ENCRYPTION": "1"},
     "compression_encryption":  {"CHIMERA_SMB_COMPRESSION": "1",
                                 "CHIMERA_SMB_ENCRYPTION": "1"},


### PR DESCRIPTION
## Summary

Greens the two multichannel durable-v2 **replay** conformance cases by homing them on a config that enables the features they actually need. No server code change.

## Root cause

`BVT_Replay_ReplayCreate` / `BVT_Replay_WriteWithInvalidChannelSequence` open a durable-v2 handle on the main channel, disconnect it, then **replay** the CREATE over a bound alternate channel (same session) and require the `Smb2CreateDurableHandleResponseV2` context back.

`chimera_smb_create_grant_durable` only grants durable handles when `config.persistent_handles` is enabled. Under the plain `multichannel` config (persistent off) the **main** durable-v2 create never gets a durable grant, so no DH2Q response is emitted and the test fails before it even replays. The ChannelSequence + create-guid replay machinery (from #711) is fine — durable simply wasn't enabled.

These cases genuinely need **both** the alternate channel (multichannel / 2nd NIC) **and** durable handles (persistent).

## Change

Add a `multichannel_persistent` home config (`CHIMERA_SMB_MULTICHANNEL=1` + `CHIMERA_SMB_PERSISTENT=1`) to `tools/wpts/sweep.py` and the CMake config matrix — mirroring the existing `dirlease_persistent` / `dirlease_appinstance` combo configs — and home the two replay cases there as `green` (xfail → green).

## Verification

- Both pass **3×** in the `multichannel_persistent` batch.
- Plain `multichannel` green batch (17) and `persistent` green batch (44) unchanged — no regression.
- `AppInstanceId_Negative_DifferentAppInstanceIdInReopen` stays `multichannel` xfail (a separate force-close defect, confirmed not fixed by enabling persistent).
- New `chimera/server/smb/wpts/memfs_multichannel_persistent` ctest entry registers; `sweep.py --lint` OK (236 green / 7 xfail / 24 skip); reuse-lint + copyright clean; Release build clean.
