### PR TITLE
nfs4: delegation-recall correctness (own-I/O self-recall + CLAIM_DELEG_CUR_FH)

### DIFF
--- a/src/server/nfs/nfs4_proc_open.c
+++ b/src/server/nfs/nfs4_proc_open.c
@@ -1108,6 +1108,17 @@ chimera_nfs4_open_parent_complete(
             break;
         case CLAIM_PREVIOUS:
         case CLAIM_FH:
+        case CLAIM_DELEG_CUR_FH:
+            /* CLAIM_DELEG_CUR_FH (RFC 8881 §18.16): the client is converting an
+             * open it held under a delegation into concrete open state on the
+             * server, identifying the file by the current filehandle (the
+             * minorversion-1 analogue of CLAIM_DELEGATE_CUR, which carries a
+             * name).  This is exactly an open-by-FH; the delegation-grant gate
+             * already declines to hand out a *new* delegation for this claim, so
+             * the client receives an ordinary open stateid it can then return
+             * the delegation against.  A client issues this in response to a
+             * CB_RECALL, so failing it (NFS4ERR_NOTSUPP) stalls the recall and
+             * prevents a clean DELEGRETURN. */
             chimera_vfs_open_fh(req->thread->vfs_thread, &req->cred,
                                 req->fh,
                                 req->fhlen,

--- a/src/server/nfs/nfs4_proc_read.c
+++ b/src/server/nfs/nfs4_proc_read.c
@@ -72,6 +72,33 @@ chimera_nfs4_read_open_callback(
     iov = xdr_dbuf_alloc_space(sizeof(*iov) * 256, req->encoding->dbuf);
     chimera_nfs_abort_if(iov == NULL, "Failed to allocate space");
 
+    if (req->io_owner_from_deleg) {
+        /* A delegation-authorized read: present the delegation holder's own
+        * lease owner (same protocol/client/fh as the CACHING lease created at
+        * OPEN) so the VFS I/O path recognises the reader as the delegation
+        * holder and does not recall the client's own delegation.  Other
+        * (anonymous-stateid / pNFS-DS) on-the-fly reads keep the implicit
+        * lease so they still recall *other* clients' conflicting leases. */
+        struct chimera_vfs_lease_owner io_owner = {
+            .protocol   = CHIMERA_VFS_LEASE_PROTO_NFSV4,
+            .client_key = req->session->client_unified->client_id,
+            .owner_lo   = handle->fh_hash,
+            .owner_hi   = 0,
+        };
+
+        chimera_vfs_read_owned(req->thread->vfs_thread, &req->cred,
+                               handle,
+                               args->offset,
+                               args->count,
+                               iov,
+                               256,
+                               0,
+                               &io_owner,
+                               chimera_nfs4_read_complete,
+                               req);
+        return;
+    }
+
     chimera_vfs_read(req->thread->vfs_thread, &req->cred,
                      handle,
                      args->offset,
@@ -161,8 +188,9 @@ chimera_nfs4_read(
     uint32_t                        current_seqid;
     nfsstat4                        status;
 
-    req->nfs_state_ref = NULL;
-    req->handle        = NULL;
+    req->nfs_state_ref       = NULL;
+    req->handle              = NULL;
+    req->io_owner_from_deleg = false;
 
     /*
      * NFS4.1 current-stateid substitution (RFC 8881 §16.2.3.1.2).
@@ -236,6 +264,11 @@ chimera_nfs4_read(
             chimera_nfs4_compound_complete(req, res->status);
             return;
         }
+        /* This read is authorized by the client's own delegation: carry the
+         * holder's lease owner on the on-the-fly read so it does not recall the
+         * client's own delegation. */
+        req->io_owner_from_deleg = (req->session &&
+                                    req->session->client_unified);
         chimera_vfs_open_fh(thread->vfs_thread, &req->cred,
                             req->fh,
                             req->fhlen,

--- a/src/server/nfs/nfs4_proc_write.c
+++ b/src/server/nfs/nfs4_proc_write.c
@@ -86,6 +86,35 @@ chimera_nfs4_write_open_callback(
     req->handle      = handle;
     req->args_write4 = args;
 
+    if (req->io_owner_from_deleg) {
+        /* A delegation-authorized write: present the delegation holder's own
+         * lease owner (same protocol/client/fh as the CACHING lease created at
+         * OPEN) so the VFS I/O path recognises the writer as the delegation
+         * holder and does not recall the client's own delegation.  Other
+         * (anonymous-stateid / pNFS-DS) on-the-fly writes keep the implicit
+         * lease so they still recall *other* clients' conflicting leases. */
+        struct chimera_vfs_lease_owner io_owner = {
+            .protocol   = CHIMERA_VFS_LEASE_PROTO_NFSV4,
+            .client_key = req->session->client_unified->client_id,
+            .owner_lo   = handle->fh_hash,
+            .owner_hi   = 0,
+        };
+
+        chimera_vfs_write_owned(req->thread->vfs_thread, &req->cred,
+                                handle,
+                                args->offset,
+                                args->data.length,
+                                args->stable,       /* 3-level requested stability */
+                                0,
+                                0,
+                                args->data.iov,
+                                args->data.niov,
+                                &io_owner,
+                                chimera_nfs4_write_complete,
+                                req);
+        return;
+    }
+
     chimera_vfs_write(req->thread->vfs_thread, &req->cred,
                       handle,
                       args->offset,
@@ -186,8 +215,9 @@ chimera_nfs4_write(
     struct nfs_open_state          *open_state;
     nfsstat4                        status;
 
-    req->nfs_state_ref = NULL;
-    req->handle        = NULL;
+    req->nfs_state_ref       = NULL;
+    req->handle              = NULL;
+    req->io_owner_from_deleg = false;
 
     /* NFS4.1 current-stateid substitution (RFC 8881 §16.2.3.1.2). */
     chimera_nfs4_resolve_current_stateid(req, &args->stateid);
@@ -277,6 +307,11 @@ chimera_nfs4_write(
             return;
         }
         req->args_write4 = args;
+        /* This write is authorized by the client's own (write) delegation:
+         * carry the holder's lease owner on the on-the-fly write so it does
+         * not recall the client's own delegation. */
+        req->io_owner_from_deleg = (req->session &&
+                                    req->session->client_unified);
         chimera_vfs_open_fh(thread->vfs_thread, &req->cred,
                             req->fh,
                             req->fhlen,

--- a/src/server/nfs/nfs_common.h
+++ b/src/server/nfs/nfs_common.h
@@ -102,6 +102,11 @@ struct nfs_request {
      * NFS4_SLOT_TYPE_OPEN / NFS4_SLOT_TYPE_LOCK. */
     void                             *nfs_state_ref;
     uint8_t                           nfs_state_type;
+    /* Set when a READ/WRITE authorized by a delegation stateid is served via an
+     * on-the-fly open: the on-the-fly I/O must carry the delegation holder's
+     * own lease owner so the VFS I/O path does not treat the client's own I/O
+     * as a foreign actor and recall the client's own delegation. */
+    bool                              io_owner_from_deleg;
     /* In-flight vfs_state byte-range lease for an async NFSv4 LOCK.
      * Allocated at lock dispatch, linked onto the lock_state on grant,
      * freed on denial.  See nfs4_proc_lock.c. */


### PR DESCRIPTION
Two related NFSv4 delegation-recall correctness fixes, found via the
`nfstest_delegation` cross-client suite. Together they take the suite from
**1303/1381 to 1775/1777** on this base, with no regressions.

## 1. Don't recall a client's own delegation on its delegation-authorized I/O

A `READ`/`WRITE` authorized by a delegation stateid carries no open handle, so
the server opens the current filehandle on the fly and issues the I/O with no
lease owner. The VFS I/O path then acquires an *implicit* lease under a
synthetic `INTERNAL` owner (`client_key = 0`), whose share probe collides with
the client's own `CACHING` delegation lease and recalls the delegation **the
client itself holds**.

The result is a self-recall: the holder's own `READ`/`WRITE` tears down its own
delegation. Downstream, `nfstest_delegation` sees the delegation recalled
before any conflict, the client falling back to sending `LOCK`s it should
handle locally, and — because the delegation is already gone — the genuine
cross-client `CB_RECALL` no longer firing at the conflicting op.

Fix: carry the holder's own lease owner (NFSv4, the client's `client_id`, the
file-handle hash) on the on-the-fly I/O via `chimera_vfs_{read,write}_owned`,
exactly as the open-stateid path already does. Scoped to the delegation path:
anonymous-stateid and pNFS-DS I/O keep the implicit lease so they still recall
*other* clients' leases.

## 2. Support OPEN with CLAIM_DELEG_CUR_FH

On `CB_RECALL`, a client converts opens it held locally under the delegation
into concrete server open state before `DELEGRETURN`. An NFSv4.1 client does
this with `OPEN(CLAIM_DELEG_CUR_FH)` (the FH-based analogue of
`CLAIM_DELEGATE_CUR`). chimera's claim switch fell through to
`NFS4ERR_NOTSUPP` for it, stalling the recall and preventing a clean
`DELEGRETURN`.

Fix: route `CLAIM_DELEG_CUR_FH` through the existing open-by-FH path (the
delegation-grant gate already declines to grant a *new* delegation for this
claim).

## Validation

`nfstest_delegation` (memfs, NFSv4.1):

| | tests | passed | failed |
|---|---|---|---|
| upstream/main | 1381 | 1303 | 78 |
| + fix 1 | 1695 | 1666 | 29 |
| + fix 2 | 1777 | 1775 | **2** |

The 2 remaining are a narrow cross-client sequencing case ("OPEN (WRITE) reply
to the second client after the READ delegation has been returned"), tracked
separately. No regressions: `nfstest_posix` 461/461, `vfs_state` unit test
80/80, `smb2.oplock.brl{1,2,3}` 3/3.
