### PR TITLE
vfs: fix mount-path matching; reject cross-mount link/rename (EXDEV)

### DIFF
--- a/src/posix/tests/CMakeLists.txt
+++ b/src/posix/tests/CMakeLists.txt
@@ -133,6 +133,27 @@ if(CHIMERA_NETNS_TESTING)
     endif()
 endif()
 
+# Cross-mount EXDEV test: link/rename across two VFS mounts must fail EXDEV.  It
+# mounts a second memfs instance alongside the primary backend, so the primary
+# must be a different module from memfs (two memfs mounts share one fsid, i.e.
+# the same filesystem).  Runs on the local non-memfs backends only.
+add_posix_testprog(test_exdev)
+if(CHIMERA_NETNS_TESTING)
+    if(CAIRN_ENABLED)
+        add_posix_test(exdev_cairn test_exdev cairn)
+    endif()
+    if(IO_URING_ENABLED)
+        add_posix_test(exdev_diskfs_io_uring test_exdev diskfs_io_uring)
+    endif()
+    if(HAVE_LIBAIO)
+        add_posix_test(exdev_diskfs_aio test_exdev diskfs_aio)
+    endif()
+    add_posix_test(exdev_linux test_exdev linux)
+    if(CHIMERA_VFS_IO_URING)
+        add_posix_test(exdev_io_uring test_exdev io_uring)
+    endif()
+endif()
+
 # ============================================================================
 # NFS3 Backend Tests
 # These tests run the POSIX tests through the Chimera NFS client,

--- a/src/posix/tests/test_exdev.c
+++ b/src/posix/tests/test_exdev.c
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * Cross-mount link(2)/rename(2) must fail with EXDEV: a hard link or rename
+ * cannot span file systems.  The primary backend is mounted at /test; a second,
+ * independent memfs instance is mounted at /test2 so the two have distinct mount
+ * ids.  Operations within a single mount must still succeed.
+ *
+ * Models pjdfstest link/14 and rename/15, which use a second mounted file
+ * system; here a second VFS mount provides the distinct device.
+ */
+#include "posix_test_common.h"
+
+static int failures;
+
+static void
+check(
+    int         cond,
+    const char *msg)
+{
+    static int n;
+
+    n++;
+    if (cond) {
+        fprintf(stderr, "ok %d - %s\n", n, msg);
+    } else {
+        fprintf(stderr, "not ok %d - %s\n", n, msg);
+        failures++;
+    }
+} /* check */
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    struct posix_test_env env;
+    int                   fd, rc;
+
+    posix_test_init(&env, argv, argc);
+
+    if (posix_test_mount(&env) != 0) {
+        fprintf(stderr, "Failed to mount primary test module: %s\n", strerror(errno));
+        posix_test_fail(&env);
+    }
+
+    /* A second, independent memfs instance -> a distinct mount id from /test. */
+    rc = chimera_posix_mount("/test2", "memfs", "/");
+    if (rc != 0) {
+        fprintf(stderr, "Failed to mount second module: %s\n", strerror(errno));
+        posix_test_fail(&env);
+    }
+
+    /* Fixtures: a file and a directory on /test, a directory on /test2. */
+    fd = chimera_posix_open("/test/file", O_CREAT | O_RDWR, 0644);
+    check(fd >= 0, "create /test/file");
+    if (fd >= 0) {
+        chimera_posix_close(fd);
+    }
+    check(chimera_posix_mkdir("/test/dir", 0755) == 0, "mkdir /test/dir");
+    check(chimera_posix_mkdir("/test2/dir", 0755) == 0, "mkdir /test2/dir");
+
+    /* Cross-mount hard link -> EXDEV. */
+    errno = 0;
+    rc    = chimera_posix_link("/test/file", "/test2/link");
+    check(rc != 0 && errno == EXDEV, "cross-mount link -> EXDEV");
+
+    /* Cross-mount rename of a file -> EXDEV. */
+    errno = 0;
+    rc    = chimera_posix_rename("/test/file", "/test2/moved");
+    check(rc != 0 && errno == EXDEV, "cross-mount rename(file) -> EXDEV");
+
+    /* Cross-mount rename of a directory -> EXDEV. */
+    errno = 0;
+    rc    = chimera_posix_rename("/test/dir", "/test2/moveddir");
+    check(rc != 0 && errno == EXDEV, "cross-mount rename(dir) -> EXDEV");
+
+    /* Same-mount operations still succeed. */
+    check(chimera_posix_link("/test/file", "/test/link2") == 0,
+          "same-mount link succeeds");
+    check(chimera_posix_rename("/test/link2", "/test/renamed") == 0,
+          "same-mount rename succeeds");
+    check(chimera_posix_rename("/test/dir", "/test/dir2") == 0,
+          "same-mount rename(dir) succeeds");
+
+    /* Cleanup. */
+    chimera_posix_unlink("/test/file");
+    chimera_posix_unlink("/test/renamed");
+    chimera_posix_rmdir("/test/dir2");
+    chimera_posix_rmdir("/test2/dir");
+
+    if (failures) {
+        posix_test_fail(&env);
+    }
+    posix_test_success(&env);
+    return 0;
+} /* main */

--- a/src/vfs/vfs_mount_table.h
+++ b/src/vfs/vfs_mount_table.h
@@ -411,7 +411,14 @@ chimera_vfs_mount_table_lookup_root_fh_by_name(
     for (i = 0; i < table->num_buckets && rc != 0; i++) {
         entry = rcu_dereference(table->buckets[i]);
         while (entry) {
-            if (strncmp(entry->mount->path, name, namelen) == 0) {
+            /* The mount path must equal the looked-up component exactly.  A bare
+             * strncmp(path, name, namelen) is a prefix test, so it would match
+             * mount "test2" when resolving component "test" (and the winner
+             * depends on bucket order -- nondeterministic) -- e.g. /test/x would
+             * land in the /test2 mount.  Require equal lengths so each component
+             * resolves to its own mount. */
+            if ((int) strlen(entry->mount->path) == namelen &&
+                strncmp(entry->mount->path, name, namelen) == 0) {
                 memcpy(r_root_fh, entry->mount->root_fh, entry->mount->root_fh_len);
                 *r_root_fh_len = entry->mount->root_fh_len;
                 rc             = 0;

--- a/src/vfs/vfs_proc_link_at.c
+++ b/src/vfs/vfs_proc_link_at.c
@@ -230,6 +230,16 @@ chimera_vfs_link_at(
         return;
     }
 
+    /* POSIX link(2): a hard link cannot span file systems.  A file handle's
+     * first CHIMERA_VFS_MOUNT_ID_SIZE bytes are its mount id, so the source file
+     * and the destination directory live on different mounts when those differ
+     * -> EXDEV (pjd link/14). */
+    if (fhlen >= CHIMERA_VFS_MOUNT_ID_SIZE && dir_fhlen >= CHIMERA_VFS_MOUNT_ID_SIZE &&
+        memcmp(fh, dir_fh, CHIMERA_VFS_MOUNT_ID_SIZE) != 0) {
+        callback(CHIMERA_VFS_EXDEV, NULL, NULL, NULL, private_data);
+        return;
+    }
+
     module = chimera_vfs_get_module(thread, dir_fh, dir_fhlen);
 
     /* WRITE+EXECUTE on the destination directory is enforced by the engine even

--- a/src/vfs/vfs_proc_rename_at.c
+++ b/src/vfs/vfs_proc_rename_at.c
@@ -473,6 +473,16 @@ chimera_vfs_rename_at(
         return;
     }
 
+    /* POSIX rename(2): the source and destination must be on the same file
+     * system.  A file handle's first CHIMERA_VFS_MOUNT_ID_SIZE bytes are its
+     * mount id; differing source- and destination-directory mount ids mean the
+     * rename would span mounts -> EXDEV (pjd rename/15). */
+    if (fhlen >= CHIMERA_VFS_MOUNT_ID_SIZE && new_fhlen >= CHIMERA_VFS_MOUNT_ID_SIZE &&
+        memcmp(fh, new_fh, CHIMERA_VFS_MOUNT_ID_SIZE) != 0) {
+        callback(CHIMERA_VFS_EXDEV, NULL, NULL, NULL, NULL, private_data);
+        return;
+    }
+
     module = chimera_vfs_get_module(thread, fh, fhlen);
 
     if (module && chimera_vfs_gate_needed(module->capabilities, cred)) {


### PR DESCRIPTION
Multi-mount correctness — a root-cause infrastructure fix, the EXDEV feature it unblocks, and a test, in one change.

## 1. Mount-path resolution bug (the root cause)
The root namespace resolved a path component to a mount with a bare `strncmp(mount->path, name, namelen)` — a **prefix** test. Resolving component `"test"` matched a mount named `"test2"`, and the winner depended on hash-bucket order, so it was **nondeterministic**: with two mounts whose names share a prefix, operations on one could silently land in the other (e.g. `/test/x` created under `/test2`). Fixed by requiring an exact length match in `chimera_vfs_mount_table_lookup_root_fh_by_name`.

This is the same class of bug that limited #868's dual-export erofs test (`/share` is a prefix of `/share_ro`).

## 2. EXDEV enforcement
POSIX `link(2)`/`rename(2)` cannot span file systems. A file handle begins with its `CHIMERA_VFS_MOUNT_ID_SIZE`-byte mount id, so when the source's mount id differs from the destination directory's, the operation crosses mounts → **EXDEV**, checked up front in `chimera_vfs_link_at` and `chimera_vfs_rename_at` (the error code was already mapped through NFS3/NFS4). Same-mount operations are unaffected (the check only fires on differing mount ids).

## 3. Test
`test_exdev.c` mounts a second memfs instance alongside the primary backend and asserts cross-mount link/rename fail EXDEV while same-mount link/rename succeed. Registered on the local non-memfs backends (two memfs mounts share one fsid — the same filesystem — so memfs isn't a valid second mount here).

## Verification
- EXDEV test is now **deterministic** (0/10 per backend; was ~50% flaky before fix 1).
- Full **pjd 2538/2538**, **pynfs 1383/1383**, **posix 2193/2193** — no regressions (the mount-path fix is on the resolution hot path for every mounted access).
- scan-build / reuse / uncrustify clean.

Note: fix 1 should also let #868's erofs test extend to cairn/diskfs/linux and is a prerequisite for cleaning up the nfs4 multi-export path.