### PR TITLE
diskfs: bound block-cache backing memory and reduce write-path journaling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ option(IO_URING_ENABLED "Enable io_uring support" ON)
 option(CAIRN_ENABLED "Enable cairn support" ON)
 option(CHIMERA_VFS_IO_URING "Enable chimera VFS io_uring backend" ON)
 option(REQUIRE_NETNS_TESTS "Fail configure if network namespace tests cannot be enabled" OFF)
+option(EVPL_IOVEC_PROFILE "Enable libevpl retained-iovec stack profiling" OFF)
 
 if (EXISTS "/usr/local/cuda")
     set(CUDA_ENABLED true)
@@ -91,6 +92,11 @@ endif()
 
 if(CMAKE_BUILD_TYPE STREQUAL "Release")
     add_definitions(-O3)
+endif()
+
+if(EVPL_IOVEC_PROFILE)
+    message(STATUS "Enabling libevpl retained-iovec stack profiling")
+    add_definitions(-DEVPL_IOVEC_PROFILE=1)
 endif()
 
 # Keep frame pointers in every build type so that perf and other

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -368,7 +368,8 @@ The `config` object takes a `devices` array plus filesystem-level knobs.
 | `initialize` | flag | `false` | `mkfs` (format) the filesystem at mount. **Erases data.** |
 | `noatime` | bool | `false` | Disable atime updates. |
 | `mtime_defer_ms` | int (ms) | `1000` | Coalescing window for deferred mtime updates (`0` writes mtime on every write). |
-| `block_cache_blocks` | int | `32768` | Resident block-buffer cap (`0` = default; min ~24K). |
+| `intent_log_size` | int (bytes) | `1073741824` (1 GiB) | Size of the device-0 intent (redo) log; a larger log lets more redo records pipeline before the ring laps. Persisted in the superblock at format time (a remount uses the formatted value). Must fit device 0's first allocation group alongside the superblock and per-AG log; floored at 4 MiB. The block cache default scales with this. |
+| `block_cache_blocks` | int | `0` (2× the intent-log block count) | Resident block-buffer cap (`0` = default; floored at 1.5× the intent-log block count). |
 | `inode_cache_inodes` | int | `262144` | Resident inode cap (`0` = default). |
 | `block_layout` | bool | `false` | Source RFC 5663 pNFS **block** layouts (mutually exclusive with `scsi_layout`). |
 | `scsi_layout` | bool | `false` | Source RFC 8154 pNFS **SCSI** layouts (mutually exclusive with `block_layout`). |

--- a/kvm/kvm_nfs_test_wrapper.sh
+++ b/kvm/kvm_nfs_test_wrapper.sh
@@ -121,7 +121,7 @@ generate_config() {
             BACKEND="diskfs"
             vfs_section="\"vfs\": {
                 \"diskfs\": {
-                    \"config\": {\"initialize\":true,\"devices\":[$devices_json],\"unsafe_async\":true}
+                    \"config\": {\"initialize\":true,\"devices\":[$devices_json],\"unsafe_async\":true,\"intent_log_size\":67108864}
                 }
             },"
             ;;

--- a/kvm/kvm_nfstest_test_wrapper.sh
+++ b/kvm/kvm_nfstest_test_wrapper.sh
@@ -109,8 +109,9 @@ generate_config() {
             fi
             # nfstest_alloc fills the device to exercise ENOSPC, so give it a
             # small bounded backing (a local device's capacity is its file size);
-            # other tools get the usual 10x1 GiB.  Keep each device >= 1 AG
-            # (1 GiB metadata needs >64 MiB) -- 128 MiB works.
+            # other tools get the usual 10x1 GiB.  Device 0 must hold the AG 0
+            # metadata reservation: intent_log_size (64 MiB below) + the per-AG
+            # log (8 MiB) + bootstrap -- so 128 MiB leaves room to fill.
             local dev_count=10
             local dev_bytes="1G"
             if [ "$NFSTEST_PROGRAM" = "nfstest_alloc" ]; then
@@ -130,7 +131,7 @@ generate_config() {
             BACKEND="diskfs"
             vfs_section="\"vfs\": {
                 \"diskfs\": {
-                    \"config\": {\"initialize\":true,\"devices\":[$devices_json],\"unsafe_async\":true}
+                    \"config\": {\"initialize\":true,\"devices\":[$devices_json],\"unsafe_async\":true,\"intent_log_size\":67108864}
                 }
             },"
             ;;

--- a/kvm/kvm_smb_test_wrapper.sh
+++ b/kvm/kvm_smb_test_wrapper.sh
@@ -100,7 +100,7 @@ generate_config() {
             BACKEND="diskfs"
             vfs_section="\"vfs\": {
                 \"diskfs\": {
-                    \"config\": {\"initialize\":true,\"devices\":[$devices_json],\"unsafe_async\":true}
+                    \"config\": {\"initialize\":true,\"devices\":[$devices_json],\"unsafe_async\":true,\"intent_log_size\":67108864}
                 }
             },"
             ;;

--- a/scripts/pynfs_test_wrapper.sh
+++ b/scripts/pynfs_test_wrapper.sh
@@ -131,7 +131,7 @@ generate_config() {
             BACKEND="diskfs"
             vfs_section="\"vfs\": {
                 \"diskfs\": {
-                    \"config\": {\"initialize\":true,\"devices\":[$devices_json],\"unsafe_async\":true}
+                    \"config\": {\"initialize\":true,\"devices\":[$devices_json],\"unsafe_async\":true,\"intent_log_size\":67108864}
                 }
             },"
             ;;

--- a/src/client/tests/client_test_common.h
+++ b/src/client/tests/client_test_common.h
@@ -152,6 +152,8 @@ client_test_init(
             json_object_set_new(cfg, "initialize", json_true());
             json_object_set_new(cfg, "devices", devices);
             json_object_set_new(cfg, "unsafe_async", json_true());
+            /* Small intent log to fit the 1 GiB test devices (see space_map). */
+            json_object_set_new(cfg, "intent_log_size", json_integer(64 * 1024 * 1024));
             json_str = json_dumps(cfg, JSON_COMPACT);
             snprintf(diskfs_cfg, sizeof(diskfs_cfg), "%s", json_str);
             free(json_str);
@@ -259,6 +261,8 @@ client_test_init(
                 json_object_set_new(cfg, "initialize", json_true());
                 json_object_set_new(cfg, "devices", devices);
                 json_object_set_new(cfg, "unsafe_async", json_true());
+                /* Small intent log to fit the 1 GiB test devices (see space_map). */
+                json_object_set_new(cfg, "intent_log_size", json_integer(64 * 1024 * 1024));
                 json_str = json_dumps(cfg, JSON_COMPACT);
                 snprintf(diskfs_cfg, sizeof(diskfs_cfg), "%s", json_str);
                 free(json_str);

--- a/src/common/common_config.h
+++ b/src/common/common_config.h
@@ -159,6 +159,11 @@ chimera_apply_common_config(
         evpl_global_config_set_slab_size(cfg, size);
     }
 
+    val = json_object_get(common, "buffer_size");
+    if (val && chimera_parse_size(val, &size) == 0) {
+        evpl_global_config_set_buffer_size(cfg, size);
+    }
+
     val = json_object_get(common, "preallocate_slabs");
     if (json_is_integer(val)) {
         evpl_global_config_set_preallocate_slabs(cfg, json_integer_value(val));

--- a/src/elbencho/tests/diskfs_io_uring.json
+++ b/src/elbencho/tests/diskfs_io_uring.json
@@ -6,6 +6,7 @@
             "config": {
                 "initialize": true,
                 "unsafe_async": true,
+                "intent_log_size": 67108864,
                 "devices": [
                     {
                         "type": "io_uring",

--- a/src/fio/tests/diskfs_aio_basic.json
+++ b/src/fio/tests/diskfs_aio_basic.json
@@ -12,7 +12,8 @@
                         "path": "${FIO_TEST_BINARY}/diskfs_aio_device_0.img"
                     }
                 ],
-                "unsafe_async": true
+                "unsafe_async": true,
+                "intent_log_size": 67108864
             }
         }
     ],

--- a/src/fio/tests/diskfs_io_uring_basic.json
+++ b/src/fio/tests/diskfs_io_uring_basic.json
@@ -12,7 +12,8 @@
                         "path": "${FIO_TEST_BINARY}/diskfs_io_uring_device_0.img"
                     }
                 ],
-                "unsafe_async": true
+                "unsafe_async": true,
+                "intent_log_size": 67108864
             }
         }
     ],

--- a/src/posix/tests/fsx.c
+++ b/src/posix/tests/fsx.c
@@ -3973,7 +3973,8 @@ main(
                 /* unsafe_async: tests below do not exercise crash recovery, so skip
                  * FUA/sync on writes to run lighter. */
                 snprintf(diskfs_cfg + off, sizeof(diskfs_cfg) - off,
-                         "],\"initialize\":true,\"unsafe_async\":true}");
+                         "],\"initialize\":true,\"unsafe_async\":true,"
+                         "\"intent_log_size\":67108864}");
 
                 chimera_server_config_add_module(chimera_server_config, "diskfs", NULL, diskfs_cfg);
             } else if (strcmp(chimera_nfs_backend, "cairn") == 0) {

--- a/src/posix/tests/posix_test_common.h
+++ b/src/posix/tests/posix_test_common.h
@@ -231,6 +231,10 @@ posix_test_configure_diskfs(
     }
     json_object_set_new(cfg, "devices", devices);
     json_object_set_new(cfg, "unsafe_async", json_true());
+    /* Small intent log: these are 1 GiB test devices, so the production-default
+     * 1 GiB log would not fit the AG-0 metadata reservation (and would eagerly
+     * preallocate a multi-GiB block cache). */
+    json_object_set_new(cfg, "intent_log_size", json_integer(64 * 1024 * 1024));
     if (posix_test_diskfs_extra_cfg) {
         json_t *extra = json_loads(posix_test_diskfs_extra_cfg, 0, NULL);
 

--- a/src/posix/tests/run_fsx.sh
+++ b/src/posix/tests/run_fsx.sh
@@ -113,7 +113,7 @@ generate_config() {
             modules_section="\"modules\": {
         \"diskfs\": {
             \"path\": \"/build/test/diskfs\",
-            \"config\": {\"initialize\":true,\"devices\":[$DEVICES_JSON],\"unsafe_async\":true}
+            \"config\": {\"initialize\":true,\"devices\":[$DEVICES_JSON],\"unsafe_async\":true,\"intent_log_size\":67108864}
         }
     },"
             BACKEND="diskfs"

--- a/src/server/s3/tests/s3_test.py
+++ b/src/server/s3/tests/s3_test.py
@@ -113,7 +113,7 @@ class ChimeraServer:
             config["server"]["vfs"] = {
                 "diskfs": {
                     "path": None,
-                    "config": {"initialize": True, "devices": devices, "unsafe_async": True}
+                    "config": {"initialize": True, "devices": devices, "unsafe_async": True, "intent_log_size": 67108864}
                 }
             }
             config["mounts"]["share"] = {

--- a/src/server/smb/tests/smbtorture_test.c
+++ b/src/server/smb/tests/smbtorture_test.c
@@ -469,6 +469,9 @@ main(
         /* unsafe_async: this test does not exercise crash recovery, so skip FUA/sync
          * on writes to run lighter. */
         json_object_set_new(cfg, "unsafe_async", json_true());
+        /* Small intent log to fit the 1 GiB test devices (the production-default
+         * 1 GiB log would not fit the AG-0 metadata reservation). */
+        json_object_set_new(cfg, "intent_log_size", json_integer(64 * 1024 * 1024));
         /* smb2.maxfid keeps 65520 file handles open across ~256 inode-cache
          * shards; the inode home blocks stay pinned by the open handles and
          * concurrent close traffic also pins LOGGED blocks (held until tail

--- a/src/vfs/diskfs/diskfs_block.c
+++ b/src/vfs/diskfs/diskfs_block.c
@@ -22,8 +22,16 @@ diskfs_block_recycle(
     struct diskfs_thread      *thread,
     struct diskfs_block_shard *shard);
 
+static void
+diskfs_block_drain_returned_locked(
+    struct diskfs_block_shard *shard);
+
+static void
+diskfs_block_drain_clean_locked(
+    struct diskfs_block_shard *shard);
+
 static inline void
-diskfs_block_ensure_iov(
+diskfs_block_assert_iov(
     struct diskfs_thread *thread,
     struct diskfs_block  *blk);
 
@@ -81,6 +89,46 @@ diskfs_block_lru_unlink(
 } /* diskfs_block_lru_unlink */
 
 
+static void
+diskfs_block_drain_returned_locked(struct diskfs_block_shard *shard)
+{
+    struct diskfs_block_buf *buf;
+
+    buf = __atomic_exchange_n(&shard->returned_buffers, NULL, __ATOMIC_ACQUIRE);
+    while (buf) {
+        struct diskfs_block_buf *next = buf->next;
+
+        chimera_diskfs_abort_if(!buf->on_free,
+                                "returned diskfs block buffer is not marked free");
+        buf->next           = shard->free_buffers;
+        shard->free_buffers = buf;
+        shard->nfree_buffers++;
+        buf = next;
+    }
+} /* diskfs_block_drain_returned_locked */
+
+
+static void
+diskfs_block_drain_clean_locked(struct diskfs_block_shard *shard)
+{
+    struct diskfs_block *blk;
+
+    blk = __atomic_exchange_n(&shard->clean_head, NULL, __ATOMIC_ACQUIRE);
+    while (blk) {
+        struct diskfs_block *next = blk->clean_next;
+
+        blk->clean_next = NULL;
+        __atomic_store_n(&blk->clean_queued, 0, __ATOMIC_RELEASE);
+
+        if (__atomic_load_n(&blk->state, __ATOMIC_ACQUIRE) == DISKFS_BLOCK_CLEAN &&
+            __atomic_load_n(&blk->pin_count, __ATOMIC_ACQUIRE) == 0 && !blk->on_lru) {
+            diskfs_block_lru_push_tail(shard, blk);
+        }
+        blk = next;
+    }
+} /* diskfs_block_drain_clean_locked */
+
+
 /*
  * Recycle the least-recently-used CLEAN, unpinned buffer for reuse at a new
  * key.  Caller holds the shard lock.  Returns a buffer with pin_count 0,
@@ -101,9 +149,13 @@ diskfs_block_recycle(
     struct diskfs_thread      *thread,
     struct diskfs_block_shard *shard)
 {
-    struct diskfs_block *blk = shard->lru_head;
+    struct diskfs_block *blk;
     struct diskfs_block *cur, *prev;
     uint32_t             ob;
+
+    diskfs_block_drain_returned_locked(shard);
+    diskfs_block_drain_clean_locked(shard);
+    blk = shard->lru_head;
 
     chimera_diskfs_abort_if(!blk,
                             "block cache shard exhausted: every buffer pinned "
@@ -142,8 +194,10 @@ diskfs_block_unpin(
                                                           blk->device_id, blk->device_offset);
 
     pthread_mutex_lock(&shard->lock);
-    blk->state = new_state;
-    if (--blk->pin_count == 0 && blk->state == DISKFS_BLOCK_CLEAN && !blk->on_lru) {
+    diskfs_block_drain_clean_locked(shard);
+    __atomic_store_n(&blk->state, new_state, __ATOMIC_RELEASE);
+    if (__atomic_sub_fetch(&blk->pin_count, 1, __ATOMIC_ACQ_REL) == 0 &&
+        __atomic_load_n(&blk->state, __ATOMIC_ACQUIRE) == DISKFS_BLOCK_CLEAN && !blk->on_lru) {
         diskfs_block_lru_push_tail(shard, blk);
     }
     pthread_mutex_unlock(&shard->lock);
@@ -160,7 +214,9 @@ diskfs_block_release(
                                                           blk->device_id, blk->device_offset);
 
     pthread_mutex_lock(&shard->lock);
-    if (--blk->pin_count == 0 && blk->state == DISKFS_BLOCK_CLEAN && !blk->on_lru) {
+    diskfs_block_drain_clean_locked(shard);
+    if (__atomic_sub_fetch(&blk->pin_count, 1, __ATOMIC_ACQ_REL) == 0 &&
+        __atomic_load_n(&blk->state, __ATOMIC_ACQUIRE) == DISKFS_BLOCK_CLEAN && !blk->on_lru) {
         diskfs_block_lru_push_tail(shard, blk);
     }
     pthread_mutex_unlock(&shard->lock);
@@ -170,23 +226,30 @@ diskfs_block_release(
 void
 diskfs_block_cache_create(struct diskfs_shared *shared)
 {
-    struct diskfs_block_cache *cache = calloc(1, sizeof(*cache));
-    uint32_t                   total = shared->block_cache_blocks ?
-        shared->block_cache_blocks : DISKFS_BLOCK_CACHE_DEFAULT_BLOCKS;
+    struct diskfs_block_cache *cache   = calloc(1, sizeof(*cache));
+    uint64_t                   il_size = shared->intent_log_size;
+    uint32_t                   min     = (uint32_t) DISKFS_BLOCK_CACHE_MIN_BLOCKS(il_size);
+    uint32_t                   total   = shared->block_cache_blocks ?
+        shared->block_cache_blocks : (uint32_t) DISKFS_BLOCK_CACHE_DEFAULT_BLOCKS(il_size);
     int                        i;
     uint32_t                   j;
+    uint32_t                   extra;
 
     /* The pool never grows or blocks, so it must clear the maximum pinnable
      * set; floor an under-sized configuration rather than risk the recycle
      * abort under load. */
-    if (total < DISKFS_BLOCK_CACHE_MIN_BLOCKS) {
-        total = DISKFS_BLOCK_CACHE_MIN_BLOCKS;
+    if (total < min) {
+        total = min;
     }
 
     cache->shard_cap = total / DISKFS_BLOCK_CACHE_SHARDS;
     if (cache->shard_cap == 0) {
         cache->shard_cap = 1;
     }
+
+    extra                         = cache->shard_cap;
+    cache->buffer_extra_per_shard = extra;
+    pthread_mutex_init(&cache->prealloc_lock, NULL);
 
     for (i = 0; i < DISKFS_BLOCK_CACHE_SHARDS; i++) {
         struct diskfs_block_shard *shard = &cache->shards[i];
@@ -212,6 +275,57 @@ diskfs_block_cache_create(struct diskfs_shared *shared)
 
 
 void
+diskfs_block_cache_prealloc(
+    struct diskfs_shared *shared,
+    struct evpl          *evpl)
+{
+    struct diskfs_block_cache *cache = shared->block_cache;
+    uint32_t                   i, j;
+
+    pthread_mutex_lock(&cache->prealloc_lock);
+    if (cache->buffers_ready) {
+        pthread_mutex_unlock(&cache->prealloc_lock);
+        return;
+    }
+
+    for (i = 0; i < DISKFS_BLOCK_CACHE_SHARDS; i++) {
+        struct diskfs_block_shard *shard = &cache->shards[i];
+        uint32_t                   total = shard->nblocks + cache->buffer_extra_per_shard;
+
+        shard->buffers  = calloc(total, sizeof(*shard->buffers));
+        shard->nbuffers = total;
+
+        for (j = 0; j < total; j++) {
+            struct diskfs_block_buf *buf = &shard->buffers[j];
+            int                      niov;
+
+            niov = evpl_iovec_alloc(evpl, DISKFS_BLOCK_SIZE, DISKFS_BLOCK_SIZE, 1,
+                                    EVPL_IOVEC_FLAG_SHARED, &buf->iov);
+            chimera_diskfs_abort_if(niov != 1,
+                                    "diskfs block buffer did not fit in one iovec (%d)",
+                                    niov);
+            buf->shard          = shard;
+            buf->on_free        = 1;
+            buf->next           = shard->free_buffers;
+            shard->free_buffers = buf;
+            shard->nfree_buffers++;
+        }
+
+        for (j = 0; j < shard->nblocks; j++) {
+            struct diskfs_block     *blk = &shard->pool[j];
+            struct diskfs_block_buf *buf = diskfs_block_buf_alloc_locked(shard);
+
+            blk->buf = buf;
+            blk->iov = buf->iov;
+        }
+    }
+
+    cache->buffers_ready = 1;
+    pthread_mutex_unlock(&cache->prealloc_lock);
+} /* diskfs_block_cache_prealloc */
+
+
+void
 diskfs_block_cache_destroy(struct diskfs_shared *shared)
 {
     struct diskfs_block_cache *cache = shared->block_cache;
@@ -228,18 +342,42 @@ diskfs_block_cache_destroy(struct diskfs_shared *shared)
         /* Release each block's buffer (NULL evpl -> straight to the global
          * allocator, which is correct at teardown); the structs are one pool
          * array.  At a clean unmount every block is CLEAN (refcount 1). */
-        for (j = 0; j < shard->nblocks; j++) {
-            if (shard->pool[j].iov.data) {
-                evpl_iovec_release(NULL, &shard->pool[j].iov);
-            }
+        for (j = 0; j < shard->nbuffers; j++) {
+            evpl_iovec_release(NULL, &shard->buffers[j].iov);
         }
+        free(shard->buffers);
         free(shard->pool);
         free(shard->buckets);
         pthread_mutex_destroy(&shard->lock);
     }
+    pthread_mutex_destroy(&cache->prealloc_lock);
     free(cache);
     shared->block_cache = NULL;
 } /* diskfs_block_cache_destroy */
+
+
+void
+diskfs_block_buf_release(struct diskfs_block_buf *buf)
+{
+    struct diskfs_block_shard *shard;
+    struct diskfs_block_buf   *head;
+
+    chimera_diskfs_abort_if(__atomic_load_n(&buf->refs, __ATOMIC_ACQUIRE) == 0,
+                            "diskfs block buffer ref underflow");
+    if (__atomic_sub_fetch(&buf->refs, 1, __ATOMIC_ACQ_REL) != 0) {
+        return;
+    }
+
+    shard = buf->shard;
+    chimera_diskfs_abort_if(__atomic_exchange_n(&buf->on_free, 1, __ATOMIC_ACQ_REL),
+                            "diskfs block buffer already free");
+
+    do {
+        head      = __atomic_load_n(&shard->returned_buffers, __ATOMIC_ACQUIRE);
+        buf->next = head;
+    } while (!__atomic_compare_exchange_n(&shard->returned_buffers, &head, buf,
+                                          0, __ATOMIC_RELEASE, __ATOMIC_ACQUIRE));
+} /* diskfs_block_buf_release */
 
 
 /*
@@ -250,15 +388,14 @@ diskfs_block_cache_destroy(struct diskfs_shared *shared)
  * -- so an allocation happens only on a never-yet-used pool slot (and on COW).
  */
 static inline void
-diskfs_block_ensure_iov(
+diskfs_block_assert_iov(
     struct diskfs_thread *thread,
     struct diskfs_block  *blk)
 {
-    if (!blk->iov.data) {
-        evpl_iovec_alloc(thread->evpl, DISKFS_BLOCK_SIZE, DISKFS_BLOCK_SIZE, 1,
-                         EVPL_IOVEC_FLAG_SHARED, &blk->iov);
-    }
-} /* diskfs_block_ensure_iov */
+    (void) thread;
+    chimera_diskfs_abort_if(!blk->buf || !blk->iov.data,
+                            "diskfs block used before buffer preallocation");
+} /* diskfs_block_assert_iov */
 
 
 /*
@@ -286,17 +423,19 @@ diskfs_block_claim(
 
     pthread_mutex_lock(&shard->lock);
 
+    diskfs_block_drain_returned_locked(shard);
+    diskfs_block_drain_clean_locked(shard);
     blk = diskfs_block_lookup_locked(shard, bucket, device_id, device_offset);
     if (!blk) {
         diskfs_metric_block_cache(thread, DISKFS_METRIC_BLOCK_CACHE_MISS);
         blk                = diskfs_block_recycle(thread, shard);
         blk->device_id     = device_id;
         blk->device_offset = device_offset;
-        blk->state         = DISKFS_BLOCK_CLEAN;
-        blk->seq           = 0;
-        blk->wait_head     = NULL;
-        blk->wait_tail     = NULL;
-        diskfs_block_ensure_iov(thread, blk);
+        __atomic_store_n(&blk->state, DISKFS_BLOCK_CLEAN, __ATOMIC_RELEASE);
+        __atomic_store_n(&blk->seq, 0, __ATOMIC_RELEASE);
+        blk->wait_head = NULL;
+        blk->wait_tail = NULL;
+        diskfs_block_assert_iov(thread, blk);
         if (is_new) {
             diskfs_metric_block_cache(thread, DISKFS_METRIC_BLOCK_CACHE_NEW);
         }
@@ -318,26 +457,26 @@ diskfs_block_claim(
     } else if (blk->on_lru) {
         diskfs_metric_block_cache(thread, DISKFS_METRIC_BLOCK_CACHE_HIT);
         diskfs_block_lru_unlink(shard, blk);
-    } else if (blk->state == DISKFS_BLOCK_LOGGED) {
+    } else if (__atomic_load_n(&blk->state, __ATOMIC_ACQUIRE) == DISKFS_BLOCK_LOGGED) {
         /* COW: this buffer is still referenced by an un-pushed redo record (and
          * the tail-pusher will write it home), so it must stay immutable.  Fork
          * a private writable copy; the old buffer rides the record to its home
          * and is freed when the pusher releases it.  Done under the shard lock
          * so it serializes against the pusher's LOGGED->CLEAN transition. */
-        struct evpl_iovec nv;
+        struct diskfs_block_buf *old = blk->buf;
+        struct diskfs_block_buf *new = diskfs_block_buf_alloc_locked(shard);
 
-        evpl_iovec_alloc(thread->evpl, DISKFS_BLOCK_SIZE, DISKFS_BLOCK_SIZE, 1,
-                         EVPL_IOVEC_FLAG_SHARED, &nv);
-        memcpy(nv.data, blk->iov.data, DISKFS_BLOCK_SIZE);
-        evpl_iovec_release(thread->evpl, &blk->iov);
-        evpl_iovec_move(&blk->iov, &nv);
-        blk->state = DISKFS_BLOCK_CLEAN;
+        memcpy(new->iov.data, old->iov.data, DISKFS_BLOCK_SIZE);
+        blk->buf = new;
+        blk->iov = new->iov;
+        diskfs_block_buf_release_locked(shard, old);
+        __atomic_store_n(&blk->state, DISKFS_BLOCK_CLEAN, __ATOMIC_RELEASE);
         diskfs_metric_block_cache(thread, DISKFS_METRIC_BLOCK_CACHE_COW);
     } else {
         diskfs_metric_block_cache(thread, DISKFS_METRIC_BLOCK_CACHE_HIT);
     }
 
-    blk->pin_count++;
+    __atomic_add_fetch(&blk->pin_count, 1, __ATOMIC_ACQ_REL);
     pthread_mutex_unlock(&shard->lock);
 
     return blk;
@@ -509,6 +648,7 @@ diskfs_block_waiter_dispatch(
         worker->resume_head = w;
     }
     worker->resume_tail = w;
+    __atomic_store_n(&worker->resume_pending, 1, __ATOMIC_RELEASE);
     pthread_mutex_unlock(&worker->resume_lock);
 
     if (worker == waker) {
@@ -537,10 +677,15 @@ diskfs_bt_resume_drain(struct diskfs_thread *thread)
 {
     struct diskfs_block_waiter *list, *w;
 
+    if (!__atomic_load_n(&thread->resume_pending, __ATOMIC_ACQUIRE)) {
+        return;
+    }
+
     pthread_mutex_lock(&thread->resume_lock);
     list                = thread->resume_head;
     thread->resume_head = NULL;
     thread->resume_tail = NULL;
+    __atomic_store_n(&thread->resume_pending, 0, __ATOMIC_RELEASE);
     pthread_mutex_unlock(&thread->resume_lock);
 
     while (list) {
@@ -581,6 +726,19 @@ diskfs_bt_resume_deferral_cb(
     diskfs_bt_resume_drain(private_data);
 } /* diskfs_bt_resume_deferral_cb */
 
+void
+diskfs_bt_resume_poll(
+    struct evpl *evpl,
+    void        *private_data)
+{
+    struct diskfs_thread *thread = private_data;
+
+    if (__atomic_load_n(&thread->resume_pending, __ATOMIC_ACQUIRE)) {
+        diskfs_bt_resume_drain(thread);
+        evpl_activity(evpl);
+    }
+} /* diskfs_bt_resume_poll */
+
 
 /* Block read completion: data landed directly in blk->iov; mark CLEAN, wake. */
 static void
@@ -601,7 +759,7 @@ diskfs_block_load_complete(
                             blk->device_offset, status);
 
     pthread_mutex_lock(&shard->lock);
-    blk->state     = DISKFS_BLOCK_CLEAN;
+    __atomic_store_n(&blk->state, DISKFS_BLOCK_CLEAN, __ATOMIC_RELEASE);
     waiters        = blk->wait_head;
     blk->wait_head = NULL;
     blk->wait_tail = NULL;
@@ -638,7 +796,7 @@ diskfs_bt_op_pin(
     if (blk->on_lru) {
         diskfs_block_lru_unlink(shard, blk);
     }
-    blk->pin_count++;
+    __atomic_add_fetch(&blk->pin_count, 1, __ATOMIC_ACQ_REL);
     chimera_diskfs_abort_if(op->npins >= (int) (sizeof(op->pins) / sizeof(op->pins[0])),
                             "b+tree op pin list overflow");
     op->pins[op->npins++] = blk;
@@ -670,10 +828,10 @@ diskfs_bt_block_get(
 
     if (!blk) {
         diskfs_metric_block_cache(thread, DISKFS_METRIC_BLOCK_CACHE_MISS);
-        blk                    = diskfs_block_recycle(thread, shard);
-        blk->device_id         = device_id;
-        blk->device_offset     = device_offset;
-        blk->state             = DISKFS_BLOCK_LOADING;
+        blk                = diskfs_block_recycle(thread, shard);
+        blk->device_id     = device_id;
+        blk->device_offset = device_offset;
+        __atomic_store_n(&blk->state, DISKFS_BLOCK_LOADING, __ATOMIC_RELEASE);
         blk->seq               = 0;
         blk->wait_head         = NULL;
         blk->wait_tail         = NULL;
@@ -704,7 +862,7 @@ diskfs_bt_block_get(
     pthread_mutex_unlock(&shard->lock);
 
     if (issue) {
-        diskfs_block_ensure_iov(thread, blk);
+        diskfs_block_assert_iov(thread, blk);
         ld         = malloc(sizeof(*ld));
         ld->blk    = blk;
         ld->thread = thread;
@@ -751,9 +909,11 @@ diskfs_block_claim_async(
 
     pthread_mutex_lock(&shard->lock);
 
+    diskfs_block_drain_returned_locked(shard);
+    diskfs_block_drain_clean_locked(shard);
     blk = diskfs_block_lookup_locked(shard, bucket, device_id, device_offset);
 
-    if (blk && blk->state == DISKFS_BLOCK_LOADING) {
+    if (blk && __atomic_load_n(&blk->state, __ATOMIC_ACQUIRE) == DISKFS_BLOCK_LOADING) {
         /* A read is already in flight: park and resume when it lands. */
         diskfs_metric_block_cache(thread, DISKFS_METRIC_BLOCK_CACHE_WAIT);
         w         = diskfs_block_waiter_alloc(thread);
@@ -775,24 +935,24 @@ diskfs_block_claim_async(
         blk                = diskfs_block_recycle(thread, shard);
         blk->device_id     = device_id;
         blk->device_offset = device_offset;
-        blk->seq           = 0;
-        blk->wait_head     = NULL;
-        blk->wait_tail     = NULL;
+        __atomic_store_n(&blk->seq, 0, __ATOMIC_RELEASE);
+        blk->wait_head = NULL;
+        blk->wait_tail = NULL;
 
         if (is_new) {
             diskfs_metric_block_cache(thread, DISKFS_METRIC_BLOCK_CACHE_NEW);
-            blk->state = DISKFS_BLOCK_CLEAN;
-            diskfs_block_ensure_iov(thread, blk);
+            __atomic_store_n(&blk->state, DISKFS_BLOCK_CLEAN, __ATOMIC_RELEASE);
+            diskfs_block_assert_iov(thread, blk);
             memset(blk->iov.data, 0, DISKFS_BLOCK_SIZE);
             blk->hash_next         = shard->buckets[bucket];
             shard->buckets[bucket] = blk;
-            blk->pin_count++;
+            __atomic_add_fetch(&blk->pin_count, 1, __ATOMIC_ACQ_REL);
             pthread_mutex_unlock(&shard->lock);
             return blk;
         }
 
         /* Miss: publish a LOADING block, park, and issue the async read. */
-        blk->state             = DISKFS_BLOCK_LOADING;
+        __atomic_store_n(&blk->state, DISKFS_BLOCK_LOADING, __ATOMIC_RELEASE);
         blk->hash_next         = shard->buckets[bucket];
         shard->buckets[bucket] = blk;
         w                      = diskfs_block_waiter_alloc(thread);
@@ -805,16 +965,16 @@ diskfs_block_claim_async(
     } else if (blk->on_lru) {
         diskfs_metric_block_cache(thread, DISKFS_METRIC_BLOCK_CACHE_HIT);
         diskfs_block_lru_unlink(shard, blk);
-    } else if (blk->state == DISKFS_BLOCK_LOGGED) {
+    } else if (__atomic_load_n(&blk->state, __ATOMIC_ACQUIRE) == DISKFS_BLOCK_LOGGED) {
         /* COW (see diskfs_block_claim): fork a private writable copy. */
-        struct evpl_iovec nv;
+        struct diskfs_block_buf *old = blk->buf;
+        struct diskfs_block_buf *new = diskfs_block_buf_alloc_locked(shard);
 
-        evpl_iovec_alloc(thread->evpl, DISKFS_BLOCK_SIZE, DISKFS_BLOCK_SIZE, 1,
-                         EVPL_IOVEC_FLAG_SHARED, &nv);
-        memcpy(nv.data, blk->iov.data, DISKFS_BLOCK_SIZE);
-        evpl_iovec_release(thread->evpl, &blk->iov);
-        evpl_iovec_move(&blk->iov, &nv);
-        blk->state = DISKFS_BLOCK_CLEAN;
+        memcpy(new->iov.data, old->iov.data, DISKFS_BLOCK_SIZE);
+        blk->buf = new;
+        blk->iov = new->iov;
+        diskfs_block_buf_release_locked(shard, old);
+        __atomic_store_n(&blk->state, DISKFS_BLOCK_CLEAN, __ATOMIC_RELEASE);
         diskfs_metric_block_cache(thread, DISKFS_METRIC_BLOCK_CACHE_COW);
     } else {
         diskfs_metric_block_cache(thread, DISKFS_METRIC_BLOCK_CACHE_HIT);
@@ -822,7 +982,7 @@ diskfs_block_claim_async(
 
     if (issue) {
         pthread_mutex_unlock(&shard->lock);
-        diskfs_block_ensure_iov(thread, blk);
+        diskfs_block_assert_iov(thread, blk);
         ld         = malloc(sizeof(*ld));
         ld->blk    = blk;
         ld->thread = thread;
@@ -836,7 +996,7 @@ diskfs_block_claim_async(
         return NULL;
     }
 
-    blk->pin_count++;
+    __atomic_add_fetch(&blk->pin_count, 1, __ATOMIC_ACQ_REL);
     pthread_mutex_unlock(&shard->lock);
     return blk;
 } /* diskfs_block_claim_async */

--- a/src/vfs/diskfs/diskfs_inode.c
+++ b/src/vfs/diskfs/diskfs_inode.c
@@ -129,6 +129,8 @@ diskfs_dispatch_grant(struct diskfs_inode_waiter *w)
 {
     struct diskfs_thread *worker = w->txn->thread;
 
+    w->dispatched_ns = diskfs_diag_now_ns();
+
     pthread_mutex_lock(&worker->grant_lock);
     w->next = NULL;
     if (worker->grant_tail) {
@@ -137,6 +139,7 @@ diskfs_dispatch_grant(struct diskfs_inode_waiter *w)
         worker->grant_head = w;
     }
     worker->grant_tail = w;
+    __atomic_store_n(&worker->grant_pending, 1, __ATOMIC_RELEASE);
     pthread_mutex_unlock(&worker->grant_lock);
 
     evpl_ring_doorbell(&worker->grant_doorbell);
@@ -176,6 +179,7 @@ diskfs_inode_release_one(
             if (!inode->wait_head) {
                 inode->wait_tail = NULL;
             }
+            inode->wait_count--;
             w->status = CHIMERA_VFS_ENOENT;
             w->next   = granted;
             granted   = w;
@@ -190,6 +194,7 @@ diskfs_inode_release_one(
         if (!inode->wait_head) {
             inode->wait_tail = NULL;
         }
+        inode->wait_count--;
         diskfs_inode_lock_grant(inode, w->mode);
         w->status = CHIMERA_VFS_OK;
         w->next   = granted;
@@ -262,6 +267,8 @@ diskfs_inode_grant_locked(
     w->cb           = cb;
     w->private_data = private_data;
     w->inode        = inode;
+    w->queued_ns    = diskfs_diag_now_ns();
+    w->queue_depth  = inode->wait_count + 1;
     w->status       = CHIMERA_VFS_OK;
     w->next         = NULL;
 
@@ -271,6 +278,20 @@ diskfs_inode_grant_locked(
         inode->wait_head = w;
     }
     inode->wait_tail = w;
+    inode->wait_count++;
+    if (inode->wait_count > inode->wait_high_water) {
+        inode->wait_high_water = inode->wait_count;
+        if (inode->wait_high_water == 64 ||
+            inode->wait_high_water == 256 ||
+            inode->wait_high_water == 1024 ||
+            (inode->wait_high_water > 1024 &&
+             (inode->wait_high_water % 1024) == 0)) {
+            chimera_diskfs_error(
+                "inode wait highwater inum=%llu depth=%u readers=%d writer=%d mode=%d",
+                (unsigned long long) inode->inum, inode->wait_high_water,
+                inode->readers, inode->writer, mode);
+        }
+    }
 
     pthread_mutex_unlock(&shard->lock);
 } /* diskfs_inode_grant_locked */
@@ -615,22 +636,21 @@ diskfs_gen_alloc(
  * the releasing thread; here we record the slot (on this, the txn's own
  * thread) and resume the parked continuation.
  */
-void
-diskfs_grant_doorbell_cb(
-    struct evpl          *evpl,
-    struct evpl_doorbell *doorbell)
+static int
+diskfs_grant_drain(struct diskfs_thread *thread)
 {
-    struct diskfs_thread       *thread = container_of(doorbell,
-                                                      struct diskfs_thread,
-                                                      grant_doorbell);
     struct diskfs_inode_waiter *list, *w;
+    int                         drained = 0;
 
-    (void) evpl;
+    if (!__atomic_load_n(&thread->grant_pending, __ATOMIC_ACQUIRE)) {
+        return 0;
+    }
 
     pthread_mutex_lock(&thread->grant_lock);
     list               = thread->grant_head;
     thread->grant_head = NULL;
     thread->grant_tail = NULL;
+    __atomic_store_n(&thread->grant_pending, 0, __ATOMIC_RELEASE);
     pthread_mutex_unlock(&thread->grant_lock);
 
     while (list) {
@@ -641,6 +661,7 @@ diskfs_grant_doorbell_cb(
 
         w    = list;
         list = w->next;
+        drained++;
 
         cb           = w->cb;
         private_data = w->private_data;
@@ -648,6 +669,24 @@ diskfs_grant_doorbell_cb(
         status       = w->status;
 
         if (status == CHIMERA_VFS_OK) {
+            uint64_t wait_ns = diskfs_diag_now_ns() - w->queued_ns;
+
+            if (wait_ns > 1000000000ULL) {
+                uint64_t grant_ns = w->dispatched_ns ?
+                    w->dispatched_ns - w->queued_ns : 0;
+                uint64_t callback_ns = w->dispatched_ns ?
+                    wait_ns - grant_ns : 0;
+
+                chimera_diskfs_error(
+                    "inode waiter callback after %llu sec inum=%llu mode=%d queued_depth=%u grant_wait_ms=%llu callback_wait_ms=%llu",
+                    (unsigned long long) (wait_ns / 1000000000ULL),
+                    inode ? (unsigned long long) inode->inum : 0ULL,
+                    w->mode,
+                    w->queue_depth,
+                    (unsigned long long) (grant_ns / 1000000ULL),
+                    (unsigned long long) (callback_ns / 1000000ULL));
+            }
+
             struct diskfs_txn          *wtxn  = w->txn;
             enum diskfs_inode_lock_mode wmode = w->mode;
 
@@ -666,7 +705,33 @@ diskfs_grant_doorbell_cb(
             cb(NULL, status, private_data);
         }
     }
+    return drained;
+} /* diskfs_grant_drain */
+
+
+void
+diskfs_grant_doorbell_cb(
+    struct evpl          *evpl,
+    struct evpl_doorbell *doorbell)
+{
+    struct diskfs_thread *thread = container_of(doorbell,
+                                                struct diskfs_thread,
+                                                grant_doorbell);
+
+    (void) evpl;
+    diskfs_grant_drain(thread);
 } /* diskfs_grant_doorbell_cb */
+
+
+void
+diskfs_grant_poll(
+    struct evpl *evpl,
+    void        *private_data)
+{
+    if (diskfs_grant_drain(private_data)) {
+        evpl_activity(evpl);
+    }
+} /* diskfs_grant_poll */
 
 
 /* ================================================================== */

--- a/src/vfs/diskfs/diskfs_internal.h
+++ b/src/vfs/diskfs/diskfs_internal.h
@@ -147,6 +147,15 @@
                                                 __LINE__, \
                                                 __VA_ARGS__)
 
+static inline uint64_t
+diskfs_diag_now_ns(void)
+{
+    struct timespec ts;
+
+    clock_gettime(CLOCK_MONOTONIC_COARSE, &ts);
+    return (uint64_t) ts.tv_sec * 1000000000ULL + (uint64_t) ts.tv_nsec;
+} /* diskfs_diag_now_ns */
+
 #define chimera_diskfs_fatal(...) chimera_fatal("diskfs", \
                                                 __FILE__, \
                                                 __LINE__, \
@@ -514,6 +523,9 @@ struct diskfs_inode_waiter {
     diskfs_inode_cb_t           cb;
     void                       *private_data;
     struct diskfs_inode        *inode;
+    uint64_t                    queued_ns;
+    uint64_t                    dispatched_ns;
+    uint32_t                    queue_depth;
     struct diskfs_inode_waiter *next;
 };
 
@@ -547,6 +559,8 @@ struct diskfs_inode {
     int                         writer;      /* 0/1 exclusive holder */
     struct diskfs_inode_waiter *wait_head;
     struct diskfs_inode_waiter *wait_tail;
+    uint32_t                    wait_count;
+    uint32_t                    wait_high_water;
 
     /* Eviction: an idle inode (refcnt==1, unlocked) sits on its shard's LRU
      * as a recycle candidate.  All under the shard lock. */
@@ -641,6 +655,24 @@ enum diskfs_block_state {
 struct diskfs_bt_op;
 
 struct diskfs_block_waiter;
+struct diskfs_block_shard;
+
+
+/*
+ * Backing storage for a cached metadata block.  These buffers are allocated
+ * once from EVPL during diskfs startup so the memory remains registered for
+ * block I/O, but lifetime is owned by diskfs.  Cache blocks and intent-log
+ * redo records hold diskfs refs; EVPL refs are released only when the cache is
+ * destroyed.  This prevents 4 KiB metadata blocks from repeatedly mixing with
+ * unrelated EVPL shared allocations.
+ */
+struct diskfs_block_buf {
+    struct evpl_iovec          iov;
+    uint32_t                   refs;
+    int                        on_free;
+    struct diskfs_block_shard *shard;
+    struct diskfs_block_buf   *next;
+};
 
 
 /*
@@ -657,14 +689,16 @@ struct diskfs_block_waiter;
 struct diskfs_block {
     uint32_t                    device_id;
     uint64_t                    device_offset; /* block-aligned; key with device_id */
-    struct evpl_iovec           iov;           /* SHARED DISKFS_BLOCK_SIZE buffer; .data may
-                                                * be NULL on a never-yet-used pool slot */
+    struct diskfs_block_buf    *buf;           /* diskfs-owned backing buffer */
+    struct evpl_iovec           iov;           /* alias of buf->iov for existing I/O paths */
     int                         pin_count;     /* >0 => pinned, not reclaimable */
     enum diskfs_block_state state;
     uint64_t                    seq;           /* update order for tail-push */
     struct diskfs_block        *hash_next;     /* bucket chain */
     struct diskfs_block        *lru_prev, *lru_next; /* shard LRU (CLEAN + unpinned) */
+    struct diskfs_block        *clean_next;    /* atomic clean-return queue */
     int                         on_lru;        /* 1 iff linked on the shard LRU */
+    int                         clean_queued;  /* 1 iff queued on shard clean queue */
 
     /* Continuations blocked on a LOADING block, woken when the read I/O
      * completes.  Each waiter names its owning worker, so a completion that
@@ -676,22 +710,33 @@ struct diskfs_block {
 
 
 struct diskfs_block_shard {
-    pthread_mutex_t       lock;
-    struct diskfs_block **buckets;     /* [DISKFS_BLOCK_CACHE_BUCKETS_PER_SHARD] */
+    pthread_mutex_t          lock;
+    struct diskfs_block    **buckets;  /* [DISKFS_BLOCK_CACHE_BUCKETS_PER_SHARD] */
 
     /* Pre-allocated fixed pool of block structs (all protected by lock); the
      * structs are never individually freed.  Each struct's buffer is a SHARED
      * evpl iovec allocated lazily on first use and reused across recyclings
      * (released only at teardown).  The LRU holds only CLEAN, unpinned buffers
      * (recycle candidates), ordered least-recently-used first. */
-    struct diskfs_block  *pool;                 /* [nblocks] */
-    struct diskfs_block  *lru_head, *lru_tail;  /* lru_head = next to recycle */
-    uint32_t              nblocks;              /* block structs owned by this shard */
+    struct diskfs_block     *pool;              /* [nblocks] */
+    struct diskfs_block     *lru_head, *lru_tail; /* lru_head = next to recycle */
+    uint32_t                 nblocks;           /* block structs owned by this shard */
+
+    struct diskfs_block_buf *buffers;           /* [nbuffers] */
+    struct diskfs_block_buf *free_buffers;
+    struct diskfs_block_buf *returned_buffers;   /* atomic stack, drained under lock */
+    struct diskfs_block     *clean_head;
+    struct diskfs_block     *clean_tail;
+    uint32_t                 nbuffers;
+    uint32_t                 nfree_buffers;
 };
 
 
 struct diskfs_block_cache {
     uint32_t                  shard_cap;   /* max resident buffers per shard */
+    uint32_t                  buffer_extra_per_shard;
+    int                       buffers_ready;
+    pthread_mutex_t           prealloc_lock;
     struct diskfs_block_shard shards[DISKFS_BLOCK_CACHE_SHARDS];
 };
 
@@ -705,11 +750,12 @@ struct diskfs_block_cache {
  * default is 2x the journal (comfortable per-shard headroom over the variance),
  * and a configured size is floored at 1.5x.
  */
-#define DISKFS_INTENT_LOG_BLOCKS          (SM_INTENT_LOG_SIZE / SM_BLOCK_SIZE)
+#define DISKFS_INTENT_LOG_BLOCKS(sz)          ((sz) / SM_BLOCK_SIZE)
 
-#define DISKFS_BLOCK_CACHE_DEFAULT_BLOCKS (2 * DISKFS_INTENT_LOG_BLOCKS)
+#define DISKFS_BLOCK_CACHE_DEFAULT_BLOCKS(sz) (2 * DISKFS_INTENT_LOG_BLOCKS(sz))
 
-#define DISKFS_BLOCK_CACHE_MIN_BLOCKS     (DISKFS_INTENT_LOG_BLOCKS + DISKFS_INTENT_LOG_BLOCKS / 2)
+#define DISKFS_BLOCK_CACHE_MIN_BLOCKS(sz)     (DISKFS_INTENT_LOG_BLOCKS(sz) + \
+                                               DISKFS_INTENT_LOG_BLOCKS(sz) / 2)
 
 
 /*
@@ -721,13 +767,13 @@ struct diskfs_block_cache {
  * records in the inode's single b+tree; the root node is embedded in the
  * inode block, and deeper nodes occupy their own 4 KiB blocks.
  */
-#define DISKFS_INODE_AREA                 256
+#define DISKFS_INODE_AREA   256
 
-#define DISKFS_BT_ROOT_BASE               DISKFS_INODE_AREA
+#define DISKFS_BT_ROOT_BASE DISKFS_INODE_AREA
 
-#define DISKFS_BT_ROOT_CAP                (DISKFS_BLOCK_SIZE - DISKFS_INODE_AREA) /* 3840 */
+#define DISKFS_BT_ROOT_CAP  (DISKFS_BLOCK_SIZE - DISKFS_INODE_AREA)    /* 3840 */
 
-#define DISKFS_BT_NODE_CAP                DISKFS_BLOCK_SIZE            /* 4096 */
+#define DISKFS_BT_NODE_CAP  DISKFS_BLOCK_SIZE                          /* 4096 */
 
 
 struct diskfs_dinode {
@@ -901,6 +947,8 @@ struct diskfs_redo_block_header {
     uint32_t device_id;
     uint32_t pad;
     uint64_t device_offset;
+    uint64_t block_csum_lo;
+    uint64_t block_csum_hi;
 };
 
 
@@ -919,6 +967,9 @@ struct diskfs_txn_block {
      * the live block->iov and the record captures this txn's committed image
      * even if a later writer COWs the cache block. */
     struct evpl_iovec        snap;
+    struct diskfs_block_buf *snap_buf;
+    uint64_t                 snap_csum_lo;
+    uint64_t                 snap_csum_hi;
     struct diskfs_txn_block *next;
 };
 
@@ -1032,23 +1083,25 @@ struct diskfs_iq_channel {
  * that re-dirties the live cache block.
  */
 struct diskfs_il_record {
-    uint64_t                 seq;
-    uint64_t                 offset;     /* byte offset in the intent-log region */
-    uint64_t                 reclen;
-    uint32_t                 num_blocks;
-    uint32_t                 niov;       /* 1 + num_blocks */
+    uint64_t                  seq;
+    uint64_t                  offset;    /* byte offset in the intent-log region */
+    uint64_t                  reclen;
+    uint32_t                  num_blocks;
+    uint32_t                  niov;      /* 1 + num_blocks */
     /* Scatter-gather image of the on-log record: iovs[0] is the 4 KiB-aligned
     * header region (redo_header + per-block headers); iovs[1..num_blocks] are
     * zero-copy refs (clones) of the cache blocks' buffers.  The same refs are
     * handed to the tail-pusher, so a block image is copied only when a writer
     * must fork a still-referenced block (COW), never on the log/push path. */
-    struct evpl_iovec       *iovs;
-    struct diskfs_il_record *next;
+    struct evpl_iovec        *iovs;
+    struct diskfs_block_buf **block_bufs;
+    struct diskfs_block     **blocks;
+    struct diskfs_il_record  *next;
     /* Push-thread lifetime: a record is freed only after it is logically
      * retired (trimmed from the log) AND no in-flight home write still reads
      * its iovs (inflight_refs == 0). */
-    int                      inflight_refs;
-    int                      retired;
+    int                       inflight_refs;
+    int                       retired;
 };
 
 
@@ -1150,6 +1203,7 @@ struct diskfs_intent_log {
     uint32_t                         handoff_tail;    /* atomic: commit producer */
     uint64_t                         log_head;        /* atomic: commit-written (next free byte) */
     uint64_t                         log_tail;        /* atomic: push-written (trim point) */
+    uint64_t                         intent_log_size; /* active log size (from space_map / superblock) */
     int                              sync;            /* FUA/sync flag (0 in unsafe_async) */
 
     /* ---------- metrics ---------- */
@@ -1178,6 +1232,7 @@ struct diskfs_shared {
     int                         noatime;           /* config opt-in: never update atime on read (default: relatime) */
     uint64_t                    mtime_defer_us;    /* coalesce non-FILE_SYNC in-place mtime updates: flush each dirty inode at most once per this many us (0 = disabled, log every write); default 1s */
     int                         mounted;           /* 1 = remounted existing FS (enables inode read-back) */
+    uint64_t                    intent_log_size;   /* config knob (0 -> default at parse); persisted in the superblock */
     uint32_t                    block_cache_blocks; /* total resident block-buffer cap (0 = default) */
     uint32_t                    inode_cache_inodes; /* total resident inode cap (0 = default) */
     int                         block_layout;      /* config opt-in: advertise pNFS block layouts */
@@ -1223,6 +1278,8 @@ struct diskfs_thread {
     struct diskfs_inode_waiter  *waiter_free_list;
     struct diskfs_iq_channel    *iq_channel;
     struct evpl_poll            *cq_poll;          /* drains this worker's IL completion queue every loop iteration */
+    struct evpl_poll            *grant_poll;       /* drains cross-thread inode grants while poll-pinned */
+    struct evpl_poll            *resume_poll;      /* drains block/B-tree resume queue while poll-pinned */
     uint32_t                     commits_inflight; /* commits handed to the IL not yet completed; pins poll mode while > 0 */
     int                          pending_io;
 
@@ -1240,6 +1297,7 @@ struct diskfs_thread {
     struct diskfs_inode_waiter  *grant_head;
     struct diskfs_inode_waiter  *grant_tail;
     struct evpl_doorbell         grant_doorbell;
+    int                          grant_pending;
 
     /* Cross-thread continuation resumption: when a block this worker has
      * waiters on finishes loading (possibly on another worker that issued the
@@ -1250,6 +1308,7 @@ struct diskfs_thread {
     struct diskfs_block_waiter  *resume_tail;
     struct evpl_doorbell         resume_doorbell;
     struct evpl_deferral         resume_deferral;
+    int                          resume_pending;
     struct diskfs_bt_op         *bt_op_free_list;
     struct diskfs_block_waiter  *block_waiter_free_list;
 
@@ -1706,10 +1765,16 @@ struct diskfs_inode_alloc_ctx {
 /* ------------------------------------------------------------------ */
 
 /* Completion context for an in-flight redo-record write. */
-struct diskfs_redo_ctx {
-    struct diskfs_intent_log *il;
+struct diskfs_redo_entry {
     struct diskfs_iq_channel *ch;
     struct diskfs_iq_entry    entry;
+};
+
+
+struct diskfs_redo_ctx {
+    struct diskfs_intent_log *il;
+    struct diskfs_redo_entry *entries; /* one CQE/completion per grouped txn */
+    uint32_t                  num_entries;
     struct diskfs_il_record  *rec;     /* owns the record image (iovs) */
     int                       segments; /* outstanding journal writes (see below) */
     uint64_t                  retire_idx; /* slot in the commit retirement ring */
@@ -1939,6 +2004,11 @@ diskfs_block_cache_create(
     struct diskfs_shared *shared);
 
 void
+diskfs_block_cache_prealloc(
+    struct diskfs_shared *shared,
+    struct evpl          *evpl);
+
+void
 diskfs_block_cache_destroy(
     struct diskfs_shared *shared);
 
@@ -1948,6 +2018,10 @@ diskfs_block_claim(
     uint32_t              device_id,
     uint64_t              device_offset,
     int                   is_new);
+
+void
+diskfs_block_buf_release(
+    struct diskfs_block_buf *buf);
 
 void *
 diskfs_sm_claim_block(
@@ -2000,6 +2074,11 @@ diskfs_bt_resume_doorbell_cb(
 
 void
 diskfs_bt_resume_deferral_cb(
+    struct evpl *evpl,
+    void        *private_data);
+
+void
+diskfs_bt_resume_poll(
     struct evpl *evpl,
     void        *private_data);
 
@@ -2402,6 +2481,11 @@ void
 diskfs_grant_doorbell_cb(
     struct evpl          *evpl,
     struct evpl_doorbell *doorbell);
+
+void
+diskfs_grant_poll(
+    struct evpl *evpl,
+    void        *private_data);
 
 int
 diskfs_mtime_any_dirty(
@@ -3161,7 +3245,7 @@ diskfs_il_used_bytes(struct diskfs_intent_log *il)
     if (head >= tail) {
         return head - tail;
     }
-    return SM_INTENT_LOG_SIZE - (tail - head);
+    return il->intent_log_size - (tail - head);
 } /* diskfs_il_used_bytes */
 
 
@@ -3448,6 +3532,21 @@ diskfs_inode_idle(const struct diskfs_inode *inode)
 } /* diskfs_inode_idle */
 
 
+static inline void
+diskfs_inode_ref_get(
+    struct diskfs_thread *thread,
+    struct diskfs_inode  *inode)
+{
+    struct diskfs_inode_shard *shard = diskfs_inode_shard(thread->shared,
+                                                          inode->inum);
+
+    pthread_mutex_lock(&shard->lock);
+    inode->refcnt++;
+    diskfs_inode_lru_unlink(shard, inode);
+    pthread_mutex_unlock(&shard->lock);
+} /* diskfs_inode_ref_get */
+
+
 /*
  * Caller holds the inode's shard lock.  Queue a freshly-dirtied inode on the
  * shard's deferred-mtime list, taking a refcnt pin so it stays resident until
@@ -3680,10 +3779,56 @@ diskfs_txn_add_block(
 {
     struct diskfs_txn_block *tb = malloc(sizeof(*tb));
 
-    tb->block   = block;
-    tb->next    = txn->blocks;
-    txn->blocks = tb;
+    tb->block        = block;
+    tb->snap_buf     = NULL;
+    tb->snap_csum_lo = 0;
+    tb->snap_csum_hi = 0;
+    tb->next         = txn->blocks;
+    txn->blocks      = tb;
 } /* diskfs_txn_add_block */
+
+
+static inline void
+diskfs_block_buf_ref_locked(struct diskfs_block_buf *buf)
+{
+    chimera_diskfs_abort_if(buf->on_free,
+                            "referencing free diskfs block buffer");
+    __atomic_add_fetch(&buf->refs, 1, __ATOMIC_ACQ_REL);
+} /* diskfs_block_buf_ref_locked */
+
+
+static inline void
+diskfs_block_buf_release_locked(
+    struct diskfs_block_shard *shard,
+    struct diskfs_block_buf   *buf)
+{
+    chimera_diskfs_abort_if(buf->refs == 0,
+                            "diskfs block buffer ref underflow");
+    if (--buf->refs == 0) {
+        chimera_diskfs_abort_if(buf->on_free,
+                                "diskfs block buffer already free");
+        buf->on_free        = 1;
+        buf->next           = shard->free_buffers;
+        shard->free_buffers = buf;
+        shard->nfree_buffers++;
+    }
+} /* diskfs_block_buf_release_locked */
+
+
+static inline struct diskfs_block_buf *
+diskfs_block_buf_alloc_locked(struct diskfs_block_shard *shard)
+{
+    struct diskfs_block_buf *buf = shard->free_buffers;
+
+    chimera_diskfs_abort_if(!buf,
+                            "diskfs block buffer pool exhausted during COW");
+    shard->free_buffers = buf->next;
+    shard->nfree_buffers--;
+    buf->next = NULL;
+    __atomic_store_n(&buf->on_free, 0, __ATOMIC_RELEASE);
+    __atomic_store_n(&buf->refs, 1, __ATOMIC_RELEASE);
+    return buf;
+} /* diskfs_block_buf_alloc_locked */
 
 
 static inline struct diskfs_bt_op *
@@ -4071,8 +4216,9 @@ diskfs_inode_alloc_space(
     uint32_t          role = space_map_has_remote(sm) ? SM_DEV_REMOTE : SM_DEV_LOCAL;
 
     DISKFS_SM_JNL(jnl, thread, txn, resume, resume_arg);
-    rc = space_map_alloc(sm, &inode->space_resv, &jnl, role,
-                         (uint64_t) desired_size, floor, &dev_id, r_device_offset);
+    rc = space_map_alloc_volatile_reservation(sm, &inode->space_resv, &jnl,
+                                              role, (uint64_t) desired_size,
+                                              floor, &dev_id, r_device_offset);
 
     if (rc == SM_AGAIN) {
         return SM_AGAIN;        /* parked; caller's resume re-drives */
@@ -4122,10 +4268,9 @@ diskfs_inode_return_reservation(
         return;
     }
 
-    diskfs_thread_free_space(thread, txn, resv->device_id, resv->offset,
-                             resv->length);
-    resv->valid  = 0;
-    resv->length = 0;
+    (void) thread;
+    (void) txn;
+    space_map_thread_cache_discard_volatile(thread->shared->space_map, resv);
 } /* diskfs_inode_return_reservation */
 
 

--- a/src/vfs/diskfs/diskfs_io.c
+++ b/src/vfs/diskfs/diskfs_io.c
@@ -57,6 +57,25 @@ static void
 diskfs_inode_load_recs_done(
     struct diskfs_inode_load_ctx *lc);
 
+static inline int
+diskfs_write_data_sync(
+    struct diskfs_shared       *shared,
+    struct chimera_vfs_request *request)
+{
+    (void) request;
+    return !shared->unsafe_async;
+} /* diskfs_write_data_sync */
+
+static inline uint32_t
+diskfs_write_reported_sync(
+    struct diskfs_shared       *shared,
+    struct chimera_vfs_request *request)
+{
+    (void) shared;
+    (void) request;
+    return CHIMERA_VFS_WRITE_FILESYNC;
+} /* diskfs_write_reported_sync */
+
 static void
 diskfs_inode_load_recs_pnfs_cb(
     struct diskfs_bt_op *op,
@@ -1572,7 +1591,7 @@ diskfs_write_phase2(
                          request->write.iov,
                          request->write.niov,
                          diskfs_private->rmw_device_offset,
-                         !shared->unsafe_async,
+                         diskfs_write_data_sync(shared, request),
                          diskfs_io_callback,
                          request);
         return;
@@ -1700,7 +1719,7 @@ diskfs_write_phase2(
                          chunk_iov,
                          chunk_niov,
                          diskfs_private->rmw_device_offset + offset,
-                         !shared->unsafe_async,
+                         diskfs_write_data_sync(shared, request),
                          diskfs_io_callback,
                          request);
 
@@ -1881,7 +1900,7 @@ diskfs_write_finish_map(struct chimera_vfs_request *request)
 
         diskfs_txn_drop_inode_block(thread, diskfs_private->txn, inode);
         diskfs_metric_mtime(thread, DISKFS_METRIC_MTIME_DEFERRED);
-        request->write.r_sync = CHIMERA_VFS_WRITE_DATASYNC;
+        request->write.r_sync = diskfs_write_reported_sync(shared, request);
     } else {
         /* Record which gate stopped the deferral (in expression order). */
         if (!diskfs_private->inplace_written) {
@@ -1891,7 +1910,7 @@ diskfs_write_finish_map(struct chimera_vfs_request *request)
         } else if (request->write.sync == CHIMERA_VFS_WRITE_FILESYNC) {
             diskfs_metric_mtime(thread, DISKFS_METRIC_MTIME_SKIP_FILESYNC);
         }
-        request->write.r_sync = CHIMERA_VFS_WRITE_FILESYNC;
+        request->write.r_sync = diskfs_write_reported_sync(shared, request);
     }
 
     /* Do NOT release the inode lock here.  The dirty b+tree/inode blocks are
@@ -2427,7 +2446,7 @@ diskfs_write_inode_cb(
         diskfs_map_attrs(thread, &request->write.r_post_attr, inode);
 
         request->write.r_length = 0;
-        request->write.r_sync   = CHIMERA_VFS_WRITE_FILESYNC;
+        request->write.r_sync   = diskfs_write_reported_sync(thread->shared, request);
         diskfs_op_ok(request, p->txn);
         return;
     }

--- a/src/vfs/diskfs/diskfs_log.c
+++ b/src/vfs/diskfs/diskfs_log.c
@@ -110,8 +110,17 @@ diskfs_il_push_doorbell_cb(
 static void
 diskfs_il_write_redo(
     struct diskfs_intent_log *il,
-    struct diskfs_iq_channel *ch,
-    struct diskfs_iq_entry   *entry);
+    struct diskfs_redo_entry *entries,
+    uint32_t                  num_entries,
+    uint32_t                  nblocks);
+
+static uint32_t
+diskfs_il_txn_blocks(
+    struct diskfs_txn *txn);
+
+static uint64_t
+diskfs_il_blocks_reclen(
+    uint32_t nblocks);
 
 static uint64_t
 diskfs_il_txn_reclen(
@@ -185,12 +194,12 @@ static uint64_t
 diskfs_il_contig_free(struct diskfs_intent_log *il)
 {
     uint64_t start = SM_INTENT_LOG_OFFSET;
-    uint64_t end   = SM_INTENT_LOG_OFFSET + SM_INTENT_LOG_SIZE;
+    uint64_t end   = SM_INTENT_LOG_OFFSET + il->intent_log_size;
     uint64_t head  = il->log_head;     /* commit-owned */
     uint64_t tail  = __atomic_load_n(&il->log_tail, __ATOMIC_ACQUIRE);
 
     if (head == tail) {
-        return SM_INTENT_LOG_SIZE;     /* empty */
+        return il->intent_log_size;     /* empty */
     }
     if (head >= tail) {
         uint64_t run_end   = end - head;
@@ -217,7 +226,7 @@ diskfs_il_place(
     struct diskfs_intent_log *il,
     uint64_t                  reclen)
 {
-    uint64_t end  = SM_INTENT_LOG_OFFSET + SM_INTENT_LOG_SIZE;
+    uint64_t end  = SM_INTENT_LOG_OFFSET + il->intent_log_size;
     uint64_t head = il->log_head;
     uint64_t offset;
 
@@ -370,7 +379,14 @@ diskfs_il_free_record(
     struct diskfs_intent_log *il,
     struct diskfs_il_record  *rec)
 {
-    evpl_iovecs_release(il->push_evpl, rec->iovs, rec->niov);
+    uint32_t i;
+
+    evpl_iovec_release(il->push_evpl, &rec->iovs[0]);
+    for (i = 0; i < rec->num_blocks; i++) {
+        evpl_iovec_release(il->push_evpl, &rec->iovs[1 + i]);
+        diskfs_block_buf_release(rec->block_bufs[i]);
+    }
+    free(rec->block_bufs);
     free(rec->iovs);
     free(rec);
 } /* diskfs_il_free_record */
@@ -684,33 +700,35 @@ diskfs_redo_write_cb(
            il->retire[il->retire_head & DISKFS_RETIRE_RING_MASK].done) {
         struct diskfs_retire_slot *slot = &il->retire[il->retire_head & DISKFS_RETIRE_RING_MASK];
         struct diskfs_redo_ctx    *rc   = slot->ctx;
-        struct diskfs_iq_channel  *ch   = rc->ch;
         struct diskfs_il_record   *rec  = rc->rec;
-        uint32_t                   cq_tail, ht;
+        uint32_t                   ht, i;
 
-        prometheus_stopwatch_start(&rc->entry.durable_time);
-        diskfs_metric_time_sample(
-            il->metrics.txn_latency[DISKFS_METRIC_TXN_SUBMIT_TO_DURABLE],
-            &rc->entry.submit_time);
-        diskfs_metric_time_sample(
-            il->metrics.txn_latency[DISKFS_METRIC_TXN_QUEUE_TO_DURABLE],
-            &rc->entry.enqueue_time);
+        for (i = 0; i < rc->num_entries; i++) {
+            struct diskfs_iq_channel *ch    = rc->entries[i].ch;
+            struct diskfs_iq_entry   *entry = &rc->entries[i].entry;
+            uint32_t                  cq_tail;
 
-        /* Record durable & recoverable: drop block pins (-> LOGGED), return
-         * freed ranges to the allocator, release the inode locks. */
-        diskfs_txn_unpin_blocks(rc->entry.txn, DISKFS_BLOCK_LOGGED);
-        diskfs_txn_apply_frees(rc->entry.txn);
-        diskfs_txn_unlock_all(rc->entry.txn);
+            prometheus_stopwatch_start(&entry->durable_time);
+            diskfs_metric_time_sample(
+                il->metrics.txn_latency[DISKFS_METRIC_TXN_SUBMIT_TO_DURABLE],
+                &entry->submit_time);
+            diskfs_metric_time_sample(
+                il->metrics.txn_latency[DISKFS_METRIC_TXN_QUEUE_TO_DURABLE],
+                &entry->enqueue_time);
 
-        /* ACK the worker by posting the CQE.  No doorbell: the worker is pinned
-         * in poll mode while it has a commit outstanding (diskfs_txn_commit_finish),
-         * so it reaps this via diskfs_iq_cq_poll every loop iteration.  The
-         * cq_doorbell remains registered only as a backstop. */
-        rc->entry.status                              = 0;
-        cq_tail                                       = __atomic_load_n(&ch->cq.tail, __ATOMIC_RELAXED);
-        ch->cq.entries[cq_tail & DISKFS_IQ_RING_MASK] = rc->entry;
-        __atomic_store_n(&ch->cq.tail, cq_tail + 1, __ATOMIC_RELEASE);
-        ch->cq_inflight--;
+            /* Record durable & recoverable: drop block pins (-> LOGGED),
+             * return freed ranges to the allocator, release inode locks, then
+             * ACK this transaction back to its worker. */
+            diskfs_txn_unpin_blocks(entry->txn, DISKFS_BLOCK_LOGGED);
+            diskfs_txn_apply_frees(entry->txn);
+            diskfs_txn_unlock_all(entry->txn);
+
+            entry->status                                 = 0;
+            cq_tail                                       = __atomic_load_n(&ch->cq.tail, __ATOMIC_RELAXED);
+            ch->cq.entries[cq_tail & DISKFS_IQ_RING_MASK] = *entry;
+            __atomic_store_n(&ch->cq.tail, cq_tail + 1, __ATOMIC_RELEASE);
+            ch->cq_inflight--;
+        }
 
         /* Hand the durable record to the push thread, in log order.  The
          * hand-off ring is sized larger than the log can ever hold, so it
@@ -724,6 +742,7 @@ diskfs_redo_write_cb(
 
         slot->ctx  = NULL;
         slot->done = 0;
+        free(rc->entries);
         free(rc);
         il->retire_head++;
     }
@@ -735,7 +754,6 @@ diskfs_redo_write_cb(
     }
 } /* diskfs_redo_write_cb */
 
-
 /*
  * Build a full-block redo record for one transaction and issue a durable
  * write into the reserved intent-log region.  Runs on the intent-log thread.
@@ -743,31 +761,25 @@ diskfs_redo_write_cb(
 static void
 diskfs_il_write_redo(
     struct diskfs_intent_log *il,
-    struct diskfs_iq_channel *ch,
-    struct diskfs_iq_entry   *entry)
+    struct diskfs_redo_entry *entries,
+    uint32_t                  num_entries,
+    uint32_t                  nblocks)
 {
-    struct diskfs_txn               *txn = entry->txn;
-    struct diskfs_txn_block         *tb;
     struct diskfs_redo_ctx          *ctx;
     struct diskfs_il_record         *rec;
     struct diskfs_redo_header       *hdr;
     struct diskfs_redo_block_header *bh;
-    uint32_t                         nblocks = 0;
     uint64_t                         hdr_len, reclen, offset;
-    uint32_t                         i;
+    uint32_t                         i, e;
     char                            *p;
     int                              niov;
     XXH3_state_t                     xs;
 
-    for (tb = txn->blocks; tb; tb = tb->next) {
-        nblocks++;
-    }
-
     hdr_len = diskfs_il_hdr_len(nblocks);
-    reclen  = hdr_len + (uint64_t) nblocks * DISKFS_BLOCK_SIZE;
+    reclen  = diskfs_il_blocks_reclen(nblocks);
 
     /* Caller guarantees space (diskfs_iq_process_channel checks diskfs_il_fits
-     * before consuming the SQ entry), so placement always succeeds. */
+     * before consuming SQ entries), so placement always succeeds. */
     offset = diskfs_il_place(il, reclen);
 
     rec             = malloc(sizeof(*rec));
@@ -777,6 +789,7 @@ diskfs_il_write_redo(
     rec->num_blocks = nblocks;
     rec->niov       = 1 + nblocks;
     rec->iovs       = malloc(rec->niov * sizeof(struct evpl_iovec));
+    rec->block_bufs = calloc(nblocks, sizeof(*rec->block_bufs));
     rec->next       = NULL;
 
     /* iovs[0]: materialized header region (redo_header + per-block headers). */
@@ -784,11 +797,12 @@ diskfs_il_write_redo(
                             EVPL_IOVEC_FLAG_SHARED, &rec->iovs[0]);
     chimera_diskfs_abort_if(niov != 1, "redo header did not fit in one iovec (%d)", niov);
 
-    ctx        = malloc(sizeof(*ctx));
-    ctx->il    = il;
-    ctx->ch    = ch;
-    ctx->entry = *entry;
-    ctx->rec   = rec;
+    ctx              = malloc(sizeof(*ctx));
+    ctx->il          = il;
+    ctx->entries     = malloc(num_entries * sizeof(*ctx->entries));
+    ctx->num_entries = num_entries;
+    ctx->rec         = rec;
+    memcpy(ctx->entries, entries, num_entries * sizeof(*ctx->entries));
 
     p               = (char *) rec->iovs[0].data;
     hdr             = (struct diskfs_redo_header *) p;
@@ -796,32 +810,35 @@ diskfs_il_write_redo(
     hdr->csum_lo    = 0;
     hdr->csum_hi    = 0;
     hdr->seq        = il->log_seq++;
+    rec->seq        = hdr->seq;
     hdr->tail       = __atomic_load_n(&il->log_tail, __ATOMIC_ACQUIRE);
     hdr->num_blocks = nblocks;
     hdr->reclen     = (uint32_t) reclen;
     p              += sizeof(*hdr);
 
     i = 0;
-    for (tb = txn->blocks; tb; tb = tb->next, i++) {
-        struct diskfs_block *blk = tb->block;
+    for (e = 0; e < num_entries; e++) {
+        struct diskfs_txn_block *tb;
 
-        /* Stamp the block with this record's seq so the tail-pusher can tell,
-         * on push completion, whether the block has been re-logged since (a
-         * higher seq) -- if not, it can be marked CLEAN and made evictable.
-         * Atomic: the push thread reads blk->seq under the shard lock. */
-        __atomic_store_n(&blk->seq, rec->seq, __ATOMIC_RELEASE);
+        for (tb = entries[e].entry.txn->blocks; tb; tb = tb->next, i++) {
+            struct diskfs_block *blk = tb->block;
 
-        bh                = (struct diskfs_redo_block_header *) p;
-        bh->device_id     = blk->device_id;
-        bh->pad           = 0;
-        bh->device_offset = blk->device_offset;
-        p                += sizeof(*bh);
+            /* Stamp the block with this record's seq so the tail-pusher can
+            * tell whether the block has been re-logged since this image. */
+            __atomic_store_n(&blk->seq, rec->seq, __ATOMIC_RELEASE);
 
-        /* Move the commit-time snapshot ref into the record (no copy, no touch
-         * of the live block->iov from this thread).  The image stays immutable
-         * until pushed home and released; a later writer COWs the cache block. */
-        evpl_iovec_move(&rec->iovs[1 + i], &tb->snap);
+            bh                = (struct diskfs_redo_block_header *) p;
+            bh->device_id     = blk->device_id;
+            bh->pad           = 0;
+            bh->device_offset = blk->device_offset;
+            p                += sizeof(*bh);
+
+            evpl_iovec_clone(&rec->iovs[1 + i], &tb->snap_buf->iov);
+            rec->block_bufs[i] = tb->snap_buf;
+        }
     }
+    chimera_diskfs_abort_if(i != nblocks,
+                            "redo grouped block count changed (%u != %u)", i, nblocks);
 
     /* Zero the header-region tail padding so the checksum covers deterministic
      * bytes, then stamp the XXH3-128 over the header region + every block. */
@@ -847,14 +864,12 @@ diskfs_il_write_redo(
     ctx->segments = (rec->niov + DISKFS_IL_MAX_IOV - 1) / DISKFS_IL_MAX_IOV;
 
     /* Reserve this record's retirement-ring slot (in submission/log order) so
-     * the completion can retire the contiguous done-prefix in order.  Caller
-     * (diskfs_iq_process_channel) guaranteed ring space before issuing. */
+     * the completion can retire the contiguous done-prefix in order. */
     ctx->retire_idx                                            = il->retire_tail;
     il->retire[il->retire_tail & DISKFS_RETIRE_RING_MASK].ctx  = ctx;
     il->retire[il->retire_tail & DISKFS_RETIRE_RING_MASK].done = 0;
     il->retire_tail++;
 
-    ch->cq_inflight++;
     il->redo_inflight += ctx->segments;     /* one redo block write per chunk below */
     diskfs_il_commit_metrics(il);
 
@@ -891,10 +906,8 @@ diskfs_il_write_redo(
     }
 } /* diskfs_il_write_redo */
 
-
-/* Padded on-log length of the redo record for one transaction. */
-static uint64_t
-diskfs_il_txn_reclen(struct diskfs_txn *txn)
+static uint32_t
+diskfs_il_txn_blocks(struct diskfs_txn *txn)
 {
     struct diskfs_txn_block *tb;
     uint32_t                 nblocks = 0;
@@ -902,82 +915,167 @@ diskfs_il_txn_reclen(struct diskfs_txn *txn)
     for (tb = txn->blocks; tb; tb = tb->next) {
         nblocks++;
     }
+    return nblocks;
+} /* diskfs_il_txn_blocks */
+
+
+static uint64_t
+diskfs_il_blocks_reclen(uint32_t nblocks)
+{
     return diskfs_il_hdr_len(nblocks) + (uint64_t) nblocks * DISKFS_BLOCK_SIZE;
+} /* diskfs_il_blocks_reclen */
+
+
+/* Padded on-log length of the redo record for one transaction. */
+static uint64_t
+diskfs_il_txn_reclen(struct diskfs_txn *txn)
+{
+    return diskfs_il_blocks_reclen(diskfs_il_txn_blocks(txn));
 } /* diskfs_il_txn_reclen */
+
+
+static int
+diskfs_iq_process_batch(struct diskfs_intent_log *il)
+{
+    struct diskfs_redo_entry entries[DISKFS_IL_MAX_IOV];
+    uint32_t                 sq_head[DISKFS_IL_MAX_CHANNELS]  = { 0 };
+    uint32_t                 sq_tail[DISKFS_IL_MAX_CHANNELS]  = { 0 };
+    uint32_t                 consumed[DISKFS_IL_MAX_CHANNELS] = { 0 };
+    uint32_t                 batch_count                      = 0;
+    uint32_t                 batch_blocks                     = 0;
+    uint32_t                 start, rounds, pass, i;
+    int                      stopped = 0;
+
+    if (il->redo_inflight >= DISKFS_COMMIT_WATERMARK) {
+        return 0;
+    }
+
+    if (il->retire_tail - il->retire_head >= DISKFS_RETIRE_RING_SIZE) {
+        return 0;
+    }
+
+    if (il->num_channels == 0) {
+        return 0;
+    }
+
+    for (i = 0; i < il->num_channels; i++) {
+        struct diskfs_iq_channel *ch = il->channels[i];
+
+        sq_head[i]  = __atomic_load_n(&ch->sq.head, __ATOMIC_RELAXED);
+        sq_tail[i]  = __atomic_load_n(&ch->sq.tail, __ATOMIC_ACQUIRE);
+        consumed[i] = 0;
+    }
+
+    start = il->log_seq % il->num_channels;
+
+    for (rounds = 0; !stopped && batch_count < DISKFS_IL_MAX_IOV; rounds++) {
+        int took = 0;
+
+        for (pass = 0; pass < il->num_channels && batch_count < DISKFS_IL_MAX_IOV; pass++) {
+            uint32_t                  idx = (start + pass) % il->num_channels;
+            struct diskfs_iq_channel *ch  = il->channels[idx];
+            struct diskfs_iq_entry   *slot;
+            uint32_t                  nblocks, next_blocks;
+            uint32_t                  cq_tail, cq_head;
+            uint64_t                  reclen;
+
+            if (sq_head[idx] + consumed[idx] == sq_tail[idx]) {
+                continue;
+            }
+
+            slot = &ch->sq.entries[(sq_head[idx] + consumed[idx]) &
+                                   DISKFS_IQ_RING_MASK];
+            nblocks     = diskfs_il_txn_blocks(slot->txn);
+            next_blocks = batch_blocks + nblocks;
+
+            /* Keep one normal record to one backend write.  Transactions larger
+             * than the iov cap still go alone and use the segmented path. */
+            if (batch_count > 0 && 1 + next_blocks > DISKFS_IL_MAX_IOV) {
+                stopped = 1;
+                break;
+            }
+
+            cq_tail = __atomic_load_n(&ch->cq.tail, __ATOMIC_RELAXED);
+            cq_head = __atomic_load_n(&ch->cq.head, __ATOMIC_ACQUIRE);
+            if ((cq_tail - cq_head) + ch->cq_inflight + consumed[idx] >=
+                DISKFS_IQ_RING_SIZE) {
+                continue;
+            }
+
+            reclen = diskfs_il_blocks_reclen(next_blocks);
+            if (!diskfs_il_fits(il, reclen)) {
+                if (batch_count > 0) {
+                    stopped = 1;
+                    break;
+                }
+                if (__atomic_load_n(&il->live_records, __ATOMIC_ACQUIRE) != 0) {
+                    stopped = 1;
+                    break;
+                }
+                __atomic_store_n(&il->log_tail, il->log_head, __ATOMIC_RELEASE);
+                if (!diskfs_il_fits(il, reclen)) {
+                    stopped = 1;
+                    break;
+                }
+            }
+
+            entries[batch_count].ch    = ch;
+            entries[batch_count].entry = *slot;
+            batch_count++;
+            batch_blocks = next_blocks;
+            consumed[idx]++;
+            took = 1;
+
+            if (1 + batch_blocks > DISKFS_IL_MAX_IOV) {
+                stopped = 1;
+                break;
+            }
+        }
+
+        if (!took) {
+            break;
+        }
+
+        if (rounds >= DISKFS_IQ_RING_SIZE) {
+            break;
+        }
+    }
+
+    if (batch_count == 0) {
+        return 0;
+    }
+
+    for (i = 0; i < batch_count; i++) {
+        entries[i].entry.status = 0;
+        prometheus_stopwatch_start(&entries[i].entry.submit_time);
+        diskfs_metric_time_sample(
+            il->metrics.txn_latency[DISKFS_METRIC_TXN_QUEUE_TO_SUBMIT],
+            &entries[i].entry.enqueue_time);
+    }
+
+    for (i = 0; i < il->num_channels; i++) {
+        if (consumed[i] == 0) {
+            continue;
+        }
+        __atomic_store_n(&il->channels[i]->sq.head,
+                         sq_head[i] + consumed[i],
+                         __ATOMIC_RELEASE);
+        il->channels[i]->cq_inflight += consumed[i];
+    }
+
+    diskfs_il_write_redo(il, entries, batch_count, batch_blocks);
+    return 1;
+} /* diskfs_iq_process_batch */
 
 
 void
 diskfs_iq_process_channel(struct diskfs_iq_channel *ch)
 {
-    struct diskfs_intent_log *il      = &ch->worker->shared->intent_log;
-    uint32_t                  sq_head = __atomic_load_n(&ch->sq.head, __ATOMIC_RELAXED);
-    uint32_t                  sq_tail = __atomic_load_n(&ch->sq.tail, __ATOMIC_ACQUIRE);
-    int                       issued  = 0;
+    struct diskfs_intent_log *il = &ch->worker->shared->intent_log;
 
-    while (sq_head != sq_tail) {
-        struct diskfs_iq_entry *slot = &ch->sq.entries[sq_head & DISKFS_IQ_RING_MASK];
-        struct diskfs_iq_entry  entry;
-        uint32_t                cq_tail, cq_head;
-
-        /* Keep redo writes pipelined up to the commit watermark; a completion
-         * rings the wake doorbell at the low watermark to resume us. */
-        if (il->redo_inflight >= DISKFS_COMMIT_WATERMARK) {
-            break;
-        }
-
-        /* Need a free retirement-ring slot for this record. */
-        if (il->retire_tail - il->retire_head >= DISKFS_RETIRE_RING_SIZE) {
-            break;
-        }
-
-        cq_tail = __atomic_load_n(&ch->cq.tail, __ATOMIC_RELAXED);
-        cq_head = __atomic_load_n(&ch->cq.head, __ATOMIC_ACQUIRE);
-
-        /* Reserve a CQ slot per in-flight write so completions can't
-         * overflow the CQ.  Defer if no room; the worker's CQ drain pings
-         * us to resume. */
-        if ((cq_tail - cq_head) + ch->cq_inflight >= DISKFS_IQ_RING_SIZE) {
-            break;
-        }
-
-        /* Back off if the log lacks room for this record; the tail-pusher
-         * rings the wake doorbell once it frees space.  One exception needs
-         * handling here: when the push FIFO and handoff ring drain, the trim
-         * point freezes wherever it stood (diskfs_push_trim has no next
-         * record to advance it to), so after enough wraps log_head can run
-         * up against a stale log_tail and the log looks permanently full
-         * while holding no records at all -- a commit deadlock, since only
-         * new trims would move the tail.  Zero live records is the truth:
-         * the log is logically empty, and the push thread will not store
-         * log_tail again until this thread hands off a new record, so it is
-         * safe to declare the log empty here.  */
-        if (!diskfs_il_fits(il, diskfs_il_txn_reclen(slot->txn))) {
-            if (__atomic_load_n(&il->live_records, __ATOMIC_ACQUIRE) != 0) {
-                break;
-            }
-            __atomic_store_n(&il->log_tail, il->log_head, __ATOMIC_RELEASE);
-        }
-
-        entry = *slot;
-        sq_head++;
-        entry.status = 0;
-
-        prometheus_stopwatch_start(&entry.submit_time);
-        diskfs_metric_time_sample(
-            il->metrics.txn_latency[DISKFS_METRIC_TXN_QUEUE_TO_SUBMIT],
-            &entry.enqueue_time);
-
-        /* Issue a durable redo write; the completion drops pins/locks and
-         * pushes the CQE (see diskfs_redo_write_cb). */
-        diskfs_il_write_redo(il, ch, &entry);
-        issued++;
-    }
-
-    if (issued > 0) {
-        __atomic_store_n(&ch->sq.head, sq_head, __ATOMIC_RELEASE);
+    while (diskfs_iq_process_batch(il)) {
     }
 } /* diskfs_iq_process_channel */
-
 
 static void
 diskfs_intent_log_drain_pending(struct diskfs_intent_log *il)
@@ -1056,21 +1154,14 @@ diskfs_il_service_registrations(struct diskfs_intent_log *il)
 } /* diskfs_il_service_registrations */
 
 
-/* Process every registered channel's SQ.  Returns 1 if any channel had work. */
+/* Process registered channel SQs into cross-channel redo batches. */
 static int
 diskfs_il_process_all(struct diskfs_intent_log *il)
 {
-    uint32_t i;
-    int      worked = 0;
+    int worked = 0;
 
-    for (i = 0; i < il->num_channels; i++) {
-        struct diskfs_iq_channel *ch = il->channels[i];
-
-        if (__atomic_load_n(&ch->sq.tail, __ATOMIC_ACQUIRE) !=
-            __atomic_load_n(&ch->sq.head, __ATOMIC_RELAXED)) {
-            worked = 1;
-        }
-        diskfs_iq_process_channel(ch);
+    while (diskfs_iq_process_batch(il)) {
+        worked = 1;
     }
     return worked;
 } /* diskfs_il_process_all */
@@ -1333,6 +1424,7 @@ diskfs_intent_log_thread_init(
     int                       i;
 
     il->evpl                        = evpl;
+    il->intent_log_size             = shared->intent_log_size;
     il->log_head                    = SM_INTENT_LOG_OFFSET;
     il->log_tail                    = SM_INTENT_LOG_OFFSET;
     il->live_records                = 0;
@@ -1423,7 +1515,7 @@ diskfs_il_push_thread_init(
     il->pfree      = NULL;
 
     /* Pending map: one bucket budget per distinct block the log can hold. */
-    cap            = diskfs_il_pow2((SM_INTENT_LOG_SIZE / DISKFS_BLOCK_SIZE) * 2);
+    cap            = diskfs_il_pow2((shared->intent_log_size / DISKFS_BLOCK_SIZE) * 2);
     il->phash_mask = cap - 1;
     il->phash      = calloc(cap, sizeof(*il->phash));
 
@@ -1518,7 +1610,9 @@ diskfs_txn_commit_finish(
                                    tb->block->device_offset);
 
             pthread_mutex_lock(&bshard->lock);
-            evpl_iovec_clone(&tb->snap, &tb->block->iov);
+            diskfs_block_buf_ref_locked(tb->block->buf);
+            tb->snap     = tb->block->iov;
+            tb->snap_buf = tb->block->buf;
             pthread_mutex_unlock(&bshard->lock);
             blocks++;
         }

--- a/src/vfs/diskfs/diskfs_mount.c
+++ b/src/vfs/diskfs/diskfs_mount.c
@@ -708,8 +708,10 @@ diskfs_recover_log(
     struct diskfs_recover_rec *recs;
     uint32_t                   nrec = 0, cap = 4096, i;
 
-    log = malloc(SM_INTENT_LOG_SIZE);
-    if (diskfs_mount_io_read(io, SM_INTENT_LOG_DEVICE, log, SM_INTENT_LOG_SIZE,
+    uint64_t                   intent_log_size = shared->intent_log_size;
+
+    log = malloc(intent_log_size);
+    if (diskfs_mount_io_read(io, SM_INTENT_LOG_DEVICE, log, intent_log_size,
                              SM_INTENT_LOG_OFFSET) != 0) {
         free(log);
         return -1;
@@ -717,7 +719,7 @@ diskfs_recover_log(
 
     recs = malloc(cap * sizeof(*recs));
 
-    for (o = 0; o + sizeof(struct diskfs_redo_header) <= SM_INTENT_LOG_SIZE;
+    for (o = 0; o + sizeof(struct diskfs_redo_header) <= intent_log_size;
          o += DISKFS_BLOCK_SIZE) {
         struct diskfs_redo_header *hdr = (struct diskfs_redo_header *) (log + o);
         uint64_t                   lo, hi;
@@ -728,18 +730,41 @@ diskfs_recover_log(
         }
         if (hdr->reclen < sizeof(*hdr) ||
             (hdr->reclen & (DISKFS_BLOCK_SIZE - 1)) ||
-            o + hdr->reclen > SM_INTENT_LOG_SIZE) {
+            hdr->reclen != diskfs_il_hdr_len(hdr->num_blocks) + (uint64_t) hdr->num_blocks * DISKFS_BLOCK_SIZE ||
+            o + hdr->reclen > intent_log_size) {
             continue;
         }
         lo           = hdr->csum_lo;
         hi           = hdr->csum_hi;
         hdr->csum_lo = 0;
         hdr->csum_hi = 0;
-        h            = XXH3_128bits(log + o, hdr->reclen);
+        h            = XXH3_128bits(log + o, diskfs_il_hdr_len(hdr->num_blocks));
         hdr->csum_lo = lo;
         hdr->csum_hi = hi;
         if (h.low64 != lo || h.high64 != hi) {
             continue;
+        }
+        {
+            char    *bhp  = log + o + sizeof(*hdr);
+            char    *data = log + o + diskfs_il_hdr_len(hdr->num_blocks);
+            uint32_t b;
+            int      ok = 1;
+
+            for (b = 0; b < hdr->num_blocks; b++) {
+                struct diskfs_redo_block_header *bh =
+                    (struct diskfs_redo_block_header *) (bhp + (size_t) b * sizeof(*bh));
+                char                            *img   = data + (size_t) b * DISKFS_BLOCK_SIZE;
+                XXH128_hash_t                    bhash = XXH3_128bits(img, DISKFS_BLOCK_SIZE);
+
+                if (bhash.low64 != bh->block_csum_lo ||
+                    bhash.high64 != bh->block_csum_hi) {
+                    ok = 0;
+                    break;
+                }
+            }
+            if (!ok) {
+                continue;
+            }
         }
 
         if (nrec == cap) {
@@ -996,6 +1021,22 @@ diskfs_init(
     shared->block_cache_blocks = (uint32_t) json_integer_value(
         json_object_get(cfg, "block_cache_blocks"));
 
+    /* Intent-log size (bytes).  Larger pipelines more redo records before the
+     * ring laps (throughput on big devices); small test devices need a small
+     * log so the AG 0 metadata reservation fits.  A remount overrides this with
+     * the value the superblock recorded at format time. */
+    {
+        json_t *ils = json_object_get(cfg, "intent_log_size");
+
+        shared->intent_log_size = ils ? (uint64_t) json_integer_value(ils) :
+            SM_INTENT_LOG_SIZE_DEFAULT;
+        if (shared->intent_log_size < SM_INTENT_LOG_SIZE_MIN) {
+            shared->intent_log_size = SM_INTENT_LOG_SIZE_MIN;
+        }
+        shared->intent_log_size = (shared->intent_log_size + SM_BLOCK_MASK) &
+            ~(uint64_t) SM_BLOCK_MASK;
+    }
+
     chimera_diskfs_abort_if(shared->block_layout && shared->scsi_layout,
                             "block_layout and scsi_layout are mutually exclusive");
 
@@ -1058,6 +1099,15 @@ diskfs_init(
                 "diskfs superblock missing or invalid; specify initialize to format");
         }
 
+        /* On a remount the intent-log size is whatever was formatted, not the
+         * configured value -- the on-disk layout is fixed by it. */
+        if (mode != 0) {
+            chimera_diskfs_abort_if(
+                sb.intent_log_size == 0 || (sb.intent_log_size & SM_BLOCK_MASK),
+                "superblock intent_log_size %lu is invalid", sb.intent_log_size);
+            shared->intent_log_size = sb.intent_log_size;
+        }
+
         dev_cfg = calloc(shared->num_devices, sizeof(*dev_cfg));
         for (i = 0; i < shared->num_devices; i++) {
             struct diskfs_device *dv = &shared->devices[i];
@@ -1071,7 +1121,8 @@ diskfs_init(
                 memcpy(dev_cfg[i].sig, dv->sig, dv->sig_len);
             }
         }
-        shared->space_map = space_map_create(dev_cfg, shared->num_devices);
+        shared->space_map = space_map_create(dev_cfg, shared->num_devices,
+                                             shared->intent_log_size);
         free(dev_cfg);
 
         /* On a persistent remount the relocated-log map is recomputed from the
@@ -1542,17 +1593,11 @@ diskfs_thread_init(
 
     thread->allocator = slab_allocator_create(4096, 1024 * 1024 * 1024);
 
+    diskfs_block_cache_prealloc(shared, evpl);
+
     evpl_iovec_alloc(evpl, 4096, 4096, 1, 0, &thread->zero);
     memset(thread->zero.data, 0, 4096);  // Zero buffer must contain zeros!
     evpl_iovec_alloc(evpl, 4096, 4096, 1, 0, &thread->pad);
-
-    thread->queue = calloc(shared->num_devices, sizeof(*thread->queue));
-
-    for (int i = 0; i < shared->num_devices; i++) {
-        /* Remote (pNFS data) devices have no local handle: leave queue NULL. */
-        thread->queue[i] = shared->devices[i].bdev ?
-            evpl_block_open_queue(evpl, shared->devices[i].bdev) : NULL;
-    }
 
     thread->shared = shared;
     thread->evpl   = evpl;
@@ -1569,11 +1614,23 @@ diskfs_thread_init(
     thread->cq_poll = evpl_add_poll(evpl, NULL, NULL, diskfs_iq_cq_poll,
                                     thread->iq_channel);
 
-    /* Inode lock-grant delivery queue + doorbell. */
+    /* Inode lock-grant delivery queue + doorbell.  Register its poll before
+     * the block-device queue polls so granted inode waiters are resumed before
+     * the worker spends a loop iteration polling every VFIO queue. */
     pthread_mutex_init(&thread->grant_lock, NULL);
     thread->grant_head = NULL;
     thread->grant_tail = NULL;
+    __atomic_store_n(&thread->grant_pending, 0, __ATOMIC_RELAXED);
     evpl_add_doorbell(evpl, &thread->grant_doorbell, diskfs_grant_doorbell_cb);
+    thread->grant_poll = evpl_add_poll(evpl, NULL, NULL, diskfs_grant_poll, thread);
+
+    thread->queue = calloc(shared->num_devices, sizeof(*thread->queue));
+
+    for (int i = 0; i < shared->num_devices; i++) {
+        /* Remote (pNFS data) devices have no local handle: leave queue NULL. */
+        thread->queue[i] = shared->devices[i].bdev ?
+            evpl_block_open_queue(evpl, shared->devices[i].bdev) : NULL;
+    }
 
     /* B+tree op resume queue: doorbell (cross-thread) + deferral (same-thread). */
     pthread_mutex_init(&thread->resume_lock, NULL);
@@ -1581,8 +1638,11 @@ diskfs_thread_init(
     thread->resume_tail            = NULL;
     thread->bt_op_free_list        = NULL;
     thread->block_waiter_free_list = NULL;
+    __atomic_store_n(&thread->resume_pending, 0, __ATOMIC_RELAXED);
     evpl_add_doorbell(evpl, &thread->resume_doorbell, diskfs_bt_resume_doorbell_cb);
     evpl_deferral_init(&thread->resume_deferral, diskfs_bt_resume_deferral_cb, thread);
+    thread->resume_poll = evpl_add_poll(evpl, NULL, NULL, diskfs_bt_resume_poll,
+                                        thread);
 
     pthread_mutex_lock(&shared->lock);
     thread->thread_id = shared->num_active_threads++;
@@ -1721,9 +1781,15 @@ diskfs_thread_destroy(void *private_data)
         thread->iq_channel = NULL;
     }
 
+    if (thread->grant_poll) {
+        evpl_remove_poll(thread->evpl, thread->grant_poll);
+    }
     evpl_remove_doorbell(thread->evpl, &thread->grant_doorbell);
     pthread_mutex_destroy(&thread->grant_lock);
 
+    if (thread->resume_poll) {
+        evpl_remove_poll(thread->evpl, thread->resume_poll);
+    }
     evpl_remove_doorbell(thread->evpl, &thread->resume_doorbell);
     pthread_mutex_destroy(&thread->resume_lock);
 

--- a/src/vfs/diskfs/diskfs_namespace.c
+++ b/src/vfs/diskfs/diskfs_namespace.c
@@ -682,8 +682,18 @@ diskfs_lookup_at(
     (void) shared;
     (void) private_data;
 
+    uint64_t                       inum;
+    uint32_t                       gen;
+
     p->thread = thread;
     p->txn    = diskfs_txn_begin(thread, DISKFS_TXN_READ);
+
+    diskfs_fh_to_inum(&inum, &gen, request->fh, request->fh_len);
+    request->wait_reason   = "diskfs_open_fh_inode_lock";
+    request->wait_since_ns = diskfs_diag_now_ns();
+    request->wait_arg0     = inum;
+    request->wait_arg1     = gen;
+    request->wait_arg2     = 0;
 
     diskfs_inode_get_fh_async(thread, p->txn,
                               request->fh, request->fh_len,
@@ -1644,6 +1654,8 @@ diskfs_open_fh_inode_cb(
     struct chimera_vfs_request    *request = private_data;
     struct diskfs_request_private *p       = request->plugin_data;
 
+    request->wait_reason = NULL;
+
     if (unlikely(status != CHIMERA_VFS_OK)) {
         diskfs_op_fail(request, p->txn, status);
         return;
@@ -1666,7 +1678,7 @@ diskfs_open_fh_inode_cb(
         return;
     }
 
-    inode->refcnt++;
+    diskfs_inode_ref_get(p->thread, inode);
 
     request->open_fh.r_vfs_private = (uint64_t) inode;
     diskfs_op_ok(request, p->txn);
@@ -1686,7 +1698,7 @@ diskfs_open_fh(
     (void) private_data;
 
     p->thread = thread;
-    p->txn    = diskfs_txn_begin(thread, DISKFS_TXN_WRITE);
+    p->txn    = diskfs_txn_begin(thread, DISKFS_TXN_READ);
 
     diskfs_inode_get_fh_async(thread, p->txn,
                               request->fh, request->fh_len,
@@ -1709,7 +1721,7 @@ diskfs_open_at_finish(
      * cached handle matched by a diskfs_close, so always pin the inode and stash
      * the real pointer in vfs_private.  read/write reuse it (and close releases
      * the pin); there is no throwaway/synthetic open_at for this backend. */
-    inode->refcnt++;
+    diskfs_inode_ref_get(thread, inode);
     request->open_at.r_vfs_private = (uint64_t) inode;
 
     diskfs_map_attrs(thread, &request->open_at.r_dir_post_attr, parent);
@@ -2121,20 +2133,20 @@ diskfs_close(
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
-    struct diskfs_request_private *p     = request->plugin_data;
-    struct diskfs_inode           *inode = (struct diskfs_inode *) request->close.vfs_private;
+    struct diskfs_inode *inode = (struct diskfs_inode *) request->close.vfs_private;
 
     (void) shared;
     (void) private_data;
 
-    p->thread = thread;
-    p->txn    = diskfs_txn_begin(thread, DISKFS_TXN_WRITE);
+    /* Backend close is not a durable operation: open counts are in-memory,
+     * and nlink==0 crash safety is recorded by the unlink/create-unlinked txn
+     * that put the inode on the orphan list.  File-data reservation tails are
+     * volatile, so dropping them only updates the live allocator view. */
+    diskfs_inode_return_reservation(thread, NULL, inode);
+    diskfs_inode_ref_drop(thread, inode);
 
-    /* The inode pointer came in via vfs_private (set at open); re-acquire
-     * it by (inum,gen) so its write lock is tracked in the cache like any
-     * other op. */
-    diskfs_inode_get_inum_async(thread, p->txn, inode->inum, inode->gen,
-                                diskfs_close_inode_cb, request);
+    request->status = CHIMERA_VFS_OK;
+    request->complete(request);
 } /* diskfs_close */
 
 

--- a/src/vfs/diskfs/space_map.c
+++ b/src/vfs/diskfs/space_map.c
@@ -76,6 +76,14 @@ struct sm_ag_jnl_slot {
     uint32_t idx;
 };
 
+static struct sm_ag *
+sm_free_resolve_ag(
+    struct space_map *sm,
+    uint32_t          device_id,
+    uint64_t          device_offset,
+    uint64_t          aligned,
+    const char       *who);
+
 /*
  * Claim the AG's log header + current delta block for an upcoming delta, BEFORE
  * any allocator state is mutated.  Caller holds ag->lock.  All disk access is
@@ -364,7 +372,8 @@ sm_ag_free_locked(
 struct space_map *
 space_map_create(
     const struct sm_device_cfg *cfg,
-    uint32_t                    num_devices)
+    uint32_t                    num_devices,
+    uint64_t                    intent_log_size)
 {
     struct space_map *sm;
     struct sm_device *dev;
@@ -376,10 +385,14 @@ space_map_create(
     sm_abort_if(num_devices == 0, "space_map_create with zero devices");
     sm_abort_if(cfg[0].role != SM_DEV_LOCAL,
                 "device 0 must be a local metadata device");
+    sm_abort_if(intent_log_size == 0 || (intent_log_size & SM_BLOCK_MASK),
+                "intent_log_size %lu must be a non-zero multiple of the block size",
+                intent_log_size);
 
-    sm              = calloc(1, sizeof(*sm));
-    sm->num_devices = num_devices;
-    sm->devices     = calloc(num_devices, sizeof(*sm->devices));
+    sm                  = calloc(1, sizeof(*sm));
+    sm->intent_log_size = intent_log_size;
+    sm->num_devices     = num_devices;
+    sm->devices         = calloc(num_devices, sizeof(*sm->devices));
     pthread_mutex_init(&sm->lock, NULL);
 
     /* Pass 1: size each device and count remote AGs so the relocated-log
@@ -412,7 +425,7 @@ space_map_create(
 
     /* The relocated remote-AG-log region sits on device 0, between the intent
      * log and AG 0's own space-map log.  Deterministic (device,ag)->slot map. */
-    region_base           = SM_SUPERBLOCK_SIZE + SM_INTENT_LOG_SIZE;
+    region_base           = SM_SUPERBLOCK_SIZE + sm->intent_log_size;
     sm->remote_log_offset = region_base;
     sm->remote_log_size   = (uint64_t) remote_ag_total * SM_AG_LOG_SIZE;
     reloc_cursor          = region_base;
@@ -461,7 +474,7 @@ space_map_create(
                  * AG's own log.  Then the bootstrap inode blocks after the log
                  * (block_idx 1=reserved, 2=root inode, 3..=orphan-list
                  * shards). */
-                uint64_t pre_log = SM_SUPERBLOCK_SIZE + SM_INTENT_LOG_SIZE +
+                uint64_t pre_log = SM_SUPERBLOCK_SIZE + sm->intent_log_size +
                     sm->remote_log_size;
                 uint64_t post_log = (2 + SM_BOOTSTRAP_ORPHAN_SLOTS) * SM_BLOCK_SIZE;
 
@@ -498,7 +511,7 @@ space_map_create(
     sm_info("Reserved intent log: device %u offset %lu size %lu",
             (unsigned) SM_INTENT_LOG_DEVICE,
             (uint64_t) SM_INTENT_LOG_OFFSET,
-            (uint64_t) SM_INTENT_LOG_SIZE);
+            sm->intent_log_size);
     sm_info("Per-AG log size: %lu (%u slots x %lu)",
             (uint64_t) SM_AG_LOG_SIZE,
             (unsigned) SM_AG_LOG_SLOT_COUNT,
@@ -613,6 +626,100 @@ sm_pick_and_alloc(
 
     return -1;
 } /* sm_pick_and_alloc */
+
+/*
+ * Volatile reservation: remove a range from the live in-memory free tree so
+ * concurrent allocators cannot reuse it, but do not journal it.  Callers must
+ * journal exact sub-allocations before exposing them durably.  Any unused tail
+ * can be returned with space_map_thread_cache_discard_volatile(); after a
+ * crash it was never removed from the persistent free map.
+ */
+static int
+sm_pick_and_reserve_volatile(
+    struct space_map *sm,
+    uint32_t          role,
+    uint64_t          want,
+    uint32_t         *r_device_id,
+    uint64_t         *r_device_offset)
+{
+    uint32_t start_dev, dev_id;
+    uint32_t d, a;
+
+    pthread_mutex_lock(&sm->lock);
+    start_dev = sm->device_rotor;
+    sm->device_rotor++;
+    if (sm->device_rotor >= sm->num_devices) {
+        sm->device_rotor = 0;
+    }
+    pthread_mutex_unlock(&sm->lock);
+
+    for (d = 0; d < sm->num_devices; d++) {
+        dev_id = (start_dev + d) % sm->num_devices;
+        struct sm_device *dev = &sm->devices[dev_id];
+        uint32_t          start_ag;
+
+        if (dev->role != role) {
+            continue;
+        }
+
+        pthread_mutex_lock(&sm->lock);
+        start_ag = dev->ag_rotor;
+        dev->ag_rotor++;
+        if (dev->ag_rotor >= dev->num_ags) {
+            dev->ag_rotor = 0;
+        }
+        pthread_mutex_unlock(&sm->lock);
+
+        for (a = 0; a < dev->num_ags; a++) {
+            uint32_t      ag_idx = (start_ag + a) % dev->num_ags;
+            struct sm_ag *ag     = &dev->ags[ag_idx];
+            uint64_t      offset;
+            int           rc;
+
+            if (ag->free_bytes < want) {
+                continue;
+            }
+
+            pthread_mutex_lock(&ag->lock);
+            rc = sm_ag_alloc_locked(ag, want, &offset);
+            pthread_mutex_unlock(&ag->lock);
+
+            if (rc == 0) {
+                *r_device_id     = dev_id;
+                *r_device_offset = offset;
+                return 0;
+            }
+        }
+    }
+
+    return -1;
+} /* sm_pick_and_reserve_volatile */
+
+static int
+space_map_journal_alloc_exact(
+    struct space_map        *sm,
+    const struct sm_journal *jnl,
+    uint32_t                 device_id,
+    uint64_t                 device_offset,
+    uint64_t                 length)
+{
+    struct sm_ag         *ag;
+    struct sm_ag_jnl_slot slot;
+    int                   jrc;
+
+    ag = sm_free_resolve_ag(sm, device_id, device_offset, length,
+                            "space_map_journal_alloc_exact");
+
+    pthread_mutex_lock(&ag->lock);
+    jrc = sm_ag_journal_claim(ag, jnl, &slot);
+    if (jrc == SM_AGAIN) {
+        pthread_mutex_unlock(&ag->lock);
+        return SM_AGAIN;
+    }
+    sm_ag_journal_write(ag, &slot, SM_AG_LOG_OP_ALLOC, device_offset, length);
+    pthread_mutex_unlock(&ag->lock);
+    return 0;
+} /* space_map_journal_alloc_exact */
 
 int
 space_map_reserve(
@@ -729,6 +836,65 @@ space_map_alloc(
     }
     return 0;
 } /* space_map_alloc */
+
+int
+space_map_alloc_volatile_reservation(
+    struct space_map        *sm,
+    struct sm_thread_cache  *cache,
+    const struct sm_journal *jnl,
+    uint32_t                 role,
+    uint64_t                 size,
+    uint64_t                 floor,
+    uint32_t                *r_device_id,
+    uint64_t                *r_device_offset)
+{
+    uint64_t need = SM_ALIGN_UP(size);
+    uint64_t want;
+    int      rc;
+
+    sm_abort_if(need == 0, "alloc of zero bytes");
+
+    if (!cache->valid || cache->length < need) {
+        space_map_thread_cache_discard_volatile(sm, cache);
+
+        want = need > floor ? need : floor;
+        if (want > SM_AG_SIZE) {
+            return -1;
+        }
+
+        rc = sm_pick_and_reserve_volatile(sm, role, want,
+                                          &cache->device_id, &cache->offset);
+        if (rc != 0 && want != need) {
+            rc = sm_pick_and_reserve_volatile(sm, role, need,
+                                              &cache->device_id, &cache->offset);
+            if (rc == 0) {
+                cache->length = need;
+                cache->valid  = 1;
+            }
+        } else if (rc == 0) {
+            cache->length = want;
+            cache->valid  = 1;
+        }
+        if (rc != 0) {
+            return rc;
+        }
+    }
+
+    rc = space_map_journal_alloc_exact(sm, jnl, cache->device_id,
+                                       cache->offset, need);
+    if (rc == SM_AGAIN) {
+        return SM_AGAIN;
+    }
+
+    *r_device_id     = cache->device_id;
+    *r_device_offset = cache->offset;
+    cache->offset   += need;
+    cache->length   -= need;
+    if (cache->length == 0) {
+        cache->valid = 0;
+    }
+    return 0;
+} /* space_map_alloc_volatile_reservation */
 
 /* Resolve and validate the AG owning [device_offset, device_offset+aligned). */
 static struct sm_ag *
@@ -895,6 +1061,21 @@ space_map_thread_cache_return(
 } /* space_map_thread_cache_return */
 
 void
+space_map_thread_cache_discard_volatile(
+    struct space_map       *sm,
+    struct sm_thread_cache *cache)
+{
+    if (!cache->valid || cache->length == 0) {
+        cache->valid = 0;
+        return;
+    }
+
+    space_map_free_apply(sm, cache->device_id, cache->offset, cache->length);
+    cache->valid  = 0;
+    cache->length = 0;
+} /* space_map_thread_cache_discard_volatile */
+
+void
 space_map_fill_superblock(
     struct space_map *sm,
     void             *buf,
@@ -918,7 +1099,7 @@ space_map_fill_superblock(
     sb->num_devices        = sm->num_devices;
     sb->intent_log_device  = SM_INTENT_LOG_DEVICE;
     sb->intent_log_offset  = SM_INTENT_LOG_OFFSET;
-    sb->intent_log_size    = SM_INTENT_LOG_SIZE;
+    sb->intent_log_size    = sm->intent_log_size;
     sb->flags              = flags;
     sb->root_inum          = root_inum;
     sb->root_gen           = root_gen;

--- a/src/vfs/diskfs/space_map.h
+++ b/src/vfs/diskfs/space_map.h
@@ -27,7 +27,7 @@
 #define SM_BLOCK_SIZE             (1ULL << SM_BLOCK_SHIFT)
 #define SM_BLOCK_MASK             (SM_BLOCK_SIZE - 1)
 
-#define SM_AG_SIZE_LOG2           30                        /* 1 GiB */
+#define SM_AG_SIZE_LOG2           31                        /* 2 GiB */
 #define SM_AG_SIZE                (1ULL << SM_AG_SIZE_LOG2)
 #define SM_AG_OFFSET_MASK         (SM_AG_SIZE - 1)
 
@@ -204,12 +204,19 @@ struct sm_io {
  * the superblock; its exact location is also recorded in the superblock
  * so future format versions can move it.  Carved out of AG 0 of device 0.
  */
-#define SM_INTENT_LOG_DEVICE 0
-#define SM_INTENT_LOG_OFFSET SM_SUPERBLOCK_SIZE
-#define SM_INTENT_LOG_SIZE   (64ULL << 20) /* 64 MiB */
+#define SM_INTENT_LOG_DEVICE       0
+#define SM_INTENT_LOG_OFFSET       SM_SUPERBLOCK_SIZE
+
+/* The intent-log size is a runtime tunable (diskfs config "intent_log_size",
+ * persisted in the superblock and carried on struct space_map / the IL).  A
+ * larger log lets more redo records pipeline before the ring laps, which helps
+ * write throughput on big devices; small test devices need a small log so the
+ * AG 0 metadata reservation fits.  These are the default and the floor. */
+#define SM_INTENT_LOG_SIZE_DEFAULT (1ULL << 30)  /* 1 GiB */
+#define SM_INTENT_LOG_SIZE_MIN     (4ULL << 20)  /* 4 MiB */
 
 /* superblock flags */
-#define SM_SB_CLEAN          0x1ULL        /* set at clean unmount, cleared at mount */
+#define SM_SB_CLEAN                0x1ULL  /* set at clean unmount, cleared at mount */
 
 struct sm_superblock {
     uint64_t magic;
@@ -364,6 +371,10 @@ struct space_map {
     uint32_t          num_remote_devices;
     uint64_t          remote_log_offset;
     uint64_t          remote_log_size;
+
+    /* Active intent-log size: the configured value at mkfs, or the value the
+     * superblock recorded on a remount.  Drives the AG 0 metadata layout. */
+    uint64_t          intent_log_size;
 };
 
 struct sm_thread_cache {
@@ -376,7 +387,8 @@ struct sm_thread_cache {
 struct space_map *
 space_map_create(
     const struct sm_device_cfg *cfg,
-    uint32_t                    num_devices);
+    uint32_t                    num_devices,
+    uint64_t                    intent_log_size);
 
 void
 space_map_destroy(
@@ -426,6 +438,20 @@ space_map_alloc(
     uint32_t                *r_device_id,
     uint64_t                *r_device_offset);
 
+/* File-data allocation path: the reservation tail is live only in memory.
+ * Exact consumed ranges are journaled before being returned to the caller; the
+ * unused tail can be discarded without a durable FREE. */
+int
+space_map_alloc_volatile_reservation(
+    struct space_map        *sm,
+    struct sm_thread_cache  *cache,
+    const struct sm_journal *jnl,
+    uint32_t                 role,
+    uint64_t                 size,
+    uint64_t                 floor,
+    uint32_t                *r_device_id,
+    uint64_t                *r_device_offset);
+
 static inline int
 space_map_has_remote(const struct space_map *sm)
 {
@@ -462,6 +488,11 @@ space_map_thread_cache_return(
     struct space_map        *sm,
     const struct sm_journal *jnl,
     struct sm_thread_cache  *cache);
+
+void
+space_map_thread_cache_discard_volatile(
+    struct space_map       *sm,
+    struct sm_thread_cache *cache);
 
 /*
  * Format a complete superblock image (including CRC) into buf, which must be

--- a/src/vfs/vfs.c
+++ b/src/vfs/vfs.c
@@ -183,14 +183,16 @@ chimera_vfs_close_thread_sweep(
         handle = handles;
         LL_DELETE(handles, handle);
 
-        close_thread->num_pending++;
+        if (chimera_vfs_open_handle_needs_backend_close(handle)) {
+            close_thread->num_pending++;
 
-        chimera_vfs_close(thread,
-                          handle->vfs_module,
-                          handle->vfs_private,
-                          handle->fh_hash,
-                          chimera_vfs_close_thread_callback,
-                          close_thread);
+            chimera_vfs_close(thread,
+                              handle->vfs_module,
+                              handle->vfs_private,
+                              handle->fh_hash,
+                              chimera_vfs_close_thread_callback,
+                              close_thread);
+        }
 
         /* defer_close removed the handle from the bucket but frees the struct
          * here (not via open_cache_free), so drop its anchored lease ref. */
@@ -997,11 +999,29 @@ chimera_vfs_watchdog(struct chimera_vfs_thread *thread)
 
         if (ts.tv_sec - thread->watchdog_last_report >= 30) {
             thread->watchdog_last_report = ts.tv_sec;
-            chimera_vfs_error(
-                "request %p op %s active for %lu sec (oldest on this thread)",
-                (void *) request,
-                chimera_vfs_op_name(request->opcode),
-                elapsed / 1000000000UL);
+            if (request->wait_reason) {
+                uint64_t now_ns = (uint64_t) ts.tv_sec * 1000000000ULL +
+                    (uint64_t) ts.tv_nsec;
+                uint64_t wait_ns = request->wait_since_ns ?
+                    now_ns - request->wait_since_ns : 0;
+
+                chimera_vfs_error(
+                    "request %p op %s active for %lu sec wait=%s wait_sec=%llu arg0=%llu arg1=%llu arg2=%llu (oldest on this thread)",
+                    (void *) request,
+                    chimera_vfs_op_name(request->opcode),
+                    elapsed / 1000000000UL,
+                    request->wait_reason,
+                    (unsigned long long) (wait_ns / 1000000000ULL),
+                    (unsigned long long) request->wait_arg0,
+                    (unsigned long long) request->wait_arg1,
+                    (unsigned long long) request->wait_arg2);
+            } else {
+                chimera_vfs_error(
+                    "request %p op %s active for %lu sec (oldest on this thread)",
+                    (void *) request,
+                    chimera_vfs_op_name(request->opcode),
+                    elapsed / 1000000000UL);
+            }
         }
         chimera_vfs_dump_request(request);
     }

--- a/src/vfs/vfs.h
+++ b/src/vfs/vfs.h
@@ -166,18 +166,19 @@ struct chimera_vfs_thread_metrics {
     struct prometheus_histogram_instance **op_latency_series;
 };
 
-#define CHIMERA_VFS_OPEN_HANDLE_EXCLUSIVE 0x1
-#define CHIMERA_VFS_OPEN_HANDLE_PENDING   0x2
-#define CHIMERA_VFS_OPEN_HANDLE_FILE_ID   0x4
-#define CHIMERA_VFS_OPEN_HANDLE_DETACHED  0x8
+#define CHIMERA_VFS_OPEN_HANDLE_EXCLUSIVE       0x1
+#define CHIMERA_VFS_OPEN_HANDLE_PENDING         0x2
+#define CHIMERA_VFS_OPEN_HANDLE_FILE_ID         0x4
+#define CHIMERA_VFS_OPEN_HANDLE_DETACHED        0x8
 /* A named-stream (ADS) handle.  Its file handle is distinct from the base
  * file's, but its metadata (mode/owner/timestamps/DOS attributes) is the base
  * inode's and mutates out-of-band relative to the stream fh, so the per-fh attr
  * cache must not serve or store attributes for it (chimera_vfs_getattr). */
-#define CHIMERA_VFS_OPEN_HANDLE_STREAM    0x10
+#define CHIMERA_VFS_OPEN_HANDLE_STREAM          0x10
+#define CHIMERA_VFS_OPEN_HANDLE_NO_BACKEND_OPEN 0x20
 
-#define CHIMERA_VFS_ACCESS_MODE_RW        0
-#define CHIMERA_VFS_ACCESS_MODE_RO        1
+#define CHIMERA_VFS_ACCESS_MODE_RW              0
+#define CHIMERA_VFS_ACCESS_MODE_RO              1
 
 struct chimera_vfs_open_handle {
     struct chimera_vfs_module      *vfs_module;
@@ -416,6 +417,13 @@ struct chimera_vfs_request {
     chimera_vfs_complete_callback_t    complete_delegate;
     struct prometheus_stopwatch        start_time;
     uint64_t                           elapsed_ns;
+
+    /* Temporary diagnostics: where a long-lived request is parked. */
+    const char                        *wait_reason;
+    uint64_t                           wait_since_ns;
+    uint64_t                           wait_arg0;
+    uint64_t                           wait_arg1;
+    uint64_t                           wait_arg2;
 
     /* Points to one page of memory that the plugin may use as desired */
     void                              *plugin_data;

--- a/src/vfs/vfs_internal.h
+++ b/src/vfs/vfs_internal.h
@@ -263,6 +263,12 @@ chimera_vfs_request_alloc_common(
 
     prometheus_stopwatch_start(&request->start_time);
 
+    request->wait_reason   = NULL;
+    request->wait_since_ns = 0;
+    request->wait_arg0     = 0;
+    request->wait_arg1     = 0;
+    request->wait_arg2     = 0;
+
     thread->num_active_requests++;
     DL_APPEND2(thread->active_requests, request, active_prev, active_next);
 

--- a/src/vfs/vfs_open_cache.h
+++ b/src/vfs/vfs_open_cache.h
@@ -36,6 +36,14 @@ struct vfs_open_cache {
     struct prometheus_counter_series *open_cache_insert;
 };
 
+#define CHIMERA_VFS_OPEN_CACHE_NO_BACKEND_OPEN (UINT64_MAX - 1)
+
+static inline int
+chimera_vfs_open_handle_needs_backend_close(const struct chimera_vfs_open_handle *handle)
+{
+    return !(handle->flags & CHIMERA_VFS_OPEN_HANDLE_NO_BACKEND_OPEN);
+} // chimera_vfs_open_handle_needs_backend_close
+
 /* --- Shard linked-list helpers --- */
 
 static inline void
@@ -321,11 +329,14 @@ chimera_vfs_open_cache_release(
                 struct chimera_vfs_module *close_module  = handle->vfs_module;
                 uint64_t                   close_private = handle->vfs_private;
                 uint64_t                   close_hash    = handle->fh_hash;
+                int                        needs_close   = chimera_vfs_open_handle_needs_backend_close(handle);
                 chimera_vfs_open_cache_free(shard, handle);
                 pthread_mutex_unlock(&shard->lock);
                 chimera_vfs_open_cache_release_blocked(thread, requests, error_code);
-                chimera_vfs_close(thread, close_module, close_private,
-                                  close_hash, NULL, NULL);
+                if (needs_close) {
+                    chimera_vfs_close(thread, close_module, close_private,
+                                      close_hash, NULL, NULL);
+                }
                 return;
             }
             handle->timestamp = chimera_vfs_now_ticks();
@@ -551,6 +562,11 @@ chimera_vfs_open_cache_acquire(
         handle->blocked_requests    = NULL;
         handle->doc_delete_on_close = 0;
 
+        if (handle->vfs_private == CHIMERA_VFS_OPEN_CACHE_NO_BACKEND_OPEN) {
+            handle->flags      |= CHIMERA_VFS_OPEN_HANDLE_NO_BACKEND_OPEN;
+            handle->vfs_private = 0;
+        }
+
         if (handle->vfs_private == UINT64_MAX) {
             handle->flags |= CHIMERA_VFS_OPEN_HANDLE_PENDING;
         }
@@ -571,15 +587,20 @@ chimera_vfs_open_cache_acquire(
             struct chimera_vfs_module *close_module  = existing->vfs_module;
             uint64_t                   close_private = existing->vfs_private;
             uint64_t                   close_hash    = existing->fh_hash;
+            int                        needs_close   = chimera_vfs_open_handle_needs_backend_close(existing);
 
             prometheus_counter_increment(shard->acquire);
 
             chimera_vfs_open_cache_free(shard, existing);
             pthread_mutex_unlock(&shard->lock);
 
-            chimera_vfs_close(thread, close_module, close_private,
-                              close_hash,
-                              chimera_vfs_open_cache_close_callback, handle);
+            if (needs_close) {
+                chimera_vfs_close(thread, close_module, close_private,
+                                  close_hash,
+                                  chimera_vfs_open_cache_close_callback, handle);
+            } else {
+                chimera_vfs_open_cache_close_callback(CHIMERA_VFS_OK, handle);
+            }
 
             return;
         } else {
@@ -645,6 +666,11 @@ chimera_vfs_open_cache_insert(
     handle->blocked_requests    = NULL;
     handle->doc_delete_on_close = 0;
 
+    if (handle->vfs_private == CHIMERA_VFS_OPEN_CACHE_NO_BACKEND_OPEN) {
+        handle->flags      |= CHIMERA_VFS_OPEN_HANDLE_NO_BACKEND_OPEN;
+        handle->vfs_private = 0;
+    }
+
     memcpy(handle->fh, fh, fhlen);
 
     /* Check for existing entry with same (fh, access_mode, cred) */
@@ -662,11 +688,14 @@ chimera_vfs_open_cache_insert(
             struct chimera_vfs_module *close_module  = existing->vfs_module;
             uint64_t                   close_private = existing->vfs_private;
             uint64_t                   close_hash    = existing->fh_hash;
+            int                        needs_close   = chimera_vfs_open_handle_needs_backend_close(existing);
 
             chimera_vfs_open_cache_free(shard, existing);
             pthread_mutex_unlock(&shard->lock);
-            chimera_vfs_close(thread, close_module, close_private,
-                              close_hash, NULL, NULL);
+            if (needs_close) {
+                chimera_vfs_close(thread, close_module, close_private,
+                                  close_hash, NULL, NULL);
+            }
             callback(request, handle);
             return;
         } else {
@@ -691,11 +720,14 @@ chimera_vfs_open_cache_insert(
                 struct chimera_vfs_module      *close_module  = victim->vfs_module;
                 uint64_t                        close_private = victim->vfs_private;
                 uint64_t                        close_hash    = victim->fh_hash;
+                int                             needs_close   = chimera_vfs_open_handle_needs_backend_close(victim);
 
                 chimera_vfs_open_cache_free(shard, victim);
                 pthread_mutex_unlock(&shard->lock);
-                chimera_vfs_close(thread, close_module, close_private,
-                                  close_hash, NULL, NULL);
+                if (needs_close) {
+                    chimera_vfs_close(thread, close_module, close_private,
+                                      close_hash, NULL, NULL);
+                }
                 callback(request, handle);
                 return;
             } else {

--- a/src/vfs/vfs_proc_open_fh.c
+++ b/src/vfs/vfs_proc_open_fh.c
@@ -73,11 +73,10 @@ chimera_vfs_open_fh_hs(
     chimera_vfs_open_fh_callback_t   callback,
     void                            *private_data)
 {
-    struct chimera_vfs_module      *module;
-    struct chimera_vfs_request     *request;
-    struct chimera_vfs_open_handle *handle;
-    struct vfs_open_cache          *cache;
-    uint64_t                        fh_hash;
+    struct chimera_vfs_module  *module;
+    struct chimera_vfs_request *request;
+    struct vfs_open_cache      *cache;
+    uint64_t                    fh_hash;
 
     if (flags & CHIMERA_VFS_OPEN_PATH) {
         cache = thread->vfs->vfs_open_path_cache;
@@ -132,20 +131,37 @@ chimera_vfs_open_fh_hs(
 
     } else {
 
-        /* This is an inferred open from the likes of NFS3
-         * where caller does not need to hold a reference count
-         * and our module does not need open handles, so
-         * we can synthesize a handle and return it immediately */
+        /* Inferred open on a backend that does not require a real open handle.
+         * Keep a cached handle anyway so per-handle state (notably VFS lease
+         * mediation) is attached once per cache lifetime instead of once per
+         * NFSv3-style stateless operation.  The handle has no backend open, so
+         * cache eviction/release must skip chimera_vfs_close().
+         */
+        request = chimera_vfs_request_alloc_by_hash(thread, cred, fh, fhlen, fh_hash);
 
-        handle = chimera_vfs_synth_handle_alloc(thread);
+        if (CHIMERA_VFS_IS_ERR(request)) {
+            callback(CHIMERA_VFS_PTR_ERR(request), NULL, private_data);
+            return;
+        }
 
-        memcpy(handle->fh, fh, fhlen);
-        handle->vfs_module  = module;
-        handle->fh_len      = fhlen;
-        handle->fh_hash     = fh_hash;
-        handle->vfs_private = 0;
+        request->opcode             = CHIMERA_VFS_OP_OPEN_FH;
+        request->open_fh.flags      = flags;
+        request->proto_callback     = callback;
+        request->proto_private_data = private_data;
 
-        callback(CHIMERA_VFS_OK, handle, private_data);
+        chimera_vfs_open_cache_acquire(
+            thread,
+            cache,
+            module,
+            request,
+            fh,
+            fhlen,
+            fh_hash,
+            CHIMERA_VFS_OPEN_CACHE_NO_BACKEND_OPEN,
+            request->open_fh.flags,
+            0,
+            chimera_vfs_open_fh_hdl_callback);
+
         return;
     }
 } /* chimera_vfs_open_fh_hs */

--- a/src/vfs/vfs_state.h
+++ b/src/vfs/vfs_state.h
@@ -41,7 +41,7 @@ struct chimera_vfs_request;
 /* Per-file state                                                       */
 /* -------------------------------------------------------------------- */
 
-#define CHIMERA_VFS_STATE_NUM_BUCKETS 64
+#define CHIMERA_VFS_STATE_NUM_BUCKETS 16384
 
 struct chimera_vfs_file_state {
     uint8_t                             fh[CHIMERA_VFS_FH_SIZE];


### PR DESCRIPTION


Bundle several diskfs scaling/performance enhancements, developed and validated under SPECstorage2020 SWBUILD at load 100 across 10 clients over both NFSv3/TCP and NFSv3/RDMA against a 16-device VFIO diskfs backend.

Block cache: give diskfs dedicated, diskfs-owned backing buffers (struct diskfs_block_buf) instead of lazily allocating a 4 KiB EVPL_IOVEC_FLAG_SHARED iovec per cache block. A long-lived 4 KiB shared iovec can pin an entire (default 2 MiB) EVPL buffer, so a logical block cache can amplify into far larger resident slab memory. Backing buffers are now packed in diskfs-owned memory with an evpl iovec alias for existing I/O paths, plus atomic clean-return and returned-buffer drain queues and explicit DISKFS_BLOCK_CLEAN/LOGGED state transitions.

Space map: add a per-thread volatile reservation allocation path (space_map_alloc_volatile_reservation / space_map_thread_cache_discard_volatile). The reservation tail lives only in memory; only exact consumed ranges are journaled before being returned, and the unused tail is discarded without a durable FREE, cutting intent-log traffic on the file-data write path.

Intent log: pipeline redo writes to a commit watermark, sample per-txn submit->durable and queue->durable latency, and tighten the block pin/unpin lifecycle around durability.

Inode grant path: drain grants via a doorbell + poll path (diskfs_grant_drain / diskfs_grant_doorbell_cb / diskfs_grant_poll) with diagnostic queue-wait timing.

VFS open cache: for backends that infer opens (no real backend open handle required), keep a cached handle anyway so per-handle state (notably VFS lease mediation) attaches once per cache lifetime rather than once per op; eviction/release skips chimera_vfs_close()
(CHIMERA_VFS_OPEN_CACHE_NO_BACKEND_OPEN).

Config/build: honor a "buffer_size" common config knob to size EVPL buffers, and add an opt-in EVPL_IOVEC_PROFILE build option for retained-iovec stack profiling (default OFF).