### PR TITLE
cluster: VIP + shared-backend reconnect-anywhere foundation

### DIFF
--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -607,6 +607,34 @@ main(
                                                    (uint64_t) json_integer_value(json_value));
     }
 
+    /* Cluster node identity.  0 (default) = single-node/unclustered.  In a
+     * VIP + shared-backend cluster, assign each node a distinct value in
+     * 1..255 so shared-keyspace records (e.g. SMB persistent ids) never
+     * collide across nodes and an evicted node's state can be attributed. */
+    json_value = json_object_get(server_params, "node_id");
+    if (json_is_integer(json_value)) {
+        int node_id = (int) json_integer_value(json_value);
+        if (node_id < 0 || node_id > 255) {
+            chimera_server_abort("config: node_id %d out of range (must be 0..255)", node_id);
+        }
+        chimera_server_config_set_node_id(server_config, node_id);
+    }
+
+    /* Attribute/name cache TTL in seconds (default 60).  Set to 0 for strict
+     * coherence -- attrs and name->fh mappings are not cached, so a peer's
+     * mutation in a shared-backend cluster is never masked by a stale local
+     * entry (at the cost of every metadata op hitting the backend).  The
+     * lease-coupled invalidation path (chimera_vfs_invalidate_fh) is the
+     * lower-overhead mechanism for files covered by a backend lease. */
+    json_value = json_object_get(server_params, "cache_ttl");
+    if (json_is_integer(json_value)) {
+        int ttl = (int) json_integer_value(json_value);
+        if (ttl < 0) {
+            chimera_server_abort("config: cache_ttl %d must be >= 0", ttl);
+        }
+        chimera_server_config_set_cache_ttl(server_config, ttl);
+    }
+
     /* Data-server mode: bind only the NFSv4 service (no portmap/mount/NLM) so
      * a pNFS data server can run alongside an MDS on the same host. */
     json_value = json_object_get(server_params, "data_server");

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -8,7 +8,7 @@
 # the unprefixed QSBR API, is set project-wide in the top-level CMakeLists.txt.)
 add_compile_definitions(_LGPL_SOURCE)
 
-add_library(chimera_server SHARED server.c)
+add_library(chimera_server SHARED server.c cluster.c)
 target_link_libraries(chimera_server chimera_nfs chimera_s3 chimera_smb chimera_rest chimera_vfs evpl unwind)
 
 install(TARGETS chimera_server DESTINATION lib)

--- a/src/server/cluster.c
+++ b/src/server/cluster.c
@@ -1,0 +1,248 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdatomic.h>
+
+#include "cluster.h"
+#include "server_internal.h"
+#include "vfs/vfs.h"
+#include "vfs/vfs_procs.h"
+
+/*
+ * Shared-KV key for an eviction record: a 3-byte header (magic, version, type)
+ * followed by the 1-byte node_id.  Distinct magic (0xCB) from the NFS KV band
+ * (0xC4) and the SMB "smbdh" band so the three never alias in a shared store.
+ * The value is an 8-byte marker (magic + reserved); presence is what matters.
+ */
+#define CLUSTER_KV_MAGIC       0xCB
+#define CLUSTER_KV_VERSION     0x01
+#define CLUSTER_KV_TYPE_EVICT  0x01
+#define CLUSTER_KV_HDR_LEN     3
+#define CLUSTER_KV_KEY_LEN     (CLUSTER_KV_HDR_LEN + 1)
+#define CLUSTER_KV_VALUE_MAGIC 0x5443564bU  /* 'KVCT' LE */
+#define CLUSTER_KV_VALUE_LEN   8
+
+enum cluster_load_state {
+    CLUSTER_LOAD_IDLE = 0,
+    CLUSTER_LOAD_RUNNING,
+    CLUSTER_LOAD_READY,
+};
+
+struct chimera_cluster {
+    int             local_node_id;
+    _Atomic int     load_state;
+    _Atomic uint8_t evicted[256];
+};
+
+struct chimera_cluster_load_ctx {
+    struct chimera_cluster    *cluster;
+    struct chimera_vfs_thread *vfs_thread;
+    uint8_t                    start[CLUSTER_KV_HDR_LEN];
+};
+
+static inline uint32_t
+cluster_evict_key(
+    uint8_t *buf,
+    int      node_id)
+{
+    buf[0] = CLUSTER_KV_MAGIC;
+    buf[1] = CLUSTER_KV_VERSION;
+    buf[2] = CLUSTER_KV_TYPE_EVICT;
+    buf[3] = (uint8_t) node_id;
+    return CLUSTER_KV_KEY_LEN;
+} /* cluster_evict_key */
+
+struct chimera_cluster *
+chimera_cluster_init(int local_node_id)
+{
+    struct chimera_cluster *cluster = calloc(1, sizeof(*cluster));
+
+    cluster->local_node_id = local_node_id;
+    atomic_store(&cluster->load_state, CLUSTER_LOAD_IDLE);
+    return cluster;
+} /* chimera_cluster_init */
+
+void
+chimera_cluster_destroy(struct chimera_cluster *cluster)
+{
+    free(cluster);
+} /* chimera_cluster_destroy */
+
+int
+chimera_cluster_node_is_evicted(
+    const struct chimera_cluster *cluster,
+    int                           node_id)
+{
+    if (node_id < 0 || node_id > 255) {
+        return 0;
+    }
+    return atomic_load(&cluster->evicted[node_id]);
+} /* chimera_cluster_node_is_evicted */
+
+int
+chimera_cluster_local_node_id(const struct chimera_cluster *cluster)
+{
+    return cluster->local_node_id;
+} /* chimera_cluster_local_node_id */
+
+int
+chimera_cluster_evicted_list(
+    const struct chimera_cluster *cluster,
+    uint8_t                      *out,
+    int                           cap)
+{
+    int n = 0;
+
+    for (int i = 0; i < 256 && n < cap; i++) {
+        if (atomic_load(&cluster->evicted[i])) {
+            out[n++] = (uint8_t) i;
+        }
+    }
+    return n;
+} /* chimera_cluster_evicted_list */
+
+static void
+cluster_kv_done(
+    enum chimera_vfs_error error_code,
+    void                  *private_data)
+{
+    (void) private_data;
+    if (error_code != CHIMERA_VFS_OK) {
+        chimera_server_error("cluster: KV update failed: %d", error_code);
+    }
+} /* cluster_kv_done */
+
+int
+chimera_cluster_evict(
+    struct chimera_cluster    *cluster,
+    struct chimera_vfs_thread *vfs_thread,
+    int                        node_id)
+{
+    uint8_t  key[CLUSTER_KV_KEY_LEN];
+    uint8_t  value[CLUSTER_KV_VALUE_LEN] = { 0 };
+    uint32_t key_len;
+
+    if (node_id < 1 || node_id > 255 || node_id == cluster->local_node_id) {
+        return -1;
+    }
+
+    atomic_store(&cluster->evicted[node_id], 1);
+
+    *(uint32_t *) value = CLUSTER_KV_VALUE_MAGIC;
+    key_len             = cluster_evict_key(key, node_id);
+
+    chimera_server_info("cluster: node %d evicted (signaled on node %d)",
+                        node_id, cluster->local_node_id);
+
+    chimera_vfs_put_key(vfs_thread, key, key_len, value, sizeof(value),
+                        cluster_kv_done, NULL);
+    return 0;
+} /* chimera_cluster_evict */
+
+int
+chimera_cluster_rejoin(
+    struct chimera_cluster    *cluster,
+    struct chimera_vfs_thread *vfs_thread,
+    int                        node_id)
+{
+    uint8_t  key[CLUSTER_KV_KEY_LEN];
+    uint32_t key_len;
+
+    if (node_id < 1 || node_id > 255) {
+        return -1;
+    }
+
+    atomic_store(&cluster->evicted[node_id], 0);
+
+    key_len = cluster_evict_key(key, node_id);
+    chimera_vfs_delete_key(vfs_thread, key, key_len, cluster_kv_done, NULL);
+    return 0;
+} /* chimera_cluster_rejoin */
+
+static int
+cluster_load_scan_cb(
+    const void *key,
+    uint32_t    key_len,
+    const void *value,
+    uint32_t    value_len,
+    void       *private_data)
+{
+    struct chimera_cluster_load_ctx *ctx = private_data;
+    const uint8_t                   *k   = key;
+
+    (void) value;
+    (void) value_len;
+
+    /* Keys arrive in order; stop once we walk past the eviction band. */
+    if (key_len != CLUSTER_KV_KEY_LEN ||
+        k[0] != CLUSTER_KV_MAGIC || k[1] != CLUSTER_KV_VERSION ||
+        k[2] != CLUSTER_KV_TYPE_EVICT) {
+        return 1;
+    }
+
+    atomic_store(&ctx->cluster->evicted[k[3]], 1);
+    return 0;
+} /* cluster_load_scan_cb */
+
+static void
+cluster_load_complete(
+    enum chimera_vfs_error error_code,
+    void                  *private_data)
+{
+    struct chimera_cluster_load_ctx *ctx     = private_data;
+    struct chimera_cluster          *cluster = ctx->cluster;
+    int                              local   = cluster->local_node_id;
+    int                              n;
+    uint8_t                          list[256];
+
+    if (error_code != CHIMERA_VFS_OK) {
+        chimera_server_error("cluster: eviction-set load failed: %d", error_code);
+    }
+
+    /* This node is alive: clear any stale eviction record for it (rejoin). */
+    if (local >= 1 && local <= 255 && atomic_load(&cluster->evicted[local])) {
+        chimera_cluster_rejoin(cluster, ctx->vfs_thread, local);
+    }
+
+    n = chimera_cluster_evicted_list(cluster, list, sizeof(list));
+    if (n) {
+        char buf[1024];
+        int  off = 0;
+        for (int i = 0; i < n && off < (int) sizeof(buf) - 8; i++) {
+            off += snprintf(buf + off, sizeof(buf) - off, "%s%d",
+                            i ? "," : "", list[i]);
+        }
+        chimera_server_info("cluster: %d node(s) evicted at load: %s", n, buf);
+    }
+
+    atomic_store(&cluster->load_state, CLUSTER_LOAD_READY);
+    free(ctx);
+} /* cluster_load_complete */
+
+void
+chimera_cluster_load(
+    struct chimera_cluster    *cluster,
+    struct chimera_vfs_thread *vfs_thread)
+{
+    struct chimera_cluster_load_ctx *ctx;
+    int                              expected = CLUSTER_LOAD_IDLE;
+
+    if (!atomic_compare_exchange_strong(&cluster->load_state, &expected,
+                                        CLUSTER_LOAD_RUNNING)) {
+        return;  /* another thread already kicked the load */
+    }
+
+    ctx             = malloc(sizeof(*ctx));
+    ctx->cluster    = cluster;
+    ctx->vfs_thread = vfs_thread;
+    ctx->start[0]   = CLUSTER_KV_MAGIC;
+    ctx->start[1]   = CLUSTER_KV_VERSION;
+    ctx->start[2]   = CLUSTER_KV_TYPE_EVICT;
+
+    chimera_vfs_search_keys(vfs_thread, ctx->start, CLUSTER_KV_HDR_LEN,
+                            NULL, 0, 0,
+                            cluster_load_scan_cb, cluster_load_complete, ctx);
+} /* chimera_cluster_load */

--- a/src/server/cluster.h
+++ b/src/server/cluster.h
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#pragma once
+
+#include <stdint.h>
+
+struct chimera_vfs_thread;
+struct chimera_cluster;
+
+/*
+ * Cluster eviction registry (WS-D control plane for the VIP + shared-backend
+ * model).
+ *
+ * Chimera does not run its own membership/heartbeat protocol; an external
+ * orchestrator (or the coherent backend) decides a node is dead and tells the
+ * surviving nodes via the REST control endpoint, which calls
+ * chimera_cluster_evict().  The eviction set is persisted to the shared KV so
+ * every node (and a survivor that itself restarts mid-outage) observes the same
+ * view, and is the authorization other workstreams consult:
+ *   - WS-C cont: a node only cross-node-reclaims an SMB durable handle whose
+ *     owning node (CHIMERA_SMB_PID_NODE of the persistent id) has been evicted,
+ *     so it never steals a handle a live peer still holds warm.
+ *   - WS-A: opening/extending the cluster grace window on an eviction.
+ *   - lease-persist branch: releasing the evicted node's leases/locks.
+ *
+ * node_id 0 is the single-node/unclustered sentinel and is never evictable.
+ */
+
+struct chimera_cluster *
+chimera_cluster_init(
+    int local_node_id);
+
+void
+chimera_cluster_destroy(
+    struct chimera_cluster *cluster);
+
+/* One-time async load of the persisted eviction set from the shared KV, then
+ * clear (rejoin) this node's own record -- the local node is alive by
+ * definition.  Idempotent; safe to call from the first server thread online. */
+void
+chimera_cluster_load(
+    struct chimera_cluster    *cluster,
+    struct chimera_vfs_thread *vfs_thread);
+
+/* Mark node_id evicted: set the in-memory bit and write-through to the shared
+ * KV so peers observe it.  Returns 0 on success, -1 if node_id is out of range
+ * (1..255) or is the local node (a live node cannot evict itself). */
+int
+chimera_cluster_evict(
+    struct chimera_cluster    *cluster,
+    struct chimera_vfs_thread *vfs_thread,
+    int                        node_id);
+
+/* Clear an eviction (a node has rejoined).  Returns 0 on success, -1 on a
+ * bad node_id. */
+int
+chimera_cluster_rejoin(
+    struct chimera_cluster    *cluster,
+    struct chimera_vfs_thread *vfs_thread,
+    int                        node_id);
+
+/* Lock-free query: non-zero if node_id is currently considered evicted. */
+int
+chimera_cluster_node_is_evicted(
+    const struct chimera_cluster *cluster,
+    int                           node_id);
+
+int
+chimera_cluster_local_node_id(
+    const struct chimera_cluster *cluster);
+
+/* Snapshot the evicted node ids into out[] (up to cap entries); returns the
+ * number written. */
+int
+chimera_cluster_evicted_list(
+    const struct chimera_cluster *cluster,
+    uint8_t                      *out,
+    int                           cap);

--- a/src/server/nfs/nfs.c
+++ b/src/server/nfs/nfs.c
@@ -758,6 +758,20 @@ chimera_nfs_add_export(
 
 } /* chimera_nfs_add_export */
 
+SYMBOL_EXPORT void
+chimera_nfs_cluster_grace_reopen(
+    void                      *nfs_shared,
+    struct chimera_vfs_thread *vfs_thread)
+{
+    struct chimera_server_nfs_shared *shared = nfs_shared;
+
+    /* A peer was evicted: re-open NFSv4 grace + re-scan the shared reclaim set,
+     * and re-open NLM grace, so this survivor can absorb failover clients while
+     * refusing conflicting new (non-reclaim) state until they reclaim. */
+    nfs_recovery_cluster_grace_reopen(&shared->nfs4_recovery, vfs_thread);
+    nlm_state_begin_grace(&shared->nlm_state, NLM_GRACE_PERIOD_SECS);
+} /* chimera_nfs_cluster_grace_reopen */
+
 
 SYMBOL_EXPORT int
 chimera_nfs_remove_export(

--- a/src/server/nfs/nfs.h
+++ b/src/server/nfs/nfs.h
@@ -22,6 +22,24 @@ void chimera_nfs_add_export(
     const char *name,
     const char *path);
 
+struct chimera_vfs_thread;
+
+/**
+ * @brief Re-open NFSv4 + NLM grace on a peer eviction (cluster failover).
+ *
+ * Re-scans the shared recovery records into the reclaim set and opens the grace
+ * window so this survivor can absorb clients failing over from the evicted node
+ * while refusing conflicting new (non-reclaim) locks until reclaim drains.
+ * No-op for NFSv4 when the KV backend is non-persistent.
+ *
+ * @param nfs_shared Pointer to the NFS shared context.
+ * @param vfs_thread VFS thread for the shared-KV rescan.
+ */
+void
+chimera_nfs_cluster_grace_reopen(
+    void                      *nfs_shared,
+    struct chimera_vfs_thread *vfs_thread);
+
 
 /**
  * @brief Removes an NFS export from the shared context.

--- a/src/server/nfs/nfs4_proc_exchange_id.c
+++ b/src/server/nfs/nfs4_proc_exchange_id.c
@@ -177,7 +177,18 @@ chimera_nfs4_exchange_id(
      * that do not share state -- e.g. a pNFS data server co-deployed with its
      * MDS -- must therefore differ in both, or the client coalesces them and
      * misroutes the data path.  The "nfs_server_scope" knob sets both (default
-     * 42, preserving prior behavior). */
+     * 42, preserving prior behavior).
+     *
+     * Clustering (VIP + shared coherent backend, reconnect-anywhere): every
+     * node DELIBERATELY advertises the SAME scope/owner so the client sees one
+     * logical server and a reconnect to any node is transparent.  This is safe
+     * here precisely because the nodes share state via the backend; do NOT fold
+     * node_id into the scope.  Failover is reclaim-based: a client that lands on
+     * a node lacking its (per-process) clientid/stateid gets STALE_CLIENTID /
+     * STALE_STATEID and re-establishes + reclaims during the cluster grace
+     * window.  Under a single VIP the client only ever sees one address, so
+     * identical owner/scope does not trigger multipath trunking discovery across
+     * nodes -- the trunking caveat above applies to distinct addresses. */
     uint64_t                       server_scope = chimera_server_config_get_nfs_server_scope(
         thread->shared->config);
     uint64_t                       owner_major = server_scope;

--- a/src/server/nfs/nfs4_recovery.c
+++ b/src/server/nfs/nfs4_recovery.c
@@ -520,6 +520,99 @@ nfs_recovery_kickoff(struct chimera_server_nfs_thread *thread)
 } /* nfs_recovery_kickoff */
 
 /* ------------------------------------------------------------------ *
+*  cluster grace re-open (WS-A / WS-D)                               *
+* ------------------------------------------------------------------ */
+
+static void
+nfs_recovery_reopen_complete(
+    enum chimera_vfs_error error_code,
+    void                  *private_data)
+{
+    struct nfs_recovery_load_ctx *ctx = private_data;
+    struct nfs_recovery          *rec = ctx->rec;
+
+    (void) error_code;
+
+    /* Re-stamp the window to cover the full grace duration from the moment the
+     * reclaim set is complete, then flip back to READY so per-client reclaim
+     * eligibility (nfs_recovery_open_check) is enforced again.  If the rescan
+     * found nothing reclaimable, drop straight out of grace. */
+    pthread_mutex_lock(&rec->lock);
+    if (rec->to_reclaim) {
+        rec->in_grace     = true;
+        rec->grace_end_ns = nfs_lease_now_ns() +
+            (uint64_t) rec->grace_time_s * 1000000000ULL;
+    } else {
+        rec->in_grace     = false;
+        rec->grace_end_ns = 0;
+    }
+    pthread_mutex_unlock(&rec->lock);
+
+    atomic_store_explicit(&rec->load_state, NFS_REC_LOAD_READY,
+                          memory_order_release);
+
+    chimera_nfs_info(
+        "cluster grace re-opened: %u client(s) reclaimable, window %us",
+        rec->pending_reclaim, rec->grace_time_s);
+
+    free(ctx);
+} /* nfs_recovery_reopen_complete */
+
+/*
+ * Re-open the NFSv4 grace window on a peer eviction (WS-D signal) and re-scan
+ * the SHARED recovery records into to_reclaim.  A long-running survivor only
+ * loaded the confirmed-client set at its own cold start; clients confirmed on
+ * the now-dead peer since then are in the shared KV but not yet in this node's
+ * to_reclaim, so they must be picked up before their failover reclaim arrives.
+ *
+ * The window is opened immediately and load_state is dropped to RUNNING for the
+ * duration of the rescan -- reusing the cold-load semantics so that, while the
+ * set is being rebuilt, reclaims are accepted without per-client eligibility
+ * checks (open_check treats not-READY as in-grace) and EXCHANGE_ID/
+ * CREATE_SESSION hold off with NFS4ERR_DELAY.  reopen_complete restores READY.
+ *
+ * No-op when persistence is disabled (memkv): no shared backend means no
+ * cross-node failover to absorb.  Grace ends on timeout or reclaim drain via
+ * the existing nfs_recovery_sweep_once; cluster grace relies on the timeout
+ * since the exact failover set is not known in advance.
+ *
+ * NOTE: this re-opens grace on the node that received the eviction signal.  For
+ * the whole surviving set to enter grace, the orchestrator should signal every
+ * survivor (a KV-watch fan-out is a future refinement).
+ */
+void
+nfs_recovery_cluster_grace_reopen(
+    struct nfs_recovery       *rec,
+    struct chimera_vfs_thread *vfs_thread)
+{
+    struct nfs_recovery_load_ctx *ctx;
+
+    if (rec->persistence_disabled) {
+        return;
+    }
+
+    /* Relax eligibility + force in-grace while the reclaim set is rebuilt. */
+    atomic_store_explicit(&rec->load_state, NFS_REC_LOAD_RUNNING,
+                          memory_order_release);
+
+    pthread_mutex_lock(&rec->lock);
+    rec->in_grace     = true;
+    rec->grace_end_ns = nfs_lease_now_ns() +
+        (uint64_t) rec->grace_time_s * 1000000000ULL;
+    pthread_mutex_unlock(&rec->lock);
+
+    ctx         = malloc(sizeof(*ctx));
+    ctx->thread = NULL;  /* reopen does not reconstruct the DRC */
+    ctx->rec    = rec;
+    nfs_kv_type_prefix(ctx->start, CHIMERA_KV_TYPE_NFS4_RECOVERY);
+
+    chimera_vfs_search_keys(vfs_thread, ctx->start, CHIMERA_KV_HDR_LEN,
+                            NULL, 0, 0,
+                            nfs_recovery_scan_cb, nfs_recovery_reopen_complete,
+                            ctx);
+} /* nfs_recovery_cluster_grace_reopen */
+
+/* ------------------------------------------------------------------ *
 *  OPEN gate + reclaim bookkeeping                                   *
 * ------------------------------------------------------------------ */
 
@@ -542,8 +635,6 @@ nfs_recovery_open_check(
     bool in_grace;
     int  ls;
 
-    (void) client;  /* not gated per-client yet; future use. */
-
     ls = atomic_load_explicit(&rec->load_state, memory_order_acquire);
 
     pthread_mutex_lock(&rec->lock);
@@ -562,6 +653,36 @@ nfs_recovery_open_check(
     if (!in_grace && is_reclaim) {
         return NFS4ERR_NO_GRACE;
     }
+
+    /* Validating reclaim: a CLAIM_PREVIOUS is only legitimate from a client the
+     * server has a confirmed recovery record for (single-node: persisted before
+     * the reboot; cluster: persisted to the shared KV by whichever node the
+     * client was on).  Once the record set is fully loaded, reject a reclaim
+     * from a client not in to_reclaim with NFS4ERR_NO_GRACE so a never-confirmed
+     * (or already-forgotten) client cannot mint fresh state via the reclaim
+     * path -- the previous code accepted any reclaim while in grace.  The check
+     * is skipped while the load is still in flight (ls != READY, handled above
+     * by forcing in_grace) and when the caller could not resolve the client
+     * (4.0 paths before SETCLIENTID confirm), preserving prior behavior there.
+     *
+     * NOTE: this validates reclaim *eligibility* (the client held confirmed
+     * state), not that the client previously held THIS specific file/lock --
+     * per-object validation consumes the lease-persist branch's persisted
+     * open/lock records and is layered on when those are available. */
+    if (in_grace && is_reclaim && client &&
+        ls == NFS_REC_LOAD_READY) {
+        struct nfs_recovery_record *r;
+
+        pthread_mutex_lock(&rec->lock);
+        HASH_FIND(hh, rec->to_reclaim, client->owner_string,
+                  client->owner_len, r);
+        pthread_mutex_unlock(&rec->lock);
+
+        if (!r) {
+            return NFS4ERR_NO_GRACE;
+        }
+    }
+
     return NFS4_OK;
 } /* nfs_recovery_open_check */
 

--- a/src/server/nfs/nfs4_recovery.h
+++ b/src/server/nfs/nfs4_recovery.h
@@ -133,6 +133,17 @@ void
 nfs_recovery_end_grace(
     struct nfs_recovery *rec);
 
+/*
+ * Re-open the grace window on a peer eviction (cluster failover) and re-scan
+ * the shared recovery records into to_reclaim so clients confirmed on the dead
+ * peer become reclaim-eligible here.  No-op under non-persistent KV.  See the
+ * implementation for the load_state / eligibility handling during the rescan.
+ */
+void
+nfs_recovery_cluster_grace_reopen(
+    struct nfs_recovery       *rec,
+    struct chimera_vfs_thread *vfs_thread);
+
 bool
 nfs_recovery_in_grace(
     struct nfs_recovery *rec);

--- a/src/server/nfs/nfs_nlm_state.c
+++ b/src/server/nfs/nfs_nlm_state.c
@@ -110,6 +110,19 @@ nlm_state_init(
 } /* nlm_state_init */
 
 void
+nlm_state_begin_grace(
+    struct nlm_state *state,
+    int               secs)
+{
+    pthread_mutex_lock(&state->mutex);
+    state->in_grace  = 1;
+    state->grace_end = time(NULL) + secs;
+    pthread_mutex_unlock(&state->mutex);
+
+    chimera_nfs_info("NLM grace (re)opened for %d seconds", secs);
+} /* nlm_state_begin_grace */
+
+void
 nlm_state_destroy(struct nlm_state *state)
 {
     struct nlm_client     *client, *tmp_client;

--- a/src/server/nfs/nfs_nlm_state.h
+++ b/src/server/nfs/nfs_nlm_state.h
@@ -298,6 +298,16 @@ nlm_state_init(
     struct nlm_state *state,
     const char       *state_dir);
 
+/*
+ * (Re)open the NLM grace window for `secs` seconds.  Used on a peer eviction
+ * (cluster failover) so a survivor refuses new (non-reclaim) locks while
+ * failed-over NLM clients re-establish their locks via NSM/statd notification.
+ */
+void
+nlm_state_begin_grace(
+    struct nlm_state *state,
+    int               secs);
+
 void
 nlm_state_destroy(
     struct nlm_state *state);

--- a/src/server/nfs/tests/test_nfs_persist.c
+++ b/src/server/nfs/tests/test_nfs_persist.c
@@ -551,6 +551,63 @@ test_nfs3_cross_reboot(void)
     printf("ok: nfs3_cross_reboot\n");
 } /* test_nfs3_cross_reboot */
 
+/* ------------------------------------------------------------------ *
+*  Grace gate: validating CLAIM_PREVIOUS eligibility (WS-A)          *
+* ------------------------------------------------------------------ */
+
+static void
+test_recovery_open_check(void)
+{
+    struct nfs_recovery        rec;
+    struct nfs_recovery_record rrec;
+    struct nfs_client          known;
+    struct nfs_client          unknown;
+
+    memset(&rec,0,sizeof(rec));
+    pthread_mutex_init(&rec.lock,NULL);
+    rec.persistence_disabled = false;
+    atomic_store(&rec.load_state,NFS_REC_LOAD_READY);
+
+    /* One confirmed client recorded for reclaim ("known"). */
+    memset(&rrec,0,sizeof(rrec));
+    memcpy(rrec.owner_string,"client-known",12);
+    rrec.owner_len = 12;
+    rrec.reclaimed = false;
+    HASH_ADD_KEYPTR(hh,rec.to_reclaim,rrec.owner_string,rrec.owner_len,&rrec);
+    rec.pending_reclaim = 1;
+    rec.in_grace        = true;
+
+    memset(&known,0,sizeof(known));
+    memcpy(known.owner_string,"client-known",12);
+    known.owner_len = 12;
+
+    memset(&unknown,0,sizeof(unknown));
+    memcpy(unknown.owner_string,"client-other",12);
+    unknown.owner_len = 12;
+
+    /* Non-reclaim OPEN during grace is refused. */
+    CHECK(nfs_recovery_open_check(&rec,&known,false) == NFS4ERR_GRACE);
+
+    /* Reclaim from a confirmed client is allowed. */
+    CHECK(nfs_recovery_open_check(&rec,&known,true) == NFS4_OK);
+
+    /* Reclaim from a client with no recovery record is rejected (the gap this
+    * change closes -- previously any reclaim was accepted while in grace). */
+    CHECK(nfs_recovery_open_check(&rec,&unknown,true) == NFS4ERR_NO_GRACE);
+
+    /* A NULL client (pre-confirm 4.0 path) is not gated per-client. */
+    CHECK(nfs_recovery_open_check(&rec,NULL,true) == NFS4_OK);
+
+    /* Once grace ends, a reclaim gets NO_GRACE and a normal OPEN proceeds. */
+    rec.in_grace = false;
+    CHECK(nfs_recovery_open_check(&rec,&known,true) == NFS4ERR_NO_GRACE);
+    CHECK(nfs_recovery_open_check(&rec,&known,false) == NFS4_OK);
+
+    HASH_CLEAR(hh,rec.to_reclaim);
+    pthread_mutex_destroy(&rec.lock);
+    printf("ok: recovery_open_check\n");
+} /* test_recovery_open_check */
+
 int
 main(void)
 {
@@ -564,6 +621,7 @@ main(void)
     test_session_record_roundtrip();
     test_reply_record_roundtrip();
     test_cross_reboot_replay();
+    test_recovery_open_check();
 
     test_nfs3_key_encoding();
     test_nfs3_checksum_and_cacheable();

--- a/src/server/rest/CMakeLists.txt
+++ b/src/server/rest/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(chimera_rest SHARED
     rest_shares.c
     rest_mounts.c
     rest_config.c
+    rest_cluster.c
     rest_swagger.c
     rest_debug.c
 )

--- a/src/server/rest/rest.c
+++ b/src/server/rest/rest.c
@@ -126,6 +126,22 @@ void chimera_rest_handle_config(
     struct evpl_http_request *,
     struct chimera_rest_thread *);
 
+/* External handlers from rest_cluster.c */
+void chimera_rest_handle_cluster_list(
+    struct evpl *,
+    struct evpl_http_request *,
+    struct chimera_rest_thread *);
+void chimera_rest_handle_cluster_evict(
+    struct evpl *,
+    struct evpl_http_request *,
+    struct chimera_rest_thread *,
+    const char *);
+void chimera_rest_handle_cluster_rejoin(
+    struct evpl *,
+    struct evpl_http_request *,
+    struct chimera_rest_thread *,
+    const char *);
+
 /* External handlers from rest_swagger.c */
 void chimera_rest_handle_swagger_ui(
     struct evpl *,
@@ -469,6 +485,32 @@ chimera_rest_dispatch(
     if (url_len == 14 && strncmp(url, "/api/v1/config", 14) == 0) {
         if (req_type == EVPL_HTTP_REQUEST_TYPE_GET) {
             chimera_rest_handle_config(evpl, request, thread);
+        } else {
+            chimera_rest_handle_method_not_allowed(evpl, request);
+        }
+        return;
+    }
+
+    /* Cluster API: /api/v1/cluster (eviction control plane) */
+    if (url_len == 15 && strncmp(url, "/api/v1/cluster", 15) == 0) {
+        if (req_type == EVPL_HTTP_REQUEST_TYPE_GET) {
+            chimera_rest_handle_cluster_list(evpl, request, thread);
+        } else {
+            chimera_rest_handle_method_not_allowed(evpl, request);
+        }
+        return;
+    }
+
+    if (chimera_rest_url_starts_with(url, url_len, "/api/v1/cluster/evict/", 22)) {
+        chimera_rest_extract_path_param(url, url_len, 22, param, sizeof(param));
+        if (param[0] != '\0') {
+            if (req_type == EVPL_HTTP_REQUEST_TYPE_POST) {
+                chimera_rest_handle_cluster_evict(evpl, request, thread, param);
+            } else if (req_type == EVPL_HTTP_REQUEST_TYPE_DELETE) {
+                chimera_rest_handle_cluster_rejoin(evpl, request, thread, param);
+            } else {
+                chimera_rest_handle_method_not_allowed(evpl, request);
+            }
         } else {
             chimera_rest_handle_method_not_allowed(evpl, request);
         }

--- a/src/server/rest/rest_cluster.c
+++ b/src/server/rest/rest_cluster.c
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <jansson.h>
+
+#include "evpl/evpl.h"
+#include "evpl/evpl_http.h"
+#include "server/server.h"
+#include "rest_internal.h"
+
+/*
+ * Cluster control plane (WS-D eviction signal).
+ *
+ *   GET    /api/v1/cluster              -> { local_node_id, evicted: [..] }
+ *   POST   /api/v1/cluster/evict/{node} -> mark node evicted (shared-KV write)
+ *   DELETE /api/v1/cluster/evict/{node} -> clear an eviction (node rejoined)
+ *
+ * This is the minimal admin/orchestrator hook; chimera does not detect node
+ * death itself.  Marking a node evicted authorizes survivors to reclaim its
+ * durable handles and (later) release its leases and open the grace window.
+ */
+
+void
+chimera_rest_handle_cluster_list(
+    struct evpl                *evpl,
+    struct evpl_http_request   *request,
+    struct chimera_rest_thread *thread)
+{
+    struct chimera_server *server = thread->shared->server;
+    json_t                *root;
+    json_t                *evicted;
+    uint8_t                list[256];
+    int                    n, i;
+
+    root = json_object();
+    json_object_set_new(root, "local_node_id",
+                        json_integer(chimera_server_cluster_local_node_id(server)));
+
+    evicted = json_array();
+    n       = chimera_server_cluster_evicted_list(server, list, sizeof(list));
+    for (i = 0; i < n; i++) {
+        json_array_append_new(evicted, json_integer(list[i]));
+    }
+    json_object_set_new(root, "evicted", evicted);
+
+    chimera_rest_send_json(evpl, request, 200, root);
+} /* chimera_rest_handle_cluster_list */
+
+void
+chimera_rest_handle_cluster_evict(
+    struct evpl                *evpl,
+    struct evpl_http_request   *request,
+    struct chimera_rest_thread *thread,
+    const char                 *node_str)
+{
+    struct chimera_server *server  = thread->shared->server;
+    int                    node_id = atoi(node_str);
+    json_t                *root;
+
+    if (chimera_server_cluster_evict(server, thread->vfs_thread, node_id) != 0) {
+        chimera_rest_send_error(evpl, request, 400, "Bad Request",
+                                "node_id must be 1..255 and not the local node");
+        return;
+    }
+
+    root = json_object();
+    json_object_set_new(root, "node_id", json_integer(node_id));
+    json_object_set_new(root, "evicted", json_true());
+    chimera_rest_send_json(evpl, request, 200, root);
+} /* chimera_rest_handle_cluster_evict */
+
+void
+chimera_rest_handle_cluster_rejoin(
+    struct evpl                *evpl,
+    struct evpl_http_request   *request,
+    struct chimera_rest_thread *thread,
+    const char                 *node_str)
+{
+    struct chimera_server *server  = thread->shared->server;
+    int                    node_id = atoi(node_str);
+    json_t                *root;
+
+    if (chimera_server_cluster_rejoin(server, thread->vfs_thread, node_id) != 0) {
+        chimera_rest_send_error(evpl, request, 400, "Bad Request",
+                                "node_id must be 1..255");
+        return;
+    }
+
+    root = json_object();
+    json_object_set_new(root, "node_id", json_integer(node_id));
+    json_object_set_new(root, "evicted", json_false());
+    chimera_rest_send_json(evpl, request, 200, root);
+} /* chimera_rest_handle_cluster_rejoin */

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -17,6 +17,7 @@
 #include "evpl/evpl.h"
 #include "server_internal.h"
 #include "protocol.h"
+#include "cluster.h"
 #include "nfs/nfs.h"
 #include "nfs/nfs4_lease.h"
 #include "s3/s3.h"
@@ -50,6 +51,7 @@ struct chimera_server_config {
     int                                   nfs_port;
     int                                   s3_port;
     int                                   nfs_data_server;
+    int                                   node_id;
     uint64_t                              nfs_server_scope;
     int                                   external_portmap;
     char                                  portmap_hostname[256];
@@ -120,6 +122,7 @@ struct chimera_server {
     void                               *smb_shared;
     void                               *nfs_shared;
     struct chimera_rest_server         *rest;
+    struct chimera_cluster             *cluster;
     int                                 num_protocols;
     int                                 threads_online;
     pthread_mutex_t                     lock;
@@ -240,6 +243,16 @@ chimera_server_config_init(void)
      * Default preserves the historical value; override per instance via
      * "nfs_server_scope". */
     config->nfs_server_scope = 42;
+
+    /* Cluster node identity.  0 (the default) means single-node / unclustered:
+     * persistent-handle keys and on-disk state are byte-identical to a
+     * non-clustered build and no cross-node behavior is engaged.  In a
+     * VIP + shared-backend cluster every node MUST be assigned a distinct
+     * value in 1..255 ("node_id"); it is folded into globally-shared keys
+     * (e.g. the high bits of SMB persistent ids) so two nodes never collide
+     * in the shared keyspace, and stamped on persisted state so a reaper can
+     * attribute and release the records held by an evicted node. */
+    config->node_id = 0;
 
     config->cache_ttl = 60;
 
@@ -777,6 +790,20 @@ chimera_server_config_get_nfs_server_scope(const struct chimera_server_config *c
 } /* chimera_server_config_get_nfs_server_scope */
 
 SYMBOL_EXPORT void
+chimera_server_config_set_node_id(
+    struct chimera_server_config *config,
+    int                           node_id)
+{
+    config->node_id = node_id;
+} /* chimera_server_config_set_node_id */
+
+SYMBOL_EXPORT int
+chimera_server_config_get_node_id(const struct chimera_server_config *config)
+{
+    return config->node_id;
+} /* chimera_server_config_get_node_id */
+
+SYMBOL_EXPORT void
 chimera_server_config_set_nfs_rdma_hostname(
     struct chimera_server_config *config,
     const char                   *hostname)
@@ -1172,6 +1199,10 @@ chimera_server_thread_init(
     }
 
     thread->rest_thread = chimera_rest_thread_init(evpl, server->rest, thread->vfs_thread);
+
+    /* Load the persisted cluster eviction set once, from the first thread to
+     * come online (it now has a vfs_thread for the shared KV).  Idempotent. */
+    chimera_cluster_load(server->cluster, thread->vfs_thread);
 
     pthread_mutex_lock(&server->lock);
     if (++server->threads_online == server->config->core_threads) {
@@ -1713,6 +1744,134 @@ chimera_server_thread_shutdown(
     free(thread);
 } /* chimera_server_thread_shutdown */
 
+/* Fold (acc || data) into a new 64-bit accumulator; order-sensitive so the
+ * resulting digest depends on both the values and the order they are fed. */
+static uint64_t
+chimera_digest_mix(
+    uint64_t    acc,
+    const void *data,
+    size_t      len)
+{
+    uint8_t buf[8 + sizeof(((struct chimera_vfs_module_cfg *) 0)->config_data)];
+
+    if (len > sizeof(buf) - 8) {
+        len = sizeof(buf) - 8;
+    }
+    memcpy(buf, &acc, sizeof(acc));
+    memcpy(buf + sizeof(acc), data, len);
+    return XXH3_64bits(buf, sizeof(acc) + len);
+} /* chimera_digest_mix */
+
+/* Cluster identity digest.  In a VIP + shared-backend cluster every node must
+ * present the SAME logical-server identity and resolve the SAME file handles
+ * and access decisions, or reconnect-anywhere silently breaks.  Most of that is
+ * governed by config that must be byte-identical across nodes (server scope,
+ * the module set + their fsid/path config, the cache TTL, the anon ids), with
+ * node_id the one value that must DIFFER.  This logs each determinism-critical
+ * field plus a single combined digest over the must-match fields so an operator
+ * (or a test harness) can confirm at a glance that two nodes agree on identity
+ * (digests equal) while remaining distinct nodes (node_id differs).
+ *
+ * This is observability, not enforcement: a node cannot see a peer's config, so
+ * it logs rather than fails.  Backends that derive fsid from a shared persistent
+ * superblock (cairn, diskfs) are consistent by construction; memfs needs its
+ * "fsid" config knob set identically across nodes; the nfs-proxy and
+ * linux/io_uring passthrough backends are NOT guaranteed cross-node-stable
+ * (mount-order server index / host-assigned f_fsid) and are unsuitable as the
+ * coherent cluster backend. */
+static void
+chimera_server_log_cluster_digest(const struct chimera_server_config *config)
+{
+    uint64_t d = 0;
+    int      i;
+
+    d = chimera_digest_mix(d, &config->nfs_server_scope, sizeof(config->nfs_server_scope));
+    d = chimera_digest_mix(d, &config->cache_ttl, sizeof(config->cache_ttl));
+    d = chimera_digest_mix(d, &config->anonuid, sizeof(config->anonuid));
+    d = chimera_digest_mix(d, &config->anongid, sizeof(config->anongid));
+    d = chimera_digest_mix(d, &config->num_modules, sizeof(config->num_modules));
+
+    for (i = 0; i < config->num_modules; i++) {
+        /* +1 to fold the NUL terminator as a field separator. */
+        d = chimera_digest_mix(d, config->modules[i].module_name,
+                               strlen(config->modules[i].module_name) + 1);
+        d = chimera_digest_mix(d, config->modules[i].module_path,
+                               strlen(config->modules[i].module_path) + 1);
+        d = chimera_digest_mix(d, config->modules[i].config_data,
+                               strlen(config->modules[i].config_data) + 1);
+    }
+
+    chimera_server_info(
+        "Cluster identity: node_id=%d server_scope=%llu cache_ttl=%ds anon=%u:%u modules=%d digest=%016llx",
+        config->node_id,
+        (unsigned long long) config->nfs_server_scope,
+        config->cache_ttl,
+        config->anonuid,
+        config->anongid,
+        config->num_modules,
+        (unsigned long long) d);
+
+    if (config->node_id == 0) {
+        chimera_server_info(
+            "Cluster identity: node_id=0 (single-node/unclustered) -- assign a distinct node_id (1..255) per node for a shared-backend cluster");
+    } else {
+        chimera_server_info(
+            "Cluster identity: peers must share digest=%016llx (identical config) but each carry a distinct node_id",
+            (unsigned long long) d);
+    }
+} /* chimera_server_log_cluster_digest */
+
+SYMBOL_EXPORT int
+chimera_server_cluster_evict(
+    struct chimera_server     *server,
+    struct chimera_vfs_thread *vfs_thread,
+    int                        node_id)
+{
+    int rc = chimera_cluster_evict(server->cluster, vfs_thread, node_id);
+
+    /* A peer died: re-open NFSv4 + NLM grace on this survivor so it can absorb
+     * the evicted node's failover clients (reclaim) while refusing conflicting
+     * new locks until reclaim drains.  Only on a clustered node (node_id != 0);
+     * a single-node deployment has no failover to absorb.  (The orchestrator
+     * should signal every survivor; cluster-wide grace fan-out is future work.) */
+    if (rc == 0 && chimera_cluster_local_node_id(server->cluster) != 0) {
+        if (server->nfs_shared) {
+            chimera_nfs_cluster_grace_reopen(server->nfs_shared, vfs_thread);
+        }
+        /* Re-arm SMB durable recovery so the evicted node's persisted handles
+         * are adopted (and become reclaimable) on the next tree-connect. */
+        if (server->smb_shared) {
+            chimera_smb_cluster_on_evict(server->smb_shared);
+        }
+    }
+
+    return rc;
+} /* chimera_server_cluster_evict */
+
+SYMBOL_EXPORT int
+chimera_server_cluster_rejoin(
+    struct chimera_server     *server,
+    struct chimera_vfs_thread *vfs_thread,
+    int                        node_id)
+{
+    return chimera_cluster_rejoin(server->cluster, vfs_thread, node_id);
+} /* chimera_server_cluster_rejoin */
+
+SYMBOL_EXPORT int
+chimera_server_cluster_local_node_id(struct chimera_server *server)
+{
+    return chimera_cluster_local_node_id(server->cluster);
+} /* chimera_server_cluster_local_node_id */
+
+SYMBOL_EXPORT int
+chimera_server_cluster_evicted_list(
+    struct chimera_server *server,
+    uint8_t               *out,
+    int                    cap)
+{
+    return chimera_cluster_evicted_list(server->cluster, out, cap);
+} /* chimera_server_cluster_evicted_list */
+
 SYMBOL_EXPORT struct chimera_server *
 chimera_server_init(
     const struct chimera_server_config *config,
@@ -1754,6 +1913,10 @@ chimera_server_init(
 
     pthread_mutex_init(&server->lock, NULL);
     pthread_cond_init(&server->all_threads_online, NULL);
+
+    chimera_server_log_cluster_digest(config);
+
+    server->cluster = chimera_cluster_init(config->node_id);
 
     chimera_server_info("Initializing VFS...");
     server->vfs = chimera_vfs_init(config->sync_delegation ? config->sync_delegation_threads : 0,
@@ -1805,6 +1968,12 @@ chimera_server_init(
     if (!config->nfs_data_server) {
         server->smb_shared = server->protocol_private[1];
         server->s3_shared  = server->protocol_private[2];
+
+        /* Hand the SMB layer the cluster eviction registry so its durable
+         * recovery scan only adopts an evicted (dead) peer's persisted handles
+         * for cross-node reclaim, never a live peer's. */
+        chimera_smb_set_cluster(server->smb_shared, server->cluster,
+                                chimera_cluster_node_is_evicted);
     }
 
     chimera_server_info("Initializing REST API...");
@@ -1862,6 +2031,8 @@ chimera_server_destroy(struct chimera_server *server)
     chimera_vfs_destroy(server->vfs);
 
     chimera_rest_destroy(server->rest);
+
+    chimera_cluster_destroy(server->cluster);
 
     free((void *) server->config);
     free(server);

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -366,6 +366,15 @@ chimera_server_config_get_nfs_server_scope(
     const struct chimera_server_config *config);
 
 void
+chimera_server_config_set_node_id(
+    struct chimera_server_config *config,
+    int                           node_id);
+
+int
+chimera_server_config_get_node_id(
+    const struct chimera_server_config *config);
+
+void
 chimera_server_config_set_nfs_rdma_hostname(
     struct chimera_server_config *config,
     const char                   *hostname);
@@ -605,6 +614,31 @@ chimera_server_start(
 void
 chimera_server_destroy(
     struct chimera_server *server);
+
+/* Cluster eviction control plane (see cluster.h).  These wrap the server's
+ * eviction registry so callers (e.g. the REST control endpoint) need only the
+ * opaque chimera_server handle plus a vfs_thread for the shared-KV write. */
+int
+chimera_server_cluster_evict(
+    struct chimera_server     *server,
+    struct chimera_vfs_thread *vfs_thread,
+    int                        node_id);
+
+int
+chimera_server_cluster_rejoin(
+    struct chimera_server     *server,
+    struct chimera_vfs_thread *vfs_thread,
+    int                        node_id);
+
+int
+chimera_server_cluster_local_node_id(
+    struct chimera_server *server);
+
+int
+chimera_server_cluster_evicted_list(
+    struct chimera_server *server,
+    uint8_t               *out,
+    int                    cap);
 
 int
 chimera_server_add_user(

--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -199,10 +199,16 @@ chimera_smb_server_init(
     pthread_mutex_init(&shared->trees_lock, NULL);
     pthread_mutex_init(&shared->threads_lock, NULL);
 
+    shared->node_id = chimera_server_config_get_node_id(config);
+
     /* Seed the persistent-id allocator with a random, nonzero base so ids do
      * not restart from a fixed value across daemon restarts (a courtesy to the
-     * future on-disk persistence layer; 0 is reserved for "no file id"). */
-    atomic_init(&shared->next_persistent_id, (chimera_rand64() | 1));
+     * future on-disk persistence layer; 0 is reserved for "no file id").  The
+     * counter occupies only the low 56 bits — the high byte is reserved for the
+     * node_id stamped in by chimera_smb_alloc_persistent_id — so mask the seed
+     * to 56 bits to keep the node byte clean. */
+    atomic_init(&shared->next_persistent_id,
+                ((chimera_rand64() & CHIMERA_SMB_PID_COUNTER_MASK) | 1));
 
     chimera_smb_durable_table_init(&shared->durable);
 
@@ -2362,6 +2368,41 @@ chimera_smb_add_share(
     pthread_mutex_unlock(&shared->shares_lock);
 
 } /* chimera_smb_add_share */
+
+SYMBOL_EXPORT void
+chimera_smb_set_cluster(
+    void *smb_shared,
+    struct chimera_cluster *cluster,
+    int ( *node_evicted )(const struct chimera_cluster *, int))
+{
+    struct chimera_server_smb_shared *shared = smb_shared;
+
+    shared->cluster      = cluster;
+    shared->node_evicted = node_evicted;
+} /* chimera_smb_set_cluster */
+
+SYMBOL_EXPORT void
+chimera_smb_cluster_on_evict(void *smb_shared)
+{
+    struct chimera_server_smb_shared *shared = smb_shared;
+    struct chimera_smb_share         *share;
+
+    /* A peer was evicted.  Re-arm the per-share durable recovery scan for every
+     * continuous-availability share so the NEXT tree-connect re-scans the
+     * shared backend -- the node-filtered recover scan now adopts the evicted
+     * node's persisted handles (including any minted after this node's first
+     * scan), making them reclaimable here.  The failover client must
+     * tree-connect before reconnecting its handle, so the rescan runs on that
+     * client's own SMB thread (no cross-thread scan from here). */
+    pthread_mutex_lock(&shared->shares_lock);
+    LL_FOREACH(shared->shares, share)
+    {
+        if (share->continuous_availability) {
+            share->durable_recovered = false;
+        }
+    }
+    pthread_mutex_unlock(&shared->shares_lock);
+} /* chimera_smb_cluster_on_evict */
 
 SYMBOL_EXPORT int
 chimera_smb_share_set_access_based_enum(

--- a/src/server/smb/smb.h
+++ b/src/server/smb/smb.h
@@ -8,6 +8,7 @@
 #include "vfs/vfs.h"
 #include "prometheus-c.h"
 struct chimera_smb_share;
+struct chimera_cluster;
 
 void
 chimera_smb_add_share(
@@ -15,6 +16,21 @@ chimera_smb_add_share(
     const char *name,
     const char *path,
     int         continuous_availability);
+
+/* Attach the cluster eviction registry + its query fn (post-init, from
+ * chimera_server) so the durable recovery scan can tell an evicted peer's
+ * handles (adoptable) from a live peer's (must not be stolen). */
+void
+chimera_smb_set_cluster(
+    void *smb_shared,
+    struct chimera_cluster *cluster,
+    int ( *node_evicted )(const struct chimera_cluster *, int));
+
+/* React to a peer eviction: re-arm the per-share durable recovery scan so the
+ * next tree-connect re-adopts the evicted node's persisted handles. */
+void
+chimera_smb_cluster_on_evict(
+    void *smb_shared);
 
 /* Enable access-based directory enumeration on a named share. */
 int

--- a/src/server/smb/smb_durable.c
+++ b/src/server/smb/smb_durable.c
@@ -65,6 +65,15 @@ chimera_smb_durable_table_destroy(struct chimera_smb_durable_table *table)
     pthread_mutex_destroy(&table->lock);
 } /* chimera_smb_durable_table_destroy */
 
+SYMBOL_EXPORT uint64_t
+chimera_smb_alloc_persistent_id(struct chimera_server_smb_shared *shared)
+{
+    uint64_t counter = atomic_fetch_add(&shared->next_persistent_id, 1) &
+        CHIMERA_SMB_PID_COUNTER_MASK;
+
+    return counter | ((uint64_t) (uint8_t) shared->node_id << CHIMERA_SMB_PID_NODE_SHIFT);
+} /* chimera_smb_alloc_persistent_id */
+
 SYMBOL_EXPORT void
 chimera_smb_durable_register(
     struct chimera_server_smb_shared *shared,
@@ -135,10 +144,18 @@ chimera_smb_durable_recover_entry(
     }
     HASH_ADD(hh, shared->durable.by_pid, persistent_id, sizeof(entry->persistent_id), entry);
 
-    /* Keep the id allocator ahead of every recovered persistent id so a fresh
-     * open can never collide with a not-yet-reclaimed one. */
-    if (atomic_load(&shared->next_persistent_id) <= pid) {
-        atomic_store(&shared->next_persistent_id, pid + 1);
+    /* Keep the id allocator ahead of every recovered persistent id minted by
+     * THIS node so a fresh open can never collide with a not-yet-reclaimed one.
+     * A record minted by another node carries that node's id in its high bits
+     * and lives in a different counter range — re-seeding from it would drag
+     * our counter into the peer's range and produce colliding ids.  Compare in
+     * counter space (the low 56 bits); next_persistent_id holds the bare
+     * counter, pid holds the node-tagged value. */
+    if (CHIMERA_SMB_PID_NODE(pid) == (uint8_t) shared->node_id) {
+        uint64_t counter = pid & CHIMERA_SMB_PID_COUNTER_MASK;
+        if (atomic_load(&shared->next_persistent_id) <= counter) {
+            atomic_store(&shared->next_persistent_id, counter + 1);
+        }
     }
     pthread_mutex_unlock(&shared->durable.lock);
 } /* chimera_smb_durable_recover_entry */
@@ -789,7 +806,23 @@ chimera_smb_durable_recover_cb(
     }
 
     if (chimera_smb_durable_deserialize(value, value_len, &record) == 0) {
-        chimera_smb_durable_recover_entry(ctx->shared, &record);
+        struct chimera_server_smb_shared *shared = ctx->shared;
+        int                               owner  =
+            CHIMERA_SMB_PID_NODE(record.persistent_id);
+
+        /* Cross-node adoption gate.  Adopt a persisted handle as a cold,
+         * reclaimable entry ONLY when it was minted by THIS node (restart
+         * recovery of our own prior instance) or by a peer that has been
+         * EVICTED (failover -- the dead node's handles are now ours to hand
+         * back).  A live peer's handle is left untouched so a client cannot
+         * reconnect here and steal a handle the peer still holds warm.  When
+         * unclustered (node_id 0) every record carries owner 0 == node_id, so
+         * single-node restart recovery is unchanged. */
+        if (owner == shared->node_id ||
+            (shared->cluster && shared->node_evicted &&
+             shared->node_evicted(shared->cluster, owner))) {
+            chimera_smb_durable_recover_entry(shared, &record);
+        }
     }
 
     return 0;

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -311,6 +311,16 @@ chimera_smb_set_info_rename_process(
 #define CHIMERA_SMB_DURABLE_KEY_PREFIX     "smbdh"
 #define CHIMERA_SMB_DURABLE_KEY_PREFIX_LEN 5
 #define CHIMERA_SMB_DURABLE_KEY_LEN        (CHIMERA_SMB_DURABLE_KEY_PREFIX_LEN + 8)
+
+/* Persistent-id layout for cluster-wide uniqueness: the high 8 bits carry the
+ * minting node's node_id, the low 56 bits are a per-node monotonic counter.
+ * The durable KV key is still prefix + le64(persistent_id) (format unchanged),
+ * so the keyspace stays globally addressable by the full id the client echoes
+ * back on reconnect; two nodes simply never mint the same id.  For node_id 0
+ * (single-node default) the high byte is 0, so behavior is unchanged. */
+#define CHIMERA_SMB_PID_NODE_SHIFT         56
+#define CHIMERA_SMB_PID_COUNTER_MASK       0x00FFFFFFFFFFFFFFULL
+#define CHIMERA_SMB_PID_NODE(pid) ((int) (((uint64_t) (pid)) >> CHIMERA_SMB_PID_NODE_SHIFT))
 #define CHIMERA_SMB_DURABLE_RECORD_MAGIC   0x31484453  /* 'SDH1' LE */
 /* Fixed header bytes before the variable-length name in a serialized record:
  * magic(4) pid(8) create_guid(16) client_guid(16) session(8) durable_flags(4)
@@ -1174,9 +1184,29 @@ struct chimera_server_smb_shared {
     int                               any_share_encrypt;
     struct chimera_smb_tree          *free_trees;
     pthread_mutex_t                   trees_lock;
-    /* Monotonic, process-global allocator for file persistent ids.  Replaces
-     * the old per-tree counter so persistent ids stay unique across tree
-     * teardowns — a precondition for durable-handle reconnect lookup. */
+    /* Cluster node identity (0 == single-node/unclustered, 1..255 == cluster
+     * member).  Copied from chimera_server_config at init.  Folded into the
+     * high 8 bits of every persistent id this node mints (see
+     * CHIMERA_SMB_PID_* below) so two nodes sharing a backend never collide in
+     * the "smbdh" keyspace, and so the owning node of any durable handle is
+     * recoverable from its persistent id alone (used by cross-node reclaim and
+     * the evicted-node reaper). */
+    int                               node_id;
+    /* Cluster eviction registry + query fn (owned by chimera_server; set
+     * post-init via chimera_smb_set_cluster).  Consulted by the durable
+     * recovery scan to decide which peer nodes' persisted handles this node may
+     * adopt for cross-node reclaim -- only an evicted (dead) peer's, never a
+     * live one's.  Injected as a fn pointer so this lib does not link-depend on
+     * the higher-layer cluster module. */
+    struct chimera_cluster           *cluster;
+    int                               (*node_evicted)(
+        const struct chimera_cluster *,
+        int);
+    /* Monotonic, process-global allocator for file persistent ids.  Holds the
+     * low-56-bit counter only; chimera_smb_alloc_persistent_id() OR's the node
+     * byte in at allocation.  Replaces the old per-tree counter so persistent
+     * ids stay unique across tree teardowns — a precondition for durable-handle
+     * reconnect lookup. */
     _Atomic uint64_t                  next_persistent_id;
     /* In-memory durable/persistent handle registry (see struct above). */
     struct chimera_smb_durable_table  durable;
@@ -1289,6 +1319,14 @@ void
 chimera_smb_durable_recover_entry(
     struct chimera_server_smb_shared        *shared,
     const struct chimera_smb_durable_record *record);
+
+/* Allocate the next persistent id: a per-node monotonic counter in the low 56
+ * bits with this node's node_id folded into the high 8 bits (see
+ * CHIMERA_SMB_PID_* above).  The minting node of any id is recoverable as
+ * CHIMERA_SMB_PID_NODE(pid). */
+uint64_t
+chimera_smb_alloc_persistent_id(
+    struct chimera_server_smb_shared *shared);
 
 /* Build the backend KV key for a persistent id into buf (>= CHIMERA_SMB_DURABLE_KEY_LEN). */
 uint32_t

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -1227,7 +1227,7 @@ chimera_smb_create_gen_open_file_normal(
      * written atomically with the open; adopt it here. */
     uint64_t                      pid = request->create.persist_pid ?
         request->create.persist_pid :
-        atomic_fetch_add(&request->compound->thread->shared->next_persistent_id, 1);
+        chimera_smb_alloc_persistent_id(request->compound->thread->shared);
 
     open_file = chimera_smb_create_gen_open_file(request,
                                                  CHIMERA_SMB_OPEN_FILE_TYPE_FILE,
@@ -2655,7 +2655,7 @@ chimera_smb_create_persist_prepare(
     }
 
     if (request->create.persist_pid == 0) {
-        request->create.persist_pid = atomic_fetch_add(&shared->next_persistent_id, 1);
+        request->create.persist_pid = chimera_smb_alloc_persistent_id(shared);
     }
     pid = request->create.persist_pid;
 

--- a/src/vfs/vfs.c
+++ b/src/vfs/vfs.c
@@ -648,6 +648,35 @@ chimera_vfs_set_tcp_flavor(
     vfs->tcp_flavor = flavor;
 } /* chimera_vfs_set_tcp_flavor */
 
+/*
+ * Drop this node's cached state for a file handle when the file has changed
+ * underneath us (cross-node coherence, WS-E).  The intended caller is the
+ * backend lease-recall upcall: when a CAP_LEASE backend recalls/breaks a lease
+ * on a file because a peer node mutated it, the survivor must discard its
+ * stale attr/name cache for that fh so the next lookup/getattr re-reads the
+ * authoritative state from the coherent backend.
+ *
+ * Drops the attribute cache entry and any name-cache entries referencing the
+ * fh (as parent or child).  The open-handle cache is intentionally left alone:
+ * an open handle's validity is re-checked by the backend on the next I/O (a
+ * peer unlink surfaces as a STALE/NOENT there), and a live, refcounted handle
+ * must not be torn out from under in-flight operations.
+ *
+ * Until a CAP_LEASE backend is wired (lease-persist branch), files not under a
+ * lease rely on the cache TTL (set cache_ttl = 0 for strict no-cache).
+ */
+SYMBOL_EXPORT void
+chimera_vfs_invalidate_fh(
+    struct chimera_vfs *vfs,
+    const void         *fh,
+    int                 fh_len)
+{
+    uint64_t fh_hash = chimera_vfs_hash(fh, fh_len);
+
+    chimera_vfs_attr_cache_invalidate(vfs->vfs_attr_cache, fh_hash, fh, fh_len);
+    chimera_vfs_name_cache_invalidate_fh(vfs->vfs_name_cache, fh, fh_len);
+} /* chimera_vfs_invalidate_fh */
+
 SYMBOL_EXPORT int
 chimera_vfs_fh_is_plausible(
     struct chimera_vfs_thread *thread,

--- a/src/vfs/vfs.h
+++ b/src/vfs/vfs.h
@@ -1509,6 +1509,15 @@ chimera_vfs_set_tcp_flavor(
     struct chimera_vfs     *vfs,
     enum chimera_tcp_flavor flavor);
 
+/* Invalidate this node's cached attr/name state for a file handle that changed
+ * underneath it (cross-node coherence).  Intended caller: the CAP_LEASE backend
+ * lease-recall upcall.  See chimera_vfs_invalidate_fh in vfs.c. */
+void
+chimera_vfs_invalidate_fh(
+    struct chimera_vfs *vfs,
+    const void         *fh,
+    int                 fh_len);
+
 /* Get the root pseudo-filesystem's file handle */
 void
 chimera_vfs_get_root_fh(

--- a/src/vfs/vfs_attr_cache.h
+++ b/src/vfs/vfs_attr_cache.h
@@ -224,6 +224,14 @@ chimera_vfs_attr_cache_insert(
     struct chimera_vfs_attr_cache_shard  *shard;
     struct chimera_vfs_attr_cache_entry **slot, **slot_end, **slot_best;
 
+    /* Strict-coherence mode (cache_ttl == 0): do not cache attributes at all,
+     * so every getattr hits the backend and a peer's mutation is never masked
+     * by a stale local entry.  The fallback coherence lever for files not
+     * covered by a lease-coupled invalidation (see chimera_vfs_invalidate_fh). */
+    if (cache->ttl == 0) {
+        return;
+    }
+
     shard = &cache->shards[fh_hash & cache->num_shards_mask];
 
     slot = &shard->entries[(fh_hash & cache->num_slots_mask) << cache->num_entries_bits];
@@ -288,6 +296,56 @@ chimera_vfs_attr_cache_insert(
     }
 
 } /* chimera_vfs_attr_cache_insert */
+
+/*
+ * Drop the cached attributes for a file handle, if present.  Called when this
+ * node learns the file changed underneath it -- principally from the cross-node
+ * lease-recall upcall (a peer mutated the file), so the next getattr re-reads
+ * the authoritative attrs from the (coherent) backend instead of returning a
+ * stale size/mtime.  Mirrors the insert slot walk; a no-op on a miss.
+ */
+static inline void
+chimera_vfs_attr_cache_invalidate(
+    struct chimera_vfs_attr_cache *cache,
+    uint64_t                       fh_hash,
+    const void                    *fh,
+    int                            fh_len)
+{
+    struct chimera_vfs_attr_cache_entry  *entry, *removed = NULL;
+    struct chimera_vfs_attr_cache_shard  *shard;
+    struct chimera_vfs_attr_cache_entry **slot, **slot_end;
+
+    shard = &cache->shards[fh_hash & cache->num_shards_mask];
+
+    slot = &shard->entries[(fh_hash & cache->num_slots_mask) << cache->num_entries_bits];
+
+    slot_end = slot + cache->num_entries;
+
+    urcu_qsbr_read_lock();
+
+    pthread_mutex_lock(&shard->entry_lock);
+
+    while (slot < slot_end) {
+        entry = *slot;
+
+        if (entry && entry->key == fh_hash &&
+            chimera_memequal(entry->attr.va_fh, entry->attr.va_fh_len, fh, fh_len)) {
+            removed = entry;
+            rcu_assign_pointer(*slot, NULL);
+            break;
+        }
+
+        slot++;
+    }
+
+    pthread_mutex_unlock(&shard->entry_lock);
+
+    urcu_qsbr_read_unlock();
+
+    if (removed) {
+        call_rcu(&removed->rnode.rcu, chimera_rcu_pool_retire);
+    }
+} /* chimera_vfs_attr_cache_invalidate */
 
 /*
  * Do two attr sets carry the same change-significant fields?  ctime is the

--- a/src/vfs/vfs_name_cache.h
+++ b/src/vfs/vfs_name_cache.h
@@ -235,6 +235,12 @@ chimera_vfs_name_cache_insert(
     uint64_t                              key = fh_hash ^ name_hash;
     uint64_t                              now = chimera_vfs_now_ticks();
 
+    /* Strict-coherence mode (cache_ttl == 0): do not cache name->fh mappings,
+     * so a peer's rename/unlink is never masked by a stale local entry. */
+    if (cache->ttl == 0) {
+        return;
+    }
+
     shard = &cache->shards[key & cache->num_shards_mask];
 
     slot = &shard->entries[(key & cache->num_slots_mask) << cache->num_entries_bits];
@@ -383,3 +389,47 @@ chimera_vfs_name_cache_remove(
     }
 
 } /* chimera_vfs_name_cache_remove */
+
+/*
+ * Drop every name-cache entry that references `fh` as either the parent
+ * directory or the resolved child, when this node learns the file changed
+ * underneath it (cross-node lease recall).  A directory mutation on a peer
+ * (create/remove/rename of a child) invalidates the parent==fh entries; a
+ * file's rename/unlink on a peer invalidates the child==fh entries.
+ *
+ * The cache is not indexed by child fh nor by a bare parent fh (the key folds
+ * in the name), so this walks all slots.  The table is small and bounded and
+ * recalls are infrequent (they fire only on cross-node contention), so the
+ * O(table) sweep is acceptable.
+ */
+static inline void
+chimera_vfs_name_cache_invalidate_fh(
+    struct chimera_vfs_name_cache *cache,
+    const void                    *fh,
+    int                            fh_len)
+{
+    uint32_t s;
+
+    for (s = 0; s < cache->num_shards; s++) {
+        struct chimera_vfs_name_cache_shard *shard = &cache->shards[s];
+        uint64_t                             total = cache->num_slots * cache->num_entries;
+        uint64_t                             i;
+
+        urcu_qsbr_read_lock();
+        pthread_mutex_lock(&shard->entry_lock);
+
+        for (i = 0; i < total; i++) {
+            struct chimera_vfs_name_cache_entry *entry = shard->entries[i];
+
+            if (entry &&
+                (chimera_memequal(entry->parent_fh, entry->parent_fh_len, fh, fh_len) ||
+                 chimera_memequal(entry->child_fh, entry->child_fh_len, fh, fh_len))) {
+                rcu_assign_pointer(shard->entries[i], NULL);
+                call_rcu(&entry->rnode.rcu, chimera_rcu_pool_retire);
+            }
+        }
+
+        pthread_mutex_unlock(&shard->entry_lock);
+        urcu_qsbr_read_unlock();
+    }
+} /* chimera_vfs_name_cache_invalidate_fh */


### PR DESCRIPTION
## Summary

Lays the **non-lease** groundwork for running Chimera as a cluster of equal nodes behind a single VIP over a coherent shared/parallel backend, where a client can disconnect from one node and reconnect to another. Scoped to the reconnect-anywhere model (migration / `fs_locations` / SMB Witness / DFS are explicitly **not** part of this model).

Everything new is gated on `node_id` (default `0` = single-node), so a non-clustered deployment is behaviorally unchanged; the durable-handle keyspace and on-disk records are byte-identical at `node_id=0`.

## What's included

**Foundation** — `node_id` config (0 = unclustered, 1..255 = cluster member), parsed + range-validated.

**Server-identity coherence (WS-B/WS-F)** — `server_owner`/`server_scope`/SMB GUID kept deliberately identical across nodes (documented at EXCHANGE_ID; failover is reclaim-based, and a single VIP means no cross-node trunking). New startup **cluster-identity digest** logs `node_id` + a digest over the must-match identity config so peers can be diffed (same digest, distinct `node_id`); `cache_ttl` is now actually parsed from config.

**Eviction control plane (WS-D)** — `src/server/cluster.{c,h}`: a shared-KV-persisted eviction registry (own `0xCB` key band) with mark/rejoin/query/load + startup self-rejoin, plus a REST surface (`GET /api/v1/cluster`, `POST`/`DELETE /api/v1/cluster/evict/{node}`). Chimera does not detect node death itself — an orchestrator signals it.

**SMB cross-node durable handles (WS-C)** — `persistent_id` now carries `node_id` in its high 8 bits (per-node counter in the low 56); the recovery re-seed is filtered to local-node ids so nodes never collide or strand their counter. The durable recovery scan adopts a persisted handle only when its owner node is this node (own restart) or an **evicted** peer (failover) — never a live peer's, closing a warm-handle-theft hazard clustering would otherwise introduce. Eviction re-arms the per-share scan so a failover client's tree-connect re-adopts.

**NFSv4/NLM grace + reclaim (WS-A)** — `nfs_recovery_open_check` now validates CLAIM_PREVIOUS eligibility (a reclaim from a client with no recovery record is refused with `NFS4ERR_NO_GRACE` instead of minting fresh state). On a peer eviction, a survivor re-opens NFSv4 grace + re-scans the shared recovery records and re-opens NLM grace, so it can absorb failover clients while refusing conflicting non-reclaim locks.

**Per-node cache coherence (WS-E)** — `chimera_vfs_invalidate_fh` drops cached attrs + name→fh entries for a handle (the hook the CAP_LEASE recall upcall will call); `cache_ttl=0` disables attr/name caching as a strict-coherence fallback.

## Verification

Built clean (Debug) and uncrustify-clean throughout. In-sandbox testing: a new `nfs_persist` unit case for reclaim eligibility; the NFS server unit suite; the `combined` pynfs NFSv4.0 suites on memfs **and** cairn; 73 durable/persistent smbtorture cases; and daemon+curl checks of the eviction control plane and its NFS/NLM/SMB side-effects. `make check` (full CI incl. KVM) and the persistent-KV cross-restart cluster e2e were not run in-sandbox and are left to CI.

## Deferred (cross-branch dependency)

These attach to the **`lease-persist`** branch's CAP_LEASE backend recall upcall and are intentionally not in this PR: wiring `chimera_vfs_invalidate_fh` + per-file ("held *this* object") reclaim validation + live-peer reclaim arbitration to that upcall, plus multi-node grace fan-out (orchestrator signalling each survivor).

Draft — opening for early review of the approach and layering.