### PR TITLE
smb2/streams: green smb2.streams.dir and attributes1

### DIFF
--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -553,6 +553,11 @@ struct chimera_smb_request {
              * trimmed to the base file.  base_oh is the base file's open handle
              * held across the chained chimera_vfs_open_stream. */
             uint8_t                            has_stream;
+            /* Set when the final component is the explicit default data fork
+             * "file::$DATA" (has_stream stays 0; the base file is opened).  A
+             * directory has no data fork, so the open path rejects this form on
+             * a directory target (smb2.streams.dir). */
+            uint8_t                            explicit_data_fork;
             uint16_t                           stream_name_len;
             char                               stream_name[SMB_FILENAME_MAX];
             struct chimera_vfs_open_handle    *base_oh;

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -1894,6 +1894,22 @@ chimera_smb_create_open_at_callback(
         return;
     }
 
+    /* "DNAME::$DATA" explicitly names the default data fork of the target.  A
+     * directory has no data fork, so reject it now that the open has revealed
+     * the target is a directory: NOT_A_DIRECTORY when the caller also requested
+     * FILE_DIRECTORY_FILE, FILE_IS_A_DIRECTORY otherwise (smb2.streams.dir).
+     * This fires only for the explicit "::$DATA" form on a directory, a path
+     * that otherwise opens the directory as a plain file. */
+    if (request->create.explicit_data_fork && S_ISDIR(attr->va_mode)) {
+        chimera_smb_create_release_handle(vfs_thread, oh);
+        chimera_smb_create_release_parent(request);
+        chimera_smb_complete_request(request,
+                                     (request->create.create_options & SMB2_FILE_DIRECTORY_FILE)
+                                     ? SMB2_STATUS_NOT_A_DIRECTORY
+                                     : SMB2_STATUS_FILE_IS_A_DIRECTORY);
+        return;
+    }
+
     /* Named-stream open: the base file is now open; open the stream on it and
      * build the SMB open_file around the stream handle. */
     if (request->create.has_stream) {
@@ -3504,13 +3520,15 @@ chimera_smb_parse_stream_name(
     uint16_t    *r_base_len,
     const char **r_stream,
     uint16_t    *r_stream_len,
-    uint8_t     *r_has_stream)
+    uint8_t     *r_has_stream,
+    uint8_t     *r_explicit_data_fork)
 {
     const char *colon = memchr(name, ':', name_len);
     const char *rest, *type, *colon2;
     uint16_t    base_len, rest_len, stream_len;
 
-    *r_has_stream = 0;
+    *r_has_stream         = 0;
+    *r_explicit_data_fork = 0;
 
     if (!colon) {
         *r_base_len = name_len;
@@ -3543,11 +3561,14 @@ chimera_smb_parse_stream_name(
 
     if (stream_len == 0) {
         /* "file::$DATA" is the default data fork (open the base file); a bare
-         * trailing "file:" with neither name nor type is malformed. */
+         * trailing "file:" with neither name nor type is malformed.  Flag the
+         * explicit default-data-fork form so the open path can reject it on a
+         * directory (a directory has no data fork -- smb2.streams.dir). */
         if (!colon2) {
             return SMB2_STATUS_OBJECT_NAME_INVALID;
         }
-        *r_base_len = base_len;
+        *r_base_len           = base_len;
+        *r_explicit_data_fork = 1;
         return SMB2_STATUS_SUCCESS;
     }
 
@@ -3749,8 +3770,9 @@ chimera_smb_create(struct chimera_smb_request *request)
     enum chimera_smb_pipe_magic   pipe_magic;
     chimera_smb_pipe_transceive_t transceive;
 
-    request->create.has_stream = 0;
-    request->create.base_oh    = NULL;
+    request->create.has_stream         = 0;
+    request->create.explicit_data_fork = 0;
+    request->create.base_oh            = NULL;
     /* Only the regular-file open path (open_at_callback) registers a finish
      * callback and may park on a batch-oplock break; clear it so the mkdir /
      * stream / pipe paths never inherit a stale callback and park. */
@@ -3775,18 +3797,23 @@ chimera_smb_create(struct chimera_smb_request *request)
             return;
         }
 
-        const char *sname      = NULL;
-        uint16_t    base_len   = request->create.name_len;
-        uint16_t    sname_len  = 0;
-        uint8_t     has_stream = 0;
-        uint32_t    pstatus    = chimera_smb_parse_stream_name(
+        const char *sname              = NULL;
+        uint16_t    base_len           = request->create.name_len;
+        uint16_t    sname_len          = 0;
+        uint8_t     has_stream         = 0;
+        uint8_t     explicit_data_fork = 0;
+        uint32_t    pstatus            = chimera_smb_parse_stream_name(
             request->create.name, request->create.name_len,
-            &base_len, &sname, &sname_len, &has_stream);
+            &base_len, &sname, &sname_len, &has_stream, &explicit_data_fork);
 
         if (pstatus != SMB2_STATUS_SUCCESS) {
             chimera_smb_complete_request(request, pstatus);
             return;
         }
+
+        /* "DNAME::$DATA" names the default data fork explicitly; remember it so
+         * the open-completion path can reject it on a directory target. */
+        request->create.explicit_data_fork = explicit_data_fork;
 
         /* A wildcard/invalid character in the BASE file name of a stream path
          * is rejected with OBJECT_NAME_INVALID (smb2.streams.names "stream*").

--- a/src/server/smb/smb_proc_query_info.c
+++ b/src/server/smb/smb_proc_query_info.c
@@ -269,6 +269,31 @@ chimera_smb_query_info(struct chimera_smb_request *request)
 
     switch (request->query_info.info_type) {
         case SMB2_INFO_FILE:
+            /* The attribute-bearing FILE info classes require the handle to
+             * hold FILE_READ_ATTRIBUTES (MS-FSA 2.1.5.11): a handle opened with
+             * only FILE_READ_DATA cannot query FileBasicInformation and friends
+             * -> STATUS_ACCESS_DENIED (smb2.streams.attributes1).  Classes that
+             * carry no file attributes (standard sizes, internal id, EA size,
+             * position, mode, alignment, access, name) are not gated. */
+            switch (request->query_info.info_class) {
+                case SMB2_FILE_BASIC_INFO:
+                case SMB2_FILE_NETWORK_OPEN_INFO:
+                case SMB2_FILE_ATTRIBUTE_TAG_INFO:
+                case SMB2_FILE_COMPRESSION_INFO:
+                case SMB2_FILE_ALL_INFO:
+                    if (!(request->query_info.open_file->granted_access &
+                          SMB2_FILE_READ_ATTRIBUTES)) {
+                        status = SMB2_STATUS_ACCESS_DENIED;
+                    }
+                    break;
+                default:
+                    break;
+            } /* switch */
+
+            if (status != SMB2_STATUS_SUCCESS) {
+                break;
+            }
+
             /* Calculate the output buffer length based on the info class */
             switch (request->query_info.info_class) {
                 case SMB2_FILE_BASIC_INFO:

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -1589,8 +1589,10 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.sharemode.bug14375
     smb2.sharemode.sharemode-access
     # smb2.streams
+    smb2.streams.attributes1
     smb2.streams.basefile-rename-with-open-stream
     smb2.streams.create-disposition
+    smb2.streams.dir
     smb2.streams.io
     smb2.streams.names
     smb2.streams.names2

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -5224,21 +5224,25 @@ memfs_list_streams(
     }
 
     /* Default unnamed data fork ("::$DATA"), reported first with an empty name
-     * so the SMB layer can format it as the default stream. */
-    rec = sizeof(entry);
-    if (offset + rec > max) {
-        pthread_mutex_unlock(&inode->lock);
-        request->status = CHIMERA_VFS_ERANGE;
-        request->complete(request);
-        return;
+     * so the SMB layer can format it as the default stream.  Only regular files
+     * have a data fork -- a directory reports no streams (smb2.streams.dir
+     * expects an empty stream list on a directory). */
+    if (S_ISREG(inode->mode)) {
+        rec = sizeof(entry);
+        if (offset + rec > max) {
+            pthread_mutex_unlock(&inode->lock);
+            request->status = CHIMERA_VFS_ERANGE;
+            request->complete(request);
+            return;
+        }
+        entry.size     = inode->size;
+        entry.alloc    = inode->space_used;
+        entry.name_len = 0;
+        memcpy(buf + offset, &entry, sizeof(entry));
+        offset += rec;
+        offset  = (offset + 7) & ~7u;
+        count++;
     }
-    entry.size     = inode->size;
-    entry.alloc    = inode->space_used;
-    entry.name_len = 0;
-    memcpy(buf + offset, &entry, sizeof(entry));
-    offset += rec;
-    offset  = (offset + 7) & ~7u;
-    count++;
 
     for (stream = inode->streams; stream; stream = stream->next) {
         rec = sizeof(entry) + stream->name_len;


### PR DESCRIPTION
## Summary

Two memfs named-stream (Alternate Data Stream) conformance fixes, each greening a previously-failing `smb2.streams` smbtorture subtest. memfs streams go from 9/14 to 11/14.

### `smb2.streams.dir`
An explicit default data fork named on a **directory** (`DNAME::$DATA`) must be rejected — `NOT_A_DIRECTORY` when the open also carries `FILE_DIRECTORY_FILE`, `FILE_IS_A_DIRECTORY` otherwise. Previously the stream parser collapsed `::$DATA` to "no stream", so the directory was opened as a plain file and the share path returned `SHARING_VIOLATION`.

- `chimera_smb_parse_stream_name` gains an `r_explicit_data_fork` out-param, set in the `stream_len==0 && colon2` branch.
- `chimera_smb_create_open_at_callback` rejects `explicit_data_fork && S_ISDIR` once the open reveals a directory target — this runs before the share-reservation step, so no reorder is needed.
- `memfs_list_streams` no longer reports a default `::$DATA` entry for a directory (a directory has no data fork); the spurious entry made the test client mishandle the `FILE_STREAM_INFO` reply.

### `smb2.streams.attributes1`
The attribute-bearing FILE info classes (`FileBasicInformation`, `FileNetworkOpenInformation`, `FileAttributeTagInformation`, `FileCompressionInformation`, `FileAllInformation`) now require the handle to hold `FILE_READ_ATTRIBUTES` (MS-FSA 2.1.5.11) — a handle opened with only `FILE_READ_DATA` gets `STATUS_ACCESS_DENIED`. Classes carrying no file attributes (standard sizes, internal id, EA size, position, mode, alignment, access, name) are intentionally not gated.

## Verification
- `smb2.streams.dir` and `smb2.streams.attributes1` confirmed green 3× on memfs (Debug + Release).
- No regressions: the existing enabled `smb2.streams.*`, `smb2.getinfo.*`, and `smb2.create.*` suites remain green.
- `make build_release`, scan-build (`build_clang`), `make syntax`, and the copyright-year check all pass.

## Not included (each needs a distinct, larger change — follow-ups)
- `attributes2` — base/stream metadata coherence in the per-fh VFS attr cache.
- `names3` — case-insensitive *path* lookup across memfs (not just stream names).
- `delete` — file-level delete-pending semantics shared across the base file and its streams.