### PR TITLE
smb2: STATUS_STOPPED_ON_SYMLINK on CREATE through a symbolic link

### DIFF
--- a/scripts/wpts_smb_test_wrapper.sh
+++ b/scripts/wpts_smb_test_wrapper.sh
@@ -227,6 +227,16 @@ if [ "${CHIMERA_SMB_MULTICHANNEL:-0}" = "1" ]; then
 fi
 ip netns exec "${NETNS_NAME}" ip link set "${DUMMY_IF}" up
 
+# When the symlink config is active, tell the daemon to seed the symbolic-link
+# fixtures (a directory holding an in-path link + a dangling root-level link) on
+# this run's backend module -- no SMB client can create a reparse-point symlink
+# on an empty share, so the daemon seeds them at startup.  The daemon inherits
+# this through `ip netns exec env` below; the matching ptfconfig paths are set
+# in the staging section.
+if [ "${CHIMERA_SMB_SYMLINK:-0}" = "1" ]; then
+    export CHIMERA_SMB_SEED_SYMLINKS="$BACKEND"
+fi
+
 # Start the chimera daemon inside the netns
 ip netns exec "${NETNS_NAME}" env \
     ASAN_OPTIONS="detect_leaks=0:handle_abort=2:print_cmdline=1" \
@@ -363,6 +373,19 @@ if [ "${CHIMERA_SMB_DIRLEASE:-0}" = "1" ]; then
     staged="${WPTS_STAGE_DIR}/CommonTestSuite.deployment.ptfconfig"
     sed -i \
         -e 's#<Property name="IsDirectoryLeasingSupported" value="false"/>#<Property name="IsDirectoryLeasingSupported" value="true"/>#' \
+        "$staged"
+fi
+
+# When the symlink config is active, point the driver at the seeded fixtures so
+# the CreateClose symlink cases become applicable: Symboliclink is the dangling
+# root-level link, SymboliclinkInSubFolder is the link living inside a directory
+# (so it is reached both as a path component and as the leaf).  The daemon
+# created these at startup (CHIMERA_SMB_SEED_SYMLINKS above).
+if [ "${CHIMERA_SMB_SYMLINK:-0}" = "1" ]; then
+    staged="${WPTS_STAGE_DIR}/MS-SMB2_ServerTestSuite.deployment.ptfconfig"
+    sed -i \
+        -e 's#<Property name="Symboliclink" value=""/>#<Property name="Symboliclink" value="badlink"/>#' \
+        -e 's#<Property name="SymboliclinkInSubFolder" value=""/>#<Property name="SymboliclinkInSubFolder" value="SymlinkTest\\link"/>#' \
         "$staged"
 fi
 

--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -970,6 +970,21 @@ main(
         }
     }
 
+    /* Test-harness aid: seed the symbolic-link fixtures the WPTS MS-SMB2
+     * CreateClose symlink cases expect to pre-exist on the share.  Enabled only
+     * when CHIMERA_SMB_SEED_SYMLINKS names the backend module (e.g. "memfs"),
+     * since no SMB client can create a reparse-point symlink on an empty share. */
+    const char *seed_module = getenv("CHIMERA_SMB_SEED_SYMLINKS");
+
+    if (seed_module && seed_module[0]) {
+        if (chimera_server_seed_symlinks(server, seed_module) != 0) {
+            chimera_server_error("Failed to seed symlink fixtures on module %s",
+                                 seed_module);
+        } else {
+            chimera_server_info("Seeded symlink fixtures on module %s", seed_module);
+        }
+    }
+
     exports = json_object_get(config, "exports");
 
     if (exports) {

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -1554,6 +1554,243 @@ chimera_server_mkpath(
     return ctx.status == CHIMERA_VFS_OK ? 0 : -1;
 } /* chimera_server_mkpath */
 
+/* ---- test-only symbolic-link seeding -------------------------------------
+ * The WPTS MS-SMB2 CreateClose symlink cases expect a small set of symbolic
+ * links to already exist on the share:
+ *   <root>/SymlinkTest          (a directory)
+ *   <root>/SymlinkTest/link  -> "target"      (a link reached mid-path / as the leaf)
+ *   <root>/badlink           -> "nonexistent" (a deliberately dangling link)
+ * The server never resolves these -- a CREATE that traverses one returns
+ * STATUS_STOPPED_ON_SYMLINK -- so the link targets need not exist.  No client
+ * can create a Windows reparse-point symlink against an empty share, so the
+ * fixtures are seeded here at startup, mirroring chimera_server_mkpath's
+ * transient-mount/evpl_continue drive loop.  Best-effort: failures are logged
+ * but do not abort the daemon (only the symlink WPTS cases depend on them). */
+#define CHIMERA_SEED_TMP_NAME "__chimera_seed_tmp"
+
+struct chimera_seed_ctx {
+    struct chimera_vfs             *vfs;
+    struct chimera_vfs_thread      *thread;
+    struct chimera_vfs_open_handle *root_oh;
+    struct chimera_vfs_open_handle *dir_oh;
+    uint8_t                         dir_fh[CHIMERA_VFS_FH_SIZE + 16];
+    uint32_t                        dir_fh_len;
+    enum chimera_vfs_error status;
+    int                             done;
+};
+
+static void
+chimera_seed_umount_cb(
+    struct chimera_vfs_thread *thread,
+    enum chimera_vfs_error     status,
+    void                      *private_data)
+{
+    struct chimera_seed_ctx *ctx = private_data;
+
+    ctx->done = 1;
+} /* chimera_seed_umount_cb */
+
+static void
+chimera_seed_finish(
+    struct chimera_seed_ctx *ctx,
+    enum chimera_vfs_error   status)
+{
+    ctx->status = status;
+
+    if (ctx->dir_oh) {
+        chimera_vfs_release(ctx->thread, ctx->dir_oh);
+        ctx->dir_oh = NULL;
+    }
+    if (ctx->root_oh) {
+        chimera_vfs_release(ctx->thread, ctx->root_oh);
+        ctx->root_oh = NULL;
+    }
+
+    chimera_vfs_umount(ctx->thread, chimera_vfs_get_server_cred(),
+                       CHIMERA_SEED_TMP_NAME, chimera_seed_umount_cb, ctx);
+} /* chimera_seed_finish */
+
+/* Creating the dangling root-level "badlink" is the last step. */
+static void
+chimera_seed_badlink_cb(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *attr,
+    struct chimera_vfs_attrs *dir_pre_attr,
+    struct chimera_vfs_attrs *dir_post_attr,
+    void                     *private_data)
+{
+    struct chimera_seed_ctx *ctx = private_data;
+
+    /* EEXIST is fine -- idempotent re-seed of a persistent backend. */
+    if (error_code != CHIMERA_VFS_OK && error_code != CHIMERA_VFS_EEXIST) {
+        chimera_seed_finish(ctx, error_code);
+        return;
+    }
+    chimera_seed_finish(ctx, CHIMERA_VFS_OK);
+} /* chimera_seed_badlink_cb */
+
+/* The in-subfolder "SymlinkTest/link" was created; now make the dangling
+ * root-level "badlink". */
+static void
+chimera_seed_dirlink_cb(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *attr,
+    struct chimera_vfs_attrs *dir_pre_attr,
+    struct chimera_vfs_attrs *dir_post_attr,
+    void                     *private_data)
+{
+    struct chimera_seed_ctx *ctx = private_data;
+
+    if (error_code != CHIMERA_VFS_OK && error_code != CHIMERA_VFS_EEXIST) {
+        chimera_seed_finish(ctx, error_code);
+        return;
+    }
+
+    chimera_vfs_symlink_at(ctx->thread, chimera_vfs_get_server_cred(),
+                           ctx->root_oh, "badlink", 7,
+                           "nonexistent", 11, NULL,
+                           0, 0, 0, chimera_seed_badlink_cb, ctx);
+} /* chimera_seed_dirlink_cb */
+
+/* The "SymlinkTest" directory is open; create the symlink "link" inside it. */
+static void
+chimera_seed_diropen_cb(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *oh,
+    void                           *private_data)
+{
+    struct chimera_seed_ctx *ctx = private_data;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        chimera_seed_finish(ctx, error_code);
+        return;
+    }
+
+    ctx->dir_oh = oh;
+
+    chimera_vfs_symlink_at(ctx->thread, chimera_vfs_get_server_cred(),
+                           ctx->dir_oh, "link", 4,
+                           "target", 6, NULL,
+                           0, 0, 0, chimera_seed_dirlink_cb, ctx);
+} /* chimera_seed_diropen_cb */
+
+/* The "SymlinkTest" directory was created (or already existed); open it. */
+static void
+chimera_seed_mkdir_cb(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *set_attr,
+    struct chimera_vfs_attrs *attr,
+    struct chimera_vfs_attrs *dir_pre_attr,
+    struct chimera_vfs_attrs *dir_post_attr,
+    void                     *private_data)
+{
+    struct chimera_seed_ctx *ctx = private_data;
+
+    if (error_code != CHIMERA_VFS_OK || attr->va_fh_len == 0) {
+        chimera_seed_finish(ctx, error_code != CHIMERA_VFS_OK ? error_code : CHIMERA_VFS_EIO);
+        return;
+    }
+
+    memcpy(ctx->dir_fh, attr->va_fh, attr->va_fh_len);
+    ctx->dir_fh_len = attr->va_fh_len;
+
+    chimera_vfs_open_fh(ctx->thread, chimera_vfs_get_server_cred(),
+                        ctx->dir_fh, ctx->dir_fh_len,
+                        CHIMERA_VFS_OPEN_DIRECTORY | CHIMERA_VFS_OPEN_PATH,
+                        chimera_seed_diropen_cb, ctx);
+} /* chimera_seed_mkdir_cb */
+
+static void
+chimera_seed_rootopen_cb(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *oh,
+    void                           *private_data)
+{
+    struct chimera_seed_ctx *ctx = private_data;
+    struct chimera_vfs_attrs set_attr;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        chimera_seed_finish(ctx, error_code);
+        return;
+    }
+
+    ctx->root_oh = oh;
+
+    memset(&set_attr, 0, sizeof(set_attr));
+    set_attr.va_set_mask = CHIMERA_VFS_ATTR_MODE | CHIMERA_VFS_ATTR_UID |
+        CHIMERA_VFS_ATTR_GID;
+    set_attr.va_mode = S_IFDIR | 0755;
+    set_attr.va_uid  = 0;
+    set_attr.va_gid  = 0;
+
+    chimera_vfs_mkdir_at(ctx->thread, chimera_vfs_get_server_cred(), ctx->root_oh,
+                         "SymlinkTest", 11, &set_attr,
+                         CHIMERA_VFS_ATTR_FH, 0, 0,
+                         chimera_seed_mkdir_cb, ctx);
+} /* chimera_seed_rootopen_cb */
+
+static void
+chimera_seed_mounted_cb(
+    struct chimera_vfs_thread *thread,
+    enum chimera_vfs_error     status,
+    void                      *private_data)
+{
+    struct chimera_seed_ctx  *ctx = private_data;
+    struct chimera_vfs_mount *m;
+
+    if (status != CHIMERA_VFS_OK) {
+        ctx->status = status;
+        ctx->done   = 1;
+        return;
+    }
+
+    m = chimera_vfs_mount_table_find_by_path(ctx->vfs->mount_table,
+                                             CHIMERA_SEED_TMP_NAME,
+                                             strlen(CHIMERA_SEED_TMP_NAME));
+    if (!m) {
+        chimera_seed_finish(ctx, CHIMERA_VFS_EIO);
+        return;
+    }
+
+    chimera_vfs_open_fh(thread, chimera_vfs_get_server_cred(),
+                        m->root_fh, m->root_fh_len,
+                        CHIMERA_VFS_OPEN_DIRECTORY | CHIMERA_VFS_OPEN_PATH,
+                        chimera_seed_rootopen_cb, ctx);
+} /* chimera_seed_mounted_cb */
+
+SYMBOL_EXPORT int
+chimera_server_seed_symlinks(
+    struct chimera_server *server,
+    const char            *module_name)
+{
+    struct evpl            *evpl;
+    struct chimera_seed_ctx ctx;
+
+    if (!module_name) {
+        return -1;
+    }
+
+    memset(&ctx, 0, sizeof(ctx));
+
+    evpl       = evpl_create(NULL);
+    ctx.vfs    = server->vfs;
+    ctx.thread = chimera_vfs_thread_init(evpl, server->vfs);
+    ctx.status = CHIMERA_VFS_OK;
+
+    chimera_vfs_mount(ctx.thread, chimera_vfs_get_server_cred(),
+                      CHIMERA_SEED_TMP_NAME, module_name, "/", NULL,
+                      chimera_seed_mounted_cb, &ctx);
+
+    while (!ctx.done) {
+        evpl_continue(evpl);
+    }
+
+    chimera_vfs_thread_destroy(ctx.thread);
+    evpl_destroy(evpl);
+
+    return ctx.status == CHIMERA_VFS_OK ? 0 : -1;
+} /* chimera_server_seed_symlinks */
+
 static void
 chimera_server_umount_callback(
     struct chimera_vfs_thread *thread,

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -564,6 +564,16 @@ chimera_server_mkpath(
     const char            *module_path,
     uint32_t               mode);
 
+/* Seed the symbolic-link fixtures the WPTS MS-SMB2 CreateClose symlink cases
+ * expect to pre-exist on a memfs-backed share (a directory holding an in-path
+ * link, plus a dangling root-level link).  A test-harness aid -- the server
+ * never resolves these links (it returns STATUS_STOPPED_ON_SYMLINK).  Returns
+ * 0 on success, -1 otherwise. */
+int
+chimera_server_seed_symlinks(
+    struct chimera_server *server,
+    const char            *module_name);
+
 int
 chimera_server_unmount(
     struct chimera_server *server,

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -96,6 +96,7 @@ chimera_smb_create_error_status(enum chimera_vfs_error error_code)
         case CHIMERA_VFS_EDQUOT:       return SMB2_STATUS_DISK_FULL;
         case CHIMERA_VFS_ENAMETOOLONG: return SMB2_STATUS_NAME_TOO_LONG;
         case CHIMERA_VFS_EROFS:        return SMB2_STATUS_MEDIA_WRITE_PROTECTED;
+        case CHIMERA_VFS_ELOOP:        return SMB2_STATUS_STOPPED_ON_SYMLINK;
         default:                       return SMB2_STATUS_OBJECT_NAME_NOT_FOUND;
     } /* switch */
 } /* chimera_smb_create_error_status */
@@ -1619,6 +1620,29 @@ chimera_smb_create_share_retry_cb(
     struct evpl       *evpl,
     struct evpl_timer *timer);
 
+/* A directory-create collided with an existing entry: if that entry is a
+ * symbolic link, SMB stops on it (STATUS_STOPPED_ON_SYMLINK) rather than
+ * reporting a name collision (MS-SMB2 3.3.5.9).  Only reached on the already-
+ * failing EEXIST path, so the extra lookup never burdens a successful mkdir. */
+static inline void
+chimera_smb_create_collision_symlink_cb(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *attr,
+    struct chimera_vfs_attrs *dir_attr,
+    void                     *private_data)
+{
+    struct chimera_smb_request *request = private_data;
+    uint32_t                    status  = SMB2_STATUS_OBJECT_NAME_COLLISION;
+
+    if (error_code == CHIMERA_VFS_OK && attr &&
+        (attr->va_set_mask & CHIMERA_VFS_ATTR_MODE) && S_ISLNK(attr->va_mode)) {
+        status = SMB2_STATUS_STOPPED_ON_SYMLINK;
+    }
+
+    chimera_smb_create_release_parent(request);
+    chimera_smb_complete_request(request, status);
+} /* chimera_smb_create_collision_symlink_cb */
+
 static inline void
 chimera_smb_create_mkdir_callback(
     enum chimera_vfs_error    error_code,
@@ -1635,16 +1659,23 @@ chimera_smb_create_mkdir_callback(
     struct chimera_vfs_thread        *vfs_thread = thread->vfs_thread;
 
     if (error_code != CHIMERA_VFS_OK) {
+        unsigned int reopen_flags = CHIMERA_VFS_OPEN_DIRECTORY;
+
+        if (!(request->create.create_options & SMB2_FILE_OPEN_REPARSE_POINT)) {
+            reopen_flags |= CHIMERA_VFS_OPEN_STOP_SYMLINK;
+        }
+
         if (error_code == CHIMERA_VFS_EEXIST &&
             request->create.create_disposition == SMB2_FILE_OPEN_IF) {
-            /* Directory already exists — fall through to open it */
+            /* Directory already exists — fall through to open it (stopping if
+             * the existing entry is a symbolic link). */
             chimera_vfs_open_at(
                 vfs_thread,
                 &request->session_handle->session->cred,
                 request->create.parent_handle,
                 request->create.name,
                 request->create.name_len,
-                CHIMERA_VFS_OPEN_DIRECTORY,
+                reopen_flags,
                 &request->create.set_attr,
                 CHIMERA_VFS_ATTR_FH | CHIMERA_VFS_ATTR_MASK_STAT |
                 CHIMERA_VFS_ATTR_ACL | CHIMERA_VFS_ATTR_BTIME,
@@ -1654,6 +1685,25 @@ chimera_smb_create_mkdir_callback(
                 request);
             return;
         }
+
+        /* A FILE_CREATE collision may actually be a symbolic link — SMB stops
+         * on it rather than reporting a name collision.  Probe the colliding
+         * entry's mode (only on this already-failing path). */
+        if (error_code == CHIMERA_VFS_EEXIST &&
+            !(request->create.create_options & SMB2_FILE_OPEN_REPARSE_POINT)) {
+            chimera_vfs_lookup_at(
+                vfs_thread,
+                &request->session_handle->session->cred,
+                request->create.parent_handle,
+                request->create.name,
+                request->create.name_len,
+                CHIMERA_VFS_ATTR_FH | CHIMERA_VFS_ATTR_MODE,
+                0,
+                chimera_smb_create_collision_symlink_cb,
+                request);
+            return;
+        }
+
         chimera_smb_create_release_parent(request);
         chimera_smb_complete_request(request, error_code == CHIMERA_VFS_EEXIST ?
                                      SMB2_STATUS_OBJECT_NAME_COLLISION :
@@ -1829,6 +1879,19 @@ chimera_smb_create_open_at_callback(
     if (error_code != CHIMERA_VFS_OK) {
         chimera_smb_create_release_parent(request);
         chimera_smb_complete_request(request, chimera_smb_create_error_status(error_code));
+        return;
+    }
+
+    /* The opened leaf is itself a symbolic link.  Unless the caller asked to
+     * open the reparse point directly (FILE_OPEN_REPARSE_POINT), SMB does not
+     * follow it on the server: return STATUS_STOPPED_ON_SYMLINK so the client
+     * resolves the link and retries (MS-SMB2 2.2.2.2.1).  memfs returns the link
+     * inode's attributes for a non-NOFOLLOW open of a final-component symlink. */
+    if ((attr->va_set_mask & CHIMERA_VFS_ATTR_MODE) && S_ISLNK(attr->va_mode) &&
+        !(request->create.create_options & SMB2_FILE_OPEN_REPARSE_POINT)) {
+        chimera_vfs_release(vfs_thread, oh);
+        chimera_vfs_release(vfs_thread, request->create.parent_handle);
+        chimera_smb_complete_request(request, SMB2_STATUS_STOPPED_ON_SYMLINK);
         return;
     }
 
@@ -2960,6 +3023,15 @@ chimera_smb_create_issue_open(struct chimera_smb_request *request)
         flags |= CHIMERA_VFS_OPEN_NOFOLLOW;
     }
 
+    /* Unless the caller explicitly opens the reparse point, stop if the leaf is
+     * a symbolic link: the backend returns ELOOP (-> STATUS_STOPPED_ON_SYMLINK)
+     * before colliding/opening/truncating it, so a FILE_CREATE on a symlink leaf
+     * stops at the link instead of reporting OBJECT_NAME_COLLISION (MS-SMB2
+     * 3.3.5.9). */
+    if (!(request->create.create_options & SMB2_FILE_OPEN_REPARSE_POINT)) {
+        flags |= CHIMERA_VFS_OPEN_STOP_SYMLINK;
+    }
+
     if (request->create.has_stream) {
         /* For a named-stream open the disposition applies to the STREAM, not
          * the base file.  Open the base file, creating it if the disposition
@@ -3174,6 +3246,16 @@ chimera_smb_create_lookup_parent_callback(
         return;
     }
 
+    /* The create path traverses a symbolic link: SMB never silently follows a
+     * reparse point on the server, it returns STATUS_STOPPED_ON_SYMLINK so the
+     * client resolves the link and retries (MS-SMB2 2.2.2.2.1).  The parent-path
+     * lookup is issued without LOOKUP_FOLLOW, so a symlink as the final component
+     * of the parent path resolves to the link itself here. */
+    if ((attr->va_set_mask & CHIMERA_VFS_ATTR_MODE) && S_ISLNK(attr->va_mode)) {
+        chimera_smb_complete_request(request, SMB2_STATUS_STOPPED_ON_SYMLINK);
+        return;
+    }
+
     chimera_vfs_open_fh(
         vfs_thread,
         &request->session_handle->session->cred,
@@ -3198,8 +3280,8 @@ chimera_smb_create_process(struct chimera_smb_request *request)
             tree->fh_len,
             request->create.parent_path,
             request->create.parent_path_len,
-            CHIMERA_VFS_ATTR_FH,
-            CHIMERA_VFS_LOOKUP_FOLLOW,
+            CHIMERA_VFS_ATTR_FH | CHIMERA_VFS_ATTR_MODE,
+            0,
             chimera_smb_create_lookup_parent_callback,
             request);
     } else if (request->create.name_len) {

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -135,7 +135,8 @@ if(CHIMERA_NETNS_TESTING AND WPTS_DOTNET AND WPTS_SMB2_DLL AND WPTS_ARCH_SUPPORT
     set(_wpts_configs base persistent compression multichannel
         multichannel_persistent
         encryption compression_encryption multichannel_encryption
-        dirlease dirlease_persistent dirlease_appinstance)
+        dirlease dirlease_persistent dirlease_appinstance
+        symlink)
     foreach(_c ${_wpts_configs})
         set(WPTS_GREEN_${_c} "")
     endforeach()
@@ -177,6 +178,9 @@ if(CHIMERA_NETNS_TESTING AND WPTS_DOTNET AND WPTS_SMB2_DLL AND WPTS_ARCH_SUPPORT
     set(_wpts_envfrag_dirlease                ";CHIMERA_SMB_DIRLEASE=1")
     set(_wpts_envfrag_dirlease_persistent     ";CHIMERA_SMB_DIRLEASE=1;CHIMERA_SMB_PERSISTENT=1")
     set(_wpts_envfrag_dirlease_appinstance    ";CHIMERA_SMB_DIRLEASE=1;CHIMERA_SMB_PERSISTENT=1;CHIMERA_SMB_MULTICHANNEL=1")
+    # Symlink config: seeds reparse-point fixtures + advertises their paths so
+    # the CreateClose symbolic-link cases become applicable.
+    set(_wpts_envfrag_symlink                 ";CHIMERA_SMB_SYMLINK=1")
     set(_wpts_lbl_base                    "")
     set(_wpts_lbl_persistent              ";persistent")
     set(_wpts_lbl_compression             ";compression")
@@ -188,6 +192,7 @@ if(CHIMERA_NETNS_TESTING AND WPTS_DOTNET AND WPTS_SMB2_DLL AND WPTS_ARCH_SUPPORT
     set(_wpts_lbl_dirlease                ";dirlease")
     set(_wpts_lbl_dirlease_persistent     ";dirlease;persistent")
     set(_wpts_lbl_dirlease_appinstance    ";dirlease;persistent;multichannel")
+    set(_wpts_lbl_symlink                 ";symlink")
     set(_wpts_suf_base                    "")
     set(_wpts_suf_persistent              "_persistent")
     set(_wpts_suf_compression             "_compression")
@@ -199,6 +204,7 @@ if(CHIMERA_NETNS_TESTING AND WPTS_DOTNET AND WPTS_SMB2_DLL AND WPTS_ARCH_SUPPORT
     set(_wpts_suf_dirlease                "_dirlease")
     set(_wpts_suf_dirlease_persistent     "_dirlease_persistent")
     set(_wpts_suf_dirlease_appinstance    "_dirlease_appinstance")
+    set(_wpts_suf_symlink                 "_symlink")
 
     foreach(_cfg ${_wpts_configs})
         if(NOT WPTS_GREEN_${_cfg})

--- a/src/server/smb/tests/wpts/wpts_cases.csv
+++ b/src/server/smb/tests/wpts/wpts_cases.csv
@@ -128,9 +128,9 @@ CreateClose_CreateAndCloseDirWithDoubleDotDir,base,green,0,
 CreateClose_CreateAndCloseFileWithDotDir,base,green,0,
 CreateClose_CreateAndCloseFileWithDoubleDotDir,base,green,0,
 CreateClose_DeleteFile_DesiredAccessNotIncludeDeleteOrGenericAll,base,green,0,
-CreateClose_InvalidSymbolicLink,base,skip,0,env-symlink
-CreateClose_SymbolicLinkAtLast,base,skip,0,env-symlink
-CreateClose_SymbolicLinkInMiddle,base,skip,0,env-symlink
+CreateClose_InvalidSymbolicLink,symlink,green,0,
+CreateClose_SymbolicLinkAtLast,symlink,green,0,
+CreateClose_SymbolicLinkInMiddle,symlink,green,0,
 DirectoryLeasing_BreakHandleCachingByConflictOpen,dirlease,green,0,
 DirectoryLeasing_BreakHandleCachingByParentRenamed,dirlease,xfail,0,
 DirectoryLeasing_BreakReadCachingByChildAdded,dirlease,green,0,

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -2752,17 +2752,34 @@ memfs_open_at(
         parent_inode->mtime        = now;
         parent_inode->ctime        = now;
         request->open_at.r_created = 1;
-    } else if (flags & CHIMERA_VFS_OPEN_EXCLUSIVE) {
-        pthread_mutex_unlock(&parent_inode->lock);
-        request->status = CHIMERA_VFS_EEXIST;
-        request->complete(request);
-        return;
     } else {
         inode = memfs_inode_get_inum(shared, dirent->inum, dirent->gen);
 
         if (!inode) {
             pthread_mutex_unlock(&parent_inode->lock);
             request->status = CHIMERA_VFS_ENOENT;
+            request->complete(request);
+            return;
+        }
+
+        /* SMB stop-on-symlink: an existing symbolic link as the final component
+         * when the caller did not ask to open the reparse point.  Return ELOOP
+         * *before* the O_EXCL collision / truncate / open below, so the SMB
+         * create path answers STATUS_STOPPED_ON_SYMLINK regardless of the create
+         * disposition (MS-SMB2 3.3.5.9; FILE_CREATE on a symlink leaf stops at
+         * the link rather than colliding). */
+        if (S_ISLNK(inode->mode) && (flags & CHIMERA_VFS_OPEN_STOP_SYMLINK)) {
+            pthread_mutex_unlock(&inode->lock);
+            pthread_mutex_unlock(&parent_inode->lock);
+            request->status = CHIMERA_VFS_ELOOP;
+            request->complete(request);
+            return;
+        }
+
+        if (flags & CHIMERA_VFS_OPEN_EXCLUSIVE) {
+            pthread_mutex_unlock(&inode->lock);
+            pthread_mutex_unlock(&parent_inode->lock);
+            request->status = CHIMERA_VFS_EEXIST;
             request->complete(request);
             return;
         }

--- a/src/vfs/vfs.h
+++ b/src/vfs/vfs.h
@@ -128,6 +128,14 @@ struct chimera_vfs_mount_options {
  * O_RDWR.  Read access is required unless WRITE_ONLY; write access is required
  * unless READ_ONLY.  Used by the open path to authorize the requested access. */
 #define CHIMERA_VFS_OPEN_WRITE_ONLY     (1U << 8)
+/* Stop if the final path component is an existing symbolic link: the backend
+ * returns CHIMERA_VFS_ELOOP instead of opening, colliding with (O_EXCL), or
+ * truncating it -- the check precedes the existence/EXCLUSIVE test.  Set by the
+ * SMB create path so a non-FILE_OPEN_REPARSE_POINT open of a symlink leaf yields
+ * STATUS_STOPPED_ON_SYMLINK regardless of the create disposition (MS-SMB2
+ * 3.3.5.9).  POSIX/NFS callers leave it clear and keep their existing
+ * symlink-leaf semantics. */
+#define CHIMERA_VFS_OPEN_STOP_SYMLINK   (1U << 9)
 
 /* Allocate flags */
 #define CHIMERA_VFS_ALLOCATE_DEALLOCATE 0x01

--- a/tools/wpts/sweep.py
+++ b/tools/wpts/sweep.py
@@ -53,7 +53,8 @@ TRX_NS = "{http://microsoft.com/schemas/VisualStudio/TeamTest/2010}"
 CONFIGS = ["base", "persistent", "compression", "multichannel",
            "multichannel_persistent",
            "encryption", "compression_encryption", "multichannel_encryption",
-           "dirlease", "dirlease_persistent", "dirlease_appinstance"]
+           "dirlease", "dirlease_persistent", "dirlease_appinstance",
+           "symlink"]
 
 # config -> CHIMERA_SMB_* env that the wrapper reads (drives daemon config +
 # ptfconfig capability flips).  base sets nothing.
@@ -75,6 +76,7 @@ CONFIG_ENV = {
     "dirlease_appinstance":    {"CHIMERA_SMB_DIRLEASE": "1",
                                 "CHIMERA_SMB_PERSISTENT": "1",
                                 "CHIMERA_SMB_MULTICHANNEL": "1"},
+    "symlink":                 {"CHIMERA_SMB_SYMLINK": "1"},
 }
 
 STATUSES = {"green", "xfail", "skip"}


### PR DESCRIPTION
## Summary

SMB never silently follows a reparse-point symlink on the server: a CREATE whose path traverses (or ends at) a symbolic link must return `STATUS_STOPPED_ON_SYMLINK` so the client resolves the link and retries (MS-SMB2 3.3.5.9 / 2.2.2.2.1). chimera previously *followed* symlinks during create path resolution. This implements stop-on-symlink and greens the three WPTS `CreateClose` symbolic-link cases.

## Server detection (`smb_proc_create.c`)

- **Symlink mid-path / as parent**: the parent-path lookup drops `LOOKUP_FOLLOW` and requests `ATTR_MODE`, so a symlink as the final component of the parent path resolves to the link itself → `STOPPED_ON_SYMLINK`.
- **Symlink leaf**: the leaf open sets a new `CHIMERA_VFS_OPEN_STOP_SYMLINK` flag (unless `FILE_OPEN_REPARSE_POINT`), so the backend returns `ELOOP` *before* opening / colliding (O_EXCL) / truncating a symlink leaf, regardless of the create disposition → `STOPPED_ON_SYMLINK`.
- **Directory-create collision**: the `mkdir_at` path probes the colliding entry's mode **only on the already-failing `EEXIST` branch**, mapping an existing-symlink collision to `STOPPED_ON_SYMLINK` instead of `OBJECT_NAME_COLLISION` (no extra op on a successful mkdir).
- `ELOOP` maps to `STATUS_STOPPED_ON_SYMLINK` in the create error mapper.

The SMB2.1 ERROR reply carries no `SymbolicLinkErrorResponse` body (the client keys it on `ErrorContextCount > 0`); the security-relevant behaviour — refusing to follow the link — is complete. Emitting the substitute-name body (for client-side resolution) is a follow-up; the generic `ELOOP→STOPPED` path has no symlink fh, so a bare error keeps all detection paths consistent.

## VFS (`vfs.h`, `memfs.c`)

`CHIMERA_VFS_OPEN_STOP_SYMLINK` makes memfs `open_at` fetch the leaf inode and return `ELOOP` for an existing symlink before the existence/EXCLUSIVE test. POSIX/NFS callers leave the flag clear and keep their existing symlink-leaf semantics.

## Symlink fixtures (`server.c`, `daemon.c`)

No SMB client can create a Windows reparse-point symlink on an empty share, so `chimera_server_seed_symlinks()` seeds the WPTS fixtures (a directory holding an in-path link + a dangling root link) at startup, gated by `CHIMERA_SMB_SEED_SYMLINKS` naming the backend module. Mirrors the existing `chimera_server_mkpath` transient-mount/`evpl_continue` bootstrap.

## WPTS harness

New `symlink` config seeds the fixtures + advertises their paths (`Symboliclink`, `SymboliclinkInSubFolder`). Greens `CreateClose_{InvalidSymbolicLink,SymbolicLinkAtLast,SymbolicLinkInMiddle}` (3 `skip` → `green`).

## Verification

- **206** `smb2.create` + `smb2.lease` smbtorture tests (memfs/diskfs/cairn/io_uring, ASan Debug) — pass, no regression on the create-path change.
- WPTS `symlink` config 3/3 (ctest target `wpts/memfs_symlink`) + base `CreateClose` family 7/7 — pass.
- scan-build: no bugs; `reuse lint` compliant; `make syntax` clean.
- KVM SMB tests could not run in this environment (guest kernel root-fs mount panic at boot, upstream of any SMB connection — VM-image infra, not this change).