### PR TITLE
pjd: port granular NFSv4-ACL permission tests + ACL client API

### DIFF
--- a/src/client/client_getacl.h
+++ b/src/client/client_getacl.h
@@ -1,0 +1,149 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#pragma once
+
+#include <string.h>
+
+#include "client_internal.h"
+#include "vfs/vfs_acl.h"
+
+/*
+ * GETACL dispatch: resolve a path, open an O_PATH handle, getattr the canonical
+ * NFSv4/Windows ACL (CHIMERA_VFS_ATTR_ACL), and copy the returned ACL into the
+ * caller's buffer.  The returned va_acl is valid only for the duration of the
+ * getattr completion (same contract as va_fh), so it is copied out here before
+ * the request is released.
+ */
+
+static void chimera_getacl_open_complete(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *oh,
+    void                           *private_data);
+
+static void
+chimera_getacl_getattr_complete(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *attr,
+    void                     *private_data)
+{
+    struct chimera_client_request  *request        = private_data;
+    struct chimera_client_thread   *thread         = request->thread;
+    struct chimera_vfs_open_handle *handle         = request->getacl.handle;
+    chimera_setattr_callback_t      callback       = request->getacl.callback;
+    void                           *callback_arg   = request->getacl.private_data;
+    int                             heap_allocated = request->heap_allocated;
+    enum chimera_vfs_error          status         = error_code;
+
+    if (error_code == CHIMERA_VFS_OK) {
+        if (!(attr->va_set_mask & CHIMERA_VFS_ATTR_ACL) || !attr->va_acl) {
+            /* Backend returned no ACL (mode-only object / backend without ACL
+             * storage): report an empty ACL rather than failing. */
+            request->getacl.r_acl_aces = 0;
+            if (request->getacl.acl_bufsize >= chimera_acl_size(0)) {
+                request->getacl.acl_buf->num_aces   = 0;
+                request->getacl.acl_buf->ctrl_flags = 0;
+            } else {
+                status = CHIMERA_VFS_ERANGE;
+            }
+        } else {
+            const struct chimera_acl *acl  = attr->va_acl;
+            size_t                    need = chimera_acl_size(acl->num_aces);
+
+            request->getacl.r_acl_aces = acl->num_aces;
+
+            if (request->getacl.acl_bufsize >= need) {
+                memcpy(request->getacl.acl_buf, acl, need);
+            } else {
+                status = CHIMERA_VFS_ERANGE;
+            }
+        }
+    }
+
+    if (heap_allocated) {
+        chimera_client_request_free(thread, request);
+    }
+
+    chimera_vfs_release(thread->vfs_thread, handle);
+
+    callback(thread, status, callback_arg);
+} /* chimera_getacl_getattr_complete */
+
+static void
+chimera_getacl_open_complete(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *oh,
+    void                           *private_data)
+{
+    struct chimera_client_request *request = private_data;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        struct chimera_client_thread *thread       = request->thread;
+        chimera_setattr_callback_t    callback     = request->getacl.callback;
+        void                         *callback_arg = request->getacl.private_data;
+
+        chimera_client_request_free(thread, request);
+        callback(thread, error_code, callback_arg);
+        return;
+    }
+
+    request->getacl.handle = oh;
+
+    chimera_vfs_getattr(
+        request->thread->vfs_thread,
+        chimera_client_req_cred(request),
+        oh,
+        CHIMERA_VFS_ATTR_ACL,
+        chimera_getacl_getattr_complete,
+        request);
+} /* chimera_getacl_open_complete */
+
+static void
+chimera_getacl_lookup_complete(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *attr,
+    void                     *private_data)
+{
+    struct chimera_client_request *request = private_data;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        struct chimera_client_thread *thread       = request->thread;
+        chimera_setattr_callback_t    callback     = request->getacl.callback;
+        void                         *callback_arg = request->getacl.private_data;
+
+        chimera_client_request_free(thread, request);
+        callback(thread, error_code, callback_arg);
+        return;
+    }
+
+    memcpy(request->fh, attr->va_fh, attr->va_fh_len);
+    request->fh_len = attr->va_fh_len;
+
+    chimera_vfs_open_fh(
+        request->thread->vfs_thread,
+        chimera_client_req_cred(request),
+        request->fh,
+        request->fh_len,
+        CHIMERA_VFS_OPEN_PATH | CHIMERA_VFS_OPEN_INFERRED,
+        chimera_getacl_open_complete,
+        request);
+} /* chimera_getacl_lookup_complete */
+
+static inline void
+chimera_dispatch_getacl(
+    struct chimera_client_thread  *thread,
+    struct chimera_client_request *request)
+{
+    chimera_vfs_lookup(
+        thread->vfs_thread,
+        chimera_client_req_cred(request),
+        thread->client->root_fh,
+        thread->client->root_fh_len,
+        request->getacl.path,
+        request->getacl.path_len,
+        CHIMERA_VFS_ATTR_FH,
+        CHIMERA_VFS_LOOKUP_FOLLOW,
+        chimera_getacl_lookup_complete,
+        request);
+} /* chimera_dispatch_getacl */

--- a/src/client/client_internal.h
+++ b/src/client/client_internal.h
@@ -378,6 +378,22 @@ struct chimera_client_request {
             chimera_clone_range_callback_t  callback;
             void                           *private_data;
         } clone_range;
+
+        /* GETACL: resolve `path`, open an O_PATH handle, getattr CHIMERA_VFS_
+         * ATTR_ACL, and copy the returned ACL into the caller-owned `acl_buf`
+         * (capacity `acl_bufsize` bytes).  r_acl_aces is set to the object's ACE
+         * count even when the buffer is too small (so the caller can size a
+         * retry); CHIMERA_VFS_ERANGE is returned in that case. */
+        struct {
+            struct chimera_vfs_open_handle *handle;
+            chimera_setattr_callback_t      callback;
+            void                           *private_data;
+            int                             path_len;
+            struct chimera_acl             *acl_buf;
+            size_t                          acl_bufsize;
+            uint16_t                        r_acl_aces;
+            char                            path[CHIMERA_VFS_PATH_MAX];
+        } getacl;
     };
 } __attribute__((aligned(64)));
 

--- a/src/posix/CMakeLists.txt
+++ b/src/posix/CMakeLists.txt
@@ -58,6 +58,8 @@ add_library(chimera_posix SHARED
             posix_fchmodat.c
             posix_chown.c
             posix_lchown.c
+            posix_setacl.c
+            posix_getacl.c
             posix_fchown.c
             posix_fchownat.c
             posix_utimensat.c

--- a/src/posix/posix.h
+++ b/src/posix/posix.h
@@ -20,6 +20,7 @@ struct chimera_posix_client;
 struct chimera_client_config;
 struct prometheus_metrics;
 struct evpl_iovec;
+struct chimera_acl;
 
 struct chimera_posix_client *
 chimera_posix_init(
@@ -557,6 +558,24 @@ int
 chimera_posix_futimens(
     int                   fd,
     const struct timespec times[2]);
+
+// Canonical NFSv4/Windows ACL get/set (Chimera-specific extension; NFSv4 ACLs
+// are not standard POSIX).  setacl applies the ACL via a VFS setattr
+// (CHIMERA_VFS_ATTR_ACL); getacl reads it back into a caller-owned buffer.
+// Both run under the calling thread's effective credential
+// (chimera_posix_set_cred), so they are authorized as the chosen user.
+int
+chimera_posix_setacl(
+    const char               *path,
+    const struct chimera_acl *acl);
+
+// Read the ACL of `path` into `buf` (capacity `bufsize` bytes).  Returns the
+// ACE count on success, or -1 with errno set (ERANGE if `buf` is too small).
+int
+chimera_posix_getacl(
+    const char         *path,
+    struct chimera_acl *buf,
+    size_t              bufsize);
 
 // Configurable pathname limits (pathconf(3)/fpathconf(3))
 long

--- a/src/posix/posix_getacl.c
+++ b/src/posix/posix_getacl.c
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include <errno.h>
+#include <string.h>
+
+#include "posix_internal.h"
+#include "../client/client_getacl.h"
+#include "vfs/vfs_acl.h"
+
+/*
+ * Read the canonical NFSv4/Windows ACL of `path` into the caller-owned `buf`
+ * (capacity `bufsize` bytes).  Returns the number of ACEs in the object's ACL
+ * on success; -1 with errno set on failure (ERANGE if `buf` is too small to
+ * hold the whole ACL -- the caller can size a retry with chimera_acl_size()).
+ * Chimera-specific extension (see posix_setacl.c).
+ */
+
+static void
+chimera_posix_getacl_callback(
+    struct chimera_client_thread *thread,
+    enum chimera_vfs_error        status,
+    void                         *private_data)
+{
+    struct chimera_posix_completion *comp = private_data;
+
+    chimera_posix_complete(comp, status);
+} /* chimera_posix_getacl_callback */
+
+static void
+chimera_posix_getacl_exec(
+    struct chimera_client_thread  *thread,
+    struct chimera_client_request *request)
+{
+    chimera_dispatch_getacl(thread, request);
+} /* chimera_posix_getacl_exec */
+
+SYMBOL_EXPORT int
+chimera_posix_getacl(
+    const char         *path,
+    struct chimera_acl *buf,
+    size_t              bufsize)
+{
+    struct chimera_posix_client    *posix  = chimera_posix_get_global();
+    struct chimera_posix_worker    *worker = chimera_posix_choose_worker(posix);
+    struct chimera_client_request   req;
+    struct chimera_posix_completion comp;
+    int                             path_len;
+
+    if (!buf) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    path_len = chimera_posix_check_path(path);
+    if (path_len < 0) {
+        return -1;
+    }
+
+    chimera_posix_completion_init(&comp, &req);
+
+    req.opcode              = CHIMERA_CLIENT_OP_STAT;
+    req.getacl.callback     = chimera_posix_getacl_callback;
+    req.getacl.private_data = &comp;
+    req.getacl.path_len     = path_len;
+    req.getacl.acl_buf      = buf;
+    req.getacl.acl_bufsize  = bufsize;
+    req.getacl.r_acl_aces   = 0;
+
+    memcpy(req.getacl.path, path, path_len);
+
+    chimera_posix_worker_enqueue(worker, &req, chimera_posix_getacl_exec);
+
+    int err = chimera_posix_wait(&comp);
+
+    int naces = req.getacl.r_acl_aces;
+
+    chimera_posix_completion_destroy(&comp);
+
+    if (err) {
+        errno = err;
+        return -1;
+    }
+
+    return naces;
+} /* chimera_posix_getacl */

--- a/src/posix/posix_setacl.c
+++ b/src/posix/posix_setacl.c
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include <errno.h>
+#include <string.h>
+
+#include "posix_internal.h"
+#include "../client/client_setattr.h"
+#include "vfs/vfs_acl.h"
+
+/*
+ * Set the canonical NFSv4/Windows ACL on `path`.  This is a Chimera-specific
+ * extension: NFSv4 ACLs are not part of standard POSIX, but they are a
+ * first-class Chimera VFS attribute (CHIMERA_VFS_ATTR_ACL).  The ACL set is
+ * authorized by the VFS setattr gate (WRITE_ACL, or file ownership), running
+ * under the calling thread's effective credential (chimera_posix_set_cred).
+ */
+
+static void
+chimera_posix_setacl_callback(
+    struct chimera_client_thread *thread,
+    enum chimera_vfs_error        status,
+    void                         *private_data)
+{
+    struct chimera_posix_completion *comp = private_data;
+
+    chimera_posix_complete(comp, status);
+} /* chimera_posix_setacl_callback */
+
+static void
+chimera_posix_setacl_exec(
+    struct chimera_client_thread  *thread,
+    struct chimera_client_request *request)
+{
+    chimera_dispatch_setattr(thread, request);
+} /* chimera_posix_setacl_exec */
+
+SYMBOL_EXPORT int
+chimera_posix_setacl(
+    const char               *path,
+    const struct chimera_acl *acl)
+{
+    struct chimera_posix_client    *posix  = chimera_posix_get_global();
+    struct chimera_posix_worker    *worker = chimera_posix_choose_worker(posix);
+    struct chimera_client_request   req;
+    struct chimera_posix_completion comp;
+    int                             path_len;
+
+    if (!acl) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    path_len = chimera_posix_check_path(path);
+    if (path_len < 0) {
+        return -1;
+    }
+
+    chimera_posix_completion_init(&comp, &req);
+
+    req.opcode               = CHIMERA_CLIENT_OP_SETATTR;
+    req.setattr.callback     = chimera_posix_setacl_callback;
+    req.setattr.private_data = &comp;
+    req.setattr.path_len     = path_len;
+
+    memcpy(req.setattr.path, path, path_len);
+
+    /* va_acl points at the caller's buffer, which outlives the synchronous
+    * wait below (the setattr gate copies/applies it before completing). */
+    req.setattr.set_attr.va_req_mask = 0;
+    req.setattr.set_attr.va_set_mask = CHIMERA_VFS_ATTR_ACL;
+    req.setattr.set_attr.va_acl      = (struct chimera_acl *) acl;
+
+    chimera_posix_worker_enqueue(worker, &req, chimera_posix_setacl_exec);
+
+    int err = chimera_posix_wait(&comp);
+
+    chimera_posix_completion_destroy(&comp);
+
+    if (err) {
+        errno = err;
+        return -1;
+    }
+
+    return 0;
+} /* chimera_posix_setacl */

--- a/src/posix/tests/CMakeLists.txt
+++ b/src/posix/tests/CMakeLists.txt
@@ -1166,6 +1166,21 @@ set(PJD_TESTS
     utimensat/09
 )
 
+# NFSv4 granular-ACL permission ports (pjdfstest tests/granular/).  These set
+# native NFSv4 ACLs via the Chimera-specific chimera_posix_{get,set}acl client
+# API and verify the VFS access engine enforces the granular ACE rights
+# (WRITE_DATA/APPEND_DATA, DELETE/DELETE_CHILD, WRITE_OWNER, ...).  They are only
+# meaningful on backends that store and return the canonical ACL (va_acl), so
+# they are registered separately below -- NOT on the NFS backends (the NFS client
+# cannot set FATTR4_ACL) nor passthrough linux/io_uring (POSIX-mode, not NFSv4
+# ACLs).
+set(PJD_GRANULAR_TESTS
+    granular/00
+    granular/03
+    granular/04
+    granular/05
+)
+
 macro(add_pjd_testprog path)
     string(REPLACE "/" "_" _pjd_flat ${path})
     add_executable(posix_pjd_${_pjd_flat} pjd/${path}.c)
@@ -1248,6 +1263,22 @@ foreach(t ${PJD_TESTS})
     if(CHIMERA_VFS_IO_URING)
         add_pjd_nfs_test(${t} nfs3_io_uring)
         add_pjd_nfs_test(${t} nfs4_io_uring)
+    endif()
+endforeach()
+
+# Granular-ACL ports: only on engine backends that store the canonical NFSv4 ACL
+# (memfs definitely; cairn and diskfs store/return va_acl as well).
+foreach(t ${PJD_GRANULAR_TESTS})
+    add_pjd_testprog(${t})
+    add_pjd_test(${t} memfs)
+    if(CAIRN_ENABLED)
+        add_pjd_test(${t} cairn)
+    endif()
+    if(IO_URING_ENABLED)
+        add_pjd_test(${t} diskfs_io_uring)
+    endif()
+    if(HAVE_LIBAIO)
+        add_pjd_test(${t} diskfs_aio)
     endif()
 endforeach()
 

--- a/src/posix/tests/pjd/granular/00.c
+++ b/src/posix/tests/pjd/granular/00.c
@@ -1,0 +1,126 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
+
+/* Ported from pjdfstest tests/granular/00.t:
+ * "NFSv4 granular permissions checking - WRITE_DATA vs APPEND_DATA on
+ * directories".
+ *
+ * On NFSv4/Windows directory ACLs, WRITE_DATA == ADD_FILE (create a plain file
+ * in the directory) and APPEND_DATA == ADD_SUBDIRECTORY (mkdir in the
+ * directory).  Granting one and denying the other lets a user create files but
+ * not subdirectories (and vice versa).  This exercises the WRITE_DATA gate on
+ * the open(O_CREAT)/link paths and the APPEND_DATA gate on mkdir.
+ *
+ * A faithful representative subset of the upstream 49 subtests: it covers the
+ * allow and deny path of both rights, plus the cross-directory rename and the
+ * delete_child interaction. */
+
+#include "../../pjd_common.h"
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+
+    char *n0 = pjd_namegen();
+    char *n1 = pjd_namegen();
+    char *n3 = pjd_namegen();
+    char *n2 = pjd_namegen();
+
+    EXPECT(0, pjd_mkdir(n2, 0755));
+    EXPECT(0, pjd_mkdir(n3, 0777));
+    pjd_cd(n2);
+
+    /* root can do everything in n2. */
+    EXPECT(0, pjd_create(n0, 0644));
+    EXPECT(0, pjd_link(n0, n1));
+    EXPECT(0, pjd_unlink(n1));
+    EXPECT(0, pjd_unlink(n0));
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    EXPECT(0, pjd_rmdir(n0));
+
+    /* ---- WRITE_DATA allowed, APPEND_DATA denied: files yes, dirs no. ---- */
+    {
+        struct chimera_ace a = pjd_ace_user(CHIMERA_ACE_DENIED, 65534,
+                                            CHIMERA_ACE_APPEND_DATA);
+        struct chimera_ace b = pjd_ace_user(CHIMERA_ACE_ALLOWED, 65534,
+                                            CHIMERA_ACE_WRITE_DATA);
+        EXPECT(0, pjd_prependacl(".", &a));
+        EXPECT(0, pjd_prependacl(".", &b));
+    }
+
+    pjd_set_user(65534, 65534);
+
+    /* Can create files / hardlinks (WRITE_DATA). */
+    EXPECT(0, pjd_create(n0, 0644));
+    EXPECT(0, pjd_link(n0, n1));
+    EXPECT(0, pjd_unlink(n1));
+    EXPECT(0, pjd_unlink(n0));
+
+    /* Cannot create directories (APPEND_DATA denied). */
+    EXPECT(EACCES, pjd_mkdir(n0, 0755));
+    EXPECT(ENOENT, pjd_rmdir(n0));
+
+    pjd_set_root();
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    pjd_set_user(65534, 65534);
+    EXPECT(0, pjd_rmdir(n0));
+
+    /* Can move a file in from another directory (WRITE_DATA on dest). */
+    pjd_set_root();
+    {
+        char src[256];
+        snprintf(src, sizeof(src), "../%s/%s", n3, n1);
+        EXPECT(0, pjd_create(src, 0644));
+        pjd_set_user(65534, 65534);
+        EXPECT(0, pjd_rename(src, n0));
+        EXPECT(0, pjd_unlink(n0));
+    }
+
+    /* Note on directory rename-in: upstream additionally asserts that moving a
+     * *directory* into the dest requires APPEND_DATA (so this WRITE_DATA-allowed
+     * / APPEND_DATA-denied dest would reject it).  Chimera deliberately
+     * authorizes a subdirectory rename via the destination's WRITE_DATA rather
+     * than distinguishing APPEND_DATA (see vfs_proc_rename_at.c), so that
+     * assertion does not map and is omitted here. */
+
+    /* ---- WRITE_DATA denied, APPEND_DATA allowed: dirs yes, files no. ---- */
+    pjd_set_root();
+    {
+        struct chimera_ace a = pjd_ace_user(CHIMERA_ACE_DENIED, 65534,
+                                            CHIMERA_ACE_WRITE_DATA);
+        struct chimera_ace b = pjd_ace_user(CHIMERA_ACE_ALLOWED, 65534,
+                                            CHIMERA_ACE_APPEND_DATA);
+        EXPECT(0, pjd_prependacl(".", &a));
+        EXPECT(0, pjd_prependacl(".", &b));
+    }
+
+    pjd_set_user(65534, 65534);
+
+    /* Cannot create files (WRITE_DATA denied). */
+    EXPECT(EACCES, pjd_create(n0, 0644));
+
+    /* But CAN create directories (APPEND_DATA). */
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    /* Cannot remove it: removing needs WRITE_DATA / DELETE_CHILD on the dir. */
+    EXPECT(EACCES, pjd_rmdir(n0));
+
+    pjd_set_root();
+    EXPECT(0, pjd_rmdir(n0));
+
+    pjd_cd("..");
+    EXPECT(0, pjd_rmdir(n2));
+    EXPECT(0, pjd_rmdir(n3));
+
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/granular/03.c
+++ b/src/posix/tests/pjd/granular/03.c
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
+
+/* Ported from pjdfstest tests/granular/03.t:
+ * "NFSv4 granular permissions checking - DELETE and DELETE_CHILD".
+ *
+ * NFSv4 removal: a name may be removed if the parent directory grants the caller
+ * WRITE_DATA/DELETE_CHILD.  A DELETE_CHILD::deny on the parent vetoes removal of
+ * a child the caller could otherwise delete; a DELETE_CHILD::allow on an
+ * otherwise-unwritable directory permits it.  This exercises
+ * chimera_vfs_delete_allowed / the VFS-core delete gate via unlink.
+ *
+ * Scope / Chimera deviations from the FreeBSD:ZFS upstream:
+ *   - Upstream returns EPERM when removal is vetoed by an explicit
+ *     DELETE_CHILD::deny ACE.  Chimera's delete gate reports EACCES uniformly
+ *     for "removal not authorized" (the enforcement -- removal is blocked -- is
+ *     identical; only the errno class differs), so the deny case below asserts
+ *     EACCES.
+ *   - The per-object DELETE-grant override (a DELETE::allow ACE on the *child*
+ *     letting a caller remove it regardless of the parent's rights) is an
+ *     NFSv4/NT concept that Chimera applies only to ACL-flavored (SMB / AUTH_
+ *     ATTR) callers; a POSIX (AUTH_UNIX) client -- which this harness is -- gets
+ *     directory-based POSIX deletion.  Those subtests are therefore omitted. */
+
+#include "../../pjd_common.h"
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+
+    char *n0 = pjd_namegen();
+    char *n2 = pjd_namegen();
+
+    EXPECT(0, pjd_mkdir(n2, 0755));
+    pjd_cd(n2);
+
+    /* Unlink denied on a directory the caller cannot write. */
+    EXPECT(0, pjd_create(n0, 0644));
+    pjd_set_user(65534, 65534);
+    EXPECT(EACCES, pjd_unlink(n0));
+    pjd_set_root();
+
+    /* WRITE_DATA on the parent permits unlink. */
+    {
+        struct chimera_ace a = pjd_ace_user(CHIMERA_ACE_ALLOWED, 65534,
+                                            CHIMERA_ACE_WRITE_DATA);
+        EXPECT(0, pjd_prependacl(".", &a));
+    }
+    pjd_set_user(65534, 65534);
+    EXPECT(0, pjd_unlink(n0));
+    pjd_set_root();
+
+    /* DELETE_CHILD::deny on the parent vetoes unlink even with WRITE_DATA. */
+    EXPECT(0, pjd_create(n0, 0644));
+    {
+        struct chimera_ace a = pjd_ace_user(CHIMERA_ACE_DENIED, 65534,
+                                            CHIMERA_ACE_DELETE_CHILD);
+        EXPECT(0, pjd_prependacl(".", &a));
+    }
+    pjd_set_user(65534, 65534);
+    EXPECT(EACCES, pjd_unlink(n0));
+    pjd_set_root();
+    EXPECT(0, pjd_unlink(n0));
+
+    /* DELETE_CHILD::allow on an otherwise-unwritable directory permits unlink. */
+    EXPECT(0, pjd_create(n0, 0644));
+    {
+        /* Reset the parent ACL: deny WRITE_DATA but allow DELETE_CHILD. */
+        struct chimera_ace dc = pjd_ace_user(CHIMERA_ACE_ALLOWED, 65534,
+                                             CHIMERA_ACE_DELETE_CHILD);
+        struct chimera_ace wd = pjd_ace_user(CHIMERA_ACE_DENIED, 65534,
+                                             CHIMERA_ACE_WRITE_DATA);
+        EXPECT(0, pjd_prependacl(".", &wd));
+        EXPECT(0, pjd_prependacl(".", &dc));
+    }
+    pjd_set_user(65534, 65534);
+    EXPECT(0, pjd_unlink(n0));
+    pjd_set_root();
+
+    pjd_cd("..");
+    EXPECT(0, pjd_rmdir(n2));
+
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/granular/04.c
+++ b/src/posix/tests/pjd/granular/04.c
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
+
+/* Ported from pjdfstest tests/granular/04.t:
+ * "NFSv4 granular permissions checking - ACL_WRITE_OWNER".
+ *
+ * WRITE_OWNER lets a non-owner change the file's group (chgrp) -- but only to a
+ * group the caller belongs to -- and, where the platform permits, change the
+ * owner (chown) to the caller's own uid.  Without WRITE_OWNER (or ownership) a
+ * non-owner chgrp/chown fails with EPERM.  This exercises the WRITE_OWNER ACE
+ * path of the VFS setattr gate. */
+
+#include "../../pjd_common.h"
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+
+    char    *n0 = pjd_namegen();
+    char    *n2 = pjd_namegen();
+    uint32_t gids[2];
+
+    EXPECT(0, pjd_mkdir(n2, 0755));
+    pjd_cd(n2);
+
+    /* ---- WRITE_OWNER permits setting gid to our own only. ---- */
+    EXPECT(0, pjd_create(n0, 0644));
+    EXPECT_EQ(0, pjd_lstat_uid(n0));
+    EXPECT_EQ(0, pjd_lstat_gid(n0));
+
+    /* Non-owner, no WRITE_OWNER: chgrp denied. */
+    gids[0] = 65532;
+    gids[1] = 65531;
+    pjd_set_user_groups(65534, 65532, 2, gids);
+    EXPECT(EPERM, pjd_chown(n0, (uid_t) -1, 65532));
+    pjd_set_root();
+    EXPECT_EQ(0, pjd_lstat_uid(n0));
+    EXPECT_EQ(0, pjd_lstat_gid(n0));
+
+    /* Grant WRITE_OWNER to 65534. */
+    {
+        struct chimera_ace a = pjd_ace_user(CHIMERA_ACE_ALLOWED, 65534,
+                                            CHIMERA_ACE_WRITE_OWNER);
+        EXPECT(0, pjd_prependacl(n0, &a));
+    }
+
+    /* chgrp to a group we are NOT a member of (65530): denied. */
+    pjd_set_user_groups(65534, 65532, 2, gids);
+    EXPECT(EPERM, pjd_chown(n0, (uid_t) -1, 65530));
+    pjd_set_root();
+    EXPECT_EQ(0, pjd_lstat_uid(n0));
+    EXPECT_EQ(0, pjd_lstat_gid(n0));
+
+    /* chgrp to a group we ARE a member of (65532): allowed. */
+    pjd_set_user_groups(65534, 65532, 2, gids);
+    EXPECT(0, pjd_chown(n0, (uid_t) -1, 65532));
+    pjd_set_root();
+    EXPECT_EQ(0, pjd_lstat_uid(n0));
+    EXPECT_EQ(65532, pjd_lstat_gid(n0));
+
+    EXPECT(0, pjd_unlink(n0));
+
+    pjd_cd("..");
+    EXPECT(0, pjd_rmdir(n2));
+
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd/granular/05.c
+++ b/src/posix/tests/pjd/granular/05.c
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
+
+/* Ported from pjdfstest tests/granular/05.t:
+ * "NFSv4 granular permissions checking - DELETE and DELETE_CHILD with
+ * directories".
+ *
+ * The DELETE_CHILD removal rules of granular/03.t applied to subdirectories
+ * removed with rmdir: removal is governed by the *parent* directory's
+ * WRITE_DATA/DELETE_CHILD, not by anything inside the subdirectory.
+ *
+ * Same Chimera scope/deviation notes as granular/03.c apply: the DELETE_CHILD::
+ * deny veto reports EACCES (not the upstream EPERM), and the per-object
+ * DELETE-grant override is ACL-flavored-only and omitted for this POSIX
+ * client. */
+
+#include "../../pjd_common.h"
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+
+    char *n0 = pjd_namegen();
+    char *n2 = pjd_namegen();
+
+    EXPECT(0, pjd_mkdir(n2, 0755));
+    pjd_cd(n2);
+
+    /* rmdir denied on a directory the caller cannot write. */
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    pjd_set_user(65534, 65534);
+    EXPECT(EACCES, pjd_rmdir(n0));
+    pjd_set_root();
+
+    /* WRITE_DATA on the parent permits rmdir. */
+    {
+        struct chimera_ace a = pjd_ace_user(CHIMERA_ACE_ALLOWED, 65534,
+                                            CHIMERA_ACE_WRITE_DATA);
+        EXPECT(0, pjd_prependacl(".", &a));
+    }
+    pjd_set_user(65534, 65534);
+    EXPECT(0, pjd_rmdir(n0));
+    pjd_set_root();
+
+    /* DELETE_CHILD::deny on the parent vetoes rmdir even with WRITE_DATA. */
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    {
+        struct chimera_ace a = pjd_ace_user(CHIMERA_ACE_DENIED, 65534,
+                                            CHIMERA_ACE_DELETE_CHILD);
+        EXPECT(0, pjd_prependacl(".", &a));
+    }
+    pjd_set_user(65534, 65534);
+    EXPECT(EACCES, pjd_rmdir(n0));
+    pjd_set_root();
+    EXPECT(0, pjd_rmdir(n0));
+
+    /* DELETE_CHILD::allow on an unwritable directory permits rmdir. */
+    EXPECT(0, pjd_mkdir(n0, 0755));
+    {
+        struct chimera_ace dc = pjd_ace_user(CHIMERA_ACE_ALLOWED, 65534,
+                                             CHIMERA_ACE_DELETE_CHILD);
+        struct chimera_ace wd = pjd_ace_user(CHIMERA_ACE_DENIED, 65534,
+                                             CHIMERA_ACE_WRITE_DATA);
+        EXPECT(0, pjd_prependacl(".", &wd));
+        EXPECT(0, pjd_prependacl(".", &dc));
+    }
+    pjd_set_user(65534, 65534);
+    EXPECT(0, pjd_rmdir(n0));
+    pjd_set_root();
+
+    pjd_cd("..");
+    EXPECT(0, pjd_rmdir(n2));
+
+    return pjd_end();
+} /* main */

--- a/src/posix/tests/pjd_common.h
+++ b/src/posix/tests/pjd_common.h
@@ -34,6 +34,7 @@
 #include <limits.h>
 #include <sys/sysmacros.h>
 #include "posix_test_common.h"
+#include "vfs/vfs_acl.h"
 
 /* ---- lifecycle / global state ------------------------------------------- */
 
@@ -946,3 +947,126 @@ pjd_remove_file(
     }
     return pjd_unlink(name);
 } /* pjd_remove_file */
+
+/* ---- NFSv4 ACL helpers (granular/ ports) -------------------------------- */
+/*
+ * These wrap the Chimera-specific chimera_posix_{get,set}acl client API to give
+ * the granular/ ports the same ergonomics pjdfstest's prependacl / readacl /
+ * setacl operations have on FreeBSD:ZFS.  An ACL is built on the harness stack
+ * as a fixed-capacity buffer (PJD_ACL_MAX entries is plenty for these tests).
+ */
+
+#define PJD_ACL_MAX 32
+
+/* A stack-resident ACL of up to PJD_ACL_MAX ACEs.  Use pjd_acl_hdr() to treat
+ * it as a struct chimera_acl. */
+struct pjd_acl_buf {
+    struct chimera_acl acl;
+    struct chimera_ace _aces[PJD_ACL_MAX];
+};
+
+static inline struct chimera_acl *
+pjd_acl_hdr(struct pjd_acl_buf *b)
+{
+    return &b->acl;
+} /* pjd_acl_hdr */
+
+/* Build a single ACE.  `type` is CHIMERA_ACE_ALLOWED / CHIMERA_ACE_DENIED;
+ * `who_type` is a chimera_principal_type; `id` is the uid/gid when who_type is
+ * USER/GROUP; `special` is a chimera_special_who when who_type is SPECIAL. */
+static inline struct chimera_ace
+pjd_ace(
+    uint16_t type,
+    uint8_t  who_type,
+    uint32_t id,
+    uint8_t  special,
+    uint32_t mask)
+{
+    struct chimera_ace ace;
+
+    memset(&ace, 0, sizeof(ace));
+    ace.type        = type;
+    ace.flags       = 0;
+    ace.access_mask = mask;
+    ace.who.type    = who_type;
+    ace.who.special = special;
+    ace.who.id      = id;
+    return ace;
+} /* pjd_ace */
+
+/* Convenience: a named-user ACE (the most common case in the granular tests). */
+static inline struct chimera_ace
+pjd_ace_user(
+    uint16_t type,
+    uint32_t uid,
+    uint32_t mask)
+{
+    return pjd_ace(type, CHIMERA_PRINCIPAL_USER, uid, 0, mask);
+} /* pjd_ace_user */
+
+/* Convenience: an EVERYONE@ special-who ACE. */
+static inline struct chimera_ace
+pjd_ace_everyone(
+    uint16_t type,
+    uint32_t mask)
+{
+    return pjd_ace(type, CHIMERA_PRINCIPAL_SPECIAL, 0, CHIMERA_WHO_EVERYONE, mask);
+} /* pjd_ace_everyone */
+
+static inline int
+pjd_setacl(
+    const char               *name,
+    const struct chimera_acl *acl)
+{
+    char p[PJD_PATHBUF];
+
+    return chimera_posix_setacl(pjd_resolve(name, p, sizeof(p)), acl);
+} /* pjd_setacl */
+
+/* Read the ACL of `name` into `out`.  Returns the ACE count, or -1 on error. */
+static inline int
+pjd_getacl(
+    const char         *name,
+    struct pjd_acl_buf *out)
+{
+    char p[PJD_PATHBUF];
+
+    return chimera_posix_getacl(pjd_resolve(name, p, sizeof(p)),
+                                pjd_acl_hdr(out), sizeof(*out));
+} /* pjd_getacl */
+
+/*
+ * Prepend `ace` at index 0 of `name`'s current ACL and write it back -- exactly
+ * what pjdfstest's prependacl does.  Returns 0 on success, -1 on error (errno
+ * set by the failing get/set).  The new ACE precedes all existing ACEs, so a
+ * DENY prepended ahead of an inherited/implicit ALLOW takes effect first (RFC
+ * 7530 ordered evaluation).
+ */
+static inline int
+pjd_prependacl(
+    const char               *name,
+    const struct chimera_ace *ace)
+{
+    struct pjd_acl_buf cur;
+    struct pjd_acl_buf nw;
+    int                n, i;
+
+    n = pjd_getacl(name, &cur);
+    if (n < 0) {
+        return -1;
+    }
+
+    if (n + 1 > PJD_ACL_MAX) {
+        errno = E2BIG;
+        return -1;
+    }
+
+    nw.acl.num_aces   = (uint16_t) (n + 1);
+    nw.acl.ctrl_flags = cur.acl.ctrl_flags;
+    nw._aces[0]       = *ace;
+    for (i = 0; i < n; i++) {
+        nw._aces[i + 1] = cur.acl.aces[i];
+    }
+
+    return pjd_setacl(name, pjd_acl_hdr(&nw));
+} /* pjd_prependacl */

--- a/src/vfs/cairn/cairn.c
+++ b/src/vfs/cairn/cairn.c
@@ -2840,13 +2840,17 @@ cairn_open_at(
             return;
         }
 
-        /* Creating a new name requires write+search permission on the parent
-         * directory.  Enforce POSIX semantics for AUTH_UNIX callers (root is
-         * exempt); SMB/ACL (AUTH_ATTR) callers are authorized by the engine. */
+        /* Creating a new file requires add-file (WRITE_DATA) + search (EXECUTE)
+         * permission on the parent directory.  On the NFSv4/Windows ACL model
+         * WRITE_DATA == ADD_FILE and APPEND_DATA == ADD_SUBDIRECTORY, so a plain
+         * file create is gated by WRITE_DATA (mkdir is gated by APPEND_DATA in
+         * the VFS-core mkdir_at path).  Enforce POSIX semantics for AUTH_UNIX
+         * callers (root is exempt); SMB/ACL (AUTH_ATTR) callers are authorized
+         * by the engine. */
         if (request->cred->flavor == CHIMERA_VFS_AUTH_UNIX &&
             request->cred->uid != 0 &&
             !cairn_inode_access(thread, parent_inode, request->cred,
-                                CHIMERA_ACE_APPEND_DATA | CHIMERA_ACE_EXECUTE)) {
+                                CHIMERA_ACE_WRITE_DATA | CHIMERA_ACE_EXECUTE)) {
             cairn_inode_handle_release(&parent_ih);
             request->status = CHIMERA_VFS_EACCES;
             request->complete(request);

--- a/src/vfs/diskfs/diskfs_namespace.c
+++ b/src/vfs/diskfs/diskfs_namespace.c
@@ -1913,13 +1913,17 @@ diskfs_open_at_check_cb(
             return;
         }
 
-        /* Creating a new name requires write+search permission on the parent
-         * directory.  Enforce POSIX semantics for AUTH_UNIX callers (root is
-         * exempt); SMB/ACL (AUTH_ATTR) callers are authorized by the engine. */
+        /* Creating a new file requires add-file (WRITE_DATA) + search (EXECUTE)
+         * permission on the parent directory.  On the NFSv4/Windows ACL model
+         * WRITE_DATA == ADD_FILE and APPEND_DATA == ADD_SUBDIRECTORY, so a plain
+         * file create is gated by WRITE_DATA (mkdir is gated by APPEND_DATA in
+         * the VFS-core mkdir_at path).  Enforce POSIX semantics for AUTH_UNIX
+         * callers (root is exempt); SMB/ACL (AUTH_ATTR) callers are authorized
+         * by the engine. */
         if (request->cred->flavor == CHIMERA_VFS_AUTH_UNIX &&
             request->cred->uid != 0 &&
             !diskfs_inode_access(thread, p->inode_stash[0], request->cred,
-                                 CHIMERA_ACE_APPEND_DATA | CHIMERA_ACE_EXECUTE)) {
+                                 CHIMERA_ACE_WRITE_DATA | CHIMERA_ACE_EXECUTE)) {
             diskfs_op_fail(request, p->txn, CHIMERA_VFS_EACCES);
             return;
         }

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -2705,13 +2705,17 @@ memfs_open_at(
             return;
         }
 
-        /* Creating a new name requires write+search permission on the parent
-         * directory.  Enforce POSIX semantics for AUTH_UNIX callers (root is
-         * exempt); SMB/ACL (AUTH_ATTR) callers are authorized by the engine. */
+        /* Creating a new file requires add-file (WRITE_DATA) + search (EXECUTE)
+         * permission on the parent directory.  On the NFSv4/Windows ACL model
+         * WRITE_DATA == ADD_FILE and APPEND_DATA == ADD_SUBDIRECTORY, so a plain
+         * file create is gated by WRITE_DATA (mkdir, which adds a subdirectory,
+         * is gated by APPEND_DATA in the VFS-core mkdir_at path).  Enforce POSIX
+         * semantics for AUTH_UNIX callers (root is exempt); SMB/ACL (AUTH_ATTR)
+         * callers are authorized by the engine. */
         if (request->cred->flavor == CHIMERA_VFS_AUTH_UNIX &&
             request->cred->uid != 0 &&
             !memfs_inode_access(parent_inode, request->cred,
-                                CHIMERA_ACE_APPEND_DATA | CHIMERA_ACE_EXECUTE)) {
+                                CHIMERA_ACE_WRITE_DATA | CHIMERA_ACE_EXECUTE)) {
             pthread_mutex_unlock(&parent_inode->lock);
             request->status = CHIMERA_VFS_EACCES;
             request->complete(request);

--- a/src/vfs/vfs_acl.c
+++ b/src/vfs/vfs_acl.c
@@ -254,9 +254,14 @@ chimera_acl_access_check(
     }
 
     /* Derive DELETE_CHILD from the directory's effective write+execute (see the
-     * note above); applies to mode-synthesised and explicit ACLs alike. */
+     * note above); applies to mode-synthesised and explicit ACLs alike.  An
+     * explicit DENY of DELETE_CHILD must win, though: a directory may grant
+     * WRITE_DATA (add entries) while still vetoing removal via a
+     * DELETE_CHILD::deny ACE, so do not re-synthesise a right that was
+     * explicitly denied. */
     if (is_dir && (granted & CHIMERA_ACE_WRITE_DATA) &&
-        (granted & CHIMERA_ACE_EXECUTE)) {
+        (granted & CHIMERA_ACE_EXECUTE) &&
+        !(denied & CHIMERA_ACE_DELETE_CHILD)) {
         granted |= CHIMERA_ACE_DELETE_CHILD;
     }
 

--- a/src/vfs/vfs_proc_setattr.c
+++ b/src/vfs/vfs_proc_setattr.c
@@ -147,6 +147,40 @@ chimera_vfs_setattr_chown_check(
     return CHIMERA_VFS_OK;
 } /* chimera_vfs_setattr_chown_check */
 
+/*
+ * NFSv4 ACL_WRITE_OWNER eligibility for a non-owner who has been granted the
+ * WRITE_OWNER right by an explicit ACE.  Unlike POSIX chown(2) (which lets only
+ * the super-user change the uid), WRITE_OWNER lets the holder "take" the object:
+ * but, following the BSD/Solaris NFSv4 implementations, only to its own identity
+ * -- the new uid must equal the caller's uid, and the new gid must be a group
+ * the caller is a member of.  A field left unset, or restated to its current
+ * value, is not a change.  Returns CHIMERA_VFS_OK when permitted, else EPERM.
+ */
+static enum chimera_vfs_error
+chimera_vfs_setattr_write_owner_check(
+    const struct chimera_vfs_cred  *cred,
+    const struct chimera_vfs_attrs *set_attr,
+    const struct chimera_vfs_attrs *cur)
+{
+    uint64_t m = set_attr->va_set_mask;
+
+    if ((m & CHIMERA_VFS_ATTR_UID) &&
+        !(cur && (cur->va_set_mask & CHIMERA_VFS_ATTR_UID) &&
+          cur->va_uid == set_attr->va_uid) &&
+        set_attr->va_uid != (uint64_t) cred->uid) {
+        return CHIMERA_VFS_EPERM;
+    }
+
+    if ((m & CHIMERA_VFS_ATTR_GID) &&
+        !(cur && (cur->va_set_mask & CHIMERA_VFS_ATTR_GID) &&
+          cur->va_gid == set_attr->va_gid) &&
+        !chimera_vfs_setattr_cred_in_group(cred, set_attr->va_gid)) {
+        return CHIMERA_VFS_EPERM;
+    }
+
+    return CHIMERA_VFS_OK;
+} /* chimera_vfs_setattr_write_owner_check */
+
 static enum chimera_vfs_error
 chimera_vfs_setattr_denied_error(const struct chimera_vfs_attrs *set_attr)
 {
@@ -325,17 +359,37 @@ chimera_vfs_setattr_gate_complete(
         int is_owner = (attr->va_set_mask & CHIMERA_VFS_ATTR_UID) &&
             (uint64_t) gate->cred->uid == attr->va_uid;
 
-        /* POSIX chown(2) rules are always required when a uid/gid is named
-         * (even a no-op restate by a non-owner is EPERM).  An actual change
-         * (required & WRITE_OWNER) additionally needs the chown right: the
-         * caller is the owner, is root, or an explicit WRITE_OWNER ACE grants
-         * it.  A no-op restate carries no WRITE_OWNER requirement. */
-        if (chimera_vfs_setattr_chown_check(gate->cred, gate->set_attr, attr) != CHIMERA_VFS_OK ||
-            ((required & CHIMERA_ACE_WRITE_OWNER) && !is_owner && gate->cred->uid != 0 &&
-             chimera_vfs_gate(attr, gate->cred, CHIMERA_ACE_WRITE_OWNER) != CHIMERA_VFS_OK)) {
-            gate->callback(CHIMERA_VFS_EPERM, NULL, NULL, NULL, gate->private_data);
-            free(gate);
-            return;
+        /* A non-owner who is not root, but who holds the NFSv4 WRITE_OWNER right
+         * via an explicit ACE, is authorized under WRITE_OWNER semantics
+         * (chimera_vfs_setattr_write_owner_check: take ownership to one's own
+         * uid / a group one belongs to) rather than the POSIX chown(2) rules
+         * (which would reject any non-owner change).  This is what lets a
+         * WRITE_OWNER-granted user chgrp a file they do not own.  The owner and
+         * root keep the POSIX rules (the owner may chgrp to a group it belongs
+         * to; only root may change uid). */
+        int has_write_owner = !is_owner && gate->cred->uid != 0 &&
+            (required & CHIMERA_ACE_WRITE_OWNER) &&
+            chimera_vfs_gate(attr, gate->cred, CHIMERA_ACE_WRITE_OWNER) == CHIMERA_VFS_OK;
+
+        if (has_write_owner) {
+            if (chimera_vfs_setattr_write_owner_check(gate->cred, gate->set_attr, attr) != CHIMERA_VFS_OK) {
+                gate->callback(CHIMERA_VFS_EPERM, NULL, NULL, NULL, gate->private_data);
+                free(gate);
+                return;
+            }
+        } else {
+            /* POSIX chown(2) rules are always required when a uid/gid is named
+             * (even a no-op restate by a non-owner is EPERM).  An actual change
+             * (required & WRITE_OWNER) additionally needs the chown right: the
+             * caller is the owner, is root, or an explicit WRITE_OWNER ACE
+             * grants it.  A no-op restate carries no WRITE_OWNER requirement. */
+            if (chimera_vfs_setattr_chown_check(gate->cred, gate->set_attr, attr) != CHIMERA_VFS_OK ||
+                ((required & CHIMERA_ACE_WRITE_OWNER) && !is_owner && gate->cred->uid != 0 &&
+                 chimera_vfs_gate(attr, gate->cred, CHIMERA_ACE_WRITE_OWNER) != CHIMERA_VFS_OK)) {
+                gate->callback(CHIMERA_VFS_EPERM, NULL, NULL, NULL, gate->private_data);
+                free(gate);
+                return;
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Ports the pjdfstest `granular/` tests (NFSv4 granular ACL permission enforcement) to the chimera_posix ctest suite, adds the client/test plumbing needed to set and get native NFSv4 ACLs, and fixes three ACL-enforcement gaps the ports uncovered.

## Client API (LGPL-2.1)

NFSv4 ACLs are a first-class chimera VFS attribute but had no client/POSIX accessor. Added (chimera-specific, since NFSv4 ACLs are not standard POSIX):

- `chimera_posix_setacl(path, acl)` — dispatch a setattr with `CHIMERA_VFS_ATTR_ACL` (modeled on `posix_chmod.c`).
- `chimera_posix_getacl(path, buf, bufsize)` — getattr `CHIMERA_VFS_ATTR_ACL` into a caller buffer (new `client_getacl.h` dispatch: lookup → open O_PATH → getattr → copy out `va_acl`). Returns the ACE count; `ERANGE` if the buffer is too small.

Both run under the existing per-call cred override (`chimera_posix_set_cred`), so an ACL op is authorized as a chosen user.

## Harness (`pjd_common.h`)

ACE builders (`pjd_ace`, `pjd_ace_user`, `pjd_ace_everyone`), `pjd_setacl`/`pjd_getacl`, and `pjd_prependacl` (get the current ACL, prepend an ACE at index 0, set it back — exactly what upstream `prependacl` does).

## Ports (BSD-2-Clause), registered on memfs / cairn / diskfs

Only on backends that store native `va_acl`; **not** on NFS (the NFS client can't set FATTR4_ACL) or passthrough linux/io_uring (POSIX-mode).

- `granular/00` — WRITE_DATA (ADD_FILE) vs APPEND_DATA (ADD_SUBDIRECTORY): create-file needs WRITE_DATA, mkdir needs APPEND_DATA.
- `granular/03` — DELETE_CHILD governs file removal (deny vetoes; allow on an unwritable dir permits).
- `granular/04` — WRITE_OWNER lets a non-owner chgrp to a group it belongs to.
- `granular/05` — same as 03 for directories (rmdir).

Each exercises the allow and deny path of its ACE right(s). A faithful representative subset of the upstream deny-then-allow loops (upstream has 49–83 subtests each).

### Not ported (with reasons)
- `granular/01` (READ_ATTRIBUTES via stat) and `granular/02` (READ_ACL / WRITE_ACL): the VFS-core `getattr` path is **not** gated by READ_ATTRIBUTES/READ_ACL (and `getattr` is reused internally by the access engine itself, so a global gate there is unsafe). Test 02 also relies on a "setting SUID/SGID via WRITE_ACL by a non-owner fails EPERM" semantic chimera does not implement. Left unported rather than introduce a risky hot-path/internal-reuse change.
- `granular/06`: ZFS-`aclmode=passthrough`-specific suid/sgid-clear-on-chown; does not map.

### Scope deviations noted in the ported tests
- chimera's delete gate reports `EACCES` (not the upstream `EPERM`) when removal is vetoed by a `DELETE_CHILD::deny` ACE — enforcement is identical, only the errno class differs.
- the per-object DELETE-grant override (DELETE::allow on the child) is applied only to ACL-flavored (SMB / AUTH_ATTR) callers; a POSIX (AUTH_UNIX) client gets directory-based POSIX deletion, so those subtests are omitted.
- subdirectory rename-in is authorized via the destination's WRITE_DATA rather than distinguishing APPEND_DATA (existing `vfs_proc_rename_at` behavior), so that one upstream assertion is omitted.

## Enforcement fixes uncovered by the ports

1. **Create-file gated on the wrong ACE.** memfs/cairn/diskfs gated an `open(O_CREAT)` file create on the parent's `APPEND_DATA`. Creating a *file* is ADD_FILE == `WRITE_DATA` (APPEND_DATA == ADD_SUBDIRECTORY gates `mkdir` in the VFS-core path). Fixed to `WRITE_DATA`. For mode-only objects both bits track the directory's `w` bit, so there is no behavior change there.
2. **Explicit DELETE_CHILD::deny was overridden** by the `WRITE_DATA+EXECUTE → DELETE_CHILD` synthesis in `vfs_acl.c`. Do not re-synthesise a right that was explicitly denied.
3. **WRITE_OWNER chgrp.** A non-owner holding an explicit `WRITE_OWNER` ACE is now authorized to take ownership to its own uid / a group it belongs to (NFSv4 semantics), instead of being rejected by the POSIX `chown(2)` owner rule. The owner and root keep the POSIX rules.

## Results

- 4 granular tests × 4 backends (memfs, cairn, diskfs_io_uring, diskfs_aio) = 16 new tests, all green.
- Full `ctest -L pjdfstest` (memfs/cairn/diskfs/linux/io_uring + NFS3/NFS4): **2554/2554 pass**, no regressions.
- Targeted permission/setattr posix tests pass on every backend.
- clang static analysis clean on all changed `.c`; `make syntax`, `reuse lint`, copyright-year all clean.