### PR TITLE
vfs: pin caching grant across break in break_reads_for_write (fixes #733 levelii501 flake)

### DIFF
--- a/src/vfs/vfs_state.c
+++ b/src/vfs/vfs_state.c
@@ -2685,10 +2685,11 @@ chimera_vfs_break_reads_for_write(
     struct chimera_vfs_file_state        *file,
     const struct chimera_vfs_lease_owner *writer)
 {
-    struct chimera_vfs_lease *cur;
-    struct chimera_vfs_lease *to_break[CHIMERA_VFS_STATE_MAX_BREAK_BATCH];
-    int                       n = 0;
-    int                       i;
+    struct chimera_vfs_lease         *cur;
+    struct chimera_vfs_lease         *to_break[CHIMERA_VFS_STATE_MAX_BREAK_BATCH];
+    struct chimera_vfs_caching_grant *pin[CHIMERA_VFS_STATE_MAX_BREAK_BATCH];
+    int                               n = 0;
+    int                               i;
 
     pthread_mutex_lock(&file->lock);
 
@@ -2719,6 +2720,24 @@ chimera_vfs_break_reads_for_write(
             continue;
         }
         if (n < CHIMERA_VFS_STATE_MAX_BREAK_BATCH) {
+            /* Pin the grant of every lease we are about to break, under the same
+             * file->lock that chimera_vfs_caching_grant_release() takes before it
+             * frees the grant.  For a CACHING lease the lease is embedded in its
+             * grant (grant->lease), so a close of the holder racing on another
+             * thread (drain_locks -> caching_grant_release) would otherwise drop
+             * the grant's last reference and free it -- and the lease with it --
+             * between us dropping file->lock and begin_break_ex's break cb
+             * dereferencing it (chimera_smb_lease_break_cb reads
+             * grant->break_ack_required after the lock is dropped).  That is the
+             * load-dependent heap-use-after-free behind the flaky
+             * smb2.oplock.levelii501 (#733).  This is the same embedded-lease
+             * lifetime hazard that chimera_vfs_state_try_insert pins against;
+             * break_reads_for_write needs the identical guard. */
+            pin[n] = NULL;
+            if (cur->kind == CHIMERA_VFS_LEASE_CACHING && cur->grant) {
+                cur->grant->refcount++;
+                pin[n] = cur->grant;
+            }
             to_break[n++] = cur;
         }
     }
@@ -2731,6 +2750,13 @@ chimera_vfs_break_reads_for_write(
          * notification rather than cascading RH->R->NONE (smb2.lease.complex1
          * expects exactly one break; nobreakself). */
         chimera_vfs_lease_begin_break_ex(state, to_break[i], 0, 0, true);
+
+        /* Drop the pin once the break cb has run.  pump=true: a final release may
+         * unblock an acquirer/IO parked on this grant (the breaker is no longer
+         * mid-arbitration here, unlike the try_insert re-probe loop). */
+        if (pin[i]) {
+            chimera_vfs_caching_grant_release(state, pin[i], true);
+        }
     }
 } /* chimera_vfs_break_reads_for_write */
 


### PR DESCRIPTION
## Summary

Fixes the load-dependent **heap-use-after-free** behind the flaky `smbtorture smb2.oplock.levelii501_diskfs_io_uring` (tracker #733).

`chimera_vfs_break_reads_for_write()` collects breakable CACHING leases under `file->lock`, drops the lock, then calls `chimera_vfs_lease_begin_break_ex()` on each. For a CACHING lease the lease is **embedded in its grant** (`grant->lease`), so a close of the holder racing on another thread (`chimera_smb_conn_free` → `session_release` → `tree_free` → `drain_locks` → `chimera_vfs_caching_grant_release`) drops the grant's last refcount and frees it (the lease with it) between the unlock and `begin_break`'s break callback, which dereferences it after dropping `file->lock` again — `chimera_smb_lease_break_cb` reads `grant->break_ack_required` at `smb_proc_oplock_break.c:400`.

The `levelii501` test postpones its oplock break acks (`torture_oplock_break_delay`, 500ms) and overlaps a third conflicting `OVERWRITE_IF` open with the holder connections tearing down, which widens exactly this break-vs-free window. `diskfs_io_uring` (CAP_BLOCKING) routes the break through a delegation thread, adding the cross-thread surface that makes the race fire under CPU contention.

This is the **same embedded-lease lifetime hazard that #859 pinned against** in `chimera_vfs_state_try_insert`; that fix did not cover `break_reads_for_write`, which is a separate `begin_break` call site with the identical problem. Relatedly, commit 6e291172 ("break a LEVEL_II oplock holder's own read cache on write") routes more LEVEL_II writes through this exact path, increasing how often it is exercised.

## Fix

Take a reference on each grant under the same `file->lock` that `caching_grant_release` takes before freeing, hold it across `begin_break_ex`, and release it after (`pump=true` — a final release may unblock a parked acquirer). Mirrors the existing pin idiom in `try_insert`.

## Signature reproduced (Debug / ASan)

```
ERROR: AddressSanitizer: heap-use-after-free READ of size 1
  #0 chimera_smb_lease_break_cb        src/server/smb/smb_proc_oplock_break.c:400
  #1 chimera_vfs_lease_begin_break_ex  src/vfs/vfs_state.c:2287
  #2 chimera_vfs_break_reads_for_write src/vfs/vfs_state.c:2733
  #3 chimera_vfs_state_break_on_write  src/vfs/vfs_state.c:2752
  #4 chimera_smb_create_break_for_open src/server/smb/smb_proc_create.c:474
freed by:
  chimera_vfs_caching_grant_release    src/vfs/vfs_state.c:1959
  chimera_smb_open_file_drain_locks    src/server/smb/smb_proc_lock.c:153  (conn teardown)
```

## Verification

- **Before:** crashed at iteration ~12 of a tight single-test loop (and 1/40 under `--repeat until-fail`).
- **After:** 140+ consecutive single-test runs green; full `smb2_oplock | smb2_lease | durable_open | dirlease` matrix (memfs + diskfs + cairn + linux + io_uring) green on both Release (568/568) and Debug/ASan; `vfs/state_test`, `vfs/notify_test`, sync/async delegation unit tests green.

Ref #733.