### PR TITLE
smb2/streams: green smb2.streams.names3 (case-insensitive opens on memfs)

### DIFF
--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -553,6 +553,11 @@ struct chimera_smb_request {
              * trimmed to the base file.  base_oh is the base file's open handle
              * held across the chained chimera_vfs_open_stream. */
             uint8_t                            has_stream;
+            /* Set when the final component is the explicit default data fork
+             * "file::$DATA" (has_stream stays 0; the base file is opened).  A
+             * directory has no data fork, so the open path rejects this form on
+             * a directory target (smb2.streams.dir). */
+            uint8_t                            explicit_data_fork;
             uint16_t                           stream_name_len;
             char                               stream_name[SMB_FILENAME_MAX];
             struct chimera_vfs_open_handle    *base_oh;

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -1894,6 +1894,22 @@ chimera_smb_create_open_at_callback(
         return;
     }
 
+    /* "DNAME::$DATA" explicitly names the default data fork of the target.  A
+     * directory has no data fork, so reject it now that the open has revealed
+     * the target is a directory: NOT_A_DIRECTORY when the caller also requested
+     * FILE_DIRECTORY_FILE, FILE_IS_A_DIRECTORY otherwise (smb2.streams.dir).
+     * This fires only for the explicit "::$DATA" form on a directory, a path
+     * that otherwise opens the directory as a plain file. */
+    if (request->create.explicit_data_fork && S_ISDIR(attr->va_mode)) {
+        chimera_smb_create_release_handle(vfs_thread, oh);
+        chimera_smb_create_release_parent(request);
+        chimera_smb_complete_request(request,
+                                     (request->create.create_options & SMB2_FILE_DIRECTORY_FILE)
+                                     ? SMB2_STATUS_NOT_A_DIRECTORY
+                                     : SMB2_STATUS_FILE_IS_A_DIRECTORY);
+        return;
+    }
+
     /* Named-stream open: the base file is now open; open the stream on it and
      * build the SMB open_file around the stream handle. */
     if (request->create.has_stream) {
@@ -3504,13 +3520,15 @@ chimera_smb_parse_stream_name(
     uint16_t    *r_base_len,
     const char **r_stream,
     uint16_t    *r_stream_len,
-    uint8_t     *r_has_stream)
+    uint8_t     *r_has_stream,
+    uint8_t     *r_explicit_data_fork)
 {
     const char *colon = memchr(name, ':', name_len);
     const char *rest, *type, *colon2;
     uint16_t    base_len, rest_len, stream_len;
 
-    *r_has_stream = 0;
+    *r_has_stream         = 0;
+    *r_explicit_data_fork = 0;
 
     if (!colon) {
         *r_base_len = name_len;
@@ -3543,11 +3561,14 @@ chimera_smb_parse_stream_name(
 
     if (stream_len == 0) {
         /* "file::$DATA" is the default data fork (open the base file); a bare
-         * trailing "file:" with neither name nor type is malformed. */
+         * trailing "file:" with neither name nor type is malformed.  Flag the
+         * explicit default-data-fork form so the open path can reject it on a
+         * directory (a directory has no data fork -- smb2.streams.dir). */
         if (!colon2) {
             return SMB2_STATUS_OBJECT_NAME_INVALID;
         }
-        *r_base_len = base_len;
+        *r_base_len           = base_len;
+        *r_explicit_data_fork = 1;
         return SMB2_STATUS_SUCCESS;
     }
 
@@ -3749,8 +3770,9 @@ chimera_smb_create(struct chimera_smb_request *request)
     enum chimera_smb_pipe_magic   pipe_magic;
     chimera_smb_pipe_transceive_t transceive;
 
-    request->create.has_stream = 0;
-    request->create.base_oh    = NULL;
+    request->create.has_stream         = 0;
+    request->create.explicit_data_fork = 0;
+    request->create.base_oh            = NULL;
     /* Only the regular-file open path (open_at_callback) registers a finish
      * callback and may park on a batch-oplock break; clear it so the mkdir /
      * stream / pipe paths never inherit a stale callback and park. */
@@ -3775,18 +3797,23 @@ chimera_smb_create(struct chimera_smb_request *request)
             return;
         }
 
-        const char *sname      = NULL;
-        uint16_t    base_len   = request->create.name_len;
-        uint16_t    sname_len  = 0;
-        uint8_t     has_stream = 0;
-        uint32_t    pstatus    = chimera_smb_parse_stream_name(
+        const char *sname              = NULL;
+        uint16_t    base_len           = request->create.name_len;
+        uint16_t    sname_len          = 0;
+        uint8_t     has_stream         = 0;
+        uint8_t     explicit_data_fork = 0;
+        uint32_t    pstatus            = chimera_smb_parse_stream_name(
             request->create.name, request->create.name_len,
-            &base_len, &sname, &sname_len, &has_stream);
+            &base_len, &sname, &sname_len, &has_stream, &explicit_data_fork);
 
         if (pstatus != SMB2_STATUS_SUCCESS) {
             chimera_smb_complete_request(request, pstatus);
             return;
         }
+
+        /* "DNAME::$DATA" names the default data fork explicitly; remember it so
+         * the open-completion path can reject it on a directory target. */
+        request->create.explicit_data_fork = explicit_data_fork;
 
         /* A wildcard/invalid character in the BASE file name of a stream path
          * is rejected with OBJECT_NAME_INVALID (smb2.streams.names "stream*").

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -1806,7 +1806,11 @@ chimera_smb_create_open_stream_chain(
         request->create.stream_name,
         request->create.stream_name_len,
         sflags,
-        NULL,
+        /* The create's FileAttributes (e.g. HIDDEN|ARCHIVE) live on the base
+         * file, shared by all its streams.  Stamp them when the stream open
+         * creates or overwrites the stream so a stream create reflects the
+         * requested attributes on the base (smb2.streams.attributes2). */
+        &request->create.set_attr,
         CHIMERA_VFS_ATTR_MASK_STAT | CHIMERA_VFS_ATTR_BTIME | CHIMERA_VFS_ATTR_ACL,
         chimera_smb_create_open_stream_callback,
         request);

--- a/src/server/smb/smb_proc_query_info.c
+++ b/src/server/smb/smb_proc_query_info.c
@@ -269,6 +269,31 @@ chimera_smb_query_info(struct chimera_smb_request *request)
 
     switch (request->query_info.info_type) {
         case SMB2_INFO_FILE:
+            /* The attribute-bearing FILE info classes require the handle to
+             * hold FILE_READ_ATTRIBUTES (MS-FSA 2.1.5.11): a handle opened with
+             * only FILE_READ_DATA cannot query FileBasicInformation and friends
+             * -> STATUS_ACCESS_DENIED (smb2.streams.attributes1).  Classes that
+             * carry no file attributes (standard sizes, internal id, EA size,
+             * position, mode, alignment, access, name) are not gated. */
+            switch (request->query_info.info_class) {
+                case SMB2_FILE_BASIC_INFO:
+                case SMB2_FILE_NETWORK_OPEN_INFO:
+                case SMB2_FILE_ATTRIBUTE_TAG_INFO:
+                case SMB2_FILE_COMPRESSION_INFO:
+                case SMB2_FILE_ALL_INFO:
+                    if (!(request->query_info.open_file->granted_access &
+                          SMB2_FILE_READ_ATTRIBUTES)) {
+                        status = SMB2_STATUS_ACCESS_DENIED;
+                    }
+                    break;
+                default:
+                    break;
+            } /* switch */
+
+            if (status != SMB2_STATUS_SUCCESS) {
+                break;
+            }
+
             /* Calculate the output buffer length based on the info class */
             switch (request->query_info.info_class) {
                 case SMB2_FILE_BASIC_INFO:

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -1597,6 +1597,7 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.streams.io
     smb2.streams.names
     smb2.streams.names2
+    smb2.streams.names3
     smb2.streams.rename
     smb2.streams.rename2
     smb2.streams.sharemodes

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -1589,8 +1589,10 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.sharemode.bug14375
     smb2.sharemode.sharemode-access
     # smb2.streams
+    smb2.streams.attributes1
     smb2.streams.basefile-rename-with-open-stream
     smb2.streams.create-disposition
+    smb2.streams.dir
     smb2.streams.io
     smb2.streams.names
     smb2.streams.names2

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -1590,6 +1590,7 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.sharemode.sharemode-access
     # smb2.streams
     smb2.streams.attributes1
+    smb2.streams.attributes2
     smb2.streams.basefile-rename-with-open-stream
     smb2.streams.create-disposition
     smb2.streams.dir

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -5178,6 +5178,16 @@ memfs_open_stream(
         inode->ctime       = now;
     }
 
+    /* Named streams share the base file's metadata (mode/owner/timestamps and
+     * DOS attributes).  When a stream open creates or overwrites the stream,
+     * apply the caller's requested attributes (e.g. the create's
+     * FileAttributes -> ARCHIVE/HIDDEN) to the base inode, mirroring how a
+     * regular create stamps them (smb2.streams.attributes2). */
+    if (request->open_stream.set_attr &&
+        (request->open_stream.r_created || (flags & CHIMERA_VFS_OPEN_TRUNCATE))) {
+        memfs_apply_attrs(inode, request->open_stream.set_attr);
+    }
+
     /* A stream open pins both the stream node and the base inode. */
     stream->refcnt++;
     inode->refcnt++;

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -5224,21 +5224,25 @@ memfs_list_streams(
     }
 
     /* Default unnamed data fork ("::$DATA"), reported first with an empty name
-     * so the SMB layer can format it as the default stream. */
-    rec = sizeof(entry);
-    if (offset + rec > max) {
-        pthread_mutex_unlock(&inode->lock);
-        request->status = CHIMERA_VFS_ERANGE;
-        request->complete(request);
-        return;
+     * so the SMB layer can format it as the default stream.  Only regular files
+     * have a data fork -- a directory reports no streams (smb2.streams.dir
+     * expects an empty stream list on a directory). */
+    if (S_ISREG(inode->mode)) {
+        rec = sizeof(entry);
+        if (offset + rec > max) {
+            pthread_mutex_unlock(&inode->lock);
+            request->status = CHIMERA_VFS_ERANGE;
+            request->complete(request);
+            return;
+        }
+        entry.size     = inode->size;
+        entry.alloc    = inode->space_used;
+        entry.name_len = 0;
+        memcpy(buf + offset, &entry, sizeof(entry));
+        offset += rec;
+        offset  = (offset + 7) & ~7u;
+        count++;
     }
-    entry.size     = inode->size;
-    entry.alloc    = inode->space_used;
-    entry.name_len = 0;
-    memcpy(buf + offset, &entry, sizeof(entry));
-    offset += rec;
-    offset  = (offset + 7) & ~7u;
-    count++;
 
     for (stream = inode->streams; stream; stream = stream->next) {
         rec = sizeof(entry) + stream->name_len;

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -337,6 +337,34 @@ memfs_stream_find_by_name(
     return NULL;
 } /* memfs_stream_find_by_name */
 
+/* Case-insensitive directory scan, used as a fallback when an exact (case-
+ * sensitive hash) lookup misses for an SMB/Windows (AUTH_ATTR) caller.  Windows
+ * opens are case-insensitive even on a volume that reports
+ * FILE_CASE_SENSITIVE_SEARCH (smb2.streams.names3 opens the file via its
+ * upper/lower-cased path).  O(n) in the directory size, so it is reached only
+ * on a miss; NFS/POSIX (AUTH_UNIX) callers keep strict case-sensitive semantics
+ * and never run it.  Caller holds the directory inode lock. */
+static inline struct memfs_dirent *
+memfs_dirent_find_ci(
+    struct memfs_inode *dir,
+    const char         *name,
+    uint32_t            name_len)
+{
+    struct memfs_dirent *dirent;
+
+    rb_tree_first(&dir->dir.dirents, dirent);
+
+    while (dirent) {
+        if (dirent->name_len == name_len &&
+            strncasecmp(dirent->name, name, name_len) == 0) {
+            return dirent;
+        }
+        dirent = rb_tree_next(&dir->dir.dirents, dirent);
+    }
+
+    return NULL;
+} /* memfs_dirent_find_ci */
+
 static inline struct memfs_named_stream *
 memfs_stream_find_by_id(
     struct memfs_inode *inode,
@@ -2109,6 +2137,12 @@ memfs_lookup_at(
 
     rb_tree_query_exact(&inode->dir.dirents, hash, hash, dirent);
 
+    /* Windows opens are case-insensitive: fall back to a case-insensitive scan
+     * for an SMB (AUTH_ATTR) caller when the exact match misses (names3). */
+    if (!dirent && request->cred->flavor == CHIMERA_VFS_AUTH_ATTR) {
+        dirent = memfs_dirent_find_ci(inode, name, namelen);
+    }
+
     if (!dirent) {
         pthread_mutex_unlock(&inode->lock);
         request->status = CHIMERA_VFS_ENOENT;
@@ -2696,6 +2730,15 @@ memfs_open_at(
     memfs_map_attrs(shared, &request->open_at.r_dir_pre_attr, parent_inode, request->fh);
 
     rb_tree_query_exact(&parent_inode->dir.dirents, hash, hash, dirent);
+
+    /* Windows opens are case-insensitive: an SMB (AUTH_ATTR) caller that misses
+     * the exact match falls back to a case-insensitive scan, so an existing
+     * file is opened (or collides on FILE_CREATE) regardless of the requested
+     * case (names3).  A genuine miss still creates the requested-case name. */
+    if (!dirent && request->cred->flavor == CHIMERA_VFS_AUTH_ATTR) {
+        dirent = memfs_dirent_find_ci(parent_inode, request->open_at.name,
+                                      request->open_at.namelen);
+    }
 
     if (!dirent) {
         if (!(flags & CHIMERA_VFS_OPEN_CREATE)) {

--- a/src/vfs/vfs.h
+++ b/src/vfs/vfs.h
@@ -162,6 +162,11 @@ struct chimera_vfs_thread_metrics {
 #define CHIMERA_VFS_OPEN_HANDLE_PENDING   0x2
 #define CHIMERA_VFS_OPEN_HANDLE_FILE_ID   0x4
 #define CHIMERA_VFS_OPEN_HANDLE_DETACHED  0x8
+/* A named-stream (ADS) handle.  Its file handle is distinct from the base
+ * file's, but its metadata (mode/owner/timestamps/DOS attributes) is the base
+ * inode's and mutates out-of-band relative to the stream fh, so the per-fh attr
+ * cache must not serve or store attributes for it (chimera_vfs_getattr). */
+#define CHIMERA_VFS_OPEN_HANDLE_STREAM    0x10
 
 #define CHIMERA_VFS_ACCESS_MODE_RW        0
 #define CHIMERA_VFS_ACCESS_MODE_RO        1

--- a/src/vfs/vfs_proc_getattr.c
+++ b/src/vfs/vfs_proc_getattr.c
@@ -16,7 +16,8 @@ chimera_vfs_getattr_complete(struct chimera_vfs_request *request)
     struct chimera_vfs_attr_cache *attr_cache = thread->vfs->vfs_attr_cache;
     chimera_vfs_getattr_callback_t callback   = request->proto_callback;
 
-    if (request->status == CHIMERA_VFS_OK) {
+    if (request->status == CHIMERA_VFS_OK &&
+        !(request->getattr.handle->flags & CHIMERA_VFS_OPEN_HANDLE_STREAM)) {
         chimera_vfs_attr_cache_refresh(thread, attr_cache,
                                        request->getattr.handle->fh_hash,
                                        request->getattr.handle->fh,
@@ -47,7 +48,8 @@ chimera_vfs_getattr(
     struct chimera_vfs_attrs       cached_attr;
     int                            rc;
 
-    if (!(req_attr_mask & ~(CHIMERA_VFS_ATTR_FH | CHIMERA_VFS_ATTR_MASK_CACHEABLE))) {
+    if (!(handle->flags & CHIMERA_VFS_OPEN_HANDLE_STREAM) &&
+        !(req_attr_mask & ~(CHIMERA_VFS_ATTR_FH | CHIMERA_VFS_ATTR_MASK_CACHEABLE))) {
         rc = chimera_vfs_attr_cache_lookup(attr_cache,
                                            handle->fh_hash,
                                            handle->fh,

--- a/src/vfs/vfs_proc_open_stream.c
+++ b/src/vfs/vfs_proc_open_stream.c
@@ -16,6 +16,10 @@ chimera_vfs_open_stream_hdl_callback(
 
     if (handle) {
         handle->r_created = request->open_stream.r_created;
+        /* Tag the handle so the attr cache is bypassed for it: a stream shares
+         * the base inode's metadata, which changes out-of-band relative to the
+         * stream fh (smb2.streams.attributes2). */
+        handle->flags |= CHIMERA_VFS_OPEN_HANDLE_STREAM;
     }
 
     chimera_vfs_complete(request);


### PR DESCRIPTION
## Summary

Greens `smb2.streams.names3`, bringing memfs named-stream (ADS) conformance to 13/14. Stacked on #877 (dir + attributes1) and #881 (attributes2) — those commits dedupe once they merge; this PR's net delta is the names3 fix.

Windows opens are case-insensitive even on a volume that advertises `FILE_CASE_SENSITIVE_SEARCH`. memfs resolved names by a case-sensitive hash, so opening a file via an upper/lower-cased path returned `OBJECT_PATH_NOT_FOUND`.

A case-insensitive directory scan (`memfs_dirent_find_ci`) is added as a fallback when the exact hash lookup misses, in both `memfs_lookup_at` (path components) and `memfs_open_at` (the leaf). It is gated to SMB/Windows callers (`CHIMERA_VFS_AUTH_ATTR`): NFS/POSIX (`AUTH_UNIX`) callers keep strict case-sensitive semantics and never run it. The scan is O(n) in the directory size but is only reached on a miss.

## Verification
- `smb2.streams.names3` green 3× on memfs (Debug + Release).
- No regressions: the `smb2.streams.*`, `smb2.create.*` (incl. `mkdir-dup`, `multi`, `leading-slash`) and `smb2.rename` suites stay green, and the pynfs memfs suite (41/41) is unaffected — case-sensitivity is preserved for NFS by the `AUTH_ATTR` gate.
- `make build_release`, scan-build, `make syntax`, copyright-year all pass.