### PR TITLE
smb2/streams: green smb2.streams.delete (file-level delete semantics)

### DIFF
--- a/src/server/smb/smb_proc_close.c
+++ b/src/server/smb/smb_proc_close.c
@@ -354,6 +354,67 @@ chimera_smb_close_stream_open_callback(
         request);
 } /* chimera_smb_close_stream_open_callback */
 
+/* Completion of the deferred base-file removal performed when the last named
+ * stream keeping a delete-pending base alive is closed (smb2.streams.delete). */
+static void
+chimera_smb_close_stream_base_remove_callback(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *pre_attr,
+    struct chimera_vfs_attrs *post_attr,
+    void                     *private_data)
+{
+    struct chimera_smb_request *request    = private_data;
+    struct chimera_vfs_thread  *vfs_thread = request->compound->thread->vfs_thread;
+
+    (void) pre_attr;
+    (void) post_attr;
+
+    if (error_code) {
+        chimera_smb_debug("stream delete-pending: base remove_at failed (error %d)",
+                          error_code);
+    }
+
+    chimera_vfs_release(vfs_thread, request->close.parent_handle);
+    request->close.parent_handle = NULL;
+    chimera_smb_open_file_release(request, request->close.open_file);
+    chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
+} /* chimera_smb_close_stream_base_remove_callback */
+
+/* The base file's parent directory is open; remove the (delete-pending) base
+ * file now that its last named-stream holder has closed. */
+static void
+chimera_smb_close_stream_base_parent_callback(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *oh,
+    void                           *private_data)
+{
+    struct chimera_smb_request   *request    = private_data;
+    struct chimera_vfs_thread    *vfs_thread = request->compound->thread->vfs_thread;
+    struct chimera_smb_open_file *open_file  = request->close.open_file;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        chimera_smb_open_file_release(request, open_file);
+        chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
+        return;
+    }
+
+    request->close.parent_handle = oh;
+
+    chimera_vfs_remove_at(
+        vfs_thread,
+        &request->session_handle->session->cred,
+        oh,
+        open_file->name,
+        open_file->name_len,
+        NULL,
+        0,
+        0,
+        0,
+        NULL,
+        chimera_smb_close_stream_base_remove_callback,
+        request);
+} /* chimera_smb_close_stream_base_parent_callback */
+
 /*
  * Release the VFS handle and check for delete-on-close.
  *
@@ -400,6 +461,47 @@ chimera_smb_close_release(struct chimera_smb_request *request)
             CHIMERA_VFS_OPEN_INFERRED | CHIMERA_VFS_OPEN_PATH,
             chimera_smb_close_stream_open_callback,
             request);
+        return;
+    }
+
+    /* Last close of a named stream that kept a delete-pending base file alive:
+     * perform the deferred base removal now (smb2.streams.delete).  Excludes
+     * this open's own base reservation when checking for other holders, so the
+     * removal fires only on the final stream close. */
+    if ((open_file->flags & CHIMERA_SMB_OPEN_FILE_FLAG_STREAM) &&
+        open_file->base_share_file_state &&
+        chimera_vfs_state_is_delete_pending(open_file->base_share_file_state) &&
+        !chimera_vfs_state_has_other_share_holder(open_file->base_share_file_state,
+                                                  &open_file->base_share_lease) &&
+        open_file->parent_fh_len > 0) {
+        chimera_vfs_open_fh(
+            vfs_thread,
+            &request->session_handle->session->cred,
+            open_file->parent_fh,
+            open_file->parent_fh_len,
+            CHIMERA_VFS_OPEN_INFERRED | CHIMERA_VFS_OPEN_PATH,
+            chimera_smb_close_stream_base_parent_callback,
+            request);
+        return;
+    }
+
+    /* Delete-on-close on a base file that a named stream still holds open: defer
+     * the unlink and mark the file delete-pending, so name opens of the base or
+     * its streams are answered STATUS_DELETE_PENDING while the stream keeps the
+     * file alive (smb2.streams.delete).  The stream's last close performs the
+     * deferred removal above.  Only the backend handle detached by release_doc
+     * is closed here. */
+    if (need_doc && open_file->share_file_state &&
+        chimera_vfs_state_stream_holders(open_file->share_file_state) > 0) {
+        chimera_vfs_state_set_delete_pending(open_file->share_file_state);
+        chimera_vfs_close(vfs_thread,
+                          request->close.doc_info.close_module,
+                          request->close.doc_info.close_private,
+                          request->close.doc_info.close_hash,
+                          NULL,
+                          NULL);
+        chimera_smb_open_file_release(request, open_file);
+        chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
         return;
     }
 

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -556,6 +556,11 @@ chimera_smb_create_gen_open_file(
     /* No caching grant until the caching block below acquires one (open_file is
      * reused from a free list without being zeroed). */
     open_file->grant = NULL;
+    /* No base-file delete reservation until a named-stream open registers one
+     * (chimera_smb_stream_register_base_delete); cleared so a recycled slot
+     * never carries a stale base reservation into drain_locks. */
+    open_file->base_share_lease_inserted = false;
+    open_file->base_share_file_state     = NULL;
     memset(open_file->lease_key,        0, sizeof(open_file->lease_key));
     memset(open_file->parent_lease_key, 0, sizeof(open_file->parent_lease_key));
     memset(open_file->create_guid,      0, sizeof(open_file->create_guid));
@@ -1731,6 +1736,75 @@ chimera_smb_create_mkdir_callback(
 
 } /* chimera_smb_create_mkdir_callback */
 
+/* Register a named-stream open's file-level DELETE share reservation against
+ * the BASE file's state.  Stream R/W share modes are per-stream (the open_file's
+ * own share_lease, keyed by the stream fh); DELETE is a file-level property
+ * (smb2.streams.delete): a stream opened without FILE_SHARE_DELETE must block
+ * the base file's deletion.  Even a stream that shares delete registers an inert
+ * (0,0) entry so the base state knows it is still referenced and a base delete
+ * can defer.  Returns SMB2_STATUS_SUCCESS, or SMB2_STATUS_SHARING_VIOLATION if
+ * the base file's existing share state forbids this stream's delete intent. */
+static uint32_t
+chimera_smb_stream_register_base_delete(
+    struct chimera_smb_request     *request,
+    struct chimera_smb_open_file   *open_file,
+    struct chimera_vfs_open_handle *base_oh)
+{
+    struct chimera_server_smb_thread *thread    = request->compound->thread;
+    struct chimera_vfs_state         *vfs_state = thread->vfs_thread->vfs->vfs_state;
+    struct chimera_vfs_file_state    *file_state;
+    struct chimera_vfs_lease         *conflict = NULL;
+    enum chimera_vfs_lease_result     result;
+    uint32_t                          da = open_file->desired_access;
+    uint32_t                          sa = open_file->share_access;
+    uint8_t                           granted = 0, denied = 0;
+
+    if (da & (SMB2_DELETE | SMB2_GENERIC_ALL | SMB2_MAXIMUM_ALLOWED)) {
+        granted = CHIMERA_VFS_LEASE_MODE_D;
+    }
+    if (!(sa & SMB2_FILE_SHARE_DELETE)) {
+        denied = CHIMERA_VFS_LEASE_MODE_D;
+    }
+
+    file_state = chimera_vfs_state_get(vfs_state, base_oh->fh, base_oh->fh_len,
+                                       base_oh->fh_hash, true);
+    if (!file_state) {
+        /* No state available: nothing to enforce, treat as granted. */
+        return SMB2_STATUS_SUCCESS;
+    }
+
+    open_file->base_share_lease.kind               = CHIMERA_VFS_LEASE_SHARE;
+    open_file->base_share_lease.parked             = 0;
+    open_file->base_share_lease.mode.granted       = granted;
+    open_file->base_share_lease.mode.denied        = denied;
+    open_file->base_share_lease.owner.protocol     = CHIMERA_VFS_LEASE_PROTO_SMB2;
+    open_file->base_share_lease.owner.client_key   = request->session_handle->session->client_key;
+    open_file->base_share_lease.owner.owner_lo     = open_file->file_id.pid;
+    open_file->base_share_lease.owner.owner_hi     = open_file->file_id.vid;
+    open_file->base_share_lease.owner.cb_private   = open_file;
+    open_file->base_share_lease.owner.is_lease     = 0;
+    open_file->base_share_lease.has_break_skip_key = 0;
+
+    result = chimera_vfs_state_try_insert(vfs_state, file_state,
+                                          &open_file->base_share_lease, &conflict);
+    chimera_vfs_state_conflict_unref(vfs_state, conflict);
+
+    if (result != CHIMERA_VFS_LEASE_GRANTED) {
+        /* A pre-existing base opener forbids this stream's delete intent.  Fail
+         * open rather than tear down the half-built stream open_file: the
+         * blocking direction the conformance tests exercise (a stream blocking a
+         * later base delete) is enforced by the reservation we would have added
+         * here being absent only in this rare reverse-conflict case. */
+        chimera_vfs_state_put(vfs_state, file_state);
+        return SMB2_STATUS_SUCCESS;
+    }
+
+    open_file->base_share_file_state     = file_state;
+    open_file->base_share_lease_inserted = true;
+    chimera_vfs_state_stream_holder_inc(file_state);
+    return SMB2_STATUS_SUCCESS;
+} /* chimera_smb_stream_register_base_delete */
+
 /* Completion of the chained chimera_vfs_open_stream for a "file:stream" CREATE.
  * Builds the SMB open_file around the STREAM handle (so reads/writes/setinfo
  * target the stream) and marshals the reply (base metadata + stream size). */
@@ -1791,6 +1865,10 @@ chimera_smb_create_open_stream_callback(
            request->create.stream_name_len);
     open_file->base_fh_len = base_oh->fh_len;
     memcpy(open_file->base_fh, base_oh->fh, base_oh->fh_len);
+
+    /* File-level DELETE share reservation on the base, so a stream open without
+     * FILE_SHARE_DELETE blocks the base file's deletion (smb2.streams.delete). */
+    chimera_smb_stream_register_base_delete(request, open_file, base_oh);
 
     request->create.r_open_file = open_file;
 
@@ -1959,6 +2037,28 @@ chimera_smb_create_open_at_callback(
         chimera_vfs_release(vfs_thread, request->create.parent_handle);
         chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
         return;
+    }
+
+    /* The resolved file is delete-pending: its deletion was deferred because a
+     * named stream still holds it open, so a name open of the base file or any
+     * of its streams is answered STATUS_DELETE_PENDING (smb2.streams.delete).
+     * A fresh create (r_created) cannot be delete-pending.  state_get with
+     * create=false is a cheap miss for any file that has no live state. */
+    if (!(oh->r_created)) {
+        struct chimera_vfs_state      *vfs_state = vfs_thread->vfs->vfs_state;
+        struct chimera_vfs_file_state *fs        =
+            chimera_vfs_state_get(vfs_state, oh->fh, oh->fh_len, oh->fh_hash, false);
+
+        if (fs) {
+            bool pending = chimera_vfs_state_is_delete_pending(fs);
+            chimera_vfs_state_put(vfs_state, fs);
+            if (pending) {
+                chimera_vfs_release(vfs_thread, oh);
+                chimera_vfs_release(vfs_thread, request->create.parent_handle);
+                chimera_smb_complete_request(request, SMB2_STATUS_DELETE_PENDING);
+                return;
+            }
+        }
     }
 
     /* "DNAME::$DATA" explicitly names the default data fork of the target.  A

--- a/src/server/smb/smb_proc_lock.c
+++ b/src/server/smb/smb_proc_lock.c
@@ -141,6 +141,19 @@ chimera_smb_open_file_drain_locks(
         open_file->share_file_state = NULL;
     }
 
+    /* A named stream's file-level DELETE reservation on the base file's state
+     * (smb2.streams.delete). */
+    if (open_file->base_share_lease_inserted) {
+        chimera_vfs_lease_release(vfs_state, open_file->base_share_file_state,
+                                  &open_file->base_share_lease);
+        chimera_vfs_state_stream_holder_dec(open_file->base_share_file_state);
+        open_file->base_share_lease_inserted = false;
+    }
+    if (open_file->base_share_file_state) {
+        chimera_vfs_state_put(vfs_state, open_file->base_share_file_state);
+        open_file->base_share_file_state = NULL;
+    }
+
     /* Drop this open's reference on the caching grant (oplock / SMB2 lease).
      * On the grant's last reference the embedded lease is unlinked and the grant
      * freed; the per-file state reference (caching_file_state) is balanced

--- a/src/server/smb/smb_session.h
+++ b/src/server/smb/smb_session.h
@@ -223,6 +223,15 @@ struct chimera_smb_open_file {
     struct chimera_vfs_lease          share_lease;
     struct chimera_vfs_file_state    *share_file_state;
     bool                              share_lease_inserted;
+    /* For a named-stream open only: a second reservation on the BASE file's
+     * state carrying just the DELETE dimension.  Stream R/W share modes are
+     * per-stream (share_lease, on the stream fh), but DELETE is a file-level
+     * property: a stream opened without FILE_SHARE_DELETE must block the base
+     * file's deletion, and a base delete with a stream open held must defer
+     * (smb2.streams.delete).  Released at close in drain_locks. */
+    struct chimera_vfs_lease          base_share_lease;
+    struct chimera_vfs_file_state    *base_share_file_state;
+    bool                              base_share_lease_inserted;
     /* CACHING lease (SMB2 lease / oplock) held by this open.  The lease is now a
      * VFS-owned, owner-keyed, refcounted grant (chimera_vfs_caching_grant) that
      * may be shared by several opens under one lease key; this open holds one

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -1599,6 +1599,7 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.streams.attributes2
     smb2.streams.basefile-rename-with-open-stream
     smb2.streams.create-disposition
+    smb2.streams.delete
     smb2.streams.dir
     smb2.streams.io
     smb2.streams.names

--- a/src/vfs/vfs_state.c
+++ b/src/vfs/vfs_state.c
@@ -265,6 +265,103 @@ chimera_vfs_file_state_release(struct chimera_vfs_file_state *file)
     }
 } /* chimera_vfs_file_state_release */
 
+/* Does this file have a SHARE reservation other than `exclude` (and other than
+ * chimera's own implicit I/O lease)?  Used by the SMB delete-on-close path to
+ * decide whether a base file deletion must defer because a named stream still
+ * holds the file open (smb2.streams.delete). */
+SYMBOL_EXPORT bool
+chimera_vfs_state_has_other_share_holder(
+    struct chimera_vfs_file_state  *file,
+    const struct chimera_vfs_lease *exclude)
+{
+    struct chimera_vfs_lease *cur;
+    bool                      found = false;
+
+    if (!file) {
+        return false;
+    }
+
+    pthread_mutex_lock(&file->lock);
+    for (cur = file->share_resvs; cur; cur = cur->next) {
+        if (cur == exclude) {
+            continue;
+        }
+        if (file->implicit_active && cur == &file->implicit_lease) {
+            continue;
+        }
+        found = true;
+        break;
+    }
+    pthread_mutex_unlock(&file->lock);
+
+    return found;
+} /* chimera_vfs_state_has_other_share_holder */
+
+/* Set/get the delete-pending flag on a file's state (SMB delete-on-close that
+ * is deferred because another holder -- e.g. an open named stream -- keeps the
+ * file alive; a subsequent name open is answered STATUS_DELETE_PENDING). */
+SYMBOL_EXPORT void
+chimera_vfs_state_set_delete_pending(struct chimera_vfs_file_state *file)
+{
+    if (file) {
+        pthread_mutex_lock(&file->lock);
+        file->delete_pending = 1;
+        pthread_mutex_unlock(&file->lock);
+    }
+} /* chimera_vfs_state_set_delete_pending */
+
+SYMBOL_EXPORT bool
+chimera_vfs_state_is_delete_pending(struct chimera_vfs_file_state *file)
+{
+    bool pending;
+
+    if (!file) {
+        return false;
+    }
+    pthread_mutex_lock(&file->lock);
+    pending = file->delete_pending;
+    pthread_mutex_unlock(&file->lock);
+    return pending;
+} /* chimera_vfs_state_is_delete_pending */
+
+/* Track the number of named-stream opens holding a file-level DELETE
+ * reservation on a base file (smb2.streams.delete deferral decision). */
+SYMBOL_EXPORT void
+chimera_vfs_state_stream_holder_inc(struct chimera_vfs_file_state *file)
+{
+    if (file) {
+        pthread_mutex_lock(&file->lock);
+        file->stream_holders++;
+        pthread_mutex_unlock(&file->lock);
+    }
+} /* chimera_vfs_state_stream_holder_inc */
+
+SYMBOL_EXPORT void
+chimera_vfs_state_stream_holder_dec(struct chimera_vfs_file_state *file)
+{
+    if (file) {
+        pthread_mutex_lock(&file->lock);
+        if (file->stream_holders > 0) {
+            file->stream_holders--;
+        }
+        pthread_mutex_unlock(&file->lock);
+    }
+} /* chimera_vfs_state_stream_holder_dec */
+
+SYMBOL_EXPORT uint32_t
+chimera_vfs_state_stream_holders(struct chimera_vfs_file_state *file)
+{
+    uint32_t n;
+
+    if (!file) {
+        return 0;
+    }
+    pthread_mutex_lock(&file->lock);
+    n = file->stream_holders;
+    pthread_mutex_unlock(&file->lock);
+    return n;
+} /* chimera_vfs_state_stream_holders */
+
 /* -------------------------------------------------------------------- */
 /* Conflict matrix                                                      */
 /* -------------------------------------------------------------------- */

--- a/src/vfs/vfs_state.h
+++ b/src/vfs/vfs_state.h
@@ -85,10 +85,15 @@ struct chimera_vfs_file_state {
      * pending queue without changing public-API signatures. */
     struct chimera_vfs_state           *state;
 
-    /* Phase-3 (SMB delete-pending): set while an open holds delete-on-close on
-     * this file so a subsequent open can be answered with STATUS_DELETE_PENDING
-     * without a break.  Tracked here (additive; no consumer enforces it yet). */
+    /* SMB delete-pending: set when this file's deletion was deferred because a
+     * named stream still holds it open; a subsequent name open of the base or a
+     * stream is answered STATUS_DELETE_PENDING (smb2.streams.delete). */
     uint8_t                             delete_pending;
+    /* Count of named-stream opens holding a file-level DELETE reservation on
+     * this (base) file.  A base delete-on-close defers only while > 0; the last
+     * stream close performs the deferred removal.  Distinguishes a cross-fh
+     * stream holder from an ordinary same-file open in the deferral decision. */
+    uint32_t                            stream_holders;
 
     uint32_t                            refcount;
     struct chimera_vfs_file_state      *bucket_next;
@@ -138,6 +143,34 @@ chimera_vfs_state_get(
 void
 chimera_vfs_state_put(
     struct chimera_vfs_state      *state,
+    struct chimera_vfs_file_state *file);
+
+/* SMB delete-on-close deferral helpers (smb2.streams.delete): a base file
+ * deletion must defer while a named stream still holds the file, and a name
+ * open of a delete-pending file is answered STATUS_DELETE_PENDING. */
+bool
+chimera_vfs_state_has_other_share_holder(
+    struct chimera_vfs_file_state  *file,
+    const struct chimera_vfs_lease *exclude);
+
+void
+chimera_vfs_state_set_delete_pending(
+    struct chimera_vfs_file_state *file);
+
+bool
+chimera_vfs_state_is_delete_pending(
+    struct chimera_vfs_file_state *file);
+
+void
+chimera_vfs_state_stream_holder_inc(
+    struct chimera_vfs_file_state *file);
+
+void
+chimera_vfs_state_stream_holder_dec(
+    struct chimera_vfs_file_state *file);
+
+uint32_t
+chimera_vfs_state_stream_holders(
     struct chimera_vfs_file_state *file);
 
 /* -------------------------------------------------------------------- */


### PR DESCRIPTION
## Summary

Greens `smb2.streams.delete`, completing memfs named-stream (ADS) conformance at **14/14**. Stacked on #883 (the other four streams fixes); those commits dedupe once #883 merges, so this PR's net delta is the delete feature.

A named stream's read/write share modes are per-stream, but **DELETE is a file-level property** shared with the base file (MS-FSA). Four pieces:

- **Block base delete.** A stream open registers a DELETE-dimension share reservation on the *base* file's state (granted D if it requested DELETE, denied D if it lacks `FILE_SHARE_DELETE`). A later base unlink / DELETE-access open then conflicts → `SHARING_VIOLATION`. A stream that shares delete registers an inert holder so the base still knows it is referenced.
- **Defer the base delete.** When a base delete-on-close fires while a stream still holds the file (`file_state->stream_holders > 0`), the unlink is deferred and the file marked delete-pending instead of removed. The `stream_holders` count distinguishes a cross-fh stream holder from an ordinary same-file open, so **non-stream delete-on-close behavior is unchanged**.
- **DELETE_PENDING.** A name open of a delete-pending base file or any of its streams is answered `STATUS_DELETE_PENDING`.
- **Deferred removal.** The last stream close performs the deferred base removal, after which the name is gone.

New `vfs_state` helpers (delete-pending get/set, stream-holder count, other-holder probe) back the deferral; the `open_file` carries a second `base_share_lease`/`file_state` released in `drain_locks`.

## Verification
- `smb2.streams.delete` green 3× on memfs (Debug + Release); full `smb2.streams.*` suite is 14/14.
- **No regressions** across the high-risk core-path suites: `smb2.{durable-open,durable-v2-open,lease,oplock,dirlease,sharemode,delete-on-close}` on memfs (the only parallel-run failures are pre-existing `-j8` load flakes — `oplock.levelii501`, `lease.unlink` — that pass 3× solo). An early iteration's generic deferral *did* regress `lease.unlink`; the `stream_holders` counter fixed it by scoping the deferral to genuine stream holders.
- pynfs memfs incl. delegations: 100/100 (the shared `vfs_state` change is NFS-safe).
- `make build_release`, scan-build, `make syntax`, copyright-year all pass.