### PR TITLE
nfs4 client: fix sequential server remount; enable EROFS test over NFS4

### DIFF
--- a/src/posix/tests/CMakeLists.txt
+++ b/src/posix/tests/CMakeLists.txt
@@ -281,14 +281,25 @@ macro(add_posix_erofs_test nfs_prefix nfs_backend)
     endif()
 endmacro()
 
-# Registered for nfs3_memfs only.  The test exercises the protocol-agnostic VFS
-# read-only gate; NFS3 over memfs makes that gate observable cleanly.  It is not
-# registered for NFS4 (the NFS4 client's mount/RECLAIM_COMPLETE path crashes when
-# a second export of the same backend is present in the server -- a pre-existing
-# client-side issue unrelated to the read-only enforcement) nor for backends
-# whose mount_id derivation for a subdirectory mount does not differ from the
-# parent mount (so the read-only sub-mount cannot be distinguished).
+# The test exercises the protocol-agnostic VFS read-only gate by mounting a
+# writable export and then a read-only sub-export of the same backend (in
+# sequence).  Registered over BOTH NFS3 and NFS4 for memfs.
+#
+# It is intentionally memfs-only.  The VFS read-only gate keys on the mount_id
+# (the first bytes of the mount's root_fh).  memfs encodes a distinct root_fh
+# for the read-only subdirectory mount, so the "ro" flag attaches only to that
+# mount.  cairn / diskfs / linux / io_uring derive a root_fh for a subdirectory
+# mount whose mount_id does not reliably differ from the parent root mount, so
+# the "ro" flag bleeds onto the writable mount (fixture creation then fails with
+# EROFS) -- making the sub-mount indistinguishable.  Giving those backends a
+# distinct sub-mount identity is a separate VFS change.
+#
+# The NFS4 registration also exercises (and depends on) the client mount/session
+# lifecycle fix for a sequential remount of the same server: each mount now
+# opens its own connection, and the NFSv4.1 session outlives an individual mount
+# instead of being torn down and recreated under the live per-thread slot tables.
 add_posix_erofs_test(nfs3 memfs)
+add_posix_erofs_test(nfs4 memfs)
 
 # ============================================================================
 # NFS3 over TCP-RDMA Backend Tests

--- a/src/vfs/nfs/nfs4_mount.c
+++ b/src/vfs/nfs/nfs4_mount.c
@@ -637,12 +637,22 @@ chimera_nfs4_mount(
     thread->server_threads[server->index] = server_thread;
 
     if (need_discover) {
-        enum evpl_protocol_id proto;
-
-        /* Create NFS endpoint and connect */
+        /* First mount to this server: create the shared endpoint. */
         server->nfs_endpoint = evpl_endpoint_create(server->hostname, server->nfs_port);
+    }
 
-        proto = server->use_rdma ? server->rdma_protocol : server_thread->shared->tcp_protocol;
+    /*
+     * Every mount opens its OWN transient connection to the server.  The NFSv4.1
+     * session and back channel live on the persistent control connection; this
+     * connection only carries RECLAIM_COMPLETE + the root-FH lookup, which bind
+     * to the session via bind-on-SEQUENCE.  A prior mount to the same server may
+     * have come and gone (the control connection keeps the server alive), so a
+     * reused server still needs a fresh connection here -- otherwise
+     * server_thread->nfs_conn is NULL and RECLAIM_COMPLETE dereferences it.
+     */
+    {
+        enum evpl_protocol_id proto = server->use_rdma
+            ? server->rdma_protocol : shared->tcp_protocol;
 
         server_thread->nfs_conn = evpl_rpc2_client_connect(
             thread->rpc2_thread,
@@ -660,7 +670,7 @@ chimera_nfs4_mount(
 
         chimera_nfsclient_info("NFS4 connecting to %s:%d", server->hostname, server->nfs_port);
 
-        /* Send NULL call to verify connection */
+        /* Send NULL call to verify the connection, then proceed to mount. */
         shared->nfs_v4.send_call_NFSPROC4_NULL(
             &shared->nfs_v4.rpc2,
             thread->evpl,
@@ -669,8 +679,5 @@ chimera_nfs4_mount(
             0, 0, NULL, 0, 0,
             chimera_nfs4_mount_null_callback,
             request);
-    } else {
-        /* Server already discovered, proceed with mount */
-        chimera_nfs4_mount_process_mount(server_thread, request);
     }
 } /* chimera_nfs4_mount */

--- a/src/vfs/nfs/nfs4_umount.c
+++ b/src/vfs/nfs/nfs4_umount.c
@@ -22,14 +22,15 @@ chimera_nfs4_umount(
 
     server->refcnt--;
 
-    /* Free session when last mount is removed.  Per-thread slot tables are
-     * freed in chimera_nfs_thread_destroy (they live on the server_threads). */
-    if (server->refcnt == 0 && server->nfs4_session) {
-        chimera_nfs4_session_pool_destroy(server->nfs4_session);
-        pthread_mutex_destroy(&server->nfs4_session->lock);
-        free(server->nfs4_session);
-        server->nfs4_session = NULL;
-    }
+    /*
+     * The server (and its persistent back-channel control connection) outlives
+     * an individual mount, so the NFSv4.1 session is kept alive here even when
+     * the last mount is removed: a subsequent mount of the same server reuses
+     * it (see chimera_nfs4_cb_control_doorbell).  Tearing it down on refcnt==0
+     * would force a CREATE_SESSION on remount while per-thread slot tables still
+     * reference the old session -- corrupting the slot pool.  The session and
+     * its slot pool are freed once, with the server, in chimera_nfs_destroy.
+     */
 
     pthread_mutex_unlock(&shared->lock);
 


### PR DESCRIPTION
## Summary

Extends EROFS read-only-enforcement coverage from NFS3 to NFS4, and fixes two NFS4-client bugs that the NFS4 `mount → umount → mount` sequence exposed.

The NFS4 client keeps a discovered server (and its persistent back-channel control connection) alive across umount, but two code paths assumed every mount was the first one to a freshly-discovered server:

- **NULL connection on remount.** The per-mount transient connection was established only on the discovery path. A second mount of an already-discovered server proceeded to `RECLAIM_COMPLETE` with `server_thread->nfs_conn == NULL`, crashing in `send_call_NFSPROC4_COMPOUND`. Each mount now opens its own connection (binding to the session via `SEQUENCE`), regardless of whether the server was just discovered.

- **Session torn down under live slot tables.** `umount` destroyed the NFSv4.1 session when the last mount went away, even though the server itself persists. A later mount then issued a fresh `CREATE_SESSION` and re-initialised the session slot pool while per-thread slot tables still referenced the old session, overrunning the slot-id arrays at teardown (heap-buffer-overflow). The session now lives as long as the server and is freed once — with the server — in `chimera_nfs_destroy`; a remount reuses it.

## Test

Registers the EROFS test over NFS4 (`erofs_nfs4_memfs`), which exercises exactly the sequential-remount sequence above, alongside the existing `erofs_nfs3_memfs`.

It remains **memfs-only** for the same reason it is over NFS3: the VFS read-only gate keys on the mount_id (derived from the mount's root_fh), and only memfs gives a read-only *subdirectory* sub-mount a mount_id distinct from its parent root mount. On cairn / diskfs / linux / io_uring the `ro` flag bleeds onto the writable mount (writable-side fixture creation fails with EROFS). Giving those backends a distinct sub-mount identity is a separate VFS change.

## Verification

- Full NFS4 pjd suite + erofs: 100% (500/500).
- `erofs_nfs3_memfs` and `erofs_nfs4_memfs`: 3/3 each, no crashes.
- `make syntax` clean, copyright-year clean, scan-build clean on changed files, reuse lint compliant.