### PR TITLE
io_uring: resolve open fh from the open fd, not by name (fix #733 open_at no-fh abort)

### DIFF
--- a/src/vfs/io_uring/io_uring.c
+++ b/src/vfs/io_uring/io_uring.c
@@ -522,26 +522,34 @@ chimera_io_uring_reap(
                     }
                 } else if (handle->slot == 1) {
                     if (cqe->res == 0) {
+                        int fhrc;
+
                         dir_stx = (struct statx *) request->plugin_data;
                         stx     = (struct statx *) (dir_stx + 1);
-                        name    = (char *) (stx + 1);
 
-                        if (request->open_at.flags & CHIMERA_VFS_OPEN_NOFOLLOW) {
-                            chimera_linux_map_child_attrs_statx(CHIMERA_VFS_FH_MAGIC_IO_URING,
-                                                                request,
-                                                                &request->open_at.r_attr,
-                                                                request->open_at.r_vfs_private,
-                                                                "",
-                                                                stx);
-                        } else {
-                            parent_fd = request->open_at.handle->vfs_private;
+                        /* Resolve the returned fh from the open fd itself
+                         * (AT_EMPTY_PATH) rather than by name under parent_fd.
+                         * The child statx executes in the kernel when the SQE
+                         * runs, but the fh lookup (name_to_handle_at) runs
+                         * synchronously here, much later under load -- a
+                         * concurrent unlink/rename of the name in that window
+                         * makes a by-name lookup fail (ENOENT) while statx had
+                         * succeeded, which would leave r_attr without ATTR_FH
+                         * yet status == OK and trip the "no fh returned" abort
+                         * in vfs_proc_open_at.  The fd we hold open pins the
+                         * inode, so resolving via the fd cannot race the name.
+                         * The symlink-leaf attrs still come from the by-name
+                         * statx in stx; only the fh source changes. */
+                        fhrc = chimera_linux_map_child_attrs_statx(
+                            CHIMERA_VFS_FH_MAGIC_IO_URING,
+                            request,
+                            &request->open_at.r_attr,
+                            request->open_at.r_vfs_private,
+                            "",
+                            stx);
 
-                            chimera_linux_map_child_attrs_statx(CHIMERA_VFS_FH_MAGIC_IO_URING,
-                                                                request,
-                                                                &request->open_at.r_attr,
-                                                                parent_fd,
-                                                                name,
-                                                                stx);
+                        if (fhrc != CHIMERA_VFS_OK) {
+                            request->status = fhrc;
                         }
                     } else {
                         request->status = chimera_linux_errno_to_status(-cqe->res);


### PR DESCRIPTION
## Problem

Under SMB2 bench load on the **io_uring** backend, the daemon fatally aborts:

```
fatal module=vfs  src/vfs/vfs_proc_open_at.c
  "open_at: no fh returned from vfs module"
```

`vfs_proc_open_at` asserts that a successful (`CHIMERA_VFS_OK`) open populated the
returned file handle (`CHIMERA_VFS_ATTR_FH`). The io_uring backend reaches that
assertion having completed the open as success but with no fh set. Tracker #733.

## Root cause

`chimera_io_uring_open_at` completes in stages reaped from the CQE ring:

1. slot 0 — the `openat()`
2. on its completion, `open_at_finish` sets `request->status = CHIMERA_VFS_OK` and
   submits a child `statx` (slot 1) and a parent `statx` (slot 2)
3. slot 1's handler maps the returned attributes **and resolves the file handle**

The slot-1 handler resolved the fh **by name under the parent fd**
(`name_to_handle_at(parent_fd, name, ...)` via `chimera_linux_map_child_attrs_statx`).
The `statx` runs in the kernel when the SQE executes, but the `name_to_handle_at`
runs **synchronously in the reap handler** — which, under CPU contention, can be
much later. If the name is unlinked/renamed in that window, the by-name lookup
fails `ENOENT` even though the `statx` had succeeded.
`chimera_linux_map_child_attrs_statx` then returns an error that the caller
**ignored**, so `r_attr` never gets `ATTR_FH` while `status` stays `OK` → the abort.

This is **io_uring-specific**: the linux backend issues `statx` and
`name_to_handle_at` back-to-back synchronously, so its race window is negligible.
The io_uring async statx + deferred-reap lookup widens it enough to hit under load.

Minimal isolated proof of the mechanism on the share filesystem (tmpfs/`/dev/shm`,
which the io_uring suite uses) — statx the child, unlink the name, then resolve:

```
by-name after unlink: rc=-1 errno=No such file or directory   <- old path -> no fh -> abort
by-fd  after unlink: rc=0  errno=OK                            <- new path -> fh ok
```

## Fix

Resolve the fh from the **open fd itself** via `AT_EMPTY_PATH` (exactly what the
existing `O_NOFOLLOW` branch already did) instead of by name under the parent.
The fd we hold open pins the inode, so the lookup cannot race a concurrent
unlink/rename of the name. The symlink-leaf attributes still come from the
by-name child `statx`; only the fh source changes. A residual lookup failure is
now propagated into `request->status` instead of being dropped, so it returns a
clean error rather than tripping the assertion.

## Verification

- Mechanism proof above (by-name fails / by-fd succeeds after unlink on tmpfs).
- `smb2.bench.{echo,path-contention-shared,read,session-setup}` on io_uring,
  repeated loops under all-core CPU saturation (Debug/ASan + Release): clean, no
  fatal, no ASan reports.
- All 522 `server/smb/smbtorture_*_io_uring` suites pass (Debug/ASan).
- All 620 non-KVM `chimera/posix/*_io_uring` tests pass (Debug/ASan), including
  the symlink/create suites that exercise the changed path.
- memfs and linux bench suites unaffected.
- `make syntax` clean; `etc/copyright-year.sh --base upstream/main` clean.

Ref #733
