### PR TITLE
diskfs: fix data loss on redirect write over fragmented edge blocks

### DIFF
--- a/src/vfs/diskfs/diskfs_internal.h
+++ b/src/vfs/diskfs/diskfs_internal.h
@@ -277,6 +277,12 @@ struct diskfs_request_private {
     /* Carried across the async prefix/suffix lookups + trim walk. */
     int                         need_prefix_read;
     int                         need_suffix_read;
+    /* Redirect-write edge reconstruction (diskfs_write_recon_*): which edge
+     * block is being rebuilt (0 = prefix, 1 = suffix) and whether its extent
+     * walk is still running, so a read completion that drains the in-flight
+     * reads to zero does not advance past a walk that has more reads to issue. */
+    int                         recon_edge;
+    int                         recon_walking;
     /* Set when the write hit a single already-WRITTEN extent fully covering the
      * range (in-place overwrite, extent map untouched): the only inode change
      * is the mtime/ctime bump, so a non-FILE_SYNC write can defer it. */

--- a/src/vfs/diskfs/diskfs_io.c
+++ b/src/vfs/diskfs/diskfs_io.c
@@ -266,24 +266,32 @@ diskfs_write_trim_start(
     struct chimera_vfs_request *request);
 
 static void
-diskfs_write_suffix_cb(
+diskfs_write_recon_edge(
+    struct chimera_vfs_request *request);
+
+static void
+diskfs_write_recon_next(
+    struct chimera_vfs_request *request);
+
+static void
+diskfs_write_recon_process(
+    struct chimera_vfs_request *request);
+
+static void
+diskfs_write_recon_advance(
+    struct chimera_vfs_request *request);
+
+static void
+diskfs_write_recon_walk_cb(
     struct diskfs_bt_op *op,
     int                  result,
     void                *private_data);
 
 static void
-diskfs_write_suffix_lookup(
-    struct chimera_vfs_request *request);
-
-static void
-diskfs_write_prefix_cb(
-    struct diskfs_bt_op *op,
-    int                  result,
-    void                *private_data);
-
-static void
-diskfs_write_prefix_lookup(
-    struct chimera_vfs_request *request);
+diskfs_write_recon_read_cb(
+    struct evpl *evpl,
+    int          status,
+    void        *private_data);
 
 static void
 diskfs_write_inode_cb(
@@ -2277,127 +2285,330 @@ diskfs_write_trim_start(struct chimera_vfs_request *request)
 } /* diskfs_write_trim_start */
 
 
+/*
+ * Redirect-write edge reconstruction.
+ *
+ * The redirect path (hole / partial / multi-extent write) replaces the
+ * block-aligned region [aligned_start, aligned_end) with a single freshly
+ * allocated extent.  The two sub-block remainders the write data does not
+ * cover -- the prefix [aligned_start, write_start) in the first block and the
+ * suffix [write_end, aligned_end) in the last block -- must carry over the
+ * file's current contents so the redirect does not disturb bytes outside the
+ * written range.
+ *
+ * An edge block can be fragmented at sub-block boundaries: a DEALLOCATE trims
+ * an extent to a raw byte offset, leaving a written piece adjacent to an
+ * unwritten piece or a hole inside one block.  A single floor() lookup cannot
+ * reconstruct that -- the old code read one extent and zero-filled the rest,
+ * dropping any data past that extent's end.  Instead, rebuild each
+ * edge block exactly as a read would: walk every extent the block overlaps into
+ * a zero-initialized 4 KiB block buffer (written -> device read, unwritten /
+ * hole -> left zero).  diskfs_write_phase2 then slices the prefix and suffix
+ * bytes it needs out of rmw_prefix_iov / rmw_suffix_iov.  The walk runs before
+ * the trim, while the old extents and their backing are still intact.
+ */
 static void
-diskfs_write_suffix_cb(
-    struct diskfs_bt_op *op,
-    int                  result,
-    void                *private_data)
-{
-    struct chimera_vfs_request    *request   = private_data;
-    struct diskfs_request_private *p         = request->plugin_data;
-    int                            have      = diskfs_ext_from_op(op, result, &p->ext_iter);
-    uint64_t                       write_end = request->write.offset + request->write.length;
-    uint64_t                       aend      = p->rmw_aligned_start + p->rmw_aligned_length;
-
-    diskfs_bt_op_free(p->thread, op);
-
-    if (have && p->ext_iter.file_offset <= write_end &&
-        write_end < p->ext_iter.file_offset + p->ext_iter.length) {
-        uint64_t ee = p->ext_iter.file_offset + p->ext_iter.length;
-
-        if (ee >= aend) {
-            p->rmw_suffix_valid = p->rmw_suffix_len;
-        } else if (ee > write_end) {
-            p->rmw_suffix_valid = ee - write_end;
-        } else {
-            p->rmw_suffix_valid = 0;
-        }
-
-        /* Read the block-aligned device offset that physically holds write_end.
-         * The extent maps file write_end to device_offset + (write_end -
-         * file_offset); rounding that down to a block gives a 4 KiB-aligned
-         * read (required by O_DIRECT/libaio) whose write_end byte sits at
-         * index (write_end & 4095) -- so no separate adjust is needed even
-         * when the extent starts mid-block (e.g. a punch-created extent whose
-         * file_offset/device_offset are unaligned but congruent mod 4096). */
-        p->need_suffix_read     = 1;
-        p->suffix_device_id     = p->ext_iter.device_id;
-        p->suffix_device_offset = (p->ext_iter.device_offset +
-                                   (write_end - p->ext_iter.file_offset)) & ~4095ULL;
-        p->rmw_suffix_adjust = 0;
-    }
-
-    diskfs_write_trim_start(request);
-} /* diskfs_write_suffix_cb */
-
-
-static void
-diskfs_write_suffix_lookup(struct chimera_vfs_request *request)
-{
-    struct diskfs_request_private *p         = request->plugin_data;
-    struct diskfs_thread          *thread    = p->thread;
-    uint64_t                       write_end = request->write.offset + request->write.length;
-    struct diskfs_bt_op           *op;
-
-    if (p->rmw_suffix_len == 0) {
-        diskfs_write_trim_start(request);
-        return;
-    }
-
-    op = diskfs_bt_op_alloc(thread);
-    if (diskfs_ext_floor_async(op, thread, p->inode_stash[0], write_end, p->rec_scratch,
-                               sizeof(p->rec_scratch), diskfs_write_suffix_cb, request)) {
-        diskfs_write_suffix_cb(op, op->result, request);
-    }
-} /* diskfs_write_suffix_lookup */
-
-
-static void
-diskfs_write_prefix_cb(
+diskfs_write_recon_walk_cb(
     struct diskfs_bt_op *op,
     int                  result,
     void                *private_data)
 {
     struct chimera_vfs_request    *request = private_data;
     struct diskfs_request_private *p       = request->plugin_data;
-    int                            have    = diskfs_ext_from_op(op, result, &p->ext_iter);
-    uint64_t                       astart  = p->rmw_aligned_start;
 
+    p->loop_have = diskfs_ext_from_op(op, result, &p->ext_iter);
     diskfs_bt_op_free(p->thread, op);
-
-    if (have && p->ext_iter.file_offset <= astart &&
-        astart < p->ext_iter.file_offset + p->ext_iter.length) {
-        uint64_t ee = p->ext_iter.file_offset + p->ext_iter.length;
-
-        if (ee >= astart + p->rmw_prefix_len) {
-            p->rmw_prefix_valid = p->rmw_prefix_len;
-        } else if (ee > astart) {
-            p->rmw_prefix_valid = ee - astart;
-        } else {
-            p->rmw_prefix_valid = 0;
-        }
-
-        if (p->rmw_prefix_valid > 0) {
-            p->need_prefix_read     = 1;
-            p->prefix_device_id     = p->ext_iter.device_id;
-            p->prefix_device_offset = p->ext_iter.device_offset +
-                (astart - p->ext_iter.file_offset);
-        }
-    }
-
-    diskfs_write_suffix_lookup(request);
-} /* diskfs_write_prefix_cb */
+    diskfs_write_recon_process(request);
+} /* diskfs_write_recon_walk_cb */
 
 
 static void
-diskfs_write_prefix_lookup(struct chimera_vfs_request *request)
+diskfs_write_recon_advance(struct chimera_vfs_request *request)
 {
     struct diskfs_request_private *p      = request->plugin_data;
     struct diskfs_thread          *thread = p->thread;
-    struct diskfs_bt_op           *op;
+    struct diskfs_bt_op           *op     = diskfs_bt_op_alloc(thread);
 
-    if (p->rmw_prefix_len == 0) {
-        diskfs_write_suffix_lookup(request);
+    if (diskfs_ext_next_async(op, thread, p->inode_stash[0], p->ext_iter.file_offset,
+                              p->rec_scratch, sizeof(p->rec_scratch),
+                              diskfs_write_recon_walk_cb, request)) {
+        diskfs_write_recon_walk_cb(op, op->result, request);
+    }
+} /* diskfs_write_recon_advance */
+
+
+static void
+diskfs_write_recon_read_cb(
+    struct evpl *evpl,
+    int          status,
+    void        *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+    struct diskfs_thread          *thread  = p->thread;
+
+    (void) evpl;
+
+    if (status && p->status == 0) {
+        p->status = status;
+    }
+
+    p->pending--;
+    diskfs_pending_io_add(thread, -1);
+    diskfs_io_resume_waiters(thread);
+
+    /* Advance only once the walk has issued all its reads and they are done. */
+    if (p->pending == 0 && !p->recon_walking) {
+        diskfs_write_recon_next(request);
+    }
+} /* diskfs_write_recon_read_cb */
+
+
+static void
+diskfs_write_recon_process(struct chimera_vfs_request *request)
+{
+    struct diskfs_request_private *p           = request->plugin_data;
+    struct diskfs_thread          *thread      = p->thread;
+    struct diskfs_shared          *shared      = thread->shared;
+    struct evpl                   *evpl        = thread->evpl;
+    struct diskfs_extent          *extent      = &p->ext_iter;
+    uint64_t                       read_offset = p->loop_off;
+    uint64_t                       read_left   = p->loop_left;
+    uint64_t                       block_end   = p->loop_pos;
+    uint64_t                       extent_end, overlap_start, overlap_length, chunk;
+    uint32_t                       chunk_niov;
+    struct evpl_iovec             *chunk_iov;
+
+    if (!(read_left && p->loop_have && extent->file_offset < block_end)) {
+        /* Walk done for this edge block.  Trailing bytes (no extent) stay zero
+         * because the block buffer was zero-initialized. */
+        p->recon_walking = 0;
+        if (p->pending == 0) {
+            diskfs_write_recon_next(request);
+        }
         return;
     }
 
-    op = diskfs_bt_op_alloc(thread);
-    if (diskfs_ext_floor_async(op, thread, p->inode_stash[0], p->rmw_aligned_start,
-                               p->rec_scratch, sizeof(p->rec_scratch),
-                               diskfs_write_prefix_cb, request)) {
-        diskfs_write_prefix_cb(op, op->result, request);
+    /* Bound in-flight data I/O; park (state is fully in p) and resume the walk
+     * from a completion if the queue is at the cap. */
+    if (diskfs_io_gate(thread, request, diskfs_write_recon_process)) {
+        return;
     }
-} /* diskfs_write_prefix_lookup */
+
+    if (read_offset < extent->file_offset) {
+        chunk = extent->file_offset - read_offset;
+        if (chunk > read_left) {
+            chunk = read_left;
+        }
+        evpl_iovec_cursor_zero(&p->rd_cursor, chunk);
+        read_offset += chunk;
+        read_left   -= chunk;
+    }
+
+    extent_end     = extent->file_offset + extent->length;
+    overlap_start  = read_offset - extent->file_offset;
+    overlap_length = extent_end - read_offset;
+    if (overlap_length > read_left) {
+        overlap_length = read_left;
+    }
+
+    if (extent->flags & DISKFS_EXT_UNWRITTEN) {
+        /* Reserved but never written: reads back as zeros, no device I/O. */
+        evpl_iovec_cursor_zero(&p->rd_cursor, overlap_length);
+        read_offset   += overlap_length;
+        read_left     -= overlap_length;
+        overlap_length = 0;
+    }
+
+    while (overlap_length) {
+        uint64_t dev_offset;
+        uint32_t dev_pad, total;
+        int      pad_niov = 0;
+
+        if (overlap_length > shared->devices[extent->device_id].max_request_size) {
+            chunk = shared->devices[extent->device_id].max_request_size;
+        } else {
+            chunk = overlap_length;
+        }
+
+        chunk_iov  = &p->iov[p->niov];
+        dev_offset = extent->device_offset + overlap_start;
+        dev_pad    = (uint32_t) (dev_offset & 4095ULL);
+
+        if (dev_pad) {
+            evpl_iovec_clone_segment(&chunk_iov[0], &thread->pad, 0, dev_pad);
+            pad_niov    = 1;
+            dev_offset -= dev_pad;
+        }
+
+        chunk_niov = evpl_iovec_cursor_move(&p->rd_cursor, &chunk_iov[pad_niov],
+                                            32, chunk, 1);
+        chunk_niov += pad_niov;
+
+        total = dev_pad + chunk;
+        if (total & 4095) {
+            evpl_iovec_clone_segment(&chunk_iov[chunk_niov], &thread->pad, 0,
+                                     4096 - (total & 4095));
+            chunk_niov++;
+        }
+
+        p->niov += chunk_niov;
+        p->pending++;
+        diskfs_pending_io_add(thread, 1);
+
+        diskfs_metric_block_io(thread, DISKFS_METRIC_IO_READ,
+                               DISKFS_METRIC_IO_RMW, chunk);
+        diskfs_metric_block_io_device(thread, extent->device_id,
+                                      DISKFS_METRIC_IO_READ,
+                                      DISKFS_METRIC_IO_RMW, chunk);
+        evpl_block_read(evpl, thread->queue[extent->device_id], chunk_iov,
+                        chunk_niov, dev_offset, diskfs_write_recon_read_cb, request);
+
+        overlap_length -= chunk;
+        overlap_start  += chunk;
+        read_offset    += chunk;
+        read_left      -= chunk;
+    }
+
+    p->loop_off  = read_offset;
+    p->loop_left = read_left;
+
+    diskfs_write_recon_advance(request);
+} /* diskfs_write_recon_process */
+
+
+static void
+diskfs_write_recon_first_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request     = private_data;
+    struct diskfs_request_private *p           = request->plugin_data;
+    struct diskfs_thread          *thread      = p->thread;
+    uint64_t                       block_start = p->loop_off;
+    int                            have        = diskfs_ext_from_op(op, result, &p->ext_iter);
+
+    diskfs_bt_op_free(thread, op);
+
+    if (have && p->ext_iter.file_offset + p->ext_iter.length <= block_start) {
+        /* Floor extent ends at/before the block: start at the next extent. */
+        diskfs_write_recon_advance(request);
+        return;
+    }
+    if (!have) {
+        /* No extent at/before the block start; find the first one after it. */
+        op = diskfs_bt_op_alloc(thread);
+        if (diskfs_ext_ceil_async(op, thread, p->inode_stash[0], block_start,
+                                  p->rec_scratch, sizeof(p->rec_scratch),
+                                  diskfs_write_recon_walk_cb, request)) {
+            diskfs_write_recon_walk_cb(op, op->result, request);
+        }
+        return;
+    }
+
+    p->loop_have = 1;
+    diskfs_write_recon_process(request);
+} /* diskfs_write_recon_first_cb */
+
+
+/* Begin rebuilding the current edge block (p->recon_edge: 0 = prefix first
+ * block, 1 = suffix last block). */
+static void
+diskfs_write_recon_edge(struct chimera_vfs_request *request)
+{
+    struct diskfs_request_private *p      = request->plugin_data;
+    struct diskfs_thread          *thread = p->thread;
+    struct evpl                   *evpl   = thread->evpl;
+    uint64_t                       aend   = p->rmw_aligned_start + p->rmw_aligned_length;
+    struct evpl_iovec             *buf;
+    uint64_t                       block_start;
+    struct diskfs_bt_op           *op;
+
+    if (p->recon_edge == 0) {
+        if (p->rmw_prefix_len == 0) {
+            p->recon_edge = 1;
+            diskfs_write_recon_edge(request);
+            return;
+        }
+        buf                 = &p->rmw_prefix_iov;
+        block_start         = p->rmw_aligned_start;
+        p->rmw_prefix_valid = p->rmw_prefix_len;
+    } else {
+        if (p->rmw_suffix_len == 0) {
+            diskfs_write_trim_start(request);
+            return;
+        }
+        buf                  = &p->rmw_suffix_iov;
+        block_start          = aend - 4096;
+        p->rmw_suffix_valid  = p->rmw_suffix_len;
+        p->rmw_suffix_adjust = 0;
+    }
+
+    if (evpl_iovec_alloc(evpl, 4096, 4096, 1, 0, buf) <= 0) {
+        /* The other edge's buffer (the prefix, when this is the suffix) is
+         * already allocated; release it so the failure path leaks nothing. */
+        if (p->rmw_prefix_iov.data) {
+            evpl_iovec_release(evpl, &p->rmw_prefix_iov);
+            p->rmw_prefix_iov.data = NULL;
+        }
+        diskfs_op_fail(request, p->txn, CHIMERA_VFS_EIO);
+        return;
+    }
+    memset(buf->data, 0, 4096);
+
+    evpl_iovec_cursor_init(&p->rd_cursor, buf, 1);
+    p->loop_off      = block_start;
+    p->loop_left     = 4096;
+    p->loop_pos      = block_start + 4096;
+    p->loop_have     = 0;
+    p->recon_walking = 1;
+
+    op = diskfs_bt_op_alloc(thread);
+    if (diskfs_ext_floor_async(op, thread, p->inode_stash[0], block_start,
+                               p->rec_scratch, sizeof(p->rec_scratch),
+                               diskfs_write_recon_first_cb, request)) {
+        diskfs_write_recon_first_cb(op, op->result, request);
+    }
+} /* diskfs_write_recon_edge */
+
+
+/* An edge block is fully rebuilt (walk done, all reads complete): release the
+ * device-read iovec refs and move on (prefix -> suffix -> trim). */
+static void
+diskfs_write_recon_next(struct chimera_vfs_request *request)
+{
+    struct diskfs_request_private *p      = request->plugin_data;
+    struct diskfs_thread          *thread = p->thread;
+
+    /* Release the per-chunk device-read iovec refs (slices of the edge buffer);
+     * the buffer's own ref stays in rmw_prefix_iov / rmw_suffix_iov until
+     * phase2 consumes it. */
+    if (p->niov) {
+        evpl_iovecs_release(thread->evpl, p->iov, p->niov);
+        p->niov = 0;
+    }
+
+    if (p->status) {
+        if (p->rmw_prefix_iov.data) {
+            evpl_iovec_release(thread->evpl, &p->rmw_prefix_iov);
+            p->rmw_prefix_iov.data = NULL;
+        }
+        if (p->rmw_suffix_iov.data) {
+            evpl_iovec_release(thread->evpl, &p->rmw_suffix_iov);
+            p->rmw_suffix_iov.data = NULL;
+        }
+        diskfs_op_fail(request, p->txn, p->status);
+        return;
+    }
+
+    if (p->recon_edge == 0) {
+        p->recon_edge = 1;
+        diskfs_write_recon_edge(request);
+    } else {
+        diskfs_write_trim_start(request);
+    }
+} /* diskfs_write_recon_next */
 
 
 /*
@@ -2558,7 +2769,10 @@ diskfs_write_redirect_alloc(struct chimera_vfs_request *request)
     p->rmw_device_id     = dev_id;
     p->rmw_device_offset = dev_off;
 
-    diskfs_write_prefix_lookup(request);
+    /* Rebuild the prefix/suffix edge blocks (fragmentation-aware) before the
+     * trim frees the old backing, then continue into diskfs_write_trim_start. */
+    p->recon_edge = 0;
+    diskfs_write_recon_edge(request);
 } /* diskfs_write_redirect_alloc */
 
 

--- a/src/vfs/tests/CMakeLists.txt
+++ b/src/vfs/tests/CMakeLists.txt
@@ -60,6 +60,29 @@ add_executable(vfs_statfs_mask_test vfs_statfs_mask_test.c)
 target_link_libraries(vfs_statfs_mask_test chimera_vfs chimera_vfs_memfs chimera_vfs_memkv evpl urcu-qsbr)
 add_test(chimera/vfs/statfs_mask_test vfs_statfs_mask_test)
 
+# zero_range reproducer / regression: VFS zero_range (DEALLOCATE+ALLOCATE) data
+# integrity, parameterized by backend.  memfs/linux confirm the invariant holds
+# (and that the model checker is sound); the diskfs cases reproduce the bug.
+add_executable(vfs_zerorange_test vfs_zerorange_test.c)
+target_link_libraries(vfs_zerorange_test chimera_vfs chimera_vfs_memfs
+    chimera_vfs_linux chimera_vfs_diskfs chimera_vfs_memkv evpl urcu-qsbr)
+# Engine-managed backends only: deterministic and host-fs-independent.  memfs
+# and cairn confirm the invariant holds; the diskfs cases reproduce the bug.
+# The linux / io_uring passthrough backends are also valid CLI args for manual
+# runs (their libs are linked), but they are not registered as tests -- their
+# fallocate behavior is the host kernel's and is unreliable under the
+# container / CI filesystems.
+add_test(NAME chimera/vfs/zerorange_memfs COMMAND vfs_zerorange_test memfs)
+add_test(NAME chimera/vfs/zerorange_diskfs_aio COMMAND vfs_zerorange_test diskfs_aio)
+if(CHIMERA_VFS_IO_URING)
+    target_link_libraries(vfs_zerorange_test chimera_vfs_io_uring)
+    add_test(NAME chimera/vfs/zerorange_diskfs_io_uring COMMAND vfs_zerorange_test diskfs_io_uring)
+endif()
+if(CAIRN_ENABLED)
+    target_link_libraries(vfs_zerorange_test chimera_vfs_cairn)
+    add_test(NAME chimera/vfs/zerorange_cairn COMMAND vfs_zerorange_test cairn)
+endif()
+
 # Tag every test registered above with the 'vfs' label so the suite can be run
 # independently via `ctest -L vfs`.
 get_property(_vfs_tests DIRECTORY PROPERTY TESTS)

--- a/src/vfs/tests/vfs_zerorange_test.c
+++ b/src/vfs/tests/vfs_zerorange_test.c
@@ -1,0 +1,527 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * Backend-parameterized reproducer / regression test: a VFS zero_range
+ * implemented as DEALLOCATE(range) + ALLOCATE(range) must leave the range
+ * reading as zeros without disturbing neighbouring data.
+ *
+ * The Ubuntu 26.04 NFSv4.2 client implements FALLOC_FL_ZERO_RANGE as exactly
+ * that op pair (confirmed by op-logging the server); older kernels lacked NFS
+ * ZERO_RANGE, which is why only the 26.04 diskfs+NFSv4.2 fsx run fails.  A
+ * single punch+alloc does not trip it -- the bug needs an extent map that has
+ * accumulated a mix of written / unwritten / hole extents at sub-block-
+ * unaligned boundaries.
+ *
+ * This is a small deterministic fsx-style model checker driven straight at the
+ * VFS layer (no NFS, no KVM) so it runs in the dev container.  It keeps a
+ * reference image and, after each pseudo-random (fixed-seed) write /
+ * zero_range / punch at a sub-block range, reads the whole file back and
+ * compares.  Run it per backend:
+ *
+ *     vfs_diskfs_zerorange_test <backend>
+ *
+ * where <backend> is memfs (default), diskfs_io_uring, diskfs_aio, linux,
+ * io_uring, or cairn.  memfs/linux/etc. confirm the invariant holds (and that
+ * the checker itself is sound); diskfs reproduces the bug.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#undef NDEBUG
+#include <assert.h>
+
+#include "evpl/evpl.h"
+#include "evpl/evpl_memory.h"
+#include "vfs/vfs.h"
+#include "vfs/vfs_procs.h"
+#include "vfs/vfs_release.h"
+#include "vfs/vfs_attrs.h"
+#include "vfs/vfs_cred.h"
+#include "vfs/vfs_error.h"
+#include "common/logging.h"
+#include "prometheus-c.h"
+
+#define DEV_SIZE_BYTES (1024ULL * 1024ULL * 1024ULL) /* 1 GiB, sparse */
+#define FILE_LEN       0x40000U   /* 256 KiB, matches fsx -l 262144 */
+#define MAX_OP_LEN     0x10000U   /* 64 KiB max per op */
+#define NUM_OPS        600        /* fsx tripped near op ~150 */
+#define READ_CHUNK     0x10000U   /* read back in 64 KiB chunks */
+#define READ_NIOV      64
+#define WRITE_NIOV     16
+
+struct test_ctx {
+    int                             done;
+    enum chimera_vfs_error          status;
+    struct chimera_vfs             *vfs;
+    struct chimera_vfs_thread      *vfs_thread;
+    struct evpl                    *evpl;
+    uint8_t                         fh[CHIMERA_VFS_FH_SIZE];
+    uint32_t                        fh_len;
+    struct chimera_vfs_open_handle *handle;     /* generic op result handle */
+    struct chimera_vfs_open_handle *fhandle;    /* persistent file handle */
+    uint8_t                        *readbuf;
+    uint32_t                        read_dst;
+    uint32_t                        readlen;
+};
+
+static uint64_t g_rng = 0x12345678ULL;
+
+static uint32_t
+rng(void)
+{
+    g_rng = g_rng * 6364136223846793005ULL + 1442695040888963407ULL;
+    return (uint32_t) (g_rng >> 33);
+} /* rng */
+
+static void
+wait_done(struct test_ctx *ctx)
+{
+    while (!ctx->done) {
+        evpl_continue(ctx->evpl);
+    }
+    ctx->done = 0;
+} /* wait_done */
+
+static void
+mount_cb(
+    struct chimera_vfs_thread *thread,
+    enum chimera_vfs_error     status,
+    void                      *private_data)
+{
+    struct test_ctx *ctx = private_data;
+
+    ctx->status = status;
+    ctx->done   = 1;
+} /* mount_cb */
+
+static void
+lookup_cb(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *attr,
+    void                     *private_data)
+{
+    struct test_ctx *ctx = private_data;
+
+    ctx->status = error_code;
+    if (error_code == CHIMERA_VFS_OK) {
+        memcpy(ctx->fh, attr->va_fh, attr->va_fh_len);
+        ctx->fh_len = attr->va_fh_len;
+    }
+    ctx->done = 1;
+} /* lookup_cb */
+
+static void
+openfh_cb(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *oh,
+    void                           *private_data)
+{
+    struct test_ctx *ctx = private_data;
+
+    ctx->status = error_code;
+    ctx->handle = oh;
+    ctx->done   = 1;
+} /* openfh_cb */
+
+static void
+openat_cb(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *oh,
+    struct chimera_vfs_attrs       *set_attr,
+    struct chimera_vfs_attrs       *attr,
+    struct chimera_vfs_attrs       *dir_pre,
+    struct chimera_vfs_attrs       *dir_post,
+    void                           *private_data)
+{
+    struct test_ctx *ctx = private_data;
+
+    ctx->status = error_code;
+    ctx->handle = oh;
+    if (error_code == CHIMERA_VFS_OK) {
+        memcpy(ctx->fh, oh->fh, oh->fh_len);
+        ctx->fh_len = oh->fh_len;
+    }
+    ctx->done = 1;
+} /* openat_cb */
+
+static void
+write_cb(
+    enum chimera_vfs_error    error_code,
+    uint32_t                  length,
+    uint32_t                  sync,
+    struct chimera_vfs_attrs *pre_attr,
+    struct chimera_vfs_attrs *post_attr,
+    void                     *private_data)
+{
+    struct test_ctx *ctx = private_data;
+
+    ctx->status = error_code;
+    ctx->done   = 1;
+} /* write_cb */
+
+static void
+allocate_cb(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *pre_attr,
+    struct chimera_vfs_attrs *post_attr,
+    void                     *private_data)
+{
+    struct test_ctx *ctx = private_data;
+
+    ctx->status = error_code;
+    ctx->done   = 1;
+} /* allocate_cb */
+
+static void
+read_cb(
+    enum chimera_vfs_error    error_code,
+    uint32_t                  count,
+    uint32_t                  eof,
+    struct evpl_iovec        *iov,
+    int                       niov,
+    struct chimera_vfs_attrs *attr,
+    void                     *private_data)
+{
+    struct test_ctx *ctx = private_data;
+    uint32_t         off = 0;
+
+    ctx->status = error_code;
+    if (error_code == CHIMERA_VFS_OK) {
+        for (int i = 0; i < niov && off < ctx->readlen; i++) {
+            uint32_t len = evpl_iovec_length(&iov[i]);
+
+            if (len > ctx->readlen - off) {
+                len = ctx->readlen - off;
+            }
+            memcpy(ctx->readbuf + ctx->read_dst + off, evpl_iovec_data(&iov[i]),
+                   len);
+            off += len;
+        }
+        evpl_iovecs_release(ctx->evpl, iov, niov);
+    }
+    ctx->done = 1;
+} /* read_cb */
+
+static void
+do_write(
+    struct test_ctx               *ctx,
+    const struct chimera_vfs_cred *cred,
+    uint64_t                       off,
+    uint64_t                       len,
+    uint8_t                        byte)
+{
+    struct evpl_iovec iov[WRITE_NIOV];
+    int               niov;
+
+    niov = evpl_iovec_alloc(ctx->evpl, (unsigned int) len, 4096, WRITE_NIOV, 0,
+                            iov);
+    assert(niov > 0);
+    for (int i = 0; i < niov; i++) {
+        memset(evpl_iovec_data(&iov[i]), byte, evpl_iovec_length(&iov[i]));
+    }
+
+    chimera_vfs_write(ctx->vfs_thread, cred, ctx->fhandle, off, (uint32_t) len,
+                      CHIMERA_VFS_WRITE_FILESYNC, 0, 0, iov, niov, write_cb, ctx);
+    wait_done(ctx);
+    assert(ctx->status == CHIMERA_VFS_OK);
+    evpl_iovecs_release(ctx->evpl, iov, niov);
+} /* do_write */
+
+/* Issue one allocate (flags=0) or deallocate (CHIMERA_VFS_ALLOCATE_DEALLOCATE)
+ * and return its status without asserting (used to probe support). */
+static enum chimera_vfs_error
+do_allocate(
+    struct test_ctx               *ctx,
+    const struct chimera_vfs_cred *cred,
+    uint64_t                       off,
+    uint64_t                       len,
+    uint32_t                       flags)
+{
+    chimera_vfs_allocate(ctx->vfs_thread, cred, ctx->fhandle, off, len, flags,
+                         0, 0, allocate_cb, ctx);
+    wait_done(ctx);
+    return ctx->status;
+} /* do_allocate */
+
+/* Read [0, FILE_LEN) into ctx->readbuf (holes / EOF read as zero). */
+static void
+read_all(
+    struct test_ctx               *ctx,
+    const struct chimera_vfs_cred *cred)
+{
+    memset(ctx->readbuf, 0, FILE_LEN);
+
+    for (uint64_t off = 0; off < FILE_LEN; off += READ_CHUNK) {
+        struct evpl_iovec iov[READ_NIOV];
+        uint32_t          chunk = READ_CHUNK;
+
+        if (chunk > FILE_LEN - off) {
+            chunk = (uint32_t) (FILE_LEN - off);
+        }
+        ctx->read_dst = (uint32_t) off;
+        ctx->readlen  = chunk;
+
+        chimera_vfs_read(ctx->vfs_thread, cred, ctx->fhandle, off, chunk, iov,
+                         READ_NIOV, 0, read_cb, ctx);
+        wait_done(ctx);
+        assert(ctx->status == CHIMERA_VFS_OK);
+    }
+} /* read_all */
+
+/* Per-backend wiring: module configs + mount module/path, plus any on-disk
+ * scratch (a diskfs device file; a host directory for the passthrough /
+ * persistent backends).  module_cfgs[] always ends with the memkv KV backend. */
+struct backend_spec {
+    int         ncfg;
+    const char *mount_module;
+    char        mount_path[300];
+};
+
+static void
+backend_configure(
+    const char                    *backend,
+    const char                    *session_dir,
+    struct chimera_vfs_module_cfg *cfgs,
+    struct backend_spec           *spec)
+{
+    char dev_path[300];
+    char cfg[512];
+
+    memset(spec, 0, sizeof(*spec));
+
+    if (strcmp(backend, "memfs") == 0) {
+        strncpy(cfgs[0].module_name, "memfs", sizeof(cfgs[0].module_name) - 1);
+        spec->mount_module = "memfs";
+        snprintf(spec->mount_path, sizeof(spec->mount_path), "/");
+    } else if (strcmp(backend, "linux") == 0 ||
+               strcmp(backend, "io_uring") == 0) {
+        strncpy(cfgs[0].module_name, backend, sizeof(cfgs[0].module_name) - 1);
+        spec->mount_module = (strcmp(backend, "linux") == 0) ? "linux" : "io_uring";
+        snprintf(spec->mount_path, sizeof(spec->mount_path), "%s", session_dir);
+    } else if (strcmp(backend, "cairn") == 0) {
+        strncpy(cfgs[0].module_name, "cairn", sizeof(cfgs[0].module_name) - 1);
+        snprintf(cfg, sizeof(cfg),
+                 "{\"initialize\":true,\"path\":\"%s\"}", session_dir);
+        strncpy(cfgs[0].config_data, cfg, sizeof(cfgs[0].config_data) - 1);
+        spec->mount_module = "cairn";
+        snprintf(spec->mount_path, sizeof(spec->mount_path), "/");
+    } else if (strcmp(backend, "diskfs_io_uring") == 0 ||
+               strcmp(backend, "diskfs_aio") == 0) {
+        const char *iotype = (strcmp(backend, "diskfs_aio") == 0) ? "libaio"
+                                                                  : "io_uring";
+        int         fd, rc;
+
+        snprintf(dev_path, sizeof(dev_path), "%s/device-0.img", session_dir);
+        fd = open(dev_path, O_CREAT | O_TRUNC | O_RDWR, 0644);
+        assert(fd >= 0);
+        rc = ftruncate(fd, (off_t) DEV_SIZE_BYTES);
+        assert(rc == 0);
+        close(fd);
+
+        /* Pin a small (64 MiB) intent log: the default journal size is large
+         * enough to not fit in this 1 GiB scratch device's first allocation
+         * group, and the test does not need a big log. */
+        snprintf(cfg, sizeof(cfg),
+                 "{\"initialize\":true,\"unsafe_async\":true,"
+                 "\"intent_log_size\":67108864,"
+                 "\"devices\":[{\"type\":\"%s\",\"size\":1,\"path\":\"%s\"}]}",
+                 iotype, dev_path);
+        strncpy(cfgs[0].module_name, "diskfs", sizeof(cfgs[0].module_name) - 1);
+        strncpy(cfgs[0].config_data, cfg, sizeof(cfgs[0].config_data) - 1);
+        spec->mount_module = "diskfs";
+        snprintf(spec->mount_path, sizeof(spec->mount_path), "/");
+    } else {
+        fprintf(stderr, "unknown backend: %s\n", backend);
+        exit(2);
+    }
+
+    strncpy(cfgs[1].module_name, "memkv", sizeof(cfgs[1].module_name) - 1);
+    spec->ncfg = 2;
+} /* backend_configure */
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    struct test_ctx               ctx = { 0 };
+    struct chimera_vfs_module_cfg module_cfgs[2];
+    struct backend_spec           spec;
+    struct prometheus_metrics    *metrics;
+    struct chimera_vfs_cred       cred;
+    struct chimera_vfs_attrs      sattr;
+    const char                   *backend = argc > 1 ? argv[1] : "memfs";
+    char                          tmpl[]  = "/tmp/vfs_zr_XXXXXX";
+    char                         *session_dir;
+    uint8_t                       root_fh[CHIMERA_VFS_FH_SIZE];
+    uint32_t                      root_fh_len;
+    uint8_t                       file_fh[CHIMERA_VFS_FH_SIZE];
+    uint32_t                      file_fh_len;
+    uint8_t                      *model;
+    uint64_t                      first_bad_op  = 0;
+    int                           failed        = 0;
+    int                           alloc_support = 1;
+
+    chimera_log_init();
+    chimera_vfs_cred_init_unix(&cred, 0, 0, 0, NULL);
+
+    session_dir = mkdtemp(tmpl);
+    assert(session_dir != NULL);
+
+    memset(module_cfgs, 0, sizeof(module_cfgs));
+    backend_configure(backend, session_dir, module_cfgs, &spec);
+
+    metrics = prometheus_metrics_create(NULL, NULL, 0);
+    assert(metrics != NULL);
+
+    ctx.evpl = evpl_create(NULL);
+    assert(ctx.evpl != NULL);
+
+    ctx.vfs = chimera_vfs_init(0, 0, module_cfgs, spec.ncfg, "memkv", 60, 0,
+                               metrics);
+    assert(ctx.vfs != NULL);
+
+    ctx.vfs_thread = chimera_vfs_thread_init(ctx.evpl, ctx.vfs);
+    assert(ctx.vfs_thread != NULL);
+
+    ctx.readbuf = malloc(FILE_LEN);
+    model       = calloc(1, FILE_LEN);
+    assert(ctx.readbuf && model);
+
+    chimera_vfs_mount(ctx.vfs_thread, NULL, "/test", spec.mount_module,
+                      spec.mount_path, NULL, mount_cb, &ctx);
+    wait_done(&ctx);
+    assert(ctx.status == CHIMERA_VFS_OK);
+
+    chimera_vfs_get_root_fh(root_fh, &root_fh_len);
+    chimera_vfs_lookup(ctx.vfs_thread, &cred, root_fh, root_fh_len, "test", 4,
+                       CHIMERA_VFS_ATTR_FH | CHIMERA_VFS_ATTR_MASK_STAT, 0,
+                       lookup_cb, &ctx);
+    wait_done(&ctx);
+    assert(ctx.status == CHIMERA_VFS_OK);
+    memcpy(root_fh, ctx.fh, ctx.fh_len);
+    root_fh_len = ctx.fh_len;
+
+    chimera_vfs_open_fh(ctx.vfs_thread, &cred, root_fh, root_fh_len,
+                        CHIMERA_VFS_OPEN_INFERRED, openfh_cb, &ctx);
+    wait_done(&ctx);
+    assert(ctx.status == CHIMERA_VFS_OK);
+
+    {
+        struct chimera_vfs_open_handle *root_handle = ctx.handle;
+
+        memset(&sattr, 0, sizeof(sattr));
+        sattr.va_set_mask = CHIMERA_VFS_ATTR_MODE;
+        sattr.va_mode     = 0644;
+
+        chimera_vfs_open_at(ctx.vfs_thread, &cred, root_handle, "f", 1,
+                            CHIMERA_VFS_OPEN_CREATE, &sattr, CHIMERA_VFS_ATTR_FH,
+                            0, 0, openat_cb, &ctx);
+        wait_done(&ctx);
+        assert(ctx.status == CHIMERA_VFS_OK);
+        memcpy(file_fh, ctx.fh, ctx.fh_len);
+        file_fh_len = ctx.fh_len;
+        chimera_vfs_release(ctx.vfs_thread, ctx.handle);
+        chimera_vfs_release(ctx.vfs_thread, root_handle);
+    }
+
+    chimera_vfs_open_fh(ctx.vfs_thread, &cred, file_fh, file_fh_len,
+                        CHIMERA_VFS_OPEN_INFERRED, openfh_cb, &ctx);
+    wait_done(&ctx);
+    assert(ctx.status == CHIMERA_VFS_OK);
+    ctx.fhandle = ctx.handle;
+
+    /* Seed the whole file with a non-zero pattern so zeroed ranges are
+     * distinguishable from stale data. */
+    do_write(&ctx, &cred, 0, FILE_LEN, 0xff);
+    memset(model, 0xff, FILE_LEN);
+
+    /* Probe whether this backend supports allocate/deallocate.  If not, the
+     * run still checks write/read integrity (no zero_range/punch ops). */
+    if (do_allocate(&ctx, &cred, 0, 4096, CHIMERA_VFS_ALLOCATE_DEALLOCATE) ==
+        CHIMERA_VFS_OK) {
+        (void) do_allocate(&ctx, &cred, 0, 4096, 0);
+    } else {
+        alloc_support = 0;
+        fprintf(stderr,
+                "NOTE: backend '%s' does not support ALLOCATE; "
+                "verifying writes only\n", backend);
+    }
+    /* Re-seed: the probe perturbed [0,4096). */
+    do_write(&ctx, &cred, 0, FILE_LEN, 0xff);
+    memset(model, 0xff, FILE_LEN);
+
+    for (int op = 0; op < NUM_OPS && !failed; op++) {
+        uint64_t off  = rng() % FILE_LEN;
+        uint64_t len  = (rng() % MAX_OP_LEN) + 1;
+        uint32_t kind = alloc_support ? (rng() % 4) : (rng() % 2);
+        uint8_t  byte = (uint8_t) ((op % 254) + 1); /* non-zero fill */
+
+        if (off + len > FILE_LEN) {
+            len = FILE_LEN - off;
+        }
+
+        switch (kind) {
+            case 0:
+            case 1: /* WRITE (bias 2:1 so the file keeps real data) */
+                do_write(&ctx, &cred, off, len, byte);
+                memset(model + off, byte, len);
+                break;
+            case 2: /* ZERO_RANGE = DEALLOCATE + ALLOCATE (the 26.04 sequence) */
+                assert(do_allocate(&ctx, &cred, off, len,
+                                   CHIMERA_VFS_ALLOCATE_DEALLOCATE) == CHIMERA_VFS_OK);
+                assert(do_allocate(&ctx, &cred, off, len, 0) == CHIMERA_VFS_OK);
+                memset(model + off, 0, len);
+                break;
+            case 3: /* PUNCH_HOLE = DEALLOCATE only */
+                assert(do_allocate(&ctx, &cred, off, len,
+                                   CHIMERA_VFS_ALLOCATE_DEALLOCATE) == CHIMERA_VFS_OK);
+                memset(model + off, 0, len);
+                break;
+            default:
+                break;
+        } /* switch */
+
+        read_all(&ctx, &cred);
+        if (memcmp(model, ctx.readbuf, FILE_LEN) != 0) {
+            uint64_t i;
+
+            for (i = 0; i < FILE_LEN; i++) {
+                if (model[i] != ctx.readbuf[i]) {
+                    break;
+                }
+            }
+            fprintf(stderr,
+                    "MISMATCH on '%s' after op %d (kind=%u off=0x%lx len=0x%lx): "
+                    "byte 0x%lx expected 0x%02x got 0x%02x\n",
+                    backend, op, kind, (unsigned long) off, (unsigned long) len,
+                    (unsigned long) i, model[i], ctx.readbuf[i]);
+            first_bad_op = op;
+            failed       = 1;
+        }
+    }
+
+    chimera_vfs_release(ctx.vfs_thread, ctx.fhandle);
+    chimera_vfs_thread_destroy(ctx.vfs_thread);
+    chimera_vfs_destroy(ctx.vfs);
+    evpl_destroy(ctx.evpl);
+    prometheus_metrics_destroy(metrics);
+    free(ctx.readbuf);
+    free(model);
+
+    if (failed) {
+        fprintf(stderr,
+                "FAIL [%s]: zero_range/punch returned stale data (op %lu)\n",
+                backend, (unsigned long) first_bad_op);
+        return 1;
+    }
+
+    fprintf(stderr, "PASS [%s]: %d write/%s ops verified\n", backend, NUM_OPS,
+            alloc_support ? "zero_range/punch" : "(no-allocate)");
+    return 0;
+} /* main */


### PR DESCRIPTION
An NFSv4.2 ZERO_RANGE is sent to the server as DEALLOCATE(range) followed by ALLOCATE(range).  DEALLOCATE trims extents at raw byte offsets, so an edge block can end up fragmented at sub-block boundaries: a written piece adjacent to an unwritten piece or a hole within a single 4 KiB block.

A redirect write (hole / partial / multi-extent span) allocates fresh backing for the block-aligned region and copies over the sub-block prefix [aligned_start, write_start) and suffix [write_end, aligned_end) it does not overwrite.  It reconstructed each edge from a single floor() extent lookup and zero-filled everything past that extent's end -- so when the edge block held a second extent (e.g. unwritten | written from a prior punch), the trailing written data was zeroed, losing data adjacent to the written range.

Rebuild each edge block exactly as a read would: walk every extent the block overlaps into a zero-initialized block buffer (written -> device read, unwritten / hole -> left zero), before the trim frees the old backing.  phase2 then slices the prefix/suffix bytes it needs out of the fully reconstructed buffers.  The in-place overwrite paths are unchanged.

Add a backend-parameterized, deterministic fsx-style model checker (vfs_zerorange_test) that drives write / zero_range / punch at the VFS layer and verifies read-back against a reference image.  Registered for memfs, cairn, and both diskfs IO engines.