### PR TITLE
kvm: fail fast when the nfstest second client is unusable

### DIFF
--- a/kvm/kvm_nfstest_2client_test_wrapper.sh
+++ b/kvm/kvm_nfstest_2client_test_wrapper.sh
@@ -276,7 +276,12 @@ NFSTEST_CMD="PYTHONPATH=/opt/nfstest /opt/nfstest/test/${NFSTEST_PROGRAM} \
 # KVM_DIAG_CMD overrides the nfstest invocation with an arbitrary diagnostic
 # command run on guest A after B's sshd is up (manual harness debugging).
 RUN_CMD="${KVM_DIAG_CMD:-${NFSTEST_CMD}}"
-TEST_CMD="${SSHFIX}; mkdir -p /mnt/t && for i in \$(seq 1 120); do ssh -o ConnectTimeout=2 10.0.0.3 true 2>/dev/null && break; sleep 1; done && ${RUN_CMD}"
+# Fail fast and loudly if the second client is unusable, rather than letting
+# nfstest emit hundreds of cryptic create_rexec tracebacks (an image without an
+# ssh client, or an unreachable/never-booted B, otherwise wastes the full 120s
+# wait and then fails inside the suite).  No double-quotes here: the kernel
+# cmdline parser truncates test_cmd at the first one.
+TEST_CMD="${SSHFIX}; mkdir -p /mnt/t; command -v ssh >/dev/null 2>&1 || { echo CHIMERA_KVM_FATAL: ssh client missing on guest image, cannot run 2-client test; exit 1; }; ok=0; for i in \$(seq 1 120); do ssh -o ConnectTimeout=2 10.0.0.3 true 2>/dev/null && { ok=1; break; }; sleep 1; done; [ \$ok = 1 ] || { echo CHIMERA_KVM_FATAL: second client 10.0.0.3 unreachable after 120s; exit 1; }; ${RUN_CMD}"
 
 ip netns exec "${NETNS_NAME}" "$QEMU_BIN" \
     -enable-kvm -smp 4 -m 2G -cpu host \


### PR DESCRIPTION
The two-client nfstest wrapper waited up to 120s for guest B's sshd, then ran the suite **unconditionally** — even if it never connected, because the `for` wait loop always completes and the trailing `&& run` only guards the loop's own exit, not whether a connection succeeded.

A guest image without an ssh client (or a B that never booted) therefore burned the full 120s wait and then failed deep inside nfstest with hundreds of identical `FileNotFoundError: [Errno 2] No such file or directory: 'ssh'` `create_rexec` tracebacks. That reads as a flaky delegation test under load rather than what it actually is: a broken/too-old second-client image.

This bit in practice: a local build pinned to a stale `KVM_IMAGE_VERSION` (pre-openssh) produced exactly this 150+-failure cascade, which initially looked like load contention. On the correct image, delegation passes reliably even when run concurrently with the full lock/dio/posix suite at `-j24`.

**Fix:** guard the run —
- abort immediately with a clear `CHIMERA_KVM_FATAL` message if `ssh` is missing on the guest;
- track wait-loop success and only run the suite when B was actually reached (do not trust the loop's completion).

Kept free of double-quotes so the kernel cmdline parser does not truncate `test_cmd`.

Verified: delegation green through the updated wrapper on the happy path; the guard is transparent when B is reachable.