### PR TITLE
posix: add posix_fallocate; port pjdfstest posix_fallocate/00

### DIFF
--- a/src/client/client_allocate.h
+++ b/src/client/client_allocate.h
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#pragma once
+
+#include "client_internal.h"
+
+static void
+chimera_allocate_complete(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *pre_attr,
+    struct chimera_vfs_attrs *post_attr,
+    void                     *private_data)
+{
+    struct chimera_client_request *request        = private_data;
+    struct chimera_client_thread  *client_thread  = request->thread;
+    chimera_commit_callback_t      callback       = request->allocate.callback;
+    void                          *callback_arg   = request->allocate.private_data;
+    int                            heap_allocated = request->heap_allocated;
+
+    if (heap_allocated) {
+        chimera_client_request_free(client_thread, request);
+    }
+
+    callback(client_thread, error_code, callback_arg);
+} /* chimera_allocate_complete */
+
+static inline void
+chimera_dispatch_allocate(
+    struct chimera_client_thread  *thread,
+    struct chimera_client_request *request)
+{
+    chimera_vfs_allocate(
+        thread->vfs_thread,
+        chimera_client_req_cred(request),
+        request->allocate.handle,
+        request->allocate.offset,
+        request->allocate.length,
+        request->allocate.flags,
+        0,  /* pre_attr_mask */
+        0,  /* post_attr_mask */
+        chimera_allocate_complete,
+        request);
+} /* chimera_dispatch_allocate */

--- a/src/client/client_internal.h
+++ b/src/client/client_internal.h
@@ -55,6 +55,7 @@ enum chimera_client_request_opcode {
     CHIMERA_CLIENT_OP_LOCK,
     CHIMERA_CLIENT_OP_COPY_RANGE,
     CHIMERA_CLIENT_OP_CLONE_RANGE,
+    CHIMERA_CLIENT_OP_ALLOCATE,
 };
 
 struct chimera_client_request;
@@ -327,6 +328,15 @@ struct chimera_client_request {
             chimera_commit_callback_t       callback;
             void                           *private_data;
         } commit;
+
+        struct {
+            struct chimera_vfs_open_handle *handle;
+            uint64_t                        offset;
+            uint64_t                        length;
+            uint32_t                        flags;
+            chimera_commit_callback_t       callback;
+            void                           *private_data;
+        } allocate;
 
         struct {
             struct chimera_vfs_open_handle *handle;

--- a/src/posix/CMakeLists.txt
+++ b/src/posix/CMakeLists.txt
@@ -66,6 +66,7 @@ add_library(chimera_posix SHARED
             posix_pathconf.c
             posix_truncate.c
             posix_ftruncate.c
+            posix_fallocate.c
             posix_fcntl.c
             posix_lockf.c
             posix_fsync.c

--- a/src/posix/posix.h
+++ b/src/posix/posix.h
@@ -599,6 +599,13 @@ chimera_posix_ftruncate(
     int   fd,
     off_t length);
 
+// Preallocate space for a file (posix_fallocate(3))
+int
+chimera_posix_fallocate(
+    int   fd,
+    off_t offset,
+    off_t len);
+
 // File locking
 int
 chimera_posix_fcntl(

--- a/src/posix/posix_fallocate.c
+++ b/src/posix/posix_fallocate.c
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include <errno.h>
+#include <fcntl.h>
+#include <string.h>
+
+#include "posix_internal.h"
+#include "../client/client_allocate.h"
+
+static void
+chimera_posix_fallocate_callback(
+    struct chimera_client_thread *thread,
+    enum chimera_vfs_error        status,
+    void                         *private_data)
+{
+    struct chimera_posix_completion *comp = private_data;
+
+    chimera_posix_complete(comp, status);
+} /* chimera_posix_fallocate_callback */
+
+static void
+chimera_posix_fallocate_exec(
+    struct chimera_client_thread  *thread,
+    struct chimera_client_request *request)
+{
+    chimera_dispatch_allocate(thread, request);
+} /* chimera_posix_fallocate_exec */
+
+/*
+ * posix_fallocate(3): reserve space for [offset, offset+len) and grow the file
+ * to offset+len if it is currently shorter.  Returns 0 on success or -1 with
+ * errno set.  len == 0 (and negative offset/len) are invalid -> EINVAL; a
+ * descriptor not open for writing -> EBADF.
+ */
+SYMBOL_EXPORT int
+chimera_posix_fallocate(
+    int   fd,
+    off_t offset,
+    off_t len)
+{
+    struct chimera_posix_client    *posix  = chimera_posix_get_global();
+    struct chimera_posix_worker    *worker = chimera_posix_choose_worker(posix);
+    struct chimera_posix_fd_entry  *entry;
+    struct chimera_client_request   req;
+    struct chimera_posix_completion comp;
+
+    if (offset < 0 || len <= 0) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    entry = chimera_posix_fd_acquire(posix, fd, 0);
+
+    if (!entry) {
+        errno = EBADF;
+        return -1;
+    }
+
+    /* posix_fallocate requires the descriptor be open for writing. */
+    if ((entry->oflags & O_ACCMODE) == O_RDONLY) {
+        chimera_posix_fd_release(entry, 0);
+        errno = EBADF;
+        return -1;
+    }
+
+    chimera_posix_completion_init(&comp, &req);
+
+    req.opcode                = CHIMERA_CLIENT_OP_ALLOCATE;
+    req.allocate.handle       = entry->handle;
+    req.allocate.offset       = (uint64_t) offset;
+    req.allocate.length       = (uint64_t) len;
+    req.allocate.flags        = 0;
+    req.allocate.callback     = chimera_posix_fallocate_callback;
+    req.allocate.private_data = &comp;
+
+    chimera_posix_worker_enqueue(worker, &req, chimera_posix_fallocate_exec);
+
+    int err = chimera_posix_wait(&comp);
+
+    chimera_posix_fd_release(entry, 0);
+
+    chimera_posix_completion_destroy(&comp);
+
+    if (err) {
+        errno = err;
+        return -1;
+    }
+
+    return 0;
+} /* chimera_posix_fallocate */

--- a/src/posix/tests/CMakeLists.txt
+++ b/src/posix/tests/CMakeLists.txt
@@ -1315,27 +1315,33 @@ foreach(t ${PJD_GRANULAR_TESTS})
 endforeach()
 
 # posix_fallocate: the VFS ALLOCATE op is implemented by every local backend
-# (memfs/cairn/diskfs/linux/io_uring) but not the NFS client backend (NFSv4.2
-# ALLOCATE is not plumbed through vfs_nfs), so register it on the local backends
-# only -- the same six combos as the direct-backend pjd matrix, minus NFS.
+# (memfs/cairn/diskfs/linux/io_uring) and, over NFSv4.2, by the NFS client
+# backend (vfs_nfs sends OP_ALLOCATE).  Register it on all local backends and
+# all NFSv4 backends, but NOT NFSv3 (no ALLOCATE in the protocol).
 set(PJD_LOCAL_TESTS
     posix_fallocate/00
 )
 foreach(t ${PJD_LOCAL_TESTS})
     add_pjd_testprog(${t})
     add_pjd_test(${t} memfs)
+    add_pjd_nfs_test(${t} nfs4_memfs)
     if(CAIRN_ENABLED)
         add_pjd_test(${t} cairn)
+        add_pjd_nfs_test(${t} nfs4_cairn)
     endif()
     if(IO_URING_ENABLED)
         add_pjd_test(${t} diskfs_io_uring)
+        add_pjd_nfs_test(${t} nfs4_diskfs_io_uring)
     endif()
     if(HAVE_LIBAIO)
         add_pjd_test(${t} diskfs_aio)
+        add_pjd_nfs_test(${t} nfs4_diskfs_aio)
     endif()
     add_pjd_test(${t} linux)
+    add_pjd_nfs_test(${t} nfs4_linux)
     if(CHIMERA_VFS_IO_URING)
         add_pjd_test(${t} io_uring)
+        add_pjd_nfs_test(${t} nfs4_io_uring)
     endif()
 endforeach()
 

--- a/src/posix/tests/CMakeLists.txt
+++ b/src/posix/tests/CMakeLists.txt
@@ -1314,6 +1314,31 @@ foreach(t ${PJD_GRANULAR_TESTS})
     endif()
 endforeach()
 
+# posix_fallocate: the VFS ALLOCATE op is implemented by every local backend
+# (memfs/cairn/diskfs/linux/io_uring) but not the NFS client backend (NFSv4.2
+# ALLOCATE is not plumbed through vfs_nfs), so register it on the local backends
+# only -- the same six combos as the direct-backend pjd matrix, minus NFS.
+set(PJD_LOCAL_TESTS
+    posix_fallocate/00
+)
+foreach(t ${PJD_LOCAL_TESTS})
+    add_pjd_testprog(${t})
+    add_pjd_test(${t} memfs)
+    if(CAIRN_ENABLED)
+        add_pjd_test(${t} cairn)
+    endif()
+    if(IO_URING_ENABLED)
+        add_pjd_test(${t} diskfs_io_uring)
+    endif()
+    if(HAVE_LIBAIO)
+        add_pjd_test(${t} diskfs_aio)
+    endif()
+    add_pjd_test(${t} linux)
+    if(CHIMERA_VFS_IO_URING)
+        add_pjd_test(${t} io_uring)
+    endif()
+endforeach()
+
 # Tag the non-pjd tests with the 'posix' label so that suite can be run
 # independently via `ctest -L posix`.  The pjdfstest ports are tagged separately
 # with 'pjdfstest' so they run as their own CI shard (alongside pynfs, s3, etc.)

--- a/src/posix/tests/pjd/posix_fallocate/00.c
+++ b/src/posix/tests/pjd/posix_fallocate/00.c
@@ -1,0 +1,138 @@
+// SPDX-FileCopyrightText: 2006-2012 Pawel Jakub Dawidek <pawel@dawidek.net>
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Derived from the pjdfstest POSIX filesystem test suite
+// (https://github.com/pjd/pjdfstest) by Pawel Jakub Dawidek.  These are C
+// reimplementations of the upstream shell test cases, run against the Chimera
+// POSIX client, and are distributed under pjdfstest's original 2-clause BSD
+// license.
+
+/* Ported from pjdfstest tests/posix_fallocate/00.t:
+ * posix_fallocate(3) reserves space for [offset, offset+len) and grows the file
+ * to offset+len when that exceeds the current size; it updates ctime on
+ * success, fails with EINVAL when len is 0, and is governed by the
+ * descriptor's access mode rather than the created file's mode bits. */
+
+#include <stdlib.h>
+
+#include "../../pjd_common.h"
+
+/* open `name` with flags/mode, posix_fallocate(offset,len), return errno-or-0. */
+static int
+open_fallocate(
+    const char *name,
+    int         flags,
+    mode_t      mode,
+    off_t       offset,
+    off_t       len)
+{
+    int fd = pjd_open(name, flags, mode);
+    int rc;
+
+    if (fd < 0) {
+        return errno ? errno : EBADF;
+    }
+    rc = chimera_posix_fallocate(fd, offset, len);
+    int e = (rc < 0) ? errno : 0;
+    chimera_posix_close(fd);
+    return e;
+} /* open_fallocate */
+
+/* Write `len` zero bytes into an existing file (stands in for the upstream
+ * `dd if=/dev/random` that gives the file a non-zero starting size). */
+static int
+fill_file(
+    const char *name,
+    size_t      len)
+{
+    int     fd = pjd_open(name, O_RDWR, 0644);
+
+    if (fd < 0) {
+        return errno ? errno : EBADF;
+    }
+
+    char   *buf = calloc(1, len);
+    ssize_t w   = chimera_posix_write(fd, buf, len);
+
+    free(buf);
+    chimera_posix_close(fd);
+    return (w == (ssize_t) len) ? 0 : -1;
+} /* fill_file */
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+
+    char           *n0 = pjd_namegen();
+    char           *n1 = pjd_namegen();
+    struct timespec c1, c2;
+    int             r;
+
+    /* open_fallocate()/fill_file() create files, so each must be evaluated
+     * exactly once -- capture the result before asserting (EXPECT_EQ evaluates
+     * its arguments more than once). */
+
+    EXPECT(0, pjd_mkdir(n1, 0755));
+    pjd_cd(n1);
+
+    /* fallocate grows an empty file to len. */
+    EXPECT(0, pjd_create(n0, 0644));
+    r = open_fallocate(n0, O_RDWR, 0644, 0, 567);
+    EXPECT_EQ(0, r);
+    EXPECT_EQ(567, pjd_stat_size(n0));
+    EXPECT(0, pjd_unlink(n0));
+
+    /* fallocate past EOF grows size to offset+len. */
+    EXPECT(0, pjd_create(n0, 0644));
+    r = fill_file(n0, 12345);
+    EXPECT_EQ(0, r);
+    r = open_fallocate(n0, O_RDWR, 0644, 20000, 3456);
+    EXPECT_EQ(0, r);
+    EXPECT_EQ(23456, pjd_stat_size(n0));
+    EXPECT(0, pjd_unlink(n0));
+
+    /* successful posix_fallocate updates ctime. */
+    EXPECT(0, pjd_create(n0, 0644));
+    pjd_stat_ctime(n0, &c1);
+    pjd_settle();
+    r = open_fallocate(n0, O_RDWR, 0644, 0, 123);
+    EXPECT_EQ(0, r);
+    pjd_stat_ctime(n0, &c2);
+    PJD_CHECK(pjd_timespec_lt(&c1, &c2), "ctime advanced after posix_fallocate");
+    EXPECT(0, pjd_unlink(n0));
+
+    /* unsuccessful posix_fallocate (len 0 -> EINVAL) does not update ctime. */
+    EXPECT(0, pjd_create(n0, 0644));
+    pjd_stat_ctime(n0, &c1);
+    pjd_settle();
+    r = open_fallocate(n0, O_WRONLY, 0644, 0, 0);
+    EXPECT_EQ(EINVAL, r);
+    pjd_stat_ctime(n0, &c2);
+    PJD_CHECK(c1.tv_sec == c2.tv_sec && c1.tv_nsec == c2.tv_nsec,
+              "ctime unchanged after failed posix_fallocate");
+    EXPECT(0, pjd_unlink(n0));
+
+    /* The file mode of a newly created file must not affect whether
+     * posix_fallocate works -- only the descriptor's access mode does.
+     * (https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=154873) */
+    r = open_fallocate(n0, O_CREAT | O_RDWR, 0, 0, 1);
+    EXPECT_EQ(0, r);
+    EXPECT(0, pjd_unlink(n0));
+    EXPECT(0, pjd_chmod(".", 0777));
+    pjd_set_user(65534, 65534);
+    r = open_fallocate(n0, O_CREAT | O_RDWR, 0, 0, 1);
+    EXPECT_EQ(0, r);
+    pjd_set_root();
+    EXPECT(0, pjd_unlink(n0));
+
+    pjd_cd("..");
+    EXPECT(0, pjd_rmdir(n1));
+
+    pjd_end();
+    return 0;
+} /* main */

--- a/src/server/nfs/nfs4_proc_open.c
+++ b/src/server/nfs/nfs4_proc_open.c
@@ -303,6 +303,7 @@ chimera_nfs4_open_install_state(
     struct nfs_request             *req,
     struct chimera_vfs_open_handle *handle,
     const struct chimera_vfs_attrs *attr,
+    bool                            file_created,
     struct stateid4                *out_stateid,
     uint32_t                       *out_rflags)
 {
@@ -326,8 +327,11 @@ chimera_nfs4_open_install_state(
     /* Enforce the object's ACL against the requested share access before the
      * share-reservation check, so a permission failure surfaces as
      * NFS4ERR_ACCESS (not NFS4ERR_SHARE_DENIED).  `attr` is NULL on a reopen by
-     * filehandle (CLAIM_FH), where access was already established. */
-    if (attr) {
+     * filehandle (CLAIM_FH), where access was already established.  A create
+     * that actually made the file grants the creator the requested access
+     * regardless of the mode it was created with (POSIX/RFC: the access check
+     * is bypassed for the creating open), so skip it when file_created. */
+    if (attr && !file_created) {
         uint32_t required = 0;
 
         if (args->share_access & OPEN4_SHARE_ACCESS_READ) {
@@ -536,6 +540,7 @@ chimera_nfs4_open_exclusive_verify(
         req->fhlen = handle->fh_len;
 
         status = chimera_nfs4_open_install_state(req, handle, attr,
+                                                 handle->r_created,
                                                  &res->resok4.stateid,
                                                  &install_rflags);
         if (status != NFS4_OK) {
@@ -628,6 +633,7 @@ chimera_nfs4_open_at_complete(
         req->fhlen = handle->fh_len;
 
         status = chimera_nfs4_open_install_state(req, handle, attr,
+                                                 handle->r_created,
                                                  &res->resok4.stateid,
                                                  &install_rflags);
         if (status != NFS4_OK) {
@@ -812,7 +818,7 @@ chimera_nfs4_open_claim_fh_complete(
         uint32_t install_rflags = 0;
         lock_caps = handle->vfs_module->capabilities;
 
-        status = chimera_nfs4_open_install_state(req, handle, NULL,
+        status = chimera_nfs4_open_install_state(req, handle, NULL, false,
                                                  &res->resok4.stateid,
                                                  &install_rflags);
         if (status != NFS4_OK) {

--- a/src/vfs/nfs/CMakeLists.txt
+++ b/src/vfs/nfs/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(chimera_vfs_nfs SHARED
     nfs3_setattr.c
     nfs3_symlink_at.c
     nfs3_write.c
+    nfs4_allocate.c
     nfs4_cb.c
     nfs4_close.c
     nfs4_commit.c

--- a/src/vfs/nfs/nfs4.c
+++ b/src/vfs/nfs/nfs4.c
@@ -58,6 +58,9 @@ chimera_nfs4_dispatch(
         case CHIMERA_VFS_OP_COMMIT:
             chimera_nfs4_commit(thread, shared, request, private_data);
             break;
+        case CHIMERA_VFS_OP_ALLOCATE:
+            chimera_nfs4_allocate(thread, shared, request, private_data);
+            break;
         case CHIMERA_VFS_OP_SYMLINK_AT:
             chimera_nfs4_symlink_at(thread, shared, request, private_data);
             break;

--- a/src/vfs/nfs/nfs4_allocate.c
+++ b/src/vfs/nfs/nfs4_allocate.c
@@ -1,0 +1,152 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "nfs_internal.h"
+#include "nfs4_open_state.h"
+#include "vfs/vfs.h"
+
+static void
+chimera_nfs4_allocate_callback(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    struct COMPOUND4res         *res,
+    int                          status,
+    void                        *private_data)
+{
+    struct chimera_vfs_request *request    = private_data;
+    int                         is_dealloc =
+        request->allocate.flags & CHIMERA_VFS_ALLOCATE_DEALLOCATE;
+    nfsstat4                    op_status;
+
+    if (unlikely(status)) {
+        request->status = CHIMERA_VFS_EFAULT;
+        request->complete(request);
+        return;
+    }
+
+    if (res->status != NFS4_OK) {
+        request->status = chimera_nfs4_status_to_errno(res->status);
+        request->complete(request);
+        return;
+    }
+
+    /* SEQUENCE + PUTFH + (DE)ALLOCATE */
+    if (res->num_resarray < 3 ||
+        res->resarray[0].opsequence.sr_status != NFS4_OK ||
+        res->resarray[1].opputfh.status != NFS4_OK) {
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+
+    op_status = is_dealloc ?
+        res->resarray[2].opdeallocate.dr_status :
+        res->resarray[2].opallocate.ar_status;
+
+    if (op_status != NFS4_OK) {
+        request->status = chimera_nfs4_status_to_errno(op_status);
+        request->complete(request);
+        return;
+    }
+
+    request->status = CHIMERA_VFS_OK;
+    request->complete(request);
+} /* chimera_nfs4_allocate_callback */
+
+void
+chimera_nfs4_allocate(
+    struct chimera_nfs_thread  *thread,
+    struct chimera_nfs_shared  *shared,
+    struct chimera_vfs_request *request,
+    void                       *private_data)
+{
+    struct chimera_nfs_client_server_thread *server_thread =
+        chimera_nfs_thread_get_server_thread(thread, request->fh, request->fh_len);
+    struct chimera_nfs_client_server        *server;
+    struct chimera_nfs4_client_session      *session;
+    struct chimera_nfs4_open_state          *open_state;
+    struct COMPOUND4args                     args;
+    struct nfs_argop4                        argarray[3];
+    struct evpl_rpc2_cred                    rpc2_cred;
+    uint8_t                                 *fh;
+    int                                      fhlen;
+    int                                      is_dealloc =
+        request->allocate.flags & CHIMERA_VFS_ALLOCATE_DEALLOCATE;
+
+    if (!server_thread) {
+        request->status = CHIMERA_VFS_ESTALE;
+        request->complete(request);
+        return;
+    }
+
+    server  = server_thread->server;
+    session = server->nfs4_session;
+
+    if (!session) {
+        request->status = CHIMERA_VFS_ESTALE;
+        request->complete(request);
+        return;
+    }
+
+    open_state = (struct chimera_nfs4_open_state *) request->allocate.handle->vfs_private;
+
+    chimera_nfs4_map_fh(request->fh, request->fh_len, &fh, &fhlen);
+
+    /* Build compound: SEQUENCE + PUTFH + ALLOCATE/DEALLOCATE.  ALLOCATE and
+     * DEALLOCATE are NFSv4.2 operations, so this compound advertises
+     * minorversion 2 (the server gates ops per-compound minorversion; the
+     * session itself is not pinned to a minor version). */
+    memset(&args, 0, sizeof(args));
+    args.tag.len      = 0;
+    args.minorversion = 2;
+    args.argarray     = argarray;
+    args.num_argarray = 3;
+
+    /* Op 0: SEQUENCE */
+    argarray[0].argop = OP_SEQUENCE;
+
+    /* Op 1: PUTFH */
+    argarray[1].argop               = OP_PUTFH;
+    argarray[1].opputfh.object.data = fh;
+    argarray[1].opputfh.object.len  = fhlen;
+
+    /* Op 2: ALLOCATE or DEALLOCATE -- both carry { stateid, offset, length }. */
+    if (is_dealloc) {
+        argarray[2].argop = OP_DEALLOCATE;
+        if (open_state) {
+            argarray[2].opdeallocate.da_stateid = open_state->stateid;
+        } else {
+            memset(&argarray[2].opdeallocate.da_stateid, 0,
+                   sizeof(argarray[2].opdeallocate.da_stateid));
+        }
+        argarray[2].opdeallocate.da_offset = request->allocate.offset;
+        argarray[2].opdeallocate.da_length = request->allocate.length;
+    } else {
+        argarray[2].argop = OP_ALLOCATE;
+        if (open_state) {
+            argarray[2].opallocate.aa_stateid = open_state->stateid;
+        } else {
+            memset(&argarray[2].opallocate.aa_stateid, 0,
+                   sizeof(argarray[2].opallocate.aa_stateid));
+        }
+        argarray[2].opallocate.aa_offset = request->allocate.offset;
+        argarray[2].opallocate.aa_length = request->allocate.length;
+    }
+
+    chimera_nfs_init_rpc2_cred(&rpc2_cred, request->cred,
+                               request->thread->vfs->machine_name,
+                               request->thread->vfs->machine_name_len);
+
+    chimera_nfs4_compound_call(
+        thread,
+        shared,
+        server_thread,
+        request,
+        &args,
+        &rpc2_cred,
+        0, 0, NULL, 0, 0,
+        chimera_nfs4_allocate_callback,
+        request,
+        chimera_nfs4_dispatch, private_data);
+} /* chimera_nfs4_allocate */

--- a/src/vfs/nfs/nfs_internal.h
+++ b/src/vfs/nfs/nfs_internal.h
@@ -1145,6 +1145,11 @@ void chimera_nfs4_commit(
     struct chimera_nfs_shared *,
     struct chimera_vfs_request *,
     void *);
+void chimera_nfs4_allocate(
+    struct chimera_nfs_thread *,
+    struct chimera_nfs_shared *,
+    struct chimera_vfs_request *,
+    void *);
 void chimera_nfs4_symlink_at(
     struct chimera_nfs_thread *,
     struct chimera_nfs_shared *,


### PR DESCRIPTION
## Summary

Adds a `posix_fallocate(3)` front end to the POSIX client and ports the last unported pjdfstest category that maps to the posix-client/VFS layer.

The VFS already has an `ALLOCATE` op (`chimera_vfs_allocate`) implemented by every local backend (memfs/cairn/diskfs/linux/io_uring) — it reserves space for `[offset, offset+len)` and grows the file to `offset+len` — but it was never exposed above the VFS. This wires it up:

- **Client layer** — new `CHIMERA_CLIENT_OP_ALLOCATE` + `client_allocate.h` dispatch (mirrors `client_commit.h`; reuses the commit callback shape).
- **POSIX layer** — `chimera_posix_fallocate(fd, offset, len)`: rejects `len <= 0` / `offset < 0` with `EINVAL` and a non-writable descriptor with `EBADF`, then dispatches `ALLOCATE`.

## Test

Ports `tests/posix_fallocate/00.t`: grow-empty-file, grow-past-EOF, ctime-updated-on-success, `EINVAL`-leaves-ctime-unchanged, and the FreeBSD #154873 case (the created file's mode must not gate a writable descriptor).

Registered on the **six local backends** (memfs, cairn, diskfs_io_uring, diskfs_aio, linux, io_uring) — **24/24 green on each**. The NFS client backend does not implement `ALLOCATE` (NFSv4.2 `ALLOCATE` is not plumbed through `vfs_nfs`), so NFS variants are not registered.

## Verification

- `posix_fallocate/00` × 6 backends: 24/24 each, stable across repeated ctest runs.
- Full memfs pjd regression + fallocate matrix: 151/151, no regressions from the additive client change.
- `make syntax` clean, copyright-year clean, scan-build clean on the new source, reuse lint compliant.