### PR TITLE
test/smbtorture: un-skip smb2.lock.open-brlock-deadlock

### DIFF
--- a/src/server/smb/tests/smbtorture_test.c
+++ b/src/server/smb/tests/smbtorture_test.c
@@ -141,6 +141,10 @@ run_smbtorture(
                     * exit, so the rules cannot leak between tests.  The default
                     * iptables_command (/usr/sbin/iptables) is correct here. */
                    " --option=torture:use_iptables=yes"
+                   /* smb2.lock.open-brlock-deadlock self-skips without the
+                    * deadlock timeout it uses to bound the blocking-lock wait;
+                    * the option is specific to that test. */
+                   " --option=torture:open_brlock_deadlock_timemout=2"
                    /* SMB3 signing algorithms the client offers (see sign_algos
                     * above): GMAC-first only for the signing/encryption subtests
                     * that require it, CMAC otherwise. */


### PR DESCRIPTION
## Summary

Un-skips `smb2.lock.open-brlock-deadlock` (already enabled in every backend's allowlist) by passing the torture option it requires. **+1 subtest × 6 backends = 6 cells, SKIP → PASS**, harness-only.

The test self-skips with *"Test skipped, pass `--option=torture:open_brlock_deadlock_timemout=SEC` to run"* — it needs a deadlock timeout to bound its blocking-lock wait. Pass `2`; the subtest then runs and passes on all six backends. The option is specific to this test, so no other suite is affected.

## Verification
- `open-brlock-deadlock` 3×-confirmed green on all six backends.
- Other `smb2.lock.*` subtests unaffected (the option is test-specific).
- `make build_release` + `make syntax` clean.

Part of a skip audit (companion to the `smb2.session` signing/encryption un-skip): tests that self-skip only because the harness withheld a parameter or capability chimera already supports.