### PR TITLE
nfs4: send NFSv4.2 ALLOCATE/DEALLOCATE; run posix_fallocate over NFS4

### DIFF
--- a/src/posix/tests/CMakeLists.txt
+++ b/src/posix/tests/CMakeLists.txt
@@ -1315,27 +1315,33 @@ foreach(t ${PJD_GRANULAR_TESTS})
 endforeach()
 
 # posix_fallocate: the VFS ALLOCATE op is implemented by every local backend
-# (memfs/cairn/diskfs/linux/io_uring) but not the NFS client backend (NFSv4.2
-# ALLOCATE is not plumbed through vfs_nfs), so register it on the local backends
-# only -- the same six combos as the direct-backend pjd matrix, minus NFS.
+# (memfs/cairn/diskfs/linux/io_uring) and, over NFSv4.2, by the NFS client
+# backend (vfs_nfs sends OP_ALLOCATE).  Register it on all local backends and
+# all NFSv4 backends, but NOT NFSv3 (no ALLOCATE in the protocol).
 set(PJD_LOCAL_TESTS
     posix_fallocate/00
 )
 foreach(t ${PJD_LOCAL_TESTS})
     add_pjd_testprog(${t})
     add_pjd_test(${t} memfs)
+    add_pjd_nfs_test(${t} nfs4_memfs)
     if(CAIRN_ENABLED)
         add_pjd_test(${t} cairn)
+        add_pjd_nfs_test(${t} nfs4_cairn)
     endif()
     if(IO_URING_ENABLED)
         add_pjd_test(${t} diskfs_io_uring)
+        add_pjd_nfs_test(${t} nfs4_diskfs_io_uring)
     endif()
     if(HAVE_LIBAIO)
         add_pjd_test(${t} diskfs_aio)
+        add_pjd_nfs_test(${t} nfs4_diskfs_aio)
     endif()
     add_pjd_test(${t} linux)
+    add_pjd_nfs_test(${t} nfs4_linux)
     if(CHIMERA_VFS_IO_URING)
         add_pjd_test(${t} io_uring)
+        add_pjd_nfs_test(${t} nfs4_io_uring)
     endif()
 endforeach()
 

--- a/src/server/nfs/nfs4_proc_open.c
+++ b/src/server/nfs/nfs4_proc_open.c
@@ -303,6 +303,7 @@ chimera_nfs4_open_install_state(
     struct nfs_request             *req,
     struct chimera_vfs_open_handle *handle,
     const struct chimera_vfs_attrs *attr,
+    bool                            file_created,
     struct stateid4                *out_stateid,
     uint32_t                       *out_rflags)
 {
@@ -326,8 +327,11 @@ chimera_nfs4_open_install_state(
     /* Enforce the object's ACL against the requested share access before the
      * share-reservation check, so a permission failure surfaces as
      * NFS4ERR_ACCESS (not NFS4ERR_SHARE_DENIED).  `attr` is NULL on a reopen by
-     * filehandle (CLAIM_FH), where access was already established. */
-    if (attr) {
+     * filehandle (CLAIM_FH), where access was already established.  A create
+     * that actually made the file grants the creator the requested access
+     * regardless of the mode it was created with (POSIX/RFC: the access check
+     * is bypassed for the creating open), so skip it when file_created. */
+    if (attr && !file_created) {
         uint32_t required = 0;
 
         if (args->share_access & OPEN4_SHARE_ACCESS_READ) {
@@ -536,6 +540,7 @@ chimera_nfs4_open_exclusive_verify(
         req->fhlen = handle->fh_len;
 
         status = chimera_nfs4_open_install_state(req, handle, attr,
+                                                 handle->r_created,
                                                  &res->resok4.stateid,
                                                  &install_rflags);
         if (status != NFS4_OK) {
@@ -628,6 +633,7 @@ chimera_nfs4_open_at_complete(
         req->fhlen = handle->fh_len;
 
         status = chimera_nfs4_open_install_state(req, handle, attr,
+                                                 handle->r_created,
                                                  &res->resok4.stateid,
                                                  &install_rflags);
         if (status != NFS4_OK) {
@@ -812,7 +818,7 @@ chimera_nfs4_open_claim_fh_complete(
         uint32_t install_rflags = 0;
         lock_caps = handle->vfs_module->capabilities;
 
-        status = chimera_nfs4_open_install_state(req, handle, NULL,
+        status = chimera_nfs4_open_install_state(req, handle, NULL, false,
                                                  &res->resok4.stateid,
                                                  &install_rflags);
         if (status != NFS4_OK) {

--- a/src/vfs/nfs/CMakeLists.txt
+++ b/src/vfs/nfs/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(chimera_vfs_nfs SHARED
     nfs3_setattr.c
     nfs3_symlink_at.c
     nfs3_write.c
+    nfs4_allocate.c
     nfs4_cb.c
     nfs4_close.c
     nfs4_commit.c

--- a/src/vfs/nfs/nfs4.c
+++ b/src/vfs/nfs/nfs4.c
@@ -58,6 +58,9 @@ chimera_nfs4_dispatch(
         case CHIMERA_VFS_OP_COMMIT:
             chimera_nfs4_commit(thread, shared, request, private_data);
             break;
+        case CHIMERA_VFS_OP_ALLOCATE:
+            chimera_nfs4_allocate(thread, shared, request, private_data);
+            break;
         case CHIMERA_VFS_OP_SYMLINK_AT:
             chimera_nfs4_symlink_at(thread, shared, request, private_data);
             break;

--- a/src/vfs/nfs/nfs4_allocate.c
+++ b/src/vfs/nfs/nfs4_allocate.c
@@ -1,0 +1,152 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "nfs_internal.h"
+#include "nfs4_open_state.h"
+#include "vfs/vfs.h"
+
+static void
+chimera_nfs4_allocate_callback(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    struct COMPOUND4res         *res,
+    int                          status,
+    void                        *private_data)
+{
+    struct chimera_vfs_request *request    = private_data;
+    int                         is_dealloc =
+        request->allocate.flags & CHIMERA_VFS_ALLOCATE_DEALLOCATE;
+    nfsstat4                    op_status;
+
+    if (unlikely(status)) {
+        request->status = CHIMERA_VFS_EFAULT;
+        request->complete(request);
+        return;
+    }
+
+    if (res->status != NFS4_OK) {
+        request->status = chimera_nfs4_status_to_errno(res->status);
+        request->complete(request);
+        return;
+    }
+
+    /* SEQUENCE + PUTFH + (DE)ALLOCATE */
+    if (res->num_resarray < 3 ||
+        res->resarray[0].opsequence.sr_status != NFS4_OK ||
+        res->resarray[1].opputfh.status != NFS4_OK) {
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+
+    op_status = is_dealloc ?
+        res->resarray[2].opdeallocate.dr_status :
+        res->resarray[2].opallocate.ar_status;
+
+    if (op_status != NFS4_OK) {
+        request->status = chimera_nfs4_status_to_errno(op_status);
+        request->complete(request);
+        return;
+    }
+
+    request->status = CHIMERA_VFS_OK;
+    request->complete(request);
+} /* chimera_nfs4_allocate_callback */
+
+void
+chimera_nfs4_allocate(
+    struct chimera_nfs_thread  *thread,
+    struct chimera_nfs_shared  *shared,
+    struct chimera_vfs_request *request,
+    void                       *private_data)
+{
+    struct chimera_nfs_client_server_thread *server_thread =
+        chimera_nfs_thread_get_server_thread(thread, request->fh, request->fh_len);
+    struct chimera_nfs_client_server        *server;
+    struct chimera_nfs4_client_session      *session;
+    struct chimera_nfs4_open_state          *open_state;
+    struct COMPOUND4args                     args;
+    struct nfs_argop4                        argarray[3];
+    struct evpl_rpc2_cred                    rpc2_cred;
+    uint8_t                                 *fh;
+    int                                      fhlen;
+    int                                      is_dealloc =
+        request->allocate.flags & CHIMERA_VFS_ALLOCATE_DEALLOCATE;
+
+    if (!server_thread) {
+        request->status = CHIMERA_VFS_ESTALE;
+        request->complete(request);
+        return;
+    }
+
+    server  = server_thread->server;
+    session = server->nfs4_session;
+
+    if (!session) {
+        request->status = CHIMERA_VFS_ESTALE;
+        request->complete(request);
+        return;
+    }
+
+    open_state = (struct chimera_nfs4_open_state *) request->allocate.handle->vfs_private;
+
+    chimera_nfs4_map_fh(request->fh, request->fh_len, &fh, &fhlen);
+
+    /* Build compound: SEQUENCE + PUTFH + ALLOCATE/DEALLOCATE.  ALLOCATE and
+     * DEALLOCATE are NFSv4.2 operations, so this compound advertises
+     * minorversion 2 (the server gates ops per-compound minorversion; the
+     * session itself is not pinned to a minor version). */
+    memset(&args, 0, sizeof(args));
+    args.tag.len      = 0;
+    args.minorversion = 2;
+    args.argarray     = argarray;
+    args.num_argarray = 3;
+
+    /* Op 0: SEQUENCE */
+    argarray[0].argop = OP_SEQUENCE;
+
+    /* Op 1: PUTFH */
+    argarray[1].argop               = OP_PUTFH;
+    argarray[1].opputfh.object.data = fh;
+    argarray[1].opputfh.object.len  = fhlen;
+
+    /* Op 2: ALLOCATE or DEALLOCATE -- both carry { stateid, offset, length }. */
+    if (is_dealloc) {
+        argarray[2].argop = OP_DEALLOCATE;
+        if (open_state) {
+            argarray[2].opdeallocate.da_stateid = open_state->stateid;
+        } else {
+            memset(&argarray[2].opdeallocate.da_stateid, 0,
+                   sizeof(argarray[2].opdeallocate.da_stateid));
+        }
+        argarray[2].opdeallocate.da_offset = request->allocate.offset;
+        argarray[2].opdeallocate.da_length = request->allocate.length;
+    } else {
+        argarray[2].argop = OP_ALLOCATE;
+        if (open_state) {
+            argarray[2].opallocate.aa_stateid = open_state->stateid;
+        } else {
+            memset(&argarray[2].opallocate.aa_stateid, 0,
+                   sizeof(argarray[2].opallocate.aa_stateid));
+        }
+        argarray[2].opallocate.aa_offset = request->allocate.offset;
+        argarray[2].opallocate.aa_length = request->allocate.length;
+    }
+
+    chimera_nfs_init_rpc2_cred(&rpc2_cred, request->cred,
+                               request->thread->vfs->machine_name,
+                               request->thread->vfs->machine_name_len);
+
+    chimera_nfs4_compound_call(
+        thread,
+        shared,
+        server_thread,
+        request,
+        &args,
+        &rpc2_cred,
+        0, 0, NULL, 0, 0,
+        chimera_nfs4_allocate_callback,
+        request,
+        chimera_nfs4_dispatch, private_data);
+} /* chimera_nfs4_allocate */

--- a/src/vfs/nfs/nfs_internal.h
+++ b/src/vfs/nfs/nfs_internal.h
@@ -1145,6 +1145,11 @@ void chimera_nfs4_commit(
     struct chimera_nfs_shared *,
     struct chimera_vfs_request *,
     void *);
+void chimera_nfs4_allocate(
+    struct chimera_nfs_thread *,
+    struct chimera_nfs_shared *,
+    struct chimera_vfs_request *,
+    void *);
 void chimera_nfs4_symlink_at(
     struct chimera_nfs_thread *,
     struct chimera_nfs_shared *,


### PR DESCRIPTION
## Summary

Follow-up to #893 (posix_fallocate). Plumbs the VFS `ALLOCATE` op through the NFS client backend so `posix_fallocate` works over NFSv4, and registers the pjdfstest port over the NFSv4 backends.

- **`vfs_nfs` (client)** — new `nfs4_allocate.c` handles `CHIMERA_VFS_OP_ALLOCATE` by issuing `SEQUENCE + PUTFH + ALLOCATE` (or `DEALLOCATE`, per the `CHIMERA_VFS_ALLOCATE_DEALLOCATE` flag) with the open handle's stateid. Both are NFSv4.2 operations, so the compound advertises **minorversion 2** (the server gates ops per-compound minor version; the session is not pinned to one). The op returns no attrs, which invalidates the client attr cache, so a following `GETATTR` observes the new size — the same path `SETATTR`/`ftruncate` already rely on.

- **nfs4 server OPEN** — a create that actually made the file now grants the creator the requested share access regardless of the mode it was created with (skip the share-access ACL check in `open_install_state` when `handle->r_created`). This matches POSIX/RFC semantics and the local backends; previously a non-root `OPEN(O_CREAT|O_RDWR, 0)` was rejected with `NFS4ERR_ACCESS` over NFSv4 (FreeBSD #154873).

## Test

`posix_fallocate/00` is now registered over all six NFSv4 backends (NFSv3 has no `ALLOCATE`) — **24/24 green on each**.

## Verification

- Full NFSv4 pjd suite + fallocate matrix: **858/858**.
- Combined pynfs across all six backends × {4.0, 4.1, 4.2}: **18/18** (validates the server OPEN change is regression-free).
- scan-build clean on the new/changed source, copyright-year clean, reuse lint compliant.