### PR TITLE
smb/tests: green MultipleChannel encryption-negative WPTS cases

### DIFF
--- a/src/server/smb/tests/wpts/wpts_cases.csv
+++ b/src/server/smb/tests/wpts/wpts_cases.csv
@@ -177,8 +177,8 @@ MultipleChannel_FileLease,multichannel,green,0,
 MultipleChannel_LockUnlockOnDiffChannel,multichannel,green,0,
 MultipleChannel_LockUnlockOnSameChannel,multichannel,green,0,
 MultipleChannel_MultiChannelOnSameNic,multichannel,green,0,
-MultipleChannel_Negative_EncryptionOnAlternativeChannel,base,skip,0,env-2nic
-MultipleChannel_Negative_EncryptionOnMainChannel,base,skip,0,env-2nic
+MultipleChannel_Negative_EncryptionOnAlternativeChannel,multichannel_persistent_encryption,green,0,
+MultipleChannel_Negative_EncryptionOnMainChannel,multichannel_persistent_encryption,green,0,
 MultipleChannel_Negative_SMB2002,multichannel,green,0,
 MultipleChannel_Negative_SMB21,multichannel,green,0,
 MultipleChannel_NicRedundantOnClient,multichannel,green,0,


### PR DESCRIPTION
Promote `MultipleChannel_Negative_EncryptionOnAlternativeChannel` and `MultipleChannel_Negative_EncryptionOnMainChannel` from `skip:env-2nic` to `multichannel_persistent_encryption/green`.

These are SMB3 multichannel failover negatives that verify the server rejects encryption mismatches on the alternative/main channel. They need (a) a second NIC — already supplied by the multichannel config — and (b) per-share encryption enforcement, which landed with the `multichannel_persistent_encryption` config (#887). Like the AppInstanceId encryption cases, they were never truly 2-NIC-blocked; they just needed the right config.

A full WPTS discovery sweep flagged them as stale skips (now passing); this confirms and lands them.

**Verified:** both pass 3× solo and in the full `multichannel_persistent_encryption` batch (memfs) via the `wpts/memfs_multichannel_persistent_encryption` ctest target. No regressions (the discovery sweep showed 0 real green regressions across all 13 configs).