### PR TITLE
smb: reject GMAC-signed session bind onto a non-GMAC session (NOT_SUPPORTED)

### DIFF
--- a/src/server/smb/smb_proc_session_setup.c
+++ b/src/server/smb/smb_proc_session_setup.c
@@ -75,6 +75,29 @@ process_kerberos_auth(
     return rc;
 } // process_kerberos_auth
 
+/* The signing algorithm a connection effectively uses, derived from its dialect
+ * and (for 3.1.1) its negotiated SMB2_SIGNING_* value.  Only 3.1.1 negotiates a
+ * signing algorithm; 2.x is fixed at HMAC-SHA256 and 3.0/3.0.2 at AES-128-CMAC
+ * (MS-SMB2 §3.1.4.1 / §3.3.5.4), and for those dialects negotiated.signing_alg
+ * is left at its 0 default rather than the true algorithm.  Used to compare a
+ * binding connection against the connection the session was established on. */
+static inline uint16_t
+chimera_smb_effective_signing_alg(
+    uint16_t dialect,
+    uint16_t signing_alg)
+{
+    switch (dialect) {
+        case SMB2_DIALECT_2_0_2:
+        case SMB2_DIALECT_2_1:
+            return SMB2_SIGNING_HMAC_SHA256;
+        case SMB2_DIALECT_3_0:
+        case SMB2_DIALECT_3_0_2:
+            return SMB2_SIGNING_AES_CMAC;
+        default: /* 3.1.1: the negotiated algorithm is authoritative. */
+            return signing_alg;
+    } /* switch */
+} /* chimera_smb_effective_signing_alg */
+
 void
 chimera_smb_session_setup(struct chimera_smb_request *request)
 {
@@ -149,33 +172,58 @@ chimera_smb_session_setup(struct chimera_smb_request *request)
         conn->dialect >= SMB2_DIALECT_3_0 &&
         request->smb2_hdr.session_id != 0 &&
         request->session_handle) {
-        struct chimera_smb_session *bind_session = request->session_handle->session;
-        int                         reject       = 0;
+        struct chimera_smb_session *bind_session  = request->session_handle->session;
+        uint32_t                    reject_status = 0;
+        uint16_t                    bind_sign_alg =
+            chimera_smb_effective_signing_alg(conn->dialect,
+                                              conn->negotiated.signing_alg);
+        uint16_t                    sess_sign_alg =
+            chimera_smb_effective_signing_alg(bind_session->dialect,
+                                              bind_session->sign_alg);
 
         if (!(request->smb2_hdr.flags & SMB2_FLAGS_SIGNED)) {
-            reject = 1;
+            reject_status = SMB2_STATUS_INVALID_PARAMETER;
+        } else if ((bind_session->flags & CHIMERA_SMB_SESSION_AUTHORIZED) &&
+                   bind_sign_alg == SMB2_SIGNING_AES_GMAC &&
+                   sess_sign_alg != SMB2_SIGNING_AES_GMAC) {
+            /* MS-SMB2 3.3.5.5: AES-128-GMAC ties the per-message signing key to
+             * the connection's GMAC nonce derivation, so a connection that
+             * negotiated GMAC cannot bind to a session whose establishing
+             * connection used a different (non-GMAC) signing algorithm.  This is
+             * rejected with STATUS_NOT_SUPPORTED -- a DIFFERENT status from the
+             * cipher/dialect/unsigned cases (which return INVALID_PARAMETER).
+             * Checked before the dialect mismatch because a 3.0.2-established
+             * session bound from a 3.1.1/GMAC connection (smb2.session.
+             * bind_negative_smb3signC30toG*) differs in both dialect and signing
+             * algorithm yet must report NOT_SUPPORTED.  smb2.session.bind_
+             * negative_smb3sign{CtoG,HtoG,C30toG} and smb3sne{CtoG,HtoG}
+             * exercise this; the reverse (a non-GMAC connection binding a
+             * GMAC-established session, GtoX) fails earlier in signature
+             * verification, and a CMAC/HMAC mismatch (CtoH or HtoC) is
+             * permitted (bind succeeds). */
+            reject_status = SMB2_STATUS_NOT_SUPPORTED;
         } else if ((bind_session->flags & CHIMERA_SMB_SESSION_AUTHORIZED) &&
                    bind_session->dialect != conn->dialect) {
             /* MS-SMB2 3.3.5.5: the binding connection's dialect MUST equal the
              * dialect of the connection the session was established on
              * (smb2.session.bind_negative_smb3to3* binds a 3.0.2 session from
              * a 3.1.1 connection and expects STATUS_INVALID_PARAMETER). */
-            reject = 1;
+            reject_status = SMB2_STATUS_INVALID_PARAMETER;
         } else if ((bind_session->flags & CHIMERA_SMB_SESSION_AUTHORIZED) &&
                    conn->negotiated.cipher_id != bind_session->conn_cipher_id) {
             /* MS-SMB2 3.3.5.5: likewise the negotiated cipher must match the
              * establishing connection's (smb2.session.bind_negative_
              * smb3encGtoC* negotiates AES-128-GCM on the first connection and
              * AES-128-CCM on the binding one). */
-            reject = 1;
+            reject_status = SMB2_STATUS_INVALID_PARAMETER;
         } else if (conn->dialect == SMB2_DIALECT_3_1_1 &&
                    bind_session->supports_notifications !=
                    conn->supports_notifications) {
-            reject = 1;
+            reject_status = SMB2_STATUS_INVALID_PARAMETER;
         }
 
-        if (reject) {
-            chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
+        if (reject_status) {
+            chimera_smb_complete_request(request, reject_status);
             evpl_iovecs_release(thread->evpl, request->session_setup.input_iov,
                                 request->session_setup.input_niov);
             return;

--- a/src/server/smb/tests/smbtorture_test.c
+++ b/src/server/smb/tests/smbtorture_test.c
@@ -85,18 +85,25 @@ run_smbtorture(
 
     /* SMB3 signing-algorithm offer.  The smb2.session.signing-* and
      * session.encryption-* subtests skip unless the server negotiated signing
-     * >= AES-128-GMAC (they exercise per-algorithm negotiation), so offer GMAC
-     * (preferred) for those.  Every other suite -- including the
-     * bind_negative_smb3sign* cases, which need a signing-mismatch bind
-     * rejection chimera does not yet implement -- stays on AES-128-CMAC so it
-     * keeps its current behaviour rather than un-skipping into a failure.
-     * smb2.session is force-isolated (one daemon per subtest) so this scopes
-     * per-test. */
+     * >= AES-128-GMAC, so offer GMAC (preferred) for those.
+     *
+     * The bind_negative_smb3sign / smb3sne family exercises session-bind
+     * signing-algorithm mismatches.  chimera currently implements only the
+     * non-GMAC-session-bound-from-a-GMAC-connection direction (the *toG cases
+     * -- CtoG/HtoG/C30toG/sneCtoG/sneHtoG -- which MS-SMB2 3.3.5.5 rejects with
+     * STATUS_NOT_SUPPORTED), so offer GMAC only for those (every *toG name
+     * carries the "toG" substring; none of the unimplemented reverse "Gto*"
+     * REQUEST_OUT_OF_SEQUENCE or CMAC<->HMAC cross-bind cases do).  The
+     * remainder keep AES-128-CMAC and so stay skipped rather than un-skipping
+     * into a failure; implementing them is a follow-up.  smb2.session is
+     * force-isolated (one daemon per subtest) so this scopes per-test. */
     const char *sign_algos = "aes-128-cmac";
 
     for (i = 0; i < num_tests; i++) {
         if (strstr(tests[i], "session.signing") != NULL ||
-            strstr(tests[i], "session.encryption") != NULL) {
+            strstr(tests[i], "session.encryption") != NULL ||
+            (strstr(tests[i], "bind_negative_smb3s") != NULL &&
+             strstr(tests[i], "toG") != NULL)) {
             sign_algos = "aes-128-gmac, aes-128-cmac, hmac-sha256";
             break;
         }
@@ -565,6 +572,8 @@ main(
      * that asserts unencrypted behaviour such as reconnect2. */
     for (i = 0; i < num_tests; i++) {
         if (strstr(tests[i], "bind_negative_smb3enc") != NULL ||
+            (strstr(tests[i], "bind_negative_smb3s") != NULL &&
+             strstr(tests[i], "toG") != NULL) ||
             strstr(tests[i], "session.encryption") != NULL ||
             strstr(tests[i], "anon-encryption") != NULL) {
             chimera_server_config_set_smb_encryption(config, 1);


### PR DESCRIPTION
## Summary

On an SMB3 multichannel session bind (SESSION_SETUP with `SMB2_SESSION_FLAG_BINDING`), the binding connection's negotiated signing algorithm must be compatible with the connection the session was established on. AES-128-GMAC ties the per-message signing key to the connection's GMAC nonce derivation, so a connection that negotiated **GMAC** cannot bind to a session whose establishing connection used a **different (non-GMAC)** signing algorithm. Windows/Samba reject this with **`STATUS_NOT_SUPPORTED`** — a *different* status from the cipher/dialect/unsigned bind rejections, which return `STATUS_INVALID_PARAMETER`.

chimera already enforced the analogous **cipher**-match constraint on a bind but never checked **signing**. This adds the missing check.

> Stacks on #894 (`smb-session`), which added the per-test smbtorture harness infrastructure (`sign_algos` selection + per-test encryption-enable loop) this PR extends. Based on `main` for review; the diff is just the two-file delta on top of #894.

## The fix

- **`smb_proc_session_setup.c`**: replace the bind-validation `int reject` boolean with a `uint32_t reject_status` so different mismatches can return different statuses. Add a GMAC-mismatch case returning `STATUS_NOT_SUPPORTED`, evaluated **before** the dialect-mismatch case so a 3.0.2-established session bound from a 3.1.1/GMAC connection (which differs in *both* dialect and signing algorithm) reports `NOT_SUPPORTED` rather than `INVALID_PARAMETER`. The existing cipher / notifications / dialect / unsigned cases keep returning `INVALID_PARAMETER` (the `bind_negative_smb3enc*`, `smb3to3*` and SupportsNotifications tests depend on that).
- A new `chimera_smb_effective_signing_alg()` helper resolves the true per-dialect signing algorithm (2.x = HMAC-SHA256, 3.0/3.0.2 = AES-128-CMAC, 3.1.1 = negotiated), since `negotiated.signing_alg` is only populated for 3.1.1. The establishing connection's algorithm is read from the existing `session->sign_alg` + `session->dialect` — no new session field is needed (`sign_alg` already records the establishing connection's signing algorithm).

The reverse case (a non-GMAC connection binding a GMAC-established session) fails earlier in signature verification, and a CMAC↔HMAC mismatch is *permitted* (the bind succeeds); both match Windows behaviour.

## Harness scoping

The `bind_negative_smb3sign*`/`smb3sne*` subtests skip unless the server negotiated signing >= GMAC and they connect with encryption REQUIRED. The two existing per-test conditionals in `run_smbtorture` (the GMAC signing-algo offer and the encryption-enable loop) are extended to match these test names. `smb2.session` is force-isolated (one daemon per subtest, `SMBTORTURE_ISOLATE_SUITES`), so the scoping stays per-test and never bleeds into suites that assert CMAC/unencrypted behaviour (e.g. `reconnect2`).

## Tests greened

10 tests flip SKIP→PASS, **3×-confirmed on all six backends** (memfs, linux, io_uring, cairn, diskfs_io_uring, diskfs_aio — signing is transport-level, so backend-agnostic):

- `bind_negative_smb3signCtoGd` / `…CtoGs`
- `bind_negative_smb3signHtoGd` / `…HtoGs`
- `bind_negative_smb3signC30toGd` / `…C30toGs`
- `bind_negative_smb3sneCtoGd` / `…CtoGs`
- `bind_negative_smb3sneHtoGd` / `…HtoGs`

These are already in the per-backend `SMBTORTURE_ENABLED_*` allowlists (enabled-but-skipping), so **no CMakeLists allowlist change is needed**.

Not greened (out of scope for this PR):
- `…smb3signH2XtoG{d,s}` — self-skip ("Can't test SMB 2.10 if encryption is required"): they establish a 2.x session but our harness sets encryption REQUIRED, so the test skips inherently.
- `…smb3signGtoC*/GtoH*/sneGtoC/sneGtoH` — expect `STATUS_REQUEST_OUT_OF_SEQUENCE` (a *non*-GMAC connection binding a GMAC-established session must fail signature verification); chimera does not yet implement that path. Pre-existing, unchanged.
- `…smb3signCtoH*/HtoC*` — expect the bind to *succeed* (`NT_STATUS_OK`); the bind now correctly succeeds, but a later "session-setup without keys" leg returns `CONNECTION_DISCONNECTED` instead of `ACCESS_DENIED` (pre-existing, separate defect).

## Regression check

Re-ran the full enabled `smb2.session` suite on memfs: no test went PASS→FAIL/SKIP. `bind1`, `bind2`, `bind_invalid_auth`, `bind_negative_smb3encGtoC{d,s}` (cipher mismatch, still `INVALID_PARAMETER`), `reconnect2`, `reauth1/2/3/6` all still PASS. Non-matching suites keep CMAC and no encryption.

`make syntax` clean, Release `-Werror` clean, scan-build "No bugs found" on both changed TUs, copyright-year clean.