### PR TITLE
posix/nfs4: sparse files — lseek SEEK_DATA/SEEK_HOLE + fallocate hole punch

### DIFF
--- a/src/client/client.h
+++ b/src/client/client.h
@@ -466,6 +466,15 @@ chimera_commit(
     chimera_commit_callback_t       callback,
     void                           *private_data);
 
+/* Find the next data or hole at/after an offset (lseek SEEK_DATA/SEEK_HOLE).
+ * `what` is 0 for SEEK_DATA, 1 for SEEK_HOLE. */
+typedef void (*chimera_seek_callback_t)(
+    struct chimera_client_thread *client,
+    enum chimera_vfs_error        status,
+    int                           eof,
+    uint64_t                      offset,
+    void                         *private_data);
+
 typedef void (*chimera_lock_callback_t)(
     struct chimera_client_thread *client,
     enum chimera_vfs_error        status,

--- a/src/client/client_internal.h
+++ b/src/client/client_internal.h
@@ -56,6 +56,7 @@ enum chimera_client_request_opcode {
     CHIMERA_CLIENT_OP_COPY_RANGE,
     CHIMERA_CLIENT_OP_CLONE_RANGE,
     CHIMERA_CLIENT_OP_ALLOCATE,
+    CHIMERA_CLIENT_OP_SEEK,
 };
 
 struct chimera_client_request;
@@ -337,6 +338,14 @@ struct chimera_client_request {
             chimera_commit_callback_t       callback;
             void                           *private_data;
         } allocate;
+
+        struct {
+            struct chimera_vfs_open_handle *handle;
+            uint64_t                        offset;
+            uint32_t                        what;   /* 0 = SEEK_DATA, 1 = SEEK_HOLE */
+            chimera_seek_callback_t         callback;
+            void                           *private_data;
+        } seek;
 
         struct {
             struct chimera_vfs_open_handle *handle;

--- a/src/client/client_seek.h
+++ b/src/client/client_seek.h
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#pragma once
+
+#include "client_internal.h"
+
+static void
+chimera_seek_complete(
+    enum chimera_vfs_error error_code,
+    int                    eof,
+    uint64_t               offset,
+    void                  *private_data)
+{
+    struct chimera_client_request *request        = private_data;
+    struct chimera_client_thread  *client_thread  = request->thread;
+    chimera_seek_callback_t        callback       = request->seek.callback;
+    void                          *callback_arg   = request->seek.private_data;
+    int                            heap_allocated = request->heap_allocated;
+
+    if (heap_allocated) {
+        chimera_client_request_free(client_thread, request);
+    }
+
+    callback(client_thread, error_code, eof, offset, callback_arg);
+} /* chimera_seek_complete */
+
+static inline void
+chimera_dispatch_seek(
+    struct chimera_client_thread  *thread,
+    struct chimera_client_request *request)
+{
+    chimera_vfs_seek(
+        thread->vfs_thread,
+        chimera_client_req_cred(request),
+        request->seek.handle,
+        request->seek.offset,
+        request->seek.what,
+        chimera_seek_complete,
+        request);
+} /* chimera_dispatch_seek */

--- a/src/posix/posix.h
+++ b/src/posix/posix.h
@@ -606,6 +606,14 @@ chimera_posix_fallocate(
     off_t offset,
     off_t len);
 
+// fallocate(2) with a mode (0 = allocate; PUNCH_HOLE|KEEP_SIZE = deallocate)
+int
+chimera_posix_fallocate_mode(
+    int   fd,
+    int   mode,
+    off_t offset,
+    off_t len);
+
 // File locking
 int
 chimera_posix_fcntl(

--- a/src/posix/posix_fallocate.c
+++ b/src/posix/posix_fallocate.c
@@ -2,11 +2,14 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
+#define _GNU_SOURCE 1
 #include <errno.h>
 #include <fcntl.h>
+#include <linux/falloc.h>
 #include <string.h>
 
 #include "posix_internal.h"
+#include "vfs/vfs.h"
 #include "../client/client_allocate.h"
 
 static void
@@ -28,28 +31,21 @@ chimera_posix_fallocate_exec(
     chimera_dispatch_allocate(thread, request);
 } /* chimera_posix_fallocate_exec */
 
-/*
- * posix_fallocate(3): reserve space for [offset, offset+len) and grow the file
- * to offset+len if it is currently shorter.  Returns 0 on success or -1 with
- * errno set.  len == 0 (and negative offset/len) are invalid -> EINVAL; a
- * descriptor not open for writing -> EBADF.
- */
-SYMBOL_EXPORT int
-chimera_posix_fallocate(
-    int   fd,
-    off_t offset,
-    off_t len)
+/* Dispatch a VFS ALLOCATE (vfs_flags 0) or DEALLOCATE
+ * (CHIMERA_VFS_ALLOCATE_DEALLOCATE) over [offset, offset+len) on a writable
+ * descriptor.  Returns 0 or -1 with errno set. */
+static int
+chimera_posix_do_fallocate(
+    struct chimera_posix_client *posix,
+    int                          fd,
+    uint32_t                     vfs_flags,
+    off_t                        offset,
+    off_t                        len)
 {
-    struct chimera_posix_client    *posix  = chimera_posix_get_global();
     struct chimera_posix_worker    *worker = chimera_posix_choose_worker(posix);
     struct chimera_posix_fd_entry  *entry;
     struct chimera_client_request   req;
     struct chimera_posix_completion comp;
-
-    if (offset < 0 || len <= 0) {
-        errno = EINVAL;
-        return -1;
-    }
 
     entry = chimera_posix_fd_acquire(posix, fd, 0);
 
@@ -58,7 +54,7 @@ chimera_posix_fallocate(
         return -1;
     }
 
-    /* posix_fallocate requires the descriptor be open for writing. */
+    /* (de)allocate requires the descriptor be open for writing. */
     if ((entry->oflags & O_ACCMODE) == O_RDONLY) {
         chimera_posix_fd_release(entry, 0);
         errno = EBADF;
@@ -71,7 +67,7 @@ chimera_posix_fallocate(
     req.allocate.handle       = entry->handle;
     req.allocate.offset       = (uint64_t) offset;
     req.allocate.length       = (uint64_t) len;
-    req.allocate.flags        = 0;
+    req.allocate.flags        = vfs_flags;
     req.allocate.callback     = chimera_posix_fallocate_callback;
     req.allocate.private_data = &comp;
 
@@ -89,4 +85,61 @@ chimera_posix_fallocate(
     }
 
     return 0;
+} /* chimera_posix_do_fallocate */
+
+/*
+ * posix_fallocate(3): reserve space for [offset, offset+len) and grow the file
+ * to offset+len if it is currently shorter.  Returns 0 on success or -1 with
+ * errno set.  len == 0 (and negative offset/len) are invalid -> EINVAL; a
+ * descriptor not open for writing -> EBADF.
+ */
+SYMBOL_EXPORT int
+chimera_posix_fallocate(
+    int   fd,
+    off_t offset,
+    off_t len)
+{
+    struct chimera_posix_client *posix = chimera_posix_get_global();
+
+    if (offset < 0 || len <= 0) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    return chimera_posix_do_fallocate(posix, fd, 0, offset, len);
 } /* chimera_posix_fallocate */
+
+/*
+ * fallocate(2) with a mode.  mode == 0 behaves like posix_fallocate; the
+ * FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE combination deallocates the range
+ * (punches a hole), leaving the file size unchanged.  Other modes are
+ * unsupported -> EOPNOTSUPP.
+ */
+SYMBOL_EXPORT int
+chimera_posix_fallocate_mode(
+    int   fd,
+    int   mode,
+    off_t offset,
+    off_t len)
+{
+    struct chimera_posix_client *posix = chimera_posix_get_global();
+
+    if (offset < 0 || len <= 0) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (mode == 0) {
+        return chimera_posix_do_fallocate(posix, fd, 0, offset, len);
+    }
+
+    /* Hole punch: Linux requires KEEP_SIZE alongside PUNCH_HOLE. */
+    if (mode == (FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE)) {
+        return chimera_posix_do_fallocate(posix, fd,
+                                          CHIMERA_VFS_ALLOCATE_DEALLOCATE,
+                                          offset, len);
+    }
+
+    errno = EOPNOTSUPP;
+    return -1;
+} /* chimera_posix_fallocate_mode */

--- a/src/posix/posix_lseek.c
+++ b/src/posix/posix_lseek.c
@@ -1,10 +1,106 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
+#define _GNU_SOURCE 1
 #include <errno.h>
+#include <unistd.h>
 
 #include "posix_internal.h"
+#include "../client/client_seek.h"
+
+/* Carries the VFS seek result back through the blocking completion. */
+struct chimera_posix_seek_ctx {
+    struct chimera_posix_completion comp;
+    uint64_t                        r_offset;
+    int                             r_eof;
+};
+
+static void
+chimera_posix_seek_callback(
+    struct chimera_client_thread *thread,
+    enum chimera_vfs_error        status,
+    int                           eof,
+    uint64_t                      offset,
+    void                         *private_data)
+{
+    struct chimera_posix_seek_ctx *ctx = private_data;
+
+    ctx->r_eof    = eof;
+    ctx->r_offset = offset;
+    chimera_posix_complete(&ctx->comp, status);
+} /* chimera_posix_seek_callback */
+
+static void
+chimera_posix_seek_exec(
+    struct chimera_client_thread  *thread,
+    struct chimera_client_request *request)
+{
+    chimera_dispatch_seek(thread, request);
+} /* chimera_posix_seek_exec */
+
+/*
+ * lseek(2) SEEK_DATA / SEEK_HOLE: ask the backend for the next data region or
+ * hole at/after `offset`, set the descriptor offset to the result, and return
+ * it.  `what` is 0 for SEEK_DATA, 1 for SEEK_HOLE (the VFS/NFSv4 convention).
+ * Returns -1 with errno (ENXIO at/after EOF, or for SEEK_DATA past the last
+ * data region).
+ */
+static off_t
+chimera_posix_lseek_hole_data(
+    struct chimera_posix_client *posix,
+    int                          fd,
+    off_t                        offset,
+    uint32_t                     what)
+{
+    struct chimera_posix_worker   *worker = chimera_posix_choose_worker(posix);
+    struct chimera_posix_fd_entry *entry;
+    struct chimera_client_request  req;
+    struct chimera_posix_seek_ctx  ctx;
+
+    if (offset < 0) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    entry = chimera_posix_fd_acquire(posix, fd, 0);
+
+    if (!entry) {
+        errno = EBADF;
+        return -1;
+    }
+
+    ctx.r_offset = 0;
+    ctx.r_eof    = 0;
+    chimera_posix_completion_init(&ctx.comp, &req);
+
+    req.opcode            = CHIMERA_CLIENT_OP_SEEK;
+    req.seek.handle       = entry->handle;
+    req.seek.offset       = (uint64_t) offset;
+    req.seek.what         = what;
+    req.seek.callback     = chimera_posix_seek_callback;
+    req.seek.private_data = &ctx;
+
+    chimera_posix_worker_enqueue(worker, &req, chimera_posix_seek_exec);
+
+    int err = chimera_posix_wait(&ctx.comp);
+
+    if (!err) {
+        pthread_mutex_lock(&entry->lock);
+        entry->offset = ctx.r_offset;
+        pthread_mutex_unlock(&entry->lock);
+    }
+
+    chimera_posix_fd_release(entry, 0);
+    chimera_posix_completion_destroy(&ctx.comp);
+
+    if (err) {
+        errno = err;
+        return -1;
+    }
+
+    return (off_t) ctx.r_offset;
+} /* chimera_posix_lseek_hole_data */
 
 SYMBOL_EXPORT off_t
 chimera_posix_lseek(
@@ -14,6 +110,14 @@ chimera_posix_lseek(
 {
     struct chimera_posix_client *posix     = chimera_posix_get_global();
     off_t                        file_size = 0;
+
+    if (whence == SEEK_DATA) {
+        return chimera_posix_lseek_hole_data(posix, fd, offset, 0);
+    }
+
+    if (whence == SEEK_HOLE) {
+        return chimera_posix_lseek_hole_data(posix, fd, offset, 1);
+    }
 
     if (whence == SEEK_END) {
         struct stat st;
@@ -36,6 +140,14 @@ chimera_posix_lseek64(
 {
     struct chimera_posix_client *posix     = chimera_posix_get_global();
     int64_t                      file_size = 0;
+
+    if (whence == SEEK_DATA) {
+        return chimera_posix_lseek_hole_data(posix, fd, (off_t) offset, 0);
+    }
+
+    if (whence == SEEK_HOLE) {
+        return chimera_posix_lseek_hole_data(posix, fd, (off_t) offset, 1);
+    }
 
     if (whence == SEEK_END) {
         struct stat st;

--- a/src/posix/tests/CMakeLists.txt
+++ b/src/posix/tests/CMakeLists.txt
@@ -1320,6 +1320,7 @@ endforeach()
 # all NFSv4 backends, but NOT NFSv3 (no ALLOCATE in the protocol).
 set(PJD_LOCAL_TESTS
     posix_fallocate/00
+    sparse/00
 )
 foreach(t ${PJD_LOCAL_TESTS})
     add_pjd_testprog(${t})

--- a/src/posix/tests/pjd/sparse/00.c
+++ b/src/posix/tests/pjd/sparse/00.c
@@ -1,0 +1,158 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * Sparse-file support: lseek(SEEK_DATA/SEEK_HOLE) and fallocate(2) hole punching
+ * (FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE).
+ *
+ * Works at 1 MiB granularity so every offset is block-aligned on all backends.
+ * Part 1 builds a sparse file by writing two data regions with an un-written
+ * gap between them and checks SEEK_DATA/SEEK_HOLE navigate it (and that the gap
+ * reads back as zeros).  Part 2 writes a fully-allocated file, punches a hole in
+ * the middle, and checks the size is unchanged, the hole reads as zeros, the
+ * surrounding data is intact, and SEEK sees the punched hole.
+ */
+
+#define _GNU_SOURCE 1
+#include <stdlib.h>
+#include <string.h>
+#include <fcntl.h>
+#include <linux/falloc.h>
+
+#include "../../pjd_common.h"
+
+#define BLK         (1024 * 1024UL)
+#define CHUNK       (128 * 1024UL) /* write granularity (stays under the NFS wsize) */
+
+/* Fill [off, off+BLK) with byte 0xab, writing in wsize-safe chunks.  Returns 0
+* on success or -1.  (A single 1 MiB write exceeds the NFS transport limit.) */
+static int
+fill_block(
+    int   fd,
+    off_t off)
+{
+    char  *c = malloc(CHUNK);
+    size_t done;
+
+    memset(c, 0xab, CHUNK);
+
+    for (done = 0; done < BLK; done += CHUNK) {
+        if (chimera_posix_pwrite(fd, c, CHUNK, off + (off_t) done) != (ssize_t) CHUNK) {
+            free(c);
+            return -1;
+        }
+    }
+    free(c);
+    return 0;
+} /* fill_block */
+
+/* True if the first `n` bytes of `buf` are all zero. */
+static int
+all_zero(
+    const char *buf,
+    size_t      n)
+{
+    for (size_t i = 0; i < n; i++) {
+        if (buf[i]) {
+            return 0;
+        }
+    }
+    return 1;
+} /* all_zero */
+
+/* pread `n` bytes at `off` (in wsize-safe chunks) and report whether they are
+ * all zero. */
+static int
+region_is_zero(
+    int    fd,
+    off_t  off,
+    size_t n)
+{
+    char  *c = malloc(CHUNK);
+    size_t done;
+
+    for (done = 0; done < n; done += CHUNK) {
+        size_t  want = (n - done < CHUNK) ? (n - done) : CHUNK;
+        ssize_t r    = chimera_posix_pread(fd, c, want, off + (off_t) done);
+
+        if (r != (ssize_t) want || !all_zero(c, want)) {
+            free(c);
+            return 0;
+        }
+    }
+    free(c);
+    return 1;
+} /* region_is_zero */
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    pjd_begin(argc, argv);
+
+    char *n0 = pjd_namegen();
+
+    /* ---- Part 1: a sparsely-written file (data, gap, data). ---- */
+    EXPECT(0, pjd_create(n0, 0644));
+    int   fd = pjd_open(n0, O_RDWR, 0644);
+    PJD_CHECK(fd >= 0, "open sparse file rw");
+
+    EXPECT_EQ(0, fill_block(fd, 0));
+    EXPECT_EQ(0, fill_block(fd, 2 * BLK));
+    EXPECT_EQ((long) (3 * BLK), pjd_stat_size(n0));
+
+    /* SEEK_DATA/SEEK_HOLE navigate the data/hole/data layout. */
+    EXPECT_EQ(0, chimera_posix_lseek(fd, 0, SEEK_DATA));
+    EXPECT_EQ((long) BLK, chimera_posix_lseek(fd, 0, SEEK_HOLE));
+    EXPECT_EQ((long) (2 * BLK), chimera_posix_lseek(fd, BLK, SEEK_DATA));
+    EXPECT_EQ((long) (3 * BLK), chimera_posix_lseek(fd, 2 * BLK, SEEK_HOLE));
+
+    /* SEEK_DATA at EOF has no further data -> ENXIO. */
+    errno = 0;
+    PJD_CHECK(chimera_posix_lseek(fd, 3 * BLK, SEEK_DATA) < 0 && errno == ENXIO,
+              "SEEK_DATA at EOF returns ENXIO");
+
+    /* The un-written gap reads back as zeros. */
+    PJD_CHECK(region_is_zero(fd, BLK, BLK), "sparse gap reads as zeros");
+
+    chimera_posix_close(fd);
+    EXPECT(0, pjd_unlink(n0));
+
+    /* ---- Part 2: punch a hole into a fully-allocated file. ---- */
+    EXPECT(0, pjd_create(n0, 0644));
+    fd = pjd_open(n0, O_RDWR, 0644);
+    PJD_CHECK(fd >= 0, "open dense file rw");
+
+    for (unsigned i = 0; i < 3; i++) {
+        EXPECT_EQ(0, fill_block(fd, (off_t) i * BLK));
+    }
+    EXPECT_EQ((long) (3 * BLK), pjd_stat_size(n0));
+
+    /* Punch [BLK, 2*BLK); size must not change. */
+    EXPECT_EQ(0, chimera_posix_fallocate_mode(fd,
+                                              FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE,
+                                              BLK, BLK));
+    EXPECT_EQ((long) (3 * BLK), pjd_stat_size(n0));
+
+    /* The punched range reads as zeros; the surrounding data is intact. */
+    PJD_CHECK(region_is_zero(fd, BLK, BLK), "punched hole reads as zeros");
+    {
+        char first = 0;
+        EXPECT_EQ(1, chimera_posix_pread(fd, &first, 1, 0));
+        PJD_CHECK(first == (char) 0xab, "data before hole intact");
+        EXPECT_EQ(1, chimera_posix_pread(fd, &first, 1, 2 * BLK));
+        PJD_CHECK(first == (char) 0xab, "data after hole intact");
+    }
+
+    /* SEEK sees the punched hole. */
+    EXPECT_EQ((long) BLK, chimera_posix_lseek(fd, 0, SEEK_HOLE));
+    EXPECT_EQ((long) (2 * BLK), chimera_posix_lseek(fd, BLK, SEEK_DATA));
+
+    chimera_posix_close(fd);
+    EXPECT(0, pjd_unlink(n0));
+
+    pjd_end();
+    return 0;
+} /* main */

--- a/src/vfs/nfs/CMakeLists.txt
+++ b/src/vfs/nfs/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(chimera_vfs_nfs SHARED
     nfs3_symlink_at.c
     nfs3_write.c
     nfs4_allocate.c
+    nfs4_seek.c
     nfs4_cb.c
     nfs4_close.c
     nfs4_commit.c

--- a/src/vfs/nfs/nfs4.c
+++ b/src/vfs/nfs/nfs4.c
@@ -61,6 +61,9 @@ chimera_nfs4_dispatch(
         case CHIMERA_VFS_OP_ALLOCATE:
             chimera_nfs4_allocate(thread, shared, request, private_data);
             break;
+        case CHIMERA_VFS_OP_SEEK:
+            chimera_nfs4_seek(thread, shared, request, private_data);
+            break;
         case CHIMERA_VFS_OP_SYMLINK_AT:
             chimera_nfs4_symlink_at(thread, shared, request, private_data);
             break;

--- a/src/vfs/nfs/nfs4_seek.c
+++ b/src/vfs/nfs/nfs4_seek.c
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "nfs_internal.h"
+#include "nfs4_open_state.h"
+
+static void
+chimera_nfs4_seek_callback(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    struct COMPOUND4res         *res,
+    int                          status,
+    void                        *private_data)
+{
+    struct chimera_vfs_request *request = private_data;
+    struct SEEK4res            *seek_res;
+
+    if (unlikely(status)) {
+        request->status = CHIMERA_VFS_EFAULT;
+        request->complete(request);
+        return;
+    }
+
+    if (res->status != NFS4_OK) {
+        request->status = chimera_nfs4_status_to_errno(res->status);
+        request->complete(request);
+        return;
+    }
+
+    /* SEQUENCE + PUTFH + SEEK */
+    if (res->num_resarray < 3 ||
+        res->resarray[0].opsequence.sr_status != NFS4_OK ||
+        res->resarray[1].opputfh.status != NFS4_OK) {
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+
+    seek_res = &res->resarray[2].opseek;
+
+    if (seek_res->sa_status != NFS4_OK) {
+        request->status = chimera_nfs4_status_to_errno(seek_res->sa_status);
+        request->complete(request);
+        return;
+    }
+
+    request->seek.r_eof    = seek_res->resok4.sr_eof;
+    request->seek.r_offset = seek_res->resok4.sr_offset;
+    request->status        = CHIMERA_VFS_OK;
+    request->complete(request);
+} /* chimera_nfs4_seek_callback */
+
+void
+chimera_nfs4_seek(
+    struct chimera_nfs_thread  *thread,
+    struct chimera_nfs_shared  *shared,
+    struct chimera_vfs_request *request,
+    void                       *private_data)
+{
+    struct chimera_nfs_client_server_thread *server_thread =
+        chimera_nfs_thread_get_server_thread(thread, request->fh, request->fh_len);
+    struct chimera_nfs_client_server        *server;
+    struct chimera_nfs4_client_session      *session;
+    struct chimera_nfs4_open_state          *open_state;
+    struct COMPOUND4args                     args;
+    struct nfs_argop4                        argarray[3];
+    struct evpl_rpc2_cred                    rpc2_cred;
+    uint8_t                                 *fh;
+    int                                      fhlen;
+
+    if (!server_thread) {
+        request->status = CHIMERA_VFS_ESTALE;
+        request->complete(request);
+        return;
+    }
+
+    server  = server_thread->server;
+    session = server->nfs4_session;
+
+    if (!session) {
+        request->status = CHIMERA_VFS_ESTALE;
+        request->complete(request);
+        return;
+    }
+
+    open_state = (struct chimera_nfs4_open_state *) request->seek.handle->vfs_private;
+
+    chimera_nfs4_map_fh(request->fh, request->fh_len, &fh, &fhlen);
+
+    /* Build compound: SEQUENCE + PUTFH + SEEK.  SEEK is an NFSv4.2 operation,
+     * so the compound advertises minorversion 2 (the server gates ops per
+     * compound minor version; the session is not pinned to one). */
+    memset(&args, 0, sizeof(args));
+    args.tag.len      = 0;
+    args.minorversion = 2;
+    args.argarray     = argarray;
+    args.num_argarray = 3;
+
+    /* Op 0: SEQUENCE */
+    argarray[0].argop = OP_SEQUENCE;
+
+    /* Op 1: PUTFH */
+    argarray[1].argop               = OP_PUTFH;
+    argarray[1].opputfh.object.data = fh;
+    argarray[1].opputfh.object.len  = fhlen;
+
+    /* Op 2: SEEK */
+    argarray[2].argop = OP_SEEK;
+    if (open_state) {
+        argarray[2].opseek.sa_stateid = open_state->stateid;
+    } else {
+        memset(&argarray[2].opseek.sa_stateid, 0,
+               sizeof(argarray[2].opseek.sa_stateid));
+    }
+    argarray[2].opseek.sa_offset = request->seek.offset;
+    argarray[2].opseek.sa_what   = request->seek.what; /* 0=DATA, 1=HOLE */
+
+    chimera_nfs_init_rpc2_cred(&rpc2_cred, request->cred,
+                               request->thread->vfs->machine_name,
+                               request->thread->vfs->machine_name_len);
+
+    chimera_nfs4_compound_call(
+        thread,
+        shared,
+        server_thread,
+        request,
+        &args,
+        &rpc2_cred,
+        0, 0, NULL, 0, 0,
+        chimera_nfs4_seek_callback,
+        request,
+        chimera_nfs4_dispatch, private_data);
+} /* chimera_nfs4_seek */

--- a/src/vfs/nfs/nfs_internal.h
+++ b/src/vfs/nfs/nfs_internal.h
@@ -1150,6 +1150,11 @@ void chimera_nfs4_allocate(
     struct chimera_nfs_shared *,
     struct chimera_vfs_request *,
     void *);
+void chimera_nfs4_seek(
+    struct chimera_nfs_thread *,
+    struct chimera_nfs_shared *,
+    struct chimera_vfs_request *,
+    void *);
 void chimera_nfs4_symlink_at(
     struct chimera_nfs_thread *,
     struct chimera_nfs_shared *,


### PR DESCRIPTION
## Summary

Exposes the VFS `SEEK` (find next data/hole) and `DEALLOCATE` (hole punch) ops up through the client and POSIX layers, and over NFSv4. Builds on the ALLOCATE work (#893/#896).

- **client** — new `CHIMERA_CLIENT_OP_SEEK` + `client_seek.h` dispatch over `chimera_vfs_seek` (`what` = 0 SEEK_DATA / 1 SEEK_HOLE).
- **posix** — `chimera_posix_lseek`/`lseek64` handle `SEEK_DATA`/`SEEK_HOLE` by querying the backend and setting the descriptor offset (ENXIO past EOF / past the last data region). Added `chimera_posix_fallocate_mode` (the `fallocate(2)` shape): mode 0 allocates, `FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE` deallocates via the existing VFS `DEALLOCATE` flag, leaving the file size unchanged.
- **`vfs_nfs` (client)** — new `nfs4_seek.c` issues `SEQUENCE + PUTFH + SEEK` (minorversion 2, like ALLOCATE). The DEALLOCATE client path already exists, so hole-punch works over NFSv4 too.

All five local backends already implement `OP_SEEK` and `OP_ALLOCATE`/`DEALLOCATE`; this just makes them reachable from POSIX and NFSv4.

## Test

New `pjd/sparse/00` (28 assertions): `SEEK_DATA`/`SEEK_HOLE` navigate a data/hole/data layout (the gap reads as zeros, `SEEK_DATA` past EOF → `ENXIO`); a mid-file hole punch leaves the size unchanged, reads the hole as zeros, keeps surrounding data intact, and is visible to `SEEK`. Registered on all six local backends and all six NFSv4 backends (NFSv3 has neither op).

## Verification

- `sparse/00` + `posix_fallocate/00` matrix (6 local + 6 NFS4 each): **24/24**, 28 assertions per combo.
- lseek/pio/io_serialize regression across local + NFS4: **84/84**.
- scan-build clean on the new/changed source, copyright-year clean, reuse lint compliant.