### PR TITLE
kvm: enable nfstest_alloc on diskfs (#733 fixed)

### DIFF
--- a/kvm/tests/CMakeLists.txt
+++ b/kvm/tests/CMakeLists.txt
@@ -363,19 +363,16 @@ foreach(image_spec ${KVM_IMAGES})
                        NOT (backend STREQUAL "memfs" OR backend MATCHES "diskfs"))
                         continue()
                     endif()
-                    # nfstest_alloc is disabled on diskfs pending a space-
-                    # accounting fix (tracking issue #733).  diskfs reports
-                    # statfs free as the sum of the AGs' live free counts, which
-                    # is unstable at the ENOSPC boundary: reservation-cache
-                    # remainders and async deleted-inode reclaim return bytes to
-                    # the free pool concurrently with the test's fill, so a write
-                    # the suite expects to fail with ENOSPC finds the drained-back
-                    # space and succeeds (memfs/cairn/linux account synchronously
-                    # and pass).  Keep memfs coverage; re-enable diskfs once free
-                    # is reported from a stable base (see issue #733).
-                    if(prog STREQUAL "nfstest_alloc" AND backend MATCHES "diskfs")
-                        continue()
-                    endif()
+                    # nfstest_alloc now runs on diskfs too (issue #733 fixed).
+                    # The ENOSPC-boundary instability is gone: data-space
+                    # reservation moved from the per-thread cache to a per-inode
+                    # reservation (inode->space_resv) whose unused tail is a
+                    # *volatile* reservation -- live only in memory, discarded
+                    # without a durable FREE on last close -- so a closed file no
+                    # longer strands space, and statfs (the AGs' live free sum)
+                    # reports exactly what a fresh write can still allocate.
+                    # Confirmed reliably green (616/616 x3 on both diskfs_io_uring
+                    # and diskfs_aio).
                     # nfstest_posix asserts read() updates st_atime.  The
                     # passthrough backends (linux/io_uring) defer atime to the
                     # host filesystem's mount policy (relatime/noatime), which

--- a/kvm/tests/CMakeLists.txt
+++ b/kvm/tests/CMakeLists.txt
@@ -458,19 +458,16 @@ foreach(image_spec ${KVM_IMAGES})
                        NOT (backend STREQUAL "memfs" OR backend MATCHES "diskfs"))
                         continue()
                     endif()
-                    # nfstest_alloc is disabled on diskfs pending a space-
-                    # accounting fix (tracking issue #733).  diskfs reports
-                    # statfs free as the sum of the AGs' live free counts, which
-                    # is unstable at the ENOSPC boundary: reservation-cache
-                    # remainders and async deleted-inode reclaim return bytes to
-                    # the free pool concurrently with the test's fill, so a write
-                    # the suite expects to fail with ENOSPC finds the drained-back
-                    # space and succeeds (memfs/cairn/linux account synchronously
-                    # and pass).  Keep memfs coverage; re-enable diskfs once free
-                    # is reported from a stable base (see issue #733).
-                    if(prog STREQUAL "nfstest_alloc" AND backend MATCHES "diskfs")
-                        continue()
-                    endif()
+                    # nfstest_alloc now runs on diskfs too (issue #733 fixed).
+                    # The ENOSPC-boundary instability is gone: data-space
+                    # reservation moved from the per-thread cache to a per-inode
+                    # reservation (inode->space_resv) whose unused tail is a
+                    # *volatile* reservation -- live only in memory, discarded
+                    # without a durable FREE on last close -- so a closed file no
+                    # longer strands space, and statfs (the AGs' live free sum)
+                    # reports exactly what a fresh write can still allocate.
+                    # Confirmed reliably green (616/616 x3 on both diskfs_io_uring
+                    # and diskfs_aio).
                     # nfstest_posix asserts read() updates st_atime.  The
                     # passthrough backends (linux/io_uring) defer atime to the
                     # host filesystem's mount policy (relatime/noatime), which


### PR DESCRIPTION
Re-enables `nfstest_alloc` on the diskfs backends (`diskfs_io_uring`, `diskfs_aio`), which had been memfs-only pending the space-accounting fix tracked in #733.

## Why it's safe now

The ENOSPC-boundary instability that motivated the skip is gone. The underlying fix already landed: data-space reservation moved from the per-thread cache to a **per-inode reservation** (`inode->space_resv`) whose unused tail is a **volatile reservation** — live only in memory and discarded *without* a durable FREE on last close. Consequences:

- A closed file no longer **strands** space (no per-thread tail held across operations that another thread can't reclaim).
- `statfs` (the sum of the AGs' live free counts) now reports **exactly** what a fresh write can still allocate, so a write the suite expects to fail with ENOSPC no longer races drained-back space and spuriously succeeds.

This PR is just the test-enablement: it drops the `backend MATCHES "diskfs"` skip in the nfstest matrix. The bounded 128 MiB diskfs backing the test needs is already set up by the wrapper.

## Verification

- `nfstest_alloc` **616/616, 0 failed** across **three** runs each on `diskfs_io_uring` and `diskfs_aio` (no ENOSPC-boundary failure ever observed).
- Via `ctest` end-to-end: Test #244 (`diskfs_io_uring`, 184s) and #245 (`diskfs_aio`, 171s) both pass.