### PR TITLE
smb2/notify: coalesce duplicate records + sticky client-buffer overflow (green valid-req)

### DIFF
--- a/src/server/smb/smb_notify.c
+++ b/src/server/smb/smb_notify.c
@@ -218,6 +218,50 @@ chimera_smb_notify_write_record(
     return aligned;
 } /* chimera_smb_notify_write_record */
 
+/* The FILE_ACTION_* a non-rename event serializes to.  Shared by the
+ * serializer and the coalescer so they agree on a record's identity. */
+static uint32_t
+chimera_smb_notify_file_action(uint32_t a)
+{
+    if (a & (CHIMERA_VFS_NOTIFY_FILE_ADDED | CHIMERA_VFS_NOTIFY_DIR_ADDED)) {
+        return FILE_ACTION_ADDED;
+    } else if (a & (CHIMERA_VFS_NOTIFY_FILE_REMOVED | CHIMERA_VFS_NOTIFY_DIR_REMOVED)) {
+        return FILE_ACTION_REMOVED;
+    }
+    return FILE_ACTION_MODIFIED;
+} /* chimera_smb_notify_file_action */
+
+int
+chimera_smb_notify_coalesce_events(
+    struct chimera_vfs_notify_event *events,
+    int                              nevents)
+{
+    int i, j = 0;
+
+    for (i = 0; i < nevents; i++) {
+        /* Rename events carry a distinct OLD/NEW pair and are never merged. */
+        if (j > 0 &&
+            !(events[i].action & CHIMERA_VFS_NOTIFY_RENAMED) &&
+            !(events[j - 1].action & CHIMERA_VFS_NOTIFY_RENAMED) &&
+            chimera_smb_notify_file_action(events[i].action) ==
+            chimera_smb_notify_file_action(events[j - 1].action) &&
+            events[i].name_len == events[j - 1].name_len &&
+            memcmp(events[i].name, events[j - 1].name, events[i].name_len) == 0) {
+            /* Same record as the previous kept event — fold the class bits in
+            * (harmless; matching already happened) and drop the duplicate. */
+            events[j - 1].action |= events[i].action;
+            continue;
+        }
+
+        if (i != j) {
+            events[j] = events[i];
+        }
+        j++;
+    }
+
+    return j;
+} /* chimera_smb_notify_coalesce_events */
+
 /* ----------------------------------------------------------------
  * Serialize VFS notify events into FILE_NOTIFY_INFORMATION records.
  * RENAMED events produce two records (OLD_NAME + NEW_NAME).
@@ -296,13 +340,7 @@ chimera_smb_notify_serialize_events(
              * smbtorture smb2.notify.mask, which requires ACTION_MODIFIED for
              * a write under every filter bit).  So the stream bits only widen
              * which watchers are notified; they do not change the action. */
-            if (ev->action & (CHIMERA_VFS_NOTIFY_FILE_ADDED | CHIMERA_VFS_NOTIFY_DIR_ADDED)) {
-                action = FILE_ACTION_ADDED;
-            } else if (ev->action & (CHIMERA_VFS_NOTIFY_FILE_REMOVED | CHIMERA_VFS_NOTIFY_DIR_REMOVED)) {
-                action = FILE_ACTION_REMOVED;
-            } else {
-                action = FILE_ACTION_MODIFIED;
-            }
+            action = chimera_smb_notify_file_action(ev->action);
 
             if (prev_entry) {
                 *(uint32_t *) prev_entry = (uint32_t) (p - prev_entry);
@@ -548,6 +586,8 @@ chimera_smb_notify_do_send_response(
         nevents = j;
     }
 
+    nevents = chimera_smb_notify_coalesce_events(events, nevents);
+
     if (nevents == 0 && !overflowed && !cleanup && !deleted) {
         /* All drained events were filtered out — treat as a spurious
          * wakeup.  Leave state->pending == nr so the next matching
@@ -657,6 +697,16 @@ chimera_smb_notify_do_send_response(
         if (consumed < nevents) {
             overflowed      = 1;
             notify_data_len = 0;
+
+            /* The drained events were discarded because they did not fit the
+            * client's OutputBufferLength.  A client that asked for a non-zero
+            * buffer and still could not be served has lost events, so the
+            * next CHANGE_NOTIFY on this handle must also report overflow until
+            * the client rescans (smb2.notify.valid-req).  OutputBufferLength
+            * == 0 is a deliberate "poll without data" and does not stick. */
+            if (nr->output_buffer_length > 0) {
+                chimera_vfs_notify_mark_overflow(state->watch);
+            }
         }
         p = data_start + notify_data_len;
 

--- a/src/server/smb/smb_notify.h
+++ b/src/server/smb/smb_notify.h
@@ -209,6 +209,19 @@ chimera_smb_notify_serialize_events(
     int                             *events_consumed);
 
 /*
+ * Collapse runs of adjacent events that serialize to the same
+ * FILE_NOTIFY_INFORMATION record (same FILE_ACTION + same name).  A single
+ * client-visible operation can drive several VFS events (e.g. a create stamps
+ * the data fork then its size/attributes), and Windows reports one record per
+ * (action,name) transition.  Applied after the per-request filter so the count
+ * the client sees matches.  Returns the new event count.
+ */
+int
+chimera_smb_notify_coalesce_events(
+    struct chimera_vfs_notify_event *events,
+    int                              nevents);
+
+/*
  * Map an SMB2 CHANGE_NOTIFY CompletionFilter (Windows-style bits) to
  * the chimera VFS event mask.  Exposed so the async response builder
  * can re-filter ring contents against the *current request's* filter

--- a/src/server/smb/smb_proc_change_notify.c
+++ b/src/server/smb/smb_proc_change_notify.c
@@ -188,6 +188,8 @@ chimera_smb_change_notify(struct chimera_smb_request *request)
         nevents = j;
     }
 
+    nevents = chimera_smb_notify_coalesce_events(events, nevents);
+
     if (nevents > 0 || overflowed) {
         pthread_mutex_unlock(&state->lock);
 
@@ -214,6 +216,15 @@ chimera_smb_change_notify(struct chimera_smb_request *request)
             if (consumed < nevents) {
                 overflowed = 1;
                 nevents    = 0;
+
+                /* Events dropped for not fitting the client's non-zero
+                 * OutputBufferLength: make the next CHANGE_NOTIFY on this
+                 * handle report overflow too, until the client rescans
+                 * (smb2.notify.valid-req).  Buffer == 0 is a poll and does
+                 * not stick. */
+                if (request->change_notify.output_buffer_length > 0) {
+                    chimera_vfs_notify_mark_overflow(state->watch);
+                }
             }
         }
 

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -1423,6 +1423,7 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.notify.tcp
     smb2.notify.tdis
     smb2.notify.tdis1
+    smb2.notify.valid-req
     # smb2.openattr
     smb2.openattr
     # smb2.oplock
@@ -3046,6 +3047,7 @@ set(SMBTORTURE_ENABLED_cairn
     smb2.notify.tcp
     smb2.notify.tdis
     smb2.notify.tdis1
+    smb2.notify.valid-req
     # smb2.openattr
     smb2.openattr
     # smb2.oplock
@@ -3618,6 +3620,7 @@ set(SMBTORTURE_ENABLED_diskfs_io_uring
     smb2.notify.tcp
     smb2.notify.tdis
     smb2.notify.tdis1
+    smb2.notify.valid-req
     # smb2.openattr
     smb2.openattr
     # smb2.oplock
@@ -4187,6 +4190,7 @@ set(SMBTORTURE_ENABLED_diskfs_aio
     smb2.notify.tcp
     smb2.notify.tdis
     smb2.notify.tdis1
+    smb2.notify.valid-req
     # smb2.openattr
     smb2.openattr
     # smb2.oplock

--- a/src/vfs/vfs_notify.c
+++ b/src/vfs/vfs_notify.c
@@ -97,6 +97,12 @@ chimera_vfs_notify_watch_overflow(struct chimera_vfs_notify_watch *watch)
     pthread_mutex_unlock(&watch->lock);
 } /* chimera_vfs_notify_watch_overflow */
 
+SYMBOL_EXPORT void
+chimera_vfs_notify_mark_overflow(struct chimera_vfs_notify_watch *watch)
+{
+    chimera_vfs_notify_watch_overflow(watch);
+} /* chimera_vfs_notify_mark_overflow */
+
 /*
  * Look up or create a mount_entry for a given mount_id.
  * Caller must hold notify->mount_entries_lock.

--- a/src/vfs/vfs_notify.h
+++ b/src/vfs/vfs_notify.h
@@ -217,6 +217,17 @@ chimera_vfs_notify_drain(
     int                             *overflowed);
 
 /*
+ * Mark a watch as overflowed so the next drain reports STATUS_NOTIFY_ENUM_DIR.
+ * Used by the SMB layer when a set of drained events cannot be delivered in the
+ * client's OutputBufferLength: the events are dropped and the client must
+ * rescan, so the *next* CHANGE_NOTIFY on the handle must also report overflow
+ * (MS-SMB2 / smb2.notify.valid-req).
+ */
+void
+chimera_vfs_notify_mark_overflow(
+    struct chimera_vfs_notify_watch *watch);
+
+/*
  * Atomically read and clear a watch's "deleted" flag.  Returns non-zero if
  * the watched object had been removed since the last call.  The SMB layer
  * polls this alongside drain to complete a pending CHANGE_NOTIFY with


### PR DESCRIPTION
## Summary

Two SMB2 change-notify correctness fixes that green `smb2.notify.valid-req`, plus its enablement on the backends where it passes.

### 1. Coalesce duplicate notify records
A single client-visible operation can drive several VFS notify events — a create stamps a file's data fork (`ADDED`) and then its size/attributes (`MODIFIED`), and a follow-on size restamp yields a *second* `MODIFIED`-class event on the same name. Windows reports **one** `FILE_NOTIFY_INFORMATION` record per `(action, name)` transition, so recreating a file is `REMOVED + ADDED + MODIFIED` (3), not `… + MODIFIED` (4).

New `chimera_smb_notify_coalesce_events` collapses adjacent events that serialize to the same record, applied after the per-request filter in **both** the sync and async notify paths. Rename events (distinct OLD/NEW pair) are never merged. The serializer and coalescer share one action-mapping helper so they agree on record identity.

### 2. Sticky client-buffer overflow
When a set of drained events is dropped because it does not fit the client's non-zero `OutputBufferLength`, the watch is now marked overflowed so the **next** `CHANGE_NOTIFY` on the handle also returns `STATUS_NOTIFY_ENUM_DIR` until the client rescans — the events were lost, so the client must re-enumerate. `OutputBufferLength == 0` is a deliberate "poll without data" and does **not** stick (matching the buffer=0-vs-1 distinction `valid-req` pins). Reuses the VFS watch's existing sticky-overflow flag via a new exported `chimera_vfs_notify_mark_overflow`.

## Enablement
`smb2.notify.valid-req` enabled on **memfs, cairn, diskfs_io_uring, diskfs_aio** (3×-confirmed; full notify suite green, zero regressions across all backends).

Left disabled on **linux / io_uring**: they hit a *separate, pre-existing* `INTERNAL_ERROR` on this test's round-1 pattern (the other notify subtests pass there), tracked as a passthrough-notify follow-up.

The deeper `smb2.notify.{mask-change, rec, tree}` remain disabled — they need recursive sub-path event naming and Windows' rename-action-under-non-FILE_NAME-filter semantics, which are larger features.

## Verification
- `valid-req` 3× green on each enabled backend; full `smb2.notify.*` suite green on memfs with no regressions; overflow/basedir/file spot-checked clean on every backend.
- `make build_release` `-Werror` clean; scan-build clean; `make syntax`, copyright-year clean.