### PR TITLE
Add a clang source-based Coverage build type

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -40,7 +40,7 @@ RUN apt-get -y update && \
     apt-get -y --no-install-recommends install unminimize apt-utils && \
     yes | unminimize && \
     apt-get -y --no-install-recommends install clang clang-tools cmake ninja-build ccache git flex bison lldb gdb less vim psmisc uncrustify \
-    net-tools tshark tcpdump uuid-dev iproute2 man-db manpages-dev ca-certificates ssh libjansson-dev libclang-rt-18-dev llvm wget \
+    net-tools tshark tcpdump uuid-dev iproute2 man-db manpages-dev ca-certificates ssh libjansson-dev libclang-rt-21-dev llvm wget \
     libxxhash-dev liburcu-dev librdmacm-dev liburing-dev libaio-dev libunwind-dev librocksdb-dev libcurl4-openssl-dev clangd uthash-dev libnuma-dev \
     libboost-dev libboost-program-options-dev libboost-thread-dev libboost-system-dev \
     libcurl4-openssl-dev build-essential ruby-full autoconf automake make libtool pkg-config libs3-dev gh npm reuse libssl-dev openssl \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,21 @@ if(CMAKE_BUILD_TYPE STREQUAL "Release")
     add_definitions(-O3)
 endif()
 
+# Coverage build: clang source-based code coverage. Instruments every TU (and,
+# being directory-scoped, the bundled libevpl under ext/ too -- the report step
+# filters those back out). The matching merge/report step lives in
+# etc/coverage-report.sh, driven by the Makefile's test_coverage target.
+if(CMAKE_BUILD_TYPE STREQUAL "Coverage")
+    if(NOT CMAKE_C_COMPILER_ID MATCHES "Clang")
+        message(FATAL_ERROR
+            "Coverage build requires clang for source-based coverage "
+            "(re-run with -DCMAKE_C_COMPILER=clang; the Makefile does this for you).")
+    endif()
+    message(STATUS "Enabling clang source-based code coverage")
+    add_definitions(-O0 -fprofile-instr-generate -fcoverage-mapping -DCHIMERA_COVERAGE=1)
+    add_link_options(-fprofile-instr-generate -fcoverage-mapping)
+endif()
+
 if(EVPL_IOVEC_PROFILE)
     message(STATUS "Enabling libevpl retained-iovec stack profiling")
     add_definitions(-DEVPL_IOVEC_PROFILE=1)
@@ -120,6 +135,24 @@ add_definitions(${MARCH_FLAG})
 
 if(CMAKE_C_COMPILER_ID MATCHES "GNU")
     add_link_options(-Wl,--no-as-needed)
+endif()
+
+if(CMAKE_C_COMPILER_ID MATCHES "Clang")
+    # The codebase (and the xdrzcc-generated XDR sources) is written for gcc's
+    # GNU C dialect, which clang flags under -Werror where gcc -- the default
+    # toolchain for Release/Debug -- stays silent: a declaration immediately
+    # after a label (-Wc23-extensions) and a variable-sized struct member that
+    # is not the last field (-Wgnu-...). Accept the same GNU/C23 extensions gcc
+    # does so the clang-only Coverage build isn't tripped. Added after -Werror
+    # above so these are not re-promoted.
+    #
+    # Likewise tolerate clang/gcc warning-tooling differences in the test
+    # sources: gcc-only `#pragma GCC diagnostic ignored` names clang doesn't
+    # know (-Wunknown-warning-option, e.g. -Wstringop-truncation in
+    # cthon_common.c) and clang-only diagnostics gcc lacks (-Wabsolute-value on
+    # an unsigned abs() in fsx.c).
+    add_definitions(-Wno-c23-extensions -Wno-gnu
+                    -Wno-unknown-warning-option -Wno-absolute-value)
 endif()
 
 if (CUDA_ENABLED)

--- a/Dockerfile.ubuntu26.04
+++ b/Dockerfile.ubuntu26.04
@@ -20,7 +20,7 @@ RUN if [ -n "$APT_MIRROR" ]; then \
 RUN apt-get -y update && \
     apt-get -y --no-install-recommends upgrade && \
     apt-get -y --no-install-recommends install clang clang-tools cmake ninja-build ccache git flex bison llvm \
-    libclang-rt-18-dev uuid-dev uthash-dev libkrb5-dev libgssapi-krb5-2 gss-ntlmssp-dev \
+    libclang-rt-21-dev uuid-dev uthash-dev libkrb5-dev libgssapi-krb5-2 gss-ntlmssp-dev \
     librdmacm-dev libjansson-dev libxxhash-dev liburcu-dev liburing-dev libunwind-dev librocksdb-dev \
     libssl-dev openssl libnuma-dev libcurl4-openssl-dev libs3-dev libaio-dev libcrypt-dev \
     build-essential autoconf automake libtool pkg-config ca-certificates uncrustify iproute2 curl \

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,8 @@ endif
 CMAKE_ARGS := -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -G Ninja
 CMAKE_ARGS_RELEASE := -DCMAKE_BUILD_TYPE=Release
 CMAKE_ARGS_DEBUG := -DCMAKE_BUILD_TYPE=Debug
+# Coverage uses clang's source-based coverage, so force the clang toolchain.
+CMAKE_ARGS_COVERAGE := -DCMAKE_BUILD_TYPE=Coverage -DCMAKE_C_COMPILER=clang
 CTEST_PARALLEL := $(shell n=$$(nproc); echo $$(( n < 64 ? n : 64 )))
 CTEST_ARGS := --output-on-failure --timeout 30 -j $(CTEST_PARALLEL)
 
@@ -42,11 +44,33 @@ test_debug: build_debug
 test_release: build_release
 	cd ${CHIMERA_BUILD_DIR}/Release && ctest ${CTEST_ARGS}
 
+.PHONY: build_coverage
+build_coverage:
+	@mkdir -p ${CHIMERA_BUILD_DIR}/Coverage
+	@cmake ${CMAKE_ARGS} ${CMAKE_ARGS_COVERAGE} -S . -B ${CHIMERA_BUILD_DIR}/Coverage
+	@ninja -C ${CHIMERA_BUILD_DIR}/Coverage
+
+# Run the suite against the instrumented build, then merge the raw profiles and
+# print a coverage report. Each test (and any daemon it spawns) writes its own
+# profile via the %p/%m patterns; the path is absolute so it survives the cwd
+# changes and netns hops the tests make. The report runs even when tests fail.
+COVERAGE_DIR := $(abspath ${CHIMERA_BUILD_DIR}/Coverage)/coverage
+.PHONY: test_coverage
+test_coverage: build_coverage
+	@rm -rf ${COVERAGE_DIR}
+	@mkdir -p ${COVERAGE_DIR}/profraw
+	-cd ${CHIMERA_BUILD_DIR}/Coverage && \
+		LLVM_PROFILE_FILE=${COVERAGE_DIR}/profraw/%m-%p.profraw ctest ${CTEST_ARGS}
+	@bash etc/coverage-report.sh ${CHIMERA_BUILD_DIR}/Coverage
+
 .PHONY: debug
 debug: build_debug test_debug
 
 .PHONY: release
 release: build_release test_release
+
+.PHONY: coverage
+coverage: build_coverage test_coverage
 
 clean:
 	@rm -rf ${CHIMERA_BUILD_DIR}/*

--- a/etc/coverage-report.sh
+++ b/etc/coverage-report.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+#
+# SPDX-License-Identifier: Unlicense
+
+# coverage-report.sh - Merge clang source-based coverage data and print a report
+#
+# Usage: coverage-report.sh BUILD_DIR
+#
+# Expects the test suite to have already run with the binaries instrumented by a
+# Coverage build (-fprofile-instr-generate -fcoverage-mapping) and with
+# LLVM_PROFILE_FILE pointing into BUILD_DIR/coverage/profraw (see the Makefile's
+# test_coverage target). This merges every *.profraw into a single profdata file
+# and prints a per-file llvm-cov report covering the chimera source tree.
+#
+# Set COVERAGE_HTML=1 to additionally emit a browsable HTML report under
+# BUILD_DIR/coverage/html.
+
+set -euo pipefail
+
+BUILD_DIR="${1:?usage: coverage-report.sh BUILD_DIR}"
+COV_DIR="${BUILD_DIR}/coverage"
+PROFRAW_DIR="${COV_DIR}/profraw"
+PROFDATA="${COV_DIR}/coverage.profdata"
+
+PROFDATA_TOOL="${LLVM_PROFDATA:-llvm-profdata}"
+COV_TOOL="${LLVM_COV:-llvm-cov}"
+
+# Drop everything that isn't first-party chimera source from the report.
+IGNORE_REGEX='(/ext/|/usr/|/3rdparty/|/CMakeFiles/)'
+
+# By default, also exclude generated code so it doesn't distort the totals.
+# Generated sources (the xdrzcc/ndrzcc XDR/NDR marshallers, embedded asset
+# blobs, etc.) are emitted into the build tree, whereas hand-written sources
+# live under the source tree -- so "compiled from under BUILD_DIR" is a reliable,
+# generator-agnostic way to spot generated code. Set COVERAGE_INCLUDE_GENERATED=1
+# to fold it back into the report.
+INCLUDE_GENERATED="${COVERAGE_INCLUDE_GENERATED:-0}"
+if [[ "${INCLUDE_GENERATED}" == "1" ]]; then
+    echo "coverage: including generated code (COVERAGE_INCLUDE_GENERATED=1)"
+else
+    abs_build=$(readlink -f "${BUILD_DIR}")
+    # Escape regex metacharacters so the path is matched literally.
+    esc_build=$(printf '%s' "${abs_build}" | sed 's/[.[\*^$()+?{|/]/\\&/g')
+    IGNORE_REGEX="(${esc_build}/|/ext/|/usr/|/3rdparty/|/CMakeFiles/)"
+    echo "coverage: excluding generated code under ${abs_build} (set COVERAGE_INCLUDE_GENERATED=1 to include)"
+fi
+
+# A full suite run produces hundreds of thousands of .profraw files (one per
+# test process / spawned daemon), which overflows ARG_MAX if globbed onto the
+# command line. Build a newline-separated list file and hand it to llvm-profdata
+# via --input-files instead.
+raw_list="${COV_DIR}/profraw.list"
+find "${PROFRAW_DIR}" -type f -name '*.profraw' > "${raw_list}"
+raw_count=$(wc -l < "${raw_list}")
+if [[ "${raw_count}" -eq 0 ]]; then
+    echo "coverage: no .profraw files found under ${PROFRAW_DIR}" >&2
+    echo "coverage: did the tests run against a Coverage build with LLVM_PROFILE_FILE set?" >&2
+    exit 1
+fi
+
+echo "coverage: merging ${raw_count} raw profile(s) ..."
+"${PROFDATA_TOOL}" merge -sparse --input-files="${raw_list}" -o "${PROFDATA}"
+
+# Collect the instrumented binaries: any executable or shared object in the
+# build tree that carries an __llvm_covmap section. llvm-cov fails outright if
+# handed an object with no coverage mapping, so we must filter rather than glob.
+objs=()
+while IFS= read -r f; do
+    if readelf -SW "$f" 2>/dev/null | grep -q '__llvm_covmap'; then
+        objs+=("$f")
+    fi
+done < <(find "${BUILD_DIR}" -type f \
+            \( -perm -u+x -o -name '*.so' -o -name '*.so.*' \) \
+            ! -path '*/CMakeFiles/*')
+
+if [[ ${#objs[@]} -eq 0 ]]; then
+    echo "coverage: no instrumented binaries found under ${BUILD_DIR}" >&2
+    exit 1
+fi
+
+# llvm-cov takes the first object positionally and the rest via -object.
+object_args=()
+for o in "${objs[@]:1}"; do
+    object_args+=(-object "$o")
+done
+
+echo "coverage: reporting over ${#objs[@]} instrumented binaries"
+echo
+"${COV_TOOL}" report "${objs[0]}" "${object_args[@]}" \
+    -instr-profile="${PROFDATA}" \
+    -ignore-filename-regex="${IGNORE_REGEX}" \
+    -show-region-summary=false
+
+if [[ "${COVERAGE_HTML:-0}" == "1" ]]; then
+    HTML_DIR="${COV_DIR}/html"
+    echo
+    echo "coverage: writing HTML report to ${HTML_DIR} ..."
+    "${COV_TOOL}" show "${objs[0]}" "${object_args[@]}" \
+        -instr-profile="${PROFDATA}" \
+        -ignore-filename-regex="${IGNORE_REGEX}" \
+        -format=html -output-dir="${HTML_DIR}" \
+        -show-line-counts-or-regions
+    echo "coverage: open ${HTML_DIR}/index.html"
+fi


### PR DESCRIPTION
Adds a third build type alongside Release/Debug that instruments the tree with clang source-based code coverage and prints a report at the end of the test run.

## Usage
- `make coverage` — build instrumented + run the suite + print the report
- `make build_coverage` / `make test_coverage` — build / test+report separately
- `bash etc/coverage-report.sh <build>/Coverage` — re-print the report from existing profiles

Env knobs on the report: `COVERAGE_INCLUDE_GENERATED=1` (fold generated code back into the totals), `COVERAGE_HTML=1` (also emit a browsable HTML report).

## What's here
- **CMakeLists.txt** — a `Coverage` build type (requires clang) adding `-fprofile-instr-generate -fcoverage-mapping` at `-O0`. Coverage is the first build to compile the whole tree with clang as the *primary* compiler (Release/Debug use gcc; `build_clang` only runs clang as the scan-build analyzer over gcc objects), so a clang branch suppresses GNU/C23-dialect diagnostics gcc accepts silently (`-Wno-c23-extensions`, `-Wno-gnu`) plus clang/gcc warning-tooling differences in the test sources (`-Wno-unknown-warning-option`, `-Wno-absolute-value`) that would otherwise trip `-Werror`.
- **Makefile** — `build_coverage` / `test_coverage` / `coverage` targets. The test target runs the suite with `LLVM_PROFILE_FILE` set to an absolute, per-process path (`%m-%p`) so every test and spawned daemon writes its own profile across cwd changes and netns hops, then prints the report even when tests fail.
- **etc/coverage-report.sh** — merges the raw profiles and prints a per-file `llvm-cov` report. Generated code (xdrzcc/ndrzcc marshallers, embedded blobs) is excluded by default — it's emitted into the build tree, so "compiled from under BUILD_DIR" identifies it generically — which raises reported line coverage of hand-written code from ~59% to ~73% on a full run. Uses `--input-files` because a full run produces ~200k `.profraw` files, well past `ARG_MAX`.
- **Dockerfiles** (devcontainer, ubuntu26.04) — install `libclang-rt-21-dev` to match clang-21 on ubuntu:26.04; the stale `libclang-rt-18-dev` lacks the profile runtime (`libclang_rt.profile.a`) and the matching ASan runtime. ubuntu24.04 stays on -18 (its clang defaults to 18).

## Notes
- Not wired into `make check`/CI — this is an on-demand build.
- Validated end-to-end: full suite (incl. KVM) ran 9152 tests and produced a report; overall hand-written coverage ~73% lines / ~86% functions.