### PR TITLE
kvm: add Ubuntu 26.04 test image; consume kvm-test-base v1.8.0

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -834,7 +834,7 @@ jobs:
                 kvm-ltp)      SEL="-L kvm -R /ltp/";      NEED_KVM=1 ;;
               esac
               if [ -n "$NEED_KVM" ]; then
-                ninja kvm_ubuntu2404_image kvm_ubuntu2404_hwe_image kvm_ubuntu2204_hwe_image
+                ninja kvm_ubuntu2404_image kvm_ubuntu2404_hwe_image kvm_ubuntu2204_hwe_image kvm_ubuntu2604_image
               fi
               mkdir -p /workspace/ctest-results
               rm -f /workspace/flaky-rescued.log

--- a/kvm/CMakeLists.txt
+++ b/kvm/CMakeLists.txt
@@ -16,15 +16,17 @@ get_filename_component(BUILD_ROOT ${CMAKE_BINARY_DIR} DIRECTORY)
 set(KVM_IMAGE_REGISTRY "ghcr.io/chimera-nas/kvm-test-base" CACHE STRING
     "OCI registry base that hosts the prebuilt KVM guest images.")
 # Pinned version of the prebuilt images to consume; bump to adopt a newer
-# kvm-test-base release.  v1.7.0 bakes sshd + a symmetric key so nfstest's
-# cross-client suites can drive a second NFS client over ssh (and parameterizes
-# the guest IP from the kernel cmdline); v1.6.0 pinned cthon04 to a gcc-15 fix;
-# v1.5.0 pares LTP to the non-duplicative slice and adds the curated
-# chimera_nfs42 runtest + an ltp-run.sh JSON-fallback; v1.4.0 added the
+# kvm-test-base release.  v1.8.0 pins nfstest to the chimera fork tag
+# v3.2-chimera2, carrying the Python 3.14 compatibility fixes so the nfstest
+# suite runs on Ubuntu 26.04 (Python 3.14); v1.7.0 bakes sshd + a symmetric key
+# so nfstest's cross-client suites can drive a second NFS client over ssh (and
+# parameterizes the guest IP from the kernel cmdline); v1.6.0 pinned cthon04 to
+# a gcc-15 fix; v1.5.0 pares LTP to the non-duplicative slice and adds the
+# curated chimera_nfs42 runtest + an ltp-run.sh JSON-fallback; v1.4.0 added the
 # ubuntu2604 variant; v1.3.0 added the Linux Test Project (LTP) tree under
 # /opt/ltp{,-skip}; v1.2.0 added the Linux nfstest suite; v1.1.0 dropped the 22.04
 # generic variant (see the KVM_IMAGES note below); v1.0.0 still has all four.
-set(KVM_IMAGE_VERSION "v1.7.0" CACHE STRING
+set(KVM_IMAGE_VERSION "v1.8.0" CACHE STRING
     "Version tag of the KVM guest images to consume.")
 
 # Note: the 22.04 generic (non-HWE) kernel does not build the virtio block
@@ -36,6 +38,7 @@ set(KVM_IMAGES
     ubuntu2404
     ubuntu2404_hwe
     ubuntu2204_hwe
+    ubuntu2604
 )
 
 # When ON (default) the guest images are fetched as part of the default build

--- a/kvm/kvm_nfstest_2client_test_wrapper.sh
+++ b/kvm/kvm_nfstest_2client_test_wrapper.sh
@@ -216,7 +216,15 @@ NFSTEST_MTOPTS="hard,rsize=4096,wsize=4096"
 # the same on authorized_keys.  No double quotes: this is embedded in the
 # kernel-cmdline test_cmd="..." which the guest parses by stripping at the
 # first quote.
-SSHFIX='mkdir -p /run/sshd; chown root:root /run/sshd; chmod 0755 /run/sshd; chown root:root /root; chmod 700 /root; chown -R root:root /root/.ssh /etc/ssh 2>/dev/null; chmod 700 /root/.ssh 2>/dev/null; chmod 600 /root/.ssh/id_ed25519 /root/.ssh/authorized_keys /root/.ssh/config 2>/dev/null; chmod 600 /etc/ssh/ssh_host_ed25519_key /etc/ssh/ssh_host_rsa_key /etc/ssh/ssh_host_ecdsa_key 2>/dev/null; /usr/sbin/sshd'
+#
+# Ubuntu 26.04 ships /etc/ssh/ssh_config.d/20-systemd-ssh-proxy.conf (a symlink
+# whose perms `chown -R`/`chmod -R` on /etc/ssh cannot normalise), and ssh
+# treats a bad-mode Include in the system ssh_config as fatal -- so *every*
+# `ssh 10.0.0.3` on guest A dies before connecting: the reachability wait times
+# out ("second client unreachable") and nfstest's rexec gets ConnectionRefused.
+# That drop-in only proxies systemd machine names (.host etc.), never the IP we
+# use, so just remove it.  (No-op on 24.04, which ships no such file.)
+SSHFIX='mkdir -p /run/sshd; chown root:root /run/sshd; chmod 0755 /run/sshd; chown root:root /root; chmod 700 /root; chown -R root:root /root/.ssh /etc/ssh 2>/dev/null; rm -f /etc/ssh/ssh_config.d/*.conf 2>/dev/null; chmod 700 /root/.ssh 2>/dev/null; chmod 600 /root/.ssh/id_ed25519 /root/.ssh/authorized_keys /root/.ssh/config 2>/dev/null; chmod 600 /etc/ssh/ssh_host_ed25519_key /etc/ssh/ssh_host_rsa_key /etc/ssh/ssh_host_ecdsa_key 2>/dev/null; /usr/sbin/sshd'
 
 # ----- guest B (secondary client): idle with sshd up -------------------------
 ip netns exec "${NETNS_NAME}" "$QEMU_BIN" \

--- a/kvm/tests/CMakeLists.txt
+++ b/kvm/tests/CMakeLists.txt
@@ -314,7 +314,7 @@ foreach(image_spec ${KVM_IMAGES})
         endforeach()
     endif()
 
-    # ----- Linux nfstest single-host suite (ubuntu2404 only) -----
+    # ----- Linux nfstest single-host suite (ubuntu2404 + ubuntu2604) -----
     # nfstest is a client-side conformance suite: it mounts the share itself (so
     # this uses a dedicated no-pre-mount wrapper) and verifies on-the-wire
     # behaviour with its own tcpdump-driven RPC dissector.  The nfstest tree and
@@ -331,7 +331,7 @@ foreach(image_spec ${KVM_IMAGES})
     # nfstest_cache and nfstest_delegation are registered below (they need a
     # second client host -- see the 2-client wrapper).  Not yet registered:
     # nfstest_pnfs.
-    if(IMAGE_NAME STREQUAL "ubuntu2404")
+    if(IMAGE_NAME STREQUAL "ubuntu2404" OR IMAGE_NAME STREQUAL "ubuntu2604")
         set(NFSTEST_MATRIX
             "nfstest_posix|3 4.0 4.1 4.2"
             "nfstest_interop|4.0"
@@ -447,11 +447,11 @@ foreach(image_spec ${KVM_IMAGES})
             PROPERTIES LABELS "kvm;${IMAGE_NAME}" PROCESSORS 4 TIMEOUT 1800)
     endif()
 
-    # Linux Test Project (LTP) -- ubuntu2404 only.  Reuses the plain NFS wrapper:
+    # Linux Test Project (LTP) -- ubuntu2404 + ubuntu2604.  Reuses the plain NFS wrapper:
     # LTP runs against the pre-mounted share at /mnt exactly like cthon/xfstests,
     # so it needs no dedicated wrapper.  See LTP_MATRIX above for the pared-down
     # group selection (the non-duplicative slice).
-    if(IMAGE_NAME STREQUAL "ubuntu2404")
+    if(IMAGE_NAME STREQUAL "ubuntu2404" OR IMAGE_NAME STREQUAL "ubuntu2604")
         set(LTP_BACKENDS ${KVM_BACKENDS})
         if(CAIRN_ENABLED)
             list(APPEND LTP_BACKENDS cairn)
@@ -548,6 +548,17 @@ foreach(image_spec ${KVM_IMAGES})
     # pNFS block layout (RFC 5663): diskfs sources block layouts; the client
     # does data I/O directly to the signed virtio-SCSI data disk (/dev/sda),
     # never through the MDS (which can't reach it).
+    #
+    # Disabled on ubuntu2604: Ubuntu 26.04 (resolute) dropped the blkmapd binary
+    # from nfs-common (nfs-utils 2.8.5) and ships it in no package, so the block-
+    # layout client cannot be brought up (PNFS_BLOCK_SETUP runs /usr/sbin/blkmapd).
+    # The block-layout MDS path stays covered by the ubuntu2404 / ubuntu2204_hwe
+    # variants.  Only block layout needs blkmapd; the file/proxy pNFS tests above
+    # still run on 2604.
+    set(PNFS_BLOCK_DISABLED FALSE)
+    if(IMAGE_NAME STREQUAL "ubuntu2604")
+        set(PNFS_BLOCK_DISABLED TRUE)
+    endif()
     foreach(prog ${PNFS_BLOCK_PROGRAMS})
         foreach(pbackend ${PNFS_BLOCK_BACKENDS})
             add_test(NAME chimera/kvm/${IMAGE_NAME}/pnfs/block_${prog}_${pbackend}_nfs4.1
@@ -556,7 +567,8 @@ foreach(image_spec ${KVM_IMAGES})
                         ${CHIMERA_BINARY} ${pbackend}
                         "${PNFS_BLOCK_SETUP} && ${PNFS_BLOCK_WL_${prog}}")
             set_tests_properties(chimera/kvm/${IMAGE_NAME}/pnfs/block_${prog}_${pbackend}_nfs4.1
-                PROPERTIES LABELS "kvm;${IMAGE_NAME};pnfs" PROCESSORS 2)
+                PROPERTIES LABELS "kvm;${IMAGE_NAME};pnfs" PROCESSORS 2
+                           DISABLED ${PNFS_BLOCK_DISABLED})
         endforeach()
     endforeach()
 


### PR DESCRIPTION
Add the ubuntu2604 guest (Ubuntu 26.04 "resolute") to the KVM test matrix and bump the consumed kvm-test-base image from v1.7.0 to v1.8.0. v1.8.0 pins nfstest to the chimera fork tag v3.2-chimera2, which carries Python 3.14 compatibility fixes so the nfstest suite runs on 26.04 (Python 3.14).

kvm/CMakeLists.txt:
  - KVM_IMAGES += ubuntu2604.
  - KVM_IMAGE_VERSION v1.7.0 -> v1.8.0.

kvm/tests/CMakeLists.txt:
  - Enable the nfstest single-host suite and the LTP suite on ubuntu2604 (gates extended from ubuntu2404 to ubuntu2404 + ubuntu2604).
  - Disable block-layout pNFS on ubuntu2604: Ubuntu 26.04 nfs-common (nfs-utils 2.8.5) dropped the blkmapd binary and ships it in no package, so the block-layout client cannot be brought up. Block- layout MDS coverage stays on ubuntu2404 / ubuntu2204_hwe; the file/proxy pNFS tests still run on 2604.