### PR TITLE
nfs4: NFSv4.2 change_attr_type + native VFS change attribute

### DIFF
--- a/src/server/nfs/nfs4_attr.h
+++ b/src/server/nfs/nfs4_attr.h
@@ -120,7 +120,12 @@ chimera_nfs4_attr2mask(
                         attr_mask |= CHIMERA_VFS_ATTR_FH;
                         break;
                     case FATTR4_CHANGE:
-                        attr_mask |= CHIMERA_VFS_ATTR_CTIME;
+                    case FATTR4_CHANGE_ATTR_TYPE:
+                        /* Request the native change counter as well as ctime:
+                         * backends with CHIMERA_VFS_CAP_CHANGE fill va_change,
+                         * the rest fill only ctime and the marshaller derives
+                         * change from it. */
+                        attr_mask |= CHIMERA_VFS_ATTR_CTIME | CHIMERA_VFS_ATTR_CHANGE;
                         break;
                     case FATTR4_SIZE:
                         attr_mask |= CHIMERA_VFS_ATTR_SIZE;
@@ -472,9 +477,13 @@ chimera_nfs4_marshall_attrs(
                     word2 |= (1 << (FATTR4_OPEN_ARGUMENTS - 64));
                 }
 
-                /* Extended attributes (RFC 8276) are an NFSv4.2 feature. */
+                /* Extended attributes (RFC 8276) and change_attr_type
+                 * (RFC 7862) are NFSv4.2 features.  change_attr_type is always
+                 * supported at 4.2: the marshaller returns a value for every
+                 * object (native MONOTONIC_INCR or ctime-derived TIME_METADATA). */
                 if (minorversion >= 2) {
                     word2 |= (1 << (FATTR4_XATTR_SUPPORT - 64));
+                    word2 |= (1 << (FATTR4_CHANGE_ATTR_TYPE - 64));
                 }
 
                 /* Layout types (attr 64) advertised when pNFS is enabled. */
@@ -529,7 +538,14 @@ chimera_nfs4_marshall_attrs(
             rsp_mask[0]  |= (1 << FATTR4_CHANGE);
             *num_rsp_mask = 1;
 
-            v64 = attr->va_ctime.tv_sec * 1000000000 + attr->va_ctime.tv_nsec;
+            if (attr->va_set_mask & CHIMERA_VFS_ATTR_CHANGE) {
+                /* Backend supplied a native monotonic version counter. */
+                v64 = attr->va_change;
+            } else {
+                /* Derive change from ctime (matches Linux nfsd without
+                 * i_version: change_attr_type is then TIME_METADATA). */
+                v64 = attr->va_ctime.tv_sec * 1000000000 + attr->va_ctime.tv_nsec;
+            }
             chimera_nfs4_attr_append_uint64(&attrs, v64);
         }
 
@@ -915,6 +931,21 @@ chimera_nfs4_marshall_attrs(
                                             (1UL << (FATTR4_MODE - 32)) |
                                             (1UL << (FATTR4_OWNER - 32)) |
                                             (1UL << (FATTR4_OWNER_GROUP - 32)));
+        }
+
+        if ((req_mask[2] & (1 << (FATTR4_CHANGE_ATTR_TYPE - 64))) &&
+            minorversion >= 2) {
+            rsp_mask[2]  |= (1 << (FATTR4_CHANGE_ATTR_TYPE - 64));
+            *num_rsp_mask = 3;
+
+            /* Per-object: a backend with a native change counter
+             * (CHIMERA_VFS_ATTR_CHANGE) reports a strictly increasing value;
+             * otherwise change is the ctime, i.e. time_metadata.  Mirrors the
+             * fattr4_change source chosen in the FATTR4_CHANGE block above. */
+            chimera_nfs4_attr_append_uint32(&attrs,
+                                            (attr->va_set_mask & CHIMERA_VFS_ATTR_CHANGE) ?
+                                            NFS4_CHANGE_TYPE_IS_MONOTONIC_INCR :
+                                            NFS4_CHANGE_TYPE_IS_TIME_METADATA);
         }
 
         if (nfs4_delegations &&

--- a/src/server/nfs/nfs4_attr.h
+++ b/src/server/nfs/nfs4_attr.h
@@ -907,16 +907,6 @@ chimera_nfs4_marshall_attrs(
             chimera_nfs4_attr_append_uint32(&attrs, 4096);
         }
 
-        if ((req_mask[2] & (1 << (FATTR4_XATTR_SUPPORT - 64))) &&
-            minorversion >= 2) {
-            rsp_mask[2]  |= (1 << (FATTR4_XATTR_SUPPORT - 64));
-            *num_rsp_mask = 3;
-
-            /* Per-object: TRUE only if this file's backend implements xattrs
-             * (CHIMERA_VFS_CAP_XATTR). See RFC 8276 sec 8.2.1 - per-fs attribute. */
-            chimera_nfs4_attr_append_uint32(&attrs, xattr_supported);
-        }
-
         if (req_mask[2] & (1 << (FATTR4_SUPPATTR_EXCLCREAT - 64))) {
             rsp_mask[2]  |= (1 << (FATTR4_SUPPATTR_EXCLCREAT - 64));
             *num_rsp_mask = 3;
@@ -946,6 +936,21 @@ chimera_nfs4_marshall_attrs(
                                             (attr->va_set_mask & CHIMERA_VFS_ATTR_CHANGE) ?
                                             NFS4_CHANGE_TYPE_IS_MONOTONIC_INCR :
                                             NFS4_CHANGE_TYPE_IS_TIME_METADATA);
+        }
+
+        /* xattr_support is attr 82: it MUST be emitted after change_attr_type
+         * (79) and suppattr_exclcreat (75) -- fattr4 values are packed in
+         * ascending attribute order to match the response bitmap the client
+         * decodes low-to-high.  (Previously emitted before them, a latent bug
+         * that bit once change_attr_type became co-requested at v4.2 mount.) */
+        if ((req_mask[2] & (1 << (FATTR4_XATTR_SUPPORT - 64))) &&
+            minorversion >= 2) {
+            rsp_mask[2]  |= (1 << (FATTR4_XATTR_SUPPORT - 64));
+            *num_rsp_mask = 3;
+
+            /* Per-object: TRUE only if this file's backend implements xattrs
+             * (CHIMERA_VFS_CAP_XATTR). See RFC 8276 sec 8.2.1 - per-fs attribute. */
+            chimera_nfs4_attr_append_uint32(&attrs, xattr_supported);
         }
 
         if (nfs4_delegations &&

--- a/src/server/nfs/nfs4_proc_getattr.c
+++ b/src/server/nfs/nfs4_proc_getattr.c
@@ -126,12 +126,19 @@ chimera_nfs4_getattr_cb_resume(
 
     if (status == 0) {
         if (got_change) {
-            /* The CHANGE attribute is encoded from va_ctime as
-             * sec*1e9 + nsec; reconstruct a ctime that re-encodes to the
-             * holder's exact change value. */
-            park->attr.va_ctime.tv_sec  = change / 1000000000ULL;
-            park->attr.va_ctime.tv_nsec = change % 1000000000ULL;
-            park->attr.va_set_mask     |= CHIMERA_VFS_ATTR_CTIME;
+            /* Override the server's view with the holder's change value, in
+            * whichever representation this file's backend uses -- so the
+            * marshaller emits the holder's value AND keeps change_attr_type
+            * stable per object.  A native-counter backend (CAP_CHANGE) carries
+            * it in va_change; a ctime-derived backend has no CHANGE bit, so we
+            * reconstruct a ctime that re-encodes (sec*1e9 + nsec) to it. */
+            if (park->attr.va_set_mask & CHIMERA_VFS_ATTR_CHANGE) {
+                park->attr.va_change = change;
+            } else {
+                park->attr.va_ctime.tv_sec  = change / 1000000000ULL;
+                park->attr.va_ctime.tv_nsec = change % 1000000000ULL;
+                park->attr.va_set_mask     |= CHIMERA_VFS_ATTR_CTIME;
+            }
         }
         if (got_size) {
             park->attr.va_size      = size;

--- a/src/server/nfs/tests/test_protocol_advertise.c
+++ b/src/server/nfs/tests/test_protocol_advertise.c
@@ -230,6 +230,41 @@ test_change_value_native_vs_ctime(void)
     assert(get_u64(attrvals, 0) == 1000ULL * 1000000000ULL + 500ULL);
 } /* test_change_value_native_vs_ctime */
 
+/* fattr4 values must be packed in ascending attribute order so the client,
+ * which decodes the response bitmap low-to-high, reads each value at the right
+ * offset.  change_attr_type (79) and xattr_support (82) live in word 2 and are
+ * co-requested by the Linux v4.2 client at mount; emitting them out of order
+ * misframes the reply (this regressed nfstest_xattr). */
+static void
+test_word2_values_packed_in_ascending_order(void)
+{
+    struct chimera_vfs_attrs attr;
+    uint32_t                 req_mask[3] = { 0 };
+    uint32_t                 rsp_mask[3] = { 0 };
+    uint32_t                 num_rsp_mask;
+    uint32_t                 attrvals_len;
+    uint8_t                  attrvals[256];
+
+    memset(&attr, 0, sizeof(attr));
+    attr.va_set_mask = CHIMERA_VFS_ATTR_CHANGE; /* native -> MONOTONIC_INCR */
+    attr.va_change   = 1;
+    req_mask[2]      = (1 << (FATTR4_CHANGE_ATTR_TYPE - 64)) |
+        (1 << (FATTR4_XATTR_SUPPORT - 64));
+
+    /* xattr_supported = 1 passed in. */
+    chimera_nfs4_marshall_attrs(&attr, 3, req_mask, &num_rsp_mask, rsp_mask, 3,
+                                attrvals, &attrvals_len, sizeof(attrvals), 2, 0, 1, 0, 60, 0, NULL, 0);
+
+    assert(num_rsp_mask == 3);
+    assert((rsp_mask[2] & (1 << (FATTR4_CHANGE_ATTR_TYPE - 64))) != 0);
+    assert((rsp_mask[2] & (1 << (FATTR4_XATTR_SUPPORT - 64))) != 0);
+    assert(attrvals_len == 8); /* two uint32 values */
+
+    /* Ascending: change_attr_type (79) first, then xattr_support (82). */
+    assert(get_u32(attrvals, 0) == NFS4_CHANGE_TYPE_IS_MONOTONIC_INCR);
+    assert(get_u32(attrvals, 1) == 1);
+} /* test_word2_values_packed_in_ascending_order */
+
 int
 main(void)
 {
@@ -240,6 +275,7 @@ main(void)
     test_change_attr_type_advertised_for_v42();
     test_change_attr_type_value_follows_native_change();
     test_change_value_native_vs_ctime();
+    test_word2_values_packed_in_ascending_order();
 
     return 0;
 } /* main */

--- a/src/server/nfs/tests/test_protocol_advertise.c
+++ b/src/server/nfs/tests/test_protocol_advertise.c
@@ -20,6 +20,14 @@ get_u32(
     return chimera_nfs_ntoh32(((const uint32_t *) buf)[index]);
 } /* get_u32 */
 
+static uint64_t
+get_u64(
+    const uint8_t *buf,
+    int            index)
+{
+    return chimera_nfs_ntoh64(((const uint64_t *) buf)[index]);
+} /* get_u64 */
+
 static void
 test_unimplemented_delegation_ops_not_advertised(void)
 {
@@ -130,6 +138,98 @@ test_xattr_support_value_follows_backend_capability(void)
     assert(get_u32(attrvals, 0) == 1);
 } /* test_xattr_support_value_follows_backend_capability */
 
+static void
+test_change_attr_type_advertised_for_v42(void)
+{
+    struct chimera_vfs_attrs attr;
+    uint32_t                 req_mask[3] = { 0 };
+    uint32_t                 rsp_mask[3] = { 0 };
+    uint32_t                 num_rsp_mask;
+    uint32_t                 attrvals_len;
+    uint8_t                  attrvals[256];
+
+    memset(&attr, 0, sizeof(attr));
+    req_mask[0] = (1 << FATTR4_SUPPORTED_ATTRS);
+
+    /* change_attr_type (attr 79) is an NFSv4.2 attribute: not advertised at 4.1. */
+    chimera_nfs4_marshall_attrs(&attr, 3, req_mask, &num_rsp_mask, rsp_mask, 3,
+                                attrvals, &attrvals_len, sizeof(attrvals), 1, 0, 0, 0, 60, 0, NULL, 0);
+    assert((get_u32(attrvals, 3) & (1 << (FATTR4_CHANGE_ATTR_TYPE - 64))) == 0);
+
+    /* Advertised at 4.2. */
+    memset(rsp_mask, 0, sizeof(rsp_mask));
+    memset(attrvals, 0, sizeof(attrvals));
+    chimera_nfs4_marshall_attrs(&attr, 3, req_mask, &num_rsp_mask, rsp_mask, 3,
+                                attrvals, &attrvals_len, sizeof(attrvals), 2, 0, 0, 0, 60, 0, NULL, 0);
+    assert((get_u32(attrvals, 3) & (1 << (FATTR4_CHANGE_ATTR_TYPE - 64))) != 0);
+} /* test_change_attr_type_advertised_for_v42 */
+
+static void
+test_change_attr_type_value_follows_native_change(void)
+{
+    struct chimera_vfs_attrs attr;
+    uint32_t                 req_mask[3] = { 0 };
+    uint32_t                 rsp_mask[3] = { 0 };
+    uint32_t                 num_rsp_mask;
+    uint32_t                 attrvals_len;
+    uint8_t                  attrvals[256];
+
+    req_mask[2] = (1 << (FATTR4_CHANGE_ATTR_TYPE - 64));
+
+    /* Backend with a native change counter -> MONOTONIC_INCR. */
+    memset(&attr, 0, sizeof(attr));
+    attr.va_set_mask = CHIMERA_VFS_ATTR_CHANGE;
+    attr.va_change   = 7;
+    chimera_nfs4_marshall_attrs(&attr, 3, req_mask, &num_rsp_mask, rsp_mask, 3,
+                                attrvals, &attrvals_len, sizeof(attrvals), 2, 0, 0, 0, 60, 0, NULL, 0);
+    assert(num_rsp_mask == 3);
+    assert(attrvals_len == 4);
+    assert((rsp_mask[2] & (1 << (FATTR4_CHANGE_ATTR_TYPE - 64))) != 0);
+    assert(get_u32(attrvals, 0) == NFS4_CHANGE_TYPE_IS_MONOTONIC_INCR);
+
+    /* Backend without a native counter (ctime fallback) -> TIME_METADATA. */
+    memset(&attr, 0, sizeof(attr));
+    attr.va_set_mask = CHIMERA_VFS_ATTR_CTIME;
+    memset(rsp_mask, 0, sizeof(rsp_mask));
+    memset(attrvals, 0, sizeof(attrvals));
+    chimera_nfs4_marshall_attrs(&attr, 3, req_mask, &num_rsp_mask, rsp_mask, 3,
+                                attrvals, &attrvals_len, sizeof(attrvals), 2, 0, 0, 0, 60, 0, NULL, 0);
+    assert(get_u32(attrvals, 0) == NFS4_CHANGE_TYPE_IS_TIME_METADATA);
+} /* test_change_attr_type_value_follows_native_change */
+
+static void
+test_change_value_native_vs_ctime(void)
+{
+    struct chimera_vfs_attrs attr;
+    uint32_t                 req_mask[3] = { 0 };
+    uint32_t                 rsp_mask[3] = { 0 };
+    uint32_t                 num_rsp_mask;
+    uint32_t                 attrvals_len;
+    uint8_t                  attrvals[256];
+
+    req_mask[0] = (1 << FATTR4_CHANGE);
+
+    /* Native counter: fattr4_change is the raw counter value. */
+    memset(&attr, 0, sizeof(attr));
+    attr.va_set_mask = CHIMERA_VFS_ATTR_CHANGE;
+    attr.va_change   = 0x1122334455667788ULL;
+    chimera_nfs4_marshall_attrs(&attr, 3, req_mask, &num_rsp_mask, rsp_mask, 3,
+                                attrvals, &attrvals_len, sizeof(attrvals), 2, 0, 0, 0, 60, 0, NULL, 0);
+    assert((rsp_mask[0] & (1 << FATTR4_CHANGE)) != 0);
+    assert(get_u64(attrvals, 0) == 0x1122334455667788ULL);
+
+    /* No native counter: fattr4_change is derived from ctime (sec*1e9 + nsec). */
+    memset(&attr, 0, sizeof(attr));
+    attr.va_set_mask      = CHIMERA_VFS_ATTR_CTIME;
+    attr.va_ctime.tv_sec  = 1000;
+    attr.va_ctime.tv_nsec = 500;
+    memset(rsp_mask, 0, sizeof(rsp_mask));
+    memset(attrvals, 0, sizeof(attrvals));
+    chimera_nfs4_marshall_attrs(&attr, 3, req_mask, &num_rsp_mask, rsp_mask, 3,
+                                attrvals, &attrvals_len, sizeof(attrvals), 2, 0, 0, 0, 60, 0, NULL, 0);
+    assert(get_u64(attrvals, 0) == 1000ULL * 1000000000ULL + 500ULL);
+} /* test_change_value_native_vs_ctime */
+
 int
 main(void)
 {
@@ -137,6 +237,9 @@ main(void)
     test_open_arguments_supported_attrs_follows_delegation_config();
     test_open_arguments_attr_follows_delegation_config();
     test_xattr_support_value_follows_backend_capability();
+    test_change_attr_type_advertised_for_v42();
+    test_change_attr_type_value_follows_native_change();
+    test_change_value_native_vs_ctime();
 
     return 0;
 } /* main */

--- a/src/vfs/cairn/cairn.c
+++ b/src/vfs/cairn/cairn.c
@@ -181,6 +181,7 @@ struct cairn_inode {
     struct timespec ctime;
     struct timespec btime;
     uint32_t        dos_attributes;
+    uint64_t        change;       /* native monotonic change counter */
 };
 
 struct cairn_inode_handle {
@@ -1227,6 +1228,7 @@ cairn_init(
         inode.ctime          = now;
         inode.btime          = now;
         inode.dos_attributes = 0;
+        inode.change         = 0;
 
         super.fsid = chimera_rand64();
 
@@ -1673,8 +1675,9 @@ cairn_alloc_inum(
 {
     uint64_t id = thread->next_inum++;
 
-    inode->inum = (id << 8) + thread->thread_id;
-    inode->gen  = 1;
+    inode->inum   = (id << 8) + thread->thread_id;
+    inode->gen    = 1;
+    inode->change = 0;
 } /* cairn_alloc_inum */
 
 static inline void
@@ -1717,6 +1720,12 @@ cairn_map_attrs(
     if (attr->va_req_mask & CHIMERA_VFS_ATTR_BTIME) {
         attr->va_set_mask |= CHIMERA_VFS_ATTR_BTIME;
         attr->va_btime     = inode->btime;
+    }
+
+    /* Native monotonic change counter (CHIMERA_VFS_CAP_CHANGE). */
+    if (attr->va_req_mask & CHIMERA_VFS_ATTR_CHANGE) {
+        attr->va_set_mask |= CHIMERA_VFS_ATTR_CHANGE;
+        attr->va_change    = inode->change;
     }
 
     if (attr->va_req_mask & CHIMERA_VFS_ATTR_FSID) {
@@ -1798,6 +1807,9 @@ cairn_apply_attrs(
     } else {
         inode->ctime = now;
     }
+
+    /* Any setattr is a metadata change; advance the native change counter. */
+    inode->change++;
 
 } /* cairn_apply_attrs */
 
@@ -2236,17 +2248,18 @@ cairn_mkdir_at(
     }
 
     cairn_alloc_inum(thread, &inode);
-    inode.parent_inum    = parent_inode->inum; /* Set parent for ".." lookup */
-    inode.size           = 4096;
-    inode.space_used     = 4096;
-    inode.uid            = request->cred->uid;
-    inode.gid            = request->cred->gid;
-    inode.nlink          = 2;
-    inode.rdev           = 0;
-    inode.mode           = S_IFDIR | 0755;
-    inode.atime          = now;
-    inode.mtime          = now;
-    inode.ctime          = now;
+    inode.parent_inum = parent_inode->inum;    /* Set parent for ".." lookup */
+    inode.size        = 4096;
+    inode.space_used  = 4096;
+    inode.uid         = request->cred->uid;
+    inode.gid         = request->cred->gid;
+    inode.nlink       = 2;
+    inode.rdev        = 0;
+    inode.mode        = S_IFDIR | 0755;
+    inode.atime       = now;
+    inode.mtime       = now;
+    inode.ctime       = now;
+    inode.change++;
     inode.btime          = now;
     inode.dos_attributes = 0;
 
@@ -2275,6 +2288,7 @@ cairn_mkdir_at(
 
     parent_inode->mtime = now;
     parent_inode->ctime = now;
+    parent_inode->change++;
 
     cairn_map_attrs(shared, &request->mkdir_at.r_dir_post_attr, parent_inode);
 
@@ -2348,16 +2362,17 @@ cairn_mknod_at(
     }
 
     cairn_alloc_inum(thread, &inode);
-    inode.parent_inum    = parent_inode->inum;
-    inode.size           = 0;
-    inode.space_used     = 0;
-    inode.uid            = request->cred->uid;
-    inode.gid            = request->cred->gid;
-    inode.nlink          = 1;
-    inode.rdev           = 0;
-    inode.atime          = now;
-    inode.mtime          = now;
-    inode.ctime          = now;
+    inode.parent_inum = parent_inode->inum;
+    inode.size        = 0;
+    inode.space_used  = 0;
+    inode.uid         = request->cred->uid;
+    inode.gid         = request->cred->gid;
+    inode.nlink       = 1;
+    inode.rdev        = 0;
+    inode.atime       = now;
+    inode.mtime       = now;
+    inode.ctime       = now;
+    inode.change++;
     inode.btime          = now;
     inode.dos_attributes = 0;
 
@@ -2384,6 +2399,7 @@ cairn_mknod_at(
 
     parent_inode->mtime = now;
     parent_inode->ctime = now;
+    parent_inode->change++;
 
     cairn_map_attrs(shared, &request->mknod_at.r_dir_post_attr, parent_inode);
 
@@ -2474,6 +2490,7 @@ cairn_remove_at(
 
     parent_inode->mtime = now;
     parent_inode->ctime = now;
+    parent_inode->change++;
 
     if (S_ISDIR(inode->mode)) {
         inode->nlink = 0;
@@ -2485,6 +2502,7 @@ cairn_remove_at(
          * link count, which is a status change: bump its ctime. */
         if (inode->nlink > 0) {
             inode->ctime = now;
+            inode->change++;
         }
     }
 
@@ -2860,16 +2878,17 @@ cairn_open_at(
         is_new_inode = 1;
 
         cairn_alloc_inum(thread, &new_inode);
-        new_inode.size           = 0;
-        new_inode.space_used     = 0;
-        new_inode.uid            = request->cred->uid;
-        new_inode.gid            = request->cred->gid;
-        new_inode.nlink          = 1;
-        new_inode.rdev           = 0;
-        new_inode.mode           = S_IFREG |  0644;
-        new_inode.atime          = now;
-        new_inode.mtime          = now;
-        new_inode.ctime          = now;
+        new_inode.size       = 0;
+        new_inode.space_used = 0;
+        new_inode.uid        = request->cred->uid;
+        new_inode.gid        = request->cred->gid;
+        new_inode.nlink      = 1;
+        new_inode.rdev       = 0;
+        new_inode.mode       = S_IFREG |  0644;
+        new_inode.atime      = now;
+        new_inode.mtime      = now;
+        new_inode.ctime      = now;
+        new_inode.change++;
         new_inode.btime          = now;
         new_inode.dos_attributes = 0;
         new_inode.refcnt         = 1;
@@ -2894,6 +2913,7 @@ cairn_open_at(
 
         parent_inode->mtime = now;
         parent_inode->ctime = now;
+        parent_inode->change++;
 
         /* Signal to the protocol layer that this open created the file (vs.
          * opened an existing one) so the SMB CREATE reply reports the correct
@@ -3448,6 +3468,7 @@ cairn_write(
     inode->space_used += total_space;
     inode->mtime       = now;
     inode->ctime       = now;
+    inode->change++;
 
     /* POSIX kill-priv: a non-privileged write to a regular file clears the
      * set-user-ID bit and the set-group-ID bit (when group-executable). */
@@ -3512,6 +3533,7 @@ cairn_allocate(
 
     inode->mtime = now;
     inode->ctime = now;
+    inode->change++;
 
     cairn_map_attrs(shared, &request->allocate.r_post_attr, inode);
 
@@ -3760,16 +3782,17 @@ cairn_symlink_at(
     }
 
     cairn_alloc_inum(thread, &new_inode);
-    new_inode.size           = request->symlink_at.targetlen;
-    new_inode.space_used     = request->symlink_at.targetlen;
-    new_inode.uid            = request->cred->uid;
-    new_inode.gid            = request->cred->gid;
-    new_inode.nlink          = 1;
-    new_inode.rdev           = 0;
-    new_inode.mode           = S_IFLNK | 0755;
-    new_inode.atime          = now;
-    new_inode.mtime          = now;
-    new_inode.ctime          = now;
+    new_inode.size       = request->symlink_at.targetlen;
+    new_inode.space_used = request->symlink_at.targetlen;
+    new_inode.uid        = request->cred->uid;
+    new_inode.gid        = request->cred->gid;
+    new_inode.nlink      = 1;
+    new_inode.rdev       = 0;
+    new_inode.mode       = S_IFLNK | 0755;
+    new_inode.atime      = now;
+    new_inode.mtime      = now;
+    new_inode.ctime      = now;
+    new_inode.change++;
     new_inode.btime          = now;
     new_inode.dos_attributes = 0;
 
@@ -3779,6 +3802,7 @@ cairn_symlink_at(
 
     parent_inode->mtime = now;
     parent_inode->ctime = now;
+    parent_inode->change++;
 
     cairn_map_attrs(shared, &request->symlink_at.r_attr, &new_inode);
     cairn_map_attrs(shared, &request->symlink_at.r_dir_post_attr, parent_inode);
@@ -4163,6 +4187,7 @@ cairn_rename_at(
     }
 
     target_inode->ctime = now;
+    target_inode->change++;
     if (cmp != 0 && S_ISDIR(target_inode->mode)) {
         target_inode->parent_inum = new_parent_inode->inum;
     }
@@ -4179,8 +4204,10 @@ cairn_rename_at(
 
     old_parent_inode->mtime = now;
     old_parent_inode->ctime = now;
+    old_parent_inode->change++;
     new_parent_inode->mtime = now;
     new_parent_inode->ctime = now;
+    new_parent_inode->change++;
 
     if (cmp != 0 && S_ISDIR(target_inode->mode)) {
         old_parent_inode->nlink--;
@@ -4280,8 +4307,10 @@ cairn_link_at(
 
     target_inode->nlink++;
     target_inode->ctime = now;
+    target_inode->change++;
     parent_inode->mtime = now;
     parent_inode->ctime = now;
+    parent_inode->change++;
 
     cairn_put_dirent(thread, &dirent_key, &dirent_value);
     cairn_put_inode(thread, parent_inode);
@@ -5016,7 +5045,7 @@ SYMBOL_EXPORT struct chimera_vfs_module vfs_cairn = {
         CHIMERA_VFS_CAP_FS_RELATIVE_OP | CHIMERA_VFS_CAP_ACL_NATIVE |
         CHIMERA_VFS_CAP_ATOMIC_HANDLE_STATE |
         CHIMERA_VFS_CAP_XATTR | CHIMERA_VFS_CAP_READ_PROVIDES_BUFFERS |
-        CHIMERA_VFS_CAP_FS_LOCK,
+        CHIMERA_VFS_CAP_FS_LOCK | CHIMERA_VFS_CAP_CHANGE,
     .init           = cairn_init,
     .destroy        = cairn_destroy,
     .thread_init    = cairn_thread_init,

--- a/src/vfs/diskfs/diskfs.c
+++ b/src/vfs/diskfs/diskfs.c
@@ -142,7 +142,8 @@ SYMBOL_EXPORT struct chimera_vfs_module vfs_diskfs = {
         /* Require a real open so every file op carries a pinned inode in
          * handle->vfs_private (diskfs_open_fh_inode_cb), which read/write reuse
          * to skip per-I/O inode resolution. */
-        CHIMERA_VFS_CAP_OPEN_FILE_REQUIRED | CHIMERA_VFS_CAP_FS_LOCK,
+        CHIMERA_VFS_CAP_OPEN_FILE_REQUIRED | CHIMERA_VFS_CAP_FS_LOCK |
+        CHIMERA_VFS_CAP_CHANGE,
     .init           = diskfs_init,
     .destroy        = diskfs_destroy,
     .thread_init    = diskfs_thread_init,

--- a/src/vfs/diskfs/diskfs_attr.c
+++ b/src/vfs/diskfs/diskfs_attr.c
@@ -1592,6 +1592,7 @@ diskfs_set_xattr_inserted_cb(
     clock_gettime(CLOCK_REALTIME, &now);
     inode->ctime_sec  = now.tv_sec;
     inode->ctime_nsec = now.tv_nsec;
+    inode->change++;
 
     diskfs_map_attrs(p->thread, &request->set_xattr.r_post_attr, inode);
     diskfs_op_ok(request, p->txn);
@@ -1928,6 +1929,7 @@ diskfs_remove_xattr_removed_cb(
     clock_gettime(CLOCK_REALTIME, &now);
     inode->ctime_sec  = now.tv_sec;
     inode->ctime_nsec = now.tv_nsec;
+    inode->change++;
 
     diskfs_map_attrs(p->thread, &request->remove_xattr.r_post_attr, inode);
     diskfs_op_ok(request, p->txn);

--- a/src/vfs/diskfs/diskfs_block.c
+++ b/src/vfs/diskfs/diskfs_block.c
@@ -1153,6 +1153,7 @@ diskfs_inode_flush(struct diskfs_inode *inode)
     di->ctime_nsec     = inode->ctime_nsec;
     di->btime_nsec     = inode->btime_nsec;
     di->dos_attributes = inode->dos_attributes;
+    di->change         = inode->change;
     if (S_ISDIR(inode->mode)) {
         di->parent_inum = inode->parent_inum;
         di->parent_gen  = inode->parent_gen;

--- a/src/vfs/diskfs/diskfs_inode.c
+++ b/src/vfs/diskfs/diskfs_inode.c
@@ -465,6 +465,7 @@ diskfs_inode_load_sync(
         inode->btime_sec      = di->btime_sec;
         inode->btime_nsec     = di->btime_nsec;
         inode->dos_attributes = di->dos_attributes;
+        inode->change         = di->change;
         inode->parent_inum    = di->parent_inum;
         inode->parent_gen     = di->parent_gen;
         rb_tree_insert(&shard->inodes, inum, inode);

--- a/src/vfs/diskfs/diskfs_internal.h
+++ b/src/vfs/diskfs/diskfs_internal.h
@@ -556,6 +556,7 @@ struct diskfs_inode {
     uint32_t                    mtime_nsec;
     uint32_t                    btime_nsec;
     uint32_t                    dos_attributes;
+    uint64_t                    change;      /* native monotonic change counter */
 
     /* Inode-cache linkage, keyed by inum.  Lock state and the wait list
      * below are protected by the owning shard's mutex, never held across
@@ -803,6 +804,7 @@ struct diskfs_dinode {
     uint32_t dos_attributes;
     uint64_t parent_inum;     /* directories only */
     uint32_t parent_gen;
+    uint64_t change;          /* native monotonic change counter */
 };
 
 
@@ -4476,6 +4478,12 @@ diskfs_map_attrs(
         attr->va_btime.tv_nsec = inode->btime_nsec;
     }
 
+    /* Native monotonic change counter (CHIMERA_VFS_CAP_CHANGE). */
+    if (attr->va_req_mask & CHIMERA_VFS_ATTR_CHANGE) {
+        attr->va_set_mask |= CHIMERA_VFS_ATTR_CHANGE;
+        attr->va_change    = inode->change;
+    }
+
     if (attr->va_req_mask & CHIMERA_VFS_ATTR_FSID) {
         attr->va_set_mask |= CHIMERA_VFS_ATTR_FSID;
         attr->va_fsid      = shared->fsid;
@@ -4603,5 +4611,8 @@ diskfs_apply_attrs(
         inode->ctime_sec  = now.tv_sec;
         inode->ctime_nsec = now.tv_nsec;
     }
+
+    /* Any setattr is a metadata change; advance the native change counter. */
+    inode->change++;
 
 } /* diskfs_apply_attrs */

--- a/src/vfs/diskfs/diskfs_io.c
+++ b/src/vfs/diskfs/diskfs_io.c
@@ -847,6 +847,7 @@ diskfs_inode_load_complete(
         inode->btime_sec      = di->btime_sec;
         inode->btime_nsec     = di->btime_nsec;
         inode->dos_attributes = di->dos_attributes;
+        inode->change         = di->change;
         inode->parent_inum    = di->parent_inum;
         inode->parent_gen     = di->parent_gen;
         /* Publish write-locked, held by this fault: nobody can grant (or
@@ -1867,6 +1868,7 @@ diskfs_write_finish_map(struct chimera_vfs_request *request)
     inode->mtime_nsec = now.tv_nsec;
     inode->ctime_sec  = now.tv_sec;
     inode->ctime_nsec = now.tv_nsec;
+    inode->change++;
 
     /* POSIX kill-priv: a non-privileged write to a regular file clears the
      * set-user-ID bit and the set-group-ID bit (when group-executable).  When
@@ -2995,6 +2997,7 @@ diskfs_allocate_finalize(struct chimera_vfs_request *request)
     inode->mtime_nsec = now.tv_nsec;
     inode->ctime_sec  = now.tv_sec;
     inode->ctime_nsec = now.tv_nsec;
+    inode->change++;
 
     diskfs_map_attrs(thread, &request->allocate.r_post_attr, inode);
     diskfs_op_ok(request, p->txn);

--- a/src/vfs/diskfs/diskfs_mount.c
+++ b/src/vfs/diskfs/diskfs_mount.c
@@ -1362,13 +1362,14 @@ diskfs_bootstrap(struct diskfs_thread *thread)
      * enforcement a root-owned 0755 root would refuse all creation by non-root
      * clients on this engine-authoritative backend (matches memfs/cairn).
      * Subdirs are still created owned by their creator with 0755. */
-    inode->mode           = S_IFDIR | 0777;
-    inode->atime_sec      = now.tv_sec;
-    inode->atime_nsec     = now.tv_nsec;
-    inode->mtime_sec      = now.tv_sec;
-    inode->mtime_nsec     = now.tv_nsec;
-    inode->ctime_sec      = now.tv_sec;
-    inode->ctime_nsec     = now.tv_nsec;
+    inode->mode       = S_IFDIR | 0777;
+    inode->atime_sec  = now.tv_sec;
+    inode->atime_nsec = now.tv_nsec;
+    inode->mtime_sec  = now.tv_sec;
+    inode->mtime_nsec = now.tv_nsec;
+    inode->ctime_sec  = now.tv_sec;
+    inode->ctime_nsec = now.tv_nsec;
+    inode->change++;
     inode->btime_sec      = now.tv_sec;
     inode->btime_nsec     = now.tv_nsec;
     inode->dos_attributes = 0;
@@ -1408,16 +1409,17 @@ diskfs_bootstrap(struct diskfs_thread *thread)
                                                              oinum, &odev);
         struct diskfs_inode *oin = diskfs_inode_struct_new(oinum);
 
-        oin->size           = 4096;
-        oin->space_used     = 4096;
-        oin->nlink          = 1;
-        oin->mode           = S_IFDIR | 0700;
-        oin->atime_sec      = now.tv_sec;
-        oin->atime_nsec     = now.tv_nsec;
-        oin->mtime_sec      = now.tv_sec;
-        oin->mtime_nsec     = now.tv_nsec;
-        oin->ctime_sec      = now.tv_sec;
-        oin->ctime_nsec     = now.tv_nsec;
+        oin->size       = 4096;
+        oin->space_used = 4096;
+        oin->nlink      = 1;
+        oin->mode       = S_IFDIR | 0700;
+        oin->atime_sec  = now.tv_sec;
+        oin->atime_nsec = now.tv_nsec;
+        oin->mtime_sec  = now.tv_sec;
+        oin->mtime_nsec = now.tv_nsec;
+        oin->ctime_sec  = now.tv_sec;
+        oin->ctime_nsec = now.tv_nsec;
+        oin->change++;
         oin->btime_sec      = now.tv_sec;
         oin->btime_nsec     = now.tv_nsec;
         oin->dos_attributes = 0;

--- a/src/vfs/diskfs/diskfs_namespace.c
+++ b/src/vfs/diskfs/diskfs_namespace.c
@@ -787,18 +787,19 @@ diskfs_mkdir_at_alloc_cb(
 
     clock_gettime(CLOCK_REALTIME, &now);
 
-    inode->size           = 4096;
-    inode->space_used     = 4096;
-    inode->uid            = request->cred->uid;
-    inode->gid            = request->cred->gid;
-    inode->nlink          = 2;
-    inode->mode           = S_IFDIR | 0755;
-    inode->atime_sec      = now.tv_sec;
-    inode->atime_nsec     = now.tv_nsec;
-    inode->mtime_sec      = now.tv_sec;
-    inode->mtime_nsec     = now.tv_nsec;
-    inode->ctime_sec      = now.tv_sec;
-    inode->ctime_nsec     = now.tv_nsec;
+    inode->size       = 4096;
+    inode->space_used = 4096;
+    inode->uid        = request->cred->uid;
+    inode->gid        = request->cred->gid;
+    inode->nlink      = 2;
+    inode->mode       = S_IFDIR | 0755;
+    inode->atime_sec  = now.tv_sec;
+    inode->atime_nsec = now.tv_nsec;
+    inode->mtime_sec  = now.tv_sec;
+    inode->mtime_nsec = now.tv_nsec;
+    inode->ctime_sec  = now.tv_sec;
+    inode->ctime_nsec = now.tv_nsec;
+    inode->change++;
     inode->btime_sec      = now.tv_sec;
     inode->btime_nsec     = now.tv_nsec;
     inode->dos_attributes = 0;
@@ -819,6 +820,7 @@ diskfs_mkdir_at_alloc_cb(
     parent->mtime_nsec = now.tv_nsec;
     parent->ctime_sec  = now.tv_sec;
     parent->ctime_nsec = now.tv_nsec;
+    parent->change++;
 
     p->inode_stash[1] = inode;
 
@@ -972,18 +974,19 @@ diskfs_mknod_at_alloc_cb(
 
     clock_gettime(CLOCK_REALTIME, &now);
 
-    inode->size           = 0;
-    inode->space_used     = 0;
-    inode->uid            = request->cred->uid;
-    inode->gid            = request->cred->gid;
-    inode->nlink          = 1;
-    inode->rdev           = 0;
-    inode->atime_sec      = now.tv_sec;
-    inode->atime_nsec     = now.tv_nsec;
-    inode->mtime_sec      = now.tv_sec;
-    inode->mtime_nsec     = now.tv_nsec;
-    inode->ctime_sec      = now.tv_sec;
-    inode->ctime_nsec     = now.tv_nsec;
+    inode->size       = 0;
+    inode->space_used = 0;
+    inode->uid        = request->cred->uid;
+    inode->gid        = request->cred->gid;
+    inode->nlink      = 1;
+    inode->rdev       = 0;
+    inode->atime_sec  = now.tv_sec;
+    inode->atime_nsec = now.tv_nsec;
+    inode->mtime_sec  = now.tv_sec;
+    inode->mtime_nsec = now.tv_nsec;
+    inode->ctime_sec  = now.tv_sec;
+    inode->ctime_nsec = now.tv_nsec;
+    inode->change++;
     inode->btime_sec      = now.tv_sec;
     inode->btime_nsec     = now.tv_nsec;
     inode->dos_attributes = 0;
@@ -1004,6 +1007,7 @@ diskfs_mknod_at_alloc_cb(
     parent->mtime_nsec = now.tv_nsec;
     parent->ctime_sec  = now.tv_sec;
     parent->ctime_nsec = now.tv_nsec;
+    parent->change++;
 
     diskfs_map_attrs(thread, &request->mknod_at.r_dir_post_attr, parent);
 
@@ -1156,6 +1160,7 @@ diskfs_remove_at_removed_cb(
     parent->mtime_nsec = now.tv_nsec;
     parent->ctime_sec  = now.tv_sec;
     parent->ctime_nsec = now.tv_nsec;
+    parent->change++;
 
     if (S_ISDIR(inode->mode)) {
         inode->nlink = 0;
@@ -1166,6 +1171,7 @@ diskfs_remove_at_removed_cb(
         if (inode->nlink > 0) {
             inode->ctime_sec  = now.tv_sec;
             inode->ctime_nsec = now.tv_nsec;
+            inode->change++;
         }
     }
 
@@ -1862,18 +1868,19 @@ diskfs_open_at_alloc_cb(
 
     clock_gettime(CLOCK_REALTIME, &now);
 
-    inode->size           = 0;
-    inode->space_used     = 0;
-    inode->uid            = request->cred->uid;
-    inode->gid            = request->cred->gid;
-    inode->nlink          = 1;
-    inode->mode           = S_IFREG | 0644;
-    inode->atime_sec      = now.tv_sec;
-    inode->atime_nsec     = now.tv_nsec;
-    inode->mtime_sec      = now.tv_sec;
-    inode->mtime_nsec     = now.tv_nsec;
-    inode->ctime_sec      = now.tv_sec;
-    inode->ctime_nsec     = now.tv_nsec;
+    inode->size       = 0;
+    inode->space_used = 0;
+    inode->uid        = request->cred->uid;
+    inode->gid        = request->cred->gid;
+    inode->nlink      = 1;
+    inode->mode       = S_IFREG | 0644;
+    inode->atime_sec  = now.tv_sec;
+    inode->atime_nsec = now.tv_nsec;
+    inode->mtime_sec  = now.tv_sec;
+    inode->mtime_nsec = now.tv_nsec;
+    inode->ctime_sec  = now.tv_sec;
+    inode->ctime_nsec = now.tv_nsec;
+    inode->change++;
     inode->btime_sec      = now.tv_sec;
     inode->btime_nsec     = now.tv_nsec;
     inode->dos_attributes = 0;
@@ -1890,6 +1897,7 @@ diskfs_open_at_alloc_cb(
     parent->mtime_nsec = now.tv_nsec;
     parent->ctime_sec  = now.tv_sec;
     parent->ctime_nsec = now.tv_nsec;
+    parent->change++;
 
     p->inode_stash[1] = inode;
 
@@ -2043,18 +2051,19 @@ diskfs_create_unlinked_alloc_cb(
 
     clock_gettime(CLOCK_REALTIME, &now);
 
-    inode->size           = 0;
-    inode->space_used     = 0;
-    inode->uid            = request->cred->uid;
-    inode->gid            = request->cred->gid;
-    inode->nlink          = 0;     /* anonymous; orphan-recorded below */
-    inode->mode           = S_IFREG | 0644;
-    inode->atime_sec      = now.tv_sec;
-    inode->atime_nsec     = now.tv_nsec;
-    inode->mtime_sec      = now.tv_sec;
-    inode->mtime_nsec     = now.tv_nsec;
-    inode->ctime_sec      = now.tv_sec;
-    inode->ctime_nsec     = now.tv_nsec;
+    inode->size       = 0;
+    inode->space_used = 0;
+    inode->uid        = request->cred->uid;
+    inode->gid        = request->cred->gid;
+    inode->nlink      = 0;         /* anonymous; orphan-recorded below */
+    inode->mode       = S_IFREG | 0644;
+    inode->atime_sec  = now.tv_sec;
+    inode->atime_nsec = now.tv_nsec;
+    inode->mtime_sec  = now.tv_sec;
+    inode->mtime_nsec = now.tv_nsec;
+    inode->ctime_sec  = now.tv_sec;
+    inode->ctime_nsec = now.tv_nsec;
+    inode->change++;
     inode->btime_sec      = now.tv_sec;
     inode->btime_nsec     = now.tv_nsec;
     inode->dos_attributes = 0;
@@ -2234,18 +2243,19 @@ diskfs_symlink_at_alloc_cb(
 
     clock_gettime(CLOCK_REALTIME, &now);
 
-    inode->size           = request->symlink_at.targetlen;
-    inode->space_used     = request->symlink_at.targetlen;
-    inode->uid            = request->cred->uid;
-    inode->gid            = request->cred->gid;
-    inode->nlink          = 1;
-    inode->mode           = S_IFLNK | 0755;
-    inode->atime_sec      = now.tv_sec;
-    inode->atime_nsec     = now.tv_nsec;
-    inode->mtime_sec      = now.tv_sec;
-    inode->mtime_nsec     = now.tv_nsec;
-    inode->ctime_sec      = now.tv_sec;
-    inode->ctime_nsec     = now.tv_nsec;
+    inode->size       = request->symlink_at.targetlen;
+    inode->space_used = request->symlink_at.targetlen;
+    inode->uid        = request->cred->uid;
+    inode->gid        = request->cred->gid;
+    inode->nlink      = 1;
+    inode->mode       = S_IFLNK | 0755;
+    inode->atime_sec  = now.tv_sec;
+    inode->atime_nsec = now.tv_nsec;
+    inode->mtime_sec  = now.tv_sec;
+    inode->mtime_nsec = now.tv_nsec;
+    inode->ctime_sec  = now.tv_sec;
+    inode->ctime_nsec = now.tv_nsec;
+    inode->change++;
     inode->btime_sec      = now.tv_sec;
     inode->btime_nsec     = now.tv_nsec;
     inode->dos_attributes = 0;
@@ -2256,6 +2266,7 @@ diskfs_symlink_at_alloc_cb(
     parent->mtime_nsec = now.tv_nsec;
     parent->ctime_sec  = now.tv_sec;
     parent->ctime_nsec = now.tv_nsec;
+    parent->change++;
 
     diskfs_map_attrs(thread, &request->symlink_at.r_dir_post_attr, parent);
 
@@ -2561,16 +2572,19 @@ diskfs_rename_at_perform_final_cb(
     op->mtime_nsec = now.tv_nsec;
     op->ctime_sec  = now.tv_sec;
     op->ctime_nsec = now.tv_nsec;
+    op->change++;
     if (np != op) {
         np->mtime_sec  = now.tv_sec;
         np->mtime_nsec = now.tv_nsec;
         np->ctime_sec  = now.tv_sec;
         np->ctime_nsec = now.tv_nsec;
+        np->change++;
     }
 
     /* POSIX: a successful rename marks the renamed file's status-change time. */
     child->ctime_sec  = now.tv_sec;
     child->ctime_nsec = now.tv_nsec;
+    child->change++;
 
     diskfs_map_attrs(thread, &request->rename_at.r_fromdir_post_attr, op);
     diskfs_map_attrs(thread, &request->rename_at.r_todir_post_attr, np);
@@ -3091,12 +3105,14 @@ diskfs_link_at_finish(struct chimera_vfs_request *request)
     clock_gettime(CLOCK_REALTIME, &now);
 
     inode->nlink++;
-    inode->ctime_sec   = now.tv_sec;
-    inode->ctime_nsec  = now.tv_nsec;
+    inode->ctime_sec  = now.tv_sec;
+    inode->ctime_nsec = now.tv_nsec;
+    inode->change++;
     parent->mtime_sec  = now.tv_sec;
     parent->mtime_nsec = now.tv_nsec;
     parent->ctime_sec  = now.tv_sec;
     parent->ctime_nsec = now.tv_nsec;
+    parent->change++;
 
     diskfs_map_attrs(thread, &request->link_at.r_attr, inode);
     diskfs_map_attrs(thread, &request->link_at.r_dir_post_attr, parent);

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -183,6 +183,7 @@ struct memfs_inode {
     struct timespec            mtime;
     struct timespec            ctime;
     struct timespec            btime;
+    uint64_t                   change; /* native monotonic change counter */
     struct memfs_inode        *next;
     struct memfs_xattr        *xattrs;
     struct memfs_remote       *remote; /* non-NULL => pNFS stub (data lives on a DS) */
@@ -672,6 +673,7 @@ memfs_inode_alloc(
     inode->gen++;
     inode->refcnt         = 1;
     inode->mode           = 0;
+    inode->change         = 0;
     inode->dos_attributes = 0;
     inode->acl            = NULL;
     inode->xattrs         = NULL;
@@ -1093,6 +1095,7 @@ memfs_init(
     inode->atime = now;
     inode->mtime = now;
     inode->ctime = now;
+    inode->change++;
     inode->btime = now;
 
     rb_tree_init(&inode->dir.dirents);
@@ -1360,6 +1363,12 @@ memfs_map_attrs(
         attr->va_btime     = inode->btime;
     }
 
+    /* Native monotonic change counter (CHIMERA_VFS_CAP_CHANGE). */
+    if (attr->va_req_mask & CHIMERA_VFS_ATTR_CHANGE) {
+        attr->va_set_mask |= CHIMERA_VFS_ATTR_CHANGE;
+        attr->va_change    = inode->change;
+    }
+
     if (attr->va_req_mask & CHIMERA_VFS_ATTR_FSID) {
         attr->va_set_mask |= CHIMERA_VFS_ATTR_FSID;
         attr->va_fsid      = shared->fsid;
@@ -1519,6 +1528,9 @@ memfs_apply_attrs(
     } else {
         inode->ctime = now;
     }
+
+    /* Any setattr is a metadata change; advance the native change counter. */
+    inode->change++;
 
 } /* memfs_apply_attrs */
 
@@ -1931,6 +1943,12 @@ memfs_mount(
         attr->va_btime     = inode->btime;
     }
 
+    /* Native monotonic change counter (CHIMERA_VFS_CAP_CHANGE). */
+    if (attr->va_req_mask & CHIMERA_VFS_ATTR_CHANGE) {
+        attr->va_set_mask |= CHIMERA_VFS_ATTR_CHANGE;
+        attr->va_change    = inode->change;
+    }
+
     if (attr->va_req_mask & CHIMERA_VFS_ATTR_FSID) {
         attr->va_set_mask |= CHIMERA_VFS_ATTR_FSID;
         attr->va_fsid      = shared->fsid;
@@ -2200,7 +2218,8 @@ memfs_mkdir_at(
     inode->atime      = now;
     inode->mtime      = now;
     inode->ctime      = now;
-    inode->btime      = now;
+    inode->change++;
+    inode->btime = now;
 
     rb_tree_init(&inode->dir.dirents);
 
@@ -2276,6 +2295,7 @@ memfs_mkdir_at(
 
     parent_inode->mtime = now;
     parent_inode->ctime = now;
+    parent_inode->change++;
 
     memfs_map_attrs(shared, r_dir_post_attr, parent_inode, request->fh);
 
@@ -2316,7 +2336,8 @@ memfs_mknod_at(
     inode->atime      = now;
     inode->mtime      = now;
     inode->ctime      = now;
-    inode->btime      = now;
+    inode->change++;
+    inode->btime = now;
 
     /* The mode (including file type bits S_IFCHR/S_IFBLK/S_IFSOCK/S_IFIFO)
      * and rdev are set via set_attr by the caller */
@@ -2390,6 +2411,7 @@ memfs_mknod_at(
 
     parent_inode->mtime = now;
     parent_inode->ctime = now;
+    parent_inode->change++;
 
     memfs_map_attrs(shared, r_dir_post_attr, parent_inode, request->fh);
 
@@ -2463,6 +2485,7 @@ memfs_remove_at(
     }
     parent_inode->mtime = now;
     parent_inode->ctime = now;
+    parent_inode->change++;
 
     rb_tree_remove(&parent_inode->dir.dirents, &dirent->node);
 
@@ -2474,6 +2497,7 @@ memfs_remove_at(
          * link count, which is a status change: bump its ctime. */
         if (inode->nlink > 0) {
             inode->ctime = now;
+            inode->change++;
         }
     }
 
@@ -2769,15 +2793,16 @@ memfs_open_at(
 
         pthread_mutex_lock(&inode->lock);
 
-        inode->size            = 0;
-        inode->space_used      = 0;
-        inode->uid             = request->cred->uid;
-        inode->gid             = request->cred->gid;
-        inode->nlink           = 1;
-        inode->mode            = S_IFREG |  0644;
-        inode->atime           = now;
-        inode->mtime           = now;
-        inode->ctime           = now;
+        inode->size       = 0;
+        inode->space_used = 0;
+        inode->uid        = request->cred->uid;
+        inode->gid        = request->cred->gid;
+        inode->nlink      = 1;
+        inode->mode       = S_IFREG |  0644;
+        inode->atime      = now;
+        inode->mtime      = now;
+        inode->ctime      = now;
+        inode->change++;
         inode->file.blocks     = NULL;
         inode->file.max_blocks = 0;
         inode->file.num_blocks = 0;
@@ -2796,8 +2821,9 @@ memfs_open_at(
 
         rb_tree_insert(&parent_inode->dir.dirents, hash, dirent);
 
-        parent_inode->mtime        = now;
-        parent_inode->ctime        = now;
+        parent_inode->mtime = now;
+        parent_inode->ctime = now;
+        parent_inode->change++;
         request->open_at.r_created = 1;
     } else {
         inode = memfs_inode_get_inum(shared, dirent->inum, dirent->gen);
@@ -2923,15 +2949,16 @@ memfs_create_unlinked(
 
     inode = memfs_inode_alloc_thread(thread);
 
-    inode->size            = 0;
-    inode->space_used      = 0;
-    inode->uid             = request->cred->uid;
-    inode->gid             = request->cred->gid;
-    inode->nlink           = 0;
-    inode->mode            = S_IFREG |  0644;
-    inode->atime           = now;
-    inode->mtime           = now;
-    inode->ctime           = now;
+    inode->size       = 0;
+    inode->space_used = 0;
+    inode->uid        = request->cred->uid;
+    inode->gid        = request->cred->gid;
+    inode->nlink      = 0;
+    inode->mode       = S_IFREG |  0644;
+    inode->atime      = now;
+    inode->mtime      = now;
+    inode->ctime      = now;
+    inode->change++;
     inode->file.blocks     = NULL;
     inode->file.max_blocks = 0;
     inode->file.num_blocks = 0;
@@ -3361,6 +3388,7 @@ memfs_write(
 
     inode->mtime = now;
     inode->ctime = now;
+    inode->change++;
 
     /* POSIX kill-priv: a non-privileged write to a regular file clears the
      * set-user-ID bit and the set-group-ID bit (when group-executable).  Named
@@ -3553,6 +3581,7 @@ memfs_allocate(
 
     inode->mtime = now;
     inode->ctime = now;
+    inode->change++;
 
     memfs_map_attrs_fork(shared, &request->allocate.r_post_attr, inode, stream, request->fh);
 
@@ -3862,6 +3891,7 @@ memfs_copy_range(
 
     dst_inode->mtime = now;
     dst_inode->ctime = now;
+    dst_inode->change++;
     src_inode->atime = now;
 
     memfs_map_attrs(shared, &request->copy_range.r_post_attr, dst_inode,
@@ -4008,8 +4038,10 @@ memfs_move_range(
 
     dst_inode->mtime = now;
     dst_inode->ctime = now;
+    dst_inode->change++;
     src_inode->mtime = now;
     src_inode->ctime = now;
+    src_inode->change++;
 
     memfs_map_attrs(shared, &request->move_range.r_dst_post_attr, dst_inode,
                     request->move_range.dst_handle->fh);
@@ -4251,6 +4283,7 @@ memfs_clone_range(
 
     dst_inode->mtime = now;
     dst_inode->ctime = now;
+    dst_inode->change++;
     src_inode->atime = now;
 
     memfs_map_attrs(shared, &request->clone_range.r_post_attr, dst_inode,
@@ -4401,7 +4434,8 @@ memfs_symlink_at(
     inode->atime      = now;
     inode->mtime      = now;
     inode->ctime      = now;
-    inode->btime      = now;
+    inode->change++;
+    inode->btime = now;
 
     inode->symlink.target = memfs_symlink_target_alloc(thread);
 
@@ -4456,6 +4490,7 @@ memfs_symlink_at(
 
     parent_inode->mtime = now;
     parent_inode->ctime = now;
+    parent_inode->change++;
 
     memfs_map_attrs(shared, &request->symlink_at.r_dir_post_attr, parent_inode, request->fh);
 
@@ -4783,11 +4818,14 @@ memfs_rename_at(
 
     old_parent_inode->mtime = now;
     old_parent_inode->ctime = now;
+    old_parent_inode->change++;
     new_parent_inode->mtime = now;
     new_parent_inode->ctime = now;
+    new_parent_inode->change++;
 
     /* POSIX: a successful rename marks the renamed file's status-change time. */
     child_inode->ctime = now;
+    child_inode->change++;
 
     memfs_map_attrs(shared, &request->rename_at.r_fromdir_post_attr, old_parent_inode, request->fh);
     memfs_map_attrs(shared, &request->rename_at.r_todir_post_attr, new_parent_inode, request->rename_at.new_fh);
@@ -4884,9 +4922,11 @@ memfs_link_at(
          * the target's mutex. */
         if (existing_dirent->inum == inode->inum &&
             existing_dirent->gen == inode->gen) {
-            inode->ctime        = now;
+            inode->ctime = now;
+            inode->change++;
             parent_inode->mtime = now;
             parent_inode->ctime = now;
+            parent_inode->change++;
             memfs_map_attrs(shared, &request->link_at.r_dir_post_attr,
                             parent_inode, request->link_at.dir_fh);
             memfs_map_attrs(shared, &request->link_at.r_attr, inode,
@@ -4938,9 +4978,11 @@ memfs_link_at(
 
     inode->nlink++;
 
-    inode->ctime        = now;
+    inode->ctime = now;
+    inode->change++;
     parent_inode->mtime = now;
     parent_inode->ctime = now;
+    parent_inode->change++;
 
     memfs_map_attrs(shared, &request->link_at.r_dir_post_attr, parent_inode, request->link_at.dir_fh);
     memfs_map_attrs(shared, &request->link_at.r_attr, inode, request->fh);
@@ -5067,6 +5109,7 @@ memfs_set_xattr(
 
     chimera_vfs_realtime(&now);
     inode->ctime = now;
+    inode->change++;
 
     memfs_map_attrs(shared, &request->set_xattr.r_post_attr, inode, request->fh);
 
@@ -5166,6 +5209,7 @@ memfs_remove_xattr(
 
     chimera_vfs_realtime(&now);
     inode->ctime = now;
+    inode->change++;
 
     memfs_map_attrs(shared, &request->remove_xattr.r_post_attr, inode, request->fh);
 
@@ -5221,13 +5265,14 @@ memfs_open_stream(
         stream->name = malloc(request->open_stream.namelen);
         memcpy(stream->name, request->open_stream.name,
                request->open_stream.namelen);
-        stream->name_len               = request->open_stream.namelen;
-        stream->id                     = ++inode->next_stream_id;
-        stream->linked                 = 1;
-        stream->next                   = inode->streams;
-        inode->streams                 = stream;
-        inode->mtime                   = now;
-        inode->ctime                   = now;
+        stream->name_len = request->open_stream.namelen;
+        stream->id       = ++inode->next_stream_id;
+        stream->linked   = 1;
+        stream->next     = inode->streams;
+        inode->streams   = stream;
+        inode->mtime     = now;
+        inode->ctime     = now;
+        inode->change++;
         request->open_stream.r_created = 1;
     } else if (flags & CHIMERA_VFS_OPEN_EXCLUSIVE) {
         pthread_mutex_unlock(&inode->lock);
@@ -5240,6 +5285,7 @@ memfs_open_stream(
         stream->space_used = 0;
         inode->mtime       = now;
         inode->ctime       = now;
+        inode->change++;
     }
 
     /* Named streams share the base file's metadata (mode/owner/timestamps and
@@ -5401,6 +5447,7 @@ memfs_remove_stream(
     }
 
     inode->ctime = now;
+    inode->change++;
 
     memfs_map_attrs(shared, &request->remove_stream.r_post_attr, inode, request->fh);
 
@@ -5535,7 +5582,8 @@ SYMBOL_EXPORT struct chimera_vfs_module vfs_memfs = {
         CHIMERA_VFS_CAP_COPY_RANGE | CHIMERA_VFS_CAP_CLONE_RANGE | CHIMERA_VFS_CAP_MOVE_RANGE |
         CHIMERA_VFS_CAP_ACL_NATIVE | CHIMERA_VFS_CAP_XATTR | CHIMERA_VFS_CAP_LAYOUT |
         CHIMERA_VFS_CAP_READ_PROVIDES_BUFFERS |
-        CHIMERA_VFS_CAP_NAMED_STREAMS | CHIMERA_VFS_CAP_RPL | CHIMERA_VFS_CAP_FS_LOCK,
+        CHIMERA_VFS_CAP_NAMED_STREAMS | CHIMERA_VFS_CAP_RPL | CHIMERA_VFS_CAP_FS_LOCK |
+        CHIMERA_VFS_CAP_CHANGE,
     .init           = memfs_init,
     .destroy        = memfs_destroy,
     .thread_init    = memfs_thread_init,

--- a/src/vfs/vfs.h
+++ b/src/vfs/vfs.h
@@ -1325,6 +1325,14 @@ struct chimera_vfs_handle_state {
  * ENOTSUP.  Currently only memfs advertises it. */
 #define CHIMERA_VFS_CAP_NAMED_STREAMS         (1U << 22)
 
+/* If set, the module supplies a native change attribute: a monotonically
+ * increasing per-object version counter returned via va_change /
+ * CHIMERA_VFS_ATTR_CHANGE, bumped on every data or metadata mutation.  This
+ * lets the NFS server return the counter as fattr4_change and report
+ * change_attr_type NFS4_CHANGE_TYPE_IS_MONOTONIC_INCR.  Modules that leave this
+ * unset have change derived from ctime (change_attr_type TIME_METADATA). */
+#define CHIMERA_VFS_CAP_CHANGE                (1U << 24)
+
 struct chimera_vfs_module {
     /* Required
      * Short name for the module to be used in creating shares

--- a/src/vfs/vfs_attrs.h
+++ b/src/vfs/vfs_attrs.h
@@ -65,6 +65,13 @@ struct chimera_acl;
  * fresh, mask-gated, only when a protocol asks for them. */
 #define CHIMERA_VFS_ATTR_ACL                (1UL << 24)
 
+/* Native change attribute (va_change).  Optional and cacheable, modeled on
+ * BTIME: a backend sets this bit in va_set_mask only if it tracks a real
+ * monotonic change counter (CHIMERA_VFS_CAP_CHANGE).  Deliberately NOT part of
+ * MASK_STAT (which every backend must supply); backends without a native
+ * counter simply leave it unset and the NFS server derives change from ctime. */
+#define CHIMERA_VFS_ATTR_CHANGE             (1UL << 25)
+
 #define CHIMERA_VFS_ATTR_MASK_STAT          ( \
             CHIMERA_VFS_ATTR_DEV | \
             CHIMERA_VFS_ATTR_INUM | \
@@ -108,7 +115,8 @@ struct chimera_acl;
  * track btime (linux/io_uring/cairn) must still satisfy MASK_STAT. */
 #define CHIMERA_VFS_ATTR_MASK_CACHEABLE     ( \
             CHIMERA_VFS_ATTR_MASK_STAT | \
-            CHIMERA_VFS_ATTR_BTIME)
+            CHIMERA_VFS_ATTR_BTIME | \
+            CHIMERA_VFS_ATTR_CHANGE)
 
 #define CHIMERA_VFS_TIME_NOW                ((1l << 30) - 3l)
 
@@ -165,6 +173,13 @@ struct chimera_vfs_attrs {
     struct timespec     va_mtime;
     struct timespec     va_ctime;
     struct timespec     va_btime;
+
+    /* Native change attribute (CHIMERA_VFS_ATTR_CHANGE): a monotonically
+     * increasing per-object version counter.  Optional: a backend sets this bit
+     * in va_set_mask only if it supplies a real counter (CHIMERA_VFS_CAP_CHANGE),
+     * letting the NFS server report change_attr_type MONOTONIC_INCR instead of
+     * falling back to a ctime-derived change value. */
+    uint64_t            va_change;
 
     uint64_t            va_fs_space_avail;
     uint64_t            va_fs_space_free;


### PR DESCRIPTION
## Summary

Adds the NFSv4.2 `change_attr_type` attribute (RFC 7862, attr 79) and, underneath it, a first-class **native VFS change attribute** — a monotonically increasing per-inode version counter — so `fattr4_change` no longer has to be derived from ctime on backends that can do better.

Previously `fattr4_change` was always computed from ctime (`sec*1e9 + nsec`) for every backend, so its quality was bound to timestamp granularity, and `change_attr_type` was not advertised at all.

## What changed

- **VFS core**: new optional `va_change` field + `CHIMERA_VFS_ATTR_CHANGE` bit (cacheable, modeled on `btime`; deliberately not in `MASK_STAT`) and a `CHIMERA_VFS_CAP_CHANGE` capability flag.
- **NFS server**: the marshaller decides **per object** from `va_set_mask`. When the backend supplies `va_change`, `fattr4_change` is the raw counter and `change_attr_type` is `MONOTONIC_INCR`; otherwise change is ctime-derived and the type is `TIME_METADATA` — matching Linux nfsd with/without `i_version`. `change_attr_type` is advertised for minorversion ≥ 2.
- **memfs / diskfs / cairn**: bump a per-inode counter on every mutation (at each ctime stamp; the central setattr path bumps once) and surface it in getattr. diskfs persists it in both the in-memory and on-disk inode; cairn rides it along in its RocksDB inode blob.
- **linux / io_uring**: unchanged — they keep the ctime fallback and report `TIME_METADATA`.
- **Delegation fix**: the write-delegation `CB_GETATTR` merge path reconstructed a synthetic ctime from the holder's change value, which a native-counter backend's marshaller ignores (it prefers `va_change`), silently dropping the holder's value. It now overrides in whichever representation the backend uses, keeping `change_attr_type` stable per object.

## Other front-ends (considered, intentionally not wired)

- **SMB**: has no client-pollable change/version analog (ChangeTime is a timestamp; coherency is lease/oplock-driven; CHANGE_NOTIFY is already event-driven). Left as-is.
- **S3**: ETag must remain a stable content identifier; folding in a counter that bumps on metadata-only changes would break ETag stability. Left as-is.
- **NFSv3**: no change attribute in the protocol; wcc uses size/mtime/ctime. Unaffected.

## Verification

- `protocol_advertise` unit test extended (advertise @4.2-not-4.1; MONOTONIC vs TIME_METADATA; native vs ctime value) — green in Debug and Release.
- Full pynfs `combined` runs pass on memfs/cairn/diskfs_io_uring **and** linux/io_uring across NFS 4.0/4.1/4.2 (includes WRT18/SATT15 change-granularity).
- All 151 delegation tests pass (memfs/cairn/diskfs × 4.0/4.1/4.2, incl. KVM e2e), covering the CB_GETATTR fix.
- `make syntax-check`, `reuse-lint`, copyright-year clean; both build configs compile. Rebased onto current main and re-verified.