### PR TITLE
kvm/nfstest: raise delegation/cache guest RAM to 4 GiB to avoid tcpdump OOM

### DIFF
--- a/kvm/kvm_nfstest_test_wrapper.sh
+++ b/kvm/kvm_nfstest_test_wrapper.sh
@@ -300,6 +300,15 @@ case "$NFSTEST_PROGRAM" in
     # nfstest_alloc analyses the whole packet trace in memory; nfstest_dio drives
     # 1 MiB direct-I/O transfers whose traces and buffers blow past 1 GiB.
     nfstest_alloc | nfstest_dio) QEMU_MEM="8G" ;;
+    # nfstest_delegation / nfstest_cache bracket every subtest with a fresh
+    # in-guest tcpdump trace window whose AF_PACKET ring is ~192 MiB and is not
+    # reliably reaped before the next window opens.  Several live rings have
+    # OOM-killed tcpdump in a 1 GiB guest (8 x 192 MiB observed under -j32 load),
+    # which then fails the trace-based assertions ("OPEN should be sent", "WRITE
+    # delegation should be granted") even though the functional sub-asserts pass.
+    # The -m value is only a ceiling -- KVM guest RAM is demand-paged -- so the
+    # extra headroom costs no host memory unless the guest actually touches it.
+    nfstest_delegation | nfstest_cache) QEMU_MEM="4G" ;;
 esac
 
 # Boot QEMU inside the netns; the guest's /init.sh runs test_cmd (no pre-mount).


### PR DESCRIPTION
## Problem

`nfstest_delegation_memfs_nfs4.1` and `nfstest_cache_memfs_nfs4.1` intermittently hard-fail in the KVM merge-queue with:

```
FAIL: OPEN should be sent
FAIL: WRITE delegation should be granted
1644 tests (1642 passed, 2 failed)
```

These two messages are **packet-trace assertions**, not functional failures. nfstest brackets every subtest with a fresh in-guest `tcpdump` window, captures the wire traffic to a `.cap`, then parses it to verify on-the-wire behaviour (`OPEN should be sent` = "I expected an NFS OPEN op in the capture"). The functional sub-asserts of the same subtest — open / lock / conflicting write / recall — all `PASS`; only the post-hoc trace verification trips.

## Root cause

The failures are caused by a **guest OOM**, not a server bug. Each per-window `tcpdump` runs a ~192 MiB `AF_PACKET` ring (`-B`), and the rings are not reliably reaped before the next window opens. Under `-j32` CI load the windows stretch and overlap, so several live rings pile up and exhaust the **1 GiB** guest:

- The failing run logged **92 OOM-kills of tcpdump** (8 × 192 MiB rings observed simultaneously in the OOM table).
- When tcpdump is killed mid-window its `.cap` is empty/truncated, so the trace assertion finds no OPEN / no delegation-grant packet and fails.
- The automatic rerun of the same test had **0 OOM-kills and passed 5/5** — same binary, same server. A genuine "server didn't send OPEN" defect would reproduce; a lost-capture artifact does not.

## Fix

Give `nfstest_delegation` and `nfstest_cache` a 4 GiB guest-RAM ceiling (`nfstest_alloc` / `nfstest_dio` already get 8 GiB). The observed peak was ~1.5 GiB of live tcpdump rings, so 4 GiB leaves comfortable headroom. The `-m` value is only a ceiling — KVM guest RAM is demand-paged — so the extra headroom costs no host memory unless the guest actually touches it.

This keeps the trace-based delegation/cache verification fully intact (no coverage loss); it just stops the capturer from being OOM-killed.