### PR TITLE
NFS: RPCSEC_GSS / Kerberos (sec=krb5, krb5i), per-export sec= policy, and SP4_MACH_CRED

### DIFF
--- a/kvm/CMakeLists.txt
+++ b/kvm/CMakeLists.txt
@@ -16,7 +16,9 @@ get_filename_component(BUILD_ROOT ${CMAKE_BINARY_DIR} DIRECTORY)
 set(KVM_IMAGE_REGISTRY "ghcr.io/chimera-nas/kvm-test-base" CACHE STRING
     "OCI registry base that hosts the prebuilt KVM guest images.")
 # Pinned version of the prebuilt images to consume; bump to adopt a newer
-# kvm-test-base release.  v1.8.0 pins nfstest to the chimera fork tag
+# kvm-test-base release.  v1.9.0 adds krb5-user + an init.sh sec=krb5 bring-up
+# (rpc.gssd, with the per-test keytab/conf handed in over a 9p share) for the
+# RPCSEC_GSS/Kerberos NFS test; v1.8.0 pins nfstest to the chimera fork tag
 # v3.2-chimera2, carrying the Python 3.14 compatibility fixes so the nfstest
 # suite runs on Ubuntu 26.04 (Python 3.14); v1.7.0 bakes sshd + a symmetric key
 # so nfstest's cross-client suites can drive a second NFS client over ssh (and
@@ -26,7 +28,7 @@ set(KVM_IMAGE_REGISTRY "ghcr.io/chimera-nas/kvm-test-base" CACHE STRING
 # ubuntu2604 variant; v1.3.0 added the Linux Test Project (LTP) tree under
 # /opt/ltp{,-skip}; v1.2.0 added the Linux nfstest suite; v1.1.0 dropped the 22.04
 # generic variant (see the KVM_IMAGES note below); v1.0.0 still has all four.
-set(KVM_IMAGE_VERSION "v1.8.0" CACHE STRING
+set(KVM_IMAGE_VERSION "v1.9.0" CACHE STRING
     "Version tag of the KVM guest images to consume.")
 
 # Note: the 22.04 generic (non-HWE) kernel does not build the virtio block

--- a/kvm/kvm_nfs_kerberos_test_wrapper.sh
+++ b/kvm/kvm_nfs_kerberos_test_wrapper.sh
@@ -1,0 +1,273 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+#
+# SPDX-License-Identifier: Unlicense
+#
+# Usage: kvm_nfs_kerberos_test_wrapper.sh <vmlinuz> <rootfs.qcow2> <chimera_binary> \
+#                                         <backend> <nfsver> <post_mount_cmd>
+#
+# Boots a real Linux NFS client (QEMU/KVM) and mounts a chimera export with
+# sec=krb5, proving the RPCSEC_GSS path against the kernel client + rpc.gssd.
+#
+#   1. Network namespace + TAP (host 10.0.0.1, guest 10.0.0.2).
+#   2. An ephemeral MIT KDC in the netns (realm TEST.LOCAL, KDC on 10.0.0.1).
+#   3. chimera NFS server with Kerberos enabled (keytab holds nfs/<server>).
+#   4. A 9p share carrying the client's krb5.conf + machine keytab + hosts; the
+#      guest (image >= v1.9.0, booted with krb5=1) copies it into place and
+#      starts rpc.gssd.
+#   5. The guest runs: mount -o sec=krb5 <server>:/share /mnt && <post_mount_cmd>
+#
+# Skips (exit 77) without /dev/kvm or the krb5 tooling.
+
+set -u
+
+ARCH=$(uname -m)
+if [ "$ARCH" = "aarch64" ]; then
+    QEMU_BIN="qemu-system-aarch64"
+    QEMU_MACHINE="-machine virt"
+    QEMU_CONSOLE="ttyAMA0"
+else
+    QEMU_BIN="qemu-system-x86_64"
+    QEMU_MACHINE="-M microvm,acpi=on,rtc=on,pit=on,pcie=on"
+    QEMU_CONSOLE="ttyS0"
+fi
+
+VMLINUZ=$1; shift
+ROOTFS=$1; shift
+CHIMERA_BINARY=$1; shift
+BACKEND=$1; shift
+NFS_VERSION=$1; shift
+POST_MOUNT_CMD="$*"
+
+REALM="TEST.LOCAL"
+KDC_IP="10.0.0.1"
+KDC_PORT="8899"
+SERVER_HOST="nfsserver.test.local"
+CLIENT_HOST="nfsclient.test.local"
+
+TEST_ID="$$_$(date +%s%N | tail -c 6)"
+NETNS_NAME="kvm_krb_${TEST_ID}"
+TAP_NAME="tapk_$$"
+KRB_DIR="/tmp/kvmkrb_${TEST_ID}"
+KRB_SHARE="${KRB_DIR}/share"
+SERVER_KEYTAB="${KRB_DIR}/server.keytab"
+BUILD_DIR=$(dirname "$(dirname "$CHIMERA_BINARY")")
+SESSION_DIR=$(mktemp -d "${BUILD_DIR}/kvm_krb_session_XXXXXX")
+CONFIG_FILE="${SESSION_DIR}/chimera.json"
+LOG_FILE=$(mktemp /tmp/kvm_krb_XXXXXX.log)
+CHIMERA_PID=""
+
+log() { echo "[kvm_krb] $*" >&2; }
+
+cleanup() {
+    if [ -n "$CHIMERA_PID" ]; then
+        kill "$CHIMERA_PID" 2>/dev/null || true
+        for _ in $(seq 1 150); do kill -0 "$CHIMERA_PID" 2>/dev/null || break; sleep 0.02; done
+        kill -9 "$CHIMERA_PID" 2>/dev/null || true
+        wait "$CHIMERA_PID" 2>/dev/null || true
+    fi
+    if [ -f "$LOG_FILE" ]; then
+        echo "=== Guest serial log ==="
+        cat "$LOG_FILE"
+    fi
+    if ip netns list 2>/dev/null | grep -q "^${NETNS_NAME}"; then
+        ip netns pids "${NETNS_NAME}" 2>/dev/null | xargs -r kill -9 2>/dev/null || true
+        sleep 0.1
+        ip netns delete "${NETNS_NAME}" 2>/dev/null || true
+    fi
+    rm -f "$LOG_FILE"
+    rm -rf "$KRB_DIR" "$SESSION_DIR"
+}
+trap cleanup EXIT
+
+check_requirements() {
+    if [ ! -e /dev/kvm ]; then
+        log "SKIP: /dev/kvm not available"
+        exit 77
+    fi
+    local cmd
+    for cmd in kdb5_util krb5kdc kadmin.local; do
+        command -v "$cmd" &>/dev/null || { log "SKIP: missing $cmd"; exit 77; }
+    done
+}
+
+setup_kdc() {
+    mkdir -p "${KRB_DIR}"/{etc,var/lib/krb5kdc} "${KRB_SHARE}"
+
+    cat > "${KRB_DIR}/etc/kdc.conf" <<EOF
+[kdcdefaults]
+    kdc_ports = ${KDC_PORT}
+    kdc_tcp_ports = ${KDC_PORT}
+
+[realms]
+    ${REALM} = {
+        database_name = ${KRB_DIR}/var/lib/krb5kdc/principal
+        admin_keytab = ${KRB_DIR}/var/lib/krb5kdc/kadm5.keytab
+        acl_file = ${KRB_DIR}/var/lib/krb5kdc/kadm5.acl
+        key_stash_file = ${KRB_DIR}/var/lib/krb5kdc/.k5.${REALM}
+        kdc_ports = ${KDC_PORT}
+        max_life = 24h
+        max_renewable_life = 7d
+    }
+EOF
+
+    # Shared by both the server (KRB5_CONFIG) and, via the 9p share, the client.
+    cat > "${KRB_DIR}/etc/krb5.conf" <<EOF
+[libdefaults]
+    default_realm = ${REALM}
+    dns_lookup_realm = false
+    dns_lookup_kdc = false
+    dns_canonicalize_hostname = false
+    rdns = false
+    ticket_lifetime = 24h
+    forwardable = true
+
+[realms]
+    ${REALM} = {
+        kdc = ${KDC_IP}:${KDC_PORT}
+        admin_server = ${KDC_IP}:${KDC_PORT}
+    }
+
+[domain_realm]
+    .test.local = ${REALM}
+    test.local = ${REALM}
+EOF
+
+    echo "*/admin@${REALM} *" > "${KRB_DIR}/var/lib/krb5kdc/kadm5.acl"
+
+    export KRB5_CONFIG="${KRB_DIR}/etc/krb5.conf"
+    export KRB5_KDC_PROFILE="${KRB_DIR}/etc/kdc.conf"
+
+    kdb5_util create -s -r "${REALM}" -P "$(head -c 32 /dev/urandom | base64)" 2>/dev/null
+
+    # nfs/<server> -> chimera's acceptor keytab; host/<client> -> the client's
+    # machine keytab that rpc.gssd uses for the mount.
+    kadmin.local -q "addprinc -randkey nfs/${SERVER_HOST}@${REALM}" 2>/dev/null
+    kadmin.local -q "addprinc -randkey host/${CLIENT_HOST}@${REALM}" 2>/dev/null
+
+    kadmin.local -q "ktadd -k ${SERVER_KEYTAB} nfs/${SERVER_HOST}@${REALM}" 2>/dev/null
+    kadmin.local -q "ktadd -k ${KRB_SHARE}/krb5.keytab host/${CLIENT_HOST}@${REALM}" 2>/dev/null
+
+    # Material handed to the guest over 9p.
+    cp "${KRB_DIR}/etc/krb5.conf" "${KRB_SHARE}/krb5.conf"
+    cat > "${KRB_SHARE}/hosts" <<EOF
+10.0.0.1 ${SERVER_HOST}
+10.0.0.2 ${CLIENT_HOST}
+EOF
+    chmod -R a+rX "${KRB_SHARE}"
+}
+
+generate_config() {
+    local mount_path="/" vfs_section=""
+    case "$BACKEND" in
+        linux | io_uring) mount_path="$SESSION_DIR/data"; mkdir -p "$SESSION_DIR/data" ;;
+        memfs) mount_path="/" ;;
+        cairn)
+            vfs_section="\"vfs\": { \"cairn\": { \"config\": {\"initialize\":true,\"path\":\"$SESSION_DIR\"} } },"
+            ;;
+        *) log "Unsupported backend: $BACKEND"; exit 1 ;;
+    esac
+
+    cat > "$CONFIG_FILE" <<EOF
+{
+    "common": { "rcu_reclaim_threads": 4 },
+    "server": {
+        "threads": 4,
+        "delegation_threads": 4,
+        ${vfs_section}
+        "nfs_auth": { "kerberos_enabled": true, "kerberos_keytab": "${SERVER_KEYTAB}" },
+        "external_portmap": false
+    },
+    "mounts": { "share": { "module": "$BACKEND", "path": "$mount_path" } },
+    "exports": { "/share": { "path": "/share" } }
+}
+EOF
+}
+
+check_requirements
+setup_kdc
+generate_config
+
+ulimit -l unlimited
+echo 16777216 > /proc/sys/fs/aio-max-nr 2>/dev/null || true
+
+# netns + TAP
+ip netns add "${NETNS_NAME}"
+ip netns exec "${NETNS_NAME}" ip link set lo up
+ip netns exec "${NETNS_NAME}" ip tuntap add dev "${TAP_NAME}" mode tap
+ip netns exec "${NETNS_NAME}" ip addr add 10.0.0.1/24 dev "${TAP_NAME}"
+ip netns exec "${NETNS_NAME}" ip link set "${TAP_NAME}" up
+
+if [ -n "${KVM_KRB_PCAP:-}" ]; then
+    ip netns exec "${NETNS_NAME}" tcpdump -U -i "${TAP_NAME}" -w "${KVM_KRB_PCAP}" -s 0 port 2049 &
+    sleep 0.3
+fi
+
+# KDC (binds 10.0.0.1 inside the netns; the guest reaches it over the TAP)
+ip netns exec "${NETNS_NAME}" env \
+    KRB5_CONFIG="${KRB_DIR}/etc/krb5.conf" KRB5_KDC_PROFILE="${KRB_DIR}/etc/kdc.conf" \
+    krb5kdc -n -P "${KRB_DIR}/kdc.pid" &
+for _ in $(seq 1 60); do
+    [ -f "${KRB_DIR}/kdc.pid" ] && kill -0 "$(cat "${KRB_DIR}/kdc.pid" 2>/dev/null)" 2>/dev/null && break
+    sleep 0.5
+done
+
+# chimera NFS server (Kerberos acceptor via SERVER_KEYTAB)
+ip netns exec "${NETNS_NAME}" env \
+    KRB5_CONFIG="${KRB_DIR}/etc/krb5.conf" KRB5_KTNAME="${SERVER_KEYTAB}" \
+    "$CHIMERA_BINARY" -c "$CONFIG_FILE" &
+CHIMERA_PID=$!
+for _ in $(seq 1 250); do
+    ip netns exec "${NETNS_NAME}" bash -c "echo > /dev/tcp/10.0.0.1/2049" 2>/dev/null && break
+    kill -0 "$CHIMERA_PID" 2>/dev/null || { log "chimera exited prematurely"; exit 1; }
+    sleep 0.02
+done
+
+# Guest test command: bring up the GSS client, krb5 mount, caller checks.
+# rpc.gssd backs the kernel's sec=krb5 upcall over rpc_pipefs; this nfs-utils
+# build looks for it at /run/rpc_pipefs.  (init.sh copies the krb5.conf/keytab/
+# hosts material from the 9p share; we start gssd here so the mount path is
+# explicit and correct regardless of the guest's nfs-utils pipefs default.)
+NFS_MOUNT_OPTS="vers=${NFS_VERSION},sec=krb5,tcp"
+# Self-contained krb5 client bring-up (does not rely on init.sh's single-shot
+# attempt): set the hostname, then deliver the per-test realm material from the
+# 9p share with a retry loop -- under ctest the 9p backend can race the guest's
+# probe and a one-shot mount silently misses, leaving rpc.gssd without a keytab.
+# Then mount rpc_pipefs (/run is this nfs-utils' default) and (re)start rpc.gssd.
+KRB_PREP="hostname ${CLIENT_HOST} 2>/dev/null; modprobe 9pnet_virtio 2>/dev/null; modprobe 9p 2>/dev/null; for i in 1 2 3 4 5 6 7 8; do [ -s /etc/krb5.keytab ] && break; mkdir -p /mnt/krb; if mount -t 9p -o trans=virtio,version=9p2000.L krbshare /mnt/krb 2>/dev/null; then cp /mnt/krb/krb5.conf /etc/krb5.conf; cp /mnt/krb/krb5.keytab /etc/krb5.keytab; cat /mnt/krb/hosts >> /etc/hosts; umount /mnt/krb; else sleep 1; fi; done; mkdir -p /run/rpc_pipefs; mountpoint -q /run/rpc_pipefs || mount -t rpc_pipefs rpc_pipefs /run/rpc_pipefs; pkill -x rpc.gssd 2>/dev/null; /usr/sbin/rpc.gssd; sleep 1;"
+if [ -n "${KVM_KRB_DEBUG:-}" ]; then
+    TEST_CMD="${KRB_PREP} echo '=== keytab ==='; ls -l /etc/krb5.keytab; klist -k /etc/krb5.keytab 2>&1; echo '=== KDC reach ==='; (echo > /dev/tcp/10.0.0.1/${KDC_PORT}) 2>&1 && echo kdc-tcp-ok || echo kdc-tcp-FAIL; echo '=== kinit -k ==='; timeout 10 kinit -k -t /etc/krb5.keytab host/${CLIENT_HOST}@${REALM} 2>&1; echo kinit_rc=\$?; klist 2>&1; echo '=== krb5 mount -v ==='; timeout 25 mount -v -t nfs -o ${NFS_MOUNT_OPTS} ${SERVER_HOST}:/share /mnt 2>&1; echo krb5_rc=\$?"
+else
+    TEST_CMD="${KRB_PREP} mount -t nfs -o ${NFS_MOUNT_OPTS} ${SERVER_HOST}:/share /mnt && ${POST_MOUNT_CMD}"
+fi
+
+# Boot the guest with the 9p krb material + krb5=1 trigger.
+ip netns exec "${NETNS_NAME}" "$QEMU_BIN" \
+    -enable-kvm -smp 4 -m 1G -cpu host \
+    -kernel "$VMLINUZ" \
+    $QEMU_MACHINE \
+    -nodefaults \
+    -drive file="$ROOTFS",if=virtio,format=qcow2,snapshot=on \
+    -netdev tap,id=net0,ifname="${TAP_NAME}",script=no,downscript=no \
+    -device virtio-net-pci,netdev=net0,romfile="" \
+    -fsdev local,id=krbfs,path="${KRB_SHARE}",security_model=none \
+    -device virtio-9p-pci,fsdev=krbfs,mount_tag=krbshare \
+    -serial stdio \
+    -nographic \
+    -no-reboot \
+    -append "root=/dev/vda rw console=${QEMU_CONSOLE} net.ifnames=0 biosdevname=0 quiet mitigations=off tsc=reliable panic=-1 krb5=1 guest_host=${CLIENT_HOST} test_cmd=\"${TEST_CMD}\" init=/init.sh" \
+    > "$LOG_FILE" 2>&1
+# NB: capture the guest serial to a file rather than `tee`-ing it to our own
+# stdout.  The guest's in-image watchdog dumps diagnostics every 5s once a test
+# runs past 10s (a krb5 mount + rpc.gssd setup can), and under `ctest` that flood
+# would backpressure the captured-stdout pipe, block the guest's console writes,
+# and wedge the VM.  Writing to a file never blocks; we print it below.
+
+if ! kill -0 "$CHIMERA_PID" 2>/dev/null; then
+    wait "$CHIMERA_PID" 2>/dev/null
+    echo "=== Chimera daemon DIED during test (exit $?) ==="
+    CHIMERA_PID=""
+fi
+
+EXIT_CODE=$(grep -oP 'CHIMERA_KVM_EXIT_CODE=\K[0-9]+' "$LOG_FILE" | tail -1)
+exit "${EXIT_CODE:-1}"

--- a/kvm/tests/CMakeLists.txt
+++ b/kvm/tests/CMakeLists.txt
@@ -4,6 +4,7 @@
 
 set(CHIMERA_BINARY ${CMAKE_BINARY_DIR}/src/daemon/chimera)
 set(NFS_WRAPPER ${CMAKE_SOURCE_DIR}/kvm/kvm_nfs_test_wrapper.sh)
+set(NFS_KRB_WRAPPER ${CMAKE_SOURCE_DIR}/kvm/kvm_nfs_kerberos_test_wrapper.sh)
 set(NFS_REBOOT_WRAPPER ${CMAKE_SOURCE_DIR}/kvm/kvm_nfs_reboot_test_wrapper.sh)
 set(NFS3_DRC_REBOOT_WRAPPER ${CMAKE_SOURCE_DIR}/kvm/kvm_nfs3_drc_reboot_test_wrapper.sh)
 set(NFSTEST_WRAPPER ${CMAKE_SOURCE_DIR}/kvm/kvm_nfstest_test_wrapper.sh)
@@ -255,6 +256,20 @@ foreach(image_spec ${KVM_IMAGES})
         set_tests_properties(chimera/kvm/${IMAGE_NAME}/reboot/multinode_cairn
             PROPERTIES LABELS "kvm;${IMAGE_NAME}" PROCESSORS 2)
     endif()
+
+    # RPCSEC_GSS / Kerberos: boot the real Linux NFS client and mount the
+    # chimera export with sec=krb5 (rpc.gssd + machine keytab handed in over a
+    # 9p share).  Proves the full GSS path -- context establishment + per-request
+    # verifiers -- against the kernel client.  memfs only; NFSv4.1.  Skips (77)
+    # without /dev/kvm or krb5 tooling, or on an image too old to honour krb5=1.
+    add_test(NAME chimera/kvm/${IMAGE_NAME}/kerberos/krb5_mount_memfs_nfs4.1
+        COMMAND bash ${NFS_KRB_WRAPPER}
+                ${IMAGE_DIR}/vmlinuz ${IMAGE_DIR}/rootfs.qcow2
+                ${CHIMERA_BINARY} memfs 4.1
+                "stat /mnt && echo hello-krb5 > /mnt/f && grep -q hello-krb5 /mnt/f && dd if=/dev/zero of=/mnt/big bs=4k count=64 2>/dev/null && rm /mnt/f /mnt/big && echo KRB5_RW_OK")
+    set_tests_properties(chimera/kvm/${IMAGE_NAME}/kerberos/krb5_mount_memfs_nfs4.1
+        PROPERTIES LABELS "kvm;${IMAGE_NAME};rpcsec_gss" PROCESSORS 2
+        SKIP_RETURN_CODE 77)
 
     # NFS cthon04 tests
     foreach(nfsver ${NFS_VERSIONS})

--- a/pynfs/CMakeLists.txt
+++ b/pynfs/CMakeLists.txt
@@ -365,3 +365,21 @@ set_tests_properties(chimera/pynfs/kerberos/krb5_smoke_memfs_nfs4.1 PROPERTIES
     LABELS "pynfs;pynfs_kerberos;rpcsec_gss;memfs;nfs4.1"
     SKIP_RETURN_CODE 77
     ENVIRONMENT "PYTHONUNBUFFERED=1")
+
+# Per-export sec= policy (Phase 2).  Restrict the export to krb5/krb5i and
+# verify (a) an allowed flavor (krb5) still works end-to-end through the
+# enforcement path, and (b) a disallowed flavor (sys) is rejected with
+# NFS4ERR_WRONGSEC at the export boundary.
+add_test(NAME chimera/pynfs/kerberos/sec_krb5only_allow_memfs_nfs4.1
+    COMMAND bash ${NFS_KRB_WRAPPER} ${CHIMERA_BINARY} memfs ${PYNFS_DIR} ${NFS_KRB_CODES})
+set_tests_properties(chimera/pynfs/kerberos/sec_krb5only_allow_memfs_nfs4.1 PROPERTIES
+    LABELS "pynfs;pynfs_kerberos;rpcsec_gss;memfs;nfs4.1"
+    SKIP_RETURN_CODE 77
+    ENVIRONMENT "PYTHONUNBUFFERED=1;NFS_EXPORT_SEC=krb5,krb5i;NFS_KRB_SEC=krb5")
+
+add_test(NAME chimera/pynfs/kerberos/sec_krb5only_deny_sys_memfs_nfs4.1
+    COMMAND bash ${NFS_KRB_WRAPPER} ${CHIMERA_BINARY} memfs ${PYNFS_DIR} EID1 CSESS1)
+set_tests_properties(chimera/pynfs/kerberos/sec_krb5only_deny_sys_memfs_nfs4.1 PROPERTIES
+    LABELS "pynfs;pynfs_kerberos;rpcsec_gss;memfs;nfs4.1"
+    SKIP_RETURN_CODE 77
+    ENVIRONMENT "PYTHONUNBUFFERED=1;NFS_EXPORT_SEC=krb5;NFS_KRB_SEC=sys;NFS_EXPECT_WRONGSEC=1")

--- a/pynfs/CMakeLists.txt
+++ b/pynfs/CMakeLists.txt
@@ -349,3 +349,19 @@ foreach(code ${PYNFS_FLEX_CODES})
         LABELS "pynfs;pynfs_flex;memfs;nfs4.1"
         ENVIRONMENT "PYTHONUNBUFFERED=1;PYNFS_RUNDEPS=1")
 endforeach()
+
+# RPCSEC_GSS / Kerberos (sec=krb5) end-to-end smoke.  Stands up an MIT KDC and a
+# chimera NFS server with Kerberos enabled inside a netns, then drives pynfs 4.1
+# with sec=krb5 (pynfs 4.1 derives the GSS target as nfs@<server>, so it works
+# unmodified).  Exercises the full RPCSEC_GSS path: context establishment, the
+# per-request call/reply verifiers, the replay window, and -- via BIND -- a GSS
+# context shared across trunked connections.  Skips (77) without krb5 tooling or
+# python gssapi.  memfs only; gated like the other netns tests.
+set(NFS_KRB_WRAPPER ${CMAKE_SOURCE_DIR}/scripts/nfs_kerberos_test_wrapper.sh)
+set(NFS_KRB_CODES EID1 EID2 CSESS1 CSESS2 SEQ1 SEQ4 BIND1 BIND2 BIND3 RECC1 OPEN1 OPEN2)
+add_test(NAME chimera/pynfs/kerberos/krb5_smoke_memfs_nfs4.1
+    COMMAND bash ${NFS_KRB_WRAPPER} ${CHIMERA_BINARY} memfs ${PYNFS_DIR} ${NFS_KRB_CODES})
+set_tests_properties(chimera/pynfs/kerberos/krb5_smoke_memfs_nfs4.1 PROPERTIES
+    LABELS "pynfs;pynfs_kerberos;rpcsec_gss;memfs;nfs4.1"
+    SKIP_RETURN_CODE 77
+    ENVIRONMENT "PYTHONUNBUFFERED=1")

--- a/scripts/nfs_kerberos_test_wrapper.sh
+++ b/scripts/nfs_kerberos_test_wrapper.sh
@@ -1,0 +1,333 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+#
+# SPDX-License-Identifier: Unlicense
+#
+# RPCSEC_GSS / Kerberos NFS test wrapper.
+#
+# Stands up a minimal MIT KDC, a chimera NFS server with Kerberos enabled, and
+# runs the pynfs 4.1 suite against it with sec=krb5 -- all inside an isolated
+# network namespace.  Exercises the full RPCSEC_GSS path end to end: context
+# establishment (NULL-proc INIT/CONTINUE), per-request call verifiers and the
+# sequence window, and reply verifiers.
+#
+# Usage:
+#   nfs_kerberos_test_wrapper.sh <chimera_binary> <backend> <pynfs_dir> [pynfs_flags...]
+#
+# Requirements: krb5-kdc, krb5-user, python3-gssapi, root (for the netns).
+# Skips (exit 77) if the krb5 tooling or python gssapi module is missing.
+
+set -u
+
+# Clear LD_PRELOAD up front so ASAN does not perturb system binaries (ip,
+# kadmin, ...).  Restored only for the chimera daemon.
+SAVED_LD_PRELOAD="${LD_PRELOAD:-}"
+unset LD_PRELOAD
+
+CHIMERA_BINARY=$1; shift
+BACKEND=$1; shift
+PYNFS_DIR=$1; shift
+FLAG_ARGS="$*"
+
+TEST_ID="$$_$(date +%s%N | tail -c 6)"
+NETNS_NAME="ns_nfskrb_${TEST_ID}"
+KRB_DIR="/tmp/nfskrb_${TEST_ID}"
+REALM="TEST.LOCAL"
+KDC_IP="127.0.0.1"
+KDC_PORT="8899"
+NFS_HOST="nfshost.test.local"
+KEYTAB_FILE="${KRB_DIR}/chimera.keytab"
+CCACHE="FILE:${KRB_DIR}/krb5cc_testuser1"
+
+BUILD_DIR=$(dirname "$(dirname "$CHIMERA_BINARY")")
+SESSION_DIR=$(mktemp -d "${BUILD_DIR}/nfskrb_session_XXXXXX")
+CONFIG_FILE="${SESSION_DIR}/chimera.json"
+RESULTS_XML="${SESSION_DIR}/results.xml"
+CHIMERA_LOG="${SESSION_DIR}/chimera.log"
+CHIMERA_PID=""
+HOSTS_MODIFIED=0
+
+log() {
+    echo "[nfs_krb] $*" >&2
+}
+
+cleanup() {
+    if [ -n "$CHIMERA_PID" ]; then
+        kill "$CHIMERA_PID" 2>/dev/null || true
+        for _ in $(seq 1 150); do
+            kill -0 "$CHIMERA_PID" 2>/dev/null || break
+            sleep 0.02
+        done
+        kill -9 "$CHIMERA_PID" 2>/dev/null || true
+        wait "$CHIMERA_PID" 2>/dev/null || true
+    fi
+    if [ -f "$CHIMERA_LOG" ]; then
+        echo "=== Chimera log (last 100 lines) ==="
+        tail -100 "$CHIMERA_LOG"
+    fi
+    if ip netns list 2>/dev/null | grep -q "^${NETNS_NAME}"; then
+        ip netns pids "${NETNS_NAME}" 2>/dev/null | xargs -r kill -9 2>/dev/null || true
+        sleep 0.1
+        ip netns delete "${NETNS_NAME}" 2>/dev/null || true
+    fi
+    if [ "${HOSTS_MODIFIED}" = "1" ]; then
+        sed -i "/^127\.0\.0\.1 ${NFS_HOST}\$/d" /etc/hosts 2>/dev/null || true
+    fi
+    rm -rf "${KRB_DIR}" "${SESSION_DIR}" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+check_requirements() {
+    local missing=""
+    for cmd in kdb5_util krb5kdc kadmin.local kinit; do
+        command -v "$cmd" &>/dev/null || missing="$missing $cmd"
+    done
+    if [ -n "$missing" ]; then
+        log "SKIP: missing krb5 tooling:$missing"
+        exit 77
+    fi
+    if ! python3 -c 'import gssapi' 2>/dev/null; then
+        log "SKIP: python3 gssapi module not available (pynfs cannot do krb5)"
+        exit 77
+    fi
+}
+
+setup_namespace() {
+    ip netns add "${NETNS_NAME}"
+    ip netns exec "${NETNS_NAME}" ip link set lo up
+    # gssapi refuses hostbased 'nfs@127.0.0.1'; map a stable hostname to lo.
+    echo "127.0.0.1 ${NFS_HOST}" >> /etc/hosts
+    HOSTS_MODIFIED=1
+}
+
+setup_kdc() {
+    mkdir -p "${KRB_DIR}"/{etc,var/lib/krb5kdc,var/run}
+
+    cat > "${KRB_DIR}/etc/kdc.conf" <<EOF
+[kdcdefaults]
+    kdc_ports = ${KDC_PORT}
+    kdc_tcp_ports = ${KDC_PORT}
+
+[realms]
+    ${REALM} = {
+        database_name = ${KRB_DIR}/var/lib/krb5kdc/principal
+        admin_keytab = ${KRB_DIR}/var/lib/krb5kdc/kadm5.keytab
+        acl_file = ${KRB_DIR}/var/lib/krb5kdc/kadm5.acl
+        key_stash_file = ${KRB_DIR}/var/lib/krb5kdc/.k5.${REALM}
+        kdc_ports = ${KDC_PORT}
+        max_life = 24h
+        max_renewable_life = 7d
+    }
+EOF
+
+    cat > "${KRB_DIR}/etc/krb5.conf" <<EOF
+[libdefaults]
+    default_realm = ${REALM}
+    dns_lookup_realm = false
+    dns_lookup_kdc = false
+    dns_canonicalize_hostname = false
+    rdns = false
+    ticket_lifetime = 24h
+    forwardable = true
+
+[realms]
+    ${REALM} = {
+        kdc = ${KDC_IP}:${KDC_PORT}
+        admin_server = ${KDC_IP}:${KDC_PORT}
+    }
+
+[domain_realm]
+    .test.local = ${REALM}
+    test.local = ${REALM}
+    ${NFS_HOST} = ${REALM}
+EOF
+
+    echo "*/admin@${REALM} *" > "${KRB_DIR}/var/lib/krb5kdc/kadm5.acl"
+
+    export KRB5_CONFIG="${KRB_DIR}/etc/krb5.conf"
+    export KRB5_KDC_PROFILE="${KRB_DIR}/etc/kdc.conf"
+
+    kdb5_util create -s -r "${REALM}" -P "$(head -c 32 /dev/urandom | base64)" 2>/dev/null
+
+    # NFS service principal (what the client targets as nfs@<host>) + a test user.
+    kadmin.local -q "addprinc -randkey nfs/${NFS_HOST}@${REALM}" 2>/dev/null
+    kadmin.local -q "addprinc -randkey host/${NFS_HOST}@${REALM}" 2>/dev/null
+    kadmin.local -q "addprinc -pw Password1! testuser1@${REALM}" 2>/dev/null
+
+    kadmin.local -q "ktadd -k ${KEYTAB_FILE} nfs/${NFS_HOST}@${REALM}" 2>/dev/null
+    kadmin.local -q "ktadd -k ${KEYTAB_FILE} host/${NFS_HOST}@${REALM}" 2>/dev/null
+    chmod 644 "${KEYTAB_FILE}"
+}
+
+start_kdc() {
+    ip netns exec "${NETNS_NAME}" env \
+        KRB5_CONFIG="${KRB_DIR}/etc/krb5.conf" \
+        KRB5_KDC_PROFILE="${KRB_DIR}/etc/kdc.conf" \
+        krb5kdc -n -P "${KRB_DIR}/kdc.pid" &
+    local launcher=$!
+    local waited
+    for waited in $(seq 1 60); do
+        if [ -f "${KRB_DIR}/kdc.pid" ]; then
+            local pid
+            pid=$(cat "${KRB_DIR}/kdc.pid" 2>/dev/null)
+            if [ -n "${pid}" ] && kill -0 "${pid}" 2>/dev/null; then
+                log "KDC up (pid ${pid})"
+                return 0
+            fi
+        fi
+        kill -0 "${launcher}" 2>/dev/null || { log "KDC exited early"; return 1; }
+        sleep 1
+    done
+    log "KDC failed to start"
+    return 1
+}
+
+obtain_ticket() {
+    ip netns exec "${NETNS_NAME}" env \
+        KRB5_CONFIG="${KRB_DIR}/etc/krb5.conf" \
+        KRB5CCNAME="${CCACHE}" \
+        sh -c 'printf "%s" "Password1!" | kinit testuser1@'"${REALM}" 2>/dev/null || {
+        log "kinit failed"
+        return 1
+    }
+    # Pre-fetch the nfs service ticket so the test never blocks on the KDC.
+    ip netns exec "${NETNS_NAME}" env \
+        KRB5_CONFIG="${KRB_DIR}/etc/krb5.conf" \
+        KRB5CCNAME="${CCACHE}" \
+        kvno "nfs/${NFS_HOST}@${REALM}" 2>/dev/null || true
+}
+
+generate_config() {
+    local mount_path="/"
+    local vfs_section=""
+
+    case "$BACKEND" in
+        linux | io_uring)
+            mount_path="$SESSION_DIR/data"
+            mkdir -p "$SESSION_DIR/data"
+            ;;
+        memfs)
+            mount_path="/"
+            ;;
+        cairn)
+            mount_path="/"
+            vfs_section="\"vfs\": { \"cairn\": { \"config\": {\"initialize\":true,\"path\":\"$SESSION_DIR\"} } },"
+            ;;
+        *)
+            log "Unsupported backend for krb5 test: $BACKEND"
+            exit 1
+            ;;
+    esac
+
+    cat > "$CONFIG_FILE" <<EOF
+{
+    "common": { "rcu_reclaim_threads": 4 },
+    "server": {
+        "threads": 4,
+        "delegation_threads": 4,
+        "nfs4_lease_time": 5,
+        "nfs4_grace_time": 10,
+        ${vfs_section}
+        "nfs_auth": {
+            "kerberos_enabled": true,
+            "kerberos_keytab": "${KEYTAB_FILE}"
+        },
+        "external_portmap": false
+    },
+    "mounts": {
+        "share": { "module": "$BACKEND", "path": "$mount_path" }
+    },
+    "exports": {
+        "/share": { "path": "/share" }
+    }
+}
+EOF
+}
+
+start_chimera() {
+    local preload_env=()
+    [ -n "${SAVED_LD_PRELOAD}" ] && preload_env=(LD_PRELOAD="${SAVED_LD_PRELOAD}")
+
+    ip netns exec "${NETNS_NAME}" env \
+        KRB5_CONFIG="${KRB_DIR}/etc/krb5.conf" \
+        KRB5_KTNAME="${KEYTAB_FILE}" \
+        "${preload_env[@]}" \
+        "$CHIMERA_BINARY" -c "$CONFIG_FILE" >"$CHIMERA_LOG" 2>&1 &
+    CHIMERA_PID=$!
+
+    local i
+    for i in $(seq 1 500); do
+        if grep -q "Server is ready." "$CHIMERA_LOG" &&
+           ip netns exec "${NETNS_NAME}" bash -c "echo > /dev/tcp/127.0.0.1/2049" 2>/dev/null; then
+            return 0
+        fi
+        kill -0 "$CHIMERA_PID" 2>/dev/null || { log "chimera exited during startup"; return 1; }
+        sleep 0.02
+    done
+    log "chimera NFS port never became ready"
+    return 1
+}
+
+run_pynfs() {
+    export PYTHONPATH="${PYNFS_DIR}:${PYTHONPATH:-}"
+    local testserver="${PYNFS_DIR}/nfs4.1/testserver.py"
+    local timeout_s="${PYNFS_TIMEOUT:-120}"
+
+    # pynfs 4.1 derives the GSS target as nfs@<server>, so the server must be
+    # addressed by the keytab hostname, not 127.0.0.1.
+    # shellcheck disable=SC2086
+    timeout --foreground -k 5 "${timeout_s}" \
+        ip netns exec "${NETNS_NAME}" env \
+        KRB5_CONFIG="${KRB_DIR}/etc/krb5.conf" \
+        KRB5CCNAME="${CCACHE}" \
+        KRB5_KTNAME="${KEYTAB_FILE}" \
+        PYTHONPATH="${PYTHONPATH}" \
+        python3 "${testserver}" "${NFS_HOST}:/share" \
+        --minorversion=1 --security="${NFS_KRB_SEC:-krb5}" --maketree --force -v \
+        --xml="${RESULTS_XML}" $FLAG_ARGS
+    return $?
+}
+
+main() {
+    check_requirements
+    setup_namespace
+    setup_kdc
+    start_kdc || exit 1
+    obtain_ticket || exit 1
+    generate_config
+    start_chimera || exit 1
+
+    run_pynfs
+    local rc=$?
+
+    if [ "$rc" -eq 124 ] || [ "$rc" -eq 137 ]; then
+        log "pynfs wall-clock timeout"
+        exit 1
+    fi
+    if [ "$rc" -ne 0 ]; then
+        exit "$rc"
+    fi
+
+    if [ ! -f "$RESULTS_XML" ]; then
+        log "results file missing"
+        exit 1
+    fi
+    read -r FAILURES ERRORS < <(python3 - "$RESULTS_XML" <<'PY'
+import sys, xml.etree.ElementTree as ET
+try:
+    root = ET.parse(sys.argv[1]).getroot()
+    ts = root if root.tag == "testsuite" else (root.find("testsuite") or root)
+    print(ts.get("failures", "1"), ts.get("errors", "1"))
+except Exception:
+    print("1", "1")
+PY
+)
+    if [ "${FAILURES:-1}" != "0" ] || [ "${ERRORS:-1}" != "0" ]; then
+        log "pynfs reported ${FAILURES} failure(s), ${ERRORS} error(s)"
+        exit 1
+    fi
+    log "PASS (sec=krb5)"
+    exit 0
+}
+
+main "$@"

--- a/scripts/nfs_kerberos_test_wrapper.sh
+++ b/scripts/nfs_kerberos_test_wrapper.sh
@@ -39,6 +39,13 @@ NFS_HOST="nfshost.test.local"
 KEYTAB_FILE="${KRB_DIR}/chimera.keytab"
 CCACHE="FILE:${KRB_DIR}/krb5cc_testuser1"
 
+# Optional per-export security policy: NFS_EXPORT_SEC="krb5,krb5i" restricts the
+# /share export to those flavors (testing NFS4ERR_WRONGSEC enforcement).
+EXPORT_SEC_JSON=""
+if [ -n "${NFS_EXPORT_SEC:-}" ]; then
+    EXPORT_SEC_JSON=", \"sec\": [$(echo "${NFS_EXPORT_SEC}" | sed 's/[^,]\+/"&"/g')]"
+fi
+
 BUILD_DIR=$(dirname "$(dirname "$CHIMERA_BINARY")")
 SESSION_DIR=$(mktemp -d "${BUILD_DIR}/nfskrb_session_XXXXXX")
 CONFIG_FILE="${SESSION_DIR}/chimera.json"
@@ -238,7 +245,7 @@ generate_config() {
         "share": { "module": "$BACKEND", "path": "$mount_path" }
     },
     "exports": {
-        "/share": { "path": "/share" }
+        "/share": { "path": "/share"${EXPORT_SEC_JSON} }
     }
 }
 EOF
@@ -284,8 +291,8 @@ run_pynfs() {
         PYTHONPATH="${PYTHONPATH}" \
         python3 "${testserver}" "${NFS_HOST}:/share" \
         --minorversion=1 --security="${NFS_KRB_SEC:-krb5}" --maketree --force -v \
-        --xml="${RESULTS_XML}" $FLAG_ARGS
-    return $?
+        --xml="${RESULTS_XML}" $FLAG_ARGS 2>&1 | tee "${SESSION_DIR}/pynfs.out"
+    return "${PIPESTATUS[0]}"
 }
 
 main() {
@@ -299,6 +306,17 @@ main() {
 
     run_pynfs
     local rc=$?
+
+    # Negative test: a disallowed flavor must be rejected with NFS4ERR_WRONGSEC.
+    # pynfs then fails to initialize, which is the expected, passing outcome.
+    if [ -n "${NFS_EXPECT_WRONGSEC:-}" ]; then
+        if grep -q 'NFS4ERR_WRONGSEC' "${SESSION_DIR}/pynfs.out" 2>/dev/null; then
+            log "PASS (got expected NFS4ERR_WRONGSEC for disallowed flavor)"
+            exit 0
+        fi
+        log "FAIL (expected NFS4ERR_WRONGSEC, not observed)"
+        exit 1
+    fi
 
     if [ "$rc" -eq 124 ] || [ "$rc" -eq 137 ]; then
         log "pynfs wall-clock timeout"

--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -801,6 +801,21 @@ main(
         }
     }
 
+    // Parse NFS auth configuration (RPCSEC_GSS / Kerberos)
+    json_t *nfs_auth = json_object_get(server_params, "nfs_auth");
+    if (nfs_auth && json_is_object(nfs_auth)) {
+        json_t *kerberos_enabled = json_object_get(nfs_auth, "kerberos_enabled");
+        if (kerberos_enabled && json_is_true(kerberos_enabled)) {
+            chimera_server_config_set_nfs_kerberos_enabled(server_config, 1);
+        }
+
+        json_t *kerberos_keytab = json_object_get(nfs_auth, "kerberos_keytab");
+        if (kerberos_keytab && json_is_string(kerberos_keytab)) {
+            chimera_server_config_set_nfs_kerberos_keytab(server_config,
+                                                          json_string_value(kerberos_keytab));
+        }
+    }
+
     json_t *smb_multichannel = json_object_get(server_params, "smb_multichannel");
     if (json_is_array(smb_multichannel)) {
         json_t *smb_nic_info_json;

--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -1086,6 +1086,37 @@ main(
                 anongid = (uint32_t) json_integer_value(anongid_j);
             }
 
+            /* Allowed security flavors: an optional array of
+             * "sys"/"krb5"/"krb5i"/"krb5p".  Absent (mask 0) permits any
+             * flavor, preserving historical behavior; a non-empty list
+             * restricts the export and rejects others with NFS4ERR_WRONGSEC. */
+            json_t  *sec_j    = json_object_get(export, "sec");
+            uint32_t sec_mask = 0;
+            if (sec_j && json_is_array(sec_j)) {
+                size_t  si;
+                json_t *flavor_j;
+                json_array_foreach(sec_j, si, flavor_j)
+                {
+                    const char *f = json_string_value(flavor_j);
+
+                    if (!f) {
+                        continue;
+                    }
+                    if (strcasecmp(f, "sys") == 0 || strcasecmp(f, "auth_sys") == 0) {
+                        sec_mask |= CHIMERA_NFS_SEC_SYS;
+                    } else if (strcasecmp(f, "krb5") == 0) {
+                        sec_mask |= CHIMERA_NFS_SEC_KRB5;
+                    } else if (strcasecmp(f, "krb5i") == 0) {
+                        sec_mask |= CHIMERA_NFS_SEC_KRB5I;
+                    } else if (strcasecmp(f, "krb5p") == 0) {
+                        sec_mask |= CHIMERA_NFS_SEC_KRB5P;
+                    } else {
+                        chimera_server_error("Invalid export '%s' sec flavor '%s' "
+                                             "(expected sys/krb5/krb5i/krb5p)", name, f);
+                    }
+                }
+            }
+
             chimera_server_info("Adding NFS export %s -> %s (%s, %s)", name, path,
                                 options & CHIMERA_NFS_EXPORT_OPT_RO ? "ro" : "rw",
                                 squash == CHIMERA_NFS_SQUASH_ALL ? "all_squash" :
@@ -1094,6 +1125,9 @@ main(
             chimera_server_create_export(server, name, path);
             chimera_server_export_set_options(server, name, options, squash,
                                               anonuid, anongid);
+            if (sec_mask) {
+                chimera_server_export_set_sec(server, name, sec_mask);
+            }
         }
     }
 

--- a/src/server/nfs/CMakeLists.txt
+++ b/src/server/nfs/CMakeLists.txt
@@ -34,10 +34,11 @@ add_library(chimera_nfs SHARED nfs.c nfs4_session.c nfs4_state.c nfs4_lease.c nf
             nfs4_proc_open_downgrade.c nfs4_proc_release_lockowner.c
             nfs4_proc_getxattr.c nfs4_proc_setxattr.c
             nfs4_proc_listxattrs.c nfs4_proc_removexattr.c
-            nfs4_pnfs.c nfs4_cb.c nfs4_layout_table.c)
+            nfs4_pnfs.c nfs4_cb.c nfs4_layout_table.c
+            nfs_gss.c)
 
 target_compile_definitions(chimera_nfs PRIVATE XXH_INLINE_ALL)
-target_link_libraries(chimera_nfs chimera_nfs_common chimera_common evpl evpl_rpc2 pthread uuid urcu-qsbr urcu-common)
+target_link_libraries(chimera_nfs chimera_nfs_common chimera_common evpl evpl_rpc2 pthread uuid urcu-qsbr urcu-common gssapi_krb5)
 
 install(TARGETS chimera_nfs DESTINATION lib)
 

--- a/src/server/nfs/nfs.c
+++ b/src/server/nfs/nfs.c
@@ -16,6 +16,8 @@
 #include "server/server.h"
 #include "vfs/vfs.h"
 #include "evpl/evpl_rpc2.h"
+#include "evpl/evpl_rpc2_gss.h"
+#include "nfs_gss.h"
 #include "nfs3_procs.h"
 #include "nfs4_procs.h"
 #include "nfs_mount.h"
@@ -175,6 +177,13 @@ nfs_server_init(
     shared->config = config;
 
     nfs_fh_key_init(shared, config);
+
+    /* RPCSEC_GSS (Kerberos): register the acceptor keytab once at startup.
+     * Per-thread provider registration happens in nfs_server_thread_init. */
+    if (chimera_server_config_get_nfs_kerberos_enabled(config)) {
+        chimera_nfs_gss_init(chimera_server_config_get_nfs_kerberos_keytab(config));
+        chimera_nfs_info("RPCSEC_GSS: Kerberos authentication enabled");
+    }
 
     shared->portmap_hostname[0] = '\0';
     if (portmap_hostname) {
@@ -796,6 +805,13 @@ nfs_server_thread_init(
     thread->vfs_thread = vfs_thread;
 
     thread->rpc2_thread = evpl_rpc2_thread_init(evpl, NULL, 0, chimera_nfs_server_notify, thread);
+
+    /* Install the GSSAPI/Kerberos acceptor on this rpc2 thread so RPCSEC_GSS
+     * calls (sec=krb5) can establish contexts and authenticate. */
+    if (chimera_server_config_get_nfs_kerberos_enabled(shared->config)) {
+        evpl_rpc2_set_gss_provider(thread->rpc2_thread,
+                                   &chimera_nfs_gss_provider, shared);
+    }
 
     if (shared->mount_server) {
         evpl_rpc2_server_attach(thread->rpc2_thread, shared->mount_server, thread);

--- a/src/server/nfs/nfs.c
+++ b/src/server/nfs/nfs.c
@@ -969,6 +969,30 @@ chimera_nfs_export_set_options(
     return found ? 0 : -1;
 } /* chimera_nfs_export_set_options */
 
+SYMBOL_EXPORT int
+chimera_nfs_export_set_sec(
+    void       *nfs_shared,
+    const char *name,
+    uint32_t    sec_allowed)
+{
+    struct chimera_server_nfs_shared *shared = nfs_shared;
+    struct chimera_nfs_export        *export;
+    int                               found = 0;
+
+    pthread_mutex_lock(&shared->exports_lock);
+    LL_FOREACH(shared->exports, export)
+    {
+        if (strcmp(export->name, name) == 0) {
+            export->sec_allowed = sec_allowed;
+            found               = 1;
+            break;
+        }
+    }
+    pthread_mutex_unlock(&shared->exports_lock);
+
+    return found ? 0 : -1;
+} /* chimera_nfs_export_set_sec */
+
 SYMBOL_EXPORT const struct chimera_nfs_export *
 chimera_nfs_get_export_by_id(
     void    *nfs_shared,

--- a/src/server/nfs/nfs.h
+++ b/src/server/nfs/nfs.h
@@ -21,6 +21,20 @@ struct chimera_nfs_export;
 #define CHIMERA_NFS_SQUASH_ROOT   1u   /* root_squash (default): uid 0 -> anon      */
 #define CHIMERA_NFS_SQUASH_ALL    2u   /* all_squash: every caller -> anon          */
 
+/*
+ * Per-export allowed RPC security flavors, as a bitmask.  sec_allowed == 0
+ * permits any flavor (the historical pass-through default); a non-zero mask
+ * restricts the export to exactly those flavors (others -> NFS4ERR_WRONGSEC).
+ * krb5/krb5i/krb5p all ride RPCSEC_GSS, distinguished by the GSS service.
+ */
+#define CHIMERA_NFS_SEC_SYS       0x01u  /* AUTH_SYS (and AUTH_NONE)         */
+#define CHIMERA_NFS_SEC_KRB5      0x02u  /* RPCSEC_GSS, service = none       */
+#define CHIMERA_NFS_SEC_KRB5I     0x04u  /* RPCSEC_GSS, service = integrity  */
+#define CHIMERA_NFS_SEC_KRB5P     0x08u  /* RPCSEC_GSS, service = privacy    */
+#define CHIMERA_NFS_SEC_ALL \
+        (CHIMERA_NFS_SEC_SYS | CHIMERA_NFS_SEC_KRB5 | \
+         CHIMERA_NFS_SEC_KRB5I | CHIMERA_NFS_SEC_KRB5P)
+
 
 /**
  * @brief Adds a new NFS export to the shared context.
@@ -158,6 +172,12 @@ chimera_nfs_export_set_options(
     uint32_t    squash,
     uint32_t    anonuid,
     uint32_t    anongid);
+
+int
+chimera_nfs_export_set_sec(
+    void       *nfs_shared,
+    const char *name,
+    uint32_t    sec_allowed);
 
 /**
  * @brief Retrieves an NFS export by its stable id (as embedded in file handles).

--- a/src/server/nfs/nfs4_proc_bind_conn_to_session.c
+++ b/src/server/nfs/nfs4_proc_bind_conn_to_session.c
@@ -58,6 +58,24 @@ chimera_nfs4_bind_conn_to_session(
         return;
     }
 
+    /* SP4_MACH_CRED: only the bound machine credential may bind a connection
+     * to the session (RFC 8881 §2.10.8.3). */
+    {
+        const struct nfs4_client_principal p = {
+            .flavor          = req->principal_flavor,
+            .uid             = req->principal_uid,
+            .gid             = req->principal_gid,
+            .machinename     = req->principal_machinename,
+            .machinename_len = req->principal_machinename_len,
+        };
+        if (!nfs4_client_mach_cred_ok(session->nfs4_session_client, &p)) {
+            nfs4_session_put(session);
+            res->bctsr_status = NFS4ERR_WRONG_CRED;
+            chimera_nfs4_compound_complete(req, NFS4ERR_WRONG_CRED);
+            return;
+        }
+    }
+
     switch (args->bctsa_dir) {
         case CDFC4_FORE:
             bind_fore = true;

--- a/src/server/nfs/nfs4_proc_compound.c
+++ b/src/server/nfs/nfs4_proc_compound.c
@@ -405,6 +405,16 @@ chimera_nfs4_compound(
         req->principal_machinename     = cred->authsys.machinename;
         req->principal_machinename_len = cred->authsys.machinename_len > 0 ?
             (uint32_t) cred->authsys.machinename_len : 0;
+    } else if (cred && cred->flavor == EVPL_RPC2_AUTH_RPCSEC_GSS &&
+               cred->gss.principal) {
+        /* For RPCSEC_GSS the "machine credential" identity is the GSS principal
+         * name; carry it as the machinename so EXCHANGE_ID can bind it for
+         * SP4_MACH_CRED and per-op enforcement can compare against it. */
+        req->principal_flavor          = cred->flavor;
+        req->principal_uid             = 0;
+        req->principal_gid             = 0;
+        req->principal_machinename     = cred->gss.principal;
+        req->principal_machinename_len = (uint32_t) strlen(cred->gss.principal);
     } else {
         req->principal_flavor          = cred ? cred->flavor : EVPL_RPC2_AUTH_NONE;
         req->principal_uid             = 0;

--- a/src/server/nfs/nfs4_proc_create_session.c
+++ b/src/server/nfs/nfs4_proc_create_session.c
@@ -102,6 +102,28 @@ chimera_nfs4_create_session(
     principal.machinename     = req->principal_machinename;
     principal.machinename_len = req->principal_machinename_len;
 
+    /* SP4_MACH_CRED: CREATE_SESSION for this client must use the bound machine
+     * credential (RFC 8881 §2.10.8.3). */
+    {
+        struct nfs4_client *c;
+        bool                wrong_cred = false;
+
+        pthread_mutex_lock(&shared->nfs4_shared_clients.nfs4_ct_lock);
+        HASH_FIND(nfs4_client_hh_by_id,
+                  shared->nfs4_shared_clients.nfs4_ct_clients_by_id,
+                  &args->csa_clientid, sizeof(args->csa_clientid), c);
+        if (c && !nfs4_client_mach_cred_ok(c, &principal)) {
+            wrong_cred = true;
+        }
+        pthread_mutex_unlock(&shared->nfs4_shared_clients.nfs4_ct_lock);
+
+        if (wrong_cred) {
+            res->csr_status = NFS4ERR_WRONG_CRED;
+            chimera_nfs4_compound_complete(req, NFS4ERR_WRONG_CRED);
+            return;
+        }
+    }
+
     nfs4_client_create_session_classify(&shared->nfs4_shared_clients,
                                         args->csa_clientid,
                                         args->csa_sequence,

--- a/src/server/nfs/nfs4_proc_destroy_clientid.c
+++ b/src/server/nfs/nfs4_proc_destroy_clientid.c
@@ -36,19 +36,39 @@ chimera_nfs4_destroy_clientid(
      * persistent recovery record once the destroy succeeds (the nfs4_client is
      * freed inside nfs4_client_destroy_clientid). */
     uint8_t  owner[NFS4_OPAQUE_LIMIT];
-    uint16_t owner_len = 0;
+    uint16_t owner_len  = 0;
+    bool     wrong_cred = false;
     {
-        struct nfs4_client *c;
+        struct nfs4_client                *c;
+        const struct nfs4_client_principal p = {
+            .flavor          = req->principal_flavor,
+            .uid             = req->principal_uid,
+            .gid             = req->principal_gid,
+            .machinename     = req->principal_machinename,
+            .machinename_len = req->principal_machinename_len,
+        };
 
         pthread_mutex_lock(&shared->nfs4_shared_clients.nfs4_ct_lock);
         HASH_FIND(nfs4_client_hh_by_id,
                   shared->nfs4_shared_clients.nfs4_ct_clients_by_id,
                   &args->dca_clientid, sizeof(args->dca_clientid), c);
         if (c) {
-            owner_len = c->nfs4_client_owner_len;
-            memcpy(owner, c->nfs4_client_owner, owner_len);
+            /* SP4_MACH_CRED: only the bound machine credential may destroy
+             * this client (RFC 8881 §2.10.8.3). */
+            if (!nfs4_client_mach_cred_ok(c, &p)) {
+                wrong_cred = true;
+            } else {
+                owner_len = c->nfs4_client_owner_len;
+                memcpy(owner, c->nfs4_client_owner, owner_len);
+            }
         }
         pthread_mutex_unlock(&shared->nfs4_shared_clients.nfs4_ct_lock);
+    }
+
+    if (wrong_cred) {
+        res->dcr_status = NFS4ERR_WRONG_CRED;
+        chimera_nfs4_compound_complete(req, res->dcr_status);
+        return;
     }
 
     /* NFS4ERR_STALE_CLIENTID for an unknown clientid, NFS4ERR_CLIENTID_BUSY

--- a/src/server/nfs/nfs4_proc_destroy_session.c
+++ b/src/server/nfs/nfs4_proc_destroy_session.c
@@ -51,6 +51,24 @@ chimera_nfs4_destroy_session(
         return;
     }
 
+    /* SP4_MACH_CRED: only the bound machine credential may destroy the
+     * session (RFC 8881 §2.10.8.3). */
+    {
+        const struct nfs4_client_principal p = {
+            .flavor          = req->principal_flavor,
+            .uid             = req->principal_uid,
+            .gid             = req->principal_gid,
+            .machinename     = req->principal_machinename,
+            .machinename_len = req->principal_machinename_len,
+        };
+        if (!nfs4_client_mach_cred_ok(session->nfs4_session_client, &p)) {
+            nfs4_session_put(session);
+            res->dsr_status = NFS4ERR_WRONG_CRED;
+            chimera_nfs4_compound_complete(req, res->dsr_status);
+            return;
+        }
+    }
+
     nfs4_session_put(session);
 
     nfs4_destroy_session(&shared->nfs4_shared_clients, args->dsa_sessionid);

--- a/src/server/nfs/nfs4_proc_exchange_id.c
+++ b/src/server/nfs/nfs4_proc_exchange_id.c
@@ -114,19 +114,43 @@ nfs4_copy_protect_ops(
     }
 } /* nfs4_copy_protect_ops */
 
+/* State-management operations chimera enforces under SP4_MACH_CRED, as a
+ * bitmap4 (RFC 8881 §2.10.8.3): BIND_CONN_TO_SESSION(41), EXCHANGE_ID(42),
+ * CREATE_SESSION(43), DESTROY_SESSION(44), DESTROY_CLIENTID(57).  Bit op N is
+ * word[N/32] bit (N%32); ops 41-57 all fall in word 1. */
+#define NFS4_MACH_ENFORCE_WORD1                                                 \
+        ((1u << (41 - 32)) | (1u << (42 - 32)) | (1u << (43 - 32)) |            \
+         (1u << (44 - 32)) | (1u << (57 - 32)))
+
 /*
- * Build the EXCHANGE_ID reply's state-protection result (RFC 8881 §18.35.3).
- * SP4_SSV is honored when the client offers an SSV hash (and cipher) we
- * support; the server picks the algorithms, echoes the operation-protection
- * bitmaps, and reports the negotiated SSV length so the client can size its
- * key.  SP4_NONE and any case we cannot satisfy fall back to SP4_NONE.
+ * Build the EXCHANGE_ID reply's state-protection result (RFC 8881 §18.35.3)
+ * and return the negotiated mode (stored on the client record for per-op
+ * enforcement).  SP4_MACH_CRED is honored when requested: the server echoes
+ * the operations it will enforce against the machine credential.  SP4_SSV is
+ * honored when the client offers an SSV hash (and cipher) we support.  Any
+ * case we cannot satisfy falls back to SP4_NONE.
  */
-static void
+static uint32_t
 nfs4_set_state_protect(
     const struct state_protect4_a *req_sp,
     struct state_protect4_r       *res_sp,
     xdr_dbuf                      *dbuf)
 {
+    if (req_sp->spa_how == SP4_MACH_CRED) {
+        static const uint32_t      enforce[2] = { 0, NFS4_MACH_ENFORCE_WORD1 };
+        struct state_protect_ops4 *ops        = &res_sp->spr_mach_ops;
+
+        chimera_nfs_debug("EXCHANGE_ID: negotiated SP4_MACH_CRED state protection");
+        res_sp->spr_how           = SP4_MACH_CRED;
+        ops->num_spo_must_enforce = 2;
+        ops->spo_must_enforce     = xdr_dbuf_alloc_space(sizeof(enforce), dbuf);
+        chimera_nfs_abort_if(ops->spo_must_enforce == NULL, "Failed to allocate space");
+        memcpy(ops->spo_must_enforce, enforce, sizeof(enforce));
+        ops->num_spo_must_allow = 0;
+        ops->spo_must_allow     = NULL;
+        return SP4_MACH_CRED;
+    }
+
     if (req_sp->spa_how == SP4_SSV) {
         const struct ssv_sp_parms4 *p = &req_sp->spa_ssv_parms;
         uint32_t                    hash_idx, encr_idx, ssv_len;
@@ -154,11 +178,12 @@ nfs4_set_state_protect(
              * RPCSEC_GSS SSV mechanism if/when it uses SSV-secured RPC. */
             info->spi_handles.len  = 0;
             info->spi_handles.data = NULL;
-            return;
+            return SP4_SSV;
         }
     }
 
     res_sp->spr_how = SP4_NONE;
+    return SP4_NONE;
 } /* nfs4_set_state_protect */
 
 void
@@ -257,6 +282,12 @@ chimera_nfs4_exchange_id(
         return;
     }
 
+    /* Negotiate state protection (RFC 8881 §18.35.3) and record the chosen mode
+     * on the client so per-op enforcement (SP4_MACH_CRED) can consult it. */
+    uint32_t sp_how = nfs4_set_state_protect(&args->eia_state_protect,
+                                             &res->eir_resok4.eir_state_protect,
+                                             req->encoding->dbuf);
+
     /* Phase 5: 4.1+ EXCHANGE_ID is the moment of identity establishment;
      * stub-persist the unified client so a future stable-storage backend
      * can pick it up after a restart. */
@@ -268,7 +299,8 @@ chimera_nfs4_exchange_id(
                   thread->shared->nfs4_shared_clients.nfs4_ct_clients_by_id,
                   &eid.clientid, sizeof(eid.clientid), c);
         if (c) {
-            uc = c->unified;
+            c->nfs4_client_sp_how = sp_how;
+            uc                    = c->unified;
             /* EXCHANGE_ID is client liveness: renew the lease so a client
              * mid-handshake (EXCHANGE_ID -> CREATE_SESSION -> first SEQUENCE)
              * is not expired by the lease sweep before it establishes a
@@ -301,9 +333,8 @@ chimera_nfs4_exchange_id(
     res->eir_resok4.eir_sequenceid = 1;
     res->eir_resok4.eir_flags      = pnfs_flags |
         (eid.confirmed ? EXCHGID4_FLAG_CONFIRMED_R : 0);
-    nfs4_set_state_protect(&args->eia_state_protect,
-                           &res->eir_resok4.eir_state_protect,
-                           req->encoding->dbuf);
+    /* eir_state_protect was already filled (and the mode recorded on the
+     * client) above. */
     res->eir_resok4.num_eir_server_impl_id = 1;
 
     res->eir_resok4.eir_server_impl_id = xdr_dbuf_alloc_space(sizeof(struct nfs_impl_id4), req->encoding->dbuf);

--- a/src/server/nfs/nfs4_proc_putfh.c
+++ b/src/server/nfs/nfs4_proc_putfh.c
@@ -134,9 +134,19 @@ chimera_nfs4_putfh(
      * the squashed credential.  A forged/tampered handle fails authentication
      * here; a well-formed but deleted handle surfaces NFS4ERR_STALE on the
      * operation that dereferences it. */
-    if (args->object.len > NFS4_FHSIZE ||
+    int decode_rc = args->object.len > NFS4_FHSIZE ? CHIMERA_NFS_FH_BADHANDLE :
         chimera_nfs_fh_decode(req, args->object.data, args->object.len,
-                              req->fh, &req->fhlen) != CHIMERA_NFS_FH_OK ||
+                              req->fh, &req->fhlen);
+
+    if (decode_rc == CHIMERA_NFS_FH_WRONGSEC) {
+        /* Handle is valid but its export does not permit this RPC security
+         * flavor; the client renegotiates via SECINFO (RFC 7530 §16.20.5). */
+        res->status = NFS4ERR_WRONGSEC;
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    if (decode_rc != CHIMERA_NFS_FH_OK ||
         !chimera_vfs_fh_is_plausible(thread->vfs_thread, req->fh, req->fhlen)) {
         res->status = NFS4ERR_BADHANDLE;
         chimera_nfs4_compound_complete(req, res->status);

--- a/src/server/nfs/nfs4_proc_secinfo.c
+++ b/src/server/nfs/nfs4_proc_secinfo.c
@@ -4,15 +4,17 @@
 
 #include "nfs4_procs.h"
 #include "nfs4_status.h"
+#include "nfs.h"
 #include "evpl/evpl_rpc2.h"
 #include "vfs/vfs_procs.h"
 #include "vfs/vfs_release.h"
 
 /* RFC 7530 §16.31: SECINFO returns the security mechanisms the server will
- * accept for the named entry in the current-filehandle directory. Chimera
- * only offers AUTH_SYS, so a successful lookup yields a single-flavor list.
- * The name lookup also produces the spec-mandated error returns:
- * NFS4ERR_NOTDIR (cfh not a directory) and NFS4ERR_NOENT (name absent). */
+ * accept for the named entry in the current-filehandle directory.  Chimera
+ * advertises the owning export's configured flavors (or all supported flavors
+ * if the export has no explicit policy).  The name lookup also produces the
+ * spec-mandated error returns: NFS4ERR_NOTDIR (cfh not a directory) and
+ * NFS4ERR_NOENT (name absent). */
 
 static void
 chimera_nfs4_secinfo_complete(
@@ -21,11 +23,9 @@ chimera_nfs4_secinfo_complete(
     struct chimera_vfs_attrs *dir_attr,
     void                     *private_data)
 {
-    struct nfs_request  *req        = private_data;
-    struct SECINFO4res  *res        = &req->res_compound.resarray[req->index].opsecinfo;
-    static const uint8_t krb5_oid[] = {
-        0x2a, 0x86, 0x48, 0x86, 0xf7, 0x12, 0x01, 0x02, 0x02
-    };
+    struct nfs_request              *req = private_data;
+    struct SECINFO4res              *res = &req->res_compound.resarray[req->index].opsecinfo;
+    const struct chimera_nfs_export *export;
 
     chimera_vfs_release(req->thread->vfs_thread, req->handle);
 
@@ -35,17 +35,13 @@ chimera_nfs4_secinfo_complete(
         return;
     }
 
-    res->resok4 = xdr_dbuf_alloc_space(2 * sizeof(struct secinfo4), req->encoding->dbuf);
+    /* The looked-up name lives in the current FH's export. */
+    export      = chimera_nfs_get_export_by_id(req->thread->shared, req->export_id);
+    res->resok4 = xdr_dbuf_alloc_space(4 * sizeof(struct secinfo4), req->encoding->dbuf);
     chimera_nfs_abort_if(res->resok4 == NULL, "Failed to allocate space");
 
-    res->num_resok4                         = 2;
-    res->resok4[0].flavor                   = AUTH_SYS;
-    res->resok4[1].flavor                   = RPCSEC_GSS;
-    res->resok4[1].flavor_info.oid.oid.len  = sizeof(krb5_oid);
-    res->resok4[1].flavor_info.oid.oid.data = (void *) krb5_oid;
-    res->resok4[1].flavor_info.qop          = 0;
-    res->resok4[1].flavor_info.service      = RPC_GSS_SVC_NONE;
-
+    res->num_resok4 = chimera_nfs_fill_secinfo(res->resok4,
+                                               export ? export->sec_allowed : 0);
     res->status = NFS4_OK;
     chimera_nfs4_compound_complete(req, NFS4_OK);
 } /* chimera_nfs4_secinfo_complete */
@@ -99,6 +95,32 @@ chimera_nfs4_secinfo(
     res->status = chimera_nfs4_validate_name(&args->name);
     if (res->status != NFS4_OK) {
         chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    /* When the current FH is the NFSv4 pseudo-fs root, the name is an export
+     * name (not a VFS object).  This is the path a client takes to renegotiate
+     * after NFS4ERR_WRONGSEC at the export boundary, so resolve the export
+     * directly and advertise its configured flavors. */
+    if (fh_is_nfs4_root(req->fh, req->fhlen)) {
+        const struct chimera_nfs_export *export    = NULL;
+        char                            *full_path = NULL;
+
+        if (chimera_nfs_find_export_path(thread->shared, args->name.data,
+                                         args->name.len, &full_path, &export) != 0) {
+            res->status = NFS4ERR_NOENT;
+            chimera_nfs4_compound_complete(req, NFS4ERR_NOENT);
+            return;
+        }
+        free(full_path);
+
+        res->resok4 = xdr_dbuf_alloc_space(4 * sizeof(struct secinfo4),
+                                           req->encoding->dbuf);
+        chimera_nfs_abort_if(res->resok4 == NULL, "Failed to allocate space");
+        res->num_resok4 = chimera_nfs_fill_secinfo(res->resok4,
+                                                   export ? export->sec_allowed : 0);
+        res->status = NFS4_OK;
+        chimera_nfs4_compound_complete(req, NFS4_OK);
         return;
     }
 

--- a/src/server/nfs/nfs4_proc_secinfo_no_name.c
+++ b/src/server/nfs/nfs4_proc_secinfo_no_name.c
@@ -1,10 +1,18 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
 #include "nfs4_procs.h"
+#include "nfs4_status.h"
+#include "nfs_common.h"
 #include "evpl/evpl_rpc2.h"
 
+/*
+ * SECINFO_NO_NAME (RFC 8881 §18.45) reports the security flavors the server
+ * accepts for the current filehandle.  We advertise the owning export's
+ * configured flavors (or everything chimera supports if the export has no
+ * explicit policy), as RPCSEC_GSS triples for krb5/krb5i/krb5p.
+ */
 void
 chimera_nfs4_secinfo_no_name(
     struct chimera_server_nfs_thread *thread,
@@ -12,15 +20,18 @@ chimera_nfs4_secinfo_no_name(
     struct nfs_argop4                *argop,
     struct nfs_resop4                *resop)
 {
-    struct SECINFO4res *res = &resop->opsecinfo_no_name;
+    struct SECINFO4res              *res = &resop->opsecinfo_no_name;
+    const struct chimera_nfs_export *export;
 
-    res->status     = NFS4_OK;
-    res->num_resok4 = 1;
+    export = chimera_nfs_get_export_by_id(thread->shared, req->export_id);
 
-    res->resok4 = xdr_dbuf_alloc_space(sizeof(struct secinfo4), req->encoding->dbuf);
+    res->resok4 = xdr_dbuf_alloc_space(4 * sizeof(struct secinfo4),
+                                       req->encoding->dbuf);
     chimera_nfs_abort_if(res->resok4 == NULL, "Failed to allocate space");
 
-    res->resok4[0].flavor = RPC_GSS_SVC_NONE;
+    res->num_resok4 = chimera_nfs_fill_secinfo(res->resok4,
+                                               export ? export->sec_allowed : 0);
+    res->status = NFS4_OK;
 
     chimera_nfs4_compound_complete(req, NFS4_OK);
-} /* chimera_nfs4_reclaim_complete */
+} /* chimera_nfs4_secinfo_no_name */

--- a/src/server/nfs/nfs4_root.c
+++ b/src/server/nfs/nfs4_root.c
@@ -129,6 +129,15 @@ nfs4_root_lookup(
         return;
     }
 
+    /* Enforce the export's security-flavor policy at the pseudo-fs boundary:
+     * a client traversing into the export under a disallowed flavor gets
+     * NFS4ERR_WRONGSEC and renegotiates via SECINFO. */
+    if (!chimera_nfs_export_sec_ok(export, req->sec_bit)) {
+        res->status = NFS4ERR_WRONGSEC;
+        chimera_nfs4_compound_complete(req, NFS4ERR_WRONGSEC);
+        return;
+    }
+
     /* Entering an export from the pseudo-fs: adopt its id (so the handle minted
      * for the client carries it) and apply its squash policy. */
     chimera_nfs_set_export(req, export);

--- a/src/server/nfs/nfs4_session.c
+++ b/src/server/nfs/nfs4_session.c
@@ -218,6 +218,24 @@ nfs4_principal_matches(
                   p->machinename_len) == 0;
 } /* nfs4_principal_matches */
 
+/*
+ * SP4_MACH_CRED enforcement (RFC 8881 §2.10.8.3): a state-management operation
+ * on a client that negotiated SP4_MACH_CRED must be issued with the same
+ * (machine) credential that established the client at EXCHANGE_ID.  Returns 1
+ * if the operation is permitted (client absent, or SP4_NONE/SP4_SSV, or the
+ * principal matches), 0 if it must be rejected with NFS4ERR_WRONG_CRED.
+ */
+SYMBOL_EXPORT int
+nfs4_client_mach_cred_ok(
+    const struct nfs4_client           *c,
+    const struct nfs4_client_principal *p)
+{
+    if (!c || c->nfs4_client_sp_how != SP4_MACH_CRED) {
+        return 1;
+    }
+    return nfs4_principal_matches(c, p);
+} /* nfs4_client_mach_cred_ok */
+
 /* Caller must hold table->nfs4_ct_lock.  Allocates a fresh (unconfirmed)
  * client record, brings up its unified state hierarchy, and inserts it into
  * both hash tables. */

--- a/src/server/nfs/nfs4_session.h
+++ b/src/server/nfs/nfs4_session.h
@@ -121,6 +121,14 @@ struct nfs4_client_principal {
     uint32_t    machinename_len;
 };
 
+/* SP4_MACH_CRED enforcement: 1 if `p` may operate on client `c` (no protection,
+ * or the bound machine principal matches); 0 -> reject with NFS4ERR_WRONG_CRED. */
+struct nfs4_client;
+int
+nfs4_client_mach_cred_ok(
+    const struct nfs4_client           *c,
+    const struct nfs4_client_principal *p);
+
 struct nfs4_client {
     uint64_t              nfs4_client_id;
     uint32_t              nfs4_client_owner_len;
@@ -136,12 +144,18 @@ struct nfs4_client {
      * possession of the clientid via a successful CREATE_SESSION; only then
      * is it "confirmed". */
     uint8_t               nfs4_client_confirmed;
-    /* Principal that created the record (see nfs4_client_principal). */
+    /* Principal that created the record (see nfs4_client_principal).  Under
+     * SP4_MACH_CRED this is the bound "machine credential": state-management
+     * operations must be issued with this same (RPCSEC_GSS) principal. */
     uint32_t              nfs4_client_princ_flavor;
     uint32_t              nfs4_client_princ_uid;
     uint32_t              nfs4_client_princ_gid;
     uint32_t              nfs4_client_princ_mach_len;
     char                  nfs4_client_princ_mach[NFS4_OPAQUE_LIMIT];
+    /* Negotiated state-protection mode (RFC 8881 §2.10.8.3): SP4_NONE (0,
+     * default), SP4_MACH_CRED, or SP4_SSV.  When SP4_MACH_CRED, the enforced
+     * state-management ops require the bound principal above. */
+    uint32_t              nfs4_client_sp_how;
     /* Client-reboot (RFC 8881 §18.35.4 case 5): when a confirmed record is
      * replaced by a new EXCHANGE_ID from the same principal with a new boot
      * verifier, the new (unconfirmed) record records the old clientid here.

--- a/src/server/nfs/nfs_common.h
+++ b/src/server/nfs/nfs_common.h
@@ -99,6 +99,10 @@ struct nfs_request {
      * root). */
     uint16_t                          export_id;
     uint16_t                          saved_export_id;
+    /* The request's RPC security flavor as a CHIMERA_NFS_SEC_* bit, derived
+     * from the RPC credential at request entry.  Checked against the target
+     * export's sec_allowed mask. */
+    uint32_t                          sec_bit;
     struct chimera_vfs_open_handle   *handle;
     int                               index;
     uint8_t                           minorversion;     /* COMPOUND4args.minorversion */
@@ -220,6 +224,7 @@ struct chimera_nfs_export {
     uint32_t                   squash;
     uint32_t                   anonuid;
     uint32_t                   anongid;
+    uint32_t                   sec_allowed;  /* CHIMERA_NFS_SEC_* mask; 0 = any */
     struct chimera_nfs_export *prev;
     struct chimera_nfs_export *next;
 };
@@ -476,6 +481,42 @@ chimera_nfs_map_cred(
 } /* chimera_nfs_map_cred */
 
 /*
+ * Classify an RPC credential into a CHIMERA_NFS_SEC_* bit for per-export
+ * security-flavor policy.  AUTH_SYS and AUTH_NONE both map to "sys";
+ * RPCSEC_GSS maps to krb5 / krb5i / krb5p by its negotiated GSS service.
+ */
+static inline uint32_t
+chimera_nfs_sec_bit(const struct evpl_rpc2_cred *rpc_cred)
+{
+    if (rpc_cred && rpc_cred->flavor == EVPL_RPC2_AUTH_RPCSEC_GSS) {
+        switch (rpc_cred->gss.service) {
+            case EVPL_RPC2_GSS_SVC_INTEGRITY:
+                return CHIMERA_NFS_SEC_KRB5I;
+            case EVPL_RPC2_GSS_SVC_PRIVACY:
+                return CHIMERA_NFS_SEC_KRB5P;
+            default:
+                return CHIMERA_NFS_SEC_KRB5;
+        } /* switch */
+    }
+    return CHIMERA_NFS_SEC_SYS;
+} /* chimera_nfs_sec_bit */
+
+/*
+ * True if an export permits the given security-flavor bit.  An export with no
+ * explicit policy (sec_allowed == 0) permits everything.
+ */
+static inline int
+chimera_nfs_export_sec_ok(
+    const struct chimera_nfs_export *export,
+    uint32_t sec_bit)
+{
+    if (!export || export->sec_allowed == 0) {
+        return 1;
+    }
+    return (export->sec_allowed & sec_bit) != 0;
+} /* chimera_nfs_export_sec_ok */
+
+/*
  * Map the RPC credential into a request and snapshot it as the pre-squash
  * original.  Use this from every proc/compound entry instead of calling
  * chimera_nfs_map_cred directly so that file-handle decoding can recompute the
@@ -488,6 +529,7 @@ chimera_nfs_map_cred_req(
 {
     chimera_nfs_map_cred(&req->cred, rpc_cred);
     req->orig_cred = req->cred;
+    req->sec_bit   = chimera_nfs_sec_bit(rpc_cred);
 } /* chimera_nfs_map_cred_req */
 
 /*
@@ -556,7 +598,15 @@ chimera_nfs_fh_decode(
     /* Recompute the effective credential from the pre-squash original so that
      * switching exports within a compound applies the new export's policy
      * rather than stacking on a previous squash. */
-    export    = chimera_nfs_get_export_by_id(shared, req->export_id);
+    export = chimera_nfs_get_export_by_id(shared, req->export_id);
+
+    /* Enforce the export's security-flavor policy: a handle that authenticates
+     * fine but arrives under a flavor the export does not permit is rejected
+     * (NFS4ERR_WRONGSEC), which drives the client to renegotiate via SECINFO. */
+    if (!chimera_nfs_export_sec_ok(export, req->sec_bit)) {
+        return CHIMERA_NFS_FH_WRONGSEC;
+    }
+
     req->cred = req->orig_cred;
     chimera_nfs_squash_cred(&req->cred, export);
 
@@ -596,3 +646,47 @@ chimera_nfs_fh_encode(
     chimera_nfs_fh_wrap(out, outlen, req->export_id, vfs_fh, vfs_len,
                         shared->fh_key, shared->fh_sign);
 } /* chimera_nfs_fh_encode */
+
+/*
+ * Populate `out` (capacity >= 4) with the secinfo4 entries advertising an
+ * export's allowed security flavors.  An export with no explicit policy
+ * (sec_allowed == 0) advertises everything chimera supports.  Returns the
+ * number of entries written, in the server's preference order.
+ */
+static inline int
+chimera_nfs_fill_secinfo(
+    struct secinfo4 *out,
+    uint32_t         sec_allowed)
+{
+    /* Kerberos v5 mechanism OID 1.2.840.113554.1.2.2 (RFC 1964). */
+    static const uint8_t krb5_oid[9] = {
+        0x2a, 0x86, 0x48, 0x86, 0xf7, 0x12, 0x01, 0x02, 0x02
+    };
+    uint32_t             mask = sec_allowed ? sec_allowed : CHIMERA_NFS_SEC_ALL;
+    int                  n    = 0;
+
+    static const struct {
+        uint32_t bit;
+        uint32_t service;
+    } gss_flavors[] = {
+        { CHIMERA_NFS_SEC_KRB5,  RPC_GSS_SVC_NONE       },
+        { CHIMERA_NFS_SEC_KRB5I, RPC_GSS_SVC_INTEGRITY  },
+        { CHIMERA_NFS_SEC_KRB5P, RPC_GSS_SVC_PRIVACY    },
+    };
+    unsigned             i;
+
+    if (mask & CHIMERA_NFS_SEC_SYS) {
+        out[n++].flavor = AUTH_SYS;
+    }
+    for (i = 0; i < sizeof(gss_flavors) / sizeof(gss_flavors[0]); i++) {
+        if (mask & gss_flavors[i].bit) {
+            out[n].flavor                   = RPCSEC_GSS;
+            out[n].flavor_info.oid.oid.len  = sizeof(krb5_oid);
+            out[n].flavor_info.oid.oid.data = (void *) krb5_oid;
+            out[n].flavor_info.qop          = 0;
+            out[n].flavor_info.service      = gss_flavors[i].service;
+            n++;
+        }
+    }
+    return n;
+} /* chimera_nfs_fill_secinfo */

--- a/src/server/nfs/nfs_common.h
+++ b/src/server/nfs/nfs_common.h
@@ -669,9 +669,9 @@ chimera_nfs_fill_secinfo(
         uint32_t bit;
         uint32_t service;
     } gss_flavors[] = {
-        { CHIMERA_NFS_SEC_KRB5,  RPC_GSS_SVC_NONE       },
-        { CHIMERA_NFS_SEC_KRB5I, RPC_GSS_SVC_INTEGRITY  },
-        { CHIMERA_NFS_SEC_KRB5P, RPC_GSS_SVC_PRIVACY    },
+        { CHIMERA_NFS_SEC_KRB5,  RPC_GSS_SVC_NONE        },
+        { CHIMERA_NFS_SEC_KRB5I, RPC_GSS_SVC_INTEGRITY   },
+        { CHIMERA_NFS_SEC_KRB5P, RPC_GSS_SVC_PRIVACY     },
     };
     unsigned             i;
 

--- a/src/server/nfs/nfs_common.h
+++ b/src/server/nfs/nfs_common.h
@@ -665,15 +665,20 @@ chimera_nfs_fill_secinfo(
     uint32_t             mask = sec_allowed ? sec_allowed : CHIMERA_NFS_SEC_ALL;
     int                  n    = 0;
 
+    /* *INDENT-OFF* */
+    /* uncrustify oscillates on the column alignment of this initializer, so
+     * format it by hand (see the same treatment of the OID tables in
+     * nfs4_proc_exchange_id.c). */
     static const struct {
         uint32_t bit;
         uint32_t service;
     } gss_flavors[] = {
-        { CHIMERA_NFS_SEC_KRB5,  RPC_GSS_SVC_NONE        },
-        { CHIMERA_NFS_SEC_KRB5I, RPC_GSS_SVC_INTEGRITY   },
-        { CHIMERA_NFS_SEC_KRB5P, RPC_GSS_SVC_PRIVACY     },
+        { CHIMERA_NFS_SEC_KRB5,  RPC_GSS_SVC_NONE },
+        { CHIMERA_NFS_SEC_KRB5I, RPC_GSS_SVC_INTEGRITY },
+        { CHIMERA_NFS_SEC_KRB5P, RPC_GSS_SVC_PRIVACY },
     };
-    unsigned             i;
+    /* *INDENT-ON* */
+    unsigned i;
 
     if (mask & CHIMERA_NFS_SEC_SYS) {
         out[n++].flavor = AUTH_SYS;

--- a/src/server/nfs/nfs_common.h
+++ b/src/server/nfs/nfs_common.h
@@ -11,6 +11,7 @@
 #include "evpl/evpl_rpc2.h"
 #include "portmap_xdr.h"
 #include "vfs/vfs_cred.h"
+#include "nfs_gss.h"
 #include "nfs_mount_xdr.h"
 #include "nfs3_xdr.h"
 #include "nfs4_xdr.h"
@@ -463,6 +464,9 @@ chimera_nfs_map_cred(
                                    rpc_cred->authsys.gid,
                                    rpc_cred->authsys.num_gids,
                                    rpc_cred->authsys.gids);
+    } else if (rpc_cred->flavor == EVPL_RPC2_AUTH_RPCSEC_GSS) {
+        /* RPCSEC_GSS: map the authenticated principal to a UNIX identity. */
+        chimera_nfs_gss_map_principal(rpc_cred->gss.principal, vfs_cred);
     } else {
         /* Unknown auth flavor - use anonymous */
         chimera_vfs_cred_init_anonymous(vfs_cred,

--- a/src/server/nfs/nfs_fh_wrap.h
+++ b/src/server/nfs/nfs_fh_wrap.h
@@ -44,6 +44,8 @@
 enum chimera_nfs_fh_status {
     CHIMERA_NFS_FH_OK        = 0,
     CHIMERA_NFS_FH_BADHANDLE = -1,   /* malformed, wrong tag, or MAC mismatch */
+    CHIMERA_NFS_FH_WRONGSEC  = -2,   /* handle ok, but RPC sec flavor not permitted
+                                      * for the owning export (NFS4ERR_WRONGSEC) */
 };
 
 /*

--- a/src/server/nfs/nfs_gss.c
+++ b/src/server/nfs/nfs_gss.c
@@ -1,0 +1,314 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include <stdlib.h>
+#include <string.h>
+#include <pwd.h>
+#include <gssapi/gssapi.h>
+#include <gssapi/gssapi_krb5.h>
+
+#include "nfs_gss.h"
+#include "nfs_internal.h"
+#include "vfs/vfs_cred.h"
+
+/*
+ * Feed one leg of the context-establishment token exchange into
+ * gss_accept_sec_context().  The opaque *gss_ctx cookie is the gss_ctx_id_t
+ * itself (a pointer), carried across continuation legs by libevpl.
+ */
+static int
+chimera_nfs_gss_accept(
+    void       *arg,
+    void      **gss_ctx,
+    const void *in_token,
+    size_t      in_len,
+    void      **out_token,
+    size_t     *out_len,
+    int        *complete,
+    char       *principal,
+    size_t      principal_sz)
+{
+    OM_uint32       major, minor;
+    gss_ctx_id_t    gctx = *gss_ctx ? (gss_ctx_id_t) *gss_ctx : GSS_C_NO_CONTEXT;
+    gss_buffer_desc itok = { in_len, (void *) in_token };
+    gss_buffer_desc otok = GSS_C_EMPTY_BUFFER;
+    gss_name_t      src  = GSS_C_NO_NAME;
+    OM_uint32       flags;
+
+    (void) arg;
+
+    *out_token = NULL;
+    *out_len   = 0;
+    *complete  = 0;
+
+    major = gss_accept_sec_context(&minor, &gctx, GSS_C_NO_CREDENTIAL, &itok,
+                                   GSS_C_NO_CHANNEL_BINDINGS, &src, NULL,
+                                   &otok, &flags, NULL, NULL);
+
+    /* gctx may be allocated even on a continue or a soft failure. */
+    *gss_ctx = gctx;
+
+    if (GSS_ERROR(major)) {
+        chimera_nfs_error("rpcsec_gss: accept_sec_context failed: %u.%u",
+                          major, minor);
+        if (otok.length) {
+            gss_release_buffer(&minor, &otok);
+        }
+        if (src != GSS_C_NO_NAME) {
+            gss_release_name(&minor, &src);
+        }
+        return -1;
+    }
+
+    if (otok.length) {
+        *out_token = malloc(otok.length);
+        if (*out_token) {
+            memcpy(*out_token, otok.value, otok.length);
+            *out_len = otok.length;
+        }
+        gss_release_buffer(&minor, &otok);
+    }
+
+    if (major == GSS_S_COMPLETE) {
+        *complete = 1;
+
+        if (src != GSS_C_NO_NAME) {
+            gss_buffer_desc nb = GSS_C_EMPTY_BUFFER;
+
+            if (!GSS_ERROR(gss_display_name(&minor, src, &nb, NULL)) &&
+                nb.length) {
+                size_t n = nb.length < principal_sz - 1 ?
+                    nb.length : principal_sz - 1;
+                memcpy(principal, nb.value, n);
+                principal[n] = '\0';
+                gss_release_buffer(&minor, &nb);
+            }
+        }
+    }
+
+    if (src != GSS_C_NO_NAME) {
+        gss_release_name(&minor, &src);
+    }
+
+    return 0;
+} /* chimera_nfs_gss_accept */
+
+static int
+chimera_nfs_gss_get_mic(
+    void       *arg,
+    void       *gss_ctx,
+    const void *msg,
+    size_t      msg_len,
+    void      **mic,
+    size_t     *mic_len)
+{
+    OM_uint32       major, minor;
+    gss_buffer_desc m   = { msg_len, (void *) msg };
+    gss_buffer_desc out = GSS_C_EMPTY_BUFFER;
+
+    (void) arg;
+    *mic     = NULL;
+    *mic_len = 0;
+
+    major = gss_get_mic(&minor, (gss_ctx_id_t) gss_ctx, GSS_C_QOP_DEFAULT,
+                        &m, &out);
+    if (GSS_ERROR(major)) {
+        return -1;
+    }
+
+    *mic = malloc(out.length);
+    if (!*mic) {
+        gss_release_buffer(&minor, &out);
+        return -1;
+    }
+    memcpy(*mic, out.value, out.length);
+    *mic_len = out.length;
+    gss_release_buffer(&minor, &out);
+    return 0;
+} /* chimera_nfs_gss_get_mic */
+
+static int
+chimera_nfs_gss_verify_mic(
+    void       *arg,
+    void       *gss_ctx,
+    const void *msg,
+    size_t      msg_len,
+    const void *mic,
+    size_t      mic_len)
+{
+    OM_uint32       major, minor;
+    gss_qop_t       qop;
+    gss_buffer_desc m = { msg_len, (void *) msg };
+    gss_buffer_desc t = { mic_len, (void *) mic };
+
+    (void) arg;
+
+    major = gss_verify_mic(&minor, (gss_ctx_id_t) gss_ctx, &m, &t, &qop);
+    return GSS_ERROR(major) ? -1 : 0;
+} /* chimera_nfs_gss_verify_mic */
+
+static int
+chimera_nfs_gss_wrap(
+    void       *arg,
+    void       *gss_ctx,
+    const void *in,
+    size_t      in_len,
+    void      **out,
+    size_t     *out_len)
+{
+    OM_uint32       major, minor;
+    int             conf_state;
+    gss_buffer_desc i = { in_len, (void *) in };
+    gss_buffer_desc o = GSS_C_EMPTY_BUFFER;
+
+    (void) arg;
+    *out     = NULL;
+    *out_len = 0;
+
+    major = gss_wrap(&minor, (gss_ctx_id_t) gss_ctx, 1 /* conf_req */,
+                     GSS_C_QOP_DEFAULT, &i, &conf_state, &o);
+    if (GSS_ERROR(major)) {
+        return -1;
+    }
+
+    *out = malloc(o.length);
+    if (!*out) {
+        gss_release_buffer(&minor, &o);
+        return -1;
+    }
+    memcpy(*out, o.value, o.length);
+    *out_len = o.length;
+    gss_release_buffer(&minor, &o);
+    return 0;
+} /* chimera_nfs_gss_wrap */
+
+static int
+chimera_nfs_gss_unwrap(
+    void       *arg,
+    void       *gss_ctx,
+    const void *in,
+    size_t      in_len,
+    void      **out,
+    size_t     *out_len)
+{
+    OM_uint32       major, minor;
+    int             conf_state;
+    gss_qop_t       qop;
+    gss_buffer_desc i = { in_len, (void *) in };
+    gss_buffer_desc o = GSS_C_EMPTY_BUFFER;
+
+    (void) arg;
+    *out     = NULL;
+    *out_len = 0;
+
+    major = gss_unwrap(&minor, (gss_ctx_id_t) gss_ctx, &i, &o, &conf_state,
+                       &qop);
+    if (GSS_ERROR(major)) {
+        return -1;
+    }
+
+    *out = malloc(o.length);
+    if (!*out) {
+        gss_release_buffer(&minor, &o);
+        return -1;
+    }
+    memcpy(*out, o.value, o.length);
+    *out_len = o.length;
+    gss_release_buffer(&minor, &o);
+    return 0;
+} /* chimera_nfs_gss_unwrap */
+
+static void
+chimera_nfs_gss_destroy(
+    void *arg,
+    void *gss_ctx)
+{
+    OM_uint32    minor;
+    gss_ctx_id_t g = (gss_ctx_id_t) gss_ctx;
+
+    (void) arg;
+
+    if (g != GSS_C_NO_CONTEXT) {
+        gss_delete_sec_context(&minor, &g, GSS_C_NO_BUFFER);
+    }
+} /* chimera_nfs_gss_destroy */
+
+const struct evpl_rpc2_gss_provider chimera_nfs_gss_provider = {
+    .accept     = chimera_nfs_gss_accept,
+    .get_mic    = chimera_nfs_gss_get_mic,
+    .verify_mic = chimera_nfs_gss_verify_mic,
+    .wrap       = chimera_nfs_gss_wrap,
+    .unwrap     = chimera_nfs_gss_unwrap,
+    .destroy    = chimera_nfs_gss_destroy,
+};
+
+int
+chimera_nfs_gss_init(const char *keytab)
+{
+    OM_uint32 major;
+
+    if (keytab && keytab[0]) {
+        major = gsskrb5_register_acceptor_identity(keytab);
+        if (GSS_ERROR(major)) {
+            chimera_nfs_error("rpcsec_gss: failed to register keytab '%s'",
+                              keytab);
+            return -1;
+        }
+        chimera_nfs_info("rpcsec_gss: using keytab '%s'", keytab);
+    } else {
+        chimera_nfs_info("rpcsec_gss: using default keytab (KRB5_KTNAME)");
+    }
+
+    return 0;
+} /* chimera_nfs_gss_init */
+
+void
+chimera_nfs_gss_map_principal(
+    const char              *principal,
+    struct chimera_vfs_cred *cred)
+{
+    char           user[256];
+    const char    *at;
+    size_t         ulen;
+    struct passwd  pw;
+    struct passwd *result = NULL;
+    char           buf[4096];
+
+    if (!principal || !principal[0]) {
+        chimera_vfs_cred_init_anonymous(cred, CHIMERA_VFS_ANON_UID,
+                                        CHIMERA_VFS_ANON_GID);
+        return;
+    }
+
+    /* Take the primary component up to '@REALM'. */
+    at   = strchr(principal, '@');
+    ulen = at ? (size_t) (at - principal) : strlen(principal);
+    if (ulen >= sizeof(user)) {
+        ulen = sizeof(user) - 1;
+    }
+    memcpy(user, principal, ulen);
+    user[ulen] = '\0';
+
+    /*
+     * A machine/service principal ("host/h", "nfs/h", "root/h") is the
+     * credential rpc.gssd presents for the mount itself and for root's I/O on
+     * the client.  Map it to root: it is the authenticated machine identity,
+     * which is exactly the "no root squash" trust chimera already extends to
+     * AUTH_SYS by default.  (A later per-export sec/squash policy can refine
+     * this; see the export-options work.)
+     */
+    if (strchr(user, '/')) {
+        chimera_vfs_cred_init_unix(cred, 0, 0, 0, NULL);
+        return;
+    }
+
+    if (getpwnam_r(user, &pw, buf, sizeof(buf), &result) == 0 && result) {
+        chimera_vfs_cred_init_unix(cred, pw.pw_uid, pw.pw_gid, 0, NULL);
+        return;
+    }
+
+    /* A user principal with no local account squashes to anonymous. */
+    chimera_vfs_cred_init_anonymous(cred, CHIMERA_VFS_ANON_UID,
+                                    CHIMERA_VFS_ANON_GID);
+} /* chimera_nfs_gss_map_principal */

--- a/src/server/nfs/nfs_gss.h
+++ b/src/server/nfs/nfs_gss.h
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#pragma once
+
+#include "evpl/evpl_rpc2_gss.h"
+
+struct chimera_vfs_cred;
+
+/*
+ * Chimera's RPCSEC_GSS acceptor, backed by GSSAPI/Kerberos.  This implements
+ * the provider vtable that libevpl's rpc2 layer drives (see evpl_rpc2_gss.h):
+ * libevpl owns all RPC-level framing and the handshake/replay state machine,
+ * while this module wraps the actual Kerberos primitives.
+ */
+
+/*
+ * Register the keytab to accept security contexts against (process-global,
+ * via gsskrb5_register_acceptor_identity).  keytab may be NULL/empty to fall
+ * back to the KRB5_KTNAME environment variable.  Returns 0 on success.
+ * Idempotent; safe to call once per server start.
+ */
+int
+chimera_nfs_gss_init(
+    const char *keytab);
+
+/* The GSSAPI-backed RPCSEC_GSS provider vtable. */
+extern const struct evpl_rpc2_gss_provider chimera_nfs_gss_provider;
+
+/*
+ * Map an authenticated GSS principal ("user@REALM") to a VFS credential.
+ * A user principal resolves via the local password database to its uid/gid;
+ * a service/machine principal (one containing '/') or an unresolvable name
+ * is squashed to the anonymous credential.
+ */
+void
+chimera_nfs_gss_map_principal(
+    const char              *principal,
+    struct chimera_vfs_cred *cred);

--- a/src/server/nfs/nfs_mount.c
+++ b/src/server/nfs/nfs_mount.c
@@ -180,16 +180,35 @@ chimera_nfs_mount_lookup_complete(
     struct chimera_server_nfs_thread *thread = req->thread;
     struct evpl                      *evpl   = thread->evpl;
     struct chimera_server_nfs_shared *shared = thread->shared;
-    int32_t                           auth_flavors[2];
+    int32_t                           auth_flavors[3];
     struct mountres3                  res;
     int                               rc;
 
     if (error_code == CHIMERA_VFS_OK) {
-        res.fhs_status                 = MNT3_OK;
-        res.mountinfo.num_auth_flavors = 2;
+        const struct chimera_nfs_export *export =
+            chimera_nfs_get_export_by_id(shared, req->export_id);
+        uint32_t                         sec = export ? export->sec_allowed : 0;
+        int                              nf  = 0;
+
+        res.fhs_status = MNT3_OK;
+
+        /* Advertise the export's allowed flavors.  MOUNT carries bare flavor
+         * numbers, so krb5/krb5i/krb5p collapse to RPCSEC_GSS (6).  An export
+         * with no explicit policy keeps the historical [AUTH_NONE, AUTH_SYS]. */
+        if (sec == 0) {
+            auth_flavors[nf++] = AUTH_NONE;
+            auth_flavors[nf++] = AUTH_SYS;
+        } else {
+            if (sec & CHIMERA_NFS_SEC_SYS) {
+                auth_flavors[nf++] = AUTH_SYS;
+            }
+            if (sec & (CHIMERA_NFS_SEC_KRB5 | CHIMERA_NFS_SEC_KRB5I |
+                       CHIMERA_NFS_SEC_KRB5P)) {
+                auth_flavors[nf++] = 6;   /* RPCSEC_GSS */
+            }
+        }
+        res.mountinfo.num_auth_flavors = nf;
         res.mountinfo.auth_flavors     = auth_flavors;
-        auth_flavors[0]                = AUTH_NONE;
-        auth_flavors[1]                = AUTH_SYS;
 
         uint8_t wire[CHIMERA_NFS_FH_MAX];
         int     wirelen;

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -42,6 +42,11 @@ struct chimera_server_config_smb_auth {
     char kerberos_realm[256];
 };
 
+struct chimera_server_config_nfs_auth {
+    int  kerberos_enabled;       /* enable RPCSEC_GSS (sec=krb5) on the NFS server */
+    char kerberos_keytab[256];   /* keytab path; empty => KRB5_KTNAME default */
+};
+
 struct chimera_server_config {
     int                                   nfs_rdma;
     int                                   nfs_rdma_port;
@@ -104,6 +109,7 @@ struct chimera_server_config {
     struct chimera_vfs_module_cfg         modules[CHIMERA_SERVER_MAX_MODULES];
     struct chimera_server_config_smb_nic  smb_nic_info[16];
     struct chimera_server_config_smb_auth smb_auth;
+    struct chimera_server_config_nfs_auth nfs_auth;
     int                                   pnfs_enabled;
     int                                   pnfs_num_ds;
     struct chimera_server_config_pnfs_ds {
@@ -229,6 +235,8 @@ chimera_server_config_init(void)
     config->smb_auth.winbind_domain[0]  = '\0';
     config->smb_auth.kerberos_keytab[0] = '\0';
     config->smb_auth.kerberos_realm[0]  = '\0';
+    config->nfs_auth.kerberos_enabled   = 0;
+    config->nfs_auth.kerberos_keytab[0] = '\0';
 
     config->anonuid = 65534;
     config->anongid = 65534;
@@ -2588,6 +2596,35 @@ chimera_server_config_get_smb_kerberos_keytab(const struct chimera_server_config
 {
     return config->smb_auth.kerberos_keytab;
 } /* chimera_server_config_get_smb_kerberos_keytab */
+
+SYMBOL_EXPORT void
+chimera_server_config_set_nfs_kerberos_enabled(
+    struct chimera_server_config *config,
+    int                           enabled)
+{
+    config->nfs_auth.kerberos_enabled = enabled;
+} /* chimera_server_config_set_nfs_kerberos_enabled */
+
+SYMBOL_EXPORT int
+chimera_server_config_get_nfs_kerberos_enabled(const struct chimera_server_config *config)
+{
+    return config->nfs_auth.kerberos_enabled;
+} /* chimera_server_config_get_nfs_kerberos_enabled */
+
+SYMBOL_EXPORT void
+chimera_server_config_set_nfs_kerberos_keytab(
+    struct chimera_server_config *config,
+    const char                   *keytab)
+{
+    strncpy(config->nfs_auth.kerberos_keytab, keytab,
+            sizeof(config->nfs_auth.kerberos_keytab) - 1);
+} /* chimera_server_config_set_nfs_kerberos_keytab */
+
+SYMBOL_EXPORT const char *
+chimera_server_config_get_nfs_kerberos_keytab(const struct chimera_server_config *config)
+{
+    return config->nfs_auth.kerberos_keytab;
+} /* chimera_server_config_get_nfs_kerberos_keytab */
 
 SYMBOL_EXPORT void
 chimera_server_config_set_smb_kerberos_realm(

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -2041,6 +2041,19 @@ chimera_server_export_set_options(
                                           squash, anonuid, anongid);
 } /* chimera_server_export_set_options */
 
+SYMBOL_EXPORT int
+chimera_server_export_set_sec(
+    struct chimera_server *server,
+    const char            *name,
+    uint32_t               sec_allowed)
+{
+    if (!server->nfs_shared) {
+        return -1;
+    }
+
+    return chimera_nfs_export_set_sec(server->nfs_shared, name, sec_allowed);
+} /* chimera_server_export_set_sec */
+
 static void
 chimera_server_thread_shutdown(
     struct evpl *evpl,

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -824,6 +824,24 @@ chimera_server_config_get_smb_kerberos_keytab(
     const struct chimera_server_config *config);
 
 void
+chimera_server_config_set_nfs_kerberos_enabled(
+    struct chimera_server_config *config,
+    int                           enabled);
+
+int
+chimera_server_config_get_nfs_kerberos_enabled(
+    const struct chimera_server_config *config);
+
+void
+chimera_server_config_set_nfs_kerberos_keytab(
+    struct chimera_server_config *config,
+    const char                   *keytab);
+
+const char *
+chimera_server_config_get_nfs_kerberos_keytab(
+    const struct chimera_server_config *config);
+
+void
 chimera_server_config_set_smb_kerberos_realm(
     struct chimera_server_config *config,
     const char                   *realm);

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -666,6 +666,12 @@ chimera_server_export_set_options(
     uint32_t               anonuid,
     uint32_t               anongid);
 
+int
+chimera_server_export_set_sec(
+    struct chimera_server *server,
+    const char            *name,
+    uint32_t               sec_allowed);
+
 struct chimera_server *
 chimera_server_init(
     const struct chimera_server_config *config,


### PR DESCRIPTION
## Summary

Adds **RPCSEC_GSS / Kerberos** authentication to the chimera NFS server, a
**per-export `sec=` policy** with NFSv4 SECINFO advertising, and
**SP4_MACH_CRED** NFSv4.1 state protection — the first consumer of the new
cryptographic identity.

Chimera previously authenticated only with `AUTH_NONE`/`AUTH_SYS`. This brings
real, cryptographic client identity (`sec=krb5`, `sec=krb5i`) and lets NFSv4.1
clients bind state-management operations to a verified machine credential.

Pairs with the already-merged libevpl RPCSEC_GSS framing
(chimera-nas/libevpl#108); the submodule bump to that merge is the first commit.

## What's included

- **RPCSEC_GSS server (krb5 + krb5i).** A GSSAPI acceptor provider
  (`src/server/nfs/nfs_gss.c`) plugged into libevpl's krb5-free provider vtable.
  Context establishment over the NULL proc, per-request MIC verify, sequence
  replay window, and krb5i integrity wrap/unwrap. krb5p (privacy) is rejected
  as `AUTH_TOOWEAK` (not implemented). Principal → uid/gid mapping
  (`user@REALM` via getpwnam; machine principals → root; unresolved → anon).
- **Per-export `sec=` policy.** `sec` array in export config
  (`sys`/`krb5`/`krb5i`/`krb5p`), enforced on every request via the
  export-id-in-filehandle infrastructure; disallowed flavor →
  `NFS4ERR_WRONGSEC` (NFSv4) at PUTFH and the pseudo-fs boundary. SECINFO /
  SECINFO_NO_NAME and MOUNT advertise the export's flavors.
- **SP4_MACH_CRED.** EXCHANGE_ID negotiates the scheme and echoes the
  enforced-op bitmap; EXCHANGE_ID / CREATE_SESSION / BIND_CONN_TO_SESSION /
  DESTROY_SESSION / DESTROY_CLIENTID verify the bound machine principal,
  returning `NFS4ERR_WRONG_CRED` on mismatch. Zero effect on SP4_NONE clients.

## Testing

Netns-isolated MIT-KDC harness plus a real Linux NFS client in KVM:

- `scripts/nfs_kerberos_test_wrapper.sh` — netns + KDC + chimera nfs_auth + pynfs 4.1.
- `kvm/kvm_nfs_kerberos_test_wrapper.sh` — host KDC + 9p keytab/krb5.conf hand-off,
  `rpc.gssd`, real `mount -o vers=4.1,sec=krb5` (kvm-test-base v1.9.0).
- ctests: `pynfs/kerberos/krb5_smoke`, `sec_krb5only_allow`, `sec_krb5only_deny_sys`,
  `kvm/kerberos/krb5_mount` (3 guest images). All green; pynfs unmodified.

The Linux kernel client negotiates SP4_MACH_CRED on `sec=krb5` NFSv4.1 and RW
I/O works (positive enforcement confirmed). `make check` clean (syntax,
reuse-lint, copyright, release/debug build+test, clang scan-build, ASan pynfs
4.0/4.1/4.2).

## Notes

- `sec=sys` remains the default and SP4_NONE clients hit no new gates — no
  regression to existing pynfs/cthon/KVM suites.
- libevpl stays krb5-free; all GSS crypto lives in chimera behind the provider
  vtable.
