### PR TITLE
Implement NFSv4.2 READ_PLUS, IO_ADVISE, WRITE_SAME, CLONE (#407-#410)

### DIFF
--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -8,7 +8,7 @@ add_library(chimera_client SHARED client.c client_dispatch.c
             client_symlink.c client_link.c client_remove.c client_rename.c
             client_readlink.c client_stat.c client_fstat.c client_readdir.c client_statfs.c
             client_fstatfs.c client_commit.c client_ftruncate.c
-            client_copy_range.c client_clone_range.c)
+            client_copy_range.c client_clone_range.c client_write_same.c)
 target_link_libraries(chimera_client chimera_vfs evpl prometheus-c jansson)
 
 install(TARGETS chimera_client DESTINATION lib)

--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -9,7 +9,7 @@ add_library(chimera_client SHARED client.c client_dispatch.c
             client_symlink.c client_link.c client_remove.c client_rename.c
             client_readlink.c client_stat.c client_fstat.c client_readdir.c client_statfs.c
             client_fstatfs.c client_commit.c client_ftruncate.c
-            client_copy_range.c client_clone_range.c)
+            client_copy_range.c client_clone_range.c client_write_same.c)
 target_link_libraries(chimera_client chimera_vfs evpl prometheus-c)
 
 install(TARGETS chimera_client DESTINATION lib)

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -264,6 +264,29 @@ chimera_copy_range(
     chimera_copy_range_callback_t   callback,
     void                           *private_data);
 
+typedef void (*chimera_write_same_callback_t)(
+    struct chimera_client_thread *thread,
+    enum chimera_vfs_error        status,
+    uint64_t                      bytes_written,
+    void                         *private_data);
+
+/* NFSv4.2 WRITE_SAME: write `block_count` blocks of `block_size` bytes from
+ * `offset`, each zero-filled with `pattern` placed at `reloff_pattern`.
+ * Requires CHIMERA_VFS_CAP_WRITE_SAME on the backend; ENOTSUP otherwise.
+ */
+void
+chimera_write_same(
+    struct chimera_client_thread   *thread,
+    struct chimera_vfs_open_handle *handle,
+    uint64_t                        offset,
+    uint32_t                        block_size,
+    uint64_t                        block_count,
+    const void                     *pattern,
+    uint32_t                        pattern_len,
+    uint32_t                        reloff_pattern,
+    chimera_write_same_callback_t   callback,
+    void                           *private_data);
+
 typedef void (*chimera_clone_range_callback_t)(
     struct chimera_client_thread *thread,
     enum chimera_vfs_error        status,

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -294,6 +294,29 @@ chimera_copy_range(
     chimera_copy_range_callback_t   callback,
     void                           *private_data);
 
+typedef void (*chimera_write_same_callback_t)(
+    struct chimera_client_thread *thread,
+    enum chimera_vfs_error        status,
+    uint64_t                      bytes_written,
+    void                         *private_data);
+
+/* NFSv4.2 WRITE_SAME: write `block_count` blocks of `block_size` bytes from
+ * `offset`, each zero-filled with `pattern` placed at `reloff_pattern`.
+ * Requires CHIMERA_VFS_CAP_WRITE_SAME on the backend; ENOTSUP otherwise.
+ */
+void
+chimera_write_same(
+    struct chimera_client_thread   *thread,
+    struct chimera_vfs_open_handle *handle,
+    uint64_t                        offset,
+    uint32_t                        block_size,
+    uint64_t                        block_count,
+    const void                     *pattern,
+    uint32_t                        pattern_len,
+    uint32_t                        reloff_pattern,
+    chimera_write_same_callback_t   callback,
+    void                           *private_data);
+
 typedef void (*chimera_clone_range_callback_t)(
     struct chimera_client_thread *thread,
     enum chimera_vfs_error        status,

--- a/src/client/client_internal.h
+++ b/src/client/client_internal.h
@@ -57,6 +57,7 @@ enum chimera_client_request_opcode {
     CHIMERA_CLIENT_OP_CLONE_RANGE,
     CHIMERA_CLIENT_OP_ALLOCATE,
     CHIMERA_CLIENT_OP_SEEK,
+    CHIMERA_CLIENT_OP_WRITE_SAME,
 };
 
 struct chimera_client_request;
@@ -413,6 +414,18 @@ struct chimera_client_request {
             uint16_t                        r_acl_aces;
             char                            path[CHIMERA_VFS_PATH_MAX];
         } getacl;
+
+        struct {
+            struct chimera_vfs_open_handle *handle;
+            uint64_t                        offset;
+            uint32_t                        block_size;
+            uint64_t                        block_count;
+            const void                     *pattern;
+            uint32_t                        pattern_len;
+            uint32_t                        reloff_pattern;
+            chimera_write_same_callback_t   callback;
+            void                           *private_data;
+        } write_same;
     };
 } __attribute__((aligned(64)));
 

--- a/src/client/client_internal.h
+++ b/src/client/client_internal.h
@@ -59,6 +59,7 @@ enum chimera_client_request_opcode {
     CHIMERA_CLIENT_OP_CLONE_RANGE,
     CHIMERA_CLIENT_OP_ALLOCATE,
     CHIMERA_CLIENT_OP_SEEK,
+    CHIMERA_CLIENT_OP_WRITE_SAME,
 };
 
 struct chimera_client_request;
@@ -436,6 +437,18 @@ struct chimera_client_request {
             uint16_t                        r_acl_aces;
             char                            path[CHIMERA_VFS_PATH_MAX];
         } getacl;
+
+        struct {
+            struct chimera_vfs_open_handle *handle;
+            uint64_t                        offset;
+            uint32_t                        block_size;
+            uint64_t                        block_count;
+            const void                     *pattern;
+            uint32_t                        pattern_len;
+            uint32_t                        reloff_pattern;
+            chimera_write_same_callback_t   callback;
+            void                           *private_data;
+        } write_same;
     };
 } __attribute__((aligned(64)));
 

--- a/src/client/client_write_same.c
+++ b/src/client/client_write_same.c
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "client_write_same.h"
+
+SYMBOL_EXPORT void
+chimera_write_same(
+    struct chimera_client_thread   *thread,
+    struct chimera_vfs_open_handle *handle,
+    uint64_t                        offset,
+    uint32_t                        block_size,
+    uint64_t                        block_count,
+    const void                     *pattern,
+    uint32_t                        pattern_len,
+    uint32_t                        reloff_pattern,
+    chimera_write_same_callback_t   callback,
+    void                           *private_data)
+{
+    struct chimera_client_request *request;
+
+    request = chimera_client_request_alloc(thread);
+
+    request->opcode                    = CHIMERA_CLIENT_OP_WRITE_SAME;
+    request->write_same.handle         = handle;
+    request->write_same.offset         = offset;
+    request->write_same.block_size     = block_size;
+    request->write_same.block_count    = block_count;
+    request->write_same.pattern        = pattern;
+    request->write_same.pattern_len    = pattern_len;
+    request->write_same.reloff_pattern = reloff_pattern;
+    request->write_same.callback       = callback;
+    request->write_same.private_data   = private_data;
+
+    chimera_dispatch_write_same(thread, request);
+} /* chimera_write_same */

--- a/src/client/client_write_same.h
+++ b/src/client/client_write_same.h
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#pragma once
+
+#include "client_internal.h"
+#include "vfs/vfs_procs.h"
+
+static void
+chimera_write_same_complete(
+    enum chimera_vfs_error    error_code,
+    uint64_t                  count,
+    uint32_t                  sync,
+    struct chimera_vfs_attrs *pre_attr,
+    struct chimera_vfs_attrs *post_attr,
+    void                     *private_data)
+{
+    struct chimera_client_request *request        = private_data;
+    struct chimera_client_thread  *client_thread  = request->thread;
+    chimera_write_same_callback_t  callback       = request->write_same.callback;
+    void                          *callback_arg   = request->write_same.private_data;
+    int                            heap_allocated = request->heap_allocated;
+
+    (void) sync;
+    (void) pre_attr;
+    (void) post_attr;
+
+    if (heap_allocated) {
+        chimera_client_request_free(client_thread, request);
+    }
+
+    callback(client_thread, error_code, count, callback_arg);
+} /* chimera_write_same_complete */
+
+static inline void
+chimera_dispatch_write_same(
+    struct chimera_client_thread  *thread,
+    struct chimera_client_request *request)
+{
+    chimera_vfs_write_same(
+        thread->vfs_thread,
+        chimera_client_req_cred(request),
+        request->write_same.handle,
+        request->write_same.offset,
+        request->write_same.block_size,
+        request->write_same.block_count,
+        request->write_same.pattern,
+        request->write_same.pattern_len,
+        request->write_same.reloff_pattern,
+        CHIMERA_VFS_WRITE_FILESYNC,
+        0,
+        0,
+        chimera_write_same_complete,
+        request);
+} /* chimera_dispatch_write_same */

--- a/src/posix/CMakeLists.txt
+++ b/src/posix/CMakeLists.txt
@@ -76,7 +76,8 @@ add_library(chimera_posix SHARED
             posix_fdopen.c
             posix_statfs.c
             posix_copy_file_range.c
-            posix_clone_file_range.c)
+            posix_clone_file_range.c
+            posix_write_same.c)
 
 target_link_libraries(chimera_posix chimera_client evpl pthread)
 

--- a/src/posix/CMakeLists.txt
+++ b/src/posix/CMakeLists.txt
@@ -78,7 +78,8 @@ add_library(chimera_posix SHARED
             posix_fdopen.c
             posix_statfs.c
             posix_copy_file_range.c
-            posix_clone_file_range.c)
+            posix_clone_file_range.c
+            posix_write_same.c)
 
 target_link_libraries(chimera_posix chimera_client evpl)
 

--- a/src/posix/posix.h
+++ b/src/posix/posix.h
@@ -650,6 +650,20 @@ chimera_posix_clone_file_range(
     off_t  src_offset,
     size_t len);
 
+// NFSv4.2 WRITE_SAME: write block_count blocks of block_size bytes from offset,
+// each zero-filled with `pattern` placed at reloff_pattern. Backend must
+// advertise CHIMERA_VFS_CAP_WRITE_SAME; otherwise returns -1 errno=EOPNOTSUPP.
+// Returns the number of bytes written (block_size * block_count) or -1.
+ssize_t
+chimera_posix_write_same(
+    int         fd,
+    off_t       offset,
+    uint32_t    block_size,
+    uint64_t    block_count,
+    const void *pattern,
+    uint32_t    pattern_len,
+    uint32_t    reloff_pattern);
+
 // Sync functions
 int
 chimera_posix_fsync(

--- a/src/posix/posix.h
+++ b/src/posix/posix.h
@@ -669,6 +669,20 @@ chimera_posix_clone_file_range(
     off_t  src_offset,
     size_t len);
 
+// NFSv4.2 WRITE_SAME: write block_count blocks of block_size bytes from offset,
+// each zero-filled with `pattern` placed at reloff_pattern. Backend must
+// advertise CHIMERA_VFS_CAP_WRITE_SAME; otherwise returns -1 errno=EOPNOTSUPP.
+// Returns the number of bytes written (block_size * block_count) or -1.
+ssize_t
+chimera_posix_write_same(
+    int         fd,
+    off_t       offset,
+    uint32_t    block_size,
+    uint64_t    block_count,
+    const void *pattern,
+    uint32_t    pattern_len,
+    uint32_t    reloff_pattern);
+
 // Sync functions
 int
 chimera_posix_fsync(

--- a/src/posix/posix_write_same.c
+++ b/src/posix/posix_write_same.c
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include <errno.h>
+
+#include "posix_internal.h"
+#include "../client/client_write_same.h"
+
+struct chimera_posix_write_same_state {
+    struct chimera_posix_completion comp;
+    uint64_t                        bytes_written;
+};
+
+static void
+chimera_posix_write_same_callback(
+    struct chimera_client_thread *thread,
+    enum chimera_vfs_error        status,
+    uint64_t                      bytes_written,
+    void                         *private_data)
+{
+    struct chimera_posix_write_same_state *st = private_data;
+
+    (void) thread;
+    st->bytes_written = bytes_written;
+    chimera_posix_complete(&st->comp, status);
+} /* chimera_posix_write_same_callback */
+
+static void
+chimera_posix_write_same_exec(
+    struct chimera_client_thread  *thread,
+    struct chimera_client_request *request)
+{
+    chimera_dispatch_write_same(thread, request);
+} /* chimera_posix_write_same_exec */
+
+SYMBOL_EXPORT ssize_t
+chimera_posix_write_same(
+    int         fd,
+    off_t       offset,
+    uint32_t    block_size,
+    uint64_t    block_count,
+    const void *pattern,
+    uint32_t    pattern_len,
+    uint32_t    reloff_pattern)
+{
+    struct chimera_posix_client          *posix  = chimera_posix_get_global();
+    struct chimera_posix_worker          *worker = chimera_posix_choose_worker(posix);
+    struct chimera_posix_fd_entry        *entry;
+    struct chimera_client_request         req;
+    struct chimera_posix_write_same_state st;
+
+    entry = chimera_posix_fd_acquire(posix, fd, 0);
+    if (!entry) {
+        return -1;
+    }
+
+    chimera_posix_completion_init(&st.comp, &req);
+    st.bytes_written = 0;
+
+    req.opcode                    = CHIMERA_CLIENT_OP_WRITE_SAME;
+    req.write_same.handle         = entry->handle;
+    req.write_same.offset         = (uint64_t) offset;
+    req.write_same.block_size     = block_size;
+    req.write_same.block_count    = block_count;
+    req.write_same.pattern        = pattern;
+    req.write_same.pattern_len    = pattern_len;
+    req.write_same.reloff_pattern = reloff_pattern;
+    req.write_same.callback       = chimera_posix_write_same_callback;
+    req.write_same.private_data   = &st;
+
+    chimera_posix_worker_enqueue(worker, &req, chimera_posix_write_same_exec);
+
+    int err = chimera_posix_wait(&st.comp);
+
+    chimera_posix_fd_release(entry, 0);
+    chimera_posix_completion_destroy(&st.comp);
+
+    if (err) {
+        errno = err;
+        return -1;
+    }
+
+    return (ssize_t) st.bytes_written;
+} /* chimera_posix_write_same */

--- a/src/posix/tests/CMakeLists.txt
+++ b/src/posix/tests/CMakeLists.txt
@@ -71,6 +71,7 @@ set(POSIX_TEST_PROGRAMS
     test_dup
     test_fdopen
     test_copy_range
+    test_write_same
 )
 
 # Create test programs

--- a/src/posix/tests/CMakeLists.txt
+++ b/src/posix/tests/CMakeLists.txt
@@ -99,6 +99,7 @@ set(POSIX_TEST_PROGRAMS
     test_dup
     test_fdopen
     test_copy_range
+    test_write_same
 )
 
 # Create test programs

--- a/src/posix/tests/test_copy_range.c
+++ b/src/posix/tests/test_copy_range.c
@@ -357,6 +357,75 @@ test_clone_content(void)
     fprintf(stderr, "  clone content + COW passed\n");
 } /* test_clone_content */
 
+/* Clone, then unlink the source: the destination must keep the (now sole-owned)
+ * data, and a write to it must still succeed.  Exercises the refcount-decrement
+ * free path on the unlinked source's shared extents. */
+static void
+test_clone_unlink(void)
+{
+    char   *src_buf;
+    char   *over;
+    char   *verify;
+    int     src_fd, dst_fd, rc;
+    ssize_t n;
+
+    fprintf(stderr, "Testing clone then unlink source (refcount free path)...\n");
+
+    src_buf = malloc(CLONE_PROBE_LEN);
+    over    = malloc(CLONE_PROBE_LEN);
+    verify  = malloc(CLONE_PROBE_LEN);
+    if (!src_buf || !over || !verify) {
+        die("clone_unlink malloc", -1);
+    }
+    fill_pattern(src_buf, CLONE_PROBE_LEN, 'm');
+    fill_pattern(over, CLONE_PROBE_LEN, 'n');
+
+    src_fd = chimera_posix_open("/test/clone_ul_src", O_CREAT | O_RDWR | O_TRUNC, 0644);
+    dst_fd = chimera_posix_open("/test/clone_ul_dst", O_CREAT | O_RDWR | O_TRUNC, 0644);
+    if (src_fd < 0 || dst_fd < 0) {
+        die("clone_unlink open", -1);
+    }
+
+    n = chimera_posix_pwrite(src_fd, src_buf, CLONE_PROBE_LEN, 0);
+    if (n != CLONE_PROBE_LEN) {
+        die("clone_unlink pwrite", n);
+    }
+
+    rc = chimera_posix_clone_file_range(dst_fd, 0, src_fd, 0, CLONE_PROBE_LEN);
+    if (rc != 0) {
+        die("clone_unlink clone", rc);
+    }
+
+    /* Unlink + close the source; its shared extents must decrement, not free. */
+    chimera_posix_close(src_fd);
+    if (chimera_posix_unlink("/test/clone_ul_src") != 0) {
+        die("clone_unlink unlink", -1);
+    }
+
+    /* Destination still reads the cloned data... */
+    n = chimera_posix_pread(dst_fd, verify, CLONE_PROBE_LEN, 0);
+    if (n != CLONE_PROBE_LEN || memcmp(src_buf, verify, CLONE_PROBE_LEN) != 0) {
+        die("clone_unlink dst data lost after src unlink", n);
+    }
+
+    /* ...and remains writable (it is now the sole owner). */
+    n = chimera_posix_pwrite(dst_fd, over, CLONE_PROBE_LEN, 0);
+    if (n != CLONE_PROBE_LEN) {
+        die("clone_unlink dst rewrite", n);
+    }
+    n = chimera_posix_pread(dst_fd, verify, CLONE_PROBE_LEN, 0);
+    if (n != CLONE_PROBE_LEN || memcmp(over, verify, CLONE_PROBE_LEN) != 0) {
+        die("clone_unlink dst rewrite mismatch", n);
+    }
+
+    chimera_posix_close(dst_fd);
+    free(src_buf);
+    free(over);
+    free(verify);
+
+    fprintf(stderr, "  clone-then-unlink passed\n");
+} /* test_clone_unlink */
+
 static void
 test_clone_unsupported(void)
 {
@@ -421,6 +490,7 @@ main(
         fprintf(stderr, "Backend '%s' supports clone_file_range - validating content\n",
                 env.backend);
         test_clone_content();
+        test_clone_unlink();
     } else {
         fprintf(stderr, "Backend '%s' does not advertise CAP_CLONE_RANGE - "
                 "verifying ENOTSUP path\n", env.backend);

--- a/src/posix/tests/test_copy_range.c
+++ b/src/posix/tests/test_copy_range.c
@@ -357,6 +357,201 @@ test_clone_content(void)
     fprintf(stderr, "  clone content + COW passed\n");
 } /* test_clone_content */
 
+/* Clone onto a destination that ALREADY has data in the target range.  The
+ * backend must release what is there before recording the shared extent;
+ * diskfs inserted over the live key and the request never completed, which is
+ * what every smbtorture smb2.ioctl.dup_extents_* case does (they write the
+ * destination first) and what hung them for 600s. */
+static void
+test_clone_over_existing(void)
+{
+    char   *src_buf;
+    char   *dst_buf;
+    char   *verify;
+    int     src_fd, dst_fd, rc;
+    ssize_t n;
+
+    fprintf(stderr, "Testing clone_file_range over existing destination data...\n");
+
+    src_buf = malloc(CLONE_PROBE_LEN);
+    dst_buf = malloc(CLONE_PROBE_LEN);
+    verify  = malloc(CLONE_PROBE_LEN);
+    if (!src_buf || !dst_buf || !verify) {
+        die("clone over malloc", -1);
+    }
+
+    fill_pattern(src_buf, CLONE_PROBE_LEN, 'p');
+    fill_pattern(dst_buf, CLONE_PROBE_LEN, 'q');
+
+    src_fd = chimera_posix_open("/test/clone_ov_src", O_CREAT | O_RDWR | O_TRUNC, 0644);
+    dst_fd = chimera_posix_open("/test/clone_ov_dst", O_CREAT | O_RDWR | O_TRUNC, 0644);
+    if (src_fd < 0 || dst_fd < 0) {
+        die("clone over open", -1);
+    }
+
+    if (chimera_posix_pwrite(src_fd, src_buf, CLONE_PROBE_LEN, 0) != CLONE_PROBE_LEN ||
+        chimera_posix_pwrite(dst_fd, dst_buf, CLONE_PROBE_LEN, 0) != CLONE_PROBE_LEN) {
+        die("clone over seed", -1);
+    }
+
+    rc = chimera_posix_clone_file_range(dst_fd, 0, src_fd, 0, CLONE_PROBE_LEN);
+    if (rc != 0) {
+        die("clone over clone_file_range", rc);
+    }
+
+    n = chimera_posix_pread(dst_fd, verify, CLONE_PROBE_LEN, 0);
+    if (n != CLONE_PROBE_LEN || memcmp(src_buf, verify, CLONE_PROBE_LEN) != 0) {
+        die("clone over content mismatch", n);
+    }
+
+    /* The displaced destination data is gone, and CoW still isolates the two. */
+    n = chimera_posix_pwrite(dst_fd, dst_buf, CLONE_PROBE_LEN, 0);
+    if (n != CLONE_PROBE_LEN) {
+        die("clone over rewrite dst", n);
+    }
+
+    n = chimera_posix_pread(src_fd, verify, CLONE_PROBE_LEN, 0);
+    if (n != CLONE_PROBE_LEN || memcmp(src_buf, verify, CLONE_PROBE_LEN) != 0) {
+        die("clone over src disturbed", n);
+    }
+
+    chimera_posix_close(src_fd);
+    chimera_posix_close(dst_fd);
+    free(src_buf);
+    free(dst_buf);
+    free(verify);
+
+    /* Spans case: one destination extent strictly larger than the clone range
+     * on BOTH sides.  Clearing must reinsert the head AND the tail -- dropping
+     * either silently loses that data. */
+    {
+        int   big_fd;
+        char *big = malloc(CLONE_PROBE_LEN * 3);
+        char *chk = malloc(CLONE_PROBE_LEN * 3);
+
+        if (!big || !chk) {
+            die("clone spans malloc", -1);
+        }
+        fill_pattern(big, CLONE_PROBE_LEN * 3, 'r');
+
+        big_fd = chimera_posix_open("/test/clone_spans", O_CREAT | O_RDWR | O_TRUNC, 0644);
+        src_fd = chimera_posix_open("/test/clone_spans_src", O_CREAT | O_RDWR | O_TRUNC, 0644);
+        if (big_fd < 0 || src_fd < 0) {
+            die("clone spans open", -1);
+        }
+
+        src_buf = malloc(CLONE_PROBE_LEN);
+        if (!src_buf) {
+            die("clone spans malloc2", -1);
+        }
+        fill_pattern(src_buf, CLONE_PROBE_LEN, 's');
+
+        if (chimera_posix_pwrite(big_fd, big, CLONE_PROBE_LEN * 3, 0) != CLONE_PROBE_LEN * 3 ||
+            chimera_posix_pwrite(src_fd, src_buf, CLONE_PROBE_LEN, 0) != CLONE_PROBE_LEN) {
+            die("clone spans seed", -1);
+        }
+
+        /* Clone into the MIDDLE third. */
+        if (chimera_posix_clone_file_range(big_fd, CLONE_PROBE_LEN, src_fd, 0,
+                                           CLONE_PROBE_LEN) != 0) {
+            die("clone spans clone_file_range", -1);
+        }
+
+        if (chimera_posix_pread(big_fd, chk, CLONE_PROBE_LEN * 3, 0) != CLONE_PROBE_LEN * 3) {
+            die("clone spans pread", -1);
+        }
+        /* Head and tail thirds must survive untouched; the middle is the clone. */
+        if (memcmp(chk, big, CLONE_PROBE_LEN) != 0) {
+            die("clone spans head lost", -1);
+        }
+        if (memcmp(chk + CLONE_PROBE_LEN, src_buf, CLONE_PROBE_LEN) != 0) {
+            die("clone spans middle wrong", -1);
+        }
+        if (memcmp(chk + 2 * CLONE_PROBE_LEN, big, CLONE_PROBE_LEN) != 0) {
+            die("clone spans tail lost", -1);
+        }
+
+        chimera_posix_close(big_fd);
+        chimera_posix_close(src_fd);
+        free(big);
+        free(chk);
+        free(src_buf);
+        fprintf(stderr, "  clone spanning an existing extent passed\n");
+    }
+
+    fprintf(stderr, "  clone over existing destination passed\n");
+} /* test_clone_over_existing */
+
+/* Clone a range of a file onto a DISJOINT range of the SAME file.  One inode
+ * on both ends, which the backend must handle without taking that inode's lock
+ * twice -- diskfs deadlocked here and the request never completed, surfacing
+ * as a 600s timeout in smb2.ioctl.dup_extents_src_is_dest (SMB2's
+ * FSCTL_DUPLICATE_EXTENTS_TO_FILE permits a self-clone as long as the ranges
+ * do not overlap). */
+static void
+test_clone_self(void)
+{
+    char   *src_buf;
+    char   *verify;
+    int     fd;
+    ssize_t n;
+    int     rc;
+
+    fprintf(stderr, "Testing clone_file_range onto the same file...\n");
+
+    src_buf = malloc(CLONE_PROBE_LEN);
+    verify  = malloc(CLONE_PROBE_LEN);
+    if (!src_buf || !verify) {
+        die("clone self malloc", -1);
+    }
+
+    fill_pattern(src_buf, CLONE_PROBE_LEN, 'k');
+
+    fd = chimera_posix_open("/test/clone_self", O_CREAT | O_RDWR | O_TRUNC, 0644);
+    if (fd < 0) {
+        die("clone self open", -1);
+    }
+
+    /* Seed [0, LEN) and reserve [LEN, 2*LEN) so the destination range exists. */
+    n = chimera_posix_pwrite(fd, src_buf, CLONE_PROBE_LEN, 0);
+    if (n != CLONE_PROBE_LEN) {
+        die("clone self pwrite", n);
+    }
+
+    /* Seed the destination range too, so the clone lands ON an existing
+     * extent: the destination must be cleared before the shared extent is
+     * recorded there. */
+    fill_pattern(verify, CLONE_PROBE_LEN, 'm');
+    n = chimera_posix_pwrite(fd, verify, CLONE_PROBE_LEN, CLONE_PROBE_LEN);
+    if (n != CLONE_PROBE_LEN) {
+        die("clone self pwrite tail", n);
+    }
+
+    /* [0, LEN) -> [LEN, 2*LEN): disjoint, same inode.  Must not hang. */
+    rc = chimera_posix_clone_file_range(fd, CLONE_PROBE_LEN, fd, 0,
+                                        CLONE_PROBE_LEN);
+    if (rc != 0) {
+        die("clone self clone_file_range", rc);
+    }
+
+    n = chimera_posix_pread(fd, verify, CLONE_PROBE_LEN, CLONE_PROBE_LEN);
+    if (n != CLONE_PROBE_LEN || memcmp(src_buf, verify, CLONE_PROBE_LEN) != 0) {
+        die("clone self content mismatch", n);
+    }
+
+    /* The source half is untouched. */
+    n = chimera_posix_pread(fd, verify, CLONE_PROBE_LEN, 0);
+    if (n != CLONE_PROBE_LEN || memcmp(src_buf, verify, CLONE_PROBE_LEN) != 0) {
+        die("clone self source disturbed", n);
+    }
+
+    chimera_posix_close(fd);
+    free(src_buf);
+    free(verify);
+
+    fprintf(stderr, "  clone onto the same file passed\n");
+} /* test_clone_self */
+
 /* Clone, then unlink the source: the destination must keep the (now sole-owned)
  * data, and a write to it must still succeed.  Exercises the refcount-decrement
  * free path on the unlinked source's shared extents. */
@@ -490,6 +685,8 @@ main(
         fprintf(stderr, "Backend '%s' supports clone_file_range - validating content\n",
                 env.backend);
         test_clone_content();
+        test_clone_self();
+        test_clone_over_existing();
         test_clone_unlink();
     } else {
         fprintf(stderr, "Backend '%s' does not advertise CAP_CLONE_RANGE - "

--- a/src/posix/tests/test_write_same.c
+++ b/src/posix/tests/test_write_same.c
@@ -1,0 +1,288 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Tests for chimera_posix_write_same (NFSv4.2 WRITE_SAME / Application Data
+ * Block expansion).  memfs and diskfs advertise CHIMERA_VFS_CAP_WRITE_SAME; the
+ * other backends return ENOTSUP at the cap gate, in which case the test only
+ * asserts the clean ENOTSUP path. */
+
+#include "posix_test_common.h"
+
+static struct posix_test_env *g_env;
+
+static const char             PATTERN[] = "WXYZ"; /* 4-byte pattern */
+#define PATLEN     4
+#define RELOFF     8
+#define BLOCK_SIZE 512
+#define BLOCK_CNT  16
+#define TOTAL      (BLOCK_SIZE * BLOCK_CNT)
+
+static void
+die(
+    const char *what,
+    ssize_t     n)
+{
+    fprintf(stderr, "%s: ret=%zd errno=%s\n", what, n, strerror(errno));
+    posix_test_fail(g_env);
+} /* die */
+
+/* Expected byte at absolute file offset `off` for the ADB written at adb_off. */
+static unsigned char
+expected_byte(
+    uint64_t off,
+    uint64_t adb_off)
+{
+    uint64_t rel = off - adb_off;
+    uint32_t pos = rel % BLOCK_SIZE;
+
+    if (pos >= RELOFF && pos < RELOFF + PATLEN) {
+        return (unsigned char) PATTERN[pos - RELOFF];
+    }
+    return 0;
+} /* expected_byte */
+
+static void
+verify_pattern(
+    int      fd,
+    uint64_t adb_off)
+{
+    unsigned char buf[TOTAL];
+    ssize_t       n;
+
+    n = chimera_posix_pread(fd, buf, TOTAL, (off_t) adb_off);
+    if (n != TOTAL) {
+        die("pread verify", n);
+    }
+    for (uint64_t i = 0; i < TOTAL; i++) {
+        if (buf[i] != expected_byte(adb_off + i, adb_off)) {
+            fprintf(stderr, "pattern mismatch at off %llu: got %02x want %02x\n",
+                    (unsigned long long) (adb_off + i), buf[i],
+                    expected_byte(adb_off + i, adb_off));
+            posix_test_fail(g_env);
+        }
+    }
+} /* verify_pattern */
+
+/* Returns 1 if WRITE_SAME is supported, 0 if ENOTSUP. */
+static int
+probe_support(void)
+{
+    int     fd;
+    ssize_t n;
+
+    fd = chimera_posix_open("/test/ws_probe", O_CREAT | O_RDWR | O_TRUNC, 0644);
+    if (fd < 0) {
+        die("probe open", fd);
+    }
+
+    n = chimera_posix_write_same(fd, 0, BLOCK_SIZE, BLOCK_CNT, PATTERN, PATLEN,
+                                 RELOFF);
+    chimera_posix_close(fd);
+
+    if (n == TOTAL) {
+        return 1;
+    }
+    if (n == -1 && (errno == ENOTSUP || errno == EOPNOTSUPP)) {
+        return 0;
+    }
+    fprintf(stderr, "probe write_same unexpected: ret=%zd errno=%s\n",
+            n, strerror(errno));
+    posix_test_fail(g_env);
+    return 0; /* unreachable */
+} /* probe_support */
+
+static void
+test_basic_pattern(void)
+{
+    int     fd;
+    ssize_t n;
+
+    fprintf(stderr, "Testing write_same fixed pattern into a fresh file...\n");
+
+    fd = chimera_posix_open("/test/ws_basic", O_CREAT | O_RDWR | O_TRUNC, 0644);
+    if (fd < 0) {
+        die("open basic", fd);
+    }
+
+    n = chimera_posix_write_same(fd, 0, BLOCK_SIZE, BLOCK_CNT, PATTERN, PATLEN,
+                                 RELOFF);
+    if (n != TOTAL) {
+        die("write_same basic", n);
+    }
+
+    verify_pattern(fd, 0);
+    chimera_posix_close(fd);
+    fprintf(stderr, "  basic passed\n");
+} /* test_basic_pattern */
+
+static void
+test_offset(void)
+{
+    int      fd;
+    ssize_t  n;
+    uint64_t adb_off = 4096;
+
+    fprintf(stderr, "Testing write_same at a non-zero offset...\n");
+
+    fd = chimera_posix_open("/test/ws_off", O_CREAT | O_RDWR | O_TRUNC, 0644);
+    if (fd < 0) {
+        die("open off", fd);
+    }
+
+    n = chimera_posix_write_same(fd, (off_t) adb_off, BLOCK_SIZE, BLOCK_CNT,
+                                 PATTERN, PATLEN, RELOFF);
+    if (n != TOTAL) {
+        die("write_same off", n);
+    }
+
+    verify_pattern(fd, adb_off);
+    chimera_posix_close(fd);
+    fprintf(stderr, "  offset passed\n");
+} /* test_offset */
+
+static void
+test_overwrite(void)
+{
+    char    junk[TOTAL];
+    int     fd;
+    ssize_t n;
+
+    fprintf(stderr, "Testing write_same overwriting existing data...\n");
+
+    memset(junk, 'X', sizeof(junk));
+
+    fd = chimera_posix_open("/test/ws_over", O_CREAT | O_RDWR | O_TRUNC, 0644);
+    if (fd < 0) {
+        die("open over", fd);
+    }
+
+    n = chimera_posix_pwrite(fd, junk, TOTAL, 0);
+    if (n != TOTAL) {
+        die("pwrite junk", n);
+    }
+
+    n = chimera_posix_write_same(fd, 0, BLOCK_SIZE, BLOCK_CNT, PATTERN, PATLEN,
+                                 RELOFF);
+    if (n != TOTAL) {
+        die("write_same over", n);
+    }
+
+    /* The old 'X' data must be fully replaced by the pattern. */
+    verify_pattern(fd, 0);
+    chimera_posix_close(fd);
+    fprintf(stderr, "  overwrite passed\n");
+} /* test_overwrite */
+
+static void
+test_zero_pattern(void)
+{
+    char    junk[TOTAL];
+    char    buf[TOTAL];
+    int     fd;
+    ssize_t n;
+
+    fprintf(stderr, "Testing write_same zero pattern (reads back as zeros)...\n");
+
+    memset(junk, 'Q', sizeof(junk));
+
+    fd = chimera_posix_open("/test/ws_zero", O_CREAT | O_RDWR | O_TRUNC, 0644);
+    if (fd < 0) {
+        die("open zero", fd);
+    }
+
+    n = chimera_posix_pwrite(fd, junk, TOTAL, 0);
+    if (n != TOTAL) {
+        die("pwrite zero-junk", n);
+    }
+
+    /* pattern_len 0 -> blocks are all zero. */
+    n = chimera_posix_write_same(fd, 0, BLOCK_SIZE, BLOCK_CNT, NULL, 0, 0);
+    if (n != TOTAL) {
+        die("write_same zero", n);
+    }
+
+    n = chimera_posix_pread(fd, buf, TOTAL, 0);
+    if (n != TOTAL) {
+        die("pread zero", n);
+    }
+    for (int i = 0; i < TOTAL; i++) {
+        if (buf[i] != 0) {
+            fprintf(stderr, "zero-pattern: nonzero byte %02x at %d\n",
+                    (unsigned char) buf[i], i);
+            posix_test_fail(g_env);
+        }
+    }
+
+    chimera_posix_close(fd);
+    fprintf(stderr, "  zero-pattern passed\n");
+} /* test_zero_pattern */
+
+static void
+test_unsupported(void)
+{
+    int     fd;
+    ssize_t n;
+
+    fprintf(stderr, "Testing write_same surfaces ENOTSUP cleanly...\n");
+
+    fd = chimera_posix_open("/test/ws_unsup", O_CREAT | O_RDWR | O_TRUNC, 0644);
+    if (fd < 0) {
+        die("open unsup", fd);
+    }
+
+    errno = 0;
+    n     = chimera_posix_write_same(fd, 0, BLOCK_SIZE, BLOCK_CNT, PATTERN,
+                                     PATLEN, RELOFF);
+    if (n != -1 || (errno != ENOTSUP && errno != EOPNOTSUPP)) {
+        fprintf(stderr, "expected ENOTSUP/EOPNOTSUPP, got n=%zd errno=%s\n",
+                n, strerror(errno));
+        posix_test_fail(g_env);
+    }
+
+    chimera_posix_close(fd);
+    fprintf(stderr, "  ENOTSUP path passed\n");
+} /* test_unsupported */
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    struct posix_test_env env;
+    int                   rc;
+
+    g_env = &env;
+
+    posix_test_init(&env, argv, argc);
+
+    rc = posix_test_mount(&env);
+    if (rc != 0) {
+        fprintf(stderr, "Failed to mount: %s\n", strerror(errno));
+        posix_test_fail(&env);
+    }
+
+    if (probe_support()) {
+        fprintf(stderr, "Backend '%s' supports write_same - running full tests\n",
+                env.backend);
+        test_basic_pattern();
+        test_offset();
+        test_overwrite();
+        test_zero_pattern();
+    } else {
+        fprintf(stderr, "Backend '%s' does not advertise CAP_WRITE_SAME - "
+                "verifying ENOTSUP path\n", env.backend);
+        test_unsupported();
+    }
+
+    fprintf(stderr, "All write_same tests passed!\n");
+
+    rc = posix_test_umount();
+    if (rc != 0) {
+        fprintf(stderr, "Failed to unmount: %s\n", strerror(errno));
+        posix_test_fail(&env);
+    }
+
+    posix_test_success(&env);
+    return 0;
+} /* main */

--- a/src/server/fuse/fuse_coherence.c
+++ b/src/server/fuse/fuse_coherence.c
@@ -527,7 +527,10 @@ chimera_fuse_grant_arm(
      * writer parks until this grant's break is ACKED (its advertised mode
      * survives break-begin), so "the write returned" implies "this kernel's
      * cache is gone".  Unlike a delegation it stays sweep-revocable at the
-     * break deadline, which bounds the wait if the notifier ever wedges. */
+     * break deadline, which bounds the wait if the notifier ever wedges --
+     * CHIMERA_VFS_FUSE_GRANT_BREAK_MS, sized for a local channel write rather
+     * than a network callback, so a missed ack costs the parked writer that
+     * and not the generic 30s default. */
     chimera_fuse_grant_owner(&owner, grant->mount, grant->fh_hash);
 
     chimera_vfs_claim_init_fuse_grant(&grant->claim, &owner);

--- a/src/server/nfs/CMakeLists.txt
+++ b/src/server/nfs/CMakeLists.txt
@@ -27,6 +27,7 @@ add_library(chimera_nfs SHARED nfs.c nfs4_session.c nfs4_state.c nfs4_lease.c nf
             nfs4_proc_set_ssv.c
             nfs4_proc_free_stateid.c nfs4_root.c
             nfs4_proc_allocate.c nfs4_proc_deallocate.c nfs4_proc_seek.c
+            nfs4_proc_read_plus.c nfs4_proc_io_advise.c nfs4_proc_write_same.c nfs4_proc_clone.c
             nfs4_proc_lock.c nfs4_proc_lockt.c nfs4_proc_locku.c
             nfs4_proc_verify.c
             nfs4_proc_putpubfh.c

--- a/src/server/nfs/nfs4_proc_clone.c
+++ b/src/server/nfs/nfs4_proc_clone.c
@@ -1,0 +1,197 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "nfs4_procs.h"
+#include "nfs4_status.h"
+#include "nfs4_state.h"
+#include "vfs/vfs_procs.h"
+
+/*
+ * CLONE (RFC 7862 15.13) reflinks a byte range from the SAVED_FH (source) into
+ * the CURRENT_FH (destination): the ranges share physical storage copy-on-write.
+ * Chimera projects this onto the backend's native reflink (chimera_vfs_clone_range,
+ * CAP_CLONE_RANGE).  A cross-module clone, or a backend without reflink support,
+ * yields NFS4ERR_NOTSUPP.  cl_count == 0 means "to the end of the source file".
+ */
+
+struct nfs4_clone_state_refs {
+    void               *src_state;
+    uint8_t             src_type;
+    void               *dst_state;
+    uint8_t             dst_type;
+    struct nfs_request *req;
+};
+
+static struct chimera_vfs_open_handle *
+chimera_nfs4_clone_state_handle(
+    void   *state,
+    uint8_t state_type)
+{
+    if (state_type == NFS4_SLOT_TYPE_OPEN) {
+        return ((struct nfs_open_state *) state)->handle;
+    }
+    return ((struct nfs_lock_state *) state)->handle;
+} /* chimera_nfs4_clone_state_handle */
+
+static void
+chimera_nfs4_clone_finish(
+    struct nfs_request *req,
+    nfsstat4            status)
+{
+    struct CLONE4res             *res   = &req->res_compound.resarray[req->index].opclone;
+    struct nfs4_clone_state_refs *refs  = req->nfs_state_ref;
+    struct nfs_state_table       *table = &req->thread->shared->nfs4_state_table;
+
+    req->nfs_state_ref = NULL;
+
+    if (refs) {
+        if (refs->src_state) {
+            nfs_state_table_release(table, refs->src_state, refs->src_type,
+                                    req->thread->vfs_thread);
+        }
+        if (refs->dst_state) {
+            nfs_state_table_release(table, refs->dst_state, refs->dst_type,
+                                    req->thread->vfs_thread);
+        }
+        free(refs);
+    }
+
+    res->cl_status = status;
+    chimera_nfs4_compound_complete(req, status);
+} /* chimera_nfs4_clone_finish */
+
+static void
+chimera_nfs4_clone_complete(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *pre_attr,
+    struct chimera_vfs_attrs *post_attr,
+    void                     *private_data)
+{
+    struct nfs_request *req = private_data;
+
+    chimera_nfs4_clone_finish(req, error_code == CHIMERA_VFS_OK ?
+                              NFS4_OK : chimera_nfs4_errno_to_nfsstat4(error_code));
+} /* chimera_nfs4_clone_complete */
+
+static void
+chimera_nfs4_clone_issue(
+    struct nfs_request *req,
+    uint64_t            length)
+{
+    struct CLONE4args              *args = &req->args_compound->argarray[req->index].opclone;
+    struct nfs4_clone_state_refs   *refs = req->nfs_state_ref;
+    struct chimera_vfs_open_handle *src_handle;
+    struct chimera_vfs_open_handle *dst_handle;
+
+    src_handle = chimera_nfs4_clone_state_handle(refs->src_state, refs->src_type);
+    dst_handle = chimera_nfs4_clone_state_handle(refs->dst_state, refs->dst_type);
+
+    /* Reflink requires both files be served by the same module and that module
+     * support clone_range; otherwise it is not a supported operation. */
+    if (src_handle->vfs_module != dst_handle->vfs_module ||
+        !(dst_handle->vfs_module->capabilities & CHIMERA_VFS_CAP_CLONE_RANGE)) {
+        chimera_nfs4_clone_finish(req, NFS4ERR_NOTSUPP);
+        return;
+    }
+
+    chimera_vfs_clone_range(req->thread->vfs_thread, &req->cred,
+                            src_handle, args->cl_src_offset,
+                            dst_handle, args->cl_dst_offset,
+                            length,
+                            0, 0,
+                            chimera_nfs4_clone_complete,
+                            req);
+} /* chimera_nfs4_clone_issue */
+
+static void
+chimera_nfs4_clone_getattr_complete(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *attr,
+    void                     *private_data)
+{
+    struct nfs_request *req  = private_data;
+    struct CLONE4args  *args = &req->args_compound->argarray[req->index].opclone;
+    uint64_t            src_size;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        chimera_nfs4_clone_finish(req, chimera_nfs4_errno_to_nfsstat4(error_code));
+        return;
+    }
+
+    src_size = (attr->va_set_mask & CHIMERA_VFS_ATTR_SIZE) ? attr->va_size : 0;
+
+    /* cl_count == 0: clone from cl_src_offset to the end of the source.  If the
+     * offset is at or past EOF there is nothing to clone. */
+    if (src_size <= args->cl_src_offset) {
+        chimera_nfs4_clone_finish(req, NFS4_OK);
+        return;
+    }
+
+    chimera_nfs4_clone_issue(req, src_size - args->cl_src_offset);
+} /* chimera_nfs4_clone_getattr_complete */
+
+void
+chimera_nfs4_clone(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_request               *req,
+    struct nfs_argop4                *argop,
+    struct nfs_resop4                *resop)
+{
+    struct CLONE4args              *args  = &argop->opclone;
+    struct CLONE4res               *res   = &resop->opclone;
+    struct nfs_state_table         *table = &thread->shared->nfs4_state_table;
+    struct nfs4_clone_state_refs   *refs;
+    struct chimera_vfs_open_handle *src_handle;
+    nfsstat4                        status;
+
+    req->nfs_state_ref = NULL;
+
+    if (req->saved_fhlen == 0 || req->fhlen == 0) {
+        res->cl_status = NFS4ERR_NOFILEHANDLE;
+        chimera_nfs4_compound_complete(req, res->cl_status);
+        return;
+    }
+
+    chimera_nfs4_resolve_current_stateid(req, &args->cl_src_stateid);
+    chimera_nfs4_resolve_current_stateid(req, &args->cl_dst_stateid);
+
+    refs = calloc(1, sizeof(*refs));
+    chimera_nfs_abort_if(refs == NULL, "clone state refs OOM");
+    refs->req = req;
+
+    status = nfs_state_table_acquire(table, &args->cl_src_stateid, 0,
+                                     &refs->src_state, &refs->src_type);
+    if (status != NFS4_OK) {
+        free(refs);
+        res->cl_status = status;
+        chimera_nfs4_compound_complete(req, res->cl_status);
+        return;
+    }
+
+    status = nfs_state_table_acquire(table, &args->cl_dst_stateid, 0,
+                                     &refs->dst_state, &refs->dst_type);
+    if (status != NFS4_OK) {
+        nfs_state_table_release(table, refs->src_state, refs->src_type,
+                                thread->vfs_thread);
+        free(refs);
+        res->cl_status = status;
+        chimera_nfs4_compound_complete(req, res->cl_status);
+        return;
+    }
+
+    req->nfs_state_ref = refs;
+
+    if (args->cl_count != 0) {
+        chimera_nfs4_clone_issue(req, args->cl_count);
+        return;
+    }
+
+    /* Resolve the source size to bound a clone-to-EOF. */
+    src_handle = chimera_nfs4_clone_state_handle(refs->src_state, refs->src_type);
+    chimera_vfs_getattr(thread->vfs_thread, &req->cred,
+                        src_handle,
+                        CHIMERA_VFS_ATTR_SIZE,
+                        chimera_nfs4_clone_getattr_complete,
+                        req);
+} /* chimera_nfs4_clone */

--- a/src/server/nfs/nfs4_proc_compound.c
+++ b/src/server/nfs/nfs4_proc_compound.c
@@ -298,6 +298,18 @@ chimera_nfs4_compound_process(
                 case OP_SEEK:
                     chimera_nfs4_seek(thread, req, argop, resop);
                     break;
+                case OP_READ_PLUS:
+                    chimera_nfs4_read_plus(thread, req, argop, resop);
+                    break;
+                case OP_IO_ADVISE:
+                    chimera_nfs4_io_advise(thread, req, argop, resop);
+                    break;
+                case OP_WRITE_SAME:
+                    chimera_nfs4_write_same(thread, req, argop, resop);
+                    break;
+                case OP_CLONE:
+                    chimera_nfs4_clone(thread, req, argop, resop);
+                    break;
                 case OP_GETXATTR:
                     chimera_nfs4_getxattr(thread, req, argop, resop);
                     break;

--- a/src/server/nfs/nfs4_proc_compound.c
+++ b/src/server/nfs/nfs4_proc_compound.c
@@ -405,6 +405,18 @@ chimera_nfs4_compound_process(
                 case OP_SEEK:
                     chimera_nfs4_seek(thread, req, argop, resop);
                     break;
+                case OP_READ_PLUS:
+                    chimera_nfs4_read_plus(thread, req, argop, resop);
+                    break;
+                case OP_IO_ADVISE:
+                    chimera_nfs4_io_advise(thread, req, argop, resop);
+                    break;
+                case OP_WRITE_SAME:
+                    chimera_nfs4_write_same(thread, req, argop, resop);
+                    break;
+                case OP_CLONE:
+                    chimera_nfs4_clone(thread, req, argop, resop);
+                    break;
                 case OP_GETXATTR:
                     chimera_nfs4_getxattr(thread, req, argop, resop);
                     break;

--- a/src/server/nfs/nfs4_proc_io_advise.c
+++ b/src/server/nfs/nfs4_proc_io_advise.c
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "nfs4_procs.h"
+#include "nfs4_status.h"
+#include "nfs4_state.h"
+
+/*
+ * IO_ADVISE (RFC 7862 15.5) conveys client I/O hints (sequential, random,
+ * willneed, dontneed, ...).  The hints are purely advisory: a server is
+ * permitted to honor none of them, in which case it returns an empty
+ * ior_hints bitmap.  Chimera's VFS exposes no fadvise primitive, so this is a
+ * validating no-op -- it confirms a file handle and a usable stateid are
+ * present, then reports that no hints were applied.
+ */
+void
+chimera_nfs4_io_advise(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_request               *req,
+    struct nfs_argop4                *argop,
+    struct nfs_resop4                *resop)
+{
+    struct IO_ADVISE4args  *args  = &argop->opio_advise;
+    struct IO_ADVISE4res   *res   = &resop->opio_advise;
+    struct nfs_state_table *table = &thread->shared->nfs4_state_table;
+    void                   *state_void;
+    uint8_t                 state_type;
+    nfsstat4                status;
+
+    if (req->fhlen == 0) {
+        res->ior_status = NFS4ERR_NOFILEHANDLE;
+        chimera_nfs4_compound_complete(req, res->ior_status);
+        return;
+    }
+
+    /* NFS4.1 current-stateid substitution (RFC 8881 16.2.3.1.2). */
+    chimera_nfs4_resolve_current_stateid(req, &args->iaa_stateid);
+
+    /*
+     * A special (anonymous/read-bypass) stateid carries no state-table entry
+     * and is always acceptable for an advisory operation.  Otherwise validate
+     * the stateid against the state table.
+     */
+    if (!nfs4_stateid_is_special(&args->iaa_stateid)) {
+        status = nfs_state_table_acquire(table, &args->iaa_stateid, 0,
+                                         &state_void, &state_type);
+        if (status != NFS4_OK) {
+            res->ior_status = status;
+            chimera_nfs4_compound_complete(req, res->ior_status);
+            return;
+        }
+        nfs_state_table_release(table, state_void, state_type,
+                                thread->vfs_thread);
+    }
+
+    /* No hints honored: return an empty ior_hints bitmap. */
+    res->ior_status           = NFS4_OK;
+    res->resok4.num_ior_hints = 0;
+    res->resok4.ior_hints     = NULL;
+
+    chimera_nfs4_compound_complete(req, res->ior_status);
+} /* chimera_nfs4_io_advise */

--- a/src/server/nfs/nfs4_proc_read_plus.c
+++ b/src/server/nfs/nfs4_proc_read_plus.c
@@ -1,0 +1,389 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "nfs4_procs.h"
+#include "server/server.h"
+#include "nfs4_status.h"
+#include "nfs4_session.h"
+#include "nfs4_state.h"
+#include "vfs/vfs_procs.h"
+#include "vfs/vfs_release.h"
+#include "evpl/evpl.h"
+#include "common/evpl_iovec_cursor.h"
+#include <sys/stat.h>
+
+/*
+ * READ_PLUS (RFC 7862 15.10) is a sparse-aware READ: the server may report the
+ * file as a sequence of DATA and HOLE segments so a client reading a sparse
+ * file transfers no bytes for the holes.  Chimera projects the work into the
+ * backend (chimera_vfs_read_plus), which classifies the leading byte-run at the
+ * requested offset as a single DATA or HOLE segment.  Returning one segment per
+ * call is RFC-legal (rpr_contents is an array; the client re-issues from the
+ * last byte returned).  Backends without CAP_READ_PLUS surface NFS4ERR_NOTSUPP,
+ * and the client falls back to plain READ.
+ */
+
+/* Release the acquired state ref or on-the-fly handle, then complete. */
+static void
+chimera_nfs4_read_plus_finish(
+    struct nfs_request *req,
+    nfsstat4            status)
+{
+    struct READ_PLUS4res *res = &req->res_compound.resarray[req->index].opread_plus;
+
+    res->rp_status = status;
+
+    if (req->nfs_state_ref) {
+        nfs_state_table_release(&req->thread->shared->nfs4_state_table,
+                                req->nfs_state_ref, req->nfs_state_type,
+                                req->thread->vfs_thread);
+        req->nfs_state_ref = NULL;
+        req->handle        = NULL; /* borrowed from the state; not ours to free */
+    } else if (req->handle) {
+        chimera_vfs_release(req->thread->vfs_thread, req->handle);
+        req->handle = NULL;
+    }
+
+    chimera_nfs4_compound_complete(req, status);
+} /* chimera_nfs4_read_plus_finish */
+
+/* Completion of the data read for a DATA segment: flatten the bytes into the
+ * (copying) data4 opaque and emit one NFS4_CONTENT_DATA element. */
+static void
+chimera_nfs4_read_plus_data_complete(
+    enum chimera_vfs_error    error_code,
+    uint32_t                  count,
+    uint32_t                  eof,
+    struct evpl_iovec        *iov,
+    int                       niov,
+    struct chimera_vfs_attrs *attr,
+    void                     *private_data)
+{
+    struct nfs_request       *req  = private_data;
+    struct READ_PLUS4args    *args = &req->args_compound->argarray[req->index].opread_plus;
+    struct READ_PLUS4res     *res  = &req->res_compound.resarray[req->index].opread_plus;
+    struct read_plus_content *content;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        evpl_iovecs_release(req->thread->evpl, iov, niov);
+        chimera_nfs4_read_plus_finish(req, chimera_nfs4_errno_to_nfsstat4(error_code));
+        return;
+    }
+
+    res->rp_resok4.rpr_eof = eof;
+
+    if (count == 0) {
+        res->rp_resok4.num_rpr_contents = 0;
+        res->rp_resok4.rpr_contents     = NULL;
+        evpl_iovecs_release(req->thread->evpl, iov, niov);
+        chimera_nfs4_read_plus_finish(req, NFS4_OK);
+        return;
+    }
+
+    content = xdr_dbuf_alloc_space(sizeof(*content), req->encoding->dbuf);
+    chimera_nfs_abort_if(content == NULL, "Failed to allocate space");
+
+    content->rpc_content       = NFS4_CONTENT_DATA;
+    content->rpc_data.d_offset = args->rpa_offset;
+
+    /* data4.d_data is a plain (copying) opaque, so flatten the read iovecs into
+     * a contiguous dbuf-backed buffer for the marshaller. */
+    chimera_nfs_abort_if(
+        xdr_dbuf_alloc_opaque(&content->rpc_data.d_data, count,
+                              req->encoding->dbuf) != 0,
+        "Failed to allocate space");
+    content->rpc_data.d_data.len = count;
+
+    struct evpl_iovec_cursor cursor;
+    evpl_iovec_cursor_init(&cursor, iov, niov);
+    evpl_iovec_cursor_copy(&cursor, content->rpc_data.d_data.data, count);
+
+    evpl_iovecs_release(req->thread->evpl, iov, niov);
+
+    res->rp_resok4.num_rpr_contents = 1;
+    res->rp_resok4.rpr_contents     = content;
+
+    chimera_nfs4_read_plus_finish(req, NFS4_OK);
+} /* chimera_nfs4_read_plus_data_complete */
+
+/* Completion of the backend segment classification.  For a DATA run, fetch the
+ * bytes with a normal read; for a HOLE run, emit a hole descriptor; at EOF,
+ * emit an empty content array. */
+static void
+chimera_nfs4_read_plus_classify_complete(
+    enum chimera_vfs_error error_code,
+    uint32_t               is_data,
+    uint64_t               length,
+    uint32_t               eof,
+    void                  *private_data)
+{
+    struct nfs_request       *req  = private_data;
+    struct READ_PLUS4args    *args = &req->args_compound->argarray[req->index].opread_plus;
+    struct READ_PLUS4res     *res  = &req->res_compound.resarray[req->index].opread_plus;
+    struct read_plus_content *content;
+    struct evpl_iovec        *iov;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        chimera_nfs4_read_plus_finish(req, chimera_nfs4_errno_to_nfsstat4(error_code));
+        return;
+    }
+
+    res->rp_resok4.rpr_eof = eof;
+
+    if (is_data && length > 0) {
+        /* Fetch the data run via the normal read path (handles buffer and
+         * thread ownership); the response is built in the read completion. */
+        iov = xdr_dbuf_alloc_space(sizeof(*iov) * 256, req->encoding->dbuf);
+        chimera_nfs_abort_if(iov == NULL, "Failed to allocate space");
+
+        chimera_vfs_read(req->thread->vfs_thread, &req->cred,
+                         req->handle,
+                         args->rpa_offset,
+                         (uint32_t) length,
+                         iov, 256, 0,
+                         chimera_nfs4_read_plus_data_complete,
+                         req);
+        return;
+    }
+
+    if (!is_data && length > 0) {
+        content = xdr_dbuf_alloc_space(sizeof(*content), req->encoding->dbuf);
+        chimera_nfs_abort_if(content == NULL, "Failed to allocate space");
+
+        content->rpc_content        = NFS4_CONTENT_HOLE;
+        content->rpc_hole.di_offset = args->rpa_offset;
+        content->rpc_hole.di_length = length;
+
+        res->rp_resok4.num_rpr_contents = 1;
+        res->rp_resok4.rpr_contents     = content;
+    } else {
+        /* At/past EOF or empty range: no content segments. */
+        res->rp_resok4.num_rpr_contents = 0;
+        res->rp_resok4.rpr_contents     = NULL;
+    }
+
+    chimera_nfs4_read_plus_finish(req, NFS4_OK);
+} /* chimera_nfs4_read_plus_classify_complete */
+
+static void
+chimera_nfs4_read_plus_issue(
+    struct nfs_request             *req,
+    struct chimera_vfs_open_handle *handle)
+{
+    struct READ_PLUS4args *args = &req->args_compound->argarray[req->index].opread_plus;
+
+    /* Stash the read target so the classify completion can fetch DATA bytes.
+     * For a state-based handle this is borrowed (nfs_state_ref owns release);
+     * for an on-the-fly open it is already req->handle. */
+    req->handle = handle;
+
+    chimera_vfs_read_plus(req->thread->vfs_thread, &req->cred,
+                          handle,
+                          args->rpa_offset,
+                          args->rpa_count,
+                          chimera_nfs4_read_plus_classify_complete,
+                          req);
+} /* chimera_nfs4_read_plus_issue */
+
+static void
+chimera_nfs4_read_plus_open_callback(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *handle,
+    void                           *private_data)
+{
+    struct nfs_request   *req = private_data;
+    struct READ_PLUS4res *res = &req->res_compound.resarray[req->index].opread_plus;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        res->rp_status = chimera_nfs4_errno_to_nfsstat4(error_code);
+        chimera_nfs4_compound_complete(req, res->rp_status);
+        return;
+    }
+
+    req->handle = handle;
+    chimera_nfs4_read_plus_issue(req, handle);
+} /* chimera_nfs4_read_plus_open_callback */
+
+static void
+chimera_nfs4_read_plus_typecheck_complete(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *attr,
+    void                     *private_data)
+{
+    struct nfs_request   *req = private_data;
+    struct READ_PLUS4res *res = &req->res_compound.resarray[req->index].opread_plus;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        res->rp_status = chimera_nfs4_errno_to_nfsstat4(error_code);
+        chimera_vfs_release(req->thread->vfs_thread, req->handle);
+        req->handle = NULL;
+        chimera_nfs4_compound_complete(req, res->rp_status);
+        return;
+    }
+
+    if ((attr->va_set_mask & CHIMERA_VFS_ATTR_MODE) &&
+        !S_ISREG(attr->va_mode)) {
+        res->rp_status = S_ISDIR(attr->va_mode) ? NFS4ERR_ISDIR : NFS4ERR_INVAL;
+        chimera_vfs_release(req->thread->vfs_thread, req->handle);
+        req->handle = NULL;
+        chimera_nfs4_compound_complete(req, res->rp_status);
+        return;
+    }
+
+    chimera_vfs_release(req->thread->vfs_thread, req->handle);
+    req->handle = NULL;
+
+    chimera_vfs_open_fh(req->thread->vfs_thread, &req->cred,
+                        req->fh,
+                        req->fhlen,
+                        CHIMERA_VFS_OPEN_INFERRED | CHIMERA_VFS_OPEN_READ_ONLY,
+                        chimera_nfs4_read_plus_open_callback,
+                        req);
+} /* chimera_nfs4_read_plus_typecheck_complete */
+
+static void
+chimera_nfs4_read_plus_typecheck_open_callback(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *handle,
+    void                           *private_data)
+{
+    struct nfs_request   *req = private_data;
+    struct READ_PLUS4res *res = &req->res_compound.resarray[req->index].opread_plus;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        res->rp_status = chimera_nfs4_errno_to_nfsstat4(error_code);
+        chimera_nfs4_compound_complete(req, res->rp_status);
+        return;
+    }
+
+    req->handle = handle;
+    chimera_vfs_getattr(req->thread->vfs_thread, &req->cred,
+                        handle,
+                        CHIMERA_VFS_ATTR_MODE,
+                        chimera_nfs4_read_plus_typecheck_complete,
+                        req);
+} /* chimera_nfs4_read_plus_typecheck_open_callback */
+
+void
+chimera_nfs4_read_plus(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_request               *req,
+    struct nfs_argop4                *argop,
+    struct nfs_resop4                *resop)
+{
+    struct READ_PLUS4args          *args  = &argop->opread_plus;
+    struct READ_PLUS4res           *res   = &resop->opread_plus;
+    struct nfs_state_table         *table = &thread->shared->nfs4_state_table;
+    void                           *state_void;
+    uint8_t                         state_type;
+    struct chimera_vfs_open_handle *state_handle;
+    struct nfs_open_state          *open_state;
+    nfsstat4                        status;
+
+    req->nfs_state_ref = NULL;
+    req->handle        = NULL;
+
+    /* NFS4.1 current-stateid substitution (RFC 8881 16.2.3.1.2). */
+    chimera_nfs4_resolve_current_stateid(req, &args->rpa_stateid);
+
+    /* Special/anonymous stateids (and a pNFS data server) carry no state-table
+     * entry: open the current FH on the fly, mirroring READ. */
+    if (nfs4_stateid_is_special(&args->rpa_stateid) ||
+        chimera_server_config_get_nfs_data_server(thread->shared->config)) {
+        if (req->fhlen == 0) {
+            res->rp_status = NFS4ERR_NOFILEHANDLE;
+            chimera_nfs4_compound_complete(req, res->rp_status);
+            return;
+        }
+
+        if (req->session && req->session->client_unified) {
+            status = nfs_client_check_io_denied(req->session->client_unified,
+                                                NULL, req->fh, req->fhlen,
+                                                OPEN4_SHARE_ACCESS_READ);
+            if (status != NFS4_OK) {
+                res->rp_status = status;
+                chimera_nfs4_compound_complete(req, res->rp_status);
+                return;
+            }
+        }
+
+        chimera_vfs_open_fh(thread->vfs_thread, &req->cred,
+                            req->fh, req->fhlen,
+                            CHIMERA_VFS_OPEN_INFERRED | CHIMERA_VFS_OPEN_PATH | CHIMERA_VFS_OPEN_NOFOLLOW,
+                            chimera_nfs4_read_plus_typecheck_open_callback,
+                            req);
+        return;
+    }
+
+    status = nfs_state_table_acquire(table, &args->rpa_stateid, 0,
+                                     &state_void, &state_type);
+    if (status != NFS4_OK) {
+        res->rp_status = status;
+        chimera_nfs4_compound_complete(req, res->rp_status);
+        return;
+    }
+
+    status = nfs_state_check_client(
+        state_void, state_type,
+        req->session ? req->session->client_unified : NULL);
+    if (status != NFS4_OK) {
+        nfs_state_table_release(table, state_void, state_type,
+                                thread->vfs_thread);
+        res->rp_status = status;
+        chimera_nfs4_compound_complete(req, res->rp_status);
+        return;
+    }
+
+    /* A delegation stateid authorizes the READ but carries no open handle;
+     * drop the ref and open the current FH on the fly, as for READ. */
+    if (state_type == NFS4_SLOT_TYPE_DELEG) {
+        nfs_state_table_release(table, state_void, state_type,
+                                thread->vfs_thread);
+        if (req->fhlen == 0) {
+            res->rp_status = NFS4ERR_NOFILEHANDLE;
+            chimera_nfs4_compound_complete(req, res->rp_status);
+            return;
+        }
+        chimera_vfs_open_fh(thread->vfs_thread, &req->cred,
+                            req->fh, req->fhlen,
+                            CHIMERA_VFS_OPEN_INFERRED | CHIMERA_VFS_OPEN_PATH | CHIMERA_VFS_OPEN_NOFOLLOW,
+                            chimera_nfs4_read_plus_typecheck_open_callback,
+                            req);
+        return;
+    }
+
+    if (state_type == NFS4_SLOT_TYPE_OPEN) {
+        open_state   = state_void;
+        state_handle = open_state->handle;
+    } else {
+        open_state   = ((struct nfs_lock_state *) state_void)->open_state;
+        state_handle = ((struct nfs_lock_state *) state_void)->handle;
+    }
+
+    status = nfs_open_state_check_io_denied(open_state,
+                                            OPEN4_SHARE_ACCESS_READ);
+    if (status != NFS4_OK) {
+        nfs_state_table_release(table, state_void, state_type,
+                                thread->vfs_thread);
+        res->rp_status = status;
+        chimera_nfs4_compound_complete(req, res->rp_status);
+        return;
+    }
+
+    if (!nfs_open_state_check_principal(open_state,
+                                        req->principal_flavor,
+                                        req->principal_machinename,
+                                        req->principal_machinename_len)) {
+        nfs_state_table_release(table, state_void, state_type,
+                                thread->vfs_thread);
+        res->rp_status = NFS4ERR_ACCESS;
+        chimera_nfs4_compound_complete(req, res->rp_status);
+        return;
+    }
+
+    req->nfs_state_ref  = state_void;
+    req->nfs_state_type = state_type;
+
+    chimera_nfs4_read_plus_issue(req, state_handle);
+} /* chimera_nfs4_read_plus */

--- a/src/server/nfs/nfs4_proc_read_plus.c
+++ b/src/server/nfs/nfs4_proc_read_plus.c
@@ -297,10 +297,19 @@ chimera_nfs4_read_plus(
             return;
         }
 
-        if (req->session && req->session->client_unified) {
-            status = nfs_client_check_io_denied(req->session->client_unified,
-                                                NULL, req->fh, req->fhlen,
-                                                OPEN4_SHARE_ACCESS_READ);
+        /* RFC 7530 9.1.4.3 / RFC 8881 9.7: a special-stateid read against a
+        * deny-READ share reservation held by ANY owner of ANY client is
+        * NFS4ERR_LOCKED.  READ_PLUS is a READ, so it owes the same answer --
+        * check the shared client table, not just this client's own opens,
+        * and do it whether or not the request carries a session (4.0 has
+        * none).  A pNFS data server is authorized by the layout instead. */
+        if (!chimera_server_config_get_nfs_data_server(
+                thread->shared->config)) {
+            status = nfs4_clients_check_io_denied(
+                &thread->shared->nfs4_shared_clients,
+                req->fh,
+                req->fhlen,
+                OPEN4_SHARE_ACCESS_READ);
             if (status != NFS4_OK) {
                 res->rp_status = status;
                 chimera_nfs4_compound_complete(req, res->rp_status);

--- a/src/server/nfs/nfs4_proc_write_same.c
+++ b/src/server/nfs/nfs4_proc_write_same.c
@@ -1,0 +1,246 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "nfs4_procs.h"
+#include "server/server.h"
+#include "nfs4_status.h"
+#include "nfs4_session.h"
+#include "nfs4_state.h"
+#include "vfs/vfs_procs.h"
+#include "vfs/vfs_release.h"
+#include <sys/stat.h>
+
+/*
+ * WRITE_SAME (RFC 7862 15.13) writes an Application Data Block pattern -- a
+ * small pattern replicated across a run of fixed-size blocks -- so the client
+ * initializes a large region with a tiny request.  Chimera projects the
+ * expansion into the backend (chimera_vfs_write_same); backends without
+ * CAP_WRITE_SAME surface NFS4ERR_NOTSUPP.
+ *
+ * Phase 1 does not stamp per-block numbers: an ADB requesting block-number
+ * stamping (adb_reloff_blocknum != NFS4_UINT64_MAX) is rejected with
+ * NFS4ERR_UNION_NOTSUPP (the unsupported arm of the operation).
+ */
+
+static void
+chimera_nfs4_write_same_complete(
+    enum chimera_vfs_error    error_code,
+    uint64_t                  count,
+    uint32_t                  sync,
+    struct chimera_vfs_attrs *pre_attr,
+    struct chimera_vfs_attrs *post_attr,
+    void                     *private_data)
+{
+    struct nfs_request    *req = private_data;
+    struct WRITE_SAME4res *res = &req->res_compound.resarray[req->index].opwrite_same;
+
+    if (error_code == CHIMERA_VFS_OK) {
+        res->wsr_status                = NFS4_OK;
+        res->resok4.num_wr_callback_id = 0;
+        res->resok4.wr_callback_id     = NULL;
+        res->resok4.wr_count           = count;
+        res->resok4.wr_committed       = sync;
+        memcpy(res->resok4.wr_writeverf,
+               &req->thread->shared->nfs_verifier,
+               sizeof(res->resok4.wr_writeverf));
+    } else {
+        res->wsr_status = chimera_nfs4_errno_to_nfsstat4(error_code);
+    }
+
+    if (req->nfs_state_ref) {
+        nfs_state_table_release(&req->thread->shared->nfs4_state_table,
+                                req->nfs_state_ref, req->nfs_state_type,
+                                req->thread->vfs_thread);
+        req->nfs_state_ref = NULL;
+    } else if (req->handle) {
+        chimera_vfs_release(req->thread->vfs_thread, req->handle);
+        req->handle = NULL;
+    }
+
+    chimera_nfs4_compound_complete(req, res->wsr_status);
+} /* chimera_nfs4_write_same_complete */
+
+static void
+chimera_nfs4_write_same_issue(
+    struct nfs_request             *req,
+    struct chimera_vfs_open_handle *handle)
+{
+    struct WRITE_SAME4args *args = &req->args_compound->argarray[req->index].opwrite_same;
+
+    chimera_vfs_write_same(req->thread->vfs_thread, &req->cred,
+                           handle,
+                           args->wsa_adb.adb_offset,
+                           (uint32_t) args->wsa_adb.adb_block_size,
+                           args->wsa_adb.adb_block_count,
+                           args->wsa_adb.adb_pattern.data,
+                           args->wsa_adb.adb_pattern.len,
+                           (uint32_t) args->wsa_adb.adb_reloff_pattern,
+                           args->wsa_stable,
+                           0, 0,
+                           chimera_nfs4_write_same_complete,
+                           req);
+} /* chimera_nfs4_write_same_issue */
+
+static void
+chimera_nfs4_write_same_open_callback(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *handle,
+    void                           *private_data)
+{
+    struct nfs_request    *req = private_data;
+    struct WRITE_SAME4res *res = &req->res_compound.resarray[req->index].opwrite_same;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        res->wsr_status = chimera_nfs4_errno_to_nfsstat4(error_code);
+        chimera_nfs4_compound_complete(req, res->wsr_status);
+        return;
+    }
+
+    req->handle = handle;
+    chimera_nfs4_write_same_issue(req, handle);
+} /* chimera_nfs4_write_same_open_callback */
+
+void
+chimera_nfs4_write_same(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_request               *req,
+    struct nfs_argop4                *argop,
+    struct nfs_resop4                *resop)
+{
+    struct WRITE_SAME4args         *args  = &argop->opwrite_same;
+    struct WRITE_SAME4res          *res   = &resop->opwrite_same;
+    struct app_data_block4         *adb   = &args->wsa_adb;
+    struct nfs_state_table         *table = &thread->shared->nfs4_state_table;
+    void                           *state_void;
+    uint8_t                         state_type;
+    struct chimera_vfs_open_handle *state_handle;
+    struct nfs_open_state          *open_state;
+    nfsstat4                        status;
+
+    req->nfs_state_ref = NULL;
+    req->handle        = NULL;
+
+    /* Reject per-block-number stamping (Phase 1): the union arm is unsupported. */
+    if (adb->adb_reloff_blocknum != NFS4_UINT64_MAX) {
+        res->wsr_status = NFS4ERR_UNION_NOTSUPP;
+        chimera_nfs4_compound_complete(req, res->wsr_status);
+        return;
+    }
+
+    /* Validate the ADB geometry.  block_size is length4 (64-bit) but a sane
+     * block fits in 32 bits; oversize or zero is invalid. */
+    if (adb->adb_block_size == 0 || adb->adb_block_size > UINT32_MAX ||
+        adb->adb_reloff_pattern > adb->adb_block_size ||
+        adb->adb_reloff_pattern + adb->adb_pattern.len > adb->adb_block_size) {
+        res->wsr_status = NFS4ERR_INVAL;
+        chimera_nfs4_compound_complete(req, res->wsr_status);
+        return;
+    }
+
+    /* Guard against block_size * block_count overflowing 64 bits. */
+    if (adb->adb_block_count != 0 &&
+        adb->adb_block_size > NFS4_UINT64_MAX / adb->adb_block_count) {
+        res->wsr_status = NFS4ERR_INVAL;
+        chimera_nfs4_compound_complete(req, res->wsr_status);
+        return;
+    }
+
+    /* NFS4.1 current-stateid substitution (RFC 8881 16.2.3.1.2). */
+    chimera_nfs4_resolve_current_stateid(req, &args->wsa_stateid);
+
+    /* Special/anonymous stateids carry no state-table entry: open the current
+     * FH on the fly.  The backend enforces the regular-file requirement. */
+    if (nfs4_stateid_is_special(&args->wsa_stateid)) {
+        if (req->fhlen == 0) {
+            res->wsr_status = NFS4ERR_NOFILEHANDLE;
+            chimera_nfs4_compound_complete(req, res->wsr_status);
+            return;
+        }
+
+        chimera_vfs_open_fh(thread->vfs_thread, &req->cred,
+                            req->fh, req->fhlen,
+                            CHIMERA_VFS_OPEN_INFERRED,
+                            chimera_nfs4_write_same_open_callback,
+                            req);
+        return;
+    }
+
+    status = nfs_state_table_acquire(table, &args->wsa_stateid, 0,
+                                     &state_void, &state_type);
+    if (status != NFS4_OK) {
+        res->wsr_status = status;
+        chimera_nfs4_compound_complete(req, res->wsr_status);
+        return;
+    }
+
+    status = nfs_state_check_client(
+        state_void, state_type,
+        req->session ? req->session->client_unified : NULL);
+    if (status != NFS4_OK) {
+        nfs_state_table_release(table, state_void, state_type,
+                                thread->vfs_thread);
+        res->wsr_status = status;
+        chimera_nfs4_compound_complete(req, res->wsr_status);
+        return;
+    }
+
+    /* A write-delegation stateid carries no open handle; open the FH on the fly. */
+    if (state_type == NFS4_SLOT_TYPE_DELEG) {
+        nfs_state_table_release(table, state_void, state_type,
+                                thread->vfs_thread);
+        if (req->fhlen == 0) {
+            res->wsr_status = NFS4ERR_NOFILEHANDLE;
+            chimera_nfs4_compound_complete(req, res->wsr_status);
+            return;
+        }
+        chimera_vfs_open_fh(thread->vfs_thread, &req->cred,
+                            req->fh, req->fhlen,
+                            CHIMERA_VFS_OPEN_INFERRED,
+                            chimera_nfs4_write_same_open_callback,
+                            req);
+        return;
+    }
+
+    if (state_type == NFS4_SLOT_TYPE_OPEN) {
+        open_state   = state_void;
+        state_handle = open_state->handle;
+    } else {
+        open_state   = ((struct nfs_lock_state *) state_void)->open_state;
+        state_handle = ((struct nfs_lock_state *) state_void)->handle;
+    }
+
+    if ((open_state->share_access & OPEN4_SHARE_ACCESS_WRITE) == 0) {
+        nfs_state_table_release(table, state_void, state_type,
+                                thread->vfs_thread);
+        res->wsr_status = NFS4ERR_OPENMODE;
+        chimera_nfs4_compound_complete(req, res->wsr_status);
+        return;
+    }
+
+    status = nfs_open_state_check_io_denied(open_state,
+                                            OPEN4_SHARE_ACCESS_WRITE);
+    if (status != NFS4_OK) {
+        nfs_state_table_release(table, state_void, state_type,
+                                thread->vfs_thread);
+        res->wsr_status = status;
+        chimera_nfs4_compound_complete(req, res->wsr_status);
+        return;
+    }
+
+    if (!nfs_open_state_check_principal(open_state,
+                                        req->principal_flavor,
+                                        req->principal_machinename,
+                                        req->principal_machinename_len)) {
+        nfs_state_table_release(table, state_void, state_type,
+                                thread->vfs_thread);
+        res->wsr_status = NFS4ERR_ACCESS;
+        chimera_nfs4_compound_complete(req, res->wsr_status);
+        return;
+    }
+
+    req->nfs_state_ref  = state_void;
+    req->nfs_state_type = state_type;
+
+    chimera_nfs4_write_same_issue(req, state_handle);
+} /* chimera_nfs4_write_same */

--- a/src/server/nfs/nfs4_proc_write_same.c
+++ b/src/server/nfs/nfs4_proc_write_same.c
@@ -158,6 +158,26 @@ chimera_nfs4_write_same(
             return;
         }
 
+        /* RFC 7530 9.1.4.3 / RFC 8881 9.7: a special-stateid write against a
+         * deny-WRITE share reservation held by ANY owner of ANY client is
+         * NFS4ERR_LOCKED.  WRITE_SAME is a write, so it owes the same answer
+         * as WRITE -- the open-state path below already checks its own
+         * reservation, but the special-stateid path names no state and must
+         * consult the shared client table. */
+        if (!chimera_server_config_get_nfs_data_server(
+                thread->shared->config)) {
+            status = nfs4_clients_check_io_denied(
+                &thread->shared->nfs4_shared_clients,
+                req->fh,
+                req->fhlen,
+                OPEN4_SHARE_ACCESS_WRITE);
+            if (status != NFS4_OK) {
+                res->wsr_status = status;
+                chimera_nfs4_compound_complete(req, res->wsr_status);
+                return;
+            }
+        }
+
         chimera_vfs_open_fh(thread->vfs_thread, &req->cred,
                             req->fh, req->fhlen,
                             CHIMERA_VFS_OPEN_INFERRED,

--- a/src/server/nfs/nfs4_procs.h
+++ b/src/server/nfs/nfs4_procs.h
@@ -490,6 +490,34 @@ chimera_nfs4_seek(
     struct nfs_argop4                *argop,
     struct nfs_resop4                *resop);
 
+void
+chimera_nfs4_read_plus(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_request               *req,
+    struct nfs_argop4                *argop,
+    struct nfs_resop4                *resop);
+
+void
+chimera_nfs4_io_advise(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_request               *req,
+    struct nfs_argop4                *argop,
+    struct nfs_resop4                *resop);
+
+void
+chimera_nfs4_write_same(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_request               *req,
+    struct nfs_argop4                *argop,
+    struct nfs_resop4                *resop);
+
+void
+chimera_nfs4_clone(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_request               *req,
+    struct nfs_argop4                *argop,
+    struct nfs_resop4                *resop);
+
 /* pNFS (NFSv4.1 file layout) operations — see nfs4_pnfs.c */
 void
 chimera_nfs4_getdeviceinfo(

--- a/src/server/nfs/nfs4_procs.h
+++ b/src/server/nfs/nfs4_procs.h
@@ -568,6 +568,34 @@ chimera_nfs4_seek(
     struct nfs_argop4                *argop,
     struct nfs_resop4                *resop);
 
+void
+chimera_nfs4_read_plus(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_request               *req,
+    struct nfs_argop4                *argop,
+    struct nfs_resop4                *resop);
+
+void
+chimera_nfs4_io_advise(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_request               *req,
+    struct nfs_argop4                *argop,
+    struct nfs_resop4                *resop);
+
+void
+chimera_nfs4_write_same(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_request               *req,
+    struct nfs_argop4                *argop,
+    struct nfs_resop4                *resop);
+
+void
+chimera_nfs4_clone(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_request               *req,
+    struct nfs_argop4                *argop,
+    struct nfs_resop4                *resop);
+
 /* pNFS (NFSv4.1 file layout) operations — see nfs4_pnfs.c */
 void
 chimera_nfs4_getdeviceinfo(

--- a/src/server/nfs/tests/quint/nfs4_mbt_replay.c
+++ b/src/server/nfs/tests/quint/nfs4_mbt_replay.c
@@ -55,6 +55,11 @@
 #define V4_NAME_LEN         128
 #define V4_HISTORY          6
 #define V4_DATA_ARENA       (4 << 20)
+
+/* READ_PLUS: the model asks for at most a handful of blocks, and a
+ * conforming server returns at most one segment per block. */
+#define V4_RP_MAX_SEGS      16
+#define V4_IA_MAX_HINTS     8
 #define V4_RETRY_DELAY_MAX  40
 
 #define E_DELAY             10008
@@ -113,6 +118,16 @@ itf_i64(json_t *v)
     fprintf(stderr, "trace format error: expected integer\n");
     exit(2);
 } /* itf_i64 */
+
+static int
+itf_bool(json_t *v)
+{
+    if (!v || !json_is_boolean(v)) {
+        fprintf(stderr, "trace format error: expected bool\n");
+        exit(2);
+    }
+    return json_is_true(v);
+} /* itf_bool */
 
 static json_t *
 itf_seq(json_t *v)
@@ -265,6 +280,25 @@ struct v4_res {
     uint32_t        data_len;
 
     uint64_t        offset;           /* SEEK */
+
+    /* READ_PLUS segments, as returned.  The server may legally answer with
+     * fewer segments than cover the request (the client re-issues from the
+     * last byte returned), so the SReadPlus arm checks them as a prefix of
+     * the model's classification rather than for equality.  DATA bytes are
+     * copied into the compound arena: the reply buffers do not outlive the
+     * decode. */
+    int             rp_present;
+    int             rp_nsegs;
+    int             rp_bad;           /* unusable segment list */
+    struct {
+        int      is_data;
+        uint64_t offset;
+        uint64_t length;
+        uint8_t *data;                /* arena copy; DATA segments only */
+    }        rp_segs[V4_RP_MAX_SEGS];
+
+    uint32_t        ia_nhints;        /* IO_ADVISE hints the server honored */
+    uint32_t        ia_hints[V4_IA_MAX_HINTS];
 
     char            xvalue[V4_NAME_LEN]; /* GETXATTR */
     uint32_t        xvalue_len;
@@ -800,6 +834,8 @@ struct v4_argscratch {
     struct evpl_iovec wiov;
     int               wiov_used;
     char              xval[64];
+    uint32_t          ia_hint;               /* IO_ADVISE request hint */
+    uint8_t           ws_pattern[V4_BLOCK_SIZE]; /* WRITE_SAME ADB pattern */
 };
 
 static void
@@ -1513,6 +1549,76 @@ encode_op(
         a->opcopy.num_ca_source_server = 0;
         return 0;
     }
+    if (strcmp(tag, "RReadPlus") == 0) {
+        a->argop = OP_READ_PLUS;
+        if (resolve_sel(o, json_object_get(v, "sel"),
+                        &a->opread_plus.rpa_stateid, m) < 0) {
+            return -1;
+        }
+        a->opread_plus.rpa_offset = (uint64_t) jf_i64(v, "off") *
+            V4_BLOCK_SIZE;
+        a->opread_plus.rpa_count = (uint32_t) (jf_i64(v, "len") *
+                                               V4_BLOCK_SIZE);
+        return 0;
+    }
+    if (strcmp(tag, "RIoAdvise") == 0) {
+        a->argop = OP_IO_ADVISE;
+        if (resolve_sel(o, json_object_get(v, "sel"),
+                        &a->opio_advise.iaa_stateid, m) < 0) {
+            return -1;
+        }
+        a->opio_advise.iaa_offset = (uint64_t) jf_i64(v, "off") *
+            V4_BLOCK_SIZE;
+        a->opio_advise.iaa_count = (uint64_t) jf_i64(v, "len") *
+            V4_BLOCK_SIZE;
+        /* One hint per request: the model draws an io_advise_type4 bit
+         * number and the server may honor any subset (here, none). */
+        s->ia_hint                   = (uint32_t) jf_i64(v, "hint");
+        a->opio_advise.num_iaa_hints = 1;
+        a->opio_advise.iaa_hints     = &s->ia_hint;
+        return 0;
+    }
+    if (strcmp(tag, "RWriteSame") == 0) {
+        int64_t nblk = jf_i64(v, "blocks");
+
+        a->argop = OP_WRITE_SAME;
+        if (resolve_sel(o, json_object_get(v, "sel"),
+                        &a->opwrite_same.wsa_stateid, m) < 0) {
+            return -1;
+        }
+        a->opwrite_same.wsa_stable = FILE_SYNC4;
+        /* One ADB block == one model block, so the pattern is a whole block
+         * and the model's block count is the ADB block count. */
+        block_fill(jf_i64(v, "pat"), s->ws_pattern);
+        a->opwrite_same.wsa_adb.adb_offset = (uint64_t)
+            jf_i64(v, "off") * V4_BLOCK_SIZE;
+        a->opwrite_same.wsa_adb.adb_block_size  = V4_BLOCK_SIZE;
+        a->opwrite_same.wsa_adb.adb_block_count = (uint64_t) nblk;
+        /* NFS4_UINT64_MAX == "no per-block-number stamping"; anything else
+         * selects the union arm the server rejects with UNION_NOTSUPP. */
+        a->opwrite_same.wsa_adb.adb_reloff_blocknum =
+            jf_bool(v, "blocknum") ? 0 : NFS4_UINT64_MAX;
+        a->opwrite_same.wsa_adb.adb_block_num      = 0;
+        a->opwrite_same.wsa_adb.adb_reloff_pattern = 0;
+        a->opwrite_same.wsa_adb.adb_pattern.data   = s->ws_pattern;
+        a->opwrite_same.wsa_adb.adb_pattern.len    = V4_BLOCK_SIZE;
+        return 0;
+    }
+    if (strcmp(tag, "RClone") == 0) {
+        a->argop = OP_CLONE;
+        if (resolve_sel(o, json_object_get(v, "srcSel"),
+                        &a->opclone.cl_src_stateid, m) < 0 ||
+            resolve_sel(o, json_object_get(v, "dstSel"),
+                        &a->opclone.cl_dst_stateid, m) < 0) {
+            return -1;
+        }
+        a->opclone.cl_src_offset = (uint64_t) jf_i64(v, "srcOff") *
+            V4_BLOCK_SIZE;
+        a->opclone.cl_dst_offset = (uint64_t) jf_i64(v, "dstOff") *
+            V4_BLOCK_SIZE;
+        a->opclone.cl_count = (uint64_t) jf_i64(v, "cnt") * V4_BLOCK_SIZE;
+        return 0;
+    }
     if (strcmp(tag, "RGetxattr") == 0) {
         a->argop                    = OP_GETXATTR;
         a->opgetxattr.gxa_name.data = (void *) json_string_value(v);
@@ -1979,6 +2085,70 @@ decode_resop(
                 r->offset = rop->opseek.resok4.sr_offset;
             }
             break;
+        case OP_READ_PLUS:
+            st = rop->opread_plus.rp_status;
+            if (st == NFS4_OK) {
+                uint32_t nc = rop->opread_plus.rp_resok4.num_rpr_contents;
+                uint32_t ci;
+
+                r->rp_present = 1;
+                r->eof        = rop->opread_plus.rp_resok4.rpr_eof != 0;
+                if (nc > V4_RP_MAX_SEGS) {
+                    r->rp_bad = 1;
+                    break;
+                }
+                for (ci = 0; ci < nc; ci++) {
+                    struct read_plus_content *c =
+                        &rop->opread_plus.rp_resok4.rpr_contents[ci];
+                    int                       j = r->rp_nsegs;
+
+                    if (c->rpc_content == NFS4_CONTENT_DATA) {
+                        uint32_t n = c->rpc_data.d_data.len;
+
+                        if (o->arena_used + n > V4_DATA_ARENA) {
+                            r->rp_bad = 1;
+                            break;
+                        }
+                        r->rp_segs[j].is_data = 1;
+                        r->rp_segs[j].offset  = c->rpc_data.d_offset;
+                        r->rp_segs[j].length  = n;
+                        r->rp_segs[j].data    = o->arena + o->arena_used;
+                        memcpy(r->rp_segs[j].data, c->rpc_data.d_data.data, n);
+                        o->arena_used += n;
+                    } else if (c->rpc_content == NFS4_CONTENT_HOLE) {
+                        r->rp_segs[j].is_data = 0;
+                        r->rp_segs[j].offset  = c->rpc_hole.di_offset;
+                        r->rp_segs[j].length  = c->rpc_hole.di_length;
+                        r->rp_segs[j].data    = NULL;
+                    } else {
+                        r->rp_bad = 1;
+                        break;
+                    }
+                    r->rp_nsegs++;
+                }
+            }
+            break;
+        case OP_IO_ADVISE:
+            st = rop->opio_advise.ior_status;
+            if (st == NFS4_OK) {
+                uint32_t hi;
+
+                r->ia_nhints = rop->opio_advise.resok4.num_ior_hints;
+                for (hi = 0; hi < r->ia_nhints &&
+                     hi < V4_IA_MAX_HINTS; hi++) {
+                    r->ia_hints[hi] = rop->opio_advise.resok4.ior_hints[hi];
+                }
+            }
+            break;
+        case OP_WRITE_SAME:
+            st = rop->opwrite_same.wsr_status;
+            if (st == NFS4_OK) {
+                r->count = (uint32_t) rop->opwrite_same.resok4.wr_count;
+            }
+            break;
+        case OP_CLONE:
+            st = rop->opclone.cl_status;
+            break;
         case OP_COPY:
             st = rop->opcopy.cr_status;
             if (st == NFS4_OK) {
@@ -2243,6 +2413,30 @@ classify_status_mismatch(
     }
     if (strcmp(tag, "SCopy") == 0 && has_notsupp) {
         caps_mismatch(o, m, "copy", "%s: expected %u, got %u",
+                      tag, est, ast);
+        return;
+    }
+    /* The RFC 7862 data ops are per-backend capabilities (CAP_READ_PLUS,
+     * CAP_WRITE_SAME, CAP_CLONE_RANGE): a backend without one answers
+     * NFS4ERR_NOTSUPP, which is a profile mismatch rather than a defect
+     * unless the instance pinned the feature FeatMandatory. */
+    if (strcmp(tag, "SReadPlus") == 0 && has_notsupp) {
+        caps_mismatch(o, m, "readPlus", "%s: expected %u, got %u",
+                      tag, est, ast);
+        return;
+    }
+    if (strcmp(tag, "SIoAdvise") == 0 && has_notsupp) {
+        caps_mismatch(o, m, "ioAdvise", "%s: expected %u, got %u",
+                      tag, est, ast);
+        return;
+    }
+    if (strcmp(tag, "SWriteSame") == 0 && has_notsupp) {
+        caps_mismatch(o, m, "writeSame", "%s: expected %u, got %u",
+                      tag, est, ast);
+        return;
+    }
+    if (strcmp(tag, "SClone") == 0 && has_notsupp) {
+        caps_mismatch(o, m, "clone", "%s: expected %u, got %u",
                       tag, est, ast);
         return;
     }
@@ -2550,6 +2744,111 @@ check_result(
                 }
             }
         }
+    } else if (strcmp(tag, "SReadPlus") == 0) {
+        /* The model predicts the DATA/HOLE classification and contents of the
+         * whole requested range.  A server may legally return a shorter
+         * prefix -- rpr_contents is an array and the client re-issues from
+         * the last byte returned -- so the segments are validated as a
+         * contiguous, block-aligned prefix starting at the requested offset,
+         * and only the blocks actually returned are compared. */
+        json_t  *blocks  = itf_seq(json_object_get(v, "blocks"));
+        json_t  *isdata  = itf_seq(json_object_get(v, "isData"));
+        uint64_t req_off = req ? (uint64_t) jf_i64(jf_val(req), "off") *
+            V4_BLOCK_SIZE : 0;
+        uint64_t want   = req_off;
+        int      nmodel = (int) json_array_size(blocks);
+        int      got    = 0;
+        int      i;
+
+        if (r->rp_bad) {
+            mism_add(m, "read_plus: unusable segment list");
+        }
+        for (i = 0; i < r->rp_nsegs && !r->rp_bad; i++) {
+            uint64_t soff = r->rp_segs[i].offset;
+            uint64_t slen = r->rp_segs[i].length;
+            uint64_t b;
+
+            if (soff != want) {
+                mism_add(m, "read_plus seg %d: offset %llu, expected %llu "
+                         "(segments must tile the range from the requested "
+                         "offset)", i, (unsigned long long) soff,
+                         (unsigned long long) want);
+                break;
+            }
+            if (slen == 0 || (slen % V4_BLOCK_SIZE) != 0) {
+                mism_add(m, "read_plus seg %d: length %llu is not a whole "
+                         "number of %u-byte blocks", i,
+                         (unsigned long long) slen, V4_BLOCK_SIZE);
+                break;
+            }
+            for (b = 0; b < slen / V4_BLOCK_SIZE; b++) {
+                int is_data;
+
+                if (got >= nmodel) {
+                    mism_add(m, "read_plus: returned %d blocks, model "
+                             "predicts only %d", got + 1, nmodel);
+                    break;
+                }
+                is_data = itf_bool(json_array_get(isdata, (size_t) got));
+                if (r->rp_segs[i].is_data != is_data) {
+                    mism_add(m, "read_plus block %d: expected %s, got %s",
+                             got, is_data ? "DATA" : "HOLE",
+                             r->rp_segs[i].is_data ? "DATA" : "HOLE");
+                } else if (r->rp_segs[i].is_data) {
+                    block_fill(itf_i64(json_array_get(blocks, (size_t) got)),
+                               o->scratch);
+                    if (memcmp(r->rp_segs[i].data + b * V4_BLOCK_SIZE,
+                               o->scratch, V4_BLOCK_SIZE) != 0) {
+                        mism_add(m, "read_plus block %d: data mismatch "
+                                 "(expected byte %#x, got byte %#x)", got,
+                                 o->scratch[0],
+                                 r->rp_segs[i].data[b * V4_BLOCK_SIZE]);
+                    }
+                }
+                got++;
+            }
+            want += slen;
+        }
+        /* A short answer is legal, but it must make progress: returning no
+        * segment at all while the model still has blocks to report, without
+        * claiming EOF, leaves the client with nowhere to re-issue from. */
+        if (!r->rp_bad && got == 0 && nmodel > 0 && !r->eof) {
+            mism_add(m, "read_plus: no segment returned for %d predicted "
+                     "blocks and eof is unset", nmodel);
+        }
+        if (!r->rp_bad && got < nmodel && r->eof) {
+            mism_add(m, "read_plus: eof set after %d of %d predicted blocks",
+                     got, nmodel);
+        }
+        if (!r->rp_bad && got == nmodel && r->eof != jf_bool(v, "eof")) {
+            mism_add(m, "read_plus.eof: expected %d, got %d",
+                     jf_bool(v, "eof"), r->eof);
+        }
+    } else if (strcmp(tag, "SIoAdvise") == 0) {
+        /* IO_ADVISE is advisory: the server may honor none of the hints, but
+         * it must not invent one the client did not ask for (RFC 7862
+         * 15.5). */
+        uint32_t asked = req ? (uint32_t) jf_i64(jf_val(req), "hint") : 0;
+        uint32_t hi;
+
+        for (hi = 0; hi < r->ia_nhints && hi < V4_IA_MAX_HINTS; hi++) {
+            if (r->ia_hints[hi] != 0 && r->ia_hints[hi] != asked) {
+                mism_add(m, "io_advise: honored hint %u was not requested "
+                         "(asked for %u)", r->ia_hints[hi], asked);
+            }
+        }
+    } else if (strcmp(tag, "SWriteSame") == 0) {
+        uint32_t want = (uint32_t) (jf_i64(v, "count") * V4_BLOCK_SIZE);
+
+        if (r->count != want) {
+            mism_add(m, "write_same.count: expected %u, got %u", want,
+                     r->count);
+        }
+    } else if (strcmp(tag, "SClone") == 0) {
+        /* CLONE reports status only; its data effect is checked by the
+         * subsequent READ/READ_PLUS the generator emits against the model's
+         * updated filesystem. */
+        (void) 0;
     } else if (strcmp(tag, "SWrite") == 0) {
         uint32_t want = (uint32_t) (jf_i64(v, "count") * V4_BLOCK_SIZE);
 
@@ -3478,6 +3777,8 @@ main(
           'X'                                                                             },
         { "mandatory",      required_argument,          0,
           'M'                                                                                                  },
+        { "backend",        required_argument,          0,
+          'b'                                                                                                  },
         { "dry-run",        no_argument,                0,
           'n'                                                                                                                      },
         { "verbose",        no_argument,                0,
@@ -3496,7 +3797,8 @@ main(
     int                  c;
     int                  i;
     struct mbt_env       env;
-    struct mbt_env_opts  opts = {
+    const char          *backend = "memfs";
+    struct mbt_env_opts  opts    = {
         .disable_caches = 1,
         /* Pin memfs's block size to the model's block granularity so sub-block
          * holes line up with SEEK_HOLE/SEEK_DATA (DEVIATIONS-NFS4.md round 8).
@@ -3509,7 +3811,7 @@ main(
      * shared helper; getopt only recognizes them so it does not error. */
     traces = mbt_collect_traces(argc, argv, &ntraces);
 
-    while ((c = getopt_long(argc, argv, "t:D:X:M:nv", long_options,
+    while ((c = getopt_long(argc, argv, "t:D:X:M:b:nv", long_options,
                             NULL)) != -1) {
         switch (c) {
             case 't':
@@ -3521,6 +3823,9 @@ main(
                     mandatory[nmandatory++] = optarg;
                 }
                 break;
+            case 'b':
+                backend = optarg;
+                break;
             case 'n':
                 dry_run = 1;
                 break;
@@ -3530,6 +3835,7 @@ main(
             default:
                 fprintf(stderr,
                         "usage: %s [--trace FILE ...] [--trace-dir DIR] "
+                        "[--backend memfs|diskfs|cairn] "
                         "[--mandatory CAP] [--dry-run] [--verbose]\n",
                         argv[0]);
                 mbt_free_traces(traces, ntraces);
@@ -3548,6 +3854,10 @@ main(
      * the corpus; each trace gets a fresh, uniquely-named memfs and a fresh
      * client identity (g_owner_epoch).  The backchannel recorder is registered
      * once here (it dispatches to the trace-local oracle via g_recall_oracle). */
+    /* memfs_config only reaches the memfs module; diskfs and cairn
+     * self-provision their scratch under the env's session dir. */
+    opts.module = backend;
+
     if (!dry_run) {
         mbt_env_open_opts(&env, &opts);
         env.nfs_v4_cb.recv_call_CB_COMPOUND = v4_cb_compound;

--- a/src/vfs/CMakeLists.txt
+++ b/src/vfs/CMakeLists.txt
@@ -32,6 +32,7 @@ add_library(chimera_vfs SHARED vfs.c vfs_lsan.c
             vfs_proc_delete_key.c vfs_proc_search_keys.c
             vfs_proc_allocate.c vfs_proc_seek.c vfs_proc_lock.c
             vfs_proc_copy_range.c vfs_proc_clone_range.c vfs_proc_move_range.c
+            vfs_proc_read_plus.c vfs_proc_write_same.c
             vfs_proc_getparent.c vfs_notify.c vfs_state.c vfs_dump.c
             vfs_proc_get_xattr.c vfs_proc_set_xattr.c
             vfs_proc_list_xattrs.c vfs_proc_remove_xattr.c

--- a/src/vfs/CMakeLists.txt
+++ b/src/vfs/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library(chimera_vfs SHARED vfs.c vfs_lsan.c vfs_cred.c vfs_sdk_utils.c
             vfs_proc_delete_key.c vfs_proc_search_keys.c
             vfs_proc_allocate.c vfs_proc_seek.c vfs_proc_lock.c
             vfs_proc_copy_range.c vfs_proc_clone_range.c vfs_proc_move_range.c
+            vfs_proc_read_plus.c vfs_proc_write_same.c
             vfs_proc_getparent.c vfs_notify.c vfs_dump.c
             vfs_claim.c vfs_claim_break.c vfs_claim_io.c vfs_claim_backend.c
             vfs_proc_lease_acquire.c vfs_proc_lease_release.c

--- a/src/vfs/diskfs/CMakeLists.txt
+++ b/src/vfs/diskfs/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(chimera_vfs_diskfs SHARED
     diskfs_attr.c
     diskfs_block.c
     diskfs_btree.c
+    diskfs_clone.c
     diskfs_inode.c
     diskfs_io.c
     diskfs_log.c

--- a/src/vfs/diskfs/diskfs.c
+++ b/src/vfs/diskfs/diskfs.c
@@ -85,6 +85,15 @@ diskfs_dispatch(
         case CHIMERA_VFS_OP_SEEK:
             diskfs_seek(thread, shared, request, private_data);
             break;
+        case CHIMERA_VFS_OP_READ_PLUS:
+            diskfs_read_plus(thread, shared, request, private_data);
+            break;
+        case CHIMERA_VFS_OP_WRITE_SAME:
+            diskfs_write_same(thread, shared, request, private_data);
+            break;
+        case CHIMERA_VFS_OP_CLONE_RANGE:
+            diskfs_clone_range(thread, shared, request, private_data);
+            break;
         case CHIMERA_VFS_OP_SYMLINK_AT:
             diskfs_symlink_at(thread, shared, request, private_data);
             break;
@@ -143,7 +152,9 @@ SYMBOL_EXPORT struct chimera_vfs_module vfs_diskfs = {
          * handle->vfs_private (diskfs_open_fh_inode_cb), which read/write reuse
          * to skip per-I/O inode resolution. */
         CHIMERA_VFS_CAP_OPEN_FILE_REQUIRED | CHIMERA_VFS_CAP_FS_LOCK |
-        CHIMERA_VFS_CAP_CHANGE,
+        CHIMERA_VFS_CAP_CHANGE |
+        CHIMERA_VFS_CAP_READ_PLUS | CHIMERA_VFS_CAP_WRITE_SAME |
+        CHIMERA_VFS_CAP_CLONE_RANGE,
     .init           = diskfs_init,
     .destroy        = diskfs_destroy,
     .thread_init    = diskfs_thread_init,

--- a/src/vfs/diskfs/diskfs.c
+++ b/src/vfs/diskfs/diskfs.c
@@ -130,6 +130,15 @@ diskfs_dispatch(
         case CHIMERA_VFS_OP_SEEK:
             diskfs_seek(thread, shared, request, private_data);
             break;
+        case CHIMERA_VFS_OP_READ_PLUS:
+            diskfs_read_plus(thread, shared, request, private_data);
+            break;
+        case CHIMERA_VFS_OP_WRITE_SAME:
+            diskfs_write_same(thread, shared, request, private_data);
+            break;
+        case CHIMERA_VFS_OP_CLONE_RANGE:
+            diskfs_clone_range(thread, shared, request, private_data);
+            break;
         case CHIMERA_VFS_OP_SYMLINK_AT:
             diskfs_symlink_at(thread, shared, request, private_data);
             break;
@@ -189,7 +198,9 @@ SYMBOL_EXPORT struct chimera_vfs_module vfs_diskfs = {
          * handle->vfs_private (diskfs_open_fh_inode_cb), which read/write reuse
          * to skip per-I/O inode resolution. */
         CHIMERA_VFS_CAP_OPEN_FILE_REQUIRED | CHIMERA_VFS_CAP_FS_LOCK |
-        CHIMERA_VFS_CAP_CHANGE | CHIMERA_VFS_CAP_MKFS,
+        CHIMERA_VFS_CAP_CHANGE | CHIMERA_VFS_CAP_MKFS |
+        CHIMERA_VFS_CAP_READ_PLUS | CHIMERA_VFS_CAP_WRITE_SAME |
+        CHIMERA_VFS_CAP_CLONE_RANGE,
     .init           = diskfs_init,
     .destroy        = diskfs_destroy,
     .thread_init    = diskfs_thread_init,

--- a/src/vfs/diskfs/diskfs_attr.c
+++ b/src/vfs/diskfs/diskfs_attr.c
@@ -623,6 +623,22 @@ diskfs_setattr_trunc_removed_cb(
 } /* diskfs_setattr_trunc_removed_cb */
 
 
+/* Remove the (about-to-be-trimmed-or-dropped) extent's slot; the continuation
+ * reinserts the surviving head for the trim case, or advances. */
+static void
+diskfs_setattr_trunc_remove_slot(struct chimera_vfs_request *request)
+{
+    struct diskfs_request_private *p      = request->plugin_data;
+    struct diskfs_thread          *thread = p->thread;
+    struct diskfs_bt_op           *op     = diskfs_bt_op_alloc(thread);
+    struct diskfs_bt_key           key    = diskfs_extent_key(p->ext_iter.file_offset);
+
+    if (diskfs_bt_remove_async(op, thread, p->txn, p->inode_stash[0], &key,
+                               diskfs_setattr_trunc_removed_cb, request)) {
+        diskfs_setattr_trunc_removed_cb(op, op->result, request);
+    }
+} /* diskfs_setattr_trunc_remove_slot */
+
 static void
 diskfs_setattr_trunc_process(struct chimera_vfs_request *request)
 {
@@ -630,7 +646,6 @@ diskfs_setattr_trunc_process(struct chimera_vfs_request *request)
     struct diskfs_thread          *thread   = p->thread;
     uint64_t                       new_size = p->loop_off;
     uint64_t                       extent_start, extent_end;
-    struct diskfs_bt_op           *op;
 
     if (!p->loop_have) {
         diskfs_setattr_trunc_done(request);
@@ -641,34 +656,29 @@ diskfs_setattr_trunc_process(struct chimera_vfs_request *request)
     extent_end   = extent_start + p->ext_iter.length;
 
     if (extent_start >= new_size) {
-        diskfs_thread_free_space(thread, p->txn, p->ext_iter.device_id,
-                                 p->ext_iter.device_offset,
-                                 SM_ALIGN_UP(p->ext_iter.length));
+        /* Full remove: release the backing (decrement if reflink-shared, freeing
+         * only at the last owner), then drop the slot. */
+        diskfs_ext_release(request, &p->ext_iter, diskfs_setattr_trunc_remove_slot);
+        return;
     } else if (extent_end > new_size) {
         uint64_t old_aligned = SM_ALIGN_UP(p->ext_iter.length);
         uint64_t new_logical = new_size - extent_start;
         uint64_t new_aligned = SM_ALIGN_UP(new_logical);
 
-        if (old_aligned > new_aligned) {
+        /* A shared extent keeps its tail blocks (other owners reference the full
+         * device range; the refcount frees them at the last owner).  Only a
+         * private extent frees the trimmed tail here. */
+        if (!(p->ext_iter.flags & DISKFS_EXT_SHARED) && old_aligned > new_aligned) {
             diskfs_thread_free_space(thread, p->txn, p->ext_iter.device_id,
                                      p->ext_iter.device_offset + new_aligned,
                                      old_aligned - new_aligned);
         }
+        diskfs_setattr_trunc_remove_slot(request);
+        return;
     } else {
         /* Extent entirely within new size: nothing to do, just advance. */
         diskfs_setattr_trunc_advance(request);
         return;
-    }
-
-    /* Both the full-remove and trim cases start by removing the slot. */
-    op = diskfs_bt_op_alloc(thread);
-    {
-        struct diskfs_bt_key key = diskfs_extent_key(extent_start);
-
-        if (diskfs_bt_remove_async(op, thread, p->txn, p->inode_stash[0], &key,
-                                   diskfs_setattr_trunc_removed_cb, request)) {
-            diskfs_setattr_trunc_removed_cb(op, op->result, request);
-        }
     }
 } /* diskfs_setattr_trunc_process */
 
@@ -890,6 +900,7 @@ diskfs_setattr_inode_cb(
     diskfs_apply_attrs(inode, request->setattr.set_attr);
 
     p->inode_stash[0] = inode;
+    p->inode_stash[2] = NULL;   /* refcount inode (acquired lazily on shared free) */
 
     /* Persist the opaque pNFS layout blob as this inode's single PNFS record,
      * replacing any previous one (the insert aborts on a duplicate key).  The

--- a/src/vfs/diskfs/diskfs_attr.c
+++ b/src/vfs/diskfs/diskfs_attr.c
@@ -623,6 +623,22 @@ diskfs_setattr_trunc_removed_cb(
 } /* diskfs_setattr_trunc_removed_cb */
 
 
+/* Remove the (about-to-be-trimmed-or-dropped) extent's slot; the continuation
+ * reinserts the surviving head for the trim case, or advances. */
+static void
+diskfs_setattr_trunc_remove_slot(struct chimera_vfs_request *request)
+{
+    struct diskfs_request_private *p      = request->plugin_data;
+    struct diskfs_thread          *thread = p->thread;
+    struct diskfs_bt_op           *op     = diskfs_bt_op_alloc(thread);
+    struct diskfs_bt_key           key    = diskfs_extent_key(p->ext_iter.file_offset);
+
+    if (diskfs_bt_remove_async(op, thread, p->txn, p->inode_stash[0], &key,
+                               diskfs_setattr_trunc_removed_cb, request)) {
+        diskfs_setattr_trunc_removed_cb(op, op->result, request);
+    }
+} /* diskfs_setattr_trunc_remove_slot */
+
 static void
 diskfs_setattr_trunc_process(struct chimera_vfs_request *request)
 {
@@ -630,7 +646,6 @@ diskfs_setattr_trunc_process(struct chimera_vfs_request *request)
     struct diskfs_thread          *thread   = p->thread;
     uint64_t                       new_size = p->loop_off;
     uint64_t                       extent_start, extent_end;
-    struct diskfs_bt_op           *op;
 
     if (!p->loop_have) {
         diskfs_setattr_trunc_done(request);
@@ -641,34 +656,29 @@ diskfs_setattr_trunc_process(struct chimera_vfs_request *request)
     extent_end   = extent_start + p->ext_iter.length;
 
     if (extent_start >= new_size) {
-        diskfs_thread_free_space(thread, p->txn, p->ext_iter.device_id,
-                                 p->ext_iter.device_offset,
-                                 SM_ALIGN_UP(p->ext_iter.length));
+        /* Full remove: release the backing (decrement if reflink-shared, freeing
+         * only at the last owner), then drop the slot. */
+        diskfs_ext_release(request, &p->ext_iter, diskfs_setattr_trunc_remove_slot);
+        return;
     } else if (extent_end > new_size) {
         uint64_t old_aligned = SM_ALIGN_UP(p->ext_iter.length);
         uint64_t new_logical = new_size - extent_start;
         uint64_t new_aligned = SM_ALIGN_UP(new_logical);
 
-        if (old_aligned > new_aligned) {
+        /* A shared extent keeps its tail blocks (other owners reference the full
+         * device range; the refcount frees them at the last owner).  Only a
+         * private extent frees the trimmed tail here. */
+        if (!(p->ext_iter.flags & DISKFS_EXT_SHARED) && old_aligned > new_aligned) {
             diskfs_thread_free_space(thread, p->txn, p->ext_iter.device_id,
                                      p->ext_iter.device_offset + new_aligned,
                                      old_aligned - new_aligned);
         }
+        diskfs_setattr_trunc_remove_slot(request);
+        return;
     } else {
         /* Extent entirely within new size: nothing to do, just advance. */
         diskfs_setattr_trunc_advance(request);
         return;
-    }
-
-    /* Both the full-remove and trim cases start by removing the slot. */
-    op = diskfs_bt_op_alloc(thread);
-    {
-        struct diskfs_bt_key key = diskfs_extent_key(extent_start);
-
-        if (diskfs_bt_remove_async(op, thread, p->txn, p->inode_stash[0], &key,
-                                   diskfs_setattr_trunc_removed_cb, request)) {
-            diskfs_setattr_trunc_removed_cb(op, op->result, request);
-        }
     }
 } /* diskfs_setattr_trunc_process */
 
@@ -913,6 +923,7 @@ diskfs_setattr_inode_cb(
     }
 
     p->inode_stash[0] = inode;
+    p->inode_stash[2] = NULL;   /* refcount inode (acquired lazily on shared free) */
 
     /* Persist the opaque pNFS layout blob as this inode's single PNFS record,
      * replacing any previous one (the insert aborts on a duplicate key).  The

--- a/src/vfs/diskfs/diskfs_clone.c
+++ b/src/vfs/diskfs/diskfs_clone.c
@@ -1,0 +1,915 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * Reflink (NFSv4.2 CLONE) for diskfs: true copy-on-write sharing of byte ranges
+ * between files.
+ *
+ * Sharing is tracked by a refcount per shared device range, stored as
+ * DISKFS_REC_REFCOUNT records in a statically-reserved refcount inode
+ * (DISKFS_REFCOUNT_INUM_BASE).  An extent that participates in sharing carries
+ * the DISKFS_EXT_SHARED flag; a write to such an extent must copy-on-write
+ * (diskfs_cow_privatize, driven from the write path) and a free of such an
+ * extent must decrement instead of releasing the backing space
+ * (diskfs_ext_release, called from truncate/unlink/deallocate).
+ *
+ * Refcount semantics: a device range with a sole owner has NO record (implicit
+ * count 1) and is not flagged SHARED.  The first clone creates a record with
+ * count 2 and flags both extents SHARED.  Privatizing or freeing a shared
+ * extent decrements; at count 1 the record is removed (one owner remains, who
+ * keeps the blocks); a decrement that finds no record means this was the last
+ * owner and the blocks are freed.
+ *
+ * Crash consistency: every refcount record update, extent-map change, and the
+ * conditional space free all ride the one diskfs txn (redo log), so a crash
+ * either keeps or discards the whole clone/CoW atomically.
+ */
+
+#include "diskfs_internal.h"
+#include <sys/stat.h>
+
+#define DISKFS_COW_CHUNK (1ULL << 20)   /* device-copy chunk for privatization */
+
+static struct diskfs_inode *
+diskfs_refcount_inode(struct chimera_vfs_request *request)
+{
+    struct diskfs_request_private *p = request->plugin_data;
+
+    return p->inode_stash[2];
+} /* diskfs_refcount_inode */
+
+/* ---------------------------------------------------------------- refcount inc */
+
+static void
+diskfs_refcount_inc_inserted_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+
+    (void) result;
+    diskfs_bt_op_free(p->thread, op);
+    p->rc_cont(request);
+} /* diskfs_refcount_inc_inserted_cb */
+
+static void
+diskfs_refcount_inc_insert(struct chimera_vfs_request *request)
+{
+    struct diskfs_request_private *p      = request->plugin_data;
+    struct diskfs_thread          *thread = p->thread;
+    struct diskfs_bt_key           key    = diskfs_refcount_key(p->rc_devid, p->rc_devoff);
+    struct diskfs_refcount_rec     rec    = { .length = p->rc_length, .refcount = p->rc_newcount };
+    struct diskfs_bt_op           *op     = diskfs_bt_op_alloc(thread);
+
+    if (diskfs_bt_insert_async(op, thread, p->txn, diskfs_refcount_inode(request),
+                               &key, &rec, sizeof(rec),
+                               diskfs_refcount_inc_inserted_cb, request)) {
+        diskfs_refcount_inc_inserted_cb(op, op->result, request);
+    }
+} /* diskfs_refcount_inc_insert */
+
+static void
+diskfs_refcount_inc_removed_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+
+    (void) result;
+    diskfs_bt_op_free(p->thread, op);
+    diskfs_refcount_inc_insert(request);
+} /* diskfs_refcount_inc_removed_cb */
+
+static void
+diskfs_refcount_inc_lookup_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+    struct diskfs_thread          *thread  = p->thread;
+    int                            found   = (result >= 0);
+
+    if (found) {
+        struct diskfs_refcount_rec *rec = (struct diskfs_refcount_rec *) p->rec_scratch;
+        p->rc_newcount = rec->refcount + 1;
+    } else {
+        p->rc_newcount = 2;     /* sole owner (implicit 1) + this new share */
+    }
+    diskfs_bt_op_free(thread, op);
+
+    if (found) {
+        struct diskfs_bt_key key = diskfs_refcount_key(p->rc_devid, p->rc_devoff);
+        op = diskfs_bt_op_alloc(thread);
+        if (diskfs_bt_remove_async(op, thread, p->txn, diskfs_refcount_inode(request),
+                                   &key, diskfs_refcount_inc_removed_cb, request)) {
+            diskfs_refcount_inc_removed_cb(op, op->result, request);
+        }
+    } else {
+        diskfs_refcount_inc_insert(request);
+    }
+} /* diskfs_refcount_inc_lookup_cb */
+
+void
+diskfs_refcount_inc(
+    struct chimera_vfs_request *request,
+    uint32_t                    device_id,
+    uint64_t                    device_offset,
+    uint64_t                    length,
+    void (                     *cont )(struct chimera_vfs_request *))
+{
+    struct diskfs_request_private *p      = request->plugin_data;
+    struct diskfs_thread          *thread = p->thread;
+    struct diskfs_bt_key           key    = diskfs_refcount_key(device_id, device_offset);
+    struct diskfs_bt_op           *op;
+
+    p->rc_devid  = device_id;
+    p->rc_devoff = device_offset;
+    p->rc_length = length;
+    p->rc_cont   = cont;
+
+    op = diskfs_bt_op_alloc(thread);
+    if (diskfs_bt_lookup_async(op, thread, diskfs_refcount_inode(request),
+                               DISKFS_BT_OP_LOOKUP_EXACT, &key, &op->found_key,
+                               p->rec_scratch, sizeof(struct diskfs_refcount_rec),
+                               diskfs_refcount_inc_lookup_cb, request)) {
+        diskfs_refcount_inc_lookup_cb(op, op->result, request);
+    }
+} /* diskfs_refcount_inc */
+
+/* ---------------------------------------------------------------- refcount dec */
+
+static void
+diskfs_refcount_dec_done_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+
+    (void) result;
+    diskfs_bt_op_free(p->thread, op);
+    p->rc_cont(request);
+} /* diskfs_refcount_dec_done_cb */
+
+static void
+diskfs_refcount_dec_removed_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+    struct diskfs_thread          *thread  = p->thread;
+
+    (void) result;
+    diskfs_bt_op_free(thread, op);
+
+    if (p->rc_newcount >= 2) {
+        /* Still shared by others: reinsert the decremented record. */
+        struct diskfs_bt_key       key = diskfs_refcount_key(p->rc_devid, p->rc_devoff);
+        struct diskfs_refcount_rec rec = { .length = p->rc_length, .refcount = p->rc_newcount };
+        op = diskfs_bt_op_alloc(thread);
+        if (diskfs_bt_insert_async(op, thread, p->txn, diskfs_refcount_inode(request),
+                                   &key, &rec, sizeof(rec),
+                                   diskfs_refcount_dec_done_cb, request)) {
+            diskfs_refcount_dec_done_cb(op, op->result, request);
+        }
+        return;
+    }
+
+    /* Dropped to a single owner: no record (implicit 1), do not free. */
+    p->rc_cont(request);
+} /* diskfs_refcount_dec_removed_cb */
+
+static void
+diskfs_refcount_dec_lookup_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+    struct diskfs_thread          *thread  = p->thread;
+    int                            found   = (result >= 0);
+
+    if (!found) {
+        /* No record: this was the last (sole) owner, so the caller frees. */
+        diskfs_bt_op_free(thread, op);
+        p->rc_should_free = 1;
+        p->rc_cont(request);
+        return;
+    }
+
+    struct diskfs_refcount_rec *rec = (struct diskfs_refcount_rec *) p->rec_scratch;
+    p->rc_length      = rec->length;
+    p->rc_newcount    = rec->refcount - 1;
+    p->rc_should_free = 0;
+    diskfs_bt_op_free(thread, op);
+
+    struct diskfs_bt_key        key = diskfs_refcount_key(p->rc_devid, p->rc_devoff);
+    op = diskfs_bt_op_alloc(thread);
+    if (diskfs_bt_remove_async(op, thread, p->txn, diskfs_refcount_inode(request),
+                               &key, diskfs_refcount_dec_removed_cb, request)) {
+        diskfs_refcount_dec_removed_cb(op, op->result, request);
+    }
+} /* diskfs_refcount_dec_lookup_cb */
+
+void
+diskfs_refcount_dec(
+    struct chimera_vfs_request *request,
+    uint32_t                    device_id,
+    uint64_t                    device_offset,
+    void (                     *cont )(struct chimera_vfs_request *))
+{
+    struct diskfs_request_private *p      = request->plugin_data;
+    struct diskfs_thread          *thread = p->thread;
+    struct diskfs_bt_key           key    = diskfs_refcount_key(device_id, device_offset);
+    struct diskfs_bt_op           *op;
+
+    p->rc_devid       = device_id;
+    p->rc_devoff      = device_offset;
+    p->rc_should_free = 0;
+    p->rc_cont        = cont;
+
+    op = diskfs_bt_op_alloc(thread);
+    if (diskfs_bt_lookup_async(op, thread, diskfs_refcount_inode(request),
+                               DISKFS_BT_OP_LOOKUP_EXACT, &key, &op->found_key,
+                               p->rec_scratch, sizeof(struct diskfs_refcount_rec),
+                               diskfs_refcount_dec_lookup_cb, request)) {
+        diskfs_refcount_dec_lookup_cb(op, op->result, request);
+    }
+} /* diskfs_refcount_dec */
+
+/* ----------------------------------------------- copy-on-write: privatize one */
+
+static void
+diskfs_cow_replace_done_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+
+    (void) result;
+    diskfs_bt_op_free(p->thread, op);
+    p->cow_cont(request);
+} /* diskfs_cow_replace_done_cb */
+
+/* After the device copy and the refcount decrement: free the old blocks if this
+ * was the last owner, then resume. */
+static void
+diskfs_cow_after_dec(struct chimera_vfs_request *request)
+{
+    struct diskfs_request_private *p = request->plugin_data;
+
+    if (p->rc_should_free) {
+        diskfs_thread_free_space(p->thread, p->txn, p->cow_ext.device_id,
+                                 p->cow_ext.device_offset,
+                                 SM_ALIGN_UP(p->cow_ext.length));
+    }
+    p->cow_cont(request);
+} /* diskfs_cow_after_dec */
+
+/* Old extent removed; insert the private replacement, then drop the refcount. */
+static void
+diskfs_cow_inserted_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+
+    (void) result;
+    diskfs_bt_op_free(p->thread, op);
+
+    diskfs_refcount_dec(request, p->cow_ext.device_id, p->cow_ext.device_offset,
+                        diskfs_cow_after_dec);
+} /* diskfs_cow_inserted_cb */
+
+static void
+diskfs_cow_removed_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+    struct diskfs_thread          *thread  = p->thread;
+
+    (void) result;
+    diskfs_bt_op_free(thread, op);
+
+    op = diskfs_bt_op_alloc(thread);
+    if (diskfs_ext_insert_async(op, thread, p->txn, p->inode_stash[0],
+                                p->cow_ext.file_offset, p->cow_ext.length,
+                                p->cow_new_devid, p->cow_new_devoff,
+                                p->cow_ext.flags & ~(uint32_t) DISKFS_EXT_SHARED,
+                                diskfs_cow_inserted_cb, request)) {
+        diskfs_cow_inserted_cb(op, op->result, request);
+    }
+} /* diskfs_cow_removed_cb */
+
+/* Device copy complete: swap the shared extent record for the private copy. */
+static void
+diskfs_cow_replace(struct chimera_vfs_request *request)
+{
+    struct diskfs_request_private *p      = request->plugin_data;
+    struct diskfs_thread          *thread = p->thread;
+    struct diskfs_bt_op           *op     = diskfs_bt_op_alloc(thread);
+
+    if (diskfs_ext_remove_async(op, thread, p->txn, p->inode_stash[0],
+                                p->cow_ext.file_offset, diskfs_cow_removed_cb,
+                                request)) {
+        diskfs_cow_removed_cb(op, op->result, request);
+    }
+} /* diskfs_cow_replace */
+
+/* Chunked device-to-device copy of the shared extent into the freshly allocated
+ * private blocks.  Each chunk is read then written before advancing. */
+static void diskfs_cow_copy_step(
+    struct chimera_vfs_request *request);
+
+static void
+diskfs_cow_write_cb(
+    struct evpl *evpl,
+    int          status,
+    void        *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+    struct diskfs_thread          *thread  = p->thread;
+
+    (void) evpl;
+    diskfs_pending_io_add(thread, -1);
+    diskfs_io_resume_waiters(thread);
+
+    evpl_iovecs_release(thread->evpl, p->iov, p->niov);
+    p->niov = 0;
+
+    if (status) {
+        diskfs_op_fail(request, p->txn, status);
+        return;
+    }
+    diskfs_cow_copy_step(request);
+} /* diskfs_cow_write_cb */
+
+static void
+diskfs_cow_read_cb(
+    struct evpl *evpl,
+    int          status,
+    void        *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+    struct diskfs_thread          *thread  = p->thread;
+    struct diskfs_shared          *shared  = thread->shared;
+
+    (void) evpl;
+    diskfs_pending_io_add(thread, -1);
+    diskfs_io_resume_waiters(thread);
+
+    if (status) {
+        evpl_iovecs_release(thread->evpl, p->iov, p->niov);
+        p->niov = 0;
+        diskfs_op_fail(request, p->txn, status);
+        return;
+    }
+
+    /* Write the chunk just read to the new private device range. */
+    uint64_t off   = p->cow_copied;
+    uint64_t left  = p->cow_ext.length - off;
+    uint64_t chunk = left < DISKFS_COW_CHUNK ? left : DISKFS_COW_CHUNK;
+
+    p->cow_copied += chunk;
+    diskfs_pending_io_add(thread, 1);
+    evpl_block_write(thread->evpl, thread->queue[p->cow_new_devid],
+                     p->iov, p->niov,
+                     p->cow_new_devoff + off, !shared->unsafe_async,
+                     diskfs_cow_write_cb, request);
+} /* diskfs_cow_read_cb */
+
+static void
+diskfs_cow_copy_step(struct chimera_vfs_request *request)
+{
+    struct diskfs_request_private *p      = request->plugin_data;
+    struct diskfs_thread          *thread = p->thread;
+    struct diskfs_shared          *shared = thread->shared;
+    struct evpl                   *evpl   = thread->evpl;
+    uint64_t                       off    = p->cow_copied;
+    uint64_t                       left   = p->cow_ext.length - off;
+    uint64_t                       chunk;
+
+    if (left == 0) {
+        diskfs_cow_replace(request);
+        return;
+    }
+
+    if (diskfs_io_gate(thread, request, diskfs_cow_copy_step)) {
+        return;
+    }
+
+    chunk = left < DISKFS_COW_CHUNK ? left : DISKFS_COW_CHUNK;
+
+    p->niov = evpl_iovec_alloc(evpl, chunk, 4096, 32, 0, p->iov);
+    if (p->niov <= 0) {
+        diskfs_op_fail(request, p->txn, CHIMERA_VFS_EIO);
+        return;
+    }
+
+    diskfs_pending_io_add(thread, 1);
+    evpl_block_read(evpl, thread->queue[p->cow_ext.device_id], p->iov, p->niov,
+                    p->cow_ext.device_offset + off, diskfs_cow_read_cb, request);
+    (void) shared;
+} /* diskfs_cow_copy_step */
+
+static void
+diskfs_cow_alloc_resume(
+    struct diskfs_thread *thread,
+    void                 *arg);
+
+static void
+diskfs_cow_alloc(struct chimera_vfs_request *request)
+{
+    struct diskfs_request_private *p      = request->plugin_data;
+    struct diskfs_thread          *thread = p->thread;
+    uint64_t                       dev_id, dev_off;
+    int                            rc;
+
+    rc = diskfs_inode_alloc_space(thread, p->txn, p->inode_stash[0],
+                                  (int64_t) p->cow_ext.length, SM_RESERVATION_MIN,
+                                  &dev_id, &dev_off, diskfs_cow_alloc_resume, request);
+    if (rc == SM_AGAIN) {
+        return;
+    }
+    if (rc) {
+        diskfs_op_fail(request, p->txn, CHIMERA_VFS_ENOSPC);
+        return;
+    }
+
+    p->cow_new_devid  = (uint32_t) dev_id;
+    p->cow_new_devoff = dev_off;
+    p->cow_copied     = 0;
+    diskfs_cow_copy_step(request);
+} /* diskfs_cow_alloc */
+
+static void
+diskfs_cow_alloc_resume(
+    struct diskfs_thread *thread,
+    void                 *arg)
+{
+    (void) thread;
+    diskfs_cow_alloc((struct chimera_vfs_request *) arg);
+} /* diskfs_cow_alloc_resume */
+
+void
+diskfs_cow_privatize(
+    struct chimera_vfs_request *request,
+    const struct diskfs_extent *ext,
+    void (                     *cont )(struct chimera_vfs_request *))
+{
+    struct diskfs_request_private *p = request->plugin_data;
+
+    p->cow_ext  = *ext;
+    p->cow_cont = cont;
+    diskfs_cow_alloc(request);
+} /* diskfs_cow_privatize */
+
+/* --------------------------------------------- ext_release (truncate/unlink/dealloc)
+ *
+ * Release one extent's backing space.  A non-shared extent is freed directly; a
+ * shared extent decrements its refcount and frees the device range only when it
+ * was the last owner.  The refcount inode must already be acquired at
+ * inode_stash[2] (the caller acquires it lazily when it meets a shared extent). */
+
+static void
+diskfs_ext_release_after_dec(struct chimera_vfs_request *request)
+{
+    struct diskfs_request_private *p = request->plugin_data;
+
+    if (p->rc_should_free) {
+        diskfs_thread_free_space(p->thread, p->txn, p->rc_devid, p->rc_devoff,
+                                 SM_ALIGN_UP(p->rc_length));
+    }
+    p->rc_cont(request);
+} /* diskfs_ext_release_after_dec */
+
+/* Lazily acquired the refcount inode for a free of a shared extent; retry. */
+static void
+diskfs_ext_release_acquired_cb(
+    struct diskfs_inode *inode,
+    int                  status,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+
+    if (unlikely(status != CHIMERA_VFS_OK)) {
+        diskfs_op_fail(request, p->txn, status);
+        return;
+    }
+
+    p->inode_stash[2] = inode;
+    diskfs_ext_release(request, &p->cow_ext, p->cow_cont);
+} /* diskfs_ext_release_acquired_cb */
+
+void
+diskfs_ext_release(
+    struct chimera_vfs_request *request,
+    const struct diskfs_extent *ext,
+    void (                     *cont )(struct chimera_vfs_request *))
+{
+    struct diskfs_request_private *p = request->plugin_data;
+
+    if (ext->flags & DISKFS_EXT_SHARED) {
+        if (p->inode_stash[2] == NULL) {
+            /* Acquire the refcount inode (lock leaf, last), then retry. */
+            p->cow_ext  = *ext;
+            p->cow_cont = cont;
+            diskfs_inode_acquire(p->thread, p->txn, DISKFS_REFCOUNT_INUM_BASE,
+                                 DISKFS_REFCOUNT_GEN, DISKFS_INODE_LOCK_WRITE,
+                                 diskfs_ext_release_acquired_cb, request);
+            return;
+        }
+        p->rc_cont   = cont;
+        p->rc_length = ext->length;
+        diskfs_refcount_dec(request, ext->device_id, ext->device_offset,
+                            diskfs_ext_release_after_dec);
+        return;
+    }
+
+    diskfs_thread_free_space(p->thread, p->txn, ext->device_id,
+                             ext->device_offset, SM_ALIGN_UP(ext->length));
+    cont(request);
+} /* diskfs_ext_release */
+
+/* --------------------------------------------------------------------- CLONE */
+
+static void diskfs_clone_walk(
+    struct chimera_vfs_request *request);
+
+static void diskfs_clone_walk_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *private_data);
+
+static void
+diskfs_clone_finalize(struct chimera_vfs_request *request)
+{
+    struct diskfs_request_private *p      = request->plugin_data;
+    struct diskfs_thread          *thread = p->thread;
+    struct diskfs_inode           *dst    = p->inode_stash[0];
+    uint64_t                       end    = p->clone_dst_base +
+        (p->loop_pos - p->clone_src_base);
+    struct timespec                now;
+
+    if (end > dst->size) {
+        dst->size       = end;
+        dst->space_used = (dst->size + 4095) & ~4095;
+    }
+
+    clock_gettime(CLOCK_REALTIME, &now);
+    dst->mtime_sec  = now.tv_sec;
+    dst->mtime_nsec = now.tv_nsec;
+    dst->ctime_sec  = now.tv_sec;
+    dst->ctime_nsec = now.tv_nsec;
+
+    diskfs_map_attrs(thread, &request->clone_range.r_post_attr, dst);
+    diskfs_op_ok(request, p->txn);
+} /* diskfs_clone_finalize */
+
+static void
+diskfs_clone_advance(struct chimera_vfs_request *request)
+{
+    struct diskfs_request_private *p      = request->plugin_data;
+    struct diskfs_thread          *thread = p->thread;
+    struct diskfs_bt_op           *op     = diskfs_bt_op_alloc(thread);
+
+    /* Step to the extent following the one just processed.  (A plain re-floor of
+     * an advanced offset would return the same extent again, since floor is the
+     * largest key <= offset.) */
+    if (diskfs_ext_next_async(op, thread, p->inode_stash[1], p->ext_iter.file_offset,
+                              p->rec_scratch, sizeof(p->rec_scratch),
+                              diskfs_clone_walk_cb, request)) {
+        diskfs_clone_walk_cb(op, op->result, request);
+    }
+} /* diskfs_clone_advance */
+
+/* Bump the share count for the overlap, then advance. */
+static void
+diskfs_clone_share_refcount(struct chimera_vfs_request *request)
+{
+    struct diskfs_request_private *p      = request->plugin_data;
+    struct diskfs_extent          *e      = &p->ext_iter;
+    uint64_t                       ostart = e->file_offset > p->clone_src_base ?
+        e->file_offset : p->clone_src_base;
+    uint64_t                       oend = (e->file_offset + e->length) < p->loop_pos ?
+        (e->file_offset + e->length) : p->loop_pos;
+    uint64_t                       odevoff = e->device_offset + (ostart - e->file_offset);
+
+    diskfs_refcount_inc(request, e->device_id, odevoff, oend - ostart,
+                        diskfs_clone_advance);
+} /* diskfs_clone_share_refcount */
+
+/* Insert the destination extent (shared) for the overlap, then bump refcount. */
+static void
+diskfs_clone_dst_inserted_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+
+    (void) result;
+    diskfs_bt_op_free(p->thread, op);
+    diskfs_clone_share_refcount(request);
+} /* diskfs_clone_dst_inserted_cb */
+
+static void
+diskfs_clone_insert_dst(struct chimera_vfs_request *request)
+{
+    struct diskfs_request_private *p      = request->plugin_data;
+    struct diskfs_thread          *thread = p->thread;
+    struct diskfs_extent          *e      = &p->ext_iter;
+    uint64_t                       ostart = e->file_offset > p->clone_src_base ?
+        e->file_offset : p->clone_src_base;
+    uint64_t                       oend = (e->file_offset + e->length) < p->loop_pos ?
+        (e->file_offset + e->length) : p->loop_pos;
+    uint64_t                       odevoff = e->device_offset + (ostart - e->file_offset);
+    uint64_t                       dst_off = p->clone_dst_base + (ostart - p->clone_src_base);
+    struct diskfs_bt_op           *op      = diskfs_bt_op_alloc(thread);
+
+    if (diskfs_ext_insert_async(op, thread, p->txn, p->inode_stash[0],
+                                dst_off, oend - ostart, e->device_id, odevoff,
+                                (e->flags | DISKFS_EXT_SHARED) & ~(uint32_t) DISKFS_EXT_UNWRITTEN,
+                                diskfs_clone_dst_inserted_cb, request)) {
+        diskfs_clone_dst_inserted_cb(op, op->result, request);
+    }
+} /* diskfs_clone_insert_dst */
+
+/* Source-side: rewrite e as [head][overlap=SHARED][tail] so the shared piece is
+ * its own extent (devoff == the overlap's), then insert the destination. */
+static void
+diskfs_clone_src_step(
+    struct chimera_vfs_request *request,
+    int                         stage);
+
+static void
+diskfs_clone_src_step_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+
+    (void) result;
+    diskfs_bt_op_free(p->thread, op);
+    diskfs_clone_src_step(request, (int) p->op_scratch);
+} /* diskfs_clone_src_step_cb */
+
+static void
+diskfs_clone_src_step(
+    struct chimera_vfs_request *request,
+    int                         stage)
+{
+    struct diskfs_request_private *p       = request->plugin_data;
+    struct diskfs_thread          *thread  = p->thread;
+    struct diskfs_extent          *e       = &p->ext_iter;
+    uint64_t                       estart  = e->file_offset;
+    uint64_t                       eend    = e->file_offset + e->length;
+    uint64_t                       ostart  = estart > p->clone_src_base ? estart : p->clone_src_base;
+    uint64_t                       oend    = eend < p->loop_pos ? eend : p->loop_pos;
+    uint64_t                       odevoff = e->device_offset + (ostart - estart);
+    struct diskfs_bt_op           *op;
+
+    p->op_scratch = stage + 1;
+
+    switch (stage) {
+        case 0:     /* remove the original source extent */
+            op = diskfs_bt_op_alloc(thread);
+            if (diskfs_ext_remove_async(op, thread, p->txn, p->inode_stash[1],
+                                        estart, diskfs_clone_src_step_cb, request)) {
+                diskfs_clone_src_step_cb(op, op->result, request);
+            }
+            return;
+        case 1:     /* head [estart, ostart) keeps the original (non-shared) flags */
+            if (ostart > estart) {
+                op = diskfs_bt_op_alloc(thread);
+                if (diskfs_ext_insert_async(op, thread, p->txn, p->inode_stash[1],
+                                            estart, ostart - estart, e->device_id,
+                                            e->device_offset, e->flags,
+                                            diskfs_clone_src_step_cb, request)) {
+                    diskfs_clone_src_step_cb(op, op->result, request);
+                }
+                return;
+            }
+            diskfs_clone_src_step(request, 2);
+            return;
+        case 2:     /* overlap [ostart, oend) becomes SHARED */
+            op = diskfs_bt_op_alloc(thread);
+            if (diskfs_ext_insert_async(op, thread, p->txn, p->inode_stash[1],
+                                        ostart, oend - ostart, e->device_id, odevoff,
+                                        e->flags | DISKFS_EXT_SHARED,
+                                        diskfs_clone_src_step_cb, request)) {
+                diskfs_clone_src_step_cb(op, op->result, request);
+            }
+            return;
+        case 3:     /* tail [oend, eend) keeps the original flags */
+            if (oend < eend) {
+                op = diskfs_bt_op_alloc(thread);
+                if (diskfs_ext_insert_async(op, thread, p->txn, p->inode_stash[1],
+                                            oend, eend - oend, e->device_id,
+                                            e->device_offset + (oend - estart), e->flags,
+                                            diskfs_clone_src_step_cb, request)) {
+                    diskfs_clone_src_step_cb(op, op->result, request);
+                }
+                return;
+            }
+            diskfs_clone_src_step(request, 4);
+            return;
+        default:    /* done splitting source; record the destination extent */
+            diskfs_clone_insert_dst(request);
+            return;
+    } /* switch */
+} /* diskfs_clone_src_step */
+
+static void
+diskfs_clone_walk_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+    int                            have;
+
+    have = diskfs_ext_from_op(op, result, &p->ext_iter);
+    diskfs_bt_op_free(p->thread, op);
+
+    if (!have || p->ext_iter.file_offset >= p->loop_pos) {
+        diskfs_clone_finalize(request);
+        return;
+    }
+
+    uint64_t estart = p->ext_iter.file_offset;
+    uint64_t eend   = estart + p->ext_iter.length;
+    uint64_t ostart = estart > p->clone_src_base ? estart : p->clone_src_base;
+    uint64_t oend   = eend < p->loop_pos ? eend : p->loop_pos;
+
+    /* Skip holes and reserved-but-unwritten ranges: the destination simply has
+     * no extent there and reads as zeros, matching the source. */
+    if (ostart >= oend || (p->ext_iter.flags & DISKFS_EXT_UNWRITTEN)) {
+        diskfs_clone_advance(request);
+        return;
+    }
+
+    diskfs_clone_src_step(request, 0);
+} /* diskfs_clone_walk_cb */
+
+static void
+diskfs_clone_walk(struct chimera_vfs_request *request)
+{
+    struct diskfs_request_private *p      = request->plugin_data;
+    struct diskfs_thread          *thread = p->thread;
+    struct diskfs_bt_op           *op     = diskfs_bt_op_alloc(thread);
+
+    /* Walk the source extents covering [loop_off, loop_pos). */
+    if (diskfs_ext_floor_async(op, thread, p->inode_stash[1], p->loop_off,
+                               p->rec_scratch, sizeof(p->rec_scratch),
+                               diskfs_clone_walk_cb, request)) {
+        diskfs_clone_walk_cb(op, op->result, request);
+    }
+} /* diskfs_clone_walk */
+
+static void
+diskfs_clone_rc_acquired_cb(
+    struct diskfs_inode *inode,
+    int                  status,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+    struct diskfs_inode           *src     = (struct diskfs_inode *) request->clone_range.src_handle->vfs_private;
+    struct diskfs_inode           *dst     = (struct diskfs_inode *) request->clone_range.dst_handle->vfs_private;
+
+    if (unlikely(status != CHIMERA_VFS_OK)) {
+        diskfs_op_fail(request, p->txn, status);
+        return;
+    }
+
+    p->inode_stash[0] = dst;
+    p->inode_stash[1] = src;
+    p->inode_stash[2] = inode;     /* refcount inode (acquired last) */
+
+    diskfs_map_attrs(p->thread, &request->clone_range.r_pre_attr, dst);
+
+    p->clone_src_base = request->clone_range.src_offset;
+    p->clone_dst_base = request->clone_range.dst_offset;
+    p->loop_off       = request->clone_range.src_offset;
+    p->loop_pos       = request->clone_range.src_offset + request->clone_range.length;
+
+    diskfs_clone_walk(request);
+} /* diskfs_clone_rc_acquired_cb */
+
+static void
+diskfs_clone_second_cb(
+    struct diskfs_inode *inode,
+    int                  status,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+
+    if (unlikely(status != CHIMERA_VFS_OK)) {
+        diskfs_op_fail(request, p->txn, status);
+        return;
+    }
+
+    /* Acquire the refcount inode last (it is a deadlock-free lock leaf: only
+     * clone / CoW / shared-free touch it, and always after their file inodes). */
+    diskfs_inode_acquire(p->thread, p->txn, DISKFS_REFCOUNT_INUM_BASE,
+                         DISKFS_REFCOUNT_GEN, DISKFS_INODE_LOCK_WRITE,
+                         diskfs_clone_rc_acquired_cb, request);
+} /* diskfs_clone_second_cb */
+
+static void
+diskfs_clone_first_cb(
+    struct diskfs_inode *inode,
+    int                  status,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+    struct diskfs_inode           *src     = (struct diskfs_inode *) request->clone_range.src_handle->vfs_private;
+    struct diskfs_inode           *dst     = (struct diskfs_inode *) request->clone_range.dst_handle->vfs_private;
+    struct diskfs_inode           *second;
+
+    if (unlikely(status != CHIMERA_VFS_OK)) {
+        diskfs_op_fail(request, p->txn, status);
+        return;
+    }
+
+    second = (src->inum < dst->inum) ? dst : src;
+    diskfs_inode_acquire_pinned(p->thread, p->txn, second,
+                                DISKFS_INODE_LOCK_WRITE, diskfs_clone_second_cb,
+                                request);
+} /* diskfs_clone_first_cb */
+
+void
+diskfs_clone_range(
+    struct diskfs_thread       *thread,
+    struct diskfs_shared       *shared,
+    struct chimera_vfs_request *request,
+    void                       *private_data)
+{
+    struct diskfs_request_private *p   = request->plugin_data;
+    struct diskfs_inode           *src = (struct diskfs_inode *) request->clone_range.src_handle->vfs_private;
+    struct diskfs_inode           *dst = (struct diskfs_inode *) request->clone_range.dst_handle->vfs_private;
+    struct diskfs_inode           *first;
+
+    (void) private_data;
+
+    if (unlikely(shared->block_layout || shared->scsi_layout)) {
+        request->status = CHIMERA_VFS_EINVAL;
+        request->complete(request);
+        return;
+    }
+
+    /* Block-aligned ranges only (reflink shares whole device blocks). */
+    if ((request->clone_range.src_offset & 4095) ||
+        (request->clone_range.dst_offset & 4095) ||
+        (request->clone_range.length & 4095)) {
+        request->status = CHIMERA_VFS_EINVAL;
+        request->complete(request);
+        return;
+    }
+
+    p->thread  = thread;
+    p->status  = 0;
+    p->pending = 0;
+    p->niov    = 0;
+    p->txn     = diskfs_txn_begin(thread, DISKFS_TXN_WRITE);
+
+    if (request->clone_range.length == 0) {
+        diskfs_map_attrs(thread, &request->clone_range.r_pre_attr, dst);
+        diskfs_map_attrs(thread, &request->clone_range.r_post_attr, dst);
+        diskfs_op_ok(request, p->txn);
+        return;
+    }
+
+    /* Acquire the two file inodes in ascending-inum order (deadlock-free). */
+    first = (src->inum < dst->inum) ? src : dst;
+    diskfs_inode_acquire_pinned(thread, p->txn, first, DISKFS_INODE_LOCK_WRITE,
+                                diskfs_clone_first_cb, request);
+} /* diskfs_clone_range */

--- a/src/vfs/diskfs/diskfs_clone.c
+++ b/src/vfs/diskfs/diskfs_clone.c
@@ -500,7 +500,10 @@ diskfs_ext_release_after_dec(struct chimera_vfs_request *request)
         diskfs_thread_free_space(p->thread, p->txn, p->rc_devid, p->rc_devoff,
                                  SM_ALIGN_UP(p->rc_length));
     }
-    p->rc_cont(request);
+    /* rel_cont, not rc_cont: diskfs_refcount_dec overwrote rc_cont with its
+     * own completion (this function), so calling that here would recurse
+     * until the stack ran out. */
+    p->rel_cont(request);
 } /* diskfs_ext_release_after_dec */
 
 /* Lazily acquired the refcount inode for a free of a shared extent; retry. */
@@ -540,7 +543,7 @@ diskfs_ext_release(
                                  diskfs_ext_release_acquired_cb, request);
             return;
         }
-        p->rc_cont   = cont;
+        p->rel_cont  = cont;
         p->rc_length = ext->length;
         diskfs_refcount_dec(request, ext->device_id, ext->device_offset,
                             diskfs_ext_release_after_dec);

--- a/src/vfs/diskfs/diskfs_clone.c
+++ b/src/vfs/diskfs/diskfs_clone.c
@@ -635,8 +635,10 @@ diskfs_clone_dst_inserted_cb(
     diskfs_clone_share_refcount(request);
 } /* diskfs_clone_dst_inserted_cb */
 
+/* Record the shared extent at the destination.  The range is clear by now
+ * (diskfs_clone_dst_clear), so this insert can never collide with a live key. */
 static void
-diskfs_clone_insert_dst(struct chimera_vfs_request *request)
+diskfs_clone_insert_dst_record(struct chimera_vfs_request *request)
 {
     struct diskfs_request_private *p      = request->plugin_data;
     struct diskfs_thread          *thread = p->thread;
@@ -655,6 +657,276 @@ diskfs_clone_insert_dst(struct chimera_vfs_request *request)
                                 diskfs_clone_dst_inserted_cb, request)) {
         diskfs_clone_dst_inserted_cb(op, op->result, request);
     }
+} /* diskfs_clone_insert_dst_record */
+
+/* ------------------------------------------------- destination range clearing
+ *
+ * A clone overwrites its destination range, so whatever the destination already
+ * has there must go before the shared extent is recorded -- otherwise the
+ * insert collides with a live key and the request never completes.  This is the
+ * clone-side counterpart of the write path's CoW scan plus trim, and it makes
+ * the same two distinctions:
+ *
+ *   - a shared extent covered ENTIRELY by the range is released through
+ *     diskfs_ext_release, which decrements its refcount and frees the device
+ *     range only at the last owner (no data copy: it is all being replaced);
+ *
+ *   - a shared extent covered only PARTIALLY is privatized first
+ *     (diskfs_cow_privatize).  A refcount record is keyed by the device offset
+ *     of the whole shared extent, so splitting one would leave a piece whose
+ *     key names no record -- releasing that piece later would free device
+ *     blocks the surviving piece still points at.  Privatizing keeps the
+ *     "a shared extent is never split" invariant the refcount keying relies on.
+ *
+ * Once nothing shared overlaps, every remaining extent is solely owned and is
+ * freed and split exactly as diskfs_write_trim_process does.
+ */
+
+static void diskfs_clone_dst_clear(
+    struct chimera_vfs_request *request);
+
+static void
+diskfs_clone_dst_clear_step_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+
+    (void) result;
+    diskfs_bt_op_free(p->thread, op);
+    diskfs_clone_dst_clear(request);
+} /* diskfs_clone_dst_clear_step_cb */
+
+/* Re-scan from the range start after a release/privatize/split. */
+static void
+diskfs_clone_dst_clear_resume(struct chimera_vfs_request *request)
+{
+    diskfs_clone_dst_clear(request);
+} /* diskfs_clone_dst_clear_resume */
+
+/* Reinsert the piece that survives past the cleared range, then re-scan. */
+static void
+diskfs_clone_dst_clear_tail_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+
+    (void) result;
+    diskfs_bt_op_free(p->thread, op);
+    diskfs_clone_dst_clear(request);
+} /* diskfs_clone_dst_clear_tail_cb */
+
+static void
+diskfs_clone_dst_clear_insert_tail(struct chimera_vfs_request *request)
+{
+    struct diskfs_request_private *p      = request->plugin_data;
+    struct diskfs_thread          *thread = p->thread;
+    struct diskfs_extent          *e      = &p->clone_dst_ext;
+    uint64_t                       dend   = p->clone_dst_clear_end;
+    uint64_t                       es     = e->file_offset;
+    uint64_t                       ee     = es + e->length;
+    struct diskfs_bt_op           *op;
+
+    if (ee > dend) {
+        op = diskfs_bt_op_alloc(thread);
+        if (diskfs_ext_insert_async(op, thread, p->txn, p->inode_stash[0], dend,
+                                    ee - dend, e->device_id,
+                                    e->device_offset + (dend - es), e->flags,
+                                    diskfs_clone_dst_clear_tail_cb, request)) {
+            diskfs_clone_dst_clear_tail_cb(op, op->result, request);
+        }
+        return;
+    }
+
+    diskfs_clone_dst_clear(request);
+} /* diskfs_clone_dst_clear_insert_tail */
+
+static void
+diskfs_clone_dst_clear_head_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+
+    (void) result;
+    diskfs_bt_op_free(p->thread, op);
+    diskfs_clone_dst_clear_insert_tail(request);
+} /* diskfs_clone_dst_clear_head_cb */
+
+static void
+diskfs_clone_dst_clear_removed_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+    struct diskfs_thread          *thread  = p->thread;
+    struct diskfs_extent          *e       = &p->clone_dst_ext;
+    uint64_t                       dstart  = p->clone_dst_clear_start;
+    uint64_t                       es      = e->file_offset;
+
+    (void) result;
+    diskfs_bt_op_free(thread, op);
+
+    /* Head first, then tail: an extent that SPANS the cleared range leaves a
+     * survivor on both sides, so neither may be skipped.  (Re-scanning after
+     * only the head would lose the tail outright -- the removal took the whole
+     * record with it.) */
+    if (es < dstart) {
+        op = diskfs_bt_op_alloc(thread);
+        if (diskfs_ext_insert_async(op, thread, p->txn, p->inode_stash[0], es,
+                                    dstart - es, e->device_id, e->device_offset,
+                                    e->flags, diskfs_clone_dst_clear_head_cb,
+                                    request)) {
+            diskfs_clone_dst_clear_head_cb(op, op->result, request);
+        }
+        return;
+    }
+
+    diskfs_clone_dst_clear_insert_tail(request);
+} /* diskfs_clone_dst_clear_removed_cb */
+
+/* The extent is gone from the tree; free the device blocks the cleared range
+ * covered (solely-owned extents only -- shared ones took the release path). */
+static void
+diskfs_clone_dst_clear_owned(struct chimera_vfs_request *request)
+{
+    struct diskfs_request_private *p      = request->plugin_data;
+    struct diskfs_thread          *thread = p->thread;
+    struct diskfs_extent          *e      = &p->clone_dst_ext;
+    uint64_t                       dstart = p->clone_dst_clear_start;
+    uint64_t                       dend   = p->clone_dst_clear_end;
+    uint64_t                       es     = e->file_offset;
+    uint64_t                       ee     = es + e->length;
+    uint64_t                       cs     = es > dstart ? es : dstart;
+    uint64_t                       ce     = ee < dend ? ee : dend;
+    struct diskfs_bt_op           *op;
+
+    /* UNWRITTEN is reserved space (fallocate), not a hole: it has device
+     * blocks behind it that reads simply answer as zeros, so dropping the
+     * record without freeing them would leak.  diskfs_write_trim_process
+     * frees the same way. */
+    if (ce > cs) {
+        diskfs_thread_free_space(thread, p->txn, e->device_id,
+                                 e->device_offset + (cs - es), ce - cs);
+    }
+
+    op = diskfs_bt_op_alloc(thread);
+    if (diskfs_ext_remove_async(op, thread, p->txn, p->inode_stash[0], es,
+                                diskfs_clone_dst_clear_removed_cb, request)) {
+        diskfs_clone_dst_clear_removed_cb(op, op->result, request);
+    }
+} /* diskfs_clone_dst_clear_owned */
+
+/* A wholly-covered shared extent: its backing is released (refcount-aware) and
+ * the record removed outright. */
+static void
+diskfs_clone_dst_clear_released(struct chimera_vfs_request *request)
+{
+    struct diskfs_request_private *p      = request->plugin_data;
+    struct diskfs_thread          *thread = p->thread;
+    struct diskfs_bt_op           *op     = diskfs_bt_op_alloc(thread);
+
+    if (diskfs_ext_remove_async(op, thread, p->txn, p->inode_stash[0],
+                                p->clone_dst_ext.file_offset,
+                                diskfs_clone_dst_clear_step_cb, request)) {
+        diskfs_clone_dst_clear_step_cb(op, op->result, request);
+    }
+} /* diskfs_clone_dst_clear_released */
+
+static void
+diskfs_clone_dst_clear_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+    struct diskfs_thread          *thread  = p->thread;
+    uint64_t                       dstart  = p->clone_dst_clear_start;
+    uint64_t                       dend    = p->clone_dst_clear_end;
+    uint64_t                       es, ee;
+    int                            have;
+
+    have = diskfs_ext_from_op(op, result, &p->clone_dst_ext);
+    diskfs_bt_op_free(thread, op);
+
+    if (!have || p->clone_dst_ext.file_offset >= dend) {
+        /* Nothing (left) overlapping: the range is clear. */
+        diskfs_clone_insert_dst_record(request);
+        return;
+    }
+
+    es = p->clone_dst_ext.file_offset;
+    ee = es + p->clone_dst_ext.length;
+
+    if (ee <= dstart) {
+        /* Entirely before the range: step past it. */
+        op = diskfs_bt_op_alloc(thread);
+        if (diskfs_ext_next_async(op, thread, p->inode_stash[0], es,
+                                  p->rec_scratch, sizeof(p->rec_scratch),
+                                  diskfs_clone_dst_clear_cb, request)) {
+            diskfs_clone_dst_clear_cb(op, op->result, request);
+        }
+        return;
+    }
+
+    if (p->clone_dst_ext.flags & DISKFS_EXT_SHARED) {
+        if (es >= dstart && ee <= dend) {
+            /* Wholly covered: decrement rather than copy. */
+            diskfs_ext_release(request, &p->clone_dst_ext,
+                               diskfs_clone_dst_clear_released);
+            return;
+        }
+        /* Partially covered: privatize, then re-scan as a solely-owned extent
+         * (a shared extent must never be split -- see the block comment). */
+        diskfs_cow_privatize(request, &p->clone_dst_ext,
+                             diskfs_clone_dst_clear_resume);
+        return;
+    }
+
+    diskfs_clone_dst_clear_owned(request);
+} /* diskfs_clone_dst_clear_cb */
+
+static void
+diskfs_clone_dst_clear(struct chimera_vfs_request *request)
+{
+    struct diskfs_request_private *p      = request->plugin_data;
+    struct diskfs_thread          *thread = p->thread;
+    struct diskfs_bt_op           *op     = diskfs_bt_op_alloc(thread);
+
+    if (diskfs_ext_floor_async(op, thread, p->inode_stash[0],
+                               p->clone_dst_clear_start, p->rec_scratch,
+                               sizeof(p->rec_scratch),
+                               diskfs_clone_dst_clear_cb, request)) {
+        diskfs_clone_dst_clear_cb(op, op->result, request);
+    }
+} /* diskfs_clone_dst_clear */
+
+static void
+diskfs_clone_insert_dst(struct chimera_vfs_request *request)
+{
+    struct diskfs_request_private *p      = request->plugin_data;
+    struct diskfs_extent          *e      = &p->ext_iter;
+    uint64_t                       ostart = e->file_offset > p->clone_src_base ?
+        e->file_offset : p->clone_src_base;
+    uint64_t                       oend = (e->file_offset + e->length) < p->loop_pos ?
+        (e->file_offset + e->length) : p->loop_pos;
+
+    /* Clear whatever the destination already holds across this step's range
+     * before recording the shared extent there. */
+    p->clone_dst_clear_start = p->clone_dst_base + (ostart - p->clone_src_base);
+    p->clone_dst_clear_end   = p->clone_dst_clear_start + (oend - ostart);
+
+    diskfs_clone_dst_clear(request);
 } /* diskfs_clone_insert_dst */
 
 /* Source-side: rewrite e as [head][overlap=SHARED][tail] so the shared piece is
@@ -694,6 +966,7 @@ diskfs_clone_src_step(
     struct diskfs_bt_op           *op;
 
     p->op_scratch = stage + 1;
+
 
     switch (stage) {
         case 0:     /* remove the original source extent */
@@ -905,6 +1178,21 @@ diskfs_clone_range(
         diskfs_map_attrs(thread, &request->clone_range.r_pre_attr, dst);
         diskfs_map_attrs(thread, &request->clone_range.r_post_attr, dst);
         diskfs_op_ok(request, p->txn);
+        return;
+    }
+
+    /* A self-clone -- one inode, disjoint ranges -- must take that inode's
+     * write lock exactly ONCE.  Both ascending-inum selectors below pick the
+     * same inode when the inums are equal, so the second acquire would block
+     * on the lock the first one already holds and the request would never
+     * complete.  FSCTL_DUPLICATE_EXTENTS_TO_FILE permits this (the SMB layer
+     * rejects only *overlapping* same-file ranges) and
+     * smb2.ioctl.dup_extents_src_is_dest exercises it; memfs_clone_range
+     * makes the same distinction.  The walk re-looks-up the source extent by
+     * offset on every step, so mutating the one b+tree between steps is safe. */
+    if (src->inum == dst->inum && src->gen == dst->gen) {
+        diskfs_inode_acquire_pinned(thread, p->txn, src, DISKFS_INODE_LOCK_WRITE,
+                                    diskfs_clone_second_cb, request);
         return;
     }
 

--- a/src/vfs/diskfs/diskfs_clone.c
+++ b/src/vfs/diskfs/diskfs_clone.c
@@ -1,0 +1,915 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * Reflink (NFSv4.2 CLONE) for diskfs: true copy-on-write sharing of byte ranges
+ * between files.
+ *
+ * Sharing is tracked by a refcount per shared device range, stored as
+ * DISKFS_REC_REFCOUNT records in a statically-reserved refcount inode
+ * (DISKFS_REFCOUNT_INUM_BASE).  An extent that participates in sharing carries
+ * the DISKFS_EXT_SHARED flag; a write to such an extent must copy-on-write
+ * (diskfs_cow_privatize, driven from the write path) and a free of such an
+ * extent must decrement instead of releasing the backing space
+ * (diskfs_ext_release, called from truncate/unlink/deallocate).
+ *
+ * Refcount semantics: a device range with a sole owner has NO record (implicit
+ * count 1) and is not flagged SHARED.  The first clone creates a record with
+ * count 2 and flags both extents SHARED.  Privatizing or freeing a shared
+ * extent decrements; at count 1 the record is removed (one owner remains, who
+ * keeps the blocks); a decrement that finds no record means this was the last
+ * owner and the blocks are freed.
+ *
+ * Crash consistency: every refcount record update, extent-map change, and the
+ * conditional space free all ride the one diskfs txn (redo log), so a crash
+ * either keeps or discards the whole clone/CoW atomically.
+ */
+
+#include "diskfs_internal.h"
+#include <sys/stat.h>
+
+#define DISKFS_COW_CHUNK (1ULL << 20)   /* device-copy chunk for privatization */
+
+static struct diskfs_inode *
+diskfs_refcount_inode(struct chimera_vfs_request *request)
+{
+    struct diskfs_request_private *p = request->plugin_data;
+
+    return p->inode_stash[2];
+} /* diskfs_refcount_inode */
+
+/* ---------------------------------------------------------------- refcount inc */
+
+static void
+diskfs_refcount_inc_inserted_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+
+    (void) result;
+    diskfs_bt_op_free(p->thread, op);
+    p->rc_cont(request);
+} /* diskfs_refcount_inc_inserted_cb */
+
+static void
+diskfs_refcount_inc_insert(struct chimera_vfs_request *request)
+{
+    struct diskfs_request_private *p      = request->plugin_data;
+    struct diskfs_thread          *thread = p->thread;
+    struct diskfs_bt_key           key    = diskfs_refcount_key(p->rc_devid, p->rc_devoff);
+    struct diskfs_refcount_rec     rec    = { .length = p->rc_length, .refcount = p->rc_newcount };
+    struct diskfs_bt_op           *op     = diskfs_bt_op_alloc(thread);
+
+    if (diskfs_bt_insert_async(op, thread, p->txn, diskfs_refcount_inode(request),
+                               &key, &rec, sizeof(rec),
+                               diskfs_refcount_inc_inserted_cb, request)) {
+        diskfs_refcount_inc_inserted_cb(op, op->result, request);
+    }
+} /* diskfs_refcount_inc_insert */
+
+static void
+diskfs_refcount_inc_removed_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+
+    (void) result;
+    diskfs_bt_op_free(p->thread, op);
+    diskfs_refcount_inc_insert(request);
+} /* diskfs_refcount_inc_removed_cb */
+
+static void
+diskfs_refcount_inc_lookup_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+    struct diskfs_thread          *thread  = p->thread;
+    int                            found   = (result >= 0);
+
+    if (found) {
+        struct diskfs_refcount_rec *rec = (struct diskfs_refcount_rec *) p->rec_scratch;
+        p->rc_newcount = rec->refcount + 1;
+    } else {
+        p->rc_newcount = 2;     /* sole owner (implicit 1) + this new share */
+    }
+    diskfs_bt_op_free(thread, op);
+
+    if (found) {
+        struct diskfs_bt_key key = diskfs_refcount_key(p->rc_devid, p->rc_devoff);
+        op = diskfs_bt_op_alloc(thread);
+        if (diskfs_bt_remove_async(op, thread, p->txn, diskfs_refcount_inode(request),
+                                   &key, diskfs_refcount_inc_removed_cb, request)) {
+            diskfs_refcount_inc_removed_cb(op, op->result, request);
+        }
+    } else {
+        diskfs_refcount_inc_insert(request);
+    }
+} /* diskfs_refcount_inc_lookup_cb */
+
+void
+diskfs_refcount_inc(
+    struct chimera_vfs_request *request,
+    uint32_t                    device_id,
+    uint64_t                    device_offset,
+    uint64_t                    length,
+    void (                     *cont )(struct chimera_vfs_request *))
+{
+    struct diskfs_request_private *p      = request->plugin_data;
+    struct diskfs_thread          *thread = p->thread;
+    struct diskfs_bt_key           key    = diskfs_refcount_key(device_id, device_offset);
+    struct diskfs_bt_op           *op;
+
+    p->rc_devid  = device_id;
+    p->rc_devoff = device_offset;
+    p->rc_length = length;
+    p->rc_cont   = cont;
+
+    op = diskfs_bt_op_alloc(thread);
+    if (diskfs_bt_lookup_async(op, thread, diskfs_refcount_inode(request),
+                               DISKFS_BT_OP_LOOKUP_EXACT, &key, &op->found_key,
+                               p->rec_scratch, sizeof(struct diskfs_refcount_rec),
+                               diskfs_refcount_inc_lookup_cb, request)) {
+        diskfs_refcount_inc_lookup_cb(op, op->result, request);
+    }
+} /* diskfs_refcount_inc */
+
+/* ---------------------------------------------------------------- refcount dec */
+
+static void
+diskfs_refcount_dec_done_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+
+    (void) result;
+    diskfs_bt_op_free(p->thread, op);
+    p->rc_cont(request);
+} /* diskfs_refcount_dec_done_cb */
+
+static void
+diskfs_refcount_dec_removed_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+    struct diskfs_thread          *thread  = p->thread;
+
+    (void) result;
+    diskfs_bt_op_free(thread, op);
+
+    if (p->rc_newcount >= 2) {
+        /* Still shared by others: reinsert the decremented record. */
+        struct diskfs_bt_key       key = diskfs_refcount_key(p->rc_devid, p->rc_devoff);
+        struct diskfs_refcount_rec rec = { .length = p->rc_length, .refcount = p->rc_newcount };
+        op = diskfs_bt_op_alloc(thread);
+        if (diskfs_bt_insert_async(op, thread, p->txn, diskfs_refcount_inode(request),
+                                   &key, &rec, sizeof(rec),
+                                   diskfs_refcount_dec_done_cb, request)) {
+            diskfs_refcount_dec_done_cb(op, op->result, request);
+        }
+        return;
+    }
+
+    /* Dropped to a single owner: no record (implicit 1), do not free. */
+    p->rc_cont(request);
+} /* diskfs_refcount_dec_removed_cb */
+
+static void
+diskfs_refcount_dec_lookup_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+    struct diskfs_thread          *thread  = p->thread;
+    int                            found   = (result >= 0);
+
+    if (!found) {
+        /* No record: this was the last (sole) owner, so the caller frees. */
+        diskfs_bt_op_free(thread, op);
+        p->rc_should_free = 1;
+        p->rc_cont(request);
+        return;
+    }
+
+    struct diskfs_refcount_rec *rec = (struct diskfs_refcount_rec *) p->rec_scratch;
+    p->rc_length      = rec->length;
+    p->rc_newcount    = rec->refcount - 1;
+    p->rc_should_free = 0;
+    diskfs_bt_op_free(thread, op);
+
+    struct diskfs_bt_key        key = diskfs_refcount_key(p->rc_devid, p->rc_devoff);
+    op = diskfs_bt_op_alloc(thread);
+    if (diskfs_bt_remove_async(op, thread, p->txn, diskfs_refcount_inode(request),
+                               &key, diskfs_refcount_dec_removed_cb, request)) {
+        diskfs_refcount_dec_removed_cb(op, op->result, request);
+    }
+} /* diskfs_refcount_dec_lookup_cb */
+
+void
+diskfs_refcount_dec(
+    struct chimera_vfs_request *request,
+    uint32_t                    device_id,
+    uint64_t                    device_offset,
+    void (                     *cont )(struct chimera_vfs_request *))
+{
+    struct diskfs_request_private *p      = request->plugin_data;
+    struct diskfs_thread          *thread = p->thread;
+    struct diskfs_bt_key           key    = diskfs_refcount_key(device_id, device_offset);
+    struct diskfs_bt_op           *op;
+
+    p->rc_devid       = device_id;
+    p->rc_devoff      = device_offset;
+    p->rc_should_free = 0;
+    p->rc_cont        = cont;
+
+    op = diskfs_bt_op_alloc(thread);
+    if (diskfs_bt_lookup_async(op, thread, diskfs_refcount_inode(request),
+                               DISKFS_BT_OP_LOOKUP_EXACT, &key, &op->found_key,
+                               p->rec_scratch, sizeof(struct diskfs_refcount_rec),
+                               diskfs_refcount_dec_lookup_cb, request)) {
+        diskfs_refcount_dec_lookup_cb(op, op->result, request);
+    }
+} /* diskfs_refcount_dec */
+
+/* ----------------------------------------------- copy-on-write: privatize one */
+
+static void
+diskfs_cow_replace_done_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+
+    (void) result;
+    diskfs_bt_op_free(p->thread, op);
+    p->cow_cont(request);
+} /* diskfs_cow_replace_done_cb */
+
+/* After the device copy and the refcount decrement: free the old blocks if this
+ * was the last owner, then resume. */
+static void
+diskfs_cow_after_dec(struct chimera_vfs_request *request)
+{
+    struct diskfs_request_private *p = request->plugin_data;
+
+    if (p->rc_should_free) {
+        diskfs_thread_free_space(p->thread, p->txn, p->cow_ext.device_id,
+                                 p->cow_ext.device_offset,
+                                 SM_ALIGN_UP(p->cow_ext.length));
+    }
+    p->cow_cont(request);
+} /* diskfs_cow_after_dec */
+
+/* Old extent removed; insert the private replacement, then drop the refcount. */
+static void
+diskfs_cow_inserted_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+
+    (void) result;
+    diskfs_bt_op_free(p->thread, op);
+
+    diskfs_refcount_dec(request, p->cow_ext.device_id, p->cow_ext.device_offset,
+                        diskfs_cow_after_dec);
+} /* diskfs_cow_inserted_cb */
+
+static void
+diskfs_cow_removed_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+    struct diskfs_thread          *thread  = p->thread;
+
+    (void) result;
+    diskfs_bt_op_free(thread, op);
+
+    op = diskfs_bt_op_alloc(thread);
+    if (diskfs_ext_insert_async(op, thread, p->txn, p->inode_stash[0],
+                                p->cow_ext.file_offset, p->cow_ext.length,
+                                p->cow_new_devid, p->cow_new_devoff,
+                                p->cow_ext.flags & ~(uint32_t) DISKFS_EXT_SHARED,
+                                diskfs_cow_inserted_cb, request)) {
+        diskfs_cow_inserted_cb(op, op->result, request);
+    }
+} /* diskfs_cow_removed_cb */
+
+/* Device copy complete: swap the shared extent record for the private copy. */
+static void
+diskfs_cow_replace(struct chimera_vfs_request *request)
+{
+    struct diskfs_request_private *p      = request->plugin_data;
+    struct diskfs_thread          *thread = p->thread;
+    struct diskfs_bt_op           *op     = diskfs_bt_op_alloc(thread);
+
+    if (diskfs_ext_remove_async(op, thread, p->txn, p->inode_stash[0],
+                                p->cow_ext.file_offset, diskfs_cow_removed_cb,
+                                request)) {
+        diskfs_cow_removed_cb(op, op->result, request);
+    }
+} /* diskfs_cow_replace */
+
+/* Chunked device-to-device copy of the shared extent into the freshly allocated
+ * private blocks.  Each chunk is read then written before advancing. */
+static void diskfs_cow_copy_step(
+    struct chimera_vfs_request *request);
+
+static void
+diskfs_cow_write_cb(
+    struct evpl *evpl,
+    int          status,
+    void        *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+    struct diskfs_thread          *thread  = p->thread;
+
+    (void) evpl;
+    diskfs_pending_io_add(thread, -1);
+    diskfs_io_resume_waiters(thread);
+
+    evpl_iovecs_release(thread->evpl, p->iov, p->niov);
+    p->niov = 0;
+
+    if (status) {
+        diskfs_op_fail(request, p->txn, status);
+        return;
+    }
+    diskfs_cow_copy_step(request);
+} /* diskfs_cow_write_cb */
+
+static void
+diskfs_cow_read_cb(
+    struct evpl *evpl,
+    int          status,
+    void        *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+    struct diskfs_thread          *thread  = p->thread;
+    struct diskfs_shared          *shared  = thread->shared;
+
+    (void) evpl;
+    diskfs_pending_io_add(thread, -1);
+    diskfs_io_resume_waiters(thread);
+
+    if (status) {
+        evpl_iovecs_release(thread->evpl, p->iov, p->niov);
+        p->niov = 0;
+        diskfs_op_fail(request, p->txn, status);
+        return;
+    }
+
+    /* Write the chunk just read to the new private device range. */
+    uint64_t off   = p->cow_copied;
+    uint64_t left  = p->cow_ext.length - off;
+    uint64_t chunk = left < DISKFS_COW_CHUNK ? left : DISKFS_COW_CHUNK;
+
+    p->cow_copied += chunk;
+    diskfs_pending_io_add(thread, 1);
+    evpl_block_write(thread->evpl, thread->queue[p->cow_new_devid],
+                     p->iov, p->niov,
+                     p->cow_new_devoff + off, !shared->unsafe_async,
+                     diskfs_cow_write_cb, request);
+} /* diskfs_cow_read_cb */
+
+static void
+diskfs_cow_copy_step(struct chimera_vfs_request *request)
+{
+    struct diskfs_request_private *p      = request->plugin_data;
+    struct diskfs_thread          *thread = p->thread;
+    struct diskfs_shared          *shared = thread->shared;
+    struct evpl                   *evpl   = thread->evpl;
+    uint64_t                       off    = p->cow_copied;
+    uint64_t                       left   = p->cow_ext.length - off;
+    uint64_t                       chunk;
+
+    if (left == 0) {
+        diskfs_cow_replace(request);
+        return;
+    }
+
+    if (diskfs_io_gate(thread, request, diskfs_cow_copy_step)) {
+        return;
+    }
+
+    chunk = left < DISKFS_COW_CHUNK ? left : DISKFS_COW_CHUNK;
+
+    p->niov = evpl_iovec_alloc(evpl, chunk, 4096, 32, 0, p->iov);
+    if (p->niov <= 0) {
+        diskfs_op_fail(request, p->txn, CHIMERA_VFS_EIO);
+        return;
+    }
+
+    diskfs_pending_io_add(thread, 1);
+    evpl_block_read(evpl, thread->queue[p->cow_ext.device_id], p->iov, p->niov,
+                    p->cow_ext.device_offset + off, diskfs_cow_read_cb, request);
+    (void) shared;
+} /* diskfs_cow_copy_step */
+
+static void
+diskfs_cow_alloc_resume(
+    struct diskfs_thread *thread,
+    void                 *arg);
+
+static void
+diskfs_cow_alloc(struct chimera_vfs_request *request)
+{
+    struct diskfs_request_private *p      = request->plugin_data;
+    struct diskfs_thread          *thread = p->thread;
+    uint64_t                       dev_id, dev_off;
+    int                            rc;
+
+    rc = diskfs_inode_alloc_space(thread, p->txn, p->inode_stash[0],
+                                  (int64_t) p->cow_ext.length, SM_RESERVATION_MIN,
+                                  &dev_id, &dev_off, diskfs_cow_alloc_resume, request);
+    if (rc == SM_AGAIN) {
+        return;
+    }
+    if (rc) {
+        diskfs_op_fail(request, p->txn, CHIMERA_VFS_ENOSPC);
+        return;
+    }
+
+    p->cow_new_devid  = (uint32_t) dev_id;
+    p->cow_new_devoff = dev_off;
+    p->cow_copied     = 0;
+    diskfs_cow_copy_step(request);
+} /* diskfs_cow_alloc */
+
+static void
+diskfs_cow_alloc_resume(
+    struct diskfs_thread *thread,
+    void                 *arg)
+{
+    (void) thread;
+    diskfs_cow_alloc((struct chimera_vfs_request *) arg);
+} /* diskfs_cow_alloc_resume */
+
+void
+diskfs_cow_privatize(
+    struct chimera_vfs_request *request,
+    const struct diskfs_extent *ext,
+    void (                     *cont )(struct chimera_vfs_request *))
+{
+    struct diskfs_request_private *p = request->plugin_data;
+
+    p->cow_ext  = *ext;
+    p->cow_cont = cont;
+    diskfs_cow_alloc(request);
+} /* diskfs_cow_privatize */
+
+/* --------------------------------------------- ext_release (truncate/unlink/dealloc)
+ *
+ * Release one extent's backing space.  A non-shared extent is freed directly; a
+ * shared extent decrements its refcount and frees the device range only when it
+ * was the last owner.  The refcount inode must already be acquired at
+ * inode_stash[2] (the caller acquires it lazily when it meets a shared extent). */
+
+static void
+diskfs_ext_release_after_dec(struct chimera_vfs_request *request)
+{
+    struct diskfs_request_private *p = request->plugin_data;
+
+    if (p->rc_should_free) {
+        diskfs_thread_free_space(p->thread, p->txn, p->rc_devid, p->rc_devoff,
+                                 SM_ALIGN_UP(p->rc_length));
+    }
+    p->rc_cont(request);
+} /* diskfs_ext_release_after_dec */
+
+/* Lazily acquired the refcount inode for a free of a shared extent; retry. */
+static void
+diskfs_ext_release_acquired_cb(
+    struct diskfs_inode *inode,
+    int                  status,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+
+    if (unlikely(status != CHIMERA_VFS_OK)) {
+        diskfs_op_fail(request, p->txn, status);
+        return;
+    }
+
+    p->inode_stash[2] = inode;
+    diskfs_ext_release(request, &p->cow_ext, p->cow_cont);
+} /* diskfs_ext_release_acquired_cb */
+
+void
+diskfs_ext_release(
+    struct chimera_vfs_request *request,
+    const struct diskfs_extent *ext,
+    void (                     *cont )(struct chimera_vfs_request *))
+{
+    struct diskfs_request_private *p = request->plugin_data;
+
+    if (ext->flags & DISKFS_EXT_SHARED) {
+        if (p->inode_stash[2] == NULL) {
+            /* Acquire the refcount inode (lock leaf, last), then retry. */
+            p->cow_ext  = *ext;
+            p->cow_cont = cont;
+            diskfs_inode_acquire(p->thread, p->txn, NULL, DISKFS_REFCOUNT_INUM_BASE,
+                                 DISKFS_REFCOUNT_GEN, DISKFS_INODE_LOCK_WRITE,
+                                 diskfs_ext_release_acquired_cb, request);
+            return;
+        }
+        p->rc_cont   = cont;
+        p->rc_length = ext->length;
+        diskfs_refcount_dec(request, ext->device_id, ext->device_offset,
+                            diskfs_ext_release_after_dec);
+        return;
+    }
+
+    diskfs_thread_free_space(p->thread, p->txn, ext->device_id,
+                             ext->device_offset, SM_ALIGN_UP(ext->length));
+    cont(request);
+} /* diskfs_ext_release */
+
+/* --------------------------------------------------------------------- CLONE */
+
+static void diskfs_clone_walk(
+    struct chimera_vfs_request *request);
+
+static void diskfs_clone_walk_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *private_data);
+
+static void
+diskfs_clone_finalize(struct chimera_vfs_request *request)
+{
+    struct diskfs_request_private *p      = request->plugin_data;
+    struct diskfs_thread          *thread = p->thread;
+    struct diskfs_inode           *dst    = p->inode_stash[0];
+    uint64_t                       end    = p->clone_dst_base +
+        (p->loop_pos - p->clone_src_base);
+    struct timespec                now;
+
+    if (end > dst->size) {
+        dst->size       = end;
+        dst->space_used = (dst->size + 4095) & ~4095;
+    }
+
+    clock_gettime(CLOCK_REALTIME, &now);
+    dst->mtime_sec  = now.tv_sec;
+    dst->mtime_nsec = now.tv_nsec;
+    dst->ctime_sec  = now.tv_sec;
+    dst->ctime_nsec = now.tv_nsec;
+
+    diskfs_map_attrs(thread, &request->clone_range.r_post_attr, dst);
+    diskfs_op_ok(request, p->txn);
+} /* diskfs_clone_finalize */
+
+static void
+diskfs_clone_advance(struct chimera_vfs_request *request)
+{
+    struct diskfs_request_private *p      = request->plugin_data;
+    struct diskfs_thread          *thread = p->thread;
+    struct diskfs_bt_op           *op     = diskfs_bt_op_alloc(thread);
+
+    /* Step to the extent following the one just processed.  (A plain re-floor of
+     * an advanced offset would return the same extent again, since floor is the
+     * largest key <= offset.) */
+    if (diskfs_ext_next_async(op, thread, p->inode_stash[1], p->ext_iter.file_offset,
+                              p->rec_scratch, sizeof(p->rec_scratch),
+                              diskfs_clone_walk_cb, request)) {
+        diskfs_clone_walk_cb(op, op->result, request);
+    }
+} /* diskfs_clone_advance */
+
+/* Bump the share count for the overlap, then advance. */
+static void
+diskfs_clone_share_refcount(struct chimera_vfs_request *request)
+{
+    struct diskfs_request_private *p      = request->plugin_data;
+    struct diskfs_extent          *e      = &p->ext_iter;
+    uint64_t                       ostart = e->file_offset > p->clone_src_base ?
+        e->file_offset : p->clone_src_base;
+    uint64_t                       oend = (e->file_offset + e->length) < p->loop_pos ?
+        (e->file_offset + e->length) : p->loop_pos;
+    uint64_t                       odevoff = e->device_offset + (ostart - e->file_offset);
+
+    diskfs_refcount_inc(request, e->device_id, odevoff, oend - ostart,
+                        diskfs_clone_advance);
+} /* diskfs_clone_share_refcount */
+
+/* Insert the destination extent (shared) for the overlap, then bump refcount. */
+static void
+diskfs_clone_dst_inserted_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+
+    (void) result;
+    diskfs_bt_op_free(p->thread, op);
+    diskfs_clone_share_refcount(request);
+} /* diskfs_clone_dst_inserted_cb */
+
+static void
+diskfs_clone_insert_dst(struct chimera_vfs_request *request)
+{
+    struct diskfs_request_private *p      = request->plugin_data;
+    struct diskfs_thread          *thread = p->thread;
+    struct diskfs_extent          *e      = &p->ext_iter;
+    uint64_t                       ostart = e->file_offset > p->clone_src_base ?
+        e->file_offset : p->clone_src_base;
+    uint64_t                       oend = (e->file_offset + e->length) < p->loop_pos ?
+        (e->file_offset + e->length) : p->loop_pos;
+    uint64_t                       odevoff = e->device_offset + (ostart - e->file_offset);
+    uint64_t                       dst_off = p->clone_dst_base + (ostart - p->clone_src_base);
+    struct diskfs_bt_op           *op      = diskfs_bt_op_alloc(thread);
+
+    if (diskfs_ext_insert_async(op, thread, p->txn, p->inode_stash[0],
+                                dst_off, oend - ostart, e->device_id, odevoff,
+                                (e->flags | DISKFS_EXT_SHARED) & ~(uint32_t) DISKFS_EXT_UNWRITTEN,
+                                diskfs_clone_dst_inserted_cb, request)) {
+        diskfs_clone_dst_inserted_cb(op, op->result, request);
+    }
+} /* diskfs_clone_insert_dst */
+
+/* Source-side: rewrite e as [head][overlap=SHARED][tail] so the shared piece is
+ * its own extent (devoff == the overlap's), then insert the destination. */
+static void
+diskfs_clone_src_step(
+    struct chimera_vfs_request *request,
+    int                         stage);
+
+static void
+diskfs_clone_src_step_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+
+    (void) result;
+    diskfs_bt_op_free(p->thread, op);
+    diskfs_clone_src_step(request, (int) p->op_scratch);
+} /* diskfs_clone_src_step_cb */
+
+static void
+diskfs_clone_src_step(
+    struct chimera_vfs_request *request,
+    int                         stage)
+{
+    struct diskfs_request_private *p       = request->plugin_data;
+    struct diskfs_thread          *thread  = p->thread;
+    struct diskfs_extent          *e       = &p->ext_iter;
+    uint64_t                       estart  = e->file_offset;
+    uint64_t                       eend    = e->file_offset + e->length;
+    uint64_t                       ostart  = estart > p->clone_src_base ? estart : p->clone_src_base;
+    uint64_t                       oend    = eend < p->loop_pos ? eend : p->loop_pos;
+    uint64_t                       odevoff = e->device_offset + (ostart - estart);
+    struct diskfs_bt_op           *op;
+
+    p->op_scratch = stage + 1;
+
+    switch (stage) {
+        case 0:     /* remove the original source extent */
+            op = diskfs_bt_op_alloc(thread);
+            if (diskfs_ext_remove_async(op, thread, p->txn, p->inode_stash[1],
+                                        estart, diskfs_clone_src_step_cb, request)) {
+                diskfs_clone_src_step_cb(op, op->result, request);
+            }
+            return;
+        case 1:     /* head [estart, ostart) keeps the original (non-shared) flags */
+            if (ostart > estart) {
+                op = diskfs_bt_op_alloc(thread);
+                if (diskfs_ext_insert_async(op, thread, p->txn, p->inode_stash[1],
+                                            estart, ostart - estart, e->device_id,
+                                            e->device_offset, e->flags,
+                                            diskfs_clone_src_step_cb, request)) {
+                    diskfs_clone_src_step_cb(op, op->result, request);
+                }
+                return;
+            }
+            diskfs_clone_src_step(request, 2);
+            return;
+        case 2:     /* overlap [ostart, oend) becomes SHARED */
+            op = diskfs_bt_op_alloc(thread);
+            if (diskfs_ext_insert_async(op, thread, p->txn, p->inode_stash[1],
+                                        ostart, oend - ostart, e->device_id, odevoff,
+                                        e->flags | DISKFS_EXT_SHARED,
+                                        diskfs_clone_src_step_cb, request)) {
+                diskfs_clone_src_step_cb(op, op->result, request);
+            }
+            return;
+        case 3:     /* tail [oend, eend) keeps the original flags */
+            if (oend < eend) {
+                op = diskfs_bt_op_alloc(thread);
+                if (diskfs_ext_insert_async(op, thread, p->txn, p->inode_stash[1],
+                                            oend, eend - oend, e->device_id,
+                                            e->device_offset + (oend - estart), e->flags,
+                                            diskfs_clone_src_step_cb, request)) {
+                    diskfs_clone_src_step_cb(op, op->result, request);
+                }
+                return;
+            }
+            diskfs_clone_src_step(request, 4);
+            return;
+        default:    /* done splitting source; record the destination extent */
+            diskfs_clone_insert_dst(request);
+            return;
+    } /* switch */
+} /* diskfs_clone_src_step */
+
+static void
+diskfs_clone_walk_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+    int                            have;
+
+    have = diskfs_ext_from_op(op, result, &p->ext_iter);
+    diskfs_bt_op_free(p->thread, op);
+
+    if (!have || p->ext_iter.file_offset >= p->loop_pos) {
+        diskfs_clone_finalize(request);
+        return;
+    }
+
+    uint64_t estart = p->ext_iter.file_offset;
+    uint64_t eend   = estart + p->ext_iter.length;
+    uint64_t ostart = estart > p->clone_src_base ? estart : p->clone_src_base;
+    uint64_t oend   = eend < p->loop_pos ? eend : p->loop_pos;
+
+    /* Skip holes and reserved-but-unwritten ranges: the destination simply has
+     * no extent there and reads as zeros, matching the source. */
+    if (ostart >= oend || (p->ext_iter.flags & DISKFS_EXT_UNWRITTEN)) {
+        diskfs_clone_advance(request);
+        return;
+    }
+
+    diskfs_clone_src_step(request, 0);
+} /* diskfs_clone_walk_cb */
+
+static void
+diskfs_clone_walk(struct chimera_vfs_request *request)
+{
+    struct diskfs_request_private *p      = request->plugin_data;
+    struct diskfs_thread          *thread = p->thread;
+    struct diskfs_bt_op           *op     = diskfs_bt_op_alloc(thread);
+
+    /* Walk the source extents covering [loop_off, loop_pos). */
+    if (diskfs_ext_floor_async(op, thread, p->inode_stash[1], p->loop_off,
+                               p->rec_scratch, sizeof(p->rec_scratch),
+                               diskfs_clone_walk_cb, request)) {
+        diskfs_clone_walk_cb(op, op->result, request);
+    }
+} /* diskfs_clone_walk */
+
+static void
+diskfs_clone_rc_acquired_cb(
+    struct diskfs_inode *inode,
+    int                  status,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+    struct diskfs_inode           *src     = (struct diskfs_inode *) request->clone_range.src_handle->vfs_private;
+    struct diskfs_inode           *dst     = (struct diskfs_inode *) request->clone_range.dst_handle->vfs_private;
+
+    if (unlikely(status != CHIMERA_VFS_OK)) {
+        diskfs_op_fail(request, p->txn, status);
+        return;
+    }
+
+    p->inode_stash[0] = dst;
+    p->inode_stash[1] = src;
+    p->inode_stash[2] = inode;     /* refcount inode (acquired last) */
+
+    diskfs_map_attrs(p->thread, &request->clone_range.r_pre_attr, dst);
+
+    p->clone_src_base = request->clone_range.src_offset;
+    p->clone_dst_base = request->clone_range.dst_offset;
+    p->loop_off       = request->clone_range.src_offset;
+    p->loop_pos       = request->clone_range.src_offset + request->clone_range.length;
+
+    diskfs_clone_walk(request);
+} /* diskfs_clone_rc_acquired_cb */
+
+static void
+diskfs_clone_second_cb(
+    struct diskfs_inode *inode,
+    int                  status,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+
+    if (unlikely(status != CHIMERA_VFS_OK)) {
+        diskfs_op_fail(request, p->txn, status);
+        return;
+    }
+
+    /* Acquire the refcount inode last (it is a deadlock-free lock leaf: only
+     * clone / CoW / shared-free touch it, and always after their file inodes). */
+    diskfs_inode_acquire(p->thread, p->txn, NULL, DISKFS_REFCOUNT_INUM_BASE,
+                         DISKFS_REFCOUNT_GEN, DISKFS_INODE_LOCK_WRITE,
+                         diskfs_clone_rc_acquired_cb, request);
+} /* diskfs_clone_second_cb */
+
+static void
+diskfs_clone_first_cb(
+    struct diskfs_inode *inode,
+    int                  status,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+    struct diskfs_inode           *src     = (struct diskfs_inode *) request->clone_range.src_handle->vfs_private;
+    struct diskfs_inode           *dst     = (struct diskfs_inode *) request->clone_range.dst_handle->vfs_private;
+    struct diskfs_inode           *second;
+
+    if (unlikely(status != CHIMERA_VFS_OK)) {
+        diskfs_op_fail(request, p->txn, status);
+        return;
+    }
+
+    second = (src->inum < dst->inum) ? dst : src;
+    diskfs_inode_acquire_pinned(p->thread, p->txn, second,
+                                DISKFS_INODE_LOCK_WRITE, diskfs_clone_second_cb,
+                                request);
+} /* diskfs_clone_first_cb */
+
+void
+diskfs_clone_range(
+    struct diskfs_thread       *thread,
+    struct diskfs_shared       *shared,
+    struct chimera_vfs_request *request,
+    void                       *private_data)
+{
+    struct diskfs_request_private *p   = request->plugin_data;
+    struct diskfs_inode           *src = (struct diskfs_inode *) request->clone_range.src_handle->vfs_private;
+    struct diskfs_inode           *dst = (struct diskfs_inode *) request->clone_range.dst_handle->vfs_private;
+    struct diskfs_inode           *first;
+
+    (void) private_data;
+
+    if (unlikely(shared->block_layout || shared->scsi_layout)) {
+        request->status = CHIMERA_VFS_EINVAL;
+        request->complete(request);
+        return;
+    }
+
+    /* Block-aligned ranges only (reflink shares whole device blocks). */
+    if ((request->clone_range.src_offset & 4095) ||
+        (request->clone_range.dst_offset & 4095) ||
+        (request->clone_range.length & 4095)) {
+        request->status = CHIMERA_VFS_EINVAL;
+        request->complete(request);
+        return;
+    }
+
+    p->thread  = thread;
+    p->status  = 0;
+    p->pending = 0;
+    p->niov    = 0;
+    p->txn     = diskfs_txn_begin(thread, DISKFS_TXN_WRITE);
+
+    if (request->clone_range.length == 0) {
+        diskfs_map_attrs(thread, &request->clone_range.r_pre_attr, dst);
+        diskfs_map_attrs(thread, &request->clone_range.r_post_attr, dst);
+        diskfs_op_ok(request, p->txn);
+        return;
+    }
+
+    /* Acquire the two file inodes in ascending-inum order (deadlock-free). */
+    first = (src->inum < dst->inum) ? src : dst;
+    diskfs_inode_acquire_pinned(thread, p->txn, first, DISKFS_INODE_LOCK_WRITE,
+                                diskfs_clone_first_cb, request);
+} /* diskfs_clone_range */

--- a/src/vfs/diskfs/diskfs_internal.h
+++ b/src/vfs/diskfs/diskfs_internal.h
@@ -116,6 +116,21 @@
         (DISKFS_ORPHAN_INUM_BASE + ((inum) % DISKFS_ORPHAN_SHARDS))
 
 
+/* Statically-reserved extent-refcount inodes (inums after the orphan shards):
+ * their b+trees hold DISKFS_REC_REFCOUNT records (keyed by device offset)
+ * counting how many inodes share a reflinked device range.  Created at format,
+ * permanent.  Count is baked into the on-disk bootstrap layout. */
+#define DISKFS_REFCOUNT_INUM_BASE (DISKFS_ORPHAN_INUM_BASE + DISKFS_ORPHAN_SHARDS)
+
+#define DISKFS_REFCOUNT_SHARDS    SM_BOOTSTRAP_REFCOUNT_SLOTS
+
+#define DISKFS_REFCOUNT_GEN       1   /* permanent: created at format */
+
+#define DISKFS_REFCOUNT_SHARD_INUM(device_offset) \
+        (DISKFS_REFCOUNT_INUM_BASE + \
+         (((device_offset) >> 12) % DISKFS_REFCOUNT_SHARDS))
+
+
 /* Max inodes a single transaction can hold locked at once.  rename needs
  * 5 (two parents, child, replaced target, plus the orphan-list shard when
  * the replace deletes the target); others (e.g. readdir) touch many but
@@ -315,6 +330,38 @@ struct diskfs_request_private {
     uint64_t                    ci_off, ci_len, ci_devoff;
     uint32_t                    ci_devid, ci_flags;
     void                        (*ci_cont)(
+        struct chimera_vfs_request *);
+
+    /* WRITE_SAME state.  ws_active marks that the shared punch (dealloc) loop is
+     * being borrowed by WRITE_SAME, so diskfs_dealloc_finish hands control back
+     * to the pattern-fill phase instead of finalizing.  ws_tmpl is the one
+     * block-size pattern template (zero + pattern at reloff) tiled into each
+     * device write; freed at finish. */
+    int                         ws_active;
+    uint8_t                    *ws_tmpl;
+
+    /* Reflink (CLONE) + copy-on-write state.  inode_stash[2] holds the acquired
+     * refcount inode.  rc_* describe the device range a refcount op acts on;
+     * rc_cont is the continuation after the lookup->remove->insert chain;
+     * rc_should_free is the dec result (free the range only when it hits 0). */
+    void                        (*rc_cont)(
+        struct chimera_vfs_request *);
+    uint64_t                    rc_devoff;
+    uint64_t                    rc_length;
+    uint64_t                    rc_newcount;
+    uint32_t                    rc_devid;
+    int                         rc_should_free;
+    int                         rc_found;
+    /* CLONE: source/destination base offsets for translating extent keys. */
+    uint64_t                    clone_src_base;
+    uint64_t                    clone_dst_base;
+    /* Whole-extent CoW privatize: the shared extent being copied to private
+     * blocks, the freshly-allocated destination, and the bytes copied so far. */
+    struct diskfs_extent        cow_ext;
+    uint64_t                    cow_new_devoff;
+    uint32_t                    cow_new_devid;
+    uint64_t                    cow_copied;
+    void                        (*cow_cont)(
         struct chimera_vfs_request *);
 };
 
@@ -876,13 +923,15 @@ struct diskfs_dinode {
 
 /* Record types share one tree per inode; each occupies a key range. */
 enum diskfs_bt_rectype {
-    DISKFS_REC_DIRENT  = 1,
-    DISKFS_REC_EXTENT  = 2,
-    DISKFS_REC_SYMLINK = 3,
-    DISKFS_REC_ORPHAN  = 4,   /* orphan-list inode only: subkey = orphaned inum */
-    DISKFS_REC_XATTR   = 5,
-    DISKFS_REC_PNFS    = 6,   /* regular file: opaque pNFS layout blob (flex-files) */
-    DISKFS_REC_ACL     = 7,   /* single record: serialized NFSv4/Windows ACL (subkey 0) */
+    DISKFS_REC_DIRENT   = 1,
+    DISKFS_REC_EXTENT   = 2,
+    DISKFS_REC_SYMLINK  = 3,
+    DISKFS_REC_ORPHAN   = 4,  /* orphan-list inode only: subkey = orphaned inum */
+    DISKFS_REC_XATTR    = 5,
+    DISKFS_REC_PNFS     = 6,  /* regular file: opaque pNFS layout blob (flex-files) */
+    DISKFS_REC_ACL      = 7,  /* single record: serialized NFSv4/Windows ACL (subkey 0) */
+    DISKFS_REC_REFCOUNT = 8,  /* refcount inode only: subkey = device offset of a
+                               * reflink-shared extent; payload = share count */
 };
 
 
@@ -939,12 +988,25 @@ struct diskfs_dirent_rec {
                                      *
                                      * written: reads return zeros, the first
                                      * write clears the bit */
+#define DISKFS_EXT_SHARED    0x2u   /* reflink-shared (CLONE): the backing device
+                                    * range has a refcount > 1.  A write must
+                                    * copy-on-write (the write path forces the
+                                    * redirect branch) and a free must decrement
+                                    * the refcount instead of releasing space. */
 
 struct diskfs_extent_rec {
     uint64_t length;
     uint32_t device_id;
     uint32_t flags;
     uint64_t device_offset;
+} __attribute__((packed));
+
+
+/* DISKFS_REC_REFCOUNT payload: how many inodes share the device range named by
+ * the record's key (device offset).  device_id is folded into the key. */
+struct diskfs_refcount_rec {
+    uint64_t length;        /* device byte range length (for the free at ref 0) */
+    uint64_t refcount;      /* number of inodes sharing this range */
 } __attribute__((packed));
 
 
@@ -1836,6 +1898,14 @@ struct diskfs_drain {
     struct diskfs_bt_key  found_key;
     uint8_t               recbuf[sizeof(struct diskfs_extent_rec)];
     struct diskfs_drain  *next;
+    /* Reflink: the refcount inode (acquired lazily when a doomed inode holds a
+     * shared extent) plus transient state for the decrement chain. */
+    struct diskfs_inode  *rc_inode;
+    uint64_t              rc_devoff;
+    uint64_t              rc_length;
+    uint64_t              rc_newcount;
+    uint32_t              rc_devid;
+    uint8_t               rc_scratch[sizeof(struct diskfs_refcount_rec)];
 };
 
 
@@ -2616,6 +2686,22 @@ diskfs_ext_next_async(
     void                 *private_data);
 
 int
+diskfs_ext_remove_async(
+    struct diskfs_bt_op  *op,
+    struct diskfs_thread *thread,
+    struct diskfs_txn    *txn,
+    struct diskfs_inode  *inode,
+    uint64_t              file_offset,
+    diskfs_bt_cb_t        cb,
+    void                 *private_data);
+
+int
+diskfs_io_gate(
+    struct diskfs_thread       *thread,
+    struct chimera_vfs_request *request,
+    void (                     *resume )(struct chimera_vfs_request *));
+
+int
 diskfs_ext_insert_async(
     struct diskfs_bt_op  *op,
     struct diskfs_thread *thread,
@@ -2979,6 +3065,62 @@ diskfs_seek(
     struct diskfs_shared       *shared,
     struct chimera_vfs_request *request,
     void                       *private_data);
+
+void
+diskfs_read_plus(
+    struct diskfs_thread       *thread,
+    struct diskfs_shared       *shared,
+    struct chimera_vfs_request *request,
+    void                       *private_data);
+
+void
+diskfs_write_same(
+    struct diskfs_thread       *thread,
+    struct diskfs_shared       *shared,
+    struct chimera_vfs_request *request,
+    void                       *private_data);
+
+void
+diskfs_clone_range(
+    struct diskfs_thread       *thread,
+    struct diskfs_shared       *shared,
+    struct chimera_vfs_request *request,
+    void                       *private_data);
+
+/* Reflink refcount + copy-on-write helpers (diskfs_clone.c).  The refcount
+ * inode must already be acquired (write-locked) in the txn at inode_stash[2]. */
+void
+diskfs_refcount_inc(
+    struct chimera_vfs_request *request,
+    uint32_t                    device_id,
+    uint64_t                    device_offset,
+    uint64_t                    length,
+    void (                     *cont )(struct chimera_vfs_request *));
+
+void
+diskfs_refcount_dec(
+    struct chimera_vfs_request *request,
+    uint32_t                    device_id,
+    uint64_t                    device_offset,
+    void (                     *cont )(struct chimera_vfs_request *));
+
+/* Privatize one reflink-shared extent of inode_stash[0]: copy its blocks to
+ * fresh private space, replace the extent record (clearing SHARED), and drop
+ * the refcount (freeing the old range when it hits zero).  Runs cont when done. */
+void
+diskfs_cow_privatize(
+    struct chimera_vfs_request *request,
+    const struct diskfs_extent *ext,
+    void (                     *cont )(struct chimera_vfs_request *));
+
+/* Release one extent's backing space: free a private extent directly, or
+ * decrement a shared extent's refcount (freeing only at the last owner).  The
+ * refcount inode must be acquired at inode_stash[2] when ext is SHARED. */
+void
+diskfs_ext_release(
+    struct chimera_vfs_request *request,
+    const struct diskfs_extent *ext,
+    void (                     *cont )(struct chimera_vfs_request *));
 
 void
 diskfs_symlink_at(
@@ -4343,6 +4485,23 @@ diskfs_extent_key(uint64_t file_offset)
 
     return k;
 } /* diskfs_extent_key */
+
+/* Refcount records are keyed by (device_id, device_offset) folded into the
+ * 64-bit subkey: device_id in the top 8 bits, the (4 KiB-block-aligned) device
+ * offset in the low 56 bits.  56 bits of byte offset covers 64 PiB per device. */
+static inline struct diskfs_bt_key
+diskfs_refcount_key(
+    uint32_t device_id,
+    uint64_t device_offset)
+{
+    struct diskfs_bt_key k = {
+        .type              = DISKFS_REC_REFCOUNT,
+        .subkey            = ((uint64_t) device_id << 56) |
+            (device_offset & ((1ULL << 56) - 1)),
+    };
+
+    return k;
+} /* diskfs_refcount_key */
 
 
 /* Materialize the extent from a completed async lookup op (result + the

--- a/src/vfs/diskfs/diskfs_internal.h
+++ b/src/vfs/diskfs/diskfs_internal.h
@@ -119,6 +119,21 @@
         (DISKFS_ORPHAN_INUM_BASE + ((inum) % DISKFS_ORPHAN_SHARDS))
 
 
+/* Statically-reserved extent-refcount inodes (inums after the orphan shards):
+ * their b+trees hold DISKFS_REC_REFCOUNT records (keyed by device offset)
+ * counting how many inodes share a reflinked device range.  Created at format,
+ * permanent.  Count is baked into the on-disk bootstrap layout. */
+#define DISKFS_REFCOUNT_INUM_BASE (DISKFS_ORPHAN_INUM_BASE + DISKFS_ORPHAN_SHARDS)
+
+#define DISKFS_REFCOUNT_SHARDS    SM_BOOTSTRAP_REFCOUNT_SLOTS
+
+#define DISKFS_REFCOUNT_GEN       1   /* permanent: created at format */
+
+#define DISKFS_REFCOUNT_SHARD_INUM(device_offset) \
+        (DISKFS_REFCOUNT_INUM_BASE + \
+         (((device_offset) >> 12) % DISKFS_REFCOUNT_SHARDS))
+
+
 /* Max inodes a single transaction can hold locked at once.  rename needs
  * 5 (two parents, child, replaced target, plus the orphan-list shard when
  * the replace deletes the target); others (e.g. readdir) touch many but
@@ -325,6 +340,38 @@ struct diskfs_request_private {
     uint64_t                    ci_off, ci_len, ci_devoff;
     uint32_t                    ci_devid, ci_flags;
     void                        (*ci_cont)(
+        struct chimera_vfs_request *);
+
+    /* WRITE_SAME state.  ws_active marks that the shared punch (dealloc) loop is
+     * being borrowed by WRITE_SAME, so diskfs_dealloc_finish hands control back
+     * to the pattern-fill phase instead of finalizing.  ws_tmpl is the one
+     * block-size pattern template (zero + pattern at reloff) tiled into each
+     * device write; freed at finish. */
+    int                         ws_active;
+    uint8_t                    *ws_tmpl;
+
+    /* Reflink (CLONE) + copy-on-write state.  inode_stash[2] holds the acquired
+     * refcount inode.  rc_* describe the device range a refcount op acts on;
+     * rc_cont is the continuation after the lookup->remove->insert chain;
+     * rc_should_free is the dec result (free the range only when it hits 0). */
+    void                        (*rc_cont)(
+        struct chimera_vfs_request *);
+    uint64_t                    rc_devoff;
+    uint64_t                    rc_length;
+    uint64_t                    rc_newcount;
+    uint32_t                    rc_devid;
+    int                         rc_should_free;
+    int                         rc_found;
+    /* CLONE: source/destination base offsets for translating extent keys. */
+    uint64_t                    clone_src_base;
+    uint64_t                    clone_dst_base;
+    /* Whole-extent CoW privatize: the shared extent being copied to private
+     * blocks, the freshly-allocated destination, and the bytes copied so far. */
+    struct diskfs_extent        cow_ext;
+    uint64_t                    cow_new_devoff;
+    uint32_t                    cow_new_devid;
+    uint64_t                    cow_copied;
+    void                        (*cow_cont)(
         struct chimera_vfs_request *);
 };
 
@@ -895,13 +942,15 @@ struct diskfs_dinode {
 
 /* Record types share one tree per inode; each occupies a key range. */
 enum diskfs_bt_rectype {
-    DISKFS_REC_DIRENT  = 1,
-    DISKFS_REC_EXTENT  = 2,
-    DISKFS_REC_SYMLINK = 3,
-    DISKFS_REC_ORPHAN  = 4,   /* orphan-list inode only: subkey = orphaned inum */
-    DISKFS_REC_XATTR   = 5,
-    DISKFS_REC_PNFS    = 6,   /* regular file: opaque pNFS layout blob (flex-files) */
-    DISKFS_REC_ACL     = 7,   /* single record: serialized NFSv4/Windows ACL (subkey 0) */
+    DISKFS_REC_DIRENT   = 1,
+    DISKFS_REC_EXTENT   = 2,
+    DISKFS_REC_SYMLINK  = 3,
+    DISKFS_REC_ORPHAN   = 4,  /* orphan-list inode only: subkey = orphaned inum */
+    DISKFS_REC_XATTR    = 5,
+    DISKFS_REC_PNFS     = 6,  /* regular file: opaque pNFS layout blob (flex-files) */
+    DISKFS_REC_ACL      = 7,  /* single record: serialized NFSv4/Windows ACL (subkey 0) */
+    DISKFS_REC_REFCOUNT = 8,  /* refcount inode only: subkey = device offset of a
+                               * reflink-shared extent; payload = share count */
 };
 
 
@@ -958,12 +1007,25 @@ struct diskfs_dirent_rec {
                                      *
                                      * written: reads return zeros, the first
                                      * write clears the bit */
+#define DISKFS_EXT_SHARED    0x2u   /* reflink-shared (CLONE): the backing device
+                                    * range has a refcount > 1.  A write must
+                                    * copy-on-write (the write path forces the
+                                    * redirect branch) and a free must decrement
+                                    * the refcount instead of releasing space. */
 
 struct diskfs_extent_rec {
     uint64_t length;
     uint32_t device_id;
     uint32_t flags;
     uint64_t device_offset;
+} __attribute__((packed));
+
+
+/* DISKFS_REC_REFCOUNT payload: how many inodes share the device range named by
+ * the record's key (device offset).  device_id is folded into the key. */
+struct diskfs_refcount_rec {
+    uint64_t length;        /* device byte range length (for the free at ref 0) */
+    uint64_t refcount;      /* number of inodes sharing this range */
 } __attribute__((packed));
 
 
@@ -1894,6 +1956,14 @@ struct diskfs_drain {
     uint64_t              child_inum;
     uint32_t              child_gen;
     struct diskfs_drain  *next;
+    /* Reflink: the refcount inode (acquired lazily when a doomed inode holds a
+     * shared extent) plus transient state for the decrement chain. */
+    struct diskfs_inode  *rc_inode;
+    uint64_t              rc_devoff;
+    uint64_t              rc_length;
+    uint64_t              rc_newcount;
+    uint32_t              rc_devid;
+    uint8_t               rc_scratch[sizeof(struct diskfs_refcount_rec)];
 };
 
 
@@ -2697,6 +2767,22 @@ diskfs_ext_next_async(
     void                 *private_data);
 
 int
+diskfs_ext_remove_async(
+    struct diskfs_bt_op  *op,
+    struct diskfs_thread *thread,
+    struct diskfs_txn    *txn,
+    struct diskfs_inode  *inode,
+    uint64_t              file_offset,
+    diskfs_bt_cb_t        cb,
+    void                 *private_data);
+
+int
+diskfs_io_gate(
+    struct diskfs_thread       *thread,
+    struct chimera_vfs_request *request,
+    void (                     *resume )(struct chimera_vfs_request *));
+
+int
 diskfs_ext_insert_async(
     struct diskfs_bt_op  *op,
     struct diskfs_thread *thread,
@@ -3094,6 +3180,62 @@ diskfs_seek(
     struct diskfs_shared       *shared,
     struct chimera_vfs_request *request,
     void                       *private_data);
+
+void
+diskfs_read_plus(
+    struct diskfs_thread       *thread,
+    struct diskfs_shared       *shared,
+    struct chimera_vfs_request *request,
+    void                       *private_data);
+
+void
+diskfs_write_same(
+    struct diskfs_thread       *thread,
+    struct diskfs_shared       *shared,
+    struct chimera_vfs_request *request,
+    void                       *private_data);
+
+void
+diskfs_clone_range(
+    struct diskfs_thread       *thread,
+    struct diskfs_shared       *shared,
+    struct chimera_vfs_request *request,
+    void                       *private_data);
+
+/* Reflink refcount + copy-on-write helpers (diskfs_clone.c).  The refcount
+ * inode must already be acquired (write-locked) in the txn at inode_stash[2]. */
+void
+diskfs_refcount_inc(
+    struct chimera_vfs_request *request,
+    uint32_t                    device_id,
+    uint64_t                    device_offset,
+    uint64_t                    length,
+    void (                     *cont )(struct chimera_vfs_request *));
+
+void
+diskfs_refcount_dec(
+    struct chimera_vfs_request *request,
+    uint32_t                    device_id,
+    uint64_t                    device_offset,
+    void (                     *cont )(struct chimera_vfs_request *));
+
+/* Privatize one reflink-shared extent of inode_stash[0]: copy its blocks to
+ * fresh private space, replace the extent record (clearing SHARED), and drop
+ * the refcount (freeing the old range when it hits zero).  Runs cont when done. */
+void
+diskfs_cow_privatize(
+    struct chimera_vfs_request *request,
+    const struct diskfs_extent *ext,
+    void (                     *cont )(struct chimera_vfs_request *));
+
+/* Release one extent's backing space: free a private extent directly, or
+ * decrement a shared extent's refcount (freeing only at the last owner).  The
+ * refcount inode must be acquired at inode_stash[2] when ext is SHARED. */
+void
+diskfs_ext_release(
+    struct chimera_vfs_request *request,
+    const struct diskfs_extent *ext,
+    void (                     *cont )(struct chimera_vfs_request *));
 
 void
 diskfs_symlink_at(
@@ -4466,6 +4608,23 @@ diskfs_extent_key(uint64_t file_offset)
 
     return k;
 } /* diskfs_extent_key */
+
+/* Refcount records are keyed by (device_id, device_offset) folded into the
+ * 64-bit subkey: device_id in the top 8 bits, the (4 KiB-block-aligned) device
+ * offset in the low 56 bits.  56 bits of byte offset covers 64 PiB per device. */
+static inline struct diskfs_bt_key
+diskfs_refcount_key(
+    uint32_t device_id,
+    uint64_t device_offset)
+{
+    struct diskfs_bt_key k = {
+        .type              = DISKFS_REC_REFCOUNT,
+        .subkey            = ((uint64_t) device_id << 56) |
+            (device_offset & ((1ULL << 56) - 1)),
+    };
+
+    return k;
+} /* diskfs_refcount_key */
 
 
 /* Materialize the extent from a completed async lookup op (result + the

--- a/src/vfs/diskfs/diskfs_internal.h
+++ b/src/vfs/diskfs/diskfs_internal.h
@@ -365,6 +365,13 @@ struct diskfs_request_private {
     /* CLONE: source/destination base offsets for translating extent keys. */
     uint64_t                    clone_src_base;
     uint64_t                    clone_dst_base;
+    /* Destination sub-range being cleared before this step's shared extent is
+     * recorded there (diskfs_clone_dst_clear).  The clear pass keeps its own
+     * extent cursor: p->ext_iter holds the SOURCE extent that the walk, the
+     * refcount bump and the advance all still need. */
+    uint64_t                    clone_dst_clear_start;
+    uint64_t                    clone_dst_clear_end;
+    struct diskfs_extent        clone_dst_ext;
     /* Whole-extent CoW privatize: the shared extent being copied to private
      * blocks, the freshly-allocated destination, and the bytes copied so far. */
     struct diskfs_extent        cow_ext;

--- a/src/vfs/diskfs/diskfs_internal.h
+++ b/src/vfs/diskfs/diskfs_internal.h
@@ -380,6 +380,11 @@ struct diskfs_request_private {
     uint64_t                    cow_copied;
     void                        (*cow_cont)(
         struct chimera_vfs_request *);
+    /* diskfs_ext_release's caller continuation.  It cannot live in rc_cont:
+     * diskfs_refcount_dec takes that slot for its own completion, so sharing
+     * it makes diskfs_ext_release_after_dec call itself. */
+    void                        (*rel_cont)(
+        struct chimera_vfs_request *);
 };
 
 

--- a/src/vfs/diskfs/diskfs_io.c
+++ b/src/vfs/diskfs/diskfs_io.c
@@ -13,7 +13,7 @@
 
 /* Forward declarations (definitions below, in call-graph order) */
 
-static int
+int
 diskfs_ext_remove_async(
     struct diskfs_bt_op  *op,
     struct diskfs_thread *thread,
@@ -117,7 +117,7 @@ diskfs_dirent_free(
     struct diskfs_thread *thread,
     struct diskfs_dirent *dirent);
 
-static int
+int
 diskfs_io_gate(
     struct diskfs_thread       *thread,
     struct chimera_vfs_request *request,
@@ -304,6 +304,10 @@ diskfs_write_classify_cb(
     struct diskfs_bt_op *op,
     int                  result,
     void                *private_data);
+
+static void
+diskfs_write_cow_scan(
+    struct chimera_vfs_request *request);
 
 static void
 diskfs_write_redirect_alloc(
@@ -583,7 +587,7 @@ diskfs_ext_insert_async(
 } /* diskfs_ext_insert_async */
 
 
-static int
+int
 diskfs_ext_remove_async(
     struct diskfs_bt_op  *op,
     struct diskfs_thread *thread,
@@ -1028,7 +1032,7 @@ diskfs_kv_entry_release(
  * caller must then return without issuing); 0 if it is clear to submit.  resume
  * re-enters the paused path once a completion drains the queue.
  */
-static int
+int
 diskfs_io_gate(
     struct diskfs_thread       *thread,
     struct chimera_vfs_request *request,
@@ -2661,7 +2665,6 @@ diskfs_write_inode_cb(
     uint64_t                       write_start = request->write.offset;
     uint64_t                       write_end   = write_start + request->write.length;
     uint64_t                       aligned_start, aligned_end;
-    struct diskfs_bt_op           *op;
 
     if (unlikely(status != CHIMERA_VFS_OK)) {
         diskfs_op_fail(request, p->txn, status);
@@ -2698,13 +2701,104 @@ diskfs_write_inode_cb(
     p->need_suffix_read   = 0;
     p->inode_stash[0]     = inode;
 
-    op = diskfs_bt_op_alloc(thread);
-    if (diskfs_ext_floor_async(op, thread, inode, aligned_start, p->rec_scratch,
-                               sizeof(p->rec_scratch), diskfs_write_classify_cb,
-                               request)) {
+    /* Reflink copy-on-write: privatize any shared extents overlapping the write
+     * before the normal write machinery runs, so the redirect/trim never frees a
+     * block another file still references. */
+    diskfs_write_cow_scan(request);
+} /* diskfs_write_inode_cb */
+
+/* Start the normal write classification (after any CoW privatization). */
+static void
+diskfs_write_classify_start(struct chimera_vfs_request *request)
+{
+    struct diskfs_request_private *p      = request->plugin_data;
+    struct diskfs_thread          *thread = p->thread;
+    struct diskfs_bt_op           *op     = diskfs_bt_op_alloc(thread);
+
+    if (diskfs_ext_floor_async(op, thread, p->inode_stash[0], p->rmw_aligned_start,
+                               p->rec_scratch, sizeof(p->rec_scratch),
+                               diskfs_write_classify_cb, request)) {
         diskfs_write_classify_cb(op, op->result, request);
     }
-} /* diskfs_write_inode_cb */
+} /* diskfs_write_classify_start */
+
+static void
+diskfs_write_cow_rc_acquired_cb(
+    struct diskfs_inode *inode,
+    int                  status,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+
+    if (unlikely(status != CHIMERA_VFS_OK)) {
+        diskfs_op_fail(request, p->txn, status);
+        return;
+    }
+
+    p->inode_stash[2] = inode;
+    /* cow_ext was stashed by the scan callback; privatize then re-scan. */
+    diskfs_cow_privatize(request, &p->cow_ext, diskfs_write_cow_scan);
+} /* diskfs_write_cow_rc_acquired_cb */
+
+static void
+diskfs_write_cow_scan_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+    struct diskfs_thread          *thread  = p->thread;
+    uint64_t                       astart  = p->rmw_aligned_start;
+    uint64_t                       aend    = astart + p->rmw_aligned_length;
+    struct diskfs_extent           e;
+    int                            have;
+
+    have = diskfs_ext_from_op(op, result, &e);
+    diskfs_bt_op_free(thread, op);
+
+    /* No (more) extents overlapping the write region: nothing to privatize. */
+    if (!have || e.file_offset >= aend) {
+        diskfs_write_classify_start(request);
+        return;
+    }
+
+    if ((e.flags & DISKFS_EXT_SHARED) && e.file_offset + e.length > astart) {
+        p->cow_ext = e;
+        if (p->inode_stash[2] == NULL) {
+            /* Acquire the refcount inode (lock leaf, always last), then CoW. */
+            diskfs_inode_acquire(thread, p->txn, DISKFS_REFCOUNT_INUM_BASE,
+                                 DISKFS_REFCOUNT_GEN, DISKFS_INODE_LOCK_WRITE,
+                                 diskfs_write_cow_rc_acquired_cb, request);
+            return;
+        }
+        diskfs_cow_privatize(request, &p->cow_ext, diskfs_write_cow_scan);
+        return;
+    }
+
+    /* Not shared: step to the next extent. */
+    op = diskfs_bt_op_alloc(thread);
+    if (diskfs_ext_next_async(op, thread, p->inode_stash[0], e.file_offset,
+                              p->rec_scratch, sizeof(p->rec_scratch),
+                              diskfs_write_cow_scan_cb, request)) {
+        diskfs_write_cow_scan_cb(op, op->result, request);
+    }
+} /* diskfs_write_cow_scan_cb */
+
+static void
+diskfs_write_cow_scan(struct chimera_vfs_request *request)
+{
+    struct diskfs_request_private *p      = request->plugin_data;
+    struct diskfs_thread          *thread = p->thread;
+    struct diskfs_bt_op           *op     = diskfs_bt_op_alloc(thread);
+
+    if (diskfs_ext_floor_async(op, thread, p->inode_stash[0], p->rmw_aligned_start,
+                               p->rec_scratch, sizeof(p->rec_scratch),
+                               diskfs_write_cow_scan_cb, request)) {
+        diskfs_write_cow_scan_cb(op, op->result, request);
+    }
+} /* diskfs_write_cow_scan */
 
 
 static void
@@ -2724,7 +2818,8 @@ diskfs_write_classify_cb(
     have = diskfs_ext_from_op(op, result, &e);
     diskfs_bt_op_free(thread, op);
 
-    if (have && e.file_offset <= astart && e.file_offset + e.length >= aend) {
+    if (have && e.file_offset <= astart && e.file_offset + e.length >= aend &&
+        !(e.flags & DISKFS_EXT_SHARED)) {
         /* Single extent fully covers the region: overwrite its blocks in
          * place at the matching device offset. */
         p->rmw_device_id     = e.device_id;
@@ -2986,6 +3081,7 @@ diskfs_write(
     p->need_prefix_read    = 0;
     p->need_suffix_read    = 0;
     p->inplace_written     = 0;
+    p->inode_stash[2]      = NULL;   /* refcount inode (acquired lazily on CoW) */
     p->txn                 = diskfs_txn_begin(thread, DISKFS_TXN_WRITE);
 
     /* Warm-handle fast path (see diskfs_read): reuse the inode pinned at open
@@ -3025,10 +3121,21 @@ diskfs_allocate_finalize(struct chimera_vfs_request *request)
 
 
 static void
+diskfs_write_same_after_punch(
+    struct chimera_vfs_request *request);
+
+static void
 diskfs_dealloc_finish(struct chimera_vfs_request *request)
 {
     struct diskfs_request_private *p     = request->plugin_data;
     struct diskfs_inode           *inode = p->inode_stash[0];
+
+    /* WRITE_SAME borrows this punch loop to clear existing extents before
+     * filling; hand back to its fill phase rather than finalizing. */
+    if (p->ws_active) {
+        diskfs_write_same_after_punch(request);
+        return;
+    }
 
     inode->space_used = (inode->size + 4095) & ~4095;
     diskfs_allocate_finalize(request);
@@ -3247,10 +3354,14 @@ diskfs_dealloc_process(struct chimera_vfs_request *request)
      * (a file whose size is sub-block-aligned), so freeing it whole is correct and
      * is what keeps the space-map free accounting from leaking the edge. */
     if (es >= hole_start && ee <= hole_end) {
-        /* Completely inside the hole: free + remove, then advance. */
-        diskfs_thread_free_space(thread, p->txn, p->ext_iter.device_id,
-                                 p->ext_iter.device_offset,
-                                 SM_ALIGN_UP(p->ext_iter.length));
+        /* Completely inside the hole: free + remove, then advance.  A reflink-
+         * shared extent keeps its backing (other owners reference it; the
+         * refcount frees it at the last owner) -- see diskfs_ext_release. */
+        if (!(p->ext_iter.flags & DISKFS_EXT_SHARED)) {
+            diskfs_thread_free_space(thread, p->txn, p->ext_iter.device_id,
+                                     p->ext_iter.device_offset,
+                                     SM_ALIGN_UP(p->ext_iter.length));
+        }
         op = diskfs_bt_op_alloc(thread);
         if (diskfs_ext_remove_async(op, thread, p->txn, p->inode_stash[0], es,
                                     diskfs_dealloc_modify_advance_cb, request)) {
@@ -3259,10 +3370,13 @@ diskfs_dealloc_process(struct chimera_vfs_request *request)
     } else if (es < hole_start && ee > hole_end) {
         /* Spans the hole: free the (block-aligned) punched-out middle
          * [hole_start, hole_end) of this extent's backing, then insert the tail at
-         * hole_end (block-aligned device offset). */
-        diskfs_thread_free_space(thread, p->txn, p->ext_iter.device_id,
-                                 p->ext_iter.device_offset + (hole_start - es),
-                                 hole_end - hole_start);
+         * hole_end (block-aligned device offset).  A reflink-shared extent keeps
+         * its backing (the refcount frees it at the last owner). */
+        if (!(p->ext_iter.flags & DISKFS_EXT_SHARED)) {
+            diskfs_thread_free_space(thread, p->txn, p->ext_iter.device_id,
+                                     p->ext_iter.device_offset + (hole_start - es),
+                                     hole_end - hole_start);
+        }
         op = diskfs_bt_op_alloc(thread);
         if (diskfs_ext_insert_async(op, thread, p->txn, p->inode_stash[0], hole_end,
                                     ee - hole_end, p->ext_iter.device_id,
@@ -3274,10 +3388,13 @@ diskfs_dealloc_process(struct chimera_vfs_request *request)
     } else if (es < hole_start) {
         /* Overlaps the hole start: free the punched tail [hole_start, ee) of this
          * extent's backing (rounded up to whole blocks -- the extent is removed
-         * entirely past hole_start), then remove + reinsert the kept head. */
-        diskfs_thread_free_space(thread, p->txn, p->ext_iter.device_id,
-                                 p->ext_iter.device_offset + (hole_start - es),
-                                 SM_ALIGN_UP(ee - hole_start));
+         * entirely past hole_start), then remove + reinsert the kept head.  A
+         * reflink-shared extent keeps its backing (refcount frees at last owner). */
+        if (!(p->ext_iter.flags & DISKFS_EXT_SHARED)) {
+            diskfs_thread_free_space(thread, p->txn, p->ext_iter.device_id,
+                                     p->ext_iter.device_offset + (hole_start - es),
+                                     SM_ALIGN_UP(ee - hole_start));
+        }
         op = diskfs_bt_op_alloc(thread);
         if (diskfs_ext_remove_async(op, thread, p->txn, p->inode_stash[0], es,
                                     diskfs_dealloc_ostart_removed_cb, request)) {
@@ -3286,9 +3403,11 @@ diskfs_dealloc_process(struct chimera_vfs_request *request)
     } else {
         /* Overlaps the hole end: free the punched head [es, hole_end) of this
          * extent's backing, then remove + reinsert the kept tail at hole_end. */
-        diskfs_thread_free_space(thread, p->txn, p->ext_iter.device_id,
-                                 p->ext_iter.device_offset,
-                                 hole_end - es);
+        if (!(p->ext_iter.flags & DISKFS_EXT_SHARED)) {
+            diskfs_thread_free_space(thread, p->txn, p->ext_iter.device_id,
+                                     p->ext_iter.device_offset,
+                                     hole_end - es);
+        }
         op = diskfs_bt_op_alloc(thread);
         if (diskfs_ext_remove_async(op, thread, p->txn, p->inode_stash[0], es,
                                     diskfs_dealloc_oend_removed_cb, request)) {
@@ -3789,8 +3908,9 @@ diskfs_allocate(
     (void) shared;
     (void) private_data;
 
-    p->thread = thread;
-    p->txn    = diskfs_txn_begin(thread, DISKFS_TXN_WRITE);
+    p->thread    = thread;
+    p->ws_active = 0;      /* not a WRITE_SAME-borrowed punch */
+    p->txn       = diskfs_txn_begin(thread, DISKFS_TXN_WRITE);
 
     diskfs_inode_get_fh_async(thread, p->txn,
                               request->fh, request->fh_len,
@@ -3977,6 +4097,556 @@ diskfs_seek(
                               request->fh, request->fh_len,
                               diskfs_seek_inode_cb, request);
 } /* diskfs_seek */
+
+
+/*
+ * READ_PLUS classification: report the leading byte-run at request->read_plus
+ * .offset as a single DATA or HOLE segment from the extent map.  An extent
+ * covering the offset is data (running to the extent end); a gap is a hole
+ * (running to the next extent or EOF).  Mirrors diskfs_seek's extent semantics
+ * (an extent is data, a gap is a hole); the NFS server fetches DATA bytes via a
+ * normal read.
+ */
+static void
+diskfs_read_plus_finish_data(
+    struct chimera_vfs_request *request,
+    uint64_t                    seg_end)
+{
+    struct diskfs_request_private *p      = request->plugin_data;
+    struct diskfs_inode           *inode  = p->inode_stash[0];
+    uint64_t                       offset = request->read_plus.offset;
+
+    if (seg_end > inode->size) {
+        seg_end = inode->size;
+    }
+    if (seg_end > offset + request->read_plus.length) {
+        seg_end = offset + request->read_plus.length;
+    }
+
+    request->read_plus.r_is_data = 1;
+    request->read_plus.r_length  = seg_end - offset;
+    request->read_plus.r_eof     = (seg_end >= inode->size);
+    diskfs_op_ok(request, p->txn);
+} /* diskfs_read_plus_finish_data */
+
+static void
+diskfs_read_plus_finish_hole(
+    struct chimera_vfs_request *request,
+    uint64_t                    seg_end)
+{
+    struct diskfs_request_private *p      = request->plugin_data;
+    struct diskfs_inode           *inode  = p->inode_stash[0];
+    uint64_t                       offset = request->read_plus.offset;
+
+    if (seg_end > inode->size) {
+        seg_end = inode->size;
+    }
+    if (seg_end > offset + request->read_plus.length) {
+        seg_end = offset + request->read_plus.length;
+    }
+
+    request->read_plus.r_is_data = 0;
+    request->read_plus.r_length  = seg_end - offset;
+    request->read_plus.r_eof     = (seg_end >= inode->size);
+    diskfs_op_ok(request, p->txn);
+} /* diskfs_read_plus_finish_hole */
+
+/* Found the extent after a gap: its start bounds the hole (else EOF). */
+static void
+diskfs_read_plus_holeend_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+    struct diskfs_extent           next;
+    int                            have;
+
+    have = diskfs_ext_from_op(op, result, &next);
+    diskfs_bt_op_free(p->thread, op);
+
+    diskfs_read_plus_finish_hole(request,
+                                 have ? next.file_offset : p->inode_stash[0]->size);
+} /* diskfs_read_plus_holeend_cb */
+
+/* floor(offset): if it covers offset the run is data, else offset is in a hole
+ * and we look up the following extent to bound it. */
+static void
+diskfs_read_plus_floor_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+    struct diskfs_thread          *thread  = p->thread;
+    uint64_t                       offset  = request->read_plus.offset;
+    struct diskfs_extent           e;
+    int                            have;
+
+    have = diskfs_ext_from_op(op, result, &e);
+    diskfs_bt_op_free(thread, op);
+
+    if (have && e.file_offset <= offset && e.file_offset + e.length > offset) {
+        /* Data extent covering the offset: run to the end of this extent. */
+        diskfs_read_plus_finish_data(request, e.file_offset + e.length);
+        return;
+    }
+
+    /* Hole at offset: bound it by the next extent after the floor (or, if there
+     * is no floor extent, the first extent at/after the offset). */
+    op = diskfs_bt_op_alloc(thread);
+    if (have) {
+        if (diskfs_ext_next_async(op, thread, p->inode_stash[0], e.file_offset,
+                                  p->rec_scratch, sizeof(p->rec_scratch),
+                                  diskfs_read_plus_holeend_cb, request)) {
+            diskfs_read_plus_holeend_cb(op, op->result, request);
+        }
+    } else {
+        if (diskfs_ext_ceil_async(op, thread, p->inode_stash[0], offset,
+                                  p->rec_scratch, sizeof(p->rec_scratch),
+                                  diskfs_read_plus_holeend_cb, request)) {
+            diskfs_read_plus_holeend_cb(op, op->result, request);
+        }
+    }
+} /* diskfs_read_plus_floor_cb */
+
+static void
+diskfs_read_plus_inode_cb(
+    struct diskfs_inode *inode,
+    int                  status,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+    struct diskfs_thread          *thread  = p->thread;
+    uint64_t                       offset  = request->read_plus.offset;
+    struct diskfs_bt_op           *op;
+
+    if (unlikely(status != CHIMERA_VFS_OK)) {
+        diskfs_op_fail(request, p->txn, status);
+        return;
+    }
+
+    p->inode_stash[0] = inode;
+
+    if (offset >= inode->size || request->read_plus.length == 0) {
+        request->read_plus.r_is_data = 0;
+        request->read_plus.r_length  = 0;
+        request->read_plus.r_eof     = (offset >= inode->size);
+        diskfs_op_ok(request, p->txn);
+        return;
+    }
+
+    op = diskfs_bt_op_alloc(thread);
+    if (diskfs_ext_floor_async(op, thread, inode, offset, p->rec_scratch,
+                               sizeof(p->rec_scratch), diskfs_read_plus_floor_cb,
+                               request)) {
+        diskfs_read_plus_floor_cb(op, op->result, request);
+    }
+} /* diskfs_read_plus_inode_cb */
+
+void
+diskfs_read_plus(
+    struct diskfs_thread       *thread,
+    struct diskfs_shared       *shared,
+    struct chimera_vfs_request *request,
+    void                       *private_data)
+{
+    struct diskfs_request_private *p = request->plugin_data;
+
+    (void) shared;
+    (void) private_data;
+
+    p->thread = thread;
+    p->txn    = diskfs_txn_begin(thread, DISKFS_TXN_READ);
+
+    diskfs_inode_get_fh_async(thread, p->txn,
+                              request->fh, request->fh_len,
+                              diskfs_read_plus_inode_cb, request);
+} /* diskfs_read_plus */
+
+
+/*
+ * WRITE_SAME (RFC 7862): expand an Application Data Block pattern across a run
+ * of blocks.  Implemented as punch-then-fill in one write txn:
+ *   1. free any existing extents in the range (reusing the dealloc punch loop),
+ *   2a. zero pattern  -> just extend the size (the punched range reads as zero),
+ *   2b. fixed pattern -> allocate + write the tiled pattern, chunk by chunk.
+ */
+
+#define DISKFS_WS_CHUNK (256ULL << 10)   /* per-step alloc + device-write chunk */
+
+/* Tile one block-size template into dst[0..len), starting at the template phase
+ * for the given file offset (relative to the ADB offset). */
+static void
+diskfs_ws_tile(
+    uint8_t       *dst,
+    uint64_t       len,
+    uint64_t       rel_off,
+    const uint8_t *tmpl,
+    uint32_t       block_size)
+{
+    uint32_t phase = rel_off % block_size;
+    uint64_t done  = 0;
+
+    while (done < len) {
+        uint32_t chunk = block_size - phase;
+        if (chunk > len - done) {
+            chunk = len - done;
+        }
+        memcpy(dst + done, tmpl + phase, chunk);
+        done += chunk;
+        phase = 0;
+    }
+} /* diskfs_ws_tile */
+
+static void
+diskfs_write_same_fill_step(
+    struct chimera_vfs_request *request);
+
+static void
+diskfs_write_same_fail(
+    struct chimera_vfs_request *request,
+    int                         status)
+{
+    struct diskfs_request_private *p = request->plugin_data;
+
+    p->ws_active = 0;
+    if (p->ws_tmpl) {
+        free(p->ws_tmpl);
+        p->ws_tmpl = NULL;
+    }
+    diskfs_op_fail(request, p->txn, status);
+} /* diskfs_write_same_fail */
+
+static void
+diskfs_write_same_finalize(struct chimera_vfs_request *request)
+{
+    struct diskfs_request_private *p      = request->plugin_data;
+    struct diskfs_thread          *thread = p->thread;
+    struct diskfs_inode           *inode  = p->inode_stash[0];
+    uint64_t                       total  = (uint64_t) request->write_same.block_size *
+        request->write_same.block_count;
+    uint64_t                       end = request->write_same.offset + total;
+    struct timespec                now;
+
+    p->ws_active = 0;
+    if (p->ws_tmpl) {
+        free(p->ws_tmpl);
+        p->ws_tmpl = NULL;
+    }
+
+    if (end > inode->size) {
+        inode->size = end;
+    }
+    inode->space_used = (inode->size + 4095) & ~4095;
+
+    clock_gettime(CLOCK_REALTIME, &now);
+    inode->mtime_sec  = now.tv_sec;
+    inode->mtime_nsec = now.tv_nsec;
+    inode->ctime_sec  = now.tv_sec;
+    inode->ctime_nsec = now.tv_nsec;
+
+    request->write_same.r_count = total;
+    request->write_same.r_sync  = CHIMERA_VFS_WRITE_FILESYNC;
+    diskfs_map_attrs(thread, &request->write_same.r_post_attr, inode);
+    diskfs_op_ok(request, p->txn);
+} /* diskfs_write_same_finalize */
+
+/* Device-write completion: when a chunk's writes all land, record it as a
+ * WRITTEN extent and continue the fill loop. */
+static void
+diskfs_write_same_io_cb(
+    struct evpl *evpl,
+    int          status,
+    void        *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+    struct diskfs_thread          *thread  = p->thread;
+
+    (void) evpl;
+
+    if (p->status == 0 && status) {
+        p->status = status;
+    }
+
+    p->pending--;
+    diskfs_pending_io_add(thread, -1);
+    diskfs_io_resume_waiters(thread);
+
+    if (p->pending == 0) {
+        evpl_iovecs_release(thread->evpl, p->iov, p->niov);
+        p->niov = 0;
+
+        if (p->status) {
+            diskfs_write_same_fail(request, p->status);
+            return;
+        }
+
+        /* Record the just-written chunk (ci_* set in fill_step), then continue. */
+        p->ci_flags = 0;   /* WRITTEN */
+        p->ci_cont  = diskfs_write_same_fill_step;
+        diskfs_ext_put(request);
+    }
+} /* diskfs_write_same_io_cb */
+
+static void
+diskfs_write_same_alloc_resume(
+    struct diskfs_thread *thread,
+    void                 *arg)
+{
+    (void) thread;
+    diskfs_write_same_fill_step((struct chimera_vfs_request *) arg);
+} /* diskfs_write_same_alloc_resume */
+
+static void
+diskfs_write_same_fill_step(struct chimera_vfs_request *request)
+{
+    struct diskfs_request_private *p      = request->plugin_data;
+    struct diskfs_thread          *thread = p->thread;
+    struct diskfs_shared          *shared = thread->shared;
+    struct evpl                   *evpl   = thread->evpl;
+    uint64_t                       off    = p->loop_off;
+    uint64_t                       end    = p->loop_pos;
+    uint64_t                       chunk, dev_id, dev_off, max_req, written;
+    int                            rc;
+
+    if (off >= end) {
+        diskfs_write_same_finalize(request);
+        return;
+    }
+
+    chunk = end - off;
+    if (chunk > p->alloc_cap) {
+        chunk = p->alloc_cap;
+    }
+
+    /* Park if the device queue is full; resume re-enters fill_step (nothing
+     * allocated yet, so re-entry is clean). */
+    if (diskfs_io_gate(thread, request, diskfs_write_same_fill_step)) {
+        return;
+    }
+
+    rc = diskfs_inode_alloc_space(thread, p->txn, p->inode_stash[0],
+                                  (int64_t) chunk, 0, &dev_id, &dev_off,
+                                  diskfs_write_same_alloc_resume, request);
+    if (rc == SM_AGAIN) {
+        return;     /* parked mid-allocation; resume retries cleanly */
+    }
+    if (rc) {
+        /* Spread a large request across allocation groups before giving up. */
+        if (p->alloc_cap > SM_BLOCK_SIZE) {
+            p->alloc_cap >>= 1;
+            diskfs_write_same_fill_step(request);
+            return;
+        }
+        diskfs_write_same_fail(request, CHIMERA_VFS_ENOSPC);
+        return;
+    }
+
+    p->alloc_cap = DISKFS_WS_CHUNK;     /* reset for the next chunk */
+
+    /* Extent to record once the device writes for this chunk complete. */
+    p->ci_off    = off;
+    p->ci_len    = chunk;
+    p->ci_devid  = (uint32_t) dev_id;
+    p->ci_devoff = dev_off;
+    p->loop_off  = off + chunk;         /* advance for the next step */
+
+    /* Issue the device writes for [dev_off, dev_off+chunk), each piece filled
+     * with the tiled pattern, split by the device's max request size. */
+    max_req    = shared->devices[dev_id].max_request_size;
+    p->niov    = 0;
+    p->pending = 0;
+    written    = 0;
+
+    while (written < chunk) {
+        struct evpl_iovec *piece_iov = &p->iov[p->niov];
+        uint64_t           piece     = chunk - written;
+        uint64_t           rel, fill_done;
+        int                piece_niov, i;
+
+        if (piece > max_req) {
+            piece = max_req;
+        }
+
+        /* Defensive: never overrun the fixed per-request iovec scratch. */
+        if (p->niov + 32 > (int) (sizeof(p->iov) / sizeof(p->iov[0]))) {
+            if (p->pending == 0) {
+                diskfs_write_same_fail(request, CHIMERA_VFS_EIO);
+                return;
+            }
+            p->status = CHIMERA_VFS_EIO;
+            break;
+        }
+
+        piece_niov = evpl_iovec_alloc(evpl, piece, 4096, 32, 0, piece_iov);
+        if (piece_niov <= 0) {
+            if (p->pending == 0) {
+                diskfs_write_same_fail(request, CHIMERA_VFS_EIO);
+                return;
+            }
+            p->status = CHIMERA_VFS_EIO;
+            break;
+        }
+
+        rel       = (off + written) - request->write_same.offset;
+        fill_done = 0;
+        for (i = 0; i < piece_niov; i++) {
+            diskfs_ws_tile(piece_iov[i].data, piece_iov[i].length,
+                           rel + fill_done, p->ws_tmpl,
+                           request->write_same.block_size);
+            fill_done += piece_iov[i].length;
+        }
+
+        p->niov += piece_niov;
+        p->pending++;
+        diskfs_pending_io_add(thread, 1);
+
+        evpl_block_write(evpl, thread->queue[dev_id], piece_iov, piece_niov,
+                         dev_off + written, !shared->unsafe_async,
+                         diskfs_write_same_io_cb, request);
+
+        written += piece;
+    }
+} /* diskfs_write_same_fill_step */
+
+static void
+diskfs_write_same_after_punch(struct chimera_vfs_request *request)
+{
+    struct diskfs_request_private *p      = request->plugin_data;
+    uint64_t                       offset = request->write_same.offset;
+    uint64_t                       total  = (uint64_t) request->write_same.block_size *
+        request->write_same.block_count;
+    const uint8_t                 *pat     = request->write_same.pattern;
+    uint32_t                       patlen  = request->write_same.pattern_len;
+    int                            is_zero = 1;
+    uint32_t                       i;
+
+    for (i = 0; i < patlen; i++) {
+        if (pat[i]) {
+            is_zero = 0;
+            break;
+        }
+    }
+
+    if (is_zero) {
+        /* The punched range already reads as zeros; just extend the size. */
+        diskfs_write_same_finalize(request);
+        return;
+    }
+
+    p->loop_off  = offset;
+    p->loop_pos  = offset + total;
+    p->alloc_cap = DISKFS_WS_CHUNK;
+    diskfs_write_same_fill_step(request);
+} /* diskfs_write_same_after_punch */
+
+static void
+diskfs_write_same_inode_cb(
+    struct diskfs_inode *inode,
+    int                  status,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+    struct diskfs_thread          *thread  = p->thread;
+    uint64_t                       offset  = request->write_same.offset;
+    uint32_t                       bs      = request->write_same.block_size;
+    uint64_t                       total, punch_end;
+    struct diskfs_bt_op           *op;
+
+    if (unlikely(status != CHIMERA_VFS_OK)) {
+        diskfs_op_fail(request, p->txn, status);
+        return;
+    }
+
+    p->inode_stash[0] = inode;
+
+    if (!S_ISREG(inode->mode)) {
+        diskfs_op_fail(request, p->txn,
+                       S_ISDIR(inode->mode) ? CHIMERA_VFS_EISDIR : CHIMERA_VFS_EINVAL);
+        return;
+    }
+
+    diskfs_map_attrs(thread, &request->write_same.r_pre_attr, inode);
+
+    total = (uint64_t) bs * request->write_same.block_count;
+    if (total == 0) {
+        request->write_same.r_count = 0;
+        request->write_same.r_sync  = CHIMERA_VFS_WRITE_FILESYNC;
+        diskfs_map_attrs(thread, &request->write_same.r_post_attr, inode);
+        diskfs_op_ok(request, p->txn);
+        return;
+    }
+
+    /* Build the one block-size pattern template (zero + pattern at reloff). */
+    p->ws_tmpl = malloc(bs);
+    chimera_diskfs_abort_if(p->ws_tmpl == NULL, "write_same template OOM");
+    memset(p->ws_tmpl, 0, bs);
+    if (request->write_same.pattern_len) {
+        memcpy(p->ws_tmpl + request->write_same.reloff_pattern,
+               request->write_same.pattern,
+               request->write_same.pattern_len);
+    }
+
+    p->ws_active = 1;
+
+    /* Punch existing extents in [offset, min(offset+total, size)); the dealloc
+     * loop hands back to diskfs_write_same_after_punch via ws_active. */
+    punch_end = offset + total;
+    if (punch_end > inode->size) {
+        punch_end = inode->size;
+    }
+
+    if (offset < punch_end) {
+        p->loop_off  = offset;
+        p->loop_left = punch_end;
+
+        op = diskfs_bt_op_alloc(thread);
+        if (diskfs_ext_floor_async(op, thread, inode, offset, p->rec_scratch,
+                                   sizeof(p->rec_scratch), diskfs_dealloc_first_cb,
+                                   request)) {
+            diskfs_dealloc_first_cb(op, op->result, request);
+        }
+        return;
+    }
+
+    diskfs_write_same_after_punch(request);
+} /* diskfs_write_same_inode_cb */
+
+void
+diskfs_write_same(
+    struct diskfs_thread       *thread,
+    struct diskfs_shared       *shared,
+    struct chimera_vfs_request *request,
+    void                       *private_data)
+{
+    struct diskfs_request_private *p = request->plugin_data;
+
+    (void) private_data;
+
+    if (unlikely(shared->block_layout || shared->scsi_layout)) {
+        request->status = CHIMERA_VFS_EINVAL;
+        request->complete(request);
+        return;
+    }
+
+    p->thread    = thread;
+    p->status    = 0;
+    p->pending   = 0;
+    p->niov      = 0;
+    p->ws_active = 0;
+    p->ws_tmpl   = NULL;
+    p->txn       = diskfs_txn_begin(thread, DISKFS_TXN_WRITE);
+
+    diskfs_inode_get_fh_async(thread, p->txn,
+                              request->fh, request->fh_len,
+                              diskfs_write_same_inode_cb, request);
+} /* diskfs_write_same */
 
 
 /*

--- a/src/vfs/diskfs/diskfs_io.c
+++ b/src/vfs/diskfs/diskfs_io.c
@@ -13,7 +13,7 @@
 
 /* Forward declarations (definitions below, in call-graph order) */
 
-static int
+int
 diskfs_ext_remove_async(
     struct diskfs_bt_op  *op,
     struct diskfs_thread *thread,
@@ -116,7 +116,7 @@ diskfs_dirent_free(
     struct diskfs_thread *thread,
     struct diskfs_dirent *dirent);
 
-static int
+int
 diskfs_io_gate(
     struct diskfs_thread       *thread,
     struct chimera_vfs_request *request,
@@ -304,6 +304,10 @@ diskfs_write_classify_cb(
     struct diskfs_bt_op *op,
     int                  result,
     void                *private_data);
+
+static void
+diskfs_write_cow_scan(
+    struct chimera_vfs_request *request);
 
 static void
 diskfs_write_redirect_alloc(
@@ -583,7 +587,7 @@ diskfs_ext_insert_async(
 } /* diskfs_ext_insert_async */
 
 
-static int
+int
 diskfs_ext_remove_async(
     struct diskfs_bt_op  *op,
     struct diskfs_thread *thread,
@@ -1043,7 +1047,7 @@ diskfs_kv_entry_release(
  * caller must then return without issuing); 0 if it is clear to submit.  resume
  * re-enters the paused path once a completion drains the queue.
  */
-static int
+int
 diskfs_io_gate(
     struct diskfs_thread       *thread,
     struct chimera_vfs_request *request,
@@ -2681,7 +2685,6 @@ diskfs_write_inode_cb(
     uint64_t                       write_start = request->write.offset;
     uint64_t                       write_end   = write_start + request->write.length;
     uint64_t                       aligned_start, aligned_end;
-    struct diskfs_bt_op           *op;
 
     if (unlikely(status != CHIMERA_VFS_OK)) {
         diskfs_op_fail(request, p->txn, status);
@@ -2718,13 +2721,104 @@ diskfs_write_inode_cb(
     p->need_suffix_read   = 0;
     p->inode_stash[0]     = inode;
 
-    op = diskfs_bt_op_alloc(thread);
-    if (diskfs_ext_floor_async(op, thread, inode, aligned_start, p->rec_scratch,
-                               sizeof(p->rec_scratch), diskfs_write_classify_cb,
-                               request)) {
+    /* Reflink copy-on-write: privatize any shared extents overlapping the write
+     * before the normal write machinery runs, so the redirect/trim never frees a
+     * block another file still references. */
+    diskfs_write_cow_scan(request);
+} /* diskfs_write_inode_cb */
+
+/* Start the normal write classification (after any CoW privatization). */
+static void
+diskfs_write_classify_start(struct chimera_vfs_request *request)
+{
+    struct diskfs_request_private *p      = request->plugin_data;
+    struct diskfs_thread          *thread = p->thread;
+    struct diskfs_bt_op           *op     = diskfs_bt_op_alloc(thread);
+
+    if (diskfs_ext_floor_async(op, thread, p->inode_stash[0], p->rmw_aligned_start,
+                               p->rec_scratch, sizeof(p->rec_scratch),
+                               diskfs_write_classify_cb, request)) {
         diskfs_write_classify_cb(op, op->result, request);
     }
-} /* diskfs_write_inode_cb */
+} /* diskfs_write_classify_start */
+
+static void
+diskfs_write_cow_rc_acquired_cb(
+    struct diskfs_inode *inode,
+    int                  status,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+
+    if (unlikely(status != CHIMERA_VFS_OK)) {
+        diskfs_op_fail(request, p->txn, status);
+        return;
+    }
+
+    p->inode_stash[2] = inode;
+    /* cow_ext was stashed by the scan callback; privatize then re-scan. */
+    diskfs_cow_privatize(request, &p->cow_ext, diskfs_write_cow_scan);
+} /* diskfs_write_cow_rc_acquired_cb */
+
+static void
+diskfs_write_cow_scan_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+    struct diskfs_thread          *thread  = p->thread;
+    uint64_t                       astart  = p->rmw_aligned_start;
+    uint64_t                       aend    = astart + p->rmw_aligned_length;
+    struct diskfs_extent           e;
+    int                            have;
+
+    have = diskfs_ext_from_op(op, result, &e);
+    diskfs_bt_op_free(thread, op);
+
+    /* No (more) extents overlapping the write region: nothing to privatize. */
+    if (!have || e.file_offset >= aend) {
+        diskfs_write_classify_start(request);
+        return;
+    }
+
+    if ((e.flags & DISKFS_EXT_SHARED) && e.file_offset + e.length > astart) {
+        p->cow_ext = e;
+        if (p->inode_stash[2] == NULL) {
+            /* Acquire the refcount inode (lock leaf, always last), then CoW. */
+            diskfs_inode_acquire(thread, p->txn, NULL, DISKFS_REFCOUNT_INUM_BASE,
+                                 DISKFS_REFCOUNT_GEN, DISKFS_INODE_LOCK_WRITE,
+                                 diskfs_write_cow_rc_acquired_cb, request);
+            return;
+        }
+        diskfs_cow_privatize(request, &p->cow_ext, diskfs_write_cow_scan);
+        return;
+    }
+
+    /* Not shared: step to the next extent. */
+    op = diskfs_bt_op_alloc(thread);
+    if (diskfs_ext_next_async(op, thread, p->inode_stash[0], e.file_offset,
+                              p->rec_scratch, sizeof(p->rec_scratch),
+                              diskfs_write_cow_scan_cb, request)) {
+        diskfs_write_cow_scan_cb(op, op->result, request);
+    }
+} /* diskfs_write_cow_scan_cb */
+
+static void
+diskfs_write_cow_scan(struct chimera_vfs_request *request)
+{
+    struct diskfs_request_private *p      = request->plugin_data;
+    struct diskfs_thread          *thread = p->thread;
+    struct diskfs_bt_op           *op     = diskfs_bt_op_alloc(thread);
+
+    if (diskfs_ext_floor_async(op, thread, p->inode_stash[0], p->rmw_aligned_start,
+                               p->rec_scratch, sizeof(p->rec_scratch),
+                               diskfs_write_cow_scan_cb, request)) {
+        diskfs_write_cow_scan_cb(op, op->result, request);
+    }
+} /* diskfs_write_cow_scan */
 
 
 static void
@@ -2744,7 +2838,8 @@ diskfs_write_classify_cb(
     have = diskfs_ext_from_op(op, result, &e);
     diskfs_bt_op_free(thread, op);
 
-    if (have && e.file_offset <= astart && e.file_offset + e.length >= aend) {
+    if (have && e.file_offset <= astart && e.file_offset + e.length >= aend &&
+        !(e.flags & DISKFS_EXT_SHARED)) {
         /* Single extent fully covers the region: overwrite its blocks in
          * place at the matching device offset. */
         p->rmw_device_id     = e.device_id;
@@ -3006,6 +3101,7 @@ diskfs_write(
     p->need_prefix_read    = 0;
     p->need_suffix_read    = 0;
     p->inplace_written     = 0;
+    p->inode_stash[2]      = NULL;   /* refcount inode (acquired lazily on CoW) */
     p->txn                 = diskfs_txn_begin(thread, DISKFS_TXN_WRITE);
 
     /* Warm-handle fast path (see diskfs_read): reuse the inode pinned at open
@@ -3045,10 +3141,21 @@ diskfs_allocate_finalize(struct chimera_vfs_request *request)
 
 
 static void
+diskfs_write_same_after_punch(
+    struct chimera_vfs_request *request);
+
+static void
 diskfs_dealloc_finish(struct chimera_vfs_request *request)
 {
     struct diskfs_request_private *p     = request->plugin_data;
     struct diskfs_inode           *inode = p->inode_stash[0];
+
+    /* WRITE_SAME borrows this punch loop to clear existing extents before
+     * filling; hand back to its fill phase rather than finalizing. */
+    if (p->ws_active) {
+        diskfs_write_same_after_punch(request);
+        return;
+    }
 
     inode->space_used = (inode->size + 4095) & ~4095;
     diskfs_allocate_finalize(request);
@@ -3267,10 +3374,14 @@ diskfs_dealloc_process(struct chimera_vfs_request *request)
      * (a file whose size is sub-block-aligned), so freeing it whole is correct and
      * is what keeps the space-map free accounting from leaking the edge. */
     if (es >= hole_start && ee <= hole_end) {
-        /* Completely inside the hole: free + remove, then advance. */
-        diskfs_thread_free_space(thread, p->txn, p->ext_iter.device_id,
-                                 p->ext_iter.device_offset,
-                                 SM_ALIGN_UP(p->ext_iter.length));
+        /* Completely inside the hole: free + remove, then advance.  A reflink-
+         * shared extent keeps its backing (other owners reference it; the
+         * refcount frees it at the last owner) -- see diskfs_ext_release. */
+        if (!(p->ext_iter.flags & DISKFS_EXT_SHARED)) {
+            diskfs_thread_free_space(thread, p->txn, p->ext_iter.device_id,
+                                     p->ext_iter.device_offset,
+                                     SM_ALIGN_UP(p->ext_iter.length));
+        }
         op = diskfs_bt_op_alloc(thread);
         if (diskfs_ext_remove_async(op, thread, p->txn, p->inode_stash[0], es,
                                     diskfs_dealloc_modify_advance_cb, request)) {
@@ -3279,10 +3390,13 @@ diskfs_dealloc_process(struct chimera_vfs_request *request)
     } else if (es < hole_start && ee > hole_end) {
         /* Spans the hole: free the (block-aligned) punched-out middle
          * [hole_start, hole_end) of this extent's backing, then insert the tail at
-         * hole_end (block-aligned device offset). */
-        diskfs_thread_free_space(thread, p->txn, p->ext_iter.device_id,
-                                 p->ext_iter.device_offset + (hole_start - es),
-                                 hole_end - hole_start);
+         * hole_end (block-aligned device offset).  A reflink-shared extent keeps
+         * its backing (the refcount frees it at the last owner). */
+        if (!(p->ext_iter.flags & DISKFS_EXT_SHARED)) {
+            diskfs_thread_free_space(thread, p->txn, p->ext_iter.device_id,
+                                     p->ext_iter.device_offset + (hole_start - es),
+                                     hole_end - hole_start);
+        }
         op = diskfs_bt_op_alloc(thread);
         if (diskfs_ext_insert_async(op, thread, p->txn, p->inode_stash[0], hole_end,
                                     ee - hole_end, p->ext_iter.device_id,
@@ -3294,10 +3408,13 @@ diskfs_dealloc_process(struct chimera_vfs_request *request)
     } else if (es < hole_start) {
         /* Overlaps the hole start: free the punched tail [hole_start, ee) of this
          * extent's backing (rounded up to whole blocks -- the extent is removed
-         * entirely past hole_start), then remove + reinsert the kept head. */
-        diskfs_thread_free_space(thread, p->txn, p->ext_iter.device_id,
-                                 p->ext_iter.device_offset + (hole_start - es),
-                                 SM_ALIGN_UP(ee - hole_start));
+         * entirely past hole_start), then remove + reinsert the kept head.  A
+         * reflink-shared extent keeps its backing (refcount frees at last owner). */
+        if (!(p->ext_iter.flags & DISKFS_EXT_SHARED)) {
+            diskfs_thread_free_space(thread, p->txn, p->ext_iter.device_id,
+                                     p->ext_iter.device_offset + (hole_start - es),
+                                     SM_ALIGN_UP(ee - hole_start));
+        }
         op = diskfs_bt_op_alloc(thread);
         if (diskfs_ext_remove_async(op, thread, p->txn, p->inode_stash[0], es,
                                     diskfs_dealloc_ostart_removed_cb, request)) {
@@ -3306,9 +3423,11 @@ diskfs_dealloc_process(struct chimera_vfs_request *request)
     } else {
         /* Overlaps the hole end: free the punched head [es, hole_end) of this
          * extent's backing, then remove + reinsert the kept tail at hole_end. */
-        diskfs_thread_free_space(thread, p->txn, p->ext_iter.device_id,
-                                 p->ext_iter.device_offset,
-                                 hole_end - es);
+        if (!(p->ext_iter.flags & DISKFS_EXT_SHARED)) {
+            diskfs_thread_free_space(thread, p->txn, p->ext_iter.device_id,
+                                     p->ext_iter.device_offset,
+                                     hole_end - es);
+        }
         op = diskfs_bt_op_alloc(thread);
         if (diskfs_ext_remove_async(op, thread, p->txn, p->inode_stash[0], es,
                                     diskfs_dealloc_oend_removed_cb, request)) {
@@ -3809,8 +3928,9 @@ diskfs_allocate(
     (void) shared;
     (void) private_data;
 
-    p->thread = thread;
-    p->txn    = diskfs_txn_begin(thread, DISKFS_TXN_WRITE);
+    p->thread    = thread;
+    p->ws_active = 0;      /* not a WRITE_SAME-borrowed punch */
+    p->txn       = diskfs_txn_begin(thread, DISKFS_TXN_WRITE);
 
     diskfs_inode_get_fh_async(thread, p->txn, p->fs,
                               request->fh, request->fh_len,
@@ -3997,6 +4117,556 @@ diskfs_seek(
                               request->fh, request->fh_len,
                               diskfs_seek_inode_cb, request);
 } /* diskfs_seek */
+
+
+/*
+ * READ_PLUS classification: report the leading byte-run at request->read_plus
+ * .offset as a single DATA or HOLE segment from the extent map.  An extent
+ * covering the offset is data (running to the extent end); a gap is a hole
+ * (running to the next extent or EOF).  Mirrors diskfs_seek's extent semantics
+ * (an extent is data, a gap is a hole); the NFS server fetches DATA bytes via a
+ * normal read.
+ */
+static void
+diskfs_read_plus_finish_data(
+    struct chimera_vfs_request *request,
+    uint64_t                    seg_end)
+{
+    struct diskfs_request_private *p      = request->plugin_data;
+    struct diskfs_inode           *inode  = p->inode_stash[0];
+    uint64_t                       offset = request->read_plus.offset;
+
+    if (seg_end > inode->size) {
+        seg_end = inode->size;
+    }
+    if (seg_end > offset + request->read_plus.length) {
+        seg_end = offset + request->read_plus.length;
+    }
+
+    request->read_plus.r_is_data = 1;
+    request->read_plus.r_length  = seg_end - offset;
+    request->read_plus.r_eof     = (seg_end >= inode->size);
+    diskfs_op_ok(request, p->txn);
+} /* diskfs_read_plus_finish_data */
+
+static void
+diskfs_read_plus_finish_hole(
+    struct chimera_vfs_request *request,
+    uint64_t                    seg_end)
+{
+    struct diskfs_request_private *p      = request->plugin_data;
+    struct diskfs_inode           *inode  = p->inode_stash[0];
+    uint64_t                       offset = request->read_plus.offset;
+
+    if (seg_end > inode->size) {
+        seg_end = inode->size;
+    }
+    if (seg_end > offset + request->read_plus.length) {
+        seg_end = offset + request->read_plus.length;
+    }
+
+    request->read_plus.r_is_data = 0;
+    request->read_plus.r_length  = seg_end - offset;
+    request->read_plus.r_eof     = (seg_end >= inode->size);
+    diskfs_op_ok(request, p->txn);
+} /* diskfs_read_plus_finish_hole */
+
+/* Found the extent after a gap: its start bounds the hole (else EOF). */
+static void
+diskfs_read_plus_holeend_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+    struct diskfs_extent           next;
+    int                            have;
+
+    have = diskfs_ext_from_op(op, result, &next);
+    diskfs_bt_op_free(p->thread, op);
+
+    diskfs_read_plus_finish_hole(request,
+                                 have ? next.file_offset : p->inode_stash[0]->size);
+} /* diskfs_read_plus_holeend_cb */
+
+/* floor(offset): if it covers offset the run is data, else offset is in a hole
+ * and we look up the following extent to bound it. */
+static void
+diskfs_read_plus_floor_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+    struct diskfs_thread          *thread  = p->thread;
+    uint64_t                       offset  = request->read_plus.offset;
+    struct diskfs_extent           e;
+    int                            have;
+
+    have = diskfs_ext_from_op(op, result, &e);
+    diskfs_bt_op_free(thread, op);
+
+    if (have && e.file_offset <= offset && e.file_offset + e.length > offset) {
+        /* Data extent covering the offset: run to the end of this extent. */
+        diskfs_read_plus_finish_data(request, e.file_offset + e.length);
+        return;
+    }
+
+    /* Hole at offset: bound it by the next extent after the floor (or, if there
+     * is no floor extent, the first extent at/after the offset). */
+    op = diskfs_bt_op_alloc(thread);
+    if (have) {
+        if (diskfs_ext_next_async(op, thread, p->inode_stash[0], e.file_offset,
+                                  p->rec_scratch, sizeof(p->rec_scratch),
+                                  diskfs_read_plus_holeend_cb, request)) {
+            diskfs_read_plus_holeend_cb(op, op->result, request);
+        }
+    } else {
+        if (diskfs_ext_ceil_async(op, thread, p->inode_stash[0], offset,
+                                  p->rec_scratch, sizeof(p->rec_scratch),
+                                  diskfs_read_plus_holeend_cb, request)) {
+            diskfs_read_plus_holeend_cb(op, op->result, request);
+        }
+    }
+} /* diskfs_read_plus_floor_cb */
+
+static void
+diskfs_read_plus_inode_cb(
+    struct diskfs_inode *inode,
+    int                  status,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+    struct diskfs_thread          *thread  = p->thread;
+    uint64_t                       offset  = request->read_plus.offset;
+    struct diskfs_bt_op           *op;
+
+    if (unlikely(status != CHIMERA_VFS_OK)) {
+        diskfs_op_fail(request, p->txn, status);
+        return;
+    }
+
+    p->inode_stash[0] = inode;
+
+    if (offset >= inode->size || request->read_plus.length == 0) {
+        request->read_plus.r_is_data = 0;
+        request->read_plus.r_length  = 0;
+        request->read_plus.r_eof     = (offset >= inode->size);
+        diskfs_op_ok(request, p->txn);
+        return;
+    }
+
+    op = diskfs_bt_op_alloc(thread);
+    if (diskfs_ext_floor_async(op, thread, inode, offset, p->rec_scratch,
+                               sizeof(p->rec_scratch), diskfs_read_plus_floor_cb,
+                               request)) {
+        diskfs_read_plus_floor_cb(op, op->result, request);
+    }
+} /* diskfs_read_plus_inode_cb */
+
+void
+diskfs_read_plus(
+    struct diskfs_thread       *thread,
+    struct diskfs_shared       *shared,
+    struct chimera_vfs_request *request,
+    void                       *private_data)
+{
+    struct diskfs_request_private *p = request->plugin_data;
+
+    (void) shared;
+    (void) private_data;
+
+    p->thread = thread;
+    p->txn    = diskfs_txn_begin(thread, DISKFS_TXN_READ);
+
+    diskfs_inode_get_fh_async(thread, p->txn, p->fs,
+                              request->fh, request->fh_len,
+                              diskfs_read_plus_inode_cb, request);
+} /* diskfs_read_plus */
+
+
+/*
+ * WRITE_SAME (RFC 7862): expand an Application Data Block pattern across a run
+ * of blocks.  Implemented as punch-then-fill in one write txn:
+ *   1. free any existing extents in the range (reusing the dealloc punch loop),
+ *   2a. zero pattern  -> just extend the size (the punched range reads as zero),
+ *   2b. fixed pattern -> allocate + write the tiled pattern, chunk by chunk.
+ */
+
+#define DISKFS_WS_CHUNK (256ULL << 10)   /* per-step alloc + device-write chunk */
+
+/* Tile one block-size template into dst[0..len), starting at the template phase
+ * for the given file offset (relative to the ADB offset). */
+static void
+diskfs_ws_tile(
+    uint8_t       *dst,
+    uint64_t       len,
+    uint64_t       rel_off,
+    const uint8_t *tmpl,
+    uint32_t       block_size)
+{
+    uint32_t phase = rel_off % block_size;
+    uint64_t done  = 0;
+
+    while (done < len) {
+        uint32_t chunk = block_size - phase;
+        if (chunk > len - done) {
+            chunk = len - done;
+        }
+        memcpy(dst + done, tmpl + phase, chunk);
+        done += chunk;
+        phase = 0;
+    }
+} /* diskfs_ws_tile */
+
+static void
+diskfs_write_same_fill_step(
+    struct chimera_vfs_request *request);
+
+static void
+diskfs_write_same_fail(
+    struct chimera_vfs_request *request,
+    int                         status)
+{
+    struct diskfs_request_private *p = request->plugin_data;
+
+    p->ws_active = 0;
+    if (p->ws_tmpl) {
+        free(p->ws_tmpl);
+        p->ws_tmpl = NULL;
+    }
+    diskfs_op_fail(request, p->txn, status);
+} /* diskfs_write_same_fail */
+
+static void
+diskfs_write_same_finalize(struct chimera_vfs_request *request)
+{
+    struct diskfs_request_private *p      = request->plugin_data;
+    struct diskfs_thread          *thread = p->thread;
+    struct diskfs_inode           *inode  = p->inode_stash[0];
+    uint64_t                       total  = (uint64_t) request->write_same.block_size *
+        request->write_same.block_count;
+    uint64_t                       end = request->write_same.offset + total;
+    struct timespec                now;
+
+    p->ws_active = 0;
+    if (p->ws_tmpl) {
+        free(p->ws_tmpl);
+        p->ws_tmpl = NULL;
+    }
+
+    if (end > inode->size) {
+        inode->size = end;
+    }
+    inode->space_used = (inode->size + 4095) & ~4095;
+
+    clock_gettime(CLOCK_REALTIME, &now);
+    inode->mtime_sec  = now.tv_sec;
+    inode->mtime_nsec = now.tv_nsec;
+    inode->ctime_sec  = now.tv_sec;
+    inode->ctime_nsec = now.tv_nsec;
+
+    request->write_same.r_count = total;
+    request->write_same.r_sync  = CHIMERA_VFS_WRITE_FILESYNC;
+    diskfs_map_attrs(thread, &request->write_same.r_post_attr, inode);
+    diskfs_op_ok(request, p->txn);
+} /* diskfs_write_same_finalize */
+
+/* Device-write completion: when a chunk's writes all land, record it as a
+ * WRITTEN extent and continue the fill loop. */
+static void
+diskfs_write_same_io_cb(
+    struct evpl *evpl,
+    int          status,
+    void        *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+    struct diskfs_thread          *thread  = p->thread;
+
+    (void) evpl;
+
+    if (p->status == 0 && status) {
+        p->status = status;
+    }
+
+    p->pending--;
+    diskfs_pending_io_add(thread, -1);
+    diskfs_io_resume_waiters(thread);
+
+    if (p->pending == 0) {
+        evpl_iovecs_release(thread->evpl, p->iov, p->niov);
+        p->niov = 0;
+
+        if (p->status) {
+            diskfs_write_same_fail(request, p->status);
+            return;
+        }
+
+        /* Record the just-written chunk (ci_* set in fill_step), then continue. */
+        p->ci_flags = 0;   /* WRITTEN */
+        p->ci_cont  = diskfs_write_same_fill_step;
+        diskfs_ext_put(request);
+    }
+} /* diskfs_write_same_io_cb */
+
+static void
+diskfs_write_same_alloc_resume(
+    struct diskfs_thread *thread,
+    void                 *arg)
+{
+    (void) thread;
+    diskfs_write_same_fill_step((struct chimera_vfs_request *) arg);
+} /* diskfs_write_same_alloc_resume */
+
+static void
+diskfs_write_same_fill_step(struct chimera_vfs_request *request)
+{
+    struct diskfs_request_private *p      = request->plugin_data;
+    struct diskfs_thread          *thread = p->thread;
+    struct diskfs_shared          *shared = thread->shared;
+    struct evpl                   *evpl   = thread->evpl;
+    uint64_t                       off    = p->loop_off;
+    uint64_t                       end    = p->loop_pos;
+    uint64_t                       chunk, dev_id, dev_off, max_req, written;
+    int                            rc;
+
+    if (off >= end) {
+        diskfs_write_same_finalize(request);
+        return;
+    }
+
+    chunk = end - off;
+    if (chunk > p->alloc_cap) {
+        chunk = p->alloc_cap;
+    }
+
+    /* Park if the device queue is full; resume re-enters fill_step (nothing
+     * allocated yet, so re-entry is clean). */
+    if (diskfs_io_gate(thread, request, diskfs_write_same_fill_step)) {
+        return;
+    }
+
+    rc = diskfs_inode_alloc_space(thread, p->txn, p->inode_stash[0],
+                                  (int64_t) chunk, 0, &dev_id, &dev_off,
+                                  diskfs_write_same_alloc_resume, request);
+    if (rc == SM_AGAIN) {
+        return;     /* parked mid-allocation; resume retries cleanly */
+    }
+    if (rc) {
+        /* Spread a large request across allocation groups before giving up. */
+        if (p->alloc_cap > SM_BLOCK_SIZE) {
+            p->alloc_cap >>= 1;
+            diskfs_write_same_fill_step(request);
+            return;
+        }
+        diskfs_write_same_fail(request, CHIMERA_VFS_ENOSPC);
+        return;
+    }
+
+    p->alloc_cap = DISKFS_WS_CHUNK;     /* reset for the next chunk */
+
+    /* Extent to record once the device writes for this chunk complete. */
+    p->ci_off    = off;
+    p->ci_len    = chunk;
+    p->ci_devid  = (uint32_t) dev_id;
+    p->ci_devoff = dev_off;
+    p->loop_off  = off + chunk;         /* advance for the next step */
+
+    /* Issue the device writes for [dev_off, dev_off+chunk), each piece filled
+     * with the tiled pattern, split by the device's max request size. */
+    max_req    = shared->devices[dev_id].max_request_size;
+    p->niov    = 0;
+    p->pending = 0;
+    written    = 0;
+
+    while (written < chunk) {
+        struct evpl_iovec *piece_iov = &p->iov[p->niov];
+        uint64_t           piece     = chunk - written;
+        uint64_t           rel, fill_done;
+        int                piece_niov, i;
+
+        if (piece > max_req) {
+            piece = max_req;
+        }
+
+        /* Defensive: never overrun the fixed per-request iovec scratch. */
+        if (p->niov + 32 > (int) (sizeof(p->iov) / sizeof(p->iov[0]))) {
+            if (p->pending == 0) {
+                diskfs_write_same_fail(request, CHIMERA_VFS_EIO);
+                return;
+            }
+            p->status = CHIMERA_VFS_EIO;
+            break;
+        }
+
+        piece_niov = evpl_iovec_alloc(evpl, piece, 4096, 32, 0, piece_iov);
+        if (piece_niov <= 0) {
+            if (p->pending == 0) {
+                diskfs_write_same_fail(request, CHIMERA_VFS_EIO);
+                return;
+            }
+            p->status = CHIMERA_VFS_EIO;
+            break;
+        }
+
+        rel       = (off + written) - request->write_same.offset;
+        fill_done = 0;
+        for (i = 0; i < piece_niov; i++) {
+            diskfs_ws_tile(piece_iov[i].data, piece_iov[i].length,
+                           rel + fill_done, p->ws_tmpl,
+                           request->write_same.block_size);
+            fill_done += piece_iov[i].length;
+        }
+
+        p->niov += piece_niov;
+        p->pending++;
+        diskfs_pending_io_add(thread, 1);
+
+        evpl_block_write(evpl, thread->queue[dev_id], piece_iov, piece_niov,
+                         dev_off + written, !shared->unsafe_async,
+                         diskfs_write_same_io_cb, request);
+
+        written += piece;
+    }
+} /* diskfs_write_same_fill_step */
+
+static void
+diskfs_write_same_after_punch(struct chimera_vfs_request *request)
+{
+    struct diskfs_request_private *p      = request->plugin_data;
+    uint64_t                       offset = request->write_same.offset;
+    uint64_t                       total  = (uint64_t) request->write_same.block_size *
+        request->write_same.block_count;
+    const uint8_t                 *pat     = request->write_same.pattern;
+    uint32_t                       patlen  = request->write_same.pattern_len;
+    int                            is_zero = 1;
+    uint32_t                       i;
+
+    for (i = 0; i < patlen; i++) {
+        if (pat[i]) {
+            is_zero = 0;
+            break;
+        }
+    }
+
+    if (is_zero) {
+        /* The punched range already reads as zeros; just extend the size. */
+        diskfs_write_same_finalize(request);
+        return;
+    }
+
+    p->loop_off  = offset;
+    p->loop_pos  = offset + total;
+    p->alloc_cap = DISKFS_WS_CHUNK;
+    diskfs_write_same_fill_step(request);
+} /* diskfs_write_same_after_punch */
+
+static void
+diskfs_write_same_inode_cb(
+    struct diskfs_inode *inode,
+    int                  status,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+    struct diskfs_thread          *thread  = p->thread;
+    uint64_t                       offset  = request->write_same.offset;
+    uint32_t                       bs      = request->write_same.block_size;
+    uint64_t                       total, punch_end;
+    struct diskfs_bt_op           *op;
+
+    if (unlikely(status != CHIMERA_VFS_OK)) {
+        diskfs_op_fail(request, p->txn, status);
+        return;
+    }
+
+    p->inode_stash[0] = inode;
+
+    if (!S_ISREG(inode->mode)) {
+        diskfs_op_fail(request, p->txn,
+                       S_ISDIR(inode->mode) ? CHIMERA_VFS_EISDIR : CHIMERA_VFS_EINVAL);
+        return;
+    }
+
+    diskfs_map_attrs(thread, &request->write_same.r_pre_attr, inode);
+
+    total = (uint64_t) bs * request->write_same.block_count;
+    if (total == 0) {
+        request->write_same.r_count = 0;
+        request->write_same.r_sync  = CHIMERA_VFS_WRITE_FILESYNC;
+        diskfs_map_attrs(thread, &request->write_same.r_post_attr, inode);
+        diskfs_op_ok(request, p->txn);
+        return;
+    }
+
+    /* Build the one block-size pattern template (zero + pattern at reloff). */
+    p->ws_tmpl = malloc(bs);
+    chimera_diskfs_abort_if(p->ws_tmpl == NULL, "write_same template OOM");
+    memset(p->ws_tmpl, 0, bs);
+    if (request->write_same.pattern_len) {
+        memcpy(p->ws_tmpl + request->write_same.reloff_pattern,
+               request->write_same.pattern,
+               request->write_same.pattern_len);
+    }
+
+    p->ws_active = 1;
+
+    /* Punch existing extents in [offset, min(offset+total, size)); the dealloc
+     * loop hands back to diskfs_write_same_after_punch via ws_active. */
+    punch_end = offset + total;
+    if (punch_end > inode->size) {
+        punch_end = inode->size;
+    }
+
+    if (offset < punch_end) {
+        p->loop_off  = offset;
+        p->loop_left = punch_end;
+
+        op = diskfs_bt_op_alloc(thread);
+        if (diskfs_ext_floor_async(op, thread, inode, offset, p->rec_scratch,
+                                   sizeof(p->rec_scratch), diskfs_dealloc_first_cb,
+                                   request)) {
+            diskfs_dealloc_first_cb(op, op->result, request);
+        }
+        return;
+    }
+
+    diskfs_write_same_after_punch(request);
+} /* diskfs_write_same_inode_cb */
+
+void
+diskfs_write_same(
+    struct diskfs_thread       *thread,
+    struct diskfs_shared       *shared,
+    struct chimera_vfs_request *request,
+    void                       *private_data)
+{
+    struct diskfs_request_private *p = request->plugin_data;
+
+    (void) private_data;
+
+    if (unlikely(shared->block_layout || shared->scsi_layout)) {
+        request->status = CHIMERA_VFS_EINVAL;
+        request->complete(request);
+        return;
+    }
+
+    p->thread    = thread;
+    p->status    = 0;
+    p->pending   = 0;
+    p->niov      = 0;
+    p->ws_active = 0;
+    p->ws_tmpl   = NULL;
+    p->txn       = diskfs_txn_begin(thread, DISKFS_TXN_WRITE);
+
+    diskfs_inode_get_fh_async(thread, p->txn, p->fs,
+                              request->fh, request->fh_len,
+                              diskfs_write_same_inode_cb, request);
+} /* diskfs_write_same */
 
 
 /*

--- a/src/vfs/diskfs/diskfs_io.c
+++ b/src/vfs/diskfs/diskfs_io.c
@@ -4368,6 +4368,10 @@ diskfs_write_same_finalize(struct chimera_vfs_request *request)
     inode->mtime_nsec = now.tv_nsec;
     inode->ctime_sec  = now.tv_sec;
     inode->ctime_nsec = now.tv_nsec;
+    /* WRITE_SAME changes file data, so it advances the change attribute like
+     * WRITE does (diskfs_write_finish_map); a client validating its cache
+     * against change would otherwise never notice the write. */
+    inode->change++;
 
     request->write_same.r_count = total;
     request->write_same.r_sync  = CHIMERA_VFS_WRITE_FILESYNC;

--- a/src/vfs/diskfs/diskfs_mount.c
+++ b/src/vfs/diskfs/diskfs_mount.c
@@ -1471,6 +1471,48 @@ diskfs_bootstrap(struct diskfs_thread *thread)
         oin->block = NULL;
     }
 
+    /* Statically-reserved extent-refcount inodes (inums after the orphan
+     * shards): empty b+trees holding DISKFS_REC_REFCOUNT records that count how
+     * many inodes share a reflinked (CLONE) device range.  Created at format
+     * alongside root; persist and load from disk on remount. */
+    for (int s = 0; s < DISKFS_REFCOUNT_SHARDS; s++) {
+        uint64_t             rinum = DISKFS_REFCOUNT_INUM_BASE + s;
+        uint32_t             rdev;
+        uint64_t             roff = sm_inum_to_device_offset(shared->space_map,
+                                                             rinum, &rdev);
+        struct diskfs_inode *rin = diskfs_inode_struct_new(rinum);
+
+        rin->size           = 4096;
+        rin->space_used     = 4096;
+        rin->nlink          = 1;
+        rin->mode           = S_IFREG | 0600;
+        rin->atime_sec      = now.tv_sec;
+        rin->atime_nsec     = now.tv_nsec;
+        rin->mtime_sec      = now.tv_sec;
+        rin->mtime_nsec     = now.tv_nsec;
+        rin->ctime_sec      = now.tv_sec;
+        rin->ctime_nsec     = now.tv_nsec;
+        rin->btime_sec      = now.tv_sec;
+        rin->btime_nsec     = now.tv_nsec;
+        rin->dos_attributes = 0;
+        rin->parent_inum    = rinum;
+        rin->parent_gen     = rin->gen;
+
+        diskfs_inode_cache_insert(shared, rin);
+
+        rin->block = diskfs_block_claim(thread, rdev, roff, 1);
+        diskfs_bt_node_init(rin->block->iov.data, DISKFS_BT_ROOT_BASE,
+                            DISKFS_BT_ROOT_CAP, 0);
+        diskfs_inode_flush(rin);
+        rc = diskfs_mount_io_write(mio, rdev, rin->block->iov.data,
+                                   DISKFS_BLOCK_SIZE, roff);
+        chimera_diskfs_abort_if(rc != 0, "bootstrap refcount write failed");
+        diskfs_mount_io_flush(mio, rdev);
+        rin->block->state = DISKFS_BLOCK_CLEAN;
+        diskfs_block_unpin(thread, rin->block, DISKFS_BLOCK_CLEAN);
+        rin->block = NULL;
+    }
+
     /* Create 16-byte fsid buffer for root FH encoding (8-byte fsid + 8 bytes padding) */
     {
         uint8_t fsid_buf[CHIMERA_VFS_FSID_SIZE] = { 0 };

--- a/src/vfs/diskfs/diskfs_mount.c
+++ b/src/vfs/diskfs/diskfs_mount.c
@@ -1199,8 +1199,8 @@ diskfs_init(
          * stored root_gen is authoritative even after a crash.  The orphan
          * shards were created at first use on the previous instance. */
         if (mode != 0) {
-            uint64_t             oinum = DISKFS_ORPHAN_INUM_BASE +
-                DISKFS_ORPHAN_SHARDS - 1;
+            uint64_t             oinum = DISKFS_REFCOUNT_INUM_BASE +
+                DISKFS_REFCOUNT_SHARDS - 1;
             uint32_t             odev;
             uint64_t             ooff;
             struct diskfs_dinode odi;
@@ -1216,13 +1216,14 @@ diskfs_init(
                                  e->fsid, e->root_inum, e->root_gen);
             }
 
-            /* The orphan shards are created (all of them, in inum order) on
-             * the first dispatched op; probe the last one so a pool that was
-             * formatted but never used re-creates them instead of faulting
+            /* The pool-level bootstrap inodes (orphan shards then the
+             * extent-refcount shards, all of them in inum order) are created on
+             * the first dispatched op; probe the last one written so a pool that
+             * was formatted but never used re-creates them instead of faulting
              * garbage. */
             ooff = sm_inum_to_device_offset(shared->space_map, oinum, &odev);
             if (diskfs_mount_io_read(mio, odev, &odi, sizeof(odi), ooff) == 0 &&
-                odi.inum == oinum && odi.gen == DISKFS_ORPHAN_GEN) {
+                odi.inum == oinum && odi.gen == DISKFS_REFCOUNT_GEN) {
                 shared->orphans_created = 1;
             }
         }
@@ -1475,6 +1476,48 @@ diskfs_bootstrap_orphans(struct diskfs_thread *thread)
         oin->block->state = DISKFS_BLOCK_CLEAN;
         diskfs_block_unpin(thread, oin->block, DISKFS_BLOCK_CLEAN);
         oin->block = NULL;
+    }
+
+    /* Statically-reserved extent-refcount inodes (inums after the orphan
+     * shards): empty b+trees holding DISKFS_REC_REFCOUNT records that count how
+     * many inodes share a reflinked (CLONE) device range.  Created at format
+     * alongside root; persist and load from disk on remount. */
+    for (int s = 0; s < DISKFS_REFCOUNT_SHARDS; s++) {
+        uint64_t             rinum = DISKFS_REFCOUNT_INUM_BASE + s;
+        uint32_t             rdev;
+        uint64_t             roff = sm_inum_to_device_offset(shared->space_map,
+                                                             rinum, &rdev);
+        struct diskfs_inode *rin = diskfs_inode_struct_new(rinum);
+
+        rin->size           = 4096;
+        rin->space_used     = 4096;
+        rin->nlink          = 1;
+        rin->mode           = S_IFREG | 0600;
+        rin->atime_sec      = now.tv_sec;
+        rin->atime_nsec     = now.tv_nsec;
+        rin->mtime_sec      = now.tv_sec;
+        rin->mtime_nsec     = now.tv_nsec;
+        rin->ctime_sec      = now.tv_sec;
+        rin->ctime_nsec     = now.tv_nsec;
+        rin->btime_sec      = now.tv_sec;
+        rin->btime_nsec     = now.tv_nsec;
+        rin->dos_attributes = 0;
+        rin->parent_inum    = rinum;
+        rin->parent_gen     = rin->gen;
+
+        diskfs_inode_cache_insert(shared, rin);
+
+        rin->block = diskfs_block_claim(thread, rdev, roff, 1);
+        diskfs_bt_node_init(rin->block->iov.data, DISKFS_BT_ROOT_BASE,
+                            DISKFS_BT_ROOT_CAP, 0);
+        diskfs_inode_flush(rin);
+        rc = diskfs_mount_io_write(mio, rdev, rin->block->iov.data,
+                                   DISKFS_BLOCK_SIZE, roff);
+        chimera_diskfs_abort_if(rc != 0, "bootstrap refcount write failed");
+        diskfs_mount_io_flush(mio, rdev);
+        rin->block->state = DISKFS_BLOCK_CLEAN;
+        diskfs_block_unpin(thread, rin->block, DISKFS_BLOCK_CLEAN);
+        rin->block = NULL;
     }
 
     /* Freshly-created shards are empty: nothing to scan. */

--- a/src/vfs/diskfs/diskfs_reclaim.c
+++ b/src/vfs/diskfs/diskfs_reclaim.c
@@ -221,7 +221,8 @@ diskfs_drain_acquired_cb(
 static void
 diskfs_drain_begin(struct diskfs_drain *d)
 {
-    d->txn = diskfs_txn_begin(d->thread, DISKFS_TXN_WRITE);
+    d->txn      = diskfs_txn_begin(d->thread, DISKFS_TXN_WRITE);
+    d->rc_inode = NULL;     /* refcount inode is per-txn; re-acquire if needed */
     diskfs_inode_acquire(d->thread, d->txn, d->inum, d->gen,
                          DISKFS_INODE_LOCK_WRITE, diskfs_drain_acquired_cb, d);
 } /* diskfs_drain_begin */
@@ -335,6 +336,142 @@ diskfs_drain_removed_cb(
 } /* diskfs_drain_removed_cb */
 
 
+/* Remove the just-processed record (its backing already released). */
+static void
+diskfs_drain_remove_record(struct diskfs_drain *d)
+{
+    struct diskfs_bt_op *rop = diskfs_bt_op_alloc(d->thread);
+
+    if (diskfs_bt_remove_async(rop, d->thread, d->txn, d->inode, &d->found_key,
+                               diskfs_drain_removed_cb, d)) {
+        diskfs_drain_removed_cb(rop, rop->result, d);
+    }
+} /* diskfs_drain_remove_record */
+
+/* Reflink decrement for a unlinked file's shared extent (drain context).  The
+ * refcount inode is at d->rc_inode.  Frees the device range only at the last
+ * owner; otherwise the surviving owner keeps it. */
+static void
+diskfs_drain_dec_reinserted_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *priv)
+{
+    struct diskfs_drain *d = priv;
+
+    (void) result;
+    diskfs_bt_op_free(d->thread, op);
+    diskfs_drain_remove_record(d);
+} /* diskfs_drain_dec_reinserted_cb */
+
+static void
+diskfs_drain_dec_removed_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *priv)
+{
+    struct diskfs_drain *d = priv;
+
+    (void) result;
+    diskfs_bt_op_free(d->thread, op);
+
+    if (d->rc_newcount >= 2) {
+        struct diskfs_bt_key       key = diskfs_refcount_key(d->rc_devid, d->rc_devoff);
+        struct diskfs_refcount_rec rec = { .length = d->rc_length, .refcount = d->rc_newcount };
+        op = diskfs_bt_op_alloc(d->thread);
+        if (diskfs_bt_insert_async(op, d->thread, d->txn, d->rc_inode, &key, &rec,
+                                   sizeof(rec), diskfs_drain_dec_reinserted_cb, d)) {
+            diskfs_drain_dec_reinserted_cb(op, op->result, d);
+        }
+        return;
+    }
+    /* Dropped to a single owner: no record, keep the blocks for that owner. */
+    diskfs_drain_remove_record(d);
+} /* diskfs_drain_dec_removed_cb */
+
+static void
+diskfs_drain_dec_lookup_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *priv)
+{
+    struct diskfs_drain *d = priv;
+
+    if (result < 0) {
+        /* No record: this was the last owner, release the device range. */
+        diskfs_bt_op_free(d->thread, op);
+        diskfs_thread_free_space(d->thread, d->txn, d->rc_devid, d->rc_devoff,
+                                 SM_ALIGN_UP(d->rc_length));
+        diskfs_drain_remove_record(d);
+        return;
+    }
+
+    struct diskfs_refcount_rec *rec = (struct diskfs_refcount_rec *) d->rc_scratch;
+    d->rc_length   = rec->length;
+    d->rc_newcount = rec->refcount - 1;
+    diskfs_bt_op_free(d->thread, op);
+
+    struct diskfs_bt_key        key = diskfs_refcount_key(d->rc_devid, d->rc_devoff);
+    op = diskfs_bt_op_alloc(d->thread);
+    if (diskfs_bt_remove_async(op, d->thread, d->txn, d->rc_inode, &key,
+                               diskfs_drain_dec_removed_cb, d)) {
+        diskfs_drain_dec_removed_cb(op, op->result, d);
+    }
+} /* diskfs_drain_dec_lookup_cb */
+
+static void
+diskfs_drain_release_ext(
+    struct diskfs_drain *d);
+
+static void
+diskfs_drain_rc_acquired_cb(
+    struct diskfs_inode *inode,
+    int                  status,
+    void                *priv)
+{
+    struct diskfs_drain *d = priv;
+
+    chimera_diskfs_abort_if(status != CHIMERA_VFS_OK,
+                            "reclaim: refcount inode acquire failed (%d)", status);
+    d->rc_inode = inode;
+    diskfs_drain_release_ext(d);   /* retry now that the refcount inode is held */
+} /* diskfs_drain_rc_acquired_cb */
+
+/* Release the current extent record's backing: decrement if reflink-shared
+ * (acquiring the refcount inode lazily), else free outright.  Continues to the
+ * record removal. */
+static void
+diskfs_drain_release_ext(struct diskfs_drain *d)
+{
+    struct diskfs_extent_rec *e = (struct diskfs_extent_rec *) d->recbuf;
+
+    if (e->flags & DISKFS_EXT_SHARED) {
+        if (d->rc_inode == NULL) {
+            diskfs_inode_acquire(d->thread, d->txn, DISKFS_REFCOUNT_INUM_BASE,
+                                 DISKFS_REFCOUNT_GEN, DISKFS_INODE_LOCK_WRITE,
+                                 diskfs_drain_rc_acquired_cb, d);
+            return;
+        }
+        d->rc_devid  = e->device_id;
+        d->rc_devoff = e->device_offset;
+        d->rc_length = e->length;
+
+        struct diskfs_bt_key key = diskfs_refcount_key(e->device_id, e->device_offset);
+        struct diskfs_bt_op *op  = diskfs_bt_op_alloc(d->thread);
+        if (diskfs_bt_lookup_async(op, d->thread, d->rc_inode,
+                                   DISKFS_BT_OP_LOOKUP_EXACT, &key, &op->found_key,
+                                   d->rc_scratch, sizeof(struct diskfs_refcount_rec),
+                                   diskfs_drain_dec_lookup_cb, d)) {
+            diskfs_drain_dec_lookup_cb(op, op->result, d);
+        }
+        return;
+    }
+
+    diskfs_thread_free_space(d->thread, d->txn, e->device_id, e->device_offset,
+                             SM_ALIGN_UP(e->length));
+    diskfs_drain_remove_record(d);
+} /* diskfs_drain_release_ext */
+
 static void
 diskfs_drain_looked_cb(
     struct diskfs_bt_op *op,
@@ -342,7 +479,6 @@ diskfs_drain_looked_cb(
     void                *priv)
 {
     struct diskfs_drain *d = priv;
-    struct diskfs_bt_op *rop;
 
     if (result < 0) {
         /* Tree empty: remove the durable orphan entry, then retire the inode in
@@ -355,21 +491,16 @@ diskfs_drain_looked_cb(
         return;
     }
 
-    /* Free a file extent's backing data before removing the record.  The
-     * remove reclaims any emptied b+tree node blocks (generic, any entry). */
+    /* Free a file extent's backing before removing the record (a reflink-shared
+     * extent decrements its refcount instead).  The remove reclaims any emptied
+     * b+tree node blocks (generic, any entry). */
     if (d->found_key.type == DISKFS_REC_EXTENT) {
-        struct diskfs_extent_rec *e = (struct diskfs_extent_rec *) d->recbuf;
-
-        diskfs_thread_free_space(d->thread, d->txn, e->device_id, e->device_offset,
-                                 SM_ALIGN_UP(e->length));
+        diskfs_bt_op_free(d->thread, op);
+        diskfs_drain_release_ext(d);
+        return;
     }
     diskfs_bt_op_free(d->thread, op);
-
-    rop = diskfs_bt_op_alloc(d->thread);
-    if (diskfs_bt_remove_async(rop, d->thread, d->txn, d->inode, &d->found_key,
-                               diskfs_drain_removed_cb, d)) {
-        diskfs_drain_removed_cb(rop, rop->result, d);
-    }
+    diskfs_drain_remove_record(d);
 } /* diskfs_drain_looked_cb */
 
 

--- a/src/vfs/diskfs/diskfs_reclaim.c
+++ b/src/vfs/diskfs/diskfs_reclaim.c
@@ -223,7 +223,8 @@ diskfs_drain_acquired_cb(
 static void
 diskfs_drain_begin(struct diskfs_drain *d)
 {
-    d->txn = diskfs_txn_begin(d->thread, DISKFS_TXN_WRITE);
+    d->txn      = diskfs_txn_begin(d->thread, DISKFS_TXN_WRITE);
+    d->rc_inode = NULL;     /* refcount inode is per-txn; re-acquire if needed */
     /* Orphaned inodes are pool-level from here on (their filesystem may
      * already be removed); no fs stamp. */
     diskfs_inode_acquire(d->thread, d->txn, NULL, d->inum, d->gen,
@@ -408,6 +409,137 @@ diskfs_drain_child_cb(
 } /* diskfs_drain_child_cb */
 
 
+/* Reflink decrement for an unlinked file's shared extent (drain context).  The
+ * refcount inode is at d->rc_inode.  Frees the device range only at the last
+ * owner; otherwise the surviving owner keeps it. */
+static void
+diskfs_drain_dec_reinserted_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *priv)
+{
+    struct diskfs_drain *d = priv;
+
+    (void) result;
+    diskfs_bt_op_free(d->thread, op);
+    diskfs_drain_child_remove(d);
+} /* diskfs_drain_dec_reinserted_cb */
+
+static void
+diskfs_drain_dec_removed_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *priv)
+{
+    struct diskfs_drain *d = priv;
+
+    (void) result;
+    diskfs_bt_op_free(d->thread, op);
+
+    if (d->rc_newcount >= 2) {
+        struct diskfs_bt_key       key = diskfs_refcount_key(d->rc_devid, d->rc_devoff);
+        struct diskfs_refcount_rec rec = { .length = d->rc_length, .refcount = d->rc_newcount };
+        op = diskfs_bt_op_alloc(d->thread);
+        if (diskfs_bt_insert_async(op, d->thread, d->txn, d->rc_inode, &key, &rec,
+                                   sizeof(rec), diskfs_drain_dec_reinserted_cb, d)) {
+            diskfs_drain_dec_reinserted_cb(op, op->result, d);
+        }
+        return;
+    }
+    /* Dropped to a single owner: no record, keep the blocks for that owner. */
+    diskfs_drain_child_remove(d);
+} /* diskfs_drain_dec_removed_cb */
+
+static void
+diskfs_drain_dec_lookup_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *priv)
+{
+    struct diskfs_drain        *d = priv;
+    struct diskfs_refcount_rec *rec;
+    struct diskfs_bt_key        key;
+
+    if (result < 0) {
+        /* No record: this was the last owner, release the device range. */
+        diskfs_bt_op_free(d->thread, op);
+        diskfs_thread_free_space(d->thread, d->txn, d->rc_devid, d->rc_devoff,
+                                 SM_ALIGN_UP(d->rc_length));
+        diskfs_drain_child_remove(d);
+        return;
+    }
+
+    rec            = (struct diskfs_refcount_rec *) d->rc_scratch;
+    d->rc_length   = rec->length;
+    d->rc_newcount = rec->refcount - 1;
+    diskfs_bt_op_free(d->thread, op);
+
+    key = diskfs_refcount_key(d->rc_devid, d->rc_devoff);
+    op  = diskfs_bt_op_alloc(d->thread);
+    if (diskfs_bt_remove_async(op, d->thread, d->txn, d->rc_inode, &key,
+                               diskfs_drain_dec_removed_cb, d)) {
+        diskfs_drain_dec_removed_cb(op, op->result, d);
+    }
+} /* diskfs_drain_dec_lookup_cb */
+
+static void
+diskfs_drain_release_ext(
+    struct diskfs_drain *d);
+
+static void
+diskfs_drain_rc_acquired_cb(
+    struct diskfs_inode *inode,
+    int                  status,
+    void                *priv)
+{
+    struct diskfs_drain *d = priv;
+
+    chimera_diskfs_abort_if(status != CHIMERA_VFS_OK,
+                            "reclaim: refcount inode acquire failed (%d)", status);
+    d->rc_inode = inode;
+    diskfs_drain_release_ext(d);   /* retry now that the refcount inode is held */
+} /* diskfs_drain_rc_acquired_cb */
+
+/* Release the current extent record's backing: decrement if reflink-shared
+ * (acquiring the refcount inode lazily), else free outright.  Continues to the
+ * record removal. */
+static void
+diskfs_drain_release_ext(struct diskfs_drain *d)
+{
+    struct diskfs_extent_rec *e = (struct diskfs_extent_rec *) d->recbuf;
+    struct diskfs_bt_key      key;
+    struct diskfs_bt_op      *op;
+
+    if (e->flags & DISKFS_EXT_SHARED) {
+        if (d->rc_inode == NULL) {
+            /* Pool-level bootstrap inode (no fs stamp), acquired last: a leaf
+             * in the lock order, so it cannot deadlock the drained inode. */
+            diskfs_inode_acquire(d->thread, d->txn, NULL, DISKFS_REFCOUNT_INUM_BASE,
+                                 DISKFS_REFCOUNT_GEN, DISKFS_INODE_LOCK_WRITE,
+                                 diskfs_drain_rc_acquired_cb, d);
+            return;
+        }
+        d->rc_devid  = e->device_id;
+        d->rc_devoff = e->device_offset;
+        d->rc_length = e->length;
+
+        key = diskfs_refcount_key(e->device_id, e->device_offset);
+        op  = diskfs_bt_op_alloc(d->thread);
+        if (diskfs_bt_lookup_async(op, d->thread, d->rc_inode,
+                                   DISKFS_BT_OP_LOOKUP_EXACT, &key, &op->found_key,
+                                   d->rc_scratch, sizeof(struct diskfs_refcount_rec),
+                                   diskfs_drain_dec_lookup_cb, d)) {
+            diskfs_drain_dec_lookup_cb(op, op->result, d);
+        }
+        return;
+    }
+
+    diskfs_thread_free_space(d->thread, d->txn, e->device_id, e->device_offset,
+                             SM_ALIGN_UP(e->length));
+    diskfs_drain_child_remove(d);
+} /* diskfs_drain_release_ext */
+
+
 static void
 diskfs_drain_looked_cb(
     struct diskfs_bt_op *op,
@@ -415,7 +547,6 @@ diskfs_drain_looked_cb(
     void                *priv)
 {
     struct diskfs_drain *d = priv;
-    struct diskfs_bt_op *rop;
 
     if (result < 0) {
         /* Tree empty: remove the durable orphan entry, then retire the inode in
@@ -442,21 +573,16 @@ diskfs_drain_looked_cb(
         return;
     }
 
-    /* Free a file extent's backing data before removing the record.  The
-     * remove reclaims any emptied b+tree node blocks (generic, any entry). */
+    /* Free a file extent's backing before removing the record (a reflink-shared
+     * extent decrements its refcount instead).  The remove reclaims any emptied
+     * b+tree node blocks (generic, any entry). */
     if (d->found_key.type == DISKFS_REC_EXTENT) {
-        struct diskfs_extent_rec *e = (struct diskfs_extent_rec *) d->recbuf;
-
-        diskfs_thread_free_space(d->thread, d->txn, e->device_id, e->device_offset,
-                                 SM_ALIGN_UP(e->length));
+        diskfs_bt_op_free(d->thread, op);
+        diskfs_drain_release_ext(d);
+        return;
     }
     diskfs_bt_op_free(d->thread, op);
-
-    rop = diskfs_bt_op_alloc(d->thread);
-    if (diskfs_bt_remove_async(rop, d->thread, d->txn, d->inode, &d->found_key,
-                               diskfs_drain_removed_cb, d)) {
-        diskfs_drain_removed_cb(rop, rop->result, d);
-    }
+    diskfs_drain_child_remove(d);
 } /* diskfs_drain_looked_cb */
 
 

--- a/src/vfs/diskfs/space_map.c
+++ b/src/vfs/diskfs/space_map.c
@@ -551,11 +551,12 @@ space_map_create(
                 /* AG 0 of device 0 also hosts the superblock, the intent log
                  * and the relocated remote-AG-log region, all *before* this
                  * AG's own log.  Then the bootstrap inode blocks after the log
-                 * (block_idx 1=reserved, 2=root inode, 3..=orphan-list
-                 * shards). */
+                 * (block_idx 1=reserved, 2=root inode, 3..=orphan-list shards,
+                 * then the extent-refcount tree(s)). */
                 uint64_t pre_log = SM_SUPERBLOCK_SIZE + sm->intent_log_size +
                     sm->remote_log_size;
-                uint64_t post_log = (2 + SM_BOOTSTRAP_ORPHAN_SLOTS) * SM_BLOCK_SIZE;
+                uint64_t post_log = (2 + SM_BOOTSTRAP_ORPHAN_SLOTS +
+                                     SM_BOOTSTRAP_REFCOUNT_SLOTS) * SM_BLOCK_SIZE;
 
                 log_offset = base + pre_log;
 

--- a/src/vfs/diskfs/space_map.h
+++ b/src/vfs/diskfs/space_map.h
@@ -23,29 +23,37 @@
  * intent log will replace; this is where on-disk durability hooks in.
  */
 
-#define SM_BLOCK_SHIFT            12
-#define SM_BLOCK_SIZE             (1ULL << SM_BLOCK_SHIFT)
-#define SM_BLOCK_MASK             (SM_BLOCK_SIZE - 1)
+#define SM_BLOCK_SHIFT              12
+#define SM_BLOCK_SIZE               (1ULL << SM_BLOCK_SHIFT)
+#define SM_BLOCK_MASK               (SM_BLOCK_SIZE - 1)
 
-#define SM_AG_SIZE_LOG2           31                        /* 2 GiB */
-#define SM_AG_SIZE                (1ULL << SM_AG_SIZE_LOG2)
-#define SM_AG_OFFSET_MASK         (SM_AG_SIZE - 1)
+#define SM_AG_SIZE_LOG2             31                      /* 2 GiB */
+#define SM_AG_SIZE                  (1ULL << SM_AG_SIZE_LOG2)
+#define SM_AG_OFFSET_MASK           (SM_AG_SIZE - 1)
 
-#define SM_SUPERBLOCK_OFFSET      0
-#define SM_SUPERBLOCK_SIZE        4096
-#define SM_SUPERBLOCK_MAGIC       0x4D5346534B534944ULL     /* "DISKSFSM" */
-#define SM_FORMAT_VERSION         3
+#define SM_SUPERBLOCK_OFFSET        0
+#define SM_SUPERBLOCK_SIZE          4096
+#define SM_SUPERBLOCK_MAGIC         0x4D5346534B534944ULL   /* "DISKSFSM" */
+/*
+ * v3 added the upstream reservation-allocator / checkpoint / FSID layout; v4
+ * additionally carves SM_BOOTSTRAP_REFCOUNT_SLOTS extent-refcount inode(s) into
+ * the bootstrap region for reflink/CLONE copy-on-write share counts.
+ */
+#define SM_FORMAT_VERSION           4
 
 /*
  * Bootstrap inode blocks carved after AG 0's log on device 0 at format time:
  * block_idx 1 is reserved (inum 1 invalid by convention), 2 is the root
- * inode, and the next SM_BOOTSTRAP_ORPHAN_SLOTS blocks (inums 3..) are the
+ * inode, the next SM_BOOTSTRAP_ORPHAN_SLOTS blocks (inums 3..) are the
  * sharded orphan-list inodes (diskfs spreads deleted-inode records across
- * them so unlinks don't serialize on one inode's write lock).
+ * them so unlinks don't serialize on one inode's write lock), and the final
+ * SM_BOOTSTRAP_REFCOUNT_SLOTS block(s) host the extent-refcount tree(s) used by
+ * reflink/CLONE (copy-on-write share counts keyed by device offset).
  */
-#define SM_BOOTSTRAP_ORPHAN_SLOTS 16
+#define SM_BOOTSTRAP_ORPHAN_SLOTS   16
+#define SM_BOOTSTRAP_REFCOUNT_SLOTS 1
 
-#define SM_RESERVATION_MIN        (1ULL << 20)              /* 1 MiB */
+#define SM_RESERVATION_MIN          (1ULL << 20)            /* 1 MiB */
 
 #define SM_ALIGN_UP(x) (((x) + SM_BLOCK_MASK) & ~SM_BLOCK_MASK)
 
@@ -58,7 +66,7 @@
  * size index lets allocation find an adequate free extent without the old
  * O(N) first-fit scan over the offset-ordered tree.
  */
-#define SM_SIZE_CLASSES           22
+#define SM_SIZE_CLASSES             22
 
 /*
  * Inode-number encoding.  A 64-bit inum is a (disk, ag, block_idx) tuple
@@ -73,16 +81,16 @@
  * 0 we reserve block_idx == 1 at format time so the very first allocation
  * lands at block_idx == 2 (= inum 2 = the root inode).
  */
-#define SM_INUM_INDEX_BITS        32
-#define SM_INUM_AG_BITS           24
-#define SM_INUM_DISK_BITS         8
+#define SM_INUM_INDEX_BITS          32
+#define SM_INUM_AG_BITS             24
+#define SM_INUM_DISK_BITS           8
 
-#define SM_INUM_INDEX_MASK        ((1ULL << SM_INUM_INDEX_BITS) - 1)
-#define SM_INUM_AG_MASK           ((1ULL << SM_INUM_AG_BITS)    - 1)
-#define SM_INUM_DISK_MASK         ((1ULL << SM_INUM_DISK_BITS)  - 1)
+#define SM_INUM_INDEX_MASK          ((1ULL << SM_INUM_INDEX_BITS) - 1)
+#define SM_INUM_AG_MASK             ((1ULL << SM_INUM_AG_BITS)    - 1)
+#define SM_INUM_DISK_MASK           ((1ULL << SM_INUM_DISK_BITS)  - 1)
 
-#define SM_INUM_AG_SHIFT          SM_INUM_INDEX_BITS
-#define SM_INUM_DISK_SHIFT        (SM_INUM_INDEX_BITS + SM_INUM_AG_BITS)
+#define SM_INUM_AG_SHIFT            SM_INUM_INDEX_BITS
+#define SM_INUM_DISK_SHIFT          (SM_INUM_INDEX_BITS + SM_INUM_AG_BITS)
 
 /*
  * Each AG carves a fixed prefix off the front of its data range for its
@@ -91,14 +99,14 @@
  * fragmentation of a 1 GiB AG with 4 KiB blocks (~2 MiB per snapshot) with
  * comfortable headroom.
  */
-#define SM_AG_LOG_SLOT_SIZE       (4ULL << 20) /* 4 MiB */
-#define SM_AG_LOG_SLOT_COUNT      2
-#define SM_AG_LOG_SIZE            (SM_AG_LOG_SLOT_SIZE * SM_AG_LOG_SLOT_COUNT)
+#define SM_AG_LOG_SLOT_SIZE         (4ULL << 20) /* 4 MiB */
+#define SM_AG_LOG_SLOT_COUNT        2
+#define SM_AG_LOG_SIZE              (SM_AG_LOG_SLOT_SIZE * SM_AG_LOG_SLOT_COUNT)
 
 /* Free headroom (bytes) left in a slot's delta region when runtime
  * condensation is triggered; new journaling parks behind the condense, so
  * this is margin against the hard-full abort, not a budget that fills. */
-#define SM_AG_LOG_CONDENSE_MARGIN (64ULL << 10)
+#define SM_AG_LOG_CONDENSE_MARGIN   (64ULL << 10)
 
 /*
  * On-disk per-AG allocation log.  Each slot begins with this header, followed
@@ -112,10 +120,10 @@
  * no separate checksum -- a torn condensation simply leaves the older slot
  * live.
  */
-#define SM_AG_LOG_MAGIC           0x474F4C47414B5344ULL /* "DSKAGLOG" */
+#define SM_AG_LOG_MAGIC             0x474F4C47414B5344ULL /* "DSKAGLOG" */
 
-#define SM_AG_LOG_OP_ALLOC        0u /* [offset,len) was handed out: remove from free */
-#define SM_AG_LOG_OP_FREE         1u /* [offset,len) was returned:   add to free */
+#define SM_AG_LOG_OP_ALLOC          0u /* [offset,len) was handed out: remove from free */
+#define SM_AG_LOG_OP_FREE           1u /* [offset,len) was returned:   add to free */
 
 struct sm_ag_log_header {
     uint64_t magic;

--- a/src/vfs/diskfs/space_map.h
+++ b/src/vfs/diskfs/space_map.h
@@ -23,31 +23,41 @@
  * intent log will replace; this is where on-disk durability hooks in.
  */
 
-#define SM_BLOCK_SHIFT            12
-#define SM_BLOCK_SIZE             (1ULL << SM_BLOCK_SHIFT)
-#define SM_BLOCK_MASK             (SM_BLOCK_SIZE - 1)
+#define SM_BLOCK_SHIFT              12
+#define SM_BLOCK_SIZE               (1ULL << SM_BLOCK_SHIFT)
+#define SM_BLOCK_MASK               (SM_BLOCK_SIZE - 1)
 
-#define SM_AG_SIZE_LOG2           31                        /* 2 GiB */
-#define SM_AG_SIZE                (1ULL << SM_AG_SIZE_LOG2)
-#define SM_AG_OFFSET_MASK         (SM_AG_SIZE - 1)
+#define SM_AG_SIZE_LOG2             31                      /* 2 GiB */
+#define SM_AG_SIZE                  (1ULL << SM_AG_SIZE_LOG2)
+#define SM_AG_OFFSET_MASK           (SM_AG_SIZE - 1)
 
-#define SM_SUPERBLOCK_OFFSET      0
-#define SM_SUPERBLOCK_SIZE        4096
-#define SM_SUPERBLOCK_MAGIC       0x4D5346534B534944ULL     /* "DISKSFSM" */
-#define SM_FORMAT_VERSION         4
+#define SM_SUPERBLOCK_OFFSET        0
+#define SM_SUPERBLOCK_SIZE          4096
+#define SM_SUPERBLOCK_MAGIC         0x4D5346534B534944ULL   /* "DISKSFSM" */
+/*
+ * v3 added the reservation-allocator / checkpoint / FSID layout; v4 moved
+ * filesystem roots into the superblock fs_table (named filesystems); v5
+ * additionally carves SM_BOOTSTRAP_REFCOUNT_SLOTS extent-refcount inode(s) into
+ * the bootstrap region for reflink/CLONE copy-on-write share counts.
+ */
+#define SM_FORMAT_VERSION           5
 
 /*
  * Bootstrap inode blocks carved after AG 0's log on device 0 at format time:
  * block_idx 1 and 2 are reserved (inum 1 invalid by convention; inum 2 was
  * the pre-named-filesystem static root, kept reserved for layout stability),
- * and the next SM_BOOTSTRAP_ORPHAN_SLOTS blocks (inums 3..) are the sharded
+ * the next SM_BOOTSTRAP_ORPHAN_SLOTS blocks (inums 3..) are the sharded
  * orphan-list inodes (diskfs spreads deleted-inode records across them so
- * unlinks don't serialize on one inode's write lock).  Filesystem roots are
- * ordinary allocated inodes recorded in the superblock fs_table.
+ * unlinks don't serialize on one inode's write lock), and the final
+ * SM_BOOTSTRAP_REFCOUNT_SLOTS block(s) host the extent-refcount tree(s) used by
+ * reflink/CLONE (copy-on-write share counts keyed by device offset).
+ * Filesystem roots are ordinary allocated inodes recorded in the superblock
+ * fs_table.
  */
-#define SM_BOOTSTRAP_ORPHAN_SLOTS 16
+#define SM_BOOTSTRAP_ORPHAN_SLOTS   16
+#define SM_BOOTSTRAP_REFCOUNT_SLOTS 1
 
-#define SM_RESERVATION_MIN        (1ULL << 20)              /* 1 MiB */
+#define SM_RESERVATION_MIN          (1ULL << 20)            /* 1 MiB */
 
 #define SM_ALIGN_UP(x) (((x) + SM_BLOCK_MASK) & ~SM_BLOCK_MASK)
 
@@ -60,7 +70,7 @@
  * size index lets allocation find an adequate free extent without the old
  * O(N) first-fit scan over the offset-ordered tree.
  */
-#define SM_SIZE_CLASSES           22
+#define SM_SIZE_CLASSES             22
 
 /*
  * Inode-number encoding.  A 64-bit inum is a (disk, ag, block_idx) tuple
@@ -75,16 +85,16 @@
  * 0 we reserve block_idx == 1 at format time so the very first allocation
  * lands at block_idx == 2 (= inum 2 = the root inode).
  */
-#define SM_INUM_INDEX_BITS        32
-#define SM_INUM_AG_BITS           24
-#define SM_INUM_DISK_BITS         8
+#define SM_INUM_INDEX_BITS          32
+#define SM_INUM_AG_BITS             24
+#define SM_INUM_DISK_BITS           8
 
-#define SM_INUM_INDEX_MASK        ((1ULL << SM_INUM_INDEX_BITS) - 1)
-#define SM_INUM_AG_MASK           ((1ULL << SM_INUM_AG_BITS)    - 1)
-#define SM_INUM_DISK_MASK         ((1ULL << SM_INUM_DISK_BITS)  - 1)
+#define SM_INUM_INDEX_MASK          ((1ULL << SM_INUM_INDEX_BITS) - 1)
+#define SM_INUM_AG_MASK             ((1ULL << SM_INUM_AG_BITS)    - 1)
+#define SM_INUM_DISK_MASK           ((1ULL << SM_INUM_DISK_BITS)  - 1)
 
-#define SM_INUM_AG_SHIFT          SM_INUM_INDEX_BITS
-#define SM_INUM_DISK_SHIFT        (SM_INUM_INDEX_BITS + SM_INUM_AG_BITS)
+#define SM_INUM_AG_SHIFT            SM_INUM_INDEX_BITS
+#define SM_INUM_DISK_SHIFT          (SM_INUM_INDEX_BITS + SM_INUM_AG_BITS)
 
 /*
  * Each AG carves a fixed prefix off the front of its data range for its
@@ -93,14 +103,14 @@
  * fragmentation of a 1 GiB AG with 4 KiB blocks (~2 MiB per snapshot) with
  * comfortable headroom.
  */
-#define SM_AG_LOG_SLOT_SIZE       (4ULL << 20) /* 4 MiB */
-#define SM_AG_LOG_SLOT_COUNT      2
-#define SM_AG_LOG_SIZE            (SM_AG_LOG_SLOT_SIZE * SM_AG_LOG_SLOT_COUNT)
+#define SM_AG_LOG_SLOT_SIZE         (4ULL << 20) /* 4 MiB */
+#define SM_AG_LOG_SLOT_COUNT        2
+#define SM_AG_LOG_SIZE              (SM_AG_LOG_SLOT_SIZE * SM_AG_LOG_SLOT_COUNT)
 
 /* Free headroom (bytes) left in a slot's delta region when runtime
  * condensation is triggered; new journaling parks behind the condense, so
  * this is margin against the hard-full abort, not a budget that fills. */
-#define SM_AG_LOG_CONDENSE_MARGIN (64ULL << 10)
+#define SM_AG_LOG_CONDENSE_MARGIN   (64ULL << 10)
 
 /*
  * On-disk per-AG allocation log.  Each slot begins with this header, followed
@@ -114,10 +124,10 @@
  * no separate checksum -- a torn condensation simply leaves the older slot
  * live.
  */
-#define SM_AG_LOG_MAGIC           0x474F4C47414B5344ULL /* "DSKAGLOG" */
+#define SM_AG_LOG_MAGIC             0x474F4C47414B5344ULL /* "DSKAGLOG" */
 
-#define SM_AG_LOG_OP_ALLOC        0u /* [offset,len) was handed out: remove from free */
-#define SM_AG_LOG_OP_FREE         1u /* [offset,len) was returned:   add to free */
+#define SM_AG_LOG_OP_ALLOC          0u /* [offset,len) was handed out: remove from free */
+#define SM_AG_LOG_OP_FREE           1u /* [offset,len) was returned:   add to free */
 
 struct sm_ag_log_header {
     uint64_t magic;

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -4510,6 +4510,317 @@ memfs_seek(
     }
 } /* memfs_seek */
 
+/*
+ * READ_PLUS: classify the leading byte-run at request->read_plus.offset as a
+ * single DATA or HOLE segment from the sparse block map (NULL block = hole).
+ * Returns only the classification + run length; the NFS server fetches DATA
+ * bytes via a normal read.  One segment per call is sufficient (the client
+ * re-issues from the last byte returned).
+ */
+static void
+memfs_read_plus(
+    struct memfs_thread        *thread,
+    struct memfs_shared        *shared,
+    struct chimera_vfs_request *request,
+    void                       *private_data)
+{
+    struct memfs_inode        *inode;
+    struct memfs_named_stream *stream;
+    struct memfs_fork         *fork;
+    uint64_t                   fork_size;
+    uint64_t                   offset = request->read_plus.offset;
+    uint64_t                   length = request->read_plus.length;
+    uint64_t                   first_block, bi, natural_end, seg_end;
+    int                        is_data;
+
+    (void) thread;
+
+    inode = memfs_resolve_io(shared, request->read_plus.handle,
+                             request->fh, request->fh_len, &stream);
+
+    if (unlikely(!inode)) {
+        request->status = CHIMERA_VFS_ENOENT;
+        request->complete(request);
+        return;
+    }
+
+    fork      = stream ? &stream->fork : &inode->file;
+    fork_size = stream ? stream->size : inode->size;
+
+    /* At or past EOF: no segment, just report eof (the NFS server returns
+     * NFS4_OK with an empty content array). */
+    if (offset >= fork_size || length == 0) {
+        pthread_mutex_unlock(&inode->lock);
+        request->status              = CHIMERA_VFS_OK;
+        request->read_plus.r_is_data = 0;
+        request->read_plus.r_length  = 0;
+        request->read_plus.r_eof     = (offset >= fork_size);
+        request->complete(request);
+        return;
+    }
+
+    const uint32_t block_shift = shared->block_shift;
+
+    first_block = offset >> block_shift;
+    is_data     = (fork->blocks && first_block < fork->num_blocks &&
+                   fork->blocks[first_block]) ? 1 : 0;
+
+    /* Walk forward to the run boundary (where block presence flips). */
+    bi = first_block;
+    if (is_data) {
+        while (bi < fork->num_blocks && fork->blocks[bi]) {
+            bi++;
+        }
+        natural_end = bi << block_shift;
+    } else {
+        while (bi < fork->num_blocks &&
+               !(fork->blocks && fork->blocks[bi])) {
+            bi++;
+        }
+        natural_end = (bi >= fork->num_blocks) ? fork_size : (bi << block_shift);
+    }
+
+    if (natural_end > fork_size) {
+        natural_end = fork_size;
+    }
+
+    seg_end = natural_end;
+    if (seg_end > offset + length) {
+        seg_end = offset + length;
+    }
+
+    pthread_mutex_unlock(&inode->lock);
+
+    request->status              = CHIMERA_VFS_OK;
+    request->read_plus.r_is_data = is_data;
+    request->read_plus.r_length  = seg_end - offset;
+    request->read_plus.r_eof     = (seg_end >= fork_size);
+
+    request->complete(request);
+} /* memfs_read_plus */
+
+/* Tile `tmpl` (period `period` bytes) into dst[0..len), starting at template
+ * phase (rel_off % period). */
+static inline void
+memfs_tile_pattern(
+    uint8_t       *dst,
+    uint64_t       len,
+    uint64_t       rel_off,
+    const uint8_t *tmpl,
+    uint32_t       period)
+{
+    uint32_t phase = rel_off % period;
+    uint64_t done  = 0;
+
+    while (done < len) {
+        uint32_t chunk = period - phase;
+        if (chunk > len - done) {
+            chunk = len - done;
+        }
+        memcpy(dst + done, tmpl + phase, chunk);
+        done += chunk;
+        phase = 0;
+    }
+} /* memfs_tile_pattern */
+
+/*
+ * WRITE_SAME: materialize block_count Application Data Blocks of block_size
+ * bytes from offset, each block zero-filled with `pattern` placed at
+ * reloff_pattern.  Implemented by tiling a single ADB-block template across the
+ * affected memfs blocks (memfs block size is independent of the ADB block size).
+ */
+static void
+memfs_write_same(
+    struct memfs_thread        *thread,
+    struct memfs_shared        *shared,
+    struct chimera_vfs_request *request,
+    void                       *private_data)
+{
+    struct evpl               *evpl = thread->evpl;
+    struct memfs_inode        *inode;
+    struct memfs_named_stream *stream;
+    struct memfs_fork         *fork;
+    uint64_t                  *p_size, *p_space_used;
+    struct memfs_block        *block, *old_block;
+    uint64_t                   offset    = request->write_same.offset;
+    uint32_t                   adb_bsize = request->write_same.block_size;
+    uint64_t                   total;
+    uint64_t                   first_block, last_block, bi;
+    uint32_t                   block_offset, block_len;
+    uint64_t                   left, cur_off;
+    uint8_t                   *tmpl;
+    struct timespec            now;
+
+    total = adb_bsize * request->write_same.block_count;
+
+    if (total == 0) {
+        /* Nothing to write (block_count or block_size is 0). */
+        inode = memfs_resolve_io(shared, request->write_same.handle,
+                                 request->fh, request->fh_len, &stream);
+        if (unlikely(!inode)) {
+            request->status = CHIMERA_VFS_ENOENT;
+            request->complete(request);
+            return;
+        }
+        memfs_map_attrs_fork(shared, &request->write_same.r_pre_attr, inode, stream, request->fh);
+        memfs_map_attrs_fork(shared, &request->write_same.r_post_attr, inode, stream, request->fh);
+        pthread_mutex_unlock(&inode->lock);
+        request->status             = CHIMERA_VFS_OK;
+        request->write_same.r_count = 0;
+        request->write_same.r_sync  = CHIMERA_VFS_WRITE_FILESYNC;
+        request->complete(request);
+        return;
+    }
+
+    chimera_vfs_realtime(&now);
+
+    const uint32_t block_size  = shared->block_size;
+    const uint32_t block_shift = shared->block_shift;
+    const uint32_t block_mask  = shared->block_mask;
+
+    /* Build one ADB-block template: zero-filled with the pattern at
+     * reloff_pattern.  The NFS server has already validated that
+     * reloff_pattern + pattern_len <= adb_bsize. */
+    tmpl = malloc(adb_bsize);
+    chimera_memfs_abort_if(tmpl == NULL, "write_same template OOM");
+    memset(tmpl, 0, adb_bsize);
+    if (request->write_same.pattern_len) {
+        memcpy(tmpl + request->write_same.reloff_pattern,
+               request->write_same.pattern,
+               request->write_same.pattern_len);
+    }
+
+    inode = memfs_resolve_io(shared, request->write_same.handle,
+                             request->fh, request->fh_len, &stream);
+
+    if (unlikely(!inode)) {
+        free(tmpl);
+        request->status = CHIMERA_VFS_ENOENT;
+        request->complete(request);
+        return;
+    }
+
+    if (!S_ISREG(inode->mode)) {
+        request->status = S_ISDIR(inode->mode) ?
+            CHIMERA_VFS_EISDIR : CHIMERA_VFS_EINVAL;
+        pthread_mutex_unlock(&inode->lock);
+        free(tmpl);
+        request->complete(request);
+        return;
+    }
+
+    fork         = stream ? &stream->fork : &inode->file;
+    p_size       = stream ? &stream->size : &inode->size;
+    p_space_used = stream ? &stream->space_used : &inode->space_used;
+
+    memfs_map_attrs_fork(shared, &request->write_same.r_pre_attr, inode, stream, request->fh);
+
+    first_block  = offset >> block_shift;
+    block_offset = offset & block_mask;
+    last_block   = (offset + total - 1) >> block_shift;
+    left         = total;
+    cur_off      = offset;
+
+    if (fork->max_blocks <= last_block || !fork->blocks) {
+        struct memfs_block **new_blocks;
+        unsigned int         new_max_blocks = 1024;
+
+        while (new_max_blocks <= last_block) {
+            new_max_blocks <<= 1;
+        }
+
+        new_blocks = calloc(new_max_blocks, sizeof(struct memfs_block *));
+
+        if (!new_blocks) {
+            pthread_mutex_unlock(&inode->lock);
+            free(tmpl);
+            request->status = CHIMERA_VFS_ENOSPC;
+            request->complete(request);
+            return;
+        }
+
+        if (fork->blocks) {
+            memcpy(new_blocks, fork->blocks,
+                   fork->num_blocks * sizeof(struct memfs_block *));
+            free(fork->blocks);
+        }
+
+        fork->blocks     = new_blocks;
+        fork->max_blocks = new_max_blocks;
+    }
+
+    if (last_block + 1 > fork->num_blocks) {
+        fork->num_blocks = last_block + 1;
+    }
+
+    for (bi = first_block; bi <= last_block; bi++) {
+        block_len = block_size - block_offset;
+        if (left < block_len) {
+            block_len = left;
+        }
+
+        old_block = fork->blocks ? fork->blocks[bi] : NULL;
+
+        block = memfs_block_alloc_charged(thread, old_block ? 0 : 1);
+
+        if (!block) {
+            pthread_mutex_unlock(&inode->lock);
+            free(tmpl);
+            request->status = CHIMERA_VFS_ENOSPC;
+            request->complete(request);
+            return;
+        }
+
+        block->niov = evpl_iovec_alloc(evpl, block_size, 4096,
+                                       CHIMERA_MEMFS_BLOCK_MAX_IOV,
+                                       EVPL_IOVEC_FLAG_SHARED, block->iov);
+
+        /* Zero any prefix/suffix of this memfs block that the ADB region does
+         * not cover (partial leading/trailing block). */
+        if (block_offset) {
+            memset(block->iov[0].data, 0, block_offset);
+        }
+        if (block_offset + block_len < block_size) {
+            memset(block->iov[0].data + block_offset + block_len, 0,
+                   block_size - block_offset - block_len);
+        }
+
+        /* Tile the ADB pattern into the covered span. */
+        memfs_tile_pattern(block->iov[0].data + block_offset, block_len,
+                           cur_off - offset, tmpl, adb_bsize);
+
+        if (old_block) {
+            fork->blocks[bi] = NULL;
+            memfs_block_free_charged(thread, old_block, 0);
+        }
+        fork->blocks[bi] = block;
+
+        cur_off     += block_len;
+        left        -= block_len;
+        block_offset = 0;
+    }
+
+    if (*p_size < offset + total) {
+        *p_size       = offset + total;
+        *p_space_used = (*p_size + 4095) & ~4095;
+    }
+
+    inode->mtime = now;
+    inode->ctime = now;
+
+    memfs_map_attrs_fork(shared, &request->write_same.r_post_attr, inode, stream, request->fh);
+
+    pthread_mutex_unlock(&inode->lock);
+
+    free(tmpl);
+
+    request->status             = CHIMERA_VFS_OK;
+    request->write_same.r_count = total;
+    request->write_same.r_sync  = CHIMERA_VFS_WRITE_FILESYNC;
+
+    request->complete(request);
+} /* memfs_write_same */
+
 static void
 memfs_symlink_at(
     struct memfs_thread        *thread,
@@ -5647,6 +5958,12 @@ memfs_dispatch(
         case CHIMERA_VFS_OP_SEEK:
             memfs_seek(thread, shared, request, private_data);
             break;
+        case CHIMERA_VFS_OP_READ_PLUS:
+            memfs_read_plus(thread, shared, request, private_data);
+            break;
+        case CHIMERA_VFS_OP_WRITE_SAME:
+            memfs_write_same(thread, shared, request, private_data);
+            break;
         case CHIMERA_VFS_OP_SYMLINK_AT:
             memfs_symlink_at(thread, shared, request, private_data);
             break;
@@ -5698,7 +6015,8 @@ SYMBOL_EXPORT struct chimera_vfs_module vfs_memfs = {
         CHIMERA_VFS_CAP_ACL_NATIVE | CHIMERA_VFS_CAP_XATTR | CHIMERA_VFS_CAP_LAYOUT |
         CHIMERA_VFS_CAP_READ_PROVIDES_BUFFERS |
         CHIMERA_VFS_CAP_NAMED_STREAMS | CHIMERA_VFS_CAP_RPL | CHIMERA_VFS_CAP_FS_LOCK |
-        CHIMERA_VFS_CAP_CHANGE,
+        CHIMERA_VFS_CAP_CHANGE |
+        CHIMERA_VFS_CAP_READ_PLUS | CHIMERA_VFS_CAP_WRITE_SAME,
     .init           = memfs_init,
     .destroy        = memfs_destroy,
     .thread_init    = memfs_thread_init,

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -5229,6 +5229,317 @@ memfs_seek(
     }
 } /* memfs_seek */
 
+/*
+ * READ_PLUS: classify the leading byte-run at request->read_plus.offset as a
+ * single DATA or HOLE segment from the sparse block map (NULL block = hole).
+ * Returns only the classification + run length; the NFS server fetches DATA
+ * bytes via a normal read.  One segment per call is sufficient (the client
+ * re-issues from the last byte returned).
+ */
+static void
+memfs_read_plus(
+    struct memfs_thread        *thread,
+    struct memfs_fs            *fs,
+    struct chimera_vfs_request *request,
+    void                       *private_data)
+{
+    struct memfs_inode        *inode;
+    struct memfs_named_stream *stream;
+    struct memfs_fork         *fork;
+    uint64_t                   fork_size;
+    uint64_t                   offset = request->read_plus.offset;
+    uint64_t                   length = request->read_plus.length;
+    uint64_t                   first_block, bi, natural_end, seg_end;
+    int                        is_data;
+
+    (void) thread;
+
+    inode = memfs_resolve_io(fs, request->read_plus.handle,
+                             request->fh, request->fh_len, &stream);
+
+    if (unlikely(!inode)) {
+        request->status = CHIMERA_VFS_ENOENT;
+        request->complete(request);
+        return;
+    }
+
+    fork      = stream ? &stream->fork : &inode->file;
+    fork_size = stream ? stream->size : inode->size;
+
+    /* At or past EOF: no segment, just report eof (the NFS server returns
+     * NFS4_OK with an empty content array). */
+    if (offset >= fork_size || length == 0) {
+        pthread_mutex_unlock(&inode->lock);
+        request->status              = CHIMERA_VFS_OK;
+        request->read_plus.r_is_data = 0;
+        request->read_plus.r_length  = 0;
+        request->read_plus.r_eof     = (offset >= fork_size);
+        request->complete(request);
+        return;
+    }
+
+    const uint32_t block_shift = thread->shared->block_shift;
+
+    first_block = offset >> block_shift;
+    is_data     = (fork->blocks && first_block < fork->num_blocks &&
+                   fork->blocks[first_block]) ? 1 : 0;
+
+    /* Walk forward to the run boundary (where block presence flips). */
+    bi = first_block;
+    if (is_data) {
+        while (bi < fork->num_blocks && fork->blocks[bi]) {
+            bi++;
+        }
+        natural_end = bi << block_shift;
+    } else {
+        while (bi < fork->num_blocks &&
+               !(fork->blocks && fork->blocks[bi])) {
+            bi++;
+        }
+        natural_end = (bi >= fork->num_blocks) ? fork_size : (bi << block_shift);
+    }
+
+    if (natural_end > fork_size) {
+        natural_end = fork_size;
+    }
+
+    seg_end = natural_end;
+    if (seg_end > offset + length) {
+        seg_end = offset + length;
+    }
+
+    pthread_mutex_unlock(&inode->lock);
+
+    request->status              = CHIMERA_VFS_OK;
+    request->read_plus.r_is_data = is_data;
+    request->read_plus.r_length  = seg_end - offset;
+    request->read_plus.r_eof     = (seg_end >= fork_size);
+
+    request->complete(request);
+} /* memfs_read_plus */
+
+/* Tile `tmpl` (period `period` bytes) into dst[0..len), starting at template
+ * phase (rel_off % period). */
+static inline void
+memfs_tile_pattern(
+    uint8_t       *dst,
+    uint64_t       len,
+    uint64_t       rel_off,
+    const uint8_t *tmpl,
+    uint32_t       period)
+{
+    uint32_t phase = rel_off % period;
+    uint64_t done  = 0;
+
+    while (done < len) {
+        uint32_t chunk = period - phase;
+        if (chunk > len - done) {
+            chunk = len - done;
+        }
+        memcpy(dst + done, tmpl + phase, chunk);
+        done += chunk;
+        phase = 0;
+    }
+} /* memfs_tile_pattern */
+
+/*
+ * WRITE_SAME: materialize block_count Application Data Blocks of block_size
+ * bytes from offset, each block zero-filled with `pattern` placed at
+ * reloff_pattern.  Implemented by tiling a single ADB-block template across the
+ * affected memfs blocks (memfs block size is independent of the ADB block size).
+ */
+static void
+memfs_write_same(
+    struct memfs_thread        *thread,
+    struct memfs_fs            *fs,
+    struct chimera_vfs_request *request,
+    void                       *private_data)
+{
+    struct evpl               *evpl = thread->evpl;
+    struct memfs_inode        *inode;
+    struct memfs_named_stream *stream;
+    struct memfs_fork         *fork;
+    uint64_t                  *p_size, *p_space_used;
+    struct memfs_block        *block, *old_block;
+    uint64_t                   offset    = request->write_same.offset;
+    uint32_t                   adb_bsize = request->write_same.block_size;
+    uint64_t                   total;
+    uint64_t                   first_block, last_block, bi;
+    uint32_t                   block_offset, block_len;
+    uint64_t                   left, cur_off;
+    uint8_t                   *tmpl;
+    struct timespec            now;
+
+    total = adb_bsize * request->write_same.block_count;
+
+    if (total == 0) {
+        /* Nothing to write (block_count or block_size is 0). */
+        inode = memfs_resolve_io(fs, request->write_same.handle,
+                                 request->fh, request->fh_len, &stream);
+        if (unlikely(!inode)) {
+            request->status = CHIMERA_VFS_ENOENT;
+            request->complete(request);
+            return;
+        }
+        memfs_map_attrs_fork(fs, &request->write_same.r_pre_attr, inode, stream, request->fh);
+        memfs_map_attrs_fork(fs, &request->write_same.r_post_attr, inode, stream, request->fh);
+        pthread_mutex_unlock(&inode->lock);
+        request->status             = CHIMERA_VFS_OK;
+        request->write_same.r_count = 0;
+        request->write_same.r_sync  = CHIMERA_VFS_WRITE_FILESYNC;
+        request->complete(request);
+        return;
+    }
+
+    chimera_vfs_realtime(&now);
+
+    const uint32_t block_size  = thread->shared->block_size;
+    const uint32_t block_shift = thread->shared->block_shift;
+    const uint32_t block_mask  = thread->shared->block_mask;
+
+    /* Build one ADB-block template: zero-filled with the pattern at
+     * reloff_pattern.  The NFS server has already validated that
+     * reloff_pattern + pattern_len <= adb_bsize. */
+    tmpl = malloc(adb_bsize);
+    chimera_memfs_abort_if(tmpl == NULL, "write_same template OOM");
+    memset(tmpl, 0, adb_bsize);
+    if (request->write_same.pattern_len) {
+        memcpy(tmpl + request->write_same.reloff_pattern,
+               request->write_same.pattern,
+               request->write_same.pattern_len);
+    }
+
+    inode = memfs_resolve_io(fs, request->write_same.handle,
+                             request->fh, request->fh_len, &stream);
+
+    if (unlikely(!inode)) {
+        free(tmpl);
+        request->status = CHIMERA_VFS_ENOENT;
+        request->complete(request);
+        return;
+    }
+
+    if (!S_ISREG(inode->mode)) {
+        request->status = S_ISDIR(inode->mode) ?
+            CHIMERA_VFS_EISDIR : CHIMERA_VFS_EINVAL;
+        pthread_mutex_unlock(&inode->lock);
+        free(tmpl);
+        request->complete(request);
+        return;
+    }
+
+    fork         = stream ? &stream->fork : &inode->file;
+    p_size       = stream ? &stream->size : &inode->size;
+    p_space_used = stream ? &stream->space_used : &inode->space_used;
+
+    memfs_map_attrs_fork(fs, &request->write_same.r_pre_attr, inode, stream, request->fh);
+
+    first_block  = offset >> block_shift;
+    block_offset = offset & block_mask;
+    last_block   = (offset + total - 1) >> block_shift;
+    left         = total;
+    cur_off      = offset;
+
+    if (fork->max_blocks <= last_block || !fork->blocks) {
+        struct memfs_block **new_blocks;
+        unsigned int         new_max_blocks = 1024;
+
+        while (new_max_blocks <= last_block) {
+            new_max_blocks <<= 1;
+        }
+
+        new_blocks = calloc(new_max_blocks, sizeof(struct memfs_block *));
+
+        if (!new_blocks) {
+            pthread_mutex_unlock(&inode->lock);
+            free(tmpl);
+            request->status = CHIMERA_VFS_ENOSPC;
+            request->complete(request);
+            return;
+        }
+
+        if (fork->blocks) {
+            memcpy(new_blocks, fork->blocks,
+                   fork->num_blocks * sizeof(struct memfs_block *));
+            free(fork->blocks);
+        }
+
+        fork->blocks     = new_blocks;
+        fork->max_blocks = new_max_blocks;
+    }
+
+    if (last_block + 1 > fork->num_blocks) {
+        fork->num_blocks = last_block + 1;
+    }
+
+    for (bi = first_block; bi <= last_block; bi++) {
+        block_len = block_size - block_offset;
+        if (left < block_len) {
+            block_len = left;
+        }
+
+        old_block = fork->blocks ? fork->blocks[bi] : NULL;
+
+        block = memfs_block_alloc_charged(thread, fs, old_block ? 0 : 1);
+
+        if (!block) {
+            pthread_mutex_unlock(&inode->lock);
+            free(tmpl);
+            request->status = CHIMERA_VFS_ENOSPC;
+            request->complete(request);
+            return;
+        }
+
+        block->niov = evpl_iovec_alloc(evpl, block_size, 4096,
+                                       CHIMERA_MEMFS_BLOCK_MAX_IOV,
+                                       EVPL_IOVEC_FLAG_SHARED, block->iov);
+
+        /* Zero any prefix/suffix of this memfs block that the ADB region does
+         * not cover (partial leading/trailing block). */
+        if (block_offset) {
+            memset(block->iov[0].data, 0, block_offset);
+        }
+        if (block_offset + block_len < block_size) {
+            memset(block->iov[0].data + block_offset + block_len, 0,
+                   block_size - block_offset - block_len);
+        }
+
+        /* Tile the ADB pattern into the covered span. */
+        memfs_tile_pattern(block->iov[0].data + block_offset, block_len,
+                           cur_off - offset, tmpl, adb_bsize);
+
+        if (old_block) {
+            fork->blocks[bi] = NULL;
+            memfs_block_free_charged(thread, fs, old_block, 0);
+        }
+        fork->blocks[bi] = block;
+
+        cur_off     += block_len;
+        left        -= block_len;
+        block_offset = 0;
+    }
+
+    if (*p_size < offset + total) {
+        *p_size       = offset + total;
+        *p_space_used = (*p_size + 4095) & ~4095;
+    }
+
+    inode->mtime = now;
+    inode->ctime = now;
+
+    memfs_map_attrs_fork(fs, &request->write_same.r_post_attr, inode, stream, request->fh);
+
+    pthread_mutex_unlock(&inode->lock);
+
+    free(tmpl);
+
+    request->status             = CHIMERA_VFS_OK;
+    request->write_same.r_count = total;
+    request->write_same.r_sync  = CHIMERA_VFS_WRITE_FILESYNC;
+
+    request->complete(request);
+} /* memfs_write_same */
+
 static void
 memfs_symlink_at(
     struct memfs_thread        *thread,
@@ -6740,6 +7051,12 @@ memfs_dispatch(
         case CHIMERA_VFS_OP_SEEK:
             memfs_seek(thread, fs, request, private_data);
             break;
+        case CHIMERA_VFS_OP_READ_PLUS:
+            memfs_read_plus(thread, fs, request, private_data);
+            break;
+        case CHIMERA_VFS_OP_WRITE_SAME:
+            memfs_write_same(thread, fs, request, private_data);
+            break;
         case CHIMERA_VFS_OP_SYMLINK_AT:
             memfs_symlink_at(thread, fs, request, private_data);
             break;
@@ -6799,7 +7116,8 @@ SYMBOL_EXPORT struct chimera_vfs_module vfs_memfs = {
         CHIMERA_VFS_CAP_READ_PROVIDES_BUFFERS |
         CHIMERA_VFS_CAP_NAMED_STREAMS | CHIMERA_VFS_CAP_RPL | CHIMERA_VFS_CAP_FS_LOCK |
         CHIMERA_VFS_CAP_CHANGE | CHIMERA_VFS_CAP_MKFS |
-        CHIMERA_VFS_CAP_LEASE,
+        CHIMERA_VFS_CAP_LEASE |
+        CHIMERA_VFS_CAP_READ_PLUS | CHIMERA_VFS_CAP_WRITE_SAME,
     .init           = memfs_init,
     .destroy        = memfs_destroy,
     .thread_init    = memfs_thread_init,

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -5526,6 +5526,10 @@ memfs_write_same(
 
     inode->mtime = now;
     inode->ctime = now;
+    /* WRITE_SAME changes file data, so it must advance the change attribute
+     * like WRITE does -- a client that validates its cache against change
+     * would otherwise never notice the write. */
+    inode->change++;
 
     memfs_map_attrs_fork(fs, &request->write_same.r_post_attr, inode, stream, request->fh);
 

--- a/src/vfs/sdk/vfs_module.h
+++ b/src/vfs/sdk/vfs_module.h
@@ -254,6 +254,19 @@ struct chimera_vfs_handle_state {
  * is no partial mode. */
 #define CHIMERA_VFS_CAP_LEASE                 (1U << 26)
 
+/* If set, the module can natively answer a sparse READ_PLUS (RFC 7862 15.10):
+ * given an offset it classifies the leading byte-run as DATA or HOLE from its
+ * own block/extent map and, for DATA, returns the bytes in one round trip
+ * (chimera_vfs_read_plus).  Modules that leave this unset cause the VFS layer to
+ * return ENOTSUP and the NFS server to report NFS4ERR_NOTSUPP, so the client
+ * falls back to plain READ. */
+#define CHIMERA_VFS_CAP_READ_PLUS             (1U << 27)
+
+/* If set, the module can natively expand an NFSv4.2 WRITE_SAME (RFC 7862 15.13)
+* Application Data Block -- writing a repeated pattern across a run of blocks --
+* via chimera_vfs_write_same.  Modules that leave this unset surface ENOTSUP. */
+#define CHIMERA_VFS_CAP_WRITE_SAME            (1U << 28)
+
 struct chimera_vfs_module {
     /* Required
      * Set to CHIMERA_VFS_SDK_VERSION.  Checked at registration so a module

--- a/src/vfs/sdk/vfs_request.h
+++ b/src/vfs/sdk/vfs_request.h
@@ -113,7 +113,9 @@ struct chimera_vfs_mount_options {
 #define CHIMERA_VFS_OP_RMFS                     41
 #define CHIMERA_VFS_OP_LEASE_ACQUIRE            42
 #define CHIMERA_VFS_OP_LEASE_RELEASE            43
-#define CHIMERA_VFS_OP_NUM                      44
+#define CHIMERA_VFS_OP_READ_PLUS                44
+#define CHIMERA_VFS_OP_WRITE_SAME               45
+#define CHIMERA_VFS_OP_NUM                      46
 
 #define CHIMERA_VFS_OPEN_CREATE                 (1U << 0)
 #define CHIMERA_VFS_OPEN_PATH                   (1U << 1)
@@ -1142,6 +1144,41 @@ struct chimera_vfs_request {
             struct chimera_vfs_attrs        r_dst_pre_attr;
             struct chimera_vfs_attrs        r_dst_post_attr;
         } move_range;
+
+        /* READ_PLUS: classify the leading byte-run at `offset` as DATA or HOLE
+         * from the backend's block/extent map, in one round trip.  The backend
+         * sets r_is_data (1 = DATA run, 0 = HOLE run), r_length (the run length
+         * to the next boundary or EOF, clamped to the requested `length`), and
+         * r_eof (the segment reaches end-of-file).  The data bytes themselves are
+         * fetched by the caller via a normal read, so this op never moves data
+         * and avoids the read path's buffer/thread-ownership machinery. */
+        struct {
+            struct chimera_vfs_open_handle *handle;
+            uint64_t                        offset;
+            uint64_t                        length;
+            uint32_t                        r_is_data;
+            uint64_t                        r_length;
+            uint32_t                        r_eof;
+        } read_plus;
+
+        /* WRITE_SAME: write `block_count` blocks of `block_size` bytes from
+         * `offset`, each block zero-filled then `pattern` (pattern_len bytes)
+         * placed at reloff_pattern.  Per-block-number stamping is not requested
+         * (the NFS layer rejects it).  r_count = total bytes written. */
+        struct {
+            struct chimera_vfs_open_handle *handle;
+            uint64_t                        offset;
+            uint32_t                        block_size;
+            uint64_t                        block_count;
+            uint32_t                        reloff_pattern;
+            const void                     *pattern;
+            uint32_t                        pattern_len;
+            uint32_t                        sync;
+            uint64_t                        r_count;
+            uint32_t                        r_sync;
+            struct chimera_vfs_attrs        r_pre_attr;
+            struct chimera_vfs_attrs        r_post_attr;
+        } write_same;
 
         struct {
             struct chimera_vfs_open_handle *handle;

--- a/src/vfs/vfs.h
+++ b/src/vfs/vfs.h
@@ -111,7 +111,9 @@ struct chimera_vfs_mount_options {
 #define CHIMERA_VFS_OP_OPEN_STREAM      37
 #define CHIMERA_VFS_OP_LIST_STREAMS     38
 #define CHIMERA_VFS_OP_REMOVE_STREAM    39
-#define CHIMERA_VFS_OP_NUM              40
+#define CHIMERA_VFS_OP_READ_PLUS        40
+#define CHIMERA_VFS_OP_WRITE_SAME       41
+#define CHIMERA_VFS_OP_NUM              42
 
 #define CHIMERA_VFS_OPEN_CREATE         (1U << 0)
 #define CHIMERA_VFS_OPEN_PATH           (1U << 1)
@@ -1002,6 +1004,41 @@ struct chimera_vfs_request {
             struct chimera_vfs_attrs        r_dst_post_attr;
         } move_range;
 
+        /* READ_PLUS: classify the leading byte-run at `offset` as DATA or HOLE
+         * from the backend's block/extent map, in one round trip.  The backend
+         * sets r_is_data (1 = DATA run, 0 = HOLE run), r_length (the run length
+         * to the next boundary or EOF, clamped to the requested `length`), and
+         * r_eof (the segment reaches end-of-file).  The data bytes themselves are
+         * fetched by the caller via a normal read, so this op never moves data
+         * and avoids the read path's buffer/thread-ownership machinery. */
+        struct {
+            struct chimera_vfs_open_handle *handle;
+            uint64_t                        offset;
+            uint64_t                        length;
+            uint32_t                        r_is_data;
+            uint64_t                        r_length;
+            uint32_t                        r_eof;
+        } read_plus;
+
+        /* WRITE_SAME: write `block_count` blocks of `block_size` bytes from
+         * `offset`, each block zero-filled then `pattern` (pattern_len bytes)
+         * placed at reloff_pattern.  Per-block-number stamping is not requested
+         * (the NFS layer rejects it).  r_count = total bytes written. */
+        struct {
+            struct chimera_vfs_open_handle *handle;
+            uint64_t                        offset;
+            uint32_t                        block_size;
+            uint64_t                        block_count;
+            uint32_t                        reloff_pattern;
+            const void                     *pattern;
+            uint32_t                        pattern_len;
+            uint32_t                        sync;
+            uint64_t                        r_count;
+            uint32_t                        r_sync;
+            struct chimera_vfs_attrs        r_pre_attr;
+            struct chimera_vfs_attrs        r_post_attr;
+        } write_same;
+
         struct {
             struct chimera_vfs_open_handle *handle;
             uint64_t                        offset;
@@ -1353,6 +1390,19 @@ struct chimera_vfs_handle_state {
  * change_attr_type NFS4_CHANGE_TYPE_IS_MONOTONIC_INCR.  Modules that leave this
  * unset have change derived from ctime (change_attr_type TIME_METADATA). */
 #define CHIMERA_VFS_CAP_CHANGE                (1U << 24)
+
+/* If set, the module can natively answer a sparse READ_PLUS (RFC 7862 15.10):
+ * given an offset it classifies the leading byte-run as DATA or HOLE from its
+ * own block/extent map and, for DATA, returns the bytes in one round trip
+ * (chimera_vfs_read_plus).  Modules that leave this unset cause the VFS layer to
+ * return ENOTSUP and the NFS server to report NFS4ERR_NOTSUPP, so the client
+ * falls back to plain READ. */
+#define CHIMERA_VFS_CAP_READ_PLUS             (1U << 25)
+
+/* If set, the module can natively expand an NFSv4.2 WRITE_SAME (RFC 7862 15.13)
+* Application Data Block -- writing a repeated pattern across a run of blocks --
+* via chimera_vfs_write_same.  Modules that leave this unset surface ENOTSUP. */
+#define CHIMERA_VFS_CAP_WRITE_SAME            (1U << 26)
 
 struct chimera_vfs_module {
     /* Required

--- a/src/vfs/vfs_claim_break.c
+++ b/src/vfs/vfs_claim_break.c
@@ -631,13 +631,18 @@ chimera_vfs_claim_trigger_row(
 
     if (awaited) {
         /* Awaited-class victims always floor 0 and never cascade
-         * (CB_RECALL / FUSE_NOTIFY_INVAL_INODE are all-or-nothing).  The
-         * NFSv4 recall deadline is delegation-specific; a FUSE grant keeps
-         * the default break deadline as its force-revoke backstop. */
+         * (CB_RECALL / FUSE_NOTIFY_INVAL_INODE are all-or-nothing).  Both
+         * recall deadlines are construct-specific: an NFSv4 delegation is
+         * recalled over the network, a FUSE grant by a local write to the
+         * mount's own channel, so they are orders of magnitude apart. */
         row->floor    = 0;
         row->one_shot = true;
-        if (is_deleg && row->deadline_ms == 0) {
-            row->deadline_ms = CHIMERA_VFS_NFS_DELEG_RECALL_MS;
+        if (row->deadline_ms == 0) {
+            if (is_deleg) {
+                row->deadline_ms = CHIMERA_VFS_NFS_DELEG_RECALL_MS;
+            } else if (victim->construct == CHIMERA_CONSTRUCT_FUSE_GRANT) {
+                row->deadline_ms = CHIMERA_VFS_FUSE_GRANT_BREAK_MS;
+            }
         }
     }
 } /* chimera_vfs_claim_trigger_row */

--- a/src/vfs/vfs_claim_internal.h
+++ b/src/vfs/vfs_claim_internal.h
@@ -16,6 +16,16 @@
 #define CHIMERA_VFS_NFS_DELEG_RECALL_MS             15000
 #define CHIMERA_VFS_NFS_DELEG_METAOP_MS             5000
 
+/* Force-revoke backstop for a FUSE cache grant.  Breaking one is a single
+ * non-reply write to the mount's own /dev/fuse channel answered by a local
+ * kernel, not a callback to a client across a network, so the deadlines above
+ * are the wrong order of magnitude: a conflicting writer parks until the break
+ * is acked, and inheriting the 30s default meant one missed ack stalled that
+ * writer for thirty seconds.  Two seconds is still several orders of magnitude
+ * more than the notification costs and keeps the sweep a backstop rather than
+ * something a caller ever waits out. */
+#define CHIMERA_VFS_FUSE_GRANT_BREAK_MS             2000
+
 /* ------------------------------------------------------------------ */
 /* Deny rows (derived, never stored)                                  */
 /* ------------------------------------------------------------------ */

--- a/src/vfs/vfs_dump.c
+++ b/src/vfs/vfs_dump.c
@@ -51,6 +51,8 @@ chimera_vfs_op_name(unsigned int opcode)
         case CHIMERA_VFS_OP_OPEN_STREAM: return "OpenStream";
         case CHIMERA_VFS_OP_LIST_STREAMS: return "ListStreams";
         case CHIMERA_VFS_OP_REMOVE_STREAM: return "RemoveStream";
+        case CHIMERA_VFS_OP_READ_PLUS: return "ReadPlus";
+        case CHIMERA_VFS_OP_WRITE_SAME: return "WriteSame";
         default: return "Unknown";
     } /* switch */
 

--- a/src/vfs/vfs_dump.c
+++ b/src/vfs/vfs_dump.c
@@ -61,6 +61,8 @@ chimera_vfs_op_name(unsigned int opcode)
         case CHIMERA_VFS_OP_REMOVE_STREAM: return "RemoveStream";
         case CHIMERA_VFS_OP_MKFS: return "MkFs";
         case CHIMERA_VFS_OP_RMFS: return "RmFs";
+        case CHIMERA_VFS_OP_READ_PLUS: return "ReadPlus";
+        case CHIMERA_VFS_OP_WRITE_SAME: return "WriteSame";
         default: return "Unknown";
     } /* switch */
 

--- a/src/vfs/vfs_proc_read_plus.c
+++ b/src/vfs/vfs_proc_read_plus.c
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "vfs/vfs_procs.h"
+#include "vfs_internal.h"
+#include "common/macros.h"
+
+static void
+chimera_vfs_read_plus_complete(struct chimera_vfs_request *request)
+{
+    chimera_vfs_read_plus_callback_t callback = request->proto_callback;
+
+    chimera_vfs_complete(request);
+
+    callback(request->status,
+             request->read_plus.r_is_data,
+             request->read_plus.r_length,
+             request->read_plus.r_eof,
+             request->proto_private_data);
+
+    chimera_vfs_request_free(request->thread, request);
+} /* chimera_vfs_read_plus_complete */
+
+SYMBOL_EXPORT void
+chimera_vfs_read_plus(
+    struct chimera_vfs_thread       *thread,
+    const struct chimera_vfs_cred   *cred,
+    struct chimera_vfs_open_handle  *handle,
+    uint64_t                         offset,
+    uint64_t                         length,
+    chimera_vfs_read_plus_callback_t callback,
+    void                            *private_data)
+{
+    struct chimera_vfs_request *request;
+
+    if (!(handle->vfs_module->capabilities & CHIMERA_VFS_CAP_READ_PLUS)) {
+        callback(CHIMERA_VFS_ENOTSUP, 0, 0, 0, private_data);
+        return;
+    }
+
+    request = chimera_vfs_request_alloc_by_handle(thread, cred, handle);
+
+    if (CHIMERA_VFS_IS_ERR(request)) {
+        callback(CHIMERA_VFS_PTR_ERR(request), 0, 0, 0, private_data);
+        return;
+    }
+
+    request->opcode              = CHIMERA_VFS_OP_READ_PLUS;
+    request->complete            = chimera_vfs_read_plus_complete;
+    request->read_plus.handle    = handle;
+    request->read_plus.offset    = offset;
+    request->read_plus.length    = length;
+    request->read_plus.r_is_data = 0;
+    request->read_plus.r_length  = 0;
+    request->read_plus.r_eof     = 0;
+    request->proto_callback      = callback;
+    request->proto_private_data  = private_data;
+
+    chimera_vfs_dispatch(request);
+} /* chimera_vfs_read_plus */

--- a/src/vfs/vfs_proc_write_same.c
+++ b/src/vfs/vfs_proc_write_same.c
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "vfs/vfs_procs.h"
+#include "vfs_internal.h"
+#include "vfs_attr_cache.h"
+#include "common/macros.h"
+
+static void
+chimera_vfs_write_same_complete(struct chimera_vfs_request *request)
+{
+    chimera_vfs_write_same_callback_t callback = request->proto_callback;
+
+    if (request->status == CHIMERA_VFS_OK) {
+        chimera_vfs_attr_cache_insert(request->thread,
+                                      request->thread->vfs->vfs_attr_cache,
+                                      request->write_same.handle->fh_hash,
+                                      request->write_same.handle->fh,
+                                      request->write_same.handle->fh_len,
+                                      &request->write_same.r_post_attr);
+    }
+
+    chimera_vfs_complete(request);
+
+    callback(request->status,
+             request->write_same.r_count,
+             request->write_same.r_sync,
+             &request->write_same.r_pre_attr,
+             &request->write_same.r_post_attr,
+             request->proto_private_data);
+
+    chimera_vfs_request_free(request->thread, request);
+} /* chimera_vfs_write_same_complete */
+
+SYMBOL_EXPORT void
+chimera_vfs_write_same(
+    struct chimera_vfs_thread        *thread,
+    const struct chimera_vfs_cred    *cred,
+    struct chimera_vfs_open_handle   *handle,
+    uint64_t                          offset,
+    uint32_t                          block_size,
+    uint64_t                          block_count,
+    const void                       *pattern,
+    uint32_t                          pattern_len,
+    uint32_t                          reloff_pattern,
+    uint32_t                          sync,
+    uint64_t                          pre_attr_mask,
+    uint64_t                          post_attr_mask,
+    chimera_vfs_write_same_callback_t callback,
+    void                             *private_data)
+{
+    struct chimera_vfs_request *request;
+
+    if (!(handle->vfs_module->capabilities & CHIMERA_VFS_CAP_WRITE_SAME)) {
+        callback(CHIMERA_VFS_ENOTSUP, 0, 0, NULL, NULL, private_data);
+        return;
+    }
+
+    request = chimera_vfs_request_alloc_by_handle(thread, cred, handle);
+
+    if (CHIMERA_VFS_IS_ERR(request)) {
+        callback(CHIMERA_VFS_PTR_ERR(request), 0, 0, NULL, NULL, private_data);
+        return;
+    }
+
+    request->opcode                             = CHIMERA_VFS_OP_WRITE_SAME;
+    request->complete                           = chimera_vfs_write_same_complete;
+    request->write_same.handle                  = handle;
+    request->write_same.offset                  = offset;
+    request->write_same.block_size              = block_size;
+    request->write_same.block_count             = block_count;
+    request->write_same.pattern                 = pattern;
+    request->write_same.pattern_len             = pattern_len;
+    request->write_same.reloff_pattern          = reloff_pattern;
+    request->write_same.sync                    = sync;
+    request->write_same.r_count                 = 0;
+    request->write_same.r_sync                  = sync;
+    request->write_same.r_pre_attr.va_req_mask  = pre_attr_mask;
+    request->write_same.r_pre_attr.va_set_mask  = 0;
+    request->write_same.r_post_attr.va_req_mask = post_attr_mask | CHIMERA_VFS_ATTR_MASK_CACHEABLE;
+    request->write_same.r_post_attr.va_set_mask = 0;
+    request->proto_callback                     = callback;
+    request->proto_private_data                 = private_data;
+
+    chimera_vfs_dispatch(request);
+} /* chimera_vfs_write_same */

--- a/src/vfs/vfs_proc_write_same.c
+++ b/src/vfs/vfs_proc_write_same.c
@@ -7,6 +7,221 @@
 #include "vfs_attr_cache.h"
 #include "common/macros.h"
 
+/*
+ * WRITE_SAME (RFC 7862) expands a small Application Data Block pattern into a
+ * run of identical blocks.  A backend that advertises CHIMERA_VFS_CAP_WRITE_SAME
+ * does this natively (and can be smartest -- e.g. diskfs routes an all-zero
+ * pattern to a hole-punch, O(metadata)).  A backend WITHOUT the cap still gets
+ * the operation's main benefit -- the pattern is not sent over the wire, the
+ * server expands it -- via this generic fallback: build ONE block-size template
+ * buffer and issue ordinary writes whose iovec array is N refcounted clones of
+ * that single buffer.  No data is duplicated in memory (the clones share the
+ * one buffer) and nothing crosses the wire; the only cost not saved is handing
+ * the full-size write to the backend.
+ *
+ * (A further refinement, left to the native backends which already do it, is to
+ * map an all-zero pattern to allocate/punch for a metadata-only result.)
+ */
+
+/* Bound a single fallback write: at most this many cloned blocks, and at most
+ * this many bytes, per hop. */
+#define CHIMERA_VFS_WS_FALLBACK_IOV   128
+#define CHIMERA_VFS_WS_FALLBACK_BYTES (256 * 1024)
+
+struct chimera_vfs_write_same_fallback {
+    struct chimera_vfs_thread        *thread;
+    struct chimera_vfs_cred           cred;
+    struct chimera_vfs_open_handle   *handle;
+    uint64_t                          offset;       /* next write offset */
+    uint64_t                          remaining;    /* bytes left (block multiple) */
+    uint64_t                          written;
+    uint32_t                          block_size;
+    uint32_t                          sync;
+    uint32_t                          r_sync;
+    uint64_t                          post_attr_mask;
+    struct chimera_vfs_attrs          r_pre_attr;
+    struct chimera_vfs_attrs          r_post_attr;
+    /* One block-size template (zero-filled + pattern at reloff); each write
+     * borrows N refcounted clones of it. */
+    struct evpl_iovec                 tmpl;
+    struct evpl_iovec                 chunk_iov[CHIMERA_VFS_WS_FALLBACK_IOV];
+    int                               chunk_niov;
+    chimera_vfs_write_same_callback_t callback;
+    void                             *private_data;
+};
+
+static void
+chimera_vfs_write_same_fallback_step(
+    struct chimera_vfs_write_same_fallback *ctx);
+
+static void
+chimera_vfs_write_same_fallback_finish(
+    struct chimera_vfs_write_same_fallback *ctx,
+    enum chimera_vfs_error                  error_code)
+{
+    chimera_vfs_write_same_callback_t callback     = ctx->callback;
+    void                             *private_data = ctx->private_data;
+    uint64_t                          written      = ctx->written;
+    uint32_t                          r_sync       = ctx->r_sync;
+    struct chimera_vfs_attrs          pre          = ctx->r_pre_attr;
+    struct chimera_vfs_attrs          post         = ctx->r_post_attr;
+
+    evpl_iovec_release(ctx->thread->evpl, &ctx->tmpl);
+    free(ctx);
+
+    callback(error_code, written, r_sync, &pre, &post, private_data);
+} /* chimera_vfs_write_same_fallback_finish */
+
+static void
+chimera_vfs_write_same_fallback_write_cb(
+    enum chimera_vfs_error    error_code,
+    uint32_t                  length,
+    uint32_t                  sync,
+    struct chimera_vfs_attrs *pre_attr,
+    struct chimera_vfs_attrs *post_attr,
+    void                     *private_data)
+{
+    struct chimera_vfs_write_same_fallback *ctx = private_data;
+
+    /* Drop the per-write clones; the template's own ref persists for the next
+     * hop (and is released in finish). */
+    if (ctx->chunk_niov) {
+        evpl_iovecs_release(ctx->thread->evpl, ctx->chunk_iov, ctx->chunk_niov);
+        ctx->chunk_niov = 0;
+    }
+
+    if (error_code != CHIMERA_VFS_OK) {
+        chimera_vfs_write_same_fallback_finish(ctx, error_code);
+        return;
+    }
+
+    if (ctx->written == 0 && pre_attr) {
+        ctx->r_pre_attr = *pre_attr;
+    }
+    if (post_attr) {
+        ctx->r_post_attr = *post_attr;
+    }
+    ctx->r_sync     = sync;
+    ctx->written   += length;
+    ctx->offset    += length;
+    ctx->remaining -= length;
+
+    chimera_vfs_write_same_fallback_step(ctx);
+} /* chimera_vfs_write_same_fallback_write_cb */
+
+static void
+chimera_vfs_write_same_fallback_step(struct chimera_vfs_write_same_fallback *ctx)
+{
+    uint64_t blocks, k;
+    uint32_t chunk;
+
+    if (ctx->remaining == 0) {
+        chimera_vfs_write_same_fallback_finish(ctx, CHIMERA_VFS_OK);
+        return;
+    }
+
+    /* Clone as many whole blocks as fit the per-hop iovec and byte budgets. */
+    blocks = ctx->remaining / ctx->block_size;
+    k      = blocks;
+    if (k > CHIMERA_VFS_WS_FALLBACK_IOV) {
+        k = CHIMERA_VFS_WS_FALLBACK_IOV;
+    }
+    if (k * ctx->block_size > CHIMERA_VFS_WS_FALLBACK_BYTES) {
+        k = CHIMERA_VFS_WS_FALLBACK_BYTES / ctx->block_size;
+    }
+    if (k == 0) {
+        k = 1;          /* a single block larger than the byte budget */
+    }
+
+    for (uint64_t i = 0; i < k; i++) {
+        evpl_iovec_clone(&ctx->chunk_iov[i], &ctx->tmpl);
+    }
+    ctx->chunk_niov = (int) k;
+    chunk           = (uint32_t) (k * ctx->block_size);
+
+    chimera_vfs_write(
+        ctx->thread,
+        &ctx->cred,
+        ctx->handle,
+        ctx->offset,
+        chunk,
+        ctx->sync,
+        ctx->written == 0 ? CHIMERA_VFS_ATTR_MASK_STAT : 0,
+        ctx->post_attr_mask | CHIMERA_VFS_ATTR_MASK_CACHEABLE,
+        ctx->chunk_iov,
+        ctx->chunk_niov,
+        chimera_vfs_write_same_fallback_write_cb,
+        ctx);
+} /* chimera_vfs_write_same_fallback_step */
+
+static void
+chimera_vfs_write_same_fallback(
+    struct chimera_vfs_thread        *thread,
+    const struct chimera_vfs_cred    *cred,
+    struct chimera_vfs_open_handle   *handle,
+    uint64_t                          offset,
+    uint32_t                          block_size,
+    uint64_t                          block_count,
+    const void                       *pattern,
+    uint32_t                          pattern_len,
+    uint32_t                          reloff_pattern,
+    uint32_t                          sync,
+    uint64_t                          pre_attr_mask,
+    uint64_t                          post_attr_mask,
+    chimera_vfs_write_same_callback_t callback,
+    void                             *private_data)
+{
+    struct chimera_vfs_write_same_fallback *ctx;
+    int                                     n;
+
+    if (block_size == 0 || block_count == 0) {
+        callback(CHIMERA_VFS_OK, 0, sync, NULL, NULL, private_data);
+        return;
+    }
+
+    ctx = calloc(1, sizeof(*ctx));
+    if (unlikely(!ctx)) {
+        callback(CHIMERA_VFS_EIO, 0, 0, NULL, NULL, private_data);
+        return;
+    }
+
+    /* One contiguous template block: zero-filled with the pattern at reloff. */
+    n = evpl_iovec_alloc(thread->evpl, block_size, 4096, 1, 0, &ctx->tmpl);
+    if (unlikely(n != 1)) {
+        if (n > 0) {
+            evpl_iovec_release(thread->evpl, &ctx->tmpl);
+        }
+        free(ctx);
+        callback(CHIMERA_VFS_EIO, 0, 0, NULL, NULL, private_data);
+        return;
+    }
+    ctx->tmpl.length = block_size;
+    memset(ctx->tmpl.data, 0, block_size);
+    if (pattern_len) {
+        memcpy((uint8_t *) ctx->tmpl.data + reloff_pattern, pattern, pattern_len);
+    }
+
+    ctx->thread         = thread;
+    ctx->cred           = *cred;
+    ctx->handle         = handle;
+    ctx->offset         = offset;
+    ctx->remaining      = (uint64_t) block_size * block_count;
+    ctx->written        = 0;
+    ctx->block_size     = block_size;
+    ctx->sync           = sync;
+    ctx->r_sync         = sync;
+    ctx->post_attr_mask = post_attr_mask;
+    ctx->callback       = callback;
+    ctx->private_data   = private_data;
+
+    ctx->r_pre_attr.va_req_mask  = pre_attr_mask;
+    ctx->r_pre_attr.va_set_mask  = 0;
+    ctx->r_post_attr.va_req_mask = post_attr_mask;
+    ctx->r_post_attr.va_set_mask = 0;
+
+    chimera_vfs_write_same_fallback_step(ctx);
+} /* chimera_vfs_write_same_fallback */
+
 static void
 chimera_vfs_write_same_complete(struct chimera_vfs_request *request)
 {
@@ -52,8 +267,21 @@ chimera_vfs_write_same(
 {
     struct chimera_vfs_request *request;
 
+    /* No native WRITE_SAME: expand the pattern in the VFS core and write it via
+     * the backend's ordinary write path.  The NFS proxy is excluded -- its write
+     * MOVES (consumes) the supplied iovecs onto the upstream RPC rather than
+     * borrowing them, which the clone-and-release fallback cannot drive safely
+     * (same reasoning as the copy_range fallback) -- so it keeps surfacing
+     * ENOTSUP and lets the client send a plain WRITE. */
     if (!(handle->vfs_module->capabilities & CHIMERA_VFS_CAP_WRITE_SAME)) {
-        callback(CHIMERA_VFS_ENOTSUP, 0, 0, NULL, NULL, private_data);
+        if (handle->vfs_module->fh_magic == CHIMERA_VFS_FH_MAGIC_NFS) {
+            callback(CHIMERA_VFS_ENOTSUP, 0, 0, NULL, NULL, private_data);
+            return;
+        }
+        chimera_vfs_write_same_fallback(thread, cred, handle, offset, block_size,
+                                        block_count, pattern, pattern_len,
+                                        reloff_pattern, sync, pre_attr_mask,
+                                        post_attr_mask, callback, private_data);
         return;
     }
 

--- a/src/vfs/vfs_procs.h
+++ b/src/vfs/vfs_procs.h
@@ -895,6 +895,48 @@ chimera_vfs_clone_range(
     chimera_vfs_clone_range_callback_t callback,
     void                              *private_data);
 
+typedef void (*chimera_vfs_read_plus_callback_t)(
+    enum chimera_vfs_error error_code,
+    uint32_t               is_data,
+    uint64_t               length,
+    uint32_t               eof,
+    void                  *private_data);
+
+void
+chimera_vfs_read_plus(
+    struct chimera_vfs_thread       *thread,
+    const struct chimera_vfs_cred   *cred,
+    struct chimera_vfs_open_handle  *handle,
+    uint64_t                         offset,
+    uint64_t                         length,
+    chimera_vfs_read_plus_callback_t callback,
+    void                            *private_data);
+
+typedef void (*chimera_vfs_write_same_callback_t)(
+    enum chimera_vfs_error    error_code,
+    uint64_t                  count,
+    uint32_t                  sync,
+    struct chimera_vfs_attrs *pre_attr,
+    struct chimera_vfs_attrs *post_attr,
+    void                     *private_data);
+
+void
+chimera_vfs_write_same(
+    struct chimera_vfs_thread        *thread,
+    const struct chimera_vfs_cred    *cred,
+    struct chimera_vfs_open_handle   *handle,
+    uint64_t                          offset,
+    uint32_t                          block_size,
+    uint64_t                          block_count,
+    const void                       *pattern,
+    uint32_t                          pattern_len,
+    uint32_t                          reloff_pattern,
+    uint32_t                          sync,
+    uint64_t                          pre_attr_mask,
+    uint64_t                          post_attr_mask,
+    chimera_vfs_write_same_callback_t callback,
+    void                             *private_data);
+
 typedef void (*chimera_vfs_move_range_callback_t)(
     enum chimera_vfs_error    error_code,
     struct chimera_vfs_attrs *src_post_attr,

--- a/src/vfs/vfs_procs.h
+++ b/src/vfs/vfs_procs.h
@@ -985,6 +985,48 @@ chimera_vfs_clone_range(
     chimera_vfs_clone_range_callback_t callback,
     void                              *private_data);
 
+typedef void (*chimera_vfs_read_plus_callback_t)(
+    enum chimera_vfs_error error_code,
+    uint32_t               is_data,
+    uint64_t               length,
+    uint32_t               eof,
+    void                  *private_data);
+
+void
+chimera_vfs_read_plus(
+    struct chimera_vfs_thread       *thread,
+    const struct chimera_vfs_cred   *cred,
+    struct chimera_vfs_open_handle  *handle,
+    uint64_t                         offset,
+    uint64_t                         length,
+    chimera_vfs_read_plus_callback_t callback,
+    void                            *private_data);
+
+typedef void (*chimera_vfs_write_same_callback_t)(
+    enum chimera_vfs_error    error_code,
+    uint64_t                  count,
+    uint32_t                  sync,
+    struct chimera_vfs_attrs *pre_attr,
+    struct chimera_vfs_attrs *post_attr,
+    void                     *private_data);
+
+void
+chimera_vfs_write_same(
+    struct chimera_vfs_thread        *thread,
+    const struct chimera_vfs_cred    *cred,
+    struct chimera_vfs_open_handle   *handle,
+    uint64_t                          offset,
+    uint32_t                          block_size,
+    uint64_t                          block_count,
+    const void                       *pattern,
+    uint32_t                          pattern_len,
+    uint32_t                          reloff_pattern,
+    uint32_t                          sync,
+    uint64_t                          pre_attr_mask,
+    uint64_t                          post_attr_mask,
+    chimera_vfs_write_same_callback_t callback,
+    void                             *private_data);
+
 typedef void (*chimera_vfs_move_range_callback_t)(
     enum chimera_vfs_error    error_code,
     struct chimera_vfs_attrs *src_post_attr,


### PR DESCRIPTION
Implements the four NFSv4.2 OPTIONAL operations that were advertised in the
op-support matrix but unimplemented (they fell through to `NFS4ERR_NOTSUPP`):
**READ_PLUS** (#407), **IO_ADVISE** (#408), **WRITE_SAME** (#409), **CLONE** (#410).

### Approach
Native VFS operations projected straight into the backend (memfs + diskfs), with
`ENOTSUP` → `NFS4ERR_NOTSUPP` on backends that can't do it. RFC 7862 permits
`NFS4ERR_NOTSUPP` for optional ops; NFSv4 has no supported-ops query, so support
is expressed at runtime by the capability gate (`CHIMERA_VFS_CAP_*`). No `nfs4.x`
changes were needed — the XDR was already generated.

### NFS/VFS layer + memfs
- **IO_ADVISE** — validating no-op (validate stateid/FH, return empty honored hints).
- **READ_PLUS** — new `CHIMERA_VFS_OP_READ_PLUS` classifies the leading DATA/HOLE
  segment from the backend's block map; the NFS handler fetches DATA bytes via the
  existing read path (one segment per call, RFC-legal).
- **WRITE_SAME** — new `CHIMERA_VFS_OP_WRITE_SAME` expands an Application Data Block
  pattern; rejects per-block-number stamping with `NFS4ERR_UNION_NOTSUPP`. Backends
  without native support get a **VFS-core fallback** that expands the pattern into one
  block-size buffer and writes N refcounted clones of it via the ordinary write path —
  so the data still never crosses the wire (works on linux/io_uring/cairn; the NFS
  proxy keeps surfacing `ENOTSUP`).
- **CLONE** — reuses the existing `clone_range` VFS op; gates on `CAP_CLONE_RANGE`
  and same-module.

### diskfs `read_plus` + `write_same`
- `read_plus`: extent-map classification (modeled on `diskfs_seek`).
- `write_same`: punch-then-fill in one txn — zero pattern → punch-hole (O(metadata));
  non-zero → chunked allocate + device-write loop. Added a client op +
  `chimera_posix_write_same` + a per-backend `test_write_same` (Linux clients never
  issue WRITE_SAME, so it needs a direct test path).

### diskfs reflink (CLONE): real block-level copy-on-write
- **Format v5**: refcount bootstrap inode, `DISKFS_REC_REFCOUNT`, `DISKFS_EXT_SHARED`
  (older filesystems are cleanly refused → reformat).
- **CLONE** shares source extents (split at clone boundaries so the shared piece is
  its own extent) and increments a per-device-range refcount in the refcount inode's
  b+tree; lock order is dst+src (ascending inum) then the refcount inode (a
  deadlock-free "always-last" leaf).
- **Copy-on-write**: a write pre-pass privatizes shared extents (chunked device copy
  → fresh blocks → decrement refcount) before the normal write machinery runs.
- **Free hooks**: truncate / unlink (reclaim drain) / deallocate decrement instead of
  freeing shared extents; the device range is freed only at the last owner.
- **Crash consistency**: all refcount updates, extent-map changes, and conditional
  frees ride the one diskfs txn redo.

### Model-based coverage (new)

The four operations were at **0.00% line coverage** under `ctest -L quint` — they
had no model, and the flavor that should have carried them was inert.

`stepData` has never generated a single data operation. It carries neither
`reclaimComplete` nor `nsCreate`, so every OPEN in it returns `NFS4ERR_GRACE`
(107 of 107 across the corpus) and `files` stays empty, which disables every
data action's guard. No ALLOCATE, DEALLOCATE, SEEK or COPY has ever reached a
server from it either.

chimera-nas/specs#4 adds the four operations to the NFSv4 model with a dedicated
`stepData42` flavor that builds the state they need; this branch teaches the MBT
harness to replay them. READ_PLUS is checked as a *prefix* — the model predicts
the whole range's DATA/HOLE classification and contents, but `rpr_contents` is an
array and a server may legally return fewer segments, so the harness requires the
returned segments to tile the range contiguously from the requested offset,
compares only the blocks returned, and rejects an `eof` that arrives early or a
reply that makes no progress at all.

| file | lines | before | after |
| --- | ---: | ---: | ---: |
| `nfs4_proc_read_plus.c` | 251 | 0.00% | 68.13% |
| `nfs4_proc_write_same.c` | 178 | 0.00% | 62.36% |
| `nfs4_proc_clone.c` | 113 | 0.00% | 84.07% |
| `nfs4_proc_io_advise.c` | 29 | 0.00% | 72.41% |
| `vfs_proc_read_plus.c` | 33 | 0.00% | 81.82% |
| `vfs_proc_write_same.c` | 171 | 0.00% | 25.73% |

### Three defects the model found

All three are fixed here; each is a case the hand-written tests did not reach.

- **READ_PLUS skipped most of the share-reservation check.** Its special-stateid
  path called `nfs_client_check_io_denied` (the requesting client's own opens
  only) and only when the request carried a session — so a deny-READ reservation
  held by *another* client did not block it, and in NFSv4.0, which has no
  session, nothing was checked at all. READ makes the same call against the
  shared client table unconditionally.
- **WRITE_SAME's special-stateid path had no deny check at all.** The open-state
  path checks its own reservation, but a write through the anonymous stateid
  reached the backend without consulting anyone, where WRITE returns
  `NFS4ERR_LOCKED`.
- **WRITE_SAME never advanced the change attribute**, on either memfs or diskfs.
  It updates size, mtime and ctime but left `change` alone, so a client
  validating its cache against it would never notice the write. WRITE and CLONE
  both bump it.

### Three more defects the merge queue found

The full backend matrix only runs in the merge queue, and it found what the
memfs-only MBT batch could not.

**diskfs CLONE deadlocked on a self-clone.** `diskfs_clone_range` acquires the
two file inodes in ascending-inum order, but both selectors pick the same inode
when the inums are equal, so a same-file clone took that write lock twice and
never returned.  The SMB layer rejects only *overlapping* same-file ranges, so a
disjoint self-clone reaches the backend -- `dup_extents_src_is_dest`.
`memfs_clone_range` already made the distinction.

**diskfs CLONE hung cloning onto a destination that already held data.** The
destination extent was inserted without clearing the range first, so the insert
met a live key.  Every `dup_extents_*` case writes the destination before
duplicating; the clone tests here only ever cloned into a freshly-truncated
file, which is why it went unseen.  Clearing now borrows the write path's shape
and keeps the refcount invariants: a wholly-covered shared extent is released
through `diskfs_ext_release`, a partially-covered one is privatized first
(a refcount record is keyed by the whole extent's device offset, so splitting
one would leave a piece whose key names no record), and once nothing shared
overlaps the remainder is freed and split as `diskfs_write_trim_process` does.
Three cases were added to the per-backend clone tests: self-clone, clone over
existing destination data, and a clone into the middle of an extent that spans
the target range.

**A FUSE grant break inherited a network-scale deadline.** `fuse_sync_test`
failed the queue twice on different distros, always with the cross-mount
same-file write churn finishing in ~31s against its 20s assertion -- that is
`CHIMERA_VFS_CLAIM_DEFAULT_BREAK_DEADLINE_MS` exactly.  A conflicting writer
parks until the other mount's grant break is acked, and a missed ack was only
resolved by the sweep at the 30s deadline.  Recall deadlines are already
construct-specific (an NFSv4 delegation gets `CHIMERA_VFS_NFS_DELEG_RECALL_MS`);
a FUSE grant now gets `CHIMERA_VFS_FUSE_GRANT_BREAK_MS`, sized for a local
channel write rather than a network callback.  Measured on the test's own
scenario: before, 5 failures in 40 runs, every one at 31.0s; after, 0 in 60 with
a worst case of 2.9s.  The missed ack is bounded rather than eliminated -- what
causes it is worth its own investigation.

### Why the model did not catch the CLONE defects

Measured against the shipped corpus, two separate gaps:

- **10 of 24** generated CLONE operations land on a destination range that
  already holds blocks, so the model does produce the second defect's trigger.
  It never fired because the nfs4 MBT corpus is memfs-only and memfs handles
  that case correctly -- the `diskfs_clone.c` coverage gap noted below.
- **0 of 24** are same-file: `clonePairs` requires distinct files by
  construction, so the self-clone defect was unreachable on any backend.

Both are follow-ups: a diskfs instance for the nfs4 model (the harness already
takes `--backend`), and letting `clonePairs` emit same-file pairs with disjoint
ranges.

### Validation
- pynfs 4.0/4.1/4.2 + `protocol_advertise`; clang `scan-build`: no bugs found;
  `make syntax-check` / reuse-lint / copyright all green.
- Per-backend posix content tests for read_plus/write_same/clone on memfs + diskfs
  (io_uring + aio), incl. **CoW divergence** (write to a clone leaves the source
  intact) and **unlink-source-survives** (delete a clone, the other keeps its data
  and stays writable); WRITE_SAME content tests also pass on linux/io_uring/cairn via
  the fallback; fsx stress.
- KVM e2e: `nfstest_sparse` + `nfstest_posix` on memfs and diskfs (NFSv4.2, real
  Linux client).
- `ctest -L quint` green, including the new NFSv4 batch
  (`chimera/server/nfs/mbt4/batch_memfs`, which replays the
  `nfs4Memfs42/stepData42` traces).  The `ext/specs` bump moves the pin from
  `add37ac` (landed with #1553) to the specs-main merge commit carrying this
  branch's model, so it adds only chimera-nas/specs#4.

### Deferred follow-ups
`fattr4_clone_blksize` advertisement; per-block CoW (currently whole-extent copy);
refcount-inode sharding; the dealloc full-inside decrement (currently skip-free → a
rare leak on punch-hole-of-a-clone, not corruption); a per-inode has-shared-extents
flag to skip the CoW-scan on non-clone writes.

Two gaps the coverage table makes visible:

- `vfs_proc_write_same.c` sits at 25.73% because it is the **fallback** path, which
  memfs never takes (it has native `CAP_WRITE_SAME`). Reaching it needs a backend
  without native support — cairn or the passthrough backends.
- `diskfs_clone.c` (the 559-line reflink/CoW implementation) is still ~1% covered by
  quint: the nfs4 MBT corpus instances are memfs-tuned (block size and capability
  profile), so a diskfs run needs its own model instance. The harness now takes
  `--backend`, which is the hook for it; the on-disk reflink paths are meanwhile
  covered by the per-backend posix content and persistence tests, **not** by
  crash-injection.

### Known issue
A reference leak reachable only with the four operations exercised together leaves
`mount_count > 0`, so the MBT harness's per-trace `rmfs` fails ("still failed after
5000 retries") and the next trace inherits the previous filesystem. It reproduces
in roughly 2 traces in 32 at seed `0x11`; the 8-trace batch this branch ships does
not hit it. An op-free control flavor with the identical setup mix, and the
pre-existing 92-trace corpus, are both clean, so it is attributable to these
operations rather than to the harness. Not yet root-caused.

### Notes
- Draft: the diskfs format-version bump means existing diskfs filesystems need a
  reformat; flagging for review before un-drafting. Rebasing onto main moved this
  from v3 to **v5** — main had independently taken v4 for named filesystems.
- The rebase also crossed main's VFS SDK split: the op table and request union now
  live in `sdk/vfs_request.h` and the capability bits in `sdk/vfs_module.h`, so the
  new ops are 44/45 and the new capabilities are bits 27/28 (25/26 were taken by
  MKFS/LEASE).
