### PR TITLE
posix/tests: arm the lock-test wedge watchdog before the ctest timeout

### DIFF
--- a/src/posix/tests/cthon_lock_tlock.c
+++ b/src/posix/tests/cthon_lock_tlock.c
@@ -622,13 +622,17 @@ main(
     if ((childpid = fork()) == 0) {
         who = CHILD;
         signal(SIGINT, childsig);
-        /* Fail fast with a stack if this child wedges (the recurring
-         * lock-family post-fork hang); fires well before the ctest timeout. */
-        posix_test_child_watchdog(240);
+        /* Fail fast with a stack if either side wedges (the recurring
+         * lock-family hang).  45 s beats the shortest ctest timeout this binary
+         * runs under while leaving room for the gstack dump; normal runtime is
+         * <2 s so it never false-fires.  Armed on both sides so a parent-side
+         * wedge is captured too. */
+        posix_test_child_watchdog(45);
     } else {
         who = PARENT;
         signal(SIGINT, parentsig);
         signal(SIGCHLD, SIG_DFL);
+        posix_test_child_watchdog(45);
     }
 
     /*

--- a/src/posix/tests/test_fcntl.c
+++ b/src/posix/tests/test_fcntl.c
@@ -59,8 +59,12 @@ child_main(
     close(c2p[0]);
 
     /* Fail fast with a stack if this child wedges (the recurring lock-family
-     * post-fork hang); fires well before the 300s ctest timeout. */
-    posix_test_child_watchdog(240);
+     * hang).  Must fire before the *shortest* ctest timeout for any test built
+     * from this binary -- the _myuser / nfs3rdma variants run with TIMEOUT 60,
+     * so a 240 s alarm never fired (ctest SIGKILLed at 60 s first, leaving zero
+     * diagnostics).  45 s leaves headroom for the gstack dump before the 60 s
+     * kill, and normal runtime is <2 s so it never false-fires. */
+    posix_test_child_watchdog(45);
 
     fprintf(stderr, "child: Testing chimera_posix_fcntl()...\n");
     env->posix = chimera_posix_init_json(posix_json_path, cred, env->metrics);
@@ -286,6 +290,11 @@ main(
     /* ---- parent ---- */
     close(p2c[0]);
     close(c2p[1]);
+
+    /* The hang can wedge the parent too (it runs the in-process NFS server and
+     * its own lock ops, then waitpid()s the child).  Arm the same self-dumping
+     * watchdog here so a parent-side wedge is captured, not just a child one. */
+    posix_test_child_watchdog(45);
 
     fprintf(stderr, "parent: Testing chimera_posix_fcntl()...\n");
     if (is_nfs) {

--- a/src/posix/tests/test_lockf.c
+++ b/src/posix/tests/test_lockf.c
@@ -55,8 +55,11 @@ child_main(
     close(c2p[0]);
 
     /* Fail fast with a stack if this child wedges (the recurring lock-family
-     * post-fork hang); fires well before the 300s ctest timeout. */
-    posix_test_child_watchdog(240);
+     * hang).  Must beat the *shortest* ctest timeout for this binary: the
+     * _myuser / nfs3rdma variants run with TIMEOUT 60, so a 240 s alarm never
+     * fired (ctest SIGKILLed at 60 s, leaving zero diagnostics).  45 s leaves
+     * room for the gstack dump; normal runtime <2 s so it never false-fires. */
+    posix_test_child_watchdog(45);
 
     env->posix = chimera_posix_init_json(posix_json_path, cred, env->metrics);
 
@@ -271,6 +274,11 @@ main(
     /* ---- parent ---- */
     close(p2c[0]);
     close(c2p[1]);
+
+    /* The hang can wedge the parent too (it runs the in-process NFS server and
+     * its own lock ops, then waitpid()s the child).  Arm the same self-dumping
+     * watchdog here so a parent-side wedge is captured, not just a child one. */
+    posix_test_child_watchdog(45);
 
     if (is_nfs) {
         posix_test_start_nfs_server(&env);


### PR DESCRIPTION
## Why

The `fcntl`/`lockf` lock-family flake (`fcntl_nfs3_linux_myuser`, `lockf_nfs3*`, …) keeps hitting the merge queue as a bare `***Timeout`, with **zero diagnostics** — which is why it has never been root-caused.

These tests already carry a self-dumping watchdog (`SIGALRM` → per-thread `wchan` + all-thread `gstack` → abort) for exactly this hang. But it was armed at **240 s**, tuned for the base tests' 300 s `TIMEOUT`. The **`_myuser` and `nfs3rdma` variants run with `TIMEOUT 60`**, so ctest SIGKILLs the test at 60 s — a full ~3 minutes before the alarm could fire. The watchdog never ran, so every CI occurrence produced nothing but `Timeout 59.9s`.

I confirmed this is the whole reason we've had no stack: the watchdog mechanism itself works fine (it emits a fully symbolized all-thread backtrace), it just never got the chance to fire.

## What

- Arm the watchdog at **45 s** instead of 240 s — beats the shortest (60 s) timeout with headroom for the gstack dump, and well beats the 300 s ones. Normal runtime is <2 s, so it never false-fires.
- Arm it in the **parent** too, not just the forked child. The parent runs the in-process NFS server + its own lock ops then `waitpid()`s the child, so a parent-side wedge was previously invisible (and the one CI capture I have *was* the parent process).

No behavior change to the tests. This is purely a diagnostics fix: the **next** time the flake hits CI it will leave a full symbolized stack so the actual hang can finally be root-caused.

## Verification
`CHIMERA_TEST_WATCHDOG_SECONDS=2 ... posix_test_fcntl -b nfs3_linux` → the alarm fires and emits `child-watchdog: ... wchan ...` + a symbolized `gstack all threads` dump. Lock tests still pass 100% (finish in <2 s, far below 45 s).

## Context
Investigation notes: the "lockf issue" is actually two distinct hangs — the original `pthread_create`-EAGAIN *init* hang (fixed in #834) and a separate *post-init* hang in the NFS3/NLM lock path that only reproduces under CI load (5000+ local stress runs stayed clean). This PR is what lets us capture the latter's stack.