### PR TITLE
nfs3: map a sec= policy rejection to NFS3ERR_ACCES (not BADHANDLE)

### DIFF
--- a/kvm/kvm_nfs_kerberos_test_wrapper.sh
+++ b/kvm/kvm_nfs_kerberos_test_wrapper.sh
@@ -168,6 +168,13 @@ generate_config() {
         *) log "Unsupported backend: $BACKEND"; exit 1 ;;
     esac
 
+    # Optional per-export security policy: NFS_EXPORT_SEC="krb5,krb5i" restricts
+    # the export to those flavors so a disallowed flavor is rejected.
+    local export_sec_json=""
+    if [ -n "${NFS_EXPORT_SEC:-}" ]; then
+        export_sec_json=", \"sec\": [$(echo "${NFS_EXPORT_SEC}" | sed 's/[^,]\+/"&"/g')]"
+    fi
+
     cat > "$CONFIG_FILE" <<EOF
 {
     "common": { "rcu_reclaim_threads": 4 },
@@ -179,7 +186,7 @@ generate_config() {
         "external_portmap": false
     },
     "mounts": { "share": { "module": "$BACKEND", "path": "$mount_path" } },
-    "exports": { "/share": { "path": "/share" } }
+    "exports": { "/share": { "path": "/share"${export_sec_json} } }
 }
 EOF
 }
@@ -256,6 +263,12 @@ case "${NFS_VERSION}" in
 esac
 if [ -n "${KVM_KRB_DEBUG:-}" ]; then
     TEST_CMD="${KRB_PREP} echo '=== keytab ==='; ls -l /etc/krb5.keytab; klist -k /etc/krb5.keytab 2>&1; echo '=== KDC reach ==='; (echo > /dev/tcp/10.0.0.1/${KDC_PORT}) 2>&1 && echo kdc-tcp-ok || echo kdc-tcp-FAIL; echo '=== kinit -k ==='; timeout 10 kinit -k -t /etc/krb5.keytab host/${CLIENT_HOST}@${REALM} 2>&1; echo kinit_rc=\$?; klist 2>&1; echo '=== krb5 mount -v ==='; timeout 25 mount -v -t nfs -o ${NFS_MOUNT_OPTS} ${SERVER_HOST}:/share /mnt 2>&1; echo krb5_rc=\$?"
+elif [ -n "${NFS_EXPECT_DENY:-}" ]; then
+    # Negative test: the export's sec= policy forbids this mount's flavor, so the
+    # mount must be rejected -- the server returns a permission error (for NFSv3,
+    # NFS3ERR_ACCES on the post-mount probe).  Pass only if the mount fails with a
+    # denied/permission error; a successful mount or any other failure is a fail.
+    TEST_CMD="${KRB_PREP} if mount -t nfs -o ${NFS_MOUNT_OPTS} ${SERVER_HOST}:/share /mnt 2>/tmp/mnterr; then echo SEC_DENY_FAILED_MOUNTED; umount /mnt 2>/dev/null; exit 1; fi; cat /tmp/mnterr; if grep -qiE 'denied|not permitted|permission' /tmp/mnterr; then echo NFS_SEC_DENY_OK; exit 0; else echo SEC_DENY_WRONG_ERROR; exit 1; fi"
 else
     TEST_CMD="${KRB_PREP} mount -t nfs -o ${NFS_MOUNT_OPTS} ${SERVER_HOST}:/share /mnt && ${POST_MOUNT_CMD}"
 fi

--- a/kvm/tests/CMakeLists.txt
+++ b/kvm/tests/CMakeLists.txt
@@ -307,6 +307,20 @@ foreach(image_spec ${KVM_IMAGES})
         SKIP_RETURN_CODE 77
         ENVIRONMENT "NFS_ENABLE_NLM=1")
 
+    # NFSv3 sec= policy rejection: an export restricted to krb5 must reject a
+    # sec=sys mount.  The real client reports "access denied by server" only if
+    # the server answers the post-mount probe with NFS3ERR_ACCES -- a stale/bad
+    # handle (the pre-fix behaviour) would surface a different error and fail
+    # this test, so it pins the WRONGSEC->ACCES mapping.
+    add_test(NAME chimera/kvm/${IMAGE_NAME}/kerberos/sec_krb5only_deny_sys_memfs_nfs3
+        COMMAND bash ${NFS_KRB_WRAPPER}
+                ${IMAGE_DIR}/vmlinuz ${IMAGE_DIR}/rootfs.qcow2
+                ${CHIMERA_BINARY} memfs 3 "deny")
+    set_tests_properties(chimera/kvm/${IMAGE_NAME}/kerberos/sec_krb5only_deny_sys_memfs_nfs3
+        PROPERTIES LABELS "kvm;${IMAGE_NAME};rpcsec_gss" PROCESSORS 2
+        SKIP_RETURN_CODE 77
+        ENVIRONMENT "MOUNT_SEC=sys;NFS_EXPORT_SEC=krb5;NFS_EXPECT_DENY=1")
+
     # NFS cthon04 tests
     foreach(nfsver ${NFS_VERSIONS})
         foreach(category ${CTHON_CATEGORIES})

--- a/src/server/nfs/nfs3_proc_access.c
+++ b/src/server/nfs/nfs3_proc_access.c
@@ -148,10 +148,11 @@ chimera_nfs3_access(
 
     req->args_access = args;
 
-    if (chimera_nfs_fh_decode(req, args->object.data.data, args->object.data.len,
-                              req->fh, &req->fhlen) != CHIMERA_NFS_FH_OK) {
+    res.status = chimera_nfs3_decode_fh(req, args->object.data.data, args->object.data.len);
+    if (res.status != NFS3_OK) {
+        nfsstat3 fh_status = res.status;
         memset(&res, 0, sizeof(res));
-        res.status = NFS3ERR_BADHANDLE;
+        res.status = fh_status;
         rc         = shared->nfs_v3.send_reply_NFSPROC3_ACCESS(evpl, NULL, &res, req->encoding);
         chimera_nfs_abort_if(rc, "Failed to send RPC2 reply");
         nfs_request_free(thread, req);

--- a/src/server/nfs/nfs3_proc_commit.c
+++ b/src/server/nfs/nfs3_proc_commit.c
@@ -101,10 +101,11 @@ chimera_nfs3_commit(
 
     req->args_commit = args;
 
-    if (chimera_nfs_fh_decode(req, args->file.data.data, args->file.data.len,
-                              req->fh, &req->fhlen) != CHIMERA_NFS_FH_OK) {
+    res.status = chimera_nfs3_decode_fh(req, args->file.data.data, args->file.data.len);
+    if (res.status != NFS3_OK) {
+        nfsstat3 fh_status = res.status;
         memset(&res, 0, sizeof(res));
-        res.status = NFS3ERR_BADHANDLE;
+        res.status = fh_status;
         rc         = shared->nfs_v3.send_reply_NFSPROC3_COMMIT(evpl, NULL, &res, req->encoding);
         chimera_nfs_abort_if(rc, "Failed to send RPC2 reply");
         nfs_request_free(thread, req);

--- a/src/server/nfs/nfs3_proc_create.c
+++ b/src/server/nfs/nfs3_proc_create.c
@@ -213,10 +213,11 @@ chimera_nfs3_create(
 
     req->args_create = args;
 
-    if (chimera_nfs_fh_decode(req, args->where.dir.data.data, args->where.dir.data.len,
-                              req->fh, &req->fhlen) != CHIMERA_NFS_FH_OK) {
+    res.status = chimera_nfs3_decode_fh(req, args->where.dir.data.data, args->where.dir.data.len);
+    if (res.status != NFS3_OK) {
+        nfsstat3 fh_status = res.status;
         memset(&res, 0, sizeof(res));
-        res.status = NFS3ERR_BADHANDLE;
+        res.status = fh_status;
         rc         = shared->nfs_v3.send_reply_NFSPROC3_CREATE(evpl, NULL, &res, req->encoding);
         chimera_nfs_abort_if(rc, "Failed to send RPC2 reply");
         nfs_request_free(thread, req);

--- a/src/server/nfs/nfs3_proc_fsinfo.c
+++ b/src/server/nfs/nfs3_proc_fsinfo.c
@@ -105,10 +105,11 @@ chimera_nfs3_fsinfo(
 
     req->args_fsinfo = args;
 
-    if (chimera_nfs_fh_decode(req, args->fsroot.data.data, args->fsroot.data.len,
-                              req->fh, &req->fhlen) != CHIMERA_NFS_FH_OK) {
+    res.status = chimera_nfs3_decode_fh(req, args->fsroot.data.data, args->fsroot.data.len);
+    if (res.status != NFS3_OK) {
+        nfsstat3 fh_status = res.status;
         memset(&res, 0, sizeof(res));
-        res.status = NFS3ERR_BADHANDLE;
+        res.status = fh_status;
         rc         = shared->nfs_v3.send_reply_NFSPROC3_FSINFO(evpl, NULL, &res, req->encoding);
         chimera_nfs_abort_if(rc, "Failed to send RPC2 reply");
         nfs_request_free(thread, req);

--- a/src/server/nfs/nfs3_proc_fsstat.c
+++ b/src/server/nfs/nfs3_proc_fsstat.c
@@ -101,10 +101,11 @@ chimera_nfs3_fsstat(
 
     req->args_fsstat = args;
 
-    if (chimera_nfs_fh_decode(req, args->fsroot.data.data, args->fsroot.data.len,
-                              req->fh, &req->fhlen) != CHIMERA_NFS_FH_OK) {
+    res.status = chimera_nfs3_decode_fh(req, args->fsroot.data.data, args->fsroot.data.len);
+    if (res.status != NFS3_OK) {
+        nfsstat3 fh_status = res.status;
         memset(&res, 0, sizeof(res));
-        res.status = NFS3ERR_BADHANDLE;
+        res.status = fh_status;
         rc         = shared->nfs_v3.send_reply_NFSPROC3_FSSTAT(evpl, NULL, &res, req->encoding);
         chimera_nfs_abort_if(rc, "Failed to send RPC2 reply");
         nfs_request_free(thread, req);

--- a/src/server/nfs/nfs3_proc_getattr.c
+++ b/src/server/nfs/nfs3_proc_getattr.c
@@ -88,10 +88,11 @@ chimera_nfs3_getattr(
 
     req->args_getattr = args;
 
-    if (chimera_nfs_fh_decode(req, args->object.data.data, args->object.data.len,
-                              req->fh, &req->fhlen) != CHIMERA_NFS_FH_OK) {
+    res.status = chimera_nfs3_decode_fh(req, args->object.data.data, args->object.data.len);
+    if (res.status != NFS3_OK) {
+        nfsstat3 fh_status = res.status;
         memset(&res, 0, sizeof(res));
-        res.status = NFS3ERR_BADHANDLE;
+        res.status = fh_status;
         rc         = shared->nfs_v3.send_reply_NFSPROC3_GETATTR(evpl, NULL, &res, req->encoding);
         chimera_nfs_abort_if(rc, "Failed to send RPC2 reply");
         nfs_request_free(thread, req);

--- a/src/server/nfs/nfs3_proc_link.c
+++ b/src/server/nfs/nfs3_proc_link.c
@@ -64,13 +64,14 @@ chimera_nfs3_link(
      * the target-directory handle (authenticated into req->saved_fh).  The
      * target handle must outlive this (async) call, so it lives in the request
      * rather than on the stack (saved_fh is unused by NFSv3). */
-    if (chimera_nfs_fh_decode(req, args->file.data.data, args->file.data.len,
-                              req->fh, &req->fhlen) != CHIMERA_NFS_FH_OK ||
+    res.status = chimera_nfs3_decode_fh(req, args->file.data.data, args->file.data.len);
+    if (res.status != NFS3_OK ||
         chimera_nfs_fh_unwrap(args->link.dir.data.data, args->link.dir.data.len,
                               &linkdir_export_id, req->saved_fh, &req->saved_fhlen,
                               shared->fh_key, shared->fh_sign) != CHIMERA_NFS_FH_OK) {
+        nfsstat3 fh_status = res.status != NFS3_OK ? res.status : NFS3ERR_BADHANDLE;
         memset(&res, 0, sizeof(res));
-        res.status = NFS3ERR_BADHANDLE;
+        res.status = fh_status;
         rc         = shared->nfs_v3.send_reply_NFSPROC3_LINK(evpl, NULL, &res, req->encoding);
         chimera_nfs_abort_if(rc, "Failed to send RPC2 reply");
         nfs_request_free(thread, req);

--- a/src/server/nfs/nfs3_proc_lookup.c
+++ b/src/server/nfs/nfs3_proc_lookup.c
@@ -117,10 +117,11 @@ chimera_nfs3_lookup(
 
     req->args_lookup = args;
 
-    if (chimera_nfs_fh_decode(req, args->what.dir.data.data, args->what.dir.data.len,
-                              req->fh, &req->fhlen) != CHIMERA_NFS_FH_OK) {
+    res.status = chimera_nfs3_decode_fh(req, args->what.dir.data.data, args->what.dir.data.len);
+    if (res.status != NFS3_OK) {
+        nfsstat3 fh_status = res.status;
         memset(&res, 0, sizeof(res));
-        res.status = NFS3ERR_BADHANDLE;
+        res.status = fh_status;
         rc         = shared->nfs_v3.send_reply_NFSPROC3_LOOKUP(evpl, NULL, &res, req->encoding);
         chimera_nfs_abort_if(rc, "Failed to send RPC2 reply");
         nfs_request_free(thread, req);

--- a/src/server/nfs/nfs3_proc_mkdir.c
+++ b/src/server/nfs/nfs3_proc_mkdir.c
@@ -124,10 +124,11 @@ chimera_nfs3_mkdir(
 
     req->args_mkdir = args;
 
-    if (chimera_nfs_fh_decode(req, args->where.dir.data.data, args->where.dir.data.len,
-                              req->fh, &req->fhlen) != CHIMERA_NFS_FH_OK) {
+    res.status = chimera_nfs3_decode_fh(req, args->where.dir.data.data, args->where.dir.data.len);
+    if (res.status != NFS3_OK) {
+        nfsstat3 fh_status = res.status;
         memset(&res, 0, sizeof(res));
-        res.status = NFS3ERR_BADHANDLE;
+        res.status = fh_status;
         rc         = shared->nfs_v3.send_reply_NFSPROC3_MKDIR(evpl, NULL, &res, req->encoding);
         chimera_nfs_abort_if(rc, "Failed to send RPC2 reply");
         nfs_request_free(thread, req);

--- a/src/server/nfs/nfs3_proc_mknod.c
+++ b/src/server/nfs/nfs3_proc_mknod.c
@@ -153,10 +153,11 @@ chimera_nfs3_mknod(
 
     req->args_mknod = args;
 
-    if (chimera_nfs_fh_decode(req, args->where.dir.data.data, args->where.dir.data.len,
-                              req->fh, &req->fhlen) != CHIMERA_NFS_FH_OK) {
+    res.status = chimera_nfs3_decode_fh(req, args->where.dir.data.data, args->where.dir.data.len);
+    if (res.status != NFS3_OK) {
+        nfsstat3 fh_status = res.status;
         memset(&res, 0, sizeof(res));
-        res.status = NFS3ERR_BADHANDLE;
+        res.status = fh_status;
         rc         = shared->nfs_v3.send_reply_NFSPROC3_MKNOD(evpl, NULL, &res, req->encoding);
         chimera_nfs_abort_if(rc, "Failed to send RPC2 reply");
         nfs_request_free(thread, req);

--- a/src/server/nfs/nfs3_proc_read.c
+++ b/src/server/nfs/nfs3_proc_read.c
@@ -112,10 +112,11 @@ chimera_nfs3_read(
 
     req->args_read = args;
 
-    if (chimera_nfs_fh_decode(req, args->file.data.data, args->file.data.len,
-                              req->fh, &req->fhlen) != CHIMERA_NFS_FH_OK) {
+    res.status = chimera_nfs3_decode_fh(req, args->file.data.data, args->file.data.len);
+    if (res.status != NFS3_OK) {
+        nfsstat3 fh_status = res.status;
         memset(&res, 0, sizeof(res));
-        res.status = NFS3ERR_BADHANDLE;
+        res.status = fh_status;
         rc         = shared->nfs_v3.send_reply_NFSPROC3_READ(evpl, NULL, &res, req->encoding);
         chimera_nfs_abort_if(rc, "Failed to send RPC2 reply");
         nfs_request_free(thread, req);

--- a/src/server/nfs/nfs3_proc_readdir.c
+++ b/src/server/nfs/nfs3_proc_readdir.c
@@ -159,11 +159,12 @@ chimera_nfs3_readdir(
 
     res->resok.reply.entries = NULL;
 
-    if (chimera_nfs_fh_decode(req, args->dir.data.data, args->dir.data.len,
-                              req->fh, &req->fhlen) != CHIMERA_NFS_FH_OK) {
-        int rc;
+    res->status = chimera_nfs3_decode_fh(req, args->dir.data.data, args->dir.data.len);
+    if (res->status != NFS3_OK) {
+        int      rc;
+        nfsstat3 fh_status = res->status;
         memset(res, 0, sizeof(*res));
-        res->status = NFS3ERR_BADHANDLE;
+        res->status = fh_status;
         rc          = thread->shared->nfs_v3.send_reply_NFSPROC3_READDIR(evpl, NULL, res, req->encoding);
         chimera_nfs_abort_if(rc, "Failed to send RPC2 reply");
         nfs_request_free(thread, req);

--- a/src/server/nfs/nfs3_proc_readdirplus.c
+++ b/src/server/nfs/nfs3_proc_readdirplus.c
@@ -191,11 +191,12 @@ chimera_nfs3_readdirplus(
     cursor->entries  = NULL;
     cursor->last     = NULL;
 
-    if (chimera_nfs_fh_decode(req, args->dir.data.data, args->dir.data.len,
-                              req->fh, &req->fhlen) != CHIMERA_NFS_FH_OK) {
-        int rc;
+    res->status = chimera_nfs3_decode_fh(req, args->dir.data.data, args->dir.data.len);
+    if (res->status != NFS3_OK) {
+        int      rc;
+        nfsstat3 fh_status = res->status;
         memset(res, 0, sizeof(*res));
-        res->status = NFS3ERR_BADHANDLE;
+        res->status = fh_status;
         rc          = thread->shared->nfs_v3.send_reply_NFSPROC3_READDIRPLUS(evpl, NULL, res, req->encoding);
         chimera_nfs_abort_if(rc, "Failed to send RPC2 reply");
         nfs_request_free(thread, req);

--- a/src/server/nfs/nfs3_proc_readlink.c
+++ b/src/server/nfs/nfs3_proc_readlink.c
@@ -102,10 +102,11 @@ chimera_nfs3_readlink(
 
     req->args_readlink = args;
 
-    if (chimera_nfs_fh_decode(req, args->symlink.data.data, args->symlink.data.len,
-                              req->fh, &req->fhlen) != CHIMERA_NFS_FH_OK) {
+    res->status = chimera_nfs3_decode_fh(req, args->symlink.data.data, args->symlink.data.len);
+    if (res->status != NFS3_OK) {
+        nfsstat3 fh_status = res->status;
         memset(res, 0, sizeof(*res));
-        res->status = NFS3ERR_BADHANDLE;
+        res->status = fh_status;
         rc          = shared->nfs_v3.send_reply_NFSPROC3_READLINK(evpl, NULL, res, req->encoding);
         chimera_nfs_abort_if(rc, "Failed to send RPC2 reply");
         nfs_request_free(thread, req);

--- a/src/server/nfs/nfs3_proc_remove.c
+++ b/src/server/nfs/nfs3_proc_remove.c
@@ -98,10 +98,11 @@ chimera_nfs3_remove(
 
     req->args_remove = args;
 
-    if (chimera_nfs_fh_decode(req, args->object.dir.data.data, args->object.dir.data.len,
-                              req->fh, &req->fhlen) != CHIMERA_NFS_FH_OK) {
+    res.status = chimera_nfs3_decode_fh(req, args->object.dir.data.data, args->object.dir.data.len);
+    if (res.status != NFS3_OK) {
+        nfsstat3 fh_status = res.status;
         memset(&res, 0, sizeof(res));
-        res.status = NFS3ERR_BADHANDLE;
+        res.status = fh_status;
         rc         = shared->nfs_v3.send_reply_NFSPROC3_REMOVE(evpl, NULL, &res, req->encoding);
         chimera_nfs_abort_if(rc, "Failed to send RPC2 reply");
         nfs_request_free(thread, req);

--- a/src/server/nfs/nfs3_proc_rename.c
+++ b/src/server/nfs/nfs3_proc_rename.c
@@ -65,13 +65,14 @@ chimera_nfs3_rename(
      * squash); the destination is authenticated into req->saved_fh.  The
      * destination handle must outlive this (async) call, so it goes in the
      * request rather than on the stack (saved_fh is unused by NFSv3). */
-    if (chimera_nfs_fh_decode(req, args->from.dir.data.data, args->from.dir.data.len,
-                              req->fh, &req->fhlen) != CHIMERA_NFS_FH_OK ||
+    res.status = chimera_nfs3_decode_fh(req, args->from.dir.data.data, args->from.dir.data.len);
+    if (res.status != NFS3_OK ||
         chimera_nfs_fh_unwrap(args->to.dir.data.data, args->to.dir.data.len,
                               &todir_export_id, req->saved_fh, &req->saved_fhlen,
                               shared->fh_key, shared->fh_sign) != CHIMERA_NFS_FH_OK) {
+        nfsstat3 fh_status = res.status != NFS3_OK ? res.status : NFS3ERR_BADHANDLE;
         memset(&res, 0, sizeof(res));
-        res.status = NFS3ERR_BADHANDLE;
+        res.status = fh_status;
         rc         = shared->nfs_v3.send_reply_NFSPROC3_RENAME(evpl, NULL, &res, req->encoding);
         chimera_nfs_abort_if(rc, "Failed to send RPC2 reply");
         nfs_request_free(thread, req);

--- a/src/server/nfs/nfs3_proc_rmdir.c
+++ b/src/server/nfs/nfs3_proc_rmdir.c
@@ -98,10 +98,11 @@ chimera_nfs3_rmdir(
 
     req->args_rmdir = args;
 
-    if (chimera_nfs_fh_decode(req, args->object.dir.data.data, args->object.dir.data.len,
-                              req->fh, &req->fhlen) != CHIMERA_NFS_FH_OK) {
+    res.status = chimera_nfs3_decode_fh(req, args->object.dir.data.data, args->object.dir.data.len);
+    if (res.status != NFS3_OK) {
+        nfsstat3 fh_status = res.status;
         memset(&res, 0, sizeof(res));
-        res.status = NFS3ERR_BADHANDLE;
+        res.status = fh_status;
         rc         = shared->nfs_v3.send_reply_NFSPROC3_RMDIR(evpl, NULL, &res, req->encoding);
         chimera_nfs_abort_if(rc, "Failed to send RPC2 reply");
         nfs_request_free(thread, req);

--- a/src/server/nfs/nfs3_proc_setattr.c
+++ b/src/server/nfs/nfs3_proc_setattr.c
@@ -157,10 +157,11 @@ chimera_nfs3_setattr(
 
     req->args_setattr = args;
 
-    if (chimera_nfs_fh_decode(req, args->object.data.data, args->object.data.len,
-                              req->fh, &req->fhlen) != CHIMERA_NFS_FH_OK) {
+    res.status = chimera_nfs3_decode_fh(req, args->object.data.data, args->object.data.len);
+    if (res.status != NFS3_OK) {
+        nfsstat3 fh_status = res.status;
         memset(&res, 0, sizeof(res));
-        res.status = NFS3ERR_BADHANDLE;
+        res.status = fh_status;
         rc         = shared->nfs_v3.send_reply_NFSPROC3_SETATTR(evpl, NULL, &res, req->encoding);
         chimera_nfs_abort_if(rc, "Failed to send RPC2 reply");
         nfs_request_free(thread, req);

--- a/src/server/nfs/nfs3_proc_symlink.c
+++ b/src/server/nfs/nfs3_proc_symlink.c
@@ -124,10 +124,11 @@ chimera_nfs3_symlink(
     nfs3_dump_symlink(req, args);
     req->args_symlink = args;
 
-    if (chimera_nfs_fh_decode(req, args->where.dir.data.data, args->where.dir.data.len,
-                              req->fh, &req->fhlen) != CHIMERA_NFS_FH_OK) {
+    res.status = chimera_nfs3_decode_fh(req, args->where.dir.data.data, args->where.dir.data.len);
+    if (res.status != NFS3_OK) {
+        nfsstat3 fh_status = res.status;
         memset(&res, 0, sizeof(res));
-        res.status = NFS3ERR_BADHANDLE;
+        res.status = fh_status;
         rc         = shared->nfs_v3.send_reply_NFSPROC3_SYMLINK(evpl, NULL, &res, req->encoding);
         chimera_nfs_abort_if(rc, "Failed to send RPC2 reply");
         nfs_request_free(thread, req);

--- a/src/server/nfs/nfs3_proc_write.c
+++ b/src/server/nfs/nfs3_proc_write.c
@@ -135,10 +135,11 @@ chimera_nfs3_write(
      */
     evpl_rpc2_encoding_take_read_chunk(req->encoding, NULL, NULL);
 
-    if (chimera_nfs_fh_decode(req, args->file.data.data, args->file.data.len,
-                              req->fh, &req->fhlen) != CHIMERA_NFS_FH_OK) {
+    res.status = chimera_nfs3_decode_fh(req, args->file.data.data, args->file.data.len);
+    if (res.status != NFS3_OK) {
+        nfsstat3 fh_status = res.status;
         memset(&res, 0, sizeof(res));
-        res.status = NFS3ERR_BADHANDLE;
+        res.status = fh_status;
         chimera_nfs3_set_wcc_data(&res.resfail.file_wcc, NULL, NULL);
         rc = shared->nfs_v3.send_reply_NFSPROC3_WRITE(evpl, NULL, &res, req->encoding);
         chimera_nfs_abort_if(rc, "Failed to send RPC2 reply");

--- a/src/server/nfs/nfs3_procs.h
+++ b/src/server/nfs/nfs3_procs.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/server/nfs/nfs3_procs.h
+++ b/src/server/nfs/nfs3_procs.h
@@ -6,6 +6,31 @@
 
 #include "nfs_common.h"
 
+/*
+ * Decode a wire NFSv3 filehandle into req->fh and translate a decode failure to
+ * the appropriate NFSv3 status.  A security-policy rejection -- the request's
+ * RPC auth flavor is not permitted by the target export's sec= list -- maps to
+ * NFS3ERR_ACCES; any other malformed/unrecognized handle stays NFS3ERR_BADHANDLE.
+ * (NFSv3 has no dedicated wrong-security error, unlike NFSv4's NFS4ERR_WRONGSEC,
+ * so a permission error is the closest honest answer.)  Returns NFS3_OK on
+ * success.
+ */
+static inline nfsstat3
+chimera_nfs3_decode_fh(
+    struct nfs_request *req,
+    const void         *fhdata,
+    uint32_t            fhlen)
+{
+    switch (chimera_nfs_fh_decode(req, fhdata, fhlen, req->fh, &req->fhlen)) {
+        case CHIMERA_NFS_FH_OK:
+            return NFS3_OK;
+        case CHIMERA_NFS_FH_WRONGSEC:
+            return NFS3ERR_ACCES;
+        default:
+            return NFS3ERR_BADHANDLE;
+    } /* switch */
+} /* chimera_nfs3_decode_fh */
+
 void chimera_nfs3_null(
     struct evpl               *evpl,
     struct evpl_rpc2_conn     *conn,


### PR DESCRIPTION
> **Draft — stacked on #911.** Depends on the RPCSEC_GSS krb5/krb5i work (#911)
> for the per-export `sec=` policy and the export-id-in-FH infrastructure, and on
> the NFSv3-krb5 test coverage branch for the v3 KVM harness. Against `main` the
> diff therefore also shows those commits; **the gap-specific commits are the last
> two** (the `nfs3:` fix and the `kvm/tests:` deny test). Rebases clean onto `main`
> once #911 lands.

## Gap: NFSv3 returns the wrong status on a `sec=` policy rejection

When an NFSv3 request's RPC auth flavor is not permitted by the target export's
`sec=` list, `chimera_nfs_fh_decode` returns `CHIMERA_NFS_FH_WRONGSEC`, but every
v3 proc collapsed *any* decode failure to `NFS3ERR_BADHANDLE` — so a
wrong-security request looked like a stale/garbage handle rather than a
permission problem (the real Linux client reports "Stale file handle" instead of
"access denied").

NFSv3 has no dedicated wrong-security status (unlike NFSv4's `NFS4ERR_WRONGSEC`),
so this maps the policy rejection to **`NFS3ERR_ACCES`** — the closest honest
answer, and one the client surfaces as "access denied by server". A new
`chimera_nfs3_decode_fh()` helper centralises the decode + status mapping; all 20
v3 procs route their filehandle decode through it (a genuinely malformed/unknown
handle still yields `BADHANDLE`).

## Test

A real-client KVM negative test: restrict the export to `sec=krb5` and attempt a
`vers=3,sec=sys` mount. The client reports "access denied by server" only when
the post-mount probe is answered with `NFS3ERR_ACCES`; the pre-fix `BADHANDLE`
surfaced a different error, so the test **fails without the fix** and pins the
mapping. The kerberos wrapper gains a per-export `sec=` policy knob
(`NFS_EXPORT_SEC`) and an expect-denied mode (`NFS_EXPECT_DENY`).
