### PR TITLE
nfs/nlm: fix NULL-cred crash on lock (open with a system credential)

### DIFF
--- a/kvm/kvm_nfs_kerberos_test_wrapper.sh
+++ b/kvm/kvm_nfs_kerberos_test_wrapper.sh
@@ -228,13 +228,26 @@ done
 # build looks for it at /run/rpc_pipefs.  (init.sh copies the krb5.conf/keytab/
 # hosts material from the 9p share; we start gssd here so the mount path is
 # explicit and correct regardless of the guest's nfs-utils pipefs default.)
-NFS_MOUNT_OPTS="vers=${NFS_VERSION},sec=krb5,tcp"
+# Mount security flavor: krb5 (auth), krb5i (integrity) or krb5p (privacy).
+# Defaults to krb5; a test sets MOUNT_SEC to exercise the integrity/privacy
+# wrapping on the data path.
+NFS_MOUNT_OPTS="vers=${NFS_VERSION},sec=${MOUNT_SEC:-krb5},tcp"
 # Self-contained krb5 client bring-up (does not rely on init.sh's single-shot
 # attempt): set the hostname, then deliver the per-test realm material from the
 # 9p share with a retry loop -- under ctest the 9p backend can race the guest's
 # probe and a one-shot mount silently misses, leaving rpc.gssd without a keytab.
 # Then mount rpc_pipefs (/run is this nfs-utils' default) and (re)start rpc.gssd.
 KRB_PREP="hostname ${CLIENT_HOST} 2>/dev/null; modprobe 9pnet_virtio 2>/dev/null; modprobe 9p 2>/dev/null; for i in 1 2 3 4 5 6 7 8; do [ -s /etc/krb5.keytab ] && break; mkdir -p /mnt/krb; if mount -t 9p -o trans=virtio,version=9p2000.L krbshare /mnt/krb 2>/dev/null; then cp /mnt/krb/krb5.conf /etc/krb5.conf; cp /mnt/krb/krb5.keytab /etc/krb5.keytab; cat /mnt/krb/hosts >> /etc/hosts; umount /mnt/krb; else sleep 1; fi; done; mkdir -p /run/rpc_pipefs; mountpoint -q /run/rpc_pipefs || mount -t rpc_pipefs rpc_pipefs /run/rpc_pipefs; pkill -x rpc.gssd 2>/dev/null; /usr/sbin/rpc.gssd; sleep 1;"
+# NFSv3's kernel mount path wants rpc.statd (NSM) for NLM locking and aborts the
+# mount (rc=32) if it cannot reach it; rpc.statd is not in the test image, so we
+# mount v3 with nolock (the krb5 data path -- MOUNT + portmap + NFS READ/WRITE
+# under RPCSEC_GSS -- is what we are validating; NLM-under-krb5 needs statd in
+# the guest image and is a separate exercise).  NFSv4 needs none of this.
+NFS_NOLOCK=""
+case "${NFS_VERSION}" in
+    3*) NFS_NOLOCK=",nolock" ;;
+esac
+NFS_MOUNT_OPTS="${NFS_MOUNT_OPTS}${NFS_NOLOCK}"
 if [ -n "${KVM_KRB_DEBUG:-}" ]; then
     TEST_CMD="${KRB_PREP} echo '=== keytab ==='; ls -l /etc/krb5.keytab; klist -k /etc/krb5.keytab 2>&1; echo '=== KDC reach ==='; (echo > /dev/tcp/10.0.0.1/${KDC_PORT}) 2>&1 && echo kdc-tcp-ok || echo kdc-tcp-FAIL; echo '=== kinit -k ==='; timeout 10 kinit -k -t /etc/krb5.keytab host/${CLIENT_HOST}@${REALM} 2>&1; echo kinit_rc=\$?; klist 2>&1; echo '=== krb5 mount -v ==='; timeout 25 mount -v -t nfs -o ${NFS_MOUNT_OPTS} ${SERVER_HOST}:/share /mnt 2>&1; echo krb5_rc=\$?"
 else

--- a/kvm/kvm_nfs_kerberos_test_wrapper.sh
+++ b/kvm/kvm_nfs_kerberos_test_wrapper.sh
@@ -239,15 +239,21 @@ NFS_MOUNT_OPTS="vers=${NFS_VERSION},sec=${MOUNT_SEC:-krb5},tcp"
 # Then mount rpc_pipefs (/run is this nfs-utils' default) and (re)start rpc.gssd.
 KRB_PREP="hostname ${CLIENT_HOST} 2>/dev/null; modprobe 9pnet_virtio 2>/dev/null; modprobe 9p 2>/dev/null; for i in 1 2 3 4 5 6 7 8; do [ -s /etc/krb5.keytab ] && break; mkdir -p /mnt/krb; if mount -t 9p -o trans=virtio,version=9p2000.L krbshare /mnt/krb 2>/dev/null; then cp /mnt/krb/krb5.conf /etc/krb5.conf; cp /mnt/krb/krb5.keytab /etc/krb5.keytab; cat /mnt/krb/hosts >> /etc/hosts; umount /mnt/krb; else sleep 1; fi; done; mkdir -p /run/rpc_pipefs; mountpoint -q /run/rpc_pipefs || mount -t rpc_pipefs rpc_pipefs /run/rpc_pipefs; pkill -x rpc.gssd 2>/dev/null; /usr/sbin/rpc.gssd; sleep 1;"
 # NFSv3's kernel mount path wants rpc.statd (NSM) for NLM locking and aborts the
-# mount (rc=32) if it cannot reach it; rpc.statd is not in the test image, so we
-# mount v3 with nolock (the krb5 data path -- MOUNT + portmap + NFS READ/WRITE
-# under RPCSEC_GSS -- is what we are validating; NLM-under-krb5 needs statd in
-# the guest image and is a separate exercise).  NFSv4 needs none of this.
-NFS_NOLOCK=""
+# mount (rc=32) if it cannot reach it.  By default we mount v3 with nolock and
+# validate just the krb5 data path (MOUNT + portmap + NFS READ/WRITE under
+# RPCSEC_GSS).  With NFS_ENABLE_NLM=1 we instead bring up rpcbind + rpc.statd in
+# the guest and mount *with* locking, so a post-mount file lock exercises the NLM
+# (lock-manager) program under RPCSEC_GSS.  NFSv4 needs none of this.
+NFS_NOLOCK=",nolock"
 case "${NFS_VERSION}" in
-    3*) NFS_NOLOCK=",nolock" ;;
+    3*)
+        if [ -n "${NFS_ENABLE_NLM:-}" ]; then
+            NFS_NOLOCK=""
+            KRB_PREP="${KRB_PREP} mkdir -p /run/rpcbind /var/lib/nfs/sm /var/lib/nfs/sm.bak /var/lib/nfs/statd; modprobe lockd 2>/dev/null; /usr/sbin/rpcbind 2>/dev/null; sleep 0.3; /usr/sbin/rpc.statd 2>/dev/null; sleep 0.5;"
+        fi
+        NFS_MOUNT_OPTS="${NFS_MOUNT_OPTS}${NFS_NOLOCK}"
+        ;;
 esac
-NFS_MOUNT_OPTS="${NFS_MOUNT_OPTS}${NFS_NOLOCK}"
 if [ -n "${KVM_KRB_DEBUG:-}" ]; then
     TEST_CMD="${KRB_PREP} echo '=== keytab ==='; ls -l /etc/krb5.keytab; klist -k /etc/krb5.keytab 2>&1; echo '=== KDC reach ==='; (echo > /dev/tcp/10.0.0.1/${KDC_PORT}) 2>&1 && echo kdc-tcp-ok || echo kdc-tcp-FAIL; echo '=== kinit -k ==='; timeout 10 kinit -k -t /etc/krb5.keytab host/${CLIENT_HOST}@${REALM} 2>&1; echo kinit_rc=\$?; klist 2>&1; echo '=== krb5 mount -v ==='; timeout 25 mount -v -t nfs -o ${NFS_MOUNT_OPTS} ${SERVER_HOST}:/share /mnt 2>&1; echo krb5_rc=\$?"
 else

--- a/kvm/tests/CMakeLists.txt
+++ b/kvm/tests/CMakeLists.txt
@@ -271,6 +271,26 @@ foreach(image_spec ${KVM_IMAGES})
         PROPERTIES LABELS "kvm;${IMAGE_NAME};rpcsec_gss" PROCESSORS 2
         SKIP_RETURN_CODE 77)
 
+    # RPCSEC_GSS over NFSv3: the GSS layer lives below the RPC program dispatch,
+    # so krb5/krb5i work for NFSv3 just as for NFSv4 -- this drives a real-client
+    # vers=3 mount through MOUNT + portmap + a directory/file workload (MKDIR,
+    # CREATE, WRITE, READ, RENAME, READDIR, REMOVE) under GSS.  Mounted nolock:
+    # NFSv3's kernel mount wants rpc.statd for NLM, which is not in the image, so
+    # NLM-under-krb5 is out of scope here (the data path is what we validate).
+    # One entry per flavor (krb5 = auth, krb5i = integrity wrapping on v3 I/O).
+    set(KRB_V3_WORKLOAD "stat /mnt && mkdir /mnt/d && echo hello-v3 > /mnt/d/f && grep -q hello-v3 /mnt/d/f && dd if=/dev/zero of=/mnt/d/big bs=4k count=64 2>/dev/null && mv /mnt/d/f /mnt/d/f2 && ls /mnt/d | grep -q f2 && rm /mnt/d/f2 /mnt/d/big && rmdir /mnt/d && echo NFS3_KRB_RW_OK")
+    foreach(krbflavor krb5 krb5i)
+        add_test(NAME chimera/kvm/${IMAGE_NAME}/kerberos/${krbflavor}_mount_memfs_nfs3
+            COMMAND bash ${NFS_KRB_WRAPPER}
+                    ${IMAGE_DIR}/vmlinuz ${IMAGE_DIR}/rootfs.qcow2
+                    ${CHIMERA_BINARY} memfs 3
+                    "${KRB_V3_WORKLOAD}")
+        set_tests_properties(chimera/kvm/${IMAGE_NAME}/kerberos/${krbflavor}_mount_memfs_nfs3
+            PROPERTIES LABELS "kvm;${IMAGE_NAME};rpcsec_gss" PROCESSORS 2
+            SKIP_RETURN_CODE 77
+            ENVIRONMENT "MOUNT_SEC=${krbflavor}")
+    endforeach()
+
     # NFS cthon04 tests
     foreach(nfsver ${NFS_VERSIONS})
         foreach(category ${CTHON_CATEGORIES})

--- a/kvm/tests/CMakeLists.txt
+++ b/kvm/tests/CMakeLists.txt
@@ -291,6 +291,22 @@ foreach(image_spec ${KVM_IMAGES})
             ENVIRONMENT "MOUNT_SEC=${krbflavor}")
     endforeach()
 
+    # NLM (lock manager) under RPCSEC_GSS: bring up rpcbind + rpc.statd in the
+    # guest (NFS_ENABLE_NLM), mount vers=3,sec=krb5 *with* locking, then take an
+    # exclusive file lock -- which routes a krb5-authenticated NLM LOCK to the
+    # server.  The lock-bookkeeping FH open runs with a system credential; before
+    # the fix it passed a NULL cred and crashed the server (NULL deref in the DAC
+    # gate) on engine-DAC backends like memfs.
+    add_test(NAME chimera/kvm/${IMAGE_NAME}/kerberos/krb5_nlm_lock_memfs_nfs3
+        COMMAND bash ${NFS_KRB_WRAPPER}
+                ${IMAGE_DIR}/vmlinuz ${IMAGE_DIR}/rootfs.qcow2
+                ${CHIMERA_BINARY} memfs 3
+                "echo data > /mnt/lf && flock -x /mnt/lf -c 'echo NLM_LOCK_HELD' && echo NFS3_NLM_KRB5_OK")
+    set_tests_properties(chimera/kvm/${IMAGE_NAME}/kerberos/krb5_nlm_lock_memfs_nfs3
+        PROPERTIES LABELS "kvm;${IMAGE_NAME};rpcsec_gss" PROCESSORS 2
+        SKIP_RETURN_CODE 77
+        ENVIRONMENT "NFS_ENABLE_NLM=1")
+
     # NFS cthon04 tests
     foreach(nfsver ${NFS_VERSIONS})
         foreach(category ${CTHON_CATEGORIES})

--- a/src/server/nfs/nfs_nlm.c
+++ b/src/server/nfs/nfs_nlm.c
@@ -16,6 +16,22 @@
 #include "vfs/vfs_release.h"
 #include "vfs/vfs_state.h"
 
+/*
+ * The FH opens below are internal lock-bookkeeping opens (the client already
+ * opened the file via NFS), not user data access, so they run with a system
+ * credential rather than re-evaluating DAC.  AUTH_NONE is the engine's
+ * privileged sentinel: chimera_vfs_gate_needed() short-circuits it, so the open
+ * is not access-gated.  Must be non-NULL -- the gate dereferences cred->flavor
+ * (passing NULL crashes on backends that do not delegate DAC, e.g. memfs).
+ * File-scope const so its lifetime spans the asynchronous open.
+ */
+static const struct chimera_vfs_cred nlm_system_cred = {
+    .flavor = CHIMERA_VFS_AUTH_NONE,
+    .uid    = 0,
+    .gid    = 0,
+    .ngids  = 0,
+};
+
 /* Peer IP of an NLM connection with the ephemeral port stripped, written as a
  * C-string into out (size bytes).  Handles both "ipv4:port" and "[ipv6]:port".
  * Used to record where a lock-holder's statd can be reached (NSM monitor). */
@@ -547,7 +563,7 @@ chimera_nfs_nlm4_do_test(
 
     /* Conflict detection is delegated to vfs_state — the test_open_cb
      * does the lookup and probe synchronously once the FH is validated. */
-    chimera_vfs_open_fh(thread->vfs_thread, NULL,
+    chimera_vfs_open_fh(thread->vfs_thread, &nlm_system_cred,
                         vfh,
                         vfh_len,
                         CHIMERA_VFS_OPEN_INFERRED,
@@ -747,7 +763,7 @@ chimera_nfs_nlm4_do_lock(
         pthread_mutex_unlock(&shared->nlm_state.mutex);
     }
 
-    chimera_vfs_open_fh(thread->vfs_thread, NULL,
+    chimera_vfs_open_fh(thread->vfs_thread, &nlm_system_cred,
                         vfh,
                         vfh_len,
                         CHIMERA_VFS_OPEN_INFERRED,


### PR DESCRIPTION
> **Draft — stacked on #911.** Depends on the RPCSEC_GSS krb5/krb5i work (#911)
> and the NFSv3-krb5 test coverage branch for the v3 KVM harness. Against `main`
> the diff also shows those commits; **the gap-specific commit is the last one**
> (`nfs/nlm: pass a system credential ...`). Sibling of #915 (they share the v3
> coverage base, neither contains the other). Rebases clean onto `main` once #911
> lands.

## Gap: NLM lock crashes the server (NULL cred), found via NLM-under-krb5

While wiring up a Kerberized NFSv3 NLM (lock-manager) test, the server **SIGSEGVs**
the moment a real client takes an NLM lock. Root cause is not krb5-specific:

The NLM `TEST`/`LOCK` handlers open the target filehandle (for vfs_state lock
conflict detection) with a **NULL credential**. `chimera_vfs_gate_needed()`
dereferences `cred->flavor`, so on a backend that does not delegate DAC to the
kernel (`memfs`/`diskfs`/`cairn`) the NULL crashes the server. Passthrough
backends (`linux`/`io_uring`) masked it via the `CHIMERA_VFS_CAP_DELEGATES_DAC`
early-out — which is why it had gone unnoticed.

These opens are internal lock bookkeeping (the client already opened the file
over NFS), not user data access, so they now run with a file-scope **AUTH_NONE
system credential** — the engine's privileged sentinel, which the DAC gate
short-circuits — rather than re-evaluating access. Non-NULL, and `const` so its
lifetime spans the asynchronous open.

## Test

A KVM test brings up `rpcbind` + `rpc.statd` in the guest, mounts
`vers=3,sec=krb5` **with** locking, and takes an exclusive `flock` that drives a
krb5-authenticated NLM `LOCK` to the server (which crashed pre-fix). The wrapper
gains an `NFS_ENABLE_NLM` mode that starts the NSM services and mounts with
locking instead of `nolock`.
