### PR TITLE
smb2/create: AllocationSize reservation, timewarp + bad-context validation

### DIFF
--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -3207,6 +3207,17 @@ chimera_smb_create_issue_open(struct chimera_smb_request *request)
         request->create.set_attr.va_dos_attributes |= SMB2_FILE_ATTRIBUTE_ARCHIVE;
         request->create.set_attr.va_req_mask       |= CHIMERA_VFS_ATTR_DOS_ATTRIBUTES;
         request->create.set_attr.va_set_mask       |= CHIMERA_VFS_ATTR_DOS_ATTRIBUTES;
+
+        /* An AllocationSize create context reserves space for the new (or
+         * overwritten, hence 0-length) file.  Carry it to the backend so the
+         * reservation is reflected in the reported AllocationSize (MS-SMB2
+         * 2.2.13.2 "AlSi"; smb2.create.blob).  Backends that do not persist a
+         * reservation simply ignore the mask. */
+        if (request->create.alsi_alloc_size > 0) {
+            request->create.set_attr.va_alloc_size = request->create.alsi_alloc_size;
+            request->create.set_attr.va_req_mask  |= CHIMERA_VFS_ATTR_ALLOC_SIZE;
+            request->create.set_attr.va_set_mask  |= CHIMERA_VFS_ATTR_ALLOC_SIZE;
+        }
     }
 
     /* Persistent-handle grants are keyed by the base file name; skip them for
@@ -3969,6 +3980,15 @@ chimera_smb_create(struct chimera_smb_request *request)
     request->create.access_retry_oh        = NULL;
     request->create.share_conflict_retries = 0;
     request->create.share_conflict_oh      = NULL;
+
+    /* A TWRP ("@GMT-..." timewarp) create context opens a file as of a VSS
+     * snapshot.  chimera exposes no snapshots, so any non-zero timewarp names a
+     * version that cannot exist -- per MS-SMB2 3.3.5.9 report OBJECT_NAME_NOT_
+     * FOUND rather than silently opening the live file (smb2.create.blob). */
+    if (request->create.twrp_timestamp != 0) {
+        chimera_smb_complete_request(request, SMB2_STATUS_OBJECT_NAME_NOT_FOUND);
+        return;
+    }
 
     /* Handle stream-name syntax (file:stream[:$DATA]).  When named streams are
      * disabled (config off, or the backend lacks the capability) the legacy
@@ -4884,6 +4904,17 @@ chimera_smb_parse_create_contexts(
             return -1;
         }
 
+        /* A create-context name (tag) is a 4-byte identifier.  Windows rejects a
+         * 1-3 byte name as malformed (>=4 is accepted; an unknown 4+ byte tag is
+         * simply ignored).  Fail the whole CREATE with INVALID_PARAMETER, but
+         * gracefully (PARSE_FAILED, not a connection teardown) so the client
+         * gets an in-order error -- smb2.create.blob bad-tag-length 1/2/3. */
+        if (name_len > 0 && name_len < 4) {
+            request->status = SMB2_STATUS_INVALID_PARAMETER;
+            request->flags |= CHIMERA_SMB_REQUEST_FLAG_PARSE_FAILED;
+            return 0;
+        }
+
         if (data_len > 0) {
             if (data_off == 0 || data_off > avail || data_len > avail - data_off) {
                 chimera_smb_error("CREATE-context data out of bounds (pos=%u, data_off=%u, data_len=%u)",
@@ -4990,6 +5021,13 @@ chimera_smb_parse_create(
         request->flags |= CHIMERA_SMB_REQUEST_FLAG_PARSE_FAILED;
         return 0;
     }
+
+    /* Create-context outputs default to "absent".  The request struct is pooled
+     * and reused, and these are only written when their context is present, so
+     * reset them here for every CREATE or a prior request's value would leak
+     * (e.g. a stale TWRP would spuriously fail an unrelated open). */
+    request->create.twrp_timestamp  = 0;
+    request->create.alsi_alloc_size = 0;
 
     /* SMB2 CREATE fixed body (after the already-consumed 2-byte StructureSize):
      * SecurityFlags(1) | RequestedOplockLevel(1) | ImpersonationLevel(4) | ...

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -1120,6 +1120,7 @@ set(SMBTORTURE_ENABLED_memfs
     # smb2.create
     smb2.create.acldir
     smb2.create.aclfile
+    smb2.create.blob
     smb2.create.bench-path-contention-shared
     smb2.create.brlocked
     smb2.create.delete

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -172,6 +172,7 @@ struct memfs_inode {
     uint32_t                   refcnt;
     uint64_t                   size;
     uint64_t                   space_used;
+    uint64_t                   alloc_size;   /* SMB AllocationSize reservation */
     uint32_t                   mode;
     uint32_t                   nlink;
     uint32_t                   uid;
@@ -1317,19 +1318,22 @@ memfs_map_attrs(
     }
 
     if (attr->va_req_mask & CHIMERA_VFS_ATTR_MASK_STAT) {
-        attr->va_set_mask  |= CHIMERA_VFS_ATTR_MASK_STAT;
-        attr->va_mode       = inode->mode;
-        attr->va_nlink      = inode->nlink;
-        attr->va_uid        = inode->uid;
-        attr->va_gid        = inode->gid;
-        attr->va_size       = inode->size;
-        attr->va_space_used = inode->space_used;
-        attr->va_atime      = inode->atime;
-        attr->va_mtime      = inode->mtime;
-        attr->va_ctime      = inode->ctime;
-        attr->va_ino        = inode->inum;
-        attr->va_dev        = (42UL << 32) | 42;
-        attr->va_rdev       = inode->rdev;
+        attr->va_set_mask |= CHIMERA_VFS_ATTR_MASK_STAT;
+        attr->va_mode      = inode->mode;
+        attr->va_nlink     = inode->nlink;
+        attr->va_uid       = inode->uid;
+        attr->va_gid       = inode->gid;
+        attr->va_size      = inode->size;
+        /* Report the larger of real usage and any AllocationSize reservation so
+         * an over-allocated file's AllocationSize reflects the reserved space. */
+        attr->va_space_used = inode->space_used > inode->alloc_size ?
+            inode->space_used : inode->alloc_size;
+        attr->va_atime = inode->atime;
+        attr->va_mtime = inode->mtime;
+        attr->va_ctime = inode->ctime;
+        attr->va_ino   = inode->inum;
+        attr->va_dev   = (42UL << 32) | 42;
+        attr->va_rdev  = inode->rdev;
 
         /* memfs persists DOS attributes, so report them alongside stat. */
         attr->va_set_mask      |= CHIMERA_VFS_ATTR_DOS_ATTRIBUTES;
@@ -1457,6 +1461,19 @@ memfs_apply_attrs(
     if (set_mask & CHIMERA_VFS_ATTR_SIZE) {
         attr->va_set_mask |= CHIMERA_VFS_ATTR_SIZE;
         inode->size        = attr->va_size;
+        /* A reservation only holds while it exceeds the live data; once EOF is
+         * set at/above it the reservation is subsumed and no longer separate. */
+        if (inode->alloc_size <= inode->size) {
+            inode->alloc_size = 0;
+        }
+    }
+
+    if (set_mask & CHIMERA_VFS_ATTR_ALLOC_SIZE) {
+        attr->va_set_mask |= CHIMERA_VFS_ATTR_ALLOC_SIZE;
+        /* Reserve only the part of the allocation beyond the current EOF; a
+         * request at/below EOF is already satisfied by real usage. */
+        inode->alloc_size = attr->va_alloc_size > inode->size ?
+            attr->va_alloc_size : 0;
     }
 
     if (set_mask & CHIMERA_VFS_ATTR_DOS_ATTRIBUTES) {
@@ -1917,19 +1934,22 @@ memfs_mount(
 
     /* Fill in other attrs if requested */
     if (attr->va_req_mask & CHIMERA_VFS_ATTR_MASK_STAT) {
-        attr->va_set_mask  |= CHIMERA_VFS_ATTR_MASK_STAT;
-        attr->va_mode       = inode->mode;
-        attr->va_nlink      = inode->nlink;
-        attr->va_uid        = inode->uid;
-        attr->va_gid        = inode->gid;
-        attr->va_size       = inode->size;
-        attr->va_space_used = inode->space_used;
-        attr->va_atime      = inode->atime;
-        attr->va_mtime      = inode->mtime;
-        attr->va_ctime      = inode->ctime;
-        attr->va_ino        = inode->inum;
-        attr->va_dev        = (42UL << 32) | 42;
-        attr->va_rdev       = inode->rdev;
+        attr->va_set_mask |= CHIMERA_VFS_ATTR_MASK_STAT;
+        attr->va_mode      = inode->mode;
+        attr->va_nlink     = inode->nlink;
+        attr->va_uid       = inode->uid;
+        attr->va_gid       = inode->gid;
+        attr->va_size      = inode->size;
+        /* Report the larger of real usage and any AllocationSize reservation so
+         * an over-allocated file's AllocationSize reflects the reserved space. */
+        attr->va_space_used = inode->space_used > inode->alloc_size ?
+            inode->space_used : inode->alloc_size;
+        attr->va_atime = inode->atime;
+        attr->va_mtime = inode->mtime;
+        attr->va_ctime = inode->ctime;
+        attr->va_ino   = inode->inum;
+        attr->va_dev   = (42UL << 32) | 42;
+        attr->va_rdev  = inode->rdev;
 
         /* memfs persists DOS attributes, so report them alongside stat. */
         attr->va_set_mask      |= CHIMERA_VFS_ATTR_DOS_ATTRIBUTES;

--- a/src/vfs/vfs_attrs.h
+++ b/src/vfs/vfs_attrs.h
@@ -72,6 +72,13 @@ struct chimera_acl;
  * counter simply leave it unset and the NFS server derives change from ctime. */
 #define CHIMERA_VFS_ATTR_CHANGE             (1UL << 25)
 
+/* SMB AllocationSize reservation (va_alloc_size): the minimum allocated size a
+ * file reserves independent of its EOF, set via a CREATE AllocationSize context
+ * or FileAllocationInformation.  Optional: a backend sets this bit in
+ * va_set_mask only if it persists the reservation, and folds it into the
+ * reported va_space_used (max of real usage and the reservation). */
+#define CHIMERA_VFS_ATTR_ALLOC_SIZE         (1UL << 26)
+
 #define CHIMERA_VFS_ATTR_MASK_STAT          ( \
             CHIMERA_VFS_ATTR_DEV | \
             CHIMERA_VFS_ATTR_INUM | \
@@ -169,6 +176,7 @@ struct chimera_vfs_attrs {
     uint64_t            va_rdev;
     uint64_t            va_size;
     uint64_t            va_space_used;
+    uint64_t            va_alloc_size;
     struct timespec     va_atime;
     struct timespec     va_mtime;
     struct timespec     va_ctime;


### PR DESCRIPTION
## Summary

Three `smb2.create` correctness fixes, all surfaced by `smb2.create.blob` (chimera failed at the first and never reached the rest). Greens `smb2.create.blob` on memfs.

### 1. AllocationSize reservation
A CREATE `AlSi` context (and `FileAllocationInformation`) is a *reservation* that may exceed EOF. chimera ignored growth and reported `AllocationSize == 0` for a freshly-allocated empty file. Added an optional `va_alloc_size` VFS attr (`CHIMERA_VFS_ATTR_ALLOC_SIZE`):
- memfs persists the reservation and folds it into reported space-used (`max(real, reservation)`), dropping it once EOF reaches/exceeds it.
- the CREATE path forwards the context's size to the backend.
- backends that don't persist a reservation ignore the mask (test enabled on **memfs only** for now).

### 2. Timewarp (`@GMT` / TWRP context)
Opens a file as of a VSS snapshot. chimera exposes no snapshots but was silently opening the **live** file. Per MS-SMB2 3.3.5.9 any non-zero timewarp now returns `OBJECT_NAME_NOT_FOUND`.

### 3. Create-context name-length validation
A context tag is a 4-byte identifier; a 1-3 byte name is malformed → `INVALID_PARAMETER` (≥4, including unknown tags, is accepted). chimera accepted the short names. Reported gracefully (`PARSE_FAILED`, no connection teardown).

Also resets the per-request `twrp_timestamp` / `alsi_alloc_size` at parse time — the request struct is pooled and these are written only when their context is present, so a stale value could leak into an unrelated open.

## Scope note
The disabled `create`/`timestamps` tests are mostly deep features — security-descriptor enforcement (`nulldacl`, `mkdir-visible`), exhaustive access-mask compliance (`gentest`), NTFS quota pseudo-files (`quota-fake-file`), and passthrough write-time/btime semantics (the linux/io_uring `timestamps` set). `blob` was the one with a bounded, self-contained path to green. `FileAllocationInformation` *growth* via setinfo (currently truncate-only) is left as a follow-up — this PR covers the create path.

## Verification
- `smb2.create.blob` 3× green on memfs, clean under ASan.
- Full `smb2.create.*` suite green on **all six** backends (zero regressions); `getinfo`/`qfileinfo`/`ioctl.sparse` unaffected (the space-used fold is a no-op unless an allocation was explicitly set).
- `-Werror` release + debug clean; scan-build clean; `make syntax`, copyright-year clean.