### PR TITLE
ci: split the kvm-nfstest job into three suite shards

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -765,7 +765,7 @@ jobs:
       matrix:
         arch: [amd64, arm64]
         build_type: [Release, Debug]
-        category: [pynfs, smbtorture, wpts, posix-client, pjdfstest, s3, ceph-s3, client, unit, kvm-cthon, kvm-xfsprogs, kvm-pnfs, kvm-nfstest, kvm-ltp]
+        category: [pynfs, smbtorture, wpts, posix-client, pjdfstest, s3, ceph-s3, client, unit, kvm-cthon, kvm-xfsprogs, kvm-pnfs, kvm-nfstest-lock, kvm-nfstest-dio, kvm-nfstest-rest, kvm-ltp]
         include:
           - { arch: amd64, runner: arc-amd64 }
           - { arch: arm64, runner: arc-arm64 }
@@ -774,7 +774,9 @@ jobs:
           - { arch: arm64, category: kvm-cthon }
           - { arch: arm64, category: kvm-xfsprogs }
           - { arch: arm64, category: kvm-pnfs }
-          - { arch: arm64, category: kvm-nfstest }
+          - { arch: arm64, category: kvm-nfstest-lock }
+          - { arch: arm64, category: kvm-nfstest-dio }
+          - { arch: arm64, category: kvm-nfstest-rest }
           - { arch: arm64, category: kvm-ltp }
           # WPTS (Microsoft Protocol Test Suite) is not supported on arm64 —
           # the shard would only skip every test, so don't run it at all.
@@ -830,7 +832,14 @@ jobs:
                 kvm-cthon)    SEL="-L kvm -R /cthon/";    NEED_KVM=1 ;;
                 kvm-xfsprogs) SEL="-L kvm -R /xfstests/"; NEED_KVM=1 ;;
                 kvm-pnfs)     SEL="-L pnfs";              NEED_KVM=1 ;;
-                kvm-nfstest)  SEL="-L kvm -R /nfstest/";  NEED_KVM=1 ;;
+                # nfstest is the test long-pole; split by suite so each shard
+                # lands on its own runner.  lock isolates the single longest
+                # test (nfstest_lock_*_linux), dio the next-heaviest family, and
+                # rest is everything else.  Keep these three collectively exact
+                # to "-L kvm -R /nfstest/" so no nfstest test is dropped.
+                kvm-nfstest-lock) SEL="-L kvm -R nfstest_lock_";                    NEED_KVM=1 ;;
+                kvm-nfstest-dio)  SEL="-L kvm -R nfstest_dio_";                     NEED_KVM=1 ;;
+                kvm-nfstest-rest) SEL="-L kvm -R /nfstest/ -E nfstest_(lock|dio)_"; NEED_KVM=1 ;;
                 kvm-ltp)      SEL="-L kvm -R /ltp/";      NEED_KVM=1 ;;
               esac
               if [ -n "$NEED_KVM" ]; then


### PR DESCRIPTION
## Why

`kvm-nfstest` is the long pole of the merge-queue test matrix — **~26.5 min (Release) / ~22.9 min (Debug)**, ~2.5× the next job (smbtorture ~11 min). It runs as a single ctest invocation (`-L kvm -R /nfstest/`, 106 tests, ~15,000 test-seconds) on one runner.

The work is concentrated in two families:

| family | tests | total | max test |
|---|---|---|---|
| **nfstest_lock** | 12 | 5029 s (33%) | **566 s** (the floor) |
| **nfstest_dio** | 12 | 3809 s (25%) | 319 s |
| everything else | ~82 | ~6400 s | — |

## What

The test job is already a `category` matrix where each category is a ctest selector. This splits the one `kvm-nfstest` category into three, so each suite runs on its **own runner** instead of contending for cores on a single box:

```bash
kvm-nfstest-lock) SEL="-L kvm -R nfstest_lock_"                    # isolates the floor
kvm-nfstest-dio)  SEL="-L kvm -R nfstest_dio_"
kvm-nfstest-rest) SEL="-L kvm -R /nfstest/ -E nfstest_(lock|dio)_" # everything else
```

The three selectors **partition the suite exactly** — `lock + dio + rest` equals `-L kvm -R /nfstest/` with no overlap and nothing dropped (verified with `ctest -N`: all=52 = 6+6+40 locally; 2× in CI).

**Expected wall: ~26.5 → ~9–10 min**, balanced roughly lock ≈ 9.4 min, dio ≈ 5.5 min, rest ≈ 7–8 min.

## Why by-suite (not by-kernel)

Splitting by distro (2404/2604) only gets ~13 min, because both heavy families run on **both** kernels, so each kernel-shard still carries a 566 s lock test. By suite, the lock floor lands in one shard and the rest finish well under it.

## Safety

Fully self-contained: `ci-complete` (`needs: [test-dev]`) and the report / flake-gate jobs match shards generically (`ctest-junit-*` / `flaky-marker-*` artifacts keyed on `${{ matrix.category }}`), so the new shard names flow through automatically. Only the arm64 `exclude:` list needed the rename. Cost: each KVM shard re-runs the image fetch (`ninja kvm_*_image`) — 3× instead of 1×, in parallel.

## Follow-up (not in this PR)

The ~9.4 min floor is one test (`nfstest_lock_*_linux`). To go below it, subtest-shard `nfstest_lock` via the wrapper's `--runtest` (split its 5296 subtests into ranges) — complementary to this change.