### PR TITLE
memfs: enforce parent-directory DACL on SMB file create

### DIFF
--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -1300,6 +1300,7 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.create.impersonation
     smb2.create.leading-slash
     smb2.create.mkdir-dup
+    smb2.create.mkdir-visible
     smb2.create.multi
     smb2.create.open
     smb2.create.path-length

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -2794,17 +2794,28 @@ memfs_open_at(
             return;
         }
 
-        /* Creating a new file requires add-file (WRITE_DATA) + search (EXECUTE)
-         * permission on the parent directory.  On the NFSv4/Windows ACL model
-         * WRITE_DATA == ADD_FILE and APPEND_DATA == ADD_SUBDIRECTORY, so a plain
-         * file create is gated by WRITE_DATA (mkdir, which adds a subdirectory,
-         * is gated by APPEND_DATA in the VFS-core mkdir_at path).  Enforce POSIX
-         * semantics for AUTH_UNIX callers (root is exempt); SMB/ACL (AUTH_ATTR)
-         * callers are authorized by the engine. */
+        /* Creating a new file requires add-file permission on the parent
+         * directory.  On the NFSv4/Windows ACL model WRITE_DATA == ADD_FILE and
+         * APPEND_DATA == ADD_SUBDIRECTORY, so a plain file create is gated by
+         * WRITE_DATA (mkdir, which adds a subdirectory, is gated by APPEND_DATA in
+         * the VFS-core mkdir_at path).  The required parent access differs by
+         * credential model: AUTH_UNIX (POSIX, root exempt) needs write + search
+         * (WRITE_DATA | EXECUTE) on the directory; AUTH_ATTR (SMB/Windows) checks
+         * ADD_FILE (WRITE_DATA) only -- traverse (EXECUTE) is bypassed by default
+         * on Windows (SeChangeNotifyPrivilege), so a directory whose DACL grants
+         * ADD_FILE without EXECUTE must still permit the create (smb2.acls.DYNAMIC),
+         * while an explicit deny-ADD_FILE ace still blocks it (smb2.create.mkdir-visible). */
+        uint32_t create_access = 0;
+
         if (request->cred->flavor == CHIMERA_VFS_AUTH_UNIX &&
-            request->cred->uid != 0 &&
-            !memfs_inode_access(parent_inode, request->cred,
-                                CHIMERA_ACE_WRITE_DATA | CHIMERA_ACE_EXECUTE)) {
+            request->cred->uid != 0) {
+            create_access = CHIMERA_ACE_WRITE_DATA | CHIMERA_ACE_EXECUTE;
+        } else if (request->cred->flavor == CHIMERA_VFS_AUTH_ATTR) {
+            create_access = CHIMERA_ACE_WRITE_DATA;
+        }
+
+        if (create_access &&
+            !memfs_inode_access(parent_inode, request->cred, create_access)) {
             pthread_mutex_unlock(&parent_inode->lock);
             request->status = CHIMERA_VFS_EACCES;
             request->complete(request);


### PR DESCRIPTION
## Summary

Enforce a directory's DACL on SMB file creation — chimera advertised and stored security descriptors but never enforced an explicit *deny* on create.

memfs already gates a create on the parent directory's add-file (`WRITE_DATA`) + search (`EXECUTE`) permission through the shared canonical access engine (`chimera_vfs_access_check`), but **only for `AUTH_UNIX` callers**. SMB (`AUTH_ATTR`) creates were exempted, so a directory whose DACL explicitly denies `FILE_ADD_FILE` still accepted new files over SMB. This runs the same engine check for `AUTH_ATTR` creates: the SMB credential carries the authenticated user's identity and the engine evaluates the parent's stored ACL, where a deny ACE wins over the owner-implicit grant (Windows semantics).

Greens **`smb2.create.mkdir-visible`** on memfs (sets a WORLD deny `ADD_FILE` ACE on a directory, then expects a subsequent create to fail `ACCESS_DENIED`).

## Scope
- **memfs only.** The change is in `memfs_open_at`; cairn/diskfs store ACLs too and could adopt the same one-line gate in a follow-up, and the linux/io_uring passthrough enforces via the real FS. mkdir-visible is enabled on memfs.
- Directory-create (`mkdir_at`) enforcement and NULL-DACL round-trip fidelity (`smb2.create.nulldacl`, which needs an ACL-model "null DACL" state distinct from "no ACEs") are separate follow-ups — this PR is the file-create enforcement path.

## Verification
- `smb2.create.mkdir-visible` green on memfs, clean under ASan.
- Full `smb2.create.*` suite + a broad sample of the file-creating suites (oplock, lease, streams, durable-open, set/getinfo, ioctl, rename, delete-on-close) stay green on memfs — the gate denies only an explicit deny ACE; normal creates (the SMB user owns its directories) are unaffected.
- NFS unaffected (unchanged `AUTH_UNIX` path).
- scan-build clean; `make syntax`, copyright-year clean.