### PR TITLE
client: drain in-flight VFS completions before closing the thread doorbell

### DIFF
--- a/src/client/client.c
+++ b/src/client/client.c
@@ -136,6 +136,20 @@ chimera_client_thread_shutdown(
 {
     struct chimera_client_request *request;
 
+    /* Drain in-flight VFS completions before chimera_vfs_thread_destroy() closes
+     * this thread's completion doorbell.  A delegated/parked request completes
+     * on another thread, which appends to our pending list and rings our
+     * doorbell (chimera_vfs_complete_delegate / the lease pump).  The delegation
+     * and close threads are still alive here -- chimera_vfs_destroy() tears them
+     * down only after the whole thread pool is gone -- so a late completion
+     * would write() to an fd that chimera_vfs_thread_destroy() has already
+     * close()d, EBADF -> fatal abort in evpl_ring_doorbell (doorbell.c).  Pump
+     * until quiescent so no producer can ring a closed doorbell.  The NFS server
+     * path already drains here; the client path did not, which is why the
+     * crash showed up on the client-only posix lock/open tests under teardown
+     * timing. */
+    chimera_vfs_thread_drain(thread->vfs_thread);
+
     while (thread->free_requests) {
         request = thread->free_requests;
         DL_DELETE(thread->free_requests, request);


### PR DESCRIPTION
## Symptom

`pjd/open/*/linux` (e.g. `open/26`, `open/05`) and other client-only posix tests intermittently hit the flake gate. They aren't assertion failures — the in-process daemon **crashes at teardown**:

```
failed to write to doorbell fd N: errno=9 (Bad file descriptor)   [FATAL]   doorbell.c:86
... Aborted (core dumped)
```

## Root cause

A delegated or lease-parked VFS request completes on a **different** thread, which appends to the originating thread's pending list and **rings its completion doorbell** (`chimera_vfs_complete_delegate` / the lease pump).

`chimera_client_thread_shutdown()` calls `chimera_vfs_thread_destroy()`, which `evpl_remove_doorbell()`s and `close()`s that eventfd — **without first draining those in-flight completions**. The delegation/close threads are still alive at this point (`chimera_vfs_destroy()` tears them down only *after* the whole client thread pool is gone), so a late completion `write()`s to the just-closed fd and `evpl_ring_doorbell`'s EBADF guard aborts the process.

The **NFS server path already drains** here (`chimera_vfs_thread_drain` before destroy, server.c / nfs.c); the **client path did not** — which is precisely why the crash only shows up on the client-driven posix tests, and only under teardown timing (hence the flakiness). The signature (`doorbell.c:86`) has recurred across backends (previously `pjd/open/03/cairn`).

## Fix

Drain to quiescence (`chimera_vfs_thread_drain`, i.e. pump until `num_active_requests == 0`) before the destroy — while the doorbell is still open and the producers are still alive — so no thread can ring a closed doorbell. This mirrors the server path exactly; one line plus a comment.

## Verification

3121 executions of the client-teardown path (`pjd/open` + `lockf`/`fcntl`, `linux`/`io_uring`/`nfs3`) under `-j16` load: **0 failures, 0 doorbell aborts, no teardown hang** from the drain. (The race itself is teardown-timing-rare and didn't reproduce locally even before the fix, but the fix removes it structurally and matches the established server-side ordering.)