### PR TITLE
smb2: reject/disconnect on invalid credit requests per MS-SMB2 3.3.5.2

### DIFF
--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -1324,6 +1324,43 @@ chimera_smb_server_handle_smb2(
                                &request->request_struct_size,
                                sizeof(request->request_struct_size));
 
+        /* Validate the request's MessageId / CreditCharge against
+         * Connection.CommandSequenceWindow (MS-SMB2 3.3.5.2.3).  Every command
+         * consumes max(CreditCharge, 1) MessageIds from the window; if the range
+         * is not currently granted-and-unconsumed -- a MessageId the client has
+         * already used, or one beyond the credits the server has granted (the
+         * model's UsedMid / UnavailableMid cases, and a multi-credit
+         * CreditCharge that exceeds the window's remaining width) -- the server
+         * SHOULD terminate the connection rather than process it.  SMB2_CANCEL is
+         * exempt: it reuses the MessageId of an in-flight request and does not
+         * consume a new sequence number (MS-SMB2 3.3.5.16). */
+        if (likely(request->smb2_hdr.command != SMB2_CANCEL)) {
+            /* The window consumes CreditCharge MessageIds only when
+             * Connection.SupportsMultiCredit is TRUE (dialect 2.1 / 3.x).  On
+             * SMB 2.0.2 the CreditCharge field is reserved and each request
+             * consumes exactly one sequence number regardless of its value
+             * (MS-SMB2 3.1.5.2 / 3.3.5.2.3); treating it otherwise would
+             * spuriously reject a valid 2.0.2 request whose header happens to
+             * carry a non-zero CreditCharge. */
+            uint32_t charge =
+                (conn->dialect >= SMB2_DIALECT_2_1 &&
+                 request->smb2_hdr.credit_charge) ?
+                request->smb2_hdr.credit_charge : 1;
+
+            if (unlikely(chimera_smb_seq_window_consume(conn,
+                                                        request->smb2_hdr.message_id,
+                                                        charge) != 0)) {
+                chimera_smb_error(
+                    "SMB2 request MessageId %lu (CreditCharge %u) outside the "
+                    "command sequence window [%lu, %lu); closing connection",
+                    request->smb2_hdr.message_id, charge,
+                    conn->seq_low, conn->seq_high);
+                chimera_smb_request_free(thread, request);
+                evpl_close(evpl, conn->bind);
+                return;
+            }
+        }
+
         /* Validate the compound chain link before anything trusts it -- the
          * per-element cursor window, the signing payload length, and the skip to
          * the next element all derive from NextCommand.  When present it must be
@@ -1661,6 +1698,42 @@ chimera_smb_server_handle_smb2(
                 request->status = SMB2_STATUS_NOT_IMPLEMENTED;
                 rc              = 0;
         } /* switch */
+
+        /* MS-SMB2 3.3.5.2.5: when Connection.SupportsMultiCredit is TRUE (the
+         * negotiated dialect is 2.1 or a 3.x family member) the server MUST
+         * verify the request's CreditCharge against the payload size of the
+         * operation (here a READ or WRITE data length).  Compute the credits the
+         * operation actually requires -- one per 64 KiB started (3.1.5.2) -- and
+         * fail the request with STATUS_INVALID_PARAMETER if the client charged
+         * fewer: a CreditCharge of zero for a payload over 64 KiB, or a non-zero
+         * CreditCharge smaller than the calculated number.  A normal small
+         * operation needs one credit, so any CreditCharge >= 1 (or 0 for <= 64
+         * KiB) passes untouched. */
+        if (rc == 0 && conn->dialect >= SMB2_DIALECT_2_1 &&
+            (request->smb2_hdr.command == SMB2_READ ||
+             request->smb2_hdr.command == SMB2_WRITE)) {
+            uint32_t payload = request->smb2_hdr.command == SMB2_READ ?
+                request->read.length : request->write.length;
+            uint16_t charge        = request->smb2_hdr.credit_charge;
+            int      charge_failed = 0;
+
+            if (charge == 0) {
+                charge_failed = payload > 65536;
+            } else {
+                uint32_t need = payload ? (payload - 1) / 65536 + 1 : 1;
+
+                charge_failed = need > charge;
+            }
+
+            if (unlikely(charge_failed)) {
+                /* Fail the request itself (not the connection) -- the model and
+                 * MS-SMB2 expect the error reply, with the connection left up. */
+                request->status                              = SMB2_STATUS_INVALID_PARAMETER;
+                request->flags                              |= CHIMERA_SMB_REQUEST_FLAG_PARSE_FAILED;
+                compound->requests[compound->num_requests++] = request;
+                goto next_compound_request;
+            }
+        }
 
         compound->requests[compound->num_requests++] = request;
 
@@ -2357,6 +2430,14 @@ chimera_smb_server_accept(
     conn->requests_completed = 0;
     conn->async_outstanding  = 0;
     conn->credits_balance    = 0;
+    /* Connection.CommandSequenceWindow starts holding exactly MessageId 0 -- the
+     * one implicit credit a client may use for its first request (NEGOTIATE)
+     * before any credits are granted (MS-SMB2 3.3.1.1).  Each credit granted in a
+     * response extends the window (chimera_smb_grant_credits). */
+    conn->seq_low  = 0;
+    conn->seq_high = 1;
+    memset(conn->seq_bitmap, 0, sizeof(conn->seq_bitmap));
+    conn->seq_bitmap[0] = 1ULL;
 
     evpl_bind_get_local_address(bind, conn->local_addr, sizeof(conn->local_addr));
     evpl_bind_get_remote_address(bind, conn->remote_addr, sizeof(conn->remote_addr));

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -1078,6 +1078,16 @@ struct chimera_smb_notify_request;
 
 #define CHIMERA_SMB_RPC_MAX_HANDLES                 16
 
+/* Ceiling on the credit balance the server will let a single connection
+ * accumulate.  A response grants the credits the client asked for, but never so
+ * many that the client's balance would exceed this -- otherwise a client that
+ * keeps requesting more (smb2.credits async flood requests 1,2,3,...) would
+ * overflow its 16-bit credit window and fault the connection.  Matches Samba's
+ * default `smb2 max credits`; the credits.c tests require >= 8192 grantable.
+ * Defined here (ahead of struct chimera_smb_conn) because the connection's
+ * sequence-window bitmap is sized to it. */
+#define CHIMERA_SMB_MAX_CREDITS                     8192
+
 struct chimera_smb_conn {
     OM_uint32                          gss_major;
     OM_uint32                          gss_minor;
@@ -1214,6 +1224,20 @@ struct chimera_smb_conn {
      * that keeps requesting more (e.g. the smb2.credits async flood) cannot
      * overflow its 16-bit credit window.  See chimera_smb_grant_credits. */
     uint32_t                           credits_balance;
+    /* Connection.CommandSequenceWindow (MS-SMB2 3.3.1.1).  The set of MessageIds
+     * the server has granted credits for and the client has not yet consumed,
+     * tracked as a sliding bitmap based at seq_low: bit i set means MessageId
+     * (seq_low + i) is granted-and-unconsumed.  seq_high is one past the highest
+     * MessageId ever granted (every credit granted in a response extends it).
+     * Used by chimera_smb_seq_window_consume to reject a request whose
+     * MessageId range falls outside the window (already used, or never granted),
+     * which MS-SMB2 3.3.5.2.3 requires the server to terminate the connection
+     * for.  Capped at CHIMERA_SMB_MAX_CREDITS outstanding ids (the same ceiling
+     * credits_balance is clamped to), so the bitmap is fixed-size.  Only touched
+     * on the conn's owning SMB thread. */
+    uint64_t                           seq_low;
+    uint64_t                           seq_high;
+    uint64_t                           seq_bitmap[CHIMERA_SMB_MAX_CREDITS / 64];
     struct chimera_server_smb_thread  *thread;
     struct evpl_bind                  *bind;
     struct chimera_smb_conn           *prev;
@@ -1228,14 +1252,6 @@ struct chimera_smb_conn {
     char                               remote_addr[128];
 };
 
-/* Ceiling on the credit balance the server will let a single connection
- * accumulate.  A response grants the credits the client asked for, but never so
- * many that the client's balance would exceed this -- otherwise a client that
- * keeps requesting more (smb2.credits async flood requests 1,2,3,...) would
- * overflow its 16-bit credit window and fault the connection.  Matches Samba's
- * default `smb2 max credits`; the credits.c tests require >= 8192 grantable. */
-#define CHIMERA_SMB_MAX_CREDITS 8192
-
 /*
  * Compute the SMB2 CreditResponse for one response and update the connection's
  * running estimate of the client's credit balance.
@@ -1247,6 +1263,77 @@ struct chimera_smb_conn {
  * below CHIMERA_SMB_MAX_CREDITS, and never zero while the client holds none (so
  * the window cannot collapse).  Single-threaded on the conn's SMB thread.
  */
+/* Mark MessageId `mid` as granted-and-unconsumed in the connection's sequence
+ * window bitmap (see seq_bitmap above).  `mid` must be in [seq_low, seq_high). */
+static inline void
+chimera_smb_seq_window_set(
+    struct chimera_smb_conn *conn,
+    uint64_t                 mid)
+{
+    uint64_t off = mid - conn->seq_low;
+
+    conn->seq_bitmap[off >> 6] |= (1ULL << (off & 63));
+} /* chimera_smb_seq_window_set */
+
+/* Slide the sequence-window base forward over any leading consumed (cleared)
+ * bits, so the bitmap stays anchored at the lowest still-granted MessageId and
+ * the window width never exceeds the granted-credit ceiling. */
+static inline void
+chimera_smb_seq_window_slide(struct chimera_smb_conn *conn)
+{
+    while (conn->seq_low < conn->seq_high && !(conn->seq_bitmap[0] & 1ULL)) {
+        /* Lowest bit is clear (that MessageId was consumed) -- drop it by
+         * shifting the whole bitmap down one and advancing the base. */
+        for (int i = 0; i < CHIMERA_SMB_MAX_CREDITS / 64; i++) {
+            uint64_t next = (i + 1 < CHIMERA_SMB_MAX_CREDITS / 64) ?
+                conn->seq_bitmap[i + 1] : 0;
+
+            conn->seq_bitmap[i] = (conn->seq_bitmap[i] >> 1) | (next << 63);
+        }
+        conn->seq_low++;
+    }
+} /* chimera_smb_seq_window_slide */
+
+/*
+ * Validate and consume a request's MessageId range against the connection's
+ * sequence window (MS-SMB2 3.3.5.2.3 / 3.3.1.1).  `mid` is the request's
+ * MessageId and `charge` its effective CreditCharge (>= 1).  Returns 0 if the
+ * full range [mid, mid+charge) is currently granted-and-unconsumed (the bits are
+ * then cleared); returns -1 if any MessageId in the range is already consumed
+ * (below the window / cleared) or has never been granted (at or beyond
+ * seq_high) -- an invalid identifier the caller must terminate the connection
+ * for.  Single-threaded on the conn's owning SMB thread.
+ */
+static inline int
+chimera_smb_seq_window_consume(
+    struct chimera_smb_conn *conn,
+    uint64_t                 mid,
+    uint32_t                 charge)
+{
+    uint64_t m;
+
+    if (mid < conn->seq_low || mid + charge > conn->seq_high) {
+        return -1;
+    }
+
+    for (m = mid; m < mid + charge; m++) {
+        uint64_t off = m - conn->seq_low;
+
+        if (!(conn->seq_bitmap[off >> 6] & (1ULL << (off & 63)))) {
+            return -1;
+        }
+    }
+
+    for (m = mid; m < mid + charge; m++) {
+        uint64_t off = m - conn->seq_low;
+
+        conn->seq_bitmap[off >> 6] &= ~(1ULL << (off & 63));
+    }
+
+    chimera_smb_seq_window_slide(conn);
+    return 0;
+} /* chimera_smb_seq_window_consume */
+
 static inline uint16_t
 chimera_smb_grant_credits(
     struct chimera_smb_conn *conn,
@@ -1266,6 +1353,21 @@ chimera_smb_grant_credits(
     }
 
     conn->credits_balance = bal + grant;
+
+    /* Extend Connection.CommandSequenceWindow by the granted credits: each new
+     * credit makes one more MessageId (seq_high, seq_high+1, ...) valid for a
+     * future request (MS-SMB2 3.3.1.1).  Guarded against the bitmap width -- the
+     * balance clamp above keeps the unconsumed window within the ceiling, but
+     * slide first to reclaim space from anything already consumed. */
+    chimera_smb_seq_window_slide(conn);
+    for (uint32_t i = 0; i < grant; i++) {
+        if (conn->seq_high - conn->seq_low >= CHIMERA_SMB_MAX_CREDITS) {
+            break;
+        }
+        chimera_smb_seq_window_set(conn, conn->seq_high);
+        conn->seq_high++;
+    }
+
     return (uint16_t) grant;
 } /* chimera_smb_grant_credits */
 

--- a/src/server/smb/tests/wpts/smb2model_cases.csv
+++ b/src/server/smb/tests/wpts/smb2model_cases.csv
@@ -544,38 +544,38 @@ CreditMgmtTestCaseS1066,base,green,0,
 CreditMgmtTestCaseS1080,base,green,0,
 CreditMgmtTestCaseS1094,base,green,0,
 CreditMgmtTestCaseS1110,base,green,0,
-CreditMgmtTestCaseS1124,base,xfail,0,executed but fails (candidate defect)
-CreditMgmtTestCaseS1147,base,xfail,0,executed but fails (candidate defect)
-CreditMgmtTestCaseS1168,base,xfail,0,executed but fails (candidate defect)
-CreditMgmtTestCaseS1182,base,xfail,0,executed but fails (candidate defect)
-CreditMgmtTestCaseS1199,base,xfail,0,executed but fails (candidate defect)
-CreditMgmtTestCaseS121,base,xfail,0,executed but fails (candidate defect)
-CreditMgmtTestCaseS1217,base,xfail,0,executed but fails (candidate defect)
-CreditMgmtTestCaseS1225,base,xfail,0,executed but fails (candidate defect)
-CreditMgmtTestCaseS1233,base,xfail,0,executed but fails (candidate defect)
-CreditMgmtTestCaseS1241,base,xfail,0,executed but fails (candidate defect)
-CreditMgmtTestCaseS1249,base,xfail,0,executed but fails (candidate defect)
-CreditMgmtTestCaseS1257,base,xfail,0,executed but fails (candidate defect)
+CreditMgmtTestCaseS1124,base,green,0,
+CreditMgmtTestCaseS1147,base,green,0,
+CreditMgmtTestCaseS1168,base,green,0,
+CreditMgmtTestCaseS1182,base,green,0,
+CreditMgmtTestCaseS1199,base,green,0,
+CreditMgmtTestCaseS121,base,green,0,
+CreditMgmtTestCaseS1217,base,green,0,
+CreditMgmtTestCaseS1225,base,green,0,
+CreditMgmtTestCaseS1233,base,green,0,
+CreditMgmtTestCaseS1241,base,green,0,
+CreditMgmtTestCaseS1249,base,green,0,
+CreditMgmtTestCaseS1257,base,green,0,
 CreditMgmtTestCaseS151,base,green,0,
-CreditMgmtTestCaseS185,base,xfail,0,executed but fails (candidate defect)
+CreditMgmtTestCaseS185,base,green,0,
 CreditMgmtTestCaseS216,base,green,0,
 CreditMgmtTestCaseS248,base,green,0,
 CreditMgmtTestCaseS276,base,green,0,
-CreditMgmtTestCaseS300,base,xfail,0,executed but fails (candidate defect)
+CreditMgmtTestCaseS300,base,green,0,
 CreditMgmtTestCaseS325,base,green,0,
-CreditMgmtTestCaseS349,base,xfail,0,executed but fails (candidate defect)
-CreditMgmtTestCaseS397,base,xfail,0,executed but fails (candidate defect)
-CreditMgmtTestCaseS435,base,xfail,0,executed but fails (candidate defect)
+CreditMgmtTestCaseS349,base,green,0,
+CreditMgmtTestCaseS397,base,green,0,
+CreditMgmtTestCaseS435,base,green,0,
 CreditMgmtTestCaseS462,base,green,0,
-CreditMgmtTestCaseS492,base,xfail,0,executed but fails (candidate defect)
+CreditMgmtTestCaseS492,base,green,0,
 CreditMgmtTestCaseS520,base,green,0,
 CreditMgmtTestCaseS552,base,green,0,
 CreditMgmtTestCaseS578,base,green,0,
 CreditMgmtTestCaseS602,base,green,0,
-CreditMgmtTestCaseS627,base,xfail,0,executed but fails (candidate defect)
-CreditMgmtTestCaseS63,base,xfail,0,executed but fails (candidate defect)
-CreditMgmtTestCaseS681,base,xfail,0,executed but fails (candidate defect)
-CreditMgmtTestCaseS717,base,xfail,0,executed but fails (candidate defect)
+CreditMgmtTestCaseS627,base,green,0,
+CreditMgmtTestCaseS63,base,green,0,
+CreditMgmtTestCaseS681,base,green,0,
+CreditMgmtTestCaseS717,base,green,0,
 CreditMgmtTestCaseS748,base,green,0,
 CreditMgmtTestCaseS776,base,green,0,
 CreditMgmtTestCaseS801,base,green,0,
@@ -583,10 +583,10 @@ CreditMgmtTestCaseS836,base,green,0,
 CreditMgmtTestCaseS861,base,green,0,
 CreditMgmtTestCaseS885,base,green,0,
 CreditMgmtTestCaseS909,base,green,0,
-CreditMgmtTestCaseS933,base,xfail,0,executed but fails (candidate defect)
-CreditMgmtTestCaseS959,base,xfail,0,executed but fails (candidate defect)
-CreditMgmtTestCaseS978,base,xfail,0,executed but fails (candidate defect)
-CreditMgmtTestCaseS997,base,xfail,0,executed but fails (candidate defect)
+CreditMgmtTestCaseS933,base,green,0,
+CreditMgmtTestCaseS959,base,green,0,
+CreditMgmtTestCaseS978,base,green,0,
+CreditMgmtTestCaseS997,base,green,0,
 DurableHandleV1PreparedWithBatchOplockReconnectTestCaseS0,base,green,0,
 DurableHandleV1PreparedWithBatchOplockReconnectTestCaseS109,persistent,green,0,
 DurableHandleV1PreparedWithBatchOplockReconnectTestCaseS125,persistent,green,0,

--- a/src/vfs/smb/smb_io.c
+++ b/src/vfs/smb/smb_io.c
@@ -202,6 +202,21 @@ chimera_smb_read_send_chunk(
 
     chimera_smb_client_pdu_begin(conn, SMB2_READ, &iov, &cursor, &hdr);
 
+    /* Multi-credit charging: a READ whose payload exceeds 64 KiB consumes
+     * ceil(len / 64 KiB) credits and that many MessageIds from the server's
+     * command sequence window (MS-SMB2 3.1.5.2 / 3.3.5.2.5).  A server that
+     * verifies CreditCharge rejects an under-charged large READ with
+     * STATUS_INVALID_PARAMETER, so charge the right amount and claim the extra
+     * MessageIds (pdu_begin already took one).  Only meaningful once the
+     * negotiated dialect supports multi-credit (2.1+); 2.0.2 keeps a request at
+     * one credit and the read chunk fits in 64 KiB. */
+    if (conn->server->dialect >= SMB2_DIALECT_2_1 && len > 65536) {
+        uint16_t charge = (len - 1) / 65536 + 1;
+
+        hdr->credit_charge     = charge;
+        conn->next_message_id += charge - 1;
+    }
+
     evpl_iovec_cursor_append_uint16(&cursor, SMB2_READ_REQUEST_SIZE);
     evpl_iovec_cursor_append_uint8(&cursor, 0);              /* Padding */
     evpl_iovec_cursor_append_uint8(&cursor, 0);              /* Flags */


### PR DESCRIPTION
## Root cause

The SMB2 server never maintained `Connection.CommandSequenceWindow` and never validated a request's `CreditCharge` against its payload size. It echoed whatever `MessageId` the client sent and always answered with `STATUS_SUCCESS`, granting credits unconditionally. This violates:

- **MS-SMB2 3.3.5.2.3 / 3.3.1.1** — the server tracks a sliding window of valid `MessageId`s (extended as credits are granted, consumed as requests arrive). A request whose `MessageId` range is already-used or beyond the granted window is invalid and the server SHOULD terminate the connection.
- **MS-SMB2 3.3.5.2.5 / 3.1.5.2** — on a multi-credit dialect the server MUST verify `CreditCharge` against the operation's payload size (one credit per 64 KiB started) and fail an under-charged/zero-charge large request with `STATUS_INVALID_PARAMETER`.

## Fix

- New per-connection **sliding-bitmap sequence window** (`chimera_smb_seq_window_consume` / `_set` / `_slide` in `smb_internal.h`), sized to `CHIMERA_SMB_MAX_CREDITS`. `chimera_smb_grant_credits` extends it by each granted credit; it starts holding `MessageId 0` (the implicit first-request credit) in `chimera_smb_server_accept`.
- On receive (`smb.c`), the request's `[MessageId, MessageId+CreditCharge)` range is validated and consumed. An out-of-window range closes the connection. `CreditCharge` is treated as `1` on SMB 2.0.2 (no multi-credit) so valid 2.0.2 traffic is never rejected. `SMB2_CANCEL` is exempt (it reuses an in-flight `MessageId`).
- For `READ`/`WRITE` on a multi-credit dialect, `CreditCharge` is verified against the data length; an under-charged or zero-charge over-64 KiB request fails with `STATUS_INVALID_PARAMETER` while the connection stays up.

## Tests

Greens **26** MS-SMB2Model `CreditMgmt` (base) model cases — the `UsedMid` / `UnavailableMid` / `CreditChargeExceedBoundary` disconnect cases and the over-boundary `STATUS_INVALID_PARAMETER` cases — promoted `xfail` -> `green` in `smb2model_cases.csv`. Each passes two consecutive runs.

## Regression

A 290-case base sample (`Negotiate`, `CreditMgmt`, `CreateClose`, `ValidateNegotiateInfo`, `SessionMgmtNewSessionScenario`, `OplockOnShareWithoutForceLevel2OrSOFS`) stays green. An early iteration disconnected on a valid SMB 2.0.2 request carrying a non-zero `CreditCharge` (`CreditMgmtTestCaseS776`); fixed by counting `CreditCharge` as 1 when multi-credit is not negotiated — all 290 then pass.

Stacked on #926 (the MS-SMB2Model suite PR); the diff reduces to just this fix once #926 merges.