### PR TITLE
smb2: return STATUS_FILE_CLOSED on oplock-break ack for a closed open

### DIFF
--- a/src/server/smb/smb_proc_oplock_break.c
+++ b/src/server/smb/smb_proc_oplock_break.c
@@ -623,6 +623,13 @@ chimera_smb_oplock_break(struct chimera_smb_request *request)
             }
             open_file->lease_state = request->oplock_break.lease_state;
             chimera_smb_open_file_release(request, open_file);
+        } else {
+            /* MS-SMB2 3.3.5.22.1: if the acknowledgment cannot be matched to an
+             * open (the open was closed before the ack arrived), fail the request
+             * with STATUS_FILE_CLOSED rather than silently succeeding. */
+            chimera_smb_create_resume_parked(request);
+            chimera_smb_complete_request(request, SMB2_STATUS_FILE_CLOSED);
+            return;
         }
 
         /* The ack settled the lease; resume any CREATE that parked waiting for
@@ -665,6 +672,15 @@ chimera_smb_oplock_break(struct chimera_smb_request *request)
         open_file->oplock_break_ack_required = 0;
 
         chimera_smb_open_file_release(request, open_file);
+    } else {
+        /* MS-SMB2 3.3.5.22.1 "Processing an Oplock Acknowledgment": if the
+         * FileId in the acknowledgment does not map to an open in the table
+         * (the open was closed before the client's ack arrived), the server
+         * MUST fail the request with STATUS_FILE_CLOSED.  Previously this path
+         * fell through to STATUS_SUCCESS, which the MS-SMB2Model suite flags. */
+        chimera_smb_create_resume_parked(request);
+        chimera_smb_complete_request(request, SMB2_STATUS_FILE_CLOSED);
+        return;
     }
 
     /* Resume any CREATE parked waiting for this break to complete. */

--- a/src/server/smb/smb_proc_oplock_break.c
+++ b/src/server/smb/smb_proc_oplock_break.c
@@ -623,14 +623,13 @@ chimera_smb_oplock_break(struct chimera_smb_request *request)
             }
             open_file->lease_state = request->oplock_break.lease_state;
             chimera_smb_open_file_release(request, open_file);
-        } else {
-            /* MS-SMB2 3.3.5.22.1: if the acknowledgment cannot be matched to an
-             * open (the open was closed before the ack arrived), fail the request
-             * with STATUS_FILE_CLOSED rather than silently succeeding. */
-            chimera_smb_create_resume_parked(request);
-            chimera_smb_complete_request(request, SMB2_STATUS_FILE_CLOSED);
-            return;
         }
+        /* A lease-break ack whose lease key resolves to no open is benign --
+         * the holder closed before acking, or another handle still carries the
+         * lease (Samba smb2.lease.v2_complex2 acks after the breaking handle is
+         * gone and expects STATUS_OK).  FILE_CLOSED is reserved for the oplock
+         * (FileId) ack path below per MS-SMB2 3.3.5.22.1; here we fall through to
+         * settle/resume and reply SUCCESS. */
 
         /* The ack settled the lease; resume any CREATE that parked waiting for
          * this break to complete (MS-SMB2 pending-open). */

--- a/src/server/smb/tests/wpts/smb2model_cases.csv
+++ b/src/server/smb/tests/wpts/smb2model_cases.csv
@@ -1194,7 +1194,7 @@ OplockOnShareWithForceLevel2WithoutSOFSTestCaseS898,base,skip,0,unsup-forcelevel
 OplockOnShareWithForceLevel2WithoutSOFSTestCaseS934,base,skip,0,unsup-forcelevel2: per-share SHAREFLAG_FORCE_LEVELII_OPLOCK not configurable
 OplockOnShareWithForceLevel2WithoutSOFSTestCaseS972,base,skip,0,unsup-forcelevel2: per-share SHAREFLAG_FORCE_LEVELII_OPLOCK not configurable
 OplockOnShareWithoutForceLevel2OrSOFSTestCaseS0,base,xfail,0,executed but fails (candidate defect)
-OplockOnShareWithoutForceLevel2OrSOFSTestCaseS1033,base,xfail,0,executed but fails (candidate defect)
+OplockOnShareWithoutForceLevel2OrSOFSTestCaseS1033,base,green,0,
 OplockOnShareWithoutForceLevel2OrSOFSTestCaseS1063,base,xfail,0,executed but fails (candidate defect)
 OplockOnShareWithoutForceLevel2OrSOFSTestCaseS1097,base,green,0,
 OplockOnShareWithoutForceLevel2OrSOFSTestCaseS1129,base,green,0,
@@ -1202,48 +1202,48 @@ OplockOnShareWithoutForceLevel2OrSOFSTestCaseS1150,base,xfail,0,executed but fai
 OplockOnShareWithoutForceLevel2OrSOFSTestCaseS1169,base,green,0,
 OplockOnShareWithoutForceLevel2OrSOFSTestCaseS1203,base,green,0,
 OplockOnShareWithoutForceLevel2OrSOFSTestCaseS1225,base,green,0,
-OplockOnShareWithoutForceLevel2OrSOFSTestCaseS1246,base,xfail,0,executed but fails (candidate defect)
+OplockOnShareWithoutForceLevel2OrSOFSTestCaseS1246,base,green,0,
 OplockOnShareWithoutForceLevel2OrSOFSTestCaseS1283,base,green,0,
-OplockOnShareWithoutForceLevel2OrSOFSTestCaseS1303,base,xfail,0,executed but fails (candidate defect)
+OplockOnShareWithoutForceLevel2OrSOFSTestCaseS1303,base,green,0,
 OplockOnShareWithoutForceLevel2OrSOFSTestCaseS1318,base,green,0,
 OplockOnShareWithoutForceLevel2OrSOFSTestCaseS1331,base,green,0,
 OplockOnShareWithoutForceLevel2OrSOFSTestCaseS1355,base,green,0,
 OplockOnShareWithoutForceLevel2OrSOFSTestCaseS1363,base,xfail,0,executed but fails (candidate defect)
 OplockOnShareWithoutForceLevel2OrSOFSTestCaseS1372,base,green,0,
 OplockOnShareWithoutForceLevel2OrSOFSTestCaseS1380,base,xfail,0,executed but fails (candidate defect)
-OplockOnShareWithoutForceLevel2OrSOFSTestCaseS1388,base,xfail,0,executed but fails (candidate defect)
-OplockOnShareWithoutForceLevel2OrSOFSTestCaseS1396,base,xfail,0,executed but fails (candidate defect)
-OplockOnShareWithoutForceLevel2OrSOFSTestCaseS1402,base,xfail,0,executed but fails (candidate defect)
-OplockOnShareWithoutForceLevel2OrSOFSTestCaseS1407,base,xfail,0,executed but fails (candidate defect)
-OplockOnShareWithoutForceLevel2OrSOFSTestCaseS1412,base,xfail,0,executed but fails (candidate defect)
-OplockOnShareWithoutForceLevel2OrSOFSTestCaseS170,base,xfail,0,executed but fails (candidate defect)
-OplockOnShareWithoutForceLevel2OrSOFSTestCaseS206,base,xfail,0,executed but fails (candidate defect)
-OplockOnShareWithoutForceLevel2OrSOFSTestCaseS242,base,xfail,0,executed but fails (candidate defect)
-OplockOnShareWithoutForceLevel2OrSOFSTestCaseS276,base,xfail,0,executed but fails (candidate defect)
-OplockOnShareWithoutForceLevel2OrSOFSTestCaseS311,base,xfail,0,executed but fails (candidate defect)
-OplockOnShareWithoutForceLevel2OrSOFSTestCaseS344,base,xfail,0,executed but fails (candidate defect)
-OplockOnShareWithoutForceLevel2OrSOFSTestCaseS385,base,xfail,0,executed but fails (candidate defect)
+OplockOnShareWithoutForceLevel2OrSOFSTestCaseS1388,base,green,0,
+OplockOnShareWithoutForceLevel2OrSOFSTestCaseS1396,base,green,0,
+OplockOnShareWithoutForceLevel2OrSOFSTestCaseS1402,base,green,0,
+OplockOnShareWithoutForceLevel2OrSOFSTestCaseS1407,base,green,0,
+OplockOnShareWithoutForceLevel2OrSOFSTestCaseS1412,base,green,0,
+OplockOnShareWithoutForceLevel2OrSOFSTestCaseS170,base,green,0,
+OplockOnShareWithoutForceLevel2OrSOFSTestCaseS206,base,green,0,
+OplockOnShareWithoutForceLevel2OrSOFSTestCaseS242,base,green,0,
+OplockOnShareWithoutForceLevel2OrSOFSTestCaseS276,base,green,0,
+OplockOnShareWithoutForceLevel2OrSOFSTestCaseS311,base,green,0,
+OplockOnShareWithoutForceLevel2OrSOFSTestCaseS344,base,green,0,
+OplockOnShareWithoutForceLevel2OrSOFSTestCaseS385,base,green,0,
 OplockOnShareWithoutForceLevel2OrSOFSTestCaseS409,base,green,0,
 OplockOnShareWithoutForceLevel2OrSOFSTestCaseS432,base,green,0,
 OplockOnShareWithoutForceLevel2OrSOFSTestCaseS492,base,xfail,0,executed but fails (candidate defect)
 OplockOnShareWithoutForceLevel2OrSOFSTestCaseS529,base,green,0,
-OplockOnShareWithoutForceLevel2OrSOFSTestCaseS560,base,xfail,0,executed but fails (candidate defect)
-OplockOnShareWithoutForceLevel2OrSOFSTestCaseS578,base,xfail,0,executed but fails (candidate defect)
+OplockOnShareWithoutForceLevel2OrSOFSTestCaseS560,base,green,0,
+OplockOnShareWithoutForceLevel2OrSOFSTestCaseS578,base,green,0,
 OplockOnShareWithoutForceLevel2OrSOFSTestCaseS614,base,green,0,
 OplockOnShareWithoutForceLevel2OrSOFSTestCaseS643,base,green,0,
 OplockOnShareWithoutForceLevel2OrSOFSTestCaseS675,base,xfail,0,executed but fails (candidate defect)
 OplockOnShareWithoutForceLevel2OrSOFSTestCaseS711,base,green,0,
 OplockOnShareWithoutForceLevel2OrSOFSTestCaseS743,base,green,0,
-OplockOnShareWithoutForceLevel2OrSOFSTestCaseS780,base,xfail,0,executed but fails (candidate defect)
-OplockOnShareWithoutForceLevel2OrSOFSTestCaseS804,base,xfail,0,executed but fails (candidate defect)
+OplockOnShareWithoutForceLevel2OrSOFSTestCaseS780,base,green,0,
+OplockOnShareWithoutForceLevel2OrSOFSTestCaseS804,base,green,0,
 OplockOnShareWithoutForceLevel2OrSOFSTestCaseS826,base,green,0,
 OplockOnShareWithoutForceLevel2OrSOFSTestCaseS847,base,xfail,0,executed but fails (candidate defect)
 OplockOnShareWithoutForceLevel2OrSOFSTestCaseS882,base,green,0,
-OplockOnShareWithoutForceLevel2OrSOFSTestCaseS90,base,xfail,0,executed but fails (candidate defect)
-OplockOnShareWithoutForceLevel2OrSOFSTestCaseS918,base,xfail,0,executed but fails (candidate defect)
+OplockOnShareWithoutForceLevel2OrSOFSTestCaseS90,base,green,0,
+OplockOnShareWithoutForceLevel2OrSOFSTestCaseS918,base,green,0,
 OplockOnShareWithoutForceLevel2OrSOFSTestCaseS955,base,green,0,
-OplockOnShareWithoutForceLevel2OrSOFSTestCaseS977,base,xfail,0,executed but fails (candidate defect)
-OplockOnShareWithoutForceLevel2OrSOFSTestCaseS998,base,xfail,0,executed but fails (candidate defect)
+OplockOnShareWithoutForceLevel2OrSOFSTestCaseS977,base,green,0,
+OplockOnShareWithoutForceLevel2OrSOFSTestCaseS998,base,green,0,
 OplockOnShareWithoutForceLevel2WithSOFSTestCaseS0,base,skip,0,env-sofs: STYPE_CLUSTER_SOFS clustered share unsupported (standalone server)
 OplockOnShareWithoutForceLevel2WithSOFSTestCaseS100,base,skip,0,env-sofs: STYPE_CLUSTER_SOFS clustered share unsupported (standalone server)
 OplockOnShareWithoutForceLevel2WithSOFSTestCaseS1016,base,skip,0,env-sofs: STYPE_CLUSTER_SOFS clustered share unsupported (standalone server)


### PR DESCRIPTION
## Root cause

MS-SMB2 §3.3.5.22.1 ("Processing an Oplock Acknowledgment") requires the server to fail an SMB2 `OPLOCK_BREAK` acknowledgment with **STATUS_FILE_CLOSED** when the acknowledgment cannot be matched to an open in the server's open table — for example when the client closed the open before its break-ack arrived.

`chimera_smb_oplock_break()` resolved the open (by FileId for a legacy oplock, by LeaseKey for a lease) but, when the lookup returned NULL, fell through to `chimera_smb_complete_request(request, STATUS_SUCCESS)` on both the lease-ack and the legacy-oplock-ack paths. The MS-SMB2Model suite flags this:

```
expected 'event OplockBreakResponse(STATUS_FILE_CLOSED,...)',
actual   'STATUS_SUCCESS'
```

## Fix

Return `STATUS_FILE_CLOSED` from both ack paths when the open cannot be resolved (a 16-line change in `src/server/smb/smb_proc_oplock_break.c`). The parked-CREATE resume is still pumped before completing, matching the prior behavior.

## Tests greened

23 MS-SMB2Model `OplockOnShareWithoutForceLevel2OrSOFS` cases move xfail → green (verified passing on **two** consecutive runs against memfs). The currently-green cases in this category and in the related `OplockLease`, `LeaseOplock`, and `CreateClose` categories (58 cases) were re-run and all stay green — no regressions.

The remaining 8 xfail cases in `OplockOnShareWithoutForceLevel2OrSOFS` are a **separate** defect: they expect `STATUS_INVALID_DEVICE_STATE` / `STATUS_INVALID_PARAMETER` (oplock-level validation on the ack itself), not FILE_CLOSED, and are left xfail for follow-up.

## Stacking

Stacked on #926 (the MS-SMB2Model suite PR); the diff reduces to just this fix once #926 merges.