### PR TITLE
nfs4: named attributes sharing the SMB ADS VFS stream primitives

### DIFF
--- a/src/server/nfs/CMakeLists.txt
+++ b/src/server/nfs/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(chimera_nfs SHARED nfs.c nfs4_session.c nfs4_state.c nfs4_lease.c nf
 
             nfs4_proc_getfh.c nfs4_proc_access.c nfs4_proc_putrootfh.c nfs4_proc_putfh.c
             nfs4_proc_getattr.c nfs4_proc_lookup.c nfs4_proc_lookupp.c nfs4_proc_compound.c nfs4_proc_null.c
+            nfs4_proc_openattr.c
             nfs4_proc_readdir.c nfs4_proc_close.c nfs4_proc_create.c  nfs4_proc_open.c nfs4_proc_delegreturn.c nfs4_proc_free_stateid.c nfs4_proc_backchannel_ctl.c
             nfs4_proc_setclientid.c nfs4_proc_setclientid_confirm.c nfs4_proc_remove.c
             nfs4_proc_read.c nfs4_proc_write.c nfs4_proc_copy.c nfs4_proc_commit.c nfs4_proc_readlink.c

--- a/src/server/nfs/nfs4_attr.h
+++ b/src/server/nfs/nfs4_attr.h
@@ -136,7 +136,7 @@ chimera_nfs4_attr2mask(
                         attr_mask |= CHIMERA_VFS_ATTR_MODE;
                         break;
                     case FATTR4_NAMED_ATTR:
-                        attr_mask |= CHIMERA_VFS_ATTR_MODE;
+                        attr_mask |= CHIMERA_VFS_ATTR_NAMED_ATTR;
                         break;
                     case FATTR4_FSID:
                         attr_mask |= CHIMERA_VFS_ATTR_FSID;
@@ -389,7 +389,8 @@ chimera_nfs4_marshall_attrs(
     uint32_t                        pnfs_layout_type,
     int                             xattr_supported,
     int                             nfs4_delegations,
-    uint32_t                        lease_time_s)
+    uint32_t                        lease_time_s,
+    uint32_t                        type_override)
 {
     /* pnfs_layout_type is the single layouttype4 this file's backend supports
      * (LAYOUT4_FLEX_FILES 0x4 or LAYOUT4_BLOCK_VOLUME 0x3), or 0 when pNFS is
@@ -491,11 +492,16 @@ chimera_nfs4_marshall_attrs(
         }
 
         if (req_mask[0] & (1 << FATTR4_TYPE) &&
-            (attr->va_set_mask & CHIMERA_VFS_ATTR_MODE)) {
+            ((attr->va_set_mask & CHIMERA_VFS_ATTR_MODE) || type_override)) {
             rsp_mask[0]  |= (1 << FATTR4_TYPE);
             *num_rsp_mask = 1;
 
-            if (S_ISREG(attr->va_mode)) {
+            if (type_override) {
+                /* Named-attribute namespace: the synthetic attr directory
+                 * (NF4ATTRDIR) and its entries (NF4NAMEDATTR) carry a type the
+                 * underlying mode bits cannot express. */
+                chimera_nfs4_attr_append_uint32(&attrs, type_override);
+            } else if (S_ISREG(attr->va_mode)) {
                 chimera_nfs4_attr_append_uint32(&attrs, NF4REG);
             } else if (S_ISDIR(attr->va_mode)) {
                 chimera_nfs4_attr_append_uint32(&attrs, NF4DIR);
@@ -552,10 +558,16 @@ chimera_nfs4_marshall_attrs(
         }
 
         if (req_mask[0] & (1 << FATTR4_NAMED_ATTR)) {
+            /* Backend-reported (CHIMERA_VFS_ATTR_NAMED_ATTR): true iff the object
+             * currently has >=1 named stream (SMB ADS / NFSv4 named attribute).
+             * Backends without named-stream support leave the bit unset, which we
+             * report as false. */
             rsp_mask[0]  |= (1 << FATTR4_NAMED_ATTR);
             *num_rsp_mask = 1;
 
-            chimera_nfs4_attr_append_uint32(&attrs, 0);
+            chimera_nfs4_attr_append_uint32(&attrs,
+                                            (attr->va_set_mask & CHIMERA_VFS_ATTR_NAMED_ATTR) &&
+                                            attr->va_named_attr ? 1 : 0);
         }
 
         if ((req_mask[0] & (1 << FATTR4_FSID)) &&

--- a/src/server/nfs/nfs4_attr.h
+++ b/src/server/nfs/nfs4_attr.h
@@ -161,7 +161,7 @@ chimera_nfs4_attr2mask(
                         attr_mask |= CHIMERA_VFS_ATTR_MODE;
                         break;
                     case FATTR4_NAMED_ATTR:
-                        attr_mask |= CHIMERA_VFS_ATTR_MODE;
+                        attr_mask |= CHIMERA_VFS_ATTR_NAMED_ATTR;
                         break;
                     case FATTR4_FSID:
                         attr_mask |= CHIMERA_VFS_ATTR_FSID;
@@ -418,7 +418,8 @@ chimera_nfs4_marshall_attrs(
     uint32_t                        lease_time_s,
     uint16_t                        export_id,
     const uint8_t                  *fh_key,
-    int                             fh_sign)
+    int                             fh_sign,
+    uint32_t                        type_override)
 {
     /* pnfs_layout_type is the single layouttype4 this file's backend supports
      * (LAYOUT4_FLEX_FILES 0x4 or LAYOUT4_BLOCK_VOLUME 0x3), or 0 when pNFS is
@@ -524,11 +525,16 @@ chimera_nfs4_marshall_attrs(
         }
 
         if (req_mask[0] & (1 << FATTR4_TYPE) &&
-            (attr->va_set_mask & CHIMERA_VFS_ATTR_MODE)) {
+            ((attr->va_set_mask & CHIMERA_VFS_ATTR_MODE) || type_override)) {
             rsp_mask[0]  |= (1 << FATTR4_TYPE);
             *num_rsp_mask = 1;
 
-            if (S_ISREG(attr->va_mode)) {
+            if (type_override) {
+                /* Named-attribute namespace: the synthetic attr directory
+                 * (NF4ATTRDIR) and its entries (NF4NAMEDATTR) carry a type the
+                 * underlying mode bits cannot express. */
+                chimera_nfs4_attr_append_uint32(&attrs, type_override);
+            } else if (S_ISREG(attr->va_mode)) {
                 chimera_nfs4_attr_append_uint32(&attrs, NF4REG);
             } else if (S_ISDIR(attr->va_mode)) {
                 chimera_nfs4_attr_append_uint32(&attrs, NF4DIR);
@@ -592,10 +598,16 @@ chimera_nfs4_marshall_attrs(
         }
 
         if (req_mask[0] & (1 << FATTR4_NAMED_ATTR)) {
+            /* Backend-reported (CHIMERA_VFS_ATTR_NAMED_ATTR): true iff the object
+             * currently has >=1 named stream (SMB ADS / NFSv4 named attribute).
+             * Backends without named-stream support leave the bit unset, which we
+             * report as false. */
             rsp_mask[0]  |= (1 << FATTR4_NAMED_ATTR);
             *num_rsp_mask = 1;
 
-            chimera_nfs4_attr_append_uint32(&attrs, 0);
+            chimera_nfs4_attr_append_uint32(&attrs,
+                                            (attr->va_set_mask & CHIMERA_VFS_ATTR_NAMED_ATTR) &&
+                                            attr->va_named_attr ? 1 : 0);
         }
 
         if ((req_mask[0] & (1 << FATTR4_FSID)) &&

--- a/src/server/nfs/nfs4_named_attr.h
+++ b/src/server/nfs/nfs4_named_attr.h
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#pragma once
+
+#include <stdint.h>
+#include <string.h>
+#include "nfs_common.h"
+
+/*
+ * NFSv4 named attributes (RFC 7530/8881 sec 5.3) are projected onto the VFS
+ * named-stream primitives (the same backend storage as SMB alternate data
+ * streams).  The per-file "named attribute directory" returned by OPENATTR is a
+ * purely server-side synthetic object: its file handle is the base file's VFS fh
+ * with an 8-byte magic prefix.  The directory's *entries* (the named streams)
+ * use the real backend stream fh that open_stream returns, so READ/WRITE/CLOSE
+ * on a stream need no special handling here.
+ *
+ * The marker is a fixed 8-byte magic prefix rather than a single sentinel byte:
+ * a real chimera fh begins with a 16-byte XXH128 mount-id hash (effectively
+ * random), so a 1-byte sentinel would alias ~1/256 of real handles.  An 8-byte
+ * magic collides with probability ~2^-64, the same order as the fh-hash
+ * collisions the system already tolerates.
+ */
+#define CHIMERA_NFS4_ATTRDIR_MAGIC     "\xc4NMADIR"
+#define CHIMERA_NFS4_ATTRDIR_MAGIC_LEN 8
+
+/* True iff `fh` is a synthetic named-attribute-directory handle. */
+static inline int
+chimera_nfs4_fh_is_attrdir(
+    const uint8_t *fh,
+    int            fh_len)
+{
+    return fh_len > CHIMERA_NFS4_ATTRDIR_MAGIC_LEN &&
+           memcmp(fh, CHIMERA_NFS4_ATTRDIR_MAGIC,
+                  CHIMERA_NFS4_ATTRDIR_MAGIC_LEN) == 0;
+} /* chimera_nfs4_fh_is_attrdir */
+
+/*
+ * Build the attr-dir handle for a base file fh into `out` (must hold at least
+ * base_len + CHIMERA_NFS4_ATTRDIR_MAGIC_LEN bytes, which stays within
+ * NFS4_FHSIZE for every backend fh).  Returns the encoded length.
+ */
+static inline int
+chimera_nfs4_make_attrdir_fh(
+    uint8_t       *out,
+    const uint8_t *base_fh,
+    int            base_len)
+{
+    memcpy(out, CHIMERA_NFS4_ATTRDIR_MAGIC, CHIMERA_NFS4_ATTRDIR_MAGIC_LEN);
+    memcpy(out + CHIMERA_NFS4_ATTRDIR_MAGIC_LEN, base_fh, base_len);
+    return base_len + CHIMERA_NFS4_ATTRDIR_MAGIC_LEN;
+} /* chimera_nfs4_make_attrdir_fh */
+
+/*
+ * Strip the magic prefix, yielding the underlying base-file fh.  `*r_base` points
+ * into `fh`; valid for the lifetime of `fh`.  Caller must have checked
+ * chimera_nfs4_fh_is_attrdir().
+ */
+static inline void
+chimera_nfs4_attrdir_base(
+    const uint8_t  *fh,
+    int             fh_len,
+    const uint8_t **r_base,
+    int            *r_base_len)
+{
+    *r_base     = fh + CHIMERA_NFS4_ATTRDIR_MAGIC_LEN;
+    *r_base_len = fh_len - CHIMERA_NFS4_ATTRDIR_MAGIC_LEN;
+} /* chimera_nfs4_attrdir_base */

--- a/src/server/nfs/nfs4_proc_compound.c
+++ b/src/server/nfs/nfs4_proc_compound.c
@@ -186,6 +186,9 @@ chimera_nfs4_compound_process(
                 case OP_LOOKUP:
                     chimera_nfs4_lookup(thread, req, argop, resop);
                     break;
+                case OP_OPENATTR:
+                    chimera_nfs4_openattr(thread, req, argop, resop);
+                    break;
                 case OP_LOOKUPP:
                     chimera_nfs4_lookupp(thread, req, argop, resop);
                     break;

--- a/src/server/nfs/nfs4_proc_compound.c
+++ b/src/server/nfs/nfs4_proc_compound.c
@@ -293,6 +293,9 @@ chimera_nfs4_compound_process(
                 case OP_LOOKUP:
                     chimera_nfs4_lookup(thread, req, argop, resop);
                     break;
+                case OP_OPENATTR:
+                    chimera_nfs4_openattr(thread, req, argop, resop);
+                    break;
                 case OP_LOOKUPP:
                     chimera_nfs4_lookupp(thread, req, argop, resop);
                     break;

--- a/src/server/nfs/nfs4_proc_getattr.c
+++ b/src/server/nfs/nfs4_proc_getattr.c
@@ -5,6 +5,7 @@
 #include "nfs4_procs.h"
 #include "nfs4_status.h"
 #include "nfs4_attr.h"
+#include "nfs4_named_attr.h"
 #include "nfs4_session.h"
 #include "nfs4_state.h"
 #include "nfs4_callback.h"
@@ -81,6 +82,16 @@ chimera_nfs4_getattr_finish(
                                        req->fh,
                                        req->fhlen);
 
+    /* The synthetic named-attribute directory reports NF4ATTRDIR (invisible in
+     * the underlying mode bits).  The named-attribute *files* themselves are
+     * plain data forks and report NF4REG, matching how Solaris/Linux clients
+     * (and SMB ADS) treat them -- NF4NAMEDATTR is avoided as some clients
+     * mishandle it. */
+    uint32_t type_override = 0;
+    if (chimera_nfs4_fh_is_attrdir(req->fh, req->fhlen)) {
+        type_override = NF4ATTRDIR;
+    }
+
     chimera_nfs4_marshall_attrs(&marshall_attr,
                                 args->num_attr_request,
                                 args->attr_request,
@@ -98,7 +109,8 @@ chimera_nfs4_getattr_finish(
                                                              req->fh, req->fhlen),
                                 chimera_server_config_get_nfs4_delegations(
                                     req->thread->shared->config),
-                                req->thread->shared->nfs_lease_time_s);
+                                req->thread->shared->nfs_lease_time_s,
+                                type_override);
 
     if (req->handle) {
         chimera_vfs_release(req->thread->vfs_thread, req->handle);
@@ -205,6 +217,61 @@ chimera_nfs4_getattr_open_callback(
     }
 } /* chimera_nfs4_getattr_open_callback */
 
+/* A named-attribute directory is synthetic: its attributes are the base file's
+ * owner/timestamps presented as a directory.  Override mode/type/nlink so the
+ * object reads back as NF4ATTRDIR, then run the normal marshalling path (which
+ * derives the NF4ATTRDIR type override from req->fh). */
+static void
+chimera_nfs4_getattr_attrdir_complete(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *attr,
+    void                     *private_data)
+{
+    struct nfs_request *req = private_data;
+    struct GETATTR4res *res = &req->res_compound.resarray[req->index].opgetattr;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        if (req->handle) {
+            chimera_vfs_release(req->thread->vfs_thread, req->handle);
+            req->handle = NULL;
+        }
+        res->status = chimera_nfs4_errno_to_nfsstat4(error_code);
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    attr->va_mode      = S_IFDIR | 0755;
+    attr->va_nlink     = 2;
+    attr->va_size      = 0;
+    attr->va_set_mask |= CHIMERA_VFS_ATTR_MODE | CHIMERA_VFS_ATTR_NLINK;
+
+    chimera_nfs4_getattr_finish(req, attr);
+} /* chimera_nfs4_getattr_attrdir_complete */
+
+static void
+chimera_nfs4_getattr_attrdir_open_callback(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *handle,
+    void                           *private_data)
+{
+    struct nfs_request  *req  = private_data;
+    struct GETATTR4args *args = &req->args_compound->argarray[req->index].opgetattr;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        chimera_nfs4_compound_complete(req, chimera_nfs4_errno_to_nfsstat4(error_code));
+        return;
+    }
+
+    req->handle = handle;
+
+    chimera_vfs_getattr(req->thread->vfs_thread, &req->cred,
+                        handle,
+                        chimera_nfs4_attr2mask(args->attr_request,
+                                               args->num_attr_request),
+                        chimera_nfs4_getattr_attrdir_complete,
+                        req);
+} /* chimera_nfs4_getattr_attrdir_open_callback */
+
 void
 chimera_nfs4_getattr(
     struct chimera_server_nfs_thread *thread,
@@ -225,6 +292,22 @@ chimera_nfs4_getattr(
                                                         args->attr_request);
     if (res->status != NFS4_OK) {
         chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    /* GETATTR on a synthetic named-attribute directory: stat the base file it
+     * wraps, then present it as a directory. */
+    if (chimera_nfs4_fh_is_attrdir(req->fh, req->fhlen)) {
+        const uint8_t *base;
+        int            base_len;
+
+        chimera_nfs4_attrdir_base(req->fh, req->fhlen, &base, &base_len);
+
+        chimera_vfs_open_fh(thread->vfs_thread, &req->cred,
+                            base, base_len,
+                            CHIMERA_VFS_OPEN_INFERRED | CHIMERA_VFS_OPEN_PATH,
+                            chimera_nfs4_getattr_attrdir_open_callback,
+                            req);
         return;
     }
 

--- a/src/server/nfs/nfs4_proc_getattr.c
+++ b/src/server/nfs/nfs4_proc_getattr.c
@@ -5,6 +5,7 @@
 #include "nfs4_procs.h"
 #include "nfs4_status.h"
 #include "nfs4_attr.h"
+#include "nfs4_named_attr.h"
 #include "nfs4_session.h"
 #include "nfs4_state.h"
 #include "nfs4_callback.h"
@@ -84,6 +85,16 @@ chimera_nfs4_getattr_finish(
                                        req->fh,
                                        req->fhlen);
 
+    /* The synthetic named-attribute directory reports NF4ATTRDIR (invisible in
+     * the underlying mode bits).  The named-attribute *files* themselves are
+     * plain data forks and report NF4REG, matching how Solaris/Linux clients
+     * (and SMB ADS) treat them -- NF4NAMEDATTR is avoided as some clients
+     * mishandle it. */
+    uint32_t type_override = 0;
+    if (chimera_nfs4_fh_is_attrdir(req->fh, req->fhlen)) {
+        type_override = NF4ATTRDIR;
+    }
+
     chimera_nfs4_marshall_attrs(&marshall_attr,
                                 args->num_attr_request,
                                 args->attr_request,
@@ -104,7 +115,8 @@ chimera_nfs4_getattr_finish(
                                 req->thread->shared->nfs_lease_time_s,
                                 req->export_id,
                                 req->thread->shared->fh_key,
-                                req->thread->shared->fh_sign);
+                                req->thread->shared->fh_sign,
+                                type_override);
 
     if (req->handle) {
         chimera_vfs_release(req->thread->vfs_thread, req->handle);
@@ -292,6 +304,61 @@ chimera_nfs4_getattr_open_callback(
     }
 } /* chimera_nfs4_getattr_open_callback */
 
+/* A named-attribute directory is synthetic: its attributes are the base file's
+ * owner/timestamps presented as a directory.  Override mode/type/nlink so the
+ * object reads back as NF4ATTRDIR, then run the normal marshalling path (which
+ * derives the NF4ATTRDIR type override from req->fh). */
+static void
+chimera_nfs4_getattr_attrdir_complete(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *attr,
+    void                     *private_data)
+{
+    struct nfs_request *req = private_data;
+    struct GETATTR4res *res = &req->res_compound.resarray[req->index].opgetattr;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        if (req->handle) {
+            chimera_vfs_release(req->thread->vfs_thread, req->handle);
+            req->handle = NULL;
+        }
+        res->status = chimera_nfs4_errno_to_nfsstat4(error_code);
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    attr->va_mode      = S_IFDIR | 0755;
+    attr->va_nlink     = 2;
+    attr->va_size      = 0;
+    attr->va_set_mask |= CHIMERA_VFS_ATTR_MODE | CHIMERA_VFS_ATTR_NLINK;
+
+    chimera_nfs4_getattr_finish(req, attr);
+} /* chimera_nfs4_getattr_attrdir_complete */
+
+static void
+chimera_nfs4_getattr_attrdir_open_callback(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *handle,
+    void                           *private_data)
+{
+    struct nfs_request  *req  = private_data;
+    struct GETATTR4args *args = &req->args_compound->argarray[req->index].opgetattr;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        chimera_nfs4_compound_complete(req, chimera_nfs4_errno_to_nfsstat4(error_code));
+        return;
+    }
+
+    req->handle = handle;
+
+    chimera_vfs_getattr(req->thread->vfs_thread, &req->cred,
+                        handle,
+                        chimera_nfs4_attr2mask(args->attr_request,
+                                               args->num_attr_request),
+                        chimera_nfs4_getattr_attrdir_complete,
+                        req);
+} /* chimera_nfs4_getattr_attrdir_open_callback */
+
 void
 chimera_nfs4_getattr(
     struct chimera_server_nfs_thread *thread,
@@ -312,6 +379,22 @@ chimera_nfs4_getattr(
                                                         args->attr_request);
     if (res->status != NFS4_OK) {
         chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    /* GETATTR on a synthetic named-attribute directory: stat the base file it
+     * wraps, then present it as a directory. */
+    if (chimera_nfs4_fh_is_attrdir(req->fh, req->fhlen)) {
+        const uint8_t *base;
+        int            base_len;
+
+        chimera_nfs4_attrdir_base(req->fh, req->fhlen, &base, &base_len);
+
+        chimera_vfs_open_fh(thread->vfs_thread, &req->cred,
+                            base, base_len,
+                            CHIMERA_VFS_OPEN_INFERRED | CHIMERA_VFS_OPEN_PATH,
+                            chimera_nfs4_getattr_attrdir_open_callback,
+                            req);
         return;
     }
 

--- a/src/server/nfs/nfs4_proc_lookup.c
+++ b/src/server/nfs/nfs4_proc_lookup.c
@@ -4,8 +4,82 @@
 
 #include "nfs4_procs.h"
 #include "nfs4_status.h"
+#include "nfs4_named_attr.h"
 #include "vfs/vfs_procs.h"
 #include "vfs/vfs_release.h"
+
+/* LOOKUP of a name inside a named-attribute directory resolves to the named
+ * stream of that name on the base file.  open_stream (no-create) is the lightest
+ * way to obtain the stream's file handle; we then drop the transient handle and
+ * leave the stream fh as the current filehandle. */
+static void
+chimera_nfs4_lookup_attrdir_stream_complete(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *oh,
+    struct chimera_vfs_attrs       *attr,
+    void                           *private_data)
+{
+    struct nfs_request *req = private_data;
+    struct LOOKUP4res  *res = &req->res_compound.resarray[req->index].oplookup;
+
+    /* Release the base handle opened to reach the stream. */
+    chimera_vfs_release(req->thread->vfs_thread, req->handle);
+    req->handle = NULL;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        res->status = chimera_nfs4_errno_to_nfsstat4(error_code);
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    if (!(attr->va_set_mask & CHIMERA_VFS_ATTR_FH)) {
+        res->status = NFS4ERR_SERVERFAULT;
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    memcpy(req->fh, attr->va_fh, attr->va_fh_len);
+    req->fhlen = attr->va_fh_len;
+
+    /* The stream open handle is transient -- the current fh is stateless until a
+     * subsequent OPEN.  Release it. */
+    if (oh) {
+        chimera_vfs_release(req->thread->vfs_thread, oh);
+    }
+
+    res->status = NFS4_OK;
+    chimera_nfs4_compound_complete(req, NFS4_OK);
+} /* chimera_nfs4_lookup_attrdir_stream_complete */
+
+static void
+chimera_nfs4_lookup_attrdir_open_callback(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *handle,
+    void                           *private_data)
+{
+    struct nfs_request *req  = private_data;
+    struct LOOKUP4args *args = &req->args_compound->argarray[req->index].oplookup;
+    struct LOOKUP4res  *res  = &req->res_compound.resarray[req->index].oplookup;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        res->status = chimera_nfs4_errno_to_nfsstat4(error_code);
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    req->handle = handle;
+
+    chimera_vfs_open_stream(req->thread->vfs_thread, &req->cred,
+                            handle,
+                            args->objname.data,
+                            args->objname.len,
+                            0, /* no create: a plain lookup */
+                            NULL,
+                            0,
+                            chimera_nfs4_lookup_attrdir_stream_complete,
+                            req);
+} /* chimera_nfs4_lookup_attrdir_open_callback */
+
 static void
 chimera_nfs4_lookup_complete(
     enum chimera_vfs_error    error_code,
@@ -86,6 +160,22 @@ chimera_nfs4_lookup(
 
     if (fh_is_nfs4_root(req->fh, req->fhlen)) {
         nfs4_root_lookup(thread, req);
+        return;
+    }
+
+    /* LOOKUP inside a named-attribute directory: open the base file and resolve
+     * the named stream of this name. */
+    if (chimera_nfs4_fh_is_attrdir(req->fh, req->fhlen)) {
+        const uint8_t *base;
+        int            base_len;
+
+        chimera_nfs4_attrdir_base(req->fh, req->fhlen, &base, &base_len);
+
+        chimera_vfs_open_fh(thread->vfs_thread, &req->cred,
+                            base, base_len,
+                            CHIMERA_VFS_OPEN_INFERRED | CHIMERA_VFS_OPEN_PATH,
+                            chimera_nfs4_lookup_attrdir_open_callback,
+                            req);
         return;
     }
 

--- a/src/server/nfs/nfs4_proc_lookup.c
+++ b/src/server/nfs/nfs4_proc_lookup.c
@@ -5,8 +5,82 @@
 #include "nfs.h"
 #include "nfs4_procs.h"
 #include "nfs4_status.h"
+#include "nfs4_named_attr.h"
 #include "vfs/vfs_procs.h"
 #include "vfs/vfs_release.h"
+
+/* LOOKUP of a name inside a named-attribute directory resolves to the named
+ * stream of that name on the base file.  open_stream (no-create) is the lightest
+ * way to obtain the stream's file handle; we then drop the transient handle and
+ * leave the stream fh as the current filehandle. */
+static void
+chimera_nfs4_lookup_attrdir_stream_complete(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *oh,
+    struct chimera_vfs_attrs       *attr,
+    void                           *private_data)
+{
+    struct nfs_request *req = private_data;
+    struct LOOKUP4res  *res = &req->res_compound.resarray[req->index].oplookup;
+
+    /* Release the base handle opened to reach the stream. */
+    chimera_vfs_release(req->thread->vfs_thread, req->handle);
+    req->handle = NULL;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        res->status = chimera_nfs4_errno_to_nfsstat4(error_code);
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    if (!(attr->va_set_mask & CHIMERA_VFS_ATTR_FH)) {
+        res->status = NFS4ERR_SERVERFAULT;
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    memcpy(req->fh, attr->va_fh, attr->va_fh_len);
+    req->fhlen = attr->va_fh_len;
+
+    /* The stream open handle is transient -- the current fh is stateless until a
+     * subsequent OPEN.  Release it. */
+    if (oh) {
+        chimera_vfs_release(req->thread->vfs_thread, oh);
+    }
+
+    res->status = NFS4_OK;
+    chimera_nfs4_compound_complete(req, NFS4_OK);
+} /* chimera_nfs4_lookup_attrdir_stream_complete */
+
+static void
+chimera_nfs4_lookup_attrdir_open_callback(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *handle,
+    void                           *private_data)
+{
+    struct nfs_request *req  = private_data;
+    struct LOOKUP4args *args = &req->args_compound->argarray[req->index].oplookup;
+    struct LOOKUP4res  *res  = &req->res_compound.resarray[req->index].oplookup;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        res->status = chimera_nfs4_errno_to_nfsstat4(error_code);
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    req->handle = handle;
+
+    chimera_vfs_open_stream(req->thread->vfs_thread, &req->cred,
+                            handle,
+                            args->objname.data,
+                            args->objname.len,
+                            0, /* no create: a plain lookup */
+                            NULL,
+                            0,
+                            chimera_nfs4_lookup_attrdir_stream_complete,
+                            req);
+} /* chimera_nfs4_lookup_attrdir_open_callback */
+
 static void
 chimera_nfs4_lookup_complete(
     enum chimera_vfs_error    error_code,
@@ -119,6 +193,22 @@ chimera_nfs4_lookup(
 
     if (fh_is_nfs4_root(req->fh, req->fhlen)) {
         nfs4_root_lookup(thread, req);
+        return;
+    }
+
+    /* LOOKUP inside a named-attribute directory: open the base file and resolve
+     * the named stream of this name. */
+    if (chimera_nfs4_fh_is_attrdir(req->fh, req->fhlen)) {
+        const uint8_t *base;
+        int            base_len;
+
+        chimera_nfs4_attrdir_base(req->fh, req->fhlen, &base, &base_len);
+
+        chimera_vfs_open_fh(thread->vfs_thread, &req->cred,
+                            base, base_len,
+                            CHIMERA_VFS_OPEN_INFERRED | CHIMERA_VFS_OPEN_PATH,
+                            chimera_nfs4_lookup_attrdir_open_callback,
+                            req);
         return;
     }
 

--- a/src/server/nfs/nfs4_proc_open.c
+++ b/src/server/nfs/nfs4_proc_open.c
@@ -9,6 +9,7 @@
 #include "nfs4_attr.h"
 #include "nfs4_state.h"
 #include "nfs4_callback.h"
+#include "nfs4_named_attr.h"
 #include "server/server.h"
 #include "vfs/vfs_procs.h"
 #include "vfs/vfs_release.h"
@@ -303,6 +304,8 @@ chimera_nfs4_open_install_state(
     struct nfs_request             *req,
     struct chimera_vfs_open_handle *handle,
     const struct chimera_vfs_attrs *attr,
+    const uint8_t                  *base_fh,
+    int                             base_fh_len,
     struct stateid4                *out_stateid,
     uint32_t                       *out_rflags)
 {
@@ -406,6 +409,23 @@ chimera_nfs4_open_install_state(
                                    &req->thread->shared->nfs4_state_table,
                                    req->thread->vfs_thread);
             return share_status;
+        }
+
+        /* Named-attribute (stream) open: take a stream holder on the BASE file so
+         * a cross-protocol base delete-on-close defers while this stream is open,
+         * unifying delete-on-close with SMB ADS (smb_proc_close checks
+         * stream_holders).  Released in open_state_cleanup. */
+        if (base_fh) {
+            struct chimera_vfs_state      *vfs_state = req->thread->vfs->vfs_state;
+            struct chimera_vfs_file_state *base_fs;
+
+            base_fs = chimera_vfs_state_get(vfs_state, base_fh, base_fh_len,
+                                            chimera_vfs_hash(base_fh, base_fh_len),
+                                            true);
+            if (base_fs) {
+                chimera_vfs_state_stream_holder_inc(base_fs);
+                new_state->base_stream_file_state = base_fs;
+            }
         }
     }
 
@@ -536,6 +556,7 @@ chimera_nfs4_open_exclusive_verify(
         req->fhlen = handle->fh_len;
 
         status = chimera_nfs4_open_install_state(req, handle, attr,
+                                                 NULL, 0,
                                                  &res->resok4.stateid,
                                                  &install_rflags);
         if (status != NFS4_OK) {
@@ -628,6 +649,7 @@ chimera_nfs4_open_at_complete(
         req->fhlen = handle->fh_len;
 
         status = chimera_nfs4_open_install_state(req, handle, attr,
+                                                 NULL, 0,
                                                  &res->resok4.stateid,
                                                  &install_rflags);
         if (status != NFS4_OK) {
@@ -813,6 +835,7 @@ chimera_nfs4_open_claim_fh_complete(
         lock_caps = handle->vfs_module->capabilities;
 
         status = chimera_nfs4_open_install_state(req, handle, NULL,
+                                                 NULL, 0,
                                                  &res->resok4.stateid,
                                                  &install_rflags);
         if (status != NFS4_OK) {
@@ -1141,6 +1164,114 @@ chimera_nfs4_open_parent_complete(
 
 } /* chimera_nfs4_open_complete */
 
+/*
+ * OPEN of a named attribute (CLAIM_NULL with the current fh being a synthetic
+ * named-attribute directory): create/open the named stream of that name on the
+ * base file and install ordinary NFSv4 open state keyed on the stream fh.  No
+ * delegation is offered for named attributes.
+ */
+static void
+chimera_nfs4_open_attrdir_stream_complete(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *oh,
+    struct chimera_vfs_attrs       *attr,
+    void                           *private_data)
+{
+    struct nfs_request *req = private_data;
+    struct OPEN4res    *res = &req->res_compound.resarray[req->index].opopen;
+    uint8_t             base_fh[NFS4_FHSIZE];
+    int                 base_fh_len;
+    const uint8_t      *base;
+
+    /* Release the base-file handle opened to reach the stream. */
+    chimera_vfs_release(req->thread->vfs_thread, req->handle);
+    req->handle = NULL;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        res->status = chimera_nfs4_errno_to_nfsstat4(error_code);
+        chimera_nfs4_open_complete(req, res->status);
+        return;
+    }
+
+    /* Capture the base fh (for the stream holder) before req->fh is overwritten
+     * with the stream fh. */
+    chimera_nfs4_attrdir_base(req->fh, req->fhlen, &base, &base_fh_len);
+    memcpy(base_fh, base, base_fh_len);
+
+    {
+        uint32_t lock_caps      = oh->vfs_module->capabilities;
+        uint32_t install_rflags = 0;
+        nfsstat4 status;
+
+        /* Capture the stream fh before install_state may release the handle. */
+        memcpy(req->fh, oh->fh, oh->fh_len);
+        req->fhlen = oh->fh_len;
+
+        status = chimera_nfs4_open_install_state(req, oh, attr,
+                                                 base_fh, base_fh_len,
+                                                 &res->resok4.stateid,
+                                                 &install_rflags);
+        if (status != NFS4_OK) {
+            res->status = status;
+            chimera_nfs4_open_complete(req, status);
+            return;
+        }
+
+        res->status              = NFS4_OK;
+        res->resok4.cinfo.atomic = 0;
+        res->resok4.cinfo.before = 0;
+        res->resok4.cinfo.after  = 0;
+        res->resok4.rflags       = install_rflags |
+            ((lock_caps & CHIMERA_VFS_CAP_FS_LOCK) ?
+             OPEN4_RESULT_LOCKTYPE_POSIX : 0);
+        res->resok4.num_attrset = 0;
+    }
+
+    /* Named attributes are never delegated. */
+    res->resok4.delegation.delegation_type = OPEN_DELEGATE_NONE;
+    chimera_nfs4_open_complete(req, NFS4_OK);
+} /* chimera_nfs4_open_attrdir_stream_complete */
+
+static void
+chimera_nfs4_open_attrdir_base_open_callback(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *handle,
+    void                           *private_data)
+{
+    struct nfs_request *req   = private_data;
+    struct OPEN4args   *args  = &req->args_compound->argarray[req->index].opopen;
+    struct OPEN4res    *res   = &req->res_compound.resarray[req->index].opopen;
+    uint32_t            flags = 0;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        res->status = chimera_nfs4_errno_to_nfsstat4(error_code);
+        chimera_nfs4_open_complete(req, res->status);
+        return;
+    }
+
+    req->handle = handle;
+
+    if (args->openhow.opentype == OPEN4_CREATE) {
+        flags |= CHIMERA_VFS_OPEN_CREATE;
+        if (args->openhow.how.mode == GUARDED4 ||
+            args->openhow.how.mode == EXCLUSIVE4 ||
+            args->openhow.how.mode == EXCLUSIVE4_1) {
+            flags |= CHIMERA_VFS_OPEN_EXCLUSIVE;
+        }
+    }
+
+    /* set_attr is NULL: a named-stream open must not stamp the base file's
+    * mode/owner (memfs applies open_stream set_attr to the base inode). */
+    chimera_vfs_open_stream(req->thread->vfs_thread, &req->cred,
+                            handle,
+                            args->claim.file.data, args->claim.file.len,
+                            flags,
+                            NULL,
+                            CHIMERA_VFS_ATTR_MASK_STAT,
+                            chimera_nfs4_open_attrdir_stream_complete,
+                            req);
+} /* chimera_nfs4_open_attrdir_base_open_callback */
+
 void
 chimera_nfs4_open(
     struct chimera_server_nfs_thread *thread,
@@ -1271,6 +1402,29 @@ chimera_nfs4_open(
             chimera_nfs4_open_complete(req, res->status);
             return;
         }
+    }
+
+    /* OPEN of a named attribute: the current fh is a synthetic named-attribute
+     * directory and the claim names the attribute.  Only CLAIM_NULL is defined
+     * inside a named-attr directory. */
+    if (chimera_nfs4_fh_is_attrdir(req->fh, req->fhlen)) {
+        const uint8_t *base;
+        int            base_len;
+
+        if (args->claim.claim != CLAIM_NULL) {
+            res->status = NFS4ERR_NOTSUPP;
+            chimera_nfs4_open_complete(req, res->status);
+            return;
+        }
+
+        chimera_nfs4_attrdir_base(req->fh, req->fhlen, &base, &base_len);
+
+        chimera_vfs_open_fh(thread->vfs_thread, &req->cred,
+                            base, base_len,
+                            CHIMERA_VFS_OPEN_INFERRED | CHIMERA_VFS_OPEN_PATH,
+                            chimera_nfs4_open_attrdir_base_open_callback,
+                            req);
+        return;
     }
 
     chimera_vfs_open_fh(thread->vfs_thread, &req->cred,

--- a/src/server/nfs/nfs4_proc_open.c
+++ b/src/server/nfs/nfs4_proc_open.c
@@ -10,6 +10,7 @@
 #include "nfs4_state.h"
 #include "nfs4_session.h"
 #include "nfs4_callback.h"
+#include "nfs4_named_attr.h"
 #include "server/server.h"
 #include "vfs/vfs_procs.h"
 #include "vfs/vfs_release.h"
@@ -324,6 +325,8 @@ chimera_nfs4_open_install_state(
     struct chimera_vfs_open_handle *handle,
     const struct chimera_vfs_attrs *attr,
     bool                            file_created,
+    const uint8_t                  *base_fh,
+    int                             base_fh_len,
     struct stateid4                *out_stateid,
     uint32_t                       *out_rflags)
 {
@@ -469,6 +472,23 @@ chimera_nfs4_open_install_state(
                                    &req->thread->shared->nfs4_state_table,
                                    req->thread->vfs_thread);
             goto err_put_owner;
+        }
+
+        /* Named-attribute (stream) open: take a stream holder on the BASE file so
+         * a cross-protocol base delete-on-close defers while this stream is open,
+         * unifying delete-on-close with SMB ADS (smb_proc_close checks
+         * stream_holders).  Released in open_state_cleanup. */
+        if (base_fh) {
+            struct chimera_vfs_state      *vfs_state = req->thread->vfs->vfs_state;
+            struct chimera_vfs_file_state *base_fs;
+
+            base_fs = chimera_vfs_state_get(vfs_state, base_fh, base_fh_len,
+                                            chimera_vfs_hash(base_fh, base_fh_len),
+                                            true);
+            if (base_fs) {
+                chimera_vfs_state_stream_holder_inc(base_fs);
+                new_state->base_stream_file_state = base_fs;
+            }
         }
     }
 
@@ -758,6 +778,7 @@ chimera_nfs4_open_exclusive_verify(
 
         status = chimera_nfs4_open_install_state(req, handle, attr,
                                                  handle->r_created,
+                                                 NULL, 0,
                                                  &res->resok4.stateid,
                                                  &install_rflags);
         if (status != NFS4_OK) {
@@ -855,6 +876,7 @@ chimera_nfs4_open_at_complete(
 
         status = chimera_nfs4_open_install_state(req, handle, attr,
                                                  handle->r_created,
+                                                 NULL, 0,
                                                  &res->resok4.stateid,
                                                  &install_rflags);
         if (status != NFS4_OK) {
@@ -1061,6 +1083,7 @@ chimera_nfs4_open_claim_fh_complete(
         uint32_t install_rflags = 0;
 
         status = chimera_nfs4_open_install_state(req, handle, NULL, false,
+                                                 NULL, 0,
                                                  &res->resok4.stateid,
                                                  &install_rflags);
         if (status != NFS4_OK) {
@@ -1417,6 +1440,113 @@ chimera_nfs4_open_parent_complete(
 
 } /* chimera_nfs4_open_complete */
 
+/*
+ * OPEN of a named attribute (CLAIM_NULL with the current fh being a synthetic
+ * named-attribute directory): create/open the named stream of that name on the
+ * base file and install ordinary NFSv4 open state keyed on the stream fh.  No
+ * delegation is offered for named attributes.
+ */
+static void
+chimera_nfs4_open_attrdir_stream_complete(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *oh,
+    struct chimera_vfs_attrs       *attr,
+    void                           *private_data)
+{
+    struct nfs_request *req = private_data;
+    struct OPEN4res    *res = &req->res_compound.resarray[req->index].opopen;
+    uint8_t             base_fh[NFS4_FHSIZE];
+    int                 base_fh_len;
+    const uint8_t      *base;
+
+    /* Release the base-file handle opened to reach the stream. */
+    chimera_vfs_release(req->thread->vfs_thread, req->handle);
+    req->handle = NULL;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        res->status = chimera_nfs4_errno_to_nfsstat4(error_code);
+        chimera_nfs4_open_complete(req, res->status);
+        return;
+    }
+
+    /* Capture the base fh (for the stream holder) before req->fh is overwritten
+     * with the stream fh. */
+    chimera_nfs4_attrdir_base(req->fh, req->fhlen, &base, &base_fh_len);
+    memcpy(base_fh, base, base_fh_len);
+
+    {
+        uint32_t install_rflags = 0;
+        nfsstat4 status;
+
+        /* Capture the stream fh before install_state may release the handle. */
+        memcpy(req->fh, oh->fh, oh->fh_len);
+        req->fhlen = oh->fh_len;
+
+        status = chimera_nfs4_open_install_state(req, oh, attr,
+                                                 oh->r_created,
+                                                 base_fh, base_fh_len,
+                                                 &res->resok4.stateid,
+                                                 &install_rflags);
+        if (status != NFS4_OK) {
+            res->status = status;
+            chimera_nfs4_open_complete(req, status);
+            return;
+        }
+
+        res->status              = NFS4_OK;
+        res->resok4.cinfo.atomic = 0;
+        res->resok4.cinfo.before = 0;
+        res->resok4.cinfo.after  = 0;
+        res->resok4.rflags       = install_rflags |
+            OPEN4_RESULT_LOCKTYPE_POSIX;
+        res->resok4.num_attrset = 0;
+    }
+
+    /* Named attributes are never delegated. */
+    res->resok4.delegation.delegation_type = OPEN_DELEGATE_NONE;
+    chimera_nfs4_open_complete(req, NFS4_OK);
+} /* chimera_nfs4_open_attrdir_stream_complete */
+
+static void
+chimera_nfs4_open_attrdir_base_open_callback(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *handle,
+    void                           *private_data)
+{
+    struct nfs_request *req   = private_data;
+    struct OPEN4args   *args  = &req->args_compound->argarray[req->index].opopen;
+    struct OPEN4res    *res   = &req->res_compound.resarray[req->index].opopen;
+    uint32_t            flags = 0;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        res->status = chimera_nfs4_errno_to_nfsstat4(error_code);
+        chimera_nfs4_open_complete(req, res->status);
+        return;
+    }
+
+    req->handle = handle;
+
+    if (args->openhow.opentype == OPEN4_CREATE) {
+        flags |= CHIMERA_VFS_OPEN_CREATE;
+        if (args->openhow.how.mode == GUARDED4 ||
+            args->openhow.how.mode == EXCLUSIVE4 ||
+            args->openhow.how.mode == EXCLUSIVE4_1) {
+            flags |= CHIMERA_VFS_OPEN_EXCLUSIVE;
+        }
+    }
+
+    /* set_attr is NULL: a named-stream open must not stamp the base file's
+    * mode/owner (memfs applies open_stream set_attr to the base inode). */
+    chimera_vfs_open_stream(req->thread->vfs_thread, &req->cred,
+                            handle,
+                            args->claim.file.data, args->claim.file.len,
+                            flags,
+                            NULL,
+                            CHIMERA_VFS_ATTR_MASK_STAT,
+                            chimera_nfs4_open_attrdir_stream_complete,
+                            req);
+} /* chimera_nfs4_open_attrdir_base_open_callback */
+
 void
 chimera_nfs4_open(
     struct chimera_server_nfs_thread *thread,
@@ -1562,6 +1692,29 @@ chimera_nfs4_open(
             chimera_nfs4_open_complete(req, res->status);
             return;
         }
+    }
+
+    /* OPEN of a named attribute: the current fh is a synthetic named-attribute
+     * directory and the claim names the attribute.  Only CLAIM_NULL is defined
+     * inside a named-attr directory. */
+    if (chimera_nfs4_fh_is_attrdir(req->fh, req->fhlen)) {
+        const uint8_t *base;
+        int            base_len;
+
+        if (args->claim.claim != CLAIM_NULL) {
+            res->status = NFS4ERR_NOTSUPP;
+            chimera_nfs4_open_complete(req, res->status);
+            return;
+        }
+
+        chimera_nfs4_attrdir_base(req->fh, req->fhlen, &base, &base_len);
+
+        chimera_vfs_open_fh(thread->vfs_thread, &req->cred,
+                            base, base_len,
+                            CHIMERA_VFS_OPEN_INFERRED | CHIMERA_VFS_OPEN_PATH,
+                            chimera_nfs4_open_attrdir_base_open_callback,
+                            req);
+        return;
     }
 
     chimera_vfs_open_fh(thread->vfs_thread, &req->cred,

--- a/src/server/nfs/nfs4_proc_openattr.c
+++ b/src/server/nfs/nfs4_proc_openattr.c
@@ -1,0 +1,130 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "nfs4_procs.h"
+#include "nfs4_status.h"
+#include "nfs4_named_attr.h"
+#include "server/server.h"
+#include "vfs/vfs_procs.h"
+#include "vfs/vfs_release.h"
+
+/*
+ * OPENATTR (RFC 7530 §16.21 / RFC 8881 §18.17): set the current filehandle to
+ * the named-attribute directory of the current object.  Chimera projects NFSv4
+ * named attributes onto the VFS named-stream primitives (the same backend
+ * storage as SMB alternate data streams), so the attr directory is a synthetic
+ * server-side object whose handle is the base file's fh with a magic prefix
+ * (nfs4_named_attr.h).  Its entries -- the named streams -- are created/listed/
+ * removed via open_stream/list_streams/remove_stream when ops run against the
+ * attr-dir fh.
+ *
+ * `createdir` is advisory here: the attr directory is conceptually always
+ * present for a streams-capable regular file (entries are created on demand by
+ * OPEN), so OPENATTR succeeds regardless and the directory simply enumerates
+ * empty until a named attribute is written.
+ */
+
+static void
+chimera_nfs4_openattr_getattr_complete(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *attr,
+    void                     *private_data)
+{
+    struct nfs_request  *req = private_data;
+    struct OPENATTR4res *res = &req->res_compound.resarray[req->index].opopenattr;
+    uint8_t              attrdir_fh[NFS4_FHSIZE];
+    int                  attrdir_len;
+
+    chimera_vfs_release(req->thread->vfs_thread, req->handle);
+    req->handle = NULL;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        res->status = chimera_nfs4_errno_to_nfsstat4(error_code);
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    /* The VFS named-stream backend attaches streams only to regular files, so a
+     * named-attribute directory exists only for a regular file. */
+    if (!S_ISREG(attr->va_mode)) {
+        res->status = NFS4ERR_NOTSUPP;
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    attrdir_len = chimera_nfs4_make_attrdir_fh(attrdir_fh, req->fh, req->fhlen);
+
+    memcpy(req->fh, attrdir_fh, attrdir_len);
+    req->fhlen = attrdir_len;
+
+    res->status = NFS4_OK;
+    chimera_nfs4_compound_complete(req, NFS4_OK);
+} /* chimera_nfs4_openattr_getattr_complete */
+
+static void
+chimera_nfs4_openattr_open_callback(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *handle,
+    void                           *private_data)
+{
+    struct nfs_request  *req = private_data;
+    struct OPENATTR4res *res = &req->res_compound.resarray[req->index].opopenattr;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        res->status = chimera_nfs4_errno_to_nfsstat4(error_code);
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    req->handle = handle;
+
+    chimera_vfs_getattr(req->thread->vfs_thread, &req->cred,
+                        handle,
+                        CHIMERA_VFS_ATTR_MODE,
+                        chimera_nfs4_openattr_getattr_complete,
+                        req);
+} /* chimera_nfs4_openattr_open_callback */
+
+void
+chimera_nfs4_openattr(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_request               *req,
+    struct nfs_argop4                *argop,
+    struct nfs_resop4                *resop)
+{
+    struct OPENATTR4res *res = &resop->opopenattr;
+
+    if (req->fhlen == 0) {
+        res->status = NFS4ERR_NOFILEHANDLE;
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    /* The pseudo-root and an existing attr directory have no named-attribute
+     * directory of their own. */
+    if (fh_is_nfs4_root(req->fh, req->fhlen) ||
+        chimera_nfs4_fh_is_attrdir(req->fh, req->fhlen)) {
+        res->status = NFS4ERR_NOTSUPP;
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    /* Named streams are one VFS feature shared by SMB ADS and NFSv4 named
+     * attributes: gate on the same switch, and require the backend that owns
+     * this object to support named streams. */
+    if (!chimera_server_config_get_named_streams(thread->shared->config) ||
+        !(chimera_vfs_module_capabilities(thread->vfs_thread, req->fh, req->fhlen) &
+          CHIMERA_VFS_CAP_NAMED_STREAMS)) {
+        res->status = NFS4ERR_NOTSUPP;
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    chimera_vfs_open_fh(thread->vfs_thread, &req->cred,
+                        req->fh,
+                        req->fhlen,
+                        CHIMERA_VFS_OPEN_INFERRED | CHIMERA_VFS_OPEN_PATH,
+                        chimera_nfs4_openattr_open_callback,
+                        req);
+} /* chimera_nfs4_openattr */

--- a/src/server/nfs/nfs4_proc_putfh.c
+++ b/src/server/nfs/nfs4_proc_putfh.c
@@ -5,8 +5,40 @@
 #include "nfs4_procs.h"
 #include "nfs4_status.h"
 #include "nfs4_state.h"
+#include "nfs4_named_attr.h"
 #include "vfs/vfs_procs.h"
 #include "vfs/vfs_release.h"
+
+/* A synthetic named-attribute-directory handle (OPENATTR result): validate that
+ * the underlying base file still exists, then accept the *marked* handle as the
+ * current fh so GETFH/SAVEFH round-trip it back to the client unchanged.  The
+ * attr-dir-aware ops (READDIR/LOOKUP/OPEN/REMOVE/GETATTR) unwrap it on use. */
+static void
+chimera_nfs4_putfh_attrdir_complete(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *handle,
+    void                           *private_data)
+{
+    struct nfs_request *req  = private_data;
+    struct PUTFH4args  *args = &req->args_compound->argarray[req->index].opputfh;
+    struct PUTFH4res   *res  = &req->res_compound.resarray[req->index].opputfh;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        res->status = (error_code == CHIMERA_VFS_ENOENT ||
+                       error_code == CHIMERA_VFS_ESTALE) ?
+            NFS4ERR_STALE : chimera_nfs4_errno_to_nfsstat4(error_code);
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    chimera_vfs_release(req->thread->vfs_thread, handle);
+
+    memcpy(req->fh, args->object.data, args->object.len);
+    req->fhlen = args->object.len;
+
+    res->status = NFS4_OK;
+    chimera_nfs4_compound_complete(req, NFS4_OK);
+} /* chimera_nfs4_putfh_attrdir_complete */
 
 static bool
 chimera_nfs4_putfh_has_open_state(
@@ -113,6 +145,30 @@ chimera_nfs4_putfh(
 {
     struct PUTFH4args *args = &argop->opputfh;
     struct  PUTFH4res *res  = &resop->opputfh;
+
+    /* A named-attribute-directory handle is a base-file fh wrapped with a magic
+    * prefix; validate the base it wraps and keep the marked form as current. */
+    if (chimera_nfs4_fh_is_attrdir(args->object.data, args->object.len)) {
+        const uint8_t *base;
+        int            base_len;
+
+        chimera_nfs4_attrdir_base(args->object.data, args->object.len,
+                                  &base, &base_len);
+
+        if (base_len > NFS4_FHSIZE ||
+            !chimera_vfs_fh_is_plausible(thread->vfs_thread, base, base_len)) {
+            res->status = NFS4ERR_BADHANDLE;
+            chimera_nfs4_compound_complete(req, res->status);
+            return;
+        }
+
+        chimera_vfs_open_fh(thread->vfs_thread, &req->cred,
+                            base, base_len,
+                            CHIMERA_VFS_OPEN_INFERRED | CHIMERA_VFS_OPEN_PATH,
+                            chimera_nfs4_putfh_attrdir_complete,
+                            req);
+        return;
+    }
 
     /* RFC 7530 §16.20.5: a structurally invalid handle (wrong length, unknown
      * mount) is NFS4ERR_BADHANDLE. Existence of the target is not checked here

--- a/src/server/nfs/nfs4_proc_putfh.c
+++ b/src/server/nfs/nfs4_proc_putfh.c
@@ -7,8 +7,39 @@
 #include "nfs4_state.h"
 #include "nfs4_session.h"
 #include "server/server.h"
+#include "nfs4_named_attr.h"
 #include "vfs/vfs_procs.h"
 #include "vfs/vfs_release.h"
+
+/* A synthetic named-attribute-directory handle (OPENATTR result): validate that
+ * the underlying base file still exists, then keep the *decoded* marked handle
+ * (already in req->fh from PUTFH's decode) as the current fh so GETFH/SAVEFH
+ * round-trip it back to the client.  The attr-dir-aware ops (READDIR/LOOKUP/
+ * OPEN/REMOVE/GETATTR) recognise it on req->fh. */
+static void
+chimera_nfs4_putfh_attrdir_complete(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *handle,
+    void                           *private_data)
+{
+    struct nfs_request *req = private_data;
+    struct PUTFH4res   *res = &req->res_compound.resarray[req->index].opputfh;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        res->status = (error_code == CHIMERA_VFS_ENOENT ||
+                       error_code == CHIMERA_VFS_ESTALE) ?
+            NFS4ERR_STALE : chimera_nfs4_errno_to_nfsstat4(error_code);
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    chimera_vfs_release(req->thread->vfs_thread, handle);
+
+    /* req->fh already holds the decoded marked (MAGIC-prefixed) handle from the
+     * PUTFH decode; leave it current unchanged. */
+    res->status = NFS4_OK;
+    chimera_nfs4_compound_complete(req, NFS4_OK);
+} /* chimera_nfs4_putfh_attrdir_complete */
 
 static void
 chimera_nfs4_putfh_getattr_complete(
@@ -131,8 +162,41 @@ chimera_nfs4_putfh(
         return;
     }
 
-    if (decode_rc != CHIMERA_NFS_FH_OK ||
-        !chimera_vfs_fh_is_plausible(thread->vfs_thread, req->fh, req->fhlen)) {
+    if (decode_rc != CHIMERA_NFS_FH_OK) {
+        res->status = NFS4ERR_BADHANDLE;
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    /* A named-attribute-directory handle is the base file's VFS fh with a magic
+     * prefix.  It is wrapped on the wire like any handle (OPENATTR builds the
+     * marked inner fh; GETFH wraps it), so the marker is only visible AFTER
+     * decode -- checking the wire bytes would miss it behind the wrap header.
+     * Validate the base it wraps; the decoded marked form stays the current fh
+     * so the attr-dir-aware ops (READDIR/LOOKUP/OPEN/REMOVE/GETATTR) route on
+     * it. */
+    if (chimera_nfs4_fh_is_attrdir(req->fh, req->fhlen)) {
+        const uint8_t *base;
+        int            base_len;
+
+        chimera_nfs4_attrdir_base(req->fh, req->fhlen, &base, &base_len);
+
+        if (base_len > NFS4_FHSIZE ||
+            !chimera_vfs_fh_is_plausible(thread->vfs_thread, base, base_len)) {
+            res->status = NFS4ERR_BADHANDLE;
+            chimera_nfs4_compound_complete(req, res->status);
+            return;
+        }
+
+        chimera_vfs_open_fh(thread->vfs_thread, &req->cred,
+                            base, base_len,
+                            CHIMERA_VFS_OPEN_INFERRED | CHIMERA_VFS_OPEN_PATH,
+                            chimera_nfs4_putfh_attrdir_complete,
+                            req);
+        return;
+    }
+
+    if (!chimera_vfs_fh_is_plausible(thread->vfs_thread, req->fh, req->fhlen)) {
         res->status = NFS4ERR_BADHANDLE;
         chimera_nfs4_compound_complete(req, res->status);
         return;

--- a/src/server/nfs/nfs4_proc_readdir.c
+++ b/src/server/nfs/nfs4_proc_readdir.c
@@ -5,6 +5,7 @@
 #include "nfs4_procs.h"
 #include "nfs4_attr.h"
 #include "nfs4_status.h"
+#include "nfs4_named_attr.h"
 #include "server/server.h"
 #include "vfs/vfs_procs.h"
 #include "vfs/vfs_release.h"
@@ -80,7 +81,11 @@ chimera_nfs4_readdir_callback(
                                                              req->fh, req->fhlen),
                                 chimera_server_config_get_nfs4_delegations(
                                     req->thread->shared->config),
-                                req->thread->shared->nfs_lease_time_s);
+                                req->thread->shared->nfs_lease_time_s,
+                                /* Named-attribute files report NF4REG (their
+                                 * mode-derived type), like ordinary directory
+                                 * entries -- see the type note in nfs4_proc_getattr. */
+                                0);
 
     dbuf_cur = req->encoding->dbuf->used - dbuf_before;
 
@@ -180,6 +185,177 @@ chimera_nfs4_readdir_open_callback(
                         req);
 } /* chimera_nfs4_readdir_open_callback */
 
+/* ---- Named-attribute directory READDIR ----------------------------------
+ *
+ * The synthetic attr directory has no backend directory to enumerate; its
+ * entries are the base file's named streams.  We stat the base once (the entries
+ * inherit its owner/timestamps), list the streams (with their file handles), and
+ * synthesize one entry per named stream.  memfs returns the full stream list in
+ * one shot, so a single pass with index-based cookies covers continuation. */
+
+struct nfs4_attrdir_readdir_ctx {
+    struct nfs_request      *req;
+    struct chimera_vfs_attrs base_attr;
+    uint8_t                  records[64 * 1024];
+};
+
+static void
+chimera_nfs4_readdir_attrdir_list_callback(
+    enum chimera_vfs_error error_code,
+    const void            *records,
+    uint32_t               records_len,
+    uint32_t               count,
+    uint32_t               eof,
+    uint64_t               cookie,
+    void                  *private_data)
+{
+    struct nfs4_attrdir_readdir_ctx *ctx   = private_data;
+    struct nfs_request              *req   = ctx->req;
+    uint32_t                         in    = 0;
+    uint32_t                         index = 0;
+    uint32_t                         r_eof = eof;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        chimera_nfs4_readdir_complete(error_code, req->handle, 0, 0, 0, NULL, req);
+        free(ctx);
+        return;
+    }
+
+    while (in < records_len) {
+        struct chimera_vfs_stream_entry entry;
+        const char                     *name;
+        const uint8_t                  *fh;
+        struct chimera_vfs_attrs        attr;
+        uint32_t                        reclen;
+
+        memcpy(&entry, (const uint8_t *) records + in, sizeof(entry));
+        name = (const char *) records + in + sizeof(entry);
+        fh   = (const uint8_t *) records + in + sizeof(entry) + entry.name_len;
+
+        reclen = (sizeof(entry) + entry.name_len + entry.fh_len + 7) & ~7u;
+
+        /* Skip the unnamed default fork ("::$DATA") -- it is the file's own data,
+         * not a named attribute. */
+        if (entry.name_len == 0) {
+            in += reclen;
+            continue;
+        }
+
+        index++;
+
+        /* Index-based cookie: resume after the client's last-seen entry. */
+        if (index <= cookie) {
+            in += reclen;
+            continue;
+        }
+
+        attr               = ctx->base_attr;
+        attr.va_size       = entry.size;
+        attr.va_space_used = entry.alloc;
+        attr.va_set_mask  |= CHIMERA_VFS_ATTR_SIZE | CHIMERA_VFS_ATTR_SPACE_USED;
+
+        if (entry.fh_len) {
+            memcpy(attr.va_fh, fh, entry.fh_len);
+            attr.va_fh_len    = entry.fh_len;
+            attr.va_set_mask |= CHIMERA_VFS_ATTR_FH;
+            /* Give each named attribute a distinct, stable fileid derived from
+             * its handle (the base inode's ino would collide across streams). */
+            attr.va_ino       = chimera_vfs_hash(fh, entry.fh_len);
+            attr.va_set_mask |= CHIMERA_VFS_ATTR_INUM;
+        }
+
+        if (chimera_nfs4_readdir_callback(attr.va_ino, index, name,
+                                          entry.name_len, &attr, req) != 0) {
+            /* Entry did not fit: stop here, more remain. */
+            r_eof = 0;
+            break;
+        }
+
+        in += reclen;
+    }
+
+    chimera_nfs4_readdir_complete(CHIMERA_VFS_OK, req->handle, index, 0, r_eof,
+                                  NULL, req);
+    free(ctx);
+} /* chimera_nfs4_readdir_attrdir_list_callback */
+
+static void
+chimera_nfs4_readdir_attrdir_getattr_callback(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *attr,
+    void                     *private_data)
+{
+    struct nfs4_attrdir_readdir_ctx *ctx = private_data;
+    struct nfs_request              *req = ctx->req;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        chimera_nfs4_readdir_complete(error_code, req->handle, 0, 0, 0, NULL, req);
+        free(ctx);
+        return;
+    }
+
+    ctx->base_attr = *attr;
+
+    chimera_vfs_list_streams(req->thread->vfs_thread, &req->cred,
+                             req->handle,
+                             0,
+                             ctx->records,
+                             sizeof(ctx->records),
+                             1, /* want per-stream file handles */
+                             chimera_nfs4_readdir_attrdir_list_callback,
+                             ctx);
+} /* chimera_nfs4_readdir_attrdir_getattr_callback */
+
+static void
+chimera_nfs4_readdir_attrdir_open_callback(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *handle,
+    void                           *private_data)
+{
+    struct nfs4_attrdir_readdir_ctx *ctx  = private_data;
+    struct nfs_request              *req  = ctx->req;
+    struct READDIR4args             *args = &req->args_compound->argarray[req->index].opreaddir;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        req->handle = NULL;
+        chimera_nfs4_readdir_complete(error_code, NULL, 0, 0, 0, NULL, req);
+        free(ctx);
+        return;
+    }
+
+    req->handle = handle;
+
+    /* Stat the base file once; every named attribute inherits its
+     * owner/group/timestamps (size/fh/fileid are overridden per stream). */
+    chimera_vfs_getattr(req->thread->vfs_thread, &req->cred,
+                        handle,
+                        chimera_nfs4_attr2mask(args->attr_request,
+                                               args->num_attr_request),
+                        chimera_nfs4_readdir_attrdir_getattr_callback,
+                        ctx);
+} /* chimera_nfs4_readdir_attrdir_open_callback */
+
+static void
+chimera_nfs4_readdir_attrdir(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_request               *req)
+{
+    struct nfs4_attrdir_readdir_ctx *ctx;
+    const uint8_t                   *base;
+    int                              base_len;
+
+    ctx      = calloc(1, sizeof(*ctx));
+    ctx->req = req;
+
+    chimera_nfs4_attrdir_base(req->fh, req->fhlen, &base, &base_len);
+
+    chimera_vfs_open_fh(thread->vfs_thread, &req->cred,
+                        base, base_len,
+                        CHIMERA_VFS_OPEN_INFERRED | CHIMERA_VFS_OPEN_PATH,
+                        chimera_nfs4_readdir_attrdir_open_callback,
+                        ctx);
+} /* chimera_nfs4_readdir_attrdir */
+
 void
 chimera_nfs4_readdir(
     struct chimera_server_nfs_thread *thread,
@@ -241,6 +417,13 @@ chimera_nfs4_readdir(
     cursor->last    = NULL;
 
     res->resok4.reply.entries = NULL;
+
+    /* READDIR of a synthetic named-attribute directory: enumerate the base
+     * file's named streams instead of a real directory. */
+    if (chimera_nfs4_fh_is_attrdir(req->fh, req->fhlen)) {
+        chimera_nfs4_readdir_attrdir(thread, req);
+        return;
+    }
 
     chimera_vfs_open_fh(thread->vfs_thread, &req->cred,
                         req->fh,

--- a/src/server/nfs/nfs4_proc_readdir.c
+++ b/src/server/nfs/nfs4_proc_readdir.c
@@ -5,6 +5,7 @@
 #include "nfs4_procs.h"
 #include "nfs4_attr.h"
 #include "nfs4_status.h"
+#include "nfs4_named_attr.h"
 #include "server/server.h"
 #include "vfs/vfs_procs.h"
 #include "vfs/vfs_release.h"
@@ -83,7 +84,11 @@ chimera_nfs4_readdir_callback(
                                 req->thread->shared->nfs_lease_time_s,
                                 req->export_id,
                                 req->thread->shared->fh_key,
-                                req->thread->shared->fh_sign);
+                                req->thread->shared->fh_sign,
+                                /* Named-attribute files report NF4REG (their
+                                 * mode-derived type), like ordinary directory
+                                 * entries -- see the type note in nfs4_proc_getattr. */
+                                0);
 
     dbuf_cur = req->encoding->dbuf->used - dbuf_before;
 
@@ -184,6 +189,177 @@ chimera_nfs4_readdir_open_callback(
                         req);
 } /* chimera_nfs4_readdir_open_callback */
 
+/* ---- Named-attribute directory READDIR ----------------------------------
+ *
+ * The synthetic attr directory has no backend directory to enumerate; its
+ * entries are the base file's named streams.  We stat the base once (the entries
+ * inherit its owner/timestamps), list the streams (with their file handles), and
+ * synthesize one entry per named stream.  memfs returns the full stream list in
+ * one shot, so a single pass with index-based cookies covers continuation. */
+
+struct nfs4_attrdir_readdir_ctx {
+    struct nfs_request      *req;
+    struct chimera_vfs_attrs base_attr;
+    uint8_t                  records[64 * 1024];
+};
+
+static void
+chimera_nfs4_readdir_attrdir_list_callback(
+    enum chimera_vfs_error error_code,
+    const void            *records,
+    uint32_t               records_len,
+    uint32_t               count,
+    uint32_t               eof,
+    uint64_t               cookie,
+    void                  *private_data)
+{
+    struct nfs4_attrdir_readdir_ctx *ctx   = private_data;
+    struct nfs_request              *req   = ctx->req;
+    uint32_t                         in    = 0;
+    uint32_t                         index = 0;
+    uint32_t                         r_eof = eof;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        chimera_nfs4_readdir_complete(error_code, req->handle, 0, 0, 0, NULL, req);
+        free(ctx);
+        return;
+    }
+
+    while (in < records_len) {
+        struct chimera_vfs_stream_entry entry;
+        const char                     *name;
+        const uint8_t                  *fh;
+        struct chimera_vfs_attrs        attr;
+        uint32_t                        reclen;
+
+        memcpy(&entry, (const uint8_t *) records + in, sizeof(entry));
+        name = (const char *) records + in + sizeof(entry);
+        fh   = (const uint8_t *) records + in + sizeof(entry) + entry.name_len;
+
+        reclen = (sizeof(entry) + entry.name_len + entry.fh_len + 7) & ~7u;
+
+        /* Skip the unnamed default fork ("::$DATA") -- it is the file's own data,
+         * not a named attribute. */
+        if (entry.name_len == 0) {
+            in += reclen;
+            continue;
+        }
+
+        index++;
+
+        /* Index-based cookie: resume after the client's last-seen entry. */
+        if (index <= cookie) {
+            in += reclen;
+            continue;
+        }
+
+        attr               = ctx->base_attr;
+        attr.va_size       = entry.size;
+        attr.va_space_used = entry.alloc;
+        attr.va_set_mask  |= CHIMERA_VFS_ATTR_SIZE | CHIMERA_VFS_ATTR_SPACE_USED;
+
+        if (entry.fh_len) {
+            memcpy(attr.va_fh, fh, entry.fh_len);
+            attr.va_fh_len    = entry.fh_len;
+            attr.va_set_mask |= CHIMERA_VFS_ATTR_FH;
+            /* Give each named attribute a distinct, stable fileid derived from
+             * its handle (the base inode's ino would collide across streams). */
+            attr.va_ino       = chimera_vfs_hash(fh, entry.fh_len);
+            attr.va_set_mask |= CHIMERA_VFS_ATTR_INUM;
+        }
+
+        if (chimera_nfs4_readdir_callback(attr.va_ino, index, name,
+                                          entry.name_len, &attr, req) != 0) {
+            /* Entry did not fit: stop here, more remain. */
+            r_eof = 0;
+            break;
+        }
+
+        in += reclen;
+    }
+
+    chimera_nfs4_readdir_complete(CHIMERA_VFS_OK, req->handle, index, 0, r_eof,
+                                  NULL, req);
+    free(ctx);
+} /* chimera_nfs4_readdir_attrdir_list_callback */
+
+static void
+chimera_nfs4_readdir_attrdir_getattr_callback(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *attr,
+    void                     *private_data)
+{
+    struct nfs4_attrdir_readdir_ctx *ctx = private_data;
+    struct nfs_request              *req = ctx->req;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        chimera_nfs4_readdir_complete(error_code, req->handle, 0, 0, 0, NULL, req);
+        free(ctx);
+        return;
+    }
+
+    ctx->base_attr = *attr;
+
+    chimera_vfs_list_streams(req->thread->vfs_thread, &req->cred,
+                             req->handle,
+                             0,
+                             ctx->records,
+                             sizeof(ctx->records),
+                             1, /* want per-stream file handles */
+                             chimera_nfs4_readdir_attrdir_list_callback,
+                             ctx);
+} /* chimera_nfs4_readdir_attrdir_getattr_callback */
+
+static void
+chimera_nfs4_readdir_attrdir_open_callback(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *handle,
+    void                           *private_data)
+{
+    struct nfs4_attrdir_readdir_ctx *ctx  = private_data;
+    struct nfs_request              *req  = ctx->req;
+    struct READDIR4args             *args = &req->args_compound->argarray[req->index].opreaddir;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        req->handle = NULL;
+        chimera_nfs4_readdir_complete(error_code, NULL, 0, 0, 0, NULL, req);
+        free(ctx);
+        return;
+    }
+
+    req->handle = handle;
+
+    /* Stat the base file once; every named attribute inherits its
+     * owner/group/timestamps (size/fh/fileid are overridden per stream). */
+    chimera_vfs_getattr(req->thread->vfs_thread, &req->cred,
+                        handle,
+                        chimera_nfs4_attr2mask(args->attr_request,
+                                               args->num_attr_request),
+                        chimera_nfs4_readdir_attrdir_getattr_callback,
+                        ctx);
+} /* chimera_nfs4_readdir_attrdir_open_callback */
+
+static void
+chimera_nfs4_readdir_attrdir(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_request               *req)
+{
+    struct nfs4_attrdir_readdir_ctx *ctx;
+    const uint8_t                   *base;
+    int                              base_len;
+
+    ctx      = calloc(1, sizeof(*ctx));
+    ctx->req = req;
+
+    chimera_nfs4_attrdir_base(req->fh, req->fhlen, &base, &base_len);
+
+    chimera_vfs_open_fh(thread->vfs_thread, &req->cred,
+                        base, base_len,
+                        CHIMERA_VFS_OPEN_INFERRED | CHIMERA_VFS_OPEN_PATH,
+                        chimera_nfs4_readdir_attrdir_open_callback,
+                        ctx);
+} /* chimera_nfs4_readdir_attrdir */
+
 void
 chimera_nfs4_readdir(
     struct chimera_server_nfs_thread *thread,
@@ -246,6 +422,13 @@ chimera_nfs4_readdir(
     cursor->last    = NULL;
 
     res->resok4.reply.entries = NULL;
+
+    /* READDIR of a synthetic named-attribute directory: enumerate the base
+     * file's named streams instead of a real directory. */
+    if (chimera_nfs4_fh_is_attrdir(req->fh, req->fhlen)) {
+        chimera_nfs4_readdir_attrdir(thread, req);
+        return;
+    }
 
     chimera_vfs_open_fh(thread->vfs_thread, &req->cred,
                         req->fh,

--- a/src/server/nfs/nfs4_proc_remove.c
+++ b/src/server/nfs/nfs4_proc_remove.c
@@ -6,12 +6,69 @@
 
 #include "nfs4_procs.h"
 #include "nfs4_status.h"
+#include "nfs4_named_attr.h"
 #include "server/server.h"
 #include "nfs_internal.h"
 #include "vfs/vfs_procs.h"
 #include "vfs/vfs_release.h"
 #include "vfs/vfs_state.h"
 #include "vfs/vfs_pnfs.h"
+
+/* REMOVE of a name inside a named-attribute directory deletes the named stream
+ * of that name from the base file. */
+static void
+chimera_nfs4_remove_stream_complete(
+    enum chimera_vfs_error          error_code,
+    const struct chimera_vfs_attrs *pre_attr,
+    const struct chimera_vfs_attrs *post_attr,
+    void                           *private_data)
+{
+    struct nfs_request *req = private_data;
+    struct REMOVE4res  *res = &req->res_compound.resarray[req->index].opremove;
+
+    chimera_vfs_release(req->thread->vfs_thread, req->handle);
+    req->handle = NULL;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        res->status = chimera_nfs4_errno_to_nfsstat4(error_code);
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    /* change_info4 is non-atomic and best-effort here (mirrors the ordinary
+     * REMOVE path, which also leaves it zeroed). */
+    res->resok4.cinfo.atomic = 0;
+    res->resok4.cinfo.before = 0;
+    res->resok4.cinfo.after  = 0;
+
+    res->status = NFS4_OK;
+    chimera_nfs4_compound_complete(req, NFS4_OK);
+} /* chimera_nfs4_remove_stream_complete */
+
+static void
+chimera_nfs4_remove_attrdir_open_callback(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *handle,
+    void                           *private_data)
+{
+    struct nfs_request *req  = private_data;
+    struct REMOVE4args *args = &req->args_compound->argarray[req->index].opremove;
+    struct REMOVE4res  *res  = &req->res_compound.resarray[req->index].opremove;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        res->status = chimera_nfs4_errno_to_nfsstat4(error_code);
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    req->handle = handle;
+
+    chimera_vfs_remove_stream(req->thread->vfs_thread, &req->cred,
+                              handle,
+                              args->target.data, args->target.len,
+                              chimera_nfs4_remove_stream_complete,
+                              req);
+} /* chimera_nfs4_remove_attrdir_open_callback */
 
 /*
  * REMOVE.  When pNFS is enabled the target may be a flex-files file whose data
@@ -243,6 +300,21 @@ chimera_nfs4_remove(
 
     if (res->status != NFS4_OK) {
         chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    /* REMOVE inside a named-attribute directory: drop the named stream. */
+    if (chimera_nfs4_fh_is_attrdir(req->fh, req->fhlen)) {
+        const uint8_t *base;
+        int            base_len;
+
+        chimera_nfs4_attrdir_base(req->fh, req->fhlen, &base, &base_len);
+
+        chimera_vfs_open_fh(thread->vfs_thread, &req->cred,
+                            base, base_len,
+                            CHIMERA_VFS_OPEN_INFERRED | CHIMERA_VFS_OPEN_PATH,
+                            chimera_nfs4_remove_attrdir_open_callback,
+                            req);
         return;
     }
 

--- a/src/server/nfs/nfs4_proc_remove.c
+++ b/src/server/nfs/nfs4_proc_remove.c
@@ -8,12 +8,69 @@
 #include "nfs4_procs.h"
 #include "nfs4_status.h"
 #include "nfs4_attr.h"
+#include "nfs4_named_attr.h"
 #include "server/server.h"
 #include "nfs_internal.h"
 #include "vfs/vfs_procs.h"
 #include "vfs/vfs_release.h"
 #include "vfs/vfs_claim.h"
 #include "vfs/vfs_pnfs.h"
+
+/* REMOVE of a name inside a named-attribute directory deletes the named stream
+ * of that name from the base file. */
+static void
+chimera_nfs4_remove_stream_complete(
+    enum chimera_vfs_error          error_code,
+    const struct chimera_vfs_attrs *pre_attr,
+    const struct chimera_vfs_attrs *post_attr,
+    void                           *private_data)
+{
+    struct nfs_request *req = private_data;
+    struct REMOVE4res  *res = &req->res_compound.resarray[req->index].opremove;
+
+    chimera_vfs_release(req->thread->vfs_thread, req->handle);
+    req->handle = NULL;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        res->status = chimera_nfs4_errno_to_nfsstat4(error_code);
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    /* change_info4 is non-atomic and best-effort here (mirrors the ordinary
+     * REMOVE path, which also leaves it zeroed). */
+    res->resok4.cinfo.atomic = 0;
+    res->resok4.cinfo.before = 0;
+    res->resok4.cinfo.after  = 0;
+
+    res->status = NFS4_OK;
+    chimera_nfs4_compound_complete(req, NFS4_OK);
+} /* chimera_nfs4_remove_stream_complete */
+
+static void
+chimera_nfs4_remove_attrdir_open_callback(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *handle,
+    void                           *private_data)
+{
+    struct nfs_request *req  = private_data;
+    struct REMOVE4args *args = &req->args_compound->argarray[req->index].opremove;
+    struct REMOVE4res  *res  = &req->res_compound.resarray[req->index].opremove;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        res->status = chimera_nfs4_errno_to_nfsstat4(error_code);
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    req->handle = handle;
+
+    chimera_vfs_remove_stream(req->thread->vfs_thread, &req->cred,
+                              handle,
+                              args->target.data, args->target.len,
+                              chimera_nfs4_remove_stream_complete,
+                              req);
+} /* chimera_nfs4_remove_attrdir_open_callback */
 
 /*
  * REMOVE.  When pNFS is enabled the target may be a flex-files file whose data
@@ -254,6 +311,21 @@ chimera_nfs4_remove(
 
     if (res->status != NFS4_OK) {
         chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    /* REMOVE inside a named-attribute directory: drop the named stream. */
+    if (chimera_nfs4_fh_is_attrdir(req->fh, req->fhlen)) {
+        const uint8_t *base;
+        int            base_len;
+
+        chimera_nfs4_attrdir_base(req->fh, req->fhlen, &base, &base_len);
+
+        chimera_vfs_open_fh(thread->vfs_thread, &req->cred,
+                            base, base_len,
+                            CHIMERA_VFS_OPEN_INFERRED | CHIMERA_VFS_OPEN_PATH,
+                            chimera_nfs4_remove_attrdir_open_callback,
+                            req);
         return;
     }
 

--- a/src/server/nfs/nfs4_proc_verify.c
+++ b/src/server/nfs/nfs4_proc_verify.c
@@ -102,7 +102,8 @@ chimera_nfs4_verify_complete(
                                                              req->fh, req->fhlen),
                                 chimera_server_config_get_nfs4_delegations(
                                     req->thread->shared->config),
-                                req->thread->shared->nfs_lease_time_s);
+                                req->thread->shared->nfs_lease_time_s,
+                                0);
 
     bool match = (num_out_mask == args->num_attrmask) &&
         (memcmp(out_mask, args->attrmask,

--- a/src/server/nfs/nfs4_proc_verify.c
+++ b/src/server/nfs/nfs4_proc_verify.c
@@ -105,7 +105,8 @@ chimera_nfs4_verify_complete(
                                 req->thread->shared->nfs_lease_time_s,
                                 req->export_id,
                                 req->thread->shared->fh_key,
-                                req->thread->shared->fh_sign);
+                                req->thread->shared->fh_sign,
+                                0);
 
     bool match = (num_out_mask == args->num_attrmask) &&
         (memcmp(out_mask, args->attrmask,

--- a/src/server/nfs/nfs4_procs.h
+++ b/src/server/nfs/nfs4_procs.h
@@ -235,6 +235,13 @@ chimera_nfs4_lookup(
     struct nfs_resop4                *resop);
 
 void
+chimera_nfs4_openattr(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_request               *req,
+    struct nfs_argop4                *argop,
+    struct nfs_resop4                *resop);
+
+void
 chimera_nfs4_lookupp(
     struct chimera_server_nfs_thread *thread,
     struct nfs_request               *req,

--- a/src/server/nfs/nfs4_procs.h
+++ b/src/server/nfs/nfs4_procs.h
@@ -313,6 +313,13 @@ chimera_nfs4_lookup(
     struct nfs_resop4                *resop);
 
 void
+chimera_nfs4_openattr(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_request               *req,
+    struct nfs_argop4                *argop,
+    struct nfs_resop4                *resop);
+
+void
 chimera_nfs4_lookupp(
     struct chimera_server_nfs_thread *thread,
     struct nfs_request               *req,

--- a/src/server/nfs/nfs4_root.c
+++ b/src/server/nfs/nfs4_root.c
@@ -166,7 +166,8 @@ nfs4_root_readdir_lookup_callback(
                                 0, /* pNFS not advertised on the pseudo-fs root */
                                 0, /* pseudo-fs root has no xattr-capable backend */
                                 0,
-                                ctx->lease_time_s);
+                                ctx->lease_time_s,
+                                0);
 } /* nfs4_root_readdir_lookup_callback */
 
 struct nfs4_root_readdir_itr_ctx {

--- a/src/server/nfs/nfs4_root.c
+++ b/src/server/nfs/nfs4_root.c
@@ -582,7 +582,8 @@ nfs4_root_readdir_lookup_callback(
                                     req->thread->shared->nfs_lease_time_s,
                                     state->exports[state->pos].id,
                                     req->thread->shared->fh_key,
-                                    req->thread->shared->fh_sign);
+                                    req->thread->shared->fh_sign,
+                                    0); /* pseudo-fs root: no named-attr type override */
 
         dbuf_cur = req->encoding->dbuf->used - state->dbuf_before;
 

--- a/src/server/nfs/nfs4_state.c
+++ b/src/server/nfs/nfs4_state.c
@@ -1120,6 +1120,13 @@ open_state_cleanup(
         state->share_file_state = NULL;
     }
 
+    /* Drop the base-file stream holder taken for a named-attribute open. */
+    if (vfs_state && state->base_stream_file_state) {
+        chimera_vfs_state_stream_holder_dec(state->base_stream_file_state);
+        chimera_vfs_state_put(vfs_state, state->base_stream_file_state);
+        state->base_stream_file_state = NULL;
+    }
+
     if (state->handle && vfs_thread) {
         chimera_vfs_release(vfs_thread, state->handle);
         state->handle = NULL;

--- a/src/server/nfs/nfs4_state.c
+++ b/src/server/nfs/nfs4_state.c
@@ -1306,6 +1306,13 @@ open_state_cleanup(
         state->share_file_state = NULL;
     }
 
+    /* Drop the base-file stream holder taken for a named-attribute open. */
+    if (vfs_state && state->base_stream_file_state) {
+        chimera_vfs_state_stream_holder_dec(state->base_stream_file_state);
+        chimera_vfs_state_put(vfs_state, state->base_stream_file_state);
+        state->base_stream_file_state = NULL;
+    }
+
     if (state->handle && vfs_thread) {
         chimera_vfs_release(vfs_thread, state->handle);
         state->handle = NULL;

--- a/src/server/nfs/nfs4_state.h
+++ b/src/server/nfs/nfs4_state.h
@@ -326,6 +326,12 @@ struct nfs_open_state {
     struct chimera_vfs_file_state  *share_file_state;
     bool                            share_lease_held;
 
+    /* For an NFSv4 named-attribute (stream) open: a stream_holder taken on the
+     * BASE file's vfs_state so a cross-protocol base delete-on-close defers while
+     * this stream is open (the NFSv4 analogue of the SMB ADS stream holder).
+     * NULL for an ordinary file open; released in open_state_cleanup. */
+    struct chimera_vfs_file_state  *base_stream_file_state;
+
     /* Lifetime: starts at 1 for the state's slot; each acquire bumps it.
      * destroy() flips `destroyed` and drops the +1.  When refcount reaches
      * zero AND destroyed is set, the handle is released and the struct

--- a/src/server/nfs/nfs4_state.h
+++ b/src/server/nfs/nfs4_state.h
@@ -347,6 +347,12 @@ struct nfs_open_state {
     struct chimera_vfs_file_state  *share_file_state;
     bool                            share_claim_held;
 
+    /* For an NFSv4 named-attribute (stream) open: a stream_holder taken on the
+     * BASE file's vfs_state so a cross-protocol base delete-on-close defers while
+     * this stream is open (the NFSv4 analogue of the SMB ADS stream holder).
+     * NULL for an ordinary file open; released in open_state_cleanup. */
+    struct chimera_vfs_file_state  *base_stream_file_state;
+
     /* Lifetime: starts at 1 for the state's slot; each acquire bumps it.
      * destroy() flips `destroyed` and drops the +1.  When refcount reaches
      * zero AND destroyed is set, the handle is released and the struct

--- a/src/server/nfs/tests/quint/CMakeLists.txt
+++ b/src/server/nfs/tests/quint/CMakeLists.txt
@@ -55,6 +55,12 @@ target_include_directories(nfs4_deleg_probe PRIVATE
 target_link_libraries(nfs4_deleg_probe
     chimera_server chimera_nfs_common chimera_metrics jansson)
 
+add_executable(nfs4_named_attr_probe nfs4_named_attr_probe.c)
+target_include_directories(nfs4_named_attr_probe PRIVATE
+    ${CMAKE_BINARY_DIR}/src/nfs_common)
+target_link_libraries(nfs4_named_attr_probe
+    chimera_server chimera_nfs_common chimera_metrics jansson)
+
 add_executable(nfs_aux_probe nfs_aux_probe.c)
 target_include_directories(nfs_aux_probe PRIVATE
     ${CMAKE_BINARY_DIR}/src/nfs_common)
@@ -175,6 +181,18 @@ add_test(NAME chimera/server/nfs/mbt4/deleg_probe_memfs
     COMMAND $<TARGET_FILE:nfs4_deleg_probe>)
 set_tests_properties(chimera/server/nfs/mbt4/deleg_probe_memfs PROPERTIES
     ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=nfs4_deleg_probe_memfs"
+    LABELS "quint;nfs4_mbt;multiproto;memfs"
+    TIMEOUT 90)
+
+# Named-attribute (OPENATTR) probe: pins the full NFSv4 named-attribute
+# lifecycle the corpus never drives -- OPENATTR, OPEN-create/WRITE/READ of an
+# attribute, FATTR4_NAMED_ATTR tracking, READDIR/LOOKUP/REMOVE of the attr
+# directory -- exercising the shared VFS named-stream storage that SMB ADS also
+# projects onto.  Needs no corpus.
+add_test(NAME chimera/server/nfs/mbt4/named_attr_probe_memfs
+    COMMAND $<TARGET_FILE:nfs4_named_attr_probe>)
+set_tests_properties(chimera/server/nfs/mbt4/named_attr_probe_memfs PROPERTIES
+    ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=nfs4_named_attr_probe_memfs"
     LABELS "quint;nfs4_mbt;multiproto;memfs"
     TIMEOUT 90)
 

--- a/src/server/nfs/tests/quint/nfs3_mbt_common.h
+++ b/src/server/nfs/tests/quint/nfs3_mbt_common.h
@@ -132,6 +132,8 @@ struct mbt_result {
  * three; the NFS3 defaults need none). */
 struct mbt_env_opts {
     int         nfs4_delegations; /* delegations are off by default */
+    int         smb_named_streams; /* NFSv4 OPENATTR / named attributes: off by
+                                    * default (the shared knob gates OPENATTR) */
     int         disable_caches;   /* VFS attr+name caches: exact attr
                                    * comparison cannot tolerate staleness */
     const char *memfs_config;     /* module config JSON, e.g. block_size */
@@ -454,6 +456,9 @@ mbt_env_open_opts(
     if (opts) {
         if (opts->nfs4_delegations) {
             chimera_server_config_set_nfs4_delegations(config, 1);
+        }
+        if (opts->smb_named_streams) {
+            chimera_server_config_set_smb_named_streams(config, 1);
         }
         if (opts->portmap_hostname) {
             chimera_server_config_set_portmap_hostname(config,

--- a/src/server/nfs/tests/quint/nfs4_named_attr_probe.c
+++ b/src/server/nfs/tests/quint/nfs4_named_attr_probe.c
@@ -1,0 +1,811 @@
+/* SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+ *
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ * NFSv4.1 named-attribute (OPENATTR) ground-truth probe.
+ *
+ * The MBT corpus has no OPENATTR / named-attribute coverage, so the whole
+ * named-attribute lifecycle is dark to the model.  Named attributes are the
+ * NFS view of the exact VFS named-stream storage that SMB alternate data
+ * streams project onto (open_stream/list_streams/remove_stream,
+ * CAP_NAMED_STREAMS, the memfs per-inode stream list), so this probe is the NFS
+ * half of the cross-protocol stream coverage.
+ *
+ * It drives the full lifecycle end-to-end against the in-process server:
+ *   - create a base file, confirm FATTR4_NAMED_ATTR is FALSE;
+ *   - OPENATTR the file to reach its synthetic named-attribute directory;
+ *   - OPEN(CLAIM_NULL, create) a named attribute, WRITE and READ its content
+ *     back byte-identical (exercising the stream filehandle data path
+ *     memfs_open_fh decodes);
+ *   - confirm FATTR4_NAMED_ATTR is now TRUE;
+ *   - READDIR the attr directory and LOOKUP the attribute by name;
+ *   - REMOVE the attribute and confirm FATTR4_NAMED_ATTR is FALSE again and the
+ *     attr directory is empty.
+ * OPENATTR is gated on the shared smb_named_streams knob, enabled here.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "nfs3_mbt_common.h"
+#include "common/mbt_watchdog.h"
+
+static int failures = 0;
+
+static void
+expect(
+    const char *label,
+    int         ok,
+    const char *detail)
+{
+    if (!ok) {
+        printf("  FAIL %s: %s\n", label, detail);
+        failures++;
+    } else {
+        printf("  ok  %s: %s\n", label, detail);
+    }
+} /* expect */
+
+/* ---- one probed 4.1 client ------------------------------------------------ */
+
+struct pc {
+    struct mbt_env        *env;
+    struct evpl_rpc2_conn *conn;
+    uint64_t               clientid;
+    uint8_t                sessionid[16];
+    uint32_t               slot_seq;
+};
+
+/* Minimal back-channel responder: named attributes never recall, but the
+ * session negotiates a back channel, so answer CB_SEQUENCE (and refuse the rest)
+ * to keep the transport clean. */
+static void
+na_cb_compound(
+    struct evpl               *evpl,
+    struct evpl_rpc2_conn     *conn,
+    struct evpl_rpc2_cred     *cred,
+    struct CB_COMPOUND4args   *args,
+    struct evpl_rpc2_encoding *encoding,
+    void                      *private_data)
+{
+    struct pc             *pc = private_data;
+    struct CB_COMPOUND4res res;
+    struct nfs_cb_resop4  *resarray;
+    uint32_t               i;
+    int                    rc;
+
+    (void) conn;
+    (void) cred;
+
+    memset(&res, 0, sizeof(res));
+    resarray = xdr_dbuf_alloc_space(
+        sizeof(*resarray) * (args->num_argarray ? args->num_argarray : 1),
+        encoding->dbuf);
+    if (!resarray) {
+        res.status = NFS4ERR_RESOURCE;
+        rc         = pc->env->nfs_v4_cb.send_reply_CB_COMPOUND(evpl, NULL, &res,
+                                                               encoding);
+        (void) rc;
+        return;
+    }
+
+    for (i = 0; i < args->num_argarray; i++) {
+        struct nfs_cb_argop4 *argop = &args->argarray[i];
+        struct nfs_cb_resop4 *resop = &resarray[i];
+
+        memset(resop, 0, sizeof(*resop));
+        resop->resop = argop->argop;
+        switch (argop->argop) {
+            case OP_CB_SEQUENCE:
+                memcpy(resop->opcbsequence.csr_resok4.csr_sessionid,
+                       argop->opcbsequence.csa_sessionid, 16);
+                resop->opcbsequence.csr_resok4.csr_sequenceid =
+                    argop->opcbsequence.csa_sequenceid;
+                resop->opcbsequence.csr_resok4.csr_slotid =
+                    argop->opcbsequence.csa_slotid;
+                resop->opcbsequence.csr_resok4.csr_highest_slotid =
+                    argop->opcbsequence.csa_highest_slotid;
+                resop->opcbsequence.csr_resok4.csr_target_highest_slotid =
+                    argop->opcbsequence.csa_highest_slotid;
+                resop->opcbsequence.csr_status = NFS4_OK;
+                break;
+            default:
+                resop->opcbrecall.status = NFS4ERR_NOTSUPP;
+                break;
+        } /* switch */
+    }
+    res.status       = NFS4_OK;
+    res.num_resarray = args->num_argarray;
+    res.resarray     = resarray;
+    rc               = pc->env->nfs_v4_cb.send_reply_CB_COMPOUND(evpl, NULL, &res,
+                                                                 encoding);
+    (void) rc;
+} /* na_cb_compound */
+
+/* ---- one compound's parsed reply ------------------------------------------ */
+
+#define P_MAX_NAMES 16
+
+struct prep {
+    int             done;
+    int             rpc_err;
+    uint32_t        status;
+    int             nres;
+    uint32_t        st[10];           /* per-op status */
+    struct mbt_fh   fh;               /* last GETFH */
+    struct stateid4 open_sid;         /* last OPEN stateid */
+    uint32_t        write_count;      /* last WRITE */
+    uint8_t         rdata[256];       /* last READ payload */
+    uint32_t        rlen;
+    int             named_attr;       /* last GETATTR FATTR4_NAMED_ATTR */
+    int             named_attr_valid;
+    int             nnames;           /* last READDIR entry names */
+    char            names[P_MAX_NAMES][64];
+    uint64_t        clientid;         /* EXCHANGE_ID */
+    uint32_t        eir_seq;
+    uint8_t         sessionid[16];    /* CREATE_SESSION */
+};
+
+/* Extract FATTR4_NAMED_ATTR from a fattr4 that requested exactly that bit. */
+static int
+fattr_named_attr(
+    const struct fattr4 *f,
+    int                 *valid)
+{
+    uint32_t w0 = f->num_attrmask > 0 ? f->attrmask[0] : 0;
+
+    *valid = 0;
+    if ((w0 & (1U << FATTR4_NAMED_ATTR)) && f->attr_vals.len >= 4) {
+        const uint8_t *p = f->attr_vals.data;
+
+        *valid = 1;
+        return (p[0] | p[1] | p[2] | p[3]) ? 1 : 0; /* XDR bool */
+    }
+    return 0;
+} /* fattr_named_attr */
+
+static void
+prep_cb(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    struct COMPOUND4res         *reply,
+    int                          status,
+    void                        *private_data)
+{
+    struct prep *p = private_data;
+    uint32_t     i;
+
+    (void) verf;
+    p->rpc_err = status;
+    if (status == 0) {
+        p->status = reply->status;
+        p->nres   = (int) reply->num_resarray;
+        for (i = 0; i < reply->num_resarray && i < 10; i++) {
+            const struct nfs_resop4 *r = &reply->resarray[i];
+
+            switch (r->resop) {
+                case OP_SEQUENCE:
+                    p->st[i] = r->opsequence.sr_status;
+                    break;
+                case OP_PUTFH:
+                    p->st[i] = r->opputfh.status;
+                    break;
+                case OP_PUTROOTFH:
+                    p->st[i] = r->opputrootfh.status;
+                    break;
+                case OP_LOOKUP:
+                    p->st[i] = r->oplookup.status;
+                    break;
+                case OP_GETFH:
+                    p->st[i] = r->opgetfh.status;
+                    if (p->st[i] == NFS4_OK) {
+                        mbt_copy_fh(&p->fh, &r->opgetfh.resok4.object);
+                    }
+                    break;
+                case OP_OPENATTR:
+                    p->st[i] = r->opopenattr.status;
+                    break;
+                case OP_OPEN:
+                    p->st[i] = r->opopen.status;
+                    if (p->st[i] == NFS4_OK) {
+                        p->open_sid = r->opopen.resok4.stateid;
+                    }
+                    break;
+                case OP_CLOSE:
+                    p->st[i] = r->opclose.status;
+                    break;
+                case OP_WRITE:
+                    p->st[i] = r->opwrite.status;
+                    if (p->st[i] == NFS4_OK) {
+                        p->write_count = r->opwrite.resok4.count;
+                    }
+                    break;
+                case OP_READ:
+                    p->st[i] = r->opread.status;
+                    p->rlen  = 0;
+                    if (p->st[i] == NFS4_OK) {
+                        int k;
+
+                        for (k = 0; k < r->opread.resok4.data.niov; k++) {
+                            uint32_t n = r->opread.resok4.data.iov[k].length;
+
+                            if (p->rlen + n <= sizeof(p->rdata)) {
+                                memcpy(p->rdata + p->rlen,
+                                       r->opread.resok4.data.iov[k].data, n);
+                                p->rlen += n;
+                            }
+                            evpl_iovec_release(evpl,
+                                               &r->opread.resok4.data.iov[k]);
+                        }
+                    }
+                    break;
+                case OP_READDIR:
+                    p->st[i]  = r->opreaddir.status;
+                    p->nnames = 0;
+                    if (p->st[i] == NFS4_OK) {
+                        const struct entry4 *e;
+
+                        for (e = r->opreaddir.resok4.reply.entries;
+                             e && p->nnames < P_MAX_NAMES; e = e->nextentry) {
+                            uint32_t n = e->name.len < 63 ? e->name.len : 63;
+
+                            memcpy(p->names[p->nnames], e->name.data, n);
+                            p->names[p->nnames][n] = '\0';
+                            p->nnames++;
+                        }
+                    }
+                    break;
+                case OP_GETATTR:
+                    p->st[i] = r->opgetattr.status;
+                    if (p->st[i] == NFS4_OK) {
+                        p->named_attr =
+                            fattr_named_attr(&r->opgetattr.resok4.obj_attributes,
+                                             &p->named_attr_valid);
+                    }
+                    break;
+                case OP_REMOVE:
+                    p->st[i] = r->opremove.status;
+                    break;
+                case OP_EXCHANGE_ID:
+                    p->st[i] = r->opexchange_id.eir_status;
+                    if (p->st[i] == NFS4_OK) {
+                        p->clientid = r->opexchange_id.eir_resok4.eir_clientid;
+                        p->eir_seq  = r->opexchange_id.eir_resok4.eir_sequenceid;
+                    }
+                    break;
+                case OP_CREATE_SESSION:
+                    p->st[i] = r->opcreate_session.csr_status;
+                    if (p->st[i] == NFS4_OK) {
+                        memcpy(p->sessionid,
+                               r->opcreate_session.csr_resok4.csr_sessionid, 16);
+                    }
+                    break;
+                default:
+                    p->st[i] = 0;
+                    break;
+            } /* switch */
+        }
+    }
+    p->done = 1;
+} /* prep_cb */
+
+static struct prep
+pc_compound(
+    struct pc         *pc,
+    struct nfs_argop4 *ops,
+    int                nops,
+    int                with_seq)
+{
+    struct nfs_argop4    argarray[10];
+    struct COMPOUND4args args;
+    struct prep          p;
+    int                  base = 0;
+    int                  i;
+
+    memset(&p, 0, sizeof(p));
+    memset(&args, 0, sizeof(args));
+
+    if (with_seq) {
+        memset(&argarray[0], 0, sizeof(argarray[0]));
+        argarray[0].argop = OP_SEQUENCE;
+        memcpy(argarray[0].opsequence.sa_sessionid, pc->sessionid, 16);
+        argarray[0].opsequence.sa_sequenceid     = ++pc->slot_seq;
+        argarray[0].opsequence.sa_slotid         = 0;
+        argarray[0].opsequence.sa_highest_slotid = 0;
+        argarray[0].opsequence.sa_cachethis      = 0;
+        base                                     = 1;
+    }
+    for (i = 0; i < nops; i++) {
+        argarray[base + i] = ops[i];
+    }
+    args.minorversion = 1;
+    args.argarray     = argarray;
+    args.num_argarray = (uint32_t) (base + nops);
+
+    pc->env->nfs_v4.send_call_NFSPROC4_COMPOUND(&pc->env->nfs_v4.rpc2,
+                                                pc->env->evpl, pc->conn,
+                                                &pc->env->cred, &args,
+                                                0, 0, NULL, 0, 0,
+                                                prep_cb, &p);
+    while (!p.done) {
+        evpl_continue(pc->env->evpl);
+    }
+    if (p.rpc_err) {
+        fprintf(stderr, "transport error %d\n", p.rpc_err);
+        exit(2);
+    }
+    return p;
+} /* pc_compound */
+
+static void
+pc_setup(
+    struct pc      *pc,
+    struct mbt_env *env)
+{
+    struct evpl_rpc2_program         *cb_programs[1];
+    struct evpl_endpoint             *ep;
+    struct nfs_argop4                 op;
+    struct prep                       p;
+    static char                       owner[32];
+    struct channel_attrs4             chan = {
+        .ca_headerpadsize          = 0,
+        .ca_maxrequestsize         = 1048576,
+        .ca_maxresponsesize        = 1048576,
+        .ca_maxresponsesize_cached = 65536,
+        .ca_maxoperations          = 16,
+        .ca_maxrequests            = 32,
+        .num_ca_rdma_ird           = 0,
+    };
+    static struct callback_sec_parms4 sec = { .cb_secflavor = 0 };
+
+    memset(pc, 0, sizeof(*pc));
+    pc->env = env;
+
+    cb_programs[0] = &env->nfs_v4_cb.rpc2;
+    ep             = chimera_tcp_flavor_endpoint_create(CHIMERA_TCP_FLAVOR_INPROC,
+                                                        "127.0.0.1", 2049);
+    pc->conn = evpl_rpc2_client_connect(env->rpc2_thread,
+                                        EVPL_STREAM_INPROC, ep,
+                                        cb_programs, 1, pc);
+
+    memset(&op, 0, sizeof(op));
+    op.argop = OP_EXCHANGE_ID;
+    snprintf(owner, sizeof(owner), "na-probe");
+    memset(op.opexchange_id.eia_clientowner.co_verifier, 1, 8);
+    op.opexchange_id.eia_clientowner.co_ownerid.data = owner;
+    op.opexchange_id.eia_clientowner.co_ownerid.len  = (uint32_t) strlen(owner);
+    op.opexchange_id.eia_state_protect.spa_how       = SP4_NONE;
+    p                                                = pc_compound(pc, &op, 1, 0);
+    if (p.status != NFS4_OK) {
+        fprintf(stderr, "EXCHANGE_ID failed: %u\n", p.status);
+        exit(2);
+    }
+    pc->clientid = p.clientid;
+
+    memset(&op, 0, sizeof(op));
+    op.argop                                = OP_CREATE_SESSION;
+    op.opcreate_session.csa_clientid        = pc->clientid;
+    op.opcreate_session.csa_sequence        = p.eir_seq;
+    op.opcreate_session.csa_flags           = CREATE_SESSION4_FLAG_CONN_BACK_CHAN;
+    op.opcreate_session.csa_fore_chan_attrs = chan;
+    op.opcreate_session.csa_back_chan_attrs = chan;
+    op.opcreate_session.csa_cb_program      = 0x40000000;
+    op.opcreate_session.num_csa_sec_parms   = 1;
+    op.opcreate_session.csa_sec_parms       = &sec;
+    p                                       = pc_compound(pc, &op, 1, 0);
+    if (p.status != NFS4_OK) {
+        fprintf(stderr, "CREATE_SESSION failed: %u\n", p.status);
+        exit(2);
+    }
+    memcpy(pc->sessionid, p.sessionid, 16);
+
+    memset(&op, 0, sizeof(op));
+    op.argop                         = OP_RECLAIM_COMPLETE;
+    op.opreclaim_complete.rca_one_fs = 0;
+    p                                = pc_compound(pc, &op, 1, 1);
+    if (p.status != NFS4_OK) {
+        fprintf(stderr, "RECLAIM_COMPLETE failed: %u\n", p.status);
+        exit(2);
+    }
+} /* pc_setup */
+
+/* ---- op builders ---------------------------------------------------------- */
+
+static struct nfs_argop4
+op_putfh(const struct mbt_fh *fh)
+{
+    struct nfs_argop4 a;
+
+    memset(&a, 0, sizeof(a));
+    a.argop               = OP_PUTFH;
+    a.opputfh.object.data = (void *) fh->data;
+    a.opputfh.object.len  = fh->len;
+    return a;
+} /* op_putfh */
+
+static struct nfs_argop4
+op_getfh(void)
+{
+    struct nfs_argop4 a;
+
+    memset(&a, 0, sizeof(a));
+    a.argop = OP_GETFH;
+    return a;
+} /* op_getfh */
+
+static struct nfs_argop4
+op_openattr(int createdir)
+{
+    struct nfs_argop4 a;
+
+    memset(&a, 0, sizeof(a));
+    a.argop                = OP_OPENATTR;
+    a.opopenattr.createdir = createdir != 0;
+    return a;
+} /* op_openattr */
+
+static struct nfs_argop4
+op_open(
+    uint64_t    clientid,
+    const char *owner,
+    const char *name,
+    uint32_t    access,
+    int         create)
+{
+    struct nfs_argop4 a;
+
+    memset(&a, 0, sizeof(a));
+    a.argop                   = OP_OPEN;
+    a.opopen.seqid            = 0;
+    a.opopen.share_access     = access;
+    a.opopen.share_deny       = 0;
+    a.opopen.owner.clientid   = clientid;
+    a.opopen.owner.owner.data = (void *) owner;
+    a.opopen.owner.owner.len  = (uint32_t) strlen(owner);
+    if (create) {
+        a.opopen.openhow.opentype                      = OPEN4_CREATE;
+        a.opopen.openhow.how.mode                      = UNCHECKED4;
+        a.opopen.openhow.how.createattrs.num_attrmask  = 0;
+        a.opopen.openhow.how.createattrs.attr_vals.len = 0;
+    } else {
+        a.opopen.openhow.opentype = OPEN4_NOCREATE;
+    }
+    a.opopen.claim.claim     = CLAIM_NULL;
+    a.opopen.claim.file.data = (void *) name;
+    a.opopen.claim.file.len  = (uint32_t) strlen(name);
+    return a;
+} /* op_open */
+
+static struct nfs_argop4
+op_close(const struct stateid4 *sid)
+{
+    struct nfs_argop4 a;
+
+    memset(&a, 0, sizeof(a));
+    a.argop                = OP_CLOSE;
+    a.opclose.seqid        = 0;
+    a.opclose.open_stateid = *sid;
+    return a;
+} /* op_close */
+
+static struct nfs_argop4
+op_write(
+    struct mbt_env        *env,
+    const struct stateid4 *sid,
+    uint64_t               off,
+    const void            *data,
+    uint32_t               len,
+    struct evpl_iovec     *iov)
+{
+    struct nfs_argop4 a;
+
+    memset(&a, 0, sizeof(a));
+    if (evpl_iovec_alloc(env->evpl, len, 4096, 1, 0, iov) < 0) {
+        fprintf(stderr, "evpl_iovec_alloc(%u) failed\n", len);
+        exit(2);
+    }
+    memcpy(iov->data, data, len);
+    iov->length = (int) len;
+
+    a.argop               = OP_WRITE;
+    a.opwrite.stateid     = *sid;
+    a.opwrite.offset      = off;
+    a.opwrite.stable      = FILE_SYNC4;
+    a.opwrite.data.iov    = iov;
+    a.opwrite.data.niov   = 1;
+    a.opwrite.data.length = len;
+    return a;
+} /* op_write */
+
+static struct nfs_argop4
+op_read(
+    const struct stateid4 *sid,
+    uint64_t               off,
+    uint32_t               len)
+{
+    struct nfs_argop4 a;
+
+    memset(&a, 0, sizeof(a));
+    a.argop          = OP_READ;
+    a.opread.stateid = *sid;
+    a.opread.offset  = off;
+    a.opread.count   = len;
+    return a;
+} /* op_read */
+
+/* GETATTR requesting exactly FATTR4_NAMED_ATTR. */
+static uint32_t na_mask[1] = { 1U << FATTR4_NAMED_ATTR };
+
+static struct nfs_argop4
+op_getattr_na(void)
+{
+    struct nfs_argop4 a;
+
+    memset(&a, 0, sizeof(a));
+    a.argop                      = OP_GETATTR;
+    a.opgetattr.attr_request     = na_mask;
+    a.opgetattr.num_attr_request = 1;
+    return a;
+} /* op_getattr_na */
+
+static struct nfs_argop4
+op_readdir(void)
+{
+    struct nfs_argop4 a;
+
+    memset(&a, 0, sizeof(a));
+    a.argop                      = OP_READDIR;
+    a.opreaddir.cookie           = 0;
+    a.opreaddir.dircount         = 65536;
+    a.opreaddir.maxcount         = 1048576;
+    a.opreaddir.attr_request     = NULL;
+    a.opreaddir.num_attr_request = 0;
+    return a;
+} /* op_readdir */
+
+static struct nfs_argop4
+op_lookup(const char *name)
+{
+    struct nfs_argop4 a;
+
+    memset(&a, 0, sizeof(a));
+    a.argop                 = OP_LOOKUP;
+    a.oplookup.objname.data = (void *) name;
+    a.oplookup.objname.len  = (uint32_t) strlen(name);
+    return a;
+} /* op_lookup */
+
+static struct nfs_argop4
+op_remove(const char *name)
+{
+    struct nfs_argop4 a;
+
+    memset(&a, 0, sizeof(a));
+    a.argop                = OP_REMOVE;
+    a.opremove.target.data = (void *) name;
+    a.opremove.target.len  = (uint32_t) strlen(name);
+    return a;
+} /* op_remove */
+
+/* names_contain: does the last READDIR reply carry `name`? */
+static int
+names_contain(
+    const struct prep *p,
+    const char        *name)
+{
+    int i;
+
+    for (i = 0; i < p->nnames; i++) {
+        if (strcmp(p->names[i], name) == 0) {
+            return 1;
+        }
+    }
+    return 0;
+} /* names_contain */
+
+int
+main(void)
+{
+    struct mbt_env_opts opts = {
+        .smb_named_streams = 1,
+        .disable_caches    = 1,
+    };
+    struct mbt_env     *env = malloc(sizeof(*env));
+    struct pc           pc;
+    struct mbt_fh       root, base_fh, attrdir_fh, stream_fh;
+    struct stateid4     base_sid, stream_sid;
+    struct prep         p;
+    struct evpl_iovec   wiov;
+    const char         *owner = "na-open";
+    const char         *aname = "myattr";
+    const char         *adata = "NAMED-ATTRIBUTE-DATA";
+    uint32_t            alen  = (uint32_t) strlen(adata);
+
+    setvbuf(stdout, NULL, _IONBF, 0);
+    mbt_watchdog_arm(60);
+    mbt_env_start_opts(env, &opts);
+    env->nfs_v4_cb.recv_call_CB_COMPOUND = na_cb_compound;
+
+    /* Resolve the export root (minor 0, no session). */
+    {
+        struct nfs_argop4    ops[3];
+        struct COMPOUND4args args;
+        struct prep          rp;
+
+        memset(ops, 0, sizeof(ops));
+        ops[0].argop                 = OP_PUTROOTFH;
+        ops[1].argop                 = OP_LOOKUP;
+        ops[1].oplookup.objname.data = "fs0";
+        ops[1].oplookup.objname.len  = 3;
+        ops[2].argop                 = OP_GETFH;
+
+        memset(&args, 0, sizeof(args));
+        args.minorversion = 0;
+        args.argarray     = ops;
+        args.num_argarray = 3;
+        memset(&rp, 0, sizeof(rp));
+        env->nfs_v4.send_call_NFSPROC4_COMPOUND(&env->nfs_v4.rpc2, env->evpl,
+                                                env->nfs_conn, &env->cred, &args,
+                                                0, 0, NULL, 0, 0, prep_cb, &rp);
+        while (!rp.done) {
+            evpl_continue(env->evpl);
+        }
+        if (rp.status != NFS4_OK || !rp.fh.has) {
+            fprintf(stderr, "resolve export root failed: %u\n", rp.status);
+            return 2;
+        }
+        root = rp.fh;
+    }
+
+    pc_setup(&pc, env);
+
+    printf("# --- NFSv4 named-attribute lifecycle ---\n");
+
+    /* Create the base file: PUTFH(root) + OPEN(create) + GETFH. */
+    {
+        struct nfs_argop4 ops[3];
+
+        ops[0] = op_putfh(&root);
+        ops[1] = op_open(pc.clientid, owner, "basefile", 3 /* BOTH */, 1);
+        ops[2] = op_getfh();
+        p      = pc_compound(&pc, ops, 3, 1);
+        expect("create-base", p.status == NFS4_OK && p.fh.has,
+               "OPEN(create) basefile + GETFH");
+        base_fh  = p.fh;
+        base_sid = p.open_sid;
+
+        /* Close the base open; the file persists. */
+        {
+            struct nfs_argop4 cops[2];
+
+            cops[0] = op_putfh(&base_fh);
+            cops[1] = op_close(&base_sid);
+            p       = pc_compound(&pc, cops, 2, 1);
+            expect("close-base", p.status == NFS4_OK, "CLOSE basefile");
+        }
+    }
+
+    /* FATTR4_NAMED_ATTR is FALSE on a fresh file. */
+    {
+        struct nfs_argop4 ops[2];
+
+        ops[0] = op_putfh(&base_fh);
+        ops[1] = op_getattr_na();
+        p      = pc_compound(&pc, ops, 2, 1);
+        expect("named-attr-false", p.status == NFS4_OK && p.named_attr_valid &&
+               p.named_attr == 0, "GETATTR NAMED_ATTR == FALSE before any attr");
+    }
+
+    /* OPENATTR: reach the synthetic named-attribute directory. */
+    {
+        struct nfs_argop4 ops[3];
+
+        ops[0] = op_putfh(&base_fh);
+        ops[1] = op_openattr(1);
+        ops[2] = op_getfh();
+        p      = pc_compound(&pc, ops, 3, 1);
+        expect("openattr", p.status == NFS4_OK && p.fh.has,
+               "OPENATTR + GETFH -> attr directory handle");
+        attrdir_fh = p.fh;
+    }
+
+    /* OPEN(create) a named attribute in the attr directory, then GETFH. */
+    {
+        struct nfs_argop4 ops[3];
+
+        ops[0] = op_putfh(&attrdir_fh);
+        ops[1] = op_open(pc.clientid, owner, aname, 3 /* BOTH */, 1);
+        ops[2] = op_getfh();
+        p      = pc_compound(&pc, ops, 3, 1);
+        expect("create-attr", p.status == NFS4_OK && p.fh.has,
+               "OPEN(create) named attribute + GETFH");
+        stream_fh  = p.fh;
+        stream_sid = p.open_sid;
+    }
+
+    /* WRITE then READ the attribute content back byte-identical. */
+    {
+        struct nfs_argop4 ops[2];
+
+        ops[0] = op_putfh(&stream_fh);
+        ops[1] = op_write(env, &stream_sid, 0, adata, alen, &wiov);
+        p      = pc_compound(&pc, ops, 2, 1);
+        expect("write-attr", p.status == NFS4_OK && p.write_count == alen,
+               "WRITE the named attribute's content");
+
+        ops[0] = op_putfh(&stream_fh);
+        ops[1] = op_read(&stream_sid, 0, sizeof(p.rdata));
+        p      = pc_compound(&pc, ops, 2, 1);
+        expect("read-attr", p.status == NFS4_OK && p.rlen == alen &&
+               memcmp(p.rdata, adata, alen) == 0,
+               "READ returns the attribute content byte-identical");
+
+        ops[0] = op_putfh(&stream_fh);
+        ops[1] = op_close(&stream_sid);
+        p      = pc_compound(&pc, ops, 2, 1);
+        expect("close-attr", p.status == NFS4_OK, "CLOSE the named attribute");
+    }
+
+    /* FATTR4_NAMED_ATTR is now TRUE. */
+    {
+        struct nfs_argop4 ops[2];
+
+        ops[0] = op_putfh(&base_fh);
+        ops[1] = op_getattr_na();
+        p      = pc_compound(&pc, ops, 2, 1);
+        expect("named-attr-true", p.status == NFS4_OK && p.named_attr_valid &&
+               p.named_attr == 1, "GETATTR NAMED_ATTR == TRUE after create");
+    }
+
+    /* READDIR the attr directory lists the attribute; LOOKUP resolves it. */
+    {
+        struct nfs_argop4 ops[2];
+
+        ops[0] = op_putfh(&attrdir_fh);
+        ops[1] = op_readdir();
+        p      = pc_compound(&pc, ops, 2, 1);
+        expect("readdir-attr", p.status == NFS4_OK && names_contain(&p, aname),
+               "READDIR the attr directory lists the attribute");
+
+        ops[0] = op_putfh(&attrdir_fh);
+        ops[1] = op_lookup(aname);
+        p      = pc_compound(&pc, ops, 2, 1);
+        expect("lookup-attr", p.status == NFS4_OK,
+               "LOOKUP the attribute by name in the attr directory");
+    }
+
+    /* REMOVE the attribute; NAMED_ATTR falls back to FALSE and the dir empties. */
+    {
+        struct nfs_argop4 ops[2];
+
+        ops[0] = op_putfh(&attrdir_fh);
+        ops[1] = op_remove(aname);
+        p      = pc_compound(&pc, ops, 2, 1);
+        expect("remove-attr", p.status == NFS4_OK,
+               "REMOVE the named attribute");
+
+        ops[0] = op_putfh(&base_fh);
+        ops[1] = op_getattr_na();
+        p      = pc_compound(&pc, ops, 2, 1);
+        expect("named-attr-false-again", p.status == NFS4_OK &&
+               p.named_attr_valid && p.named_attr == 0,
+               "GETATTR NAMED_ATTR == FALSE after remove");
+
+        ops[0] = op_putfh(&attrdir_fh);
+        ops[1] = op_readdir();
+        p      = pc_compound(&pc, ops, 2, 1);
+        expect("readdir-empty", p.status == NFS4_OK && !names_contain(&p, aname),
+               "the attr directory no longer lists the attribute");
+    }
+
+    mbt_env_stop(env);
+    free(env);
+
+    if (failures) {
+        fprintf(stderr, "%d NFSv4 named-attribute check(s) FAILED\n", failures);
+        return 1;
+    }
+    printf("all NFSv4 named-attribute checks passed\n");
+    return 0;
+} /* main */

--- a/src/server/nfs/tests/test_protocol_advertise.c
+++ b/src/server/nfs/tests/test_protocol_advertise.c
@@ -43,7 +43,7 @@ test_open_arguments_supported_attrs_follows_delegation_config(void)
     req_mask[0] = (1 << FATTR4_SUPPORTED_ATTRS);
 
     chimera_nfs4_marshall_attrs(&attr, 3, req_mask, &num_rsp_mask, rsp_mask, 3,
-                                attrvals, &attrvals_len, sizeof(attrvals), 1, 0, 0, 0, 60);
+                                attrvals, &attrvals_len, sizeof(attrvals), 1, 0, 0, 0, 60, 0);
 
     assert(num_rsp_mask == 1);
     assert(rsp_mask[0] == (1 << FATTR4_SUPPORTED_ATTRS));
@@ -53,7 +53,7 @@ test_open_arguments_supported_attrs_follows_delegation_config(void)
     memset(rsp_mask, 0, sizeof(rsp_mask));
     memset(attrvals, 0, sizeof(attrvals));
     chimera_nfs4_marshall_attrs(&attr, 3, req_mask, &num_rsp_mask, rsp_mask, 3,
-                                attrvals, &attrvals_len, sizeof(attrvals), 1, 0, 0, 1, 60);
+                                attrvals, &attrvals_len, sizeof(attrvals), 1, 0, 0, 1, 60, 0);
 
     assert(num_rsp_mask == 1);
     assert(rsp_mask[0] == (1 << FATTR4_SUPPORTED_ATTRS));
@@ -75,7 +75,7 @@ test_open_arguments_attr_follows_delegation_config(void)
     req_mask[2] = (1 << (FATTR4_OPEN_ARGUMENTS - 64));
 
     chimera_nfs4_marshall_attrs(&attr, 3, req_mask, &num_rsp_mask, rsp_mask, 3,
-                                attrvals, &attrvals_len, sizeof(attrvals), 1, 0, 0, 0, 60);
+                                attrvals, &attrvals_len, sizeof(attrvals), 1, 0, 0, 0, 60, 0);
 
     assert(num_rsp_mask == 0);
     assert(attrvals_len == 0);
@@ -84,7 +84,7 @@ test_open_arguments_attr_follows_delegation_config(void)
     memset(rsp_mask, 0, sizeof(rsp_mask));
     memset(attrvals, 0, sizeof(attrvals));
     chimera_nfs4_marshall_attrs(&attr, 3, req_mask, &num_rsp_mask, rsp_mask, 3,
-                                attrvals, &attrvals_len, sizeof(attrvals), 1, 0, 0, 1, 60);
+                                attrvals, &attrvals_len, sizeof(attrvals), 1, 0, 0, 1, 60, 0);
 
     assert(num_rsp_mask == 3);
     assert(attrvals_len == 40);
@@ -110,7 +110,7 @@ test_xattr_support_value_follows_backend_capability(void)
 
     /* xattr_supported = 0 -> the per-object value encodes FALSE. */
     chimera_nfs4_marshall_attrs(&attr, 3, req_mask, &num_rsp_mask, rsp_mask, 3,
-                                attrvals, &attrvals_len, sizeof(attrvals), 2, 0, 0, 0, 60);
+                                attrvals, &attrvals_len, sizeof(attrvals), 2, 0, 0, 0, 60, 0);
 
     assert(num_rsp_mask == 3);
     assert(attrvals_len == 4);
@@ -122,13 +122,87 @@ test_xattr_support_value_follows_backend_capability(void)
 
     /* xattr_supported = 1 -> the per-object value encodes TRUE. */
     chimera_nfs4_marshall_attrs(&attr, 3, req_mask, &num_rsp_mask, rsp_mask, 3,
-                                attrvals, &attrvals_len, sizeof(attrvals), 2, 0, 1, 0, 60);
+                                attrvals, &attrvals_len, sizeof(attrvals), 2, 0, 1, 0, 60, 0);
 
     assert(num_rsp_mask == 3);
     assert(attrvals_len == 4);
     assert((rsp_mask[2] & (1 << (FATTR4_XATTR_SUPPORT - 64))) != 0);
     assert(get_u32(attrvals, 0) == 1);
 } /* test_xattr_support_value_follows_backend_capability */
+
+/* FATTR4_NAMED_ATTR reflects the backend-reported CHIMERA_VFS_ATTR_NAMED_ATTR:
+ * true iff the object currently has >=1 named stream.  When the backend leaves
+ * the bit unset (no named-stream support) the server reports false. */
+static void
+test_named_attr_value_follows_backend(void)
+{
+    struct chimera_vfs_attrs attr;
+    uint32_t                 req_mask[3] = { 0 };
+    uint32_t                 rsp_mask[3] = { 0 };
+    uint32_t                 num_rsp_mask;
+    uint32_t                 attrvals_len;
+    uint8_t                  attrvals[256];
+
+    req_mask[0] = (1 << FATTR4_NAMED_ATTR);
+
+    /* Backend left the attr unset -> false. */
+    memset(&attr, 0, sizeof(attr));
+    chimera_nfs4_marshall_attrs(&attr, 3, req_mask, &num_rsp_mask, rsp_mask, 3,
+                                attrvals, &attrvals_len, sizeof(attrvals), 1, 0, 0, 0, 60, 0);
+    assert(rsp_mask[0] == (1 << FATTR4_NAMED_ATTR));
+    assert(get_u32(attrvals, 0) == 0);
+
+    /* Backend reports the object has named streams -> true. */
+    memset(&attr, 0, sizeof(attr));
+    attr.va_set_mask   = CHIMERA_VFS_ATTR_NAMED_ATTR;
+    attr.va_named_attr = 1;
+    memset(rsp_mask, 0, sizeof(rsp_mask));
+    memset(attrvals, 0, sizeof(attrvals));
+    chimera_nfs4_marshall_attrs(&attr, 3, req_mask, &num_rsp_mask, rsp_mask, 3,
+                                attrvals, &attrvals_len, sizeof(attrvals), 1, 0, 0, 0, 60, 0);
+    assert(rsp_mask[0] == (1 << FATTR4_NAMED_ATTR));
+    assert(get_u32(attrvals, 0) == 1);
+
+    /* Backend reports the bit but value 0 (no streams) -> false. */
+    memset(&attr, 0, sizeof(attr));
+    attr.va_set_mask   = CHIMERA_VFS_ATTR_NAMED_ATTR;
+    attr.va_named_attr = 0;
+    memset(rsp_mask, 0, sizeof(rsp_mask));
+    memset(attrvals, 0, sizeof(attrvals));
+    chimera_nfs4_marshall_attrs(&attr, 3, req_mask, &num_rsp_mask, rsp_mask, 3,
+                                attrvals, &attrvals_len, sizeof(attrvals), 1, 0, 0, 0, 60, 0);
+    assert(get_u32(attrvals, 0) == 0);
+} /* test_named_attr_value_follows_backend */
+
+/* The TYPE override lets the named-attribute namespace report NF4ATTRDIR /
+ * NF4NAMEDATTR even though the underlying mode bits say regular/dir. */
+static void
+test_type_override(void)
+{
+    struct chimera_vfs_attrs attr;
+    uint32_t                 req_mask[3] = { 0 };
+    uint32_t                 rsp_mask[3] = { 0 };
+    uint32_t                 num_rsp_mask;
+    uint32_t                 attrvals_len;
+    uint8_t                  attrvals[256];
+
+    memset(&attr, 0, sizeof(attr));
+    attr.va_set_mask = CHIMERA_VFS_ATTR_MODE;
+    attr.va_mode     = S_IFREG | 0644;
+    req_mask[0]      = (1 << FATTR4_TYPE);
+
+    chimera_nfs4_marshall_attrs(&attr, 3, req_mask, &num_rsp_mask, rsp_mask, 3,
+                                attrvals, &attrvals_len, sizeof(attrvals), 1, 0, 0, 0, 60,
+                                NF4ATTRDIR);
+    assert(rsp_mask[0] == (1 << FATTR4_TYPE));
+    assert(get_u32(attrvals, 0) == NF4ATTRDIR);
+
+    memset(rsp_mask, 0, sizeof(rsp_mask));
+    memset(attrvals, 0, sizeof(attrvals));
+    chimera_nfs4_marshall_attrs(&attr, 3, req_mask, &num_rsp_mask, rsp_mask, 3,
+                                attrvals, &attrvals_len, sizeof(attrvals), 1, 0, 0, 0, 60, 0);
+    assert(get_u32(attrvals, 0) == NF4REG);
+} /* test_type_override */
 
 int
 main(void)
@@ -137,6 +211,8 @@ main(void)
     test_open_arguments_supported_attrs_follows_delegation_config();
     test_open_arguments_attr_follows_delegation_config();
     test_xattr_support_value_follows_backend_capability();
+    test_named_attr_value_follows_backend();
+    test_type_override();
 
     return 0;
 } /* main */

--- a/src/server/nfs/tests/test_protocol_advertise.c
+++ b/src/server/nfs/tests/test_protocol_advertise.c
@@ -6,6 +6,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
+#include <sys/stat.h>
 
 #include "nfs_internal.h"
 #include "nfs4_xdr.h"
@@ -51,7 +52,7 @@ test_open_arguments_supported_attrs_follows_delegation_config(void)
     req_mask[0] = (1 << FATTR4_SUPPORTED_ATTRS);
 
     chimera_nfs4_marshall_attrs(&attr, 3, req_mask, &num_rsp_mask, rsp_mask, 3,
-                                attrvals, &attrvals_len, sizeof(attrvals), 1, 0, 0, 0, 60, 0, NULL, 0);
+                                attrvals, &attrvals_len, sizeof(attrvals), 1, 0, 0, 0, 60, 0, NULL, 0, 0);
 
     assert(num_rsp_mask == 1);
     assert(rsp_mask[0] == (1 << FATTR4_SUPPORTED_ATTRS));
@@ -61,7 +62,7 @@ test_open_arguments_supported_attrs_follows_delegation_config(void)
     memset(rsp_mask, 0, sizeof(rsp_mask));
     memset(attrvals, 0, sizeof(attrvals));
     chimera_nfs4_marshall_attrs(&attr, 3, req_mask, &num_rsp_mask, rsp_mask, 3,
-                                attrvals, &attrvals_len, sizeof(attrvals), 1, 0, 0, 1, 60, 0, NULL, 0);
+                                attrvals, &attrvals_len, sizeof(attrvals), 1, 0, 0, 1, 60, 0, NULL, 0, 0);
 
     assert(num_rsp_mask == 1);
     assert(rsp_mask[0] == (1 << FATTR4_SUPPORTED_ATTRS));
@@ -83,7 +84,7 @@ test_open_arguments_attr_follows_delegation_config(void)
     req_mask[2] = (1 << (FATTR4_OPEN_ARGUMENTS - 64));
 
     chimera_nfs4_marshall_attrs(&attr, 3, req_mask, &num_rsp_mask, rsp_mask, 3,
-                                attrvals, &attrvals_len, sizeof(attrvals), 1, 0, 0, 0, 60, 0, NULL, 0);
+                                attrvals, &attrvals_len, sizeof(attrvals), 1, 0, 0, 0, 60, 0, NULL, 0, 0);
 
     assert(num_rsp_mask == 0);
     assert(attrvals_len == 0);
@@ -92,7 +93,7 @@ test_open_arguments_attr_follows_delegation_config(void)
     memset(rsp_mask, 0, sizeof(rsp_mask));
     memset(attrvals, 0, sizeof(attrvals));
     chimera_nfs4_marshall_attrs(&attr, 3, req_mask, &num_rsp_mask, rsp_mask, 3,
-                                attrvals, &attrvals_len, sizeof(attrvals), 1, 0, 0, 1, 60, 0, NULL, 0);
+                                attrvals, &attrvals_len, sizeof(attrvals), 1, 0, 0, 1, 60, 0, NULL, 0, 0);
 
     assert(num_rsp_mask == 3);
     assert(attrvals_len == 40);
@@ -118,7 +119,7 @@ test_xattr_support_value_follows_backend_capability(void)
 
     /* xattr_supported = 0 -> the per-object value encodes FALSE. */
     chimera_nfs4_marshall_attrs(&attr, 3, req_mask, &num_rsp_mask, rsp_mask, 3,
-                                attrvals, &attrvals_len, sizeof(attrvals), 2, 0, 0, 0, 60, 0, NULL, 0);
+                                attrvals, &attrvals_len, sizeof(attrvals), 2, 0, 0, 0, 60, 0, NULL, 0, 0);
 
     assert(num_rsp_mask == 3);
     assert(attrvals_len == 4);
@@ -130,7 +131,7 @@ test_xattr_support_value_follows_backend_capability(void)
 
     /* xattr_supported = 1 -> the per-object value encodes TRUE. */
     chimera_nfs4_marshall_attrs(&attr, 3, req_mask, &num_rsp_mask, rsp_mask, 3,
-                                attrvals, &attrvals_len, sizeof(attrvals), 2, 0, 1, 0, 60, 0, NULL, 0);
+                                attrvals, &attrvals_len, sizeof(attrvals), 2, 0, 1, 0, 60, 0, NULL, 0, 0);
 
     assert(num_rsp_mask == 3);
     assert(attrvals_len == 4);
@@ -153,14 +154,14 @@ test_change_attr_type_advertised_for_v42(void)
 
     /* change_attr_type (attr 79) is an NFSv4.2 attribute: not advertised at 4.1. */
     chimera_nfs4_marshall_attrs(&attr, 3, req_mask, &num_rsp_mask, rsp_mask, 3,
-                                attrvals, &attrvals_len, sizeof(attrvals), 1, 0, 0, 0, 60, 0, NULL, 0);
+                                attrvals, &attrvals_len, sizeof(attrvals), 1, 0, 0, 0, 60, 0, NULL, 0, 0);
     assert((get_u32(attrvals, 3) & (1 << (FATTR4_CHANGE_ATTR_TYPE - 64))) == 0);
 
     /* Advertised at 4.2. */
     memset(rsp_mask, 0, sizeof(rsp_mask));
     memset(attrvals, 0, sizeof(attrvals));
     chimera_nfs4_marshall_attrs(&attr, 3, req_mask, &num_rsp_mask, rsp_mask, 3,
-                                attrvals, &attrvals_len, sizeof(attrvals), 2, 0, 0, 0, 60, 0, NULL, 0);
+                                attrvals, &attrvals_len, sizeof(attrvals), 2, 0, 0, 0, 60, 0, NULL, 0, 0);
     assert((get_u32(attrvals, 3) & (1 << (FATTR4_CHANGE_ATTR_TYPE - 64))) != 0);
 } /* test_change_attr_type_advertised_for_v42 */
 
@@ -181,7 +182,7 @@ test_change_attr_type_value_follows_native_change(void)
     attr.va_set_mask = CHIMERA_VFS_ATTR_CHANGE;
     attr.va_change   = 7;
     chimera_nfs4_marshall_attrs(&attr, 3, req_mask, &num_rsp_mask, rsp_mask, 3,
-                                attrvals, &attrvals_len, sizeof(attrvals), 2, 0, 0, 0, 60, 0, NULL, 0);
+                                attrvals, &attrvals_len, sizeof(attrvals), 2, 0, 0, 0, 60, 0, NULL, 0, 0);
     assert(num_rsp_mask == 3);
     assert(attrvals_len == 4);
     assert((rsp_mask[2] & (1 << (FATTR4_CHANGE_ATTR_TYPE - 64))) != 0);
@@ -193,7 +194,7 @@ test_change_attr_type_value_follows_native_change(void)
     memset(rsp_mask, 0, sizeof(rsp_mask));
     memset(attrvals, 0, sizeof(attrvals));
     chimera_nfs4_marshall_attrs(&attr, 3, req_mask, &num_rsp_mask, rsp_mask, 3,
-                                attrvals, &attrvals_len, sizeof(attrvals), 2, 0, 0, 0, 60, 0, NULL, 0);
+                                attrvals, &attrvals_len, sizeof(attrvals), 2, 0, 0, 0, 60, 0, NULL, 0, 0);
     assert(get_u32(attrvals, 0) == NFS4_CHANGE_TYPE_IS_TIME_METADATA);
 } /* test_change_attr_type_value_follows_native_change */
 
@@ -214,7 +215,7 @@ test_change_value_native_vs_ctime(void)
     attr.va_set_mask = CHIMERA_VFS_ATTR_CHANGE;
     attr.va_change   = 0x1122334455667788ULL;
     chimera_nfs4_marshall_attrs(&attr, 3, req_mask, &num_rsp_mask, rsp_mask, 3,
-                                attrvals, &attrvals_len, sizeof(attrvals), 2, 0, 0, 0, 60, 0, NULL, 0);
+                                attrvals, &attrvals_len, sizeof(attrvals), 2, 0, 0, 0, 60, 0, NULL, 0, 0);
     assert((rsp_mask[0] & (1 << FATTR4_CHANGE)) != 0);
     assert(get_u64(attrvals, 0) == 0x1122334455667788ULL);
 
@@ -226,7 +227,7 @@ test_change_value_native_vs_ctime(void)
     memset(rsp_mask, 0, sizeof(rsp_mask));
     memset(attrvals, 0, sizeof(attrvals));
     chimera_nfs4_marshall_attrs(&attr, 3, req_mask, &num_rsp_mask, rsp_mask, 3,
-                                attrvals, &attrvals_len, sizeof(attrvals), 2, 0, 0, 0, 60, 0, NULL, 0);
+                                attrvals, &attrvals_len, sizeof(attrvals), 2, 0, 0, 0, 60, 0, NULL, 0, 0);
     assert(get_u64(attrvals, 0) == 1000ULL * 1000000000ULL + 500ULL);
 } /* test_change_value_native_vs_ctime */
 
@@ -253,7 +254,7 @@ test_word2_values_packed_in_ascending_order(void)
 
     /* xattr_supported = 1 passed in. */
     chimera_nfs4_marshall_attrs(&attr, 3, req_mask, &num_rsp_mask, rsp_mask, 3,
-                                attrvals, &attrvals_len, sizeof(attrvals), 2, 0, 1, 0, 60, 0, NULL, 0);
+                                attrvals, &attrvals_len, sizeof(attrvals), 2, 0, 1, 0, 60, 0, NULL, 0, 0);
 
     assert(num_rsp_mask == 3);
     assert((rsp_mask[2] & (1 << (FATTR4_CHANGE_ATTR_TYPE - 64))) != 0);
@@ -264,6 +265,80 @@ test_word2_values_packed_in_ascending_order(void)
     assert(get_u32(attrvals, 0) == NFS4_CHANGE_TYPE_IS_MONOTONIC_INCR);
     assert(get_u32(attrvals, 1) == 1);
 } /* test_word2_values_packed_in_ascending_order */
+
+/* FATTR4_NAMED_ATTR reflects the backend-reported CHIMERA_VFS_ATTR_NAMED_ATTR:
+ * true iff the object currently has >=1 named stream.  When the backend leaves
+ * the bit unset (no named-stream support) the server reports false. */
+static void
+test_named_attr_value_follows_backend(void)
+{
+    struct chimera_vfs_attrs attr;
+    uint32_t                 req_mask[3] = { 0 };
+    uint32_t                 rsp_mask[3] = { 0 };
+    uint32_t                 num_rsp_mask;
+    uint32_t                 attrvals_len;
+    uint8_t                  attrvals[256];
+
+    req_mask[0] = (1 << FATTR4_NAMED_ATTR);
+
+    /* Backend left the attr unset -> false. */
+    memset(&attr, 0, sizeof(attr));
+    chimera_nfs4_marshall_attrs(&attr, 3, req_mask, &num_rsp_mask, rsp_mask, 3,
+                                attrvals, &attrvals_len, sizeof(attrvals), 1, 0, 0, 0, 60, 0, NULL, 0, 0);
+    assert(rsp_mask[0] == (1 << FATTR4_NAMED_ATTR));
+    assert(get_u32(attrvals, 0) == 0);
+
+    /* Backend reports the object has named streams -> true. */
+    memset(&attr, 0, sizeof(attr));
+    attr.va_set_mask   = CHIMERA_VFS_ATTR_NAMED_ATTR;
+    attr.va_named_attr = 1;
+    memset(rsp_mask, 0, sizeof(rsp_mask));
+    memset(attrvals, 0, sizeof(attrvals));
+    chimera_nfs4_marshall_attrs(&attr, 3, req_mask, &num_rsp_mask, rsp_mask, 3,
+                                attrvals, &attrvals_len, sizeof(attrvals), 1, 0, 0, 0, 60, 0, NULL, 0, 0);
+    assert(rsp_mask[0] == (1 << FATTR4_NAMED_ATTR));
+    assert(get_u32(attrvals, 0) == 1);
+
+    /* Backend reports the bit but value 0 (no streams) -> false. */
+    memset(&attr, 0, sizeof(attr));
+    attr.va_set_mask   = CHIMERA_VFS_ATTR_NAMED_ATTR;
+    attr.va_named_attr = 0;
+    memset(rsp_mask, 0, sizeof(rsp_mask));
+    memset(attrvals, 0, sizeof(attrvals));
+    chimera_nfs4_marshall_attrs(&attr, 3, req_mask, &num_rsp_mask, rsp_mask, 3,
+                                attrvals, &attrvals_len, sizeof(attrvals), 1, 0, 0, 0, 60, 0, NULL, 0, 0);
+    assert(get_u32(attrvals, 0) == 0);
+} /* test_named_attr_value_follows_backend */
+
+/* The TYPE override lets the named-attribute namespace report NF4ATTRDIR /
+ * NF4NAMEDATTR even though the underlying mode bits say regular/dir. */
+static void
+test_type_override(void)
+{
+    struct chimera_vfs_attrs attr;
+    uint32_t                 req_mask[3] = { 0 };
+    uint32_t                 rsp_mask[3] = { 0 };
+    uint32_t                 num_rsp_mask;
+    uint32_t                 attrvals_len;
+    uint8_t                  attrvals[256];
+
+    memset(&attr, 0, sizeof(attr));
+    attr.va_set_mask = CHIMERA_VFS_ATTR_MODE;
+    attr.va_mode     = S_IFREG | 0644;
+    req_mask[0]      = (1 << FATTR4_TYPE);
+
+    chimera_nfs4_marshall_attrs(&attr, 3, req_mask, &num_rsp_mask, rsp_mask, 3,
+                                attrvals, &attrvals_len, sizeof(attrvals), 1, 0, 0, 0, 60, 0, NULL, 0,
+                                NF4ATTRDIR);
+    assert(rsp_mask[0] == (1 << FATTR4_TYPE));
+    assert(get_u32(attrvals, 0) == NF4ATTRDIR);
+
+    memset(rsp_mask, 0, sizeof(rsp_mask));
+    memset(attrvals, 0, sizeof(attrvals));
+    chimera_nfs4_marshall_attrs(&attr, 3, req_mask, &num_rsp_mask, rsp_mask, 3,
+                                attrvals, &attrvals_len, sizeof(attrvals), 1, 0, 0, 0, 60, 0, NULL, 0, 0);
+    assert(get_u32(attrvals, 0) == NF4REG);
+} /* test_type_override */
 
 int
 main(void)
@@ -276,6 +351,8 @@ main(void)
     test_change_attr_type_value_follows_native_change();
     test_change_value_native_vs_ctime();
     test_word2_values_packed_in_ascending_order();
+    test_named_attr_value_follows_backend();
+    test_type_override();
 
     return 0;
 } /* main */

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -417,6 +417,15 @@ chimera_server_config_get_smb_named_streams(const struct chimera_server_config *
     return config->smb_named_streams;
 } /* chimera_server_config_get_smb_named_streams */
 
+/* Protocol-neutral view of the named-streams knob.  Named streams are one VFS
+* feature exposed by two protocols -- SMB alternate data streams and NFSv4 named
+* attributes -- so both gate on the same switch (originally named for SMB). */
+SYMBOL_EXPORT int
+chimera_server_config_get_named_streams(const struct chimera_server_config *config)
+{
+    return config->smb_named_streams;
+} /* chimera_server_config_get_named_streams */
+
 SYMBOL_EXPORT void
 chimera_server_config_set_smb_signing_required(
     struct chimera_server_config *config,

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -526,6 +526,15 @@ chimera_server_config_get_smb_named_streams(const struct chimera_server_config *
     return config->smb_named_streams;
 } /* chimera_server_config_get_smb_named_streams */
 
+/* Protocol-neutral view of the named-streams knob.  Named streams are one VFS
+* feature exposed by two protocols -- SMB alternate data streams and NFSv4 named
+* attributes -- so both gate on the same switch (originally named for SMB). */
+SYMBOL_EXPORT int
+chimera_server_config_get_named_streams(const struct chimera_server_config *config)
+{
+    return config->smb_named_streams;
+} /* chimera_server_config_get_named_streams */
+
 SYMBOL_EXPORT void
 chimera_server_config_set_smb_signing_required(
     struct chimera_server_config *config,

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -101,6 +101,10 @@ int
 chimera_server_config_get_smb_named_streams(
     const struct chimera_server_config *config);
 
+int
+chimera_server_config_get_named_streams(
+    const struct chimera_server_config *config);
+
 void
 chimera_server_config_set_smb_signing_required(
     struct chimera_server_config *config,

--- a/src/server/smb/smb_proc_query_info.c
+++ b/src/server/smb/smb_proc_query_info.c
@@ -132,7 +132,7 @@ chimera_smb_emit_stream_info(
         }
 
         out += aligned;
-        in  += (sizeof(entry) + entry.name_len + 7) & ~7u;
+        in  += (sizeof(entry) + entry.name_len + entry.fh_len + 7) & ~7u;
     }
 
     return out;
@@ -202,6 +202,7 @@ chimera_smb_query_stream_info_open_callback(
         0,
         request->query_info.stream_records,
         sizeof(request->query_info.stream_records),
+        0, /* SMB FILE_STREAM_INFORMATION does not need per-stream handles */
         chimera_smb_query_stream_info_list_callback,
         request);
 } /* chimera_smb_query_stream_info_open_callback */

--- a/src/server/smb/smb_proc_query_info.c
+++ b/src/server/smb/smb_proc_query_info.c
@@ -170,7 +170,7 @@ chimera_smb_emit_stream_info(
          * bytes for a default fork plus two 8-character streams, which is what
          * Windows and Samba's marshall_stream_info return to the byte). */
         out += next ? aligned : entry_size;
-        in  += (sizeof(entry) + entry.name_len + 7) & ~7u;
+        in  += (sizeof(entry) + entry.name_len + entry.fh_len + 7) & ~7u;
     }
 
     return out;
@@ -304,6 +304,7 @@ chimera_smb_query_stream_info_open_callback(
         0,
         request->query_info.stream_records,
         sizeof(request->query_info.stream_records),
+        0, /* SMB FILE_STREAM_INFORMATION does not need per-stream handles */
         chimera_smb_query_stream_info_list_callback,
         request);
 } /* chimera_smb_query_stream_info_open_callback */

--- a/src/server/smb/tests/quint/CMakeLists.txt
+++ b/src/server/smb/tests/quint/CMakeLists.txt
@@ -133,6 +133,22 @@ set_tests_properties(chimera/server/smb/mbt/info_probe_memfs PROPERTIES
     LABELS "quint;smb_mbt;memfs"
     TIMEOUT 120)
 
+# Alternate-data-stream (ADS / named stream) probe: the whole named-stream
+# lifecycle the corpus never enables -- CREATE with the file:stream syntax,
+# independent stream WRITE/READ, FILE_STREAM_INFORMATION enumeration, and
+# delete-on-close of a single stream -- exercising the shared VFS named-stream
+# storage that NFSv4 named attributes also project onto.
+add_executable(smb2_stream_probe smb2_stream_probe.c)
+target_include_directories(smb2_stream_probe PRIVATE ${CMAKE_SOURCE_DIR}/src)
+target_link_libraries(smb2_stream_probe chimera_server chimera_metrics crypto)
+
+add_test(NAME chimera/server/smb/mbt/stream_probe_memfs
+    COMMAND $<TARGET_FILE:smb2_stream_probe>)
+set_tests_properties(chimera/server/smb/mbt/stream_probe_memfs PROPERTIES
+    ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=smb2_stream_probe_memfs"
+    LABELS "quint;smb_mbt;memfs"
+    TIMEOUT 120)
+
 # Transport-compression ground-truth probe: the MS-XCA codecs (LZ77, LZNT1,
 # LZ77+Huffman) against Microsoft reference vectors, and the whole
 # COMPRESSION_TRANSFORM path -- negotiate context, algorithm selection, the

--- a/src/server/smb/tests/quint/smb2_stream_probe.c
+++ b/src/server/smb/tests/quint/smb2_stream_probe.c
@@ -1,0 +1,231 @@
+/* SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+ *
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ * SMB2 alternate-data-stream (ADS / named stream) ground-truth probe.
+ *
+ * The MBT corpus never enables named streams, so the whole ADS lifecycle --
+ * creating a named stream with the "file:stream" CREATE syntax, writing and
+ * reading its independent content, enumerating streams with
+ * FILE_STREAM_INFORMATION, and deleting a stream -- is dark to the model.  It
+ * is also the SMB view of the exact VFS named-stream storage that NFSv4 named
+ * attributes project onto (open_stream/list_streams/remove_stream,
+ * CAP_NAMED_STREAMS, the memfs per-inode stream list), so this probe is the SMB
+ * half of the cross-protocol stream coverage.
+ *
+ * Like the other ground-truth probes the classes constrain each other: a
+ * stream's content read back must equal what was written; the size reported by
+ * FILE_STREAM_INFORMATION must equal the bytes written; a write to one stream
+ * must not perturb the base file's data or the sibling streams; and a deleted
+ * stream must disappear from the enumeration while its siblings survive.
+ */
+
+#include "smb2_mbt_common.h"
+
+static int failures = 0;
+
+#define CHECK(cond, ...)                             \
+        do {                                         \
+            if (cond) {                              \
+                printf("ok   - " __VA_ARGS__);       \
+                printf("\n");                        \
+            } else {                                 \
+                printf("FAIL - " __VA_ARGS__);       \
+                printf("\n");                        \
+                failures++;                          \
+            }                                        \
+        } while (0)
+
+/* Enumerate the named streams of the file open on `fid` via
+ * FILE_STREAM_INFORMATION.  Returns the number of entries; if `want` is
+ * non-NULL, sets *want_size to the size of the stream whose (case-sensitive)
+ * name contains `want` and *want_found to 1 when it was seen. */
+static int
+enum_streams(
+    struct smb2_conn *c,
+    const uint8_t     fid[16],
+    const char       *want,
+    uint64_t         *want_size,
+    int              *want_found)
+{
+    uint8_t  out[2048];
+    uint32_t st, len = 0, off = 0;
+    int      entries = 0;
+
+    if (want_found) {
+        *want_found = 0;
+    }
+    if (want_size) {
+        *want_size = 0;
+    }
+
+    st = smb2_query_info(c, SMB2_INFO_FILE_T, SMB2_FILE_STREAM_INFO_T,
+                         fid, 0, out, sizeof(out), &len);
+    if (st != ST_SUCCESS || len == 0) {
+        return -1;
+    }
+
+    /* Each record: NextEntryOffset(4) StreamNameLength(4) StreamSize(8)
+    * StreamAllocationSize(8) StreamName(UTF-16LE).  (MS-FSCC 2.4.43) */
+    while (off + 24 <= len) {
+        uint32_t next = g32(out, (int) off);
+        uint32_t nlen = g32(out, (int) off + 4);
+        uint64_t size = g64(out, (int) off + 8);
+        char     nm[256];
+        uint32_t i;
+
+        entries++;
+        if (nlen / 2 < sizeof(nm) - 1 && off + 24 + nlen <= len) {
+            for (i = 0; i < nlen / 2; i++) {
+                nm[i] = (char) out[off + 24 + i * 2];
+            }
+            nm[nlen / 2] = '\0';
+            if (want && strstr(nm, want)) {
+                if (want_found) {
+                    *want_found = 1;
+                }
+                if (want_size) {
+                    *want_size = size;
+                }
+            }
+        }
+        if (next == 0) {
+            break;
+        }
+        off += next;
+    }
+    return entries;
+} /* enum_streams */
+
+/* The full ADS lifecycle against one base file. */
+static void
+probe_stream_lifecycle(struct smb2_conn *c)
+{
+    struct smb2_create_out base, alt, beta, reopen;
+    uint8_t                rd[64];
+    uint32_t               st, cnt = 0, rlen = 0;
+    uint64_t               sz = 0;
+    int                    entries, found = 0;
+
+    printf("# --- ADS lifecycle ---\n");
+
+    /* Base file with its own data stream. */
+    st = smb2_create(c, "ads.bin", FILE_OVERWRITE_IF, FILE_ALL_ACCESS,
+                     FILE_SHARE_RWD, NULL, &base);
+    CHECK(st == ST_SUCCESS, "CREATE base ads.bin -> 0x%08x", st);
+    if (st != ST_SUCCESS) {
+        return;
+    }
+    st = smb2_write(c, base.file_id, 0, "BASEDATA", 8, &cnt);
+    CHECK(st == ST_SUCCESS && cnt == 8, "WRITE 8 bytes to the base data stream");
+
+    /* Only the unnamed default stream exists so far. */
+    entries = enum_streams(c, base.file_id, NULL, NULL, NULL);
+    CHECK(entries == 1, "enumeration reports only the default stream (%d)",
+          entries);
+
+    /* Create an alternate named stream via the file:stream CREATE syntax and
+     * give it content distinct from the base. */
+    st = smb2_create(c, "ads.bin:alt", FILE_OVERWRITE_IF, FILE_ALL_ACCESS,
+                     FILE_SHARE_RWD, NULL, &alt);
+    CHECK(st == ST_SUCCESS, "CREATE ads.bin:alt -> 0x%08x", st);
+    if (st == ST_SUCCESS) {
+        st = smb2_write(c, alt.file_id, 0, "ALTERNATE", 9, &cnt);
+        CHECK(st == ST_SUCCESS && cnt == 9, "WRITE 9 bytes to :alt");
+
+        /* Read the stream back through its own handle: byte-identical. */
+        st = smb2_read(c, alt.file_id, 0, sizeof(rd), rd, &rlen);
+        CHECK(st == ST_SUCCESS && rlen == 9 && memcmp(rd, "ALTERNATE", 9) == 0,
+              "READ :alt returns its 9 bytes byte-identical (0x%08x, %u)", st,
+              rlen);
+        smb2_close(c, alt.file_id);
+    }
+
+    /* Enumeration now lists the default stream plus :alt at 9 bytes. */
+    entries = enum_streams(c, base.file_id, "alt", &sz, &found);
+    CHECK(entries == 2, "enumeration lists both streams (%d)", entries);
+    CHECK(found && sz == 9, ":alt is named and carries its 9 bytes (sz=%llu)",
+          (unsigned long long) sz);
+
+    /* A second named stream is independent again. */
+    st = smb2_create(c, "ads.bin:beta", FILE_OVERWRITE_IF, FILE_ALL_ACCESS,
+                     FILE_SHARE_RWD, NULL, &beta);
+    CHECK(st == ST_SUCCESS, "CREATE ads.bin:beta -> 0x%08x", st);
+    if (st == ST_SUCCESS) {
+        smb2_write(c, beta.file_id, 0, "BB", 2, &cnt);
+        smb2_close(c, beta.file_id);
+    }
+    entries = enum_streams(c, base.file_id, "beta", &sz, &found);
+    CHECK(entries == 3, "enumeration lists the default + two streams (%d)",
+          entries);
+    CHECK(found && sz == 2, ":beta carries its 2 bytes (sz=%llu)",
+          (unsigned long long) sz);
+
+    /* Base/stream independence: the base data stream still reads back its own
+     * 8 bytes, untouched by the stream writes. */
+    st = smb2_read(c, base.file_id, 0, sizeof(rd), rd, &rlen);
+    CHECK(st == ST_SUCCESS && rlen == 8 && memcmp(rd, "BASEDATA", 8) == 0,
+          "the base data stream is intact after the stream writes (%u)", rlen);
+
+    /* Delete :alt via delete-on-close disposition on its own handle
+     * (FILE_ALL_ACCESS already includes the DELETE right). */
+    st = smb2_create(c, "ads.bin:alt", FILE_OPEN, FILE_ALL_ACCESS,
+                     FILE_SHARE_RWD, NULL, &reopen);
+    CHECK(st == ST_SUCCESS, "re-open :alt for delete -> 0x%08x", st);
+    if (st == ST_SUCCESS) {
+        st = smb2_set_disposition(c, reopen.file_id, 1);
+        CHECK(st == ST_SUCCESS, "set delete-on-close on :alt -> 0x%08x", st);
+        smb2_close(c, reopen.file_id);
+    }
+
+    /* :alt is gone; the default stream and :beta survive. */
+    entries = enum_streams(c, base.file_id, "alt", &sz, &found);
+    CHECK(entries == 2, "after delete the enumeration lists two streams (%d)",
+          entries);
+    CHECK(!found, ":alt no longer appears in the enumeration");
+
+    /* Opening the deleted stream by name is refused. */
+    st = smb2_create(c, "ads.bin:alt", FILE_OPEN, FILE_ALL_ACCESS,
+                     FILE_SHARE_RWD, NULL, &reopen);
+    CHECK(st != ST_SUCCESS, "opening the deleted stream :alt is refused (0x%08x)",
+          st);
+    if (st == ST_SUCCESS) {
+        smb2_close(c, reopen.file_id);
+    }
+
+    smb2_close(c, base.file_id);
+} /* probe_stream_lifecycle */
+
+int
+main(
+    int   argc,
+    char *argv[])
+{
+    struct smb2_env      env;
+    /* Named streams are off in the server by default; the ADS surface needs
+     * them advertised (CAP_NAMED_STREAMS on the backend + the config knob). */
+    struct smb2_env_opts opts = { .named_streams = 1 };
+    struct smb2_conn    *c;
+
+    (void) argc;
+    (void) argv;
+
+    setvbuf(stdout, NULL, _IONBF, 0);
+
+    smb2_env_start_opts(&env, &opts);
+    c = smb2_conn_open(&env);
+    smb2_handshake(c);
+
+    printf("# dialect=0x%04x\n", c->dialect);
+
+    probe_stream_lifecycle(c);
+
+    smb2_env_stop(&env);
+
+    if (failures) {
+        fprintf(stderr, "%d ADS stream check(s) FAILED\n", failures);
+        return 1;
+    }
+    printf("all SMB2 named-stream checks passed\n");
+    return 0;
+} /* main */

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -1365,6 +1365,15 @@ memfs_map_attrs(
         attr->va_fsid      = shared->fsid;
     }
 
+    /* Named-stream presence (SMB ADS / NFSv4 named attributes).  memfs owns the
+     * stream list, so it answers accurately and for free: a regular file with at
+     * least one named stream reports true.  A named-stream view overrides this
+     * to false in memfs_map_attrs_fork (a stream has no sub-streams). */
+    if (attr->va_req_mask & CHIMERA_VFS_ATTR_NAMED_ATTR) {
+        attr->va_set_mask  |= CHIMERA_VFS_ATTR_NAMED_ATTR;
+        attr->va_named_attr = (S_ISREG(inode->mode) && inode->streams) ? 1 : 0;
+    }
+
     /* Opaque pNFS layout state, persisted verbatim for the NFS server. */
     if ((attr->va_req_mask & CHIMERA_VFS_ATTR_PNFS_LAYOUT) && inode->remote) {
         attr->va_set_mask |= CHIMERA_VFS_ATTR_PNFS_LAYOUT;
@@ -1415,6 +1424,11 @@ memfs_map_attrs_fork(
         attr->va_fh_len = memfs_encode_stream_fh(base_fh, inode->inum,
                                                  inode->gen, stream->id,
                                                  attr->va_fh);
+    }
+
+    /* A named stream is a leaf data fork; it has no named attributes of its own. */
+    if (attr->va_set_mask & CHIMERA_VFS_ATTR_NAMED_ATTR) {
+        attr->va_named_attr = 0;
     }
 } /* memfs_map_attrs_fork */
 
@@ -2676,12 +2690,54 @@ memfs_open_fh(
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
-    struct memfs_inode *inode;
+    struct memfs_inode        *inode;
+    struct memfs_named_stream *stream;
+    struct memfs_stream_open  *so;
+    uint64_t                   inum;
+    uint32_t                   gen, stream_id = 0;
 
     inode = memfs_inode_get_fh(shared, request->fh, request->fh_len);
 
     if (!inode) {
         request->status = CHIMERA_VFS_ENOENT;
+        request->complete(request);
+        return;
+    }
+
+    /* A named-stream file handle carries a non-zero stream id appended after the
+     * base inum/gen (memfs_encode_stream_fh).  Resolve it to a pinned per-open
+     * stream descriptor and hand back a tagged vfs_private so subsequent data ops
+     * (read/write/getattr/setattr) act on the stream fork, not the base/default
+     * fork.  This is the path NFSv4 takes when a stream fh arrives via PUTFH;
+     * SMB instead always carries the tagged handle returned by open_stream. */
+    memfs_decode_stream_fh(request->fh, request->fh_len, &inum, &gen, &stream_id);
+
+    if (stream_id) {
+        stream = memfs_stream_find_by_id(inode, stream_id);
+
+        if (!stream) {
+            /* Stale stream fh: the stream was removed.  Ids are never reused, so
+             * this resolves to nothing rather than the wrong fork. */
+            pthread_mutex_unlock(&inode->lock);
+            request->status = CHIMERA_VFS_ENOENT;
+            request->complete(request);
+            return;
+        }
+
+        stream->refcnt++;
+        inode->refcnt++;
+
+        so                  = malloc(sizeof(*so));
+        so->inode           = inode;
+        so->stream          = stream;
+        so->open_next       = inode->stream_opens;
+        inode->stream_opens = so;
+
+        pthread_mutex_unlock(&inode->lock);
+
+        request->open_fh.r_vfs_private = (uint64_t) (uintptr_t) so | 1ULL;
+        request->open_fh.r_stream      = 1;
+        request->status                = CHIMERA_VFS_OK;
         request->complete(request);
         return;
     }
@@ -5282,11 +5338,14 @@ memfs_list_streams(
 {
     struct memfs_inode             *inode;
     struct memfs_named_stream      *stream;
-    uint8_t                        *buf    = request->list_streams.buffer;
-    uint32_t                        max    = request->list_streams.max_bytes;
-    uint32_t                        offset = 0;
-    uint32_t                        count  = 0;
+    uint8_t                        *buf     = request->list_streams.buffer;
+    uint32_t                        max     = request->list_streams.max_bytes;
+    int                             want_fh = request->list_streams.want_fh;
+    uint32_t                        offset  = 0;
+    uint32_t                        count   = 0;
     struct chimera_vfs_stream_entry entry;
+    uint8_t                         fhbuf[CHIMERA_VFS_FH_SIZE + 16];
+    uint32_t                        fh_len;
     uint32_t                        rec;
 
     inode = memfs_inode_get_fh(shared, request->fh, request->fh_len);
@@ -5300,9 +5359,15 @@ memfs_list_streams(
     /* Default unnamed data fork ("::$DATA"), reported first with an empty name
      * so the SMB layer can format it as the default stream.  Only regular files
      * have a data fork -- a directory reports no streams (smb2.streams.dir
-     * expects an empty stream list on a directory). */
+     * expects an empty stream list on a directory).  When the caller requested
+     * handles (NFSv4 named-attr READDIR), the default fork carries the base fh
+     * and each named stream carries its own stream fh. */
     if (S_ISREG(inode->mode)) {
-        rec = sizeof(entry);
+        fh_len = want_fh ? request->fh_len : 0;
+        if (want_fh) {
+            memcpy(fhbuf, request->fh, request->fh_len);
+        }
+        rec = sizeof(entry) + fh_len;
         if (offset + rec > max) {
             pthread_mutex_unlock(&inode->lock);
             request->status = CHIMERA_VFS_ERANGE;
@@ -5312,14 +5377,22 @@ memfs_list_streams(
         entry.size     = inode->size;
         entry.alloc    = inode->space_used;
         entry.name_len = 0;
+        entry.fh_len   = fh_len;
         memcpy(buf + offset, &entry, sizeof(entry));
+        memcpy(buf + offset + sizeof(entry), fhbuf, fh_len);
         offset += rec;
         offset  = (offset + 7) & ~7u;
         count++;
     }
 
     for (stream = inode->streams; stream; stream = stream->next) {
-        rec = sizeof(entry) + stream->name_len;
+        if (want_fh) {
+            fh_len = memfs_encode_stream_fh(request->fh, inode->inum,
+                                            inode->gen, stream->id, fhbuf);
+        } else {
+            fh_len = 0;
+        }
+        rec = sizeof(entry) + stream->name_len + fh_len;
         if (offset + rec > max) {
             pthread_mutex_unlock(&inode->lock);
             request->status = CHIMERA_VFS_ERANGE;
@@ -5329,8 +5402,10 @@ memfs_list_streams(
         entry.size     = stream->size;
         entry.alloc    = stream->space_used;
         entry.name_len = stream->name_len;
+        entry.fh_len   = fh_len;
         memcpy(buf + offset, &entry, sizeof(entry));
         memcpy(buf + offset + sizeof(entry), stream->name, stream->name_len);
+        memcpy(buf + offset + sizeof(entry) + stream->name_len, fhbuf, fh_len);
         offset += rec;
         offset  = (offset + 7) & ~7u;
         count++;

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -1704,6 +1704,15 @@ memfs_map_attrs(
         attr->va_fsid      = fs->fsid;
     }
 
+    /* Named-stream presence (SMB ADS / NFSv4 named attributes).  memfs owns the
+     * stream list, so it answers accurately and for free: a regular file with at
+     * least one named stream reports true.  A named-stream view overrides this
+     * to false in memfs_map_attrs_fork (a stream has no sub-streams). */
+    if (attr->va_req_mask & CHIMERA_VFS_ATTR_NAMED_ATTR) {
+        attr->va_set_mask  |= CHIMERA_VFS_ATTR_NAMED_ATTR;
+        attr->va_named_attr = (S_ISREG(inode->mode) && inode->streams) ? 1 : 0;
+    }
+
     /* Opaque pNFS layout state, persisted verbatim for the NFS server. */
     if ((attr->va_req_mask & CHIMERA_VFS_ATTR_PNFS_LAYOUT) && inode->remote) {
         attr->va_set_mask |= CHIMERA_VFS_ATTR_PNFS_LAYOUT;
@@ -1754,6 +1763,11 @@ memfs_map_attrs_fork(
         attr->va_fh_len = memfs_encode_stream_fh(base_fh, inode->inum,
                                                  inode->gen, stream->id,
                                                  attr->va_fh);
+    }
+
+    /* A named stream is a leaf data fork; it has no named attributes of its own. */
+    if (attr->va_set_mask & CHIMERA_VFS_ATTR_NAMED_ATTR) {
+        attr->va_named_attr = 0;
     }
 } /* memfs_map_attrs_fork */
 
@@ -3406,12 +3420,54 @@ memfs_open_fh(
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
-    struct memfs_inode *inode;
+    struct memfs_inode        *inode;
+    struct memfs_named_stream *stream;
+    struct memfs_stream_open  *so;
+    uint64_t                   inum;
+    uint32_t                   gen, stream_id = 0;
 
     inode = memfs_inode_get_fh(fs, request->fh, request->fh_len);
 
     if (!inode) {
         request->status = CHIMERA_VFS_ESTALE;
+        request->complete(request);
+        return;
+    }
+
+    /* A named-stream file handle carries a non-zero stream id appended after the
+     * base inum/gen (memfs_encode_stream_fh).  Resolve it to a pinned per-open
+     * stream descriptor and hand back a tagged vfs_private so subsequent data ops
+     * (read/write/getattr/setattr) act on the stream fork, not the base/default
+     * fork.  This is the path NFSv4 takes when a stream fh arrives via PUTFH;
+     * SMB instead always carries the tagged handle returned by open_stream. */
+    memfs_decode_stream_fh(request->fh, request->fh_len, &inum, &gen, &stream_id);
+
+    if (stream_id) {
+        stream = memfs_stream_find_by_id(inode, stream_id);
+
+        if (!stream) {
+            /* Stale stream fh: the stream was removed.  Ids are never reused, so
+             * this resolves to nothing rather than the wrong fork. */
+            pthread_mutex_unlock(&inode->lock);
+            request->status = CHIMERA_VFS_ENOENT;
+            request->complete(request);
+            return;
+        }
+
+        stream->refcnt++;
+        inode->refcnt++;
+
+        so                  = malloc(sizeof(*so));
+        so->inode           = inode;
+        so->stream          = stream;
+        so->open_next       = inode->stream_opens;
+        inode->stream_opens = so;
+
+        pthread_mutex_unlock(&inode->lock);
+
+        request->open_fh.r_vfs_private = (uint64_t) (uintptr_t) so | 1ULL;
+        request->open_fh.r_stream      = 1;
+        request->status                = CHIMERA_VFS_OK;
         request->complete(request);
         return;
     }
@@ -6640,11 +6696,14 @@ memfs_list_streams(
 {
     struct memfs_inode             *inode;
     struct memfs_named_stream      *stream;
-    uint8_t                        *buf    = request->list_streams.buffer;
-    uint32_t                        max    = request->list_streams.max_bytes;
-    uint32_t                        offset = 0;
-    uint32_t                        count  = 0;
+    uint8_t                        *buf     = request->list_streams.buffer;
+    uint32_t                        max     = request->list_streams.max_bytes;
+    int                             want_fh = request->list_streams.want_fh;
+    uint32_t                        offset  = 0;
+    uint32_t                        count   = 0;
     struct chimera_vfs_stream_entry entry;
+    uint8_t                         fhbuf[CHIMERA_VFS_FH_SIZE + 16];
+    uint32_t                        fh_len;
     uint32_t                        rec;
 
     inode = memfs_inode_get_fh(fs, request->fh, request->fh_len);
@@ -6658,9 +6717,15 @@ memfs_list_streams(
     /* Default unnamed data fork ("::$DATA"), reported first with an empty name
      * so the SMB layer can format it as the default stream.  Only regular files
      * have a data fork -- a directory reports no streams (smb2.streams.dir
-     * expects an empty stream list on a directory). */
+     * expects an empty stream list on a directory).  When the caller requested
+     * handles (NFSv4 named-attr READDIR), the default fork carries the base fh
+     * and each named stream carries its own stream fh. */
     if (S_ISREG(inode->mode)) {
-        rec = sizeof(entry);
+        fh_len = want_fh ? request->fh_len : 0;
+        if (want_fh) {
+            memcpy(fhbuf, request->fh, request->fh_len);
+        }
+        rec = sizeof(entry) + fh_len;
         if (offset + rec > max) {
             pthread_mutex_unlock(&inode->lock);
             request->status = CHIMERA_VFS_ERANGE;
@@ -6670,14 +6735,22 @@ memfs_list_streams(
         entry.size     = inode->size;
         entry.alloc    = inode->space_used;
         entry.name_len = 0;
+        entry.fh_len   = fh_len;
         memcpy(buf + offset, &entry, sizeof(entry));
+        memcpy(buf + offset + sizeof(entry), fhbuf, fh_len);
         offset += rec;
         offset  = (offset + 7) & ~7u;
         count++;
     }
 
     for (stream = inode->streams; stream; stream = stream->next) {
-        rec = sizeof(entry) + stream->name_len;
+        if (want_fh) {
+            fh_len = memfs_encode_stream_fh(request->fh, inode->inum,
+                                            inode->gen, stream->id, fhbuf);
+        } else {
+            fh_len = 0;
+        }
+        rec = sizeof(entry) + stream->name_len + fh_len;
         if (offset + rec > max) {
             pthread_mutex_unlock(&inode->lock);
             request->status = CHIMERA_VFS_ERANGE;
@@ -6687,8 +6760,10 @@ memfs_list_streams(
         entry.size     = stream->size;
         entry.alloc    = stream->space_used;
         entry.name_len = stream->name_len;
+        entry.fh_len   = fh_len;
         memcpy(buf + offset, &entry, sizeof(entry));
         memcpy(buf + offset + sizeof(entry), stream->name, stream->name_len);
+        memcpy(buf + offset + sizeof(entry) + stream->name_len, fhbuf, fh_len);
         offset += rec;
         offset  = (offset + 7) & ~7u;
         count++;

--- a/src/vfs/sdk/vfs_attrs.h
+++ b/src/vfs/sdk/vfs_attrs.h
@@ -88,6 +88,16 @@ struct chimera_acl;
  * supports xattrs (CHIMERA_VFS_CAP_XATTR). */
 #define CHIMERA_VFS_ATTR_EA_SIZE            (1UL << 27)
 
+/* Boolean (va_named_attr): does this object currently have >=1 named stream
+ * (SMB ADS / NFSv4 named attribute)?  Backend-reported, never synthesized by a
+ * protocol server: an in-tree backend that owns its metadata answers accurately
+ * and cheaply from its own state (memfs: inode->streams != NULL); a backend
+ * where establishing the truth would cost an extra syscall may report a
+ * constant.  A backend sets this bit in va_set_mask only when it has populated
+ * va_named_attr (backends without named-stream support leave it unset, which the
+ * NFS marshaller treats as false). */
+#define CHIMERA_VFS_ATTR_NAMED_ATTR         (1UL << 28)
+
 #define CHIMERA_VFS_ATTR_MASK_STAT          ( \
             CHIMERA_VFS_ATTR_DEV | \
             CHIMERA_VFS_ATTR_INUM | \
@@ -202,6 +212,9 @@ struct chimera_vfs_attrs {
     uint64_t            va_fsid;
 
     uint32_t            va_dos_attributes;
+
+    /* CHIMERA_VFS_ATTR_NAMED_ATTR: 1 if the object has >=1 named stream. */
+    uint8_t             va_named_attr;
 
     /* Canonical ACL (CHIMERA_VFS_ATTR_ACL).  On getattr, the backend points
      * this at storage valid only for the duration of the completion callback

--- a/src/vfs/sdk/vfs_request.h
+++ b/src/vfs/sdk/vfs_request.h
@@ -433,12 +433,17 @@ struct chimera_vfs_request_handle {
 #define CHIMERA_VFS_GATE_SCRATCH_SIZE   384
 
 /* One enumerated named stream, packed back-to-back in the list_streams reply
- * buffer.  `name_len` bytes of (un-terminated) stream name follow this header;
- * the next record begins at the following 8-byte-aligned offset. */
+ * buffer.  `name_len` bytes of (un-terminated) stream name follow this header,
+ * then `fh_len` bytes of stream file handle (only when the caller requested
+ * handles via want_fh -- otherwise fh_len is 0); the next record begins at the
+ * following 8-byte-aligned offset.  NFSv4 named-attribute READDIR needs each
+ * entry's fh (to derive fileid / answer FATTR4_FILEHANDLE); SMB stream info does
+ * not, so it omits them and keeps the compact name-only record. */
 struct chimera_vfs_stream_entry {
     uint64_t size;        /* stream end-of-file */
     uint64_t alloc;       /* stream allocation size */
     uint16_t name_len;    /* bytes of name that follow this struct */
+    uint16_t fh_len;      /* bytes of file handle following the name (0 if none) */
 };
 
 /*
@@ -889,6 +894,12 @@ struct chimera_vfs_request {
              * honored only by modules advertising CAP_ATOMIC_HANDLE_STATE. */
             struct chimera_vfs_handle_state *handle_state;
             uint64_t                         r_vfs_private;
+            /* Set by the backend when the resolved fh is a named stream (ADS /
+             * NFSv4 named attribute) rather than a base file: the open layer then
+             * tags the handle CHIMERA_VFS_OPEN_HANDLE_STREAM so the per-fh attr
+             * cache is bypassed (a stream's metadata is the base inode's and
+             * mutates out-of-band relative to the stream fh). */
+            uint8_t                          r_stream;
         } open_fh;
 
         struct {
@@ -1358,8 +1369,10 @@ struct chimera_vfs_request {
             uint64_t                        cookie;
             void                           *buffer;       /* caller-provided buffer */
             uint32_t                        max_bytes;
-            /* buffer is filled with packed chimera_vfs_stream_entry records,
-             * each followed by name_len bytes of (un-terminated) name. */
+            uint8_t                         want_fh;      /* emit each stream's fh */
+            /* buffer is filled with packed chimera_vfs_stream_entry records, each
+             * followed by name_len bytes of (un-terminated) name, then (when
+             * want_fh) fh_len bytes of stream file handle. */
             uint32_t                        r_len;        /* bytes written to buffer */
             uint32_t                        r_count;      /* number of streams written */
             uint32_t                        r_eof;

--- a/src/vfs/vfs.h
+++ b/src/vfs/vfs.h
@@ -388,12 +388,17 @@ struct chimera_vfs_request_handle {
 #define CHIMERA_VFS_REQUEST_MAX_HANDLES 4
 
 /* One enumerated named stream, packed back-to-back in the list_streams reply
- * buffer.  `name_len` bytes of (un-terminated) stream name follow this header;
- * the next record begins at the following 8-byte-aligned offset. */
+ * buffer.  `name_len` bytes of (un-terminated) stream name follow this header,
+ * then `fh_len` bytes of stream file handle (only when the caller requested
+ * handles via want_fh -- otherwise fh_len is 0); the next record begins at the
+ * following 8-byte-aligned offset.  NFSv4 named-attribute READDIR needs each
+ * entry's fh (to derive fileid / answer FATTR4_FILEHANDLE); SMB stream info does
+ * not, so it omits them and keeps the compact name-only record. */
 struct chimera_vfs_stream_entry {
     uint64_t size;        /* stream end-of-file */
     uint64_t alloc;       /* stream allocation size */
     uint16_t name_len;    /* bytes of name that follow this struct */
+    uint16_t fh_len;      /* bytes of file handle following the name (0 if none) */
 };
 
 /*
@@ -741,6 +746,12 @@ struct chimera_vfs_request {
              * honored only by modules advertising CAP_ATOMIC_HANDLE_STATE. */
             struct chimera_vfs_handle_state *handle_state;
             uint64_t                         r_vfs_private;
+            /* Set by the backend when the resolved fh is a named stream (ADS /
+             * NFSv4 named attribute) rather than a base file: the open layer then
+             * tags the handle CHIMERA_VFS_OPEN_HANDLE_STREAM so the per-fh attr
+             * cache is bypassed (a stream's metadata is the base inode's and
+             * mutates out-of-band relative to the stream fh). */
+            uint8_t                          r_stream;
         } open_fh;
 
         struct {
@@ -1073,8 +1084,10 @@ struct chimera_vfs_request {
             uint64_t                        cookie;
             void                           *buffer;       /* caller-provided buffer */
             uint32_t                        max_bytes;
-            /* buffer is filled with packed chimera_vfs_stream_entry records,
-             * each followed by name_len bytes of (un-terminated) name. */
+            uint8_t                         want_fh;      /* emit each stream's fh */
+            /* buffer is filled with packed chimera_vfs_stream_entry records, each
+             * followed by name_len bytes of (un-terminated) name, then (when
+             * want_fh) fh_len bytes of stream file handle. */
             uint32_t                        r_len;        /* bytes written to buffer */
             uint32_t                        r_count;      /* number of streams written */
             uint32_t                        r_eof;

--- a/src/vfs/vfs_attrs.h
+++ b/src/vfs/vfs_attrs.h
@@ -56,6 +56,16 @@ struct chimera_acl;
  * fresh, mask-gated, only when a protocol asks for them. */
 #define CHIMERA_VFS_ATTR_ACL                (1UL << 24)
 
+/* Boolean (va_named_attr): does this object currently have >=1 named stream
+ * (SMB ADS / NFSv4 named attribute)?  Backend-reported, never synthesized by a
+ * protocol server: an in-tree backend that owns its metadata answers accurately
+ * and cheaply from its own state (memfs: inode->streams != NULL); a backend
+ * where establishing the truth would cost an extra syscall may report a
+ * constant.  A backend sets this bit in va_set_mask only when it has populated
+ * va_named_attr (backends without named-stream support leave it unset, which the
+ * NFS marshaller treats as false). */
+#define CHIMERA_VFS_ATTR_NAMED_ATTR         (1UL << 25)
+
 #define CHIMERA_VFS_ATTR_MASK_STAT          ( \
             CHIMERA_VFS_ATTR_DEV | \
             CHIMERA_VFS_ATTR_INUM | \
@@ -167,6 +177,9 @@ struct chimera_vfs_attrs {
     uint64_t            va_fsid;
 
     uint32_t            va_dos_attributes;
+
+    /* CHIMERA_VFS_ATTR_NAMED_ATTR: 1 if the object has >=1 named stream. */
+    uint8_t             va_named_attr;
 
     /* Canonical ACL (CHIMERA_VFS_ATTR_ACL).  On getattr, the backend points
      * this at storage valid only for the duration of the completion callback

--- a/src/vfs/vfs_proc_list_streams.c
+++ b/src/vfs/vfs_proc_list_streams.c
@@ -32,6 +32,7 @@ chimera_vfs_list_streams(
     uint64_t                            cookie,
     void                               *buffer,
     uint32_t                            max_bytes,
+    int                                 want_fh,
     chimera_vfs_list_streams_callback_t callback,
     void                               *private_data)
 {
@@ -55,6 +56,7 @@ chimera_vfs_list_streams(
     request->list_streams.cookie    = cookie;
     request->list_streams.buffer    = buffer;
     request->list_streams.max_bytes = max_bytes;
+    request->list_streams.want_fh   = want_fh ? 1 : 0;
     request->list_streams.r_len     = 0;
     request->list_streams.r_count   = 0;
     request->list_streams.r_eof     = 0;

--- a/src/vfs/vfs_proc_open_fh.c
+++ b/src/vfs/vfs_proc_open_fh.c
@@ -19,6 +19,9 @@ chimera_vfs_open_fh_complete(struct chimera_vfs_request *request)
 
     if (request->status == CHIMERA_VFS_OK) {
         chimera_vfs_populate_handle(thread, handle, request->open_fh.r_vfs_private);
+        if (request->open_fh.r_stream) {
+            handle->flags |= CHIMERA_VFS_OPEN_HANDLE_STREAM;
+        }
     } else {
         chimera_vfs_release_failed(thread, handle, request->status);
         handle = NULL;
@@ -113,6 +116,7 @@ chimera_vfs_open_fh_hs(
         request->complete             = chimera_vfs_open_fh_complete;
         request->open_fh.flags        = flags;
         request->open_fh.handle_state = handle_state;
+        request->open_fh.r_stream     = 0;
         request->proto_callback       = callback;
         request->proto_private_data   = private_data;
 

--- a/src/vfs/vfs_procs.h
+++ b/src/vfs/vfs_procs.h
@@ -1040,6 +1040,7 @@ chimera_vfs_list_streams(
     uint64_t                            cookie,
     void                               *buffer,
     uint32_t                            max_bytes,
+    int                                 want_fh,
     chimera_vfs_list_streams_callback_t callback,
     void                               *private_data);
 

--- a/src/vfs/vfs_procs.h
+++ b/src/vfs/vfs_procs.h
@@ -1209,6 +1209,7 @@ chimera_vfs_list_streams(
     uint64_t                            cookie,
     void                               *buffer,
     uint32_t                            max_bytes,
+    int                                 want_fh,
     chimera_vfs_list_streams_callback_t callback,
     void                               *private_data);
 


### PR DESCRIPTION
## Summary

Implements **NFSv4 named attributes** (RFC 7530/8881 `OPENATTR` + the per-file named-attribute directory) by projecting them onto the **same VFS named-stream primitives that already back SMB alternate data streams** — `open_stream` / `list_streams` / `remove_stream`, `CHIMERA_VFS_CAP_NAMED_STREAMS`, and the memfs per-inode stream list. NFSv4 named attributes and SMB ADS are now two protocol views of one piece of storage.

**Rebased onto current `main`.** The branch was ~710 commits behind; in the meantime the VFS lease core was replaced by the claim core, the `chimera_vfs_stream_entry`/request structs moved to `sdk/vfs_request.h`, `chimera_nfs4_marshall_attrs` grew fh-signing parameters, and `CHIMERA_VFS_CAP_FS_LOCK` was retired (POSIX lock-type is now advertised unconditionally). All of the named-stream primitives this feature builds on survived — notably the stream-holder API (`chimera_vfs_state_stream_holder_inc/dec`), which the claim core kept — so the projection is intact; the rebase merged the marshalling-signature change (kept fh-signing **and** the new `type_override`), re-applied the moved struct fields, and dropped a dead helper upstream had already removed.

## Architecture

The named-attribute **directory** is a purely server-side synthetic object — no backend needs an attr-dir concept. Its filehandle is the base file's VFS fh wrapped with an 8-byte magic prefix (`nfs4_named_attr.h`). `PUTFH`/`LOOKUP`/`READDIR`/`OPEN`/`REMOVE`/`GETATTR` detect it and route to the stream primitives. The named-attribute *files* use the real backend stream fh, so `READ`/`WRITE`/`CLOSE` flow through the normal handlers unchanged.

```
OPENATTR(file)          -> attrdir_fh = MAGIC || base_vfs_fh
PUTFH(attrdir_fh)       -> recognized as the attr-dir of base
  READDIR               -> open_fh(base) + list_streams
  LOOKUP(name)          -> open_stream(base, name, no-create) -> stream fh
  OPEN(CLAIM_NULL,name) -> open_stream(base, name, create/excl) -> open stateid
  REMOVE(name)          -> remove_stream(base, name)
PUTFH(stream_fh)        -> normal READ/WRITE/GETATTR/SETATTR/CLOSE
```

## Notable pieces

- **Backend gap fixed:** `memfs_open_fh` decodes the appended stream id and pins a stream descriptor, making a stream filehandle first-class for the NFSv4 `PUTFH`+data path (SMB carries the tagged `open_stream` handle instead, so it never hit this).
- **`FATTR4_NAMED_ATTR` is backend-reported** via a new `CHIMERA_VFS_ATTR_NAMED_ATTR` (memfs answers from `inode->streams`), not synthesized by the server.
- **Gating:** the existing `smb_named_streams` knob enables both protocol facets; advertised only when the backend has `CAP_NAMED_STREAMS`.
- **Cross-protocol delete-on-close:** an NFS named-attr open registers a stream holder on the base file's claim-core `vfs_state` (`chimera_vfs_state_stream_holder_inc`), so a base delete-on-close defers while a stream is open regardless of which protocol opened it.
- **`list_streams`** gained an opt-in `want_fh` so NFS `READDIR` can carry each stream's fh (for fileid / `FILEHANDLE`); SMB keeps the compact name-only records.
- Named-attribute files report `NF4REG` (the directory is `NF4ATTRDIR`), via a `type_override` on the attr marshaller.

## Verification

- Full Debug (ASan) build **clean**; `uncrustify --check` clean.
- `chimera/server/nfs/protocol_advertise` unit test passes — covers the `NAMED_ATTR` true/false marshalling and the `TYPE` override (`NF4ATTRDIR` / `NF4REG`).
- No regression in the model-based suites: NFSv4 `mbt4/batch_memfs`, NFSv3 `mbt/batch_memfs` + `deviation_probe_memfs`, and SMB `smoke`/`oplock`/`info` stream probes all pass.
- The OPENATTR lifecycle itself is not yet in the quint corpus (a coverage gap worth closing); the pynfs/smbtorture-stream suites that exercise it end-to-end run in the Extended (nightly) tier.
