### PR TITLE
smb2: only echo the lease create-context in CREATE response when warranted

### DIFF
--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -5187,5 +5187,19 @@ chimera_smb_parse_create(
         }
     }
 
+    /* Leasing was introduced in SMB 2.1.  Per MS-SMB2 3.3.5.9, if the negotiated
+     * dialect does not support leasing (i.e. it is "2.0.2"), the server MUST
+     * ignore the "RqLs" create context: it acquires no lease and emits no lease
+     * response context (ReturnLeaseContextNotIncluded).  Drop the RQLS request
+     * bits here so neither the lease-acquisition path nor the response-context
+     * emitter acts on them.  (The standalone context-parser unit test has no
+     * connection, so this dialect gate lives in the wire-parse path, not the
+     * shared parser.) */
+    if (request->compound && request->compound->conn &&
+        request->compound->conn->dialect < SMB2_DIALECT_2_1) {
+        request->create.ctx_present_mask &= ~(CHIMERA_SMB_CREATE_CTX_RQLS |
+                                              CHIMERA_SMB_CREATE_CTX_RQLS_V2);
+    }
+
     return 0;
 } /* chimera_smb_parse_create */

--- a/src/server/smb/tests/wpts/smb2model_cases.csv
+++ b/src/server/smb/tests/wpts/smb2model_cases.csv
@@ -199,20 +199,20 @@ BreakReadLeaseV1TestCaseS223,base,green,0,
 BreakReadLeaseV1TestCaseS231,base,xfail,0,executed but fails (candidate defect)
 BreakReadLeaseV1TestCaseS247,base,green,0,
 BreakReadLeaseV1TestCaseS259,base,xfail,0,executed but fails (candidate defect)
-BreakReadLeaseV1TestCaseS271,base,xfail,0,executed but fails (candidate defect)
-BreakReadLeaseV1TestCaseS292,base,xfail,0,executed but fails (candidate defect)
-BreakReadLeaseV1TestCaseS299,base,xfail,0,executed but fails (candidate defect)
-BreakReadLeaseV1TestCaseS309,base,xfail,0,executed but fails (candidate defect)
-BreakReadLeaseV1TestCaseS317,base,xfail,0,executed but fails (candidate defect)
-BreakReadLeaseV1TestCaseS329,base,xfail,0,executed but fails (candidate defect)
-BreakReadLeaseV1TestCaseS337,base,xfail,0,executed but fails (candidate defect)
-BreakReadLeaseV1TestCaseS345,base,xfail,0,executed but fails (candidate defect)
-BreakReadLeaseV1TestCaseS347,base,xfail,0,executed but fails (candidate defect)
-BreakReadLeaseV1TestCaseS359,base,xfail,0,executed but fails (candidate defect)
-BreakReadLeaseV1TestCaseS371,base,xfail,0,executed but fails (candidate defect)
-BreakReadLeaseV1TestCaseS379,base,xfail,0,executed but fails (candidate defect)
-BreakReadLeaseV1TestCaseS391,base,xfail,0,executed but fails (candidate defect)
-BreakReadLeaseV1TestCaseS399,base,xfail,0,executed but fails (candidate defect)
+BreakReadLeaseV1TestCaseS271,base,green,0,
+BreakReadLeaseV1TestCaseS292,base,green,0,
+BreakReadLeaseV1TestCaseS299,base,green,0,
+BreakReadLeaseV1TestCaseS309,base,green,0,
+BreakReadLeaseV1TestCaseS317,base,green,0,
+BreakReadLeaseV1TestCaseS329,base,green,0,
+BreakReadLeaseV1TestCaseS337,base,green,0,
+BreakReadLeaseV1TestCaseS345,base,green,0,
+BreakReadLeaseV1TestCaseS347,base,green,0,
+BreakReadLeaseV1TestCaseS359,base,green,0,
+BreakReadLeaseV1TestCaseS371,base,green,0,
+BreakReadLeaseV1TestCaseS379,base,green,0,
+BreakReadLeaseV1TestCaseS391,base,green,0,
+BreakReadLeaseV1TestCaseS399,base,green,0,
 BreakReadLeaseV1TestCaseS407,base,green,0,
 BreakReadLeaseV1TestCaseS423,base,green,0,
 BreakReadLeaseV1TestCaseS439,base,xfail,0,executed but fails (candidate defect)
@@ -233,7 +233,7 @@ BreakReadLeaseV1TestCaseS607,base,xfail,0,executed but fails (candidate defect)
 BreakReadLeaseV1TestCaseS623,base,green,0,
 BreakReadLeaseV1TestCaseS631,base,xfail,0,executed but fails (candidate defect)
 BreakReadLeaseV1TestCaseS643,base,green,0,
-BreakReadLeaseV1TestCaseS651,base,xfail,0,executed but fails (candidate defect)
+BreakReadLeaseV1TestCaseS651,base,green,0,
 BreakReadLeaseV1TestCaseS659,base,green,0,
 BreakReadLeaseV1TestCaseS82,base,green,0,
 BreakReadLeaseV1TestCaseS98,base,green,0,
@@ -435,7 +435,7 @@ BreakReadWriteLeaseV1TestCaseS1194,base,green,0,
 BreakReadWriteLeaseV1TestCaseS1215,base,green,0,
 BreakReadWriteLeaseV1TestCaseS1232,base,green,0,
 BreakReadWriteLeaseV1TestCaseS1245,base,green,0,
-BreakReadWriteLeaseV1TestCaseS1266,base,xfail,0,executed but fails (candidate defect)
+BreakReadWriteLeaseV1TestCaseS1266,base,green,0,
 BreakReadWriteLeaseV1TestCaseS1268,base,green,0,
 BreakReadWriteLeaseV1TestCaseS1289,base,green,0,
 BreakReadWriteLeaseV1TestCaseS155,base,green,0,
@@ -446,17 +446,17 @@ BreakReadWriteLeaseV1TestCaseS315,base,green,0,
 BreakReadWriteLeaseV1TestCaseS355,base,green,0,
 BreakReadWriteLeaseV1TestCaseS387,base,green,0,
 BreakReadWriteLeaseV1TestCaseS411,base,green,0,
-BreakReadWriteLeaseV1TestCaseS435,base,xfail,0,executed but fails (candidate defect)
-BreakReadWriteLeaseV1TestCaseS504,base,xfail,0,executed but fails (candidate defect)
-BreakReadWriteLeaseV1TestCaseS544,base,xfail,0,executed but fails (candidate defect)
-BreakReadWriteLeaseV1TestCaseS584,base,xfail,0,executed but fails (candidate defect)
-BreakReadWriteLeaseV1TestCaseS624,base,xfail,0,executed but fails (candidate defect)
-BreakReadWriteLeaseV1TestCaseS664,base,xfail,0,executed but fails (candidate defect)
-BreakReadWriteLeaseV1TestCaseS704,base,xfail,0,executed but fails (candidate defect)
-BreakReadWriteLeaseV1TestCaseS744,base,xfail,0,executed but fails (candidate defect)
+BreakReadWriteLeaseV1TestCaseS435,base,green,0,
+BreakReadWriteLeaseV1TestCaseS504,base,green,0,
+BreakReadWriteLeaseV1TestCaseS544,base,green,0,
+BreakReadWriteLeaseV1TestCaseS584,base,green,0,
+BreakReadWriteLeaseV1TestCaseS624,base,green,0,
+BreakReadWriteLeaseV1TestCaseS664,base,green,0,
+BreakReadWriteLeaseV1TestCaseS704,base,green,0,
+BreakReadWriteLeaseV1TestCaseS744,base,green,0,
 BreakReadWriteLeaseV1TestCaseS75,base,green,0,
-BreakReadWriteLeaseV1TestCaseS776,base,xfail,0,executed but fails (candidate defect)
-BreakReadWriteLeaseV1TestCaseS800,base,xfail,0,executed but fails (candidate defect)
+BreakReadWriteLeaseV1TestCaseS776,base,green,0,
+BreakReadWriteLeaseV1TestCaseS800,base,green,0,
 BreakReadWriteLeaseV1TestCaseS840,base,green,0,
 BreakReadWriteLeaseV1TestCaseS890,base,green,0,
 BreakReadWriteLeaseV1TestCaseS911,base,xfail,0,executed but fails (candidate defect)


### PR DESCRIPTION
## Root cause

Per **MS-SMB2 §3.3.5.9**, leasing was introduced in SMB 2.1. If the negotiated dialect does **not** support leasing (i.e. it is `2.0.2`), the server MUST *ignore* the `"RqLs"` create context even when `RequestedOplockLevel == SMB2_OPLOCK_LEVEL_LEASE`: it acquires no lease and its CREATE response carries **no** lease create-context (`ReturnLeaseContextNotIncluded`).

chimera was unconditionally echoing the `RqLs` lease response context whenever the client supplied one, *regardless of the negotiated dialect*. So a CREATE over a 2.0.2 connection (and the V1 `RqLs` leg of the 3.x model paths that exercise the same "ignore" requirement) wrongly returned `ReturnLeaseContextIncluded`. The MS-SMB2Model `BreakReadLeaseV1` / `BreakReadWriteLeaseV1` create-context cases caught this as:

```
expected 'event CreateResponse(...,ReturnLeaseContextNotIncluded,...)',
found   'CreateResponse(STATUS_SUCCESS,ReturnLeaseContextIncluded,...)'
```

## Fix

In the CREATE wire-parse path (`chimera_smb_parse_create`), when the negotiated dialect is below SMB 2.1, drop the `RQLS`/`RQLS_V2` bits from `ctx_present_mask`. This single point suppresses both the lease-acquisition path and the response-context emitter, exactly matching the spec's "MUST ignore the RqLs create context" requirement. The gate lives in the wire-parse function (which has the connection) rather than the shared, connection-less context parser that the `phase0_contexts` unit test drives standalone.

## Model tests greened

**26 previously-`xfail` MS-SMB2Model cases**, each verified passing across **two** runs:

- **15 × `BreakReadLeaseV1`**: S271, S292, S299, S309, S317, S329, S337, S345, S347, S359, S371, S379, S391, S399, S651
- **11 × `BreakReadWriteLeaseV1`**: S435, S504, S544, S584, S624, S664, S704, S744, S776, S800, S1266

The remaining `xfail` cases in these categories are lease-break-*notification* timing failures (`Event must occur within Nms ... OnLeaseBreakNotification`) — a separate, harder root cause — and stay `xfail`.

## Regressions

None. The currently-green lease/oplock/create families (`BreakRead*Lease`, `OplockLease`, `LeaseOplock`, `CreateClose`, `RequestDurableHandleV1LeaseV1`) were re-run. The 7 `RequestDurableHandleV1LeaseV1` failures observed in that set are **pre-existing** — they fail identically on the pristine pre-fix binary (dialect 3.0.2, outside this change's `< SMB 2.1` gate), so they are not caused by this fix and are left untouched.

Stacked on #926 (the MS-SMB2Model suite PR); the diff reduces to just this fix once #926 merges.