### PR TITLE
smb: validate SetFileBasicInformation buffer length (greens FSAModel cases)

### DIFF
--- a/src/server/smb/smb_proc_set_info.c
+++ b/src/server/smb/smb_proc_set_info.c
@@ -498,6 +498,15 @@ chimera_smb_parse_set_info(
         case SMB2_INFO_FILE:
             switch (request->set_info.info_class) {
                 case SMB2_FILE_BASIC_INFO:
+                    /* [MS-FSA] 2.1.5.14.2 / [MS-FSCC] 2.4.7: the input buffer
+                     * must be at least sizeof(FILE_BASIC_INFORMATION) (40 bytes:
+                     * four 8-byte timestamps + 4-byte FileAttributes + 4-byte
+                     * Reserved).  A shorter buffer is rejected with
+                     * STATUS_INFO_LENGTH_MISMATCH rather than silently accepted
+                     * (WPTS MS-FSAModel SetFileBasicInformation cases). */
+                    if (unlikely(request->set_info.buffer_length < SMB2_FILE_BASIC_INFO_SIZE)) {
+                        return chimera_smb_parse_reject(request, SMB2_STATUS_INFO_LENGTH_MISMATCH);
+                    }
                     rc = chimera_smb_parse_basic_info(request_cursor, &request->set_info.attrs);
                     break;
                 case SMB2_FILE_DISPOSITION_INFO:

--- a/src/server/smb/tests/wpts/fsamodel_cases.csv
+++ b/src/server/smb/tests/wpts/fsamodel_cases.csv
@@ -240,11 +240,11 @@ SetFileAllocOrObjIdInformationTestCaseS2,skip,unimplemented: info-class/op
 SetFileAllocOrObjIdInformationTestCaseS4,green,
 SetFileAllocOrObjIdInformationTestCaseS6,xfail,fidelity: no parameter validation
 SetFileAllocOrObjIdInformationTestCaseS8,skip,unimplemented: info-class/op
-SetFileBasicInformationTestCaseS0,xfail,fidelity: no buffer-length validation
+SetFileBasicInformationTestCaseS0,green,
 SetFileBasicInformationTestCaseS10,xfail,fidelity: no parameter validation
-SetFileBasicInformationTestCaseS12,xfail,fidelity: no buffer-length validation
-SetFileBasicInformationTestCaseS14,xfail,fidelity: no buffer-length validation
-SetFileBasicInformationTestCaseS2,xfail,fidelity: no buffer-length validation
+SetFileBasicInformationTestCaseS12,green,
+SetFileBasicInformationTestCaseS14,green,
+SetFileBasicInformationTestCaseS2,green,
 SetFileBasicInformationTestCaseS4,xfail,fidelity: no parameter validation
 SetFileBasicInformationTestCaseS6,xfail,fidelity: no parameter validation
 SetFileBasicInformationTestCaseS8,xfail,fidelity: no parameter validation


### PR DESCRIPTION
## Problem

A SMB2 `SET_INFO(FileBasicInformation)` request whose input buffer is shorter than `FILE_BASIC_INFORMATION` must be rejected with `STATUS_INFO_LENGTH_MISMATCH`. Per [MS-FSA] 2.1.5.14.2 and [MS-FSCC] 2.4.7, `FILE_BASIC_INFORMATION` is 40 bytes (four 8-byte timestamps + 4-byte FileAttributes + 4-byte Reserved).

chimera's SET_INFO parser only reads the 36 leading bytes (it does not read the trailing Reserved field), so any buffer holding at least those 36 bytes was silently accepted and the operation returned `STATUS_SUCCESS`. As a result the WPTS MS-FSAModel `SetFileBasicInformation` buffer-length cases failed (expected `INFO_LENGTH_MISMATCH`, got `SUCCESS`).

## Fix

Add an explicit `buffer_length >= SMB2_FILE_BASIC_INFO_SIZE` (40) check in `chimera_smb_parse_set_info` for the `SMB2_FILE_BASIC_INFO` class, returning `SMB2_STATUS_INFO_LENGTH_MISMATCH` via the existing `chimera_smb_parse_reject` idiom (the same pattern already used for the security-descriptor and the generic short-buffer fallback in this function).

## Cases greened

- SetFileBasicInformationTestCaseS0
- SetFileBasicInformationTestCaseS2
- SetFileBasicInformationTestCaseS12
- SetFileBasicInformationTestCaseS14

The remaining `SetFileBasicInformation` failures (S4/S6/S8/S10, detail "no parameter validation") expect `STATUS_INVALID_PARAMETER` for invalid field *values*, which is a distinct validation and out of scope here.

Baseline (memfs): 99 -> 103 passing, no regressions across the full 343-case MS-FSAModel run.

Layers on PR #925 (the FSAModel CI shard).