### PR TITLE
smb: validate CreateOptions combination before directory-type check (greens FSAModel cases)

### DIFF
--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -4201,6 +4201,23 @@ chimera_smb_create(struct chimera_smb_request *request)
             return;
         }
 
+        /* MS-FSA 2.1.5.1 Phase 1 (MS-FSA_R2374 / R2376): a CreateOptions of
+         * FILE_DIRECTORY_FILE combined with a destructive CreateDisposition is
+         * a contradiction -- SUPERSEDE/OVERWRITE/OVERWRITE_IF replace the data
+         * of a target that, as a directory, has none -- so the open MUST fail
+         * with STATUS_INVALID_PARAMETER.  This validation runs in Phase 1,
+         * BEFORE the open reaches the backend and resolves a directory-vs-file
+         * type mismatch (which would otherwise surface as NOT_A_DIRECTORY and
+         * mask the parameter error).  FSAModel CreateFileTestCaseS24/S26,
+         * OpenFileTestCaseS22/S24. */
+        if ((request->create.create_options & SMB2_FILE_DIRECTORY_FILE) &&
+            (request->create.create_disposition == SMB2_FILE_SUPERSEDE ||
+             request->create.create_disposition == SMB2_FILE_OVERWRITE ||
+             request->create.create_disposition == SMB2_FILE_OVERWRITE_IF)) {
+            chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
+            return;
+        }
+
         /* MS-FSCC 2.6 FileAttributes validation (smb2.create.gentest).  Any bit
         * outside the settable/valid set -- e.g. FILE_ATTRIBUTE_VOLUME (0x08) or
         * FILE_ATTRIBUTE_DEVICE (0x40) -- is rejected with INVALID_PARAMETER. */

--- a/src/server/smb/tests/wpts/fsamodel_cases.csv
+++ b/src/server/smb/tests/wpts/fsamodel_cases.csv
@@ -10,9 +10,9 @@ CreateFileTestCaseS16,skip,inapplicable: model branch not executed
 CreateFileTestCaseS18,xfail,fidelity: expected INVALID_PARAMETER got ACCESS_DENIED
 CreateFileTestCaseS2,xfail,fidelity: expected ACCESS_DENIED got OBJECT_PATH_NOT_FOUND
 CreateFileTestCaseS20,skip,inapplicable: model branch not executed
-CreateFileTestCaseS22,xfail,fidelity: expected INVALID_PARAMETER got OBJECT_NAME_NOT_FOUND
-CreateFileTestCaseS24,xfail,fidelity: expected INVALID_PARAMETER got NOT_A_DIRECTORY
-CreateFileTestCaseS26,xfail,fidelity: expected INVALID_PARAMETER got NOT_A_DIRECTORY
+CreateFileTestCaseS22,green,
+CreateFileTestCaseS24,green,
+CreateFileTestCaseS26,green,
 CreateFileTestCaseS28,skip,inapplicable: model branch not executed
 CreateFileTestCaseS30,skip,inapplicable: model branch not executed
 CreateFileTestCaseS32,xfail,fidelity: expected OBJECT_NAME_INVALID got 3221225734
@@ -108,9 +108,9 @@ OpenFileTestCaseS14,skip,inapplicable: model branch not executed
 OpenFileTestCaseS16,xfail,fidelity: expected INVALID_PARAMETER got ACCESS_DENIED
 OpenFileTestCaseS18,skip,inapplicable: model branch not executed
 OpenFileTestCaseS2,xfail,fidelity: no parameter validation
-OpenFileTestCaseS20,xfail,fidelity: expected INVALID_PARAMETER got OBJECT_NAME_NOT_FOUND
-OpenFileTestCaseS22,xfail,fidelity: expected INVALID_PARAMETER got NOT_A_DIRECTORY
-OpenFileTestCaseS24,xfail,fidelity: expected INVALID_PARAMETER got NOT_A_DIRECTORY
+OpenFileTestCaseS20,green,
+OpenFileTestCaseS22,green,
+OpenFileTestCaseS24,green,
 OpenFileTestCaseS26,green,
 OpenFileTestCaseS28,xfail,fidelity: access check too permissive
 OpenFileTestCaseS30,xfail,fidelity: expected OBJECT_NAME_INVALID got SUCCESS


### PR DESCRIPTION
## Problem

The WPTS MS-FSAModel CreateFile/OpenFile cases that exercise CreateOptions parameter validation were failing on a fidelity mismatch: chimera resolved the directory-vs-file type of the target before validating the CreateOptions/CreateDisposition combination, so it returned the wrong NTSTATUS.

## Rule (MS-FSA 2.1.5.1 Phase 1, MS-FSA_R2374 / R2376)

> The operation MUST be failed with STATUS_INVALID_PARAMETER if `CreateOptions.FILE_DIRECTORY_FILE` is set together with `CreateDisposition == FILE_SUPERSEDE`, `FILE_OVERWRITE`, or `FILE_OVERWRITE_IF`.

These dispositions replace the data of the target, which a directory does not have, so the combination is invalid and must be rejected in the parameter-validation phase, *before* the open reaches the backend.

## Fix

Chimera let the open proceed to the VFS backend, which resolved the directory-vs-file type mismatch first and returned `STATUS_NOT_A_DIRECTORY` (when the target existed) or `STATUS_OBJECT_NAME_NOT_FOUND` (when it did not), masking the parameter error.

`chimera_smb_create` now performs this Phase 1 check alongside the existing CreateOptions validations (INVALID/UNSUPPORTED mask, FileAttributes, ImpersonationLevel), returning `SMB2_STATUS_INVALID_PARAMETER` before dispatching the open. The pre-existing explicit-`::$DATA`-on-a-directory path that intentionally returns NOT_A_DIRECTORY is unaffected (it requires `explicit_data_fork` and only runs after the open reveals a directory target).

## Cases greened

- CreateFileTestCaseS22 (DIRECTORY_FILE + OVERWRITE)
- CreateFileTestCaseS24 (DIRECTORY_FILE + SUPERSEDE)
- CreateFileTestCaseS26 (DIRECTORY_FILE + OVERWRITE_IF)
- OpenFileTestCaseS20 (DIRECTORY_FILE + OVERWRITE)
- OpenFileTestCaseS22 (DIRECTORY_FILE + SUPERSEDE)
- OpenFileTestCaseS24 (DIRECTORY_FILE + OVERWRITE_IF)

FSAModel baseline: 99 -> 105 pass, full-suite comparator reports `[OK] no regressions`.

Layers on #925.