### PR TITLE
kvm/smb: SMB3 feature-config tests (encryption, signing, leases)

### DIFF
--- a/kvm/kvm_smb_test_wrapper.sh
+++ b/kvm/kvm_smb_test_wrapper.sh
@@ -54,6 +54,41 @@ case "$SECMODE" in
     *) echo "invalid secmode '$SECMODE' (expected none|sign|seal)" >&2; exit 1 ;;
 esac
 
+# Optional server-side feature knobs, passed through the environment so the
+# positional argument list stays stable.
+#   SMB_FEATURES  comma-separated tokens injected into the generated config:
+#                   encrypt -> smb_encryption="enabled" + share encrypt_data:true
+#                   sign    -> smb_signing_required:true
+#                   leases  -> smb_leases + smb_oplocks + smb_directory_leases
+#   SMB_EXPECT    pass (default) | denied.  "denied" inverts the verdict: the
+#                 test passes iff the mount/first access is rejected (used for
+#                 the per-share encryption-enforcement negative case).
+SMB_FEATURES="${SMB_FEATURES:-}"
+SMB_EXPECT="${SMB_EXPECT:-pass}"
+#   SMB_CACHE     cifs cache mode (loose|strict|none); default loose.  strict
+#                 makes the client lean on leases/oplocks for cache coherency,
+#                 which is what the leases feature test wants to exercise.
+SMB_CACHE="${SMB_CACHE:-loose}"
+
+SERVER_EXTRA=""
+SHARE_EXTRA=""
+for feat in ${SMB_FEATURES//,/ }; do
+    case "$feat" in
+        encrypt)
+            SERVER_EXTRA="${SERVER_EXTRA}\"smb_encryption\": \"enabled\","
+            SHARE_EXTRA="${SHARE_EXTRA}\"encrypt_data\": true,"
+            ;;
+        sign)
+            SERVER_EXTRA="${SERVER_EXTRA}\"smb_signing_required\": true,"
+            ;;
+        leases)
+            SERVER_EXTRA="${SERVER_EXTRA}\"smb_leases\": true, \"smb_oplocks\": true, \"smb_directory_leases\": true,"
+            ;;
+        "") ;;
+        *) echo "unknown SMB_FEATURES token '$feat'" >&2; exit 1 ;;
+    esac
+done
+
 # Boot with no initrd: every kernel in the KVM image matrix builds the virtio
 # block/net drivers in, so the kernel mounts the virtio root disk directly.
 # Skipping the ~63MB initrd unpack saves ~0.9s/test.  (See kvm/CMakeLists.txt:
@@ -151,6 +186,7 @@ generate_config() {
         "threads": 4,
         "delegation_threads": 4,
         $vfs_section
+        $SERVER_EXTRA
         "smb_min_dialect": "$DIALECT",
         "external_portmap": false
     },
@@ -162,6 +198,7 @@ generate_config() {
     },
     "shares": {
         "share": {
+            $SHARE_EXTRA
             "path": "/share"
         }
     },
@@ -232,14 +269,28 @@ esac
 
 # Build the mount options for the CIFS mount.  vers= pins the dialect; seal/sign
 # add SMB3 transport encryption / signing for the secmode variants.
-SMB_MOUNT_OPTS="username=root,password=secret,vers=${VERS},nobrl,modefromsid,cache=loose"
+SMB_MOUNT_OPTS="username=root,password=secret,vers=${VERS},nobrl,modefromsid,cache=${SMB_CACHE}"
 case "$SECMODE" in
     seal) SMB_MOUNT_OPTS="${SMB_MOUNT_OPTS},seal" ;;
     sign) SMB_MOUNT_OPTS="${SMB_MOUNT_OPTS},sign" ;;
 esac
 
-# Build the test command to run inside the VM
-TEST_CMD="mount -t cifs //10.0.0.1/share /mnt -o ${SMB_MOUNT_OPTS} && ${TEST_CMD_ARG}"
+# Build the test command to run inside the VM.  Normally we mount and then run
+# the supplied command; for SMB_EXPECT=denied we instead assert that the mount
+# (or the first access through it) is rejected -- the per-share encryption
+# enforcement returns STATUS_ACCESS_DENIED, which tree-connect is exempt from,
+# so a mount can succeed while the first I/O is denied.  Either is a pass.
+if [ "$SMB_EXPECT" = "denied" ]; then
+    # Pass iff access is denied: the if/else is the last command so its status
+    # becomes the test's exit code (no explicit `exit`, which could terminate
+    # the guest init harness before it records the result -- as the positive
+    # path also relies on $? of its last command).  If the mount succeeds, the
+    # first I/O ("! ls") must fail; if the mount itself is refused, that is also
+    # a pass.
+    TEST_CMD="if mount -t cifs //10.0.0.1/share /mnt -o ${SMB_MOUNT_OPTS} 2>/dev/null; then ! ls /mnt >/dev/null 2>&1; else true; fi"
+else
+    TEST_CMD="mount -t cifs //10.0.0.1/share /mnt -o ${SMB_MOUNT_OPTS} && ${TEST_CMD_ARG}"
+fi
 
 # Boot QEMU inside the netns
 # Use -serial stdio so serial output goes to stdout in real-time (captured by ctest).

--- a/kvm/tests/CMakeLists.txt
+++ b/kvm/tests/CMakeLists.txt
@@ -194,6 +194,28 @@ set(XFSTESTS_CMD_nametest  "mkdir -p /mnt/test && cd /mnt/test && /opt/xfstests/
 set(XFSTESTS_CMD_fstest    "mkdir -p /mnt/test && /opt/xfstests/src/fstest -p /mnt/test -n 1 -f 2 -l 5 -s 65536")
 set(XFSTESTS_CMD_rewinddir "mkdir -p /mnt/test && /opt/xfstests/src/rewinddir-test /mnt/test")
 
+# SMB3 feature-config tests.  Each combines a server-side config knob (injected
+# via the SMB_FEATURES env knob the wrapper reads) with the matching kernel
+# cifs mount mode, to drive one SMB3 feature end-to-end through a real client.
+# Pinned to memfs (feature correctness is backend-independent at this layer).
+# Each entry is "<name>|<SMB_FEATURES>|<secmode>|<cache>|<expect>|<workload>":
+#   encrypt_seal*    encrypt_data share + seal mount -> TRANSFORM path e2e.
+#   signing          smb_signing_required + sign mount.
+#   leases           file+dir leases + oplocks under cache=strict (the client
+#                    leans on leases for coherency, exercising grant/break).
+#                    DISABLED below pending a server fix (see the foreach).
+# There is deliberately no encryption "negative" case: a compliant kernel cifs
+# client auto-encrypts once TREE_CONNECT advertises SMB2_SHAREFLAG_ENCRYPT_DATA,
+# so an unsealed mount of an encrypt_data share is never denied -- it just seals
+# transparently.  Per-share denial is only observable against a non-compliant
+# client (covered by smbtorture/WPTS), not from a real Linux client.
+set(SMB_FEATURE_TESTS
+    "encrypt_seal|encrypt|seal|loose|pass|${XFSTESTS_CMD_fsstress}"
+    "encrypt_seal_cthon|encrypt|seal|loose|pass|cd /opt/cthon04 && CIFS=yes MNTOPTIONS=vers=3.1.1 ./runtests -g -f /mnt/test"
+    "signing|sign|sign|loose|pass|${XFSTESTS_CMD_fsstress}"
+    "leases|leases|none|strict|pass|${XFSTESTS_CMD_fsx}"
+)
+
 # Linux Test Project (LTP) scenario groups, run against the server-mounted share.
 # Matrix entries are "<group>|<space-separated NFS versions>"; <group> names a
 # runtest file shipped in the guest's /opt/ltp/runtest (>= kvm-test-base v1.5.0).
@@ -746,6 +768,36 @@ foreach(image_spec ${KVM_IMAGES})
             # rewinddir_cairn timeout, #733).  Give them matching headroom.
             set_tests_properties(chimera/kvm/${IMAGE_NAME}/smb/3.1.1/xfstests/${prog}_cairn
                 PROPERTIES LABELS "kvm;${IMAGE_NAME}" PROCESSORS 2 TIMEOUT 600)
+        endforeach()
+    endif()
+
+    # SMB3 feature-config tests -- ubuntu2404 + memfs only (see SMB_FEATURE_TESTS).
+    if(IMAGE_NAME STREQUAL "ubuntu2404")
+        foreach(entry ${SMB_FEATURE_TESTS})
+            string(REPLACE "|" ";" parts "${entry}")
+            list(GET parts 0 fname)
+            list(GET parts 1 ffeatures)
+            list(GET parts 2 fsecmode)
+            list(GET parts 3 fcache)
+            list(GET parts 4 fexpect)
+            list(GET parts 5 fworkload)
+            add_test(NAME chimera/kvm/${IMAGE_NAME}/smb/feature/${fname}_memfs
+                COMMAND env SMB_FEATURES=${ffeatures} SMB_EXPECT=${fexpect} SMB_CACHE=${fcache}
+                        bash ${SMB_WRAPPER}
+                        ${IMAGE_DIR}/vmlinuz ${IMAGE_DIR}/rootfs.qcow2
+                        ${CHIMERA_BINARY} memfs 3.1.1 ${fsecmode}
+                        "${fworkload}")
+            set_tests_properties(chimera/kvm/${IMAGE_NAME}/smb/feature/${fname}_memfs
+                PROPERTIES LABELS "kvm;${IMAGE_NAME}" PROCESSORS 2)
+            # The leases test deadlocks the server: a kernel-client ftruncate on
+            # a file it holds a write lease on hangs (state=D wait_for_response)
+            # -- the SET_INFO end-of-file recall/break path never completes (a
+            # lease self-break).  fsx is clean without leases, so this is a real
+            # lease-path bug; disabled until it is fixed.
+            if(fname STREQUAL "leases")
+                set_tests_properties(chimera/kvm/${IMAGE_NAME}/smb/feature/leases_memfs
+                    PROPERTIES DISABLED TRUE)
+            endif()
         endforeach()
     endif()
 

--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -438,6 +438,11 @@ main(
         chimera_server_config_set_smb_oplocks(server_config, json_is_true(json_value));
     }
 
+    json_value = json_object_get(server_params, "smb_signing_required");
+    if (json_is_boolean(json_value)) {
+        chimera_server_config_set_smb_signing_required(server_config, json_is_true(json_value));
+    }
+
     /* smb_min_dialect: lowest SMB2 dialect to advertise ("2.0.2"|"2.1"|"3.0"|
      * "3.0.2"|"3.1.1").  Defaults to 2.1; lower it to 2.0.2 only where a client
      * (e.g. a conformance suite) explicitly needs the original SMB2 dialect. */

--- a/src/server/smb/smb_ntlm.c
+++ b/src/server/smb/smb_ntlm.c
@@ -547,11 +547,16 @@ generate_challenge(
     u32 = (uint32_t) fixed_len;
     memcpy(buf + 16, &u32, 4);
 
-    // Negotiate flags
+    // Negotiate flags.  NTLMSSP_NEGOTIATE_SIGN advertises that the server
+    // supports NTLM message signing: the Linux cifs client gates SMB2 signing
+    // on it (a signing-required mount, or any mount against a server that sets
+    // SMB2_NEGOTIATE_SIGNING_REQUIRED, aborts with -EOPNOTSUPP if the CHALLENGE
+    // omits it), so it must be present for kernel-client signing to work.
     flags = NTLMSSP_NEGOTIATE_128 |
         NTLMSSP_NEGOTIATE_TARGET_INFO |
         NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY |
         NTLMSSP_NEGOTIATE_NTLM |
+        NTLMSSP_NEGOTIATE_SIGN |
         NTLMSSP_REQUEST_TARGET |
         NTLMSSP_NEGOTIATE_UNICODE;
 


### PR DESCRIPTION
Stacked on #936. KVM-validated against the cifs client.

Drives SMB3 features the kernel client can reach, each pairing a server knob with the matching mount mode.

**Server fixes this surfaced:**
- `daemon.c`: parse `smb_signing_required` (had a setter/getter but was never wired into the JSON parser).
- `smb_ntlm.c`: advertise `NTLMSSP_NEGOTIATE_SIGN` in the CHALLENGE — the Linux cifs client gates SMB2 signing on it (signing-required mounts aborted with -EOPNOTSUPP without it).

**Tests (ubuntu2404 + memfs):** `encrypt_seal`/`encrypt_seal_cthon` (TRANSFORM path, **pass**), `signing` (**passes** with the NTLM fix). `leases` is **DISABLED** — a kernel ftruncate on a leased file hangs (lease self-break); fsx is clean without leases, so it's a real lease-path bug for a separate fix.

No encryption-negative case: a compliant cifs client auto-encrypts once TREE_CONNECT advertises SHAREFLAG_ENCRYPT_DATA, so it's never observably denied from a real Linux client.