### PR TITLE
kvm/smb: real byte-range locking + server-side copy tests

### DIFF
--- a/kvm/kvm_smb_test_wrapper.sh
+++ b/kvm/kvm_smb_test_wrapper.sh
@@ -68,7 +68,11 @@ SMB_EXPECT="${SMB_EXPECT:-pass}"
 #   SMB_CACHE     cifs cache mode (loose|strict|none); default loose.  strict
 #                 makes the client lean on leases/oplocks for cache coherency,
 #                 which is what the leases feature test wants to exercise.
+#   SMB_BRL       0 (default) mounts with nobrl, suppressing byte-range locks;
+#                 1 drops nobrl so the kernel client drives real SMB2 LOCK
+#                 requests (for the locking suites).
 SMB_CACHE="${SMB_CACHE:-loose}"
+SMB_BRL="${SMB_BRL:-0}"
 
 SERVER_EXTRA=""
 SHARE_EXTRA=""
@@ -269,7 +273,11 @@ esac
 
 # Build the mount options for the CIFS mount.  vers= pins the dialect; seal/sign
 # add SMB3 transport encryption / signing for the secmode variants.
-SMB_MOUNT_OPTS="username=root,password=secret,vers=${VERS},nobrl,modefromsid,cache=${SMB_CACHE}"
+# nobrl suppresses byte-range locking; drop it when SMB_BRL=1 so the kernel
+# client issues real SMB2 LOCK requests.
+BRL_OPT=",nobrl"
+[ "$SMB_BRL" = "1" ] && BRL_OPT=""
+SMB_MOUNT_OPTS="username=root,password=secret,vers=${VERS}${BRL_OPT},modefromsid,cache=${SMB_CACHE}"
 case "$SECMODE" in
     seal) SMB_MOUNT_OPTS="${SMB_MOUNT_OPTS},seal" ;;
     sign) SMB_MOUNT_OPTS="${SMB_MOUNT_OPTS},sign" ;;

--- a/kvm/tests/CMakeLists.txt
+++ b/kvm/tests/CMakeLists.txt
@@ -42,6 +42,18 @@ if(HAVE_LIBAIO)
     list(APPEND PNFS_BACKENDS diskfs_aio)
 endif()
 
+# Backends that implement a native VFS clone (reflink / FSCTL_DUPLICATE_EXTENTS):
+# memfs (4K-aligned CoW) and diskfs.  Passthrough backends (linux/io_uring) can
+# only clone if the host filesystem does, so they are excluded from the SMB
+# clone test (which forces the offload with `cp --reflink=always`).
+set(SMB_CLONE_BACKENDS memfs)
+if(IO_URING_ENABLED)
+    list(APPEND SMB_CLONE_BACKENDS diskfs_io_uring)
+endif()
+if(HAVE_LIBAIO)
+    list(APPEND SMB_CLONE_BACKENDS diskfs_aio)
+endif()
+
 # pNFS block layout (RFC 5663): diskfs-only (it sources block layouts).  The
 # data lives on a signed virtio-SCSI disk the client reaches directly as
 # /dev/sda; the MDS only allocates extents and never touches it.
@@ -798,6 +810,56 @@ foreach(image_spec ${KVM_IMAGES})
                 set_tests_properties(chimera/kvm/${IMAGE_NAME}/smb/feature/leases_memfs
                     PROPERTIES DISABLED TRUE)
             endif()
+        endforeach()
+    endif()
+
+    # SMB real byte-range locking + server-side copy -- ubuntu2404 only.
+    if(IMAGE_NAME STREQUAL "ubuntu2404")
+        # Byte-range locking: drop nobrl (SMB_BRL=1) so the kernel client issues
+        # real SMB2 LOCK requests, and run LTP's fcntl-locktests over the cifs
+        # mount.  With nobrl (every other SMB suite) locking is never exercised.
+        foreach(backend ${KVM_BACKENDS})
+            add_test(NAME chimera/kvm/${IMAGE_NAME}/smb/locking/fcntl-locktests_${backend}
+                COMMAND env SMB_BRL=1
+                        bash ${SMB_WRAPPER}
+                        ${IMAGE_DIR}/vmlinuz ${IMAGE_DIR}/rootfs.qcow2
+                        ${CHIMERA_BINARY} ${backend} 3.1.1 none
+                        "/opt/ltp-run.sh fcntl-locktests")
+            set_tests_properties(chimera/kvm/${IMAGE_NAME}/smb/locking/fcntl-locktests_${backend}
+                PROPERTIES LABELS "kvm;${IMAGE_NAME}" PROCESSORS 2 TIMEOUT 600)
+        endforeach()
+
+        # Server-side copy via copy_file_range -> FSCTL_SRV_COPYCHUNK.
+        # --reflink=never keeps the kernel off the clone path so this exercises
+        # CopyChunk specifically; cmp verifies the bytes.
+        foreach(backend ${KVM_BACKENDS})
+            add_test(NAME chimera/kvm/${IMAGE_NAME}/smb/copy/copychunk_${backend}
+                COMMAND bash ${SMB_WRAPPER}
+                        ${IMAGE_DIR}/vmlinuz ${IMAGE_DIR}/rootfs.qcow2
+                        ${CHIMERA_BINARY} ${backend} 3.1.1 none
+                        "mkdir -p /mnt/test && dd if=/dev/urandom of=/mnt/test/src bs=1M count=4 2>/dev/null && cp --reflink=never /mnt/test/src /mnt/test/dst && cmp /mnt/test/src /mnt/test/dst")
+            set_tests_properties(chimera/kvm/${IMAGE_NAME}/smb/copy/copychunk_${backend}
+                PROPERTIES LABELS "kvm;${IMAGE_NAME}" PROCESSORS 2)
+        endforeach()
+
+        # Clone via FSCTL_DUPLICATE_EXTENTS_TO_FILE.  --reflink=always forces the
+        # offload and errors loudly if it is not honored, so a pass proves the
+        # clone path end-to-end.  Only backends with a native VFS clone.
+        #
+        # DISABLED: the kernel cifs client refuses to even attempt FICLONE
+        # because chimera does not advertise FILE_SUPPORTS_BLOCK_REFCOUNTING in
+        # FileFsAttributeInformation, so cp fails with "Operation not supported"
+        # before any FSCTL is sent.  chimera handles the duplicate-extents FSCTL
+        # (exercised by smbtorture/WPTS), but advertising the FS-attribute flag
+        # has known smbtorture fallout; enable once that is sorted.
+        foreach(backend ${SMB_CLONE_BACKENDS})
+            add_test(NAME chimera/kvm/${IMAGE_NAME}/smb/copy/clone_${backend}
+                COMMAND bash ${SMB_WRAPPER}
+                        ${IMAGE_DIR}/vmlinuz ${IMAGE_DIR}/rootfs.qcow2
+                        ${CHIMERA_BINARY} ${backend} 3.1.1 none
+                        "mkdir -p /mnt/test && dd if=/dev/urandom of=/mnt/test/src bs=1M count=4 2>/dev/null && cp --reflink=always /mnt/test/src /mnt/test/dst && cmp /mnt/test/src /mnt/test/dst")
+            set_tests_properties(chimera/kvm/${IMAGE_NAME}/smb/copy/clone_${backend}
+                PROPERTIES LABELS "kvm;${IMAGE_NAME}" PROCESSORS 2 DISABLED TRUE)
         endforeach()
     endif()
 


### PR DESCRIPTION
Stacked on the feature-configs PR. KVM-validated.

Every SMB suite mounted with `nobrl` (locking untested) and server-side copy was never driven from a real client.

- `SMB_BRL=1` drops nobrl so the client issues real SMB2 LOCK requests.
- `smb/locking/fcntl-locktests_<backend>`: LTP fcntl-locktests over cifs — **passes on every backend**.
- `smb/copy/copychunk_<backend>`: `cp --reflink=never` → FSCTL_SRV_COPYCHUNK — **passes on every backend**.
- `smb/copy/clone_<backend>`: `cp --reflink=always` → DUPLICATE_EXTENTS. **DISABLED** — cifs won't attempt FICLONE because chimera doesn't advertise `FILE_SUPPORTS_BLOCK_REFCOUNTING` (cp fails 'not supported' pre-FSCTL); advertising it has known smbtorture fallout.