### PR TITLE
kvm/nfstest: raise 2-client guest-A RAM to 6 GiB to stop tcpdump OOM flake

### DIFF
--- a/kvm/kvm_nfstest_2client_test_wrapper.sh
+++ b/kvm/kvm_nfstest_2client_test_wrapper.sh
@@ -304,8 +304,21 @@ RUN_CMD="${KVM_DIAG_CMD:-${NFSTEST_CMD}}"
 # cmdline parser truncates test_cmd at the first one.
 TEST_CMD="${SSHFIX}; mkdir -p /mnt/t; command -v ssh >/dev/null 2>&1 || { echo CHIMERA_KVM_FATAL: ssh client missing on guest image, cannot run 2-client test; exit 1; }; ok=0; for i in \$(seq 1 120); do ssh -o ConnectTimeout=2 10.0.0.3 true 2>/dev/null && { ok=1; break; }; sleep 1; done; [ \$ok = 1 ] || { echo CHIMERA_KVM_FATAL: second client 10.0.0.3 unreachable after 120s; exit 1; }; ${RUN_CMD}"
 
+# Guest A RAM: nfstest brackets each subtest with a fresh in-guest tcpdump
+# whose AF_PACKET ring is ~192 MiB (the default --tbsize 192k -- which we must
+# NOT shrink here: on the primary the capture has to absorb its own traffic
+# plus the second client's flooded traffic, and a smaller -B drops the short
+# conflict ops the suite asserts on, see CLIENT_SPEC above).  Several of those
+# rings pile up before the kernel reaps them, OOM-killing tcpdump in a 2 GiB
+# guest -- the captures then go empty and the trace assertions ("OPEN should be
+# sent", "WRITE delegation should be granted") fail, which is the recurring
+# nfstest_delegation/_cache flake.  Give it 6 GiB; -m is only a ceiling (KVM
+# RAM is demand-paged) so the headroom costs no host memory unless touched.
+# (nfstest_alloc/_dio use 8 GiB for the same reason in the single-client
+# wrapper; #909 raised it there but those programs run via the *other* wrapper,
+# so the 2-client delegation/cache tests never got the bump.)
 ip netns exec "${NETNS_NAME}" "$QEMU_BIN" \
-    -enable-kvm -smp 4 -m 2G -cpu host \
+    -enable-kvm -smp 4 -m 6G -cpu host \
     -kernel "$VMLINUZ" $QEMU_INITRD $QEMU_MACHINE -nodefaults \
     -drive file="$ROOTFS",if=virtio,format=qcow2,snapshot=on \
     -netdev tap,id=net0,ifname="${TAP_A}",script=no,downscript=no \


### PR DESCRIPTION
nfstest_delegation_memfs / nfstest_cache_memfs are the top recurring merge-queue flake.

**Root cause.** Their guest A (the primary — runs nfstest and the promiscuous capture) boots with `-m 2G`. nfstest brackets every subtest with a fresh in-guest tcpdump whose AF_PACKET ring is ~192 MiB. On the 2-client primary that ring cannot be shrunk — it must absorb its own traffic *plus* the flooded second-client traffic and the server replies; a smaller `-B` drops the short conflict ops the suite asserts on (see the `CLIENT_SPEC` comment in the wrapper). Several 192 MiB rings pile up before the kernel reaps them and OOM-kill tcpdump in the 2 GiB guest. The captures then go empty and the trace assertions ("OPEN should be sent", "WRITE delegation should be granted") fail. CI logs confirm `Out of memory: Killed process N (tcpdump)`.

**Fix.** Give guest A 6 GiB. `-m` is only a ceiling — KVM guest RAM is demand-paged — so the headroom costs no host memory unless the guest touches it. Guest B stays at 1 GiB (idle sshd only).

**Why #909 did not fix this.** #909 raised delegation/cache RAM but in the single-client wrapper (`kvm_nfstest_test_wrapper.sh`), which these tests do not use — they run via `kvm_nfstest_2client_test_wrapper.sh`, so the bump never reached them. This is the same fix on the correct wrapper.

Smoke-tested locally: guest A boots at 6G, the second client is reachable, and `nfstest_delegation` runs the cross-client suite with no boot or regression.