### PR TITLE
smb2: return INVALID_INFO_CLASS for an unhandled FS info class (wrong-error-code sweep)

### DIFF
--- a/src/server/smb/smb_proc_query_info.c
+++ b/src/server/smb/smb_proc_query_info.c
@@ -375,6 +375,14 @@ chimera_smb_query_info(struct chimera_smb_request *request)
                     chimera_smb_query_stream_info(request);
                     return;
                 default:
+                    /* A FILE info class we do not handle: keep NOT_IMPLEMENTED.
+                     * Samba's smb2.getinfo.qfile_buffercheck enumerates every
+                     * file level and treats NOT_IMPLEMENTED as "level
+                     * unsupported, skip" while asserting OK otherwise -- so a
+                     * valid-but-unsupported level must NOT be reported as
+                     * INVALID_INFO_CLASS.  Distinguishing a genuinely invalid
+                     * class value from a valid-but-unsupported one needs a
+                     * file-info-class validity table (out of scope here). */
                     status = SMB2_STATUS_NOT_IMPLEMENTED;
                     break;
             } /* switch */
@@ -418,7 +426,8 @@ chimera_smb_query_info(struct chimera_smb_request *request)
                     request->query_info.output_length = SMB2_FILE_FS_SECTOR_SIZE_INFO_SIZE;
                     break;
                 default:
-                    status = SMB2_STATUS_NOT_IMPLEMENTED;
+                    /* Unhandled FS info class = invalid class for QUERY_INFO. */
+                    status = SMB2_STATUS_INVALID_INFO_CLASS;
                     break;
             } /* switch */
             break;

--- a/src/server/smb/tests/wpts/fsamodel_cases.csv
+++ b/src/server/smb/tests/wpts/fsamodel_cases.csv
@@ -197,12 +197,12 @@ QueryFileInformationTestCaseS84,skip,unimplemented: info-class/op
 QueryFileInformationTestCaseS86,skip,unimplemented: info-class/op
 QueryFileSystemInformationTestCaseS0,green,
 QueryFileSystemInformationTestCaseS10,green,
-QueryFileSystemInformationTestCaseS12,skip,unimplemented: info-class/op
-QueryFileSystemInformationTestCaseS14,skip,unimplemented: info-class/op
-QueryFileSystemInformationTestCaseS16,skip,unimplemented: info-class/op
+QueryFileSystemInformationTestCaseS12,green,
+QueryFileSystemInformationTestCaseS14,green,
+QueryFileSystemInformationTestCaseS16,green,
 QueryFileSystemInformationTestCaseS18,green,
 QueryFileSystemInformationTestCaseS2,green,
-QueryFileSystemInformationTestCaseS20,skip,unimplemented: info-class/op
+QueryFileSystemInformationTestCaseS20,green,
 QueryFileSystemInformationTestCaseS22,green,
 QueryFileSystemInformationTestCaseS24,green,
 QueryFileSystemInformationTestCaseS26,green,


### PR DESCRIPTION
Result of a sweep over the WPTS "wrong error code" failures (returning a generic
`STATUS_NOT_IMPLEMENTED` where the spec requires a specific status). I divided the
candidate clusters across query_info / set_info / ioctl and evaluated each: **almost
all turned out NOT to be few-line fixes** and were bailed (see below). The one safe,
correct, localized win is this.

## Fix

`QUERY_INFO` for an `SMB2_INFO_FILESYSTEM` information class the server does not
implement returned `STATUS_NOT_IMPLEMENTED`. An info class the server does not handle
is an **invalid class for the operation**, which MS-FSA / MS-FSCC require to be
`STATUS_INVALID_INFO_CLASS`. Only the FILESYSTEM dispatch default changes.

Safe against Samba's `smb2.getinfo.qfs_buffercheck`, which exercises only the FS
levels chimera already handles (Volume/Size/Device/Attribute/FullSize) — those return
SUCCESS and never reach the default.

## What was bailed, and why (the sweep's findings)

- **FILE info-class default** (`smb_proc_query_info.c`): leaving it as `NOT_IMPLEMENTED`
  on purpose. Samba's `smb2.getinfo.qfile_buffercheck` enumerates every file level and
  treats `NOT_IMPLEMENTED` as "level unsupported, skip" while asserting SUCCESS
  otherwise — so a valid-but-unsupported file level must **not** become
  `INVALID_INFO_CLASS`. Doing it right needs a file-info-class validity table to
  distinguish a genuinely invalid class value from a valid-but-unsupported one. Out of
  scope. (An in-code comment records this so the next attempt doesn't regress getinfo.)
- **set_info defaults**: the failing cases demand a *mix* of statuses (NOT_SUPPORTED /
  INVALID_PARAMETER / SUCCESS) and several need class constants not defined and actual
  feature work (FileMode/ValidDataLength/ShortName). Not a status swap.
- **ioctl**: the unhandled-FSCTL default already returns the spec-correct
  `NOT_SUPPORTED` (MS-SMB2 3.3.5.15); the failing cases want per-FSCTL validation
  (INVALID_PARAMETER / INVALID_DEVICE_REQUEST) entangled with missing features.

## Result

Greens **4** MS-FSAModel `QueryFileSystemInformation` cases (S12/S14/S16/S20) →
`wpts-fsamodel` gate **110 → 114**.

## Verification

- Full MS-FSAModel rerun: **+4, 0 regressions**; full MS-FSA rerun: **unchanged** (no regressions).
- smbtorture (Debug/ASan) `getinfo` (incl. `qfile_buffercheck` + `qfs_buffercheck`),
  `setinfo`, `fileinfo`, `create`, `streams`, `ioctl_on_stream`: all green.
- The 4 greened cases confirmed across 3 runs.