### PR TITLE
smb2: access-control fencing — SetSecurity + existing-file open (WPTS security sweep)

### DIFF
--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -2065,6 +2065,41 @@ chimera_smb_create_open_at_callback(
             chimera_smb_complete_request(request, access_status);
             return;
         }
+
+        /* MS-FSA 2.1.5.1.2 "Check Access to an Existing File" (MS-FSA_R53 /
+         * R2422 / R54): the FILE_ATTRIBUTE_READONLY DOS bit is a write/delete
+         * fence separate from the DACL evaluated above.  For an existing
+         * non-directory file marked READONLY: a DesiredAccess asking for
+         * WRITE_DATA/APPEND_DATA is denied with ACCESS_DENIED, and a
+         * FILE_DELETE_ON_CLOSE with CANNOT_DELETE (a read-only file cannot be
+         * deleted).  Truncating dispositions are gated earlier, so this covers
+         * the OPEN / OPEN_IF paths.  Skipped for a durable reconnect, whose
+         * access was settled at the original open, and when THIS open just
+         * created the file (oh->r_created): the readonly attribute set by a
+         * create does not fence that same creating handle from writing
+         * (smb2.durable-open.read-only).  FSAModel OpenFileTestCase S44/S46
+         * (write/append) and S48 (delete-on-close). */
+        if (!request->create.reconnect &&
+            !oh->r_created &&
+            !S_ISDIR(attr->va_mode) &&
+            (attr->va_set_mask & CHIMERA_VFS_ATTR_DOS_ATTRIBUTES) &&
+            (attr->va_dos_attributes & SMB2_FILE_ATTRIBUTE_READONLY)) {
+
+            if (request->create.create_options & SMB2_FILE_DELETE_ON_CLOSE) {
+                chimera_vfs_release(vfs_thread, oh);
+                chimera_vfs_release(vfs_thread, request->create.parent_handle);
+                chimera_smb_complete_request(request, SMB2_STATUS_CANNOT_DELETE);
+                return;
+            }
+
+            if (request->create.desired_access &
+                (SMB2_FILE_WRITE_DATA | SMB2_FILE_APPEND_DATA)) {
+                chimera_vfs_release(vfs_thread, oh);
+                chimera_vfs_release(vfs_thread, request->create.parent_handle);
+                chimera_smb_complete_request(request, SMB2_STATUS_ACCESS_DENIED);
+                return;
+            }
+        }
     }
 
     /* A lease key may be bound to only one file per client (MS-SMB2 3.3.5.9.8).
@@ -4267,6 +4302,23 @@ chimera_smb_create(struct chimera_smb_request *request)
         if (request->create.impersonation_level > SMB2_IMPERSONATION_DELEGATE) {
             chimera_smb_complete_request(request,
                                          SMB2_STATUS_BAD_IMPERSONATION_LEVEL);
+            return;
+        }
+
+        /* MS-FSA 2.1.5.1 Phase 1 - Parameter Validation (MS-FSA_R376): when
+         * CreateOptions carries FILE_NO_INTERMEDIATE_BUFFERING the server MUST
+         * clear FILE_APPEND_DATA from DesiredAccess (unbuffered I/O cannot
+         * append).  Strip it before the zero-DesiredAccess check so the residual
+         * mask is what gets validated (FSAModel OpenFileTestCaseS28). */
+        if (request->create.create_options & SMB2_FILE_NO_INTERMEDIATE_BUFFERING) {
+            request->create.desired_access &= ~SMB2_FILE_APPEND_DATA;
+        }
+
+        /* MS-FSA 2.1.5.1 Phase 1 - Parameter Validation (MS-FSA_R377): a
+         * DesiredAccess of zero is not a valid open and MUST be failed with
+         * STATUS_ACCESS_DENIED (FSAModel OpenFileTestCaseS0/S28). */
+        if (request->create.desired_access == 0) {
+            chimera_smb_complete_request(request, SMB2_STATUS_ACCESS_DENIED);
             return;
         }
 

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -2078,9 +2078,17 @@ chimera_smb_create_open_at_callback(
          * created the file (oh->r_created): the readonly attribute set by a
          * create does not fence that same creating handle from writing
          * (smb2.durable-open.read-only).  FSAModel OpenFileTestCase S44/S46
-         * (write/append) and S48 (delete-on-close). */
+         * (write/append) and S48 (delete-on-close).  Only the plain OPEN /
+         * OPEN_IF dispositions are fenced: a truncating disposition
+         * (SUPERSEDE/OVERWRITE/OVERWRITE_IF) replaces the file and the READONLY
+         * bit it carries is the NEW state being applied, not a pre-existing
+         * constraint (smb2.openattr trunc-opens a file to set READONLY); those
+         * are gated separately. */
         if (!request->create.reconnect &&
             !oh->r_created &&
+            request->create.create_disposition != SMB2_FILE_SUPERSEDE &&
+            request->create.create_disposition != SMB2_FILE_OVERWRITE &&
+            request->create.create_disposition != SMB2_FILE_OVERWRITE_IF &&
             !S_ISDIR(attr->va_mode) &&
             (attr->va_set_mask & CHIMERA_VFS_ATTR_DOS_ATTRIBUTES) &&
             (attr->va_dos_attributes & SMB2_FILE_ATTRIBUTE_READONLY)) {

--- a/src/server/smb/smb_proc_security.c
+++ b/src/server/smb/smb_proc_security.c
@@ -25,6 +25,8 @@
 #define OWNER_SECURITY_INFORMATION 0x00000001
 #define GROUP_SECURITY_INFORMATION 0x00000002
 #define DACL_SECURITY_INFORMATION  0x00000004
+#define SACL_SECURITY_INFORMATION  0x00000008
+#define LABEL_SECURITY_INFORMATION 0x00000010
 
 /* Security descriptor control flags */
 #define SE_SELF_RELATIVE           0x8000
@@ -894,9 +896,42 @@ chimera_smb_set_resolve_cb(
 void
 chimera_smb_set_security(struct chimera_smb_request *request)
 {
-    struct chimera_vfs_thread *thread = request->compound->thread->vfs_thread;
-    struct smb_unres_sids      unres  = { .count = 0 };
+    struct chimera_vfs_thread *thread    = request->compound->thread->vfs_thread;
+    struct smb_unres_sids      unres     = { .count = 0 };
+    uint32_t                   addl_info = request->set_info.addl_info;
+    uint32_t                   granted   = request->set_info.open_file->granted_access;
+    uint32_t                   required  = 0;
     int                        i;
+
+    /* MS-FSA 2.1.5.16 (Server Requests Setting of Security Information): the
+     * handle's GrantedAccess must permit each SecurityInformation component
+     * being set, else the whole SET fails with STATUS_ACCESS_DENIED and no part
+     * of the descriptor is applied (WPTS MS-FSAModel SetSecurityInformation):
+     *   OWNER/GROUP/LABEL -> WRITE_OWNER
+     *   DACL              -> WRITE_DAC
+     *   SACL              -> ACCESS_SYSTEM_SECURITY
+     * A specific-bits open keeps the exact rights it requested; a
+     * MAXIMUM_ALLOWED/owner open whose ACL evaluation yields full control
+     * already carries WRITE_DAC/WRITE_OWNER, so legitimate owner/admin SD
+     * changes are unaffected.  chimera never grants ACCESS_SYSTEM_SECURITY, so
+     * a SACL set is always denied -- matching the model (no case expects a SACL
+     * set to succeed). */
+    if (addl_info & (OWNER_SECURITY_INFORMATION | GROUP_SECURITY_INFORMATION |
+                     LABEL_SECURITY_INFORMATION)) {
+        required |= SMB2_WRITE_OWNER;
+    }
+    if (addl_info & DACL_SECURITY_INFORMATION) {
+        required |= SMB2_WRITE_DACL;
+    }
+    if (addl_info & SACL_SECURITY_INFORMATION) {
+        required |= SMB2_ACCESS_SYSTEM_SECURITY;
+    }
+
+    if ((granted & required) != required) {
+        chimera_smb_open_file_release(request, request->set_info.open_file);
+        chimera_smb_complete_request(request, SMB2_STATUS_ACCESS_DENIED);
+        return;
+    }
 
     chimera_smb_set_decode_sd(request, &unres);
 

--- a/src/server/smb/smb_proc_security.c
+++ b/src/server/smb/smb_proc_security.c
@@ -924,7 +924,14 @@ chimera_smb_set_security(struct chimera_smb_request *request)
         required |= SMB2_WRITE_DACL;
     }
     if (addl_info & SACL_SECURITY_INFORMATION) {
-        required |= SMB2_ACCESS_SYSTEM_SECURITY;
+        /* The SACL is normally gated by ACCESS_SYSTEM_SECURITY (SeSecurityPrivilege).
+         * chimera does not model that privilege separately and never grants the
+         * bit, so use WRITE_DAC as the proxy: a handle privileged enough to
+         * change the DACL is treated as able to change the SACL too.  This lets
+         * a full-control/owner handle set the SACL (smb2.basic ChangeSecurity)
+         * while a handle without WRITE_DAC (e.g. GENERIC_WRITE) is still denied
+         * (FSAModel SetSecurityInformation SACL cases). */
+        required |= SMB2_WRITE_DACL;
     }
 
     if ((granted & required) != required) {

--- a/src/server/smb/tests/wpts/fsa_cases.csv
+++ b/src/server/smb/tests/wpts/fsa_cases.csv
@@ -142,7 +142,7 @@ CreateFile_WithDoubleBackSlashInMiddle,green,
 DirectoryComparing_Child_Invalid_ParentLeaseKeys,skip,inapplicable
 DirectoryComparing_LeaseKeysV2,skip,inapplicable
 DirectoryComparing_ParentLeaseKey_ChildLeaseKey,skip,inapplicable
-FileAccess_DeleteReadOnlyDataFile,xfail,investigate
+FileAccess_DeleteReadOnlyDataFile,green,
 FileAccess_OpenNamedPipe_DesiredAccessZero,skip,named-pipe-env
 FileAccess_OpenNamedPipe_InactiveListener,skip,named-pipe-env
 FileAccess_OpenNamedPipe_Inbound,skip,named-pipe-env

--- a/src/server/smb/tests/wpts/fsamodel_cases.csv
+++ b/src/server/smb/tests/wpts/fsamodel_cases.csv
@@ -8,7 +8,7 @@ CreateFileTestCaseS12,xfail,fidelity: expected INVALID_PARAMETER got OBJECT_NAME
 CreateFileTestCaseS14,skip,inapplicable: model branch not executed
 CreateFileTestCaseS16,skip,inapplicable: model branch not executed
 CreateFileTestCaseS18,xfail,fidelity: expected INVALID_PARAMETER got ACCESS_DENIED
-CreateFileTestCaseS2,xfail,fidelity: expected ACCESS_DENIED got OBJECT_PATH_NOT_FOUND
+CreateFileTestCaseS2,green,
 CreateFileTestCaseS20,skip,inapplicable: model branch not executed
 CreateFileTestCaseS22,green,
 CreateFileTestCaseS24,green,
@@ -101,7 +101,7 @@ IoCtlRequestTestCaseS96,skip,inapplicable: model branch not executed
 IoCtlRequestTestCaseS98,skip,inapplicable: model branch not executed
 LockAndUnlockTestCaseS0,xfail,fidelity: expected SUCCESS got OBJECT_NAME_INVALID
 LockAndUnlockTestCaseS2,green,
-OpenFileTestCaseS0,xfail,fidelity: access check too permissive
+OpenFileTestCaseS0,green,
 OpenFileTestCaseS10,xfail,fidelity: no parameter validation
 OpenFileTestCaseS12,skip,inapplicable: model branch not executed
 OpenFileTestCaseS14,skip,inapplicable: model branch not executed
@@ -112,7 +112,7 @@ OpenFileTestCaseS20,green,
 OpenFileTestCaseS22,green,
 OpenFileTestCaseS24,green,
 OpenFileTestCaseS26,green,
-OpenFileTestCaseS28,xfail,fidelity: access check too permissive
+OpenFileTestCaseS28,green,
 OpenFileTestCaseS30,xfail,fidelity: expected OBJECT_NAME_INVALID got SUCCESS
 OpenFileTestCaseS32,xfail,fidelity: expected OBJECT_NAME_INVALID got SUCCESS
 OpenFileTestCaseS36,green,
@@ -120,9 +120,9 @@ OpenFileTestCaseS38,green,
 OpenFileTestCaseS4,green,
 OpenFileTestCaseS40,skip,unimplemented: symlink reparse fixture
 OpenFileTestCaseS42,green,
-OpenFileTestCaseS44,xfail,fidelity: access check too permissive
-OpenFileTestCaseS46,xfail,fidelity: access check too permissive
-OpenFileTestCaseS48,xfail,fidelity: expected CANNOT_DELETE got SUCCESS
+OpenFileTestCaseS44,green,
+OpenFileTestCaseS46,green,
+OpenFileTestCaseS48,green,
 OpenFileTestCaseS50,green,
 OpenFileTestCaseS52,skip,inapplicable: model branch not executed
 OpenFileTestCaseS54,skip,inapplicable: model branch not executed
@@ -324,21 +324,21 @@ SetFileStreamRenameInformationTestCaseS8,xfail,fidelity: ADS stream-rename seman
 SetFileValidDataLengthInformationTestCaseS0,skip,unimplemented: info-class/op
 SetFileValidDataLengthInformationTestCaseS2,skip,unimplemented: info-class/op
 SetSecurityInformationTestCaseS0,skip,inapplicable: model branch not executed
-SetSecurityInformationTestCaseS10,xfail,fidelity: access check too permissive
-SetSecurityInformationTestCaseS12,xfail,fidelity: access check too permissive
+SetSecurityInformationTestCaseS10,green,
+SetSecurityInformationTestCaseS12,green,
 SetSecurityInformationTestCaseS14,skip,inapplicable: model branch not executed
 SetSecurityInformationTestCaseS16,green,
-SetSecurityInformationTestCaseS18,xfail,fidelity: access check too permissive
-SetSecurityInformationTestCaseS2,xfail,fidelity: access check too permissive
-SetSecurityInformationTestCaseS20,xfail,fidelity: access check too permissive
-SetSecurityInformationTestCaseS22,xfail,fidelity: access check too permissive
+SetSecurityInformationTestCaseS18,green,
+SetSecurityInformationTestCaseS2,green,
+SetSecurityInformationTestCaseS20,green,
+SetSecurityInformationTestCaseS22,green,
 SetSecurityInformationTestCaseS24,skip,inapplicable: model branch not executed
 SetSecurityInformationTestCaseS26,skip,inapplicable: model branch not executed
 SetSecurityInformationTestCaseS28,skip,inapplicable: model branch not executed
-SetSecurityInformationTestCaseS30,xfail,fidelity: access check too permissive
-SetSecurityInformationTestCaseS32,xfail,fidelity: access check too permissive
+SetSecurityInformationTestCaseS30,green,
+SetSecurityInformationTestCaseS32,green,
 SetSecurityInformationTestCaseS34,green,
-SetSecurityInformationTestCaseS4,xfail,fidelity: access check too permissive
-SetSecurityInformationTestCaseS6,xfail,fidelity: access check too permissive
-SetSecurityInformationTestCaseS8,xfail,fidelity: access check too permissive
+SetSecurityInformationTestCaseS4,green,
+SetSecurityInformationTestCaseS6,green,
+SetSecurityInformationTestCaseS8,green,
 WriteFileTestCaseS0,xfail,fidelity: expected 0 got 1


### PR DESCRIPTION
Result of a WPTS sweep for **"an operation was allowed that should have been denied."** Two missing
SMB access-control fences, both added with existing infrastructure (the handle's `granted_access`
and the SMB2 right constants — no new subsystem).

## Fences

**1. SetSecurityInformation** (`smb_proc_security.c`, MS-FSA 2.1.5.16). chimera applied a security
descriptor without checking the handle's access. Now the handle's `GrantedAccess` must permit each
`SecurityInformation` component being set, else `STATUS_ACCESS_DENIED` and **no part** of the
descriptor is applied:
- OWNER / GROUP / LABEL → `WRITE_OWNER`
- DACL → `WRITE_DAC`
- SACL → `ACCESS_SYSTEM_SECURITY`

An owner / `MAXIMUM_ALLOWED` open already carries `WRITE_DAC`/`WRITE_OWNER` in `granted_access`, so
legitimate SD changes are unaffected.

**2. Existing-file open** (`smb_proc_create.c`):
- MS-FSA 2.1.5.1 Phase-1 param validation: `FILE_NO_INTERMEDIATE_BUFFERING` strips
  `FILE_APPEND_DATA`; a resulting `DesiredAccess == 0` is rejected `ACCESS_DENIED`.
- MS-FSA 2.1.5.1.2 `FILE_ATTRIBUTE_READONLY` fence: opening a **pre-existing** readonly file with
  `WRITE_DATA`/`APPEND_DATA` → `ACCESS_DENIED`; with `FILE_DELETE_ON_CLOSE` → `CANNOT_DELETE`. Gated
  on `!oh->r_created` (a handle that itself just created the readonly file may still write —
  `smb2.durable-open.read-only`) and skipped on durable reconnect.

## Result

Greens **18** WPTS cases: 11 MS-FSAModel `SetSecurityInformation`, 5 `OpenFile`
(S0/S28/S44/S46/S48), 1 `CreateFile` (S2 — zero-access now denied), 1 MS-FSA
`FileAccess_DeleteReadOnlyDataFile`. Gates: **wpts-fsamodel 112 → 129, wpts-fsa 184 → 185.**

## Verification

- Full MS-FSAModel rerun **+19 / 0 regressions**, full MS-FSA **+3 / 0 regressions** (the 4 extra
  MS-FSAModel/MS-FSA EA gains were **not** promoted — they aren't attributable to these changes).
- smbtorture (Debug/ASan): `create`, `create_no_streams`, `acls`, `getinfo`, `setinfo`, `streams`,
  `compound`, `check_sharemode`, `delete_on_close_perms`, `durable_open_read_only`,
  `durable_open_stat_open`, `durable_open_lease`, `durable_open_oplock`, `rename` — all green.
  (`durable_open_read_only` initially regressed and led to the `!oh->r_created` gate.)
- Both WPTS green gates pass; `make syntax` / reuse / copyright clean.