### PR TITLE
nfs: batch of extra-small (1-SP) conformance fixes from the 2026-06 audit

### DIFF
--- a/src/server/nfs/nfs.c
+++ b/src/server/nfs/nfs.c
@@ -1089,7 +1089,9 @@ chimera_nfs_find_export_path(
             // path is shorter than export name, cannot match
             continue;
         }
-        if (strncasecmp(export_name, path, export_name_len) == 0) {
+        /* NFSv4 component names are case-sensitive and the synthetic pseudo-fs
+         * has no case-insensitive backend; match export names exactly. */
+        if (strncmp(export_name, path, export_name_len) == 0) {
             export = cur_export;
             // Check if this is a valid prefix match (at path boundary)
             if (path_len == export_name_len) {

--- a/src/server/nfs/nfs3_proc_pathconf.c
+++ b/src/server/nfs/nfs3_proc_pathconf.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -31,6 +31,7 @@ chimera_nfs3_pathconf(
     res.resok.no_trunc         = 1;
     res.resok.linkmax          = UINT32_MAX;
     res.resok.name_max         = 255;
+    res.resok.chown_restricted = 1;   /* POSIX restricts chown to the superuser */
 
     rc = shared->nfs_v3.send_reply_NFSPROC3_PATHCONF(evpl, NULL, &res, encoding);
     chimera_nfs_abort_if(rc, "Failed to send RPC2 reply");

--- a/src/server/nfs/nfs4_attr.h
+++ b/src/server/nfs/nfs4_attr.h
@@ -356,9 +356,10 @@ chimera_nfs4_attr_append_acl(
         uint32_t                  flag = ace->flags;
         int                       is_group;
 
-        is_group = (ace->who.type == CHIMERA_PRINCIPAL_GROUP) ||
-            (ace->who.type == CHIMERA_PRINCIPAL_SPECIAL &&
-             ace->who.special == CHIMERA_WHO_GROUP);
+        /* ACE4_IDENTIFIER_GROUP applies only to a named group principal; for
+         * special identifiers (incl. GROUP@) it SHOULD be zero on encode
+         * (RFC 7530 §6.2.1.5) and the decoder ignores it for specials. */
+        is_group = (ace->who.type == CHIMERA_PRINCIPAL_GROUP);
 
         if (is_group) {
             flag |= CHIMERA_ACE_FLAG_IDENTIFIER_GROUP;

--- a/src/server/nfs/nfs4_pnfs.c
+++ b/src/server/nfs/nfs4_pnfs.c
@@ -210,10 +210,13 @@ chimera_nfs4_getdeviceinfo(
                 break;
         } /* switch */
     } else {
+        /* Known layout type but unrecognized device id => NFS4ERR_NOENT so the
+         * client can distinguish a stale deviceid from a malformed request
+         * (RFC 8881 §18.40.3); an unsupported layout type => UNKNOWN_LAYOUTTYPE. */
         res->gdir_status = (args->gdia_layout_type != LAYOUT4_FLEX_FILES &&
                             args->gdia_layout_type != LAYOUT4_BLOCK_VOLUME &&
                             args->gdia_layout_type != LAYOUT4_SCSI)
-                           ? NFS4ERR_UNKNOWN_LAYOUTTYPE : NFS4ERR_INVAL;
+                           ? NFS4ERR_UNKNOWN_LAYOUTTYPE : NFS4ERR_NOENT;
         chimera_nfs4_compound_complete(req, res->gdir_status);
         return;
     }

--- a/src/server/nfs/nfs4_pnfs.c
+++ b/src/server/nfs/nfs4_pnfs.c
@@ -111,7 +111,9 @@ chimera_nfs4_encode_ff_device_addr(
      * (NFSv3 or NFSv4.x), loosely coupled. */
     pnfs_put_u32(&p, 1);
     pnfs_put_u32(&p, version);                /* ffdv_version          */
-    pnfs_put_u32(&p, minorversion);           /* ffdv_minorversion     */
+    /* RFC 8435 §4.1: if ffdv_version == 3 the server MUST set ffdv_minorversion
+     * to 0 (and ffdv_tightly_coupled to false, hardcoded below). */
+    pnfs_put_u32(&p, version == 3 ? 0 : minorversion); /* ffdv_minorversion */
     pnfs_put_u32(&p, NFS4_PNFS_STRIPE_UNIT);  /* ffdv_rsize            */
     pnfs_put_u32(&p, NFS4_PNFS_STRIPE_UNIT);  /* ffdv_wsize            */
     pnfs_put_u32(&p, 0);                      /* ffdv_tightly_coupled=false */

--- a/src/server/nfs/nfs4_pnfs.c
+++ b/src/server/nfs/nfs4_pnfs.c
@@ -221,10 +221,14 @@ chimera_nfs4_getdeviceinfo(
         return;
     }
 
-    /* gdia_maxcount bounds the bytes the client will accept for the
-     * da_addr_body (RFC 8881 §18.40.3); signal TOOSMALL with the required
-     * size if it cannot fit. */
-    if (args->gdia_maxcount < body_len) {
+    /* gdia_maxcount bounds the bytes the client will accept for the da_addr_body
+     * (RFC 8881 §18.40.3).  A maxcount of 0 is the defined way for a client to
+     * validate a device id or (de)register notifications: TOOSMALL MUST NOT be
+     * returned and the reply's da_addr_body is zero length.  Otherwise signal
+     * TOOSMALL with the required size when the body cannot fit. */
+    if (args->gdia_maxcount == 0) {
+        body_len = 0;
+    } else if (args->gdia_maxcount < body_len) {
         res->gdir_status   = NFS4ERR_TOOSMALL;
         res->gdir_mincount = body_len;
         chimera_nfs4_compound_complete(req, res->gdir_status);

--- a/src/server/nfs/nfs4_proc_bind_conn_to_session.c
+++ b/src/server/nfs/nfs4_proc_bind_conn_to_session.c
@@ -45,6 +45,14 @@ chimera_nfs4_bind_conn_to_session(
     bool                              bind_fore, bind_back;
     channel_dir_from_server4          reply_dir;
 
+    /* BIND_CONN_TO_SESSION MUST be the only operation in the COMPOUND
+     * (RFC 8881 §18.34.3, §15.1.3.3); it is never preceded by SEQUENCE. */
+    if (!req->seen_sequence && req->args_compound->num_argarray != 1) {
+        res->bctsr_status = NFS4ERR_NOT_ONLY_OP;
+        chimera_nfs4_compound_complete(req, NFS4ERR_NOT_ONLY_OP);
+        return;
+    }
+
     session = nfs4_session_lookup(&thread->shared->nfs4_shared_clients,
                                   args->bctsa_sessid);
     if (!session) {

--- a/src/server/nfs/nfs4_proc_create_session.c
+++ b/src/server/nfs/nfs4_proc_create_session.c
@@ -170,6 +170,12 @@ chimera_nfs4_create_session(
      * to the client. */
     clamped_fore = args->csa_fore_chan_attrs;
 
+    /* Chimera applies no header padding, so its preferred ca_headerpadsize is 0
+     * on both channels (RFC 8881 §18.36: reply the preferred value, or zero if
+     * padding is not in use); do not parrot the client's requested value. */
+    clamped_fore.ca_headerpadsize              = 0;
+    args->csa_back_chan_attrs.ca_headerpadsize = 0;
+
     /* Server cap on fore-channel slots is configurable (server.nfs4_session_slots);
      * fall back to the compiled-in default if it is unset/invalid. */
     server_max_slots = (uint32_t) chimera_server_config_get_nfs4_session_slots(shared->config);

--- a/src/server/nfs/nfs4_proc_open.c
+++ b/src/server/nfs/nfs4_proc_open.c
@@ -40,6 +40,13 @@ chimera_nfs4_open_acquire_share(
     uint8_t                         granted = 0;
     uint8_t                         denied  = 0;
 
+    /* share_access MUST request at least one of READ or WRITE (RFC 7530
+     * §16.16.5 / §9.9); a value with neither base mode is invalid. */
+    if ((args->share_access &
+         (OPEN4_SHARE_ACCESS_READ | OPEN4_SHARE_ACCESS_WRITE)) == 0) {
+        return NFS4ERR_INVAL;
+    }
+
     if (args->share_access & OPEN4_SHARE_ACCESS_READ) {
         granted |= CHIMERA_VFS_LEASE_MODE_R;
     }

--- a/src/server/nfs/nfs4_proc_open.c
+++ b/src/server/nfs/nfs4_proc_open.c
@@ -1255,9 +1255,9 @@ chimera_nfs4_open(
      *
      *   1. Server-reboot grace window (nfs_recovery_open_check): non-reclaim
      *      OPENs are refused while in_grace, and CLAIM_PREVIOUS reclaims are
-     *      refused outside it.  Persistence is stubbed so in_grace is false in
-     *      practice today, leaving only the reclaim-outside-grace NO_GRACE leg
-     *      live.
+     *      refused outside it.  Recovery records are persisted to the KV store
+     *      (nfs4_recovery.c), so in_grace reflects a real post-restart grace
+     *      period.
      *
      *   2. Per-client reclaim completion (RFC 8881 §18.51.3): once a 4.1+
      *      client establishes a new client ID it MUST send RECLAIM_COMPLETE

--- a/src/server/nfs/nfs4_proc_renew.c
+++ b/src/server/nfs/nfs4_proc_renew.c
@@ -6,14 +6,15 @@
 #include "nfs4_session.h"
 #include "nfs4_state.h"
 
-/* RFC 7530 §16.30: RENEW refreshes the lease for the given client. Chimera
- * does not currently enforce lease expiry, so this is a no-op that always
- * succeeds. Tests that require true lease-expiry semantics (e.g. pynfs
- * testExpired) will not behave correctly until real lease tracking lands.
+/* RFC 7530 §16.28: RENEW refreshes the lease for the given client. Chimera
+ * does enforce lease expiry (nfs4_lease.c sweeps expired leases at ~1 Hz), so
+ * RENEW returns NFS4ERR_STALE_CLIENTID for an unknown client and
+ * NFS4ERR_EXPIRED when the client's lease has been lost to a conflicting
+ * acquirer.
  *
  * One exception: if the client holds delegations but its callback path has
  * been found unusable (a CB_RECALL failed), RENEW returns NFS4ERR_CB_PATH_DOWN
- * (RFC 7530 §16.30.4) so the client knows to re-establish the callback path;
+ * (RFC 7530 §16.28.4) so the client knows to re-establish the callback path;
  * the server retains the delegations meanwhile. */
 void
 chimera_nfs4_renew(

--- a/src/server/nfs/nfs4_proc_verify.c
+++ b/src/server/nfs/nfs4_proc_verify.c
@@ -163,7 +163,7 @@ verify_validate_mask(
         (1 << FATTR4_SYMLINK_SUPPORT) | (1 << FATTR4_NAMED_ATTR) |
         (1 << FATTR4_FSID)            | (1 << FATTR4_UNIQUE_HANDLES) |
         (1 << FATTR4_LEASE_TIME)      | (1 << FATTR4_RDATTR_ERROR) |
-        (1 << FATTR4_ACLSUPPORT)      | (1 << FATTR4_ARCHIVE) |
+        (1 << FATTR4_ACL)             | (1 << FATTR4_ACLSUPPORT)      | (1 << FATTR4_ARCHIVE) |
         (1 << FATTR4_CANSETTIME)      | (1 << FATTR4_CASE_INSENSITIVE) |
         (1 << FATTR4_CASE_PRESERVING) | (1 << FATTR4_CHOWN_RESTRICTED) |
         (1 << FATTR4_FILEHANDLE)      | (1 << FATTR4_FILEID) |

--- a/src/server/nfs/nfs4_session.c
+++ b/src/server/nfs/nfs4_session.c
@@ -583,8 +583,10 @@ nfs4_client_setclientid_confirm(
     if (!r->nfs4_client_scid_confirm_valid ||
         memcmp(confirm, r->nfs4_client_scid_confirm, NFS4_VERIFIER_SIZE) != 0) {
         /* The (clientid, verifier) pair does not name a record awaiting
-         * confirmation (RFC 7530 §16.34.5). */
-        status = NFS4ERR_STALE_STATEID;
+         * confirmation.  SETCLIENTID_CONFIRM's error set (RFC 7530 §13 / §16.34.5)
+         * specifies NFS4ERR_STALE_CLIENTID here; NFS4ERR_STALE_STATEID is only
+         * valid for stateid operations. */
+        status = NFS4ERR_STALE_CLIENTID;
         goto out_unlock;
     }
 

--- a/src/vfs/linux/linux.c
+++ b/src/vfs/linux/linux.c
@@ -1080,7 +1080,10 @@ chimera_linux_read(
     } else {
         chimera_linux_map_attrs(CHIMERA_VFS_FH_MAGIC_LINUX, &request->read.r_attr, fd);
 
-        request->read.r_eof = (len < request->read.length);
+        /* fstat() failed: we cannot compare against the file size, so report
+         * EOF only when the read returned nothing for a non-zero request -- a
+         * short read is NOT end-of-file (RFC 1813 §3.3.6). */
+        request->read.r_eof = (len == 0 && request->read.length > 0);
     }
 
     request->read.r_length = len;

--- a/src/vfs/vfs_acl.c
+++ b/src/vfs/vfs_acl.c
@@ -459,7 +459,9 @@ mask_to_perm_bits(
     if (mask & CHIMERA_ACE_READ_DATA) {
         bits |= S_IROTH;
     }
-    if (mask & CHIMERA_ACE_WRITE_DATA) {
+    /* RFC 7530 §6.3.2: set the write mode bit iff BOTH WRITE_DATA and
+     * APPEND_DATA are granted in the mask. */
+    if ((mask & CHIMERA_ACE_WRITE_DATA) && (mask & CHIMERA_ACE_APPEND_DATA)) {
         bits |= S_IWOTH;
     }
     if (mask & CHIMERA_ACE_EXECUTE) {


### PR DESCRIPTION
Batches the **extra-small (1-SP) NFS-area fixes** from the 2026-06 server-side conformance audit into a single PR — one self-contained commit per fix — to avoid running the full merge-queue matrix once per trivial fix.

Each commit is independent and references the issue it closes.

## Fixes (one commit each)
| Commit | Issue | What |
|---|---|---|
| linux: short read is not EOF when post-read fstat fails | #1138 | only report EOF on a zero-length read of a non-zero request |
| nfs4: SETCLIENTID_CONFIRM returns STALE_CLIENTID | #965 | correct error for verifier mismatch (was STALE_STATEID) |
| nfs4: case-sensitive pseudo-fs export name match | #1160 | strncasecmp → strncmp |
| nfs4: BIND_CONN_TO_SESSION must be the only COMPOUND op | #1143 | add the NFS4ERR_NOT_ONLY_OP guard the sibling ops have |
| vfs/acl: write mode bit needs WRITE_DATA **and** APPEND_DATA | #1154 | RFC 7530 §6.3.2 |
| nfs4: clear ACE4_IDENTIFIER_GROUP on special GROUP@ | #1156 | SHOULD be zero on encode (§6.2.1.5) |
| nfs3: report chown_restricted in PATHCONF | #80 | field was left unset |
| nfs4: VERIFY/NVERIFY accept FATTR4_ACL | #962 | ACL is advertised + handled by GET/SETATTR |
| nfs4: reject OPEN share_access with neither READ nor WRITE | #1002 | NFS4ERR_INVAL (§16.16.5/§9.9) |
| nfs4: correct stale RENEW / OPEN-recovery comments | #1151 | comment-only; expiry & KV-persisted grace are implemented |
| nfs4: reply ca_headerpadsize=0 in CREATE_SESSION | #1164 | server does no header padding (§18.36) |
| nfs4/pnfs: ffdv_minorversion=0 when ffdv_version==3 | #1172 | RFC 8435 §4.1 (flex-files) |
| nfs4/pnfs: GETDEVICEINFO unknown device id → NFS4ERR_NOENT | #1170 | was NFS4ERR_INVAL (§18.40.3) |
| nfs4/pnfs: GETDEVICEINFO maxcount==0 → OK, empty body | #1091 | TOOSMALL MUST NOT be returned (§18.40.3) |

## Validation
Built Release; `uncrustify` clean on all changed files. The combined **pynfs** suites pass 100% locally on **memfs and linux** across **NFSv4.0 / 4.1 / 4.2** (this exercises SETCLIENTID_CONFIRM, OPEN, RENEW, VERIFY, ACL, CREATE_SESSION, BIND_CONN_TO_SESSION, and pNFS GETDEVICEINFO). The NFSv3 PATHCONF and linux READ-EOF fallback changes are exercised by the KVM cthon matrix in the merge queue.

## Notes
- **#1166** (CREATE_SESSION returning NFS4ERR_TOOSMALL for a small `ca_maxrequestsize`) was investigated and **deliberately not applied**: the change regresses pynfs `CSESS28 st_create_session.testTooSmallMaxReq`, which expects TOOSMALL for an undersized `ca_maxrequestsize`. The audit finding appears incorrect; recommend closing #1166 as invalid.
- The audit also flagged an ONC-RPC `unmarshall_rpc_msg` issue, but it lives in the `libevpl` submodule and is out of scope for this repo PR; it needs a separate `libevpl` change.
