### PR TITLE
nfs4: guard RENAME/LINK changeinfo against unfilled directory attrs

### DIFF
--- a/src/server/nfs/nfs4_attr.h
+++ b/src/server/nfs/nfs4_attr.h
@@ -1337,9 +1337,23 @@ chimera_nfs4_set_changeinfo(
     struct chimera_vfs_attrs *dir_pre_attr,
     struct chimera_vfs_attrs *dir_post_attr)
 {
-    cinfo->atomic = (dir_pre_attr->va_set_mask & CHIMERA_VFS_ATTR_ATOMIC) &&
-        (dir_post_attr->va_set_mask & CHIMERA_VFS_ATTR_ATOMIC);
-    cinfo->before = dir_pre_attr->va_mtime.tv_sec * 1000000000 + dir_pre_attr->va_mtime.tv_nsec;
-    cinfo->after  = dir_post_attr->va_mtime.tv_sec * 1000000000 + dir_post_attr->va_mtime.tv_nsec;
-
+    /* before/after are the directory's change attribute (here, its mtime)
+     * pre and post the operation.  They are only meaningful if the backend
+     * actually filled mtime in both snapshots: not every backend populates the
+     * rename/link pre/post directory attrs, and reading va_mtime when the
+     * attr was never set reads uninitialized memory -- which a self-rename
+     * (RFC 7530 §10.4.5: must be a no-op) then reports as a spurious change,
+     * failing pynfs RNM18/19/20.  Without both mtimes, report a non-atomic,
+     * no-change cinfo (before == after) rather than fabricating a delta. */
+    if ((dir_pre_attr->va_set_mask & CHIMERA_VFS_ATTR_MTIME) &&
+        (dir_post_attr->va_set_mask & CHIMERA_VFS_ATTR_MTIME)) {
+        cinfo->atomic = (dir_pre_attr->va_set_mask & CHIMERA_VFS_ATTR_ATOMIC) &&
+            (dir_post_attr->va_set_mask & CHIMERA_VFS_ATTR_ATOMIC);
+        cinfo->before = dir_pre_attr->va_mtime.tv_sec * 1000000000 + dir_pre_attr->va_mtime.tv_nsec;
+        cinfo->after  = dir_post_attr->va_mtime.tv_sec * 1000000000 + dir_post_attr->va_mtime.tv_nsec;
+    } else {
+        cinfo->atomic = 0;
+        cinfo->before = 0;
+        cinfo->after  = 0;
+    }
 } /* chimera_nfs4_set_changeinfo */


### PR DESCRIPTION
chimera_nfs4_set_changeinfo() derived change_info4.before/after from the directory's va_mtime unconditionally. But not every backend fills the rename/link pre/post directory attributes — cairn, linux and io_uring leave them with an empty va_set_mask — so before/after were read from **uninitialized memory**.

**Symptom.** A self-rename (RFC 7530 §10.4.5 — renaming a file onto itself, or onto its own hard link, must be a no-op) then reports `before != after`, i.e. a spurious directory change. Whether this is observed depends entirely on what the uninitialized memory happens to contain: today it reads as zero (`before == after`, tests pass), but any change to `struct chimera_vfs_attrs` shifts the garbage and the self-rename pynfs cases start failing:

```
RNM18 st_rename.testSelfRenameDir  : FAILURE
RNM19 st_rename.testSelfRenameFile : FAILURE  ("should do nothing, but cinfo was changed")
RNM20 st_rename.testLinkRename     : FAILURE
```

(This is exactly what surfaced when the in-flight diskfs PR #935 — which extends `struct chimera_vfs_attrs` — entered the merge queue: `combined_{cairn,linux,io_uring}_nfs4.{0,1,2}` went red while memfs/diskfs stayed green.)

**Fix.** Only consult `va_mtime` when **both** snapshots actually set it; otherwise report a non-atomic, no-change cinfo (`before == after == 0`). This makes deterministic what the non-filling backends already produced by luck.

**Verified locally:** pynfs `combined_{cairn,linux,io_uring}_nfs4.{0,1,2}` all pass; memfs/diskfs unaffected.