### PR TITLE
vfs: make the attribute cache optional (common.attr_cache, default on)

### DIFF
--- a/src/client/client.c
+++ b/src/client/client.c
@@ -32,6 +32,7 @@ chimera_client_config_init(void)
     config->async_delegation         = 0;
     config->async_delegation_threads = 8;
     config->cache_ttl                = 60;
+    config->attr_cache_enabled       = 1;
     config->rcu_reclaim_threads      = 4; /* 4 = cap RCU reclaim workers to avoid thread exhaustion on many-core hosts */
     config->max_fds                  = 1024;
 
@@ -194,6 +195,7 @@ chimera_client_init(
                                    config->num_modules,
                                    config->kv_module,
                                    config->cache_ttl,
+                                   config->attr_cache_enabled,
                                    config->rcu_reclaim_threads,
                                    metrics);
 
@@ -337,6 +339,10 @@ chimera_client_init_json(
             config->rcu_reclaim_threads = rcu_threads;
         }
     }
+
+    /* The VFS attribute cache (common.attr_cache) is a VFS-level facility shared
+     * with the server; on by default. */
+    config->attr_cache_enabled = chimera_common_attr_cache_enabled(root);
 
     client = chimera_client_init(config, cred, metrics);
 

--- a/src/client/client_internal.h
+++ b/src/client/client_internal.h
@@ -423,6 +423,7 @@ struct chimera_client_config {
     int                           async_delegation;
     int                           async_delegation_threads;
     int                           cache_ttl;
+    int                           attr_cache_enabled;
     int                           rcu_reclaim_threads;
     int                           max_fds;
     enum chimera_tcp_flavor       tcp_flavor;

--- a/src/common/common_config.h
+++ b/src/common/common_config.h
@@ -308,3 +308,33 @@ chimera_common_rcu_reclaim_threads(json_t *root)
 
     return -1;
 } /* chimera_common_rcu_reclaim_threads */
+
+/*
+ * Whether the VFS attribute cache is enabled, from the shared "common" section's
+ * "attr_cache" boolean key.  The attr cache is a VFS-level facility used by both
+ * the server and the client, so this is honored identically by both.  When
+ * disabled the cache is not instantiated and nothing is inserted into or looked
+ * up from it (the cache helpers no-op on a NULL cache).  Defaults to enabled
+ * (returns 1) when the section or key is absent; `root` may be NULL.
+ */
+static inline int
+chimera_common_attr_cache_enabled(json_t *root)
+{
+    json_t *common, *val;
+
+    if (!root) {
+        return 1;
+    }
+
+    common = json_object_get(root, "common");
+    if (!json_is_object(common)) {
+        return 1;
+    }
+
+    val = json_object_get(common, "attr_cache");
+    if (json_is_boolean(val)) {
+        return json_is_true(val) ? 1 : 0;
+    }
+
+    return 1;
+} /* chimera_common_attr_cache_enabled */

--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -413,6 +413,11 @@ main(
         }
     }
 
+    /* The VFS attribute cache (common.attr_cache) is a VFS-level facility shared
+     * with the client; on by default. */
+    chimera_server_config_set_attr_cache_enabled(server_config,
+                                                 chimera_common_attr_cache_enabled(config));
+
     json_value = json_object_get(server_params, "smb_persistent_handles");
     if (json_is_boolean(json_value)) {
         chimera_server_config_set_smb_persistent_handles(server_config, json_is_true(json_value));

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -67,6 +67,7 @@ struct chimera_server_config {
     int                                   async_delegation;
     int                                   async_delegation_threads;
     int                                   cache_ttl;
+    int                                   attr_cache_enabled;
     int                                   rcu_reclaim_threads;
     int                                   nfs4_session_slots;
     int                                   nfs4_delegations;
@@ -266,6 +267,9 @@ chimera_server_config_init(void)
     config->nfs_server_scope = 42;
 
     config->cache_ttl = 60;
+
+    /* The VFS attribute cache is on by default (common.attr_cache). */
+    config->attr_cache_enabled = 1;
 
     /* Number of liburcu call_rcu reclaim worker threads.  0 (the default) means
      * one worker per CPU (create_all_cpu_call_rcu_data) to keep RCU reclaim up
@@ -590,6 +594,14 @@ chimera_server_config_get_cache_ttl(const struct chimera_server_config *config)
 {
     return config->cache_ttl;
 } /* chimera_server_config_get_cache_ttl */
+
+SYMBOL_EXPORT void
+chimera_server_config_set_attr_cache_enabled(
+    struct chimera_server_config *config,
+    int                           enabled)
+{
+    config->attr_cache_enabled = enabled;
+} /* chimera_server_config_set_attr_cache_enabled */
 
 SYMBOL_EXPORT void
 chimera_server_config_set_rcu_reclaim_threads(
@@ -2291,6 +2303,7 @@ chimera_server_init(
                                    config->num_modules,
                                    config->kv_module,
                                    config->cache_ttl,
+                                   config->attr_cache_enabled,
                                    config->rcu_reclaim_threads,
                                    metrics);
 

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -188,6 +188,11 @@ chimera_server_config_set_rcu_reclaim_threads(
     int                           threads);
 
 void
+chimera_server_config_set_attr_cache_enabled(
+    struct chimera_server_config *config,
+    int                           enabled);
+
+void
 chimera_server_config_set_nfs4_session_slots(
     struct chimera_server_config *config,
     int                           slots);

--- a/src/vfs/tests/vfs_async_delegation_test.c
+++ b/src/vfs/tests/vfs_async_delegation_test.c
@@ -279,6 +279,7 @@ run_phase(
         1,
         "",
         60,
+        1,                  /* attr_cache_enabled */
         0,                  /* num_rcu_reclaim_threads: 0 = one per CPU */
         metrics);
     assert(ctx.vfs != NULL);

--- a/src/vfs/tests/vfs_clone_range_test.c
+++ b/src/vfs/tests/vfs_clone_range_test.c
@@ -329,7 +329,7 @@ main(
     ctx.evpl = evpl_create(NULL);
     assert(ctx.evpl != NULL);
 
-    ctx.vfs = chimera_vfs_init(0, 0, module_cfgs, 2, "memkv", 60, 0, metrics);
+    ctx.vfs = chimera_vfs_init(0, 0, module_cfgs, 2, "memkv", 60, 1, 0, metrics);
     assert(ctx.vfs != NULL);
 
     ctx.vfs_thread = chimera_vfs_thread_init(ctx.evpl, ctx.vfs);

--- a/src/vfs/tests/vfs_enforce_test.c
+++ b/src/vfs/tests/vfs_enforce_test.c
@@ -386,7 +386,7 @@ main(
     ctx.evpl = evpl_create(NULL);
     assert(ctx.evpl != NULL);
 
-    ctx.vfs = chimera_vfs_init(0, 0, module_cfgs, 2, "memkv", 60, 0, metrics);
+    ctx.vfs = chimera_vfs_init(0, 0, module_cfgs, 2, "memkv", 60, 1, 0, metrics);
     assert(ctx.vfs != NULL);
 
     ctx.vfs_thread = chimera_vfs_thread_init(ctx.evpl, ctx.vfs);

--- a/src/vfs/tests/vfs_identity_test.c
+++ b/src/vfs/tests/vfs_identity_test.c
@@ -74,7 +74,7 @@ main(
     evpl = evpl_create(NULL);
     assert(evpl != NULL);
 
-    vfs = chimera_vfs_init(0, 0, module_cfgs, 2, "memkv", 60, 0, metrics);
+    vfs = chimera_vfs_init(0, 0, module_cfgs, 2, "memkv", 60, 1, 0, metrics);
     assert(vfs != NULL);
 
     thread = chimera_vfs_thread_init(evpl, vfs);

--- a/src/vfs/tests/vfs_kv_test.c
+++ b/src/vfs/tests/vfs_kv_test.c
@@ -471,6 +471,7 @@ run_suite(
         1,              /* num_modules */
         kv_name,        /* kv_module_name */
         60,             /* cache_ttl */
+        1,              /* attr_cache_enabled */
         0,              /* num_rcu_reclaim_threads: 0 = one per CPU */
         metrics);
     assert(ctx.vfs != NULL);

--- a/src/vfs/tests/vfs_statfs_mask_test.c
+++ b/src/vfs/tests/vfs_statfs_mask_test.c
@@ -192,7 +192,7 @@ test_memfs_behaviour(void)
     ctx.evpl = evpl_create(NULL);
     assert(ctx.evpl != NULL);
 
-    vfs = chimera_vfs_init(0, 0, module_cfgs, 2, "memkv", 60, 0, metrics);
+    vfs = chimera_vfs_init(0, 0, module_cfgs, 2, "memkv", 60, 1, 0, metrics);
     assert(vfs != NULL);
 
     ctx.vfs_thread = chimera_vfs_thread_init(ctx.evpl, vfs);

--- a/src/vfs/tests/vfs_sync_delegation_test.c
+++ b/src/vfs/tests/vfs_sync_delegation_test.c
@@ -289,6 +289,7 @@ run_phase(
         1,
         "cairn",
         60,
+        1,                 /* attr_cache_enabled */
         0,                 /* num_rcu_reclaim_threads: 0 = one per CPU */
         metrics);
     assert(ctx.vfs != NULL);

--- a/src/vfs/tests/vfs_zerorange_test.c
+++ b/src/vfs/tests/vfs_zerorange_test.c
@@ -382,7 +382,7 @@ main(
     ctx.evpl = evpl_create(NULL);
     assert(ctx.evpl != NULL);
 
-    ctx.vfs = chimera_vfs_init(0, 0, module_cfgs, spec.ncfg, "memkv", 60, 0,
+    ctx.vfs = chimera_vfs_init(0, 0, module_cfgs, spec.ncfg, "memkv", 60, 1, 0,
                                metrics);
     assert(ctx.vfs != NULL);
 

--- a/src/vfs/vfs.c
+++ b/src/vfs/vfs.c
@@ -474,6 +474,7 @@ chimera_vfs_init(
     int                                  num_modules,
     const char                          *kv_module_name,
     int                                  cache_ttl,
+    int                                  attr_cache_enabled,
     int                                  num_rcu_reclaim_threads,
     struct prometheus_metrics           *metrics)
 {
@@ -527,7 +528,11 @@ chimera_vfs_init(
                                                            "file_handles");
 
     vfs->vfs_name_cache = chimera_vfs_name_cache_create(8, 4, 2, cache_ttl, metrics);
-    vfs->vfs_attr_cache = chimera_vfs_attr_cache_create(8, 4, 2, cache_ttl, metrics);
+    /* The attr cache is optional (common.attr_cache).  When off we leave it
+     * NULL; the cache helpers (lookup/insert/refresh/destroy) are all no-ops on
+     * a NULL cache, so nothing is cached, consulted, or freed. */
+    vfs->vfs_attr_cache = attr_cache_enabled ?
+        chimera_vfs_attr_cache_create(8, 4, 2, cache_ttl, metrics) : NULL;
 
     vfs->vfs_user_cache = chimera_vfs_user_cache_create(8192, 600);
     vfs->identity       = chimera_vfs_identity_create(vfs, 4);

--- a/src/vfs/vfs.h
+++ b/src/vfs/vfs.h
@@ -1567,6 +1567,7 @@ chimera_vfs_init(
     int                                  num_modules,
     const char                          *kv_module_name,
     int                                  cache_ttl,
+    int                                  attr_cache_enabled,
     int                                  num_rcu_reclaim_threads,
     struct prometheus_metrics           *metrics);
 

--- a/src/vfs/vfs_attr_cache.h
+++ b/src/vfs/vfs_attr_cache.h
@@ -123,6 +123,10 @@ chimera_vfs_attr_cache_destroy(struct chimera_vfs_attr_cache *cache)
     struct chimera_vfs_attr_cache_entry *entry;
     int                                  i, j;
 
+    if (!cache) {
+        return;
+    }
+
     rcu_barrier();
 
     for (i = 0; i < cache->num_shards; i++) {
@@ -172,6 +176,10 @@ chimera_vfs_attr_cache_lookup(
     struct chimera_vfs_attr_cache_entry **slot, **slot_end;
     int                                   rc;
     uint64_t                              now = chimera_vfs_now_ticks();
+
+    if (!cache) {
+        return -1;
+    }
 
     shard = &cache->shards[fh_hash & cache->num_shards_mask];
 
@@ -223,6 +231,10 @@ chimera_vfs_attr_cache_insert(
     struct chimera_vfs_attr_cache_entry  *entry, *old_entry, *best_entry;
     struct chimera_vfs_attr_cache_shard  *shard;
     struct chimera_vfs_attr_cache_entry **slot, **slot_end, **slot_best;
+
+    if (!cache) {
+        return;
+    }
 
     shard = &cache->shards[fh_hash & cache->num_shards_mask];
 
@@ -335,6 +347,10 @@ chimera_vfs_attr_cache_refresh(
     struct chimera_vfs_attr_cache_entry **slot, **slot_end;
     int                                   unchanged = 0;
     uint64_t                              now       = chimera_vfs_now_ticks();
+
+    if (!cache) {
+        return;
+    }
 
     /* Only stat-complete attrs are cacheable (same gate as _insert). */
     if ((attr->va_set_mask & CHIMERA_VFS_ATTR_MASK_STAT) != CHIMERA_VFS_ATTR_MASK_STAT) {


### PR DESCRIPTION
Adds a `common` JSON config knob, **`attr_cache`** (default `true`), to enable/disable the VFS attribute cache. The attr cache is a VFS-level facility, so the knob lives in the shared `common` section and is honored identically by the **server** (daemon) and the **client**.

```json
{ "common": { "attr_cache": false } }
```

**When disabled,** `chimera_vfs_init()` leaves `vfs->vfs_attr_cache` NULL and never creates it. The cache helpers (`lookup`/`insert`/`refresh`/`destroy`) all no-op on a NULL cache, so nothing is inserted, consulted, or freed — the hot-path getattr/lookup cache-consult simply misses and falls through to the backend, and mutating ops skip the insert.

**Wiring:** `chimera_common_attr_cache_enabled()` parses the key; the daemon and client read it and pass it to `chimera_vfs_init()` alongside `cache_ttl`. Default-on preserves current behavior; test harnesses pass enabled.

**Validated:** enabled (default) — vfs unit + pynfs suites green; disabled — `combined_{memfs,diskfs_io_uring}` pass 100% (full NFS-server path with the cache off, verified by injecting `attr_cache:false`).

**Follow-up (not in this PR):** also narrowing the pre/post attribute requests issued to backends when the cache is off (so disabled mode fetches only what the ultimate recipient uses). That is deferred because several NFS recipients (setattr/write post-op) currently under-request and rely on the cacheable widening to populate attrs their response code reads; doing it safely needs a per-recipient request audit.